### PR TITLE
Canvas Bobbit Sprites

### DIFF
--- a/src/app/role-manager-page.ts
+++ b/src/app/role-manager-page.ts
@@ -26,7 +26,7 @@ import { setHashRoute } from "./routing.js";
  *  .bobbit-blob__wand, .bobbit-blob__wizard-hat divs with .bobbit-blob--inline
  *  CSS overrides.
  */
-function idleBlob(accId: string, size = 40, hueIndex = 0, _phaseIndex = 0): TemplateResult {
+function idleBlob(accId: string, size = 40, hueIndex = 0, phaseIndex = 0): TemplateResult {
 	const hue = BOBBIT_HUE_ROTATIONS[hueIndex % BOBBIT_HUE_ROTATIONS.length];
 	const acc = accId && accId !== "none" ? accId : undefined;
 	// Scale so the body (10px wide) fills ~77% of the container.
@@ -42,6 +42,7 @@ function idleBlob(accId: string, size = 40, hueIndex = 0, _phaseIndex = 0): Temp
 				animated: true,
 				schedule: IDLE_EYE_SCHEDULE,
 				cycleDuration: 10000,
+				eyeDelay: phaseIndex * 800,
 			})}></canvas>
 		</div>
 	`;

--- a/src/app/role-manager-page.ts
+++ b/src/app/role-manager-page.ts
@@ -5,6 +5,7 @@ import { html, nothing, type TemplateResult } from "lit";
 import { ArrowLeft, Pencil, Plus, Trash2 } from "lucide";
 import { fetchRoles, fetchTools, createRole, updateRole, deleteRole, gatewayFetch, fetchAssistantPrompts, updateAssistantPrompt, type RoleData, type ToolInfo, type AssistantPromptInfo } from "./api.js";
 import { ACCESSORY_IDS, BOBBIT_HUE_ROTATIONS, getAccessory } from "./session-colors.js";
+import { bobbitSprite, IDLE_EYE_SCHEDULE } from "../ui/bobbit-sprite.js";
 import { state, renderApp } from "./state.js";
 import { setHashRoute } from "./routing.js";
 
@@ -12,43 +13,36 @@ import { setHashRoute } from "./routing.js";
 // HELPERS
 // ============================================================================
 
-/** Render an idle in-chat blob with the given accessory in a self-contained box.
+/** Render an idle bobbit with the given accessory in a self-contained box.
  *
- *  The blob's CSS assumes chat context: the sprite has margin 8px 18px 28px 18px,
- *  the blob container has margin-bottom:-24px and overflow:visible. To render it
- *  outside chat we use a CSS class (.bobbit-blob--inline) that resets these
- *  properties, added via role-manager.css.
+ *  Uses a single <canvas> with the bobbitSprite directive that paints body,
+ *  eyes, and the active accessory. The directive handles DPR-aware sizing,
+ *  eye animation via BobbitEyeTimer, and DPR change repaints.
+ *
+ *  Replaces the old chat-blob-structure approach that used CSS box-shadow on
+ *  .bobbit-blob__sprite, .bobbit-blob__crown, .bobbit-blob__bandana,
+ *  .bobbit-blob__magnifier, .bobbit-blob__palette, .bobbit-blob__pencil,
+ *  .bobbit-blob__shield, .bobbit-blob__set-square, .bobbit-blob__flask,
+ *  .bobbit-blob__wand, .bobbit-blob__wizard-hat divs with .bobbit-blob--inline
+ *  CSS overrides.
  */
-function idleBlob(accId: string, size = 40, hueIndex = 0, phaseIndex = 0): TemplateResult {
-	const accClass = accId && accId !== "none"
-		? `bobbit-${accId === "crown" ? "crowned" : accId}`
-		: "";
-	const cls = `bobbit-blob bobbit-blob--idle bobbit-blob--inline ${accClass}`.trim();
-	// The sprite margin-box is ~40×36px at 4× scale but accessories overflow it.
-	// Use a larger viewport to capture everything, then scale down.
-	const naturalSize = 76;
-	const s = size / naturalSize;
+function idleBlob(accId: string, size = 40, hueIndex = 0, _phaseIndex = 0): TemplateResult {
 	const hue = BOBBIT_HUE_ROTATIONS[hueIndex % BOBBIT_HUE_ROTATIONS.length];
-	// Offset animations so multiple blobs don't blink/shimmer in sync
-	const eyeDelay = -(phaseIndex * 1.3 % 10).toFixed(2);
-	const shimmerDelay = -(phaseIndex * 1.7 % 8).toFixed(2);
+	const acc = accId && accId !== "none" ? accId : undefined;
+	// Scale so the body (10px wide) fills ~77% of the container.
+	// drawBobbitSprite() sizes the canvas automatically, accounting for accessory overflow.
+	const scale = size / 13;
 	return html`
-		<div style="width:${size}px;height:${size}px;flex-shrink:0;">
-			<div style="width:${naturalSize}px;height:${naturalSize}px;position:relative;overflow:hidden;transform:scale(${s.toFixed(3)});transform-origin:top left;">
-				<div class="${cls}" style="--bobbit-hue-rotate:${hue}deg;--bobbit-eye-delay:${eyeDelay}s;--bobbit-shimmer-delay:${shimmerDelay}s;">
-					<div class="bobbit-blob__sprite"></div>
-					<div class="bobbit-blob__crown"></div>
-					<div class="bobbit-blob__bandana"></div>
-					<div class="bobbit-blob__magnifier"></div>
-					<div class="bobbit-blob__palette"></div>
-					<div class="bobbit-blob__pencil"></div>
-					<div class="bobbit-blob__shield"></div>
-					<div class="bobbit-blob__set-square"></div>
-					<div class="bobbit-blob__flask"></div>
-					<div class="bobbit-blob__wand"></div>
-					<div class="bobbit-blob__wizard-hat"></div>
-				</div>
-			</div>
+		<div class="bobbit-blob-canvas-inline" style="width:${size}px;height:${size}px;filter:hue-rotate(${hue}deg);">
+			<canvas ${bobbitSprite({
+				eyeState: 'center',
+				scale,
+				accessory: acc,
+				hueRotate: hue,
+				animated: true,
+				schedule: IDLE_EYE_SCHEDULE,
+				cycleDuration: 10000,
+			})}></canvas>
 		</div>
 	`;
 }

--- a/src/app/role-manager.css
+++ b/src/app/role-manager.css
@@ -621,18 +621,31 @@
 }
 
 /* ============================================================================
- * Inline blob — resets chat-specific blob layout for use in rows/grids.
+ * Canvas-based inline blob — renders the bobbit sprite on a single <canvas>
+ * using the bobbitSprite directive. Body, eyes, and accessories are all
+ * painted via drawBobbitSprite() with DPR-aware integer pixel sizing.
  *
- * The normal .bobbit-blob has:
- *   - margin-bottom: -24px (pulls up in chat)
- *   - overflow: visible (accessories extend beyond)
- *   - sprite margin: 8px 18px 28px 18px (spacing for bounce animations)
- *
- * .bobbit-blob--inline cancels all of that and renders the sprite centered
- * within a fixed-size box at a smaller scale.
+ * Replaces the old .bobbit-blob--inline approach that reused the chat blob
+ * structure (box-shadow + CSS overrides). The canvas approach gives crisp
+ * rendering at any DPR without the scaling artifacts of transform + box-shadow.
  * ============================================================================ */
-/* The blob container renders at natural size (3.5x sprite = ~37×37px margin-box)
- * inside an overflow:hidden viewport, then the outer div scales it down. */
+.bobbit-blob-canvas-inline {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	overflow: hidden;
+	flex-shrink: 0;
+}
+
+.bobbit-blob-canvas-inline canvas {
+	image-rendering: pixelated;
+	display: block;
+}
+
+/* ============================================================================
+ * Legacy inline blob rules — kept for backward compatibility with tests and
+ * any external code that may reference .bobbit-blob--inline.
+ * ============================================================================ */
 .bobbit-blob--inline {
 	margin-bottom: 0 !important;
 	overflow: visible;

--- a/src/app/session-colors.ts
+++ b/src/app/session-colors.ts
@@ -298,10 +298,13 @@ export function statusBobbit(status: string, isCompacting = false, sessionId?: s
 
 	// Canvas positioning — offset for accessories that add height
 	const compactTopOffset = compactSquish ? 5.4 : 0;
-	const canvasTop = addsHeight ? `${compactTopOffset}px` : `${compactTopOffset}px`;
+	const canvasTop = `${compactTopOffset}px`;
 
 	// Compute hue-rotate value to pass to the directive for counter-rotating accessories
 	const accessoryHueRotate = (hueRotate && status !== "starting" && status !== "terminated") ? hueRotate : 0;
+
+	// Squish animation for compaction state
+	const squishStyle = compactSquish ? "animation:bobbit-squish 3s ease-in-out infinite;transform-origin:0 9px;" : "";
 
 	return html`<span style="display:inline-flex;align-items:center;justify-content:center;width:${containerWidth};height:${containerHeight};flex-shrink:0;position:relative;overflow:hidden;margin-top:1px;${filterStyle}${bobAnim}${cancelAnim}${idleAnim}"><canvas ${bobbitSprite({
 		eyeState: "center",
@@ -311,5 +314,5 @@ export function statusBobbit(status: string, isCompacting = false, sessionId?: s
 		hueRotate: accessoryHueRotate,
 		selected: isSelected,
 		animated: isSelected,
-	})} style="position:absolute;left:0;top:${canvasTop};image-rendering:pixelated;${shimmer}"></canvas></span>`;
+	})} style="position:absolute;left:0;top:${canvasTop};image-rendering:pixelated;${shimmer}${squishStyle}"></canvas></span>`;
 }

