### PR TITLE
feat: Visible Verification Reviews

### DIFF
--- a/.bobbit/config/roles/team-lead.yaml
+++ b/.bobbit/config/roles/team-lead.yaml
@@ -203,6 +203,14 @@ promptTemplate: |+
   6. **Cleanup** — Dismiss idle agents with `team_dismiss`.
   7. **Done** — All tasks complete, all gates passed → call `team_complete`.
 
+  ## Consuming Agent Results
+  When a reviewer or tester finishes, you are notified with a summary. To get the full results:
+  1. **Task result summaries** — call `task_list` to see `result_summary` on completed tasks. This gives you a quick overview (e.g. "2 high, 1 medium issues found" or "All 12 tests pass").
+  2. **Gate content** — call `gate_status(gate_id="...")` to read the full content the agent signaled (review findings, test commands, etc.). This is where the detailed findings live.
+  3. **Act on findings** — if a reviewer found issues, spawn a coder to fix them. If tests failed, create a fix task. If everything passed, proceed to the next workflow gate.
+
+  This is how results flow: agents write to tasks (`task_update`) and gates (`gate_signal`) → you read from tasks (`task_list`) and gates (`gate_status`). You do NOT need to read agent session logs or parse their chat output.
+
   ## Handling Merge Conflicts
 
   ### Resolution Strategy

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -638,6 +638,11 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			state.chatPanel.agentInterface.readOnly = true;
 		}
 
