### PR TITLE
Project Setup Assistant

### DIFF
--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -921,6 +921,29 @@ export async function deleteRole(name: string): Promise<boolean> {
 }
 
 // ============================================================================
+// SETUP STATUS API
+// ============================================================================
+
+export async function fetchSetupStatus(): Promise<boolean> {
+	try {
+		const res = await gatewayFetch("/api/setup-status");
+		if (!res.ok) return true; // assume complete on error
+		const data = await res.json();
+		return data.complete;
+	} catch {
+		return true;
+	}
+}
+
+export async function dismissSetup(): Promise<void> {
+	try {
+		await gatewayFetch("/api/setup-status/dismiss", { method: "POST" });
+	} catch { /* ignore */ }
+	state.setupComplete = true;
+	renderApp();
+}
+
+// ============================================================================
 // DRAFT API
 // ============================================================================
 

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -9,7 +9,7 @@ import {
 	GW_TOKEN_KEY,
 	activeSessionId,
 } from "./state.js";
-import { gatewayFetch, refreshSessions } from "./api.js";
+import { gatewayFetch, refreshSessions, fetchSetupStatus } from "./api.js";
 import { getRouteFromHash, setHashRoute } from "./routing.js";
 import { authenticateGateway, connectToSession, createAndConnectSession, terminateSession } from "./session-manager.js";
 import { doRenderApp } from "./render.js";
@@ -292,6 +292,13 @@ async function initApp() {
 					import("./aigw-config.js").then(({ applyAigwConfig }) => applyAigwConfig(prefs));
 				}
 			} catch {}
+
+			// Load setup wizard status
+			try {
+				state.setupComplete = await fetchSetupStatus();
+			} catch {
+				state.setupComplete = true; // safe default
+			}
 
 			const route = getRouteFromHash();
 			if (route.view === "goal" && route.goalId) {

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -9,7 +9,7 @@ import {
 	GW_TOKEN_KEY,
 	activeSessionId,
 } from "./state.js";
-import { gatewayFetch, refreshSessions, fetchSetupStatus } from "./api.js";
+import { gatewayFetch, refreshSessions } from "./api.js";
 import { getRouteFromHash, setHashRoute } from "./routing.js";
 import { authenticateGateway, connectToSession, createAndConnectSession, terminateSession } from "./session-manager.js";
 import { doRenderApp } from "./render.js";
@@ -292,13 +292,6 @@ async function initApp() {
 					import("./aigw-config.js").then(({ applyAigwConfig }) => applyAigwConfig(prefs));
 				}
 			} catch {}
