### PR TITLE
Fix QA Screenshot Paths

### DIFF
--- a/.bobbit/config/roles/qa-tester.yaml
+++ b/.bobbit/config/roles/qa-tester.yaml
@@ -81,7 +81,7 @@ promptTemplate: |-
 
   **Use `browser_console_messages` for error detection** — check for JavaScript errors and warnings regularly. Call with `level="error"` to filter for errors only.
 
-  **Save screenshots using absolute paths** — e.g. `browser_screenshot(savePath="/tmp/qa-workdir/screenshot-01.png")`. Relative paths resolve against the master repo root, not your worktree, so you won't find the files later.
+  **Capture screenshots inline** — call `browser_screenshot()` without `savePath`. The tool response includes base64 image data directly. Use this data to embed screenshots in your HTML report as `data:image/png;base64,<data>` URIs. No need to save to disk or read back.
 
   **After navigating**, always verify you're on the right URL:
   ```

--- a/.bobbit/config/tools/browser/extension.ts
+++ b/.bobbit/config/tools/browser/extension.ts
@@ -125,7 +125,7 @@ export default function (pi: ExtensionAPI) {
 			savePath: Type.Optional(Type.String({ description: "File path to save the screenshot to (png). Optional." })),
 			fullPage: Type.Optional(Type.Boolean({ description: "Capture the full scrollable page. Default false." })),
 		}),
-		async execute(_toolCallId, params, signal) {
+		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 			const p = await withAbort(ensurePage(), signal);
 
 			let buffer: Buffer;
@@ -136,16 +136,17 @@ export default function (pi: ExtensionAPI) {
 				buffer = await withAbort(p.screenshot({ type: "png", fullPage: params.fullPage ?? false }), signal) as Buffer;
 			}
 
+			let savedTo: string | undefined;
 			if (params.savePath) {
-				const abs = path.resolve(params.savePath);
+				const abs = path.isAbsolute(params.savePath) ? params.savePath : path.resolve(ctx.cwd, params.savePath);
 				fs.mkdirSync(path.dirname(abs), { recursive: true });
 				fs.writeFileSync(abs, buffer);
+				savedTo = abs;
 			}
 
 			const base64 = buffer.toString("base64");
 			const url = await p.url();
 			const title = await p.title();
-			const savedTo = params.savePath ? path.resolve(params.savePath) : undefined;
 
 			return {
 				content: [

--- a/.bobbit/config/workflows/bug-fix.yaml
+++ b/.bobbit/config/workflows/bug-fix.yaml
@@ -183,9 +183,10 @@ gates:
 
           ## Critical Rules
 
-          1. **Save screenshots to absolute paths in $WORK_DIR** — never use relative paths.
-             Relative paths save to the master repo root, not your worktree. Example:
-             `browser_screenshot(savePath="/tmp/qa-work-xxx/screenshot-01.png")`
+          1. **Capture screenshots inline** — call `browser_screenshot()` without `savePath`.
+             The tool response includes base64 image data directly. Use this data to embed
+             screenshots in your HTML report as `data:image/png;base64,<data>` URIs.
+             No need to save to disk or read back.
 
           2. **Verify your port is unique** — check `cat .bobbit/state/gateway-url` to see
              the dev server port. Your ephemeral server MUST use a different port. If port

--- a/.bobbit/config/workflows/feature.yaml
+++ b/.bobbit/config/workflows/feature.yaml
@@ -144,9 +144,10 @@ gates:
 
           ## Critical Rules
 
-          1. **Save screenshots to absolute paths in $WORK_DIR** — never use relative paths.
-             Relative paths save to the master repo root, not your worktree. Example:
-             `browser_screenshot(savePath="/tmp/qa-work-xxx/screenshot-01.png")`
+          1. **Capture screenshots inline** — call `browser_screenshot()` without `savePath`.
+             The tool response includes base64 image data directly. Use this data to embed
+             screenshots in your HTML report as `data:image/png;base64,<data>` URIs.
+             No need to save to disk or read back.
 
           2. **Verify your port is unique** — check `cat .bobbit/state/gateway-url` to see
              the dev server port. Your ephemeral server MUST use a different port. If port

--- a/.claude/skills/qa-test/SKILL.md
+++ b/.claude/skills/qa-test/SKILL.md
@@ -112,7 +112,7 @@ Substitute `$PORT` and `$TOKEN` in the browser entry URL. Navigate to it using `
 
 **Available browser tools:**
 - `browser_navigate(url=...)` — navigate to your ephemeral server
