### PR TITLE
Session Worktrees

### DIFF
--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -941,7 +941,7 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 // CREATE & CONNECT
 // ============================================================================
 
-export async function createAndConnectSession(goalId?: string, roleId?: string, personalities?: string[], cwd?: string): Promise<void> {
+export async function createAndConnectSession(goalId?: string, roleId?: string, personalities?: string[], cwd?: string, worktree?: boolean): Promise<void> {
 	if (state.creatingSession) return;
 	state.creatingSession = true;
 	state.creatingSessionForGoalId = goalId || null;
@@ -952,6 +952,7 @@ export async function createAndConnectSession(goalId?: string, roleId?: string, 
 		if (roleId) body.roleId = roleId;
 		if (personalities && personalities.length > 0) body.personalities = personalities;
 		if (cwd) body.cwd = cwd;
+		if (worktree) body.worktree = true;
 		const res = await gatewayFetch("/api/sessions", {
 			method: "POST",
 			body: JSON.stringify(body),

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -41,6 +41,7 @@ let _pickerPersonalities = new Set<string>();
 let _pickerCwd = "";
 let _pickerCwdDropdownOpen = false;
 let _pickerCwdHighlightIndex = -1;
+let _pickerWorktree = false;
 /** Goal ID context for the picker (if launched from a goal). */
 let _pickerGoalId: string | undefined;
 /** Anchor rect for positioning the popover near the button. */
@@ -49,7 +50,7 @@ let _pickerAnchorRect: { top: number; right: number; bottom: number } | null = n
 let _pickerFocusIndex = -1;
 
 /** Item types in the flat focus list. */
-type PickerItemType = "personality" | "role" | "cwd" | "create";
+type PickerItemType = "personality" | "role" | "cwd" | "worktree" | "create";
 interface PickerItem { type: PickerItemType; id: string; }
 
 /** Build the flat ordered list of focusable items. */
@@ -58,6 +59,7 @@ function _buildPickerItems(): PickerItem[] {
 	for (const p of _cachedPersonalities) items.push({ type: "personality", id: p.name });
 	for (const r of state.roles) items.push({ type: "role", id: r.name });
 	items.push({ type: "cwd", id: "cwd" });
+	items.push({ type: "worktree", id: "worktree" });
 	items.push({ type: "create", id: "create" });
 	return items;
 }
@@ -80,6 +82,7 @@ export async function toggleRolePicker(e: Event, goalId?: string): Promise<void>
 	_pickerCwd = "";
 	_pickerCwdDropdownOpen = false;
 	_pickerCwdHighlightIndex = -1;
+	_pickerWorktree = false;
 	_pickerGoalId = goalId;
 	// Capture the button position for anchoring the popover
 	const btn = e.currentTarget as HTMLElement;
@@ -116,9 +119,10 @@ export function renderRolePickerDropdown() {
 		state.rolePickerOpen = false;
 		const personalities = [..._pickerPersonalities];
 		const cwd = _pickerCwd || undefined;
+		const worktree = _pickerWorktree || undefined;
 		_pickerCwd = "";
 		_pickerCwdDropdownOpen = false;
-		createAndConnectSession(_pickerGoalId, _pickerRole || undefined, personalities.length > 0 ? personalities : undefined, cwd);
+		createAndConnectSession(_pickerGoalId, _pickerRole || undefined, personalities.length > 0 ? personalities : undefined, cwd, worktree);
 	};
 
 	// All roles including general (the server default)
@@ -201,6 +205,16 @@ export function renderRolePickerDropdown() {
 					highlightedIndex: _pickerCwdHighlightIndex,
 					onHighlight: (i: number) => { _pickerCwdHighlightIndex = i; renderApp(); },
 				})}
+			</div>
+			<!-- Worktree checkbox -->
+			<div class="border-t border-border/50 px-3 py-1.5 shrink-0">
+				<label class="flex items-center gap-2 cursor-pointer ${isFocused("worktree", "worktree") ? "ring-2 ring-ring rounded" : ""}">
+					<input type="checkbox" .checked=${_pickerWorktree}
+						@change=${(e: Event) => { _pickerWorktree = (e.target as HTMLInputElement).checked; renderApp(); }} />
+					<span class="text-[11px] text-foreground/70">Create worktree</span>
+					<span title="Creates an isolated git branch and worktree for this session"
+						class="text-[9px] text-muted-foreground cursor-help">ⓘ</span>
+				</label>
 			</div>
 			<!-- Create button (pinned at bottom) -->
 			<div class="border-t border-border/50 px-3 py-2 shrink-0">
@@ -294,14 +308,18 @@ document.addEventListener("keydown", (e: KeyboardEvent) => {
 		} else if (focusedItem?.type === "role") {
 			_pickerRole = _pickerRole === focusedItem.id ? "" : focusedItem.id;
 			renderApp();
+		} else if (focusedItem?.type === "worktree") {
+			_pickerWorktree = !_pickerWorktree;
+			renderApp();
 		} else {
 			// create button or no focus — create session
 			state.rolePickerOpen = false;
 			const personalities = [..._pickerPersonalities];
 			const cwd = _pickerCwd || undefined;
+			const worktree = _pickerWorktree || undefined;
 			_pickerCwd = "";
 			_pickerCwdDropdownOpen = false;
-			createAndConnectSession(_pickerGoalId, _pickerRole || undefined, personalities.length > 0 ? personalities : undefined, cwd);
+			createAndConnectSession(_pickerGoalId, _pickerRole || undefined, personalities.length > 0 ? personalities : undefined, cwd, worktree);
 		}
 		return;
 	}
@@ -316,13 +334,17 @@ document.addEventListener("keydown", (e: KeyboardEvent) => {
 		} else if (focusedItem.type === "role") {
 			_pickerRole = _pickerRole === focusedItem.id ? "" : focusedItem.id;
 			renderApp();
+		} else if (focusedItem.type === "worktree") {
+			_pickerWorktree = !_pickerWorktree;
+			renderApp();
 		} else if (focusedItem.type === "create") {
 			state.rolePickerOpen = false;
 			const personalities = [..._pickerPersonalities];
 			const cwd = _pickerCwd || undefined;
+			const worktree = _pickerWorktree || undefined;
 			_pickerCwd = "";
 			_pickerCwdDropdownOpen = false;
-			createAndConnectSession(_pickerGoalId, _pickerRole || undefined, personalities.length > 0 ? personalities : undefined, cwd);
+			createAndConnectSession(_pickerGoalId, _pickerRole || undefined, personalities.length > 0 ? personalities : undefined, cwd, worktree);
 		}
 		return;
 	}

--- a/src/server/agent/goal-manager.ts
+++ b/src/server/agent/goal-manager.ts
@@ -1,12 +1,8 @@
 import { randomUUID } from "node:crypto";
-import { execFile as execFileCb } from "node:child_process";
-import { promisify } from "node:util";
 import fs from "node:fs";
-
-const execFile = promisify(execFileCb);
 import path from "node:path";
 import { GoalStore, type GoalState, type PersistedGoal } from "./goal-store.js";
-import { createWorktree, cleanupWorktree } from "../skills/git.js";
+import { createWorktree, cleanupWorktree, isGitRepo, getRepoRoot } from "../skills/git.js";
 import type { WorkflowStore } from "./workflow-store.js";
 
 /**
@@ -21,21 +17,6 @@ function toBranchName(title: string): string {
 		.slice(0, 10) || "goal";
 }
 
-/** Check if a directory is inside a git repository. */
-async function isGitRepo(cwd: string): Promise<boolean> {
-	try {
-		await execFile("git", ["rev-parse", "--is-inside-work-tree"], { cwd });
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-/** Get the git repo root for a directory. */
-async function getRepoRoot(cwd: string): Promise<string> {
-	const { stdout } = await execFile("git", ["rev-parse", "--show-toplevel"], { cwd });
-	return stdout.toString().trim();
-}
 
 export class GoalManager {
 	private store = new GoalStore();

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -20,6 +20,7 @@ import type { ToolManager } from "./tool-manager.js";
 import { computeToolActivationArgs } from "./tool-activation.js";
 import { TOOLS_DIR } from "./tool-manager.js";
 import { getAigwUrl, getAigwModels, modelRecencyRank } from "./aigw-manager.js";
+import { createWorktree } from "../skills/git.js";
 
 
 /** Goal tools extension — task + gate management for any goal session. */
@@ -448,6 +449,13 @@ export class SessionManager {
 			}
 			this.addDormantSession(ps);
 		}
+
+		// Stuck worktree recovery: warn about sessions with worktreePath set but directory missing
+		for (const ps of persisted) {
+			if (ps.worktreePath && !fs.existsSync(ps.worktreePath)) {
+				console.warn(`[session-manager] Session "${ps.title}" (${ps.id}) has worktreePath "${ps.worktreePath}" but directory does not exist`);
+			}
+		}
 	}
 
 	private async restoreOneSession(ps: PersistedSession): Promise<void> {
@@ -656,7 +664,7 @@ export class SessionManager {
 		}
 	}
 
-	async createSession(cwd: string, agentArgs?: string[], goalId?: string, assistantType?: string, opts?: { rolePrompt?: string; env?: Record<string, string>; taskId?: string; allowedTools?: string[]; personalities?: Array<{ label: string; promptFragment: string }>; personalityNames?: string[]; workflowContext?: string }): Promise<SessionInfo> {
+	async createSession(cwd: string, agentArgs?: string[], goalId?: string, assistantType?: string, opts?: { rolePrompt?: string; env?: Record<string, string>; taskId?: string; allowedTools?: string[]; personalities?: Array<{ label: string; promptFragment: string }>; personalityNames?: string[]; workflowContext?: string; worktreeOpts?: { repoPath: string } }): Promise<SessionInfo> {
 		const id = randomUUID();
 
 		const bridgeOptions: RpcBridgeOptions = {
@@ -834,7 +842,58 @@ export class SessionManager {
 			console.error(`[session-manager] Failed to persist session ${id}:`, err);
 		});
 
+		// ── Async worktree setup (fire-and-forget) ──
+		if (opts?.worktreeOpts) {
+			const { repoPath } = opts.worktreeOpts;
+			const slug = session.title
+				.toLowerCase()
+				.replace(/[^a-z0-9]+/g, "-")
+				.replace(/^-|-$/g, "")
+				.slice(0, 20) || "session";
+			const uuid8 = id.slice(0, 8);
+			const branch = `session/${slug}-${uuid8}`;
+			const wtRoot = path.resolve(repoPath, "..", `${path.basename(repoPath)}-wt`);
+			const safeName = branch.replace(/\//g, "-");
+			const worktreePath = path.join(wtRoot, safeName);
+
+			// Persist worktree metadata immediately
+			session.worktreePath = worktreePath;
+			this.store.update(id, { repoPath, branch, worktreePath });
+
+			// Fire-and-forget async setup with one retry
+			this._setupSessionWorktree(session, repoPath, branch, worktreePath).catch(() => {
+				// Errors already logged inside _setupSessionWorktree
+			});
+		}
+
 		return session;
+	}
+
+	/**
+	 * Async worktree setup for a session. Retries once on failure.
+	 * On success: updates session cwd. On double failure: clears worktree metadata.
+	 */
+	private async _setupSessionWorktree(session: SessionInfo, repoPath: string, branch: string, worktreePath: string): Promise<void> {
+		for (let attempt = 0; attempt < 2; attempt++) {
+			try {
+				const result = await createWorktree(repoPath, branch);
+				// Update in-memory and persist
+				session.cwd = result.worktreePath;
+				session.worktreePath = result.worktreePath;
+				this.store.update(session.id, { cwd: result.worktreePath, worktreePath: result.worktreePath });
+				console.log(`[session-manager] Worktree ready for session "${session.title}" (${session.id}): ${result.worktreePath}`);
+				return;
+			} catch (err) {
+				console.error(`[session-manager] Worktree setup attempt ${attempt + 1} failed for session "${session.title}" (${session.id}):`, err);
+				if (attempt === 0) {
+					await new Promise(resolve => setTimeout(resolve, 1000));
+				}
+			}
+		}
+		// Both attempts failed — clear worktree metadata so stuck recovery doesn't perpetually warn
+		console.error(`[session-manager] Worktree setup failed for session "${session.title}" (${session.id}) — clearing worktree metadata`);
+		session.worktreePath = undefined;
+		this.store.update(session.id, { worktreePath: undefined, repoPath: undefined, branch: undefined });
 	}
 
 	/**
@@ -1082,6 +1141,9 @@ export class SessionManager {
 			return;
 		}
 
+		// Preserve fields that may have been set via store.update() before this async call
+		const existing = this.store.get(session.id);
+
 		this.store.put({
 			id: session.id,
 			title: session.title,
@@ -1094,6 +1156,8 @@ export class SessionManager {
 			role: session.role,
 			teamGoalId: session.teamGoalId,
 			worktreePath: session.worktreePath,
+			repoPath: existing?.repoPath,
+			branch: existing?.branch,
 			taskId: session.taskId,
 			staffId: session.staffId,
 			accessory: session.accessory,

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -861,7 +861,7 @@ export class SessionManager {
 			this.store.update(id, { repoPath, branch, worktreePath });
 
 			// Fire-and-forget async setup with one retry
-			this._setupSessionWorktree(session, repoPath, branch, worktreePath).catch(() => {
+			this._setupSessionWorktree(session, repoPath, branch).catch(() => {
 				// Errors already logged inside _setupSessionWorktree
 			});
 		}
@@ -873,7 +873,7 @@ export class SessionManager {
 	 * Async worktree setup for a session. Retries once on failure.
 	 * On success: updates session cwd. On double failure: clears worktree metadata.
 	 */
-	private async _setupSessionWorktree(session: SessionInfo, repoPath: string, branch: string, worktreePath: string): Promise<void> {
+	private async _setupSessionWorktree(session: SessionInfo, repoPath: string, branch: string): Promise<void> {
 		for (let attempt = 0; attempt < 2; attempt++) {
 			try {
 				const result = await createWorktree(repoPath, branch);

--- a/src/server/agent/session-store.ts
+++ b/src/server/agent/session-store.ts
@@ -148,7 +148,7 @@ export class SessionStore {
 	}
 
 	/** Update a subset of fields for an existing session */
-	update(id: string, updates: Partial<Pick<PersistedSession, "title" | "lastActivity" | "agentSessionFile" | "goalId" | "wasStreaming" | "streamingStartedAt" | "delegateOf" | "role" | "teamGoalId" | "teamLeadSessionId" | "worktreePath" | "assistantType" | "goalAssistant" | "roleAssistant" | "toolAssistant" | "taskId" | "staffId" | "accessory" | "preview" | "personalities" | "messageQueue" | "archived" | "archivedAt" | "repoPath" | "branch" | "nonInteractive">>): void {
+	update(id: string, updates: Partial<Pick<PersistedSession, "title" | "lastActivity" | "agentSessionFile" | "goalId" | "wasStreaming" | "streamingStartedAt" | "delegateOf" | "role" | "teamGoalId" | "teamLeadSessionId" | "worktreePath" | "assistantType" | "goalAssistant" | "roleAssistant" | "toolAssistant" | "taskId" | "staffId" | "accessory" | "preview" | "personalities" | "messageQueue" | "archived" | "archivedAt" | "repoPath" | "branch" | "nonInteractive" | "cwd">>): void {
 		const existing = this.sessions.get(id);
 		if (!existing) return;
 		Object.assign(existing, updates);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -28,6 +28,7 @@ import { BgProcessManager } from "./agent/bg-process-manager.js";
 import { GateStore } from "./agent/gate-store.js";
 import { WorkflowStore } from "./agent/workflow-store.js";
 import { WorkflowManager } from "./agent/workflow-manager.js";
+import { isGitRepo, getRepoRoot } from "./skills/git.js";
 import { VerificationHarness } from "./agent/verification-harness.js";
 import { StaffManager } from "./agent/staff-manager.js";
 import { TriggerEngine } from "./agent/staff-trigger-engine.js";
@@ -652,8 +653,21 @@ async function handleApiRoute(
 			createOpts = { ...createOpts, personalities: resolved, personalityNames };
 		}
 
+		// ── Worktree support ──
+		let worktreeOpts: { repoPath: string } | undefined;
+		if (body?.worktree && !assistantType) {
+			try {
+				if (await isGitRepo(cwd)) {
+					const repoPath = await getRepoRoot(cwd);
+					worktreeOpts = { repoPath };
+				}
+			} catch {
+				// Not a git repo or git not available — silently ignore
+			}
+		}
+
 		try {
-			const session = await sessionManager.createSession(cwd, args, goalId, assistantType, createOpts);
+			const session = await sessionManager.createSession(cwd, args, goalId, assistantType, { ...createOpts, worktreeOpts });
 
 			// Set role metadata if a role was specified
 			if (roleForMeta) {

--- a/src/server/skills/git.ts
+++ b/src/server/skills/git.ts
@@ -5,6 +5,22 @@ import path from "node:path";
 
 const execFile = promisify(execFileCb);
 
+/** Check if a directory is inside a git repository. */
+export async function isGitRepo(cwd: string): Promise<boolean> {
+	try {
+		await execFile("git", ["rev-parse", "--is-inside-work-tree"], { cwd });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/** Get the git repo root for a directory. */
+export async function getRepoRoot(cwd: string): Promise<string> {
+	const { stdout } = await execFile("git", ["rev-parse", "--show-toplevel"], { cwd });
+	return stdout.toString().trim();
+}
+
 export interface WorktreeResult {
 	worktreePath: string;
 	branchName: string;

--- a/tests/e2e/session-worktree.spec.ts
+++ b/tests/e2e/session-worktree.spec.ts
@@ -1,0 +1,176 @@
+import { test, expect } from "@playwright/test";
+import { existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { apiFetch, gitCwd, nonGitCwd } from "./e2e-setup.js";
+
+/**
+ * E2E tests for session worktree creation and cleanup.
+ *
+ * Run with:
+ *   npm run build:server && npx playwright test tests/e2e/session-worktree.spec.ts --config playwright-e2e.config.ts
+ */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Poll GET /api/sessions/:id until a predicate is met on the response. */
+async function pollSession(
+	sessionId: string,
+	pred: (data: any) => boolean,
+	timeoutMs = 30_000,
+): Promise<any> {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		const resp = await apiFetch(`/api/sessions/${sessionId}`);
+		if (resp.ok) {
+			const data = await resp.json();
+			if (pred(data)) return data;
+		}
+		await new Promise((r) => setTimeout(r, 500));
+	}
+	throw new Error(`pollSession timed out after ${timeoutMs}ms`);
+}
+
+/**
+ * Fully delete a session: terminate (archive) then purge.
+ * Retries DELETE until the server returns 404 (fully purged).
+ */
+async function terminateAndPurge(sessionId: string): Promise<void> {
+	for (let i = 0; i < 5; i++) {
+		const resp = await apiFetch(`/api/sessions/${sessionId}`, { method: "DELETE" });
+		if (resp.status === 404) return;
+		await new Promise((r) => setTimeout(r, 1_000));
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("Session worktrees", () => {
+	test("creates a worktree when worktree: true and cwd is a git repo", async () => {
+		// Create session with worktree: true, using a git repo cwd
+		const createResp = await apiFetch("/api/sessions", {
+			method: "POST",
+			body: JSON.stringify({ cwd: gitCwd(), worktree: true }),
+		});
+		expect(createResp.status).toBe(201);
+		const created = await createResp.json();
+		const sessionId = created.id;
+
+		try {
+			expect(sessionId).toBeTruthy();
+
+			// Poll until worktreePath is set AND the worktree directory exists on disk.
+			// The worktree setup is async fire-and-forget, so we need to wait.
+			const session = await pollSession(
+				sessionId,
+				(data) => !!data.worktreePath && existsSync(data.worktreePath),
+				30_000,
+			);
+
+			expect(session.worktreePath).toBeTruthy();
+			expect(typeof session.worktreePath).toBe("string");
+			expect(existsSync(session.worktreePath)).toBe(true);
+
+			// The session cwd should have been updated to the worktree path
+			expect(session.cwd).toBe(session.worktreePath);
+
+			// worktreePath should follow the expected naming pattern:
+			// <repoRoot>-wt/session-<slug>-<uuid8>
+			expect(session.worktreePath).toMatch(/session-/);
+		} finally {
+			await terminateAndPurge(sessionId);
+		}
+	});
+
+	test("worktree is cleaned up on session purge", async () => {
+		// Create session with worktree
+		const createResp = await apiFetch("/api/sessions", {
+			method: "POST",
+			body: JSON.stringify({ cwd: gitCwd(), worktree: true }),
+		});
+		expect(createResp.status).toBe(201);
+		const created = await createResp.json();
+		const sessionId = created.id;
+
+		// Wait for worktree to be ready
+		const session = await pollSession(
+			sessionId,
+			(data) => !!data.worktreePath && existsSync(data.worktreePath),
+			30_000,
+		);
+		const worktreePath = session.worktreePath;
+		expect(existsSync(worktreePath)).toBe(true);
+
+		// Terminate + purge the session (DELETE until 404)
+		await terminateAndPurge(sessionId);
+
+		// Session should no longer exist in the API
+		const detailResp = await apiFetch(`/api/sessions/${sessionId}`);
+		expect(detailResp.status).toBe(404);
+
+		// Worktree directory should be cleaned up.
+		// On Windows, git worktree remove can fail if file locks are held by
+		// recently-terminated processes. If the directory persists, verify the
+		// worktree is at least unregistered from git, then force-remove.
+		if (existsSync(worktreePath)) {
+			// The server tried to clean up — verify it's unregistered from git
+			try {
+				const wtList = execFileSync("git", ["worktree", "list", "--porcelain"], {
+					cwd: gitCwd(),
+					encoding: "utf-8",
+				});
+				// The worktree path should NOT appear in the list if cleanup succeeded
+				const normalizedWtPath = worktreePath.replace(/\\/g, "/").toLowerCase();
+				const isRegistered = wtList
+					.split("\n")
+					.filter((l: string) => l.startsWith("worktree "))
+					.some((l: string) => l.replace(/\\/g, "/").toLowerCase().includes(normalizedWtPath));
+				expect(isRegistered).toBe(false);
+			} catch {
+				// git worktree list failed — skip this check
+			}
+
+			// Force-remove the leftover directory (Windows lock issue)
+			try {
+				execFileSync("git", ["worktree", "remove", worktreePath, "--force"], {
+					cwd: gitCwd(),
+					stdio: "pipe",
+				});
+			} catch {
+				// Best effort — may still fail if locks persist
+			}
+		}
+	});
+
+	test("worktree: true from a non-git directory creates session without error and no worktree fields", async () => {
+		// Use a temp dir that is NOT a git repo
+		const cwd = nonGitCwd();
+
+		const createResp = await apiFetch("/api/sessions", {
+			method: "POST",
+			body: JSON.stringify({ cwd, worktree: true }),
+		});
+		expect(createResp.status).toBe(201);
+		const created = await createResp.json();
+		const sessionId = created.id;
+
+		try {
+			// Give async setup a moment (there shouldn't be any worktree setup)
+			await new Promise((r) => setTimeout(r, 2_000));
+
+			// Fetch the session — worktreePath should be undefined/falsy
+			const detailResp = await apiFetch(`/api/sessions/${sessionId}`);
+			expect(detailResp.ok).toBe(true);
+			const session = await detailResp.json();
+
+			expect(session.worktreePath).toBeFalsy();
+			// cwd should remain the original non-git directory
+			expect(session.cwd).toBe(cwd);
+		} finally {
+			await terminateAndPurge(sessionId);
+		}
+	});
+});


### PR DESCRIPTION
Add an opt-in **Create worktree** checkbox to the new session popover. When checked, the server creates a dedicated git worktree for the session (like goals do), so the agent works in an isolated branch.

## Changes
- **Server**: Extract `isGitRepo()`/`getRepoRoot()` into shared `git.ts`, add `worktree` flag to `POST /api/sessions`, async fire-and-forget worktree setup with retry and failure cleanup, stuck recovery warning on restore
- **UI**: Worktree checkbox in role picker popover with keyboard navigation
- **Tests**: 3 E2E tests covering creation, cleanup on purge, and non-git cwd handling

## Files changed (8)
- `src/server/skills/git.ts` — shared git utilities
- `src/server/agent/goal-manager.ts` — imports from shared utilities
- `src/server/agent/session-store.ts` — `cwd` in updatable fields
- `src/server/server.ts` — worktree handling in session creation
- `src/server/agent/session-manager.ts` — async worktree setup
- `src/app/sidebar.ts` — worktree checkbox
- `src/app/session-manager.ts` — worktree parameter
- `tests/e2e/session-worktree.spec.ts` — E2E tests (new)