### PR TITLE
Fix context bar on restart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,7 @@ Quick pointers for the most common issues:
 
 - **Streaming sluggishness**: `AgentInterface` must NOT call `requestUpdate()` in the `message_update` handler — only `StreamingMessageContainer.setMessage()` updates during streaming (rAF-batched). See @docs/debugging.md#streaming-performance for full checklist.
 - **Duplicate messages**: Check `flushDeferredMessage()` in `remote-agent.ts` — `MessageList` and `StreamingMessageContainer` must never overlap.
+- **Context bar / model state**: After restart, `sendFallbackModelState()` in `handler.ts` sends persisted model info when `getState()` fails. If context bar shows wrong values, verify `modelProvider`/`modelId` in `<project-root>/.bobbit/state/sessions.json`. Client retries `get_state` after 3s on reconnect. See @docs/debugging.md#context-bar--model-state for full checklist.
 - **Session persistence**: Check `<project-root>/.bobbit/state/sessions.json` (per-project). Missing `.jsonl` = session skipped on restore.
 - **Sandbox**: `GET /api/sandbox-status` for Docker state. Containers use `bobbit-sandbox-net` bridge network — check `docker network inspect bobbit-sandbox-net` for connectivity issues.
 - **Search**: Each project has its own `<project-root>/.bobbit/state/search.db`. Delete and restart to rebuild. Searches aggregate across all project indexes. See @docs/debugging.md#search-index for full checklist.

--- a/docs/agent-debug-cycle.md
+++ b/docs/agent-debug-cycle.md
@@ -1,122 +1,125 @@
 # Agent-in-the-Loop Debug Cycle
 
-How to debug UI features that automated tests miss, using an agent driving a browser against an isolated test gateway.
+How to debug and validate UI features using an agent driving a real browser against an isolated gateway — without touching the production dev server.
 
-## Context: The Permission Card Bug
+## Why This Exists
 
-The tool permission card (shown when a guard blocks a tool call) had two bugs:
-1. `AgentInterface` didn't handle the `"render"` event emitted by `RemoteAgent`, so Lit never re-rendered with the card
-2. The card was only broadcast via WebSocket at block time — reconnecting clients never saw it
+Automated E2E tests use mock agents and synthetic REST calls to simulate user flows. This misses bugs that only manifest through the **real code path**: real agent → real tool call → real guard extension → real WebSocket broadcast → real UI render.
 
-The existing E2E test (`tool-ask-policy.spec.ts`) didn't catch this because it **called the REST endpoint directly** to simulate the guard, bypassing the real flow where the agent's guard extension POSTs to the gateway, the gateway broadcasts via WS, and the client renders the card.
+Example: the tool permission card had two bugs that the existing E2E test missed because the test called the REST endpoint directly instead of letting the real agent trigger the guard extension.
 
-## The Debug Session (What Worked)
+## The Protocol
 
-An agent drove the production dev server's browser UI:
+### 1. Spin up an isolated gateway
 
