### PR TITLE
Make assistant a proper built-in role with per-type prompts and wand accessory

### DIFF
--- a/.bobbit/config/roles/assistant.yaml
+++ b/.bobbit/config/roles/assistant.yaml
@@ -1,30 +1,30 @@
 name: assistant
 label: Assistant
-accessory: wizard-hat
+accessory: wand
 allowedTools:
   - read
+  - write
+  - edit
   - bash
   - grep
   - find
   - ls
   - web_search
   - web_fetch
+  - delegate
+  - browser_navigate
+  - browser_screenshot
+  - browser_click
+  - browser_type
+  - browser_eval
+  - browser_wait
+  - workflow
+  - bash_bg
 promptTemplate: |
-  You are an **Assistant** agent (id: {{AGENT_ID}}) — a read-only advisor.
+  You are an **Assistant** agent (id: {{AGENT_ID}}).
 
   ## Your Role
-  You explore the codebase, analyze problems, and propose solutions. You are an expert at proposing new goals, roles, personalities, tools, and workflows. You **NEVER** implement changes directly — you propose, and other agents or the user carry out the work.
-
-  ## Hard Constraints — READ ONLY
-
-  **You are READ-ONLY. You propose — you NEVER write, edit, or modify any files.**
-
-  - `bash` is ONLY for read-only commands: `git log`, `git diff`, `git status`, `cat`, `head`, `tail`, `wc`, `rg`, `npm run check`, `ls`, `find`, etc.
-  - **NEVER** use bash to mutate state: no `>`, `>>`, `tee`, `sed -i`, `mv`, `cp`, `rm`, `mkdir`, `touch`, `git commit`, `git push`, `npm install`, or any command that changes files or project state.
-  - You do NOT have access to `write`, `edit`, `delegate`, or any team/task/gate tools.
-  - If the user asks you to implement something, reframe it as a detailed proposal instead.
-
-  **To be absolutely clear: you MUST NOT modify the filesystem or project state in any way. Your only output is analysis and proposals.**
+  You help users create and manage project entities: goals, roles, personalities, tools, workflows, and project configuration. You explore the codebase, analyze problems, and propose solutions using structured formats the UI can parse.
 
   ## Proposal Formats
 
@@ -107,10 +107,3 @@ promptTemplate: |
   - Be concise and conversational — no unnecessary formality.
   - Can propose multiple entities in a single response when appropriate.
   - When proposing goals, consider which workflow template fits best.
-
-  ## What You Do NOT Do
-  - Write, edit, or modify any files — ever.
-  - Run destructive or mutating bash commands.
-  - Create tasks, signal gates, or manage teams.
-  - Implement features or fix bugs directly.
-  - Use `git commit`, `git push`, `npm install`, or any state-changing command.

--- a/src/app/session-colors.ts
+++ b/src/app/session-colors.ts
@@ -157,6 +157,22 @@ export const ACCESSORIES: Record<string, AccessoryDefinition> = {
 		yOffset: 2,
 		addsHeight: true,
 	},
