### PR TITLE
Configurable skill directories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,13 @@ If you only changed UI code (`src/ui/`, `src/app/`), unit tests are sufficient. 
 
 **Add a new tool renderer**: Create in `src/ui/tools/renderers/`, register in `src/ui/tools/index.ts`.
 
-**Add a slash skill**: Create a `SKILL.md` file in `.claude/skills/<name>/` (project-level) or `~/.claude/skills/<name>/` (personal). The file should have YAML frontmatter with `description` and optional `argument_hint`, `allowed_tools`, `context`, `agent` fields. Skills are discovered automatically via `discoverSlashSkills()` in `src/server/skills/slash-skills.ts` and served at `GET /api/slash-skills`.
+**Add a slash skill**: Create a `SKILL.md` file in `.claude/skills/<name>/` (project-level) or `~/.claude/skills/<name>/` (personal). The file should have YAML frontmatter with `description` and optional `argument_hint`, `allowed_tools`, `context`, `agent` fields. Skills are discovered automatically via `discoverSlashSkills()` in `src/server/skills/slash-skills.ts` and served at `GET /api/slash-skills`. You can also configure additional skill directories via the Skills page UI (`#/skills`) or by adding `skill_directories` to `.bobbit/config/project.yaml`:
+
+```yaml
+skill_directories: '[{"path":"~/my-team-skills"},{"path":"/shared/skills"}]'
+```
+
+The value is a JSON-encoded array of `{"path": "..."}` objects. Paths support `~` expansion. Custom directories are additive — the default directories (`.claude/skills/`, `.bobbit/skills/`, `~/.claude/skills/`, `~/.bobbit/skills/`, `.claude/commands/`) are always scanned. Skills from custom directories get source label `"custom"` and have lower priority than built-in directories (built-in skills with the same name win).
 
 **Add a goal-related feature**: Goal CRUD is in `goal-manager.ts`/`goal-store.ts`. REST endpoints in `server.ts`. Goal assistant prompt in `goal-assistant.ts`. Client-side proposal parsing in `remote-agent.ts` `_checkForGoalProposal()`.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -56,10 +56,11 @@ Personality definitions that modify agent behaviour via prompt fragments.
 
 Slash-command skills discovered from Claude Code-compatible `SKILL.md` files.
 
-- **Discovery**: Skills are found in `.claude/skills/<name>/SKILL.md` (project), `~/.claude/skills/<name>/SKILL.md` (personal), and `.claude/commands/<name>.md` (legacy).
+- **Discovery**: Skills are found in `.claude/skills/<name>/SKILL.md` (project), `~/.claude/skills/<name>/SKILL.md` (personal), `.bobbit/skills/<name>/SKILL.md` (project/personal), and `.claude/commands/<name>.md` (legacy). Additional directories can be configured via the Skills page UI or `skill_directories` in `.bobbit/config/project.yaml`.
+- **Custom directories**: Configure via the Skills page (`#/skills`) "Skill Directories" section or by setting `skill_directories` in project config. Custom directories are additive — defaults always scan. Skills from custom dirs get source `"custom"` with lower priority than built-in directories.
 - **Invocation**: Via `/skill-name` slash commands in the chat input. Skill instructions are injected into the agent's prompt.
 - **Frontmatter**: YAML frontmatter supports `description`, `argument_hint`, `allowed_tools`, `context` (e.g. `fork`), `agent`, `disable_model_invocation`, and `user_invocable`.
-- **API**: `GET /api/slash-skills` for autocomplete data, `GET /api/slash-skills/details` for full content and file paths.
+- **API**: `GET /api/slash-skills` for autocomplete data, `GET /api/slash-skills/details` for full content, file paths, and scanned directories.
 
 ## Cost Tracking
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -116,7 +116,7 @@ Routes accept both `/team/` and legacy `/swarm/` paths.
 | Method | Path | Description |
 |---|---|---|
 | `GET` | `/api/slash-skills` | Discover slash skills for autocomplete (name, description, argument hint) |
-| `GET` | `/api/slash-skills/details` | Full slash skill details including content and file paths |
+| `GET` | `/api/slash-skills/details` | Full slash skill details including content, file paths, and `directories` array listing all scanned directories (default + custom) |
 
 ### Assistant Prompts
 

--- a/src/app/skills-page.ts
+++ b/src/app/skills-page.ts
@@ -1,7 +1,7 @@
 // src/app/skills-page.ts
 import { icon } from "@mariozechner/mini-lit";
 import { html, TemplateResult } from "lit";
