### PR TITLE
feat: show disabled 'Archived' button on archived goals

### DIFF
--- a/src/app/goal-dashboard.ts
+++ b/src/app/goal-dashboard.ts
@@ -897,8 +897,8 @@ function renderNavBar(goal: Goal): TemplateResult {
 				${goal.archived ? nothing : html`
 					<button class="btn-icon" @click=${() => showGoalDialog(goal)} title="Edit goal">${svgPencil}<span>Edit</span></button>
 					<button class="btn-icon danger" @click=${() => deleteGoal(goal.id)} title="Archive goal">${svgTrash}<span>Archive</span></button>
-					${isTeamGoal ? renderTeamButton(goal) : renderSessionButton(goal)}
 				`}
+				${isTeamGoal ? renderTeamButton(goal) : renderSessionButton(goal)}
 			</div>
 		</div>
 	`;
@@ -911,6 +911,15 @@ function renderTeamButton(goal: Goal): TemplateResult {
 				<button class="btn-split-main danger" title="Stop the goal team" @click=${() => handleEndTeam(goal.id)} ?disabled=${teamStopping}>
 					${svgStop}
 					<span>${teamStopping ? "Stopping\u2026" : "Stop Team"}</span>
+				</button>
+			</div>
+		`;
+	}
+	if (goal.archived) {
+		return html`
+			<div class="btn-split">
+				<button class="btn-split-main" ?disabled=${true} style="opacity:0.5;cursor:default">
+					${svgCrown}<span>Archived</span>
 				</button>
 			</div>
 		`;
@@ -928,6 +937,15 @@ function renderTeamButton(goal: Goal): TemplateResult {
 }
 
 function renderSessionButton(goal: Goal): TemplateResult {
+	if (goal.archived) {
+		return html`
+			<div class="btn-split">
+				<button class="btn-split-main" ?disabled=${true} style="opacity:0.5;cursor:default">
+					<span>Archived</span>
+				</button>
+			</div>
+		`;
+	}
 	return html`
 		<div class="btn-split">
 			<button class="btn-split-main" title="New session for this goal" @click=${() => createAndConnectSession(goal.id)} ?disabled=${goal.setupStatus !== undefined && goal.setupStatus !== "ready"}>

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -496,7 +496,9 @@ export function renderGoalGroup(goal: Goal) {
 
 	const emptyState = html`
 		<div class="pl-2 py-1 ${mobile ? "text-xs" : "text-[11px]"} text-muted-foreground">
-			${isTeamGoal
+			${goal.archived
+				? html`<span style="color:var(--text-tertiary)">Archived</span>`
+				: isTeamGoal
 				? html`<span style="vertical-align:middle">No agents —</span> <button class="inline-flex items-center gap-1 px-1.5 py-px rounded bg-primary/10 text-primary text-[10px] font-semibold hover:bg-primary/20 transition-colors align-middle ${isPreparing ? "opacity-60 pointer-events-none" : ""}" title="${isPreparing ? "Setting up worktree\u2026" : "Start team"}" @click=${handleStartTeam} ?disabled=${isLoading || isPreparing}>${isPreparing ? html`<svg class="animate-spin" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>` : html`<svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor"><path d="M2 12h12v1.5H2V12zm0-1L1 4l4 3 3-5 3 5 4-3-1 7H2z"/></svg>`}${isLoading ? "Starting\u2026" : isPreparing ? "Setting up\u2026" : "Start Team"}</button>`
 				: html`No sessions — <button class="inline-flex items-center gap-1 px-1.5 py-px rounded bg-primary/10 text-primary font-semibold hover:bg-primary/20 transition-colors" title="Start a session" @click=${() => createAndConnectSession(goal.id)}><svg width="8" height="8" viewBox="0 0 16 16" fill="currentColor"><path d="M5 3l8 5-8 5V3z"/></svg>start one</button>`}
 		</div>


### PR DESCRIPTION
When a goal is archived, the Start Team / New Session button now appears disabled and greyed out with 'Archived' label instead of being completely hidden.

## Changes
- **goal-dashboard.ts**: Edit/Archive buttons hidden when archived; team/session button always rendered as disabled 'Archived' button with opacity:0.5
- **render-helpers.ts**: Sidebar empty state shows muted 'Archived' text instead of Start Team / start one buttons
- teamActive (Stop Team) still takes precedence over archived state

UI-only, 2 files, +22/-2 lines.