### PR TITLE
Session Creation Pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,8 @@ UI-only changes need only unit tests. Server changes need E2E too.
 
 **Add a goal feature**: CRUD in `goal-manager.ts`/`goal-store.ts`. REST in `server.ts`. Assistant prompt in `goal-assistant.ts`. Proposal parsing in `remote-agent.ts` `_checkForGoalProposal()`. Re-attempt: `buildReattemptContext()`, `startReattempt()`.
 
+**Add/modify session creation logic**: Session creation uses a plan/execute pipeline in `session-setup.ts`. The three creation modes (normal, worktree, delegate) share composable pipeline steps (`resolveBridgeOptions`, `resolveGoalExtensions`, `resolveTools`, `resolvePrompt`, `resolveToolActivation`) with different executors (`executePlan` for normal/delegate, `executeWorktreeAsync` for worktree). `session-manager.ts` contains thin wrappers (`createSession`, `createDelegateSession`) that build a `SessionSetupPlan` and delegate to the pipeline. Persistence uses put-once-then-update: `persistOnce()` does a single `store.put()` at creation, then `persistSessionMetadata()` only calls `store.update()` for the `agentSessionFile` field.
+
 **Change tool access policy**: Edit `.bobbit/config/tool-group-policies.yaml` (per-group) or role YAML `toolPolicies` (per-role). Resolution: role+tool → role+group → tool default → group default → `always-allow`. See @docs/internals.md#tool-access-policies for full details.
 
 **Change message rendering**: `src/ui/components/Messages.ts` for standard roles, `message-renderer-registry.ts` for custom types.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -10,6 +10,11 @@ Scannable checklists for common issues. Each entry: symptom → where to look �
 
 ## Session connection issues
 
+- Session creation logic lives in `session-setup.ts` (pipeline steps + executors) and `session-manager.ts` (thin wrappers)
+- `executePlan()` runs the full pipeline synchronously for normal/delegate sessions
+- `executeWorktreeAsync()` runs asynchronously for worktree sessions (fire-and-forget, returns immediately with `status: "preparing"`)
+- `handleSetupFailure()` in `session-setup.ts` handles cleanup on pipeline errors
+- `subscribeToEvents()` is the shared event subscription function across all session types
 - `connectToSession()` in `session-manager.ts` creates ChatPanel before `remote.connect()`
 - Model + WebSocket connect run in parallel via `Promise.all`
 - `switchGeneration` / `isStale()` invalidates in-flight work on rapid switches
@@ -30,6 +35,10 @@ Scannable checklists for common issues. Each entry: symptom → where to look �
 ## Session persistence
 
 - Check `.bobbit/state/sessions.json`
+- Initial persist happens via `persistOnce()` in `session-setup.ts` — a single `store.put()` with all structural fields at creation time
+- `persistSessionMetadata()` only calls `store.update()` (never `store.put()`) — updates `agentSessionFile` once the agent reports it
+- `persistSessionMetadata()` retries 3 times with backoff (500ms, 1s, 2s) on failure
+- `sandboxed` is a typed field on `SessionInfo` (no `(session as any)._sandboxed` hack)
 - `restoreSessions()` in `session-manager.ts` skips sessions with missing `.jsonl` files
 - Failed restores create dormant entries that revive on client connect
 
@@ -65,6 +74,7 @@ Scannable checklists for common issues. Each entry: symptom → where to look �
 ## Sandbox sessions
 
 - `GET /api/sandbox-status` for Docker availability
+- Worktree sessions now correctly call `applySandboxWiring()` via the pipeline (previously `_setupWorktreeAndLaunchAgent()` skipped sandbox wiring)
 - `sessions.json` has `sandboxed: boolean`
 - Proxy logs: `[sandbox-proxy]` prefix — look for `BLOCKED` / `CONNECT`
 - Container can't reach gateway? Check: (1) proxy allowlist has gateway hostname, (2) `BOBBIT_GATEWAY_URL` matches real address, (3) CONNECT forwarding in proxy logs

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -2479,8 +2479,14 @@ export class SessionManager {
 		session.clients.clear();
 
 		this.sessions.delete(id);
-		// Archive instead of delete — keep metadata for 7 days
-		this.store.archive(id);
+		// Archive the session — keep metadata for 7 days.
+		// But sessions with no agentSessionFile are unrestorable, so just remove them.
+		const persisted = this.store.get(id);
+		if (persisted?.agentSessionFile) {
+			this.store.archive(id);
+		} else {
+			this.store.remove(id);
+		}
 		// Don't remove color or session prompt — they're needed for archived view
 		return true;
 	}

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -29,10 +29,20 @@ import { McpManager } from "../mcp/mcp-manager.js";
 import { getAigwUrl, discoverAigwModels, deriveName } from "./aigw-manager.js";
 import { modelRecencyRank } from "./model-registry.js";
 import { buildAvailableRolesList } from "./team-manager.js";
-import { createWorktree } from "../skills/git.js";
+// createWorktree is used in session-setup.ts pipeline
 import { bobbitStateDir } from "../bobbit-dir.js";
 import { SandboxProxy } from "./sandbox-proxy.js";
 import type { SandboxPool, ClaimOptions } from "./sandbox-pool.js";
+import {
+	type SessionSetupPlan,
+	type PipelineContext,
+	executePlan,
+	executeWorktreeAsync,
+	persistOnce,
+	handleSetupFailure,
+	sendDelegatePrompt,
+	DELEGATE_SPAWN_TIMEOUT_MS,
+} from "./session-setup.js";
 
 
 /** Goal tools extension — task + gate management for any goal session. */
