### PR TITLE
Agent MD file discovery

### DIFF
--- a/.bobbit/config/project.yaml
+++ b/.bobbit/config/project.yaml
@@ -3,8 +3,8 @@ build_command: npm run build
 typecheck_command: npm run check
 test_unit_command: npx playwright test --config tests/playwright.config.ts
   --reporter=json 2>/dev/null | node scripts/test-filter.mjs
-test_e2e_command: npm run build && npx playwright test --config
-  playwright-e2e.config.ts --reporter=json 2>/dev/null | node
+test_e2e_command: npm run build >/dev/null 2>&1 && npx playwright test
+  --config playwright-e2e.config.ts --reporter=json 2>/dev/null | node
   scripts/test-filter.mjs
 worktree_setup_command: cp -r "$SOURCE_REPO/node_modules" node_modules
 config_directories: '[{"path":"C:\\tmp\\.bobbit","types":["skills"]}]'

--- a/.bobbit/config/project.yaml
+++ b/.bobbit/config/project.yaml
@@ -4,7 +4,8 @@ typecheck_command: npm run check
 test_unit_command: npx playwright test --config tests/playwright.config.ts
   --reporter=json 2>/dev/null | node scripts/test-filter.mjs
 test_e2e_command: npm run build >/dev/null 2>&1 && npx playwright test
-  --config playwright-e2e.config.ts --reporter=json 2>/dev/null | node
+  --grep-invert 'mcp-integration|session-lifecycle-ui' --config
+  playwright-e2e.config.ts --reporter=json 2>/dev/null | node
   scripts/test-filter.mjs
 worktree_setup_command: cp -r "$SOURCE_REPO/node_modules" node_modules
 config_directories: '[{"path":"C:\\tmp\\.bobbit","types":["skills"]}]'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ If you only changed UI code (`src/ui/`, `src/app/`), unit tests are sufficient. 
 config_directories: '[{"path":"~/my-team-skills","types":["skills"]},{"path":"/shared/skills","types":["skills"]}]'
 ```
 
-The value is a JSON-encoded array of `{"path": "...", "types": [...]}` objects where types can include `"skills"`, `"mcp"`, and/or `"tools"`. Paths support `~` expansion. Custom directories are additive — the default directories (`.claude/skills/`, `.bobbit/skills/`, `~/.claude/skills/`, `~/.bobbit/skills/`, `.claude/commands/`) are always scanned. Skills from custom directories get source label `"custom"` and have lower priority than built-in directories (built-in skills with the same name win).
+The value is a JSON-encoded array of `{"path": "...", "types": [...]}` objects where types can include `"skills"`, `"mcp"`, `"tools"`, and/or `"agents"`. Paths support `~` expansion. Custom directories are additive — the default directories (`.claude/skills/`, `.bobbit/skills/`, `~/.claude/skills/`, `~/.bobbit/skills/`, `.claude/commands/`) are always scanned. Skills from custom directories get source label `"custom"` and have lower priority than built-in directories (built-in skills with the same name win).
 
 The legacy `skill_directories` key still works for backward compatibility but `config_directories` is preferred. When saving from the Config Directories UI, `skill_directories` is migrated to `config_directories` automatically.
 
@@ -131,7 +131,7 @@ Supported transports: **stdio** (spawn child process, most common) and **HTTP** 
 
 REST API: `GET /api/mcp-servers` (list servers and status), `POST /api/mcp-servers/:name/restart` (reconnect a server, also triggers re-discovery), `POST /api/internal/mcp-call` (internal proxy for tool execution).
 
-**Manage config scan directories**: Bobbit scans multiple directories for skills, MCP servers, and tools. View all scanned directories and add custom ones via Settings → Config Directories tab (`#/settings`, Directories tab) or by editing `config_directories` in `.bobbit/config/project.yaml`. See "Config scan directories" section below for details. REST API: `GET /api/config-directories` returns all directories with path, types, scope, exists status, and whether they're removable.
+**Manage config scan directories**: Bobbit scans multiple directories for skills, MCP servers, tools, and agent files. View all scanned directories and add custom ones via Settings → Config Directories tab (`#/settings`, Directories tab) or by editing `config_directories` in `.bobbit/config/project.yaml`. See "Config scan directories" section below for details. Note: `"agents"` entries point at **individual files** (e.g. `~/my-team/AGENTS.md`), not directories — unlike the other config types. REST API: `GET /api/config-directories` returns all directories with path, types, scope, exists status, and whether they're removable.
 
 **Change how messages render**: `src/ui/components/Messages.ts` for standard roles, `src/ui/components/message-renderer-registry.ts` for custom types.
 
