### PR TITLE
Replace dead sandbox pool settings with worktree pool settings

### DIFF
--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -168,8 +168,8 @@ let sandboxStatusLocal: { available: boolean; error?: string; dockerVersion?: st
 let sandboxStatusLoaded = false;
 let sandboxBuildInProgress = false;
 let sandboxBuildError = "";
-let poolStatus: { enabled: boolean; total?: number; idle?: number; claimed?: number; warming?: number } | null = null;
-let poolStatusLoaded = false;
+let worktreePoolStatus: { enabled: boolean; ready?: number; target?: number; filling?: boolean } | null = null;
+let worktreePoolStatusLoaded = false;
 let hostTokens: { envVar: string; label: string; available: boolean }[] | null = null;
 let hostTokensLoaded = false;
 
@@ -203,18 +203,18 @@ function loadHostTokens(): void {
 	});
 }
 
-function loadPoolStatus(): void {
-	if (poolStatusLoaded) return;
-	poolStatusLoaded = true;
-	gatewayFetch("/api/sandbox-pool").then(async (res) => {
+function loadWorktreePoolStatus(): void {
+	if (worktreePoolStatusLoaded) return;
+	worktreePoolStatusLoaded = true;
+	gatewayFetch("/api/worktree-pool").then(async (res) => {
 		if (res.ok) {
-			poolStatus = await res.json();
+			worktreePoolStatus = await res.json();
 		} else {
-			poolStatus = { enabled: false };
+			worktreePoolStatus = { enabled: false };
 		}
 		renderApp();
 	}).catch(() => {
-		poolStatus = { enabled: false };
+		worktreePoolStatus = { enabled: false };
 		renderApp();
 	});
 }
@@ -562,70 +562,52 @@ function renderSandboxSection(
 				>${icon(Plus, "xs")} Add mount</button>
 			</div>
 
-			<!-- Container Pool -->
-			${sandboxMode === "docker" ? html`
-				<div class="border-t border-border pt-2 mt-1 flex flex-col gap-2">
-					<div class="text-[11px] text-muted-foreground uppercase tracking-wider font-medium">Container Pool</div>
-					<p class="text-xs text-muted-foreground -mt-1">
-						Pre-warmed containers reduce sandbox startup time. Changes take effect on gateway restart.
-					</p>
+			<!-- Worktree Pool -->
+			<div class="border-t border-border pt-2 mt-1 flex flex-col gap-2">
+				<div class="text-[11px] text-muted-foreground uppercase tracking-wider font-medium">Worktree Pool</div>
+				<p class="text-xs text-muted-foreground -mt-1">
+					Pre-built git worktrees so new sessions start instantly instead of waiting for setup. Changes take effect on gateway restart.
+				</p>
 
-					<div class="flex items-center gap-3">
-						<span class="${labelClass}">Pool Size</span>
-						<input
-							type="number"
-							min="0"
-							class="${inputClass} max-w-32"
-							placeholder="2"
-							.value=${pendingChanges.sandbox_pool_size ?? resolved.sandbox_pool_size?.value ?? ""}
-							@input=${(e: Event) => {
-								pendingChanges.sandbox_pool_size = (e.target as HTMLInputElement).value;
-							}}
-						/>
-						<span class="text-xs text-muted-foreground">Pre-warmed containers (0 = disable)</span>
-					</div>
-
-					<div class="flex items-center gap-3">
-						<span class="${labelClass}">Max Idle Time</span>
-						<input
-							type="number"
-							min="0"
-							class="${inputClass} max-w-32"
-							placeholder="300"
-							.value=${pendingChanges.sandbox_pool_max_idle ?? resolved.sandbox_pool_max_idle?.value ?? ""}
-							@input=${(e: Event) => {
-								pendingChanges.sandbox_pool_max_idle = (e.target as HTMLInputElement).value;
-							}}
-						/>
-						<span class="text-xs text-muted-foreground">Seconds before excess containers culled</span>
-					</div>
-
-					<div class="flex items-center gap-3">
-						<span class="${labelClass}">Pool Status</span>
-						<div class="flex items-center gap-2 text-sm">
-							${(() => {
-								loadPoolStatus();
-								if (poolStatus === null) return html`<span class="text-muted-foreground">Loading...</span>`;
-								if (!poolStatus.enabled) return html`<span class="text-muted-foreground">Pool disabled</span>`;
-								return html`
-									<span class="text-xs font-mono flex items-center gap-3">
-										<span>Total: <span class="text-foreground font-medium">${poolStatus.total}</span></span>
-										<span>Idle: <span class="text-foreground font-medium">${poolStatus.idle}</span></span>
-										<span>Claimed: <span class="text-foreground font-medium">${poolStatus.claimed}</span></span>
-										<span>Warming: <span class="text-foreground font-medium">${poolStatus.warming}</span></span>
-									</span>
-								`;
-							})()}
-							<button
-								class="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors ml-1"
-								title="Refresh pool status"
-								@click=${() => { poolStatusLoaded = false; poolStatus = null; loadPoolStatus(); }}
-							>${icon(RotateCcw, "xs")}</button>
-						</div>
-					</div>
-
+				<div class="flex items-center gap-3">
+					<span class="${labelClass}">Pool Size</span>
+					<input
+						type="number"
+						min="0"
+						class="${inputClass} max-w-32"
+						placeholder="2"
+						.value=${pendingChanges.worktree_pool_size ?? resolved.worktree_pool_size?.value ?? ""}
+						@input=${(e: Event) => {
+							pendingChanges.worktree_pool_size = (e.target as HTMLInputElement).value;
+						}}
+					/>
+					<span class="text-xs text-muted-foreground">Pre-built worktrees (0 = disable)</span>
 				</div>
-			` : ""}
+
+				<div class="flex items-center gap-3">
+					<span class="${labelClass}">Pool Status</span>
+					<div class="flex items-center gap-2 text-sm">
+						${(() => {
+							loadWorktreePoolStatus();
+							if (worktreePoolStatus === null) return html`<span class="text-muted-foreground">Loading...</span>`;
+							if (!worktreePoolStatus.enabled) return html`<span class="text-muted-foreground">Pool disabled</span>`;
+							return html`
+								<span class="text-xs font-mono flex items-center gap-3">
+									<span>Ready: <span class="text-foreground font-medium">${worktreePoolStatus.ready}</span></span>
+									<span>Target: <span class="text-foreground font-medium">${worktreePoolStatus.target}</span></span>
+									${worktreePoolStatus.filling ? html`<span class="text-orange-500">Filling…</span>` : ""}
+								</span>
+							`;
+						})()}
+						<button
+							class="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors ml-1"
+							title="Refresh pool status"
+							@click=${() => { worktreePoolStatusLoaded = false; worktreePoolStatus = null; loadWorktreePoolStatus(); }}
+						>${icon(RotateCcw, "xs")}</button>
+					</div>
+				</div>
+
+			</div>
 		</div>
 	`;
 }
@@ -1963,7 +1945,8 @@ function renderProjectScopeTab(projectId: string) {
 	// Keys to show in the Commands & Sandbox tab
 	const HIDDEN_KEYS = new Set([
 		"default_thinking_level", "sandbox", "sandbox_image",
-		"sandbox_tokens", "sandbox_credentials", "sandbox_github_token", "sandbox_host_token_overrides", "sandbox_mounts", "sandbox_pool_size", "sandbox_pool_max_idle",
+		"sandbox_tokens", "sandbox_credentials", "sandbox_github_token", "sandbox_host_token_overrides", "sandbox_mounts",
+		"worktree_pool_size",
 		"config_directories", "skill_directories",
 		// Rendered in dedicated sections below
 		"qa_start_command", "qa_build_command", "qa_health_check", "qa_browser_entry",

--- a/src/server/agent/project-config-store.ts
+++ b/src/server/agent/project-config-store.ts
@@ -29,8 +29,7 @@ const DEFAULTS: Record<string, string> = {
 	sandbox_github_token: "true",       // DEPRECATED — use sandbox_tokens. "true" | "false"
 	sandbox_host_token_overrides: "",   // DEPRECATED — use sandbox_tokens. JSON object: '{"GITHUB_TOKEN":"false","NPM_TOKEN":"false"}'
 	sandbox_mounts: "",                 // JSON array: '["/shared/data:/data:ro"]'
-	sandbox_pool_size: "2",             // Pre-warmed containers (0 = disable pooling)
-	sandbox_pool_max_idle: "300",       // Seconds before excess idle containers culled
+	worktree_pool_size: "2",            // Pre-built worktrees for instant session startup (0 = disable)
 	qa_start_command: "",               // How to start an isolated server for QA
 	qa_build_command: "",               // Build command for QA (defaults to build_command)
 	qa_health_check: "",                // URL to check server health

--- a/src/server/agent/worktree-pool.ts
+++ b/src/server/agent/worktree-pool.ts
@@ -40,6 +40,22 @@ export class WorktreePool {
 	/** Number of ready worktrees available. */
 	get size(): number { return this.pool.length; }
 
+	/** Target pool size. */
+	get target(): number { return this.targetSize; }
+
+	/** Whether the pool is currently filling. */
+	get isFilling(): boolean { return this.filling; }
+
+	/** Status snapshot for the API. */
+	getStatus(): { enabled: boolean; ready: number; target: number; filling: boolean } {
+		return {
+			enabled: this.targetSize > 0,
+			ready: this.pool.length,
+			target: this.targetSize,
+			filling: this.filling,
+		};
+	}
+
 	/**
 	 * Start filling the pool in the background. Call once after startup.
 	 *

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1194,13 +1194,24 @@ async function handleApiRoute(
 		return;
 	}
 
-	// GET /api/sandbox-pool
+	// GET /api/sandbox-pool (deprecated — no longer a real pool, returns basic stats)
 	if (url.pathname === "/api/sandbox-pool" && req.method === "GET") {
 		if (sandboxManager) {
 			const stats = sandboxManager.getStats();
 			json({ ...stats, type: "sandbox" });
 		} else {
 			json({ enabled: false });
+		}
+		return;
+	}
+
+	// GET /api/worktree-pool
+	if (url.pathname === "/api/worktree-pool" && req.method === "GET") {
+		const pool = sessionManager.getWorktreePool();
+		if (pool) {
+			json(pool.getStatus());
+		} else {
+			json({ enabled: false, ready: 0, target: 0, filling: false });
 		}
 		return;
 	}


### PR DESCRIPTION
## Summary

Replace the defunct Docker container pool settings UI with worktree pool settings. The old per-agent container pool was replaced by a single persistent container per project (`ProjectSandbox`), making `sandbox_pool_size` and `sandbox_pool_max_idle` dead code. Meanwhile, the worktree pool (`WorktreePool`) had no UI — it was only configurable by manually editing `project.yaml`.

## Changes

- **Remove** `sandbox_pool_size` and `sandbox_pool_max_idle` from project config defaults
- **Remove** the "Container Pool" UI section from settings (was gated on sandbox docker mode)
- **Add** `worktree_pool_size` to project config defaults (default: `"2"`)
- **Add** `GET /api/worktree-pool` endpoint returning `{ enabled, ready, target, filling }`
- **Add** `getStatus()` method to `WorktreePool` class
- **Add** "Worktree Pool" UI section in settings with:
  - Pool size input (0 = disable)
  - Live status display (ready/target counts + filling indicator)
  - Refresh button
- Worktree pool section is always visible (not gated on sandbox mode) since pooling applies to all session types

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)