### PR TITLE
Fix palette flash on load

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,12 @@
 	</head>
 	<body class="bg-background">
 		<div id="app"></div>
+		<script>
+			(function() {
+				var p = localStorage.getItem('palette');
+				if (p && p !== 'forest') document.documentElement.dataset.palette = p;
+			})();
+		</script>
 		<script type="module" src="/src/app/main.ts"></script>
 	</body>
 </html>

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -317,6 +317,9 @@ async function initApp() {
 					const prefs = await prefRes.json();
 					if (prefs.palette && prefs.palette !== "forest") {
 						document.documentElement.dataset.palette = prefs.palette;
+						localStorage.setItem('palette', prefs.palette);
+					} else {
+						localStorage.removeItem('palette');
 					}
 					// Apply showTimestamps
 					if (prefs.showTimestamps) {
@@ -552,8 +555,10 @@ async function initApp() {
 			const palette = (prefs.palette as string) || "forest";
 			if (palette === "forest") {
 				delete document.documentElement.dataset.palette;
+				localStorage.removeItem('palette');
 			} else {
 				document.documentElement.dataset.palette = palette;
+				localStorage.setItem('palette', palette);
 			}
 			// Apply showTimestamps
 			document.documentElement.dataset.showTimestamps = prefs.showTimestamps ? "true" : "";

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -831,8 +831,10 @@ export class RemoteAgent {
 			const palette = prefs.palette as string;
 			if (!palette || palette === "forest") {
 				delete document.documentElement.dataset.palette;
+				localStorage.removeItem('palette');
 			} else {
 				document.documentElement.dataset.palette = palette;
+				localStorage.setItem('palette', palette);
 			}
 		}
 

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -338,8 +338,10 @@ function getActivePaletteId(): string {
 async function selectPalette(id: string): Promise<void> {
 	if (id === "forest") {
 		delete document.documentElement.dataset.palette;
+		localStorage.removeItem('palette');
 	} else {
 		document.documentElement.dataset.palette = id;
+		localStorage.setItem('palette', id);
 	}
 	try {
 		await gatewayFetch("/api/preferences", {


### PR DESCRIPTION
## Problem
On page load, the app always renders with the default "forest" palette before switching to the user's chosen palette, causing a visible flash of wrong colours every time the app loads.

## Solution
Mirror the palette preference to `localStorage` and apply it synchronously before first paint — matching the existing pattern used for the dark/light theme toggle.

### Changes (4 files, +15 lines)
- **`index.html`** — Blocking inline `<script>` reads palette from localStorage before first paint
- **`src/app/settings-page.ts`** — Write to localStorage when user selects a palette
- **`src/app/main.ts`** — Sync localStorage when server preferences load (init + visibilitychange)
- **`src/app/remote-agent.ts`** — Sync localStorage on live preference push from server

### Design
- "forest" is implicit default — absence of key means forest
- Server `/api/preferences` remains source of truth; localStorage is a fast cache only
- Type-check and all tests pass