### PR TITLE
Fix staff agent wake bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ Each recipe gives the entry point and key files. For detailed walkthroughs, see 
 
 **Change message rendering**: `src/ui/components/Messages.ts` for standard roles, `message-renderer-registry.ts` for custom types.
 
-**Modify sandbox behavior**: Set `sandbox: "docker"` in `project.yaml`. Key files: `project-sandbox.ts`, `sandbox-manager.ts`, `docker-args.ts`. One long-lived container per project. See [docs/internals.md — Docker sandbox](docs/internals.md#docker-sandbox).
+**Modify sandbox behavior**: Set `sandbox: "docker"` in `project.yaml`. Key files: `project-sandbox.ts`, `sandbox-manager.ts`, `docker-args.ts`. One long-lived container per project. Staff agents in sandbox mode use container-internal worktrees via `sandboxBranch`. See [docs/internals.md — Docker sandbox](docs/internals.md#docker-sandbox).
 
 **Run maintenance cleanup**: Settings → Maintenance tab. Three sections: orphaned worktrees, orphaned sessions, expired archives. Each has scan → preview → execute. Cleanup is never automatic.
 
@@ -166,6 +166,8 @@ worktree_setup_command: npm ci --prefer-offline --no-audit --no-fund
 ```
 
 If not set, no setup runs (intentional — Bobbit doesn't assume your package manager).
+
+Staff agent worktrees are automatically refreshed on each wake cycle — the branch is rebased onto the primary branch and `worktree_setup_command` is re-run. This prevents stale dependencies and outdated code in long-lived staff sessions. The underlying `setupWorktreeDeps()` function is exported from `src/server/skills/git.ts` for reuse. Sandboxed staff skip the host-side refresh (their worktrees live inside the container).
 
 ## Reference docs
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -300,6 +300,8 @@ Every non-goal, non-assistant session automatically gets its own git worktree br
 4. **Orphan detection**: Orphaned `session/*` worktrees (from ungraceful shutdowns where cleanup didn't run) are **not** removed automatically on startup. Use Settings → Maintenance tab to preview orphaned worktrees and clean them up manually. The REST API (`GET /api/maintenance/orphaned-worktrees`) lists orphans; `POST /api/maintenance/cleanup-worktrees` removes them after validation.
 5. **Restore**: After a restart, existing session worktrees are reused — the server reconnects to the worktree on disk without recreating it.
 
+**Staff agent worktrees:** Staff agents get a permanent worktree at creation time. Because staff sessions are long-lived (they persist across wake/sleep cycles rather than being recreated), their worktrees can become stale over time. To address this, `StaffManager.refreshWorktree()` runs on each wake cycle for non-sandboxed staff: it rebases the worktree branch onto the primary branch and re-runs the project's `worktree_setup_command` (e.g. `npm ci`). Sandboxed staff agents skip the host-side refresh — their container-internal worktrees are managed via `sandboxBranch`, which is passed to `createSession()` during staff creation and legacy migration so the container creates the worktree properly.
+
 ### Sidebar grouping
 
 The sidebar always groups sessions and goals under collapsible project folder rows — even with a single project. This unified code path avoids duplication between single-project and multi-project layouts.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -154,9 +154,13 @@ Routes accept both `/team/` and legacy `/swarm/` paths.
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/api/staff` | List all staff agent definitions |
+| `GET` | `/api/staff` | List all staff agent definitions. Each entry includes a `sandboxed` boolean (inherited from project config). |
+| `GET` | `/api/staff/:id` | Get a single staff agent definition (includes `sandboxed` boolean) |
 | `POST` | `/api/staff` | Create a staff agent (`{ name, description, triggers, skillId?, prompt? }`) |
+| `PUT` | `/api/staff/:id` | Update a staff agent (`{ name, description, systemPrompt, cwd, state, triggers, memory, roleId }`) |
+| `DELETE` | `/api/staff/:id` | Delete a staff agent and terminate its session |
 | `POST` | `/api/staff/:id/wake` | Manually trigger a staff agent's wake cycle |
+| `GET` | `/api/staff/:id/sessions` | **Deprecated (410)**. Use `GET /api/staff/:id` instead. |
 
 ### Project Config
 

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -977,6 +977,7 @@ export interface StaffAgent {
 	lastWakeAt?: number;
 	currentSessionId?: string;
 	projectId?: string;
+	sandboxed?: boolean;
 }
 
 export async function fetchStaff(projectId?: string): Promise<StaffAgent[]> {

--- a/src/app/staff-page.ts
+++ b/src/app/staff-page.ts
@@ -541,6 +541,17 @@ function renderEditView(): TemplateResult {
 						onInput: (e: Event) => { editCwd = (e.target as HTMLInputElement).value; renderApp(); },
 					})}
 				</div>
+				<!-- Sandbox indicator -->
+				<div>
+					<label class="text-xs text-muted-foreground mb-1.5 block font-medium">Sandbox</label>
+					<div class="flex items-center gap-2">
+						${selectedStaff.sandboxed
+							? html`<span class="px-2 py-0.5 text-xs rounded-full bg-cyan-500/15 text-cyan-700 dark:text-cyan-400">🐳 Docker Sandbox</span>`
+							: html`<span class="px-2 py-0.5 text-xs rounded-full bg-muted text-muted-foreground">No Sandbox</span>`
+						}
+					</div>
+					<p class="text-[10px] text-muted-foreground mt-1">Inherited from project settings</p>
+				</div>
 				<!-- Colour picker -->
 				<div>
 					<div class="text-xs text-muted-foreground mb-2 font-medium">Colour</div>

--- a/src/server/agent/staff-manager.ts
+++ b/src/server/agent/staff-manager.ts
@@ -1,8 +1,12 @@
 import { randomUUID } from "node:crypto";
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
 import { StaffStore, type PersistedStaff, type StaffState, type StaffTrigger } from "./staff-store.js";
 import type { SessionManager } from "./session-manager.js";
 import type { ProjectContextManager } from "./project-context-manager.js";
-import { createWorktree, cleanupWorktree } from "../skills/git.js";
+import { createWorktree, cleanupWorktree, setupWorktreeDeps } from "../skills/git.js";
+
+const execFile = promisify(execFileCb);
 
 function sanitiseBranchName(name: string): string {
 	return name.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
@@ -87,6 +91,7 @@ export class StaffManager {
 				rolePrompt: fullPrompt,
 				env: { BOBBIT_STAFF_ID: id },
 				sandboxed: sessionManager.isSandboxEnabled,
+				sandboxBranch: sessionManager.isSandboxEnabled ? branchName : undefined,
 				projectId,
 			});
 			session.staffId = id;
@@ -213,6 +218,43 @@ export class StaffManager {
 	}
 
 	/**
+	 * Refresh a staff agent's worktree: rebase onto the primary branch and
+	 * re-run the project's worktree setup command (e.g. npm ci).
+	 * Non-fatal — logs warnings on failure so the agent can still operate.
+	 */
+	private async refreshWorktree(staff: PersistedStaff, projectId: string): Promise<void> {
+		if (!staff.worktreePath) return;
+
+		// Skip refresh for sandboxed staff — their worktree lives inside the container
+		const ctx = this.pcm.getOrCreate(projectId);
+		if (ctx?.projectConfigStore.get("sandbox") === "docker") return;
+
+		const wt = staff.worktreePath;
+		try {
+			await execFile("git", ["fetch", "origin"], { cwd: wt, timeout: 60_000 });
+		} catch (err) {
+			console.warn(`[staff-manager] git fetch failed in ${wt} (non-fatal):`, err);
+			return; // Can't rebase without fetch
+		}
+
+		try {
+			const { stdout } = await execFile("git", ["symbolic-ref", "refs/remotes/origin/HEAD"], { cwd: wt });
+			const primary = stdout.trim().replace("refs/remotes/origin/", "");
+			await execFile("git", ["rebase", `origin/${primary}`], { cwd: wt, timeout: 60_000 });
+		} catch (err) {
+			console.warn(`[staff-manager] git rebase failed in ${wt} (non-fatal):`, err);
+			// Abort any in-progress rebase to leave worktree in a usable state
+			try { await execFile("git", ["rebase", "--abort"], { cwd: wt }); } catch { /* ignore */ }
+		}
+
+		// Run worktree setup command (e.g. npm ci)
+		const setupCmd = ctx?.projectConfigStore.get("worktree_setup_command") as string | undefined;
+		if (setupCmd) {
+			await setupWorktreeDeps(staff.cwd, wt, setupCmd);
+		}
+	}
+
+	/**
 	 * Wake a staff agent: enqueue a prompt on its permanent session.
 	 * If the session doesn't exist yet (legacy migration), create one first.
 	 * If the session subprocess is terminated, restore it before enqueuing.
@@ -240,6 +282,7 @@ export class StaffManager {
 				rolePrompt: fullPrompt,
 				env: { BOBBIT_STAFF_ID: staffId },
 				sandboxed: sessionManager.isSandboxEnabled,
+				sandboxBranch: sessionManager.isSandboxEnabled ? staff.branch : undefined,
 			});
 			session.staffId = staffId;
 			sessionManager.setTitle(session.id, staff.name);
@@ -264,6 +307,9 @@ export class StaffManager {
 				return this.wake(staffId, prompt, sessionManager);
 			}
 		}
+
+		// Refresh the worktree before waking (rebase + deps)
+		await this.refreshWorktree(staff, found.projectId);
 
 		// Enqueue the wake prompt on the existing session
 		await sessionManager.enqueuePrompt(staff.currentSessionId, wakePrompt);

--- a/src/server/agent/staff-manager.ts
+++ b/src/server/agent/staff-manager.ts
@@ -238,9 +238,13 @@ export class StaffManager {
 		}
 
 		try {
-			const { stdout } = await execFile("git", ["symbolic-ref", "refs/remotes/origin/HEAD"], { cwd: wt });
+			const { stdout } = await execFile("git", ["symbolic-ref", "refs/remotes/origin/HEAD"], { cwd: wt, timeout: 5_000 });
 			const primary = stdout.trim().replace("refs/remotes/origin/", "");
-			await execFile("git", ["rebase", `origin/${primary}`], { cwd: wt, timeout: 60_000 });
+			if (!primary || primary.startsWith("-")) {
+				console.warn(`[staff-manager] Could not detect primary branch in ${wt} (got "${primary}"), skipping rebase`);
+			} else {
+				await execFile("git", ["rebase", `origin/${primary}`], { cwd: wt, timeout: 60_000 });
+			}
 		} catch (err) {
 			console.warn(`[staff-manager] git rebase failed in ${wt} (non-fatal):`, err);
 			// Abort any in-progress rebase to leave worktree in a usable state
@@ -248,7 +252,7 @@ export class StaffManager {
 		}
 
 		// Run worktree setup command (e.g. npm ci)
-		const setupCmd = ctx?.projectConfigStore.get("worktree_setup_command") as string | undefined;
+		const setupCmd = ctx?.projectConfigStore.get("worktree_setup_command");
 		if (setupCmd) {
 			await setupWorktreeDeps(staff.cwd, wt, setupCmd);
 		}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5847,8 +5847,7 @@ async function handleApiRoute(
 	if (url.pathname === "/api/staff" && req.method === "GET") {
 		const projectId = url.searchParams.get("projectId") || undefined;
 		const list = staffManager.listStaff(projectId).map(s => {
-			const ctx = projectContextManager.getOrCreate(s.projectId!);
-			const sandboxed = ctx?.projectConfigStore.get("sandbox") === "docker";
+			const sandboxed = s.projectId ? (projectContextManager.getOrCreate(s.projectId)?.projectConfigStore.get("sandbox") === "docker") : false;
 			return { ...s, sandboxed };
 		});
 		json({ staff: list });
@@ -5898,8 +5897,7 @@ async function handleApiRoute(
 		if (req.method === "GET") {
 			const staff = staffManager.getStaff(id);
 			if (!staff) { json({ error: "Staff agent not found" }, 404); return; }
-			const ctx = projectContextManager.getOrCreate(staff.projectId!);
-			const sandboxed = ctx?.projectConfigStore.get("sandbox") === "docker";
+			const sandboxed = staff.projectId ? (projectContextManager.getOrCreate(staff.projectId)?.projectConfigStore.get("sandbox") === "docker") : false;
 			json({ ...staff, sandboxed });
 			return;
 		}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5846,7 +5846,12 @@ async function handleApiRoute(
 	// GET /api/staff
 	if (url.pathname === "/api/staff" && req.method === "GET") {
 		const projectId = url.searchParams.get("projectId") || undefined;
-		json({ staff: staffManager.listStaff(projectId) });
+		const list = staffManager.listStaff(projectId).map(s => {
+			const ctx = projectContextManager.getOrCreate(s.projectId!);
+			const sandboxed = ctx?.projectConfigStore.get("sandbox") === "docker";
+			return { ...s, sandboxed };
+		});
+		json({ staff: list });
 		return;
 	}
 
@@ -5893,7 +5898,9 @@ async function handleApiRoute(
 		if (req.method === "GET") {
 			const staff = staffManager.getStaff(id);
 			if (!staff) { json({ error: "Staff agent not found" }, 404); return; }
-			json(staff);
+			const ctx = projectContextManager.getOrCreate(staff.projectId!);
+			const sandboxed = ctx?.projectConfigStore.get("sandbox") === "docker";
+			json({ ...staff, sandboxed });
 			return;
 		}
 

--- a/src/server/skills/git.ts
+++ b/src/server/skills/git.ts
@@ -206,7 +206,7 @@ export async function createWorktree(repoPath: string, branchName: string, opts?
  * prerequisite for Bobbit, Git Bash is always available.
  * The SOURCE_REPO env var is set to the original repo path.
  */
-async function setupWorktreeDeps(repoPath: string, worktreePath: string, setupCommand: string): Promise<void> {
+export async function setupWorktreeDeps(repoPath: string, worktreePath: string, setupCommand: string): Promise<void> {
 	if (!setupCommand) return;
 	try {
 		console.log(`[git] Running worktree setup command: ${setupCommand}`);

--- a/tests/e2e/staff.spec.ts
+++ b/tests/e2e/staff.spec.ts
@@ -342,4 +342,68 @@ test.describe("Staff Agents — REST API", () => {
 		});
 		expect(wakeRes.status).toBe(400);
 	});
+
+	test("GET /api/staff/:id includes sandboxed field", async () => {
+		const res = await apiFetch(`/api/staff/${sharedStaff.id}`, {});
+		expect(res.ok).toBe(true);
+		const staff = await res.json();
+		expect(typeof staff.sandboxed).toBe("boolean");
+		// Test environment has no Docker — sandboxed should be false
+		expect(staff.sandboxed).toBe(false);
+	});
+
+	test("GET /api/staff list includes sandboxed field on each item", async () => {
+		const res = await apiFetch(`/api/staff`, {});
+		expect(res.ok).toBe(true);
+		const data = await res.json();
+		expect(Array.isArray(data.staff)).toBe(true);
+		for (const s of data.staff) {
+			expect(typeof s.sandboxed).toBe("boolean");
+		}
+	});
+
+	test("POST /api/staff/:id/wake refreshes worktree from primary branch", async () => {
+		// Get staff details to find worktreePath
+		const getRes = await apiFetch(`/api/staff/${sharedStaff.id}`, {});
+		const staff = await getRes.json();
+		const worktreePath = staff.worktreePath;
+		if (!worktreePath) {
+			console.warn("No worktreePath on shared staff — skipping refresh test");
+			return;
+		}
+
+		const { execFileSync } = await import("node:child_process");
+		const fs = await import("node:fs");
+		const path = await import("node:path");
+
+		// Set up origin pointing to the test repo itself so git fetch/rebase work
+		try {
+			execFileSync("git", ["remote", "add", "origin", gitCwd()], { cwd: gitCwd(), stdio: "pipe" });
+		} catch { /* already exists */ }
+		execFileSync("git", ["fetch", "origin"], { cwd: gitCwd(), stdio: "pipe" });
+
+		// Detect primary branch name and set symbolic ref
+		const primaryBranch = execFileSync("git", ["branch", "--show-current"], { cwd: gitCwd(), encoding: "utf-8" }).trim();
+		execFileSync("git", ["symbolic-ref", "refs/remotes/origin/HEAD", `refs/remotes/origin/${primaryBranch}`], { cwd: gitCwd(), stdio: "pipe" });
+
+		// Create a unique marker commit on the test repo's primary branch
+		const marker = `wake-refresh-${Date.now()}`;
+		fs.writeFileSync(path.join(gitCwd(), `${marker}.txt`), marker);
+		execFileSync("git", ["add", `${marker}.txt`], { cwd: gitCwd(), stdio: "pipe" });
+		execFileSync("git", ["commit", "-m", `test: ${marker}`], { cwd: gitCwd(), stdio: "pipe" });
+
+		// Wake the staff agent — triggers refreshWorktree (fetch + rebase onto primary)
+		const wakeRes = await apiFetch(`/api/staff/${sharedStaff.id}/wake`, {
+			method: "POST",
+			body: JSON.stringify({ prompt: "refresh test" }),
+		});
+		expect(wakeRes.status).toBe(201);
+
+		// Wait for the async refreshWorktree to complete
+		await new Promise((r) => setTimeout(r, 5_000));
+
+		// Verify the marker commit is now in the worktree's log
+		const log = execFileSync("git", ["log", "--oneline", "-5"], { cwd: worktreePath, encoding: "utf-8" });
+		expect(log).toContain(marker);
+	});
 });


### PR DESCRIPTION
Fixes three related bugs in staff agent wake cycle:

## Bug 1: Staff wake reuses stale worktree
Staff worktrees are now rebased onto the primary branch and the project's `worktree_setup_command` is re-run on each wake cycle. New `refreshWorktree()` method in `StaffManager` with proper timeout guards and rebase abort on failure. Skipped for sandboxed staff.

## Bug 2: Staff agent can't use tools in sandbox
`createStaff()` and wake legacy migration now pass `sandboxBranch` to `createSession()` when sandbox is enabled, so `applySandboxWiring` properly creates container-internal worktrees.

## Bug 3: No sandbox toggle in propose_staff form
Staff API (`GET /api/staff`, `GET /api/staff/:id`) now returns a `sandboxed` boolean derived from project config. The staff edit page shows a read-only sandbox indicator badge with "Inherited from project settings" helper text.

## Additional improvements
- Exported `setupWorktreeDeps` from `git.ts`
- Added timeout and guard to `git symbolic-ref` call
- Replaced `projectId!` non-null assertions with safe ternary checks
- Added 3 new E2E tests covering sandboxed field and wake worktree refresh

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)