### PR TITLE
Fix failing unit tests for new grant policy values

### DIFF
--- a/src/server/agent/tool-group-policy-store.ts
+++ b/src/server/agent/tool-group-policy-store.ts
@@ -11,7 +11,7 @@ import path from "node:path";
 import { stringify, parse } from "yaml";
 import type { GrantPolicy } from "./role-store.js";
 
-const VALID_POLICIES = new Set<string>(['always-ask', 'ask-once', 'never-ask', 'never', 'always-allow']);
+const VALID_POLICIES = new Set<string>(['allow', 'ask', 'never', 'always-ask', 'ask-once', 'never-ask', 'always-allow']);
 
 export class ToolGroupPolicyStore {
 	private readonly policyFile: string;

--- a/tests/grant-policy.test.ts
+++ b/tests/grant-policy.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for resolveGrantPolicy() in tool-activation.ts.
  * Covers 5-layer priority resolution:
- *   role tool-specific > role group > tool YAML default > group default > system fallback ('always-allow').
+ *   role tool-specific > role group > tool YAML default > group default > system fallback ('allow').
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
@@ -31,94 +31,94 @@ function mockGroupPolicyStore(policies: Record<string, string>) {
 
 describe("resolveGrantPolicy", () => {
 	it("role tool-specific override wins over tool YAML default", () => {
-		const role = { toolPolicies: { "mcp__pw__snap": "always-ask" as const } };
-		const tm = mockToolManager({ "mcp__pw__snap": { grantPolicy: "ask-once" } });
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm), "always-ask");
+		const role = { toolPolicies: { "mcp__pw__snap": "ask" as const } };
+		const tm = mockToolManager({ "mcp__pw__snap": { grantPolicy: "ask" } });
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm), "ask");
 	});
 
 	it("role group-level override when no tool-specific", () => {
-		const role = { toolPolicies: { "mcp__playwright": "ask-once" as const } };
+		const role = { toolPolicies: { "mcp__playwright": "ask" as const } };
 		const tm = mockToolManager({});
-		assert.equal(resolveGrantPolicy("mcp__playwright__snap", "mcp__playwright", role, tm), "ask-once");
+		assert.equal(resolveGrantPolicy("mcp__playwright__snap", "mcp__playwright", role, tm), "ask");
 	});
 
 	it("tool YAML default when no role toolPolicies", () => {
 		const role = {};
-		const tm = mockToolManager({ "mcp__pw__snap": { grantPolicy: "ask-once" } });
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm), "ask-once");
+		const tm = mockToolManager({ "mcp__pw__snap": { grantPolicy: "ask" } });
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm), "ask");
 	});
 
-	it("returns always-allow (system fallback) when no configuration exists", () => {
+	it("returns allow (system fallback) when no configuration exists", () => {
 		const role = {};
 		const tm = mockToolManager({ "mcp__pw__snap": {} });
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm), "always-allow");
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm), "allow");
 	});
 
 	it("falls through to tool YAML when role is undefined", () => {
-		const tm = mockToolManager({ "mcp__pw__snap": { grantPolicy: "ask-once" } });
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", undefined, tm), "ask-once");
+		const tm = mockToolManager({ "mcp__pw__snap": { grantPolicy: "ask" } });
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", undefined, tm), "ask");
 	});
 
-	it("returns always-allow with undefined role and no tool grantPolicy", () => {
+	it("returns allow with undefined role and no tool grantPolicy", () => {
 		const tm = mockToolManager({ "mcp__pw__snap": {} });
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", undefined, tm), "always-allow");
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", undefined, tm), "allow");
 	});
 
-	it("returns always-allow with undefined toolManager and no role policy", () => {
+	it("returns allow with undefined toolManager and no role policy", () => {
 		const role = {};
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, undefined), "always-allow");
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, undefined), "allow");
 	});
 
 	it("falls through to tool YAML with empty toolPolicies", () => {
 		const role = { toolPolicies: {} };
-		const tm = mockToolManager({ "mcp__pw__snap": { grantPolicy: "always-ask" } });
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm), "always-ask");
+		const tm = mockToolManager({ "mcp__pw__snap": { grantPolicy: "ask" } });
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm), "ask");
 	});
 