+		// Disable input for non-interactive sessions (e.g. verification reviewers)
+		if (state.chatPanel.agentInterface && sessionData?.nonInteractive) {
+			state.chatPanel.agentInterface.readOnly = true;
+		}
+
 		// Set up bg process kill/dismiss handlers
 		if (state.chatPanel.agentInterface) {
 			state.chatPanel.agentInterface.onBgProcessKill = (processId: string) => {

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -41,6 +41,8 @@ export interface GatewaySession {
 	staffAssistant?: boolean;
 	/** Whether this session has a live HTML preview panel */
 	preview?: boolean;
+	/** Whether this is an automated non-interactive session (e.g. verification reviewer) */
+	nonInteractive?: boolean;
 	/** Personality names assigned to this session */
 	personalities?: string[];
 }

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -62,6 +62,8 @@ export interface SessionInfo {
 	staffId?: string;
 	/** Pixel-art accessory ID for the Bobbit sprite overlay */
 	accessory?: string;
+	/** Whether this is an automated non-interactive session (e.g. verification reviewer) */
+	nonInteractive?: boolean;
 	/** Personality names */
 	personalities?: string[];
 	/** Allowed tools for this session */
@@ -1069,6 +1071,7 @@ export class SessionManager {
 			taskId: session.taskId,
 			staffId: session.staffId,
 			accessory: session.accessory,
+			nonInteractive: session.nonInteractive,
 			preview: session.preview,
 			personalities: session.personalities,
 		});
@@ -1099,6 +1102,7 @@ export class SessionManager {
 		taskId?: string;
 		staffId?: string;
 		accessory?: string;
+		nonInteractive?: boolean;
 		preview?: boolean;
 		personalities?: string[];
 	}> {
@@ -1124,6 +1128,7 @@ export class SessionManager {
 			taskId: s.taskId,
 			staffId: s.staffId,
 			accessory: s.accessory,
+			nonInteractive: s.nonInteractive,
 			preview: s.preview,
 			personalities: s.personalities,
 		}));
@@ -1155,13 +1160,14 @@ export class SessionManager {
 	}
 
 	/** Update session metadata fields (role, teamGoalId, worktreePath, accessory) and persist. */
-	updateSessionMeta(id: string, updates: { role?: string; teamGoalId?: string; worktreePath?: string; accessory?: string }): boolean {
+	updateSessionMeta(id: string, updates: { role?: string; teamGoalId?: string; worktreePath?: string; accessory?: string; nonInteractive?: boolean }): boolean {
 		const session = this.sessions.get(id);
 		if (!session) return false;
 		if (updates.role !== undefined) session.role = updates.role;
 		if (updates.teamGoalId !== undefined) session.teamGoalId = updates.teamGoalId;
 		if (updates.worktreePath !== undefined) session.worktreePath = updates.worktreePath;
 		if (updates.accessory !== undefined) session.accessory = updates.accessory;
+		if (updates.nonInteractive !== undefined) session.nonInteractive = updates.nonInteractive;
 		this.store.update(id, updates);
 		return true;
 	}

--- a/src/server/agent/session-store.ts
+++ b/src/server/agent/session-store.ts
@@ -53,6 +53,8 @@ export interface PersistedSession {
 	archived?: boolean;
 	/** Epoch ms when this session was archived */
 	archivedAt?: number;
+	/** Whether this is an automated non-interactive session (e.g. verification reviewer) */
+	nonInteractive?: boolean;
 	/** Repository path (preserved from goal for worktree cleanup) */
 	repoPath?: string;
 	/** Branch name (preserved for worktree cleanup) */
@@ -144,7 +146,7 @@ export class SessionStore {
 	}
 
 	/** Update a subset of fields for an existing session */
-	update(id: string, updates: Partial<Pick<PersistedSession, "title" | "lastActivity" | "agentSessionFile" | "goalId" | "wasStreaming" | "streamingStartedAt" | "delegateOf" | "role" | "teamGoalId" | "worktreePath" | "assistantType" | "goalAssistant" | "roleAssistant" | "toolAssistant" | "taskId" | "staffId" | "accessory" | "preview" | "personalities" | "messageQueue" | "archived" | "archivedAt" | "repoPath" | "branch">>): void {
+	update(id: string, updates: Partial<Pick<PersistedSession, "title" | "lastActivity" | "agentSessionFile" | "goalId" | "wasStreaming" | "streamingStartedAt" | "delegateOf" | "role" | "teamGoalId" | "worktreePath" | "assistantType" | "goalAssistant" | "roleAssistant" | "toolAssistant" | "taskId" | "staffId" | "accessory" | "preview" | "personalities" | "messageQueue" | "archived" | "archivedAt" | "repoPath" | "branch" | "nonInteractive">>): void {
 		const existing = this.sessions.get(id);
 		if (!existing) return;
 		Object.assign(existing, updates);

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -827,6 +827,47 @@ export class TeamManager {
 	}
 
 	/**
+	 * Register a verification reviewer session as a team agent without creating a worktree.
+	 * The verification harness manages the session lifecycle — no agent_end subscription is needed.
+	 * Silently returns if no team exists for the goal (handles manual gate signals).
+	 */
+	registerReviewerSession(goalId: string, sessionId: string, stepName: string): void {
+		const entry = this.teams.get(goalId);
+		if (!entry) return; // No active team — skip registration silently
+
+		const agent: TeamAgent = {
+			sessionId,
+			role: 'reviewer',
+			worktreePath: undefined,
+			branch: undefined,
+			task: `Verification review: ${stepName}`,
+			createdAt: Date.now(),
+		};
+		entry.agents.push(agent);
+		this.sessionToGoal.set(sessionId, goalId);
+		this.assignUniqueColor(sessionId);
+		this.persistEntry(goalId);
+	}
+
+	/**
+	 * Unregister a verification reviewer session from the team.
+	 * Called after the session is terminated so archiving happens first.
+	 */
+	unregisterReviewerSession(goalId: string, sessionId: string): void {
+		const entry = this.teams.get(goalId);
+		if (!entry) return;
+
+		const idx = entry.agents.findIndex(a => a.sessionId === sessionId);
+		if (idx !== -1) {
+			const agent = entry.agents[idx];
+			if (agent.unsubscribeEvent) agent.unsubscribeEvent();
+			entry.agents.splice(idx, 1);
+		}
+		this.sessionToGoal.delete(sessionId);
+		this.persistEntry(goalId);
+	}
+
+	/**
 	 * List all active agents for a goal.
 	 */
 	listAgents(goalId: string): TeamAgentInfo[] {

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -707,8 +707,12 @@ export class TeamManager {
 
 		let message: string;
 		if (tasks.length > 0) {
-			const taskSummaries = tasks.map(t => `"${t.title}" (state: ${t.state})`).join(", ");
-			message = `Agent ${agentId} (${role}) has finished. Tasks: ${taskSummaries}. Check tasks and decide next steps.`;
+			const taskSummaries = tasks.map(t => {
+				let s = `"${t.title}" (state: ${t.state})`;
+				if (t.resultSummary) s += ` — ${t.resultSummary}`;
+				return s;
+			}).join("; ");
+			message = `Agent ${agentId} (${role}) has finished. Tasks: ${taskSummaries}. Check task details and gate content (gate_status) for full results.`;
 		} else {
 			message = `Agent ${agentId} (${role}) has finished with no assigned tasks. Check tasks and decide next steps.`;
 		}
@@ -739,7 +743,7 @@ export class TeamManager {
 		const teamLeadSession = this.sessionManager.getSession(entry.teamLeadSessionId);
 		if (!teamLeadSession || teamLeadSession.status === "terminated") return;
 
-		const message = `Task "${taskTitle}" transitioned to ${taskState}. Check tasks and decide next steps.`;
+		const message = `Task "${taskTitle}" transitioned to ${taskState}. Use task_list for result summaries and gate_status to read any gate content the agent produced.`;
 
 		if (teamLeadSession.status === "streaming") {
 			teamLeadSession.rpcClient.steer(message).catch((err: any) => {

--- a/src/server/agent/verification-harness.ts
+++ b/src/server/agent/verification-harness.ts
@@ -69,6 +69,8 @@ export class VerificationHarness {
 		private broadcastFn: (goalId: string, event: any) => void,
 		private roleStore: RoleStore,
 		private preferencesStore?: PreferencesStore,
+		private sessionManager?: import("./session-manager.js").SessionManager,
+		private teamManager?: import("./team-manager.js").TeamManager,
 	) {}
 
 	/** Register a callback to notify the team lead agent when verification completes. */
@@ -222,6 +224,7 @@ export class VerificationHarness {
 									signal.metadata,
 									goalSpec,
 									allGateStates,
+									signal.goalId,
 								);
 								const isTransient = result.output.includes("timed out") || result.output.includes("no <verdict> tag");
 								if (result.passed || !isTransient || attempt === maxAttempts) break;
@@ -323,19 +326,75 @@ export class VerificationHarness {
 		signalMetadata?: Record<string, string>,
 		goalSpec?: string,
 		allGateStates?: Map<string, { metadata?: Record<string, string>; content?: string; status?: string; injectDownstream?: boolean }>,
+		goalId?: string,
 	): Promise<{ passed: boolean; output: string }> {
 		const role = this.roleStore.get("reviewer");
 		if (!role) {
 			return { passed: false, output: "LLM review failed: 'reviewer' role not found in role store." };
 		}
 
-		const subSessionId = `llm-review-${randomUUID().slice(0, 12)}`;
 		const timeoutMs = (step.timeout || 600) * 1000;
 
-		// Build system prompt from reviewer role template + step prompt + signal context
+		// Build the combined prompt sections (shared between session-based and direct-RpcBridge paths)
+		const combinedPrompt = this.buildReviewPrompt(role, step, cwd, builtinVars, signalContent, signalMetadata, goalSpec, allGateStates);
+
+		// Build the kickoff message (shared between both paths)
+		const kickoff = [
+			`Perform a code review for the gate verification step: "${step.name}".`,
+			"",
+			step.prompt || "",
+			"",
+			"## Required Output Format",
+			"",
+			"Produce your review, then end with a <verdict> tag. Example:",
+			"",
+			"```",
+			"## Summary",
+			"Brief overview of what was reviewed and the outcome.",
+			"",
+			"## Findings",
+			"[critical] file.ts:line — Description",
+			"[high] file.ts:line — Description",
+			"[medium] file.ts:line — Description",
+			"[low] file.ts:line — Description",
+			"",
+			"## Verdict",
+			"Explanation of pass/fail decision.",
+			"",
+			"<verdict>pass</verdict>",
+			"```",
+			"",
+			"## Rules",
+			"- **<verdict>fail</verdict>** if any critical or high severity findings exist",
+			"- **<verdict>pass</verdict>** if no critical or high severity findings",
+			"- **You MUST include exactly one `<verdict>pass</verdict>` or `<verdict>fail</verdict>` tag — if you omit it, the review fails automatically regardless of your findings**",
+		].join("\n");
+
+		// ── Session-based path (visible in UI) ──
+		if (this.sessionManager && goalId) {
+			return this.runLlmReviewViaSession(step, cwd, goalId, role, combinedPrompt, kickoff, timeoutMs);
+		}
+
+		// ── Legacy direct-RpcBridge path (fallback when SessionManager unavailable) ──
+		return this.runLlmReviewDirect(step, cwd, role, combinedPrompt, kickoff, timeoutMs);
+	}
+
+	/**
+	 * Build the combined system prompt for a review step.
+	 */
+	private buildReviewPrompt(
+		role: { promptTemplate: string; allowedTools: string[] },
+		step: { name: string; prompt?: string },
+		cwd: string,
+		builtinVars: Record<string, string>,
+		signalContent?: string,
+		signalMetadata?: Record<string, string>,
+		goalSpec?: string,
+		allGateStates?: Map<string, { metadata?: Record<string, string>; content?: string; status?: string; injectDownstream?: boolean }>,
+	): string {
 		let rolePrompt = role.promptTemplate
 			.replace(/\{\{GOAL_BRANCH\}\}/g, builtinVars.branch || "HEAD")
-			.replace(/\{\{AGENT_ID\}\}/g, subSessionId);
+			.replace(/\{\{AGENT_ID\}\}/g, "reviewer");
 
 		const sections: string[] = [rolePrompt];
 
@@ -343,7 +402,6 @@ export class VerificationHarness {
 			sections.push(`\n## Review Step Instructions\n\n${step.prompt}`);
 		}
 
-		// Reinforce verdict requirement in system prompt (LLMs prioritise system prompt over user messages)
 		sections.push([
 			"\n## CRITICAL: Verdict Tag Requirement",
 			"",
@@ -355,12 +413,10 @@ export class VerificationHarness {
 			"This is the single most important formatting requirement. Never omit it.",
 		].join("\n"));
 
-		// Goal specification context
 		if (goalSpec) {
 			sections.push(`\n## Goal Specification\n\n${goalSpec}`);
 		}
 
-		// Upstream gate content (from passed gates with injectDownstream)
 		if (allGateStates) {
 			const upstreamParts: string[] = [];
 			for (const [gateId, gs] of allGateStates) {
@@ -373,7 +429,6 @@ export class VerificationHarness {
 			}
 		}
 
-		// Signal context
 		const contextLines: string[] = [
 			"\n## Signal Context",
 			`- Branch: ${builtinVars.branch || "HEAD"}`,
@@ -391,7 +446,116 @@ export class VerificationHarness {
 		}
 		sections.push(contextLines.join("\n"));
 
-		const combinedPrompt = sections.join("\n");
+		return sections.join("\n");
+	}
+
+	/**
+	 * Run an LLM review step via SessionManager (visible in UI as a proper session).
+	 */
+	private async runLlmReviewViaSession(
+		step: { name: string; prompt?: string; timeout?: number },
+		cwd: string,
+		goalId: string,
+		role: { promptTemplate: string; allowedTools: string[]; accessory?: string },
+		combinedPrompt: string,
+		kickoff: string,
+		timeoutMs: number,
+	): Promise<{ passed: boolean; output: string }> {
+		let sessionId: string | undefined;
+		try {
+			// Create session via SessionManager — no worktree created (direct createSession, not spawnRole)
+			const session = await this.sessionManager!.createSession(cwd, undefined, goalId, undefined, {
+				rolePrompt: combinedPrompt,
+				allowedTools: role.allowedTools,
+			});
+			sessionId = session.id;
+
+			// Set title and metadata
+			this.sessionManager!.setTitle(sessionId, `Reviewer: ${step.name}`);
+			this.sessionManager!.updateSessionMeta(sessionId, {
+				role: "reviewer",
+				teamGoalId: goalId,
+				accessory: role.accessory || "magnifying-glass",
+				nonInteractive: true,
+			} as any); // cast to any — nonInteractive is being added by parallel coder
+
+			// Register in team store (if team manager available)
+			if (this.teamManager) {
+				try {
+					await (this.teamManager as any).registerReviewerSession(goalId, sessionId, step.name);
+				} catch (err) {
+					// Non-fatal — session still works even if team registration fails
+					console.warn(`[verification] Failed to register reviewer session in team:`, err);
+				}
+			}
+
+			// Override model if default.reviewModel preference is set
+			if (this.preferencesStore) {
+				const reviewModelPref = this.preferencesStore.get("default.reviewModel") as string | undefined;
+				if (reviewModelPref) {
+					const slash = reviewModelPref.indexOf("/");
+					if (slash > 0 && slash < reviewModelPref.length - 1) {
+						const provider = reviewModelPref.slice(0, slash);
+						const modelId = reviewModelPref.slice(slash + 1);
+						try {
+							await session.rpcClient.setModel(provider, modelId);
+							console.log(`[verification] Set review model "${reviewModelPref}" for ${sessionId}`);
+						} catch (err) {
+							console.warn(`[verification] Failed to set review model "${reviewModelPref}", using default:`, err);
+						}
+					} else {
+						console.warn(`[verification] Malformed default.reviewModel preference: "${reviewModelPref}", ignoring`);
+					}
+				}
+			}
+
+			// Send kickoff prompt and wait for idle
+			await session.rpcClient.prompt(kickoff);
+			await this.sessionManager!.waitForIdle(sessionId, timeoutMs);
+
+			// Get output from the session
+			const output = await this.sessionManager!.getSessionOutput(sessionId);
+
+			const verdict = parseVerdict(output);
+			if (verdict === null) {
+				return { passed: false, output: output || "LLM review failed: no <verdict> tag found in sub-agent output." };
+			}
+
+			return { passed: verdict, output };
+		} catch (err: any) {
+			const isTimeout = err.message?.includes("timed out") || err.message?.includes("Timeout");
+			const errOutput = isTimeout
+				? `LLM review timed out after ${(timeoutMs / 1000)}s.`
+				: `LLM review failed: ${err.message}`;
+			return { passed: false, output: errOutput };
+		} finally {
+			// Always terminate and unregister, even on error/timeout
+			if (sessionId) {
+				try {
+					await this.sessionManager!.terminateSession(sessionId);
+				} catch { /* ignore — session may already be terminated */ }
+				if (this.teamManager) {
+					try {
+						await (this.teamManager as any).unregisterReviewerSession(goalId, sessionId);
+					} catch { /* ignore */ }
+				}
+			}
+		}
+	}
+
+	/**
+	 * Legacy direct-RpcBridge path for LLM review (invisible to UI).
+	 * Used when SessionManager is not available.
+	 */
+	private async runLlmReviewDirect(
+		step: { name: string; prompt?: string; timeout?: number },
+		cwd: string,
+		role: { promptTemplate: string; allowedTools: string[] },
+		combinedPrompt: string,
+		kickoff: string,
+		timeoutMs: number,
+	): Promise<{ passed: boolean; output: string }> {
+		const subSessionId = `llm-review-${randomUUID().slice(0, 12)}`;
 
 		// Assemble system prompt to temp file
 		const systemPromptPath = assembleSystemPrompt(subSessionId, {
@@ -433,18 +597,14 @@ export class VerificationHarness {
 			}
 
 			// Collect assistant text from streaming events as a fallback
-			// in case getMessages() fails after agent_end (race with process exit).
 			let streamedAssistantText = "";
 
-			// Wait for agent_end event with timeout
 			const completionPromise = new Promise<void>((resolve, reject) => {
 				const timer = setTimeout(() => {
 					reject(new Error(`LLM review sub-agent timed out after ${timeoutMs / 1000}s`));
 				}, timeoutMs);
 
 				const eventUnsub = rpc.onEvent((event: any) => {
-					// Capture assistant text from message_end events as they arrive.
-					// This serves as a fallback if getMessages() fails after agent_end.
 					if (event.type === "message_end" && event.message?.role === "assistant") {
 						const msg = event.message;
 						if (Array.isArray(msg.content)) {
@@ -465,42 +625,9 @@ export class VerificationHarness {
 				});
 			});
 
-			// Send kickoff prompt
-			const kickoff = [
-				`Perform a code review for the gate verification step: "${step.name}".`,
-				"",
-				step.prompt || "",
-				"",
-				"## Required Output Format",
-				"",
-				"Produce your review, then end with a <verdict> tag. Example:",
-				"",
-				"```",
-				"## Summary",
-				"Brief overview of what was reviewed and the outcome.",
-				"",
-				"## Findings",
-				"[critical] file.ts:line — Description",
-				"[high] file.ts:line — Description",
-				"[medium] file.ts:line — Description",
-				"[low] file.ts:line — Description",
-				"",
-				"## Verdict",
-				"Explanation of pass/fail decision.",
-				"",
-				"<verdict>pass</verdict>",
-				"```",
-				"",
-				"## Rules",
-				"- **<verdict>fail</verdict>** if any critical or high severity findings exist",
-				"- **<verdict>pass</verdict>** if no critical or high severity findings",
-				"- **You MUST include exactly one `<verdict>pass</verdict>` or `<verdict>fail</verdict>` tag — if you omit it, the review fails automatically regardless of your findings**",
-			].join("\n");
-
 			await rpc.prompt(kickoff);
 			await completionPromise;
 
-			// Extract last assistant message — try getMessages() first, fall back to streamed text
 			let output = "";
 			try {
 				const msgsResp = await rpc.getMessages();
@@ -508,9 +635,8 @@ export class VerificationHarness {
 					output = extractLastAssistantOutput(msgsResp.data);
 				}
 			} catch {
-				// Non-fatal — we may still have partial output from streaming
+				// Non-fatal
 			}
-			// If getMessages() returned nothing (race with process exit), use streamed text
 			if (!output && streamedAssistantText) {
 				output = streamedAssistantText;
 			}
@@ -529,7 +655,6 @@ export class VerificationHarness {
 			return { passed: false, output: errOutput };
 		} finally {
 			await rpc.stop().catch(() => {});
-			// Clean up temporary system prompt
 			try {
 				const promptDir = path.join(bobbitStateDir(), "session-prompts");
 				const promptFile = path.join(promptDir, `${subSessionId}.md`);

--- a/src/server/agent/verification-harness.ts
+++ b/src/server/agent/verification-harness.ts
@@ -477,12 +477,12 @@ export class VerificationHarness {
 				teamGoalId: goalId,
 				accessory: role.accessory || "magnifying-glass",
 				nonInteractive: true,
-			} as any); // cast to any — nonInteractive is being added by parallel coder
+			});
 
 			// Register in team store (if team manager available)
 			if (this.teamManager) {
 				try {
-					await (this.teamManager as any).registerReviewerSession(goalId, sessionId, step.name);
+					await this.teamManager.registerReviewerSession(goalId, sessionId, step.name);
 				} catch (err) {
 					// Non-fatal — session still works even if team registration fails
 					console.warn(`[verification] Failed to register reviewer session in team:`, err);
@@ -536,7 +536,7 @@ export class VerificationHarness {
 				} catch { /* ignore — session may already be terminated */ }
 				if (this.teamManager) {
 					try {
-						await (this.teamManager as any).unregisterReviewerSession(goalId, sessionId);
+						await this.teamManager.unregisterReviewerSession(goalId, sessionId);
 					} catch { /* ignore */ }
 				}
 			}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1509,7 +1509,7 @@ async function handleApiRoute(
 			json({ error: "Session not found" }, 404);
 			return;
 		}
-		if ((session as any).nonInteractive) {
+		if (session.nonInteractive) {
 			json({ error: "Cannot steer a non-interactive (automated review) session" }, 400);
 			return;
 		}
@@ -1576,7 +1576,7 @@ async function handleApiRoute(
 			json({ error: "Session not found" }, 404);
 			return;
 		}
-		if ((session as any).nonInteractive) {
+		if (session.nonInteractive) {
 			json({ error: "Cannot prompt a non-interactive (automated review) session" }, 400);
 			return;
 		}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -235,7 +235,7 @@ export function createGateway(config: GatewayConfig) {
 		}
 	}
 	teamManager.setBroadcastToGoal(broadcastToGoal);
-	verificationHarness = new VerificationHarness(gateStore, broadcastToGoal, roleStore, preferencesStore);
+	verificationHarness = new VerificationHarness(gateStore, broadcastToGoal, roleStore, preferencesStore, sessionManager, teamManager);
 	verificationHarness.setTeamLeadNotifier((goalId, message) => {
 		const team = teamManager.getTeamState(goalId);
 		if (!team?.teamLeadSessionId) return;
@@ -1509,6 +1509,10 @@ async function handleApiRoute(
 			json({ error: "Session not found" }, 404);
 			return;
 		}
+		if ((session as any).nonInteractive) {
+			json({ error: "Cannot steer a non-interactive (automated review) session" }, 400);
+			return;
+		}
 		if (session.status !== "streaming") {
 			json({ error: "Agent is not currently streaming — use team/prompt instead" }, 409);
 			return;
@@ -1570,6 +1574,10 @@ async function handleApiRoute(
 		const session = sessionManager.getSession(body.sessionId);
 		if (!session) {
 			json({ error: "Session not found" }, 404);
+			return;
+		}
+		if ((session as any).nonInteractive) {
+			json({ error: "Cannot prompt a non-interactive (automated review) session" }, 400);
 			return;
 		}
 		// Enforce gate dependency check for team/prompt


### PR DESCRIPTION
## Summary

Make LLM review verification steps (gate verification `type: llm-review`) appear as visible team member sessions in the UI, so users can watch reviews happen in real-time and read back the reviewer's analysis.

## Changes

### Session metadata (`nonInteractive` flag)
- Added `nonInteractive?: boolean` to `PersistedSession` and `SessionInfo`
- Exposed in `listSessions()`, `updateSessionMeta()`, `persistSessionMetadata()`
- UI sets `readOnly = true` on `AgentInterface` for non-interactive sessions (hides prompt bar)

### Team registration without worktree
- Added `registerReviewerSession()` / `unregisterReviewerSession()` to `TeamManager`
- Registers reviewer sessions under the goal's team for sidebar grouping
- No worktree creation — reviewers are read-only

### Verification harness refactor
- Accepts `SessionManager` and `TeamManager` as optional constructor params
- New `runLlmReviewViaSession()` creates visible sessions with proper metadata
- Sessions get title `Reviewer: {step.name}`, role `reviewer`, magnifying-glass accessory
- Auto-terminates and archives on completion (7-day archive system)
- Legacy direct-RpcBridge path preserved as fallback
- `BOBBIT_LLM_REVIEW_SKIP` bypass still works

### Server wiring
- Wired `sessionManager` and `teamManager` to `VerificationHarness` constructor
- Added `nonInteractive` guard on `team_prompt`/`team_steer` endpoints

## Test Results
- Type check: PASS
- Unit tests: 183/183 passed
- E2E tests: 226/226 passed