### PR TITLE
Auto-nudge sleep guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,7 @@ Key quick checks:
 - **Stuck gate verification**: Cancel via `POST /api/goals/:id/gates/:gateId/cancel-verification` or the dashboard Cancel button.
 - **Gate/task tool bloat**: Agent tools (`gate_list`, `gate_status`, `task_list`) use `?view=summary` by default for slim responses. Use `gate_inspect` to drill into content, verification output, or signal history on demand. See [docs/rest-api.md — Summary views](docs/rest-api.md#summary-views-viewsummary).
 - **Search index**: Delete `<project-root>/.bobbit/state/search.db` and restart to rebuild.
+- **Auto-nudge flooding**: If a team lead receives duplicate nudges after sleep/wake, check `nudgePending` state in TeamManager. The guard prevents re-enqueuing while a nudge is already pending — cleared on `agent_start`.
 
 ## Git conventions
 

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -137,6 +137,8 @@ export class TeamManager {
 	private idleNudgeTimers = new Map<string, ReturnType<typeof setInterval>>();
 	/** Separate timer for nudging when no workers remain (goalId → timer). */
 	private noWorkersNudgeTimers = new Map<string, ReturnType<typeof setInterval>>();
+	/** Guard flag: true while an auto-nudge prompt is pending (not yet processed by the agent). */
+	private nudgePending = new Map<string, boolean>();
 	private verificationHarness?: VerificationHarness;
 	/** Delay before nudging the idle team lead when workers are active (ms). */
 	private static readonly IDLE_NUDGE_DELAY_MS = 600_000;
@@ -345,6 +347,7 @@ export class TeamManager {
 			clearInterval(nwTimer);
 			this.noWorkersNudgeTimers.delete(goalId);
 		}
+		this.nudgePending.delete(goalId);
 	}
 
 	/**
@@ -361,6 +364,7 @@ export class TeamManager {
 		const tl = this.sessionManager.getSession(entry.teamLeadSessionId);
 		if (!tl || tl.status !== "idle") return true;
 		if (this.verificationHarness?.getActiveVerifications(goalId).length) return true;
+		if (this.nudgePending.get(goalId)) return true;
 		return false;
 	}
 
@@ -404,6 +408,7 @@ export class TeamManager {
 				`Check your progress — use task_list and gate_list to review what's done and what remains. ` +
 				`If there's more work to do, spawn agents or do it yourself. ` +
 				`If all work is complete and gates are passed, call team_complete to finish the goal.`;
+			this.nudgePending.set(goalId, true);
 			this.sessionManager.enqueuePrompt(entry.teamLeadSessionId!, message, { isSteered: true });
 			console.log(`[team-manager] Sent no-workers idle nudge to team lead for goal ${goalId}`);
 
@@ -439,6 +444,7 @@ export class TeamManager {
 				`If an agent is idle and their work looks complete, mark their task as done and dismiss them. ` +
 				`If idle agents have more to do, prompt them to continue.`;
 
+			this.nudgePending.set(goalId, true);
 			this.sessionManager.enqueuePrompt(entry.teamLeadSessionId!, message, { isSteered: true });
 			console.log(`[team-manager] Sent idle nudge to team lead for goal ${goalId}`);
 		}, TeamManager.IDLE_NUDGE_DELAY_MS);
@@ -463,6 +469,7 @@ export class TeamManager {
 			if (event.type === "agent_end") {
 				this.startIdleNudgeTimer(goalId);
 			} else if (event.type === "agent_start") {
+				this.nudgePending.delete(goalId);
 				this.clearIdleNudgeTimer(goalId);
 			}
 		});

--- a/tests/team-manager.test.ts
+++ b/tests/team-manager.test.ts
@@ -141,6 +141,7 @@ function createMockTaskManager() {
 	const tasks: any[] = [];
 	return {
 		getTasksByGoal: (_goalId: string) => tasks,
+		getTasksForSession: (_sessionId: string) => tasks.filter((t: any) => t.assignedSessionId === _sessionId),
 		createTask: (_goalId: string, task: any) => { tasks.push(task); return task; },
 		getTask: (id: string) => tasks.find((t: any) => t.id === id),
 		updateTask: (_id: string, _updates: any) => true,
@@ -666,6 +667,86 @@ describe("TeamManager", () => {
 			assert.equal(sm._sessions.has("session-0"), true); // team lead alive
 			assert.ok(team.getTeamState("goal-1"), "team state should still exist");
 			assert.equal(goal.state, "complete");
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Tests: idle nudge sleep guard (reproducing bug)
+	// ---------------------------------------------------------------------------
+
+	describe("idle nudge sleep guard", () => {
+		it("should allow multiple nudges when no pending guard exists (reproducing bug)", async (t) => {
+			t.mock.timers.enable({ apis: ["setInterval"] });
+
+			const goals = new Map<string, MockGoal>();
+			const goal = createMockGoal();
+			goals.set(goal.id, goal);
+			const sm = createMockSessionManager(goals);
+
+			// Add enqueuePrompt to the mock session manager (not present by default)
+			const enqueuePrompt = mock.fn(async (_id: string, _msg: string, _opts?: any) => {});
+			sm.enqueuePrompt = enqueuePrompt;
+
+			// Capture onEvent callbacks so we can simulate lifecycle events
+			const eventCallbacks: Array<(event: any) => void> = [];
+			const origCreateSession = sm.createSession.bind(sm);
+			sm.createSession = async (
+				cwd: string,
+				args?: string[],
+				goalId?: string,
+				goalAssistant?: boolean,
+				opts?: any,
+			) => {
+				const session = await origCreateSession(cwd, args, goalId, goalAssistant, opts);
+				// Replace onEvent to capture the callback
+				session.rpcClient.onEvent = mock.fn((cb: any) => {
+					eventCallbacks.push(cb);
+					return () => {};
+				});
+				return session;
+			};
+
+			const team = createTeamManager(sm);
+			await team.startTeam("goal-1");
+
+			// Get the team lead session and inject a fake active worker
+			const entry = (team as any).teams.get("goal-1")!;
+			const workerSession = {
+				id: "worker-1",
+				status: "streaming",
+				cwd: "/tmp/worker",
+				rpcClient: { prompt: mock.fn(async () => {}), onEvent: mock.fn(() => () => {}) },
+				clients: new Set(),
+			};
+			sm._sessions.set("worker-1", workerSession);
+			entry.agents.push({
+				sessionId: "worker-1",
+				role: "coder",
+				task: "work on feature",
+				createdAt: Date.now(),
+			});
+
+			// Set the team lead to idle so shouldSkipNudge() passes
+			const tlSession = sm._sessions.get(entry.teamLeadSessionId)!;
+			tlSession.status = "idle";
+
+			// Simulate agent_end on the team lead — this triggers startIdleNudgeTimer()
+			for (const cb of eventCallbacks) {
+				cb({ type: "agent_end" });
+			}
+
+			// Advance time by 5 hours — the 10-min interval should fire ~30 times
+			t.mock.timers.tick(5 * 60 * 60 * 1000);
+
+			// BUG: without a pending guard, every tick enqueues a nudge
+			const callCount = enqueuePrompt.mock.callCount();
+			assert.ok(
+				callCount > 1,
+				`Expected enqueuePrompt to be called more than once (bug reproduction), got ${callCount}`,
+			);
+			console.log(`[test] enqueuePrompt called ${callCount} times in 5h (expected ~30 without guard)`);
+
+			t.mock.timers.reset();
 		});
 	});
 

--- a/tests/team-manager.test.ts
+++ b/tests/team-manager.test.ts
@@ -747,6 +747,58 @@ describe("TeamManager", () => {
 
 			t.mock.timers.reset();
 		});
+
+		it("should resume nudging after agent processes the pending nudge", async (t) => {
+			t.mock.timers.enable({ apis: ["setInterval"] });
+
+			const goals = new Map<string, MockGoal>();
+			const goal = createMockGoal();
+			goals.set(goal.id, goal);
+			const sm = createMockSessionManager(goals);
+			const enqueuePrompt = mock.fn((_id: string, _msg: string, _opts?: any) => {});
+			sm.enqueuePrompt = enqueuePrompt;
+
+			const eventCallbacks: Array<(event: any) => void> = [];
+			const origCreateSession = sm.createSession.bind(sm);
+			sm.createSession = async (cwd: string, args?: string[], goalId?: string, goalAssistant?: boolean, opts?: any) => {
+				const session = await origCreateSession(cwd, args, goalId, goalAssistant, opts);
+				session.rpcClient.onEvent = mock.fn((cb: any) => { eventCallbacks.push(cb); return () => {}; });
+				return session;
+			};
+
+			const team = createTeamManager(sm);
+			await team.startTeam("goal-1");
+
+			const entry = (team as any).teams.get("goal-1")!;
+			const workerSession = {
+				id: "worker-1", status: "streaming", cwd: "/tmp/worker",
+				rpcClient: { prompt: mock.fn(async () => {}), onEvent: mock.fn(() => () => {}) },
+				clients: new Set(),
+			};
+			sm._sessions.set("worker-1", workerSession);
+			entry.agents.push({ sessionId: "worker-1", role: "coder", task: "work", createdAt: Date.now() });
+
+			const tlSession = sm._sessions.get(entry.teamLeadSessionId)!;
+			tlSession.status = "idle";
+
+			// Trigger agent_end to start nudge timer
+			for (const cb of eventCallbacks) cb({ type: "agent_end" });
+
+			// Advance 5 hours — should get exactly 1 nudge (pending guard blocks the rest)
+			t.mock.timers.tick(5 * 60 * 60 * 1000);
+			assert.equal(enqueuePrompt.mock.callCount(), 1, "First batch: exactly 1 nudge");
+
+			// Simulate agent processing the nudge: agent_start then agent_end
+			for (const cb of eventCallbacks) cb({ type: "agent_start" });
+			tlSession.status = "idle";
+			for (const cb of eventCallbacks) cb({ type: "agent_end" });
+
+			// Advance another 15 minutes — should get a second nudge
+			t.mock.timers.tick(15 * 60 * 1000);
+			assert.ok(enqueuePrompt.mock.callCount() >= 2, "Second nudge should fire after agent processes first");
+
+			t.mock.timers.reset();
+		});
 	});
 
 	// ---------------------------------------------------------------------------

--- a/tests/team-manager.test.ts
+++ b/tests/team-manager.test.ts
@@ -675,7 +675,7 @@ describe("TeamManager", () => {
 	// ---------------------------------------------------------------------------
 
 	describe("idle nudge sleep guard", () => {
-		it("should allow multiple nudges when no pending guard exists (reproducing bug)", async (t) => {
+		it("should only enqueue one nudge after sleep wake (pending guard)", async (t) => {
 			t.mock.timers.enable({ apis: ["setInterval"] });
 
 			const goals = new Map<string, MockGoal>();
@@ -684,7 +684,7 @@ describe("TeamManager", () => {
 			const sm = createMockSessionManager(goals);
 
 			// Add enqueuePrompt to the mock session manager (not present by default)
-			const enqueuePrompt = mock.fn(async (_id: string, _msg: string, _opts?: any) => {});
+			const enqueuePrompt = mock.fn((_id: string, _msg: string, _opts?: any) => {});
 			sm.enqueuePrompt = enqueuePrompt;
 
 			// Capture onEvent callbacks so we can simulate lifecycle events
@@ -735,16 +735,15 @@ describe("TeamManager", () => {
 				cb({ type: "agent_end" });
 			}
 
-			// Advance time by 5 hours — the 10-min interval should fire ~30 times
+			// Advance time by 5 hours — simulates a sleep/wake where all overdue intervals fire
 			t.mock.timers.tick(5 * 60 * 60 * 1000);
 
-			// BUG: without a pending guard, every tick enqueues a nudge
+			// CORRECT behavior: only ONE nudge should be enqueued, not ~30
 			const callCount = enqueuePrompt.mock.callCount();
 			assert.ok(
-				callCount > 1,
-				`Expected enqueuePrompt to be called more than once (bug reproduction), got ${callCount}`,
+				callCount <= 1,
+				`Expected enqueuePrompt to be called at most once (pending guard), but got ${callCount}`,
 			);
-			console.log(`[test] enqueuePrompt called ${callCount} times in 5h (expected ~30 without guard)`);
 
 			t.mock.timers.reset();
 		});


### PR DESCRIPTION
## Summary

Adds a `nudgePending` guard to `TeamManager` to prevent duplicate auto-nudge messages when the host machine wakes from sleep.

### Problem
When the host wakes from sleep, `setInterval` timer callbacks that were overdue fire simultaneously. Both the 5-min (no-workers) and 10-min (workers) nudge timers pass `shouldSkipNudge()` and enqueue multiple nudges because `enqueuePrompt` doesn't synchronously change session status.

### Solution
- Added `nudgePending` Map field to track whether a nudge is already enqueued per goal
- `shouldSkipNudge()` checks the flag and skips if a nudge is pending
- Both timer callbacks set the flag before calling `enqueuePrompt`
- Flag cleared on `agent_start` (nudge delivered) and in `clearIdleNudgeTimer()` (teardown)

### Tests
- Reproducing test: advances 5 hours with mocked timers, asserts only 1 nudge (was 30 before fix)
- Resume test: verifies nudge→agent_start→agent_end→nudge cycle works correctly
- All 42 existing tests pass with no regressions

### Files Changed
- `src/server/agent/team-manager.ts` — nudgePending guard implementation
- `tests/team-manager.test.ts` — 2 new tests for sleep guard behavior
- `AGENTS.md` — debugging bullet for nudgePending

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)