### PR TITLE
Fix search UX and bugs

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -147,8 +147,9 @@ When a sandbox container is killed or removed, sessions auto-recover. Use this c
 - FTS5 on 10K docs < 10ms — slow search means network/serialization bottleneck
 - Purged sessions still showing? Check `purgeOneSession()` calls index cleanup
 - Staff not appearing in search? `StaffManager` uses per-project `searchIndex` from `ProjectContextManager` — verify the correct project context's search index is being used. `rebuildFromStores()` passes `staff.projectId` for correct project filtering
-- Sidebar filter not working? Check `state.searchContentMode` — `false` = client-side title filter, `true` = FTS API call. Toggle state persisted in `localStorage`
-- Full search page (`#/search`) manages its own state — independent from sidebar search
+- Sidebar filter not working? The sidebar uses client-side filtering only (no API calls). It matches goal titles, session titles, session agent roles, and staff names. Check `_applySearchFilter()` in `Sidebar.ts`
+- Full search page (`#/search`) is the sole consumer of the FTS API — it manages its own state, independent from sidebar filtering
+- Archived section not auto-opening on search match? Check `_archivedBySearch` flag — it distinguishes search-triggered expansion from manual clicks
 
 ## Paginated archives
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -442,7 +442,7 @@ This happens transparently in `normalizeGrantPolicy()` — existing role YAML an
 
 SQLite FTS5 via `better-sqlite3`. Each project has its own index at `<project-root>/.bobbit/state/search.db` (rebuildable cache). `ProjectContextManager.searchAll()` aggregates results across all project indexes.
 
-**Key files:** `search-index.ts`, `message-extractor.ts`, `SearchBox.ts`, `SearchResults.ts`, `search-page.ts`.
+**Key files:** `search-index.ts` (server-side FTS5 index), `message-extractor.ts` (text extraction from messages), `SearchBox.ts` (sidebar input component), `SearchResults.ts` (result display used by full search page), `search-page.ts` (full search route).
 
 **Indexed:** Goals (title, spec), sessions (title, role), messages (text blocks, tool call names), staff agents (name, description).
 
@@ -450,24 +450,25 @@ SQLite FTS5 via `better-sqlite3`. Each project has its own index at `<project-ro
 
 **Indexing:** Incremental via store hooks + `RpcBridge`. Staff indexing hooks live in `StaffManager` — index on create/update, remove on delete. Indexing methods (`indexGoal`, `indexSession`, `indexMessage`, `indexStaff`) accept a `projectId` parameter. Full rebuild on first run or schema version mismatch; `rebuildFromStores()` iterates all project contexts to re-index everything.
 
+**Query sanitisation:** User input is tokenised and special characters (`(`, `)`, `+`, `-`, `*`, `"`, etc.) are stripped from all tokens before constructing the FTS5 MATCH expression. Each token except the last is quoted as an exact term; the last token gets a `*` suffix for prefix matching. This prevents FTS5 syntax errors from user input while supporting incremental search-as-you-type.
+
 **API:** `GET /api/search?q=<query>&limit=20&offset=0&type=all|goals|sessions|messages|staff&projectId=<optional>` — when `projectId` is omitted, searches across all projects. Search results include `projectId` and `projectName` fields so the UI can show which project each result belongs to.
 
-### Dual-mode sidebar search
+### Two-mode search design
 
-The sidebar search box operates in two modes, controlled by a "Search Content" toggle that appears below the input when a query is active:
+Search has two distinct modes with clear separation of concerns:
 
-- **Title-only (default):** Client-side instant filtering. Filters goals by title, sessions by title, and staff by name using case-insensitive substring matching. No API call. The sidebar structure (goal groups, ungrouped sessions, staff, archived) is preserved — non-matching entries are hidden.
-- **Content search:** Uses `GET /api/search` (FTS5) and maps results back to sidebar entries by ID. Message matches resolve to their parent session/goal. 200ms debounce on input.
+**1. Filter mode (sidebar):** Instant client-side filtering — no API calls. Filters goals by title, sessions by title and agent role, and staff by name using case-insensitive substring matching. The sidebar structure (goal groups, ungrouped sessions, staff, archived) is preserved — non-matching entries are hidden. Archived sections auto-expand when a match is found inside them and auto-collapse when the query clears (tracked by an internal flag to distinguish search-triggered vs manual expansion). A "Full Search" link below the input navigates to the full search page with the current query.
 
-State field `searchContentMode` (persisted in `localStorage`) tracks which mode is active.
+**Key file:** `SearchBox.ts` handles the input with debounce, Escape-to-clear, and Ctrl+K shortcut. Filtering logic lives in `Sidebar.ts`.
 
-### Full search page
-
-Route: `#/search` (with optional `?q=<query>` parameter). Accessible via the "Full Search" button in the sidebar controls row or directly by URL.
+**2. Full search page (`#/search`):** The sole consumer of the FTS5 `GET /api/search` endpoint. Route: `#/search` (with optional `?q=<query>` parameter). Accessible via the "Full Search" link in the sidebar or directly by URL.
 
 Features: large auto-focused input, type filter toggles (Goals, Sessions, Staff, Messages), grouped results with snippets and `<b>` match highlighting, relative timestamps, archived badges, and "Load More" pagination. Clicking a result navigates to the relevant goal dashboard, session, or staff edit page.
 
 **Key file:** `search-page.ts` manages its own local state (query, results, type filters, pagination offset).
+
+> **Design note — gate content:** Gate content (design specs, review findings) is not currently indexed in the FTS tables. This is a deliberate deferral — adding it requires schema changes and a rebuild trigger. Tracked for future work.
 
 **Paginated archives:**
 - `GET /api/goals?archived=true&limit=50&after=<cursor>` — cursor is `archivedAt` timestamp

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -16,7 +16,6 @@ import {
 
 	resetArchivedExpandState,
 	getSidebarData,
-	setSearchContentMode,
 } from "./state.js";
 import { createGoal, createRole, gatewayFetch, refreshSessions, dismissSetup, fetchSandboxStatus } from "./api.js";
 import { clearSessionModel } from "./routing.js";
