### PR TITLE
Fix remaining this.store and this.searchIndex bypasses in session-manager.ts

### DIFF
--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -270,6 +270,40 @@ export class SessionManager {
 		return this.searchIndex;
 	}
 
+	/** Resolve the correct SessionStore for an in-memory session by ID. */
+	private resolveStoreForSession(id: string): SessionStore {
+		const session = this.sessions.get(id);
+		if (session?.projectId) {
+			return this.getSessionStore(session.projectId);
+		}
+		return this.store;
+	}
+
+	/** Resolve the correct SessionStore for any session by ID (in-memory or persisted). */
+	private resolveStoreForId(id: string): SessionStore {
+		// Try in-memory first (fast path)
+		const session = this.sessions.get(id);
+		if (session?.projectId) {
+			return this.getSessionStore(session.projectId);
+		}
+		// Search all project stores for persisted/archived sessions
+		if (this.projectContextManager) {
+			for (const ctx of this.projectContextManager.all()) {
+				if (ctx.sessionStore.get(id)) return ctx.sessionStore;
+			}
+		}
+		return this.store;
+	}
+
+	/** Resolve the correct SearchIndex for a session based on its project. */
+	private resolveSearchIndex(session: { projectId?: string }): SearchIndex {
+		if (session.projectId && this.projectContextManager) {
+			const ctx = this.projectContextManager.getOrCreate(session.projectId);
+			if (ctx) return ctx.searchIndex;
+		}
+		return this.searchIndex;
+	}
+
 	/** Resolve a goal across all project contexts. */
 	private resolveGoal(goalId: string): PersistedGoal | undefined {
 		if (this.projectContextManager) {
@@ -525,7 +559,7 @@ export class SessionManager {
 			if (session.assistantType === "goal") {
 				assistantGoalSpec = assistantGoalSpec.replace('{{AVAILABLE_WORKFLOWS}}', this._buildWorkflowList());
 				// Inject re-attempt context if this is a re-attempt session
-				const reattemptId = (this.store.get(session.id) as any)?.reattemptGoalId;
+				const reattemptId = (this.resolveStoreForSession(session.id).get(session.id) as any)?.reattemptGoalId;
 				if (reattemptId) {
 					const origGoal = this.resolveGoal(reattemptId);
 					if (origGoal) {
@@ -599,7 +633,7 @@ export class SessionManager {
 			sessionId: session.id,
 			queue: session.promptQueue.toArray(),
 		});
-		this.store.update(session.id, { messageQueue: session.promptQueue.toArray() });
+		this.resolveStoreForSession(session.id).update(session.id, { messageQueue: session.promptQueue.toArray() });
 	}
 
 	/**
@@ -709,7 +743,7 @@ export class SessionManager {
 		// Optimistic status update to prevent double-dispatch race
 		session.status = "streaming";
 		session.streamingStartedAt = session.streamingStartedAt ?? Date.now();
-		this.store.update(session.id, { wasStreaming: true, streamingStartedAt: session.streamingStartedAt });
+		this.resolveStoreForSession(session.id).update(session.id, { wasStreaming: true, streamingStartedAt: session.streamingStartedAt });
 		broadcast(session.clients, { type: "session_status", status: "streaming", streamingStartedAt: session.streamingStartedAt });
 
 		// Always dispatch as prompt — agent is idle, steer is only for mid-turn
@@ -822,7 +856,7 @@ export class SessionManager {
 			session.turnHadToolCalls = false;
 			session.permissionBroadcastSent = false;
 			session.streamingStartedAt = Date.now();
-			this.store.update(session.id, { wasStreaming: true, streamingStartedAt: session.streamingStartedAt });
+			this.resolveStoreForSession(session.id).update(session.id, { wasStreaming: true, streamingStartedAt: session.streamingStartedAt });
 			broadcast(session.clients, { type: "session_status", status: "streaming", streamingStartedAt: session.streamingStartedAt });
 		} else if (event.type === "agent_end") {
 			// Revoke one-time granted tools after the turn completes
@@ -836,7 +870,7 @@ export class SessionManager {
 
 			session.status = "idle";
 			session.streamingStartedAt = undefined;
-			this.store.update(session.id, { wasStreaming: false, streamingStartedAt: undefined });
+			this.resolveStoreForSession(session.id).update(session.id, { wasStreaming: false, streamingStartedAt: undefined });
 			broadcast(session.clients, { type: "session_status", status: "idle" });
 			// Don't drain the queue if the turn ended with a model error —
 			// queued/steered messages should wait for a retry.
@@ -865,7 +899,7 @@ export class SessionManager {
 			try {
 				const { text, toolNames } = extractTextFromMessage(event.message);
 				if (text.trim()) {
-					this.searchIndex.indexMessage(
+					this.resolveSearchIndex(session).indexMessage(
 						session.id,
 						session.title,
 						text,
@@ -1042,7 +1076,7 @@ export class SessionManager {
 	 * which re-applies tool activation with the updated role.
 	 */
 	private async _restartSessionWithUpdatedRole(session: SessionInfo): Promise<void> {
-		const ps = this.store.get(session.id);
+		const ps = this.resolveStoreForSession(session.id).get(session.id);
 		if (!ps) return;
 
 		// Save state that must survive the restart
@@ -1204,23 +1238,26 @@ export class SessionManager {
 		// Get session IDs that the verification harness will resume — skip those
 		const resumingIds = this._verificationHarness?.getResumingSessionIds() ?? new Set<string>();
 
-		const orphans: string[] = [];
-		for (const ps of this.store.getLive()) {
+		const orphans: { id: string; projectId?: string }[] = [];
+		const allLive = this.projectContextManager
+			? [...this.projectContextManager.getAllLiveSessions()]
+			: this.store.getLive();
+		for (const ps of allLive) {
 			if (ps.nonInteractive && !resumingIds.has(ps.id)) {
-				orphans.push(ps.id);
+				orphans.push({ id: ps.id, projectId: ps.projectId });
 			}
 		}
 		if (orphans.length === 0) return;
 
 		console.log(`[session-manager] Cleaning up ${orphans.length} orphaned non-interactive session(s)...`);
-		for (const id of orphans) {
+		for (const { id, projectId } of orphans) {
 			try {
 				await this.terminateSession(id);
 				console.log(`[session-manager] Terminated orphaned non-interactive session ${id}`);
 			} catch (err) {
 				// If terminate fails (e.g. session wasn't fully restored), archive directly
 				console.warn(`[session-manager] Failed to terminate orphan ${id}, archiving:`, err);
-				this.store.archive(id);
+				this.getSessionStore(projectId).archive(id);
 			}
 		}
 	}
@@ -1447,9 +1484,10 @@ export class SessionManager {
 		// all historical message_update events which would double-count costs)
 		let restoring = true;
 
+		const restoreStore = this.getSessionStore(ps.projectId);
 		const unsub = rpcClient.onEvent((event: any) => {
 			session.lastActivity = Date.now();
-			this.store.update(ps.id, { lastActivity: session.lastActivity });
+			restoreStore.update(ps.id, { lastActivity: session.lastActivity });
 
 			this.handleAgentLifecycle(session, event);
 
@@ -1481,7 +1519,7 @@ export class SessionManager {
 		// If the agent was mid-turn when the server died, re-prompt it to continue
 		if (ps.wasStreaming) {
 			console.log(`[session-manager] Session "${ps.title}" (${ps.id}) was interrupted mid-turn — re-prompting to continue`);
-			this.store.update(ps.id, { wasStreaming: false });
+			restoreStore.update(ps.id, { wasStreaming: false });
 			rpcClient.prompt(
 				"[SYSTEM: The infrastructure server restarted while you were mid-turn. " +
 				"Your previous work has been preserved. Please continue where you left off. " +
@@ -1621,12 +1659,11 @@ export class SessionManager {
 		const id = randomUUID();
 		// Resolve projectId from parent session
 		const parentProjectId = this.sessions.get(parentSessionId)?.projectId
-			?? this.store.get(parentSessionId)?.projectId;
+			?? this.resolveStoreForId(parentSessionId).get(parentSessionId)?.projectId;
 		const ctx = this.buildPipelineContext(parentProjectId);
 
 		// ── Sandbox propagation from parent ──
-		const parentMeta = this.getSessionStore(parentProjectId).get(parentSessionId)
-			?? this.store.get(parentSessionId);
+		const parentMeta = this.getSessionStore(parentProjectId).get(parentSessionId);
 		let delegateSandboxed = false;
 		if (parentMeta?.sandboxed) {
 			// Always use the parent's validated host-side cwd — never trust the
@@ -1775,7 +1812,7 @@ export class SessionManager {
 				try {
 					await session.rpcClient.setModel(provider, modelId);
 					this._writeModelNameFile(session.id, sessionModelPref);
-					this.store.update(session.id, { modelProvider: provider, modelId });
+					this.resolveStoreForSession(session.id).update(session.id, { modelProvider: provider, modelId });
 					console.log(`[session-manager] Set preferred model "${sessionModelPref}" for session ${session.id}`);
 					broadcast(session.clients, {
 						type: "state",
@@ -1815,7 +1852,7 @@ export class SessionManager {
 
 			await session.rpcClient.setModel("aigw", modelToUse.id);
 			this._writeModelNameFile(session.id, modelToUse.id);
-			this.store.update(session.id, { modelProvider: "aigw", modelId: modelToUse.id });
+			this.resolveStoreForSession(session.id).update(session.id, { modelProvider: "aigw", modelId: modelToUse.id });
 			console.log(`[session-manager] Auto-selected aigw model "${modelToUse.id}" for session ${session.id}`);
 
 			broadcast(session.clients, {
@@ -1875,7 +1912,7 @@ export class SessionManager {
 					? containerToHostSessionPath(stateResp.data.sessionFile)
 					: stateResp.data.sessionFile;
 
-				this.store.update(session.id, { agentSessionFile });
+				this.resolveStoreForSession(session.id).update(session.id, { agentSessionFile });
 				return; // success
 			} catch (err) {
 				if (attempt < maxRetries) {
@@ -1940,9 +1977,16 @@ export class SessionManager {
 
 		this.sessions.set(id, session);
 
+		// Resolve project from goal
+		const extProjectId = opts.goalId
+			? this.projectContextManager?.getContextForGoal(opts.goalId)?.project.id
+			: undefined;
+		const extStore = extProjectId ? this.getSessionStore(extProjectId) : this.store;
+		if (extProjectId) session.projectId = extProjectId;
+
 		// Initial persist — structural fields (store.put must precede persistSessionMetadata
 		// since persistSessionMetadata now only does store.update)
-		this.store.put({
+		extStore.put({
 			id,
 			title: opts.title,
 			cwd: opts.cwd,
@@ -1953,6 +1997,7 @@ export class SessionManager {
 			role: opts.role,
 			teamGoalId: opts.teamGoalId,
 			nonInteractive: true,
+			projectId: extProjectId,
 		});
 
 		// Then update with agentSessionFile
@@ -1970,7 +2015,7 @@ export class SessionManager {
 			}
 			session.clients.clear();
 			this.sessions.delete(id);
-			this.store.remove(id);
+			extStore.remove(id);
 			cleanupSessionPrompt(id);
 			console.log(`[session-manager] Unregistered external session ${id}`);
 		};
@@ -2005,36 +2050,39 @@ export class SessionManager {
 		sandboxed?: boolean;
 		projectId?: string;
 	}> {
-		return Array.from(this.sessions.values()).map((s) => ({
-			id: s.id,
-			title: s.title,
-			cwd: s.cwd,
-			status: s.status,
-			createdAt: s.createdAt,
-			lastActivity: s.lastActivity,
-			clientCount: s.clients.size,
-			isCompacting: s.isCompacting,
-			goalId: s.goalId,
-			assistantType: s.assistantType,
-			// Legacy boolean fields for backward compat
-			goalAssistant: s.assistantType === "goal",
-			roleAssistant: s.assistantType === "role",
-			toolAssistant: s.assistantType === "tool",
-			delegateOf: s.delegateOf,
-			role: s.role,
-			teamGoalId: s.teamGoalId,
-			teamLeadSessionId: s.teamLeadSessionId,
-			worktreePath: s.worktreePath,
-			taskId: s.taskId,
-			staffId: s.staffId,
-			accessory: s.accessory,
-			nonInteractive: s.nonInteractive,
-			preview: s.preview,
-			personalities: s.personalities,
-			reattemptGoalId: this.store.get(s.id)?.reattemptGoalId,
-			sandboxed: this.store.get(s.id)?.sandboxed || s.sandboxed,
-			projectId: this.store.get(s.id)?.projectId,
-		}));
+		return Array.from(this.sessions.values()).map((s) => {
+			const ps = this.resolveStoreForSession(s.id).get(s.id);
+			return {
+				id: s.id,
+				title: s.title,
+				cwd: s.cwd,
+				status: s.status,
+				createdAt: s.createdAt,
+				lastActivity: s.lastActivity,
+				clientCount: s.clients.size,
+				isCompacting: s.isCompacting,
+				goalId: s.goalId,
+				assistantType: s.assistantType,
+				// Legacy boolean fields for backward compat
+				goalAssistant: s.assistantType === "goal",
+				roleAssistant: s.assistantType === "role",
+				toolAssistant: s.assistantType === "tool",
+				delegateOf: s.delegateOf,
+				role: s.role,
+				teamGoalId: s.teamGoalId,
+				teamLeadSessionId: s.teamLeadSessionId,
+				worktreePath: s.worktreePath,
+				taskId: s.taskId,
+				staffId: s.staffId,
+				accessory: s.accessory,
+				nonInteractive: s.nonInteractive,
+				preview: s.preview,
+				personalities: s.personalities,
+				reattemptGoalId: ps?.reattemptGoalId,
+				sandboxed: ps?.sandboxed || s.sandboxed,
+				projectId: ps?.projectId,
+			};
+		});
 	}
 
 	/**
@@ -2047,7 +2095,10 @@ export class SessionManager {
 				.filter((s) => s.goalId === goalId)
 				.map((s) => s.id),
 		);
-		for (const ps of this.store.getAll()) {
+		const allPersisted = this.projectContextManager
+			? [...this.projectContextManager.all()].flatMap(ctx => ctx.sessionStore.getAll())
+			: this.store.getAll();
+		for (const ps of allPersisted) {
 			if (ps.goalId === goalId) ids.add(ps.id);
 		}
 		return [...ids];
@@ -2057,7 +2108,7 @@ export class SessionManager {
 		const session = this.sessions.get(id);
 		if (!session) return false;
 		session.title = title;
-		this.store.update(id, { title });
+		this.resolveStoreForSession(id).update(id, { title });
 		broadcast(session.clients, { type: "session_title", sessionId: id, title });
 		return true;
 	}
@@ -2079,7 +2130,7 @@ export class SessionManager {
 		if (title) {
 			const finalTitle = `New goal: ${title}`;
 			session.title = finalTitle;
-			this.store.update(session.id, { title: finalTitle });
+			this.resolveStoreForSession(session.id).update(session.id, { title: finalTitle });
 			broadcast(session.clients, { type: "session_title", sessionId: session.id, title: finalTitle });
 		}
 	}
@@ -2089,7 +2140,7 @@ export class SessionManager {
 		const session = this.sessions.get(id);
 		if (!session) {
 			// Store-only session (dormant/delegate) — update store directly
-			this.store.update(id, updates);
+			this.resolveStoreForId(id).update(id, updates);
 			return true;
 		}
 		if (updates.role !== undefined) session.role = updates.role;
@@ -2099,7 +2150,7 @@ export class SessionManager {
 		if (updates.nonInteractive !== undefined) session.nonInteractive = updates.nonInteractive;
 		if (updates.teamLeadSessionId !== undefined) session.teamLeadSessionId = updates.teamLeadSessionId;
 		if (updates.delegateOf !== undefined) session.delegateOf = updates.delegateOf;
-		this.store.update(id, updates);
+		this.resolveStoreForSession(id).update(id, updates);
 		return true;
 	}
 
@@ -2114,8 +2165,9 @@ export class SessionManager {
 	private ensureStoreEntry(id: string): boolean {
 		const session = this.sessions.get(id);
 		if (!session) return false;
-		if (!this.store.get(id)) {
-			this.store.put({
+		const store = this.resolveStoreForSession(id);
+		if (!store.get(id)) {
+			store.put({
 				id: session.id,
 				title: session.title,
 				cwd: session.cwd,
@@ -2124,6 +2176,7 @@ export class SessionManager {
 				lastActivity: session.lastActivity,
 				goalId: session.goalId,
 				sandboxed: session.sandboxed,
+				projectId: session.projectId,
 			});
 		}
 		return true;
@@ -2132,19 +2185,19 @@ export class SessionManager {
 	/** Get a draft for a session by type. */
 	getDraft(id: string, type: string): unknown | undefined {
 		if (!this.ensureStoreEntry(id)) return undefined;
-		return this.store.getDraft(id, type);
+		return this.resolveStoreForSession(id).getDraft(id, type);
 	}
 
 	/** Set a draft for a session by type. Returns false if session not found. */
 	setDraft(id: string, type: string, data: unknown): boolean {
 		if (!this.ensureStoreEntry(id)) return false;
-		return this.store.setDraft(id, type, data);
+		return this.resolveStoreForSession(id).setDraft(id, type, data);
 	}
 
 	/** Delete a draft for a session by type. */
 	deleteDraft(id: string, type: string): boolean {
 		if (!this.ensureStoreEntry(id)) return false;
-		return this.store.deleteDraft(id, type);
+		return this.resolveStoreForSession(id).deleteDraft(id, type);
 	}
 
 	/**
@@ -2163,7 +2216,7 @@ export class SessionManager {
 			const stateResp = await session.rpcClient.getState();
 			if (stateResp.success) agentSessionFile = stateResp.data?.sessionFile;
 		} catch {
-			const persisted = this.store.get(id);
+			const persisted = this.resolveStoreForSession(id).get(id);
 			agentSessionFile = persisted?.agentSessionFile;
 		}
 
@@ -2228,9 +2281,10 @@ export class SessionManager {
 
 		const rpcClient = new RpcBridge(bridgeOptions);
 		let switchingSession = true;
+		const roleStore = this.resolveStoreForSession(id);
 		const unsub = rpcClient.onEvent((event: any) => {
 			session.lastActivity = Date.now();
-			this.store.update(id, { lastActivity: session.lastActivity });
+			roleStore.update(id, { lastActivity: session.lastActivity });
 			this.handleAgentLifecycle(session, event);
 			session.eventBuffer.push(event);
 			broadcast(session.clients, { type: "event", data: event });
@@ -2241,7 +2295,7 @@ export class SessionManager {
 
 		// Restore conversation from session file
 		if (agentSessionFile && fs.existsSync(agentSessionFile)) {
-			const rolePersisted = this.store.get(id);
+			const rolePersisted = roleStore.get(id);
 			const roleSwitchPath = rolePersisted?.sandboxed ? hostToContainerSessionPath(agentSessionFile) : agentSessionFile;
 			const switchResp = await rpcClient.sendCommand(
 				{ type: "switch_session", sessionPath: roleSwitchPath },
@@ -2262,7 +2316,7 @@ export class SessionManager {
 		session.allowedTools = role.allowedTools;
 		if (opts?.personalities) session.personalities = opts.personalities;
 
-		this.store.update(id, { role: role.name, accessory: role.accessory, personalities: opts?.personalities });
+		roleStore.update(id, { role: role.name, accessory: role.accessory, personalities: opts?.personalities });
 
 		broadcast(session.clients, { type: "session_status", status: "idle" } as any);
 
@@ -2294,7 +2348,7 @@ export class SessionManager {
 			const stateResp = await session.rpcClient.getState();
 			if (stateResp.success) agentSessionFile = stateResp.data?.sessionFile;
 		} catch {
-			const persisted = this.store.get(id);
+			const persisted = this.resolveStoreForSession(id).get(id);
 			agentSessionFile = persisted?.agentSessionFile;
 		}
 
@@ -2370,9 +2424,10 @@ export class SessionManager {
 
 		const rpcClient = new RpcBridge(bridgeOptions);
 		let switchingSession = true;
+		const persoStore = this.resolveStoreForSession(id);
 		const unsub = rpcClient.onEvent((event: any) => {
 			session.lastActivity = Date.now();
-			this.store.update(id, { lastActivity: session.lastActivity });
+			persoStore.update(id, { lastActivity: session.lastActivity });
 			this.handleAgentLifecycle(session, event);
 			session.eventBuffer.push(event);
 			broadcast(session.clients, { type: "event", data: event });
@@ -2382,7 +2437,7 @@ export class SessionManager {
 		await rpcClient.start();
 
 		if (agentSessionFile && fs.existsSync(agentSessionFile)) {
-			const persoPersisted = this.store.get(id);
+			const persoPersisted = persoStore.get(id);
 			const persoSwitchPath = persoPersisted?.sandboxed ? hostToContainerSessionPath(agentSessionFile) : agentSessionFile;
 			const switchResp = await rpcClient.sendCommand(
 				{ type: "switch_session", sessionPath: persoSwitchPath },
@@ -2400,7 +2455,7 @@ export class SessionManager {
 		session.status = "idle";
 		session.personalities = personalityNames;
 
-		this.store.update(id, { personalities: personalityNames });
+		persoStore.update(id, { personalities: personalityNames });
 
 		broadcast(session.clients, { type: "session_status", status: "idle" } as any);
 
@@ -2443,7 +2498,7 @@ export class SessionManager {
 		const title = await generateSessionTitle(messages, this.getTitleGenOptions());
 		if (title) {
 			session.title = title;
-			this.store.update(session.id, { title });
+			this.resolveStoreForSession(session.id).update(session.id, { title });
 			broadcast(session.clients, { type: "session_title", sessionId: session.id, title });
 		}
 	}
@@ -2459,7 +2514,7 @@ export class SessionManager {
 			const title = await generateSessionTitle(messages, this.getTitleGenOptions());
 			if (title) {
 				session.title = title;
-				this.store.update(session.id, { title });
+				this.resolveStoreForSession(session.id).update(session.id, { title });
 				broadcast(session.clients, { type: "session_title", sessionId: session.id, title });
 			}
 		} catch (err) {
@@ -2477,7 +2532,7 @@ export class SessionManager {
 		if (existing && existing.status !== "terminated") return; // already alive
 
 		// Try to restore from persisted data
-		const persisted = this.store.get(sessionId);
+		const persisted = this.resolveStoreForId(sessionId).get(sessionId);
 		if (!persisted) {
 			throw new Error(`Cannot restore session ${sessionId}: no persisted data found`);
 		}
@@ -2502,7 +2557,7 @@ export class SessionManager {
 
 	/** Persist model provider/id so archived sessions can display model info. */
 	persistSessionModel(sessionId: string, provider: string, modelId: string): void {
-		this.store.update(sessionId, { modelProvider: provider, modelId });
+		this.resolveStoreForSession(sessionId).update(sessionId, { modelProvider: provider, modelId });
 	}
 
 	async terminateSession(id: string): Promise<boolean> {
@@ -2516,9 +2571,12 @@ export class SessionManager {
 			await this.terminateSession(child.id);
 		}
 		// Also archive persisted-but-not-in-memory delegate sessions
-		for (const ps of this.store.getLive()) {
+		const allLiveForTerminate = this.projectContextManager
+			? [...this.projectContextManager.getAllLiveSessions()]
+			: this.store.getLive();
+		for (const ps of allLiveForTerminate) {
 			if (ps.delegateOf === id && !this.sessions.has(ps.id)) {
-				this.store.archive(ps.id);
+				this.getSessionStore(ps.projectId).archive(ps.id);
 			}
 		}
 
@@ -2561,11 +2619,12 @@ export class SessionManager {
 		this.sessions.delete(id);
 		// Archive the session — keep metadata for 7 days.
 		// But sessions with no agentSessionFile are unrestorable, so just remove them.
-		const persisted = this.store.get(id);
+		const terminateStore = this.resolveStoreForSession(id);
+		const persisted = terminateStore.get(id);
 		if (persisted?.agentSessionFile) {
-			this.store.archive(id);
+			terminateStore.archive(id);
 		} else {
-			this.store.remove(id);
+			terminateStore.remove(id);
 		}
 		// Don't remove color or session prompt — they're needed for archived view
 		return true;
@@ -2573,26 +2632,27 @@ export class SessionManager {
 
 	/** Get an archived session's metadata. */
 	getArchivedSession(id: string): PersistedSession | undefined {
-		const ps = this.store.get(id);
+		const ps = this.resolveStoreForId(id).get(id);
 		return ps?.archived ? ps : undefined;
 	}
 
 	/** Archive a session directly in the store (for dormant/store-only sessions). */
 	storeArchive(id: string): boolean {
-		return this.store.archive(id);
+		return this.resolveStoreForId(id).archive(id);
 	}
 
 	/** Update metadata on an archived session (stored in the session store). */
 	updateArchivedMeta(id: string, updates: { teamLeadSessionId?: string }): boolean {
-		const ps = this.store.get(id);
+		const store = this.resolveStoreForId(id);
+		const ps = store.get(id);
 		if (!ps?.archived) return false;
-		this.store.update(id, updates);
+		store.update(id, updates);
 		return true;
 	}
 
 	/** Parse the .jsonl file for an archived session and return messages. */
 	getArchivedMessages(id: string): unknown[] {
-		const ps = this.store.get(id);
+		const ps = this.resolveStoreForId(id).get(id);
 		if (!ps?.archived || !ps.agentSessionFile) return [];
 		try {
 			if (!fs.existsSync(ps.agentSessionFile)) return [];
@@ -2644,7 +2704,10 @@ export class SessionManager {
 		archived: boolean;
 		archivedAt?: number;
 	}> {
-		return this.store.getArchived().map((ps) => ({
+		const allArchived = this.projectContextManager
+			? [...this.projectContextManager.all()].flatMap(ctx => ctx.sessionStore.getArchived())
+			: this.store.getArchived();
+		return allArchived.map((ps) => ({
 			id: ps.id,
 			title: ps.title,
 			cwd: ps.cwd,
@@ -2674,7 +2737,7 @@ export class SessionManager {
 
 	/** Permanently purge a single archived session immediately. */
 	async purgeArchivedSession(id: string): Promise<boolean> {
-		const ps = this.store.get(id);
+		const ps = this.resolveStoreForId(id).get(id);
 		if (!ps?.archived) return false;
 		await this.purgeOneSession(ps);
 		return true;
@@ -2684,7 +2747,9 @@ export class SessionManager {
 	async purgeExpiredArchives(): Promise<void> {
 		const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 		const cutoff = Date.now() - SEVEN_DAYS_MS;
-		const archived = this.store.getArchived();
+		const archived = this.projectContextManager
+			? [...this.projectContextManager.all()].flatMap(ctx => ctx.sessionStore.getArchived())
+			: this.store.getArchived();
 		for (const ps of archived) {
 			if (ps.archivedAt && ps.archivedAt < cutoff) {
 				try {
@@ -2701,8 +2766,9 @@ export class SessionManager {
 	private async purgeOneSession(ps: PersistedSession): Promise<void> {
 		// Remove from search index
 		try {
-			this.searchIndex.removeMessagesForSession(ps.id);
-			this.searchIndex.removeSession(ps.id);
+			const purgeSearchIndex = this.resolveSearchIndex(ps);
+			purgeSearchIndex.removeMessagesForSession(ps.id);
+			purgeSearchIndex.removeSession(ps.id);
 		} catch (err) {
 			console.error(`[session-manager] Failed to remove session ${ps.id} from search index:`, err);
 		}
@@ -2741,7 +2807,7 @@ export class SessionManager {
 		}
 
 		// Remove from store
-		this.store.purge(ps.id);
+		this.resolveStoreForId(ps.id).purge(ps.id);
 	}
 
 	/** Start the archive purge schedule — call after restoreSessions(). */
@@ -2764,7 +2830,7 @@ export class SessionManager {
 
 		// If session is dormant (failed restore), try to revive it
 		if (session.status === "terminated") {
-			const ps = this.store.get(sessionId);
+			const ps = this.resolveStoreForId(sessionId).get(sessionId);
 			if (ps && fs.existsSync(ps.agentSessionFile)) {
 				console.log(`[session-manager] Client connected to dormant session "${session.title}" — attempting restore`);
 				this.restoreSession(ps)
@@ -2850,7 +2916,7 @@ export class SessionManager {
 			}
 		} catch {
 			// Process may be unresponsive — try the persisted store
-			const persisted = this.store.get(id);
+			const persisted = this.resolveStoreForSession(id).get(id);
 			agentSessionFile = persisted?.agentSessionFile;
 		}
 
@@ -2897,9 +2963,10 @@ export class SessionManager {
 
 			const rpcClient = new RpcBridge(bridgeOptions);
 			let switchingSession = true;
+			const abortStore = this.resolveStoreForSession(id);
 			const unsub = rpcClient.onEvent((event: any) => {
 				session.lastActivity = Date.now();
-				this.store.update(id, { lastActivity: session.lastActivity });
+				abortStore.update(id, { lastActivity: session.lastActivity });
 
 				this.handleAgentLifecycle(session, event);
 
@@ -2912,7 +2979,7 @@ export class SessionManager {
 
 			// Resume session if we have the session file
 			if (agentSessionFile && fs.existsSync(agentSessionFile)) {
-				const abortPersisted = this.store.get(id);
+				const abortPersisted = abortStore.get(id);
 				const abortSwitchPath = abortPersisted?.sandboxed ? hostToContainerSessionPath(agentSessionFile) : agentSessionFile;
 				const switchResp = await rpcClient.sendCommand(
 					{ type: "switch_session", sessionPath: abortSwitchPath },
@@ -2954,7 +3021,7 @@ export class SessionManager {
 			// This is authoritative — the in-memory status is always correct,
 			// and we write it here to handle the case where shutdown() races
 			// with a pending agent_end that hasn't flushed to disk yet.
-			this.store.update(id, { wasStreaming: session.status === "streaming", streamingStartedAt: session.streamingStartedAt });
+			this.resolveStoreForSession(id).update(id, { wasStreaming: session.status === "streaming", streamingStartedAt: session.streamingStartedAt });
 
 			session.unsubscribe();
 			await session.rpcClient.stop();
@@ -2968,11 +3035,19 @@ export class SessionManager {
 		}
 
 		// Flush any debounced store writes before exit
-		this.store.flush();
+		if (this.projectContextManager) {
+			for (const ctx of this.projectContextManager.all()) ctx.sessionStore.flush();
+		} else {
+			this.store.flush();
+		}
 
 		// Close search index
 		try {
-			this.searchIndex.close();
+			if (this.projectContextManager) {
+				// ProjectContextManager.closeAll() handles search index closing
+			} else {
+				this.searchIndex.close();
+			}
 		} catch (err) {
 			console.error("[search] Failed to close search index:", err);
 		}


### PR DESCRIPTION
Fix all remaining `this.store` and `this.searchIndex` references in `session-manager.ts` that bypass per-project store routing.

## Changes

- Add `resolveStoreForSession(id)` — resolves correct SessionStore for in-memory sessions
- Add `resolveStoreForId(id)` — resolves correct SessionStore for any session (in-memory or archived), searching across all project stores
- Add `resolveSearchIndex(session)` — resolves correct SearchIndex based on session's projectId

### Fixed methods (30+ call sites):
- Archived session CRUD (getArchivedSession, storeArchive, updateArchivedMeta, getArchivedMessages, purgeArchivedSession, purgeOneSession)
- List aggregation (listArchivedSessions, purgeExpiredArchives, getAllSessionIdsForGoal, listSessions enrichment, cleanupOrphanedNonInteractiveSessions)
- registerExternalSession (route put/remove via goal's project)
- indexMessage (route to session's project SearchIndex)
- Force-abort agent restart (store.get/update for session state)
- shutdown (flush all project stores, close correct search index)
- addClient revive path
- assignRole / updatePersonalities (event handlers and metadata)
- Title generation, draft storage, model persistence
- Queue persistence, streaming state updates
- ensureStoreEntry, ensureSessionAlive, updateSessionMeta
- terminateSession (delegate cascade, archive routing)

All remaining `this.store.` references are in fallback paths guarded by `if (!this.projectContextManager)` checks — those are correct and untouched.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)