-- `browser_screenshot(savePath="...")` — take screenshots (always use absolute paths in $WORK_DIR)
+- `browser_screenshot()` — take screenshots (returns base64 in tool response — no need to save to disk)
 - `browser_snapshot()` — get ARIA accessibility tree (best for understanding page structure and finding elements)
 - `browser_click(selector=...)` — click elements
 - `browser_type(selector=..., text=...)` — type into inputs
@@ -147,18 +147,13 @@ For each scenario from your task prompt (respecting `qa_max_scenarios`):
 3. **After**: Take a screenshot documenting the result
 4. **Verdict**: Record PASS, FAIL, or SKIPPED with a clear explanation
 
-Use `browser_screenshot(savePath="$WORK_DIR/screenshot-N.png")` to save screenshots — always use **absolute paths** in `$WORK_DIR`, never relative paths (relative paths resolve against the master repo root, not your worktree).
+Call `browser_screenshot()` (no `savePath` needed). The tool response includes a `{ type: "image", data: "<base64>" }` content block — note this base64 string for each screenshot. You will embed these directly in the HTML report in Step 7.
 
 Track elapsed time. If `qa_max_duration_minutes` is exceeded, stop testing immediately and proceed to report generation with partial results.
 
 ## Step 7: Produce HTML Report
 
-Write a self-contained HTML report. Screenshots should be embedded as base64 data URIs. Use the **absolute paths** from Step 6:
-```bash
-base64 -w0 "$WORK_DIR/screenshot-1.png"
-```
-
-On Windows/MSYS, use `base64 -w 0` (with space) or `cat "$WORK_DIR/screenshot-1.png" | base64 | tr -d '\n'`.
+Write a self-contained HTML report. Embed screenshots using the base64 data returned directly by `browser_screenshot()` in Step 6 — each tool response contains `{ type: "image", data: "<base64>" }`. Use this data in `<img>` tags as `data:image/png;base64,<data>` URIs. No need to save screenshots to disk or read them back.
 
 The report structure:
 


### PR DESCRIPTION
## Summary

Fix QA agents' inability to reliably find saved screenshots when building HTML reports.

### Changes

**Part 1: Fix savePath resolution (extension.ts)**
- `browser_screenshot`'s `savePath` now resolves relative paths against the agent's session working directory (`ctx.cwd`) instead of `process.cwd()` (the server root)
- Absolute paths pass through unchanged for backward compatibility

**Part 2: Eliminate disk round-trip (SKILL.md)**
- Updated QA skill to use base64 data returned directly by `browser_screenshot` instead of saving to disk and reading back with `base64 -w0`
- Removed fragile Windows workaround for `base64` command

**Part 3: Update workflow YAML prompts**
- Updated Critical Rule #1 in both `feature.yaml` and `bug-fix.yaml` QA prompts to match the new inline base64 approach

**Part 4: Update qa-tester role**
- Updated screenshot guidance in `qa-tester.yaml` to match the new approach

### Files Changed
- `.bobbit/config/tools/browser/extension.ts`
- `.claude/skills/qa-test/SKILL.md`
- `.bobbit/config/workflows/feature.yaml`
- `.bobbit/config/workflows/bug-fix.yaml`
- `.bobbit/config/roles/qa-tester.yaml`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)