### PR TITLE
Per-project state isolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,9 +66,9 @@ UI-only changes need only unit tests. Server changes need E2E too.
 
 **Add/use MCP servers**: Configure in `.mcp.json` (project), `.bobbit/config/mcp.json` (overrides), or any of 7 discovery locations. See @docs/internals.md#mcp-servers for full priority list.
 
-**Add a goal feature**: CRUD in `goal-manager.ts`/`goal-store.ts`. REST in `server.ts`. Assistant prompt in `goal-assistant.ts`. Proposal parsing in `remote-agent.ts` `_checkForGoalProposal()`. Re-attempt: `buildReattemptContext()`, `startReattempt()`. Goals carry an optional `projectId` linking them to a registered project.
+**Add a goal feature**: CRUD in `goal-manager.ts`/`goal-store.ts`. REST in `server.ts`. Assistant prompt in `goal-assistant.ts`. Proposal parsing in `remote-agent.ts` `_checkForGoalProposal()`. Re-attempt: `buildReattemptContext()`, `startReattempt()`. Goals carry an optional `projectId` linking them to a registered project. All goal/task/gate operations route through `ProjectContextManager` to resolve the correct per-project store.
 
-**Modify a store constructor**: All stores accept `stateDir` or `configDir` as a constructor parameter (not module-level globals). State stores (GoalStore, SessionStore, etc.) take `stateDir: string`; config stores (RoleStore, WorkflowStore, etc.) take `configDir: string`. When adding a new store, follow this pattern — never call `bobbitStateDir()` or `bobbitConfigDir()` at module level. See `ProjectContext` in `project-context.ts` for how stores are wired together.
+**Modify a store constructor**: All stores accept `stateDir` or `configDir` as a constructor parameter (not module-level globals). State stores (GoalStore, SessionStore, etc.) take `stateDir: string`; config stores (RoleStore, WorkflowStore, etc.) take `configDir: string`. When adding a new store, follow this pattern — never call `bobbitStateDir()` or `bobbitConfigDir()` at module level. See `ProjectContext` in `project-context.ts` for how stores are wired together. Managers (`GoalManager`, `TaskManager`, `StaffManager`) accept their store instance directly — they no longer create stores internally.
 
 **Add/modify session creation logic**: Session creation uses a plan/execute pipeline in `session-setup.ts`. The three creation modes (normal, worktree, delegate) share composable pipeline steps (`resolveBridgeOptions`, `resolveGoalExtensions`, `resolveTools`, `resolvePrompt`, `resolveToolActivation`) with different executors (`executePlan` for normal/delegate, `executeWorktreeAsync` for worktree). `session-manager.ts` contains thin wrappers (`createSession`, `createDelegateSession`) that build a `SessionSetupPlan` and delegate to the pipeline. Persistence uses put-once-then-update: `persistOnce()` does a single `store.put()` at creation, then `persistSessionMetadata()` only calls `store.update()` for the `agentSessionFile` field.
 
@@ -90,11 +90,12 @@ Quick pointers for the most common issues:
 
 - **Streaming sluggishness**: `AgentInterface` must NOT call `requestUpdate()` in the `message_update` handler — only `StreamingMessageContainer.setMessage()` updates during streaming (rAF-batched). See @docs/debugging.md#streaming-performance for full checklist.
 - **Duplicate messages**: Check `flushDeferredMessage()` in `remote-agent.ts` — `MessageList` and `StreamingMessageContainer` must never overlap.
-- **Session persistence**: Check `.bobbit/state/sessions.json`. Missing `.jsonl` = session skipped on restore.
+- **Session persistence**: Check `<project-root>/.bobbit/state/sessions.json` (per-project). Missing `.jsonl` = session skipped on restore.
 - **Sandbox**: `GET /api/sandbox-status` for Docker state. Proxy logs prefixed `[sandbox-proxy]`.
-- **Search**: Delete `.bobbit/state/search.db` and restart to rebuild index. Schema version 3 adds `project_id` column for multi-project filtering. See @docs/debugging.md#search-index for full checklist.
+- **Search**: Each project has its own `<project-root>/.bobbit/state/search.db`. Delete and restart to rebuild. Searches aggregate across all project indexes. See @docs/debugging.md#search-index for full checklist.
 - **Gates**: Check `GET /api/goals/:id/gates` for dependency state.
