### PR TITLE
Dynamic Page Title

### DIFF
--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -1,6 +1,7 @@
 import {
 	state,
 	renderApp,
+	setProjects,
 	expandedGoals,
 	saveExpandedGoals,
 	GW_URL_KEY,
@@ -117,7 +118,7 @@ export async function refreshSessions(): Promise<void> {
 		// Apply projects before processing sessions so the first renderApp()
 		// already has the correct project list for sidebar grouping.
 		if (projectsResult) {
-			state.projects = projectsResult;
+			setProjects(projectsResult);
 		}
 		if (!sessionsRes.ok) throw new Error(`Failed to fetch sessions: ${sessionsRes.status}`);
 		const sessionsData = await sessionsRes.json();

--- a/src/app/dialogs.ts
+++ b/src/app/dialogs.ts
@@ -9,6 +9,7 @@ import QRCode from "qrcode";
 import {
 	state,
 	renderApp,
+	setProjects,
 	activeSessionId,
 	GW_URL_KEY,
 	GW_TOKEN_KEY,
@@ -1142,7 +1143,7 @@ export function showProjectDialog(): void {
 				// Path A: Auto-import
 				const project = await registerProject(detection.name, trimmedPath, undefined);
 				if (project) {
-					state.projects = await fetchProjects();
+					setProjects(await fetchProjects());
 					renderApp();
 					cleanup();
 				} else {

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -2213,7 +2213,9 @@ export function doRenderApp(): void {
 	if (!app) return;
 
 	// Dynamic page title
-	const activeProject = state.projects.find(p => p.id === state.activeProjectId);
+	const activeProject = state.activeProjectId
+		? state.projects.find(p => p.id === state.activeProjectId)
+		: state.projects[0];
 	document.title = activeProject ? `${activeProject.name} · Bobbit` : "Bobbit";
 
 	document.documentElement.style.setProperty("--bobbit-shimmer-delay", `${-(Date.now() % 8000)}ms`);

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -2212,6 +2212,10 @@ export function doRenderApp(): void {
 	const app = document.getElementById("app");
 	if (!app) return;
 
+	// Dynamic page title
+	const activeProject = state.projects.find(p => p.id === state.activeProjectId);
+	document.title = activeProject ? `${activeProject.name} · Bobbit` : "Bobbit";
+
 	document.documentElement.style.setProperty("--bobbit-shimmer-delay", `${-(Date.now() % 8000)}ms`);
 
 	// Disconnected state

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -2213,9 +2213,7 @@ export function doRenderApp(): void {
 	if (!app) return;
 
 	// Dynamic page title
-	const activeProject = state.activeProjectId
-		? state.projects.find(p => p.id === state.activeProjectId)
-		: state.projects[0];
+	const activeProject = state.projects.find(p => p.id === state.activeProjectId);
 	document.title = activeProject ? `${activeProject.name} · Bobbit` : "Bobbit";
 
 	document.documentElement.style.setProperty("--bobbit-shimmer-delay", `${-(Date.now() % 8000)}ms`);

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -5,6 +5,7 @@ import { RemoteAgent } from "./remote-agent.js";
 import {
 	state,
 	renderApp,
+	setProjects,
 	activeSessionId,
 	isDesktop,
 	GW_URL_KEY,
@@ -1051,7 +1052,7 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 					}
 				}
 				// Refresh project list
-				state.projects = await fetchProjects();
+				setProjects(await fetchProjects());
 			}
 			renderApp();
 		};

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -18,7 +18,7 @@ import {
 	type KeyBinding,
 	type ShortcutEntry,
 } from "./shortcut-registry.js";
-import { renderApp, state } from "./state.js";
+import { renderApp, setProjects, state } from "./state.js";
 import { getRouteFromHash, setHashRoute, toggleConfigPage, type SettingsTabId } from "./routing.js";
 import { gatewayFetch, fetchSandboxStatus, removeProject, fetchProjects } from "./api.js";
 import { openOAuthDialog } from "./dialogs.js";
@@ -146,7 +146,7 @@ async function saveProjectScopeConfig(projectId: string, updates: Record<string,
 			if (rootPath !== undefined) {
 				try {
 					const res = await gatewayFetch("/api/projects");
-					if (res.ok) state.projects = await res.json();
+					if (res.ok) setProjects(await res.json());
 				} catch {}
 			}
 			setTimeout(() => { projectScopeSaveStatus = ""; renderApp(); }, 2000);
@@ -2151,7 +2151,7 @@ function renderProjectGeneralTab(projectId: string) {
 							if (!ok) return;
 							const success = await removeProject(projectId);
 							if (success) {
-								state.projects = await fetchProjects();
+								setProjects(await fetchProjects());
 								setHashRoute("settings", "system/general", true);
 								renderApp();
 							}

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -433,6 +433,19 @@ export function renderAppSync(): void {
 }
 
 // ============================================================================
+// PROJECT HELPERS
+// ============================================================================
+
+/** Update the project list and ensure activeProjectId stays in sync.
+ *  Defaults to the first project when no explicit selection exists. */
+export function setProjects(projects: Project[]): void {
+	state.projects = projects;
+	if (!state.activeProjectId || !projects.some(p => p.id === state.activeProjectId)) {
+		state.activeProjectId = projects[0]?.id ?? null;
+	}
+}
+
+// ============================================================================
 // SEARCH CONTENT MODE
 // ============================================================================
 

--- a/tests/e2e/ui/page-title.spec.ts
+++ b/tests/e2e/ui/page-title.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * Page title E2E test: verify dynamic document.title reflects active project.
+ */
+import { test, expect } from "../gateway-harness.js";
+import { openApp } from "./ui-helpers.js";
+
+test.describe("Dynamic page title", () => {
+	test("shows active project name with interpunct and Bobbit", async ({ page }) => {
+		await openApp(page);
+
+		// The gateway harness auto-creates a default project.
+		// After openApp, the title should reflect the active project.
+		const title = await page.evaluate(() => document.title);
+
+		expect(title).toContain("·");
+		expect(title).toContain("Bobbit");
+		// Title format: "<ProjectName> · Bobbit"
+		expect(title).toMatch(/.+ · Bobbit$/);
+	});
+});

--- a/tests/e2e/ui/page-title.spec.ts
+++ b/tests/e2e/ui/page-title.spec.ts
@@ -9,12 +9,12 @@ test.describe("Dynamic page title", () => {
 		await openApp(page);
 
 		// The gateway harness auto-creates a default project.
-		// After openApp, the title should reflect the active project.
-		const title = await page.evaluate(() => document.title);
-
-		expect(title).toContain("·");
-		expect(title).toContain("Bobbit");
-		// Title format: "<ProjectName> · Bobbit"
-		expect(title).toMatch(/.+ · Bobbit$/);
+		// Wait for the title to update after projects load and render cycle runs.
+		await expect(async () => {
+			const title = await page.evaluate(() => document.title);
+			expect(title).toContain("·");
+			expect(title).toContain("Bobbit");
+			expect(title).toMatch(/.+ · Bobbit$/);
+		}).toPass({ timeout: 5000 });
 	});
 });


### PR DESCRIPTION
Set the browser page title to `ProjectName · Bobbit` format, showing the active project name in Chrome tabs, Windows taskbar, etc.

## Changes

- **`src/app/state.ts`**: New `setProjects()` helper that keeps `state.activeProjectId` in sync with the project list
- **`src/app/render.ts`**: Dynamic `document.title` update in `doRenderApp()` — looks up the active project and sets the title reactively
- **`src/app/api.ts`, `dialogs.ts`, `session-manager.ts`, `settings-page.ts`**: All project list assignments routed through `setProjects()`
- **`tests/e2e/ui/page-title.spec.ts`**: Browser E2E test verifying the title format

## Behavior

- Active project exists → `ProjectName · Bobbit`
- No projects → `Bobbit`
- Project removed → falls back to next project or `Bobbit`
- Static `<title>Bobbit</title>` in index.html preserved as initial fallback

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)