### PR TITLE
docs: fix stale refs after tool system restructure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,6 @@ src/
 │   ├── index.ts     # Server barrel export
 │   ├── bobbit-dir.ts # Resolves .bobbit/ directory paths (config, state, global auth)
 │   ├── scaffold.ts  # First-run scaffolding — creates .bobbit/ with defaults
-│   ├── pi-dir.ts    # @deprecated — use bobbit-dir.ts instead
 │   ├── watchdog.ts  # Process health watchdog
 │   ├── defaults/    # Bundled default templates (roles, workflows, personalities, system-prompt)
 │   ├── agent/       # Session lifecycle, RPC bridge, persistence, goals, teams, title generation
@@ -53,7 +52,6 @@ src/
 │   │   ├── title-generator.ts          # Auto-generate session titles via Claude Haiku
 │   │   ├── tool-activation.ts          # Tool activation/deactivation logic
 │   │   ├── tool-assistant.ts           # System prompt for tool management assistant
-│   │   ├── tool-manager.ts             # Tool CRUD with renderer discovery
 │   │   ├── tool-manager.ts              # Tool CRUD, YAML scanning from .bobbit/config/tools/<group>/*.yaml
 │   │   ├── personality-manager.ts       # Personality definitions and management
 │   │   ├── personality-store.ts        # Personality persistence (YAML files in personalities/)
@@ -143,6 +141,7 @@ src/
 │   │   │   ├── DelegateRenderer.ts        # Delegate/sub-agent renderer
 │   │   │   ├── EditRenderer.ts            # File edit renderer with diff
 │   │   │   ├── FindRenderer.ts            # File find renderer
+│   │   │   ├── GateToolRenderers.ts       # Gate management tool renderers
 │   │   │   ├── GetCurrentTimeRenderer.ts  # Time tool renderer
 │   │   │   ├── GrepRenderer.ts            # Grep results renderer
 │   │   │   ├── HtmlRenderer.ts            # HTML preview renderer
@@ -183,11 +182,8 @@ src/
 │   │   └── stores/
 │   │       ├── command-history-store.ts          # Command history persistence
 │   │       ├── custom-providers-store.ts         # Custom AI provider persistence
-│   │       ├── goal-draft-store.ts              # Goal draft persistence
 │   │       ├── provider-keys-store.ts           # API key persistence
-│   │       ├── role-draft-store.ts              # Role draft persistence
 │   │       ├── sessions-store.ts                # Session metadata persistence
-│   │       ├── personality-draft-store.ts        # Personality draft persistence
 │   │       └── settings-store.ts                # App settings persistence
 │   └── utils/       # Formatting, auth token, model discovery, i18n
 │       ├── ansi.ts              # ANSI escape code processing
@@ -233,6 +229,7 @@ src/
 │   └── workflow-page.css        # Workflow page styles
 docs/
 ├── bobbit-sprites.md    # Bobbit pixel art, animation & accessory system reference
+├── coverage.md          # Code coverage setup and scripts
 ├── dev-workflow.md      # Development workflow guide
 ├── goals-workflows-tasks.md  # Goals, workflows, tasks & gates architecture
 └── prompt-queue.md      # Prompt queue architecture
@@ -374,9 +371,9 @@ All per-project state lives under `<project-root>/.bobbit/`:
 | `desec.json` | `desec.ts` | deSEC dynDNS config (domain + API token) |
 | `rpc-debug.log` | `rpc-bridge.ts` | Debug log of all RPC events |
 
-### `.bobbit/extensions/` — pi-coding-agent extension resolution directory
+### `.bobbit/config/tools/<group>/` — tool definitions and extensions
 
-Retained for pi-coding-agent's `user-extension` resolution (delegate, browser, web tools). Bobbit-owned tool extensions and YAML definitions are co-located in `.bobbit/config/tools/<group>/` (scaffolded from `src/server/defaults/tools/`).
+Tool YAML definitions and extension code, organized by group (agent, browser, filesystem, shell, tasks, team, web). Scaffolded from `src/server/defaults/tools/`. Each group contains `*.yaml` tool definitions and optionally an `extension.ts` for custom tool logic.
 
 ### Global state (not per-project)
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ bobbit [options]
 | `index.ts` | Barrel export of the server's public API (`createGateway`, `SessionManager`, `RpcBridge`, etc.). |
 | `bobbit-dir.ts` | Resolves `.bobbit/` directory paths (config, state, global auth). Override via `BOBBIT_DIR` env var for test isolation. |
 | `scaffold.ts` | First-run scaffolding — creates `.bobbit/` with default configs. |
-| `pi-dir.ts` | @deprecated — use `bobbit-dir.ts` instead. |
 | `watchdog.ts` | Process health watchdog. |
 | `harness.ts` | Dev server wrapper. Watches sentinel file for restart signals, auto-restarts on crash. |
 | `harness-signal.ts` | Touches the sentinel file to trigger a harness restart. |
@@ -109,8 +108,7 @@ bobbit [options]
 | `role-manager.ts` | Role definitions CRUD. Maintains built-in tool registry (`AVAILABLE_TOOLS`). |
 | `role-store.ts` | Persists roles as YAML files under `.bobbit/config/roles/`. |
 | `role-assistant.ts` | System prompt for role creation assistant sessions. |
