### PR TITLE
Fix failing E2E tests for per-project config dirs

### DIFF
--- a/tests/e2e/per-project-config-dirs.spec.ts
+++ b/tests/e2e/per-project-config-dirs.spec.ts
@@ -29,12 +29,16 @@ async function registerProject(name: string): Promise<{ id: string; rootPath: st
 async function openApp(page: Page, hash?: string): Promise<void> {
 	const token = readE2EToken();
 	const base = `http://127.0.0.1:${process.env.E2E_PORT}`;
-	const url = hash
-		? `${base}/?token=${encodeURIComponent(token)}#${hash}`
-		: `${base}/?token=${encodeURIComponent(token)}`;
-	await page.goto(url);
-	// Wait for the app to be interactive
-	await page.waitForLoadState("networkidle");
+	// First load the app root and wait for it to be fully interactive
+	// (projects list must be loaded before navigating to project-scoped settings)
+	await page.goto(`${base}/?token=${encodeURIComponent(token)}`);
+	await expect(
+		page.getByRole("button", { name: "Settings", exact: true }),
+	).toBeVisible({ timeout: 15_000 });
+	// Now navigate to the desired hash route
+	if (hash) {
+		await page.evaluate((h) => { window.location.hash = h; }, hash);
+	}
 }
 
 test.describe("Per-project Config Directories", () => {


### PR DESCRIPTION
Fix the two failing UI E2E tests in `per-project-config-dirs.spec.ts`.

**Problem:** `openApp` navigated directly to the settings hash URL, but the app hadn't loaded the project list yet, causing 'Project not found' / strict mode violations.

**Fix:**
1. Navigate to app root first, wait for sidebar 'Settings' button (confirms app + projects loaded)
2. Then set `window.location.hash` to navigate to project-scoped settings
3. Use `exact: true` on the Settings button locator to avoid matching 'Project settings' buttons

All 3 tests now pass.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)