### PR TITLE
Fix bobbit accessory depth (magnifier-depth-busy z-index sync)

### DIFF
--- a/scripts/check-depth-fix.mjs
+++ b/scripts/check-depth-fix.mjs
@@ -1,0 +1,12 @@
+// Verifies magnifier-depth-busy keyframes have the correct z-index transitions
+import { readFileSync } from 'fs';
+const css = readFileSync('src/ui/app.css', 'utf8');
+const m = css.match(/@keyframes magnifier-depth-busy \{[\s\S]*?\n\}/);
+if (!m) { console.log('FAIL: keyframes not found'); process.exit(1); }
+const block = m[0];
+const has54 = /54%\s*\{[^}]*z-index:\s*1/.test(block);
+const has60 = /60%\s*\{[^}]*z-index:\s*-1/.test(block);
+const has98 = /98%[^{]*\{[^}]*z-index:\s*1/.test(block);
+if (has54 && has60 && has98) { console.log('PASS: all depth fixes present'); process.exit(0); }
+console.log('FAIL: missing fixes -', !has54?'no 54%':'', !has60?'no 60%':'', !has98?'no 98%':'');
+process.exit(1);

--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -1401,16 +1401,16 @@ html {
 
 /* ===== Magnifying Glass overlay (hand-held, right side) ===== */
 /* When bobbit faces right, magnifier goes behind the body.
-   Busy: eyes right at 34-57% and micro-glance at 96-98%.
+   Busy: eyes right at 34-54%, eyes up at 60-65%, and micro-glance at 96-98%.
    Idle: eyes up-right at 25-45%, right at 55-85%. */
 @keyframes magnifier-depth-busy {
 	0%, 33% { z-index: 1; }
 	34%     { z-index: -1; }
-	57%     { z-index: -1; }
-	58%, 95% { z-index: 1; }
+	54%     { z-index: 1; }
+	60%     { z-index: -1; }
+	65%, 95% { z-index: 1; }
 	96%     { z-index: -1; }
-	98%     { z-index: -1; }
-	99%, 100% { z-index: 1; }
+	98%, 100% { z-index: 1; }
 }
 @keyframes magnifier-depth-idle {
 	0%, 24% { z-index: 1; }


### PR DESCRIPTION
## Summary

Fixes the `magnifier-depth-busy` z-index animation to stay in sync with `blob-busy-eyes` in `src/ui/app.css`.

### Problem
Hand-held accessories (magnifier, palette, pencil, shield, set-square, flask) would visually overlap the bobbit's eyes during the busy animation:
- **60-64%**: Eyes look up-right (pupils at x=4,7) but accessories stayed in front (z-index: 1)
- **54-58%**: Eyes returned to center at 54% but accessories lagged behind until 58%
- **98-99%**: Same trailing lag for the micro-glance phase

### Fix
Updated `@keyframes magnifier-depth-busy` to cover all three rightward eye phases:
- Added z-index: -1 at 60% for the "eyes up" phase (60-65%)
- Tightened 54% transition (was 57%/58%)
- Tightened 98% transition (was 99%)

### Changes
- `src/ui/app.css`: Updated keyframes and comment
- `scripts/check-depth-fix.mjs`: Verification script for the fix