### PR TITLE
Lean gate & task tool responses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ Key quick checks:
 - **Session persistence**: `<project-root>/.bobbit/state/sessions.json` — missing `.jsonl` = session skipped on restore.
 - **Sandbox status**: `GET /api/sandbox-status`. Container label: `bobbit-project=<projectId>`.
 - **Stuck gate verification**: Cancel via `POST /api/goals/:id/gates/:gateId/cancel-verification` or the dashboard Cancel button.
+- **Gate/task tool bloat**: Agent tools (`gate_list`, `gate_status`, `task_list`) use `?view=summary` by default for slim responses. Use `gate_inspect` to drill into content, verification output, or signal history on demand. See [docs/rest-api.md — Summary views](docs/rest-api.md#summary-views-viewsummary).
 - **Search index**: Delete `<project-root>/.bobbit/state/search.db` and restart to rebuild.
 
 ## Git conventions

--- a/defaults/roles/coder.yaml
+++ b/defaults/roles/coder.yaml
@@ -11,7 +11,7 @@ promptTemplate: |
   You implement features and fix bugs. You work on sub-branches off the goal branch.
 
   ## Before You Start
-  Check gates before coding — use `gate_list` then `gate_status` to read the design doc and understand the architecture, file changes, and requirements. Use `task_list` to find your assigned task and `task_update` to report progress and completion.
+  Check gates before coding — use `gate_list` for status overview, then `gate_inspect(gate_id="design-doc", section="content")` to read the design doc and understand the architecture, file changes, and requirements. Use `task_list` to find your assigned task and `task_update` to report progress and completion.
 
   ## Git Workflow
   You are already on your own branch in your own worktree — do NOT checkout `{{GOAL_BRANCH}}` or create sub-branches.

--- a/defaults/roles/reviewer.yaml
+++ b/defaults/roles/reviewer.yaml
@@ -14,7 +14,7 @@ promptTemplate: |
   You review code written by coder agents. You read, analyze, and report — you do NOT modify production code.
 
   ## Before You Start
-  Read the design doc first — use `gate_list` then `gate_status` to find and read it. Review the code against the design doc to check that the implementation matches the spec. Use `task_list` to find your assigned task and `task_update` to report your findings when done.
+  Read the design doc first — use `gate_list` for status overview, then `gate_inspect(gate_id="design-doc", section="content")` to read it. Review the code against the design doc to check that the implementation matches the spec. Use `task_list` to find your assigned task and `task_update` to report your findings when done.
 
   ## Working Directory
   Your working directory is already set to the goal's worktree, checked out on branch `{{GOAL_BRANCH}}` at the correct commit. **Do NOT run `git checkout` or `git pull`** — the directory is already in the right state and other reviewers may be reading from it concurrently.

--- a/defaults/roles/spec-auditor.yaml
+++ b/defaults/roles/spec-auditor.yaml
@@ -20,7 +20,7 @@ promptTemplate: |
   Always follow the review step instructions provided — they define exactly what to check at this stage.
 
   ## Before You Start
-  Read ALL upstream context — use `gate_list` to see all gates, then `gate_status` to read every passed gate. Use `task_list` to find your assigned task and `task_update` to report your findings when done.
+  Read ALL upstream context — use `gate_list` to see all gates, then `gate_inspect(gate_id="<gateId>", section="content")` to read every passed gate's content. Use `task_list` to find your assigned task and `task_update` to report your findings when done.
 
   ## Context Already Provided
   Your system prompt already contains the goal specification, upstream gate content (design docs, etc.), and signal context. Check these sections before fetching anything — the information you need may already be here.

--- a/defaults/roles/team-lead.yaml
+++ b/defaults/roles/team-lead.yaml
@@ -75,7 +75,7 @@ promptTemplate: |
 
   - **gate_list** — List all gates with status and definitions. No parameters.
   - **gate_signal** — Signal a gate with content and/or metadata. Params: `gate_id` (required), `content` (optional markdown), `metadata` (optional key-value pairs). Re-signaling a passed gate cascade-resets downstream gates to pending.
-  - **gate_status** — Get a gate's detail (status, content, signals, definition). Param: `gate_id`.
+  - **gate_status** — Get latest signal details for a gate — verdict, truncated failed-step output, and metadata. Param: `gate_id`.
   - **gate_inspect** — Read gate content, verification output, or signal history. Params: `gate_id`, `section` ("content"/"verification"/"signals"), optional `signal_index`.
 
   ### Personality Management

--- a/defaults/roles/team-lead.yaml
+++ b/defaults/roles/team-lead.yaml
@@ -11,6 +11,7 @@ toolPolicies:
   gate_list: always-allow
   gate_signal: always-allow
   gate_status: always-allow
+  gate_inspect: always-allow
 createdAt: 1773875507369
 updatedAt: 1775088361805
 promptTemplate: |
@@ -75,6 +76,7 @@ promptTemplate: |
   - **gate_list** — List all gates with status and definitions. No parameters.
   - **gate_signal** — Signal a gate with content and/or metadata. Params: `gate_id` (required), `content` (optional markdown), `metadata` (optional key-value pairs). Re-signaling a passed gate cascade-resets downstream gates to pending.
   - **gate_status** — Get a gate's detail (status, content, signals, definition). Param: `gate_id`.
+  - **gate_inspect** — Read gate content, verification output, or signal history. Params: `gate_id`, `section` ("content"/"verification"/"signals"), optional `signal_index`.
 
   ### Personality Management
 
@@ -234,13 +236,35 @@ promptTemplate: |
   6. **Cleanup** — Dismiss idle agents with `team_dismiss`.
   7. **Done** — All tasks complete, all gates passed → call `team_complete`.
 
-  ## Consuming Agent Results
-  When a reviewer or tester finishes, you are notified with a summary. To get the full results:
-  1. **Task result summaries** — call `task_list` to see `result_summary` on completed tasks. This gives you a quick overview (e.g. "2 high, 1 medium issues found" or "All 12 tests pass").
-  2. **Gate content** — call `gate_status(gate_id="...")` to read the full content the agent signaled (review findings, test commands, etc.). This is where the detailed findings live.
-  3. **Act on findings** — if a reviewer found issues, spawn a coder to fix them. If tests failed, create a fix task. If everything passed, proceed to the next workflow gate.
+  ## Consuming Agent Results — Layered Information Gathering
 
-  This is how results flow: agents write to tasks (`task_update`) and gates (`gate_signal`) → you read from tasks (`task_list`) and gates (`gate_status`). You do NOT need to read agent session logs or parse their chat output.
+  Gate and task tools return **summaries by default** — slim responses
+  designed for quick decisions. Content is fetched on demand.
+
+  ### The three layers
+
+  1. **Dashboard** (`gate_list`, `task_list`) — call freely, costs almost nothing.
+     Returns status, counts, and failed step names. Use on every wake-up.
+
+  2. **Detail** (`gate_status`) — call for a specific gate after a notification.
+     Returns latest verdict, failed step output tail, and metadata.
+     Usually enough to decide next steps.
+
+  3. **Content** (`gate_inspect`) — call only when you need to READ something:
+     - `gate_inspect(gate_id="design-doc", section="content")` — read a design doc
+     - `gate_inspect(gate_id="implementation", section="verification")` — full verification output
+     - `gate_inspect(gate_id="implementation", section="signals")` — signal history overview
+
+  ### Decision flow after a gate notification
+
+  1. Already know what failed from the notification? → Spawn fix agent directly.
+  2. Need more detail? → `gate_status(gate_id="...")` — check the output tail.
+  3. Still unclear? → `gate_inspect(gate_id="...", section="verification")` — full output.
+  4. Need to read upstream content? → `gate_inspect(gate_id="...", section="content")`.
+
+  Do NOT call `gate_inspect` "just in case" — only when the decision requires it.
+
+  This is how results flow: agents write to tasks (`task_update`) and gates (`gate_signal`) → you read from tasks (`task_list`) and gates (`gate_status` / `gate_inspect`). You do NOT need to read agent session logs or parse their chat output.
 
   ## Handling Merge Conflicts
 

--- a/defaults/roles/test-engineer.yaml
+++ b/defaults/roles/test-engineer.yaml
@@ -11,7 +11,7 @@ promptTemplate: |-
   You write and run tests to verify that implemented features work correctly.
 
   ## Before You Start
-  Check gates first — use `gate_list` then `gate_status` to read the test plan and understand what to verify and the pass/fail criteria. Use `task_list` to find your assigned task and `task_update` to report results.
+  Check gates first — use `gate_list` for status overview, then `gate_inspect(gate_id="test-plan", section="content")` to read the test plan and understand what to verify and the pass/fail criteria. Use `task_list` to find your assigned task and `task_update` to report results.
 
   ## Git Workflow
   You are already on your own branch in your own worktree — do NOT checkout `{{GOAL_BRANCH}}` or create sub-branches.

--- a/defaults/tools/tasks/extension.ts
+++ b/defaults/tools/tasks/extension.ts
@@ -75,12 +75,12 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "task_list",
 		label: "List Tasks",
-		description: "List all tasks for the current goal with their state, type, assignment, and dependencies.",
+		description: "List all tasks for the current goal with their state, type, assignment, and dependencies. Returns a slim summary — use task detail for full spec or result.",
 		promptSnippet: "List all tasks for the goal.",
 		parameters: Type.Object({}),
 		async execute() {
 			try {
-				return ok(await api("GET", `/api/goals/${goalId}/tasks`));
+				return ok(await api("GET", `/api/goals/${goalId}/tasks?view=summary`));
 			} catch (e: any) { return err(e.message); }
 		},
 	});
