### PR TITLE
Goal assistant title sync

### DIFF
--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -502,6 +502,10 @@ export class RemoteAgent {
 		this.send({ type: "generate_title" });
 	}
 
+	summarizeGoalTitle(goalTitle: string): void {
+		this.send({ type: "summarize_goal_title", goalTitle });
+	}
+
 	clearSteeringQueue(): void {}
 	clearFollowUpQueue(): void {}
 	clearAllQueues(): void {}

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -252,6 +252,17 @@ function goalPreviewPanel() {
 							state.previewTitleEdited = true;
 							const sid = activeSessionId();
 							if (sid) saveGoalDraft(sid);
+							// Debounced goal title summarization (1s)
+							if ((state as any)._goalTitleDebounceTimer) {
+								clearTimeout((state as any)._goalTitleDebounceTimer);
+							}
+							const trimmedTitle = (e.target as HTMLInputElement).value.trim();
+							if (trimmedTitle.length >= 3 && state.remoteAgent) {
+								(state as any)._goalTitleDebounceTimer = setTimeout(() => {
+									state.remoteAgent?.summarizeGoalTitle(trimmedTitle);
+									(state as any)._goalTitleDebounceTimer = null;
+								}, 1000);
+							}
 						},
 					})}
 				</div>

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -470,6 +470,15 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 				if (state.assistantTab === "chat" && !isDesktop()) {
 					state.assistantTab = "preview";
 				}
