### PR TITLE
Fix Bobbit sprite eyes appearing semi-transparent

### DIFF
--- a/src/ui/bobbit-render.ts
+++ b/src/ui/bobbit-render.ts
@@ -58,9 +58,9 @@ export interface SidebarBobbitOptions {
 // PALETTES
 // ============================================================================
 
-export const CANONICAL_PALETTE: BobbitPalette = { main: "#8ec63f", light: "#b5d98a", dark: "#6b9930", eye: "#1a3010" };
-export const STARTING_PALETTE: BobbitPalette = { main: "#eab308", light: "#fde047", dark: "#ca8a04", eye: "#2d2006" };
-export const TERMINATED_PALETTE: BobbitPalette = { main: "#ef4444", light: "#fca5a5", dark: "#dc2626", eye: "#2c0b0e" };
+export const CANONICAL_PALETTE: BobbitPalette = { main: "#8ec63f", light: "#b5d98a", dark: "#6b9930", eye: "#000000" };
+export const STARTING_PALETTE: BobbitPalette = { main: "#eab308", light: "#fde047", dark: "#ca8a04", eye: "#000000" };
+export const TERMINATED_PALETTE: BobbitPalette = { main: "#ef4444", light: "#fca5a5", dark: "#dc2626", eye: "#000000" };
 
 export const NO_ACCESSORY: AccessoryDef = { id: "none", label: "None", shadow: "", yOffset: 0, addsHeight: false };
 


### PR DESCRIPTION
The Bobbit sprite's eyes used dark-tinted variants of the body color (`#1a3010` dark green, `#2d2006` dark yellow, `#2c0b0e` dark red for canonical/starting/terminated palettes) instead of pure black. At the small pixel-art scale, these appeared noticeably lighter than the `#000` outline, giving a semi-transparent look.

Changed all three palette eye colors to `#000000` to match the outline for a crisp, consistent appearance.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)