### PR TITLE
feat: replace commitSha with baseSha/headSha/branch on tasks

### DIFF
--- a/src/server/agent/task-manager.ts
+++ b/src/server/agent/task-manager.ts
@@ -102,6 +102,10 @@ export class TaskManager {
 			dependsOn?: string[];
 			workflowGateId?: string;
 			inputGateIds?: string[];
+			headSha?: string;
+			baseSha?: string;
+			branch?: string;
+			resultSummary?: string;
 		},
 	): boolean {
 		const task = this.store.get(id);
@@ -299,19 +303,18 @@ export class TaskManager {
  * Mark test/review tasks as stale when a new commit lands on the goal branch.
  * Tasks completed at a different commitSha than the current HEAD are stale.
  */
-export function markStaleTasks(store: TaskStore, goalId: string, currentCommitSha: string): PersistedTask[] {
+export function markStaleTasks(store: TaskStore, goalId: string, currentHeadSha: string): PersistedTask[] {
 	const tasks = store.getByGoalId(goalId);
 	const staleMarked: PersistedTask[] = [];
 	for (const task of tasks) {
 		if (
 			task.state === "complete" &&
 			(task.type === "testing" || task.type === "tdd-tests" || task.type === "code-review" || task.type === "security-review" || task.type === "design-review") &&
-			task.commitSha &&
-			task.commitSha !== currentCommitSha
+			task.headSha &&
+			task.headSha !== currentHeadSha
 		) {
 			// Don't change state to avoid breaking master's state machine,
-			// but set commitSha to empty to indicate staleness
-			// The dashboard can compare task.commitSha vs branch HEAD to show stale badges
+			// but the dashboard can compare task.headSha vs branch HEAD to show stale badges
 			staleMarked.push(task);
 		}
 	}

--- a/src/server/agent/task-store.ts
+++ b/src/server/agent/task-store.ts
@@ -16,7 +16,9 @@ export interface PersistedTask {
 	updatedAt: number;
 	completedAt?: number;
 	dependsOn?: string[];
-	commitSha?: string;
+	baseSha?: string;
+	headSha?: string;
+	branch?: string;
 	resultSummary?: string;
 	/** Workflow gate ID this task should produce (0 or 1). */
 	workflowGateId?: string;
@@ -55,6 +57,11 @@ export class TaskStore {
 								t.inputGateIds = t.inputArtifactIds;
 								delete t.inputArtifactIds;
 							}
+							// Migrate commitSha -> headSha
+							if (t.commitSha && !t.headSha) {
+								t.headSha = t.commitSha;
+							}
+							delete t.commitSha;
 							this.tasks.set(t.id, t);
 						}
 					}

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -66,6 +66,7 @@ export interface TeamAgent {
 	role: string;
 	worktreePath?: string;
 	branch?: string;
+	baseSha?: string;
 	task: string;
 	createdAt: number;
 	/** Unsubscribe from the agent_end event listener (cleanup on dismiss). */
@@ -209,6 +210,7 @@ export class TeamManager {
 				role: a.role,
 				worktreePath: a.worktreePath,
 				branch: a.branch,
+				baseSha: a.baseSha,
 				task: a.task,
 				createdAt: a.createdAt,
 			})),
@@ -254,6 +256,7 @@ export class TeamManager {
 					role: a.role,
 					worktreePath: a.worktreePath,
 					branch: a.branch,
+					baseSha: a.baseSha,
 					task: a.task,
 					createdAt: a.createdAt,
 				})),
@@ -755,12 +758,21 @@ export class TeamManager {
 				teamLeadSessionId: entry.teamLeadSessionId ?? undefined,
 			});
 
+			// Resolve baseSha from the agent's working directory
+			let baseSha: string | undefined;
+			try {
+				const effectiveCwd = actualWorktreePath || session.cwd || agentCwd;
+				const { stdout } = await execFile("git", ["rev-parse", "HEAD"], { cwd: effectiveCwd, timeout: 5_000 });
+				baseSha = stdout.trim() || undefined;
+			} catch { /* non-fatal — baseSha stays undefined */ }
+
 			// Track the agent
 			const agent: TeamAgent = {
 				sessionId: session.id,
 				role,
 				worktreePath: actualWorktreePath,
 				branch: branchName,
+				baseSha,
 				task,
 				createdAt: Date.now(),
 			};