-1. **Created a UX Designer session** (the only role with `bash_bg: ask` policy)
-2. **Sent a message** asking the agent to use `bash_bg`
-3. **Observed the tool spinner stuck** — guard was blocking but no card appeared
-4. **Added diagnostic console.log** to both server (`requestToolGrant`) and client (`handleServerMessage`)
-5. **Checked browser state** via `browser_eval`:
-   - `state.messages` had 2 items (user + `tool_permission_needed`) — server broadcast worked
-   - `message-list.messages` had 1 item (user only) — Lit wasn't re-rendering
-6. **Found root cause**: `AgentInterface.subscribe()` didn't handle `type: "render"` events
-7. **Fixed both bugs**, rebuilt, created a new session, confirmed the card appeared
-8. **Tested persistence** by navigating away and back — card reappeared
-
-Total diagnostic artifacts: browser screenshots at each step, JS console state dumps, server log traces.
-
-## What Went Wrong: Isolation
-
-The agent ran the debug cycle against the **production dev server**, which:
-- Meant the user couldn't use their own server during testing
-- Risked corrupting production state
-- Failed when the agent tried to spin up an "isolated" gateway inside the same repo directory, which shared git state and file watchers with the dev harness, taking down the production server
-
-## How to Do It Properly
-
-### Isolated Gateway Setup
-
-The key requirement: **nothing shared with the source repo at runtime**.
+Everything in a temp dir **completely outside the repo**:
 
 ```bash
-# 1. Create temp directory completely outside the repo
 WORK_DIR=$(mktemp -d)
-BOBBIT_DIR="$WORK_DIR/.bobbit"
-mkdir -p "$BOBBIT_DIR/state" "$BOBBIT_DIR/config/roles"
-echo "test" > "$BOBBIT_DIR/state/setup-complete"
+mkdir -p "$WORK_DIR/.bobbit/state"
+echo "test" > "$WORK_DIR/.bobbit/state/setup-complete"
 
-# 2. Reference built artifacts from the repo (read-only)
 REPO="/path/to/bobbit"
-SERVER_CLI="$REPO/dist/server/cli.js"
-MOCK_AGENT="$REPO/tests/e2e/mock-agent.mjs"
+FREE_PORT=$(node -e "const s=require('net').createServer();s.listen(0,'127.0.0.1',()=>{console.log(s.address().port);s.close()})")
 
-# 3. Create test-specific config
-cat > "$BOBBIT_DIR/config/roles/test-role.yaml" << EOF
-name: test-role
-label: Test Role
-toolPolicies:
-  bash_bg: ask
-EOF
-
-# 4. Start gateway with full isolation
-BOBBIT_DIR="$BOBBIT_DIR" \
+BOBBIT_DIR="$WORK_DIR/.bobbit" \
 BOBBIT_NO_OPEN=1 \
-  node "$SERVER_CLI" \
+BOBBIT_LLM_REVIEW_SKIP=1 \
+BOBBIT_SKIP_NPM_CI=1 \
+  node "$REPO/dist/server/cli.js" \
     --host 127.0.0.1 \
-    --port 0 \
+    --port "$FREE_PORT" \
     --no-tls \
     --auth \
-    --agent-cli "$MOCK_AGENT" \
-    --cwd "$WORK_DIR"
+    --cwd "$WORK_DIR" &
+```
 
-# 5. Clean up after
+**Use the real agent, not the mock.** The mock bypasses the extension system — tool_call guards, MCP proxies, etc. never fire. If you're spending the cost of browser automation and agent reasoning, don't undermine it by skipping the component most likely to have the bug.
+
+The mock agent is for repeatable unit-style E2E tests where you need determinism and speed. This debug cycle is for validating that the **real system works as a user would experience it**.
+
+### 2. Wait for health, read the token
+
+```bash
+# Poll until healthy
+TOKEN=$(cat "$WORK_DIR/.bobbit/state/token")
+curl -s "http://127.0.0.1:$FREE_PORT/api/health" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Note: the token may regenerate if the server restarts. Always re-read from the state file.
+
+### 3. Connect the browser
+
+```bash
+# Navigate with token in URL
+http://127.0.0.1:$FREE_PORT/?token=$TOKEN
+```
+
+If the UI shows "Not connected" despite the token, set localStorage directly:
+```js
+localStorage.setItem('gateway.url', 'http://127.0.0.1:PORT');
+localStorage.setItem('gateway.token', 'TOKEN');
+location.reload();
+```
+
+### 4. Drive the test scenario
+
+Use browser tools to interact as a real user:
+- Create sessions via the role picker
+- Send messages via the textarea
+- Take screenshots at each step
+- Use `browser_eval` to inspect DOM state, console logs, WebSocket messages
+- Test persistence by navigating away and back
+
+### 5. Verify production is unaffected
+
+```bash
+# Production gateway should still respond
+curl -sk "$PROD_GATEWAY/api/health" -H "Authorization: Bearer $PROD_TOKEN"
+```
+
+### 6. Clean up
+
+```bash
+kill $GW_PID
 rm -rf "$WORK_DIR"
 ```
 
-Critical isolation rules:
-- `--cwd` points to the temp dir, NOT the repo
-- `BOBBIT_DIR` points to temp dir's `.bobbit/`, NOT the repo's
-- The repo is only referenced for `dist/` and `tests/` (read-only)
-- No git operations in the temp dir (or init a fresh repo if needed)
+## Isolation Rules
 
-### Browser-Driven Verification
+| Rule | Why |
+|------|-----|
+| `--cwd` points to temp dir, not repo | Prevents file watcher interference |
+| `BOBBIT_DIR` points to temp's `.bobbit/` | Prevents state file corruption |
+| Repo referenced read-only for `dist/` only | No writes to source tree |
+| Separate port via `--port 0` or free port | No conflict with dev server |
+| No `--agent-cli mock` | Real agent exercises the real code path |
 
-Once the gateway is running, the agent uses browser tools to:
+## What This Caught That Tests Missed
 
-1. Navigate to `http://127.0.0.1:<port>/?token=<token>`
-2. Create a session with the test role
-3. Send a message that triggers the guarded tool
-4. Take screenshots at each step (saved to the temp dir)
-5. Use `browser_eval` to inspect DOM state and JS console
-6. Test persistence by navigating away and back
-7. Generate an HTML report with embedded screenshots
+The permission card bug had two components:
 
