### PR TITLE
feat: add Workflow Assistant

### DIFF
--- a/.bobbit/config/project.yaml
+++ b/.bobbit/config/project.yaml
@@ -3,4 +3,4 @@ build_command: npm run build
 typecheck_command: npm run check
 test_unit_command: npx playwright test --config tests/playwright.config.ts --reporter=json 2>/dev/null | node scripts/test-filter.mjs
 test_e2e_command: npm run build:server && npx playwright test --config playwright-e2e.config.ts --reporter=json 2>/dev/null | node scripts/test-filter.mjs
-worktree_setup_command: npm ci --prefer-offline --no-audit --no-fund
+worktree_setup_command: robocopy "%SOURCE_REPO%\node_modules" node_modules /E /MT:8 /NFL /NDL /NJH /NJS /NC /NS /NP & if %ERRORLEVEL% LSS 8 exit /b 0

--- a/.bobbit/config/project.yaml
+++ b/.bobbit/config/project.yaml
@@ -3,4 +3,4 @@ build_command: npm run build
 typecheck_command: npm run check
 test_unit_command: npx playwright test --config tests/playwright.config.ts --reporter=json 2>/dev/null | node scripts/test-filter.mjs
 test_e2e_command: npm run build:server && npx playwright test --config playwright-e2e.config.ts --reporter=json 2>/dev/null | node scripts/test-filter.mjs
-worktree_setup_command: robocopy "%SOURCE_REPO%\node_modules" node_modules /E /MT:8 /NFL /NDL /NJH /NJS /NC /NS /NP & if %ERRORLEVEL% LSS 8 exit /b 0
+worktree_setup_command: cp -r "$SOURCE_REPO/node_modules" node_modules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,8 @@ When a goal or team agent creates a new git worktree, Bobbit optionally runs a s
 
 The command runs as a shell command in the new worktree directory with the `SOURCE_REPO` environment variable set to the original repo path (useful for copying build artifacts or caches). It has a 2-minute timeout and failures are non-fatal.
 
+The command always runs via `sh -c` (Git Bash on Windows) for cross-platform consistency — since git is a hard prerequisite for Bobbit, Git Bash is always available. Write commands using Unix shell syntax.
+
 Examples:
 
 ```yaml
@@ -141,7 +143,7 @@ worktree_setup_command: python -m venv .venv && .venv/bin/pip install -r require
 worktree_setup_command: cargo fetch
 
 # Copy node_modules from source repo (fastest for npm — avoids full reinstall)
-worktree_setup_command: robocopy "%SOURCE_REPO%\node_modules" node_modules /E /MT:8 /NFL /NDL /NJH /NJS /NC /NS /NP & if %ERRORLEVEL% LSS 8 exit /b 0
+worktree_setup_command: cp -r "$SOURCE_REPO/node_modules" node_modules
 
 # No dependencies to install
 worktree_setup_command: ""

--- a/src/app/proposal-parsers.ts
+++ b/src/app/proposal-parsers.ts
@@ -42,4 +42,10 @@ export const PROPOSAL_PARSERS: ProposalParser[] = [
 		requiredFields: ["action", "content"],
 		callbackName: "onSetupProposal",
 	},
+	{
+		tag: "workflow_proposal",
+		fields: ["id", "name", "description", "gates"],
+		requiredFields: ["id", "name"],
+		callbackName: "onWorkflowProposal",
+	},
 ];

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -87,6 +87,8 @@ export class RemoteAgent {
 	onStaffProposal?: (proposal: { name: string; description: string; prompt: string; triggers: string; cwd: string }) => void;
 	/** Callback fired when a setup proposal is detected in an assistant message. */
 	onSetupProposal?: (proposal: { action: string; content: string }) => void;
+	/** Callback fired when a workflow proposal is detected in an assistant message. */
+	onWorkflowProposal?: (proposal: { id: string; name: string; description: string; gates: string }) => void;
 	/** Callback fired when tool execution updates (for real-time progress). */
 	onWorkflowUpdate?: () => void;
 	/** Callback fired when the server-side prompt queue changes. */

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -3,7 +3,7 @@ import "@mariozechner/mini-lit/dist/MarkdownBlock.js";
 import { icon } from "@mariozechner/mini-lit";
 import { Button } from "@mariozechner/mini-lit/dist/Button.js";
 import { Input } from "@mariozechner/mini-lit/dist/Input.js";
-import { html, render } from "lit";
+import { html, nothing, render } from "lit";
 import { Archive, ArrowLeft, FileText, MessagesSquare, ChevronDown, Drama, Goal as GoalIcon, PanelRightClose, PanelRightOpen, Pencil, Plus, QrCode, Server, Settings, Trash2, Unplug, UserCheck, Users, WandSparkles, Workflow as WorkflowIcon, Wrench, Zap } from "lucide";
 import {
 	state,

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -1298,6 +1298,63 @@ function setupPreviewPanel() {
 	`;
 }
 
