### PR TITLE
Reduce MCP prompt bloat

### DIFF
--- a/src/server/mcp/mcp-manager.ts
+++ b/src/server/mcp/mcp-manager.ts
@@ -278,7 +278,7 @@ export class McpManager {
           name: this._makeBobbitToolName(serverName, tool.name),
           description: tool.description || `MCP tool ${tool.name} from ${serverName}`,
           group: `MCP: ${serverName}`,
-          docs: this._generateToolDocs(tool),
+          docs: undefined,
           serverName,
           mcpToolName: tool.name,
           inputSchema: tool.inputSchema as Record<string, unknown>,
@@ -289,7 +289,8 @@ export class McpManager {
     return infos;
   }
 
-  /** Auto-generate docs from inputSchema. */
+  /** Auto-generate docs from inputSchema. Kept for potential use in Tools UI detail view. */
+  // @ts-expect-error Intentionally unused — kept for future use
   private _generateToolDocs(tool: McpToolDef): string {
     const schema = tool.inputSchema;
     if (!schema || typeof schema !== "object") return "";


### PR DESCRIPTION
Stop injecting auto-generated MCP tool parameter tables into the system prompt. These are redundant — Claude already receives the identical information via the API-level tool inputSchema.

**Change:** In `src/server/mcp/mcp-manager.ts`, `getToolInfos()` now sets `docs: undefined` instead of `docs: this._generateToolDocs(tool)`.

**Impact:** Playwright alone saves ~8KB / ~200 lines per prompt. Each additional MCP server saves proportionally. MCP tools still appear in the `# Tools` overview with one-liner descriptions. Built-in tool docs are unaffected.