### PR TITLE
Respect worktree checkbox on new session popover (default true)

### DIFF
--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -1218,7 +1218,7 @@ export async function createAndConnectSession(goalId?: string, roleId?: string, 
 		if (roleId) body.roleId = roleId;
 		if (personalities && personalities.length > 0) body.personalities = personalities;
 		if (cwd) body.cwd = cwd;
-		if (worktree) body.worktree = true;
+		if (worktree !== undefined) body.worktree = worktree;
 		if (sandboxed) body.sandboxed = true;
 		if (projectId) body.projectId = projectId;
 		const res = await gatewayFetch("/api/sessions", {

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -67,7 +67,7 @@ let _pickerPersonalities = new Set<string>();
 let _pickerCwd = "";
 let _pickerCwdDropdownOpen = false;
 let _pickerCwdHighlightIndex = -1;
-let _pickerWorktree = false;
+let _pickerWorktree = true;
 let _pickerSandbox = false;
 /** Goal ID context for the picker (if launched from a goal). */
 let _pickerGoalId: string | undefined;
@@ -112,7 +112,7 @@ export async function toggleRolePicker(e: Event, goalId?: string, opts?: { proje
 	_pickerCwd = opts?.projectCwd || "";
 	_pickerCwdDropdownOpen = false;
 	_pickerCwdHighlightIndex = -1;
-	_pickerWorktree = false;
+	_pickerWorktree = true;
 	_pickerGoalId = goalId;
 	_pickerProjectId = opts?.projectId;
 	_pickerProjectName = opts?.projectName;
@@ -154,7 +154,7 @@ export function renderRolePickerDropdown() {
 		state.rolePickerOpen = false;
 		const personalities = [..._pickerPersonalities];
 		const cwd = _pickerCwd || undefined;
-		const worktree = _pickerWorktree || undefined;
+		const worktree = _pickerWorktree;
 		const sandboxed = _pickerSandbox || undefined;
 		const projectId = _pickerProjectId;
 		_pickerCwd = "";
@@ -381,7 +381,7 @@ document.addEventListener("keydown", (e: KeyboardEvent) => {
 			state.rolePickerOpen = false;
 			const personalities = [..._pickerPersonalities];
 			const cwd = _pickerCwd || undefined;
-			const worktree = _pickerWorktree || undefined;
+			const worktree = _pickerWorktree;
 			_pickerCwd = "";
 			_pickerCwdDropdownOpen = false;
 			createAndConnectSession(_pickerGoalId, _pickerRole || undefined, personalities.length > 0 ? personalities : undefined, cwd, worktree);
@@ -406,7 +406,7 @@ document.addEventListener("keydown", (e: KeyboardEvent) => {
 			state.rolePickerOpen = false;
 			const personalities = [..._pickerPersonalities];
 			const cwd = _pickerCwd || undefined;
-			const worktree = _pickerWorktree || undefined;
+			const worktree = _pickerWorktree;
 			_pickerCwd = "";
 			_pickerCwdDropdownOpen = false;
 			createAndConnectSession(_pickerGoalId, _pickerRole || undefined, personalities.length > 0 ? personalities : undefined, cwd, worktree);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1490,21 +1490,11 @@ async function handleApiRoute(
 		}
 
 		// ── Worktree support ──
-		// Every non-assistant, non-goal session automatically gets its own worktree branch.
+		// Non-assistant, non-goal sessions get a worktree by default unless explicitly opted out.
 		// Goal sessions have their own worktree logic via goalManager.setupWorktreeAndStartTeam().
 		let worktreeOpts: { repoPath: string } | undefined;
-		if (!assistantType && !goalId) {
-			// Auto-worktree for all regular sessions
-			try {
-				if (await isGitRepo(cwd)) {
-					const repoPath = await getRepoRoot(cwd);
-					worktreeOpts = { repoPath };
-				}
-			} catch {
-				// Not a git repo or git not available — silently ignore
-			}
-		} else if (body?.worktree && !assistantType) {
-			// Explicit worktree request (e.g. goal sessions using body.worktree flag)
+		const wantWorktree = body?.worktree !== undefined ? !!body.worktree : (!assistantType && !goalId);
+		if (wantWorktree && !assistantType) {
 			try {
 				if (await isGitRepo(cwd)) {
 					const repoPath = await getRepoRoot(cwd);


### PR DESCRIPTION
The "Create worktree" checkbox on the new session popover was not being obeyed — the server always created a worktree for regular sessions regardless of the checkbox state, and the checkbox defaulted to unchecked.

**Changes:**

- **Default the checkbox to checked** — worktrees are the expected default for regular sessions
- **Send explicit `worktree: false` to the server** when unchecked, instead of omitting the field
- **Server respects `body.worktree`** when explicitly provided (true or false); when absent, preserves the existing default (auto-worktree for non-assistant, non-goal sessions)

Unified the two separate worktree code paths in the server into a single check.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)