### PR TITLE
Fix 200k compaction bug

### DIFF
--- a/src/server/agent/aigw-manager.ts
+++ b/src/server/agent/aigw-manager.ts
@@ -17,6 +17,7 @@ import https from "node:https";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { fileURLToPath } from "node:url";
 import type { PreferencesStore } from "./preferences-store.js";
 
 // ── Types ──────────────────────────────────────────────────────────
@@ -225,6 +226,90 @@ function writeModelsJson(data: Record<string, any>): void {
 		console.log(`[aigw-manager] Wrote models.json to ${p}`);
 	} catch (err) {
 		console.error("[aigw-manager] Failed to write models.json:", err);
+	}
+}
+
+/**
+ * Parse model IDs from pi-ai's models.generated.js, grouped by provider.
+ * Reads the file as text and extracts id+provider pairs via regex.
+ */
+function parseModelsGenerated(): Map<string, string[]> {
+	const providerModels = new Map<string, string[]>();
+	try {
+		const pkgUrl = import.meta.resolve("@mariozechner/pi-ai");
+		const pkgDir = path.dirname(fileURLToPath(pkgUrl));
+		const modelsPath = path.join(pkgDir, "models.generated.js");
+		const text = fs.readFileSync(modelsPath, "utf-8");
+
+		// The file has entries like:
+		//   "some-model-id": {
+		//       id: "some-model-id",
+		//       ...
+		//       provider: "amazon-bedrock",
+		// We extract (id, provider) pairs.
+		const entryRegex = /"([^"]+)":\s*\{[^}]*?provider:\s*"([^"]+)"/g;
+		let match: RegExpExecArray | null;
+		while ((match = entryRegex.exec(text)) !== null) {
+			const modelId = match[1];
+			const provider = match[2];
+			if (!providerModels.has(provider)) providerModels.set(provider, []);
+			providerModels.get(provider)!.push(modelId);
+		}
+	} catch (err) {
+		console.error("[aigw-manager] Failed to parse models.generated.js:", err);
+	}
+	return providerModels;
+}
+
+/**
+ * Write contextWindow overrides to models.json for all Claude models where
+ * inferMeta() returns a larger context window than the built-in 200k.
+ *
+ * This fixes the 200k compaction bug: pi-ai hardcodes contextWindow: 200000
+ * for all Claude models, but Sonnet/Opus actually support 1M tokens.
+ * The modelOverrides in models.json tell pi-coding-agent to use the correct value.
+ *
+ * Preserves existing user modelOverrides — only sets contextWindow if the user
+ * hasn't already overridden it for that model.
+ */
+export function writeContextWindowOverrides(): void {
+	const providerModels = parseModelsGenerated();
+	const targetProviders = ["amazon-bedrock", "anthropic"];
+
+	const data = readModelsJson();
+	if (!data.providers) data.providers = {};
+
+	let overridesWritten = 0;
+
+	for (const provider of targetProviders) {
+		const modelIds = providerModels.get(provider) || [];
+		const claudeIds = modelIds.filter(id => id.toLowerCase().includes("claude"));
+
+		if (claudeIds.length === 0) continue;
+
+		if (!data.providers[provider]) data.providers[provider] = {};
+		if (!data.providers[provider].modelOverrides) data.providers[provider].modelOverrides = {};
+
+		const overrides = data.providers[provider].modelOverrides;
+
+		for (const modelId of claudeIds) {
+			const meta = inferMeta(modelId);
+			if (meta.contextWindow > 200_000) {
+				// Don't clobber existing user contextWindow override
+				if (overrides[modelId]?.contextWindow !== undefined) continue;
+
+				if (!overrides[modelId]) overrides[modelId] = {};
+				overrides[modelId].contextWindow = meta.contextWindow;
+				overridesWritten++;
+			}
+		}
+	}
+
+	if (overridesWritten > 0) {
+		writeModelsJson(data);
+		console.log(`[aigw-manager] Wrote ${overridesWritten} contextWindow overrides to models.json`);
+	} else {
+		console.log("[aigw-manager] No contextWindow overrides needed");
 	}
 }
 
@@ -529,8 +614,8 @@ export async function discoverAigwModels(baseUrl: string): Promise<AigwModel[]> 
 			api: "openai-completions",
 			reasoning: meta.reasoning,
 			input: meta.input,
-			contextWindow: ctxFromGw || meta.contextWindow,
-			maxTokens: maxTokFromGw || meta.maxTokens,
+			contextWindow: Math.max(ctxFromGw || 0, meta.contextWindow),
+			maxTokens: Math.max(maxTokFromGw || 0, meta.maxTokens),
 			...(meta.compat ? { compat: meta.compat } : {}),
 		};
 	});

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -35,7 +35,7 @@ import { StaffManager } from "./agent/staff-manager.js";
 import { TriggerEngine } from "./agent/staff-trigger-engine.js";
 import { PreferencesStore } from "./agent/preferences-store.js";
 import { ProjectConfigStore } from "./agent/project-config-store.js";
-import { configureAigw, removeAigw, getAigwUrl, getAigwModels, discoverAigwModels, proxyRequest, startupAigwCheck } from "./agent/aigw-manager.js";
+import { configureAigw, removeAigw, getAigwUrl, getAigwModels, discoverAigwModels, proxyRequest, startupAigwCheck, writeContextWindowOverrides } from "./agent/aigw-manager.js";
 
 const VALID_TASK_STATES = new Set<string>(["todo", "in-progress", "blocked", "complete", "skipped"]);
 
