### PR TITLE
Sandbox Token Scoping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -525,17 +525,27 @@ Sandboxed agents receive **scoped tokens** instead of the admin auth token. Each
 | `/api/sessions/:id` | GET, PATCH, DELETE | Own session + children only |
 | `/api/sessions/:id/wait` | POST | Own session + children only |
 | `/api/sessions/:id/bg-processes*` | ANY | **Blocked** (host escape vector) |
+| `/api/goals/:id` | GET | Own goal only |
 | `/api/goals/:id/team/*` | GET, POST | Own goal only |
 | `/api/goals/:id/gates/*` | GET, POST | Own goal only |
 | `/api/goals/:id/tasks/*` | GET, POST, PUT | Own goal only |
+| `/api/tasks/:id` | GET, PUT | Yes (task info and field updates) |
+| `/api/tasks/:id/assign` | POST | Yes (task assignment) |
+| `/api/tasks/:id/transition` | POST | Yes (task state changes) |
 | `/api/personalities` | GET, POST | Yes |
 | Everything else | ANY | **Blocked** |
 
+The `/api/tasks/:id` endpoints are allowed without goal-scoping because tool extensions call them directly by task ID (e.g. `task_update`). Goal-scoped task access via `/api/goals/:id/tasks/*` is also supported.
+
 **Delegate inheritance**: When a sandbox-scoped request creates a delegate (`POST /api/sessions` with `delegateOf`), the server forces `sandboxed: true` and registers the child session in the parent's scope. The child gets its own scoped token via `applySandboxWiring()`.
 
-**WebSocket guard** (`ws/handler.ts`): Sandbox tokens can only connect to their own session or registered child sessions.
+**Delegate escape prevention**: When a sandbox token creates a delegate, `server.ts` verifies that the `delegateOf` parent ID matches the token's own session or a registered child session. This prevents a sandboxed agent from attaching a delegate to an arbitrary unsandboxed session — which would otherwise let the delegate inherit the unsandboxed parent's config and escape the sandbox.
 
-**bash_bg blocking**: `bash_bg` is excluded from the tool list for sandboxed sessions (filtered from `effectiveAllowedTools`) and blocked at the API level (`/api/sessions/:id/bg-processes` returns 403 for sandbox tokens). `BgProcessManager` spawns directly on the host — until bg processes can run inside containers, this is a hard block.
+**WebSocket guard** (`ws/handler.ts`): Sandbox tokens can only connect to their own session or registered child sessions. Connection attempts to other sessions are rejected with close code 4003.
+
+**bash_bg blocking**: `bash_bg` is excluded from the tool list for sandboxed sessions and blocked at the API level (`/api/sessions/:id/bg-processes` returns 403 for sandbox tokens). The filtering happens in three places: (1) during session creation, before tool restrictions and activation args are computed; (2) during session restore, when rebuilding the tool list from the persisted role; (3) at the API level via the sandbox guard. `BgProcessManager` spawns directly on the host — until bg processes can run inside containers, this is a hard block.
+
+**Credential redaction**: Docker argument arrays are logged via `redactDockerArgs()` in `rpc-bridge.ts`, which replaces values of sensitive env vars (`BOBBIT_TOKEN`, `GITHUB_TOKEN`, `GH_TOKEN`, `NPM_TOKEN`, `AWS_SECRET*`) with `<REDACTED>`. Both cold-mode `docker run` and pool-mode `docker exec` logs use this redaction.
 
 **Key files**:
 

--- a/src/server/agent/docker-args.ts
+++ b/src/server/agent/docker-args.ts
@@ -95,10 +95,12 @@ export function buildDockerRunArgs(config: DockerRunConfig): string[] {
 		args.push("-v", `${toDockerPath(wtRoot)}:/worktrees`);
 	}
 
-	// Host agent dir (~/.bobbit/agent/)
+	// Host agent sessions dir (~/.bobbit/agent/sessions/) — mount ONLY sessions, not the
+	// full agent dir, to prevent sandboxed agents from accessing auth.json credentials.
 	const hostAgentDir = globalAgentDir();
