### PR TITLE
Keyboard Shortcut Manager

### DIFF
--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -11,9 +11,10 @@ import {
 } from "./state.js";
 import { gatewayFetch, refreshSessions } from "./api.js";
 import { getRouteFromHash, setHashRoute } from "./routing.js";
-import { authenticateGateway, connectToSession, createAndConnectSession } from "./session-manager.js";
+import { authenticateGateway, connectToSession, createAndConnectSession, terminateSession } from "./session-manager.js";
 import { doRenderApp } from "./render.js";
 import { loadDashboardData, clearDashboardState } from "./goal-dashboard.js";
+import { registerShortcut, startListening, loadSavedBindings } from "./shortcut-registry.js";
 
 // ============================================================================
 // WIRE UP RENDER
@@ -314,95 +315,141 @@ async function initApp() {
 	// Listen for browser back/forward navigation
 	window.addEventListener("hashchange", handleHashChange);
 
-	// Global keyboard shortcuts
-	window.addEventListener("keydown", (e: KeyboardEvent) => {
-		const mod = e.ctrlKey || e.metaKey;
+	// ========================================================================
+	// KEYBOARD SHORTCUT REGISTRY
+	// ========================================================================
 
-		// Ctrl+T / Cmd+T — New session
-		if (mod && e.key === "t") {
-			if (state.appView === "authenticated") {
-				e.preventDefault();
-				createAndConnectSession();
+	// Helper: build ordered session list and navigate up/down
+	function navigateSession(direction: "up" | "down"): void {
+		const allSessions = state.gatewaySessions;
+		const nonDelegate = allSessions.filter((s) => !s.delegateOf);
+		const staffSessionIds = new Set(state.staffList.map((s) => s.currentSessionId).filter(Boolean));
+		const byAge = (a: { createdAt: number }, b: { createdAt: number }) => a.createdAt - b.createdAt;
+		const stateOrder: Record<string, number> = { "in-progress": 0, "todo": 1, "complete": 2, "shelved": 3 };
+		const sortedGoals = [...state.goals].sort((a, b) => (stateOrder[a.state] ?? 9) - (stateOrder[b.state] ?? 9));
+
+		const ordered: string[] = [];
+		for (const goal of sortedGoals) {
+			const goalSessions = nonDelegate
+				.filter((s) => s.goalId === goal.id || s.teamGoalId === goal.id)
+				.sort(byAge);
+			for (const s of goalSessions) ordered.push(s.id);
+		}
+		const ungrouped = nonDelegate
+			.filter((s) => !s.goalId && !s.teamGoalId && !staffSessionIds.has(s.id))
+			.sort(byAge);
+		for (const s of ungrouped) ordered.push(s.id);
+		const staffSessions = nonDelegate
+			.filter((s) => staffSessionIds.has(s.id))
+			.sort(byAge);
+		for (const s of staffSessions) ordered.push(s.id);
+
+		if (ordered.length > 1) {
+			const currentId = activeSessionId();
+			const currentIndex = currentId ? ordered.indexOf(currentId) : -1;
+			let nextIndex: number;
+			if (direction === "up") {
+				nextIndex = currentIndex <= 0 ? ordered.length - 1 : currentIndex - 1;
+			} else {
+				nextIndex = currentIndex >= ordered.length - 1 ? 0 : currentIndex + 1;
+			}
+			const nextId = ordered[nextIndex];
+			if (nextId && nextId !== currentId) {
+				connectToSession(nextId, true);
 			}
 		}
+	}
 
-		// Ctrl+/ / Cmd+/ — Focus message input
-		if (mod && e.key === "/") {
-			e.preventDefault();
+	// MIGRATED shortcuts (all allowInInput: true to preserve existing behavior)
+	registerShortcut({
+		id: "new-session", label: "New session", category: "Sessions",
+		defaultBindings: [
+			{ key: "t", ctrlOrMeta: true, shift: false, alt: false },
+			{ key: "n", ctrlOrMeta: false, shift: false, alt: true },
+		],
+		allowInInput: true,
+		handler: () => { if (state.appView === "authenticated") createAndConnectSession(); },
+	});
+
+	registerShortcut({
+		id: "focus-input", label: "Focus message input", category: "Navigation",
+		defaultBindings: [{ key: "/", ctrlOrMeta: true, shift: false, alt: false }],
+		allowInInput: true,
+		handler: () => {
 			const textarea = document.querySelector("message-editor")?.querySelector("textarea");
-			if (textarea) {
-				(textarea as HTMLElement).focus();
-			}
-		}
+			if (textarea) (textarea as HTMLElement).focus();
+		},
+	});
 
-		// Ctrl+[ / Cmd+[ — Toggle sidebar
-		if (mod && e.key === "[") {
-			e.preventDefault();
+	registerShortcut({
+		id: "toggle-sidebar", label: "Toggle sidebar", category: "UI",
+		defaultBindings: [{ key: "[", ctrlOrMeta: true, shift: false, alt: false }],
+		allowInInput: true,
+		handler: () => {
 			state.sidebarCollapsed = !state.sidebarCollapsed;
 			localStorage.setItem("bobbit-sidebar-collapsed", String(state.sidebarCollapsed));
 			renderApp();
-		}
+		},
+	});
 
-		// Ctrl+Up / Cmd+Up — Previous session
-		// Ctrl+Down / Cmd+Down — Next session
-		if (mod && (e.key === "ArrowUp" || e.key === "ArrowDown")) {
-			// Build navigable list: Goals -> Sessions -> Staff
-			// Within each section, oldest session first (by createdAt)
-			const allSessions = state.gatewaySessions;
-			const nonDelegate = allSessions.filter((s) => !s.delegateOf);
-			const staffSessionIds = new Set(state.staffList.map((s) => s.currentSessionId).filter(Boolean));
-			const byAge = (a: { createdAt: number }, b: { createdAt: number }) => a.createdAt - b.createdAt;
-			const stateOrder: Record<string, number> = { "in-progress": 0, "todo": 1, "complete": 2, "shelved": 3 };
-			const sortedGoals = [...state.goals].sort((a, b) => (stateOrder[a.state] ?? 9) - (stateOrder[b.state] ?? 9));
+	registerShortcut({
+		id: "prev-session", label: "Previous session", category: "Sessions",
+		defaultBindings: [{ key: "ArrowUp", ctrlOrMeta: true, shift: false, alt: false }],
+		allowInInput: true,
+		handler: () => navigateSession("up"),
+	});
 
-			const ordered: string[] = [];
-			// 1. Goal sessions (goals sorted by state, sessions by age within each)
-			for (const goal of sortedGoals) {
-				const goalSessions = nonDelegate
-					.filter((s) => s.goalId === goal.id || s.teamGoalId === goal.id)
-					.sort(byAge);
-				for (const s of goalSessions) ordered.push(s.id);
-			}
-			// 2. Ungrouped sessions (by age)
-			const ungrouped = nonDelegate
-				.filter((s) => !s.goalId && !s.teamGoalId && !staffSessionIds.has(s.id))
-				.sort(byAge);
-			for (const s of ungrouped) ordered.push(s.id);
-			// 3. Staff sessions (by age)
-			const staffSessions = nonDelegate
-				.filter((s) => staffSessionIds.has(s.id))
-				.sort(byAge);
-			for (const s of staffSessions) ordered.push(s.id);
+	registerShortcut({
+		id: "next-session", label: "Next session", category: "Sessions",
+		defaultBindings: [{ key: "ArrowDown", ctrlOrMeta: true, shift: false, alt: false }],
+		allowInInput: true,
+		handler: () => navigateSession("down"),
+	});
 
-			if (ordered.length > 1) {
-				const currentId = activeSessionId();
-				const currentIndex = currentId ? ordered.indexOf(currentId) : -1;
-				let nextIndex: number;
-				if (e.key === "ArrowUp") {
-					nextIndex = currentIndex <= 0 ? ordered.length - 1 : currentIndex - 1;
-				} else {
-					nextIndex = currentIndex >= ordered.length - 1 ? 0 : currentIndex + 1;
-				}
-				const nextId = ordered[nextIndex];
-				if (nextId && nextId !== currentId) {
-					e.preventDefault();
-					connectToSession(nextId, true);
-				}
-			}
-		}
-
-		// Ctrl+] / Cmd+] — Toggle preview panel
-		if (mod && e.key === "]") {
+	registerShortcut({
+		id: "toggle-preview", label: "Toggle preview panel", category: "UI",
+		defaultBindings: [{ key: "]", ctrlOrMeta: true, shift: false, alt: false }],
+		allowInInput: true,
+		handler: () => {
 			const hasPanel = !state.assistantType && (state.isPreviewSession || state.activeGoalProposal != null);
 			if (hasPanel) {
-				e.preventDefault();
 				const key = `bobbit-preview-collapsed-${activeSessionId()}`;
 				const collapsed = localStorage.getItem(key) === "true";
 				localStorage.setItem(key, String(!collapsed));
 				renderApp();
 			}
-		}
+		},
 	});
+
+	// NEW shortcuts
+	registerShortcut({
+		id: "new-goal", label: "New goal", category: "Goals",
+		defaultBindings: [{ key: "g", ctrlOrMeta: false, shift: false, alt: true }],
+		handler: () => {
+			import("./dialogs.js").then(({ showGoalDialog }) => showGoalDialog());
+		},
+	});
+
+	registerShortcut({
+		id: "terminate-session", label: "Terminate session", category: "Sessions",
+		defaultBindings: [{ key: "d", ctrlOrMeta: true, shift: true, alt: false }],
+		handler: () => {
+			const id = activeSessionId();
+			if (id) terminateSession(id);
+		},
+	});
+
+	registerShortcut({
+		id: "show-shortcuts", label: "Keyboard shortcuts", category: "UI",
+		defaultBindings: [{ key: "/", ctrlOrMeta: true, shift: true, alt: false }],
+		handler: async () => {
+			const { showShortcutsDialog } = await import("./shortcuts-dialog.js");
+			showShortcutsDialog();
+		},
+	});
+
+	await loadSavedBindings();
+	startListening();
 }
 
 initApp();

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -1,6 +1,6 @@
 import { icon } from "@mariozechner/mini-lit";
 import { html, svg } from "lit";
-import { Goal as GoalIcon, LayoutDashboard, Pencil, Shield, Trash2 } from "lucide";
+import { Goal as GoalIcon, LayoutDashboard, Pencil, Trash2 } from "lucide";
 import {
 	state,
 	renderApp,
@@ -16,7 +16,7 @@ import {
 } from "./state.js";
 import { statusBobbit } from "./session-colors.js";
 import { connectToSession, terminateSession, createAndConnectSession } from "./session-manager.js";
-import { showRenameDialog, showAssignRoleDialog } from "./dialogs.js";
+import { showRenameDialog } from "./dialogs.js";
 import { setHashRoute } from "./routing.js";
 import { startTeam, teardownTeam, refreshSessions } from "./api.js";
 
@@ -215,17 +215,13 @@ export function renderSessionRow(session: GatewaySession) {
 	const btnPad = mobile ? "p-1.5" : "p-0.5";
 
 	// Desktop: hover-revealed gradient overlay. Mobile: always-visible inline buttons.
-	const isTeamAgent = !!session.teamGoalId;
 	const buttons = html`
-		${isTeamAgent ? "" : html`<button class="${btnPad} rounded ${mobile ? "text-muted-foreground active:bg-secondary/80" : "hover:bg-secondary/80 text-muted-foreground hover:text-foreground"}"
-			@click=${(e: Event) => { e.stopPropagation(); showAssignRoleDialog(session.id); }}
-			title="Assign Role">${icon(Shield, "xs")}</button>`}
 		<button class="${btnPad} rounded ${mobile ? "text-muted-foreground active:bg-secondary/80" : "hover:bg-secondary/80 text-muted-foreground hover:text-foreground"}"
 			@click=${(e: Event) => { e.stopPropagation(); showRenameDialog(session.id, displayTitle); }}
-			title="Rename">${icon(Pencil, "xs")}</button>
+			title="Modify">${icon(Pencil, "xs")}</button>
 		<button class="${btnPad} rounded ${mobile ? "text-muted-foreground active:bg-destructive/10" : "hover:bg-destructive/10 text-muted-foreground hover:text-destructive"}"
 			@click=${(e: Event) => { e.stopPropagation(); terminateSession(session.id); }}
-			title="Terminate">${icon(Trash2, "xs")}</button>
+			title="Terminate (Ctrl+Shift+D)">${icon(Trash2, "xs")}</button>
 	`;
 
 	return html`
@@ -288,10 +284,10 @@ function renderTeamLeadRow(session: GatewaySession, childCount: number, expanded
 	const buttons = html`
 		<button class="${btnPad} rounded ${mobile ? "text-muted-foreground active:bg-secondary/80" : "hover:bg-secondary/80 text-muted-foreground hover:text-foreground"}"
 			@click=${(e: Event) => { e.stopPropagation(); showRenameDialog(session.id, displayTitle); }}
-			title="Rename">${icon(Pencil, "xs")}</button>
+			title="Modify">${icon(Pencil, "xs")}</button>
 		<button class="${btnPad} rounded ${mobile ? "text-muted-foreground active:bg-destructive/10" : "hover:bg-destructive/10 text-muted-foreground hover:text-destructive"}"
 			@click=${(e: Event) => { e.stopPropagation(); terminateSession(session.id); }}
-			title="Terminate">${icon(Trash2, "xs")}</button>
+			title="Terminate (Ctrl+Shift+D)">${icon(Trash2, "xs")}</button>
 	`;
 
 	const chevron = html`<span
@@ -340,7 +336,7 @@ function renderGoalBadge(goalId: string) {
 	// PR status takes priority over gate counts
 	const pr = state.prStatusCache.get(goalId);
 	if (pr) {
-		const color = pr.state === "OPEN" ? "#6bc485" : pr.state === "MERGED" ? "#9f8abf" : "#c47070";
+		const color = pr.state === "OPEN" ? "#6bc485" : pr.state === "MERGED" ? "#a87fd4" : "#c47070";
 		const label = pr.number ? `PR #${pr.number} ${pr.state.toLowerCase()}` : `PR ${pr.state.toLowerCase()}`;
 		const icon = html`<svg class="shrink-0" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="${color}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 0 1 2 2v7"/><path d="M6 9v12"/></svg>`;
 		if (pr.url) {

--- a/src/app/shortcut-registry.ts
+++ b/src/app/shortcut-registry.ts
@@ -1,0 +1,288 @@
+/**
+ * Central keyboard shortcut registry.
+ *
+ * Replaces the hardcoded keydown listener in main.ts with a data-driven
+ * registry that supports rebinding, persistence, and conflict detection.
+ */
+
+import { getAppStorage } from "../ui/storage/app-storage.js";
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+export interface KeyBinding {
+	key: string;           // e.g. "t", "/", "[", "ArrowUp"
+	ctrlOrMeta: boolean;   // true = Ctrl on Win/Linux, Cmd on Mac
+	shift: boolean;
+	alt: boolean;
+}
+
+export interface ShortcutEntry {
+	id: string;
+	label: string;
+	category: string;
+	defaultBindings: KeyBinding[];
+	currentBindings: KeyBinding[];
+	allowInInput?: boolean;
+	handler: () => void;
+}
+
+// ============================================================================
+// PLATFORM DETECTION
+// ============================================================================
+
+const isMac = typeof navigator !== "undefined"
+	? /Mac|iPhone|iPad/.test(navigator.platform || navigator.userAgent)
+	: false;
+
+// ============================================================================
+// REGISTRY
+// ============================================================================
+
+const shortcuts: Map<string, ShortcutEntry> = new Map();
+
+/**
+ * Register a shortcut. If `currentBindings` is omitted, it is
+ * auto-cloned from `defaultBindings`.
+ */
+export function registerShortcut(
+	entry: Omit<ShortcutEntry, "currentBindings"> & { currentBindings?: KeyBinding[] },
+): void {
+	const full: ShortcutEntry = {
+		...entry,
+		currentBindings: entry.currentBindings
+			? entry.currentBindings
+			: entry.defaultBindings.map((b) => ({ ...b })),
+	};
+	shortcuts.set(full.id, full);
+}
+
+export function unregisterShortcut(id: string): void {
+	shortcuts.delete(id);
+}
+
+export function getShortcuts(): ShortcutEntry[] {
+	return [...shortcuts.values()];
+}
+
+export function getShortcutById(id: string): ShortcutEntry | undefined {
+	return shortcuts.get(id);
+}
+
+export function updateBinding(id: string, bindingIndex: number, newBinding: KeyBinding): void {
+	const entry = shortcuts.get(id);
+	if (!entry || bindingIndex < 0 || bindingIndex >= entry.currentBindings.length) return;
+	entry.currentBindings[bindingIndex] = { ...newBinding };
+}
+
+export function addBinding(id: string, binding: KeyBinding): void {
+	const entry = shortcuts.get(id);
+	if (!entry) return;
+	entry.currentBindings.push({ ...binding });
+}
+
+export function removeBinding(id: string, bindingIndex: number): void {
+	const entry = shortcuts.get(id);
+	if (!entry || bindingIndex < 0 || bindingIndex >= entry.currentBindings.length) return;
+	entry.currentBindings.splice(bindingIndex, 1);
+}
+
+export function resetBinding(id: string): void {
+	const entry = shortcuts.get(id);
+	if (!entry) return;
+	entry.currentBindings = entry.defaultBindings.map((b) => ({ ...b }));
+}
+
+export function resetAllBindings(): void {
+	for (const entry of shortcuts.values()) {
+		entry.currentBindings = entry.defaultBindings.map((b) => ({ ...b }));
+	}
+}
+
+/**
+ * Find a shortcut that already uses the given binding.
+ * Optionally exclude a shortcut ID (e.g. the one being rebound).
+ */
+export function findConflict(binding: KeyBinding, excludeId?: string): ShortcutEntry | undefined {
+	for (const entry of shortcuts.values()) {
+		if (entry.id === excludeId) continue;
+		for (const b of entry.currentBindings) {
+			if (bindingsEqual(b, binding)) return entry;
+		}
+	}
+	return undefined;
+}
+
+export function bindingsEqual(a: KeyBinding, b: KeyBinding): boolean {
+	return (
+		a.key.toLowerCase() === b.key.toLowerCase() &&
+		a.ctrlOrMeta === b.ctrlOrMeta &&
+		a.shift === b.shift &&
+		a.alt === b.alt
+	);
+}
+
+// ============================================================================
+// FORMATTING
+// ============================================================================
+
+const SPECIAL_KEYS: Record<string, string> = {
+	arrowup: "↑",
+	arrowdown: "↓",
+	arrowleft: "←",
+	arrowright: "→",
+	escape: "Esc",
+	backspace: "⌫",
+	delete: "Del",
+	enter: "↵",
+	tab: "Tab",
+	" ": "Space",
+};
+
+export function formatBinding(binding: KeyBinding): string {
+	const parts: string[] = [];
+	if (binding.ctrlOrMeta) parts.push(isMac ? "Cmd" : "Ctrl");
+	if (binding.shift) parts.push("Shift");
+	if (binding.alt) parts.push("Alt");
+
+	const keyLower = binding.key.toLowerCase();
+	const keyDisplay = SPECIAL_KEYS[keyLower] ?? binding.key.toUpperCase();
+	parts.push(keyDisplay);
+
+	return parts.join("+");
+}
+
+// ============================================================================
+// BROWSER-RESERVED COMBOS
+// ============================================================================
+
+const BROWSER_RESERVED: KeyBinding[] = [
+	{ key: "w", ctrlOrMeta: true, shift: false, alt: false },   // Close tab
+	{ key: "n", ctrlOrMeta: true, shift: false, alt: false },   // New window
+	{ key: "Tab", ctrlOrMeta: true, shift: false, alt: false }, // Next tab
+	{ key: "l", ctrlOrMeta: true, shift: false, alt: false },   // Address bar
+	{ key: "d", ctrlOrMeta: true, shift: false, alt: false },   // Bookmark
+	{ key: "q", ctrlOrMeta: true, shift: false, alt: false },   // Quit
+	{ key: "r", ctrlOrMeta: true, shift: false, alt: false },   // Reload
+	{ key: "p", ctrlOrMeta: true, shift: false, alt: false },   // Print
+	{ key: "f", ctrlOrMeta: true, shift: false, alt: false },   // Find
+];
+
+export function isBrowserReserved(binding: KeyBinding): boolean {
+	return BROWSER_RESERVED.some((reserved) => bindingsEqual(reserved, binding));
+}
+
+// ============================================================================
+// KEYDOWN LISTENER
+// ============================================================================
+
+function matchesBinding(e: KeyboardEvent, b: KeyBinding): boolean {
+	const modMatch = b.ctrlOrMeta
+		? (isMac ? e.metaKey : e.ctrlKey)
+		: !(isMac ? e.metaKey : e.ctrlKey);
+	return (
+		modMatch &&
+		e.shiftKey === b.shift &&
+		e.altKey === b.alt &&
+		e.key.toLowerCase() === b.key.toLowerCase()
+	);
+}
+
+function isInputFocused(): boolean {
+	const active = document.activeElement;
+	if (!active) return false;
+
+	// Check the directly focused element
+	if (isInputElement(active)) return true;
+
+	// Check inside shadow DOM
+	const shadowActive = (active as any).shadowRoot?.activeElement;
+	if (shadowActive && isInputElement(shadowActive)) return true;
+
+	return false;
+}
+
+function isInputElement(el: Element): boolean {
+	const tag = el.tagName.toLowerCase();
+	if (tag === "input" || tag === "textarea") return true;
+	if (el.hasAttribute("contenteditable") && el.getAttribute("contenteditable") !== "false") return true;
+	return false;
+}
+
+function handleKeydown(e: KeyboardEvent): void {
+	// Ignore bare modifier presses
+	if (["Control", "Meta", "Shift", "Alt"].includes(e.key)) return;
+
+	const inputFocused = isInputFocused();
+
+	for (const entry of shortcuts.values()) {
+		if (inputFocused && !entry.allowInInput) continue;
+
+		for (const binding of entry.currentBindings) {
+			if (matchesBinding(e, binding)) {
+				e.preventDefault();
+				entry.handler();
+				return;
+			}
+		}
+	}
+}
+
+let listening = false;
+
+export function startListening(): void {
+	if (listening) return;
+	listening = true;
+	window.addEventListener("keydown", handleKeydown);
+}
+
+export function stopListening(): void {
+	if (!listening) return;
+	listening = false;
+	window.removeEventListener("keydown", handleKeydown);
+}
+
+// ============================================================================
+// PERSISTENCE
+// ============================================================================
+
+export async function loadSavedBindings(): Promise<void> {
+	try {
+		const store = getAppStorage().shortcutBindings;
+		const saved = await store.getBindings();
+		if (!saved) return;
+
+		for (const [id, bindings] of Object.entries(saved)) {
+			const entry = shortcuts.get(id);
+			if (entry && Array.isArray(bindings) && bindings.length > 0) {
+				entry.currentBindings = bindings.map((b) => ({ ...b }));
+			}
+		}
+	} catch {
+		// Silently ignore — use defaults
+	}
+}
+
+export async function saveBindings(): Promise<void> {
+	try {
+		const store = getAppStorage().shortcutBindings;
+		const data: Record<string, KeyBinding[]> = {};
+		for (const entry of shortcuts.values()) {
+			// Only save if current differs from default
+			const isDefault =
+				entry.currentBindings.length === entry.defaultBindings.length &&
+				entry.currentBindings.every((cb, i) => bindingsEqual(cb, entry.defaultBindings[i]));
+			if (!isDefault) {
+				data[entry.id] = entry.currentBindings.map((b) => ({ ...b }));
+			}
+		}
+		if (Object.keys(data).length > 0) {
+			await store.saveBindings(data);
+		} else {
+			await store.clearBindings();
+		}
+	} catch {
+		// Silently ignore
+	}
+}

--- a/src/app/shortcuts-dialog.ts
+++ b/src/app/shortcuts-dialog.ts
@@ -1,0 +1,395 @@
+/**
+ * Keyboard shortcuts dialog — view and rebind shortcuts.
+ */
+
+import { icon } from "@mariozechner/mini-lit";
+import { Button } from "@mariozechner/mini-lit/dist/Button.js";
+import { Dialog, DialogContent, DialogFooter, DialogHeader } from "@mariozechner/mini-lit/dist/Dialog.js";
+import { html, render } from "lit";
+import { RotateCcw } from "lucide";
+import {
+	getShortcuts,
+	formatBinding,
+	findConflict,
+	isBrowserReserved,
+	updateBinding,
+	addBinding,
+	removeBinding,
+	resetBinding,
+	resetAllBindings,
+	saveBindings,
+	bindingsEqual,
+	type KeyBinding,
+	type ShortcutEntry,
+} from "./shortcut-registry.js";
+
+// ============================================================================
+// STATE
+// ============================================================================
+
+let dialogContainer: HTMLDivElement | null = null;
+
+// Rebind state
+let rebindingId: string | null = null;
+let rebindingIndex: number | null = null; // null = adding new binding
+let pendingBinding: KeyBinding | null = null;
+let conflictEntry: ShortcutEntry | null = null;
+let browserReservedWarning = false;
+
+function resetRebindState(): void {
+	rebindingId = null;
+	rebindingIndex = null;
+	pendingBinding = null;
+	conflictEntry = null;
+	browserReservedWarning = false;
+}
+
+// ============================================================================
+// PUBLIC API
+// ============================================================================
+
+export function showShortcutsDialog(): void {
+	if (dialogContainer) return; // already open
+	dialogContainer = document.createElement("div");
+	document.body.appendChild(dialogContainer);
+	resetRebindState();
+	renderDialog();
+}
+
+export function hideShortcutsDialog(): void {
+	if (!dialogContainer) return;
+	resetRebindState();
+	render(html``, dialogContainer);
+	dialogContainer.remove();
+	dialogContainer = null;
+}
+
+// ============================================================================
+// REBIND KEYDOWN HANDLER
+// ============================================================================
+
+function handleRebindKeydown(e: KeyboardEvent): void {
+	e.preventDefault();
+	e.stopPropagation();
+
+	// Ignore bare modifier presses
+	if (["Control", "Meta", "Shift", "Alt"].includes(e.key)) return;
+
+	// Escape cancels rebind
+	if (e.key === "Escape") {
+		resetRebindState();
+		renderDialog();
+		return;
+	}
+
+	const isMac = /Mac|iPhone|iPad/.test(navigator.platform || navigator.userAgent);
+	const newBinding: KeyBinding = {
+		key: e.key,
+		ctrlOrMeta: isMac ? e.metaKey : e.ctrlKey,
+		shift: e.shiftKey,
+		alt: e.altKey,
+	};
+
+	// Check for duplicate on the same action
+	if (rebindingId) {
+		const entry = getShortcuts().find((s) => s.id === rebindingId);
+		if (entry) {
+			const isDuplicate = entry.currentBindings.some((b) => bindingsEqual(b, newBinding));
+			if (isDuplicate) {
+				// No-op — binding already exists on this action
+				resetRebindState();
+				renderDialog();
+				return;
+			}
+		}
+	}
+
+	// Check for conflict with another action
+	const conflict = findConflict(newBinding, rebindingId ?? undefined);
+	if (conflict) {
+		pendingBinding = newBinding;
+		conflictEntry = conflict;
+		browserReservedWarning = false;
+		renderDialog();
+		return;
+	}
+
+	// Check for browser-reserved combo
+	if (isBrowserReserved(newBinding)) {
+		pendingBinding = newBinding;
+		conflictEntry = null;
+		browserReservedWarning = true;
+		renderDialog();
+		return;
+	}
+
+	// Apply binding
+	applyBinding(newBinding);
+}
+
+async function applyBinding(binding: KeyBinding): Promise<void> {
+	if (!rebindingId) return;
+
+	if (rebindingIndex !== null) {
+		updateBinding(rebindingId, rebindingIndex, binding);
+	} else {
+		addBinding(rebindingId, binding);
+	}
+
+	resetRebindState();
+	await saveBindings();
+	renderDialog();
+}
+
+async function unbindConflictAndApply(): Promise<void> {
+	if (!conflictEntry || !pendingBinding || !rebindingId) return;
+
+	// Remove the conflicting binding from the other action
+	const conflictBindingIndex = conflictEntry.currentBindings.findIndex((b) =>
+		bindingsEqual(b, pendingBinding!),
+	);
+	if (conflictBindingIndex >= 0) {
+		removeBinding(conflictEntry.id, conflictBindingIndex);
+	}
+
+	const binding = pendingBinding;
+	pendingBinding = null;
+	conflictEntry = null;
+	browserReservedWarning = false;
+
+	await applyBinding(binding);
+}
+
+async function acceptBrowserReservedAndApply(): Promise<void> {
+	if (!pendingBinding) return;
+	const binding = pendingBinding;
+	pendingBinding = null;
+	browserReservedWarning = false;
+	await applyBinding(binding);
+}
+
+async function handleResetBinding(id: string): Promise<void> {
+	resetBinding(id);
+	await saveBindings();
+	renderDialog();
+}
+
+async function handleResetAll(): Promise<void> {
+	resetAllBindings();
+	await saveBindings();
+	renderDialog();
+}
+
+async function handleRemoveBinding(id: string, index: number): Promise<void> {
+	removeBinding(id, index);
+	await saveBindings();
+	renderDialog();
+}
+
+// ============================================================================
+// RENDER
+// ============================================================================
+
+function renderDialog(): void {
+	if (!dialogContainer) return;
+
+	const allShortcuts = getShortcuts();
+
+	// Group by category
+	const categories = new Map<string, ShortcutEntry[]>();
+	for (const entry of allShortcuts) {
+		const list = categories.get(entry.category) || [];
+		list.push(entry);
+		categories.set(entry.category, list);
+	}
+
+	// Category display order
+	const categoryOrder = ["Sessions", "Navigation", "Goals", "UI"];
+	const sortedCategories = [...categories.entries()].sort((a, b) => {
+		const ai = categoryOrder.indexOf(a[0]);
+		const bi = categoryOrder.indexOf(b[0]);
+		return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
+	});
+
+	const isRebinding = rebindingId !== null;
+
+	render(
+		Dialog({
+			isOpen: true,
+			onClose: () => {
+				if (isRebinding && !pendingBinding && !conflictEntry && !browserReservedWarning) {
+					resetRebindState();
+					renderDialog();
+					return;
+				}
+				hideShortcutsDialog();
+			},
+			width: "min(520px, 92vw)",
+			height: "auto",
+			className: "max-h-[80vh]",
+			backdropClassName: "bg-black/50 backdrop-blur-sm",
+			children: html`
+				${DialogContent({
+					className: "overflow-y-auto",
+					children: html`
+						${DialogHeader({ title: "Keyboard Shortcuts" })}
+						<div class="mt-3 flex flex-col gap-4">
+							${sortedCategories.map(
+								([category, entries]) => html`
+									<div>
+										<div class="text-[10px] text-muted-foreground uppercase tracking-wider font-medium mb-1.5 px-1">
+											${category}
+										</div>
+										<div class="flex flex-col gap-0.5">
+											${entries.map((entry) => renderShortcutRow(entry))}
+										</div>
+									</div>
+								`,
+							)}
+						</div>
+					`,
+				})}
+				${DialogFooter({
+					className: "px-6 pb-4",
+					children: html`
+						<div class="flex gap-2 justify-between w-full">
+							<div>
+								${Button({
+									variant: "ghost",
+									size: "sm",
+									onClick: handleResetAll,
+									children: html`${icon(RotateCcw, "xs")}<span class="ml-1">Reset All Defaults</span>`,
+								})}
+							</div>
+							<div>
+								${Button({ variant: "ghost", onClick: () => hideShortcutsDialog(), children: "Close" })}
+							</div>
+						</div>
+					`,
+				})}
+			`,
+		}),
+		dialogContainer,
+	);
+
+	// Attach or detach rebind keydown listener
+	if (isRebinding && !pendingBinding && !conflictEntry && !browserReservedWarning) {
+		window.addEventListener("keydown", handleRebindKeydown, true);
+	} else {
+		window.removeEventListener("keydown", handleRebindKeydown, true);
+	}
+}
+
+function renderShortcutRow(entry: ShortcutEntry) {
+	const isActiveRebind = rebindingId === entry.id;
+	const showConflict = isActiveRebind && conflictEntry !== null && pendingBinding !== null;
+	const showBrowserWarning = isActiveRebind && browserReservedWarning && pendingBinding !== null;
+
+	// Check if current bindings differ from defaults
+	const isCustom =
+		entry.currentBindings.length !== entry.defaultBindings.length ||
+		!entry.currentBindings.every((cb, i) => bindingsEqual(cb, entry.defaultBindings[i]));
+
+	return html`
+		<div class="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-secondary/30 transition-colors group">
+			<span class="flex-1 text-sm text-foreground">${entry.label}</span>
+			<div class="flex items-center gap-1.5">
+				${entry.currentBindings.map((binding, idx) => {
+					const isThisRebinding = isActiveRebind && rebindingIndex === idx && !pendingBinding;
+					return html`
+						<button
+							class="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-xs font-mono transition-all
+								${isThisRebinding
+									? "bg-primary/20 text-primary border border-primary animate-pulse"
+									: "bg-secondary text-secondary-foreground hover:bg-secondary/80 border border-transparent"}"
+							@click=${() => startRebind(entry.id, idx)}
+							title=${isThisRebinding ? "Press a key combo..." : `Click to rebind (${formatBinding(binding)})`}
+						>
+							${isThisRebinding ? "Press a key combo..." : formatBinding(binding)}
+						</button>
+					`;
+				})}
+				${entry.currentBindings.length === 0
+					? html`<button
+							class="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-xs font-mono
+								${isActiveRebind && rebindingIndex === null && !pendingBinding
+									? "bg-primary/20 text-primary border border-primary animate-pulse"
+									: "bg-secondary/50 text-muted-foreground hover:bg-secondary/80 border border-dashed border-border"}"
+							@click=${() => startRebind(entry.id, null)}
+						>
+							${isActiveRebind && rebindingIndex === null && !pendingBinding
+								? "Press a key combo..."
+								: "Add binding"}
+						</button>`
+					: ""}
+				${isCustom
+					? html`<button
+							class="p-0.5 rounded text-muted-foreground hover:text-foreground hover:bg-secondary/80 transition-colors opacity-0 group-hover:opacity-100"
+							@click=${() => handleResetBinding(entry.id)}
+							title="Reset to default"
+						>${icon(RotateCcw, "xs")}</button>`
+					: ""}
+			</div>
+		</div>
+		${showConflict
+			? html`
+					<div class="mx-2 mb-1 px-3 py-2 rounded-md bg-destructive/10 border border-destructive/20 text-sm">
+						<p class="text-destructive mb-2">
+							<strong>${formatBinding(pendingBinding!)}</strong> is already bound to
+							<strong>${conflictEntry!.label}</strong>.
+						</p>
+						<div class="flex gap-2">
+							${Button({
+								size: "sm",
+								onClick: unbindConflictAndApply,
+								children: "Unbind & Assign",
+							})}
+							${Button({
+								variant: "ghost",
+								size: "sm",
+								onClick: () => {
+									resetRebindState();
+									renderDialog();
+								},
+								children: "Cancel",
+							})}
+						</div>
+					</div>
+				`
+			: ""}
+		${showBrowserWarning
+			? html`
+					<div class="mx-2 mb-1 px-3 py-2 rounded-md bg-yellow-500/10 border border-yellow-500/20 text-sm">
+						<p class="text-yellow-600 dark:text-yellow-400 mb-2">
+							<strong>${formatBinding(pendingBinding!)}</strong> may be intercepted by the browser.
+						</p>
+						<div class="flex gap-2">
+							${Button({
+								size: "sm",
+								onClick: acceptBrowserReservedAndApply,
+								children: "Assign Anyway",
+							})}
+							${Button({
+								variant: "ghost",
+								size: "sm",
+								onClick: () => {
+									resetRebindState();
+									renderDialog();
+								},
+								children: "Cancel",
+							})}
+						</div>
+					</div>
+				`
+			: ""}
+	`;
+}
+
+function startRebind(id: string, index: number | null): void {
+	rebindingId = id;
+	rebindingIndex = index;
+	pendingBinding = null;
+	conflictEntry = null;
+	browserReservedWarning = false;
+	renderDialog();
+}

--- a/src/app/shortcuts-dialog.ts
+++ b/src/app/shortcuts-dialog.ts
@@ -59,6 +59,7 @@ export function showShortcutsDialog(): void {
 export function hideShortcutsDialog(): void {
 	if (!dialogContainer) return;
 	resetRebindState();
+	window.removeEventListener("keydown", handleRebindKeydown, true);
 	render(html``, dialogContainer);
 	dialogContainer.remove();
 	dialogContainer = null;

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -1,6 +1,6 @@
 import { icon } from "@mariozechner/mini-lit";
 import { html } from "lit";
-import { Bot, ChevronDown, Drama, Goal as GoalIcon, List, MessagesSquare, PanelLeftClose, PanelLeftOpen, Pencil, Plus, Users, Workflow, Wrench } from "lucide";
+import { Bot, ChevronDown, Drama, Goal as GoalIcon, Keyboard, List, MessagesSquare, PanelLeftClose, PanelLeftOpen, Pencil, Plus, Users, Workflow, Wrench } from "lucide";
 import {
 	state,
 	renderApp,
@@ -436,6 +436,14 @@ export function renderSidebar() {
 				}
 			</div>
 			<div class="flex items-center border-t border-border/50">
+				<button
+					class="flex items-center gap-1.5 px-3 py-2 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary/50 transition-colors"
+					@click=${() => { import("./shortcuts-dialog.js").then((m) => m.showShortcutsDialog()); }}
+					title="Keyboard shortcuts (Ctrl+Shift+/)"
+				>
+					${icon(Keyboard, "sm")}
+					<span>Shortcuts</span>
+				</button>
 				<span class="flex-1"></span>
 				<button
 					class="flex items-center gap-1.5 px-3 py-2 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary/50 transition-colors"

--- a/src/app/storage.ts
+++ b/src/app/storage.ts
@@ -5,6 +5,7 @@ import {
 	ProviderKeysStore,
 	SessionsStore,
 	SettingsStore,
+	ShortcutBindingsStore,
 	setAppStorage,
 } from "../ui/index.js";
 import { CommandHistoryStore } from "../ui/storage/stores/command-history-store.js";
@@ -14,10 +15,11 @@ const providerKeys = new ProviderKeysStore();
 const sessions = new SessionsStore();
 const customProviders = new CustomProvidersStore();
 const commandHistory = new CommandHistoryStore();
+const shortcutBindings = new ShortcutBindingsStore();
 
 const backend = new IndexedDBStorageBackend({
 	dbName: "pi-gateway-ui",
-	version: 5,
+	version: 6,
 	stores: [
 		settings.getConfig(),
 		SessionsStore.getMetadataConfig(),
@@ -25,6 +27,7 @@ const backend = new IndexedDBStorageBackend({
 		customProviders.getConfig(),
 		sessions.getConfig(),
 		commandHistory.getConfig(),
+		shortcutBindings.getConfig(),
 	],
 });
 
@@ -33,6 +36,7 @@ providerKeys.setBackend(backend);
 customProviders.setBackend(backend);
 sessions.setBackend(backend);
 commandHistory.setBackend(backend);
+shortcutBindings.setBackend(backend);
 
-export const storage = new AppStorage(settings, providerKeys, sessions, customProviders, commandHistory, backend);
+export const storage = new AppStorage(settings, providerKeys, sessions, customProviders, commandHistory, shortcutBindings, backend);
 setAppStorage(storage);

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -85,6 +85,7 @@ export type { CommandHistoryEntry } from "./storage/stores/command-history-store
 export { ProviderKeysStore } from "./storage/stores/provider-keys-store.js";
 export { SessionsStore } from "./storage/stores/sessions-store.js";
 export { SettingsStore } from "./storage/stores/settings-store.js";
+export { ShortcutBindingsStore } from "./storage/stores/shortcut-bindings-store.js";
 export type {
 	IndexConfig,
 	IndexedDBConfig,

--- a/src/ui/storage/app-storage.ts
+++ b/src/ui/storage/app-storage.ts
@@ -3,6 +3,7 @@ import type { CustomProvidersStore } from "./stores/custom-providers-store.js";
 import type { ProviderKeysStore } from "./stores/provider-keys-store.js";
 import type { SessionsStore } from "./stores/sessions-store.js";
 import type { SettingsStore } from "./stores/settings-store.js";
+import type { ShortcutBindingsStore } from "./stores/shortcut-bindings-store.js";
 import type { StorageBackend } from "./types.js";
 
 /**
@@ -16,6 +17,7 @@ export class AppStorage {
 	readonly sessions: SessionsStore;
 	readonly customProviders: CustomProvidersStore;
 	readonly commandHistory: CommandHistoryStore;
+	readonly shortcutBindings: ShortcutBindingsStore;
 
 	constructor(
 		settings: SettingsStore,
@@ -23,6 +25,7 @@ export class AppStorage {
 		sessions: SessionsStore,
 		customProviders: CustomProvidersStore,
 		commandHistory: CommandHistoryStore,
+		shortcutBindings: ShortcutBindingsStore,
 		backend: StorageBackend,
 	) {
 		this.settings = settings;
@@ -30,6 +33,7 @@ export class AppStorage {
 		this.sessions = sessions;
 		this.customProviders = customProviders;
 		this.commandHistory = commandHistory;
+		this.shortcutBindings = shortcutBindings;
 		this.backend = backend;
 	}
 

--- a/src/ui/storage/stores/shortcut-bindings-store.ts
+++ b/src/ui/storage/stores/shortcut-bindings-store.ts
@@ -1,0 +1,33 @@
+import { Store } from "../store.js";
+import type { StoreConfig } from "../types.js";
+
+export interface StoredKeyBinding {
+	key: string;
+	ctrlOrMeta: boolean;
+	shift: boolean;
+	alt: boolean;
+}
+
+/**
+ * Store for persisting custom keyboard shortcut bindings.
+ * Stores all bindings under a single "bindings" key as a flat map.
+ */
+export class ShortcutBindingsStore extends Store {
+	getConfig(): StoreConfig {
+		return {
+			name: "shortcut-bindings",
+		};
+	}
+
+	async getBindings(): Promise<Record<string, StoredKeyBinding[]> | null> {
+		return this.getBackend().get("shortcut-bindings", "bindings");
+	}
+
+	async saveBindings(bindings: Record<string, StoredKeyBinding[]>): Promise<void> {
+		await this.getBackend().set("shortcut-bindings", "bindings", bindings);
+	}
+
+	async clearBindings(): Promise<void> {
+		await this.getBackend().delete("shortcut-bindings", "bindings");
+	}
+}

--- a/tests/fixtures/shortcut-registry.html
+++ b/tests/fixtures/shortcut-registry.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html>
+<head><title>Shortcut Registry Tests</title></head>
+<body>
+<input id="test-input" type="text" />
+<textarea id="test-textarea"></textarea>
+<div id="test-contenteditable" contenteditable="true">editable</div>
+<div id="test-div">not editable</div>
+
+<script>
+// ============================================================================
+// Inlined shortcut registry logic (from src/app/shortcut-registry.ts)
+// Persistence (loadSavedBindings/saveBindings) is excluded — requires IndexedDB
+// ============================================================================
+
+// Allow tests to override platform detection
+let _isMac = false;
+
+const shortcuts = new Map();
+
+function registerShortcut(entry) {
+	const full = {
+		...entry,
+		currentBindings: entry.currentBindings
+			? entry.currentBindings
+			: entry.defaultBindings.map((b) => ({ ...b })),
+	};
+	shortcuts.set(full.id, full);
+}
+
+function unregisterShortcut(id) {
+	shortcuts.delete(id);
+}
+
+function getShortcuts() {
+	return [...shortcuts.values()];
+}
+
+function getShortcutById(id) {
+	return shortcuts.get(id);
+}
+
+function updateBinding(id, bindingIndex, newBinding) {
+	const entry = shortcuts.get(id);
+	if (!entry || bindingIndex < 0 || bindingIndex >= entry.currentBindings.length) return;
+	entry.currentBindings[bindingIndex] = { ...newBinding };
+}
+
+function addBinding(id, binding) {
+	const entry = shortcuts.get(id);
+	if (!entry) return;
+	entry.currentBindings.push({ ...binding });
+}
+
+function removeBinding(id, bindingIndex) {
+	const entry = shortcuts.get(id);
+	if (!entry || bindingIndex < 0 || bindingIndex >= entry.currentBindings.length) return;
+	entry.currentBindings.splice(bindingIndex, 1);
+}
+
+function resetBinding(id) {
+	const entry = shortcuts.get(id);
+	if (!entry) return;
+	entry.currentBindings = entry.defaultBindings.map((b) => ({ ...b }));
+}
+
+function resetAllBindings() {
+	for (const entry of shortcuts.values()) {
+		entry.currentBindings = entry.defaultBindings.map((b) => ({ ...b }));
+	}
+}
+
+function bindingsEqual(a, b) {
+	return (
+		a.key.toLowerCase() === b.key.toLowerCase() &&
+		a.ctrlOrMeta === b.ctrlOrMeta &&
+		a.shift === b.shift &&
+		a.alt === b.alt
+	);
+}
+
+function findConflict(binding, excludeId) {
+	for (const entry of shortcuts.values()) {
+		if (entry.id === excludeId) continue;
+		for (const b of entry.currentBindings) {
+			if (bindingsEqual(b, binding)) return entry;
+		}
+	}
+	return undefined;
+}
+
+// Formatting
+const SPECIAL_KEYS = {
+	arrowup: "↑",
+	arrowdown: "↓",
+	arrowleft: "←",
+	arrowright: "→",
+	escape: "Esc",
+	backspace: "⌫",
+	delete: "Del",
+	enter: "↵",
+	tab: "Tab",
+	" ": "Space",
+};
+
+function formatBinding(binding) {
+	const parts = [];
+	if (binding.ctrlOrMeta) parts.push(_isMac ? "Cmd" : "Ctrl");
+	if (binding.shift) parts.push("Shift");
+	if (binding.alt) parts.push("Alt");
+
+	const keyLower = binding.key.toLowerCase();
+	const keyDisplay = SPECIAL_KEYS[keyLower] ?? binding.key.toUpperCase();
+	parts.push(keyDisplay);
+
+	return parts.join("+");
+}
+
+// Browser reserved combos
+const BROWSER_RESERVED = [
+	{ key: "w", ctrlOrMeta: true, shift: false, alt: false },
+	{ key: "n", ctrlOrMeta: true, shift: false, alt: false },
+	{ key: "Tab", ctrlOrMeta: true, shift: false, alt: false },
+	{ key: "l", ctrlOrMeta: true, shift: false, alt: false },
+	{ key: "d", ctrlOrMeta: true, shift: false, alt: false },
+	{ key: "q", ctrlOrMeta: true, shift: false, alt: false },
+	{ key: "r", ctrlOrMeta: true, shift: false, alt: false },
+	{ key: "p", ctrlOrMeta: true, shift: false, alt: false },
+	{ key: "f", ctrlOrMeta: true, shift: false, alt: false },
+];
+
+function isBrowserReserved(binding) {
+	return BROWSER_RESERVED.some((reserved) => bindingsEqual(reserved, binding));
+}
+
+// Keydown listener
+function matchesBinding(e, b) {
+	const modMatch = b.ctrlOrMeta
+		? (_isMac ? e.metaKey : e.ctrlKey)
+		: !(_isMac ? e.metaKey : e.ctrlKey);
+	return (
+		modMatch &&
+		e.shiftKey === b.shift &&
+		e.altKey === b.alt &&
+		e.key.toLowerCase() === b.key.toLowerCase()
+	);
+}
+
+function isInputFocused() {
+	const active = document.activeElement;
+	if (!active) return false;
+	if (isInputElement(active)) return true;
+	const shadowActive = active.shadowRoot?.activeElement;
+	if (shadowActive && isInputElement(shadowActive)) return true;
+	return false;
+}
+
+function isInputElement(el) {
+	const tag = el.tagName.toLowerCase();
+	if (tag === "input" || tag === "textarea") return true;
+	if (el.hasAttribute("contenteditable") && el.getAttribute("contenteditable") !== "false") return true;
+	return false;
+}
+
+function handleKeydown(e) {
+	if (["Control", "Meta", "Shift", "Alt"].includes(e.key)) return;
+	const inputFocused = isInputFocused();
+	for (const entry of shortcuts.values()) {
+		if (inputFocused && !entry.allowInInput) continue;
+		for (const binding of entry.currentBindings) {
+			if (matchesBinding(e, binding)) {
+				e.preventDefault();
+				entry.handler();
+				return;
+			}
+		}
+	}
+}
+
+let listening = false;
+
+function startListening() {
+	if (listening) return;
+	listening = true;
+	window.addEventListener("keydown", handleKeydown);
+}
+
+function stopListening() {
+	if (!listening) return;
+	listening = false;
+	window.removeEventListener("keydown", handleKeydown);
+}
+
+function clearAll() {
+	shortcuts.clear();
+	stopListening();
+}
+
+// Expose on window for Playwright tests
+window.__registry = {
+	registerShortcut,
+	unregisterShortcut,
+	getShortcuts,
+	getShortcutById,
+	updateBinding,
+	addBinding,
+	removeBinding,
+	resetBinding,
+	resetAllBindings,
+	findConflict,
+	bindingsEqual,
+	formatBinding,
+	isBrowserReserved,
+	matchesBinding,
+	startListening,
+	stopListening,
+	clearAll,
+	setMac: (val) => { _isMac = val; },
+};
+</script>
+</body>
+</html>

--- a/tests/shortcut-registry.spec.ts
+++ b/tests/shortcut-registry.spec.ts
@@ -1,0 +1,626 @@
+import { test, expect } from "@playwright/test";
+import path from "node:path";
+
+const TEST_PAGE = `file://${path.resolve("tests/fixtures/shortcut-registry.html")}`;
+
+function reg(page: any) {
+	return page.evaluate("window.__registry");
+}
+
+test.describe("Shortcut Registry", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(TEST_PAGE);
+		await page.evaluate(() => (window as any).__registry.clearAll());
+	});
+
+	// ========================================================================
+	// 1. registerShortcut + getShortcuts
+	// ========================================================================
+	test("registerShortcut adds entry, getShortcuts returns it", async ({ page }) => {
+		const count = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			r.registerShortcut({
+				id: "test-1",
+				label: "Test One",
+				category: "Testing",
+				defaultBindings: [{ key: "t", ctrlOrMeta: true, shift: false, alt: false }],
+				handler: () => {},
+			});
+			return r.getShortcuts().length;
+		});
+		expect(count).toBe(1);
+
+		const entry = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			const e = r.getShortcutById("test-1");
+			return { id: e.id, label: e.label, category: e.category };
+		});
+		expect(entry).toEqual({ id: "test-1", label: "Test One", category: "Testing" });
+	});
+
+	// ========================================================================
+	// 2. currentBindings auto-cloned from defaultBindings
+	// ========================================================================
+	test("currentBindings auto-cloned from defaultBindings when omitted", async ({ page }) => {
+		const result = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			r.registerShortcut({
+				id: "clone-test",
+				label: "Clone",
+				category: "Test",
+				defaultBindings: [{ key: "c", ctrlOrMeta: true, shift: false, alt: false }],
+				handler: () => {},
+			});
+			const e = r.getShortcutById("clone-test");
+			// currentBindings should equal defaultBindings
+			const equal = r.bindingsEqual(e.currentBindings[0], e.defaultBindings[0]);
+			// But should NOT be the same object reference
+			const sameRef = e.currentBindings[0] === e.defaultBindings[0];
+			return { equal, sameRef, len: e.currentBindings.length };
+		});
+		expect(result.equal).toBe(true);
+		expect(result.sameRef).toBe(false);
+		expect(result.len).toBe(1);
+	});
+
+	// ========================================================================
+	// 3. findConflict detects conflicts
+	// ========================================================================
+	test("findConflict detects binding conflicts", async ({ page }) => {
+		const conflictId = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			r.registerShortcut({
+				id: "action-a",
+				label: "Action A",
+				category: "Test",
+				defaultBindings: [{ key: "t", ctrlOrMeta: true, shift: false, alt: false }],
+				handler: () => {},
+			});
+			r.registerShortcut({
+				id: "action-b",
+				label: "Action B",
+				category: "Test",
+				defaultBindings: [{ key: "s", ctrlOrMeta: true, shift: false, alt: false }],
+				handler: () => {},
+			});
+			const conflict = r.findConflict({ key: "t", ctrlOrMeta: true, shift: false, alt: false });
+			return conflict?.id;
+		});
+		expect(conflictId).toBe("action-a");
+	});
+
+	// ========================================================================
+	// 4. findConflict returns undefined for non-conflicting
+	// ========================================================================
+	test("findConflict returns undefined for non-conflicting bindings", async ({ page }) => {
+		const result = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			r.registerShortcut({
+				id: "only-action",
+				label: "Only",
+				category: "Test",
+				defaultBindings: [{ key: "t", ctrlOrMeta: true, shift: false, alt: false }],
+				handler: () => {},
+			});
+			return r.findConflict({ key: "s", ctrlOrMeta: true, shift: false, alt: false });
+		});
+		expect(result).toBeUndefined();
+	});
+
+	// ========================================================================
+	// 5. findConflict with excludeId
+	// ========================================================================
+	test("findConflict with excludeId excludes that shortcut", async ({ page }) => {
+		const result = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			r.registerShortcut({
+				id: "self",
+				label: "Self",
+				category: "Test",
+				defaultBindings: [{ key: "t", ctrlOrMeta: true, shift: false, alt: false }],
+				handler: () => {},
+			});
+			// Same binding but excluding "self" — no conflict
+			const conflict = r.findConflict(
+				{ key: "t", ctrlOrMeta: true, shift: false, alt: false },
+				"self",
+			);
+			return conflict;
+		});
+		expect(result).toBeUndefined();
+	});
+
+	// ========================================================================
+	// 6. formatBinding platform-aware (Mac vs non-Mac)
+	// ========================================================================
+	test("formatBinding shows Cmd on Mac, Ctrl on non-Mac", async ({ page }) => {
+		const results = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			const binding = { key: "t", ctrlOrMeta: true, shift: false, alt: false };
+
+			r.setMac(false);
+			const win = r.formatBinding(binding);
+
+			r.setMac(true);
+			const mac = r.formatBinding(binding);
+
+			r.setMac(false); // reset
+			return { win, mac };
+		});
+		expect(results.win).toBe("Ctrl+T");
+		expect(results.mac).toBe("Cmd+T");
+	});
+
+	// ========================================================================
+	// 7. formatBinding special keys
+	// ========================================================================
+	test("formatBinding formats special keys", async ({ page }) => {
+		const results = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			r.setMac(false);
+			return {
+				up: r.formatBinding({ key: "ArrowUp", ctrlOrMeta: true, shift: false, alt: false }),
+				down: r.formatBinding({ key: "ArrowDown", ctrlOrMeta: true, shift: false, alt: false }),
+				left: r.formatBinding({ key: "ArrowLeft", ctrlOrMeta: false, shift: false, alt: true }),
+				right: r.formatBinding({ key: "ArrowRight", ctrlOrMeta: false, shift: false, alt: true }),
+				esc: r.formatBinding({ key: "Escape", ctrlOrMeta: false, shift: false, alt: false }),
+				backspace: r.formatBinding({ key: "Backspace", ctrlOrMeta: false, shift: false, alt: false }),
+			};
+		});
+		expect(results.up).toBe("Ctrl+↑");
+		expect(results.down).toBe("Ctrl+↓");
+		expect(results.left).toBe("Alt+←");
+		expect(results.right).toBe("Alt+→");
+		expect(results.esc).toBe("Esc");
+		expect(results.backspace).toBe("⌫");
+	});
+
+	// ========================================================================
+	// 8. resetBinding restores defaults for a single shortcut
+	// ========================================================================
+	test("resetBinding restores default bindings", async ({ page }) => {
+		const result = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			r.registerShortcut({
+				id: "reset-test",
+				label: "Reset Test",
+				category: "Test",
+				defaultBindings: [{ key: "t", ctrlOrMeta: true, shift: false, alt: false }],
+				handler: () => {},
+			});
+			// Change binding
+			r.updateBinding("reset-test", 0, { key: "x", ctrlOrMeta: true, shift: false, alt: false });
+			const before = r.getShortcutById("reset-test").currentBindings[0].key;
+
+			// Reset
+			r.resetBinding("reset-test");
+			const after = r.getShortcutById("reset-test").currentBindings[0].key;
+
+			return { before, after };
+		});
+		expect(result.before).toBe("x");
+		expect(result.after).toBe("t");
+	});
+
+	// ========================================================================
+	// 9. resetAllBindings restores all defaults
+	// ========================================================================
+	test("resetAllBindings restores all defaults", async ({ page }) => {
+		const result = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			r.registerShortcut({
+				id: "a",
+				label: "A",
+				category: "T",
+				defaultBindings: [{ key: "a", ctrlOrMeta: true, shift: false, alt: false }],
+				handler: () => {},
+			});
+			r.registerShortcut({
+				id: "b",
+				label: "B",
+				category: "T",
+				defaultBindings: [{ key: "b", ctrlOrMeta: true, shift: false, alt: false }],
+				handler: () => {},
+			});
+			r.updateBinding("a", 0, { key: "x", ctrlOrMeta: true, shift: false, alt: false });
+			r.updateBinding("b", 0, { key: "y", ctrlOrMeta: true, shift: false, alt: false });
+
+			r.resetAllBindings();
+
+			return {
+				aKey: r.getShortcutById("a").currentBindings[0].key,
+				bKey: r.getShortcutById("b").currentBindings[0].key,
+			};
+		});
+		expect(result.aKey).toBe("a");
+		expect(result.bKey).toBe("b");
+	});
+
+	// ========================================================================
+	// 10. updateBinding changes a specific binding at an index
+	// ========================================================================
+	test("updateBinding changes a specific binding at an index", async ({ page }) => {
+		const result = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			r.registerShortcut({
+				id: "update-test",
+				label: "Update",
+				category: "T",
+				defaultBindings: [
+					{ key: "a", ctrlOrMeta: true, shift: false, alt: false },
+					{ key: "b", ctrlOrMeta: false, shift: false, alt: true },
+				],
+				handler: () => {},
+			});
+			r.updateBinding("update-test", 1, { key: "z", ctrlOrMeta: false, shift: true, alt: false });
+			const entry = r.getShortcutById("update-test");
+			return {
+				first: entry.currentBindings[0].key,
+				second: entry.currentBindings[1].key,
+				secondShift: entry.currentBindings[1].shift,
+			};
+		});
+		expect(result.first).toBe("a"); // unchanged
+		expect(result.second).toBe("z"); // updated
+		expect(result.secondShift).toBe(true);
+	});
+
+	// ========================================================================
+	// 11. isBrowserReserved
+	// ========================================================================
+	test("isBrowserReserved returns true for Ctrl+W, false for Ctrl+T", async ({ page }) => {
+		const result = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			return {
+				ctrlW: r.isBrowserReserved({ key: "w", ctrlOrMeta: true, shift: false, alt: false }),
+				ctrlT: r.isBrowserReserved({ key: "t", ctrlOrMeta: true, shift: false, alt: false }),
+				ctrlN: r.isBrowserReserved({ key: "n", ctrlOrMeta: true, shift: false, alt: false }),
+				altG: r.isBrowserReserved({ key: "g", ctrlOrMeta: false, shift: false, alt: true }),
+			};
+		});
+		expect(result.ctrlW).toBe(true);
+		expect(result.ctrlT).toBe(false);
+		expect(result.ctrlN).toBe(true);
+		expect(result.altG).toBe(false);
+	});
+
+	// ========================================================================
+	// 12. Keydown matching: matchesBinding
+	// ========================================================================
+	test("matchesBinding correctly matches keyboard events", async ({ page }) => {
+		const results = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			r.setMac(false);
+
+			const binding = { key: "t", ctrlOrMeta: true, shift: false, alt: false };
+
+			// Simulate matching event
+			const match = r.matchesBinding(
+				{ key: "t", ctrlKey: true, metaKey: false, shiftKey: false, altKey: false },
+				binding,
+			);
+
+			// Wrong key
+			const wrongKey = r.matchesBinding(
+				{ key: "s", ctrlKey: true, metaKey: false, shiftKey: false, altKey: false },
+				binding,
+			);
+
+			// Missing ctrl
+			const noCtrl = r.matchesBinding(
+				{ key: "t", ctrlKey: false, metaKey: false, shiftKey: false, altKey: false },
+				binding,
+			);
+
+			// Extra shift
+			const extraShift = r.matchesBinding(
+				{ key: "t", ctrlKey: true, metaKey: false, shiftKey: true, altKey: false },
+				binding,
+			);
+
+			// Case insensitive
+			const caseInsensitive = r.matchesBinding(
+				{ key: "T", ctrlKey: true, metaKey: false, shiftKey: false, altKey: false },
+				binding,
+			);
+
+			return { match, wrongKey, noCtrl, extraShift, caseInsensitive };
+		});
+		expect(results.match).toBe(true);
+		expect(results.wrongKey).toBe(false);
+		expect(results.noCtrl).toBe(false);
+		expect(results.extraShift).toBe(false);
+		expect(results.caseInsensitive).toBe(true);
+	});
+
+	test("matchesBinding uses metaKey on Mac", async ({ page }) => {
+		const result = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			r.setMac(true);
+			const binding = { key: "t", ctrlOrMeta: true, shift: false, alt: false };
+
+			const metaMatch = r.matchesBinding(
+				{ key: "t", ctrlKey: false, metaKey: true, shiftKey: false, altKey: false },
+				binding,
+			);
+			const ctrlNoMatch = r.matchesBinding(
+				{ key: "t", ctrlKey: true, metaKey: false, shiftKey: false, altKey: false },
+				binding,
+			);
+
+			r.setMac(false);
+			return { metaMatch, ctrlNoMatch };
+		});
+		expect(result.metaMatch).toBe(true);
+		expect(result.ctrlNoMatch).toBe(false);
+	});
+
+	// ========================================================================
+	// 13. Keydown: no handler fires for unregistered combo
+	// ========================================================================
+	test("no handler fires for unregistered combo", async ({ page }) => {
+		const fired = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			let called = false;
+			r.registerShortcut({
+				id: "specific",
+				label: "Specific",
+				category: "T",
+				defaultBindings: [{ key: "t", ctrlOrMeta: true, shift: false, alt: false }],
+				handler: () => { called = true; },
+			});
+			r.startListening();
+
+			// Dispatch an unrelated combo (Ctrl+S)
+			document.dispatchEvent(new KeyboardEvent("keydown", {
+				key: "s",
+				ctrlKey: true,
+				bubbles: true,
+			}));
+
+			return called;
+		});
+		expect(fired).toBe(false);
+	});
+
+	test("handler fires for registered combo via keydown", async ({ page }) => {
+		const fired = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			let called = false;
+			r.registerShortcut({
+				id: "fire-test",
+				label: "Fire",
+				category: "T",
+				defaultBindings: [{ key: "t", ctrlOrMeta: true, shift: false, alt: false }],
+				allowInInput: true,
+				handler: () => { called = true; },
+			});
+			r.startListening();
+
+			document.dispatchEvent(new KeyboardEvent("keydown", {
+				key: "t",
+				ctrlKey: true,
+				bubbles: true,
+			}));
+
+			return called;
+		});
+		expect(fired).toBe(true);
+	});
+
+	// ========================================================================
+	// Input guard tests
+	// ========================================================================
+	test("handler NOT called when input focused and allowInInput is false", async ({ page }) => {
+		const fired = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			let called = false;
+			r.registerShortcut({
+				id: "no-input",
+				label: "No Input",
+				category: "T",
+				defaultBindings: [{ key: "g", ctrlOrMeta: false, shift: false, alt: true }],
+				// allowInInput defaults to undefined/false
+				handler: () => { called = true; },
+			});
+			r.startListening();
+
+			// Focus the input
+			document.getElementById("test-input").focus();
+
+			document.dispatchEvent(new KeyboardEvent("keydown", {
+				key: "g",
+				altKey: true,
+				bubbles: true,
+			}));
+
+			return called;
+		});
+		expect(fired).toBe(false);
+	});
+
+	test("allowInInput shortcut fires even when input focused", async ({ page }) => {
+		const fired = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			let called = false;
+			r.registerShortcut({
+				id: "allow-input",
+				label: "Allow Input",
+				category: "T",
+				defaultBindings: [{ key: "t", ctrlOrMeta: true, shift: false, alt: false }],
+				allowInInput: true,
+				handler: () => { called = true; },
+			});
+			r.startListening();
+
+			document.getElementById("test-input").focus();
+
+			document.dispatchEvent(new KeyboardEvent("keydown", {
+				key: "t",
+				ctrlKey: true,
+				bubbles: true,
+			}));
+
+			return called;
+		});
+		expect(fired).toBe(true);
+	});
+
+	test("handler NOT called when textarea focused and allowInInput is false", async ({ page }) => {
+		const fired = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			let called = false;
+			r.registerShortcut({
+				id: "no-textarea",
+				label: "No TA",
+				category: "T",
+				defaultBindings: [{ key: "g", ctrlOrMeta: false, shift: false, alt: true }],
+				handler: () => { called = true; },
+			});
+			r.startListening();
+
+			document.getElementById("test-textarea").focus();
+
+			document.dispatchEvent(new KeyboardEvent("keydown", {
+				key: "g",
+				altKey: true,
+				bubbles: true,
+			}));
+
+			return called;
+		});
+		expect(fired).toBe(false);
+	});
+
+	test("handler NOT called when contenteditable focused and allowInInput is false", async ({ page }) => {
+		const fired = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			let called = false;
+			r.registerShortcut({
+				id: "no-ce",
+				label: "No CE",
+				category: "T",
+				defaultBindings: [{ key: "g", ctrlOrMeta: false, shift: false, alt: true }],
+				handler: () => { called = true; },
+			});
+			r.startListening();
+
+			document.getElementById("test-contenteditable").focus();
+
+			document.dispatchEvent(new KeyboardEvent("keydown", {
+				key: "g",
+				altKey: true,
+				bubbles: true,
+			}));
+
+			return called;
+		});
+		expect(fired).toBe(false);
+	});
+
+	test("handler fires when non-input div is focused", async ({ page }) => {
+		const fired = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			let called = false;
+			r.registerShortcut({
+				id: "div-focus",
+				label: "Div",
+				category: "T",
+				defaultBindings: [{ key: "g", ctrlOrMeta: false, shift: false, alt: true }],
+				// allowInInput: false (default)
+				handler: () => { called = true; },
+			});
+			r.startListening();
+
+			// Focus a plain div (tabindex needed to actually focus)
+			const div = document.getElementById("test-div");
+			div.setAttribute("tabindex", "0");
+			div.focus();
+
+			document.dispatchEvent(new KeyboardEvent("keydown", {
+				key: "g",
+				altKey: true,
+				bubbles: true,
+			}));
+
+			return called;
+		});
+		expect(fired).toBe(true);
+	});
+
+	// ========================================================================
+	// Bare modifier press ignored
+	// ========================================================================
+	test("bare modifier keypress does not fire handlers", async ({ page }) => {
+		const fired = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			let called = false;
+			r.registerShortcut({
+				id: "mod-test",
+				label: "Mod",
+				category: "T",
+				defaultBindings: [{ key: "t", ctrlOrMeta: true, shift: false, alt: false }],
+				allowInInput: true,
+				handler: () => { called = true; },
+			});
+			r.startListening();
+
+			// Dispatch bare Control press
+			document.dispatchEvent(new KeyboardEvent("keydown", {
+				key: "Control",
+				ctrlKey: true,
+				bubbles: true,
+			}));
+
+			return called;
+		});
+		expect(fired).toBe(false);
+	});
+
+	// ========================================================================
+	// Multi-binding support
+	// ========================================================================
+	test("multiple bindings for same action both fire handler", async ({ page }) => {
+		const result = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			let count = 0;
+			r.registerShortcut({
+				id: "multi",
+				label: "Multi",
+				category: "T",
+				defaultBindings: [
+					{ key: "t", ctrlOrMeta: true, shift: false, alt: false },
+					{ key: "n", ctrlOrMeta: false, shift: false, alt: true },
+				],
+				allowInInput: true,
+				handler: () => { count++; },
+			});
+			r.startListening();
+
+			// First binding: Ctrl+T
+			document.dispatchEvent(new KeyboardEvent("keydown", {
+				key: "t", ctrlKey: true, bubbles: true,
+			}));
+
+			// Second binding: Alt+N
+			document.dispatchEvent(new KeyboardEvent("keydown", {
+				key: "n", altKey: true, bubbles: true,
+			}));
+
+			return count;
+		});
+		expect(result).toBe(2);
+	});
+
+	// ========================================================================
+	// formatBinding with shift+alt combos
+	// ========================================================================
+	test("formatBinding includes Shift and Alt modifiers", async ({ page }) => {
+		const result = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			r.setMac(false);
+			return r.formatBinding({ key: "d", ctrlOrMeta: true, shift: true, alt: false });
+		});
+		expect(result).toBe("Ctrl+Shift+D");
+	});
+});


