### PR TITLE
Fix steer mid-turn delivery

### DIFF
--- a/docs/prompt-queue.md
+++ b/docs/prompt-queue.md
@@ -17,9 +17,11 @@ Browser (RemoteAgent)          Server (SessionManager)         Agent subprocess
                      ├─ drainQueue()
                      │  └─ dequeue next ──► rpcClient.prompt()
                      └─ broadcastQueue() ──WS──► queue_update
+
+  steer()  ──WS──►  (streaming?) ──► rpcClient.steer() ──► injected mid-turn
 ```
 
-## Three dispatch paths
+## Four dispatch paths
 
 ### 1. Direct dispatch (idle + empty queue)
 
@@ -29,9 +31,17 @@ The fast path. Agent is idle and nothing is queued — the prompt goes straight 
 
 Agent is streaming or the queue already has items. The message is added to `PromptQueue`, and a `queue_update` is broadcast to all connected clients so the UI can show the pending messages. If the agent happens to be idle (queue was non-empty), `drainQueue()` is called immediately.
 
+Note: when the agent is streaming and the user sends a text-only message via the UI, `sendMessage()` uses the steer path (path 4) instead of enqueuing. Messages only reach this enqueue path during streaming if they have attachments (the steer protocol is text-only) or are sent programmatically via `{ type: "prompt" }`.
+
 ### 3. Drain (agent becomes idle)
 
 On `agent_end`, if the queue has items and the turn didn't end with an error, `drainQueue()` pops the next undispatched message and sends it via `rpcClient.prompt()`. Status is set to `"streaming"` optimistically to prevent a race where another `enqueuePrompt()` call sees idle+empty and dispatches a second concurrent prompt.
+
+### 4. Direct steer (streaming, text-only)
+
+When the user sends a text-only message while the agent is streaming, `AgentInterface.sendMessage()` calls `session.steer()` instead of `session.prompt()`. This sends `{ type: "steer" }` over WebSocket, and the server dispatches it immediately via `rpcClient.steer()` — injected between tool calls without waiting for the turn to end. The message bypasses the queue entirely. An optimistic user message is rendered in chat so the user sees it immediately.
+
+This path is only used when: (a) the agent is streaming, and (b) the message has no attachments (the steer WS protocol is text-only). Messages with attachments fall back to `session.prompt()` and are enqueued via path 2.
 
 ## Message types
 
@@ -86,7 +96,9 @@ Sent whenever the queue changes — enqueue, dequeue, steer, remove, reorder. Co
 
 When the user sends a prompt and the agent is **idle** (`!isStreaming`), `RemoteAgent.prompt()` adds the message to `state.messages` immediately with an `optimistic_*` id prefix. This ensures the message appears in chat without waiting for the server echo.
 
-When the agent is **streaming** (prompt will be queued), no optimistic message is added. The server will echo it in the correct interleaved position when the queue drains and the agent processes it.
+When the agent is **streaming** and the message is sent as a **direct steer** (no attachments), `RemoteAgent.steer()` also adds an optimistic message so the user sees it in chat immediately — matching the idle-prompt pattern.
+
+When the agent is **streaming** and the message is sent as a **queued prompt** (has attachments, or sent via the queue), no optimistic message is added. The server will echo it in the correct interleaved position when the queue drains and the agent processes it.
 
 ### Deduplication
 

--- a/docs/prompt-queue.md
+++ b/docs/prompt-queue.md
@@ -41,9 +41,9 @@ Standard user message. Always routed through `enqueuePrompt()` — never sent di
 
 ### `steer` (client → server)
 
-A mid-turn interrupt. Behavior depends on agent state:
+A mid-turn redirect. Behavior depends on agent state:
 
-- **Agent streaming**: Enqueued as a steered message (`isSteered: true`). The message is **not** dispatched immediately — it is held until the user presses Stop/Escape. On `forceAbort()`, all steered+undispatched messages are concatenated and sent as a single `rpcClient.steer()` call. This batching ensures multiple steered messages arrive as one coherent block rather than racing individually.
+- **Agent streaming**: Dispatched **immediately** via `rpcClient.steer()` — injected between tool calls in real-time. The message is NOT queued. The UI sends `steer` (instead of `prompt`) when `isStreaming` is true and there are no attachments. Optimistic rendering adds the user message to chat immediately.
 - **Agent idle**: Enqueued as a steered message. Steered messages sort before normal messages in the queue.
 
 ### `follow_up` (client → server)
@@ -52,7 +52,7 @@ Similar to `prompt` but dispatched via `rpcClient.followUp()` instead of `rpcCli
 
 ### `steer_queued` (client → server)
 
