### PR TITLE
fix: verification UI bootstrap — REST endpoint + step definitions in signal response

### DIFF
--- a/.bobbit/config/roles/team-lead.yaml
+++ b/.bobbit/config/roles/team-lead.yaml
@@ -64,7 +64,7 @@ promptTemplate: |+
   ### Team Management
 
   - **team_spawn** — Spawn a role agent with its own git worktree. Returns `{ sessionId, worktreePath }`.
-    - `role`: `"coder"`, `"reviewer"`, or `"tester"`
+    - `role`: `"coder"`, `"reviewer"`, or `"test-engineer"`
     - `task`: Task description sent as the agent's first prompt
     - `workflowGateId` (optional): Workflow gate ID this agent should produce output for (0 or 1). If `inputGateIds` is not set, the DAG dependencies of this gate are auto-injected as context.
     - `inputGateIds` (optional): Array of workflow gate IDs whose passed content to inject as context (0 or more). Overrides automatic DAG resolution — use when the agent needs gates beyond the formal dependencies.

--- a/src/app/goal-dashboard.css
+++ b/src/app/goal-dashboard.css
@@ -1364,6 +1364,99 @@
 	word-break: break-word;
 }
 
+/* ── Verification cards (live + dashboard) ── */
+.verify-cards {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+.verify-cards__header {
+	font-size: 12px;
+	font-weight: 500;
+	margin-bottom: 2px;
+}
+.verify-cards__header-status--pass { color: oklch(0.72 0.15 145); }
+.verify-cards__header-status--fail { color: var(--destructive); }
+.verify-cards__header-status--running { color: var(--muted-foreground); }
+
+.verify-card {
+	border: 1px solid var(--border);
+	border-radius: 6px;
+	font-size: 12px;
+	overflow: hidden;
+}
+.verify-card--running { border-color: oklch(0.62 0.15 250 / 0.3); }
+.verify-card--pass { border-color: oklch(0.65 0.15 145 / 0.3); background: oklch(0.65 0.15 145 / 0.03); }
+.verify-card--fail { border-color: color-mix(in oklch, var(--destructive) 30%, transparent); background: color-mix(in oklch, var(--destructive) 3%, transparent); }
+
+.verify-card__header {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 6px 8px;
+}
+.verify-card__header--clickable { cursor: pointer; }
+.verify-card__header--clickable:hover { background: var(--accent); }
+
+.verify-card__icon {
+	font-weight: 700;
+	width: 14px;
+	text-align: center;
+	flex-shrink: 0;
+}
+.verify-card__icon--running { color: oklch(0.62 0.15 250); animation: pulse-verify 1.5s ease-in-out infinite; }
+.verify-card__icon--pass { color: oklch(0.72 0.15 145); }
+.verify-card__icon--fail { color: var(--destructive); }
+
+@keyframes pulse-verify {
+	0%, 100% { opacity: 1; }
+	50% { opacity: 0.4; }
+}
+
+.verify-card__name {
+	font-weight: 500;
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.verify-card__type-badge {
+	font-size: 10px;
+	padding: 1px 5px;
+	border-radius: 3px;
+	background: var(--secondary);
+	color: var(--text-tertiary);
+	flex-shrink: 0;
+}
+.verify-card__type-badge--llm {
+	background: oklch(0.55 0.15 290 / 0.15);
+	color: oklch(0.72 0.15 290);
+}
+.verify-card__duration {
+	font-size: 10px;
+	color: var(--text-tertiary);
+	flex-shrink: 0;
+}
+.verify-card__expand {
+	font-size: 10px;
+	color: var(--muted-foreground);
+	flex-shrink: 0;
+}
+.verify-card__output {
+	background: rgba(0,0,0,0.3);
+	padding: 8px;
+	font-family: var(--font-mono, monospace);
+	font-size: 11px;
+	white-space: pre-wrap;
+	max-height: 300px;
+	overflow-y: auto;
+	border-top: 1px solid var(--border);
+	color: var(--muted-foreground);
+	word-break: break-word;
+	margin: 0;
+}
+
 /* ── Signal metadata ── */
 .signal-metadata {
 	display: flex;

--- a/src/app/goal-dashboard.ts
+++ b/src/app/goal-dashboard.ts
@@ -99,6 +99,7 @@ interface LiveVerification {
 }
 let liveVerifications: Map<string, LiveVerification> = new Map();
 let liveVerifTimer: ReturnType<typeof setInterval> | null = null;
+let expandedLiveStepKeys: Set<string> = new Set();
 
 /** Current dashboard tab */
 let dashboardTab: "spec" | "tasks" | "agents" | "commits" | "gates" = "gates";
@@ -204,6 +205,7 @@ export function clearDashboardState(): void {
 	stopGitStatusPolling();
 	document.removeEventListener("gate-verification-event", handleLiveVerificationEvent);
 	liveVerifications = new Map();
+	expandedLiveStepKeys = new Set();
 	stopLiveVerifTimer();
 }
 
@@ -1469,7 +1471,17 @@ function renderSignalEntry(signal: GateSignal): TemplateResult {
 			</div>
 			${isExpanded ? html`
 				<div class="signal-entry__body">
-					${isLive ? renderLiveVerificationSteps(liveEntry!) : html`
+					${isLive ? renderLiveVerificationSteps(liveEntry!) : vStatus === "running" && signal.verification.steps.length === 0
+						? html`<div class="verify-card verify-card--running" style="padding:8px 10px;">
+							<span class="verify-card__icon verify-card__icon--running">\u25CF</span>
+							<span>Verification in progress\u2026</span>
+						</div>`
+						: signal.verification.steps.length === 0 && vStatus === "passed"
+							? html`<div class="verify-card verify-card--pass" style="padding:8px 10px;">
+								<span class="verify-card__icon verify-card__icon--pass">\u2713</span>
+								<span>Passed (no verification)</span>
+							</div>`
+						: html`
 						${signal.verification.steps.map(step => html`
 							<div class="verify-step verify-step--${step.passed ? "pass" : "fail"}">
 								<div class="verify-step__header">
@@ -1499,28 +1511,92 @@ function renderSignalEntry(signal: GateSignal): TemplateResult {
 	`;
 }
 
-function renderLiveVerificationSteps(entry: LiveVerification): TemplateResult {
-	if (entry.steps.length === 0) {
-		return html`<div class="verify-step"><div class="verify-step__header"><span class="verify-step__icon">\u23F3</span><span class="verify-step__name">Verification in progress\u2026</span></div></div>`;
+function toggleLiveStepExpand(key: string): void {
+	if (expandedLiveStepKeys.has(key)) {
+		expandedLiveStepKeys.delete(key);
+	} else {
+		expandedLiveStepKeys.add(key);
 	}
-	return html`${entry.steps.map(step => {
-		const isRunning = step.status === "running";
-		const passed = step.status === "passed";
-		const elapsed = isRunning ? Math.max(0, Math.round((Date.now() - step.startedAt) / 1000)) : 0;
-		const elapsedStr = elapsed < 60 ? `${elapsed}s` : `${Math.floor(elapsed / 60)}m ${String(elapsed % 60).padStart(2, "0")}s`;
-		const durStr = step.durationMs != null ? (step.durationMs < 1000 ? `${Math.round(step.durationMs)}ms` : `${(step.durationMs / 1000).toFixed(1)}s`) : "";
-		return html`
-			<div class="verify-step verify-step--${isRunning ? "running" : passed ? "pass" : "fail"}">
-				<div class="verify-step__header">
-					<span class="verify-step__icon">${isRunning ? "\u23F3" : passed ? "\u2713" : "\u2717"}</span>
-					<span class="verify-step__name">${step.name}</span>
-					<span class="verify-step__type">${step.type}</span>
-					<span class="verify-step__duration">${isRunning ? elapsedStr : durStr}</span>
-				</div>
-				${step.output ? html`<div class="verify-step__output">${step.output}</div>` : nothing}
+	renderApp();
+}
+
+function formatStepElapsed(startedAt: number): string {
+	const s = Math.max(0, Math.round((Date.now() - startedAt) / 1000));
+	return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m ${String(s % 60).padStart(2, "0")}s`;
+}
+
+function formatStepDuration(ms: number): string {
+	if (ms < 1000) return `${Math.round(ms)}ms`;
+	if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+	const m = Math.floor(ms / 60000);
+	const s = Math.round((ms % 60000) / 1000);
+	return `${m}m ${s}s`;
+}
+
+function renderLiveVerificationSteps(entry: LiveVerification): TemplateResult {
+	// Auto-pass: complete with no steps
+	if (entry.steps.length === 0 && entry.overallStatus !== "running") {
+		const isPassed = entry.overallStatus === "passed";
+		return html`<div class="verify-card verify-card--${isPassed ? "pass" : "fail"}" style="padding:8px 10px;">
+			<span class="verify-card__icon verify-card__icon--${isPassed ? "pass" : "fail"}">${isPassed ? "\u2713" : "\u2717"}</span>
+			<span>${isPassed ? "Passed (no verification)" : "Failed"}</span>
+		</div>`;
+	}
+
+	// Still waiting for step definitions
+	if (entry.steps.length === 0) {
+		return html`<div class="verify-card verify-card--running" style="padding:8px 10px;">
+			<span class="verify-card__icon verify-card__icon--running">\u25CF</span>
+			<span>Verification in progress\u2026</span>
+		</div>`;
+	}
+
+	const passedCount = entry.steps.filter(s => s.status === "passed").length;
+	const failedCount = entry.steps.filter(s => s.status === "failed").length;
+	const totalCount = entry.steps.length;
+	const isDone = entry.overallStatus !== "running";
+
+	return html`
+		<div class="verify-cards">
+			<div class="verify-cards__header">
+				${isDone
+					? entry.overallStatus === "passed"
+						? html`<span class="verify-cards__header-status verify-cards__header-status--pass">\u2713 Verified \u2014 passed</span>`
+						: html`<span class="verify-cards__header-status verify-cards__header-status--fail">\u2717 Verified \u2014 failed</span>`
+					: html`<span class="verify-cards__header-status verify-cards__header-status--running">Verifying \u2014 ${passedCount}/${totalCount} checks passed${failedCount > 0 ? html`, <span style="color:var(--destructive)">${failedCount} failed</span>` : nothing}</span>`
+				}
 			</div>
-		`;
-	})}`;
+			${entry.steps.map((step, i) => {
+				const stepKey = `${entry.gateId}:${entry.signalId}:${i}`;
+				const isRunning = step.status === "running";
+				const isPassed = step.status === "passed";
+				const isFailed = step.status === "failed";
+				const hasOutput = !!step.output;
+				const isExpanded = expandedLiveStepKeys.has(stepKey);
+				const isLlm = step.type === "llm-review";
+
+				return html`
+					<div class="verify-card verify-card--${isRunning ? "running" : isPassed ? "pass" : "fail"}">
+						<div class="verify-card__header ${hasOutput ? "verify-card__header--clickable" : ""}"
+							@click=${hasOutput ? () => toggleLiveStepExpand(stepKey) : null}>
+							<span class="verify-card__icon verify-card__icon--${isRunning ? "running" : isPassed ? "pass" : "fail"}">
+								${isRunning ? "\u25CF" : isPassed ? "\u2713" : "\u2717"}
+							</span>
+							<span class="verify-card__name">${step.name}</span>
+							<span class="verify-card__type-badge ${isLlm ? "verify-card__type-badge--llm" : ""}">${step.type}</span>
+							<span class="verify-card__duration">
+								${isRunning ? formatStepElapsed(step.startedAt) : step.durationMs != null ? formatStepDuration(step.durationMs) : ""}
+							</span>
+							${hasOutput ? html`<span class="verify-card__expand">${isExpanded ? "\u25B4" : "\u25BE"}</span>` : nothing}
+						</div>
+						${isExpanded && step.output ? html`
+							<pre class="verify-card__output">${step.output}</pre>
+						` : nothing}
+					</div>
+				`;
+			})}
+		</div>
+	`;
 }
 
 // ============================================================================

--- a/src/app/goal-dashboard.ts
+++ b/src/app/goal-dashboard.ts
@@ -171,6 +171,9 @@ export async function loadDashboardData(goalId: string): Promise<void> {
 		startCostPolling(goalId);
 		startGitStatusPolling(goalId);
 
+		// Bootstrap live verification state from REST (catches in-progress verifications)
+		fetchActiveVerifications(goalId);
+
 		loading = false;
 	} catch (err) {
 		error = err instanceof Error ? err.message : String(err);
@@ -178,6 +181,45 @@ export async function loadDashboardData(goalId: string): Promise<void> {
 	}
 
 	renderApp();
+}
+
+async function fetchActiveVerifications(goalId: string): Promise<void> {
+	try {
+		const resp = await gatewayFetch(`/api/goals/${goalId}/verifications/active`);
+		if (!resp.ok) return;
+		const data = await resp.json();
+		const verifications: Array<any> = data.verifications || [];
+
+		for (const v of verifications) {
+			const key = `${v.gateId}:${v.signalId}`;
+			// Only seed if we don't already have a live entry (WS events take priority)
+			if (!liveVerifications.has(key)) {
+				liveVerifications.set(key, {
+					gateId: v.gateId,
+					signalId: v.signalId,
+					steps: v.steps.map((s: any) => ({
+						name: s.name,
+						type: s.type,
+						status: s.status,
+						durationMs: s.durationMs,
+						output: s.output,
+						startedAt: s.startedAt,
+					})),
+					overallStatus: v.overallStatus,
+				});
+			}
+		}
+
+		// Start timer if we have running verifications
+		if (verifications.some((v: any) => v.overallStatus === "running")) {
+			startLiveVerifTimer();
+		}
+
+		renderApp();
+	} catch (err) {
+		// Non-fatal — WS events will still work
+		console.warn("[dashboard] Failed to fetch active verifications:", err);
+	}
 }
 
 export function clearDashboardState(): void {
@@ -302,6 +344,8 @@ function startGatePolling(goalId: string): void {
 				gates = newGates;
 				renderApp();
 			}
+			// Also refresh active verifications alongside gate polling
+			fetchActiveVerifications(goalId);
 		} catch { /* ignore */ }
 	}, 8_000);
 }
@@ -329,16 +373,25 @@ function handleLiveVerificationEvent(e: Event) {
 			break;
 		}
 		case "gate_verification_step_complete": {
-			const entry = liveVerifications.get(key);
-			if (entry && entry.steps[detail.stepIndex]) {
-				entry.steps[detail.stepIndex] = {
-					...entry.steps[detail.stepIndex],
-					status: detail.status,
-					durationMs: detail.durationMs,
-					output: detail.output,
-				};
-				renderApp();
+			let entry = liveVerifications.get(key);
+			if (!entry) {
+				// Create entry dynamically — we missed the started event
+				entry = { gateId: detail.gateId, signalId: detail.signalId, steps: [], overallStatus: "running" };
+				liveVerifications.set(key, entry);
+				startLiveVerifTimer();
 			}
+			// Expand steps array if stepIndex is beyond current length
+			while (entry.steps.length <= detail.stepIndex) {
+				entry.steps.push({ name: `Step ${entry.steps.length + 1}`, type: "unknown", status: "running", startedAt: Date.now() });
+			}
+			entry.steps[detail.stepIndex] = {
+				...entry.steps[detail.stepIndex],
+				name: detail.stepName || entry.steps[detail.stepIndex].name,
+				status: detail.status,
+				durationMs: detail.durationMs,
+				output: detail.output,
+			};
+			renderApp();
 			break;
 		}
 		case "gate_verification_complete": {

--- a/src/server/agent/verification-harness.ts
+++ b/src/server/agent/verification-harness.ts
@@ -44,8 +44,25 @@ export function parseVerdict(output: string): boolean | null {
 	return match[1].toLowerCase() === "pass";
 }
 
+/** In-flight verification state for REST bootstrapping */
+export interface ActiveVerification {
+	goalId: string;
+	gateId: string;
+	signalId: string;
+	steps: Array<{ name: string; type: string; status: "running" | "passed" | "failed"; durationMs?: number; output?: string; startedAt: number }>;
+	overallStatus: "running" | "passed" | "failed";
+	startedAt: number;
+}
+
 export class VerificationHarness {
 	private notifyTeamLeadFn?: (goalId: string, message: string) => void;
+	private activeVerifications = new Map<string, ActiveVerification>();
+
+	/** Get all active (in-flight) verifications, optionally filtered by goalId */
+	getActiveVerifications(goalId?: string): ActiveVerification[] {
+		const all = [...this.activeVerifications.values()];
+		return goalId ? all.filter(v => v.goalId === goalId) : all;
+	}
 
 	constructor(
 		private gateStore: GateStore,
@@ -109,6 +126,17 @@ export class VerificationHarness {
 			steps: steps.map(s => ({ name: s.name, type: s.type })),
 		});
 
+		// Track active verification for REST bootstrapping
+		const active: ActiveVerification = {
+			goalId: signal.goalId,
+			gateId: signal.gateId,
+			signalId: signal.id,
+			steps: steps.map(s => ({ name: s.name, type: s.type, status: "running" as const, startedAt: Date.now() })),
+			overallStatus: "running",
+			startedAt: Date.now(),
+		};
+		this.activeVerifications.set(signal.id, active);
+
 		try {
 			const builtinVars: Record<string, string> = {
 				branch: goalBranch || "HEAD",
@@ -163,6 +191,10 @@ export class VerificationHarness {
 							durationMs: cachedResult.duration_ms || 0,
 							output: cachedResult.output,
 						});
+						const av = this.activeVerifications.get(signal.id);
+						if (av && av.steps[index]) {
+							av.steps[index] = { ...av.steps[index], status: cachedResult.passed ? "passed" : "failed", durationMs: cachedResult.duration_ms || 0, output: cachedResult.output };
+						}
 						return { index, stepResult: cachedResult };
 					}
 
@@ -210,6 +242,10 @@ export class VerificationHarness {
 						durationMs: duration_ms,
 						output: result.output || "",
 					});
+					const av = this.activeVerifications.get(signal.id);
+					if (av && av.steps[index]) {
+						av.steps[index] = { ...av.steps[index], status: result.passed ? "passed" : "failed", durationMs: duration_ms, output: result.output || "" };
+					}
 					return {
 						index,
 						stepResult: {
@@ -234,6 +270,7 @@ export class VerificationHarness {
 
 			this.gateStore.updateSignalVerification(signal.id, { status, steps: results });
 			this.gateStore.updateGateStatus(signal.goalId, signal.gateId, status);
+			this.activeVerifications.delete(signal.id);
 
 			this.broadcastFn(signal.goalId, {
 				type: "gate_verification_complete",
@@ -255,6 +292,7 @@ export class VerificationHarness {
 				steps: [{ name: "Error", type: "command", passed: false, output: err.message, duration_ms: 0 }],
 			});
 			this.gateStore.updateGateStatus(signal.goalId, signal.gateId, "failed");
+			this.activeVerifications.delete(signal.id);
 
 			this.broadcastFn(signal.goalId, {
 				type: "gate_verification_complete",

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1120,6 +1120,15 @@ async function handleApiRoute(
 		return;
 	}
 
+	// GET /api/goals/:goalId/verifications/active — get in-flight verification state
+	const activeVerifMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/verifications\/active$/);
+	if (activeVerifMatch && req.method === "GET") {
+		const [, goalId] = activeVerifMatch;
+		const active = verificationHarness.getActiveVerifications(goalId);
+		json({ verifications: active });
+		return;
+	}
+
 	// GET /api/goals/:goalId/gates/:gateId/content — gate content
 	const gateContentMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/gates\/([^/]+)\/content$/);
 	if (gateContentMatch && req.method === "GET") {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1105,7 +1105,8 @@ async function handleApiRoute(
 			signal, gateDef, goal.cwd, goal.branch, "master", allGateStates, goal.spec,
 		).catch(err => console.error("[verification] Gate signal error:", err));
 
-		json({ signal: { id: signal.id, gateId, status: "running" } }, 201);
+		const verifySteps = (gateDef.verify || []).map((s: any) => ({ name: s.name, type: s.type }));
+		json({ signal: { id: signal.id, gateId, goalId, status: "running", steps: verifySteps } }, 201);
 		return;
 	}
 

--- a/src/ui/tools/renderers/GateToolRenderers.ts
+++ b/src/ui/tools/renderers/GateToolRenderers.ts
@@ -142,6 +142,7 @@ export class GateSignalRenderer implements ToolRenderer {
 		}
 
 		// Running — show live verification component
+		const steps = data?.signal?.steps || [];
 		return {
 			content: html`<div>
 				${renderHeader(state, ShieldCheck, html`Signaled <span class="font-mono text-xs">${gateId}</span>`)}
@@ -149,6 +150,7 @@ export class GateSignalRenderer implements ToolRenderer {
 					.goalId=${goalId2}
 					.gateId=${gateId}
 					.signalId=${signalId}
+					.initialSteps=${steps}
 				></gate-verification-live>
 			</div>`,
 			isCustom: false,

--- a/src/ui/tools/renderers/GateVerificationLive.ts
+++ b/src/ui/tools/renderers/GateVerificationLive.ts
@@ -2,11 +2,19 @@
  * <gate-verification-live> — Lit element that subscribes to gate-verification-event
  * CustomEvents on document and renders live step cards with timers.
  *
+ * Uses the shared delegate-cards.ts components to match the delegate UX pattern.
  * Used by GateSignalRenderer (chat) and could be embedded in the dashboard.
  */
 import { LitElement, html, nothing, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import "../../components/LiveTimer.js";
+import {
+	type DelegateCardEntry,
+	statusColor,
+	statusIcon,
+	formatDuration,
+	renderDuration,
+} from "./delegate-cards.js";
 
 interface VerificationStep {
 	name: string;
@@ -15,6 +23,28 @@ interface VerificationStep {
 	durationMs?: number;
 	output?: string;
 	startedAt: number;
+}
+
+/** Map verification step status to delegate-cards status strings */
+function toDelegateStatus(status: "running" | "passed" | "failed"): string {
+	if (status === "passed") return "completed";
+	if (status === "failed") return "error";
+	return "running";
+}
+
+/** Build a DelegateCardEntry-compatible object for renderDuration() */
+function toCardEntry(step: VerificationStep, index: number): DelegateCardEntry {
+	const delegateStatus = toDelegateStatus(step.status);
+	// For running steps, compute durationMs from startedAt so <live-timer> works
+	const durationMs = step.status === "running"
+		? Date.now() - step.startedAt
+		: (step.durationMs ?? 0);
+	return {
+		id: `step-${index}`,
+		name: step.name || "step",
+		status: delegateStatus,
+		durationMs,
+	};
 }
 
 @customElement("gate-verification-live")
@@ -29,7 +59,6 @@ export class GateVerificationLive extends LitElement {
 	@state() private overallStatus: "idle" | "running" | "passed" | "failed" = "idle";
 	@state() private expandedSteps = new Set<number>();
 
-	private _timerInterval: ReturnType<typeof setInterval> | null = null;
 	private _boundOnEvent = this._onEvent.bind(this);
 
 	override createRenderRoot() { return this; }
@@ -42,19 +71,6 @@ export class GateVerificationLive extends LitElement {
 	override disconnectedCallback() {
 		super.disconnectedCallback();
 		document.removeEventListener("gate-verification-event", this._boundOnEvent);
-		this._stopTimer();
-	}
-
-	private _startTimer() {
-		if (this._timerInterval) return;
-		this._timerInterval = setInterval(() => this.requestUpdate(), 1000);
-	}
-
-	private _stopTimer() {
-		if (this._timerInterval) {
-			clearInterval(this._timerInterval);
-			this._timerInterval = null;
-		}
 	}
 
 	private _onEvent(e: Event) {
@@ -74,7 +90,6 @@ export class GateVerificationLive extends LitElement {
 					startedAt: Date.now(),
 				}));
 				this.overallStatus = "running";
-				this._startTimer();
 				break;
 			}
 			case "gate_verification_step_complete": {
@@ -108,7 +123,6 @@ export class GateVerificationLive extends LitElement {
 			}
 			case "gate_verification_complete": {
 				this.overallStatus = detail.status || "passed";
-				this._stopTimer();
 				this.requestUpdate();
 				break;
 			}
@@ -121,36 +135,22 @@ export class GateVerificationLive extends LitElement {
 		this.expandedSteps = next;
 	}
 
-	private _formatElapsed(startedAt: number): string {
-		const s = Math.max(0, Math.round((Date.now() - startedAt) / 1000));
-		return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m ${String(s % 60).padStart(2, "0")}s`;
-	}
-
-	private _formatDuration(ms: number): string {
-		if (ms < 1000) return `${Math.round(ms)}ms`;
-		if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
-		const m = Math.floor(ms / 60000);
-		const s = Math.round((ms % 60000) / 1000);
-		return `${m}m ${s}s`;
-	}
-
 	override render() {
 		// No events yet — show placeholder based on finalStatus or idle state
 		if (this.overallStatus === "idle" && this.steps.length === 0) {
 			if (this.finalStatus === "passed") {
-				return html`<div class="mt-2 text-xs text-green-600 dark:text-green-400">✓ Passed (no verification steps)</div>`;
+				return html`<div class="mt-2 text-xs ${statusColor("completed")}">${statusIcon("completed")} Passed (no verification)</div>`;
 			}
 			if (this.finalStatus === "failed") {
-				return html`<div class="mt-2 text-xs text-red-600 dark:text-red-400">✗ Failed</div>`;
+				return html`<div class="mt-2 text-xs ${statusColor("error")}">${statusIcon("error")} Failed</div>`;
 			}
-			return html`<div class="mt-2 text-xs text-muted-foreground animate-pulse">Verification in progress…</div>`;
+			return html`<div class="mt-2 text-xs ${statusColor("running")}">Verification in progress…</div>`;
 		}
 
 		// Auto-pass: complete arrived with no steps
 		if (this.steps.length === 0 && this.overallStatus !== "running") {
-			const color = this.overallStatus === "passed" ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400";
-			const icon = this.overallStatus === "passed" ? "✓" : "✗";
-			return html`<div class="mt-2 text-xs ${color}">${icon} ${this.overallStatus === "passed" ? "Passed (no verification steps)" : "Failed"}</div>`;
+			const dStatus = toDelegateStatus(this.overallStatus as "passed" | "failed");
+			return html`<div class="mt-2 text-xs ${statusColor(dStatus)}">${statusIcon(dStatus)} ${this.overallStatus === "passed" ? "Passed (no verification)" : "Failed"}</div>`;
 		}
 
 		const passedCount = this.steps.filter(s => s.status === "passed").length;
@@ -167,43 +167,26 @@ export class GateVerificationLive extends LitElement {
 
 	private _renderHeader(passed: number, failed: number, total: number): TemplateResult {
 		if (this.overallStatus === "passed") {
-			return html`<div class="text-xs font-medium text-green-600 dark:text-green-400 mb-1">✓ Verified <code class="text-[10px]">${this.gateId}</code> — passed</div>`;
+			return html`<div class="text-xs font-medium ${statusColor("completed")} mb-1">${statusIcon("completed")} Verified <code class="text-[10px]">${this.gateId}</code> — <span class="text-green-500">${passed}/${total} passed</span></div>`;
 		}
 		if (this.overallStatus === "failed") {
-			return html`<div class="text-xs font-medium text-red-600 dark:text-red-400 mb-1">✗ Verified <code class="text-[10px]">${this.gateId}</code> — failed</div>`;
+			return html`<div class="text-xs font-medium ${statusColor("error")} mb-1">${statusIcon("error")} Verified <code class="text-[10px]">${this.gateId}</code> — <span class="text-green-500">${passed} passed</span>, <span class="text-red-500">${failed} failed</span></div>`;
 		}
-		return html`<div class="text-xs font-medium text-muted-foreground mb-1">Verifying <code class="text-[10px]">${this.gateId}</code> — ${passed}/${total} steps passed${failed > 0 ? html`, <span class="text-red-600 dark:text-red-400">${failed} failed</span>` : nothing}</div>`;
+		// Running
+		const completedCount = passed + failed;
+		return html`<div class="text-xs font-medium ${statusColor("running")} mb-1">Verifying <code class="text-[10px]">${this.gateId}</code> — <span class="text-xs">${completedCount}/${total} steps</span>${failed > 0 ? html` <span class="text-red-500">(${failed} failed)</span>` : nothing}</div>`;
 	}
 
 	private _renderStepCard(step: VerificationStep, index: number): TemplateResult {
 		const isExpanded = this.expandedSteps.has(index);
 		const hasOutput = !!step.output;
+		const dStatus = toDelegateStatus(step.status);
+		const entry = toCardEntry(step, index);
 
-		// Status icon and color
-		let iconStr: string;
-		let iconCls: string;
-		if (step.status === "running") {
-			iconStr = "●";
-			iconCls = "text-blue-500 animate-pulse";
-		} else if (step.status === "passed") {
-			iconStr = "✓";
-			iconCls = "text-green-600 dark:text-green-400";
-		} else {
-			iconStr = "✗";
-			iconCls = "text-red-600 dark:text-red-400";
-		}
-
-		// Type badge
+		// Type badge (verification-specific, not in delegate-cards)
 		const typeBadgeCls = step.type === "command"
 			? "bg-muted text-muted-foreground"
 			: "bg-purple-500/20 text-purple-600 dark:text-purple-400";
-
-		// Duration or live timer
-		const durationPart = step.status === "running"
-			? html`<span class="text-xs text-muted-foreground">${this._formatElapsed(step.startedAt)}</span>`
-			: step.durationMs != null
-				? html`<span class="text-xs text-muted-foreground">${this._formatDuration(step.durationMs)}</span>`
-				: nothing;
 
 		return html`
 			<div class="border border-border rounded text-sm">
@@ -211,10 +194,10 @@ export class GateVerificationLive extends LitElement {
 					class="p-2 flex items-center gap-2 ${hasOutput ? "cursor-pointer hover:bg-accent/50" : ""}"
 					@click=${hasOutput ? () => this._toggleStep(index) : null}
 				>
-					<span class="${iconCls} font-bold shrink-0">${iconStr}</span>
-					<span class="truncate flex-1 text-xs">${step.name || "step"}</span>
+					<span class="${statusColor(dStatus)}">${statusIcon(dStatus)}</span>
+					<span class="font-mono text-xs flex-1 min-w-0 truncate">${step.name || "step"}</span>
 					<span class="px-1.5 py-0.5 rounded text-[10px] font-medium ${typeBadgeCls}">${step.type}</span>
-					${durationPart}
+					${renderDuration(entry)}
 					${hasOutput ? html`<span class="text-muted-foreground text-[10px] shrink-0">${isExpanded ? "▴" : "▾"}</span>` : nothing}
 				</div>
 				${isExpanded && step.output ? html`

--- a/src/ui/tools/renderers/GateVerificationLive.ts
+++ b/src/ui/tools/renderers/GateVerificationLive.ts
@@ -5,7 +5,7 @@
  * Uses the shared delegate-cards.ts components to match the delegate UX pattern.
  * Used by GateSignalRenderer (chat) and could be embedded in the dashboard.
  */
-import { LitElement, html, nothing, type TemplateResult } from "lit";
+import { LitElement, html, nothing, type TemplateResult, type PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import "../../components/LiveTimer.js";
 import {
@@ -54,6 +54,8 @@ export class GateVerificationLive extends LitElement {
 	@property() signalId = "";
 	/** If set, used to show static final state when no events arrive (e.g. chat history). */
 	@property() finalStatus: string | undefined;
+	/** Step definitions from signal response — used to seed placeholder cards before WS events arrive. */
+	@property({ type: Array }) initialSteps: Array<{ name: string; type: string }> = [];
 
 	@state() private steps: VerificationStep[] = [];
 	@state() private overallStatus: "idle" | "running" | "passed" | "failed" = "idle";
@@ -62,6 +64,19 @@ export class GateVerificationLive extends LitElement {
 	private _boundOnEvent = this._onEvent.bind(this);
 
 	override createRenderRoot() { return this; }
+
+	override willUpdate(_changed: PropertyValues) {
+		// Seed steps from initialSteps once, before the gate_verification_started WS event arrives
+		if (this.overallStatus === "idle" && this.steps.length === 0 && this.initialSteps.length > 0) {
+			this.steps = this.initialSteps.map(s => ({
+				name: s.name,
+				type: s.type,
+				status: "running" as const,
+				startedAt: Date.now(),
+			}));
+			this.overallStatus = "running";
+		}
+	}
 
 	override connectedCallback() {
 		super.connectedCallback();


### PR DESCRIPTION
## Summary

Follow-up to PR #28. Addresses gaps in the streaming verification UI:

### Changes

**Server: active verification tracking + REST endpoint**
- `VerificationHarness` now tracks in-flight verifications in an in-memory map
- New endpoint: `GET /api/goals/:goalId/verifications/active` returns current verification state (steps with status, duration, output)
- Entries are created on verification start, updated per step, cleaned up on completion
- Architecture: REST for bootstrap, WS events for live updates

**Signal response: include step definitions**
- `POST /api/goals/:goalId/gates/:gateId/signal` now returns `steps` (name + type) and `goalId` in the response
- Chat renderer seeds placeholder cards immediately via `initialSteps` property on `<gate-verification-live>`
- Uses Lit `willUpdate()` lifecycle to seed steps without mutating state in render

**Dashboard: bootstrap from REST**
- Calls `/verifications/active` on dashboard load and during gate polling
- Seeds `liveVerifications` map so step cards render immediately (even if WS events were missed)
- Handles late-arriving `gate_verification_step_complete` events gracefully (auto-creates entries, expands step arrays)

### Files changed (5)
- `src/server/agent/verification-harness.ts` — ActiveVerification tracking
- `src/server/server.ts` — REST endpoint + signal response enhancement  
- `src/ui/tools/renderers/GateVerificationLive.ts` — initialSteps + willUpdate seeding
- `src/ui/tools/renderers/GateToolRenderers.ts` — pass initialSteps to component
- `src/app/goal-dashboard.ts` — REST bootstrap + resilient event handling

### Testing
- `npm run check` passes
- 183/183 unit tests pass