### PR TITLE
feat: Gate Tool Renderers

### DIFF
--- a/src/ui/tools/index.ts
+++ b/src/ui/tools/index.ts
@@ -21,6 +21,7 @@ import { WebSearchRenderer } from "./renderers/WebSearchRenderer.js";
 import { WriteRenderer } from "./renderers/WriteRenderer.js";
 import { TeamSpawnRenderer, TeamListRenderer, TeamDismissRenderer, TeamCompleteRenderer, TeamSteerRenderer, TeamPromptRenderer, TeamAbortRenderer } from "./renderers/TeamToolRenderers.js";
 import { TaskListRenderer, TaskCreateRenderer, TaskUpdateRenderer } from "./renderers/TaskToolRenderers.js";
+import { GateListRenderer, GateSignalRenderer, GateStatusRenderer } from "./renderers/GateToolRenderers.js";
 import { BgProcessRenderer } from "./renderers/BgProcessRenderer.js";
 import { PersonalitiesListRenderer, PersonalitiesCreateRenderer } from "./renderers/PersonalityToolRenderers.js";
 import type { ToolRenderResult } from "./types.js";
@@ -57,6 +58,9 @@ registerToolRenderer("task_update", new TaskUpdateRenderer());
 registerToolRenderer("bash_bg", new BgProcessRenderer());
 registerToolRenderer("personalities_list", new PersonalitiesListRenderer());
 registerToolRenderer("personalities_create", new PersonalitiesCreateRenderer());
+registerToolRenderer("gate_list", new GateListRenderer());
+registerToolRenderer("gate_signal", new GateSignalRenderer());
+registerToolRenderer("gate_status", new GateStatusRenderer());
 
 const defaultRenderer = new DefaultRenderer();
 

