### PR TITLE
Prompt source provenance in system prompt inspector

### DIFF
--- a/src/server/agent/system-prompt.ts
+++ b/src/server/agent/system-prompt.ts
@@ -243,12 +243,34 @@ export function getPromptSections(parts: PromptParts): PromptSection[] {
 	// 1. Global system prompt
 	if (parts.baseSystemPromptPath && fs.existsSync(parts.baseSystemPromptPath)) {
 		const base = fs.readFileSync(parts.baseSystemPromptPath, "utf-8").trim();
-		if (base) sections.push({ label: "System Prompt", source: "config/system-prompt.md", content: base });
+		if (base) sections.push({ label: "System Prompt", source: parts.baseSystemPromptPath!, content: base });
 	}
 
-	// 2. Agent files
-	const agentsMd = readAllAgentFiles(parts.cwd, parts.projectConfigStore);
-	if (agentsMd.trim()) sections.push({ label: "Project Context", source: "AGENTS.md", content: agentsMd.trim() });
+	// 2. Agent files (individual sections per file for provenance)
+	if (parts.projectConfigStore) {
+		const dirs = getAllConfigDirectories(parts.cwd, parts.projectConfigStore);
+		const agentEntries = dirs.filter(d => d.types.includes("agents") && d.exists);
+		for (const entry of agentEntries) {
+			try {
+				const content = fs.readFileSync(entry.path, "utf-8");
+				const resolved = resolveMarkdownRefs(content, path.dirname(entry.path));
+				if (resolved.trim()) {
+					sections.push({ label: "Project Context", source: entry.path, content: resolved.trim() });
+				}
+			} catch {
+				// skip unreadable files
+			}
+		}
+	} else {
+		// Legacy fallback: single AGENTS.md with absolute path
+		const agentsPath = path.join(parts.cwd, "AGENTS.md");
+		if (fs.existsSync(agentsPath)) {
+			const content = readAgentsMd(parts.cwd);
+			if (content.trim()) {
+				sections.push({ label: "Project Context", source: agentsPath, content: content.trim() });
+			}
+		}
+	}
 
 	// 3. Goal spec (separate from role)
 	if (parts.goalSpec?.trim()) {

--- a/src/ui/dialogs/SystemPromptDialog.ts
+++ b/src/ui/dialogs/SystemPromptDialog.ts
@@ -53,6 +53,18 @@ export class SystemPromptDialog extends DialogBase {
 		}
 	}
 
+	private truncatePath(source: string): { display: string; full: string; isPath: boolean } {
+		const isPath = source.includes('/') || source.includes('\\');
+		if (!isPath) return { display: source, full: source, isPath: false };
+
+		const normalized = source.replace(/\\/g, '/');
+		const segments = normalized.split('/');
+		const display = segments.length > 3
+			? '…/' + segments.slice(-3).join('/')
+			: source;
+		return { display, full: source, isPath: true };
+	}
+
 	private toggleSection(index: number) {
 		const next = new Set(this.expandedSections);
 		if (next.has(index)) {
@@ -107,9 +119,15 @@ export class SystemPromptDialog extends DialogBase {
 					>
 						<path d="m9 18 6-6-6-6"></path>
 					</svg>
-					<div class="flex-1 min-w-0">
-						<span class="font-medium text-sm text-foreground">${section.label}</span>
-						<span class="text-xs text-muted-foreground ml-2">${section.source}</span>
+					<div class="flex-1 min-w-0 flex items-center gap-2">
+						${(() => { const p = this.truncatePath(section.source); return html`
+						<span
+							class="text-sm text-foreground truncate ${p.isPath ? 'font-mono' : 'font-medium'}"
+							title="${p.full}"
+							style="max-width: 70%"
+						>${p.display}</span>
+						<span class="text-[11px] px-1.5 py-0.5 rounded bg-secondary text-muted-foreground shrink-0">${section.label}</span>
+						`; })()}
 					</div>
 					<span class="text-xs text-muted-foreground shrink-0">${this.formatSize(section.content.length)}</span>
 				</button>


### PR DESCRIPTION
The system prompt inspector dialog now shows the **original file path** for every component of the assembled prompt, with each source file in its own collapsible section.

## Changes

### Server: `src/server/agent/system-prompt.ts`
- **Split agent files into individual sections**: Each agent file (AGENTS.md, custom agent files from config directories) gets its own collapsible section with its absolute file path as the source identifier
- **Absolute path for system-prompt.md**: Source now shows the real file path instead of generic `config/system-prompt.md`
- Legacy fallback (no projectConfigStore) uses absolute path for single AGENTS.md

### UI: `src/ui/dialogs/SystemPromptDialog.ts`
- Source file path is now the **primary identifier** in each section header (monospace for paths)
- Long paths truncated to last 3 segments with full path in tooltip
- Section type label shown as a small badge
- Non-path sources (Personalities, Tool documentation) displayed as-is