### PR TITLE
Fix git status widget breaking for sessions after server restart

### DIFF
--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -3242,6 +3242,20 @@ export class SessionManager {
 		try {
 			const { stdout } = await execFileAsync("git", ["worktree", "list", "--porcelain"], { cwd: repoPath });
 			const blocks = stdout.split("\n\n");
+
+			// Build a set of branches owned by live (non-archived) persisted sessions.
+			// Prior to the fix, pool worktree directories were renamed on claim but
+			// `git worktree repair` could fail — git tracked the OLD path while
+			// the session stored the NEW path. Matching by branch prevents the
+			// cleanup from deleting worktrees that are actually in use.
+			const persistedBranches = new Set<string>();
+			const allPersisted = this.projectContextManager
+				? [...this.projectContextManager.getAllLiveSessions()]
+				: (this._testStore?.getLive() ?? []);
+			for (const ps of allPersisted) {
+				if (ps.branch) persistedBranches.add(ps.branch);
+			}
+
 			for (const block of blocks) {
 				const branchMatch = block.match(/^branch refs\/heads\/(session\/.+)$/m);
 				if (!branchMatch) continue;
@@ -3254,10 +3268,10 @@ export class SessionManager {
 				// every session worktree is considered "orphaned" and deleted on restart.
 				const normalize = (p: string | undefined) => p?.replace(/\\/g, "/").toLowerCase();
 				const normalizedWtPath = normalize(wtPath);
-				// Check if any active session uses this worktree
+				// Check if any active session uses this worktree (by path or branch)
 				const isActive = [...this.sessions.values()].some(
 					s => normalize(s.worktreePath) === normalizedWtPath || normalize(s.cwd) === normalizedWtPath
-				);
+				) || persistedBranches.has(branch);
 				if (!isActive) {
 					console.log(`[session-manager] Cleaning up orphaned session worktree: ${wtPath} (branch: ${branch})`);
 					const { cleanupWorktree } = await import("../skills/git.js");

--- a/src/server/agent/worktree-pool.ts
+++ b/src/server/agent/worktree-pool.ts
@@ -3,15 +3,13 @@
  * instead of waiting 10-30s for `git worktree add` + `npm ci` + `git push`.
  *
  * On startup, the pool fills to `targetSize` (default 2) in the background.
- * When a session claims a worktree, the pool renames the branch/directory
+ * When a session claims a worktree, the pool renames the branch
  * and starts replenishing immediately.
  *
  * If the pool is empty, callers fall back to the normal `createWorktree()` path.
  */
 
 import { randomUUID } from "node:crypto";
-import fs from "node:fs";
-import path from "node:path";
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import { createWorktree, cleanupWorktree, type WorktreeResult } from "../skills/git.js";
@@ -68,7 +66,9 @@ export class WorktreePool {
 		// Kick off background replenishment immediately
 		this.replenish();
 
-		// 1. Rename the git branch
+		// Rename the git branch (needed for push / upstream tracking).
+		// The directory stays at its pool path — renaming directories causes
+		// git worktree tracking mismatches that break sessions on restart.
 		try {
 			await execFile("git", ["branch", "-m", entry.branchName, targetBranch], {
 				cwd: entry.worktreePath,
@@ -80,45 +80,16 @@ export class WorktreePool {
 			return null;
 		}
 
-		// 2. Move the directory to match the branch-name convention
-		const wtRoot = path.resolve(this.repoPath, "..", `${path.basename(this.repoPath)}-wt`);
-		const safeName = targetBranch.replace(/\//g, "-");
-		const newPath = path.join(wtRoot, safeName);
-		let finalPath = entry.worktreePath;
-
-		if (newPath !== entry.worktreePath) {
-			try {
-				fs.renameSync(entry.worktreePath, newPath);
-				finalPath = newPath;
-			} catch (err) {
-				// Directory rename failed — worktree still works at old path
-				console.warn(`[worktree-pool] Directory rename failed, using original path:`, err);
-			}
-
-			// If directory was moved, tell git about the new location
-			if (finalPath === newPath) {
-				try {
-					await execFile("git", ["worktree", "repair"], {
-						cwd: this.repoPath,
-						timeout: 10_000,
-					});
-				} catch (err) {
-					// repair failure is non-fatal — git may still find it
-					console.warn(`[worktree-pool] git worktree repair failed (non-fatal):`, err);
-				}
-			}
-		}
-
-		// 3. Push the renamed branch to origin (fire-and-forget, non-blocking)
+		// Push the renamed branch to origin (fire-and-forget, non-blocking)
 		execFile("git", ["push", "-u", "origin", targetBranch], {
-			cwd: finalPath,
+			cwd: entry.worktreePath,
 			timeout: 30_000,
 		}).catch(() => {
 			// Push failure is non-fatal (offline, auth issues, etc.)
 		});
 
-		console.log(`[worktree-pool] Claimed worktree: ${targetBranch} at ${finalPath} (pool: ${this.pool.length}/${this.targetSize})`);
-		return { worktreePath: finalPath, branchName: targetBranch };
+		console.log(`[worktree-pool] Claimed worktree: ${targetBranch} at ${entry.worktreePath} (pool: ${this.pool.length}/${this.targetSize})`);
+		return { worktreePath: entry.worktreePath, branchName: targetBranch };
 	}
 
 	/** Fill pool up to targetSize in the background. */


### PR DESCRIPTION
## Problem

Every session's git status widget stopped working after a server restart. Git commands failed because the worktree metadata was destroyed.

## Root cause

When a pool worktree was claimed for a session, the directory was renamed from `session-_pool-xxx` to `session-new-session-xxx`, then `git worktree repair` was called to update git's tracking. But `repair` consistently failed (e.g. due to unrelated broken worktree entries elsewhere in the repo), leaving git tracking the **old** path while the session stored the **new** path.

On restart, the orphan worktree cleanup:
1. Listed git worktrees and saw the old path (`session-_pool-xxx`)
2. Checked all active sessions' `cwd` and `worktreePath` — no match (they stored the renamed path)
3. Deleted the git worktree entry **and** the branch

This broke git for every session that survived a restart.

## Fix

**`worktree-pool.ts`**: Stop renaming worktree directories on claim. The directory stays at its pool path (`session-_pool-xxx`) — only the git branch is renamed (needed for push/upstream tracking). The directory name is opaque and doesn't need to be human-readable.

**`session-manager.ts`**: Add branch-based matching to the orphan cleanup as a safety net. Before deleting a worktree, it now also checks whether any persisted session owns that branch. This protects sessions created before this fix whose directories were already renamed.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)