### PR TITLE
Fix sandboxed session worktrees created on host instead of inside container

### DIFF
--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -3149,8 +3149,10 @@ export class SessionManager {
 			console.error(`[session-manager] Failed to cleanup prompt for ${ps.id}:`, err);
 		}
 
-		// Clean up worktree (skip for sandboxed sessions — container worktrees are cleaned via ProjectSandbox)
-		if (ps.worktreePath && ps.repoPath && !ps.sandboxed) {
+		// Clean up host worktree.  Sandboxed session worktrees also create a host-side
+		// worktree for server bookkeeping, so we clean those up too.  Skip paths that
+		// are container-internal (start with /workspace) — those have no host counterpart.
+		if (ps.worktreePath && ps.repoPath && !ps.worktreePath.startsWith("/workspace")) {
 			try {
 				const { cleanupWorktree } = await import("../skills/git.js");
 				await cleanupWorktree(ps.repoPath, ps.worktreePath, ps.branch, true);

--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -466,6 +466,14 @@ export async function executeWorktreeAsync(
 		);
 	}
 
+	// For sandboxed sessions, set sandboxBranch so applySandboxWiring() creates
+	// the worktree inside the container (via ProjectSandbox.createWorktree).
+	// The host worktree is still kept for server-side bookkeeping (worktreePath).
+	if (plan.sandboxed && !plan.sandboxBranch && plan.branch) {
+		plan.sandboxBranch = plan.branch;
+		// No baseBranch for regular sessions — they branch from HEAD
+	}
+
 	// Update session and plan with worktree CWD
 	session.cwd = worktreeCwd;
 	session.worktreePath = worktreeCwd;


### PR DESCRIPTION
## Problem

Regular (non-goal) sandboxed sessions had their `cwd` set to `/workspace` inside the container instead of an isolated session-specific worktree. The agent worked in the repo root, losing the branch isolation that worktrees provide.

### Root cause

`executeWorktreeAsync()` in `session-setup.ts` called `createWorktree()` from `skills/git.ts`, which creates the worktree on the **host** filesystem. Then `applySandboxWiring()` ran and checked:

```ts
} else if (!bridgeOptions.cwd || !bridgeOptions.cwd.startsWith("/")) {
    bridgeOptions.cwd = "/workspace";
}
```

Since the host worktree path (e.g. `/workspace-wt/session/s-6fc689a2`) is absolute, the condition was false and the path passed through unchanged — but it doesn't exist inside the container. The agent fell back to `/workspace`.

Goal agents didn't have this problem because `team-manager.ts` passes `sandboxBranch` to the pipeline, which triggers `ProjectSandbox.createWorktree()` inside `applySandboxWiring()`.

## Fix

**`session-setup.ts`** — In `executeWorktreeAsync()`, after creating the host worktree, set `plan.sandboxBranch = plan.branch` when the session is sandboxed. This causes `applySandboxWiring()` to call `ProjectSandbox.createWorktree()`, creating the worktree inside the container at `/workspace-wt/<name>` and setting `bridgeOptions.cwd` to that container-internal path. The host worktree is still kept for server-side bookkeeping.

**`session-manager.ts`** — In `purgeOneSession()`, changed the worktree cleanup guard from `!ps.sandboxed` to `!ps.worktreePath.startsWith("/workspace")`. This ensures host-side worktrees created for sandboxed sessions are cleaned up on purge, while container-internal paths (from goal agents that skip host worktree creation) are still skipped.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)