+				// Summarize goal title for sidebar display
+				if (proposal.title.trim().length >= 3) {
+					// Cancel any pending debounced title summarization from hand-edits
+					if ((state as any)._goalTitleDebounceTimer) {
+						clearTimeout((state as any)._goalTitleDebounceTimer);
+						(state as any)._goalTitleDebounceTimer = null;
+					}
+					remote.summarizeGoalTitle(proposal.title);
+				}
 				// Persist draft to IndexedDB
 				saveGoalDraft(sessionId);
 			} else {

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -11,7 +11,7 @@ import { RpcBridge, type RpcBridgeOptions } from "./rpc-bridge.js";
 import { SessionStore, type PersistedSession } from "./session-store.js";
 import { getAssistantDef } from "./assistant-registry.js";
 import { assembleSystemPrompt, cleanupSessionPrompt } from "./system-prompt.js";
-import { generateSessionTitle } from "./title-generator.js";
+import { generateSessionTitle, generateGoalSummaryTitle } from "./title-generator.js";
 import { CostTracker } from "./cost-tracker.js";
 import type { ColorStore } from "./color-store.js";
 import type { PersonalityManager } from "./personality-manager.js";
@@ -1152,6 +1152,28 @@ export class SessionManager {
 		this.store.update(id, { title });
 		broadcast(session.clients, { type: "session_title", sessionId: id, title });
 		return true;
+	}
+
+	/**
+	 * Generate an AI-summarized goal title and rename the session.
+	 * Fire-and-forget — does NOT check titleGenerated (independent of first-message auto-title).
+	 */
+	generateGoalTitle(sessionId: string, goalTitle: string): void {
+		const session = this.sessions.get(sessionId);
+		if (!session) return;
+		this._generateGoalTitleAsync(session, goalTitle).catch(err => {
+			console.error(`[session ${session.id}] Goal title generation failed:`, err);
+		});
+	}
+
+	private async _generateGoalTitleAsync(session: SessionInfo, goalTitle: string): Promise<void> {
+		const title = await generateGoalSummaryTitle(goalTitle, this.getTitleGenOptions());
+		if (title) {
+			const finalTitle = `New goal: ${title}`;
+			session.title = finalTitle;
+			this.store.update(session.id, { title: finalTitle });
+			broadcast(session.clients, { type: "session_title", sessionId: session.id, title: finalTitle });
+		}
 	}
 
 	/** Update session metadata fields (role, teamGoalId, worktreePath, accessory) and persist. */

--- a/src/server/agent/title-generator.ts
+++ b/src/server/agent/title-generator.ts
@@ -290,3 +290,155 @@ export async function generateSessionTitle(messages: any[], options?: TitleGenOp
 	// the gateway may not host the default Haiku model ID.
 	return generateViaAnthropic(preview);
 }
+
+// ── Goal title summarization ──────────────────────────────────────────
+
+const GOAL_SUMMARY_SYSTEM = "Summarize this goal title in exactly 3 words. Output ONLY the 3-word summary. No quotes, no markdown, no explanation. No emojis.";
+
+/**
+ * Generate a 3-word summary of a goal title via the AI Gateway.
+ */
+async function generateGoalSummaryViaGateway(aigwUrl: string, modelId: string, goalTitle: string): Promise<string | null> {
+	const baseUrl = aigwUrl.replace(/\/+$/, "");
+	const resolvedModel = await resolveGatewayModelId(baseUrl, modelId);
+	const url = baseUrl.endsWith("/v1") ? `${baseUrl}/chat/completions` : `${baseUrl}/v1/chat/completions`;
+
+	const body = {
+		model: resolvedModel,
+		max_tokens: 20,
+		messages: [
+			{ role: "system", content: GOAL_SUMMARY_SYSTEM },
+			{ role: "user", content: `Goal title:\n\n---\n${goalTitle}\n---\n\n3-word summary:` },
+		],
+	};
+
+	console.log(`[title-gen] Requesting goal summary via gateway model "${resolvedModel}"…`);
+
+	try {
+		const response = await fetch(url, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		});
+
+		if (!response.ok) {
+			const errText = await response.text();
+			console.error(`[title-gen] Gateway error ${response.status}: ${errText.slice(0, 200)}`);
+			return null;
+		}
+
+		const data = await response.json() as any;
+		const text = data.choices?.[0]?.message?.content?.trim();
+		if (!text) return null;
+
+		const title = cleanTitle(text);
+		console.log(`[title-gen] Generated goal summary: "${title}"`);
+		return title || null;
+	} catch (err) {
+		console.error("[title-gen] Gateway goal summary request failed:", err);
+		return null;
+	}
+}
+
+/**
+ * Generate a 3-word summary of a goal title via direct Anthropic API.
+ */
+async function generateGoalSummaryViaAnthropic(goalTitle: string): Promise<string | null> {
+	let auth = loadAuth();
+	if (!auth) return null;
+
+	if (auth.type === "oauth" && auth.expires && Date.now() > auth.expires) {
+		const newToken = await refreshOAuthToken();
+		if (newToken) {
+			auth = { ...auth, access: newToken };
+		} else {
+			console.error("[title-gen] Token expired and refresh failed");
+			return null;
+		}
+	}
+
+	const headers: Record<string, string> = {
+		"Content-Type": "application/json",
+		"anthropic-version": "2023-06-01",
+	};
+
+	if (auth.type === "oauth") {
+		headers["Authorization"] = `Bearer ${auth.access}`;
+		headers["anthropic-beta"] = "claude-code-20250219,oauth-2025-04-20";
+	} else {
+		headers["x-api-key"] = auth.access;
+	}
+
+	const systemText = auth.type === "oauth"
+		? `You are Claude Code, Anthropic's official CLI for Claude. ${GOAL_SUMMARY_SYSTEM}`
+		: GOAL_SUMMARY_SYSTEM;
+
+	const body = {
+		model: DEFAULT_TITLE_MODEL,
+		max_tokens: 12,
+		system: auth.type === "oauth"
+			? [{ type: "text", text: systemText }]
+			: systemText,
+		messages: [
+			{ role: "user", content: `Goal title:\n\n---\n${goalTitle}\n---\n\n3-word summary:` },
+		],
+	};
+
+	console.log(`[title-gen] Requesting goal summary via ${DEFAULT_TITLE_MODEL}…`);
+
+	try {
+		const response = await fetch(ANTHROPIC_API_URL, {
+			method: "POST",
+			headers,
+			body: JSON.stringify(body),
+		});
+
+		if (!response.ok) {
+			const errText = await response.text();
+			console.error(`[title-gen] API error ${response.status}: ${errText}`);
+			return null;
+		}
+
+		const data = (await response.json()) as {
+			content: Array<{ type: string; text?: string }>;
+		};
+
+		const text = data.content
+			?.filter((c) => c.type === "text")
+			.map((c) => c.text || "")
+			.join("")
+			.trim();
+
+		if (!text) return null;
+
+		const title = cleanTitle(text);
+		console.log(`[title-gen] Generated goal summary: "${title}"`);
+		return title || null;
+	} catch (err) {
+		console.error("[title-gen] Goal summary failed:", err);
+		return null;
+	}
+}
+
+/**
+ * Generate a 3-word summary of a goal title for sidebar display.
+ * Returns the cleaned summary (without "New goal: " prefix — caller adds that).
+ * Returns null if generation fails.
+ */
+export async function generateGoalSummaryTitle(goalTitle: string, options?: TitleGenOptions): Promise<string | null> {
+	if (!goalTitle.trim()) {
+		console.error("[title-gen] No goal title to summarise");
+		return null;
+	}
+
+	if (options?.namingModel && options.aigwUrl) {
+		const slash = options.namingModel.indexOf("/");
+		if (slash > 0 && slash < options.namingModel.length - 1) {
+			const modelId = options.namingModel.slice(slash + 1);
+			return generateGoalSummaryViaGateway(options.aigwUrl, modelId, goalTitle);
+		}
+		console.warn(`[title-gen] Malformed namingModel preference: "${options.namingModel}", ignoring`);
+	}
+
+	return generateGoalSummaryViaAnthropic(goalTitle);
+}

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -274,6 +274,13 @@ export function handleWebSocketConnection(
 						send(ws, { type: "error", message: `Title generation failed: ${err}`, code: "TITLE_GEN_ERROR" });
 					});
 					break;
