### PR TITLE
ask_user_choices: visual polish + multi-select

### DIFF
--- a/defaults/tools/ask/ask_user_choices.yaml
+++ b/defaults/tools/ask/ask_user_choices.yaml
@@ -25,16 +25,32 @@ detail_docs: |
   ```
 
   - **questions**: 1–5 questions
-  - Each question has a **question** string, an **options** array (2–8 items), and an optional
-    **allow_other** boolean that adds an "Other" free-text choice.
+  - Each question has a **question** string, an **options** array (2–8 items), and these
+    optional fields:
+    - **allow_other** (boolean) — adds an "Other" free-text choice.
+    - **multi** (boolean) — allow multiple selections; `selected` is returned as an array.
+    - **min** / **max** (integers) — min/max selections when `multi` is true (defaults: 1 and options.length).
 
   ## Output
+
+  Single-select (default):
 
   ```json
   {
     "answers": [
       { "question": "...", "selected": "Grid",  "other_text": null },
       { "question": "...", "selected": "Other", "other_text": "user's typed text" }
+    ]
+  }
+  ```
+
+  Multi-select (`multi: true`) — `selected` is always an array; may contain "Other":
+
+  ```json
+  {
+    "answers": [
+      { "question": "...", "selected": ["Grid", "List"],        "other_text": null },
+      { "question": "...", "selected": ["List", "Other"],       "other_text": "user's typed text" }
     ]
   }
   ```

--- a/defaults/tools/ask/extension.ts
+++ b/defaults/tools/ask/extension.ts
@@ -84,6 +84,17 @@ export default function (pi: ExtensionAPI) {
 					allow_other: Type.Optional(Type.Boolean({
 						description: "If true, render an 'Other' option with a free-text input",
 					})),
+					multi: Type.Optional(Type.Boolean({
+						description: "If true, user may select multiple options; selected is returned as a string[].",
+					})),
+					min: Type.Optional(Type.Integer({
+						minimum: 1,
+						description: "Minimum selections when multi:true (default 1).",
+					})),
+					max: Type.Optional(Type.Integer({
+						minimum: 1,
+						description: "Maximum selections when multi:true (default = options.length).",
+					})),
 				}),
 				{ minItems: 1, maxItems: 5, description: "1–5 multiple-choice questions" },
 			),

--- a/docs/blocking-tools.md
+++ b/docs/blocking-tools.md
@@ -4,7 +4,7 @@ Some builtin tools need to pause the agent turn and wait for something the user 
 
 The canonical examples today are:
 
-- `ask_user_choices` — agent asks the user 1–5 multiple-choice questions via an inline widget; the widget POSTs answers.
+- `ask_user_choices` — agent asks the user 1–5 multiple-choice questions (single- or multi-select, with optional free-text "Other") via an inline widget; the widget POSTs answers.
 - `verification_result` — a reviewer/QA agent submits a verdict; the signal that originally triggered verification resolves with the result.
 
 This page uses `ask_user_choices` as the walkthrough. `verification_result` follows the same shape, just with a different UI surface and a different resolver target (a gate signal rather than a chat widget).
@@ -58,10 +58,12 @@ src/server/server.ts
   (session-termination listener calls userQuestionHarness.rejectAllForSession)
 
 src/ui/components/AskUserChoicesWidget.ts
-                                     Lit element <ask-user-choices-widget>. Renders tabs, auto-
-                                     advances on selection, Submit calls /submit. Listens for
-                                     the window event "user-question-answered" to finalize if
-                                     another client submits first.
+                                     Lit element <ask-user-choices-widget>. Renders tabs; auto-
+                                     advances on selection for single-select questions only
+                                     (multi-select questions require explicit tab navigation so
+                                     the user can tick several options). Submit calls /submit.
+                                     Listens for the window event "user-question-answered" to
+                                     finalize if another client submits first.
 
 src/ui/tools/renderers/AskUserChoicesRenderer.ts
                                      ToolRenderer that mounts the widget, feeds it params,

--- a/src/server/agent/user-question-harness.ts
+++ b/src/server/agent/user-question-harness.ts
@@ -15,13 +15,22 @@ export interface UserQuestion {
 	question: string;
 	options: string[];
 	allow_other?: boolean;
+	/** When true, the UI renders checkboxes and `selected` is an array. */
+	multi?: boolean;
+	/** Minimum number of selections when `multi`. Defaults to 1. */
+	min?: number;
+	/** Maximum number of selections when `multi`. Defaults to options.length (+1 if allow_other). */
+	max?: number;
 }
 
 export interface UserQuestionAnswer {
 	question: string;
-	/** Option text the user picked; "Other" when the user typed a free-text answer. */
-	selected: string;
-	/** Free-text content when `selected === "Other"`, otherwise null. */
+	/**
+	 * Single-select: option text the user picked; "Other" when free-text.
+	 * Multi-select: array of option texts (may include "Other").
+	 */
+	selected: string | string[];
+	/** Free-text content when "Other" was picked, otherwise null. */
 	other_text: string | null;
 }
 
@@ -63,12 +72,38 @@ export function validateQuestions(questions: unknown): string | null {
 		if (qq.allow_other !== undefined && typeof qq.allow_other !== "boolean") {
 			return `questions[${i}].allow_other must be a boolean if present`;
 		}
+		if (qq.multi !== undefined && typeof qq.multi !== "boolean") {
+			return `questions[${i}].multi must be a boolean if present`;
+		}
+		const maxOptionCount = qq.options.length + (qq.allow_other === true ? 1 : 0);
+		if (qq.min !== undefined) {
+			if (typeof qq.min !== "number" || !Number.isInteger(qq.min) || qq.min < 1) {
+				return `questions[${i}].min must be a positive integer if present`;
+			}
+			if (qq.min > maxOptionCount) {
+				return `questions[${i}].min (${qq.min}) exceeds the number of options (${maxOptionCount})`;
+			}
+		}
+		if (qq.max !== undefined) {
+			if (typeof qq.max !== "number" || !Number.isInteger(qq.max) || qq.max < 1) {
+				return `questions[${i}].max must be a positive integer if present`;
+			}
+			if (qq.max > maxOptionCount) {
+				return `questions[${i}].max (${qq.max}) exceeds the number of options (${maxOptionCount})`;
+			}
+		}
+		if (qq.min !== undefined && qq.max !== undefined && (qq.min as number) > (qq.max as number)) {
+			return `questions[${i}].min (${qq.min}) must be <= max (${qq.max})`;
+		}
+		// min/max only meaningful when multi:true — but we don't reject if
+		// they're set without multi; they're silently ignored.
 	}
 	return null;
 }
 
 /**
- * Validate the shape of `answers` submitted by the UI. Returns null on success.
+ * Validate the raw shape of `answers` submitted by the UI (no cross-check
+ * against questions — that happens inside submit()).
  */
 export function validateAnswers(answers: unknown): string | null {
 	if (!Array.isArray(answers)) return "answers must be an array";
@@ -77,13 +112,77 @@ export function validateAnswers(answers: unknown): string | null {
 		if (!a || typeof a !== "object") return `answers[${i}] must be an object`;
 		const aa = a as Record<string, unknown>;
 		if (typeof aa.question !== "string") return `answers[${i}].question must be a string`;
-		if (typeof aa.selected !== "string") return `answers[${i}].selected must be a string`;
+		if (typeof aa.selected !== "string" && !Array.isArray(aa.selected)) {
+			return `answers[${i}].selected must be a string or an array of strings`;
+		}
+		if (Array.isArray(aa.selected)) {
+			for (let j = 0; j < aa.selected.length; j++) {
+				if (typeof aa.selected[j] !== "string") {
+					return `answers[${i}].selected[${j}] must be a string`;
+				}
+			}
+		}
 		if (aa.other_text !== null && typeof aa.other_text !== "string") {
 			return `answers[${i}].other_text must be a string or null`;
 		}
 	}
 	return null;
 }
+
+/**
+ * Cross-check submitted answers against the registered question shape.
+ * Returns null on success, or a human-readable error message on failure.
+ */
+function crossValidate(
+	questions: UserQuestion[],
+	answers: UserQuestionAnswer[],
+): string | null {
+	if (answers.length !== questions.length) {
+		return `answers length (${answers.length}) does not match questions length (${questions.length})`;
+	}
+	for (let i = 0; i < questions.length; i++) {
+		const q = questions[i];
+		const a = answers[i];
+		const multi = q.multi === true;
+		const maxOptionCount = q.options.length + (q.allow_other === true ? 1 : 0);
+		const min = multi ? (q.min ?? 1) : 1;
+		const max = multi ? (q.max ?? maxOptionCount) : 1;
+		if (multi) {
+			if (!Array.isArray(a.selected)) {
+				return `answers[${i}].selected must be an array for multi-select question`;
+			}
+			if (a.selected.length < min) {
+				return `answers[${i}].selected has ${a.selected.length} items, minimum is ${min}`;
+			}
+			if (a.selected.length > max) {
+				return `answers[${i}].selected has ${a.selected.length} items, maximum is ${max}`;
+			}
+			const hasOther = a.selected.includes("Other");
+			if (hasOther && (a.other_text === null || a.other_text.trim() === "")) {
+				return `answers[${i}].other_text must be a non-empty string when "Other" is selected`;
+			}
+			if (!hasOther && a.other_text !== null) {
+				return `answers[${i}].other_text must be null when "Other" is not selected`;
+			}
+		} else {
+			if (typeof a.selected !== "string") {
+				return `answers[${i}].selected must be a string for single-select question`;
+			}
+			const isOther = a.selected === "Other";
+			if (isOther && (a.other_text === null || a.other_text.trim() === "")) {
+				return `answers[${i}].other_text must be a non-empty string when "Other" is selected`;
+			}
+			if (!isOther && a.other_text !== null) {
+				return `answers[${i}].other_text must be null when "Other" is not selected`;
+			}
+		}
+	}
+	return null;
+}
+
+export type SubmitResult =
+	| { ok: true }
+	| { ok: false; code: "not_found" | "invalid"; error: string };
 
 export class UserQuestionHarness {
 	/** keyed by `${sessionId}:${toolUseId}` — allows concurrent questions per session */
@@ -129,19 +228,21 @@ export class UserQuestionHarness {
 
 	/**
 	 * Resolve a pending question with the user's answers.
-	 * Returns true if a pending entry was found and resolved, false otherwise.
+	 * Cross-validates the answers against the registered question shape.
 	 */
 	submit(
 		sessionId: string,
 		toolUseId: string,
 		answers: UserQuestionAnswer[],
-	): boolean {
+	): SubmitResult {
 		const key = this.key(sessionId, toolUseId);
 		const p = this.pending.get(key);
-		if (!p) return false;
+		if (!p) return { ok: false, code: "not_found", error: "No pending question for this session/toolUseId" };
+		const crossErr = crossValidate(p.questions, answers);
+		if (crossErr) return { ok: false, code: "invalid", error: crossErr };
 		this.pending.delete(key);
 		p.resolve(answers);
-		return true;
+		return { ok: true };
 	}
 
 	/**

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -6218,8 +6218,12 @@ async function handleApiRoute(
 		}
 		const answerErr = validateAnswers(answers);
 		if (answerErr) { json({ error: answerErr }, 400); return; }
-		const ok = userQuestionHarness.submit(sessionId, toolUseId, answers);
-		if (!ok) { json({ error: "No pending question for this session/toolUseId" }, 404); return; }
+		const result = userQuestionHarness.submit(sessionId, toolUseId, answers);
+		if (!result.ok) {
+			const status = result.code === "not_found" ? 404 : 400;
+			json({ error: result.error }, status);
+			return;
+		}
 		if (broadcastToSession) {
 			broadcastToSession(sessionId, { type: "user_question_answered", sessionId, toolUseId, answers });
 		}

--- a/src/ui/components/AskUserChoicesWidget.ts
+++ b/src/ui/components/AskUserChoicesWidget.ts
@@ -2,10 +2,13 @@
  * Interactive widget rendered inline in the chat for the `ask_user_choices` tool.
  *
  * - Tabs across the top (one per question).
- * - Options render as radio-style cards.
- * - Selecting a non-"Other" option auto-advances to the next tab.
- * - "Other" (when enabled per question) reveals a text input; does NOT auto-advance.
- * - Submit is disabled until all questions have a valid selection.
+ * - Options render as radio/checkbox cards. The native input is visually hidden
+ *   (sr-only) and card styling (border-primary + a ✓ badge) signals selection.
+ * - Single-select: selecting a non-"Other" option auto-advances to the next tab.
+ * - Multi-select (`multi: true`): checkboxes; no auto-advance.
+ * - "Other" (when enabled) reveals a text input; does NOT auto-advance.
+ * - Submit is disabled until every question has a valid selection (respecting
+ *   min/max for multi-select).
  * - Once submitted (or `answers` prop is populated), the widget is read-only.
  */
 import { LitElement, html, nothing, type TemplateResult } from "lit";
@@ -29,16 +32,21 @@ export interface AskQuestion {
 	question: string;
 	options: string[];
 	allow_other?: boolean;
+	multi?: boolean;
+	min?: number;
+	max?: number;
 }
 
 export interface AskAnswer {
 	question: string;
-	selected: string;
+	/** string for single-select; string[] for multi-select. */
+	selected: string | string[];
 	other_text: string | null;
 }
 
 interface DraftEntry {
-	selected: string | null;
+	/** null (none), a single option (single-select), or an array (multi-select). */
+	selected: string | string[] | null;
 	other_text: string;
 }
 
@@ -82,7 +90,10 @@ export class AskUserChoicesWidget extends LitElement {
 	private _ensureDraft(): void {
 		if (!Array.isArray(this.questions)) return;
 		if (this._draft.length !== this.questions.length) {
-			this._draft = this.questions.map(() => ({ selected: null, other_text: "" }));
+			this._draft = this.questions.map((q) => ({
+				selected: q.multi ? [] : null,
+				other_text: "",
+			}));
 			this._activeTab = Math.min(this._activeTab, Math.max(0, this.questions.length - 1));
 		}
 	}
@@ -102,6 +113,19 @@ export class AskUserChoicesWidget extends LitElement {
 
 	private _selectOption(qIdx: number, option: string): void {
 		if (this._isReadOnly()) return;
+		const q = this.questions[qIdx];
+		if (q?.multi) {
+			this._draft = this._draft.map((d, i) => {
+				if (i !== qIdx) return d;
+				const cur = Array.isArray(d.selected) ? d.selected : [];
+				const next = cur.includes(option)
+					? cur.filter(x => x !== option)
+					: [...cur, option];
+				return { ...d, selected: next };
+			});
+			// No auto-advance for multi-select.
+			return;
+		}
 		this._draft = this._draft.map((d, i) => i === qIdx ? { ...d, selected: option } : d);
 		// Auto-advance unless "Other" was selected or this is the last question.
 		if (option !== OTHER_SENTINEL && qIdx < this.questions.length - 1) {
@@ -116,8 +140,18 @@ export class AskUserChoicesWidget extends LitElement {
 
 	private _canSubmit(): boolean {
 		if (this._draft.length !== this.questions.length) return false;
-		return this._draft.every((d) => {
-			if (!d.selected) return false;
+		return this._draft.every((d, i) => {
+			const q = this.questions[i];
+			if (q.multi) {
+				const arr = Array.isArray(d.selected) ? d.selected : [];
+				const maxOptionCount = q.options.length + (q.allow_other ? 1 : 0);
+				const min = q.min ?? 1;
+				const max = q.max ?? maxOptionCount;
+				if (arr.length < min || arr.length > max) return false;
+				if (arr.includes(OTHER_SENTINEL) && !d.other_text.trim()) return false;
+				return true;
+			}
+			if (!d.selected || Array.isArray(d.selected)) return false;
 			if (d.selected === OTHER_SENTINEL && !d.other_text.trim()) return false;
 			return true;
 		});
@@ -133,10 +167,19 @@ export class AskUserChoicesWidget extends LitElement {
 		this._submitError = "";
 		const answers: AskAnswer[] = this.questions.map((q, i) => {
 			const d = this._draft[i];
+			if (q.multi) {
+				const arr = (Array.isArray(d.selected) ? d.selected : []).map(v => v === OTHER_SENTINEL ? "Other" : v);
+				const hasOther = arr.includes("Other");
+				return {
+					question: q.question,
+					selected: arr,
+					other_text: hasOther ? d.other_text.trim() : null,
+				};
+			}
 			const isOther = d.selected === OTHER_SENTINEL;
 			return {
 				question: q.question,
-				selected: isOther ? "Other" : (d.selected || ""),
+				selected: isOther ? "Other" : (typeof d.selected === "string" ? d.selected : ""),
 				other_text: isOther ? d.other_text.trim() : null,
 			};
 		});
@@ -193,13 +236,19 @@ export class AskUserChoicesWidget extends LitElement {
 			</div>`;
 	}
 
