### PR TITLE
Replace commit_sha with head_sha in tool extension + UI dashboard

### DIFF
--- a/.bobbit/config/tools/tasks/extension.ts
+++ b/.bobbit/config/tools/tasks/extension.ts
@@ -115,7 +115,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Update Task",
 		description: [
 			"Update a task's fields, assignment, and/or state in a single call.",
-			"Provide any combination: field updates (title, spec, result_summary, commit_sha),",
+			"Provide any combination: field updates (title, spec, result_summary, head_sha),",
 			"assignment (assigned_to session ID), and/or state transition (state).",
 			"States: todo, in-progress, blocked, complete, skipped.",
 		].join(" "),
@@ -125,7 +125,7 @@ export default function (pi: ExtensionAPI) {
 			title: Type.Optional(Type.String({ description: "New title" })),
 			spec: Type.Optional(Type.String({ description: "New spec" })),
 			result_summary: Type.Optional(Type.String({ description: "Summary of results" })),
-			commit_sha: Type.Optional(Type.String({ description: "Commit SHA" })),
+			head_sha: Type.Optional(Type.String({ description: "HEAD commit SHA of your finished work" })),
 			assigned_to: Type.Optional(Type.String({ description: "Session ID to assign task to" })),
 			state: Type.Optional(Type.String({ description: "Transition to: todo, in-progress, blocked, complete, skipped" })),
 		}),
@@ -136,7 +136,7 @@ export default function (pi: ExtensionAPI) {
 				if (fields.title !== undefined) updateBody.title = fields.title;
 				if (fields.spec !== undefined) updateBody.spec = fields.spec;
 				if (fields.result_summary !== undefined) updateBody.resultSummary = fields.result_summary;
-				if (fields.commit_sha !== undefined) updateBody.commitSha = fields.commit_sha;
+				if (fields.head_sha !== undefined) updateBody.headSha = fields.head_sha;
 				if (Object.keys(updateBody).length > 0) {
 					await api("PUT", `/api/tasks/${task_id}`, updateBody);
 				}

--- a/src/app/goal-dashboard.ts
+++ b/src/app/goal-dashboard.ts
@@ -25,7 +25,9 @@ export interface Task {
 	state: TaskState;
 	assignedSessionId?: string;
 	goalId: string;
-	commitSha?: string;
+	baseSha?: string;
+	headSha?: string;
+	branch?: string;
 	resultSummary?: string;
 	spec?: string;
 	createdAt: number;
@@ -754,11 +756,11 @@ function deriveBadges(commitList: CommitInfo[], taskList: Task[]): Map<string, C
 	const badges = new Map<string, CommitBadges>();
 	for (const c of commitList) badges.set(c.sha, {});
 
-	const testTasks = taskList.filter(t => t.type === "test" && t.commitSha);
-	const reviewTasks = taskList.filter(t => t.type === "review" && t.commitSha);
+	const testTasks = taskList.filter(t => t.type === "test" && t.headSha);
+	const reviewTasks = taskList.filter(t => t.type === "review" && t.headSha);
 
 	for (const task of testTasks) {
-		const sha = task.commitSha!;
+		const sha = task.headSha!;
 		if (!badges.has(sha)) continue;
 		const b = badges.get(sha)!;
 		if (task.state === "complete") b.tests = "pass";
@@ -767,7 +769,7 @@ function deriveBadges(commitList: CommitInfo[], taskList: Task[]): Map<string, C
 	}
 
 	for (const task of reviewTasks) {
-		const sha = task.commitSha!;
+		const sha = task.headSha!;
 		if (!badges.has(sha)) continue;
 		const b = badges.get(sha)!;
 		if (task.state === "complete") b.review = "pass";


### PR DESCRIPTION
Replace `commit_sha` with `head_sha` in the agent-facing tool extension and UI dashboard.

## Changes

### `.bobbit/config/tools/tasks/extension.ts`
- Renamed `commit_sha` parameter to `head_sha` with updated description
- Updated mapping to send `headSha` in the PUT body instead of `commitSha`

### `src/app/goal-dashboard.ts`
- Replaced `commitSha?: string` with `baseSha?: string; headSha?: string; branch?: string;` on Task interface
- Updated `deriveBadges()` to filter/read `headSha` instead of `commitSha`
- Gate signal `commitSha` left unchanged (different concept — goal branch HEAD for verification caching)

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)