### PR TITLE
Server data model + API + shared palette colors

### DIFF
--- a/src/server/agent/project-registry.ts
+++ b/src/server/agent/project-registry.ts
@@ -1,13 +1,21 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import {
+  DEFAULT_PROJECT_COLOR_DARK,
+  DEFAULT_PROJECT_COLOR_LIGHT,
+  PALETTE_PRIMARY_COLORS,
+} from "../../shared/palette-colors.js";
 
 export interface RegisteredProject {
   id: string;           // UUID
   name: string;         // Display name
   rootPath: string;     // Absolute path to project directory
   createdAt: number;    // Epoch ms
-  color?: string;       // Optional accent color
+  color?: string;       // Deprecated — kept for backward compat
+  palette?: string;     // One of 10 palette IDs or undefined
+  colorLight: string;   // Accent color for light mode (always present)
+  colorDark: string;    // Accent color for dark mode (always present)
 }
 
 export class ProjectRegistry {
@@ -23,10 +31,20 @@ export class ProjectRegistry {
   load(): void {
     try {
       const raw = fs.readFileSync(this.storePath, "utf-8");
-      const arr: RegisteredProject[] = JSON.parse(raw);
+      const arr: any[] = JSON.parse(raw);
       this.projects.clear();
       for (const p of arr) {
-        this.projects.set(p.id, p);
+        // Migration: ensure colorLight/colorDark always present
+        if (!p.colorLight || !p.colorDark) {
+          if (p.color) {
+            p.colorLight = p.colorLight || p.color;
+            p.colorDark = p.colorDark || p.color;
+          } else {
+            p.colorLight = p.colorLight || DEFAULT_PROJECT_COLOR_LIGHT;
+            p.colorDark = p.colorDark || DEFAULT_PROJECT_COLOR_DARK;
+          }
+        }
+        this.projects.set(p.id, p as RegisteredProject);
       }
     } catch {
       // File missing or corrupt — start empty
@@ -68,7 +86,11 @@ export class ProjectRegistry {
    * - Scaffolds `.bobbit/config/` and `.bobbit/state/` if they don't exist.
    * - Persists immediately.
    */
-  register(name: string, rootPath: string, color?: string): RegisteredProject {
+  register(
+    name: string,
+    rootPath: string,
+    opts?: { color?: string; palette?: string; colorLight?: string; colorDark?: string },
+  ): RegisteredProject {
     if (!path.isAbsolute(rootPath)) {
       throw new Error(`rootPath must be absolute, got: ${rootPath}`);
     }
@@ -88,12 +110,31 @@ export class ProjectRegistry {
     fs.mkdirSync(path.join(bobbitDir, "config"), { recursive: true });
     fs.mkdirSync(path.join(bobbitDir, "state"), { recursive: true });
 
+    // Determine colors: explicit > palette-seeded > legacy color > defaults
+    let colorLight = opts?.colorLight;
+    let colorDark = opts?.colorDark;
+    const palette = opts?.palette;
+
+    if (palette && PALETTE_PRIMARY_COLORS[palette]) {
+      if (!colorLight) colorLight = PALETTE_PRIMARY_COLORS[palette].light;
+      if (!colorDark) colorDark = PALETTE_PRIMARY_COLORS[palette].dark;
+    }
+
+    if (!colorLight && opts?.color) colorLight = opts.color;
+    if (!colorDark && opts?.color) colorDark = opts.color;
+
+    colorLight = colorLight || DEFAULT_PROJECT_COLOR_LIGHT;
+    colorDark = colorDark || DEFAULT_PROJECT_COLOR_DARK;
+
     const project: RegisteredProject = {
       id: randomUUID(),
       name,
       rootPath,
       createdAt: Date.now(),
-      ...(color ? { color } : {}),
+      color: colorLight, // backward compat
+      colorLight,
+      colorDark,
+      ...(palette ? { palette } : {}),
     };
 
     this.projects.set(project.id, project);
@@ -101,17 +142,38 @@ export class ProjectRegistry {
     return project;
   }
 
-  /** Update mutable fields (name, color, rootPath) of an existing project. */
+  /** Update mutable fields of an existing project. */
   update(
     id: string,
-    updates: Partial<Pick<RegisteredProject, "name" | "color" | "rootPath">>,
+    updates: Partial<Pick<RegisteredProject, "name" | "color" | "rootPath" | "palette" | "colorLight" | "colorDark">>,
   ): RegisteredProject {
     const project = this.projects.get(id);
     if (!project) throw new Error(`Project not found: ${id}`);
 
     if (updates.name !== undefined) project.name = updates.name;
-    if (updates.color !== undefined) project.color = updates.color;
     if (updates.rootPath !== undefined) project.rootPath = path.resolve(updates.rootPath);
+
+    // Handle palette change
+    if (updates.palette !== undefined) {
+      project.palette = updates.palette || undefined; // empty string → clear palette
+      // Auto-seed colors from palette when colors not explicitly provided
+      if (project.palette && PALETTE_PRIMARY_COLORS[project.palette]) {
+        if (updates.colorLight === undefined) {
+          project.colorLight = PALETTE_PRIMARY_COLORS[project.palette].light;
+        }
+        if (updates.colorDark === undefined) {
+          project.colorDark = PALETTE_PRIMARY_COLORS[project.palette].dark;
+        }
+      }
+    }
+
+    // Explicit color overrides
+    if (updates.colorLight !== undefined) project.colorLight = updates.colorLight;
+    if (updates.colorDark !== undefined) project.colorDark = updates.colorDark;
+
+    // Legacy color field — keep in sync
+    if (updates.color !== undefined) project.color = updates.color;
+    else project.color = project.colorLight;
 
     this.projects.set(id, project);
     this.save();

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -980,7 +980,10 @@ async function handleApiRoute(
 		}
 		try {
 			const color = typeof body.color === "string" ? body.color : undefined;
-			const project = projectRegistry.register(body.name, body.rootPath, color);
+			const palette = typeof body.palette === "string" ? body.palette : undefined;
+			const colorLight = typeof body.colorLight === "string" ? body.colorLight : undefined;
+			const colorDark = typeof body.colorDark === "string" ? body.colorDark : undefined;
+			const project = projectRegistry.register(body.name, body.rootPath, { color, palette, colorLight, colorDark });
 			// Initialize project context for the new project
 			const newCtx = projectContextManager.getOrCreate(project.id);
 			if (newCtx) {
@@ -1007,10 +1010,13 @@ async function handleApiRoute(
 	// PUT /api/projects/:id
 	if (projectGetMatch && req.method === "PUT") {
 		const body = await readBody(req);
-		const updates: { name?: string; color?: string; rootPath?: string } = {};
+		const updates: { name?: string; color?: string; rootPath?: string; palette?: string; colorLight?: string; colorDark?: string } = {};
 		if (typeof body?.name === "string") updates.name = body.name;
 		if (typeof body?.color === "string") updates.color = body.color;
 		if (typeof body?.rootPath === "string") updates.rootPath = body.rootPath;
+		if (typeof body?.palette === "string" || body?.palette === null || body?.palette === "") updates.palette = body.palette ?? "";
+		if (typeof body?.colorLight === "string") updates.colorLight = body.colorLight;
+		if (typeof body?.colorDark === "string") updates.colorDark = body.colorDark;
 		try {
 			const updated = projectRegistry.update(projectGetMatch[1], updates);
 			json(updated);

--- a/src/shared/palette-colors.ts
+++ b/src/shared/palette-colors.ts
@@ -1,0 +1,19 @@
+/** Primary color values for each palette, extracted from CSS --primary variables. */
+export const PALETTE_PRIMARY_COLORS: Record<string, { light: string; dark: string }> = {
+  forest: { light: "oklch(0.42 0.14 148)", dark: "oklch(0.72 0.12 140)" },
+  ocean:  { light: "oklch(0.42 0.14 230)", dark: "oklch(0.72 0.12 230)" },
+  dusk:   { light: "oklch(0.42 0.14 300)", dark: "oklch(0.72 0.12 300)" },
+  ember:  { light: "oklch(0.42 0.14 65)",  dark: "oklch(0.72 0.12 65)"  },
+  rose:   { light: "oklch(0.42 0.14 10)",  dark: "oklch(0.72 0.12 10)"  },
+  slate:  { light: "oklch(0.38 0.04 260)", dark: "oklch(0.72 0.06 260)" },
+  sand:   { light: "oklch(0.42 0.14 85)",  dark: "oklch(0.72 0.12 85)"  },
+  teal:   { light: "oklch(0.42 0.14 195)", dark: "oklch(0.72 0.12 195)" },
+  copper: { light: "oklch(0.42 0.14 50)",  dark: "oklch(0.72 0.12 50)"  },
+  mono:   { light: "oklch(0.38 0 0)",      dark: "oklch(0.72 0 0)"      },
+};
+
+export const DEFAULT_PROJECT_COLOR_LIGHT = "oklch(0.45 0.03 260)";
+export const DEFAULT_PROJECT_COLOR_DARK = "oklch(0.65 0.03 260)";
+
+export const PALETTE_IDS = ["forest", "ocean", "dusk", "ember", "rose", "slate", "sand", "teal", "copper", "mono"] as const;
+export type PaletteId = typeof PALETTE_IDS[number];

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -17,11 +17,12 @@
     "sourceMap": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "rootDir": "src/server",
-    "outDir": "dist/server"
+    "rootDir": "src",
+    "outDir": "dist"
   },
   "include": [
-    "src/server/**/*.ts"
+    "src/server/**/*.ts",
+    "src/shared/**/*.ts"
   ],
   "exclude": [
     ".bobbit/config/tools/**/*.ts"

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -15,5 +15,5 @@
     "noUnusedParameters": true,
     "noEmit": true
   },
-  "include": ["src/ui/**/*.ts", "src/app/**/*.ts"]
+  "include": ["src/ui/**/*.ts", "src/app/**/*.ts", "src/shared/**/*.ts"]
 }


### PR DESCRIPTION
Implements the server-side data model and API changes for per-project palette support.

## Changes

### New file: `src/shared/palette-colors.ts`
- `PALETTE_PRIMARY_COLORS` constant mapping palette IDs to light/dark primary color values
- `DEFAULT_PROJECT_COLOR_LIGHT` / `DEFAULT_PROJECT_COLOR_DARK` defaults
- `PALETTE_IDS` array and `PaletteId` type

### Updated: `src/server/agent/project-registry.ts`
- Added `palette?`, `colorLight`, `colorDark` to `RegisteredProject` interface
- Migration in `load()`: existing `color` field maps to both colorLight/colorDark; missing colors get defaults
- `register()` accepts `{ palette, colorLight, colorDark }` opts; auto-seeds from palette primary colors
- `update()` handles palette changes with auto-seeding; keeps `color` in sync for backward compat

### Updated: `src/server/server.ts`
- `POST /api/projects`: reads palette, colorLight, colorDark from body
- `PUT /api/projects/:id`: reads palette, colorLight, colorDark from body (supports clearing palette with empty string/null)

### Updated: `tsconfig.server.json` / `tsconfig.web.json`
- Include `src/shared/**/*.ts` so both server and UI can import shared constants

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)