### PR TITLE
Config page toggle buttons

### DIFF
--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -43,7 +43,7 @@ function skipSetup(): void {
 import { cwdCombobox } from "./cwd-combobox.js";
 
 import { teardownMobileScrollTracking, ensureMobileScrollTracking } from "./mobile-header.js";
-import { getRouteFromHash, setHashRoute } from "./routing.js";
+import { getRouteFromHash, setHashRoute, isRouteActive, toggleConfigPage } from "./routing.js";
 import { renderGoalDashboard } from "./goal-dashboard.js";
 import "./goal-dashboard.css";
 import { renderRoleManagerPage, loadRolePageData } from "./role-manager-page.js";
@@ -76,32 +76,39 @@ function renderMobileLanding() {
 		<div class="flex-1 flex flex-col overflow-y-auto">
 			<div class="w-full max-w-xl mx-auto px-2 py-4 pb-16 flex flex-col gap-1">
 				<div class="flex flex-col gap-1 px-1 pb-2 mb-1 border-b border-border/30">
+					${(() => {
+						const isRolesActive = isRouteActive("roles", "role-edit");
+						const isPersonalitiesActive = isRouteActive("personalities", "personality-edit");
+						const isToolsActive = isRouteActive("tools", "tool-edit");
+						const isWorkflowsActive = isRouteActive("workflows", "workflow-edit");
+						const isSkillsActive = isRouteActive("skills");
+						return html`
 					<div class="flex items-center gap-1">
-						<button class="flex-1 text-sm text-muted-foreground px-1.5 py-1 rounded active:bg-secondary/50 transition-colors flex items-center justify-center gap-1"
+						<button class="flex-1 text-sm px-1.5 py-1 rounded transition-colors flex items-center justify-center gap-1 ${isRolesActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}"
 							title="Manage roles"
-							@click=${() => { import("./role-manager-page.js").then((m) => m.loadRolePageData()); setHashRoute("roles"); }}>
+							@click=${() => toggleConfigPage(["roles", "role-edit"], () => { import("./role-manager-page.js").then((m) => m.loadRolePageData()); setHashRoute("roles"); })}>
 							${icon(Users, "xs")} Roles
 						</button>
-						<button class="flex-1 text-sm text-muted-foreground px-1.5 py-1 rounded active:bg-secondary/50 transition-colors flex items-center justify-center gap-1"
+						<button class="flex-1 text-sm px-1.5 py-1 rounded transition-colors flex items-center justify-center gap-1 ${isPersonalitiesActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}"
 							title="Manage personalities"
-							@click=${() => { import("./personality-manager-page.js").then((m) => m.loadPersonalityPageData()); setHashRoute("personalities"); }}>
+							@click=${() => toggleConfigPage(["personalities", "personality-edit"], () => { import("./personality-manager-page.js").then((m) => m.loadPersonalityPageData()); setHashRoute("personalities"); })}>
 							${icon(Drama, "xs")} Personalities
 						</button>
-						<button class="flex-1 text-sm text-muted-foreground px-1.5 py-1 rounded active:bg-secondary/50 transition-colors flex items-center justify-center gap-1"
+						<button class="flex-1 text-sm px-1.5 py-1 rounded transition-colors flex items-center justify-center gap-1 ${isToolsActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}"
 							title="Manage tools"
-							@click=${() => { import("./tool-manager-page.js").then((m) => m.loadToolPageData()); setHashRoute("tools"); }}>
+							@click=${() => toggleConfigPage(["tools", "tool-edit"], () => { import("./tool-manager-page.js").then((m) => m.loadToolPageData()); setHashRoute("tools"); })}>
 							${icon(Wrench, "xs")} Tools
 						</button>
 					</div>
 					<div class="flex items-center gap-1">
-						<button class="flex-1 text-sm text-muted-foreground px-1.5 py-1 rounded active:bg-secondary/50 transition-colors flex items-center justify-center gap-1"
+						<button class="flex-1 text-sm px-1.5 py-1 rounded transition-colors flex items-center justify-center gap-1 ${isWorkflowsActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}"
 							title="Manage workflows"
-							@click=${() => { import("./workflow-page.js").then((m) => m.loadWorkflowPageData()); setHashRoute("workflows"); }}>
+							@click=${() => toggleConfigPage(["workflows", "workflow-edit"], () => { import("./workflow-page.js").then((m) => m.loadWorkflowPageData()); setHashRoute("workflows"); })}>
 							${icon(WorkflowIcon, "xs")} Workflows
 						</button>
-						<button class="flex-1 text-sm text-muted-foreground px-1.5 py-1 rounded active:bg-secondary/50 transition-colors flex items-center justify-center gap-1"
+						<button class="flex-1 text-sm px-1.5 py-1 rounded transition-colors flex items-center justify-center gap-1 ${isSkillsActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}"
 							title="View skills"
-							@click=${() => { import("./skills-page.js").then((m) => m.loadSkillsPageData()); setHashRoute("skills"); }}>
+							@click=${() => toggleConfigPage(["skills"], () => { import("./skills-page.js").then((m) => m.loadSkillsPageData()); setHashRoute("skills"); })}>
 							${icon(Zap, "xs")} Skills
 						</button>
 						<button class="flex-1 text-sm text-muted-foreground px-1.5 py-1 rounded active:bg-secondary/50 transition-colors flex items-center justify-center gap-1"
@@ -110,6 +117,8 @@ function renderMobileLanding() {
 							${icon(GoalIcon, "xs")} New Goal
 						</button>
 					</div>
+					`;
+					})()}
 				</div>
 				${renderSetupBanner(true)}
 				${state.sessionsLoading
@@ -233,7 +242,7 @@ function renderMobileLanding() {
 			</div>
 		</div>
 		<div class="fixed bottom-0 left-0 right-0 flex items-center justify-between px-4 py-2 border-t border-border bg-background z-10">
-			${(() => { const isSettings = window.location.hash === "#/settings"; return html`<button class="flex items-center gap-1.5 px-2 py-2.5 text-xs rounded transition-colors ${isSettings ? "text-primary bg-primary/10 font-medium" : "text-muted-foreground active:bg-secondary/50"}"
+			${(() => { const isSettings = isRouteActive("settings"); return html`<button class="flex items-center gap-1.5 px-2 py-2.5 text-xs rounded transition-colors ${isSettings ? "text-primary bg-primary/10 font-medium" : "text-muted-foreground active:bg-secondary/50"}"
 				@click=${() => { import("./settings-page.js").then((m) => m.toggleSettings()); }}
 				title="Settings">
 				${icon(Settings, "sm")}

--- a/src/app/routing.ts
+++ b/src/app/routing.ts
@@ -103,6 +103,49 @@ export function setHashRoute(view: RouteView, id?: string, replace?: boolean): v
 }
 
 // ============================================================================
+// CONFIG PAGE HELPERS
+// ============================================================================
+
+/** Config page route views (not landing, session, or goal-dashboard). */
+const CONFIG_VIEWS: Set<RouteView> = new Set([
+	"roles", "role-edit", "tools", "tool-edit", "workflows", "workflow-edit",
+	"personalities", "personality-edit", "skills", "settings", "staff", "staff-edit",
+]);
+
+/** Returns true if the current hash route is a config page (not a session or landing). */
+export function isConfigPageRoute(): boolean {
+	return CONFIG_VIEWS.has(getRouteFromHash().view);
+}
+
+/** Check if the current route view matches any of the given view names. */
+export function isRouteActive(...views: RouteView[]): boolean {
+	const current = getRouteFromHash().view;
+	return views.some(v => v === current);
+}
+
+/** Shared previous-hash for all config page toggle buttons. */
+let _configPreviousHash: string | null = null;
+
+/**
+ * Toggle a config page. If already on a matching route, navigate back.
+ * Otherwise save current hash and call navigateFn.
+ */
+export function toggleConfigPage(activeViews: RouteView[], navigateFn: () => void): void {
+	const current = getRouteFromHash().view;
+	if (activeViews.some(v => v === current)) {
+		const hash = _configPreviousHash || "#/";
+		_configPreviousHash = null;
+		if (window.location.hash !== hash) {
+			history.replaceState({}, "", hash);
+			window.dispatchEvent(new HashChangeEvent("hashchange"));
+		}
+	} else {
+		_configPreviousHash = window.location.hash || "#/";
+		navigateFn();
+	}
+}
+
+// ============================================================================
 // PER-SESSION MODEL PERSISTENCE
 // ============================================================================
 

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -18,7 +18,7 @@ import {
 	type ShortcutEntry,
 } from "./shortcut-registry.js";
 import { renderApp, state } from "./state.js";
-import { getRouteFromHash, setHashRoute } from "./routing.js";
+import { getRouteFromHash, setHashRoute, toggleConfigPage } from "./routing.js";
 import { gatewayFetch } from "./api.js";
 import { ModelSelector } from "../ui/dialogs/ModelSelector.js";
 
@@ -54,20 +54,8 @@ function resetRebindState(): void {
 	browserReservedWarning = false;
 }
 
-let _previousHash: string | null = null;
-
 export function toggleSettings(): void {
-	if (getRouteFromHash().view === "settings") {
-		const hash = _previousHash || "#/";
-		_previousHash = null;
-		if (window.location.hash !== hash) {
-			history.replaceState({}, "", hash);
-			window.dispatchEvent(new HashChangeEvent("hashchange"));
-		}
-	} else {
-		_previousHash = window.location.hash || "#/";
-		setHashRoute("settings");
-	}
+	toggleConfigPage(["settings"], () => setHashRoute("settings"));
 }
 
 function handleRebindKeydown(e: KeyboardEvent): void {

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -25,6 +25,7 @@ import { statusBobbit, sessionAcronym } from "./session-colors.js";
 import { renderGoalGroup, renderSessionRow, renderArchivedSessionRow, renderArchivedDelegates, showSessionTooltip, hideSessionTooltip, SESSION_ROW_PY, INDENT, CHEVRON_W, HEADER_CHEVRON_W, terseRelativeTime, hasUnseenActivity, formatSessionAge, renderSessionTitle } from "./render-helpers.js";
 import type { GatewaySession } from "./state.js";
 import { resetArchivedExpandState } from "./state.js";
+import { isRouteActive, toggleConfigPage } from "./routing.js";
 
 // ============================================================================
 // ROLE + PERSONALITY PICKER
@@ -619,29 +620,35 @@ export function renderSidebar() {
 		return renderCollapsedSidebar(liveGoals, ungroupedSessions, archivedGoals);
 	}
 
+	const isRolesActive = isRouteActive("roles", "role-edit");
+	const isPersonalitiesActive = isRouteActive("personalities", "personality-edit");
+	const isToolsActive = isRouteActive("tools", "tool-edit");
+	const isWorkflowsActive = isRouteActive("workflows", "workflow-edit");
+	const isSkillsActive = isRouteActive("skills");
+
 	return html`
 		<div class="w-[240px] shrink-0 h-full flex flex-col sidebar-edge" style="background: var(--sidebar);">
 			<div class="flex flex-col border-b border-border/50 px-0.5 py-1 gap-0.5">
 				<div class="flex items-center">
 					<button
-						class="flex-1 flex items-center justify-center gap-1 px-1 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary/50 rounded-md transition-colors"
-						@click=${() => { import("./role-manager-page.js").then((m) => m.loadRolePageData()); import("./routing.js").then((m) => m.setHashRoute("roles")); }}
+						class="flex-1 flex items-center justify-center gap-1 px-1 py-1 text-xs ${isRolesActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'} rounded-md transition-colors"
+						@click=${() => toggleConfigPage(["roles", "role-edit"], () => { import("./role-manager-page.js").then((m) => m.loadRolePageData()); import("./routing.js").then((m) => m.setHashRoute("roles")); })}
 						title="Manage roles"
 					>
 						${icon(Users, "xs", "!w-3.5 !h-3.5")}
 						<span>Roles</span>
 					</button>
 					<button
-						class="flex-1 flex items-center justify-center gap-1 px-1 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary/50 rounded-md transition-colors"
-						@click=${() => { import("./personality-manager-page.js").then((m) => m.loadPersonalityPageData()); import("./routing.js").then((m) => m.setHashRoute("personalities")); }}
+						class="flex-1 flex items-center justify-center gap-1 px-1 py-1 text-xs ${isPersonalitiesActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'} rounded-md transition-colors"
+						@click=${() => toggleConfigPage(["personalities", "personality-edit"], () => { import("./personality-manager-page.js").then((m) => m.loadPersonalityPageData()); import("./routing.js").then((m) => m.setHashRoute("personalities")); })}
 						title="Manage personalities"
 					>
 						${icon(Drama, "xs", "!w-3.5 !h-3.5")}
 						<span>Personalities</span>
 					</button>
 					<button
-						class="flex-1 flex items-center justify-center gap-1 px-1 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary/50 rounded-md transition-colors"
-						@click=${() => { import("./tool-manager-page.js").then((m) => m.loadToolPageData()); import("./routing.js").then((m) => m.setHashRoute("tools")); }}
+						class="flex-1 flex items-center justify-center gap-1 px-1 py-1 text-xs ${isToolsActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'} rounded-md transition-colors"
+						@click=${() => toggleConfigPage(["tools", "tool-edit"], () => { import("./tool-manager-page.js").then((m) => m.loadToolPageData()); import("./routing.js").then((m) => m.setHashRoute("tools")); })}
 						title="Manage tools"
 					>
 						${icon(Wrench, "xs", "!w-3.5 !h-3.5")}
@@ -650,16 +657,16 @@ export function renderSidebar() {
 				</div>
 				<div class="flex items-center">
 					<button
-						class="flex-1 flex items-center justify-center gap-1 px-1 py-1 text-xs whitespace-nowrap text-muted-foreground hover:text-foreground hover:bg-secondary/50 rounded-md transition-colors"
-						@click=${() => { import("./workflow-page.js").then((m) => m.loadWorkflowPageData()); import("./routing.js").then((m) => m.setHashRoute("workflows")); }}
+						class="flex-1 flex items-center justify-center gap-1 px-1 py-1 text-xs whitespace-nowrap ${isWorkflowsActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'} rounded-md transition-colors"
+						@click=${() => toggleConfigPage(["workflows", "workflow-edit"], () => { import("./workflow-page.js").then((m) => m.loadWorkflowPageData()); import("./routing.js").then((m) => m.setHashRoute("workflows")); })}
 						title="Manage workflows"
 					>
 						${icon(Workflow, "xs", "!w-3.5 !h-3.5")}
 						<span>Workflows</span>
 					</button>
 					<button
-						class="flex-1 flex items-center justify-center gap-1 px-1 py-1 text-xs whitespace-nowrap text-muted-foreground hover:text-foreground hover:bg-secondary/50 rounded-md transition-colors"
-						@click=${() => { import("./skills-page.js").then((m) => m.loadSkillsPageData()); import("./routing.js").then((m) => m.setHashRoute("skills")); }}
+						class="flex-1 flex items-center justify-center gap-1 px-1 py-1 text-xs whitespace-nowrap ${isSkillsActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'} rounded-md transition-colors"
+						@click=${() => toggleConfigPage(["skills"], () => { import("./skills-page.js").then((m) => m.loadSkillsPageData()); import("./routing.js").then((m) => m.setHashRoute("skills")); })}
 						title="View skills"
 					>
 						${icon(Zap, "xs", "!w-3.5 !h-3.5")}
@@ -800,7 +807,7 @@ export function renderSidebar() {
 				}
 			</div>
 			<div class="flex items-center border-t border-border/50">
-				${(() => { const isSettings = window.location.hash === "#/settings"; return html`<button
+				${(() => { const isSettings = isRouteActive("settings"); return html`<button
 					class="flex items-center gap-1.5 px-3 py-2 text-xs transition-colors ${isSettings ? "text-primary bg-primary/10 font-medium" : "text-muted-foreground hover:text-foreground hover:bg-secondary/50"}"
 					@click=${() => { import("./settings-page.js").then((m) => m.toggleSettings()); }}
 					title="Settings (Ctrl+,)"

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -1,5 +1,6 @@
 import type { ChatPanel } from "../ui/index.js";
 import type { RemoteAgent, ConnectionStatus } from "./remote-agent.js";
+import { isConfigPageRoute } from "./routing.js";
 
 // ============================================================================
 // TYPES
@@ -360,8 +361,8 @@ export function hasActiveSession(): boolean {
 }
 
 export function activeSessionId(): string | undefined {
-	// Don't highlight any session when settings (or other non-session views) are open
-	if (window.location.hash === "#/settings") return undefined;
+	// Don't highlight any session when a config page is open
+	if (isConfigPageRoute()) return undefined;
 	return state.selectedSessionId ?? state.remoteAgent?.gatewaySessionId;
 }
 

--- a/tests/config-page-toggle.html
+++ b/tests/config-page-toggle.html
@@ -38,16 +38,26 @@ function getRouteFromHash() {
   return { view: "landing" };
 }
 
+// --- isConfigPageRoute() from src/app/routing.ts (fixed version) ---
+const CONFIG_VIEWS = new Set([
+  "roles", "role-edit", "tools", "tool-edit", "workflows", "workflow-edit",
+  "personalities", "personality-edit", "skills", "settings", "staff", "staff-edit",
+]);
+
+function isConfigPageRoute() {
+  return CONFIG_VIEWS.has(getRouteFromHash().view);
+}
+
 // --- Mock state (simulates a connected session) ---
 const state = {
   selectedSessionId: "mock-session-123",
   remoteAgent: null,
 };
 
-// --- activeSessionId() from src/app/state.ts (current buggy version) ---
-// BUG: Only suppresses highlighting for #/settings, not other config pages.
+// --- activeSessionId() from src/app/state.ts (fixed version) ---
+// FIXED: Suppresses highlighting for ALL config pages, not just settings.
 function activeSessionId() {
-  if (window.location.hash === "#/settings") return undefined;
+  if (isConfigPageRoute()) return undefined;
   return state.selectedSessionId ?? (state.remoteAgent ? state.remoteAgent.gatewaySessionId : undefined);
 }
 

--- a/tests/config-page-toggle.html
+++ b/tests/config-page-toggle.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Config Page Toggle Bug Reproducer</title>
+</head>
+<body>
+<script>
+// ==========================================================================
+// Reproduces the CURRENT (buggy) routing + activeSessionId logic.
+// Copied from src/app/routing.ts and src/app/state.ts verbatim.
+// ==========================================================================
+
+// --- getRouteFromHash() from src/app/routing.ts (current) ---
+function getRouteFromHash() {
+  const hash = window.location.hash || "";
+  const sessionMatch = hash.match(/^#\/session\/([a-f0-9-]+)$/i);
+  if (sessionMatch) return { view: "session", sessionId: sessionMatch[1] };
+  const goalMatch = hash.match(/^#\/goal\/([a-f0-9-]+)$/i);
+  if (goalMatch) return { view: "goal-dashboard", goalId: goalMatch[1] };
+  const roleEditMatch = hash.match(/^#\/roles\/([a-zA-Z0-9_-]+)$/);
+  if (roleEditMatch) return { view: "role-edit", roleName: roleEditMatch[1] };
+  if (hash === "#/roles") return { view: "roles" };
+  const toolEditMatch = hash.match(/^#\/tools\/([a-zA-Z0-9_-]+)$/);
+  if (toolEditMatch) return { view: "tool-edit", toolName: toolEditMatch[1] };
+  if (hash === "#/tools") return { view: "tools" };
+  const workflowEditMatch = hash.match(/^#\/workflows\/([a-zA-Z0-9_-]+)$/);
+  if (workflowEditMatch) return { view: "workflow-edit", workflowId: workflowEditMatch[1] };
+  if (hash === "#/workflows") return { view: "workflows" };
+  const staffEditMatch = hash.match(/^#\/staff\/([a-f0-9-]+)$/i);
+  if (staffEditMatch) return { view: "staff-edit", staffId: staffEditMatch[1] };
+  if (hash === "#/staff") return { view: "staff" };
+  if (hash === "#/skills") return { view: "skills" };
+  const personalityEditMatch = hash.match(/^#\/personalities\/([a-zA-Z0-9_-]+)$/);
+  if (personalityEditMatch) return { view: "personality-edit", personalityName: personalityEditMatch[1] };
+  if (hash === "#/personalities") return { view: "personalities" };
+  if (hash === "#/settings") return { view: "settings" };
+  return { view: "landing" };
+}
+
+// --- Mock state (simulates a connected session) ---
+const state = {
+  selectedSessionId: "mock-session-123",
+  remoteAgent: null,
+};
+
+// --- activeSessionId() from src/app/state.ts (current buggy version) ---
+// BUG: Only suppresses highlighting for #/settings, not other config pages.
+function activeSessionId() {
+  if (window.location.hash === "#/settings") return undefined;
+  return state.selectedSessionId ?? (state.remoteAgent ? state.remoteAgent.gatewaySessionId : undefined);
+}
+
+// Expose to tests
+window.getRouteFromHash = getRouteFromHash;
+window.activeSessionId = activeSessionId;
+window.mockState = state;
+</script>
+</body>
+</html>

--- a/tests/config-page-toggle.spec.ts
+++ b/tests/config-page-toggle.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "@playwright/test";
+import path from "node:path";
+
+const TEST_PAGE = `file://${path.resolve("tests/config-page-toggle.html")}`;
+
+// All config-page routes that should suppress session highlighting
+const CONFIG_ROUTES = [
+	{ hash: "#/roles", view: "roles", label: "Roles" },
+	{ hash: "#/tools", view: "tools", label: "Tools" },
+	{ hash: "#/workflows", view: "workflows", label: "Workflows" },
+	{ hash: "#/personalities", view: "personalities", label: "Personalities" },
+	{ hash: "#/skills", view: "skills", label: "Skills" },
+	{ hash: "#/roles/coder", view: "role-edit", label: "Roles sub-route" },
+	{ hash: "#/tools/browser_click", view: "tool-edit", label: "Tools sub-route" },
+	{ hash: "#/workflows/bug-fix", view: "workflow-edit", label: "Workflows sub-route" },
+	{ hash: "#/personalities/friendly", view: "personality-edit", label: "Personalities sub-route" },
+];
+
+test.describe("Config page toggle buttons — activeSessionId suppression", () => {
+
+	test("baseline: activeSessionId() returns undefined for #/settings (already works)", async ({ page }) => {
+		await page.goto(TEST_PAGE);
+		await page.evaluate(() => { window.location.hash = "#/settings"; });
+		const result = await page.evaluate(() => (window as any).activeSessionId());
+		expect(result).toBeUndefined();
+	});
+
+	test("baseline: activeSessionId() returns session ID for #/session/abc route", async ({ page }) => {
+		await page.goto(TEST_PAGE);
+		await page.evaluate(() => { window.location.hash = "#/session/abc"; });
+		const result = await page.evaluate(() => (window as any).activeSessionId());
+		expect(result).toBe("mock-session-123");
+	});
+
+	test("baseline: activeSessionId() returns session ID on landing page", async ({ page }) => {
+		await page.goto(TEST_PAGE);
+		await page.evaluate(() => { window.location.hash = "#/"; });
+		const result = await page.evaluate(() => (window as any).activeSessionId());
+		expect(result).toBe("mock-session-123");
+	});
+
+	for (const route of CONFIG_ROUTES) {
+		test(`activeSessionId should be undefined on config route ${route.hash}`, async ({ page }) => {
+			await page.goto(TEST_PAGE);
+			await page.evaluate((h) => { window.location.hash = h; }, route.hash);
+			const result = await page.evaluate(() => (window as any).activeSessionId());
+			expect(result, `activeSessionId should be undefined on config route ${route.hash} but got "${result}"`).toBeUndefined();
+		});
+	}
+
+	test("getRouteFromHash correctly identifies config page views", async ({ page }) => {
+		await page.goto(TEST_PAGE);
+		for (const route of CONFIG_ROUTES) {
+			await page.evaluate((h) => { window.location.hash = h; }, route.hash);
+			const result = await page.evaluate(() => (window as any).getRouteFromHash());
+			expect(result.view, `Expected view "${route.view}" for ${route.hash}`).toBe(route.view);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Fixes sidebar config buttons (Roles, Personalities, Tools, Workflows, Skills) to match the Settings button pattern:

1. **Active highlighting** — buttons now show `text-primary bg-primary/10 font-medium` when their config page is active (including sub-routes like `#/roles/coder`)
2. **Toggle behavior** — clicking a button while its page is active navigates back to the previously viewed session
3. **Session suppression** — no session row shows as active while any config page is open

### Changes
- `src/app/routing.ts` — Added `isConfigPageRoute()`, `isRouteActive()`, and `toggleConfigPage()` helpers with shared `_configPreviousHash` state
- `src/app/state.ts` — Updated `activeSessionId()` to suppress for all config routes (not just Settings)
- `src/app/sidebar.ts` — Desktop sidebar buttons use active styling + toggle
- `src/app/render.ts` — Mobile buttons use same active styling + toggle  
- `src/app/settings-page.ts` — Refactored `toggleSettings()` to use shared `toggleConfigPage()`
- `tests/config-page-toggle.spec.ts` + `.html` — Reproducing test (13 cases)