### PR TITLE
Fix page help spacing (margin-inline fix)

### DIFF
--- a/src/app/personality-manager-page.ts
+++ b/src/app/personality-manager-page.ts
@@ -333,7 +333,7 @@ function renderListView(): TemplateResult {
 	}
 
 	return html`
-		<p class="text-sm text-muted-foreground mb-3" style="max-width: 600px; margin: 0 auto;">Personalities change how an agent behaves \u2014 its communication style, thoroughness, and approach. They\u2019re optional modifiers you can apply when spawning agents.</p>
+		<p class="text-sm text-muted-foreground mb-6" style="max-width: 600px; margin: 0 auto;">Personalities change how an agent behaves \u2014 its communication style, thoroughness, and approach. They\u2019re optional modifiers you can apply when spawning agents.</p>
 		<div class="personalities-list">
 			${personalities.map((p) => renderPersonalityRow(p))}
 		</div>

--- a/src/app/personality-manager-page.ts
+++ b/src/app/personality-manager-page.ts
@@ -333,7 +333,7 @@ function renderListView(): TemplateResult {
 	}
 
 	return html`
-		<p class="text-sm text-muted-foreground mb-6" style="max-width: 600px; margin: 0 auto;">Personalities change how an agent behaves \u2014 its communication style, thoroughness, and approach. They\u2019re optional modifiers you can apply when spawning agents.</p>
+		<p class="text-sm text-muted-foreground mb-6" style="max-width: 600px; margin-inline: auto;">Personalities change how an agent behaves \u2014 its communication style, thoroughness, and approach. They\u2019re optional modifiers you can apply when spawning agents.</p>
 		<div class="personalities-list">
 			${personalities.map((p) => renderPersonalityRow(p))}
 		</div>

--- a/src/app/role-manager-page.ts
+++ b/src/app/role-manager-page.ts
@@ -399,7 +399,7 @@ function renderListView(): TemplateResult {
 	}
 
 	return html`
-		<p class="text-sm text-muted-foreground mb-3" style="max-width: 600px; margin: 0 auto;">Roles define what an agent can do \u2014 its system prompt and which tools it has access to. Bobbit includes built-in roles (coder, reviewer, tester) and you can create custom ones.</p>
+		<p class="text-sm text-muted-foreground mb-6" style="max-width: 600px; margin: 0 auto;">Roles define what an agent can do \u2014 its system prompt and which tools it has access to. Bobbit includes built-in roles (coder, reviewer, tester) and you can create custom ones.</p>
 		<div class="roles-list">
 			${roles.map((role, i) => renderRoleRow(role, i))}
 		</div>

--- a/src/app/role-manager-page.ts
+++ b/src/app/role-manager-page.ts
@@ -399,7 +399,7 @@ function renderListView(): TemplateResult {
 	}
 
 	return html`
-		<p class="text-sm text-muted-foreground mb-6" style="max-width: 600px; margin: 0 auto;">Roles define what an agent can do \u2014 its system prompt and which tools it has access to. Bobbit includes built-in roles (coder, reviewer, tester) and you can create custom ones.</p>
+		<p class="text-sm text-muted-foreground mb-6" style="max-width: 600px; margin-inline: auto;">Roles define what an agent can do \u2014 its system prompt and which tools it has access to. Bobbit includes built-in roles (coder, reviewer, tester) and you can create custom ones.</p>
 		<div class="roles-list">
 			${roles.map((role, i) => renderRoleRow(role, i))}
 		</div>

--- a/src/app/tool-manager-page.ts
+++ b/src/app/tool-manager-page.ts
@@ -469,7 +469,7 @@ function renderListView(): TemplateResult {
 	const chevronSvg = html`<svg class="tool-group-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>`;
 
 	return html`
-		<p class="text-sm text-muted-foreground mb-6" style="max-width: 700px; margin: 0 auto;">Tools are the capabilities available to agents \u2014 file editing, shell commands, web search, and more. This page lets you view and document them.</p>
+		<p class="text-sm text-muted-foreground mb-6" style="max-width: 700px; margin-inline: auto;">Tools are the capabilities available to agents \u2014 file editing, shell commands, web search, and more. This page lets you view and document them.</p>
 		<div class="tools-list">
 			${sortedGroups.map((groupName) => {
 				const groupTools = groups.get(groupName)!;

--- a/src/app/tool-manager-page.ts
+++ b/src/app/tool-manager-page.ts
@@ -469,7 +469,7 @@ function renderListView(): TemplateResult {
 	const chevronSvg = html`<svg class="tool-group-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>`;
 
 	return html`
-		<p class="text-sm text-muted-foreground mb-3" style="max-width: 700px; margin: 0 auto;">Tools are the capabilities available to agents \u2014 file editing, shell commands, web search, and more. This page lets you view and document them.</p>
+		<p class="text-sm text-muted-foreground mb-6" style="max-width: 700px; margin: 0 auto;">Tools are the capabilities available to agents \u2014 file editing, shell commands, web search, and more. This page lets you view and document them.</p>
 		<div class="tools-list">
 			${sortedGroups.map((groupName) => {
 				const groupTools = groups.get(groupName)!;

--- a/src/app/workflow-page.ts
+++ b/src/app/workflow-page.ts
@@ -784,7 +784,7 @@ function renderListView(): TemplateResult {
 	}
 
 	return html`
-		<p class="text-sm text-muted-foreground mb-3" style="max-width: 600px; margin: 0 auto;">Workflows define the stages (gates) a goal goes through \u2014 like design \u2192 implement \u2192 test \u2192 review. They ensure quality by enforcing order and verification.</p>
+		<p class="text-sm text-muted-foreground mb-6" style="max-width: 600px; margin: 0 auto;">Workflows define the stages (gates) a goal goes through \u2014 like design \u2192 implement \u2192 test \u2192 review. They ensure quality by enforcing order and verification.</p>
 		<div class="wf-list">
 			${workflows.map((wf) => renderWorkflowRow(wf))}
 		</div>

--- a/src/app/workflow-page.ts
+++ b/src/app/workflow-page.ts
@@ -784,7 +784,7 @@ function renderListView(): TemplateResult {
 	}
 
 	return html`
-		<p class="text-sm text-muted-foreground mb-6" style="max-width: 600px; margin: 0 auto;">Workflows define the stages (gates) a goal goes through \u2014 like design \u2192 implement \u2192 test \u2192 review. They ensure quality by enforcing order and verification.</p>
+		<p class="text-sm text-muted-foreground mb-6" style="max-width: 600px; margin-inline: auto;">Workflows define the stages (gates) a goal goes through \u2014 like design \u2192 implement \u2192 test \u2192 review. They ensure quality by enforcing order and verification.</p>
 		<div class="wf-list">
 			${workflows.map((wf) => renderWorkflowRow(wf))}
 		</div>


### PR DESCRIPTION
Follow-up to PR #103. The original `mb-6` change had no visible effect because the inline `margin: 0 auto` was overriding the Tailwind bottom margin class.

### Fix
Changed `margin: 0 auto` → `margin-inline: auto` in the inline style so `mb-6` (1.5rem bottom margin) actually takes effect.

### Files changed
- `src/app/role-manager-page.ts`
- `src/app/tool-manager-page.ts`
- `src/app/personality-manager-page.ts`
- `src/app/workflow-page.ts`