### PR TITLE
Fix Setup Wizard

### DIFF
--- a/.bobbit/config/workflows/bug-fix.yaml
+++ b/.bobbit/config/workflows/bug-fix.yaml
@@ -47,17 +47,17 @@ gates:
     verify:
       - name: "Type check"
         type: command
-        run: "npm run check"
+        run: "{{typecheck_command}}"
       - name: "Repro test passes (bug fixed)"
         type: command
         run: "{{reproducing-test.test_command}}"
         expect: success
       - name: "Unit tests"
         type: command
-        run: "npm run test:unit"
+        run: "{{test_unit_command}}"
       - name: "E2E tests"
         type: command
-        run: "npm run test:e2e"
+        run: "{{test_e2e_command}}"
       - name: "Gap analysis"
         type: llm-review
         prompt: |

--- a/.bobbit/config/workflows/feature.yaml
+++ b/.bobbit/config/workflows/feature.yaml
@@ -39,13 +39,13 @@ gates:
     verify:
       - name: "Type check passes"
         type: command
-        run: "npm run check"
+        run: "{{typecheck_command}}"
       - name: "Unit tests"
         type: command
-        run: "npm run test:unit"
+        run: "{{test_unit_command}}"
       - name: "E2E tests"
         type: command
-        run: "npm run test:e2e"
+        run: "{{test_e2e_command}}"
       - name: "Gap analysis"
         type: llm-review
         prompt: |

--- a/.bobbit/config/workflows/general.yaml
+++ b/.bobbit/config/workflows/general.yaml
@@ -39,13 +39,13 @@ gates:
     verify:
       - name: "Type check passes"
         type: command
-        run: "npm run check"
+        run: "{{typecheck_command}}"
       - name: "Unit tests"
         type: command
-        run: "npm run test:unit"
+        run: "{{test_unit_command}}"
       - name: "E2E tests"
         type: command
