### PR TITLE
Exploratory validation workflow gate

### DIFF
--- a/.bobbit/config/project.yaml
+++ b/.bobbit/config/project.yaml
@@ -11,3 +11,14 @@ worktree_setup_command: npm ci --prefer-offline --no-audit --no-fund
 config_directories: '[{"path":"C:\\tmp\\.bobbit","types":["skills"]},{"path":"C:\\Users\\jsubr\\.claude\\AGENTS.md","types":["agents"]}]'
 sandbox: docker
 sandbox_image: bobbit-agent
+ev_build_command: npm run build
+ev_start_command: >-
+  PORT=$PORT WORK_DIR=$WORK_DIR BOBBIT_DIR=$WORK_DIR/.bobbit
+  BOBBIT_NO_OPEN=1 BOBBIT_LLM_REVIEW_SKIP=1 BOBBIT_SKIP_NPM_CI=1
+  node dist/server/cli.js
+  --host 127.0.0.1 --port $PORT --no-tls --auth --cwd $WORK_DIR
+ev_health_check: http://127.0.0.1:$PORT/api/health
+ev_browser_entry: http://127.0.0.1:$PORT/?token=$TOKEN
+ev_env: '{"BOBBIT_NO_OPEN":"1","BOBBIT_LLM_REVIEW_SKIP":"1","BOBBIT_SKIP_NPM_CI":"1"}'
+ev_max_duration_minutes: "10"
+ev_max_scenarios: "5"

--- a/.bobbit/config/roles/team-lead.yaml
+++ b/.bobbit/config/roles/team-lead.yaml
@@ -280,6 +280,24 @@ promptTemplate: |
   - If you receive a gate failure notification, check `gate_status` to confirm the failure is from the latest signal — stale failures are automatically suppressed, but if verification was already complete before your re-signal, you may still receive the notification
   - Do not re-signal repeatedly in quick succession — each re-signal cancels the previous one, wasting reviewer resources
 
+  ## Exploratory Validation Gate
+
+  When the workflow includes an `exploratory-validation` gate:
+
+  1. **Decide if validation is needed**: If the goal has no UI changes or is purely backend/infrastructure, 
+     signal the gate with content "N/A — no UI changes require exploratory validation" and metadata 
+     `{scenarios_passed: "0", scenarios_failed: "0", budget_used: "0m"}`.
+
+  2. **If validation is needed**: Spawn a test-engineer with:
+     - `workflowGateId: "exploratory-validation"`
+     - Task prompt that includes: the specific scenarios to validate (derived from the design doc 
+       and goal spec), instruction to invoke the `/validate` slash skill, and the expected report format
+     - The test-engineer will use `/validate` to stand up an ephemeral environment, drive the browser 
+       through scenarios, and produce an HTML report with screenshots
+
+  3. **The test-engineer signals the gate** with the report as content and metadata including 
+     `scenarios_passed`, `scenarios_failed`, and `budget_used`
+
   ## Completion
 
   When all implementation/review/documentation gates have passed, prepare for the `ready-to-merge` gate:

--- a/.bobbit/config/workflows/bug-fix.yaml
+++ b/.bobbit/config/workflows/bug-fix.yaml
@@ -130,9 +130,30 @@ gates:
           4. Secrets handling — no hardcoded secrets, tokens, or credentials
           5. Dependency risks — any new dependencies with known vulnerabilities?
 
+  - id: exploratory-validation
+    name: Exploratory Validation
+    depends_on: [implementation]
+    content: true
+    optional: true
+    metadata:
+      scenarios_passed: string
+      scenarios_failed: string
+      budget_used: string
+    verify:
+      - name: "Report has evidence"
+        type: llm-review
+        prompt: |
+          Review this exploratory validation report for a bug fix.
+          
+          1. Does every scenario include screenshots as evidence?
+          2. Are failures explained with actionable detail?
+          3. Were automated test coverage gaps identified?
+          
+          If the content says "N/A" or "Skipped", that is acceptable — pass the gate.
+
   - id: documentation
     name: Documentation
-    depends_on: [implementation]
+    depends_on: [exploratory-validation]
     verify:
       - name: "Documentation coverage"
         type: llm-review

--- a/.bobbit/config/workflows/feature.yaml
+++ b/.bobbit/config/workflows/feature.yaml
@@ -91,9 +91,34 @@ gates:
           4. Secrets handling — no hardcoded secrets, tokens, or credentials
           5. Dependency risks — any new dependencies with known vulnerabilities?
 
