### PR TITLE
Improve proposal tool card UX

### DIFF
--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -948,6 +948,9 @@ export class RemoteAgent {
 			if (!input && typeof block.arguments === "string") {
 				try { input = JSON.parse(block.arguments); } catch { continue; }
 			}
+			if (!input && typeof block.arguments === "object" && block.arguments !== null) {
+				input = block.arguments;
+			}
 			if (!input || typeof input !== "object") continue;
 			callback(input);
 			// Track that this message had a tool-based proposal

--- a/src/ui/tools/renderers/ProposalRenderer.ts
+++ b/src/ui/tools/renderers/ProposalRenderer.ts
@@ -7,6 +7,7 @@ import { html } from "lit";
 import { FileText } from "lucide";
 import { renderHeader, getToolState } from "../renderer-registry.js";
 import type { ToolRenderer, ToolRenderResult } from "../types.js";
+import "../../../ui/components/ExpandableSection.js";
 
 /** Map tool name → display label and proposal type key */
 const PROPOSAL_LABELS: Record<string, { label: string; type: string; titleField: string; previewField: string }> = {
@@ -80,14 +81,16 @@ export class ProposalRenderer implements ToolRenderer {
 				<div class="space-y-2">
 					${renderHeader(state, FileText, meta.label)}
 					${title ? html`<div class="text-sm font-medium">${title}</div>` : ""}
-					${preview ? html`<div class="text-xs text-muted-foreground">${truncate(preview)}</div>` : ""}
+					${preview ? html`<expandable-section .summary=${truncate(preview, 80)}><markdown-block .content=${preview}></markdown-block></expandable-section>` : ""}
 					${result ? html`
-						<button
-							@click=${openProposal}
-							class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded bg-primary/10 text-primary hover:bg-primary/20 transition-colors cursor-pointer"
-						>
-							Open proposal
-						</button>
+						<div class="flex justify-end">
+							<button
+								@click=${openProposal}
+								class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded bg-primary/10 text-primary hover:bg-primary/20 transition-colors cursor-pointer"
+							>
+								Open proposal
+							</button>
+						</div>
 					` : ""}
 				</div>
 			`,


### PR DESCRIPTION
Three UX improvements to the proposal tool card (ProposalRenderer) plus a bug fix:

### 1. Fix: Auto-populate form from `propose_*` tool calls (BUG)
Added fallback in `_checkToolProposals()` for pi-ai `toolCall` blocks where `block.arguments` is already an object. Previously, proposals from pi-ai were silently skipped because the code only handled string arguments.

### 2. Right-align "Open proposal" button
Wrapped the button in a `flex justify-end` container so it sits on the right side of the card.

### 3. Expandable description with markdown rendering
Replaced truncated plain-text preview with a collapsible `<expandable-section>` that renders the full spec/description as markdown when expanded. Summary shows first ~80 chars when collapsed.

**Files changed:**
- `src/app/remote-agent.ts` — bug fix in `_checkToolProposals()`
- `src/ui/tools/renderers/ProposalRenderer.ts` — button alignment + expandable markdown

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)