### PR TITLE
docs: fix stale skill refs, add 20+ missing API/WS docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ If you only changed UI code (`src/ui/`, `src/app/`), unit tests are sufficient. 
 
 **Add a new tool renderer**: Create in `src/ui/tools/renderers/`, register in `src/ui/tools/index.ts`.
 
-**Add a new skill definition**: Create in `src/server/skills/definitions/`, import and register in `src/server/skills/index.ts`. Define a `Skill` object with id, instructions, isolation level, and expected output. Run `exportDefinitions()` to sync to disk.
+**Add a slash skill**: Create a `SKILL.md` file in `.claude/skills/<name>/` (project-level) or `~/.claude/skills/<name>/` (personal). The file should have YAML frontmatter with `description` and optional `argument_hint`, `allowed_tools`, `context`, `agent` fields. Skills are discovered automatically via `discoverSlashSkills()` in `src/server/skills/slash-skills.ts` and served at `GET /api/slash-skills`.
 
 **Add a goal-related feature**: Goal CRUD is in `goal-manager.ts`/`goal-store.ts`. REST endpoints in `server.ts`. Goal assistant prompt in `goal-assistant.ts`. Client-side proposal parsing in `remote-agent.ts` `_checkForGoalProposal()`.
 
@@ -133,6 +133,8 @@ All per-project state lives under `<project-root>/.bobbit/`:
 | `workflows/*.yaml` | `WorkflowStore` | Workflow templates (gate DAGs, verification configs) |
 | `personalities/*.yaml` | `PersonalityStore` | Personality definitions |
 | `tools/<group>/*.yaml` | `ToolManager` | Tool definitions and extension code (name, description, docs, provider, renderer, extension.ts) |
+| `project.yaml` | `ProjectConfigStore` | Project settings (build/test/typecheck commands, custom config) |
+| `roles/assistant/*.yaml` | `assistant-registry.ts` | Assistant prompt definitions (goal, role, tool, personality, staff, setup) |
 
 
 ### `.bobbit/state/` — runtime state (gitignored)
@@ -149,7 +151,6 @@ All per-project state lives under `<project-root>/.bobbit/`:
 | `session-costs.json` | `CostTracker` | Per-session token and cost data |
 | `session-colors.json` | `ColorStore` | Session → color index (0-13) mapping |
 | `preferences.json` | `PreferencesStore` | Key-value preferences (AI gateway config, etc.) |
-| `skill-definitions.json` | `definitions-sync.ts` | Exported skill definitions for agent discovery |
 | `session-prompts/` | `system-prompt.ts` | Assembled per-session prompt files (cleaned up on terminate) |
 | `tls/` | `tls.ts` | TLS certificates and keys |
 | `gateway-url` | `cli.ts` | Last-started gateway base URL (e.g. `https://100.x.x.x:3001`) |

--- a/docs/features.md
+++ b/docs/features.md
@@ -54,12 +54,12 @@ Personality definitions that modify agent behaviour via prompt fragments.
 
 ## Skills
 
-Skills are reusable templates for spawning isolated sub-agents that produce structured outputs.
+Slash-command skills discovered from Claude Code-compatible `SKILL.md` files.
 
-- **Isolation**: Sub-agents receive only skill instructions + explicit context + `AGENTS.md` — never the parent conversation.
-- **Built-in skills**: `correctness-review`, `security-review`, `design-review` (three code review perspectives), and `test-suite-report` (runs tests and produces a structured report).
-- **Invocation**: Via `invoke_skill` WebSocket command. Server broadcasts `skill_started`, then `skill_completed` or `skill_failed`.
-- **Definition sync**: Registered skills are exported to `.bobbit/state/skill-definitions.json` for agent-side tool extensions to discover.
+- **Discovery**: Skills are found in `.claude/skills/<name>/SKILL.md` (project), `~/.claude/skills/<name>/SKILL.md` (personal), and `.claude/commands/<name>.md` (legacy).
+- **Invocation**: Via `/skill-name` slash commands in the chat input. Skill instructions are injected into the agent's prompt.
+- **Frontmatter**: YAML frontmatter supports `description`, `argument_hint`, `allowed_tools`, `context` (e.g. `fork`), `agent`, `disable_model_invocation`, and `user_invocable`.
+- **API**: `GET /api/slash-skills` for autocomplete data, `GET /api/slash-skills/details` for full content and file paths.
 
 ## Cost Tracking
 