@@ -155,12 +155,12 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "gate_list",
 		label: "List Gates",
-		description: "List all gates for the current goal with their status, dependencies, and signal count.",
+		description: "List all gates for the current goal — status, dependencies, signal count, and failed step names. Slim summary with no content bodies.",
 		promptSnippet: "List all gates for the goal with status.",
 		parameters: Type.Object({}),
 		async execute() {
 			try {
-				return ok(await api("GET", `/api/goals/${goalId}/gates`));
+				return ok(await api("GET", `/api/goals/${goalId}/gates?view=summary`));
 			} catch (e: any) { return err(e.message); }
 		},
 	});
@@ -168,14 +168,14 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "gate_status",
 		label: "Gate Status",
-		description: "Get current status of a specific gate (pending/passed/failed) plus latest verification results and signal history.",
-		promptSnippet: "Get gate status, verification results, and signal history.",
+		description: "Get latest signal details for a specific gate — verdict, truncated failed-step output, and metadata. Use gate_inspect for full content or history.",
+		promptSnippet: "Get gate status, latest verification results, and metadata.",
 		parameters: Type.Object({
 			gate_id: Type.String({ description: "Gate ID (e.g. 'issue-analysis', 'implementation')" }),
 		}),
 		async execute(_id, params) {
 			try {
-				return ok(await api("GET", `/api/goals/${goalId}/gates/${params.gate_id}`));
+				return ok(await api("GET", `/api/goals/${goalId}/gates/${params.gate_id}?view=summary`));
 			} catch (e: any) { return err(e.message); }
 		},
 	});
