### PR TITLE
Fix wand chat blob accessory

### DIFF
--- a/src/app/role-manager.css
+++ b/src/app/role-manager.css
@@ -674,6 +674,7 @@
 .bobbit-blob--inline .bobbit-blob__shield,
 .bobbit-blob--inline .bobbit-blob__set-square,
 .bobbit-blob--inline .bobbit-blob__flask,
+.bobbit-blob--inline .bobbit-blob__wand,
 .bobbit-blob--inline .bobbit-blob__wizard-hat {
 	display: none !important;
 }
@@ -687,4 +688,4 @@
 .bobbit-blob--inline.bobbit-set-square .bobbit-blob__set-square { display: block !important; }
 .bobbit-blob--inline.bobbit-flask .bobbit-blob__flask { display: block !important; }
 .bobbit-blob--inline.bobbit-wand .bobbit-blob__wand { display: block !important; }
- .bobbit-blob--inline.bobbit-wizard-hat .bobbit-blob__wizard-hat { display: block !important; }
+.bobbit-blob--inline.bobbit-wizard-hat .bobbit-blob__wizard-hat { display: block !important; }

--- a/src/app/role-manager.css
+++ b/src/app/role-manager.css
@@ -686,4 +686,5 @@
 .bobbit-blob--inline.bobbit-shield .bobbit-blob__shield { display: block !important; }
 .bobbit-blob--inline.bobbit-set-square .bobbit-blob__set-square { display: block !important; }
 .bobbit-blob--inline.bobbit-flask .bobbit-blob__flask { display: block !important; }
-.bobbit-blob--inline.bobbit-wizard-hat .bobbit-blob__wizard-hat { display: block !important; }
+.bobbit-blob--inline.bobbit-wand .bobbit-blob__wand { display: block !important; }
+ .bobbit-blob--inline.bobbit-wizard-hat .bobbit-blob__wizard-hat { display: block !important; }

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -378,7 +378,7 @@ export function selectSession(sessionId: string, replaceHistory?: boolean): void
 
 	// Update accessory class synchronously
 	const sessionData = state.gatewaySessions.find((s) => s.id === sessionId);
-	const accClasses = ["bobbit-crowned", "bobbit-bandana", "bobbit-magnifier", "bobbit-palette", "bobbit-pencil", "bobbit-shield", "bobbit-set-square", "bobbit-flask", "bobbit-wand", "bobbit-wizard-hat"];
+	const accClasses = ["bobbit-crowned", "bobbit-bandana", "bobbit-magnifier", "bobbit-palette", "bobbit-pencil", "bobbit-shield", "bobbit-set-square", "bobbit-flask", "bobbit-wizard-hat", "bobbit-wand"];
 	accClasses.forEach((c) => document.documentElement.classList.remove(c));
 	const accId = sessionData?.accessory
 		?? (sessionData?.role === "team-lead" ? "crown" : sessionData?.role === "coder" ? "bandana" : undefined);
@@ -656,7 +656,7 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 
 		// Re-apply accessory class after refreshSessions (may have new data)
 		const sessionForRole = state.gatewaySessions.find((s) => s.id === sessionId);
-		const accClasses = ["bobbit-crowned", "bobbit-bandana", "bobbit-magnifier", "bobbit-palette", "bobbit-pencil", "bobbit-shield", "bobbit-set-square", "bobbit-flask", "bobbit-wand", "bobbit-wizard-hat"];
+		const accClasses = ["bobbit-crowned", "bobbit-bandana", "bobbit-magnifier", "bobbit-palette", "bobbit-pencil", "bobbit-shield", "bobbit-set-square", "bobbit-flask", "bobbit-wizard-hat", "bobbit-wand"];
 		accClasses.forEach((c) => document.documentElement.classList.remove(c));
 		const accId = sessionForRole?.accessory
 			?? (sessionForRole?.role === "team-lead" ? "crown" : sessionForRole?.role === "coder" ? "bandana" : undefined);

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -378,7 +378,7 @@ export function selectSession(sessionId: string, replaceHistory?: boolean): void
 
 	// Update accessory class synchronously
 	const sessionData = state.gatewaySessions.find((s) => s.id === sessionId);
-	const accClasses = ["bobbit-crowned", "bobbit-bandana", "bobbit-magnifier", "bobbit-palette", "bobbit-pencil", "bobbit-shield", "bobbit-set-square", "bobbit-flask", "bobbit-wizard-hat"];
+	const accClasses = ["bobbit-crowned", "bobbit-bandana", "bobbit-magnifier", "bobbit-palette", "bobbit-pencil", "bobbit-shield", "bobbit-set-square", "bobbit-flask", "bobbit-wand", "bobbit-wizard-hat"];
 	accClasses.forEach((c) => document.documentElement.classList.remove(c));
 	const accId = sessionData?.accessory
 		?? (sessionData?.role === "team-lead" ? "crown" : sessionData?.role === "coder" ? "bandana" : undefined);