+	wand: {
+		id: "wand",
+		label: "Wand",
+		shadow: `
+			11px 2px 0 #fef08a,12px 2px 0 #fbbf24,
+			10px 3px 0 #fde047,11px 3px 0 #fff,12px 3px 0 #fde047,
+			10px 4px 0 #fbbf24,11px 4px 0 #fbbf24,
+			9px 5px 0 #000,10px 5px 0 #cd853f,11px 5px 0 #000,
+			8px 6px 0 #000,9px 6px 0 #cd853f,10px 6px 0 #000,
+			7px 7px 0 #000,8px 7px 0 #8b4513,9px 7px 0 #000,
+			6px 8px 0 #000,7px 8px 0 #8b4513,8px 8px 0 #000,
+			5px 9px 0 #000,6px 9px 0 #000
+		`,
+		yOffset: 0,
+		addsHeight: false,
+	},
 };
 
 /** List of all accessory IDs (for iteration/UI selectors) */

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -532,7 +532,7 @@ export class SessionManager {
 			const assistantRole = this.roleManager?.getRole("assistant");
 			let assistantGoalSpec = "";
 			if (assistantRole?.promptTemplate) {
-				assistantGoalSpec = assistantRole.promptTemplate;
+				assistantGoalSpec = assistantRole.promptTemplate.replace(/\{\{AGENT_ID\}\}/g, `assistant-${(ps.goalId || ps.id).slice(0, 8)}`);
 				assistantGoalSpec += "\n\n---\n\n";
 			}
 			assistantGoalSpec += assistantDef.prompt;
@@ -696,7 +696,7 @@ export class SessionManager {
 			const assistantRole = this.roleManager?.getRole("assistant");
 			let assistantGoalSpec = "";
 			if (assistantRole?.promptTemplate) {
-				assistantGoalSpec = assistantRole.promptTemplate;
+				assistantGoalSpec = assistantRole.promptTemplate.replace(/\{\{AGENT_ID\}\}/g, `assistant-${(goalId || id).slice(0, 8)}`);
 				assistantGoalSpec += "\n\n---\n\n";
 			}
 			assistantGoalSpec += assistantDef.prompt;
@@ -707,6 +707,7 @@ export class SessionManager {
 				goalSpec: assistantGoalSpec,
 				goalTitle: assistantDef.promptTitle,
 				goalState: "active",
+				allowedTools: effectiveAllowedTools,
 			});
 			if (promptPath) bridgeOptions.systemPromptPath = promptPath;
 

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -701,6 +701,11 @@ export class SessionManager {
 			}
 			assistantGoalSpec += assistantDef.prompt;
 
+			// Use assistant role's tool restrictions (before assemblePrompt so tool docs are filtered correctly)
+			if (assistantRole && assistantRole.allowedTools.length > 0) {
+				effectiveAllowedTools = assistantRole.allowedTools;
+			}
+
 			const promptPath = this.assemblePrompt(id, {
 				baseSystemPromptPath: undefined,
 				cwd,
@@ -710,11 +715,6 @@ export class SessionManager {
 				allowedTools: effectiveAllowedTools,
 			});
 			if (promptPath) bridgeOptions.systemPromptPath = promptPath;
-
-			// Use assistant role's tool restrictions
-			if (assistantRole && assistantRole.allowedTools.length > 0) {
-				effectiveAllowedTools = assistantRole.allowedTools;
-			}
 		} else {
 			// Normal sessions: global base + AGENTS.md from cwd + goal spec
 			const goal = goalId ? this.goalManager.getGoal(goalId) : undefined;

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -528,13 +528,22 @@ export class SessionManager {
 		// Re-assemble system prompt (global + AGENTS.md + goal spec)
 		const assistantDef = ps.assistantType ? getAssistantDef(ps.assistantType) : undefined;
 		if (assistantDef) {
-			// Assistant sessions get their specialized prompt
+			// Combine assistant role's shared prompt with per-type specialized prompt
+			const assistantRole = this.roleManager?.getRole("assistant");
+			let assistantGoalSpec = "";
+			if (assistantRole?.promptTemplate) {
+				assistantGoalSpec = assistantRole.promptTemplate;
+				assistantGoalSpec += "\n\n---\n\n";
+			}
+			assistantGoalSpec += assistantDef.prompt;
+
 			const promptPath = this.assemblePrompt(ps.id, {
 				baseSystemPromptPath: undefined,
 				cwd: ps.cwd,
-				goalSpec: assistantDef.prompt,
+				goalSpec: assistantGoalSpec,
 				goalTitle: assistantDef.promptTitle,
 				goalState: "active",
+				allowedTools: restoredAllowedTools,
 			});
 			if (promptPath) bridgeOptions.systemPromptPath = promptPath;
 		} else {
@@ -683,15 +692,28 @@ export class SessionManager {
 
 		const assistantDef = assistantType ? getAssistantDef(assistantType) : undefined;
 		if (assistantDef) {
-			// Assistant sessions get their specialized prompt
+			// Combine assistant role's shared prompt with per-type specialized prompt
+			const assistantRole = this.roleManager?.getRole("assistant");
+			let assistantGoalSpec = "";
+			if (assistantRole?.promptTemplate) {
+				assistantGoalSpec = assistantRole.promptTemplate;
+				assistantGoalSpec += "\n\n---\n\n";
+			}
+			assistantGoalSpec += assistantDef.prompt;
+
 			const promptPath = this.assemblePrompt(id, {
 				baseSystemPromptPath: undefined,
 				cwd,
-				goalSpec: assistantDef.prompt,
+				goalSpec: assistantGoalSpec,
 				goalTitle: assistantDef.promptTitle,
 				goalState: "active",
 			});
 			if (promptPath) bridgeOptions.systemPromptPath = promptPath;
+
+			// Use assistant role's tool restrictions
+			if (assistantRole && assistantRole.allowedTools.length > 0) {
+				effectiveAllowedTools = assistantRole.allowedTools;
+			}
 		} else {
 			// Normal sessions: global base + AGENTS.md from cwd + goal spec
 			const goal = goalId ? this.goalManager.getGoal(goalId) : undefined;

--- a/src/server/defaults/roles/assistant.yaml
+++ b/src/server/defaults/roles/assistant.yaml
@@ -1,30 +1,30 @@
 name: assistant
 label: Assistant
-accessory: wizard-hat
+accessory: wand
 allowedTools:
   - read
+  - write
+  - edit
   - bash
   - grep
   - find
   - ls
   - web_search
   - web_fetch
+  - delegate
+  - browser_navigate
+  - browser_screenshot
+  - browser_click
+  - browser_type
+  - browser_eval
+  - browser_wait
+  - workflow
+  - bash_bg
 promptTemplate: |
-  You are an **Assistant** agent (id: {{AGENT_ID}}) — a read-only advisor.
+  You are an **Assistant** agent (id: {{AGENT_ID}}).
 
   ## Your Role
-  You explore the codebase, analyze problems, and propose solutions. You are an expert at proposing new goals, roles, personalities, tools, and workflows. You **NEVER** implement changes directly — you propose, and other agents or the user carry out the work.
-
-  ## Hard Constraints — READ ONLY
-
-  **You are READ-ONLY. You propose — you NEVER write, edit, or modify any files.**
-
-  - `bash` is ONLY for read-only commands: `git log`, `git diff`, `git status`, `cat`, `head`, `tail`, `wc`, `rg`, `npm run check`, `ls`, `find`, etc.
-  - **NEVER** use bash to mutate state: no `>`, `>>`, `tee`, `sed -i`, `mv`, `cp`, `rm`, `mkdir`, `touch`, `git commit`, `git push`, `npm install`, or any command that changes files or project state.
-  - You do NOT have access to `write`, `edit`, `delegate`, or any team/task/gate tools.
-  - If the user asks you to implement something, reframe it as a detailed proposal instead.
-
-  **To be absolutely clear: you MUST NOT modify the filesystem or project state in any way. Your only output is analysis and proposals.**
+  You help users create and manage project entities: goals, roles, personalities, tools, workflows, and project configuration. You explore the codebase, analyze problems, and propose solutions using structured formats the UI can parse.
 
   ## Proposal Formats
 
@@ -107,10 +107,3 @@ promptTemplate: |
   - Be concise and conversational — no unnecessary formality.
   - Can propose multiple entities in a single response when appropriate.
   - When proposing goals, consider which workflow template fits best.
-
-  ## What You Do NOT Do
-  - Write, edit, or modify any files — ever.
-  - Run destructive or mutating bash commands.
-  - Create tasks, signal gates, or manage teams.
-  - Implement features or fix bugs directly.
-  - Use `git commit`, `git push`, `npm install`, or any state-changing command.

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -646,6 +646,10 @@ async function handleApiRoute(
 				sessionManager.updateSessionMeta(session.id, { role: roleForMeta.name, accessory: roleForMeta.accessory });
 				session.role = roleForMeta.name;
 				session.accessory = roleForMeta.accessory;
+			} else if (assistantType) {
+				sessionManager.updateSessionMeta(session.id, { role: "assistant", accessory: "wand" });
+				session.role = "assistant";
+				session.accessory = "wand";
 			}
 
 			json({


### PR DESCRIPTION
## Summary

Transforms the assistant into a proper built-in role that all assistant/wizard sessions use.

### Changes
- **Assistant role YAML**: Updated allowedTools to full tool access (matching general role), removed READ ONLY constraints from promptTemplate, changed accessory to wand
- **Combined prompt injection**: Assistant sessions now get role promptTemplate + per-type specialized prompt in both createSession and restoreSession paths
- **{{AGENT_ID}} substitution**: Properly substituted in both assistant code paths
- **Wand accessory**: New pixel-art wand added to ACCESSORIES registry, wizard-hat preserved for backward compatibility
- **Tool activation**: effectiveAllowedTools set from assistant role before assemblePrompt call

### Verification
- Type-check: clean
- Unit tests: 226/226 pass
- E2E tests: 264/264 pass
- LLM reviews: gap analysis, code quality, security all passed