-- **Multi-project**: Project registry at `.bobbit/state/projects.json`. Server CWD auto-registered as default project on startup. Check `GET /api/projects` for registered projects. Sessions/goals carry optional `projectId`; filter with `?projectId=` on list endpoints. Per-project config: `GET /api/projects/:id/config/resolved` shows resolved values with source. See [docs/internals.md](docs/internals.md#multi-project-architecture) for architecture.
+- **Multi-project / per-project state**: Each project stores its own state in `<project-root>/.bobbit/state/` (goals, sessions, tasks, teams, gates, search index, costs). The server aggregates via `ProjectContextManager`. Check `GET /api/projects` for registered projects. Sessions/goals carry optional `projectId`; filter with `?projectId=` on list endpoints. Per-project config: `GET /api/projects/:id/config/resolved` shows resolved values with source. See [docs/internals.md](docs/internals.md#multi-project-architecture) for architecture.
+- **State migration**: On first startup after upgrade, centralized state files are distributed to per-project dirs based on `projectId` tags. Central files renamed with `.pre-migration` suffix. Check for `.bobbit/state/.migrated-to-per-project` marker. See @docs/internals.md#state-migration for details.
 
 ## Git conventions
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -42,7 +42,7 @@ Scannable checklists for common issues. Each entry: symptom → where to look �
 
 ## Session persistence
 
-- Check `.bobbit/state/sessions.json`
+- Check `<project-root>/.bobbit/state/sessions.json` (per-project, not centralized)
 - Initial persist happens via `persistOnce()` in `session-setup.ts` — a single `store.put()` with all structural fields at creation time
 - `persistSessionMetadata()` only calls `store.update()` (never `store.put()`) — updates `agentSessionFile` once the agent reports it
 - `persistSessionMetadata()` retries 3 times with backoff (500ms, 1s, 2s) on failure
@@ -99,7 +99,8 @@ Scannable checklists for common issues. Each entry: symptom → where to look �
 
 ## Search index
 
-- `.bobbit/state/search.db` is a rebuildable cache — delete and restart to rebuild
+- Each project has its own `<project-root>/.bobbit/state/search.db` — delete and restart to rebuild
+- `ProjectContextManager.searchAll()` aggregates results across all project indexes
 - Schema version is 3 (added `project_id` column for multi-project filtering). Version mismatch triggers automatic rebuild on next server start
 - Check `better-sqlite3` loaded correctly (native addon)
 - FTS5 on 10K docs < 10ms — slow search means network/serialization bottleneck
@@ -114,16 +115,21 @@ Scannable checklists for common issues. Each entry: symptom → where to look �
 - Missing items? Check `archivedAt` is set (older items may lack it)
 - Count mismatch? Verify total from paginated response metadata
 
-## Multi-project
+## Multi-project / per-project state
 
-- Project registry at `.bobbit/state/projects.json` — check file exists and is valid JSON
+- State is per-project: goals, sessions, tasks, teams, gates, search, costs all live in `<project-root>/.bobbit/state/`
+- `ProjectContextManager` manages all `ProjectContext` instances and routes store access
+- Project registry at `<server-cwd>/.bobbit/state/projects.json` — check file exists and is valid JSON
 - Server CWD auto-registered as default project via `ensureDefaultProject()` on startup
 - `GET /api/projects` to list all registered projects
-- Sessions/goals not appearing? Check `projectId` field matches the expected project
+- Sessions/goals not appearing? Check `projectId` field matches the expected project. Verify the correct project's `sessions.json` / `goals.json` contains the record
 - Sidebar not grouping? Only groups when multiple projects are registered
 - Project registration failing? `rootPath` must be absolute and exist on disk; duplicate paths are rejected
-- Search not filtering by project? Verify `?projectId=` query param is passed; check `project_id` column exists in search.db (schema v3)
+- Search not filtering by project? Verify `?projectId=` query param is passed; each project has its own `search.db`
 - Config not cascading? Check all three `.bobbit/config/` directories (global, server, project) and verify `resolveScalarConfig()` / `resolveEntities()` return expected scope
+- **State migration**: On first startup after upgrade, central state is distributed to per-project dirs. Check for `.bobbit/state/.migrated-to-per-project` marker. Central files renamed with `.pre-migration` suffix (not deleted). If migration didn't run, check that projects are registered before migration runs
+- **Store routing bugs**: All store access must go through `ProjectContextManager` — direct `this.store` calls bypass per-project routing. `SessionManager` uses `resolveStoreForSession()` / `resolveStoreForId()` to find the correct per-project `SessionStore`
+- **Known limitations**: Staff is only per-default-project (API doesn't route staff by project yet). Cost tracking uses the default project's `CostTracker`. `active-verifications.json` stays in central state dir
 
 ## Gate re-signal cancellation
 

--- a/docs/goals-workflows-tasks.md
+++ b/docs/goals-workflows-tasks.md
@@ -278,12 +278,14 @@ Here's the typical flow for a team goal with a workflow:
 
 ## Storage
 
+State is per-project — each project has its own copies of these files in `<project-root>/.bobbit/state/`. The server aggregates across all projects via `ProjectContextManager`.
+
 | Location | What |
 |---|---|
 | `.bobbit/config/workflows/*.yaml` | Workflow templates (repo-local, version controlled) |
-| `.bobbit/state/goals.json` | Goals with snapshotted workflows (includes `projectId`) |
-| `.bobbit/state/gates.json` | Gate state and signal history |
-| `.bobbit/state/tasks.json` | Tasks with workflow gate links |
+| `<project>/.bobbit/state/goals.json` | Goals with snapshotted workflows (includes `projectId`) |
+| `<project>/.bobbit/state/gates.json` | Gate state and signal history |
+| `<project>/.bobbit/state/tasks.json` | Tasks with workflow gate links |
 
 ## Key source files
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -30,16 +30,77 @@ Key behaviors:
 - `remove()` only unregisters — it does not delete files. Callers guard against removing the default project.
 - Persistence is atomic (write to `.tmp` then rename).
 
+### Per-project state isolation
+
+Each registered project is a self-contained unit on disk. State (goals, sessions, tasks, teams, gates, search, costs) lives in `<project-root>/.bobbit/state/`, not in a central directory. The server aggregates across all projects.
+
+```
+<project-root>/.bobbit/
+  config/          # Project config (roles, tools, etc.)
+  state/
+    goals.json     # Goals for THIS project
+    sessions.json  # Sessions for THIS project
+    tasks.json     # Tasks for THIS project's goals
+    team-state.json # Team state
+    gates.json     # Gate state and signals
+    staff.json     # Staff agents
+    search.db      # Search index for THIS project
+    costs/         # Cost tracking
+
+<server-cwd>/.bobbit/
+  state/
+    projects.json     # Global project registry (only truly global state)
+    preferences.json  # Global UI preferences
+    token             # Auth token
+    gateway-url       # Gateway address
+    colors.json       # Session colors
+```
+
+This means removing a project cleanly removes its state, and pointing a different Bobbit instance at a project directory gives access to its history.
+
 ### ProjectContext (scoped stores)
 
 `ProjectContext` (`project-context.ts`) holds a complete set of stores scoped to one project. Every store constructor accepts a directory parameter (`stateDir` or `configDir`) instead of using module-level globals:
 
-- **State stores** (stateDir): GoalStore, SessionStore, GateStore, TaskStore, TeamStore, StaffStore, ColorStore
+- **State stores** (stateDir): GoalStore, SessionStore, GateStore, TaskStore, TeamStore, StaffStore, ColorStore, SearchIndex, CostTracker
 - **Config stores** (configDir): RoleStore, PersonalityStore, WorkflowStore, ToolManager, ProjectConfigStore, ToolGroupPolicyStore
+- **Managers**: GoalManager (wraps GoalStore)
 
 Directories derive from the project's `rootPath`:
 - `stateDir` = `<rootPath>/.bobbit/state/`
 - `configDir` = `<rootPath>/.bobbit/config/`
+
+`ProjectContext.open()` initializes the search index and wires mutation hooks so goal/session changes are automatically indexed. `ProjectContext.close()` flushes the session store and closes the search index.
+
+### ProjectContextManager
+
+`ProjectContextManager` (`project-context-manager.ts`) is the central registry of `ProjectContext` instances. It initializes a context for each registered project on startup and provides aggregation methods for cross-project queries.
+
+Key responsibilities:
+- **Lazy creation**: `getOrCreate(projectId)` — creates and opens a context on first access
+- **Store routing**: `getContextForGoal(goalId)` / `getContextForSession(sessionId)` — scans all contexts to find the owning project
+- **Aggregation**: `getAllLiveGoals()`, `getAllLiveSessions()`, `searchAll()` — merge results across all projects
+- **Generation counters**: Sums per-project generation counters so clients detect any change via a single `?since=N` parameter
+- **Lifecycle**: `closeAll()` on shutdown, `remove(projectId)` when a project is unregistered
+
+All API endpoints and WebSocket handlers resolve the correct per-project store through `ProjectContextManager` rather than accessing stores directly. Managers (`GoalManager`, `TaskManager`, `StaffManager`) accept store instances directly — they no longer create stores internally.
+
+### State migration
+
+On first startup after upgrading to per-project state, `migrateToPerProjectState()` (`state-migration.ts`) distributes centralized state to per-project directories:
+
+1. Reads central `goals.json`, `sessions.json`, `tasks.json`, `team-state.json`, `gates.json`, `staff.json`
+2. Groups records by `projectId` (tasks/teams/gates resolve via their goal's project)
+3. Merges into each project's `<rootPath>/.bobbit/state/` (avoids duplicates by ID)
+4. Staff agents (no `projectId`) go to the default project
+5. Renames central files with `.pre-migration` suffix (not deleted)
+6. Writes `.bobbit/state/.migrated-to-per-project` marker to prevent re-running
+
+The migration is idempotent and handles missing files gracefully (fresh installs have nothing to migrate). Central `search.db` is renamed — per-project indexes rebuild automatically on first access.
+
+**What stays global**: `projects.json`, auth token, gateway URL, preferences, session colors, PR status.
+
+**Known limitations**: Staff is only per-default-project (the API doesn't yet route staff by project). Cost tracking uses the default project's `CostTracker` for all sessions. `active-verifications.json` stays in the central state dir (transient operational state).
 
 ### Config resolution (3-tier hierarchy)
 
@@ -69,7 +130,7 @@ Each registered project can override system-level settings (from `project.yaml`)
 
 **Resolution cascade**: For each config key, `resolveScalarConfig()` checks project → server → global → built-in default. The first defined value wins. This reuses the same `config-resolver.ts` infrastructure described in [Config resolution](#config-resolution-3-tier-hierarchy) above.
 
-**Server-side caching**: The server lazily instantiates a `ProjectContext` per project via `getOrCreateProjectContext()` (cached in a `Map<string, ProjectContext>` in `server.ts`). This avoids creating stores for projects that are never accessed during a server lifetime.
+**Server-side caching**: `ProjectContextManager` lazily instantiates a `ProjectContext` per project via `getOrCreate()`. On startup, `initAll()` pre-creates contexts for all registered projects.
 
 **REST API**:
 
@@ -132,7 +193,9 @@ Session/goal/search endpoints accept optional `?projectId=` filter:
 | File | Purpose |
 |---|---|
 | `project-registry.ts` | Project CRUD and persistence |
-| `project-context.ts` | Scoped store container per project |
+| `project-context.ts` | Scoped store container per project (with `open()`/`close()` lifecycle) |
+| `project-context-manager.ts` | Central registry of contexts, aggregation, store routing |
+| `state-migration.ts` | One-time migration from centralized to per-project state |
 | `config-resolver.ts` | 3-tier config cascade |
 | `project-assistant.ts` | Guided project registration |
 
@@ -171,7 +234,7 @@ All tool access uses a **grant policy** system. Every tool resolves to one of fo
 
 ## Full-text search & paginated archives
 
-SQLite FTS5 via `better-sqlite3`. Index at `.bobbit/state/search.db` (rebuildable cache).
+SQLite FTS5 via `better-sqlite3`. Each project has its own index at `<project-root>/.bobbit/state/search.db` (rebuildable cache). `ProjectContextManager.searchAll()` aggregates results across all project indexes.
 
 **Key files:** `search-index.ts`, `message-extractor.ts`, `SearchBox.ts`, `SearchResults.ts`, `search-page.ts`.
 
@@ -393,19 +456,29 @@ See [goals-workflows-tasks.md](goals-workflows-tasks.md) for the full architectu
 | `tool-group-policies.yaml` | `ToolGroupPolicyStore` | Group grant policies |
 | `mcp.json` | `McpManager` | MCP server overrides |
 
-### `.bobbit/state/` — gitignored runtime
+### `<project-root>/.bobbit/state/` — per-project, gitignored
+
+Each registered project has its own state directory. All store data is scoped to the owning project.
+
+| File / Directory | Owner | Purpose |
+|---|---|---|
+| `goals.json` | `GoalStore` | Goal definitions |
+| `sessions.json` | `SessionStore` | Session metadata |
+| `tasks.json` | `TaskStore` | Task state |
+| `gates.json` | `GateStore` | Gate state + signals |
+| `team-state.json` | `TeamStore` | Team agents/roles |
+| `staff.json` | `StaffStore` | Staff agents |
+| `search.db` | `SearchIndex` | FTS5 search index |
+| `costs/` | `CostTracker` | Token/cost data |
+
+### `<server-cwd>/.bobbit/state/` — global, gitignored
+
+Only truly global state lives in the server's central state directory.
 
 | File / Directory | Owner | Purpose |
 |---|---|---|
 | `projects.json` | `ProjectRegistry` | Registered project definitions |
 | `token` | `token.ts` | Auth token (0600) |
-| `sessions.json` | `SessionStore` | Session metadata |
-| `goals.json` | `GoalStore` | Goal definitions |
-| `tasks.json` | `TaskStore` | Task state |
-| `gates.json` | `GateStore` | Gate state + signals |
-| `team-state.json` | `TeamStore` | Team agents/roles |
-| `staff.json` | `StaffStore` | Staff agents |
-| `session-costs.json` | `CostTracker` | Token/cost data |
 | `session-colors.json` | `ColorStore` | Session colors |
 | `preferences.json` | `PreferencesStore` | Key-value prefs |
 | `session-prompts/` | `system-prompt.ts` | Per-session prompts |
@@ -414,7 +487,6 @@ See [goals-workflows-tasks.md](goals-workflows-tasks.md) for the full architectu
 | `gateway-restart` | `harness.ts` | Dev restart sentinel |
 | `rpc-debug.log` | `rpc-bridge.ts` | RPC event log |
 | `mcp-extensions/` | `tool-activation.ts` | MCP proxy extensions |
-| `search.db` | `SearchIndex` | FTS5 search index |
 
 ### Global
 

--- a/src/server/agent/goal-manager.ts
+++ b/src/server/agent/goal-manager.ts
@@ -2,7 +2,6 @@ import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { GoalStore, type GoalState, type PersistedGoal } from "./goal-store.js";
 import { createWorktree, isGitRepo, getRepoRoot } from "../skills/git.js";
-import { bobbitStateDir } from "../bobbit-dir.js";
 import type { WorkflowStore } from "./workflow-store.js";
 
 /**
@@ -24,8 +23,8 @@ export class GoalManager {
 	/** Track in-flight worktree setups to prevent concurrent calls for the same goal. */
 	private _setupsInFlight = new Set<string>();
 
-	constructor(workflowStore?: WorkflowStore, stateDir?: string) {
-		this.store = new GoalStore(stateDir ?? bobbitStateDir());
+	constructor(goalStore: GoalStore, workflowStore?: WorkflowStore) {
+		this.store = goalStore;
 		this.workflowStore = workflowStore;
 		// Mark any goals stuck in "preparing" from a previous run as error
 		this._recoverStuckSetups();

--- a/src/server/agent/project-context-manager.ts
+++ b/src/server/agent/project-context-manager.ts
@@ -1,0 +1,233 @@
+import { ProjectContext } from "./project-context.js";
+import { ProjectRegistry } from "./project-registry.js";
+import type { PersistedGoal } from "./goal-store.js";
+import type { PersistedSession } from "./session-store.js";
+import type { SearchResults, SearchResult } from "../search/search-index.js";
+
+/**
+ * Central registry of ProjectContext instances.
+ *
+ * Manages per-project state contexts and provides aggregation methods
+ * for cross-project queries (goals, sessions, search).
+ */
+export class ProjectContextManager {
+  private contexts = new Map<string, ProjectContext>();
+  private registry: ProjectRegistry;
+  private defaultProjectId: string | null = null;
+
+  constructor(registry: ProjectRegistry) {
+    this.registry = registry;
+  }
+
+  /** Initialize contexts for all registered projects. */
+  initAll(): void {
+    const projects = this.registry.list();
+    for (const project of projects) {
+      this.getOrCreate(project.id);
+    }
+    // First project is the default (server CWD, registered via ensureDefaultProject)
+    if (projects.length > 0 && !this.defaultProjectId) {
+      this.defaultProjectId = projects[0].id;
+    }
+  }
+
+  /** Get or lazily create a ProjectContext. */
+  getOrCreate(projectId: string): ProjectContext | null {
+    let ctx = this.contexts.get(projectId);
+    if (ctx) return ctx;
+
+    const project = this.registry.get(projectId);
+    if (!project) return null;
+
+    ctx = new ProjectContext(project);
+    // Call open() if available (added by the ProjectContext lifecycle task)
+    if (typeof (ctx as any).open === "function") {
+      (ctx as any).open();
+    }
+    this.contexts.set(projectId, ctx);
+
+    // Set as default if this is the first context
+    if (!this.defaultProjectId) {
+      this.defaultProjectId = projectId;
+    }
+
+    return ctx;
+  }
+
+  /** Get the default project context (server CWD project). Throws if not initialized. */
+  getDefault(): ProjectContext {
+    if (!this.defaultProjectId) {
+      throw new Error("Default project context not initialized — call initAll() first");
+    }
+    const ctx = this.contexts.get(this.defaultProjectId);
+    if (!ctx) {
+      throw new Error(`Default project context not found for id=${this.defaultProjectId}`);
+    }
+    return ctx;
+  }
+
+  /** Get the default project ID. */
+  getDefaultProjectId(): string {
+    if (!this.defaultProjectId) {
+      throw new Error("Default project not initialized — call initAll() first");
+    }
+    return this.defaultProjectId;
+  }
+
+  /** Get the underlying project registry. */
+  getRegistry(): ProjectRegistry {
+    return this.registry;
+  }
+
+  /** Resolve which project a goal belongs to by scanning all contexts. */
+  getContextForGoal(goalId: string): ProjectContext | null {
+    for (const ctx of this.contexts.values()) {
+      if (ctx.goalStore.get(goalId)) return ctx;
+    }
+    return null;
+  }
+
+  /** Resolve which project a session belongs to by scanning all contexts. */
+  getContextForSession(sessionId: string): ProjectContext | null {
+    for (const ctx of this.contexts.values()) {
+      if (ctx.sessionStore.get(sessionId)) return ctx;
+    }
+    return null;
+  }
+
+  // ── Aggregation methods ────────────────────────────────────────
+
+  /** All live (non-archived) goals across all projects, sorted by updatedAt desc. */
+  getAllLiveGoals(): PersistedGoal[] {
+    const goals: PersistedGoal[] = [];
+    for (const ctx of this.contexts.values()) {
+      goals.push(...ctx.goalStore.getLive());
+    }
+    return goals.sort((a, b) => b.updatedAt - a.updatedAt);
+  }
+
+  /** All live (non-archived) sessions across all projects. */
+  getAllLiveSessions(): PersistedSession[] {
+    const sessions: PersistedSession[] = [];
+    for (const ctx of this.contexts.values()) {
+      sessions.push(...ctx.sessionStore.getLive());
+    }
+    return sessions;
+  }
+
+  /** All goals (including archived) across all projects. */
+  getAllGoals(): PersistedGoal[] {
+    const goals: PersistedGoal[] = [];
+    for (const ctx of this.contexts.values()) {
+      goals.push(...ctx.goalStore.getAll());
+    }
+    return goals.sort((a, b) => b.updatedAt - a.updatedAt);
+  }
+
+  /** All sessions (including archived) across all projects. */
+  getAllSessions(): PersistedSession[] {
+    const sessions: PersistedSession[] = [];
+    for (const ctx of this.contexts.values()) {
+      sessions.push(...ctx.sessionStore.getAll());
+    }
+    return sessions;
+  }
+
+  /** Aggregate search across all (or filtered) project indexes. */
+  searchAll(
+    query: string,
+    opts: {
+      type?: string;
+      limit?: number;
+      offset?: number;
+      projectId?: string;
+      projectNames?: Map<string, string>;
+    } = {},
+  ): SearchResults {
+    const allResults: SearchResult[] = [];
+    let totalCount = 0;
+    const limit = opts.limit ?? 50;
+    const offset = opts.offset ?? 0;
+
+    for (const ctx of this.contexts.values()) {
+      // Filter by projectId if specified
+      if (opts.projectId && ctx.project.id !== opts.projectId) continue;
+
+      // Only call search if context has a searchIndex (added by lifecycle task)
+      const searchIndex = (ctx as any).searchIndex;
+      if (!searchIndex || typeof searchIndex.search !== "function") continue;
+
+      const { results, total } = searchIndex.search(query, {
+        type: opts.type as any,
+        // Fetch enough results for cross-project merging
+        limit: limit + offset,
+        offset: 0,
+        projectId: undefined, // Already filtered above
+        projectNames: opts.projectNames,
+      });
+
+      allResults.push(...results);
+      totalCount += total;
+    }
+
+    // Sort by timestamp descending (most recent first) and apply pagination
+    allResults.sort((a, b) => b.timestamp - a.timestamp);
+    return {
+      results: allResults.slice(offset, offset + limit),
+      total: totalCount,
+    };
+  }
+
+  // ── Generation counters (for polling optimization) ─────────────
+
+  /** Sum of all goal store generations — any single project change is detected. */
+  getGoalGeneration(): number {
+    let gen = 0;
+    for (const ctx of this.contexts.values()) {
+      gen += ctx.goalStore.getGeneration();
+    }
+    return gen;
+  }
+
+  /** Sum of all session store generations — any single project change is detected. */
+  getSessionGeneration(): number {
+    let gen = 0;
+    for (const ctx of this.contexts.values()) {
+      gen += ctx.sessionStore.getGeneration();
+    }
+    return gen;
+  }
+
+  // ── Lifecycle ──────────────────────────────────────────────────
+
+  /** Close all contexts on shutdown. */
+  closeAll(): void {
+    for (const ctx of this.contexts.values()) {
+      if (typeof (ctx as any).close === "function") {
+        (ctx as any).close();
+      }
+    }
+    this.contexts.clear();
+  }
+
+  /** Remove a context when a project is unregistered. */
+  remove(projectId: string): void {
+    const ctx = this.contexts.get(projectId);
+    if (ctx) {
+      if (typeof (ctx as any).close === "function") {
+        (ctx as any).close();
+      }
+      this.contexts.delete(projectId);
+    }
+  }
+
+  /** Iterate all contexts. */
+  all(): IterableIterator<ProjectContext> {
+    return this.contexts.values();
+  }
+
+  /** Number of initialized project contexts. */
+  get size(): number {
+    return this.contexts.size;
+  }
+}

--- a/src/server/agent/project-context-manager.ts
+++ b/src/server/agent/project-context-manager.ts
@@ -40,10 +40,7 @@ export class ProjectContextManager {
     if (!project) return null;
 
     ctx = new ProjectContext(project);
-    // Call open() if available (added by the ProjectContext lifecycle task)
-    if (typeof (ctx as any).open === "function") {
-      (ctx as any).open();
-    }
+    ctx.open();
     this.contexts.set(projectId, ctx);
 
     // Set as default if this is the first context
@@ -153,11 +150,9 @@ export class ProjectContextManager {
       // Filter by projectId if specified
       if (opts.projectId && ctx.project.id !== opts.projectId) continue;
 
-      // Only call search if context has a searchIndex (added by lifecycle task)
-      const searchIndex = (ctx as any).searchIndex;
-      if (!searchIndex || typeof searchIndex.search !== "function") continue;
+      if (!ctx.searchIndex) continue;
 
-      const { results, total } = searchIndex.search(query, {
+      const { results, total } = ctx.searchIndex.search(query, {
         type: opts.type as any,
         // Fetch enough results for cross-project merging
         limit: limit + offset,
@@ -203,9 +198,7 @@ export class ProjectContextManager {
   /** Close all contexts on shutdown. */
   closeAll(): void {
     for (const ctx of this.contexts.values()) {
-      if (typeof (ctx as any).close === "function") {
-        (ctx as any).close();
-      }
+      ctx.close();
     }
     this.contexts.clear();
   }
@@ -214,9 +207,7 @@ export class ProjectContextManager {
   remove(projectId: string): void {
     const ctx = this.contexts.get(projectId);
     if (ctx) {
-      if (typeof (ctx as any).close === "function") {
-        (ctx as any).close();
-      }
+      ctx.close();
       this.contexts.delete(projectId);
     }
   }

--- a/src/server/agent/project-context.ts
+++ b/src/server/agent/project-context.ts
@@ -15,6 +15,7 @@ import { ToolGroupPolicyStore } from "./tool-group-policy-store.js";
 import { ColorStore } from "./color-store.js";
 import { SearchIndex } from "../search/search-index.js";
 import { CostTracker } from "./cost-tracker.js";
+import { GoalManager } from "./goal-manager.js";
 
 /**
  * A container holding a complete set of stores scoped to one project.
@@ -42,6 +43,7 @@ export class ProjectContext {
   readonly colorStore: ColorStore;
   readonly searchIndex: SearchIndex;
   readonly costTracker: CostTracker;
+  readonly goalManager: GoalManager;
 
   // Config stores
   readonly roleStore: RoleStore;
@@ -67,6 +69,7 @@ export class ProjectContext {
     this.colorStore = new ColorStore(this.stateDir);
     this.searchIndex = new SearchIndex(path.join(this.stateDir, "search.db"));
     this.costTracker = new CostTracker(this.stateDir);
+    this.goalManager = new GoalManager(this.goalStore);
 
     // Instantiate config stores with project-scoped config directory
     this.roleStore = new RoleStore(this.configDir);

--- a/src/server/agent/project-context.ts
+++ b/src/server/agent/project-context.ts
@@ -13,6 +13,8 @@ import { ToolManager } from "./tool-manager.js";
 import { ProjectConfigStore } from "./project-config-store.js";
 import { ToolGroupPolicyStore } from "./tool-group-policy-store.js";
 import { ColorStore } from "./color-store.js";
+import { SearchIndex } from "../search/search-index.js";
+import { CostTracker } from "./cost-tracker.js";
 
 /**
  * A container holding a complete set of stores scoped to one project.
@@ -38,6 +40,8 @@ export class ProjectContext {
   readonly teamStore: TeamStore;
   readonly staffStore: StaffStore;
   readonly colorStore: ColorStore;
+  readonly searchIndex: SearchIndex;
+  readonly costTracker: CostTracker;
 
   // Config stores
   readonly roleStore: RoleStore;
@@ -61,6 +65,8 @@ export class ProjectContext {
     this.teamStore = new TeamStore(this.stateDir);
     this.staffStore = new StaffStore(this.stateDir);
     this.colorStore = new ColorStore(this.stateDir);
+    this.searchIndex = new SearchIndex(path.join(this.stateDir, "search.db"));
+    this.costTracker = new CostTracker(this.stateDir);
 
     // Instantiate config stores with project-scoped config directory
     this.roleStore = new RoleStore(this.configDir);
@@ -69,5 +75,28 @@ export class ProjectContext {
     this.toolManager = new ToolManager(this.configDir);
     this.projectConfigStore = new ProjectConfigStore(this.configDir);
     this.toolGroupPolicyStore = new ToolGroupPolicyStore(this.configDir);
+  }
+
+  /** Open resources that require initialization (e.g. SQLite). */
+  open(): void {
+    this.searchIndex.staffStore = this.staffStore;
+    this.searchIndex.open();
+    if (this.searchIndex.needsRebuild()) {
+      this.searchIndex.rebuildFromStores(this.goalStore, this.sessionStore, undefined, this.staffStore);
+    }
+    // Wire search index updates on goal/session mutations
+    this.goalStore.onIndexUpdate = (goal) => {
+      this.searchIndex.indexGoal(goal, this.project.id);
+    };
+    this.sessionStore.onIndexUpdate = (session) => {
+      const goalTitle = session.goalId ? this.goalStore.get(session.goalId)?.title : undefined;
+      this.searchIndex.indexSession(session, goalTitle, this.project.id);
+    };
+  }
+
+  /** Close resources for clean shutdown. */
+  close(): void {
+    this.sessionStore.flush();
+    this.searchIndex.close();
   }
 }

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -1605,7 +1605,7 @@ export class SessionManager {
 			};
 
 			// Persist immediately with all known structural fields
-			persistOnce(session, plan, this.store);
+			persistOnce(session, plan, ctx.store);
 
 			// Fire-and-forget: create worktree then complete pipeline
 			executeWorktreeAsync(plan, session, ctx).then(() => {

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -270,6 +270,40 @@ export class SessionManager {
 		return this.searchIndex;
 	}
 
+	/** Resolve the correct SessionStore for an in-memory session by ID. */
+	private resolveStoreForSession(id: string): SessionStore {
+		const session = this.sessions.get(id);
+		if (session?.projectId) {
+			return this.getSessionStore(session.projectId);
+		}
+		return this.store;
+	}
+
+	/** Resolve the correct SessionStore for any session by ID (in-memory or persisted). */
+	private resolveStoreForId(id: string): SessionStore {
+		// Try in-memory first (fast path)
+		const session = this.sessions.get(id);
+		if (session?.projectId) {
+			return this.getSessionStore(session.projectId);
+		}
+		// Search all project stores for persisted/archived sessions
+		if (this.projectContextManager) {
+			for (const ctx of this.projectContextManager.all()) {
+				if (ctx.sessionStore.get(id)) return ctx.sessionStore;
+			}
+		}
+		return this.store;
+	}
+
+	/** Resolve the correct SearchIndex for a session based on its project. */
+	private resolveSearchIndex(session: { projectId?: string }): SearchIndex {
+		if (session.projectId && this.projectContextManager) {
+			const ctx = this.projectContextManager.getOrCreate(session.projectId);
+			if (ctx) return ctx.searchIndex;
+		}
+		return this.searchIndex;
+	}
+
 	/** Resolve a goal across all project contexts. */
 	private resolveGoal(goalId: string): PersistedGoal | undefined {
 		if (this.projectContextManager) {
@@ -525,7 +559,7 @@ export class SessionManager {
 			if (session.assistantType === "goal") {
 				assistantGoalSpec = assistantGoalSpec.replace('{{AVAILABLE_WORKFLOWS}}', this._buildWorkflowList());
 				// Inject re-attempt context if this is a re-attempt session
-				const reattemptId = (this.store.get(session.id) as any)?.reattemptGoalId;
+				const reattemptId = (this.resolveStoreForSession(session.id).get(session.id) as any)?.reattemptGoalId;
 				if (reattemptId) {
 					const origGoal = this.resolveGoal(reattemptId);
 					if (origGoal) {
@@ -599,7 +633,7 @@ export class SessionManager {
 			sessionId: session.id,
 			queue: session.promptQueue.toArray(),
 		});
-		this.store.update(session.id, { messageQueue: session.promptQueue.toArray() });
+		this.resolveStoreForSession(session.id).update(session.id, { messageQueue: session.promptQueue.toArray() });
 	}
 
 	/**
@@ -709,7 +743,7 @@ export class SessionManager {
 		// Optimistic status update to prevent double-dispatch race
 		session.status = "streaming";
 		session.streamingStartedAt = session.streamingStartedAt ?? Date.now();
-		this.store.update(session.id, { wasStreaming: true, streamingStartedAt: session.streamingStartedAt });
+		this.resolveStoreForSession(session.id).update(session.id, { wasStreaming: true, streamingStartedAt: session.streamingStartedAt });
 		broadcast(session.clients, { type: "session_status", status: "streaming", streamingStartedAt: session.streamingStartedAt });
 
 		// Always dispatch as prompt — agent is idle, steer is only for mid-turn
@@ -822,7 +856,7 @@ export class SessionManager {
 			session.turnHadToolCalls = false;
 			session.permissionBroadcastSent = false;
 			session.streamingStartedAt = Date.now();
-			this.store.update(session.id, { wasStreaming: true, streamingStartedAt: session.streamingStartedAt });
+			this.resolveStoreForSession(session.id).update(session.id, { wasStreaming: true, streamingStartedAt: session.streamingStartedAt });
 			broadcast(session.clients, { type: "session_status", status: "streaming", streamingStartedAt: session.streamingStartedAt });
 		} else if (event.type === "agent_end") {
 			// Revoke one-time granted tools after the turn completes
@@ -836,7 +870,7 @@ export class SessionManager {
 
 			session.status = "idle";
 			session.streamingStartedAt = undefined;
-			this.store.update(session.id, { wasStreaming: false, streamingStartedAt: undefined });
+			this.resolveStoreForSession(session.id).update(session.id, { wasStreaming: false, streamingStartedAt: undefined });
 			broadcast(session.clients, { type: "session_status", status: "idle" });
 			// Don't drain the queue if the turn ended with a model error —
 			// queued/steered messages should wait for a retry.
@@ -865,7 +899,7 @@ export class SessionManager {
 			try {
 				const { text, toolNames } = extractTextFromMessage(event.message);
 				if (text.trim()) {
-					this.searchIndex.indexMessage(
+					this.resolveSearchIndex(session).indexMessage(
 						session.id,
 						session.title,
 						text,
@@ -1042,7 +1076,7 @@ export class SessionManager {
 	 * which re-applies tool activation with the updated role.
 	 */
 	private async _restartSessionWithUpdatedRole(session: SessionInfo): Promise<void> {
-		const ps = this.store.get(session.id);
+		const ps = this.resolveStoreForSession(session.id).get(session.id);
 		if (!ps) return;
 
 		// Save state that must survive the restart
@@ -1204,23 +1238,26 @@ export class SessionManager {
 		// Get session IDs that the verification harness will resume — skip those
 		const resumingIds = this._verificationHarness?.getResumingSessionIds() ?? new Set<string>();
 
-		const orphans: string[] = [];
-		for (const ps of this.store.getLive()) {
+		const orphans: { id: string; projectId?: string }[] = [];
+		const allLive = this.projectContextManager
+			? [...this.projectContextManager.getAllLiveSessions()]
+			: this.store.getLive();
+		for (const ps of allLive) {
 			if (ps.nonInteractive && !resumingIds.has(ps.id)) {
-				orphans.push(ps.id);
+				orphans.push({ id: ps.id, projectId: ps.projectId });
 			}
 		}
 		if (orphans.length === 0) return;
 
 		console.log(`[session-manager] Cleaning up ${orphans.length} orphaned non-interactive session(s)...`);
-		for (const id of orphans) {
+		for (const { id, projectId } of orphans) {
 			try {
 				await this.terminateSession(id);
 				console.log(`[session-manager] Terminated orphaned non-interactive session ${id}`);
 			} catch (err) {
 				// If terminate fails (e.g. session wasn't fully restored), archive directly
 				console.warn(`[session-manager] Failed to terminate orphan ${id}, archiving:`, err);
-				this.store.archive(id);
+				this.getSessionStore(projectId).archive(id);
 			}
 		}
 	}
@@ -1447,9 +1484,10 @@ export class SessionManager {
 		// all historical message_update events which would double-count costs)
 		let restoring = true;
 
+		const restoreStore = this.getSessionStore(ps.projectId);
 		const unsub = rpcClient.onEvent((event: any) => {
 			session.lastActivity = Date.now();
-			this.store.update(ps.id, { lastActivity: session.lastActivity });
+			restoreStore.update(ps.id, { lastActivity: session.lastActivity });
 
 			this.handleAgentLifecycle(session, event);
 
@@ -1481,7 +1519,7 @@ export class SessionManager {
 		// If the agent was mid-turn when the server died, re-prompt it to continue
 		if (ps.wasStreaming) {
 			console.log(`[session-manager] Session "${ps.title}" (${ps.id}) was interrupted mid-turn — re-prompting to continue`);
-			this.store.update(ps.id, { wasStreaming: false });
+			restoreStore.update(ps.id, { wasStreaming: false });
 			rpcClient.prompt(
 				"[SYSTEM: The infrastructure server restarted while you were mid-turn. " +
 				"Your previous work has been preserved. Please continue where you left off. " +
@@ -1621,12 +1659,11 @@ export class SessionManager {
 		const id = randomUUID();
 		// Resolve projectId from parent session
 		const parentProjectId = this.sessions.get(parentSessionId)?.projectId
-			?? this.store.get(parentSessionId)?.projectId;
+			?? this.resolveStoreForId(parentSessionId).get(parentSessionId)?.projectId;
 		const ctx = this.buildPipelineContext(parentProjectId);
 
 		// ── Sandbox propagation from parent ──
-		const parentMeta = this.getSessionStore(parentProjectId).get(parentSessionId)
-			?? this.store.get(parentSessionId);
+		const parentMeta = this.getSessionStore(parentProjectId).get(parentSessionId);
 		let delegateSandboxed = false;
 		if (parentMeta?.sandboxed) {
 			// Always use the parent's validated host-side cwd — never trust the
@@ -1775,7 +1812,7 @@ export class SessionManager {
 				try {
 					await session.rpcClient.setModel(provider, modelId);
 					this._writeModelNameFile(session.id, sessionModelPref);
-					this.store.update(session.id, { modelProvider: provider, modelId });
+					this.resolveStoreForSession(session.id).update(session.id, { modelProvider: provider, modelId });
 					console.log(`[session-manager] Set preferred model "${sessionModelPref}" for session ${session.id}`);
 					broadcast(session.clients, {
 						type: "state",
@@ -1815,7 +1852,7 @@ export class SessionManager {
 
 			await session.rpcClient.setModel("aigw", modelToUse.id);
 			this._writeModelNameFile(session.id, modelToUse.id);
-			this.store.update(session.id, { modelProvider: "aigw", modelId: modelToUse.id });
+			this.resolveStoreForSession(session.id).update(session.id, { modelProvider: "aigw", modelId: modelToUse.id });
 			console.log(`[session-manager] Auto-selected aigw model "${modelToUse.id}" for session ${session.id}`);
 
 			broadcast(session.clients, {
@@ -1875,7 +1912,7 @@ export class SessionManager {
 					? containerToHostSessionPath(stateResp.data.sessionFile)
 					: stateResp.data.sessionFile;
 
-				this.store.update(session.id, { agentSessionFile });
+				this.resolveStoreForSession(session.id).update(session.id, { agentSessionFile });
 				return; // success
 			} catch (err) {
 				if (attempt < maxRetries) {
@@ -1940,9 +1977,16 @@ export class SessionManager {
 
 		this.sessions.set(id, session);
 
+		// Resolve project from goal
+		const extProjectId = opts.goalId
+			? this.projectContextManager?.getContextForGoal(opts.goalId)?.project.id
+			: undefined;
+		const extStore = extProjectId ? this.getSessionStore(extProjectId) : this.store;
+		if (extProjectId) session.projectId = extProjectId;
+
 		// Initial persist — structural fields (store.put must precede persistSessionMetadata
 		// since persistSessionMetadata now only does store.update)
-		this.store.put({
+		extStore.put({
 			id,
 			title: opts.title,
 			cwd: opts.cwd,
@@ -1953,6 +1997,7 @@ export class SessionManager {
 			role: opts.role,
 			teamGoalId: opts.teamGoalId,
 			nonInteractive: true,
+			projectId: extProjectId,
 		});
 
 		// Then update with agentSessionFile
@@ -1970,7 +2015,7 @@ export class SessionManager {
 			}
 			session.clients.clear();
 			this.sessions.delete(id);
-			this.store.remove(id);
+			extStore.remove(id);
 			cleanupSessionPrompt(id);
 			console.log(`[session-manager] Unregistered external session ${id}`);
 		};
@@ -2005,36 +2050,39 @@ export class SessionManager {
 		sandboxed?: boolean;
 		projectId?: string;
 	}> {
-		return Array.from(this.sessions.values()).map((s) => ({
-			id: s.id,
-			title: s.title,
-			cwd: s.cwd,
-			status: s.status,
-			createdAt: s.createdAt,
-			lastActivity: s.lastActivity,
-			clientCount: s.clients.size,
-			isCompacting: s.isCompacting,
-			goalId: s.goalId,
-			assistantType: s.assistantType,
-			// Legacy boolean fields for backward compat
-			goalAssistant: s.assistantType === "goal",
-			roleAssistant: s.assistantType === "role",
-			toolAssistant: s.assistantType === "tool",
-			delegateOf: s.delegateOf,
-			role: s.role,
-			teamGoalId: s.teamGoalId,
-			teamLeadSessionId: s.teamLeadSessionId,
-			worktreePath: s.worktreePath,
-			taskId: s.taskId,
-			staffId: s.staffId,
-			accessory: s.accessory,
-			nonInteractive: s.nonInteractive,
-			preview: s.preview,
-			personalities: s.personalities,
-			reattemptGoalId: this.store.get(s.id)?.reattemptGoalId,
-			sandboxed: this.store.get(s.id)?.sandboxed || s.sandboxed,
-			projectId: this.store.get(s.id)?.projectId,
-		}));
+		return Array.from(this.sessions.values()).map((s) => {
+			const ps = this.resolveStoreForSession(s.id).get(s.id);
+			return {
+				id: s.id,
+				title: s.title,
+				cwd: s.cwd,
+				status: s.status,
+				createdAt: s.createdAt,
+				lastActivity: s.lastActivity,
+				clientCount: s.clients.size,
+				isCompacting: s.isCompacting,
+				goalId: s.goalId,
+				assistantType: s.assistantType,
+				// Legacy boolean fields for backward compat
+				goalAssistant: s.assistantType === "goal",
+				roleAssistant: s.assistantType === "role",
+				toolAssistant: s.assistantType === "tool",
+				delegateOf: s.delegateOf,
+				role: s.role,
+				teamGoalId: s.teamGoalId,
+				teamLeadSessionId: s.teamLeadSessionId,
+				worktreePath: s.worktreePath,
+				taskId: s.taskId,
+				staffId: s.staffId,
+				accessory: s.accessory,
+				nonInteractive: s.nonInteractive,
+				preview: s.preview,
+				personalities: s.personalities,
+				reattemptGoalId: ps?.reattemptGoalId,
+				sandboxed: ps?.sandboxed || s.sandboxed,
+				projectId: ps?.projectId,
+			};
+		});
 	}
 
 	/**
@@ -2047,7 +2095,10 @@ export class SessionManager {
 				.filter((s) => s.goalId === goalId)
 				.map((s) => s.id),
 		);
-		for (const ps of this.store.getAll()) {
+		const allPersisted = this.projectContextManager
+			? [...this.projectContextManager.all()].flatMap(ctx => ctx.sessionStore.getAll())
+			: this.store.getAll();
+		for (const ps of allPersisted) {
 			if (ps.goalId === goalId) ids.add(ps.id);
 		}
 		return [...ids];
@@ -2057,7 +2108,7 @@ export class SessionManager {
 		const session = this.sessions.get(id);
 		if (!session) return false;
 		session.title = title;
-		this.store.update(id, { title });
+		this.resolveStoreForSession(id).update(id, { title });
 		broadcast(session.clients, { type: "session_title", sessionId: id, title });
 		return true;
 	}
@@ -2079,7 +2130,7 @@ export class SessionManager {
 		if (title) {
 			const finalTitle = `New goal: ${title}`;
 			session.title = finalTitle;
-			this.store.update(session.id, { title: finalTitle });
+			this.resolveStoreForSession(session.id).update(session.id, { title: finalTitle });
 			broadcast(session.clients, { type: "session_title", sessionId: session.id, title: finalTitle });
 		}
 	}
@@ -2089,7 +2140,7 @@ export class SessionManager {
 		const session = this.sessions.get(id);
 		if (!session) {
 			// Store-only session (dormant/delegate) — update store directly
-			this.store.update(id, updates);
+			this.resolveStoreForId(id).update(id, updates);
 			return true;
 		}
 		if (updates.role !== undefined) session.role = updates.role;
@@ -2099,7 +2150,7 @@ export class SessionManager {
 		if (updates.nonInteractive !== undefined) session.nonInteractive = updates.nonInteractive;
 		if (updates.teamLeadSessionId !== undefined) session.teamLeadSessionId = updates.teamLeadSessionId;
 		if (updates.delegateOf !== undefined) session.delegateOf = updates.delegateOf;
-		this.store.update(id, updates);
+		this.resolveStoreForSession(id).update(id, updates);
 		return true;
 	}
 
@@ -2114,8 +2165,9 @@ export class SessionManager {
 	private ensureStoreEntry(id: string): boolean {
 		const session = this.sessions.get(id);
 		if (!session) return false;
-		if (!this.store.get(id)) {
-			this.store.put({
+		const store = this.resolveStoreForSession(id);
+		if (!store.get(id)) {
+			store.put({
 				id: session.id,
 				title: session.title,
 				cwd: session.cwd,
@@ -2124,6 +2176,7 @@ export class SessionManager {
 				lastActivity: session.lastActivity,
 				goalId: session.goalId,
 				sandboxed: session.sandboxed,
+				projectId: session.projectId,
 			});
 		}
 		return true;
@@ -2132,19 +2185,19 @@ export class SessionManager {
 	/** Get a draft for a session by type. */
 	getDraft(id: string, type: string): unknown | undefined {
 		if (!this.ensureStoreEntry(id)) return undefined;
-		return this.store.getDraft(id, type);
+		return this.resolveStoreForSession(id).getDraft(id, type);
 	}
 
 	/** Set a draft for a session by type. Returns false if session not found. */
 	setDraft(id: string, type: string, data: unknown): boolean {
 		if (!this.ensureStoreEntry(id)) return false;
-		return this.store.setDraft(id, type, data);
+		return this.resolveStoreForSession(id).setDraft(id, type, data);
 	}
 
 	/** Delete a draft for a session by type. */
 	deleteDraft(id: string, type: string): boolean {
 		if (!this.ensureStoreEntry(id)) return false;
-		return this.store.deleteDraft(id, type);
+		return this.resolveStoreForSession(id).deleteDraft(id, type);
 	}
 
 	/**
@@ -2163,7 +2216,7 @@ export class SessionManager {
 			const stateResp = await session.rpcClient.getState();
 			if (stateResp.success) agentSessionFile = stateResp.data?.sessionFile;
 		} catch {
-			const persisted = this.store.get(id);
+			const persisted = this.resolveStoreForSession(id).get(id);
 			agentSessionFile = persisted?.agentSessionFile;
 		}
 
@@ -2228,9 +2281,10 @@ export class SessionManager {
 
 		const rpcClient = new RpcBridge(bridgeOptions);
 		let switchingSession = true;
+		const roleStore = this.resolveStoreForSession(id);
 		const unsub = rpcClient.onEvent((event: any) => {
 			session.lastActivity = Date.now();
-			this.store.update(id, { lastActivity: session.lastActivity });
+			roleStore.update(id, { lastActivity: session.lastActivity });
 			this.handleAgentLifecycle(session, event);
 			session.eventBuffer.push(event);
 			broadcast(session.clients, { type: "event", data: event });
@@ -2241,7 +2295,7 @@ export class SessionManager {
 
 		// Restore conversation from session file
 		if (agentSessionFile && fs.existsSync(agentSessionFile)) {
-			const rolePersisted = this.store.get(id);
+			const rolePersisted = roleStore.get(id);
 			const roleSwitchPath = rolePersisted?.sandboxed ? hostToContainerSessionPath(agentSessionFile) : agentSessionFile;
 			const switchResp = await rpcClient.sendCommand(
 				{ type: "switch_session", sessionPath: roleSwitchPath },
@@ -2262,7 +2316,7 @@ export class SessionManager {
 		session.allowedTools = role.allowedTools;
 		if (opts?.personalities) session.personalities = opts.personalities;
 
-		this.store.update(id, { role: role.name, accessory: role.accessory, personalities: opts?.personalities });
+		roleStore.update(id, { role: role.name, accessory: role.accessory, personalities: opts?.personalities });
 
 		broadcast(session.clients, { type: "session_status", status: "idle" } as any);
 
@@ -2294,7 +2348,7 @@ export class SessionManager {
 			const stateResp = await session.rpcClient.getState();
 			if (stateResp.success) agentSessionFile = stateResp.data?.sessionFile;
 		} catch {
-			const persisted = this.store.get(id);
+			const persisted = this.resolveStoreForSession(id).get(id);
 			agentSessionFile = persisted?.agentSessionFile;
 		}
 
@@ -2370,9 +2424,10 @@ export class SessionManager {
 
 		const rpcClient = new RpcBridge(bridgeOptions);
 		let switchingSession = true;
+		const persoStore = this.resolveStoreForSession(id);
 		const unsub = rpcClient.onEvent((event: any) => {
 			session.lastActivity = Date.now();
-			this.store.update(id, { lastActivity: session.lastActivity });
+			persoStore.update(id, { lastActivity: session.lastActivity });
 			this.handleAgentLifecycle(session, event);
 			session.eventBuffer.push(event);
 			broadcast(session.clients, { type: "event", data: event });
@@ -2382,7 +2437,7 @@ export class SessionManager {
 		await rpcClient.start();
 
 		if (agentSessionFile && fs.existsSync(agentSessionFile)) {
-			const persoPersisted = this.store.get(id);
+			const persoPersisted = persoStore.get(id);
 			const persoSwitchPath = persoPersisted?.sandboxed ? hostToContainerSessionPath(agentSessionFile) : agentSessionFile;
 			const switchResp = await rpcClient.sendCommand(
 				{ type: "switch_session", sessionPath: persoSwitchPath },
@@ -2400,7 +2455,7 @@ export class SessionManager {
 		session.status = "idle";
 		session.personalities = personalityNames;
 
-		this.store.update(id, { personalities: personalityNames });
+		persoStore.update(id, { personalities: personalityNames });
 
 		broadcast(session.clients, { type: "session_status", status: "idle" } as any);
 
@@ -2443,7 +2498,7 @@ export class SessionManager {
 		const title = await generateSessionTitle(messages, this.getTitleGenOptions());
 		if (title) {
 			session.title = title;
-			this.store.update(session.id, { title });
+			this.resolveStoreForSession(session.id).update(session.id, { title });
 			broadcast(session.clients, { type: "session_title", sessionId: session.id, title });
 		}
 	}
@@ -2459,7 +2514,7 @@ export class SessionManager {
 			const title = await generateSessionTitle(messages, this.getTitleGenOptions());
 			if (title) {
 				session.title = title;
-				this.store.update(session.id, { title });
+				this.resolveStoreForSession(session.id).update(session.id, { title });
 				broadcast(session.clients, { type: "session_title", sessionId: session.id, title });
 			}
 		} catch (err) {
@@ -2477,7 +2532,7 @@ export class SessionManager {
 		if (existing && existing.status !== "terminated") return; // already alive
 
 		// Try to restore from persisted data
-		const persisted = this.store.get(sessionId);
+		const persisted = this.resolveStoreForId(sessionId).get(sessionId);
 		if (!persisted) {
 			throw new Error(`Cannot restore session ${sessionId}: no persisted data found`);
 		}
@@ -2502,7 +2557,7 @@ export class SessionManager {
 
 	/** Persist model provider/id so archived sessions can display model info. */
 	persistSessionModel(sessionId: string, provider: string, modelId: string): void {
-		this.store.update(sessionId, { modelProvider: provider, modelId });
+		this.resolveStoreForSession(sessionId).update(sessionId, { modelProvider: provider, modelId });
 	}
 
 	async terminateSession(id: string): Promise<boolean> {
@@ -2516,9 +2571,12 @@ export class SessionManager {
 			await this.terminateSession(child.id);
 		}
 		// Also archive persisted-but-not-in-memory delegate sessions
-		for (const ps of this.store.getLive()) {
+		const allLiveForTerminate = this.projectContextManager
+			? [...this.projectContextManager.getAllLiveSessions()]
+			: this.store.getLive();
+		for (const ps of allLiveForTerminate) {
 			if (ps.delegateOf === id && !this.sessions.has(ps.id)) {
-				this.store.archive(ps.id);
+				this.getSessionStore(ps.projectId).archive(ps.id);
 			}
 		}
 
@@ -2561,11 +2619,12 @@ export class SessionManager {
 		this.sessions.delete(id);
 		// Archive the session — keep metadata for 7 days.
 		// But sessions with no agentSessionFile are unrestorable, so just remove them.
-		const persisted = this.store.get(id);
+		const terminateStore = this.resolveStoreForSession(id);
+		const persisted = terminateStore.get(id);
 		if (persisted?.agentSessionFile) {
-			this.store.archive(id);
+			terminateStore.archive(id);
 		} else {
-			this.store.remove(id);
+			terminateStore.remove(id);
 		}
 		// Don't remove color or session prompt — they're needed for archived view
 		return true;
@@ -2573,26 +2632,27 @@ export class SessionManager {
 
 	/** Get an archived session's metadata. */
 	getArchivedSession(id: string): PersistedSession | undefined {
-		const ps = this.store.get(id);
+		const ps = this.resolveStoreForId(id).get(id);
 		return ps?.archived ? ps : undefined;
 	}
 
 	/** Archive a session directly in the store (for dormant/store-only sessions). */
 	storeArchive(id: string): boolean {
-		return this.store.archive(id);
+		return this.resolveStoreForId(id).archive(id);
 	}
 
 	/** Update metadata on an archived session (stored in the session store). */
 	updateArchivedMeta(id: string, updates: { teamLeadSessionId?: string }): boolean {
-		const ps = this.store.get(id);
+		const store = this.resolveStoreForId(id);
+		const ps = store.get(id);
 		if (!ps?.archived) return false;
-		this.store.update(id, updates);
+		store.update(id, updates);
 		return true;
 	}
 
 	/** Parse the .jsonl file for an archived session and return messages. */
 	getArchivedMessages(id: string): unknown[] {
-		const ps = this.store.get(id);
+		const ps = this.resolveStoreForId(id).get(id);
 		if (!ps?.archived || !ps.agentSessionFile) return [];
 		try {
 			if (!fs.existsSync(ps.agentSessionFile)) return [];
@@ -2644,7 +2704,10 @@ export class SessionManager {
 		archived: boolean;
 		archivedAt?: number;
 	}> {
-		return this.store.getArchived().map((ps) => ({
+		const allArchived = this.projectContextManager
+			? [...this.projectContextManager.all()].flatMap(ctx => ctx.sessionStore.getArchived())
+			: this.store.getArchived();
+		return allArchived.map((ps) => ({
 			id: ps.id,
 			title: ps.title,
 			cwd: ps.cwd,
@@ -2674,7 +2737,7 @@ export class SessionManager {
 
 	/** Permanently purge a single archived session immediately. */
 	async purgeArchivedSession(id: string): Promise<boolean> {
-		const ps = this.store.get(id);
+		const ps = this.resolveStoreForId(id).get(id);
 		if (!ps?.archived) return false;
 		await this.purgeOneSession(ps);
 		return true;
@@ -2684,7 +2747,9 @@ export class SessionManager {
 	async purgeExpiredArchives(): Promise<void> {
 		const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 		const cutoff = Date.now() - SEVEN_DAYS_MS;
-		const archived = this.store.getArchived();
+		const archived = this.projectContextManager
+			? [...this.projectContextManager.all()].flatMap(ctx => ctx.sessionStore.getArchived())
+			: this.store.getArchived();
 		for (const ps of archived) {
 			if (ps.archivedAt && ps.archivedAt < cutoff) {
 				try {
@@ -2701,8 +2766,9 @@ export class SessionManager {
 	private async purgeOneSession(ps: PersistedSession): Promise<void> {
 		// Remove from search index
 		try {
-			this.searchIndex.removeMessagesForSession(ps.id);
-			this.searchIndex.removeSession(ps.id);
+			const purgeSearchIndex = this.resolveSearchIndex(ps);
+			purgeSearchIndex.removeMessagesForSession(ps.id);
+			purgeSearchIndex.removeSession(ps.id);
 		} catch (err) {
 			console.error(`[session-manager] Failed to remove session ${ps.id} from search index:`, err);
 		}
@@ -2741,7 +2807,7 @@ export class SessionManager {
 		}
 
 		// Remove from store
-		this.store.purge(ps.id);
+		this.resolveStoreForId(ps.id).purge(ps.id);
 	}
 
 	/** Start the archive purge schedule — call after restoreSessions(). */
@@ -2764,7 +2830,7 @@ export class SessionManager {
 
 		// If session is dormant (failed restore), try to revive it
 		if (session.status === "terminated") {
-			const ps = this.store.get(sessionId);
+			const ps = this.resolveStoreForId(sessionId).get(sessionId);
 			if (ps && fs.existsSync(ps.agentSessionFile)) {
 				console.log(`[session-manager] Client connected to dormant session "${session.title}" — attempting restore`);
 				this.restoreSession(ps)
@@ -2850,7 +2916,7 @@ export class SessionManager {
 			}
 		} catch {
 			// Process may be unresponsive — try the persisted store
-			const persisted = this.store.get(id);
+			const persisted = this.resolveStoreForSession(id).get(id);
 			agentSessionFile = persisted?.agentSessionFile;
 		}
 
@@ -2897,9 +2963,10 @@ export class SessionManager {
 
 			const rpcClient = new RpcBridge(bridgeOptions);
 			let switchingSession = true;
+			const abortStore = this.resolveStoreForSession(id);
 			const unsub = rpcClient.onEvent((event: any) => {
 				session.lastActivity = Date.now();
-				this.store.update(id, { lastActivity: session.lastActivity });
+				abortStore.update(id, { lastActivity: session.lastActivity });
 
 				this.handleAgentLifecycle(session, event);
 
@@ -2912,7 +2979,7 @@ export class SessionManager {
 
 			// Resume session if we have the session file
 			if (agentSessionFile && fs.existsSync(agentSessionFile)) {
-				const abortPersisted = this.store.get(id);
+				const abortPersisted = abortStore.get(id);
 				const abortSwitchPath = abortPersisted?.sandboxed ? hostToContainerSessionPath(agentSessionFile) : agentSessionFile;
 				const switchResp = await rpcClient.sendCommand(
 					{ type: "switch_session", sessionPath: abortSwitchPath },
@@ -2954,7 +3021,7 @@ export class SessionManager {
 			// This is authoritative — the in-memory status is always correct,
 			// and we write it here to handle the case where shutdown() races
 			// with a pending agent_end that hasn't flushed to disk yet.
-			this.store.update(id, { wasStreaming: session.status === "streaming", streamingStartedAt: session.streamingStartedAt });
+			this.resolveStoreForSession(id).update(id, { wasStreaming: session.status === "streaming", streamingStartedAt: session.streamingStartedAt });
 
 			session.unsubscribe();
 			await session.rpcClient.stop();
@@ -2968,11 +3035,19 @@ export class SessionManager {
 		}
 
 		// Flush any debounced store writes before exit
-		this.store.flush();
+		if (this.projectContextManager) {
+			for (const ctx of this.projectContextManager.all()) ctx.sessionStore.flush();
+		} else {
+			this.store.flush();
+		}
 
 		// Close search index
 		try {
-			this.searchIndex.close();
+			if (this.projectContextManager) {
+				// ProjectContextManager.closeAll() handles search index closing
+			} else {
+				this.searchIndex.close();
+			}
 		} catch (err) {
 			console.error("[search] Failed to close search index:", err);
 		}

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -1119,26 +1119,29 @@ export class SessionManager {
 	 * Re-spawns agent processes and uses switch_session to resume each one.
 	 */
 	async restoreSessions(): Promise<void> {
-		// Initialize search index
-		try {
-			this.searchIndex.open();
-			if (this.searchIndex.needsRebuild()) {
-				const goalStore = (this.goalManager as any).store as import("./goal-store.js").GoalStore;
-				this.searchIndex.rebuildFromStores(goalStore, this.store);
+		// Initialize search index (skip when ProjectContextManager is active —
+		// ProjectContext.open() already opens the index and wires callbacks)
+		if (!this.projectContextManager) {
+			try {
+				this.searchIndex.open();
+				if (this.searchIndex.needsRebuild()) {
+					const goalStore = this.goalManager.getGoalStore();
+					this.searchIndex.rebuildFromStores(goalStore, this.store);
+				}
+				// Wire index update callbacks
+				const goalStore = this.goalManager.getGoalStore();
+				goalStore.onIndexUpdate = (goal) => {
+					try { this.searchIndex.indexGoal(goal, goal.projectId || ""); } catch (err) { console.error("[search] Failed to index goal:", err); }
+				};
+				this.store.onIndexUpdate = (session) => {
+					try {
+						const goalTitle = session.goalId ? this.goalManager.getGoal(session.goalId)?.title : undefined;
+						this.searchIndex.indexSession(session, goalTitle, session.projectId || "");
+					} catch (err) { console.error("[search] Failed to index session:", err); }
+				};
+			} catch (err) {
+				console.error("[search] Failed to initialize search index:", err);
 			}
-			// Wire index update callbacks
-			const goalStore = (this.goalManager as any).store as import("./goal-store.js").GoalStore;
-			goalStore.onIndexUpdate = (goal) => {
-				try { this.searchIndex.indexGoal(goal, goal.projectId || ""); } catch (err) { console.error("[search] Failed to index goal:", err); }
-			};
-			this.store.onIndexUpdate = (session) => {
-				try {
-					const goalTitle = session.goalId ? this.goalManager.getGoal(session.goalId)?.title : undefined;
-					this.searchIndex.indexSession(session, goalTitle, session.projectId || "");
-				} catch (err) { console.error("[search] Failed to index session:", err); }
-			};
-		} catch (err) {
-			console.error("[search] Failed to initialize search index:", err);
 		}
 
 		const persisted = this.store.getLive();

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -1318,6 +1318,7 @@ export class SessionManager {
 			titleGenerated: true,
 			goalId: ps.goalId,
 			delegateOf: ps.delegateOf,
+			projectId: ps.projectId,
 			promptQueue: new PromptQueue(ps.messageQueue),
 		});
 	}
@@ -1487,6 +1488,7 @@ export class SessionManager {
 			allowedTools: restoredAllowedTools,
 			promptQueue: new PromptQueue(ps.messageQueue),
 			streamingStartedAt: ps.streamingStartedAt,
+			projectId: ps.projectId,
 		};
 
 		// Skip cost tracking during session restore (switch_session replays

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -411,9 +411,7 @@ export class SessionManager {
 		return this.costTracker;
 	}
 
-	getSessionStore(): SessionStore {
-		return this.store;
-	}
+
 
 	getMcpManager(): McpManager | null {
 		return this.mcpManager;

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -1577,6 +1577,7 @@ export class SessionManager {
 				personalities: opts?.personalityNames,
 				allowedTools: opts?.allowedTools,
 				worktreePath,
+				projectId,
 				promptQueue: new PromptQueue(),
 			};
 
@@ -1646,6 +1647,7 @@ export class SessionManager {
 		};
 
 		const session = await executePlan(plan, ctx);
+		if (projectId) session.projectId = projectId;
 
 		// Persist session metadata (fire-and-forget)
 		this.persistSessionMetadata(session).catch((err) => {
@@ -1707,6 +1709,8 @@ export class SessionManager {
 		this.persistSessionMetadata(session).catch((err) => {
 			console.error(`[session-manager] Failed to persist delegate session ${id}:`, err);
 		});
+
+		if (parentProjectId) session.projectId = parentProjectId;
 
 		// Send delegate prompt with 30s timeout
 		await sendDelegatePrompt(session, opts.instructions, DELEGATE_SPAWN_TIMEOUT_MS);

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -30,6 +30,10 @@ import { getAigwUrl, discoverAigwModels, deriveName } from "./aigw-manager.js";
 import { modelRecencyRank } from "./model-registry.js";
 import { buildAvailableRolesList } from "./team-manager.js";
 // createWorktree is used in session-setup.ts pipeline
+import { ProjectContextManager } from "./project-context-manager.js";
+import { GoalStore } from "./goal-store.js";
+import { TaskStore } from "./task-store.js";
+import type { GateStore } from "./gate-store.js";
 import { bobbitStateDir, globalAuthPath } from "../bobbit-dir.js";
 import { SandboxProxy } from "./sandbox-proxy.js";
 import type { SandboxPool, ClaimOptions } from "./sandbox-pool.js";
@@ -151,6 +155,8 @@ export interface SessionManagerOptions {
 	preferencesStore?: import("./preferences-store.js").PreferencesStore;
 	/** Project config store for reading project defaults (e.g. default_thinking_level) */
 	projectConfigStore?: import("./project-config-store.js").ProjectConfigStore;
+	/** Project context manager for per-project store resolution */
+	projectContextManager?: ProjectContextManager;
 }
 
 export class SessionManager {
@@ -167,6 +173,7 @@ export class SessionManager {
 	private preferencesStore?: import("./preferences-store.js").PreferencesStore;
 	private workflowStore?: import("./workflow-store.js").WorkflowStore;
 	private projectConfigStore?: import("./project-config-store.js").ProjectConfigStore;
+	private projectContextManager: ProjectContextManager | null = null;
 	private mcpManager: McpManager | null = null;
 	private sandboxProxy: SandboxProxy | null = null;
 	sandboxPool: SandboxPool | null = null;
@@ -195,7 +202,6 @@ export class SessionManager {
 	}
 
 	constructor(options?: SessionManagerOptions) {
-		const stateDir = bobbitStateDir();
 		this.agentCliPath = options?.agentCliPath;
 		this.systemPromptPath = options?.systemPromptPath;
 		this.colorStore = options?.colorStore;
@@ -206,11 +212,62 @@ export class SessionManager {
 		this.preferencesStore = options?.preferencesStore;
 		this.workflowStore = options?.workflowStore;
 		this.projectConfigStore = options?.projectConfigStore;
-		this.store = new SessionStore(stateDir);
-		this.costTracker = new CostTracker(stateDir);
-		this.goalManager = new GoalManager(options?.workflowStore, stateDir);
-		this.taskManager = new TaskManager(stateDir);
-		this.searchIndex = new SearchIndex(path.join(stateDir, "search.db"));
+		this.projectContextManager = options?.projectContextManager ?? null;
+		if (this.projectContextManager) {
+			const defaultCtx = this.projectContextManager.getDefault();
+			this.store = defaultCtx.sessionStore;
+			this.costTracker = defaultCtx.costTracker;
+			this.goalManager = new GoalManager(defaultCtx.goalStore, options?.workflowStore);
+			this.taskManager = new TaskManager(defaultCtx.taskStore);
+			this.searchIndex = defaultCtx.searchIndex;
+		} else {
+			const stateDir = bobbitStateDir();
+			this.store = new SessionStore(stateDir);
+			this.costTracker = new CostTracker(stateDir);
+			this.goalManager = new GoalManager(new GoalStore(stateDir), options?.workflowStore);
+			this.taskManager = new TaskManager(new TaskStore(stateDir));
+			this.searchIndex = new SearchIndex(path.join(stateDir, "search.db"));
+		}
+	}
+
+	getProjectContextManager(): ProjectContextManager | null {
+		return this.projectContextManager;
+	}
+
+	/** Resolve the SessionStore for a given project. */
+	getSessionStore(projectId?: string): SessionStore {
+		if (projectId && this.projectContextManager) {
+			const ctx = this.projectContextManager.getOrCreate(projectId);
+			if (ctx) return ctx.sessionStore;
+		}
+		return this.store;
+	}
+
+	/** Resolve the GoalStore for a given project. */
+	getGoalStoreForProject(projectId?: string): GoalStore {
+		if (projectId && this.projectContextManager) {
+			const ctx = this.projectContextManager.getOrCreate(projectId);
+			if (ctx) return ctx.goalStore;
+		}
+		return this.goalManager.getGoalStore();
+	}
+
+	/** Resolve the GateStore for a goal. */
+	getGateStoreForGoal(goalId: string): GateStore | null {
+		if (this.projectContextManager) {
+			const ctx = this.projectContextManager.getContextForGoal(goalId);
+			if (ctx) return ctx.gateStore;
+		}
+		return null;
+	}
+
+	/** Resolve SearchIndex for a project. */
+	getSearchIndexForProject(projectId?: string): SearchIndex {
+		if (projectId && this.projectContextManager) {
+			const ctx = this.projectContextManager.getOrCreate(projectId);
+			if (ctx) return ctx.searchIndex;
+		}
+		return this.searchIndex;
 	}
 
 	/** Whether Docker sandbox mode is enabled in project config. */

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -327,7 +327,7 @@ export class SessionManager {
 		if (projectId && this.projectContextManager) {
 			const ctx = this.projectContextManager.getOrCreate(projectId);
 			if (ctx) {
-				resolvedGoalManager = new GoalManager(ctx.goalStore);
+				resolvedGoalManager = ctx.goalManager;
 				resolvedTaskManager = new TaskManager(ctx.taskStore);
 			}
 		}

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -322,14 +322,23 @@ export class SessionManager {
 	buildPipelineContext(projectId?: string): PipelineContext {
 		const resolvedStore = this.getSessionStore(projectId);
 		const resolvedSearchIndex = this.getSearchIndexForProject(projectId);
+		let resolvedGoalManager = this.goalManager;
+		let resolvedTaskManager = this.taskManager;
+		if (projectId && this.projectContextManager) {
+			const ctx = this.projectContextManager.getOrCreate(projectId);
+			if (ctx) {
+				resolvedGoalManager = new GoalManager(ctx.goalStore);
+				resolvedTaskManager = new TaskManager(ctx.taskStore);
+			}
+		}
 		return {
 			agentCliPath: this.agentCliPath,
 			systemPromptPath: this.systemPromptPath,
 			roleManager: this.roleManager ?? null,
 			toolManager: this.toolManager ?? null,
 			mcpManager: this.mcpManager,
-			goalManager: this.goalManager,
-			taskManager: this.taskManager,
+			goalManager: resolvedGoalManager,
+			taskManager: resolvedTaskManager,
 			personalityManager: this.personalityManager ?? null,
 			projectConfigStore: this.projectConfigStore ?? null,
 			sandboxPool: this.sandboxPool,

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -31,7 +31,7 @@ import { modelRecencyRank } from "./model-registry.js";
 import { buildAvailableRolesList } from "./team-manager.js";
 // createWorktree is used in session-setup.ts pipeline
 import { ProjectContextManager } from "./project-context-manager.js";
-import { GoalStore } from "./goal-store.js";
+import { GoalStore, type PersistedGoal } from "./goal-store.js";
 import { TaskStore } from "./task-store.js";
 import type { GateStore } from "./gate-store.js";
 import { bobbitStateDir, globalAuthPath } from "../bobbit-dir.js";
@@ -270,13 +270,24 @@ export class SessionManager {
 		return this.searchIndex;
 	}
 
+	/** Resolve a goal across all project contexts. */
+	private resolveGoal(goalId: string): PersistedGoal | undefined {
+		if (this.projectContextManager) {
+			const ctx = this.projectContextManager.getContextForGoal(goalId);
+			if (ctx) return ctx.goalStore.get(goalId);
+		}
+		return this.goalManager.getGoalStore().get(goalId);
+	}
+
 	/** Whether Docker sandbox mode is enabled in project config. */
 	get isSandboxEnabled(): boolean {
 		return (this.projectConfigStore?.get("sandbox") || "none") === "docker";
 	}
 
 	/** Build a PipelineContext from this manager's fields. */
-	buildPipelineContext(): PipelineContext {
+	buildPipelineContext(projectId?: string): PipelineContext {
+		const resolvedStore = this.getSessionStore(projectId);
+		const resolvedSearchIndex = this.getSearchIndexForProject(projectId);
 		return {
 			agentCliPath: this.agentCliPath,
 			systemPromptPath: this.systemPromptPath,
@@ -291,8 +302,8 @@ export class SessionManager {
 			sandboxTokenStore: this.sandboxTokenStore,
 			groupPolicyStore: this.groupPolicyStore ?? null,
 			costTracker: this.costTracker,
-			store: this.store,
-			searchIndex: this.searchIndex,
+			store: resolvedStore,
+			searchIndex: resolvedSearchIndex,
 			sessions: this.sessions,
 			assemblePrompt: (id, parts) => this.assemblePrompt(id, parts),
 			buildToolRestrictionsText: (tools, role) => this.buildToolRestrictionsText(tools, role),
@@ -516,7 +527,7 @@ export class SessionManager {
 				// Inject re-attempt context if this is a re-attempt session
 				const reattemptId = (this.store.get(session.id) as any)?.reattemptGoalId;
 				if (reattemptId) {
-					const origGoal = this.goalManager.getGoal(reattemptId);
+					const origGoal = this.resolveGoal(reattemptId);
 					if (origGoal) {
 						assistantGoalSpec += "\n\n" + buildReattemptContext(origGoal);
 					}
@@ -532,7 +543,7 @@ export class SessionManager {
 				projectConfigStore: this.projectConfigStore,
 			};
 		} else {
-			const goal = session.goalId ? this.goalManager.getGoal(session.goalId) : undefined;
+			const goal = session.goalId ? this.resolveGoal(session.goalId) : undefined;
 			const resolvedPersonalities = (session.personalities && session.personalities.length > 0 && this.personalityManager)
 				? this.personalityManager.resolvePersonalities(session.personalities)
 				: undefined;
@@ -1135,7 +1146,7 @@ export class SessionManager {
 				};
 				this.store.onIndexUpdate = (session) => {
 					try {
-						const goalTitle = session.goalId ? this.goalManager.getGoal(session.goalId)?.title : undefined;
+						const goalTitle = session.goalId ? this.resolveGoal(session.goalId)?.title : undefined;
 						this.searchIndex.indexSession(session, goalTitle, session.projectId || "");
 					} catch (err) { console.error("[search] Failed to index session:", err); }
 				};
@@ -1144,7 +1155,9 @@ export class SessionManager {
 			}
 		}
 
-		const persisted = this.store.getLive();
+		const persisted = this.projectContextManager
+			? [...this.projectContextManager.getAllLiveSessions()]
+			: this.store.getLive();
 		if (persisted.length === 0) return;
 
 		// Separate regular sessions from delegate sessions
@@ -1163,7 +1176,7 @@ export class SessionManager {
 		// Delegate sessions: dormant entries only — restored on-demand via addClient()
 		for (const ps of delegates) {
 			if (!ps.agentSessionFile || !fs.existsSync(ps.agentSessionFile)) {
-				this.store.remove(ps.id);
+				this.getSessionStore(ps.projectId).remove(ps.id);
 				continue;
 			}
 			this.addDormantSession(ps);
@@ -1213,6 +1226,7 @@ export class SessionManager {
 	}
 
 	private async restoreOneSession(ps: PersistedSession): Promise<void> {
+		const sessionStore = this.getSessionStore(ps.projectId);
 		if (!ps.agentSessionFile) {
 			if (ps.worktreePath && ps.branch) {
 				// Code may be recoverable — the branch exists in git
@@ -1221,16 +1235,16 @@ export class SessionManager {
 					`(branch: ${ps.branch}, path: ${ps.worktreePath}). ` +
 					`Code may be recoverable. Archiving session — branch "${ps.branch}" preserved in git.`,
 				);
-				this.store.archive(ps.id);
+				sessionStore.archive(ps.id);
 			} else {
 				console.log(`[session-manager] Removing ${ps.id} — no agent session file and no worktree`);
-				this.store.remove(ps.id);
+				sessionStore.remove(ps.id);
 			}
 			return;
 		}
 		if (!fs.existsSync(ps.agentSessionFile)) {
 			console.log(`[session-manager] Removing ${ps.id} — agent session file missing: ${ps.agentSessionFile}`);
-			this.store.remove(ps.id);
+			sessionStore.remove(ps.id);
 			return;
 		}
 		try {
@@ -1337,7 +1351,7 @@ export class SessionManager {
 				assistantGoalSpec = assistantGoalSpec.replace('{{AVAILABLE_WORKFLOWS}}', this._buildWorkflowList());
 				// Inject re-attempt context if this is a re-attempt session
 				if (ps.reattemptGoalId) {
-					const origGoal = this.goalManager.getGoal(ps.reattemptGoalId);
+					const origGoal = this.resolveGoal(ps.reattemptGoalId);
 					if (origGoal) {
 						assistantGoalSpec += "\n\n" + buildReattemptContext(origGoal);
 					}
@@ -1355,7 +1369,7 @@ export class SessionManager {
 			});
 			if (promptPath) bridgeOptions.systemPromptPath = promptPath;
 		} else {
-			const goal = ps.goalId ? this.goalManager.getGoal(ps.goalId) : undefined;
+			const goal = ps.goalId ? this.resolveGoal(ps.goalId) : undefined;
 			// Resolve persisted personality names to prompt fragments
 			const resolvedPersonalities = (ps.personalities && ps.personalities.length > 0 && this.personalityManager)
 				? this.personalityManager.resolvePersonalities(ps.personalities)
@@ -1478,9 +1492,11 @@ export class SessionManager {
 		}
 	}
 
-	async createSession(cwd: string, agentArgs?: string[], goalId?: string, assistantType?: string, opts?: { rolePrompt?: string; roleName?: string; env?: Record<string, string>; taskId?: string; allowedTools?: string[]; personalities?: Array<{ label: string; promptFragment: string }>; personalityNames?: string[]; workflowContext?: string; worktreeOpts?: { repoPath: string }; reattemptGoalId?: string; sandboxed?: boolean; sandboxClaim?: ClaimOptions }): Promise<SessionInfo> {
+	async createSession(cwd: string, agentArgs?: string[], goalId?: string, assistantType?: string, opts?: { rolePrompt?: string; roleName?: string; env?: Record<string, string>; taskId?: string; allowedTools?: string[]; personalities?: Array<{ label: string; promptFragment: string }>; personalityNames?: string[]; workflowContext?: string; worktreeOpts?: { repoPath: string }; reattemptGoalId?: string; sandboxed?: boolean; sandboxClaim?: ClaimOptions; projectId?: string }): Promise<SessionInfo> {
 		const id = randomUUID();
-		const ctx = this.buildPipelineContext();
+		// Resolve projectId from opts or from the goal's project
+		const projectId = opts?.projectId ?? (goalId ? this.resolveGoal(goalId)?.projectId : undefined);
+		const ctx = this.buildPipelineContext(projectId);
 
 		// ── Worktree: return a "preparing" session immediately, launch agent async ──
 		if (opts?.worktreeOpts) {
@@ -1603,10 +1619,14 @@ export class SessionManager {
 		context?: Record<string, string>;
 	}): Promise<SessionInfo> {
 		const id = randomUUID();
-		const ctx = this.buildPipelineContext();
+		// Resolve projectId from parent session
+		const parentProjectId = this.sessions.get(parentSessionId)?.projectId
+			?? this.store.get(parentSessionId)?.projectId;
+		const ctx = this.buildPipelineContext(parentProjectId);
 
 		// ── Sandbox propagation from parent ──
-		const parentMeta = this.store.get(parentSessionId);
+		const parentMeta = this.getSessionStore(parentProjectId).get(parentSessionId)
+			?? this.store.get(parentSessionId);
 		let delegateSandboxed = false;
 		if (parentMeta?.sandboxed) {
 			// Always use the parent's validated host-side cwd — never trust the
@@ -2152,7 +2172,7 @@ export class SessionManager {
 		await session.rpcClient.stop();
 
 		// Reassemble system prompt with role instructions as separate fields
-		const goal = session.goalId ? this.goalManager.getGoal(session.goalId) : undefined;
+		const goal = session.goalId ? this.resolveGoal(session.goalId) : undefined;
 		const goalSpec = goal?.spec;
 		let toolRestrictionsText: string | undefined;
 		// Look up the full role (with toolPolicies) from roleManager if available
@@ -2283,7 +2303,7 @@ export class SessionManager {
 		await session.rpcClient.stop();
 
 		// Reassemble system prompt with new personalities (preserving role prompt if assigned)
-		const goal = session.goalId ? this.goalManager.getGoal(session.goalId) : undefined;
+		const goal = session.goalId ? this.resolveGoal(session.goalId) : undefined;
 		const goalSpec = goal?.spec;
 
 		// If the session has a role, include its prompt template as separate fields

--- a/src/server/agent/staff-manager.ts
+++ b/src/server/agent/staff-manager.ts
@@ -3,7 +3,6 @@ import { StaffStore, type PersistedStaff, type StaffState, type StaffTrigger } f
 import type { SessionManager } from "./session-manager.js";
 import type { SearchIndex } from "../search/search-index.js";
 import { createWorktree, cleanupWorktree } from "../skills/git.js";
-import { bobbitStateDir } from "../bobbit-dir.js";
 
 function sanitiseBranchName(name: string): string {
 	return name.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
@@ -12,8 +11,8 @@ function sanitiseBranchName(name: string): string {
 export class StaffManager {
 	private store: StaffStore;
 
-	constructor(stateDir?: string) {
-		this.store = new StaffStore(stateDir ?? bobbitStateDir());
+	constructor(staffStore: StaffStore) {
+		this.store = staffStore;
 	}
 	searchIndex?: SearchIndex;
 

--- a/src/server/agent/state-migration.ts
+++ b/src/server/agent/state-migration.ts
@@ -77,7 +77,7 @@ export function migrateToPerProjectState(
 	}
 
 	// Helper: merge items into an existing JSON array file by ID field, write back
-	function mergeAndWrite<T extends Record<string, unknown>>(
+	function mergeAndWrite<T>(
 		targetFile: string,
 		newItems: T[],
 		idField: string,

--- a/src/server/agent/state-migration.ts
+++ b/src/server/agent/state-migration.ts
@@ -1,0 +1,284 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { ProjectRegistry, RegisteredProject } from "./project-registry.js";
+import type { PersistedGoal } from "./goal-store.js";
+import type { PersistedSession } from "./session-store.js";
+import type { PersistedStaff } from "./staff-store.js";
+import type { PersistedTask } from "./task-store.js";
+import type { PersistedTeamEntry } from "./team-store.js";
+import type { GateState } from "./gate-store.js";
+
+const MIGRATION_MARKER = ".migrated-to-per-project";
+const PRE_MIGRATION_SUFFIX = ".pre-migration";
+
+/**
+ * One-time migration from centralized state (`<server-cwd>/.bobbit/state/`)
+ * to per-project state (`<project-root>/.bobbit/state/`).
+ *
+ * Distributes goals, sessions, tasks, teams, gates, and staff to the
+ * correct project's state directory based on `projectId` tags.
+ * Records without a `projectId` go to the default project.
+ *
+ * Renamed (not deleted) central files get a `.pre-migration` suffix.
+ * A marker file prevents re-running.
+ *
+ * Uses synchronous fs operations — runs once at startup.
+ */
+export function migrateToPerProjectState(
+	centralStateDir: string,
+	projectRegistry: ProjectRegistry,
+	serverCwd: string,
+): void {
+	const markerPath = path.join(centralStateDir, MIGRATION_MARKER);
+
+	// 1. Already migrated?
+	if (fs.existsSync(markerPath)) return;
+
+	const projects = projectRegistry.list();
+	if (projects.length === 0) {
+		// No projects registered — nothing to migrate to
+		return;
+	}
+
+	// Find the default project: prefer the one at serverCwd, else first registered
+	const defaultProject =
+		projectRegistry.getByPath(serverCwd) ?? projects[0];
+
+	console.log(
+		`[migration] Starting per-project state migration. Default project: "${defaultProject.name}" (${defaultProject.id})`,
+	);
+
+	// Helper: resolve project for a given projectId
+	const resolveProject = (projectId?: string): RegisteredProject => {
+		if (projectId) {
+			const p = projectRegistry.get(projectId);
+			if (p) return p;
+		}
+		return defaultProject;
+	};
+
+	// Helper: ensure <project>/.bobbit/state/ exists
+	const ensureProjectStateDir = (project: RegisteredProject): string => {
+		const dir = path.join(project.rootPath, ".bobbit", "state");
+		fs.mkdirSync(dir, { recursive: true });
+		return dir;
+	};
+
+	// Helper: read a JSON array file, return empty array if missing/corrupt
+	function readJsonArray<T>(filePath: string): T[] {
+		try {
+			if (!fs.existsSync(filePath)) return [];
+			const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+			return Array.isArray(data) ? data : [];
+		} catch {
+			console.log(`[migration] Warning: could not parse ${filePath}, skipping`);
+			return [];
+		}
+	}
+
+	// Helper: merge items into an existing JSON array file by ID field, write back
+	function mergeAndWrite<T extends Record<string, unknown>>(
+		targetFile: string,
+		newItems: T[],
+		idField: string,
+	): void {
+		if (newItems.length === 0) return;
+		const dir = path.dirname(targetFile);
+		fs.mkdirSync(dir, { recursive: true });
+		const existing = readJsonArray<T>(targetFile);
+		const existingIds = new Set(existing.map((item) => String((item as Record<string, unknown>)[idField])));
+		let added = 0;
+		for (const item of newItems) {
+			if (!existingIds.has(String((item as Record<string, unknown>)[idField]))) {
+				existing.push(item);
+				added++;
+			}
+		}
+		fs.writeFileSync(targetFile, JSON.stringify(existing, null, 2), "utf-8");
+		if (added > 0) {
+			console.log(
+				`[migration] Wrote ${added} new items to ${targetFile}`,
+			);
+		}
+	}
+
+	// Helper: safely rename a file with .pre-migration suffix
+	function renameForBackup(filePath: string): void {
+		try {
+			if (fs.existsSync(filePath)) {
+				const backupPath = filePath + PRE_MIGRATION_SUFFIX;
+				// Don't overwrite an existing backup
+				if (!fs.existsSync(backupPath)) {
+					fs.renameSync(filePath, backupPath);
+					console.log(`[migration] Renamed ${path.basename(filePath)} → ${path.basename(backupPath)}`);
+				}
+			}
+		} catch (err) {
+			console.log(`[migration] Warning: could not rename ${filePath}: ${err}`);
+		}
+	}
+
+	// ── 2. Read central goals.json and build goal→project map ──
+	const centralGoalsFile = path.join(centralStateDir, "goals.json");
+	const centralGoals = readJsonArray<PersistedGoal>(centralGoalsFile);
+	const goalProjectMap = new Map<string, RegisteredProject>();
+	const goalsByProject = new Map<string, PersistedGoal[]>();
+
+	for (const goal of centralGoals) {
+		const project = resolveProject(goal.projectId);
+		goalProjectMap.set(goal.id, project);
+		let bucket = goalsByProject.get(project.id);
+		if (!bucket) {
+			bucket = [];
+			goalsByProject.set(project.id, bucket);
+		}
+		bucket.push(goal);
+	}
+
+	// Write goals to per-project state dirs
+	for (const [projectId, goals] of goalsByProject) {
+		const project = projectRegistry.get(projectId)!;
+		const stateDir = ensureProjectStateDir(project);
+		mergeAndWrite(path.join(stateDir, "goals.json"), goals, "id");
+	}
+	console.log(`[migration] Distributed ${centralGoals.length} goals across ${goalsByProject.size} project(s)`);
+
+	// ── 3. Sessions ──
+	const centralSessionsFile = path.join(centralStateDir, "sessions.json");
+	const centralSessions = readJsonArray<PersistedSession>(centralSessionsFile);
+	const sessionsByProject = new Map<string, PersistedSession[]>();
+
+	for (const session of centralSessions) {
+		const project = resolveProject(session.projectId);
+		let bucket = sessionsByProject.get(project.id);
+		if (!bucket) {
+			bucket = [];
+			sessionsByProject.set(project.id, bucket);
+		}
+		bucket.push(session);
+	}
+
+	for (const [projectId, sessions] of sessionsByProject) {
+		const project = projectRegistry.get(projectId)!;
+		const stateDir = ensureProjectStateDir(project);
+		mergeAndWrite(path.join(stateDir, "sessions.json"), sessions, "id");
+	}
+	console.log(`[migration] Distributed ${centralSessions.length} sessions across ${sessionsByProject.size} project(s)`);
+
+	// ── 4. Tasks — resolve project via goalId → goal's project ──
+	const centralTasksFile = path.join(centralStateDir, "tasks.json");
+	const centralTasks = readJsonArray<PersistedTask>(centralTasksFile);
+	const tasksByProject = new Map<string, PersistedTask[]>();
+
+	for (const task of centralTasks) {
+		const project = goalProjectMap.get(task.goalId) ?? defaultProject;
+		let bucket = tasksByProject.get(project.id);
+		if (!bucket) {
+			bucket = [];
+			tasksByProject.set(project.id, bucket);
+		}
+		bucket.push(task);
+	}
+
+	for (const [projectId, tasks] of tasksByProject) {
+		const project = projectRegistry.get(projectId)!;
+		const stateDir = ensureProjectStateDir(project);
+		mergeAndWrite(path.join(stateDir, "tasks.json"), tasks, "id");
+	}
+	console.log(`[migration] Distributed ${centralTasks.length} tasks`);
+
+	// ── 5. Teams — resolve project via goalId ──
+	// TeamStore uses "team-state.json" (with legacy "gateway-swarms.json" fallback)
+	let centralTeamsFile = path.join(centralStateDir, "team-state.json");
+	if (!fs.existsSync(centralTeamsFile)) {
+		centralTeamsFile = path.join(centralStateDir, "gateway-swarms.json");
+	}
+	const centralTeams = readJsonArray<PersistedTeamEntry>(centralTeamsFile);
+	const teamsByProject = new Map<string, PersistedTeamEntry[]>();
+
+	for (const team of centralTeams) {
+		const project = goalProjectMap.get(team.goalId) ?? defaultProject;
+		let bucket = teamsByProject.get(project.id);
+		if (!bucket) {
+			bucket = [];
+			teamsByProject.set(project.id, bucket);
+		}
+		bucket.push(team);
+	}
+
+	for (const [projectId, teams] of teamsByProject) {
+		const project = projectRegistry.get(projectId)!;
+		const stateDir = ensureProjectStateDir(project);
+		mergeAndWrite(path.join(stateDir, "team-state.json"), teams, "goalId");
+	}
+	console.log(`[migration] Distributed ${centralTeams.length} teams`);
+
+	// ── 6. Gates — single gates.json file, distribute by goalId ──
+	const centralGatesFile = path.join(centralStateDir, "gates.json");
+	const centralGates = readJsonArray<GateState>(centralGatesFile);
+	const gatesByProject = new Map<string, GateState[]>();
+
+	for (const gate of centralGates) {
+		const project = goalProjectMap.get(gate.goalId) ?? defaultProject;
+		let bucket = gatesByProject.get(project.id);
+		if (!bucket) {
+			bucket = [];
+			gatesByProject.set(project.id, bucket);
+		}
+		bucket.push(gate);
+	}
+
+	for (const [projectId, gates] of gatesByProject) {
+		const project = projectRegistry.get(projectId)!;
+		const stateDir = ensureProjectStateDir(project);
+		// Gates use composite key (goalId::gateId), so merge with a custom approach
+		const targetFile = path.join(stateDir, "gates.json");
+		fs.mkdirSync(path.dirname(targetFile), { recursive: true });
+		const existing = readJsonArray<GateState>(targetFile);
+		const existingKeys = new Set(
+			existing.map((g) => `${g.goalId}::${g.gateId}`),
+		);
+		let added = 0;
+		for (const gate of gates) {
+			const key = `${gate.goalId}::${gate.gateId}`;
+			if (!existingKeys.has(key)) {
+				existing.push(gate);
+				added++;
+			}
+		}
+		fs.writeFileSync(targetFile, JSON.stringify(existing, null, 2), "utf-8");
+		if (added > 0) {
+			console.log(`[migration] Wrote ${added} gate states to ${targetFile}`);
+		}
+	}
+	console.log(`[migration] Distributed ${centralGates.length} gate states`);
+
+	// ── 7. Staff — no projectId, all go to default project ──
+	const centralStaffFile = path.join(centralStateDir, "staff.json");
+	const centralStaff = readJsonArray<PersistedStaff>(centralStaffFile);
+	if (centralStaff.length > 0) {
+		const stateDir = ensureProjectStateDir(defaultProject);
+		mergeAndWrite(path.join(stateDir, "staff.json"), centralStaff, "id");
+		console.log(`[migration] Moved ${centralStaff.length} staff agents to default project`);
+	}
+
+	// ── 8. Rename central files for backup ──
+	renameForBackup(centralGoalsFile);
+	renameForBackup(centralSessionsFile);
+	renameForBackup(centralTasksFile);
+	renameForBackup(centralStaffFile);
+	renameForBackup(centralGatesFile);
+	// Team store files
+	renameForBackup(path.join(centralStateDir, "team-state.json"));
+	renameForBackup(path.join(centralStateDir, "gateway-swarms.json"));
+	// Search index — will be rebuilt per-project on first access
+	renameForBackup(path.join(centralStateDir, "search.db"));
+
+	// ── 9. Write migration marker ──
+	try {
+		fs.writeFileSync(markerPath, new Date().toISOString(), "utf-8");
+		console.log("[migration] Per-project state migration complete. Marker written.");
+	} catch (err) {
+		console.error("[migration] Failed to write migration marker:", err);
+	}
+}

--- a/src/server/agent/task-manager.ts
+++ b/src/server/agent/task-manager.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 import { TaskStore, type TaskState, type PersistedTask } from "./task-store.js";
-import { bobbitStateDir } from "../bobbit-dir.js";
 
 /** Valid state transitions. Terminal states (complete, skipped) have no outgoing transitions. */
 const VALID_TRANSITIONS: Record<TaskState, TaskState[]> = {
@@ -14,8 +13,8 @@ const VALID_TRANSITIONS: Record<TaskState, TaskState[]> = {
 export class TaskManager {
 	private store: TaskStore;
 
-	constructor(stateDir?: string) {
-		this.store = new TaskStore(stateDir ?? bobbitStateDir());
+	constructor(taskStore: TaskStore) {
+		this.store = taskStore;
 	}
 
 	/**

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import type { SessionManager, SessionInfo } from "./session-manager.js";
-import type { GoalManager } from "./goal-manager.js";
+import { GoalManager } from "./goal-manager.js";
+import type { PersistedGoal } from "./goal-store.js";
 import { createWorktree, cleanupWorktree } from "../skills/git.js";
 import type { RoleStore, Role } from "./role-store.js";
 import { TeamStore } from "./team-store.js";
@@ -228,7 +229,15 @@ export class TeamManager {
 	 * Event subscriptions are deferred to resubscribeTeamEvents().
 	 */
 	private restoreTeams(): void {
-		const persisted = this.store.getAll();
+		let persisted: PersistedTeamEntry[];
+		if (this.config.projectContextManager) {
+			persisted = [];
+			for (const ctx of this.config.projectContextManager.all()) {
+				persisted.push(...ctx.teamStore.getAll());
+			}
+		} else {
+			persisted = this.store.getAll();
+		}
 		for (const p of persisted) {
 			const entry: TeamEntry = {
 				goalId: p.goalId,
@@ -403,12 +412,30 @@ export class TeamManager {
 		return this.sessionManager.goalManager;
 	}
 
+	/** Resolve a goal across all project contexts. */
+	private resolveGoal(goalId: string): PersistedGoal | undefined {
+		if (this.config.projectContextManager) {
+			const ctx = this.config.projectContextManager.getContextForGoal(goalId);
+			if (ctx) return ctx.goalStore.get(goalId);
+		}
+		return this.goalManager.getGoal(goalId);
+	}
+
+	/** Get a GoalManager scoped to the project owning the given goal. */
+	private resolveGoalManager(goalId: string): GoalManager {
+		if (this.config.projectContextManager) {
+			const ctx = this.config.projectContextManager.getContextForGoal(goalId);
+			if (ctx) return new GoalManager(ctx.goalStore);
+		}
+		return this.goalManager;
+	}
+
 	/**
 	 * Start a team for the given goal.
 	 * Creates a Team Lead session and returns it.
 	 */
 	async startTeam(goalId: string): Promise<SessionInfo> {
-		const goal = this.goalManager.getGoal(goalId);
+		const goal = this.resolveGoal(goalId);
 		if (!goal) {
 			throw new Error(`Goal not found: ${goalId}`);
 		}
@@ -486,7 +513,7 @@ export class TeamManager {
 
 		// Transition goal to in-progress if needed
 		if (goal.state === "todo") {
-			await this.goalManager.updateGoal(goalId, { state: "in-progress" });
+			await this.resolveGoalManager(goalId).updateGoal(goalId, { state: "in-progress" });
 		}
 
 		// Kick off the team lead with an initial prompt (same pattern as delegate sessions)
@@ -510,7 +537,7 @@ export class TeamManager {
 	 * Otherwise, auto-resolves from the DAG's `dependsOn` for `workflowGateId`.
 	 */
 	buildDependencyContext(goalId: string, workflowGateId?: string, explicitInputIds?: string[]): string {
-		const goal = this.goalManager.getGoal(goalId);
+		const goal = this.resolveGoal(goalId);
 		const resolvedGateStore = this.resolveGateStore(goalId);
 		if (!goal?.workflow || !resolvedGateStore) return "";
 
@@ -564,7 +591,7 @@ export class TeamManager {
 		if (tagMatch) return tagMatch[1];
 
 		// Try to match against workflow gate names/IDs in the goal
-		const goal = this.goalManager.getGoal(goalId);
+		const goal = this.resolveGoal(goalId);
 		if (!goal?.workflow) return undefined;
 
 		const taskLower = task.toLowerCase();
@@ -605,7 +632,7 @@ export class TeamManager {
 			);
 		}
 
-		const goal = this.goalManager.getGoal(goalId);
+		const goal = this.resolveGoal(goalId);
 		if (!goal) {
 			throw new Error(`Goal not found: ${goalId}`);
 		}
@@ -870,7 +897,7 @@ export class TeamManager {
 		}
 
 		// Persist repoPath and branch before archiving so worktree can be cleaned up later
-		const goal = this.goalManager.getGoal(goalId);
+		const goal = this.resolveGoal(goalId);
 		if (goal?.repoPath && agent.worktreePath) {
 			this.sessionManager.updateSessionMeta(sessionId, {
 				worktreePath: agent.worktreePath,
@@ -986,7 +1013,7 @@ export class TeamManager {
 		// Enforce gate requirements before allowing completion
 		const completeGateStore = this.resolveGateStore(goalId);
 		if (completeGateStore) {
-			const goal = this.goalManager.getGoal(goalId);
+			const goal = this.resolveGoal(goalId);
 			const skipReqs = goal?.skipGateRequirements;
 
 			if (goal?.workflow && (!skipReqs || !skipReqs.includes("workflow"))) {
@@ -1017,7 +1044,7 @@ export class TeamManager {
 		// The team lead will await further instructions.
 
 		// Update goal state
-		await this.goalManager.updateGoal(goalId, { state: "complete" });
+		await this.resolveGoalManager(goalId).updateGoal(goalId, { state: "complete" });
 
 		// Keep team tracking alive so the team lead can still be found
 		// but persist the updated state (agents cleared)
@@ -1052,7 +1079,7 @@ export class TeamManager {
 
 		// Terminate the team lead session — persist worktree info first so purge can clean up
 		if (entry.teamLeadSessionId) {
-			const goal = this.goalManager.getGoal(goalId);
+			const goal = this.resolveGoal(goalId);
 			if (goal?.repoPath) {
 				const store = (this.sessionManager as any).store;
 				if (store) {

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -903,7 +903,12 @@ export class TeamManager {
 				worktreePath: agent.worktreePath,
 			});
 			// Store repoPath and branch in the session store for later purge cleanup
-			const store = (this.sessionManager as any).store;
+			const projectCtx = goalId && this.config.projectContextManager
+				? this.config.projectContextManager.getContextForGoal(goalId)
+				: null;
+			const store = projectCtx
+				? projectCtx.sessionStore
+				: (this.sessionManager as any).store;
 			if (store) {
 				store.update(sessionId, { repoPath: goal.repoPath, branch: agent.branch });
 			}
@@ -1081,7 +1086,12 @@ export class TeamManager {
 		if (entry.teamLeadSessionId) {
 			const goal = this.resolveGoal(goalId);
 			if (goal?.repoPath) {
-				const store = (this.sessionManager as any).store;
+				const projectCtx = this.config.projectContextManager
+					? this.config.projectContextManager.getContextForGoal(goalId)
+					: null;
+				const store = projectCtx
+					? projectCtx.sessionStore
+					: (this.sessionManager as any).store;
 				if (store) {
 					store.update(entry.teamLeadSessionId, {
 						repoPath: goal.repoPath,

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -13,6 +13,7 @@ import type { ColorStore } from "./color-store.js";
 import type { GateStore } from "./gate-store.js";
 import type { PersonalityManager } from "./personality-manager.js";
 import type { VerificationHarness } from "./verification-harness.js";
+import type { ProjectContextManager } from "./project-context-manager.js";
 
 
 /**
@@ -112,6 +113,8 @@ export interface TeamManagerConfig {
 	personalityManager?: PersonalityManager;
 	/** Broadcast a WS event to all clients viewing a goal */
 	broadcastToGoal?: (goalId: string, event: any) => void;
+	/** Project context manager for per-project store resolution */
+	projectContextManager?: ProjectContextManager;
 }
 
 export class TeamManager {
@@ -133,8 +136,29 @@ export class TeamManager {
 		this.sessionManager = sessionManager;
 		this.config = config;
 		this.taskManager = config.taskManager;
-		this.store = new TeamStore(stateDir ?? bobbitStateDir());
+		if (config.projectContextManager) {
+			const defaultCtx = config.projectContextManager.getDefault();
+			this.store = defaultCtx.teamStore;
+		} else {
+			this.store = new TeamStore(stateDir ?? bobbitStateDir());
+		}
 		this.restoreTeams();
+	}
+
+	private resolveTeamStore(goalId?: string): TeamStore {
+		if (goalId && this.config.projectContextManager) {
+			const ctx = this.config.projectContextManager.getContextForGoal(goalId);
+			if (ctx) return ctx.teamStore;
+		}
+		return this.store;
+	}
+
+	private resolveGateStore(goalId?: string): GateStore | undefined {
+		if (goalId && this.config.projectContextManager) {
+			const ctx = this.config.projectContextManager.getContextForGoal(goalId);
+			if (ctx) return ctx.gateStore;
+		}
+		return this.config.gateStore;
 	}
 
 	/** Set the broadcastToGoal function (called after WebSocket server is created). */
@@ -190,7 +214,7 @@ export class TeamManager {
 	private persistEntry(goalId: string): void {
 		const entry = this.teams.get(goalId);
 		if (entry) {
-			this.store.put(this.toPersistedEntry(entry));
+			this.resolveTeamStore(goalId).put(this.toPersistedEntry(entry));
 		}
 	}
 
@@ -487,7 +511,8 @@ export class TeamManager {
 	 */
 	buildDependencyContext(goalId: string, workflowGateId?: string, explicitInputIds?: string[]): string {
 		const goal = this.goalManager.getGoal(goalId);
-		if (!goal?.workflow || !this.config.gateStore) return "";
+		const resolvedGateStore = this.resolveGateStore(goalId);
+		if (!goal?.workflow || !resolvedGateStore) return "";
 
 		// Determine which gate IDs to inject content from
 		let inputIds: string[];
@@ -501,7 +526,7 @@ export class TeamManager {
 			return "";
 		}
 
-		const gateStates = this.config.gateStore.getGatesForGoal(goalId);
+		const gateStates = resolvedGateStore.getGatesForGoal(goalId);
 		const parts: string[] = [];
 
 		for (const depId of inputIds) {
@@ -591,10 +616,11 @@ export class TeamManager {
 
 		// Enforce gate dependency check: upstream gates must be passed before spawning for a gate
 		const resolvedWorkflowGateId = opts?.workflowGateId ?? this.extractWorkflowGateId(task, goalId);
-		if (resolvedWorkflowGateId && this.config.gateStore && goal.workflow) {
+		const spawnGateStore = this.resolveGateStore(goalId);
+		if (resolvedWorkflowGateId && spawnGateStore && goal.workflow) {
 			const wfGate = goal.workflow.gates.find(g => g.id === resolvedWorkflowGateId);
 			if (wfGate?.dependsOn?.length) {
-				const gateStates = this.config.gateStore.getGatesForGoal(goalId);
+				const gateStates = spawnGateStore.getGatesForGoal(goalId);
 				const passedIds = new Set(gateStates.filter(g => g.status === "passed").map(g => g.gateId));
 				const notPassed = wfGate.dependsOn.filter(depId => !passedIds.has(depId));
 				if (notPassed.length > 0) {
@@ -958,12 +984,13 @@ export class TeamManager {
 		}
 
 		// Enforce gate requirements before allowing completion
-		if (this.config.gateStore) {
+		const completeGateStore = this.resolveGateStore(goalId);
+		if (completeGateStore) {
 			const goal = this.goalManager.getGoal(goalId);
 			const skipReqs = goal?.skipGateRequirements;
 
 			if (goal?.workflow && (!skipReqs || !skipReqs.includes("workflow"))) {
-				const gateStates = this.config.gateStore.getGatesForGoal(goalId);
+				const gateStates = completeGateStore.getGatesForGoal(goalId);
 				const passedIds = new Set(gateStates.filter(g => g.status === "passed").map(g => g.gateId));
 				const failedGates = goal.workflow.gates.filter(g => !passedIds.has(g.id));
 				if (failedGates.length > 0) {
@@ -1046,7 +1073,7 @@ export class TeamManager {
 
 		// Remove team tracking entirely
 		this.teams.delete(goalId);
-		this.store.remove(goalId);
+		this.resolveTeamStore(goalId).remove(goalId);
 
 		console.log(`[team-manager] Tore down team for goal ${goalId}`);
 	}

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -425,7 +425,7 @@ export class TeamManager {
 	private resolveGoalManager(goalId: string): GoalManager {
 		if (this.config.projectContextManager) {
 			const ctx = this.config.projectContextManager.getContextForGoal(goalId);
-			if (ctx) return new GoalManager(ctx.goalStore);
+			if (ctx) return ctx.goalManager;
 		}
 		return this.goalManager;
 	}

--- a/src/server/agent/verification-harness.ts
+++ b/src/server/agent/verification-harness.ts
@@ -885,7 +885,10 @@ export class VerificationHarness {
 			const session = await this.sessionManager!.createSession(cwd, undefined, goalId, undefined, {
 				rolePrompt: combinedPrompt,
 				allowedTools: role.allowedTools,
-				sandboxed: (goalId ? this.sessionManager!.goalManager.getGoal(goalId)?.sandboxed : undefined) ?? this.sessionManager!.isSandboxEnabled,
+				sandboxed: (goalId
+				? (this.projectContextManager?.getContextForGoal(goalId)?.goalStore.get(goalId)?.sandboxed
+					?? this.sessionManager!.goalManager.getGoal(goalId)?.sandboxed)
+				: undefined) ?? this.sessionManager!.isSandboxEnabled,
 			});
 			sessionId = session.id;
 

--- a/src/server/agent/verification-harness.ts
+++ b/src/server/agent/verification-harness.ts
@@ -10,6 +10,7 @@ import { assembleSystemPrompt } from "./system-prompt.js";
 import type { WorkflowGate } from "./workflow-store.js";
 import type { ProjectConfigStore } from "./project-config-store.js";
 import { GIT_BASH, getShellConfig } from "./shell-util.js";
+import type { ProjectContextManager } from "./project-context-manager.js";
 
 /** Extract pass/fail verdict from sub-agent output. Exported for unit testing. */
 export function parseVerdict(output: string): boolean | null {
@@ -54,6 +55,7 @@ export class VerificationHarness {
 	private notifyTeamLeadFn?: (goalId: string, message: string) => void;
 	private activeVerifications = new Map<string, ActiveVerification>();
 	private readonly _persistPath: string;
+	private projectContextManager: ProjectContextManager | null;
 
 	/** Get all active (in-flight) verifications, optionally filtered by goalId */
 	getActiveVerifications(goalId?: string): ActiveVerification[] {
@@ -126,11 +128,11 @@ export class VerificationHarness {
 			} catch (err) {
 				console.error(`[verification] Failed to resume verification ${v.signalId}:`, err);
 				// Mark as failed and update gate
-				this.gateStore.updateSignalVerification(v.signalId, {
+				this.resolveGateStore(v.goalId).updateSignalVerification(v.signalId, {
 					status: "failed",
 					steps: [{ name: "Resume Error", type: "command", passed: false, output: `Failed to resume after restart: ${(err as Error).message}`, duration_ms: 0 }],
 				});
-				this.gateStore.updateGateStatus(v.goalId, v.gateId, "failed");
+				this.resolveGateStore(v.goalId).updateGateStatus(v.goalId, v.gateId, "failed");
 				this.broadcastFn(v.goalId, {
 					type: "gate_verification_complete",
 					goalId: v.goalId, gateId: v.gateId, signalId: v.signalId, status: "failed",
@@ -259,7 +261,7 @@ export class VerificationHarness {
 		const allPassed = resolvedSteps.every(r => r.passed);
 		const status = allPassed ? "passed" as const : "failed" as const;
 
-		this.gateStore.updateSignalVerification(v.signalId, {
+		this.resolveGateStore(v.goalId).updateSignalVerification(v.signalId, {
 			status,
 			steps: resolvedSteps.map(r => ({
 				name: r.name,
@@ -269,7 +271,7 @@ export class VerificationHarness {
 				duration_ms: r.duration_ms,
 			})),
 		});
-		this.gateStore.updateGateStatus(v.goalId, v.gateId, status);
+		this.resolveGateStore(v.goalId).updateGateStatus(v.goalId, v.gateId, status);
 
 		this.broadcastFn(v.goalId, {
 			type: "gate_verification_complete",
@@ -295,15 +297,25 @@ export class VerificationHarness {
 		private sessionManager?: import("./session-manager.js").SessionManager,
 		private teamManager?: import("./team-manager.js").TeamManager,
 		private projectConfigStore?: ProjectConfigStore,
+		projectContextManager?: ProjectContextManager,
 	) {
 		this._stateDir = stateDir;
 		this._persistPath = path.join(stateDir, "active-verifications.json");
+		this.projectContextManager = projectContextManager ?? null;
 		// Load any persisted active verifications from a prior run into memory
 		// (they'll be resumed by resumeInterruptedVerifications() after session restore)
 		const persisted = this._loadActive();
 		for (const v of persisted) {
 			this.activeVerifications.set(v.signalId, v);
 		}
+	}
+
+	private resolveGateStore(goalId: string): GateStore {
+		if (this.projectContextManager) {
+			const ctx = this.projectContextManager.getContextForGoal(goalId);
+			if (ctx) return ctx.gateStore;
+		}
+		return this.gateStore;
 	}
 
 	/** Register a callback to notify the team lead agent when verification completes. */
@@ -374,8 +386,8 @@ export class VerificationHarness {
 		const steps = gate.verify;
 		if (!steps || steps.length === 0) {
 			// No verification — auto-pass
-			this.gateStore.updateSignalVerification(signal.id, { status: "passed", steps: [] });
-			this.gateStore.updateGateStatus(signal.goalId, signal.gateId, "passed");
+			this.resolveGateStore(signal.goalId).updateSignalVerification(signal.id, { status: "passed", steps: [] });
+			this.resolveGateStore(signal.goalId).updateGateStatus(signal.goalId, signal.gateId, "passed");
 			this.broadcastFn(signal.goalId, {
 				type: "gate_verification_complete",
 				goalId: signal.goalId,
@@ -437,7 +449,7 @@ export class VerificationHarness {
 			// This avoids re-running expensive LLM reviews that already passed on a prior signal.
 			const cachedSteps = new Map<string, GateSignalStep>();
 			if (signal.commitSha) {
-				const gateState = this.gateStore.getGate(signal.goalId, signal.gateId);
+				const gateState = this.resolveGateStore(signal.goalId).getGate(signal.goalId, signal.gateId);
 				if (gateState) {
 					for (const prev of gateState.signals) {
 						if (prev.id === signal.id) continue;
@@ -464,8 +476,8 @@ export class VerificationHarness {
 				});
 				const allPassed = results.every(r => r.passed);
 				const status = allPassed ? "passed" as const : "failed" as const;
-				this.gateStore.updateSignalVerification(signal.id, { status, steps: results });
-				this.gateStore.updateGateStatus(signal.goalId, signal.gateId, status);
+				this.resolveGateStore(signal.goalId).updateSignalVerification(signal.id, { status, steps: results });
+				this.resolveGateStore(signal.goalId).updateGateStatus(signal.goalId, signal.gateId, status);
 				this.activeVerifications.delete(signal.id);
 				this._persistActive();
 				// Broadcast step completions and overall result
@@ -652,8 +664,8 @@ export class VerificationHarness {
 			const allPassed = results.every(r => r.passed);
 			const status = allPassed ? "passed" : "failed";
 
-			this.gateStore.updateSignalVerification(signal.id, { status, steps: results });
-			this.gateStore.updateGateStatus(signal.goalId, signal.gateId, status);
+			this.resolveGateStore(signal.goalId).updateSignalVerification(signal.id, { status, steps: results });
+			this.resolveGateStore(signal.goalId).updateGateStatus(signal.goalId, signal.gateId, status);
 			this.activeVerifications.delete(signal.id);
 			this._persistActive();
 
@@ -677,11 +689,11 @@ export class VerificationHarness {
 				this._persistActive();
 				return;
 			}
-			this.gateStore.updateSignalVerification(signal.id, {
+			this.resolveGateStore(signal.goalId).updateSignalVerification(signal.id, {
 				status: "failed",
 				steps: [{ name: "Error", type: "command", passed: false, output: err.message, duration_ms: 0 }],
 			});
-			this.gateStore.updateGateStatus(signal.goalId, signal.gateId, "failed");
+			this.resolveGateStore(signal.goalId).updateGateStatus(signal.goalId, signal.gateId, "failed");
 			this.activeVerifications.delete(signal.id);
 			this._persistActive();
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1501,7 +1501,7 @@ async function handleApiRoute(
 				json({ error: "Invalid project" }, 400);
 				return;
 			}
-			const targetGoalManager = new GoalManager(targetCtx.goalStore, workflowManager.store);
+			const targetGoalManager = targetCtx.goalManager;
 			const goal = await targetGoalManager.createGoal(title, cwd, {
 				spec,
 				workflowId,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -26,7 +26,7 @@ import { PersonalityManager } from "./agent/personality-manager.js";
 import { getPromptSections, initPromptDirs } from "./agent/system-prompt.js";
 import type { TaskState } from "./agent/task-store.js";
 import { BgProcessManager } from "./agent/bg-process-manager.js";
-import type { GateStore } from "./agent/gate-store.js";
+
 import { WorkflowStore } from "./agent/workflow-store.js";
 import { WorkflowManager } from "./agent/workflow-manager.js";
 import { isGitRepo, getRepoRoot } from "./skills/git.js";
@@ -46,7 +46,6 @@ import { configureAigw, removeAigw, getAigwUrl, discoverAigwModels, proxyRequest
 import { getAvailableModels, discoverModelsForConfig } from "./agent/model-registry.js";
 import type { CustomProviderConfig } from "./agent/model-registry.js";
 import { ProjectRegistry } from "./agent/project-registry.js";
-import { ProjectContext } from "./agent/project-context.js";
 import { ProjectContextManager } from "./agent/project-context-manager.js";
 import { migrateToPerProjectState } from "./agent/state-migration.js";
 import { resolveScalarConfig } from "./agent/config-resolver.js";

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -47,6 +47,8 @@ import { getAvailableModels, discoverModelsForConfig } from "./agent/model-regis
 import type { CustomProviderConfig } from "./agent/model-registry.js";
 import { ProjectRegistry } from "./agent/project-registry.js";
 import { ProjectContextManager } from "./agent/project-context-manager.js";
+import { GoalManager } from "./agent/goal-manager.js";
+import type { PersistedGoal } from "./agent/goal-store.js";
 import { migrateToPerProjectState } from "./agent/state-migration.js";
 import { resolveScalarConfig } from "./agent/config-resolver.js";
 import { initAssistantRegistry } from "./agent/assistant-registry.js";
@@ -424,7 +426,8 @@ export function createGateway(config: GatewayConfig) {
 	sessionManager.setOnPrCreationDetected((session) => {
 		const goalId = session.goalId || session.teamGoalId;
 		if (!goalId) return;
-		const goal = sessionManager.goalManager.getGoal(goalId);
+		const goalCtx = projectContextManager.getContextForGoal(goalId);
+		const goal = goalCtx?.goalStore.get(goalId);
 		if (!goal) return;
 		_prCache.delete(goal.cwd);
 		if (goal.branch) _prCache.delete(`${goal.cwd}::${goal.branch}`);
@@ -603,6 +606,7 @@ export function createGateway(config: GatewayConfig) {
 			triggerEngine.stop();
 			wss.close();
 			await sessionManager.shutdown();
+			projectContextManager.closeAll();
 			if (sandboxPool) {
 				await sandboxPool.shutdown();
 			}
@@ -685,6 +689,29 @@ async function handleApiRoute(
 		res.writeHead(status, { "Content-Type": "application/json" });
 		res.end(JSON.stringify(data));
 	};
+
+	// ── Cross-project helper functions ─────────────────────────────
+
+	/** Retrieve a goal from any project context. */
+	function getGoalAcrossProjects(goalId: string): PersistedGoal | undefined {
+		const ctx = projectContextManager.getContextForGoal(goalId);
+		return ctx?.goalStore.get(goalId);
+	}
+
+	/** List live goals across all projects, optionally filtered by projectId. */
+	function listGoalsAcrossProjects(opts?: { projectId?: string }): PersistedGoal[] {
+		if (opts?.projectId) {
+			const ctx = projectContextManager.getOrCreate(opts.projectId);
+			return ctx ? ctx.goalStore.getLive() : [];
+		}
+		return projectContextManager.getAllLiveGoals();
+	}
+
+	/** Get a GoalManager for the project that owns the given goal. Falls back to default. */
+	function getGoalManagerForGoal(goalId: string): GoalManager {
+		const ctx = projectContextManager.getContextForGoal(goalId) ?? projectContextManager.getDefault();
+		return new GoalManager(ctx.goalStore, workflowManager.store);
+	}
 
 	// GET /api/health — unauthenticated so the client can probe localhost mode
 	if (url.pathname === "/api/health" && req.method === "GET") {
@@ -929,6 +956,13 @@ async function handleApiRoute(
 		try {
 			const color = typeof body.color === "string" ? body.color : undefined;
 			const project = projectRegistry.register(body.name, body.rootPath, color);
+			// Initialize project context for the new project
+			const newCtx = projectContextManager.getOrCreate(project.id);
+			if (newCtx) {
+				newCtx.gateStore.onStatusChange = () => {
+					newCtx.goalStore.bumpGeneration();
+				};
+			}
 			json(project, 201);
 		} catch (err: any) {
 			json({ error: err.message }, 400);
@@ -970,6 +1004,7 @@ async function handleApiRoute(
 			return;
 		}
 		try {
+			projectContextManager.remove(projectId);
 			projectRegistry.remove(projectId);
 			json({ ok: true });
 		} catch (err: any) {
@@ -1036,7 +1071,7 @@ async function handleApiRoute(
 		try {
 			const projectId = url.searchParams.get("projectId") || undefined;
 			const projectNames = new Map(projectRegistry.list().map(p => [p.id, p.name]));
-			const results = sessionManager.searchIndex.search(q, { type, limit, offset, projectId, projectNames });
+			const results = projectContextManager.searchAll(q, { type, limit, offset, projectId, projectNames });
 			json(results);
 		} catch (err) {
 			json({ error: `Search failed: ${err}` }, 500);
@@ -1046,7 +1081,7 @@ async function handleApiRoute(
 
 	// GET /api/sessions
 	if (url.pathname === "/api/sessions" && req.method === "GET") {
-		const currentGen = sessionManager.getSessionStore().getGeneration();
+		const currentGen = projectContextManager.getSessionGeneration();
 		const sinceParam = url.searchParams.get("since");
 		if (sinceParam !== null) {
 			const since = parseInt(sinceParam, 10);
@@ -1220,12 +1255,12 @@ async function handleApiRoute(
 			if (proj) cwd = proj.rootPath;
 		}
 		if (goalId) {
-			const goal = sessionManager.goalManager.getGoal(goalId);
+			const goal = getGoalAcrossProjects(goalId);
 			if (goal) {
 				cwd = body?.cwd || goal.cwd;
 				// Auto-transition goal to in-progress when first session starts
 				if (goal.state === "todo") {
-					await sessionManager.goalManager.updateGoal(goalId, { state: "in-progress" });
+					await getGoalManagerForGoal(goalId).updateGoal(goalId, { state: "in-progress" });
 				}
 			}
 		}
@@ -1364,17 +1399,31 @@ async function handleApiRoute(
 
 	// GET /api/goals
 	if (url.pathname === "/api/goals" && req.method === "GET") {
-		// Paginated archived goals
+		// Paginated archived goals — aggregate across all projects
 		if (url.searchParams.get("archived") === "true") {
 			const limit = Math.min(Math.max(1, parseInt(url.searchParams.get("limit") || "50", 10) || 50), 200);
 			const afterParam = url.searchParams.get("after");
 			const afterCursor = afterParam ? parseInt(afterParam, 10) : undefined;
-			const page = sessionManager.goalManager.getGoalStore().listArchivedGoalsPaginated(limit, afterCursor);
-			json({ goals: page.goals, total: page.total, hasMore: page.hasMore, nextCursor: page.nextCursor });
+			const filterProjectId = url.searchParams.get("projectId") || undefined;
+			// Aggregate archived goals across all project contexts
+			let allArchived: PersistedGoal[] = [];
+			for (const ctx of projectContextManager.all()) {
+				if (filterProjectId && ctx.project.id !== filterProjectId) continue;
+				allArchived.push(...ctx.goalStore.getArchived());
+			}
+			allArchived.sort((a, b) => (b.archivedAt ?? 0) - (a.archivedAt ?? 0));
+			const total = allArchived.length;
+			if (afterCursor !== undefined) {
+				allArchived = allArchived.filter(g => (g.archivedAt ?? 0) < afterCursor);
+			}
+			const page = allArchived.slice(0, limit);
+			const hasMore = allArchived.length > limit;
+			const nextCursor = page.length > 0 ? page[page.length - 1].archivedAt : undefined;
+			json({ goals: page, total, hasMore, nextCursor });
 			return;
 		}
 
-		const currentGen = sessionManager.goalManager.getGoalGeneration();
+		const currentGen = projectContextManager.getGoalGeneration();
 		const sinceParam = url.searchParams.get("since");
 		if (sinceParam !== null) {
 			const since = parseInt(sinceParam, 10);
@@ -1384,10 +1433,7 @@ async function handleApiRoute(
 			}
 		}
 		const filterProjectId = url.searchParams.get("projectId") || undefined;
-		let goals = sessionManager.goalManager.listGoals();
-		if (filterProjectId) {
-			goals = goals.filter(g => g.projectId === filterProjectId);
-		}
+		const goals = listGoalsAcrossProjects({ projectId: filterProjectId });
 		json({ generation: currentGen, goals });
 		return;
 	}
@@ -1410,7 +1456,15 @@ async function handleApiRoute(
 		}
 		try {
 			const sandboxed = body.sandboxed === true;
-			const goal = await sessionManager.goalManager.createGoal(title, cwd, {
+			// Resolve target project context for goal creation
+			const targetProjectId = (body.projectId && typeof body.projectId === "string") ? body.projectId : projectContextManager.getDefaultProjectId();
+			const targetCtx = projectContextManager.getOrCreate(targetProjectId);
+			if (!targetCtx) {
+				json({ error: "Invalid project" }, 400);
+				return;
+			}
+			const targetGoalManager = new GoalManager(targetCtx.goalStore, workflowManager.store);
+			const goal = await targetGoalManager.createGoal(title, cwd, {
 				spec,
 				workflowId,
 				workflowStore: workflowManager.store,
@@ -1418,24 +1472,23 @@ async function handleApiRoute(
 			});
 			// Set projectId if provided
 			if (body.projectId && typeof body.projectId === "string") {
-				sessionManager.goalManager.updateGoal(goal.id, { projectId: body.projectId });
+				targetGoalManager.updateGoal(goal.id, { projectId: body.projectId });
 				goal.projectId = body.projectId;
 			}
 			// Set reattemptOf if provided
 			if (body.reattemptOf && typeof body.reattemptOf === "string") {
-				sessionManager.goalManager.updateGoal(goal.id, { reattemptOf: body.reattemptOf });
+				targetGoalManager.updateGoal(goal.id, { reattemptOf: body.reattemptOf });
 				goal.reattemptOf = body.reattemptOf;
 			}
 			// Initialize gate states for the workflow
 			if (goal.workflow) {
-				const goalCtx = projectContextManager.getContextForGoal(goal.id) ?? projectContextManager.getDefault();
-				goalCtx.gateStore.initGatesForGoal(goal.id, goal.workflow.gates.map(g => g.id));
+				targetCtx.gateStore.initGatesForGoal(goal.id, goal.workflow.gates.map(g => g.id));
 			}
 			json(goal, 201);
 
 			// Fire-and-forget async worktree setup
 			if (goal.setupStatus === "preparing") {
-				sessionManager.goalManager.setupWorktree(goal.id).then(() => {
+				targetGoalManager.setupWorktree(goal.id).then(() => {
 					broadcastToAll({ type: "goal_setup_complete", goalId: goal.id });
 				}).catch((err) => {
 					broadcastToAll({ type: "goal_setup_error", goalId: goal.id, error: String(err) });
@@ -1451,14 +1504,15 @@ async function handleApiRoute(
 	const retrySetupMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/retry-setup$/);
 	if (retrySetupMatch && req.method === "POST") {
 		const goalId = retrySetupMatch[1];
-		const ok = sessionManager.goalManager.retrySetup(goalId);
+		const retryGoalManager = getGoalManagerForGoal(goalId);
+		const ok = retryGoalManager.retrySetup(goalId);
 		if (!ok) {
 			json({ error: "Goal not found or not in error state" }, 400);
 			return;
 		}
 		json({ ok: true });
 		// Fire-and-forget async worktree setup
-		sessionManager.goalManager.setupWorktree(goalId).then(() => {
+		retryGoalManager.setupWorktree(goalId).then(() => {
 			broadcastToAll({ type: "goal_setup_complete", goalId });
 		}).catch((err) => {
 			broadcastToAll({ type: "goal_setup_error", goalId, error: String(err) });
@@ -1472,18 +1526,19 @@ async function handleApiRoute(
 		const id = goalMatch[1];
 
 		if (req.method === "GET") {
-			const goal = sessionManager.goalManager.getGoal(id);
+			const goal = getGoalAcrossProjects(id);
 			if (!goal) { json({ error: "Goal not found" }, 404); return; }
 			json(goal);
 			return;
 		}
 
 		if (req.method === "PUT") {
-			const putGoal = sessionManager.goalManager.getGoal(id);
+			const putGoal = getGoalAcrossProjects(id);
 			if (putGoal?.archived) { json({ error: "Goal is archived" }, 409); return; }
 			const body = await readBody(req);
 			if (!body) { json({ error: "Missing body" }, 400); return; }
-			const ok = await sessionManager.goalManager.updateGoal(id, {
+			const goalMgr = getGoalManagerForGoal(id);
+			const ok = await goalMgr.updateGoal(id, {
 				title: body.title,
 				cwd: body.cwd,
 				state: body.state,
@@ -1518,7 +1573,8 @@ async function handleApiRoute(
 				}
 			}
 			// Archive instead of hard-delete — tasks, gates, team state remain intact
-			await sessionManager.goalManager.archiveGoal(id);
+			const deleteGoalMgr = getGoalManagerForGoal(id);
+			await deleteGoalMgr.archiveGoal(id);
 			prStatusStore.remove(id);
 			json({ ok: true });
 			return;
@@ -2072,7 +2128,7 @@ async function handleApiRoute(
 	// POST /api/goals/:goalId/tasks — create a task
 	if (goalTasksMatch && req.method === "POST") {
 		const goalId = goalTasksMatch[1];
-		const goal = sessionManager.goalManager.getGoal(goalId);
+		const goal = getGoalAcrossProjects(goalId);
 		if (!goal) { json({ error: "Goal not found" }, 404); return; }
 		if (goal.archived) { json({ error: "Goal is archived" }, 409); return; }
 
@@ -2108,7 +2164,7 @@ async function handleApiRoute(
 	const goalGatesMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/gates$/);
 	if (goalGatesMatch && req.method === "GET") {
 		const goalId = goalGatesMatch[1];
-		const goal = sessionManager.goalManager.getGoal(goalId);
+		const goal = getGoalAcrossProjects(goalId);
 		if (!goal) { json({ error: "Goal not found" }, 404); return; }
 		const gateCtx = projectContextManager.getContextForGoal(goalId) ?? projectContextManager.getDefault();
 		const gateStore = gateCtx.gateStore;
@@ -2129,7 +2185,7 @@ async function handleApiRoute(
 		const gateStore = (projectContextManager.getContextForGoal(goalId) ?? projectContextManager.getDefault()).gateStore;
 		const gate = gateStore.getGate(goalId, gateId);
 		if (!gate) { json({ error: "Gate not found" }, 404); return; }
-		const goal = sessionManager.goalManager.getGoal(goalId);
+		const goal = getGoalAcrossProjects(goalId);
 		const def = goal?.workflow?.gates.find(wg => wg.id === gateId);
 		json({ ...gate, name: def?.name, dependsOn: def?.dependsOn, content: def?.content, injectDownstream: def?.injectDownstream });
 		return;
@@ -2139,7 +2195,7 @@ async function handleApiRoute(
 	const gateSignalMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/gates\/([^/]+)\/signal$/);
 	if (gateSignalMatch && req.method === "POST") {
 		const [, goalId, gateId] = gateSignalMatch;
-		const goal = sessionManager.goalManager.getGoal(goalId);
+		const goal = getGoalAcrossProjects(goalId);
 		if (!goal) { json({ error: "Goal not found" }, 404); return; }
 		if (goal.archived) { json({ error: "Goal is archived" }, 409); return; }
 		if (!goal.workflow) { json({ error: "Goal has no workflow" }, 400); return; }
@@ -2345,7 +2401,7 @@ async function handleApiRoute(
 	if (workflowContextMatch && req.method === "GET") {
 		const goalId = workflowContextMatch[1];
 		const gateId = workflowContextMatch[2];
-		const goal = sessionManager.goalManager.getGoal(goalId);
+		const goal = getGoalAcrossProjects(goalId);
 		if (!goal) { json({ error: "Goal not found" }, 404); return; }
 		if (!goal.workflow) { json({ error: "Goal has no workflow" }, 404); return; }
 		const gateDef = goal.workflow.gates.find(g => g.id === gateId);
@@ -2479,7 +2535,7 @@ async function handleApiRoute(
 	if (teamSpawnMatch && req.method === "POST") {
 		const goalId = teamSpawnMatch[1];
 		// Guard: reject spawn if goal is archived
-		const spawnGoal = sessionManager.goalManager.getGoal(goalId);
+		const spawnGoal = getGoalAcrossProjects(goalId);
 		if (spawnGoal?.archived) {
 			json({ error: "Goal is archived" }, 409);
 			return;
@@ -2532,7 +2588,7 @@ async function handleApiRoute(
 	const commitsMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/commits$/);
 	if (commitsMatch && req.method === "GET") {
 		const goalId = commitsMatch[1];
-		const goal = sessionManager.goalManager.getGoal(goalId);
+		const goal = getGoalAcrossProjects(goalId);
 		if (!goal) { json({ error: "Goal not found" }, 404); return; }
 		if (!fs.existsSync(goal.cwd)) { json({ commits: [] }); return; }
 		const branch = goal.branch || "HEAD";
@@ -2572,7 +2628,7 @@ async function handleApiRoute(
 	const goalGitMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/git-status$/);
 	if (goalGitMatch && req.method === "GET") {
 		const goalId = goalGitMatch[1];
-		const goal = sessionManager.goalManager.getGoal(goalId);
+		const goal = getGoalAcrossProjects(goalId);
 		if (!goal) { json({ error: "Goal not found" }, 404); return; }
 		const cwd = goal.cwd;
 		if (!fs.existsSync(cwd)) { json({ error: "Working directory not found" }, 404); return; }
@@ -2656,7 +2712,7 @@ async function handleApiRoute(
 	const goalDiffMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/git-diff$/);
 	if (goalDiffMatch && req.method === "GET") {
 		const goalId = goalDiffMatch[1];
-		const goal = sessionManager.goalManager.getGoal(goalId);
+		const goal = getGoalAcrossProjects(goalId);
 		if (!goal) { json({ error: "Goal not found" }, 404); return; }
 		const cwd = goal.cwd;
 		if (!fs.existsSync(cwd)) { json({ error: "Working directory not found" }, 404); return; }
@@ -2682,7 +2738,7 @@ async function handleApiRoute(
 	const goalPrStatusMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/pr-status$/);
 	if (goalPrStatusMatch && req.method === "GET") {
 		const goalId = goalPrStatusMatch[1];
-		const goal = sessionManager.goalManager.getGoal(goalId);
+		const goal = getGoalAcrossProjects(goalId);
 		if (!goal) { json({ error: "Goal not found" }, 404); return; }
 		const cwd = goal.cwd;
 		if (!fs.existsSync(cwd)) { json({ error: "Working directory not found" }, 404); return; }
@@ -2697,7 +2753,7 @@ async function handleApiRoute(
 	const goalPrCacheBustMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/pr-cache-bust$/);
 	if (req.method === 'POST' && goalPrCacheBustMatch) {
 		const goalId = goalPrCacheBustMatch[1];
-		const goal = sessionManager.goalManager.getGoal(goalId);
+		const goal = getGoalAcrossProjects(goalId);
 		if (!goal) { json({ error: "Goal not found" }, 404); return; }
 		const cwd = goal.cwd;
 		_prCache.delete(cwd);
@@ -2711,7 +2767,7 @@ async function handleApiRoute(
 	const goalPrMergeMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/pr-merge$/);
 	if (goalPrMergeMatch && req.method === "POST") {
 		const goalId = goalPrMergeMatch[1];
-		const goal = sessionManager.goalManager.getGoal(goalId);
+		const goal = getGoalAcrossProjects(goalId);
 		if (!goal) { json({ error: "Goal not found" }, 404); return; }
 		const cwd = goal.cwd;
 		if (!fs.existsSync(cwd)) { json({ error: "Working directory not found" }, 404); return; }
@@ -2842,7 +2898,7 @@ async function handleApiRoute(
 		const wfGateId = typeof body.workflowGateId === "string" ? body.workflowGateId : undefined;
 		const inputIds = Array.isArray(body.inputGateIds) ? body.inputGateIds as string[] : undefined;
 		if (wfGateId) {
-			const goal = sessionManager.goalManager.getGoal(goalId);
+			const goal = getGoalAcrossProjects(goalId);
 			const goalGateStore = (projectContextManager.getContextForGoal(goalId) ?? projectContextManager.getDefault()).gateStore;
 			if (goal?.workflow && goalGateStore) {
 				const wfGate = goal.workflow.gates.find((g: any) => g.id === wfGateId);
@@ -3454,7 +3510,7 @@ async function handleApiRoute(
 		const cwd = session.cwd;
 		if (!fs.existsSync(cwd)) { json({ error: "Working directory not found" }, 404); return; }
 		// Use goal branch if available so we find the right PR even if the worktree HEAD diverged
-		const goalBranch = session.goalId ? sessionManager.goalManager.getGoal(session.goalId)?.branch : undefined;
+		const goalBranch = session.goalId ? getGoalAcrossProjects(session.goalId)?.branch : undefined;
 		const pr = await getCachedPrStatus(cwd, goalBranch, process.cwd());
 		if (pr) {
 			const goalId = session.goalId;
@@ -3512,7 +3568,7 @@ async function handleApiRoute(
 			return;
 		}
 		const sessAdminFlag = body?.admin ? " --admin" : "";
-		const sessMergeBranch = session.goalId ? sessionManager.goalManager.getGoal(session.goalId)?.branch : undefined;
+		const sessMergeBranch = session.goalId ? getGoalAcrossProjects(session.goalId)?.branch : undefined;
 		try {
 			await execAsync(`gh pr merge --${method}${sessAdminFlag}`, { cwd, encoding: "utf-8", timeout: 30000 });
 			_prCache.delete(cwd);
@@ -3600,7 +3656,7 @@ async function handleApiRoute(
 		const wf = workflowManager.getWorkflow(id);
 		if (!wf) { json({ error: "Workflow not found" }, 404); return; }
 		// Check if any active goal references this workflow
-		const allGoals = sessionManager.goalManager.listGoals();
+		const allGoals = projectContextManager.getAllLiveGoals();
 		if (allGoals.some((g: any) => g.workflowId === id && g.state !== "complete")) {
 			json({ error: "Cannot delete: workflow is in use by active goals" }, 409);
 			return;
@@ -3666,7 +3722,7 @@ async function handleApiRoute(
 	const goalCostBreakdownMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/cost\/breakdown$/);
 	if (goalCostBreakdownMatch && req.method === "GET") {
 		const goalId = goalCostBreakdownMatch[1];
-		const goal = sessionManager.goalManager.getGoal(goalId);
+		const goal = getGoalAcrossProjects(goalId);
 		if (!goal) {
 			json({ error: "Goal not found" }, 404);
 			return;
@@ -3711,7 +3767,7 @@ async function handleApiRoute(
 	const goalCostMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/cost$/);
 	if (goalCostMatch && req.method === "GET") {
 		const goalId = goalCostMatch[1];
-		const goal = sessionManager.goalManager.getGoal(goalId);
+		const goal = getGoalAcrossProjects(goalId);
 		if (!goal) {
 			json({ error: "Goal not found" }, 404);
 			return;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -711,7 +711,7 @@ async function handleApiRoute(
 	/** Get a GoalManager for the project that owns the given goal. Falls back to default. */
 	function getGoalManagerForGoal(goalId: string): GoalManager {
 		const ctx = projectContextManager.getContextForGoal(goalId) ?? projectContextManager.getDefault();
-		return new GoalManager(ctx.goalStore, workflowManager.store);
+		return ctx.goalManager;
 	}
 
 	/** Get a TaskManager for the project that owns the given goal. Falls back to default. */

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -26,7 +26,7 @@ import { PersonalityManager } from "./agent/personality-manager.js";
 import { getPromptSections, initPromptDirs } from "./agent/system-prompt.js";
 import type { TaskState } from "./agent/task-store.js";
 import { BgProcessManager } from "./agent/bg-process-manager.js";
-import { GateStore } from "./agent/gate-store.js";
+import type { GateStore } from "./agent/gate-store.js";
 import { WorkflowStore } from "./agent/workflow-store.js";
 import { WorkflowManager } from "./agent/workflow-manager.js";
 import { isGitRepo, getRepoRoot } from "./skills/git.js";
@@ -47,21 +47,10 @@ import { getAvailableModels, discoverModelsForConfig } from "./agent/model-regis
 import type { CustomProviderConfig } from "./agent/model-registry.js";
 import { ProjectRegistry } from "./agent/project-registry.js";
 import { ProjectContext } from "./agent/project-context.js";
+import { ProjectContextManager } from "./agent/project-context-manager.js";
+import { migrateToPerProjectState } from "./agent/state-migration.js";
 import { resolveScalarConfig } from "./agent/config-resolver.js";
 import { initAssistantRegistry } from "./agent/assistant-registry.js";
-
-const projectContextCache = new Map<string, ProjectContext>();
-
-function getOrCreateProjectContext(projectId: string, projectRegistry: ProjectRegistry): ProjectContext | null {
-	const project = projectRegistry.get(projectId);
-	if (!project) return null;
-	let ctx = projectContextCache.get(projectId);
-	if (!ctx) {
-		ctx = new ProjectContext(project);
-		projectContextCache.set(projectId, ctx);
-	}
-	return ctx;
-}
 
 const VALID_TASK_STATES = new Set<string>(["todo", "in-progress", "blocked", "complete", "skipped"]);
 
@@ -228,6 +217,13 @@ export function createGateway(config: GatewayConfig) {
 	const projectRegistry = new ProjectRegistry(stateDir);
 	projectRegistry.ensureDefaultProject(getProjectRoot());
 
+	// Run one-time migration from centralized to per-project state
+	migrateToPerProjectState(stateDir, projectRegistry, getProjectRoot());
+
+	// Initialize per-project contexts
+	const projectContextManager = new ProjectContextManager(projectRegistry);
+	projectContextManager.initAll();
+
 	const colorStore = new ColorStore(stateDir);
 	const prStatusStore = new PrStatusStore(stateDir);
 	const preferencesStore = new PreferencesStore(stateDir);
@@ -242,7 +238,6 @@ export function createGateway(config: GatewayConfig) {
 	const roleManager = new RoleManager(roleStore);
 	const toolManager = new ToolManager(configDir);
 	const groupPolicyStore = new ToolGroupPolicyStore(configDir);
-	const gateStore = new GateStore(stateDir);
 	const workflowStore = new WorkflowStore(configDir);
 	const sandboxTokenStore = new SandboxTokenStore();
 	const sessionManager = new SessionManager({
@@ -256,14 +251,17 @@ export function createGateway(config: GatewayConfig) {
 		preferencesStore,
 		projectConfigStore,
 		groupPolicyStore,
+		projectContextManager,
 	});
 	sessionManager.sandboxTokenStore = sandboxTokenStore;
-	// Wire gate status changes to bump goal generation so the UI polling detects them
-	gateStore.onStatusChange = () => {
-		sessionManager.goalManager.getGoalStore().bumpGeneration();
-	};
+	// Wire gate status changes to bump goal generation for all project contexts
+	for (const ctx of projectContextManager.all()) {
+		ctx.gateStore.onStatusChange = () => {
+			ctx.goalStore.bumpGeneration();
+		};
+	}
 	const workflowManager = new WorkflowManager(workflowStore);
-	const staffManager = new StaffManager();
+	const staffManager = new StaffManager(projectContextManager.getDefault().staffStore);
 	// Wire staff into search index for indexing and rebuilds
 	sessionManager.searchIndex.staffStore = staffManager.getStore();
 	staffManager.searchIndex = sessionManager.searchIndex;
@@ -273,8 +271,9 @@ export function createGateway(config: GatewayConfig) {
 		colorStore,
 		taskManager: sessionManager.taskManager,
 		roleStore,
-		gateStore,
+		gateStore: projectContextManager.getDefault().gateStore,
 		personalityManager,
+		projectContextManager,
 	});
 	const bgProcessManager = new BgProcessManager((sessionId: string) => {
 		const session = sessionManager.getSession(sessionId);
@@ -363,7 +362,7 @@ export function createGateway(config: GatewayConfig) {
 				return;
 			}
 
-			await handleApiRoute(url, req, res, sessionManager, config, colorStore, prStatusStore, teamManager, roleManager, toolManager, gateStore, personalityManager, bgProcessManager, staffManager, workflowManager, verificationHarness, preferencesStore, projectConfigStore, groupPolicyStore, broadcastToGoal, broadcastToAll, sandboxPool, projectRegistry, sandboxScope, sandboxTokenStore);
+			await handleApiRoute(url, req, res, sessionManager, config, colorStore, prStatusStore, teamManager, roleManager, toolManager, projectContextManager, personalityManager, bgProcessManager, staffManager, workflowManager, verificationHarness, preferencesStore, projectConfigStore, groupPolicyStore, broadcastToGoal, broadcastToAll, sandboxPool, projectRegistry, sandboxScope, sandboxTokenStore);
 
 			return;
 		}
@@ -432,7 +431,7 @@ export function createGateway(config: GatewayConfig) {
 		if (goal.branch) _prCache.delete(`${goal.cwd}::${goal.branch}`);
 		broadcastToAll({ type: "pr_status_changed", goalId });
 	});
-	verificationHarness = new VerificationHarness(stateDir, gateStore, broadcastToGoal, roleStore, preferencesStore, sessionManager, teamManager, projectConfigStore);
+	verificationHarness = new VerificationHarness(stateDir, projectContextManager.getDefault().gateStore, broadcastToGoal, roleStore, preferencesStore, sessionManager, teamManager, projectConfigStore, projectContextManager);
 	teamManager.setVerificationHarness(verificationHarness);
 	verificationHarness.setTeamLeadNotifier((goalId, message) => {
 		const team = teamManager.getTeamState(goalId);
@@ -667,7 +666,7 @@ async function handleApiRoute(
 	teamManager: TeamManager,
 	roleManager: RoleManager,
 	toolManager: ToolManager,
-	gateStore: GateStore,
+	projectContextManager: ProjectContextManager,
 	personalityManager: PersonalityManager,
 	bgProcessManager: BgProcessManager,
 	staffManager: StaffManager,
@@ -983,7 +982,7 @@ async function handleApiRoute(
 	// GET/PUT /api/projects/:id/config, GET /api/projects/:id/config/defaults, GET /api/projects/:id/config/resolved
 	const projectConfigMatch = url.pathname.match(/^\/api\/projects\/([^/]+)\/config(?:\/(defaults|resolved))?$/);
 	if (projectConfigMatch) {
-		const ctx = getOrCreateProjectContext(projectConfigMatch[1], projectRegistry);
+		const ctx = projectContextManager.getOrCreate(projectConfigMatch[1]);
 		if (!ctx) { json({ error: "Project not found" }, 404); return; }
 		const suffix = projectConfigMatch[2]; // undefined | "defaults" | "resolved"
 
@@ -1430,7 +1429,8 @@ async function handleApiRoute(
 			}
 			// Initialize gate states for the workflow
 			if (goal.workflow) {
-				gateStore.initGatesForGoal(goal.id, goal.workflow.gates.map(g => g.id));
+				const goalCtx = projectContextManager.getContextForGoal(goal.id) ?? projectContextManager.getDefault();
+				goalCtx.gateStore.initGatesForGoal(goal.id, goal.workflow.gates.map(g => g.id));
 			}
 			json(goal, 201);
 
@@ -2111,6 +2111,8 @@ async function handleApiRoute(
 		const goalId = goalGatesMatch[1];
 		const goal = sessionManager.goalManager.getGoal(goalId);
 		if (!goal) { json({ error: "Goal not found" }, 404); return; }
+		const gateCtx = projectContextManager.getContextForGoal(goalId) ?? projectContextManager.getDefault();
+		const gateStore = gateCtx.gateStore;
 		const gates = gateStore.getGatesForGoal(goalId);
 		// Enrich with workflow gate definitions
 		const enriched = gates.map(g => {
@@ -2125,6 +2127,7 @@ async function handleApiRoute(
 	const gateDetailMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/gates\/([^/]+)$/);
 	if (gateDetailMatch && req.method === "GET") {
 		const [, goalId, gateId] = gateDetailMatch;
+		const gateStore = (projectContextManager.getContextForGoal(goalId) ?? projectContextManager.getDefault()).gateStore;
 		const gate = gateStore.getGate(goalId, gateId);
 		if (!gate) { json({ error: "Gate not found" }, 404); return; }
 		const goal = sessionManager.goalManager.getGoal(goalId);
@@ -2141,6 +2144,7 @@ async function handleApiRoute(
 		if (!goal) { json({ error: "Goal not found" }, 404); return; }
 		if (goal.archived) { json({ error: "Goal is archived" }, 409); return; }
 		if (!goal.workflow) { json({ error: "Goal has no workflow" }, 400); return; }
+		const gateStore = (projectContextManager.getContextForGoal(goalId) ?? projectContextManager.getDefault()).gateStore;
 		const gateDef = goal.workflow.gates.find(g => g.id === gateId);
 		if (!gateDef) { json({ error: `Unknown gate: ${gateId}` }, 404); return; }
 
@@ -2310,6 +2314,7 @@ async function handleApiRoute(
 	const gateSignalsMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/gates\/([^/]+)\/signals$/);
 	if (gateSignalsMatch && req.method === "GET") {
 		const [, goalId, gateId] = gateSignalsMatch;
+		const gateStore = (projectContextManager.getContextForGoal(goalId) ?? projectContextManager.getDefault()).gateStore;
 		const gate = gateStore.getGate(goalId, gateId);
 		if (!gate) { json({ error: "Gate not found" }, 404); return; }
 		json({ signals: gate.signals });
@@ -2329,6 +2334,7 @@ async function handleApiRoute(
 	const gateContentMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/gates\/([^/]+)\/content$/);
 	if (gateContentMatch && req.method === "GET") {
 		const [, goalId, gateId] = gateContentMatch;
+		const gateStore = (projectContextManager.getContextForGoal(goalId) ?? projectContextManager.getDefault()).gateStore;
 		const gate = gateStore.getGate(goalId, gateId);
 		if (!gate) { json({ error: "Gate not found" }, 404); return; }
 		json({ content: gate.currentContent, version: gate.currentContentVersion });
@@ -2838,10 +2844,11 @@ async function handleApiRoute(
 		const inputIds = Array.isArray(body.inputGateIds) ? body.inputGateIds as string[] : undefined;
 		if (wfGateId) {
 			const goal = sessionManager.goalManager.getGoal(goalId);
-			if (goal?.workflow && gateStore) {
+			const goalGateStore = (projectContextManager.getContextForGoal(goalId) ?? projectContextManager.getDefault()).gateStore;
+			if (goal?.workflow && goalGateStore) {
 				const wfGate = goal.workflow.gates.find((g: any) => g.id === wfGateId);
 				if (wfGate?.dependsOn?.length) {
-					const gateStates = gateStore.getGatesForGoal(goalId);
+					const gateStates = goalGateStore.getGatesForGoal(goalId);
 					const passedIds = new Set(gateStates.filter((g: any) => g.status === "passed").map((g: any) => g.gateId));
 					const notPassed = wfGate.dependsOn.filter((depId: string) => !passedIds.has(depId));
 					if (notPassed.length > 0) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1205,7 +1205,7 @@ async function handleApiRoute(
 			res.end(JSON.stringify({ error: "Session not found" }));
 			return;
 		}
-		const sessionPs = sessionManager.getSessionStore().get(session.id);
+		const sessionPs = sessionManager.getSessionStore(session.projectId).get(session.id);
 		json({
 			id: session.id,
 			title: session.title,
@@ -1404,12 +1404,12 @@ async function handleApiRoute(
 
 			// Store reattemptGoalId on the session if provided
 			if (reattemptGoalId) {
-				sessionManager.getSessionStore().update(session.id, { reattemptGoalId });
+				sessionManager.getSessionStore(session.projectId).update(session.id, { reattemptGoalId });
 			}
 
 			// Store projectId on the session if provided
 			if (body?.projectId && typeof body.projectId === "string") {
-				sessionManager.getSessionStore().update(session.id, { projectId: body.projectId });
+				sessionManager.getSessionStore(session.projectId).update(session.id, { projectId: body.projectId });
 			}
 
 			json({
@@ -4170,7 +4170,11 @@ async function handleApiRoute(
 			}
 			// Verify the session exists (live or persisted).
 			const mcpSession = sessionManager.getSession(mcpSessionId);
-			const persistedSession = mcpSession ? null : sessionManager.getSessionStore().get(mcpSessionId);
+			const persistedSession = mcpSession ? null : (
+				// Search across all project stores for persisted session
+				projectContextManager.getContextForSession(mcpSessionId)?.sessionStore.get(mcpSessionId)
+				?? sessionManager.getSessionStore().get(mcpSessionId)
+			);
 			if (!mcpSession && !persistedSession) {
 				json({ error: `Session "${mcpSessionId}" not found` }, 403);
 				return;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -25,6 +25,7 @@ import { PersonalityManager } from "./agent/personality-manager.js";
 
 import { getPromptSections, initPromptDirs } from "./agent/system-prompt.js";
 import type { TaskState } from "./agent/task-store.js";
+import { TaskManager } from "./agent/task-manager.js";
 import { BgProcessManager } from "./agent/bg-process-manager.js";
 
 import { WorkflowStore } from "./agent/workflow-store.js";
@@ -713,6 +714,30 @@ async function handleApiRoute(
 		return new GoalManager(ctx.goalStore, workflowManager.store);
 	}
 
+	/** Get a TaskManager for the project that owns the given goal. Falls back to default. */
+	const taskManagerCache = new Map<string, TaskManager>();
+	function getTaskManagerForGoal(goalId: string): TaskManager {
+		const ctx = projectContextManager.getContextForGoal(goalId);
+		if (!ctx) return sessionManager.taskManager;
+		const projectId = ctx.project.id;
+		let tm = taskManagerCache.get(projectId);
+		if (!tm) {
+			tm = new TaskManager(ctx.taskStore);
+			taskManagerCache.set(projectId, tm);
+		}
+		return tm;
+	}
+
+	/** Get a TaskManager for a task by looking up which goal it belongs to. Falls back to default. */
+	function getTaskManagerForTask(taskId: string): TaskManager {
+		// Search all project contexts for the task
+		for (const ctx of projectContextManager.all()) {
+			const task = ctx.taskStore.get(taskId);
+			if (task) return getTaskManagerForGoal(task.goalId);
+		}
+		return sessionManager.taskManager;
+	}
+
 	// GET /api/health — unauthenticated so the client can probe localhost mode
 	if (url.pathname === "/api/health" && req.method === "GET") {
 		const isLocalhost = !config.forceAuth && (config.host === "localhost" || config.host === "127.0.0.1" || config.host === "::1");
@@ -1100,26 +1125,39 @@ async function handleApiRoute(
 		}
 		// Support ?include=archived to return archived sessions too
 		if (url.searchParams.get("include") === "archived") {
+			// Collect archived sessions across all project contexts
+			const allArchived: typeof sessions = [];
+			for (const ctx of projectContextManager.all()) {
+				const store = ctx.sessionStore;
+				for (const s of store.getArchived()) {
+					allArchived.push({ ...s, colorIndex: colorStore.get(s.id), status: "archived" } as any);
+				}
+			}
+			// Sort by archivedAt descending
+			allArchived.sort((a: any, b: any) => ((b as any).archivedAt ?? 0) - ((a as any).archivedAt ?? 0));
+			// Apply projectId filter if present
+			const filteredArchived = filterProjectId
+				? allArchived.filter((s: any) => s.projectId === filterProjectId)
+				: allArchived;
+
 			const limitParam = url.searchParams.get("limit");
 			const afterParam = url.searchParams.get("after");
 			if (limitParam) {
 				// Paginated archived sessions
 				const limit = Math.min(Math.max(1, parseInt(limitParam, 10) || 50), 200);
 				const afterCursor = afterParam ? parseInt(afterParam, 10) : undefined;
-				const page = sessionManager.getSessionStore().listArchivedSessionsPaginated(limit, afterCursor);
-				const archivedSessions = page.sessions.map((s) => ({
-					...s,
-					colorIndex: colorStore.get(s.id),
-					status: "archived",
-				}));
-				json({ generation: currentGen, sessions: [...sessions, ...archivedSessions], total: page.total, hasMore: page.hasMore, nextCursor: page.nextCursor });
+				let page = filteredArchived;
+				if (afterCursor !== undefined) {
+					page = page.filter((s: any) => ((s as any).archivedAt ?? 0) < afterCursor);
+				}
+				const total = filteredArchived.length;
+				const hasMore = page.length > limit;
+				const sliced = page.slice(0, limit);
+				const nextCursor = sliced.length > 0 ? (sliced[sliced.length - 1] as any).archivedAt : undefined;
+				json({ generation: currentGen, sessions: [...sessions, ...sliced], total, hasMore, nextCursor });
 			} else {
 				// Backward compatible: return all archived sessions
-				const archived = sessionManager.listArchivedSessions().map((s) => ({
-					...s,
-					colorIndex: colorStore.get(s.id),
-				}));
-				json({ generation: currentGen, sessions: [...sessions, ...archived] });
+				json({ generation: currentGen, sessions: [...sessions, ...filteredArchived] });
 			}
 		} else {
 			json({ generation: currentGen, sessions });
@@ -2120,7 +2158,7 @@ async function handleApiRoute(
 	// GET /api/goals/:goalId/tasks — list tasks for a goal
 	const goalTasksMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/tasks$/);
 	if (goalTasksMatch && req.method === "GET") {
-		const tasks = sessionManager.taskManager.getTasksForGoal(goalTasksMatch[1]);
+		const tasks = getTaskManagerForGoal(goalTasksMatch[1]).getTasksForGoal(goalTasksMatch[1]);
 		json({ tasks });
 		return;
 	}
@@ -2144,7 +2182,7 @@ async function handleApiRoute(
 			return;
 		}
 		try {
-			const task = sessionManager.taskManager.createTask(goalId, title, type, {
+			const task = getTaskManagerForGoal(goalId).createTask(goalId, title, type, {
 				parentTaskId: body.parentTaskId,
 				spec: body.spec,
 				dependsOn: body.dependsOn,
@@ -2419,7 +2457,7 @@ async function handleApiRoute(
 
 		// GET /api/tasks/:id
 		if (req.method === "GET") {
-			const task = sessionManager.taskManager.getTask(id);
+			const task = getTaskManagerForTask(id).getTask(id);
 			if (!task) { json({ error: "Task not found" }, 404); return; }
 			json(task);
 			return;
@@ -2430,9 +2468,10 @@ async function handleApiRoute(
 			const body = await readBody(req);
 			if (!body) { json({ error: "Missing body" }, 400); return; }
 			try {
-				const task = sessionManager.taskManager.getTask(id);
+				const tm = getTaskManagerForTask(id);
+				const task = tm.getTask(id);
 				const prevState = task?.state;
-				const ok = sessionManager.taskManager.updateTask(id, {
+				const ok = tm.updateTask(id, {
 					title: body.title,
 					spec: body.spec,
 					state: body.state,
@@ -2457,7 +2496,7 @@ async function handleApiRoute(
 
 		// DELETE /api/tasks/:id
 		if (req.method === "DELETE") {
-			const ok = sessionManager.taskManager.deleteTask(id);
+			const ok = getTaskManagerForTask(id).deleteTask(id);
 			if (!ok) { json({ error: "Task not found" }, 404); return; }
 			json({ ok: true });
 			return;
@@ -2474,7 +2513,7 @@ async function handleApiRoute(
 			return;
 		}
 		try {
-			const ok = sessionManager.taskManager.assignTask(taskAssignMatch[1], sessionId);
+			const ok = getTaskManagerForTask(taskAssignMatch[1]).assignTask(taskAssignMatch[1], sessionId);
 			if (!ok) { json({ error: "Task not found" }, 400); return; }
 			json({ ok: true });
 		} catch (err: any) {
@@ -2498,8 +2537,9 @@ async function handleApiRoute(
 		}
 		try {
 			const taskId = taskTransitionMatch[1];
-			const task = sessionManager.taskManager.getTask(taskId);
-			const ok = sessionManager.taskManager.transitionTask(taskId, state as TaskState);
+			const tm = getTaskManagerForTask(taskId);
+			const task = tm.getTask(taskId);
+			const ok = tm.transitionTask(taskId, state as TaskState);
 			if (!ok) { json({ error: "Task not found" }, 400); return; }
 
 			// Notify team lead when a task reaches a terminal or blocked state
@@ -3782,7 +3822,7 @@ async function handleApiRoute(
 	const taskCostMatch = url.pathname.match(/^\/api\/tasks\/([^/]+)\/cost$/);
 	if (taskCostMatch && req.method === "GET") {
 		const taskId = taskCostMatch[1];
-		const task = sessionManager.taskManager.getTask(taskId);
+		const task = getTaskManagerForTask(taskId).getTask(taskId);
 		if (!task) {
 			json({ error: "Task not found" }, 404);
 			return;

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -7,6 +7,7 @@ import { validateToken } from "../auth/token.js";
 import type { SandboxTokenStore } from "../auth/sandbox-token.js";
 import type { ClientMessage, ServerMessage } from "./protocol.js";
 import type { TaskState } from "../agent/task-store.js";
+import { TaskManager } from "../agent/task-manager.js";
 import { getSlashSkill, buildSlashSkillPrompt } from "../skills/slash-skills.js";
 // patchModelContextWindow removed — model-registry returns correct context windows via inferMeta()
 
@@ -334,7 +335,8 @@ export function handleWebSocketConnection(
 					break;
 				}
 				case "task_create": {
-					const task = sessionManager.taskManager.createTask(
+					const tm = resolveTaskManagerForGoal(sessionManager, msg.goalId);
+					const task = tm.createTask(
 						msg.goalId,
 						msg.title,
 						msg.taskType,
@@ -344,10 +346,11 @@ export function handleWebSocketConnection(
 					break;
 				}
 				case "task_update": {
+					const tm = resolveTaskManagerForTask(sessionManager, msg.taskId);
 					const updates = { ...msg.updates, state: msg.updates.state as TaskState | undefined };
-					const updated = sessionManager.taskManager.updateTask(msg.taskId, updates);
+					const updated = tm.updateTask(msg.taskId, updates);
 					if (updated) {
-						const task = sessionManager.taskManager.getTask(msg.taskId);
+						const task = tm.getTask(msg.taskId);
 						broadcast(session.clients, { type: "task_changed", task });
 					} else {
 						send(ws, { type: "error", message: `Task ${msg.taskId} not found`, code: "TASK_NOT_FOUND" });
@@ -355,9 +358,10 @@ export function handleWebSocketConnection(
 					break;
 				}
 				case "task_delete": {
-					const task = sessionManager.taskManager.getTask(msg.taskId);
+					const tm = resolveTaskManagerForTask(sessionManager, msg.taskId);
+					const task = tm.getTask(msg.taskId);
 					if (task) {
-						sessionManager.taskManager.deleteTask(msg.taskId);
+						tm.deleteTask(msg.taskId);
 						broadcast(session.clients, { type: "task_changed", task: { ...task, _deleted: true } });
 					} else {
 						send(ws, { type: "error", message: `Task ${msg.taskId} not found`, code: "TASK_NOT_FOUND" });
@@ -403,4 +407,31 @@ export function handleWebSocketConnection(
 	ws.on("error", (err) => {
 		console.error(`[gateway] WebSocket error from ${ip}:`, err.message);
 	});
+}
+
+/** Resolve the correct TaskManager for a goal (uses per-project store if available). */
+function resolveTaskManagerForGoal(sessionManager: SessionManager, goalId?: string): TaskManager {
+	const pcm = sessionManager.getProjectContextManager();
+	if (goalId && pcm) {
+		const ctx = pcm.getContextForGoal(goalId);
+		if (ctx) return new TaskManager(ctx.taskStore);
+	}
+	return sessionManager.taskManager;
+}
+
+/** Resolve the correct TaskManager for a task ID (finds via goalId lookup). */
+function resolveTaskManagerForTask(sessionManager: SessionManager, taskId: string): TaskManager {
+	// Try default first
+	const task = sessionManager.taskManager.getTask(taskId);
+	if (task) return sessionManager.taskManager;
+
+	// Search across projects
+	const pcm = sessionManager.getProjectContextManager();
+	if (pcm) {
+		for (const ctx of pcm.all()) {
+			const candidateTm = new TaskManager(ctx.taskStore);
+			if (candidateTm.getTask(taskId)) return candidateTm;
+		}
+	}
+	return sessionManager.taskManager;
 }

--- a/tests/task-state-machine.test.ts
+++ b/tests/task-state-machine.test.ts
@@ -25,13 +25,14 @@ function ensureStateDir() {
 
 // Import after env var is set
 const { TaskManager } = await import("../src/server/agent/task-manager.ts");
+const { TaskStore } = await import("../src/server/agent/task-store.ts");
 
 describe("TaskManager State Machine", () => {
 	let mgr: InstanceType<typeof TaskManager>;
 
 	beforeEach(() => {
 		ensureStateDir();
-		mgr = new TaskManager();
+		mgr = new TaskManager(new TaskStore(path.join(TEST_DIR, "state")));
 	});
 
 	afterEach(() => {


### PR DESCRIPTION
## Summary

Restructures Bobbit so each registered project is a self-contained unit on disk, with its own `.bobbit/state/` holding goals, sessions, staff, search index, gates, tasks, teams, and costs. The server becomes an aggregation layer that stitches N independent project states into a unified UI.

## Key changes

- **ProjectContextManager** — Central registry managing per-project `ProjectContext` instances with aggregation methods for goals, sessions, and search
- **ProjectContext** — Extended with `SearchIndex`, `CostTracker`, `GoalManager`, and `open()`/`close()` lifecycle
- **State migration** — One-time migration distributes existing centralized state to per-project directories, renames central files as `.pre-migration` backups
- **Store refactoring** — `GoalManager`, `TaskManager`, `StaffManager` accept stores directly instead of creating them
- **Complete store routing** — All API endpoints, WebSocket handlers, session creation/restore/archive, team operations, and verification harness resolve the correct per-project store
- **Cross-project aggregation** — List endpoints aggregate across all projects; generation counters sum across stores for polling

## Files changed (14)

New: `project-context-manager.ts`, `state-migration.ts`
Modified: `project-context.ts`, `goal-manager.ts`, `task-manager.ts`, `staff-manager.ts`, `session-manager.ts`, `team-manager.ts`, `verification-harness.ts`, `server.ts`, `ws/handler.ts`
Tests: `task-state-machine.test.ts`
Docs: `AGENTS.md`, `docs/internals.md`, `docs/debugging.md`, `docs/goals-workflows-tasks.md`

## Verification

- `npm run check` passes
- 325 unit tests pass
- 338 E2E tests pass
- 10 rounds of LLM review (gap analysis, code quality, security) — all passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)