### PR TITLE
Remove dashboard summary row

### DIFF
--- a/src/app/goal-dashboard.css
+++ b/src/app/goal-dashboard.css
@@ -227,83 +227,6 @@
 .meta-tag.merge-merged { background: oklch(0.65 0.15 145 / 0.12); color: oklch(0.72 0.15 145); }
 .meta-tag.cost-tag { background: oklch(0.65 0.12 145 / 0.12); color: oklch(0.75 0.12 145); }
 
-/* ── COMPACT SUMMARY ROW ── */
-.summary-row {
-	display: flex;
-	align-items: center;
-	padding: 8px 20px;
-	gap: 0;
-	border-bottom: 1px solid var(--border);
-	background: var(--background);
-	flex-shrink: 0;
-}
-.summary-ring {
-	display: flex;
-	align-items: center;
-	gap: 10px;
-	padding-right: 16px;
-	border-right: 1px solid var(--border);
-}
-.ring-container { position: relative; width: 36px; height: 36px; flex-shrink: 0; }
-.ring-bg, .ring-fg {
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 36px;
-	height: 36px;
-	fill: none;
-	stroke-width: 3.5;
-	stroke-linecap: round;
-}
-.ring-bg { stroke: var(--border); }
-.ring-fg {
-	stroke: var(--primary);
-	transform: rotate(-90deg);
-	transform-origin: center;
-}
-.ring-label {
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	transform: translate(-50%,-50%);
-	font-size: 10px;
-	font-weight: 700;
-}
-.ring-text { font-size: 12px; font-weight: 600; white-space: nowrap; }
-.ring-sub { font-size: 10px; color: var(--text-tertiary); }
-.summary-stats { display: flex; gap: 0; }
-.mini-stat {
-	display: flex;
-	align-items: center;
-	gap: 5px;
-	padding: 6px 14px;
-	border-right: 1px solid var(--border-subtle);
-	white-space: nowrap;
-}
-.mini-stat:last-child { border-right: none; }
-.mini-stat-value { font-size: 15px; font-weight: 700; line-height: 1; }
-.mini-stat-label {
-	font-size: 10px;
-	color: var(--text-tertiary);
-	text-transform: uppercase;
-	letter-spacing: 0.04em;
-}
-.summary-agents {
-	display: flex;
-	align-items: center;
-	gap: 6px;
-	margin-left: auto;
-	padding-left: 16px;
-	border-left: 1px solid var(--border);
-}
-.bobbit-row { display: flex; gap: 4px; align-items: center; }
-.bobbit-mini-label {
-	font-size: 10px;
-	color: var(--text-tertiary);
-	margin-left: 4px;
-	white-space: nowrap;
-}
-
 /* ── PHASE PIPELINE ── */
 .phase-pipeline {
 	display: flex;
@@ -873,8 +796,6 @@
 
 /* ── RESPONSIVE ── */
 @media (max-width: 900px) {
-	.summary-row { flex-wrap: wrap; gap: 8px; }
-	.summary-agents { margin-left: 0; border-left: none; padding-left: 0; }
 	.phase-pipeline { flex-wrap: wrap; gap: 4px; justify-content: flex-start; }
 	.agent-grid { grid-template-columns: 1fr; }
 }

--- a/src/app/goal-dashboard.ts
+++ b/src/app/goal-dashboard.ts
@@ -1040,74 +1040,6 @@ function renderMetaRows(goal: Goal): TemplateResult {
 }
 
 // ============================================================================
-// RENDER: SUMMARY ROW
-// ============================================================================
-
-function renderSummaryRow(taskList: Task[], agentList: TeamAgent[]): TemplateResult {
-	const total = taskList.length;
-	const done = taskList.filter((t) => t.state === "complete").length;
-	const inProgress = taskList.filter((t) => t.state === "in-progress").length;
-	const failed = taskList.filter((t) => t.state === "skipped").length;
-	const pct = total > 0 ? Math.round((done / total) * 100) : 0;
-	const circumference = 2 * Math.PI * 14; // radius 14
-	const offset = circumference - (pct / 100) * circumference;
-
-	const workingAgents = agentList.filter(a => a.status === "streaming").length;
-	const idleAgents = agentList.length - workingAgents;
-
-	return html`
-		<div class="summary-row">
-			<div class="summary-ring">
-				<div class="ring-container">
-					<svg class="ring-bg" viewBox="0 0 36 36"><circle cx="18" cy="18" r="14"/></svg>
-					<svg class="ring-fg" viewBox="0 0 36 36"><circle cx="18" cy="18" r="14" stroke-dasharray="${circumference}" stroke-dashoffset="${offset}"/></svg>
-					<div class="ring-label">${pct}%</div>
-				</div>
-				<div>
-					<div class="ring-text">${done}/${total} tasks</div>
-					<div class="ring-sub">complete</div>
-				</div>
-			</div>
-			<div class="summary-stats">
-				<div class="mini-stat">
-					<span class="mini-stat-value" style="color:oklch(0.72 0.15 250)">${inProgress}</span>
-					<span class="mini-stat-label">Active</span>
-				</div>
-				<div class="mini-stat">
-					<span class="mini-stat-value" style="color:var(--destructive)">${failed}</span>
-					<span class="mini-stat-label">Failed</span>
-				</div>
-				<div class="mini-stat">
-					<span class="mini-stat-value" style="color:oklch(0.72 0.15 145)">${agentList.length}</span>
-					<span class="mini-stat-label">Agents</span>
-				</div>
-			</div>
-			${agentList.length > 0 ? html`
-				<div class="summary-agents">
-					<div class="bobbit-row">
-						${agentList.map(agent => {
-							const session = state.gatewaySessions.find(s => s.id === agent.sessionId)
-								|| state.archivedSessions.find(s => s.id === agent.sessionId);
-							return statusBobbit(
-								session?.status ?? agent.status,
-								session?.isCompacting ?? false,
-								agent.sessionId,
-								false,
-								session?.isAborting ?? false,
-								agent.role === "team-lead",
-								agent.role === "coder",
-								session?.accessory,
-							);
-						})}
-					</div>
-					<span class="bobbit-mini-label">${workingAgents} working, ${idleAgents} idle</span>
-				</div>
-			` : nothing}
-		</div>
-	`;
-}
-
-// ============================================================================
 // RENDER: GATE PIPELINE (horizontal visualization)
 // ============================================================================
 
@@ -1813,7 +1745,6 @@ export function renderGoalDashboard(): TemplateResult {
 			` : nothing}
 			${renderSetupBanner(currentGoal)}
 			${renderMetaRows(currentGoal)}
-			${renderSummaryRow(tasks, agents)}
 			${renderGatePipeline()}
 			${renderTabBar()}
 			<div class="tab-content">


### PR DESCRIPTION
Removes the summary row from the goal dashboard — the horizontal strip between the metadata rows and the gate pipeline containing the task completion ring chart, Active/Failed/Agents mini-stats, and animated bobbit avatar row.

## Changes
- **`src/app/goal-dashboard.ts`**: Removed `renderSummaryRow()` function and its call
- **`src/app/goal-dashboard.css`**: Removed all summary row CSS rules and responsive overrides

All type checks, unit tests, and E2E tests pass.