### PR TITLE
Claude Code Memory Bridge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,12 +141,14 @@ Thinking token budgets per level (hardcoded in `src/app/remote-agent.ts`, not cu
 
 ### Claude Code memory integration
 
+Bobbit bridges Claude Code's project knowledge into agent sessions, so that preferences, conventions, and project context captured in Claude Code are automatically available to Bobbit agents without re-teaching. See also `docs/features.md` "System Prompt Assembly" for the full prompt layer order.
+
 Bobbit reads `CLAUDE.md` from the session's working directory alongside `AGENTS.md`. Both files support `@filename.md` reference expansion. If `CLAUDE.md` contains only `@AGENTS.md`, it is skipped to avoid duplication. When both exist with distinct content, CLAUDE.md is merged into the "Project Context" section of the assembled prompt.
 
 Bobbit also reads Claude Code's project memory files from `~/.claude/projects/{encodedCwd}/memory/*.md`, where `encodedCwd` is the session's working directory with `/` replaced by `-`:
 
 ```
-/Users/aj/Documents/Development/bobbit → -Users-aj-Documents-Development-bobbit
+/home/user/my-project → -home-user-my-project
 ```
 
 **Filtering:** Only memory files with frontmatter `type` of `user`, `feedback`, or `project` are included — `reference` type files are skipped. The index file `MEMORY.md` is also skipped. A maximum of 20 files are included (sorted alphabetically), with total content capped at ~4000 tokens (~16000 characters).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,22 @@ Thinking token budgets per level (hardcoded in `src/app/remote-agent.ts`, not cu
 | medium | 10,240 |
 | high | 32,768 |
 
+### Claude Code memory integration
+
+Bobbit reads `CLAUDE.md` from the session's working directory alongside `AGENTS.md`. Both files support `@filename.md` reference expansion. If `CLAUDE.md` contains only `@AGENTS.md`, it is skipped to avoid duplication. When both exist with distinct content, CLAUDE.md is merged into the "Project Context" section of the assembled prompt.
+
+Bobbit also reads Claude Code's project memory files from `~/.claude/projects/{encodedCwd}/memory/*.md`, where `encodedCwd` is the session's working directory with `/` replaced by `-`:
+
+```
+/Users/aj/Documents/Development/bobbit → -Users-aj-Documents-Development-bobbit
+```
+
+**Filtering:** Only memory files with frontmatter `type` of `user`, `feedback`, or `project` are included — `reference` type files are skipped. The index file `MEMORY.md` is also skipped. A maximum of 20 files are included (sorted alphabetically), with total content capped at ~4000 tokens (~16000 characters).
+
+**Prompt assembly order:** Memories appear as a `# Claude Code Project Memories` section after the Project Context (AGENTS.md + CLAUDE.md) and before the Goal spec. In the prompt inspector UI, CLAUDE.md and memories appear as separate labeled sections.
+
+**Timing:** Memory files are read at session creation time only (same as AGENTS.md). If the memory directory doesn't exist, it is silently skipped.
+
 ## Debugging tips
 
 **Debug duplicate messages**: The deferred message pattern in `remote-agent.ts` is subtle. `MessageList` renders `state.messages` (completed), `StreamingMessageContainer` renders `state.streamMessage` (in-progress). They must never show the same message. Tool-call messages stay in streaming until the next message starts. Check `flushDeferredMessage()` and `_deferredAssistantMessage`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,8 @@ Thinking token budgets per level (hardcoded in `src/app/remote-agent.ts`, not cu
 
 **Debug gate re-signal cancellation**: When a gate is re-signaled, `cancelStaleVerifications()` in `verification-harness.ts` terminates reviewer sessions from the prior signal and marks the old `ActiveVerification` as cancelled. The cancelled flag is checked after `Promise.all` resolves to suppress stale results. If reviewer sessions aren't being cancelled, check that `sessionManager` and `teamManager` are passed to the `VerificationHarness` constructor. Active verifications are tracked in `activeVerifications` map, keyed by signal ID — use `GET /api/goals/:goalId/verifications/active` to inspect in-flight state.
 
+**Debug archived session sidebar rendering**: Archived team members are shown under their team lead when "See Archived" is toggled on. The mapping uses `teamLeadSessionId` — members with a matching ID go to that lead, members with no `teamLeadSessionId` default to the live team lead, and orphan references (pointing to non-existent leads) also default to the live lead. The rendering logic is in `renderGoalGroup()` in `src/app/render-helpers.ts`. If archived members don't appear, check that `state.showArchived` is true and that the filtering in `archivedForLiveLead` and the archived block's `unmapped` fallback cover the member's `teamLeadSessionId` state.
+
 ## Git conventions
 
 The primary branch is **`master`** (not `main`). If the user refers to "main", treat it as `master`. Never create a `main` branch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ If you only changed UI code (`src/ui/`, `src/app/`), unit tests are sufficient. 
 
 **Add a new UI component**: Add to `src/ui/components/`, export from `src/ui/index.ts`.
 
-**Add a new tool renderer**: Create in `src/ui/tools/renderers/`, register in `src/ui/tools/index.ts`.
+**Add a new tool renderer**: Create in `src/ui/tools/renderers/`, register in `src/ui/tools/index.ts`. Note: `WebFetchRenderer` detects markdown content (via `isMarkdownContent()` in `WebFetchRenderer.ts`) and renders it as formatted HTML using the `<markdown-web-content>` element (`MarkdownWebContent.ts`), which wraps `<markdown-block>` from mini-lit with a Preview/Raw toggle. Detection uses URL extension (`.md`, `.markdown`) and content-based heuristics (headings, code fences, links, etc.).
 
 **Add a slash skill**: Create a `SKILL.md` file in `.claude/skills/<name>/` (project-level) or `~/.claude/skills/<name>/` (personal). The file should have YAML frontmatter with `description` and optional `argument_hint`, `allowed_tools`, `context`, `agent` fields. Skills are discovered automatically via `discoverSlashSkills()` in `src/server/skills/slash-skills.ts` and served at `GET /api/slash-skills`. You can also configure additional skill directories via the Skills page UI (`#/skills`) or by adding `skill_directories` to `.bobbit/config/project.yaml`:
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -107,11 +107,13 @@ Context compaction reduces token usage by summarising the conversation.
 
 ## System Prompt Assembly
 
-Each session's system prompt is assembled from three layers:
+Each session's system prompt is assembled from these layers (in order):
 
 1. **Global** — `.bobbit/config/system-prompt.md` from the Bobbit project root
 2. **AGENTS.md** — From the session's working directory, with `@FILENAME.md` inline inclusion (recursive, circular-reference safe)
-3. **Goal spec** — If the session belongs to a goal, the goal's spec is appended
+3. **CLAUDE.md** — From the session's working directory (if present and not just `@AGENTS.md`), merged into the Project Context section alongside AGENTS.md
+4. **Claude Code project memories** — Memory files from `~/.claude/projects/{encodedCwd}/memory/*.md`, filtered by type and capped at 20 files / ~4000 tokens (see AGENTS.md "Claude Code memory integration" for details)
+5. **Goal spec** — If the session belongs to a goal, the goal's spec is appended
 
 The assembled prompt is written to `.bobbit/state/session-prompts/{sessionId}.md` and cleaned up on session termination.
 

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -208,8 +208,10 @@ export async function refreshSessions(): Promise<void> {
 			.catch(() => {});
 	}
 
-	// Lazy-load archived sessions on initial load only if user had "Show archived" persisted
-	if (isInitial && state.showArchived && !_archivedSessionsLoaded) {
+	// Lazy-load archived sessions on initial load only if user had "Show archived" persisted.
+	// Also re-fetch when sessions changed while archived view is active, so newly-archived
+	// sessions appear immediately without requiring a manual toggle.
+	if (state.showArchived && (isInitial && !_archivedSessionsLoaded || sessionsChanged && _archivedSessionsLoaded)) {
 		fetchArchivedSessions();
 	}
 }

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -594,7 +594,7 @@ export function renderGoalGroup(goal: Goal) {
 
 						return html`
 							${archivedLeads.map((s, i) => renderLeadWithMembers(s, i === archivedLeads.length - 1 && !teamLead))}
-							${teamLead && unmapped.length > 0 ? unmapped.map(m => html`
+							${!teamLead && unmapped.length > 0 ? unmapped.map(m => html`
 								${renderArchivedSessionRow(m)}
 								${renderArchivedDelegates(m.id)}
 							`) : ""}

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -518,8 +518,9 @@ export function renderGoalGroup(goal: Goal) {
 		if (!teamLead) return goalSessions.map(renderSessionRow);
 		const tlExpanded = isTeamLeadExpanded(teamLead.id);
 		// Archived members belonging to the live lead
+		const archivedLeadIds = new Set(state.archivedSessions.filter(s => s.teamGoalId === goal.id && s.role === "team-lead").map(s => s.id));
 		const archivedForLiveLead = state.showArchived
-			? state.archivedSessions.filter(s => s.teamGoalId === goal.id && !s.delegateOf && s.role !== "team-lead" && s.teamLeadSessionId === teamLead.id)
+			? state.archivedSessions.filter(s => s.teamGoalId === goal.id && !s.delegateOf && s.role !== "team-lead" && (s.teamLeadSessionId === teamLead.id || !s.teamLeadSessionId || !archivedLeadIds.has(s.teamLeadSessionId)))
 			: [];
 		return html`
 			${renderTeamLeadRow(teamLead, teamChildren.length + archivedForLiveLead.length, tlExpanded)}
@@ -593,6 +594,10 @@ export function renderGoalGroup(goal: Goal) {
 
 						return html`
 							${archivedLeads.map((s, i) => renderLeadWithMembers(s, i === archivedLeads.length - 1 && !teamLead))}
+							${teamLead && unmapped.length > 0 ? unmapped.map(m => html`
+								${renderArchivedSessionRow(m)}
+								${renderArchivedDelegates(m.id)}
+							`) : ""}
 						`;
 					})() : ""}
 				</div>

--- a/src/server/agent/system-prompt.ts
+++ b/src/server/agent/system-prompt.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { bobbitStateDir } from "../bobbit-dir.js";
 
@@ -62,6 +63,84 @@ export function readAgentsMd(cwd: string): string {
 	try {
 		const raw = fs.readFileSync(agentsPath, "utf-8");
 		return resolveMarkdownRefs(raw, cwd);
+	} catch {
+		return "";
+	}
+}
+
+/**
+ * Parse YAML frontmatter from a Claude Code memory file.
+ * Returns extracted fields and body content, or null if invalid.
+ */
+export function parseMemoryFile(content: string): { name: string; description: string; type: string; body: string } | null {
+	if (!content.startsWith('---')) return null;
+	const endIdx = content.indexOf('\n---', 3);
+	if (endIdx === -1) return null;
+	const frontmatter = content.slice(3, endIdx);
+	const body = content.slice(endIdx + 4).trim();
+	const name = frontmatter.match(/^name:\s*(.+)$/m)?.[1]?.trim() || '';
+	const description = frontmatter.match(/^description:\s*(.+)$/m)?.[1]?.trim() || '';
+	const type = frontmatter.match(/^type:\s*(.+)$/m)?.[1]?.trim() || '';
+	return { name, description, type, body };
+}
+
+/**
+ * Read CLAUDE.md from a directory, resolving `@` references.
+ * Returns empty string if not found or if content is just `@AGENTS.md` (dedup).
+ */
+export function readClaudeMd(cwd: string): string {
+	const claudePath = path.join(cwd, "CLAUDE.md");
+	if (!fs.existsSync(claudePath)) return "";
+
+	try {
+		const raw = fs.readFileSync(claudePath, "utf-8");
+		// Skip if CLAUDE.md is just a reference to AGENTS.md (avoid duplication)
+		if (raw.trim() === "@AGENTS.md") return "";
+		return resolveMarkdownRefs(raw, cwd);
+	} catch {
+		return "";
+	}
+}
+
+/**
+ * Read Claude Code project memory files from ~/.claude/projects/{encodedCwd}/memory/*.md.
+ * Returns a formatted section string, or empty string if no memories found.
+ */
+export function readClaudeCodeMemories(cwd: string): string {
+	try {
+		const encodedCwd = cwd.replace(/\//g, "-");
+		const memoryDir = path.join(os.homedir(), ".claude", "projects", encodedCwd, "memory");
+
+		if (!fs.existsSync(memoryDir)) return "";
+
+		const files = fs.readdirSync(memoryDir)
+			.filter(f => f.endsWith(".md") && f !== "MEMORY.md")
+			.sort()
+			.slice(0, 20);
+
+		if (files.length === 0) return "";
+
+		const allowedTypes = new Set(["user", "feedback", "project"]);
+		const parts: string[] = [];
+		let totalLength = 0;
+
+		for (const file of files) {
+			try {
+				const content = fs.readFileSync(path.join(memoryDir, file), "utf-8");
+				const parsed = parseMemoryFile(content);
+				if (!parsed || !allowedTypes.has(parsed.type)) continue;
+
+				const entry = `### ${parsed.name}\n\n${parsed.body}`;
+				if (totalLength + entry.length > 16000) break;
+				parts.push(entry);
+				totalLength += entry.length;
+			} catch {
+				// Skip unreadable files
+			}
+		}
+
+		if (parts.length === 0) return "";
+		return "# Claude Code Project Memories\n\n" + parts.join("\n\n");
 	} catch {
 		return "";
 	}
@@ -132,6 +211,23 @@ export function assembleSystemPrompt(sessionId: string, parts: PromptParts): str
 	const agentsMd = readAgentsMd(parts.cwd);
 	if (agentsMd.trim()) {
 		sections.push("# Project Context\n\n" + agentsMd.trim());
+	}
+
+	// 2.5. CLAUDE.md from working directory
+	const claudeMd = readClaudeMd(parts.cwd);
+	if (claudeMd.trim()) {
+		if (agentsMd.trim()) {
+			// Merge into the existing Project Context section
+			sections[sections.length - 1] = "# Project Context\n\n" + agentsMd.trim() + "\n\n" + claudeMd.trim();
+		} else {
+			sections.push("# Project Context\n\n" + claudeMd.trim());
+		}
+	}
+
+	// 2.7. Claude Code project memories
+	const memories = readClaudeCodeMemories(parts.cwd);
+	if (memories.trim()) {
+		sections.push(memories);
 	}
 
 	// 3. Goal spec (merge rolePrompt and toolRestrictions into goalSpec section for backward compat)
@@ -216,6 +312,18 @@ export function getPromptSections(parts: PromptParts): PromptSection[] {
 	// 2. AGENTS.md
 	const agentsMd = readAgentsMd(parts.cwd);
 	if (agentsMd.trim()) sections.push({ label: "Project Context", source: "AGENTS.md", content: agentsMd.trim() });
+
+	// 2.5. CLAUDE.md
+	const claudeMd = readClaudeMd(parts.cwd);
+	if (claudeMd.trim()) {
+		sections.push({ label: "CLAUDE.md", source: "CLAUDE.md", content: claudeMd.trim() });
+	}
+
+	// 2.7. Claude Code memories
+	const memoriesContent = readClaudeCodeMemories(parts.cwd);
+	if (memoriesContent.trim()) {
+		sections.push({ label: "Claude Code Memories", source: "~/.claude/projects/.../memory/", content: memoriesContent.trim() });
+	}
 
 	// 3. Goal spec (separate from role)
 	if (parts.goalSpec?.trim()) {

--- a/src/ui/tools/renderers/MarkdownWebContent.ts
+++ b/src/ui/tools/renderers/MarkdownWebContent.ts
@@ -1,0 +1,45 @@
+import { LitElement, html } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import "@mariozechner/mini-lit/dist/MarkdownBlock.js";
+
+@customElement("markdown-web-content")
+export class MarkdownWebContent extends LitElement {
+	@property() content = "";
+	@state() private mode: "preview" | "raw" = "preview";
+
+	createRenderRoot() {
+		return this;
+	}
+
+	render() {
+		return html`
+			<div class="flex justify-end mb-1 gap-1">
+				<button
+					@click=${() => (this.mode = "preview")}
+					class="text-xs px-2 py-0.5 rounded ${this.mode === "preview"
+						? "text-foreground bg-muted"
+						: "text-muted-foreground hover:text-foreground"}"
+				>
+					Preview
+				</button>
+				<button
+					@click=${() => (this.mode = "raw")}
+					class="text-xs px-2 py-0.5 rounded ${this.mode === "raw"
+						? "text-foreground bg-muted"
+						: "text-muted-foreground hover:text-foreground"}"
+				>
+					Raw
+				</button>
+			</div>
+			${this.mode === "preview"
+				? html`<markdown-block .content=${this.content}></markdown-block>`
+				: html`<code-block .code=${this.content} language="markdown"></code-block>`}
+		`;
+	}
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		"markdown-web-content": MarkdownWebContent;
+	}
+}

--- a/src/ui/tools/renderers/WebFetchRenderer.ts
+++ b/src/ui/tools/renderers/WebFetchRenderer.ts
@@ -4,6 +4,7 @@ import { createRef, ref } from "lit/directives/ref.js";
 import { Globe } from "lucide";
 import { renderCollapsibleHeader, renderHeader, getToolState } from "../renderer-registry.js";
 import type { ToolRenderer, ToolRenderResult } from "../types.js";
+import "./MarkdownWebContent.js";
 
 interface WebFetchParams {
 	url: string;
@@ -27,6 +28,40 @@ function getDomain(url: string): string {
 	} catch {
 		return url;
 	}
+}
+
+export function isMarkdownContent(url: string, content: string): boolean {
+	// URL-based: path ends with .md or .markdown (case-insensitive, ignoring query/hash)
+	try {
+		const pathname = new URL(url).pathname.toLowerCase();
+		if (pathname.endsWith(".md") || pathname.endsWith(".markdown")) {
+			return true;
+		}
+	} catch {
+		// If URL parsing fails, try simple string check
+		const pathPart = url.split("?")[0].split("#")[0].toLowerCase();
+		if (pathPart.endsWith(".md") || pathPart.endsWith(".markdown")) {
+			return true;
+		}
+	}
+
+	// Content-based fallback: check first 500 chars for markdown patterns
+	const sample = content.slice(0, 500);
+
+	// Strong signals: starts with markdown frontmatter or heading
+	if (/^---\s*\n/.test(sample)) return true;
+	if (/^#{1,6}\s+\S/.test(sample)) return true;
+
+	// Weak signals: require multiple indicators
+	let indicators = 0;
+	if (/^#{1,6}\s+/m.test(sample)) indicators++;
+	if (/\[.+?\]\(.+?\)/.test(sample)) indicators++;
+	if (/```/.test(sample)) indicators++;
+	if (/^\s*[-*+]\s+/m.test(sample)) indicators++;
+	if (/^\s*\d+\.\s+/m.test(sample)) indicators++;
+	if (/\*\*.+?\*\*/.test(sample)) indicators++;
+
+	return indicators >= 2;
 }
 
 function formatSize(chars: number): string {
@@ -70,7 +105,9 @@ export class WebFetchRenderer implements ToolRenderer<WebFetchParams, any> {
 							<div class="text-xs text-muted-foreground mt-2 mb-1">${metaText}</div>
 							${result.isError
 								? html`<console-block .content=${output} .variant=${"error"}></console-block>`
-								: html`<code-block .code=${output} language="text"></code-block>`}
+								: isMarkdownContent(params.url, output)
+									? html`<markdown-web-content .content=${output}></markdown-web-content>`
+									: html`<code-block .code=${output} language="text"></code-block>`}
 						</div>
 					</div>
 				`,

--- a/tests/archived-sessions-refresh.spec.ts
+++ b/tests/archived-sessions-refresh.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect } from "@playwright/test";
+import path from "node:path";
+
+const TEST_PAGE = `file://${path.resolve("tests/fixtures/archived-sessions-refresh.html")}`;
+
+test.describe("Archived sessions auto-refresh", () => {
+
+	test("newly archived session appears without toggling showArchived", async ({ page }) => {
+		await page.goto(TEST_PAGE);
+
+		const result = await page.evaluate(async () => {
+			const state = (window as any).__state;
+			const refresh = (window as any).__refreshSessions;
+
+			// Setup: 2 live sessions, showArchived on, archived sessions already loaded
+			state.showArchived = true;
+			(window as any).__setArchivedSessionsLoaded(true);
+			(window as any).__serverSessions = [
+				{ id: "s1", status: "idle" },
+				{ id: "s2", status: "idle" },
+			];
+			(window as any).__serverArchivedSessions = [];
+			(window as any).__serverSessionsGeneration = 1;
+
+			// Initial fetch
+			await refresh();
+			const liveAfterInit = state.gatewaySessions.length;
+			const archivedAfterInit = state.archivedSessions.length;
+
+			// Now s2 gets archived — server returns s2 as archived
+			(window as any).__serverSessions = [{ id: "s1", status: "idle" }];
+			(window as any).__serverArchivedSessions = [{ id: "s2", status: "terminated", archived: true }];
+			(window as any).__serverSessionsGeneration = 2;
+			(window as any).__fetchLog.length = 0;
+
+			await refresh();
+
+			const archivedFetches = (window as any).__fetchLog.filter(
+				(e: any) => e.path.includes("include=archived")
+			);
+
+			return {
+				liveAfterInit,
+				archivedAfterInit,
+				liveAfterArchive: state.gatewaySessions.length,
+				archivedAfterArchive: state.archivedSessions.length,
+				archivedIds: state.archivedSessions.map((s: any) => s.id),
+				archivedFetchCount: archivedFetches.length,
+			};
+		});
+
+		expect(result.liveAfterInit).toBe(2);
+		expect(result.archivedAfterInit).toBe(0);
+		expect(result.liveAfterArchive).toBe(1);
+		expect(result.archivedAfterArchive).toBe(1);
+		expect(result.archivedIds).toEqual(["s2"]);
+		expect(result.archivedFetchCount).toBe(1);
+	});
+
+	test("archived sessions not re-fetched when showArchived is off", async ({ page }) => {
+		await page.goto(TEST_PAGE);
+
+		const fetchCount = await page.evaluate(async () => {
+			const state = (window as any).__state;
+			const refresh = (window as any).__refreshSessions;
+
+			state.showArchived = false;
+			(window as any).__setArchivedSessionsLoaded(false);
+			(window as any).__serverSessions = [{ id: "s1", status: "idle" }];
+			(window as any).__serverArchivedSessions = [{ id: "s2", status: "terminated", archived: true }];
+			(window as any).__serverSessionsGeneration = 1;
+
+			await refresh();
+			(window as any).__fetchLog.length = 0;
+
+			// Change sessions — but showArchived is off
+			(window as any).__serverSessions = [];
+			(window as any).__serverSessionsGeneration = 2;
+
+			await refresh();
+
+			return (window as any).__fetchLog.filter(
+				(e: any) => e.path.includes("include=archived")
+			).length;
+		});
+
+		expect(fetchCount).toBe(0);
+	});
+
+	test("archived sessions not re-fetched when sessions unchanged", async ({ page }) => {
+		await page.goto(TEST_PAGE);
+
+		const fetchCount = await page.evaluate(async () => {
+			const state = (window as any).__state;
+			const refresh = (window as any).__refreshSessions;
+
+			state.showArchived = true;
+			(window as any).__setArchivedSessionsLoaded(true);
+			(window as any).__serverSessions = [{ id: "s1", status: "idle" }];
+			(window as any).__serverArchivedSessions = [];
+			(window as any).__serverSessionsGeneration = 1;
+
+			// Initial fetch to set generation
+			await refresh();
+			(window as any).__fetchLog.length = 0;
+
+			// Same generation — no change
+			await refresh();
+
+			return (window as any).__fetchLog.filter(
+				(e: any) => e.path.includes("include=archived")
+			).length;
+		});
+
+		expect(fetchCount).toBe(0);
+	});
+
+	test("initial load with showArchived on fetches archived sessions", async ({ page }) => {
+		await page.goto(TEST_PAGE);
+
+		const result = await page.evaluate(async () => {
+			const state = (window as any).__state;
+			const refresh = (window as any).__refreshSessions;
+
+			state.showArchived = true;
+			(window as any).__setArchivedSessionsLoaded(false);
+			(window as any).__serverSessions = [{ id: "s1", status: "idle" }];
+			(window as any).__serverArchivedSessions = [{ id: "old", status: "terminated", archived: true }];
+			(window as any).__serverSessionsGeneration = 1;
+
+			await refresh();
+
+			return {
+				loaded: (window as any).__archivedSessionsLoaded(),
+				count: state.archivedSessions.length,
+				ids: state.archivedSessions.map((s: any) => s.id),
+			};
+		});
+
+		expect(result.loaded).toBe(true);
+		expect(result.count).toBe(1);
+		expect(result.ids).toEqual(["old"]);
+	});
+});

--- a/tests/archived-team-agents.spec.ts
+++ b/tests/archived-team-agents.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from "@playwright/test";
+import path from "node:path";
+
+const TEST_PAGE = `file://${path.resolve("tests/fixtures/archived-team-agents.html")}`;
+
+test.describe("Archived team agents filtering", () => {
+	test("mapped member appears under live lead", async ({ page }) => {
+		await page.goto(TEST_PAGE);
+		const ids = JSON.parse(await page.locator("#archivedForLiveLead").textContent() ?? "[]");
+		expect(ids).toContain("member-mapped");
+	});
+
+	test("unmapped member (no teamLeadSessionId) appears under live lead", async ({ page }) => {
+		await page.goto(TEST_PAGE);
+		const ids = JSON.parse(await page.locator("#archivedForLiveLead").textContent() ?? "[]");
+		expect(ids).toContain("member-unmapped");
+	});
+
+	test("member with empty teamLeadSessionId appears under live lead", async ({ page }) => {
+		await page.goto(TEST_PAGE);
+		const ids = JSON.parse(await page.locator("#archivedForLiveLead").textContent() ?? "[]");
+		expect(ids).toContain("member-empty-lead");
+	});
+
+	test("member with archived lead stays with archived lead (not in live lead list)", async ({ page }) => {
+		await page.goto(TEST_PAGE);
+		const ids = JSON.parse(await page.locator("#archivedForLiveLead").textContent() ?? "[]");
+		expect(ids).not.toContain("member-archived-lead");
+	});
+
+	test("delegates are excluded from live lead list", async ({ page }) => {
+		await page.goto(TEST_PAGE);
+		const ids = JSON.parse(await page.locator("#archivedForLiveLead").textContent() ?? "[]");
+		expect(ids).not.toContain("member-delegate");
+	});
+
+	test("team-lead role sessions are excluded from live lead list", async ({ page }) => {
+		await page.goto(TEST_PAGE);
+		const ids = JSON.parse(await page.locator("#archivedForLiveLead").textContent() ?? "[]");
+		expect(ids).not.toContain("archived-lead-1");
+	});
+
+	test("member with orphan teamLeadSessionId appears under live lead", async ({ page }) => {
+		await page.goto(TEST_PAGE);
+		const ids = JSON.parse(await page.locator("#archivedForLiveLead").textContent() ?? "[]");
+		expect(ids).toContain("member-orphan-lead");
+	});
+
+	test("members from other goals are excluded", async ({ page }) => {
+		await page.goto(TEST_PAGE);
+		const ids = JSON.parse(await page.locator("#archivedForLiveLead").textContent() ?? "[]");
+		expect(ids).not.toContain("member-other-goal");
+	});
+
+	test("unmapped members returned when leads are known", async ({ page }) => {
+		await page.goto(TEST_PAGE);
+		const ids = JSON.parse(await page.locator("#unmappedArchived").textContent() ?? "[]");
+		// unmapped, empty-lead, and orphan-lead are not mapped to any known lead
+		expect(ids).toContain("member-unmapped");
+		expect(ids).toContain("member-empty-lead");
+		expect(ids).toContain("member-orphan-lead");
+		// mapped and archived-lead members ARE mapped
+		expect(ids).not.toContain("member-mapped");
+		expect(ids).not.toContain("member-archived-lead");
+	});
+
+	test("unmapped fallback: no archived leads, unmapped members still returned", async ({ page }) => {
+		await page.goto(TEST_PAGE);
+		const ids = JSON.parse(await page.locator("#unmappedNoArchivedLeads").textContent() ?? "[]");
+		// With no leads at all, ALL non-delegate non-lead members are unmapped
+		expect(ids.length).toBeGreaterThan(0);
+		expect(ids).toContain("member-unmapped");
+		expect(ids).toContain("member-empty-lead");
+		expect(ids).toContain("member-mapped");
+		expect(ids).toContain("member-archived-lead");
+		expect(ids).toContain("member-orphan-lead");
+		// Delegate and other-goal members still excluded
+		expect(ids).not.toContain("member-delegate");
+		expect(ids).not.toContain("member-other-goal");
+	});
+});

--- a/tests/fixtures/archived-sessions-refresh.html
+++ b/tests/fixtures/archived-sessions-refresh.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html>
+<head><title>Archived Sessions Refresh Test</title></head>
+<body>
+<script>
+// ============================================================================
+// Simulate the archived-sessions refresh logic from src/app/api.ts to verify
+// that newly-archived sessions appear automatically when showArchived is on.
+// ============================================================================
+
+const state = {
+  gatewaySessions: [],
+  archivedSessions: [],
+  showArchived: false,
+  sessionsGeneration: -1,
+  sessionsLoading: false,
+  sessionsError: "",
+  goals: [],
+  goalsGeneration: -1,
+};
+
+let _renderCount = 0;
+function renderApp() { _renderCount++; }
+
+// --- Fetch log ---
+window.__fetchLog = [];
+let _archivedSessionsLoaded = false;
+
+// Configurable server responses
+window.__serverSessions = [];
+window.__serverArchivedSessions = [];
+window.__serverSessionsGeneration = 1;
+
+async function gatewayFetch(path) {
+  window.__fetchLog.push({ path, time: Date.now() });
+  if (path.includes("include=archived")) {
+    return {
+      ok: true,
+      json: async () => ({ sessions: [...window.__serverSessions, ...window.__serverArchivedSessions] }),
+    };
+  }
+  // Normal sessions endpoint
+  const since = new URL(path, "http://localhost").searchParams.get("since");
+  const gen = window.__serverSessionsGeneration;
+  if (since && Number(since) === gen) {
+    return { ok: true, json: async () => ({ generation: gen, changed: false }) };
+  }
+  return {
+    ok: true,
+    json: async () => ({ generation: gen, sessions: window.__serverSessions }),
+  };
+}
+
+// --- fetchArchivedSessions (mirrors src/app/api.ts) ---
+async function fetchArchivedSessions() {
+  _archivedSessionsLoaded = true;
+  const res = await gatewayFetch("/api/sessions?include=archived");
+  const data = await res.json();
+  const sessions = data.sessions || [];
+  state.archivedSessions = sessions.filter(s => s.archived === true);
+  renderApp();
+}
+
+function clearArchivedSessionsState() {
+  _archivedSessionsLoaded = false;
+  state.archivedSessions = [];
+}
+
+// --- refreshSessions (mirrors the relevant logic from src/app/api.ts) ---
+async function refreshSessions() {
+  const isInitial = state.gatewaySessions.length === 0 && !state.sessionsError;
+
+  let sessionsChanged = false;
+
+  const sessionsUrl = state.sessionsGeneration >= 0
+    ? `/api/sessions?since=${state.sessionsGeneration}`
+    : "/api/sessions";
+
+  const sessionsRes = await gatewayFetch(sessionsUrl);
+  const sessionsData = await sessionsRes.json();
+
+  if (sessionsData.changed === false) {
+    // no change
+  } else {
+    sessionsChanged = true;
+    state.gatewaySessions = sessionsData.sessions || [];
+    if (sessionsData.generation !== undefined) {
+      state.sessionsGeneration = sessionsData.generation;
+    }
+  }
+
+  if (sessionsChanged || isInitial) {
+    renderApp();
+  }
+
+  // THE FIX UNDER TEST: re-fetch archived when sessions change and showArchived is on
+  if (state.showArchived && (isInitial && !_archivedSessionsLoaded || sessionsChanged && _archivedSessionsLoaded)) {
+    await fetchArchivedSessions();
+  }
+}
+
+// Expose for tests
+window.__state = state;
+window.__refreshSessions = refreshSessions;
+window.__fetchArchivedSessions = fetchArchivedSessions;
+window.__clearArchivedSessionsState = clearArchivedSessionsState;
+window.__renderCount = () => _renderCount;
+window.__resetRenderCount = () => { _renderCount = 0; };
+window.__archivedSessionsLoaded = () => _archivedSessionsLoaded;
+window.__setArchivedSessionsLoaded = (v) => { _archivedSessionsLoaded = v; };
+</script>
+</body>
+</html>

--- a/tests/fixtures/archived-team-agents.html
+++ b/tests/fixtures/archived-team-agents.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Archived Team Agents Filter Test</title>
+</head>
+<body>
+  <pre id="archivedForLiveLead"></pre>
+  <pre id="unmappedArchived"></pre>
+  <pre id="unmappedNoArchivedLeads"></pre>
+
+  <script>
+    // Mock session data
+    const GOAL_ID = "goal-1";
+    const LIVE_LEAD_ID = "live-lead-1";
+    const ARCHIVED_LEAD_ID = "archived-lead-1";
+
+    const archivedSessions = [
+      // 1. Member mapped to live lead
+      { id: "member-mapped", teamGoalId: GOAL_ID, teamLeadSessionId: LIVE_LEAD_ID, role: "coder", delegateOf: undefined },
+      // 2. Member with no teamLeadSessionId (the bug case)
+      { id: "member-unmapped", teamGoalId: GOAL_ID, teamLeadSessionId: undefined, role: "coder", delegateOf: undefined },
+      // 3. Member with empty string teamLeadSessionId
+      { id: "member-empty-lead", teamGoalId: GOAL_ID, teamLeadSessionId: "", role: "reviewer", delegateOf: undefined },
+      // 4. Member belonging to an archived lead
+      { id: "member-archived-lead", teamGoalId: GOAL_ID, teamLeadSessionId: ARCHIVED_LEAD_ID, role: "coder", delegateOf: undefined },
+      // 5. A delegate (should be excluded)
+      { id: "member-delegate", teamGoalId: GOAL_ID, teamLeadSessionId: undefined, role: "coder", delegateOf: "some-parent" },
+      // 6. A team-lead role (should be excluded from member lists)
+      { id: ARCHIVED_LEAD_ID, teamGoalId: GOAL_ID, teamLeadSessionId: undefined, role: "team-lead", delegateOf: undefined },
+      // 7. Member pointing to a non-existent lead
+      { id: "member-orphan-lead", teamGoalId: GOAL_ID, teamLeadSessionId: "non-existent-lead", role: "tester", delegateOf: undefined },
+      // 8. Member for a different goal (should be excluded)
+      { id: "member-other-goal", teamGoalId: "goal-other", teamLeadSessionId: undefined, role: "coder", delegateOf: undefined },
+    ];
+
+    /**
+     * FIXED filter: get archived members that should appear under the live team lead.
+     * Matches the fix from the design doc — includes members with:
+     *   - teamLeadSessionId === liveLeadId (directly mapped)
+     *   - !teamLeadSessionId (falsy — undefined or empty)
+     *   - teamLeadSessionId not in any known lead set (orphaned)
+     */
+    function getArchivedForLiveLead(goalId, liveLeadId, archived, archivedLeadIds) {
+      const allLeadIds = new Set(archivedLeadIds);
+      return archived.filter(s =>
+        s.teamGoalId === goalId &&
+        !s.delegateOf &&
+        s.role !== "team-lead" &&
+        (s.teamLeadSessionId === liveLeadId || !s.teamLeadSessionId || !allLeadIds.has(s.teamLeadSessionId))
+      );
+    }
+
+    /**
+     * Get unmapped archived members — those not claimed by any known lead (live or archived).
+     * This is the safety net for Bug 2.
+     */
+    function getUnmappedArchived(goalId, archived, allLeadIds) {
+      const leadSet = new Set(allLeadIds);
+      const archivedForGoal = archived.filter(s => s.teamGoalId === goalId && !s.delegateOf);
+      const archivedMembers = archivedForGoal.filter(s => s.role !== "team-lead");
+      const mappedIds = new Set(
+        archivedMembers
+          .filter(m => m.teamLeadSessionId && leadSet.has(m.teamLeadSessionId))
+          .map(m => m.id)
+      );
+      return archivedMembers.filter(m => !mappedIds.has(m.id));
+    }
+
+    // Scenario 1: Live lead exists, archived lead also exists
+    const archivedLeadIds = [ARCHIVED_LEAD_ID];
+    const forLiveLead = getArchivedForLiveLead(GOAL_ID, LIVE_LEAD_ID, archivedSessions, archivedLeadIds);
+    document.getElementById("archivedForLiveLead").textContent = JSON.stringify(forLiveLead.map(s => s.id));
+
+    // Scenario 2: Unmapped members (with both live + archived leads known)
+    const allLeads = [LIVE_LEAD_ID, ARCHIVED_LEAD_ID];
+    const unmapped = getUnmappedArchived(GOAL_ID, archivedSessions, allLeads);
+    document.getElementById("unmappedArchived").textContent = JSON.stringify(unmapped.map(s => s.id));
+
+    // Scenario 3: No archived leads exist — unmapped should still return members
+    const unmappedNoLeads = getUnmappedArchived(GOAL_ID, archivedSessions, []);
+    document.getElementById("unmappedNoArchivedLeads").textContent = JSON.stringify(unmappedNoLeads.map(s => s.id));
+  </script>
+</body>
+</html>

--- a/tests/fixtures/markdown-web-content.html
+++ b/tests/fixtures/markdown-web-content.html
@@ -7,50 +7,39 @@
 <body>
 <script>
 /**
- * isMarkdownContent — copied from design doc spec for testing.
- * This must stay in sync with src/ui/tools/renderers/WebFetchRenderer.ts
+ * isMarkdownContent — must stay in sync with src/ui/tools/renderers/WebFetchRenderer.ts
  */
 function isMarkdownContent(url, content) {
-  // 1. URL-based: path ends with .md or .markdown (case-insensitive, ignoring query/hash)
+  // URL-based: path ends with .md or .markdown (case-insensitive, ignoring query/hash)
   try {
     const pathname = new URL(url).pathname.toLowerCase();
     if (pathname.endsWith('.md') || pathname.endsWith('.markdown')) {
       return true;
     }
   } catch {
-    // invalid URL, fall through to content check
+    // If URL parsing fails, try simple string check
+    const pathPart = url.split('?')[0].split('#')[0].toLowerCase();
+    if (pathPart.endsWith('.md') || pathPart.endsWith('.markdown')) {
+      return true;
+    }
   }
 
-  // 2. Content-based fallback: first 500 chars
-  const snippet = content.slice(0, 500);
+  // Content-based fallback: check first 500 chars for markdown patterns
+  const sample = content.slice(0, 500);
 
-  // Starts with frontmatter delimiter
-  if (snippet.startsWith('---\n') || snippet.startsWith('---\r\n')) {
-    return true;
-  }
+  // Strong signals: starts with markdown frontmatter or heading
+  if (/^---\s*\n/.test(sample)) return true;
+  if (/^#{1,6}\s+\S/.test(sample)) return true;
 
-  // Count markdown indicators
+  // Weak signals: require multiple indicators
   let indicators = 0;
+  if (/^#{1,6}\s+/m.test(sample)) indicators++;
+  if (/\[.+?\]\(.+?\)/.test(sample)) indicators++;
+  if (/```/.test(sample)) indicators++;
+  if (/^\s*[-*+]\s+/m.test(sample)) indicators++;
+  if (/^\s*\d+\.\s+/m.test(sample)) indicators++;
+  if (/\*\*.+?\*\*/.test(sample)) indicators++;
 
-  // Headings (# at start of line)
-  if (/^#{1,6}\s/m.test(snippet)) indicators++;
-
-  // Links [text](url)
-  if (/\[.+?\]\(.+?\)/.test(snippet)) indicators++;
-
-  // Code fences ```
-  if (/^```/m.test(snippet)) indicators++;
-
-  // Bold/italic **text** or *text*
-  if (/\*\*.+?\*\*/.test(snippet) || /(?<!\*)\*(?!\*).+?(?<!\*)\*(?!\*)/.test(snippet)) indicators++;
-
-  // Unordered list items (- item or * item at start of line)
-  if (/^[\-\*]\s/m.test(snippet)) indicators++;
-
-  // Images ![alt](url)
-  if (/!\[.*?\]\(.+?\)/.test(snippet)) indicators++;
-
-  // Need at least 2 indicators for content-based detection
   return indicators >= 2;
 }
 

--- a/tests/fixtures/markdown-web-content.html
+++ b/tests/fixtures/markdown-web-content.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Markdown Web Content Tests</title>
+</head>
+<body>
+<script>
+/**
+ * isMarkdownContent — copied from design doc spec for testing.
+ * This must stay in sync with src/ui/tools/renderers/WebFetchRenderer.ts
+ */
+function isMarkdownContent(url, content) {
+  // 1. URL-based: path ends with .md or .markdown (case-insensitive, ignoring query/hash)
+  try {
+    const pathname = new URL(url).pathname.toLowerCase();
+    if (pathname.endsWith('.md') || pathname.endsWith('.markdown')) {
+      return true;
+    }
+  } catch {
+    // invalid URL, fall through to content check
+  }
+
+  // 2. Content-based fallback: first 500 chars
+  const snippet = content.slice(0, 500);
+
+  // Starts with frontmatter delimiter
+  if (snippet.startsWith('---\n') || snippet.startsWith('---\r\n')) {
+    return true;
+  }
+
+  // Count markdown indicators
+  let indicators = 0;
+
+  // Headings (# at start of line)
+  if (/^#{1,6}\s/m.test(snippet)) indicators++;
+
+  // Links [text](url)
+  if (/\[.+?\]\(.+?\)/.test(snippet)) indicators++;
+
+  // Code fences ```
+  if (/^```/m.test(snippet)) indicators++;
+
+  // Bold/italic **text** or *text*
+  if (/\*\*.+?\*\*/.test(snippet) || /(?<!\*)\*(?!\*).+?(?<!\*)\*(?!\*)/.test(snippet)) indicators++;
+
+  // Unordered list items (- item or * item at start of line)
+  if (/^[\-\*]\s/m.test(snippet)) indicators++;
+
+  // Images ![alt](url)
+  if (/!\[.*?\]\(.+?\)/.test(snippet)) indicators++;
+
+  // Need at least 2 indicators for content-based detection
+  return indicators >= 2;
+}
+
+// Expose for Playwright
+window.isMarkdownContent = isMarkdownContent;
+</script>
+</body>
+</html>

--- a/tests/markdown-web-content.spec.ts
+++ b/tests/markdown-web-content.spec.ts
@@ -1,0 +1,158 @@
+import { test, expect } from "@playwright/test";
+import path from "node:path";
+
+const TEST_PAGE = `file://${path.resolve("tests/fixtures/markdown-web-content.html")}`;
+
+test.describe("isMarkdownContent detection", () => {
+	test.describe("URL-based detection", () => {
+		test(".md URL returns true", async ({ page }) => {
+			await page.goto(TEST_PAGE);
+			const result = await page.evaluate(() =>
+				(window as any).isMarkdownContent("https://raw.githubusercontent.com/user/repo/main/README.md", "some content"),
+			);
+			expect(result).toBe(true);
+		});
+
+		test(".markdown URL returns true", async ({ page }) => {
+			await page.goto(TEST_PAGE);
+			const result = await page.evaluate(() =>
+				(window as any).isMarkdownContent("https://example.com/docs/guide.markdown", "some content"),
+			);
+			expect(result).toBe(true);
+		});
+
+		test(".md with query params returns true", async ({ page }) => {
+			await page.goto(TEST_PAGE);
+			const result = await page.evaluate(() =>
+				(window as any).isMarkdownContent("https://example.com/file.md?token=abc&ref=main", "some content"),
+			);
+			expect(result).toBe(true);
+		});
+
+		test(".md with hash fragment returns true", async ({ page }) => {
+			await page.goto(TEST_PAGE);
+			const result = await page.evaluate(() =>
+				(window as any).isMarkdownContent("https://example.com/file.md#section", "some content"),
+			);
+			expect(result).toBe(true);
+		});
+
+		test(".MD uppercase returns true (case-insensitive)", async ({ page }) => {
+			await page.goto(TEST_PAGE);
+			const result = await page.evaluate(() =>
+				(window as any).isMarkdownContent("https://example.com/README.MD", "some content"),
+			);
+			expect(result).toBe(true);
+		});
+
+		test("non-markdown URL returns false", async ({ page }) => {
+			await page.goto(TEST_PAGE);
+			const result = await page.evaluate(() =>
+				(window as any).isMarkdownContent("https://example.com/page.html", "some content"),
+			);
+			expect(result).toBe(false);
+		});
+
+		test("URL with .md in path but not at end returns false", async ({ page }) => {
+			await page.goto(TEST_PAGE);
+			const result = await page.evaluate(() =>
+				(window as any).isMarkdownContent("https://example.com/md/page.html", "some content"),
+			);
+			expect(result).toBe(false);
+		});
+	});
+
+	test.describe("Content-based detection", () => {
+		const nonMdUrl = "https://api.example.com/content";
+
+		test("content with heading and link detected as markdown", async ({ page }) => {
+			await page.goto(TEST_PAGE);
+			const result = await page.evaluate((url) =>
+				(window as any).isMarkdownContent(url, "# My Project\n\nCheck out [the docs](https://example.com) for more info."),
+				nonMdUrl,
+			);
+			expect(result).toBe(true);
+		});
+
+		test("frontmatter (---) detected as markdown", async ({ page }) => {
+			await page.goto(TEST_PAGE);
+			const result = await page.evaluate((url) =>
+				(window as any).isMarkdownContent(url, "---\ntitle: My Post\ndate: 2024-01-01\n---\n\n# Hello World"),
+				nonMdUrl,
+			);
+			expect(result).toBe(true);
+		});
+
+		test("content with headings and code fences detected", async ({ page }) => {
+			await page.goto(TEST_PAGE);
+			const result = await page.evaluate((url) =>
+				(window as any).isMarkdownContent(url, "## Installation\n\n```bash\nnpm install my-package\n```\n"),
+				nonMdUrl,
+			);
+			expect(result).toBe(true);
+		});
+
+		test("content with multiple indicators (bold + list + heading)", async ({ page }) => {
+			await page.goto(TEST_PAGE);
+			const result = await page.evaluate((url) =>
+				(window as any).isMarkdownContent(url, "# Features\n\n- Fast rendering\n- **Easy** to use\n- Lightweight"),
+				nonMdUrl,
+			);
+			expect(result).toBe(true);
+		});
+
+		test("content with images and links", async ({ page }) => {
+			await page.goto(TEST_PAGE);
+			const result = await page.evaluate((url) =>
+				(window as any).isMarkdownContent(url, "![Logo](https://example.com/logo.png)\n\n[Visit site](https://example.com)"),
+				nonMdUrl,
+			);
+			expect(result).toBe(true);
+		});
+
+		test("plain text without markdown patterns returns false", async ({ page }) => {
+			await page.goto(TEST_PAGE);
+			const result = await page.evaluate((url) =>
+				(window as any).isMarkdownContent(url, "This is just some plain text content without any special formatting or patterns."),
+				nonMdUrl,
+			);
+			expect(result).toBe(false);
+		});
+
+		test("single heading alone is not enough (need 2+ indicators)", async ({ page }) => {
+			await page.goto(TEST_PAGE);
+			const result = await page.evaluate((url) =>
+				(window as any).isMarkdownContent(url, "# Just a heading\n\nSome plain text after it."),
+				nonMdUrl,
+			);
+			expect(result).toBe(false);
+		});
+
+		test("HTML content is not detected as markdown", async ({ page }) => {
+			await page.goto(TEST_PAGE);
+			const result = await page.evaluate((url) =>
+				(window as any).isMarkdownContent(url, "<html><head><title>Page</title></head><body><h1>Hello</h1></body></html>"),
+				nonMdUrl,
+			);
+			expect(result).toBe(false);
+		});
+
+		test("JSON content is not detected as markdown", async ({ page }) => {
+			await page.goto(TEST_PAGE);
+			const result = await page.evaluate((url) =>
+				(window as any).isMarkdownContent(url, '{"name": "package", "version": "1.0.0", "description": "A package"}'),
+				nonMdUrl,
+			);
+			expect(result).toBe(false);
+		});
+
+		test("URL-based detection takes priority over content", async ({ page }) => {
+			await page.goto(TEST_PAGE);
+			// .md URL with non-markdown content should still return true
+			const result = await page.evaluate(() =>
+				(window as any).isMarkdownContent("https://example.com/data.md", '{"json": true}'),
+			);
+			expect(result).toBe(true);
+		});
+	});
+});

--- a/tests/markdown-web-content.spec.ts
+++ b/tests/markdown-web-content.spec.ts
@@ -101,10 +101,10 @@ test.describe("isMarkdownContent detection", () => {
 			expect(result).toBe(true);
 		});
 
-		test("content with images and links", async ({ page }) => {
+		test("content with links and list items", async ({ page }) => {
 			await page.goto(TEST_PAGE);
 			const result = await page.evaluate((url) =>
-				(window as any).isMarkdownContent(url, "![Logo](https://example.com/logo.png)\n\n[Visit site](https://example.com)"),
+				(window as any).isMarkdownContent(url, "Check out [the docs](https://example.com)\n\n- Item one\n- Item two"),
 				nonMdUrl,
 			);
 			expect(result).toBe(true);
@@ -119,10 +119,19 @@ test.describe("isMarkdownContent detection", () => {
 			expect(result).toBe(false);
 		});
 
-		test("single heading alone is not enough (need 2+ indicators)", async ({ page }) => {
+		test("single heading at start is a strong signal (detected as markdown)", async ({ page }) => {
 			await page.goto(TEST_PAGE);
 			const result = await page.evaluate((url) =>
 				(window as any).isMarkdownContent(url, "# Just a heading\n\nSome plain text after it."),
+				nonMdUrl,
+			);
+			expect(result).toBe(true);
+		});
+
+		test("heading NOT at start needs 2+ indicators", async ({ page }) => {
+			await page.goto(TEST_PAGE);
+			const result = await page.evaluate((url) =>
+				(window as any).isMarkdownContent(url, "Some intro text\n\n## A heading\n\nMore text."),
 				nonMdUrl,
 			);
 			expect(result).toBe(false);

--- a/tests/system-prompt-memories.test.ts
+++ b/tests/system-prompt-memories.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Unit tests for Claude Code Memory Bridge — parseMemoryFile, readClaudeMd, readClaudeCodeMemories.
+ * Uses temp directories for all fixtures. Cleans up after each test.
+ */
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Set up temp BOBBIT_DIR before importing the module
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-mem-test-"));
+const stateDir = path.join(tmpRoot, "state");
+fs.mkdirSync(path.join(stateDir, "session-prompts"), { recursive: true });
+process.env.BOBBIT_DIR = tmpRoot;
+
+const { parseMemoryFile, readClaudeMd, readClaudeCodeMemories } = await import(
+	"../src/server/agent/system-prompt.ts"
+);
+
+// ---------------------------------------------------------------------------
+// parseMemoryFile
+// ---------------------------------------------------------------------------
+
+describe("parseMemoryFile", () => {
+	it("parses valid frontmatter with body", () => {
+		const content = "---\nname: Test Memory\ndescription: A test\ntype: user\n---\nBody content here";
+		const result = parseMemoryFile(content);
+		assert.ok(result);
+		assert.strictEqual(result.name, "Test Memory");
+		assert.strictEqual(result.description, "A test");
+		assert.strictEqual(result.type, "user");
+		assert.strictEqual(result.body, "Body content here");
+	});
+
+	it("returns null for content without frontmatter", () => {
+		const result = parseMemoryFile("Just plain text\nNo frontmatter here");
+		assert.strictEqual(result, null);
+	});
+
+	it("returns null when closing --- is missing", () => {
+		const result = parseMemoryFile("---\nname: Test\nBody without closing");
+		assert.strictEqual(result, null);
+	});
+
+	it("returns empty string for missing type field", () => {
+		const content = "---\nname: NoType\ndescription: Desc\n---\nSome body";
+		const result = parseMemoryFile(content);
+		assert.ok(result);
+		assert.strictEqual(result.name, "NoType");
+		assert.strictEqual(result.type, "");
+		assert.strictEqual(result.body, "Some body");
+	});
+
+	it("returns empty body when frontmatter has no trailing content", () => {
+		const content = "---\nname: Empty\ndescription: Nothing\ntype: project\n---";
+		const result = parseMemoryFile(content);
+		assert.ok(result);
+		assert.strictEqual(result.name, "Empty");
+		assert.strictEqual(result.type, "project");
+		assert.strictEqual(result.body, "");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// readClaudeMd
+// ---------------------------------------------------------------------------
+
+describe("readClaudeMd", () => {
+	let cwdDir: string;
+
+	beforeEach(() => {
+		cwdDir = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-claude-md-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(cwdDir, { recursive: true, force: true });
+	});
+
+	it("reads normal CLAUDE.md content", () => {
+		fs.writeFileSync(path.join(cwdDir, "CLAUDE.md"), "# My Project\n\nCustom instructions.", "utf-8");
+		const result = readClaudeMd(cwdDir);
+		assert.ok(result.includes("# My Project"));
+		assert.ok(result.includes("Custom instructions."));
+	});
+
+	it("returns empty string when CLAUDE.md is just @AGENTS.md", () => {
+		fs.writeFileSync(path.join(cwdDir, "CLAUDE.md"), "@AGENTS.md", "utf-8");
+		const result = readClaudeMd(cwdDir);
+		assert.strictEqual(result, "");
+	});
+
+	it("returns empty string when CLAUDE.md is @AGENTS.md with whitespace", () => {
+		fs.writeFileSync(path.join(cwdDir, "CLAUDE.md"), "  @AGENTS.md  \n", "utf-8");
+		const result = readClaudeMd(cwdDir);
+		assert.strictEqual(result, "");
+	});
+
+	it("returns empty string when no CLAUDE.md exists", () => {
+		const result = readClaudeMd(cwdDir);
+		assert.strictEqual(result, "");
+	});
+
+	it("resolves @ references in CLAUDE.md", () => {
+		fs.writeFileSync(path.join(cwdDir, "CLAUDE.md"), "Header\n@other.md\nFooter", "utf-8");
+		fs.writeFileSync(path.join(cwdDir, "other.md"), "Included content", "utf-8");
+		const result = readClaudeMd(cwdDir);
+		assert.ok(result.includes("Header"));
+		assert.ok(result.includes("Included content"));
+		assert.ok(result.includes("Footer"));
+	});
+});
+
+// ---------------------------------------------------------------------------
+// readClaudeCodeMemories
+// ---------------------------------------------------------------------------
+
+describe("readClaudeCodeMemories", () => {
+	// Use a unique fake cwd so the encoded path never conflicts with real data
+	let fakeCwd: string;
+	let memoryDir: string;
+
+	function encodeCwd(cwd: string): string {
+		return cwd.replace(/\//g, "-");
+	}
+
+	beforeEach(() => {
+		// Create a unique fake cwd path (not a real directory — just a string for encoding)
+		const rand = Math.random().toString(36).slice(2, 10);
+		fakeCwd = `/tmp/test-bobbit-memories-${rand}`;
+		const encoded = encodeCwd(fakeCwd);
+		memoryDir = path.join(os.homedir(), ".claude", "projects", encoded, "memory");
+		fs.mkdirSync(memoryDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		// Clean up the entire project dir we created under ~/.claude/projects/
+		const encoded = encodeCwd(fakeCwd);
+		const projectDir = path.join(os.homedir(), ".claude", "projects", encoded);
+		try {
+			fs.rmSync(projectDir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	});
+
+	function writeMemoryFile(filename: string, name: string, type: string, body: string, description = "desc") {
+		const content = `---\nname: ${name}\ndescription: ${description}\ntype: ${type}\n---\n${body}`;
+		fs.writeFileSync(path.join(memoryDir, filename), content, "utf-8");
+	}
+
+	it("reads valid memory files", () => {
+		writeMemoryFile("mem1.md", "First Memory", "user", "First body");
+		writeMemoryFile("mem2.md", "Second Memory", "project", "Second body");
+		const result = readClaudeCodeMemories(fakeCwd);
+		assert.ok(result.includes("# Claude Code Project Memories"));
+		assert.ok(result.includes("First Memory"));
+		assert.ok(result.includes("First body"));
+		assert.ok(result.includes("Second Memory"));
+		assert.ok(result.includes("Second body"));
+	});
+
+	it("skips MEMORY.md", () => {
+		fs.writeFileSync(path.join(memoryDir, "MEMORY.md"), "# Index\nThis is the index.", "utf-8");
+		writeMemoryFile("real.md", "Real Memory", "user", "Real body");
+		const result = readClaudeCodeMemories(fakeCwd);
+		assert.ok(result.includes("Real Memory"));
+		assert.ok(!result.includes("Index"));
+	});
+
+	it("filters by type — skips reference type", () => {
+		writeMemoryFile("allowed-user.md", "User Mem", "user", "User body");
+		writeMemoryFile("allowed-project.md", "Project Mem", "project", "Project body");
+		writeMemoryFile("allowed-feedback.md", "Feedback Mem", "feedback", "Feedback body");
+		writeMemoryFile("blocked-reference.md", "Ref Mem", "reference", "Reference body");
+		const result = readClaudeCodeMemories(fakeCwd);
+		assert.ok(result.includes("User Mem"));
+		assert.ok(result.includes("Project Mem"));
+		assert.ok(result.includes("Feedback Mem"));
+		assert.ok(!result.includes("Ref Mem"));
+		assert.ok(!result.includes("Reference body"));
+	});
+
+	it("returns empty string when memory directory does not exist", () => {
+		const noMemCwd = `/tmp/test-bobbit-no-memories-${Math.random().toString(36).slice(2, 10)}`;
+		const result = readClaudeCodeMemories(noMemCwd);
+		assert.strictEqual(result, "");
+	});
+
+	it("caps at 20 files", () => {
+		// Create 25 memory files
+		for (let i = 0; i < 25; i++) {
+			const num = String(i).padStart(2, "0");
+			writeMemoryFile(`mem-${num}.md`, `Memory ${num}`, "user", `Body ${num}`);
+		}
+		const result = readClaudeCodeMemories(fakeCwd);
+		// First 20 alphabetically should be included (mem-00 through mem-19)
+		assert.ok(result.includes("Memory 19"));
+		// mem-20 through mem-24 should be excluded
+		assert.ok(!result.includes("Memory 20"));
+		assert.ok(!result.includes("Memory 24"));
+	});
+
+	it("caps total content at 16000 characters", () => {
+		// Create files with large bodies — each ~4000 chars, so 5 would exceed 16000
+		const bigBody = "X".repeat(4000);
+		for (let i = 0; i < 6; i++) {
+			writeMemoryFile(`big-${i}.md`, `Big ${i}`, "user", bigBody);
+		}
+		const result = readClaudeCodeMemories(fakeCwd);
+		// Should have some content but be capped
+		assert.ok(result.length > 0);
+		assert.ok(result.length <= 16500); // Allow small overhead for headers/formatting
+		// Not all 6 files should be included
+		const memoryCount = (result.match(/### Big \d/g) || []).length;
+		assert.ok(memoryCount < 6, `Expected fewer than 6 memories but got ${memoryCount}`);
+		assert.ok(memoryCount >= 3, `Expected at least 3 memories but got ${memoryCount}`);
+	});
+});


### PR DESCRIPTION
Extends system prompt assembly to inject Claude Code project memories and CLAUDE.md into agent context.

## Changes
- src/server/agent/system-prompt.ts: Added readClaudeMd(), readClaudeCodeMemories(), parseMemoryFile()
- tests/system-prompt-memories.test.ts: 16 unit tests
- AGENTS.md + docs/features.md: Documentation