### PR TITLE
Extend native browser tools to eliminate MCP Playwright dependency for QA agents

### DIFF
--- a/.bobbit/config/roles/qa-tester.yaml
+++ b/.bobbit/config/roles/qa-tester.yaml
@@ -13,6 +13,12 @@ toolPolicies:
   browser_type: allow
   browser_eval: allow
   browser_wait: allow
+  browser_snapshot: allow
+  browser_console_messages: allow
+  browser_press_key: allow
+  browser_hover: allow
+  browser_select_option: allow
+  browser_resize: allow
   gate_list: allow
   gate_status: allow
   task_list: allow
@@ -21,27 +27,6 @@ toolPolicies:
   preview_open: allow
   edit: allow
   bash_bg: allow
-  mcp__playwright__browser_close: allow
-  mcp__playwright__browser_resize: allow
-  mcp__playwright__browser_console_messages: allow
-  mcp__playwright__browser_handle_dialog: allow
-  mcp__playwright__browser_evaluate: allow
-  mcp__playwright__browser_file_upload: allow
-  mcp__playwright__browser_fill_form: allow
-  mcp__playwright__browser_press_key: allow
-  mcp__playwright__browser_type: allow
-  mcp__playwright__browser_wait_for: allow
-  mcp__playwright__browser_select_option: allow
-  mcp__playwright__browser_drag: allow
-  mcp__playwright__browser_take_screenshot: allow
-  mcp__playwright__browser_network_requests: allow
-  mcp__playwright__browser_snapshot: allow
-  mcp__playwright__browser_navigate: allow
-  mcp__playwright__browser_navigate_back: allow
-  mcp__playwright__browser_run_code: allow
-  mcp__playwright__browser_click: allow
-  mcp__playwright__browser_hover: allow
-  mcp__playwright__browser_tabs: allow
 createdAt: 1775146326827
 updatedAt: 1775146382164
 promptTemplate: |-
@@ -74,9 +59,13 @@ promptTemplate: |-
   Your task prompt will tell you how to access the application (URL, build commands, etc.). If you need to start a dev server, use `bash_bg` — **never start servers with `bash` directly** (pipes will hang your session). Poll with `bash_bg(action="logs")` until the server is ready.
 
   ### 2b. Browser tool selection — CRITICAL
-  **Use the non-MCP browser tools**: `browser_navigate`, `browser_screenshot`, `browser_click`, `browser_type`, `browser_eval`, `browser_wait`.
+  **Use the native browser tools**: `browser_navigate`, `browser_screenshot`, `browser_click`, `browser_type`, `browser_eval`, `browser_wait`, `browser_snapshot`, `browser_console_messages`, `browser_press_key`, `browser_hover`, `browser_select_option`, `browser_resize`.
 
-  **Do NOT use `mcp__playwright__*` tools** (e.g. `mcp__playwright__browser_navigate`, `mcp__playwright__browser_snapshot`). The MCP Playwright server is a single shared instance across ALL agent sessions. Other agents and the dev server will navigate your page away mid-test, causing cascading failures.
+  **Do NOT use `mcp__playwright__*` tools** — they are not available. The native browser tools are per-session isolated and cover all QA testing needs.
+
+  **Use `browser_snapshot` for page understanding** — it returns the ARIA accessibility tree, which is more reliable than screenshots for finding interactive elements, reading text content, and understanding page structure. Use it after navigating to a new page.
+
+  **Use `browser_console_messages` for error detection** — check for JavaScript errors and warnings regularly. Call with `level="error"` to filter for errors only.
 
   **Save screenshots using absolute paths** — e.g. `browser_screenshot(savePath="/tmp/qa-workdir/screenshot-01.png")`. Relative paths resolve against the master repo root, not your worktree, so you won't find the files later.
 
@@ -94,7 +83,7 @@ promptTemplate: |-
   - **Visual quality**: Are there layout shifts, overlapping elements, misaligned text, broken styling, or rendering artifacts?
   - **Responsiveness**: Resize the browser and check the layout at different widths (mobile ~375px, tablet ~768px, desktop ~1280px).
   - **Keyboard navigation**: Tab through interactive elements. Can you reach everything? Is focus visible?
