### PR TITLE
Notification color system with palette chooser

### DIFF
--- a/src/app/custom-messages.ts
+++ b/src/app/custom-messages.ts
@@ -1,4 +1,3 @@
-import { Alert } from "@mariozechner/mini-lit/dist/Alert.js";
 import type { Message } from "@mariozechner/pi-ai";
 import type { AgentMessage, MessageRenderer } from "../ui/index.js";
 import { defaultConvertToLlm, registerMessageRenderer } from "../ui/index.js";
@@ -8,16 +7,14 @@ import { html } from "lit";
 // 1. EXTEND AppMessage TYPE VIA DECLARATION MERGING
 // ============================================================================
 
-// Define custom message types
 export interface SystemNotificationMessage {
 	role: "system-notification";
 	message: string;
 	variant: "default" | "destructive";
+	category?: "system" | "task" | "team" | "error";
 	timestamp: string;
 }
 
-// Extend CustomAgentMessages interface via declaration merging
-// This must target pi-agent-core where CustomAgentMessages is defined
 declare module "@mariozechner/pi-agent-core" {
 	interface CustomAgentMessages {
 		"system-notification": SystemNotificationMessage;
@@ -25,30 +22,38 @@ declare module "@mariozechner/pi-agent-core" {
 }
 
 // ============================================================================
-// 2. CREATE CUSTOM RENDERER (TYPED TO SystemNotificationMessage)
+// 2. CATEGORY ICONS
+// ============================================================================
+
+const CATEGORY_ICONS: Record<string, string> = {
+	system: "\u27F3",  // ⟳
+	task: "\u2713",    // ✓
+	team: "\u25CF",    // ●
+	error: "\u2715",   // ✕
+};
+
+// ============================================================================
+// 3. COMPACT INLINE NOTIFICATION RENDERER
 // ============================================================================
 
 const systemNotificationRenderer: MessageRenderer<SystemNotificationMessage> = {
 	render: (notification) => {
-		// notification is fully typed as SystemNotificationMessage!
+		const category = notification.category || "system";
+		const icon = CATEGORY_ICONS[category] || CATEGORY_ICONS.system;
+		const time = new Date(notification.timestamp).toLocaleTimeString();
+
 		return html`
-			<div class="px-4">
-				${Alert({
-					variant: notification.variant,
-					children: html`
-						<div class="flex flex-col gap-1">
-							<div>${notification.message}</div>
-							<div class="text-xs opacity-70">${new Date(notification.timestamp).toLocaleTimeString()}</div>
-						</div>
-					`,
-				})}
+			<div class="notification-inline notification-${category}">
+				<span class="notification-icon">${icon}</span>
+				<span class="notification-text">${notification.message}</span>
+				<span class="notification-time">${time}</span>
 			</div>
 		`;
 	},
 };
 
 // ============================================================================
-// 3. REGISTER RENDERER
+// 4. REGISTER RENDERER
 // ============================================================================
 
 export function registerCustomMessageRenderers() {
@@ -56,35 +61,31 @@ export function registerCustomMessageRenderers() {
 }
 
 // ============================================================================
-// 4. HELPER TO CREATE CUSTOM MESSAGES
+// 5. HELPER TO CREATE CUSTOM MESSAGES
 // ============================================================================
 
 export function createSystemNotification(
 	message: string,
+	category: "system" | "task" | "team" | "error" = "system",
 	variant: "default" | "destructive" = "default",
 ): SystemNotificationMessage {
 	return {
 		role: "system-notification",
 		message,
 		variant,
+		category,
 		timestamp: new Date().toISOString(),
 	};
 }
 
 // ============================================================================
-// 5. CUSTOM MESSAGE TRANSFORMER
+// 6. CUSTOM MESSAGE TRANSFORMER
 // ============================================================================
 
-/**
- * Custom message transformer that extends defaultConvertToLlm.
- * Handles system-notification messages by converting them to user messages.
- */
 export function customConvertToLlm(messages: AgentMessage[]): Message[] {
-	// First, handle our custom system-notification type
 	const processed = messages.map((m): AgentMessage => {
 		if (m.role === "system-notification") {
 			const notification = m as SystemNotificationMessage;
-			// Convert to user message with <system> tags
 			return {
 				role: "user",
 				content: `<system>${notification.message}</system>`,
@@ -94,6 +95,5 @@ export function customConvertToLlm(messages: AgentMessage[]): Message[] {
 		return m;
 	});
 
-	// Then use defaultConvertToLlm for standard handling
 	return defaultConvertToLlm(processed);
 }

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -238,6 +238,16 @@ async function initApp() {
 	const app = document.getElementById("app");
 	if (!app) throw new Error("App container not found");
 
+	// Load saved color palette
+	try {
+		const { getAppStorage } = await import("../ui/storage/app-storage.js");
+		const storage = getAppStorage();
+		const palette = await storage.settings.get<string>("palette");
+		if (palette && palette !== "forest") {
+			document.documentElement.dataset.palette = palette;
+		}
+	} catch {}
+
 	state.chatPanel = new ChatPanel();
 
 	// Check for token in URL (passed by gateway auto-open)
@@ -458,4 +468,11 @@ initApp();
 // Register service worker for PWA installability
 if ('serviceWorker' in navigator) {
 	navigator.serviceWorker.register('/sw.js').catch(() => {});
+}
+
+// Vite HMR hot-reload detection
+if (import.meta.hot) {
+	import.meta.hot.on('vite:beforeFullReload', () => {
+		sessionStorage.setItem('bobbit-hot-reload', '1');
+	});
 }

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -2,6 +2,7 @@ import { getModel } from "@mariozechner/pi-ai";
 import { PROPOSAL_PARSERS } from "./proposal-parsers.js";
 import { state } from "./state.js";
 import { showFaviconBadge } from "./favicon-badge.js";
+import { createSystemNotification } from "./custom-messages.js";
 
 /**
  * A remote agent adapter that connects to the Pi Gateway via WebSocket.
@@ -69,6 +70,7 @@ export class RemoteAgent {
 	private _reconnectAttempt = 0;
 	private _intentionalDisconnect = false;
 	private _connectionStatus: ConnectionStatus = "disconnected";
+	private _pendingReconnectNotif = false;
 	private static readonly MAX_RECONNECT_DELAY = 30_000;
 	private static readonly BASE_RECONNECT_DELAY = 1_000;
 
@@ -231,6 +233,7 @@ export class RemoteAgent {
 						resolve();
 						// On reconnect, request current messages to resync state
 						if (!initial) {
+							this._pendingReconnectNotif = true;
 							this.requestMessages();
 							this.send({ type: "get_state" });
 						}
@@ -579,6 +582,11 @@ export class RemoteAgent {
 					if (this._isCompacting) {
 						this._addCompactingPlaceholder();
 					}
+					// Append reconnect notification after messages are refreshed
+					if (this._pendingReconnectNotif) {
+						this._pendingReconnectNotif = false;
+						this._appendNotification("Reconnected to server", "system");
+					}
 					// Note: we intentionally do NOT try to reconstruct streamMessage
 					// for late-joining clients. The message-list will show all messages
 					// including pending tool calls. The streaming container will pick up
@@ -621,6 +629,44 @@ export class RemoteAgent {
 				this.onGoalSetupEvent?.();
 				break;
 
+			case "task_changed": {
+				const task = msg.task as any;
+				if (task && !task._deleted) {
+					if (task.state === "complete") {
+						this._appendNotification(`Task "${task.title}" completed`, "task");
+					} else if (task.state === "blocked") {
+						this._appendNotification(`Task "${task.title}" blocked`, "task");
+					} else if (task.state === "in-progress" && task.assignedSessionId) {
+						this._appendNotification(`Task "${task.title}" assigned`, "task");
+					}
+				}
+				break;
+			}
+
+			case "gate_status_changed": {
+				const gateCat = (msg as any).status === "failed" ? "error" as const : "task" as const;
+				this._appendNotification(`Gate "${(msg as any).gateId}" \u2192 ${(msg as any).status}`, gateCat);
+				break;
+			}
+
+			case "gate_verification_complete": {
+				const gateVerifCat = (msg as any).status === "failed" ? "error" as const : "task" as const;
+				this._appendNotification(`Gate "${(msg as any).gateId}" verification ${(msg as any).status}`, gateVerifCat);
+				break;
+			}
+
+			case "team_agent_spawned":
+				this._appendNotification(`Agent ${(msg as any).name} (${(msg as any).role}) started`, "team");
+				break;
+
+			case "team_agent_dismissed":
+				this._appendNotification(`Agent ${(msg as any).name} (${(msg as any).role}) dismissed`, "team");
+				break;
+
+			case "team_agent_finished":
+				this._appendNotification(`Agent ${(msg as any).name} (${(msg as any).role}) finished`, "team");
+				break;
+
 			case "bg_process_created":
 			case "bg_process_output":
 			case "bg_process_exited":
@@ -644,6 +690,7 @@ export class RemoteAgent {
 					timestamp: Date.now(),
 					id: `err_${Date.now()}_${Math.random().toString(36).slice(2)}`,
 				} as any];
+				this._appendNotification(msg.message || "Unknown server error", "error");
 				this.emit({ type: "error", error: msg.message });
 				break;
 		}
@@ -693,6 +740,12 @@ export class RemoteAgent {
 
 			callback(normalized);
 		}
+	}
+
+	private _appendNotification(message: string, category: "system" | "task" | "team" | "error"): void {
+		const notif = createSystemNotification(message, category);
+		this._state.messages = [...this._state.messages, notif];
+		this.emit({ type: "message_end", message: notif });
 	}
 
 	private flushDeferredMessage() {

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -19,8 +19,9 @@ import {
 } from "./shortcut-registry.js";
 import { renderApp } from "./state.js";
 import { getRouteFromHash, setHashRoute } from "./routing.js";
+import { getAppStorage } from "../ui/storage/app-storage.js";
 
-type SettingsTab = "shortcuts";
+type SettingsTab = "shortcuts" | "palette";
 let activeTab: SettingsTab = "shortcuts";
 
 // Rebind state (same as shortcuts-dialog)
@@ -296,12 +297,97 @@ function renderShortcutsTab() {
 	`;
 }
 
+// ── Palette chooser ──
+
+interface ColorPalette {
+	id: string;
+	name: string;
+	swatches: [string, string, string, string, string];
+}
+
+const PALETTES: ColorPalette[] = [
+	{ id: "forest", name: "Forest", swatches: ["#508C50", "#6478A0", "#B99130", "#9169C3", "#C34B4B"] },
+	{ id: "ocean",  name: "Ocean",  swatches: ["#32968C", "#3C78BE", "#E07850", "#8C8C9A", "#C34B4B"] },
+	{ id: "dusk",   name: "Dusk",   swatches: ["#D2788C", "#5A5AAF", "#D4A017", "#8B5FCF", "#C85050"] },
+	{ id: "mono",   name: "Mono",   swatches: ["#9CA3AF", "#6B7280", "#D1D5DB", "#A1A1AA", "#EF4444"] },
+];
+
+const SWATCH_LABELS = ["User", "System", "Task", "Team", "Error"];
+
+let activePaletteId = "forest";
+let paletteLoaded = false;
+
+async function loadPalette(): Promise<void> {
+	if (paletteLoaded) return;
+	paletteLoaded = true;
+	try {
+		const storage = getAppStorage();
+		const saved = await storage.settings.get<string>("palette");
+		if (saved) activePaletteId = saved;
+	} catch {}
+}
+
+async function selectPalette(id: string): Promise<void> {
+	activePaletteId = id;
+	if (id === "forest") {
+		delete document.documentElement.dataset.palette;
+	} else {
+		document.documentElement.dataset.palette = id;
+	}
+	try {
+		const storage = getAppStorage();
+		await storage.settings.set("palette", id);
+	} catch {}
+	renderApp();
+}
+
+function renderPaletteTab() {
+	loadPalette();
+
+	return html`
+		<div class="flex flex-col gap-3">
+			<p class="text-sm text-muted-foreground">
+				Choose a color palette for notifications and user messages.
+			</p>
+			<div class="flex flex-col gap-2">
+				${PALETTES.map((palette) => {
+					const isActive = activePaletteId === palette.id;
+					return html`
+						<button
+							class="flex items-center gap-3 px-3 py-2.5 rounded-lg border transition-all cursor-pointer text-left w-full
+								${isActive
+									? "border-primary bg-primary/5 ring-1 ring-primary/30"
+									: "border-border hover:border-primary/40 hover:bg-secondary/30"}"
+							@click=${() => selectPalette(palette.id)}
+						>
+							<div class="flex gap-1.5">
+								${palette.swatches.map((color, i) => html`
+									<div
+										class="w-6 h-6 rounded-full border border-black/10"
+										style="background: ${color}"
+										title="${SWATCH_LABELS[i]}"
+									></div>
+								`)}
+							</div>
+							<span class="text-sm font-medium ${isActive ? 'text-foreground' : 'text-muted-foreground'}">
+								${palette.name}
+							</span>
+							${isActive ? html`<span class="ml-auto text-xs text-primary">Active</span>` : ""}
+						</button>
+					`;
+				})}
+			</div>
+		</div>
+	`;
+}
+
 export function renderSettingsPage() {
 	// Manage keydown listener lifecycle
 	updateKeydownListener();
 
 	const tabs: { id: SettingsTab; label: string }[] = [
 		{ id: "shortcuts", label: "Shortcuts" },
+		{ id: "palette", label: "Color Palette" },
 	];
 
 	return html`
@@ -331,6 +417,7 @@ export function renderSettingsPage() {
 			<div class="flex-1 overflow-y-auto p-4">
 				<div class="max-w-xl">
 					${activeTab === "shortcuts" ? renderShortcutsTab() : ""}
+					${activeTab === "palette" ? renderPaletteTab() : ""}
 				</div>
 			</div>
 		</div>

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -92,6 +92,8 @@ export interface TeamManagerConfig {
 	gateStore?: GateStore;
 	/** Personality manager for resolving personality names to prompt fragments */
 	personalityManager?: PersonalityManager;
+	/** Broadcast a WS event to all clients viewing a goal */
+	broadcastToGoal?: (goalId: string, event: any) => void;
 }
 
 export class TeamManager {
@@ -114,6 +116,11 @@ export class TeamManager {
 		this.taskManager = config.taskManager;
 		this.store = new TeamStore();
 		this.restoreTeams();
+	}
+
+	/** Set the broadcastToGoal function (called after WebSocket server is created). */
+	setBroadcastToGoal(fn: (goalId: string, event: any) => void): void {
+		this.config.broadcastToGoal = fn;
 	}
 
 	/** Pick a palette index (0-19) not already used by any session, with randomisation. */
@@ -650,6 +657,10 @@ export class TeamManager {
 			// Subscribe to worker events to steer the team lead when the worker goes idle
 			const unsubscribe = session.rpcClient.onEvent((event: any) => {
 				if (event.type !== "agent_end") return;
+				// Broadcast team agent finished event
+				this.config.broadcastToGoal?.(goalId, {
+					type: "team_agent_finished", goalId, sessionId: session.id, role, name: roleName,
+				});
 				this.notifyTeamLead(goalId, session.id, role, agentId).catch((err) => {
 					console.error("[team-manager] Failed to notify team lead:", err);
 				});
@@ -659,6 +670,11 @@ export class TeamManager {
 			console.log(
 				`[team-manager] Spawned ${role} agent (${session.id}) for goal "${goal.title}" — cwd: ${agentCwd}`,
 			);
+
+			// Broadcast team agent spawned event
+			this.config.broadcastToGoal?.(goalId, {
+				type: "team_agent_spawned", goalId, sessionId: session.id, role, name: roleName,
+			});
 
 			return { sessionId: session.id, worktreePath: worktreeResult?.worktreePath };
 		} catch (err) {
@@ -791,6 +807,14 @@ export class TeamManager {
 		}
 
 		console.log(`[team-manager] Dismissed ${agent.role} agent (${sessionId}) for goal ${goalId}`);
+
+		// Broadcast team agent dismissed event
+		const sessionMeta = this.sessionManager.getSession(sessionId);
+		const dismissedName = sessionMeta?.title || `${agent.role}-${sessionId.slice(0, 8)}`;
+		this.config.broadcastToGoal?.(goalId, {
+			type: "team_agent_dismissed", goalId, sessionId, role: agent.role, name: dismissedName,
+		});
+
 		return true;
 	}
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -223,6 +223,7 @@ export function createGateway(config: GatewayConfig) {
 			}
 		}
 	}
+	teamManager.setBroadcastToGoal(broadcastToGoal);
 	verificationHarness = new VerificationHarness(gateStore, broadcastToGoal, roleStore);
 	verificationHarness.setTeamLeadNotifier((goalId, message) => {
 		const team = teamManager.getTeamState(goalId);

--- a/src/server/ws/protocol.ts
+++ b/src/server/ws/protocol.ts
@@ -61,4 +61,7 @@ export type ServerMessage =
 	| { type: "gate_verification_complete"; goalId: string; gateId: string; signalId: string; status: string }
 	| { type: "gate_status_changed"; goalId: string; gateId: string; status: string }
 	| { type: "goal_setup_complete"; goalId: string }
-	| { type: "goal_setup_error"; goalId: string; error: string };
+	| { type: "goal_setup_error"; goalId: string; error: string }
+	| { type: "team_agent_spawned"; goalId: string; sessionId: string; role: string; name: string }
+	| { type: "team_agent_dismissed"; goalId: string; sessionId: string; role: string; name: string }
+	| { type: "team_agent_finished"; goalId: string; sessionId: string; role: string; name: string };

--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -70,6 +70,122 @@
 	--sidebar-border: oklch(0.30 0.012 145);
 }
 
+/* ── Notification category colors — Forest palette (default) ── */
+:root {
+	--notif-system-bg: rgba(100, 120, 160, 0.12);
+	--notif-system-border: rgba(100, 120, 160, 0.30);
+	--notif-system-text: rgba(130, 150, 190, 0.90);
+	--notif-task-bg: rgba(185, 145, 45, 0.12);
+	--notif-task-border: rgba(185, 145, 45, 0.30);
+	--notif-task-text: rgba(205, 170, 65, 0.90);
+	--notif-team-bg: rgba(145, 105, 195, 0.12);
+	--notif-team-border: rgba(145, 105, 195, 0.30);
+	--notif-team-text: rgba(165, 130, 210, 0.90);
+	--notif-error-bg: rgba(195, 75, 75, 0.12);
+	--notif-error-border: rgba(195, 75, 75, 0.30);
+	--notif-error-text: rgba(215, 100, 100, 0.90);
+	--user-msg-accent: rgba(80, 140, 80, 1);
+	--user-msg-bg: rgba(80, 140, 80, 0.10);
+	--user-msg-bg2: rgba(90, 150, 85, 0.05);
+	--user-msg-shadow: rgba(80, 140, 80, 0.14);
+	--user-msg-shadow2: rgba(80, 140, 80, 0.08);
+}
+
+/* ── Notification inline styles ── */
+.notification-inline {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 12px;
+	padding: 4px 10px;
+	border-radius: 6px;
+	margin: 2px 16px;
+	border: 1px solid transparent;
+	opacity: 0.85;
+}
+.notification-system {
+	background: var(--notif-system-bg);
+	border-color: var(--notif-system-border);
+	color: var(--notif-system-text);
+}
+.notification-task {
+	background: var(--notif-task-bg);
+	border-color: var(--notif-task-border);
+	color: var(--notif-task-text);
+}
+.notification-team {
+	background: var(--notif-team-bg);
+	border-color: var(--notif-team-border);
+	color: var(--notif-team-text);
+}
+.notification-error {
+	background: var(--notif-error-bg);
+	border-color: var(--notif-error-border);
+	color: var(--notif-error-text);
+}
+.notification-icon { font-size: 11px; flex-shrink: 0; }
+.notification-text { flex: 1; }
+.notification-time { font-size: 11px; opacity: 0.6; flex-shrink: 0; }
+
+/* ── Palette overrides ── */
+[data-palette="ocean"] {
+	--notif-system-bg: rgba(60, 120, 190, 0.12);
+	--notif-system-border: rgba(60, 120, 190, 0.30);
+	--notif-system-text: rgba(90, 150, 210, 0.90);
+	--notif-task-bg: rgba(224, 120, 80, 0.12);
+	--notif-task-border: rgba(224, 120, 80, 0.30);
+	--notif-task-text: rgba(240, 145, 105, 0.90);
+	--notif-team-bg: rgba(140, 140, 154, 0.12);
+	--notif-team-border: rgba(140, 140, 154, 0.30);
+	--notif-team-text: rgba(165, 165, 180, 0.90);
+	--notif-error-bg: rgba(195, 75, 75, 0.12);
+	--notif-error-border: rgba(195, 75, 75, 0.30);
+	--notif-error-text: rgba(215, 100, 100, 0.90);
+	--user-msg-accent: rgba(50, 150, 140, 1);
+	--user-msg-bg: rgba(50, 150, 140, 0.10);
+	--user-msg-bg2: rgba(55, 160, 145, 0.05);
+	--user-msg-shadow: rgba(50, 150, 140, 0.14);
+	--user-msg-shadow2: rgba(50, 150, 140, 0.08);
+}
+[data-palette="dusk"] {
+	--notif-system-bg: rgba(90, 90, 175, 0.12);
+	--notif-system-border: rgba(90, 90, 175, 0.30);
+	--notif-system-text: rgba(120, 120, 200, 0.90);
+	--notif-task-bg: rgba(212, 160, 23, 0.12);
+	--notif-task-border: rgba(212, 160, 23, 0.30);
+	--notif-task-text: rgba(230, 185, 50, 0.90);
+	--notif-team-bg: rgba(139, 95, 207, 0.12);
+	--notif-team-border: rgba(139, 95, 207, 0.30);
+	--notif-team-text: rgba(165, 125, 225, 0.90);
+	--notif-error-bg: rgba(200, 80, 80, 0.12);
+	--notif-error-border: rgba(200, 80, 80, 0.30);
+	--notif-error-text: rgba(220, 105, 105, 0.90);
+	--user-msg-accent: rgba(210, 120, 140, 1);
+	--user-msg-bg: rgba(210, 120, 140, 0.10);
+	--user-msg-bg2: rgba(215, 130, 150, 0.05);
+	--user-msg-shadow: rgba(210, 120, 140, 0.14);
+	--user-msg-shadow2: rgba(210, 120, 140, 0.08);
+}
+[data-palette="mono"] {
+	--notif-system-bg: rgba(107, 114, 128, 0.12);
+	--notif-system-border: rgba(107, 114, 128, 0.30);
+	--notif-system-text: rgba(140, 147, 161, 0.90);
+	--notif-task-bg: rgba(209, 213, 219, 0.12);
+	--notif-task-border: rgba(209, 213, 219, 0.30);
+	--notif-task-text: rgba(225, 228, 233, 0.90);
+	--notif-team-bg: rgba(161, 161, 170, 0.12);
+	--notif-team-border: rgba(161, 161, 170, 0.30);
+	--notif-team-text: rgba(185, 185, 195, 0.90);
+	--notif-error-bg: rgba(239, 68, 68, 0.12);
+	--notif-error-border: rgba(239, 68, 68, 0.30);
+	--notif-error-text: rgba(248, 113, 113, 0.90);
+	--user-msg-accent: rgba(156, 163, 175, 1);
+	--user-msg-bg: rgba(156, 163, 175, 0.10);
+	--user-msg-bg2: rgba(166, 173, 185, 0.05);
+	--user-msg-shadow: rgba(156, 163, 175, 0.14);
+	--user-msg-shadow2: rgba(156, 163, 175, 0.08);
+}
+
 body {
 	font-size: 16px;
 	-webkit-font-smoothing: antialiased;
@@ -2087,12 +2203,12 @@ html {
 .user-message-container {
 	transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 	position: relative;
-	background: linear-gradient(135deg, rgba(80, 140, 80, 0.10), rgba(90, 150, 85, 0.05));
+	background: linear-gradient(135deg, var(--user-msg-bg), var(--user-msg-bg2));
 	border: none;
 	border-radius: 6px;
 	max-width: 100%;
 	padding-left: 24px;
-	box-shadow: 0 1px 4px rgba(80, 140, 80, 0.14), 0 2px 8px rgba(80, 140, 80, 0.08);
+	box-shadow: 0 1px 4px var(--user-msg-shadow), 0 2px 8px var(--user-msg-shadow2);
 }
 /* Sage green chevron marker */
 .user-message-container::before {
@@ -2102,7 +2218,7 @@ html {
 	top: 1.15em;
 	font-size: 12px;
 	font-weight: 700;
-	color: rgba(75, 140, 70, 0.85);
+	color: var(--user-msg-accent);
 	text-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
 	z-index: 1;
 	line-height: 1;

--- a/tests/e2e/notifications.spec.ts
+++ b/tests/e2e/notifications.spec.ts
@@ -1,0 +1,205 @@
+/**
+ * E2E tests for task notification events over WebSocket.
+ *
+ * Verifies that `task_changed` WS events are broadcast to connected clients
+ * when tasks are created and updated via WS commands.
+ */
+import { test, expect } from "@playwright/test";
+import {
+	apiFetch,
+	createGoal,
+	createSession,
+	deleteGoal,
+	deleteSession,
+	connectWs,
+	WsConnection,
+} from "./e2e-setup.js";
+
+let goalId: string;
+let sessionId: string;
+let wsConn: WsConnection;
+
+test.beforeAll(async () => {
+	// Create a goal (no workflow, no worktree — lightweight)
+	const goal = await createGoal({ title: "Notifications E2E test goal" });
+	goalId = goal.id;
+
+	// Create a session linked to this goal
+	sessionId = await createSession({ goalId });
+
+	// Connect WebSocket to the session
+	wsConn = await connectWs(sessionId);
+});
+
+test.afterAll(async () => {
+	wsConn?.close();
+	await deleteSession(sessionId).catch(() => {});
+	await deleteGoal(goalId).catch(() => {});
+});
+
+test.describe("task_changed WS notifications", () => {
+	let taskId: string;
+
+	test("task_create via WS broadcasts task_changed event", async () => {
+		// Send a task_create command over WebSocket
+		wsConn.send({
+			type: "task_create",
+			goalId,
+			title: "Test notification task",
+			taskType: "implementation",
+			spec: "A task to test notifications",
+		});
+
+		// Wait for the task_changed event
+		const msg = await wsConn.waitFor(
+			(m) => m.type === "task_changed" && m.task?.title === "Test notification task",
+			5000,
+		);
+
+		expect(msg.type).toBe("task_changed");
+		expect(msg.task).toBeDefined();
+		expect(msg.task.title).toBe("Test notification task");
+		expect(msg.task.type).toBe("implementation");
+		expect(msg.task.state).toBe("todo");
+		expect(msg.task.goalId).toBe(goalId);
+		expect(typeof msg.task.id).toBe("string");
+
+		// Save the task ID for subsequent tests
+		taskId = msg.task.id;
+	});
+
+	test("task_update state to in-progress broadcasts task_changed event", async () => {
+		expect(taskId).toBeDefined();
+
+		// Clear previously received messages for clean waiting
+		const prevCount = wsConn.messages.length;
+
+		// Update task state to in-progress via WS
+		wsConn.send({
+			type: "task_update",
+			taskId,
+			updates: { state: "in-progress" },
+		});
+
+		// Wait for the task_changed event with in-progress state
+		const msg = await wsConn.waitFor(
+			(m) =>
+				m.type === "task_changed" &&
+				m.task?.id === taskId &&
+				m.task?.state === "in-progress",
+			5000,
+		);
+
+		expect(msg.type).toBe("task_changed");
+		expect(msg.task.id).toBe(taskId);
+		expect(msg.task.state).toBe("in-progress");
+		expect(msg.task.title).toBe("Test notification task");
+	});
+
+	test("task_update state to complete broadcasts task_changed event", async () => {
+		expect(taskId).toBeDefined();
+
+		// Update task state to complete via WS
+		wsConn.send({
+			type: "task_update",
+			taskId,
+			updates: { state: "complete" },
+		});
+
+		// Wait for the task_changed event with complete state
+		const msg = await wsConn.waitFor(
+			(m) =>
+				m.type === "task_changed" &&
+				m.task?.id === taskId &&
+				m.task?.state === "complete",
+			5000,
+		);
+
+		expect(msg.type).toBe("task_changed");
+		expect(msg.task.id).toBe(taskId);
+		expect(msg.task.state).toBe("complete");
+	});
+
+	test("task_update with spec change broadcasts task_changed event", async () => {
+		// Create a second task for this test
+		wsConn.send({
+			type: "task_create",
+			goalId,
+			title: "Spec update task",
+			taskType: "testing",
+		});
+
+		const createMsg = await wsConn.waitFor(
+			(m) => m.type === "task_changed" && m.task?.title === "Spec update task",
+			5000,
+		);
+		const task2Id = createMsg.task.id;
+
+		// Update just the spec
+		wsConn.send({
+			type: "task_update",
+			taskId: task2Id,
+			updates: { spec: "Updated spec content" },
+		});
+
+		const updateMsg = await wsConn.waitFor(
+			(m) =>
+				m.type === "task_changed" &&
+				m.task?.id === task2Id &&
+				m.task?.spec === "Updated spec content",
+			5000,
+		);
+
+		expect(updateMsg.task.spec).toBe("Updated spec content");
+		expect(updateMsg.task.state).toBe("todo"); // unchanged
+	});
+
+	test("task_delete broadcasts task_changed event with _deleted flag", async () => {
+		// Create a task to delete
+		wsConn.send({
+			type: "task_create",
+			goalId,
+			title: "Task to delete",
+			taskType: "custom",
+		});
+
+		const createMsg = await wsConn.waitFor(
+			(m) => m.type === "task_changed" && m.task?.title === "Task to delete",
+			5000,
+		);
+		const deleteTaskId = createMsg.task.id;
+
+		// Delete it
+		wsConn.send({
+			type: "task_delete",
+			taskId: deleteTaskId,
+		});
+
+		const deleteMsg = await wsConn.waitFor(
+			(m) =>
+				m.type === "task_changed" &&
+				m.task?.id === deleteTaskId &&
+				m.task?._deleted === true,
+			5000,
+		);
+
+		expect(deleteMsg.task._deleted).toBe(true);
+		expect(deleteMsg.task.id).toBe(deleteTaskId);
+	});
+
+	test("task_update for nonexistent task returns error", async () => {
+		wsConn.send({
+			type: "task_update",
+			taskId: "nonexistent-task-id-12345",
+			updates: { state: "in-progress" },
+		});
+
+		const errMsg = await wsConn.waitFor(
+			(m) => m.type === "error" && m.code === "TASK_NOT_FOUND",
+			5000,
+		);
+
+		expect(errMsg.type).toBe("error");
+		expect(errMsg.code).toBe("TASK_NOT_FOUND");
+	});
+});

--- a/tests/fixtures/notification-renderer.html
+++ b/tests/fixtures/notification-renderer.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.notification-inline {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  margin: 2px 16px;
+  border: 1px solid transparent;
+  opacity: 0.85;
+}
+.notification-system { background: rgba(100,120,160,0.12); border-color: rgba(100,120,160,0.30); color: rgba(130,150,190,0.90); }
+.notification-task { background: rgba(185,145,45,0.12); border-color: rgba(185,145,45,0.30); color: rgba(205,170,65,0.90); }
+.notification-team { background: rgba(145,105,195,0.12); border-color: rgba(145,105,195,0.30); color: rgba(165,130,210,0.90); }
+.notification-error { background: rgba(195,75,75,0.12); border-color: rgba(195,75,75,0.30); color: rgba(215,100,100,0.90); }
+.notification-icon { font-size: 11px; flex-shrink: 0; }
+.notification-text { flex: 1; }
+.notification-time { font-size: 11px; opacity: 0.6; flex-shrink: 0; }
+</style>
+</head>
+<body>
+<div id="container"></div>
+<script>
+const CATEGORY_ICONS = {
+  system: '\u27F3',
+  task: '\u2713',
+  team: '\u25CF',
+  error: '\u2715',
+};
+
+function createNotification(message, category) {
+  return {
+    role: 'system-notification',
+    message,
+    variant: 'default',
+    category: category || 'system',
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function renderNotification(notif) {
+  const category = notif.category || 'system';
+  const icon = CATEGORY_ICONS[category] || CATEGORY_ICONS.system;
+  const time = new Date(notif.timestamp).toLocaleTimeString();
+  const div = document.createElement('div');
+  div.className = `notification-inline notification-${category}`;
+  div.innerHTML = `<span class="notification-icon">${icon}</span><span class="notification-text">${notif.message}</span><span class="notification-time">${time}</span>`;
+  return div;
+}
+
+// Render all four categories
+const container = document.getElementById('container');
+const categories = ['system', 'task', 'team', 'error'];
+categories.forEach(cat => {
+  const notif = createNotification(`Test ${cat} notification`, cat);
+  container.appendChild(renderNotification(notif));
+});
+
+// Also render one without category (should default to system)
+const defaultNotif = createNotification('Default notification');
+defaultNotif.category = undefined;
+container.appendChild(renderNotification(defaultNotif));
+</script>
+</body>
+</html>

--- a/tests/fixtures/palette-css.html
+++ b/tests/fixtures/palette-css.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+:root {
+  --notif-system-bg: rgba(100, 120, 160, 0.12);
+  --notif-system-border: rgba(100, 120, 160, 0.30);
+  --notif-system-text: rgba(130, 150, 190, 0.90);
+  --notif-task-bg: rgba(185, 145, 45, 0.12);
+  --user-msg-accent: rgba(80, 140, 80, 1);
+  --user-msg-bg: rgba(80, 140, 80, 0.10);
+}
+
+[data-palette="ocean"] {
+  --notif-system-bg: rgba(60, 120, 190, 0.12);
+  --notif-system-border: rgba(60, 120, 190, 0.30);
+  --notif-system-text: rgba(90, 150, 210, 0.90);
+  --notif-task-bg: rgba(224, 120, 80, 0.12);
+  --user-msg-accent: rgba(50, 150, 140, 1);
+  --user-msg-bg: rgba(50, 150, 140, 0.10);
+}
+
+[data-palette="mono"] {
+  --notif-system-bg: rgba(107, 114, 128, 0.12);
+  --notif-system-border: rgba(107, 114, 128, 0.30);
+  --notif-system-text: rgba(140, 147, 161, 0.90);
+  --notif-task-bg: rgba(209, 213, 219, 0.12);
+  --user-msg-accent: rgba(156, 163, 175, 1);
+  --user-msg-bg: rgba(156, 163, 175, 0.10);
+}
+
+.test-box {
+  width: 100px;
+  height: 20px;
+  background: var(--notif-system-bg);
+  border: 1px solid var(--notif-system-border);
+  color: var(--notif-system-text);
+}
+.user-box {
+  width: 100px;
+  height: 20px;
+  background: var(--user-msg-bg);
+  color: var(--user-msg-accent);
+}
+</style>
+</head>
+<body>
+<div class="test-box" id="system-box">System</div>
+<div class="user-box" id="user-box">User</div>
+</body>
+</html>

--- a/tests/notification-renderer.spec.ts
+++ b/tests/notification-renderer.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "@playwright/test";
+import path from "node:path";
+
+const FIXTURE = `file:///${path.resolve("tests/fixtures/notification-renderer.html").replace(/\\/g, "/")}`;
+
+test.describe("notification renderer", () => {
+  test("renders correct DOM structure per category", async ({ page }) => {
+    await page.goto(FIXTURE);
+    const notifications = page.locator(".notification-inline");
+    await expect(notifications).toHaveCount(5);
+
+    // Check each category has the right class
+    await expect(notifications.nth(0)).toHaveClass(/notification-system/);
+    await expect(notifications.nth(1)).toHaveClass(/notification-task/);
+    await expect(notifications.nth(2)).toHaveClass(/notification-team/);
+    await expect(notifications.nth(3)).toHaveClass(/notification-error/);
+
+    // Default (no category) should fall back to system
+    await expect(notifications.nth(4)).toHaveClass(/notification-system/);
+  });
+
+  test("each notification has icon, text, and time spans", async ({ page }) => {
+    await page.goto(FIXTURE);
+    const first = page.locator(".notification-inline").first();
+    await expect(first.locator(".notification-icon")).toHaveCount(1);
+    await expect(first.locator(".notification-text")).toHaveCount(1);
+    await expect(first.locator(".notification-time")).toHaveCount(1);
+  });
+
+  test("category icons are correct", async ({ page }) => {
+    await page.goto(FIXTURE);
+    const icons = page.locator(".notification-icon");
+    await expect(icons.nth(0)).toHaveText("\u27F3"); // system
+    await expect(icons.nth(1)).toHaveText("\u2713"); // task
+    await expect(icons.nth(2)).toHaveText("\u25CF"); // team
+    await expect(icons.nth(3)).toHaveText("\u2715"); // error
+  });
+
+  test("notification text content is rendered", async ({ page }) => {
+    await page.goto(FIXTURE);
+    const texts = page.locator(".notification-text");
+    await expect(texts.nth(0)).toHaveText("Test system notification");
+    await expect(texts.nth(1)).toHaveText("Test task notification");
+    await expect(texts.nth(2)).toHaveText("Test team notification");
+    await expect(texts.nth(3)).toHaveText("Test error notification");
+  });
+});

--- a/tests/palette-css.spec.ts
+++ b/tests/palette-css.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from "@playwright/test";
+import path from "node:path";
+
+const FIXTURE = `file:///${path.resolve("tests/fixtures/palette-css.html").replace(/\\/g, "/")}`;
+
+test.describe("palette CSS custom properties", () => {
+  test("default (forest) palette values are applied", async ({ page }) => {
+    await page.goto(FIXTURE);
+    const val = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue("--notif-system-bg").trim()
+    );
+    expect(val).toContain("100");
+    expect(val).toContain("120");
+    expect(val).toContain("160");
+  });
+
+  test("ocean palette overrides custom properties", async ({ page }) => {
+    await page.goto(FIXTURE);
+    await page.evaluate(() => {
+      document.documentElement.dataset.palette = "ocean";
+    });
+    const val = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue("--notif-system-bg").trim()
+    );
+    expect(val).toContain("60");
+    expect(val).toContain("120");
+    expect(val).toContain("190");
+  });
+
+  test("mono palette overrides custom properties", async ({ page }) => {
+    await page.goto(FIXTURE);
+    await page.evaluate(() => {
+      document.documentElement.dataset.palette = "mono";
+    });
+    const val = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue("--user-msg-accent").trim()
+    );
+    expect(val).toContain("156");
+    expect(val).toContain("163");
+    expect(val).toContain("175");
+  });
+
+  test("removing palette resets to forest defaults", async ({ page }) => {
+    await page.goto(FIXTURE);
+    // Set ocean
+    await page.evaluate(() => { document.documentElement.dataset.palette = "ocean"; });
+    // Verify it changed
+    let val = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue("--user-msg-accent").trim()
+    );
+    expect(val).toContain("50");
+    expect(val).toContain("150");
+    expect(val).toContain("140");
+    // Remove palette
+    await page.evaluate(() => { delete document.documentElement.dataset.palette; });
+    val = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue("--user-msg-accent").trim()
+    );
+    expect(val).toContain("80");
+    expect(val).toContain("140");
+    expect(val).toContain("80");
+  });
+
+  test("computed styles on elements change with palette", async ({ page }) => {
+    await page.goto(FIXTURE);
+    // Forest default
+    let bg = await page.evaluate(() =>
+      getComputedStyle(document.getElementById("system-box")!).backgroundColor
+    );
+    expect(bg).toContain("100");
+
+    // Switch to ocean
+    await page.evaluate(() => { document.documentElement.dataset.palette = "ocean"; });
+    bg = await page.evaluate(() =>
+      getComputedStyle(document.getElementById("system-box")!).backgroundColor
+    );
+    expect(bg).toContain("60");
+  });
+});

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -4,6 +4,7 @@
     "module": "ES2022",
     "moduleResolution": "bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
     "strict": true,
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary

Add category-based coloring to chat notifications (system, task, team, error) and a color palette chooser in Settings.

### Changes (14 files, +784/-31)

**Core Feature**
- Extended `SystemNotificationMessage` with `category` field
- Compact inline notification renderer (icon + text + timestamp) replacing Alert component
- CSS custom properties for notification colors on `:root` with palette override support

**Server**
- New WS broadcasts: `team_agent_spawned`, `team_agent_dismissed`, `team_agent_finished`
- Wired `broadcastToGoal` into team-manager for lifecycle events

**Notification Sources**
- `task_changed` → task category (complete, blocked, assigned)
- `gate_status_changed` / `gate_verification_complete` → task or error
- Team agent lifecycle → team category
- Reconnection → system category
- Server errors → error category

**Palette Chooser**
- 4 presets: Forest (default), Ocean, Dusk, Mono
- Swatch-based UI in Settings page
- Persisted via settings store, applied via `data-palette` attribute

### Tests
- 173/173 unit tests passed (includes 4 notification + 5 palette tests)
- 6/6 E2E notification tests passed
- Type check clean

### Known Fast-Follow Items
- Hot-reload notification flag set but not consumed on load
- Session-restored notification not yet implemented
- `team_agent_finished` fires per turn (may want filtering)