@@ -77,6 +87,8 @@ export interface SessionInfo {
 	staffId?: string;
 	/** Pixel-art accessory ID for the Bobbit sprite overlay */
 	accessory?: string;
+	/** Whether this session runs inside a Docker sandbox */
+	sandboxed?: boolean;
 	/** Container ID if using a pooled Docker container */
 	containerId?: string;
 	/** Whether this is an automated non-interactive session (e.g. verification reviewer) */
@@ -199,6 +211,37 @@ export class SessionManager {
 	/** Whether Docker sandbox mode is enabled in project config. */
 	get isSandboxEnabled(): boolean {
 		return (this.projectConfigStore?.get("sandbox") || "none") === "docker";
+	}
+
+	/** Build a PipelineContext from this manager's fields. */
+	buildPipelineContext(): PipelineContext {
+		return {
+			agentCliPath: this.agentCliPath,
+			systemPromptPath: this.systemPromptPath,
+			roleManager: this.roleManager ?? null,
+			toolManager: this.toolManager ?? null,
+			mcpManager: this.mcpManager,
+			goalManager: this.goalManager,
+			taskManager: this.taskManager,
+			personalityManager: this.personalityManager ?? null,
+			projectConfigStore: this.projectConfigStore ?? null,
+			sandboxPool: this.sandboxPool,
+			sandboxTokenStore: this.sandboxTokenStore,
+			groupPolicyStore: this.groupPolicyStore ?? null,
+			costTracker: this.costTracker,
+			store: this.store,
+			searchIndex: this.searchIndex,
+			sessions: this.sessions,
+			assemblePrompt: (id, parts) => this.assemblePrompt(id, parts),
+			buildToolRestrictionsText: (tools, role) => this.buildToolRestrictionsText(tools, role),
+			applySandboxWiring: (opts, id, sandboxOpts) => this.applySandboxWiring(opts, id, sandboxOpts),
+			handleAgentLifecycle: (session, event) => this.handleAgentLifecycle(session, event),
+			trackCostFromEvent: (session, event) => this.trackCostFromEvent(session, event),
+			broadcast: (clients, msg) => broadcast(clients, msg),
+			tryAutoSelectModel: (session) => this.tryAutoSelectModel(session),
+			tryApplyDefaultThinkingLevel: (session) => this.tryApplyDefaultThinkingLevel(session),
+			buildWorkflowList: () => this._buildWorkflowList(),
+		};
 	}
 
 	/** Ensure a SandboxProxy is running with the given allowlist. Returns the port. */
@@ -1105,10 +1148,18 @@ export class SessionManager {
 
 	private async restoreOneSession(ps: PersistedSession): Promise<void> {
 		if (!ps.agentSessionFile) {
-			// Session was persisted before the agent session file was obtained
-			// (e.g. server restarted during session creation). Remove it.
-			console.log(`[session-manager] Removing ${ps.id} — no agent session file recorded (session was mid-creation)`);
-			this.store.remove(ps.id);
+			if (ps.worktreePath && ps.branch) {
+				// Code may be recoverable — the branch exists in git
+				console.warn(
+					`[session-manager] Session ${ps.id} has no agentSessionFile but has worktree ` +
+					`(branch: ${ps.branch}, path: ${ps.worktreePath}). ` +
+					`Code may be recoverable. Archiving session — branch "${ps.branch}" preserved in git.`,
+				);
+				this.store.archive(ps.id);
+			} else {
+				console.log(`[session-manager] Removing ${ps.id} — no agent session file and no worktree`);
+				this.store.remove(ps.id);
+			}
 			return;
 		}
 		if (!fs.existsSync(ps.agentSessionFile)) {
@@ -1363,6 +1414,7 @@ export class SessionManager {
 
 	async createSession(cwd: string, agentArgs?: string[], goalId?: string, assistantType?: string, opts?: { rolePrompt?: string; roleName?: string; env?: Record<string, string>; taskId?: string; allowedTools?: string[]; personalities?: Array<{ label: string; promptFragment: string }>; personalityNames?: string[]; workflowContext?: string; worktreeOpts?: { repoPath: string }; reattemptGoalId?: string; sandboxed?: boolean; sandboxClaim?: ClaimOptions }): Promise<SessionInfo> {
 		const id = randomUUID();
+		const ctx = this.buildPipelineContext();
 
 		// ── Worktree: return a "preparing" session immediately, launch agent async ──
 		if (opts?.worktreeOpts) {
@@ -1398,421 +1450,78 @@ export class SessionManager {
 			};
 
 			this.sessions.set(id, session);
-			// Persist immediately with what we know — agentSessionFile will be
-			// empty until the agent starts, but this ensures the session appears
-			// in the store and survives a restart (as a removable placeholder).
-			this.store.put({
+
+			// Build the plan for the worktree pipeline
+			const plan: SessionSetupPlan = {
 				id,
-				title: session.title,
-				cwd: session.cwd,
-				agentSessionFile: "",
-				createdAt: session.createdAt,
-				lastActivity: session.lastActivity,
+				mode: "worktree",
+				title: "New session",
+				cwd,
 				goalId,
+				taskId: opts?.taskId,
 				worktreePath,
 				repoPath,
 				branch,
-				taskId: opts?.taskId,
-				personalities: opts?.personalityNames,
 				sandboxed: opts?.sandboxed,
-			});
+				personalities: opts?.personalityNames,
+				agentArgs,
+				env: opts?.env,
+				rolePrompt: opts?.rolePrompt,
+				roleName: opts?.roleName,
+				personalityFragments: opts?.personalities,
+				workflowContext: opts?.workflowContext,
+				effectiveAllowedTools: opts?.allowedTools,
+				sandboxClaim: opts?.sandboxClaim,
+				bridgeOptions: { cwd },
+			};
 
-			// Fire-and-forget: create worktree then launch agent
-			this._setupWorktreeAndLaunchAgent(session, repoPath, branch, cwd, agentArgs, goalId, opts).catch((err) => {
-				console.error(`[session-manager] Worktree session setup failed for ${id}:`, err);
-				session.status = "terminated";
-				broadcast(session.clients, { type: "session_status", status: "terminated" });
+			// Persist immediately with all known structural fields
+			persistOnce(session, plan, this.store);
+
+			// Fire-and-forget: create worktree then complete pipeline
+			executeWorktreeAsync(plan, session, ctx).then(() => {
+				// Persist session metadata now that the agent is running
+				this.persistSessionMetadata(session).catch((err) => {
+					console.warn(`[session-manager] Early persist failed for worktree session ${session.id}:`, err);
+				});
+			}).catch((err) => {
+				handleSetupFailure(session, plan, err, ctx);
 			});
 
 			return session;
 		}
 
-		const bridgeOptions: RpcBridgeOptions = {
-			cwd,
-			args: agentArgs ? [...agentArgs] : [],
-			env: { BOBBIT_SESSION_ID: id, ...opts?.env },
-		};
-		if (this.agentCliPath) {
-			bridgeOptions.cliPath = this.agentCliPath;
-		}
-
-		// Auto-load goal tools extension for any goal-associated session
-		// (unless it's a goal/role assistant, or already has an extension —
-		// tool-activation handles loading both tasks + team extensions via YAML providers)
-		if (goalId && !assistantType) {
-			const alreadyHasExtension = bridgeOptions.args?.includes("--extension");
-			if (!alreadyHasExtension) {
-				bridgeOptions.args = bridgeOptions.args || [];
-				bridgeOptions.args.push("--extension", GOAL_TOOLS_EXTENSION_PATH);
-			}
-			// Ensure BOBBIT_GOAL_ID is set for the extension to read
-			bridgeOptions.env = { ...bridgeOptions.env, BOBBIT_GOAL_ID: goalId };
-		}
-
-		// Determine tool restrictions: explicit role tools > General role > no restriction
-		let effectiveAllowedTools = opts?.allowedTools;
-		if (!effectiveAllowedTools && this.roleManager) {
-			const generalRole = this.roleManager.getRole("general");
-			if (generalRole && generalRole.allowedTools.length > 0) {
-				effectiveAllowedTools = generalRole.allowedTools;
-			}
-		}
-
-		const assistantDef = assistantType ? getAssistantDef(assistantType) : undefined;
-		if (assistantDef) {
-			// Combine assistant role's shared prompt with per-type specialized prompt
-			const assistantRole = this.roleManager?.getRole("assistant");
-			let assistantGoalSpec = "";
-			if (assistantRole?.promptTemplate) {
-				assistantGoalSpec = assistantRole.promptTemplate.replace(/\{\{AGENT_ID\}\}/g, `assistant-${(goalId || id).slice(0, 8)}`);
-				assistantGoalSpec += "\n\n---\n\n";
-			}
-			assistantGoalSpec += assistantDef.prompt;
-			if (assistantType === "goal") {
-				assistantGoalSpec = assistantGoalSpec.replace('{{AVAILABLE_WORKFLOWS}}', this._buildWorkflowList());
-				// Inject re-attempt context if this is a re-attempt session
-				if (opts?.reattemptGoalId) {
-					const origGoal = this.goalManager.getGoal(opts.reattemptGoalId);
-					if (origGoal) {
-						assistantGoalSpec += "\n\n" + buildReattemptContext(origGoal);
-					}
-				}
-			}
-
-			// Use assistant role's tool restrictions (before assemblePrompt so tool docs are filtered correctly)
-			if (assistantRole && assistantRole.allowedTools.length > 0) {
-				effectiveAllowedTools = assistantRole.allowedTools;
-			}
-
-			const promptPath = this.assemblePrompt(id, {
-				baseSystemPromptPath: undefined,
-				cwd,
-				goalSpec: assistantGoalSpec,
-				goalTitle: assistantDef.promptTitle,
-				goalState: "active",
-				allowedTools: effectiveAllowedTools,
-				projectConfigStore: this.projectConfigStore,
-			});
-			if (promptPath) bridgeOptions.systemPromptPath = promptPath;
-		} else {
-			// Normal sessions: global base + AGENTS.md from cwd + goal spec
-			const goal = goalId ? this.goalManager.getGoal(goalId) : undefined;
-			const goalSpec = goal?.spec;
-
-			// Exclude bash_bg for sandboxed sessions — BgProcessManager spawns on host
-			if (opts?.sandboxed && effectiveAllowedTools) {
-				effectiveAllowedTools = effectiveAllowedTools.filter(t => t !== "bash_bg");
-			}
-
-			// Build tool restrictions text if allowedTools is specified and non-empty
-			let toolRestrictionsText: string | undefined;
-			if (effectiveAllowedTools && effectiveAllowedTools.length > 0) {
-				const effectiveRole = (opts?.roleName && this.roleManager) ? this.roleManager.getRole(opts.roleName) : undefined;
-				toolRestrictionsText = this.buildToolRestrictionsText(effectiveAllowedTools, effectiveRole ?? undefined);
-			}
-
-			// Build task context if taskId is provided
-			let taskTitle: string | undefined;
-			let taskType: string | undefined;
-			let taskSpec: string | undefined;
-			let taskDependsOn: string[] | undefined;
-			if (opts?.taskId) {
-				const task = this.taskManager.getTask(opts.taskId);
-				if (task) {
-					taskTitle = task.title;
-					taskType = task.type;
-					taskSpec = task.spec;
-					if (task.dependsOn && task.dependsOn.length > 0) {
-						taskDependsOn = task.dependsOn.map(depId => {
-							const dep = this.taskManager.getTask(depId);
-							return dep?.title || depId;
-						});
-					}
-				}
-			}
-
-			const promptPath = this.assemblePrompt(id, {
-				baseSystemPromptPath: this.systemPromptPath,
-				cwd,
-				goalTitle: goal?.title,
-				goalState: goal?.state,
-				goalSpec,
-				rolePrompt: opts?.rolePrompt,
-				roleName: opts?.roleName,
-				toolRestrictions: toolRestrictionsText,
-				taskTitle,
-				taskType,
-				taskSpec,
-				taskDependsOn,
-				personalities: opts?.personalities,
-				allowedTools: effectiveAllowedTools,
-				workflowContext: opts?.workflowContext,
-				projectConfigStore: this.projectConfigStore,
-			});
-			if (promptPath) bridgeOptions.systemPromptPath = promptPath;
-		}
-
-		// Apply tool activation args based on allowedTools (controls --tools and --extension flags)
-		if (effectiveAllowedTools && effectiveAllowedTools.length > 0) {
-			const effectiveRole = (opts?.roleName && this.roleManager) ? this.roleManager.getRole(opts.roleName) : undefined;
-			const mcpExtPaths = this.mcpManager ? writeMcpProxyExtensions(this.mcpManager, effectiveAllowedTools, effectiveRole ?? undefined, this.toolManager, this.groupPolicyStore) : undefined;
-			const activation = computeToolActivationArgs(effectiveAllowedTools, this.toolManager, cwd, mcpExtPaths);
-			bridgeOptions.args = [...activation.args, ...(bridgeOptions.args || [])];
-		} else if (this.mcpManager) {
-			const mcpExtPaths = writeMcpProxyExtensions(this.mcpManager);
-			for (const extPath of mcpExtPaths) {
-				bridgeOptions.args = [...(bridgeOptions.args || []), "--extension", extPath];
-			}
-		}
-
-		// ── Docker sandbox wiring ──
-		if (opts?.sandboxed) {
-			const applied = await this.applySandboxWiring(bridgeOptions, id, { sandboxClaim: opts.sandboxClaim });
-			if (!applied) {
-				throw new Error("Sandbox is not configured as docker");
-			}
-		}
-
-		const rpcClient = new RpcBridge(bridgeOptions);
-		const eventBuffer = new EventBuffer();
-
-		const now = Date.now();
-		// If the sandbox pool overrode the CWD (pool slot worktree), use that
-		const effectiveCwd = bridgeOptions.cwd || cwd;
-
-		const session: SessionInfo = {
+		// ── Normal session: build plan and execute full pipeline ──
+		const plan: SessionSetupPlan = {
 			id,
-			title: assistantDef?.title ?? "New session",
-			cwd: effectiveCwd,
-			status: "starting",
-			createdAt: now,
-			lastActivity: now,
-			clients: new Set(),
-			rpcClient,
-			eventBuffer,
-			unsubscribe: () => {},
-			isCompacting: false,
-			titleGenerated: !!assistantDef,
+			mode: "normal",
+			title: "New session",
+			cwd,
 			goalId,
 			assistantType,
 			taskId: opts?.taskId,
+			sandboxed: opts?.sandboxed,
 			personalities: opts?.personalityNames,
-			allowedTools: effectiveAllowedTools ?? opts?.allowedTools,
-			promptQueue: new PromptQueue(),
+			agentArgs,
+			env: opts?.env,
+			rolePrompt: opts?.rolePrompt,
+			roleName: opts?.roleName,
+			personalityFragments: opts?.personalities,
+			workflowContext: opts?.workflowContext,
+			reattemptGoalId: opts?.reattemptGoalId,
+			effectiveAllowedTools: opts?.allowedTools,
+			sandboxClaim: opts?.sandboxClaim,
+			bridgeOptions: { cwd },
 		};
 
-		// Mark session as sandboxed (persisted later in store.put() via _sandboxed flag)
-		if (opts?.sandboxed) {
-			(session as any)._sandboxed = true;
-		}
+		const session = await executePlan(plan, ctx);
 
-		// Store container ID from pool claim
-		if (bridgeOptions.containerId) {
-			session.containerId = bridgeOptions.containerId;
-		}
-
-		// Auto-assign task to this session
-		if (opts?.taskId) {
-			try {
-				this.taskManager.assignTask(opts.taskId, id);
-			} catch (err) {
-				console.error(`[session-manager] Failed to assign task ${opts.taskId} to session ${id}:`, err);
-			}
-		}
-
-		// Subscribe to agent events — broadcast to all connected clients
-		const unsub = rpcClient.onEvent((event: any) => {
-			session.lastActivity = Date.now();
-			this.store.update(id, { lastActivity: session.lastActivity });
-
-			this.handleAgentLifecycle(session, event);
-
-			eventBuffer.push(event);
-			broadcast(session.clients, { type: "event", data: event });
-			this.trackCostFromEvent(session, event);
-		});
-
-		session.unsubscribe = unsub;
-
-		await rpcClient.start();
-		session.status = "idle";
-
-		this.sessions.set(id, session);
-
-		// Persist session metadata immediately so it survives server restarts.
-		// This is fire-and-forget to avoid blocking session creation — getState()
-		// is a fast RPC call but we don't need to wait for disk flush.
+		// Persist session metadata (fire-and-forget)
 		this.persistSessionMetadata(session).catch((err) => {
 			console.warn(`[session-manager] Early persist failed for ${session.id}:`, err);
 		});
 
-		// Fire model + thinking level setup immediately (non-blocking).
-		// These are fast stdin writes — the agent processes set_model and
-		// set_thinking_level in microseconds.  We don't await the responses
-		// so the user's prompt (arriving shortly after) isn't blocked.
-		this._fireEarlySetup(session);
-
 		return session;
-	}
-
-	/**
-	 * Async worktree setup + agent launch for sessions created with worktreeOpts.
-	 * Creates the worktree, then launches the agent in it.
-	 */
-	private async _setupWorktreeAndLaunchAgent(
-		session: SessionInfo,
-		repoPath: string,
-		branch: string,
-		_originalCwd: string,
-		agentArgs?: string[],
-		goalId?: string,
-		opts?: { rolePrompt?: string; roleName?: string; env?: Record<string, string>; taskId?: string; allowedTools?: string[]; personalities?: Array<{ label: string; promptFragment: string }>; personalityNames?: string[]; workflowContext?: string; worktreeOpts?: { repoPath: string } },
-	): Promise<void> {
-		// Create worktree with one retry
-		let worktreeCwd: string;
-		try {
-			const result = await createWorktree(repoPath, branch);
-			worktreeCwd = result.worktreePath;
-		} catch (err) {
-			await new Promise(resolve => setTimeout(resolve, 1000));
-			const result = await createWorktree(repoPath, branch);
-			worktreeCwd = result.worktreePath;
-		}
-
-		// Update session metadata
-		session.cwd = worktreeCwd;
-		session.worktreePath = worktreeCwd;
-		this.store.update(session.id, { cwd: worktreeCwd, worktreePath: worktreeCwd });
-		console.log(`[session-manager] Worktree ready for session ${session.id}: ${worktreeCwd} (branch: ${branch})`);
-
-		// Now launch the agent (mirrors the non-worktree path in createSession)
-		const cwd = worktreeCwd;
-		const id = session.id;
-
-		const bridgeOptions: RpcBridgeOptions = {
-			cwd,
-			args: agentArgs ? [...agentArgs] : [],
-			env: { BOBBIT_SESSION_ID: id, ...opts?.env },
-		};
-		if (this.agentCliPath) {
-			bridgeOptions.cliPath = this.agentCliPath;
-		}
-
-		if (goalId) {
-			const alreadyHasExtension = bridgeOptions.args?.includes("--extension");
-			if (!alreadyHasExtension) {
-				bridgeOptions.args = bridgeOptions.args || [];
-				bridgeOptions.args.push("--extension", GOAL_TOOLS_EXTENSION_PATH);
-			}
-			bridgeOptions.env = { ...bridgeOptions.env, BOBBIT_GOAL_ID: goalId };
-		}
-
-		let effectiveAllowedTools = opts?.allowedTools;
-		if (!effectiveAllowedTools && this.roleManager) {
-			const generalRole = this.roleManager.getRole("general");
-			if (generalRole && generalRole.allowedTools.length > 0) {
-				effectiveAllowedTools = generalRole.allowedTools;
-			}
-		}
-
-		// Build system prompt
-		const goal = goalId ? this.goalManager.getGoal(goalId) : undefined;
-		let toolRestrictionsText: string | undefined;
-		if (effectiveAllowedTools && effectiveAllowedTools.length > 0) {
-			const effectiveRole = (opts?.roleName && this.roleManager) ? this.roleManager.getRole(opts.roleName) : undefined;
-			toolRestrictionsText = this.buildToolRestrictionsText(effectiveAllowedTools, effectiveRole ?? undefined);
-		}
-
-		let taskTitle: string | undefined;
-		let taskType: string | undefined;
-		let taskSpec: string | undefined;
-		let taskDependsOn: string[] | undefined;
-		if (opts?.taskId) {
-			const task = this.taskManager.getTask(opts.taskId);
-			if (task) {
-				taskTitle = task.title;
-				taskType = task.type;
-				taskSpec = task.spec;
-				if (task.dependsOn && task.dependsOn.length > 0) {
-					taskDependsOn = task.dependsOn.map(depId => {
-						const dep = this.taskManager.getTask(depId);
-						return dep?.title || depId;
-					});
-				}
-			}
-		}
-
-		const promptPath = this.assemblePrompt(id, {
-			baseSystemPromptPath: this.systemPromptPath,
-			cwd,
-			goalTitle: goal?.title,
-			goalState: goal?.state,
-			goalSpec: goal?.spec,
-			rolePrompt: opts?.rolePrompt,
-			roleName: opts?.roleName,
-			toolRestrictions: toolRestrictionsText,
-			taskTitle,
-			taskType,
-			taskSpec,
-			taskDependsOn,
-			personalities: opts?.personalities,
-			allowedTools: effectiveAllowedTools,
-			workflowContext: opts?.workflowContext,
-			projectConfigStore: this.projectConfigStore,
-		});
-		if (promptPath) bridgeOptions.systemPromptPath = promptPath;
-
-		if (effectiveAllowedTools && effectiveAllowedTools.length > 0) {
-			const effectiveRole = (opts?.roleName && this.roleManager) ? this.roleManager.getRole(opts.roleName) : undefined;
-			const mcpExtPaths = this.mcpManager ? writeMcpProxyExtensions(this.mcpManager, effectiveAllowedTools, effectiveRole ?? undefined, this.toolManager, this.groupPolicyStore) : undefined;
-			const activation = computeToolActivationArgs(effectiveAllowedTools, this.toolManager, cwd, mcpExtPaths);
-			bridgeOptions.args = [...activation.args, ...(bridgeOptions.args || [])];
-		} else if (this.mcpManager) {
-			const mcpExtPaths = writeMcpProxyExtensions(this.mcpManager);
-			for (const extPath of mcpExtPaths) {
-				bridgeOptions.args = [...(bridgeOptions.args || []), "--extension", extPath];
-			}
-		}
-
-		// Replace the placeholder rpcClient with a real one
-		const rpcClient = new RpcBridge(bridgeOptions);
-		session.rpcClient = rpcClient;
-		session.allowedTools = effectiveAllowedTools ?? opts?.allowedTools;
-
-		if (opts?.taskId) {
-			try {
-				this.taskManager.assignTask(opts.taskId, id);
-			} catch (err) {
-				console.error(`[session-manager] Failed to assign task ${opts.taskId} to session ${id}:`, err);
-			}
-		}
-
-		const unsub = rpcClient.onEvent((event: any) => {
-			session.lastActivity = Date.now();
-			this.store.update(id, { lastActivity: session.lastActivity });
-			this.handleAgentLifecycle(session, event);
-			eventBuffer.push(event);
-			broadcast(session.clients, { type: "event", data: event });
-			this.trackCostFromEvent(session, event);
-		});
-		session.unsubscribe = unsub;
-
-		const eventBuffer = session.eventBuffer;
-
-		await rpcClient.start();
-		session.status = "idle";
-
-		// Persist session metadata now that the agent is running and has a session file.
-		// Fire-and-forget to avoid blocking the worktree session launch.
-		this.persistSessionMetadata(session).catch((err) => {
-			console.warn(`[session-manager] Early persist failed for worktree session ${session.id}:`, err);
-		});
-
-		// Notify connected clients that the session is ready
-		broadcast(session.clients, { type: "session_status", status: "idle" });
-
-		// Fire model + thinking level immediately (non-blocking, same as createSession)
-		this._fireEarlySetup(session);
 	}
 
 	/**
@@ -1828,6 +1537,7 @@ export class SessionManager {
 		context?: Record<string, string>;
 	}): Promise<SessionInfo> {
 		const id = randomUUID();
+		const ctx = this.buildPipelineContext();
 
 		// ── Sandbox propagation from parent ──
 		const parentMeta = this.store.get(parentSessionId);
@@ -1840,114 +1550,32 @@ export class SessionManager {
 			// allow a malicious agent to mount an arbitrary host path into the
 			// delegate container.
 			opts.cwd = parentMeta.cwd;
-		}
-
-		// Build the task spec: instructions + optional context
-		let taskSpec = opts.instructions;
-		if (opts.context && Object.keys(opts.context).length > 0) {
-			taskSpec += "\n\n## Context";
-			for (const [key, value] of Object.entries(opts.context)) {
-				taskSpec += `\n- **${key}**: ${value}`;
-			}
-		}
-
-		// assembleSystemPrompt handles AGENTS.md from cwd automatically
-		const promptPath = this.assemblePrompt(id, {
-			baseSystemPromptPath: undefined, // No global prompt — delegate gets AGENTS.md only
-			cwd: opts.cwd,
-			goalSpec: taskSpec,
-			goalTitle: "Delegate Task",
-			goalState: "active",
-			projectConfigStore: this.projectConfigStore,
-		});
-
-		const bridgeOptions: RpcBridgeOptions = { cwd: opts.cwd, env: { BOBBIT_SESSION_ID: id, BOBBIT_DELEGATE_OF: parentSessionId } };
-		if (this.agentCliPath) bridgeOptions.cliPath = this.agentCliPath;
-		if (promptPath) bridgeOptions.systemPromptPath = promptPath;
-
-		// Apply sandbox wiring if parent was sandboxed
-		if (parentMeta?.sandboxed) {
-			const applied = await this.applySandboxWiring(bridgeOptions, id);
-			if (!applied) {
-				throw new Error("Cannot create delegate: parent is sandboxed but sandbox is not configured as docker");
-			}
 			delegateSandboxed = true;
 		}
 
-		const rpcClient = new RpcBridge(bridgeOptions);
-		const eventBuffer = new EventBuffer();
-		const now = Date.now();
-
 		const titleSummary = opts.title || opts.instructions.split("\n")[0].slice(0, 60) || "Delegate";
-		const session: SessionInfo = {
+
+		const plan: SessionSetupPlan = {
 			id,
-			title: `⚡${titleSummary}`,
+			mode: "delegate",
+			title: titleSummary,
 			cwd: opts.cwd,
-			status: "starting",
-			createdAt: now,
-			lastActivity: now,
-			clients: new Set(),
-			rpcClient,
-			eventBuffer,
-			unsubscribe: () => {},
-			isCompacting: false,
-			titleGenerated: true,
 			delegateOf: parentSessionId,
-			promptQueue: new PromptQueue(),
+			sandboxed: delegateSandboxed || undefined,
+			instructions: opts.instructions,
+			context: opts.context,
+			bridgeOptions: { cwd: opts.cwd },
 		};
 
-		if (delegateSandboxed) {
-			(session as any)._sandboxed = true;
-		}
-		if (bridgeOptions.containerId) {
-			session.containerId = bridgeOptions.containerId;
-		}
+		const session = await executePlan(plan, ctx);
 
-		const unsub = rpcClient.onEvent((event: any) => {
-			session.lastActivity = Date.now();
-			this.store.update(id, { lastActivity: session.lastActivity });
-
-			this.handleAgentLifecycle(session, event);
-
-			eventBuffer.push(event);
-			broadcast(session.clients, { type: "event", data: event });
-			this.trackCostFromEvent(session, event);
+		// Persist with all structural fields (delegateOf is in the initial put)
+		this.persistSessionMetadata(session).catch((err) => {
+			console.error(`[session-manager] Failed to persist delegate session ${id}:`, err);
 		});
 
-		session.unsubscribe = unsub;
-		await rpcClient.start();
-		session.status = "idle";
-		this.sessions.set(id, session);
-
-		// Auto-select model and persist in parallel (delegate needs model before prompt)
-		await Promise.all([
-			this.tryAutoSelectModel(session),
-			this.tryApplyDefaultThinkingLevel(session),
-			this.persistSessionMetadata(session).then(() => {
-				this.store.update(id, { delegateOf: parentSessionId });
-			}).catch((err) => {
-				console.error(`[session-manager] Failed to persist delegate session ${id}:`, err);
-			}),
-		]);
-
-		// Send the task prompt and wait for the agent to start streaming
-		// so that waitForIdle() doesn't return immediately.
-		await rpcClient.prompt(
-			"Execute the task described in your system prompt. Follow the instructions carefully."
-		);
-
-		// Wait for agent_start event (so session.status becomes "streaming")
-		await new Promise<void>((resolve) => {
-			if (session.status === "streaming") { resolve(); return; }
-			const timeout = setTimeout(() => { unsub2(); resolve(); }, 10_000);
-			const unsub2 = rpcClient.onEvent((event: any) => {
-				if (event.type === "agent_start") {
-					clearTimeout(timeout);
-					unsub2();
-					resolve();
-				}
-			});
-		});
+		// Send delegate prompt with 30s timeout
+		await sendDelegatePrompt(session, opts.instructions, DELEGATE_SPAWN_TIMEOUT_MS);
 
 		console.log(`[session-manager] Created delegate session ${id} (parent: ${parentSessionId}, status: ${session.status})`);
 		return session;
@@ -2030,37 +1658,6 @@ export class SessionManager {
 		} catch (err) {
 			console.error(`[session-manager] Failed to refresh after compaction for ${session.id}:`, err);
 		}
-	}
-
-	/**
-	 * If an AI Gateway is configured, automatically set the session model
-	 * to the first aigw model. Called on every new session — no internet
-	 * check here; the gateway's presence was validated at startup or by
-	 * the user via Settings.
-	 */
-	/**
-	 * Auto-select a model for a new session. Uses `default.sessionModel`
-	 * Fire model selection and thinking level as non-blocking RPC commands
-	 * immediately after the agent process starts.  These are fast stdin writes
-	 * that the agent processes in microseconds — they won't meaningfully delay
-	 * the user's prompt which arrives shortly after via WebSocket.
-	 *
-	 * We intentionally don't await the responses.  If model selection fails
-	 * (e.g. aigw cache miss), the deferred setup in _finishSessionSetup will
-	 * retry after the first turn.
-	 */
-	private _fireEarlySetup(session: SessionInfo): void {
-		// Model selection — fast path only (preference or cached aigw list).
-		// If this requires an HTTP discovery, it returns without sending set_model
-		// and the deferred _finishSessionSetup handles it after the first turn.
-		this.tryAutoSelectModel(session).catch((err) => {
-			console.warn(`[session-manager] Early model selection failed for ${session.id}:`, err);
-		});
-
-		// Thinking level — always fast (just a preference lookup + stdin write)
-		this.tryApplyDefaultThinkingLevel(session).catch((err) => {
-			console.warn(`[session-manager] Early thinking level failed for ${session.id}:`, err);
-		});
 	}
 
 	/**
@@ -2166,60 +1763,54 @@ export class SessionManager {
 	}
 
 	async persistSessionMetadata(session: SessionInfo): Promise<void> {
-		const stateResp = await session.rpcClient.getState();
-		if (!stateResp.success || !stateResp.data?.sessionFile) {
-			console.warn(`[session-manager] Could not get agent session file for ${session.id}`);
-			return;
+		const maxRetries = 3;
+		const delays = [500, 1000, 2000];
+
+		for (let attempt = 0; attempt <= maxRetries; attempt++) {
+			try {
+				const stateResp = await session.rpcClient.getState();
+				if (!stateResp.success || !stateResp.data?.sessionFile) {
+					if (attempt < maxRetries) {
+						console.warn(`[session-manager] getState() returned no sessionFile for ${session.id}, retrying...`);
+						await new Promise(resolve => setTimeout(resolve, delays[attempt]));
+						continue;
+					}
+					console.error(
+						`[session-manager] CRITICAL: Could not get agent session file for ${session.id} after ${maxRetries + 1} attempts. ` +
+						`This session will NOT survive a server restart.`,
+					);
+					return;
+				}
+
+				const agentSessionFile = session.sandboxed
+					? containerToHostSessionPath(stateResp.data.sessionFile)
+					: stateResp.data.sessionFile;
+
+				// Validate the remapped path actually exists on the host
+				if (!fs.existsSync(agentSessionFile)) {
+					console.error(
+						`[session-manager] CRITICAL: Session file does not exist after path remapping for ${session.id}!\n` +
+						`  Agent reported: ${stateResp.data.sessionFile}\n` +
+						`  Remapped to:   ${agentSessionFile}\n` +
+						`  Sandboxed:     ${!!session.sandboxed}\n` +
+						`  This session will NOT survive a server restart.`,
+					);
+				}
+
+				this.store.update(session.id, { agentSessionFile });
+				return; // success
+			} catch (err) {
+				if (attempt < maxRetries) {
+					console.warn(`[session-manager] persistSessionMetadata failed for ${session.id} (attempt ${attempt + 1}), retrying: ${err}`);
+					await new Promise(resolve => setTimeout(resolve, delays[attempt]));
+				} else {
+					console.error(
+						`[session-manager] CRITICAL: persistSessionMetadata failed for ${session.id} after ${maxRetries + 1} attempts: ${err}\n` +
+						`  This session will NOT survive a server restart.`,
+					);
+				}
+			}
 		}
-
-		// Preserve fields that may have been set via store.update() before this async call
-		const existing = this.store.get(session.id);
-
-		const isSandboxed = existing?.sandboxed || (session as any)._sandboxed;
-		const agentSessionFile = isSandboxed
-			? containerToHostSessionPath(stateResp.data.sessionFile)
-			: stateResp.data.sessionFile;
-
-		// Validate the remapped path actually exists on the host — catch remapping
-		// bugs immediately rather than discovering lost sessions on next restart.
-		if (!fs.existsSync(agentSessionFile)) {
-			console.error(
-				`[session-manager] CRITICAL: Session file does not exist after path remapping for ${session.id}!\n` +
-				`  Agent reported: ${stateResp.data.sessionFile}\n` +
-				`  Remapped to:   ${agentSessionFile}\n` +
-				`  Sandboxed:     ${!!isSandboxed}\n` +
-				`  This session will NOT survive a server restart.`,
-			);
-		}
-
-		this.store.put({
-			id: session.id,
-			title: session.title,
-			cwd: session.cwd,
-			agentSessionFile,
-			createdAt: session.createdAt,
-			lastActivity: session.lastActivity,
-			goalId: session.goalId,
-			assistantType: session.assistantType,
-			role: session.role,
-			teamGoalId: session.teamGoalId,
-			worktreePath: session.worktreePath,
-			repoPath: existing?.repoPath,
-			branch: existing?.branch,
-			taskId: session.taskId,
-			staffId: session.staffId,
-			accessory: session.accessory,
-			nonInteractive: session.nonInteractive,
-			preview: session.preview,
-			personalities: session.personalities,
-			sandboxed: existing?.sandboxed || (session as any)._sandboxed,
-			// Preserve fields that may be set on the session object or via store.update()
-			delegateOf: session.delegateOf || existing?.delegateOf,
-			reattemptGoalId: existing?.reattemptGoalId,
-			teamLeadSessionId: existing?.teamLeadSessionId,
-			modelProvider: existing?.modelProvider,
-			modelId: existing?.modelId,
-		});
 	}
 
 	getSession(id: string): SessionInfo | undefined {
@@ -2271,6 +1862,22 @@ export class SessionManager {
 
 		this.sessions.set(id, session);
 
+		// Initial persist — structural fields (store.put must precede persistSessionMetadata
+		// since persistSessionMetadata now only does store.update)
+		this.store.put({
+			id,
+			title: opts.title,
+			cwd: opts.cwd,
+			agentSessionFile: "",
+			createdAt: now,
+			lastActivity: now,
+			goalId: opts.goalId,
+			role: opts.role,
+			teamGoalId: opts.teamGoalId,
+			nonInteractive: true,
+		});
+
+		// Then update with agentSessionFile
 		this.persistSessionMetadata(session).catch((err) => {
 			console.error(`[session-manager] Failed to persist external session ${id}:`, err);
 		});
@@ -2346,7 +1953,7 @@ export class SessionManager {
 			preview: s.preview,
 			personalities: s.personalities,
 			reattemptGoalId: this.store.get(s.id)?.reattemptGoalId,
-			sandboxed: this.store.get(s.id)?.sandboxed || (s as any)._sandboxed,
+			sandboxed: this.store.get(s.id)?.sandboxed || s.sandboxed,
 		}));
 	}
 
@@ -2436,7 +2043,7 @@ export class SessionManager {
 				createdAt: session.createdAt,
 				lastActivity: session.lastActivity,
 				goalId: session.goalId,
-				sandboxed: (session as any)._sandboxed,
+				sandboxed: session.sandboxed,
 			});
 		}
 		return true;

--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -1,0 +1,683 @@
+/**
+ * Session creation pipeline — plan/execute architecture.
+ *
+ * Extracts duplicated session-creation logic from SessionManager into composable
+ * pipeline steps.  Three creation paths (normal, worktree, delegate) share the
+ * same step functions but differ in *when* the steps execute:
+ *
+ *   normal   — await full pipeline, return ready session
+ *   worktree — return immediately with "preparing", pipeline runs async
+ *   delegate — await pipeline + first prompt + streaming confirmation
+ */
+
+import path from "node:path";
+import type { WebSocket } from "ws";
+import type { ServerMessage } from "../ws/protocol.js";
+import type { SessionInfo } from "./session-manager.js";
+import type { RpcBridgeOptions } from "./rpc-bridge.js";
+import { RpcBridge } from "./rpc-bridge.js";
+import { EventBuffer } from "./event-buffer.js";
+import { PromptQueue } from "./prompt-queue.js";
+import type { SessionStore } from "./session-store.js";
+import type { GoalManager } from "./goal-manager.js";
+import type { TaskManager } from "./task-manager.js";
+import type { SearchIndex } from "../search/search-index.js";
+import type { CostTracker } from "./cost-tracker.js";
+import type { PersonalityManager } from "./personality-manager.js";
+import type { RoleManager } from "./role-manager.js";
+import type { ToolManager } from "./tool-manager.js";
+import type { ToolGroupPolicyStore } from "./tool-group-policy-store.js";
+import type { McpManager } from "../mcp/mcp-manager.js";
+import type { SandboxPool, ClaimOptions } from "./sandbox-pool.js";
+import type { PromptParts } from "./system-prompt.js";
+import type { GrantPolicy } from "./role-store.js";
+import { getAssistantDef } from "./assistant-registry.js";
+import { buildReattemptContext } from "./goal-assistant.js";
+import { computeToolActivationArgs, writeMcpProxyExtensions } from "./tool-activation.js";
+import { TOOLS_DIR } from "./tool-manager.js";
+import { createWorktree, cleanupWorktree } from "../skills/git.js";
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+/** Goal tools extension — task + gate management for any goal session. */
+const GOAL_TOOLS_EXTENSION_PATH = path.join(TOOLS_DIR, "tasks", "extension.ts");
+
+/** Delegate spawn timeout (30 seconds). */
+export const DELEGATE_SPAWN_TIMEOUT_MS = 30_000;
+
+// ── Interfaces ─────────────────────────────────────────────────────────────
+
+export type SessionSetupMode = "normal" | "worktree" | "delegate";
+
+export interface SessionSetupPlan {
+	// Identity
+	id: string;
+	mode: SessionSetupMode;
+
+	// Structural fields (known at creation, persisted immediately)
+	title: string;
+	cwd: string;
+	goalId?: string;
+	assistantType?: string;
+	delegateOf?: string;
+	taskId?: string;
+	worktreePath?: string;
+	repoPath?: string;
+	branch?: string;
+	sandboxed?: boolean;
+	personalities?: string[];
+	role?: string;
+	staffId?: string;
+	accessory?: string;
+	nonInteractive?: boolean;
+
+	// Computed during planning
+	bridgeOptions: RpcBridgeOptions;
+	effectiveAllowedTools?: string[];
+	promptPath?: string;
+
+	// Options passed through from caller
+	agentArgs?: string[];
+	env?: Record<string, string>;
+	rolePrompt?: string;
+	roleName?: string;
+	personalityFragments?: Array<{ label: string; promptFragment: string }>;
+	workflowContext?: string;
+	reattemptGoalId?: string;
+	sandboxClaim?: ClaimOptions;
+
+	// Delegate-specific
+	instructions?: string;
+	context?: Record<string, string>;
+}
+
+/**
+ * Dependencies from SessionManager that pipeline steps need.
+ * Created via SessionManager.buildPipelineContext().
+ */
+export interface PipelineContext {
+	agentCliPath?: string;
+	systemPromptPath?: string;
+	roleManager: RoleManager | null;
+	toolManager: ToolManager | null;
+	mcpManager: McpManager | null;
+	goalManager: GoalManager;
+	taskManager: TaskManager;
+	personalityManager: PersonalityManager | null;
+	projectConfigStore: import("./project-config-store.js").ProjectConfigStore | null;
+	sandboxPool: SandboxPool | null;
+	sandboxTokenStore: import("../auth/sandbox-token.js").SandboxTokenStore | null;
+	groupPolicyStore: ToolGroupPolicyStore | null;
+	costTracker: CostTracker;
+	store: SessionStore;
+	searchIndex: SearchIndex;
+	sessions: Map<string, SessionInfo>;
+	assemblePrompt: (id: string, parts: PromptParts) => string | undefined;
+	buildToolRestrictionsText: (tools: string[], role?: { toolPolicies?: Record<string, GrantPolicy> }) => string;
+	applySandboxWiring: (opts: RpcBridgeOptions, id: string, sandboxOpts?: { skipMountValidation?: boolean; sandboxClaim?: ClaimOptions }) => Promise<boolean>;
+	handleAgentLifecycle: (session: SessionInfo, event: any) => void;
+	trackCostFromEvent: (session: SessionInfo, event: any) => void;
+	broadcast: (clients: Set<WebSocket>, msg: ServerMessage) => void;
+	tryAutoSelectModel: (session: SessionInfo) => Promise<void>;
+	tryApplyDefaultThinkingLevel: (session: SessionInfo) => Promise<void>;
+	buildWorkflowList: () => string;
+}
+
+// ── Retry helper ───────────────────────────────────────────────────────────
+
+export async function withRetry<T>(
+	fn: () => Promise<T>,
+	opts: { retries: number; delays: number[]; label: string; sessionId: string },
+): Promise<T> {
+	let lastError: Error | undefined;
+	for (let attempt = 0; attempt <= opts.retries; attempt++) {
+		try {
+			return await fn();
+		} catch (err) {
+			lastError = err as Error;
+			if (attempt < opts.retries) {
+				const delay = opts.delays[attempt] ?? opts.delays[opts.delays.length - 1];
+				console.warn(
+					`[session-setup] ${opts.label} failed for ${opts.sessionId} (attempt ${attempt + 1}/${opts.retries + 1}), ` +
+					`retrying in ${delay}ms: ${lastError.message}`,
+				);
+				await new Promise(resolve => setTimeout(resolve, delay));
+			}
+		}
+	}
+	throw lastError!;
+}
+
+// ── Pipeline steps ─────────────────────────────────────────────────────────
+
+/** Step 1: Construct RpcBridgeOptions base (cliPath, env, args). */
+export function resolveBridgeOptions(plan: SessionSetupPlan, ctx: PipelineContext): void {
+	plan.bridgeOptions = {
+		cwd: plan.cwd,
+		args: plan.agentArgs ? [...plan.agentArgs] : [],
+		env: { BOBBIT_SESSION_ID: plan.id, ...plan.env },
+	};
+	if (ctx.agentCliPath) {
+		plan.bridgeOptions.cliPath = ctx.agentCliPath;
+	}
+
+	// Delegate-specific env
+	if (plan.delegateOf) {
+		plan.bridgeOptions.env = {
+			...plan.bridgeOptions.env,
+			BOBBIT_DELEGATE_OF: plan.delegateOf,
+		};
+	}
+}
+
+/** Step 2: Add goal/team extension paths to bridge args. */
+export function resolveGoalExtensions(plan: SessionSetupPlan, _ctx: PipelineContext): void {
+	if (plan.goalId && !plan.assistantType) {
+		const alreadyHasExtension = plan.bridgeOptions.args?.includes("--extension");
+		if (!alreadyHasExtension) {
+			plan.bridgeOptions.args = plan.bridgeOptions.args || [];
+			plan.bridgeOptions.args.push("--extension", GOAL_TOOLS_EXTENSION_PATH);
+		}
+		plan.bridgeOptions.env = { ...plan.bridgeOptions.env, BOBBIT_GOAL_ID: plan.goalId };
+	}
+}
+
+/** Step 3: Compute effectiveAllowedTools, filter bash_bg for sandbox. */
+export function resolveTools(plan: SessionSetupPlan, ctx: PipelineContext): void {
+	let effectiveAllowedTools = plan.effectiveAllowedTools;
+
+	if (!effectiveAllowedTools && ctx.roleManager) {
+		const generalRole = ctx.roleManager.getRole("general");
+		if (generalRole && generalRole.allowedTools.length > 0) {
+			effectiveAllowedTools = generalRole.allowedTools;
+		}
+	}
+
+	// Exclude bash_bg for sandboxed sessions — BgProcessManager spawns on host
+	if (plan.sandboxed && effectiveAllowedTools) {
+		effectiveAllowedTools = effectiveAllowedTools.filter(t => t !== "bash_bg");
+	}
+
+	plan.effectiveAllowedTools = effectiveAllowedTools;
+}
+
+/** Step 4: Assemble system prompt (handles assistant, normal, delegate variants). */
+export function resolvePrompt(plan: SessionSetupPlan, ctx: PipelineContext): void {
+	const assistantDef = plan.assistantType ? getAssistantDef(plan.assistantType) : undefined;
+
+	if (assistantDef) {
+		// Assistant sessions (goal/role/tool assistants)
+		const assistantRole = ctx.roleManager?.getRole("assistant");
+		let assistantGoalSpec = "";
+		if (assistantRole?.promptTemplate) {
+			assistantGoalSpec = assistantRole.promptTemplate.replace(
+				/\{\{AGENT_ID\}\}/g,
+				`assistant-${(plan.goalId || plan.id).slice(0, 8)}`,
+			);
+			assistantGoalSpec += "\n\n---\n\n";
+		}
+		assistantGoalSpec += assistantDef.prompt;
+		if (plan.assistantType === "goal") {
+			assistantGoalSpec = assistantGoalSpec.replace("{{AVAILABLE_WORKFLOWS}}", ctx.buildWorkflowList());
+			if (plan.reattemptGoalId) {
+				const origGoal = ctx.goalManager.getGoal(plan.reattemptGoalId);
+				if (origGoal) {
+					assistantGoalSpec += "\n\n" + buildReattemptContext(origGoal);
+				}
+			}
+		}
+
+		// Use assistant role's tool restrictions
+		if (assistantRole && assistantRole.allowedTools.length > 0) {
+			plan.effectiveAllowedTools = assistantRole.allowedTools;
+		}
+
+		const promptPath = ctx.assemblePrompt(plan.id, {
+			baseSystemPromptPath: undefined,
+			cwd: plan.cwd,
+			goalSpec: assistantGoalSpec,
+			goalTitle: assistantDef.promptTitle,
+			goalState: "active",
+			allowedTools: plan.effectiveAllowedTools,
+			projectConfigStore: ctx.projectConfigStore ?? undefined,
+		});
+		if (promptPath) plan.bridgeOptions.systemPromptPath = promptPath;
+	} else if (plan.mode === "delegate") {
+		// Delegate sessions: AGENTS.md only + task spec
+		let taskSpec = plan.instructions || "";
+		if (plan.context && Object.keys(plan.context).length > 0) {
+			taskSpec += "\n\n## Context";
+			for (const [key, value] of Object.entries(plan.context)) {
+				taskSpec += `\n- **${key}**: ${value}`;
+			}
+		}
+
+		const promptPath = ctx.assemblePrompt(plan.id, {
+			baseSystemPromptPath: undefined,
+			cwd: plan.cwd,
+			goalSpec: taskSpec,
+			goalTitle: "Delegate Task",
+			goalState: "active",
+			projectConfigStore: ctx.projectConfigStore ?? undefined,
+		});
+		if (promptPath) plan.bridgeOptions.systemPromptPath = promptPath;
+	} else {
+		// Normal / worktree sessions: global base + AGENTS.md + goal spec
+		const goal = plan.goalId ? ctx.goalManager.getGoal(plan.goalId) : undefined;
+
+		// Build tool restrictions text
+		let toolRestrictionsText: string | undefined;
+		if (plan.effectiveAllowedTools && plan.effectiveAllowedTools.length > 0) {
+			const effectiveRole = (plan.roleName && ctx.roleManager) ? ctx.roleManager.getRole(plan.roleName) : undefined;
+			toolRestrictionsText = ctx.buildToolRestrictionsText(plan.effectiveAllowedTools, effectiveRole ?? undefined);
+		}
+
+		// Build task context
+		let taskTitle: string | undefined;
+		let taskType: string | undefined;
+		let taskSpec: string | undefined;
+		let taskDependsOn: string[] | undefined;
+		if (plan.taskId) {
+			const task = ctx.taskManager.getTask(plan.taskId);
+			if (task) {
+				taskTitle = task.title;
+				taskType = task.type;
+				taskSpec = task.spec;
+				if (task.dependsOn && task.dependsOn.length > 0) {
+					taskDependsOn = task.dependsOn.map(depId => {
+						const dep = ctx.taskManager.getTask(depId);
+						return dep?.title || depId;
+					});
+				}
+			}
+		}
+
+		const promptPath = ctx.assemblePrompt(plan.id, {
+			baseSystemPromptPath: ctx.systemPromptPath,
+			cwd: plan.cwd,
+			goalTitle: goal?.title,
+			goalState: goal?.state,
+			goalSpec: goal?.spec,
+			rolePrompt: plan.rolePrompt,
+			roleName: plan.roleName,
+			toolRestrictions: toolRestrictionsText,
+			taskTitle,
+			taskType,
+			taskSpec,
+			taskDependsOn,
+			personalities: plan.personalityFragments,
+			allowedTools: plan.effectiveAllowedTools,
+			workflowContext: plan.workflowContext,
+			projectConfigStore: ctx.projectConfigStore ?? undefined,
+		});
+		if (promptPath) plan.bridgeOptions.systemPromptPath = promptPath;
+	}
+}
+
+/** Step 5: computeToolActivationArgs + writeMcpProxyExtensions. */
+export function resolveToolActivation(plan: SessionSetupPlan, ctx: PipelineContext): void {
+	if (plan.effectiveAllowedTools && plan.effectiveAllowedTools.length > 0) {
+		const effectiveRole = (plan.roleName && ctx.roleManager) ? ctx.roleManager.getRole(plan.roleName) : undefined;
+		const mcpExtPaths = ctx.mcpManager
+			? writeMcpProxyExtensions(ctx.mcpManager, plan.effectiveAllowedTools, effectiveRole ?? undefined, ctx.toolManager ?? undefined, ctx.groupPolicyStore ?? undefined)
+			: undefined;
+		const activation = computeToolActivationArgs(plan.effectiveAllowedTools, ctx.toolManager ?? undefined, plan.cwd, mcpExtPaths);
+		plan.bridgeOptions.args = [...activation.args, ...(plan.bridgeOptions.args || [])];
+	} else if (ctx.mcpManager) {
+		const mcpExtPaths = writeMcpProxyExtensions(ctx.mcpManager);
+		for (const extPath of mcpExtPaths) {
+			plan.bridgeOptions.args = [...(plan.bridgeOptions.args || []), "--extension", extPath];
+		}
+	}
+}
+
+// ── Event subscription ─────────────────────────────────────────────────────
+
+/** Shared event subscription, returns unsubscribe fn. */
+export function subscribeToEvents(session: SessionInfo, ctx: PipelineContext): () => void {
+	return session.rpcClient.onEvent((event: any) => {
+		session.lastActivity = Date.now();
+		ctx.store.update(session.id, { lastActivity: session.lastActivity });
+		ctx.handleAgentLifecycle(session, event);
+		session.eventBuffer.push(event);
+		ctx.broadcast(session.clients, { type: "event", data: event });
+		ctx.trackCostFromEvent(session, event);
+	});
+}
+
+// ── Persistence ────────────────────────────────────────────────────────────
+
+/** Single store.put() with ALL structural fields. Called exactly once per session. */
+export function persistOnce(session: SessionInfo, plan: SessionSetupPlan, store: SessionStore): void {
+	store.put({
+		id: session.id,
+		title: session.title,
+		cwd: session.cwd,
+		agentSessionFile: "",
+		createdAt: session.createdAt,
+		lastActivity: session.lastActivity,
+		goalId: plan.goalId,
+		assistantType: plan.assistantType,
+		role: plan.role,
+		worktreePath: plan.worktreePath,
+		repoPath: plan.repoPath,
+		branch: plan.branch,
+		taskId: plan.taskId,
+		staffId: plan.staffId,
+		accessory: plan.accessory,
+		nonInteractive: plan.nonInteractive,
+		personalities: plan.personalities,
+		sandboxed: plan.sandboxed,
+		delegateOf: plan.delegateOf,
+		reattemptGoalId: plan.reattemptGoalId,
+	});
+}
+
+// ── Executors ──────────────────────────────────────────────────────────────
+
+/**
+ * Run the full pipeline synchronously: resolve steps → spawn agent → persist → post-spawn.
+ * Used by normal and delegate session creation.
+ */
+export async function executePlan(plan: SessionSetupPlan, ctx: PipelineContext): Promise<SessionInfo> {
+	// Step 1-5: resolve all configuration
+	resolveBridgeOptions(plan, ctx);
+	resolveGoalExtensions(plan, ctx);
+	resolveTools(plan, ctx);
+	resolvePrompt(plan, ctx);
+	resolveToolActivation(plan, ctx);
+
+	// Step 6: sandbox wiring (needs final CWD)
+	if (plan.sandboxed) {
+		await withRetry(
+			() => ctx.applySandboxWiring(plan.bridgeOptions, plan.id, { sandboxClaim: plan.sandboxClaim }),
+			{ retries: 1, delays: [1000], label: "wireSandbox", sessionId: plan.id },
+		).then(applied => {
+			if (!applied) throw new Error("Sandbox is not configured as docker");
+		});
+	}
+
+	// Step 7: spawn agent
+	const session = await spawnAgent(plan, ctx);
+
+	// Step 8: persist once with all structural fields
+	persistOnce(session, plan, ctx.store);
+
+	// Step 9: post-spawn setup (model, thinking level)
+	await postSpawn(session, plan, ctx);
+
+	return session;
+}
+
+/**
+ * For worktree sessions: create worktree, then run remaining pipeline
+ * on the existing "preparing" session. Updates session in place.
+ */
+export async function executeWorktreeAsync(
+	plan: SessionSetupPlan,
+	session: SessionInfo,
+	ctx: PipelineContext,
+): Promise<void> {
+	// Create worktree with retry
+	const worktreeCwd = await withRetry(
+		async () => {
+			const result = await createWorktree(plan.repoPath!, plan.branch!);
+			return result.worktreePath;
+		},
+		{ retries: 2, delays: [1000, 2000], label: "createWorktree", sessionId: plan.id },
+	);
+
+	// Update session and plan with worktree CWD
+	session.cwd = worktreeCwd;
+	session.worktreePath = worktreeCwd;
+	plan.cwd = worktreeCwd;
+	ctx.store.update(session.id, { cwd: worktreeCwd, worktreePath: worktreeCwd });
+	console.log(`[session-setup] Worktree ready for session ${session.id}: ${worktreeCwd} (branch: ${plan.branch})`);
+
+	// Run remaining pipeline steps on the worktree CWD
+	resolveBridgeOptions(plan, ctx);
+	resolveGoalExtensions(plan, ctx);
+	resolveTools(plan, ctx);
+	resolvePrompt(plan, ctx);
+	resolveToolActivation(plan, ctx);
+
+	// Sandbox wiring (now with final CWD from worktree)
+	if (plan.sandboxed) {
+		await withRetry(
+			() => ctx.applySandboxWiring(plan.bridgeOptions, plan.id, { sandboxClaim: plan.sandboxClaim }),
+			{ retries: 1, delays: [1000], label: "wireSandbox", sessionId: plan.id },
+		).then(applied => {
+			if (!applied) throw new Error("Sandbox is not configured as docker");
+		});
+	}
+
+	// Create real RpcBridge (replacing placeholder)
+	const rpcClient = new RpcBridge(plan.bridgeOptions);
+	session.rpcClient = rpcClient;
+	session.allowedTools = plan.effectiveAllowedTools;
+
+	// Store container ID from pool claim
+	if (plan.bridgeOptions.containerId) {
+		session.containerId = plan.bridgeOptions.containerId;
+	}
+
+	// Mark session as sandboxed
+	if (plan.sandboxed) {
+		session.sandboxed = true;
+	}
+
+	// If sandbox pool overrode CWD, update session
+	if (plan.bridgeOptions.cwd && plan.bridgeOptions.cwd !== plan.cwd) {
+		session.cwd = plan.bridgeOptions.cwd;
+		ctx.store.update(session.id, { cwd: session.cwd });
+	}
+
+	// Task assignment
+	if (plan.taskId) {
+		try {
+			ctx.taskManager.assignTask(plan.taskId, plan.id);
+		} catch (err) {
+			console.error(`[session-setup] Failed to assign task ${plan.taskId} to session ${plan.id}:`, err);
+		}
+	}
+
+	// Subscribe to events
+	session.unsubscribe = subscribeToEvents(session, ctx);
+
+	// Start agent with retry
+	await withRetry(
+		() => rpcClient.start(),
+		{ retries: 2, delays: [500, 1000], label: "rpcClient.start", sessionId: plan.id },
+	);
+	session.status = "idle";
+
+	// Notify connected clients that the session is ready
+	ctx.broadcast(session.clients, { type: "session_status", status: "idle" });
+
+	// Fire model + thinking level immediately (non-blocking)
+	postSpawnFireAndForget(session, ctx);
+}
+
+// ── Internal helpers ───────────────────────────────────────────────────────
+
+/**
+ * Create RpcBridge, subscribe events, start the agent process.
+ * Returns the fully wired SessionInfo.
+ */
+async function spawnAgent(plan: SessionSetupPlan, ctx: PipelineContext): Promise<SessionInfo> {
+	const rpcClient = new RpcBridge(plan.bridgeOptions);
+	const eventBuffer = new EventBuffer();
+	const now = Date.now();
+
+	// If sandbox pool overrode CWD, use that
+	const effectiveCwd = plan.bridgeOptions.cwd || plan.cwd;
+
+	const assistantDef = plan.assistantType ? getAssistantDef(plan.assistantType) : undefined;
+
+	const session: SessionInfo = {
+		id: plan.id,
+		title: assistantDef?.title ?? (plan.mode === "delegate"
+			? `⚡${plan.title}`
+			: plan.title),
+		cwd: effectiveCwd,
+		status: "starting",
+		createdAt: now,
+		lastActivity: now,
+		clients: new Set(),
+		rpcClient,
+		eventBuffer,
+		unsubscribe: () => {},
+		isCompacting: false,
+		titleGenerated: !!assistantDef || plan.mode === "delegate",
+		goalId: plan.goalId,
+		assistantType: plan.assistantType,
+		taskId: plan.taskId,
+		delegateOf: plan.delegateOf,
+		personalities: plan.personalities,
+		allowedTools: plan.effectiveAllowedTools,
+		promptQueue: new PromptQueue(),
+	};
+
+	// Mark session as sandboxed (typed field)
+	if (plan.sandboxed) {
+		session.sandboxed = true;
+	}
+
+	// Store container ID from pool claim
+	if (plan.bridgeOptions.containerId) {
+		session.containerId = plan.bridgeOptions.containerId;
+	}
+
+	// Task assignment
+	if (plan.taskId) {
+		try {
+			ctx.taskManager.assignTask(plan.taskId, plan.id);
+		} catch (err) {
+			console.error(`[session-setup] Failed to assign task ${plan.taskId} to session ${plan.id}:`, err);
+		}
+	}
+
+	// Subscribe to events
+	session.unsubscribe = subscribeToEvents(session, ctx);
+
+	// Start agent with retry
+	await withRetry(
+		() => rpcClient.start(),
+		{ retries: 2, delays: [500, 1000], label: "rpcClient.start", sessionId: plan.id },
+	);
+	session.status = "idle";
+
+	ctx.sessions.set(session.id, session);
+
+	return session;
+}
+
+/**
+ * Post-spawn setup for synchronous paths (normal, delegate):
+ * fire-and-forget metadata persist + model/thinking level.
+ */
+async function postSpawn(session: SessionInfo, plan: SessionSetupPlan, ctx: PipelineContext): Promise<void> {
+	// For delegates, model + thinking level are awaited (delegate needs model before prompt)
+	if (plan.mode === "delegate") {
+		await Promise.all([
+			ctx.tryAutoSelectModel(session),
+			ctx.tryApplyDefaultThinkingLevel(session),
+		]);
+	} else {
+		// Normal sessions: fire-and-forget
+		postSpawnFireAndForget(session, ctx);
+	}
+}
+
+/** Fire model + thinking level setup as non-blocking (fire-and-forget). */
+function postSpawnFireAndForget(session: SessionInfo, ctx: PipelineContext): void {
+	ctx.tryAutoSelectModel(session).catch((err) => {
+		console.warn(`[session-setup] Early model selection failed for ${session.id}:`, err);
+	});
+	ctx.tryApplyDefaultThinkingLevel(session).catch((err) => {
+		console.warn(`[session-setup] Early thinking level failed for ${session.id}:`, err);
+	});
+}
+
+// ── Delegate prompt ────────────────────────────────────────────────────────
+
+/**
+ * Send the task prompt to a delegate session and wait for streaming to begin.
+ * Enforces a timeout — rejects if the agent doesn't start streaming in time.
+ */
+export async function sendDelegatePrompt(
+	session: SessionInfo,
+	_instructions: string,
+	timeoutMs: number,
+): Promise<void> {
+	await session.rpcClient.prompt(
+		"Execute the task described in your system prompt. Follow the instructions carefully.",
+	);
+
+	// Wait for agent_start event (session.status becomes "streaming")
+	await new Promise<void>((resolve, reject) => {
+		if (session.status === "streaming") { resolve(); return; }
+		const timeout = setTimeout(() => {
+			unsub();
+			reject(new Error(
+				`Delegate session ${session.id} did not start streaming within ${timeoutMs}ms. ` +
+				`The delegate may have failed to initialize.`,
+			));
+		}, timeoutMs);
+		const unsub = session.rpcClient.onEvent((event: any) => {
+			if (event.type === "agent_start") {
+				clearTimeout(timeout);
+				unsub();
+				resolve();
+			}
+		});
+	});
+}
+
+// ── Failure handling ───────────────────────────────────────────────────────
+
+/**
+ * Clean up after a failed session setup. Order:
+ * 1. Remove from in-memory map (fast — UI updates immediately)
+ * 2. Archive in store (preserves evidence for debugging)
+ * 3. Notify connected clients
+ * 4. Background worktree cleanup (slow, non-blocking)
+ * 5. Release sandbox pool slot if claimed
+ * 6. Clean up sandbox token
+ */
+export function handleSetupFailure(
+	session: SessionInfo,
+	plan: SessionSetupPlan,
+	error: Error,
+	ctx: PipelineContext,
+): void {
+	console.error(
+		`[session-setup] Session ${session.id} setup failed ` +
+		`(mode: ${plan.mode}, step: ${error.message}):`,
+		error,
+	);
+
+	// 1. Remove from in-memory map
+	ctx.sessions.delete(session.id);
+
+	// 2. Archive in store (preserves evidence)
+	ctx.store.archive(session.id);
+
+	// 3. Notify connected clients
+	ctx.broadcast(session.clients, { type: "session_status", status: "terminated" });
+
+	// 4. Background worktree cleanup (slow, non-blocking)
+	if (plan.worktreePath && plan.repoPath && plan.branch) {
+		cleanupWorktree(plan.repoPath, plan.worktreePath, plan.branch, true).catch(() => {});
+	}
+
+	// 5. Release sandbox pool slot if claimed
+	if (session.containerId && ctx.sandboxPool) {
+		ctx.sandboxPool.release(session.id, session.containerId).catch(() => {});
+	}
+
+	// 6. Clean up sandbox token
+	if (ctx.sandboxTokenStore) {
+		ctx.sandboxTokenStore.remove(session.id);
+	}
+}


### PR DESCRIPTION
## Summary

Refactors `session-manager.ts` session creation from three duplicated code paths into a single composable pipeline.

### Problems fixed
1. **Three creation paths with massive duplication** — `createSession()`, `_setupWorktreeAndLaunchAgent()`, and `createDelegateSession()` shared ~100 lines of near-identical code. Now unified into a plan/execute pipeline in `session-setup.ts`.
2. **Worktree sessions skip sandbox wiring** — `_setupWorktreeAndLaunchAgent()` never called `applySandboxWiring()`. Fixed by pipeline ordering (wireSandbox always runs after resolveWorktree).
3. **`persistSessionMetadata` race condition** — Fire-and-forget `store.put()` with ~20 fields could overwrite concurrent `store.update()` calls. Now uses put-once-then-update: `persistOnce()` at creation, then `persistSessionMetadata()` only calls `store.update()` for `agentSessionFile`.
4. **`(session as any)._sandboxed` type hack** — 6 call sites used `any` cast. Now `sandboxed?: boolean` is a proper field on `SessionInfo`.
5. **Two-phase persist gap** — Worktree sessions persisted with `agentSessionFile: ""` then overwrote later. Crash between writes left unrestorable sessions. Now handled gracefully on restore.

### Changes
- **Created** `src/server/agent/session-setup.ts` (683 lines) — composable pipeline with `SessionSetupPlan`, `PipelineContext`, `executePlan()`, `executeWorktreeAsync()`, `withRetry()`, `handleSetupFailure()`, `sendDelegatePrompt()`
- **Refactored** `src/server/agent/session-manager.ts` (3287 → 2900 lines, net -387)
- **Added** `docs/internals.md`, `docs/debugging.md` — extracted and expanded documentation
- **Updated** `AGENTS.md` — references new docs

### Verification
- Type check: 0 errors
- Unit tests: 325/325 pass
- E2E tests: 349/349 pass
- `grep -rn "(session as any)._sandboxed" src/` — zero results

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)