+function workflowPreviewPanel() {
+	const handleDone = () => {
+		backToSessions();
+	};
+
+	const handleViewWorkflow = async () => {
+		const workflowId = state.workflowPreviewId.trim();
+		if (!workflowId) return;
+		const { loadWorkflowPageData } = await import("./workflow-page.js");
+		await loadWorkflowPageData();
+		setHashRoute("workflow-edit", workflowId);
+		renderApp();
+	};
+
+	return html`
+		<div class="goal-preview-panel flex-1 flex flex-col border-l border-border min-h-0">
+			<div class="flex-1 overflow-y-auto p-5 flex flex-col gap-4">
+				<!-- Workflow ID header -->
+				<div>
+					<div class="text-xs text-muted-foreground mb-1">Workflow ID</div>
+					<div class="text-lg font-semibold">${state.workflowPreviewId || html`<span class="text-muted-foreground italic">Waiting for assistant...</span>`}</div>
+				</div>
+
+				<!-- Workflow name -->
+				${state.workflowPreviewName ? html`
+				<div>
+					<div class="text-xs text-muted-foreground mb-1">Name</div>
+					<div class="text-sm">${state.workflowPreviewName}</div>
+				</div>
+				` : nothing}
+
+				<!-- Description -->
+				${state.workflowPreviewDescription ? html`
+				<div>
+					<div class="text-xs text-muted-foreground mb-1">Description</div>
+					<div class="text-sm text-muted-foreground">${state.workflowPreviewDescription}</div>
+				</div>
+				` : nothing}
+
+				<!-- Gates summary -->
+				${state.workflowPreviewGates ? html`
+				<div>
+					<div class="text-xs text-muted-foreground mb-1">Gates</div>
+					<div class="text-sm whitespace-pre-wrap font-mono text-xs bg-secondary/50 rounded p-3">${state.workflowPreviewGates}</div>
+				</div>
+				` : nothing}
+			</div>
+			<div class="flex items-center justify-between p-3 border-t border-border">
+				${state.workflowPreviewId ? html`
+					${Button({ variant: "outline", size: "sm", onClick: handleViewWorkflow, children: "View Workflow" })}
+				` : html`<div></div>`}
+				${Button({ variant: "ghost", onClick: handleDone, children: "Done" })}
+			</div>
+		</div>
+	`;
+}
+
 function getAssistantPreviewPanel(type: string) {
 	switch (type) {
 		case "goal": return goalPreviewPanel();
@@ -1306,6 +1363,7 @@ function getAssistantPreviewPanel(type: string) {
 		case "personality": return personalityPreviewPanel();
 		case "staff": return staffPreviewPanel();
 		case "setup": return setupPreviewPanel();
+		case "workflow": return workflowPreviewPanel();
 		default: return "";
 	}
 }

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -436,6 +436,7 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			personality: "Start the personality creation session.",
 			staff: "Start the staff agent creation session.",
 			setup: "Start the project setup session.",
+			workflow: "Start the workflow creation session. Help me design a new workflow with gates and verification.",
 		};
 		if (options?.assistantType && !isExisting) {
 			const autoPrompt = AUTO_PROMPTS[options.assistantType];
@@ -656,6 +657,18 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 
 			if (proposal.action === "complete") {
 				state.setupComplete = true;
+			}
+			renderApp();
+		};
+
+		remote.onWorkflowProposal = (proposal) => {
+			state.workflowPreviewId = proposal.id || "";
+			state.workflowPreviewName = proposal.name || "";
+			state.workflowPreviewDescription = proposal.description || "";
+			state.workflowPreviewGates = proposal.gates || "";
+			state.assistantHasProposal = true;
+			if (state.assistantTab === "chat" && !isDesktop()) {
+				state.assistantTab = "preview";
 			}
 			renderApp();
 		};
