### PR TITLE
Per-model thinking levels

### DIFF
--- a/.bobbit/config/project.yaml
+++ b/.bobbit/config/project.yaml
@@ -3,7 +3,7 @@ build_command: npm run build
 typecheck_command: npm run check
 test_unit_command: npx playwright test --config tests/playwright.config.ts
   --reporter=json 2>/dev/null | node scripts/test-filter.mjs
-test_e2e_command: npm run build:server && npx playwright test --config
+test_e2e_command: npm run build && npx playwright test --config
   playwright-e2e.config.ts --reporter=json 2>/dev/null | node
   scripts/test-filter.mjs
 worktree_setup_command: cp -r "$SOURCE_REPO/node_modules" node_modules

--- a/playwright-e2e.config.ts
+++ b/playwright-e2e.config.ts
@@ -5,7 +5,7 @@
  * port, unique BOBBIT_DIR, mock agent). This provides full isolation —
  * tests never interfere with each other or the real app.
  *
- * Prerequisites: `npm run build` (both server and UI).
+ * Global setup ensures both server and UI are built (builds only what's missing).
  */
 import { defineConfig } from "@playwright/test";
 
@@ -15,5 +15,6 @@ export default defineConfig({
 	timeout: 30_000,
 	workers: 4,
 	// No webServer — each worker spawns its own via gateway-harness.ts
+	globalSetup: "./tests/e2e/e2e-global-setup.ts",
 	globalTeardown: "./tests/e2e/e2e-teardown.ts",
 });

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -449,6 +449,10 @@ let aigwModels: Array<{ id: string; name: string; contextWindow: number; maxToke
 let prefSessionModel = "";   // "provider/modelId" e.g. "aigw/claude-sonnet-4-6" or "anthropic/claude-sonnet-4-6"
 let prefReviewModel = "";    // same format
 let prefNamingModel = "";    // same format
+let prefSessionThinking = "";   // "off"|"minimal"|"low"|"medium"|"high"|""
+let prefReviewThinking = "";
+let prefNamingThinking = "";
+let allModels: Array<{ id: string; provider: string; reasoning: boolean }> = [];
 let _modelsLoaded = false;
 
 function loadModelsState(): void {
@@ -456,9 +460,10 @@ function loadModelsState(): void {
 	_modelsLoaded = true;
 	(async () => {
 		try {
-			const [statusRes, prefsRes] = await Promise.all([
+			const [statusRes, prefsRes, modelsRes] = await Promise.all([
 				gatewayFetch("/api/aigw/status"),
 				gatewayFetch("/api/preferences"),
+				gatewayFetch("/api/models"),
 			]);
 			if (statusRes.ok) {
 				const data = await statusRes.json();
@@ -474,6 +479,15 @@ function loadModelsState(): void {
 				prefSessionModel = prefs["default.sessionModel"] || "";
 				prefReviewModel = prefs["default.reviewModel"] || "";
 				prefNamingModel = prefs["default.namingModel"] || "";
+				prefSessionThinking = prefs["default.sessionThinkingLevel"] || "";
+				prefReviewThinking = prefs["default.reviewThinkingLevel"] || "";
+				prefNamingThinking = prefs["default.namingThinkingLevel"] || "";
+			}
+			if (modelsRes.ok) {
+				const models = await modelsRes.json();
+				if (Array.isArray(models)) {
+					allModels = models;
+				}
 			}
 		} catch {}
 		renderApp();
@@ -504,6 +518,22 @@ async function setReviewModel(value: string): Promise<void> {
 async function setNamingModel(value: string): Promise<void> {
 	prefNamingModel = value;
 	await savePref("default.namingModel", value || null);
+	renderApp();
+}
+
+async function setSessionThinking(value: string): Promise<void> {
+	prefSessionThinking = value;
+	await savePref("default.sessionThinkingLevel", value || null);
+	renderApp();
+}
+async function setReviewThinking(value: string): Promise<void> {
+	prefReviewThinking = value;
+	await savePref("default.reviewThinkingLevel", value || null);
+	renderApp();
+}
+async function setNamingThinking(value: string): Promise<void> {
+	prefNamingThinking = value;
+	await savePref("default.namingThinkingLevel", value || null);
 	renderApp();
 }
 
@@ -649,6 +679,44 @@ function renderModelPicker(label: string, hint: string, value: string, onChange:
 	`;
 }
 
+function renderThinkingPicker(label: string, hint: string, value: string, onChange: (v: string) => void, modelValue: string) {
+	// Determine if selected model supports reasoning
+	let disabled = false;
+	let disabledReason = "";
+	if (modelValue) {
+		const model = allModels.find(m => `${m.provider}/${m.id}` === modelValue);
+		if (model && !model.reasoning) {
+			disabled = true;
+			disabledReason = "Selected model does not support thinking";
+		}
+	}
+
+	return html`
+		<div class="flex flex-col gap-1.5">
+			<label class="text-sm font-medium text-foreground ${disabled ? "opacity-50" : ""}">${label}</label>
+			<select
+				class="px-3 py-2 rounded-md border border-input bg-background text-foreground text-sm
+					focus:outline-none focus:ring-2 focus:ring-ring
+					${disabled ? "opacity-50 cursor-not-allowed" : ""}"
+				.value=${value}
+				?disabled=${disabled}
+				title=${disabled ? disabledReason : ""}
+				@change=${(e: Event) => {
+					onChange((e.target as HTMLSelectElement).value);
+				}}
+			>
+				<option value="">(Auto)</option>
+				<option value="off">Off</option>
+				<option value="minimal">Minimal</option>
+				<option value="low">Low</option>
+				<option value="medium">Medium</option>
+				<option value="high">High</option>
+			</select>
+			<p class="text-xs text-muted-foreground">${disabled ? disabledReason : hint}</p>
+		</div>
+	`;
+}
+
 function renderModelsTab() {
 	loadModelsState();
 
@@ -661,24 +729,51 @@ function renderModelsTab() {
 			<!-- Default model preferences -->
 			<div class="flex flex-col gap-4">
 				<h3 class="text-sm font-semibold text-foreground">Default Models</h3>
-				${renderModelPicker(
-					"Session Model",
-					"Model used when creating new sessions. \"Auto\" picks the best available model by tier.",
-					prefSessionModel,
-					setSessionModel,
-				)}
-				${renderModelPicker(
-					"Review Model",
-					"Model used for automated LLM code reviews during gate verification.",
-					prefReviewModel,
-					setReviewModel,
-				)}
-				${renderModelPicker(
-					"Naming Model",
-					"Lightweight model used to auto-generate session titles. Best with a fast, cheap model like Haiku.",
-					prefNamingModel,
-					setNamingModel,
-				)}
+				<div class="flex flex-col gap-3">
+					${renderModelPicker(
+						"Session Model",
+						"Model used when creating new sessions. \"Auto\" picks the best available model by tier.",
+						prefSessionModel,
+						setSessionModel,
+					)}
+					${renderThinkingPicker(
+						"Session Thinking Level",
+						"Thinking level applied to new sessions. Per-session toggle overrides this.",
+						prefSessionThinking,
+						setSessionThinking,
+						prefSessionModel,
+					)}
+				</div>
+				<div class="flex flex-col gap-3 pt-3 border-t border-border">
+					${renderModelPicker(
+						"Review Model",
+						"Model used for automated LLM code reviews during gate verification.",
+						prefReviewModel,
+						setReviewModel,
+					)}
+					${renderThinkingPicker(
+						"Review Thinking Level",
+						"Thinking level for automated gate review sessions.",
+						prefReviewThinking,
+						setReviewThinking,
+						prefReviewModel,
+					)}
+				</div>
+				<div class="flex flex-col gap-3 pt-3 border-t border-border">
+					${renderModelPicker(
+						"Naming Model",
+						"Lightweight model used to auto-generate session titles. Best with a fast, cheap model like Haiku.",
+						prefNamingModel,
+						setNamingModel,
+					)}
+					${renderThinkingPicker(
+						"Naming Thinking Level",
+						"Thinking level for session title generation.",
+						prefNamingThinking,
+						setNamingThinking,
+						prefNamingModel,
+					)}
+				</div>
 			</div>
 
 			<!-- AI Gateway section -->
@@ -858,30 +953,7 @@ function renderProjectTab() {
 
 	return html`
 		<div class="flex flex-col gap-3">
-			<!-- Default Thinking Level -->
-			<div class="flex flex-col gap-1.5">
-				<label class="text-sm font-medium text-foreground">Default Thinking Level</label>
-				<p class="text-xs text-muted-foreground">
-					Thinking level applied to new sessions. Per-session toggle overrides this.
-				</p>
-				<select
-					class="px-3 py-2 rounded-md border border-input bg-background text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-					.value=${projectConfig["default_thinking_level"] || ""}
-					@change=${(e: Event) => {
-						projectConfig["default_thinking_level"] = (e.target as HTMLSelectElement).value;
-						projectSaveStatus = "";
-						renderApp();
-					}}
-				>
-					<option value="">(Agent default)</option>
-					<option value="off">Off</option>
-					<option value="minimal">Minimal</option>
-					<option value="low">Low</option>
-					<option value="medium">Medium</option>
-					<option value="high">High</option>
-				</select>
-			</div>
-			<hr class="border-border" />
+
 			<!-- Default entries -->
 			${defaultKeys.map((key) => html`
 				<div class="flex items-end gap-2">

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -2076,7 +2076,8 @@ export class SessionManager {
 	private getTitleGenOptions(): import("./title-generator.js").TitleGenOptions {
 		const namingModel = this.preferencesStore?.get("default.namingModel") as string | undefined;
 		const aigwUrl = this.preferencesStore ? getAigwUrl(this.preferencesStore) : undefined;
-		return { namingModel: namingModel || undefined, aigwUrl };
+		const namingThinking = this.preferencesStore?.get("default.namingThinkingLevel") as string | undefined;
+		return { namingModel: namingModel || undefined, aigwUrl, thinkingLevel: namingThinking || undefined };
 	}
 
 	private async autoGenerateTitleFromText(session: SessionInfo, userText: string): Promise<void> {

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -1511,10 +1511,16 @@ export class SessionManager {
 		}
 	}
 
-	/** Apply default_thinking_level from project config if set. */
+	/** Apply default_thinking_level from preferences (per-model) or project config (legacy). */
 	private async tryApplyDefaultThinkingLevel(session: SessionInfo): Promise<void> {
-		if (!this.projectConfigStore) return;
-		const level = this.projectConfigStore.get("default_thinking_level");
+		// Prefer per-model thinking preference, fall back to project config
+		let level: string | undefined;
+		if (this.preferencesStore) {
+			level = this.preferencesStore.get("default.sessionThinkingLevel") as string | undefined;
+		}
+		if (!level && this.projectConfigStore) {
+			level = this.projectConfigStore.get("default_thinking_level");
+		}
 		if (!level) return;
 		const valid = ["off", "minimal", "low", "medium", "high"];
 		if (!valid.includes(level)) return;

--- a/src/server/agent/title-generator.ts
+++ b/src/server/agent/title-generator.ts
@@ -18,6 +18,8 @@ export interface TitleGenOptions {
 	namingModel?: string;
 	/** AI Gateway URL for proxying requests (used when provider is "aigw") */
 	aigwUrl?: string;
+	/** Thinking level for title generation: "off"|"minimal"|"low"|"medium"|"high" */
+	thinkingLevel?: string;
 }
 
 interface AuthCredentials {
@@ -132,12 +134,12 @@ async function resolveGatewayModelId(baseUrl: string, strippedId: string): Promi
 /**
  * Generate title via the AI Gateway using OpenAI-compatible chat completions.
  */
-async function generateViaGateway(aigwUrl: string, modelId: string, preview: string): Promise<string | null> {
+async function generateViaGateway(aigwUrl: string, modelId: string, preview: string, thinkingLevel?: string): Promise<string | null> {
 	const baseUrl = aigwUrl.replace(/\/+$/, "");
 	const resolvedModel = await resolveGatewayModelId(baseUrl, modelId);
 	const url = baseUrl.endsWith("/v1") ? `${baseUrl}/chat/completions` : `${baseUrl}/v1/chat/completions`;
 
-	const body = {
+	const body: any = {
 		model: resolvedModel,
 		max_tokens: 20,
 		messages: [
@@ -151,6 +153,16 @@ async function generateViaGateway(aigwUrl: string, modelId: string, preview: str
 			},
 		],
 	};
+
+	// Add thinking if configured and not "off"
+	if (thinkingLevel && thinkingLevel !== "off") {
+		const budgets: Record<string, number> = { minimal: 1024, low: 4096, medium: 10240, high: 32768 };
+		const budget = budgets[thinkingLevel];
+		if (budget) {
+			body.thinking = { type: "enabled", budget_tokens: budget };
+			body.max_tokens = Math.max(body.max_tokens, budget + 20);
+		}
+	}
 
 	console.log(`[title-gen] Requesting title via gateway model "${resolvedModel}"${resolvedModel !== modelId ? ` (resolved from "${modelId}")` : ""}…`);
 
@@ -183,7 +195,7 @@ async function generateViaGateway(aigwUrl: string, modelId: string, preview: str
 /**
  * Generate title via direct Anthropic API call.
  */
-async function generateViaAnthropic(preview: string): Promise<string | null> {
+async function generateViaAnthropic(preview: string, thinkingLevel?: string): Promise<string | null> {
 	let auth = loadAuth();
 	if (!auth) return null;
 
@@ -214,7 +226,7 @@ async function generateViaAnthropic(preview: string): Promise<string | null> {
 		? `You are Claude Code, Anthropic's official CLI for Claude. ${coreInstruction}`
 		: coreInstruction;
 
-	const body = {
+	const body: any = {
 		model: DEFAULT_TITLE_MODEL,
 		max_tokens: 12,
 		system: auth.type === "oauth"
@@ -227,6 +239,16 @@ async function generateViaAnthropic(preview: string): Promise<string | null> {
 			},
 		],
 	};
+
+	// Add thinking if configured and not "off"
+	if (thinkingLevel && thinkingLevel !== "off") {
+		const budgets: Record<string, number> = { minimal: 1024, low: 4096, medium: 10240, high: 32768 };
+		const budget = budgets[thinkingLevel];
+		if (budget) {
+			body.thinking = { type: "enabled", budget_tokens: budget };
+			body.max_tokens = Math.max(body.max_tokens, budget + 12);
+		}
+	}
 
 	console.log(`[title-gen] Requesting title via ${DEFAULT_TITLE_MODEL}…`);
 
@@ -280,7 +302,7 @@ export async function generateSessionTitle(messages: any[], options?: TitleGenOp
 		const slash = options.namingModel.indexOf("/");
 		if (slash > 0 && slash < options.namingModel.length - 1) {
 			const modelId = options.namingModel.slice(slash + 1);
-			return generateViaGateway(options.aigwUrl, modelId, preview);
+			return generateViaGateway(options.aigwUrl, modelId, preview, options.thinkingLevel);
 		}
 		console.warn(`[title-gen] Malformed namingModel preference: "${options.namingModel}", ignoring`);
 	}
@@ -288,7 +310,7 @@ export async function generateSessionTitle(messages: any[], options?: TitleGenOp
 	// Default: direct Anthropic API (works for both public and gateway-less setups).
 	// We don't fall back to the gateway without an explicit naming model because
 	// the gateway may not host the default Haiku model ID.
-	return generateViaAnthropic(preview);
+	return generateViaAnthropic(preview, options?.thinkingLevel);
 }
 
 // ── Goal title summarization ──────────────────────────────────────────

--- a/src/server/agent/verification-harness.ts
+++ b/src/server/agent/verification-harness.ts
@@ -623,6 +623,19 @@ export class VerificationHarness {
 				}
 			}
 
+			// Apply review thinking level if set
+			if (this.preferencesStore) {
+				const reviewThinking = this.preferencesStore.get("default.reviewThinkingLevel") as string | undefined;
+				if (reviewThinking && ["off", "minimal", "low", "medium", "high"].includes(reviewThinking)) {
+					try {
+						await session.rpcClient.setThinkingLevel(reviewThinking);
+						console.log(`[verification] Set review thinking level "${reviewThinking}" for ${sessionId}`);
+					} catch (err) {
+						console.warn(`[verification] Failed to set review thinking level:`, err);
+					}
+				}
+			}
+
 			// Send kickoff prompt and wait for idle
 			await session.rpcClient.prompt(kickoff);
 			await this.sessionManager!.waitForIdle(sessionId, timeoutMs);
@@ -725,6 +738,19 @@ export class VerificationHarness {
 						}
 					} else {
 						console.warn(`[verification] Malformed default.reviewModel preference: "${reviewModelPref}", ignoring`);
+					}
+				}
+			}
+
+			// Apply review thinking level if set
+			if (this.preferencesStore) {
+				const reviewThinking = this.preferencesStore.get("default.reviewThinkingLevel") as string | undefined;
+				if (reviewThinking && ["off", "minimal", "low", "medium", "high"].includes(reviewThinking)) {
+					try {
+						await rpc.setThinkingLevel(reviewThinking);
+						console.log(`[verification] Set review thinking level "${reviewThinking}" for ${subSessionId}`);
+					} catch (err) {
+						console.warn(`[verification] Failed to set review thinking level:`, err);
 					}
 				}
 			}

--- a/tests/e2e/e2e-global-setup.ts
+++ b/tests/e2e/e2e-global-setup.ts
@@ -1,0 +1,31 @@
+/**
+ * Global setup for E2E tests: ensures both server and UI are built.
+ *
+ * The gateway harness serves the UI from dist/ui/ (static files) and runs
+ * the server from dist/server/cli.js. Without this build step, fullstack
+ * browser tests fail because the UI assets don't exist.
+ */
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+export default function globalSetup() {
+	const projectRoot = join(import.meta.dirname, "..", "..");
+	const serverEntry = join(projectRoot, "dist", "server", "cli.js");
+	const uiDir = join(projectRoot, "dist", "ui");
+
+	// Only build what's missing to keep repeated runs fast
+	const needServer = !existsSync(serverEntry);
+	const needUI = !existsSync(uiDir);
+
+	if (needServer && needUI) {
+		console.log("[e2e-setup] Building server and UI...");
+		execSync("npm run build", { cwd: projectRoot, stdio: "inherit" });
+	} else if (needServer) {
+		console.log("[e2e-setup] Building server...");
+		execSync("npm run build:server", { cwd: projectRoot, stdio: "inherit" });
+	} else if (needUI) {
+		console.log("[e2e-setup] Building UI...");
+		execSync("npm run build:ui", { cwd: projectRoot, stdio: "inherit" });
+	}
+}


### PR DESCRIPTION
## Summary

Adds per-model thinking level configuration to the Models tab in Settings, replacing the single global dropdown on the Project tab.

### Changes

**UI (settings-page.ts)**
- Added thinking level selectors (Auto/Off/Minimal/Low/Medium/High) paired with each model picker (Session, Review, Naming)
- Disabled state + tooltip when selected model doesn't support reasoning (via /api/models lookup)
- Removed thinking level dropdown from Project tab

**Server**
- `session-manager.ts`: `tryApplyDefaultThinkingLevel()` reads `default.sessionThinkingLevel` pref first, falls back to `default_thinking_level` project config
- `session-manager.ts`: `getNamingOptions()` reads and passes `default.namingThinkingLevel`
- `verification-harness.ts`: Both review session paths apply `default.reviewThinkingLevel`
- `title-generator.ts`: Extended `TitleGenOptions` with `thinkingLevel`, applied in both gateway and Anthropic API paths

**Test infrastructure**
- Added E2E globalSetup that builds server+UI before tests
- Fixed pre-existing session-lifecycle-ui test failure
- Updated project config E2E command to build both server and UI

### Backward compatibility
- `default_thinking_level` in project config still works as fallback
- Per-session toggle still overrides defaults

### Tests
- Type check: clean
- Unit: 325/325
- E2E: 319/319