### PR TITLE
Fix setup wizard panel

### DIFF
--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -1796,6 +1796,7 @@ export function doRenderApp(): void {
 
 	const assistantTabBar = () => {
 		if (!state.assistantType) return "";
+		if (!getAssistantPreviewPanel(state.assistantType)) return "";
 		return html`
 			<div class="goal-tab-bar shrink-0 flex items-center gap-1 px-3 py-2 border-b border-border bg-background">
 				<button
@@ -1955,6 +1956,13 @@ export function doRenderApp(): void {
 
 		if (connected && state.assistantType) {
 			const previewPanel = getAssistantPreviewPanel(state.assistantType);
+			if (!previewPanel) {
+				// No preview panel (e.g. setup wizard) — use full-width chat
+				return html`
+					${reconnectBanner()}
+					<div class="flex-1 flex flex-col min-h-0">${state.chatPanel}</div>
+				`;
+			}
 			if (desktop) {
 				return html`
 					${reconnectBanner()}


### PR DESCRIPTION
## Summary

Fixed the setup wizard panel bug where the right panel was empty/blank on desktop (chat constrained to 50% width with nothing on the right) and mobile showed an empty "preview" tab.

## Root Cause

`getAssistantPreviewPanel()` has no `case "setup"` — returns `""`. But because `state.assistantType` is `"setup"`, the split-panel layout was still activated.

## Fix

Two surgical edits to `src/app/render.ts`:

1. **`mainArea()`**: Early return with full-width chat layout when `getAssistantPreviewPanel()` returns empty
2. **`assistantTabBar()`**: Hide mobile tab bar when no preview panel exists

## Verification

- Type-check passes
- Unit tests: 221/221 passed
- E2E tests: passed
- Code reviews: all passed (gap analysis, code quality, security)