### PR TITLE
Test suite maintenance

### DIFF
--- a/tests/e2e/ui/sidebar-archived-layout.spec.ts
+++ b/tests/e2e/ui/sidebar-archived-layout.spec.ts
@@ -110,23 +110,30 @@ test.describe("SB-28: Archived team structure", () => {
 		await expect(seeArchivedBtn).toBeVisible({ timeout: 10_000 });
 		await seeArchivedBtn.click();
 
-		// Wait for archived section to load
-		await expect(
-			page.locator("span.uppercase").filter({ hasText: "Archived" }).first(),
-		).toBeVisible({ timeout: 10_000 });
+		// Wait for the See-Archived toggle to activate. The goal here is LIVE
+		// (not archived) — only its team sessions were archived via teardown.
+		// Those sessions have teamGoalId set so they're excluded from the
+		// per-project Archived subsection and instead render nested inside
+		// the live goal group (see renderGoalGroup's state.showArchived branch).
+		// There's therefore no separate "Archived" subsection header to wait
+		// for — just poll the toggle's active state.
+		await expect.poll(
+			async () => seeArchivedBtn.evaluate((el) => el.className.includes("text-primary")),
+			{ timeout: 10_000 },
+		).toBe(true);
 
-		// The goal should appear in the archived section.
-		// Look for the goal title text (case-insensitive since it's uppercased in sidebar)
+		// The live goal row should appear in the sidebar.
 		const goalText = page.getByText("Archived Team Test", { exact: false });
 		await expect(goalText.first()).toBeVisible({ timeout: 10_000 });
 
 		// Expand the goal by clicking it
 		await goalText.first().click();
 
-		// After expanding, archived sessions under the goal should be visible
-		// They should be in a container with greyscale/reduced-opacity styling
-		// Wait for any session row to appear under the goal
-		const archivedSessions = page.locator(".opacity-60");
+		// After expanding, archived team-lead + member rows should be visible
+		// under the goal. renderArchivedSessionRow applies an inline
+		// `filter:grayscale(1); opacity:0.75` style rather than a Tailwind
+		// .opacity-60 class — match on the inline style attribute instead.
+		const archivedSessions = page.locator("[style*='grayscale(1)']");
 		await expect(archivedSessions.first()).toBeVisible({ timeout: 10_000 });
 	});
 });


### PR DESCRIPTION
Test suite maintenance from the Green Knight wake cycle.

## Fix

`test(e2e): fix SB-28 assertions that never matched what they claimed` — the SB-28 "archived team lead and children appear with greyscale under goal" test in `sidebar-archived-layout.spec.ts` was failing deterministically (3/3 in isolation, consistent in the full suite). Two stale assumptions in the test, both masked by coincidental matches:

1. **Step 2** waited on `span.uppercase "Archived"` as a proxy for the Archived subsection header. After #328 that header renders only when the project has standalone archived goals or archived sessions. In this test the goal is LIVE (teardownTeam archives its sessions but not the goal itself) and the team-lead/member sessions carry `teamGoalId`, which excludes them from `standaloneArchived`. No Archived subsection is produced. The assertion had been passing only because the goal title `Archived Team Test` happens to contain "Archived" and the goal-row title span has class `uppercase tracking-wider` — a coincidental match, not the intended one.

2. **Step 5** looked for `.opacity-60` to verify the archived session rows. But `renderArchivedSessionRow` applies an inline `filter:grayscale(1); opacity:0.75` style (not a Tailwind `.opacity-60` class). The selector never actually matched archived session rows; it was matching stray `.opacity-60` elements elsewhere in the sidebar chrome that happened to be present on older layouts.

### Fix
- Poll the See-Archived button's `text-primary` active class to confirm the toggle took effect — there's nothing async to wait for, the subsection header wouldn't exist anyway.
- Match `[style*='grayscale(1)']` to actually find the archived session rows.

Verified 3× green in isolation and full suite passing.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
