### PR TITLE
Align page help margins

### DIFF
--- a/src/app/personality-manager-page.ts
+++ b/src/app/personality-manager-page.ts
@@ -333,7 +333,7 @@ function renderListView(): TemplateResult {
 	}
 
 	return html`
-		<p class="text-sm text-muted-foreground mb-3">Personalities change how an agent behaves \u2014 its communication style, thoroughness, and approach. They\u2019re optional modifiers you can apply when spawning agents.</p>
+		<p class="text-sm text-muted-foreground mb-3" style="max-width: 600px; margin: 0 auto;">Personalities change how an agent behaves \u2014 its communication style, thoroughness, and approach. They\u2019re optional modifiers you can apply when spawning agents.</p>
 		<div class="personalities-list">
 			${personalities.map((p) => renderPersonalityRow(p))}
 		</div>

--- a/src/app/role-manager-page.ts
+++ b/src/app/role-manager-page.ts
@@ -399,7 +399,7 @@ function renderListView(): TemplateResult {
 	}
 
 	return html`
-		<p class="text-sm text-muted-foreground mb-3">Roles define what an agent can do \u2014 its system prompt and which tools it has access to. Bobbit includes built-in roles (coder, reviewer, tester) and you can create custom ones.</p>
+		<p class="text-sm text-muted-foreground mb-3" style="max-width: 600px; margin: 0 auto;">Roles define what an agent can do \u2014 its system prompt and which tools it has access to. Bobbit includes built-in roles (coder, reviewer, tester) and you can create custom ones.</p>
 		<div class="roles-list">
 			${roles.map((role, i) => renderRoleRow(role, i))}
 		</div>

--- a/src/app/tool-manager-page.ts
+++ b/src/app/tool-manager-page.ts
@@ -460,7 +460,7 @@ function renderListView(): TemplateResult {
 	const chevronSvg = html`<svg class="tool-group-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>`;
 
 	return html`
-		<p class="text-sm text-muted-foreground mb-3">Tools are the capabilities available to agents \u2014 file editing, shell commands, web search, and more. This page lets you view and document them.</p>
+		<p class="text-sm text-muted-foreground mb-3" style="max-width: 700px; margin: 0 auto;">Tools are the capabilities available to agents \u2014 file editing, shell commands, web search, and more. This page lets you view and document them.</p>
 		<div class="tools-list">
 			${sortedGroups.map((groupName) => {
 				const groupTools = groups.get(groupName)!;

--- a/src/app/workflow-page.ts
+++ b/src/app/workflow-page.ts
@@ -753,7 +753,7 @@ function renderListView(): TemplateResult {
 	}
 
 	return html`
-		<p class="text-sm text-muted-foreground mb-3">Workflows define the stages (gates) a goal goes through \u2014 like design \u2192 implement \u2192 test \u2192 review. They ensure quality by enforcing order and verification.</p>
+		<p class="text-sm text-muted-foreground mb-3" style="max-width: 600px; margin: 0 auto;">Workflows define the stages (gates) a goal goes through \u2014 like design \u2192 implement \u2192 test \u2192 review. They ensure quality by enforcing order and verification.</p>
 		<div class="wf-list">
 			${workflows.map((wf) => renderWorkflowRow(wf))}
 		</div>

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -233,10 +233,7 @@ export class SessionManager {
 			}
 			assistantGoalSpec += assistantDef.prompt;
 			if (session.assistantType === "goal") {
-<<<<<<< HEAD
 				assistantGoalSpec = assistantGoalSpec.replace('{{AVAILABLE_WORKFLOWS}}', this._buildWorkflowList());
-=======
-				assistantGoalSpec = this._injectWorkflowList(assistantGoalSpec);
 				// Inject re-attempt context if this is a re-attempt session
 				const reattemptId = (this.store.get(session.id) as any)?.reattemptGoalId;
 				if (reattemptId) {
@@ -245,7 +242,6 @@ export class SessionManager {
 						assistantGoalSpec += "\n\n" + buildReattemptContext(origGoal);
 					}
 				}
->>>>>>> 9469e59ac29b379976e65edc201a69fbf4fe5030
 			}
 			parts = {
 				baseSystemPromptPath: undefined,
@@ -722,10 +718,7 @@ export class SessionManager {
 			}
 			assistantGoalSpec += assistantDef.prompt;
 			if (ps.assistantType === "goal") {
-<<<<<<< HEAD
 				assistantGoalSpec = assistantGoalSpec.replace('{{AVAILABLE_WORKFLOWS}}', this._buildWorkflowList());
-=======
-				assistantGoalSpec = this._injectWorkflowList(assistantGoalSpec);
 				// Inject re-attempt context if this is a re-attempt session
 				if (ps.reattemptGoalId) {
 					const origGoal = this.goalManager.getGoal(ps.reattemptGoalId);
@@ -733,7 +726,6 @@ export class SessionManager {
 						assistantGoalSpec += "\n\n" + buildReattemptContext(origGoal);
 					}
 				}
->>>>>>> 9469e59ac29b379976e65edc201a69fbf4fe5030
 			}
 
 			const promptPath = this.assemblePrompt(ps.id, {
@@ -957,10 +949,7 @@ export class SessionManager {
 			}
 			assistantGoalSpec += assistantDef.prompt;
 			if (assistantType === "goal") {
-<<<<<<< HEAD
 				assistantGoalSpec = assistantGoalSpec.replace('{{AVAILABLE_WORKFLOWS}}', this._buildWorkflowList());
-=======
-				assistantGoalSpec = this._injectWorkflowList(assistantGoalSpec);
 				// Inject re-attempt context if this is a re-attempt session
 				if (opts?.reattemptGoalId) {
 					const origGoal = this.goalManager.getGoal(opts.reattemptGoalId);
@@ -968,7 +957,6 @@ export class SessionManager {
 						assistantGoalSpec += "\n\n" + buildReattemptContext(origGoal);
 					}
 				}
->>>>>>> 9469e59ac29b379976e65edc201a69fbf4fe5030
 			}
 
 			// Use assistant role's tool restrictions (before assemblePrompt so tool docs are filtered correctly)


### PR DESCRIPTION
Constrains the help `<p>` text on the Roles, Tools, Personalities, and Workflow pages to the same `max-width` and `margin: 0 auto` as their sibling list containers, so they align on wider screens.

**Changes:**
- `role-manager-page.ts`: help `<p>` → `max-width: 600px` (matches `.roles-list`)
- `tool-manager-page.ts`: help `<p>` → `max-width: 700px` (matches `.tools-list`)
- `personality-manager-page.ts`: help `<p>` → `max-width: 600px` (matches `.personalities-list`)
- `workflow-page.ts`: help `<p>` → `max-width: 600px` (matches `.wf-list`)

Also resolved pre-existing merge conflict markers in `session-manager.ts`.