+  - id: exploratory-validation
+    name: Exploratory Validation
+    depends_on: [implementation]
+    content: true
+    optional: true
+    metadata:
+      scenarios_passed: string
+      scenarios_failed: string
+      budget_used: string
+    verify:
+      - name: "Report has evidence"
+        type: llm-review
+        prompt: |
+          Review this exploratory validation report for a goal.
+          
+          1. Does every scenario include screenshots as evidence?
+          2. Are failures explained with actionable detail?
+          3. Were automated test coverage gaps identified?
+          4. Was the ephemeral environment properly isolated (temp dir, separate port)?
+          
+          If the content says "N/A" or "Skipped — no UI changes", that is acceptable — pass the gate.
+          If the content describes scenarios with screenshots and verdicts, evaluate the quality.
+          Fail only if scenarios claim to have evidence but screenshots are missing, or if
+          failures are described without enough detail to act on.
+
   - id: documentation
     name: Documentation
-    depends_on: [implementation]
+    depends_on: [exploratory-validation]
     verify:
       - name: "Documentation coverage"
         type: llm-review

--- a/.claude/skills/validate/SKILL.md
+++ b/.claude/skills/validate/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: validate
+description: Stand up an ephemeral test environment and drive browser-based exploratory validation scenarios
+argument-hint: [scenario description]
+---
+
+# Exploratory Validation Protocol
+
+You are running exploratory validation for a goal. This protocol stands up an isolated copy of the application, drives a real browser through user scenarios, captures screenshot evidence, and produces an HTML validation report.
+
+## Prerequisites
+
+- You need browser tools (Playwright MCP) available
+- The project must have `ev_*` keys in `.bobbit/config/project.yaml`
+
+## Step 1: Read Configuration
+
+Read the project config to get the exploratory validation settings:
+
+```bash
+cat .bobbit/config/project.yaml
+```
+
+Look for these keys:
+- `ev_build_command` — how to build the project (falls back to `build_command`)
+- `ev_start_command` — how to start an isolated server (REQUIRED — if missing, stop)
+- `ev_health_check` — URL to poll for readiness
+- `ev_browser_entry` — URL to open in the browser
+- `ev_env` — JSON object of extra environment variables
+- `ev_max_duration_minutes` — time budget (default: 10)
+- `ev_max_scenarios` — scenario budget (default: 5)
+
+If `ev_start_command` is not set, report "No exploratory validation configured for this project" and stop.
+
+## Step 2: Create Isolated Environment
+
+Create a temp directory COMPLETELY OUTSIDE the repo. The ephemeral server must NEVER share state with the repo or the production dev server.
+
+```bash
+WORK_DIR=$(mktemp -d)
+mkdir -p "$WORK_DIR/.bobbit/state"
+echo "test" > "$WORK_DIR/.bobbit/state/setup-complete"
+```
+
+Record the repo path:
+```bash
+REPO=$(pwd)
+```
+
+Record the current branch and commit for the report:
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+COMMIT=$(git rev-parse --short HEAD)
+```
+
+## Step 3: Build the Project
+
+Run the build command from the repo directory:
+```bash
+cd "$REPO" && eval "<ev_build_command value>"
+```
+
+If the build fails, produce a report documenting the build failure and skip to Step 9 (Cleanup).
+
+## Step 4: Allocate Port and Start Server
+
+Get a free port:
+```bash
+FREE_PORT=$(node -e "const s=require('net').createServer();s.listen(0,'127.0.0.1',()=>{console.log(s.address().port);s.close()})")
+```
+
+Start the server using `bash_bg` (NEVER use `bash` with `&`):
+```bash
+bash_bg(action="create", command="PORT=<free_port> WORK_DIR=<work_dir> BOBBIT_DIR=<work_dir>/.bobbit <ev_env vars> eval '<ev_start_command>'")
+```
+
+Record the background process ID for later cleanup.
+
+## Step 5: Wait for Health Check
+
+Substitute `$PORT` in the health check URL and poll until ready:
+```bash
+for i in $(seq 1 30); do
+  if curl -sf "<health_check_url>" > /dev/null 2>&1; then
+    echo "Server ready"
+    break
+  fi
+  sleep 2
+done
+```
+
+Read the auth token:
+```bash
+TOKEN=$(cat "$WORK_DIR/.bobbit/state/token")
+```
+
+If the server doesn't become healthy after 60 seconds, document the failure and skip to cleanup.
+
+## Step 6: Drive Browser Scenarios
+
+Substitute `$PORT` and `$TOKEN` in the browser entry URL. Navigate to it.
+
+For each scenario from your task prompt (respecting `ev_max_scenarios`):
+
+1. **Before**: Take a screenshot documenting the starting state
+2. **Action**: Perform the user interaction (click, type, navigate, etc.)
+3. **After**: Take a screenshot documenting the result
+4. **Verdict**: Record PASS or FAIL with a clear explanation
+
+Use `browser_screenshot(savePath="<work_dir>/screenshot-N.png")` to save screenshots.
+
+Track elapsed time. If `ev_max_duration_minutes` is exceeded, stop testing immediately and proceed to report generation with partial results.
+
+## Step 7: Produce HTML Report
+
+Write a self-contained HTML report. Screenshots should be embedded as base64 data URIs:
+```bash
+base64 -w0 "$WORK_DIR/screenshot-1.png"
+```
+
+The report structure:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Exploratory Validation Report</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 960px; margin: 0 auto; padding: 2rem; line-height: 1.6; }
+    h1 { border-bottom: 2px solid #333; padding-bottom: 0.5rem; }
+    .env-table { width: 100%; border-collapse: collapse; margin: 1rem 0; }
+    .env-table td, .env-table th { border: 1px solid #ddd; padding: 0.5rem; text-align: left; }
+    .scenario { border: 1px solid #ddd; border-radius: 8px; padding: 1.5rem; margin: 1.5rem 0; }
+    .pass { border-left: 4px solid #22c55e; }
+    .fail { border-left: 4px solid #ef4444; }
+    .skip { border-left: 4px solid #f59e0b; }
+    .screenshot { max-width: 100%; border: 1px solid #ccc; border-radius: 4px; margin: 0.5rem 0; }
+    .verdict { font-weight: bold; font-size: 1.1em; margin-top: 1rem; }
+    .verdict.pass { color: #16a34a; }
+    .verdict.fail { color: #dc2626; }
+    .summary { background: #f1f5f9; padding: 1.5rem; border-radius: 8px; margin: 2rem 0; }
+    .summary h2 { margin-top: 0; }
+    .gap-list { background: #fffbeb; padding: 1rem; border-radius: 8px; border-left: 4px solid #f59e0b; }
+  </style>
+</head>
+<body>
+  <h1>Exploratory Validation Report</h1>
+  
+  <h2>Environment</h2>
+  <table class="env-table">
+    <tr><th>Branch</th><td>[branch name]</td></tr>
+    <tr><th>Commit</th><td>[commit hash]</td></tr>
+    <tr><th>Server</th><td>http://127.0.0.1:[port] (ephemeral, killed after validation)</td></tr>
+    <tr><th>Working Directory</th><td>[temp dir path]</td></tr>
+  </table>
+
+  <!-- For each scenario: -->
+  <div class="scenario pass|fail|skip">
+    <h3>Scenario N: [Title]</h3>
+    <ol>
+      <li>[Step description]
+        <br><img class="screenshot" src="data:image/png;base64,[...]" alt="[description]">
+      </li>
+      <!-- more steps -->
+    </ol>
+    <p class="verdict pass|fail">Result: PASS|FAIL — [explanation]</p>
+  </div>
+
+  <div class="gap-list">
+    <h2>Automated Test Coverage Gaps</h2>
+    <ul>
+      <li>[Identified gap with file/test references]</li>
+    </ul>
+  </div>
+
+  <div class="summary">
+    <h2>Summary</h2>
+    <p><strong>Passed:</strong> N | <strong>Failed:</strong> N | <strong>Skipped:</strong> N</p>
+    <p><strong>Budget used:</strong> Nm of Nm</p>
+  </div>
+</body>
+</html>
+```
+
+Save the report to `$WORK_DIR/validation-report.html`.
+
+## Step 8: Signal Gate
+
+Convert key sections of the HTML report to markdown and signal the gate:
+
+```
+gate_signal(
+  gate_id="exploratory-validation",
+  content="<markdown version of the report>",
+  metadata={
+    "scenarios_passed": "<count>",
+    "scenarios_failed": "<count>",
+    "budget_used": "<minutes>m of <max>m"
+  }
+)
+```
+
+## Step 9: Cleanup
+
+**Always run cleanup**, even if earlier steps failed:
+
+1. Kill the background server: `bash_bg(action="kill", id="<server-id>")`
+2. Remove the temp directory: `rm -rf "$WORK_DIR"`
+3. Verify production is unaffected (optional): `curl -sf` the production health endpoint
+
+## Important Rules
+
+- **NEVER** share state with the repo's `.bobbit/` directory
+- **NEVER** use `bash` with `&` for the server — always use `bash_bg`
+- **ALWAYS** clean up, even on failure
+- **ALWAYS** embed screenshots as base64 in the report (self-contained)
+- **RESPECT** the time and scenario budgets — partial results are better than no results
+- If $ARGUMENTS were provided, use them as scenario descriptions to validate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,8 @@ UI-only changes need only unit tests. Server changes need E2E too.
 
 **Manage config directories**: Settings → Config Directories tab, or `config_directories` in `project.yaml`. Config directories are scoped per-project — each project's `config_directories` affects only that project's sessions for skills, MCP servers, and agent files. See @docs/internals.md#config-scan-directories.
 