@@ -205,6 +205,34 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
+	pi.registerTool({
+		name: "gate_inspect",
+		label: "Inspect Gate",
+		description: [
+			"Read gate content, verification output, or signal history.",
+			"section='content': returns the markdown content from a signal.",
+			"section='verification': returns full verification step output.",
+			"section='signals': returns summary list of all signals (no content bodies).",
+		].join(" "),
+		promptSnippet: "Read detailed gate data: content, verification output, or signal history.",
+		parameters: Type.Object({
+			gate_id: Type.String({ description: "Gate ID" }),
+			section: Type.Union([
+				Type.Literal("content"),
+				Type.Literal("verification"),
+				Type.Literal("signals"),
+			], { description: "What to read: 'content', 'verification', or 'signals'" }),
+			signal_index: Type.Optional(Type.Number({ description: "Which signal (0-based, negative from end, default: -1 = latest)" })),
+		}),
+		async execute(_id, params) {
+			try {
+				const qs = new URLSearchParams({ section: params.section });
+				if (params.signal_index !== undefined) qs.set("signal_index", String(params.signal_index));
+				return ok(await api("GET", `/api/goals/${goalId}/gates/${params.gate_id}/inspect?${qs}`));
+			} catch (e: any) { return err(e.message); }
+		},
+	});
+
 	// ── verification_result ──────────────────────────────────────────
 	pi.registerTool({
 		name: "verification_result",
@@ -230,5 +258,5 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
-	console.log(`[goal-tools] Registered 7 task/gate tools for session ${sessionId}, goal ${goalId}`);
+	console.log(`[goal-tools] Registered 8 task/gate tools for session ${sessionId}, goal ${goalId}`);
 }

--- a/defaults/tools/tasks/gate_inspect.yaml
+++ b/defaults/tools/tasks/gate_inspect.yaml
@@ -1,0 +1,188 @@
+name: gate_inspect
+description: "Read gate content, verification output, or signal history"
+summary: "Read detailed gate data by section: content, verification output, or signal history."
+provider:
+  type: bobbit-extension
+  extension: extension.ts
+group: Gates
+docs: >-
+  Scoped read tool for gate data. Fetches exactly one section per call:
+  content (markdown body), verification (full step output), or signals
+  (summary list of all signals). Use after gate_status when you need to
+  drill deeper.
+detail_docs: >-
+  ## Purpose
+
+
+  Read detailed gate data by section. This is the Layer 3 content retrieval
+  tool — use it when `gate_list` (Layer 1) and `gate_status` (Layer 2) don't
+  have enough detail. Each call fetches exactly one piece of data to keep
+  responses focused.
+
+
+  ## Parameters
+
+
+  | Name | Type | Required | Default | Description |
+
+  |------|------|----------|---------|-------------|
+
+  | `gate_id` | string | **Yes** | — | Gate ID (e.g. "design-doc",
+  "implementation") |
+
+  | `section` | `"content"` / `"verification"` / `"signals"` | **Yes** | — |
+  What to read |
+
+  | `signal_index` | number | No | -1 (latest) | Which signal. 0-based,
+  negative from end. |
+
+
+  ## Returns
+
+
+  ### section="content" — Read gate content
+
+
+  Returns the markdown content from the specified signal.
+
+
+  - `gateId` — gate identifier
+
+  - `section` — `"content"`
+
+  - `signalIndex` — resolved 0-based index
+
+  - `signalId` — signal identifier
+
+  - `text` — the markdown content body (or null if no content)
+
+
+  Typical size: 2–8KB for a design doc.
+
+
+  ### section="verification" — Read full verification output
+
+
+  Returns all verification steps with full (untruncated) output.
+
+
+  - `gateId` — gate identifier
+
+  - `section` — `"verification"`
+
+  - `signalIndex` — resolved 0-based index
+
+  - `signalId` — signal identifier
+
+  - `steps[]` — array of verification step results:
+    - `name` — step name
+    - `type` — step type (e.g. "command", "llm-review")
+    - `passed` — boolean
+    - `skipped` — boolean (if skipped)
+    - `duration_ms` — execution time in milliseconds
+    - `output` — full output text (untruncated)
+
+
+  Can be large (10–50KB for LLM review steps).
+
+
+  ### section="signals" — Browse signal history
+
+
+  Summary-only listing of all signals. No content bodies, no verification
+  output.
+
+
+  - `gateId` — gate identifier
+
+  - `section` — `"signals"`
+
+  - `signals[]` — array of signal summaries:
+    - `index` — 0-based position
+    - `id` — signal identifier
+    - `timestamp` — when the signal was sent
+    - `sessionId` — which session sent it
+    - `commitSha` — git commit SHA (if provided)
+    - `verdict` — `"passed"`, `"failed"`, or `"running"`
+    - `hasContent` — whether this signal included content
+    - `metadataKeys` — array of metadata key names
+
+
+  Each entry is ~150 bytes. Even 22 signals = ~3.3KB.
+
+
+  ## When to Use
+
+
+  - **Reading a design doc** —
+  `gate_inspect(gate_id="design-doc", section="content")`
+
+  - **Getting full verification output** — when the 40-line tail from
+  `gate_status` wasn't enough to diagnose the issue
+
+  - **Browsing signal history** — to see how many attempts were made, compare
+  versions, or find a specific signal
+
+  - **Reading upstream content for planning** — get the content from any gate
+  to understand requirements
+
+
+  ## When NOT to Use
+
+
+  - **Quick status check** — use `gate_list` (Layer 1) instead.
+
+  - **Latest verdict and truncated output** — use `gate_status` (Layer 2)
+  instead.
+
+  - **Do NOT call "just in case"** — only when the decision requires reading
+  the actual content or full output.
+
+
+  ## Examples
+
+
+  ```
+
+  # Read the design document content
+
+  gate_inspect(gate_id="design-doc", section="content")
+
+
+  # Get full verification output for the latest signal
+
+  gate_inspect(gate_id="implementation", section="verification")
+
+
+  # Browse all signals to see attempt history
+
+  gate_inspect(gate_id="implementation", section="signals")
+
+
+  # Read content from a specific earlier signal (comparing versions)
+
+  gate_inspect(gate_id="implementation", section="content", signal_index=0)
+
+
+  # Read verification from second-to-last signal
+
+  gate_inspect(gate_id="implementation", section="verification",
+  signal_index=-2)
+
+  ```
+
+
+  ## Notes / Gotchas
+
+
+  - **signal_index** defaults to -1 (latest). Use 0 for the first signal,
+  -2 for second-to-last, etc.
+
+  - **section="signals" ignores signal_index** — it always returns all
+  signals as summaries.
+
+  - **Large responses possible** — `section="verification"` can return
+  10–50KB for LLM review steps. Only call when needed.
+
+  - **404 if signal not found** — if the signal_index is out of range, the
+  endpoint returns a 404 error.

--- a/defaults/tools/tasks/gate_list.yaml
+++ b/defaults/tools/tasks/gate_list.yaml
@@ -40,10 +40,13 @@ detail_docs: >-
   - `dependsOn` — array of gate IDs that must pass before this gate can be
   signaled
 
-  - `content` — whether this gate accepts markdown content
+  - `signalCount` — number of times this gate has been signaled
 
-  - `injectDownstream` — whether passed content is auto-injected into downstream
-  agents
+  - `updatedAt` — last activity timestamp (only present if signaled at least
+  once)
+
+  - `failedSteps` — names of failed verification steps (only present if status
+  is `failed`)
 
 
   ## When to Use
@@ -65,8 +68,11 @@ detail_docs: >-
   ## When NOT to Use
 
 
-  - **Getting a single gate's full detail** — use `gate_status` for a specific
-  gate's content and signal history.
+  - **Getting a single gate's detail** — use `gate_status` for latest verdict
+  and truncated verification output.
+
+  - **Reading gate content** — use `gate_inspect` to read content, full
+  verification output, or signal history.
 
 
   ## Examples

--- a/defaults/tools/tasks/gate_status.yaml
+++ b/defaults/tools/tasks/gate_status.yaml
@@ -1,23 +1,22 @@
 name: gate_status
-description: "Get a gate's detail (status, content, signals)"
-summary: "Get a workflow gate's detail including status, content, signal
-  history, and definition."
+description: "Get latest signal details for a specific gate — verdict, truncated failed-step output, and metadata. Use gate_inspect for full content or history."
+summary: "Get latest signal details for a specific gate — verdict, truncated failed-step output, and metadata. Use gate_inspect for full content or history."
 provider:
   type: bobbit-extension
   extension: extension.ts
 group: Gates
 docs: >-
-  Use to read upstream gate content (e.g. design docs) before starting
-  downstream work. Returns content body, signal history, and verification
-  results.
+  Returns latest signal with truncated verification output (last 40 lines for
+  failed steps). Shows hasContent/contentLength instead of content body. Use
+  gate_inspect for full content, verification output, or signal history.
 detail_docs: >-
   ## Purpose
 
 
-  Get detailed information about a specific workflow gate, including its current
-  status, content, signal history, and definition. This is how agents read
-  upstream gate content (design docs, test plans, review findings) to understand
-  context.
+  Get the latest signal details for a specific workflow gate — verdict,
+  truncated failed-step output, and metadata. This is the Layer 2 detail view:
+  more than `gate_list` but less than `gate_inspect`. Returns enough to decide
+  next steps without dumping full content or history.
 
 
   ## Parameters
@@ -42,41 +41,61 @@ detail_docs: >-
 
   - `status` — current state: `pending`, `passed`, or `failed`
 
-  - `currentContent` — the latest passed content (markdown text)
-
-  - `currentContentVersion` — content version number
-
-  - `currentMetadata` — key-value metadata
-
   - `dependsOn` — array of upstream gate IDs
 
-  - `signals` — full signal history with verification results
+  - `signalCount` — total number of signals sent to this gate
 
   - `updatedAt` — last update timestamp
+
+  - `hasContent` — boolean, whether the gate has content
+
+  - `contentLength` — character length of the content body (0 if none)
+
+  - `currentMetadata` — key-value metadata from the latest signal (if any)
+
+  - `latestSignal` — the most recent signal object:
+    - `id` — signal identifier
+    - `sessionId` — which session sent it
+    - `timestamp` — when it was sent
+    - `commitSha` — git commit (if provided)
+    - `verification` — verification result:
+      - `status` — `passed`, `failed`, or `running`
+      - `steps[]` — array of step results:
+        - `name` — step name
+        - `passed` — boolean
+        - `output` — last 40 lines of output (failed steps only; omitted for passed steps)
+
+
+  Does **not** return: content body (use `gate_inspect section=content`), full
+  signal history (use `gate_inspect section=signals`), full verification output
+  (use `gate_inspect section=verification`).
 
 
   ## When to Use
 
 
-  - **Reading the design doc** — `gate_status(gate_id="design-doc")` to get the
-  full design content.
+  - **Checking verification results** — after a gate notification, see the
+  latest verdict and truncated error output.
 
-  - **Checking verification results** — see why a gate failed and what the
-  verification output was.
+  - **Seeing latest verdict** — quick check on what failed and why.
 
-  - **Reading upstream context** — get the content of any passed gate to
-  understand requirements.
-
-  - **Checking signal history** — see all previous signals, who sent them, and
-  their verification results.
+  - **Checking metadata** — read key-value metadata the signaling agent
+  attached.
 
 
   ## When NOT to Use
 
 
-  - **Listing all gates** — use `gate_list` for an overview of all gates.
+  - **Reading gate content** — use `gate_inspect(gate_id="...",
+  section="content")` instead.
 
-  - **Signaling a gate** — use `gate_signal` to submit work.
+  - **Reading full verification output** — use `gate_inspect(gate_id="...",
+  section="verification")` if the 40-line tail wasn't enough.
+
+  - **Browsing signal history** — use `gate_inspect(gate_id="...",
+  section="signals")` to see all past signals.
+
+  - **Quick overview of all gates** — use `gate_list` instead.
 
 
   ## Examples
@@ -84,14 +103,19 @@ detail_docs: >-
 
   ```
 
-  # Read the design document
+  # Check why implementation failed
+
+  gate_status(gate_id="implementation")
+
+  # → See latestSignal.verification.steps for which step failed and truncated
+  output
+
+
+  # Check if design doc has content worth reading
 
   gate_status(gate_id="design-doc")
 
-
-  # Check why implementation verification failed
-
-  gate_status(gate_id="implementation")
+  # → See hasContent=true, contentLength=4520 → then gate_inspect to read it
 
   ```
 
@@ -99,15 +123,14 @@ detail_docs: >-
   ## Notes / Gotchas
 
 
+  - **No content body** — the content text is NOT included. Check `hasContent`
+  and `contentLength`, then use `gate_inspect(section="content")` to read it.
+
+  - **Only the latest signal** — historical signals are not returned. Use
+  `gate_inspect(section="signals")` for history.
+
+  - **Truncated output** — failed verification steps show only the last 40
+  lines of output. Use `gate_inspect(section="verification")` for full output.
+
   - **Use `gate_list` first** — to discover gate IDs before querying specific
   gates.
-
-  - **Content may be large** — design docs and review findings can be
-  substantial. The full content is returned without truncation.
-
-  - **Signal history** — the `signals` array contains every signal ever sent to
-  this gate, including failed ones. Check the latest signal's verification
-  status for the current state.
-
-  - **Read before coding** — always read the design-doc gate before starting
-  implementation work.

--- a/defaults/tools/tasks/task_list.yaml
+++ b/defaults/tools/tasks/task_list.yaml
@@ -12,9 +12,9 @@ detail_docs: >-
   ## Purpose
 
 
-  List all tasks for the current goal with their full metadata: state, type,
-  assignment, dependencies, spec, and results. This is the dashboard view of the
-  goal's task board.
+  List all tasks for the current goal with a slim summary: state, type,
+  assignment, and dependencies. This is the dashboard view of the goal's task
+  board. Full spec and result details are available via individual task detail.
 
 
   ## Parameters
@@ -42,20 +42,15 @@ detail_docs: >-
 
   - `dependsOn` — array of task IDs this task depends on
 
-  - `spec` — detailed task specification
-
-  - `resultSummary` — completion summary (populated when task is completed)
-
-  - `baseSha` — commit the agent started from (set by system at spawn)
+  - `branch` — agent's working branch name (set by system at spawn)
 
   - `headSha` — tip of the agent's finished work (set by agent on completion)
 
-  - `branch` — agent's working branch name (set by system at spawn)
+  - `workflowGateId` — linked workflow gate ID (if any)
 
-  - `parentTaskId` — ID of the parent task (null if top-level)
 
-  - `completedAt` — timestamp when the task was completed (null if not yet
-  complete)
+  Does **not** return: `spec`, `resultSummary`, `baseSha`, `parentTaskId`,
+  `completedAt`. Use `GET /api/tasks/:id` for full task detail.
 
 
   ## When to Use
@@ -106,6 +101,10 @@ detail_docs: >-
 
   ## Notes / Gotchas
 
+
+  - **Slim summary** — returns only orchestration fields. `spec` and
+  `resultSummary` are omitted to keep responses small. Use individual task
+  detail (`GET /api/tasks/:id`) when you need the full spec or result.
 
   - **Lightweight and fast** — no parameters, instant response. Call frequently
   to stay informed.

--- a/docs/goals-workflows-tasks.md
+++ b/docs/goals-workflows-tasks.md
@@ -403,11 +403,14 @@ Here's the typical flow for a team goal with a workflow:
 |---|---|---|
 | `GET` | `/api/goals/:id/gates` | List all gates for a goal with status and definitions |
 | `GET` | `/api/goals/:id/gates/:gateId` | Get gate detail (status, signals, definition) |
+| `GET` | `/api/goals/:id/gates/:gateId/inspect` | Scoped gate data retrieval — content, verification, or signal history |
 | `POST` | `/api/goals/:id/gates/:gateId/signal` | Signal a gate — triggers verification |
 | `GET` | `/api/goals/:id/gates/:gateId/signals` | Get signal history for a gate |
 | `GET` | `/api/goals/:id/gates/:gateId/content` | Get the current passed content of a gate |
 | `POST` | `/api/goals/:id/gates/:gateId/cancel-verification` | Cancel a stuck running verification (idempotent) |
 | `GET` | `/api/goals/:id/verifications/active` | Get in-flight verification state (running steps, sessions) |
+
+The gate list, gate detail, and task list endpoints support `?view=summary` for slim agent-facing responses. See [rest-api.md — Summary views](rest-api.md#summary-views-viewsummary) for response shapes and the [Gate inspect endpoint](rest-api.md#gate-inspect-endpoint) for the `/inspect` endpoint.
 
 ### Tasks (gate-linked)
 
@@ -446,7 +449,7 @@ State is per-project — each project has its own copies of these files in `<pro
 | `src/server/agent/task-store.ts` | Task persistence with `workflowGateId` and `inputGateIds` |
 | `src/server/agent/team-manager.ts` | Context injection via `buildDependencyContext()` |
 | `src/server/agent/system-prompt.ts` | System prompt assembly including gate context |
-| `defaults/tools/tasks/extension.ts` | Agent tools: `gate_signal`, `gate_status`, `gate_list`, `task_create` |
+| `defaults/tools/tasks/extension.ts` | Agent tools: `gate_signal`, `gate_status`, `gate_list`, `gate_inspect`, `task_create` |
 | `defaults/tools/team/extension.ts` | Agent tools: `team_spawn`, `team_prompt` with context injection |
 | `defaults/roles/team-lead.yaml` | Team Lead prompt template (workflow-aware) |
 | `defaults/workflows/general.yaml` | Seed workflow: general-purpose lifecycle |

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -67,6 +67,8 @@ Per-session review annotations are stored server-side so they survive browser cl
 | Method | Path | Description |
 |---|---|---|
 | `GET` | `/api/goals/:id/gates` | List gates for a goal |
+| `GET` | `/api/goals/:id/gates/:gateId` | Get gate detail (status, signals, definition) |
+| `GET` | `/api/goals/:id/gates/:gateId/inspect` | Scoped gate data retrieval (content, verification, or signal history) |
 | `POST` | `/api/goals/:id/gates/:gateId/signal` | Signal a gate (`{ status, content?, verifiedBy? }`) |
 | `POST` | `/api/goals/:id/gates/:gateId/cancel-verification` | Cancel a stuck running verification (idempotent) |
 
@@ -256,6 +258,134 @@ Routes accept both `/team/` and legacy `/swarm/` paths.
 |---|---|---|
 | `GET` | `/api/preview` | Get preview HTML for a session (`?sessionId=`) |
 | `POST` | `/api/preview` | Set preview HTML for a session (`?sessionId=`, `{ html }`) |
+
+### Summary views (`?view=summary`)
+
+Three endpoints support a `?view=summary` query parameter that returns slim responses optimized for agent tool calls. Without this parameter, the full response is returned (used by the UI dashboard).
+
+**Why this exists:** Full gate and task responses include signal history, content bodies, verification output, and task specs — often hundreds of KB. Agent tools call these endpoints frequently, and every byte enters the LLM context window permanently. Summary views strip non-essential data, reducing typical `gate_list` responses from ~436KB to ~500B.
+
+**`GET /api/goals/:id/gates?view=summary`**
+
+Returns status, dependency, and signal count per gate — no signal arrays or content bodies.
+
+```json
+{
+  "gates": [{
+    "gateId": "implementation",
+    "name": "Implementation",
+    "status": "failed",
+    "dependsOn": ["design-doc"],
+    "signalCount": 22,
+    "updatedAt": 1775853741666,
+    "failedSteps": ["E2E tests"]
+  }]
+}
+```
+
+Fields: `gateId`, `name`, `status`, `dependsOn`, `signalCount`. Conditional: `updatedAt` (if signaled), `failedSteps` (if failed — names of non-passed, non-skipped verification steps).
+
+**`GET /api/goals/:id/gates/:gateId?view=summary`**
+
+Returns the latest signal only, with truncated output for failed verification steps (last 40 lines). Content body is replaced with `hasContent` + `contentLength`.
+
+```json
+{
+  "gateId": "implementation",
+  "name": "Implementation",
+  "status": "failed",
+  "dependsOn": ["design-doc"],
+  "signalCount": 22,
+  "updatedAt": 1775853741666,
+  "hasContent": true,
+  "contentLength": 15234,
+  "currentMetadata": { "new_regressions": "1" },
+  "latestSignal": {
+    "id": "sig-22",
+    "sessionId": "08c8adf2",
+    "timestamp": 1775853741666,
+    "commitSha": "bd8fc7b",
+    "verification": {
+      "status": "failed",
+      "steps": [
+        { "name": "Type check passes", "passed": true },
+        { "name": "E2E tests", "passed": false, "output": "… last 40 lines …" }
+      ]
+    }
+  }
+}
+```
+
+Passed verification steps include only `name` and `passed: true` — no output. Failed steps include a tail of their output (40 lines max).
+
+**`GET /api/goals/:id/tasks?view=summary`**
+
+Strips `spec`, `resultSummary`, `baseSha`, timestamps (`createdAt`, `updatedAt`, `completedAt`), and `inputGateIds`.
+
+```json
+{
+  "tasks": [{
+    "id": "743d021a",
+    "title": "Server-side annotation store",
+    "type": "implementation",
+    "state": "complete",
+    "assignedSessionId": "d425cf52",
+    "branch": "goal-...-coder-d425cf52",
+    "headSha": "def456",
+    "workflowGateId": "implementation",
+    "dependsOn": []
+  }]
+}
+```
+
+### Gate inspect endpoint
+
+**`GET /api/goals/:id/gates/:gateId/inspect`**
+
+A scoped read endpoint for targeted gate data retrieval. Used by the `gate_inspect` agent tool.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `section` | `"content"` \| `"verification"` \| `"signals"` | yes | — | What data to retrieve |
+| `signal_index` | integer | no | -1 (latest) | Which signal. 0-based, negative indexes from end. |
+
+**`section=content`** — Returns the markdown content body from a specific signal.
+```json
+{
+  "gateId": "design-doc",
+  "section": "content",
+  "signalIndex": 0,
+  "signalId": "sig-1",
+  "text": "## Design Document\n\n..."
+}
+```
+
+**`section=verification`** — Returns full verification step output (all steps, not truncated).
+```json
+{
+  "gateId": "implementation",
+  "section": "verification",
+  "signalIndex": 21,
+  "signalId": "sig-22",
+  "steps": [
+    { "name": "Type check", "type": "command", "passed": true, "duration_ms": 12400, "output": "Found 0 errors.\n" },
+    { "name": "E2E tests", "type": "command", "passed": false, "duration_ms": 95200, "output": "..." }
+  ]
+}
+```
+
+**`section=signals`** — Returns a summary list of all signals (no content bodies or verification output).
+```json
+{
+  "gateId": "implementation",
+  "section": "signals",
+  "signals": [
+    { "index": 0, "id": "sig-1", "timestamp": 1775812345000, "sessionId": "efed71fb", "commitSha": "abc123", "verdict": "failed", "hasContent": true, "metadataKeys": ["new_regressions"] }
+  ]
+}
+```
+
+Returns 400 if `section` is missing or invalid. Returns 404 if the resolved signal index is out of range.
 
 ### Generation counters (conditional fetch)
 

--- a/src/server/agent/role-assistant.ts
+++ b/src/server/agent/role-assistant.ts
@@ -30,7 +30,7 @@ When ready, call the \`propose_role\` tool with these parameters:
 - **name**: URL-safe identifier (lowercase alphanumeric + hyphens). This is immutable after creation.
 - **label**: Short human-readable display name.
 - **prompt**: The full system prompt template. Use markdown formatting. You can include {{GOAL_BRANCH}} and {{AGENT_ID}} placeholders. Be specific about what the agent should and shouldn't do. Include git conventions and idle behavior.
-- **tools**: (optional) Comma-separated list of allowed tools. Every role must explicitly list its tools. Available tools: read, write, edit, bash, grep, find, ls, web_search, web_fetch, delegate, browser_navigate, browser_screenshot, browser_click, browser_type, browser_eval, browser_wait, team_spawn, team_list, team_dismiss, team_complete, team_abort, task_list, task_create, task_update, gate_signal, gate_status, gate_list.
+- **tools**: (optional) Comma-separated list of allowed tools. Every role must explicitly list its tools. Available tools: read, write, edit, bash, grep, find, ls, web_search, web_fetch, delegate, browser_navigate, browser_screenshot, browser_click, browser_type, browser_eval, browser_wait, team_spawn, team_list, team_dismiss, team_complete, team_abort, task_list, task_create, task_update, gate_signal, gate_status, gate_list, gate_inspect.
 - **accessory**: (optional) Pixel-art accessory for the agent's avatar. Options: crown, bandana, magnifier, palette, set-square, pencil, shield, wizard-hat, none.
 
 ### Accessory guide

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -977,7 +977,7 @@ export class TeamManager {
 				if (t.resultSummary) s += ` — ${t.resultSummary}`;
 				return s;
 			}).join("; ");
-			message = `Agent ${agentId} (${role}) has finished. Tasks: ${taskSummaries}. Check task details and gate content (gate_status) for full results.`;
+			message = `Agent ${agentId} (${role}) has finished. Tasks: ${taskSummaries}. Check task details and decide next steps.`;
 		} else {
 			message = `Agent ${agentId} (${role}) has finished with no assigned tasks. Check tasks and decide next steps.`;
 		}
@@ -1008,7 +1008,7 @@ export class TeamManager {
 		const teamLeadSession = this.sessionManager.getSession(entry.teamLeadSessionId);
 		if (!teamLeadSession || teamLeadSession.status === "terminated") return;
 
-		const message = `Task "${taskTitle}" transitioned to ${taskState}. Use task_list for result summaries and gate_status to read any gate content the agent produced.`;
+		const message = `Task "${taskTitle}" transitioned to ${taskState}. Use task_list for result summaries and gate_status for verification details.`;
 
 		if (teamLeadSession.status === "streaming") {
 			teamLeadSession.rpcClient.steer(message).catch((err: any) => {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3231,6 +3231,21 @@ async function handleApiRoute(
 	const goalTasksMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/tasks$/);
 	if (goalTasksMatch && req.method === "GET") {
 		const tasks = getTaskManagerForGoal(goalTasksMatch[1]).getTasksForGoal(goalTasksMatch[1]);
+		if (url.searchParams.get("view") === "summary") {
+			const slim = tasks.map(t => ({
+				id: t.id,
+				title: t.title,
+				type: t.type,
+				state: t.state,
+				assignedSessionId: t.assignedSessionId,
+				branch: t.branch,
+				headSha: t.headSha,
+				workflowGateId: t.workflowGateId,
+				dependsOn: t.dependsOn || [],
+			}));
+			json({ tasks: slim });
+			return;
+		}
 		json({ tasks });
 		return;
 	}
@@ -3285,6 +3300,29 @@ async function handleApiRoute(
 			const def = goal.workflow?.gates.find(wg => wg.id === g.gateId);
 			return { ...g, name: def?.name, dependsOn: def?.dependsOn, content: def?.content, injectDownstream: def?.injectDownstream, metadata: def?.metadata || g.currentMetadata, signalCount: g.signals.length };
 		});
+		if (url.searchParams.get("view") === "summary") {
+			const slim = enriched.map(g => {
+				const base: Record<string, unknown> = {
+					gateId: g.gateId,
+					name: g.name,
+					status: g.status,
+					dependsOn: g.dependsOn || [],
+					signalCount: g.signalCount,
+				};
+				if (g.signals.length > 0) base.updatedAt = g.updatedAt;
+				if (g.status === "failed") {
+					const latest = g.signals[g.signals.length - 1];
+					if (latest?.verification?.steps) {
+						base.failedSteps = latest.verification.steps
+							.filter((s: any) => !s.passed && !s.skipped)
+							.map((s: any) => s.name);
+					}
+				}
+				return base;
+			});
+			json({ gates: slim });
+			return;
+		}
 		json({ gates: enriched });
 		return;
 	}
@@ -3300,8 +3338,120 @@ async function handleApiRoute(
 		if (!gate) { json({ error: "Gate not found" }, 404); return; }
 		const goal = getGoalAcrossProjects(goalId);
 		const def = goal?.workflow?.gates.find(wg => wg.id === gateId);
+		if (url.searchParams.get("view") === "summary") {
+			const latestSignal = gate.signals[gate.signals.length - 1];
+			const MAX_TAIL_LINES = 40;
+			const slim: Record<string, unknown> = {
+				gateId: gate.gateId,
+				name: def?.name,
+				status: gate.status,
+				dependsOn: def?.dependsOn || [],
+				signalCount: gate.signals.length,
+				updatedAt: gate.updatedAt,
+				hasContent: !!gate.currentContent,
+				contentLength: gate.currentContent?.length || 0,
+			};
+			if (gate.currentMetadata) slim.currentMetadata = gate.currentMetadata;
+			if (latestSignal) {
+				slim.latestSignal = {
+					id: latestSignal.id,
+					sessionId: latestSignal.sessionId,
+					timestamp: latestSignal.timestamp,
+					commitSha: latestSignal.commitSha,
+					verification: latestSignal.verification ? {
+						status: latestSignal.verification.status,
+						steps: latestSignal.verification.steps.map(s => {
+							const base: Record<string, unknown> = { name: s.name, passed: s.passed };
+							if (!s.passed && !s.skipped && s.output) {
+								const lines = s.output.split("\n");
+								base.output = lines.length > MAX_TAIL_LINES
+									? lines.slice(-MAX_TAIL_LINES).join("\n")
+									: s.output;
+							}
+							return base;
+						}),
+					} : undefined,
+				};
+			}
+			json(slim);
+			return;
+		}
 		json({ ...gate, name: def?.name, dependsOn: def?.dependsOn, content: def?.content, injectDownstream: def?.injectDownstream });
 		return;
+	}
+
+	// GET /api/goals/:goalId/gates/:gateId/inspect — scoped gate data retrieval
+	const gateInspectMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/gates\/([^/]+)\/inspect$/);
+	if (gateInspectMatch && req.method === "GET") {
+		const [, goalId, gateId] = gateInspectMatch;
+		const ctx = projectContextManager.getContextForGoal(goalId);
+		if (!ctx) { json({ error: "Goal not found" }, 404); return; }
+		const gate = ctx.gateStore.getGate(goalId, gateId);
+		if (!gate) { json({ error: "Gate not found" }, 404); return; }
+
+		const section = url.searchParams.get("section");
+		if (!section || !["content", "verification", "signals"].includes(section)) {
+			json({ error: "section query parameter is required: 'content', 'verification', or 'signals'" }, 400);
+			return;
+		}
+
+		const resolveSignal = () => {
+			const idxStr = url.searchParams.get("signal_index");
+			let idx = idxStr !== null ? parseInt(idxStr, 10) : -1;
+			if (isNaN(idx)) idx = -1;
+			if (idx < 0) idx = gate.signals.length + idx;
+			if (idx < 0 || idx >= gate.signals.length) return null;
+			return { signal: gate.signals[idx], index: idx };
+		};
+
+		if (section === "content") {
+			const resolved = resolveSignal();
+			if (!resolved) { json({ error: "Signal not found" }, 404); return; }
+			json({
+				gateId, section: "content",
+				signalIndex: resolved.index,
+				signalId: resolved.signal.id,
+				text: resolved.signal.content || null,
+			});
+			return;
+		}
+
+		if (section === "verification") {
+			const resolved = resolveSignal();
+			if (!resolved) { json({ error: "Signal not found" }, 404); return; }
+			const v = resolved.signal.verification;
+			json({
+				gateId, section: "verification",
+				signalIndex: resolved.index,
+				signalId: resolved.signal.id,
+				steps: v ? v.steps.map(s => ({
+					name: s.name,
+					type: s.type,
+					passed: s.passed,
+					skipped: s.skipped || undefined,
+					duration_ms: s.duration_ms,
+					output: s.output,
+				})) : [],
+			});
+			return;
+		}
+
+		if (section === "signals") {
+			json({
+				gateId, section: "signals",
+				signals: gate.signals.map((s, i) => ({
+					index: i,
+					id: s.id,
+					timestamp: s.timestamp,
+					sessionId: s.sessionId,
+					commitSha: s.commitSha,
+					verdict: s.verification?.status || "running",
+					hasContent: !!s.content,
+					metadataKeys: s.metadata ? Object.keys(s.metadata) : [],
+				})),
+			});
+			return;
+		}
 	}
 
 	// POST /api/goals/:goalId/gates/:gateId/signal — signal a gate


### PR DESCRIPTION
## Summary

Redesign gate and task tool responses to use decision-first information layering. Reduces gate/task tool context from ~825KB to ~5KB per session through three-layered responses.

## Changes

### Server (`src/server/server.ts`)
- `?view=summary` query param on gate list, gate detail, and task list endpoints
- New `GET /api/goals/:id/gates/:gateId/inspect` endpoint with section-based retrieval (content/verification/signals)

### Agent Tools (`defaults/tools/tasks/extension.ts`)
- `gate_list`, `gate_status`, `task_list` now use `?view=summary` by default
- New `gate_inspect` tool for targeted content retrieval

### Role Prompts
- Team lead prompt updated with three-layer information gathering guidance
- Coder, reviewer, spec-auditor, test-engineer prompts updated to use `gate_inspect` for content reading
- Team manager notification messages updated

### Documentation
- `docs/rest-api.md` — Summary views and inspect endpoint docs
- `docs/goals-workflows-tasks.md` — Cross-references
- `AGENTS.md` — Debugging tip
- Tool YAML docs updated/created for all affected tools

## Impact Estimate
- gate_list: ~436KB → ~500B
- gate_status: ~389KB → ~2KB  
- task_list: ~46KB → ~2KB
- Estimated session cost reduction: ~46%

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)