### PR TITLE
Fix model race in verification sessions and use server-authoritative cost display

### DIFF
--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -151,6 +151,7 @@ export class RemoteAgent {
 			isArchived: false,
 			isPreparing: false,
 			archivedAt: null as number | null,
+			serverCost: null as { inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheWriteTokens: number; totalCost: number } | null,
 			streamMessage: null as any,
 			pendingToolCalls: new Set<string>(),
 			error: undefined as string | undefined,
@@ -882,6 +883,11 @@ export class RemoteAgent {
 			case "bg_process_output":
 			case "bg_process_exited":
 				this.onBgProcessEvent?.(msg as any);
+				break;
+
+			case "cost_update":
+				this._state.serverCost = msg.cost;
+				this.emit({ type: "cost_update" as any, cost: msg.cost });
 				break;
 
 			case "pr_status_changed":

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -2138,7 +2138,7 @@ export class SessionManager {
 		}
 	}
 
-	async createSession(cwd: string, agentArgs?: string[], goalId?: string, assistantType?: string, opts?: { rolePrompt?: string; roleName?: string; role?: string; accessory?: string; env?: Record<string, string>; taskId?: string; allowedTools?: string[]; personalities?: Array<{ label: string; promptFragment: string }>; personalityNames?: string[]; workflowContext?: string; worktreeOpts?: { repoPath: string }; reattemptGoalId?: string; sandboxed?: boolean; projectId?: string; sessionId?: string; sandboxBranch?: string; sandboxBaseBranch?: string }): Promise<SessionInfo> {
+	async createSession(cwd: string, agentArgs?: string[], goalId?: string, assistantType?: string, opts?: { rolePrompt?: string; roleName?: string; role?: string; accessory?: string; env?: Record<string, string>; taskId?: string; allowedTools?: string[]; personalities?: Array<{ label: string; promptFragment: string }>; personalityNames?: string[]; workflowContext?: string; worktreeOpts?: { repoPath: string }; reattemptGoalId?: string; sandboxed?: boolean; projectId?: string; sessionId?: string; sandboxBranch?: string; sandboxBaseBranch?: string; skipAutoModel?: boolean; skipAutoThinking?: boolean }): Promise<SessionInfo> {
 		const id = opts?.sessionId || randomUUID();
 		// Resolve projectId from opts or from the goal's project
 		const projectId = opts?.projectId ?? (goalId ? this.resolveGoal(goalId)?.projectId : undefined);
@@ -2207,6 +2207,8 @@ export class SessionManager {
 				projectId,
 				sandboxBranch: opts?.sandboxBranch,
 				sandboxBaseBranch: opts?.sandboxBaseBranch,
+				skipAutoModel: opts?.skipAutoModel,
+				skipAutoThinking: opts?.skipAutoThinking,
 				bridgeOptions: { cwd },
 			};
 
@@ -2262,6 +2264,8 @@ export class SessionManager {
 			projectId,
 			sandboxBranch: opts?.sandboxBranch,
 			sandboxBaseBranch: opts?.sandboxBaseBranch,
+			skipAutoModel: opts?.skipAutoModel,
+			skipAutoThinking: opts?.skipAutoThinking,
 			bridgeOptions: { cwd },
 		};
 

--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -92,6 +92,10 @@ export interface SessionSetupPlan {
 	// Project association
 	projectId?: string;
 
+	// Skip fire-and-forget model/thinking-level selection (verification sessions set their own)
+	skipAutoModel?: boolean;
+	skipAutoThinking?: boolean;
+
 	// Sandbox worktree: branch to create inside the container
 	sandboxBranch?: string;
 	sandboxBaseBranch?: string;
@@ -614,7 +618,7 @@ export async function executeWorktreeAsync(
 	ctx.broadcast(session.clients, { type: "session_status", status: "idle" });
 
 	// Fire model + thinking level immediately (non-blocking)
-	postSpawnFireAndForget(session, ctx);
+	postSpawnFireAndForget(session, plan, ctx);
 }
 
 // ── Internal helpers ───────────────────────────────────────────────────────
@@ -700,24 +704,28 @@ async function spawnAgent(plan: SessionSetupPlan, ctx: PipelineContext): Promise
 async function postSpawn(session: SessionInfo, plan: SessionSetupPlan, ctx: PipelineContext): Promise<void> {
 	// For delegates, model + thinking level are awaited (delegate needs model before prompt)
 	if (plan.mode === "delegate") {
-		await Promise.all([
-			ctx.tryAutoSelectModel(session),
-			ctx.tryApplyDefaultThinkingLevel(session),
-		]);
+		const tasks: Promise<void>[] = [];
+		if (!plan.skipAutoModel) tasks.push(ctx.tryAutoSelectModel(session));
+		if (!plan.skipAutoThinking) tasks.push(ctx.tryApplyDefaultThinkingLevel(session));
+		await Promise.all(tasks);
 	} else {
 		// Normal sessions: fire-and-forget
-		postSpawnFireAndForget(session, ctx);
+		postSpawnFireAndForget(session, plan, ctx);
 	}
 }
 
 /** Fire model + thinking level setup as non-blocking (fire-and-forget). */
-function postSpawnFireAndForget(session: SessionInfo, ctx: PipelineContext): void {
-	ctx.tryAutoSelectModel(session).catch((err) => {
-		console.warn(`[session-setup] Early model selection failed for ${session.id}:`, err);
-	});
-	ctx.tryApplyDefaultThinkingLevel(session).catch((err) => {
-		console.warn(`[session-setup] Early thinking level failed for ${session.id}:`, err);
-	});
+function postSpawnFireAndForget(session: SessionInfo, plan: SessionSetupPlan, ctx: PipelineContext): void {
+	if (!plan.skipAutoModel) {
+		ctx.tryAutoSelectModel(session).catch((err) => {
+			console.warn(`[session-setup] Early model selection failed for ${session.id}:`, err);
+		});
+	}
+	if (!plan.skipAutoThinking) {
+		ctx.tryApplyDefaultThinkingLevel(session).catch((err) => {
+			console.warn(`[session-setup] Early thinking level failed for ${session.id}:`, err);
+		});
+	}
 }
 
 // ── Delegate prompt ────────────────────────────────────────────────────────

--- a/src/server/agent/verification-harness.ts
+++ b/src/server/agent/verification-harness.ts
@@ -1357,6 +1357,8 @@ export class VerificationHarness {
 				roleName,
 				sandboxed: isSandboxed,
 				sessionId,
+				skipAutoModel: true,
+				skipAutoThinking: true,
 			});
 
 			// Set title and metadata
@@ -1557,6 +1559,8 @@ export class VerificationHarness {
 				roleName: qaRoleName,
 				sandboxed: qaIsSandboxed,
 				sessionId: qaSessionId,
+				skipAutoModel: true,
+				skipAutoThinking: true,
 			});
 			qaSessionId = session.id;
 

--- a/src/ui/components/AgentInterface.ts
+++ b/src/ui/components/AgentInterface.ts
@@ -331,6 +331,11 @@ export class AgentInterface extends LitElement {
 				}
 				return;
 			}
+			if ((ev as any).type === "cost_update") {
+				// Server-authoritative cost data — re-render stats bar
+				this.requestUpdate();
+				return;
+			}
 			if ((ev as any).type === "render") {
 				// Generic re-render request (e.g. tool permission card added)
 				this.requestUpdate();
@@ -623,7 +628,10 @@ export class AgentInterface extends LitElement {
 				} satisfies Usage,
 			);
 
-		const costText = totals.cost?.total ? formatCost(totals.cost.total) : "";
+		// Prefer server-authoritative cost when available (via cost_update WS messages)
+		const serverCost = (this.session as any)?.state?.serverCost;
+		const costValue = serverCost?.totalCost ?? totals.cost?.total;
+		const costText = costValue ? formatCost(costValue) : "";
 
 		// Compute context usage from the last assistant message's usage
 		let contextHtml = html``;


### PR DESCRIPTION
## Summary

Two fixes addressing model and cost display accuracy in verification sessions.

### 1. Model race condition in verification sessions

The verification harness creates sessions via `createSession()`, which fires `tryAutoSelectModel()` as fire-and-forget (applying `default.sessionModel`). The harness then immediately calls `setModel()` with `default.reviewModel`. These two raced non-deterministically — the session model could overwrite the review model, causing reviewers to silently run on the wrong (potentially more expensive) model.

**Fix**: Added `skipAutoModel` and `skipAutoThinking` flags to the session creation pipeline. The verification harness sets both flags so only its explicit `setModel`/`setThinkingLevel` calls run.

### 2. Server-authoritative cost display

The chat page computed cost by summing `usage.cost.total` from client-side messages. The goal dashboard used the server's `CostTracker`. These could disagree after server restarts or interrupted sessions — one observed case showed $4 on the chat page vs $7.68 on the dashboard for the same session.

The server already broadcasts `cost_update` WebSocket messages but the client never consumed them.

**Fix**: The client now handles `cost_update` messages and uses `serverCost.totalCost` as the authoritative cost in the stats bar, falling back to client-computed cost only when no server data is available.

### Changes

- `src/server/agent/session-setup.ts` — Added `skipAutoModel`/`skipAutoThinking` to `SessionSetupPlan`; `postSpawn`/`postSpawnFireAndForget` respect the flags
- `src/server/agent/session-manager.ts` — Wired new flags through `createSession()` opts
- `src/server/agent/verification-harness.ts` — Both reviewer and QA session creation calls pass `skipAutoModel: true, skipAutoThinking: true`
- `src/app/remote-agent.ts` — Handle `cost_update` WS message, store on session state
- `src/ui/components/AgentInterface.ts` — Prefer server cost over client-computed cost; re-render on `cost_update`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)