+**Add exploratory validation to a project**: Add `ev_*` keys to `project.yaml` — at minimum `ev_start_command` (how to start an isolated server). The `/validate` slash skill reads these keys and orchestrates the ephemeral environment lifecycle. See [docs/exploratory-validation.md](docs/exploratory-validation.md) for full config reference and protocol details. The `exploratory-validation` workflow gate (in `feature.yaml` and `bug-fix.yaml`) uses LLM review to verify the HTML evidence report.
+
 ## Debugging
 
 See @docs/debugging.md for scannable checklists covering all subsystems.
@@ -115,6 +117,7 @@ Quick pointers for the most common issues:
 - **Search**: Each project has its own `<project-root>/.bobbit/state/search.db`. Delete and restart to rebuild. Searches aggregate across all project indexes. See @docs/debugging.md#search-index for full checklist.
 - **Gates**: Check `GET /api/goals/:id/gates` for dependency state.
 - **Multi-project / per-project state**: Each project stores its own state in `<project-root>/.bobbit/state/` (goals, sessions, tasks, teams, gates, staff, search index, costs). The server aggregates via `ProjectContextManager`. Check `GET /api/projects` for registered projects. Sessions/goals/staff carry optional `projectId`; filter with `?projectId=` on list endpoints. Config directories (MCP servers, skills, AGENTS.md/agent files) are resolved per-project through each project's `config_directories` setting. Per-project config: `GET /api/projects/:id/config/resolved` shows resolved values with source. See [docs/internals.md](docs/internals.md#multi-project-architecture) for architecture.