@@ -1031,6 +1043,18 @@ export class TeamManager {
 				createdAt: agent.createdAt,
 			};
 		});
+	}
+
+	/**
+	 * Find a team agent by session ID across all goals.
+	 * Returns the TeamAgent record if found, undefined otherwise.
+	 */
+	findAgentBySessionId(sessionId: string): TeamAgent | undefined {
+		const goalId = this.sessionToGoal.get(sessionId);
+		if (!goalId) return undefined;
+		const entry = this.teams.get(goalId);
+		if (!entry) return undefined;
+		return entry.agents.find(a => a.sessionId === sessionId);
 	}
 
 	/**

--- a/src/server/agent/team-store.ts
+++ b/src/server/agent/team-store.ts
@@ -9,6 +9,7 @@ export interface PersistedTeamEntry {
 		role: string;
 		worktreePath?: string;
 		branch?: string;
+		baseSha?: string;
 		task: string;
 		createdAt: number;
 	}>;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2428,6 +2428,10 @@ async function handleApiRoute(
 					dependsOn: body.dependsOn,
 					workflowGateId: typeof body.workflowGateId === "string" ? body.workflowGateId : undefined,
 					inputGateIds: Array.isArray(body.inputGateIds) ? body.inputGateIds as string[] : undefined,
+					headSha: typeof body.headSha === "string" ? body.headSha : undefined,
+					baseSha: typeof body.baseSha === "string" ? body.baseSha : undefined,
+					branch: typeof body.branch === "string" ? body.branch : undefined,
+					resultSummary: typeof body.resultSummary === "string" ? body.resultSummary : undefined,
 				});
 				if (!ok) { json({ error: "Task not found" }, 404); return; }
 
@@ -2462,8 +2466,26 @@ async function handleApiRoute(
 			return;
 		}
 		try {
-			const ok = getTaskManagerForTask(taskAssignMatch[1]).assignTask(taskAssignMatch[1], sessionId);
+			const taskId = taskAssignMatch[1];
+			const tm = getTaskManagerForTask(taskId);
+			const ok = tm.assignTask(taskId, sessionId);
 			if (!ok) { json({ error: "Task not found" }, 400); return; }
+
+			// Auto-populate baseSha and branch from TeamAgent record
+			const agent = teamManager.findAgentBySessionId(sessionId);
+			if (agent) {
+				const task = tm.getTask(taskId);
+				if (task) {
+					let updated = false;
+					if (agent.baseSha && !task.baseSha) { task.baseSha = agent.baseSha; updated = true; }
+					if (agent.branch && !task.branch) { task.branch = agent.branch; updated = true; }
+					if (updated) {
+						task.updatedAt = Date.now();
+						tm.updateTask(taskId, { baseSha: task.baseSha, branch: task.branch });
+					}
+				}
+			}
+
 			json({ ok: true });
 		} catch (err: any) {
 			json({ error: err.message }, 400);


### PR DESCRIPTION
Core data model and server-side changes for local git handoff.

## Changes

### task-store.ts
- Remove `commitSha` field from `PersistedTask`
- Add `baseSha`, `headSha`, `branch` fields
- Add migration in `load()`: copies `commitSha` → `headSha` for existing persisted data

### task-manager.ts
- Update `markStaleTasks()` to use `headSha` instead of `commitSha`
- Add `headSha`, `baseSha`, `branch`, `resultSummary` to `updateTask()` accepted fields

### team-manager.ts
- Add `baseSha` to `TeamAgent` interface
- Resolve `baseSha` via `git rev-parse HEAD` in agent's worktree during `spawnRole()`
- Persist and restore `baseSha` through team store
- Add `findAgentBySessionId()` public method for looking up agents across all goals

### team-store.ts
- Add `baseSha` to persisted agent record schema

### server.ts
- `PUT /api/tasks/:id`: Pass `headSha`, `baseSha`, `branch`, `resultSummary` to `updateTask()`
- `POST /api/tasks/:id/assign`: Auto-populate `baseSha` and `branch` from `TeamAgent` record after assignment

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)