### PR TITLE
feat: npx bobbit single-command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
   "name": "bobbit",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
   "bin": {
     "bobbit": "dist/server/cli.js"
   },
+  "files": [
+    "dist/",
+    "README.md"
+  ],
   "scripts": {
     "build:server": "tsc -p tsconfig.server.json && shx chmod +x dist/server/cli.js && shx rm -rf dist/server/defaults && shx cp -r src/server/defaults dist/server/defaults",
     "build:ui": "vite build",
@@ -23,7 +26,8 @@
     "test:coverage": "npm run build:server && shx rm -rf coverage && npx playwright test --config playwright-e2e-coverage.config.ts && npx c8 --temp-directory=coverage/tmp --src=src/server npx tsx --test --test-force-exit tests/workflow-manager-logic.test.ts tests/task-state-machine.test.ts tests/name-validation.test.ts tests/gate-store-logic.test.ts tests/system-prompt.test.ts tests/session-store.test.ts tests/cost-tracker.test.ts tests/event-buffer.test.ts tests/staff-trigger-engine.test.ts && npx c8 report --temp-directory=coverage/tmp --reports-dir=coverage --reporter=html --reporter=lcov --reporter=text",
     "test": "npm run test:node && npm run test:unit && npm run test:e2e",
     "test:e2e:ui": "npm run build && npx playwright test --config tests/playwright-e2e-ui.config.ts",
-    "clean": "shx rm -rf dist"
+    "clean": "shx rm -rf dist",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@lmstudio/sdk": "^1.5.0",

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -19,6 +19,7 @@ interface CliArgs {
 	showToken: boolean;
 	noUi: boolean;
 	tls: boolean;
+	tlsExplicit: boolean;
 	staticDir?: string;
 	agentCliPath?: string;
 }
@@ -47,6 +48,7 @@ function parseArgs(argv: string[]): CliArgs {
 		showToken: false,
 		noUi: false,
 		tls: true,  // on by default
+		tlsExplicit: false,
 	};
 
 	for (let i = 0; i < argv.length; i++) {
@@ -77,9 +79,11 @@ function parseArgs(argv: string[]): CliArgs {
 				break;
 			case "--tls":
 				result.tls = true;
+				result.tlsExplicit = true;
 				break;
 			case "--no-tls":
 				result.tls = false;
+				result.tlsExplicit = true;
 				break;
 		}
 	}
@@ -117,11 +121,8 @@ async function main() {
 		if (nordIp) {
 			args.host = nordIp;
 		} else {
-			console.error(
-				"Error: NordVPN mesh (NordLynx) interface not found.\n" +
-				"  Start NordVPN, or pass --host <addr> to bind manually."
-			);
-			process.exit(1);
+			args.host = "localhost";
+			console.log("No mesh network found — binding to localhost (local-only access).");
 		}
 	}
 
@@ -151,6 +152,13 @@ async function main() {
 		console.log(`  System prompt: ${systemPromptPath}`);
 	}
 
+	// Auto-disable TLS for loopback to avoid self-signed cert warnings on localhost
+	const isLoopback = args.host === "127.0.0.1" || args.host === "::1" || args.host === "localhost";
+	if (isLoopback && !args.tlsExplicit) {
+		args.tls = false;
+		console.log("  Binding to localhost — TLS disabled (use --tls to override).");
+	}
+
 	// TLS setup — auto-generate cert (mkcert CA preferred, openssl fallback)
 	const tls = args.tls ? await ensureTlsCert(args.host) : undefined;
 
@@ -158,7 +166,6 @@ async function main() {
 	// Skip for loopback addresses (e.g. E2E tests with --host 127.0.0.1) to avoid
 	// clobbering the DNS record with an unreachable IP.
 	const desecConfig = loadDesecConfig();
-	const isLoopback = args.host === "127.0.0.1" || args.host === "::1" || args.host === "localhost";
 	if (desecConfig && !isLoopback) {
 		updateDesecIp(desecConfig, args.host); // fire and forget
 	}


### PR DESCRIPTION
## Summary

Make Bobbit installable and runnable via `npx bobbit` with zero prior setup.

### Changes

**package.json:**
- Removed `"private": true` — enables npm publish
- Added `"files": ["dist/", "README.md"]` — whitelists published contents
- Added `"prepublishOnly": "npm run build"` — ensures build before publish

**src/server/cli.ts:**
- Localhost fallback: when NordLynx not found, binds to `localhost` instead of exiting
- Auto-disables TLS for loopback addresses (no cert warnings on first run)
- Tracks explicit `--tls`/`--no-tls` to allow user override
- Preserves existing NordLynx-first behavior for remote access users

### Test Results
- Type check: clean
- Unit tests: 164 passed
- E2E tests: 25 passed
- LLM reviews (gap, quality, security): all passed