### PR TITLE
Fix per-project config dirs

### DIFF
--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -1539,7 +1539,11 @@ async function saveConfigDirs(customDirs: Array<{ path: string; types: string[] 
 	configDirsSaveStatus = "saving";
 	renderApp();
 	try {
-		const res = await gatewayFetch("/api/project-config", {
+		const scope = getActiveScope();
+		const endpoint = scope && scope !== "system"
+			? `/api/projects/${scope}/config`
+			: "/api/project-config";
+		const res = await gatewayFetch(endpoint, {
 			method: "PUT",
 			body: JSON.stringify({ config_directories: JSON.stringify(customDirs), skill_directories: null }),
 		});
@@ -1974,18 +1978,7 @@ function renderProjectScopeModelsTab(_projectId: string) {
 }
 
 function renderProjectScopeDirectoriesTab(_projectId: string) {
-	// For now, show the system directories tab content with a note
-	return html`
-		<div class="flex flex-col gap-4">
-			<p class="text-sm text-muted-foreground">
-				Config directories for this project. Currently inherits from System.
-			</p>
-			<p class="text-xs text-muted-foreground">
-				Per-project config directory overrides will be available in a future update. Configure directories in
-				<button class="text-primary hover:underline" @click=${() => setHashRoute("settings", "system/directories", true)}>System &rarr; Config Directories</button>.
-			</p>
-		</div>
-	`;
+	return renderDirectoriesTab();
 }
 
 function renderAppearanceTab(projectId: string) {

--- a/tests/e2e/per-project-config-dirs.spec.ts
+++ b/tests/e2e/per-project-config-dirs.spec.ts
@@ -29,12 +29,16 @@ async function registerProject(name: string): Promise<{ id: string; rootPath: st
 async function openApp(page: Page, hash?: string): Promise<void> {
 	const token = readE2EToken();
 	const base = `http://127.0.0.1:${process.env.E2E_PORT}`;
-	const url = hash
-		? `${base}/?token=${encodeURIComponent(token)}#${hash}`
-		: `${base}/?token=${encodeURIComponent(token)}`;
-	await page.goto(url);
-	// Wait for the app to be interactive
-	await page.waitForLoadState("networkidle");
+	// First load the app root and wait for it to be fully interactive
+	// (projects list must be loaded before navigating to project-scoped settings)
+	await page.goto(`${base}/?token=${encodeURIComponent(token)}`);
+	await expect(
+		page.getByRole("button", { name: "Settings", exact: true }),
+	).toBeVisible({ timeout: 15_000 });
+	// Now navigate to the desired hash route
+	if (hash) {
+		await page.evaluate((h) => { window.location.hash = h; }, hash);
+	}
 }
 
 test.describe("Per-project Config Directories", () => {

--- a/tests/e2e/per-project-config-dirs.spec.ts
+++ b/tests/e2e/per-project-config-dirs.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * E2E tests for per-project Config Directories.
+ *
+ * Verifies that:
+ * 1. Registering a project and navigating to its Config Directories tab
+ *    shows the full directory editor (not a placeholder).
+ * 2. Adding a custom directory via the UI persists to the project-scoped API.
+ * 3. Project-scoped custom dirs do NOT leak into system-level config dirs.
+ */
+import { test, expect } from "./gateway-harness.js";
+import { apiFetch, readE2EToken, nonGitCwd } from "./e2e-setup.js";
+import { resolve } from "node:path";
+import type { Page } from "@playwright/test";
+
+/** Register a project via the REST API and return its id + rootPath. */
+async function registerProject(name: string): Promise<{ id: string; rootPath: string }> {
+	const rootPath = nonGitCwd(); // temp dir outside any git repo
+	const resp = await apiFetch("/api/projects", {
+		method: "POST",
+		body: JSON.stringify({ name, rootPath }),
+	});
+	expect(resp.status).toBe(201);
+	const project = await resp.json();
+	expect(project.id).toBeTruthy();
+	return { id: project.id, rootPath };
+}
+
+/** Open the app authenticated via token query param. */
+async function openApp(page: Page, hash?: string): Promise<void> {
+	const token = readE2EToken();
+	const base = `http://127.0.0.1:${process.env.E2E_PORT}`;
+	const url = hash
+		? `${base}/?token=${encodeURIComponent(token)}#${hash}`
+		: `${base}/?token=${encodeURIComponent(token)}`;
+	await page.goto(url);
+	// Wait for the app to be interactive
+	await page.waitForLoadState("networkidle");
+}
+
+test.describe("Per-project Config Directories", () => {
+	let projectId: string;
+
+	test.beforeAll(async () => {
+		const project = await registerProject(`e2e-config-dirs-${Date.now()}`);
+		projectId = project.id;
+	});
+
+	test("project settings shows directory editor, not placeholder", async ({ page }) => {
+		await openApp(page, `/settings/${projectId}/directories`);
+
+		// The directory editor shows "Add Custom Path" heading and category headings.
+		// A placeholder would show "inherits from System" text instead.
+		await expect(
+			page.getByText("Add Custom Path"),
+		).toBeVisible({ timeout: 15_000 });
+
+		// Also verify category headings from the real editor
+		await expect(page.getByText("Skills").first()).toBeVisible();
+		await expect(page.getByText("MCP").first()).toBeVisible();
+
+		// The placeholder text should NOT be present
+		await expect(
+			page.getByText("inherits from System"),
+		).not.toBeVisible();
+	});
+
+	test("add custom directory via UI and verify via API", async ({ page }) => {
+		await openApp(page, `/settings/${projectId}/directories`);
+
+		// Wait for the editor to load
+		await expect(
+			page.getByText("Add Custom Path"),
+		).toBeVisible({ timeout: 15_000 });
+
+		const customPath = `e2e-custom-dir-${Date.now()}`;
+		// Server resolves relative paths via path.resolve()
+		const resolvedCustomPath = resolve(customPath);
+
+		// Type the custom directory path
+		const pathInput = page.locator("input[type='text'][placeholder*='my-config-dir'], input[type='text'][placeholder*='path']");
+		await pathInput.fill(customPath);
+
+		// Check the "Skills" checkbox
+		const skillsCheckbox = page.locator("label").filter({ hasText: "Skills" }).locator("input[type='checkbox']");
+		await skillsCheckbox.check();
+
+		// Click Add (exact match to avoid "Add Project" button)
+		const addButton = page.getByRole("button", { name: "Add", exact: true });
+		await addButton.click();
+
+		// Wait for "Saved successfully" confirmation
+		await expect(
+			page.getByText("Saved successfully"),
+		).toBeVisible({ timeout: 10_000 });
+
+		// Verify via API: project-scoped config dirs should include the custom path
+		const projectDirsResp = await apiFetch(`/api/config-directories?projectId=${projectId}`);
+		expect(projectDirsResp.status).toBe(200);
+		const projectDirs = await projectDirsResp.json();
+		const customEntry = projectDirs.find((d: any) => d.path === resolvedCustomPath);
+		expect(customEntry, `Expected custom dir '${resolvedCustomPath}' in project config dirs`).toBeTruthy();
+		expect(customEntry.types).toContain("skills");
+
+		// Verify system-level config dirs do NOT contain the custom path
+		const systemDirsResp = await apiFetch("/api/config-directories");
+		expect(systemDirsResp.status).toBe(200);
+		const systemDirs = await systemDirsResp.json();
+		const leaked = systemDirs.find((d: any) => d.path === resolvedCustomPath);
+		expect(leaked, `Custom dir '${resolvedCustomPath}' should NOT appear in system config dirs`).toBeFalsy();
+	});
+
+	test("project config dirs API endpoint stores data correctly", async () => {
+		// Direct API test: PUT config_directories to the project endpoint and verify
+		const skillsPath = `api-test-skills-${Date.now()}`;
+		const mcpPath = `api-test-mcp-${Date.now()}`;
+		const customDirs = [
+			{ path: skillsPath, types: ["skills"] },
+			{ path: mcpPath, types: ["mcp", "tools"] },
+		];
+
+		const putResp = await apiFetch(`/api/projects/${projectId}/config`, {
+			method: "PUT",
+			body: JSON.stringify({
+				config_directories: JSON.stringify(customDirs),
+				skill_directories: null,
+			}),
+		});
+		expect(putResp.status).toBe(200);
+
+		// The server resolves relative paths via path.resolve(), so match on the resolved value
+		const resolvedSkills = resolve(skillsPath);
+		const resolvedMcp = resolve(mcpPath);
+
+		// Verify via GET config-directories with projectId
+		const getDirsResp = await apiFetch(`/api/config-directories?projectId=${projectId}`);
+		expect(getDirsResp.status).toBe(200);
+		const dirs = await getDirsResp.json();
+
+		const skillsDir = dirs.find((d: any) => d.path === resolvedSkills);
+		expect(skillsDir, `Expected '${resolvedSkills}' in project dirs`).toBeTruthy();
+		expect(skillsDir.types).toContain("skills");
+
+		const mcpToolsDir = dirs.find((d: any) => d.path === resolvedMcp);
+		expect(mcpToolsDir, `Expected '${resolvedMcp}' in project dirs`).toBeTruthy();
+		expect(mcpToolsDir.types).toContain("mcp");
+		expect(mcpToolsDir.types).toContain("tools");
+
+		// Verify system is unaffected
+		const sysResp = await apiFetch("/api/config-directories");
+		const sysDirs = await sysResp.json();
+		expect(sysDirs.find((d: any) => d.path === resolvedSkills)).toBeFalsy();
+		expect(sysDirs.find((d: any) => d.path === resolvedMcp)).toBeFalsy();
+	});
+});


### PR DESCRIPTION
## Summary

Completes the per-project Config Directories UI that was left as a placeholder in PR #168.

### Changes

**`src/app/settings-page.ts`:**
1. `renderProjectScopeDirectoriesTab()` — replaced static placeholder ("inherits from System") with a call to `renderDirectoriesTab()`, which already loads data scoped by `getActiveScope()`.
2. `saveConfigDirs()` — now PUTs to `/api/projects/${projectId}/config` when in project scope instead of always using the system endpoint.

No backend changes — server endpoints were already correct.

### Tests

Added `tests/e2e/per-project-config-dirs.spec.ts` with 3 tests:
- Project settings shows the directory editor (not placeholder)
- Adding a custom dir via UI persists to project-scoped API and doesn't leak to system config
- Direct API PUT/GET for project-scoped config directories

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)