-### Incorporating into Goal Workflows
+1. **Missing event handler**: `AgentInterface` didn't handle the `"render"` event emitted by `RemoteAgent` after adding the permission card to messages. Lit never re-rendered.
 
-A **QA agent role** could automate this as a workflow gate:
+2. **No persistence for new clients**: `tool_permission_needed` was only broadcast at the moment the guard blocked. Reconnecting clients never saw it.
 
-1. Team lead spawns a `qa-engineer` agent after implementation
-2. QA agent checks out the goal branch
-3. Builds the server (`npm run build`)
-4. Spins up an isolated gateway in a temp dir (as above)
-5. Drives the browser through test scenarios with screenshots
-6. Produces an HTML report with pass/fail evidence
-7. Signals the `qa-validation` gate with the report
-8. Tears down the ephemeral environment
+The existing E2E test (`tool-ask-policy.spec.ts`) uses the mock agent and calls the `tool-grant-request` REST endpoint directly — this bypasses the guard extension entirely and happened to work because of timing. The real flow (agent → guard → gateway → WS broadcast → UI render) was never tested.
 
-This requires:
-- A `qa-engineer` role with browser tools and a prompt describing the test protocol
-- A skill or recipe for "spin up isolated gateway + test + report"
-- A workflow gate (`qa-validation`) that the QA agent signals
-- The team lead's prompt to know when/how to spawn the QA agent
+## Toward a QA Agent Role
 
-### Existing Infrastructure to Build On
+This protocol can be automated as a **qa-engineer** role in goal workflows:
 
-- `tests/e2e/gateway-harness.ts` — already spawns isolated gateways per Playwright worker
-- `tests/e2e/mock-agent.mjs` — deterministic mock agent (no API key needed)
-- `tests/e2e/e2e-setup.ts` — REST/WS helpers for the isolated gateway
-- `tests/e2e/ui/ui-helpers.ts` — page-object helpers for browser interaction
+1. Team lead spawns `qa-engineer` after implementation gate passes
+2. QA agent builds the server from the goal branch
+3. Spins up an isolated gateway in a temp dir
+4. Drives the browser through test scenarios with screenshots
+5. Produces an HTML report with pass/fail evidence
+6. Signals the `qa-validation` gate with the report
+7. Tears down the ephemeral environment
 
-The gap is making these available to an agent session (not just Playwright test files) and adding report generation.
+Prerequisites:
+- `qa-engineer` role with browser tools and the protocol above in its prompt
+- A skill for "ephemeral gateway lifecycle" (start, health-check, teardown)
+- HTML report generation template
+- A `qa-validation` workflow gate

