### PR TITLE
Debounce renderApp() to coalesce redundant full-app re-renders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,8 @@ REST API: `GET /api/mcp-servers` (list servers and status), `POST /api/mcp-serve
 
 **Debug compaction issues**: Check `_isCompacting`, `_compactionSyntheticMessages`, and `_usageStaleAfterCompaction` in `remote-agent.ts`. The `compacting_placeholder` message must be filtered out and re-added correctly across server refreshes. Manual compaction is fire-and-forget from the WS handler's perspective.
 
+**Debug renderApp performance**: `renderApp()` in `src/app/state.ts` is debounced via `requestAnimationFrame` — multiple calls within the same frame collapse into a single `doRenderApp()` execution. If you need synchronous DOM updates before layout measurement, use `renderAppSync()` from `state.ts` instead. To debug render frequency, add a temporary counter in the rAF callback in `state.ts` and log how many `doRenderApp()` calls occur per frame.
+
 **Debug gates**: Gate state is stored in `GateStore` (`.bobbit/state/gates.json`). Gate dependencies are enforced — if a signal fails, check gate status via `GET /api/goals/:id/gates`.
 
 ## Git conventions

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -341,12 +341,24 @@ export function resetArchivedExpandState(): void {
 // ============================================================================
 
 let _renderApp: () => void = () => {};
+let _renderScheduled = false;
 
 export function setRenderApp(fn: () => void): void {
 	_renderApp = fn;
 }
 
 export function renderApp(): void {
+	if (_renderScheduled) return;
+	_renderScheduled = true;
+	requestAnimationFrame(() => {
+		_renderScheduled = false;
+		_renderApp();
+	});
+}
+
+/** Synchronous render — bypasses rAF debounce for cases needing immediate DOM update before layout measurement. */
+export function renderAppSync(): void {
+	_renderScheduled = false;
 	_renderApp();
 }
 

--- a/tests/e2e/gates-api.spec.ts
+++ b/tests/e2e/gates-api.spec.ts
@@ -73,10 +73,11 @@ test.describe("Gates API", () => {
 			expect(resp.status).toBe(200);
 			const { gates } = await resp.json();
 
-			expect(gates).toHaveLength(3);
+			expect(gates).toHaveLength(4);
 			const ids = gates.map((g: any) => g.gateId);
 			expect(ids).toContain("design-doc");
 			expect(ids).toContain("implementation");
+			expect(ids).toContain("documentation");
 			expect(ids).toContain("ready-to-merge");
 
 			for (const gate of gates) {

--- a/tests/fixtures/render-debounce.html
+++ b/tests/fixtures/render-debounce.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+let _renderScheduled = false;
+let renderCount = 0;
+
+function doRender() { renderCount++; }
+
+function renderApp() {
+  if (_renderScheduled) return;
+  _renderScheduled = true;
+  requestAnimationFrame(() => {
+    _renderScheduled = false;
+    doRender();
+  });
+}
+
+function renderAppSync() {
+  _renderScheduled = false;
+  doRender();
+}
+
+function resetCount() { renderCount = 0; _renderScheduled = false; }
+
+// Expose to Playwright
+window.renderApp = renderApp;
+window.renderAppSync = renderAppSync;
+window.resetCount = resetCount;
+Object.defineProperty(window, 'renderCount', { get: () => renderCount });
+</script>
+</body>
+</html>

--- a/tests/render-debounce.spec.ts
+++ b/tests/render-debounce.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "@playwright/test";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const fixturePath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "fixtures/render-debounce.html",
+);
+
+test.describe("renderApp debounce", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`file://${fixturePath}`);
+  });
+
+  test("multiple renderApp() calls in one frame produce a single render", async ({ page }) => {
+    const count = await page.evaluate(async () => {
+      window.resetCount();
+      window.renderApp();
+      window.renderApp();
+      window.renderApp();
+      window.renderApp();
+      window.renderApp();
+      // Wait for rAF to fire
+      await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      return window.renderCount;
+    });
+    expect(count).toBe(1);
+  });
+
+  test("renderAppSync() executes immediately", async ({ page }) => {
+    const count = await page.evaluate(() => {
+      window.resetCount();
+      window.renderAppSync();
+      return window.renderCount;
+    });
+    expect(count).toBe(1);
+  });
+
+  test("renderAppSync() cancels pending rAF render flag but rAF callback still fires", async ({ page }) => {
+    const count = await page.evaluate(async () => {
+      window.resetCount();
+      window.renderApp(); // schedules rAF, sets _renderScheduled=true
+      window.renderAppSync(); // sets _renderScheduled=false, calls doRender() => count=1
+      // The rAF callback still fires: sets _renderScheduled=false (already false), calls doRender() => count=2
+      await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      return window.renderCount;
+    });
+    expect(count).toBe(2);
+  });
+
+  test("renderApp() after rAF fires triggers a new render", async ({ page }) => {
+    const count = await page.evaluate(async () => {
+      window.resetCount();
+      window.renderApp();
+      await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      // First rAF cycle done, count should be 1
+      window.renderApp();
+      await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      return window.renderCount;
+    });
+    expect(count).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Wraps `renderApp()` in `src/app/state.ts` with `requestAnimationFrame`-based coalescing so that multiple calls within the same frame collapse into a single `doRenderApp()` execution.

## Changes

- **`src/app/state.ts`** — rAF debounce for `renderApp()`, plus `renderAppSync()` escape hatch (+12 lines)
- **`tests/fixtures/render-debounce.html`** + **`tests/render-debounce.spec.ts`** — 4 unit tests for debounce behavior
- **`tests/e2e/gates-api.spec.ts`** — fix pre-existing test expecting 3 gates (now 4 with documentation gate)
- **`AGENTS.md`** — debugging tip for renderApp performance

## Test results
- Type check: pass
- Unit tests: 323/323 pass
- E2E tests: 315/315 pass