### PR TITLE
fix: use computeEffectiveAllowedTools for role session creation

### DIFF
--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -187,7 +187,7 @@ export function resolveTools(plan: SessionSetupPlan, ctx: PipelineContext): void
 	let effectiveAllowedTools = plan.effectiveAllowedTools;
 
 	// Fall back to general role's allowed tools
-	if (!effectiveAllowedTools && ctx.roleManager) {
+	if ((!effectiveAllowedTools || effectiveAllowedTools.length === 0) && ctx.roleManager) {
 		const generalRole = ctx.roleManager.getRole("general");
 		if (generalRole) {
 			if (generalRole.allowedTools.length > 0) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -53,6 +53,7 @@ import { GoalManager } from "./agent/goal-manager.js";
 import type { PersistedGoal } from "./agent/goal-store.js";
 import { migrateToPerProjectState } from "./agent/state-migration.js";
 import { resolveScalarConfig } from "./agent/config-resolver.js";
+import { computeEffectiveAllowedTools } from "./agent/tool-activation.js";
 import { initAssistantRegistry } from "./agent/assistant-registry.js";
 
 const VALID_TASK_STATES = new Set<string>(["todo", "in-progress", "blocked", "complete", "skipped"]);
@@ -1234,7 +1235,7 @@ async function handleApiRoute(
 
 		// If a roleId is provided, look up the role and pass its prompt/tools/accessory
 		const roleId = body?.roleId;
-		let createOpts: { rolePrompt?: string; allowedTools?: string[]; personalities?: Array<{ label: string; promptFragment: string }>; personalityNames?: string[] } | undefined;
+		let createOpts: { rolePrompt?: string; roleName?: string; allowedTools?: string[]; personalities?: Array<{ label: string; promptFragment: string }>; personalityNames?: string[] } | undefined;
 		let roleForMeta: { name: string; accessory: string } | undefined;
 
 		if (roleId && typeof roleId === "string") {
@@ -1243,9 +1244,11 @@ async function handleApiRoute(
 				json({ error: `Role "${roleId}" not found` }, 404);
 				return;
 			}
+			const computedAllowedTools = computeEffectiveAllowedTools(toolManager, role, groupPolicyStore, sessionManager.getMcpManager() ?? undefined);
 			createOpts = {
 				rolePrompt: role.promptTemplate,
-				allowedTools: role.allowedTools,
+				roleName: role.name,
+				allowedTools: computedAllowedTools,
 			};
 			roleForMeta = { name: role.name, accessory: role.accessory };
 		}

--- a/tests/e2e/tool-guard-ask-policy.spec.ts
+++ b/tests/e2e/tool-guard-ask-policy.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Reproducing test for: tool guard not enforced for roles with ask-only toolPolicies.
+ *
+ * Bug: When a role has only `ask` entries in toolPolicies (e.g. { bash_bg: "ask" })
+ * and no `allow` entries, creating a session with that role fails to generate a
+ * tool guard extension. The agent can use guarded tools without user approval.
+ *
+ * This test creates a role with toolPolicies: { bash_bg: "ask" }, creates a session
+ * with that role, and verifies that a tool guard extension was generated in the
+ * state directory. With the bug, no guard file is created.
+ */
+import { test, expect } from "./gateway-harness.js";
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+	apiFetch,
+	bobbitDir,
+	createSession,
+	deleteSession,
+	nonGitCwd,
+	waitForSessionStatus,
+} from "./e2e-setup.js";
+
+test.setTimeout(30_000);
+
+const ROLE_NAME = "ask-only-guard-test";
+
+test.beforeAll(async () => {
+	// Create a role with empty allowedTools
+	const createResp = await apiFetch("/api/roles", {
+		method: "POST",
+		body: JSON.stringify({
+			name: ROLE_NAME,
+			label: "Ask-Only Guard Test",
+			promptTemplate: "You are a test agent.",
+			allowedTools: [],
+		}),
+	});
+	expect(createResp.status).toBe(201);
+
+	// Update the role with toolPolicies: { bash_bg: "ask" }
+	const updateResp = await apiFetch(`/api/roles/${ROLE_NAME}`, {
+		method: "PUT",
+		body: JSON.stringify({
+			toolPolicies: { bash_bg: "ask" },
+		}),
+	});
+	expect(updateResp.status).toBe(200);
+
+	// Verify the role has the expected state
+	const getResp = await apiFetch(`/api/roles/${ROLE_NAME}`);
+	expect(getResp.status).toBe(200);
+	const role = await getResp.json();
+	expect(role.toolPolicies).toEqual({ bash_bg: "ask" });
+	// allowedTools should be empty since there are no "allow" policies
+	expect(role.allowedTools).toEqual([]);
+});
+
+test.afterAll(async () => {
+	await apiFetch(`/api/roles/${ROLE_NAME}`, { method: "DELETE" }).catch(() => {});
+});
+
+test.describe("Tool guard with ask-only role", () => {
+	let sessionId: string;
+	test.afterEach(async () => {
+		if (sessionId) { await deleteSession(sessionId); sessionId = ""; }
+	});
+
+	test("session with ask-only toolPolicies role should have tool guard extension", async () => {
+		// Create a session with the ask-only role
+		const resp = await apiFetch("/api/sessions", {
+			method: "POST",
+			body: JSON.stringify({
+				cwd: nonGitCwd(),
+				roleId: ROLE_NAME,
+			}),
+		});
+		expect(resp.status).toBe(201);
+		sessionId = (await resp.json()).id;
+
+		// Wait for the session to be ready
+		await waitForSessionStatus(sessionId, "idle");
+
+		// Check the tool-guard state directory for guard extension files
+		// When the bug is fixed, a guard extension should be written here
+		// that includes bash_bg as a guarded tool.
+		const guardDir = join(bobbitDir(), "state", "tool-guard");
+
+		// The guard directory must exist (created by writeToolGuardExtension)
+		expect(
+			existsSync(guardDir),
+			"Expected tool-guard directory to exist — no guard extension was generated for ask-only role",
+		).toBe(true);
+
+		// Find guard.ts files and check if any mention bash_bg
+		const subdirs = readdirSync(guardDir);
+		let foundBashBgGuard = false;
+
+		for (const sub of subdirs) {
+			const guardFile = join(guardDir, sub, "guard.ts");
+			if (existsSync(guardFile)) {
+				const content = readFileSync(guardFile, "utf-8");
+				if (content.includes("bash_bg")) {
+					foundBashBgGuard = true;
+					break;
+				}
+			}
+		}
+
+		expect(
+			foundBashBgGuard,
+			"Expected a tool guard extension for bash_bg to be generated when role has toolPolicies: { bash_bg: 'ask' }",
+		).toBe(true);
+	});
+});


### PR DESCRIPTION
Fixes tool guard not being enforced for roles with ask-only toolPolicies.

## Changes

### src/server/server.ts
- Import `computeEffectiveAllowedTools` from tool-activation
- Replace `role.allowedTools` with `computeEffectiveAllowedTools()` when building createOpts from a role — this includes both `allow` and `ask` tools
- Pass `roleName` in createOpts for downstream use

### src/server/agent/session-setup.ts
- Defense-in-depth: treat empty `effectiveAllowedTools` array same as undefined in `resolveTools()`, so the general-role fallback triggers

### tests/e2e/tool-guard-ask-policy.spec.ts
- E2E test: creates a role with `toolPolicies: { bash_bg: "ask" }`, creates a session, verifies a tool guard extension is generated containing bash_bg

All type-checks and tests pass.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)