### PR TITLE
feat: PR status disk cache for instant sidebar badges

### DIFF
--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -153,6 +153,25 @@ export async function refreshSessions(): Promise<void> {
 		refreshPrStatusCache();
 	}
 
+	// One-time hydration of PR status from disk cache (instant badge rendering)
+	if (isInitial) {
+		gatewayFetch("/api/pr-status-cache")
+			.then(r => r.ok ? r.json() : null)
+			.then(data => {
+				if (data && typeof data === "object") {
+					let changed = false;
+					for (const [goalId, entry] of Object.entries(data)) {
+						if (!state.prStatusCache.has(goalId)) {
+							state.prStatusCache.set(goalId, entry as any);
+							changed = true;
+						}
+					}
+					if (changed) renderApp();
+				}
+			})
+			.catch(() => {});
+	}
+
 	// Always fetch archived sessions so staff/goal filtering works correctly.
 	// When the toggle is off, we still need the data to hide goal-affiliated
 	// staff agents from the Staff section (they belong under their goal).
@@ -208,7 +227,7 @@ export async function refreshPrStatusCache() {
 	try {
 	// Only poll active goals — completed/archived goals keep their cached PR status
 	// Only poll active goals — completed/archived goals keep their cached PR status
-	const goalsWithBranch = state.goals.filter(g => g.branch && g.state !== 'complete' && !g.archived);
+	const goalsWithBranch = state.goals.filter(g => g.branch && g.state !== 'complete' && !g.archived && state.prStatusCache.get(g.id)?.state !== 'MERGED');
 	if (goalsWithBranch.length === 0) return;
 
 	const results = await Promise.all(

--- a/src/server/agent/pr-status-store.ts
+++ b/src/server/agent/pr-status-store.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs";
+import path from "node:path";
+import { bobbitStateDir } from "../bobbit-dir.js";
+
+const STORE_FILE = path.join(bobbitStateDir(), "pr-status-cache.json");
+
+export interface PrStatusEntry {
+	state: string;
+	url?: string;
+	number?: number;
+	title?: string;
+	reviewDecision?: string | null;
+	mergeable?: string;
+	viewerIsAdmin?: boolean;
+	headRefName?: string;
+	updatedAt?: string;
+}
+
+export class PrStatusStore {
+	private cache: Map<string, PrStatusEntry> = new Map();
+
+	constructor() {
+		this.load();
+	}
+
+	private load(): void {
+		try {
+			if (fs.existsSync(STORE_FILE)) {
+				const data = JSON.parse(fs.readFileSync(STORE_FILE, "utf-8"));
+				if (data && typeof data === "object" && !Array.isArray(data)) {
+					for (const [id, entry] of Object.entries(data)) {
+						if (entry && typeof entry === "object") this.cache.set(id, entry as PrStatusEntry);
+					}
+				}
+			}
+		} catch (err) {
+			console.error("[pr-status-store] Failed to load:", err);
+		}
+	}
+
+	private save(): void {
+		try {
+			const dir = bobbitStateDir();
+			if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+			fs.writeFileSync(STORE_FILE, JSON.stringify(Object.fromEntries(this.cache), null, 2), "utf-8");
+		} catch (err) {
+			console.error("[pr-status-store] Failed to save:", err);
+		}
+	}
+
+	get(goalId: string): PrStatusEntry | undefined {
+		return this.cache.get(goalId);
+	}
+
+	set(goalId: string, data: PrStatusEntry): void {
+		this.cache.set(goalId, data);
+		this.save();
+	}
+
+	getAll(): Record<string, PrStatusEntry> {
+		return Object.fromEntries(this.cache);
+	}
+
+	remove(goalId: string): void {
+		if (this.cache.delete(goalId)) this.save();
+	}
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 import { bobbitStateDir, bobbitConfigDir } from "./bobbit-dir.js";
 import { WebSocketServer } from "ws";
 import { ColorStore } from "./agent/color-store.js";
+import { PrStatusStore } from "./agent/pr-status-store.js";
 import { SessionManager } from "./agent/session-manager.js";
 import { RateLimiter } from "./auth/rate-limit.js";
 import { validateToken } from "./auth/token.js";
@@ -125,6 +126,7 @@ export interface GatewayConfig {
 
 export function createGateway(config: GatewayConfig) {
 	const colorStore = new ColorStore();
+	const prStatusStore = new PrStatusStore();
 	const preferencesStore = new PreferencesStore();
 	const projectConfigStore = new ProjectConfigStore();
 	const savedCwd = preferencesStore.get("defaultCwd");
@@ -214,7 +216,7 @@ export function createGateway(config: GatewayConfig) {
 				}
 			}
 
-			await handleApiRoute(url, req, res, sessionManager, config, colorStore, teamManager, roleManager, toolManager, gateStore, personalityManager, bgProcessManager, staffManager, workflowManager, verificationHarness, preferencesStore, projectConfigStore, broadcastToGoal, broadcastToAll);
+			await handleApiRoute(url, req, res, sessionManager, config, colorStore, prStatusStore, teamManager, roleManager, toolManager, gateStore, personalityManager, bgProcessManager, staffManager, workflowManager, verificationHarness, preferencesStore, projectConfigStore, broadcastToGoal, broadcastToAll);
 
 			return;
 		}
@@ -399,6 +401,7 @@ async function handleApiRoute(
 	sessionManager: SessionManager,
 	config: GatewayConfig,
 	colorStore: ColorStore,
+	prStatusStore: PrStatusStore,
 	teamManager: TeamManager,
 	roleManager: RoleManager,
 	toolManager: ToolManager,
@@ -790,6 +793,7 @@ async function handleApiRoute(
 			}
 			// Archive instead of hard-delete — tasks, gates, team state remain intact
 			await sessionManager.goalManager.archiveGoal(id);
+			prStatusStore.remove(id);
 			json({ ok: true });
 			return;
 		}
@@ -1620,6 +1624,12 @@ async function handleApiRoute(
 		return;
 	}
 
+	// GET /api/pr-status-cache — bulk PR status from disk cache (startup hydration)
+	if (req.method === "GET" && url.pathname === "/api/pr-status-cache") {
+		json(prStatusStore.getAll());
+		return;
+	}
+
 	// GET /api/goals/:id/pr-status — PR status for goal branch (async + cached)
 	const goalPrStatusMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/pr-status$/);
 	if (goalPrStatusMatch && req.method === "GET") {
@@ -1629,7 +1639,7 @@ async function handleApiRoute(
 		const cwd = goal.cwd;
 		if (!fs.existsSync(cwd)) { json({ error: "Working directory not found" }, 404); return; }
 		const pr = await getCachedPrStatus(cwd);
-		if (pr) { json(pr); } else { json({ error: "No PR found" }, 404); }
+		if (pr) { prStatusStore.set(goalId, pr); json(pr); } else { json({ error: "No PR found" }, 404); }
 		return;
 	}
 
@@ -2275,7 +2285,11 @@ async function handleApiRoute(
 		const cwd = session.cwd;
 		if (!fs.existsSync(cwd)) { json({ error: "Working directory not found" }, 404); return; }
 		const pr = await getCachedPrStatus(cwd);
-		if (pr) { json(pr); } else { json({ error: "No PR found" }, 404); }
+		if (pr) {
+			const goalId = session.goalId;
+			if (goalId) prStatusStore.set(goalId, pr);
+			json(pr);
+		} else { json({ error: "No PR found" }, 404); }
 		return;
 	}
 


### PR DESCRIPTION
## Summary

Persist PR status to disk so sidebar badges appear instantly on startup, and stop polling merged/archived PRs.

### Changes

- **New `PrStatusStore`** (`src/server/agent/pr-status-store.ts`) — persists `Record<goalId, PrStatusEntry>` to `.bobbit/state/pr-status-cache.json`, following the `ColorStore` pattern
- **Server write-through** — `GET /api/goals/:id/pr-status` and `GET /api/sessions/:id/pr-status` write to disk cache on success
- **New bulk endpoint** — `GET /api/pr-status-cache` returns all cached PR statuses for instant startup hydration
- **Cleanup** — cache entries removed on goal delete
- **Client startup hydration** — one-time fetch from `/api/pr-status-cache` on initial load populates `state.prStatusCache` before any `gh pr view` calls complete
- **Polling optimization** — merged PRs (`state === 'MERGED'`) excluded from the polling loop (terminal state)

### Files changed (3 files, +104/-4)

| File | Change |
|------|--------|
| `src/server/agent/pr-status-store.ts` | New store |
| `src/server/server.ts` | Wire store, bulk endpoint, write-through, cleanup |
| `src/app/api.ts` | Startup hydration, skip merged PRs |

All 262 E2E tests pass. Type-check passes.