### PR TITLE
Gate Inspect Renderer

### DIFF
--- a/src/ui/tools/index.ts
+++ b/src/ui/tools/index.ts
@@ -22,6 +22,7 @@ import { WriteRenderer } from "./renderers/WriteRenderer.js";
 import { TeamSpawnRenderer, TeamListRenderer, TeamDismissRenderer, TeamCompleteRenderer, TeamSteerRenderer, TeamPromptRenderer, TeamAbortRenderer } from "./renderers/TeamToolRenderers.js";
 import { TaskListRenderer, TaskCreateRenderer, TaskUpdateRenderer } from "./renderers/TaskToolRenderers.js";
 import { GateListRenderer, GateSignalRenderer, GateStatusRenderer } from "./renderers/GateToolRenderers.js";
+import { GateInspectRenderer } from "./renderers/GateInspectRenderer.js";
 import "./renderers/GateVerificationLive.js"; // registers <gate-verification-live> custom element
 import { BgProcessRenderer } from "./renderers/BgProcessRenderer.js";
 import { PersonalitiesListRenderer, PersonalitiesCreateRenderer } from "./renderers/PersonalityToolRenderers.js";
@@ -66,6 +67,7 @@ registerToolRenderer("personalities_create", new PersonalitiesCreateRenderer());
 registerToolRenderer("gate_list", new GateListRenderer());
 registerToolRenderer("gate_signal", new GateSignalRenderer());
 registerToolRenderer("gate_status", new GateStatusRenderer());
+registerToolRenderer("gate_inspect", new GateInspectRenderer());
 registerToolRenderer("preview_open", new PreviewOpenRenderer());
 registerToolRenderer("review_open", new ReviewOpenRenderer());
 registerToolRenderer("review_close", new ReviewCloseRenderer());