-	it("returns always-allow with empty toolPolicies and no tool grantPolicy", () => {
+	it("returns allow with empty toolPolicies and no tool grantPolicy", () => {
 		const role = { toolPolicies: {} };
 		const tm = mockToolManager({ "mcp__pw__snap": {} });
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm), "always-allow");
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm), "allow");
 	});
 
 	it("priority: role tool > role group > YAML — all three set", () => {
 		const role = {
 			toolPolicies: {
-				"mcp__pw__snap": "never-ask" as const,
-				"mcp__pw": "ask-once" as const,
+				"mcp__pw__snap": "never" as const,
+				"mcp__pw": "ask" as const,
 			},
 		};
-		const tm = mockToolManager({ "mcp__pw__snap": { grantPolicy: "always-ask" } });
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm), "never-ask");
+		const tm = mockToolManager({ "mcp__pw__snap": { grantPolicy: "ask" } });
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm), "never");
 	});
 
-	it("explicit never-ask via role toolPolicies", () => {
-		const role = { toolPolicies: { "mcp__pw__snap": "never-ask" as const } };
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, undefined), "never-ask");
+	it("explicit never via role toolPolicies", () => {
+		const role = { toolPolicies: { "mcp__pw__snap": "never" as const } };
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, undefined), "never");
 	});
 
-	it("returns always-allow when both role and toolManager are undefined", () => {
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", undefined, undefined), "always-allow");
+	it("returns allow when both role and toolManager are undefined", () => {
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", undefined, undefined), "allow");
 	});
 
-	it("undefined toolGroup skips group-level check, falls back to always-allow", () => {
-		const role = { toolPolicies: { "mcp__pw": "ask-once" as const } };
+	it("undefined toolGroup skips group-level check, falls back to allow", () => {
+		const role = { toolPolicies: { "mcp__pw": "ask" as const } };
 		const tm = mockToolManager({});
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", undefined, role, tm), "always-allow");
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", undefined, role, tm), "allow");
 	});
 
 	it("group override wins over tool YAML default", () => {
 		const role = {
-			toolPolicies: { "mcp__pw": "always-ask" as const },
+			toolPolicies: { "mcp__pw": "ask" as const },
 		};
-		const tm = mockToolManager({ "mcp__pw__snap": { grantPolicy: "ask-once" } });
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm), "always-ask");
+		const tm = mockToolManager({ "mcp__pw__snap": { grantPolicy: "ask" } });
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm), "ask");
 	});
 
-	it("tool not found in toolManager returns always-allow (no role policy)", () => {
+	it("tool not found in toolManager returns allow (no role policy)", () => {
 		const role = {};
 		const tm = mockToolManager({});
-		assert.equal(resolveGrantPolicy("mcp__unknown__tool", "mcp__unknown", role, tm), "always-allow");
+		assert.equal(resolveGrantPolicy("mcp__unknown__tool", "mcp__unknown", role, tm), "allow");
 	});
 
 	// ── Layer 4: Group default policy ─────────────────────────────────
@@ -126,28 +126,50 @@ describe("resolveGrantPolicy", () => {
 	it("group default policy wins over system fallback", () => {
 		const role = {};
 		const tm = mockToolManager({ "mcp__pw__snap": {} });
-		const gps = mockGroupPolicyStore({ "mcp__pw": "ask-once" });
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm, gps), "ask-once");
+		const gps = mockGroupPolicyStore({ "mcp__pw": "ask" });
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm, gps), "ask");
 	});
 
 	it("tool YAML default wins over group default", () => {
 		const role = {};
-		const tm = mockToolManager({ "mcp__pw__snap": { grantPolicy: "always-ask" } });
-		const gps = mockGroupPolicyStore({ "mcp__pw": "ask-once" });
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm, gps), "always-ask");
+		const tm = mockToolManager({ "mcp__pw__snap": { grantPolicy: "ask" } });
+		const gps = mockGroupPolicyStore({ "mcp__pw": "ask" });
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm, gps), "ask");
 	});
 
 	it("role group override wins over group default", () => {
-		const role = { toolPolicies: { "mcp__pw": "never-ask" as const } };
+		const role = { toolPolicies: { "mcp__pw": "never" as const } };
 		const tm = mockToolManager({});
-		const gps = mockGroupPolicyStore({ "mcp__pw": "ask-once" });
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm, gps), "never-ask");
+		const gps = mockGroupPolicyStore({ "mcp__pw": "ask" });
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm, gps), "never");
 	});
 
 	it("group default ignored when toolGroup is undefined", () => {
 		const role = {};
 		const tm = mockToolManager({});
-		const gps = mockGroupPolicyStore({ "mcp__pw": "ask-once" });
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", undefined, role, tm, gps), "always-allow");
+		const gps = mockGroupPolicyStore({ "mcp__pw": "ask" });
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", undefined, role, tm, gps), "allow");
+	});
+
+	// ── Legacy value normalization ────────────────────────────────────
+
+	it("normalizes legacy always-allow to allow", () => {
+		const role = { toolPolicies: { "my_tool": "always-allow" as any } };
+		assert.equal(resolveGrantPolicy("my_tool", "Group", role, undefined), "allow");
+	});
+
+	it("normalizes legacy ask-once to ask", () => {
+		const role = { toolPolicies: { "my_tool": "ask-once" as any } };
+		assert.equal(resolveGrantPolicy("my_tool", "Group", role, undefined), "ask");
+	});
+
+	it("normalizes legacy always-ask to ask", () => {
+		const role = { toolPolicies: { "my_tool": "always-ask" as any } };
+		assert.equal(resolveGrantPolicy("my_tool", "Group", role, undefined), "ask");
+	});
+
+	it("normalizes legacy never-ask to never", () => {
+		const role = { toolPolicies: { "my_tool": "never-ask" as any } };
+		assert.equal(resolveGrantPolicy("my_tool", "Group", role, undefined), "never");
 	});
 });

