### PR TITLE
Always Show Project Rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Most AI coding tools are either locked inside an IDE or limited to a terminal. B
 ## Features
 
 ### Multi-Project Support
-Register multiple project directories with a single Bobbit server. Each project gets its own `.bobbit/` directory for config and state. Config cascades hierarchically (global → server → project). Sessions, goals, and search are scoped per project, with cross-project search enabled by default. The sidebar groups work by project when multiple are registered.
+Register multiple project directories with a single Bobbit server. Each project gets its own `.bobbit/` directory for config and state. Config cascades hierarchically (global → server → project). Sessions, goals, and search are scoped per project, with cross-project search enabled by default. The sidebar always groups work under collapsible project folder rows. When only one project is registered, its row defaults to expanded.
 
 ### Sessions
 Each session is a running agent with its own conversation and persistence. Run multiple sessions in parallel, each working on different parts of your project. Connect from multiple devices at once.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -139,7 +139,7 @@ After a server restart, the context bar may show wrong info (e.g. 200k instead o
 - Server CWD auto-registered as default project via `ensureDefaultProject()` on startup
 - `GET /api/projects` to list all registered projects
 - Sessions/goals not appearing? Check `projectId` field matches the expected project. Verify the correct project's `sessions.json` / `goals.json` contains the record
-- Sidebar not grouping? Only groups when multiple projects are registered
+- Sidebar not grouping? Project folder rows are always shown — check that `state.projects` is populated and `renderProjectHeader()` is being called
 - Project registration failing? `rootPath` must be absolute and exist on disk; duplicate paths are rejected
 - Search not filtering by project? Verify `?projectId=` query param is passed; each project has its own `search.db`
 - Config not cascading? Check all three `.bobbit/config/` directories (global, server, project) and verify `resolveScalarConfig()` / `resolveEntities()` return expected scope

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -193,7 +193,7 @@ Selecting a palette seeds the color fields from `PALETTE_PRIMARY_COLORS`; the us
 
 ### Sidebar grouping
 
-When multiple projects are registered, the sidebar groups sessions and goals by project:
+The sidebar always groups sessions and goals under collapsible project folder rows — even with a single project. This unified code path avoids duplication between single-project and multi-project layouts.
 
 ```
 ├── Project A (collapsible)
@@ -206,7 +206,7 @@ When multiple projects are registered, the sidebar groups sessions and goals by 
 ├── [+ Add Project]
 ```
 
-Single-project mode minimizes visual noise — no project headers shown.
+When only one project is registered, its folder row defaults to expanded so there is no extra click required. Each project row shows a folder icon, project name, settings gear, and new-goal button.
 
 ### REST API
 

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -247,10 +247,8 @@ function renderMobileLanding() {
 								</div>`
 							: html`
 								${(() => {
-									const multiProject = state.projects.length > 1;
-									if (multiProject) {
-										// Group goals and sessions by project
-										const projectMap = new Map<string, { goals: typeof liveGoals; sessions: typeof ungroupedSessions }>();
+									// Group goals and sessions by project
+									const projectMap = new Map<string, { goals: typeof liveGoals; sessions: typeof ungroupedSessions }>();
 										for (const p of state.projects) projectMap.set(p.id, { goals: [], sessions: [] });
 										const defaultId = state.projects[0]?.id || "";
 										for (const g of liveGoals) {
@@ -314,7 +312,7 @@ function renderMobileLanding() {
 																>${icon(Plus, "sm")}</button>
 																<button
 																	class="p-1.5 rounded text-muted-foreground active:bg-secondary/50 transition-colors"
-																	@click=${(e: Event) => { e.stopPropagation(); toggleRolePicker(e); }}
+																	@click=${(e: Event) => { e.stopPropagation(); toggleRolePicker(e, undefined, { projectId: project.id, projectName: project.name, projectCwd: project.rootPath }); }}
 																	title="New session with role"
 																>${icon(ChevronDown, "sm")}</button>
 																${renderRolePickerDropdown()}
@@ -329,63 +327,6 @@ function renderMobileLanding() {
 												</div>` : ""}
 											`;
 										})}`;
-									}
-									// Single project — flat layout
-									return html`
-										${liveGoals.map((goal, i) => html`
-											${i > 0 ? html`<div class="border-t border-border/30 my-1 mx-2"></div>` : ""}
-											${renderGoalGroup(goal)}
-										`)}
-										${liveGoals.length > 0 ? html`
-											<div class="border-t border-border/30 my-1 mx-2"></div>
-											<div class="flex flex-col gap-0.5">
-												<div class="flex items-center gap-1.5 pl-0 pr-2 py-1.5 rounded-md cursor-pointer active:bg-secondary/50 transition-colors"
-													@click=${() => { setUngroupedExpanded(!ungroupedExpanded); renderApp(); }}>
-													<span class="text-sm text-muted-foreground shrink-0 select-none" style="width:14px;text-align:center;">${isUngroupedExpanded ? "▾" : "▸"}</span>
-													<span class="shrink-0 text-muted-foreground">${icon(MessagesSquare, "sm")}</span>
-												<span class="flex-1 text-sm text-muted-foreground uppercase tracking-wider font-medium">Sessions</span>
-													<div class="flex items-center relative">
-														<button
-															class="p-2 rounded text-muted-foreground active:bg-secondary/50 transition-colors"
-															@click=${(e: Event) => { e.stopPropagation(); createAndConnectSession(); }}
-															title="New session"
-														>${state.creatingSession && !state.creatingSessionForGoalId
-															? html`<svg class="animate-spin" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>`
-															: icon(Plus, "sm")}</button>
-														<button
-															class="p-1.5 rounded text-muted-foreground active:bg-secondary/50 transition-colors"
-															@click=${toggleRolePicker}
-															title="New session with role"
-														>${icon(ChevronDown, "sm")}</button>
-														${renderRolePickerDropdown()}
-													</div>
-												</div>
-												${isUngroupedExpanded ? html`<div class="flex flex-col gap-0.5" style="padding-left:${INDENT}px;">${ungroupedSessions.map(renderSessionRow)}</div>` : ""}
-											</div>
-										` : ungroupedSessions.length > 0 ? html`
-											<div class="flex flex-col gap-0.5">
-												<div class="flex items-center gap-1.5 pl-0 pr-2 py-1.5">
-													<span class="flex-1 text-sm text-muted-foreground uppercase tracking-wider font-medium flex items-center gap-1.5" style="padding-left:${INDENT}px;"><span class="shrink-0">${icon(MessagesSquare, "sm")}</span> Sessions</span>
-													<div class="flex items-center relative">
-														<button
-															class="p-2 rounded text-muted-foreground active:bg-secondary/50 transition-colors"
-															@click=${() => createAndConnectSession()}
-															title="New session"
-														>${state.creatingSession && !state.creatingSessionForGoalId
-															? html`<svg class="animate-spin" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>`
-															: icon(Plus, "sm")}</button>
-														<button
-															class="p-1.5 rounded text-muted-foreground active:bg-secondary/50 transition-colors"
-															@click=${toggleRolePicker}
-															title="New session with role"
-														>${icon(ChevronDown, "sm")}</button>
-														${renderRolePickerDropdown()}
-													</div>
-												</div>
-												<div class="flex flex-col gap-0.5" style="padding-left:${INDENT}px;">${ungroupedSessions.map(renderSessionRow)}</div>
-											</div>
-										` : ""}
-									`;
 								})()}
 								${renderStaffSidebarSection()}
 								${(() => {

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -870,7 +870,7 @@ function renderProjectContent(
 				</div>
 			` : ""}
 		</div>
-		${staff && state.projects.length > 1 ? renderStaffSidebarSection(staff) : ""}
+		${staff ? renderStaffSidebarSection(staff) : ""}
 	`;
 }
 
@@ -996,108 +996,38 @@ export function renderSidebar() {
 									filteredStaff = filteredStaff.filter(s => ids.has(s.id));
 								}
 							}
-							const multiProject = state.projects.length > 1;
+							// Group goals, sessions, and staff by project
+							const projectMap = new Map<string, { goals: Goal[]; sessions: GatewaySession[]; staff: typeof filteredStaff }>();
+							for (const p of state.projects) projectMap.set(p.id, { goals: [], sessions: [], staff: [] });
+							// Fallback bucket for items without a projectId
+							const defaultId = state.projects[0]?.id || "";
+							for (const g of filteredGoals) {
+								const pid = g.projectId || defaultId;
+								const bucket = projectMap.get(pid) || projectMap.get(defaultId)!;
+								bucket.goals.push(g);
+							}
+							for (const s of filteredUngrouped) {
+								const pid = s.projectId || defaultId;
+								const bucket = projectMap.get(pid) || projectMap.get(defaultId)!;
+								bucket.sessions.push(s);
+							}
+							for (const s of filteredStaff) {
+								const pid = s.projectId || defaultId;
+								const bucket = projectMap.get(pid) || projectMap.get(defaultId)!;
+								bucket.staff.push(s);
+							}
 							return html`
-							${multiProject ? (() => {
-								// Group goals, sessions, and staff by project
-								const projectMap = new Map<string, { goals: Goal[]; sessions: GatewaySession[]; staff: typeof filteredStaff }>();
-								for (const p of state.projects) projectMap.set(p.id, { goals: [], sessions: [], staff: [] });
-								// Fallback bucket for items without a projectId
-								const defaultId = state.projects[0]?.id || "";
-								for (const g of filteredGoals) {
-									const pid = g.projectId || defaultId;
-									const bucket = projectMap.get(pid) || projectMap.get(defaultId)!;
-									bucket.goals.push(g);
-								}
-								for (const s of filteredUngrouped) {
-									const pid = s.projectId || defaultId;
-									const bucket = projectMap.get(pid) || projectMap.get(defaultId)!;
-									bucket.sessions.push(s);
-								}
-								for (const s of filteredStaff) {
-									const pid = s.projectId || defaultId;
-									const bucket = projectMap.get(pid) || projectMap.get(defaultId)!;
-									bucket.staff.push(s);
-								}
-								return html`${state.projects.map((project, i) => {
-									const data = projectMap.get(project.id) || { goals: [], sessions: [], staff: [] };
-									const expanded = isProjectExpanded(project.id);
-									return html`
-										${i > 0 ? html`<div class="border-t border-border/30 my-1 mx-2"></div>` : ""}
-										${renderProjectHeader(project, expanded)}
-										${expanded ? html`<div class="flex flex-col gap-0.5" style="padding-left:${INDENT}px;">
-											${renderProjectContent(project, data.goals, data.sessions, data.staff)}
-										</div>` : ""}
-									`;
-								})}`;
-							})() : html`${filteredGoals.map((goal, i) => html`
-								${i > 0 ? html`<div class="border-t border-border/30 my-0.5 mx-2"></div>` : ""}
-								${renderGoalGroup(goal)}
-							`)}`}
-							${multiProject ? "" : filteredGoals.length > 0 ? html`
-								<div class="border-t border-border/30 my-1 mx-2"></div>
-								<div class="flex flex-col gap-0.5">
-									<div class="relative flex items-center gap-1 pr-1 py-0.5 rounded-md cursor-pointer hover:bg-secondary/30 transition-colors"
-										style="padding-left:${HEADER_CHEVRON_W}px;"
-										@click=${() => { setUngroupedExpanded(!ungroupedExpanded); renderApp(); }}>
-										<span class="absolute left-0 top-0 bottom-0 flex items-center justify-center text-sm text-muted-foreground select-none" style="width:${HEADER_CHEVRON_W}px;">${ungroupedExpanded ? "▾" : "▸"}</span>
-										<span class="shrink-0 text-muted-foreground" style="margin-left:-3px;">${icon(MessagesSquare, "xs")}</span>
-										<span class="flex-1 text-[9px] text-muted-foreground uppercase tracking-wider font-medium">Sessions</span>
-										<div class="flex items-center relative">
-											<button
-												class="p-0.5 rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors ${state.creatingSession ? "opacity-50 pointer-events-none" : ""}"
-												@click=${(e: Event) => { e.stopPropagation(); createAndConnectSession(); }}
-												title="New session"
-												?disabled=${state.creatingSession}
-											>
-												${state.creatingSession && !state.creatingSessionForGoalId
-													? html`<svg class="animate-spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>`
-													: icon(Plus, "xs")}
-											</button>
-											<button
-												class="p-0.5 rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
-												@click=${toggleRolePicker}
-												title="New session with role"
-											>${icon(ChevronDown, "xs")}</button>
-											${renderRolePickerDropdown()}
-										</div>
-									</div>
-									${ungroupedExpanded ? html`<div class="flex flex-col gap-0.5" style="padding-left:${INDENT}px;">${filteredUngrouped.map(renderSessionRow)}</div>` : ""}
-								</div>
-							` : html`
-								<div class="flex flex-col gap-0.5">
-									<div class="flex items-center gap-1 pl-0 pr-1 py-0.5">
-										<span class="flex-1 flex items-center gap-1 text-[9px] text-muted-foreground uppercase tracking-wider font-medium" style="padding-left:${HEADER_CHEVRON_W}px;"><span class="shrink-0" style="margin-right:-3px;">${icon(MessagesSquare, "xs")}</span> Sessions</span>
-										<div class="flex items-center relative">
-											<button
-												class="p-0.5 rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors ${state.creatingSession ? "opacity-50 pointer-events-none" : ""}"
-												@click=${() => createAndConnectSession()}
-												title="New session"
-												?disabled=${state.creatingSession}
-											>
-												${state.creatingSession && !state.creatingSessionForGoalId
-													? html`<svg class="animate-spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>`
-													: icon(Plus, "xs")}
-											</button>
-											<button
-												class="p-0.5 rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
-												@click=${toggleRolePicker}
-												title="New session with role"
-											>${icon(ChevronDown, "sm")}</button>
-											${renderRolePickerDropdown()}
-										</div>
-									</div>
-									<div class="flex flex-col gap-0.5" style="padding-left:${INDENT}px;">
-									${filteredUngrouped.length === 0
-										? html`<div class="text-center py-6">
-												<p class="text-xs text-muted-foreground mb-2">No sessions</p>
-												<button class="text-xs text-primary hover:underline" title="Create a new session" @click=${() => createAndConnectSession()}>Create one</button>
-											</div>`
-										: filteredUngrouped.map(renderSessionRow)}
-								</div>
-								</div>
-							`}
-							${!multiProject ? (state.searchQuery ? renderStaffSidebarSection(filteredStaff) : renderStaffSidebarSection()) : ""}
+							${state.projects.map((project, i) => {
+								const data = projectMap.get(project.id) || { goals: [], sessions: [], staff: [] };
+								const expanded = isProjectExpanded(project.id);
+								return html`
+									${i > 0 ? html`<div class="border-t border-border/30 my-1 mx-2"></div>` : ""}
+									${renderProjectHeader(project, expanded)}
+									${expanded ? html`<div class="flex flex-col gap-0.5" style="padding-left:${INDENT}px;">
+										${renderProjectContent(project, data.goals, data.sessions, data.staff)}
+									</div>` : ""}
+								`;
+							})}
 							${(() => {
 								// Archived section: archived goals + standalone archived sessions
 								// Goal-affiliated archived sessions render inside their goal groups.

--- a/tests/e2e/ui/single-project-sidebar.spec.ts
+++ b/tests/e2e/ui/single-project-sidebar.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * E2E tests: Single-project sidebar — project folder row always visible.
+ *
+ * Verifies the "always show project rows" feature: even with only one
+ * project registered, the sidebar renders the project folder row with
+ * folder icon, project name, settings gear, and new-goal button.
+ */
+import { test, expect } from "../gateway-harness.js";
+import { openApp, createSessionViaUI } from "./ui-helpers.js";
+
+test.describe("Single-project sidebar", () => {
+	test("project folder row visible in single-project mode", async ({ page }) => {
+		await openApp(page);
+
+		// The sidebar should contain a project folder row.
+		// The project header has: chevron, folder icon, project name, settings gear, new-goal button.
+
+		// Settings gear with title="Project settings"
+		const settingsGear = page.locator("button[title='Project settings']").first();
+		await expect(settingsGear).toBeVisible({ timeout: 10_000 });
+
+		// The project header group container (parent of gear button)
+		const projectHeader = settingsGear.locator("xpath=ancestor::div[contains(@class,'group')]").first();
+		await expect(projectHeader).toBeVisible();
+
+		// Folder icon (SVG inside the header) — the header contains a colored folder icon span
+		// Project name text — uppercase tracking-wider span
+		const projectName = projectHeader.locator("span.uppercase").first();
+		await expect(projectName).toBeVisible();
+		const nameText = await projectName.textContent();
+		expect(nameText!.trim().length).toBeGreaterThan(0);
+
+		// New goal button (title starts with "New goal in")
+		const newGoalBtn = projectHeader.locator("button[title^='New goal in']");
+		await expect(newGoalBtn).toBeVisible();
+
+		// Project row is expanded by default — "Sessions" label should be visible beneath it
+		await expect(
+			page.getByText("Sessions", { exact: true }).first(),
+		).toBeVisible({ timeout: 5_000 });
+	});
+
+	test("expand/collapse persists across reload", async ({ page }) => {
+		await openApp(page);
+
+		// The project header row — click it to collapse
+		const projectHeader = page.locator("button[title='Project settings']")
+			.first()
+			.locator("xpath=ancestor::div[contains(@class,'group')]")
+			.first();
+		await expect(projectHeader).toBeVisible({ timeout: 10_000 });
+
+		// Verify initially expanded — Sessions label visible
+		const sessionsLabel = page.getByText("Sessions", { exact: true }).first();
+		await expect(sessionsLabel).toBeVisible({ timeout: 5_000 });
+
+		// Click the project header to collapse
+		await projectHeader.click();
+
+		// Sessions label should now be hidden
+		await expect(sessionsLabel).not.toBeVisible({ timeout: 5_000 });
+
+		// Reload and verify still collapsed
+		await openApp(page);
+		await expect(
+			page.getByText("Sessions", { exact: true }).first(),
+		).not.toBeVisible({ timeout: 5_000 });
+
+		// Click to expand again
+		const headerAfterReload = page.locator("button[title='Project settings']")
+			.first()
+			.locator("xpath=ancestor::div[contains(@class,'group')]")
+			.first();
+		await headerAfterReload.click();
+
+		// Sessions should be visible
+		await expect(
+			page.getByText("Sessions", { exact: true }).first(),
+		).toBeVisible({ timeout: 5_000 });
+
+		// Reload and verify still expanded
+		await openApp(page);
+		await expect(
+			page.getByText("Sessions", { exact: true }).first(),
+		).toBeVisible({ timeout: 5_000 });
+	});
+
+	test("session creation from project row works", async ({ page }) => {
+		await openApp(page);
+
+		// The "New session" button inside the project's Sessions section
+		// In multi-project path, button title is "New session in <project name>"
+		const newSessionBtn = page.locator("button[title^='New session']").first();
+		await expect(newSessionBtn).toBeVisible({ timeout: 10_000 });
+		await newSessionBtn.click();
+
+		// Wait for a chat textarea to appear — indicates session was created
+		await expect(page.locator("textarea").first()).toBeVisible({ timeout: 15_000 });
+
+		// Verify the URL hash contains a session ID
+		await expect(async () => {
+			const hash = await page.evaluate(() => window.location.hash);
+			expect(hash).toMatch(/#\/session\/[a-f0-9-]+/i);
+		}).toPass({ timeout: 5_000 });
+	});
+});


### PR DESCRIPTION
## Summary

Remove the `projects.length > 1` / `multiProject` branching in the sidebar and mobile sidebar renderers. Always render the project folder row(s) via the multi-project code path, even when only one project is registered.

## Changes

### `src/app/sidebar.ts` — Desktop sidebar (-102/+32 lines)
- Removed `multiProject` conditional — always uses `renderProjectHeader()` + `renderProjectContent()`
- Staff always renders inside project content (removed `projects.length > 1` guard)
- Deleted entire single-project flat layout and standalone staff section

### `src/app/render.ts` — Mobile sidebar (-62/+3 lines)
- Same treatment — always uses project-grouped layout
- Fixed `toggleRolePicker` to pass project info in single-project mode

### `tests/e2e/ui/single-project-sidebar.spec.ts` — E2E tests (+106 lines)
- Project folder row visible in single-project mode
- Expand/collapse persists across reload
- Session creation from project row works

### Documentation
- `docs/internals.md`: Updated sidebar grouping description
- `docs/debugging.md`: Fixed stale debugging tip
- `README.md`: Fixed feature description

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)