--- a/src/app/session-colors.ts
+++ b/src/app/session-colors.ts
@@ -303,10 +303,13 @@ export function statusBobbit(status: string, isCompacting = false, sessionId?: s
 	// Compute hue-rotate value to pass to the directive for counter-rotating accessories
 	const accessoryHueRotate = (hueRotate && status !== "starting" && status !== "terminated") ? hueRotate : 0;
 
-	// Squish animation for compaction state
+	// Squish animation for compaction state — applied to outer span (not canvas)
+	// because bobbit-squish keyframes include scale(1.6) designed for a 1×1px element.
+	// The canvas is already sized at scale=1.6, so applying squish to the outer span
+	// scales the whole container as a unit.
 	const squishStyle = compactSquish ? "animation:bobbit-squish 3s ease-in-out infinite;transform-origin:0 9px;" : "";
 
-	return html`<span style="display:inline-flex;align-items:center;justify-content:center;width:${containerWidth};height:${containerHeight};flex-shrink:0;position:relative;overflow:hidden;margin-top:1px;${filterStyle}${bobAnim}${cancelAnim}${idleAnim}"><canvas ${bobbitSprite({
+	return html`<span style="display:inline-flex;align-items:center;justify-content:center;width:${containerWidth};height:${containerHeight};flex-shrink:0;position:relative;overflow:hidden;margin-top:1px;${filterStyle}${bobAnim}${cancelAnim}${idleAnim}${squishStyle}"><canvas ${bobbitSprite({
 		eyeState: "center",
 		scale: 1.6,
 		colors: palette,
@@ -314,5 +317,5 @@ export function statusBobbit(status: string, isCompacting = false, sessionId?: s
 		hueRotate: accessoryHueRotate,
 		selected: isSelected,
 		animated: isSelected,
-	})} style="position:absolute;left:0;top:${canvasTop};image-rendering:pixelated;${shimmer}${squishStyle}"></canvas></span>`;
+	})} style="position:absolute;left:0;top:${canvasTop};image-rendering:pixelated;${shimmer}"></canvas></span>`;
 }

--- a/src/app/session-colors.ts
+++ b/src/app/session-colors.ts
@@ -1,6 +1,7 @@
 import { html } from "lit";
 import { patchSession } from "./api.js";
 import { activeSessionId, renderApp } from "./state.js";
+import { bobbitSprite, DEFAULT_PALETTE, STARTING_PALETTE, TERMINATED_PALETTE } from "../ui/bobbit-sprite.js";
 
 // ============================================================================
 // ACCESSORY REGISTRY
@@ -268,32 +269,15 @@ export function statusBobbit(status: string, isCompacting = false, sessionId?: s
 	// Crown is the only accessory that adds height above the sprite
 	const addsHeight = acc.addsHeight;
 
-	const canonical = { main: "#8ec63f", light: "#b5d98a", dark: "#6b9930", eye: "#1a3010" };
-	let p: typeof canonical;
+	// Select palette based on status
+	let palette: Partial<Record<string, string>> | undefined;
 	if (status === "starting") {
-		p = { main: "#eab308", light: "#fde047", dark: "#ca8a04", eye: "#2d2006" };
+		palette = STARTING_PALETTE;
 	} else if (status === "terminated") {
-		p = { main: "#ef4444", light: "#fca5a5", dark: "#dc2626", eye: "#2c0b0e" };
-	} else {
-		p = canonical;
+		palette = TERMINATED_PALETTE;
 	}
 
 	const isBusy = status === "streaming" || isCompacting;
-
-	const eyeColor = isSelected ? p.main : p.eye;
-	const shadow = `
-		3px 0px 0 #000,4px 0px 0 #000,5px 0px 0 #000,6px 0px 0 #000,7px 0px 0 #000,
-		2px 1px 0 #000,3px 1px 0 ${p.main},4px 1px 0 ${p.main},5px 1px 0 ${p.main},6px 1px 0 ${p.light},7px 1px 0 ${p.light},8px 1px 0 #000,
-		1px 2px 0 #000,2px 2px 0 ${p.main},3px 2px 0 ${p.main},4px 2px 0 ${p.main},5px 2px 0 ${p.main},6px 2px 0 ${p.main},7px 2px 0 ${p.light},8px 2px 0 ${p.main},9px 2px 0 #000,
-		0px 3px 0 #000,1px 3px 0 ${p.main},2px 3px 0 ${p.main},3px 3px 0 ${p.main},4px 3px 0 ${p.main},5px 3px 0 ${p.main},6px 3px 0 ${p.main},7px 3px 0 ${p.main},8px 3px 0 ${p.main},9px 3px 0 #000,
-		0px 4px 0 #000,1px 4px 0 ${p.main},2px 4px 0 ${p.main},3px 4px 0 ${eyeColor},4px 4px 0 ${p.main},5px 4px 0 ${p.main},6px 4px 0 ${eyeColor},7px 4px 0 ${p.main},8px 4px 0 ${p.main},9px 4px 0 #000,
-		0px 5px 0 #000,1px 5px 0 ${p.main},2px 5px 0 ${p.main},3px 5px 0 ${eyeColor},4px 5px 0 ${p.main},5px 5px 0 ${p.main},6px 5px 0 ${eyeColor},7px 5px 0 ${p.main},8px 5px 0 ${p.main},9px 5px 0 #000,
-		0px 6px 0 #000,1px 6px 0 ${p.dark},2px 6px 0 ${p.main},3px 6px 0 ${p.main},4px 6px 0 ${p.main},5px 6px 0 ${p.main},6px 6px 0 ${p.main},7px 6px 0 ${p.main},8px 6px 0 ${p.main},9px 6px 0 #000,
-		1px 7px 0 #000,2px 7px 0 ${p.dark},3px 7px 0 ${p.main},4px 7px 0 ${p.main},5px 7px 0 ${p.main},6px 7px 0 ${p.main},7px 7px 0 ${p.main},8px 7px 0 #000,
-		2px 8px 0 #000,3px 8px 0 #000,4px 8px 0 #000,5px 8px 0 #000,6px 8px 0 #000,7px 8px 0 #000
-	`;
-
-	const eyeShadow = `3px 4px 0 ${p.eye},6px 4px 0 ${p.eye},3px 5px 0 ${p.eye},6px 5px 0 ${p.eye}`;
 
 	const shimmerDelay = -(Date.now() % 8000);
 	const shimmer = isBusy && !isCompacting ? `animation:blob-shimmer 8s ease-in-out infinite;animation-delay:${shimmerDelay}ms;` : "";
@@ -308,48 +292,24 @@ export function statusBobbit(status: string, isCompacting = false, sessionId?: s
 	const bobAnim = isBusy && !isCancelling && !isCompacting ? "animation:bobbit-bob 1.8s cubic-bezier(0.34,1.2,0.64,1) infinite;" : "";
 	const cancelAnim = isCancelling ? "animation:bobbit-cancel-fade 1.2s ease-in-out infinite;" : "";
 	const compactSquish = isCompacting && !isCancelling;
-	const baseTransform = isCompacting
-		? (compactSquish
-			? "transform-origin:0 9px;animation:bobbit-squish 3s ease-in-out infinite;"
-			: "transform:scale(1.6) scaleX(1.0) scaleY(0.75) translateY(4.5px);transform-origin:0 9px;")
-		: "transform:scale(1.6);transform-origin:0 0;";
-	const eyeAnim = isSelected
-		? (compactSquish
-			? "transform-origin:0 9px;animation:bobbit-squish 3s ease-in-out infinite;"
-			: `animation:${isCompacting ? "bobbit-eyes-squash" : "bobbit-eyes"} 6s step-end infinite;transform-origin:0 ${isCompacting ? "9px" : "0"};`)
-		: baseTransform;
 
-	const compactTopOffset = compactSquish ? 5.4 : 0;
-	const eyeTop = addsHeight ? `${4 + compactTopOffset}px` : `${compactTopOffset}px`;
-	const eyeLeft = "0";
-	const eyeLayer = isSelected
-		? html`<span style="position:absolute;left:${eyeLeft};top:${eyeTop};display:block;width:1px;height:1px;image-rendering:pixelated;will-change:transform;backface-visibility:hidden;box-shadow:${eyeShadow};${eyeAnim}"></span>`
-		: "";
-
-	// Accessory overlay layer — counter-hue-rotated to keep fixed colours
-	// Flask intentionally rotates with the bobbit for contrast
-	const accFilter = hueRotate && status !== "starting" && status !== "terminated" && acc.id !== "flask"
-		? `filter:hue-rotate(${-hueRotate}deg);`
-		: "";
-	// Bandana needs a slight translateY adjustment; crown uses yOffset for top positioning
-	const isBandanaStyle = acc.id === "bandana";
-	const isCrown = acc.id === "crown";
-	const accTransform = isCompacting
-		? (compactSquish
-			? `transform-origin:0 9px;animation:${isCrown ? "bobbit-squish-crown" : "bobbit-squish"} 3s ease-in-out infinite;`
-			: `transform:scale(1.6) scaleX(1.0) scaleY(0.75) translateY(${isBandanaStyle ? "4px" : "4.5px"})${isCrown ? " translateX(-0.5px)" : ""};transform-origin:0 9px;`)
-		: `transform:scale(1.6)${isBandanaStyle ? " translateY(-0.5px)" : ""}${isCrown ? " translateX(-0.5px)" : ""};transform-origin:0 0;`;
-	const accTop = addsHeight ? `${acc.yOffset + compactTopOffset}px` : `${compactTopOffset}px`;
-	const accessoryLayer = hasAccessory
-		? html`<span style="position:absolute;left:0;top:${accTop};display:block;width:1px;height:1px;image-rendering:pixelated;will-change:transform;backface-visibility:hidden;box-shadow:${acc.shadow};${accTransform}${accFilter}"></span>`
-		: "";
-
-	// Shift inner content down when accessory adds height so tips aren't clipped
-	const innerTop = addsHeight ? `${4 + compactTopOffset}px` : `${compactTopOffset}px`;
 	const containerHeight = addsHeight ? "19px" : "15px";
-
 	const containerWidth = "20px";
 
-	const innerLeft = "0";
-	return html`<span style="display:inline-flex;align-items:center;justify-content:center;width:${containerWidth};height:${containerHeight};flex-shrink:0;position:relative;overflow:hidden;margin-top:1px;${filterStyle}${bobAnim}${cancelAnim}${idleAnim}"><span style="position:absolute;left:${innerLeft};top:${innerTop};display:block;width:1px;height:1px;image-rendering:pixelated;will-change:transform;backface-visibility:hidden;${baseTransform}box-shadow:${shadow};${shimmer}"></span>${eyeLayer}${accessoryLayer}</span>`;
+	// Canvas positioning — offset for accessories that add height
+	const compactTopOffset = compactSquish ? 5.4 : 0;
+	const canvasTop = addsHeight ? `${compactTopOffset}px` : `${compactTopOffset}px`;
+
+	// Compute hue-rotate value to pass to the directive for counter-rotating accessories
+	const accessoryHueRotate = (hueRotate && status !== "starting" && status !== "terminated") ? hueRotate : 0;
+
+	return html`<span style="display:inline-flex;align-items:center;justify-content:center;width:${containerWidth};height:${containerHeight};flex-shrink:0;position:relative;overflow:hidden;margin-top:1px;${filterStyle}${bobAnim}${cancelAnim}${idleAnim}"><canvas ${bobbitSprite({
+		eyeState: "center",
+		scale: 1.6,
+		colors: palette,
+		accessory: hasAccessory ? resolvedAccessoryId : undefined,
+		hueRotate: accessoryHueRotate,
+		selected: isSelected,
+		animated: isSelected,
+	})} style="position:absolute;left:0;top:${canvasTop};image-rendering:pixelated;${shimmer}"></canvas></span>`;
 }

--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -2292,16 +2292,6 @@ html {
 	}
 }
 
-/* Entry + Exit + Idle states — no blink overlay */
-.bobbit-blob--enter .bobbit-blob__sprite::before,
-.bobbit-blob--enter-roll .bobbit-blob__sprite::before,
-.bobbit-blob--exit .bobbit-blob__sprite::before,
-.bobbit-blob--exit-roll .bobbit-blob__sprite::before,
-.bobbit-blob--idle .bobbit-blob__sprite::before {
-	animation: none !important;
-	opacity: 0 !important;
-}
-
 /* ===== Compaction animation — hydraulic press squash ===== */
 
 /* Build-up shake before compaction — vibrating anticipation */
@@ -2311,11 +2301,6 @@ html {
 }
 
 .bobbit-blob--compact-shake .bobbit-blob__shadow {
-	display: none !important;
-}
-
-/* No blink/overlays during shake */
-.bobbit-blob--compact-shake .bobbit-blob__sprite::before {
 	display: none !important;
 }
 
@@ -2351,11 +2336,6 @@ html {
    the shadow's right edge slide diagonally since it can't track the
    sprite's non-uniform transform. The squash reads fine without it. */
 .bobbit-blob--compacting .bobbit-blob__shadow {
-	display: none !important;
-}
-
-/* No overlays during compaction */
-.bobbit-blob--compacting .bobbit-blob__sprite::before {
 	display: none !important;
 }
 
@@ -2441,11 +2421,6 @@ html {
 	display: none !important;
 }
 
-.bobbit-blob--compact-pop .bobbit-blob__sprite::before {
-	animation: none !important;
-	opacity: 0 !important;
-}
-
 @keyframes blob-compact-pop {
 	/* Start from squashed */
 	0% {
@@ -2469,28 +2444,6 @@ html {
 	transform: scale(4) translateX(-7px);
 	animation: none !important;
 }
-
-/* Blink overlay — disabled; eyes now managed by canvas rendering */
-.bobbit-blob__sprite::before {
-	content: '';
-	position: absolute;
-	top: 4px;
-	left: 3px;
-	width: 4px;
-	height: 2px;
-	background: #8ec63f;
-	opacity: 0;
-	z-index: 1;
-	display: none;
-}
-
-@keyframes blob-blink-overlay {
-	0%, 92%, 96%, 100% { opacity: 0; }
-	93%, 95% { opacity: 1; }
-}
-
-/* Slow sine-wave light ripple across the sprite surface */
-/* Wave overlay removed — blue shimmer handled by blob-shimmer filter */
 
 /* Reptilian shimmer — subtle pearlescent skin shift */
 @keyframes blob-shimmer {

--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -1075,87 +1075,12 @@ html {
 	will-change: transform;
 	backface-visibility: hidden;
 	margin: 8px 18px 28px 18px;
+	display: block;
+	image-rendering: pixelated;
 	animation:
 		blob-busy-move 10s cubic-bezier(0.34, 1, 0.64, 1) infinite,
-		blob-busy-eyes 10s steps(1) infinite,
 		blob-shimmer 8s ease-in-out infinite;
-	animation-delay: 0ms, 0ms, var(--bobbit-shimmer-delay, 0ms);
-	box-shadow:
-		3px 0px 0 #000,
-		4px 0px 0 #000,
-		5px 0px 0 #000,
-		6px 0px 0 #000,
-		7px 0px 0 #000,
-		2px 1px 0 #000,
-		3px 1px 0 #8ec63f,
-		4px 1px 0 #8ec63f,
-		5px 1px 0 #8ec63f,
-		6px 1px 0 #b5d98a,
-		7px 1px 0 #b5d98a,
-		8px 1px 0 #000,
-		1px 2px 0 #000,
-		2px 2px 0 #8ec63f,
-		3px 2px 0 #8ec63f,
-		4px 2px 0 #8ec63f,
-		5px 2px 0 #8ec63f,
-		6px 2px 0 #8ec63f,
-		7px 2px 0 #b5d98a,
-		8px 2px 0 #8ec63f,
-		9px 2px 0 #000,
-		0px 3px 0 #000,
-		1px 3px 0 #8ec63f,
-		2px 3px 0 #8ec63f,
-		3px 3px 0 #8ec63f,
-		4px 3px 0 #8ec63f,
-		5px 3px 0 #8ec63f,
-		6px 3px 0 #8ec63f,
-		7px 3px 0 #8ec63f,
-		8px 3px 0 #8ec63f,
-		9px 3px 0 #000,
-		0px 4px 0 #000,
-		1px 4px 0 #8ec63f,
-		2px 4px 0 #8ec63f,
-		3px 4px 0 #1a3010,
-		4px 4px 0 #8ec63f,
-		5px 4px 0 #8ec63f,
-		6px 4px 0 #1a3010,
-		7px 4px 0 #8ec63f,
-		8px 4px 0 #8ec63f,
-		9px 4px 0 #000,
-		0px 5px 0 #000,
-		1px 5px 0 #8ec63f,
-		2px 5px 0 #8ec63f,
-		3px 5px 0 #1a3010,
-		4px 5px 0 #8ec63f,
-		5px 5px 0 #8ec63f,
-		6px 5px 0 #1a3010,
-		7px 5px 0 #8ec63f,
-		8px 5px 0 #8ec63f,
-		9px 5px 0 #000,
-		0px 6px 0 #000,
-		1px 6px 0 #6b9930,
-		2px 6px 0 #8ec63f,
-		3px 6px 0 #8ec63f,
-		4px 6px 0 #8ec63f,
-		5px 6px 0 #8ec63f,
-		6px 6px 0 #8ec63f,
-		7px 6px 0 #8ec63f,
-		8px 6px 0 #8ec63f,
-		9px 6px 0 #000,
-		1px 7px 0 #000,
-		2px 7px 0 #6b9930,
-		3px 7px 0 #8ec63f,
-		4px 7px 0 #8ec63f,
-		5px 7px 0 #8ec63f,
-		6px 7px 0 #8ec63f,
-		7px 7px 0 #8ec63f,
-		8px 7px 0 #000,
-		2px 8px 0 #000,
-		3px 8px 0 #000,
-		4px 8px 0 #000,
-		5px 8px 0 #000,
-		6px 8px 0 #000,
-		7px 8px 0 #000;
+	animation-delay: 0ms, var(--bobbit-shimmer-delay, 0ms);
 }
 
 /* ===== Crown overlay for team leads ===== */
@@ -1179,12 +1104,6 @@ html {
 	image-rendering: pixelated;
 	/* Counter hue-rotate so crown stays gold */
 	filter: hue-rotate(calc(-1 * var(--bobbit-hue-rotate, 0deg)));
-	box-shadow:
-		3px -2px 0 #000, 5px -2px 0 #000, 7px -2px 0 #000,
-		2px -1px 0 #000, 3px -1px 0 #fef08a, 4px -1px 0 #000, 5px -1px 0 #fef08a, 6px -1px 0 #000, 7px -1px 0 #fef08a, 8px -1px 0 #000,
-		1px 0px 0 #000, 2px 0px 0 #fde047, 3px 0px 0 #fef08a, 4px 0px 0 #fde047, 5px 0px 0 #ef4444, 6px 0px 0 #fde047, 7px 0px 0 #fef08a, 8px 0px 0 #fde047, 9px 0px 0 #000,
-		1px 1px 0 #000, 2px 1px 0 #ca8a04, 3px 1px 0 #eab308, 4px 1px 0 #eab308, 5px 1px 0 #eab308, 6px 1px 0 #eab308, 7px 1px 0 #eab308, 8px 1px 0 #ca8a04, 9px 1px 0 #000,
-		1px 2px 0 #000, 2px 2px 0 #000, 3px 2px 0 #000, 4px 2px 0 #000, 5px 2px 0 #000, 6px 2px 0 #000, 7px 2px 0 #000, 8px 2px 0 #000, 9px 2px 0 #000;
 	/* Match sprite's busy animation so crown moves in sync */
 	animation:
 		blob-busy-move 10s cubic-bezier(0.34, 1, 0.64, 1) infinite;
@@ -1234,157 +1153,19 @@ html {
 	image-rendering: pixelated;
 	/* Counter hue-rotate so bandana stays red */
 	filter: hue-rotate(calc(-1 * var(--bobbit-hue-rotate, 0deg)));
-	/* Static fallback — full bandana with tail (used when non-busy animations override) */
-	box-shadow:
-		1px 2px 0 #000, 2px 2px 0 #000, 3px 2px 0 #000, 4px 2px 0 #000, 5px 2px 0 #000, 6px 2px 0 #000, 7px 2px 0 #000, 8px 2px 0 #000, 9px 2px 0 #000,
-		0 3px 0 #000, 1px 3px 0 #b91c1c, 2px 3px 0 #dc2626, 3px 3px 0 #ef4444, 4px 3px 0 #ef4444, 5px 3px 0 #ef4444, 6px 3px 0 #ef4444, 7px 3px 0 #ef4444, 8px 3px 0 #f87171, 9px 3px 0 #000,
-		0 4px 0 #000, 1px 4px 0 #000, 2px 4px 0 #000, 3px 4px 0 #000, 4px 4px 0 #000, 5px 4px 0 #000, 6px 4px 0 #000, 7px 4px 0 #000, 8px 4px 0 #000, 9px 4px 0 #000,
-		10px 3px 0 #000, 10px 4px 0 #b91c1c, 11px 4px 0 #000,
-		10px 5px 0 #991b1b, 11px 5px 0 #000, 10px 6px 0 #000;
-	/* Three synced animations:
-	   1. blob-busy-move — body motion (transform)
-	   2. blob-bandana-adjust — vertical offset for eyes-up phase (translate)
-	   3. blob-bandana-shadow — tail hide on right-face, thin on eyes-up (box-shadow) */
-	animation-name: blob-busy-move, blob-bandana-adjust, blob-bandana-shadow;
-	animation-duration: 10s, 10s, 10s;
-	animation-timing-function: cubic-bezier(0.34, 1, 0.64, 1), step-end, step-end;
-	animation-iteration-count: infinite, infinite, infinite;
-}
-
-/* Bandana vertical shift: half-pixel up when eyes look up (60-65%) */
-@keyframes blob-bandana-adjust {
-	0%  { translate: 0 -2px; }  /* baseline half-pixel up */
-	60% { translate: 0 -3.5px; }   /* half-pixel shift: 1 × 3.5 = 3.5 */
-	65% { translate: 0 -2px; }  /* back to baseline */
-}
-
-/* Bandana shadow states synced to blob-busy-eyes:
-   0-33%   normal (tail visible)
-   34-56%  facing right — tail hidden
-   57-59%  normal
-   60-64%  eyes up — thin (no bottom outline, no tail) so eyes show through
-   65-95%  normal
-   96-97%  micro-glance right — tail hidden
-   98-100% normal */
-@keyframes blob-bandana-shadow {
-	/* Normal — full bandana with tail */
-	0% { box-shadow:
-		1px 2px 0 #000, 2px 2px 0 #000, 3px 2px 0 #000, 4px 2px 0 #000, 5px 2px 0 #000, 6px 2px 0 #000, 7px 2px 0 #000, 8px 2px 0 #000, 9px 2px 0 #000,
-		0 3px 0 #000, 1px 3px 0 #b91c1c, 2px 3px 0 #dc2626, 3px 3px 0 #ef4444, 4px 3px 0 #ef4444, 5px 3px 0 #ef4444, 6px 3px 0 #ef4444, 7px 3px 0 #ef4444, 8px 3px 0 #f87171, 9px 3px 0 #000,
-		0 4px 0 #000, 1px 4px 0 #000, 2px 4px 0 #000, 3px 4px 0 #000, 4px 4px 0 #000, 5px 4px 0 #000, 6px 4px 0 #000, 7px 4px 0 #000, 8px 4px 0 #000, 9px 4px 0 #000,
-		10px 3px 0 #000, 10px 4px 0 #b91c1c, 11px 4px 0 #000,
-		10px 5px 0 #991b1b, 11px 5px 0 #000, 10px 6px 0 #000;
-	}
-	/* Facing right — no tail (knot+tail hidden behind body) */
-	34% { box-shadow:
-		1px 2px 0 #000, 2px 2px 0 #000, 3px 2px 0 #000, 4px 2px 0 #000, 5px 2px 0 #000, 6px 2px 0 #000, 7px 2px 0 #000, 8px 2px 0 #000, 9px 2px 0 #000,
-		0 3px 0 #000, 1px 3px 0 #b91c1c, 2px 3px 0 #dc2626, 3px 3px 0 #ef4444, 4px 3px 0 #ef4444, 5px 3px 0 #ef4444, 6px 3px 0 #ef4444, 7px 3px 0 #ef4444, 8px 3px 0 #f87171, 9px 3px 0 #000,
-		0 4px 0 #000, 1px 4px 0 #000, 2px 4px 0 #000, 3px 4px 0 #000, 4px 4px 0 #000, 5px 4px 0 #000, 6px 4px 0 #000, 7px 4px 0 #000, 8px 4px 0 #000, 9px 4px 0 #000;
-	}
-	/* Back to normal after rightward hops */
-	57% { box-shadow:
-		1px 2px 0 #000, 2px 2px 0 #000, 3px 2px 0 #000, 4px 2px 0 #000, 5px 2px 0 #000, 6px 2px 0 #000, 7px 2px 0 #000, 8px 2px 0 #000, 9px 2px 0 #000,
-		0 3px 0 #000, 1px 3px 0 #b91c1c, 2px 3px 0 #dc2626, 3px 3px 0 #ef4444, 4px 3px 0 #ef4444, 5px 3px 0 #ef4444, 6px 3px 0 #ef4444, 7px 3px 0 #ef4444, 8px 3px 0 #f87171, 9px 3px 0 #000,
-		0 4px 0 #000, 1px 4px 0 #000, 2px 4px 0 #000, 3px 4px 0 #000, 4px 4px 0 #000, 5px 4px 0 #000, 6px 4px 0 #000, 7px 4px 0 #000, 8px 4px 0 #000, 9px 4px 0 #000,
-		10px 3px 0 #000, 10px 4px 0 #b91c1c, 11px 4px 0 #000,
-		10px 5px 0 #991b1b, 11px 5px 0 #000, 10px 6px 0 #000;
-	}
-	/* Eyes up — bandana without tail but keeping bottom outline */
-	60% { box-shadow:
-		1px 2px 0 #000, 2px 2px 0 #000, 3px 2px 0 #000, 4px 2px 0 #000, 5px 2px 0 #000, 6px 2px 0 #000, 7px 2px 0 #000, 8px 2px 0 #000, 9px 2px 0 #000,
-		0 3px 0 #000, 1px 3px 0 #b91c1c, 2px 3px 0 #dc2626, 3px 3px 0 #ef4444, 4px 3px 0 #ef4444, 5px 3px 0 #ef4444, 6px 3px 0 #ef4444, 7px 3px 0 #ef4444, 8px 3px 0 #f87171, 9px 3px 0 #000,
-		0 4px 0 #000, 1px 4px 0 #000, 2px 4px 0 #000, 3px 4px 0 #000, 4px 4px 0 #000, 5px 4px 0 #000, 6px 4px 0 #000, 7px 4px 0 #000, 8px 4px 0 #000, 9px 4px 0 #000;
-	}
-	/* Eyes back to center — restore full bandana with tail */
-	65% { box-shadow:
-		1px 2px 0 #000, 2px 2px 0 #000, 3px 2px 0 #000, 4px 2px 0 #000, 5px 2px 0 #000, 6px 2px 0 #000, 7px 2px 0 #000, 8px 2px 0 #000, 9px 2px 0 #000,
-		0 3px 0 #000, 1px 3px 0 #b91c1c, 2px 3px 0 #dc2626, 3px 3px 0 #ef4444, 4px 3px 0 #ef4444, 5px 3px 0 #ef4444, 6px 3px 0 #ef4444, 7px 3px 0 #ef4444, 8px 3px 0 #f87171, 9px 3px 0 #000,
-		0 4px 0 #000, 1px 4px 0 #000, 2px 4px 0 #000, 3px 4px 0 #000, 4px 4px 0 #000, 5px 4px 0 #000, 6px 4px 0 #000, 7px 4px 0 #000, 8px 4px 0 #000, 9px 4px 0 #000,
-		10px 3px 0 #000, 10px 4px 0 #b91c1c, 11px 4px 0 #000,
-		10px 5px 0 #991b1b, 11px 5px 0 #000, 10px 6px 0 #000;
-	}
-	/* Micro-glance right — tail hidden */
-	96% { box-shadow:
-		1px 2px 0 #000, 2px 2px 0 #000, 3px 2px 0 #000, 4px 2px 0 #000, 5px 2px 0 #000, 6px 2px 0 #000, 7px 2px 0 #000, 8px 2px 0 #000, 9px 2px 0 #000,
-		0 3px 0 #000, 1px 3px 0 #b91c1c, 2px 3px 0 #dc2626, 3px 3px 0 #ef4444, 4px 3px 0 #ef4444, 5px 3px 0 #ef4444, 6px 3px 0 #ef4444, 7px 3px 0 #ef4444, 8px 3px 0 #f87171, 9px 3px 0 #000,
-		0 4px 0 #000, 1px 4px 0 #000, 2px 4px 0 #000, 3px 4px 0 #000, 4px 4px 0 #000, 5px 4px 0 #000, 6px 4px 0 #000, 7px 4px 0 #000, 8px 4px 0 #000, 9px 4px 0 #000;
-	}
-	/* Back to normal */
-	98% { box-shadow:
-		1px 2px 0 #000, 2px 2px 0 #000, 3px 2px 0 #000, 4px 2px 0 #000, 5px 2px 0 #000, 6px 2px 0 #000, 7px 2px 0 #000, 8px 2px 0 #000, 9px 2px 0 #000,
-		0 3px 0 #000, 1px 3px 0 #b91c1c, 2px 3px 0 #dc2626, 3px 3px 0 #ef4444, 4px 3px 0 #ef4444, 5px 3px 0 #ef4444, 6px 3px 0 #ef4444, 7px 3px 0 #ef4444, 8px 3px 0 #f87171, 9px 3px 0 #000,
-		0 4px 0 #000, 1px 4px 0 #000, 2px 4px 0 #000, 3px 4px 0 #000, 4px 4px 0 #000, 5px 4px 0 #000, 6px 4px 0 #000, 7px 4px 0 #000, 8px 4px 0 #000, 9px 4px 0 #000,
-		10px 3px 0 #000, 10px 4px 0 #b91c1c, 11px 4px 0 #000,
-		10px 5px 0 #991b1b, 11px 5px 0 #000, 10px 6px 0 #000;
-	}
+	animation-name: blob-busy-move;
+	animation-duration: 10s;
+	animation-timing-function: cubic-bezier(0.34, 1, 0.64, 1);
+	animation-iteration-count: infinite;
 }
 
 /* Bandana follows all sprite state animations */
 .bobbit-blob--idle .bobbit-blob__bandana {
-	animation-name: blob-bandana-idle-adjust, blob-bandana-idle-shadow;
-	animation-duration: 10s, 10s;
-	animation-timing-function: step-end, step-end;
-	animation-iteration-count: infinite, infinite;
+	animation: none;
 	transform: scale(4) translateX(-7px);
 	translate: 0 -2px;
 }
 
-/* Bandana idle vertical shift: up when eyes look up-right (25-45%, 70-85%) */
-@keyframes blob-bandana-idle-adjust {
-	0%  { translate: 0 -2px; }
-	25% { translate: 0 -3.5px; }
-	45% { translate: 0 -2px; }
-	70% { translate: 0 -3.5px; }
-	85% { translate: 0 -2px; }
-}
-
-/* Bandana idle shadow: hide tail when eyes face right (25-45%, 55-67%, 70-85%)
-   thin (no tail) when eyes look up-right (25-45%, 70-85%) */
-@keyframes blob-bandana-idle-shadow {
-	/* Normal — full bandana with tail */
-	0% { box-shadow:
-		1px 2px 0 #000, 2px 2px 0 #000, 3px 2px 0 #000, 4px 2px 0 #000, 5px 2px 0 #000, 6px 2px 0 #000, 7px 2px 0 #000, 8px 2px 0 #000, 9px 2px 0 #000,
-		0 3px 0 #000, 1px 3px 0 #b91c1c, 2px 3px 0 #dc2626, 3px 3px 0 #ef4444, 4px 3px 0 #ef4444, 5px 3px 0 #ef4444, 6px 3px 0 #ef4444, 7px 3px 0 #ef4444, 8px 3px 0 #f87171, 9px 3px 0 #000,
-		0 4px 0 #000, 1px 4px 0 #000, 2px 4px 0 #000, 3px 4px 0 #000, 4px 4px 0 #000, 5px 4px 0 #000, 6px 4px 0 #000, 7px 4px 0 #000, 8px 4px 0 #000, 9px 4px 0 #000,
-		10px 3px 0 #000, 10px 4px 0 #b91c1c, 11px 4px 0 #000,
-		10px 5px 0 #991b1b, 11px 5px 0 #000, 10px 6px 0 #000;
-	}
-	/* 25% — Eyes up-right: no tail */
-	25% { box-shadow:
-		1px 2px 0 #000, 2px 2px 0 #000, 3px 2px 0 #000, 4px 2px 0 #000, 5px 2px 0 #000, 6px 2px 0 #000, 7px 2px 0 #000, 8px 2px 0 #000, 9px 2px 0 #000,
-		0 3px 0 #000, 1px 3px 0 #b91c1c, 2px 3px 0 #dc2626, 3px 3px 0 #ef4444, 4px 3px 0 #ef4444, 5px 3px 0 #ef4444, 6px 3px 0 #ef4444, 7px 3px 0 #ef4444, 8px 3px 0 #f87171, 9px 3px 0 #000,
-		0 4px 0 #000, 1px 4px 0 #000, 2px 4px 0 #000, 3px 4px 0 #000, 4px 4px 0 #000, 5px 4px 0 #000, 6px 4px 0 #000, 7px 4px 0 #000, 8px 4px 0 #000, 9px 4px 0 #000;
-	}
-	/* 45% — Center: tail back */
-	45% { box-shadow:
-		1px 2px 0 #000, 2px 2px 0 #000, 3px 2px 0 #000, 4px 2px 0 #000, 5px 2px 0 #000, 6px 2px 0 #000, 7px 2px 0 #000, 8px 2px 0 #000, 9px 2px 0 #000,
-		0 3px 0 #000, 1px 3px 0 #b91c1c, 2px 3px 0 #dc2626, 3px 3px 0 #ef4444, 4px 3px 0 #ef4444, 5px 3px 0 #ef4444, 6px 3px 0 #ef4444, 7px 3px 0 #ef4444, 8px 3px 0 #f87171, 9px 3px 0 #000,
-		0 4px 0 #000, 1px 4px 0 #000, 2px 4px 0 #000, 3px 4px 0 #000, 4px 4px 0 #000, 5px 4px 0 #000, 6px 4px 0 #000, 7px 4px 0 #000, 8px 4px 0 #000, 9px 4px 0 #000,
-		10px 3px 0 #000, 10px 4px 0 #b91c1c, 11px 4px 0 #000,
-		10px 5px 0 #991b1b, 11px 5px 0 #000, 10px 6px 0 #000;
-	}
-	/* 55% — Look right: no tail */
-	55% { box-shadow:
-		1px 2px 0 #000, 2px 2px 0 #000, 3px 2px 0 #000, 4px 2px 0 #000, 5px 2px 0 #000, 6px 2px 0 #000, 7px 2px 0 #000, 8px 2px 0 #000, 9px 2px 0 #000,
-		0 3px 0 #000, 1px 3px 0 #b91c1c, 2px 3px 0 #dc2626, 3px 3px 0 #ef4444, 4px 3px 0 #ef4444, 5px 3px 0 #ef4444, 6px 3px 0 #ef4444, 7px 3px 0 #ef4444, 8px 3px 0 #f87171, 9px 3px 0 #000,
-		0 4px 0 #000, 1px 4px 0 #000, 2px 4px 0 #000, 3px 4px 0 #000, 4px 4px 0 #000, 5px 4px 0 #000, 6px 4px 0 #000, 7px 4px 0 #000, 8px 4px 0 #000, 9px 4px 0 #000;
-	}
-	/* 67% — Right blink, still no tail */
-	/* 70% — Eyes up-right again: no tail */
-	70% { box-shadow:
-		1px 2px 0 #000, 2px 2px 0 #000, 3px 2px 0 #000, 4px 2px 0 #000, 5px 2px 0 #000, 6px 2px 0 #000, 7px 2px 0 #000, 8px 2px 0 #000, 9px 2px 0 #000,
-		0 3px 0 #000, 1px 3px 0 #b91c1c, 2px 3px 0 #dc2626, 3px 3px 0 #ef4444, 4px 3px 0 #ef4444, 5px 3px 0 #ef4444, 6px 3px 0 #ef4444, 7px 3px 0 #ef4444, 8px 3px 0 #f87171, 9px 3px 0 #000,
-		0 4px 0 #000, 1px 4px 0 #000, 2px 4px 0 #000, 3px 4px 0 #000, 4px 4px 0 #000, 5px 4px 0 #000, 6px 4px 0 #000, 7px 4px 0 #000, 8px 4px 0 #000, 9px 4px 0 #000;
-	}
-	/* 85% — Back to center: tail returns */
-	85% { box-shadow:
-		1px 2px 0 #000, 2px 2px 0 #000, 3px 2px 0 #000, 4px 2px 0 #000, 5px 2px 0 #000, 6px 2px 0 #000, 7px 2px 0 #000, 8px 2px 0 #000, 9px 2px 0 #000,
-		0 3px 0 #000, 1px 3px 0 #b91c1c, 2px 3px 0 #dc2626, 3px 3px 0 #ef4444, 4px 3px 0 #ef4444, 5px 3px 0 #ef4444, 6px 3px 0 #ef4444, 7px 3px 0 #ef4444, 8px 3px 0 #f87171, 9px 3px 0 #000,
-		0 4px 0 #000, 1px 4px 0 #000, 2px 4px 0 #000, 3px 4px 0 #000, 4px 4px 0 #000, 5px 4px 0 #000, 6px 4px 0 #000, 7px 4px 0 #000, 8px 4px 0 #000, 9px 4px 0 #000,
-		10px 3px 0 #000, 10px 4px 0 #b91c1c, 11px 4px 0 #000,
-		10px 5px 0 #991b1b, 11px 5px 0 #000, 10px 6px 0 #000;
-	}
-}
 .bobbit-blob--exit .bobbit-blob__bandana {
 	animation: blob-exit 0.7s cubic-bezier(0.34, 1.56, 0.64, 1) forwards !important;
 }
@@ -1444,14 +1225,6 @@ html {
 	margin: 8px 18px 28px 18px;
 	image-rendering: pixelated;
 	filter: hue-rotate(calc(-1 * var(--bobbit-hue-rotate, 0deg)));
-	box-shadow:
-		8px 2px 0 #000, 9px 2px 0 #000, 10px 2px 0 #000,
-		7px 3px 0 #000, 8px 3px 0 #87ceeb, 9px 3px 0 #b0e0f0, 10px 3px 0 #87ceeb, 11px 3px 0 #000,
-		7px 4px 0 #000, 8px 4px 0 #b0e0f0, 9px 4px 0 #e0f4ff, 10px 4px 0 #87ceeb, 11px 4px 0 #000,
-		7px 5px 0 #000, 8px 5px 0 #87ceeb, 9px 5px 0 #b0e0f0, 10px 5px 0 #87ceeb, 11px 5px 0 #000,
-		7px 6px 0 #000, 8px 6px 0 #000, 9px 6px 0 #000, 10px 6px 0 #000,
-		6px 7px 0 #000, 7px 7px 0 #8b4513,
-		5px 8px 0 #000, 6px 8px 0 #8b4513;
 	animation:
 		blob-busy-move-rigid 10s cubic-bezier(0.34, 1, 0.64, 1) infinite,
 		magnifier-depth-busy 10s steps(1) infinite;
@@ -1497,13 +1270,6 @@ html {
 	margin: 8px 18px 28px 18px;
 	image-rendering: pixelated;
 	filter: hue-rotate(calc(-1 * var(--bobbit-hue-rotate, 0deg)));
-	box-shadow:
-		/* Compact brown palette with thumb-hole cutout, 3 bright paint dots: R, G, B */
-		9px 5px 0 #000, 10px 5px 0 #000,
-		8px 6px 0 #000, 9px 6px 0 #a16207, 10px 6px 0 #ef4444, 11px 6px 0 #000,
-		7px 7px 0 #000, 8px 7px 0 #4ade80, 9px 7px 0 #a16207, 10px 7px 0 #a16207, 11px 7px 0 #000,
-		7px 8px 0 #000, 8px 8px 0 #a16207, 9px 8px 0 #a16207, 10px 8px 0 #60a5fa, 11px 8px 0 #000,
-		8px 9px 0 #000, 9px 9px 0 #000, 10px 9px 0 #000;
 	animation:
 		blob-busy-move-rigid 10s cubic-bezier(0.34, 1, 0.64, 1) infinite,
 		magnifier-depth-busy 10s steps(1) infinite;
@@ -1549,19 +1315,6 @@ html {
 	margin: 8px 18px 28px 18px;
 	image-rendering: pixelated;
 	filter: hue-rotate(calc(-1 * var(--bobbit-hue-rotate, 0deg)));
-	box-shadow:
-		/* Eraser (pink) */
-		11px 2px 0 #000, 12px 2px 0 #000,
-		10px 3px 0 #000, 11px 3px 0 #f9a8d4, 12px 3px 0 #ec4899, 13px 3px 0 #000,
-		/* Ferrule (silver band) */
-		9px 4px 0 #000, 10px 4px 0 #9ca3af, 11px 4px 0 #d1d5db, 12px 4px 0 #000,
-		/* Yellow body */
-		8px 5px 0 #000, 9px 5px 0 #fde047, 10px 5px 0 #fbbf24, 11px 5px 0 #000,
-		7px 6px 0 #000, 8px 6px 0 #fde047, 9px 6px 0 #fbbf24, 10px 6px 0 #000,
-		/* Wood */
-		6px 7px 0 #000, 7px 7px 0 #f4a460, 8px 7px 0 #cd853f, 9px 7px 0 #000,
-		/* Graphite tip */
-		5px 8px 0 #000, 6px 8px 0 #4b5563, 7px 8px 0 #000;
 	animation:
 		blob-busy-move-rigid 10s cubic-bezier(0.34, 1, 0.64, 1) infinite,
 		magnifier-depth-busy 10s steps(1) infinite;
@@ -1607,14 +1360,6 @@ html {
 	margin: 8px 18px 28px 18px;
 	image-rendering: pixelated;
 	filter: hue-rotate(calc(-1 * var(--bobbit-hue-rotate, 0deg)));
-	box-shadow:
-		/* Pointed shield with red emblem, right side */
-		8px 3px 0 #000, 9px 3px 0 #000, 10px 3px 0 #000, 11px 3px 0 #000, 12px 3px 0 #000,
-		7px 4px 0 #000, 8px 4px 0 #9ca3af, 9px 4px 0 #d1d5db, 10px 4px 0 #d1d5db, 11px 4px 0 #9ca3af, 12px 4px 0 #000,
-		7px 5px 0 #000, 8px 5px 0 #d1d5db, 9px 5px 0 #f3f4f6, 10px 5px 0 #ef4444, 11px 5px 0 #d1d5db, 12px 5px 0 #000,
-		7px 6px 0 #000, 8px 6px 0 #9ca3af, 9px 6px 0 #d1d5db, 10px 6px 0 #d1d5db, 11px 6px 0 #9ca3af, 12px 6px 0 #000,
-		8px 7px 0 #000, 9px 7px 0 #9ca3af, 10px 7px 0 #9ca3af, 11px 7px 0 #000,
-		9px 8px 0 #000, 10px 8px 0 #000;
 	animation:
 		blob-busy-move-rigid 10s cubic-bezier(0.34, 1, 0.64, 1) infinite,
 		magnifier-depth-busy 10s steps(1) infinite;
@@ -1660,14 +1405,6 @@ html {
 	margin: 8px 18px 28px 18px;
 	image-rendering: pixelated;
 	filter: hue-rotate(calc(-1 * var(--bobbit-hue-rotate, 0deg)));
-	box-shadow:
-		/* Right-angle triangle with cutout hole in centre */
-		10px 4px 0 #000,
-		9px 5px 0 #000, 10px 5px 0 #93c5fd, 11px 5px 0 #000,
-		8px 6px 0 #000, 9px 6px 0 #bfdbfe, 10px 6px 0 #93c5fd, 11px 6px 0 #000,
-		7px 7px 0 #000, 8px 7px 0 #bfdbfe, 9px 7px 0 #000, 10px 7px 0 #bfdbfe, 11px 7px 0 #000,
-		6px 8px 0 #000, 7px 8px 0 #bfdbfe, 8px 8px 0 #bfdbfe, 9px 8px 0 #bfdbfe, 10px 8px 0 #93c5fd, 11px 8px 0 #000,
-		5px 9px 0 #000, 6px 9px 0 #000, 7px 9px 0 #000, 8px 9px 0 #000, 9px 9px 0 #000, 10px 9px 0 #000, 11px 9px 0 #000;
 	animation:
 		blob-busy-move-rigid 10s cubic-bezier(0.34, 1, 0.64, 1) infinite,
 		magnifier-depth-busy 10s steps(1) infinite;
@@ -1712,19 +1449,6 @@ html {
 	transform: scale(4);
 	margin: 8px 18px 28px 18px;
 	image-rendering: pixelated;
-	box-shadow:
-		/* Cork */
-		8px 4px 0 #000, 9px 4px 0 #fff, 10px 4px 0 #000,
-		/* Neck with liquid */
-		8px 5px 0 #000, 9px 5px 0 #7dd3fc, 10px 5px 0 #000,
-		/* Shoulder */
-		7px 6px 0 #000, 8px 6px 0 #0369a1, 9px 6px 0 #38bdf8, 10px 6px 0 #0ea5e9, 11px 6px 0 #000,
-		/* Upper body */
-		6px 7px 0 #000, 7px 7px 0 #1e3a5f, 8px 7px 0 #0ea5e9, 9px 7px 0 #0284c7, 10px 7px 0 #0369a1, 11px 7px 0 #1e3a5f, 12px 7px 0 #000,
-		/* Lower body — deeper */
-		6px 8px 0 #000, 7px 8px 0 #1e3a5f, 8px 8px 0 #0284c7, 9px 8px 0 #0c4a6e, 10px 8px 0 #082f49, 11px 8px 0 #1e3a5f, 12px 8px 0 #000,
-		/* Bottom */
-		6px 9px 0 #000, 7px 9px 0 #000, 8px 9px 0 #000, 9px 9px 0 #000, 10px 9px 0 #000, 11px 9px 0 #000, 12px 9px 0 #000;
 	animation:
 		blob-busy-move-rigid 10s cubic-bezier(0.34, 1, 0.64, 1) infinite,
 		magnifier-depth-busy 10s steps(1) infinite;
@@ -1825,22 +1549,6 @@ html {
 	margin: 8px 18px 28px 18px;
 	image-rendering: pixelated;
 	filter: hue-rotate(calc(-1 * var(--bobbit-hue-rotate, 0deg)));
-	box-shadow:
-		/* Outlined diamond star */
-		11px 2px 0 #000,
-		10px 3px 0 #000, 12px 3px 0 #000,
-		9px 4px 0 #000, 13px 4px 0 #000,
-		10px 5px 0 #000, 12px 5px 0 #000,
-		11px 6px 0 #000,
-		11px 3px 0 #fef9c4,
-		10px 4px 0 #fde047, 11px 4px 0 #fff, 12px 4px 0 #fde047,
-		11px 5px 0 #fef9c4,
-		/* Handle */
-		9px 5px 0 #000, 10px 5px 0 #cd853f, 11px 5px 0 #000,
-		8px 6px 0 #000, 9px 6px 0 #cd853f, 10px 6px 0 #000,
-		7px 7px 0 #000, 8px 7px 0 #8b4513, 9px 7px 0 #000,
-		6px 8px 0 #000, 7px 8px 0 #8b4513, 8px 8px 0 #000,
-		5px 9px 0 #000, 6px 9px 0 #000;
 	animation:
 		blob-busy-move-rigid 10s cubic-bezier(0.34, 1, 0.64, 1) infinite,
 		wand-depth-busy 10s steps(1) infinite;
@@ -1936,12 +1644,6 @@ html {
 	margin: 8px 18px 28px 18px;
 	image-rendering: pixelated;
 	filter: hue-rotate(calc(-1 * var(--bobbit-hue-rotate, 0deg)));
-	box-shadow:
-		7px -2px 0 #2dd4bf, 8px -2px 0 #fde047,
-		5px -1px 0 #000, 6px -1px 0 #6366f1, 7px -1px 0 #818cf8, 8px -1px 0 #000,
-		2px 0px 0 #000, 3px 0px 0 #6d28d9, 4px 0px 0 #7c3aed, 5px 0px 0 #8b5cf6, 6px 0px 0 #6366f1, 7px 0px 0 #a78bfa, 8px 0px 0 #000,
-		1px 1px 0 #000, 2px 1px 0 #6d28d9, 3px 1px 0 #7c3aed, 4px 1px 0 #fbbf24, 5px 1px 0 #fde047, 6px 1px 0 #14b8a6, 7px 1px 0 #a78bfa, 8px 1px 0 #6d28d9, 9px 1px 0 #000,
-		0px 2px 0 #000, 1px 2px 0 #000, 2px 2px 0 #000, 3px 2px 0 #000, 4px 2px 0 #000, 5px 2px 0 #000, 6px 2px 0 #000, 7px 2px 0 #000, 8px 2px 0 #000, 9px 2px 0 #000, 10px 2px 0 #000;
 	animation:
 		blob-busy-move 10s cubic-bezier(0.34, 1, 0.64, 1) infinite;
 }
@@ -2131,90 +1833,6 @@ html {
 	100% { transform: scale(4) translateX(0) translateY(0) scaleX(1) scaleY(1) rotate(0deg); }
 }
 
-
-/* Eye direction changes via box-shadow (steps timing — instant switches).
-   SPEC: Steps 1 + 5 from bobbit-animation-emotion.md
-   Step 1: Eyes lead body by 2-4% on all directional transitions.
-   Step 5: Settle blink at 92%, micro-glance right at 96%.
-
-   0-16%: center eyes during bounce 1.
-   16-18%: blink between bounces.
-   18-34%: center during bounce 2 + anticipation crouch.
-   34-36%: eyes right — looking where we're about to go (LEADS body by 4%).
-   36-37%: blink — anticipation beat.
-   37-54%: eyes right — eager hopping (LEADS landing at 57% by 3%).
-   54-60%: center — arrival bounce.
-   60-64%: eyes up — looking at chat (LEADS body lean-left at 64%).
-   64-65%: blink.
-   65-68%: eyes left — looking back (LEADS body lean-right at 67%).
-   68-87%: center — hopping home.
-   87-92%: center — settle follow-through.
-   92-94%: blink — satisfied "ahhh".
-   94-96%: center.
-   96-98%: eyes right — tiny "checking in" glance.
-   98-100%: center. */
-@keyframes blob-busy-eyes {
-	/* 0-16%  Center — bounce 1 */
-	0% { box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #1a3010, 4px 4px 0 #8ec63f, 5px 4px 0 #8ec63f, 6px 4px 0 #1a3010, 7px 4px 0 #8ec63f, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #1a3010, 4px 5px 0 #8ec63f, 5px 5px 0 #8ec63f, 6px 5px 0 #1a3010, 7px 5px 0 #8ec63f, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 16-18%  Blink between bounces */
-	16% { box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #8ec63f, 4px 4px 0 #8ec63f, 5px 4px 0 #8ec63f, 6px 4px 0 #8ec63f, 7px 4px 0 #8ec63f, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #1a3010, 4px 5px 0 #8ec63f, 5px 5px 0 #8ec63f, 6px 5px 0 #1a3010, 7px 5px 0 #8ec63f, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 18-34%  Center — bounce 2 + crouch */
-	18% { box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #1a3010, 4px 4px 0 #8ec63f, 5px 4px 0 #8ec63f, 6px 4px 0 #1a3010, 7px 4px 0 #8ec63f, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #1a3010, 4px 5px 0 #8ec63f, 5px 5px 0 #8ec63f, 6px 5px 0 #1a3010, 7px 5px 0 #8ec63f, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 34-36%  Eyes right — looking where we're about to go [Step 1: leads body by 4%] */
-	34% { box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #8ec63f, 4px 4px 0 #1a3010, 5px 4px 0 #8ec63f, 6px 4px 0 #8ec63f, 7px 4px 0 #1a3010, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #8ec63f, 4px 5px 0 #1a3010, 5px 5px 0 #8ec63f, 6px 5px 0 #8ec63f, 7px 5px 0 #1a3010, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 36-37%  Blink — right-facing squint during held crouch */
-	36% { box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #8ec63f, 4px 4px 0 #8ec63f, 5px 4px 0 #8ec63f, 6px 4px 0 #8ec63f, 7px 4px 0 #8ec63f, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #8ec63f, 4px 5px 0 #1a3010, 5px 5px 0 #8ec63f, 6px 5px 0 #8ec63f, 7px 5px 0 #1a3010, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 37-54%  Eyes right — eager hopping [Step 1: leads landing at 57% by 3%] */
-	37% { box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #8ec63f, 4px 4px 0 #1a3010, 5px 4px 0 #8ec63f, 6px 4px 0 #8ec63f, 7px 4px 0 #1a3010, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #8ec63f, 4px 5px 0 #1a3010, 5px 5px 0 #8ec63f, 6px 5px 0 #8ec63f, 7px 5px 0 #1a3010, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 54-60%  Center — arrival settling [Step 1: leads body settle at 57% by 3%] */
-	54% { box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #1a3010, 4px 4px 0 #8ec63f, 5px 4px 0 #8ec63f, 6px 4px 0 #1a3010, 7px 4px 0 #8ec63f, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #1a3010, 4px 5px 0 #8ec63f, 5px 5px 0 #8ec63f, 6px 5px 0 #1a3010, 7px 5px 0 #8ec63f, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 60-64%  Eyes up — looking at chat [Step 1: leads body lean-left at 64%] */
-	60% { box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #1a3010, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #1a3010, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #8ec63f, 4px 4px 0 #1a3010, 5px 4px 0 #8ec63f, 6px 4px 0 #8ec63f, 7px 4px 0 #1a3010, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #8ec63f, 4px 5px 0 #8ec63f, 5px 5px 0 #8ec63f, 6px 5px 0 #8ec63f, 7px 5px 0 #8ec63f, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 64-65%  Blink — up-facing squint while looking at chat */
-	64% { box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #8ec63f, 4px 4px 0 #1a3010, 5px 4px 0 #8ec63f, 6px 4px 0 #8ec63f, 7px 4px 0 #1a3010, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #8ec63f, 4px 5px 0 #8ec63f, 5px 5px 0 #8ec63f, 6px 5px 0 #8ec63f, 7px 5px 0 #8ec63f, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 65-68%  Eyes left — looking back [Step 1: leads body lean-right at 67%] */
-	65% { box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #1a3010, 3px 4px 0 #8ec63f, 4px 4px 0 #8ec63f, 5px 4px 0 #1a3010, 6px 4px 0 #8ec63f, 7px 4px 0 #8ec63f, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #1a3010, 3px 5px 0 #8ec63f, 4px 5px 0 #8ec63f, 5px 5px 0 #1a3010, 6px 5px 0 #8ec63f, 7px 5px 0 #8ec63f, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 68-92%  Center — hopping home + settle [Step 1: eyes center before body at 70%] */
-	68% { box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #1a3010, 4px 4px 0 #8ec63f, 5px 4px 0 #8ec63f, 6px 4px 0 #1a3010, 7px 4px 0 #8ec63f, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #1a3010, 4px 5px 0 #8ec63f, 5px 5px 0 #8ec63f, 6px 5px 0 #1a3010, 7px 5px 0 #8ec63f, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 92-94%  Blink — satisfied "ahhh" [Step 5: during follow-through] */
-	92% { box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #8ec63f, 4px 4px 0 #8ec63f, 5px 4px 0 #8ec63f, 6px 4px 0 #8ec63f, 7px 4px 0 #8ec63f, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #1a3010, 4px 5px 0 #8ec63f, 5px 5px 0 #8ec63f, 6px 5px 0 #1a3010, 7px 5px 0 #8ec63f, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 94-96%  Center */
-	94% { box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #1a3010, 4px 4px 0 #8ec63f, 5px 4px 0 #8ec63f, 6px 4px 0 #1a3010, 7px 4px 0 #8ec63f, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #1a3010, 4px 5px 0 #8ec63f, 5px 5px 0 #8ec63f, 6px 5px 0 #1a3010, 7px 5px 0 #8ec63f, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 96-98%  Eyes right — tiny "checking in" glance [Step 5: moving hold] */
-	96% { box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #8ec63f, 4px 4px 0 #1a3010, 5px 4px 0 #8ec63f, 6px 4px 0 #8ec63f, 7px 4px 0 #1a3010, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #8ec63f, 4px 5px 0 #1a3010, 5px 5px 0 #8ec63f, 6px 5px 0 #8ec63f, 7px 5px 0 #1a3010, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 98-100%  Center — rest before loop */
-	98% { box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #1a3010, 4px 4px 0 #8ec63f, 5px 4px 0 #8ec63f, 6px 4px 0 #1a3010, 7px 4px 0 #8ec63f, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #1a3010, 4px 5px 0 #8ec63f, 5px 5px 0 #8ec63f, 6px 5px 0 #1a3010, 7px 5px 0 #8ec63f, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-}
 
 /* Shadow follows horizontal position during busy hops */
 @keyframes blob-busy-shadow {
@@ -2849,61 +2467,10 @@ html {
 /* Idle state — sitting still, offset left, eyes looking around */
 .bobbit-blob--idle .bobbit-blob__sprite {
 	transform: scale(4) translateX(-7px);
-	animation: blob-idle-eyes 10s steps(1) infinite !important;
+	animation: none !important;
 }
 
-/* Idle eye cycle: center → look at user → blink left → look up-right →
-   center → look right → blink right → look up-right → center → blink center.
-   Blinks squish pupils to one row in the current gaze direction.
-   Timing is irregular (22%, 67%, 93%) to feel natural. */
-@keyframes blob-idle-eyes {
-	/* 0% — Center eyes */
-	0% { transform: scale(4) translateX(-7px); box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #1a3010, 4px 4px 0 #8ec63f, 5px 4px 0 #8ec63f, 6px 4px 0 #1a3010, 7px 4px 0 #8ec63f, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #1a3010, 4px 5px 0 #8ec63f, 5px 5px 0 #8ec63f, 6px 5px 0 #1a3010, 7px 5px 0 #8ec63f, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 10% — Look left (at user) */
-	10% { transform: scale(4) translateX(-7px); box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #1a3010, 3px 4px 0 #8ec63f, 4px 4px 0 #8ec63f, 5px 4px 0 #1a3010, 6px 4px 0 #8ec63f, 7px 4px 0 #8ec63f, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #1a3010, 3px 5px 0 #8ec63f, 4px 5px 0 #8ec63f, 5px 5px 0 #1a3010, 6px 5px 0 #8ec63f, 7px 5px 0 #8ec63f, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 22% — Left-blink: pupils squish to row 5 at left position (2,5 + 5,5) */
-	22% { transform: scale(4) translateX(-7px); box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #8ec63f, 4px 4px 0 #8ec63f, 5px 4px 0 #8ec63f, 6px 4px 0 #8ec63f, 7px 4px 0 #8ec63f, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #1a3010, 3px 5px 0 #8ec63f, 4px 5px 0 #8ec63f, 5px 5px 0 #1a3010, 6px 5px 0 #8ec63f, 7px 5px 0 #8ec63f, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 25% — Look up-right (at chat history) */
-	25% { transform: scale(4) translateX(-7px); box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #1a3010, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #1a3010, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #8ec63f, 4px 4px 0 #1a3010, 5px 4px 0 #8ec63f, 6px 4px 0 #8ec63f, 7px 4px 0 #1a3010, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #8ec63f, 4px 5px 0 #8ec63f, 5px 5px 0 #8ec63f, 6px 5px 0 #8ec63f, 7px 5px 0 #8ec63f, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 45% — Center eyes */
-	45% { transform: scale(4) translateX(-7px); box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #1a3010, 4px 4px 0 #8ec63f, 5px 4px 0 #8ec63f, 6px 4px 0 #1a3010, 7px 4px 0 #8ec63f, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #1a3010, 4px 5px 0 #8ec63f, 5px 5px 0 #8ec63f, 6px 5px 0 #1a3010, 7px 5px 0 #8ec63f, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 55% — Look right (at chat area) */
-	55% { transform: scale(4) translateX(-7px); box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #8ec63f, 4px 4px 0 #1a3010, 5px 4px 0 #8ec63f, 6px 4px 0 #8ec63f, 7px 4px 0 #1a3010, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #8ec63f, 4px 5px 0 #1a3010, 5px 5px 0 #8ec63f, 6px 5px 0 #8ec63f, 7px 5px 0 #1a3010, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 67% — Right-blink: pupils squish to row 5 at right position (4,5 + 7,5) */
-	67% { transform: scale(4) translateX(-7px); box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #8ec63f, 4px 4px 0 #8ec63f, 5px 4px 0 #8ec63f, 6px 4px 0 #8ec63f, 7px 4px 0 #8ec63f, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #8ec63f, 4px 5px 0 #1a3010, 5px 5px 0 #8ec63f, 6px 5px 0 #8ec63f, 7px 5px 0 #1a3010, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 70% — Look up-right (at chat history) */
-	70% { transform: scale(4) translateX(-7px); box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #1a3010, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #1a3010, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #8ec63f, 4px 4px 0 #1a3010, 5px 4px 0 #8ec63f, 6px 4px 0 #8ec63f, 7px 4px 0 #1a3010, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #8ec63f, 4px 5px 0 #8ec63f, 5px 5px 0 #8ec63f, 6px 5px 0 #8ec63f, 7px 5px 0 #8ec63f, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 85% — Back to center */
-	85% { transform: scale(4) translateX(-7px); box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #1a3010, 4px 4px 0 #8ec63f, 5px 4px 0 #8ec63f, 6px 4px 0 #1a3010, 7px 4px 0 #8ec63f, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #1a3010, 4px 5px 0 #8ec63f, 5px 5px 0 #8ec63f, 6px 5px 0 #1a3010, 7px 5px 0 #8ec63f, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 93% — Center-blink: third blink breaks the two-blink pattern */
-	93% { transform: scale(4) translateX(-7px); box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #8ec63f, 4px 4px 0 #8ec63f, 5px 4px 0 #8ec63f, 6px 4px 0 #8ec63f, 7px 4px 0 #8ec63f, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #1a3010, 4px 5px 0 #8ec63f, 5px 5px 0 #8ec63f, 6px 5px 0 #1a3010, 7px 5px 0 #8ec63f, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-	/* 96% — Center eyes (recover from blink, hold to loop) */
-	96% { transform: scale(4) translateX(-7px); box-shadow:
-		3px 0px 0 #000, 4px 0px 0 #000, 5px 0px 0 #000, 6px 0px 0 #000, 7px 0px 0 #000, 2px 1px 0 #000, 3px 1px 0 #8ec63f, 4px 1px 0 #8ec63f, 5px 1px 0 #8ec63f, 6px 1px 0 #b5d98a, 7px 1px 0 #b5d98a, 8px 1px 0 #000, 1px 2px 0 #000, 2px 2px 0 #8ec63f, 3px 2px 0 #8ec63f, 4px 2px 0 #8ec63f, 5px 2px 0 #8ec63f, 6px 2px 0 #8ec63f, 7px 2px 0 #b5d98a, 8px 2px 0 #8ec63f, 9px 2px 0 #000, 0px 3px 0 #000, 1px 3px 0 #8ec63f, 2px 3px 0 #8ec63f, 3px 3px 0 #8ec63f, 4px 3px 0 #8ec63f, 5px 3px 0 #8ec63f, 6px 3px 0 #8ec63f, 7px 3px 0 #8ec63f, 8px 3px 0 #8ec63f, 9px 3px 0 #000, 0px 4px 0 #000, 1px 4px 0 #8ec63f, 2px 4px 0 #8ec63f, 3px 4px 0 #1a3010, 4px 4px 0 #8ec63f, 5px 4px 0 #8ec63f, 6px 4px 0 #1a3010, 7px 4px 0 #8ec63f, 8px 4px 0 #8ec63f, 9px 4px 0 #000, 0px 5px 0 #000, 1px 5px 0 #8ec63f, 2px 5px 0 #8ec63f, 3px 5px 0 #1a3010, 4px 5px 0 #8ec63f, 5px 5px 0 #8ec63f, 6px 5px 0 #1a3010, 7px 5px 0 #8ec63f, 8px 5px 0 #8ec63f, 9px 5px 0 #000, 0px 6px 0 #000, 1px 6px 0 #6b9930, 2px 6px 0 #8ec63f, 3px 6px 0 #8ec63f, 4px 6px 0 #8ec63f, 5px 6px 0 #8ec63f, 6px 6px 0 #8ec63f, 7px 6px 0 #8ec63f, 8px 6px 0 #8ec63f, 9px 6px 0 #000, 1px 7px 0 #000, 2px 7px 0 #6b9930, 3px 7px 0 #8ec63f, 4px 7px 0 #8ec63f, 5px 7px 0 #8ec63f, 6px 7px 0 #8ec63f, 7px 7px 0 #8ec63f, 8px 7px 0 #000, 2px 8px 0 #000, 3px 8px 0 #000, 4px 8px 0 #000, 5px 8px 0 #000, 6px 8px 0 #000, 7px 8px 0 #000;
-	}
-}
-
-/* Blink overlay — disabled; eyes now managed by blob-busy-eyes keyframes */
+/* Blink overlay — disabled; eyes now managed by canvas rendering */
 .bobbit-blob__sprite::before {
 	content: '';
 	position: absolute;

--- a/src/ui/bobbit-sprite-data.ts
+++ b/src/ui/bobbit-sprite-data.ts
@@ -1,0 +1,254 @@
+/**
+ * Bobbit sprite pixel data — extracted from CSS box-shadow definitions.
+ * Pure data module with no side effects.
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Semantic color keys for body pixels — resolved at paint time via palette */
+export type ColorKey = 'main' | 'light' | 'dark' | 'eye' | 'outline';
+
+/** A body pixel with a semantic color key */
+export interface BodyPixel {
+  x: number;
+  y: number;
+  colorKey: ColorKey;
+}
+
+/** A pixel with an absolute hex color (used for accessories) */
+export interface Pixel {
+  x: number;
+  y: number;
+  color: string;
+}
+
+/** Eye animation state */
+export type EyeState =
+  | 'center' | 'right' | 'left' | 'up'
+  | 'blink-center' | 'blink-right' | 'blink-left' | 'blink-up';
+
+/** An entry in an eye animation schedule */
+export interface EyeScheduleEntry {
+  pct: number;
+  state: EyeState;
+}
+
+// ============================================================================
+// Palettes
+// ============================================================================
+
+/** Default bobbit palette (canonical green) */
+export const DEFAULT_PALETTE: Record<ColorKey, string> = {
+  main:    '#8ec63f',
+  light:   '#b5d98a',
+  dark:    '#6b9930',
+  eye:     '#1a3010',
+  outline: '#000000',
+};
+
+/** Starting status palette (yellow) */
+export const STARTING_PALETTE: Record<ColorKey, string> = {
+  main:    '#eab308',
+  light:   '#fde047',
+  dark:    '#ca8a04',
+  eye:     '#2d2006',
+  outline: '#000000',
+};
+
+/** Terminated status palette (red) */
+export const TERMINATED_PALETTE: Record<ColorKey, string> = {
+  main:    '#ef4444',
+  light:   '#fca5a5',
+  dark:    '#dc2626',
+  eye:     '#2c0b0e',
+  outline: '#000000',
+};
+
+// ============================================================================
+// Body Pixel Grid — extracted from .bobbit-blob__sprite box-shadow
+// ============================================================================
+// The 10×9 body grid with semantic color keys.
+// Pixels at eye positions (3,4), (3,5), (6,4), (6,5) are included as 'eye'
+// but eyes are painted separately by drawBobbitSprite for animation.
+
+/** Map from hex color to semantic ColorKey */
+const COLOR_MAP: Record<string, ColorKey> = {
+  '#000':    'outline',
+  '#000000': 'outline',
+  '#8ec63f': 'main',
+  '#b5d98a': 'light',
+  '#6b9930': 'dark',
+  '#1a3010': 'eye',
+};
+
+function c(hex: string): ColorKey {
+  return COLOR_MAP[hex] ?? 'outline';
+}
+
+/**
+ * Body pixels for the 10×9 bobbit sprite.
+ * Eye pixels (at center gaze) are included but will be painted over by
+ * the eye rendering pass.
+ */
+export const BODY_PIXELS: BodyPixel[] = [
+  // Row 0 (y=0): top edge outline
+  { x: 3, y: 0, colorKey: c('#000') },
+  { x: 4, y: 0, colorKey: c('#000') },
+  { x: 5, y: 0, colorKey: c('#000') },
+  { x: 6, y: 0, colorKey: c('#000') },
+  { x: 7, y: 0, colorKey: c('#000') },
+
+  // Row 1 (y=1)
+  { x: 2, y: 1, colorKey: c('#000') },
+  { x: 3, y: 1, colorKey: c('#8ec63f') },
+  { x: 4, y: 1, colorKey: c('#8ec63f') },
+  { x: 5, y: 1, colorKey: c('#8ec63f') },
+  { x: 6, y: 1, colorKey: c('#b5d98a') },
+  { x: 7, y: 1, colorKey: c('#b5d98a') },
+  { x: 8, y: 1, colorKey: c('#000') },
+
+  // Row 2 (y=2)
+  { x: 1, y: 2, colorKey: c('#000') },
+  { x: 2, y: 2, colorKey: c('#8ec63f') },
+  { x: 3, y: 2, colorKey: c('#8ec63f') },
+  { x: 4, y: 2, colorKey: c('#8ec63f') },
+  { x: 5, y: 2, colorKey: c('#8ec63f') },
+  { x: 6, y: 2, colorKey: c('#8ec63f') },
+  { x: 7, y: 2, colorKey: c('#b5d98a') },
+  { x: 8, y: 2, colorKey: c('#8ec63f') },
+  { x: 9, y: 2, colorKey: c('#000') },
+
+  // Row 3 (y=3)
+  { x: 0, y: 3, colorKey: c('#000') },
+  { x: 1, y: 3, colorKey: c('#8ec63f') },
+  { x: 2, y: 3, colorKey: c('#8ec63f') },
+  { x: 3, y: 3, colorKey: c('#8ec63f') },
+  { x: 4, y: 3, colorKey: c('#8ec63f') },
+  { x: 5, y: 3, colorKey: c('#8ec63f') },
+  { x: 6, y: 3, colorKey: c('#8ec63f') },
+  { x: 7, y: 3, colorKey: c('#8ec63f') },
+  { x: 8, y: 3, colorKey: c('#8ec63f') },
+  { x: 9, y: 3, colorKey: c('#000') },
+
+  // Row 4 (y=4) — contains eye pixels
+  { x: 0, y: 4, colorKey: c('#000') },
+  { x: 1, y: 4, colorKey: c('#8ec63f') },
+  { x: 2, y: 4, colorKey: c('#8ec63f') },
+  // (3,4) = eye — painted separately
+  { x: 4, y: 4, colorKey: c('#8ec63f') },
+  { x: 5, y: 4, colorKey: c('#8ec63f') },
+  // (6,4) = eye — painted separately
+  { x: 7, y: 4, colorKey: c('#8ec63f') },
+  { x: 8, y: 4, colorKey: c('#8ec63f') },
+  { x: 9, y: 4, colorKey: c('#000') },
+
+  // Row 5 (y=5) — contains eye pixels
+  { x: 0, y: 5, colorKey: c('#000') },
+  { x: 1, y: 5, colorKey: c('#8ec63f') },
+  { x: 2, y: 5, colorKey: c('#8ec63f') },
+  // (3,5) = eye — painted separately
+  { x: 4, y: 5, colorKey: c('#8ec63f') },
+  { x: 5, y: 5, colorKey: c('#8ec63f') },
+  // (6,5) = eye — painted separately
+  { x: 7, y: 5, colorKey: c('#8ec63f') },
+  { x: 8, y: 5, colorKey: c('#8ec63f') },
+  { x: 9, y: 5, colorKey: c('#000') },
+
+  // Row 6 (y=6)
+  { x: 0, y: 6, colorKey: c('#000') },
+  { x: 1, y: 6, colorKey: c('#6b9930') },
+  { x: 2, y: 6, colorKey: c('#8ec63f') },
+  { x: 3, y: 6, colorKey: c('#8ec63f') },
+  { x: 4, y: 6, colorKey: c('#8ec63f') },
+  { x: 5, y: 6, colorKey: c('#8ec63f') },
+  { x: 6, y: 6, colorKey: c('#8ec63f') },
+  { x: 7, y: 6, colorKey: c('#8ec63f') },
+  { x: 8, y: 6, colorKey: c('#8ec63f') },
+  { x: 9, y: 6, colorKey: c('#000') },
+
+  // Row 7 (y=7)
+  { x: 1, y: 7, colorKey: c('#000') },
+  { x: 2, y: 7, colorKey: c('#6b9930') },
+  { x: 3, y: 7, colorKey: c('#8ec63f') },
+  { x: 4, y: 7, colorKey: c('#8ec63f') },
+  { x: 5, y: 7, colorKey: c('#8ec63f') },
+  { x: 6, y: 7, colorKey: c('#8ec63f') },
+  { x: 7, y: 7, colorKey: c('#8ec63f') },
+  { x: 8, y: 7, colorKey: c('#000') },
+
+  // Row 8 (y=8) — feet
+  { x: 2, y: 8, colorKey: c('#000') },
+  { x: 3, y: 8, colorKey: c('#000') },
+  { x: 4, y: 8, colorKey: c('#000') },
+  { x: 5, y: 8, colorKey: c('#000') },
+  { x: 6, y: 8, colorKey: c('#000') },
+  { x: 7, y: 8, colorKey: c('#000') },
+];
+
+// ============================================================================
+// Eye State Positions
+// ============================================================================
+// Each eye state maps to an array of {x,y} positions for the eye pixels.
+// Non-blink states have 4 pixels (2 per eye, 2 rows).
+// Blink states have 2 pixels (1 per eye, single row).
+
+export const EYE_STATES: Record<EyeState, { x: number; y: number }[]> = {
+  'center':       [{ x: 3, y: 4 }, { x: 3, y: 5 }, { x: 6, y: 4 }, { x: 6, y: 5 }],
+  'right':        [{ x: 4, y: 4 }, { x: 4, y: 5 }, { x: 7, y: 4 }, { x: 7, y: 5 }],
+  'left':         [{ x: 2, y: 4 }, { x: 2, y: 5 }, { x: 5, y: 4 }, { x: 5, y: 5 }],
+  'up':           [{ x: 4, y: 3 }, { x: 4, y: 4 }, { x: 7, y: 3 }, { x: 7, y: 4 }],
+  'blink-center': [{ x: 3, y: 5 }, { x: 6, y: 5 }],
+  'blink-right':  [{ x: 4, y: 5 }, { x: 7, y: 5 }],
+  'blink-left':   [{ x: 2, y: 5 }, { x: 5, y: 5 }],
+  'blink-up':     [{ x: 4, y: 4 }, { x: 7, y: 4 }],
+};
+
+// ============================================================================
+// Eye Timing Schedules — extracted from CSS @keyframes
+// ============================================================================
+
+/** Busy eye cycle: 10s total (from blob-busy-eyes) */
+export const BUSY_EYE_SCHEDULE: EyeScheduleEntry[] = [
+  { pct: 0,  state: 'center' },
+  { pct: 16, state: 'blink-center' },
+  { pct: 18, state: 'center' },
+  { pct: 34, state: 'right' },
+  { pct: 36, state: 'blink-right' },
+  { pct: 37, state: 'right' },
+  { pct: 54, state: 'center' },
+  { pct: 60, state: 'up' },
+  { pct: 64, state: 'blink-up' },
+  { pct: 65, state: 'left' },
+  { pct: 68, state: 'center' },
+  { pct: 92, state: 'blink-center' },
+  { pct: 94, state: 'center' },
+  { pct: 96, state: 'right' },
+  { pct: 98, state: 'center' },
+];
+
+/** Idle eye cycle: 10s total (from blob-idle-eyes) */
+export const IDLE_EYE_SCHEDULE: EyeScheduleEntry[] = [
+  { pct: 0,  state: 'center' },
+  { pct: 10, state: 'left' },
+  { pct: 22, state: 'blink-left' },
+  { pct: 25, state: 'up' },
+  { pct: 45, state: 'center' },
+  { pct: 55, state: 'right' },
+  { pct: 67, state: 'blink-right' },
+  { pct: 70, state: 'up' },
+  { pct: 85, state: 'center' },
+  { pct: 93, state: 'blink-center' },
+  { pct: 96, state: 'center' },
+];
+
+/** Sidebar selected eye cycle: 6s (from bobbit-eyes in app.css) */
+export const SIDEBAR_EYE_SCHEDULE: EyeScheduleEntry[] = [
+  { pct: 0,  state: 'center' },
+  { pct: 56, state: 'blink-center' },
+  { pct: 59, state: 'center' },
+  { pct: 74, state: 'right' },
+  { pct: 87, state: 'blink-center' },
+  { pct: 90, state: 'center' },
+];

--- a/src/ui/bobbit-sprite.ts
+++ b/src/ui/bobbit-sprite.ts
@@ -1,0 +1,474 @@
+/**
+ * Canvas-based bobbit sprite renderer.
+ *
+ * Replaces CSS box-shadow rasterization with <canvas> + fillRect for
+ * crisp rendering at any DPR. CSS animations continue to work on the
+ * canvas element for movement, squash/stretch, enter/exit, etc.
+ */
+
+import { AsyncDirective, directive } from 'lit/async-directive.js';
+import { noChange } from 'lit';
+import type { ElementPart } from 'lit/directive.js';
+
+import { ACCESSORIES, getAccessory } from '../app/session-colors.js';
+import {
+  type BodyPixel,
+  type ColorKey,
+  type EyeScheduleEntry,
+  type EyeState,
+  type Pixel,
+  BODY_PIXELS,
+  DEFAULT_PALETTE,
+  EYE_STATES,
+  SIDEBAR_EYE_SCHEDULE,
+} from './bobbit-sprite-data.js';
+
+// Re-export types for downstream consumers
+export type { BodyPixel, ColorKey, EyeScheduleEntry, EyeState, Pixel };
+export {
+  BODY_PIXELS,
+  DEFAULT_PALETTE,
+  EYE_STATES,
+  BUSY_EYE_SCHEDULE,
+  IDLE_EYE_SCHEDULE,
+  SIDEBAR_EYE_SCHEDULE,
+  STARTING_PALETTE,
+  TERMINATED_PALETTE,
+} from './bobbit-sprite-data.js';
+
+// ============================================================================
+// parseBoxShadow — convert CSS box-shadow strings to Pixel arrays
+// ============================================================================
+
+/**
+ * Parse a CSS box-shadow string into an array of {x, y, color} pixels.
+ * Handles the format used by bobbit accessories: "Xpx Ypx 0 #color, ..."
+ * Coordinates can be negative. Colors can be #rgb, #rrggbb, or named.
+ */
+export function parseBoxShadow(shadow: string): Pixel[] {
+  if (!shadow || !shadow.trim()) return [];
+  const pixels: Pixel[] = [];
+  // Split on commas, handling potential whitespace
+  const parts = shadow.split(',');
+  for (const part of parts) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    // Match: Xpx Ypx 0 color  OR  Xpx Ypx 0px color
+    // Also handle: X Ypx 0 color (0 without px)
+    const match = trimmed.match(
+      /^(-?\d+)(?:px)?\s+(-?\d+)(?:px)?\s+\d+(?:px)?\s+(#[0-9a-fA-F]{3,8}|\w+)$/
+    );
+    if (match) {
+      pixels.push({
+        x: parseInt(match[1], 10),
+        y: parseInt(match[2], 10),
+        color: match[3],
+      });
+    }
+  }
+  return pixels;
+}
+
+// ============================================================================
+// ACCESSORY_PIXELS — parsed once at module load
+// ============================================================================
+
+/** Pre-parsed accessory pixel data, keyed by accessory ID */
+export const ACCESSORY_PIXELS: Record<string, Pixel[]> = {};
+
+// Parse all accessory shadows into pixel arrays at module load time
+for (const [id, def] of Object.entries(ACCESSORIES)) {
+  if (def.shadow) {
+    ACCESSORY_PIXELS[id] = parseBoxShadow(def.shadow);
+  }
+}
+
+// ============================================================================
+// Color utilities
+// ============================================================================
+
+/** Convert a hex color (#rgb or #rrggbb) to {h, s, l} (h in degrees, s/l in 0-1) */
+function hexToHSL(hex: string): { h: number; s: number; l: number } {
+  // Expand shorthand #rgb → #rrggbb
+  let h = hex.replace('#', '');
+  if (h.length === 3) {
+    h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+  }
+  const r = parseInt(h.substring(0, 2), 16) / 255;
+  const g = parseInt(h.substring(2, 4), 16) / 255;
+  const b = parseInt(h.substring(4, 6), 16) / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+
+  if (max === min) {
+    return { h: 0, s: 0, l };
+  }
+
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+
+  let hue: number;
+  if (max === r) hue = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+  else if (max === g) hue = ((b - r) / d + 2) / 6;
+  else hue = ((r - g) / d + 4) / 6;
+
+  return { h: hue * 360, s, l };
+}
+
+/** Convert HSL (h in degrees, s/l in 0-1) to hex string #rrggbb */
+function hslToHex(h: number, s: number, l: number): string {
+  const hue2rgb = (p: number, q: number, t: number) => {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+
+  let r: number, g: number, b: number;
+  if (s === 0) {
+    r = g = b = l;
+  } else {
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    const hNorm = h / 360;
+    r = hue2rgb(p, q, hNorm + 1 / 3);
+    g = hue2rgb(p, q, hNorm);
+    b = hue2rgb(p, q, hNorm - 1 / 3);
+  }
+
+  const toHex = (v: number) => {
+    const hex = Math.round(v * 255).toString(16);
+    return hex.length === 1 ? '0' + hex : hex;
+  };
+
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+/**
+ * Rotate a hex color's hue by -degrees to cancel a CSS hue-rotate(degrees).
+ * Converts hex → HSL, subtracts hue, converts back to hex.
+ */
+export function counterHueRotate(hexColor: string, degrees: number): string {
+  const { h, s, l } = hexToHSL(hexColor);
+  const newH = ((h - degrees) % 360 + 360) % 360;
+  return hslToHex(newH, s, l);
+}
+
+// ============================================================================
+// DPR change listener
+// ============================================================================
+
+/** Current DPR — updated on monitor changes */
+let currentDpr = typeof window !== 'undefined' ? window.devicePixelRatio : 1;
+
+/** Listeners notified when DPR changes (e.g. window moved between monitors) */
+export const dprListeners = new Set<() => void>();
+
+/** Register a callback for DPR changes. Returns an unregister function. */
+export function onDprChange(listener: () => void): () => void {
+  dprListeners.add(listener);
+  return () => dprListeners.delete(listener);
+}
+
+function watchDpr() {
+  if (typeof window === 'undefined') return;
+  const mq = window.matchMedia(`(resolution: ${currentDpr}dppx)`);
+  mq.addEventListener('change', () => {
+    currentDpr = window.devicePixelRatio;
+    for (const listener of dprListeners) listener();
+    watchDpr();
+  }, { once: true });
+}
+watchDpr();
+
+// ============================================================================
+// drawBobbitSprite
+// ============================================================================
+
+/** Options for drawBobbitSprite */
+export interface SpriteOptions {
+  /** Current eye animation state */
+  eyeState: EyeState;
+  /** CSS pixel size per sprite pixel (default: 4 for chat, 1.6 for sidebar) */
+  scale?: number;
+  /** devicePixelRatio override (default: window.devicePixelRatio) */
+  dpr?: number;
+  /** Override palette colors (for starting/terminated status) */
+  colors?: Partial<Record<ColorKey, string>>;
+  /** Accessory ID from registry (e.g. "crown", "bandana") */
+  accessory?: string;
+  /** Hue rotation in degrees — used to counter-rotate accessory colors */
+  hueRotate?: number;
+  /** Whether eyes should use main color instead of eye color (selected state) */
+  selected?: boolean;
+  /** Whether this is an animated sprite (eyes tick automatically) */
+  animated?: boolean;
+  /** Eye schedule for animated sprites */
+  schedule?: EyeScheduleEntry[];
+  /** Cycle duration in ms for animated sprites */
+  cycleDuration?: number;
+}
+
+/**
+ * Paint the bobbit sprite onto a canvas: body, eyes, and optional accessory.
+ * The canvas is sized to fit the sprite at the given scale × DPR, with
+ * integer device pixels per sprite pixel for crisp rendering.
+ */
+export function drawBobbitSprite(canvas: HTMLCanvasElement, opts: SpriteOptions): void {
+  const scale = opts.scale ?? 4;
+  const dpr = opts.dpr ?? currentDpr;
+  const pxSize = Math.max(1, Math.round(scale * dpr));
+
+  // Compute canvas bounds including accessory overflow
+  const acc = opts.accessory ? ACCESSORY_PIXELS[opts.accessory] : null;
+  const accDef = opts.accessory ? getAccessory(opts.accessory) : null;
+
+  // Body grid is 10×9 at (0,0)-(9,8). Accessories can extend beyond.
+  let minX = 0, minY = 0, maxX = 9, maxY = 8;
+  if (acc) {
+    for (const p of acc) {
+      if (p.x < minX) minX = p.x;
+      if (p.y < minY) minY = p.y;
+      if (p.x > maxX) maxX = p.x;
+      if (p.y > maxY) maxY = p.y;
+    }
+  }
+
+  const gridW = maxX - minX + 1;
+  const gridH = maxY - minY + 1;
+  const width = gridW * pxSize;
+  const height = gridH * pxSize;
+  const offsetX = -minX;
+  const offsetY = -minY;
+
+  // Only resize if dimensions changed (avoid expensive canvas reset)
+  if (canvas.width !== width || canvas.height !== height) {
+    canvas.width = width;
+    canvas.height = height;
+    canvas.style.width = `${width / dpr}px`;
+    canvas.style.height = `${height / dpr}px`;
+  }
+
+  const ctx = canvas.getContext('2d')!;
+  ctx.imageSmoothingEnabled = false;
+  ctx.clearRect(0, 0, width, height);
+
+  // Resolve palette
+  const palette: Record<ColorKey, string> = { ...DEFAULT_PALETTE, ...opts.colors };
+
+  // Paint body pixels
+  for (const pixel of BODY_PIXELS) {
+    ctx.fillStyle = palette[pixel.colorKey];
+    ctx.fillRect(
+      (pixel.x + offsetX) * pxSize,
+      (pixel.y + offsetY) * pxSize,
+      pxSize,
+      pxSize,
+    );
+  }
+
+  // Paint eyes based on current state
+  const eyePixels = EYE_STATES[opts.eyeState];
+  const eyeColor = opts.selected ? palette.main : palette.eye;
+  ctx.fillStyle = eyeColor;
+  for (const pos of eyePixels) {
+    ctx.fillRect(
+      (pos.x + offsetX) * pxSize,
+      (pos.y + offsetY) * pxSize,
+      pxSize,
+      pxSize,
+    );
+  }
+
+  // Paint accessory pixels (if any)
+  if (acc && acc.length > 0) {
+    const hueRotate = opts.hueRotate ?? 0;
+    for (const pixel of acc) {
+      // Counter-rotate accessory colors to cancel the parent's CSS hue-rotate
+      // (except flask, which intentionally rotates with the bobbit)
+      const color = (hueRotate !== 0 && accDef?.id !== 'flask')
+        ? counterHueRotate(pixel.color, hueRotate)
+        : pixel.color;
+      ctx.fillStyle = color;
+      ctx.fillRect(
+        (pixel.x + offsetX) * pxSize,
+        (pixel.y + offsetY) * pxSize,
+        pxSize,
+        pxSize,
+      );
+    }
+  }
+}
+
+// ============================================================================
+// BobbitEyeTimer — JS-driven eye animation replacing CSS keyframes
+// ============================================================================
+
+/**
+ * Drives eye animation state changes via requestAnimationFrame.
+ * Replaces CSS step-keyframe animations for eyes.
+ */
+export class BobbitEyeTimer {
+  private _raf = 0;
+  private _startTime = 0;
+  private _schedule: EyeScheduleEntry[] = [];
+  private _cycleDuration = 10000;
+  private _currentState: EyeState = 'center';
+  private _onStateChange: (state: EyeState) => void;
+  private _offset = 0;
+  private _unsubDpr: (() => void) | null = null;
+
+  constructor(onStateChange: (state: EyeState) => void) {
+    this._onStateChange = onStateChange;
+  }
+
+  /**
+   * Start (or restart) the animation loop.
+   * Cancels any previously-running loop before beginning a new one.
+   */
+  start(schedule: EyeScheduleEntry[], cycleDurationMs: number, offset = 0): void {
+    this.stop();
+    this._schedule = schedule;
+    this._cycleDuration = cycleDurationMs;
+    this._startTime = performance.now();
+    this._offset = offset;
+    this._currentState = 'center';
+    this._tick();
+  }
+
+  private _tick = (): void => {
+    const elapsed = (performance.now() - this._startTime + this._offset) % this._cycleDuration;
+    const pct = (elapsed / this._cycleDuration) * 100;
+
+    // Find current state from schedule (last entry where pct >= entry.pct)
+    let state = this._schedule[0]?.state ?? 'center';
+    for (const entry of this._schedule) {
+      if (pct >= entry.pct) state = entry.state;
+      else break;
+    }
+
+    if (state !== this._currentState) {
+      this._currentState = state;
+      this._onStateChange(state);
+    }
+
+    this._raf = requestAnimationFrame(this._tick);
+  };
+
+  /** Stop the animation loop. Safe to call multiple times. */
+  stop(): void {
+    if (this._raf) {
+      cancelAnimationFrame(this._raf);
+      this._raf = 0;
+    }
+  }
+
+  /** Get current eye state without waiting for next tick */
+  get currentState(): EyeState {
+    return this._currentState;
+  }
+
+  /** Subscribe to DPR changes. Call cleanup() to unsubscribe. */
+  subscribeDpr(repaint: () => void): void {
+    this._unsubDpr = onDprChange(repaint);
+  }
+
+  /** Unsubscribe from DPR changes */
+  unsubscribeDpr(): void {
+    this._unsubDpr?.();
+    this._unsubDpr = null;
+  }
+}
+
+// ============================================================================
+// bobbitSprite — Lit AsyncDirective for declarative canvas rendering
+// ============================================================================
+
+/**
+ * Lit directive for rendering a bobbit sprite on a <canvas> element.
+ * Manages eye animation timer and DPR change listener.
+ *
+ * Usage:
+ * ```ts
+ * html`<canvas ${bobbitSprite({ eyeState: 'center', scale: 1.6, animated: true })}></canvas>`
+ * ```
+ */
+class BobbitSpriteDirective extends AsyncDirective {
+  private _timer: BobbitEyeTimer | null = null;
+  private _canvas: HTMLCanvasElement | null = null;
+  private _opts: SpriteOptions = { eyeState: 'center' };
+  private _unsubDpr: (() => void) | null = null;
+
+  override update(part: ElementPart, [opts]: [SpriteOptions]) {
+    this._opts = opts;
+    this._canvas = part.element as HTMLCanvasElement;
+    this._draw();
+
+    // Manage eye timer based on animated flag
+    if (opts.animated && !this._timer) {
+      this._timer = new BobbitEyeTimer((state) => {
+        this._opts = { ...this._opts, eyeState: state };
+        this._draw();
+      });
+      this._timer.start(
+        opts.schedule ?? SIDEBAR_EYE_SCHEDULE,
+        opts.cycleDuration ?? 6000,
+      );
+      // Subscribe to DPR changes
+      this._unsubDpr = onDprChange(() => this._draw());
+    } else if (!opts.animated && this._timer) {
+      this._timer.stop();
+      this._timer = null;
+      this._unsubDpr?.();
+      this._unsubDpr = null;
+    } else if (opts.animated && this._timer) {
+      // Update schedule if changed (e.g. switching between busy/idle)
+      // Timer is already running, just update opts
+    }
+
+    // If not animated, still handle DPR changes
+    if (!opts.animated && !this._unsubDpr) {
+      this._unsubDpr = onDprChange(() => this._draw());
+    }
+
+    return noChange;
+  }
+
+  render(_opts: SpriteOptions) {
+    return noChange;
+  }
+
+  private _draw() {
+    if (this._canvas) {
+      drawBobbitSprite(this._canvas, this._opts);
+    }
+  }
+
+  override disconnected() {
+    this._timer?.stop();
+    this._timer = null;
+    this._unsubDpr?.();
+    this._unsubDpr = null;
+  }
+
+  override reconnected() {
+    if (this._opts.animated) {
+      this._timer = new BobbitEyeTimer((state) => {
+        this._opts = { ...this._opts, eyeState: state };
+        this._draw();
+      });
+      this._timer.start(
+        this._opts.schedule ?? SIDEBAR_EYE_SCHEDULE,
+        this._opts.cycleDuration ?? 6000,
+      );
+    }
+    this._unsubDpr = onDprChange(() => this._draw());
+    this._draw();
+  }
+}
+
+export const bobbitSprite = directive(BobbitSpriteDirective);

--- a/src/ui/bobbit-sprite.ts
+++ b/src/ui/bobbit-sprite.ts
@@ -213,6 +213,14 @@ export interface SpriteOptions {
   cycleDuration?: number;
   /** Eye animation offset in ms — staggers multiple blobs so they don't blink in sync */
   eyeDelay?: number;
+  /**
+   * When set, use this value (instead of DPR-derived size) for the canvas CSS
+   * display dimensions. Each sprite pixel maps to `cssScale` CSS pixels.
+   * Use cssScale=1 for chat blobs where CSS `transform: scale(4)` handles
+   * the visual scaling — the canvas must be exactly gridW×gridH CSS pixels
+   * regardless of DPR, so the CSS transform produces deterministic results.
+   */
+  cssScale?: number;
 }
 
 /**
@@ -251,8 +259,16 @@ export function drawBobbitSprite(canvas: HTMLCanvasElement, opts: SpriteOptions)
   if (canvas.width !== width || canvas.height !== height) {
     canvas.width = width;
     canvas.height = height;
-    canvas.style.width = `${width / dpr}px`;
-    canvas.style.height = `${height / dpr}px`;
+    // When cssScale is provided (e.g. chat blob with CSS transform: scale(4)),
+    // use deterministic CSS sizing independent of DPR. Otherwise use DPR-derived sizing.
+    const cssScale = opts.cssScale;
+    if (cssScale != null) {
+      canvas.style.width = `${gridW * cssScale}px`;
+      canvas.style.height = `${gridH * cssScale}px`;
+    } else {
+      canvas.style.width = `${width / dpr}px`;
+      canvas.style.height = `${height / dpr}px`;
+    }
   }
 
   const ctx = canvas.getContext('2d')!;

--- a/src/ui/bobbit-sprite.ts
+++ b/src/ui/bobbit-sprite.ts
@@ -211,6 +211,8 @@ export interface SpriteOptions {
   schedule?: EyeScheduleEntry[];
   /** Cycle duration in ms for animated sprites */
   cycleDuration?: number;
+  /** Eye animation offset in ms — staggers multiple blobs so they don't blink in sync */
+  eyeDelay?: number;
 }
 
 /**
@@ -320,7 +322,6 @@ export class BobbitEyeTimer {
   private _currentState: EyeState = 'center';
   private _onStateChange: (state: EyeState) => void;
   private _offset = 0;
-  private _unsubDpr: (() => void) | null = null;
 
   constructor(onStateChange: (state: EyeState) => void) {
     this._onStateChange = onStateChange;
@@ -372,16 +373,6 @@ export class BobbitEyeTimer {
     return this._currentState;
   }
 
-  /** Subscribe to DPR changes. Call cleanup() to unsubscribe. */
-  subscribeDpr(repaint: () => void): void {
-    this._unsubDpr = onDprChange(repaint);
-  }
-
-  /** Unsubscribe from DPR changes */
-  unsubscribeDpr(): void {
-    this._unsubDpr?.();
-    this._unsubDpr = null;
-  }
 }
 
 // ============================================================================
@@ -417,8 +408,10 @@ class BobbitSpriteDirective extends AsyncDirective {
       this._timer.start(
         opts.schedule ?? SIDEBAR_EYE_SCHEDULE,
         opts.cycleDuration ?? 6000,
+        opts.eyeDelay ?? 0,
       );
-      // Subscribe to DPR changes
+      // Subscribe to DPR changes (unsubscribe previous first to avoid leak)
+      this._unsubDpr?.();
       this._unsubDpr = onDprChange(() => this._draw());
     } else if (!opts.animated && this._timer) {
       this._timer.stop();
@@ -431,8 +424,10 @@ class BobbitSpriteDirective extends AsyncDirective {
     }
 
     // If not animated, still handle DPR changes
-    if (!opts.animated && !this._unsubDpr) {
-      this._unsubDpr = onDprChange(() => this._draw());
+    if (!opts.animated) {
+      if (!this._unsubDpr) {
+        this._unsubDpr = onDprChange(() => this._draw());
+      }
     }
 
     return noChange;
@@ -464,6 +459,7 @@ class BobbitSpriteDirective extends AsyncDirective {
       this._timer.start(
         this._opts.schedule ?? SIDEBAR_EYE_SCHEDULE,
         this._opts.cycleDuration ?? 6000,
+        this._opts.eyeDelay ?? 0,
       );
     }
     this._unsubDpr = onDprChange(() => this._draw());

--- a/src/ui/components/StreamingMessageContainer.ts
+++ b/src/ui/components/StreamingMessageContainer.ts
@@ -74,6 +74,12 @@ function drawAccessoryCanvas(
 		}
 	}
 
+	// Position the canvas at the correct pre-transform coordinate within
+	// the 1×1px wrapper so that after scale(4) it aligns with the body sprite.
+	canvas.style.position = 'absolute';
+	canvas.style.left = `${minX}px`;
+	canvas.style.top = `${minY}px`;
+
 	const ctx = canvas.getContext('2d')!;
 	ctx.imageSmoothingEnabled = false;
 	ctx.clearRect(0, 0, width, height);
@@ -124,7 +130,7 @@ export class StreamingMessageContainer extends LitElement {
 	/** DPR change unsubscribe */
 	private _unsubDpr: (() => void) | null = null;
 	/** Previous blob state — used to avoid redundant repaints in updated() */
-	private _prevBlobState: string = 'idle';
+	private _prevBlobState: string = '';
 
 	constructor() {
 		super();

--- a/src/ui/components/StreamingMessageContainer.ts
+++ b/src/ui/components/StreamingMessageContainer.ts
@@ -3,6 +3,92 @@ import type { ToolResultMessage } from "@mariozechner/pi-ai";
 import { html, LitElement, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 import "./LiveTimer.js";
+import {
+	type EyeState,
+	BobbitEyeTimer,
+	BUSY_EYE_SCHEDULE,
+	IDLE_EYE_SCHEDULE,
+	drawBobbitSprite,
+	onDprChange,
+	ACCESSORY_PIXELS,
+	counterHueRotate,
+} from "../bobbit-sprite.js";
+import { getAccessory } from "../../app/session-colors.js";
+
+/**
+ * Paint only the accessory pixels onto a canvas.
+ * For the chat blob, accessories are separate elements with their own CSS animations.
+ */
+function drawAccessoryCanvas(
+	canvas: HTMLCanvasElement,
+	accessoryId: string,
+	opts: { scale?: number; dpr?: number; hueRotate?: number; excludeTail?: boolean; },
+): void {
+	const pixels = ACCESSORY_PIXELS[accessoryId];
+	if (!pixels || pixels.length === 0) return;
+
+	const scale = opts.scale ?? 4;
+	const dpr = opts.dpr ?? window.devicePixelRatio;
+	const pxSize = Math.max(1, Math.round(scale * dpr));
+
+	// Filter tail pixels for bandana when facing right/up
+	let paintPixels = pixels;
+	if (opts.excludeTail && accessoryId === 'bandana') {
+		// Tail pixels are x >= 10 (the knot and tail extending right)
+		paintPixels = pixels.filter(p => p.x < 10);
+	}
+
+	// Compute bounding box
+	let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+	for (const p of paintPixels) {
+		if (p.x < minX) minX = p.x;
+		if (p.y < minY) minY = p.y;
+		if (p.x > maxX) maxX = p.x;
+		if (p.y > maxY) maxY = p.y;
+	}
+	if (paintPixels.length === 0) {
+		// No pixels to paint — clear canvas
+		canvas.width = 1;
+		canvas.height = 1;
+		canvas.style.width = '0px';
+		canvas.style.height = '0px';
+		return;
+	}
+
+	const gridW = maxX - minX + 1;
+	const gridH = maxY - minY + 1;
+	const width = gridW * pxSize;
+	const height = gridH * pxSize;
+	const offsetX = -minX;
+	const offsetY = -minY;
+
+	if (canvas.width !== width || canvas.height !== height) {
+		canvas.width = width;
+		canvas.height = height;
+		canvas.style.width = `${width / dpr}px`;
+		canvas.style.height = `${height / dpr}px`;
+	}
+
+	const ctx = canvas.getContext('2d')!;
+	ctx.imageSmoothingEnabled = false;
+	ctx.clearRect(0, 0, width, height);
+
+	const hueRotate = opts.hueRotate ?? 0;
+	const accDef = getAccessory(accessoryId);
+
+	for (const pixel of paintPixels) {
+		const color = (hueRotate !== 0 && accDef?.id !== 'flask')
+			? counterHueRotate(pixel.color, hueRotate)
+			: pixel.color;
+		ctx.fillStyle = color;
+		ctx.fillRect(
+			(pixel.x + offsetX) * pxSize,
+			(pixel.y + offsetY) * pxSize,
+			pxSize,
+			pxSize,
+		);
+	}
+}
 
 export class StreamingMessageContainer extends LitElement {
 	@property({ type: Array }) tools: AgentTool[] = [];
@@ -26,6 +112,22 @@ export class StreamingMessageContainer extends LitElement {
 	private _updateScheduled = false;
 	private _immediateUpdate = false;
 
+	/** Eye animation timer — drives canvas repaints */
+	private _eyeTimer: BobbitEyeTimer;
+	/** Current eye state for repainting */
+	private _eyeState: EyeState = 'center';
+	/** DPR change unsubscribe */
+	private _unsubDpr: (() => void) | null = null;
+
+	constructor() {
+		super();
+		this._eyeTimer = new BobbitEyeTimer((eyeState) => {
+			this._eyeState = eyeState;
+			this._repaintSprite();
+			this._repaintBandana();
+		});
+	}
+
 	protected override createRenderRoot(): HTMLElement | DocumentFragment {
 		return this;
 	}
@@ -33,6 +135,87 @@ export class StreamingMessageContainer extends LitElement {
 	override connectedCallback(): void {
 		super.connectedCallback();
 		this.style.display = "block";
+		this._unsubDpr = onDprChange(() => {
+			this._repaintSprite();
+			this._repaintAllAccessories();
+		});
+	}
+
+	override disconnectedCallback(): void {
+		super.disconnectedCallback();
+		this._eyeTimer.stop();
+		this._unsubDpr?.();
+		this._unsubDpr = null;
+	}
+
+	/** Repaint the body+eyes sprite canvas */
+	private _repaintSprite(): void {
+		const canvas = this.querySelector<HTMLCanvasElement>('canvas.bobbit-blob__sprite');
+		if (!canvas) return;
+		drawBobbitSprite(canvas, {
+			eyeState: this._eyeState,
+			scale: 4,
+		});
+	}
+
+	/** Repaint bandana canvas with tail state based on eye direction */
+	private _repaintBandana(): void {
+		const wrapper = this.querySelector<HTMLElement>('.bobbit-blob__bandana');
+		if (!wrapper || wrapper.style.display === 'none') return;
+		const canvas = wrapper.querySelector<HTMLCanvasElement>('canvas');
+		if (!canvas) return;
+
+		// Determine if tail should be hidden and translate shift
+		const eyeState = this._eyeState;
+		const facingRight = eyeState === 'right' || eyeState === 'blink-right';
+		const lookingUp = eyeState === 'up' || eyeState === 'blink-up';
+		const excludeTail = facingRight || lookingUp;
+
+		drawAccessoryCanvas(canvas, 'bandana', { scale: 4, excludeTail });
+
+		// Translate shift for eyes-up state (per design doc)
+		if (lookingUp) {
+			wrapper.style.translate = '0 -3.5px';
+		} else {
+			wrapper.style.translate = '0 -2px';
+		}
+	}
+
+	/** Repaint all visible accessory canvases */
+	private _repaintAllAccessories(): void {
+		const accessories = [
+			'crown', 'bandana', 'magnifier', 'palette', 'pencil',
+			'shield', 'set-square', 'flask', 'wand', 'wizard-hat',
+		];
+		for (const accId of accessories) {
+			const wrapper = this.querySelector<HTMLElement>(`.bobbit-blob__${accId}`);
+			if (!wrapper) continue;
+			const canvas = wrapper.querySelector<HTMLCanvasElement>('canvas');
+			if (!canvas) continue;
+			if (accId === 'bandana') {
+				this._repaintBandana();
+			} else {
+				drawAccessoryCanvas(canvas, accId, { scale: 4 });
+			}
+		}
+	}
+
+	/** Start/restart/stop eye timer based on blob state */
+	private _updateEyeTimer(): void {
+		switch (this._blobState) {
+			case 'active':
+			case 'entering':
+				this._eyeTimer.start(BUSY_EYE_SCHEDULE, 10000);
+				break;
+			case 'idle':
+				this._eyeTimer.start(IDLE_EYE_SCHEDULE, 10000);
+				break;
+			case 'exiting':
+			case 'hidden':
+				this._eyeTimer.stop();
+				break;
+			// compact-shake, compacting, compact-pop: timer keeps running
+		}
 	}
 
 	override updated(changed: Map<string, unknown>) {
@@ -44,12 +227,15 @@ export class StreamingMessageContainer extends LitElement {
 				// Coming from idle — play entry animation
 				this._entryVariant = Math.random() < 0.5 ? 'enter' : 'enter-roll';
 				this._blobState = 'entering';
+				this._updateEyeTimer();
 				this._entryTimer = setTimeout(() => {
 					this._entryTimer = null;
 					this._blobState = 'active';
+					this._updateEyeTimer();
 				}, this._entryVariant === 'enter-roll' ? 900 : 700);
 			} else if (this.isStreaming) {
 				this._blobState = 'active';
+				this._updateEyeTimer();
 			} else if (this._blobState === 'active' || this._blobState === 'entering') {
 				// Streaming stopped — cancel any pending entry timer and play exit
 				if (this._entryTimer) {
@@ -58,12 +244,22 @@ export class StreamingMessageContainer extends LitElement {
 				}
 				this._exitVariant = Math.random() < 0.5 ? 'exit' : 'exit-roll';
 				this._blobState = 'exiting';
+				this._updateEyeTimer();
 				setTimeout(() => {
 					this._blobState = 'idle';
+					this._updateEyeTimer();
 				}, this._exitVariant === 'exit-roll' ? 900 : 700);
 			}
 		}
 
+		// After render, do initial canvas paint if blob is visible
+		if (this._blobVisible) {
+			// Use requestAnimationFrame to ensure DOM is rendered
+			requestAnimationFrame(() => {
+				this._repaintSprite();
+				this._repaintAllAccessories();
+			});
+		}
 	}
 
 	private get _blobVisible() {
@@ -88,14 +284,17 @@ export class StreamingMessageContainer extends LitElement {
 		// If idle, enter first then shake then compact; if active, shake then compact
 		const startShake = () => {
 			this._blobState = 'compact-shake';
+			this._updateEyeTimer();
 			this._compactShakeTimer = setTimeout(() => {
 				this._compactShakeTimer = null;
 				this._blobState = 'compacting';
+				this._updateEyeTimer();
 			}, 800); // matches blob-compact-shake duration
 		};
 		if (this._blobState === 'idle') {
 			this._entryVariant = Math.random() < 0.5 ? 'enter' : 'enter-roll';
 			this._blobState = 'entering';
+			this._updateEyeTimer();
 			this._compactEntryTimer = setTimeout(() => {
 				this._compactEntryTimer = null;
 				startShake();
@@ -145,11 +344,14 @@ export class StreamingMessageContainer extends LitElement {
 			this._compactSafetyTimer = null;
 		}
 		this._blobState = 'compact-pop';
+		this._updateEyeTimer();
 		setTimeout(() => {
 			this._exitVariant = Math.random() < 0.5 ? 'exit' : 'exit-roll';
 			this._blobState = 'exiting';
+			this._updateEyeTimer();
 			setTimeout(() => {
 				this._blobState = 'idle';
+				this._updateEyeTimer();
 			}, this._exitVariant === 'exit-roll' ? 900 : 700);
 		}, 600); // pop duration
 	}
@@ -190,25 +392,30 @@ export class StreamingMessageContainer extends LitElement {
 		}
 	}
 
+	/** Render the blob section with canvas elements for sprite and accessories */
+	private _renderBlob() {
+		return html`<div class="${this._blobClass}">
+			<canvas class="bobbit-blob__sprite"></canvas>
+			<div class="bobbit-blob__crown"><canvas></canvas></div>
+			<div class="bobbit-blob__bandana"><canvas></canvas></div>
+			<div class="bobbit-blob__magnifier"><canvas></canvas></div>
+			<div class="bobbit-blob__palette"><canvas></canvas></div>
+			<div class="bobbit-blob__pencil"><canvas></canvas></div>
+			<div class="bobbit-blob__shield"><canvas></canvas></div>
+			<div class="bobbit-blob__set-square"><canvas></canvas></div>
+			<div class="bobbit-blob__flask"><canvas></canvas></div>
+			<div class="bobbit-blob__wand"><canvas></canvas></div>
+			<div class="bobbit-blob__wizard-hat"><canvas></canvas></div>
+			<div class="bobbit-blob__shadow"></div>
+		</div>`;
+	}
+
 	override render() {
 		// Show loading indicator if loading but no message yet
 		if (!this._message) {
 			if (this._blobVisible)
 				return html`<div class="flex flex-col gap-3 mb-3">
-					<div class="${this._blobClass}">
-						<div class="bobbit-blob__sprite"></div>
-						<div class="bobbit-blob__crown"></div>
-						<div class="bobbit-blob__bandana"></div>
-						<div class="bobbit-blob__magnifier"></div>
-						<div class="bobbit-blob__palette"></div>
-						<div class="bobbit-blob__pencil"></div>
-						<div class="bobbit-blob__shield"></div>
-						<div class="bobbit-blob__set-square"></div>
-						<div class="bobbit-blob__flask"></div>
-						<div class="bobbit-blob__wand"></div>
-						<div class="bobbit-blob__wizard-hat"></div>
-						<div class="bobbit-blob__shadow"></div>
-					</div>
+					${this._renderBlob()}
 					${this.isStreaming && this.turnStartTime
 						? html`<div class="px-2 sm:px-4 text-xs text-muted-foreground text-right tabular-nums" style="margin-top:-32px;">
 							<live-timer .startTime=${this.turnStartTime} .running=${true}></live-timer>
@@ -240,20 +447,7 @@ export class StreamingMessageContainer extends LitElement {
 						.onCostClick=${this.onCostClick}
 						.turnStartTime=${this.turnStartTime}
 					></assistant-message>
-					${this._blobVisible ? html`<div class="${this._blobClass}">
-						<div class="bobbit-blob__sprite"></div>
-						<div class="bobbit-blob__crown"></div>
-						<div class="bobbit-blob__bandana"></div>
-						<div class="bobbit-blob__magnifier"></div>
-						<div class="bobbit-blob__palette"></div>
-						<div class="bobbit-blob__pencil"></div>
-						<div class="bobbit-blob__shield"></div>
-						<div class="bobbit-blob__set-square"></div>
-						<div class="bobbit-blob__flask"></div>
-						<div class="bobbit-blob__wand"></div>
-						<div class="bobbit-blob__wizard-hat"></div>
-						<div class="bobbit-blob__shadow"></div>
-					</div>` : ""}
+					${this._blobVisible ? this._renderBlob() : ""}
 				</div>
 			`;
 		}

--- a/src/ui/components/StreamingMessageContainer.ts
+++ b/src/ui/components/StreamingMessageContainer.ts
@@ -22,7 +22,7 @@ import { getAccessory } from "../../app/session-colors.js";
 function drawAccessoryCanvas(
 	canvas: HTMLCanvasElement,
 	accessoryId: string,
-	opts: { scale?: number; dpr?: number; hueRotate?: number; excludeTail?: boolean; },
+	opts: { scale?: number; dpr?: number; hueRotate?: number; excludeTail?: boolean; cssScale?: number; },
 ): void {
 	const pixels = ACCESSORY_PIXELS[accessoryId];
 	if (!pixels || pixels.length === 0) return;
@@ -65,8 +65,13 @@ function drawAccessoryCanvas(
 	if (canvas.width !== width || canvas.height !== height) {
 		canvas.width = width;
 		canvas.height = height;
-		canvas.style.width = `${width / dpr}px`;
-		canvas.style.height = `${height / dpr}px`;
+		if (opts.cssScale != null) {
+			canvas.style.width = `${gridW * opts.cssScale}px`;
+			canvas.style.height = `${gridH * opts.cssScale}px`;
+		} else {
+			canvas.style.width = `${width / dpr}px`;
+			canvas.style.height = `${height / dpr}px`;
+		}
 	}
 
 	const ctx = canvas.getContext('2d')!;
@@ -118,6 +123,8 @@ export class StreamingMessageContainer extends LitElement {
 	private _eyeState: EyeState = 'center';
 	/** DPR change unsubscribe */
 	private _unsubDpr: (() => void) | null = null;
+	/** Previous blob state — used to avoid redundant repaints in updated() */
+	private _prevBlobState: string = 'idle';
 
 	constructor() {
 		super();
@@ -155,6 +162,7 @@ export class StreamingMessageContainer extends LitElement {
 		drawBobbitSprite(canvas, {
 			eyeState: this._eyeState,
 			scale: 1,
+			cssScale: 1,
 		});
 	}
 
@@ -171,7 +179,7 @@ export class StreamingMessageContainer extends LitElement {
 		const lookingUp = eyeState === 'up' || eyeState === 'blink-up';
 		const excludeTail = facingRight || lookingUp;
 
-		drawAccessoryCanvas(canvas, 'bandana', { scale: 1, excludeTail });
+		drawAccessoryCanvas(canvas, 'bandana', { scale: 1, excludeTail, cssScale: 1 });
 
 		// Translate shift for eyes-up state (per design doc)
 		if (lookingUp) {
@@ -195,7 +203,7 @@ export class StreamingMessageContainer extends LitElement {
 			if (accId === 'bandana') {
 				this._repaintBandana();
 			} else {
-				drawAccessoryCanvas(canvas, accId, { scale: 1 });
+				drawAccessoryCanvas(canvas, accId, { scale: 1, cssScale: 1 });
 			}
 		}
 	}
@@ -252,13 +260,16 @@ export class StreamingMessageContainer extends LitElement {
 			}
 		}
 
-		// After render, do initial canvas paint if blob is visible
-		if (this._blobVisible) {
-			// Use requestAnimationFrame to ensure DOM is rendered
-			requestAnimationFrame(() => {
-				this._repaintSprite();
-				this._repaintAllAccessories();
-			});
+		// Repaint canvases only when blob state actually changed (e.g. hidden→visible)
+		// The eye timer handles ongoing repaints during animation.
+		if (this._blobState !== this._prevBlobState) {
+			this._prevBlobState = this._blobState;
+			if (this._blobVisible) {
+				requestAnimationFrame(() => {
+					this._repaintSprite();
+					this._repaintAllAccessories();
+				});
+			}
 		}
 	}
 

--- a/src/ui/components/StreamingMessageContainer.ts
+++ b/src/ui/components/StreamingMessageContainer.ts
@@ -154,7 +154,7 @@ export class StreamingMessageContainer extends LitElement {
 		if (!canvas) return;
 		drawBobbitSprite(canvas, {
 			eyeState: this._eyeState,
-			scale: 4,
+			scale: 1,
 		});
 	}
 
@@ -171,7 +171,7 @@ export class StreamingMessageContainer extends LitElement {
 		const lookingUp = eyeState === 'up' || eyeState === 'blink-up';
 		const excludeTail = facingRight || lookingUp;
 
-		drawAccessoryCanvas(canvas, 'bandana', { scale: 4, excludeTail });
+		drawAccessoryCanvas(canvas, 'bandana', { scale: 1, excludeTail });
 
 		// Translate shift for eyes-up state (per design doc)
 		if (lookingUp) {
@@ -195,7 +195,7 @@ export class StreamingMessageContainer extends LitElement {
 			if (accId === 'bandana') {
 				this._repaintBandana();
 			} else {
-				drawAccessoryCanvas(canvas, accId, { scale: 4 });
+				drawAccessoryCanvas(canvas, accId, { scale: 1 });
 			}
 		}
 	}


### PR DESCRIPTION
Replace CSS box-shadow pixel-art sprites with canvas + fillRect rendering for crisp display at all DPR values (1.25x, 1.5x, 1.75x, 2x).

## Changes
- **New**: `src/ui/bobbit-sprite-data.ts` (pixel data, eye states, timing schedules, palettes), `src/ui/bobbit-sprite.ts` (canvas renderer, BobbitEyeTimer, Lit directive, DPR listener)
- **Modified**: StreamingMessageContainer.ts (canvas elements + eye timer), app.css (-500 lines of box-shadow/keyframes), session-colors.ts (single canvas via directive), role-manager-page.ts (eye delay stagger), role-manager.css (canvas-compatible CSS)

## Approach
Hybrid canvas/CSS: canvas handles sharp pixel rasterization, CSS handles all movement/squash/enter/exit animations. DPR-aware sizing ensures integer device pixels at every scale factor. Eye animations driven by JS timer matching exact CSS keyframe percentages.

## Verification
- npm run check passes
- 279/279 unit tests pass  
- 266/266 E2E tests pass
- 4 rounds of automated code review (gap analysis, code quality, security) all passed