-        run: "npm run test:e2e"
+        run: "{{test_e2e_command}}"
       - name: "Gap analysis"
         type: llm-review
         prompt: |

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -1208,6 +1208,81 @@ function personalityPreviewPanel() {
 	`;
 }
 
+// ============================================================================
+// SETUP PREVIEW PANEL (setup wizard split-screen)
+// ============================================================================
+
+function setupPreviewPanel() {
+	const handleDone = () => {
+		backToSessions();
+	};
+
+	const actionLabels: Record<string, string> = {
+		"system-prompt": "System Prompt",
+		"preferences": "Preferences",
+		"project-config": "Project Config",
+		"complete": "Setup Complete",
+	};
+
+	return html`
+		<div class="goal-preview-panel flex-1 flex flex-col border-l border-border min-h-0">
+			<div class="flex-1 overflow-y-auto p-5 flex flex-col gap-4">
+				<!-- Header -->
+				<div>
+					<div class="text-lg font-semibold flex items-center gap-2">
+						${icon(WandSparkles, "sm")}
+						Setup Progress
+					</div>
+					${state.setupComplete ? html`
+						<div class="mt-2 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-green-500/15 text-green-700 dark:text-green-400">
+							<span class="text-green-500">&#10003;</span> Setup Complete
+						</div>
+					` : ""}
+				</div>
+
+				<!-- Completed steps -->
+				${state.setupPreviewSteps.length > 0 ? html`
+					<div>
+						<div class="text-xs text-muted-foreground mb-2 font-medium">Completed Steps</div>
+						<div class="flex flex-col gap-2">
+							${state.setupPreviewSteps.map((step, i) => html`
+								<div class="flex items-start gap-2.5 p-2.5 rounded-md border border-border ${step.action === "complete" ? "bg-green-500/5" : ""}">
+									<div class="mt-0.5 text-sm">
+										<span class="text-green-500">&#10003;</span>
+									</div>
+									<div class="flex-1 min-w-0">
+										<div class="text-sm font-medium">${actionLabels[step.action] || step.action}</div>
+										${step.content ? html`<div class="text-xs text-muted-foreground mt-0.5 line-clamp-2">${step.content.slice(0, 200)}</div>` : ""}
+									</div>
+								</div>
+							`)}
+						</div>
+					</div>
+				` : html`
+					<div class="text-xs text-muted-foreground italic p-3 border border-dashed border-border rounded-md">
+						The setup wizard will configure your project. Steps will appear here as they complete.
+					</div>
+				`}
+
+				<!-- Current content preview -->
+				${state.setupPreviewContent ? html`
+					<div>
+						<div class="text-xs text-muted-foreground mb-1.5 font-medium">Latest Update</div>
+						<div class="p-3 rounded-md border border-border bg-secondary/30 overflow-y-auto text-sm max-h-[300px]">
+							<markdown-block .content=${state.setupPreviewContent}></markdown-block>
+						</div>
+					</div>
+				` : ""}
+			</div>
+
+			<!-- Footer -->
+			<div class="shrink-0 flex items-center justify-end gap-2 px-5 py-3 border-t border-border">
+				${Button({ variant: "ghost", onClick: handleDone, children: "Done" })}
+			</div>
+		</div>
+	`;
+}
+
 function getAssistantPreviewPanel(type: string) {
 	switch (type) {
 		case "goal": return goalPreviewPanel();
@@ -1215,6 +1290,7 @@ function getAssistantPreviewPanel(type: string) {
 		case "tool": return toolPreviewPanel();
 		case "personality": return personalityPreviewPanel();
 		case "staff": return staffPreviewPanel();
+		case "setup": return setupPreviewPanel();
 		default: return "";
 	}
 }

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -617,10 +617,16 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 		};
 
 		remote.onSetupProposal = (proposal) => {
+			// Track all setup actions in preview state
+			state.setupPreviewAction = proposal.action;
+			state.setupPreviewContent = proposal.content || "";
+			state.setupPreviewSteps.push({ action: proposal.action, content: proposal.content || "" });
+			state.assistantHasProposal = true;
+
 			if (proposal.action === "complete") {
 				state.setupComplete = true;
-				renderApp();
 			}
+			renderApp();
 		};
 
 		remote.onStaffProposal = (proposal) => {

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -679,6 +679,9 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			: null);
 		state.assistantTab = "chat";
 		state.assistantHasProposal = false;
+		state.setupPreviewSteps = [];
+		state.setupPreviewContent = "";
+		state.setupPreviewAction = "";
 		state.isPreviewSession = options?.isPreview || sessionData?.preview || false;
 		state.previewPanelHtml = ""; // Clear stale preview from previous session
 		if (state.isPreviewSession) startPreviewPolling();

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -227,6 +227,11 @@ export const state = {
 	/** Whether the setup wizard has been completed (safe default: true — don't show banner until we know) */
 	setupComplete: true,
 
+	// Setup assistant preview state
+	setupPreviewContent: "",
+	setupPreviewAction: "",  // last action: "system-prompt", "preferences", "complete"
+	setupPreviewSteps: [] as Array<{ action: string; content: string }>,
+
 	/** Cached roles for the role picker menu */
 	roles: [] as Array<{ name: string; label: string; accessory: string }>,
 	/** Whether the new-session role picker dropdown is open */

--- a/src/server/agent/project-config-store.ts
+++ b/src/server/agent/project-config-store.ts
@@ -71,8 +71,11 @@ export class ProjectConfigStore {
 		return { ...this.data };
 	}
 
-	/** Returns all fields with defaults applied for any missing values. */
+	/** Returns all fields with defaults applied for any missing values.
+	 *  Re-reads from disk to pick up changes made by external processes (e.g. setup wizard agent).
+	 */
 	getWithDefaults(): Required<ProjectConfig> {
+		this.load();
 		return { ...DEFAULTS, ...this.data };
 	}
 }

--- a/src/server/agent/project-config-store.ts
+++ b/src/server/agent/project-config-store.ts
@@ -1,0 +1,78 @@
+import fs from "node:fs";
+import path from "node:path";
+import yaml from "yaml";
+import { bobbitConfigDir } from "../bobbit-dir.js";
+
+const CONFIG_FILE = path.join(bobbitConfigDir(), "project.yaml");
+
+export interface ProjectConfig {
+	build_command?: string;
+	test_command?: string;
+	typecheck_command?: string;
+	test_unit_command?: string;
+	test_e2e_command?: string;
+}
+
+const DEFAULTS: Required<ProjectConfig> = {
+	build_command: "npm run build",
+	test_command: "npm test",
+	typecheck_command: "npm run check",
+	test_unit_command: "npm run test:unit",
+	test_e2e_command: "npm run test:e2e",
+};
+
+/**
+ * Project config store persisted to .bobbit/config/project.yaml.
+ * Stores build/test/typecheck commands for the project.
+ * Auto-saves on every set. Handles missing file gracefully.
+ */
+export class ProjectConfigStore {
+	private data: ProjectConfig = {};
+
+	constructor() {
+		this.load();
+	}
+
+	private load(): void {
+		try {
+			if (fs.existsSync(CONFIG_FILE)) {
+				const raw = yaml.parse(fs.readFileSync(CONFIG_FILE, "utf-8"));
+				if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+					this.data = raw as ProjectConfig;
+				}
+			}
+		} catch (err) {
+			console.error("[project-config-store] Failed to load project config:", err);
+		}
+	}
+
+	private save(): void {
+		try {
+			const dir = path.dirname(CONFIG_FILE);
+			if (!fs.existsSync(dir)) {
+				fs.mkdirSync(dir, { recursive: true });
+			}
+			fs.writeFileSync(CONFIG_FILE, yaml.stringify(this.data), "utf-8");
+		} catch (err) {
+			console.error("[project-config-store] Failed to save project config:", err);
+		}
+	}
+
+	get(key: keyof ProjectConfig): string | undefined {
+		return this.data[key];
+	}
+
+	set(key: keyof ProjectConfig, value: string): void {
+		this.data[key] = value;
+		this.save();
+	}
+
+	getAll(): ProjectConfig {
+		return { ...this.data };
+	}
+
+	/** Returns all fields with defaults applied for any missing values. */
+	getWithDefaults(): Required<ProjectConfig> {
+		return { ...DEFAULTS, ...this.data };
+	}
+}

--- a/src/server/agent/setup-assistant.ts
+++ b/src/server/agent/setup-assistant.ts
@@ -88,6 +88,30 @@ Project-specific instructions and guidelines:
 - No external dependencies without discussion
 \`\`\`
 
+### Project config (\`.bobbit/config/project.yaml\`)
+
+Write a YAML file with the detected build/test/typecheck commands. This file is used by workflow verification gates to run the correct commands for this project.
+
+Example:
+\`\`\`yaml
+build_command: npm run build
+test_command: npm test
+typecheck_command: npm run check
+test_unit_command: npm run test:unit
+test_e2e_command: npm run test:e2e
+\`\`\`
+
+Adjust the commands based on what you detected in the exploration phase. For example, a Python project might use:
+\`\`\`yaml
+build_command: python -m build
+test_command: pytest
+typecheck_command: mypy src/
+test_unit_command: pytest tests/unit
+test_e2e_command: pytest tests/e2e
+\`\`\`
+
+If a command doesn't apply (e.g. no type-checker), use a no-op like \`echo "no typecheck configured"\`.
+
 After writing the system prompt, emit a progress block:
 
 <setup_proposal>

--- a/src/server/agent/verification-harness.ts
+++ b/src/server/agent/verification-harness.ts
@@ -10,6 +10,7 @@ import { RpcBridge, type RpcBridgeOptions } from "./rpc-bridge.js";
 import type { SessionManager } from "./session-manager.js";
 import { assembleSystemPrompt } from "./system-prompt.js";
 import type { WorkflowGate, Workflow } from "./workflow-store.js";
+import type { ProjectConfigStore } from "./project-config-store.js";
 
 /** Resolve Git Bash path on Windows for commands needing Unix tools. */
 function findGitBash(): string | null {
@@ -74,6 +75,7 @@ export class VerificationHarness {
 		private preferencesStore?: PreferencesStore,
 		private sessionManager?: import("./session-manager.js").SessionManager,
 		private teamManager?: import("./team-manager.js").TeamManager,
+		private projectConfigStore?: ProjectConfigStore,
 	) {}
 
 	/** Register a callback to notify the team lead agent when verification completes. */
@@ -151,6 +153,14 @@ export class VerificationHarness {
 				cwd,
 				goal_spec: goalSpec || "",
 			};
+
+			// Load project config into builtinVars so {{typecheck_command}} etc. resolve
+			if (this.projectConfigStore) {
+				const projectConfig = this.projectConfigStore.getWithDefaults();
+				for (const [k, v] of Object.entries(projectConfig)) {
+					builtinVars[k] = v;
+				}
+			}
 
 			// Also include the current signal's metadata as bare variables
 			if (signal.metadata) {

--- a/src/server/defaults/workflows/bug-fix.yaml
+++ b/src/server/defaults/workflows/bug-fix.yaml
@@ -46,17 +46,17 @@ gates:
     verify:
       - name: "Type check"
         type: command
-        run: "npm run check"
+        run: "{{typecheck_command}}"
       - name: "Repro test passes (bug fixed)"
         type: command
         run: "{{reproducing-test.test_command}}"
         expect: success
       - name: "Unit tests"
         type: command
-        run: "npm run test:unit"
+        run: "{{test_unit_command}}"
       - name: "E2E tests"
         type: command
-        run: "npm run test:e2e"
+        run: "{{test_e2e_command}}"
       - name: "Gap analysis"
         type: llm-review
         prompt: |

--- a/src/server/defaults/workflows/feature.yaml
+++ b/src/server/defaults/workflows/feature.yaml
@@ -39,13 +39,13 @@ gates:
     verify:
       - name: "Type check passes"
         type: command
-        run: "npm run check"
+        run: "{{typecheck_command}}"
       - name: "Unit tests"
         type: command
-        run: "npm run test:unit"
+        run: "{{test_unit_command}}"
       - name: "E2E tests"
         type: command
-        run: "npm run test:e2e"
+        run: "{{test_e2e_command}}"
       - name: "Gap analysis"
         type: llm-review
         prompt: |

--- a/src/server/defaults/workflows/general.yaml
+++ b/src/server/defaults/workflows/general.yaml
@@ -39,13 +39,13 @@ gates:
     verify:
       - name: "Type check passes"
         type: command
-        run: "npm run check"
+        run: "{{typecheck_command}}"
       - name: "Unit tests"
         type: command
-        run: "npm run test:unit"
+        run: "{{test_unit_command}}"
       - name: "E2E tests"
         type: command
-        run: "npm run test:e2e"
+        run: "{{test_e2e_command}}"
       - name: "Gap analysis"
         type: llm-review
         prompt: |

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -31,6 +31,7 @@ import { VerificationHarness } from "./agent/verification-harness.js";
 import { StaffManager } from "./agent/staff-manager.js";
 import { TriggerEngine } from "./agent/staff-trigger-engine.js";
 import { PreferencesStore } from "./agent/preferences-store.js";
+import { ProjectConfigStore } from "./agent/project-config-store.js";
 import { configureAigw, removeAigw, getAigwUrl, getAigwModels, discoverAigwModels, proxyRequest, startupAigwCheck } from "./agent/aigw-manager.js";
 
 const VALID_TASK_STATES = new Set<string>(["todo", "in-progress", "blocked", "complete", "skipped"]);
@@ -116,6 +117,7 @@ export function createGateway(config: GatewayConfig) {
 
 	const colorStore = new ColorStore();
 	const preferencesStore = new PreferencesStore();
+	const projectConfigStore = new ProjectConfigStore();
 	const savedCwd = preferencesStore.get("defaultCwd");
 	if (savedCwd && typeof savedCwd === "string") {
 		config.defaultCwd = savedCwd;
@@ -203,7 +205,7 @@ export function createGateway(config: GatewayConfig) {
 				}
 			}
 
-			await handleApiRoute(url, req, res, sessionManager, config, colorStore, teamManager, roleManager, toolManager, gateStore, personalityManager, bgProcessManager, staffManager, workflowManager, verificationHarness, preferencesStore, broadcastToGoal, broadcastToAll);
+			await handleApiRoute(url, req, res, sessionManager, config, colorStore, teamManager, roleManager, toolManager, gateStore, personalityManager, bgProcessManager, staffManager, workflowManager, verificationHarness, preferencesStore, projectConfigStore, broadcastToGoal, broadcastToAll);
 
 			return;
 		}
@@ -261,7 +263,7 @@ export function createGateway(config: GatewayConfig) {
 		}
 	}
 	teamManager.setBroadcastToGoal(broadcastToGoal);
-	verificationHarness = new VerificationHarness(gateStore, broadcastToGoal, roleStore, preferencesStore, sessionManager, teamManager);
+	verificationHarness = new VerificationHarness(gateStore, broadcastToGoal, roleStore, preferencesStore, sessionManager, teamManager, projectConfigStore);
 	verificationHarness.setTeamLeadNotifier((goalId, message) => {
 		const team = teamManager.getTeamState(goalId);
 		if (!team?.teamLeadSessionId) return;
@@ -398,6 +400,7 @@ async function handleApiRoute(
 	workflowManager: WorkflowManager,
 	verificationHarness: VerificationHarness,
 	preferencesStore: PreferencesStore,
+	projectConfigStore: ProjectConfigStore,
 	broadcastToGoal: (goalId: string, event: any) => void,
 	broadcastToAll: (event: any) => void,
 ) {
@@ -855,6 +858,25 @@ async function handleApiRoute(
 		}
 		json({ ok: true });
 		broadcastToAll({ type: "preferences_changed", preferences: preferencesStore.getAll() });
+		return;
+	}
+
+	// GET /api/project-config — return project config with defaults
+	if (url.pathname === "/api/project-config" && req.method === "GET") {
+		json(projectConfigStore.getWithDefaults());
+		return;
+	}
+
+	// PUT /api/project-config — update project config fields
+	if (url.pathname === "/api/project-config" && req.method === "PUT") {
+		const body = await readBody(req);
+		if (!body || typeof body !== "object") { json({ error: "Missing body" }, 400); return; }
+		for (const [key, value] of Object.entries(body)) {
+			if (typeof value === "string") {
+				projectConfigStore.set(key as any, value);
+			}
+		}
+		json({ ok: true });
 		return;
 	}
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -871,9 +871,10 @@ async function handleApiRoute(
 	if (url.pathname === "/api/project-config" && req.method === "PUT") {
 		const body = await readBody(req);
 		if (!body || typeof body !== "object") { json({ error: "Missing body" }, 400); return; }
+		const VALID_KEYS = new Set(["build_command", "test_command", "typecheck_command", "test_unit_command", "test_e2e_command"]);
 		for (const [key, value] of Object.entries(body)) {
-			if (typeof value === "string") {
-				projectConfigStore.set(key as any, value);
+			if (typeof value === "string" && VALID_KEYS.has(key)) {
+				projectConfigStore.set(key as keyof import("./agent/project-config-store.js").ProjectConfig, value);
 			}
 		}
 		json({ ok: true });

--- a/tests/e2e/setup-wizard-bugs.spec.ts
+++ b/tests/e2e/setup-wizard-bugs.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * E2E tests that reproduce the two setup wizard bugs.
+ *
+ * These tests FAIL on the current (unfixed) codebase, proving the bugs exist.
+ * After the fix, they will PASS.
+ *
+ * Bug 1: No project config API — GET /api/project-config returns 404.
+ * Bug 2: Workflow verification uses hardcoded commands instead of template variables.
+ */
+import { test, expect } from "@playwright/test";
+import { apiFetch, createGoal, deleteGoal, nonGitCwd } from "./e2e-setup.js";
+
+// ---------------------------------------------------------------------------
+// Bug 1: Project config API does not exist
+// ---------------------------------------------------------------------------
+
+test.describe("Bug 1: Project config API", () => {
+	test("GET /api/project-config returns 200", async () => {
+		const resp = await apiFetch("/api/project-config");
+		expect(resp.status, "Expected GET /api/project-config to return 200 but got 404 — endpoint does not exist yet").toBe(200);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Bug 2: Workflow verification uses hardcoded commands
+// ---------------------------------------------------------------------------
+
+test.describe("Bug 2: Workflow verification uses template variables", () => {
+	test("general workflow implementation gate uses {{typecheck_command}} not hardcoded npm run check", async () => {
+		const goal = await createGoal({
+			title: `Setup Bug Test ${Date.now()}`,
+			cwd: nonGitCwd(),
+			workflowId: "general",
+		});
+		try {
+			// The goal object includes the full workflow with gates and verify steps
+			const workflow = (goal as any).workflow;
+			expect(workflow).toBeTruthy();
+
+			const implGate = workflow.gates.find((g: any) => g.id === "implementation");
+			expect(implGate).toBeTruthy();
+			expect(implGate.verify).toBeTruthy();
+
+			// Find the type-check verification step
+			const typeCheckStep = implGate.verify.find(
+				(v: any) => v.type === "command" && v.name?.toLowerCase().includes("type check"),
+			);
+			expect(typeCheckStep, "Expected a type-check verification step in implementation gate").toBeTruthy();
+
+			// This assertion will FAIL on unfixed code because `run` is "npm run check"
+			// After fix, it should be "{{typecheck_command}}"
+			expect(typeCheckStep.run).toContain("{{typecheck_command}}");
+		} finally {
+			await deleteGoal(goal.id);
+		}
+	});
+
+	test("general workflow implementation gate uses {{test_unit_command}} not hardcoded npm run test:unit", async () => {
+		const goal = await createGoal({
+			title: `Setup Bug Test Unit ${Date.now()}`,
+			cwd: nonGitCwd(),
+			workflowId: "general",
+		});
+		try {
+			const workflow = (goal as any).workflow;
+			const implGate = workflow.gates.find((g: any) => g.id === "implementation");
+			const unitTestStep = implGate.verify.find(
+				(v: any) => v.type === "command" && v.name?.toLowerCase().includes("unit test"),
+			);
+			expect(unitTestStep, "Expected a unit-test verification step in implementation gate").toBeTruthy();
+
+			// This assertion will FAIL on unfixed code because `run` is "npm run test:unit"
+			// After fix, it should be "{{test_unit_command}}"
+			expect(unitTestStep.run).toContain("{{test_unit_command}}");
+		} finally {
+			await deleteGoal(goal.id);
+		}
+	});
+
+	test("bug-fix workflow implementation gate uses {{typecheck_command}} not hardcoded npm run check", async () => {
+		const goal = await createGoal({
+			title: `Setup Bug Test BugFix ${Date.now()}`,
+			cwd: nonGitCwd(),
+			workflowId: "bug-fix",
+		});
+		try {
+			const workflow = (goal as any).workflow;
+			const implGate = workflow.gates.find((g: any) => g.id === "implementation");
+			const typeCheckStep = implGate.verify.find(
+				(v: any) => v.type === "command" && v.name?.toLowerCase().includes("type check"),
+			);
+			expect(typeCheckStep, "Expected a type-check verification step in bug-fix implementation gate").toBeTruthy();
+
+			// This assertion will FAIL on unfixed code because `run` is "npm run check"
+			expect(typeCheckStep.run).toContain("{{typecheck_command}}");
+		} finally {
+			await deleteGoal(goal.id);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Fixes two bugs in the setup wizard:

### Bug 1: No preview panel
- Added `setupPreviewPanel()` to `render.ts` with `case "setup"` in `getAssistantPreviewPanel()`
- `onSetupProposal` handler now populates preview state for all actions (not just "complete")
- Added setup preview state fields (`setupPreviewSteps`, `setupPreviewContent`, `setupPreviewAction`)
- State properly resets on session reconnect

### Bug 2: Hardcoded build/test commands in workflow verification
- Created `ProjectConfigStore` (`.bobbit/config/project.yaml`) with sensible defaults matching current behavior
- Wired into `VerificationHarness` so `{{typecheck_command}}`, `{{test_unit_command}}`, `{{test_e2e_command}}` resolve in workflow YAMLs
- Replaced hardcoded `npm run check`/`npm run test:unit`/`npm run test:e2e` in all workflow YAMLs (general, feature, bug-fix)
- Added `GET/PUT /api/project-config` REST endpoints with key allowlist
- Updated setup assistant prompt to write `project.yaml` with detected commands

### Files changed
- `src/app/state.ts`, `src/app/render.ts`, `src/app/session-manager.ts` (UI)
- `src/server/agent/project-config-store.ts` (new)
- `src/server/agent/verification-harness.ts`, `src/server/server.ts`, `src/server/agent/setup-assistant.ts`
- `.bobbit/config/workflows/{general,feature,bug-fix}.yaml` + `src/server/defaults/workflows/` copies
- `tests/e2e/setup-wizard-bugs.spec.ts` (reproducing tests)

### Test results
- Type check: PASS
- Unit tests: 221/221 PASS
- E2E tests: 260/260 PASS (including 4 new reproducing tests)