+- **Exploratory validation**: Check `ev_*` keys in project.yaml. The `/validate` skill requires `ev_start_command` at minimum. See [docs/exploratory-validation.md](docs/exploratory-validation.md).
 - **State migration**: On first startup after upgrade, centralized state files are distributed to per-project dirs based on `projectId` tags. Central files renamed with `.pre-migration` suffix. Check for `.bobbit/state/.migrated-to-per-project` marker. See @docs/internals.md#state-migration for details.
 
 ## Git conventions

--- a/docs/exploratory-validation.md
+++ b/docs/exploratory-validation.md
@@ -143,7 +143,7 @@ The `exploratory-validation` gate appears in both `feature.yaml` and `bug-fix.ya
 ```
 
 Key properties:
-- **`optional: true`** — The gate can be signaled with "N/A" content and still pass. Downstream gates (documentation) don't block if this gate hasn't been signaled.
+- **`optional: true`** — Marks the gate as skippable. The team lead **must still signal it** (even with "N/A" content) before downstream gates unblock — the `optional` flag is metadata for the team lead's decision, not an automatic bypass. The LLM reviewer accepts "N/A" or "Skipped" content as valid.
 - **`content: true`** — The gate carries the validation report as content.
 - **`metadata`** — Structured data about results (`scenarios_passed`, `scenarios_failed`, `budget_used`).
 