--- a/tests/tool-activation.spec.ts
+++ b/tests/tool-activation.spec.ts
@@ -174,39 +174,27 @@ test.describe("computeToolActivationArgs", () => {
 		expect(extPaths.some(p => p.includes("/team/extension.ts"))).toBe(true);
 	});
 
-	test("detects leaked tools from shared extensions — bash_bg loads bash via shell/extension.ts", () => {
+	test("shared extensions register all their tools — bash_bg includes bash via shell/extension.ts", () => {
 		const tm = mockToolManager(standardProviders());
-		// Allow bash_bg but NOT bash — both share shell/extension.ts
+		// Allow bash_bg — both bash and bash_bg share shell/extension.ts
 		const result = computeToolActivationArgs(["read", "bash_bg"], tm);
 
-		// bash should be detected as a leaked tool
-		expect(result.leakedTools).toBeDefined();
-		expect(result.leakedTools!.some(t => t.name === "bash")).toBe(true);
+		// Guard extension handles access control, no leaked tool detection needed
+		const extPaths = result.args
+			.filter((_a: string, i: number) => i > 0 && result.args[i - 1] === "--extension")
+			.map((p: string) => p.replace(/\\/g, "/"));
+		expect(extPaths.some((p: string) => p.includes("/shell/extension.ts"))).toBe(true);
 	});
 
-	test("detects leaked tools from shared extensions — web_search leaks web_fetch", () => {
+	test("shared extensions register all their tools — web_search includes web_fetch", () => {
 		const tm = mockToolManager(standardProviders());
-		// Allow web_search but NOT web_fetch — both share web/extension.ts
+		// Allow web_search — both share web/extension.ts
 		const result = computeToolActivationArgs(["read", "web_search"], tm);
 
-		expect(result.leakedTools).toBeDefined();
-		expect(result.leakedTools!.some(t => t.name === "web_fetch")).toBe(true);
-	});
-
-	test("no leaked tools when all tools from extension are allowed", () => {
-		const tm = mockToolManager(standardProviders());
-		// Allow both web tools — no leak
-		const result = computeToolActivationArgs(["read", "web_search", "web_fetch"], tm);
-
-		expect(result.leakedTools).toBeUndefined();
-	});
-
-	test("no leaked tools when no extensions are loaded", () => {
-		const tm = mockToolManager(standardProviders());
-		// Only builtins — no extensions loaded, nothing can leak
-		const result = computeToolActivationArgs(["read", "write", "edit"], tm);
-
-		expect(result.leakedTools).toBeUndefined();
+		const extPaths = result.args
+			.filter((_a: string, i: number) => i > 0 && result.args[i - 1] === "--extension")
+			.map((p: string) => p.replace(/\\/g, "/"));
+		expect(extPaths.some((p: string) => p.includes("/web/extension.ts"))).toBe(true);
 	});
 
 	test("bash-only role — bash excluded from --tools, gets --no-tools", () => {

--- a/tests/tool-policy-resolution.test.ts
+++ b/tests/tool-policy-resolution.test.ts
@@ -42,95 +42,95 @@ describe("resolveGrantPolicy — unified 5-layer resolution", () => {
 	it("layer 1: role tool-specific override wins over everything", () => {
 		const role = {
 			toolPolicies: {
-				"mcp__pw__snap": "never-ask" as const,
-				"mcp__pw": "ask-once" as const,
+				"mcp__pw__snap": "never" as const,
+				"mcp__pw": "ask" as const,
 			},
 		};
-		const tm = mockToolManager({ "mcp__pw__snap": { grantPolicy: "always-ask" } });
-		const gps = mockGroupPolicyStore({ "mcp__pw": "always-allow" });
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm, gps), "never-ask");
+		const tm = mockToolManager({ "mcp__pw__snap": { grantPolicy: "ask" } });
+		const gps = mockGroupPolicyStore({ "mcp__pw": "allow" });
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm, gps), "never");
 	});
 
 	it("layer 2: role group override wins over tool default and group default", () => {
-		const role = { toolPolicies: { "mcp__playwright": "always-ask" as const } };
-		const tm = mockToolManager({ "mcp__playwright__snap": { grantPolicy: "ask-once" } });
-		const gps = mockGroupPolicyStore({ "mcp__playwright": "always-allow" });
-		assert.equal(resolveGrantPolicy("mcp__playwright__snap", "mcp__playwright", role, tm, gps), "always-ask");
+		const role = { toolPolicies: { "mcp__playwright": "ask" as const } };
+		const tm = mockToolManager({ "mcp__playwright__snap": { grantPolicy: "ask" } });
+		const gps = mockGroupPolicyStore({ "mcp__playwright": "allow" });
+		assert.equal(resolveGrantPolicy("mcp__playwright__snap", "mcp__playwright", role, tm, gps), "ask");
 	});
 
 	it("layer 3: tool YAML default wins over group default", () => {
 		const role = {};
-		const tm = mockToolManager({ "mcp__pw__snap": { grantPolicy: "ask-once" } });
-		const gps = mockGroupPolicyStore({ "mcp__pw": "always-ask" });
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm, gps), "ask-once");
+		const tm = mockToolManager({ "mcp__pw__snap": { grantPolicy: "ask" } });
+		const gps = mockGroupPolicyStore({ "mcp__pw": "ask" });
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm, gps), "ask");
 	});
 
 	it("layer 4: group default wins over system fallback", () => {
 		const role = {};
 		const tm = mockToolManager({ "mcp__pw__snap": {} });
-		const gps = mockGroupPolicyStore({ "mcp__pw": "always-ask" });
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm, gps), "always-ask");
+		const gps = mockGroupPolicyStore({ "mcp__pw": "ask" });
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm, gps), "ask");
 	});
 