@@ -24,7 +23,7 @@ import { clearAllAnnotations, clearAnnotations, markReviewSubmitted, flushPendin
 import { backToSessions, createAndConnectSession, terminateSession, saveGoalDraft, deleteGoalDraft, saveRoleDraft, deleteRoleDraft, saveProjectDraft, deleteProjectDraft, markProposalDismissed } from "./session-manager.js";
 import { openGatewayDialog, showQrCodeDialog, showRenameDialog, showGoalDialog, showProjectDialog } from "./dialogs.js";
 import { renderSidebar, toggleRolePicker, renderRolePickerDropdown, renderStaffSidebarSection, renderSetupBanner, launchSetupWizard, isSetupWizardActive, isProjectExpanded, toggleProjectExpanded } from "./sidebar.js";
-import { searchApi, fetchArchivedGoalsPaginated, fetchArchivedSessionsPaginated } from "./api.js";
+import { fetchArchivedGoalsPaginated, fetchArchivedSessionsPaginated } from "./api.js";
 // Register search web components
 import "../ui/components/SearchBox.js";
 import "../ui/components/SearchResults.js";
@@ -79,50 +78,13 @@ import { renderSearchPage, initSearchPage, resetSearchPage } from "./search-page
 /** Compact session row for mobile — mirrors sidebar row with always-visible buttons */
 
 // Mobile search handlers (shared logic with sidebar but separate scope)
-async function _handleMobileSearchInput(query: string): Promise<void> {
+function _handleMobileSearchInput(query: string): void {
 	state.searchQuery = query;
-	if (!query.trim()) {
-		state.searchResults = null;
-		state.searchLoading = false;
-		renderApp();
-		return;
-	}
-	// When content mode is off, just set the query for client-side title filtering
-	if (!state.searchContentMode) {
-		state.searchResults = null;
-		state.searchLoading = false;
-		renderApp();
-		return;
-	}
-	// Content mode: use FTS API
-	state.searchLoading = true;
-	renderApp();
-	const data = await searchApi(query);
-	if (state.searchQuery !== query) return;
-	state.searchResults = data.results;
-	state.searchLoading = false;
 	renderApp();
 }
 
 function _handleMobileSearchClear(): void {
 	state.searchQuery = "";
-	state.searchResults = null;
-	state.searchLoading = false;
-	renderApp();
-}
-
-function _handleMobileResultClick(detail: { type: string; id: string; sessionId?: string; goalId?: string }): void {
-	state.searchQuery = "";
-	state.searchResults = null;
-	state.searchLoading = false;
-	if (detail.type === "goal" && detail.id) {
-		import("./routing.js").then(m => m.setHashRoute("goal-dashboard", detail.id, true));
-	} else if (detail.type === "session" && detail.id) {
-		import("./session-manager.js").then(m => m.connectToSession(detail.id, true));
-	} else if (detail.type === "message" && detail.sessionId) {
-		const sid = detail.sessionId;
-		import("./session-manager.js").then(m => m.connectToSession(sid, true));
-	}
 	renderApp();
 }
 
@@ -131,8 +93,8 @@ function renderMobileLanding() {
 	let { ungroupedSessions, liveGoals } = sidebarData;
 	const { archivedGoals } = sidebarData;
 
-	// Client-side title filtering for mobile (title-only mode)
-	if (state.searchQuery && !state.searchContentMode) {
+	// Client-side title filtering for mobile
+	if (state.searchQuery) {
 		const q = state.searchQuery.toLowerCase();
 		liveGoals = liveGoals.filter(goal => {
 			const goalMatches = goal.title.toLowerCase().includes(q);
@@ -194,26 +156,12 @@ function renderMobileLanding() {
 				${renderSetupBanner(true)}
 				<search-box
 					.query=${state.searchQuery}
-					.loading=${state.searchLoading}
-					.contentMode=${state.searchContentMode}
 					.showControls=${!!state.searchQuery}
 					@search-input=${(e: CustomEvent) => { _handleMobileSearchInput(e.detail.query); }}
 					@search-clear=${() => { _handleMobileSearchClear(); }}
-					@search-mode-change=${(e: CustomEvent) => {
-						setSearchContentMode(e.detail.contentSearch);
-						// Re-trigger search with new mode
-						if (state.searchQuery) _handleMobileSearchInput(state.searchQuery);
-					}}
 					@full-search-click=${(e: CustomEvent) => { setHashRoute("search", e.detail.query); }}
 				></search-box>
-				${state.searchQuery && state.searchContentMode ? html`
-					<search-results
-						.results=${state.searchResults || []}
-						.loading=${state.searchLoading}
-						.query=${state.searchQuery}
-						@result-click=${(e: CustomEvent) => { _handleMobileResultClick(e.detail); }}
-					></search-results>
-				` : state.sessionsLoading
+				${state.sessionsLoading
 					? html`<div class="text-center py-12 text-muted-foreground text-xs">Loading…</div>`
 					: state.sessionsError
 						? html`<div class="text-center py-12">

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -927,11 +927,11 @@ export function renderSidebar() {
 								filteredGoals = liveGoals.map(goal => {
 									const goalMatches = goal.title.toLowerCase().includes(q);
 									const goalSessions = state.gatewaySessions.filter(s => (s.goalId === goal.id || s.teamGoalId === goal.id) && !s.delegateOf);
-									const hasMatchingSession = goalSessions.some(s => s.title?.toLowerCase().includes(q));
+									const hasMatchingSession = goalSessions.some(s => s.title?.toLowerCase().includes(q) || s.role?.toLowerCase().includes(q));
 									if (!goalMatches && !hasMatchingSession) return null as unknown as Goal;
 									return goal;
 								}).filter(Boolean);
-								filteredUngrouped = ungroupedSessions.filter(s => s.title?.toLowerCase().includes(q));
+								filteredUngrouped = ungroupedSessions.filter(s => s.title?.toLowerCase().includes(q) || s.role?.toLowerCase().includes(q));
 								filteredStaff = filteredStaff.filter(s => s.name?.toLowerCase().includes(q));
 							}
 							// No longer need to filter out pending project sessions — they have real projectIds now
@@ -984,9 +984,9 @@ export function renderSidebar() {
 									filteredArchivedGoals = archivedGoals.filter(goal => {
 										if (goal.title.toLowerCase().includes(q)) return true;
 										const goalSessions = [...state.gatewaySessions, ...state.archivedSessions].filter(s => (s.goalId === goal.id || s.teamGoalId === goal.id) && !s.delegateOf);
-										return goalSessions.some(s => s.title?.toLowerCase().includes(q));
+										return goalSessions.some(s => s.title?.toLowerCase().includes(q) || s.role?.toLowerCase().includes(q));
 									});
-									filteredStandaloneArchived = allStandaloneArchived.filter(s => s.title?.toLowerCase().includes(q));
+									filteredStandaloneArchived = allStandaloneArchived.filter(s => s.title?.toLowerCase().includes(q) || s.role?.toLowerCase().includes(q));
 								}
 
 								const showArchivedContent = state.showArchived;

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -20,12 +20,11 @@ import {
 	getSidebarData,
 	type Goal,
 	type Project,
-	setSearchContentMode,
 } from "./state.js";
 import { createAndConnectSession, connectToSession } from "./session-manager.js";
 import { cwdCombobox } from "./cwd-combobox.js";
 import { showGoalDialog, showProjectDialog } from "./dialogs.js";
-import { refreshSessions, fetchRoles, fetchPersonalities, fetchStaff, wakeStaffAgent, fetchArchivedSessions, archivedSessionsLoaded, dismissSetup, gatewayFetch, fetchSandboxStatus, searchApi, fetchArchivedGoalsPaginated, fetchArchivedSessionsPaginated, type PersonalityData } from "./api.js";
+import { refreshSessions, fetchRoles, fetchPersonalities, fetchStaff, wakeStaffAgent, fetchArchivedSessions, archivedSessionsLoaded, dismissSetup, gatewayFetch, fetchSandboxStatus, fetchArchivedGoalsPaginated, fetchArchivedSessionsPaginated, type PersonalityData } from "./api.js";
 import { statusBobbit, sessionAcronym } from "./session-colors.js";
 import { renderGoalGroup, renderSessionRow, renderArchivedSessionRow, renderArchivedDelegates, SESSION_ROW_PY, INDENT, CHEVRON_W, HEADER_CHEVRON_W, terseRelativeTime, hasUnseenActivity, formatSessionAge, renderSessionTitle, getProjectAccentColor } from "./render-helpers.js";
 import type { GatewaySession } from "./state.js";
@@ -724,73 +723,21 @@ function _revertArchivedIfSearchOpened(): void {
 	}
 }
 
-async function _handleSearchInput(query: string): Promise<void> {
+function _handleSearchInput(query: string): void {
 	state.searchQuery = query;
 	if (!query.trim()) {
-		state.searchResults = null;
-		state.searchMatchIds = null;
-		state.searchLoading = false;
 		_revertArchivedIfSearchOpened();
 		renderApp();
 		return;
 	}
 	_ensureArchivedForSearch();
-	if (!state.searchContentMode) {
-		// Client-side title filter — no API call needed
-		state.searchLoading = false;
-		renderApp();
-		return;
-	}
-	// Content search mode — use FTS API
-	state.searchLoading = true;
-	renderApp();
-	const data = await searchApi(query);
-	// Guard against stale responses
-	if (state.searchQuery !== query) return;
-	state.searchResults = data.results;
-	// Build a Set of matching IDs for sidebar filtering
-	const ids = new Set<string>();
-	for (const r of data.results) {
-		if (r.type === "goal" && r.id) ids.add(r.id);
-		else if (r.type === "session" && r.id) ids.add(r.id);
-		else if (r.type === "staff" && r.id) ids.add(r.id);
-		else if (r.type === "message" && r.sessionId) {
-			ids.add(r.sessionId);
-			// Also include the parent goal so goal group is visible
-			// Check both live and archived sessions
-			const session = state.gatewaySessions.find(s => s.id === r.sessionId)
-				|| state.archivedSessions.find(s => s.id === r.sessionId);
-			if (session?.goalId) ids.add(session.goalId);
-			if (session?.teamGoalId) ids.add(session.teamGoalId);
-		}
-	}
-	state.searchMatchIds = ids;
-	state.searchLoading = false;
 	renderApp();
 }
 
 function _handleSearchClear(): void {
 	state.searchQuery = "";
-	state.searchResults = null;
-	state.searchMatchIds = null;
-	state.searchLoading = false;
 	_revertArchivedIfSearchOpened();
 	renderApp();
-}
-
-function _handleSearchModeChange(contentSearch: boolean): void {
-	setSearchContentMode(contentSearch);
-	// If switching modes with an active query, re-run the search
-	if (state.searchQuery) {
-		if (contentSearch) {
-			_handleSearchInput(state.searchQuery); // triggers API search
-		} else {
-			state.searchResults = null;
-			state.searchMatchIds = null;
-			state.searchLoading = false;
-			renderApp(); // will use client-side filter
-		}
-	}
 }
 
 function _handleFullSearchClick(query: string): void {
@@ -954,12 +901,9 @@ export function renderSidebar() {
 			${renderSetupBanner()}
 			<search-box
 				.query=${state.searchQuery}
-				.loading=${state.searchLoading}
-				.contentMode=${state.searchContentMode}
 				.showControls=${!!state.searchQuery}
 				@search-input=${(e: CustomEvent) => { _handleSearchInput(e.detail.query); }}
 				@search-clear=${() => { _handleSearchClear(); }}
-				@search-mode-change=${(e: CustomEvent) => { _handleSearchModeChange(e.detail.contentSearch); }}
 				@full-search-click=${(e: CustomEvent) => { _handleFullSearchClick(e.detail.query); }}
 			></search-box>
 			<div class="flex-1 overflow-y-auto flex flex-col gap-0.5 py-2 px-0.5">
@@ -979,30 +923,16 @@ export function renderSidebar() {
 
 							if (state.searchQuery) {
 								const q = state.searchQuery.toLowerCase();
-								if (!state.searchContentMode) {
-									// Client-side title filter
-									filteredGoals = liveGoals.map(goal => {
-										const goalMatches = goal.title.toLowerCase().includes(q);
-										const goalSessions = state.gatewaySessions.filter(s => (s.goalId === goal.id || s.teamGoalId === goal.id) && !s.delegateOf);
-										const hasMatchingSession = goalSessions.some(s => s.title?.toLowerCase().includes(q));
-										if (!goalMatches && !hasMatchingSession) return null as unknown as Goal;
-										return goal;
-									}).filter(Boolean);
-									filteredUngrouped = ungroupedSessions.filter(s => s.title?.toLowerCase().includes(q));
-									filteredStaff = filteredStaff.filter(s => s.name?.toLowerCase().includes(q));
-								} else if (state.searchMatchIds) {
-									// FTS content filter
-									const ids = state.searchMatchIds;
-									filteredGoals = liveGoals.map(goal => {
-										const goalMatches = ids.has(goal.id);
-										const goalSessions = state.gatewaySessions.filter(s => (s.goalId === goal.id || s.teamGoalId === goal.id) && !s.delegateOf);
-										const hasMatchingSession = goalSessions.some(s => ids.has(s.id));
-										if (!goalMatches && !hasMatchingSession) return null as unknown as Goal;
-										return goal;
-									}).filter(Boolean);
-									filteredUngrouped = ungroupedSessions.filter(s => ids.has(s.id));
-									filteredStaff = filteredStaff.filter(s => ids.has(s.id));
-								}
+								// Client-side title filter
+								filteredGoals = liveGoals.map(goal => {
+									const goalMatches = goal.title.toLowerCase().includes(q);
+									const goalSessions = state.gatewaySessions.filter(s => (s.goalId === goal.id || s.teamGoalId === goal.id) && !s.delegateOf);
+									const hasMatchingSession = goalSessions.some(s => s.title?.toLowerCase().includes(q));
+									if (!goalMatches && !hasMatchingSession) return null as unknown as Goal;
+									return goal;
+								}).filter(Boolean);
+								filteredUngrouped = ungroupedSessions.filter(s => s.title?.toLowerCase().includes(q));
+								filteredStaff = filteredStaff.filter(s => s.name?.toLowerCase().includes(q));
 							}
 							// No longer need to filter out pending project sessions — they have real projectIds now
 
@@ -1050,24 +980,13 @@ export function renderSidebar() {
 								let filteredStandaloneArchived = allStandaloneArchived;
 								if (state.searchQuery) {
 									const q = state.searchQuery.toLowerCase();
-									if (!state.searchContentMode) {
-										// Title filter
-										filteredArchivedGoals = archivedGoals.filter(goal => {
-											if (goal.title.toLowerCase().includes(q)) return true;
-											const goalSessions = [...state.gatewaySessions, ...state.archivedSessions].filter(s => (s.goalId === goal.id || s.teamGoalId === goal.id) && !s.delegateOf);
-											return goalSessions.some(s => s.title?.toLowerCase().includes(q));
-										});
-										filteredStandaloneArchived = allStandaloneArchived.filter(s => s.title?.toLowerCase().includes(q));
-									} else if (state.searchMatchIds) {
-										// FTS content filter
-										const ids = state.searchMatchIds;
-										filteredArchivedGoals = archivedGoals.filter(goal => {
-											if (ids.has(goal.id)) return true;
-											const goalSessions = [...state.gatewaySessions, ...state.archivedSessions].filter(s => (s.goalId === goal.id || s.teamGoalId === goal.id) && !s.delegateOf);
-											return goalSessions.some(s => ids.has(s.id));
-										});
-										filteredStandaloneArchived = allStandaloneArchived.filter(s => ids.has(s.id));
-									}
+									// Title filter
+									filteredArchivedGoals = archivedGoals.filter(goal => {
+										if (goal.title.toLowerCase().includes(q)) return true;
+										const goalSessions = [...state.gatewaySessions, ...state.archivedSessions].filter(s => (s.goalId === goal.id || s.teamGoalId === goal.id) && !s.delegateOf);
+										return goalSessions.some(s => s.title?.toLowerCase().includes(q));
+									});
+									filteredStandaloneArchived = allStandaloneArchived.filter(s => s.title?.toLowerCase().includes(q));
 								}
 
 								const showArchivedContent = state.showArchived;

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -166,10 +166,6 @@ export const state = {
 
 	// Search state
 	searchQuery: "",
-	searchResults: null as any[] | null,
-	searchLoading: false,
-	searchContentMode: localStorage.getItem("searchContentMode") === "true",
-	searchMatchIds: null as Set<string> | null,
 
 	// Pagination for archived items
 	archivedGoalsCursor: null as number | null,
@@ -464,15 +460,6 @@ export function setProjects(projects: Project[]): void {
 	if (!state.activeProjectId || !projects.some(p => p.id === state.activeProjectId)) {
 		state.activeProjectId = projects[0]?.id ?? null;
 	}
-}
-
-// ============================================================================
-// SEARCH CONTENT MODE
-// ============================================================================
-
-export function setSearchContentMode(val: boolean): void {
-	state.searchContentMode = val;
-	localStorage.setItem("searchContentMode", String(val));
 }
 
 // ============================================================================

--- a/src/server/search/search-index.ts
+++ b/src/server/search/search-index.ts
@@ -663,18 +663,16 @@ function sanitiseFtsQuery(raw: string): string {
 	const cleaned = raw.replace(/["\u201C\u201D]/g, " ").trim();
 	if (!cleaned) return "";
 
-	// Split into tokens and wrap each in double quotes
 	const tokens = cleaned.split(/\s+/).filter(Boolean);
 	if (tokens.length === 0) return "";
 
-	// Last token gets prefix matching (unquoted with *) so partial words work
-	// e.g. "sandb" → matches "sandbox". Earlier tokens are exact-quoted.
-	// Strip FTS5 special chars from the prefix token since it's unquoted.
 	return tokens.map((t, i) => {
+		// Strip FTS5 operators from all tokens
+		const safe = t.replace(/[^a-zA-Z0-9_]/g, "");
+		if (!safe) return null; // skip empty tokens
 		if (i === tokens.length - 1) {
-			const safe = t.replace(/[^a-zA-Z0-9_]/g, "");
-			return safe ? `${safe}*` : `"${t}"`;
+			return `${safe}*`; // prefix match on last token
 		}
-		return `"${t}"`;
-	}).join(" ");
+		return `"${safe}"`; // exact match on earlier tokens
+	}).filter(Boolean).join(" ");
 }

--- a/src/ui/components/SearchBox.ts
+++ b/src/ui/components/SearchBox.ts
@@ -1,7 +1,7 @@
 import { LitElement, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { icon } from "@mariozechner/mini-lit";
-import { Search, X, Loader2 } from "lucide";
+import { Search, X } from "lucide";
 
 /**
  * Sidebar search input with debounced queries, keyboard shortcut (Ctrl+K / Cmd+K),
@@ -15,7 +15,7 @@ import { Search, X, Loader2 } from "lucide";
 export class SearchBox extends LitElement {
 	@property({ type: String }) query = "";
 	@property({ type: Boolean }) collapsed = false;
-	@property({ type: Boolean }) loading = false;
+
 	@property({ type: Boolean }) showControls = false;
 
 	@state() private _focused = false;
@@ -105,9 +105,7 @@ export class SearchBox extends LitElement {
 				<div class="relative pb-1">
 					<div class="relative flex items-center">
 						<span class="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none ${this._focused ? "text-foreground" : ""}">
-							${this.loading
-								? html`<span class="inline-block animate-spin">${icon(Loader2, "sm")}</span>`
-								: icon(Search, "sm")}
+							${icon(Search, "sm")}
 						</span>
 						<input
 							data-search

--- a/src/ui/components/SearchBox.ts
+++ b/src/ui/components/SearchBox.ts
@@ -16,7 +16,6 @@ export class SearchBox extends LitElement {
 	@property({ type: String }) query = "";
 	@property({ type: Boolean }) collapsed = false;
 	@property({ type: Boolean }) loading = false;
-	@property({ type: Boolean }) contentMode = false;
 	@property({ type: Boolean }) showControls = false;
 
 	@state() private _focused = false;
@@ -91,13 +90,6 @@ export class SearchBox extends LitElement {
 		this.dispatchEvent(new CustomEvent("search-clear", { bubbles: true, composed: true }));
 	}
 
-	private _toggleContentMode() {
-		this.dispatchEvent(new CustomEvent("search-mode-change", {
-			bubbles: true, composed: true,
-			detail: { contentSearch: !this.contentMode },
-		}));
-	}
-
 	private _fullSearch() {
 		this.dispatchEvent(new CustomEvent("full-search-click", {
 			bubbles: true, composed: true,
@@ -141,19 +133,7 @@ export class SearchBox extends LitElement {
 					</div>
 				</div>
 				<div class="overflow-hidden transition-all duration-200 ease-in-out" style="max-height: ${this.showControls ? "28px" : "0"}; opacity: ${this.showControls ? "1" : "0"}">
-					<div class="flex items-center justify-between px-2 py-0.5 text-[11px]">
-						<button
-							class="flex items-center gap-1.5 text-muted-foreground hover:text-foreground cursor-pointer select-none transition-colors"
-							@click=${this._toggleContentMode}
-							title="Search message content (slower)"
-						>
-							<span class="relative inline-flex items-center shrink-0 rounded-full transition-colors duration-200"
-								style="width:26px; height:14px; background: ${this.contentMode ? "var(--primary)" : "var(--muted)"};">
-								<span class="inline-block rounded-full bg-white shadow transition-transform duration-200"
-									style="width:10px; height:10px; margin:2px; transform: translateX(${this.contentMode ? "12px" : "0"});"></span>
-							</span>
-							<span>Content</span>
-						</button>
+					<div class="flex items-center justify-end px-2 py-0.5 text-[11px]">
 						<button class="text-primary hover:text-primary/80 hover:underline transition-colors" @click=${this._fullSearch}>
 							Full Search
 						</button>

--- a/tests/e2e/ui/search-e2e.spec.ts
+++ b/tests/e2e/ui/search-e2e.spec.ts
@@ -1,0 +1,211 @@
+/**
+ * Search E2E tests — SR-01, SR-02, SR-05, SR-07.
+ *
+ * Tests sidebar filter mode (client-side title matching), full search
+ * page navigation, Ctrl+K keyboard shortcut, and archived auto-open/close.
+ */
+import { test, expect } from "../gateway-harness.js";
+import { createSession, deleteSession, createGoal, deleteGoal, apiFetch, waitForSessionStatus } from "../e2e-setup.js";
+import { openApp } from "./ui-helpers.js";
+
+test.describe("Search (UI)", () => {
+	/**
+	 * SR-01: Sidebar filter mode — typing in the sidebar search input
+	 * instantly filters visible items by title (client-side).
+	 */
+	test("SR-01: sidebar filter hides non-matching sessions", async ({ page }) => {
+		// Create two sessions with distinct titles via API
+		const id1 = await createSession();
+		const id2 = await createSession();
+		await waitForSessionStatus(id1, "idle");
+		await waitForSessionStatus(id2, "idle");
+
+		// Rename sessions so they have known, distinguishable titles
+		await apiFetch(`/api/sessions/${id1}`, {
+			method: "PATCH",
+			body: JSON.stringify({ title: "AlphaSearchTarget" }),
+		});
+		await apiFetch(`/api/sessions/${id2}`, {
+			method: "PATCH",
+			body: JSON.stringify({ title: "BetaOtherItem" }),
+		});
+
+		await openApp(page);
+
+		// Both sessions should be visible
+		await expect(page.getByText("AlphaSearchTarget")).toBeVisible({ timeout: 10_000 });
+		await expect(page.getByText("BetaOtherItem")).toBeVisible({ timeout: 10_000 });
+
+		// Type a query that matches only the first session
+		const searchInput = page.locator("input[data-search]");
+		await searchInput.fill("AlphaSearch");
+
+		// Wait for debounce (200ms) + render — matching item visible, other hidden
+		await expect(page.getByText("AlphaSearchTarget")).toBeVisible({ timeout: 5_000 });
+		await expect(page.getByText("BetaOtherItem")).not.toBeVisible({ timeout: 5_000 });
+
+		// Type a query that matches only the second session
+		await searchInput.fill("BetaOther");
+		await expect(page.getByText("BetaOtherItem")).toBeVisible({ timeout: 5_000 });
+		await expect(page.getByText("AlphaSearchTarget")).not.toBeVisible({ timeout: 5_000 });
+
+		// Clear the search — both should reappear
+		await searchInput.fill("");
+		await expect(page.getByText("AlphaSearchTarget")).toBeVisible({ timeout: 5_000 });
+		await expect(page.getByText("BetaOtherItem")).toBeVisible({ timeout: 5_000 });
+
+		// Cleanup
+		await deleteSession(id1);
+		await deleteSession(id2);
+	});
+
+	/**
+	 * SR-01 continued: sidebar filter also works for goal titles.
+	 */
+	test("SR-01: sidebar filter matches goal titles", async ({ page }) => {
+		const goal = await createGoal({ title: "UniqueGoalXYZ123" });
+
+		await openApp(page);
+
+		// Goal should be visible in sidebar (goal titles render as uppercase via CSS)
+		await expect(page.getByText("UniqueGoalXYZ123", { exact: false })).toBeVisible({ timeout: 10_000 });
+
+		// Search for the goal
+		const searchInput = page.locator("input[data-search]");
+		await searchInput.fill("UniqueGoalXYZ");
+		await expect(page.getByText("UniqueGoalXYZ123", { exact: false })).toBeVisible({ timeout: 5_000 });
+
+		// Search for something else — goal should disappear
+		await searchInput.fill("NoMatchZZZ999");
+		await expect(page.getByText("UniqueGoalXYZ123", { exact: false })).not.toBeVisible({ timeout: 5_000 });
+
+		// Clear — goal reappears
+		await searchInput.fill("");
+		await expect(page.getByText("UniqueGoalXYZ123", { exact: false })).toBeVisible({ timeout: 5_000 });
+
+		await deleteGoal(goal.id);
+	});
+
+	/**
+	 * SR-02: Full search navigation — clicking "Full Search" link navigates
+	 * to #/search?q=<query> with the query pre-filled.
+	 */
+	test("SR-02: Full Search link navigates to search page", async ({ page }) => {
+		await openApp(page);
+
+		// Type a query in sidebar search
+		const searchInput = page.locator("input[data-search]");
+		await searchInput.fill("testquery");
+
+		// Wait for the Full Search link to appear (it shows when query is non-empty)
+		const fullSearchLink = page.getByText("Full Search");
+		await expect(fullSearchLink).toBeVisible({ timeout: 5_000 });
+
+		// Click the Full Search link
+		await fullSearchLink.click();
+
+		// Verify URL contains #/search with the query
+		await expect(async () => {
+			const hash = await page.evaluate(() => window.location.hash);
+			expect(hash).toContain("#/search");
+			expect(hash).toContain("testquery");
+		}).toPass({ timeout: 5_000 });
+
+		// Verify the search page rendered — look for the back arrow or search input
+		// The search page has its own input and result area
+		await expect(page.locator("input").last()).toBeVisible({ timeout: 5_000 });
+	});
+
+	/**
+	 * SR-05: Keyboard shortcut — Ctrl+K focuses the sidebar search input,
+	 * Escape clears and blurs it.
+	 */
+	test("SR-05: Ctrl+K focuses search, Escape clears", async ({ page }) => {
+		await openApp(page);
+
+		const searchInput = page.locator("input[data-search]");
+
+		// Verify search input exists
+		await expect(searchInput).toBeVisible({ timeout: 10_000 });
+
+		// Press Ctrl+K to focus the search input
+		await page.keyboard.press("Control+k");
+
+		// Verify the input is focused
+		await expect(searchInput).toBeFocused({ timeout: 3_000 });
+
+		// Type something
+		await searchInput.fill("hello");
+		await expect(searchInput).toHaveValue("hello");
+
+		// Press Escape to clear and blur
+		await page.keyboard.press("Escape");
+
+		// Verify input is cleared
+		await expect(searchInput).toHaveValue("", { timeout: 3_000 });
+
+		// Verify input is blurred (not focused)
+		await expect(searchInput).not.toBeFocused({ timeout: 3_000 });
+	});
+
+	/**
+	 * SR-07: Archived auto-open/close — when searching, the archived section
+	 * auto-opens to include archived items in the filter. When search is cleared,
+	 * it auto-closes if it was opened by search (not manually).
+	 *
+	 * This test creates and terminates a session (which archives it), then
+	 * searches for its title to trigger archived auto-open.
+	 */
+	test("SR-07: archived section auto-opens on search match", async ({ page }) => {
+		// Create a session with a unique title, then terminate it to archive
+		const id = await createSession();
+		await waitForSessionStatus(id, "idle");
+		await apiFetch(`/api/sessions/${id}`, {
+			method: "PATCH",
+			body: JSON.stringify({ title: "ArchivedSearchTest999" }),
+		});
+		// Terminate (archives the session)
+		await deleteSession(id);
+
+		await openApp(page);
+
+		// The "Archived" header should be visible (always rendered)
+		await expect(page.getByText(/Archived/i).first()).toBeVisible({ timeout: 10_000 });
+
+		// The archived session should NOT be visible yet (section collapsed by default)
+		await expect(page.getByText("ArchivedSearchTest999")).not.toBeVisible({ timeout: 3_000 });
+
+		// Search for the archived session's title
+		const searchInput = page.locator("input[data-search]");
+		await searchInput.fill("ArchivedSearchTest999");
+
+		// The archived section should auto-open and show the item
+		await expect(page.getByText("ArchivedSearchTest999")).toBeVisible({ timeout: 15_000 });
+
+		// Clear the search — archived section should auto-close
+		await searchInput.fill("");
+
+		// The archived session should disappear (section auto-closed by search)
+		await expect(page.getByText("ArchivedSearchTest999")).not.toBeVisible({ timeout: 5_000 });
+	});
+
+	/**
+	 * Verify no Content toggle exists in sidebar search.
+	 * The old "Content" toggle should have been removed.
+	 */
+	test("no Content toggle in sidebar search", async ({ page }) => {
+		await openApp(page);
+
+		const searchInput = page.locator("input[data-search]");
+		await searchInput.fill("test");
+
+		// Wait for controls to render
+		await expect(page.getByText("Full Search")).toBeVisible({ timeout: 5_000 });
+
+		// The "Content" toggle should NOT exist in the search controls area
+		// (search-box is the parent of the search input)
+		const searchBox = page.locator("search-box");
+		const contentToggle = searchBox.getByText("Content");
+		await expect(contentToggle).not.toBeVisible({ timeout: 2_000 });
+	});
+});

--- a/tests/fixtures/search-box-fixture.html
+++ b/tests/fixtures/search-box-fixture.html
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>SearchBox &amp; SearchResults Test Fixture</title>
+<style>
+  body { font-family: sans-serif; margin: 20px; background: #1a1a2e; color: #eee; }
+  :root {
+    --foreground: #fafafa;
+    --muted-foreground: #a1a1aa;
+    --primary: #3b82f6;
+    --accent: #27272a;
+    --input: #333;
+    --ring: #3b82f6;
+  }
+  .hidden { display: none; }
+</style>
+</head>
+<body>
+
+<!-- ===== SearchBox replica ===== -->
+<div id="search-box-wrapper">
+  <div id="search-box-root">
+    <div class="relative pb-1">
+      <div class="relative flex items-center">
+        <span id="search-icon" class="search-icon"></span>
+        <input
+          data-search
+          id="search-input"
+          type="text"
+          placeholder="Search… (Ctrl+K)"
+        />
+        <button id="clear-btn" class="hidden" aria-label="Clear search">✕</button>
+      </div>
+    </div>
+    <div id="controls-row" style="max-height: 0; opacity: 0; overflow: hidden;">
+      <div style="display: flex; align-items: center; justify-content: flex-end; padding: 2px 8px;">
+        <button id="full-search-btn">Full Search</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ===== SearchResults replica ===== -->
+<div id="search-results-root"></div>
+
+<script>
+/**
+ * SearchBox: Replicates search-box component behavior.
+ *
+ * - Ctrl+K focuses input
+ * - Typing fires search-input event after 200ms debounce
+ * - Escape clears and blurs
+ * - Clear button fires search-clear event
+ * - Full Search link fires full-search-click event
+ * - Controls row visible only when query is non-empty
+ * - No Content toggle (removed per design)
+ */
+
+let _query = "";
+let _debounceTimer = null;
+const _events = [];  // captured events: { type, detail, time }
+
+const searchInput = document.getElementById("search-input");
+const clearBtn = document.getElementById("clear-btn");
+const fullSearchBtn = document.getElementById("full-search-btn");
+const controlsRow = document.getElementById("controls-row");
+
+function _updateUI() {
+  // Clear button visibility
+  if (_query) {
+    clearBtn.classList.remove("hidden");
+  } else {
+    clearBtn.classList.add("hidden");
+  }
+  // Controls row (Full Search link) — visible when query non-empty
+  if (_query) {
+    controlsRow.style.maxHeight = "28px";
+    controlsRow.style.opacity = "1";
+  } else {
+    controlsRow.style.maxHeight = "0";
+    controlsRow.style.opacity = "0";
+  }
+}
+
+function _fireEvent(type, detail) {
+  const evt = new CustomEvent(type, { bubbles: true, composed: true, detail });
+  _events.push({ type, detail, time: Date.now() });
+  document.dispatchEvent(evt);
+}
+
+// Input handler with 200ms debounce
+searchInput.addEventListener("input", (e) => {
+  _query = e.target.value;
+  _updateUI();
+  if (_debounceTimer) clearTimeout(_debounceTimer);
+  _debounceTimer = setTimeout(() => {
+    _debounceTimer = null;
+    _fireEvent("search-input", { query: _query });
+  }, 200);
+});
+
+// Keydown on input: Escape clears + blurs
+searchInput.addEventListener("keydown", (e) => {
+  if (e.key === "Escape") {
+    e.preventDefault();
+    _query = "";
+    searchInput.value = "";
+    _updateUI();
+    if (_debounceTimer) { clearTimeout(_debounceTimer); _debounceTimer = null; }
+    _fireEvent("search-clear", {});
+    searchInput.blur();
+  }
+});
+
+// Global Ctrl+K focuses input
+document.addEventListener("keydown", (e) => {
+  if (e.key === "k" && (e.ctrlKey || e.metaKey)) {
+    e.preventDefault();
+    searchInput.focus();
+  }
+});
+
+// Clear button
+clearBtn.addEventListener("click", () => {
+  _query = "";
+  searchInput.value = "";
+  _updateUI();
+  if (_debounceTimer) { clearTimeout(_debounceTimer); _debounceTimer = null; }
+  _fireEvent("search-clear", {});
+});
+
+// Full Search link
+fullSearchBtn.addEventListener("click", () => {
+  _fireEvent("full-search-click", { query: _query });
+});
+
+_updateUI();
+
+// ===== SearchResults replica =====
+
+const resultsRoot = document.getElementById("search-results-root");
+let _resultsData = { results: [], loading: false, query: "" };
+
+function _renderResults() {
+  const { results, loading, query } = _resultsData;
+  resultsRoot.innerHTML = "";
+
+  // Loading state (no results yet)
+  if (loading && results.length === 0) {
+    resultsRoot.innerHTML = '<div class="search-loading" data-testid="loading">Searching…</div>';
+    return;
+  }
+
+  // Empty state
+  if (!loading && query && results.length === 0) {
+    resultsRoot.innerHTML = `<div class="search-empty" data-testid="empty">No matches for "${query}"</div>`;
+    return;
+  }
+
+  // No query
+  if (!query) return;
+
+  // Group by type
+  const groups = {};
+  for (const r of results) {
+    const key = r.type === "goal" ? "Goals" : r.type === "session" ? "Sessions" : r.type === "message" ? "Messages" : "Other";
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(r);
+  }
+
+  // Loading overlay when updating
+  if (loading) {
+    const updEl = document.createElement("div");
+    updEl.className = "search-updating";
+    updEl.dataset.testid = "updating";
+    updEl.textContent = "Updating…";
+    resultsRoot.appendChild(updEl);
+  }
+
+  for (const [label, items] of Object.entries(groups)) {
+    const groupEl = document.createElement("div");
+    groupEl.className = "result-group";
+    groupEl.dataset.group = label;
+
+    const header = document.createElement("div");
+    header.className = "group-header";
+    header.textContent = label;
+    groupEl.appendChild(header);
+
+    for (const item of items) {
+      const btn = document.createElement("button");
+      btn.className = "result-item";
+      btn.dataset.type = item.type;
+      btn.dataset.id = item.id;
+      btn.textContent = item.title || "Untitled";
+
+      if (item.snippet) {
+        const snip = document.createElement("div");
+        snip.className = "result-snippet";
+        snip.innerHTML = _sanitizeSnippet(item.snippet);
+        btn.appendChild(snip);
+      }
+
+      btn.addEventListener("click", () => {
+        _fireEvent("result-click", {
+          type: item.type,
+          id: item.id,
+          sessionId: item.sessionId,
+          goalId: item.goalId,
+        });
+      });
+
+      groupEl.appendChild(btn);
+    }
+
+    resultsRoot.appendChild(groupEl);
+  }
+}
+
+function _sanitizeSnippet(raw) {
+  return raw
+    .replace(/<b>/gi, "\x00B")
+    .replace(/<\/b>/gi, "\x00E")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\x00B/g, "<b>")
+    .replace(/\x00E/g, "</b>");
+}
+
+// ===== Public API for tests =====
+
+window.getQuery = () => _query;
+window.setQuery = (q) => { _query = q; searchInput.value = q; _updateUI(); };
+window.getEvents = () => [..._events];
+window.clearEvents = () => { _events.length = 0; };
+window.getActiveElement = () => document.activeElement?.id || document.activeElement?.tagName;
+window.isControlsRowVisible = () => controlsRow.style.opacity === "1";
+
+// SearchResults API
+window.setResultsState = (state) => { _resultsData = { ..._resultsData, ...state }; _renderResults(); };
+window.getResultsHTML = () => resultsRoot.innerHTML;
+
+window._testReady = true;
+</script>
+</body>
+</html>

--- a/tests/search-box.spec.ts
+++ b/tests/search-box.spec.ts
@@ -1,0 +1,220 @@
+/**
+ * Unit fixture tests for <search-box> component behavior.
+ *
+ * Tests: Ctrl+K focus, debounced search-input event, Escape clear+blur,
+ * clear button, Full Search link, controls row visibility, no Content toggle.
+ */
+import { test, expect } from "@playwright/test";
+import path from "node:path";
+
+const FIXTURE = `file://${path.resolve("tests/fixtures/search-box-fixture.html").replace(/\\/g, "/")}`;
+
+test.describe("SearchBox: keyboard shortcut", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(FIXTURE);
+		await page.waitForFunction(() => (window as any)._testReady === true);
+	});
+
+	test("Ctrl+K focuses the search input", async ({ page }) => {
+		// Ensure input is not focused initially
+		const before = await page.evaluate(() => (window as any).getActiveElement());
+		expect(before).not.toBe("search-input");
+
+		await page.keyboard.press("Control+k");
+
+		const after = await page.evaluate(() => (window as any).getActiveElement());
+		expect(after).toBe("search-input");
+	});
+});
+
+test.describe("SearchBox: debounced input", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(FIXTURE);
+		await page.waitForFunction(() => (window as any)._testReady === true);
+	});
+
+	test("typing fires search-input event after ~200ms debounce", async ({ page }) => {
+		await page.click("#search-input");
+		await page.evaluate(() => (window as any).clearEvents());
+
+		await page.type("#search-input", "hello");
+
+		// Immediately after typing, no event yet
+		const eventsImmediate = await page.evaluate(() =>
+			(window as any).getEvents().filter((e: any) => e.type === "search-input")
+		);
+		expect(eventsImmediate).toHaveLength(0);
+
+		// Wait for debounce (200ms + buffer)
+		await page.waitForTimeout(350);
+
+		const events = await page.evaluate(() =>
+			(window as any).getEvents().filter((e: any) => e.type === "search-input")
+		);
+		expect(events).toHaveLength(1);
+		expect(events[0].detail.query).toBe("hello");
+	});
+
+	test("rapid typing only fires one debounced event", async ({ page }) => {
+		await page.click("#search-input");
+		await page.evaluate(() => (window as any).clearEvents());
+
+		// Type characters with small delays (within debounce window)
+		await page.type("#search-input", "a", { delay: 30 });
+		await page.type("#search-input", "b", { delay: 30 });
+		await page.type("#search-input", "c", { delay: 30 });
+
+		await page.waitForTimeout(350);
+
+		const events = await page.evaluate(() =>
+			(window as any).getEvents().filter((e: any) => e.type === "search-input")
+		);
+		expect(events).toHaveLength(1);
+		expect(events[0].detail.query).toBe("abc");
+	});
+});
+
+test.describe("SearchBox: Escape key", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(FIXTURE);
+		await page.waitForFunction(() => (window as any)._testReady === true);
+	});
+
+	test("Escape clears query and blurs input", async ({ page }) => {
+		// Type something first
+		await page.click("#search-input");
+		await page.type("#search-input", "test query");
+		await page.waitForTimeout(50);
+
+		expect(await page.evaluate(() => (window as any).getQuery())).toBe("test query");
+
+		await page.evaluate(() => (window as any).clearEvents());
+		await page.keyboard.press("Escape");
+
+		// Query should be cleared
+		expect(await page.evaluate(() => (window as any).getQuery())).toBe("");
+
+		// Input value should be empty
+		const val = await page.inputValue("#search-input");
+		expect(val).toBe("");
+
+		// Input should be blurred
+		const active = await page.evaluate(() => (window as any).getActiveElement());
+		expect(active).not.toBe("search-input");
+
+		// search-clear event should have fired
+		const events = await page.evaluate(() =>
+			(window as any).getEvents().filter((e: any) => e.type === "search-clear")
+		);
+		expect(events).toHaveLength(1);
+	});
+});
+
+test.describe("SearchBox: clear button", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(FIXTURE);
+		await page.waitForFunction(() => (window as any)._testReady === true);
+	});
+
+	test("clear button hidden when query is empty", async ({ page }) => {
+		const hidden = await page.locator("#clear-btn").evaluate(
+			(el) => el.classList.contains("hidden")
+		);
+		expect(hidden).toBe(true);
+	});
+
+	test("clear button visible when query is non-empty", async ({ page }) => {
+		await page.click("#search-input");
+		await page.type("#search-input", "foo");
+
+		const hidden = await page.locator("#clear-btn").evaluate(
+			(el) => el.classList.contains("hidden")
+		);
+		expect(hidden).toBe(false);
+	});
+
+	test("clicking clear button fires search-clear and resets query", async ({ page }) => {
+		await page.click("#search-input");
+		await page.type("#search-input", "something");
+		await page.evaluate(() => (window as any).clearEvents());
+
+		await page.click("#clear-btn");
+
+		expect(await page.evaluate(() => (window as any).getQuery())).toBe("");
+		expect(await page.inputValue("#search-input")).toBe("");
+
+		const events = await page.evaluate(() =>
+			(window as any).getEvents().filter((e: any) => e.type === "search-clear")
+		);
+		expect(events).toHaveLength(1);
+	});
+});
+
+test.describe("SearchBox: Full Search link", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(FIXTURE);
+		await page.waitForFunction(() => (window as any)._testReady === true);
+	});
+
+	test("Full Search click fires full-search-click event with query", async ({ page }) => {
+		await page.evaluate(() => (window as any).setQuery("my search"));
+		await page.evaluate(() => (window as any).clearEvents());
+
+		await page.click("#full-search-btn");
+
+		const events = await page.evaluate(() =>
+			(window as any).getEvents().filter((e: any) => e.type === "full-search-click")
+		);
+		expect(events).toHaveLength(1);
+		expect(events[0].detail.query).toBe("my search");
+	});
+});
+
+test.describe("SearchBox: controls row visibility", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(FIXTURE);
+		await page.waitForFunction(() => (window as any)._testReady === true);
+	});
+
+	test("controls row hidden when query is empty", async ({ page }) => {
+		const visible = await page.evaluate(() => (window as any).isControlsRowVisible());
+		expect(visible).toBe(false);
+	});
+
+	test("controls row visible when query is non-empty", async ({ page }) => {
+		await page.click("#search-input");
+		await page.type("#search-input", "hello");
+
+		const visible = await page.evaluate(() => (window as any).isControlsRowVisible());
+		expect(visible).toBe(true);
+	});
+
+	test("controls row hides again when query is cleared", async ({ page }) => {
+		await page.click("#search-input");
+		await page.type("#search-input", "test");
+		expect(await page.evaluate(() => (window as any).isControlsRowVisible())).toBe(true);
+
+		await page.click("#clear-btn");
+		expect(await page.evaluate(() => (window as any).isControlsRowVisible())).toBe(false);
+	});
+});
+
+test.describe("SearchBox: Content toggle removed", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(FIXTURE);
+		await page.waitForFunction(() => (window as any)._testReady === true);
+	});
+
+	test("no Content toggle exists in the component", async ({ page }) => {
+		// There should be no element with text "Content" acting as a toggle
+		const contentToggle = await page.locator('[data-testid="content-toggle"]').count();
+		expect(contentToggle).toBe(0);
+
+		// No toggle switch or checkbox labeled "Content"
+		const toggleButtons = await page.evaluate(() => {
+			const buttons = Array.from(document.querySelectorAll("button, input[type=checkbox]"));
+			return buttons.filter(b => b.textContent?.includes("Content")).length;
+		});
+		expect(toggleButtons).toBe(0);
+	});
+});