### PR DESCRIPTION
## Summary

Replaces hardcoded global keyboard shortcuts in `main.ts` with a configurable, data-driven registry. Adds a rebinding dialog, IndexedDB persistence, and a sidebar button.

### New Features
- **Shortcut Registry** (`src/app/shortcut-registry.ts`) — Central registry with single keydown listener, platform-aware formatting, input guard, conflict detection, browser-reserved blocklist
- **Shortcuts Dialog** (`src/app/shortcuts-dialog.ts`) — Modal for viewing/rebinding shortcuts with category grouping, conflict warnings, per-row and global reset
- **IndexedDB Persistence** — Custom bindings survive page reload via `ShortcutBindingsStore`
- **Sidebar Button** — Keyboard icon in expanded sidebar footer to open shortcuts dialog

### Shortcuts Registered (9 total)
| Shortcut | Binding | Status |
|---|---|---|
| New session | Ctrl+T, Alt+N | Migrated |
| Focus input | Ctrl+/ | Migrated |
| Toggle sidebar | Ctrl+[ | Migrated |
| Previous session | Ctrl+Up | Migrated |
| Next session | Ctrl+Down | Migrated |
| Toggle preview | Ctrl+] | Migrated |
| New goal | Alt+G | New |
| Terminate session | Ctrl+Shift+D | New |
| Keyboard shortcuts | Ctrl+Shift+/ | New |

### Testing
- 164/164 unit tests pass (23 new shortcut registry tests)
- E2E tests pass
- `npm run check` — 0 type errors

### Review Notes
- High-severity listener leak in `hideShortcutsDialog()` caught during code quality review and fixed
- All 3 workflow gates passed (design-doc, implementation, ready-to-merge)
