### PR TITLE
fix: worktree_setup_command missing from settings page

### DIFF
--- a/src/server/agent/project-config-store.ts
+++ b/src/server/agent/project-config-store.ts
@@ -20,6 +20,7 @@ const DEFAULTS: Record<string, string> = {
 	typecheck_command: "npm run check",
 	test_unit_command: "npm run test:unit",
 	test_e2e_command: "npm run test:e2e",
+	worktree_setup_command: "",  // Empty = no setup runs on new worktrees
 	default_thinking_level: "",  // Empty = use agent's built-in default ("medium")
 	sandbox: "none",                    // "none" | "docker"
 	sandbox_image: "bobbit-agent",      // Docker image name


### PR DESCRIPTION
## Problem

The `worktree_setup_command` field was not displayed on the per-project Commands & Sandbox settings tab.

## Root Cause

The `/api/projects/:id/config/resolved` endpoint builds its response by iterating over `Object.keys(DEFAULTS)` in `project-config-store.ts`. Since `worktree_setup_command` was not included in the `DEFAULTS` object, it was never returned by the API and therefore never rendered on the settings page.

## Fix

Added `worktree_setup_command: ""` to the `DEFAULTS` object with an empty string default, matching the existing behavior where no setup command runs if unconfigured. The field now appears alongside the other command fields on the settings page.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)