### PR TITLE
Staff Sandbox Indicator

### DIFF
--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -1253,6 +1253,7 @@ function describeCron(cron: string): string {
 }
 
 function staffPreviewPanel() {
+	ensureSandboxStatusLoaded();
 	const handleCreateStaff = async () => {
 		const trimmedName = state.staffPreviewName.trim();
 		if (!trimmedName) return;
@@ -1333,6 +1334,16 @@ function staffPreviewPanel() {
 							state.staffPreviewCwdEdited = true;
 						},
 					})}
+				</div>
+				<div>
+					<label class="text-xs text-muted-foreground mb-1.5 block font-medium">Sandbox</label>
+					<div class="flex items-center gap-2">
+						${state.sandboxStatus?.configured
+							? html`<span class="px-2 py-0.5 text-xs rounded-full bg-cyan-500/15 text-cyan-700 dark:text-cyan-400">🐳 Docker Sandbox</span>`
+							: html`<span class="px-2 py-0.5 text-xs rounded-full bg-muted text-muted-foreground">No Sandbox</span>`
+						}
+					</div>
+					<p class="text-[10px] text-muted-foreground mt-1">Inherited from project settings</p>
 				</div>
 				<div>
 					<div class="flex items-center justify-between mb-1.5">


### PR DESCRIPTION
Adds a read-only sandbox indicator to the staff proposal form (right panel during staff assistant sessions).

## Changes
- **`src/app/render.ts`** — Added sandbox indicator to `staffPreviewPanel()` between the Working Directory and Triggers fields
  - Calls `ensureSandboxStatusLoaded()` to fetch sandbox status on demand
  - Shows 🐳 Docker Sandbox (cyan badge) or No Sandbox (muted badge) based on `state.sandboxStatus?.configured`
  - Includes "Inherited from project settings" footnote
  - Styling matches the existing staff edit page (`staff-page.ts:544-557`)

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)