--- a/tests/search-index.spec.ts
+++ b/tests/search-index.spec.ts
@@ -1,0 +1,386 @@
+import { test, expect } from "@playwright/test";
+import path from "node:path";
+import os from "node:os";
+import fs from "node:fs";
+import crypto from "node:crypto";
+import { SearchIndex } from "../dist/server/search/search-index.js";
+
+/**
+ * Unit tests for SearchIndex — FTS5 search index lifecycle,
+ * indexing roundtrips, removal, type filtering, special characters,
+ * and edge cases.
+ *
+ * Run with:
+ *   npx playwright test tests/search-index.spec.ts --config tests/playwright.config.ts
+ */
+
+function makeTempDbPath(): string {
+	return path.join(os.tmpdir(), `bobbit-search-test-${crypto.randomUUID()}.db`);
+}
+
+function cleanupDb(dbPath: string): void {
+	for (const suffix of ["", "-wal", "-shm"]) {
+		try {
+			fs.unlinkSync(dbPath + suffix);
+		} catch {
+			// ignore
+		}
+	}
+}
+
+// ── Lifecycle ──────────────────────────────────────────────────────
+
+test("needsRebuild() returns true on fresh DB", () => {
+	const dbPath = makeTempDbPath();
+	const index = new SearchIndex(dbPath);
+	try {
+		index.open();
+		expect(index.needsRebuild()).toBe(true);
+	} finally {
+		index.close();
+		cleanupDb(dbPath);
+	}
+});
+
+test("needsRebuild() returns false after reopen (schema exists)", () => {
+	const dbPath = makeTempDbPath();
+	const index = new SearchIndex(dbPath);
+	try {
+		index.open();
+		index.close();
+
+		// Reopen — schema already created with correct version
+		const index2 = new SearchIndex(dbPath);
+		index2.open();
+		expect(index2.needsRebuild()).toBe(false);
+		index2.close();
+	} finally {
+		cleanupDb(dbPath);
+	}
+});
+
+// ── Goal indexing roundtrip ────────────────────────────────────────
+
+test("indexGoal + search returns the goal", () => {
+	const dbPath = makeTempDbPath();
+	const index = new SearchIndex(dbPath);
+	try {
+		index.open();
+		index.indexGoal({
+			id: "g1",
+			title: "Deploy Pipeline",
+			spec: "Deploy to production environment",
+			state: "active",
+			archived: false,
+			createdAt: Date.now(),
+		} as any);
+
+		const results = index.search("Deploy");
+		expect(results.results.length).toBeGreaterThan(0);
+		expect(results.results[0].type).toBe("goal");
+		expect(results.results[0].id).toBe("g1");
+		expect(results.results[0].title).toBe("Deploy Pipeline");
+	} finally {
+		index.close();
+		cleanupDb(dbPath);
+	}
+});
+
+// ── Session indexing roundtrip ─────────────────────────────────────
+
+test("indexSession + search returns the session", () => {
+	const dbPath = makeTempDbPath();
+	const index = new SearchIndex(dbPath);
+	try {
+		index.open();
+		index.indexSession(
+			{
+				id: "s1",
+				title: "Debugging WebSocket",
+				role: "coder",
+				goalId: "",
+				archived: false,
+				createdAt: Date.now(),
+			} as any,
+			"",
+			"",
+		);
+
+		const results = index.search("WebSocket");
+		expect(results.results.length).toBeGreaterThan(0);
+		expect(results.results[0].type).toBe("session");
+		expect(results.results[0].id).toBe("s1");
+	} finally {
+		index.close();
+		cleanupDb(dbPath);
+	}
+});
+
+// ── Message indexing roundtrip ─────────────────────────────────────
+
+test("indexMessage + search returns the message", () => {
+	const dbPath = makeTempDbPath();
+	const index = new SearchIndex(dbPath);
+	try {
+		index.open();
+		index.indexMessage("s1", "My Session", "refactored the authentication middleware", ["bash"], Date.now());
+
+		const results = index.search("authentication");
+		expect(results.results.length).toBeGreaterThan(0);
+		expect(results.results[0].type).toBe("message");
+		expect(results.results[0].sessionId).toBe("s1");
+	} finally {
+		index.close();
+		cleanupDb(dbPath);
+	}
+});
+
+// ── Staff indexing roundtrip ───────────────────────────────────────
+
+test("indexStaff + search returns the staff", () => {
+	const dbPath = makeTempDbPath();
+	const index = new SearchIndex(dbPath);
+	try {
+		index.open();
+		index.indexStaff({
+			id: "st1",
+			name: "CodeReviewer",
+			description: "Reviews pull requests and suggests improvements",
+			state: "active",
+			createdAt: Date.now(),
+		} as any);
+
+		const results = index.search("CodeReviewer");
+		expect(results.results.length).toBeGreaterThan(0);
+		expect(results.results[0].type).toBe("staff");
+		expect(results.results[0].id).toBe("st1");
+	} finally {
+		index.close();
+		cleanupDb(dbPath);
+	}
+});
+
+// ── Remove goal ────────────────────────────────────────────────────
+
+test("removeGoal removes the goal from results", () => {
+	const dbPath = makeTempDbPath();
+	const index = new SearchIndex(dbPath);
+	try {
+		index.open();
+		index.indexGoal({
+			id: "g1",
+			title: "Ephemeral Goal",
+			spec: "Will be removed",
+			state: "active",
+			archived: false,
+			createdAt: Date.now(),
+		} as any);
+
+		// Verify it's indexed
+		let results = index.search("Ephemeral");
+		expect(results.results.length).toBe(1);
+
+		// Remove and verify it's gone
+		index.removeGoal("g1");
+		results = index.search("Ephemeral");
+		expect(results.results.length).toBe(0);
+	} finally {
+		index.close();
+		cleanupDb(dbPath);
+	}
+});
+
+// ── Type filtering ─────────────────────────────────────────────────
+
+test("type filter returns only matching type", () => {
+	const dbPath = makeTempDbPath();
+	const index = new SearchIndex(dbPath);
+	try {
+		index.open();
+		index.indexGoal({
+			id: "g1",
+			title: "Terraform Module",
+			spec: "Infrastructure as code",
+			state: "active",
+			archived: false,
+			createdAt: Date.now(),
+		} as any);
+		index.indexSession(
+			{
+				id: "s1",
+				title: "Terraform Discussion",
+				role: "coder",
+				goalId: "",
+				archived: false,
+				createdAt: Date.now(),
+			} as any,
+			"",
+			"",
+		);
+
+		// Search all — both types present
+		const all = index.search("Terraform");
+		expect(all.results.length).toBe(2);
+
+		// Filter to goals only
+		const goalsOnly = index.search("Terraform", { type: "goals" });
+		expect(goalsOnly.results.length).toBe(1);
+		expect(goalsOnly.results[0].type).toBe("goal");
+
+		// Filter to sessions only
+		const sessionsOnly = index.search("Terraform", { type: "sessions" });
+		expect(sessionsOnly.results.length).toBe(1);
+		expect(sessionsOnly.results[0].type).toBe("session");
+	} finally {
+		index.close();
+		cleanupDb(dbPath);
+	}
+});
+
+// ── Special characters don't crash ─────────────────────────────────
+
+test.describe("special characters in queries do not throw", () => {
+	const queries = [
+		"deploy:prod",
+		"hello-world",
+		"path/to/file",
+		"foo(bar)",
+		"+debug -test",
+		"C:\\Users\\name",
+		"version=2.0",
+		"@mention #tag",
+		'he said "hello"',
+	];
+
+	for (const q of queries) {
+		test(`query: ${q}`, () => {
+			const dbPath = makeTempDbPath();
+			const index = new SearchIndex(dbPath);
+			try {
+				index.open();
+				// Should not throw
+				const results = index.search(q);
+				expect(results).toBeDefined();
+				expect(Array.isArray(results.results)).toBe(true);
+			} finally {
+				index.close();
+				cleanupDb(dbPath);
+			}
+		});
+	}
+});
+
+// ── Empty / whitespace queries ─────────────────────────────────────
+
+test("empty string returns empty results", () => {
+	const dbPath = makeTempDbPath();
+	const index = new SearchIndex(dbPath);
+	try {
+		index.open();
+		const results = index.search("");
+		expect(results.results.length).toBe(0);
+		expect(results.total).toBe(0);
+	} finally {
+		index.close();
+		cleanupDb(dbPath);
+	}
+});
+
+test("whitespace-only query returns empty results", () => {
+	const dbPath = makeTempDbPath();
+	const index = new SearchIndex(dbPath);
+	try {
+		index.open();
+		const results = index.search("   ");
+		expect(results.results.length).toBe(0);
+		expect(results.total).toBe(0);
+	} finally {
+		index.close();
+		cleanupDb(dbPath);
+	}
+});
+
+// ── All-special-chars query ────────────────────────────────────────
+
+test("all-special-chars query returns empty results", () => {
+	const dbPath = makeTempDbPath();
+	const index = new SearchIndex(dbPath);
+	try {
+		index.open();
+		const results = index.search("++--");
+		expect(results.results.length).toBe(0);
+		expect(results.total).toBe(0);
+	} finally {
+		index.close();
+		cleanupDb(dbPath);
+	}
+});
+
+// ── Prefix matching ───────────────────────────────────────────────
+
+test("prefix matching works (partial word)", () => {
+	const dbPath = makeTempDbPath();
+	const index = new SearchIndex(dbPath);
+	try {
+		index.open();
+		index.indexGoal({
+			id: "g1",
+			title: "Sandbox Configuration",
+			spec: "Configure the Docker sandbox",
+			state: "active",
+			archived: false,
+			createdAt: Date.now(),
+		} as any);
+
+		// "sand" should match "sandbox" via prefix
+		const results = index.search("sand");
+		expect(results.results.length).toBeGreaterThan(0);
+		expect(results.results[0].id).toBe("g1");
+	} finally {
+		index.close();
+		cleanupDb(dbPath);
+	}
+});
+
+// ── Long query ─────────────────────────────────────────────────────
+
+test("long query (500+ chars) does not crash", () => {
+	const dbPath = makeTempDbPath();
+	const index = new SearchIndex(dbPath);
+	try {
+		index.open();
+		const longQuery = "search ".repeat(100); // ~700 chars
+		const results = index.search(longQuery);
+		expect(results).toBeDefined();
+		expect(Array.isArray(results.results)).toBe(true);
+	} finally {
+		index.close();
+		cleanupDb(dbPath);
+	}
+});
+
+// ── Remove session messages ────────────────────────────────────────
+
+test("removeMessagesForSession removes all messages for that session", () => {
+	const dbPath = makeTempDbPath();
+	const index = new SearchIndex(dbPath);
+	try {
+		index.open();
+		index.indexMessage("s1", "Session A", "unique flamingo content", [], Date.now());
+		index.indexMessage("s1", "Session A", "another flamingo message", [], Date.now());
+		index.indexMessage("s2", "Session B", "flamingo in session B", [], Date.now());
+
+		// All three indexed
+		let results = index.search("flamingo");
+		expect(results.results.length).toBe(3);
+
+		// Remove s1 messages
+		index.removeMessagesForSession("s1");
+		results = index.search("flamingo");
+		expect(results.results.length).toBe(1);
+		expect(results.results[0].sessionId).toBe("s2");
+	} finally {
+		index.close();
+		cleanupDb(dbPath);
+	}
+});

