### PR TITLE
Archived Chat Blob Desaturation

### DIFF
--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -1060,6 +1060,31 @@ html {
 	transform: scale(4) translateX(-7px);
 }
 
+/* Archived blob — fully desaturated, all animations killed */
+.bobbit-blob--archived {
+  filter: grayscale(1);
+  opacity: 0.8;
+  transform: none !important;
+}
+.bobbit-blob--archived,
+.bobbit-blob--archived .bobbit-blob__sprite,
+.bobbit-blob--archived .bobbit-blob__shadow,
+.bobbit-blob--archived .bobbit-blob__crown,
+.bobbit-blob--archived .bobbit-blob__bandana,
+.bobbit-blob--archived .bobbit-blob__magnifier,
+.bobbit-blob--archived .bobbit-blob__palette,
+.bobbit-blob--archived .bobbit-blob__pencil,
+.bobbit-blob--archived .bobbit-blob__shield,
+.bobbit-blob--archived .bobbit-blob__set-square,
+.bobbit-blob--archived .bobbit-blob__flask,
+.bobbit-blob--archived .bobbit-blob__wand,
+.bobbit-blob--archived .bobbit-blob__wizard-hat,
+.bobbit-blob--archived .bobbit-blob__stamp,
+.bobbit-blob--archived .bobbit-blob__clipboard {
+  animation: none !important;
+  transition: none !important;
+}
+
 /* Shadow follows sprite horizontally during transitions */
 .bobbit-blob--exit .bobbit-blob__shadow {
 	animation: blob-shadow-exit 0.7s cubic-bezier(0.34, 1.56, 0.64, 1) forwards !important;

--- a/src/ui/bobbit-render.ts
+++ b/src/ui/bobbit-render.ts
@@ -393,7 +393,26 @@ export function startCanvasEyeAnimation(
  * eyes at any DPR/zoom level. CSS animations use -canvas keyframe variants
  * (no scale(4), translates ×4).
  */
-export function renderBlobSpriteCanvas(isIdle: boolean): TemplateResult {
+export function renderBlobSpriteCanvas(isIdle: boolean, archived = false): TemplateResult {
+	if (archived) {
+		// Static frame: center gaze, no blink, no animation loop
+		const onRef = (el: Element | undefined) => {
+			if (el && el instanceof HTMLCanvasElement) {
+				const cache = buildEyePixelCache(CANONICAL_PALETTE, [{ pct: 0, gaze: "center", blink: false }]);
+				const pixels = cache.get("center-false");
+				if (pixels) {
+					const dpr = window.devicePixelRatio || 1;
+					const devW = Math.round(BODY_WIDTH * CSS_SCALE * dpr);
+					const devH = Math.round(BODY_HEIGHT * CSS_SCALE * dpr);
+					el.width = devW;
+					el.height = devH;
+					const ctx = el.getContext("2d")!;
+					drawPixelsBresenham(ctx, pixels, devW, devH);
+				}
+			}
+		};
+		return html`<canvas ${ref(onRef)} class="bobbit-blob__sprite"></canvas>`;
+	}
 	const sequence = isIdle ? IDLE_EYE_SEQUENCE : BUSY_EYE_SEQUENCE;
 	let cleanup: (() => void) | null = null;
 	const onRef = (el: Element | undefined) => {
@@ -409,8 +428,8 @@ export function renderBlobSpriteCanvas(isIdle: boolean): TemplateResult {
 }
 
 /** @deprecated Use renderBlobSpriteCanvas instead. Kept for backward compat. */
-export function renderBlobSpriteImg(isIdle: boolean): TemplateResult {
-	return renderBlobSpriteCanvas(isIdle);
+export function renderBlobSpriteImg(isIdle: boolean, archived = false): TemplateResult {
+	return renderBlobSpriteCanvas(isIdle, archived);
 }
 
 // ============================================================================

--- a/src/ui/components/AgentInterface.ts
+++ b/src/ui/components/AgentInterface.ts
@@ -574,6 +574,7 @@ export class AgentInterface extends LitElement {
 				<streaming-message-container
 					.tools=${state.tools}
 					.isStreaming=${state.isStreaming}
+					.archived=${this.readOnly}
 					.pendingToolCalls=${state.pendingToolCalls}
 					.toolResultsById=${toolResultsById}
 					.toolPartialResults=${(state as any).toolPartialResults}

--- a/src/ui/components/StreamingMessageContainer.ts
+++ b/src/ui/components/StreamingMessageContainer.ts
@@ -8,6 +8,7 @@ import "./LiveTimer.js";
 export class StreamingMessageContainer extends LitElement {
 	@property({ type: Array }) tools: AgentTool[] = [];
 	@property({ type: Boolean }) isStreaming = false;
+	@property({ type: Boolean }) archived = false;
 
 	@property({ type: Object }) pendingToolCalls?: Set<string>;
 	@property({ type: Object }) toolResultsById?: Map<string, ToolResultMessage>;
@@ -37,6 +38,7 @@ export class StreamingMessageContainer extends LitElement {
 	}
 
 	override updated(changed: Map<string, unknown>) {
+		if (this.archived) return; // No animation state transitions when archived
 		if (changed.has("isStreaming")) {
 			// Don't let agent_start/agent_end events override the compaction animation
 			if (this._blobState === 'compact-shake' || this._blobState === 'compacting' || this._blobState === 'compact-pop' || this._compactEntryTimer) {
@@ -68,10 +70,13 @@ export class StreamingMessageContainer extends LitElement {
 	}
 
 	private get _blobVisible() {
+		if (this.archived) return true;
 		return this._blobState !== 'hidden';
 	}
 
 	private get _blobClass() {
+		if (this.archived) return 'bobbit-blob bobbit-blob--archived';
+
 		if (this._blobState === 'entering') return `bobbit-blob bobbit-blob--${this._entryVariant}`;
 		if (this._blobState === 'exiting') return `bobbit-blob bobbit-blob--${this._exitVariant}`;
 		if (this._blobState === 'idle') return 'bobbit-blob bobbit-blob--idle';
@@ -204,7 +209,7 @@ export class StreamingMessageContainer extends LitElement {
 			if (this._blobVisible)
 				return html`<div class="flex flex-col gap-3 mb-3">
 					<div class="${this._blobClass}">
-						${renderBlobSpriteImg(this._blobClass.includes("idle"))}
+						${renderBlobSpriteImg(this._blobClass.includes("idle"), this.archived)}
 						<div class="bobbit-blob__crown"></div>
 						<div class="bobbit-blob__bandana"></div>
 						<div class="bobbit-blob__magnifier"></div>
@@ -251,7 +256,7 @@ export class StreamingMessageContainer extends LitElement {
 						.turnStartTime=${this.turnStartTime}
 					></assistant-message>
 					${this._blobVisible ? html`<div class="${this._blobClass}">
-						${renderBlobSpriteImg(this._blobClass.includes("idle"))}
+						${renderBlobSpriteImg(this._blobClass.includes("idle"), this.archived)}
 						<div class="bobbit-blob__crown"></div>
 						<div class="bobbit-blob__bandana"></div>
 						<div class="bobbit-blob__magnifier"></div>

--- a/tests/e2e/ui/archived-blob.spec.ts
+++ b/tests/e2e/ui/archived-blob.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * Archived chat blob E2E tests.
+ * Verifies that the bobbit blob in archived sessions is desaturated (grayscale)
+ * and has all CSS animations stopped.
+ */
+import { test, expect } from "../gateway-harness.js";
+import { createSession, deleteSession, apiFetch, waitForSessionStatus } from "../e2e-setup.js";
+import { openApp, sendMessage, waitForAgentResponse } from "./ui-helpers.js";
+
+test.describe("Archived session blob", () => {
+	test("blob has archived class, grayscale filter, and no animations", async ({ page }) => {
+		// Create a session and wait for it to be ready
+		const sessionId = await createSession();
+		await waitForSessionStatus(sessionId, "idle");
+
+		// Open app and navigate to the session
+		await openApp(page);
+		await page.evaluate((id) => { window.location.hash = `#/session/${id}`; }, sessionId);
+		await expect(page.locator("textarea").first()).toBeVisible({ timeout: 10_000 });
+
+		// Send a message so the session has content
+		await sendMessage(page, "hello");
+		await waitForAgentResponse(page);
+
+		// Wait for idle before terminating
+		await waitForSessionStatus(sessionId, "idle");
+
+		// Terminate the session (which archives it)
+		const termResp = await apiFetch(`/api/sessions/${sessionId}`, { method: "DELETE" });
+		expect(termResp.ok).toBe(true);
+
+		// Navigate away, then back to the archived session to pick up archived state
+		await page.evaluate(() => { window.location.hash = "#/"; });
+		await expect(
+			page.locator("button").filter({ hasText: "Settings" }).first(),
+		).toBeVisible({ timeout: 10_000 });
+
+		await page.evaluate((id) => { window.location.hash = `#/session/${id}`; }, sessionId);
+
+		// Wait for the archived blob to appear
+		const archivedBlob = page.locator(".bobbit-blob--archived");
+		await expect(archivedBlob).toBeVisible({ timeout: 10_000 });
+
+		// Verify grayscale filter is applied
+		const filter = await archivedBlob.evaluate(
+			el => getComputedStyle(el).filter,
+		);
+		expect(filter).toContain("grayscale");
+
+		// Verify no CSS animations are running on the blob or its children
+		const runningAnimCount = await archivedBlob.evaluate(
+			el => el.getAnimations({ subtree: true }).filter(a => a.playState === "running").length,
+		);
+		expect(runningAnimCount).toBe(0);
+	});
+
+	test("active session blob does NOT have archived class", async ({ page }) => {
+		// Create a session and verify it does NOT get the archived treatment
+		const sessionId = await createSession();
+		await waitForSessionStatus(sessionId, "idle");
+
+		await openApp(page);
+		await page.evaluate((id) => { window.location.hash = `#/session/${id}`; }, sessionId);
+		await expect(page.locator("textarea").first()).toBeVisible({ timeout: 10_000 });
+
+		// Send a message to trigger the blob
+		await sendMessage(page, "hello");
+		await waitForAgentResponse(page);
+
+		// The blob should be visible but NOT have the archived class
+		const blob = page.locator(".bobbit-blob").first();
+		await expect(blob).toBeVisible({ timeout: 10_000 });
+		await expect(blob).not.toHaveClass(/bobbit-blob--archived/);
+
+		// Cleanup
+		await deleteSession(sessionId);
+	});
+});


### PR DESCRIPTION
When viewing an archived chat session, the bobbit blob sprite now appears **desaturated (grayscale) and completely still** — no bouncing, eye animation, shimmer, or shadow movement.

## Changes
- **StreamingMessageContainer.ts** — Added `archived` property; when true, locks blob to static state
- **bobbit-render.ts** — Static frame rendering (center gaze, no blink) without animation loop
- **app.css** — `.bobbit-blob--archived` class: grayscale filter, opacity 0.8, all animations killed
- **AgentInterface.ts** — Wired `readOnly` → `archived` on streaming container
- **archived-blob.spec.ts** — E2E tests for archived blob class, grayscale filter, and no animations; regression test for active sessions

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)