### PR TITLE
fix: handle legacy YAML when injecting dynamic workflow list

### DIFF
--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -167,6 +167,32 @@ export class SessionManager {
 		}).join('\n');
 	}
 
+	/**
+	 * Inject the dynamic workflow list into a goal assistant prompt.
+	 * Handles two cases:
+	 * 1. The prompt contains {{AVAILABLE_WORKFLOWS}} placeholder (new TS constant)
+	 * 2. The prompt contains the old hardcoded workflow list (legacy YAML on disk)
+	 */
+	private _injectWorkflowList(spec: string): string {
+		const dynamicList = this._buildWorkflowList();
+
+		// Case 1: New placeholder exists — simple replacement
+		if (spec.includes('{{AVAILABLE_WORKFLOWS}}')) {
+			return spec.replace('{{AVAILABLE_WORKFLOWS}}', dynamicList);
+		}
+
+		// Case 2: Old hardcoded list from legacy YAML — replace the section between
+		// "Available workflows:" and "Pick the workflow" with the dynamic list.
+		// The old pattern has bullet items starting with "- **" after "Available workflows:\n"
+		const oldListPattern = /(Available workflows:\s*\n)(?:\s*- \*\*.*\n?)+(\s*\n*(?:Pick the workflow))/s;
+		let result = spec.replace(oldListPattern, `$1${dynamicList}\n\n$2`);
+
+		// Also remove the "You can also check for additional workflows..." sentence
+		result = result.replace(/\s*You can also check for additional workflows[^\n]*(?:the three above cover most cases)?\.?\s*/g, ' ');
+
+		return result;
+	}
+
 	/** Generate tool docs and inject into prompt parts before assembly. */
 	private assemblePrompt(sessionId: string, parts: PromptParts): string | undefined {
 		if (this.toolManager && !parts.toolDocs) {
@@ -198,7 +224,7 @@ export class SessionManager {
 			}
 			assistantGoalSpec += assistantDef.prompt;
 			if (session.assistantType === "goal") {
-				assistantGoalSpec = assistantGoalSpec.replace('{{AVAILABLE_WORKFLOWS}}', this._buildWorkflowList());
+				assistantGoalSpec = this._injectWorkflowList(assistantGoalSpec);
 			}
 			parts = {
 				baseSystemPromptPath: undefined,
@@ -669,7 +695,7 @@ export class SessionManager {
 			}
 			assistantGoalSpec += assistantDef.prompt;
 			if (ps.assistantType === "goal") {
-				assistantGoalSpec = assistantGoalSpec.replace('{{AVAILABLE_WORKFLOWS}}', this._buildWorkflowList());
+				assistantGoalSpec = this._injectWorkflowList(assistantGoalSpec);
 			}
 
 			const promptPath = this.assemblePrompt(ps.id, {
@@ -893,7 +919,7 @@ export class SessionManager {
 			}
 			assistantGoalSpec += assistantDef.prompt;
 			if (assistantType === "goal") {
-				assistantGoalSpec = assistantGoalSpec.replace('{{AVAILABLE_WORKFLOWS}}', this._buildWorkflowList());
+				assistantGoalSpec = this._injectWorkflowList(assistantGoalSpec);
 			}
 
 			// Use assistant role's tool restrictions (before assemblePrompt so tool docs are filtered correctly)


### PR DESCRIPTION
## Problem

PR #94/#95 replaced the hardcoded workflow list with a `{{AVAILABLE_WORKFLOWS}}` placeholder, but `getAssistantDef()` reads from `.bobbit/config/roles/assistant/goal.yaml` first. Existing installs still have the old hardcoded list in that YAML, so the placeholder was never found and the dynamic list was never injected.

## Fix

Added `_injectWorkflowList(spec)` to `session-manager.ts` that handles both cases:
1. **New placeholder** — replaces `{{AVAILABLE_WORKFLOWS}}` directly
2. **Legacy YAML** — regex matches the old hardcoded bullet list between "Available workflows:" and "Pick the workflow", replaces with dynamic list, and strips the stale "You can also check for additional workflows" sentence

All 3 code paths now call `_injectWorkflowList()` instead of a simple `.replace()`.

## Verification
- Type check passes
- 296 unit tests pass
- 305 E2E tests pass