### PR TITLE
Fix: gateway crash when force-aborting sandbox sessions

### DIFF
--- a/src/server/agent/rpc-bridge.ts
+++ b/src/server/agent/rpc-bridge.ts
@@ -130,6 +130,18 @@ export class RpcBridge {
 			console.warn(`[rpc-bridge] stdin error: ${err.code || err.message}`);
 		});
 
+		// Handle spawn errors (e.g. ENOENT when executable not found) — without this
+		// the error becomes an uncaught exception and crashes the gateway.
+		this.process.on("error", (err: NodeJS.ErrnoException) => {
+			console.error(`[rpc-bridge] Process error: ${err.code || err.message}${this.options.cwd ? ` cwd=${this.options.cwd}` : ""}`);
+			for (const [, p] of this.pending) {
+				clearTimeout(p.timeout);
+				p.reject(err);
+			}
+			this.pending.clear();
+			this.process = null;
+		});
+
 		this.process.on("exit", (code, signal) => {
 			const reason = signal ? `signal ${signal}` : `code ${code}`;
 			const stderrContext = this.stderrTail.length > 0

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -3533,6 +3533,14 @@ export class SessionManager {
 			if (this.systemPromptPath) bridgeOptions.systemPromptPath = this.systemPromptPath;
 			bridgeOptions.env = { BOBBIT_SESSION_ID: id };
 
+			// Apply sandbox wiring for sandboxed sessions (container spawn, token, etc.)
+			if (session.sandboxed) {
+				await this.applySandboxWiring(bridgeOptions, id, {
+					projectId: session.projectId,
+					goalId: session.goalId,
+				});
+			}
+
 			// Restore goal extension
 			if (session.goalId) {
 				bridgeOptions.env.BOBBIT_GOAL_ID = session.goalId;


### PR DESCRIPTION
## Problem

Force-aborting a sandboxed session crashed the gateway with `spawn node ENOENT`. The force-abort restart path created a new `RpcBridge` with the session's container-internal cwd (`/workspace-wt/...`) but spawned `node` directly on the host — where that path doesn't exist and `node` isn't resolvable in that context. The resulting `ENOENT` error had no handler, so it surfaced as an uncaught exception and took down the entire gateway.

## Fix

**1. Apply sandbox wiring on force-abort restart** (`session-manager.ts`)

The restart block now calls `applySandboxWiring()` for sandboxed sessions before creating the `RpcBridge`, matching what `restoreSession()` already does. This sets `containerId` on the bridge options so the agent process spawns inside the Docker container with proper credentials.

**2. Add process error handler to RpcBridge** (`rpc-bridge.ts`)

Added a `process.on('error')` handler to catch spawn failures (ENOENT, EACCES, etc.) gracefully. Previously these had no handler and became uncaught exceptions that crashed the gateway. Now they're logged and pending RPC requests are rejected, allowing the session-level try/catch to handle the failure.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)