### PR TITLE
Clean remote branches on goal archive

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -54,6 +54,7 @@ import { ProjectContextManager } from "./agent/project-context-manager.js";
 import { GoalManager } from "./agent/goal-manager.js";
 import { detectHostTokens, resolveHostTokenValue } from "./agent/host-tokens.js";
 import type { PersistedGoal } from "./agent/goal-store.js";
+import type { PersistedTeamEntry } from "./agent/team-store.js";
 import { migrateToPerProjectState, recoverPreMigrationData } from "./agent/state-migration.js";
 import { resolveScalarConfig } from "./agent/config-resolver.js";
 import { BuiltinConfigProvider } from "./agent/builtin-config.js";
@@ -65,6 +66,36 @@ const VALID_TASK_STATES = new Set<string>(["todo", "in-progress", "blocked", "co
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFileCb);
+
+/**
+ * Delete remote branches associated with a goal (integration + agent worktree branches).
+ * Fire-and-forget — errors are logged but never block the archive flow.
+ */
+async function deleteRemoteGoalBranches(
+	goal: PersistedGoal,
+	teamEntry: PersistedTeamEntry | undefined,
+	repoPath: string,
+): Promise<void> {
+	const branches = new Set<string>();
+	if (goal.branch) branches.add(goal.branch);
+	if (teamEntry?.agents) {
+		for (const agent of teamEntry.agents) {
+			if (agent.branch) branches.add(agent.branch);
+		}
+	}
+	if (branches.size === 0) return;
+	for (const branch of branches) {
+		try {
+			await execFileAsync("git", ["push", "origin", "--delete", branch], {
+				cwd: repoPath,
+				timeout: 15_000,
+			});
+			console.log(`[api] Deleted remote branch: ${branch}`);
+		} catch (err) {
+			console.warn(`[api] Failed to delete remote branch ${branch}:`, err);
+		}
+	}
+}
 
 /** Cached Docker availability result to avoid running `docker info` per session creation */
 let _dockerAvailCache: { available: boolean; error?: string; ts: number } | null = null;
@@ -2289,6 +2320,19 @@ async function handleApiRoute(
 			// Archive instead of hard-delete — tasks, gates, team state remain intact
 			const deleteGoalMgr = getGoalManagerForGoal(id);
 			await deleteGoalMgr.archiveGoal(id);
+
+			// Fire-and-forget: clean up remote branches for this goal
+			const archivedGoal = deleteGoalMgr.getGoal(id);
+			if (archivedGoal?.repoPath) {
+				const goalProjectCtx = projectContextManager
+					? projectContextManager.getContextForGoal(id)
+					: null;
+				const teamEntry = goalProjectCtx?.teamStore.get(id);
+				deleteRemoteGoalBranches(archivedGoal, teamEntry, archivedGoal.repoPath).catch(err => {
+					console.warn(`[api] Remote branch cleanup failed for goal ${id}:`, err);
+				});
+			}
+
 			prStatusStore.remove(id);
 			json({ ok: true });
 			return;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2308,6 +2308,10 @@ async function handleApiRoute(
 					console.error(`[api] Error cancelling verification for gate ${active.gateId}:`, err);
 				}
 			}
+			// Capture agent branches BEFORE teardown erases the team store entry
+			const goalProjectCtx = projectContextManager.getContextForGoal(id);
+			const teamEntry = goalProjectCtx?.teamStore.get(id);
+
 			// Tear down any active team first (dismisses agents, cleans up their worktrees)
 			const teamState = teamManager.getTeamState(id);
 			if (teamState) {
@@ -2324,10 +2328,6 @@ async function handleApiRoute(
 			// Fire-and-forget: clean up remote branches for this goal
 			const archivedGoal = deleteGoalMgr.getGoal(id);
 			if (archivedGoal?.repoPath) {
-				const goalProjectCtx = projectContextManager
-					? projectContextManager.getContextForGoal(id)
-					: null;
-				const teamEntry = goalProjectCtx?.teamStore.get(id);
 				deleteRemoteGoalBranches(archivedGoal, teamEntry, archivedGoal.repoPath).catch(err => {
 					console.warn(`[api] Remote branch cleanup failed for goal ${id}:`, err);
 				});


### PR DESCRIPTION
When a goal is archived, delete its remote branches from origin to prevent stale branch accumulation.

## Changes
- Added `deleteRemoteGoalBranches` helper to `src/server/server.ts`
- Called fire-and-forget in DELETE `/api/goals/:id` handler after `archiveGoal()`
- Collects goal integration branch (`goal.branch`) and all agent worktree branches from the persisted team store
- Runs `git push origin --delete` for each branch with 15s timeout
- All errors swallowed (branch may not exist on remote, remote may be unreachable)
- Team store read happens before `teardownTeam()` to capture agent branches before the entry is removed

## Edge cases
- No repoPath (non-git project): no-op
- No team (solo goal): only deletes integration branch
- Branch not pushed to remote: error swallowed
- Remote unreachable: error swallowed, logged as warning
- PR still open on branch: GitHub preserves PR history after branch deletion

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)