--- a/tests/search-results.spec.ts
+++ b/tests/search-results.spec.ts
@@ -1,0 +1,250 @@
+/**
+ * Unit fixture tests for <search-results> component behavior.
+ *
+ * Tests: grouping by type, result-click event, empty state, loading state,
+ * no-query state, snippet sanitization.
+ */
+import { test, expect } from "@playwright/test";
+import path from "node:path";
+
+const FIXTURE = `file://${path.resolve("tests/fixtures/search-box-fixture.html").replace(/\\/g, "/")}`;
+
+const SAMPLE_RESULTS = [
+	{ type: "goal", id: "g1", title: "My Goal", snippet: "goal <b>match</b>", timestamp: Date.now(), archived: false },
+	{ type: "goal", id: "g2", title: "Another Goal", snippet: "second <b>goal</b>", timestamp: Date.now(), archived: true },
+	{ type: "session", id: "s1", title: "Chat Session", snippet: "session <b>result</b>", timestamp: Date.now(), archived: false, goalId: "g1" },
+	{ type: "message", id: "m1", title: "Message Hit", snippet: "message <b>text</b>", timestamp: Date.now(), archived: false, sessionId: "s1", goalId: "g1" },
+];
+
+test.describe("SearchResults: grouping", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(FIXTURE);
+		await page.waitForFunction(() => (window as any)._testReady === true);
+	});
+
+	test("groups results by type with correct headers", async ({ page }) => {
+		await page.evaluate((results) => {
+			(window as any).setResultsState({ results, loading: false, query: "match" });
+		}, SAMPLE_RESULTS);
+
+		// Check group headers
+		const headers = await page.$$eval(".group-header", (els: Element[]) =>
+			els.map(el => el.textContent)
+		);
+		expect(headers).toContain("Goals");
+		expect(headers).toContain("Sessions");
+		expect(headers).toContain("Messages");
+	});
+
+	test("goals group contains correct number of items", async ({ page }) => {
+		await page.evaluate((results) => {
+			(window as any).setResultsState({ results, loading: false, query: "match" });
+		}, SAMPLE_RESULTS);
+
+		const goalItems = await page.$$eval(
+			'[data-group="Goals"] .result-item',
+			(els: Element[]) => els.length
+		);
+		expect(goalItems).toBe(2);
+	});
+
+	test("sessions group contains correct number of items", async ({ page }) => {
+		await page.evaluate((results) => {
+			(window as any).setResultsState({ results, loading: false, query: "match" });
+		}, SAMPLE_RESULTS);
+
+		const sessionItems = await page.$$eval(
+			'[data-group="Sessions"] .result-item',
+			(els: Element[]) => els.length
+		);
+		expect(sessionItems).toBe(1);
+	});
+
+	test("messages group contains correct number of items", async ({ page }) => {
+		await page.evaluate((results) => {
+			(window as any).setResultsState({ results, loading: false, query: "match" });
+		}, SAMPLE_RESULTS);
+
+		const msgItems = await page.$$eval(
+			'[data-group="Messages"] .result-item',
+			(els: Element[]) => els.length
+		);
+		expect(msgItems).toBe(1);
+	});
+});
+
+test.describe("SearchResults: result-click event", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(FIXTURE);
+		await page.waitForFunction(() => (window as any)._testReady === true);
+	});
+
+	test("clicking a result fires result-click with correct detail", async ({ page }) => {
+		await page.evaluate((results) => {
+			(window as any).setResultsState({ results, loading: false, query: "match" });
+			(window as any).clearEvents();
+		}, SAMPLE_RESULTS);
+
+		// Click the first goal result
+		await page.click('[data-type="goal"][data-id="g1"]');
+
+		const events = await page.evaluate(() =>
+			(window as any).getEvents().filter((e: any) => e.type === "result-click")
+		);
+		expect(events).toHaveLength(1);
+		expect(events[0].detail).toEqual(
+			expect.objectContaining({ type: "goal", id: "g1" })
+		);
+	});
+
+	test("clicking a message result includes sessionId and goalId", async ({ page }) => {
+		await page.evaluate((results) => {
+			(window as any).setResultsState({ results, loading: false, query: "match" });
+			(window as any).clearEvents();
+		}, SAMPLE_RESULTS);
+
+		await page.click('[data-type="message"][data-id="m1"]');
+
+		const events = await page.evaluate(() =>
+			(window as any).getEvents().filter((e: any) => e.type === "result-click")
+		);
+		expect(events).toHaveLength(1);
+		expect(events[0].detail).toEqual(
+			expect.objectContaining({
+				type: "message",
+				id: "m1",
+				sessionId: "s1",
+				goalId: "g1",
+			})
+		);
+	});
+
+	test("clicking a session result includes goalId", async ({ page }) => {
+		await page.evaluate((results) => {
+			(window as any).setResultsState({ results, loading: false, query: "match" });
+			(window as any).clearEvents();
+		}, SAMPLE_RESULTS);
+
+		await page.click('[data-type="session"][data-id="s1"]');
+
+		const events = await page.evaluate(() =>
+			(window as any).getEvents().filter((e: any) => e.type === "result-click")
+		);
+		expect(events).toHaveLength(1);
+		expect(events[0].detail).toEqual(
+			expect.objectContaining({
+				type: "session",
+				id: "s1",
+				goalId: "g1",
+			})
+		);
+	});
+});
+
+test.describe("SearchResults: empty state", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(FIXTURE);
+		await page.waitForFunction(() => (window as any)._testReady === true);
+	});
+
+	test("shows 'No matches for ...' when query set but no results", async ({ page }) => {
+		await page.evaluate(() => {
+			(window as any).setResultsState({ results: [], loading: false, query: "nonexistent" });
+		});
+
+		const emptyEl = page.locator('[data-testid="empty"]');
+		await expect(emptyEl).toBeVisible();
+		await expect(emptyEl).toContainText('No matches for "nonexistent"');
+	});
+
+	test("no group headers present in empty state", async ({ page }) => {
+		await page.evaluate(() => {
+			(window as any).setResultsState({ results: [], loading: false, query: "nothing" });
+		});
+
+		const headers = await page.$$(".group-header");
+		expect(headers).toHaveLength(0);
+	});
+});
+
+test.describe("SearchResults: loading state", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(FIXTURE);
+		await page.waitForFunction(() => (window as any)._testReady === true);
+	});
+
+	test("shows 'Searching...' when loading with no results", async ({ page }) => {
+		await page.evaluate(() => {
+			(window as any).setResultsState({ results: [], loading: true, query: "test" });
+		});
+
+		const loadingEl = page.locator('[data-testid="loading"]');
+		await expect(loadingEl).toBeVisible();
+		await expect(loadingEl).toContainText("Searching");
+	});
+
+	test("shows 'Updating...' when loading with existing results", async ({ page }) => {
+		await page.evaluate((results) => {
+			(window as any).setResultsState({ results, loading: true, query: "match" });
+		}, SAMPLE_RESULTS);
+
+		const updatingEl = page.locator('[data-testid="updating"]');
+		await expect(updatingEl).toBeVisible();
+		await expect(updatingEl).toContainText("Updating");
+
+		// Results should still be visible alongside the updating indicator
+		const headers = await page.$$(".group-header");
+		expect(headers.length).toBeGreaterThan(0);
+	});
+});
+
+test.describe("SearchResults: no query state", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(FIXTURE);
+		await page.waitForFunction(() => (window as any)._testReady === true);
+	});
+
+	test("renders nothing when query is empty", async ({ page }) => {
+		await page.evaluate(() => {
+			(window as any).setResultsState({ results: [], loading: false, query: "" });
+		});
+
+		const html = await page.evaluate(() => (window as any).getResultsHTML());
+		expect(html).toBe("");
+	});
+});
+
+test.describe("SearchResults: snippet sanitization", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(FIXTURE);
+		await page.waitForFunction(() => (window as any)._testReady === true);
+	});
+
+	test("allows <b> tags for highlighting but escapes other HTML", async ({ page }) => {
+		const maliciousResults = [
+			{
+				type: "goal",
+				id: "xss1",
+				title: "XSS Test",
+				snippet: '<b>safe</b> <script>alert("xss")</script> <img onerror=alert(1)>',
+				timestamp: Date.now(),
+				archived: false,
+			},
+		];
+
+		await page.evaluate((results) => {
+			(window as any).setResultsState({ results, loading: false, query: "test" });
+		}, maliciousResults);
+
+		// Get the snippet HTML
+		const snippetHTML = await page.$eval(".result-snippet", (el: Element) => el.innerHTML);
+
+		// <b> tags should be preserved
+		expect(snippetHTML).toContain("<b>safe</b>");
+
+		// <script> and <img> should be escaped
+		expect(snippetHTML).not.toContain("<script>");
+		expect(snippetHTML).not.toContain("<img");
+		expect(snippetHTML).toContain("&lt;script&gt;");
+	});
+});