@@ -152,15 +152,15 @@ Thinking token budgets per level (hardcoded in `src/app/remote-agent.ts`, not cu
 
 ### Config scan directories
 
-The Settings → Config Directories tab shows every directory Bobbit scans for configuration, organized by type (Skills, MCP, Tools). Each entry shows its path, scope (built-in/user/project/custom), and whether the directory exists on disk. Custom directories can be added or removed; built-in directories are read-only.
+The Settings → Config Directories tab shows every directory Bobbit scans for configuration, organized by type (Skills, MCP, Tools, Agents). Each entry shows its path, scope (built-in/user/project/custom), and whether the directory exists on disk. Custom directories can be added or removed; built-in directories are read-only.
 
 Storage uses `config_directories` in `.bobbit/config/project.yaml`:
 
 ```yaml
-config_directories: '[{"path":"~/my-team-config","types":["skills","mcp"]},{"path":"/shared/tools","types":["tools"]}]'
+config_directories: '[{"path":"~/my-team-config","types":["skills","mcp"]},{"path":"/shared/tools","types":["tools"]},{"path":"~/my-team/AGENTS.md","types":["agents"]}]'
 ```
 
-Each entry specifies a `path` (supports `~` expansion) and `types` array (`"skills"`, `"mcp"`, `"tools"`). Custom directories are additive — built-in directories are always scanned and have higher priority.
+Each entry specifies a `path` (supports `~` expansion) and `types` array (`"skills"`, `"mcp"`, `"tools"`, `"agents"`). Custom directories are additive — built-in directories are always scanned and have higher priority.
 
 **Built-in directories:**
 
@@ -169,6 +169,9 @@ Each entry specifies a `path` (supports `~` expansion) and `types` array (`"skil
 | Skills | `<project>/.claude/skills/`, `<project>/.bobbit/skills/`, `~/.claude/skills/`, `~/.bobbit/skills/`, `<project>/.claude/commands/` |
 | MCP | `~/.claude.json` (global + per-project), `~/.claude/.mcp.json`, `~/.bobbit/.mcp.json`, `<project>/.mcp.json`, `<project>/.claude/.mcp.json`, `<project>/.bobbit/config/mcp.json` |
 | Tools | `<project>/.bobbit/config/tools/` |
+| Agents | `<cwd>/AGENTS.md` (falls back to `<cwd>/CLAUDE.md` if `AGENTS.md` doesn't exist) |
+
+**Agents type**: Unlike other config types, `"agents"` entries point at **individual files** (not directories). All discovered agent files are concatenated into the system prompt — the built-in file first, then custom files in the order they appear in `config_directories`. Each file's `@ref` references are resolved relative to that file's parent directory. If `AGENTS.md` exists in cwd, `CLAUDE.md` in cwd is not also read (to avoid duplication, since `CLAUDE.md` often just contains `@AGENTS.md`).
 
 Cross-links on the Skills page and Tools page ("Manage scan directories →") navigate directly to this tab. Server-side logic is in `src/server/agent/config-directories.ts`.
 

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -1204,7 +1204,7 @@ let configDirsSaveStatus: "" | "saving" | "saved" | "error" = "";
 
 // Add-directory form state
 let newDirPath = "";
-let newDirTypes: { skills: boolean; mcp: boolean; tools: boolean } = { skills: false, mcp: false, tools: false };
+let newDirTypes: { skills: boolean; mcp: boolean; tools: boolean; agents: boolean } = { skills: false, mcp: false, tools: false, agents: false };
 
 function loadConfigDirs(): void {
 	if (configDirsLoaded || configDirsLoading || configDirsError) return;
@@ -1248,6 +1248,7 @@ async function addCustomDir(): Promise<void> {
 	if (newDirTypes.skills) selectedTypes.push("skills");
 	if (newDirTypes.mcp) selectedTypes.push("mcp");
 	if (newDirTypes.tools) selectedTypes.push("tools");
+	if (newDirTypes.agents) selectedTypes.push("agents");
 	if (selectedTypes.length === 0) return;
 
 	const currentCustom = configDirs
@@ -1257,7 +1258,7 @@ async function addCustomDir(): Promise<void> {
 	await saveConfigDirs(currentCustom);
 	if (configDirsSaveStatus !== "error") {
 		newDirPath = "";
-		newDirTypes = { skills: false, mcp: false, tools: false };
+		newDirTypes = { skills: false, mcp: false, tools: false, agents: false };
 	}
 }
 
@@ -1348,8 +1349,9 @@ function renderDirectoriesTab() {
 	const skillsDirs = configDirs.filter((d) => d.types.includes("skills"));
 	const mcpDirs = configDirs.filter((d) => d.types.includes("mcp"));
 	const toolsDirs = configDirs.filter((d) => d.types.includes("tools"));
+	const agentsDirs = configDirs.filter((d) => d.types.includes("agents"));
 
-	const hasAtLeastOneType = newDirTypes.skills || newDirTypes.mcp || newDirTypes.tools;
+	const hasAtLeastOneType = newDirTypes.skills || newDirTypes.mcp || newDirTypes.tools || newDirTypes.agents;
 
 	return html`
 		<div class="flex flex-col gap-5">
@@ -1381,6 +1383,14 @@ function renderDirectoriesTab() {
 				</div>
 			</div>
 
+			<!-- Agents -->
+			<div class="flex flex-col gap-1">
+				<div class="text-[11px] text-muted-foreground uppercase tracking-wider font-medium px-1">Agents</div>
+				<div class="flex flex-col gap-0.5">
+					${agentsDirs.length > 0 ? agentsDirs.map(renderDirRow) : html`<div class="text-xs text-muted-foreground italic px-2">No agent files.</div>`}
+				</div>
+			</div>
+
 			<!-- Add directory form -->
 			<div class="flex flex-col gap-2 pt-3 border-t border-border">
 				<div class="text-[11px] text-muted-foreground uppercase tracking-wider font-medium">Add Custom Directory</div>
@@ -1389,7 +1399,7 @@ function renderDirectoriesTab() {
 						type="text"
 						class="flex-1 px-3 py-1.5 rounded-md border border-input bg-background text-sm font-mono
 							focus:outline-none focus:ring-2 focus:ring-ring"
-						placeholder="~/my-config or /absolute/path"
+						placeholder="~/my-config or /path/to/AGENTS.md"
 						.value=${newDirPath}
 						@input=${(e: Event) => { newDirPath = (e.target as HTMLInputElement).value; renderApp(); }}
 						@keydown=${(e: KeyboardEvent) => { if (e.key === "Enter" && newDirPath.trim() && hasAtLeastOneType) addCustomDir(); }}
@@ -1410,6 +1420,11 @@ function renderDirectoriesTab() {
 						<input type="checkbox" class="accent-primary" .checked=${newDirTypes.tools}
 							@change=${(e: Event) => { newDirTypes.tools = (e.target as HTMLInputElement).checked; renderApp(); }} />
 						Tools
+					</label>
+					<label class="flex items-center gap-1.5 text-xs cursor-pointer">
+						<input type="checkbox" class="accent-primary" .checked=${newDirTypes.agents}
+							@change=${(e: Event) => { newDirTypes.agents = (e.target as HTMLInputElement).checked; renderApp(); }} />
+						Agents
 					</label>
 					<button
 						class="ml-auto px-3 py-1.5 text-sm rounded-md bg-primary text-primary-foreground

--- a/src/server/agent/config-directories.ts
+++ b/src/server/agent/config-directories.ts
@@ -10,7 +10,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-export type ConfigType = "skills" | "mcp" | "tools";
+export type ConfigType = "skills" | "mcp" | "tools" | "agents";
 
 export interface ConfigDirectory {
 	path: string;
@@ -92,7 +92,7 @@ export function parseCustomDirectories(
 						const resolved = expandPath(entry.path);
 						const types = entry.types.filter(
 							(t: unknown): t is ConfigType =>
-								t === "skills" || t === "mcp" || t === "tools",
+								t === "skills" || t === "mcp" || t === "tools" || t === "agents",
 						);
 						if (types.length > 0) {
 							byPath.set(resolved, { path: resolved, types });
@@ -163,6 +163,20 @@ export function getAllConfigDirectories(
 		types: ["tools"],
 		scope: "project",
 		exists: fs.existsSync(toolsDir),
+		isRemovable: false,
+	});
+
+	// ── Agents (1 built-in — file path, not directory) ──
+	const agentsMdPath = path.resolve(path.join(cwd, "AGENTS.md"));
+	const claudeMdPath = path.resolve(path.join(cwd, "CLAUDE.md"));
+	const agentsMdExists = fs.existsSync(agentsMdPath);
+	const claudeMdExists = !agentsMdExists && fs.existsSync(claudeMdPath);
+	const builtinAgentPath = agentsMdExists ? agentsMdPath : claudeMdExists ? claudeMdPath : agentsMdPath;
+	dirs.push({
+		path: builtinAgentPath,
+		types: ["agents"],
+		scope: "project",
+		exists: agentsMdExists || claudeMdExists,
 		isRemovable: false,
 	});
 

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -279,6 +279,7 @@ export class SessionManager {
 				goalTitle: assistantDef.promptTitle,
 				goalState: "active",
 				allowedTools: session.allowedTools,
+				projectConfigStore: this.projectConfigStore,
 			};
 		} else {
 			const goal = session.goalId ? this.goalManager.getGoal(session.goalId) : undefined;
@@ -314,6 +315,7 @@ export class SessionManager {
 				toolRestrictions: toolRestrictionsText,
 				personalities: resolvedPersonalities,
 				allowedTools: session.allowedTools,
+				projectConfigStore: this.projectConfigStore,
 			};
 		}
 
@@ -900,6 +902,7 @@ export class SessionManager {
 				goalTitle: assistantDef.promptTitle,
 				goalState: "active",
 				allowedTools: restoredAllowedTools,
+				projectConfigStore: this.projectConfigStore,
 			});
 			if (promptPath) bridgeOptions.systemPromptPath = promptPath;
 		} else {
@@ -939,6 +942,7 @@ export class SessionManager {
 				toolRestrictions: toolRestrictionsText,
 				personalities: resolvedPersonalities,
 				allowedTools: restoredAllowedTools,
+				projectConfigStore: this.projectConfigStore,
 			});
 			if (promptPath) bridgeOptions.systemPromptPath = promptPath;
 		}
@@ -1136,6 +1140,7 @@ export class SessionManager {
 				goalTitle: assistantDef.promptTitle,
 				goalState: "active",
 				allowedTools: effectiveAllowedTools,
+				projectConfigStore: this.projectConfigStore,
 			});
 			if (promptPath) bridgeOptions.systemPromptPath = promptPath;
 		} else {
@@ -1185,6 +1190,7 @@ export class SessionManager {
 				personalities: opts?.personalities,
 				allowedTools: effectiveAllowedTools,
 				workflowContext: opts?.workflowContext,
+				projectConfigStore: this.projectConfigStore,
 			});
 			if (promptPath) bridgeOptions.systemPromptPath = promptPath;
 		}