+				case "summarize_goal_title": {
+					const goalTitle = typeof msg.goalTitle === "string" ? msg.goalTitle.trim() : "";
+					if (goalTitle.length >= 3) {
+						sessionManager.generateGoalTitle(sessionId, goalTitle);
+					}
+					break;
+				}
 				case "task_create": {
 					const task = sessionManager.taskManager.createTask(
 						msg.goalId,

--- a/src/server/ws/protocol.ts
+++ b/src/server/ws/protocol.ts
@@ -31,7 +31,8 @@ export type ClientMessage =
 	| { type: "invoke_skill"; skillId: string; context?: Record<string, string> }
 	| { type: "task_create"; goalId: string; title: string; taskType: string; parentTaskId?: string; spec?: string; dependsOn?: string[] }
 	| { type: "task_update"; taskId: string; updates: { title?: string; spec?: string; state?: string; assignedSessionId?: string; dependsOn?: string[] } }
-	| { type: "task_delete"; taskId: string };
+	| { type: "task_delete"; taskId: string }
+	| { type: "summarize_goal_title"; goalTitle: string };
 
 /** Server → Client messages over WebSocket */
 export type ServerMessage =


### PR DESCRIPTION
Auto-rename goal assistant session titles from 'Goal Assistant' to 'New goal: <3-word AI summary>' based on the goal title being composed.

## Changes (7 files)

**Server:**
- `src/server/ws/protocol.ts` — Added `summarize_goal_title` WS command
- `src/server/agent/title-generator.ts` — Added `generateGoalSummaryTitle()` using existing gateway/anthropic infrastructure
- `src/server/agent/session-manager.ts` — Added `generateGoalTitle()` method that prepends 'New goal: ' prefix
- `src/server/ws/handler.ts` — Added handler with input validation (>= 3 chars)

**Client:**
- `src/app/remote-agent.ts` — Added `summarizeGoalTitle()` method
- `src/app/session-manager.ts` — Triggers summarization on AI proposal updates
- `src/app/render.ts` — 1s debounced summarization on title hand-edits

## Verification
- Type check: pass
- Unit tests: 183 pass
- E2E tests: 229 pass