+	private _tabAnswered(idx: number, readOnly: boolean): boolean {
+		if (readOnly) return Array.isArray(this.answers) && this.answers[idx] != null;
+		const d = this._draft[idx];
+		if (!d) return false;
+		if (Array.isArray(d.selected)) return d.selected.length > 0;
+		return !!d.selected;
+	}
+
 	private _renderTab(idx: number): TemplateResult {
 		const q = this.questions[idx];
 		const isActive = idx === this._activeTab;
 		const readOnly = this._isReadOnly();
-		const answered = readOnly
-			? Array.isArray(this.answers) && this.answers[idx] != null
-			: !!this._draft[idx]?.selected;
+		const answered = this._tabAnswered(idx, readOnly);
 		const label = (q?.question || `Q${idx + 1}`).slice(0, 40);
 		const cls = [
 			"ask-tab px-2 py-1 text-xs rounded-t cursor-pointer border border-b-0",
@@ -219,16 +268,35 @@ export class AskUserChoicesWidget extends LitElement {
 			</button>`;
 	}
 
+	private _isOptionChecked(qIdx: number, value: string, readOnly: boolean): boolean {
+		const q = this.questions[qIdx];
+		if (readOnly && Array.isArray(this.answers)) {
+			const a = this.answers[qIdx];
+			if (!a) return false;
+			if (Array.isArray(a.selected)) {
+				// Multi-select answer: "Other" round-trips as "Other" (not sentinel).
+				if (value === OTHER_SENTINEL) return a.selected.includes("Other");
+				return a.selected.includes(value);
+			}
+			const stored = a.selected === "Other" ? OTHER_SENTINEL : a.selected;
+			return stored === value;
+		}
+		const d = this._draft[qIdx];
+		if (!d) return false;
+		if (q?.multi) {
+			return Array.isArray(d.selected) && d.selected.includes(value);
+		}
+		return d.selected === value;
+	}
+
 	private _renderActivePanel(readOnly: boolean): TemplateResult | typeof nothing {
 		const idx = this._activeTab;
 		const q = this.questions[idx];
 		if (!q) return nothing;
 		const answer = readOnly && Array.isArray(this.answers) ? this.answers[idx] : null;
 		const draft = this._draft[idx] || { selected: null, other_text: "" };
-		const selected = readOnly && answer
-			? (answer.selected === "Other" ? OTHER_SENTINEL : answer.selected)
-			: draft.selected;
-		const otherText = readOnly && answer && answer.selected === "Other"
+		const otherChecked = this._isOptionChecked(idx, OTHER_SENTINEL, readOnly);
+		const otherText = readOnly && answer && otherChecked
 			? (answer.other_text || "")
 			: draft.other_text;
 
@@ -236,46 +304,76 @@ export class AskUserChoicesWidget extends LitElement {
 			<div role="tabpanel" data-panel-index=${idx} class="ask-panel">
 				<div class="ask-question text-sm font-medium mb-2">${q.question}</div>
 				<div class="ask-options flex flex-col gap-1.5">
-					${q.options.map(opt => this._renderOption(idx, opt, selected === opt, readOnly))}
-					${q.allow_other ? this._renderOtherOption(idx, selected === OTHER_SENTINEL, otherText, readOnly) : nothing}
+					${q.options.map(opt => this._renderOption(idx, opt, this._isOptionChecked(idx, opt, readOnly), readOnly))}
+					${q.allow_other ? this._renderOtherOption(idx, otherChecked, otherText, readOnly) : nothing}
 				</div>
 			</div>`;
 	}
 
 	private _renderOption(qIdx: number, option: string, checked: boolean, readOnly: boolean): TemplateResult {
+		const q = this.questions[qIdx];
+		const multi = !!q?.multi;
 		const cls = [
 			"ask-option flex items-center gap-2 p-2 text-sm rounded border",
 			checked ? "border-primary bg-primary/10" : "border-border",
 			readOnly ? "cursor-default opacity-90" : "cursor-pointer hover:bg-muted",
 		].join(" ");
-		return html`
-			<label class=${cls}>
-				<input
+		const inputAttrs = multi
+			? html`<input
+					type="checkbox"
+					class="sr-only"
+					value=${option}
+					.checked=${checked}
+					?disabled=${readOnly}
+					@change=${() => this._selectOption(qIdx, option)}>`
+			: html`<input
 					type="radio"
+					class="sr-only"
 					name=${`ask-q-${qIdx}-${this.toolUseId}`}
 					value=${option}
 					.checked=${checked}
 					?disabled=${readOnly}
-					@change=${() => this._selectOption(qIdx, option)}>
+					@change=${() => this._selectOption(qIdx, option)}>`;
+		return html`
+			<label class=${cls}>
+				${inputAttrs}
+				<span class="ask-option-check inline-flex items-center justify-center w-4 h-4 rounded-full border pointer-events-none ${checked ? "border-primary bg-primary text-primary-foreground" : "border-border text-transparent"}" aria-hidden="true">
+					${checked ? html`<span class="ask-check-glyph text-[10px] leading-none">✓</span>` : nothing}
+				</span>
 				<span class="ask-option-text">${option}</span>
 			</label>`;
 	}
 
 	private _renderOtherOption(qIdx: number, checked: boolean, otherText: string, readOnly: boolean): TemplateResult {
+		const q = this.questions[qIdx];
+		const multi = !!q?.multi;
 		const cls = [
 			"ask-option ask-option-other flex items-center gap-2 p-2 text-sm rounded border",
 			checked ? "border-primary bg-primary/10" : "border-border",
 			readOnly ? "cursor-default opacity-90" : "cursor-pointer hover:bg-muted",
 		].join(" ");
-		return html`
-			<label class=${cls}>
-				<input
+		const inputEl = multi
+			? html`<input
+					type="checkbox"
+					class="sr-only"
+					value=${OTHER_SENTINEL}
+					.checked=${checked}
+					?disabled=${readOnly}
+					@change=${() => this._selectOption(qIdx, OTHER_SENTINEL)}>`
+			: html`<input
 					type="radio"
+					class="sr-only"
 					name=${`ask-q-${qIdx}-${this.toolUseId}`}
 					value=${OTHER_SENTINEL}
 					.checked=${checked}
 					?disabled=${readOnly}
-					@change=${() => this._selectOption(qIdx, OTHER_SENTINEL)}>
+					@change=${() => this._selectOption(qIdx, OTHER_SENTINEL)}>`;
+		return html`
+			<label class=${cls}>
+				${inputEl}
+				<span class="ask-option-check inline-flex items-center justify-center w-4 h-4 rounded-full border pointer-events-none ${checked ? "border-primary bg-primary text-primary-foreground" : "border-border text-transparent"}" aria-hidden="true">
+					${checked ? html`<span class="ask-check-glyph text-[10px] leading-none">✓</span>` : nothing}
+				</span>
 				<span class="ask-option-text">Other</span>
 				${checked ? html`
 					<input

--- a/src/ui/tools/renderers/AskUserChoicesRenderer.ts
+++ b/src/ui/tools/renderers/AskUserChoicesRenderer.ts
@@ -25,7 +25,8 @@ function extractAnswers(result: ToolResultMessage | undefined): AskAnswer[] | nu
 			const valid = data.answers.every((a: any) =>
 				a && typeof a === "object" &&
 				typeof a.question === "string" &&
-				typeof a.selected === "string" &&
+				(typeof a.selected === "string"
+					|| (Array.isArray(a.selected) && a.selected.every((s: any) => typeof s === "string"))) &&
 				(a.other_text === null || typeof a.other_text === "string"));
 			return valid ? data.answers as AskAnswer[] : null;
 		}

--- a/tests/ask-user-choices-widget.html
+++ b/tests/ask-user-choices-widget.html
@@ -15,11 +15,25 @@
   .ask-option { display: flex; align-items: center; gap: 8px; padding: 8px; font-size: 14px; border: 1px solid #444; border-radius: 4px; cursor: pointer; }
   .ask-option.checked { border-color: #3b82f6; background: rgba(59,130,246,0.1); }
   .ask-option[data-disabled="true"] { cursor: default; opacity: 0.9; }
+  .ask-option-check { display: inline-flex; align-items: center; justify-content: center; width: 16px; height: 16px; border-radius: 50%; border: 1px solid #444; font-size: 10px; line-height: 1; color: transparent; pointer-events: none; }
+  .ask-option.checked .ask-option-check { border-color: #3b82f6; background: #3b82f6; color: #fff; }
   .ask-other-input { margin-left: 8px; flex: 1; padding: 4px 8px; font-size: 12px; border: 1px solid #444; border-radius: 4px; background: #1a1a2e; color: #eee; }
   .ask-submit { padding: 6px 12px; font-size: 12px; font-weight: 500; border-radius: 4px; background: #3b82f6; color: white; border: 0; cursor: pointer; }
   .ask-submit:disabled { opacity: 0.5; cursor: not-allowed; }
   .ask-submit-row { display: flex; align-items: center; gap: 8px; justify-content: flex-end; margin-top: 12px; }
   .ask-submit-error { color: #f87171; font-size: 12px; }
+  /* Tailwind-compatible sr-only (visually hidden but focusable/a11y). */
+  .sr-only {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
+  }
 </style>
 </head>
 <body>
@@ -49,7 +63,10 @@ class AskWidget {
     this.submitUrl = opts.submitUrl || "/api/internal/user-question/submit";
     this.submitFetch = opts.submitFetch || window.fetch.bind(window);
     this.activeTab = 0;
-    this.draft = this.questions.map(() => ({ selected: null, other_text: "" }));
+    this.draft = this.questions.map(q => ({
+      selected: q.multi ? [] : null,
+      other_text: "",
+    }));
     this.submitting = false;
     this.submitError = "";
     this.render();
@@ -59,8 +76,18 @@ class AskWidget {
 
   canSubmit() {
     if (this.draft.length !== this.questions.length) return false;
-    return this.draft.every(d => {
-      if (!d.selected) return false;
+    return this.draft.every((d, i) => {
+      const q = this.questions[i];
+      if (q.multi) {
+        const arr = Array.isArray(d.selected) ? d.selected : [];
+        const maxOptionCount = q.options.length + (q.allow_other ? 1 : 0);
+        const min = q.min != null ? q.min : 1;
+        const max = q.max != null ? q.max : maxOptionCount;
+        if (arr.length < min || arr.length > max) return false;
+        if (arr.includes(OTHER_SENTINEL) && !d.other_text.trim()) return false;
+        return true;
+      }
+      if (!d.selected || Array.isArray(d.selected)) return false;
       if (d.selected === OTHER_SENTINEL && !d.other_text.trim()) return false;
       return true;
     });
@@ -74,12 +101,19 @@ class AskWidget {
 
   selectOption(qIdx, option) {
     if (this.isReadOnly()) return;
+    const q = this.questions[qIdx];
+    if (q.multi) {
+      const cur = Array.isArray(this.draft[qIdx].selected) ? this.draft[qIdx].selected : [];
+      const next = cur.includes(option) ? cur.filter(x => x !== option) : [...cur, option];
+      this.draft[qIdx] = { ...this.draft[qIdx], selected: next };
+      // No auto-advance for multi.
+      setTimeout(() => this.render(), 0);
+      return;
+    }
     this.draft[qIdx] = { ...this.draft[qIdx], selected: option };
     if (option !== OTHER_SENTINEL && qIdx < this.questions.length - 1) {
       this.activeTab = qIdx + 1;
     }
-    // Defer re-render so the triggering event completes first — avoids
-    // detaching the DOM element mid-action for Playwright.
     setTimeout(() => this.render(), 0);
   }
 
@@ -96,6 +130,15 @@ class AskWidget {
     this.render();
     const answers = this.questions.map((q, i) => {
       const d = this.draft[i];
+      if (q.multi) {
+        const arr = (Array.isArray(d.selected) ? d.selected : []).map(v => v === OTHER_SENTINEL ? "Other" : v);
+        const hasOther = arr.includes("Other");
+        return {
+          question: q.question,
+          selected: arr,
+          other_text: hasOther ? d.other_text.trim() : null,
+        };
+      }
       const isOther = d.selected === OTHER_SENTINEL;
       return {
         question: q.question,
@@ -123,6 +166,24 @@ class AskWidget {
     }
   }
 
+  isOptionChecked(qIdx, value, readOnly) {
+    const q = this.questions[qIdx];
+    if (readOnly && Array.isArray(this.answers)) {
+      const a = this.answers[qIdx];
+      if (!a) return false;
+      if (Array.isArray(a.selected)) {
+        if (value === OTHER_SENTINEL) return a.selected.includes("Other");
+        return a.selected.includes(value);
+      }
+      const stored = a.selected === "Other" ? OTHER_SENTINEL : a.selected;
+      return stored === value;
+    }
+    const d = this.draft[qIdx];
+    if (!d) return false;
+    if (q.multi) return Array.isArray(d.selected) && d.selected.includes(value);
+    return d.selected === value;
+  }
+
   render() {
     const root = document.createElement("div");
     root.className = "ask-widget";
@@ -145,9 +206,13 @@ class AskWidget {
       btn.setAttribute("aria-selected", String(i === this.activeTab));
       btn.setAttribute("data-tab-index", String(i));
       btn.className = "ask-tab";
-      const answered = readOnly
-        ? Array.isArray(this.answers) && this.answers[i] != null
-        : !!this.draft[i].selected;
+      let answered;
+      if (readOnly) {
+        answered = Array.isArray(this.answers) && this.answers[i] != null;
+      } else {
+        const d = this.draft[i];
+        answered = Array.isArray(d.selected) ? d.selected.length > 0 : !!d.selected;
+      }
       btn.innerHTML = `<span>${i + 1}.</span> <span>${escapeHtml(q.question.slice(0, 40))}</span>${answered ? '<span class="ask-tab-check">✓</span>' : ""}`;
       btn.addEventListener("click", () => this.selectTab(i));
       tablist.appendChild(btn);
@@ -158,10 +223,8 @@ class AskWidget {
     const q = this.questions[this.activeTab];
     const answer = readOnly && Array.isArray(this.answers) ? this.answers[this.activeTab] : null;
     const draft = this.draft[this.activeTab];
-    const selected = readOnly && answer
-      ? (answer.selected === "Other" ? OTHER_SENTINEL : answer.selected)
-      : draft.selected;
-    const otherText = readOnly && answer && answer.selected === "Other"
+    const otherChecked = this.isOptionChecked(this.activeTab, OTHER_SENTINEL, readOnly);
+    const otherText = readOnly && answer && otherChecked
       ? (answer.other_text || "")
       : draft.other_text;
 
@@ -172,18 +235,21 @@ class AskWidget {
 
     const optsDiv = document.createElement("div");
     optsDiv.className = "ask-options";
+    const inputType = q.multi ? "checkbox" : "radio";
     const renderOpt = (value, label, isOther) => {
-      const checked = selected === value;
+      const checked = this.isOptionChecked(this.activeTab, value, readOnly);
       const lbl = document.createElement("label");
       lbl.className = "ask-option" + (checked ? " checked" : "") + (isOther ? " ask-option-other" : "");
       if (readOnly) lbl.setAttribute("data-disabled", "true");
+      const nameAttr = q.multi ? "" : ` name="q-${this.activeTab}"`;
       lbl.innerHTML = `
-        <input type="radio" name="q-${this.activeTab}" value="${escapeHtml(value)}" ${checked ? "checked" : ""} ${readOnly ? "disabled" : ""}>
+        <input type="${inputType}" class="sr-only"${nameAttr} value="${escapeHtml(value)}" ${checked ? "checked" : ""} ${readOnly ? "disabled" : ""}>
+        <span class="ask-option-check" aria-hidden="true">${checked ? "✓" : ""}</span>
         <span class="ask-option-text">${escapeHtml(label)}</span>
         ${isOther && checked ? `<input type="text" class="ask-other-input" value="${escapeHtml(otherText)}" ${readOnly ? "disabled" : ""}>` : ""}
       `;
-      const radio = lbl.querySelector("input[type=radio]");
-      radio.addEventListener("change", () => this.selectOption(this.activeTab, value));
+      const input = lbl.querySelector(`input[type=${inputType}]`);
+      input.addEventListener("change", () => this.selectOption(this.activeTab, value));
       const txt = lbl.querySelector("input[type=text]");
       if (txt) {
         txt.addEventListener("input", (e) => this.setOtherText(this.activeTab, e.target.value));

--- a/tests/ask-user-choices-widget.spec.ts
+++ b/tests/ask-user-choices-widget.spec.ts
@@ -46,7 +46,7 @@ test.describe("ask_user_choices widget", () => {
 			],
 		}));
 		// Click first option on tab 0.
-		await page.locator('[role="tabpanel"] input[type=radio]').first().check();
+		await page.locator('[role="tabpanel"] input[type=radio]').first().click({ force: true });
 		// Active tab should now be 1 (async re-render).
 		await expect(page.locator('[role="tab"][data-tab-index="1"]')).toHaveAttribute("aria-selected", "true");
 	});
@@ -76,10 +76,10 @@ test.describe("ask_user_choices widget", () => {
 		// Initially disabled
 		await expect(page.locator(".ask-submit")).toBeDisabled();
 		// Answer Q1 → auto-advance → still missing Q2 → disabled
-		await page.locator('[role="tabpanel"] input[type=radio][value="a"]').check();
+		await page.locator('[role="tabpanel"] input[type=radio][value="a"]').click({ force: true });
 		await expect(page.locator(".ask-submit")).toBeDisabled();
 		// Answer Q2 → enabled
-		await page.locator('[role="tabpanel"] input[type=radio][value="c"]').check();
+		await page.locator('[role="tabpanel"] input[type=radio][value="c"]').click({ force: true });
 		await expect(page.locator(".ask-submit")).toBeEnabled();
 	});
 
@@ -91,7 +91,7 @@ test.describe("ask_user_choices widget", () => {
 			],
 		}));
 		// Select Other on Q1
-		await page.locator('[role="tabpanel"] input[type=radio][value="__OTHER__"]').check();
+		await page.locator('[role="tabpanel"] input[type=radio][value="__OTHER__"]').click({ force: true });
 		// Active tab must still be 0
 		const active = await page.locator('[role="tab"][aria-selected="true"]').getAttribute("data-tab-index");
 		expect(active).toBe("0");
@@ -99,7 +99,7 @@ test.describe("ask_user_choices widget", () => {
 		await expect(page.locator(".ask-other-input")).toBeVisible();
 		// Answer Q2 manually via tab nav
 		await page.locator('[role="tab"][data-tab-index="1"]').click();
-		await page.locator('[role="tabpanel"] input[type=radio][value="c"]').check();
+		await page.locator('[role="tabpanel"] input[type=radio][value="c"]').click({ force: true });
 		// Submit still disabled because Q1 other_text is empty — auto-advance took us to Q2
 		// We must be on Q2 now after checking 'c' on last question no advance — still 1
 		await page.locator('[role="tab"][data-tab-index="1"]').click();
@@ -122,8 +122,8 @@ test.describe("ask_user_choices widget", () => {
 				return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "Content-Type": "application/json" } });
 			},
 		}));
-		await page.locator('[role="tabpanel"] input[type=radio][value="a"]').check();
-		await page.locator('[role="tabpanel"] input[type=radio][value="c"]').check();
+		await page.locator('[role="tabpanel"] input[type=radio][value="a"]').click({ force: true });
+		await page.locator('[role="tabpanel"] input[type=radio][value="c"]').click({ force: true });
 		await page.locator(".ask-submit").click();
 		// Wait for the Submit button to disappear (read-only state).
 		await expect(page.locator(".ask-submit")).toHaveCount(0);
@@ -146,7 +146,7 @@ test.describe("ask_user_choices widget", () => {
 				return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "Content-Type": "application/json" } });
 			},
 		}));
-		await page.locator('input[type=radio][value="__OTHER__"]').check();
+		await page.locator('input[type=radio][value="__OTHER__"]').click({ force: true });
 		await page.locator(".ask-other-input").fill("  my typed answer  ");
 		await page.locator(".ask-submit").click();
 		await expect(page.locator(".ask-submit")).toHaveCount(0);
@@ -192,13 +192,139 @@ test.describe("ask_user_choices widget", () => {
 		await expect(page.locator(".ask-submit")).toHaveCount(0);
 	});
 
+	test("visual polish: input is sr-only; selected card has .checked", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [{ question: "Q1", options: ["a", "b"] }],
+		}));
+		// Native radio input carries the sr-only class.
+		const radio = page.locator('input[type=radio][value="a"]');
+		await expect(radio).toHaveClass(/sr-only/);
+		// The radio is effectively invisible (<=1px box).
+		const box = await radio.boundingBox();
+		expect(box && Math.max(box.width, box.height)).toBeLessThanOrEqual(1);
+		// Before selection, card not .checked
+		const card = page.locator('.ask-option').first();
+		await expect(card).not.toHaveClass(/checked/);
+		await radio.click({ force: true });
+		await expect(card).toHaveClass(/checked/);
+		// A visible checkmark indicator renders inside the selected card.
+		await expect(card.locator('.ask-option-check')).toContainText('✓');
+	});
+
+	test("multi:true renders checkboxes (not radios) and drops the name attribute", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [{ question: "Pick all", options: ["a", "b", "c"], multi: true }],
+		}));
+		await expect(page.locator('input[type=checkbox]')).toHaveCount(3);
+		await expect(page.locator('input[type=radio]')).toHaveCount(0);
+		// Checkboxes should not share a name attribute.
+		const names = await page.locator('input[type=checkbox]').evaluateAll(
+			(els) => els.map(e => (e as HTMLInputElement).getAttribute('name')),
+		);
+		for (const n of names) expect(n).toBeFalsy();
+		// Checkboxes are sr-only.
+		await expect(page.locator('input[type=checkbox]').first()).toHaveClass(/sr-only/);
+	});
+
+	test("multi: clicking multiple checkboxes persists all selections; unchecking removes", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [{ question: "Pick all", options: ["a", "b", "c"], multi: true }],
+			submitFetch: async (_u: string, init: any) => {
+				(window as any)._lastSubmitBody = JSON.parse(init.body);
+				return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "Content-Type": "application/json" } });
+			},
+		}));
+		await page.locator('input[type=checkbox][value="a"]').click({ force: true });
+		await page.locator('input[type=checkbox][value="c"]').click({ force: true });
+		// Both cards appear checked.
+		await expect(page.locator('.ask-option').nth(0)).toHaveClass(/checked/);
+		await expect(page.locator('.ask-option').nth(2)).toHaveClass(/checked/);
+		await expect(page.locator('.ask-option').nth(1)).not.toHaveClass(/checked/);
+		// Uncheck a.
+		await page.locator('input[type=checkbox][value="a"]').click({ force: true });
+		await expect(page.locator('.ask-option').nth(0)).not.toHaveClass(/checked/);
+		await expect(page.locator('.ask-option').nth(2)).toHaveClass(/checked/);
+		// Submit only c.
+		await page.locator('.ask-submit').click();
+		const body = await page.evaluate(() => (window as any)._lastSubmitBody);
+		expect(body.answers[0].selected).toEqual(["c"]);
+		expect(body.answers[0].other_text).toBeNull();
+	});
+
+	test("multi: auto-advance is suppressed", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [
+				{ question: "Q1", options: ["a", "b"], multi: true },
+				{ question: "Q2", options: ["c", "d"] },
+			],
+		}));
+		await page.locator('input[type=checkbox][value="a"]').click({ force: true });
+		// Active tab must still be 0.
+		const active = await page.locator('[role="tab"][aria-selected="true"]').getAttribute("data-tab-index");
+		expect(active).toBe("0");
+	});
+
+	test("multi: Submit disabled at 0 selections, enabled at ≥1 (default min=1)", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [{ question: "Pick", options: ["a", "b"], multi: true }],
+		}));
+		await expect(page.locator(".ask-submit")).toBeDisabled();
+		await page.locator('input[type=checkbox][value="a"]').click({ force: true });
+		await expect(page.locator(".ask-submit")).toBeEnabled();
+		await page.locator('input[type=checkbox][value="a"]').click({ force: true });
+		await expect(page.locator(".ask-submit")).toBeDisabled();
+	});
+
+	test("multi: min=2 requires at least two selections", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [{ question: "Pick ≥2", options: ["a", "b", "c"], multi: true, min: 2 }],
+		}));
+		await page.locator('input[type=checkbox][value="a"]').click({ force: true });
+		await expect(page.locator(".ask-submit")).toBeDisabled();
+		await page.locator('input[type=checkbox][value="b"]').click({ force: true });
+		await expect(page.locator(".ask-submit")).toBeEnabled();
+	});
+
+	test("multi + Other: submits selected array with 'Other' and other_text", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [{ question: "Pick", options: ["a", "b"], allow_other: true, multi: true }],
+			submitFetch: async (_u: string, init: any) => {
+				(window as any)._lastSubmitBody = JSON.parse(init.body);
+				return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "Content-Type": "application/json" } });
+			},
+		}));
+		await page.locator('input[type=checkbox][value="a"]').click({ force: true });
+		await page.locator('input[type=checkbox][value="__OTHER__"]').click({ force: true });
+		// Submit disabled while other_text empty.
+		await expect(page.locator(".ask-submit")).toBeDisabled();
+		await page.locator('.ask-other-input').fill('  my custom  ');
+		await expect(page.locator(".ask-submit")).toBeEnabled();
+		await page.locator('.ask-submit').click();
+		const body = await page.evaluate(() => (window as any)._lastSubmitBody);
+		expect(body.answers[0].selected).toEqual(["a", "Other"]);
+		expect(body.answers[0].other_text).toBe("my custom");
+	});
+
+	test("multi: read-only answers with array selected restore checkboxes", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [{ question: "Pick", options: ["a", "b", "c"], allow_other: true, multi: true }],
+			answers: [{ question: "Pick", selected: ["a", "c", "Other"], other_text: "zed" }],
+		}));
+		await expect(page.locator(".ask-submit")).toHaveCount(0);
+		await expect(page.locator('input[type=checkbox][value="a"]')).toBeChecked();
+		await expect(page.locator('input[type=checkbox][value="b"]')).not.toBeChecked();
+		await expect(page.locator('input[type=checkbox][value="c"]')).toBeChecked();
+		await expect(page.locator('input[type=checkbox][value="__OTHER__"]')).toBeChecked();
+		await expect(page.locator('.ask-other-input')).toHaveValue("zed");
+	});
+
 	test("failed submit surfaces server error message", async ({ page }) => {
 		await page.evaluate(() => (window as any).mountWidget({
 			questions: [{ question: "Q1", options: ["a", "b"] }],
 			submitFetch: async () =>
 				new Response(JSON.stringify({ error: "No pending question for this session/toolUseId" }), { status: 404, headers: { "Content-Type": "application/json" } }),
 		}));
-		await page.locator('input[type=radio][value="a"]').check();
+		await page.locator('input[type=radio][value="a"]').click({ force: true });
 		await page.locator(".ask-submit").click();
 		// Submit button remains visible (not read-only); error surfaces.
 		await expect(page.locator(".ask-submit-error")).toHaveText(/No pending question/);

--- a/tests/ask-user-choices-widget.spec.ts
+++ b/tests/ask-user-choices-widget.spec.ts
@@ -234,14 +234,14 @@ test.describe("ask_user_choices widget", () => {
 				return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "Content-Type": "application/json" } });
 			},
 		}));