@@ -1370,6 +1376,7 @@ export class SessionManager {
 			personalities: opts?.personalities,
 			allowedTools: effectiveAllowedTools,
 			workflowContext: opts?.workflowContext,
+			projectConfigStore: this.projectConfigStore,
 		});
 		if (promptPath) bridgeOptions.systemPromptPath = promptPath;
 
@@ -1450,6 +1457,7 @@ export class SessionManager {
 			goalSpec: taskSpec,
 			goalTitle: "Delegate Task",
 			goalState: "active",
+			projectConfigStore: this.projectConfigStore,
 		});
 
 		const bridgeOptions: RpcBridgeOptions = { cwd: opts.cwd, env: { BOBBIT_SESSION_ID: id, BOBBIT_DELEGATE_OF: parentSessionId } };
@@ -2003,6 +2011,7 @@ export class SessionManager {
 			toolRestrictions: toolRestrictionsText,
 			personalities: resolvedPersonalities,
 			allowedTools: role.allowedTools.length > 0 ? role.allowedTools : undefined,
+			projectConfigStore: this.projectConfigStore,
 		});
 
 		// Respawn with new system prompt
@@ -2140,6 +2149,7 @@ export class SessionManager {
 			toolRestrictions: toolRestrictionsText,
 			personalities: resolvedPersonalities,
 			allowedTools: roleAllowedTools,
+			projectConfigStore: this.projectConfigStore,
 		});
 
 		// Respawn with new system prompt

