### PR TITLE
Pass projectId in UI settings page API calls

### DIFF
--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -1461,18 +1461,31 @@ let configDirsLoaded = false;
 let configDirsLoading = false;
 let configDirsError = "";
 let configDirsSaveStatus: "" | "saving" | "saved" | "error" = "";
+let configDirsLastScope = "";
 
 // Add-directory form state
 let newDirPath = "";
 let newDirTypes: { skills: boolean; mcp: boolean; tools: boolean; agents: boolean } = { skills: false, mcp: false, tools: false, agents: false };
 
 function loadConfigDirs(): void {
+	const currentScope = getActiveScope();
+	if (currentScope !== configDirsLastScope) {
+		configDirsLoaded = false;
+		configDirsLoading = false;
+		configDirsError = "";
+		configDirsLastScope = currentScope;
+	}
 	if (configDirsLoaded || configDirsLoading || configDirsError) return;
 	configDirsLoading = true;
 	configDirsError = "";
 	(async () => {
 		try {
-			const res = await gatewayFetch("/api/config-directories");
+			const dirParams = new URLSearchParams();
+			const scope = getActiveScope();
+			if (scope && scope !== "system") {
+				dirParams.set("projectId", scope);
+			}
+			const res = await gatewayFetch(`/api/config-directories${dirParams.toString() ? '?' + dirParams.toString() : ''}`);
 			if (res.ok) {
 				configDirs = await res.json();
 				configDirsLoaded = true;


### PR DESCRIPTION
When viewing project-scoped settings, the config-directories API call now includes `?projectId=<uuid>` so the server returns project-specific data.

Changes:
- Add `projectId` query parameter to `/api/config-directories` fetch when `settingsScope` is a project UUID
- Track scope changes to invalidate cached config dirs when switching between system and project settings
- No slash-skills API calls exist in this file (skills are loaded elsewhere)

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)