### PR TITLE
System Prompt Inspector

### DIFF
--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -4,7 +4,7 @@ import { icon } from "@mariozechner/mini-lit";
 import { Button } from "@mariozechner/mini-lit/dist/Button.js";
 import { Input } from "@mariozechner/mini-lit/dist/Input.js";
 import { html, render } from "lit";
-import { Archive, ArrowLeft, MessagesSquare, ChevronDown, ChevronRight, Drama, Goal as GoalIcon, PanelRightClose, PanelRightOpen, Pencil, Plus, QrCode, Server, Settings, Trash2, Unplug, UserCheck, Users, WandSparkles, Workflow as WorkflowIcon, Wrench, Zap } from "lucide";
+import { Archive, ArrowLeft, FileText, MessagesSquare, ChevronDown, ChevronRight, Drama, Goal as GoalIcon, PanelRightClose, PanelRightOpen, Pencil, Plus, QrCode, Server, Settings, Trash2, Unplug, UserCheck, Users, WandSparkles, Workflow as WorkflowIcon, Wrench, Zap } from "lucide";
 import {
 	state,
 	renderApp,
@@ -1776,6 +1776,16 @@ export function doRenderApp(): void {
 	const isTeamLead = activeSession?.role === "team-lead";
 	const editDeleteBtns = (connected && state.remoteAgent && activeSid) ? html`
 		<div class="flex items-center gap-1 shrink-0">
+			${Button({
+				variant: "ghost",
+				size: "sm",
+				onClick: () => {
+					import("../ui/dialogs/SystemPromptDialog.js").then(m => m.SystemPromptDialog.show(activeSid!));
+				},
+				children: html`<span class="inline-flex items-center gap-1">${icon(FileText, "xs")}<span class="text-xs hidden sm:inline">Prompt</span></span>`,
+				className: "h-7 px-2 text-muted-foreground",
+				title: "View System Prompt",
+			})}
 			${Button({
 				variant: "ghost",
 				size: "sm",

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -10,7 +10,7 @@ import { PromptQueue } from "./prompt-queue.js";
 import { RpcBridge, type RpcBridgeOptions } from "./rpc-bridge.js";
 import { SessionStore, type PersistedSession } from "./session-store.js";
 import { getAssistantDef } from "./assistant-registry.js";
-import { assembleSystemPrompt, cleanupSessionPrompt } from "./system-prompt.js";
+import { assembleSystemPrompt, cleanupSessionPrompt, type PromptParts } from "./system-prompt.js";
 import { generateSessionTitle, generateGoalSummaryTitle } from "./title-generator.js";
 import { CostTracker } from "./cost-tracker.js";
 import type { ColorStore } from "./color-store.js";
@@ -82,6 +82,8 @@ export interface SessionInfo {
 	lastPromptText?: string;
 	/** Last user prompt images, for retry on fresh-response errors */
 	lastPromptImages?: Array<{ type: "image"; data: string; mimeType: string }>;
+	/** Cached PromptParts for serving prompt-sections API */
+	promptParts?: PromptParts;
 }
 
 function broadcast(clients: Set<WebSocket>, msg: ServerMessage): void {
@@ -144,11 +146,19 @@ export class SessionManager {
 	}
 
 	/** Generate tool docs and inject into prompt parts before assembly. */
-	private assemblePrompt(sessionId: string, parts: Parameters<typeof assembleSystemPrompt>[1]): string | undefined {
+	private assemblePrompt(sessionId: string, parts: PromptParts): string | undefined {
 		if (this.toolManager && !parts.toolDocs) {
 			parts.toolDocs = this.toolManager.getToolDocsForPrompt(parts.allowedTools);
 		}
+		// Cache parts for prompt-sections API
+		const session = this.sessions.get(sessionId);
+		if (session) session.promptParts = parts;
 		return assembleSystemPrompt(sessionId, parts);
+	}
+
+	/** Get cached PromptParts for serving prompt-sections API. */
+	getPromptParts(sessionId: string): PromptParts | undefined {
+		return this.sessions.get(sessionId)?.promptParts;
 	}
 
 	// ── Prompt queue helpers ──────────────────────────────────────────
@@ -554,14 +564,21 @@ export class SessionManager {
 				: undefined;
 
 			// Re-attach role prompt for team agents (lost on restart since rolePrompt isn't persisted)
-			let goalSpec = goal?.spec;
+			const goalSpec = goal?.spec;
+			let rolePrompt: string | undefined;
+			let roleName: string | undefined;
+			let toolRestrictionsText: string | undefined;
 			if (ps.role && this.roleManager) {
 				const role = this.roleManager.getRole(ps.role);
 				if (role?.promptTemplate) {
-					let rolePrompt = role.promptTemplate;
+					rolePrompt = role.promptTemplate;
 					if (goal?.branch) rolePrompt = rolePrompt.replace(/\{\{GOAL_BRANCH\}\}/g, goal.branch);
 					rolePrompt = rolePrompt.replace(/\{\{AGENT_ID\}\}/g, `${ps.role}-${(ps.goalId || ps.id).slice(0, 8)}`);
-					goalSpec = (goalSpec ? goalSpec + "\n\n---\n\n" : "") + rolePrompt;
+					roleName = ps.role;
+				}
+				if (role && role.allowedTools.length > 0) {
+					const toolList = role.allowedTools.join(", ");
+					toolRestrictionsText = `## Tool Restrictions\n\nYou are ONLY allowed to use the following tools: ${toolList}\n\nDo NOT use any other tools. If a task requires a tool you don't have access to, explain what you need and ask for help instead of attempting to use the restricted tool.`;
 				}
 			}
 
