### PR TITLE
fix(tests): Test health improvements

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3402,8 +3402,9 @@ async function handleApiRoute(
 			return;
 		}
 		const goalAdminFlag = body?.admin ? " --admin" : "";
+		const goalMergeBranch = goal.branch ? ` ${goal.branch}` : "";
 		try {
-			await execAsync(`gh pr merge --${method}${goalAdminFlag}`, { cwd, encoding: "utf-8", timeout: 30000 });
+			await execAsync(`gh pr merge${goalMergeBranch} --${method}${goalAdminFlag}`, { cwd, encoding: "utf-8", timeout: 30000 });
 			_prCache.delete(cwd);
 			if (goal.branch) _prCache.delete(`${cwd}::${goal.branch}`);
 			json({ ok: true });
@@ -4322,11 +4323,14 @@ async function handleApiRoute(
 			return;
 		}
 		const sessAdminFlag = body?.admin ? " --admin" : "";
-		const sessMergeBranch = session.goalId ? getGoalAcrossProjects(session.goalId)?.branch : undefined;
+		const sessMergeBranch = session.goalId
+			? getGoalAcrossProjects(session.goalId)?.branch
+			: sessionManager.getPersistedSession(id)?.branch;
+		const sessMergeBranchArg = sessMergeBranch ? ` ${sessMergeBranch}` : "";
 		try {
 			// PR merge uses `gh` CLI — for sandboxed sessions, run on host worktree
 			const mergeCwd = cid ? (session.worktreePath || cwd) : cwd;
-			await execAsync(`gh pr merge --${method}${sessAdminFlag}`, { cwd: mergeCwd, encoding: "utf-8", timeout: 30000 });
+			await execAsync(`gh pr merge${sessMergeBranchArg} --${method}${sessAdminFlag}`, { cwd: mergeCwd, encoding: "utf-8", timeout: 30000 });
 			_prCache.delete(cwd);
 			if (sessMergeBranch) _prCache.delete(`${cwd}::${sessMergeBranch}`);
 			json({ ok: true });

--- a/tests/e2e/ui/palette-session.spec.ts
+++ b/tests/e2e/ui/palette-session.spec.ts
@@ -5,13 +5,17 @@
  * refreshSessions() resolved, causing the palette to revert to the global one
  * when the session wasn't yet in gatewaySessions.
  */
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { test, expect } from "../gateway-harness.js";
-import { apiFetch, nonGitCwd } from "../e2e-setup.js";
+import { apiFetch } from "../e2e-setup.js";
 import { openApp, navigateToHash } from "./ui-helpers.js";
 
 test.describe("Project palette on session navigation", () => {
 	let projectId: string;
 	let sessionId: string;
+	let paletteDir: string;
 
 	test.afterEach(async () => {
 		if (sessionId) {
@@ -20,15 +24,21 @@ test.describe("Project palette on session navigation", () => {
 		if (projectId) {
 			await apiFetch(`/api/projects/${projectId}`, { method: "DELETE" }).catch(() => {});
 		}
+		if (paletteDir) {
+			rmSync(paletteDir, { recursive: true, force: true });
+		}
 	});
 
 	test("palette matches project after navigating to session", async ({ page }) => {
+		// Use a unique directory to avoid rootPath conflicts with other tests
+		paletteDir = mkdtempSync(join(tmpdir(), "bobbit-palette-test-"));
+
 		// Create a project with the "ocean" palette
 		const projResp = await apiFetch("/api/projects", {
 			method: "POST",
 			body: JSON.stringify({
 				name: "palette-test",
-				rootPath: nonGitCwd(),
+				rootPath: paletteDir,
 				palette: "ocean",
 			}),
 		});
@@ -40,7 +50,7 @@ test.describe("Project palette on session navigation", () => {
 		const sessResp = await apiFetch("/api/sessions", {
 			method: "POST",
 			body: JSON.stringify({
-				cwd: nonGitCwd(),
+				cwd: paletteDir,
 				projectId,
 			}),
 		});

--- a/tests/system-prompt-cwd.test.ts
+++ b/tests/system-prompt-cwd.test.ts
@@ -60,14 +60,14 @@ describe("system prompt working directory section", () => {
 			assert.ok(promptPath);
 			const content = fs.readFileSync(promptPath, "utf-8");
 
-			const projectIdx = content.indexOf("# Project Context");
+			const projectIdx = content.indexOf("# Project AGENTS.md");
 			const cwdIdx = content.indexOf("# Working Directory");
 			const goalIdx = content.indexOf("# Goal");
 
-			assert.ok(projectIdx >= 0, "should have Project Context section");
+			assert.ok(projectIdx >= 0, "should have Project AGENTS.md section");
 			assert.ok(cwdIdx >= 0, "should have Working Directory section");
 			assert.ok(goalIdx >= 0, "should have Goal section");
-			assert.ok(projectIdx < cwdIdx, "Project Context should come before Working Directory");
+			assert.ok(projectIdx < cwdIdx, "Project AGENTS.md should come before Working Directory");
 			assert.ok(cwdIdx < goalIdx, "Working Directory should come before Goal");
 		});
 
@@ -116,14 +116,14 @@ describe("system prompt working directory section", () => {
 			}));
 
 			const labels = sections.map(s => s.label);
-			const projectIdx = labels.indexOf("Project Context");
+			const projectIdx = labels.indexOf("Project AGENTS.md");
 			const cwdIdx = labels.indexOf("Working Directory");
 			const goalIdx = labels.indexOf("Goal");
 
-			assert.ok(projectIdx >= 0, "should have Project Context");
+			assert.ok(projectIdx >= 0, "should have Project AGENTS.md");
 			assert.ok(cwdIdx >= 0, "should have Working Directory");
 			assert.ok(goalIdx >= 0, "should have Goal");
-			assert.ok(projectIdx < cwdIdx, "Project Context before Working Directory");
+			assert.ok(projectIdx < cwdIdx, "Project AGENTS.md before Working Directory");
 			assert.ok(cwdIdx < goalIdx, "Working Directory before Goal");
 		});
 	});

--- a/tests/system-prompt.test.ts
+++ b/tests/system-prompt.test.ts
@@ -156,7 +156,7 @@ describe("assembleSystemPrompt", () => {
 		const result = assembleSystemPrompt("test-session-2", { cwd: cwdDir });
 		assert.ok(result);
 		const content = fs.readFileSync(result, "utf-8");
-		assert.ok(content.includes("# Project Context"));
+		assert.ok(content.includes("# Project AGENTS.md"));
 		assert.ok(content.includes("Use TypeScript."));
 	});
 


### PR DESCRIPTION
## Test Health Improvements

| Issue | File | Root Cause | Fix |
|-------|------|------------|-----|
| 3 consistent unit test failures | `system-prompt-cwd.test.ts`, `system-prompt.test.ts` | Section heading renamed from "Project Context" to "Project AGENTS.md" in source but tests still referenced old name | Updated test assertions to match current heading |
| 1 flaky E2E test | `palette-session.spec.ts` | Used shared `nonGitCwd()` path for project creation; duplicate rootPath from parallel tests caused 400 errors | Each test run now creates its own unique temp directory via `mkdtempSync` |
| PR merge fails in worktree sessions | `server.ts` (goal + session pr-merge handlers) | `gh pr merge` was called without a branch name, so it inferred the branch from the worktree HEAD (e.g. `staff-test-health-guardian-c0923f6b`) instead of the actual PR branch (e.g. `staff/test-health`) | Pass resolved branch name explicitly to `gh pr merge` in both handlers |

### Verification
- All 433 unit tests pass
- All 513 E2E tests pass
- No slow tests detected (unit <5s, E2E <30s)

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)