### PR TITLE
Fix git widget on mobile

### DIFF
--- a/src/ui/components/GitStatusWidget.ts
+++ b/src/ui/components/GitStatusWidget.ts
@@ -1,4 +1,4 @@
-import { html, LitElement, nothing } from 'lit';
+import { html, LitElement, nothing, render } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 @customElement('git-status-widget')
@@ -34,8 +34,11 @@ export class GitStatusWidget extends LitElement {
     @state() private pulling = false;
     @state() private pullError = '';
 
+    private _dropdownEl: HTMLElement | null = null;
+
     private _onDocumentClick = (e: MouseEvent) => {
-        if (this.expanded && !this.contains(e.target as Node)) {
+        const target = e.target as Node;
+        if (this.expanded && !this.contains(target) && !this._dropdownEl?.contains(target)) {
             this.expanded = false;
         }
     };
@@ -52,6 +55,14 @@ export class GitStatusWidget extends LitElement {
     disconnectedCallback() {
         super.disconnectedCallback();
         document.removeEventListener('click', this._onDocumentClick, true);
+        this._removeDropdown();
+    }
+
+    private _removeDropdown() {
+        if (this._dropdownEl) {
+            this._dropdownEl.remove();
+            this._dropdownEl = null;
+        }
     }
 
     private _toggle(e: MouseEvent) {
@@ -314,6 +325,57 @@ export class GitStatusWidget extends LitElement {
         }));
     }
 
+    /** Render the dropdown content into the portaled element */
+    private _renderDropdownContent() {
+        return html`
+            <div class="flex items-center gap-1.5 mb-2 text-foreground font-medium text-sm">
+                <span>⎇</span>
+                <span class="break-all">${this.branch}</span>
+                ${!this.isOnPrimary
+                    ? html`<span class="text-[10px] text-muted-foreground font-normal">(feature)</span>`
+                    : nothing}
+            </div>
+
+            <div class="flex flex-col gap-1 mb-2">
+                <div class="text-muted-foreground">
+                    Remote: ${this._renderRemoteStatus()}
+                </div>
+                ${this._renderPrimaryStatus()}
+            </div>
+
+            ${this._renderPrSection()}
+
+            ${this.statusFiles.length > 0
+                ? html`
+                      <div class="border-t border-border pt-2 mt-2">
+                          <div class="text-muted-foreground mb-1 font-medium">Changes</div>
+                          <div class="flex flex-col gap-0.5 max-h-[200px] overflow-y-auto">
+                              ${this.statusFiles.map(
+                                  (f) => html`
+                                      <div class="flex items-center gap-2 py-0.5 min-w-0">
+                                          <span
+                                              class="${this._statusColor(f.status)} font-mono w-[70px] shrink-0 text-right"
+                                              title=${this._statusLabel(f.status)}
+                                          >
+                                              ${this._statusLabel(f.status)}
+                                          </span>
+                                          <span class="text-foreground truncate" title=${f.file}>
+                                              ${f.file}
+                                          </span>
+                                      </div>
+                                  `
+                              )}
+                          </div>
+                      </div>
+                  `
+                : html`
+                      <div class="text-green-600 dark:text-green-400 border-t border-border pt-2 mt-2">
+                          Working tree clean
+                      </div>
+                  `}
+        `;
+    }
+
     render() {
         if (!this.branch && !this.loading) return nothing;
 
@@ -335,82 +397,54 @@ export class GitStatusWidget extends LitElement {
                 ${this._pillIndicator()}
                 ${this._prPillIcon()}
             </button>
-
-            ${this.expanded
-                ? html`
-                      <div
-                          class="fixed z-50 bg-card border border-border rounded-lg shadow-lg p-3 text-xs"
-                          style="max-width:min(420px, calc(100vw - 1rem))"
-                          id="git-status-dropdown"
-                      >
-                          <div class="flex items-center gap-1.5 mb-2 text-foreground font-medium text-sm">
-                              <span>⎇</span>
-                              <span class="break-all">${this.branch}</span>
-                              ${!this.isOnPrimary
-                                  ? html`<span class="text-[10px] text-muted-foreground font-normal">(feature)</span>`
-                                  : nothing}
-                          </div>
-
-                          <div class="flex flex-col gap-1 mb-2">
-                              <div class="text-muted-foreground">
-                                  Remote: ${this._renderRemoteStatus()}
-                              </div>
-                              ${this._renderPrimaryStatus()}
-                          </div>
-
-                          ${this._renderPrSection()}
-
-                          ${this.statusFiles.length > 0
-                              ? html`
-                                    <div class="border-t border-border pt-2 mt-2">
-                                        <div class="text-muted-foreground mb-1 font-medium">Changes</div>
-                                        <div class="flex flex-col gap-0.5 max-h-[200px] overflow-y-auto">
-                                            ${this.statusFiles.map(
-                                                (f) => html`
-                                                    <div class="flex items-center gap-2 py-0.5 min-w-0">
-                                                        <span
-                                                            class="${this._statusColor(f.status)} font-mono w-[70px] shrink-0 text-right"
-                                                            title=${this._statusLabel(f.status)}
-                                                        >
-                                                            ${this._statusLabel(f.status)}
-                                                        </span>
-                                                        <span class="text-foreground truncate" title=${f.file}>
-                                                            ${f.file}
-                                                        </span>
-                                                    </div>
-                                                `
-                                            )}
-                                        </div>
-                                    </div>
-                                `
-                              : html`
-                                    <div class="text-green-600 dark:text-green-400 border-t border-border pt-2 mt-2">
-                                        Working tree clean
-                                    </div>
-                                `}
-                      </div>
-                  `
-                : nothing}
         `;
     }
 
     override updated(changed: Map<string, unknown>) {
         super.updated(changed);
-        if (changed.has('expanded') && this.expanded) {
-            this._positionDropdown();
+        if (changed.has('expanded')) {
+            if (this.expanded) {
+                // Create portal dropdown on body
+                this._dropdownEl = document.createElement('div');
+                this._dropdownEl.id = 'git-status-dropdown';
+                this._dropdownEl.className = 'fixed z-[9999] bg-card border border-border rounded-lg shadow-lg p-3 text-xs';
+                this._dropdownEl.style.maxWidth = 'min(420px, calc(100vw - 1rem))';
+                document.body.appendChild(this._dropdownEl);
+                render(this._renderDropdownContent(), this._dropdownEl);
+                this._positionDropdown();
+            } else {
+                this._removeDropdown();
+            }
+        } else if (this.expanded && this._dropdownEl) {
+            // Re-render dropdown content when other reactive properties change
+            render(this._renderDropdownContent(), this._dropdownEl);
         }
     }
 
     private _positionDropdown() {
         const btn = this.querySelector('button');
-        const dropdown = this.querySelector('#git-status-dropdown') as HTMLElement;
+        const dropdown = this._dropdownEl;
         if (!btn || !dropdown) return;
         const rect = btn.getBoundingClientRect();
         const spaceBelow = window.innerHeight - rect.bottom;
         const spaceAbove = rect.top;
+        const vw = window.innerWidth;
+        const pad = 8; // min distance from viewport edge
 
         // Anchor right edge to button's right edge
-        dropdown.style.right = `${window.innerWidth - rect.right}px`;
+        let rightVal = vw - rect.right;
+
+        // Clamp: ensure dropdown doesn't overflow left edge of viewport
+        const dropdownWidth = dropdown.offsetWidth || 0;
+        if (dropdownWidth > 0) {
+            const leftEdge = vw - rightVal - dropdownWidth;
+            if (leftEdge < pad) {
+                rightVal = Math.max(pad, vw - dropdownWidth - pad);
+            }
+        }
+
+        dropdown.style.right = `${rightVal}px`;
+        dropdown.style.left = '';
 
         if (spaceAbove > spaceBelow) {
             // Open upward (default for chat input area)

--- a/tests/git-widget-portal.html
+++ b/tests/git-widget-portal.html
@@ -111,32 +111,7 @@
             <span class="truncate">test-branch</span>
             <span class="text-amber-600 font-medium shrink-0">+2 -1</span>
           </button>
-          <!-- Dropdown: hidden until toggled. Uses position:fixed just like GitStatusWidget.ts -->
-          <div
-            id="git-status-dropdown"
-            class="fixed z-50 bg-card border border-border rounded-lg shadow-lg p-3 text-xs"
-            style="display:none; max-width:min(420px, calc(100vw - 1rem));"
-          >
-            <div class="flex items-center gap-1.5 mb-2 text-foreground font-medium text-sm">
-              <span>⎇</span>
-              <span>test-branch</span>
-              <span class="text-muted-foreground" style="font-size:10px">(feature)</span>
-            </div>
-            <div class="flex flex-col gap-1 mb-2">
-              <div class="text-muted-foreground">
-                Remote: <span class="text-amber-600">2 unpushed commits</span>
-              </div>
-            </div>
-            <div class="border-t border-border pt-2 mt-2">
-              <div class="text-muted-foreground mb-1 font-medium">Changes</div>
-              <div>
-                <div style="display:flex;gap:8px;padding:2px 0">
-                  <span class="text-amber-600" style="font-family:monospace;width:70px;text-align:right">modified</span>
-                  <span class="text-foreground">src/ui/components/GitStatusWidget.ts</span>
-                </div>
-              </div>
-            </div>
-          </div>
+          <!-- Dropdown is portaled to document.body (fix for transform ancestor clipping) -->
         </div>
       </div>
     </div>
@@ -147,18 +122,59 @@
 </div>
 
 <script>
-  // Reproduce the exact toggle + positioning logic from GitStatusWidget.ts
+  // Reproduce the fixed toggle + positioning logic from GitStatusWidget.ts
+  // Key fix: dropdown is portaled to document.body instead of being inline
+  // inside the transformed ancestor. This avoids CSS transform breaking
+  // position:fixed positioning.
 
   const pill = document.getElementById('git-pill');
-  const dropdown = document.getElementById('git-status-dropdown');
   const widget = document.getElementById('git-widget');
+  let dropdown = null;
   let expanded = false;
+
+  const dropdownHTML = `
+    <div class="flex items-center gap-1.5 mb-2 text-foreground font-medium text-sm">
+      <span>⎇</span>
+      <span>test-branch</span>
+      <span class="text-muted-foreground" style="font-size:10px">(feature)</span>
+    </div>
+    <div class="flex flex-col gap-1 mb-2">
+      <div class="text-muted-foreground">
+        Remote: <span class="text-amber-600">2 unpushed commits</span>
+      </div>
+    </div>
+    <div class="border-t border-border pt-2 mt-2">
+      <div class="text-muted-foreground mb-1 font-medium">Changes</div>
+      <div>
+        <div style="display:flex;gap:8px;padding:2px 0">
+          <span class="text-amber-600" style="font-family:monospace;width:70px;text-align:right">modified</span>
+          <span class="text-foreground">src/ui/components/GitStatusWidget.ts</span>
+        </div>
+      </div>
+    </div>
+  `;
+
+  function createDropdown() {
+    dropdown = document.createElement('div');
+    dropdown.id = 'git-status-dropdown';
+    dropdown.className = 'fixed z-50 bg-card border border-border rounded-lg shadow-lg p-3 text-xs';
+    dropdown.style.maxWidth = 'min(420px, calc(100vw - 1rem))';
+    dropdown.innerHTML = dropdownHTML;
+    document.body.appendChild(dropdown);
+  }
+
+  function removeDropdown() {
+    if (dropdown) {
+      dropdown.remove();
+      dropdown = null;
+    }
+  }
 
   // _onDocumentClick equivalent — close when clicking outside
   document.addEventListener('click', (e) => {
-    if (expanded && !widget.contains(e.target)) {
+    if (expanded && !widget.contains(e.target) && (!dropdown || !dropdown.contains(e.target))) {
       expanded = false;
-      dropdown.style.display = 'none';
+      removeDropdown();
     }
   }, true);
 
@@ -167,23 +183,37 @@
     e.stopPropagation();
     expanded = !expanded;
     if (expanded) {
-      dropdown.style.display = '';
+      createDropdown();
       positionDropdown();
     } else {
-      dropdown.style.display = 'none';
+      removeDropdown();
     }
   });
 
-  // _positionDropdown equivalent — verbatim from GitStatusWidget.ts
+  // _positionDropdown equivalent — matches GitStatusWidget.ts portal approach
   function positionDropdown() {
     const btn = pill;
     if (!btn || !dropdown) return;
     const rect = btn.getBoundingClientRect();
     const spaceBelow = window.innerHeight - rect.bottom;
     const spaceAbove = rect.top;
+    const vw = window.innerWidth;
+    const pad = 8;
 
     // Anchor right edge to button's right edge
-    dropdown.style.right = (window.innerWidth - rect.right) + 'px';
+    let rightVal = vw - rect.right;
+
+    // Clamp: ensure dropdown doesn't overflow left edge of viewport
+    const dropdownWidth = dropdown.offsetWidth || 0;
+    if (dropdownWidth > 0) {
+      const leftEdge = vw - rightVal - dropdownWidth;
+      if (leftEdge < pad) {
+        rightVal = Math.max(pad, vw - dropdownWidth - pad);
+      }
+    }
+
+    dropdown.style.right = rightVal + 'px';
+    dropdown.style.left = '';
 
     if (spaceAbove > spaceBelow) {
       // Open upward (default for chat input area at bottom)
@@ -198,7 +228,7 @@
 
   // Expose state for test inspection
   window.__isExpanded = () => expanded;
-  window.__getDropdownRect = () => dropdown.getBoundingClientRect();
+  window.__getDropdownRect = () => dropdown ? dropdown.getBoundingClientRect() : null;
   window.__getSliderRect = () => document.getElementById('slider').getBoundingClientRect();
 </script>
 </body>

--- a/tests/git-widget-portal.html
+++ b/tests/git-widget-portal.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Git Widget Portal — Dropdown in Transformed Ancestor</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html, body { height: 100%; width: 100%; }
+
+  :root {
+    --card: #fff;
+    --border: #e5e7eb;
+    --foreground: #111;
+    --muted-foreground: #6b7280;
+  }
+
+  /* Tailwind-like utilities the widget uses */
+  .fixed { position: fixed; }
+  .z-50 { z-index: 50; }
+  .bg-card { background: var(--card); }
+  .border { border-width: 1px; border-style: solid; }
+  .border-border { border-color: var(--border); }
+  .rounded-lg { border-radius: 0.5rem; }
+  .shadow-lg { box-shadow: 0 10px 15px -3px rgba(0,0,0,.1); }
+  .p-3 { padding: 0.75rem; }
+  .text-xs { font-size: 0.75rem; }
+  .text-sm { font-size: 0.875rem; }
+  .text-foreground { color: var(--foreground); }
+  .text-muted-foreground { color: var(--muted-foreground); }
+  .font-medium { font-weight: 500; }
+  .inline-flex { display: inline-flex; }
+  .flex { display: flex; }
+  .items-center { align-items: center; }
+  .gap-1 { gap: 0.25rem; }
+  .gap-1\.5 { gap: 0.375rem; }
+  .px-1\.5 { padding-left: 0.375rem; padding-right: 0.375rem; }
+  .py-0\.5 { padding-top: 0.125rem; padding-bottom: 0.125rem; }
+  .rounded-full { border-radius: 9999px; }
+  .cursor-pointer { cursor: pointer; }
+  .truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .shrink-0 { flex-shrink: 0; }
+  .mb-2 { margin-bottom: 0.5rem; }
+  .flex-col { flex-direction: column; }
+  .leading-tight { line-height: 1.25; }
+  .text-\[11px\] { font-size: 11px; }
+  .transition-colors { transition: color 0.15s; }
+  .hover\:text-foreground:hover { color: var(--foreground); }
+  .text-green-600 { color: #16a34a; }
+  .text-amber-600 { color: #d97706; }
+  .border-t { border-top-width: 1px; border-top-style: solid; }
+  .pt-2 { padding-top: 0.5rem; }
+  .mt-2 { margin-top: 0.5rem; }
+
+  /*
+   * Simulate the mobile preview slider layout from src/app/render.ts.
+   *
+   * .preview-slider has overflow:hidden + position:relative (line ~2122)
+   * .preview-slider__track has transform + will-change:transform (line ~2123)
+   *
+   * Per CSS spec, transform on any ancestor changes the containing block
+   * for position:fixed descendants — they become relative to the transformed
+   * ancestor, not the viewport. Combined with overflow:hidden, the dropdown
+   * is clipped invisible.
+   */
+  .preview-slider {
+    overflow: hidden;
+    position: relative;
+    height: 100%;
+    width: 100%;
+  }
+  .preview-slider__track {
+    display: flex;
+    width: 200%;
+    height: 100%;
+    transform: translateX(0%);
+    will-change: transform;
+  }
+  .chat-pane {
+    width: 50%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+  .widget-area {
+    margin-top: auto;
+    padding: 12px;
+    border-top: 1px solid var(--border);
+  }
+</style>
+</head>
+<body>
+
+<!--
+  This layout mirrors the mobile preview mode from render.ts.
+  The git-status-widget sits inside the chat pane, which is inside
+  a transformed slider track with an overflow:hidden parent.
+-->
+<div class="preview-slider" id="slider">
+  <div class="preview-slider__track" id="track">
+    <div class="chat-pane">
+      <div style="flex:1;padding:12px;">Chat content area</div>
+      <div class="widget-area" id="widget-area">
+        <!-- Inline reproduction of the widget's trigger + dropdown pattern -->
+        <div id="git-widget" style="display:inline-block;position:relative;">
+          <button
+            id="git-pill"
+            class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-card border border-border text-muted-foreground hover:text-foreground transition-colors cursor-pointer text-[11px] leading-tight"
+          >
+            <span class="shrink-0">⎇</span>
+            <span class="truncate">test-branch</span>
+            <span class="text-amber-600 font-medium shrink-0">+2 -1</span>
+          </button>
+          <!-- Dropdown: hidden until toggled. Uses position:fixed just like GitStatusWidget.ts -->
+          <div
+            id="git-status-dropdown"
+            class="fixed z-50 bg-card border border-border rounded-lg shadow-lg p-3 text-xs"
+            style="display:none; max-width:min(420px, calc(100vw - 1rem));"
+          >
+            <div class="flex items-center gap-1.5 mb-2 text-foreground font-medium text-sm">
+              <span>⎇</span>
+              <span>test-branch</span>
+              <span class="text-muted-foreground" style="font-size:10px">(feature)</span>
+            </div>
+            <div class="flex flex-col gap-1 mb-2">
+              <div class="text-muted-foreground">
+                Remote: <span class="text-amber-600">2 unpushed commits</span>
+              </div>
+            </div>
+            <div class="border-t border-border pt-2 mt-2">
+              <div class="text-muted-foreground mb-1 font-medium">Changes</div>
+              <div>
+                <div style="display:flex;gap:8px;padding:2px 0">
+                  <span class="text-amber-600" style="font-family:monospace;width:70px;text-align:right">modified</span>
+                  <span class="text-foreground">src/ui/components/GitStatusWidget.ts</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="chat-pane" style="background:#f0f0f0;">
+      <div style="padding:12px;">Preview pane (HTML preview content)</div>
+    </div>
+  </div>
+</div>
+
+<script>
+  // Reproduce the exact toggle + positioning logic from GitStatusWidget.ts
+
+  const pill = document.getElementById('git-pill');
+  const dropdown = document.getElementById('git-status-dropdown');
+  const widget = document.getElementById('git-widget');
+  let expanded = false;
+
+  // _onDocumentClick equivalent — close when clicking outside
+  document.addEventListener('click', (e) => {
+    if (expanded && !widget.contains(e.target)) {
+      expanded = false;
+      dropdown.style.display = 'none';
+    }
+  }, true);
+
+  // _toggle equivalent
+  pill.addEventListener('click', (e) => {
+    e.stopPropagation();
+    expanded = !expanded;
+    if (expanded) {
+      dropdown.style.display = '';
+      positionDropdown();
+    } else {
+      dropdown.style.display = 'none';
+    }
+  });
+
+  // _positionDropdown equivalent — verbatim from GitStatusWidget.ts
+  function positionDropdown() {
+    const btn = pill;
+    if (!btn || !dropdown) return;
+    const rect = btn.getBoundingClientRect();
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const spaceAbove = rect.top;
+
+    // Anchor right edge to button's right edge
+    dropdown.style.right = (window.innerWidth - rect.right) + 'px';
+
+    if (spaceAbove > spaceBelow) {
+      // Open upward (default for chat input area at bottom)
+      dropdown.style.bottom = (window.innerHeight - rect.top + 4) + 'px';
+      dropdown.style.top = '';
+    } else {
+      // Open downward
+      dropdown.style.top = (rect.bottom + 4) + 'px';
+      dropdown.style.bottom = '';
+    }
+  }
+
+  // Expose state for test inspection
+  window.__isExpanded = () => expanded;
+  window.__getDropdownRect = () => dropdown.getBoundingClientRect();
+  window.__getSliderRect = () => document.getElementById('slider').getBoundingClientRect();
+</script>
+</body>
+</html>

--- a/tests/git-widget-portal.spec.ts
+++ b/tests/git-widget-portal.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "@playwright/test";
+import path from "node:path";
+
+const TEST_PAGE = `file://${path.resolve("tests/git-widget-portal.html")}`;
+
+test.describe("Git widget dropdown inside transformed ancestor", () => {
+	// Mobile viewport — simulates the conditions where preview slider is active
+	test.use({ viewport: { width: 375, height: 667 } });
+
+	test("dropdown should be visible within viewport when expanded inside transformed ancestor", async ({ page }) => {
+		await page.goto(TEST_PAGE);
+
+		// Click the git status pill to expand the dropdown
+		await page.click("#git-pill");
+
+		// Wait a frame for positioning to apply
+		await page.waitForTimeout(100);
+
+		// Verify the dropdown is toggled on
+		const isExpanded = await page.evaluate(() => (window as any).__isExpanded());
+		expect(isExpanded).toBe(true);
+
+		// Get the dropdown's bounding rect as seen by the browser
+		const dropdownRect = await page.evaluate(() => {
+			const dd = document.getElementById("git-status-dropdown")!;
+			const r = dd.getBoundingClientRect();
+			return { top: r.top, left: r.left, bottom: r.bottom, right: r.right, width: r.width, height: r.height };
+		});
+
+		// Get the viewport dimensions
+		const viewport = await page.evaluate(() => ({
+			width: window.innerWidth,
+			height: window.innerHeight,
+		}));
+
+		// The dropdown must have non-zero dimensions (it rendered)
+		expect(dropdownRect.width).toBeGreaterThan(0);
+		expect(dropdownRect.height).toBeGreaterThan(0);
+
+		// THE KEY ASSERTION: The dropdown must be visible within the viewport.
+		// With the bug, position:fixed inside a transformed ancestor causes the
+		// dropdown to be positioned relative to the transform ancestor, not the
+		// viewport. Combined with overflow:hidden on .preview-slider, the
+		// dropdown is clipped and its visible rect is outside the viewport or
+		// has zero intersection with it.
+		const isWithinViewport =
+			dropdownRect.top >= 0 &&
+			dropdownRect.left >= 0 &&
+			dropdownRect.bottom <= viewport.height &&
+			dropdownRect.right <= viewport.width;
+
+		// Also check: is the dropdown actually not clipped by the overflow:hidden ancestor?
+		// Use an intersection check: can the user actually see/tap the dropdown?
+		const isVisibleToUser = await page.evaluate(() => {
+			const dd = document.getElementById("git-status-dropdown")!;
+			const r = dd.getBoundingClientRect();
+			// Check if the element at the dropdown's center is the dropdown or a descendant
+			const centerX = r.left + r.width / 2;
+			const centerY = r.top + r.height / 2;
+			const elAtCenter = document.elementFromPoint(centerX, centerY);
+			return elAtCenter !== null && (dd === elAtCenter || dd.contains(elAtCenter));
+		});
+
+		const isVisible = isWithinViewport && isVisibleToUser;
+		expect(
+			isVisible,
+			"dropdown should be visible within viewport when expanded inside transformed ancestor"
+		).toBe(true);
+	});
+
+
+});


### PR DESCRIPTION
## Summary
Fix the git status widget dropdown being invisible/inaccessible on mobile when preview mode is enabled.

## Root Cause
The dropdown uses `position: fixed` but when inside mobile slider containers (`.preview-slider__track`, `.assistant-slider__track`) that have `transform: translateX(...)` and `will-change: transform`, CSS spec makes fixed positioning relative to the transformed ancestor instead of the viewport. Combined with `overflow: hidden` on the slider parent, the dropdown is clipped invisible.

## Fix
Portal the dropdown to `document.body` instead of rendering it inline in the widget DOM. The dropdown is created/removed imperatively in the `updated()` lifecycle, positioned with existing viewport-relative `getBoundingClientRect()` math, and kept reactive via Lit's `render()`.

## Changes
- `src/ui/components/GitStatusWidget.ts` — Portal dropdown to body
- `tests/git-widget-portal.spec.ts` + `tests/git-widget-portal.html` — Reproducing test

## Verification
- Type check: clean
- Reproducing test: passes (was failing before fix)
- Unit tests: pass
- E2E tests: pass