-		await page.locator('input[type=checkbox][value="a"]').click({ force: true });
-		await page.locator('input[type=checkbox][value="c"]').click({ force: true });
+		await page.locator('label:has(input[value="a"])').click();
+		await page.locator('label:has(input[value="c"])').click();
 		// Both cards appear checked.
 		await expect(page.locator('.ask-option').nth(0)).toHaveClass(/checked/);
 		await expect(page.locator('.ask-option').nth(2)).toHaveClass(/checked/);
 		await expect(page.locator('.ask-option').nth(1)).not.toHaveClass(/checked/);
 		// Uncheck a.
-		await page.locator('input[type=checkbox][value="a"]').click({ force: true });
+		await page.locator('label:has(input[value="a"])').click();
 		await expect(page.locator('.ask-option').nth(0)).not.toHaveClass(/checked/);
 		await expect(page.locator('.ask-option').nth(2)).toHaveClass(/checked/);
 		// Submit only c.
@@ -258,7 +258,7 @@ test.describe("ask_user_choices widget", () => {
 				{ question: "Q2", options: ["c", "d"] },
 			],
 		}));
-		await page.locator('input[type=checkbox][value="a"]').click({ force: true });
+		await page.locator('label:has(input[value="a"])').click();
 		// Active tab must still be 0.
 		const active = await page.locator('[role="tab"][aria-selected="true"]').getAttribute("data-tab-index");
 		expect(active).toBe("0");