-
-			// Load setup wizard status
-			try {
-				state.setupComplete = await fetchSetupStatus();
-			} catch {
-				state.setupComplete = true; // safe default
-			}
 
 			const route = getRouteFromHash();
 			if (route.view === "goal" && route.goalId) {

--- a/src/app/proposal-parsers.ts
+++ b/src/app/proposal-parsers.ts
@@ -36,4 +36,10 @@ export const PROPOSAL_PARSERS: ProposalParser[] = [
 		requiredFields: ["name", "prompt"],
 		callbackName: "onStaffProposal",
 	},
+	{
+		tag: "setup_proposal",
+		fields: ["action", "content"],
+		requiredFields: ["action", "content"],
+		callbackName: "onSetupProposal",
+	},
 ];

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -92,6 +92,8 @@ export class RemoteAgent {
 	onPersonalityProposal?: (proposal: { name: string; label: string; description: string; prompt_fragment: string }) => void;
 	/** Callback fired when a staff proposal is detected in an assistant message. */
 	onStaffProposal?: (proposal: { name: string; description: string; prompt: string; triggers: string; cwd: string }) => void;
+	/** Callback fired when a setup proposal is detected in an assistant message. */
+	onSetupProposal?: (proposal: { action: string; content: string }) => void;
 	/** Callback fired when tool execution updates (for real-time progress). */
 	onWorkflowUpdate?: () => void;
 	/** Callback fired when the server-side prompt queue changes. */

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -16,30 +16,16 @@ import {
 
 	resetArchivedExpandState,
 } from "./state.js";
-import { createGoal, createRole, gatewayFetch, refreshSessions, fetchSetupStatus, dismissSetup } from "./api.js";
+import { createGoal, createRole, gatewayFetch, refreshSessions, dismissSetup } from "./api.js";
 import { clearSessionModel } from "./routing.js";
 import { backToSessions, createAndConnectSession, connectToSession, terminateSession, saveGoalDraft, deleteGoalDraft, saveRoleDraft, deleteRoleDraft } from "./session-manager.js";
 import { openGatewayDialog, showQrCodeDialog, showRenameDialog, showGoalDialog } from "./dialogs.js";
-import { renderSidebar, toggleRolePicker, renderRolePickerDropdown, renderStaffSidebarSection, renderSetupBanner } from "./sidebar.js";
+import { renderSidebar, toggleRolePicker, renderRolePickerDropdown, renderStaffSidebarSection, renderSetupBanner, launchSetupWizard } from "./sidebar.js";
 
 import { renderGoalGroup, renderSessionRow, renderArchivedSessionRow, renderArchivedDelegates, INDENT } from "./render-helpers.js";
 
 const bobbitIcon = html`<img src="/favicon.svg" alt="" style="width:20px;height:18px;image-rendering:pixelated;" />`;
 
-async function launchSetupWizard(): Promise<void> {
-	try {
-		const res = await gatewayFetch("/api/sessions", {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ assistantType: "setup" }),
-		});
-		if (!res.ok) throw new Error(`Failed: ${res.status}`);
-		const { id } = await res.json();
-		await connectToSession(id, false, { assistantType: "setup" });
-	} catch (err) {
-		console.error("[setup] Failed to create setup assistant session:", err);
-	}
-}
 
 function skipSetup(): void {
 	dismissSetup();

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -4,7 +4,7 @@ import { icon } from "@mariozechner/mini-lit";
 import { Button } from "@mariozechner/mini-lit/dist/Button.js";
 import { Input } from "@mariozechner/mini-lit/dist/Input.js";
 import { html, render } from "lit";
-import { Archive, ArrowLeft, MessagesSquare, ChevronDown, ChevronRight, Drama, Goal as GoalIcon, PanelRightClose, PanelRightOpen, Pencil, Plus, QrCode, Server, Settings, Trash2, Unplug, UserCheck, Users, Workflow as WorkflowIcon, Wrench } from "lucide";
+import { Archive, ArrowLeft, MessagesSquare, ChevronDown, ChevronRight, Drama, Goal as GoalIcon, PanelRightClose, PanelRightOpen, Pencil, Plus, QrCode, Server, Settings, Trash2, Unplug, UserCheck, Users, WandSparkles, Workflow as WorkflowIcon, Wrench } from "lucide";
 import {
 	state,
 	renderApp,
@@ -16,15 +16,34 @@ import {
 
 	resetArchivedExpandState,
 } from "./state.js";
-import { createGoal, createRole, gatewayFetch, refreshSessions } from "./api.js";
+import { createGoal, createRole, gatewayFetch, refreshSessions, fetchSetupStatus, dismissSetup } from "./api.js";
 import { clearSessionModel } from "./routing.js";
 import { backToSessions, createAndConnectSession, connectToSession, terminateSession, saveGoalDraft, deleteGoalDraft, saveRoleDraft, deleteRoleDraft } from "./session-manager.js";
 import { openGatewayDialog, showQrCodeDialog, showRenameDialog, showGoalDialog } from "./dialogs.js";
-import { renderSidebar, toggleRolePicker, renderRolePickerDropdown, renderStaffSidebarSection } from "./sidebar.js";
+import { renderSidebar, toggleRolePicker, renderRolePickerDropdown, renderStaffSidebarSection, renderSetupBanner } from "./sidebar.js";
 
 import { renderGoalGroup, renderSessionRow, renderArchivedSessionRow, renderArchivedDelegates, INDENT } from "./render-helpers.js";
 
 const bobbitIcon = html`<img src="/favicon.svg" alt="" style="width:20px;height:18px;image-rendering:pixelated;" />`;
+
+async function launchSetupWizard(): Promise<void> {
+	try {
+		const res = await gatewayFetch("/api/sessions", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ assistantType: "setup" }),
+		});
+		if (!res.ok) throw new Error(`Failed: ${res.status}`);
+		const { id } = await res.json();
+		await connectToSession(id, false, { assistantType: "setup" });
+	} catch (err) {
+		console.error("[setup] Failed to create setup assistant session:", err);
+	}
+}
+
+function skipSetup(): void {
+	dismissSetup();
+}
 
 import { cwdCombobox } from "./cwd-combobox.js";
 