--- a/docs/exploratory-validation.md
+++ b/docs/exploratory-validation.md
@@ -1,0 +1,204 @@
+# Exploratory Validation
+
+Automated E2E tests exercise known paths through simulated components, but they can miss integration failures that only surface when a real user drives the full system. Exploratory validation closes this gap: an agent stands up an ephemeral copy of the application, drives a real browser through user scenarios, captures screenshots as evidence, and produces an HTML report. It is integrated as an optional workflow gate so it fits naturally into the goal lifecycle without blocking projects that don't need it.
+
+## How it fits in the architecture
+
+Exploratory validation sits between the **implementation** gate and the **documentation** gate in both the `feature` and `bug-fix` workflows. After code passes type checks, automated tests, and code review, the team lead decides whether visual/integration validation is needed. If so, a test-engineer agent invokes the `/validate` slash skill, which handles the ephemeral environment lifecycle. The agent handles the actual browser interaction and report authoring.
+
+```
+design-doc → implementation → exploratory-validation (optional) → documentation → ready-to-merge
+```
+
+The gate is **optional** — projects without `ev_*` config or goals without UI changes simply skip it via an "N/A" signal. The workflow continues to the documentation gate either way.
+
+## Project configuration
+
+Add `ev_*` keys to `.bobbit/config/project.yaml`. Only `ev_start_command` is required — the rest have sensible defaults or can be omitted.
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `ev_build_command` | No | Falls back to `build_command`, then `npm run build` | How to build the project before starting the ephemeral server |
+| `ev_start_command` | **Yes** | — | Command to start an isolated server. Receives `$PORT`, `$WORK_DIR`, and `$TOKEN` as environment variables |
+| `ev_health_check` | No | `""` | URL to poll for server readiness. Use `$PORT` placeholder (e.g. `http://127.0.0.1:$PORT/api/health`) |
+| `ev_browser_entry` | No | `""` | URL to open in the browser. Use `$PORT` and `$TOKEN` placeholders |
+| `ev_env` | No | `{}` | JSON object of extra environment variables for the server process |
+| `ev_max_duration_minutes` | No | `10` | Hard time budget — server is killed after this many minutes |
+| `ev_max_scenarios` | No | `5` | Maximum number of scenarios to run before stopping |
+
+### Bobbit's own config
+
+Bobbit ships with a working config in its `project.yaml`:
+
+```yaml
+ev_build_command: npm run build
+ev_start_command: >-
+  PORT=$PORT WORK_DIR=$WORK_DIR BOBBIT_DIR=$WORK_DIR/.bobbit
+  BOBBIT_NO_OPEN=1 BOBBIT_LLM_REVIEW_SKIP=1 BOBBIT_SKIP_NPM_CI=1
+  node dist/server/cli.js
+  --host 127.0.0.1 --port $PORT --no-tls --auth --cwd $WORK_DIR
+ev_health_check: http://127.0.0.1:$PORT/api/health
+ev_browser_entry: http://127.0.0.1:$PORT/?token=$TOKEN
+ev_env: '{"BOBBIT_NO_OPEN":"1","BOBBIT_LLM_REVIEW_SKIP":"1","BOBBIT_SKIP_NPM_CI":"1"}'
+ev_max_duration_minutes: "10"
+ev_max_scenarios: "5"
+```
+
+Key points for the start command:
+- `BOBBIT_DIR=$WORK_DIR/.bobbit` — isolates all state to the temp directory
+- `--cwd $WORK_DIR` — prevents the ephemeral server from touching the repo
+- `--no-tls` — avoids certificate complexity for local testing
+- `--auth` — generates a token in the temp dir's state for browser authentication
+
+### Generic project example
+
+For a Node.js web app:
+
+```yaml
+ev_start_command: "PORT=$PORT node dist/server.js"
+ev_health_check: "http://127.0.0.1:$PORT/healthz"
+ev_browser_entry: "http://127.0.0.1:$PORT"
+ev_max_scenarios: "3"
+```
+
+### REST endpoint
+
+The parsed config is available via:
+
+```
+GET /api/projects/:id/exploratory-validation-config
+```
+
+Returns `{ config: ExploratoryValidationConfig | null }`. Returns `null` when `ev_start_command` is not set. The `ExploratoryValidationConfig` object has camelCase field names: `buildCommand`, `startCommand`, `healthCheck`, `browserEntry`, `env`, `maxDurationMinutes`, `maxScenarios`.
+
+## The `/validate` slash skill
+
+The `/validate` skill (in `.claude/skills/validate/SKILL.md`) provides the full ephemeral environment protocol. Agents invoke it to run exploratory validation scenarios. The skill handles environment lifecycle; the agent handles browser interaction and report writing.
+
+### Protocol overview
+
+The protocol has 9 steps:
+
+1. **Read config** — Load `ev_*` keys from `project.yaml`. Stop if `ev_start_command` is missing.
+
+2. **Create isolated environment** — Create a temp directory completely outside the repo (`mktemp -d`). Initialize a minimal `.bobbit/state/` inside it. This isolation is critical — the ephemeral server must never read or write the repo's `.bobbit/` or affect the production dev server.
+
+3. **Build** — Run `ev_build_command` from the repo directory. If the build fails, produce a failure report and skip to cleanup.
+
+4. **Allocate port and start server** — Find a free port, then start the server via `bash_bg` (never `bash` with `&` — that hangs agent sessions). The command receives `$PORT`, `$WORK_DIR`, and any `ev_env` variables.
+
+5. **Wait for health check** — Poll `ev_health_check` (with `$PORT` substituted) every 2 seconds for up to 60 seconds. Read the auth token from the temp dir's state.
+
+6. **Drive browser scenarios** — Navigate to `ev_browser_entry` (with `$PORT` and `$TOKEN` substituted). For each scenario from the task prompt, take before/after screenshots and record a PASS/FAIL verdict. Respect `ev_max_scenarios` and `ev_max_duration_minutes`.
+
+7. **Produce HTML report** — Write a self-contained HTML report with base64-embedded screenshots (see Report Format below).
+
+8. **Signal gate** — Convert the report to markdown and signal the `exploratory-validation` gate with content and metadata (`scenarios_passed`, `scenarios_failed`, `budget_used`).
+
+9. **Cleanup** — Kill the background server via `bash_bg`, delete the temp directory. Always runs, even on failure.
+
+## Report format
+
+The validation report is a self-contained HTML file. Screenshots are embedded as base64 data URIs so the report works offline without external dependencies.
+
+### Sections
+
+- **Environment** — Branch, commit, server URL, temp directory path. Establishes what was tested.
+
+- **Scenario sections** — One per scenario, each containing:
+  - Numbered steps with descriptions
+  - Before/after screenshots for each step
+  - A PASS or FAIL verdict with explanation
+  - Visual styling: green left border for pass, red for fail, amber for skipped
+
+- **Automated test coverage gaps** — Identified gaps in existing E2E/unit test coverage. The purpose of exploratory validation is not to replace automated tests, but to discover where they should be added.
+
+- **Summary** — Total scenarios passed/failed/skipped, budget consumed.
+
+### Why self-contained HTML?
+
+The report is the gate artifact — it's stored as gate content and must be readable without a running server. Base64-embedded screenshots ensure the evidence is preserved with the report, not lost when the temp directory is cleaned up.
+
+## Workflow gate
+
+### Gate definition
+
+The `exploratory-validation` gate appears in both `feature.yaml` and `bug-fix.yaml`:
+
+```yaml
+- id: exploratory-validation
+  name: Exploratory Validation
+  depends_on: [implementation]
+  content: true
+  optional: true
+  metadata:
+    scenarios_passed: string
+    scenarios_failed: string
+    budget_used: string
+  verify:
+    - name: "Report has evidence"
+      type: llm-review
+      prompt: |
+        Review this exploratory validation report...
+```
+
+Key properties:
+- **`optional: true`** — The gate can be signaled with "N/A" content and still pass. Downstream gates (documentation) don't block if this gate hasn't been signaled.
+- **`content: true`** — The gate carries the validation report as content.
+- **`metadata`** — Structured data about results (`scenarios_passed`, `scenarios_failed`, `budget_used`).
+
+### LLM review verification
+
+The gate's verifier checks:
+1. Every scenario has screenshot evidence
+2. Failures are explained with actionable detail
+3. Automated test coverage gaps were identified
+4. "N/A" or "Skipped" content is accepted as valid
+
+### How the team lead uses it
+
+The team-lead role prompt includes instructions for the exploratory validation gate:
+
+1. **Decide if needed** — If the goal has no UI changes or is purely infrastructure, signal the gate with "N/A" content and zeroed metadata. The LLM reviewer accepts this.
+
+2. **If needed** — Spawn a test-engineer agent with `workflowGateId: "exploratory-validation"`, a task prompt listing scenarios to validate (derived from the design doc), and instructions to invoke `/validate`.
+
+3. **The test-engineer signals the gate** with the report and metadata after completing the validation.
+
+## Budget enforcement
+
+Two budgets prevent runaway validation:
+
+- **Time budget** (`ev_max_duration_minutes`, default 10) — If elapsed time exceeds the budget during scenario execution, the agent stops testing immediately and produces a report with partial results. The server is killed and cleaned up.
+
+- **Scenario budget** (`ev_max_scenarios`, default 5) — Caps the number of scenarios executed in a single validation run.
+
+Partial results are valid — the report documents what was tested and what was skipped due to budget exhaustion.
+
+## Isolation rules
+
+The ephemeral environment is fully isolated from the repo and the production dev server:
+
+| Concern | How it's isolated |
+|---------|-------------------|
+| State directory | Temp dir gets its own `.bobbit/` — never shares with the repo's `.bobbit/` |
+| Port | Dynamically allocated free port — no conflict with the dev server |
+| Working directory | `--cwd` or equivalent points to the temp dir |
+| Cleanup | Temp dir and server process are destroyed after validation, even on failure |
+| Read-only repo | The build step reads from the repo; the ephemeral server writes only to the temp dir |
+
+The production dev server is completely unaffected throughout the validation process.
+
+## Troubleshooting
+
+- **"No exploratory validation configured"** — The project's `project.yaml` is missing `ev_start_command`. Add `ev_*` keys as described above.
+- **Health check never passes** — Verify `ev_health_check` URL uses `$PORT` placeholder. Check `bash_bg` logs for server startup errors.
+- **Screenshots missing from report** — The agent needs Playwright MCP tools available. Check that the browser tools are in the session's tool set.
+- **Gate signaled as N/A but downstream is blocked** — The `optional: true` flag means N/A is accepted. Check `gate_status` for the actual verification result.
+- **Temp directory not cleaned up** — If the agent crashes mid-protocol, the temp dir may remain. These are in the system temp directory (`$TMPDIR`) and can be manually cleaned.
+
+## Related docs
+
+- [Goals, workflows, and tasks](goals-workflows-tasks.md) — Gate lifecycle and dependency model
+- [Internals](internals.md) — Project config resolution, per-project state
+- [Debugging](debugging.md) — General debugging checklists