--- a/docs/agent-debug-cycle.md
+++ b/docs/agent-debug-cycle.md
@@ -1,0 +1,122 @@
+# Agent-in-the-Loop Debug Cycle
+
+How to debug UI features that automated tests miss, using an agent driving a browser against an isolated test gateway.
+
+## Context: The Permission Card Bug
+
+The tool permission card (shown when a guard blocks a tool call) had two bugs:
+1. `AgentInterface` didn't handle the `"render"` event emitted by `RemoteAgent`, so Lit never re-rendered with the card
+2. The card was only broadcast via WebSocket at block time — reconnecting clients never saw it
+
+The existing E2E test (`tool-ask-policy.spec.ts`) didn't catch this because it **called the REST endpoint directly** to simulate the guard, bypassing the real flow where the agent's guard extension POSTs to the gateway, the gateway broadcasts via WS, and the client renders the card.
+
+## The Debug Session (What Worked)
+
+An agent drove the production dev server's browser UI:
+
+1. **Created a UX Designer session** (the only role with `bash_bg: ask` policy)
+2. **Sent a message** asking the agent to use `bash_bg`
+3. **Observed the tool spinner stuck** — guard was blocking but no card appeared
+4. **Added diagnostic console.log** to both server (`requestToolGrant`) and client (`handleServerMessage`)
+5. **Checked browser state** via `browser_eval`:
+   - `state.messages` had 2 items (user + `tool_permission_needed`) — server broadcast worked
+   - `message-list.messages` had 1 item (user only) — Lit wasn't re-rendering
+6. **Found root cause**: `AgentInterface.subscribe()` didn't handle `type: "render"` events
+7. **Fixed both bugs**, rebuilt, created a new session, confirmed the card appeared
+8. **Tested persistence** by navigating away and back — card reappeared
+
+Total diagnostic artifacts: browser screenshots at each step, JS console state dumps, server log traces.
+
+## What Went Wrong: Isolation
+
+The agent ran the debug cycle against the **production dev server**, which:
+- Meant the user couldn't use their own server during testing
+- Risked corrupting production state
+- Failed when the agent tried to spin up an "isolated" gateway inside the same repo directory, which shared git state and file watchers with the dev harness, taking down the production server
+
+## How to Do It Properly
+
+### Isolated Gateway Setup
+
+The key requirement: **nothing shared with the source repo at runtime**.
+
+```bash
+# 1. Create temp directory completely outside the repo
+WORK_DIR=$(mktemp -d)
+BOBBIT_DIR="$WORK_DIR/.bobbit"
+mkdir -p "$BOBBIT_DIR/state" "$BOBBIT_DIR/config/roles"
+echo "test" > "$BOBBIT_DIR/state/setup-complete"
+
+# 2. Reference built artifacts from the repo (read-only)
+REPO="/path/to/bobbit"
+SERVER_CLI="$REPO/dist/server/cli.js"
+MOCK_AGENT="$REPO/tests/e2e/mock-agent.mjs"
+
+# 3. Create test-specific config
+cat > "$BOBBIT_DIR/config/roles/test-role.yaml" << EOF
+name: test-role
+label: Test Role
+toolPolicies:
+  bash_bg: ask
+EOF
+
+# 4. Start gateway with full isolation
+BOBBIT_DIR="$BOBBIT_DIR" \
+BOBBIT_NO_OPEN=1 \
+  node "$SERVER_CLI" \
+    --host 127.0.0.1 \
+    --port 0 \
+    --no-tls \
+    --auth \
+    --agent-cli "$MOCK_AGENT" \
+    --cwd "$WORK_DIR"
+
+# 5. Clean up after
+rm -rf "$WORK_DIR"
+```
+
+Critical isolation rules:
+- `--cwd` points to the temp dir, NOT the repo
+- `BOBBIT_DIR` points to temp dir's `.bobbit/`, NOT the repo's
+- The repo is only referenced for `dist/` and `tests/` (read-only)
+- No git operations in the temp dir (or init a fresh repo if needed)
+
+### Browser-Driven Verification
+
+Once the gateway is running, the agent uses browser tools to:
+
+1. Navigate to `http://127.0.0.1:<port>/?token=<token>`
+2. Create a session with the test role
+3. Send a message that triggers the guarded tool
+4. Take screenshots at each step (saved to the temp dir)
+5. Use `browser_eval` to inspect DOM state and JS console
+6. Test persistence by navigating away and back
+7. Generate an HTML report with embedded screenshots
+
+### Incorporating into Goal Workflows
+
+A **QA agent role** could automate this as a workflow gate:
+
+1. Team lead spawns a `qa-engineer` agent after implementation
+2. QA agent checks out the goal branch
+3. Builds the server (`npm run build`)
+4. Spins up an isolated gateway in a temp dir (as above)
+5. Drives the browser through test scenarios with screenshots
+6. Produces an HTML report with pass/fail evidence
+7. Signals the `qa-validation` gate with the report
+8. Tears down the ephemeral environment
+
+This requires:
+- A `qa-engineer` role with browser tools and a prompt describing the test protocol
+- A skill or recipe for "spin up isolated gateway + test + report"
+- A workflow gate (`qa-validation`) that the QA agent signals
+- The team lead's prompt to know when/how to spawn the QA agent
+
+### Existing Infrastructure to Build On
+
+- `tests/e2e/gateway-harness.ts` — already spawns isolated gateways per Playwright worker
+- `tests/e2e/mock-agent.mjs` — deterministic mock agent (no API key needed)
+- `tests/e2e/e2e-setup.ts` — REST/WS helpers for the isolated gateway
+- `tests/e2e/ui/ui-helpers.ts` — page-object helpers for browser interaction
+
+The gap is making these available to an agent session (not just Playwright test files) and adding report generation.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -40,6 +40,16 @@ Scannable checklists for common issues. Each entry: symptom â†’ where to look â†
 - `state.gateStatusCache` refreshed via: (1) `refreshGateStatusCache()` on initial load, (2) `refreshGateStatusForGoal()` on WS events `gate_status_changed` / `gate_verification_complete`
 - Dashboard gate polling also syncs to this cache
 
