### PR TITLE
Fix: Archived delegates disappear when Show Archived is toggled

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -165,6 +165,7 @@ When a sandbox container is killed or removed, sessions auto-recover. Use this c
 - Cursor based on `archivedAt` timestamp
 - Missing items? Check `archivedAt` is set (older items may lack it)
 - Count mismatch? Verify total from paginated response metadata
+- Archived delegates disappearing on "Show Archived" toggle? The `?include=archived` path returns `archivedDelegates` via BFS enrichment — if they're missing, check that the server is running the delegate BFS on the archived response and the client is merging them into `state.archivedSessions`
 
 ## Slash skill expansion
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -392,6 +392,8 @@ Returns 400 if `section` is missing or invalid. Returns 404 if the resolved sign
 
 `GET /api/sessions` (without `?since`) returns an `archivedDelegates` array alongside `sessions`. This contains all archived sessions that are delegates (direct or nested) of any live session, found via BFS from live session IDs through `delegateOf` chains. Each entry has the same shape as a session object with `archived: true`.
 
+The `?include=archived` path (both paginated with `&limit=N` and non-paginated) also returns `archivedDelegates`. This ensures that when the user toggles "Show Archived" in the sidebar, archived delegates of live sessions remain visible — they are included via the same BFS enrichment rather than relying solely on the paginated window.
+
 This avoids a separate fetch for archived delegate data — the sidebar can render chevrons and nested children immediately on first load. The alternative (a dedicated delegates endpoint with lazy-fetch) was rejected because it creates a chicken-and-egg problem: the chevron only renders when children are known, but children are only fetched on chevron click.
 
 **Note:** The `?since=N` polling path does **not** include `archivedDelegates` — it only returns the changed session list. Archived delegates are loaded on the initial full fetch and refreshed on full re-fetches (e.g. after reconnect). This is intentional: delegate relationships rarely change during polling intervals.

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -455,6 +455,18 @@ export async function fetchArchivedSessionsPaginated(limit = 50, afterCursor?: n
 		} else {
 			state.archivedSessions = sessions;
 		}
