### PR TITLE
Simplify search stories: filter mode + full search mode

### DIFF
--- a/userstories/README.md
+++ b/userstories/README.md
@@ -30,7 +30,7 @@ Each file covers a feature area. Stories are numbered within each file (e.g. `S-
 | Projects | [projects.md](projects.md) | 10 | Good | Assistant flow well-tested |
 | Settings | [settings.md](settings.md) | 9 | Partial | Per-project config gaps |
 | Navigation | [navigation.md](navigation.md) | 8 | Partial | Cross-feature journeys missing |
-| Search | [search.md](search.md) | 12 | None | Title filter, FTS, full page, keyboard, archived, rebuild |
+| Search | [search.md](search.md) | 11 | None | Filter mode, full search, keyboard, archived, rebuild |
 | Config Cascade | [config-cascade.md](config-cascade.md) | 7 | API only | UI cascade effects untested |
 | Sandbox | [sandbox.md](sandbox.md) | 8 | Skipped | Docker-dependent, all skipped |
 | Prompt Interactions | [prompt-interactions.md](prompt-interactions.md) | 34 | Minimal | Race conditions, steer/abort lifecycle |

--- a/userstories/search.md
+++ b/userstories/search.md
@@ -1,36 +1,41 @@
 # Search — User Stories
 
-Search allows users to find sessions, goals, messages, and staff across all projects. There are two modes: client-side title filtering (default, instant) and server-side FTS content search (toggled via the Content switch). A full search page provides paginated results with type filtering.
+Search has two modes:
 
-**Architecture:** Server-side SQLite FTS5 index (`search.db`) indexes goals (title + spec), sessions (title + role + goal title), messages (text content + tool names), and staff (name + description). Index is rebuilt from stores on startup if missing or schema-mismatched. Incremental indexing occurs as messages stream in. Client-side search filters sidebar items by title without an API call.
+- **Filter mode** (default): If the search string matches anything visible in the sidebar — goal names, session titles, staff names, agent names — it remains visible. Everything else is hidden. Instant, client-side, no API call.
+- **Full search mode**: Matches everything Filter mode matches, PLUS content that isn't visible in the sidebar — goal specs, user prompts, agent responses, staff prompts/instructions, gate content (e.g. design specs). Uses SQLite FTS5. API call required.
+
+**Architecture:** Server-side SQLite FTS5 index (`search.db`) indexes goals (title + spec), sessions (title + role + goal title), messages (text content + tool names), and staff (name + description). Index is rebuilt from stores on startup if missing or schema-mismatched. Incremental indexing occurs as messages stream in.
 
 ---
 
-## SR-01: Sidebar title search (default mode)
+## SR-01: Filter mode — sidebar filtering
 
-**Preconditions:** Multiple sessions and goals exist with distinct titles. Content mode toggle is OFF (default).
+**Preconditions:** Multiple sessions and goals exist with distinct titles. Search is in Filter mode (default).
 
 **Steps and expectations:**
 1. Click the search input in the sidebar (or press Ctrl+K / Cmd+K).
    - Search input focuses. Placeholder shows "Search... (Ctrl+K)" or "Search... (⌘K)" on Mac.
-   - No controls row visible yet (content toggle, Full Search link hidden when query is empty).
+   - No controls row visible yet (Full Search link hidden when query is empty).
 2. Type "deploy" into the search input.
-   - Controls row appears below the input (content toggle + "Full Search" link).
-   - Sidebar filters instantly (no API call, no loading spinner) — only sessions and goals whose titles contain "deploy" (case-insensitive) are visible.
-   - Goals that match show their child sessions. Goals whose child session titles match also appear.
-   - Staff entries that match by name are visible.
-   - Non-matching items are hidden from the sidebar.
-   - Archived section (if open) also filters by title.
+   - Controls row appears below the input ("Full Search" link).
+   - Sidebar filters instantly (no API call, no loading spinner).
+   - Items remain visible if "deploy" matches (case-insensitive) any of: goal name, session title, staff name, agent name.
+   - A goal remains visible if it matches OR if any of its child sessions match.
+   - A session remains visible if it matches OR if its parent goal matches.
+   - Staff entries remain visible if their name matches.
+   - Non-matching items are hidden.
+   - Archived section (if open) also filters.
 3. Modify the query to "deployx" (no matches).
-   - Sidebar shows no sessions, no goals, no staff. No explicit "no results" message in the sidebar (items are simply hidden).
+   - Sidebar shows nothing. Items are simply hidden — no explicit "no results" message.
 4. Clear the input (click X button or select all + delete).
-   - All sessions and goals reappear in the sidebar.
-   - Controls row hides (empty query).
+   - All items reappear in the sidebar.
+   - Controls row hides.
    - If the archived section was auto-opened by search, it auto-closes.
 5. Press Escape while the search input is focused.
    - Input clears. Focus leaves the input (blur).
    - Sidebar restores to unfiltered state.
-6. Type a query, then navigate to a session by clicking it in the filtered sidebar.
+6. Type a query, then click a filtered result in the sidebar.
    - Session opens. Search query remains in the input (not cleared on navigation).
    - Sidebar continues to show filtered results.
 
@@ -38,107 +43,71 @@ Search allows users to find sessions, goals, messages, and staff across all proj
 
 ---
 
-## SR-02: Content search mode (FTS)
+## SR-02: Full search mode
 
-**Preconditions:** Multiple sessions with messages containing the word "kubernetes". Content mode is initially OFF.
+**Preconditions:** Multiple sessions with messages containing the word "kubernetes" but whose titles do NOT contain "kubernetes".
 
 **Steps and expectations:**
 1. Type "kubernetes" in the search input.
-   - Sidebar filters by title only (default mode). Sessions whose titles don't contain "kubernetes" are hidden — even if their messages do.
-2. Click the "Content" toggle switch below the search input.
-   - Toggle turns on (primary color background).
-   - Loading spinner appears in the search icon position.
-   - An API call fires to `GET /api/search?q=kubernetes`.
+   - Filter mode: no results visible (titles don't match).
+2. Click "Full Search" link below the input.
+   - Navigates to `#/search?q=kubernetes`.
+   - Full search page renders with: search input (pre-filled with "kubernetes"), type filter tabs (All, Goals, Sessions, Messages), and results area.
+   - Loading spinner appears while the API call runs (`GET /api/search?q=kubernetes`).
 3. Results return.
-   - Spinner stops. `<search-results>` component appears below the search input, replacing the session list.
-   - Results are grouped by type: Goals, Sessions, Messages — each with a header, icon, and count.
-   - Each result shows: title (bold), archived badge (if applicable), relative timestamp, and a snippet with `<b>` match highlighting.
-   - Message results show the session title (not the message ID).
-   - Sidebar items also filter to show only matching sessions/goals/staff (via `searchMatchIds`).
-4. Click a goal result.
-   - Navigates to the goal dashboard (`result-click` event with `type: "goal"`).
-5. Click a session result.
-   - Navigates to that session.
-6. Click a message result.
-   - Navigates to the session containing that message (`sessionId` from the result).
-7. Toggle Content mode OFF.
-   - `<search-results>` disappears. Sidebar reverts to title-only filtering.
-   - No API call made — client-side filter applies immediately.
-8. Toggle Content mode ON again with the same query.
-   - API call fires again. Fresh results displayed.
-
-**Coverage:** none
-
----
-
-## SR-03: Full search page
-
-**Preconditions:** Sessions and goals exist across multiple projects.
-
-**Steps and expectations:**
-1. Type a query in the sidebar search, then click "Full Search" link.
-   - Navigates to `#/search?q=<query>`.
-   - Full search page renders with: search input (pre-filled), type filter tabs (All, Goals, Sessions, Messages), and results area.
-2. Results display grouped by type with the same format as sidebar content search (title, snippet with highlights, timestamp, archived badge).
-   - Each result shows its project name (if multi-project).
-3. Click a type tab (e.g. "Messages").
+   - Grouped by type: Goals, Sessions, Messages — each with a header, icon, and count.
+   - Each result shows: title (bold), archived badge (if applicable), relative timestamp, and a snippet with match highlighting.
+   - Message results show the parent session title.
+   - Results include items that matched by title (same as filter mode) AND items that matched by content (goal specs, user prompts, agent responses, staff instructions, gate content).
+4. Click a type tab (e.g. "Messages").
    - Results filter to show only messages.
    - API re-fetches with `type=messages` parameter.
-   - Result count updates.
-4. Scroll to the bottom of results.
-   - If more results exist, a "Load more" button or infinite scroll triggers.
-   - Additional results append via `offset` pagination.
-5. Modify the query in the full search page input.
+5. Scroll to the bottom of results.
+   - If more results exist, a "Load more" button or pagination triggers via `offset`.
+6. Modify the query in the full search page input.
    - Results update after debounce.
    - URL updates to reflect the new query (`history.replaceState`).
-6. Navigate directly to `#/search?q=someterm` via URL.
-   - Full search page loads with the query pre-filled and results displayed.
-7. Click a result on the full search page.
+7. Click a result.
    - Navigates to the corresponding session, goal, or staff item.
 
 **Coverage:** none
 
 ---
 
-## SR-04: Search across projects
+## SR-03: Search across projects
 
 **Preconditions:** Two projects registered (Project A and Project B), each with sessions and goals.
 
 **Steps and expectations:**
 1. Type a query that matches items in both projects.
-   - Sidebar title filter shows matching items from both projects (items are grouped under their project headers as usual).
-2. Enable Content mode.
-   - FTS results include matches from both projects.
-   - Each result includes `projectName` in the display.
-3. On the full search page, results from both projects appear.
-   - Project name is shown on each result to disambiguate.
-4. If a project filter is applied (e.g. via `projectId` query param), only that project's results appear.
+   - Filter mode: matching items from both projects remain visible, grouped under their project headers.
+2. On the full search page, results from both projects appear.
+   - Each result shows its project name to disambiguate.
+3. If a project filter is applied (e.g. via `projectId` query param), only that project's results appear.
 
 **Coverage:** none
 
 ---
 
-## SR-05: Empty and edge-case searches
+## SR-04: Empty and edge-case searches
 
 **Preconditions:** Active app with sessions and goals.
 
 **Steps and expectations:**
-1. Enable Content mode. Search for a query that matches nothing.
+1. Full search for a query that matches nothing.
    - Loading spinner appears briefly.
-   - "No matches for '<query>'" message displays in the results area.
-   - No errors in console. No crash.
+   - "No matches for '<query>'" message displays. No errors. No crash.
 2. Search for a single character "a".
-   - Results return (FTS5 prefix matching: `a*` matches any word starting with "a").
-   - Results are reasonable — not every entry in the database.
+   - Results return (FTS5 prefix matching: `a*` matches words starting with "a").
+   - Results are reasonable — not the entire database.
 3. Search for special characters: `"deploy:prod"`, `hello-world`, `path/to/file`.
-   - FTS5 query sanitiser wraps tokens in double quotes. No FTS5 syntax error.
-   - Results match the literal terms (quotes stripped, hyphens/colons/slashes treated as word separators).
+   - No FTS5 syntax error. FTS5 query sanitiser handles special chars.
+   - Results match the literal terms (hyphens/colons/slashes treated as word separators).
 4. Search for a very long query (500+ characters).
    - No crash. API returns results or empty set.
 5. Search with leading/trailing whitespace: `  deploy  `.
-   - Whitespace is trimmed. "deploy" results appear normally.
-6. Clear the search input. No search-results component visible. Sidebar shows all items.
-7. Type a query, wait for content results, then rapidly type a different query.
+   - Whitespace is trimmed. Results appear normally.
+6. Type a query, wait for results, then rapidly type a different query.
    - Stale responses are discarded (guard: `state.searchQuery !== query`).
    - Only the final query's results display.
 
@@ -146,67 +115,61 @@ Search allows users to find sessions, goals, messages, and staff across all proj
 
 ---
 
-## SR-06: Keyboard shortcut (Ctrl+K / Cmd+K)
+## SR-05: Keyboard shortcut (Ctrl+K / Cmd+K)
 
-**Preconditions:** App is loaded. User is in any view (session, dashboard, settings).
+**Preconditions:** App is loaded. User is in any view.
 
 **Steps and expectations:**
 1. Press Ctrl+K (Cmd+K on Mac).
    - Search input in the sidebar focuses immediately.
-   - If the sidebar is collapsed (mobile), it should open or the mobile search should focus.
-2. Type a query and press Enter.
-   - Nothing special happens on Enter (search is live/debounced, not submit-on-enter).
+   - If the sidebar is collapsed (mobile), the mobile search should focus.
+2. Type a query. Filter mode engages instantly.
 3. Press Escape.
-   - Search clears and input blurs.
+   - Search clears and input blurs. Sidebar restores.
 4. Press Ctrl+K again.
    - Input re-focuses. Previous query is cleared (from the Escape).
 5. While a dialog is open (e.g. settings), press Ctrl+K.
-   - Search input should focus (keyboard shortcut is global via `document.addEventListener`).
-   - If this conflicts with dialog focus, the dialog should close first or the shortcut should be suppressed.
+   - Keyboard shortcut is global (`document.addEventListener`). Should focus search or be suppressed if a dialog has focus.
 
 **Coverage:** none
 
 ---
 
-## SR-07: Search result navigation and context preservation
+## SR-06: Result navigation and context preservation
 
-**Preconditions:** Content mode ON. Search returns results across goals, sessions, and messages.
+**Preconditions:** Full search page open with results across goals, sessions, and messages.
 
 **Steps and expectations:**
-1. Search for "deploy". Results show 2 goals, 3 sessions, 5 messages.
-2. Click a message result that belongs to session X.
+1. Search for "deploy". Results show goals, sessions, and messages.
+2. Click a message result belonging to session X.
    - App navigates to session X.
-   - The search query remains in the sidebar search input.
-   - Sidebar still shows filtered results.
-3. Press Ctrl+K and modify the query.
-   - Results update. Previous session stays open in the main panel.
-4. Click a different result (a goal).
+3. Press browser Back button.
+   - Returns to the full search page with the same query and results.
+4. Click a goal result.
    - Goal dashboard opens.
-5. Press browser Back button.
-   - Returns to the previous session.
+5. In the sidebar, the search query persists in filter mode — sidebar still shows filtered items.
 6. Clear the search.
-   - Sidebar shows all items again. The current session/goal view is unaffected.
+   - Sidebar shows all items. Current view (session/goal) is unaffected.
 
 **Coverage:** none
 
 ---
 
-## SR-08: Archived items in search
+## SR-07: Archived items in search
 
-**Preconditions:** Some sessions and goals are archived. Archived section is initially collapsed in the sidebar.
+**Preconditions:** Some sessions and goals are archived. Archived section is initially collapsed.
 
 **Steps and expectations:**
-1. Type a query that matches an archived session's title.
-   - In title-filter mode: the archived section auto-opens to show the matching archived item.
-   - A flag tracks that archived was opened by search (`_archivedBySearch`).
+1. Type a query that matches an archived item's name.
+   - Filter mode: the archived section auto-opens to show the matching item.
+   - A flag tracks that archived was opened by search.
 2. Clear the search.
-   - Archived section auto-closes (reverts to its state before search opened it).
-3. Enable Content mode. Search for text that exists in an archived session's messages.
-   - Archived results appear in the `<search-results>` component with an archive badge icon.
-   - Sidebar archived section auto-opens if matching archived items exist.
+   - Archived section auto-closes (reverts to its pre-search state).
+3. Full search for text in an archived session's messages.
+   - Archived results appear with an archive badge icon.
 4. Click an archived result.
-   - The archived session or goal opens (read-only if applicable).
-5. Manually open the archived section, then search.
+   - The archived session or goal opens.
+5. Manually open the archived section first, then search.
    - Archived section stays open (it was opened manually, not by search).
    - Clearing the search does NOT auto-close it.
 
@@ -214,78 +177,72 @@ Search allows users to find sessions, goals, messages, and staff across all proj
 
 ---
 
-## SR-09: Index rebuild and incremental indexing
+## SR-08: Index rebuild and incremental indexing
 
 **Preconditions:** Server is running with existing sessions and goals.
 
 **Steps and expectations:**
-1. Search for a message that exists in a session's chat history.
+1. Search for a message that exists in a session's chat history (full search mode).
    - Content search returns the message with a snippet. Index was built on startup.
-2. Send a new message in a session containing the word "flamingo".
-   - As the agent streams its response, messages are incrementally indexed (`indexMessage` called from `handleAgentLifecycle`).
-3. Search for "flamingo" in content mode.
+2. Send a new message containing the word "flamingo".
+   - As the agent streams, messages are incrementally indexed.
+3. Full search for "flamingo".
    - The new message appears in results without a server restart.
 4. Create a new goal titled "Flamingo Migration".
    - Goal is indexed on creation.
 5. Search for "flamingo" — both the message and the goal appear.
-6. Delete the search index file (`<project-root>/.bobbit/state/search.db`).
-7. Restart the server.
-   - The index is rebuilt automatically from stores (`rebuildFromStores` triggered by `needsRebuild()`).
-   - Console shows: `[search] Rebuilding index: N goals, M sessions, K messages, J staff`.
-8. Search works again — all previously indexed content is available.
+6. Delete the search index file (`<project-root>/.bobbit/state/search.db`). Restart the server.
+   - The index is rebuilt automatically from stores.
+   - Search works again — all previously indexed content is available.
 
 **Coverage:** none
 
 ---
 
-## SR-10: Search debounce and performance
+## SR-09: Search debounce and performance
 
 **Preconditions:** Large project with many sessions (50+).
 
 **Steps and expectations:**
 1. Type rapidly in the search input: "d", "de", "dep", "depl", "deplo", "deploy".
-   - In title mode: sidebar filters update on each keystroke (instant, no debounce needed for client-side).
-   - In content mode: API calls are debounced (200ms). Only 1-2 API calls fire, not 6.
+   - Filter mode: sidebar filters update on each keystroke (instant, client-side).
+   - Full search mode: API calls are debounced (200ms). Only 1-2 API calls fire, not 6.
    - Loading spinner shows during the API call.
    - No duplicate results or flickering.
 2. The final results correspond to the full query "deploy", not an intermediate one.
-3. Switching from Content mode to title mode mid-debounce cancels the pending API call.
-   - No stale content results appear.
 
 **Coverage:** none
 
 ---
 
-## SR-11: Mobile search
+## SR-10: Mobile search
 
 **Preconditions:** Mobile viewport (or narrow browser window where sidebar becomes an overlay).
 
 **Steps and expectations:**
 1. The search input is present in the mobile sidebar/drawer.
-   - Rendered via the mobile layout in `render.ts` (separate `<search-box>` instance).
 2. Type a query.
-   - Title filtering works (instant).
-3. Enable Content mode.
-   - FTS results appear in the `<search-results>` component within the mobile sidebar.
+   - Filter mode works (instant sidebar filtering).
+3. Click "Full Search".
+   - Full search page opens with results.
 4. Click a result.
    - Session/goal opens. Mobile sidebar closes.
-5. Ctrl+K / Cmd+K may not be relevant on mobile (no physical keyboard), but the search input is directly accessible.
 
 **Coverage:** none
 
 ---
 
-## SR-12: Staff search
+## SR-11: Staff search
 
 **Preconditions:** At least one staff member exists (active, not retired).
 
 **Steps and expectations:**
-1. Search by staff name in title mode.
-   - Matching staff entries appear in the sidebar.
-2. Enable Content mode. Search for text in a staff member's description.
-   - Staff results appear in the results grouped under a "Staff" section (if the component supports it — currently staff is not shown in SearchResults groups, only in sidebar filtering).
+1. Search by staff name in filter mode.
+   - Matching staff entries remain visible in the sidebar.
+2. Full search for text in a staff member's description or instructions.
+   - Staff results appear in the results.
 3. Click a staff result.
    - Navigates to the staff member's session or detail view.
-4. Retired staff members are filtered out of sidebar results.
+4. Retired staff members are filtered out of sidebar results in filter mode.
 
 **Coverage:** none


### PR DESCRIPTION
Simplifies the search user stories around two clean modes:

- **Filter mode** (default): instant client-side sidebar filtering against anything visible (goal names, session titles, staff names, agent names)
- **Full search mode**: separate page with FTS results covering all content (goal specs, prompts, responses, staff instructions, gate content)

Removes the confusing "Content toggle" sidebar concept. 11 stories total.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)