### PR TITLE
Fix page title not updating when navigating between projects

### DIFF
--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -74,9 +74,14 @@ export function uncacheSession(sessionId: string): void {
 // PER-PROJECT PALETTE SWITCHING
 // ============================================================================
 
-/** Apply the per-project palette (if any) or revert to the global default. */
+/** Apply the per-project palette (if any) or revert to the global default.
+ *  Also updates `activeProjectId` so the page title and other project-scoped
+ *  UI elements reflect the current project. */
 export function applyProjectPalette(projectId?: string): void {
 	const project = (state.projects || []).find((p: any) => p.id === projectId);
+	if (projectId && project) {
+		state.activeProjectId = projectId;
+	}
 	const palette = project?.palette;
 	if (palette) {
 		document.documentElement.dataset.palette = palette;


### PR DESCRIPTION
When navigating to a session or goal belonging to a different project, the browser tab title stayed on the previous project's name (or just "Bobbit").

## Root cause

`state.activeProjectId` was only set during `setProjects()` as a fallback when the current ID was missing from the project list. Navigation flows (session connect, goal dashboard, settings) called `applyProjectPalette(projectId)` to update the colour palette but never updated `activeProjectId`, so `document.title` in `doRenderApp()` continued to reflect the stale value.

## Fix

Update `state.activeProjectId` inside `applyProjectPalette()` — the single function already called at every navigation point — so the page title, staff creation default, and sidebar cache key all stay in sync with the currently viewed project.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)