### PR TITLE
Sidebar collapse memory

### DIFF
--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -14,6 +14,7 @@ import {
 	ungroupedExpanded,
 	setUngroupedExpanded,
 	type GoalState,
+	resetArchivedExpandState,
 } from "./state.js";
 import { createGoal, createRole, gatewayFetch, refreshSessions } from "./api.js";
 import { clearSessionModel } from "./routing.js";
@@ -218,6 +219,8 @@ function renderMobileLanding() {
 					localStorage.setItem("bobbit-show-archived", String(state.showArchived));
 					if (state.showArchived) {
 						import("./api.js").then(m => m.fetchArchivedSessions());
+					} else {
+						resetArchivedExpandState();
 					}
 					renderApp();
 				}}

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -23,6 +23,7 @@ import { refreshSessions, fetchRoles, fetchPersonalities, fetchStaff, wakeStaffA
 import { statusBobbit, sessionAcronym } from "./session-colors.js";
 import { renderGoalGroup, renderSessionRow, renderArchivedSessionRow, renderArchivedDelegates, showSessionTooltip, hideSessionTooltip, SESSION_ROW_PY, INDENT, CHEVRON_W, HEADER_CHEVRON_W, terseRelativeTime, hasUnseenActivity, formatSessionAge } from "./render-helpers.js";
 import type { GatewaySession } from "./state.js";
+import { resetArchivedExpandState } from "./state.js";
 
 // ============================================================================
 // ROLE + PERSONALITY PICKER
@@ -481,6 +482,8 @@ export function renderSidebar() {
 												localStorage.setItem("bobbit-show-archived", String(state.showArchived));
 												if (state.showArchived) {
 													import("./api.js").then(m => m.fetchArchivedSessions());
+												} else {
+													resetArchivedExpandState();
 												}
 												renderApp();
 											}}
@@ -522,6 +525,7 @@ export function renderSidebar() {
 							import("./api.js").then(m => m.fetchArchivedSessions());
 						} else {
 							state.showArchived = false;
+							resetArchivedExpandState();
 						}
 						renderApp();
 					}}

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -272,22 +272,39 @@ export function isTeamLeadExpanded(sessionId: string): boolean {
 	return !collapsedTeamLeadSessions.has(sessionId);
 }
 
-const COLLAPSED_ARCHIVED_PARENTS_KEY = "bobbit-collapsed-archived-parents";
-const collapsedArchivedParents: Set<string> = new Set(
-	JSON.parse(localStorage.getItem(COLLAPSED_ARCHIVED_PARENTS_KEY) || "[]"),
+const EXPANDED_DELEGATE_PARENTS_KEY = "bobbit-expanded-delegate-parents";
+const expandedDelegateParents: Set<string> = new Set(
+	JSON.parse(localStorage.getItem(EXPANDED_DELEGATE_PARENTS_KEY) || "[]"),
 );
 
 export function toggleArchivedParentExpanded(sessionId: string): void {
-	if (collapsedArchivedParents.has(sessionId)) {
-		collapsedArchivedParents.delete(sessionId);
+	if (expandedDelegateParents.has(sessionId)) {
+		expandedDelegateParents.delete(sessionId);
 	} else {
-		collapsedArchivedParents.add(sessionId);
+		expandedDelegateParents.add(sessionId);
 	}
-	localStorage.setItem(COLLAPSED_ARCHIVED_PARENTS_KEY, JSON.stringify([...collapsedArchivedParents]));
+	localStorage.setItem(EXPANDED_DELEGATE_PARENTS_KEY, JSON.stringify([...expandedDelegateParents]));
 }
 
 export function isArchivedParentExpanded(sessionId: string): boolean {
-	return !collapsedArchivedParents.has(sessionId);
+	return expandedDelegateParents.has(sessionId);
+}
+
+export function resetArchivedExpandState(): void {
+	// Remove archived goal IDs from expandedGoals
+	const archivedGoalIds = new Set(state.goals.filter(g => g.archived).map(g => g.id));
+	for (const id of archivedGoalIds) expandedGoals.delete(id);
+	saveExpandedGoals();
+
+	// Remove archived session IDs from expandedDelegateParents
+	const archivedSessionIds = new Set(state.archivedSessions.map(s => s.id));
+	for (const id of archivedSessionIds) expandedDelegateParents.delete(id);
+	localStorage.setItem(EXPANDED_DELEGATE_PARENTS_KEY, JSON.stringify([...expandedDelegateParents]));
+
+	// Reset archived team lead sessions from collapsedTeamLeadSessions
+	// (archived team leads that were explicitly collapsed — remove them so they return to default)
+	for (const id of archivedSessionIds) collapsedTeamLeadSessions.delete(id);
+	localStorage.setItem(COLLAPSED_TEAM_LEADS_KEY, JSON.stringify([...collapsedTeamLeadSessions]));
 }
 
 // ============================================================================


### PR DESCRIPTION
## Changes

- **Delegate parent sessions default to collapsed** — sessions with delegate children now start collapsed (delegates hidden). User expand/collapse state persisted to localStorage.
- **Reset archived chevrons on archive toggle off** — toggling "See Archived" OFF resets all archived goal and session chevrons to collapsed. Only archived items are affected; live items untouched.
- Team lead expand/collapse behavior unchanged (still defaults to expanded).

### Files changed
- `src/app/state.ts` — flipped delegate parent default, added `resetArchivedExpandState()`
- `src/app/sidebar.ts` — call reset on archive toggle off (2 locations)
- `src/app/render.ts` — call reset on mobile archive toggle off

### Verification
- Type check passes
- 202/202 unit tests pass
- E2E tests pass
- Code quality, gap analysis, and security reviews all pass