### PR TITLE
Dual-Mode Search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ Quick pointers for the most common issues:
 - **Duplicate messages**: Check `flushDeferredMessage()` in `remote-agent.ts` — `MessageList` and `StreamingMessageContainer` must never overlap.
 - **Session persistence**: Check `.bobbit/state/sessions.json`. Missing `.jsonl` = session skipped on restore.
 - **Sandbox**: `GET /api/sandbox-status` for Docker state. Proxy logs prefixed `[sandbox-proxy]`.
-- **Search**: Delete `.bobbit/state/search.db` and restart to rebuild index.
+- **Search**: Delete `.bobbit/state/search.db` and restart to rebuild index. Schema version 2 includes staff in the index. See @docs/debugging.md#search-index for full checklist.
 - **Gates**: Check `GET /api/goals/:id/gates` for dependency state.
 
 ## Git conventions

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -92,9 +92,13 @@ Scannable checklists for common issues. Each entry: symptom → where to look �
 ## Search index
 
 - `.bobbit/state/search.db` is a rebuildable cache — delete and restart to rebuild
+- Schema version is 2 (includes `staff_fts` table). Version mismatch triggers automatic rebuild on next server start
 - Check `better-sqlite3` loaded correctly (native addon)
 - FTS5 on 10K docs < 10ms — slow search means network/serialization bottleneck
 - Purged sessions still showing? Check `purgeOneSession()` calls index cleanup
+- Staff not appearing in search? Verify `StaffManager` has `searchIndex` dependency and calls `indexStaff()` on create/update
+- Sidebar filter not working? Check `state.searchContentMode` — `false` = client-side title filter, `true` = FTS API call. Toggle state persisted in `localStorage`
+- Full search page (`#/search`) manages its own state — independent from sidebar search
 
 ## Paginated archives
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -37,13 +37,32 @@ All tool access uses a **grant policy** system. Every tool resolves to one of fo
 
 SQLite FTS5 via `better-sqlite3`. Index at `.bobbit/state/search.db` (rebuildable cache).
 
-**Key files:** `search-index.ts`, `message-extractor.ts`, `SearchBox.ts`, `SearchResults.ts`.
+**Key files:** `search-index.ts`, `message-extractor.ts`, `SearchBox.ts`, `SearchResults.ts`, `search-page.ts`.
 
-**Indexed:** Goals (title, spec), sessions (title, role), messages (text blocks, tool call names).
+**Indexed:** Goals (title, spec), sessions (title, role), messages (text blocks, tool call names), staff agents (name, description).
 
-**Indexing:** Incremental via store hooks + `RpcBridge`. Full rebuild on first run or schema version mismatch. Purge syncs on session delete.
+**FTS5 tables:** `goals_fts`, `sessions_fts`, `messages_fts`, `staff_fts`. Schema version is 2 (bumped from 1 when staff indexing was added). Version mismatch triggers automatic rebuild.
 
-**API:** `GET /api/search?q=<query>&limit=20&offset=0&type=all|goals|sessions|messages`
+**Indexing:** Incremental via store hooks + `RpcBridge`. Staff indexing hooks live in `StaffManager` — index on create/update, remove on delete. Full rebuild on first run or schema version mismatch; `rebuildFromStores()` accepts `StaffStore` to include staff in the rebuild.
+
+**API:** `GET /api/search?q=<query>&limit=20&offset=0&type=all|goals|sessions|messages|staff`
+
+### Dual-mode sidebar search
+
+The sidebar search box operates in two modes, controlled by a "Search Content" toggle that appears below the input when a query is active:
+
+- **Title-only (default):** Client-side instant filtering. Filters goals by title, sessions by title, and staff by name using case-insensitive substring matching. No API call. The sidebar structure (goal groups, ungrouped sessions, staff, archived) is preserved — non-matching entries are hidden.
+- **Content search:** Uses `GET /api/search` (FTS5) and maps results back to sidebar entries by ID. Message matches resolve to their parent session/goal. 200ms debounce on input.
+
+State field `searchContentMode` (persisted in `localStorage`) tracks which mode is active.
+
+### Full search page
+
+Route: `#/search` (with optional `?q=<query>` parameter). Accessible via the "Full Search" button in the sidebar controls row or directly by URL.
+
+Features: large auto-focused input, type filter toggles (Goals, Sessions, Staff, Messages), grouped results with snippets and `<b>` match highlighting, relative timestamps, archived badges, and "Load More" pagination. Clicking a result navigates to the relevant goal dashboard, session, or staff edit page.
+
+**Key file:** `search-page.ts` manages its own local state (query, results, type filters, pagination offset).
 
 **Paginated archives:**
 - `GET /api/goals?archived=true&limit=50&after=<cursor>` — cursor is `archivedAt` timestamp

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -16,6 +16,7 @@ import {
 
 	resetArchivedExpandState,
 	getSidebarData,
+	setSearchContentMode,
 } from "./state.js";
 import { createGoal, createRole, gatewayFetch, refreshSessions, dismissSetup, fetchSandboxStatus } from "./api.js";
 import { clearSessionModel } from "./routing.js";
@@ -80,7 +81,7 @@ async function _handleMobileSearchInput(query: string): Promise<void> {
 		return;
 	}
 	// When content mode is off, just set the query for client-side title filtering
