### PR TITLE
Message Timestamps

### DIFF
--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -794,6 +794,11 @@ export class RemoteAgent {
 			}
 		}
 
+		// Apply showTimestamps
+		if ("showTimestamps" in prefs) {
+			document.documentElement.dataset.showTimestamps = prefs.showTimestamps ? "true" : "";
+		}
+
 		// Apply shortcuts
 		if ("shortcuts" in prefs) {
 			import("./shortcut-registry.js").then((m) => m.loadSavedBindings());

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -39,6 +39,9 @@ let settingsCwd = "";
 let settingsCwdLoaded = false;
 let settingsCwdSaveStatus: "" | "saving" | "saved" | "error" = "";
 
+let settingsShowTimestamps = false;
+let settingsShowTimestampsLoaded = false;
+
 // ── Project tab state ──
 let projectConfig: Record<string, string> = {};
 let projectDefaults: Record<string, string> = {};
@@ -992,9 +995,34 @@ function renderProjectTab() {
 }
 
 function loadGeneralSettings() {
-	if (settingsCwdLoaded) return;
-	settingsCwd = state.defaultCwd;
-	settingsCwdLoaded = true;
+	if (!settingsCwdLoaded) {
+		settingsCwd = state.defaultCwd;
+		settingsCwdLoaded = true;
+	}
+	if (!settingsShowTimestampsLoaded) {
+		settingsShowTimestampsLoaded = true;
+		(async () => {
+			try {
+				const res = await gatewayFetch("/api/preferences");
+				if (res.ok) {
+					const prefs = await res.json();
+					settingsShowTimestamps = !!prefs.showTimestamps;
+					renderApp();
+				}
+			} catch {}
+		})();
+	}
+}
+
+async function toggleShowTimestamps(): Promise<void> {
+	settingsShowTimestamps = !settingsShowTimestamps;
+	renderApp();
+	try {
+		await gatewayFetch("/api/preferences", {
+			method: "PUT",
+			body: JSON.stringify({ showTimestamps: settingsShowTimestamps }),
+		});
+	} catch {}
 }
 
 async function saveDefaultCwd(): Promise<void> {
@@ -1046,6 +1074,21 @@ function renderGeneralTab() {
 				</div>
 				${settingsCwdSaveStatus === "saved" ? html`<p class="text-xs text-green-600">Saved successfully.</p>` : ""}
 				${settingsCwdSaveStatus === "error" ? html`<p class="text-xs text-destructive">Failed to save.</p>` : ""}
+			</div>
+
+			<div class="flex flex-col gap-1.5">
+				<label class="flex items-center gap-2 cursor-pointer">
+					<input
+						type="checkbox"
+						class="w-4 h-4 rounded border-input accent-primary cursor-pointer"
+						.checked=${settingsShowTimestamps}
+						@change=${toggleShowTimestamps}
+					/>
+					<span class="text-sm font-medium text-foreground">Show message timestamps</span>
+				</label>
+				<p class="text-xs text-muted-foreground ml-6">
+					Display timestamps next to user and assistant messages.
+				</p>
 			</div>
 		</div>
 	`;

--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -3002,6 +3002,23 @@ html {
 	line-height: 1;
 }
 
+/* Message timestamps — hidden by default, shown when preference enabled */
+.message-timestamp {
+	display: none;
+	font-size: 0.7rem;
+	color: var(--muted-foreground);
+	white-space: nowrap;
+	user-select: none;
+	align-self: flex-end;
+	padding: 0 0.25rem;
+	line-height: 1;
+	opacity: 0.7;
+}
+
+[data-show-timestamps="true"] .message-timestamp {
+	display: inline-block;
+}
+
 /* ── Mobile: add left margin to bobbit so idle position doesn't hug the screen edge
       when container padding is tighter (p-2 vs p-4). This avoids changing translateX
       which would break the seamless exit/enter transition animations. ── */

--- a/src/ui/components/Messages.ts
+++ b/src/ui/components/Messages.ts
@@ -16,6 +16,14 @@ import "./LiveTimer.js";
 import "./ToolGroup.js";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 
+/** Format a message timestamp for display (locale-appropriate time). */
+export function formatTimestamp(ts: number | string | undefined): string {
+	if (!ts) return "";
+	const date = typeof ts === "string" ? new Date(ts) : new Date(ts);
+	if (isNaN(date.getTime())) return "";
+	return date.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+}
+
 /** Minimum consecutive same-name completed tool calls to form a group */
 const MIN_GROUP_SIZE = 2;
 
@@ -86,6 +94,7 @@ export class UserMessage extends LitElement {
 							: ""
 					}
 				</div>
+				<span class="message-timestamp">${formatTimestamp(this.message.timestamp)}</span>
 			</div>
 		`;
 	}
@@ -231,6 +240,7 @@ export class AssistantMessage extends LitElement {
 		return html`
 			<div>
 				${orderedParts.length ? html` <div class="px-2 sm:px-4 flex flex-col gap-3">${orderedParts}</div> ` : ""}
+				${!this.isStreaming && this.message.timestamp ? html`<div class="px-2 sm:px-4 text-right"><span class="message-timestamp">${formatTimestamp(this.message.timestamp)}</span></div>` : ""}
 				${
 					this.isStreaming && this.turnStartTime
 						? html` <div class="px-2 sm:px-4 -mt-2 text-xs text-muted-foreground text-right tabular-nums">


### PR DESCRIPTION
Add a user-togglable option to display timestamps on each chat message.

## Changes
- New `showTimestamps` preference (default: off) in Settings > General
- Locale-formatted timestamps (e.g. "2:34 PM") on user and assistant messages
- Real-time sync across all connected clients via `preferences_changed` WebSocket broadcast
- CSS-driven visibility toggle via `data-show-timestamps` attribute — no re-render needed

## Files
- `src/ui/app.css` — `.message-timestamp` styles
- `src/ui/components/Messages.ts` — `formatTimestamp()` + timestamp spans
- `src/app/remote-agent.ts` — preference propagation in `_applyPreferences()`
- `src/app/settings-page.ts` — toggle checkbox in General tab
- `tests/back-button-goal.spec.ts` + fixture — new unit test

## Verification
All workflow gates passed: design-doc, implementation (type-check, unit tests, E2E tests, code quality, security), ready-to-merge.