### PR TITLE
Persist Prompt Sections

### DIFF
--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -3496,11 +3496,7 @@ export class SessionManager {
 		}
 
 		// Delete persisted prompt sections JSON
-		try {
-			purgePromptSectionsJson(ps.id);
-		} catch (err) {
-			console.error(`[session-manager] Failed to purge prompt sections for ${ps.id}:`, err);
-		}
+		purgePromptSectionsJson(ps.id);
 
 		// Clean up host worktree.  Sandboxed session worktrees also create a host-side
 		// worktree for server bookkeeping, so we clean those up too.  Skip paths that

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -16,7 +16,7 @@ import { sessionFileExists, sessionFileRead, sessionFileDelete, type SessionFsCo
 import { SessionStore, type PersistedSession } from "./session-store.js";
 import { getAssistantDef } from "./assistant-registry.js";
 import { buildReattemptContext } from "./goal-assistant.js";
-import { assembleSystemPrompt, cleanupSessionPrompt, type PromptParts } from "./system-prompt.js";
+import { assembleSystemPrompt, cleanupSessionPrompt, persistPromptSections, purgePromptSectionsJson, type PromptParts } from "./system-prompt.js";
 import { generateSessionTitle, generateGoalSummaryTitle } from "./title-generator.js";
 import { CostTracker } from "./cost-tracker.js";
 import type { ColorStore } from "./color-store.js";
@@ -886,6 +886,8 @@ export class SessionManager {
 		// Cache parts for prompt-sections API
 		const session = this.sessions.get(sessionId);
 		if (session) session.promptParts = parts;
+		// Persist prompt sections snapshot for the inspector
+		persistPromptSections(sessionId, parts);
 		return assembleSystemPrompt(sessionId, parts);
 	}
 
@@ -3491,6 +3493,13 @@ export class SessionManager {
 			cleanupSessionPrompt(ps.id);
 		} catch (err) {
 			console.error(`[session-manager] Failed to cleanup prompt for ${ps.id}:`, err);
+		}
+
+		// Delete persisted prompt sections JSON
+		try {
+			purgePromptSectionsJson(ps.id);
+		} catch (err) {
+			console.error(`[session-manager] Failed to purge prompt sections for ${ps.id}:`, err);
 		}
 
 		// Clean up host worktree.  Sandboxed session worktrees also create a host-side

--- a/src/server/agent/system-prompt.ts
+++ b/src/server/agent/system-prompt.ts
@@ -381,6 +381,46 @@ export function getPromptSections(parts: PromptParts): PromptSection[] {
 }
 
 /**
+ * Persist the resolved prompt sections as a JSON snapshot at session creation time.
+ * This captures the actual prompt that was used, not a reconstruction from current files.
+ */
+export function persistPromptSections(sessionId: string, parts: PromptParts): void {
+	try {
+		const sections = getPromptSections(parts);
+		const totalTokens = sections.reduce((sum, s) => sum + s.tokens, 0);
+		const data = { sections, totalTokens, createdAt: new Date().toISOString() };
+		const jsonPath = path.join(getPromptsDir(), `${sessionId}-prompt.json`);
+		fs.writeFileSync(jsonPath, JSON.stringify(data), "utf-8");
+	} catch (err) {
+		console.error(`[system-prompt] Failed to persist prompt sections for ${sessionId}:`, err);
+	}
+}
+
+/**
+ * Load persisted prompt sections snapshot for a session.
+ * Returns null if the file doesn't exist or can't be parsed.
+ */
+export function loadPersistedPromptSections(sessionId: string): { sections: PromptSection[]; totalTokens: number; createdAt: string } | null {
+	try {
+		const jsonPath = path.join(getPromptsDir(), `${sessionId}-prompt.json`);
+		if (!fs.existsSync(jsonPath)) return null;
+		return JSON.parse(fs.readFileSync(jsonPath, "utf-8"));
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Delete the persisted prompt sections JSON for a session (archive purge only).
+ */
+export function purgePromptSectionsJson(sessionId: string): void {
+	try {
+		const jsonPath = path.join(getPromptsDir(), `${sessionId}-prompt.json`);
+		if (fs.existsSync(jsonPath)) fs.unlinkSync(jsonPath);
+	} catch { /* ignore */ }
+}
+
+/**
  * Clean up a session's assembled prompt file.
  */
 export function cleanupSessionPrompt(sessionId: string): void {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -24,7 +24,7 @@ import { ToolManager } from "./agent/tool-manager.js";
 import { PersonalityStore } from "./agent/personality-store.js";
 import { PersonalityManager } from "./agent/personality-manager.js";
 
-import { getPromptSections, initPromptDirs } from "./agent/system-prompt.js";
+import { getPromptSections, initPromptDirs, loadPersistedPromptSections } from "./agent/system-prompt.js";
 import type { TaskState } from "./agent/task-store.js";
 import { TaskManager } from "./agent/task-manager.js";
 import { TaskStore } from "./agent/task-store.js";
@@ -4832,6 +4832,15 @@ async function handleApiRoute(
 	const promptSectionsMatch = url.pathname.match(/^\/api\/sessions\/([^/]+)\/prompt-sections$/);
 	if (promptSectionsMatch && req.method === "GET") {
 		const id = promptSectionsMatch[1];
+
+		// Try persisted snapshot first (captures the actual prompt at creation time)
+		const persisted = loadPersistedPromptSections(id);
+		if (persisted) {
+			json(persisted);
+			return;
+		}
+
+		// Fallback: reconstruct for legacy sessions without a persisted snapshot
 		const parts = sessionManager.getPromptParts(id);
 		if (!parts) { json({ error: "Session not found or no prompt data" }, 404); return; }
 

--- a/tests/e2e/prompt-sections-persist.spec.ts
+++ b/tests/e2e/prompt-sections-persist.spec.ts
@@ -13,7 +13,6 @@ import {
 	deleteSession,
 	apiFetch,
 	connectWs,
-	waitForSessionStatus,
 	statusPredicate,
 } from "./e2e-setup.js";
 
@@ -101,10 +100,7 @@ test.describe("Persisted prompt sections", () => {
 		const delResp = await apiFetch(`/api/sessions/${sessionId}`, { method: "DELETE" });
 		expect(delResp.status).toBe(200);
 
-		// Wait briefly for cleanup to complete
-		await new Promise(r => setTimeout(r, 500));
-
-		// Prompt sections should still be available
+		// Prompt sections should still be available (persisted JSON survives termination)
 		const afterResp = await apiFetch(`/api/sessions/${sessionId}/prompt-sections`);
 		expect(afterResp.status).toBe(200);
 		const afterData = await afterResp.json();

--- a/tests/e2e/prompt-sections-persist.spec.ts
+++ b/tests/e2e/prompt-sections-persist.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * E2E tests for persisted prompt sections.
+ *
+ * Verifies that prompt sections are written as a JSON file at session creation
+ * time and served from GET /api/sessions/:id/prompt-sections. The persisted
+ * JSON survives session termination but is deleted during archive purge.
+ */
+import { test, expect } from "./in-process-harness.js";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+	createSession,
+	deleteSession,
+	apiFetch,
+	connectWs,
+	waitForSessionStatus,
+	statusPredicate,
+} from "./e2e-setup.js";
+
+test.setTimeout(30_000);
+
+test.describe("Persisted prompt sections", () => {
+	let sessionId: string;
+
+	test.afterEach(async () => {
+		if (sessionId) {
+			await deleteSession(sessionId).catch(() => {});
+			sessionId = "";
+		}
+	});
+
+	test("prompt sections returned with createdAt after session creation", async ({ gateway }) => {
+		sessionId = await createSession();
+		const conn = await connectWs(sessionId);
+		try {
+			conn.send({ type: "prompt", text: "Reply with OK" });
+			await conn.waitFor(statusPredicate("idle"), 15_000);
+		} finally {
+			conn.close();
+		}
+
+		const resp = await apiFetch(`/api/sessions/${sessionId}/prompt-sections`);
+		expect(resp.status).toBe(200);
+		const data = await resp.json();
+
+		// Must have sections array with at least one entry
+		expect(Array.isArray(data.sections)).toBe(true);
+		expect(data.sections.length).toBeGreaterThanOrEqual(1);
+
+		// Each section must have the expected fields
+		for (const section of data.sections) {
+			expect(typeof section.label).toBe("string");
+			expect(typeof section.source).toBe("string");
+			expect(typeof section.content).toBe("string");
+			expect(typeof section.tokens).toBe("number");
+		}
+
+		// Must have totalTokens as a positive number
+		expect(typeof data.totalTokens).toBe("number");
+		expect(data.totalTokens).toBeGreaterThan(0);
+
+		// Must have createdAt as a valid ISO date string
+		expect(typeof data.createdAt).toBe("string");
+		const parsed = new Date(data.createdAt);
+		expect(parsed.getTime()).not.toBeNaN();
+		// Sanity check: createdAt is recent (within last 60 seconds)
+		expect(Date.now() - parsed.getTime()).toBeLessThan(60_000);
+	});
+
+	test("prompt sections JSON file exists on disk", async ({ gateway }) => {
+		sessionId = await createSession();
+		const conn = await connectWs(sessionId);
+		try {
+			conn.send({ type: "prompt", text: "Reply with OK" });
+			await conn.waitFor(statusPredicate("idle"), 15_000);
+		} finally {
+			conn.close();
+		}
+
+		const promptFile = join(gateway.bobbitDir, "state", "session-prompts", `${sessionId}-prompt.json`);
+		expect(existsSync(promptFile)).toBe(true);
+	});
+
+	test("prompt sections survive session termination", async ({ gateway }) => {
+		sessionId = await createSession();
+		const conn = await connectWs(sessionId);
+		try {
+			conn.send({ type: "prompt", text: "Reply with OK" });
+			await conn.waitFor(statusPredicate("idle"), 15_000);
+		} finally {
+			conn.close();
+		}
+
+		// Capture the sections before termination
+		const beforeResp = await apiFetch(`/api/sessions/${sessionId}/prompt-sections`);
+		expect(beforeResp.status).toBe(200);
+		const beforeData = await beforeResp.json();
+		expect(beforeData.sections.length).toBeGreaterThanOrEqual(1);
+
+		// Terminate the session
+		const delResp = await apiFetch(`/api/sessions/${sessionId}`, { method: "DELETE" });
+		expect(delResp.status).toBe(200);
+
+		// Wait briefly for cleanup to complete
+		await new Promise(r => setTimeout(r, 500));
+
+		// Prompt sections should still be available
+		const afterResp = await apiFetch(`/api/sessions/${sessionId}/prompt-sections`);
+		expect(afterResp.status).toBe(200);
+		const afterData = await afterResp.json();
+
+		// Same data as before termination
+		expect(afterData.sections.length).toBe(beforeData.sections.length);
+		expect(afterData.totalTokens).toBe(beforeData.totalTokens);
+		expect(afterData.createdAt).toBe(beforeData.createdAt);
+
+		// The JSON file should still exist on disk
+		const promptFile = join(gateway.bobbitDir, "state", "session-prompts", `${sessionId}-prompt.json`);
+		expect(existsSync(promptFile)).toBe(true);
+
+		// Prevent afterEach from trying to delete already-terminated session
+		sessionId = "";
+	});
+});


### PR DESCRIPTION
## Summary

Persist the resolved prompt sections as a JSON file at session creation time, so the System Prompt Inspector shows the **actual** prompt used when the session was created — not a reconstruction from current files.

### Changes

**Server** (3 files, ~60 lines):
- `system-prompt.ts`: Added `persistPromptSections()`, `loadPersistedPromptSections()`, and `purgePromptSectionsJson()`
- `session-manager.ts`: Calls persist in `assemblePrompt()`, calls purge in `purgeOneSession()`
- `server.ts`: `GET /api/sessions/:id/prompt-sections` serves persisted JSON first, falls back to reconstruction for legacy sessions

**Tests** (1 new file, 120 lines):
- `prompt-sections-persist.spec.ts`: 3 API E2E tests covering creation, disk persistence, and survival after termination

### Behavior
- JSON written to `session-prompts/{sessionId}-prompt.json` at session creation
- Survives server restarts and session termination
- Deleted only during archive purge (alongside `.jsonl`)
- Legacy sessions without JSON fall back to current reconstruction
- No UI changes needed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)