### PR TITLE
feat: auto-increment port on EADDRINUSE

### DIFF
--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -14,6 +14,7 @@ import { createGateway } from "./server.js";
 interface CliArgs {
 	host: string;
 	port: number;
+	portExplicit: boolean;
 	cwd: string;
 	newToken: boolean;
 	showToken: boolean;
@@ -43,6 +44,7 @@ function parseArgs(argv: string[]): CliArgs {
 	const result: CliArgs = {
 		host: "",  // resolved after parsing
 		port: 3001,
+		portExplicit: false,
 		cwd: process.cwd(),
 		newToken: false,
 		showToken: false,
@@ -58,6 +60,7 @@ function parseArgs(argv: string[]): CliArgs {
 				break;
 			case "--port":
 				result.port = parseInt(argv[++i], 10);
+				result.portExplicit = true;
 				break;
 			case "--cwd":
 				result.cwd = path.resolve(argv[++i]);
@@ -173,6 +176,7 @@ async function main() {
 	const gateway = createGateway({
 		host: args.host,
 		port: args.port,
+		portExplicit: args.portExplicit,
 		authToken,
 		defaultCwd: args.cwd,
 		staticDir: args.staticDir,
@@ -181,7 +185,7 @@ async function main() {
 		tls,
 	});
 
-	await gateway.start();
+	const actualPort = await gateway.start();
 
 	// Collect reachable addresses for display
 	const interfaces = os.networkInterfaces();
@@ -196,7 +200,7 @@ async function main() {
 	}
 
 	const proto = args.tls ? "https" : "http";
-	const baseUrl = `${proto}://${args.host}:${args.port}`;
+	const baseUrl = `${proto}://${args.host}:${actualPort}`;
 	const fullUrl = `${baseUrl}/?token=${encodeURIComponent(authToken)}`;
 
 	// Write gateway URL to a discoverable file so extensions can call the API.

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -75,6 +75,7 @@ export interface TlsConfig {
 export interface GatewayConfig {
 	host: string;
 	port: number;
+	portExplicit?: boolean;
 	authToken: string;
 	defaultCwd: string;
 	staticDir?: string;
@@ -106,7 +107,7 @@ export function createGateway(config: GatewayConfig) {
 		workflowStore,
 	});
 	const protocol = config.tls ? "https" : "http";
-	const gatewayUrl = `${protocol}://${config.host}:${config.port}`;
+	let gatewayUrl = `${protocol}://${config.host}:${config.port}`;
 	const workflowManager = new WorkflowManager(workflowStore);
 	const staffManager = new StaffManager();
 	const triggerEngine = new TriggerEngine(staffManager, sessionManager);
@@ -264,15 +265,41 @@ export function createGateway(config: GatewayConfig) {
 	return {
 		server,
 		sessionManager,
-		async start() {
+		async start(): Promise<number> {
 			// Restore persisted sessions before accepting connections
 			await sessionManager.restoreSessions();
 			// Now that sessions are live, re-subscribe to team events
 			// (must happen after restoreSessions so session objects exist)
 			teamManager.resubscribeTeamEvents();
-			return new Promise<void>((resolve) => {
-				server.listen(config.port, config.host, () => resolve());
-			});
+
+			const maxPort = config.portExplicit !== false ? config.port : config.port + 9;
+			let port = config.port;
+
+			while (port <= maxPort) {
+				try {
+					await new Promise<void>((resolve, reject) => {
+						server.once("error", reject);
+						server.listen(port, config.host, () => {
+							server.removeListener("error", reject);
+							resolve();
+						});
+					});
+					// Update the closure gatewayUrl with the actual bound port
+					if (port !== config.port) {
+						gatewayUrl = `${protocol}://${config.host}:${port}`;
+						console.log(`Port ${config.port} in use, using port ${port}`);
+					}
+					return port;
+				} catch (err: any) {
+					if (err.code === "EADDRINUSE" && port < maxPort) {
+						console.log(`Port ${port} in use, trying ${port + 1}...`);
+						port++;
+						continue;
+					}
+					throw err;
+				}
+			}
+			throw new Error(`All ports ${config.port}-${maxPort} in use`);
 		},
 		async shutdown() {
 			clearInterval(cleanupInterval);

--- a/tests/e2e/port-auto-increment.spec.ts
+++ b/tests/e2e/port-auto-increment.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * E2E tests for port auto-increment on EADDRINUSE.
+ *
+ * These tests manage their own server lifecycle since they need to control
+ * port allocation. They do NOT use the shared webServer gateway.
+ */
+import { test, expect } from "@playwright/test";
+import { createServer as createTcpServer } from "node:net";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, "../..");
+const HELPER_SCRIPT = join(__dirname, "port-test-helper.mjs");
+const MOCK_AGENT = join(PROJECT_ROOT, "tests/e2e/mock-agent.mjs");
+
+/** Create an isolated BOBBIT_DIR for a test. */
+function makeBobbitDir(label: string): string {
+	const dir = join(tmpdir(), `bobbit-port-test-${label}-${Date.now()}`);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+/** Occupy a port with a TCP server. Returns the server (call .close() to release). */
+function occupyPort(port: number): Promise<ReturnType<typeof createTcpServer>> {
+	return new Promise((resolve, reject) => {
+		const srv = createTcpServer();
+		srv.once("error", reject);
+		srv.listen(port, "127.0.0.1", () => {
+			srv.removeListener("error", reject);
+			resolve(srv);
+		});
+	});
+}
+
+/** Find a free port to use as a base for tests. */
+function findFreePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const srv = createTcpServer();
+		srv.listen(0, "127.0.0.1", () => {
+			const port = (srv.address() as any).port;
+			srv.close(() => resolve(port));
+		});
+		srv.on("error", reject);
+	});
+}
+
+/** Run the helper script and wait for exit. Returns exit code and stdout. */
+function runHelper(env: Record<string, string>): Promise<{ code: number; output: string }> {
+	return new Promise((resolve) => {
+		const child = spawn("node", [HELPER_SCRIPT], {
+			cwd: PROJECT_ROOT,
+			env: { ...process.env, ...env },
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let output = "";
+		child.stdout?.on("data", (d: Buffer) => { output += d.toString(); });
+		child.stderr?.on("data", (d: Buffer) => { output += d.toString(); });
+		child.on("exit", (code) => resolve({ code: code ?? 1, output }));
+		// Safety timeout
+		setTimeout(() => { try { child.kill(); } catch {} }, 20_000);
+	});
+}
+
+/** Start the helper as a long-running process. */
+function startHelper(env: Record<string, string>): { child: ChildProcess; output: string[] } {
+	const child = spawn("node", [HELPER_SCRIPT], {
+		cwd: PROJECT_ROOT,
+		env: { ...process.env, ...env },
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	const output: string[] = [];
+	child.stdout?.on("data", (d: Buffer) => output.push(d.toString()));
+	child.stderr?.on("data", (d: Buffer) => output.push(d.toString()));
+	return { child, output };
+}
+
+/** Wait for the gateway to respond on the given port (any HTTP response means it's up). */
+async function waitForGateway(port: number, timeoutMs = 15_000): Promise<boolean> {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		try {
+			await fetch(`http://127.0.0.1:${port}/api/health`);
+			// Any response (even 401) means the server is listening
+			return true;
+		} catch {
+			// not ready yet — connection refused
+		}
+		await new Promise(r => setTimeout(r, 100));
+	}
+	return false;
+}
+
+/** Kill a child process and wait for it to exit. */
+function killChild(child: ChildProcess): Promise<void> {
+	return new Promise((resolve) => {
+		if (child.exitCode !== null || child.killed) { resolve(); return; }
+		child.once("exit", () => resolve());
+		child.kill("SIGTERM");
+		setTimeout(() => { try { child.kill("SIGKILL"); } catch {} }, 3000);
+	});
+}
+
+test.describe("Port auto-increment", () => {
+	test("auto-increments to next port when default port is occupied", async () => {
+		const basePort = await findFreePort();
+		const bobbitDir = makeBobbitDir("auto-inc");
+		const blocker = await occupyPort(basePort);
+
+		try {
+			const { child, output } = startHelper({
+				BOBBIT_DIR: bobbitDir,
+				TEST_PORT: String(basePort),
+				TEST_MODE: "bind-and-serve",
+				TEST_EXPLICIT: "false",
+				MOCK_AGENT,
+			});
+
+			try {
+				// Wait for the gateway to bind on next port
+				const healthy = await waitForGateway(basePort + 1, 15_000);
+				expect(healthy).toBe(true);
+
+				// Verify actual-port file
+				const actualPort = parseInt(readFileSync(join(bobbitDir, "state", "actual-port"), "utf-8").trim(), 10);
+				expect(actualPort).toBe(basePort + 1);
+
+				// Verify gateway-url file
+				const gwUrl = readFileSync(join(bobbitDir, "state", "gateway-url"), "utf-8").trim();
+				expect(gwUrl).toBe(`http://127.0.0.1:${basePort + 1}`);
+
+				// Verify console output mentions port being in use
+				const allOutput = output.join("");
+				expect(allOutput).toContain(`Port ${basePort} in use`);
+			} finally {
+				await killChild(child);
+			}
+		} finally {
+			blocker.close();
+		}
+	});
+
+	test("fails immediately with explicit portExplicit=true when port is occupied", async () => {
+		const basePort = await findFreePort();
+		const bobbitDir = makeBobbitDir("explicit");
+		const blocker = await occupyPort(basePort);
+
+		try {
+			const result = await runHelper({
+				BOBBIT_DIR: bobbitDir,
+				TEST_PORT: String(basePort),
+				TEST_MODE: "bind-and-report",
+				TEST_EXPLICIT: "true",
+				MOCK_AGENT,
+			});
+
+			expect(result.code).toBe(0);
+			expect(result.output).toContain("EADDRINUSE");
+		} finally {
+			blocker.close();
+		}
+	});
+
+	test("returns correct port when port is free (no increment needed)", async () => {
+		const basePort = await findFreePort();
+		const bobbitDir = makeBobbitDir("free");
+
+		const result = await runHelper({
+			BOBBIT_DIR: bobbitDir,
+			TEST_PORT: String(basePort),
+			TEST_MODE: "bind-and-report",
+			TEST_EXPLICIT: "false",
+			MOCK_AGENT,
+		});
+
+		expect(result.code).toBe(0);
+		expect(result.output).toContain(`OK:${basePort}`);
+	});
+});

--- a/tests/e2e/port-test-helper.mjs
+++ b/tests/e2e/port-test-helper.mjs
@@ -1,0 +1,60 @@
+/**
+ * Helper script for port auto-increment tests.
+ * 
+ * Environment variables:
+ *   BOBBIT_DIR     — isolated .bobbit directory
+ *   TEST_PORT      — port to attempt binding
+ *   TEST_EXPLICIT  — "true" if portExplicit should be true
+ *   MOCK_AGENT     — path to mock agent
+ *   TEST_MODE      — "bind-and-report" | "bind-and-serve" | "explicit-fail"
+ */
+import { createGateway } from "../../dist/server/server.js";
+import { setProjectRoot } from "../../dist/server/bobbit-dir.js";
+import { scaffoldBobbitDir } from "../../dist/server/scaffold.js";
+import { loadOrCreateToken } from "../../dist/server/auth/token.js";
+import fs from "node:fs";
+import path from "node:path";
+
+setProjectRoot(process.cwd());
+scaffoldBobbitDir(process.cwd());
+const authToken = loadOrCreateToken(false);
+
+const port = parseInt(process.env.TEST_PORT, 10);
+const portExplicit = process.env.TEST_EXPLICIT === "true";
+const mode = process.env.TEST_MODE || "bind-and-report";
+const bobbitDir = process.env.BOBBIT_DIR;
+
+const gateway = createGateway({
+	host: "127.0.0.1",
+	port,
+	portExplicit,
+	authToken,
+	defaultCwd: process.cwd(),
+	agentCliPath: process.env.MOCK_AGENT,
+});
+
+try {
+	const actualPort = await gateway.start();
+
+	if (mode === "bind-and-serve") {
+		// Write actual port to state dir and keep running
+		const stateDir = path.join(bobbitDir, "state");
+		fs.writeFileSync(path.join(stateDir, "actual-port"), String(actualPort));
+		fs.writeFileSync(path.join(stateDir, "gateway-url"), `http://127.0.0.1:${actualPort}`);
+		console.log(`BOUND:${actualPort}`);
+		// Keep alive until killed
+		await new Promise(() => {});
+	} else {
+		// Report and exit
+		console.log(`OK:${actualPort}`);
+		await gateway.shutdown();
+		process.exit(0);
+	}
+} catch (err) {
+	if (err.code === "EADDRINUSE") {
+		console.log("EADDRINUSE");
+		process.exit(0);
+	}
+	console.error("ERROR:" + err.message);
+	process.exit(1);
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,7 +27,16 @@ const piDir = path.join(os.homedir(), ".pi");
 const hasTlsCert = fs.existsSync(path.join(piDir, "gateway-cert.pem"));
 const noTls = process.env.GATEWAY_NO_TLS === "1";
 const gwProto = noTls ? "http" : (hasTlsCert ? "https" : "http");
-const GATEWAY = process.env.GATEWAY_URL || `${gwProto}://${host}:3001`;
+function resolveGatewayUrl(): string {
+	if (process.env.GATEWAY_URL) return process.env.GATEWAY_URL;
+	try {
+		const stateFile = path.join(process.cwd(), ".bobbit", "state", "gateway-url");
+		const url = fs.readFileSync(stateFile, "utf-8").trim();
+		if (url) return url;
+	} catch { /* file doesn't exist yet */ }
+	return `${gwProto}://${host}:3001`;
+}
+const GATEWAY = resolveGatewayUrl();
 const GATEWAY_WS = GATEWAY.replace(/^https/, "wss").replace(/^http/, "ws");
 
 if (!meshIp && !process.env.VITE_HOST) {


### PR DESCRIPTION
## Auto-increment port on EADDRINUSE

When the default port (3001) is already in use and no explicit `--port` flag is given, Bobbit now automatically tries the next port (up to 10 attempts, 3001-3010) instead of crashing.

### Changes
- **`src/server/cli.ts`** — Added `portExplicit` flag; uses actual bound port for all URL construction
- **`src/server/server.ts`** — Port retry loop in `start()`, returns actual port, updates `gatewayUrl` closure
- **`vite.config.ts`** — Reads `.bobbit/state/gateway-url` as Vite proxy target fallback
- **E2E tests** — Auto-increment, explicit port failure, and gateway-url file verification

### Behavior
- Default port (no `--port`): auto-increments on EADDRINUSE, logs which port was chosen
- Explicit `--port N`: fails immediately if port N is taken (unchanged)
- Backward compatible: omitting `portExplicit` defaults to no-retry