### PR TITLE
fix: E2E test flakiness — timeout hardening and draft restore race

### DIFF
--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -481,6 +481,14 @@ function _setupPromptDraftHandlers(sessionId: string): void {
 
 			if (text) {
 				editor.value = text;
+				// Guard against Lit re-renders that may reset the textarea.
+				// Re-apply the draft after a microtask to survive any pending
+				// requestUpdate() cycles triggered by connection state changes.
+				queueMicrotask(() => {
+					if (_draftSessionId !== sessionId) return;
+					const el = document.querySelector("message-editor") as any;
+					if (el && el.value !== text) el.value = text;
+				});
 			}
 		} catch { /* ignore */ }
 	})();

--- a/tests/e2e/ui/maintenance.spec.ts
+++ b/tests/e2e/ui/maintenance.spec.ts
@@ -108,7 +108,7 @@ test.describe("Maintenance tab (full-stack UI)", () => {
 		await openApp(page);
 		await navigateToHash(page, "#/settings/system/general");
 
-		await expect(page.getByText("Show message timestamps")).toBeVisible({ timeout: 10_000 });
+		await expect(page.getByText("Show message timestamps")).toBeVisible({ timeout: 15_000 });
 
 		// Click the Maintenance tab button
 		await page.locator("button").filter({ hasText: "Maintenance" }).first().click();

--- a/tests/e2e/ui/project-assistant.spec.ts
+++ b/tests/e2e/ui/project-assistant.spec.ts
@@ -67,7 +67,7 @@ async function addProjectViaDialog(
 	await expect(async () => {
 		const hash = await page.evaluate(() => window.location.hash);
 		expect(hash).toMatch(/#\/session\//);
-	}).toPass({ timeout: 10_000 });
+	}).toPass({ timeout: 15_000 });
 	await expect(page.locator("textarea").first()).toBeVisible({ timeout: 15_000 });
 
 	// Extract session ID from hash
@@ -402,7 +402,7 @@ test.describe("Project proposal preview form", () => {
 			const promoted = prjs.find((p: any) => p.id === projectId);
 			expect(promoted).toBeTruthy();
 			expect(promoted.provisional).toBeFalsy();
-		}).toPass({ timeout: 10_000 });
+		}).toPass({ timeout: 15_000 });
 
 		// Verify the project name was updated to "Test Project"
 		const projects = await getProjects();
@@ -440,17 +440,19 @@ test.describe("Project proposal preview form", () => {
 			const p = prjs.find((pp: any) => pp.id === projectId);
 			expect(p).toBeTruthy();
 			expect(p.provisional).toBeFalsy();
-		}).toPass({ timeout: 10_000 });
+		}).toPass({ timeout: 15_000 });
 
-		// Verify config was written
-		const configResp = await apiFetch(`/api/projects/${projectId}/config`);
-		if (configResp.ok) {
+		// Verify config was written — the client writes config fields after promotion,
+		// so poll until all expected fields are present.
+		await expect(async () => {
+			const configResp = await apiFetch(`/api/projects/${projectId}/config`);
+			expect(configResp.ok).toBe(true);
 			const config = await configResp.json();
 			expect(config.build_command).toBe("npm run build");
 			expect(config.test_command).toBe("npm test");
 			expect(config.typecheck_command).toBe("npm run check");
 			expect(config.worktree_setup_command).toBe("npm ci");
-		}
+		}).toPass({ timeout: 20_000 });
 
 		// Clean up
 		await deleteSession(sessionId);

--- a/tests/e2e/ui/project-removal.spec.ts
+++ b/tests/e2e/ui/project-removal.spec.ts
@@ -42,7 +42,7 @@ test.describe("Remove Project button", () => {
 
 		// Verify the Remove Project button is visible
 		const removeBtn = page.getByRole("button", { name: "Remove Project" });
-		await expect(removeBtn).toBeVisible({ timeout: 5_000 });
+		await expect(removeBtn).toBeVisible({ timeout: 15_000 });
 
 		// Set up dialog handler BEFORE clicking
 		page.on("dialog", (dialog) => dialog.accept());
@@ -74,7 +74,7 @@ test.describe("Remove Project button", () => {
 		await navigateToHash(page, `#/settings/${defaultProject.id}/general`);
 
 		// Wait for settings content to load
-		await expect(page.locator("h1").filter({ hasText: "Settings" })).toBeVisible({ timeout: 10_000 });
+		await expect(page.locator("h1").filter({ hasText: "Settings" })).toBeVisible({ timeout: 15_000 });
 
 		// Remove button should NOT be present for the default project
 		const removeBtn = page.getByRole("button", { name: "Remove Project" });

--- a/tests/e2e/ui/ui-helpers.ts
+++ b/tests/e2e/ui/ui-helpers.ts
@@ -20,7 +20,7 @@ export async function openApp(page: Page): Promise<void> {
 	// regardless of single-project or multi-project mode
 	await expect(
 		page.locator("button").filter({ hasText: "Settings" }).first(),
-	).toBeVisible({ timeout: 15_000 });
+	).toBeVisible({ timeout: 20_000 });
 }
 
 /**
@@ -29,7 +29,7 @@ export async function openApp(page: Page): Promise<void> {
 export async function createSessionViaUI(page: Page): Promise<void> {
 	// In multi-project mode the button title is "New session in <project>"
 	await page.locator("button[title^='New session']").first().click();
-	await expect(page.locator("textarea").first()).toBeVisible({ timeout: 15_000 });
+	await expect(page.locator("textarea").first()).toBeVisible({ timeout: 20_000 });
 }
 
 /**


### PR DESCRIPTION
Fixes multiple flaky E2E tests discovered through repeated health check cycles.

## Changes

**Draft restore race condition** (`session-manager.ts`):
After `loadDraftFromServer` sets `editor.value`, a Lit re-render from connection state changes could reset the textarea to empty. Added a `queueMicrotask` guard that re-applies the draft if cleared.

**Timeout hardening** (multiple test files):
Under heavy concurrent E2E load, initial settings page renders can exceed 5-10s. Bumped initial-load timeouts to 15s across:
- `maintenance.spec.ts` — settings page heading
- `project-removal.spec.ts` — Remove Project button and settings heading  
- `project-assistant.spec.ts` — promotion polling, config write polling, provisional cleanup assertions

All fixes verified with repeat-each (3-8x) before committing.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)