--- a/userstories/search.md
+++ b/userstories/search.md
@@ -7,6 +7,8 @@ Search has two modes:
 
 **Architecture:** Server-side SQLite FTS5 index (`search.db`) indexes goals (title + spec), sessions (title + role + goal title), messages (text content + tool names), and staff (name + description). Index is rebuilt from stores on startup if missing or schema-mismatched. Incremental indexing occurs as messages stream in.
 
+> **Note:** Gate content (e.g. design specs) is not currently indexed. This is a documented design decision deferred to a follow-up — see goal design doc for rationale.
+
 ---
 
 ## SR-01: Filter mode — sidebar filtering
@@ -39,7 +41,7 @@ Search has two modes:
    - Session opens. Search query remains in the input (not cleared on navigation).
    - Sidebar continues to show filtered results.
 
-**Coverage:** none
+**Coverage:** `tests/search-box.spec.ts` (Ctrl+K, debounce, escape, clear, controls visibility); `tests/e2e/ui/search-e2e.spec.ts` (sidebar filter mode — pending)
 
 ---
 
@@ -70,7 +72,7 @@ Search has two modes:
 7. Click a result.
    - Navigates to the corresponding session, goal, or staff item.
 
-**Coverage:** none
+**Coverage:** `tests/search-results.spec.ts` (result grouping, click navigation, empty state)
 
 ---
 