-import { ArrowLeft, BookOpen, FolderOpen, Zap } from "lucide";
+import { ArrowLeft, BookOpen, ChevronDown, ChevronRight, FolderOpen, Plus, X, Zap } from "lucide";
 import { renderApp } from "./state.js";
 import { gatewayFetch } from "./api.js";
 import { setHashRoute } from "./routing.js";
@@ -11,12 +11,20 @@ let slashSkills: Array<{ name: string; description: string; source: string; file
 let loading = true;
 let error = "";
 let expandedSkill: string | null = null;
+let directories: Array<{ path: string; source: string; isCustom: boolean }> = [];
+let customDirs: Array<{ path: string }> = [];
+let newDirPath = "";
+let directoriesExpanded = false;
 
 export function clearSkillsPageState(): void {
 	slashSkills = [];
 	loading = true;
 	error = "";
 	expandedSkill = null;
+	directories = [];
+	customDirs = [];
+	newDirPath = "";
+	directoriesExpanded = false;
 }
 
 export async function loadSkillsPageData(): Promise<void> {
@@ -30,8 +38,25 @@ export async function loadSkillsPageData(): Promise<void> {
 		if (slashRes.ok) {
 			const data = await slashRes.json();
 			slashSkills = data.skills || [];
+			directories = data.directories || [];
 		} else {
 			slashSkills = [];
+			directories = [];
+		}
+
+		// Load custom directories from project config
+		try {
+			const configRes = await gatewayFetch("/api/project-config");
+			if (configRes.ok) {
+				const config = await configRes.json();
+				if (config.skill_directories) {
+					try { customDirs = JSON.parse(config.skill_directories); } catch { customDirs = []; }
+				} else {
+					customDirs = [];
+				}
+			}
+		} catch {
+			// ignore config fetch errors
 		}
 	} catch (err: unknown) {
 		error = err instanceof Error ? err.message : String(err);
@@ -68,6 +93,7 @@ function sourceLabel(source: string): TemplateResult {
 		"personal": "bg-purple-500/15 text-purple-700 dark:text-purple-400",
 		"legacy": "bg-amber-500/15 text-amber-700 dark:text-amber-400",
 		"built-in": "bg-green-500/15 text-green-700 dark:text-green-400",
+		"custom": "bg-teal-500/15 text-teal-700 dark:text-teal-400",
 	};
 	const cls = colors[source] || "bg-muted text-muted-foreground";
 	return html`<span class="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full ${cls}">${source}</span>`;
@@ -101,6 +127,102 @@ function renderSkillCard(skill: typeof slashSkills[0]): TemplateResult {
 					</div>
 					<div class="rounded-md border border-border bg-background p-3 overflow-x-auto">
 						<pre class="text-xs font-mono whitespace-pre-wrap break-words text-foreground/80">${skill.content}</pre>
+					</div>
+				</div>
+			` : ""}
+		</div>
+	`;
+}
+
+async function saveCustomDirs(): Promise<void> {
+	try {
+		await gatewayFetch("/api/project-config", {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ skill_directories: JSON.stringify(customDirs) }),
+		});
+		await loadSkillsPageData();
+	} catch {
+		// ignore save errors
+	}
+}
+
+async function addCustomDir(): Promise<void> {
+	const trimmed = newDirPath.trim();
+	if (!trimmed) return;
+	customDirs = [...customDirs, { path: trimmed }];
+	newDirPath = "";
+	await saveCustomDirs();
+}
+
+async function removeCustomDir(index: number): Promise<void> {
+	customDirs = customDirs.filter((_, i) => i !== index);
+	await saveCustomDirs();
+}
+
+function renderDirectoriesSection(): TemplateResult {
+	const defaultDirs = directories.filter((d) => !d.isCustom);
+
+	return html`
+		<div class="rounded-lg border border-border overflow-hidden">
+			<button
+				class="w-full flex items-center gap-2 px-4 py-3 text-left hover:bg-secondary/30 transition-colors cursor-pointer"
+				@click=${() => { directoriesExpanded = !directoriesExpanded; renderApp(); }}
+			>
+				<span class="text-muted-foreground shrink-0">${icon(directoriesExpanded ? ChevronDown : ChevronRight, "sm")}</span>
+				<span class="text-muted-foreground shrink-0">${icon(FolderOpen, "sm")}</span>
+				<span class="text-sm font-semibold">Skill Directories</span>
+			</button>
+			${directoriesExpanded ? html`
+				<div class="border-t border-border px-4 py-3 flex flex-col gap-3">
+					<!-- Default directories -->
+					${defaultDirs.length > 0 ? html`
+						<div class="flex flex-col gap-1.5">
+							<div class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Default</div>
+							${defaultDirs.map((d) => html`
+								<div class="flex items-center gap-2 text-xs text-muted-foreground py-1 px-2 rounded bg-secondary/20">
+									<code class="flex-1 text-[11px] break-all">${d.path}</code>
+									${sourceLabel(d.source)}
+								</div>
+							`)}
+						</div>
+					` : ""}
+
+					<!-- Custom directories -->
+					<div class="flex flex-col gap-1.5">
+						<div class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Custom</div>
+						${customDirs.length > 0 ? customDirs.map((d, i) => html`
+							<div class="flex items-center gap-2 text-xs py-1 px-2 rounded bg-secondary/20">
+								<code class="flex-1 text-[11px] break-all">${d.path}</code>
+								${sourceLabel("custom")}
+								<button
+									class="p-0.5 rounded hover:bg-destructive/15 text-muted-foreground hover:text-destructive transition-colors shrink-0"
+									title="Remove directory"
+									@click=${() => removeCustomDir(i)}
+								>${icon(X, "xs")}</button>
+							</div>
+						`) : html`<div class="text-xs text-muted-foreground italic">No custom directories configured.</div>`}
+					</div>
+
+					<!-- Add row -->
+					<div class="flex items-center gap-2">
+						<input
+							type="text"
+							class="flex-1 text-xs px-2 py-1.5 rounded border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+							placeholder="~/my-skills or /absolute/path"
+							.value=${newDirPath}
+							@input=${(e: Event) => { newDirPath = (e.target as HTMLInputElement).value; renderApp(); }}
+							@keydown=${(e: KeyboardEvent) => { if (e.key === "Enter" && newDirPath.trim()) addCustomDir(); }}
+						/>
+						<button
+							class="inline-flex items-center gap-1 text-xs px-2.5 py-1.5 rounded border border-border hover:bg-secondary transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+							?disabled=${!newDirPath.trim()}
+							@click=${addCustomDir}
+						>${icon(Plus, "xs")} Add</button>
+					</div>
+
+					<div class="text-[11px] text-muted-foreground">
+						Default directories are always scanned. Custom directories are additive.
 					</div>
 				</div>
 			` : ""}
@@ -153,6 +275,8 @@ export function renderSkillsPage(): TemplateResult {
 					<div class="text-sm text-muted-foreground">
 						${total} skill${total !== 1 ? "s" : ""} available
 					</div>
+
+					${renderDirectoriesSection()}
 
 					<div>
 						<h2 class="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">

--- a/src/app/skills-page.ts
+++ b/src/app/skills-page.ts
@@ -282,7 +282,7 @@ export function renderSkillsPage(): TemplateResult {
 						<h2 class="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
 							${icon(BookOpen, "sm")}
 							Slash Skills
-							<span class="text-xs font-normal text-muted-foreground">(from .claude/skills/ and .bobbit/skills/)</span>
+							<span class="text-xs font-normal text-muted-foreground">(from .claude/skills/, .bobbit/skills/, and custom directories)</span>
 						</h2>
 						${userSkills.length > 0
 							? renderSkillList(userSkills)

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -15,7 +15,7 @@ import { RateLimiter } from "./auth/rate-limit.js";
 import { validateToken } from "./auth/token.js";
 import { oauthComplete, oauthStart, oauthStatus } from "./auth/oauth.js";
 import { handleWebSocketConnection } from "./ws/handler.js";
-import { discoverSlashSkills } from "./skills/slash-skills.js";
+import { discoverSlashSkills, getSkillDirectories } from "./skills/slash-skills.js";
 import { TeamManager, GateDependencyError } from "./agent/team-manager.js";
 import { RoleStore } from "./agent/role-store.js";
 import { RoleManager } from "./agent/role-manager.js";
@@ -2548,7 +2548,7 @@ async function handleApiRoute(
 	// GET /api/slash-skills — discover .claude/skills/ SKILL.md files for autocomplete
 	if (url.pathname === "/api/slash-skills" && req.method === "GET") {
 		const cwd = url.searchParams.get("cwd") || process.cwd();
-		const skills = discoverSlashSkills(cwd);
+		const skills = discoverSlashSkills(cwd, projectConfigStore);
 		json({ skills: skills.map((s) => ({ name: s.name, description: s.description, argumentHint: s.argumentHint, source: s.source })) });
 		return;
 	}
@@ -2556,8 +2556,9 @@ async function handleApiRoute(
 	// GET /api/slash-skills/details — full slash skill details including content and file paths
 	if (url.pathname === "/api/slash-skills/details" && req.method === "GET") {
 		const cwd = url.searchParams.get("cwd") || process.cwd();
-		const skills = discoverSlashSkills(cwd);
-		json({ skills: skills.map((s) => ({ name: s.name, description: s.description, source: s.source, filePath: s.filePath, content: s.content })) });
+		const skills = discoverSlashSkills(cwd, projectConfigStore);
+		const directories = getSkillDirectories(cwd, projectConfigStore);
+		json({ skills: skills.map((s) => ({ name: s.name, description: s.description, source: s.source, filePath: s.filePath, content: s.content })), directories });
 		return;
 	}
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -324,7 +324,7 @@ export function createGateway(config: GatewayConfig) {
 		}
 
 		wss.handleUpgrade(req, socket, head, (ws) => {
-			handleWebSocketConnection(ws, match[1], req, sessionManager, config.authToken, rateLimiter, isLocalhostServer);
+			handleWebSocketConnection(ws, match[1], req, sessionManager, config.authToken, rateLimiter, projectConfigStore, isLocalhostServer);
 		});
 	});
 

--- a/src/server/skills/slash-skills.ts
+++ b/src/server/skills/slash-skills.ts
@@ -308,8 +308,8 @@ export function discoverSlashSkills(
 }
 
 /** Look up a single slash skill by name. */
-export function getSlashSkill(cwd: string, name: string): SlashSkill | undefined {
-	return discoverSlashSkills(cwd).find((s) => s.name === name);
+export function getSlashSkill(cwd: string, name: string, projectConfigStore?: { get(key: string): string | undefined }): SlashSkill | undefined {
+	return discoverSlashSkills(cwd, projectConfigStore).find((s) => s.name === name);
 }
 
 /**

--- a/src/server/skills/slash-skills.ts
+++ b/src/server/skills/slash-skills.ts
@@ -27,8 +27,8 @@ export interface SlashSkill {
 	userInvocable?: boolean;
 	/** Raw markdown content (instructions) */
 	content: string;
-	/** Source: "project", "personal", "legacy", or "built-in" */
-	source: "project" | "personal" | "legacy" | "built-in";
+	/** Source: "project", "personal", "legacy", "built-in", or "custom" */
+	source: "project" | "personal" | "legacy" | "built-in" | "custom";
 	/** Absolute path to the SKILL.md or command .md file */
 	filePath: string;
 	/** Optional allowed tools list */
@@ -198,17 +198,71 @@ const BUILTIN_SKILLS: SlashSkill[] = [
 	},
 ];
 
+/** Parse custom skill directories from project config store. */
+function parseCustomDirectories(projectConfigStore?: { get(key: string): string | undefined }): { path: string }[] {
+	if (!projectConfigStore) return [];
+	const raw = projectConfigStore.get("skill_directories");
+	if (!raw) return [];
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (err) {
+		console.warn(`[slash-skills] Invalid skill_directories JSON, ignoring:`, err);
+		return [];
+	}
+
+	if (!Array.isArray(parsed)) return [];
+
+	return parsed.filter(
+		(entry): entry is { path: string } =>
+			typeof entry === "object" && entry !== null &&
+			typeof (entry as any).path === "string" && (entry as any).path.trim().length > 0
+	).map((entry) => ({
+		path: entry.path.startsWith("~")
+			? path.join(os.homedir(), entry.path.slice(1))
+			: entry.path,
+	}));
+}
+
+/**
+ * Get the complete list of directories scanned for slash skills.
+ * Returns both default (built-in) and custom directories.
+ */
+export function getSkillDirectories(
+	cwd: string,
+	projectConfigStore?: { get(key: string): string | undefined },
+): { path: string; source: string; isCustom: boolean }[] {
+	const dirs: { path: string; source: string; isCustom: boolean }[] = [
+		{ path: path.join(cwd, ".claude", "skills"), source: "project", isCustom: false },
+		{ path: path.join(cwd, ".bobbit", "skills"), source: "project", isCustom: false },
+		{ path: path.join(os.homedir(), ".claude", "skills"), source: "personal", isCustom: false },
+		{ path: path.join(os.homedir(), ".bobbit", "skills"), source: "personal", isCustom: false },
+		{ path: path.join(cwd, ".claude", "commands"), source: "legacy", isCustom: false },
+	];
+
+	for (const entry of parseCustomDirectories(projectConfigStore)) {
+		dirs.push({ path: entry.path, source: "custom", isCustom: true });
+	}
+
+	return dirs;
+}
+
 // Simple TTL cache
-let _cache: { skills: SlashSkill[]; cwd: string; ts: number } | null = null;
+let _cache: { skills: SlashSkill[]; cwd: string; configVal: string; ts: number } | null = null;
 const CACHE_TTL_MS = 5_000;
 
 /**
  * Discover all slash skills for a given working directory.
- * Merges project, personal, and legacy sources. Project skills take priority
- * over personal skills with the same name. Legacy commands have lowest priority.
+ * Merges project, personal, legacy, custom, and built-in sources.
+ * Priority (highest wins): project > bobbit project > personal > bobbit personal > legacy > custom > built-in.
  */
-export function discoverSlashSkills(cwd: string): SlashSkill[] {
-	if (_cache && _cache.cwd === cwd && Date.now() - _cache.ts < CACHE_TTL_MS) {
+export function discoverSlashSkills(
+	cwd: string,
+	projectConfigStore?: { get(key: string): string | undefined },
+): SlashSkill[] {
+	const configVal = projectConfigStore?.get("skill_directories") ?? "";
+	if (_cache && _cache.cwd === cwd && _cache.configVal === configVal && Date.now() - _cache.ts < CACHE_TTL_MS) {
 		return _cache.skills;
 	}
 
@@ -224,10 +278,17 @@ export function discoverSlashSkills(cwd: string): SlashSkill[] {
 	const bobbitPersonalSkills = scanSkillDir(bobbitPersonalSkillsDir, "personal");
 	const legacyCommands = scanCommandsDir(legacyCommandsDir);
 
-	// Merge with priority: project > personal > legacy > built-in
-	// .claude takes precedence over .bobbit at the same level
+	// Scan custom directories
+	const customSkills: SlashSkill[] = [];
+	for (const entry of parseCustomDirectories(projectConfigStore)) {
+		customSkills.push(...scanSkillDir(entry.path, "custom"));
+	}
+
+	// Merge with priority (lowest to highest — later insertions overwrite):
+	// built-in → custom → legacy → bobbit personal → claude personal → bobbit project → claude project
 	const byName = new Map<string, SlashSkill>();
 	for (const skill of BUILTIN_SKILLS) byName.set(skill.name, skill);
+	for (const skill of customSkills) byName.set(skill.name, skill);
 	for (const skill of legacyCommands) byName.set(skill.name, skill);
 	for (const skill of bobbitPersonalSkills) byName.set(skill.name, skill);
 	for (const skill of personalSkills) byName.set(skill.name, skill);
@@ -242,7 +303,7 @@ export function discoverSlashSkills(cwd: string): SlashSkill[] {
 	// Sort alphabetically
 	skills.sort((a, b) => a.name.localeCompare(b.name));
 
-	_cache = { skills, cwd, ts: Date.now() };
+	_cache = { skills, cwd, configVal, ts: Date.now() };
 	return skills;
 }
 

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -35,6 +35,7 @@ export function handleWebSocketConnection(
 	sessionManager: SessionManager,
 	authToken: string,
 	rateLimiter: RateLimiter,
+	projectConfigStore?: { get(key: string): string | undefined },
 	skipAuth = false,
 ): void {
 	const ip = getClientIp(req);
@@ -200,7 +201,7 @@ export function handleWebSocketConnection(
 					if (slashMatch) {
 						const skillName = slashMatch[1];
 						const skillArgs = slashMatch[2] || "";
-						const skill = getSlashSkill(session.cwd, skillName);
+						const skill = getSlashSkill(session.cwd, skillName, projectConfigStore);
 						if (skill) {
 							promptText = buildSlashSkillPrompt(skill, skillArgs);
 							console.log(`[ws-handler] Slash skill "${skillName}" invoked for session ${sessionId}`);


### PR DESCRIPTION
## Summary

Make slash skill source directories configurable via the Skills page UI and `skill_directories` in `.bobbit/config/project.yaml`.

## Changes

- **`src/server/skills/slash-skills.ts`**: Added `parseCustomDirectories()`, `getSkillDirectories()`, updated `discoverSlashSkills()` and `getSlashSkill()` to accept `projectConfigStore`. Custom dirs scanned with source `"custom"` at correct priority. Cache key includes config value for auto-invalidation.
- **`src/server/server.ts`**: Wired `projectConfigStore` to skill API endpoints. `/api/slash-skills/details` now includes `directories` array.
- **`src/server/ws/handler.ts`**: Threaded `projectConfigStore` through WebSocket handler so custom skills are invocable via `/skill-name`.
- **`src/app/skills-page.ts`**: Added collapsible "Skill Directories" section showing default (read-only) and custom (editable) directories with add/remove.
- **Docs**: Updated AGENTS.md, docs/rest-api.md, docs/features.md.

## Testing

- Type-check passes
- 305/305 E2E tests pass