### PR TITLE
docs: fix stale file path references

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ See [docs/prompt-queue.md](docs/prompt-queue.md) for the full architecture.
 
 ### Workflows
 
-Workflows define the gates a goal must pass, their dependency relationships (a DAG), quality criteria, and verification configs. Stored as YAML in `workflows/`. Snapshotted into goals at creation (frozen). See [docs/goals-workflows-tasks.md](docs/goals-workflows-tasks.md).
+Workflows define the gates a goal must pass, their dependency relationships (a DAG), quality criteria, and verification configs. Stored as YAML in `.bobbit/config/workflows/`. Snapshotted into goals at creation (frozen). See [docs/goals-workflows-tasks.md](docs/goals-workflows-tasks.md).
 
 ### Assistant Registry
 

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -63,7 +63,7 @@ This touches the sentinel file. The harness picks it up within ~500ms (polled on
 | `package.json` (new dependency) | `npm install`, then restart server |
 | `vite.config.ts` | Restart Vite (kill and re-run `npm run dev:harness`) |
 | `tsconfig.*.json` | Restart server; may need to restart Vite for web config changes |
-| `config/system-prompt.md` | Restart server (the path is resolved at startup and passed to agents) |
+| `.bobbit/config/system-prompt.md` | Restart server (the path is resolved at startup and passed to agents) |
 
 **Rule of thumb**: UI is hot. Server is compiled. If you touched anything under `src/server/`, you need a rebuild + restart.
 
@@ -236,7 +236,7 @@ npm test              # Mobile header Playwright tests (standalone)
 npm run test:e2e      # E2E integration tests (starts gateway + vite on localhost)
 ```
 
-E2E tests use `tests/playwright-e2e.config.ts` which starts both the gateway and Vite on localhost automatically. Tests run against the real system — creating sessions, sending prompts, verifying UI behavior.
+E2E tests use `playwright-e2e.config.ts` (at the project root) which starts a sandboxed gateway on localhost automatically. Tests run against the real system — creating sessions, sending prompts, verifying UI behavior.
 
 ---
 

--- a/docs/goals-workflows-tasks.md
+++ b/docs/goals-workflows-tasks.md
@@ -12,7 +12,7 @@ Goals can run in **team mode**, where a Team Lead agent orchestrates multiple ro
 
 ### Workflows
 
-A **workflow** is a reusable template that defines which gates a goal must pass, their dependency relationships (a DAG), and verification configs. Workflows are stored as YAML files in `workflows/` at the repo root.
+A **workflow** is a reusable template that defines which gates a goal must pass, their dependency relationships (a DAG), and verification configs. Workflows are stored as YAML files in `.bobbit/config/workflows/`.
 
 When a goal is created with a `workflowId`, the entire workflow is **snapshotted** into `PersistedGoal.workflow`. This frozen copy is immune to later template edits — the goal's requirements are locked at creation time.
 
@@ -52,7 +52,7 @@ interface Workflow {
 
 #### Workflow YAML format
 
-Workflows are defined in `workflows/<id>.yaml`:
+Workflows are defined in `.bobbit/config/workflows/<id>.yaml`:
 
 ```yaml
 id: general
@@ -269,7 +269,7 @@ Here's the typical flow for a team goal with a workflow:
 
 | Location | What |
 |---|---|
-| `workflows/*.yaml` | Workflow templates (repo-local, version controlled) |
+| `.bobbit/config/workflows/*.yaml` | Workflow templates (repo-local, version controlled) |
 | `.bobbit/state/goals.json` | Goals with snapshotted workflows |
 | `.bobbit/state/gates.json` | Gate state and signal history |
 | `.bobbit/state/tasks.json` | Tasks with workflow gate links |
@@ -285,7 +285,7 @@ Here's the typical flow for a team goal with a workflow:
 | `src/server/agent/task-store.ts` | Task persistence with `workflowGateId` and `inputGateIds` |
 | `src/server/agent/team-manager.ts` | Context injection via `buildDependencyContext()` |
 | `src/server/agent/system-prompt.ts` | System prompt assembly including gate context |
-| `extensions/goal-tools.ts` | Agent tools: `gate_signal`, `gate_status`, `gate_list`, `task_create` |
-| `extensions/team-lead-tools.ts` | Agent tools: `team_spawn`, `team_prompt` with context injection |
-| `roles/team-lead.yaml` | Team Lead prompt template (workflow-aware) |
-| `workflows/general.yaml` | Seed workflow: general-purpose lifecycle |
+| `.bobbit/extensions/goal-tools.ts` | Agent tools: `gate_signal`, `gate_status`, `gate_list`, `task_create` |
+| `.bobbit/extensions/team-lead-tools.ts` | Agent tools: `team_spawn`, `team_prompt` with context injection |
+| `.bobbit/config/roles/team-lead.yaml` | Team Lead prompt template (workflow-aware) |
+| `.bobbit/config/workflows/general.yaml` | Seed workflow: general-purpose lifecycle |


### PR DESCRIPTION
Fixes 10 stale path references across 3 doc files:

- **README.md**: `workflows/` → `.bobbit/config/workflows/`
- **docs/dev-workflow.md**: `config/system-prompt.md` → `.bobbit/config/system-prompt.md`; `tests/playwright-e2e.config.ts` → `playwright-e2e.config.ts` (root)
- **docs/goals-workflows-tasks.md**: Fixed 7 paths (`extensions/`, `roles/`, `workflows/`) to include correct `.bobbit/` prefix