--- a/src/ui/tools/renderers/GateInspectRenderer.ts
+++ b/src/ui/tools/renderers/GateInspectRenderer.ts
@@ -1,0 +1,210 @@
+/**
+ * Renderer for the gate_inspect tool.
+ * Handles three section types: content, verification, signals.
+ */
+import type { ToolResultMessage } from "@mariozechner/pi-ai";
+import { html, nothing, type TemplateResult } from "lit";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import { createRef, ref } from "lit/directives/ref.js";
+import { ShieldCheck } from "lucide";
+import "@mariozechner/mini-lit/dist/MarkdownBlock.js";
+import { renderCollapsibleHeader, renderHeader, getToolState, isSkippedToolResult } from "../renderer-registry.js";
+import type { ToolRenderer, ToolRenderResult } from "../types.js";
+import { getResult, gateBadge } from "./GateToolRenderers.js";
+import { ansiToHtml, hasAnsi } from "../../utils/ansi.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function formatDuration(ms: number): string {
+	if (ms >= 60000) return `${(ms / 60000).toFixed(1)}m`;
+	return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function stepStatusIcon(status: string): TemplateResult {
+	if (status === "passed") return html`<span class="text-green-600 dark:text-green-400">✓</span>`;
+	if (status === "failed") return html`<span class="text-red-600 dark:text-red-400">✗</span>`;
+	if (status === "skipped") return html`<span class="text-muted-foreground">⊘</span>`;
+	return html`<span class="text-blue-600 dark:text-blue-400">●</span>`;
+}
+
+function deriveStepStatus(step: any): string {
+	if (step.skipped) return "skipped";
+	if (step.passed === true) return "passed";
+	if (step.passed === false) return "failed";
+	return "running";
+}
+
+// ── Renderer ─────────────────────────────────────────────────────────
+
+export class GateInspectRenderer implements ToolRenderer {
+	/** Track expanded steps per render via a WeakMap keyed on the result object */
+	private _expandedSets = new WeakMap<object, Set<number>>();
+
+	render(params: any, result: ToolResultMessage | undefined, isStreaming?: boolean): ToolRenderResult {
+		const state = getToolState(result, isStreaming);
+		const gateId = params?.gate_id || "gate";
+
+		// Loading state
+		if (!result) {
+			return {
+				content: html`<div>${renderHeader(state, ShieldCheck, html`Inspecting gate <span class="font-mono">${gateId}</span>…`)}</div>`,
+				isCustom: false,
+			};
+		}
+
+		// Error/skipped state
+		const { data, text } = getResult(result);
+		if (result.isError) {
+			const skipped = isSkippedToolResult(result);
+			return {
+				content: html`<div>
+					${renderHeader(state, ShieldCheck, skipped
+						? html`Aborted inspect of gate <span class="font-mono">${gateId}</span>`
+						: html`Failed to inspect gate <span class="font-mono">${gateId}</span>`)}
+					<div class="mt-1 text-xs ${skipped ? "text-amber-600 dark:text-amber-400" : "text-destructive"}">${text}</div>
+				</div>`,
+				isCustom: false,
+			};
+		}
+
+		const section = data?.section || params?.section || "content";
+
+		switch (section) {
+			case "content": return this._renderContent(state, gateId, data);
+			case "verification": return this._renderVerification(state, gateId, data, result);
+			case "signals": return this._renderSignals(state, gateId, data);
+			default: return this._renderContent(state, gateId, data);
+		}
+	}
+
+	// ── section="content" ────────────────────────────────────────────
+
+	private _renderContent(state: any, gateId: string, data: any): ToolRenderResult {
+		const signalIndex = data?.signalIndex ?? "?";
+		const signalId = data?.signalId || "";
+		const content = data?.text;
+
+		return {
+			content: html`<div>
+				${renderHeader(state, ShieldCheck, html`Inspect gate <span class="font-mono">${gateId}</span> — content`)}
+				<div class="text-xs text-muted-foreground mt-1">Signal #${signalIndex}${signalId ? html` · ${signalId}` : nothing}</div>
+				${content
+					? html`<div class="mt-2 text-xs bg-muted/50 rounded p-3 border border-border max-h-[400px] overflow-y-auto"><markdown-block .content=${content}></markdown-block></div>`
+					: html`<div class="mt-2 text-xs text-muted-foreground italic">No content</div>`
+				}
+			</div>`,
+			isCustom: false,
+		};
+	}
+
+	// ── section="verification" ───────────────────────────────────────
+
+	private _renderVerification(state: any, gateId: string, data: any, result: ToolResultMessage): ToolRenderResult {
+		const signalIndex = data?.signalIndex ?? "?";
+		const signalId = data?.signalId || "";
+		const steps: any[] = data?.steps || [];
+
+		// Track expanded state — initialize with failed steps expanded
+		let expandedSet = this._expandedSets.get(result);
+		if (!expandedSet) {
+			expandedSet = new Set<number>();
+			steps.forEach((step: any, i: number) => {
+				if (deriveStepStatus(step) === "failed") expandedSet!.add(i);
+			});
+			this._expandedSets.set(result, expandedSet);
+		}
+
+		const toggleStep = (idx: number) => {
+			if (expandedSet!.has(idx)) expandedSet!.delete(idx);
+			else expandedSet!.add(idx);
+			// Force re-render by dispatching on the container
+			const event = new CustomEvent("gate-inspect-toggle", { bubbles: true });
+			document.dispatchEvent(event);
+		};
+
+		return {
+			content: html`<div>
+				${renderHeader(state, ShieldCheck, html`Inspect gate <span class="font-mono">${gateId}</span> — verification`)}
+				<div class="text-xs text-muted-foreground mt-1">Signal #${signalIndex}${signalId ? html` · ${signalId}` : nothing}</div>
+				<div class="mt-2 space-y-1">
+					${steps.map((step: any, i: number) => {
+						const status = deriveStepStatus(step);
+						const hasOutput = !!step.output;
+						const isExpanded = expandedSet!.has(i);
+						const typeBadgeCls = step.type === "command"
+							? "bg-muted text-muted-foreground"
+							: "bg-purple-500/20 text-purple-600 dark:text-purple-400";
+
+						return html`
+							<div class="border border-border rounded text-sm">
+								<div
+									class="p-2 flex items-center gap-2 ${hasOutput ? "cursor-pointer hover:bg-accent/50" : ""}"
+									@click=${hasOutput ? () => toggleStep(i) : null}
+								>
+									${stepStatusIcon(status)}
+									<span class="font-mono text-xs flex-1 min-w-0 truncate">${step.name}</span>
+									<span class="px-1.5 py-0.5 rounded text-[10px] font-medium ${typeBadgeCls}">${step.type}</span>
+									${step.duration_ms != null ? html`<span class="text-xs text-muted-foreground tabular-nums">${formatDuration(step.duration_ms)}</span>` : nothing}
+									${hasOutput ? html`<span class="text-muted-foreground text-[10px] shrink-0">${isExpanded ? "▴" : "▾"}</span>` : nothing}
+								</div>
+								${isExpanded && step.output ? (
+									step.type !== "command"
+										? html`<div class="text-xs text-muted-foreground max-h-[300px] overflow-y-auto bg-muted/50 rounded-b p-2 border-t border-border"><markdown-block .content=${step.output}></markdown-block></div>`
+										: html`<pre class="text-xs text-muted-foreground whitespace-pre-wrap max-h-[300px] overflow-y-auto bg-muted/50 rounded-b p-2 border-t border-border">${hasAnsi(step.output) ? unsafeHTML(ansiToHtml(step.output)) : step.output}</pre>`
+								) : nothing}
+							</div>
+						`;
+					})}
+				</div>
+			</div>`,
+			isCustom: false,
+		};
+	}
+
+	// ── section="signals" ────────────────────────────────────────────
+
+	private _renderSignals(state: any, gateId: string, data: any): ToolRenderResult {
+		const signals: any[] = data?.signals || [];
+		const count = signals.length;
+
+		const formatTime = (ts: string) => {
+			try { return new Date(ts).toLocaleString(); } catch { return ts; }
+		};
+
+		const rows = html`
+			<div class="mt-2 space-y-0.5">
+				${signals.map((s: any) => html`
+					<div class="flex items-center gap-2 text-xs py-0.5">
+						<span class="text-muted-foreground">#${s.index}</span>
+						${gateBadge(s.status)}
+						<span class="text-muted-foreground">${formatTime(s.signalledAt)}</span>
+						${s.hasContent ? html`<span title="Has content">📄</span>` : nothing}
+						${s.sessionId ? html`<span class="font-mono text-muted-foreground">${s.sessionId.slice(0, 8)}</span>` : nothing}
+					</div>
+				`)}
+			</div>
+		`;
+
+		if (count > 5) {
+			const contentRef = createRef<HTMLDivElement>();
+			const chevronRef = createRef<HTMLSpanElement>();
+			return {
+				content: html`<div>
+					${renderCollapsibleHeader(state, ShieldCheck, html`Inspect gate <span class="font-mono">${gateId}</span> — ${count} signals`, contentRef, chevronRef, false)}
+					<div ${ref(contentRef)} class="max-h-0 overflow-hidden transition-all duration-300">
+						${rows}
+					</div>
+				</div>`,
+				isCustom: false,
+			};
+		}
+
+		return {
+			content: html`<div>
+				${renderHeader(state, ShieldCheck, html`Inspect gate <span class="font-mono">${gateId}</span> — ${count} signal${count !== 1 ? "s" : ""}`)}
+				${rows}
+			</div>`,
+			isCustom: false,
+		};
+	}
+}