@@ -91,6 +110,7 @@ function renderMobileLanding() {
 						</button>
 					</div>
 				</div>
+				${renderSetupBanner(true)}
 				${state.sessionsLoading
 					? html`<div class="text-center py-12 text-muted-foreground text-xs">Loading…</div>`
 					: state.sessionsError
@@ -99,7 +119,19 @@ function renderMobileLanding() {
 								<button class="text-xs text-muted-foreground underline" title="Retry" @click=${refreshSessions}>Retry</button>
 							</div>`
 						: state.goals.length === 0 && state.gatewaySessions.length === 0
-							? html`<div class="text-center py-12">
+							? !state.setupComplete
+								? html`<div class="text-center py-12">
+										<div class="text-muted-foreground mb-3 empty-state-icon">${icon(WandSparkles, "lg")}</div>
+										<p class="text-lg font-medium text-foreground mb-1">Welcome to Bobbit</p>
+										<p class="text-sm text-muted-foreground mb-4">Set up your project to get the best results from AI agents</p>
+										${Button({
+											variant: "default",
+											onClick: () => launchSetupWizard(),
+											children: html`<span class="inline-flex items-center gap-1.5">${icon(WandSparkles, "sm")} Start Setup</span>`,
+										})}
+										<button class="block mx-auto mt-3 text-xs text-muted-foreground hover:underline cursor-pointer bg-transparent border-none" @click=${skipSetup}>Skip setup</button>
+									</div>`
+								: html`<div class="text-center py-12">
 									<div class="text-muted-foreground mb-3 empty-state-icon">${icon(Server, "lg")}</div>
 									<p class="text-base text-muted-foreground mb-4">No goals or sessions yet</p>
 									<div class="flex items-center justify-center gap-2">
@@ -1988,6 +2020,21 @@ export function doRenderApp(): void {
 		if (connected) return html`${reconnectBanner()}${renderArchivedBanner()}${state.chatPanel}`;
 
 		if (desktop) {
+			if (!state.setupComplete) {
+				return html`
+					<div class="flex-1 flex flex-col items-center justify-center gap-4 p-8 text-center">
+						<div class="text-muted-foreground empty-state-icon">${icon(WandSparkles, "lg")}</div>
+						<p class="text-lg font-medium text-foreground">Welcome to Bobbit</p>
+						<p class="text-sm text-muted-foreground">Set up your project to get the best results from AI agents</p>
+						${Button({
+							variant: "default",
+							onClick: () => launchSetupWizard(),
+							children: html`<span class="inline-flex items-center gap-1.5">${icon(WandSparkles, "sm")} Start Setup</span>`,
+						})}
+						<button class="text-xs text-muted-foreground hover:underline cursor-pointer bg-transparent border-none" @click=${skipSetup}>Skip setup</button>
+					</div>
+				`;
+			}
 			return html`
 				<div class="flex-1 flex flex-col items-center justify-center gap-4 p-8 text-center">
 					<div class="text-muted-foreground empty-state-icon">${icon(Server, "lg")}</div>

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -219,6 +219,10 @@ export async function authenticateGateway(url: string, token: string): Promise<v
 	// AI Gateway: the gateway handles LLM auth; Anthropic OAuth endpoints
 	// are likely unreachable on air-gapped networks anyway.
 	const healthData = await healthRes.json();
+	// Extract setup status from health response (avoids extra fetch)
+	if (typeof healthData.setupComplete === "boolean") {
+		state.setupComplete = healthData.setupComplete;
+	}
 	if (!healthData.localhost && !healthData.aigw) {
 		const hasAuth = await checkOAuthStatus();
 		if (!hasAuth) {
@@ -560,6 +564,13 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			}
 			savePersonalityDraft(sessionId);
 			renderApp();
+		};
+
+		remote.onSetupProposal = (proposal) => {
+			if (proposal.action === "complete") {
+				state.setupComplete = true;
+				renderApp();
+			}
 		};
 
 		remote.onStaffProposal = (proposal) => {

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -839,6 +839,7 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			tool: "Start the tool assistant session. Help me document, improve, or create tools.",
 			personality: "Start the personality creation session.",
 			staff: "Start the staff agent creation session.",
+			setup: "Start the project setup session.",
 		};
 		if (state.assistantType && !isExisting) {
 			const autoPrompt = AUTO_PROMPTS[state.assistantType];

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -336,7 +336,7 @@ export function renderStaffSidebarSection() {
 // SETUP WIZARD BANNER
 // ============================================================================
 
-async function launchSetupWizard(): Promise<void> {
+export async function launchSetupWizard(): Promise<void> {
 	try {
 		const res = await gatewayFetch("/api/sessions", {
 			method: "POST",

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -1,6 +1,6 @@
 import { icon } from "@mariozechner/mini-lit";
 import { html } from "lit";
-import { Archive, Bot, ChevronDown, ChevronRight, Drama, Goal as GoalIcon, List, MessagesSquare, PanelLeftClose, PanelLeftOpen, Pencil, Plus, Settings, Users, Workflow, Wrench } from "lucide";
+import { Archive, Bot, ChevronDown, ChevronRight, Drama, Goal as GoalIcon, List, MessagesSquare, PanelLeftClose, PanelLeftOpen, Pencil, Plus, Settings, Users, WandSparkles, Workflow, Wrench, X } from "lucide";
 import {
 	state,
 	renderApp,
@@ -19,7 +19,7 @@ import {
 } from "./state.js";
 import { createAndConnectSession, connectToSession } from "./session-manager.js";
 import { showGoalDialog } from "./dialogs.js";
-import { refreshSessions, fetchRoles, fetchPersonalities, fetchStaff, wakeStaffAgent, fetchArchivedSessions, type PersonalityData } from "./api.js";
+import { refreshSessions, fetchRoles, fetchPersonalities, fetchStaff, wakeStaffAgent, fetchArchivedSessions, dismissSetup, gatewayFetch, type PersonalityData } from "./api.js";
 import { statusBobbit, sessionAcronym } from "./session-colors.js";
 import { renderGoalGroup, renderSessionRow, renderArchivedSessionRow, renderArchivedDelegates, showSessionTooltip, hideSessionTooltip, SESSION_ROW_PY, INDENT, CHEVRON_W, HEADER_CHEVRON_W, terseRelativeTime, hasUnseenActivity, formatSessionAge } from "./render-helpers.js";
 import type { GatewaySession } from "./state.js";
@@ -310,6 +310,46 @@ export function renderStaffSidebarSection() {
 // renderArchivedSessionRow is now in render-helpers.ts
 
 // ============================================================================
+// SETUP WIZARD BANNER
+// ============================================================================
+
+async function launchSetupWizard(): Promise<void> {
+	try {
+		const res = await gatewayFetch("/api/sessions", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ assistantType: "setup" }),
+		});
+		if (!res.ok) throw new Error(`Failed: ${res.status}`);
+		const { id } = await res.json();
+		await connectToSession(id, false, { assistantType: "setup" });
+	} catch (err) {
+		console.error("[setup] Failed to create setup assistant session:", err);
+	}
+}
+
+export function renderSetupBanner(mobile = false) {
+	if (state.setupComplete) return "";
+	return html`
+		<div class="flex items-center gap-1 ${mobile ? "px-2 py-1.5 mx-1 mb-1" : "px-1.5 py-1 mx-0.5 mb-0.5"} rounded-md border border-primary/20 bg-primary/5">
+			<button
+				class="flex-1 flex items-center gap-1.5 ${mobile ? "text-sm" : "text-xs"} text-primary hover:text-primary/80 transition-colors font-medium cursor-pointer bg-transparent border-none p-0"
+				@click=${launchSetupWizard}
+				title="Set up your project for AI agents"
+			>
+				${icon(WandSparkles, mobile ? "sm" : "xs")}
+				<span>Setup Wizard</span>
+			</button>
+			<button
+				class="${mobile ? "p-1.5" : "p-0.5"} rounded text-muted-foreground hover:text-foreground transition-colors cursor-pointer bg-transparent border-none"
+				@click=${(e: Event) => { e.stopPropagation(); dismissSetup(); }}
+				title="Dismiss setup wizard"
+			>${icon(X, "xs")}</button>
+		</div>
+	`;
+}
+
+// ============================================================================
 // RENDER SIDEBAR
 // ============================================================================
 
@@ -373,6 +413,7 @@ export function renderSidebar() {
 					</button>
 				</div>
 			</div>
+			${renderSetupBanner()}
 			<div class="flex-1 overflow-y-auto flex flex-col gap-0.5 py-2 px-0.5">
 				${state.sessionsLoading
 					? html`<div class="text-center py-6 text-muted-foreground text-xs">Loading…</div>`

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -217,6 +217,9 @@ export const state = {
 	staffPreviewCwdEdited: false,
 	staffPreviewPromptEditMode: false,
 
+	/** Whether the setup wizard has been completed (safe default: true — don't show banner until we know) */
+	setupComplete: true,
+
 	/** Cached roles for the role picker menu */
 	roles: [] as Array<{ name: string; label: string; accessory: string }>,
 	/** Whether the new-session role picker dropdown is open */

--- a/src/server/agent/assistant-registry.ts
+++ b/src/server/agent/assistant-registry.ts
@@ -3,6 +3,7 @@ import { ROLE_ASSISTANT_PROMPT } from "./role-assistant.js";
 import { TOOL_ASSISTANT_PROMPT } from "./tool-assistant.js";
 import { PERSONALITY_ASSISTANT_PROMPT } from "./personality-assistant.js";
 import { STAFF_ASSISTANT_PROMPT } from "./staff-assistant.js";
+import { SETUP_ASSISTANT_PROMPT } from "./setup-assistant.js";
 
 export interface AssistantDef {
 	type: string;
@@ -41,6 +42,12 @@ export const ASSISTANT_REGISTRY: Record<string, AssistantDef> = {
 		title: "Staff Assistant",
 		promptTitle: "Staff Agent Creation Assistant",
 		prompt: STAFF_ASSISTANT_PROMPT,
+	},
+	setup: {
+		type: "setup",
+		title: "Setup Wizard",
+		promptTitle: "Project Setup Assistant",
+		prompt: SETUP_ASSISTANT_PROMPT,
 	},
 };
 

--- a/src/server/agent/setup-assistant.ts
+++ b/src/server/agent/setup-assistant.ts
@@ -1,0 +1,135 @@
+/**
+ * System prompt for project setup assistant sessions.
+ *
+ * Guides users through configuring Bobbit for a new project directory.
+ * Explores the project structure, asks targeted questions, and writes
+ * configuration to .bobbit/config/.
+ */
+
+export const SETUP_ASSISTANT_PROMPT = `You are a project setup assistant for Bobbit, a remote coding agent gateway. Your job is to explore the user's project and configure Bobbit optimally for it.
+
+You have full access to the filesystem. Use your tools to read files and write configuration directly. Do the work — don't just explain what to do.
+
+## First message
+
+When you receive the initial prompt, greet briefly (1-2 sentences), then immediately start exploring the project. Do NOT wait for the user to respond before exploring.
+
+## Exploration phase
+
+Start by reading these files in parallel (use parallel tool calls for speed):
+- \`package.json\` — detect language, framework, dependencies, build/test scripts
+- \`tsconfig.json\` or \`tsconfig*.json\` — TypeScript configuration
+- \`Makefile\`, \`CMakeLists.txt\`, \`build.gradle\`, \`pom.xml\`, \`Cargo.toml\`, \`go.mod\`, \`pyproject.toml\`, \`requirements.txt\` — build system detection
+- \`.bobbit/config/system-prompt.md\` — check for existing configuration
+- Directory listing of the project root — understand overall structure
+
+Also run \`ls src/\` or equivalent to understand the source code layout.
+
+From this exploration, identify:
+1. **Language and framework** (e.g. TypeScript + Node.js, Python + Django, Rust + Tokio)
+2. **Build command** (e.g. \`npm run build\`, \`cargo build\`, \`make\`)
+3. **Test command** (e.g. \`npm test\`, \`pytest\`, \`cargo test\`)
+4. **Type-check command** if applicable (e.g. \`npm run check\`, \`mypy\`)
+5. **Linting/formatting** tools in use
+6. **Project structure** — monorepo vs single package, key directories
+
+## Questions phase
+
+After exploration, ask 2-3 targeted questions about working style. Keep them concise and multiple-choice where possible. Examples:
+
+- "What's your quality bar? (a) Move fast, fix later (b) Production-critical, test everything (c) Balanced — tests for important paths"
+- "Build discipline: should agents always build after changes, or only before committing?"
+- "Any special constraints? (e.g. no external dependencies, specific coding style, restricted directories)"
+
+Adapt questions based on what you discovered — don't ask about build commands if you already found them.
+
+## Configuration phase
+
+Based on exploration and answers, write configuration:
+
+### System prompt (\`.bobbit/config/system-prompt.md\`)
+
+**CRITICAL: Never overwrite existing custom content.** If the file already has custom content beyond the default template:
+1. Read the existing content
+2. Append a new section with project-specific directives
+3. Write the combined content
+
+If the file only contains the default template (or doesn't exist), you may write a fresh version that includes both the default preamble and project-specific sections.
+
+Add a \`# Project Context\` section with:
+- Language/framework identification
+- Build, test, and type-check commands
+- Key directories and their purposes
+- Quality expectations and working style notes
+- Any special constraints the user mentioned
+
+Example section to add:
+\`\`\`markdown
+# Project Context
+
+Project-specific instructions and guidelines:
+
+## Build & Test
+
+- **Build**: \`npm run build\`
+- **Test**: \`npm test\`
+- **Type-check**: \`npm run check\`
+- Always run type-check before committing.
+
+## Stack
+
+- TypeScript + Node.js backend
+- Lit web components frontend
+- Playwright for testing
+
+## Quality
+
+- Production-critical code — test all important paths
+- No external dependencies without discussion
+\`\`\`
+
+After writing the system prompt, emit a progress block:
+
+<setup_proposal>
+<action>system-prompt</action>
+<content>Updated system prompt with project context: [language], [framework], build/test commands, quality preferences.</content>
+</setup_proposal>
+
+### Model preferences
+
+If the user expresses preferences about AI model or behavior, write them via the preferences store. For most projects, skip this unless the user specifically asks.
+
+If you do write preferences, emit:
+
+<setup_proposal>
+<action>preferences</action>
+<content>Set model preferences: [details].</content>
+</setup_proposal>
+
+## Completion
+
+When all configuration is written:
+
+1. Write the sentinel file to mark setup as complete:
+   \`\`\`bash
+   echo "complete" > .bobbit/state/setup-complete
+   \`\`\`
+
+2. Emit the completion block:
+
+<setup_proposal>
+<action>complete</action>
+<content>Project setup complete. Configured: [summary of what was set up].</content>
+</setup_proposal>
+
+3. Give a brief summary of what was configured and mention they can re-run the setup wizard anytime or edit \`.bobbit/config/system-prompt.md\` directly.
+
+## Guidelines
+
+- Be concise and efficient — don't over-explain
+- Use parallel tool calls to explore quickly
+- Don't ask questions you can answer from the project files
+- If the project is already well-configured, say so and make minimal changes
+- The setup should take 2-3 exchanges at most, not a long conversation
+- Never create roles, workflows, tools, or do any actual coding work
+- Focus only on system prompt directives and project context`;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5,7 +5,8 @@ import fs from "node:fs";
 import http from "node:http";
 import https from "node:https";
 import path from "node:path";
-import { bobbitStateDir } from "./bobbit-dir.js";
+import { fileURLToPath } from "node:url";
+import { bobbitStateDir, bobbitConfigDir } from "./bobbit-dir.js";
 import { WebSocketServer } from "ws";
 import { ColorStore } from "./agent/color-store.js";
 import { SessionManager } from "./agent/session-manager.js";
@@ -351,6 +352,31 @@ export function createGateway(config: GatewayConfig) {
 	};
 }
 
+/** Check if project setup has been completed (sentinel exists or system-prompt.md has been customized). */
+function isSetupComplete(): boolean {
+	// Check sentinel file
+	const sentinelPath = path.join(bobbitStateDir(), "setup-complete");
+	if (fs.existsSync(sentinelPath)) return true;
+
+	// Check if system-prompt.md has been customized beyond the default template
+	const systemPromptPath = path.join(bobbitConfigDir(), "system-prompt.md");
+	if (!fs.existsSync(systemPromptPath)) return false;
+
+	// Compare with default template — if the file differs, setup is considered done
+	const defaultTemplatePath = path.join(path.dirname(fileURLToPath(import.meta.url)), "defaults", "system-prompt.md");
+	if (!fs.existsSync(defaultTemplatePath)) {
+		// Can't find default template; if the file exists at all, assume customized
+		return true;
+	}
+	try {
+		const current = fs.readFileSync(systemPromptPath, "utf-8");
+		const defaultContent = fs.readFileSync(defaultTemplatePath, "utf-8");
+		return current.trim() !== defaultContent.trim();
+	} catch {
+		return false;
+	}
+}
+
 async function handleApiRoute(
 	url: URL,
 	req: http.IncomingMessage,
@@ -379,7 +405,22 @@ async function handleApiRoute(
 	// GET /api/health — unauthenticated so the client can probe localhost mode
 	if (url.pathname === "/api/health" && req.method === "GET") {
 		const isLocalhost = !config.forceAuth && (config.host === "localhost" || config.host === "127.0.0.1" || config.host === "::1");
-		json({ status: "ok", sessions: sessionManager.listSessions().length, localhost: isLocalhost, aigw: !!getAigwUrl(preferencesStore) });
+		json({ status: "ok", sessions: sessionManager.listSessions().length, localhost: isLocalhost, aigw: !!getAigwUrl(preferencesStore), setupComplete: isSetupComplete() });
+		return;
+	}
+
+	// GET /api/setup-status — check if project setup has been completed
+	if (url.pathname === "/api/setup-status" && req.method === "GET") {
+		json({ complete: isSetupComplete() });
+		return;
+	}
+
+	// POST /api/setup-status/dismiss — mark setup as dismissed (writes sentinel file)
+	if (url.pathname === "/api/setup-status/dismiss" && req.method === "POST") {
+		const stateDir = bobbitStateDir();
+		fs.mkdirSync(stateDir, { recursive: true });
+		fs.writeFileSync(path.join(stateDir, "setup-complete"), "dismissed\n");
+		json({ ok: true });
 		return;
 	}
 

--- a/tests/e2e/setup-status.spec.ts
+++ b/tests/e2e/setup-status.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * E2E tests for the Setup Status REST API.
+ *
+ * Tests run against an isolated gateway with its own BOBBIT_DIR.
+ * Verifies GET /api/setup-status, POST /api/setup-status/dismiss,
+ * GET /api/health setupComplete field, and setup assistant session creation.
+ */
+import { test, expect } from "@playwright/test";
+import { existsSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { apiFetch, BASE, E2E_BOBBIT_DIR, createSession, deleteSession, nonGitCwd } from "./e2e-setup.js";
+
+// Run tests serially — dismiss test modifies shared state (sentinel file)
+test.describe.configure({ mode: "serial" });
+
+/** Path to the setup-complete sentinel file in the E2E state dir. */
+const SENTINEL_PATH = join(E2E_BOBBIT_DIR, "state", "setup-complete");
+
+/** Remove sentinel file to reset setup status. */
+function removeSentinel() {
+	try { unlinkSync(SENTINEL_PATH); } catch { /* doesn't exist */ }
+}
+
+// Ensure clean state before the suite
+test.beforeAll(() => {
+	removeSentinel();
+});
+
+// Clean up after the suite — remove sentinel so other test files aren't affected
+test.afterAll(() => {
+	removeSentinel();
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 1. GET /api/setup-status — initial state
+// ═══════════════════════════════════════════════════════════════════════════
+
+test.describe("GET /api/setup-status", () => {
+	test("returns { complete: false } when no sentinel exists", async () => {
+		removeSentinel();
+		const resp = await apiFetch("/api/setup-status");
+		expect(resp.status).toBe(200);
+		const data = await resp.json();
+		expect(data).toEqual({ complete: false });
+	});
+
+	test("requires authentication", async () => {
+		const resp = await fetch(`${BASE}/api/setup-status`);
+		expect(resp.status).toBe(401);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2. POST /api/setup-status/dismiss — creates sentinel
+// ═══════════════════════════════════════════════════════════════════════════
+
+test.describe("POST /api/setup-status/dismiss", () => {
+	test("creates sentinel and subsequent GET returns { complete: true }", async () => {
+		removeSentinel();
+
+		// Dismiss
+		const dismissResp = await apiFetch("/api/setup-status/dismiss", { method: "POST" });
+		expect(dismissResp.status).toBe(200);
+		const dismissData = await dismissResp.json();
+		expect(dismissData).toEqual({ ok: true });
+
+		// Sentinel file should now exist
+		expect(existsSync(SENTINEL_PATH)).toBe(true);
+
+		// GET should now return complete: true
+		const statusResp = await apiFetch("/api/setup-status");
+		expect(statusResp.status).toBe(200);
+		const statusData = await statusResp.json();
+		expect(statusData).toEqual({ complete: true });
+	});
+
+	test("dismiss is idempotent", async () => {
+		// Call dismiss again — should succeed without error
+		const resp = await apiFetch("/api/setup-status/dismiss", { method: "POST" });
+		expect(resp.status).toBe(200);
+		expect(await resp.json()).toEqual({ ok: true });
+	});
+
+	test("requires authentication", async () => {
+		const resp = await fetch(`${BASE}/api/setup-status/dismiss`, { method: "POST" });
+		expect(resp.status).toBe(401);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 3. GET /api/health — includes setupComplete field
+// ═══════════════════════════════════════════════════════════════════════════
+
+test.describe("GET /api/health — setupComplete field", () => {
+	test("includes setupComplete: true when sentinel exists", async () => {
+		// Sentinel should still exist from the dismiss test above
+		const resp = await apiFetch("/api/health");
+		expect(resp.status).toBe(200);
+		const data = await resp.json();
+		expect(data.status).toBe("ok");
+		expect(typeof data.setupComplete).toBe("boolean");
+		expect(data.setupComplete).toBe(true);
+	});
+
+	test("includes setupComplete: false when sentinel removed", async () => {
+		removeSentinel();
+		const resp = await apiFetch("/api/health");
+		expect(resp.status).toBe(200);
+		const data = await resp.json();
+		expect(data.setupComplete).toBe(false);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 4. Session creation with assistantType: "setup"
+// ═══════════════════════════════════════════════════════════════════════════
+
+test.describe("Setup assistant session", () => {
+	let sessionId: string | undefined;
+
+	test.afterEach(async () => {
+		if (sessionId) {
+			await deleteSession(sessionId);
+			sessionId = undefined;
+		}
+	});
+
+	test("creating a session with assistantType setup succeeds", async () => {
+		const resp = await apiFetch("/api/sessions", {
+			method: "POST",
+			body: JSON.stringify({ cwd: nonGitCwd(), assistantType: "setup" }),
+		});
+		expect(resp.status).toBe(201);
+		const data = await resp.json();
+		sessionId = data.id;
+		expect(data.id).toBeTruthy();
+		expect(data.assistantType).toBe("setup");
+	});
+
+	test("session metadata includes assistantType setup", async () => {
+		// Create session
+		const createResp = await apiFetch("/api/sessions", {
+			method: "POST",
+			body: JSON.stringify({ cwd: nonGitCwd(), assistantType: "setup" }),
+		});
+		expect(createResp.status).toBe(201);
+		const created = await createResp.json();
+		sessionId = created.id;
+
+		// Fetch session detail
+		const detailResp = await apiFetch(`/api/sessions/${sessionId}`);
+		expect(detailResp.status).toBe(200);
+		const detail = await detailResp.json();
+		expect(detail.assistantType).toBe("setup");
+	});
+});


### PR DESCRIPTION
## Summary

Add a new **setup** assistant type that guides users through configuring Bobbit for a new project directory. It explores the project (package.json, tsconfig, Makefile, directory structure), asks targeted questions, and writes configuration to `.bobbit/config/`.

## What's included

### Server
- **Setup assistant prompt** (`setup-assistant.ts`) — explores project, asks questions, writes config files
- **Assistant registry** — new `setup` type registered
- **API endpoints** — `GET /api/setup-status`, `POST /api/setup-status/dismiss`, `setupComplete` field on health endpoint
- **Sentinel file** — `.bobbit/state/setup-complete` marks setup as done

### Client
- **Sidebar banner** — "Setup Wizard" banner with dismiss (X) when setup is incomplete
- **Desktop splash** — "Welcome to Bobbit" setup CTA when no session selected
- **Mobile landing** — setup CTA on mobile empty state
- **Proposal system** — `<setup_proposal>` blocks for progress tracking, auto-dismisses banner on completion
- **State management** — `setupComplete` flag from health endpoint, shared `launchSetupWizard` utility

### Tests
- E2E tests for setup status API (GET, POST dismiss, health field, session creation)
- All 204 unit tests pass, all 253 E2E tests pass

## Detection logic
Setup is considered complete when:
- `.bobbit/state/setup-complete` sentinel exists, OR
- `.bobbit/config/system-prompt.md` has been customized (differs from default template)

This ensures existing projects don't see the wizard.