-  - **Console health**: Check for JS errors and warnings regularly — silent errors that don't surface visually are still bugs.
+  - **Console health**: Use `browser_console_messages(level="error")` to check for JS errors regularly. Silent errors that don't surface visually are still bugs.
 
   ### 4. Document everything
   Take screenshots of working states, broken states, and before/after comparisons. Screenshots are your evidence — take them proactively, not just when something breaks. Use accessibility snapshots to understand page structure.

--- a/.bobbit/config/tools/browser/browser_console_messages.yaml
+++ b/.bobbit/config/tools/browser/browser_console_messages.yaml
@@ -1,0 +1,105 @@
+name: browser_console_messages
+description: "Return console messages from the current page"
+summary: "Return buffered console messages (errors, warnings, logs) from the current browser page."
+provider:
+  type: bobbit-extension
+  extension: extension.ts
+group: Browser
+docs: |-
+  Captures console.log/error/warn/info output since page load. Filter by level (log, error, warning, info, debug). Use clear=true to reset buffer.
+detail_docs: >-
+  ## Purpose
+
+
+  Return console messages that have been captured from the browser page since it
+  was opened or since the buffer was last cleared. Essential for QA agents to
+  catch silent JavaScript errors, warnings, and debug output without needing to
+  open browser DevTools.
+
+
+  ## Parameters
+
+
+  | Name | Type | Required | Description |
+
+  |------|------|----------|-------------|
+
+  | `level` | string | No | Filter messages by level. Matches Playwright's
+  raw `ConsoleMessage.type()`: `"log"`, `"error"`, `"warning"`, `"info"`,
+  `"debug"`, `"trace"`. If omitted, returns all messages. |
+
+  | `clear` | boolean | No | If `true`, clears the message buffer after
+  returning results. Default `false`. |
+
+
+  ## When to Use
+
+
+  - **Catching JavaScript errors** — filter by `level="error"` to find uncaught
+  exceptions and console.error calls.
+
+  - **Debugging test failures** — check console output for clues about why a
+  page isn't behaving as expected.
+
+  - **Verifying logging behavior** — confirm that expected log messages appear
+  during user interactions.
+
+  - **QA health checks** — scan for warnings and errors after page load.
+
+
+  ## When NOT to Use
+
+
+  - **Monitoring network requests** — console messages don't include network
+  traffic. Use `browser_eval` with the Performance API instead.
+
+  - **Getting page content** — use `browser_snapshot` or `browser_eval`.
+
+
+  ## Examples
+
+
+  ```
+
+  # Get all console messages
+
+  browser_console_messages()
+
+
+  # Get only errors
+
+  browser_console_messages(level="error")
+
+
+  # Get warnings and clear the buffer
+
+  browser_console_messages(level="warning", clear=true)
+
+
+  # Clear all messages without reading (pass clear=true)
+
+  browser_console_messages(clear=true)
+
+  ```
+
+
+  ## Notes / Gotchas
+
+
+  - **Playwright console types are distinct** — `console.log()` produces level
+  `"log"`, while `console.info()` produces `"info"`. These are NOT the same
+  despite similar behavior. The `level` filter matches the raw Playwright type
+  string.
+
+  - **Buffer is capped at 1000 messages** — oldest messages are dropped when
+  the cap is reached (FIFO). Clear periodically on chatty pages.
+
+  - **Buffer survives navigation** — messages persist across in-page
+  navigations (e.g. `browser_navigate` to a new URL). Use `clear=true` to reset
+  between test steps if needed.
+
+  - **Messages are captured from page load** — the listener is attached when the
+  page is created. Messages before the listener attachment are not captured.
+
+  - **Each message includes** — `level` (type string), `text` (message
+  content), `url` (source URL), `timestamp` (epoch ms).

