### PR TITLE
Defer archived sessions loading

### DIFF
--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -172,14 +172,29 @@ export async function refreshSessions(): Promise<void> {
 			.catch(() => {});
 	}
 
-	// Always fetch archived sessions so staff/goal filtering works correctly.
-	// When the toggle is off, we still need the data to hide goal-affiliated
-	// staff agents from the Staff section (they belong under their goal).
-	fetchArchivedSessions();
+	// Lazy-load archived sessions on initial load only if user had "Show archived" persisted
+	if (isInitial && state.showArchived && !_archivedSessionsLoaded) {
+		fetchArchivedSessions();
+	}
+}
+
+/** Whether archived sessions have been fetched at least once. */
+let _archivedSessionsLoaded = false;
+
+/** Check whether archived sessions have been loaded. */
+export function archivedSessionsLoaded(): boolean {
+	return _archivedSessionsLoaded;
+}
+
+/** Reset the archived sessions state (flag + data). Called on toggle-off. */
+export function clearArchivedSessionsState(): void {
+	_archivedSessionsLoaded = false;
+	state.archivedSessions = [];
 }
 
 /** Fetch archived sessions from the API. */
 export async function fetchArchivedSessions(): Promise<void> {
+	_archivedSessionsLoaded = true;
 	try {
 		const res = await gatewayFetch("/api/sessions?include=archived");
 		if (!res.ok) return;

--- a/src/app/goal-dashboard.ts
+++ b/src/app/goal-dashboard.ts
@@ -4,7 +4,7 @@ import "../ui/components/VerificationOutputModal.js";
 import { ansiToHtml, hasAnsi } from "../ui/utils/ansi.js";
 import { Button } from "@mariozechner/mini-lit/dist/Button.js";
 import { state, renderApp, type Goal } from "./state.js";
-import { gatewayFetch, deleteGoal, startTeam, teardownTeam, getTeamState, fetchGoalGates, fetchRoles, refreshPrStatusCache, type GateState, type GateSignal } from "./api.js";
+import { gatewayFetch, deleteGoal, startTeam, teardownTeam, getTeamState, fetchGoalGates, fetchRoles, refreshPrStatusCache, fetchArchivedSessions, archivedSessionsLoaded, type GateState, type GateSignal } from "./api.js";
 import { setHashRoute } from "./routing.js";
 import { createAndConnectSession, connectToSession } from "./session-manager.js";
 import { showGoalDialog } from "./dialogs.js";
@@ -189,6 +189,11 @@ export async function loadDashboardData(goalId: string): Promise<void> {
 		fetchActiveVerifications(goalId);
 
 		loading = false;
+
+		// Lazy-load archived sessions for assignee lookups (fire-and-forget)
+		if (!archivedSessionsLoaded()) {
+			fetchArchivedSessions();
+		}
 	} catch (err) {
 		error = err instanceof Error ? err.message : String(err);
 		loading = false;

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -256,6 +256,7 @@ function renderMobileLanding() {
 						import("./api.js").then(m => m.fetchArchivedSessions());
 					} else {
 						resetArchivedExpandState();
+						import("./api.js").then(m => m.clearArchivedSessionsState());
 					}
 					renderApp();
 				}}

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -808,6 +808,7 @@ export function renderSidebar() {
 													import("./api.js").then(m => m.fetchArchivedSessions());
 												} else {
 													resetArchivedExpandState();
+													import("./api.js").then(m => m.clearArchivedSessionsState());
 												}
 												renderApp();
 											}}
@@ -855,6 +856,7 @@ export function renderSidebar() {
 						} else {
 							state.showArchived = false;
 							resetArchivedExpandState();
+							import("./api.js").then(m => m.clearArchivedSessionsState());
 						}
 						renderApp();
 					}}

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -20,7 +20,7 @@ import {
 import { createAndConnectSession, connectToSession } from "./session-manager.js";
 import { cwdCombobox } from "./cwd-combobox.js";
 import { showGoalDialog } from "./dialogs.js";
-import { refreshSessions, fetchRoles, fetchPersonalities, fetchStaff, wakeStaffAgent, fetchArchivedSessions, dismissSetup, gatewayFetch, type PersonalityData } from "./api.js";
+import { refreshSessions, fetchRoles, fetchPersonalities, fetchStaff, wakeStaffAgent, fetchArchivedSessions, archivedSessionsLoaded, dismissSetup, gatewayFetch, type PersonalityData } from "./api.js";
 import { statusBobbit, sessionAcronym } from "./session-colors.js";
 import { renderGoalGroup, renderSessionRow, renderArchivedSessionRow, renderArchivedDelegates, SESSION_ROW_PY, INDENT, CHEVRON_W, HEADER_CHEVRON_W, terseRelativeTime, hasUnseenActivity, formatSessionAge, renderSessionTitle } from "./render-helpers.js";
 import type { GatewaySession } from "./state.js";
@@ -436,6 +436,9 @@ let _staffLoaded = false;
 function ensureStaffLoaded(): void {
 	if (_staffLoaded) return;
 	_staffLoaded = true;
+	if (!archivedSessionsLoaded()) {
+		fetchArchivedSessions();
+	}
 	fetchStaff().then((list) => {
 		state.staffList = list.map((s) => ({
 			id: s.id, name: s.name, description: s.description, state: s.state,

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -321,6 +321,9 @@ export function resetArchivedExpandState(): void {
 	// (archived team leads that were explicitly collapsed — remove them so they return to default)
 	for (const id of archivedSessionIds) collapsedTeamLeadSessions.delete(id);
 	localStorage.setItem(COLLAPSED_TEAM_LEADS_KEY, JSON.stringify([...collapsedTeamLeadSessions]));
+
+	// Free memory — archived sessions will be re-fetched on next toggle-on
+	state.archivedSessions = [];
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Removes the unconditional `fetchArchivedSessions()` call from the 5-second poll cycle in `refreshSessions()`, eliminating ~467 KB of unnecessary JSON fetched on every poll.

### What changed
- **Lazy loading**: Archived sessions are only fetched when the user toggles "Show archived", opens a goal dashboard, or loads the staff section
- **Concurrency guard**: `_archivedSessionsLoaded` flag prevents duplicate in-flight fetches and distinguishes "never fetched" from "legitimately empty"
- **Memory cleanup**: Toggling archived off clears `state.archivedSessions` and resets the loaded flag

### Files (5 files, +35/-6)
- `src/app/api.ts` — Flag, getter, reset helper, conditional fetch logic
- `src/app/state.ts` — Clear array in `resetArchivedExpandState()`
- `src/app/goal-dashboard.ts` — Lazy fetch in `loadDashboardData()`
- `src/app/sidebar.ts` — Lazy fetch in `ensureStaffLoaded()`, flag reset on toggle-off
- `src/app/render.ts` — Flag reset on mobile toggle-off

### Testing
- Type check: clean
- Unit tests: 280/280 passed
- E2E tests: 266/266 passed
- All gate reviews (gap analysis, code quality, security) passed