### PR TITLE
docs: add missing API endpoints, WS events, and disk state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,7 @@ All per-project state lives under `<project-root>/.bobbit/`:
 | `staff.json` | `StaffStore` | Staff agent definitions and state |
 | `session-costs.json` | `CostTracker` | Per-session token and cost data |
 | `session-colors.json` | `ColorStore` | Session → color index (0-13) mapping |
+| `preferences.json` | `PreferencesStore` | Key-value preferences (AI gateway config, etc.) |
 | `skill-definitions.json` | `definitions-sync.ts` | Exported skill definitions for agent discovery |
 | `session-prompts/` | `system-prompt.ts` | Assembled per-session prompt files (cleaned up on terminate) |
 | `tls/` | `tls.ts` | TLS certificates and keys |

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -23,6 +23,7 @@ All routes require `Authorization: Bearer <token>`. Token can also be passed as 
 | `POST` | `/api/sessions/:id/wait` | Block until session becomes idle, then return output |
 | `GET` | `/api/sessions/:id/output` | Get final assistant output from the last turn |
 | `GET` | `/api/sessions/:id/git-status` | Git status for session's working directory (branch, ahead/behind, dirty files) |
+| `GET` | `/api/sessions/:id/pr-status` | PR status for session's branch (via `gh pr view`) |
 | `GET` | `/api/sessions/:id/cost` | Token usage and cost for a single session |
 
 ### Goals
@@ -37,6 +38,8 @@ All routes require `Authorization: Bearer <token>`. Token can also be passed as 
 | `GET` | `/api/goals/:id/commits` | Commit history for goal branch (excludes primary branch commits) |
 | `GET` | `/api/goals/:id/git-status` | Git status for goal worktree (branch, ahead/behind primary, clean) |
 | `GET` | `/api/goals/:id/cost` | Aggregate cost across all sessions linked to a goal |
+| `GET` | `/api/goals/:id/pr-status` | PR status for goal branch (cached, via `gh pr view`) |
+| `POST` | `/api/goals/:id/pr-merge` | Merge PR for goal branch (`{ method? }`) |
 
 ### Goal Tasks
 
@@ -124,6 +127,24 @@ Routes accept both `/team/` and legacy `/swarm/` paths.
 | `PUT` | `/api/workflows/:id` | Update a workflow |
 | `DELETE` | `/api/workflows/:id` | Delete (blocked if in-use by active goals) |
 | `POST` | `/api/workflows/:id/clone` | Deep-copy a workflow with a new ID |
+
+### Preferences
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/preferences` | Get all preferences |
+| `PUT` | `/api/preferences` | Merge preferences (set `null` to delete a key) |
+
+### AI Gateway
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/aigw/status` | Check if AI gateway is configured, return available models |
+| `POST` | `/api/aigw/configure` | Set AI gateway URL, discover models (`{ url }`) |
+| `DELETE` | `/api/aigw/configure` | Remove AI gateway configuration |
+| `POST` | `/api/aigw/test` | Test connection to a URL without saving (`{ url }`) |
+| `POST` | `/api/aigw/refresh` | Re-discover models from configured gateway |
+| `*` | `/api/aigw/v1/*` | Proxy requests to configured AI gateway |
 
 ### OAuth
 

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -48,3 +48,9 @@ Connect to `wss://<host>:<port>/ws/<session-id>`. First message must be `{ "type
 | `queue_update` | `sessionId`, `queue` | Prompt queue changed |
 | `task_changed` | `task` | A task was created, updated, or deleted |
 | `tasks_list` | `tasks` | Full task list for a goal |
+| `preferences_changed` | `preferences` | Server preferences were updated |
+| `gate_verification_started` | `goalId`, `gateId`, `signalId` | Gate verification began |
+| `gate_verification_step_started` | `goalId`, `gateId`, `stepIndex`, `stepName` | A verification step began |
+| `gate_verification_step_output` | `goalId`, `gateId`, `stepIndex`, `stream`, `text` | Live output from a verification step |
+| `gate_verification_step_complete` | `goalId`, `gateId`, `stepIndex`, `status` | A verification step finished (passed/failed) |
+| `gate_verification_complete` | `goalId`, `gateId`, `signalId`, `status` | All verification steps finished |


### PR DESCRIPTION
Adds undocumented items found during validation scan:

**docs/rest-api.md** — 12 missing endpoints:
- `GET /api/sessions/:id/pr-status` — session-level PR status
- `GET /api/goals/:id/pr-status` + `POST /api/goals/:id/pr-merge` — goal PR management
- `GET/PUT /api/preferences` — server preferences
- `GET/POST/DELETE /api/aigw/configure`, `POST /api/aigw/test`, `POST /api/aigw/refresh`, `GET /api/aigw/status`, `/api/aigw/v1/*` — AI gateway

**docs/websocket-protocol.md** — 6 missing server events:
- `gate_verification_started/step_started/step_output/step_complete/complete`
- `preferences_changed`

**AGENTS.md** — missing `preferences.json` in disk state table