### PR TITLE
perf: fix UI sluggishness during LLM streaming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ See @docs/debugging.md for scannable checklists covering all subsystems.
 
 Quick pointers for the most common issues:
 
+- **Streaming sluggishness**: `AgentInterface` must NOT call `requestUpdate()` in the `message_update` handler — only `StreamingMessageContainer.setMessage()` updates during streaming (rAF-batched). See @docs/debugging.md#streaming-performance for full checklist.
 - **Duplicate messages**: Check `flushDeferredMessage()` in `remote-agent.ts` — `MessageList` and `StreamingMessageContainer` must never overlap.
 - **Session persistence**: Check `.bobbit/state/sessions.json`. Missing `.jsonl` = session skipped on restore.
 - **Sandbox**: `GET /api/sandbox-status` for Docker state. Proxy logs prefixed `[sandbox-proxy]`.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -2,6 +2,14 @@
 
 Scannable checklists for common issues. Each entry: symptom → where to look → key detail.
 
+## Streaming performance (UI sluggishness)
+
+- **Architecture**: `StreamingMessageContainer` owns rendering during streaming via `setMessage()` with `requestAnimationFrame` batching. `AgentInterface` must NOT call `this.requestUpdate()` in the `message_update` event handler — only the streaming container updates on each token.
+- **If the UI feels sluggish during streaming**: check `AgentInterface.setupSessionSubscription()` — the `message_update` case should only update the streaming container, not trigger a full `AgentInterface` re-render.
+- **toolResultsById memoization**: `AgentInterface._getToolResultsById()` caches the tool-results Map to avoid creating a new reference on every render, which would cause `MessageList` to re-render unnecessarily.
+- **content-visibility CSS**: `message-list > .flex > *` uses `content-visibility: auto` to skip layout/paint for off-screen messages in long conversations.
+- State-transition events (`message_start`, `message_end`, `agent_start`, `agent_end`, `turn_start`, `turn_end`) still call `requestUpdate()` — only `message_update` (the hot path) is excluded.
+
 ## Duplicate messages
 
 - Check `flushDeferredMessage()` and `_deferredAssistantMessage` in `remote-agent.ts`

--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -3036,3 +3036,9 @@ html {
 		font-size: 15px;
 	}
 }
+
+/* Skip layout/paint for off-screen messages to improve streaming performance */
+message-list > .flex > * {
+	content-visibility: auto;
+	contain-intrinsic-size: auto 100px;
+}

--- a/src/ui/components/AgentInterface.ts
+++ b/src/ui/components/AgentInterface.ts
@@ -16,7 +16,7 @@ import "./Messages.js"; // Import for side effects to register the custom elemen
 import "./CostPopover.js";
 import { getAppStorage } from "../storage/app-storage.js";
 import "./StreamingMessageContainer.js";
-import type { Agent, AgentEvent } from "@mariozechner/pi-agent-core";
+import type { Agent, AgentEvent, AgentMessage } from "@mariozechner/pi-agent-core";
 import type { Attachment } from "../utils/attachment-utils.js";
 import { formatCost, formatTokenCount, formatModelCost } from "../utils/format.js";
 import { i18n } from "../utils/i18n.js";
@@ -95,6 +95,8 @@ export class AgentInterface extends LitElement {
 	private _unsubscribeSession?: () => void;
 	// Server-authoritative queue state, updated via onQueueUpdate callback
 	private _serverQueue: Array<{ id: string; text: string; isSteered: boolean; createdAt: number; images?: any[]; attachments?: any[] }> = [];
+	private _cachedToolResults?: Map<string, ToolResultMessage>;
+	private _cachedMessagesRef?: AgentMessage[];
 
 	public setInput(text: string, attachments?: Attachment[]) {
 		const update = () => {
@@ -340,7 +342,6 @@ export class AgentInterface extends LitElement {
 						this._streamingContainer.turnStartTime = (this.session?.state as any).turnStartTime ?? null;
 						this._streamingContainer.setMessage(ev.message, !isStreaming);
 					}
-					this.requestUpdate();
 					break;
 			}
 		});
@@ -474,6 +475,22 @@ export class AgentInterface extends LitElement {
 
 
 
+	private _getToolResultsById(): Map<string, ToolResultMessage> {
+		const msgs = this.session?.state.messages;
+		if (msgs === this._cachedMessagesRef && this._cachedToolResults) {
+			return this._cachedToolResults;
+		}
+		this._cachedMessagesRef = msgs;
+		const map = new Map<string, ToolResultMessage>();
+		if (msgs) {
+			for (const m of msgs) {
+				if (m.role === "toolResult") map.set(m.toolCallId, m);
+			}
+		}
+		this._cachedToolResults = map;
+		return map;
+	}
+
 	private renderMessages() {
 		if (!this.session)
 			return html`<div class="p-4 text-center text-muted-foreground">${i18n("No session available")}</div>`;
@@ -490,12 +507,7 @@ export class AgentInterface extends LitElement {
 			`;
 		}
 		// Build a map of tool results to allow inline rendering in assistant messages
-		const toolResultsById = new Map<string, ToolResultMessage<any>>();
-		for (const message of state.messages) {
-			if (message.role === "toolResult") {
-				toolResultsById.set(message.toolCallId, message);
-			}
-		}
+		const toolResultsById = this._getToolResultsById();
 		return html`
 			<div class="flex flex-col gap-3">
 				<!-- Stable messages list - won't re-render during streaming -->


### PR DESCRIPTION
## Summary

Fixes UI unresponsiveness during LLM streaming by eliminating unnecessary re-renders that saturated the browser's main thread.

### Changes

1. **Remove redundant requestUpdate() from message_update handler** (highest impact) — AgentInterface was triggering a full Lit re-render (~30-60x/sec) on every streaming token. StreamingMessageContainer already handles its own rendering via rAF-batched setMessage().

2. **Memoize toolResultsById map** — Prevented MessageList from re-rendering on every cycle due to new Map reference creation.

3. **content-visibility CSS for off-screen messages** — Skips layout/paint for messages scrolled out of view in long conversations.

4. **Documentation** — Added streaming performance debugging guide to docs/debugging.md and AGENTS.md.

### Files modified
- `src/ui/components/AgentInterface.ts` — Remove requestUpdate() + add memoization
- `src/ui/app.css` — content-visibility optimization
- `docs/debugging.md` — New streaming performance section
- `AGENTS.md` — Quick pointer for streaming sluggishness

### Verification
- Type check: PASS
- Unit tests: 325/325 PASS
- E2E tests: 338/338 PASS
- Gap analysis: PASS
- Security review: PASS
- Code quality review: PASS

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)