### PR TITLE
PR conflict pulse icon

### DIFF
--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -252,7 +252,7 @@ export async function refreshPrStatusCache() {
 				if (res.status === 404) return { goalId: g.id, pr: null, noPr: true };
 				if (!res.ok) return { goalId: g.id, pr: null, noPr: false };
 				const data = await res.json();
-				return { goalId: g.id, pr: data as { state: string; url?: string; number?: number; reviewDecision?: string }, noPr: false };
+				return { goalId: g.id, pr: data as { state: string; url?: string; number?: number; reviewDecision?: string; mergeable?: string }, noPr: false };
 			} catch {
 				return { goalId: g.id, pr: null, noPr: false };
 			}
@@ -263,7 +263,7 @@ export async function refreshPrStatusCache() {
 	for (const { goalId, pr, noPr } of results) {
 		const prev = state.prStatusCache.get(goalId);
 		if (pr) {
-			if (!prev || prev.state !== pr.state || prev.reviewDecision !== pr.reviewDecision) {
+			if (!prev || prev.state !== pr.state || prev.reviewDecision !== pr.reviewDecision || prev.mergeable !== pr.mergeable) {
 				state.prStatusCache.set(goalId, pr);
 				changed = true;
 			}

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -491,3 +491,11 @@ theme-toggle button {
 	animation: title-wave 4s linear infinite;
 	will-change: background-position;
 }
+
+@keyframes pr-conflict-pulse {
+	0%, 100% { opacity: 1; }
+	50% { opacity: 0.3; }
+}
+.pr-conflict-pulse {
+	animation: pr-conflict-pulse 1.5s ease-in-out infinite;
+}

--- a/src/app/goal-dashboard.ts
+++ b/src/app/goal-dashboard.ts
@@ -77,7 +77,7 @@ interface PrStatus {
 	url: string;
 	title: string;
 	state: "OPEN" | "MERGED" | "CLOSED";
-	mergeable: boolean;
+	mergeable?: string;
 	viewerIsAdmin?: boolean;
 	reviewDecision?: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null;
 }
@@ -1062,7 +1062,7 @@ function renderMetaRows(goal: Goal): TemplateResult {
 						.prUrl=${prStatus?.url}
 						.prNumber=${prStatus?.number}
 						.prTitle=${prStatus?.title}
-						.prMergeable=${prStatus?.mergeable ?? false}
+						.prMergeable=${prStatus?.mergeable}
 						.viewerIsAdmin=${prStatus?.viewerIsAdmin ?? false}
 						.reviewDecision=${prStatus?.reviewDecision}
 						@pr-merge=${handlePrMerge}

--- a/src/app/goal-dashboard.ts
+++ b/src/app/goal-dashboard.ts
@@ -77,7 +77,7 @@ interface PrStatus {
 	url: string;
 	title: string;
 	state: "OPEN" | "MERGED" | "CLOSED";
-	mergeable: boolean;
+	mergeable?: string;
 	viewerIsAdmin?: boolean;
 	reviewDecision?: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null;
 }

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -409,12 +409,13 @@ function renderGoalBadge(goalId: string) {
 			: pr.state === "OPEN" && pr.reviewDecision === "CHANGES_REQUESTED" ? " — changes requested"
 			: pr.state === "OPEN" && pr.reviewDecision === "APPROVED" ? " — approved"
 			: "";
-		const label = (pr.number ? `PR #${pr.number} ${pr.state.toLowerCase()}` : `PR ${pr.state.toLowerCase()}`) + reviewLabel;
+		const hasConflicts = pr.state === "OPEN" && pr.mergeable === "CONFLICTING";
+		const label = (pr.number ? `PR #${pr.number} ${pr.state.toLowerCase()}` : `PR ${pr.state.toLowerCase()}`) + reviewLabel + (hasConflicts ? " — has conflicts" : "");
 		const prIcon = html`<svg class="shrink-0" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="${color}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 0 1 2 2v7"/><path d="M6 9v12"/></svg>`;
 		if (pr.url) {
-			return html`<a class="shrink-0 flex items-center" href=${pr.url} target="_blank" rel="noopener" title=${label} @click=${(e: Event) => e.stopPropagation()}>${prIcon}</a>`;
+			return html`<a class="shrink-0 flex items-center ${hasConflicts ? "pr-conflict-pulse" : ""}" href=${pr.url} target="_blank" rel="noopener" title=${label} @click=${(e: Event) => e.stopPropagation()}>${prIcon}</a>`;
 		}
-		return html`<span class="shrink-0 flex items-center" title=${label}>${prIcon}</span>`;
+		return html`<span class="shrink-0 flex items-center ${hasConflicts ? "pr-conflict-pulse" : ""}" title=${label}>${prIcon}</span>`;
 	}
 
 	// Fall back to gate status

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -1166,7 +1166,7 @@ async function refreshPrStatusForSession(sessionId: string): Promise<void> {
 		}
 		// Update goal grouping cache so sidebar reflects the new PR state immediately
 		if (goalId && data.state) {
-			state.prStatusCache.set(goalId, { state: data.state, url: data.url, number: data.number, reviewDecision: data.reviewDecision ?? null });
+			state.prStatusCache.set(goalId, { state: data.state, url: data.url, number: data.number, reviewDecision: data.reviewDecision ?? null, mergeable: data.mergeable });
 			renderApp();
 		}
 	} catch {

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -110,7 +110,7 @@ export const state = {
 	/** Gate status cache: goalId → { passed, total, verifying } */
 	gateStatusCache: new Map<string, { passed: number; total: number; verifying: boolean }>(),
 	/** PR status cache: goalId → { state, url, number, reviewDecision } */
-	prStatusCache: new Map<string, { state: string; url?: string; number?: number; reviewDecision?: string | null }>(),
+	prStatusCache: new Map<string, { state: string; url?: string; number?: number; reviewDecision?: string | null; mergeable?: string }>(),
 	sessionsLoading: false,
 	sessionsError: "",
 	creatingSession: false,

--- a/src/ui/components/AgentInterface.ts
+++ b/src/ui/components/AgentInterface.ts
@@ -57,7 +57,7 @@ export class AgentInterface extends LitElement {
 	@property() prUrl?: string;
 	@property({ type: Number }) prNumber?: number;
 	@property() prTitle?: string;
-	@property({ type: Boolean }) prMergeable?: boolean;
+	@property() prMergeable?: string;
 	@property({ type: Boolean }) viewerIsAdmin?: boolean;
 	@property() reviewDecision?: string;
 	// Background processes for this session
@@ -741,7 +741,7 @@ export class AgentInterface extends LitElement {
 								.prUrl=${this.prUrl}
 								.prNumber=${this.prNumber}
 								.prTitle=${this.prTitle}
-								.prMergeable=${this.prMergeable ?? false}
+								.prMergeable=${this.prMergeable}
 								.viewerIsAdmin=${this.viewerIsAdmin ?? false}
 								.reviewDecision=${this.reviewDecision}
 								@pr-merge=${this._handlePrMerge}

--- a/src/ui/components/GitStatusWidget.ts
+++ b/src/ui/components/GitStatusWidget.ts
@@ -23,7 +23,7 @@ export class GitStatusWidget extends LitElement {
     @property() prUrl?: string;
     @property({ type: Number }) prNumber?: number;
     @property() prTitle?: string;
-    @property({ type: Boolean }) prMergeable?: boolean;
+    @property() prMergeable?: string;
     @property({ type: Boolean }) viewerIsAdmin = false;
     @property() reviewDecision?: string; // "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null
 
@@ -193,7 +193,10 @@ export class GitStatusWidget extends LitElement {
             colorClass = 'text-green-600/70 dark:text-green-400/70';
             title = `PR #${this.prNumber} open`;
         }
-        return html`<span class="${colorClass} shrink-0" style="display:inline-flex;align-items:center;gap:1px" title=${title}><span style="font-size:10px">⦿</span>${this.prNumber != null ? html`<span style="font-size:10px">#${this.prNumber}</span>` : nothing}</span>`;
+        const hasConflicts = this.prState === 'OPEN' && this.prMergeable === 'CONFLICTING';
+        if (hasConflicts) title += ' — has conflicts';
+        const pulseClass = hasConflicts ? ' pr-conflict-pulse' : '';
+        return html`<span class="${colorClass}${pulseClass} shrink-0" style="display:inline-flex;align-items:center;gap:1px" title=${title}><span style="font-size:10px">⦿</span>${this.prNumber != null ? html`<span style="font-size:10px">#${this.prNumber}</span>` : nothing}</span>`;
     }
 
     /** Review decision badge for inside the PR section */
@@ -234,6 +237,7 @@ export class GitStatusWidget extends LitElement {
                         ${this.prState}
                     </span>
                     ${this._renderReviewBadge()}
+                    ${this.prState === 'OPEN' && this.prMergeable === 'CONFLICTING' ? html`<span style="display:inline-block;padding:1px 6px;border-radius:9999px;font-size:10px;font-weight:600;color:oklch(0.62 0.14 25);background:oklch(0.62 0.14 25 / 0.12)">Has conflicts</span>` : nothing}
                 </div>
                 ${this.prState === 'OPEN' ? html`
                     <div style="display:flex;align-items:center;gap:6px;margin-top:6px">
@@ -250,7 +254,7 @@ export class GitStatusWidget extends LitElement {
                         ${this.merging ? html`<span style="display:inline-flex;align-items:center;gap:4px;font-size:11px;color:var(--muted-foreground)"><span style="display:inline-block;width:12px;height:12px;border:2px solid var(--border);border-top-color:var(--foreground);border-radius:50%;animation:git-spin 0.6s linear infinite"></span>Merging\u2026</span>` : html`
                         <button
                             style="font-size:11px;padding:2px 10px;border-radius:4px;border:1px solid var(--border);background:oklch(0.68 0.12 145 / 0.12);color:oklch(0.68 0.12 145);cursor:pointer;font-weight:500"
-                            ?disabled=${!this.prMergeable}
+                            ?disabled=${this.prMergeable !== "MERGEABLE"}
                             @click=${this._handleMerge}
                         >
                             Merge PR
@@ -262,7 +266,7 @@ export class GitStatusWidget extends LitElement {
                         >
                             Force Merge
                         </button>` : nothing}
-                        ${!this.prMergeable && !this.viewerIsAdmin ? html`<span style="font-size:10px;color:var(--destructive)">Not mergeable</span>` : nothing}
+                        ${this.prMergeable !== "MERGEABLE" && !this.viewerIsAdmin ? html`<span style="font-size:10px;color:var(--destructive)">${this.prMergeable === "CONFLICTING" ? "Has conflicts" : "Not mergeable"}</span>` : nothing}
                         `}
                     </div>
                     ${this.mergeError ? html`<div style="font-size:11px;color:var(--destructive);margin-top:4px">${this.mergeError}</div>` : nothing}


### PR DESCRIPTION
When a PR has merge conflicts (`mergeable === "CONFLICTING"` from GitHub CLI), pulse the PR icon in both the sidebar goal badge and the git status widget.

### Changes:
- **Data flow**: Pipe `mergeable` string through `prStatusCache` (state.ts, api.ts, session-manager.ts)
- **Sidebar badge**: PR icon pulses with CSS animation when conflicting, tooltip updated
- **GitStatusWidget**: `prMergeable` changed from boolean to string; pill icon pulses when conflicting; expanded section shows red "Has conflicts" badge; merge button disable logic updated; distinguishes CONFLICTING vs UNKNOWN states
- **CSS**: Added `@keyframes pr-conflict-pulse` animation (1.5s ease-in-out opacity pulse)