--- a/src/ui/tools/renderers/GateInspectRenderer.ts
+++ b/src/ui/tools/renderers/GateInspectRenderer.ts
@@ -37,9 +37,6 @@ function deriveStepStatus(step: any): string {
 // ── Renderer ─────────────────────────────────────────────────────────
 
 export class GateInspectRenderer implements ToolRenderer {
-	/** Track expanded steps per render via a WeakMap keyed on the result object */
-	private _expandedSets = new WeakMap<object, Set<number>>();
-
 	render(params: any, result: ToolResultMessage | undefined, isStreaming?: boolean): ToolRenderResult {
 		const state = getToolState(result, isStreaming);
 		const gateId = params?.gate_id || "gate";
@@ -99,27 +96,19 @@ export class GateInspectRenderer implements ToolRenderer {
 
 	// ── section="verification" ───────────────────────────────────────
 
-	private _renderVerification(state: any, gateId: string, data: any, result: ToolResultMessage): ToolRenderResult {
+	private _renderVerification(state: any, gateId: string, data: any, _result: ToolResultMessage): ToolRenderResult {
 		const signalIndex = data?.signalIndex ?? "?";
 		const signalId = data?.signalId || "";
 		const steps: any[] = data?.steps || [];
 
-		// Track expanded state — initialize with failed steps expanded
-		let expandedSet = this._expandedSets.get(result);
-		if (!expandedSet) {
-			expandedSet = new Set<number>();
-			steps.forEach((step: any, i: number) => {
-				if (deriveStepStatus(step) === "failed") expandedSet!.add(i);
-			});
-			this._expandedSets.set(result, expandedSet);
-		}
-
-		const toggleStep = (idx: number) => {
-			if (expandedSet!.has(idx)) expandedSet!.delete(idx);
-			else expandedSet!.add(idx);
-			// Force re-render by dispatching on the container
-			const event = new CustomEvent("gate-inspect-toggle", { bubbles: true });
-			document.dispatchEvent(event);
+		const toggleStep = (e: Event) => {
+			const card = (e.currentTarget as HTMLElement).parentElement!;
+			const output = card.querySelector('[data-step-output]') as HTMLElement;
+			const chevron = card.querySelector('[data-step-chevron]') as HTMLElement;
+			if (!output) return;
+			const isHidden = output.classList.contains('hidden');
+			output.classList.toggle('hidden');
+			if (chevron) chevron.textContent = isHidden ? '▴' : '▾';
 		};
 
 		return {
@@ -127,10 +116,10 @@ export class GateInspectRenderer implements ToolRenderer {
 				${renderHeader(state, ShieldCheck, html`Inspect gate <span class="font-mono">${gateId}</span> — verification`)}
 				<div class="text-xs text-muted-foreground mt-1">Signal #${signalIndex}${signalId ? html` · ${signalId}` : nothing}</div>
 				<div class="mt-2 space-y-1">
-					${steps.map((step: any, i: number) => {
+					${steps.map((step: any, _i: number) => {
 						const status = deriveStepStatus(step);
 						const hasOutput = !!step.output;
-						const isExpanded = expandedSet!.has(i);
+						const isFailed = status === "failed";
 						const typeBadgeCls = step.type === "command"
 							? "bg-muted text-muted-foreground"
 							: "bg-purple-500/20 text-purple-600 dark:text-purple-400";
@@ -139,18 +128,18 @@ export class GateInspectRenderer implements ToolRenderer {
 							<div class="border border-border rounded text-sm">
 								<div
 									class="p-2 flex items-center gap-2 ${hasOutput ? "cursor-pointer hover:bg-accent/50" : ""}"
-									@click=${hasOutput ? () => toggleStep(i) : null}
+									@click=${hasOutput ? toggleStep : null}
 								>
 									${stepStatusIcon(status)}
 									<span class="font-mono text-xs flex-1 min-w-0 truncate">${step.name}</span>
 									<span class="px-1.5 py-0.5 rounded text-[10px] font-medium ${typeBadgeCls}">${step.type}</span>
 									${step.duration_ms != null ? html`<span class="text-xs text-muted-foreground tabular-nums">${formatDuration(step.duration_ms)}</span>` : nothing}
-									${hasOutput ? html`<span class="text-muted-foreground text-[10px] shrink-0">${isExpanded ? "▴" : "▾"}</span>` : nothing}
+									${hasOutput ? html`<span data-step-chevron class="text-muted-foreground text-[10px] shrink-0">${isFailed ? "▴" : "▾"}</span>` : nothing}
 								</div>
-								${isExpanded && step.output ? (
+								${hasOutput ? (
 									step.type !== "command"
-										? html`<div class="text-xs text-muted-foreground max-h-[300px] overflow-y-auto bg-muted/50 rounded-b p-2 border-t border-border"><markdown-block .content=${step.output}></markdown-block></div>`
-										: html`<pre class="text-xs text-muted-foreground whitespace-pre-wrap max-h-[300px] overflow-y-auto bg-muted/50 rounded-b p-2 border-t border-border">${hasAnsi(step.output) ? unsafeHTML(ansiToHtml(step.output)) : step.output}</pre>`
+										? html`<div data-step-output class="${isFailed ? "" : "hidden"} text-xs text-muted-foreground max-h-[300px] overflow-y-auto bg-muted/50 rounded-b p-2 border-t border-border"><markdown-block .content=${step.output}></markdown-block></div>`
+										: html`<pre data-step-output class="${isFailed ? "" : "hidden"} text-xs text-muted-foreground whitespace-pre-wrap max-h-[300px] overflow-y-auto bg-muted/50 rounded-b p-2 border-t border-border">${hasAnsi(step.output) ? unsafeHTML(ansiToHtml(step.output)) : step.output}</pre>`
 								) : nothing}
 							</div>
 						`;
@@ -176,8 +165,8 @@ export class GateInspectRenderer implements ToolRenderer {
 				${signals.map((s: any) => html`
 					<div class="flex items-center gap-2 text-xs py-0.5">
 						<span class="text-muted-foreground">#${s.index}</span>
-						${gateBadge(s.status)}
-						<span class="text-muted-foreground">${formatTime(s.signalledAt)}</span>
+						${gateBadge(s.verdict)}
+						<span class="text-muted-foreground">${formatTime(s.timestamp)}</span>
 						${s.hasContent ? html`<span title="Has content">📄</span>` : nothing}
 						${s.sessionId ? html`<span class="font-mono text-muted-foreground">${s.sessionId.slice(0, 8)}</span>` : nothing}
 					</div>
@@ -190,7 +179,7 @@ export class GateInspectRenderer implements ToolRenderer {
 			const chevronRef = createRef<HTMLSpanElement>();
 			return {
 				content: html`<div>
-					${renderCollapsibleHeader(state, ShieldCheck, html`Inspect gate <span class="font-mono">${gateId}</span> — ${count} signals`, contentRef, chevronRef, false)}
+					${renderCollapsibleHeader(state, ShieldCheck, html`Inspect gate <span class="font-mono">${gateId}</span> — ${count} signal${count !== 1 ? "s" : ""}`, contentRef, chevronRef, false)}
 					<div ${ref(contentRef)} class="max-h-0 overflow-hidden transition-all duration-300">
 						${rows}
 					</div>

--- a/src/ui/tools/renderers/GateToolRenderers.ts
+++ b/src/ui/tools/renderers/GateToolRenderers.ts
@@ -11,14 +11,14 @@ import type { ToolRenderer, ToolRenderResult } from "../types.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-function getResult(result: ToolResultMessage | undefined): { text: string; data: any } {
+export function getResult(result: ToolResultMessage | undefined): { text: string; data: any } {
 	const text = result?.content?.filter((c: any) => c.type === "text").map((c: any) => c.text).join("\n") || "";
 	let data: any = null;
 	try { data = JSON.parse(text); } catch { /* not JSON */ }
 	return { text, data };
 }
 
-function gateBadge(status: string): TemplateResult {
+export function gateBadge(status: string): TemplateResult {
 	const styles: Record<string, string> = {
 		pending: "bg-muted text-muted-foreground",
 		passed: "bg-green-500/20 text-green-600 dark:text-green-400",

--- a/tests/e2e/ui/queue-ui.spec.ts
+++ b/tests/e2e/ui/queue-ui.spec.ts
@@ -243,6 +243,9 @@ test.describe("Queue UI E2E", () => {
 		await page.evaluate((id) => { window.location.hash = `#/session/${id}`; }, sessionId);
 		await expect(page.locator("textarea").first()).toBeVisible({ timeout: 15_000 });
 
+		// Wait for draft restore cycle to settle before asserting
+		await page.waitForTimeout(1_000);
+
 		// Verify textarea is empty — draft was cleared on send
 		await expect(page.locator("textarea").first()).toHaveValue("", { timeout: 10_000 });
 	});

--- a/tests/fixtures/gate-inspect-renderer.html
+++ b/tests/fixtures/gate-inspect-renderer.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>GateInspectRenderer Test Fixture</title>
+</head>
+<body>
+<div id="container"></div>
+<script>
+/**
+ * Test fixture for GateInspectRenderer logic.
+ *
+ * Mirrors the rendering decisions in GateInspectRenderer.ts:
+ * - getToolState() resolves to inprogress/complete/error/warning
+ * - Three section branches: content, verification, signals
+ * - Verification step expand/collapse via DOM-direct manipulation
+ * - Signal field names: verdict (not status), timestamp (not signalledAt)
+ * - Signal count pluralization
+ */
+
+function getToolState(result, isStreaming) {
+	if (!result) return isStreaming ? "inprogress" : "complete";
+	if (result.isError) {
+		const text = (result.content || []).filter(c => c.type === "text").map(c => c.text).join("");
+		if (text.includes("Skipped due to queued user message")) return "warning";
+		return "error";
+	}
+	return "complete";
+}
+
+function getResult(result) {
+	const text = (result && result.content || [])
+		.filter(c => c.type === "text")
+		.map(c => c.text)
+		.join("\n") || "";
+	let data = null;
+	try { data = JSON.parse(text); } catch(e) {}
+	return { text, data };
+}
+
+function isSkippedToolResult(result) {
+	if (!result || !result.isError) return false;
+	const text = (result.content || []).filter(c => c.type === "text").map(c => c.text).join("");
+	return text.includes("Skipped due to queued user message");
+}
+
+function deriveStepStatus(step) {
+	if (step.skipped) return "skipped";
+	if (step.passed === true) return "passed";
+	if (step.passed === false) return "failed";
+	return "running";
+}
+
+/**
+ * Mirrors GateInspectRenderer.render() — returns rendering decision metadata.
+ */
+function renderInspect(params, result, isStreaming) {
+	const state = getToolState(result, isStreaming);
+	const gateId = (params && params.gate_id) || "gate";
+
+	// Loading state
+	if (!result) {
+		return { branch: "loading", state, gateId };
+	}
+
+	// Error/skipped state
+	const { data, text } = getResult(result);
+	if (result.isError) {
+		const skipped = isSkippedToolResult(result);
+		return { branch: skipped ? "skipped" : "error", state, gateId, text };
+	}
+
+	const section = (data && data.section) || (params && params.section) || "content";
+	if (section === "content") return renderContent(state, gateId, data);
+	if (section === "verification") return renderVerification(state, gateId, data);
+	if (section === "signals") return renderSignals(state, gateId, data);
+	return renderContent(state, gateId, data);
+}
+
+function renderContent(state, gateId, data) {
+	const signalIndex = (data && data.signalIndex != null) ? data.signalIndex : "?";
+	const signalId = (data && data.signalId) || "";
+	const content = data && data.text;
+	return {
+		branch: "content",
+		state, gateId,
+		signalIndex, signalId,
+		hasContent: !!content,
+		contentText: content || null,
+	};
+}
+
+function renderVerification(state, gateId, data) {
+	const signalIndex = (data && data.signalIndex != null) ? data.signalIndex : "?";
+	const signalId = (data && data.signalId) || "";
+	const steps = (data && data.steps) || [];
+
+	const stepInfos = steps.map(function(step) {
+		const status = deriveStepStatus(step);
+		const isFailed = status === "failed";
+		return {
+			name: step.name,
+			type: step.type,
+			status: status,
+			hasOutput: !!step.output,
+			isFailed: isFailed,
+			startsExpanded: isFailed,
+			durationMs: step.duration_ms,
+		};
+	});
+
+	return {
+		branch: "verification",
+		state, gateId,
+		signalIndex, signalId,
+		stepCount: steps.length,
+		steps: stepInfos,
+	};
+}
+
+function renderSignals(state, gateId, data) {
+	const signals = (data && data.signals) || [];
+	const count = signals.length;
+	const pluralized = count + " signal" + (count !== 1 ? "s" : "");
+	const isCollapsible = count > 5;
+
+	// Mirror the field names used in the renderer
+	const rows = signals.map(function(s) {
+		return {
+			index: s.index,
+			// BUG FIX verification: these must use `verdict` and `timestamp`
+			verdict: s.verdict,
+			timestamp: s.timestamp,
+			hasContent: !!s.hasContent,
+			sessionId: s.sessionId ? s.sessionId.slice(0, 8) : null,
+		};
+	});
+
+	return {
+		branch: "signals",
+		state, gateId,
+		count: count,
+		pluralized: pluralized,
+		isCollapsible: isCollapsible,
+		rows: rows,
+	};
+}
+
+/**
+ * Build a live DOM for verification steps to test expand/collapse behavior.
+ * Mirrors the DOM structure from GateInspectRenderer._renderVerification().
+ */
+function buildVerificationDOM(steps) {
+	const container = document.getElementById("container");
+	container.innerHTML = "";
+	const wrapper = document.createElement("div");
+
+	steps.forEach(function(step) {
+		const status = deriveStepStatus(step);
+		const isFailed = status === "failed";
+		const hasOutput = !!step.output;
+
+		const card = document.createElement("div");
+		card.className = "border border-border rounded text-sm";
+
+		const header = document.createElement("div");
+		header.className = "p-2 flex items-center gap-2" + (hasOutput ? " cursor-pointer" : "");
+
+		const nameSpan = document.createElement("span");
+		nameSpan.textContent = step.name;
+		header.appendChild(nameSpan);
+
+		if (hasOutput) {
+			const chevron = document.createElement("span");
+			chevron.setAttribute("data-step-chevron", "");
+			chevron.textContent = isFailed ? "▴" : "▾";
+			header.appendChild(chevron);
+
+			header.addEventListener("click", function(e) {
+				var parentCard = e.currentTarget.parentElement;
+				var output = parentCard.querySelector("[data-step-output]");
+				var chev = parentCard.querySelector("[data-step-chevron]");
+				if (!output) return;
+				var isHidden = output.classList.contains("hidden");
+				output.classList.toggle("hidden");
+				if (chev) chev.textContent = isHidden ? "▴" : "▾";
+			});
+		}
+
+		card.appendChild(header);
+
+		if (hasOutput) {
+			const output = document.createElement("pre");
+			output.setAttribute("data-step-output", "");
+			output.className = (isFailed ? "" : "hidden") + " text-xs";
+			output.textContent = step.output;
+			card.appendChild(output);
+		}
+
+		wrapper.appendChild(card);
+	});
+
+	container.appendChild(wrapper);
+	return wrapper;
+}
+
+// Expose
+window.renderInspect = renderInspect;
+window.buildVerificationDOM = buildVerificationDOM;
+window._testReady = true;
+</script>
+</body>
+</html>

--- a/tests/gate-inspect-renderer.spec.ts
+++ b/tests/gate-inspect-renderer.spec.ts
@@ -1,0 +1,313 @@
+/**
+ * Unit tests for GateInspectRenderer rendering logic.
+ *
+ * Tests rendering decisions, verification step expand/collapse (DOM-direct),
+ * signal field names (verdict/timestamp), and pluralization.
+ *
+ * Pattern: file:// fixture with window-exposed functions, evaluated in page context.
+ */
+import { test, expect } from "@playwright/test";
+import path from "node:path";
+
+const TEST_PAGE = `file://${path.resolve("tests/fixtures/gate-inspect-renderer.html")}`;
+
+test.describe("GateInspectRenderer", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(TEST_PAGE);
+		await page.waitForFunction(() => (window as any)._testReady === true);
+	});
+
+	// ── Loading / Error / Skipped states ─────────────────────────────
+
+	test("loading state shows inprogress when streaming", async ({ page }) => {
+		const result = await page.evaluate(() =>
+			(window as any).renderInspect({ gate_id: "design-doc" }, undefined, true),
+		);
+		expect(result.branch).toBe("loading");
+		expect(result.state).toBe("inprogress");
+		expect(result.gateId).toBe("design-doc");
+	});
+
+	test("error result shows error branch", async ({ page }) => {
+		const result = await page.evaluate(() =>
+			(window as any).renderInspect(
+				{ gate_id: "impl" },
+				{ isError: true, content: [{ type: "text", text: "Gate not found" }] },
+			),
+		);
+		expect(result.branch).toBe("error");
+		expect(result.text).toContain("Gate not found");
+	});
+
+	test("skipped result shows skipped branch", async ({ page }) => {
+		const result = await page.evaluate(() =>
+			(window as any).renderInspect(
+				{ gate_id: "impl" },
+				{ isError: true, content: [{ type: "text", text: "Skipped due to queued user message" }] },
+			),
+		);
+		expect(result.branch).toBe("skipped");
+	});
+
+	// ── section="content" ────────────────────────────────────────────
+
+	test("content section with text renders hasContent=true", async ({ page }) => {
+		const result = await page.evaluate(() =>
+			(window as any).renderInspect(
+				{ gate_id: "design-doc" },
+				{
+					isError: false,
+					content: [{ type: "text", text: JSON.stringify({ section: "content", signalIndex: 0, signalId: "sig-abc", text: "# Design\nHello" }) }],
+				},
+			),
+		);
+		expect(result.branch).toBe("content");
+		expect(result.signalIndex).toBe(0);
+		expect(result.signalId).toBe("sig-abc");
+		expect(result.hasContent).toBe(true);
+		expect(result.contentText).toBe("# Design\nHello");
+	});
+
+	test("content section with null text shows hasContent=false", async ({ page }) => {
+		const result = await page.evaluate(() =>
+			(window as any).renderInspect(
+				{ gate_id: "design-doc" },
+				{
+					isError: false,
+					content: [{ type: "text", text: JSON.stringify({ section: "content", signalIndex: 1, text: null }) }],
+				},
+			),
+		);
+		expect(result.branch).toBe("content");
+		expect(result.hasContent).toBe(false);
+	});
+
+	// ── section="verification" ───────────────────────────────────────
+
+	test("verification section derives step statuses correctly", async ({ page }) => {
+		const result = await page.evaluate(() =>
+			(window as any).renderInspect(
+				{ gate_id: "impl" },
+				{
+					isError: false,
+					content: [{
+						type: "text",
+						text: JSON.stringify({
+							section: "verification",
+							signalIndex: 0,
+							signalId: "sig-1",
+							steps: [
+								{ name: "typecheck", type: "command", passed: true, duration_ms: 5000, output: "OK" },
+								{ name: "test", type: "command", passed: false, duration_ms: 12000, output: "FAIL: 2 errors" },
+								{ name: "review", type: "agent", skipped: true },
+							],
+						}),
+					}],
+				},
+			),
+		);
+		expect(result.branch).toBe("verification");
+		expect(result.stepCount).toBe(3);
+		expect(result.steps[0].status).toBe("passed");
+		expect(result.steps[0].startsExpanded).toBe(false);
+		expect(result.steps[1].status).toBe("failed");
+		expect(result.steps[1].startsExpanded).toBe(true);
+		expect(result.steps[2].status).toBe("skipped");
+		expect(result.steps[2].hasOutput).toBe(false);
+	});
+
+	// ── Bug 1: Verification step expand/collapse (DOM-direct) ────────
+
+	test("failed steps start expanded, passed steps start collapsed", async ({ page }) => {
+		const states = await page.evaluate(() => {
+			const dom = (window as any).buildVerificationDOM([
+				{ name: "typecheck", passed: true, output: "all good" },
+				{ name: "test", passed: false, output: "FAIL: 2 errors" },
+				{ name: "lint", passed: true, output: "0 warnings" },
+			]);
+			const cards = dom.querySelectorAll(".border");
+			return Array.from(cards).map((card: any) => {
+				const output = card.querySelector("[data-step-output]");
+				const chevron = card.querySelector("[data-step-chevron]");
+				return {
+					name: card.querySelector("span").textContent,
+					outputHidden: output ? output.classList.contains("hidden") : null,
+					chevronText: chevron ? chevron.textContent : null,
+				};
+			});
+		});
+
+		// Passed step: collapsed (hidden class, ▾ chevron)
+		expect(states[0].outputHidden).toBe(true);
+		expect(states[0].chevronText).toBe("▾");
+
+		// Failed step: expanded (no hidden class, ▴ chevron)
+		expect(states[1].outputHidden).toBe(false);
+		expect(states[1].chevronText).toBe("▴");
+
+		// Passed step: collapsed
+		expect(states[2].outputHidden).toBe(true);
+		expect(states[2].chevronText).toBe("▾");
+	});
+
+	test("clicking a collapsed step expands it via DOM toggle", async ({ page }) => {
+		await page.evaluate(() => {
+			(window as any).buildVerificationDOM([
+				{ name: "typecheck", passed: true, output: "all good" },
+			]);
+		});
+
+		// Initially collapsed
+		const beforeClick = await page.evaluate(() => {
+			const card = document.querySelector("#container .border")!;
+			const output = card.querySelector("[data-step-output]") as HTMLElement;
+			return { hidden: output.classList.contains("hidden") };
+		});
+		expect(beforeClick.hidden).toBe(true);
+
+		// Click the header
+		await page.click("#container .border .cursor-pointer");
+
+		// Now expanded
+		const afterClick = await page.evaluate(() => {
+			const card = document.querySelector("#container .border")!;
+			const output = card.querySelector("[data-step-output]") as HTMLElement;
+			const chevron = card.querySelector("[data-step-chevron]") as HTMLElement;
+			return { hidden: output.classList.contains("hidden"), chevron: chevron.textContent };
+		});
+		expect(afterClick.hidden).toBe(false);
+		expect(afterClick.chevron).toBe("▴");
+	});
+
+	test("clicking an expanded step collapses it", async ({ page }) => {
+		await page.evaluate(() => {
+			(window as any).buildVerificationDOM([
+				{ name: "test", passed: false, output: "FAIL" },
+			]);
+		});
+
+		// Initially expanded (failed step)
+		await page.click("#container .border .cursor-pointer");
+
+		const afterClick = await page.evaluate(() => {
+			const card = document.querySelector("#container .border")!;
+			const output = card.querySelector("[data-step-output]") as HTMLElement;
+			const chevron = card.querySelector("[data-step-chevron]") as HTMLElement;
+			return { hidden: output.classList.contains("hidden"), chevron: chevron.textContent };
+		});
+		expect(afterClick.hidden).toBe(true);
+		expect(afterClick.chevron).toBe("▾");
+	});
+
+	// ── Bug 2: Signal field names ────────────────────────────────────
+
+	test("signals section uses verdict and timestamp fields", async ({ page }) => {
+		const result = await page.evaluate(() =>
+			(window as any).renderInspect(
+				{ gate_id: "impl" },
+				{
+					isError: false,
+					content: [{
+						type: "text",
+						text: JSON.stringify({
+							section: "signals",
+							signals: [
+								{ index: 0, verdict: "passed", timestamp: "2026-04-13T10:00:00Z", hasContent: true, sessionId: "abc12345-6789" },
+								{ index: 1, verdict: "failed", timestamp: "2026-04-13T11:00:00Z", hasContent: false, sessionId: "def98765-4321" },
+							],
+						}),
+					}],
+				},
+			),
+		);
+		expect(result.branch).toBe("signals");
+		expect(result.rows[0].verdict).toBe("passed");
+		expect(result.rows[0].timestamp).toBe("2026-04-13T10:00:00Z");
+		expect(result.rows[1].verdict).toBe("failed");
+		expect(result.rows[1].timestamp).toBe("2026-04-13T11:00:00Z");
+
+		// Verify the old field names are NOT present
+		expect(result.rows[0].status).toBeUndefined();
+		expect(result.rows[0].signalledAt).toBeUndefined();
+	});
+
+	test("signals row includes hasContent and truncated sessionId", async ({ page }) => {
+		const result = await page.evaluate(() =>
+			(window as any).renderInspect(
+				{ gate_id: "impl" },
+				{
+					isError: false,
+					content: [{
+						type: "text",
+						text: JSON.stringify({
+							section: "signals",
+							signals: [
+								{ index: 0, verdict: "passed", timestamp: "2026-04-13T10:00:00Z", hasContent: true, sessionId: "abc12345-6789-full-id" },
+							],
+						}),
+					}],
+				},
+			),
+		);
+		expect(result.rows[0].hasContent).toBe(true);
+		expect(result.rows[0].sessionId).toBe("abc12345");
+	});
+
+	// ── Bug 3: Pluralization ─────────────────────────────────────────
+
+	test("1 signal is singular", async ({ page }) => {
+		const result = await page.evaluate(() =>
+			(window as any).renderInspect(
+				{ gate_id: "impl" },
+				{
+					isError: false,
+					content: [{
+						type: "text",
+						text: JSON.stringify({
+							section: "signals",
+							signals: [{ index: 0, verdict: "passed", timestamp: "2026-04-13T10:00:00Z" }],
+						}),
+					}],
+				},
+			),
+		);
+		expect(result.pluralized).toBe("1 signal");
+		expect(result.isCollapsible).toBe(false);
+	});
+
+	test("0 signals is plural", async ({ page }) => {
+		const result = await page.evaluate(() =>
+			(window as any).renderInspect(
+				{ gate_id: "impl" },
+				{
+					isError: false,
+					content: [{
+						type: "text",
+						text: JSON.stringify({ section: "signals", signals: [] }),
+					}],
+				},
+			),
+		);
+		expect(result.pluralized).toBe("0 signals");
+	});
+
+	test("6 signals uses collapsible header with correct pluralization", async ({ page }) => {
+		const signals = Array.from({ length: 6 }, (_, i) => ({
+			index: i, verdict: "passed", timestamp: "2026-04-13T10:00:00Z",
+		}));
+		const result = await page.evaluate((sigs) =>
+			(window as any).renderInspect(
+				{ gate_id: "impl" },
+				{
+					isError: false,
+					content: [{
+						type: "text",
+						text: JSON.stringify({ section: "signals", signals: sigs }),
+					}],
+				},
+			),
+		signals);
+		expect(result.pluralized).toBe("6 signals");
+		expect(result.isCollapsible).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Add a custom `GateInspectRenderer` to replace raw JSON rendering for the `gate_inspect` tool. Handles all three section types with purpose-built UI matching the existing gate tool visual language.

### Changes

- **`src/ui/tools/renderers/GateInspectRenderer.ts`** (new) — Renders `content` (markdown), `verification` (step cards with expand/collapse), and `signals` (compact rows with verdict badges)
- **`src/ui/tools/renderers/GateToolRenderers.ts`** — Exported `getResult()` and `gateBadge()` helpers for reuse
- **`src/ui/tools/index.ts`** — Registered `gate_inspect` → `GateInspectRenderer`
- **`tests/gate-inspect-renderer.spec.ts`** + fixture — Unit tests covering all sections and states
- **`tests/e2e/ui/queue-ui.spec.ts`** — Stabilized pre-existing flaky draft clearing test

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)