--- a/docs/goals-workflows-tasks.md
+++ b/docs/goals-workflows-tasks.md
@@ -37,6 +37,7 @@ interface WorkflowGate {
   content?: boolean;       // Whether this gate accepts markdown content
   injectDownstream?: boolean; // Whether passed content is injected into downstream agents
   metadata?: Record<string, string>; // Key-value metadata schema
+  optional?: boolean;      // If true, team lead may signal with "N/A" (still must be signaled)
   verify?: VerifyStep[];   // Verification steps to run on signal
 }
 

--- a/src/server/agent/project-config-store.ts
+++ b/src/server/agent/project-config-store.ts
@@ -4,6 +4,16 @@ import yaml from "yaml";
 
 export type ProjectConfig = Record<string, string>;
 
+export interface ExploratoryValidationConfig {
+	buildCommand: string;
+	startCommand: string;
+	healthCheck: string;
+	browserEntry: string;
+	env: Record<string, string>;
+	maxDurationMinutes: number;
+	maxScenarios: number;
+}
+
 const DEFAULTS: Record<string, string> = {
 	build_command: "npm run build",
 	test_command: "npm test",
@@ -97,5 +107,20 @@ export class ProjectConfigStore {
 	getWithDefaults(): Record<string, string> {
 		this.load();
 		return { ...DEFAULTS, ...this.data };
+	}
+
+	/** Parse exploratory validation config from ev_* keys. Returns null if not configured (no ev_start_command). */
+	getExploratoryValidationConfig(): ExploratoryValidationConfig | null {
+		const all = this.getWithDefaults();
+		if (!all.ev_start_command) return null;
+		return {
+			buildCommand: all.ev_build_command || all.build_command || "npm run build",
+			startCommand: all.ev_start_command,
+			healthCheck: all.ev_health_check || "",
+			browserEntry: all.ev_browser_entry || "",
+			env: all.ev_env ? JSON.parse(all.ev_env) : {},
+			maxDurationMinutes: parseInt(all.ev_max_duration_minutes || "10", 10),
+			maxScenarios: parseInt(all.ev_max_scenarios || "5", 10),
+		};
 	}
 }

--- a/src/server/agent/workflow-store.ts
+++ b/src/server/agent/workflow-store.ts
@@ -17,6 +17,7 @@ export interface WorkflowGate {
 	dependsOn: string[];
 	content?: boolean;
 	injectDownstream?: boolean;
+	optional?: boolean;
 	metadata?: Record<string, string>;
 	verify?: VerifyStep[];
 }
@@ -106,6 +107,7 @@ export class WorkflowStore {
 		};
 		if (data.content === true) gate.content = true;
 		if (data.inject_downstream === true || data.injectDownstream === true) gate.injectDownstream = true;
+		if (data.optional === true) gate.optional = true;
 		if (data.metadata && typeof data.metadata === "object") {
 			gate.metadata = data.metadata as Record<string, string>;
 		}
@@ -142,6 +144,7 @@ export class WorkflowStore {
 					};
 					if (g.content) out.content = true;
 					if (g.injectDownstream) out.inject_downstream = true;
+					if (g.optional) out.optional = true;
 					if (g.dependsOn && g.dependsOn.length > 0) out.depends_on = g.dependsOn;
 					if (g.metadata) out.metadata = g.metadata;
 					if (g.verify && g.verify.length > 0) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -990,6 +990,16 @@ async function handleApiRoute(
 		}
 	}
 