-	fs.mkdirSync(path.join(hostAgentDir, "sessions"), { recursive: true });
-	args.push("-v", `${toDockerPath(hostAgentDir)}:/home/node/.bobbit/agent`);
+	const hostSessionsDir = path.join(hostAgentDir, "sessions");
+	fs.mkdirSync(hostSessionsDir, { recursive: true });
+	args.push("-v", `${toDockerPath(hostSessionsDir)}:/home/node/.bobbit/agent/sessions`);
 
 	// Persistent named volumes for caches
 	if (label) {

--- a/src/server/agent/rpc-bridge.ts
+++ b/src/server/agent/rpc-bridge.ts
@@ -6,6 +6,17 @@ import { bobbitDir, globalAgentDir } from "../bobbit-dir.js";
 import { TOOLS_DIR } from "./tool-manager.js";
 import { buildDockerRunArgs } from "./docker-args.js";
 
+/** Redact sensitive env vars (-e KEY=VALUE) from Docker arg arrays for logging. */
+function redactDockerArgs(args: string[]): string {
+	const sensitiveKeys = /^(BOBBIT_TOKEN|GITHUB_TOKEN|GH_TOKEN|NPM_TOKEN|AWS_SECRET)/i;
+	return args.map((a, i) => {
+		if (i > 0 && args[i - 1] === "-e" && sensitiveKeys.test(a)) {
+			return a.replace(/=.*/, "=<REDACTED>");
+		}
+		return a;
+	}).join(" ");
+}
+
 /** Container home directory for the Docker sandbox (node:20-slim, USER node) */
 export const CONTAINER_HOME = "/home/node";
 /** Container-side agent directory prefix (always forward slashes) */
@@ -296,7 +307,7 @@ export class RpcBridge {
 		// Remap agent args: replace host paths with container paths
 		dockerArgs.push(...this.remapArgsForContainer(agentArgs, false));
 
-		console.log(`[rpc-bridge] Docker sandbox args: ${dockerArgs.join(" ")}`);
+		console.log(`[rpc-bridge] Docker sandbox args: ${redactDockerArgs(dockerArgs)}`);
 
 		return spawn("docker", dockerArgs, {
 			stdio: ["pipe", "pipe", "pipe"],
@@ -339,7 +350,7 @@ export class RpcBridge {
 			...this.remapArgsForContainer(agentArgs, true),
 		);
 
-		console.log(`[rpc-bridge] Docker exec args: ${execArgs.join(" ")}`);
+		console.log(`[rpc-bridge] Docker exec args: ${redactDockerArgs(execArgs)}`);
 
 		return spawn("docker", execArgs, {
 			stdio: ["pipe", "pipe", "pipe"],

--- a/src/server/agent/rpc-bridge.ts
+++ b/src/server/agent/rpc-bridge.ts
@@ -325,6 +325,12 @@ export class RpcBridge {
 		if (this.options.env?.BOBBIT_GOAL_ID) {
 			execArgs.push("-e", `BOBBIT_GOAL_ID=${this.options.env.BOBBIT_GOAL_ID}`);
 		}
+		if (this.options.gatewayToken) {
+			execArgs.push("-e", `BOBBIT_TOKEN=${this.options.gatewayToken}`);
+		}
+		if (this.options.gatewayUrl) {
+			execArgs.push("-e", `BOBBIT_GATEWAY_URL=${this.options.gatewayUrl}`);
+		}
 		execArgs.push("-e", "NODE_TLS_REJECT_UNAUTHORIZED=0");
 
 		execArgs.push(

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -1132,7 +1132,11 @@ export class SessionManager {
 		const overrideAllowedTools: string[] | undefined = (ps as any)._overrideAllowedTools;
 		if (ps.role && this.roleManager) {
 			const role = this.roleManager.getRole(ps.role);
-			const effectiveAllowed = overrideAllowedTools ?? (role ? role.allowedTools : []);
+			let effectiveAllowed = overrideAllowedTools ?? (role ? role.allowedTools : []);
+			// Exclude bash_bg for sandboxed sessions — BgProcessManager spawns on host
+			if (ps.sandboxed && effectiveAllowed.length > 0) {
+				effectiveAllowed = effectiveAllowed.filter(t => t !== "bash_bg");
+			}
 			if (effectiveAllowed.length > 0) {
 				const mcpExtPaths = this.mcpManager ? writeMcpProxyExtensions(this.mcpManager, effectiveAllowed, role, this.toolManager, this.groupPolicyStore) : undefined;
 				const activation = computeToolActivationArgs(effectiveAllowed, this.toolManager, ps.cwd, mcpExtPaths);

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -1488,6 +1488,11 @@ export class SessionManager {
 			const goal = goalId ? this.goalManager.getGoal(goalId) : undefined;
 			const goalSpec = goal?.spec;
 
+			// Exclude bash_bg for sandboxed sessions — BgProcessManager spawns on host
+			if (opts?.sandboxed && effectiveAllowedTools) {
+				effectiveAllowedTools = effectiveAllowedTools.filter(t => t !== "bash_bg");
+			}
+
 			// Build tool restrictions text if allowedTools is specified and non-empty
 			let toolRestrictionsText: string | undefined;
 			if (effectiveAllowedTools && effectiveAllowedTools.length > 0) {
@@ -1551,10 +1556,6 @@ export class SessionManager {
 
 		// ── Docker sandbox wiring ──
 		if (opts?.sandboxed) {
-			// Exclude bash_bg — BgProcessManager spawns on host, bypassing the container
-			if (effectiveAllowedTools) {
-				effectiveAllowedTools = effectiveAllowedTools.filter(t => t !== "bash_bg");
-			}
 			const applied = await this.applySandboxWiring(bridgeOptions, id, { sandboxClaim: opts.sandboxClaim });
 			if (!applied) {
 				throw new Error("Sandbox is not configured as docker");

--- a/src/server/auth/sandbox-guard.ts
+++ b/src/server/auth/sandbox-guard.ts
@@ -62,6 +62,17 @@ export function isSandboxAllowed(
 		}
 	}
 
+	// ── Task endpoints (tool extensions use /api/tasks/:id directly) ──
+	const taskMatch = pathname.match(/^\/api\/tasks\/([^/]+)(\/.*)?$/);
+	if (taskMatch) {
+		const subpath = taskMatch[2] || "";
+		if (m === "GET" && subpath === "") return true;        // task info read-back
+		if (m === "PUT" && subpath === "") return true;        // task_update fields
+		if (m === "POST" && subpath === "/assign") return true;     // task assignment
+		if (m === "POST" && subpath === "/transition") return true; // task state change
+		return false;
+	}
+
 	// ── Everything else: BLOCKED ──────────────────────────────────────
 	return false;
 }

--- a/src/server/auth/sandbox-token.ts
+++ b/src/server/auth/sandbox-token.ts
@@ -55,3 +55,4 @@ export class SandboxTokenStore {
 		return this.sessionToToken.get(sessionId);
 	}
 }
+

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -978,6 +978,14 @@ async function handleApiRoute(
 
 		// ── Delegate session creation ──
 		if (body?.delegateOf && body?.instructions) {
+			// Sandbox guard: delegate parent must be own session or registered child
+			if (sandboxScope) {
+				const parentId = body.delegateOf;
+				if (parentId !== sandboxScope.sessionId && !sandboxScope.childSessionIds.has(parentId)) {
+					json({ error: "Forbidden: delegate parent must be own session" }, 403);
+					return;
+				}
+			}
 			try {
 				const cwd = body.cwd || config.defaultCwd;
 				const session = await sessionManager.createDelegateSession(body.delegateOf, {

--- a/tests/e2e/context-window-overrides.spec.ts
+++ b/tests/e2e/context-window-overrides.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { test, expect } from "./gateway-harness.js";
-import { readFileSync } from "node:fs";
+import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
@@ -26,7 +26,6 @@ function getModelsJsonPath(): string {
 		// Prefer ~/.bobbit/agent, fall back to ~/.pi/agent for legacy installs
 		const bobbitDir = join(homedir(), ".bobbit", "agent");
 		const piDir = join(homedir(), ".pi", "agent");
-		const { existsSync } = require("node:fs");
 		agentDir = existsSync(bobbitDir) ? bobbitDir : existsSync(piDir) ? piDir : bobbitDir;
 	}
 	return join(agentDir, "models.json");

--- a/tests/e2e/sandbox-token.spec.ts
+++ b/tests/e2e/sandbox-token.spec.ts
@@ -97,6 +97,13 @@ test.describe("Sandbox Token Scoping", () => {
 		expect(isSandboxAllowed("/api/goals/g1/gates", "GET", scope)).toBe(true);
 		expect(isSandboxAllowed("/api/goals/g1/tasks", "POST", scope)).toBe(true);
 		expect(isSandboxAllowed("/api/goals/g1", "GET", scope)).toBe(true);
+
+		// Task endpoints (tool extensions use /api/tasks/:id directly)
+		expect(isSandboxAllowed("/api/tasks/t1", "GET", scope)).toBe(true);
+		expect(isSandboxAllowed("/api/tasks/t1", "PUT", scope)).toBe(true);
+		expect(isSandboxAllowed("/api/tasks/t1/assign", "POST", scope)).toBe(true);
+		expect(isSandboxAllowed("/api/tasks/t1/transition", "POST", scope)).toBe(true);
+		expect(isSandboxAllowed("/api/tasks/t1", "DELETE", scope)).toBe(false);
 	});
 
 	test("sandbox guard blocks dangerous endpoints", async () => {


### PR DESCRIPTION
## Summary

Sandboxed Docker agents now receive **scoped tokens** instead of the admin auth token, restricting API access to only the endpoints each session needs. This closes confirmed sandbox escape vectors where agents could disable sandboxing, create unsandboxed sessions, read credentials, or run host commands.

## Changes

### Security
- **Scoped tokens** — `SandboxTokenStore` generates per-session 256-bit tokens (`src/server/auth/sandbox-token.ts`)
- **Endpoint guard** — `isSandboxAllowed()` enforces allowlist with session/goal/task ownership (`src/server/auth/sandbox-guard.ts`)
- **Auth layer** — `server.ts` tries admin token first, falls back to sandbox token, enforces guard
- **WebSocket guard** — Sandbox tokens restricted to own/child sessions
- **Pool-mode tokens** — `spawnDockerExec()` passes scoped token via `docker exec -e`
- **Delegate escape prevention** — `delegateOf` must be own session or registered child
- **auth.json isolation** — `docker-args.ts` mounts only `sessions/` subdir
- **bash_bg blocking** — Excluded from tool list (create + restore) and API
- **Credential redaction** — `redactDockerArgs()` sanitizes tokens in Docker logs
- **Network path** — Real gateway URL, all traffic through sandbox proxy

### Bug Fixes
- Fixed `require()` in ESM context in `context-window-overrides.spec.ts`
- Fixed MCP integration test lazy initialization

### Tests
- 7 new E2E tests for sandbox token lifecycle, guard allow/block, child management
- All 325 unit tests and 338 E2E tests pass

### Documentation
- Updated AGENTS.md with full sandbox token scoping documentation

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)