### PR TITLE
Test suite maintenance

### DIFF
--- a/tests/e2e/ui/sidebar-archived-delegates-e2e.spec.ts
+++ b/tests/e2e/ui/sidebar-archived-delegates-e2e.spec.ts
@@ -95,10 +95,16 @@ test.describe("SB-00b: Archived delegates visible after Show Archived toggle", (
 		await expect(seeArchivedBtn).toBeVisible({ timeout: 10_000 });
 		await seeArchivedBtn.click();
 
-		// 7. Wait for the archived section to appear
-		await expect(
-			page.locator("span.uppercase").filter({ hasText: "Archived" }).first(),
-		).toBeVisible({ timeout: 10_000 });
+		// 7. Wait for the toggle to take effect. After #328 (per-project Archived
+		// subsections), no span.uppercase "Archived" header renders in this
+		// scenario — the project has no standalone archived goals or sessions,
+		// only a delegate of a LIVE parent, so the per-project Archived
+		// subsection stays empty. Instead poll for the button's active state
+		// (text-primary class).
+		await expect.poll(
+			async () => seeArchivedBtn.evaluate((el) => el.className.includes("text-primary")),
+			{ timeout: 10_000 },
+		).toBe(true);
 
 		// Wait for sidebar to fully render with archived data
 		await page.waitForTimeout(2000);
@@ -146,9 +152,10 @@ test.describe("SB-00b: Archived delegates visible after Show Archived toggle", (
 
 		// Toggle back on
 		await seeArchivedBtn.click();
-		await expect(
-			page.locator("span.uppercase").filter({ hasText: "Archived" }).first(),
-		).toBeVisible({ timeout: 10_000 });
+		await expect.poll(
+			async () => seeArchivedBtn.evaluate((el) => el.className.includes("text-primary")),
+			{ timeout: 10_000 },
+		).toBe(true);
 		await page.waitForTimeout(2000);
 
 		// Re-expand parent if needed

--- a/tests/e2e/ui/sidebar-archived-per-project.spec.ts
+++ b/tests/e2e/ui/sidebar-archived-per-project.spec.ts
@@ -72,10 +72,13 @@ test.describe("Per-project Archived subsections", () => {
 		await expect(seeArchived).toBeVisible({ timeout: 10_000 });
 		await seeArchived.click();
 
-		// There should be TWO Archived subsection headers (one per project), not one global.
-		// Header label has class "uppercase" and text "Archived".
+		// Each project gets its own nested Archived subsection header (no single
+		// global block). Prior revisions asserted toHaveCount(2), but in a shared
+		// worker the default project or sibling specs may also have archived
+		// items, producing a 3rd subsection. Instead assert >= 2 (both of ours
+		// present) plus absence of a global archived block below all projects.
 		const archivedHeaders = page.locator("span.uppercase").filter({ hasText: /^Archived$/ });
-		await expect(archivedHeaders).toHaveCount(2, { timeout: 10_000 });
+		await expect.poll(async () => archivedHeaders.count(), { timeout: 10_000 }).toBeGreaterThanOrEqual(2);
 
 		// Per-project Archived subsections default to expanded — each archived goal
 		// title should appear immediately under its project without needing an extra click.
@@ -111,16 +114,41 @@ test.describe("Per-project Archived subsections", () => {
 		const isOn = await seeArchived.evaluate((el) => el.className.includes("text-primary"));
 		if (!isOn) await seeArchived.click();
 
-		// Wait for per-project Archived headers (default expanded)
+		// Wait for per-project Archived headers (default expanded). Sibling
+		// specs sharing this worker may have added archived items to the default
+		// project, producing an extra subsection, so assert >= 2 rather than ==.
 		const archivedButtons = page.locator("button").filter({ has: page.locator("span.uppercase", { hasText: /^Archived$/ }) });
-		await expect(archivedButtons).toHaveCount(2, { timeout: 10_000 });
+		await expect.poll(async () => archivedButtons.count(), { timeout: 10_000 }).toBeGreaterThanOrEqual(2);
 
 		// Both archived goals should be visible initially (default expanded)
 		await expect(page.getByText(goalATitle, { exact: false }).first()).toBeVisible({ timeout: 5_000 });
 		await expect(page.getByText(goalBTitle, { exact: false }).first()).toBeVisible({ timeout: 5_000 });
 
-		// Collapse project B's archived subsection (the second one in DOM)
-		await archivedButtons.nth(1).click();
+		// Collapse the Archived subsection that contains goal B. Find it by
+		// DOM proximity rather than by nth-index, so an extra Archived
+		// subsection from the default project (which sibling specs on the
+		// same worker may have populated) doesn't shift the index and make
+		// us click the wrong project's toggle.
+		await page.evaluate((title) => {
+			// Find the deepest element whose own text content matches the title.
+			const all = Array.from(document.querySelectorAll(".sidebar-edge *")) as HTMLElement[];
+			const titleEl = all.find((el) => {
+				if (!el.textContent?.includes(title)) return false;
+				return !Array.from(el.children).some((c) => c.textContent?.includes(title));
+			});
+			if (!titleEl) throw new Error(`goalB title not found: ${title}`);
+			// Scan all Archived header buttons; pick the last one that precedes
+			// titleEl in document order.
+			const buttons = Array.from(document.querySelectorAll("button")) as HTMLButtonElement[];
+			const archivedBefore = buttons.filter((btn) => {
+				const span = btn.querySelector("span.uppercase");
+				if (span?.textContent?.trim() !== "Archived") return false;
+				const pos = btn.compareDocumentPosition(titleEl);
+				return !!(pos & Node.DOCUMENT_POSITION_FOLLOWING);
+			});
+			if (archivedBefore.length === 0) throw new Error("no Archived header preceding goalB");
+			archivedBefore[archivedBefore.length - 1].click();
+		}, goalBTitle);
 
 		// Goal B should disappear (project B collapsed); Goal A still visible
 		await expect(page.getByText(goalBTitle, { exact: false })).toHaveCount(0, { timeout: 3_000 });
@@ -159,13 +187,19 @@ test.describe("Per-project Archived subsections", () => {
 		await page.waitForTimeout(400);
 
 		// Auto-open flips showArchived on; per-project subsections default expanded
-		// so the matching item appears without extra clicks.
+		// so the matching item appears without extra clicks. Only projects whose
+		// archived goals match the search should render an Archived subsection
+		// — project A matches, project B does not. The default project may also
+		// contain archived items from sibling specs, but none of them match a
+		// unique timestamped search string, so it will also be hidden.
+		//
+		// The search auto-open triggers an async fetch of archived goals; under
+		// parallel load that fetch can take noticeably longer than the default
+		// 5s Playwright assertion timeout, so poll for goalA visible first and
+		// then assert the subsection count.
+		await expect(page.getByText(goalATitle, { exact: false }).first()).toBeVisible({ timeout: 15_000 });
 		const archivedButtons = page.locator("button").filter({ has: page.locator("span.uppercase", { hasText: /^Archived$/ }) });
-		// Only project A's archived subsection has matches → only one header visible.
 		await expect(archivedButtons).toHaveCount(1, { timeout: 10_000 });
-
-		// Goal A matches, goal B does not
-		await expect(page.getByText(goalATitle, { exact: false }).first()).toBeVisible({ timeout: 5_000 });
 		await expect(page.getByText(goalBTitle, { exact: false })).toHaveCount(0, { timeout: 3_000 });
 
 		// Clear search
@@ -175,13 +209,25 @@ test.describe("Per-project Archived subsections", () => {
 
 	test("toggling See Archived off hides all per-project Archived subsections", async ({ page }) => {
 		await openApp(page);
+		// Reset sidebar state so prior tests in this file (especially a failed
+		// search test that leaves showArchived auto-flipped on) don't bleed in.
+		await page.evaluate(() => {
+			localStorage.removeItem("bobbit-show-archived");
+			localStorage.removeItem("bobbit-archived-collapsed-projects");
+		});
+		await page.reload();
+		await expect(page.locator("button").filter({ hasText: "Settings" }).first()).toBeVisible({ timeout: 15_000 });
 
 		const seeArchived = page.locator("button").filter({ hasText: "See Archived" }).first();
 		const isOn = await seeArchived.evaluate((el) => el.className.includes("text-primary"));
 		if (!isOn) {
 			await seeArchived.click();
-			// verify subsections appear
-			await expect(page.locator("span.uppercase").filter({ hasText: /^Archived$/ })).toHaveCount(2, { timeout: 10_000 });
+			// verify subsections appear (>= 2 — sibling specs may add a 3rd on
+			// the default project when sharing a worker).
+			await expect.poll(
+				async () => page.locator("span.uppercase").filter({ hasText: /^Archived$/ }).count(),
+				{ timeout: 10_000 },
+			).toBeGreaterThanOrEqual(2);
 		}
 
 		// Turn off


### PR DESCRIPTION
Ongoing test suite maintenance from the Green Knight wake cycles. Each cycle runs the `general` verification workflow (typecheck → unit → e2e) and fixes consistent failures it finds. Kept intentionally small and test-only.

## Fixes

### 1. `test(e2e): make sidebar-archived-per-project robust to worker-shared state` (7a7f08a1)
The spec asserted `toHaveCount(2)` on the per-project "Archived" subsection headers, assuming only the two projects it registers contribute. But sibling `sidebar-archived-layout.spec.ts` populates the default project with archived items in the same worker, producing a 3rd subsection and consistent flakes.
- Replace `toHaveCount(2)` with `toBeGreaterThanOrEqual(2)`.
- Find goal B's Archived toggle by DOM proximity rather than by `.nth(1)`, so an extra sibling-populated subsection doesn't shift the index.
- Reset `bobbit-show-archived` + `bobbit-archived-collapsed-projects` localStorage at the start of the "toggling See Archived off" test so a preceding failed test doesn't leak state in.
- Poll for goal A's visibility with a 15s timeout in the search test — the search auto-open flow kicks off an async archived-data fetch that can take noticeably longer than 5s under parallel CPU load.

### 2. `test(e2e): drop obsolete Archived-header assertion in SB-00b test` (e9524ac9)
After #328 (per-project Archived subsections) the global Archived block was replaced by per-project subsections that render only when the project contains standalone archived goals or archived sessions. In the SB-00b scenario the project has neither — only a delegate of a LIVE parent session — so no `span.uppercase "Archived"` header ever renders, and the test's intermediate header-visibility assertion failed every run (3/3 consistent failures including retries). The actual SB-00b contract (archived delegate visible nested under parent after toggling Show Archived on, hidden when off) still works. Poll the See-Archived button's active state instead.

## Remaining flakes (not fixed)

Two tests in `sidebar-archived-per-project.spec.ts` (`search surfaces archived items`, `toggling See Archived off`) continue to flake occasionally under full parallel load. Retries green them, and the suite as a whole is passing and within budget. A proper fix likely needs per-test project isolation or a dedicated worker — too intrusive for a wake-cycle PR.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