+## Context bar / model state
+
+After a server restart, the context bar may show wrong info (e.g. 200k instead of 1M) or nothing at all. This happens because the agent process's `getState()` RPC may fail or return incomplete data before the process is fully ready.
+
+- **Server-side fallback**: `sendFallbackModelState()` in `handler.ts` reads persisted `modelProvider`/`modelId` from the session store and calls `inferMeta()` to attach the correct `contextWindow`. This runs when `getState()` fails, is skipped (dormant/preparing sessions), or returns data without model metadata.
+- **Client-side retry**: `remote-agent.ts` retries `get_state` after 3s on reconnect if `contextWindow` is still 0.
+- **Default contextWindow is 0**: Before the server provides real data, `contextWindow` starts at 0 (not 200k), so the context bar shows nothing rather than a misleading value.
+- If context bar still shows wrong info after restart, check that `modelProvider` and `modelId` are persisted in `<project-root>/.bobbit/state/sessions.json` for the affected session.
+- `SessionManager.getPersistedSession(id)` exposes persisted session data used by the fallback mechanism.
+
 ## Session persistence
 
 - Check `<project-root>/.bobbit/state/sessions.json` (per-project, not centralized)

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -71,6 +71,7 @@ export class RemoteAgent {
 	private _taskStartTime: number | null = null;
 
 	// Auto-reconnect state
+	private _stateRetryTimer: ReturnType<typeof setTimeout> | null = null;
 	private _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 	private _reconnectAttempt = 0;
 	private _intentionalDisconnect = false;
@@ -122,7 +123,7 @@ export class RemoteAgent {
 	constructor() {
 		this._state = {
 			systemPrompt: "",
-			model: getModel("anthropic", "claude-opus-4-6"),
+			model: { ...getModel("anthropic", "claude-opus-4-6"), contextWindow: 0 },
 			thinkingLevel: "medium",
 			tools: [],
 			messages: [] as any[],
@@ -256,6 +257,14 @@ export class RemoteAgent {
 							this._pendingReconnectNotif = true;
 							this.requestMessages();
 							this.send({ type: "get_state" });
+							// Retry get_state after 3s if we still don't have real model info
+							if (this._stateRetryTimer) clearTimeout(this._stateRetryTimer);
+							this._stateRetryTimer = setTimeout(() => {
+								this._stateRetryTimer = null;
+								if (!this._state.model?.contextWindow || this._state.model.contextWindow === 0) {
+									this.send({ type: "get_state" });
+								}
+							}, 3000);
 						}
 					} else if (msg.type === "auth_failed") {
 						settled = true;
@@ -331,6 +340,10 @@ export class RemoteAgent {
 
 	disconnect(): void {
 		this._intentionalDisconnect = true;
+		if (this._stateRetryTimer) {
+			clearTimeout(this._stateRetryTimer);
+			this._stateRetryTimer = null;
+		}
 		if (this._reconnectTimer) {
 			clearTimeout(this._reconnectTimer);
 			this._reconnectTimer = null;
@@ -610,6 +623,11 @@ export class RemoteAgent {
 				// Always update model from server state (keeps context window accurate after compaction)
 				if (msg.data?.model) {
 					this._state.model = msg.data.model;
+					// Clear retry timer — we got real model info
+					if (this._stateRetryTimer) {
+						clearTimeout(this._stateRetryTimer);
+						this._stateRetryTimer = null;
+					}
 				}
 				if (msg.data?.thinkingLevel) {
 					this._state.thinkingLevel = msg.data.thinkingLevel;

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -2788,6 +2788,11 @@ export class SessionManager {
 		return true;
 	}
 
+	/** Get persisted session metadata by ID (live or dormant). */
+	getPersistedSession(id: string): PersistedSession | undefined {
+		return this.resolveStoreForId(id).get(id);
+	}
+
 	/** Get an archived session's metadata. */
 	getArchivedSession(id: string): PersistedSession | undefined {
 		const ps = this.resolveStoreForId(id).get(id);

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -10,7 +10,27 @@ import type { ClientMessage, ServerMessage } from "./protocol.js";
 import type { TaskState } from "../agent/task-store.js";
 import { TaskManager } from "../agent/task-manager.js";
 import { getSlashSkill, buildSlashSkillPrompt } from "../skills/slash-skills.js";
+import { inferMeta } from "../agent/aigw-manager.js";
 // patchModelContextWindow removed — model-registry returns correct context windows via inferMeta()
+
+/** Send persisted model info as fallback when getState() is unavailable. */
+function sendFallbackModelState(ws: WebSocket, sessionManager: SessionManager, sessionId: string): void {
+	const persisted = sessionManager.getPersistedSession(sessionId);
+	if (persisted?.modelProvider && persisted?.modelId) {
+		const meta = inferMeta(persisted.modelId);
+		send(ws, {
+			type: "state",
+			data: {
+				model: {
+					provider: persisted.modelProvider,
+					id: persisted.modelId,
+					contextWindow: meta.contextWindow,
+					maxTokens: meta.maxTokens,
+				}
+			}
+		});
+	}
+}
 
 function broadcast(clients: Set<WebSocket>, msg: ServerMessage): void {
 	const data = JSON.stringify(msg);
@@ -137,10 +157,20 @@ export function handleWebSocketConnection(
 				session.rpcClient.getState().then((stateResponse) => {
 					if (stateResponse.success) {
 						send(ws, { type: "state", data: stateResponse.data });
+						// If agent state lacks model info, supplement with persisted data
+						const data = stateResponse.data as Record<string, unknown> | undefined;
+						if (!data?.model) {
+							sendFallbackModelState(ws, sessionManager, sessionId);
+						}
+					} else {
+						sendFallbackModelState(ws, sessionManager, sessionId);
 					}
 				}).catch(() => {
-					// State not available yet — client will get events as they come
+					sendFallbackModelState(ws, sessionManager, sessionId);
 				});
+			} else {
+				// Session preparing or dormant — send persisted model info immediately
+				sendFallbackModelState(ws, sessionManager, sessionId);
 			}
 
 			// Notify other clients that a new device connected
@@ -320,9 +350,20 @@ export function handleWebSocketConnection(
 					});
 					break;
 				case "get_state": {
-					const stateResp = await session.rpcClient.getState();
-					if (stateResp.success) {
-						send(ws, { type: "state", data: stateResp.data });
+					try {
+						const stateResp = await session.rpcClient.getState();
+						if (stateResp.success) {
+							send(ws, { type: "state", data: stateResp.data });
+							// If agent state lacks model info, supplement with persisted data
+							const data = stateResp.data as Record<string, unknown> | undefined;
+							if (!data?.model) {
+								sendFallbackModelState(ws, sessionManager, sessionId);
+							}
+						} else {
+							sendFallbackModelState(ws, sessionManager, sessionId);
+						}
+					} catch {
+						sendFallbackModelState(ws, sessionManager, sessionId);
 					}
 					break;
 				}

--- a/tests/e2e/context-bar-reconnect.spec.ts
+++ b/tests/e2e/context-bar-reconnect.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * Reproducing test: context bar shows wrong info after reconnect.
+ *
+ * After a WebSocket disconnect/reconnect (simulating server restart),
+ * the server should send a `state` message with the correct model info
+ * including contextWindow. Currently it does not — the proactive getState()
+ * returns agent state without model metadata, and no fallback using
+ * persisted session data is sent.
+ */
+import { test, expect } from "./gateway-harness.js";
+import {
+	createSession,
+	connectWs,
+	agentEndPredicate,
+	type WsMsg,
+} from "./e2e-setup.js";
+
+test.describe("context bar after reconnect", () => {
+	let sessionId: string;
+
+	test.beforeEach(async () => {
+		sessionId = await createSession();
+	});
+
+	test("reconnect sends state with correct contextWindow for persisted model", async () => {
+		// 1. Connect and set model to claude-sonnet (1M context window)
+		const ws1 = await connectWs(sessionId);
+		ws1.send({ type: "set_model", provider: "anthropic", modelId: "claude-sonnet-4-20250514" });
+
+		// 2. Send a prompt so eventBuffer has content (ensures proactive getState fires on reconnect)
+		ws1.send({ type: "prompt", text: "hello" });
+		await ws1.waitFor(agentEndPredicate(), 10_000);
+
+		// Brief pause to let model persist to disk
+		await new Promise(r => setTimeout(r, 500));
+
+		// 3. Disconnect
+		ws1.close();
+		await new Promise(r => setTimeout(r, 300));
+
+		// 4. Reconnect with a new WebSocket
+		const ws2 = await connectWs(sessionId);
+
+		// 5. Also send an explicit get_state (like the client does on reconnect)
+		ws2.send({ type: "get_state" });
+
+		// 6. Collect messages for a few seconds
+		await new Promise(r => setTimeout(r, 3000));
+
+		// 7. Find all state messages received after auth
+		const stateMessages = ws2.messages.filter((m: WsMsg) => m.type === "state");
+
+		// 8. Assert: at least one state message should have the correct contextWindow
+		const hasCorrectContextWindow = stateMessages.some((m: WsMsg) => {
+			const model = (m.data as any)?.model;
+			return model && model.contextWindow === 1_000_000;
+		});
+
+		// Collect what we actually got for diagnostic output
+		const contextWindows = stateMessages
+			.map((m: WsMsg) => (m.data as any)?.model?.contextWindow)
+			.filter((v: unknown) => v !== undefined);
+
+		expect(hasCorrectContextWindow,
+			`Expected at least one state message with contextWindow === 1000000 after reconnect, ` +
+			`but got contextWindow values: [${contextWindows.join(", ")}] ` +
+			`from ${stateMessages.length} state message(s). ` +
+			`State data: ${JSON.stringify(stateMessages.map(m => m.data))}`
+		).toBe(true);
+
+		ws2.close();
+	});
+});


### PR DESCRIPTION
## Problem
After server restart, the context bar beneath the prompt either shows nothing or shows 200k as the context window for models that actually have 1M tokens (Sonnet/Opus).

## Root Cause
1. Server's proactive `getState()` RPC fails silently or is skipped for dormant sessions
2. Client default model hardcodes `contextWindow: 200000` from pi-ai
3. No retry mechanism on reconnect

## Fix

### Server-side (`handler.ts`, `session-manager.ts`)
- New `sendFallbackModelState()` helper reads persisted `modelProvider`/`modelId` and uses `inferMeta()` for correct `contextWindow`
- Called when `getState()` fails, returns no model data, or is skipped (dormant/preparing sessions)
- Also added fallback to the explicit `get_state` WS command handler
- New public `SessionManager.getPersistedSession(id)` method

### Client-side (`remote-agent.ts`)
- Default `contextWindow` changed from 200k to 0 (shows nothing instead of wrong value)
- Added 3s retry timer for `get_state` on reconnect if model info still missing

### Test
- `tests/e2e/context-bar-reconnect.spec.ts` — E2E test that creates a session, sets model, disconnects, reconnects, and verifies correct `contextWindow` in state message

### Documentation
- Updated `AGENTS.md` and `docs/debugging.md` with context bar troubleshooting info

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)