--- a/src/server/agent/system-prompt.ts
+++ b/src/server/agent/system-prompt.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { bobbitStateDir } from "../bobbit-dir.js";
+import { getAllConfigDirectories, type ProjectConfigReader } from "./config-directories.js";
 
 const PROMPTS_DIR = path.join(bobbitStateDir(), "session-prompts");
 
@@ -67,6 +68,36 @@ export function readAgentsMd(cwd: string): string {
 	}
 }
 
+/**
+ * Read all agent markdown files from configured locations.
+ * Collects entries with type "agents" from getAllConfigDirectories(),
+ * reads each existing file, resolves @refs, and concatenates.
+ * Falls back to readAgentsMd() if no projectConfigStore is provided.
+ */
+export function readAllAgentFiles(cwd: string, projectConfigStore?: ProjectConfigReader): string {
+	if (!projectConfigStore) {
+		return readAgentsMd(cwd);
+	}
+
+	const dirs = getAllConfigDirectories(cwd, projectConfigStore);
+	const agentEntries = dirs.filter(d => d.types.includes("agents") && d.exists);
+
+	const parts: string[] = [];
+	for (const entry of agentEntries) {
+		try {
+			const content = fs.readFileSync(entry.path, "utf-8");
+			const resolved = resolveMarkdownRefs(content, path.dirname(entry.path));
+			if (resolved.trim()) {
+				parts.push(resolved.trim());
+			}
+		} catch (err) {
+			console.warn(`[system-prompt] Failed to read agent file ${entry.path}, skipping:`, err);
+		}
+	}
+
+	return parts.join("\n\n");
+}
+
 export interface PromptParts {
 	/** Path to the global system prompt file (config/system-prompt.md) */
 	baseSystemPromptPath?: string;
@@ -100,6 +131,8 @@ export interface PromptParts {
 	allowedTools?: string[];
 	/** Pre-formatted upstream gate context from workflow dependencies */
 	workflowContext?: string;
+	/** Project config store for multi-file agent discovery */
+	projectConfigStore?: ProjectConfigReader;
 }
 
 export interface PromptSection {
@@ -128,8 +161,8 @@ export function assembleSystemPrompt(sessionId: string, parts: PromptParts): str
 		if (base) sections.push(base);
 	}
 
-	// 2. AGENTS.md from working directory
-	const agentsMd = readAgentsMd(parts.cwd);
+	// 2. Agent files from working directory and custom locations
+	const agentsMd = readAllAgentFiles(parts.cwd, parts.projectConfigStore);
 	if (agentsMd.trim()) {
 		sections.push("# Project Context\n\n" + agentsMd.trim());
 	}
@@ -213,8 +246,8 @@ export function getPromptSections(parts: PromptParts): PromptSection[] {
 		if (base) sections.push({ label: "System Prompt", source: "config/system-prompt.md", content: base });
 	}
 
-	// 2. AGENTS.md
-	const agentsMd = readAgentsMd(parts.cwd);
+	// 2. Agent files
+	const agentsMd = readAllAgentFiles(parts.cwd, parts.projectConfigStore);
 	if (agentsMd.trim()) sections.push({ label: "Project Context", source: "AGENTS.md", content: agentsMd.trim() });
 
 	// 3. Goal spec (separate from role)

--- a/tests/config-directories.test.ts
+++ b/tests/config-directories.test.ts
@@ -130,14 +130,14 @@ describe("parseCustomDirectories", () => {
 // ── getAllConfigDirectories ──────────────────────────────────────────
 
 describe("getAllConfigDirectories", () => {
-	it("returns 12 built-in directories", () => {
+	it("returns 13 built-in directories", () => {
 		const store = mockStore();
 		const cwd = "/fake/project";
 		const result = getAllConfigDirectories(cwd, store);
 
 		// Filter to only built-in (not custom)
 		const builtIn = result.filter(d => d.scope !== "custom");
-		assert.equal(builtIn.length, 12, `Expected 12 built-in dirs, got ${builtIn.length}`);
+		assert.equal(builtIn.length, 13, `Expected 13 built-in dirs, got ${builtIn.length}`);
 
 		// All built-ins are not removable
 		for (const d of builtIn) {
@@ -159,6 +159,14 @@ describe("getAllConfigDirectories", () => {
 		const result = getAllConfigDirectories(cwd, store);
 		const mcpDirs = result.filter(d => d.types.includes("mcp") && d.scope !== "custom");
 		assert.equal(mcpDirs.length, 6);
+	});
+
+	it("includes correct agents directory (1)", () => {
+		const store = mockStore();
+		const cwd = "/fake/project";
+		const result = getAllConfigDirectories(cwd, store);
+		const agentsDirs = result.filter(d => d.types.includes("agents") && d.scope !== "custom");
+		assert.equal(agentsDirs.length, 1);
 	});
 
 	it("includes correct tools directory (1)", () => {


### PR DESCRIPTION
## Summary

Adds `"agents"` as a new config type to the config directories system, enabling discovery of agent markdown files (`AGENTS.md`, `CLAUDE.md`) from multiple configured locations.

## Changes

### Server (`config-directories.ts`, `system-prompt.ts`, `session-manager.ts`)
- Extended `ConfigType` union with `"agents"`
- Added built-in entry for `<cwd>/AGENTS.md` with `CLAUDE.md` fallback
- Added `readAllAgentFiles()` function for multi-file discovery with error resilience
- Threaded `projectConfigStore` through all `PromptParts` construction sites

### UI (`settings-page.ts`)
- Added Agents section and checkbox to Settings > Config Directories tab

### Tests
- Updated config-directories test for new built-in entry count

### Documentation
- Updated AGENTS.md with agents config type documentation