### PR TITLE
UI types + palette switching + sidebar project colors

### DIFF
--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -11,7 +11,7 @@ import {
 } from "./state.js";
 import { gatewayFetch, refreshSessions } from "./api.js";
 import { getRouteFromHash, setHashRoute } from "./routing.js";
-import { authenticateGateway, connectToSession, createAndConnectSession, terminateSession } from "./session-manager.js";
+import { authenticateGateway, connectToSession, createAndConnectSession, terminateSession, applyProjectPalette } from "./session-manager.js";
 import { doRenderApp } from "./render.js";
 import { loadDashboardData, clearDashboardState } from "./goal-dashboard.js";
 import { registerShortcut, startListening, loadSavedBindings } from "./shortcut-registry.js";
@@ -81,6 +81,9 @@ async function handleHashChange(): Promise<void> {
 			}
 			state.selectedSessionId = null;
 			state.appView = "authenticated";
+			// Apply palette for the goal's project
+			const goalForPalette = state.goals.find(g => g.id === route.goalId);
+			applyProjectPalette(goalForPalette?.projectId);
 			await refreshSessions();
 			await loadDashboardData(route.goalId);
 		} else if (route.view === "session" && route.sessionId) {
@@ -114,6 +117,9 @@ async function handleHashChange(): Promise<void> {
 			}
 			state.selectedSessionId = null;
 			state.goalDashboardId = route.goalId;
+			// Apply palette for the goal's project
+			const gdGoal = state.goals.find(g => g.id === route.goalId);
+			applyProjectPalette(gdGoal?.projectId);
 			state.appView = "authenticated";
 			loadDashboardData(route.goalId);
 			renderApp();
@@ -282,6 +288,7 @@ async function handleHashChange(): Promise<void> {
 			state.selectedSessionId = null;
 			state.goalDashboardId = null;
 			state.appView = "authenticated";
+			applyProjectPalette(); // Revert to global palette
 			renderApp();
 			await refreshSessions();
 		}

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -31,9 +31,17 @@ export function escapeHtml(s: string): string {
 	return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
 
+/** Get the appropriate project accent color for the current theme mode. */
+export function getProjectAccentColor(project: Project): string {
+	const isDark = document.documentElement.classList.contains("dark");
+	return isDark
+		? (project.colorDark || project.color || "var(--muted-foreground)")
+		: (project.colorLight || project.color || "var(--muted-foreground)");
+}
+
 /** Render a small colored chip showing a project name. Used in search results. */
 export function renderProjectBadge(project: Project) {
-	const bg = project.color || '#6b7280';
+	const bg = getProjectAccentColor(project);
 	return html`<span
 		class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium leading-none"
 		style="background: ${bg}20; color: ${bg}; border: 1px solid ${bg}30;"

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -28,7 +28,7 @@ import { searchApi, fetchArchivedGoalsPaginated, fetchArchivedSessionsPaginated 
 import "../ui/components/SearchBox.js";
 import "../ui/components/SearchResults.js";
 
-import { renderGoalGroup, renderSessionRow, renderArchivedSessionRow, renderArchivedDelegates, renderSandboxIndicator, INDENT } from "./render-helpers.js";
+import { renderGoalGroup, renderSessionRow, renderArchivedSessionRow, renderArchivedDelegates, renderSandboxIndicator, INDENT, getProjectAccentColor } from "./render-helpers.js";
 
 const bobbitIcon = html`<img src="/favicon.svg" alt="" style="width:20px;height:18px;image-rendering:pixelated;" />`;
 
@@ -266,7 +266,7 @@ function renderMobileLanding() {
 										return html`${state.projects.map((project, i) => {
 											const data = projectMap.get(project.id) || { goals: [], sessions: [] };
 											const expanded = isProjectExpanded(project.id);
-											const color = project.color || "var(--muted-foreground)";
+											const color = getProjectAccentColor(project);
 											return html`
 												${i > 0 ? html`<div class="border-t border-border/30 my-1 mx-2"></div>` : ""}
 												<div class="flex items-center gap-1.5 pl-0.5 pr-2 py-0.5 rounded-md cursor-pointer active:bg-secondary/50 transition-colors"

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -22,6 +22,27 @@ import { markSessionVisited } from "./render-helpers.js";
 import { setSelectedWorkflowId } from "./render.js";
 
 // ============================================================================
+// PER-PROJECT PALETTE SWITCHING
+// ============================================================================
+
+/** Apply the per-project palette (if any) or revert to the global default. */
+export function applyProjectPalette(projectId?: string): void {
+	const project = (state.projects || []).find((p: any) => p.id === projectId);
+	const palette = project?.palette;
+	if (palette) {
+		document.documentElement.dataset.palette = palette;
+	} else {
+		// Revert to global default
+		const globalPalette = localStorage.getItem('palette');
+		if (!globalPalette || globalPalette === 'forest') {
+			delete document.documentElement.dataset.palette;
+		} else {
+			document.documentElement.dataset.palette = globalPalette;
+		}
+	}
+}
+
+// ============================================================================
 // GOAL PROPOSAL DISMISS PERSISTENCE
 // ============================================================================
 
@@ -446,6 +467,10 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 
 	// Phase 1: synchronous select
 	selectSession(sessionId, replaceHistory);
+
+	// Apply per-project palette
+	const sessionForPalette = state.gatewaySessions.find(s => s.id === sessionId);
+	applyProjectPalette(sessionForPalette?.projectId);
 
 	// Phase 2: async hydrate
 	const gen = state.switchGeneration;
@@ -1203,6 +1228,7 @@ export function backToSessions(): void {
 	localStorage.removeItem(GW_SESSION_KEY);
 	state.appView = "authenticated";
 	teardownMobileScrollTracking();
+	applyProjectPalette(); // Revert to global palette
 	setHashRoute("landing");
 	renderApp();
 	refreshSessions();
@@ -1221,6 +1247,7 @@ export function disconnectGateway(): void {
 	state.appView = "disconnected";
 	localStorage.removeItem(GW_SESSION_KEY);
 	teardownMobileScrollTracking();
+	applyProjectPalette(); // Revert to global palette
 	setHashRoute("landing");
 	renderApp();
 }

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -27,7 +27,7 @@ import { cwdCombobox } from "./cwd-combobox.js";
 import { showGoalDialog, showProjectDialog } from "./dialogs.js";
 import { refreshSessions, fetchRoles, fetchPersonalities, fetchStaff, wakeStaffAgent, fetchArchivedSessions, archivedSessionsLoaded, dismissSetup, gatewayFetch, fetchSandboxStatus, searchApi, fetchArchivedGoalsPaginated, fetchArchivedSessionsPaginated, type PersonalityData } from "./api.js";
 import { statusBobbit, sessionAcronym } from "./session-colors.js";
-import { renderGoalGroup, renderSessionRow, renderArchivedSessionRow, renderArchivedDelegates, SESSION_ROW_PY, INDENT, CHEVRON_W, HEADER_CHEVRON_W, terseRelativeTime, hasUnseenActivity, formatSessionAge, renderSessionTitle } from "./render-helpers.js";
+import { renderGoalGroup, renderSessionRow, renderArchivedSessionRow, renderArchivedDelegates, SESSION_ROW_PY, INDENT, CHEVRON_W, HEADER_CHEVRON_W, terseRelativeTime, hasUnseenActivity, formatSessionAge, renderSessionTitle, getProjectAccentColor } from "./render-helpers.js";
 import type { GatewaySession } from "./state.js";
 import { resetArchivedExpandState } from "./state.js";
 import { isRouteActive, setHashRoute, toggleConfigPage } from "./routing.js";
@@ -797,7 +797,7 @@ function _handleFullSearchClick(query: string): void {
 
 /** Render a collapsible project section header. */
 function renderProjectHeader(project: Project, expanded: boolean) {
-	const color = project.color || "var(--muted-foreground)";
+	const color = getProjectAccentColor(project);
 	return html`
 		<div class="group flex items-center gap-1 pr-1 py-0.5 pl-0.5 rounded-md cursor-pointer hover:bg-secondary/30 transition-colors"
 			@click=${() => { toggleProjectExpanded(project.id); renderApp(); }}>

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -10,7 +10,10 @@ export interface Project {
   id: string;
   name: string;
   rootPath: string;
-  color?: string;
+  color?: string;       // Deprecated, kept for compat
+  palette?: string;
+  colorLight: string;
+  colorDark: string;
 }
 
 export interface GatewaySession {


### PR DESCRIPTION
## Changes

- **state.ts**: Updated `Project` interface with `palette?`, `colorLight`, `colorDark` fields (keeping deprecated `color?` for compat)
- **session-manager.ts**: Added `applyProjectPalette()` helper that sets/reverts `data-palette` on `<html>` based on the project's palette. Wired into `connectToSession()`, `backToSessions()`, and `disconnectGateway()`
- **main.ts**: Palette switching on hash navigation — applies project palette for goal/goal-dashboard views, reverts to global for landing/settings/other views
- **render-helpers.ts**: Added `getProjectAccentColor()` helper that returns `colorLight` or `colorDark` based on dark mode, with fallback to legacy `color` field
- **sidebar.ts**: Uses `getProjectAccentColor()` for project header colors
- **render.ts**: Uses `getProjectAccentColor()` for mobile project header colors

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)