### PR TITLE
Simplify resolveToolActivation: replace stubs with guard extension

### DIFF
--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -33,7 +33,7 @@ import type { PromptParts } from "./system-prompt.js";
 import type { GrantPolicy } from "./role-store.js";
 import { getAssistantDef } from "./assistant-registry.js";
 import { buildReattemptContext } from "./goal-assistant.js";
-import { computeToolActivationArgs, writeMcpProxyExtensions, writeToolStubExtensions, writeLeakedToolStubs, computeEffectiveAllowedTools } from "./tool-activation.js";
+import { computeToolActivationArgs, writeMcpProxyExtensions, writeToolGuardExtension, computeEffectiveAllowedTools } from "./tool-activation.js";
 import { TOOLS_DIR } from "./tool-manager.js";
 import { createWorktree, cleanupWorktree } from "../skills/git.js";
 
@@ -323,40 +323,29 @@ export function resolvePrompt(plan: SessionSetupPlan, ctx: PipelineContext): voi
 	}
 }
 
-/** Step 5: computeToolActivationArgs + writeMcpProxyExtensions + writeToolStubExtensions. */
+/** Step 5: computeToolActivationArgs + writeMcpProxyExtensions + writeToolGuardExtension. */
 export function resolveToolActivation(plan: SessionSetupPlan, ctx: PipelineContext): void {
 	if (plan.effectiveAllowedTools && plan.effectiveAllowedTools.length > 0) {
 		const effectiveRole = (plan.roleName && ctx.roleManager) ? ctx.roleManager.getRole(plan.roleName) : undefined;
 		const mcpExtPaths = ctx.mcpManager
 			? writeMcpProxyExtensions(ctx.mcpManager, plan.effectiveAllowedTools, effectiveRole ?? undefined, ctx.toolManager ?? undefined, ctx.groupPolicyStore ?? undefined)
 			: undefined;
-		// Generate stubs for non-MCP tools that are restricted but visible (ask-once/always-ask).
-		// Loaded BEFORE real extensions because pi-coding-agent uses first-registered-wins semantics.
-		const toolStubArgs: string[] = [];
-		if (ctx.toolManager) {
-			const toolStubPaths = writeToolStubExtensions(
-				ctx.toolManager,
-				plan.effectiveAllowedTools,
-				effectiveRole ?? undefined,
-				ctx.groupPolicyStore ?? undefined,
-			);
-			for (const stubPath of toolStubPaths) {
-				toolStubArgs.push("--extension", stubPath);
-			}
-		}
 
 		const activation = computeToolActivationArgs(plan.effectiveAllowedTools, ctx.toolManager ?? undefined, plan.cwd, mcpExtPaths);
 
-		// Generate blocking stubs for "leaked" tools — tools registered by loaded extensions
-		// that aren't in allowedTools. These must load BEFORE real extensions (first-registered-wins).
-		if (activation.leakedTools && activation.leakedTools.length > 0) {
-			const leakStubPaths = writeLeakedToolStubs(activation.leakedTools);
-			for (const stubPath of leakStubPaths) {
-				toolStubArgs.push("--extension", stubPath);
-			}
-		}
+		plan.bridgeOptions.args = [...activation.args, ...(plan.bridgeOptions.args || [])];
 
-		plan.bridgeOptions.args = [...toolStubArgs, ...activation.args, ...(plan.bridgeOptions.args || [])];
+		// Generate and add the tool_call guard extension if any tools have 'ask' policy
+		const guardPath = writeToolGuardExtension(
+			plan.id,
+			ctx.toolManager ?? undefined,
+			ctx.mcpManager ?? undefined,
+			effectiveRole ?? undefined,
+			ctx.groupPolicyStore ?? undefined,
+		);
+		if (guardPath) {
+			plan.bridgeOptions.args.push("--extension", guardPath);
+		}
 	} else if (ctx.mcpManager) {
 		const mcpExtPaths = writeMcpProxyExtensions(ctx.mcpManager);
 		for (const extPath of mcpExtPaths) {

--- a/src/server/agent/tool-activation.ts
+++ b/src/server/agent/tool-activation.ts
@@ -471,6 +471,24 @@ export function writeMcpProxyExtensions(mcpManager: McpManager, allowedTools?: s
 }
 
 /**
+ * Generate and write the tool_call guard extension for a session.
+ * Returns the path to the written extension file, or undefined if no guard is needed
+ * (i.e. no tools have 'ask' policy).
+ *
+ * Stub — real implementation provided by tool-guard-extension.ts task.
+ */
+export function writeToolGuardExtension(
+	_sessionId: string,
+	_toolManager?: ToolManager,
+	_mcpManager?: McpManager,
+	_role?: { toolPolicies?: Record<string, GrantPolicy> },
+	_groupPolicyStore?: GroupPolicyProvider,
+): string | undefined {
+	// TODO: Replace with real implementation from tool-guard-extension.ts
+	return undefined;
+}
+
+/**
  * Given a role's allowedTools list and a ToolManager, compute the CLI args needed
  * to activate exactly those tools.
  *


### PR DESCRIPTION
Simplifies `resolveToolActivation()` in `session-setup.ts`:

- **Removed** imports of `writeToolStubExtensions` and `writeLeakedToolStubs`
- **Removed** stub generation, leaked tool detection, and first-registered-wins ordering tricks
- **Added** `writeToolGuardExtension` call — generates a single guard extension that intercepts `tool_call` events for tools with `ask` policy
- **Added** stub `writeToolGuardExtension` in `tool-activation.ts` (returns `undefined`) so the type-check passes. The core task will replace this with the real implementation.

The function goes from ~30 lines of fragile stub/leak/ordering logic to ~15 lines: compute args, add guard if needed.

`npm run check` passes.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)