-Promotes an already-queued message to steered priority. The steered message is reordered to the top and shows a "Sent" badge in the UI. Like direct `steer`, the message is held until the user triggers an abort — it is not dispatched immediately.
+Promotes an already-queued message to steered priority. The steered message is reordered to the top and shows a "Sent" badge in the UI. Unlike direct `steer` (which is dispatched immediately during streaming), promoted steers are held until the user triggers an abort — on `forceAbort()`, all steered+undispatched messages are concatenated and sent as a single `rpcClient.steer()` call. This batching ensures multiple promoted messages arrive as one coherent block rather than racing individually.
 
 ### `remove_queued` (client → server)
 

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -428,6 +428,18 @@ export class RemoteAgent {
 
 	steer(message: any): void {
 		const text = typeof message === "string" ? message : extractText(message);
+		// Add optimistic user message so it renders immediately in chat,
+		// matching the pattern used in prompt() for idle sends.
+		const optimisticId = `optimistic_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+		const optimisticMsg: any = {
+			role: "user",
+			content: [{ type: "text", text }],
+			timestamp: Date.now(),
+			id: optimisticId,
+		};
+		this._state.messages = [...this._state.messages, optimisticMsg];
+		this._liveEventMessages.push(optimisticMsg);
+		this.emit({ type: "message_end", message: optimisticMsg });
 		this.send({ type: "steer", text });
 	}
 

--- a/src/ui/components/AgentInterface.ts
+++ b/src/ui/components/AgentInterface.ts
@@ -493,8 +493,12 @@ export class AgentInterface extends LitElement {
 		this._stickToBottom = true;
 		this._scrollToBottom();
 
-		// Always send to the server — it handles queuing when the agent is busy
-		if (attachments && attachments.length > 0) {
+		// Dispatch: if the agent is streaming and there are no attachments,
+		// send as a steer so the message is injected between tool calls
+		// immediately. Otherwise fall back to prompt (queued if busy).
+		if (isStreaming && (!attachments || attachments.length === 0)) {
+			session.steer(input as any);
+		} else if (attachments && attachments.length > 0) {
 			const message: UserMessageWithAttachments = {
 				role: "user-with-attachments",
 				content: input,

--- a/tests/e2e/mock-agent.mjs
+++ b/tests/e2e/mock-agent.mjs
@@ -355,6 +355,16 @@ rl.on("line", async (line) => {
 
 		case "steer":
 			send({ type: "response", id: msg.id, success: true });
+			// Emit a steer_received event so E2E tests can verify delivery.
+			// Also emit a message_end with the steer text so it's visible in conversation.
+			{
+				const steerMsg = {
+					role: "assistant",
+					content: [{ type: "text", text: `[STEER_RECEIVED] ${msg.message || msg.text || ""}` }],
+				};
+				conversationMessages.push(steerMsg);
+				emit({ type: "message_end", message: steerMsg });
+			}
 			break;
 
 		case "abort":

--- a/tests/e2e/steer-midturn.spec.ts
+++ b/tests/e2e/steer-midturn.spec.ts
@@ -1,17 +1,12 @@
 /**
  * E2E tests for steer mid-turn delivery.
  *
- * BUG: When the user sends a message while the agent is streaming,
- * AgentInterface.sendMessage() always sends { type: "prompt" } which
- * gets queued. It should send { type: "steer" } so the message is
- * injected between tool calls immediately.
- *
- * The server-side steer handler (ws/handler.ts case "steer") works
- * correctly — it calls rpcClient.steer() when the agent is streaming.
- * The bug is purely in the UI dispatch path.
- *
- * These tests verify the server-side steer mechanism and demonstrate
- * the bug by showing that prompt-during-streaming gets queued.
+ * Tests verify:
+ * 1. Steers sent while streaming are delivered immediately to the agent
+ *    (via rpcClient.steer(), injected between tool calls).
+ * 2. Prompts sent while streaming are correctly queued by the server
+ *    (the UI now sends steer instead, but the server queue path is
+ *    still exercised here for completeness).
  */
 import { test, expect } from "./in-process-harness.js";
 import {
@@ -76,11 +71,10 @@ test.describe("Steer mid-turn delivery", () => {
 		}
 	});
 
-	test("prompt sent while streaming gets queued instead of being delivered as steer", async () => {
-		// This test demonstrates the BUG: the UI always sends { type: "prompt" }
-		// even when the agent is streaming. The server correctly queues prompts
-		// sent during streaming. After the fix, the UI will send { type: "steer" }
-		// instead, which bypasses the queue entirely.
+	test("prompt sent while streaming is correctly queued by the server", async () => {
+		// Verify the server correctly queues { type: "prompt" } during streaming.
+		// The UI fix sends { type: "steer" } instead (tested above), but the
+		// server's queue behavior for prompts should remain unchanged.
 		sessionId = await createSession();
 		const conn = await connectWs(sessionId);
 
@@ -94,26 +88,17 @@ test.describe("Steer mid-turn delivery", () => {
 			// Clear messages
 			conn.messages.length = 0;
 
-			// Send a prompt while streaming — this is what the UI currently does.
-			// BUG: This gets queued instead of being delivered as a steer.
-			conn.send({ type: "prompt", text: "redirect the agent please" });
+			// Send a prompt while streaming — the server should queue it
+			conn.send({ type: "prompt", text: "this should be queued" });
 
-			// The message gets QUEUED (queue_update with 1 item).
-			// After the fix, the UI sends { type: "steer" } instead, which
-			// bypasses the queue and delivers immediately.
+			// Verify the message is queued (queue_update with 1 item)
 			const queueMsg = await conn.waitFor(
 				(m: WsMsg) => m.type === "queue_update" && m.queue && m.queue.length > 0,
 				3000,
 			);
 
-			// BUG ASSERTION: The message should NOT be in the queue — it should
-			// have been delivered immediately as a steer. This fails because the
-			// current UI sends "prompt" which always queues during streaming.
-			expect(
-				queueMsg.queue.length,
-				"Expected message to be delivered as steer (queue empty), but it was queued instead — " +
-				"UI sends prompt instead of steer while streaming",
-			).toBe(0);
+			expect(queueMsg.queue.length).toBe(1);
+			expect(queueMsg.queue[0].text).toContain("this should be queued");
 		} finally {
 			conn.close();
 		}

--- a/tests/e2e/steer-midturn.spec.ts
+++ b/tests/e2e/steer-midturn.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * E2E tests for steer mid-turn delivery.
+ *
+ * BUG: When the user sends a message while the agent is streaming,
+ * AgentInterface.sendMessage() always sends { type: "prompt" } which
+ * gets queued. It should send { type: "steer" } so the message is
+ * injected between tool calls immediately.
+ *
+ * The server-side steer handler (ws/handler.ts case "steer") works
+ * correctly — it calls rpcClient.steer() when the agent is streaming.
+ * The bug is purely in the UI dispatch path.
+ *
+ * These tests verify the server-side steer mechanism and demonstrate
+ * the bug by showing that prompt-during-streaming gets queued.
+ */
+import { test, expect } from "./in-process-harness.js";
+import {
+	createSession,
+	deleteSession,
+	connectWs,
+	statusPredicate,
+	queueLenPredicate,
+	type WsMsg,
+} from "./e2e-setup.js";
+
+test.setTimeout(30_000);
+
+test.describe("Steer mid-turn delivery", () => {
+	let sessionId: string;
+	test.afterEach(async () => {
+		if (sessionId) {
+			await deleteSession(sessionId);
+			sessionId = "";
+		}
+	});
+
+	test("steer sent while streaming is delivered immediately to the agent", async () => {
+		sessionId = await createSession();
+		const conn = await connectWs(sessionId);
+
+		try {
+			await conn.waitFor((m) => m.type === "queue_update");
+
+			// Make agent busy with a long-running turn
+			conn.send({ type: "prompt", text: "STAY_BUSY:5000 working on something" });
+			await conn.waitFor(statusPredicate("streaming"));
+
+			// Clear messages to track only steer-related events
+			conn.messages.length = 0;
+
+			// Send a steer while agent is streaming — the server should
+			// deliver this immediately via rpcClient.steer()
+			conn.send({ type: "steer", text: "STEER_REDIRECT_123" });
+
+			// The mock agent emits a message_end with [STEER_RECEIVED] when
+			// it receives a steer. This should arrive BEFORE the agent_end
+			// from the original turn.
+			const steerAck = await conn.waitFor(
+				(m) =>
+					m.type === "event" &&
+					m.data?.type === "message_end" &&
+					m.data?.message?.content?.[0]?.text?.includes("STEER_RECEIVED"),
+				5000,
+			);
+
+			expect(steerAck.data.message.content[0].text).toContain("STEER_REDIRECT_123");
+
+			// The steer should NOT have been queued — verify no queue_update
+			// with items was emitted
+			const queuedMsgs = conn.messages.filter(
+				(m: WsMsg) => m.type === "queue_update" && m.queue && m.queue.length > 0,
+			);
+			expect(queuedMsgs.length).toBe(0);
+		} finally {
+			conn.close();
+		}
+	});
+
+	test("prompt sent while streaming gets queued instead of being delivered as steer", async () => {
+		// This test demonstrates the BUG: the UI always sends { type: "prompt" }
+		// even when the agent is streaming. The server correctly queues prompts
+		// sent during streaming. After the fix, the UI will send { type: "steer" }
+		// instead, which bypasses the queue entirely.
+		sessionId = await createSession();
+		const conn = await connectWs(sessionId);
+
+		try {
+			await conn.waitFor((m) => m.type === "queue_update");
+
+			// Make agent busy
+			conn.send({ type: "prompt", text: "STAY_BUSY:5000 working on something" });
+			await conn.waitFor(statusPredicate("streaming"));
+
+			// Clear messages
+			conn.messages.length = 0;
+
+			// Send a prompt while streaming — this is what the UI currently does.
+			// BUG: This gets queued instead of being delivered as a steer.
+			conn.send({ type: "prompt", text: "redirect the agent please" });
+
+			// The message gets QUEUED (queue_update with 1 item).
+			// After the fix, the UI sends { type: "steer" } instead, which
+			// bypasses the queue and delivers immediately.
+			const queueMsg = await conn.waitFor(
+				(m: WsMsg) => m.type === "queue_update" && m.queue && m.queue.length > 0,
+				3000,
+			);
+
+			// BUG ASSERTION: The message should NOT be in the queue — it should
+			// have been delivered immediately as a steer. This fails because the
+			// current UI sends "prompt" which always queues during streaming.
+			expect(
+				queueMsg.queue.length,
+				"Expected message to be delivered as steer (queue empty), but it was queued instead — " +
+				"UI sends prompt instead of steer while streaming",
+			).toBe(0);
+		} finally {
+			conn.close();
+		}
+	});
+});

--- a/tests/e2e/ui/queue-ui.spec.ts
+++ b/tests/e2e/ui/queue-ui.spec.ts
@@ -27,6 +27,11 @@ test.describe("Queue UI E2E", () => {
 		const sessionId = await createSession();
 		await waitForSessionStatus(sessionId, "idle");
 
+		const conn = await connectWs(sessionId);
+
+		try {
+		await conn.waitFor((m) => m.type === "queue_update");
+
 		await openApp(page);
 
 		// Navigate to session
@@ -39,16 +44,15 @@ test.describe("Queue UI E2E", () => {
 		// Wait for streaming status (the stop button appears)
 		await expect(page.locator("button[title='Stop streaming']")).toBeVisible({ timeout: 10_000 });
 
-		// Queue 2 messages via textarea
-		const textarea = page.locator("textarea").first();
-		await textarea.fill("steer me");
-		await textarea.press("Enter");
+		// Queue 2 messages via WS (bypasses UI's steer-during-streaming logic)
+		conn.send({ type: "prompt", text: "steer me" });
+		await conn.waitFor(queueLenPredicate(1));
 
 		// Wait for the pill to appear
 		await expect(page.locator(".queue-pill").first()).toBeVisible({ timeout: 5_000 });
 
-		await textarea.fill("normal msg");
-		await textarea.press("Enter");
+		conn.send({ type: "prompt", text: "normal msg" });
+		await conn.waitFor(queueLenPredicate(2));
 
 		// Wait for 2 pills
 		await expect(page.locator(".queue-pill")).toHaveCount(2, { timeout: 5_000 });
@@ -75,11 +79,19 @@ test.describe("Queue UI E2E", () => {
 			},
 			{ timeout: 15_000 },
 		);
+		} finally {
+			conn.close();
+		}
 	});
 
 	test("story 12: multiple steer — both delivered on abort", async ({ page }) => {
 		const sessionId = await createSession();
 		await waitForSessionStatus(sessionId, "idle");
+
+		const conn = await connectWs(sessionId);
+
+		try {
+		await conn.waitFor((m) => m.type === "queue_update");
 
 		await openApp(page);
 		await page.evaluate((id) => { window.location.hash = `#/session/${id}`; }, sessionId);
@@ -89,14 +101,13 @@ test.describe("Queue UI E2E", () => {
 		await sendMessage(page, "STAY_BUSY:15000 working");
 		await expect(page.locator("button[title='Stop streaming']")).toBeVisible({ timeout: 10_000 });
 
-		// Queue 3 messages
-		const textarea = page.locator("textarea").first();
+		// Queue 3 messages via WS (bypasses UI's steer-during-streaming logic)
 		for (const text of ["steer A", "steer B", "normal C"]) {
-			await textarea.fill(text);
-			await textarea.press("Enter");
+			conn.send({ type: "prompt", text });
 		}
 
 		// Wait for 3 pills
+		await conn.waitFor(queueLenPredicate(3));
 		await expect(page.locator(".queue-pill")).toHaveCount(3, { timeout: 5_000 });
 
 		// Steer first two pills
@@ -118,6 +129,9 @@ test.describe("Queue UI E2E", () => {
 		// The non-steered message should also drain eventually
 		// Wait for queue to be empty (all processed)
 		await expect(page.locator(".queue-pill")).toHaveCount(0, { timeout: 15_000 });
+		} finally {
+			conn.close();
+		}
 	});
 
 	test("story 22: draft text persists across page reload", async ({ page }) => {


### PR DESCRIPTION
## Summary

When a user sends a message while the agent is streaming, it should be injected between tool calls as a steer (mid-turn redirect). Instead, it was always enqueued as a normal prompt and only delivered after the agent finished its turn.

## Root Cause

`AgentInterface.sendMessage()` always called `session.prompt()` regardless of streaming state, sending `{ type: "prompt" }` which the server queued. The server's steer handler worked correctly but was unreachable from the send path.

## Changes

- **`src/ui/components/AgentInterface.ts`**: `sendMessage()` now calls `session.steer()` when `isStreaming` is true and no attachments. Attachments fall back to `session.prompt()` (steer is text-only).
- **`src/app/remote-agent.ts`**: `steer()` now renders optimistic user messages matching `prompt()`'s pattern.
- **`docs/prompt-queue.md`**: Documents the new fourth dispatch path (direct steer) and fixes the optimistic rendering section.
- **`tests/e2e/steer-midturn.spec.ts`**: New E2E tests for steer delivery and prompt queuing during streaming.
- **`tests/e2e/ui/queue-ui.spec.ts`**: Updated stories 11 & 12 to queue via WS instead of textarea (since textarea now steers during streaming).
- **`tests/e2e/mock-agent.mjs`**: Added steer receipt event for test verification.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)