### PR TITLE
Fix page help spacing

### DIFF
--- a/src/app/personality-manager-page.ts
+++ b/src/app/personality-manager-page.ts
@@ -333,7 +333,7 @@ function renderListView(): TemplateResult {
 	}
 
 	return html`
-		<p class="text-sm text-muted-foreground mb-3" style="max-width: 600px; margin: 0 auto;">Personalities change how an agent behaves \u2014 its communication style, thoroughness, and approach. They\u2019re optional modifiers you can apply when spawning agents.</p>
+		<p class="text-sm text-muted-foreground mb-6" style="max-width: 600px; margin: 0 auto;">Personalities change how an agent behaves \u2014 its communication style, thoroughness, and approach. They\u2019re optional modifiers you can apply when spawning agents.</p>
 		<div class="personalities-list">
 			${personalities.map((p) => renderPersonalityRow(p))}
 		</div>

--- a/src/app/role-manager-page.ts
+++ b/src/app/role-manager-page.ts
@@ -399,7 +399,7 @@ function renderListView(): TemplateResult {
 	}
 
 	return html`
-		<p class="text-sm text-muted-foreground mb-3" style="max-width: 600px; margin: 0 auto;">Roles define what an agent can do \u2014 its system prompt and which tools it has access to. Bobbit includes built-in roles (coder, reviewer, tester) and you can create custom ones.</p>
+		<p class="text-sm text-muted-foreground mb-6" style="max-width: 600px; margin: 0 auto;">Roles define what an agent can do \u2014 its system prompt and which tools it has access to. Bobbit includes built-in roles (coder, reviewer, tester) and you can create custom ones.</p>
 		<div class="roles-list">
 			${roles.map((role, i) => renderRoleRow(role, i))}
 		</div>

--- a/src/app/tool-manager-page.ts
+++ b/src/app/tool-manager-page.ts
@@ -469,7 +469,7 @@ function renderListView(): TemplateResult {
 	const chevronSvg = html`<svg class="tool-group-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>`;
 
 	return html`
-		<p class="text-sm text-muted-foreground mb-3" style="max-width: 700px; margin: 0 auto;">Tools are the capabilities available to agents \u2014 file editing, shell commands, web search, and more. This page lets you view and document them.</p>
+		<p class="text-sm text-muted-foreground mb-6" style="max-width: 700px; margin: 0 auto;">Tools are the capabilities available to agents \u2014 file editing, shell commands, web search, and more. This page lets you view and document them.</p>
 		<div class="tools-list">
 			${sortedGroups.map((groupName) => {
 				const groupTools = groups.get(groupName)!;

--- a/src/app/workflow-page.ts
+++ b/src/app/workflow-page.ts
@@ -784,7 +784,7 @@ function renderListView(): TemplateResult {
 	}
 
 	return html`
-		<p class="text-sm text-muted-foreground mb-3" style="max-width: 600px; margin: 0 auto;">Workflows define the stages (gates) a goal goes through \u2014 like design \u2192 implement \u2192 test \u2192 review. They ensure quality by enforcing order and verification.</p>
+		<p class="text-sm text-muted-foreground mb-6" style="max-width: 600px; margin: 0 auto;">Workflows define the stages (gates) a goal goes through \u2014 like design \u2192 implement \u2192 test \u2192 review. They ensure quality by enforcing order and verification.</p>
 		<div class="wf-list">
 			${workflows.map((wf) => renderWorkflowRow(wf))}
 		</div>


### PR DESCRIPTION
Increases bottom margin on help `<p>` from `mb-3` (0.75rem) to `mb-6` (1.5rem) in `renderListView()` on Roles, Tools, Personalities, and Workflow pages for comfortable visual separation between help text and list content.

### Changes
- `src/app/role-manager-page.ts` — `mb-3` → `mb-6`
- `src/app/tool-manager-page.ts` — `mb-3` → `mb-6`
- `src/app/personality-manager-page.ts` — `mb-3` → `mb-6`
- `src/app/workflow-page.ts` — `mb-3` → `mb-6`