@@ -85,7 +87,7 @@ Search has two modes:
    - Each result shows its project name to disambiguate.
 3. If a project filter is applied (e.g. via `projectId` query param), only that project's results appear.
 
-**Coverage:** none
+**Coverage:** `tests/search-index.spec.ts` (projectId filtering)
 
 ---
 
@@ -111,7 +113,7 @@ Search has two modes:
    - Stale responses are discarded (guard: `state.searchQuery !== query`).
    - Only the final query's results display.
 
-**Coverage:** none
+**Coverage:** `tests/search-index.spec.ts` (special chars, empty/whitespace queries, long queries, prefix matching)
 
 ---
 
@@ -131,7 +133,7 @@ Search has two modes:
 5. While a dialog is open (e.g. settings), press Ctrl+K.
    - Keyboard shortcut is global (`document.addEventListener`). Should focus search or be suppressed if a dialog has focus.
 
-**Coverage:** none
+**Coverage:** `tests/search-box.spec.ts` (Ctrl+K focus, Escape clear+blur)
 
 ---
 
@@ -195,7 +197,7 @@ Search has two modes:
    - The index is rebuilt automatically from stores.
    - Search works again — all previously indexed content is available.
 
-**Coverage:** none
+**Coverage:** `tests/search-index.spec.ts` (indexing roundtrips: goal/session/message/staff, needsRebuild, removal)
 
 ---
 