--- a/.bobbit/config/tools/browser/browser_hover.yaml
+++ b/.bobbit/config/tools/browser/browser_hover.yaml
@@ -1,0 +1,92 @@
+name: browser_hover
+description: "Hover over an element by CSS selector"
+summary: "Hover the mouse over an element identified by CSS selector."
+provider:
+  type: bobbit-extension
+  extension: extension.ts
+group: Browser
+docs: |-
+  Triggers hover/mouseover events. Use for tooltips, dropdown menus, and hover states. First match in DOM order.
+detail_docs: >-
+  ## Purpose
+
+
+  Move the mouse cursor over an element identified by a CSS selector, triggering
+  mouseenter, mouseover, and hover events. This activates CSS `:hover` styles
+  and any JavaScript hover event handlers on the element.
+
+
+  ## Parameters
+
+
+  | Name | Type | Required | Description |
+
+  |------|------|----------|-------------|
+
+  | `selector` | string | **Yes** | CSS selector identifying the element to
+  hover over. If multiple elements match, the first one in DOM order is used. |
+
+
+  ## When to Use
+
+
+  - **Tooltips** — hover over an element to trigger a tooltip, then verify its
+  content with `browser_snapshot` or `browser_eval`.
+
+  - **Dropdown menus** — hover over a menu trigger to expand a dropdown.
+
+  - **Hover states** — test that hover styles are applied correctly by hovering
+  then taking a `browser_screenshot`.
+
+  - **Revealing hidden elements** — some UI elements only appear on hover.
+
+
+  ## When NOT to Use
+
+
+  - **Clicking elements** — use `browser_click` for mouse clicks.
+
+  - **Verifying hover styles visually** — this triggers the hover, but to see
+  the result use `browser_screenshot` or `browser_eval` after.
+
+
+  ## Examples
+
+
+  ```
+
+  # Hover over a menu item to expand dropdown
+
+  browser_hover(selector=".nav-menu > li:first-child")
+
+
+  # Trigger a tooltip
+
+  browser_hover(selector="[data-tooltip]")
+
+  browser_snapshot()  # Check tooltip content
+
+
+  # Hover over a button to see hover state
+
+  browser_hover(selector=".cta-button")
+
+  browser_screenshot()  # Capture hover styling
+
+  ```
+
+
+  ## Notes / Gotchas
+
+
+  - **First match only** — if the selector matches multiple elements, the first
+  one in DOM order is hovered. Be specific with your selector.
+
+  - **Element must be visible** — hidden elements or elements with zero
+  dimensions cannot be hovered.
+
+  - **Hover state persists** — the element remains hovered until another
+  element is hovered or clicked.
+
+  - **Scrolls into view** — the browser scrolls the element into the viewport
+  before hovering.