@@ -656,7 +656,7 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 
 		// Re-apply accessory class after refreshSessions (may have new data)
 		const sessionForRole = state.gatewaySessions.find((s) => s.id === sessionId);
-		const accClasses = ["bobbit-crowned", "bobbit-bandana", "bobbit-magnifier", "bobbit-palette", "bobbit-pencil", "bobbit-shield", "bobbit-set-square", "bobbit-flask", "bobbit-wizard-hat"];
+		const accClasses = ["bobbit-crowned", "bobbit-bandana", "bobbit-magnifier", "bobbit-palette", "bobbit-pencil", "bobbit-shield", "bobbit-set-square", "bobbit-flask", "bobbit-wand", "bobbit-wizard-hat"];
 		accClasses.forEach((c) => document.documentElement.classList.remove(c));
 		const accId = sessionForRole?.accessory
 			?? (sessionForRole?.role === "team-lead" ? "crown" : sessionForRole?.role === "coder" ? "bandana" : undefined);

--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -1791,6 +1791,79 @@ html {
 	animation: blob-compact-pop-rigid 0.6s cubic-bezier(0.34, 1.56, 0.64, 1) forwards !important;
 }
 
+/* ── Wand ───────────────────────────────────────────────────── */
+@keyframes wand-depth-busy {
+	0%, 33% { z-index: 1; }
+	34%     { z-index: -1; }
+	54%     { z-index: 1; }
+	60%     { z-index: -1; }
+	65%, 95% { z-index: 1; }
+	96%     { z-index: -1; }
+	98%, 100% { z-index: 1; }
+}
+@keyframes wand-depth-idle {
+	0%, 24% { z-index: 1; }
+	25%     { z-index: -1; }
+	45%     { z-index: -1; }
+	46%, 54% { z-index: 1; }
+	55%     { z-index: -1; }
+	85%     { z-index: -1; }
+	86%, 100% { z-index: 1; }
+}
+
+.bobbit-blob__wand {
+	display: none;
+}
+.bobbit-wand .bobbit-blob__wand {
+	display: block;
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	overflow: visible;
+	transform-origin: 5px 8px;
+	transform: scale(4);
+	margin: 8px 18px 28px 18px;
+	image-rendering: pixelated;
+	filter: hue-rotate(calc(-1 * var(--bobbit-hue-rotate, 0deg)));
+	box-shadow:
+		11px 2px 0 #fef08a, 12px 2px 0 #fbbf24,
+		10px 3px 0 #fde047, 11px 3px 0 #fff, 12px 3px 0 #fde047,
+		10px 4px 0 #fbbf24, 11px 4px 0 #fbbf24,
+		9px 5px 0 #000, 10px 5px 0 #cd853f, 11px 5px 0 #000,
+		8px 6px 0 #000, 9px 6px 0 #cd853f, 10px 6px 0 #000,
+		7px 7px 0 #000, 8px 7px 0 #8b4513, 9px 7px 0 #000,
+		6px 8px 0 #000, 7px 8px 0 #8b4513, 8px 8px 0 #000,
+		5px 9px 0 #000, 6px 9px 0 #000;
+	animation:
+		blob-busy-move-rigid 10s cubic-bezier(0.34, 1, 0.64, 1) infinite,
+		wand-depth-busy 10s steps(1) infinite;
+}
+.bobbit-blob--idle .bobbit-blob__wand {
+	animation: wand-depth-idle 10s steps(1) infinite;
+	transform: scale(4) translateX(-7px);
+}
+.bobbit-blob--exit .bobbit-blob__wand {
+	animation: blob-exit-rigid 0.7s cubic-bezier(0.34, 1.56, 0.64, 1) forwards !important;
+}
+.bobbit-blob--exit-roll .bobbit-blob__wand {
+	animation: blob-exit-roll-rigid 0.9s cubic-bezier(0.22, 1, 0.36, 1) forwards !important;
+}
+.bobbit-blob--enter .bobbit-blob__wand {
+	animation: blob-enter-rigid 0.7s cubic-bezier(0.34, 1.56, 0.64, 1) forwards !important;
+}
+.bobbit-blob--enter-roll .bobbit-blob__wand {
+	animation: blob-enter-roll-rigid 0.9s cubic-bezier(0.22, 1, 0.36, 1) forwards !important;
+}
+.bobbit-blob--compact-shake .bobbit-blob__wand {
+	animation: blob-compact-shake-rigid 0.8s ease-in-out forwards !important;
+}
+.bobbit-blob--compacting .bobbit-blob__wand {
+	animation: blob-compact-squash-rigid 3s ease-in-out infinite !important;
+}
+.bobbit-blob--compact-pop .bobbit-blob__wand {
+	animation: blob-compact-pop-rigid 0.6s cubic-bezier(0.34, 1.56, 0.64, 1) forwards !important;
+}
+
 /* ── Wizard Hat ─────────────────────────────────────────────── */
 .bobbit-blob__wizard-hat {
 	display: none;

--- a/src/ui/components/StreamingMessageContainer.ts
+++ b/src/ui/components/StreamingMessageContainer.ts
@@ -205,6 +205,7 @@ export class StreamingMessageContainer extends LitElement {
 						<div class="bobbit-blob__shield"></div>
 						<div class="bobbit-blob__set-square"></div>
 						<div class="bobbit-blob__flask"></div>
+						<div class="bobbit-blob__wand"></div>
 						<div class="bobbit-blob__wizard-hat"></div>
 						<div class="bobbit-blob__shadow"></div>
 					</div>
@@ -249,6 +250,7 @@ export class StreamingMessageContainer extends LitElement {
 						<div class="bobbit-blob__shield"></div>
 						<div class="bobbit-blob__set-square"></div>
 						<div class="bobbit-blob__flask"></div>
+						<div class="bobbit-blob__wand"></div>
 						<div class="bobbit-blob__wizard-hat"></div>
 						<div class="bobbit-blob__shadow"></div>
 					</div>` : ""}

--- a/tests/wand-accessory.spec.ts
+++ b/tests/wand-accessory.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+
+test.describe("wand accessory chat blob integration", () => {
+	test("StreamingMessageContainer.ts contains bobbit-blob__wand div", () => {
+		const source = fs.readFileSync(
+			path.resolve("src/ui/components/StreamingMessageContainer.ts"),
+			"utf-8"
+		);
+		// All other accessories have their div: magnifier, palette, pencil, shield, set-square, flask, wizard-hat
+		// The wand must also have its div
+		expect(
+			source.includes("bobbit-blob__wand"),
+			"Expected StreamingMessageContainer.ts to contain bobbit-blob__wand div for wand accessory"
+		).toBe(true);
+	});
+
+	test("session-manager.ts includes bobbit-wand in accClasses arrays", () => {
+		const source = fs.readFileSync(
+			path.resolve("src/app/session-manager.ts"),
+			"utf-8"
+		);
+		// Both accClasses arrays must include "bobbit-wand" for proper class cleanup
+		const accClassesMatches = source.match(/accClasses\s*=\s*\[([^\]]+)\]/g);
+		expect(
+			accClassesMatches && accClassesMatches.length >= 2,
+			"Expected session-manager.ts to have at least 2 accClasses arrays"
+		).toBe(true);
+		for (const match of accClassesMatches!) {
+			expect(
+				match.includes("bobbit-wand"),
+				"Expected session-manager.ts accClasses to include bobbit-wand for class cleanup"
+			).toBe(true);
+		}
+	});
+
+	test("app.css contains .bobbit-blob__wand CSS rules", () => {
+		const source = fs.readFileSync(
+			path.resolve("src/ui/app.css"),
+			"utf-8"
+		);
+		expect(
+			source.includes(".bobbit-blob__wand"),
+			"Expected app.css to contain .bobbit-blob__wand CSS rules for wand accessory rendering"
+		).toBe(true);
+	});
+
+	test("role-manager.css contains inline blob wand override rule", () => {
+		const source = fs.readFileSync(
+			path.resolve("src/app/role-manager.css"),
+			"utf-8"
+		);
+		expect(
+			source.includes(".bobbit-blob--inline.bobbit-wand"),
+			"Expected role-manager.css to contain .bobbit-blob--inline.bobbit-wand rule for role picker tiles"
+		).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Wire up the wand accessory (used by the assistant role) to the chat blob rendering pipeline. The wand pixel-art data existed in session-colors.ts but was never connected to the chat blob DOM/CSS.

## Changes

1. **StreamingMessageContainer.ts** — Added `<div class="bobbit-blob__wand">` to both blob templates (active and idle)
2. **app.css** — Added full wand CSS rules: depth keyframes, base hidden rule, activation with pixel-art box-shadow, counter hue-rotate, and all 9 animation state variants (idle, exit, exit-roll, enter, enter-roll, compact-shake, compacting, compact-pop)
3. **session-manager.ts** — Added `"bobbit-wand"` to both `accClasses` arrays to prevent accessory class leaking between sessions
4. **role-manager.css** — Added wand to the inline blob blocking selector group and activation rule for role picker tiles
5. **wand-accessory.spec.ts** — Reproducing test covering all 4 requirements

## Verification

- All 4 wand-specific tests pass
- 243 unit tests pass
- 262 E2E tests pass
- Type check passes
- Gap analysis, code quality, and security reviews all pass