+
+		// Merge archived delegates from the response (BFS-enriched by server)
+		const archivedDelegates: GatewaySession[] = data.archivedDelegates || [];
+		if (archivedDelegates.length > 0) {
+			const existingIds = new Set(state.archivedSessions.map(s => s.id));
+			for (const d of archivedDelegates) {
+				if (!existingIds.has(d.id)) {
+					state.archivedSessions.push(d);
+					existingIds.add(d.id);
+				}
+			}
+		}
 		state.archivedSessionsTotal = data.total ?? sessions.length;
 		state.archivedSessionsHasMore = data.hasMore ?? false;
 		state.archivedSessionsCursor = data.nextCursor ?? null;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1714,6 +1714,16 @@ async function handleApiRoute(
 				? allArchived.filter((s: any) => s.projectId === filterProjectId)
 				: allArchived;
 
+			// Collect all archived delegates for BFS enrichment
+			const allArchivedForDelegates: typeof sessions = [];
+			for (const ctx of projectContextManager.all()) {
+				for (const s of ctx.sessionStore.getArchived()) {
+					if (s.delegateOf) {
+						allArchivedForDelegates.push({ ...s, colorIndex: colorStore.get(s.id), archived: true } as any);
+					}
+				}
+			}
+
 			const limitParam = url.searchParams.get("limit");
 			const afterParam = url.searchParams.get("after");
 			if (limitParam) {
@@ -1728,10 +1738,43 @@ async function handleApiRoute(
 				const hasMore = page.length > limit;
 				const sliced = page.slice(0, limit);
 				const nextCursor = sliced.length > 0 ? (sliced[sliced.length - 1] as any).archivedAt : undefined;
-				json({ generation: currentGen, sessions: [...sessions, ...sliced], total, hasMore, nextCursor });
+
+				// BFS: collect archived delegates reachable from live sessions
+				const liveIdSet = new Set(sessions.map(s => s.id));
+				const archivedDelegatesOfLive: typeof sessions = [];
+				const seen = new Set<string>();
+				const queue = [...liveIdSet];
+				while (queue.length > 0) {
+					const parentId = queue.shift()!;
+					for (const s of allArchivedForDelegates) {
+						if (s.delegateOf === parentId && !seen.has(s.id)) {
+							seen.add(s.id);
+							archivedDelegatesOfLive.push(s);
+							queue.push(s.id);
+						}
+					}
+				}
+
+				json({ generation: currentGen, sessions: [...sessions, ...sliced], total, hasMore, nextCursor, archivedDelegates: archivedDelegatesOfLive });
 			} else {
+				// BFS: collect archived delegates reachable from live sessions
+				const liveIdSet = new Set(sessions.map(s => s.id));
+				const archivedDelegatesOfLive: typeof sessions = [];
+				const seen = new Set<string>();
+				const queue = [...liveIdSet];
+				while (queue.length > 0) {
+					const parentId = queue.shift()!;
+					for (const s of allArchivedForDelegates) {
+						if (s.delegateOf === parentId && !seen.has(s.id)) {
+							seen.add(s.id);
+							archivedDelegatesOfLive.push(s);
+							queue.push(s.id);
+						}
+					}
+				}
+
 				// Backward compatible: return all archived sessions
-				json({ generation: currentGen, sessions: [...sessions, ...filteredArchived] });
+				json({ generation: currentGen, sessions: [...sessions, ...filteredArchived], archivedDelegates: archivedDelegatesOfLive });
 			}
 		} else {
 			// Always include archived delegates of live sessions so the sidebar

--- a/tests/e2e/archived-delegates-api.spec.ts
+++ b/tests/e2e/archived-delegates-api.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * E2E tests for SB-00b: Archived delegates of live sessions must be
+ * returned by the paginated archived sessions endpoint.
+ *
+ * Bug: GET /api/sessions?include=archived&limit=50 does NOT include
+ * `archivedDelegates` for live sessions. The non-archived path runs BFS
+ * and returns them, but the paginated archived path omits them entirely.
+ *
+ * These tests create a live session with an archived delegate, then
+ * verify that both the normal and archived fetch paths return the
+ * delegate information.
+ */
+import { test, expect } from "./in-process-harness.js";
+import { apiFetch, createSession, nonGitCwd } from "./e2e-setup.js";
+
+/**
+ * Create a delegate session for a parent session via the REST API.
+ * Returns the delegate session ID.
+ */
+async function createDelegate(parentId: string): Promise<string> {
+	const resp = await apiFetch("/api/sessions", {
+		method: "POST",
+		body: JSON.stringify({
+			delegateOf: parentId,
+			instructions: "Test delegate for archived-delegates bug",
+			cwd: nonGitCwd(),
+		}),
+	});
+	expect(resp.status).toBe(201);
+	const data = await resp.json();
+	return data.id;
+}
+
+/**
+ * Terminate (archive) a session via DELETE.
+ */
+async function terminateSession(id: string): Promise<void> {
+	const resp = await apiFetch(`/api/sessions/${id}`, { method: "DELETE" });
+	expect(resp.ok, `Failed to terminate session ${id}: ${resp.status}`).toBe(true);
+}
+
+// ---------------------------------------------------------------------------
+// Normal path: GET /api/sessions (no include=archived)
+// ---------------------------------------------------------------------------
+
+test("normal sessions fetch returns archivedDelegates for live sessions", async () => {
+	// 1. Create a live parent session
+	const parentId = await createSession();
+
+	// 2. Create a delegate of the parent
+	const delegateId = await createDelegate(parentId);
+
+	// 3. Terminate (archive) the delegate
+	await terminateSession(delegateId);
+
+	// 4. Fetch sessions normally (no include=archived)
+	const resp = await apiFetch("/api/sessions");
+	expect(resp.status).toBe(200);
+	const body = await resp.json();
+
+	// 5. The response must include archivedDelegates containing our delegate
+	expect(
+		body.archivedDelegates,
+		"Expected response to have archivedDelegates field",
+	).toBeDefined();
+	expect(
+		Array.isArray(body.archivedDelegates),
+		"Expected archivedDelegates to be an array",
+	).toBe(true);
+
+	const delegateIds = body.archivedDelegates.map((s: any) => s.id);
+	expect(
+		delegateIds,
+		"Expected archivedDelegates to include the archived delegate of the live session",
+	).toContain(delegateId);
+
+	// Cleanup
+	await terminateSession(parentId);
+});
+
+// ---------------------------------------------------------------------------
+// Bug: GET /api/sessions?include=archived&limit=50 omits archivedDelegates
+// ---------------------------------------------------------------------------
+
+test("paginated archived fetch returns archivedDelegates for live sessions", async () => {
+	// 1. Create a live parent session
+	const parentId = await createSession();
+
+	// 2. Create a delegate of the parent
+	const delegateId = await createDelegate(parentId);
+
+	// 3. Terminate (archive) the delegate
+	await terminateSession(delegateId);
+
+	// 4. Fetch archived sessions (paginated path)
+	const resp = await apiFetch("/api/sessions?include=archived&limit=50");
+	expect(resp.status).toBe(200);
+	const body = await resp.json();
+
+	// 5. The response must include archivedDelegates
+	//    BUG: Currently the paginated archived path does NOT return this field.
+	expect(
+		body.archivedDelegates,
+		"Expected archivedDelegates to be present in paginated archived response",
+	).toBeDefined();
+	expect(
+		Array.isArray(body.archivedDelegates),
+		"Expected archivedDelegates to be an array",
+	).toBe(true);
+
+	const delegateIds = (body.archivedDelegates as any[]).map((s: any) => s.id);
+	expect(
+		delegateIds,
+		"Expected archivedDelegates to include archived delegate of live session",
+	).toContain(delegateId);
+
+	// Cleanup
+	await terminateSession(parentId);
+});
+
+// ---------------------------------------------------------------------------
+// Bug: GET /api/sessions?include=archived (no limit) also omits archivedDelegates
+// ---------------------------------------------------------------------------
+
+test("non-paginated archived fetch returns archivedDelegates for live sessions", async () => {
+	// 1. Create a live parent session
+	const parentId = await createSession();
+
+	// 2. Create a delegate of the parent
+	const delegateId = await createDelegate(parentId);
+
+	// 3. Terminate (archive) the delegate
+	await terminateSession(delegateId);
+
+	// 4. Fetch archived sessions (non-paginated — no limit param)
+	const resp = await apiFetch("/api/sessions?include=archived");
+	expect(resp.status).toBe(200);
+	const body = await resp.json();
+
+	// 5. The response must include archivedDelegates
+	//    BUG: The non-paginated archived path also does NOT return this field.
+	expect(
+		body.archivedDelegates,
+		"Expected archivedDelegates to be present in non-paginated archived response",
+	).toBeDefined();
+	expect(
+		Array.isArray(body.archivedDelegates),
+		"Expected archivedDelegates to be an array",
+	).toBe(true);
+
+	const delegateIds = (body.archivedDelegates as any[]).map((s: any) => s.id);
+	expect(
+		delegateIds,
+		"Expected archivedDelegates to include archived delegate of live session",
+	).toContain(delegateId);
+
+	// Cleanup
+	await terminateSession(parentId);
+});

--- a/tests/e2e/ui/sidebar-archived-delegates-e2e.spec.ts
+++ b/tests/e2e/ui/sidebar-archived-delegates-e2e.spec.ts
@@ -1,0 +1,208 @@
+/**
+ * Browser E2E test for SB-00b: Archived delegates survive "Show Archived" toggle.
+ *
+ * Scenario: Create a session → create a delegate → archive the delegate →
+ * toggle "Show Archived" → verify the archived delegate appears nested
+ * under the parent in the sidebar.
+ */
+import { test, expect } from "../gateway-harness.js";
+import {
+	apiFetch,
+	createSession,
+	deleteSession,
+	waitForSessionStatus,
+	nonGitCwd,
+} from "../e2e-setup.js";
+import { openApp, navigateToHash } from "./ui-helpers.js";
+
+/**
+ * Create a delegate session for a parent session via the REST API.
+ */
+async function createDelegate(parentId: string): Promise<string> {
+	const resp = await apiFetch("/api/sessions", {
+		method: "POST",
+		body: JSON.stringify({
+			delegateOf: parentId,
+			instructions: "E2E delegate for SB-00b",
+			cwd: nonGitCwd(),
+		}),
+	});
+	expect(resp.status).toBe(201);
+	return (await resp.json()).id;
+}
+
+/**
+ * Terminate (archive) a session via DELETE.
+ */
+async function terminateSession(id: string): Promise<void> {
+	const resp = await apiFetch(`/api/sessions/${id}`, { method: "DELETE" });
+	expect(resp.ok, `Failed to terminate session ${id}: ${resp.status}`).toBe(true);
+}
+
+/**
+ * Rename a session via the REST API so we can find it by title in the sidebar.
+ */
+async function renameSession(id: string, title: string): Promise<void> {
+	const resp = await apiFetch(`/api/sessions/${id}`, {
+		method: "PATCH",
+		body: JSON.stringify({ title }),
+	});
+	expect(resp.ok, `Failed to rename session ${id}: ${resp.status}`).toBe(true);
+}
+
+test.describe("SB-00b: Archived delegates visible after Show Archived toggle", () => {
+	const cleanupSessionIds: string[] = [];
+
+	test.afterAll(async () => {
+		for (const id of cleanupSessionIds) {
+			await deleteSession(id).catch(() => {});
+		}
+	});
+
+	test("archived delegate appears nested under live parent after toggling Show Archived", async ({ page }) => {
+		// Use distinctive titles so we can find them in the sidebar
+		const PARENT_TITLE = "SB00b-Parent";
+		const DELEGATE_TITLE = "SB00b-Delegate";
+
+		// 1. Create a live parent session and rename it
+		const parentId = await createSession();
+		cleanupSessionIds.push(parentId);
+		await waitForSessionStatus(parentId, "idle");
+		await renameSession(parentId, PARENT_TITLE);
+
+		// 2. Create a delegate of the parent and rename it
+		const delegateId = await createDelegate(parentId);
+		cleanupSessionIds.push(delegateId);
+		await waitForSessionStatus(delegateId, "idle");
+		await renameSession(delegateId, DELEGATE_TITLE);
+
+		// 3. Terminate (archive) the delegate
+		await terminateSession(delegateId);
+
+		// 4. Open the app — the parent should be visible in the sidebar
+		await openApp(page);
+
+		// Navigate to the parent session so it's highlighted and visible
+		await navigateToHash(page, `#/session/${parentId}`);
+		await expect(page.locator("textarea").first()).toBeVisible({ timeout: 15_000 });
+
+		// 5. The delegate should NOT be visible yet (Show Archived is off)
+		await page.waitForTimeout(500);
+		await expect(page.getByText(DELEGATE_TITLE, { exact: true })).toHaveCount(0, { timeout: 3_000 });
+
+		// 6. Toggle "Show Archived" on
+		const seeArchivedBtn = page.locator("button").filter({ hasText: "See Archived" }).first();
+		await expect(seeArchivedBtn).toBeVisible({ timeout: 10_000 });
+		await seeArchivedBtn.click();
+
+		// 7. Wait for the archived section to appear
+		await expect(
+			page.locator("span.uppercase").filter({ hasText: "Archived" }).first(),
+		).toBeVisible({ timeout: 10_000 });
+
+		// Wait for sidebar to fully render with archived data
+		await page.waitForTimeout(2000);
+
+		// 8. The parent row may have a ▸ chevron if it detects its archived delegate.
+		//    Try to find and click it to expand children.
+		const parentText = page.getByText(PARENT_TITLE, { exact: true }).first();
+		await expect(parentText).toBeVisible({ timeout: 5_000 });
+
+		// Look for expand chevron ▸ near the parent row — use evaluate for reliability
+		const expanded = await page.evaluate((parentTitle: string) => {
+			// Find the parent row by title text
+			const allElements = document.querySelectorAll(".truncate");
+			for (const el of allElements) {
+				if (el.textContent?.trim() === parentTitle) {
+					// Found the parent title element. Go up to the row container.
+					const row = el.closest("[class*='cursor-pointer']");
+					if (!row) continue;
+					// Look for a collapsed chevron ▸ to click
+					const chevron = row.querySelector("span");
+					if (chevron && chevron.textContent?.trim() === "▸") {
+						(chevron as HTMLElement).click();
+						return true;
+					}
+				}
+			}
+			return false;
+		}, PARENT_TITLE);
+
+		if (expanded) {
+			await page.waitForTimeout(500);
+		}
+
+		// 9. Check if the delegate appears anywhere — it could be nested under the
+		//    parent OR in the standalone archived section at the bottom.
+		//    The bug fix ensures it appears in both contexts.
+		const delegateLocator = page.getByText(DELEGATE_TITLE, { exact: true }).first();
+		await expect(delegateLocator).toBeVisible({ timeout: 10_000 });
+
+		// 10. Toggle OFF then ON — delegate should survive the cycle
+		await seeArchivedBtn.click();
+		await page.waitForTimeout(500);
+		// Delegate should be gone while archived is off
+		await expect(page.getByText(DELEGATE_TITLE, { exact: true })).toHaveCount(0, { timeout: 3_000 });
+
+		// Toggle back on
+		await seeArchivedBtn.click();
+		await expect(
+			page.locator("span.uppercase").filter({ hasText: "Archived" }).first(),
+		).toBeVisible({ timeout: 10_000 });
+		await page.waitForTimeout(2000);
+
+		// Re-expand parent if needed
+		await page.evaluate((parentTitle: string) => {
+			const allElements = document.querySelectorAll(".truncate");
+			for (const el of allElements) {
+				if (el.textContent?.trim() === parentTitle) {
+					const row = el.closest("[class*='cursor-pointer']");
+					if (!row) continue;
+					const chevron = row.querySelector("span");
+					if (chevron && chevron.textContent?.trim() === "▸") {
+						(chevron as HTMLElement).click();
+						return;
+					}
+				}
+			}
+		}, PARENT_TITLE);
+		await page.waitForTimeout(500);
+
+		// Delegate should still be visible after toggle cycle
+		await expect(
+			page.getByText(DELEGATE_TITLE, { exact: true }).first(),
+		).toBeVisible({ timeout: 10_000 });
+	});
+
+	test("archived delegate not visible when Show Archived is off", async ({ page }) => {
+		const PARENT_TITLE = "SB00b-ParentB";
+		const DELEGATE_TITLE = "SB00b-DelegateB";
+
+		// 1. Create parent + delegate, archive the delegate
+		const parentId = await createSession();
+		cleanupSessionIds.push(parentId);
+		await waitForSessionStatus(parentId, "idle");
+		await renameSession(parentId, PARENT_TITLE);
+
+		const delegateId = await createDelegate(parentId);
+		cleanupSessionIds.push(delegateId);
+		await waitForSessionStatus(delegateId, "idle");
+		await renameSession(delegateId, DELEGATE_TITLE);
+
+		await terminateSession(delegateId);
+
+		// 2. Open the app without enabling Show Archived
+		await openApp(page);
+		await navigateToHash(page, `#/session/${parentId}`);
+		await expect(page.locator("textarea").first()).toBeVisible({ timeout: 15_000 });
+
+		// 3. Give the sidebar time to render
+		await page.waitForTimeout(1000);
+
+		// 4. The archived delegate title should NOT appear in the sidebar
+		await expect(page.getByText(DELEGATE_TITLE, { exact: true })).toHaveCount(0, { timeout: 3_000 });
+
+		// Cleanup
+		await terminateSession(parentId);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes SB-00b: When toggling "Show Archived" in the sidebar, archived delegates of live sessions would disappear because the archived fetch path didn't include BFS delegate enrichment, and the client wiped previously-merged delegate data.

### Server fix (`src/server/server.ts`)
- Added BFS delegate enrichment to the `GET /api/sessions?include=archived` path (both paginated and non-paginated), matching the behavior of the normal session fetch

### Client fix (`src/app/api.ts`)
- `fetchArchivedSessionsPaginated()` now merges `archivedDelegates` from the response into `state.archivedSessions`, preserving delegate chains across the toggle

### Tests
- Reproducing API E2E test confirming the server returns `archivedDelegates` on the archived path
- Browser E2E test verifying delegates remain visible in the sidebar after toggling Show Archived

### Documentation
- Updated `docs/rest-api.md` — documented `archivedDelegates` on `?include=archived` paths
- Updated `docs/debugging.md` — added troubleshooting entry for this symptom

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)