### PR TITLE
Merge all implementation branches: local git handoff

### DIFF
--- a/.bobbit/config/roles/coder.yaml
+++ b/.bobbit/config/roles/coder.yaml
@@ -58,10 +58,10 @@ promptTemplate: |
     - `task_id` (required): Task ID
     - `state` (optional): `"in-progress"`, `"complete"`, or `"blocked"`
     - `result_summary` (optional): Summary of what was done
-    - `commit_sha` (optional): SHA of the merge commit
+    - `head_sha` (optional): HEAD commit SHA of your finished work
     ```
     # Mark your task complete
-    task_update(task_id="d4169ce6-...", state="complete", result_summary="Implemented OAuth2 PKCE flow, merged to goal branch")
+    task_update(task_id="d4169ce6-...", state="complete", head_sha="abc123f", result_summary="Implemented OAuth2 PKCE flow")
 
     # Mark blocked if stuck
     task_update(task_id="d4169ce6-...", state="blocked", result_summary="Blocked on missing API endpoint")
@@ -78,25 +78,21 @@ promptTemplate: |
   4. **Commit frequently** — at least after each logical unit of work, with descriptive messages.
   5. When done:
      a. Commit all remaining work.
-     b. `git push` to push your branch to origin.
+     b. `git push` to push your branch to origin (safety net for crash recovery).
      c. Verify `git status` shows a clean working copy (no uncommitted changes).
-     d. **Create a pull request** against the goal branch:
-        - Check for `gh` CLI: `which gh`
-        - If available: `gh pr create --base {{GOAL_BRANCH}} --title "<task title>" --body "<brief summary of changes>" --head $(git branch --show-current)`
-        - If not available: note in the task result that a PR needs manual creation.
-        - **Do NOT merge the PR** — the team lead handles that.
-     e. Update your task to `complete` with a `result_summary` that includes the PR URL if created.
-     f. Go idle — the team lead will review and merge your PR.
+     d. Get your HEAD SHA: `git rev-parse HEAD`
+     e. Update your task to `complete` with `head_sha` and `result_summary`:
+        `task_update(task_id="...", state="complete", head_sha="<SHA from step d>", result_summary="...")`
+     f. Go idle — the team lead will merge your branch locally.
 
   ## Definition of Done
   **You are not finished until:**
   1. All changes are committed with descriptive messages
   2. Your branch is pushed (`git push`)
-  3. A pull request is created against `{{GOAL_BRANCH}}` (or noted as needing manual creation)
-  4. `git status` shows a clean working copy (no uncommitted changes)
-  5. Your task is updated to `complete` with a `result_summary` including PR URL
+  3. `git status` shows a clean working copy (no uncommitted changes)
+  4. Your task is updated to `complete` with `head_sha` (the SHA of your last commit) and a `result_summary`
 
-  Only then go idle. The team lead will review and merge your PR.
+  Only then go idle. The team lead will merge your branch locally.
 
   ## What You Do
   - Write clean, well-structured production code.
@@ -110,7 +106,7 @@ promptTemplate: |
 
   ### Verification execution context
   The verification harness runs commands in the **goal's worktree** (the team lead's branch), not yours. The team lead is responsible for merging your branch into the goal branch before signaling verification gates. Your job is to:
-  1. **Push your branch** — the team lead merges it from the remote.
+  1. **Push your branch** — the team lead merges it locally from your worktree branch.
   2. **Ensure dependencies are installed** — `npm ci` (usually already done).
   3. **Build if needed** — E2E tests need `npm run build:server` (compiles to `dist/`).
   4. **Test the command yourself first** — run it in your working directory before going idle.

--- a/.bobbit/config/roles/docs-writer.yaml
+++ b/.bobbit/config/roles/docs-writer.yaml
@@ -98,10 +98,12 @@ promptTemplate: |-
   3. **Commit frequently** — at least after each logical unit of work, with descriptive messages (short, imperative: "Add architecture doc", "Update README setup section").
   4. When done:
      a. Commit all remaining work.
-     b. `git push` to push your branch to origin.
+     b. `git push` to push your branch to origin (safety net for crash recovery).
      c. Verify `git status` shows a clean working copy (no uncommitted changes).
-     d. Update your task to `complete` with a `result_summary`.
-     e. Go idle — the team lead will merge your branch into the goal branch.
+     d. Get your HEAD SHA: `git rev-parse HEAD`
+     e. Update your task to `complete` with `head_sha` and a `result_summary`:
+        `task_update(task_id="...", state="complete", head_sha="<SHA from step d>", result_summary="...")`
+     f. Go idle — the team lead will merge your branch locally.
 
   Primary branch is `master`, not `main`.
 
@@ -110,9 +112,9 @@ promptTemplate: |-
   1. All changes are committed with descriptive messages
   2. Your branch is pushed (`git push`)
   3. `git status` shows a clean working copy (no uncommitted changes)
-  4. Your task is updated to `complete` with a `result_summary`
+  4. Your task is updated to `complete` with `head_sha` (the SHA of your last commit) and a `result_summary`
 
-  Only then go idle. The team lead will merge your branch into the goal branch.
+  Only then go idle. The team lead will merge your branch locally.
 
   ## When idle
 

--- a/.bobbit/config/roles/team-lead.yaml
+++ b/.bobbit/config/roles/team-lead.yaml
@@ -93,7 +93,7 @@ promptTemplate: |
     - `workflowGateId` (optional): workflow gate this task should produce output for
     - `inputGateIds` (optional): workflow gate IDs to inject as context when prompting the agent
   - **task_update** — Update fields, assign to a session, and/or transition state — all in one call.
-    - `task_id` (required), plus any of: `title`, `spec`, `result_summary`, `commit_sha`, `assigned_to`, `state`
+    - `task_id` (required), plus any of: `title`, `spec`, `result_summary`, `head_sha`, `assigned_to`, `state`
 
   ### Gate Management
 
@@ -162,14 +162,20 @@ promptTemplate: |
   5. **Command is self-contained** — no `cd` to other directories, no references to files outside the worktree.
 
   ### Merging member branches — the standard flow
-  Team members work on their own branches and create **pull requests** against `{{GOAL_BRANCH}}`. When you receive an "agent finished" notification:
-  1. Check the agent's task result for the PR URL.
-  2. If `gh` CLI is available, merge the PR: `gh pr merge <PR-URL-or-number> --merge --delete-branch`
-  3. If `gh` is NOT available, merge manually: `git fetch origin && git merge origin/<member-branch> && git push`
-  4. Pull the merged changes into your worktree: `git pull`
-  5. NOW signal any gate that depends on that work.
+  Team members work on their own worktree branches. When you receive an "agent finished" notification:
+  1. Check the agent's completed task for `branch` and `headSha` fields (via `task_list`).
+  2. Merge locally from the agent's branch:
+     ```
+     git merge <task.branch>
+     ```
+     Or for surgical replay of exactly the agent's commits:
+     ```
+     git cherry-pick <task.baseSha>..<task.headSha>
+     ```
+  3. Push the goal branch: `git push`
+  4. NOW signal any gate that depends on that work.
 
-  **Using PRs provides:** visibility into what each agent changed, a review checkpoint before merging, and protection against agents that worked on the wrong branch (the PR diff will immediately reveal issues like 0 files changed).
+  **No remote fetch needed** — agents work in local worktrees, so their branches are available locally. Agents push to origin as a safety net (crash recovery, inspection) but the merge path is purely local.
 
   **Do NOT signal a gate before merging the member's branch.** The verification harness runs from the goal branch's HEAD — if the member's work isn't merged, verification will fail (0/0 tests, file not found, etc.).
 

--- a/.bobbit/config/roles/test-engineer.yaml
+++ b/.bobbit/config/roles/test-engineer.yaml
@@ -82,10 +82,11 @@ promptTemplate: |-
   3. Run the tests.
   4. If tests **pass**:
      a. Commit all work with descriptive messages.
-     b. `git push` to push your branch to origin.
+     b. `git push` to push your branch to origin (safety net for crash recovery).
      c. Verify `git status` shows a clean working copy.
-     d. Update your task: `task_update(task_id="...", state="complete", result_summary="...")`
-     e. Go idle — the team lead will merge your branch into the goal branch.
+     d. Get your HEAD SHA: `git rev-parse HEAD`
+     e. Update your task: `task_update(task_id="...", state="complete", head_sha="<SHA from step d>", result_summary="...")`
+     f. Go idle — the team lead will merge your branch locally.
   5. If tests **fail**:
      a. Do NOT push failing test code.
      b. Update your task with failure details: `task_update(task_id="...", state="blocked", result_summary="...")`
@@ -96,9 +97,9 @@ promptTemplate: |-
   1. All changes are committed with descriptive messages
   2. Your branch is pushed (`git push`)
   3. `git status` shows a clean working copy (no uncommitted changes)
-  4. Your task is updated to `complete` with a `result_summary`
+  4. Your task is updated to `complete` with `head_sha` (the SHA of your last commit) and a `result_summary`
 
-  Only then go idle. The team lead will merge your branch into the goal branch.
+  Only then go idle. The team lead will merge your branch locally.
 
   ## Test Guidelines
   - Follow existing test patterns and frameworks in the repo.
@@ -114,7 +115,7 @@ promptTemplate: |-
 
   ### Verification execution context
   The verification harness runs commands in the **goal's worktree** (the team lead's branch), not yours. The team lead is responsible for merging your branch into the goal branch before signaling verification gates. Your job is to:
-  1. **Push your branch** — the team lead merges it from the remote.
+  1. **Push your branch** — the team lead merges it locally from your worktree branch.
   2. **Ensure dependencies are installed** — `npm ci` (usually already done, but verify).
   3. **Build if needed** — E2E tests need `npm run build:server` first (compiles to `dist/`).
   4. **Test the command yourself first** — run it from your working directory before going idle to catch path or build issues early.

--- a/.bobbit/config/tools/tasks/extension.ts
+++ b/.bobbit/config/tools/tasks/extension.ts
@@ -115,7 +115,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Update Task",
 		description: [
 			"Update a task's fields, assignment, and/or state in a single call.",
-			"Provide any combination: field updates (title, spec, result_summary, commit_sha),",
+			"Provide any combination: field updates (title, spec, result_summary, head_sha),",
 			"assignment (assigned_to session ID), and/or state transition (state).",
 			"States: todo, in-progress, blocked, complete, skipped.",
 		].join(" "),
@@ -125,7 +125,7 @@ export default function (pi: ExtensionAPI) {
 			title: Type.Optional(Type.String({ description: "New title" })),
 			spec: Type.Optional(Type.String({ description: "New spec" })),
 			result_summary: Type.Optional(Type.String({ description: "Summary of results" })),
-			commit_sha: Type.Optional(Type.String({ description: "Commit SHA" })),
+			head_sha: Type.Optional(Type.String({ description: "HEAD commit SHA of your finished work" })),
 			assigned_to: Type.Optional(Type.String({ description: "Session ID to assign task to" })),
 			state: Type.Optional(Type.String({ description: "Transition to: todo, in-progress, blocked, complete, skipped" })),
 		}),
@@ -136,7 +136,7 @@ export default function (pi: ExtensionAPI) {
 				if (fields.title !== undefined) updateBody.title = fields.title;
 				if (fields.spec !== undefined) updateBody.spec = fields.spec;
 				if (fields.result_summary !== undefined) updateBody.resultSummary = fields.result_summary;
-				if (fields.commit_sha !== undefined) updateBody.commitSha = fields.commit_sha;
+				if (fields.head_sha !== undefined) updateBody.headSha = fields.head_sha;
 				if (Object.keys(updateBody).length > 0) {
 					await api("PUT", `/api/tasks/${task_id}`, updateBody);
 				}

--- a/src/app/goal-dashboard.ts
+++ b/src/app/goal-dashboard.ts
@@ -25,7 +25,9 @@ export interface Task {
 	state: TaskState;
 	assignedSessionId?: string;
 	goalId: string;
-	commitSha?: string;
+	baseSha?: string;
+	headSha?: string;
+	branch?: string;
 	resultSummary?: string;
 	spec?: string;
 	createdAt: number;
@@ -754,11 +756,11 @@ function deriveBadges(commitList: CommitInfo[], taskList: Task[]): Map<string, C
 	const badges = new Map<string, CommitBadges>();
 	for (const c of commitList) badges.set(c.sha, {});
 
-	const testTasks = taskList.filter(t => t.type === "test" && t.commitSha);
-	const reviewTasks = taskList.filter(t => t.type === "review" && t.commitSha);
+	const testTasks = taskList.filter(t => t.type === "test" && t.headSha);
+	const reviewTasks = taskList.filter(t => t.type === "review" && t.headSha);
 
 	for (const task of testTasks) {
-		const sha = task.commitSha!;
+		const sha = task.headSha!;
 		if (!badges.has(sha)) continue;
 		const b = badges.get(sha)!;
 		if (task.state === "complete") b.tests = "pass";
@@ -767,7 +769,7 @@ function deriveBadges(commitList: CommitInfo[], taskList: Task[]): Map<string, C
 	}
 
 	for (const task of reviewTasks) {
-		const sha = task.commitSha!;
+		const sha = task.headSha!;
 		if (!badges.has(sha)) continue;
 		const b = badges.get(sha)!;
 		if (task.state === "complete") b.review = "pass";

--- a/src/server/agent/task-manager.ts
+++ b/src/server/agent/task-manager.ts
@@ -102,6 +102,10 @@ export class TaskManager {
 			dependsOn?: string[];
 			workflowGateId?: string;
 			inputGateIds?: string[];
+			headSha?: string;
+			baseSha?: string;
+			branch?: string;
+			resultSummary?: string;
 		},
 	): boolean {
 		const task = this.store.get(id);
@@ -299,19 +303,18 @@ export class TaskManager {
  * Mark test/review tasks as stale when a new commit lands on the goal branch.
  * Tasks completed at a different commitSha than the current HEAD are stale.
  */
-export function markStaleTasks(store: TaskStore, goalId: string, currentCommitSha: string): PersistedTask[] {
+export function markStaleTasks(store: TaskStore, goalId: string, currentHeadSha: string): PersistedTask[] {
 	const tasks = store.getByGoalId(goalId);
 	const staleMarked: PersistedTask[] = [];
 	for (const task of tasks) {
 		if (
 			task.state === "complete" &&
 			(task.type === "testing" || task.type === "tdd-tests" || task.type === "code-review" || task.type === "security-review" || task.type === "design-review") &&
-			task.commitSha &&
-			task.commitSha !== currentCommitSha
+			task.headSha &&
+			task.headSha !== currentHeadSha
 		) {
 			// Don't change state to avoid breaking master's state machine,
-			// but set commitSha to empty to indicate staleness
-			// The dashboard can compare task.commitSha vs branch HEAD to show stale badges
+			// but the dashboard can compare task.headSha vs branch HEAD to show stale badges
 			staleMarked.push(task);
 		}
 	}

--- a/src/server/agent/task-store.ts
+++ b/src/server/agent/task-store.ts
@@ -16,7 +16,9 @@ export interface PersistedTask {
 	updatedAt: number;
 	completedAt?: number;
 	dependsOn?: string[];
-	commitSha?: string;
+	baseSha?: string;
+	headSha?: string;
+	branch?: string;
 	resultSummary?: string;
 	/** Workflow gate ID this task should produce (0 or 1). */
 	workflowGateId?: string;
@@ -55,6 +57,11 @@ export class TaskStore {
 								t.inputGateIds = t.inputArtifactIds;
 								delete t.inputArtifactIds;
 							}
+							// Migrate commitSha -> headSha
+							if (t.commitSha && !t.headSha) {
+								t.headSha = t.commitSha;
+							}
+							delete t.commitSha;
 							this.tasks.set(t.id, t);
 						}
 					}

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -66,6 +66,7 @@ export interface TeamAgent {
 	role: string;
 	worktreePath?: string;
 	branch?: string;
+	baseSha?: string;
 	task: string;
 	createdAt: number;
 	/** Unsubscribe from the agent_end event listener (cleanup on dismiss). */
@@ -209,6 +210,7 @@ export class TeamManager {
 				role: a.role,
 				worktreePath: a.worktreePath,
 				branch: a.branch,
+				baseSha: a.baseSha,
 				task: a.task,
 				createdAt: a.createdAt,
 			})),
@@ -254,6 +256,7 @@ export class TeamManager {
 					role: a.role,
 					worktreePath: a.worktreePath,
 					branch: a.branch,
+					baseSha: a.baseSha,
 					task: a.task,
 					createdAt: a.createdAt,
 				})),
@@ -755,12 +758,21 @@ export class TeamManager {
 				teamLeadSessionId: entry.teamLeadSessionId ?? undefined,
 			});
 
+			// Resolve baseSha from the agent's working directory
+			let baseSha: string | undefined;
+			try {
+				const effectiveCwd = actualWorktreePath || session.cwd || agentCwd;
+				const { stdout } = await execFile("git", ["rev-parse", "HEAD"], { cwd: effectiveCwd, timeout: 5_000 });
+				baseSha = stdout.trim() || undefined;
+			} catch { /* non-fatal — baseSha stays undefined */ }
+
 			// Track the agent
 			const agent: TeamAgent = {
 				sessionId: session.id,
 				role,
 				worktreePath: actualWorktreePath,
 				branch: branchName,
+				baseSha,
 				task,
 				createdAt: Date.now(),
 			};
@@ -1031,6 +1043,18 @@ export class TeamManager {
 				createdAt: agent.createdAt,
 			};
 		});
+	}
+
+	/**
+	 * Find a team agent by session ID across all goals.
+	 * Returns the TeamAgent record if found, undefined otherwise.
+	 */
+	findAgentBySessionId(sessionId: string): TeamAgent | undefined {
+		const goalId = this.sessionToGoal.get(sessionId);
+		if (!goalId) return undefined;
+		const entry = this.teams.get(goalId);
+		if (!entry) return undefined;
+		return entry.agents.find(a => a.sessionId === sessionId);
 	}
 
 	/**

--- a/src/server/agent/team-store.ts
+++ b/src/server/agent/team-store.ts
@@ -9,6 +9,7 @@ export interface PersistedTeamEntry {
 		role: string;
 		worktreePath?: string;
 		branch?: string;
+		baseSha?: string;
 		task: string;
 		createdAt: number;
 	}>;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2428,6 +2428,10 @@ async function handleApiRoute(
 					dependsOn: body.dependsOn,
 					workflowGateId: typeof body.workflowGateId === "string" ? body.workflowGateId : undefined,
 					inputGateIds: Array.isArray(body.inputGateIds) ? body.inputGateIds as string[] : undefined,
+					headSha: typeof body.headSha === "string" ? body.headSha : undefined,
+					baseSha: typeof body.baseSha === "string" ? body.baseSha : undefined,
+					branch: typeof body.branch === "string" ? body.branch : undefined,
+					resultSummary: typeof body.resultSummary === "string" ? body.resultSummary : undefined,
 				});
 				if (!ok) { json({ error: "Task not found" }, 404); return; }
 
@@ -2462,8 +2466,26 @@ async function handleApiRoute(
 			return;
 		}
 		try {
-			const ok = getTaskManagerForTask(taskAssignMatch[1]).assignTask(taskAssignMatch[1], sessionId);
+			const taskId = taskAssignMatch[1];
+			const tm = getTaskManagerForTask(taskId);
+			const ok = tm.assignTask(taskId, sessionId);
 			if (!ok) { json({ error: "Task not found" }, 400); return; }
+
+			// Auto-populate baseSha and branch from TeamAgent record
+			const agent = teamManager.findAgentBySessionId(sessionId);
+			if (agent) {
+				const task = tm.getTask(taskId);
+				if (task) {
+					let updated = false;
+					if (agent.baseSha && !task.baseSha) { task.baseSha = agent.baseSha; updated = true; }
+					if (agent.branch && !task.branch) { task.branch = agent.branch; updated = true; }
+					if (updated) {
+						task.updatedAt = Date.now();
+						tm.updateTask(taskId, { baseSha: task.baseSha, branch: task.branch });
+					}
+				}
+			}
+
 			json({ ok: true });
 		} catch (err: any) {
 			json({ error: err.message }, 400);


### PR DESCRIPTION
Merges three implementation branches for the local git handoff feature:

1. **Core server changes** (task-store, task-manager, team-manager, server.ts) — field rename commitSha→baseSha/headSha/branch, migration, auto-populate on spawn/assign
2. **Tool extension + UI** (extension.ts, goal-dashboard.ts) — commit_sha→head_sha in tool, UI badge updates
3. **Role prompts** (coder, test-engineer, docs-writer, team-lead) — replace PR workflow with local merge + head_sha

All merges were clean (non-overlapping files). Type-check passes. All 329 unit tests pass.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)