### PR TITLE
Add projectId param to API endpoints and WS handler

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -468,7 +468,7 @@ export function createGateway(config: GatewayConfig) {
 		}
 
 		wss.handleUpgrade(req, socket, head, (ws) => {
-			handleWebSocketConnection(ws, match[1], req, sessionManager, config.authToken, rateLimiter, projectConfigStore, isLocalhostServer, sandboxTokenStore);
+			handleWebSocketConnection(ws, match[1], req, sessionManager, config.authToken, rateLimiter, projectConfigStore, isLocalhostServer, sandboxTokenStore, projectContextManager);
 		});
 	});
 
@@ -703,6 +703,15 @@ async function handleApiRoute(
 			return ctx ? ctx.goalStore.getLive() : [];
 		}
 		return projectContextManager.getAllLiveGoals();
+	}
+
+	/** Resolve per-project config store, falling back to the default. */
+	function resolveProjectConfigStore(pid: string | null): ProjectConfigStore {
+		if (pid && projectContextManager) {
+			const ctx = projectContextManager.getOrCreate(pid);
+			if (ctx) return ctx.projectConfigStore;
+		}
+		return projectConfigStore;
 	}
 
 	/** Get a GoalManager for the project that owns the given goal. Falls back to default. */
@@ -1770,7 +1779,12 @@ async function handleApiRoute(
 
 	// GET /api/config-directories — return all scanned config directories
 	if (url.pathname === "/api/config-directories" && req.method === "GET") {
-		json(getAllConfigDirectories(config.defaultCwd, projectConfigStore));
+		const projectId = url.searchParams.get("projectId");
+		const resolvedStore = resolveProjectConfigStore(projectId);
+		const resolvedCwd = projectId && projectContextManager
+			? projectContextManager.getOrCreate(projectId)?.project.rootPath ?? config.defaultCwd
+			: config.defaultCwd;
+		json(getAllConfigDirectories(resolvedCwd, resolvedStore));
 		return;
 	}
 
@@ -3652,7 +3666,9 @@ async function handleApiRoute(
 	// GET /api/slash-skills — discover .claude/skills/ SKILL.md files for autocomplete
 	if (url.pathname === "/api/slash-skills" && req.method === "GET") {
 		const cwd = url.searchParams.get("cwd") || process.cwd();
-		const skills = discoverSlashSkills(cwd, projectConfigStore);
+		const projectId = url.searchParams.get("projectId");
+		const resolvedStore = resolveProjectConfigStore(projectId);
+		const skills = discoverSlashSkills(cwd, resolvedStore);
 		json({ skills: skills.map((s) => ({ name: s.name, description: s.description, argumentHint: s.argumentHint, source: s.source })) });
 		return;
 	}
@@ -3660,8 +3676,10 @@ async function handleApiRoute(
 	// GET /api/slash-skills/details — full slash skill details including content and file paths
 	if (url.pathname === "/api/slash-skills/details" && req.method === "GET") {
 		const cwd = url.searchParams.get("cwd") || process.cwd();
-		const skills = discoverSlashSkills(cwd, projectConfigStore);
-		const directories = getSkillDirectories(cwd, projectConfigStore);
+		const projectId = url.searchParams.get("projectId");
+		const resolvedStore = resolveProjectConfigStore(projectId);
+		const skills = discoverSlashSkills(cwd, resolvedStore);
+		const directories = getSkillDirectories(cwd, resolvedStore);
 		json({ skills: skills.map((s) => ({ name: s.name, description: s.description, source: s.source, filePath: s.filePath, content: s.content })), directories });
 		return;
 	}

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -5,6 +5,7 @@ import type { SessionManager } from "../agent/session-manager.js";
 import type { RateLimiter } from "../auth/rate-limit.js";
 import { validateToken } from "../auth/token.js";
 import type { SandboxTokenStore } from "../auth/sandbox-token.js";
+import type { ProjectContextManager } from "../agent/project-context-manager.js";
 import type { ClientMessage, ServerMessage } from "./protocol.js";
 import type { TaskState } from "../agent/task-store.js";
 import { TaskManager } from "../agent/task-manager.js";
@@ -40,6 +41,7 @@ export function handleWebSocketConnection(
 	projectConfigStore?: { get(key: string): string | undefined },
 	skipAuth = false,
 	sandboxTokenStore?: SandboxTokenStore,
+	projectContextManager?: ProjectContextManager,
 ): void {
 	const ip = getClientIp(req);
 	let authenticated = false;
@@ -227,7 +229,13 @@ export function handleWebSocketConnection(
 					if (slashMatch) {
 						const skillName = slashMatch[1];
 						const skillArgs = slashMatch[2] || "";
-						const skill = getSlashSkill(session.cwd, skillName, projectConfigStore);
+						// Resolve per-project config store for skill lookup
+						let resolvedConfigStore = projectConfigStore;
+						if (session.projectId && projectContextManager) {
+							const ctx = projectContextManager.getOrCreate(session.projectId);
+							if (ctx) resolvedConfigStore = ctx.projectConfigStore;
+						}
+						const skill = getSlashSkill(session.cwd, skillName, resolvedConfigStore);
 						if (skill) {
 							promptText = buildSlashSkillPrompt(skill, skillArgs);
 							console.log(`[ws-handler] Slash skill "${skillName}" invoked for session ${sessionId}`);


### PR DESCRIPTION
Adds per-project config store resolution to skills, config-directories API endpoints and the WebSocket handler.

## Changes

### src/server/server.ts
- Added `resolveProjectConfigStore()` helper in `handleApiRoute()` to resolve per-project config store from ProjectContextManager
- `GET /api/config-directories` now accepts `?projectId=` to return directories scoped to a specific project
- `GET /api/slash-skills` now accepts `?projectId=` to discover skills from the correct project's config directories
- `GET /api/slash-skills/details` now accepts `?projectId=` similarly
- Passes `projectContextManager` to `handleWebSocketConnection`

### src/server/ws/handler.ts
- Added `projectContextManager` parameter to `handleWebSocketConnection`
- Resolves per-project config store for slash skill lookup based on `session.projectId`

All changes are backward-compatible — when no projectId is provided, falls back to the default project config store.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)