### PR TITLE
Fix type errors, race condition, and pool fail-open

### DIFF
--- a/src/server/agent/config-directories.ts
+++ b/src/server/agent/config-directories.ts
@@ -196,6 +196,37 @@ export function getAllConfigDirectories(
 }
 
 /**
+ * Remove a built-in directory from scanning by adding it to the
+ * `disabled_config_directories` list in project config.
+ */
+export function removeBuiltinDirectory(
+	projectConfigStore: ProjectConfigWriter,
+	dirPath: string,
+): void {
+	const resolved = expandPath(dirPath);
+	const raw = projectConfigStore.get("disabled_config_directories");
+	let disabled: string[] = [];
+	if (raw) {
+		try { disabled = JSON.parse(raw); } catch { disabled = []; }
+	}
+	if (!disabled.includes(resolved)) {
+		disabled.push(resolved);
+	}
+	projectConfigStore.set("disabled_config_directories", JSON.stringify(disabled));
+}
+
+/**
+ * Reset config directories to defaults by clearing both custom and disabled lists.
+ */
+export function resetConfigDirectories(
+	projectConfigStore: ProjectConfigWriter,
+): void {
+	projectConfigStore.remove("config_directories");
+	projectConfigStore.remove("skill_directories");
+	projectConfigStore.remove("disabled_config_directories");
+}
+
+/**
  * Save custom directories to project config via the `config_directories` key.
  * Also removes the legacy `skill_directories` key to prevent stale entries
  * from reappearing on next read (migrate forward).

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -374,21 +374,19 @@ export class SessionManager {
 	async ensureSandboxNetwork(): Promise<string> {
 		const name = SessionManager.SANDBOX_NETWORK;
 		try {
-			await execFileAsync("docker", ["network", "inspect", name], { timeout: 10_000 });
-			return name; // Already exists
-		} catch {
-			// Network doesn't exist — create it
-		}
-		try {
 			await execFileAsync("docker", [
 				"network", "create", name,
 				"--driver", "bridge",
 				"--opt", "com.docker.network.bridge.enable_icc=false",
 			], { timeout: 15_000 });
 			console.log(`[session-manager] Created Docker network "${name}"`);
-		} catch (err) {
-			console.error(`[session-manager] Failed to create Docker network "${name}":`, err);
-			throw err;
+		} catch (err: any) {
+			const msg = err.stderr || err.message || "";
+			if (!msg.includes("already exists")) {
+				console.error(`[session-manager] Failed to create Docker network "${name}":`, err);
+				throw err;
+			}
+			// Network was created concurrently — that's fine
 		}
 		return name;
 	}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -531,8 +531,12 @@ export function createGateway(config: GatewayConfig) {
 						try {
 							sandboxNetwork = await sessionManager.ensureSandboxNetwork();
 						} catch (err) {
-							console.warn("[sandbox-pool] Failed to create sandbox network, pool containers will use default network:", err);
+							console.error("[sandbox-pool] Cannot create sandbox network — pool disabled:", err);
 						}
+
+						if (!sandboxNetwork) {
+							console.warn("[sandbox-pool] Skipping pool initialization — no sandbox network available");
+						} else {
 
 						sandboxPool = new SandboxPool({
 							poolSize,
@@ -550,6 +554,7 @@ export function createGateway(config: GatewayConfig) {
 						});
 						await sandboxPool.init();
 						console.log(`[sandbox-pool] Initialized with poolSize=${poolSize}`);
+						} // end if (sandboxNetwork)
 					} else {
 						console.log("[sandbox-pool] Not a git repo — sandbox pool disabled (worktrees require git)");
 					}


### PR DESCRIPTION
Fixes three issues blocking the implementation gate verification:

1. **Type errors**: Added missing `removeBuiltinDirectory()` and `resetConfigDirectories()` exports to `config-directories.ts` that `server.ts` imports but didn't exist.

2. **Race condition**: Replaced TOCTOU inspect-then-create in `ensureSandboxNetwork()` with try-create-catch-already-exists pattern to handle concurrent session starts.

3. **Silent fail-open**: When `ensureSandboxNetwork()` fails, pool initialization is now skipped entirely instead of creating containers on Docker's default (unsecured) network.

`npm run check` passes with zero errors.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)