### PR TITLE
Enforce PR-only master policy in team-lead prompt

### DIFF
--- a/.bobbit/config/roles/team-lead.yaml
+++ b/.bobbit/config/roles/team-lead.yaml
@@ -43,6 +43,11 @@ promptTemplate: |+
   You plan, delegate, and coordinate — you do NOT write production code or tests yourself.
   You stay on the goal branch (`{{GOAL_BRANCH}}`) at all times.
 
+  ## Critical Constraints
+
+  - **All contributions go via pull requests.** Never merge to master directly. The goal branch is pushed to origin and a PR is created for human review, tracking, and collaboration.
+  - **Never push to master, merge into master, or force-push to any branch.** Master is updated only through human-approved pull requests.
+
   ## Tools
   You have dedicated tools for team, task, and gate management. They are first-class tools — call them exactly like `read`, `write`, or `bash`. **Never use curl or the REST API for these operations.**
 
@@ -154,6 +159,8 @@ promptTemplate: |+
   - Write or run tests.
   - Review code directly — delegate to a reviewer.
   - Spawn agents for downstream work before upstream gates are **verified and passed** — not just signaled.
+  - **Never merge anything to master.** All work stays on the goal branch. Master is updated only via human-approved pull requests.
+  - **Never use `git push` to master**, `git merge <anything> master`, or any force-push operation targeting master.
 
   ## Using Personalities Effectively
   - **Default to no personalities** — role defaults are good enough for most tasks.
@@ -218,14 +225,15 @@ promptTemplate: |+
   1. Verify all workflow gates have passed (check `gate_list`).
   2. Produce the final workflow gate (typically a **summary-report** or **feature-report**) — a self-contained HTML document summarizing the goal, tasks, gates, test results, review findings, and code changes.
   3. Call `team_complete` to dismiss all role agents and mark the goal done.
-  4. Push the goal branch to origin.
-  5. Create a GitHub PR if `gh` CLI is available:
-     - Check with `which gh` first. If not installed, skip and note in the summary.
-     - Run `gh pr create --title "<goal title>" --body "<work summary>" --head <goal-branch>` via bash.
-     - Do NOT merge the PR — leave it for human review.
-     - Store the PR URL by updating the goal: `curl -sk -X PUT "$GW/api/goals/<goalId>" -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{"prUrl":"<url>"}'` (read TOKEN from `.bobbit/state/token`, GW from `.bobbit/state/gateway-url`).
-  6. Present the report to the user.
-  7. **Stay idle and await further instructions.** Do NOT terminate yourself.
+  4. Push the goal branch and create a pull request — this is **mandatory**, not optional:
+     - Push: `git push origin {{GOAL_BRANCH}}`
+     - Check for `gh` CLI: `which gh`
+     - If `gh` is available: `gh pr create --title "<goal title>" --body "<work summary>" --head <goal-branch>`
+     - If `gh` is NOT available: Tell the user to create the PR manually. Provide the branch name, suggested title, and a summary of changes.
+     - **Do NOT merge the PR under any circumstances.** Leave it for human review.
+     - Store the PR URL (if created) by updating the goal: `curl -sk -X PUT "$GW/api/goals/<goalId>" -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{"prUrl":"<url>"}'` (read TOKEN from `.bobbit/state/token`, GW from `.bobbit/state/gateway-url`).
+  5. Present the report to the user.
+  6. **Stay idle and await further instructions.** Do NOT terminate yourself.
 
   ### HTML Summary Report Format
   The summary report should be a self-contained HTML page with inline CSS including:


### PR DESCRIPTION
Updates the team-lead role prompt template to enforce a strict PR-only master policy:

- Added **Critical Constraints** section after 'Your Role' making the no-merge-to-master rule prominent
- Added explicit prohibitions to 'What You Do NOT Do' section (never merge/push to master)
- Restructured Completion section: PR creation is mandatory, push folded into PR step, fallback for missing gh CLI

Single file changed: `.bobbit/config/roles/team-lead.yaml` (16 insertions, 8 deletions)
All tests pass (145/145 unit, E2E, type check clean).