+	// GET /api/projects/:id/exploratory-validation-config
+	const evConfigMatch = url.pathname.match(/^\/api\/projects\/([^/]+)\/exploratory-validation-config$/);
+	if (evConfigMatch && req.method === "GET") {
+		const ctx = projectContextManager.getOrCreate(evConfigMatch[1]);
+		if (!ctx) { json({ error: "Project not found" }, 404); return; }
+		const config = ctx.projectConfigStore.getExploratoryValidationConfig();
+		json({ config });
+		return;
+	}
+
 	// GET /api/search
 	if (url.pathname === "/api/search" && req.method === "GET") {
 		const q = url.searchParams.get("q");

--- a/tests/exploratory-validation-config.test.ts
+++ b/tests/exploratory-validation-config.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { ProjectConfigStore } from "../src/server/agent/project-config-store.js";
+
+describe("ExploratoryValidationConfig", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ev-config-test-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("returns null when no ev_start_command configured", () => {
+		fs.writeFileSync(path.join(tmpDir, "project.yaml"), "name: test\n");
+		const store = new ProjectConfigStore(tmpDir);
+		assert.equal(store.getExploratoryValidationConfig(), null);
+	});
+
+	it("parses ev_* keys into typed config", () => {
+		const yaml = [
+			"name: test",
+			"build_command: npm run build",
+			'ev_build_command: "npm run build:prod"',
+			'ev_start_command: "node server.js --port $PORT"',
+			'ev_health_check: "http://127.0.0.1:$PORT/health"',
+			'ev_browser_entry: "http://127.0.0.1:$PORT/?token=$TOKEN"',
+			"ev_env: '{\"FOO\":\"bar\"}'",
+			'ev_max_duration_minutes: "15"',
+			'ev_max_scenarios: "3"',
+		].join("\n");
+		fs.writeFileSync(path.join(tmpDir, "project.yaml"), yaml);
+		const store = new ProjectConfigStore(tmpDir);
+		const config = store.getExploratoryValidationConfig();
+		assert.ok(config);
+		assert.equal(config.buildCommand, "npm run build:prod");
+		assert.equal(config.startCommand, "node server.js --port $PORT");
+		assert.equal(config.healthCheck, "http://127.0.0.1:$PORT/health");
+		assert.equal(config.browserEntry, "http://127.0.0.1:$PORT/?token=$TOKEN");
+		assert.deepEqual(config.env, { FOO: "bar" });
+		assert.equal(config.maxDurationMinutes, 15);
+		assert.equal(config.maxScenarios, 3);
+	});
+
+	it("falls back to build_command when ev_build_command not set", () => {
+		const yaml = [
+			"build_command: npm run mybuild",
+			'ev_start_command: "node server.js"',
+		].join("\n");
+		fs.writeFileSync(path.join(tmpDir, "project.yaml"), yaml);
+		const store = new ProjectConfigStore(tmpDir);
+		const config = store.getExploratoryValidationConfig();
+		assert.ok(config);
+		assert.equal(config.buildCommand, "npm run mybuild");
+	});
+
+	it("uses defaults for optional fields", () => {
+		const yaml = 'ev_start_command: "node server.js"\n';
+		fs.writeFileSync(path.join(tmpDir, "project.yaml"), yaml);
+		const store = new ProjectConfigStore(tmpDir);
+		const config = store.getExploratoryValidationConfig();
+		assert.ok(config);
+		assert.equal(config.maxDurationMinutes, 10);
+		assert.equal(config.maxScenarios, 5);
+		assert.deepEqual(config.env, {});
+		assert.equal(config.healthCheck, "");
+		assert.equal(config.browserEntry, "");
+	});
+});

