### PR TITLE
Fix sandbox CPU allocation to respect Docker limits

### DIFF
--- a/src/server/agent/project-sandbox.ts
+++ b/src/server/agent/project-sandbox.ts
@@ -26,6 +26,67 @@ const execFileAsync = promisify(execFileCb);
 /** Env config for docker commands — suppresses MSYS path mangling on Windows. */
 const DOCKER_ENV = { ...process.env, MSYS_NO_PATHCONV: "1", MSYS2_ARG_CONV_EXCL: "*" };
 
+// ── Docker resource limits ─────────────────────────────────────────────────
+
+interface DockerResourceLimits {
+	cpus: number;
+	memBytes: number;
+}
+
+let _cachedDockerLimits: DockerResourceLimits | null | undefined; // undefined = not yet queried
+
+/**
+ * Query Docker daemon's available CPU and memory.
+ * Cached for the process lifetime (Docker resource limits don't change mid-session).
+ * Returns null if `docker info` fails (caller should fall back to host values).
+ */
+export async function getDockerResourceLimits(): Promise<DockerResourceLimits | null> {
+	if (_cachedDockerLimits !== undefined) return _cachedDockerLimits;
+
+	try {
+		const { stdout } = await execFileAsync(
+			"docker", ["info", "--format", "{{.NCPU}} {{.MemTotal}}"],
+			{ timeout: 5_000, env: DOCKER_ENV },
+		);
+		const parts = stdout.trim().split(/\s+/);
+		const cpus = parseInt(parts[0], 10);
+		const memBytes = parseInt(parts[1], 10);
+		if (Number.isNaN(cpus) || Number.isNaN(memBytes) || cpus <= 0 || memBytes <= 0) {
+			_cachedDockerLimits = null;
+			return null;
+		}
+		_cachedDockerLimits = { cpus, memBytes };
+		return _cachedDockerLimits;
+	} catch {
+		_cachedDockerLimits = null;
+		return null;
+	}
+}
+
+/**
+ * Pure computation of container resource limits — easy to unit-test.
+ * Takes host values and optional Docker-reported limits; returns { cpus, memoryGB }.
+ */
+export function computeResourceLimits(
+	hostCpus: number,
+	hostMemBytes: number,
+	dockerCpus?: number,
+	dockerMemBytes?: number,
+): { cpus: number; memoryGB: number } {
+	const effectiveCpus = dockerCpus != null ? Math.min(hostCpus, dockerCpus) : hostCpus;
+	const effectiveMemBytes = dockerMemBytes != null ? Math.min(hostMemBytes, dockerMemBytes) : hostMemBytes;
+
+	return {
+		cpus: Math.max(2, effectiveCpus - 2),
+		memoryGB: Math.max(4, Math.floor(effectiveMemBytes / (1024 ** 3)) - 2),
+	};
+}
+
+/** @internal — exported for testing only. Resets the cached Docker limits. */
+export function _resetDockerLimitsCache(): void {
+	_cachedDockerLimits = undefined;
+}
+
 // ── Types ──────────────────────────────────────────────────────────────────
 
 export interface ProjectSandboxOptions {
@@ -371,8 +432,14 @@ export class ProjectSandbox {
 		}
 
 		// Dynamic resource limits: N-2 cores, M-2GB memory, no PID limit
-		const totalMemGB = Math.max(4, Math.floor(os.totalmem() / (1024 ** 3)) - 2);
-		const totalCpus = Math.max(2, os.cpus().length - 2);
+		// Query Docker daemon to avoid requesting more resources than the VM has
+		const dockerLimits = await getDockerResourceLimits();
+		const { cpus: totalCpus, memoryGB: totalMemGB } = computeResourceLimits(
+			os.cpus().length,
+			os.totalmem(),
+			dockerLimits?.cpus,
+			dockerLimits?.memBytes,
+		);
 
 		const dockerArgs = buildDockerRunArgs({
 			image,

--- a/tests/sandbox-cpu-allocation.test.ts
+++ b/tests/sandbox-cpu-allocation.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, beforeEach, after } from "node:test";
+import assert from "node:assert";
+import { computeResourceLimits, getDockerResourceLimits, _resetDockerLimitsCache } from "../src/server/agent/project-sandbox.js";
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFileCb);
+
+// ── computeResourceLimits (pure function) ──────────────────────────────────
+
+describe("computeResourceLimits", () => {
+	describe("CPU limits", () => {
+		it("host=16, docker=4 → cpus=2", () => {
+			const { cpus } = computeResourceLimits(16, 32 * 1024 ** 3, 4, 32 * 1024 ** 3);
+			assert.strictEqual(cpus, 2); // min(16,4)=4, 4-2=2
+		});
+
+		it("host=16, docker=12 → cpus=10", () => {
+			const { cpus } = computeResourceLimits(16, 32 * 1024 ** 3, 12, 32 * 1024 ** 3);
+			assert.strictEqual(cpus, 10); // min(16,12)=12, 12-2=10
+		});
+
+		it("host=4, docker=8 → cpus=2 (host is lower)", () => {
+			const { cpus } = computeResourceLimits(4, 32 * 1024 ** 3, 8, 32 * 1024 ** 3);
+			assert.strictEqual(cpus, 2); // min(4,8)=4, 4-2=2
+		});
+
+		it("host=2, docker=2 → cpus=2 (floor)", () => {
+			const { cpus } = computeResourceLimits(2, 32 * 1024 ** 3, 2, 32 * 1024 ** 3);
+			assert.strictEqual(cpus, 2); // min(2,2)=2, 2-2=0, max(2,0)=2
+		});
+
+		it("host=3, docker=3 → cpus=2 (floor kicks in)", () => {
+			const { cpus } = computeResourceLimits(3, 32 * 1024 ** 3, 3, 32 * 1024 ** 3);
+			assert.strictEqual(cpus, 2); // min(3,3)=3, 3-2=1, max(2,1)=2
+		});
+
+		it("no docker limits → falls back to host-2", () => {
+			const { cpus } = computeResourceLimits(16, 32 * 1024 ** 3);
+			assert.strictEqual(cpus, 14); // 16-2=14
+		});
+
+		it("no docker limits, small host → floor at 2", () => {
+			const { cpus } = computeResourceLimits(2, 32 * 1024 ** 3);
+			assert.strictEqual(cpus, 2);
+		});
+	});
+
+	describe("memory limits", () => {
+		const GB = 1024 ** 3;
+
+		it("host=32GB, docker=8GB → memoryGB=6", () => {
+			const { memoryGB } = computeResourceLimits(16, 32 * GB, 16, 8 * GB);
+			assert.strictEqual(memoryGB, 6); // min(32,8)=8, 8-2=6
+		});
+
+		it("host=8GB, docker=32GB → memoryGB=6 (host is lower)", () => {
+			const { memoryGB } = computeResourceLimits(16, 8 * GB, 16, 32 * GB);
+			assert.strictEqual(memoryGB, 6); // min(8,32)=8, 8-2=6
+		});
+
+		it("host=4GB, docker=4GB → memoryGB=4 (floor)", () => {
+			const { memoryGB } = computeResourceLimits(16, 4 * GB, 16, 4 * GB);
+			assert.strictEqual(memoryGB, 4); // min(4,4)=4, 4-2=2, max(4,2)=4
+		});
+
+		it("no docker limits → falls back to host-2", () => {
+			const { memoryGB } = computeResourceLimits(16, 32 * GB);
+			assert.strictEqual(memoryGB, 30); // 32-2=30
+		});
+
+		it("no docker limits, small host → floor at 4", () => {
+			const { memoryGB } = computeResourceLimits(16, 4 * GB);
+			assert.strictEqual(memoryGB, 4); // 4-2=2, max(4,2)=4
+		});
+	});
+
+	describe("combined", () => {
+		it("both CPU and memory constrained by Docker", () => {
+			const GB = 1024 ** 3;
+			const result = computeResourceLimits(16, 32 * GB, 4, 8 * GB);
+			assert.strictEqual(result.cpus, 2);
+			assert.strictEqual(result.memoryGB, 6);
+		});
+	});
+});
+
+// ── getDockerResourceLimits caching ────────────────────────────────────────
+
+describe("getDockerResourceLimits", () => {
+	beforeEach(() => {
+		_resetDockerLimitsCache();
+	});
+
+	after(() => {
+		_resetDockerLimitsCache();
+	});
+
+	it("caches the result across calls", async () => {
+		// First call populates the cache, second returns cached value
+		const result1 = await getDockerResourceLimits();
+		const result2 = await getDockerResourceLimits();
+
+		// Both calls return the same object reference (cached)
+		assert.strictEqual(result1, result2);
+	});
+
+	it("returns an object with cpus and memBytes when Docker is available", async () => {
+		// Check if Docker is available first
+		try {
+			await execFileAsync("docker", ["info", "--format", "{{.NCPU}}"], { timeout: 5_000 });
+		} catch {
+			// Docker not available — skip this test
+			return;
+		}
+
+		const result = await getDockerResourceLimits();
+		if (result === null) return; // Docker info failed unexpectedly
+
+		assert.ok(typeof result.cpus === "number" && result.cpus > 0, `cpus should be positive, got ${result.cpus}`);
+		assert.ok(typeof result.memBytes === "number" && result.memBytes > 0, `memBytes should be positive, got ${result.memBytes}`);
+	});
+});


### PR DESCRIPTION
## Problem

`project-sandbox.ts` used `os.cpus().length - 2` for Docker `--cpus`, which fails when Docker Desktop/WSL2 has fewer CPUs than the host's logical CPU count.

## Fix

- Added `getDockerResourceLimits()` — queries `docker info --format '{{.NCPU}} {{.MemTotal}}'` with 5s timeout, caches for process lifetime, graceful fallback on failure
- Added `computeResourceLimits()` — pure function: `Math.max(2, Math.min(host, docker) - 2)` for CPUs, `Math.max(4, floor(min/GB) - 2)` for memory
- Modified `_createContainer()` to use these instead of raw `os.cpus().length - 2`

## Tests

15 unit tests in `tests/sandbox-cpu-allocation.test.ts` covering CPU limits, memory limits, combined constraints, floor behavior, Docker-unavailable fallback, and caching.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)