### PR TITLE
fix: use native DOM events for draft persistence instead of monkey-patching

### DIFF
--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -243,9 +243,7 @@ export async function authenticateGateway(url: string, token: string): Promise<v
 let _draftSessionId: string | null = null;
 let _draftTimer: ReturnType<typeof setTimeout> | null = null;
 let _draftAbort: AbortController | null = null;
-// Track the editor element we last patched so we can detect when the DOM
-// element is replaced (e.g. session switch recreates AgentInterface).
-let _draftPatchedEditor: WeakRef<HTMLElement> | null = null;
+let _draftListenersInstalled = false;
 
 function _teardownDraftHandlers(): void {
 	if (_draftTimer) { clearTimeout(_draftTimer); _draftTimer = null; }
@@ -271,22 +269,20 @@ function _setupPromptDraftHandlers(sessionId: string): void {
 		} catch { /* ignore */ }
 	})();
 
-	// Install onInput/onSend on the current editor element. We re-install
-	// whenever the element changes (session switches recreate AgentInterface)
-	// but use _draftSessionId (read at call time) to avoid stacking.
-	requestAnimationFrame(() => {
-		const editor = document.querySelector("message-editor") as any;
-		if (!editor) return;
-
-		// Skip if we already patched this exact element
-		if (_draftPatchedEditor?.deref() === editor) return;
-
-		const baseOnInput = editor.onInput;
-		const baseOnSend = editor.onSend;
-
-		editor.onInput = (val: string) => {
-			baseOnInput?.(val);
+	// Use document-level event listeners instead of monkey-patching.
+	// Lit re-renders overwrite property-based callbacks (.onSend, .onInput)
+	// on every state change, silently removing our patches. Native DOM
+	// events (composed: true) bubble through shadow DOM and survive re-renders.
+	if (!_draftListenersInstalled) {
+		// Debounced draft save on textarea input (native 'input' event is composed)
+		document.addEventListener("input", (e: Event) => {
+			const target = e.target as HTMLElement;
+			if (!target || target.tagName !== "TEXTAREA") return;
+			// Verify it's inside a message-editor
+			if (!target.closest("message-editor")) return;
 			if (!_draftSessionId) return;
+
+			const val = (target as HTMLTextAreaElement).value;
 			if (_draftTimer) clearTimeout(_draftTimer);
 			_draftTimer = setTimeout(() => {
 				_draftTimer = null;
@@ -301,19 +297,22 @@ function _setupPromptDraftHandlers(sessionId: string): void {
 					deleteDraftFromServer(_draftSessionId, 'prompt');
 				}
 			}, 500);
-		};
+		});
 
-		editor.onSend = (text: string, attachments: any[]) => {
-			// Cancel pending timer AND abort any in-flight save request
+		// Clear draft on send (custom composed event from MessageEditor)
+		document.addEventListener("message-send", () => {
 			if (_draftTimer) { clearTimeout(_draftTimer); _draftTimer = null; }
 			if (_draftAbort) { _draftAbort.abort(); _draftAbort = null; }
 			if (_draftSessionId) deleteDraftFromServer(_draftSessionId, 'prompt');
-			baseOnSend?.(text, attachments);
-		};
+		});
 
-		_draftPatchedEditor = new WeakRef(editor);
+		_draftListenersInstalled = true;
+	}
 
-		const textarea = editor.querySelector("textarea");
+	// Focus the textarea
+	requestAnimationFrame(() => {
+		const editor = document.querySelector("message-editor") as any;
+		const textarea = editor?.querySelector("textarea");
 		if (textarea) textarea.focus();
 	});
 }

--- a/src/ui/components/MessageEditor.ts
+++ b/src/ui/components/MessageEditor.ts
@@ -226,6 +226,9 @@ export class MessageEditor extends LitElement {
 
 	private handleSend = () => {
 		const text = this.value;
+		// Dispatch a composed event that escapes shadow DOM — used by
+		// session-manager for draft cleanup without monkey-patching.
+		this.dispatchEvent(new CustomEvent("message-send", { bubbles: true, composed: true }));
 		this.onSend?.(text, this.attachments);
 		// Reset history browsing state after send
 		this._historyIndex = -1;


### PR DESCRIPTION
## Problem

Sent messages reappear as drafts. The monkey-patched `.onSend` and `.onInput` handlers on `<message-editor>` get **overwritten by Lit on every re-render** of AgentInterface (which happens on every streaming token, message update, etc.). The draft-clearing handler silently disappears.

This is why previous fixes (#9 AbortController, #10 stacking prevention, #11 WeakRef re-install) didn't fully resolve the issue — they all relied on monkey-patching properties that Lit owns.

## Root cause

AgentInterface's Lit template binds `.onSend=${...}` on `<message-editor>`. Lit re-applies this binding on every render, replacing whatever we monkey-patched.

## Fix

Stop monkey-patching entirely. Use native DOM events that survive re-renders:

1. **Draft saving**: document-level `input` event listener (native, composed — bubbles through shadow DOM)
2. **Draft clearing on send**: new `message-send` CustomEvent dispatched from `MessageEditor.handleSend()` with `composed: true`

Both listeners are installed once at the document level and read a module-level `_draftSessionId` at call time, handling session switches naturally.

## Tests
- 199 E2E + 141 unit tests pass