### PR TITLE
Dynamic workflow list

### DIFF
--- a/src/server/agent/goal-assistant.ts
+++ b/src/server/agent/goal-assistant.ts
@@ -26,13 +26,9 @@ Keep it to 1-2 sentences. Don't explain the full process — just ask what they 
 Every goal runs with a workflow that defines the gates to pass, their dependency order, quality criteria, and verification. You should recommend the most appropriate workflow based on the goal.
 
 Available workflows:
-- **general** — Default for most goals. Design doc → implementation → test results → code review → summary report.
-- **feature** — For new features. Like general but adds a PR gate and a full feature report. Use when the goal is clearly a new feature that needs a PR.
-- **bug-fix** — For bug fixes. Issue analysis → reproducing test → implementation → code review → test results → bug fix report. Use when the goal is clearly about fixing a specific bug.
+{{AVAILABLE_WORKFLOWS}}
 
 Pick the workflow that best fits. When in doubt, use **general**.
-
-You can also check for additional workflows by reading the \`workflows/\` directory, but the three above cover most cases.
 
 ## Proposing a goal
 

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -128,6 +128,7 @@ export class SessionManager {
 	private roleManager?: RoleManager;
 	private toolManager?: ToolManager;
 	private preferencesStore?: import("./preferences-store.js").PreferencesStore;
+	private workflowStore?: import("./workflow-store.js").WorkflowStore;
 	private _onPrCreationDetected?: (session: SessionInfo) => void;
 	goalManager: GoalManager;
 	taskManager: TaskManager;
@@ -145,12 +146,25 @@ export class SessionManager {
 		this.roleManager = options?.roleManager;
 		this.toolManager = options?.toolManager;
 		this.preferencesStore = options?.preferencesStore;
+		this.workflowStore = options?.workflowStore;
 		this.goalManager = new GoalManager(options?.workflowStore);
 		this.taskManager = new TaskManager();
 	}
 
 	getCostTracker(): CostTracker {
 		return this.costTracker;
+	}
+
+	/** Build a markdown list of available workflows for the goal assistant prompt. */
+	private _buildWorkflowList(): string {
+		const workflows = this.workflowStore?.getAll();
+		if (!workflows || workflows.length === 0) {
+			return 'Use **general** as a safe default.';
+		}
+		return workflows.map(w => {
+			const gateNames = w.gates.map(g => g.name).join(', ');
+			return `- **${w.id}** (${w.name}) — ${w.description}. Gates: ${gateNames}.`;
+		}).join('\n');
 	}
 
 	/** Generate tool docs and inject into prompt parts before assembly. */
@@ -183,6 +197,9 @@ export class SessionManager {
 				assistantGoalSpec += "\n\n---\n\n";
 			}
 			assistantGoalSpec += assistantDef.prompt;
+			if (session.assistantType === "goal") {
+				assistantGoalSpec = assistantGoalSpec.replace('{{AVAILABLE_WORKFLOWS}}', this._buildWorkflowList());
+			}
 			parts = {
 				baseSystemPromptPath: undefined,
 				cwd: session.cwd,
@@ -651,6 +668,9 @@ export class SessionManager {
 				assistantGoalSpec += "\n\n---\n\n";
 			}
 			assistantGoalSpec += assistantDef.prompt;
+			if (ps.assistantType === "goal") {
+				assistantGoalSpec = assistantGoalSpec.replace('{{AVAILABLE_WORKFLOWS}}', this._buildWorkflowList());
+			}
 
 			const promptPath = this.assemblePrompt(ps.id, {
 				baseSystemPromptPath: undefined,
@@ -872,6 +892,9 @@ export class SessionManager {
 				assistantGoalSpec += "\n\n---\n\n";
 			}
 			assistantGoalSpec += assistantDef.prompt;
+			if (assistantType === "goal") {
+				assistantGoalSpec = assistantGoalSpec.replace('{{AVAILABLE_WORKFLOWS}}', this._buildWorkflowList());
+			}
 
 			// Use assistant role's tool restrictions (before assemblePrompt so tool docs are filtered correctly)
 			if (assistantRole && assistantRole.allowedTools.length > 0) {


### PR DESCRIPTION
Replace hardcoded workflow list in the goal assistant prompt with a dynamic `{{AVAILABLE_WORKFLOWS}}` placeholder populated from `WorkflowStore.getAll()` at runtime.

## Changes
- **`src/server/agent/goal-assistant.ts`** — Replaced hardcoded 3-workflow bullet list with `{{AVAILABLE_WORKFLOWS}}` placeholder; removed stale "check workflows/ directory" sentence
- **`src/server/agent/session-manager.ts`** — Added `workflowStore` field, `_buildWorkflowList()` helper, and placeholder replacement in all 3 code paths (getPromptParts, restoreSessions, createSession), gated to goal assistants only

## Behavior
- Non-hidden workflows are listed dynamically with ID, name, description, and gate names
- Hidden workflows (e.g. `test-fast`) are excluded (`getAll()` filters them)
- Falls back to "Use **general** as a safe default" if workflow store is unavailable
- Works with both hardcoded prompt and YAML override (`.bobbit/config/roles/assistant/goal.yaml`)