### PR TITLE
Resolve per-project projectConfigStore in session-manager.ts

### DIFF
--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -324,11 +324,13 @@ export class SessionManager {
 		const resolvedSearchIndex = this.getSearchIndexForProject(projectId);
 		let resolvedGoalManager = this.goalManager;
 		let resolvedTaskManager = this.taskManager;
+		let resolvedProjectConfigStore = this.projectConfigStore ?? null;
 		if (projectId && this.projectContextManager) {
 			const ctx = this.projectContextManager.getOrCreate(projectId);
 			if (ctx) {
 				resolvedGoalManager = ctx.goalManager;
 				resolvedTaskManager = new TaskManager(ctx.taskStore);
+				resolvedProjectConfigStore = ctx.projectConfigStore;
 			}
 		}
 		return {
@@ -340,7 +342,7 @@ export class SessionManager {
 			goalManager: resolvedGoalManager,
 			taskManager: resolvedTaskManager,
 			personalityManager: this.personalityManager ?? null,
-			projectConfigStore: this.projectConfigStore ?? null,
+			projectConfigStore: resolvedProjectConfigStore,
 			sandboxPool: this.sandboxPool,
 			sandboxTokenStore: this.sandboxTokenStore,
 			groupPolicyStore: this.groupPolicyStore ?? null,
@@ -474,6 +476,17 @@ export class SessionManager {
 	async initMcp(cwd: string): Promise<void> {
 		try {
 			const mgr = new McpManager(cwd, this.projectConfigStore);
+
+			// Register additional projects for multi-project MCP discovery
+			if (this.projectContextManager) {
+				const additionalProjects = Array.from(this.projectContextManager.all())
+					.filter(ctx => ctx.project.rootPath !== cwd)
+					.map(ctx => ({ cwd: ctx.project.rootPath, configStore: ctx.projectConfigStore }));
+				if (additionalProjects.length > 0) {
+					mgr.setAdditionalProjects(additionalProjects);
+				}
+			}
+
 			await mgr.connectAll();
 			this.mcpManager = mgr;
 


### PR DESCRIPTION
Two changes to session-manager.ts for per-project config scoping:

1. **buildPipelineContext**: Resolves projectConfigStore from the per-project context when a projectId is provided, fixing AGENTS.md and custom agent file resolution for non-default projects.

2. **initMcp**: Passes additional registered project directories to McpManager via setAdditionalProjects() for multi-project MCP server discovery.

Note: setAdditionalProjects() on McpManager is being added by another task — the type error on that call is expected until that PR lands.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)