--- a/tests/validate-skill-discovery.test.ts
+++ b/tests/validate-skill-discovery.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+describe("/validate slash skill", () => {
+  it("SKILL.md exists and has valid frontmatter", () => {
+    const skillPath = path.join(process.cwd(), ".claude", "skills", "validate", "SKILL.md");
+    assert.ok(fs.existsSync(skillPath), "SKILL.md should exist at .claude/skills/validate/SKILL.md");
+    
+    const content = fs.readFileSync(skillPath, "utf-8");
+    
+    // Check frontmatter
+    assert.ok(content.startsWith("---"), "Should start with YAML frontmatter");
+    assert.ok(content.includes("name: validate"), "Should have name: validate");
+    assert.ok(content.includes("description:"), "Should have a description");
+    
+    // Check key protocol sections
+    assert.ok(content.includes("Step 1"), "Should have Step 1");
+    assert.ok(content.includes("Step 9") || content.includes("Cleanup"), "Should have cleanup step");
+    assert.ok(content.includes("bash_bg"), "Should reference bash_bg for server lifecycle");
+    assert.ok(content.includes("ev_start_command"), "Should reference ev_start_command config");
+    assert.ok(content.includes("base64"), "Should mention base64 for screenshots");
+    assert.ok(content.includes("gate_signal"), "Should reference gate_signal");
+  });
+});


### PR DESCRIPTION
## Summary

Add an exploratory validation system that allows agents to stand up an ephemeral test environment, drive a real browser through user journeys, and produce an HTML evidence report with screenshots — integrated as an optional workflow gate.

## Changes

### Phase 1: Project config schema
- `ExploratoryValidationConfig` interface and `getExploratoryValidationConfig()` method on `ProjectConfigStore`
- `GET /api/projects/:id/exploratory-validation-config` REST endpoint
- Parses `ev_*` flat keys from `project.yaml` into a typed config object

### Phase 2: /validate slash skill
- `.claude/skills/validate/SKILL.md` — full ephemeral environment protocol
- 9-step protocol: read config, create temp dir, build, start server via bash_bg, health check, drive browser, produce HTML report, signal gate, cleanup

### Phase 3: Workflow gate integration
- `exploratory-validation` gate added to `feature.yaml` and `bug-fix.yaml` (between implementation and documentation)
- `optional: true` field support on `WorkflowGate` interface
- LLM review verification accepts N/A content for non-UI goals
- Team-lead prompt updated with exploratory validation instructions

### Phase 4: Bobbit self-validation config
- Working `ev_*` keys in Bobbit's own `project.yaml`

### Phase 5: Documentation
- `docs/exploratory-validation.md` — full reference documentation
- Updated AGENTS.md with recipe and debugging entries
- Updated `docs/goals-workflows-tasks.md` with `optional` field on `WorkflowGate`

## Tests
- Unit tests for `getExploratoryValidationConfig()` parsing (4 tests)
- Unit test for `/validate` skill discovery
- All 327 unit tests pass, type-check clean

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)