### PR TITLE
Show PR status in session-level git pill

### DIFF
--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -573,7 +573,6 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 		// Initial git status and bg process fetch
 		refreshGitStatusForSession(sessionId);
 		refreshBgProcessesForSession(sessionId);
-		refreshPrStatusForSession(sessionId);
 
 		if (isExisting) {
 			remote.requestMessages();
@@ -885,7 +884,17 @@ async function refreshGitStatusForSession(sessionId: string): Promise<void> {
 async function refreshPrStatusForSession(sessionId: string): Promise<void> {
 	const sessionData = state.gatewaySessions.find((s) => s.id === sessionId);
 	const goalId = sessionData?.goalId;
-	if (!goalId) return;
+	if (!goalId) {
+		const ai = state.chatPanel?.agentInterface;
+		if (activeSessionId() === sessionId && ai) {
+			ai.prState = undefined;
+			ai.prUrl = undefined;
+			ai.prNumber = undefined;
+			ai.prTitle = undefined;
+			ai.prMergeable = undefined;
+		}
+		return;
+	}
 
 	const ai = state.chatPanel?.agentInterface;
 	if (!ai) return;

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -549,11 +549,31 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			state.chatPanel.agentInterface.onBgProcessDismiss = (processId: string) => {
 				dismissBgProcess(sessionId, processId);
 			};
+			state.chatPanel.agentInterface.onPrMerge = async (method: string) => {
+				const sd = state.gatewaySessions.find((s) => s.id === sessionId);
+				if (!sd?.goalId) return 'No goal linked';
+				try {
+					const res = await gatewayFetch(`/api/goals/${sd.goalId}/pr-merge`, {
+						method: 'POST',
+						headers: { 'Content-Type': 'application/json' },
+						body: JSON.stringify({ method }),
+					});
+					if (res.ok) {
+						refreshPrStatusForSession(sessionId);
+						return undefined;
+					}
+					const data = await res.json().catch(() => ({ error: 'Merge failed' }));
+					return data.error || 'Merge failed';
+				} catch (err) {
+					return err instanceof Error ? err.message : 'Network error';
+				}
+			};
 		}
 
 		// Initial git status and bg process fetch
 		refreshGitStatusForSession(sessionId);
 		refreshBgProcessesForSession(sessionId);
+		refreshPrStatusForSession(sessionId);
 
 		if (isExisting) {
 			remote.requestMessages();
@@ -857,6 +877,46 @@ async function refreshGitStatusForSession(sessionId: string): Promise<void> {
 	} finally {
 		if (activeSessionId() === sessionId) {
 			ai.gitStatusLoading = false;
+		}
+	}
+	refreshPrStatusForSession(sessionId);
+}
+
+async function refreshPrStatusForSession(sessionId: string): Promise<void> {
+	const sessionData = state.gatewaySessions.find((s) => s.id === sessionId);
+	const goalId = sessionData?.goalId;
+	if (!goalId) return;
+
+	const ai = state.chatPanel?.agentInterface;
+	if (!ai) return;
+
+	try {
+		const res = await gatewayFetch(`/api/goals/${goalId}/pr-status`).catch(() => null);
+		if (!res || !res.ok) {
+			if (activeSessionId() === sessionId) {
+				ai.prState = undefined;
+				ai.prUrl = undefined;
+				ai.prNumber = undefined;
+				ai.prTitle = undefined;
+				ai.prMergeable = undefined;
+			}
+			return;
+		}
+		const data = await res.json();
+		if (activeSessionId() === sessionId) {
+			ai.prState = data.state;
+			ai.prUrl = data.url;
+			ai.prNumber = data.number;
+			ai.prTitle = data.title;
+			ai.prMergeable = data.mergeable;
+		}
+	} catch {
+		if (activeSessionId() === sessionId) {
+			ai.prState = undefined;
+			ai.prUrl = undefined;
+			ai.prNumber = undefined;
+			ai.prTitle = undefined;
+			ai.prMergeable = undefined;
 		}
 	}
 }

--- a/src/ui/components/AgentInterface.ts
+++ b/src/ui/components/AgentInterface.ts
@@ -52,10 +52,17 @@ export class AgentInterface extends LitElement {
 		status: Array<{ file: string; status: string }>;
 	};
 	@property({ type: Boolean }) gitStatusLoading = false;
+	// PR status properties for goal-linked sessions
+	@property() prState?: string;
+	@property() prUrl?: string;
+	@property({ type: Number }) prNumber?: number;
+	@property() prTitle?: string;
+	@property({ type: Boolean }) prMergeable?: boolean;
 	// Background processes for this session
 	@property({ attribute: false }) bgProcesses: BgProcessInfo[] = [];
 	@property({ attribute: false }) onBgProcessKill?: (id: string) => void;
 	@property({ attribute: false }) onBgProcessDismiss?: (id: string) => void;
+	@property({ attribute: false }) onPrMerge?: (method: string) => Promise<string | undefined>;
 	// Optional custom API key prompt handler - if not provided, uses default dialog
 	@property({ attribute: false }) onApiKeyRequired?: (provider: string) => Promise<boolean>;
 	// Optional callback called before sending a message
@@ -663,6 +670,12 @@ export class AgentInterface extends LitElement {
 								.unpushed=${this.gitStatus?.unpushed ?? false}
 								.statusFiles=${this.gitStatus?.status ?? []}
 								.loading=${this.gitStatusLoading}
+								.prState=${this.prState}
+								.prUrl=${this.prUrl}
+								.prNumber=${this.prNumber}
+								.prTitle=${this.prTitle}
+								.prMergeable=${this.prMergeable ?? false}
+								@pr-merge=${this._handlePrMerge}
 							></git-status-widget>` : nothing}
 						</div>
 						` : ''}
@@ -705,6 +718,17 @@ export class AgentInterface extends LitElement {
 				</div>
 			</div>
 		`;
+	}
+
+	private async _handlePrMerge(e: CustomEvent<{ method: string }>): Promise<void> {
+		if (!this.onPrMerge) return;
+		const widget = e.target as import('./GitStatusWidget.js').GitStatusWidget;
+		try {
+			const error = await this.onPrMerge(e.detail.method);
+			widget.setMergeResult(error);
+		} catch (err) {
+			widget.setMergeResult(err instanceof Error ? err.message : 'Network error');
+		}
 	}
 }
 


### PR DESCRIPTION
Wire PR status properties (state, URL, number, title, mergeable) through AgentInterface to GitStatusWidget for goal-linked sessions. Adds refreshPrStatusForSession() helper, merge callback, and stale-data clearing on session switch.

Changes:
- src/ui/components/AgentInterface.ts: 5 PR properties + merge handler
- src/app/session-manager.ts: PR status fetch, merge callback, stale data clearing

All 145 unit tests and 188 E2E tests pass.