### PR TITLE
Goal Re-attempt Flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ skill_directories: '[{"path":"~/my-team-skills"},{"path":"/shared/skills"}]'
 
 The value is a JSON-encoded array of `{"path": "..."}` objects. Paths support `~` expansion. Custom directories are additive — the default directories (`.claude/skills/`, `.bobbit/skills/`, `~/.claude/skills/`, `~/.bobbit/skills/`, `.claude/commands/`) are always scanned. Skills from custom directories get source label `"custom"` and have lower priority than built-in directories (built-in skills with the same name win).
 
-**Add a goal-related feature**: Goal CRUD is in `goal-manager.ts`/`goal-store.ts`. REST endpoints in `server.ts`. Goal assistant prompt in `goal-assistant.ts`. Client-side proposal parsing in `remote-agent.ts` `_checkForGoalProposal()`.
+**Add a goal-related feature**: Goal CRUD is in `goal-manager.ts`/`goal-store.ts`. REST endpoints in `server.ts`. Goal assistant prompt in `goal-assistant.ts`. Client-side proposal parsing in `remote-agent.ts` `_checkForGoalProposal()`. Re-attempt flow: `buildReattemptContext()` in `goal-assistant.ts`, `startReattempt()` in `session-manager.ts` (client), re-attempt buttons in `goal-dashboard.ts` and `render-helpers.ts`.
 
 **Add/edit tool documentation**: Navigate to `#/tools`, click a tool, edit the Description/Group/Docs fields, and Save. Or launch a Tool Assistant session for AI-guided documentation. Server-side: tool metadata lives in `.bobbit/config/tools/<group>/*.yaml` files, managed by `tool-manager.ts`, API routes in `server.ts`.
 
@@ -177,8 +177,8 @@ All per-project state lives under `<project-root>/.bobbit/`:
 | File / Directory | Owner | Purpose |
 |---|---|---|
 | `token` | `token.ts` | Auth token (mode 0600) |
-| `sessions.json` | `SessionStore` | Session metadata (id, title, cwd, agentSessionFile, wasStreaming) |
-| `goals.json` | `GoalStore` | Goal definitions (title, spec, cwd, state) |
+| `sessions.json` | `SessionStore` | Session metadata (id, title, cwd, agentSessionFile, wasStreaming, reattemptGoalId) |
+| `goals.json` | `GoalStore` | Goal definitions (title, spec, cwd, state, reattemptOf) |
 | `tasks.json` | `TaskStore` | Task definitions, state, assignments |
 | `gates.json` | `GateStore` | Gate state and signal history |
 | `team-state.json` | `TeamStore` | Team state (agents, roles, goal associations) |
@@ -210,3 +210,18 @@ Goals can optionally have a **workflow** — a DAG of gates with dependency orde
 **Tasks** link to workflow gates via `workflowGateId` (output) and `inputGateIds` (context inputs). **Context injection** feeds passed upstream gate content into agent prompts automatically — at spawn time (`team_spawn`) or prompt time (`team_prompt`).
 
 For the full architecture — data models, context injection mechanics, verification lifecycle, REST API, and worked examples — see [docs/goals-workflows-tasks.md](docs/goals-workflows-tasks.md).
+
+### Goal re-attempt flow
+
+When a goal's PR has been merged or the goal is archived, users can **re-attempt** it — opening a goal assistant session pre-loaded with context from the original goal to define a new, informed attempt.
+
+**How it works:**
+1. User clicks "Re-attempt" (RotateCcw icon) in the goal dashboard nav bar or sidebar pill button
+2. A goal assistant session is created with `reattemptGoalId` set to the original goal's ID
+3. The assistant receives the original goal's title, spec, branch, and PR URL via `buildReattemptContext()` in `goal-assistant.ts`
+4. The assistant guides the user through: what went wrong, preferred approach (revert & start fresh / fix up / revert & fix up), and composes a new goal spec
+5. On proposal acceptance, the old goal is archived and the new goal gets `reattemptOf` linking back to it
+
+**Data model:** `PersistedGoal.reattemptOf` (optional string, original goal ID). `PersistedSession.reattemptGoalId` (optional string, for goal assistant sessions). The dashboard shows a "Re-attempt of: [title]" badge when `reattemptOf` is set.
+
+**API:** `POST /api/sessions` accepts `reattemptGoalId` in the body. `POST /api/goals` and `PUT /api/goals/:id` accept `reattemptOf`.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -15,7 +15,7 @@ All routes require `Authorization: Bearer <token>`. Token can also be passed as 
 | Method | Path | Description |
 |---|---|---|
 | `GET` | `/api/sessions` | List all sessions (includes title, status, color, goal) |
