### PR TITLE
fix: streaming verification UI — match delegate card pattern

### DIFF
--- a/src/app/goal-dashboard.css
+++ b/src/app/goal-dashboard.css
@@ -1364,6 +1364,99 @@
 	word-break: break-word;
 }
 
+/* ── Verification cards (live + dashboard) ── */
+.verify-cards {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+.verify-cards__header {
+	font-size: 12px;
+	font-weight: 500;
+	margin-bottom: 2px;
+}
+.verify-cards__header-status--pass { color: oklch(0.72 0.15 145); }
+.verify-cards__header-status--fail { color: var(--destructive); }
+.verify-cards__header-status--running { color: var(--muted-foreground); }
+
+.verify-card {
+	border: 1px solid var(--border);
+	border-radius: 6px;
+	font-size: 12px;
+	overflow: hidden;
+}
+.verify-card--running { border-color: oklch(0.62 0.15 250 / 0.3); }
+.verify-card--pass { border-color: oklch(0.65 0.15 145 / 0.3); background: oklch(0.65 0.15 145 / 0.03); }
+.verify-card--fail { border-color: color-mix(in oklch, var(--destructive) 30%, transparent); background: color-mix(in oklch, var(--destructive) 3%, transparent); }
+
+.verify-card__header {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 6px 8px;
+}
+.verify-card__header--clickable { cursor: pointer; }
+.verify-card__header--clickable:hover { background: var(--accent); }
+
+.verify-card__icon {
+	font-weight: 700;
+	width: 14px;
+	text-align: center;
+	flex-shrink: 0;
+}
+.verify-card__icon--running { color: oklch(0.62 0.15 250); animation: pulse-verify 1.5s ease-in-out infinite; }
+.verify-card__icon--pass { color: oklch(0.72 0.15 145); }
+.verify-card__icon--fail { color: var(--destructive); }
+
+@keyframes pulse-verify {
+	0%, 100% { opacity: 1; }
+	50% { opacity: 0.4; }
+}
+
+.verify-card__name {
+	font-weight: 500;
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.verify-card__type-badge {
+	font-size: 10px;
+	padding: 1px 5px;
+	border-radius: 3px;
+	background: var(--secondary);
+	color: var(--text-tertiary);
+	flex-shrink: 0;
+}
+.verify-card__type-badge--llm {
+	background: oklch(0.55 0.15 290 / 0.15);
+	color: oklch(0.72 0.15 290);
+}
+.verify-card__duration {
+	font-size: 10px;
+	color: var(--text-tertiary);
+	flex-shrink: 0;
+}
+.verify-card__expand {
+	font-size: 10px;
+	color: var(--muted-foreground);
+	flex-shrink: 0;
+}
+.verify-card__output {
+	background: rgba(0,0,0,0.3);
+	padding: 8px;
+	font-family: var(--font-mono, monospace);
+	font-size: 11px;
+	white-space: pre-wrap;
+	max-height: 300px;
+	overflow-y: auto;
+	border-top: 1px solid var(--border);
+	color: var(--muted-foreground);
+	word-break: break-word;
+	margin: 0;
+}
+
 /* ── Signal metadata ── */
 .signal-metadata {
 	display: flex;

--- a/src/app/goal-dashboard.ts
+++ b/src/app/goal-dashboard.ts
@@ -99,6 +99,7 @@ interface LiveVerification {
 }
 let liveVerifications: Map<string, LiveVerification> = new Map();
 let liveVerifTimer: ReturnType<typeof setInterval> | null = null;
+let expandedLiveStepKeys: Set<string> = new Set();
 
 /** Current dashboard tab */
 let dashboardTab: "spec" | "tasks" | "agents" | "commits" | "gates" = "gates";
@@ -204,6 +205,7 @@ export function clearDashboardState(): void {
 	stopGitStatusPolling();
 	document.removeEventListener("gate-verification-event", handleLiveVerificationEvent);
 	liveVerifications = new Map();
+	expandedLiveStepKeys = new Set();
 	stopLiveVerifTimer();
 }
 
@@ -1469,7 +1471,17 @@ function renderSignalEntry(signal: GateSignal): TemplateResult {
 			</div>
 			${isExpanded ? html`
 				<div class="signal-entry__body">
-					${isLive ? renderLiveVerificationSteps(liveEntry!) : html`
+					${isLive ? renderLiveVerificationSteps(liveEntry!) : vStatus === "running" && signal.verification.steps.length === 0
+						? html`<div class="verify-card verify-card--running" style="padding:8px 10px;">
+							<span class="verify-card__icon verify-card__icon--running">\u25CF</span>
+							<span>Verification in progress\u2026</span>
+						</div>`
+						: signal.verification.steps.length === 0 && vStatus === "passed"
+							? html`<div class="verify-card verify-card--pass" style="padding:8px 10px;">
+								<span class="verify-card__icon verify-card__icon--pass">\u2713</span>
+								<span>Passed (no verification)</span>
+							</div>`
+						: html`
 						${signal.verification.steps.map(step => html`
 							<div class="verify-step verify-step--${step.passed ? "pass" : "fail"}">
 								<div class="verify-step__header">
@@ -1499,28 +1511,92 @@ function renderSignalEntry(signal: GateSignal): TemplateResult {
 	`;
 }
 
-function renderLiveVerificationSteps(entry: LiveVerification): TemplateResult {
-	if (entry.steps.length === 0) {
-		return html`<div class="verify-step"><div class="verify-step__header"><span class="verify-step__icon">\u23F3</span><span class="verify-step__name">Verification in progress\u2026</span></div></div>`;
+function toggleLiveStepExpand(key: string): void {
+	if (expandedLiveStepKeys.has(key)) {
+		expandedLiveStepKeys.delete(key);
+	} else {
+		expandedLiveStepKeys.add(key);
 	}
-	return html`${entry.steps.map(step => {
-		const isRunning = step.status === "running";
-		const passed = step.status === "passed";
-		const elapsed = isRunning ? Math.max(0, Math.round((Date.now() - step.startedAt) / 1000)) : 0;
-		const elapsedStr = elapsed < 60 ? `${elapsed}s` : `${Math.floor(elapsed / 60)}m ${String(elapsed % 60).padStart(2, "0")}s`;
-		const durStr = step.durationMs != null ? (step.durationMs < 1000 ? `${Math.round(step.durationMs)}ms` : `${(step.durationMs / 1000).toFixed(1)}s`) : "";
-		return html`
-			<div class="verify-step verify-step--${isRunning ? "running" : passed ? "pass" : "fail"}">
-				<div class="verify-step__header">
-					<span class="verify-step__icon">${isRunning ? "\u23F3" : passed ? "\u2713" : "\u2717"}</span>
-					<span class="verify-step__name">${step.name}</span>
-					<span class="verify-step__type">${step.type}</span>
-					<span class="verify-step__duration">${isRunning ? elapsedStr : durStr}</span>
-				</div>
-				${step.output ? html`<div class="verify-step__output">${step.output}</div>` : nothing}
+	renderApp();
+}
+
+function formatStepElapsed(startedAt: number): string {
+	const s = Math.max(0, Math.round((Date.now() - startedAt) / 1000));
+	return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m ${String(s % 60).padStart(2, "0")}s`;
+}
+
+function formatStepDuration(ms: number): string {
+	if (ms < 1000) return `${Math.round(ms)}ms`;
+	if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+	const m = Math.floor(ms / 60000);
+	const s = Math.round((ms % 60000) / 1000);
+	return `${m}m ${s}s`;
+}
+
+function renderLiveVerificationSteps(entry: LiveVerification): TemplateResult {
+	// Auto-pass: complete with no steps
+	if (entry.steps.length === 0 && entry.overallStatus !== "running") {
+		const isPassed = entry.overallStatus === "passed";
+		return html`<div class="verify-card verify-card--${isPassed ? "pass" : "fail"}" style="padding:8px 10px;">
+			<span class="verify-card__icon verify-card__icon--${isPassed ? "pass" : "fail"}">${isPassed ? "\u2713" : "\u2717"}</span>
+			<span>${isPassed ? "Passed (no verification)" : "Failed"}</span>
+		</div>`;
+	}
+
+	// Still waiting for step definitions
+	if (entry.steps.length === 0) {
+		return html`<div class="verify-card verify-card--running" style="padding:8px 10px;">
+			<span class="verify-card__icon verify-card__icon--running">\u25CF</span>
+			<span>Verification in progress\u2026</span>
+		</div>`;
+	}
+
+	const passedCount = entry.steps.filter(s => s.status === "passed").length;
+	const failedCount = entry.steps.filter(s => s.status === "failed").length;
+	const totalCount = entry.steps.length;
+	const isDone = entry.overallStatus !== "running";
+
+	return html`
+		<div class="verify-cards">
+			<div class="verify-cards__header">
+				${isDone
+					? entry.overallStatus === "passed"
+						? html`<span class="verify-cards__header-status verify-cards__header-status--pass">\u2713 Verified \u2014 passed</span>`
+						: html`<span class="verify-cards__header-status verify-cards__header-status--fail">\u2717 Verified \u2014 failed</span>`
+					: html`<span class="verify-cards__header-status verify-cards__header-status--running">Verifying \u2014 ${passedCount}/${totalCount} checks passed${failedCount > 0 ? html`, <span style="color:var(--destructive)">${failedCount} failed</span>` : nothing}</span>`
+				}
 			</div>
-		`;
-	})}`;
+			${entry.steps.map((step, i) => {
+				const stepKey = `${entry.gateId}:${entry.signalId}:${i}`;
+				const isRunning = step.status === "running";
+				const isPassed = step.status === "passed";
+				const isFailed = step.status === "failed";
+				const hasOutput = !!step.output;
+				const isExpanded = expandedLiveStepKeys.has(stepKey);
+				const isLlm = step.type === "llm-review";
+
+				return html`
+					<div class="verify-card verify-card--${isRunning ? "running" : isPassed ? "pass" : "fail"}">
+						<div class="verify-card__header ${hasOutput ? "verify-card__header--clickable" : ""}"
+							@click=${hasOutput ? () => toggleLiveStepExpand(stepKey) : null}>
+							<span class="verify-card__icon verify-card__icon--${isRunning ? "running" : isPassed ? "pass" : "fail"}">
+								${isRunning ? "\u25CF" : isPassed ? "\u2713" : "\u2717"}
+							</span>
+							<span class="verify-card__name">${step.name}</span>
+							<span class="verify-card__type-badge ${isLlm ? "verify-card__type-badge--llm" : ""}">${step.type}</span>
+							<span class="verify-card__duration">
+								${isRunning ? formatStepElapsed(step.startedAt) : step.durationMs != null ? formatStepDuration(step.durationMs) : ""}
+							</span>
+							${hasOutput ? html`<span class="verify-card__expand">${isExpanded ? "\u25B4" : "\u25BE"}</span>` : nothing}
+						</div>
+						${isExpanded && step.output ? html`
+							<pre class="verify-card__output">${step.output}</pre>
+						` : nothing}
+					</div>
+				`;
+			})}
+		</div>
+	`;
 }
 
 // ============================================================================

--- a/src/ui/tools/renderers/GateVerificationLive.ts
+++ b/src/ui/tools/renderers/GateVerificationLive.ts
@@ -2,11 +2,19 @@
  * <gate-verification-live> — Lit element that subscribes to gate-verification-event
  * CustomEvents on document and renders live step cards with timers.
  *
+ * Uses the shared delegate-cards.ts components to match the delegate UX pattern.
  * Used by GateSignalRenderer (chat) and could be embedded in the dashboard.
  */
 import { LitElement, html, nothing, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import "../../components/LiveTimer.js";
+import {
+	type DelegateCardEntry,
+	statusColor,
+	statusIcon,
+	formatDuration,
+	renderDuration,
+} from "./delegate-cards.js";
 
 interface VerificationStep {
 	name: string;
@@ -15,6 +23,28 @@ interface VerificationStep {
 	durationMs?: number;
 	output?: string;
 	startedAt: number;
+}
+
+/** Map verification step status to delegate-cards status strings */
+function toDelegateStatus(status: "running" | "passed" | "failed"): string {
+	if (status === "passed") return "completed";
+	if (status === "failed") return "error";
+	return "running";
+}
+
+/** Build a DelegateCardEntry-compatible object for renderDuration() */
+function toCardEntry(step: VerificationStep, index: number): DelegateCardEntry {
+	const delegateStatus = toDelegateStatus(step.status);
+	// For running steps, compute durationMs from startedAt so <live-timer> works
+	const durationMs = step.status === "running"
+		? Date.now() - step.startedAt
+		: (step.durationMs ?? 0);
+	return {
+		id: `step-${index}`,
+		name: step.name || "step",
+		status: delegateStatus,
+		durationMs,
+	};
 }
 
 @customElement("gate-verification-live")
@@ -29,7 +59,6 @@ export class GateVerificationLive extends LitElement {
 	@state() private overallStatus: "idle" | "running" | "passed" | "failed" = "idle";
 	@state() private expandedSteps = new Set<number>();
 
-	private _timerInterval: ReturnType<typeof setInterval> | null = null;
 	private _boundOnEvent = this._onEvent.bind(this);
 
 	override createRenderRoot() { return this; }
@@ -42,19 +71,6 @@ export class GateVerificationLive extends LitElement {
 	override disconnectedCallback() {
 		super.disconnectedCallback();
 		document.removeEventListener("gate-verification-event", this._boundOnEvent);
-		this._stopTimer();
-	}
-
-	private _startTimer() {
-		if (this._timerInterval) return;
-		this._timerInterval = setInterval(() => this.requestUpdate(), 1000);
-	}
-
-	private _stopTimer() {
-		if (this._timerInterval) {
-			clearInterval(this._timerInterval);
-			this._timerInterval = null;
-		}
 	}
 
 	private _onEvent(e: Event) {
@@ -74,7 +90,6 @@ export class GateVerificationLive extends LitElement {
 					startedAt: Date.now(),
 				}));
 				this.overallStatus = "running";
-				this._startTimer();
 				break;
 			}
 			case "gate_verification_step_complete": {
@@ -108,7 +123,6 @@ export class GateVerificationLive extends LitElement {
 			}
 			case "gate_verification_complete": {
 				this.overallStatus = detail.status || "passed";
-				this._stopTimer();
 				this.requestUpdate();
 				break;
 			}
@@ -121,36 +135,22 @@ export class GateVerificationLive extends LitElement {
 		this.expandedSteps = next;
 	}
 
-	private _formatElapsed(startedAt: number): string {
-		const s = Math.max(0, Math.round((Date.now() - startedAt) / 1000));
-		return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m ${String(s % 60).padStart(2, "0")}s`;
-	}
-
-	private _formatDuration(ms: number): string {
-		if (ms < 1000) return `${Math.round(ms)}ms`;
-		if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
-		const m = Math.floor(ms / 60000);
-		const s = Math.round((ms % 60000) / 1000);
-		return `${m}m ${s}s`;
-	}
-
 	override render() {
 		// No events yet — show placeholder based on finalStatus or idle state
 		if (this.overallStatus === "idle" && this.steps.length === 0) {
 			if (this.finalStatus === "passed") {
-				return html`<div class="mt-2 text-xs text-green-600 dark:text-green-400">✓ Passed (no verification steps)</div>`;
+				return html`<div class="mt-2 text-xs ${statusColor("completed")}">${statusIcon("completed")} Passed (no verification)</div>`;
 			}
 			if (this.finalStatus === "failed") {
-				return html`<div class="mt-2 text-xs text-red-600 dark:text-red-400">✗ Failed</div>`;
+				return html`<div class="mt-2 text-xs ${statusColor("error")}">${statusIcon("error")} Failed</div>`;
 			}
-			return html`<div class="mt-2 text-xs text-muted-foreground animate-pulse">Verification in progress…</div>`;
+			return html`<div class="mt-2 text-xs ${statusColor("running")}">Verification in progress…</div>`;
 		}
 
 		// Auto-pass: complete arrived with no steps
 		if (this.steps.length === 0 && this.overallStatus !== "running") {
-			const color = this.overallStatus === "passed" ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400";
-			const icon = this.overallStatus === "passed" ? "✓" : "✗";
-			return html`<div class="mt-2 text-xs ${color}">${icon} ${this.overallStatus === "passed" ? "Passed (no verification steps)" : "Failed"}</div>`;
+			const dStatus = toDelegateStatus(this.overallStatus as "passed" | "failed");
+			return html`<div class="mt-2 text-xs ${statusColor(dStatus)}">${statusIcon(dStatus)} ${this.overallStatus === "passed" ? "Passed (no verification)" : "Failed"}</div>`;
 		}
 
 		const passedCount = this.steps.filter(s => s.status === "passed").length;
@@ -167,43 +167,26 @@ export class GateVerificationLive extends LitElement {
 
 	private _renderHeader(passed: number, failed: number, total: number): TemplateResult {
 		if (this.overallStatus === "passed") {
-			return html`<div class="text-xs font-medium text-green-600 dark:text-green-400 mb-1">✓ Verified <code class="text-[10px]">${this.gateId}</code> — passed</div>`;
+			return html`<div class="text-xs font-medium ${statusColor("completed")} mb-1">${statusIcon("completed")} Verified <code class="text-[10px]">${this.gateId}</code> — <span class="text-green-500">${passed}/${total} passed</span></div>`;
 		}
 		if (this.overallStatus === "failed") {
-			return html`<div class="text-xs font-medium text-red-600 dark:text-red-400 mb-1">✗ Verified <code class="text-[10px]">${this.gateId}</code> — failed</div>`;
+			return html`<div class="text-xs font-medium ${statusColor("error")} mb-1">${statusIcon("error")} Verified <code class="text-[10px]">${this.gateId}</code> — <span class="text-green-500">${passed} passed</span>, <span class="text-red-500">${failed} failed</span></div>`;
 		}
-		return html`<div class="text-xs font-medium text-muted-foreground mb-1">Verifying <code class="text-[10px]">${this.gateId}</code> — ${passed}/${total} steps passed${failed > 0 ? html`, <span class="text-red-600 dark:text-red-400">${failed} failed</span>` : nothing}</div>`;
+		// Running
+		const completedCount = passed + failed;
+		return html`<div class="text-xs font-medium ${statusColor("running")} mb-1">Verifying <code class="text-[10px]">${this.gateId}</code> — <span class="text-xs">${completedCount}/${total} steps</span>${failed > 0 ? html` <span class="text-red-500">(${failed} failed)</span>` : nothing}</div>`;
 	}
 
 	private _renderStepCard(step: VerificationStep, index: number): TemplateResult {
 		const isExpanded = this.expandedSteps.has(index);
 		const hasOutput = !!step.output;
+		const dStatus = toDelegateStatus(step.status);
+		const entry = toCardEntry(step, index);
 
-		// Status icon and color
-		let iconStr: string;
-		let iconCls: string;
-		if (step.status === "running") {
-			iconStr = "●";
-			iconCls = "text-blue-500 animate-pulse";
-		} else if (step.status === "passed") {
-			iconStr = "✓";
-			iconCls = "text-green-600 dark:text-green-400";
-		} else {
-			iconStr = "✗";
-			iconCls = "text-red-600 dark:text-red-400";
-		}
-
-		// Type badge
+		// Type badge (verification-specific, not in delegate-cards)
 		const typeBadgeCls = step.type === "command"
 			? "bg-muted text-muted-foreground"
 			: "bg-purple-500/20 text-purple-600 dark:text-purple-400";
-
-		// Duration or live timer
-		const durationPart = step.status === "running"
-			? html`<span class="text-xs text-muted-foreground">${this._formatElapsed(step.startedAt)}</span>`
-			: step.durationMs != null
-				? html`<span class="text-xs text-muted-foreground">${this._formatDuration(step.durationMs)}</span>`
-				: nothing;
 
 		return html`
 			<div class="border border-border rounded text-sm">
@@ -211,10 +194,10 @@ export class GateVerificationLive extends LitElement {
 					class="p-2 flex items-center gap-2 ${hasOutput ? "cursor-pointer hover:bg-accent/50" : ""}"
 					@click=${hasOutput ? () => this._toggleStep(index) : null}
 				>
-					<span class="${iconCls} font-bold shrink-0">${iconStr}</span>
-					<span class="truncate flex-1 text-xs">${step.name || "step"}</span>
+					<span class="${statusColor(dStatus)}">${statusIcon(dStatus)}</span>
+					<span class="font-mono text-xs flex-1 min-w-0 truncate">${step.name || "step"}</span>
 					<span class="px-1.5 py-0.5 rounded text-[10px] font-medium ${typeBadgeCls}">${step.type}</span>
-					${durationPart}
+					${renderDuration(entry)}
 					${hasOutput ? html`<span class="text-muted-foreground text-[10px] shrink-0">${isExpanded ? "▴" : "▾"}</span>` : nothing}
 				</div>
 				${isExpanded && step.output ? html`


### PR DESCRIPTION
## Summary

Fixes the streaming verification UI to properly match the delegate card UX pattern as specified in the goal.

### Changes

**GateVerificationLive.ts** (chat tool renderer):
- Reuses shared `delegate-cards.ts` components (`statusColor`, `statusIcon`, `formatDuration`, `renderDuration`)
- Uses `<live-timer>` for running step timers instead of manual interval-based updates
- Removed redundant timer interval code — delegates to Lit reactivity + live-timer
- Consistent card layout: bordered rounded rows with status icon, monospace step name, type badge, duration
- Proper no-steps handling: shows "Passed (no verification)" inline

**goal-dashboard.css + goal-dashboard.ts** (goal dashboard):
- New card-style CSS classes (`.verify-card`, `.verify-card__header`, etc.) with proper status coloring and pulse animation
- Rewritten `renderLiveVerificationSteps()` with card layout, type badges, expandable output per step
- Added header with running status counts ("Verifying — 2/3 checks passed")
- Click-to-expand output per step with `expandedLiveStepKeys` state tracking  
- Graceful handling of no-steps auto-pass and mid-verification page refresh
- Proper "Verification in progress…" indicator when signal is running but no live data available

### Testing
- `npm run check` — types pass
- 183/183 unit tests pass