### PR TITLE
fix: abort in-flight draft save on send to prevent PUT/DELETE race

### DIFF
--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -910,13 +910,16 @@ export async function deleteRole(name: string): Promise<boolean> {
 // ============================================================================
 
 /** Save a draft to the server. Fire-and-forget â€” errors are logged, not thrown. */
-export async function saveDraftToServer(sessionId: string, type: string, data: unknown): Promise<void> {
+export async function saveDraftToServer(sessionId: string, type: string, data: unknown, signal?: AbortSignal): Promise<void> {
 	try {
 		await gatewayFetch(`/api/sessions/${sessionId}/draft`, {
 			method: "PUT",
 			body: JSON.stringify({ type, data }),
+			signal,
 		});
 	} catch (err) {
+		// Ignore aborted requests — they're intentionally cancelled on send
+		if (err instanceof DOMException && err.name === "AbortError") return;
 		console.error("[draft-api] Failed to save draft:", err);
 	}
 }

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -677,8 +677,9 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			} catch { /* ignore */ }
 		})();
 
-		// Set up debounced prompt draft saving
+		// Set up debounced prompt draft saving with in-flight request tracking
 		let _promptDraftTimer: ReturnType<typeof setTimeout> | null = null;
+		let _promptDraftAbort: AbortController | null = null;
 		requestAnimationFrame(() => {
 			const editor = document.querySelector("message-editor") as any;
 			if (editor) {
@@ -688,8 +689,12 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 					if (_promptDraftTimer) clearTimeout(_promptDraftTimer);
 					_promptDraftTimer = setTimeout(() => {
 						_promptDraftTimer = null;
+						// Abort any previous in-flight save
+						if (_promptDraftAbort) _promptDraftAbort.abort();
 						if (val.trim()) {
-							saveDraftToServer(sessionId, 'prompt', val);
+							_promptDraftAbort = new AbortController();
+							saveDraftToServer(sessionId, 'prompt', val, _promptDraftAbort.signal)
+								.finally(() => { _promptDraftAbort = null; });
 						} else {
 							deleteDraftFromServer(sessionId, 'prompt');
 						}
@@ -697,7 +702,9 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 				};
 				const origOnSend = editor.onSend;
 				editor.onSend = (text: string, attachments: any[]) => {
+					// Cancel pending timer AND abort any in-flight save request
 					if (_promptDraftTimer) { clearTimeout(_promptDraftTimer); _promptDraftTimer = null; }
+					if (_promptDraftAbort) { _promptDraftAbort.abort(); _promptDraftAbort = null; }
 					deleteDraftFromServer(sessionId, 'prompt');
 					origOnSend?.(text, attachments);
 				};


### PR DESCRIPTION
## Problem

After merging server-side draft storage (#7), sent messages still reappear as drafts. The bug is worse because the server-side race is more reliable than the old client-side race.

### Race condition

1. User types → 500ms debounce fires → PUT request sent (has JSON body to parse)
2. User sends → DELETE request sent immediately (no body)
3. Server processes DELETE first (instant — no body), then PUT finishes reading body and **re-saves the draft after the delete**

### Fix

Track in-flight PUT requests with `AbortController`. On send:
1. Cancel pending debounce timer
2. **Abort any in-flight PUT request** (new)
3. Fire DELETE

`saveDraftToServer` now accepts an optional `AbortSignal` and silently ignores aborted requests.

### Tests
- All 197 E2E + 141 unit tests pass
- Type check clean