### PR TITLE
Add settings and goal-creation UI E2E tests

### DIFF
--- a/src/server/agent/config-directories.ts
+++ b/src/server/agent/config-directories.ts
@@ -196,6 +196,37 @@ export function getAllConfigDirectories(
 }
 
 /**
+ * Remove a built-in directory from scanning by adding it to a suppress list.
+ * The directory won't appear in `getAllConfigDirectories()` on subsequent calls.
+ */
+export function removeBuiltinDirectory(
+	projectConfigStore: ProjectConfigWriter,
+	dirPath: string,
+): void {
+	const suppressedRaw = projectConfigStore.get("suppressed_config_directories");
+	let suppressed: string[] = [];
+	if (suppressedRaw) {
+		try { suppressed = JSON.parse(suppressedRaw); } catch {}
+	}
+	const resolved = path.resolve(dirPath.startsWith("~") ? path.join(os.homedir(), dirPath.slice(1)) : dirPath);
+	if (!suppressed.includes(resolved)) {
+		suppressed.push(resolved);
+		projectConfigStore.set("suppressed_config_directories", JSON.stringify(suppressed));
+	}
+}
+
+/**
+ * Reset config directories to defaults by clearing custom and suppressed lists.
+ */
+export function resetConfigDirectories(
+	projectConfigStore: ProjectConfigWriter,
+): void {
+	projectConfigStore.remove("config_directories");
+	projectConfigStore.remove("skill_directories");
+	projectConfigStore.remove("suppressed_config_directories");
+}
+
+/**
  * Save custom directories to project config via the `config_directories` key.
  * Also removes the legacy `skill_directories` key to prevent stale entries
  * from reappearing on next read (migrate forward).

--- a/tests/e2e/mock-agent.mjs
+++ b/tests/e2e/mock-agent.mjs
@@ -60,6 +60,13 @@ function respondToPrompt(text) {
 		const filePath = extractFilePath(text);
 		return { tool: "Edit", input: { path: filePath, oldText: "ORIGINAL_VALUE", newText: "EDITED_VALUE" }, output: "Edited successfully" };
 	}
+	// Goal proposal keyword — emit a goal_proposal block for goal assistant tests
+	if (lower.includes("goal_proposal") || lower.includes("goal proposal")) {
+		return {
+			tool: null,
+			text: `Here is a goal proposal:\n\n<goal_proposal>\n<title>E2E Test Goal</title>\n<workflow>general</workflow>\n<spec>\nThis is a test goal created via the assistant flow.\nIt validates the goal creation UI.\n</spec>\n</goal_proposal>`
+		};
+	}
 	// Default: just reply with text
 	return null;
 }
@@ -134,6 +141,14 @@ async function handlePrompt(requestId, text) {
 		const assistantMsg = {
 			role: "assistant",
 			content: [{ type: "text", text: `I tried to use ${deniedTool} but it is not allowed. Please grant permission.` }],
+		};
+		conversationMessages.push(assistantMsg);
+		emit({ type: "message_end", message: assistantMsg });
+	} else if (toolAction && toolAction.tool === null && toolAction.text) {
+		// Text-only response (e.g. goal proposal) — emit as assistant message
+		const assistantMsg = {
+			role: "assistant",
+			content: [{ type: "text", text: toolAction.text }],
 		};
 		conversationMessages.push(assistantMsg);
 		emit({ type: "message_end", message: assistantMsg });

--- a/tests/e2e/ui/goal-creation.spec.ts
+++ b/tests/e2e/ui/goal-creation.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Goal creation E2E tests: assistant flow with mock agent proposal, API creation.
+ */
+import { test, expect } from "../gateway-harness.js";
+import { apiFetch, createGoal, nonGitCwd } from "../e2e-setup.js";
+import { openApp, sendMessage, waitForAgentResponse, navigateToHash } from "./ui-helpers.js";
+
+test.describe("Goal creation (full-stack UI)", () => {
+	test("create goal via assistant flow", async ({ page }) => {
+		await openApp(page);
+
+		// Click the "New Goal" button in the sidebar (title="New goal (Alt+G)")
+		const newGoalBtn = page.locator("button[title='New goal (Alt+G)']").first();
+		await expect(newGoalBtn).toBeVisible({ timeout: 10_000 });
+		await newGoalBtn.click();
+
+		// Wait for the textarea to appear (goal assistant session is created)
+		const textarea = page.locator("textarea").first();
+		await expect(textarea).toBeVisible({ timeout: 15_000 });
+
+		// Send a message with GOAL_PROPOSAL keyword to trigger mock agent
+		await sendMessage(page, "Please create a GOAL_PROPOSAL for testing");
+
+		// The proposal parser should detect the <goal_proposal> block and populate
+		// the preview panel. On desktop, the goal preview panel always shows for
+		// assistantType="goal". Wait for the title field to be populated.
+		// The title input is in the goal-preview-panel with placeholder "Goal title"
+		const titleInput = page.locator("input[placeholder='Goal title']").first();
+		await expect(titleInput).toBeVisible({ timeout: 10_000 });
+		await expect(titleInput).toHaveValue("E2E Test Goal", { timeout: 15_000 });
+
+		// Now the Create Goal button should be enabled
+		const createGoalBtn = page.locator("button").filter({ hasText: "Create Goal" }).first();
+		await expect(createGoalBtn).toBeVisible({ timeout: 5_000 });
+
+		// Click "Create Goal"
+		await createGoalBtn.click();
+
+		// After creating, the app navigates to the goal dashboard.
+		// Wait for the URL to change to a goal-related view
+		await expect(page).toHaveURL(/#\/goal(-dashboard)?\//, { timeout: 15_000 });
+
+		// Verify the goal was created via API
+		const goalsResp = await apiFetch("/api/goals");
+		expect(goalsResp.ok).toBe(true);
+		const goalsData = await goalsResp.json();
+		const goals = goalsData.goals || goalsData;
+		const createdGoal = (goals as any[]).find((g: any) => g.title === "E2E Test Goal");
+		expect(createdGoal).toBeTruthy();
+
+		// Clean up
+		if (createdGoal) {
+			await apiFetch(`/api/goals/${createdGoal.id}`, { method: "DELETE" }).catch(() => {});
+		}
+	});
+
+	test("goal appears after API creation", async ({ page }) => {
+		// Create goal via API first
+		const goal = await createGoal({ title: "API Created Goal" });
+
+		try {
+			await openApp(page);
+
+			// The goal should appear somewhere in the UI — check the sidebar goals section
+			// Goals appear in the sidebar as clickable entries
+			await expect(page.getByText("API Created Goal").first()).toBeVisible({ timeout: 10_000 });
+		} finally {
+			await apiFetch(`/api/goals/${goal.id}`, { method: "DELETE" }).catch(() => {});
+		}
+	});
+});

--- a/tests/e2e/ui/settings.spec.ts
+++ b/tests/e2e/ui/settings.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * Settings E2E tests: tab switching, persistence, per-project scope.
+ */
+import { test, expect } from "../gateway-harness.js";
+import { apiFetch, nonGitCwd } from "../e2e-setup.js";
+import { openApp, navigateToHash } from "./ui-helpers.js";
+
+test.describe("Settings (full-stack UI)", () => {
+	test("open settings and switch tabs", async ({ page }) => {
+		await openApp(page);
+		await navigateToHash(page, "#/settings/system/general");
+
+		// Verify settings view renders — look for "Settings" heading
+		await expect(page.locator("h1").filter({ hasText: "Settings" })).toBeVisible({ timeout: 10_000 });
+
+		// Verify General tab content is visible — it has the "Show message timestamps" checkbox
+		await expect(page.getByText("Show message timestamps")).toBeVisible({ timeout: 5_000 });
+
+		// Switch to Models tab
+		const modelsTab = page.locator("button").filter({ hasText: "Models" }).first();
+		await modelsTab.click();
+
+		// The URL should update to reflect the Models tab
+		await expect(page).toHaveURL(/#\/settings\/system\/models/, { timeout: 5_000 });
+
+		// Switch to Shortcuts tab
+		const shortcutsTab = page.locator("button").filter({ hasText: "Shortcuts" }).first();
+		await shortcutsTab.click();
+		await expect(page).toHaveURL(/#\/settings\/system\/shortcuts/, { timeout: 5_000 });
+
+		// Switch to Color Palette tab
+		const paletteTab = page.locator("button").filter({ hasText: "Color Palette" }).first();
+		await paletteTab.click();
+		await expect(page).toHaveURL(/#\/settings\/system\/palette/, { timeout: 5_000 });
+	});
+
+	test("setting persists after reload", async ({ page }) => {
+		await openApp(page);
+		await navigateToHash(page, "#/settings/system/general");
+
+		// Wait for the General tab to load with the timestamps checkbox
+		const checkbox = page.locator("input[type='checkbox']").first();
+		await expect(checkbox).toBeVisible({ timeout: 10_000 });
+
+		// Get the current state of the checkbox
+		const wasChecked = await checkbox.isChecked();
+
+		// Toggle the checkbox
+		await checkbox.click();
+
+		// Verify the checkbox toggled
+		if (wasChecked) {
+			await expect(checkbox).not.toBeChecked();
+		} else {
+			await expect(checkbox).toBeChecked();
+		}
+
+		// Wait for the setting to persist (the toggle sends a PUT to /api/preferences)
+		await page.waitForTimeout(500);
+
+		// Reload the page
+		await page.reload();
+		await expect(
+			page.locator("button[title='New session']").first(),
+		).toBeVisible({ timeout: 15_000 });
+
+		// Navigate back to settings
+		await navigateToHash(page, "#/settings/system/general");
+		await expect(page.getByText("Show message timestamps")).toBeVisible({ timeout: 10_000 });
+
+		// Verify the checkbox retained its new state
+		const checkboxAfterReload = page.locator("input[type='checkbox']").first();
+		await expect(checkboxAfterReload).toBeVisible({ timeout: 5_000 });
+
+		if (wasChecked) {
+			await expect(checkboxAfterReload).not.toBeChecked();
+		} else {
+			await expect(checkboxAfterReload).toBeChecked();
+		}
+
+		// Clean up: toggle back to original state
+		await checkboxAfterReload.click();
+	});
+
+	test("per-project settings scope switching", async ({ page }) => {
+		// Create a project via API
+		const resp = await apiFetch("/api/projects", {
+			method: "POST",
+			body: JSON.stringify({ name: "Settings Test Project", rootPath: nonGitCwd() }),
+		});
+		expect(resp.ok).toBe(true);
+		const project = await resp.json();
+		const projectId = project.id;
+
+		try {
+			await openApp(page);
+
+			// Navigate to the project's appearance settings
+			await navigateToHash(page, `#/settings/${projectId}/appearance`);
+
+			// Verify settings view is rendered
+			await expect(page.locator("h1").filter({ hasText: "Settings" })).toBeVisible({ timeout: 10_000 });
+
+			// Verify the project scope button is active (has the active styling) —
+			// look for a button with the project name that has the active class
+			const projectScopeBtn = page.locator("button").filter({ hasText: "Settings Test Project" });
+			await expect(projectScopeBtn).toBeVisible({ timeout: 5_000 });
+
+			// Verify we're on the Appearance tab — look for the Appearance tab button
+			// that has the active styling (bg-background class)
+			const appearanceTab = page.locator("button").filter({ hasText: "Appearance" });
+			await expect(appearanceTab).toBeVisible({ timeout: 5_000 });
+
+			// Verify Appearance tab content is visible — it should have palette or color inputs
+			// The appearance tab has "Color Palette" and accent color controls
+			await expect(
+				page.getByText("Palette").first()
+			).toBeVisible({ timeout: 5_000 });
+		} finally {
+			// Clean up the project
+			await apiFetch(`/api/projects/${projectId}`, { method: "DELETE" }).catch(() => {});
+		}
+	});
+});

--- a/tests/e2e/ui/ui-helpers.ts
+++ b/tests/e2e/ui/ui-helpers.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared page-object helpers for UI E2E tests.
+ * STUB — will be replaced by Coder 1's full implementation.
+ */
+import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { readE2EToken, apiFetch, waitForSessionStatus } from "../e2e-setup.js";
+
+/** Open the app authenticated via token query param, wait for sidebar. */
+export async function openApp(page: Page): Promise<void> {
+	const token = readE2EToken();
+	const base = `http://127.0.0.1:${process.env.E2E_PORT}`;
+	await page.goto(`${base}/?token=${encodeURIComponent(token)}`);
+	// Wait for any "New session" button (exact or per-project variant)
+	await expect(
+		page.locator("button[title^='New session']").first(),
+	).toBeVisible({ timeout: 15_000 });
+}
+
+/** Click "New session" button, wait for textarea. */
+export async function createSessionViaUI(page: Page): Promise<void> {
+	await page.locator("button[title='New session']").first().click();
+	await expect(page.locator("textarea").first()).toBeVisible({ timeout: 15_000 });
+}
+
+/** Fill textarea, press Enter, wait for assistant response. */
+export async function sendMessage(page: Page, text: string): Promise<void> {
+	const textarea = page.locator("textarea").first();
+	await expect(textarea).toBeVisible({ timeout: 10_000 });
+	await textarea.fill(text);
+	await textarea.press("Enter");
+}
+
+/** Wait for an assistant message to appear. If opts.text provided, wait for that text. */
+export async function waitForAgentResponse(
+	page: Page,
+	opts?: { text?: string; timeout?: number },
+): Promise<void> {
+	const timeout = opts?.timeout ?? 15_000;
+	if (opts?.text) {
+		await expect(page.getByText(opts.text).first()).toBeVisible({ timeout });
+	} else {
+		await expect(page.getByText("OK", { exact: true }).first()).toBeVisible({ timeout });
+	}
+}
+
+/** Navigate by setting window.location.hash. */
+export async function navigateToHash(page: Page, hash: string): Promise<void> {
+	await page.evaluate((h) => { window.location.hash = h; }, hash);
+	// Brief wait for view transition
+	await page.waitForTimeout(300);
+}
+
+/** Navigate to goal dashboard and wait for content. */
+export async function navigateToGoalDashboard(page: Page, goalId: string): Promise<void> {
+	await navigateToHash(page, `#/goal-dashboard/${goalId}`);
+	// Wait for dashboard to render
+	await page.waitForTimeout(500);
+}
+
+/** Click a sidebar entry by text content. */
+export async function clickSidebarItem(page: Page, label: string): Promise<void> {
+	await page.getByText(label).first().click();
+}
+
+/** Return visible session names in the sidebar. */
+export async function getVisibleSessions(page: Page): Promise<string[]> {
+	const entries = page.locator(".sidebar-session-entry, [class*='session']");
+	const texts: string[] = [];
+	const count = await entries.count();
+	for (let i = 0; i < count; i++) {
+		const text = await entries.nth(i).textContent();
+		if (text) texts.push(text.trim());
+	}
+	return texts;
+}
+
+/** Wait for a session to reach idle status via API polling. */
+export async function waitForSessionIdle(sessionId: string): Promise<void> {
+	await waitForSessionStatus(sessionId, "idle");
+}


### PR DESCRIPTION
## Changes

- **tests/e2e/ui/settings.spec.ts**: 3 tests covering settings tab switching, setting persistence after reload, and per-project settings scope switching
- **tests/e2e/ui/goal-creation.spec.ts**: 2 tests covering the full goal assistant flow (New Goal → GOAL_PROPOSAL → Create Goal) and API-created goal visibility in UI
- **tests/e2e/ui/ui-helpers.ts**: Stub page-object helpers (will be replaced by Coder 1's full implementation)
- **tests/e2e/mock-agent.mjs**: Added GOAL_PROPOSAL keyword handler with XML response format, fixed text-only response ordering
- **src/server/agent/config-directories.ts**: Added missing `removeBuiltinDirectory` and `resetConfigDirectories` exports (fixes pre-existing server build error)

All 5 new tests pass. Existing tests unaffected.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)