### PR TITLE
Fix background process pill portal bugs

### DIFF
--- a/src/ui/components/BgProcessPill.ts
+++ b/src/ui/components/BgProcessPill.ts
@@ -147,15 +147,15 @@ export class BgProcessPill extends LitElement {
 		}
 	}
 
-	private _kill(e: MouseEvent) {
+	private _kill = (e: MouseEvent) => {
 		e.stopPropagation();
 		if (this.onKill) this.onKill(this.process.id);
-	}
+	};
 
-	private _dismiss(e: MouseEvent) {
+	private _dismiss = (e: MouseEvent) => {
 		e.stopPropagation();
 		if (this.onDismiss) this.onDismiss(this.process.id);
-	}
+	};
 
 	private _fmtTime(ts: number): string {
 		const d = new Date(ts);
@@ -289,6 +289,10 @@ export class BgProcessPill extends LitElement {
 			} else if (!this._closing) {
 				this._removePortal();
 			}
+		} else if (this.expanded && this._portalEl && (changed.has("loadingLogs") || changed.has("logs"))) {
+			// Re-render portal when log state changes — portal content is outside
+			// Lit's render tree so @state() changes don't automatically propagate.
+			this._renderPortal();
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fix two bugs in the background process pill dropdown caused by the dropdown being rendered into a DOM portal outside Lit's render tree.

## Bugs Fixed

### 1. Finished jobs show "Loading..." indefinitely

When clicking a finished background process pill, the dropdown shows "Loading..." and never updates. The `_fetchLogs()` method updates `loadingLogs` and `logs` `@state()` properties, but the `updated()` lifecycle callback only re-rendered the portal when `expanded` changed — log state changes were silently ignored.

**Fix:** Added portal re-render in `updated()` when `loadingLogs` or `logs` change while the dropdown is open.

### 2. Kill button in dropdown does nothing

The "Kill" button inside the expanded dropdown silently fails. `_kill` and `_dismiss` were regular class methods. When invoked from the portal (rendered via `litRender()` without a Lit host), `this` was the button element rather than the component, so `this.onKill` resolved to `undefined`. The ✕ button on the pill itself worked because it lives in Lit's own `render()` tree where host binding is preserved.

**Fix:** Changed `_kill` and `_dismiss` to arrow functions so `this` is lexically bound to the component instance.

## Changed Files

- `src/ui/components/BgProcessPill.ts`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)