@@ -269,9 +269,9 @@ test.describe("ask_user_choices widget", () => {
 			questions: [{ question: "Pick", options: ["a", "b"], multi: true }],
 		}));
 		await expect(page.locator(".ask-submit")).toBeDisabled();
-		await page.locator('input[type=checkbox][value="a"]').click({ force: true });
+		await page.locator('label:has(input[value="a"])').click();
 		await expect(page.locator(".ask-submit")).toBeEnabled();
-		await page.locator('input[type=checkbox][value="a"]').click({ force: true });
+		await page.locator('label:has(input[value="a"])').click();
 		await expect(page.locator(".ask-submit")).toBeDisabled();
 	});
 
@@ -279,9 +279,9 @@ test.describe("ask_user_choices widget", () => {
 		await page.evaluate(() => (window as any).mountWidget({
 			questions: [{ question: "Pick ≥2", options: ["a", "b", "c"], multi: true, min: 2 }],
 		}));
-		await page.locator('input[type=checkbox][value="a"]').click({ force: true });
+		await page.locator('label:has(input[value="a"])').click();
 		await expect(page.locator(".ask-submit")).toBeDisabled();
-		await page.locator('input[type=checkbox][value="b"]').click({ force: true });
+		await page.locator('label:has(input[value="b"])').click();
 		await expect(page.locator(".ask-submit")).toBeEnabled();
 	});
 