--- a/.bobbit/config/tools/browser/browser_press_key.yaml
+++ b/.bobbit/config/tools/browser/browser_press_key.yaml
@@ -1,0 +1,113 @@
+name: browser_press_key
+description: "Press a keyboard key"
+summary: "Press a keyboard key (Enter, Tab, Escape, etc.) in the current browser page."
+provider:
+  type: bobbit-extension
+  extension: extension.ts
+group: Browser
+docs: |-
+  Supports single keys (Enter, Tab, Escape) and combinations (Control+A, Shift+Tab). Key names follow Playwright's key naming.
+detail_docs: >-
+  ## Purpose
+
+
+  Press a single key or key combination on the keyboard. Dispatches keydown,
+  keypress, and keyup events to the currently focused element. Useful for form
+  submission, keyboard navigation, triggering shortcuts, and interacting with
+  elements that respond to keyboard input.
+
+
+  ## Parameters
+
+
+  | Name | Type | Required | Description |
+
+  |------|------|----------|-------------|
+
+  | `key` | string | **Yes** | Key to press. Single keys: `"Enter"`, `"Tab"`,
+  `"Escape"`, `"Backspace"`, `"ArrowDown"`, `"ArrowUp"`, `"Space"`, `"Delete"`.
+  Combinations: `"Control+A"`, `"Shift+Tab"`, `"Meta+C"`. |
+
+
+  ## When to Use
+
+
+  - **Form submission** — press Enter to submit a form after filling fields.
+
+  - **Keyboard navigation** — Tab between form fields, Arrow keys in menus.
+
+  - **Keyboard shortcuts** — trigger Ctrl+A (select all), Escape (close
+  modal), etc.
+
+  - **Dropdown interaction** — open and navigate select menus with Arrow keys.
+
+  - **Dismissing dialogs** — press Escape to close modals or popups.
+
+
+  ## When NOT to Use
+
+
+  - **Typing text into inputs** — use `browser_type` for text entry. This tool
+  is for single key presses, not sequences of characters.
+
+  - **Clicking elements** — use `browser_click` for mouse interactions.
+
+
+  ## Examples
+
+
+  ```
+
+  # Submit a form
+
+  browser_type(selector="#search-input", text="query")
+
+  browser_press_key(key="Enter")
+
+
+  # Tab to next field
+
+  browser_press_key(key="Tab")
+
+
+  # Close a modal
+
+  browser_press_key(key="Escape")
+
+
+  # Select all text
+
+  browser_press_key(key="Control+A")
+
+
+  # Navigate a dropdown
+
+  browser_press_key(key="ArrowDown")
+
+  browser_press_key(key="ArrowDown")
+
+  browser_press_key(key="Enter")
+
+
+  # Shift-Tab to previous field
+
+  browser_press_key(key="Shift+Tab")
+
+  ```
+
+
+  ## Notes / Gotchas
+
+
+  - **Key names are case-sensitive** — use `"Enter"` not `"enter"`, `"Tab"` not
+  `"tab"`. Follow Playwright's
+  [key naming](https://playwright.dev/docs/api/class-keyboard#keyboard-press).
+
+  - **Combinations use `+`** — `"Control+A"`, `"Shift+Tab"`, `"Meta+C"`. The
+  modifier is held during the key press.
+
+  - **Events go to focused element** — if no element is focused, events go to
+  the document body. Use `browser_click` to focus an element first if needed.
+
+  - **Single key press only** — this dispatches one press. For repeated presses,
+  call the tool multiple times.

--- a/.bobbit/config/tools/browser/browser_resize.yaml
+++ b/.bobbit/config/tools/browser/browser_resize.yaml
@@ -1,0 +1,102 @@
+name: browser_resize
+description: "Resize the browser viewport"
+summary: "Resize the browser viewport to specified width and height in pixels."
+provider:
+  type: bobbit-extension
+  extension: extension.ts
+group: Browser
+docs: |-
+  Changes viewport dimensions. Use for responsive design testing. Common sizes: mobile 375x667, tablet 768x1024, desktop 1280x720.
+detail_docs: >-
+  ## Purpose
+
+
+  Resize the browser viewport to a specific width and height in pixels. This
+  triggers responsive design breakpoints, media queries, and any resize event
+  handlers. Essential for testing how pages adapt to different screen sizes.
+
+
+  ## Parameters
+
+
+  | Name | Type | Required | Description |
+
+  |------|------|----------|-------------|
+
+  | `width` | number | **Yes** | Viewport width in pixels. |
+
+  | `height` | number | **Yes** | Viewport height in pixels. |
+
+
+  ## When to Use
+
+
+  - **Responsive design testing** — verify layouts at mobile, tablet, and
+  desktop breakpoints.
+
+  - **Testing media queries** — confirm that CSS media queries activate at the
+  correct widths.
+
+  - **Viewport-dependent features** — test elements that show/hide or reflow
+  based on screen size.
+
+  - **Screenshot comparisons** — capture pages at specific sizes for visual
+  regression testing.
+
+
+  ## When NOT to Use
+
+
+  - **Testing zoom behavior** — this changes viewport dimensions, not zoom
+  level.
+
+
+  ## Examples
+
+
+  ```
+
+  # Test mobile layout
+
+  browser_resize(width=375, height=667)
+
+  browser_screenshot()
+
+
+  # Test tablet layout
+
+  browser_resize(width=768, height=1024)
+
+  browser_screenshot()
+
+
+  # Test desktop layout
+
+  browser_resize(width=1280, height=720)
+
+  browser_screenshot()
+
+
+  # Test wide desktop
+
+  browser_resize(width=1920, height=1080)
+
+  browser_screenshot()
+
+  ```
+
+
+  ## Notes / Gotchas
+
+
+  - **Triggers resize events** — JavaScript `resize` event handlers and CSS
+  media queries respond to the viewport change.
+
+  - **Persists until changed** — the viewport stays at the new size for all
+  subsequent operations until resized again.
+
+  - **Common breakpoints** — mobile: 375x667 (iPhone SE), 390x844 (iPhone 14);
+  tablet: 768x1024 (iPad); desktop: 1280x720, 1920x1080.
+
+  - **Minimum dimensions** — very small values may cause rendering issues.
+  Stay above 320px width for realistic testing.

--- a/.bobbit/config/tools/browser/browser_select_option.yaml
+++ b/.bobbit/config/tools/browser/browser_select_option.yaml
@@ -1,0 +1,92 @@
+name: browser_select_option
+description: "Select option in a dropdown"
+summary: "Select one or more options in a <select> dropdown by value."
+provider:
+  type: bobbit-extension
+  extension: extension.ts
+group: Browser
+docs: |-
+  Values are matched against option value attributes. For multi-select, pass multiple values. Use browser_eval for label-based selection.
+detail_docs: >-
+  ## Purpose
+
+
+  Select one or more options in a `<select>` HTML dropdown element. Values are
+  matched against the `value` attribute of `<option>` elements. For single
+  selects, pass one value; for multi-selects, pass multiple values.
+
+
+  ## Parameters
+
+
+  | Name | Type | Required | Description |
+
+  |------|------|----------|-------------|
+
+  | `selector` | string | **Yes** | CSS selector identifying the `<select>`
+  element. |
+
+  | `values` | string[] | **Yes** | Array of option values to select. Matched
+  against `<option value="...">`. |
+
+
+  ## When to Use
+
+
+  - **Form testing** — select options in dropdown fields as part of form
+  fill flows.
+
+  - **Filter controls** — change filter/sort dropdowns to test different views.
+
+  - **Multi-select** — select multiple options in `<select multiple>` elements.
+
+
+  ## When NOT to Use
+
+
+  - **Custom dropdown components** — non-native dropdowns (React Select,
+  Material UI, etc.) use divs, not `<select>`. Use `browser_click` on the
+  trigger and options instead.
+
+  - **Selecting by visible text** — this tool matches by `value` attribute.
+  To select by label text, use `browser_eval` with custom JavaScript:
+  `browser_eval(expression="document.querySelector('select').selectedIndex = 2")`
+
+
+  ## Examples
+
+
+  ```
+
+  # Select a single option
+
+  browser_select_option(selector="#country", values=["US"])
+
+
+  # Select multiple options in a multi-select
+
+  browser_select_option(selector="#tags", values=["bug", "urgent", "frontend"])
+
+
+  # Select by a form field name
+
+  browser_select_option(selector="select[name='role']", values=["admin"])
+
+  ```
+
+
+  ## Notes / Gotchas
+
+
+  - **Matches `value` attribute, not label** — `<option value="us">United
+  States</option>` is selected with `values=["us"]`, not
+  `values=["United States"]`.
+
+  - **First match only** — if the selector matches multiple `<select>` elements,
+  the first one in DOM order is used.
+
+  - **Fires change event** — the `change` event is dispatched, triggering any
+  associated JavaScript handlers.
+
+  - **Does not work with custom dropdowns** — only native HTML `<select>`
+  elements. For custom components, use `browser_click`.

--- a/.bobbit/config/tools/browser/browser_snapshot.yaml
+++ b/.bobbit/config/tools/browser/browser_snapshot.yaml
@@ -1,0 +1,105 @@
+name: browser_snapshot
+description: "Capture accessibility snapshot of the current page"
+summary: "Return the ARIA accessibility tree of the current browser page as structured text."
+provider:
+  type: bobbit-extension
+  extension: extension.ts
+group: Browser
+docs: |-
+  Returns ARIA YAML showing page structure (headings, buttons, links, etc.). Better than screenshots for understanding page layout. Use after browser_navigate.
+detail_docs: >-
+  ## Purpose
+
+
+  Capture the ARIA accessibility tree of the current page as structured YAML
+  text. This gives agents a complete understanding of the page layout, headings,
+  buttons, links, form fields, and other interactive elements — without needing
+  visual processing of screenshots. It is the preferred way to understand page
+  structure before interacting with elements.
+
+
+  ## Parameters
+
+
+  This tool takes no parameters.
+
+
+  ## When to Use
+
+
+  - **Understanding page layout** — after navigating to a page, use this to see
+  all interactive elements and their roles.
+
+  - **Finding interactive elements** — discover button labels, link text, and
+  input fields to target with `browser_click` or `browser_type`.
+
+  - **Verifying content** — check that expected headings, text, and structure
+  are present.
+
+  - **Accessibility testing** — verify that ARIA roles, labels, and hierarchy
+  are correct.
+
+
+  ## When NOT to Use
+
+
+  - **Visual styling verification** — ARIA snapshots don't include CSS styles,
+  colors, or layout. Use `browser_screenshot` for visual checks.
+
+  - **Getting raw HTML** — use `browser_eval` with `document.body.innerHTML`
+  for raw markup.
+
+
+  ## Examples
+
+
+  ```
+
+  # Get page structure after navigation
+
+  browser_navigate(url="https://example.com")
+
+  browser_snapshot()
+
+  # Returns ARIA YAML like:
+
+  # - heading "Example Domain" [level=1]
+
+  # - paragraph: "This domain is for use in illustrative examples..."
+
+  # - link "More information..."
+
+
+  # Discover form fields
+
+  browser_navigate(url="https://example.com/login")
+
+  browser_snapshot()
+
+  # Returns:
+
+  # - heading "Login" [level=1]
+
+  # - textbox "Username"
+
+  # - textbox "Password"
+
+  # - button "Sign In"
+
+  ```
+
+
+  ## Notes / Gotchas
+
+
+  - **Returns ARIA YAML format** — the output is a YAML-like tree of ARIA
+  roles, names, and properties. Not raw HTML.
+
+  - **Requires a page to be open** — call `browser_navigate` first. Returns an
+  error if no page is active.
+
+  - **Reflects current DOM state** — captures the page as-is, including any
+  dynamic changes from JavaScript.
+
+  - **Better than screenshots for agents** — structured text is faster to
+  process and more reliable than image analysis for finding elements.

--- a/.bobbit/config/tools/browser/extension.ts
+++ b/.bobbit/config/tools/browser/extension.ts
@@ -20,9 +20,28 @@ let playwrightMod: typeof import("playwright") | null = null;
 
 let browser: import("playwright").Browser | null = null;
 let page: import("playwright").Page | null = null;
+let currentListenerPage: import("playwright").Page | null = null;
+const consoleMessages: Array<{level: string, text: string, url: string, timestamp: number}> = [];
+
+function attachConsoleListener(p: import("playwright").Page) {
+	currentListenerPage = p;
+	consoleMessages.length = 0;
+	p.on('console', (msg) => {
+		consoleMessages.push({
+			level: msg.type(),
+			text: msg.text(),
+			url: msg.location().url,
+			timestamp: Date.now(),
+		});
+		if (consoleMessages.length > 1000) consoleMessages.shift();
+	});
+}
 
 async function ensurePage(): Promise<import("playwright").Page> {
-	if (page && !page.isClosed()) return page;
+	if (page && !page.isClosed()) {
+		if (page !== currentListenerPage) attachConsoleListener(page);
+		return page;
+	}
 
 	if (!playwrightMod) throw new Error("playwright is not available");
 
@@ -33,6 +52,7 @@ async function ensurePage(): Promise<import("playwright").Page> {
 		viewport: { width: 1280, height: 720 },
 	});
 	page = await context.newPage();
+	attachConsoleListener(page);
 	return page;
 }
 
