### PR TITLE
Fix wand blob rendering

### DIFF
--- a/src/app/role-manager-page.ts
+++ b/src/app/role-manager-page.ts
@@ -45,6 +45,8 @@ function idleBlob(accId: string, size = 40, hueIndex = 0, phaseIndex = 0): Templ
 					<div class="bobbit-blob__shield"></div>
 					<div class="bobbit-blob__set-square"></div>
 					<div class="bobbit-blob__flask"></div>
+					<div class="bobbit-blob__wand"></div>
+					<div class="bobbit-blob__wizard-hat"></div>
 				</div>
 			</div>
 		</div>

--- a/tests/role-manager-wand.spec.ts
+++ b/tests/role-manager-wand.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+
+test.describe("role-manager-page idleBlob accessory divs", () => {
+	test("idleBlob template contains bobbit-blob__wand div", () => {
+		const source = fs.readFileSync(
+			path.resolve("src/app/role-manager-page.ts"),
+			"utf-8"
+		);
+		expect(
+			source.includes("bobbit-blob__wand"),
+			"Expected role-manager-page.ts idleBlob template to contain bobbit-blob__wand div for wand accessory rendering"
+		).toBe(true);
+	});
+
+	test("idleBlob template contains bobbit-blob__wizard-hat div", () => {
+		const source = fs.readFileSync(
+			path.resolve("src/app/role-manager-page.ts"),
+			"utf-8"
+		);
+		expect(
+			source.includes("bobbit-blob__wizard-hat"),
+			"Expected role-manager-page.ts idleBlob template to contain bobbit-blob__wizard-hat div for wizard-hat accessory rendering"
+		).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Adds two missing `<div>` elements to the `idleBlob()` template in `src/app/role-manager-page.ts`:
- `<div class="bobbit-blob__wand"></div>`
- `<div class="bobbit-blob__wizard-hat"></div>`

These were the only accessories missing from the template, causing roles with the wand accessory to show a plain blob on the roles page and in the accessory chooser grid.

## Changes
- `src/app/role-manager-page.ts`: Added the two missing divs after the flask div
- `tests/role-manager-wand.spec.ts`: New test verifying both divs are present

## Verification
- Type check passes
- All 6 wand-related tests pass
- All 262 E2E tests pass
- Code quality, gap, and security reviews passed