### PR TITLE
Goal Archival System

### DIFF
--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -315,18 +315,14 @@ export async function deleteGoal(id: string): Promise<void> {
 		message += ` Its ${sessionsUnderGoal.length} session(s) will become ungrouped.`;
 	}
 
-	const confirmed = await confirmAction("Delete Goal", message, "Delete", true);
+	const confirmed = await confirmAction("Archive Goal", `Archive "${goalTitle}"? It will move to the archived section.`, "Archive", false);
 	if (!confirmed) return;
 
 	try {
 		await gatewayFetch(`/api/goals/${id}`, { method: "DELETE" });
-		expandedGoals.delete(id);
-		saveExpandedGoals();
-		// Navigate away from the deleted goal's dashboard
-		setHashRoute("landing");
 		await refreshSessions();
 	} catch (err) {
-		showConnectionError("Failed to delete goal", err instanceof Error ? err.message : String(err));
+		showConnectionError("Failed to archive goal", err instanceof Error ? err.message : String(err));
 	}
 }
 

--- a/src/app/goal-dashboard.ts
+++ b/src/app/goal-dashboard.ts
@@ -859,9 +859,11 @@ function renderNavBar(goal: Goal): TemplateResult {
 				${goal.workflow ? html`<span class="nav-workflow-badge" title="Uses workflow: ${goal.workflow.name}">${goal.workflow.name}</span>` : nothing}
 			</div>
 			<div class="nav-right">
-				<button class="btn-icon" @click=${() => showGoalDialog(goal)} title="Edit goal">${svgPencil}</button>
-				<button class="btn-icon danger" @click=${() => deleteGoal(goal.id)} title="Delete goal">${svgTrash}</button>
-				${isTeamGoal ? renderTeamButton(goal) : renderSessionButton(goal)}
+				${goal.archived ? nothing : html`
+					<button class="btn-icon" @click=${() => showGoalDialog(goal)} title="Edit goal">${svgPencil}</button>
+					<button class="btn-icon danger" @click=${() => deleteGoal(goal.id)} title="Archive goal">${svgTrash}</button>
+					${isTeamGoal ? renderTeamButton(goal) : renderSessionButton(goal)}
+				`}
 			</div>
 		</div>
 	`;
@@ -1755,9 +1757,16 @@ export function renderGoalDashboard(): TemplateResult {
 
 	const activeTab = dashboardTab;
 
+	const isArchived = currentGoal.archived === true;
+
 	return html`
 		<div class="dashboard-container">
 			${renderNavBar(currentGoal)}
+			${isArchived ? html`
+				<div style="margin:0 16px 8px;padding:10px 14px;border-radius:8px;border:1px solid var(--border);background:var(--muted);color:var(--muted-foreground);font-size:13px;">
+					This goal was archived on ${new Date(currentGoal.archivedAt!).toLocaleDateString()}. Dashboard is read-only.
+				</div>
+			` : nothing}
 			${renderSetupBanner(currentGoal)}
 			${renderMetaRows(currentGoal)}
 			${renderSummaryRow(tasks, agents)}

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -317,9 +317,11 @@ export function renderSidebar() {
 	const ungroupedSessions = state.gatewaySessions.filter((s) => !s.goalId && !s.teamGoalId && !s.delegateOf && !staffSessionIds.has(s.id)).sort((a, b) => a.createdAt - b.createdAt);
 	const stateOrder: Record<GoalState, number> = { "in-progress": 0, "todo": 1, "complete": 2, "shelved": 3 };
 	const sortedGoals = [...state.goals].sort((a, b) => (stateOrder[a.state] ?? 9) - (stateOrder[b.state] ?? 9));
+	const liveGoals = sortedGoals.filter(g => !g.archived);
+	const archivedGoals = sortedGoals.filter(g => g.archived);
 
 	if (state.sidebarCollapsed) {
-		return renderCollapsedSidebar(sortedGoals, ungroupedSessions);
+		return renderCollapsedSidebar(liveGoals, ungroupedSessions, archivedGoals);
 	}
 
 	return html`
@@ -379,11 +381,11 @@ export function renderSidebar() {
 								<button class="text-xs text-muted-foreground hover:text-foreground underline" title="Retry loading sessions" @click=${refreshSessions}>Retry</button>
 							</div>`
 						: html`
-							${sortedGoals.map((goal, i) => html`
+							${liveGoals.map((goal, i) => html`
 								${i > 0 ? html`<div class="border-t border-border/30 my-1 mx-2"></div>` : ""}
 								${renderGoalGroup(goal)}
 							`)}
-							${sortedGoals.length > 0 ? html`
+							${liveGoals.length > 0 ? html`
 								<div class="border-t border-border/30 my-1 mx-2"></div>
 								<div class="flex flex-col gap-0.5">
 									<div class="relative flex items-center gap-1 pr-1 py-0.5 rounded-md cursor-pointer hover:bg-secondary/30 transition-colors"
@@ -447,6 +449,21 @@ export function renderSidebar() {
 								</div>
 							`}
 							${renderStaffSidebarSection()}
+							${state.showArchived && archivedGoals.length > 0 ? html`
+								<div class="border-t border-border/30 my-1 mx-2"></div>
+								<div class="flex flex-col gap-0.5">
+									<div class="relative flex items-center gap-1 pr-1 py-0.5 rounded-md cursor-pointer hover:bg-secondary/30 transition-colors"
+										style="padding-left:${HEADER_CHEVRON_W}px;">
+										<span class="absolute left-0 top-0 bottom-0 flex items-center justify-center text-sm text-muted-foreground select-none opacity-60" style="width:${HEADER_CHEVRON_W}px;">▾</span>
+										<span class="shrink-0 text-muted-foreground opacity-60" style="margin-left:-3px;">${icon(GoalIcon, "xs")}</span>
+										<span class="flex-1 text-[10px] text-muted-foreground uppercase tracking-wider font-medium opacity-60">Archived Goals</span>
+									</div>
+									${archivedGoals.map((goal, i) => html`
+										${i > 0 ? html`<div class="border-t border-border/30 my-1 mx-2"></div>` : ""}
+										<div class="opacity-60">${renderGoalGroup(goal)}</div>
+									`)}
+								</div>
+							` : ""}
 							${(() => {
 								// Archived section: standalone archived sessions (no goal, not a delegate)
 								// Goal-affiliated archived sessions render inside their goal groups.
@@ -530,7 +547,7 @@ export function renderSidebar() {
 // COLLAPSED SIDEBAR
 // ============================================================================
 
-function renderCollapsedSidebar(sortedGoals: Goal[], ungroupedSessions: GatewaySession[]) {
+function renderCollapsedSidebar(sortedGoals: Goal[], ungroupedSessions: GatewaySession[], archivedGoals: Goal[] = []) {
 	const allSessions = state.gatewaySessions;
 	const staffSessionIds = new Set(state.staffList.map((s) => s.currentSessionId).filter(Boolean));
 	const ungrouped = allSessions.filter((s) => !s.goalId && !s.teamGoalId && !s.delegateOf && !staffSessionIds.has(s.id)).sort((a, b) => a.createdAt - b.createdAt);
@@ -630,6 +647,26 @@ function renderCollapsedSidebar(sortedGoals: Goal[], ungroupedSessions: GatewayS
 						</button>
 					`;
 				})}
+				${state.showArchived && archivedGoals.length > 0 ? html`
+					<div class="w-7 border-t border-border/50 my-1.5"></div>
+					${archivedGoals.map((goal) => {
+						const goalSessions = allSessions.filter((s) => (s.goalId === goal.id || s.teamGoalId === goal.id) && !s.delegateOf).sort((a, b) => a.createdAt - b.createdAt);
+						const expanded = expandedGoals.has(goal.id);
+						return html`
+							<div class="opacity-60">
+								<button
+									class="flex items-center py-0.5 w-full rounded-md hover:bg-secondary/50 transition-colors" style="gap:0.225rem;"
+									title=${goal.title}
+									@click=${(e: Event) => { e.stopPropagation(); if (expandedGoals.has(goal.id)) expandedGoals.delete(goal.id); else expandedGoals.add(goal.id); saveExpandedGoals(); renderApp(); }}
+								>
+									<span class="text-[11px] text-muted-foreground shrink-0 select-none" style="width:${CHEVRON_W}px;text-align:center;">${expanded ? "▾" : "▸"}</span>
+									<span class="text-[10px] font-extrabold tracking-wider text-muted-foreground" style="font-family: ui-monospace, monospace; line-height: 1;">${sessionAcronym(goal.title)}</span>
+								</button>
+								${expanded ? renderCollapsedGoalSessions(goalSessions, goal) : ""}
+							</div>
+						`;
+					})}
+				` : ""}
 			</div>
 			<button
 				class="p-2 mb-2 rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -67,6 +67,8 @@ export interface Goal {
 	workflowId?: string;
 	setupStatus?: "ready" | "preparing" | "error";
 	setupError?: string;
+	archived?: boolean;
+	archivedAt?: number;
 	workflow?: {
 		id: string;
 		name: string;

--- a/src/server/agent/goal-manager.ts
+++ b/src/server/agent/goal-manager.ts
@@ -202,6 +202,20 @@ export class GoalManager {
 		return true;
 	}
 
+	async archiveGoal(id: string): Promise<boolean> {
+		const goal = this.store.get(id);
+		if (!goal) return false;
+		return this.store.archive(id);
+	}
+
+	listLiveGoals(): PersistedGoal[] {
+		return this.store.getLive();
+	}
+
+	listArchivedGoals(): PersistedGoal[] {
+		return this.store.getArchived();
+	}
+
 	getGoal(id: string): PersistedGoal | undefined {
 		return this.store.get(id);
 	}

--- a/src/server/agent/goal-store.ts
+++ b/src/server/agent/goal-store.ts
@@ -36,6 +36,10 @@ export interface PersistedGoal {
 	setupError?: string;
 	/** GitHub PR URL (set by team lead after creating PR) */
 	prUrl?: string;
+	/** Whether this goal has been archived (soft-deleted) */
+	archived?: boolean;
+	/** Epoch ms when the goal was archived */
+	archivedAt?: number;
 }
 
 const STORE_DIR = bobbitStateDir();
@@ -111,6 +115,23 @@ export class GoalStore {
 
 	getAll(): PersistedGoal[] {
 		return Array.from(this.goals.values());
+	}
+
+	archive(id: string): boolean {
+		const existing = this.goals.get(id);
+		if (!existing) return false;
+		existing.archived = true;
+		existing.archivedAt = Date.now();
+		this.save();
+		return true;
+	}
+
+	getLive(): PersistedGoal[] {
+		return Array.from(this.goals.values()).filter(g => !g.archived);
+	}
+
+	getArchived(): PersistedGoal[] {
+		return Array.from(this.goals.values()).filter(g => g.archived === true);
 	}
 
 	update(id: string, updates: Partial<Omit<PersistedGoal, "id" | "createdAt">>): boolean {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -698,6 +698,8 @@ async function handleApiRoute(
 		}
 
 		if (req.method === "PUT") {
+			const putGoal = sessionManager.goalManager.getGoal(id);
+			if (putGoal?.archived) { json({ error: "Goal is archived" }, 409); return; }
 			const body = await readBody(req);
 			if (!body) { json({ error: "Missing body" }, 400); return; }
 			const ok = await sessionManager.goalManager.updateGoal(id, {
@@ -725,9 +727,8 @@ async function handleApiRoute(
 					console.error(`[api] Error tearing down team for goal ${id}:`, err);
 				}
 			}
-			sessionManager.taskManager.deleteTasksForGoal(id);
-			gateStore.removeGoalGates(id);
-			await sessionManager.goalManager.deleteGoal(id);
+			// Archive instead of hard-delete — tasks, gates, team state remain intact
+			await sessionManager.goalManager.archiveGoal(id);
 			json({ ok: true });
 			return;
 		}
@@ -1002,6 +1003,7 @@ async function handleApiRoute(
 		const goalId = goalTasksMatch[1];
 		const goal = sessionManager.goalManager.getGoal(goalId);
 		if (!goal) { json({ error: "Goal not found" }, 404); return; }
+		if (goal.archived) { json({ error: "Goal is archived" }, 409); return; }
 
 		const body = await readBody(req);
 		const title = body?.title;
@@ -1065,6 +1067,7 @@ async function handleApiRoute(
 		const [, goalId, gateId] = gateSignalMatch;
 		const goal = sessionManager.goalManager.getGoal(goalId);
 		if (!goal) { json({ error: "Goal not found" }, 404); return; }
+		if (goal.archived) { json({ error: "Goal is archived" }, 409); return; }
 		if (!goal.workflow) { json({ error: "Goal has no workflow" }, 400); return; }
 		const gateDef = goal.workflow.gates.find(g => g.id === gateId);
 		if (!gateDef) { json({ error: `Unknown gate: ${gateId}` }, 404); return; }
@@ -1338,8 +1341,13 @@ async function handleApiRoute(
 	const teamSpawnMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/(?:team|swarm)\/spawn$/);
 	if (teamSpawnMatch && req.method === "POST") {
 		const goalId = teamSpawnMatch[1];
-		// Guard: reject spawn if goal worktree is not ready
+		// Guard: reject spawn if goal is archived
 		const spawnGoal = sessionManager.goalManager.getGoal(goalId);
+		if (spawnGoal?.archived) {
+			json({ error: "Goal is archived" }, 409);
+			return;
+		}
+		// Guard: reject spawn if goal worktree is not ready
 		if (spawnGoal && spawnGoal.setupStatus !== "ready") {
 			json({ error: "Goal setup not complete" }, 409);
 			return;

--- a/tests/e2e/tools-e2e.spec.ts
+++ b/tests/e2e/tools-e2e.spec.ts
@@ -285,15 +285,26 @@ test.describe("Goals API", () => {
 		expect(data.state).toBe("in-progress");
 	});
 
-	test("DELETE removes a goal", async () => {
+	test("DELETE archives a goal (soft-delete)", async () => {
 		const resp1 = await apiFetch("/api/goals", {
 			method: "POST",
-			body: JSON.stringify({ title: "Delete test", cwd: nonGitCwd() }),
+			body: JSON.stringify({ title: "Archive test", cwd: nonGitCwd() }),
 		});
 		goalId = (await resp1.json()).id;
 		const resp = await apiFetch(`/api/goals/${goalId}`, { method: "DELETE" });
 		expect(resp.status).toBe(200);
-		expect((await apiFetch(`/api/goals/${goalId}`)).status).toBe(404);
+		// Goal still exists but is archived
+		const getResp = await apiFetch(`/api/goals/${goalId}`);
+		expect(getResp.status).toBe(200);
+		const data = await getResp.json();
+		expect(data.archived).toBe(true);
+		expect(data.archivedAt).toBeGreaterThan(0);
+		// Mutations should be rejected with 409
+		const putResp = await apiFetch(`/api/goals/${goalId}`, {
+			method: "PUT",
+			body: JSON.stringify({ title: "Should fail" }),
+		});
+		expect(putResp.status).toBe(409);
 		goalId = "";
 	});
 


### PR DESCRIPTION
Replace hard-delete of goals with soft-delete archival. Archived goals remain viewable in the sidebar and their dashboard pages (gates, tasks, progress) stay accessible read-only.

## Changes

### Server
- Added `archived`/`archivedAt` fields to `PersistedGoal`
- `GoalStore.archive()` method mirrors `SessionStore.archive()` pattern
- DELETE `/api/goals/:id` now archives instead of hard-deleting (preserves tasks/gates/team state)
- 409 mutation guards on PUT goals, POST tasks, POST gate signals, POST team spawn for archived goals

### UI
- Sidebar splits live vs archived goals; archived shown in collapsible section with reduced opacity
- Dashboard shows read-only banner and hides mutation controls for archived goals
- Delete dialog becomes Archive dialog (no navigation away after archiving)

### Tests
- E2E test updated to verify soft-delete behavior and 409 on mutation
- 238/238 E2E tests pass, type check clean

## Verification
All workflow gates passed: design-doc, implementation (type check, unit tests, E2E tests, gap analysis, code quality review, security review), ready-to-merge.