-| `POST` | `/api/sessions` | Create a session (normal, delegate, or with role/traits/assistant type) |
+| `POST` | `/api/sessions` | Create a session (normal, delegate, or with role/traits/assistant type/reattemptGoalId) |
 | `GET` | `/api/sessions/:id` | Get session details |
 | `DELETE` | `/api/sessions/:id` | Terminate a session |
 | `PATCH` | `/api/sessions/:id` | Update session properties (title, colorIndex, preview, roleId, traits, assistantType, goalId) |
@@ -31,9 +31,9 @@ All routes require `Authorization: Bearer <token>`. Token can also be passed as 
 | Method | Path | Description |
 |---|---|---|
 | `GET` | `/api/goals` | List all goals |
-| `POST` | `/api/goals` | Create a goal (`{ title, cwd, spec, team?, worktree? }`) |
+| `POST` | `/api/goals` | Create a goal (`{ title, cwd, spec, team?, worktree?, reattemptOf? }`) |
 | `GET` | `/api/goals/:id` | Get a goal |
-| `PUT` | `/api/goals/:id` | Update a goal (title, cwd, state, spec, team, repoPath, branch) |
+| `PUT` | `/api/goals/:id` | Update a goal (title, cwd, state, spec, team, repoPath, branch, reattemptOf) |
 | `DELETE` | `/api/goals/:id` | Delete a goal and its tasks |
 | `GET` | `/api/goals/:id/commits` | Commit history for goal branch (excludes primary branch commits) |
 | `GET` | `/api/goals/:id/git-status` | Git status for goal worktree (branch, ahead/behind primary, clean) |

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -314,11 +314,12 @@ export async function fetchGitStatus(sessionId: string, opts?: { fetch?: boolean
 // GOAL API
 // ============================================================================
 
-export async function createGoal(title: string, cwd: string, opts?: { spec?: string; workflowId?: string }): Promise<Goal | null> {
-	const { spec = "", workflowId } = opts ?? {};
+export async function createGoal(title: string, cwd: string, opts?: { spec?: string; workflowId?: string; reattemptOf?: string }): Promise<Goal | null> {
+	const { spec = "", workflowId, reattemptOf } = opts ?? {};
 	try {
 		const body: Record<string, any> = { title, cwd, spec, team: true, worktree: true };
 		if (workflowId) body.workflowId = workflowId;
+		if (reattemptOf) body.reattemptOf = reattemptOf;
 		const res = await gatewayFetch("/api/goals", {
 			method: "POST",
 			body: JSON.stringify(body),

--- a/src/app/goal-dashboard.ts
+++ b/src/app/goal-dashboard.ts
@@ -6,7 +6,7 @@ import { Button } from "@mariozechner/mini-lit/dist/Button.js";
 import { state, renderApp, type Goal } from "./state.js";
 import { gatewayFetch, deleteGoal, startTeam, teardownTeam, getTeamState, fetchGoalGates, fetchRoles, refreshPrStatusCache, fetchArchivedSessions, archivedSessionsLoaded, type GateState, type GateSignal } from "./api.js";
 import { setHashRoute } from "./routing.js";
-import { createAndConnectSession, connectToSession } from "./session-manager.js";
+import { createAndConnectSession, connectToSession, startReattempt } from "./session-manager.js";
 import { showGoalDialog } from "./dialogs.js";
 import { statusBobbit } from "./session-colors.js";
 
@@ -901,6 +901,10 @@ function renderNavBar(goal: Goal): TemplateResult {
 				</button>
 				<span class="nav-title">${goal.title}</span>
 				${goal.workflow ? html`<span class="nav-workflow-badge" title="Uses workflow: ${goal.workflow.name}">${goal.workflow.name}</span>` : nothing}
+				${goal.reattemptOf ? (() => {
+					const orig = state.goals.find(g => g.id === goal.reattemptOf);
+					return html`<span class="text-xs text-muted-foreground" style="margin-left:8px;">Re-attempt of: <a href="#/goal-dashboard/${goal.reattemptOf}" class="underline">${orig?.title ?? goal.reattemptOf.slice(0, 8)}</a></span>`;
+				})() : nothing}
 			</div>
 			<div class="nav-right">
 				${goal.archived ? nothing : html`
@@ -909,6 +913,14 @@ function renderNavBar(goal: Goal): TemplateResult {
 						? html`<button class="btn-icon primary" @click=${() => deleteGoal(goal.id)} title="Archive goal">${svgArchive}<span>Archive</span></button>`
 						: html`<button class="btn-icon danger" @click=${() => deleteGoal(goal.id)} title="${teamActive ? "Stop the team before archiving" : "Archive goal"}" ?disabled=${teamActive}>${svgTrash}<span>Archive</span></button>`}
 				`}
+				${(prStatus?.state === "MERGED" || goal.archived) && !teamActive ? html`
+					<button class="btn-icon" @click=${() => startReattempt(goal.id)} title="Re-attempt this goal">
+						<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+							<path d="M1 4v6h6"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/>
+						</svg>
+						<span>Re-attempt</span>
+					</button>
+				` : nothing}
 				${isTeamGoal ? renderTeamButton(goal) : renderSessionButton(goal)}
 			</div>
 		</div>

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -17,7 +17,7 @@ import {
 	type GoalState,
 } from "./state.js";
 import { statusBobbit } from "./session-colors.js";
-import { connectToSession, terminateSession, createAndConnectSession } from "./session-manager.js";
+import { connectToSession, terminateSession, createAndConnectSession, startReattempt } from "./session-manager.js";
 import { showRenameDialog } from "./dialogs.js";
 import { setHashRoute } from "./routing.js";
 import { startTeam, teardownTeam, refreshSessions, deleteGoal } from "./api.js";
@@ -490,9 +490,9 @@ export function renderGoalGroup(goal: Goal) {
 	const emptyState = html`
 		<div class="pl-2 py-1 ${mobile ? "text-xs" : "text-[11px]"} text-muted-foreground">
 			${goal.archived
-				? html`<span style="color:var(--text-tertiary)">Archived</span>`
+				? html`<span style="color:var(--text-tertiary)">Archived</span> <button class="inline-flex items-center gap-1 px-1.5 py-px rounded bg-primary/10 text-primary text-[10px] font-semibold hover:bg-primary/20 transition-colors align-middle" title="Re-attempt goal" @click=${(e: Event) => { e.stopPropagation(); startReattempt(goal.id); }}><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 4v6h6"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>Re-attempt</button>`
 				: canArchive
-				? html`<span style="vertical-align:middle">Work merged —</span> <button class="inline-flex items-center gap-1 px-1.5 py-px rounded bg-secondary text-secondary-foreground text-[10px] font-semibold hover:bg-secondary/80 transition-colors align-middle" title="Archive goal" @click=${(e: Event) => { e.stopPropagation(); deleteGoal(goal.id); }}>${icon(Trash2, "xs")}Archive Goal</button>`
+				? html`<span style="vertical-align:middle">Work merged —</span> <button class="inline-flex items-center gap-1 px-1.5 py-px rounded bg-secondary text-secondary-foreground text-[10px] font-semibold hover:bg-secondary/80 transition-colors align-middle" title="Archive goal" @click=${(e: Event) => { e.stopPropagation(); deleteGoal(goal.id); }}>${icon(Trash2, "xs")}Archive Goal</button> <button class="inline-flex items-center gap-1 px-1.5 py-px rounded bg-primary/10 text-primary text-[10px] font-semibold hover:bg-primary/20 transition-colors align-middle" title="Re-attempt goal" @click=${(e: Event) => { e.stopPropagation(); startReattempt(goal.id); }}><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 4v6h6"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>Re-attempt</button>`
 				: isTeamGoal
 				? html`<span style="vertical-align:middle">No agents —</span> <button class="inline-flex items-center gap-1 px-1.5 py-px rounded bg-primary/10 text-primary text-[10px] font-semibold hover:bg-primary/20 transition-colors align-middle ${isPreparing ? "opacity-60 pointer-events-none" : ""}" title="${isPreparing ? "Setting up worktree\u2026" : "Start team"}" @click=${handleStartTeam} ?disabled=${isLoading || isPreparing}>${isPreparing ? html`<svg class="animate-spin" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>` : html`<svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor"><path d="M2 12h12v1.5H2V12zm0-1L1 4l4 3 3-5 3 5 4-3-1 7H2z"/></svg>`}${isLoading ? "Starting\u2026" : isPreparing ? "Setting up\u2026" : "Start Team"}</button>`
 				: html`No sessions — <button class="inline-flex items-center gap-1 px-1.5 py-px rounded bg-primary/10 text-primary font-semibold hover:bg-primary/20 transition-colors" title="Start a session" @click=${() => createAndConnectSession(goal.id)}><svg width="8" height="8" viewBox="0 0 16 16" fill="currentColor"><path d="M5 3l8 5-8 5V3z"/></svg>start one</button>`}

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -312,7 +312,25 @@ function goalPreviewPanel() {
 		localStorage.removeItem("gateway.sessionId");
 		state.appView = "authenticated";
 
-		const goal = await createGoal(trimmedTitle, state.previewCwd.trim(), { spec: state.previewSpec, workflowId });
+		// Detect re-attempt context from the current session
+		const currentSession = state.gatewaySessions.find(s => s.id === sessionId);
+		const reattemptGoalId = currentSession?.reattemptGoalId;
+
+		const goal = await createGoal(trimmedTitle, state.previewCwd.trim(), {
+			spec: state.previewSpec,
+			workflowId,
+			reattemptOf: reattemptGoalId || undefined,
+		});
+
+		// If this is a re-attempt, archive the old goal and link the new one
+		if (reattemptGoalId && goal) {
+			await gatewayFetch(`/api/goals/${reattemptGoalId}`, { method: "DELETE" });
+			await gatewayFetch(`/api/goals/${goal.id}`, {
+				method: "PUT",
+				body: JSON.stringify({ reattemptOf: reattemptGoalId }),
+			});
+		}
+
 		if (sessionId) {
 			await gatewayFetch(`/api/sessions/${sessionId}`, { method: "DELETE" });
 			clearSessionModel(sessionId);

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -1223,3 +1223,20 @@ async function refreshPrStatusForSession(sessionId: string): Promise<void> {
 		}
 	}
 }
+
+// ============================================================================
+// RE-ATTEMPT FLOW
+// ============================================================================
+
+export async function startReattempt(goalId: string): Promise<void> {
+	const res = await gatewayFetch("/api/sessions", {
+		method: "POST",
+		body: JSON.stringify({
+			assistantType: "goal",
+			reattemptGoalId: goalId,
+		}),
+	});
+	if (!res.ok) throw new Error(`Failed: ${res.status}`);
+	const { id } = await res.json();
+	await connectToSession(id, false, { assistantType: "goal" });
+}

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -44,6 +44,8 @@ export interface GatewaySession {
 	staffAssistant?: boolean;
 	/** Whether this session has a live HTML preview panel */
 	preview?: boolean;
+	/** Goal ID this session is re-attempting (for goal assistant sessions) */
+	reattemptGoalId?: string;
 	/** Whether this is an automated non-interactive session (e.g. verification reviewer) */
 	nonInteractive?: boolean;
 	/** Personality names assigned to this session */
@@ -70,6 +72,8 @@ export interface Goal {
 	setupError?: string;
 	archived?: boolean;
 	archivedAt?: number;
+	/** If this goal is a re-attempt of another goal, the original goal's ID */
+	reattemptOf?: string;
 	workflow?: {
 		id: string;
 		name: string;

--- a/src/server/agent/goal-assistant.ts
+++ b/src/server/agent/goal-assistant.ts
@@ -2,6 +2,42 @@
  * System prompt for goal-creation assistant sessions.
  */
 
+import type { PersistedGoal } from "./goal-store.js";
+
+/**
+ * Build a prompt section for re-attempt context.
+ * Appended to the goal assistant prompt when the session has a reattemptGoalId.
+ */
+export function buildReattemptContext(goal: PersistedGoal): string {
+	const lines: string[] = [
+		"## Re-attempt Context",
+		"",
+		"This is a re-attempt of a previous goal. Here is the context:",
+		"",
+		`**Original Goal:** ${goal.title}`,
+	];
+	if (goal.branch) lines.push(`**Branch:** ${goal.branch}`);
+	if (goal.prUrl) lines.push(`**PR URL:** ${goal.prUrl}`);
+	lines.push(`**Workflow:** ${goal.workflowId || "general"}`);
+	lines.push("");
+	lines.push("**Original Spec:**");
+	lines.push(goal.spec || "(no spec)");
+	lines.push("");
+	lines.push("## Re-attempt Instructions");
+	lines.push("");
+	lines.push(`Since this is a re-attempt, do NOT ask "what do you want to accomplish?" Instead:`);
+	lines.push("");
+	lines.push(`1. Greet the user and acknowledge this is a re-attempt of "${goal.title}"`);
+	lines.push("2. Ask what went wrong — test failures? unexpected behaviour? missing edge cases?");
+	lines.push("3. Ask their preference:");
+	lines.push("   - **Revert & start fresh**: revert the merged commit(s) from master");
+	lines.push("   - **Fix up**: keep the merged work and build on top");
+	lines.push("   - **Revert & fix up**: revert from master but use old code as starting point");
+	lines.push("4. Compose a new goal spec that includes the original spec, what went wrong, the chosen approach, and pointers to the old branch/PR");
+	lines.push(`5. Propose the new goal with a title like "Re-attempt: ${goal.title}"`);
+	return lines.join("\n");
+}
+
 export const GOAL_ASSISTANT_PROMPT = `## Goal Assistant
 
 Goals in Bobbit are structured units of work. When created, a goal gets a dedicated git worktree and branch. The team lead orchestrates coding agents to complete the goal through workflow gates. Your job is to help the user define a clear, actionable goal.

--- a/src/server/agent/goal-manager.ts
+++ b/src/server/agent/goal-manager.ts
@@ -204,7 +204,7 @@ export class GoalManager {
 		return this.store.getAll();
 	}
 
-	async updateGoal(id: string, updates: { title?: string; cwd?: string; state?: GoalState; spec?: string; team?: boolean; repoPath?: string; branch?: string; prUrl?: string }): Promise<boolean> {
+	async updateGoal(id: string, updates: { title?: string; cwd?: string; state?: GoalState; spec?: string; team?: boolean; repoPath?: string; branch?: string; prUrl?: string; reattemptOf?: string }): Promise<boolean> {
 		const existing = this.store.get(id);
 		if (!existing) return false;
 

--- a/src/server/agent/goal-store.ts
+++ b/src/server/agent/goal-store.ts
@@ -36,6 +36,8 @@ export interface PersistedGoal {
 	setupError?: string;
 	/** GitHub PR URL (set by team lead after creating PR) */
 	prUrl?: string;
+	/** If this goal is a re-attempt of another goal, the original goal's ID */
+	reattemptOf?: string;
 	/** Whether this goal has been archived (soft-deleted) */
 	archived?: boolean;
 	/** Epoch ms when the goal was archived */

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -10,6 +10,7 @@ import { PromptQueue } from "./prompt-queue.js";
 import { RpcBridge, type RpcBridgeOptions } from "./rpc-bridge.js";
 import { SessionStore, type PersistedSession } from "./session-store.js";
 import { getAssistantDef } from "./assistant-registry.js";
+import { buildReattemptContext } from "./goal-assistant.js";
 import { assembleSystemPrompt, cleanupSessionPrompt, type PromptParts } from "./system-prompt.js";
 import { generateSessionTitle, generateGoalSummaryTitle } from "./title-generator.js";
 import { CostTracker } from "./cost-tracker.js";
@@ -155,6 +156,10 @@ export class SessionManager {
 		return this.costTracker;
 	}
 
+	getSessionStore(): SessionStore {
+		return this.store;
+	}
+
 	/** Build a markdown list of available workflows for the goal assistant prompt. */
 	private _buildWorkflowList(): string {
 		const workflows = this.workflowStore?.getAll();
@@ -199,6 +204,14 @@ export class SessionManager {
 			assistantGoalSpec += assistantDef.prompt;
 			if (session.assistantType === "goal") {
 				assistantGoalSpec = assistantGoalSpec.replace('{{AVAILABLE_WORKFLOWS}}', this._buildWorkflowList());
+				// Inject re-attempt context if this is a re-attempt session
+				const reattemptId = (this.store.get(session.id) as any)?.reattemptGoalId;
+				if (reattemptId) {
+					const origGoal = this.goalManager.getGoal(reattemptId);
+					if (origGoal) {
+						assistantGoalSpec += "\n\n" + buildReattemptContext(origGoal);
+					}
+				}
 			}
 			parts = {
 				baseSystemPromptPath: undefined,
@@ -670,6 +683,13 @@ export class SessionManager {
 			assistantGoalSpec += assistantDef.prompt;
 			if (ps.assistantType === "goal") {
 				assistantGoalSpec = assistantGoalSpec.replace('{{AVAILABLE_WORKFLOWS}}', this._buildWorkflowList());
+				// Inject re-attempt context if this is a re-attempt session
+				if (ps.reattemptGoalId) {
+					const origGoal = this.goalManager.getGoal(ps.reattemptGoalId);
+					if (origGoal) {
+						assistantGoalSpec += "\n\n" + buildReattemptContext(origGoal);
+					}
+				}
 			}
 
 			const promptPath = this.assemblePrompt(ps.id, {
@@ -801,7 +821,7 @@ export class SessionManager {
 		}
 	}
 
-	async createSession(cwd: string, agentArgs?: string[], goalId?: string, assistantType?: string, opts?: { rolePrompt?: string; roleName?: string; env?: Record<string, string>; taskId?: string; allowedTools?: string[]; personalities?: Array<{ label: string; promptFragment: string }>; personalityNames?: string[]; workflowContext?: string; worktreeOpts?: { repoPath: string } }): Promise<SessionInfo> {
+	async createSession(cwd: string, agentArgs?: string[], goalId?: string, assistantType?: string, opts?: { rolePrompt?: string; roleName?: string; env?: Record<string, string>; taskId?: string; allowedTools?: string[]; personalities?: Array<{ label: string; promptFragment: string }>; personalityNames?: string[]; workflowContext?: string; worktreeOpts?: { repoPath: string }; reattemptGoalId?: string }): Promise<SessionInfo> {
 		const id = randomUUID();
 
 		// ── Worktree: return a "preparing" session immediately, launch agent async ──
@@ -894,6 +914,13 @@ export class SessionManager {
 			assistantGoalSpec += assistantDef.prompt;
 			if (assistantType === "goal") {
 				assistantGoalSpec = assistantGoalSpec.replace('{{AVAILABLE_WORKFLOWS}}', this._buildWorkflowList());
+				// Inject re-attempt context if this is a re-attempt session
+				if (opts?.reattemptGoalId) {
+					const origGoal = this.goalManager.getGoal(opts.reattemptGoalId);
+					if (origGoal) {
+						assistantGoalSpec += "\n\n" + buildReattemptContext(origGoal);
+					}
+				}
 			}
 
 			// Use assistant role's tool restrictions (before assemblePrompt so tool docs are filtered correctly)
@@ -1553,6 +1580,7 @@ export class SessionManager {
 		nonInteractive?: boolean;
 		preview?: boolean;
 		personalities?: string[];
+		reattemptGoalId?: string;
 	}> {
 		return Array.from(this.sessions.values()).map((s) => ({
 			id: s.id,
@@ -1580,6 +1608,7 @@ export class SessionManager {
 			nonInteractive: s.nonInteractive,
 			preview: s.preview,
 			personalities: s.personalities,
+			reattemptGoalId: this.store.get(s.id)?.reattemptGoalId,
 		}));
 	}
 
@@ -2132,6 +2161,7 @@ export class SessionManager {
 		accessory?: string;
 		preview?: boolean;
 		personalities?: string[];
+		reattemptGoalId?: string;
 		archived: boolean;
 		archivedAt?: number;
 	}> {
@@ -2156,6 +2186,7 @@ export class SessionManager {
 			accessory: ps.accessory,
 			preview: ps.preview,
 			personalities: ps.personalities,
+			reattemptGoalId: ps.reattemptGoalId,
 			archived: true,
 			archivedAt: ps.archivedAt,
 		}));

--- a/src/server/agent/session-store.ts
+++ b/src/server/agent/session-store.ts
@@ -51,6 +51,8 @@ export interface PersistedSession {
 	messageQueue?: QueuedMessage[];
 	/** Server-side draft storage, keyed by draft type (e.g. "prompt", "goal", "role", "personality") */
 	drafts?: Record<string, unknown>;
+	/** Goal ID this session is re-attempting (for goal assistant sessions) */
+	reattemptGoalId?: string;
 	/** Whether this session is archived (soft-deleted) */
 	archived?: boolean;
 	/** Epoch ms when this session was archived */
@@ -148,7 +150,7 @@ export class SessionStore {
 	}
 
 	/** Update a subset of fields for an existing session */
-	update(id: string, updates: Partial<Pick<PersistedSession, "title" | "lastActivity" | "agentSessionFile" | "goalId" | "wasStreaming" | "streamingStartedAt" | "delegateOf" | "role" | "teamGoalId" | "teamLeadSessionId" | "worktreePath" | "assistantType" | "goalAssistant" | "roleAssistant" | "toolAssistant" | "taskId" | "staffId" | "accessory" | "preview" | "personalities" | "messageQueue" | "archived" | "archivedAt" | "repoPath" | "branch" | "nonInteractive" | "cwd">>): void {
+	update(id: string, updates: Partial<Pick<PersistedSession, "title" | "lastActivity" | "agentSessionFile" | "goalId" | "wasStreaming" | "streamingStartedAt" | "delegateOf" | "role" | "teamGoalId" | "teamLeadSessionId" | "worktreePath" | "assistantType" | "goalAssistant" | "roleAssistant" | "toolAssistant" | "taskId" | "staffId" | "accessory" | "preview" | "personalities" | "messageQueue" | "archived" | "archivedAt" | "repoPath" | "branch" | "nonInteractive" | "cwd" | "reattemptGoalId">>): void {
 		const existing = this.sessions.get(id);
 		if (!existing) return;
 		Object.assign(existing, updates);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -530,6 +530,7 @@ async function handleApiRoute(
 					colorIndex: colorStore.get(archived.id),
 					preview: archived.preview,
 					personalities: archived.personalities,
+					reattemptGoalId: archived.reattemptGoalId,
 					archived: true,
 					archivedAt: archived.archivedAt,
 				});
@@ -539,6 +540,7 @@ async function handleApiRoute(
 			res.end(JSON.stringify({ error: "Session not found" }));
 			return;
 		}
+		const sessionPs = sessionManager.getSessionStore().get(session.id);
 		json({
 			id: session.id,
 			title: session.title,
@@ -564,6 +566,7 @@ async function handleApiRoute(
 			colorIndex: colorStore.get(session.id),
 			preview: session.preview,
 			personalities: session.personalities,
+			reattemptGoalId: sessionPs?.reattemptGoalId,
 		});
 		return;
 	}
@@ -675,8 +678,11 @@ async function handleApiRoute(
 			}
 		}
 
+		// ── Re-attempt support ──
+		const reattemptGoalId = body?.reattemptGoalId as string | undefined;
+
 		try {
-			const session = await sessionManager.createSession(cwd, args, goalId, assistantType, { ...createOpts, worktreeOpts });
+			const session = await sessionManager.createSession(cwd, args, goalId, assistantType, { ...createOpts, worktreeOpts, reattemptGoalId });
 
 			// Set role metadata if a role was specified
 			if (roleForMeta) {
@@ -687,6 +693,11 @@ async function handleApiRoute(
 				sessionManager.updateSessionMeta(session.id, { role: "assistant", accessory: "wand" });
 				session.role = "assistant";
 				session.accessory = "wand";
+			}
+
+			// Store reattemptGoalId on the session if provided
+			if (reattemptGoalId) {
+				sessionManager.getSessionStore().update(session.id, { reattemptGoalId });
 			}
 
 			json({
@@ -702,6 +713,7 @@ async function handleApiRoute(
 				role: session.role,
 				accessory: session.accessory,
 				personalities: session.personalities,
+				reattemptGoalId,
 			}, 201);
 		} catch (err) {
 			json({ error: String(err) }, 500);
@@ -734,6 +746,11 @@ async function handleApiRoute(
 				workflowId,
 				workflowStore: workflowManager.store,
 			});
+			// Set reattemptOf if provided
+			if (body.reattemptOf && typeof body.reattemptOf === "string") {
+				sessionManager.goalManager.updateGoal(goal.id, { reattemptOf: body.reattemptOf });
+				goal.reattemptOf = body.reattemptOf;
+			}
 			// Initialize gate states for the workflow
 			if (goal.workflow) {
 				gateStore.initGatesForGoal(goal.id, goal.workflow.gates.map(g => g.id));
@@ -799,6 +816,7 @@ async function handleApiRoute(
 				repoPath: body.repoPath,
 				branch: body.branch,
 				prUrl: body.prUrl,
+				reattemptOf: body.reattemptOf,
 			});
 			if (!ok) { json({ error: "Goal not found" }, 404); return; }
 			json({ ok: true });


### PR DESCRIPTION
Add a "Re-attempt" action for completed/archived goals whose work has been merged. Clicking it opens a goal assistant session pre-loaded with context from the original goal, guiding the user to define a new goal informed by the failed attempt.

## Changes (14 files, +173/-17 lines)

### Server
- `reattemptOf` field on `PersistedGoal`, `reattemptGoalId` on `PersistedSession`
- `buildReattemptContext()` in goal-assistant.ts augments the goal assistant prompt with original goal context
- Session manager injects re-attempt context in all 3 prompt assembly locations
- API: `POST /api/sessions` accepts `reattemptGoalId`, `POST/PUT /api/goals` accepts `reattemptOf`

### UI
- Re-attempt button in goal dashboard nav bar (RotateCcw icon, visible when PR merged or archived)
- Re-attempt pill button in sidebar goal group empty state
- "Re-attempt of" badge on dashboard for linked goals
- Proposal acceptance auto-archives old goal and links new one via `reattemptOf`

### Docs
- AGENTS.md: new Common Tasks entry, updated disk state summary
- docs/rest-api.md: updated endpoint docs with new parameters