@@ -86,13 +86,16 @@ Workflows define the gates a goal must pass, their dependency relationships (a D
 
 ## Assistant Registry
 
-A unified registry (`assistant-registry.ts`) maps assistant types to their prompts and display titles:
+A unified registry (`assistant-registry.ts`) maps assistant types to their prompts and display titles. Definitions load from YAML files in `.bobbit/config/roles/assistant/`, falling back to hardcoded defaults:
 
 - `goal` — Goal creation assistant
 - `role` — Role creation assistant
 - `tool` — Tool management assistant
+- `personality` — Personality creation assistant
+- `staff` — Staff agent creation assistant
+- `setup` — Project setup wizard
 
-Sessions created with an `assistantType` get the corresponding system prompt automatically.
+Sessions created with an `assistantType` get the corresponding system prompt automatically. Assistant prompts can be edited via their YAML files and are reloaded on change.
 
 ## Compaction
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -111,11 +111,61 @@ Routes accept both `/team/` and legacy `/swarm/` paths.
 | `PUT` | `/api/personalities/:name` | Update a personality |
 | `DELETE` | `/api/personalities/:name` | Delete a personality |
 
-### Skills
+### Slash Skills
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/api/skills` | List available skill definitions (id, name, description) |
+| `GET` | `/api/slash-skills` | Discover slash skills for autocomplete (name, description, argument hint) |
+| `GET` | `/api/slash-skills/details` | Full slash skill details including content and file paths |
+
+### Assistant Prompts
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/roles/assistant/prompts` | List all assistant prompt definitions |
+| `PUT` | `/api/roles/assistant/prompts/:type` | Update an assistant prompt (goal, role, tool, personality, staff, setup) |
+
+### Staff Agents
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/staff` | List all staff agent definitions |
+| `POST` | `/api/staff` | Create a staff agent (`{ name, description, triggers, skillId?, prompt? }`) |
+| `POST` | `/api/staff/:id/wake` | Manually trigger a staff agent's wake cycle |
+
+### Project Config
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/project-config` | Get project settings (build/test/typecheck commands, custom config) |
+| `GET` | `/api/project-config/defaults` | Get default project config values |
+| `PUT` | `/api/project-config` | Update project config fields |
+
+### Setup
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/setup-status` | Check if project setup wizard has been completed |
+| `POST` | `/api/setup-status/dismiss` | Mark setup wizard as dismissed |
+
+### Config
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/config/cwd` | Get the server's working directory |
+| `PUT` | `/api/config/cwd` | Update the server's working directory |
+
+### PR Status
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/pr-status-cache` | Bulk PR status from disk cache (startup hydration) |
+
+### System
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/api/shutdown` | Graceful server shutdown (used by coverage teardown) |
 
 ### Workflows
 

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -21,10 +21,10 @@ Connect to `wss://<host>:<port>/ws/<session-id>`. First message must be `{ "type
 | `set_title` | `title` | Set session title |
 | `generate_title` | — | Auto-generate title from conversation |
 | `ping` | — | Keepalive ping |
-| `invoke_skill` | `skillId`, `context?` | Invoke an isolated skill sub-agent |
 | `task_create` | `goalId`, `title`, `taskType`, `parentTaskId?`, `spec?`, `dependsOn?` | Create a task |
 | `task_update` | `taskId`, `updates` | Update a task (title, spec, state, assignment, deps) |
 | `task_delete` | `taskId` | Delete a task |
+| `summarize_goal_title` | `goalTitle` | Auto-generate a shorter goal title |
 
 ## Server → Client
 
@@ -41,16 +41,23 @@ Connect to `wss://<host>:<port>/ws/<session-id>`. First message must be `{ "type
 | `client_left` | `clientId` | A client disconnected |
 | `error` | `message`, `code` | Error message |
 | `pong` | — | Keepalive response |
-| `skill_started` | `skillId` | Skill execution began |
-| `skill_completed` | `skillId`, `result` | Skill produced output |
-| `skill_failed` | `skillId`, `error` | Skill execution failed |
 | `cost_update` | `sessionId`, `goalId?`, `taskId?`, `cost` | Token usage and cost update |
 | `queue_update` | `sessionId`, `queue` | Prompt queue changed |
 | `task_changed` | `task` | A task was created, updated, or deleted |
 | `tasks_list` | `tasks` | Full task list for a goal |
+| `session_archived` | `sessionId`, `archivedAt` | Session was archived |
 | `preferences_changed` | `preferences` | Server preferences were updated |
+| `bg_process_created` | `process` | Background process started |
+| `bg_process_output` | `processId`, `stream`, `text` | Output from a background process |
+| `bg_process_exited` | `processId`, `exitCode` | Background process terminated |
+| `gate_signal_received` | `goalId`, `gateId`, `signalId` | Gate signal received |
 | `gate_verification_started` | `goalId`, `gateId`, `signalId` | Gate verification began |
 | `gate_verification_step_started` | `goalId`, `gateId`, `stepIndex`, `stepName` | A verification step began |
 | `gate_verification_step_output` | `goalId`, `gateId`, `stepIndex`, `stream`, `text` | Live output from a verification step |
 | `gate_verification_step_complete` | `goalId`, `gateId`, `stepIndex`, `status` | A verification step finished (passed/failed) |
 | `gate_verification_complete` | `goalId`, `gateId`, `signalId`, `status` | All verification steps finished |
+| `gate_status_changed` | `goalId`, `gateId`, `status` | Gate status changed |
+| `goal_setup_complete` | `goalId` | Goal worktree/team setup finished |
+| `goal_setup_error` | `goalId`, `error` | Goal setup failed |
+| `team_agent_spawned` | `goalId`, `sessionId`, `role`, `name` | Team agent was spawned |
+| `team_agent_dismissed` | `goalId`, `sessionId`, `role`, `name` | Team agent was dismissed |


### PR DESCRIPTION
Documentation validation scan — supersedes and expands the previous version with findings from 42 new commits.

**Stale references fixed (4):**
- `src/server/skills/definitions/` directory (deleted) — AGENTS.md
- `skill-definitions.json` / `definitions-sync.ts` (deleted) — AGENTS.md disk state
- `invoke_skill` WS command + `skill_started/completed/failed` events (deleted) — features.md, websocket-protocol.md
- `/api/skills` REST endpoint (replaced by `/api/slash-skills`) — rest-api.md

**New REST endpoints documented (15):**
- `/api/slash-skills` + `/api/slash-skills/details` — slash skill discovery
- `/api/roles/assistant/prompts` (GET, PUT :type) — assistant prompt editing
- `/api/staff` (GET, POST) + `/api/staff/:id/wake` — staff agent management
- `/api/project-config` (GET, GET defaults, PUT) — project settings
- `/api/setup-status` (GET, POST dismiss) — setup wizard state
- `/api/config/cwd` (GET, PUT) — working directory config
- `/api/pr-status-cache` (GET) — bulk PR status hydration
- `POST /api/shutdown` — graceful server shutdown

**New WebSocket events documented (12):**
- `session_archived`, `bg_process_created/output/exited`
- `gate_signal_received`, `gate_status_changed`
- `goal_setup_complete/error`, `team_agent_spawned/dismissed`
- `summarize_goal_title` client command

**Config/state table updates:**
- Added `project.yaml` (ProjectConfigStore) and `roles/assistant/*.yaml`
- Removed deleted `skill-definitions.json`
- Updated assistant registry: 3 → 6 types (+ personality, staff, setup)