### PR TITLE
docs: add Docker sandbox, web proxy, custom providers, models, and WS commands

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -95,8 +95,21 @@ A unified registry (`assistant-registry.ts`) maps assistant types to their promp
 - `personality` — Personality creation assistant
 - `staff` — Staff agent creation assistant
 - `setup` — Project setup wizard
+- `workflow` — Workflow creation assistant
 
 Sessions created with an `assistantType` get the corresponding system prompt automatically. Assistant prompts can be edited via their YAML files and are reloaded on change.
+
+## Docker Sandbox
+
+Agent sessions can optionally run inside Docker containers with restricted filesystem, network, and credential access. Configured via `sandbox: "docker"` in `project.yaml`.
+
+- **Isolation**: Agents can only access the project directory (bind-mounted). No access to `~/.ssh`, `~/.aws`, or other host paths.
+- **Network control**: An allowlist of permitted hostnames (e.g. `github.com`). All other traffic is blocked via an HTTP CONNECT proxy.
+- **Container pool**: Pre-warmed containers reduce cold-start latency. Pool size and idle timeout are configurable.
+- **Web proxy**: Sandboxed sessions use gateway-proxied web search and fetch endpoints since direct internet access is blocked.
+- **Persistence**: Sandboxed sessions survive server restarts — session file paths are remapped between container and host.
+
+See the Docker sandbox section in [AGENTS.md](../AGENTS.md) for full configuration reference.
 
 ## Compaction
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -169,6 +169,50 @@ Routes accept both `/team/` and legacy `/swarm/` paths.
 |---|---|---|
 | `GET` | `/api/pr-status-cache` | Bulk PR status from disk cache (startup hydration) |
 
+### System Prompt
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/system-prompt-context` | Read the project context section from system-prompt.md |
+| `PUT` | `/api/system-prompt-context` | Append/replace the project context section in system-prompt.md |
+
+### Custom Providers
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/custom-providers` | List all custom provider configs (Ollama, LM Studio, etc.) |
+| `POST` | `/api/custom-providers` | Add or update a custom provider (`{ id, name, baseUrl, type }`) |
+| `POST` | `/api/custom-providers/test` | Discover models from a URL without persisting (`{ url, type? }`) |
+| `DELETE` | `/api/custom-providers/:id` | Remove a custom provider config |
+
+### Provider Keys
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/provider-keys` | List providers that have API keys set (no key values returned) |
+| `POST` | `/api/provider-keys/:provider` | Store a provider API key (`{ key }`) |
+| `DELETE` | `/api/provider-keys/:provider` | Remove a provider API key |
+
+### Models
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/models` | Unified model list from all sources (built-in, AI gateway, custom providers). 5s TTL cache |
+
+### Docker Sandbox
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/sandbox-status` | Docker availability, image status, and whether sandbox is configured |
+| `GET` | `/api/sandbox-pool` | Container pool stats (enabled, total, idle, claimed, warming) |
+
+### Web Proxy
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/api/web-proxy/search` | Web search proxy for sandboxed sessions (rate limited: 10 req/min per IP) |
+| `POST` | `/api/web-proxy/fetch` | Web fetch proxy for sandboxed sessions (rate limited: 10 req/min per IP) |
+
 ### System
 
 | Method | Path | Description |

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -15,6 +15,8 @@ Connect to `wss://<host>:<port>/ws/<session-id>`. First message must be `{ "type
 | `abort` | — | Abort the current agent turn |
 | `retry` | — | Retry the last failed turn |
 | `set_model` | `provider`, `modelId` | Switch the AI model |
+| `set_thinking_level` | `level` | Set thinking level (none, low, medium, high) |
+| `grant_tool_permission` | `tool`, `group?` | Grant an MCP tool permission for the current session's role |
 | `compact` | — | Trigger context compaction |
 | `get_state` | — | Request current agent state |
 | `get_messages` | — | Request full message history |
@@ -63,3 +65,4 @@ Connect to `wss://<host>:<port>/ws/<session-id>`. First message must be `{ "type
 | `team_agent_dismissed` | `goalId`, `sessionId`, `role`, `name` | Team agent was dismissed |
 | `team_agent_finished` | `goalId`, `sessionId`, `role`, `name` | Team agent finished its turn |
 | `pr_status_changed` | `goalId?`, `sessionId?`, `status` | PR status changed for a goal or session |
+| `tool_permission_needed` | `tool`, `sessionId` | Agent needs permission to use an MCP tool not in its role |


### PR DESCRIPTION
Documentation validation scan — supersedes PR #126 with additional findings from 39 new commits (Docker sandbox, tool policies, web proxy).

**REST API — 18 new endpoints documented:**
- `GET/PUT /api/system-prompt-context` — project context in system prompt
- `GET/POST/DELETE /api/custom-providers`, `POST /api/custom-providers/test` — Ollama, LM Studio, etc.
- `GET/POST/DELETE /api/provider-keys/:provider` — API key management
- `GET /api/models` — unified model list (5s cache)
- `GET /api/sandbox-status` — Docker availability and image status
- `GET /api/sandbox-pool` — container pool stats
- `POST /api/web-proxy/search`, `POST /api/web-proxy/fetch` — proxied web access for sandboxed sessions

**WebSocket — 3 new commands/events:**
- `set_thinking_level` client command
- `grant_tool_permission` client command (MCP tool access grant)
- `tool_permission_needed` server event

**Features:**
- Docker Sandbox section in features.md (isolation, network control, container pool, persistence)
- `workflow` assistant type in assistant registry

**Validated clean:**
- All internal markdown links valid
- No stale file path references
- Docker sandbox well-covered in AGENTS.md, now cross-referenced from features.md
- Tool grant policy system documented in AGENTS.md and rest-api.md

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)