--- a/src/ui/tools/renderers/GateToolRenderers.ts
+++ b/src/ui/tools/renderers/GateToolRenderers.ts
@@ -1,0 +1,195 @@
+/**
+ * Renderers for gate_list, gate_signal, gate_status tools.
+ * Compact gate cards with status badges and dependency info.
+ */
+import type { ToolResultMessage } from "@mariozechner/pi-ai";
+import { html, type TemplateResult } from "lit";
+import { createRef, ref } from "lit/directives/ref.js";
+import { ShieldCheck } from "lucide";
+import { renderCollapsibleHeader, renderHeader, getToolState, isSkippedToolResult } from "../renderer-registry.js";
+import type { ToolRenderer, ToolRenderResult } from "../types.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function getResult(result: ToolResultMessage | undefined): { text: string; data: any } {
+	const text = result?.content?.filter((c: any) => c.type === "text").map((c: any) => c.text).join("\n") || "";
+	let data: any = null;
+	try { data = JSON.parse(text); } catch { /* not JSON */ }
+	return { text, data };
+}
+
+function gateBadge(status: string): TemplateResult {
+	const styles: Record<string, string> = {
+		pending: "bg-muted text-muted-foreground",
+		passed: "bg-green-500/20 text-green-600 dark:text-green-400",
+		failed: "bg-red-500/20 text-red-600 dark:text-red-400",
+		running: "bg-blue-500/20 text-blue-600 dark:text-blue-400",
+	};
+	const cls = styles[status] || "bg-muted text-muted-foreground";
+	return html`<span class="px-1.5 py-0.5 rounded text-xs font-medium ${cls}">${status}</span>`;
+}
+
+function truncate(s: string, max = 200): string {
+	if (!s) return "";
+	return s.length > max ? s.slice(0, max) + "…" : s;
+}
+
+// ── gate_list ────────────────────────────────────────────────────────
+
+export class GateListRenderer implements ToolRenderer {
+	render(_params: any, result: ToolResultMessage | undefined, isStreaming?: boolean): ToolRenderResult {
+		const state = getToolState(result, isStreaming);
+
+		if (!result) {
+			return { content: html`<div>${renderHeader(state, ShieldCheck, "Listing gates…")}</div>`, isCustom: false };
+		}
+
+		const { data, text } = getResult(result);
+		if (result.isError) {
+			const skipped = isSkippedToolResult(result);
+			return {
+				content: html`<div>
+					${renderHeader(state, ShieldCheck, skipped ? "Aborted gate list" : "Gate list failed")}
+					<div class="mt-1 text-xs ${skipped ? "text-amber-600 dark:text-amber-400" : "text-destructive"}">${text}</div>
+				</div>`,
+				isCustom: false,
+			};
+		}
+
+		const gates: any[] = data?.gates || (Array.isArray(data) ? data : []);
+		if (gates.length === 0) {
+			return { content: html`<div>${renderHeader(state, ShieldCheck, "No gates")}</div>`, isCustom: false };
+		}
+
+		// Build status summary (only non-zero counts)
+		const byStatus = new Map<string, number>();
+		for (const g of gates) byStatus.set(g.status || "pending", (byStatus.get(g.status || "pending") || 0) + 1);
+		const summary = Array.from(byStatus.entries()).map(([s, n]) => `${n} ${s}`).join(", ");
+
+		const contentRef = createRef<HTMLDivElement>();
+		const chevronRef = createRef<HTMLSpanElement>();
+
+		return {
+			content: html`<div>
+				${renderCollapsibleHeader(state, ShieldCheck, html`${gates.length} gates <span class="text-xs text-muted-foreground ml-1">(${summary})</span>`, contentRef, chevronRef, false)}
+				<div ${ref(contentRef)} class="max-h-0 overflow-hidden transition-all duration-300">
+					<div class="mt-2 space-y-1">${gates.map((g: any) => html`
+						<div class="flex items-center gap-2 text-xs py-0.5">
+							${gateBadge(g.status || "pending")}
+							<span class="font-medium truncate">${g.name || g.gateId}</span>
+							${g.dependsOn?.length ? html`<span class="text-muted-foreground">← ${g.dependsOn.join(", ")}</span>` : ""}
+						</div>
+					`)}</div>
+				</div>
+			</div>`,
+			isCustom: false,
+		};
+	}
+}
+
+// ── gate_signal ──────────────────────────────────────────────────────
+
+export class GateSignalRenderer implements ToolRenderer {
+	render(params: any, result: ToolResultMessage | undefined, isStreaming?: boolean): ToolRenderResult {
+		const state = getToolState(result, isStreaming);
+		const gateId = params?.gate_id || "gate";
+
+		if (!result) {
+			return {
+				content: html`<div>${renderHeader(state, ShieldCheck, html`Signaling <span class="font-mono text-xs">${gateId}</span>…`)}</div>`,
+				isCustom: false,
+			};
+		}
+
+		if (result.isError) {
+			const { text } = getResult(result);
+			const skipped = isSkippedToolResult(result);
+			const is409 = text.includes("409") || text.toLowerCase().includes("upstream") || text.toLowerCase().includes("has not passed");
+			const textCls = skipped ? "text-amber-600 dark:text-amber-400" : is409 ? "text-amber-600 dark:text-amber-400" : "text-destructive";
+			return {
+				content: html`<div>
+					${renderHeader(state, ShieldCheck, skipped
+						? html`Aborted signal for <span class="font-mono text-xs">${gateId}</span>`
+						: html`Failed to signal <span class="font-mono text-xs">${gateId}</span>`)}
+					<div class="mt-1 text-xs ${textCls}">${text}</div>
+				</div>`,
+				isCustom: false,
+			};
+		}
+
+		return {
+			content: html`<div>${renderHeader(state, ShieldCheck, html`Signaled <span class="font-mono text-xs">${gateId}</span> — verification running`)}</div>`,
+			isCustom: false,
+		};
+	}
+}
+
+// ── gate_status ──────────────────────────────────────────────────────
+
+export class GateStatusRenderer implements ToolRenderer {
+	render(params: any, result: ToolResultMessage | undefined, isStreaming?: boolean): ToolRenderResult {
+		const state = getToolState(result, isStreaming);
+		const gateId = params?.gate_id || "gate";
+
+		if (!result) {
+			return {
+				content: html`<div>${renderHeader(state, ShieldCheck, html`Checking gate <span class="font-mono text-xs">${gateId}</span>…`)}</div>`,
+				isCustom: false,
+			};
+		}
+
+		const { data, text } = getResult(result);
+		if (result.isError) {
+			const skipped = isSkippedToolResult(result);
+			return {
+				content: html`<div>
+					${renderHeader(state, ShieldCheck, skipped
+						? html`Aborted check of gate <span class="font-mono text-xs">${gateId}</span>`
+						: html`Failed to check gate <span class="font-mono text-xs">${gateId}</span>`)}
+					<div class="mt-1 text-xs ${skipped ? "text-amber-600 dark:text-amber-400" : "text-destructive"}">${text}</div>
+				</div>`,
+				isCustom: false,
+			};
+		}
+
+		if (!data) {
+			return { content: html`<div>${renderHeader(state, ShieldCheck, html`Gate <span class="font-mono text-xs">${gateId}</span>`)}</div>`, isCustom: false };
+		}
+
+		const gateName = data.name || data.gateId || gateId;
+		const gateStatus = data.status || "pending";
+		const deps: string[] = data.dependsOn || [];
+		const signals: any[] = data.signals || [];
+		const contentVersion = data.currentContentVersion;
+
+		// Check for latest verification failure
+		let failureOutput = "";
+		if (signals.length > 0) {
+			const latest = signals[signals.length - 1];
+			if (latest?.verification?.status === "failed" && latest.verification.steps) {
+				const failedStep = latest.verification.steps.find((s: any) => !s.passed);
+				if (failedStep?.output) {
+					failureOutput = truncate(failedStep.output, 200);
+				}
+			}
+		}
+
+		const contentRef = createRef<HTMLDivElement>();
+		const chevronRef = createRef<HTMLSpanElement>();
+
+		return {
+			content: html`<div>
+				${renderCollapsibleHeader(state, ShieldCheck, html`${gateBadge(gateStatus)} <span class="font-medium text-xs ml-1">${gateName}</span>`, contentRef, chevronRef, false)}
+				<div ${ref(contentRef)} class="max-h-0 overflow-hidden transition-all duration-300">
+					<div class="mt-2 space-y-1 text-xs text-muted-foreground">
+						${deps.length ? html`<div>Depends on: ${deps.join(", ")}</div>` : ""}
+						<div>${signals.length} signal${signals.length !== 1 ? "s" : ""}</div>
+						${contentVersion ? html`<div>content v${contentVersion}</div>` : ""}
+						${failureOutput ? html`<div class="text-red-600 dark:text-red-400 mt-1">Verification failed: ${failureOutput}</div>` : ""}
+					</div>
+				</div>
+			</div>`,
+			isCustom: false,
+		};
+	}
+}


### PR DESCRIPTION
## Summary

Added dedicated renderers for `gate_list`, `gate_signal`, and `gate_status` tools so they display human-friendly, compact output instead of raw JSON.

## Changes

- **New**: `src/ui/tools/renderers/GateToolRenderers.ts` — 3 renderer classes (`GateListRenderer`, `GateSignalRenderer`, `GateStatusRenderer`) following the `TaskToolRenderers.ts` pattern
- **Modified**: `src/ui/tools/index.ts` — registered 3 new renderers

### Renderers

- **`gate_list`**: Collapsible gate list with status summary (e.g. "3 gates (2 passed, 1 pending)") and dependency arrows
- **`gate_signal`**: Signal confirmation with 409 dependency error highlighting in amber
- **`gate_status`**: Gate detail with status badge, dependencies, signal count, content version, and verification failure details

All use `ShieldCheck` icon from lucide. UI-only change — no server modifications.

## Quality

- Type check: clean
- Unit tests: 141/141 passed
- E2E tests: passed
- Code review: no high/critical issues
- Security review: passed