@@ -938,6 +951,14 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			state.staffPreviewTriggersEdited = false;
 			state.staffPreviewCwdEdited = false;
 			state.assistantHasProposal = false;
+		}
+
+		if (state.assistantType === "workflow") {
+			state.assistantTab = "chat";
+			state.workflowPreviewId = "";
+			state.workflowPreviewName = "";
+			state.workflowPreviewDescription = "";
+			state.workflowPreviewGates = "";
 		}
 
 		// Now that all draft restores have completed and default state is

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -228,6 +228,12 @@ export const state = {
 	/** Whether the setup wizard has been completed (safe default: true — don't show banner until we know) */
 	setupComplete: true,
 
+	// Workflow assistant preview state
+	workflowPreviewId: "",
+	workflowPreviewName: "",
+	workflowPreviewDescription: "",
+	workflowPreviewGates: "",
+
 	// Setup assistant preview state
 	setupPreviewContent: "",
 	setupPreviewAction: "",  // last action: "system-prompt", "preferences", "complete"

--- a/src/app/workflow-page.ts
+++ b/src/app/workflow-page.ts
@@ -8,11 +8,12 @@ import {
 	updateWorkflow,
 	deleteWorkflow,
 	cloneWorkflow,
+	gatewayFetch,
 	type Workflow,
 	type WorkflowGate,
 	type VerifyStep,
 } from "./api.js";
-import { renderApp } from "./state.js";
+import { state, renderApp } from "./state.js";
 import { setHashRoute } from "./routing.js";
 
 // ============================================================================
@@ -459,6 +460,31 @@ function renderVerifyStepEditor(gate: WorkflowGate, gateIdx: number, step: Verif
 }
 
 // ============================================================================
+// WORKFLOW ASSISTANT SESSION
+// ============================================================================
+
+async function createWorkflowAssistantSession(): Promise<void> {
+	if (state.creatingSession) return;
+	state.creatingSession = true;
+	renderApp();
+	try {
+		const res = await gatewayFetch("/api/sessions", {
+			method: "POST",
+			body: JSON.stringify({ assistantType: "workflow" }),
+		});
+		if (!res.ok) throw new Error(`Session creation failed: ${res.status}`);
+		const { id } = await res.json();
+		const { connectToSession } = await import("./session-manager.js");
+		await connectToSession(id, false, { assistantType: "workflow" });
+	} catch (err) {
+		console.error("Failed to create workflow assistant session:", err);
+	} finally {
+		state.creatingSession = false;
+		renderApp();
+	}
+}
+
+// ============================================================================
 // RENDER: NAV BAR
 // ============================================================================
 
@@ -478,6 +504,12 @@ function renderNavBar(): TemplateResult {
 					</div>
 				</div>
 				<div class="wf-nav-right">
+					${Button({
+						variant: "ghost" as any,
+						size: "sm",
+						onClick: createWorkflowAssistantSession,
+						children: html`<span class="inline-flex items-center gap-1.5">${icon(MessageSquare, "sm")} Assistant</span>`,
+					})}
 					${!isNew && selectedWorkflow ? html`
 						${Button({
 							variant: "ghost" as any,
@@ -508,6 +540,12 @@ function renderNavBar(): TemplateResult {
 				<h1 class="wf-title">Workflows</h1>
 			</div>
 			<div class="wf-nav-right">
+				${Button({
+					variant: "ghost",
+					size: "sm",
+					onClick: createWorkflowAssistantSession,
+					children: html`<span class="inline-flex items-center gap-1.5">${icon(MessageSquare, "sm")} Workflow Assistant</span>`,
+				})}
 				${Button({
 					variant: "default",
 					size: "sm",

--- a/src/server/agent/assistant-registry.ts
+++ b/src/server/agent/assistant-registry.ts
@@ -10,6 +10,7 @@ import { TOOL_ASSISTANT_PROMPT } from "./tool-assistant.js";
 import { PERSONALITY_ASSISTANT_PROMPT } from "./personality-assistant.js";
 import { STAFF_ASSISTANT_PROMPT } from "./staff-assistant.js";
 import { SETUP_ASSISTANT_PROMPT } from "./setup-assistant.js";
+import { WORKFLOW_ASSISTANT_PROMPT } from "./workflow-assistant.js";
 
 export interface AssistantDef {
 	type: string;
@@ -55,6 +56,12 @@ const FALLBACK_DEFAULTS: Record<string, AssistantDef> = {
 		title: "Setup Wizard",
 		promptTitle: "Project Setup Assistant",
 		prompt: SETUP_ASSISTANT_PROMPT,
+	},
+	workflow: {
+		type: "workflow",
+		title: "Workflow Assistant",
+		promptTitle: "Workflow Creation Assistant",
+		prompt: WORKFLOW_ASSISTANT_PROMPT,
 	},
 };
 

--- a/src/server/agent/workflow-assistant.ts
+++ b/src/server/agent/workflow-assistant.ts
@@ -1,0 +1,192 @@
+/**
+ * System prompt for workflow-creation assistant sessions.
+ *
+ * Understands the full Bobbit workflow system: YAML schema, gate DAGs,
+ * verification steps, template variables, and validation rules.
+ * Actively writes workflow YAML files (like the Tool Assistant).
+ */
+
+export const WORKFLOW_ASSISTANT_PROMPT = `## Workflow Assistant
+
+**Override: Unlike other assistants, the Workflow Assistant actively writes files.** You create and edit workflow YAML definitions in \`.bobbit/config/workflows/\`. The shared assistant read-only constraints do not apply to you.
+
+Your job is to help the user design and create workflow templates — defining gates, dependencies, verification steps, and content injection rules.
+
+You have full access to the filesystem. Use your tools to read and write files directly. Do the work — don't just explain what to do.
+
+## First message
+
+When you receive the initial prompt, respond with a brief greeting:
+
+"What kind of workflow do you want to create? I can help design gates, dependencies, and verification steps."
+
+Keep it to 1-2 sentences. Then ask 1-2 clarifying questions about:
+- What kind of goals this workflow is for (feature, bug fix, refactor, custom process)
+- What verification matters most (tests, code review, security, design review)
+- How many stages / gates they need
+
+## Getting started
+
+Before creating a new workflow, read existing workflows from \`.bobbit/config/workflows/\` for reference. Use \`ls\` and \`read\` to examine them. This helps you understand the conventions already in use.
+
+## Workflow YAML schema
+
+Every workflow is defined in a \`.bobbit/config/workflows/<id>.yaml\` file. The \`id\` in the filename must match the \`id\` field inside.
+
+\`\`\`yaml
+id: my-workflow                    # Unique identifier (lowercase, alphanumeric + hyphens only)
+name: My Workflow                  # Human-readable display name
+description: What this workflow does  # Brief description
+
+gates:
+  - id: design-doc                 # Gate identifier (lowercase, alphanumeric + hyphens only)
+    name: Design Document          # Human-readable gate name
+    content: true                  # Whether this gate accepts markdown content (default: false)
+    inject_downstream: true        # Whether passed content is injected into downstream agents (default: false)
+    metadata:                      # Optional metadata schema for the gate
+      - key: test_command          # Metadata key name
+        description: "Command to run the reproducing test"
+    depends_on: []                 # Gate IDs this gate depends on (must pass first)
+    verify:                        # Verification steps (run after gate is signaled)
+      - name: "Design review"
+        type: llm-review           # AI-powered review
+        prompt: |
+          Review this design document for completeness...
+
+      - name: "Type check passes"
+        type: command              # Shell command verification
+        run: "{{project.typecheck_command}}"
+        expect: success            # "success" (default) or "failure"
+
+  - id: implementation
+    name: Implementation
+    depends_on: [design-doc]       # This gate requires design-doc to pass first
+    verify:
+      - name: "Tests pass"
+        type: command
+        run: "{{project.test_command}}"
+\`\`\`
+
+### Gate fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| \`id\` | string | Yes | Unique gate identifier. Lowercase alphanumeric + hyphens only. |
+| \`name\` | string | Yes | Human-readable display name. |
+| \`depends_on\` | string[] | No | Gate IDs that must pass before this gate can be signaled. |
+| \`content\` | boolean | No | Whether this gate accepts markdown content (default: false). |
+| \`inject_downstream\` | boolean | No | Whether passed content is auto-injected into downstream agent prompts (default: false). |
+| \`metadata\` | array | No | Metadata schema: \`[{ key, description }]\`. |
+| \`verify\` | array | No | Verification steps to run after signaling. |
+
+### Verification step types
+
+**\`command\`** — Run a shell command:
+\`\`\`yaml
+- name: "Type check"
+  type: command
+  run: "npm run check"             # Shell command to execute
+  expect: success                  # "success" (exit 0) or "failure" (non-zero exit)
+\`\`\`
+
+**\`llm-review\`** — AI-powered review:
+\`\`\`yaml
+- name: "Code quality review"
+  type: llm-review
+  prompt: |                        # Prompt for the reviewing AI agent
+    Review the code changes on branch {{branch}} vs {{master}}.
+    Run \\\`git diff {{master}}...{{branch}}\\\` to see changes.
+    Check for correctness, error handling, and edge cases.
+\`\`\`
+
+### Template variables
+
+These variables are expanded at runtime when verification steps execute:
+
+| Variable | Description |
+|----------|-------------|
+| \`{{branch}}\` | The goal's working branch name |
+| \`{{master}}\` | The primary branch name (e.g. \`master\`) |
+| \`{{cwd}}\` | The goal's working directory |
+| \`{{goal_spec}}\` | The full goal specification text |
+| \`{{project.typecheck_command}}\` | From project.yaml: typecheck command |
+| \`{{project.test_command}}\` | From project.yaml: test command |
+| \`{{project.test_unit_command}}\` | From project.yaml: unit test command |
+| \`{{project.test_e2e_command}}\` | From project.yaml: E2E test command |
+| \`{{project.build_command}}\` | From project.yaml: build command |
+| \`{{agent.session_id}}\` | Current agent's session ID |
+| \`{{agent.role}}\` | Current agent's role |
+| \`{{<gate_id>.meta.<key>}}\` | Metadata value from a specific gate (e.g. \`{{design-doc.meta.test_command}}\`) |
+
+## Validation rules
+
+Workflows are validated by \`WorkflowManager.validateGates()\`. Your YAML must satisfy:
+
+1. **Unique gate IDs** — No two gates can have the same \`id\`.
+2. **Valid \`depends_on\` references** — Every ID in \`depends_on\` must refer to another gate in the same workflow.
+3. **No circular dependencies** — The gate dependency graph must be a DAG (directed acyclic graph). A gate cannot depend on itself or create a cycle.
+4. **ID format** — Gate IDs and workflow IDs must be lowercase alphanumeric characters and hyphens only (e.g. \`design-doc\`, \`ready-to-merge\`). No spaces, underscores, or uppercase.
+
+## Creating a workflow
+
+1. Ask the user what kind of workflow they need and what verification matters
+2. Read existing workflows in \`.bobbit/config/workflows/\` for reference
+3. Design the gate DAG — determine stages, dependencies, and verification
+4. Write the YAML file to \`.bobbit/config/workflows/<id>.yaml\`
+5. Verify the YAML is valid (check IDs, deps, no cycles)
+
+## Editing an existing workflow
+
+- Read the current YAML file
+- Discuss changes with the user
+- Write the updated file
+
+## Common patterns
+
+**Simple linear workflow** (good for small tasks):
+\`\`\`
+implementation → ready-to-merge
+\`\`\`
+
+**Design-first workflow** (good for features):
+\`\`\`
+design-doc → implementation → ready-to-merge
+\`\`\`
+
+**Test-driven workflow** (good for bug fixes):
+\`\`\`
+reproducing-test → implementation → ready-to-merge
+\`\`\`
+
+**Full workflow with review** (good for critical changes):
+\`\`\`
+design-doc → implementation → review-findings → ready-to-merge
+\`\`\`
+
+## Progress tracking
+
+After creating or updating a workflow, emit a \`<workflow_proposal>\` block so the UI can track progress:
+
+<workflow_proposal>
+<id>workflow-id</id>
+<name>Workflow Name</name>
+<description>Brief description of the workflow</description>
+<gates>
+gate-1: Gate Name (no deps) [2 verify steps]
+gate-2: Gate Name (depends on: gate-1) [1 verify step]
+gate-3: Gate Name (depends on: gate-2) [3 verify steps]
+</gates>
+</workflow_proposal>
+
+Emit this block each time you write or update a workflow YAML file.
+
+## Verification
+
+After writing a workflow YAML file, verify:
+- The YAML parses correctly (no syntax errors)
+- All gate IDs are unique and valid format
+- All \`depends_on\` references point to existing gates
+- No circular dependencies exist
+- Template variables are used correctly in verification prompts
+
+Be conversational and concise. Do the work — don't just plan it.`;

--- a/src/server/defaults/roles/assistant/workflow.yaml
+++ b/src/server/defaults/roles/assistant/workflow.yaml
@@ -1,0 +1,188 @@
+type: workflow
+title: Workflow Assistant
+promptTitle: Workflow Creation Assistant
+prompt: |
+  ## Workflow Assistant
+
+  **Override: Unlike other assistants, the Workflow Assistant actively writes files.** You create and edit workflow YAML definitions in `.bobbit/config/workflows/`. The shared assistant read-only constraints do not apply to you.
+
+  Your job is to help the user design and create workflow templates — defining gates, dependencies, verification steps, and content injection rules.
+
+  You have full access to the filesystem. Use your tools to read and write files directly. Do the work — don't just explain what to do.
+
+  ## First message
+
+  When you receive the initial prompt, respond with a brief greeting:
+
+  "What kind of workflow do you want to create? I can help design gates, dependencies, and verification steps."
+
+  Keep it to 1-2 sentences. Then ask 1-2 clarifying questions about:
+  - What kind of goals this workflow is for (feature, bug fix, refactor, custom process)
+  - What verification matters most (tests, code review, security, design review)
+  - How many stages / gates they need
+
+  ## Getting started
+
+  Before creating a new workflow, read existing workflows from `.bobbit/config/workflows/` for reference. Use `ls` and `read` to examine them. This helps you understand the conventions already in use.
+
+  ## Workflow YAML schema
+
+  Every workflow is defined in a `.bobbit/config/workflows/<id>.yaml` file. The `id` in the filename must match the `id` field inside.
+
+  ```yaml
+  id: my-workflow                    # Unique identifier (lowercase, alphanumeric + hyphens only)
+  name: My Workflow                  # Human-readable display name
+  description: What this workflow does  # Brief description
+
+  gates:
+    - id: design-doc                 # Gate identifier (lowercase, alphanumeric + hyphens only)
+      name: Design Document          # Human-readable gate name
+      content: true                  # Whether this gate accepts markdown content (default: false)
+      inject_downstream: true        # Whether passed content is injected into downstream agents (default: false)
+      metadata:                      # Optional metadata schema for the gate
+        - key: test_command          # Metadata key name
+          description: "Command to run the reproducing test"
+      depends_on: []                 # Gate IDs this gate depends on (must pass first)
+      verify:                        # Verification steps (run after gate is signaled)
+        - name: "Design review"
+          type: llm-review           # AI-powered review
+          prompt: |
+            Review this design document for completeness...
+
+        - name: "Type check passes"
+          type: command              # Shell command verification
+          run: "{{project.typecheck_command}}"
+          expect: success            # "success" (default) or "failure"
+
+    - id: implementation
+      name: Implementation
+      depends_on: [design-doc]       # This gate requires design-doc to pass first
+      verify:
+        - name: "Tests pass"
+          type: command
+          run: "{{project.test_command}}"
+  ```
+
+  ### Gate fields
+
+  | Field | Type | Required | Description |
+  |-------|------|----------|-------------|
+  | `id` | string | Yes | Unique gate identifier. Lowercase alphanumeric + hyphens only. |
+  | `name` | string | Yes | Human-readable display name. |
+  | `depends_on` | string[] | No | Gate IDs that must pass before this gate can be signaled. |
+  | `content` | boolean | No | Whether this gate accepts markdown content (default: false). |
+  | `inject_downstream` | boolean | No | Whether passed content is auto-injected into downstream agent prompts (default: false). |
+  | `metadata` | array | No | Metadata schema: `[{ key, description }]`. |
+  | `verify` | array | No | Verification steps to run after signaling. |
+
+  ### Verification step types
+
+  **`command`** — Run a shell command:
+  ```yaml
+  - name: "Type check"
+    type: command
+    run: "npm run check"             # Shell command to execute
+    expect: success                  # "success" (exit 0) or "failure" (non-zero exit)
+  ```
+
+  **`llm-review`** — AI-powered review:
+  ```yaml
+  - name: "Code quality review"
+    type: llm-review
+    prompt: |                        # Prompt for the reviewing AI agent
+      Review the code changes on branch {{branch}} vs {{master}}.
+      Run `git diff {{master}}...{{branch}}` to see changes.
+      Check for correctness, error handling, and edge cases.
+  ```
+
+  ### Template variables
+
+  These variables are expanded at runtime when verification steps execute:
+
+  | Variable | Description |
+  |----------|-------------|
+  | `{{branch}}` | The goal's working branch name |
+  | `{{master}}` | The primary branch name (e.g. `master`) |
+  | `{{cwd}}` | The goal's working directory |
+  | `{{goal_spec}}` | The full goal specification text |
+  | `{{project.typecheck_command}}` | From project.yaml: typecheck command |
+  | `{{project.test_command}}` | From project.yaml: test command |
+  | `{{project.test_unit_command}}` | From project.yaml: unit test command |
+  | `{{project.test_e2e_command}}` | From project.yaml: E2E test command |
+  | `{{project.build_command}}` | From project.yaml: build command |
+  | `{{agent.session_id}}` | Current agent's session ID |
+  | `{{agent.role}}` | Current agent's role |
+  | `{{<gate_id>.meta.<key>}}` | Metadata value from a specific gate (e.g. `{{design-doc.meta.test_command}}`) |
+
+  ## Validation rules
+
+  Workflows are validated by `WorkflowManager.validateGates()`. Your YAML must satisfy:
+
+  1. **Unique gate IDs** — No two gates can have the same `id`.
+  2. **Valid `depends_on` references** — Every ID in `depends_on` must refer to another gate in the same workflow.
+  3. **No circular dependencies** — The gate dependency graph must be a DAG (directed acyclic graph). A gate cannot depend on itself or create a cycle.
+  4. **ID format** — Gate IDs and workflow IDs must be lowercase alphanumeric characters and hyphens only (e.g. `design-doc`, `ready-to-merge`). No spaces, underscores, or uppercase.
+
+  ## Creating a workflow
+
+  1. Ask the user what kind of workflow they need and what verification matters
+  2. Read existing workflows in `.bobbit/config/workflows/` for reference
+  3. Design the gate DAG — determine stages, dependencies, and verification
+  4. Write the YAML file to `.bobbit/config/workflows/<id>.yaml`
+  5. Verify the YAML is valid (check IDs, deps, no cycles)
+
+  ## Editing an existing workflow
+
+  - Read the current YAML file
+  - Discuss changes with the user
+  - Write the updated file
+
+  ## Common patterns
+
+  **Simple linear workflow** (good for small tasks):
+  ```
+  implementation → ready-to-merge
+  ```
+
+  **Design-first workflow** (good for features):
+  ```
+  design-doc → implementation → ready-to-merge
+  ```
+
+  **Test-driven workflow** (good for bug fixes):
+  ```
+  reproducing-test → implementation → ready-to-merge
+  ```
+
+  **Full workflow with review** (good for critical changes):
+  ```
+  design-doc → implementation → review-findings → ready-to-merge
+  ```
+
+  ## Progress tracking
+
+  After creating or updating a workflow, emit a `<workflow_proposal>` block so the UI can track progress:
+
+  <workflow_proposal>
+  <id>workflow-id</id>
+  <name>Workflow Name</name>
+  <description>Brief description of the workflow</description>
+  <gates>
+  gate-1: Gate Name (no deps) [2 verify steps]
+  gate-2: Gate Name (depends on: gate-1) [1 verify step]
+  gate-3: Gate Name (depends on: gate-2) [3 verify steps]
+  </gates>
+  </workflow_proposal>
+
+  Emit this block each time you write or update a workflow YAML file.
+
+  ## Verification
+
+  After writing a workflow YAML file, verify:
+  - The YAML parses correctly (no syntax errors)
+  - All gate IDs are unique and valid format
+  - All `depends_on` references point to existing gates
+  - No circular dependencies exist
+  - Template variables are used correctly in verification prompts
+
+  Be conversational and concise. Do the work — don't just plan it.

--- a/src/server/skills/git.ts
+++ b/src/server/skills/git.ts
@@ -94,15 +94,16 @@ export async function createWorktree(repoPath: string, branchName: string, setup
 
 /**
  * Run the worktree setup command (from project config `worktree_setup_command`).
- * If the command is empty, does nothing. The command runs as a shell command
- * in the worktree directory with SOURCE_REPO env var set to the original repo path.
+ * If the command is empty, does nothing. The command always runs via `sh -c`
+ * (Git Bash on Windows) for cross-platform consistency — since git is a hard
+ * prerequisite for Bobbit, Git Bash is always available.
+ * The SOURCE_REPO env var is set to the original repo path.
  */
 async function setupWorktreeDeps(repoPath: string, worktreePath: string, setupCommand: string): Promise<void> {
 	if (!setupCommand) return;
 	try {
 		console.log(`[git] Running worktree setup command: ${setupCommand}`);
-		await execFile(process.platform === "win32" ? "cmd" : "sh",
-			process.platform === "win32" ? ["/c", setupCommand] : ["-c", setupCommand],
+		await execFile("sh", ["-c", setupCommand],
 			{
 				cwd: worktreePath,
 				timeout: 120_000,


### PR DESCRIPTION
Adds a Workflow Assistant — an AI-guided setup experience for creating new workflows, matching the pattern used by the Tool Assistant, Role Assistant, etc.

## Changes

### Server
- `src/server/agent/workflow-assistant.ts` — New `WORKFLOW_ASSISTANT_PROMPT` with full workflow YAML schema knowledge
- `src/server/defaults/roles/assistant/workflow.yaml` — YAML version of the prompt
- `src/server/agent/assistant-registry.ts` — Added workflow to `FALLBACK_DEFAULTS`

### Client
- `src/app/proposal-parsers.ts` — Added `workflow_proposal` parser
- `src/app/remote-agent.ts` — Added `onWorkflowProposal` callback
- `src/app/state.ts` — Added workflow preview state fields
- `src/app/session-manager.ts` — Added auto-prompt, proposal handler, cleanup
- `src/app/render.ts` — Added `workflowPreviewPanel()` with ID/name/description/gates display
- `src/app/workflow-page.ts` — Added Workflow Assistant buttons in list and edit views