-| `tool-manager.ts` | Manages tool definitions from `tools/<group>/*.yaml`. Reads, writes, and serves tool metadata. |
-| `tool-manager.ts` | Merges base tool definitions (from YAML) with store overrides. Detects tool renderers in `src/ui/tools/renderers/`. |
+| `tool-manager.ts` | Manages tool definitions from `.bobbit/config/tools/<group>/*.yaml`. Reads, writes, and serves tool metadata. Detects tool renderers in `src/ui/tools/renderers/`. |
 | `tool-assistant.ts` | System prompt for tool management assistant sessions. |
 | `personality-manager.ts` | Personality CRUD and resolution (maps personality names to prompt fragments). |
 | `personality-store.ts` | Persists personalities as YAML files under `.bobbit/config/personalities/`. |

--- a/docs/goals-workflows-tasks.md
+++ b/docs/goals-workflows-tasks.md
@@ -285,7 +285,7 @@ Here's the typical flow for a team goal with a workflow:
 | `src/server/agent/task-store.ts` | Task persistence with `workflowGateId` and `inputGateIds` |
 | `src/server/agent/team-manager.ts` | Context injection via `buildDependencyContext()` |
 | `src/server/agent/system-prompt.ts` | System prompt assembly including gate context |
-| `.bobbit/extensions/goal-tools.ts` | Agent tools: `gate_signal`, `gate_status`, `gate_list`, `task_create` |
-| `.bobbit/extensions/team-lead-tools.ts` | Agent tools: `team_spawn`, `team_prompt` with context injection |
+| `.bobbit/config/tools/tasks/extension.ts` | Agent tools: `gate_signal`, `gate_status`, `gate_list`, `task_create` |
+| `.bobbit/config/tools/team/extension.ts` | Agent tools: `team_spawn`, `team_prompt` with context injection |
 | `.bobbit/config/roles/team-lead.yaml` | Team Lead prompt template (workflow-aware) |
 | `.bobbit/config/workflows/general.yaml` | Seed workflow: general-purpose lifecycle |

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -932,23 +932,17 @@ async function refreshGitStatusForSession(sessionId: string): Promise<void> {
 async function refreshPrStatusForSession(sessionId: string): Promise<void> {
 	const sessionData = state.gatewaySessions.find((s) => s.id === sessionId);
 	const goalId = sessionData?.goalId;
-	if (!goalId) {
-		const ai = state.chatPanel?.agentInterface;
-		if (activeSessionId() === sessionId && ai) {
-			ai.prState = undefined;
-			ai.prUrl = undefined;
-			ai.prNumber = undefined;
-			ai.prTitle = undefined;
-			ai.prMergeable = undefined;
-		}
-		return;
-	}
+
+	// Build the URL: goal-scoped if available, otherwise session-scoped
+	const prStatusUrl = goalId
+		? `/api/goals/${goalId}/pr-status`
+		: `/api/sessions/${sessionId}/pr-status`;
 
 	const ai = state.chatPanel?.agentInterface;
 	if (!ai) return;
 
 	try {
-		const res = await gatewayFetch(`/api/goals/${goalId}/pr-status`).catch(() => null);
+		const res = await gatewayFetch(prStatusUrl).catch(() => null);
 		if (!res || !res.ok) {
 			if (activeSessionId() === sessionId) {
 				ai.prState = undefined;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1765,6 +1765,18 @@ async function handleApiRoute(
 		}
 		return;
 	}
+	// GET /api/sessions/:id/pr-status — PR status for session's branch
+	if (req.method === 'GET' && url.pathname.startsWith('/api/sessions/') && url.pathname.endsWith('/pr-status')) {
+		const id = url.pathname.split('/')[3];
+		const session = sessionManager.getSession(id);
+		if (!session) { json({ error: "Session not found" }, 404); return; }
+		const cwd = session.cwd;
+		if (!fs.existsSync(cwd)) { json({ error: "Working directory not found" }, 404); return; }
+		const pr = await getCachedPrStatus(cwd);
+		if (pr) { json(pr); } else { json({ error: "No PR found" }, 404); }
+		return;
+	}
+
 	// GET /api/skills — list available skill definitions
 	if (url.pathname === "/api/skills" && req.method === "GET") {
 		json({ skills: listSkills().map((s) => ({ id: s.id, name: s.name, description: s.description })) });


### PR DESCRIPTION
Removes/updates references to files deleted or moved in the tool system restructure:

**AGENTS.md repo layout tree:**
- Removed `pi-dir.ts` (deleted)
- Removed duplicate `tool-manager.ts` entry
- Removed `goal-draft-store.ts`, `role-draft-store.ts`, `personality-draft-store.ts` (deleted)
- Added missing `GateToolRenderers.ts` to renderers list
- Added `docs/coverage.md` to docs tree
- Updated `.bobbit/extensions/` section → `.bobbit/config/tools/<group>/`

**README.md:**
- Removed `pi-dir.ts` from server table
- Merged duplicate `tool-manager.ts` rows

**docs/goals-workflows-tasks.md:**
- `.bobbit/extensions/goal-tools.ts` → `.bobbit/config/tools/tasks/extension.ts`
- `.bobbit/extensions/team-lead-tools.ts` → `.bobbit/config/tools/team/extension.ts`