@@ -42,6 +62,8 @@ async function cleanup() {
 	}
 	browser = null;
 	page = null;
+	consoleMessages.length = 0;
+	currentListenerPage = null;
 }
 
 /** Race a promise against an AbortSignal. Throws if aborted. */
@@ -220,6 +242,125 @@ export default function (pi: ExtensionAPI) {
 			);
 			return {
 				content: [{ type: "text", text: `Element visible: ${params.selector}` }],
+				details: {},
+			};
+		},
+	});
+
+	// ── browser_snapshot ─────────────────────────────────────────────
+	pi.registerTool({
+		name: "browser_snapshot",
+		label: "Browser Snapshot",
+		description: "Capture accessibility snapshot of the current page. Returns the ARIA accessibility tree as structured YAML text.",
+		parameters: Type.Object({}),
+		async execute(_toolCallId, _params, signal) {
+			const p = await withAbort(ensurePage(), signal);
+			const snapshot = await withAbort(p.locator('body').ariaSnapshot(), signal);
+			return {
+				content: [{ type: "text", text: snapshot || "(empty page)" }],
+				details: {},
+			};
+		},
+	});
+
+	// ── browser_console_messages ─────────────────────────────────────
+	pi.registerTool({
+		name: "browser_console_messages",
+		label: "Browser Console Messages",
+		description: "Returns console messages (errors, warnings, info, logs) captured from the current page.",
+		parameters: Type.Object({
+			level: Type.Optional(Type.String({ description: 'Filter by message level: "log", "error", "warning", "info", "debug", "trace"' })),
+			clear: Type.Optional(Type.Boolean({ description: "Clear the message buffer after returning. Default false." })),
+		}),
+		async execute(_toolCallId, params, _signal) {
+			// Ensure page exists so listener is attached, but don't need the page ref
+			await withAbort(ensurePage(), _signal);
+			const filtered = params.level
+				? consoleMessages.filter((m) => m.level === params.level)
+				: [...consoleMessages];
+			const text = JSON.stringify(filtered, null, 2);
+			if (params.clear) {
+				consoleMessages.length = 0;
+			}
+			return {
+				content: [{ type: "text", text: filtered.length > 0 ? text : "No console messages captured." }],
+				details: {},
+			};
+		},
+	});
+
+	// ── browser_press_key ────────────────────────────────────────────
+	pi.registerTool({
+		name: "browser_press_key",
+		label: "Browser Press Key",
+		description: "Press a key on the keyboard.",
+		parameters: Type.Object({
+			key: Type.String({ description: 'Key to press, e.g. "Enter", "Tab", "Escape", "Control+A"' }),
+		}),
+		async execute(_toolCallId, params, signal) {
+			const p = await withAbort(ensurePage(), signal);
+			await withAbort(p.keyboard.press(params.key), signal);
+			return {
+				content: [{ type: "text", text: `Pressed key: ${params.key}` }],
+				details: {},
+			};
+		},
+	});
+
+	// ── browser_hover ────────────────────────────────────────────────
+	pi.registerTool({
+		name: "browser_hover",
+		label: "Browser Hover",
+		description: "Hover over an element on the page by CSS selector.",
+		parameters: Type.Object({
+			selector: Type.String({ description: "CSS selector of the element to hover over" }),
+		}),
+		async execute(_toolCallId, params, signal) {
+			const p = await withAbort(ensurePage(), signal);
+			await withAbort(p.locator(params.selector).first().hover({ timeout: 10_000 }), signal);
+			return {
+				content: [{ type: "text", text: `Hovered: ${params.selector}` }],
+				details: {},
+			};
+		},
+	});
+
+	// ── browser_select_option ────────────────────────────────────────
+	pi.registerTool({
+		name: "browser_select_option",
+		label: "Browser Select Option",
+		description: "Select an option in a <select> dropdown by value.",
+		parameters: Type.Object({
+			selector: Type.String({ description: "CSS selector of the <select> element" }),
+			values: Type.Array(Type.String(), { description: "Option values to select" }),
+		}),
+		async execute(_toolCallId, params, signal) {
+			const p = await withAbort(ensurePage(), signal);
+			const selected = await withAbort(
+				p.locator(params.selector).first().selectOption(params.values, { timeout: 10_000 }),
+				signal,
+			);
+			return {
+				content: [{ type: "text", text: `Selected option(s) in ${params.selector}: ${selected.join(", ")}` }],
+				details: {},
+			};
+		},
+	});
+
+	// ── browser_resize ───────────────────────────────────────────────
+	pi.registerTool({
+		name: "browser_resize",
+		label: "Browser Resize",
+		description: "Resize the browser viewport.",
+		parameters: Type.Object({
+			width: Type.Number({ description: "Viewport width in pixels" }),
+			height: Type.Number({ description: "Viewport height in pixels" }),
+		}),
+		async execute(_toolCallId, params, signal) {
+			const p = await withAbort(ensurePage(), signal);
+			await withAbort(p.setViewportSize({ width: params.width, height: params.height }), signal);
+			return {
+				content: [{ type: "text", text: `Resized viewport to ${params.width}x${params.height}` }],
 				details: {},
 			};
 		},

--- a/.claude/skills/qa-test/SKILL.md
+++ b/.claude/skills/qa-test/SKILL.md
@@ -10,7 +10,10 @@ You are running QA testing for a goal. This protocol stands up an isolated copy 
 
 ## Prerequisites
 
-- You need browser tools available. **Use the non-MCP browser tools** (`browser_navigate`, `browser_screenshot`, `browser_click`, `browser_type`, `browser_eval`, `browser_wait`) — NOT the `mcp__playwright__*` tools. The MCP Playwright browser is a single shared instance across all sessions — other agents and the dev server will hijack your page. The non-MCP browser tools give you an isolated browser instance.
+- You need browser tools available. **Use the native browser tools** — NOT the `mcp__playwright__*` tools. The MCP Playwright browser is a single shared instance across all sessions — other agents and the dev server will hijack your page. The native browser tools give you an isolated browser instance per session.
+- **Available native browser tools:** `browser_navigate`, `browser_screenshot`, `browser_click`, `browser_type`, `browser_eval`, `browser_wait`, `browser_snapshot`, `browser_console_messages`, `browser_press_key`, `browser_hover`, `browser_select_option`, `browser_resize`
+- **`browser_snapshot`** is the best way to understand page structure — it returns an ARIA accessibility tree with element roles, names, and refs. Use it instead of screenshots when you need to find interactive elements or verify page content.
+- **`browser_console_messages`** captures JS console output. Call with `level="error"` after each navigation to catch silent errors.
 - The project must have `qa_*` keys in `.bobbit/config/project.yaml`
 
 ## Step 1: Read Configuration
@@ -102,21 +105,33 @@ If the server doesn't become healthy after 60 seconds, document the failure and 
 
 Substitute `$PORT` and `$TOKEN` in the browser entry URL. Navigate to it using `browser_navigate` (NOT `mcp__playwright__browser_navigate`).
 
-**IMPORTANT — Use the non-MCP browser tools only:**
+**IMPORTANT — Use the native browser tools only:**
 - `browser_navigate(url=...)` — navigate to your ephemeral server
 - `browser_screenshot(savePath="...")` — take screenshots
+- `browser_snapshot()` — get ARIA accessibility tree (best for finding elements)
 - `browser_click(selector=...)` — click elements
 - `browser_type(selector=..., text=...)` — type into inputs
 - `browser_eval(expression=...)` — run JavaScript on page
 - `browser_wait(selector=...)` — wait for elements
+- `browser_press_key(key=...)` — press keyboard keys (Enter, Tab, Escape, etc.)
+- `browser_hover(selector=...)` — hover over elements (tooltips, dropdowns)
+- `browser_select_option(selector=..., value=...)` — select dropdown options
+- `browser_resize(width=..., height=...)` — resize viewport for responsive testing
+- `browser_console_messages(level=...)` — check for JS errors
 
 Do NOT use `mcp__playwright__*` tools — they share a single browser instance across all sessions and the dev server WILL hijack your page mid-test.
 
-**After each navigation or significant interaction**, verify you're still on the right URL:
-```
-browser_eval(expression="window.location.href")
-```
-If the URL doesn't match your ephemeral server (check the port), re-navigate immediately.
+**After each navigation or significant interaction:**
+1. Verify you're still on the right URL:
+   ```
+   browser_eval(expression="window.location.href")
+   ```
+   If the URL doesn't match your ephemeral server (check the port), re-navigate immediately.
+2. Check for JS errors:
+   ```
+   browser_console_messages(level="error")
+   ```
+   Log any errors in your scenario results — silent JS failures are common QA findings.
 
 For each scenario from your task prompt (respecting `qa_max_scenarios`):
 


### PR DESCRIPTION
## Summary

Add 6 new native browser tools to eliminate QA agent dependency on the shared MCP Playwright server, which caused cascading failures when multiple agents fought over one browser page.

## Changes

### New native browser tools (`.bobbit/config/tools/browser/extension.ts`)
- **`browser_snapshot`** — ARIA accessibility tree via `page.locator('body').ariaSnapshot()`
- **`browser_console_messages`** — Buffered console messages with optional level filter and clear
- **`browser_press_key`** — Keyboard input via `page.keyboard.press()`
- **`browser_hover`** — Hover over elements by CSS selector
- **`browser_select_option`** — Select dropdown options by value
- **`browser_resize`** — Viewport resize via `page.setViewportSize()`

Infrastructure: `consoleMessages` buffer (1000 cap, FIFO), idempotent `attachConsoleListener()` with page tracking.

### YAML tool definitions
6 new YAML files in `.bobbit/config/tools/browser/` following existing pattern.

### QA tester role update (`.bobbit/config/roles/qa-tester.yaml`)
- Added 6 new native tools to `toolPolicies` with `allow`
- Removed all 21 `mcp__playwright__*` entries
- Updated prompt template with guidance on `browser_snapshot` and `browser_console_messages`

### Documentation (`.claude/skills/qa-test/SKILL.md`)
- Updated tool list to include all 12 native browser tools
- Added usage guidance for new tools

## Testing
- Type-check passes
- 330 unit tests pass
- 362 E2E tests pass
- Master merged, no conflicts

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)