-	if (!(state as any).searchContentMode) {
+	if (!state.searchContentMode) {
 		state.searchResults = null;
 		state.searchLoading = false;
 		renderApp();
@@ -119,7 +120,22 @@ function _handleMobileResultClick(detail: { type: string; id: string; sessionId?
 }
 
 function renderMobileLanding() {
-	const { ungroupedSessions, liveGoals, archivedGoals } = getSidebarData();
+	const sidebarData = getSidebarData();
+	let { ungroupedSessions, liveGoals } = sidebarData;
+	const { archivedGoals } = sidebarData;
+
+	// Client-side title filtering for mobile (title-only mode)
+	if (state.searchQuery && !state.searchContentMode) {
+		const q = state.searchQuery.toLowerCase();
+		liveGoals = liveGoals.filter(goal => {
+			const goalMatches = goal.title.toLowerCase().includes(q);
+			const goalSessions = state.gatewaySessions.filter(s => (s.goalId === goal.id || s.teamGoalId === goal.id) && !s.delegateOf);
+			const hasMatchingSession = goalSessions.some(s => s.title?.toLowerCase().includes(q));
+			return goalMatches || hasMatchingSession;
+		});
+		ungroupedSessions = ungroupedSessions.filter(s => s.title?.toLowerCase().includes(q));
+	}
+
 	const isUngroupedExpanded = ungroupedExpanded;
 
 	return html`
@@ -174,19 +190,18 @@ function renderMobileLanding() {
 				<search-box
 					.query=${state.searchQuery}
 					.loading=${state.searchLoading}
-					.contentMode=${(state as any).searchContentMode ?? false}
+					.contentMode=${state.searchContentMode}
 					.showControls=${!!state.searchQuery}
 					@search-input=${(e: CustomEvent) => { _handleMobileSearchInput(e.detail.query); }}
 					@search-clear=${() => { _handleMobileSearchClear(); }}
 					@search-mode-change=${(e: CustomEvent) => {
-						(state as any).searchContentMode = e.detail.contentSearch;
-						localStorage.setItem("searchContentMode", String(e.detail.contentSearch));
+						setSearchContentMode(e.detail.contentSearch);
 						// Re-trigger search with new mode
 						if (state.searchQuery) _handleMobileSearchInput(state.searchQuery);
 					}}
 					@full-search-click=${(e: CustomEvent) => { setHashRoute("search", e.detail.query); }}
 				></search-box>
-				${state.searchQuery ? html`
+				${state.searchQuery && state.searchContentMode ? html`
 					<search-results
 						.results=${state.searchResults || []}
 						.loading=${state.searchLoading}

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -62,6 +62,7 @@ import "./personality-manager.css";
 import { renderStaffPage } from "./staff-page.js";
 import { renderSkillsPage } from "./skills-page.js";
 import { renderSettingsPage } from "./settings-page.js";
+import { renderSearchPage, initSearchPage } from "./search-page.js";
 
 // ============================================================================
 // MOBILE LANDING PAGE
@@ -78,6 +79,14 @@ async function _handleMobileSearchInput(query: string): Promise<void> {
 		renderApp();
 		return;
 	}
+	// When content mode is off, just set the query for client-side title filtering
+	if (!(state as any).searchContentMode) {
+		state.searchResults = null;
+		state.searchLoading = false;
+		renderApp();
+		return;
+	}
+	// Content mode: use FTS API
 	state.searchLoading = true;
 	renderApp();
 	const data = await searchApi(query);
@@ -165,8 +174,17 @@ function renderMobileLanding() {
 				<search-box
 					.query=${state.searchQuery}
 					.loading=${state.searchLoading}
+					.contentMode=${(state as any).searchContentMode ?? false}
+					.showControls=${!!state.searchQuery}
 					@search-input=${(e: CustomEvent) => { _handleMobileSearchInput(e.detail.query); }}
 					@search-clear=${() => { _handleMobileSearchClear(); }}
+					@search-mode-change=${(e: CustomEvent) => {
+						(state as any).searchContentMode = e.detail.contentSearch;
+						localStorage.setItem("searchContentMode", String(e.detail.contentSearch));
+						// Re-trigger search with new mode
+						if (state.searchQuery) _handleMobileSearchInput(state.searchQuery);
+					}}
+					@full-search-click=${(e: CustomEvent) => { setHashRoute("search", e.detail.query); }}
 				></search-box>
 				${state.searchQuery ? html`
 					<search-results
@@ -2348,6 +2366,10 @@ export function doRenderApp(): void {
 		}
 		if (route.view === "settings") {
 			return renderSettingsPage();
+		}
+		if (route.view === "search") {
+			initSearchPage();
+			return renderSearchPage();
 		}
 
 		if (connected && state.assistantType) {

--- a/src/app/routing.ts
+++ b/src/app/routing.ts
@@ -2,14 +2,19 @@
 // URL ROUTING (hash-based: #/ = landing, #/session/{id} = connected, #/goal/{id} = dashboard)
 // ============================================================================
 
-export type RouteView = "landing" | "session" | "goal" | "goal-dashboard" | "roles" | "role-edit" | "tools" | "tool-edit" | "workflows" | "workflow-edit" | "personalities" | "personality-edit" | "staff" | "staff-edit" | "skills" | "settings";
+export type RouteView = "landing" | "session" | "goal" | "goal-dashboard" | "roles" | "role-edit" | "tools" | "tool-edit" | "workflows" | "workflow-edit" | "personalities" | "personality-edit" | "staff" | "staff-edit" | "skills" | "settings" | "search";
 
 export type SettingsTabId = "shortcuts" | "general" | "project" | "models" | "palette" | "directories" | "account";
 
 const SETTINGS_TABS = new Set<SettingsTabId>(["shortcuts", "general", "project", "models", "palette", "directories", "account"]);
 
-export function getRouteFromHash(): { view: RouteView; sessionId?: string; goalId?: string; roleName?: string; toolName?: string; workflowId?: string; personalityName?: string; staffId?: string; settingsTab?: SettingsTabId } {
+export function getRouteFromHash(): { view: RouteView; sessionId?: string; goalId?: string; roleName?: string; toolName?: string; workflowId?: string; personalityName?: string; staffId?: string; settingsTab?: SettingsTabId; searchQuery?: string } {
 	const hash = window.location.hash || "";
+	if (hash === "#/search" || hash.startsWith("#/search?")) {
+		const qIdx = hash.indexOf("?");
+		const params = qIdx >= 0 ? new URLSearchParams(hash.slice(qIdx + 1)) : null;
+		return { view: "search", searchQuery: params?.get("q") || undefined };
+	}
 	const sessionMatch = hash.match(/^#\/session\/([a-f0-9-]+)$/i);
 	if (sessionMatch) {
 		return { view: "session", sessionId: sessionMatch[1] };
@@ -92,6 +97,8 @@ export function setHashRoute(view: RouteView, id?: string, replace?: boolean): v
 		newHash = `#/personalities/${id}`;
 	} else if (view === "personalities") {
 		newHash = "#/personalities";
+	} else if (view === "search") {
+		newHash = id ? `#/search?q=${encodeURIComponent(id)}` : "#/search";
 	} else if (view === "settings") {
 		newHash = id ? `#/settings/${id}` : "#/settings";
 	} else {
@@ -116,6 +123,7 @@ export function setHashRoute(view: RouteView, id?: string, replace?: boolean): v
 const CONFIG_VIEWS: Set<RouteView> = new Set([
 	"roles", "role-edit", "tools", "tool-edit", "workflows", "workflow-edit",
 	"personalities", "personality-edit", "skills", "settings", "staff", "staff-edit",
+	"search",
 ]);
 
 /** Returns true if the current hash route is a config page (not a session or landing). */

--- a/src/app/search-page.ts
+++ b/src/app/search-page.ts
@@ -48,8 +48,10 @@ async function _doSearch(append = false): Promise<void> {
 	}
 	_loading = true;
 	renderApp();
+	const querySnapshot = _query;
 	try {
 		const data = await searchApi(_query, "all", 50, append ? _offset : 0);
+		if (_query !== querySnapshot) return; // discard stale response
 		if (!append) {
 			_results = data.results;
 			_offset = data.results.length;
@@ -190,10 +192,6 @@ export function initSearchPage(): void {
 	}
 }
 
-/** Reset search page state (called when navigating away). */
-export function resetSearchPage(): void {
-	_initialized = false;
-}
 
 // ============================================================================
 // RENDER

--- a/src/app/search-page.ts
+++ b/src/app/search-page.ts
@@ -4,7 +4,7 @@
 
 import { html, nothing, type TemplateResult } from "lit";
 import { icon } from "@mariozechner/mini-lit";
-import { Search, Loader2, Archive, Goal as GoalIcon, MessagesSquare, MessageSquare, Users, Bot } from "lucide";
+import { Search, Loader2, Archive, Goal as GoalIcon, MessagesSquare, MessageSquare, Bot } from "lucide";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { searchApi } from "./api.js";
 import { renderApp } from "./state.js";

--- a/src/app/search-page.ts
+++ b/src/app/search-page.ts
@@ -1,0 +1,379 @@
+// ============================================================================
+// FULL SEARCH PAGE — #/search route
+// ============================================================================
+
+import { html, nothing, type TemplateResult } from "lit";
+import { icon } from "@mariozechner/mini-lit";
+import { Search, Loader2, Archive, Goal as GoalIcon, MessagesSquare, MessageSquare, Users, Bot } from "lucide";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import { searchApi } from "./api.js";
+import { renderApp } from "./state.js";
+import { setHashRoute, getRouteFromHash } from "./routing.js";
+import { connectToSession } from "./session-manager.js";
+
+// ============================================================================
+// MODULE-LEVEL STATE
+// ============================================================================
+
+let _query = "";
+let _results: Array<{
+	type: string;
+	id: string;
+	title: string;
+	snippet: string;
+	timestamp: number;
+	archived: boolean;
+	goalId?: string;
+	sessionId?: string;
+	sessionTitle?: string;
+}> = [];
+let _loading = false;
+let _typeFilters = new Set(["goals", "sessions", "staff", "messages"]);
+let _offset = 0;
+let _total = 0;
+let _debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let _initialized = false;
+
+// ============================================================================
+// SEARCH LOGIC
+// ============================================================================
+
+async function _doSearch(append = false): Promise<void> {
+	if (!_query.trim()) {
+		_results = [];
+		_total = 0;
+		_loading = false;
+		renderApp();
+		return;
+	}
+	_loading = true;
+	renderApp();
+	try {
+		const data = await searchApi(_query, "all", 50, append ? _offset : 0);
+		if (!append) {
+			_results = data.results;
+			_offset = data.results.length;
+		} else {
+			_results = [..._results, ...data.results];
+			_offset += data.results.length;
+		}
+		_total = data.total;
+	} catch (err) {
+		console.error("[search-page] Search failed:", err);
+	}
+	_loading = false;
+	renderApp();
+}
+
+function _handleInput(e: Event): void {
+	_query = (e.target as HTMLInputElement).value;
+	if (_debounceTimer) clearTimeout(_debounceTimer);
+	_debounceTimer = setTimeout(() => {
+		_offset = 0;
+		_doSearch();
+		// Update URL without navigation
+		const newHash = _query ? `#/search?q=${encodeURIComponent(_query)}` : "#/search";
+		if (window.location.hash !== newHash) {
+			history.replaceState({}, "", newHash);
+		}
+	}, 200);
+	renderApp();
+}
+
+function _handleKeydown(e: KeyboardEvent): void {
+	if (e.key === "Escape") {
+		_query = "";
+		_results = [];
+		_total = 0;
+		_offset = 0;
+		renderApp();
+	}
+}
+
+function _toggleFilter(type: string): void {
+	if (_typeFilters.has(type)) {
+		// Don't allow deselecting all
+		if (_typeFilters.size > 1) {
+			_typeFilters.delete(type);
+		}
+	} else {
+		_typeFilters.add(type);
+	}
+	renderApp();
+}
+
+function _loadMore(): void {
+	_doSearch(true);
+}
+
+// ============================================================================
+// RESULT CLICK HANDLERS
+// ============================================================================
+
+function _handleResultClick(result: typeof _results[0]): void {
+	if (result.type === "goal") {
+		setHashRoute("goal-dashboard", result.id);
+	} else if (result.type === "session") {
+		connectToSession(result.id, true);
+	} else if (result.type === "staff") {
+		setHashRoute("staff-edit", result.id);
+	} else if (result.type === "message" && result.sessionId) {
+		connectToSession(result.sessionId, true);
+	}
+}
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/** Turn a timestamp into a terse relative string (e.g. "2h", "3d"). */
+function _relativeTime(ts: number): string {
+	if (!ts) return "";
+	const diff = Math.max(0, Date.now() - ts);
+	const seconds = Math.floor(diff / 1000);
+	if (seconds < 60) return "now";
+	const minutes = Math.floor(seconds / 60);
+	if (minutes < 60) return `${minutes}m`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `${hours}h`;
+	const days = Math.floor(hours / 24);
+	if (days < 30) return `${days}d`;
+	const months = Math.floor(days / 30);
+	return `${months}mo`;
+}
+
+/**
+ * Sanitize FTS5 snippet output — only allow <b> tags for match highlighting.
+ */
+function _sanitizeSnippet(raw: string): string {
+	return raw
+		.replace(/<b>/gi, "\x00B")
+		.replace(/<\/b>/gi, "\x00E")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/\x00B/g, "<b>")
+		.replace(/\x00E/g, "</b>");
+}
+
+function _capitalize(s: string): string {
+	return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function _iconForType(type: string) {
+	switch (type) {
+		case "goals": return GoalIcon;
+		case "sessions": return MessagesSquare;
+		case "staff": return Bot;
+		case "messages": return MessageSquare;
+		default: return Search;
+	}
+}
+
+// ============================================================================
+// INIT
+// ============================================================================
+
+export function initSearchPage(): void {
+	const route = getRouteFromHash();
+	const routeQuery = route.searchQuery || "";
+	if (routeQuery !== _query || !_initialized) {
+		_query = routeQuery;
+		_offset = 0;
+		_initialized = true;
+		if (_query) {
+			_doSearch();
+		} else {
+			_results = [];
+			_total = 0;
+			_loading = false;
+		}
+	}
+}
+
+/** Reset search page state (called when navigating away). */
+export function resetSearchPage(): void {
+	_initialized = false;
+}
+
+// ============================================================================
+// RENDER
+// ============================================================================
+
+function _renderResultRow(result: typeof _results[0]) {
+	const title = result.type === "message"
+		? (result.sessionTitle || result.title)
+		: result.title;
+
+	return html`
+		<button
+			class="w-full text-left px-3 py-2.5 rounded-lg hover:bg-accent/50 transition-colors cursor-pointer flex flex-col gap-1 group"
+			@click=${() => _handleResultClick(result)}
+		>
+			<div class="flex items-center gap-2 min-w-0">
+				<span class="truncate font-medium text-foreground text-sm">${title || "Untitled"}</span>
+				${result.archived ? html`
+					<span class="shrink-0 inline-flex items-center gap-0.5 px-1.5 py-0 rounded text-[10px] bg-muted text-muted-foreground">
+						${icon(Archive, "xs")} archived
+					</span>
+				` : ""}
+				<span class="ml-auto shrink-0 text-[11px] text-muted-foreground tabular-nums">
+					${_relativeTime(result.timestamp)}
+				</span>
+			</div>
+			${result.snippet ? html`
+				<div class="text-xs text-muted-foreground line-clamp-2 leading-relaxed search-snippet">
+					${unsafeHTML(_sanitizeSnippet(result.snippet))}
+				</div>
+			` : ""}
+			${result.type === "message" && result.sessionTitle ? html`
+				<div class="text-[10px] text-muted-foreground/60 flex items-center gap-1">
+					${icon(MessagesSquare, "xs")} ${result.sessionTitle}
+				</div>
+			` : ""}
+		</button>
+	`;
+}
+
+function _renderGroup(type: string, items: typeof _results) {
+	if (items.length === 0) return nothing;
+	const lucideIcon = _iconForType(type);
+	return html`
+		<div class="mb-3">
+			<div class="flex items-center gap-2 px-3 py-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+				${icon(lucideIcon as Parameters<typeof icon>[0], "sm")}
+				${_capitalize(type)}
+				<span class="ml-auto text-[10px] tabular-nums">${items.length}</span>
+			</div>
+			<div class="flex flex-col">${items.map(r => _renderResultRow(r))}</div>
+		</div>
+	`;
+}
+
+function _renderResults(): TemplateResult | typeof nothing {
+	// Loading state (no results yet)
+	if (_loading && _results.length === 0) {
+		return html`
+			<div class="flex items-center justify-center py-12 text-muted-foreground text-sm gap-2">
+				<span class="inline-block animate-spin">${icon(Loader2, "sm")}</span>
+				Searching…
+			</div>
+		`;
+	}
+
+	// Empty state
+	if (!_loading && _query && _results.length === 0) {
+		return html`
+			<div class="flex flex-col items-center justify-center py-12 text-muted-foreground text-sm gap-1">
+				<span>No matches for "${_query}"</span>
+			</div>
+		`;
+	}
+
+	// No query yet
+	if (!_query) {
+		return html`
+			<div class="flex flex-col items-center justify-center py-12 text-muted-foreground text-sm gap-2">
+				${icon(Search, "lg")}
+				<span>Search across goals, sessions, staff, and messages</span>
+			</div>
+		`;
+	}
+
+	// Filter results by active type filters
+	const filtered = _results.filter(r => {
+		if (r.type === "goal") return _typeFilters.has("goals");
+		if (r.type === "session") return _typeFilters.has("sessions");
+		if (r.type === "staff") return _typeFilters.has("staff");
+		if (r.type === "message") return _typeFilters.has("messages");
+		return true;
+	});
+
+	// Group by type
+	const goals = filtered.filter(r => r.type === "goal");
+	const sessions = filtered.filter(r => r.type === "session");
+	const staff = filtered.filter(r => r.type === "staff");
+	const messages = filtered.filter(r => r.type === "message");
+
+	if (filtered.length === 0) {
+		return html`
+			<div class="flex flex-col items-center justify-center py-12 text-muted-foreground text-sm gap-1">
+				<span>No matches for the selected filters</span>
+			</div>
+		`;
+	}
+
+	return html`
+		<div class="flex flex-col gap-1">
+			${_loading ? html`
+				<div class="flex items-center gap-1.5 px-3 py-1 text-xs text-muted-foreground">
+					<span class="inline-block animate-spin">${icon(Loader2, "sm")}</span>
+					Updating…
+				</div>
+			` : ""}
+			${_renderGroup("goals", goals)}
+			${_renderGroup("sessions", sessions)}
+			${_renderGroup("staff", staff)}
+			${_renderGroup("messages", messages)}
+		</div>
+	`;
+}
+
+export function renderSearchPage(): TemplateResult {
+	const filterTypes = ["goals", "sessions", "staff", "messages"] as const;
+
+	return html`
+		<div class="flex-1 flex flex-col h-full overflow-hidden" style="background: var(--sidebar);">
+			<div class="max-w-3xl w-full mx-auto px-4 py-6 flex flex-col gap-4 h-full overflow-y-auto">
+				<!-- Search input -->
+				<div class="relative">
+					<span class="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
+						${_loading
+							? html`<span class="inline-block animate-spin">${icon(Loader2, "sm")}</span>`
+							: icon(Search, "sm")}
+					</span>
+					<input
+						type="text"
+						.value=${_query}
+						placeholder="Search everything..."
+						class="w-full h-11 pl-10 pr-4 rounded-lg border border-input bg-background text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
+						@input=${_handleInput}
+						@keydown=${_handleKeydown}
+						autofocus
+					/>
+				</div>
+
+				<!-- Type filter toggles -->
+				<div class="flex gap-2 flex-wrap">
+					${filterTypes.map(type => html`
+						<button
+							class="px-3 py-1 rounded-full text-xs font-medium transition-colors inline-flex items-center gap-1.5
+								${_typeFilters.has(type)
+									? "bg-primary text-primary-foreground"
+									: "bg-muted text-muted-foreground hover:bg-muted/80"}"
+							@click=${() => _toggleFilter(type)}
+						>
+							${icon(_iconForType(type) as Parameters<typeof icon>[0], "xs")}
+							${_capitalize(type)}
+						</button>
+					`)}
+				</div>
+
+				<!-- Results -->
+				${_renderResults()}
+
+				<!-- Load More -->
+				${_results.length > 0 && _results.length < _total ? html`
+					<div class="flex justify-center py-2">
+						<button
+							class="px-4 py-2 rounded-md text-sm text-primary hover:bg-primary/10 transition-colors"
+							@click=${_loadMore}
+							?disabled=${_loading}
+						>
+							${_loading ? "Loading…" : `Load More (${_total - _results.length} remaining)`}
+						</button>
+					</div>
+				` : ""}
+			</div>
+		</div>
+	`;
+}

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -19,6 +19,7 @@ import {
 	isTeamLeadExpanded,
 	getSidebarData,
 	type Goal,
+	setSearchContentMode,
 } from "./state.js";
 import { createAndConnectSession, connectToSession } from "./session-manager.js";
 import { cwdCombobox } from "./cwd-combobox.js";
@@ -527,9 +528,9 @@ async function handleStaffClick(agent: typeof state.staffList[0]): Promise<void>
 	}
 }
 
-export function renderStaffSidebarSection() {
+export function renderStaffSidebarSection(filteredList?: typeof state.staffList) {
 	ensureStaffLoaded();
-	const list = state.staffList.filter((s) => s.state !== "retired");
+	const list = filteredList ?? state.staffList.filter((s) => s.state !== "retired");
 	const mobile = !isDesktop();
 	// Always show the Staff section so users can create their first staff agent
 
@@ -668,16 +669,39 @@ async function _handleSearchInput(query: string): Promise<void> {
 	state.searchQuery = query;
 	if (!query.trim()) {
 		state.searchResults = null;
+		state.searchMatchIds = null;
 		state.searchLoading = false;
 		renderApp();
 		return;
 	}
+	if (!state.searchContentMode) {
+		// Client-side title filter — no API call needed
+		state.searchLoading = false;
+		renderApp();
+		return;
+	}
+	// Content search mode — use FTS API
 	state.searchLoading = true;
 	renderApp();
 	const data = await searchApi(query);
 	// Guard against stale responses
 	if (state.searchQuery !== query) return;
 	state.searchResults = data.results;
+	// Build a Set of matching IDs for sidebar filtering
+	const ids = new Set<string>();
+	for (const r of data.results) {
+		if (r.type === "goal" && r.id) ids.add(r.id);
+		else if (r.type === "session" && r.id) ids.add(r.id);
+		else if (r.type === "staff" && r.id) ids.add(r.id);
+		else if (r.type === "message" && r.sessionId) {
+			ids.add(r.sessionId);
+			// Also include the parent goal so goal group is visible
+			const session = state.gatewaySessions.find(s => s.id === r.sessionId);
+			if (session?.goalId) ids.add(session.goalId);
+			if (session?.teamGoalId) ids.add(session.teamGoalId);
+		}
+	}
+	state.searchMatchIds = ids;
 	state.searchLoading = false;
 	renderApp();
 }
@@ -685,24 +709,29 @@ async function _handleSearchInput(query: string): Promise<void> {
 function _handleSearchClear(): void {
 	state.searchQuery = "";
 	state.searchResults = null;
+	state.searchMatchIds = null;
 	state.searchLoading = false;
 	renderApp();
 }
 
-function _handleResultClick(detail: { type: string; id: string; sessionId?: string; goalId?: string }): void {
-	// Clear search state
-	state.searchQuery = "";
-	state.searchResults = null;
-	state.searchLoading = false;
-
-	if (detail.type === "goal" && detail.id) {
-		import("./routing.js").then(m => m.setHashRoute("goal-dashboard", detail.id, true));
-	} else if (detail.type === "session" && detail.id) {
-		connectToSession(detail.id, true);
-	} else if (detail.type === "message" && detail.sessionId) {
-		connectToSession(detail.sessionId, true);
+function _handleSearchModeChange(contentSearch: boolean): void {
+	setSearchContentMode(contentSearch);
+	// If switching modes with an active query, re-run the search
+	if (state.searchQuery) {
+		if (contentSearch) {
+			_handleSearchInput(state.searchQuery); // triggers API search
+		} else {
+			state.searchResults = null;
+			state.searchMatchIds = null;
+			state.searchLoading = false;
+			renderApp(); // will use client-side filter
+		}
 	}
-	renderApp();
+}
+
+function _handleFullSearchClick(query: string): void {
+	// Navigate to #/search?q=query — uses hash directly since route may not be registered yet
+	window.location.hash = query ? `#/search?q=${encodeURIComponent(query)}` : "#/search";
 }
 
 export function renderSidebar() {
@@ -778,19 +807,13 @@ export function renderSidebar() {
 			<search-box
 				.query=${state.searchQuery}
 				.loading=${state.searchLoading}
+				.contentMode=${state.searchContentMode}
+				.showControls=${!!state.searchQuery}
 				@search-input=${(e: CustomEvent) => { _handleSearchInput(e.detail.query); }}
 				@search-clear=${() => { _handleSearchClear(); }}
+				@search-mode-change=${(e: CustomEvent) => { _handleSearchModeChange(e.detail.contentSearch); }}
+				@full-search-click=${(e: CustomEvent) => { _handleFullSearchClick(e.detail.query); }}
 			></search-box>
-			${state.searchQuery ? html`
-				<div class="flex-1 overflow-y-auto">
-					<search-results
-						.results=${state.searchResults || []}
-						.loading=${state.searchLoading}
-						.query=${state.searchQuery}
-						@result-click=${(e: CustomEvent) => { _handleResultClick(e.detail); }}
-					></search-results>
-				</div>
-			` : html`
 			<div class="flex-1 overflow-y-auto flex flex-col gap-0.5 py-2 px-0.5">
 				${state.sessionsLoading
 					? html`<div class="text-center py-6 text-muted-foreground text-xs">Loading…</div>`
@@ -799,12 +822,46 @@ export function renderSidebar() {
 								<p class="text-xs text-red-500 mb-2">${state.sessionsError}</p>
 								<button class="text-xs text-muted-foreground hover:text-foreground underline" title="Retry loading sessions" @click=${refreshSessions}>Retry</button>
 							</div>`
-						: html`
-							${liveGoals.map((goal, i) => html`
+						: (() => {
+							// Apply search filtering
+							const staffList = state.staffList || [];
+							let filteredGoals = liveGoals;
+							let filteredUngrouped = ungroupedSessions;
+							let filteredStaff = staffList.filter(s => s.state !== "retired");
+
+							if (state.searchQuery) {
+								const q = state.searchQuery.toLowerCase();
+								if (!state.searchContentMode) {
+									// Client-side title filter
+									filteredGoals = liveGoals.map(goal => {
+										const goalMatches = goal.title.toLowerCase().includes(q);
+										const goalSessions = state.gatewaySessions.filter(s => (s.goalId === goal.id || s.teamGoalId === goal.id) && !s.delegateOf);
+										const hasMatchingSession = goalSessions.some(s => s.title?.toLowerCase().includes(q));
+										if (!goalMatches && !hasMatchingSession) return null as unknown as Goal;
+										return goal;
+									}).filter(Boolean);
+									filteredUngrouped = ungroupedSessions.filter(s => s.title?.toLowerCase().includes(q));
+									filteredStaff = filteredStaff.filter(s => s.name?.toLowerCase().includes(q));
+								} else if (state.searchMatchIds) {
+									// FTS content filter
+									const ids = state.searchMatchIds;
+									filteredGoals = liveGoals.map(goal => {
+										const goalMatches = ids.has(goal.id);
+										const goalSessions = state.gatewaySessions.filter(s => (s.goalId === goal.id || s.teamGoalId === goal.id) && !s.delegateOf);
+										const hasMatchingSession = goalSessions.some(s => ids.has(s.id));
+										if (!goalMatches && !hasMatchingSession) return null as unknown as Goal;
+										return goal;
+									}).filter(Boolean);
+									filteredUngrouped = ungroupedSessions.filter(s => ids.has(s.id));
+									filteredStaff = filteredStaff.filter(s => ids.has(s.id));
+								}
+							}
+							return html`
+							${filteredGoals.map((goal, i) => html`
 								${i > 0 ? html`<div class="border-t border-border/30 my-0.5 mx-2"></div>` : ""}
 								${renderGoalGroup(goal)}
 							`)}
-							${liveGoals.length > 0 ? html`
+							${filteredGoals.length > 0 ? html`
 								<div class="border-t border-border/30 my-1 mx-2"></div>
 								<div class="flex flex-col gap-0.5">
 									<div class="relative flex items-center gap-1 pr-1 py-0.5 rounded-md cursor-pointer hover:bg-secondary/30 transition-colors"
@@ -832,7 +889,7 @@ export function renderSidebar() {
 											${renderRolePickerDropdown()}
 										</div>
 									</div>
-									${ungroupedExpanded ? html`<div class="flex flex-col gap-0.5" style="padding-left:${INDENT}px;">${ungroupedSessions.map(renderSessionRow)}</div>` : ""}
+									${ungroupedExpanded ? html`<div class="flex flex-col gap-0.5" style="padding-left:${INDENT}px;">${filteredUngrouped.map(renderSessionRow)}</div>` : ""}
 								</div>
 							` : html`
 								<div class="flex flex-col gap-0.5">
@@ -858,16 +915,16 @@ export function renderSidebar() {
 										</div>
 									</div>
 									<div class="flex flex-col gap-0.5" style="padding-left:${INDENT}px;">
-									${ungroupedSessions.length === 0
+									${filteredUngrouped.length === 0
 										? html`<div class="text-center py-6">
 												<p class="text-xs text-muted-foreground mb-2">No sessions</p>
 												<button class="text-xs text-primary hover:underline" title="Create a new session" @click=${() => createAndConnectSession()}>Create one</button>
 											</div>`
-										: ungroupedSessions.map(renderSessionRow)}
+										: filteredUngrouped.map(renderSessionRow)}
 								</div>
 								</div>
 							`}
-							${renderStaffSidebarSection()}
+							${state.searchQuery ? renderStaffSidebarSection(filteredStaff) : renderStaffSidebarSection()}
 							${(() => {
 								// Archived section: archived goals + standalone archived sessions
 								// Goal-affiliated archived sessions render inside their goal groups.
@@ -918,10 +975,8 @@ export function renderSidebar() {
 									</div>
 								`;
 							})()}
-						`
-				}
+						`; })()}
 			</div>
-			`}
 			<div class="flex items-center border-t border-border/50">
 				${(() => { const isSettings = isRouteActive("settings"); return html`<button
 					class="flex items-center gap-1.5 px-3 py-2 text-xs transition-colors ${isSettings ? "text-primary bg-primary/10 font-medium" : "text-muted-foreground hover:text-foreground hover:bg-secondary/50"}"

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -150,6 +150,8 @@ export const state = {
 	searchQuery: "",
 	searchResults: null as any[] | null,
 	searchLoading: false,
+	searchContentMode: localStorage.getItem("searchContentMode") === "true",
+	searchMatchIds: null as Set<string> | null,
 
 	// Pagination for archived items
 	archivedGoalsCursor: null as number | null,
@@ -397,6 +399,15 @@ export function renderApp(): void {
 export function renderAppSync(): void {
 	_renderScheduled = false;
 	_renderApp();
+}
+
+// ============================================================================
+// SEARCH CONTENT MODE
+// ============================================================================
+
+export function setSearchContentMode(val: boolean): void {
+	state.searchContentMode = val;
+	localStorage.setItem("searchContentMode", String(val));
 }
 
 // ============================================================================

--- a/src/server/agent/staff-manager.ts
+++ b/src/server/agent/staff-manager.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { StaffStore, type PersistedStaff, type StaffState, type StaffTrigger } from "./staff-store.js";
 import type { SessionManager } from "./session-manager.js";
+import type { SearchIndex } from "../search/search-index.js";
 import { createWorktree, cleanupWorktree } from "../skills/git.js";
 
 function sanitiseBranchName(name: string): string {
@@ -9,6 +10,11 @@ function sanitiseBranchName(name: string): string {
 
 export class StaffManager {
 	private store = new StaffStore();
+	searchIndex?: SearchIndex;
+
+	getStore(): StaffStore {
+		return this.store;
+	}
 
 	async createStaff(
 		name: string,
@@ -48,6 +54,7 @@ export class StaffManager {
 		staff.branch = worktreeResult.branchName;
 
 		this.store.put(staff);
+		this.searchIndex?.indexStaff(staff);
 
 		// Create the permanent session for this staff agent
 		try {
@@ -74,6 +81,7 @@ export class StaffManager {
 				console.error(`[staff-manager] Failed to clean up orphaned worktree ${worktreeResult.worktreePath}:`, cleanupErr);
 			}
 			this.store.remove(id);
+			this.searchIndex?.removeStaff(id);
 			throw err;
 		}
 
@@ -109,7 +117,12 @@ export class StaffManager {
 				id: t.id || randomUUID(),
 			}));
 		}
-		return this.store.update(id, updates);
+		const ok = this.store.update(id, updates);
+		if (ok && this.searchIndex) {
+			const staff = this.store.get(id);
+			if (staff) this.searchIndex.indexStaff(staff);
+		}
+		return ok;
 	}
 
 	async deleteStaff(id: string, sessionManager: SessionManager): Promise<boolean> {
@@ -135,6 +148,7 @@ export class StaffManager {
 		}
 
 		this.store.remove(id);
+		this.searchIndex?.removeStaff(id);
 		return true;
 	}
 

--- a/src/server/search/search-index.ts
+++ b/src/server/search/search-index.ts
@@ -4,13 +4,15 @@ import path from "node:path";
 import { extractTextFromMessage } from "./message-extractor.js";
 import type { PersistedGoal, GoalStore } from "../agent/goal-store.js";
 import type { PersistedSession, SessionStore } from "../agent/session-store.js";
+import type { PersistedStaff } from "../agent/staff-store.js";
+import type { StaffStore } from "../agent/staff-store.js";
 
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
 
 // ── Public interfaces ────────────────────────────────────────────────
 
 export interface SearchResult {
-	type: "goal" | "session" | "message";
+	type: "goal" | "session" | "message" | "staff";
 	/** goalId for goals, sessionId for sessions, FTS5 rowid string for messages */
 	id: string;
 	title: string;
@@ -35,6 +37,9 @@ export class SearchIndex {
 	private readonly dbPath: string;
 	private _needsRebuild = false;
 
+	/** Optional staff store — set before open()/rebuild to include staff in the index. */
+	staffStore?: StaffStore;
+
 	// Prepared statements (lazily created after open)
 	private stmts: {
 		deleteGoal: Database.Statement;
@@ -43,6 +48,8 @@ export class SearchIndex {
 		insertSession: Database.Statement;
 		insertMessage: Database.Statement;
 		deleteMessagesBySession: Database.Statement;
+		deleteStaff: Database.Statement;
+		insertStaff: Database.Statement;
 		// Read statements (cached for search queries)
 		countGoals: Database.Statement;
 		searchGoals: Database.Statement;
@@ -50,6 +57,8 @@ export class SearchIndex {
 		searchSessions: Database.Statement;
 		countMessages: Database.Statement;
 		searchMessages: Database.Statement;
+		countStaff: Database.Statement;
+		searchStaff: Database.Statement;
 	} | null = null;
 
 	constructor(dbPath: string) {
@@ -169,14 +178,30 @@ export class SearchIndex {
 		this.stmts?.deleteMessagesBySession.run(sessionId);
 	}
 
+	// ── Staff indexing ─────────────────────────────────────────────
+
+	indexStaff(staff: PersistedStaff): void {
+		if (!this.stmts) return;
+		this.stmts.deleteStaff.run(staff.id);
+		this.stmts.insertStaff.run(staff.id, staff.name || "", staff.description || "", staff.state || "", staff.createdAt ?? 0);
+	}
+
+	removeStaff(staffId: string): void {
+		this.stmts?.deleteStaff.run(staffId);
+	}
+
 	// ── Full rebuild ───────────────────────────────────────────────
 
 	rebuildFromStores(
 		goalStore: GoalStore,
 		sessionStore: SessionStore,
 		_sessionsDir?: string,
+		staffStore?: StaffStore,
 	): void {
 		if (!this.db) return;
+
+		// Use explicit param or fallback to instance property
+		const effectiveStaffStore = staffStore || this.staffStore;
 
 		// Build a goalId → title map for session indexing
 		const goals = goalStore.getAll();
@@ -186,10 +211,11 @@ export class SearchIndex {
 		}
 
 		const sessions = sessionStore.getAll();
+		const staffEntries = effectiveStaffStore ? effectiveStaffStore.getAll() : [];
 		let messageCount = 0;
 
 		console.log(
-			`[search] Rebuilding index: ${goals.length} goals, ${sessions.length} sessions...`,
+			`[search] Rebuilding index: ${goals.length} goals, ${sessions.length} sessions, ${staffEntries.length} staff...`,
 		);
 
 		const rebuild = this.db.transaction(() => {
@@ -197,6 +223,7 @@ export class SearchIndex {
 			this.db!.exec("DELETE FROM goals_fts");
 			this.db!.exec("DELETE FROM sessions_fts");
 			this.db!.exec("DELETE FROM messages_fts");
+			this.db!.exec("DELETE FROM staff_fts");
 
 			// Index goals
 			for (const goal of goals) {
@@ -245,12 +272,17 @@ export class SearchIndex {
 					// Skip unreadable files
 				}
 			}
+
+			// Index staff
+			for (const staff of staffEntries) {
+				this.indexStaff(staff);
+			}
 		});
 
 		rebuild();
 		this._needsRebuild = false;
 		console.log(
-			`[search] Index rebuilt: ${goals.length} goals, ${sessions.length} sessions, ${messageCount} messages`,
+			`[search] Index rebuilt: ${goals.length} goals, ${sessions.length} sessions, ${messageCount} messages, ${staffEntries.length} staff`,
 		);
 	}
 
@@ -259,7 +291,7 @@ export class SearchIndex {
 	search(
 		query: string,
 		opts: {
-			type?: "all" | "goals" | "sessions" | "messages";
+			type?: "all" | "goals" | "sessions" | "messages" | "staff";
 			limit?: number;
 			offset?: number;
 		} = {},
@@ -299,6 +331,12 @@ export class SearchIndex {
 			total += count;
 		}
 
+		if (type === "all" || type === "staff") {
+			const { rows, count } = this.searchStaffEntries(ftsQuery, type === "staff" ? limit : 10, type === "staff" ? offset : 0);
+			results.push(...rows);
+			total += count;
+		}
+
 		// For type-specific queries, apply limit/offset at the top level
 		if (type !== "all") {
 			return { results, total };
@@ -333,6 +371,11 @@ export class SearchIndex {
 				text_content, tool_names,
 				timestamp UNINDEXED
 			);
+
+			CREATE VIRTUAL TABLE IF NOT EXISTS staff_fts USING fts5(
+				staff_id UNINDEXED, name, description,
+				state UNINDEXED, created_at UNINDEXED
+			);
 		`);
 
 		// Set version if not present
@@ -346,6 +389,7 @@ export class SearchIndex {
 			this.db.exec("DROP TABLE IF EXISTS goals_fts");
 			this.db.exec("DROP TABLE IF EXISTS sessions_fts");
 			this.db.exec("DROP TABLE IF EXISTS messages_fts");
+			this.db.exec("DROP TABLE IF EXISTS staff_fts");
 			this.db.exec("DROP TABLE IF EXISTS schema_version");
 			// Recurse to recreate
 			this.ensureSchema();
@@ -373,6 +417,12 @@ export class SearchIndex {
 			),
 			deleteMessagesBySession: this.db.prepare(
 				"DELETE FROM messages_fts WHERE session_id = ?",
+			),
+			deleteStaff: this.db.prepare(
+				"DELETE FROM staff_fts WHERE staff_id = ?",
+			),
+			insertStaff: this.db.prepare(
+				"INSERT INTO staff_fts (staff_id, name, description, state, created_at) VALUES (?, ?, ?, ?, ?)",
 			),
 			// Read statements for search queries
 			countGoals: this.db.prepare(
@@ -403,6 +453,16 @@ export class SearchIndex {
 					snippet(messages_fts, 2, '<b>', '</b>', '...', 40) as snippet,
 					timestamp
 				 FROM messages_fts WHERE messages_fts MATCH ?
+				 ORDER BY rank
+				 LIMIT ? OFFSET ?`,
+			),
+			countStaff: this.db.prepare(
+				"SELECT count(*) as cnt FROM staff_fts WHERE staff_fts MATCH ?",
+			),
+			searchStaff: this.db.prepare(
+				`SELECT staff_id, name, snippet(staff_fts, 2, '<b>', '</b>', '...', 40) as snippet,
+					state, created_at
+				 FROM staff_fts WHERE staff_fts MATCH ?
 				 ORDER BY rank
 				 LIMIT ? OFFSET ?`,
 			),
@@ -514,6 +574,41 @@ export class SearchIndex {
 					archived: false,
 					sessionId: r.session_id,
 					sessionTitle: r.session_title || undefined,
+				})),
+			};
+		} catch {
+			return { rows: [], count: 0 };
+		}
+	}
+
+	private searchStaffEntries(
+		ftsQuery: string,
+		limit: number,
+		offset: number,
+	): { rows: SearchResult[]; count: number } {
+		if (!this.stmts) return { rows: [], count: 0 };
+
+		try {
+			const countRow = this.stmts.countStaff.get(ftsQuery) as { cnt: number };
+			const count = countRow?.cnt ?? 0;
+
+			const rows = this.stmts.searchStaff.all(ftsQuery, limit, offset) as Array<{
+				staff_id: string;
+				name: string;
+				snippet: string;
+				state: string;
+				created_at: number;
+			}>;
+
+			return {
+				count,
+				rows: rows.map((r) => ({
+					type: "staff" as const,
+					id: r.staff_id,
+					title: r.name,
+					snippet: r.snippet,
+					timestamp: Number(r.created_at) || 0,
+					archived: false,
 				})),
 			};
 		} catch {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -232,6 +232,9 @@ export function createGateway(config: GatewayConfig) {
 	sessionManager.sandboxTokenStore = sandboxTokenStore;
 	const workflowManager = new WorkflowManager(workflowStore);
 	const staffManager = new StaffManager();
+	// Wire staff into search index for indexing and rebuilds
+	sessionManager.searchIndex.staffStore = staffManager.getStore();
+	staffManager.searchIndex = sessionManager.searchIndex;
 	const triggerEngine = new TriggerEngine(staffManager, sessionManager);
 	triggerEngine.start();
 	const teamManager = new TeamManager(sessionManager, {
@@ -883,8 +886,8 @@ async function handleApiRoute(
 		const limit = Math.min(Math.max(1, parseInt(url.searchParams.get("limit") || "20", 10) || 20), 100);
 		const offset = Math.max(0, parseInt(url.searchParams.get("offset") || "0", 10) || 0);
 		const typeParam = url.searchParams.get("type") || "all";
-		const validTypes = new Set(["all", "goals", "sessions", "messages"]);
-		const type = validTypes.has(typeParam) ? typeParam as "all" | "goals" | "sessions" | "messages" : "all";
+		const validTypes = new Set(["all", "goals", "sessions", "messages", "staff"]);
+		const type = validTypes.has(typeParam) ? typeParam as "all" | "goals" | "sessions" | "messages" | "staff" : "all";
 		try {
 			const results = sessionManager.searchIndex.search(q, { type, limit, offset });
 			json(results);

--- a/src/ui/components/SearchBox.ts
+++ b/src/ui/components/SearchBox.ts
@@ -16,6 +16,8 @@ export class SearchBox extends LitElement {
 	@property({ type: String }) query = "";
 	@property({ type: Boolean }) collapsed = false;
 	@property({ type: Boolean }) loading = false;
+	@property({ type: Boolean }) contentMode = false;
+	@property({ type: Boolean }) showControls = false;
 
 	@state() private _focused = false;
 
@@ -89,38 +91,66 @@ export class SearchBox extends LitElement {
 		this.dispatchEvent(new CustomEvent("search-clear", { bubbles: true, composed: true }));
 	}
 
+	private _toggleContentMode(e: Event) {
+		const checked = (e.target as HTMLInputElement).checked;
+		this.dispatchEvent(new CustomEvent("search-mode-change", {
+			bubbles: true, composed: true,
+			detail: { contentSearch: checked },
+		}));
+	}
+
+	private _fullSearch() {
+		this.dispatchEvent(new CustomEvent("full-search-click", {
+			bubbles: true, composed: true,
+			detail: { query: this.query },
+		}));
+	}
+
 	protected override render() {
 		if (this.collapsed) return html``;
 
 		return html`
-			<div class="relative pb-1">
-				<div class="relative flex items-center">
-					<span class="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none ${this._focused ? "text-foreground" : ""}">
-						${this.loading
-							? html`<span class="inline-block animate-spin">${icon(Loader2, "sm")}</span>`
-							: icon(Search, "sm")}
-					</span>
-					<input
-						data-search
-						type="text"
-						.value=${this.query}
-						placeholder="Search… (${navigator.platform?.includes("Mac") ? "⌘" : "Ctrl+"}K)"
-						class="w-full h-7 pl-8 pr-8 border border-input bg-transparent text-xs text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow]"
-						@input=${this._handleInput}
-						@keydown=${this._handleKeydown}
-						@focus=${() => { this._focused = true; }}
-						@blur=${() => { this._focused = false; }}
-					/>
-					${this.query
-						? html`
-							<button
-								class="absolute right-1.5 top-1/2 -translate-y-1/2 p-0.5 rounded text-muted-foreground hover:text-foreground transition-colors"
-								@click=${this._clear}
-								aria-label="Clear search"
-							>
-								${icon(X, "sm")}
-							</button>`
-						: ""}
+			<div>
+				<div class="relative pb-1">
+					<div class="relative flex items-center">
+						<span class="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none ${this._focused ? "text-foreground" : ""}">
+							${this.loading
+								? html`<span class="inline-block animate-spin">${icon(Loader2, "sm")}</span>`
+								: icon(Search, "sm")}
+						</span>
+						<input
+							data-search
+							type="text"
+							.value=${this.query}
+							placeholder="Search… (${navigator.platform?.includes("Mac") ? "⌘" : "Ctrl+"}K)"
+							class="w-full h-7 pl-8 pr-8 border border-input bg-transparent text-xs text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow]"
+							@input=${this._handleInput}
+							@keydown=${this._handleKeydown}
+							@focus=${() => { this._focused = true; }}
+							@blur=${() => { this._focused = false; }}
+						/>
+						${this.query
+							? html`
+								<button
+									class="absolute right-1.5 top-1/2 -translate-y-1/2 p-0.5 rounded text-muted-foreground hover:text-foreground transition-colors"
+									@click=${this._clear}
+									aria-label="Clear search"
+								>
+									${icon(X, "sm")}
+								</button>`
+							: ""}
+					</div>
+				</div>
+				<div class="overflow-hidden transition-all duration-200 ease-in-out" style="max-height: ${this.showControls ? "28px" : "0"}; opacity: ${this.showControls ? "1" : "0"}">
+					<div class="flex items-center justify-between px-2 py-0.5 text-[11px]">
+						<label class="flex items-center gap-1 text-muted-foreground hover:text-foreground cursor-pointer select-none transition-colors">
+							<input type="checkbox" .checked=${this.contentMode} @change=${this._toggleContentMode} class="w-3 h-3 accent-primary" />
+							Search Content
+						</label>
+						<button class="text-primary hover:text-primary/80 hover:underline transition-colors" @click=${this._fullSearch}>
+							Full Search
+						</button>
+					</div>
 				</div>
 			</div>
 		`;

--- a/src/ui/components/SearchResults.ts
+++ b/src/ui/components/SearchResults.ts
@@ -6,7 +6,7 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
 /** A single search result from the API. */
 export interface SearchResult {
-	type: "goal" | "session" | "message";
+	type: "goal" | "session" | "message" | "staff";
 	id: string;
 	title: string;
 	snippet: string;


### PR DESCRIPTION
## Dual-Mode Search

Replace the single-mode sidebar search with two distinct search modes and add staff agents to the FTS5 search index.

### Features

**Sidebar Filter Mode (default)**
- Typing in the search box filters sidebar entries in-place (goals, sessions, staff)
- Title-only mode (default): instant client-side substring filtering, no API call
- Search Content mode: FTS5 full-text search via API, results mapped to sidebar entries
- Animated controls row slides in below search box when query is non-empty

**Full Search Page (`#/search`)**
- Dedicated route with large auto-focused search input
- Type filter toggles: Goals, Sessions, Staff, Messages
- Grouped results with snippets, match highlighting, relative timestamps, archived badges
- Pagination via Load More
- Accessible via Full Search button or direct URL `#/search?q=query`

**Staff FTS5 Indexing**
- New `staff_fts` table indexing `name` and `description` fields
- `SCHEMA_VERSION` bumped to 2 (auto-rebuild on upgrade)
- `/api/search?type=staff` supported; staff included in `type=all`
- StaffManager hooks: index on create/update, remove on delete

**Mobile Parity**
- Same dual-mode filtering on mobile landing page

### Files Changed
- `src/server/search/search-index.ts` — staff FTS5 table, search methods
- `src/server/server.ts` — staffStore wiring, type=staff API
- `src/server/agent/staff-manager.ts` — search index hooks
- `src/ui/components/SearchBox.ts` — controls row
- `src/ui/components/SearchResults.ts` — staff type
- `src/app/sidebar.ts` — in-place filtering
- `src/app/state.ts` — searchContentMode, searchMatchIds
- `src/app/routing.ts` — search route
- `src/app/render.ts` — search page route, mobile dual-mode
- `src/app/search-page.ts` — new full search page
- `AGENTS.md`, `docs/debugging.md`, `docs/internals.md` — documentation

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)