### PR TITLE
feat: broadcast preview changes over WebSocket and patch model contex…

### DIFF
--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -100,6 +100,8 @@ export class RemoteAgent {
 	/** Callback fired when goal setup status changes (worktree ready or failed). */
 	onGoalSetupEvent?: () => void;
 	onBgProcessEvent?: (msg: { type: string; processId?: string; stream?: string; text?: string; ts?: number; exitCode?: number | null; process?: any }) => void;
+	/** Callback fired when preview panel flag changes for a session. */
+	onPreviewChanged?: (sessionId: string, preview: boolean) => void;
 	private _title = "New session";
 
 	constructor() {
@@ -670,6 +672,10 @@ export class RemoteAgent {
 
 			case "preferences_changed":
 				this._applyPreferences(msg.preferences);
+				break;
+
+			case "preview_changed":
+				this.onPreviewChanged?.(msg.sessionId, msg.preview);
 				break;
 
 			case "bg_process_created":

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -446,6 +446,15 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			}
 		};
 
+		remote.onPreviewChanged = (sid, preview) => {
+			if (sid === sessionId) {
+				state.isPreviewSession = preview;
+				if (preview) startPreviewPolling();
+				else stopPreviewPolling();
+				renderApp();
+			}
+		};
+
 		remote.onGoalProposal = (proposal) => {
 			state.activeGoalProposal = proposal;
 			if (state.assistantType === "goal") {

--- a/src/server/agent/aigw-manager.ts
+++ b/src/server/agent/aigw-manager.ts
@@ -123,7 +123,7 @@ const GATEWAY_COMPAT: Record<string, unknown> = {
 	maxTokensField: "max_tokens",
 };
 
-function inferMeta(modelId: string): ModelMeta {
+export function inferMeta(modelId: string): ModelMeta {
 	const id = modelId.toLowerCase();
 
 	// Anthropic models (via Bedrock or direct)

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1692,6 +1692,7 @@ async function handleApiRoute(
 			if (!session) { json({ error: "Session not found" }, 404); return; }
 			session.preview = body.preview;
 			sessionManager.persistSessionMetadata(session).catch(() => {});
+			broadcastToAll({ type: "preview_changed", sessionId: id, preview: body.preview });
 		}
 
 		// Track whether roleId handling already took care of personalities

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -8,6 +8,20 @@ import type { ClientMessage, ServerMessage } from "./protocol.js";
 import type { TaskState } from "../agent/task-store.js";
 import { getSkill } from "../skills/registry.js";
 import { runSkillAgent, createSkillRequest } from "../skills/sub-agent.js";
+import { inferMeta } from "../agent/aigw-manager.js";
+
+/**
+ * Patch model contextWindow in state data using our own inferMeta, which may
+ * be more up-to-date than the underlying agent's hardcoded model metadata.
+ */
+function patchModelContextWindow(data: any): void {
+	if (data?.model?.id) {
+		const meta = inferMeta(data.model.id);
+		if (meta.contextWindow > (data.model.contextWindow || 0)) {
+			data.model.contextWindow = meta.contextWindow;
+		}
+	}
+}
 
 function broadcast(clients: Set<WebSocket>, msg: ServerMessage): void {
 	const data = JSON.stringify(msg);
@@ -105,6 +119,7 @@ export function handleWebSocketConnection(
 			// so the client gets auth_ok immediately and can start rendering).
 			session.rpcClient.getState().then((stateResponse) => {
 				if (stateResponse.success) {
+					patchModelContextWindow(stateResponse.data);
 					send(ws, { type: "state", data: stateResponse.data });
 				}
 			}).catch(() => {
@@ -205,6 +220,7 @@ export function handleWebSocketConnection(
 				case "get_state": {
 					const stateResp = await session.rpcClient.getState();
 					if (stateResp.success) {
+						patchModelContextWindow(stateResp.data);
 						send(ws, { type: "state", data: stateResp.data });
 					}
 					break;

--- a/tests/e2e/preview-broadcast.spec.ts
+++ b/tests/e2e/preview-broadcast.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * E2E tests for preview_changed WebSocket broadcast.
+ *
+ * Verifies that when the preview flag is toggled via REST PATCH,
+ * a `preview_changed` message is broadcast to all connected WS clients.
+ */
+import { test, expect } from "@playwright/test";
+import {
+	apiFetch,
+	createSession,
+	deleteSession,
+	connectWs,
+	WsConnection,
+} from "./e2e-setup.js";
+
+let sessionId: string;
+let wsConn: WsConnection;
+
+test.beforeAll(async () => {
+	sessionId = await createSession();
+	wsConn = await connectWs(sessionId);
+});
+
+test.afterAll(async () => {
+	wsConn?.close();
+	await deleteSession(sessionId).catch(() => {});
+});
+
+test.describe("preview_changed WS broadcast", () => {
+	test("PATCH preview=true broadcasts preview_changed to WS clients", async () => {
+		const resp = await apiFetch(`/api/sessions/${sessionId}`, {
+			method: "PATCH",
+			body: JSON.stringify({ preview: true }),
+		});
+		expect(resp.status).toBe(200);
+
+		const msg = await wsConn.waitFor(
+			(m) => m.type === "preview_changed" && m.sessionId === sessionId,
+			5000,
+		);
+
+		expect(msg.type).toBe("preview_changed");
+		expect(msg.sessionId).toBe(sessionId);
+		expect(msg.preview).toBe(true);
+	});
+
+	test("PATCH preview=false broadcasts preview_changed with false", async () => {
+		const resp = await apiFetch(`/api/sessions/${sessionId}`, {
+			method: "PATCH",
+			body: JSON.stringify({ preview: false }),
+		});
+		expect(resp.status).toBe(200);
+
+		const msg = await wsConn.waitFor(
+			(m) => m.type === "preview_changed" && m.preview === false,
+			5000,
+		);
+
+		expect(msg.type).toBe("preview_changed");
+		expect(msg.sessionId).toBe(sessionId);
+		expect(msg.preview).toBe(false);
+	});
+
+	test("preview_changed is received by a second WS client", async () => {
+		const wsConn2 = await connectWs(sessionId);
+
+		try {
+			await apiFetch(`/api/sessions/${sessionId}`, {
+				method: "PATCH",
+				body: JSON.stringify({ preview: true }),
+			});
+
+			// Both clients should receive the broadcast
+			const [msg1, msg2] = await Promise.all([
+				wsConn.waitFor(
+					(m) => m.type === "preview_changed" && m.preview === true,
+					5000,
+				),
+				wsConn2.waitFor(
+					(m) => m.type === "preview_changed" && m.preview === true,
+					5000,
+				),
+			]);
+
+			expect(msg1.sessionId).toBe(sessionId);
+			expect(msg2.sessionId).toBe(sessionId);
+		} finally {
+			wsConn2.close();
+		}
+	});
+});


### PR DESCRIPTION
…t window

Broadcast a `preview_changed` WebSocket message to all clients when a session's preview flag is toggled via the REST API, so connected UIs react in real time. Also patch the model contextWindow in state responses using the server's own inferMeta, which may be more current than the underlying agent's hardcoded metadata.