### PR TITLE
Working Dir Picker UX

### DIFF
--- a/src/app/cwd-combobox.ts
+++ b/src/app/cwd-combobox.ts
@@ -10,7 +10,7 @@ export function getRecentCwds(): Array<{ path: string; source: string }> {
 
 	// Sessions (sorted by lastActivity descending)
 	const sessions = [...state.gatewaySessions]
-		.filter((s) => s.cwd && s.assistantType !== "goal" && !s.delegateOf)
+		.filter((s) => s.cwd && s.assistantType !== "goal" && !s.delegateOf && !s.teamGoalId)
 		.sort((a, b) => b.lastActivity - a.lastActivity);
 	for (const s of sessions) {
 		const p = s.cwd;
@@ -29,7 +29,8 @@ export function getRecentCwds(): Array<{ path: string; source: string }> {
 			results.push({ path: p, source: "goal" });
 		}
 	}
-	return results;
+	// Filter out worktree paths (contain -wt/ or -wt\ directory segments)
+	return results.filter(r => !/-wt[/\\]/.test(r.path));
 }
 
 export interface CwdComboboxProps {
@@ -108,7 +109,7 @@ export function cwdCombobox(opts: CwdComboboxProps) {
 					aria-controls="cwd-listbox"
 					class="flex w-full min-w-0 rounded-md border border-input bg-transparent text-foreground shadow-xs h-9 px-3 py-1 text-sm pr-8 placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none dark:bg-input/30"
 					.value=${opts.value}
-					placeholder=${opts.placeholder || "(server default)"}
+					placeholder=${opts.placeholder || (state as any).defaultCwd || "(server default)"}
 					@input=${(e: Event) => {
 						opts.onInput((e.target as HTMLInputElement).value);
 						if (!opts.dropdownOpen) opts.onToggle(true);

--- a/src/app/cwd-combobox.ts
+++ b/src/app/cwd-combobox.ts
@@ -29,7 +29,6 @@ export function getRecentCwds(): Array<{ path: string; source: string }> {
 			results.push({ path: p, source: "goal" });
 		}
 	}
-	// Filter out worktree paths (contain -wt/ or -wt\ directory segments)
 	return results.filter(r => !/-wt[/\\]/.test(r.path));
 }
 
@@ -109,7 +108,7 @@ export function cwdCombobox(opts: CwdComboboxProps) {
 					aria-controls="cwd-listbox"
 					class="flex w-full min-w-0 rounded-md border border-input bg-transparent text-foreground shadow-xs h-9 px-3 py-1 text-sm pr-8 placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none dark:bg-input/30"
 					.value=${opts.value}
-					placeholder=${opts.placeholder || (state as any).defaultCwd || "(server default)"}
+					placeholder=${opts.placeholder || state.defaultCwd || "(server default)"}
 					@input=${(e: Event) => {
 						opts.onInput((e.target as HTMLInputElement).value);
 						if (!opts.dropdownOpen) opts.onToggle(true);

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -323,7 +323,6 @@ function goalPreviewPanel() {
 					<label class="text-xs text-muted-foreground mb-1.5 block font-medium">Working Directory</label>
 					${cwdCombobox({
 						value: state.previewCwd,
-						placeholder: "(server default)",
 						onInput: (v) => {
 							state.previewCwd = v;
 							state.previewCwdEdited = true;
@@ -989,7 +988,7 @@ function staffPreviewPanel() {
 					${Input({
 						type: "text",
 						value: state.staffPreviewCwd,
-						placeholder: "(server default)",
+						placeholder: (state as any).defaultCwd || "(server default)",
 						onInput: (e: Event) => {
 							state.staffPreviewCwd = (e.target as HTMLInputElement).value;
 							state.staffPreviewCwdEdited = true;
@@ -1281,7 +1280,6 @@ function goalProposalPanel() {
 				<label class="text-xs text-muted-foreground mb-1.5 block font-medium">Working Directory</label>
 				${cwdCombobox({
 					value: _proposalCwd,
-					placeholder: "(server default)",
 					onInput: (v) => { _proposalCwd = v; renderApp(); },
 					onSelect: (v) => { _proposalCwd = v; renderApp(); },
 					dropdownOpen: _proposalCwdDropdownOpen,

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -234,6 +234,16 @@ export async function authenticateGateway(url: string, token: string): Promise<v
 	}
 	renderApp();
 	await refreshSessions();
+	// Fetch default cwd from server
+	try {
+		const cwdRes = await fetch(`${url}/api/config/cwd`, {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		if (cwdRes.ok) {
+			const cwdData = await cwdRes.json();
+			if (cwdData.cwd) (state as any).defaultCwd = cwdData.cwd;
+		}
+	} catch { /* ignore — server may not support this endpoint yet */ }
 	startSessionPolling();
 	startTimeRefresh();
 }
@@ -844,7 +854,7 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 // CREATE & CONNECT
 // ============================================================================
 
-export async function createAndConnectSession(goalId?: string, roleId?: string, personalities?: string[]): Promise<void> {
+export async function createAndConnectSession(goalId?: string, roleId?: string, personalities?: string[], cwd?: string): Promise<void> {
 	if (state.creatingSession) return;
 	state.creatingSession = true;
 	state.creatingSessionForGoalId = goalId || null;
@@ -854,6 +864,7 @@ export async function createAndConnectSession(goalId?: string, roleId?: string, 
 		if (goalId) body.goalId = goalId;
 		if (roleId) body.roleId = roleId;
 		if (personalities && personalities.length > 0) body.personalities = personalities;
+		if (cwd) body.cwd = cwd;
 		const res = await gatewayFetch("/api/sessions", {
 			method: "POST",
 			body: JSON.stringify(body),

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -234,16 +234,13 @@ export async function authenticateGateway(url: string, token: string): Promise<v
 	}
 	renderApp();
 	await refreshSessions();
-	// Fetch default cwd from server
 	try {
-		const cwdRes = await fetch(`${url}/api/config/cwd`, {
-			headers: { Authorization: `Bearer ${token}` },
-		});
+		const cwdRes = await gatewayFetch("/api/config/cwd");
 		if (cwdRes.ok) {
 			const cwdData = await cwdRes.json();
-			if (cwdData.cwd) (state as any).defaultCwd = cwdData.cwd;
+			state.defaultCwd = cwdData.cwd || "";
 		}
-	} catch { /* ignore — server may not support this endpoint yet */ }
+	} catch {}
 	startSessionPolling();
 	startTimeRefresh();
 }

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -17,13 +17,13 @@ import {
 	type KeyBinding,
 	type ShortcutEntry,
 } from "./shortcut-registry.js";
-import { renderApp } from "./state.js";
+import { renderApp, state } from "./state.js";
 import { getRouteFromHash, setHashRoute } from "./routing.js";
 import { gatewayFetch } from "./api.js";
 import { ModelSelector } from "../ui/dialogs/ModelSelector.js";
 
-type SettingsTab = "shortcuts" | "palette" | "models";
-let activeTab: SettingsTab = "shortcuts";
+type SettingsTab = "general" | "shortcuts" | "palette" | "models";
+let activeTab: SettingsTab = "general";
 
 // Rebind state (same as shortcuts-dialog)
 let rebindingId: string | null = null;
@@ -255,6 +255,82 @@ function renderShortcutRow(entry: ShortcutEntry) {
 					</div>
 				`
 			: ""}
+	`;
+}
+
+// ── General tab ──
+
+let settingsCwd = "";
+let settingsCwdLoaded = false;
+let settingsCwdSaved = false;
+let settingsCwdSaveTimer: ReturnType<typeof setTimeout> | null = null;
+
+function loadGeneralSettings(): void {
+	if (settingsCwdLoaded) return;
+	settingsCwd = state.defaultCwd;
+	settingsCwdLoaded = true;
+}
+
+/** Reset general tab state when navigating away, so it reloads fresh next time. */
+export function resetGeneralTabState(): void {
+	settingsCwdLoaded = false;
+	settingsCwd = "";
+	settingsCwdSaved = false;
+	if (settingsCwdSaveTimer) {
+		clearTimeout(settingsCwdSaveTimer);
+		settingsCwdSaveTimer = null;
+	}
+}
+
+async function saveDefaultCwd(): Promise<void> {
+	try {
+		const res = await gatewayFetch("/api/config/cwd", {
+			method: "PUT",
+			body: JSON.stringify({ cwd: settingsCwd }),
+		});
+		if (res.ok) {
+			const data = await res.json();
+			state.defaultCwd = data.cwd;
+			settingsCwdSaved = true;
+			if (settingsCwdSaveTimer) clearTimeout(settingsCwdSaveTimer);
+			settingsCwdSaveTimer = setTimeout(() => {
+				settingsCwdSaved = false;
+				settingsCwdSaveTimer = null;
+				renderApp();
+			}, 2000);
+		}
+	} catch { /* ignore */ }
+	renderApp();
+}
+
+function renderGeneralTab() {
+	loadGeneralSettings();
+	return html`
+		<div class="flex flex-col gap-4">
+			<div class="flex flex-col gap-1.5">
+				<label class="text-sm font-medium text-foreground">Default Working Directory</label>
+				<p class="text-xs text-muted-foreground">
+					The default directory used when creating new sessions and goals without an explicit path.
+				</p>
+				<div class="flex gap-2">
+					<input
+						type="text"
+						class="flex-1 px-3 py-2 rounded-md border border-input bg-background text-foreground text-sm
+							focus:outline-none focus:ring-2 focus:ring-ring"
+						.value=${settingsCwd}
+						placeholder="e.g. /home/user/projects"
+						@input=${(e: Event) => { settingsCwd = (e.target as HTMLInputElement).value; settingsCwdSaved = false; }}
+					/>
+					<button
+						class="px-4 py-2 text-sm rounded-md transition-colors
+							${settingsCwdSaved
+								? "bg-green-600 text-white"
+								: "bg-primary text-primary-foreground hover:bg-primary/90"}"
+						@click=${saveDefaultCwd}
+					>${settingsCwdSaved ? "Saved" : "Save"}</button>
+				</div>
+			</div>
+		</div>
 	`;
 }
 
@@ -772,6 +848,7 @@ export function renderSettingsPage() {
 	updateKeydownListener();
 
 	const tabs: { id: SettingsTab; label: string }[] = [
+		{ id: "general", label: "General" },
 		{ id: "shortcuts", label: "Shortcuts" },
 		{ id: "models", label: "Models" },
 		{ id: "palette", label: "Color Palette" },
@@ -804,6 +881,7 @@ export function renderSettingsPage() {
 			<!-- Tab content -->
 			<div class="flex-1 overflow-y-auto p-4">
 				<div class="${activeTab === "palette" ? "max-w-2xl" : "max-w-xl"}">
+					${activeTab === "general" ? renderGeneralTab() : ""}
 					${activeTab === "models" ? renderModelsTab() : ""}
 					${activeTab === "shortcuts" ? renderShortcutsTab() : ""}
 					${activeTab === "palette" ? renderPaletteTab() : ""}

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -33,6 +33,10 @@ let conflictEntry: ShortcutEntry | null = null;
 let browserReservedWarning = false;
 let _listening = false;
 
+let settingsCwd = "";
+let settingsCwdLoaded = false;
+let settingsCwdSaveStatus: "" | "saving" | "saved" | "error" = "";
+
 function resetRebindState(): void {
 	rebindingId = null;
 	rebindingIndex = null;
@@ -258,81 +262,7 @@ function renderShortcutRow(entry: ShortcutEntry) {
 	`;
 }
 
-// ── General tab ──
-
-let settingsCwd = "";
-let settingsCwdLoaded = false;
-let settingsCwdSaved = false;
-let settingsCwdSaveTimer: ReturnType<typeof setTimeout> | null = null;
-
-function loadGeneralSettings(): void {
-	if (settingsCwdLoaded) return;
-	settingsCwd = state.defaultCwd;
-	settingsCwdLoaded = true;
-}
-
-/** Reset general tab state when navigating away, so it reloads fresh next time. */
-export function resetGeneralTabState(): void {
-	settingsCwdLoaded = false;
-	settingsCwd = "";
-	settingsCwdSaved = false;
-	if (settingsCwdSaveTimer) {
-		clearTimeout(settingsCwdSaveTimer);
-		settingsCwdSaveTimer = null;
-	}
-}
-
-async function saveDefaultCwd(): Promise<void> {
-	try {
-		const res = await gatewayFetch("/api/config/cwd", {
-			method: "PUT",
-			body: JSON.stringify({ cwd: settingsCwd }),
-		});
-		if (res.ok) {
-			const data = await res.json();
-			state.defaultCwd = data.cwd;
-			settingsCwdSaved = true;
-			if (settingsCwdSaveTimer) clearTimeout(settingsCwdSaveTimer);
-			settingsCwdSaveTimer = setTimeout(() => {
-				settingsCwdSaved = false;
-				settingsCwdSaveTimer = null;
-				renderApp();
-			}, 2000);
-		}
-	} catch { /* ignore */ }
-	renderApp();
-}
-
-function renderGeneralTab() {
-	loadGeneralSettings();
-	return html`
-		<div class="flex flex-col gap-4">
-			<div class="flex flex-col gap-1.5">
-				<label class="text-sm font-medium text-foreground">Default Working Directory</label>
-				<p class="text-xs text-muted-foreground">
-					The default directory used when creating new sessions and goals without an explicit path.
-				</p>
-				<div class="flex gap-2">
-					<input
-						type="text"
-						class="flex-1 px-3 py-2 rounded-md border border-input bg-background text-foreground text-sm
-							focus:outline-none focus:ring-2 focus:ring-ring"
-						.value=${settingsCwd}
-						placeholder="e.g. /home/user/projects"
-						@input=${(e: Event) => { settingsCwd = (e.target as HTMLInputElement).value; settingsCwdSaved = false; }}
-					/>
-					<button
-						class="px-4 py-2 text-sm rounded-md transition-colors
-							${settingsCwdSaved
-								? "bg-green-600 text-white"
-								: "bg-primary text-primary-foreground hover:bg-primary/90"}"
-						@click=${saveDefaultCwd}
-					>${settingsCwdSaved ? "Saved" : "Save"}</button>
-				</div>
-			</div>
-		</div>
-	`;
-}
+// ── General tab (see module-level state and renderGeneralTab above) ──
 
 function renderShortcutsTab() {
 	const allShortcuts = getShortcuts();
@@ -843,12 +773,72 @@ function renderModelsTab() {
 	`;
 }
 
+function loadGeneralSettings() {
+	if (settingsCwdLoaded) return;
+	settingsCwd = state.defaultCwd;
+	settingsCwdLoaded = true;
+}
+
+async function saveDefaultCwd(): Promise<void> {
+	settingsCwdSaveStatus = "saving";
+	renderApp();
+	try {
+		const res = await gatewayFetch("/api/config/cwd", {
+			method: "PUT",
+			body: JSON.stringify({ cwd: settingsCwd }),
+		});
+		if (res.ok) {
+			const data = await res.json();
+			state.defaultCwd = data.cwd;
+			settingsCwdSaveStatus = "saved";
+			setTimeout(() => { settingsCwdSaveStatus = ""; renderApp(); }, 2000);
+		} else {
+			settingsCwdSaveStatus = "error";
+		}
+	} catch {
+		settingsCwdSaveStatus = "error";
+	}
+	renderApp();
+}
+
+function renderGeneralTab() {
+	loadGeneralSettings();
+	return html`
+		<div class="flex flex-col gap-4">
+			<div class="flex flex-col gap-1.5">
+				<label class="text-sm font-medium text-foreground">Default Working Directory</label>
+				<p class="text-xs text-muted-foreground">
+					The default directory used when creating new sessions and goals without an explicit path.
+				</p>
+				<div class="flex gap-2">
+					<input
+						type="text"
+						class="flex-1 px-3 py-2 rounded-md border border-input bg-background text-foreground text-sm
+							focus:outline-none focus:ring-2 focus:ring-ring"
+						.value=${settingsCwd}
+						placeholder="e.g. C:\\Users\\you\\projects"
+						@input=${(e: Event) => { settingsCwd = (e.target as HTMLInputElement).value; settingsCwdSaveStatus = ""; renderApp(); }}
+					/>
+					<button
+						class="px-4 py-2 text-sm rounded-md bg-primary text-primary-foreground
+							hover:bg-primary/90 transition-colors disabled:opacity-50"
+						?disabled=${settingsCwdSaveStatus === "saving"}
+						@click=${saveDefaultCwd}
+					>${settingsCwdSaveStatus === "saving" ? "Saving..." : "Save"}</button>
+				</div>
+				${settingsCwdSaveStatus === "saved" ? html`<p class="text-xs text-green-600">Saved successfully.</p>` : ""}
+				${settingsCwdSaveStatus === "error" ? html`<p class="text-xs text-destructive">Failed to save.</p>` : ""}
+			</div>
+		</div>
+	`;
+}
+
 export function renderSettingsPage() {
 	// Manage keydown listener lifecycle
 	updateKeydownListener();
 
 	const tabs: { id: SettingsTab; label: string }[] = [
-		{ id: "general", label: "General" },
+		{ id: "general" as SettingsTab, label: "General" },
 		{ id: "shortcuts", label: "Shortcuts" },
 		{ id: "models", label: "Models" },
 		{ id: "palette", label: "Color Palette" },
@@ -860,7 +850,7 @@ export function renderSettingsPage() {
 			<div class="shrink-0 flex items-center gap-3 px-4 py-3 border-b border-border">
 				<button
 					class="p-1.5 rounded-md hover:bg-secondary transition-colors text-muted-foreground hover:text-foreground"
-					@click=${() => { resetRebindState(); cleanupListener(); toggleSettings(); }}
+					@click=${() => { resetRebindState(); cleanupListener(); settingsCwdLoaded = false; toggleSettings(); }}
 					title="Back"
 				>${icon(ArrowLeft, "sm")}</button>
 				<h1 class="text-lg font-semibold">Settings</h1>

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -37,12 +37,11 @@ let _personalitiesLoaded = false;
 let _pickerRole = "";
 /** Currently selected personalities in the picker. */
 let _pickerPersonalities = new Set<string>();
-/** Goal ID context for the picker (if launched from a goal). */
-let _pickerGoalId: string | undefined;
-/** Cwd picker state for the role picker dropdown. */
 let _pickerCwd = "";
 let _pickerCwdDropdownOpen = false;
 let _pickerCwdHighlightIndex = -1;
+/** Goal ID context for the picker (if launched from a goal). */
+let _pickerGoalId: string | undefined;
 
 async function ensurePersonalitiesLoaded(): Promise<void> {
 	if (_personalitiesLoaded) return;
@@ -88,10 +87,10 @@ export function renderRolePickerDropdown() {
 	const doCreate = () => {
 		state.rolePickerOpen = false;
 		const personalities = [..._pickerPersonalities];
-		createAndConnectSession(_pickerGoalId, _pickerRole || undefined, personalities.length > 0 ? personalities : undefined, _pickerCwd || undefined);
+		const cwd = _pickerCwd || undefined;
 		_pickerCwd = "";
 		_pickerCwdDropdownOpen = false;
-		_pickerCwdHighlightIndex = -1;
+		createAndConnectSession(_pickerGoalId, _pickerRole || undefined, personalities.length > 0 ? personalities : undefined, cwd);
 	};
 
 	return html`
@@ -130,19 +129,17 @@ export function renderRolePickerDropdown() {
 					`)}
 			</div>
 			<!-- Working Directory -->
-			<div class="border-t border-border/50 px-3 py-2">
+			<div class="border-t border-border/50 px-3 py-2" style="overflow: visible;">
 				<div class="text-[10px] text-muted-foreground uppercase tracking-wider font-medium mb-1.5">Working Directory</div>
-				<div style="overflow:visible;">
-					${cwdCombobox({
-						value: _pickerCwd,
-						onInput: (v: string) => { _pickerCwd = v; renderApp(); },
-						onSelect: (v: string) => { _pickerCwd = v; renderApp(); },
-						dropdownOpen: _pickerCwdDropdownOpen,
-						onToggle: (open: boolean) => { _pickerCwdDropdownOpen = open; renderApp(); },
-						highlightedIndex: _pickerCwdHighlightIndex,
-						onHighlight: (i: number) => { _pickerCwdHighlightIndex = i; renderApp(); },
-					})}
-				</div>
+				${cwdCombobox({
+					value: _pickerCwd,
+					onInput: (v: string) => { _pickerCwd = v; renderApp(); },
+					onSelect: (v: string) => { _pickerCwd = v; _pickerCwdDropdownOpen = false; renderApp(); },
+					dropdownOpen: _pickerCwdDropdownOpen,
+					onToggle: (open: boolean) => { _pickerCwdDropdownOpen = open; renderApp(); },
+					highlightedIndex: _pickerCwdHighlightIndex,
+					onHighlight: (i: number) => { _pickerCwdHighlightIndex = i; renderApp(); },
+				})}
 			</div>
 			<!-- Create button -->
 			<div class="border-t border-border/50 px-3 py-2">

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -18,6 +18,7 @@ import {
 	type GoalState,
 } from "./state.js";
 import { createAndConnectSession, connectToSession } from "./session-manager.js";
+import { cwdCombobox } from "./cwd-combobox.js";
 import { showGoalDialog } from "./dialogs.js";
 import { refreshSessions, fetchRoles, fetchPersonalities, fetchStaff, wakeStaffAgent, fetchArchivedSessions, type PersonalityData } from "./api.js";
 import { statusBobbit, sessionAcronym } from "./session-colors.js";
@@ -37,6 +38,10 @@ let _pickerRole = "";
 let _pickerPersonalities = new Set<string>();
 /** Goal ID context for the picker (if launched from a goal). */
 let _pickerGoalId: string | undefined;
+/** Cwd picker state for the role picker dropdown. */
+let _pickerCwd = "";
+let _pickerCwdDropdownOpen = false;
+let _pickerCwdHighlightIndex = -1;
 
 async function ensurePersonalitiesLoaded(): Promise<void> {
 	if (_personalitiesLoaded) return;
@@ -54,6 +59,9 @@ export async function toggleRolePicker(e: Event, goalId?: string): Promise<void>
 	}
 	_pickerRole = "";
 	_pickerPersonalities = new Set();
+	_pickerCwd = "";
+	_pickerCwdDropdownOpen = false;
+	_pickerCwdHighlightIndex = -1;
 	_pickerGoalId = goalId;
 	if (state.roles.length === 0) await fetchRoles();
 	await ensurePersonalitiesLoaded();
@@ -79,7 +87,10 @@ export function renderRolePickerDropdown() {
 	const doCreate = () => {
 		state.rolePickerOpen = false;
 		const personalities = [..._pickerPersonalities];
-		createAndConnectSession(_pickerGoalId, _pickerRole || undefined, personalities.length > 0 ? personalities : undefined);
+		createAndConnectSession(_pickerGoalId, _pickerRole || undefined, personalities.length > 0 ? personalities : undefined, _pickerCwd || undefined);
+		_pickerCwd = "";
+		_pickerCwdDropdownOpen = false;
+		_pickerCwdHighlightIndex = -1;
 	};
 
 	return html`
@@ -116,6 +127,21 @@ export function renderRolePickerDropdown() {
 							${_pickerRole === role.name ? html`<span class="text-primary text-xs">✓</span>` : ""}
 						</button>
 					`)}
+			</div>
+			<!-- Working Directory -->
+			<div class="border-t border-border/50 px-3 py-2">
+				<div class="text-[10px] text-muted-foreground uppercase tracking-wider font-medium mb-1.5">Working Directory</div>
+				<div style="overflow:visible;">
+					${cwdCombobox({
+						value: _pickerCwd,
+						onInput: (v: string) => { _pickerCwd = v; renderApp(); },
+						onSelect: (v: string) => { _pickerCwd = v; renderApp(); },
+						dropdownOpen: _pickerCwdDropdownOpen,
+						onToggle: (open: boolean) => { _pickerCwdDropdownOpen = open; renderApp(); },
+						highlightedIndex: _pickerCwdHighlightIndex,
+						onHighlight: (i: number) => { _pickerCwdHighlightIndex = i; renderApp(); },
+					})}
+				</div>
 			</div>
 			<!-- Create button -->
 			<div class="border-t border-border/50 px-3 py-2">

--- a/src/app/staff-page.ts
+++ b/src/app/staff-page.ts
@@ -537,7 +537,7 @@ function renderEditView(): TemplateResult {
 					${Input({
 						type: "text",
 						value: editCwd,
-						placeholder: (state as any).defaultCwd || "(server default)",
+						placeholder: state.defaultCwd || "(server default)",
 						onInput: (e: Event) => { editCwd = (e.target as HTMLInputElement).value; renderApp(); },
 					})}
 				</div>

--- a/src/app/staff-page.ts
+++ b/src/app/staff-page.ts
@@ -537,7 +537,7 @@ function renderEditView(): TemplateResult {
 					${Input({
 						type: "text",
 						value: editCwd,
-						placeholder: "(server default)",
+						placeholder: (state as any).defaultCwd || "(server default)",
 						onInput: (e: Event) => { editCwd = (e.target as HTMLInputElement).value; renderApp(); },
 					})}
 				</div>

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -117,6 +117,9 @@ export const state = {
 	connectingSessionId: null as string | null,
 	sessionPollTimer: null as ReturnType<typeof setInterval> | null,
 
+	/** Persisted default working directory from server */
+	defaultCwd: "",
+
 	/** Whether the sidebar is collapsed */
 	sidebarCollapsed: localStorage.getItem("bobbit-sidebar-collapsed") === "true",
 	/** Whether to show archived sessions in the sidebar */
@@ -216,9 +219,6 @@ export const state = {
 	staffPreviewTriggersEdited: false,
 	staffPreviewCwdEdited: false,
 	staffPreviewPromptEditMode: false,
-
-	/** Server's default working directory */
-	defaultCwd: "",
 
 	/** Cached roles for the role picker menu */
 	roles: [] as Array<{ name: string; label: string; accessory: string }>,

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -217,6 +217,9 @@ export const state = {
 	staffPreviewCwdEdited: false,
 	staffPreviewPromptEditMode: false,
 
+	/** Server's default working directory */
+	defaultCwd: "",
+
 	/** Cached roles for the role picker menu */
 	roles: [] as Array<{ name: string; label: string; accessory: string }>,
 	/** Whether the new-session role picker dropdown is open */

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -305,6 +305,12 @@ export function createGateway(config: GatewayConfig) {
 			// any agent subprocesses start.
 			await startupAigwCheck(preferencesStore);
 
+			// Restore persisted defaultCwd preference
+			const savedCwd = preferencesStore.get("defaultCwd");
+			if (savedCwd && typeof savedCwd === "string") {
+				config.defaultCwd = savedCwd;
+			}
+
 			// Restore persisted sessions before accepting connections
 			await sessionManager.restoreSessions();
 			sessionManager.startPurgeSchedule();
@@ -766,6 +772,27 @@ async function handleApiRoute(
 			json({ ok: true });
 			return;
 		}
+	}
+
+	// ── Config: default cwd ──
+
+	// GET /api/config/cwd
+	if (url.pathname === "/api/config/cwd" && req.method === "GET") {
+		json({ cwd: config.defaultCwd });
+		return;
+	}
+
+	// PUT /api/config/cwd
+	if (url.pathname === "/api/config/cwd" && req.method === "PUT") {
+		const body = await readBody(req);
+		if (!body?.cwd || typeof body.cwd !== "string") {
+			json({ error: "Missing or invalid cwd" }, 400);
+			return;
+		}
+		config.defaultCwd = body.cwd;
+		preferencesStore.set("defaultCwd", body.cwd);
+		json({ cwd: config.defaultCwd });
+		return;
 	}
 
 	// ── Preferences ──

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -115,6 +115,10 @@ export function createGateway(config: GatewayConfig) {
 
 	const colorStore = new ColorStore();
 	const preferencesStore = new PreferencesStore();
+	const savedCwd = preferencesStore.get("defaultCwd");
+	if (savedCwd && typeof savedCwd === "string") {
+		config.defaultCwd = savedCwd;
+	}
 	const personalityStore = new PersonalityStore();
 	const personalityManager = new PersonalityManager(personalityStore);
 	fs.mkdirSync(bobbitStateDir(), { recursive: true });
@@ -304,12 +308,6 @@ export function createGateway(config: GatewayConfig) {
 			// Runs before session restore so models.json is written before
 			// any agent subprocesses start.
 			await startupAigwCheck(preferencesStore);
-
-			// Restore persisted defaultCwd preference
-			const savedCwd = preferencesStore.get("defaultCwd");
-			if (savedCwd && typeof savedCwd === "string") {
-				config.defaultCwd = savedCwd;
-			}
 
 			// Restore persisted sessions before accepting connections
 			await sessionManager.restoreSessions();


### PR DESCRIPTION
## Summary

Four related improvements to the working directory selection experience:

1. **Expose default cwd to client** — New `GET/PUT /api/config/cwd` endpoints. Client fetches on startup and uses actual path as placeholder instead of "(server default)".

2. **Settings page General tab** — New "General" tab (default) with Default Working Directory text input + Save button. Persists via preferencesStore.

3. **Cwd picker in session popover** — Added cwdCombobox to the role picker dropdown. `createAndConnectSession()` now accepts and passes a `cwd` parameter.

4. **Filter worktrees from dropdown** — `getRecentCwds()` now excludes worktree paths (`-wt/`), team agent sessions, and goal assistant sessions.

### Files changed
- `src/server/server.ts` — API endpoints + startup restore
- `src/app/state.ts` — `defaultCwd` field
- `src/app/settings-page.ts` — General tab
- `src/app/cwd-combobox.ts` — filtering + smart placeholder
- `src/app/sidebar.ts` — cwd picker in popover
- `src/app/session-manager.ts` — cwd param + startup fetch
- `src/app/render.ts` — removed hardcoded placeholders
- `src/app/staff-page.ts` — dynamic placeholder

### Testing
- `npm run check` passes
- Unit tests pass
- E2E tests pass