### PR TITLE
Fix project-scoped store routing in session-manager and team-manager

### DIFF
--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -322,14 +322,23 @@ export class SessionManager {
 	buildPipelineContext(projectId?: string): PipelineContext {
 		const resolvedStore = this.getSessionStore(projectId);
 		const resolvedSearchIndex = this.getSearchIndexForProject(projectId);
+		let resolvedGoalManager = this.goalManager;
+		let resolvedTaskManager = this.taskManager;
+		if (projectId && this.projectContextManager) {
+			const ctx = this.projectContextManager.getOrCreate(projectId);
+			if (ctx) {
+				resolvedGoalManager = new GoalManager(ctx.goalStore);
+				resolvedTaskManager = new TaskManager(ctx.taskStore);
+			}
+		}
 		return {
 			agentCliPath: this.agentCliPath,
 			systemPromptPath: this.systemPromptPath,
 			roleManager: this.roleManager ?? null,
 			toolManager: this.toolManager ?? null,
 			mcpManager: this.mcpManager,
-			goalManager: this.goalManager,
-			taskManager: this.taskManager,
+			goalManager: resolvedGoalManager,
+			taskManager: resolvedTaskManager,
 			personalityManager: this.personalityManager ?? null,
 			projectConfigStore: this.projectConfigStore ?? null,
 			sandboxPool: this.sandboxPool,

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -903,7 +903,12 @@ export class TeamManager {
 				worktreePath: agent.worktreePath,
 			});
 			// Store repoPath and branch in the session store for later purge cleanup
-			const store = (this.sessionManager as any).store;
+			const projectCtx = goalId && this.config.projectContextManager
+				? this.config.projectContextManager.getContextForGoal(goalId)
+				: null;
+			const store = projectCtx
+				? projectCtx.sessionStore
+				: (this.sessionManager as any).store;
 			if (store) {
 				store.update(sessionId, { repoPath: goal.repoPath, branch: agent.branch });
 			}
@@ -1081,7 +1086,12 @@ export class TeamManager {
 		if (entry.teamLeadSessionId) {
 			const goal = this.resolveGoal(goalId);
 			if (goal?.repoPath) {
-				const store = (this.sessionManager as any).store;
+				const projectCtx = this.config.projectContextManager
+					? this.config.projectContextManager.getContextForGoal(goalId)
+					: null;
+				const store = projectCtx
+					? projectCtx.sessionStore
+					: (this.sessionManager as any).store;
 				if (store) {
 					store.update(entry.teamLeadSessionId, {
 						repoPath: goal.repoPath,


### PR DESCRIPTION
Fix two issues with per-project state isolation:

1. **session-manager.ts buildPipelineContext()**: goalManager and taskManager now resolve from ProjectContext when projectId is provided, instead of always using the default project's managers.

2. **team-manager.ts**: Replace unsafe `(this.sessionManager as any).store` casts at dismissAgent (~line 906) and teardownTeam (~line 1084) with project-aware store lookups via ProjectContextManager.

Type-check passes. Unit test failures are pre-existing (missing dist/ build artifacts in worktree).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)