### PR TITLE
Hide Cancel button in dedicated assistant panels

### DIFF
--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -326,10 +326,6 @@ function goalPreviewPanel() {
 		renderApp();
 	};
 
-	const handleCancel = () => {
-		backToSessions();
-	};
-
 	return html`
 		<div class="goal-preview-panel flex-1 flex flex-col border-l border-border min-h-0">
 			<div class="flex-1 overflow-y-auto p-5 flex flex-col gap-4">
@@ -427,7 +423,6 @@ function goalPreviewPanel() {
 			</div>
 			<div class="shrink-0 flex flex-col gap-3 px-5 py-3 border-t border-border">
 				<div class="flex items-center justify-end gap-2">
-					${Button({ variant: "ghost", onClick: handleCancel, children: "Cancel" })}
 					${Button({
 						variant: "default",
 						onClick: handleCreateGoal,
@@ -502,10 +497,6 @@ function rolePreviewPanel() {
 		await loadRolePageData();
 		setHashRoute("roles");
 		renderApp();
-	};
-
-	const handleCancel = () => {
-		backToSessions();
 	};
 
 	// Parse current tools string into array for display
@@ -636,7 +627,6 @@ function rolePreviewPanel() {
 				</div>
 			</div>
 			<div class="shrink-0 flex items-center justify-end gap-2 px-5 py-3 border-t border-border">
-				${Button({ variant: "ghost", onClick: handleCancel, children: "Cancel" })}
 				${Button({
 					variant: "default",
 					onClick: handleCreateRole,
@@ -990,10 +980,6 @@ function staffPreviewPanel() {
 		renderApp();
 	};
 
-	const handleCancel = () => {
-		backToSessions();
-	};
-
 	return html`
 		<div class="goal-preview-panel flex-1 flex flex-col border-l border-border min-h-0">
 			<div class="flex-1 overflow-y-auto p-5 flex flex-col gap-4">
@@ -1079,7 +1065,6 @@ function staffPreviewPanel() {
 				</div>
 			</div>
 			<div class="shrink-0 flex items-center justify-end gap-2 px-5 py-3 border-t border-border">
-				${Button({ variant: "ghost", onClick: handleCancel, children: "Cancel" })}
 				${Button({
 					variant: "default",
 					onClick: handleCreateStaff,
@@ -1131,10 +1116,6 @@ function personalityPreviewPanel() {
 		await loadPersonalityPageData();
 		setHashRoute("personalities");
 		renderApp();
-	};
-
-	const handleCancel = () => {
-		backToSessions();
 	};
 
 	return html`
@@ -1211,7 +1192,6 @@ function personalityPreviewPanel() {
 				</div>
 			</div>
 			<div class="shrink-0 flex items-center justify-end gap-2 px-5 py-3 border-t border-border">
-				${Button({ variant: "ghost", onClick: handleCancel, children: "Cancel" })}
 				${Button({
 					variant: "default",
 					onClick: handleCreatePersonality,
@@ -1308,29 +1288,6 @@ function ensureWorkflowPageLoaded() {
 function workflowPreviewPanel() {
 	ensureWorkflowPageLoaded();
 
-	const handleCancel = async () => {
-		if (state.assistantType === "workflow") {
-			const sessionId = activeSessionId();
-			if (state.remoteAgent) {
-				state.remoteAgent.disconnect();
-				state.remoteAgent = null;
-				state.connectionStatus = "disconnected";
-			}
-			state.assistantType = null;
-			localStorage.removeItem("gateway.sessionId");
-			state.appView = "authenticated";
-			if (sessionId) {
-				await gatewayFetch(`/api/sessions/${sessionId}`, { method: "DELETE" });
-				clearSessionModel(sessionId);
-			}
-			await refreshSessions();
-			setHashRoute("landing");
-			renderApp();
-		} else {
-			backToSessions();
-		}
-	};
-
 	const handleCreateWorkflow = async () => {
 		if (_workflowPageModule) {
 			const ok = await _workflowPageModule.saveWorkflowFromPanel();
@@ -1372,7 +1329,6 @@ function workflowPreviewPanel() {
 			<div class="flex items-center justify-between p-3 border-t border-border">
 				<div></div>
 				<div class="flex items-center gap-2">
-					${Button({ variant: "ghost", size: "sm", onClick: handleCancel, children: "Cancel" })}
 					${Button({
 						variant: "default",
 						size: "sm",


### PR DESCRIPTION
Removes the Cancel button from 5 dedicated assistant preview panels in `src/app/render.ts`:

- `goalPreviewPanel()`
- `rolePreviewPanel()`
- `staffPreviewPanel()`
- `personalityPreviewPanel()`
- `workflowPreviewPanel()`

Users in dedicated assistant sessions can terminate via the header/sidebar ✕ button — the Cancel button calling `backToSessions()` was redundant and confusing.

The Dismiss button on `goalProposalPanel()` (used inline in non-assistant sessions) is unchanged.