### PR TITLE
fix: viewport-stable tool collapse — pin top of view during shrink

### DIFF
--- a/src/ui/components/AgentInterface.ts
+++ b/src/ui/components/AgentInterface.ts
@@ -88,6 +88,7 @@ export class AgentInterface extends LitElement {
 	private _scrollContainer?: HTMLElement;
 	private _resizeObserver?: ResizeObserver;
 	private _lastScrollHeight = 0;
+	private _collapseCompensation = 0;
 	private _unsubscribeSession?: () => void;
 	// Server-authoritative queue state, updated via onQueueUpdate callback
 	private _serverQueue: Array<{ id: string; text: string; isSteered: boolean; createdAt: number; images?: any[]; attachments?: any[] }> = [];
@@ -145,23 +146,53 @@ export class AgentInterface extends LitElement {
 				if (!this._scrollContainer) return;
 				const newScrollHeight = this._scrollContainer.scrollHeight;
 				const delta = newScrollHeight - this._lastScrollHeight;
-				this._lastScrollHeight = newScrollHeight;
 
 				if (this._stickToBottom) {
-					this._isAutoScrolling = true;
-					this._scrollContainer.scrollTop = this._scrollContainer.scrollHeight;
+					if (delta < 0) {
+						// Content shrunk (e.g. tool collapsed) while stuck to bottom.
+						// Add bottom padding to compensate so scrollHeight is maintained
+						// and the browser doesn't clamp scrollTop (which causes a jolt).
+						// Subsequent content growth will gradually consume this padding.
+						const wrapper = this._scrollContainer.querySelector(".max-w-5xl") as HTMLElement;
+						if (wrapper) {
+							this._collapseCompensation += Math.abs(delta);
+							wrapper.style.paddingBottom = this._collapseCompensation + "px";
+						}
+						this._lastScrollHeight = this._scrollContainer.scrollHeight;
+						this._isAutoScrolling = true;
+						this._scrollContainer.scrollTop = this._scrollContainer.scrollHeight;
+					} else if (delta > 0 && this._collapseCompensation > 0) {
+						// Content grew while we have compensation padding — absorb
+						// the growth into the padding so scrollHeight stays stable.
+						const wrapper = this._scrollContainer.querySelector(".max-w-5xl") as HTMLElement;
+						if (wrapper) {
+							const absorbed = Math.min(delta, this._collapseCompensation);
+							this._collapseCompensation -= absorbed;
+							wrapper.style.paddingBottom = this._collapseCompensation > 0 ? this._collapseCompensation + "px" : "";
+						}
+						this._lastScrollHeight = this._scrollContainer.scrollHeight;
+						this._isAutoScrolling = true;
+						this._scrollContainer.scrollTop = this._scrollContainer.scrollHeight;
+					} else {
+						this._lastScrollHeight = newScrollHeight;
+						this._isAutoScrolling = true;
+						this._scrollContainer.scrollTop = this._scrollContainer.scrollHeight;
+					}
 					clearTimeout(this._autoScrollTimer);
 					this._autoScrollTimer = setTimeout(() => {
 						this._isAutoScrolling = false;
 					}, 150);
 				} else if (delta < 0) {
 					// Content shrunk (e.g. tool collapsed) — adjust scroll to keep viewport stable
+					this._lastScrollHeight = newScrollHeight;
 					this._isAutoScrolling = true;
 					this._scrollContainer.scrollTop += delta;
 					clearTimeout(this._autoScrollTimer);
 					this._autoScrollTimer = setTimeout(() => {
 						this._isAutoScrolling = false;
 					}, 150);
+				} else {
+					this._lastScrollHeight = newScrollHeight;
 				}
 			});
 

--- a/tests/fixtures/scroll-anchor-shrink.html
+++ b/tests/fixtures/scroll-anchor-shrink.html
@@ -72,6 +72,7 @@ let _stickToBottom = true;
 let _isAutoScrolling = false;
 let _autoScrollTimer;
 let _lastScrollHeight = scrollContainer.scrollHeight;
+let _collapseCompensation = 0;
 
 // The resize handler — same logic as the ResizeObserver callback in AgentInterface.ts.
 // Called manually in the test since ResizeObserver doesn't fire in headless Chromium.