@@ -336,6 +336,7 @@ export function createGateway(config: GatewayConfig) {
 			// Runs before session restore so models.json is written before
 			// any agent subprocesses start.
 			await startupAigwCheck(preferencesStore);
+			writeContextWindowOverrides();
 
 			// Restore persisted sessions before accepting connections
 			await sessionManager.restoreSessions();

--- a/tests/e2e/context-window-overrides.spec.ts
+++ b/tests/e2e/context-window-overrides.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * E2E test: Verify that Bobbit writes contextWindow overrides to models.json
+ * for Claude models whose built-in pi-ai context window is too low (200k
+ * instead of 1M).
+ *
+ * This test FAILS on unfixed code — proving the 200k compaction bug exists.
+ */
+
+import { test, expect } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+/**
+ * Resolve the models.json path the same way aigw-manager does:
+ * PI_CODING_AGENT_DIR env → ~/.pi/agent
+ */
+function getModelsJsonPath(): string {
+	const envDir = process.env.PI_CODING_AGENT_DIR;
+	let agentDir: string;
+	if (envDir) {
+		if (envDir === "~") agentDir = homedir();
+		else if (envDir.startsWith("~/")) agentDir = homedir() + envDir.slice(1);
+		else agentDir = envDir;
+	} else {
+		agentDir = join(homedir(), ".pi", "agent");
+	}
+	return join(agentDir, "models.json");
+}
+
+test.describe("Context window overrides in models.json", () => {
+	test("server writes contextWindow overrides for Claude Sonnet/Opus models", async () => {
+		// The E2E gateway has already started by this point (Playwright webServer).
+		// Read models.json that the server should have written overrides to.
+		const modelsPath = getModelsJsonPath();
+
+		let data: Record<string, any> = { providers: {} };
+		try {
+			data = JSON.parse(readFileSync(modelsPath, "utf-8"));
+		} catch {
+			// File may not exist — that's the bug
+		}
+
+		const providers = data.providers || {};
+
+		// Check amazon-bedrock provider
+		const bedrock = providers["amazon-bedrock"] || {};
+		const bedrockOverrides = bedrock.modelOverrides || {};
+
+		// Check anthropic provider
+		const anthropic = providers["anthropic"] || {};
+		const anthropicOverrides = anthropic.modelOverrides || {};
+
+		// Find any Claude Sonnet or Opus override with contextWindow: 1000000
+		// in either provider. The fix should write these for all known models.
+		const hasSonnetBedrockOverride = Object.entries(bedrockOverrides).some(
+			([key, val]: [string, any]) =>
+				key.toLowerCase().includes("claude-sonnet") &&
+				val?.contextWindow === 1_000_000,
+		);
+
+		const hasOpusBedrockOverride = Object.entries(bedrockOverrides).some(
+			([key, val]: [string, any]) =>
+				key.toLowerCase().includes("claude-opus") &&
+				val?.contextWindow === 1_000_000,
+		);
+
+		const hasSonnetAnthropicOverride = Object.entries(anthropicOverrides).some(
+			([key, val]: [string, any]) =>
+				key.toLowerCase().includes("claude-sonnet") &&
+				val?.contextWindow === 1_000_000,
+		);
+
+		const hasOpusAnthropicOverride = Object.entries(anthropicOverrides).some(
+			([key, val]: [string, any]) =>
+				key.toLowerCase().includes("claude-opus") &&
+				val?.contextWindow === 1_000_000,
+		);
+
+		// At least one Sonnet and one Opus override must exist in each provider.
+		// This assertion will FAIL on unfixed code because no overrides are written.
+		const allPresent =
+			hasSonnetBedrockOverride &&
+			hasOpusBedrockOverride &&
+			hasSonnetAnthropicOverride &&
+			hasOpusAnthropicOverride;
+
+		expect(allPresent, "Expected contextWindow override for Claude models in amazon-bedrock and anthropic providers of models.json").toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

All Claude models were triggering auto-compaction at ~184k tokens instead of utilizing their full 1M context window. Pi-ai's `models.generated.js` hardcodes `contextWindow: 200000` for every Claude model, causing pi-coding-agent's `shouldCompact()` to trigger at ~184k.

## Changes

### `src/server/agent/aigw-manager.ts`
- **New `writeContextWindowOverrides()`** — At startup, parses pi-ai's `models.generated.js` to discover Claude model IDs, writes `modelOverrides` to `~/.pi/agent/models.json` for models where `inferMeta()` returns contextWindow > 200k (Sonnet/Opus get 1M). Preserves existing user overrides.
- **Fixed `discoverAigwModels()`** — Changed `ctxFromGw || meta.contextWindow` to `Math.max(ctxFromGw || 0, meta.contextWindow)` so Bobbit's known-correct 1M value wins even if a gateway reports 200k.

### `src/server/server.ts`
- Calls `writeContextWindowOverrides()` at startup after `startupAigwCheck()`.

### `tests/e2e/context-window-overrides.spec.ts` (new)
- E2E regression test verifying models.json contains correct contextWindow overrides.

## Test Results
- 281/281 unit tests pass
- 268/268 E2E tests pass