@@ -211,7 +213,7 @@ Search has two modes:
    - No duplicate results or flickering.
 2. The final results correspond to the full query "deploy", not an intermediate one.
 
-**Coverage:** none
+**Coverage:** `tests/search-box.spec.ts` (debounce timing, rapid typing)
 
 ---
 
@@ -245,4 +247,4 @@ Search has two modes:
    - Navigates to the staff member's session or detail view.
 4. Retired staff members are filtered out of sidebar results in filter mode.
 
-**Coverage:** none
+**Coverage:** `tests/search-index.spec.ts` (staff indexing roundtrip, staff type filtering)


### PR DESCRIPTION
## Search UX Rework

Reworks search from a confusing toggle-based dual-mode sidebar into two clean, distinct experiences:

### Changes

**UI Cleanup — Remove Content Toggle**
- Removed the confusing "Content" toggle switch from sidebar search
- Sidebar now does pure client-side title filtering (goals, sessions, staff, agent roles)
- Full search page (`#/search`) is the sole FTS API consumer
- Removed `searchContentMode`, `searchResults`, `searchMatchIds`, `searchLoading` state fields

**Bug Fixes**
- Fixed FTS5 query sanitiser: special characters now stripped from ALL tokens (not just the last prefix token), preventing MATCH syntax errors with queries like `deploy:prod`, `foo(bar)`, `+debug -test`
- Added agent role matching to sidebar filter (e.g. searching "coder" now matches coder sessions)
- Removed dead `loading` property from SearchBox component

**Test Coverage (52 new tests)**
- `tests/search-index.spec.ts` — 23 server-side unit tests (FTS5 sanitiser edge cases, indexing roundtrips, type filtering, special chars)
- `tests/search-box.spec.ts` — 12 UI fixture tests (Ctrl+K, debounce, escape, clear, Full Search link)
- `tests/search-results.spec.ts` — 13 UI fixture tests (grouping, click events, empty/loading states, XSS sanitization)
- `tests/e2e/ui/search-e2e.spec.ts` — 4 browser E2E tests (SR-01 filter mode, SR-02 full search nav, SR-05 keyboard shortcut, SR-07 archived auto-open)

**Documentation**
- Updated `docs/internals.md` and `docs/debugging.md` with new two-mode search design
- Updated coverage tags in `userstories/search.md`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)