@@ -293,8 +293,8 @@ test.describe("ask_user_choices widget", () => {
 				return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "Content-Type": "application/json" } });
 			},
 		}));
-		await page.locator('input[type=checkbox][value="a"]').click({ force: true });
-		await page.locator('input[type=checkbox][value="__OTHER__"]').click({ force: true });
+		await page.locator('label:has(input[value="a"])').click();
+		await page.locator('label:has(input[value="__OTHER__"])').click();
 		// Submit disabled while other_text empty.
 		await expect(page.locator(".ask-submit")).toBeDisabled();
 		await page.locator('.ask-other-input').fill('  my custom  ');

--- a/tests/e2e/ask-user-choices.spec.ts
+++ b/tests/e2e/ask-user-choices.spec.ts
@@ -118,6 +118,80 @@ test.describe("ask_user_choices REST round-trip", () => {
 		}
 	});
 
+	test("multi-select: answers round-trip with selected as array", async () => {
+		const sessionId = await createSession();
+		try {
+			const toolUseId = `tool-ask-multi-${Date.now()}`;
+			const questions = [
+				{ question: "Which?", options: ["a", "b", "c"], multi: true },
+			];
+			const blockingP = postInternal("/api/internal/user-question", { sessionId, toolUseId, questions });
+			// Wait for pending.
+			for (let i = 0; i < 50; i++) {
+				const r = await apiFetch(`/api/internal/user-question/pending?sessionId=${sessionId}`);
+				if ((await r.json()).pending.length > 0) break;
+				await new Promise(r => setTimeout(r, 50));
+			}
+			const answers = [{ question: "Which?", selected: ["a", "b"], other_text: null }];
+			const submitResp = await postInternal("/api/internal/user-question/submit", { sessionId, toolUseId, answers });
+			expect(submitResp.status).toBe(200);
+			const blockingResp = await blockingP;
+			expect(blockingResp.status).toBe(200);
+			expect(await blockingResp.json()).toEqual({ answers });
+		} finally {
+			await deleteSession(sessionId);
+		}
+	});
+
+	test("single-select question submitted with an array → 400", async () => {
+		const sessionId = await createSession();
+		try {
+			const toolUseId = `tool-ask-bad-single-${Date.now()}`;
+			const questions = [{ question: "Q?", options: ["a", "b"] }];
+			const blockingP = postInternal("/api/internal/user-question", { sessionId, toolUseId, questions });
+			for (let i = 0; i < 50; i++) {
+				const r = await apiFetch(`/api/internal/user-question/pending?sessionId=${sessionId}`);
+				if ((await r.json()).pending.length > 0) break;
+				await new Promise(r => setTimeout(r, 50));
+			}
+			const bad = [{ question: "Q?", selected: ["a"], other_text: null }];
+			const resp = await postInternal("/api/internal/user-question/submit", { sessionId, toolUseId, answers: bad });
+			expect(resp.status).toBe(400);
+			// Clean up: submit a valid answer so the blocking request resolves.
+			await postInternal("/api/internal/user-question/submit", {
+				sessionId, toolUseId,
+				answers: [{ question: "Q?", selected: "a", other_text: null }],
+			});
+			await blockingP;
+		} finally {
+			await deleteSession(sessionId);
+		}
+	});
+
+	test("multi-select question submitted with a string → 400", async () => {
+		const sessionId = await createSession();
+		try {
+			const toolUseId = `tool-ask-bad-multi-${Date.now()}`;
+			const questions = [{ question: "Q?", options: ["a", "b"], multi: true }];
+			const blockingP = postInternal("/api/internal/user-question", { sessionId, toolUseId, questions });
+			for (let i = 0; i < 50; i++) {
+				const r = await apiFetch(`/api/internal/user-question/pending?sessionId=${sessionId}`);
+				if ((await r.json()).pending.length > 0) break;
+				await new Promise(r => setTimeout(r, 50));
+			}
+			const bad = [{ question: "Q?", selected: "a", other_text: null }];
+			const resp = await postInternal("/api/internal/user-question/submit", { sessionId, toolUseId, answers: bad });
+			expect(resp.status).toBe(400);
+			await postInternal("/api/internal/user-question/submit", {
+				sessionId, toolUseId,
+				answers: [{ question: "Q?", selected: ["a"], other_text: null }],
+			});
+			await blockingP;
+		} finally {
+			await deleteSession(sessionId);
+		}
+	});
+
 	test("unknown session → 404", async () => {
 		const r = await postInternal("/api/internal/user-question", {
 			sessionId: "no-such-session", toolUseId: "t", questions: [{ question: "Q", options: ["a", "b"] }],
@@ -199,6 +273,52 @@ test.describe("ask_user_choices end-to-end via mock agent", () => {
 				// Pending list is now empty.
 				const r2 = await apiFetch(`/api/internal/user-question/pending?sessionId=${sessionId}`);
 				expect((await r2.json()).pending).toEqual([]);
+			} finally {
+				conn.close();
+			}
+		} finally {
+			await deleteSession(sessionId);
+		}
+	});
+
+	test("mock agent multi-select: tool_result.answers[0].selected is an array", async () => {
+		const sessionId = await createSession();
+		try {
+			const conn = await connectWs(sessionId);
+			try {
+				conn.send({ type: "prompt", text: "please use ask_user_choices_multi" });
+				await conn.waitFor(toolStartPredicate("ask_user_choices"), 10_000);
+
+				let toolUseId = "";
+				for (let i = 0; i < 100; i++) {
+					const r = await apiFetch(`/api/internal/user-question/pending?sessionId=${sessionId}`);
+					const list = (await r.json()).pending;
+					if (list.length > 0) { toolUseId = list[0].toolUseId; break; }
+					await new Promise(r => setTimeout(r, 50));
+				}
+				expect(toolUseId).not.toBe("");
+
+				const answers = [
+					{ question: "Which colors?", selected: ["red", "blue"], other_text: null },
+					{ question: "Team size?", selected: "small", other_text: null },
+				];
+				const submitResp = await fetch(`${base()}/api/internal/user-question/submit`, {
+					method: "POST",
+					headers: { "Content-Type": "application/json", Authorization: `Bearer ${readE2EToken()}` },
+					body: JSON.stringify({ sessionId, toolUseId, answers }),
+				});
+				expect(submitResp.status).toBe(200);
+
+				const toolResultMsg = await conn.waitFor(
+					(m) => messageEndPredicate("toolResult")(m)
+						&& m.data?.message?.toolName === "ask_user_choices",
+					10_000,
+				);
+				const content = toolResultMsg.data?.message?.content?.[0]?.text || "";
+				const parsed = JSON.parse(content);
+				expect(Array.isArray(parsed.answers[0].selected)).toBe(true);
+				expect(parsed.answers[0].selected).toEqual(["red", "blue"]);
+				expect(parsed.answers[1].selected).toBe("small");
 			} finally {
 				conn.close();
 			}

--- a/tests/e2e/mock-agent-core.mjs
+++ b/tests/e2e/mock-agent-core.mjs
@@ -155,6 +155,9 @@ export class MockAgentCore {
 			const filePath = MockAgentCore.extractFilePath(text);
 			return { tool: "Edit", input: { path: filePath, oldText: "ORIGINAL_VALUE", newText: "EDITED_VALUE" }, output: "Edited successfully" };
 		}
+		if (lower.includes("ask_user_choices_multi")) {
+			return { askUserChoices: "multi" };
+		}
 		if (lower.includes("ask_user_choices") || lower.includes("ask user choices")) {
 			// Signals the mock agent to hit the blocking /api/internal/user-question endpoint.
 			return { askUserChoices: true };
@@ -202,7 +205,7 @@ export class MockAgentCore {
 		if (toolAction && toolAction.toolDenied) {
 			await this._handleToolDenied(toolAction.toolDenied);
 		} else if (toolAction && toolAction.askUserChoices) {
-			await this._handleAskUserChoices();
+			await this._handleAskUserChoices(toolAction.askUserChoices === "multi");
 		} else if (toolAction && toolAction.multiTool) {
 			this._handleMultiTool(toolAction.multiTool);
 		} else if (toolAction && toolAction.mockError) {
@@ -268,7 +271,7 @@ export class MockAgentCore {
 		this.emit({ type: "session_status", status: "idle" });
 	}
 
-	async _handleAskUserChoices() {
+	async _handleAskUserChoices(multi = false) {
 		// Call the ask_user_choices tool via its REST endpoint directly, mirroring
 		// how the real extension posts to /api/internal/user-question and blocks
 		// until the UI submits. The mock agent waits for the response, then emits
@@ -282,10 +285,15 @@ export class MockAgentCore {
 			token = (this.env.BOBBIT_TOKEN || fs.readFileSync(path.join(bobbitDir, "state", "token"), "utf-8")).trim();
 		} catch {}
 
-		const questions = [
-			{ question: "Favorite color?", options: ["red", "blue", "green"] },
-			{ question: "Team size?", options: ["small", "medium", "large"], allow_other: true },
-		];
+		const questions = multi
+			? [
+				{ question: "Which colors?", options: ["red", "blue", "green"], multi: true },
+				{ question: "Team size?", options: ["small", "medium", "large"], allow_other: true },
+			]
+			: [
+				{ question: "Favorite color?", options: ["red", "blue", "green"] },
+				{ question: "Team size?", options: ["small", "medium", "large"], allow_other: true },
+			];
 
 		this.emit({ type: "tool_execution_start", toolName: "ask_user_choices", toolId, input: { questions } });
 

--- a/tests/e2e/ui/ask-user-choices-ui.spec.ts
+++ b/tests/e2e/ui/ask-user-choices-ui.spec.ts
@@ -36,13 +36,13 @@ test.describe("ask_user_choices widget (full-stack UI)", () => {
 			.toHaveAttribute("aria-selected", "true");
 
 		// Pick "blue" on Q1 — should auto-advance to Q2.
-		await widget.locator('input[type="radio"][value="blue"]').check();
+		await widget.locator('label:has(input[value="blue"])').click();
 		await expect(widget.locator('[role="tab"][data-tab-index="1"]'))
 			.toHaveAttribute("aria-selected", "true", { timeout: 5_000 });
 
 		// Q2 has allow_other. Pick "Other" — should NOT auto-advance off the last tab anyway,
 		// and should reveal the free-text input.
-		await widget.locator('input[type="radio"][value="__OTHER__"]').check();
+		await widget.locator('label:has(input[value="__OTHER__"])').click();
 		await expect(widget.locator(".ask-other-input")).toBeVisible({ timeout: 5_000 });
 
 		// Submit is still disabled until text is typed.
@@ -73,10 +73,10 @@ test.describe("ask_user_choices widget (full-stack UI)", () => {
 		await expect(widget).toBeVisible({ timeout: 20_000 });
 
 		// Answer Q1 (auto-advance), then answer Q2 non-Other, then submit.
-		await widget.locator('input[type="radio"][value="red"]').check();
+		await widget.locator('label:has(input[value="red"])').click();
 		await expect(widget.locator('[role="tab"][data-tab-index="1"]'))
 			.toHaveAttribute("aria-selected", "true", { timeout: 5_000 });
-		await widget.locator('input[type="radio"][value="medium"]').check();
+		await widget.locator('label:has(input[value="medium"])').click();
 		await widget.locator(".ask-submit").click();
 		await expect(widget.locator(".ask-submit")).toHaveCount(0, { timeout: 10_000 });
 
@@ -126,10 +126,10 @@ test.describe("ask_user_choices widget (full-stack UI)", () => {
 		const toolUseId: string = pendingJson.pending[0].toolUseId;
 
 		// Submit from the first tab.
-		await widget.locator('input[type="radio"][value="blue"]').check();
+		await widget.locator('label:has(input[value="blue"])').click();
 		await expect(widget.locator('[role="tab"][data-tab-index="1"]'))
 			.toHaveAttribute("aria-selected", "true", { timeout: 5_000 });
-		await widget.locator('input[type="radio"][value="large"]').check();
+		await widget.locator('label:has(input[value="large"])').click();
 		await widget.locator(".ask-submit").click();
 		await expect(widget.locator(".ask-submit")).toHaveCount(0, { timeout: 10_000 });
 


### PR DESCRIPTION
Polish + multi-select for the `ask_user_choices` inline widget.

## Visual polish
- Native `<input type="radio">` / `<input type="checkbox">` are now `sr-only` — present in DOM for a11y + keyboard focus, visually hidden.
- Selected cards show a small circular ✓ badge.
- Card's existing `border-primary bg-primary/10` carries selection state.

## Multi-select
- `AskQuestion` gains optional `multi`, `min`, `max`.
- `AskAnswer.selected` is now `string | string[]` — array iff `multi:true`. `other_text` remains single string.
- Widget: for multi questions renders checkboxes (no shared `name`), suppresses auto-advance, `_canSubmit` enforces min/max + requires non-empty `other_text` when "Other" is among selections. Read-only rehydration handles arrays.
- Server: `validateQuestions` sanity-checks multi/min/max; new `crossValidate` enforces question-vs-answer shape. `UserQuestionHarness.submit()` returns `{ok:true} | {ok:false; code; error}`; REST maps `invalid→400`, `not_found→404`.
- Tool manifest (YAML + Typebox) and `AskUserChoicesRenderer` validator updated.

## Backward compatibility
Single-select (no `multi` field) is unchanged — `selected` stays a string, auto-advance fires, all pre-existing tests still pass.

## Tests
- `tests/ask-user-choices-widget.spec.ts` — 18 tests (9 new): visual polish, multi rendering, toggling, auto-advance suppression, min=1/min=2 gating, Other+multi, read-only array restore.
- `tests/e2e/ask-user-choices.spec.ts` — 3 new tests: multi REST round-trip, single-with-array 400, multi-with-string 400, mock-agent end-to-end.
- `tests/e2e/ui/ask-user-choices-ui.spec.ts` — updated to click `<label>` (user flow) now that the native input is sr-only.
- `tests/e2e/mock-agent-core.mjs` — new `ask_user_choices_multi` branch.

## Docs
- `docs/blocking-tools.md` — widget summary now notes single/multi-select + optional "Other"; auto-advance noted as single-select only.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)