-	it("layer 5: system fallback returns 'always-allow' when no policy configured", () => {
+	it("layer 5: system fallback returns 'allow' when no policy configured", () => {
 		const role = {};
 		const tm = mockToolManager({});
 		const gps = mockGroupPolicyStore({});
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm, gps), "always-allow");
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm, gps), "allow");
 	});
 
 	it("system fallback when no groupPolicyStore provided", () => {
 		const role = {};
 		const tm = mockToolManager({});
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm), "always-allow");
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", role, tm), "allow");
 	});
 
 	it("system fallback with undefined role and toolManager", () => {
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", undefined, undefined), "always-allow");
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", undefined, undefined), "allow");
 	});
 
-	it("'never-ask' policy correctly returned at role tool level", () => {
-		const role = { toolPolicies: { "dangerous_tool": "never-ask" as const } };
-		assert.equal(resolveGrantPolicy("dangerous_tool", "SomeGroup", role, undefined), "never-ask");
+	it("'never' policy correctly returned at role tool level", () => {
+		const role = { toolPolicies: { "dangerous_tool": "never" as const } };
+		assert.equal(resolveGrantPolicy("dangerous_tool", "SomeGroup", role, undefined), "never");
 	});
 
-	it("'never-ask' policy correctly returned at role group level", () => {
-		const role = { toolPolicies: { "mcp__dangerous": "never-ask" as const } };
-		assert.equal(resolveGrantPolicy("mcp__dangerous__tool", "mcp__dangerous", role, undefined), "never-ask");
+	it("'never' policy correctly returned at role group level", () => {
+		const role = { toolPolicies: { "mcp__dangerous": "never" as const } };
+		assert.equal(resolveGrantPolicy("mcp__dangerous__tool", "mcp__dangerous", role, undefined), "never");
 	});
 
-	it("'never-ask' policy correctly returned at tool YAML level", () => {
-		const tm = mockToolManager({ "mcp__pw__snap": { grantPolicy: "never-ask" } });
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", {}, tm), "never-ask");
+	it("'never' policy correctly returned at tool YAML level", () => {
+		const tm = mockToolManager({ "mcp__pw__snap": { grantPolicy: "never" } });
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", "mcp__pw", {}, tm), "never");
 	});
 
-	it("'never-ask' policy correctly returned at group default level", () => {
-		const gps = mockGroupPolicyStore({ "Browser": "never-ask" });
-		assert.equal(resolveGrantPolicy("browser_click", "Browser", {}, mockToolManager({}), gps), "never-ask");
+	it("'never' policy correctly returned at group default level", () => {
+		const gps = mockGroupPolicyStore({ "Browser": "never" });
+		assert.equal(resolveGrantPolicy("browser_click", "Browser", {}, mockToolManager({}), gps), "never");
 	});
 
-	it("'always-allow' at group level matches group name exactly", () => {
-		const gps = mockGroupPolicyStore({ "Browser": "ask-once" });
+	it("'ask' at group level matches group name exactly", () => {
+		const gps = mockGroupPolicyStore({ "Browser": "ask" });
 		// Tool in a different group should not match
-		assert.equal(resolveGrantPolicy("read", "Filesystem", {}, mockToolManager({}), gps), "always-allow");
+		assert.equal(resolveGrantPolicy("read", "Filesystem", {}, mockToolManager({}), gps), "allow");
 	});
 
 	it("undefined toolGroup skips group-level checks", () => {
-		const role = { toolPolicies: { "mcp__pw": "ask-once" as const } };
-		const gps = mockGroupPolicyStore({ "mcp__pw": "always-ask" });
+		const role = { toolPolicies: { "mcp__pw": "ask" as const } };
+		const gps = mockGroupPolicyStore({ "mcp__pw": "ask" });
 		// With undefined toolGroup, neither role group nor group default apply
-		assert.equal(resolveGrantPolicy("mcp__pw__snap", undefined, role, undefined, gps), "always-allow");
+		assert.equal(resolveGrantPolicy("mcp__pw__snap", undefined, role, undefined, gps), "allow");
 	});
 
 	it("empty toolPolicies falls through to tool default", () => {
 		const role = { toolPolicies: {} };
-		const tm = mockToolManager({ "read": { grantPolicy: "always-ask" } });
-		assert.equal(resolveGrantPolicy("read", "Filesystem", role, tm), "always-ask");
+		const tm = mockToolManager({ "read": { grantPolicy: "ask" } });
+		assert.equal(resolveGrantPolicy("read", "Filesystem", role, tm), "ask");
 	});
 
-	it("'always-allow' at any layer is returned correctly", () => {
-		const role = { toolPolicies: { "my_tool": "always-allow" as const } };
-		assert.equal(resolveGrantPolicy("my_tool", "Group", role, undefined), "always-allow");
+	it("'allow' at any layer is returned correctly", () => {
+		const role = { toolPolicies: { "my_tool": "allow" as const } };
+		assert.equal(resolveGrantPolicy("my_tool", "Group", role, undefined), "allow");
 	});
 });
 
@@ -168,8 +168,8 @@ describe("ToolGroupPolicyStore", () => {
 	it("setGroupPolicy creates file and stores policy", () => {
 		const configDir = path.join(tmpDir, "config");
 		const store = new ToolGroupPolicyStore(configDir);
-		store.setGroupPolicy("Browser", "ask-once");
-		assert.equal(store.getGroupPolicy("Browser"), "ask-once");
+		store.setGroupPolicy("Browser", "ask");
+		assert.equal(store.getGroupPolicy("Browser"), "ask");
 	});
 
 	it("getGroupPolicy returns null for unknown group", () => {
@@ -181,8 +181,8 @@ describe("ToolGroupPolicyStore", () => {
 	it("setGroupPolicy with null removes the entry", () => {
 		const configDir = path.join(tmpDir, "config");
 		const store = new ToolGroupPolicyStore(configDir);
-		store.setGroupPolicy("Browser", "ask-once");
-		assert.equal(store.getGroupPolicy("Browser"), "ask-once");
+		store.setGroupPolicy("Browser", "ask");
+		assert.equal(store.getGroupPolicy("Browser"), "ask");
 		store.setGroupPolicy("Browser", null);
 		assert.equal(store.getGroupPolicy("Browser"), null);
 	});
@@ -190,33 +190,33 @@ describe("ToolGroupPolicyStore", () => {
 	it("getAll returns all stored policies", () => {
 		const configDir = path.join(tmpDir, "config");
 		const store = new ToolGroupPolicyStore(configDir);
-		store.setGroupPolicy("Agent", "always-allow");
-		store.setGroupPolicy("mcp__playwright", "always-ask");
+		store.setGroupPolicy("Agent", "allow");
+		store.setGroupPolicy("mcp__playwright", "ask");
 		const all = store.getAll();
-		assert.equal(all["Agent"], "always-allow");
-		assert.equal(all["mcp__playwright"], "always-ask");
+		assert.equal(all["Agent"], "allow");
+		assert.equal(all["mcp__playwright"], "ask");
 	});
 
 	it("persists to disk — new instance reads same data", () => {
 		const configDir = path.join(tmpDir, "config");
 		const store1 = new ToolGroupPolicyStore(configDir);
-		store1.setGroupPolicy("Shell", "never-ask");
+		store1.setGroupPolicy("Shell", "never");
 
 		// Create a new instance — should read from disk
 		const store2 = new ToolGroupPolicyStore(configDir);
-		assert.equal(store2.getGroupPolicy("Shell"), "never-ask");
+		assert.equal(store2.getGroupPolicy("Shell"), "never");
 	});
 
 	it("invalid policy values in YAML are filtered out", () => {
 		// Write invalid data directly to the file
 		const filePath = path.join(tmpDir, "config", "tool-group-policies.yaml");
-		fs.writeFileSync(filePath, "Browser: ask-once\nInvalid: not-a-policy\nAgent: always-allow\n");
+		fs.writeFileSync(filePath, "Browser: ask\nInvalid: not-a-policy\nAgent: allow\n");
 
 		const configDir = path.join(tmpDir, "config");
 		const store = new ToolGroupPolicyStore(configDir);
 		const all = store.getAll();
-		assert.equal(all["Browser"], "ask-once");
-		assert.equal(all["Agent"], "always-allow");
+		assert.equal(all["Browser"], "ask");
+		assert.equal(all["Agent"], "allow");
 		assert.equal(all["Invalid"], undefined);
 	});
 });


### PR DESCRIPTION
Update all unit tests to use the new 3-value grant policy system (allow/ask/never) instead of the old 5-value system (always-allow/ask-once/always-ask/never-ask/never).

**Changes:**
- **tests/grant-policy.test.ts**: Migrate all policy values in inputs and assertions. Add legacy normalization tests.
- **tests/tool-policy-resolution.test.ts**: Same migration for 5-layer resolution tests + ToolGroupPolicyStore CRUD tests.
- **tests/tool-activation.spec.ts**: Remove leaked tool detection tests (leakedTools property no longer exists). Replace with shared extension registration tests.
- **src/server/agent/tool-group-policy-store.ts**: Add new policy values (allow/ask/never) to VALID_POLICIES alongside legacy values.

All 327 unit tests pass. Type check clean.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)