### PR TITLE
End Team button for leads

### DIFF
--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -196,6 +196,8 @@ export function renderSessionRow(session: GatewaySession) {
 	const rowPy = mobile ? "py-1" : SESSION_ROW_PY;
 	const btnPad = mobile ? "p-1.5" : "p-0.5";
 
+	const isTeamLead = session.role === "team-lead";
+
 	// Desktop: hover-revealed gradient overlay. Mobile: always-visible inline buttons.
 	const buttons = html`
 		<button class="${btnPad} rounded ${mobile ? "text-muted-foreground active:bg-secondary/80" : "hover:bg-secondary/80 text-muted-foreground hover:text-foreground"}"
@@ -203,7 +205,7 @@ export function renderSessionRow(session: GatewaySession) {
 			title="Modify">${icon(Pencil, "xs")}</button>
 		<button class="${btnPad} rounded ${mobile ? "text-muted-foreground active:bg-destructive/10" : "hover:bg-destructive/10 text-muted-foreground hover:text-destructive"}"
 			@click=${(e: Event) => { e.stopPropagation(); terminateSession(session.id); }}
-			title="Terminate (Ctrl+Shift+D)">${icon(Trash2, "xs")}</button>
+			title="${isTeamLead ? "End team (Ctrl+Shift+D)" : "Terminate (Ctrl+Shift+D)"}">${icon(Trash2, "xs")}</button>
 	`;
 
 	return html`

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -1772,6 +1772,8 @@ export function doRenderApp(): void {
 	const activeSid = activeSessionId();
 	const activeStaffAgent = activeSid ? state.staffList.find(s => s.currentSessionId === activeSid) : undefined;
 	const editLabel = activeStaffAgent ? "Edit" : "Modify";
+	const activeSession = activeSid ? state.gatewaySessions.find(s => s.id === activeSid) : undefined;
+	const isTeamLead = activeSession?.role === "team-lead";
 	const editDeleteBtns = (connected && state.remoteAgent && activeSid) ? html`
 		<div class="flex items-center gap-1 shrink-0">
 			${Button({
@@ -1792,9 +1794,9 @@ export function doRenderApp(): void {
 				variant: "ghost",
 				size: "sm",
 				onClick: () => terminateSession(activeSid),
-				children: html`<span class="inline-flex items-center gap-1">${icon(Trash2, "xs")}<span class="text-xs hidden sm:inline">Terminate</span></span>`,
+				children: html`<span class="inline-flex items-center gap-1">${icon(Trash2, "xs")}<span class="text-xs hidden sm:inline">${isTeamLead ? "End Team" : "Terminate"}</span></span>`,
 				className: "h-7 px-2 text-muted-foreground hover:text-destructive",
-				title: "Terminate session (Ctrl+Shift+D)",
+				title: isTeamLead ? "End team (Ctrl+Shift+D)" : "Terminate session (Ctrl+Shift+D)",
 			})}
 		</div>
 	` : "";

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -11,7 +11,7 @@ import {
 	GW_TOKEN_KEY,
 	GW_SESSION_KEY,
 } from "./state.js";
-import { gatewayFetch, saveDraftToServer, loadDraftFromServer, deleteDraftFromServer, refreshSessions, startSessionPolling, updateLocalSessionTitle, updateLocalSessionStatus, fetchGitStatus, refreshPrStatusCache } from "./api.js";
+import { gatewayFetch, saveDraftToServer, loadDraftFromServer, deleteDraftFromServer, refreshSessions, startSessionPolling, updateLocalSessionTitle, updateLocalSessionStatus, fetchGitStatus, refreshPrStatusCache, teardownTeam } from "./api.js";
 import { startTimeRefresh } from "./render-helpers.js";
 import { getRouteFromHash, setHashRoute, saveSessionModel, loadSessionModel, clearSessionModel } from "./routing.js";
 import { sessionHueRotation } from "./session-colors.js";
@@ -976,10 +976,14 @@ export async function createAndConnectSession(goalId?: string, roleId?: string, 
 export async function terminateSession(sessionId: string): Promise<void> {
 	const session = state.gatewaySessions.find((s) => s.id === sessionId);
 	const sessionTitle = session?.title || "this session";
+	const isTeamLead = session?.role === "team-lead";
+	const goalId = session?.goalId || session?.teamGoalId;
 	const confirmed = await confirmAction(
-		"Terminate Session",
-		`Are you sure you want to terminate "${sessionTitle}"? This will end the agent process and cannot be undone.`,
-		"Terminate",
+		isTeamLead && goalId ? "End Team" : "Terminate Session",
+		isTeamLead && goalId
+			? `Are you sure you want to end the team for "${sessionTitle}"? This will dismiss all agents and terminate the team lead.`
+			: `Are you sure you want to terminate "${sessionTitle}"? This will end the agent process and cannot be undone.`,
+		isTeamLead && goalId ? "End Team" : "Terminate",
 		true,
 	);
 	if (!confirmed) return;
@@ -993,9 +997,13 @@ export async function terminateSession(sessionId: string): Promise<void> {
 		renderApp();
 	}
 
-	const res = await gatewayFetch(`/api/sessions/${sessionId}`, { method: "DELETE" });
-	if (!res.ok && res.status !== 404) {
-		throw new Error(`Failed to terminate session: ${res.status}`);
+	if (isTeamLead && goalId) {
+		await teardownTeam(goalId);
+	} else {
+		const res = await gatewayFetch(`/api/sessions/${sessionId}`, { method: "DELETE" });
+		if (!res.ok && res.status !== 404) {
+			throw new Error(`Failed to terminate session: ${res.status}`);
+		}
 	}
 	clearSessionModel(sessionId);
 	deleteGoalDraft(sessionId);


### PR DESCRIPTION
When the active session is a team lead, the terminate button now says **End Team** and triggers a full team teardown instead of just archiving the session.

## Changes

- **`src/app/session-manager.ts`** — `terminateSession()` detects team leads and calls `teardownTeam(goalId)` with an "End Team" confirmation dialog. Falls back to normal DELETE if no goalId.
- **`src/app/render.ts`** — Header terminate button shows "End Team" label and tooltip for team leads.
- **`src/app/render-helpers.ts`** — Sidebar terminate button shows "End team" tooltip for team leads.

## Details

- UI-only changes, no server modifications
- Keyboard shortcut (Ctrl+Shift+D) automatically uses new behavior via `terminateSession()`
- Type-check, unit tests, and E2E tests all pass