@@ -571,6 +588,9 @@ export class SessionManager {
 				goalTitle: goal?.title,
 				goalState: goal?.state,
 				goalSpec,
+				rolePrompt,
+				roleName,
+				toolRestrictions: toolRestrictionsText,
 				personalities: resolvedPersonalities,
 				allowedTools: restoredAllowedTools,
 			});
@@ -656,7 +676,7 @@ export class SessionManager {
 		}
 	}
 
-	async createSession(cwd: string, agentArgs?: string[], goalId?: string, assistantType?: string, opts?: { rolePrompt?: string; env?: Record<string, string>; taskId?: string; allowedTools?: string[]; personalities?: Array<{ label: string; promptFragment: string }>; personalityNames?: string[]; workflowContext?: string }): Promise<SessionInfo> {
+	async createSession(cwd: string, agentArgs?: string[], goalId?: string, assistantType?: string, opts?: { rolePrompt?: string; roleName?: string; env?: Record<string, string>; taskId?: string; allowedTools?: string[]; personalities?: Array<{ label: string; promptFragment: string }>; personalityNames?: string[]; workflowContext?: string }): Promise<SessionInfo> {
 		const id = randomUUID();
 
 		const bridgeOptions: RpcBridgeOptions = {
@@ -718,16 +738,13 @@ export class SessionManager {
 		} else {
 			// Normal sessions: global base + AGENTS.md from cwd + goal spec
 			const goal = goalId ? this.goalManager.getGoal(goalId) : undefined;
-			let goalSpec = goal?.spec;
-			// Append role prompt for team agents (role instructions after goal spec)
-			if (opts?.rolePrompt) {
-				goalSpec = (goalSpec ? goalSpec + "\n\n---\n\n" : "") + opts.rolePrompt;
-			}
+			const goalSpec = goal?.spec;
 
-			// Append tool restrictions if allowedTools is specified and non-empty
+			// Build tool restrictions text if allowedTools is specified and non-empty
+			let toolRestrictionsText: string | undefined;
 			if (effectiveAllowedTools && effectiveAllowedTools.length > 0) {
 				const toolList = effectiveAllowedTools.join(", ");
-				goalSpec = (goalSpec || "") + `\n\n---\n\n## Tool Restrictions\n\nYou are ONLY allowed to use the following tools: ${toolList}\n\nDo NOT use any other tools. If a task requires a tool you don't have access to, explain what you need and ask for help instead of attempting to use the restricted tool.`;
+				toolRestrictionsText = `## Tool Restrictions\n\nYou are ONLY allowed to use the following tools: ${toolList}\n\nDo NOT use any other tools. If a task requires a tool you don't have access to, explain what you need and ask for help instead of attempting to use the restricted tool.`;
 			}
 
 			// Build task context if taskId is provided
@@ -756,6 +773,9 @@ export class SessionManager {
 				goalTitle: goal?.title,
 				goalState: goal?.state,
 				goalSpec,
+				rolePrompt: opts?.rolePrompt,
+				roleName: opts?.roleName,
+				toolRestrictions: toolRestrictionsText,
 				taskTitle,
 				taskType,
 				taskSpec,
@@ -1355,13 +1375,13 @@ export class SessionManager {
 		session.unsubscribe();
 		await session.rpcClient.stop();
 
-		// Reassemble system prompt with role instructions appended
+		// Reassemble system prompt with role instructions as separate fields
 		const goal = session.goalId ? this.goalManager.getGoal(session.goalId) : undefined;
-		let goalSpec = goal?.spec;
-		goalSpec = (goalSpec ? goalSpec + "\n\n---\n\n" : "") + role.promptTemplate;
+		const goalSpec = goal?.spec;
+		let toolRestrictionsText: string | undefined;
 		if (role.allowedTools.length > 0) {
 			const toolList = role.allowedTools.join(", ");
-			goalSpec += `\n\n---\n\n## Tool Restrictions\n\nYou are ONLY allowed to use the following tools: ${toolList}\n\nDo NOT use any other tools. If a task requires a tool you don't have access to, explain what you need and ask for help instead of attempting to use the restricted tool.`;
+			toolRestrictionsText = `## Tool Restrictions\n\nYou are ONLY allowed to use the following tools: ${toolList}\n\nDo NOT use any other tools. If a task requires a tool you don't have access to, explain what you need and ask for help instead of attempting to use the restricted tool.`;
 		}
 
 		// Resolve personalities for system prompt
@@ -1376,7 +1396,11 @@ export class SessionManager {
 			goalTitle: goal?.title,
 			goalState: goal?.state,
 			goalSpec,
+			rolePrompt: role.promptTemplate,
+			roleName: role.name,
+			toolRestrictions: toolRestrictionsText,
 			personalities: resolvedPersonalities,
+			allowedTools: role.allowedTools.length > 0 ? role.allowedTools : undefined,
 		});
 
 		// Respawn with new system prompt
@@ -1474,16 +1498,22 @@ export class SessionManager {
 
 		// Reassemble system prompt with new personalities (preserving role prompt if assigned)
 		const goal = session.goalId ? this.goalManager.getGoal(session.goalId) : undefined;
-		let goalSpec = goal?.spec;
+		const goalSpec = goal?.spec;
 
-		// If the session has a role, include its prompt template (same pattern as assignRole)
+		// If the session has a role, include its prompt template as separate fields
+		let rolePrompt: string | undefined;
+		let roleName: string | undefined;
+		let toolRestrictionsText: string | undefined;
+		let roleAllowedTools: string[] | undefined;
 		if (session.role && this.roleManager) {
 			const role = this.roleManager.getRole(session.role);
 			if (role) {
-				goalSpec = (goalSpec ? goalSpec + "\n\n---\n\n" : "") + role.promptTemplate;
+				rolePrompt = role.promptTemplate;
+				roleName = role.name;
 				if (role.allowedTools.length > 0) {
+					roleAllowedTools = role.allowedTools;
 					const toolList = role.allowedTools.join(", ");
-					goalSpec += `\n\n---\n\n## Tool Restrictions\n\nYou are ONLY allowed to use the following tools: ${toolList}\n\nDo NOT use any other tools. If a task requires a tool you don't have access to, explain what you need and ask for help instead of attempting to use the restricted tool.`;
+					toolRestrictionsText = `## Tool Restrictions\n\nYou are ONLY allowed to use the following tools: ${toolList}\n\nDo NOT use any other tools. If a task requires a tool you don't have access to, explain what you need and ask for help instead of attempting to use the restricted tool.`;
 				}
 			}
 		}
@@ -1498,7 +1528,11 @@ export class SessionManager {
 			goalTitle: goal?.title,
 			goalState: goal?.state,
 			goalSpec,
+			rolePrompt,
+			roleName,
+			toolRestrictions: toolRestrictionsText,
 			personalities: resolvedPersonalities,
+			allowedTools: roleAllowedTools,
 		});
 
 		// Respawn with new system prompt

--- a/src/server/agent/system-prompt.ts
+++ b/src/server/agent/system-prompt.ts
@@ -78,6 +78,12 @@ export interface PromptParts {
 	goalState?: string;
 	/** Goal spec markdown content */
 	goalSpec?: string;
+	/** Role prompt template (separate from goalSpec for section display) */
+	rolePrompt?: string;
+	/** Role name for display */
+	roleName?: string;
+	/** Tool restrictions text (separate from goalSpec for section display) */
+	toolRestrictions?: string;
 	/** Task title */
 	taskTitle?: string;
 	/** Task type (e.g. 'implementation', 'code-review', etc.) */
@@ -94,6 +100,12 @@ export interface PromptParts {
 	allowedTools?: string[];
 	/** Pre-formatted upstream gate context from workflow dependencies */
 	workflowContext?: string;
+}
+
+export interface PromptSection {
+	label: string;
+	source: string;
+	content: string;
 }
 
 /**
@@ -122,12 +134,21 @@ export function assembleSystemPrompt(sessionId: string, parts: PromptParts): str
 		sections.push("# Project Context\n\n" + agentsMd.trim());
 	}
 
-	// 3. Goal spec
-	if (parts.goalSpec?.trim()) {
-		const header = parts.goalTitle
-			? `# Goal\n\n**${parts.goalTitle}** (Status: ${parts.goalState || "unknown"})`
-			: "# Goal";
-		sections.push(header + "\n\n" + parts.goalSpec.trim());
+	// 3. Goal spec (merge rolePrompt and toolRestrictions into goalSpec section for backward compat)
+	{
+		let effectiveGoalSpec = parts.goalSpec || "";
+		if (parts.rolePrompt?.trim()) {
+			effectiveGoalSpec = (effectiveGoalSpec ? effectiveGoalSpec + "\n\n---\n\n" : "") + parts.rolePrompt.trim();
+		}
+		if (parts.toolRestrictions?.trim()) {
+			effectiveGoalSpec = (effectiveGoalSpec ? effectiveGoalSpec + "\n\n---\n\n" : "") + parts.toolRestrictions.trim();
+		}
+		if (effectiveGoalSpec.trim()) {
+			const header = parts.goalTitle
+				? `# Goal\n\n**${parts.goalTitle}** (Status: ${parts.goalState || "unknown"})`
+				: "# Goal";
+			sections.push(header + "\n\n" + effectiveGoalSpec.trim());
+		}
 	}
 
 	// 3.5. Personalities
@@ -176,6 +197,74 @@ export function assembleSystemPrompt(sessionId: string, parts: PromptParts): str
 	const promptPath = path.join(PROMPTS_DIR, `${sessionId}.md`);
 	fs.writeFileSync(promptPath, combined, "utf-8");
 	return promptPath;
+}
+
+/**
+ * Return the system prompt broken into labeled sections for the inspector UI.
+ * Takes the same PromptParts as assembleSystemPrompt but returns structured
+ * sections instead of writing to disk.
+ */
+export function getPromptSections(parts: PromptParts): PromptSection[] {
+	const sections: PromptSection[] = [];
+
+	// 1. Global system prompt
+	if (parts.baseSystemPromptPath && fs.existsSync(parts.baseSystemPromptPath)) {
+		const base = fs.readFileSync(parts.baseSystemPromptPath, "utf-8").trim();
+		if (base) sections.push({ label: "System Prompt", source: "config/system-prompt.md", content: base });
+	}
+
+	// 2. AGENTS.md
+	const agentsMd = readAgentsMd(parts.cwd);
+	if (agentsMd.trim()) sections.push({ label: "Project Context", source: "AGENTS.md", content: agentsMd.trim() });
+
+	// 3. Goal spec (separate from role)
+	if (parts.goalSpec?.trim()) {
+		const header = parts.goalTitle
+			? `**${parts.goalTitle}** (Status: ${parts.goalState || "unknown"})`
+			: "";
+		sections.push({ label: "Goal", source: `Goal: ${parts.goalTitle || "Untitled"}`, content: (header ? header + "\n\n" : "") + parts.goalSpec.trim() });
+	}
+
+	// 4. Role prompt
+	if (parts.rolePrompt?.trim()) {
+		sections.push({ label: "Role", source: `Role: ${parts.roleName || "unknown"}`, content: parts.rolePrompt.trim() });
+	}
+
+	// 5. Tool restrictions
+	if (parts.toolRestrictions?.trim()) {
+		sections.push({ label: "Tool Restrictions", source: "Allowed tools filter", content: parts.toolRestrictions.trim() });
+	}
+
+	// 6. Personalities
+	if (parts.personalities && parts.personalities.length > 0) {
+		const lines = parts.personalities.map(p => `- **${p.label}**: ${p.promptFragment}`);
+		sections.push({ label: "Personality", source: "Personalities", content: lines.join("\n") });
+	}
+
+	// 7. Tool docs
+	if (parts.toolDocs?.trim()) {
+		sections.push({ label: "Tools", source: "Tool documentation", content: parts.toolDocs.trim() });
+	}
+
+	// 8. Task context
+	if (parts.taskTitle || parts.taskType) {
+		const taskLines: string[] = [];
+		if (parts.taskType) taskLines.push(`**Type**: ${parts.taskType}`);
+		if (parts.taskTitle) taskLines.push(`**Title**: ${parts.taskTitle}`);
+		if (parts.taskSpec?.trim()) taskLines.push(`\n## Task Specification\n${parts.taskSpec.trim()}`);
+		if (parts.taskDependsOn?.length) {
+			taskLines.push("\n## Dependencies");
+			for (const dep of parts.taskDependsOn) taskLines.push(`- ${dep}`);
+		}
+		sections.push({ label: "Task", source: `Task: ${parts.taskTitle || "Untitled"}`, content: taskLines.join("\n") });
+	}
+
+	// 9. Workflow context
+	if (parts.workflowContext?.trim()) {
+		sections.push({ label: "Workflow Context", source: "Upstream gates", content: parts.workflowContext.trim() });
+	}
+
+	return sections;
 }
 
 /**

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -617,7 +617,7 @@ export class TeamManager {
 				undefined,
 				goalId,
 				undefined,
-				{ rolePrompt, allowedTools, personalities: resolvedPersonalities, personalityNames, workflowContext },
+				{ rolePrompt, roleName: role, allowedTools, personalities: resolvedPersonalities, personalityNames, workflowContext },
 			);
 
 			// Assign a unique color and title

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -23,6 +23,7 @@ import { ToolManager } from "./agent/tool-manager.js";
 import { PersonalityStore } from "./agent/personality-store.js";
 import { PersonalityManager } from "./agent/personality-manager.js";
 
+import { getPromptSections } from "./agent/system-prompt.js";
 import type { TaskState } from "./agent/task-store.js";
 import { BgProcessManager } from "./agent/bg-process-manager.js";
 import { GateStore } from "./agent/gate-store.js";
@@ -2581,6 +2582,24 @@ async function handleApiRoute(
 		const ok = sessionManager.setDraft(id, body.type, body.data);
 		if (!ok) { json({ error: "Session not found" }, 404); return; }
 		json({ ok: true });
+		return;
+	}
+
+	// GET /api/sessions/:id/prompt-sections — return system prompt broken into labeled sections
+	const promptSectionsMatch = url.pathname.match(/^\/api\/sessions\/([^/]+)\/prompt-sections$/);
+	if (promptSectionsMatch && req.method === "GET") {
+		const id = promptSectionsMatch[1];
+		const parts = sessionManager.getPromptParts(id);
+		if (!parts) { json({ error: "Session not found or no prompt data" }, 404); return; }
+
+		// Ensure tool docs are populated (they may have been injected at assemblePrompt time,
+		// but re-inject if missing to handle edge cases)
+		if (!parts.toolDocs && toolManager) {
+			parts.toolDocs = toolManager.getToolDocsForPrompt(parts.allowedTools);
+		}
+
+		const sections = getPromptSections(parts);
+		json({ sections });
 		return;
 	}
 

--- a/src/ui/dialogs/SystemPromptDialog.ts
+++ b/src/ui/dialogs/SystemPromptDialog.ts
@@ -1,0 +1,171 @@
+import { Button } from "@mariozechner/mini-lit/dist/Button.js";
+import { DialogContent, DialogHeader } from "@mariozechner/mini-lit/dist/Dialog.js";
+import { DialogBase } from "@mariozechner/mini-lit/dist/DialogBase.js";
+import { html, nothing } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import { gatewayFetch } from "../../app/api.js";
+
+interface PromptSection {
+	label: string;
+	source: string;
+	content: string;
+}
+
+@customElement("system-prompt-dialog")
+export class SystemPromptDialog extends DialogBase {
+	@state() private sections: PromptSection[] = [];
+	@state() private loading = true;
+	@state() private error = "";
+	@state() private expandedSections = new Set<number>();
+	@state() private copied = false;
+
+	private sessionId = "";
+
+	protected modalWidth = "min(700px, 90vw)";
+	protected modalHeight = "min(80vh, 800px)";
+
+	createRenderRoot() {
+		return this;
+	}
+
+	static show(sessionId: string) {
+		const dialog = new SystemPromptDialog();
+		dialog.sessionId = sessionId;
+		document.body.appendChild(dialog);
+		dialog.open();
+		dialog.fetchSections();
+	}
+
+	private async fetchSections() {
+		try {
+			const resp = await gatewayFetch(`/api/sessions/${this.sessionId}/prompt-sections`);
+			if (!resp.ok) {
+				this.error = `Failed to load prompt sections (${resp.status})`;
+				this.loading = false;
+				return;
+			}
+			const data = await resp.json();
+			this.sections = data.sections ?? [];
+		} catch (err) {
+			this.error = `Failed to load prompt sections: ${err}`;
+		} finally {
+			this.loading = false;
+		}
+	}
+
+	private toggleSection(index: number) {
+		const next = new Set(this.expandedSections);
+		if (next.has(index)) {
+			next.delete(index);
+		} else {
+			next.add(index);
+		}
+		this.expandedSections = next;
+	}
+
+	private async copyAll() {
+		const text = this.sections
+			.map((s) => `# ${s.label}\n\n${s.content}`)
+			.join("\n\n---\n\n");
+		try {
+			await navigator.clipboard.writeText(text);
+			this.copied = true;
+			setTimeout(() => {
+				this.copied = false;
+			}, 2000);
+		} catch {
+			// Fallback
+			const ta = document.createElement("textarea");
+			ta.value = text;
+			document.body.appendChild(ta);
+			ta.select();
+			document.execCommand("copy");
+			document.body.removeChild(ta);
+			this.copied = true;
+			setTimeout(() => {
+				this.copied = false;
+			}, 2000);
+		}
+	}
+
+	private renderSection(section: PromptSection, index: number) {
+		const expanded = this.expandedSections.has(index);
+		return html`
+			<div class="border border-border rounded-lg overflow-hidden">
+				<button
+					class="w-full flex items-center gap-2 p-3 text-left hover:bg-secondary/50 transition-colors"
+					@click=${() => this.toggleSection(index)}
+				>
+					<svg
+						width="16"
+						height="16"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						class="shrink-0 transition-transform ${expanded ? "rotate-90" : ""}"
+					>
+						<path d="m9 18 6-6-6-6"></path>
+					</svg>
+					<div class="flex-1 min-w-0">
+						<span class="font-medium text-sm text-foreground">${section.label}</span>
+						<span class="text-xs text-muted-foreground ml-2">${section.source}</span>
+					</div>
+					<span class="text-xs text-muted-foreground shrink-0">${this.formatSize(section.content.length)}</span>
+				</button>
+				${expanded
+					? html`
+							<div class="border-t border-border">
+								<pre
+									class="text-xs text-foreground p-3 m-0 overflow-y-auto"
+									style="white-space: pre-wrap; word-wrap: break-word; max-height: 400px; background: var(--muted);"
+								>${section.content}</pre>
+							</div>
+						`
+					: nothing}
+			</div>
+		`;
+	}
+
+	private formatSize(chars: number): string {
+		if (chars < 1000) return `${chars} chars`;
+		return `${(chars / 1000).toFixed(1)}k chars`;
+	}
+
+	protected override renderContent() {
+		return html`
+			${DialogContent({
+				className: "h-full flex flex-col",
+				children: html`
+					${DialogHeader({
+						title: "System Prompt Inspector",
+						description: `Assembled prompt sections for this session`,
+					})}
+
+					<div class="flex-1 overflow-y-auto mt-4 space-y-2">
+						${this.loading
+							? html`<div class="text-center py-8 text-muted-foreground">Loading...</div>`
+							: this.error
+								? html`<div class="text-center py-8 text-destructive">${this.error}</div>`
+								: this.sections.length === 0
+									? html`<div class="text-center py-8 text-muted-foreground">No prompt sections available</div>`
+									: this.sections.map((s, i) => this.renderSection(s, i))}
+					</div>
+
+					${!this.loading && this.sections.length > 0
+						? html`
+								<div class="mt-4 flex justify-end border-t border-border pt-3">
+									${Button({
+										variant: "outline",
+										size: "sm",
+										onClick: () => this.copyAll(),
+										children: this.copied ? "Copied!" : "Copy All",
+									})}
+								</div>
+							`
+						: nothing}
+				`,
+			})}
+		`;
+	}
+}


### PR DESCRIPTION
Adds a **Prompt** button in the chat header that opens a modal showing the assembled system prompt broken into labeled, collapsible sections with source attribution.

## Changes
- **Server**: New `GET /api/sessions/:id/prompt-sections` endpoint that returns the system prompt as structured sections (System Prompt, Project Context, Goal, Role, Personalities, Tools, Tool Restrictions, Task, Workflow Context)
- **Server**: Extended `PromptParts` with `rolePrompt`, `roleName`, `toolRestrictions` fields for section-level separation; cached on `SessionInfo` for on-demand retrieval
- **UI**: New `SystemPromptDialog` component with collapsible accordion sections, loading state, and Copy All button
- **UI**: FileText icon button in chat header nav bar (next to Edit/Terminate)

## Testing
- All 262 E2E tests pass
- Type check passes (server + web)