@@ -82,8 +83,33 @@ function handleResize() {
   _lastScrollHeight = newScrollHeight;
 
   if (_stickToBottom) {
-    _isAutoScrolling = true;
-    scrollContainer.scrollTop = scrollContainer.scrollHeight;
+    if (delta < 0) {
+      // Content shrunk (e.g. tool collapsed) while stuck to bottom.
+      // Add bottom padding to compensate so scrollHeight is maintained
+      // and the browser doesn't clamp scrollTop (which causes a jolt).
+      const wrapper = document.getElementById('content-wrapper');
+      if (wrapper) {
+        _collapseCompensation += Math.abs(delta);
+        wrapper.style.paddingBottom = _collapseCompensation + 'px';
+      }
+      _lastScrollHeight = scrollContainer.scrollHeight;
+      _isAutoScrolling = true;
+      scrollContainer.scrollTop = scrollContainer.scrollHeight;
+    } else if (delta > 0 && _collapseCompensation > 0) {
+      // Content grew while we have compensation padding — absorb growth
+      const wrapper = document.getElementById('content-wrapper');
+      if (wrapper) {
+        const absorbed = Math.min(delta, _collapseCompensation);
+        _collapseCompensation -= absorbed;
+        wrapper.style.paddingBottom = _collapseCompensation + 'px';
+        _lastScrollHeight = scrollContainer.scrollHeight;
+      }
+      _isAutoScrolling = true;
+      scrollContainer.scrollTop = scrollContainer.scrollHeight;
+    } else {
+      _isAutoScrolling = true;
+      scrollContainer.scrollTop = scrollContainer.scrollHeight;
+    }
     clearTimeout(_autoScrollTimer);
     _autoScrollTimer = setTimeout(() => { _isAutoScrolling = false; }, 150);
   } else if (delta < 0) {

--- a/tests/scroll-anchor-shrink.spec.ts
+++ b/tests/scroll-anchor-shrink.spec.ts
@@ -124,4 +124,42 @@ test.describe("Scroll anchor on shrink", () => {
 		// scrollTop should not change — new content below viewport shouldn't pull user down
 		expect(scrollTopAfter).toBe(scrollTopBefore);
 	});
+
+	test("preserves viewport position when content shrinks while stuck to bottom", async ({ page }) => {
+		await page.goto(TEST_PAGE);
+
+		// Scroll to bottom so stickToBottom = true
+		await page.evaluate(() => {
+			const sc = document.getElementById("scroll-container")!;
+			(window as any).__scrollTo(sc.scrollHeight);
+		});
+		await page.waitForTimeout(200);
+
+		const state = await page.evaluate(() => (window as any).__getState());
+		expect(state.stickToBottom).toBe(true);
+
+		// Record scrollTop before collapse
+		const scrollTopBefore = await page.evaluate(() =>
+			document.getElementById("scroll-container")!.scrollTop,
+		);
+
+		// Collapse the element and trigger resize handler
+		await page.evaluate(() => {
+			(window as any).__collapseElement();
+			(window as any).__handleResize();
+		});
+		await page.waitForTimeout(100);
+
+		const scrollTopAfter = await page.evaluate(() =>
+			document.getElementById("scroll-container")!.scrollTop,
+		);
+
+		// The collapsible shrank by 400px. scrollTop should be preserved (not snapped
+		// to the new, lower bottom). Currently FAILS because the ResizeObserver callback
+		// unconditionally scrolls to bottom when _stickToBottom is true.
+		expect(
+			scrollTopAfter,
+			"scrollTop should be preserved during collapse when stickToBottom is true",
+		).toBe(scrollTopBefore);
+	});
 });


### PR DESCRIPTION
## Problem

When a tool renderer completes and collapses (e.g. `ls` output shrinking from expanded to collapsed via `max-h-[2000px]` → `max-h-0` CSS transition), the stick-to-bottom logic in `AgentInterface.ts` snaps the viewport to the new bottom. This pulls content the user was actively reading upward and out of view.

## Fix

Modified the `ResizeObserver` callback in `AgentInterface.ts` to distinguish content **growth** (new streaming content) from **shrinkage** (tool collapse):

- **Growth (delta >= 0)**: scroll to bottom as before (streaming auto-scroll)
- **Shrinkage (delta < 0)**: add bottom padding compensation to maintain `scrollHeight`, preventing the browser from clamping `scrollTop` and causing a viewport jolt. Subsequent content growth gradually absorbs the compensation padding.

This uses a `_collapseCompensation` counter that tracks accumulated padding added during collapses, which is then absorbed as new content streams in.

## Changes

- `src/ui/components/AgentInterface.ts` — shrinkage detection + padding compensation in ResizeObserver callback
- `tests/fixtures/scroll-anchor-shrink.html` — updated fixture to mirror new logic  
- `tests/scroll-anchor-shrink.spec.ts` — added reproducing test for the stickToBottom+collapse case

## Testing

- All 263 unit tests pass
- All 262 E2E tests pass
- Type check passes
- Reproducing test confirms the fix works