### PR TITLE
Ask widget keyboard nav + label polish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,4 +189,4 @@ Staff agent worktrees are automatically refreshed on each wake cycle — the bra
 - [docs/dev-workflow.md](docs/dev-workflow.md) — running modes, restart workflow, safe change process
 - [docs/goals-workflows-tasks.md](docs/goals-workflows-tasks.md) — goal/workflow/gate data model and lifecycle
 - [docs/blocking-tools.md](docs/blocking-tools.md) — blocking-tool pattern (`verification_result`): harness + REST + UI widget round-trip
-- [docs/non-blocking-ask.md](docs/non-blocking-ask.md) — non-blocking `ask_user_choices` flow: stub tool_result, envelope user message, multi-tab/restart semantics
+- [docs/non-blocking-ask.md](docs/non-blocking-ask.md) — non-blocking `ask_user_choices` flow: stub tool_result, envelope user message, multi-tab/restart semantics, widget UX (required `tab_label` on multi-question asks, numbered option badges, keyboard shortcuts)

--- a/defaults/tools/ask/ask_user_choices.yaml
+++ b/defaults/tools/ask/ask_user_choices.yaml
@@ -31,9 +31,31 @@ detail_docs: |
   - **questions**: 1–5 questions
   - Each question has a **question** string, an **options** array (2–8 items), and these
     optional fields:
+    - **tab_label** (string, 2–4 words, ≤24 chars) — short topical summary shown as the tab title when there are multiple questions. **Required** when `questions.length > 1`; ignored for single-question asks. Example: `"User behavior"`, `"Follow-up timing"`.
     - **allow_other** (boolean) — adds an "Other" free-text choice.
     - **multi** (boolean) — allow multiple selections; `selected` is returned as an array.
     - **min** / **max** (integers) — min/max selections when `multi` is true (defaults: 1 and options.length).
+
+  ## Tab labels (multi-question asks)
+
+  When you post **more than one question**, every question MUST include a
+  `tab_label` field. The widget renders the tab strip as
+  `A. <tab_label>`, `B. <tab_label>`, … so the user can jump between
+  questions without re-reading the full prompt.
+
+  Keep it to **2–4 words, ≤24 characters**, topical and question-scoped
+  — not the full question.
+
+  ```json
+  {
+    "questions": [
+      { "question": "How often do users retry failed logins?", "tab_label": "User behavior", "options": ["Rarely", "Sometimes", "Often"] },
+      { "question": "Should we show a CAPTCHA after 3 failures?",  "tab_label": "CAPTCHA policy", "options": ["Yes", "No", "Only for flagged IPs"] }
+    ]
+  }
+  ```
+
+  Single-question asks do not need `tab_label` (the tab strip is hidden).
 
   ## Non-blocking contract
 

--- a/defaults/tools/ask/extension.ts
+++ b/defaults/tools/ask/extension.ts
@@ -48,6 +48,11 @@ export default function (pi: ExtensionAPI) {
 						maxItems: 8,
 						description: "2–8 answer options",
 					}),
+					tab_label: Type.Optional(Type.String({
+						minLength: 1,
+						maxLength: 24,
+						description: "Short 2–4 word tab label (≤24 chars) summarizing the question. REQUIRED when posting more than one question — used as the tab title so users can jump between questions without reading full prompts.",
+					})),
 					allow_other: Type.Optional(Type.Boolean({
 						description: "If true, render an 'Other' option with a free-text input",
 					})),
@@ -66,7 +71,27 @@ export default function (pi: ExtensionAPI) {
 				{ minItems: 1, maxItems: 5, description: "1–5 multiple-choice questions" },
 			),
 		}),
-		async execute(toolUseId, _params) {
+		async execute(toolUseId, params) {
+			// Enforce `tab_label` on multi-question asks before the UI renders.
+			// Mirrors src/server/agent/ask-user-choices-validation.ts — we can't
+			// import it here (agent sub-process), so the checks are duplicated.
+			const questions = (params as any)?.questions;
+			if (Array.isArray(questions) && questions.length > 1) {
+				for (let i = 0; i < questions.length; i++) {
+					const q = questions[i];
+					const label = q?.tab_label;
+					if (typeof label !== "string" || label.trim().length === 0) {
+						return ok({
+							error: `ask_user_choices: questions[${i}].tab_label is required for multi-question asks (2–4 words, ≤24 chars).`,
+						});
+					}
+					if (label.length > 24) {
+						return ok({
+							error: `ask_user_choices: questions[${i}].tab_label exceeds 24 chars (got ${label.length}).`,
+						});
+					}
+				}
+			}
 			// Non-blocking: return the stub immediately. The tool_use event flowing
 			// through the agent's stdout → pi-coding-agent → our WS broadcast is
 			// what tells the UI to render the widget. When the user submits, the

--- a/design-doc.md
+++ b/design-doc.md
@@ -1,0 +1,264 @@
+# Design Doc — Ask widget keyboard navigation + label polish
+
+Translates the goal spec into a concrete implementation plan. No code here — just
+shapes, formats, and test surface.
+
+## 1. Files to modify
+
+### Tool schema
+- `defaults/tools/ask/ask_user_choices.yaml` — update `description`, `promptSnippet`,
+  `docs`, and `detail_docs` so the agent is told to supply `tab_label` on every
+  question when `questions.length > 1`. Add a short "Tab labels" section + an
+  example with `tab_label` populated.
+- `defaults/tools/ask/extension.ts` — extend the TypeBox `Type.Object({...})` for
+  each question with `tab_label: Type.Optional(Type.String({ minLength: 1, maxLength: 24 }))`.
+  It stays optional at the JSON-schema layer (single-question asks don't need it);
+  server-side validation enforces "required when questions.length > 1".
+
+### Server validation
+- `src/server/agent/ask-user-choices-validation.ts`
+  - Extend `UserQuestion` interface with `tab_label?: string`.
+  - In `validateQuestions()`: if `questions.length > 1`, require every `q.tab_label`
+    to be a non-empty string ≤ 24 chars; reject with a clear error string
+    (`questions[i].tab_label is required for multi-question asks (got <value>)`).
+    Also validate that when present (even in single-question asks) it is a
+    string ≤ 24 chars — so bad input is always rejected.
+  - `crossValidate()` does not need changes (answers don't carry `tab_label`).
+- `src/server/server.ts` (~ line 6276) — no behavioural change needed here;
+  `validateQuestions` is already invoked upstream of the tool_use broadcast via
+  the normal tool parameter pipeline. Confirm during implementation whether
+  `validateQuestions` is called on the tool_use input before broadcasting the
+  widget — if not, add a call at the point that builds `matchedQuestions` so
+  malformed asks surface an error to the agent instead of rendering a broken
+  widget. (See Open Questions #1.)
+
+### Widget
+- `src/ui/components/AskUserChoicesWidget.ts`
+  - Extend `AskQuestion` interface with `tab_label?: string`.
+  - Tab rendering: replace `${idx + 1}. ${q.question.slice(0,40)}` with
+    `${letter(idx)}. ${q.tab_label}` (letter = `String.fromCharCode(65 + idx)`).
+    Only shown when `questions.length > 1` (tabs already hidden otherwise).
+  - Option rendering: prefix every option card's visible text with a numbered
+    badge (`1.`, `2.`, …) via a dedicated `<span class="ask-option-index">`
+    before `.ask-option-text`. "Other" uses `options.length + 1`.
+  - Primary button: compute `isLast = this._activeTab === this.questions.length - 1`
+    in `render()`.
+    - Multi-question + not last → render **Next** button in place of Submit.
+      Disabled until the active question's draft entry is valid (re-use the
+      per-question validity predicate extracted from `_canSubmit()`).
+    - Multi-question + last → render **Submit** (existing behaviour), disabled
+      until all questions valid.
+    - Single-question → unchanged (`_shouldHideSubmit()` already handles this).
+  - Add a keydown listener on the `.ask-widget` root (`@keydown=${this._onKey}`).
+  - New state: `@state() private _focusedOption = 0` — index of focused option
+    card within the active question (0 = first real option, `q.options.length`
+    = "Other" when `allow_other`). Reset to 0 on tab change. Applied as a
+    roving `tabindex="0"` on the focused card, `-1` on others.
+  - Tabs get roving tabindex too: the active tab button has `tabindex="0"`,
+    others `tabindex="-1"`. ArrowLeft/ArrowRight on a focused tab button moves
+    tab focus and activates the new tab (ARIA tablist with automatic activation).
+
+### Fixture (plain-JS mirror)
+- `tests/ask-user-choices-widget.html` — mirror all rendering changes (numbered
+  tabs, numbered options, Next vs. Submit, roving tabindex, keydown handler,
+  Escape/number/letter shortcuts). Every multi-question fixture call must pass
+  `tab_label` so it matches the real widget's expected input.
+
+### Unit tests
+- `tests/ask-user-choices-widget.spec.ts` — update existing multi-question
+  fixtures to include `tab_label`; add new tests (see Test plan §6).
+
+### Browser E2E
+- `tests/e2e/ui/ask-user-choices-ui.spec.ts` — add one keyboard-only
+  multi-question flow; update any existing multi-question scenarios to include
+  `tab_label`.
+
+### Mock agent
+- `tests/e2e/mock-agent-core.mjs` — all multi-question mock ask emissions now
+  include `tab_label` on each question.
+
+## 2. Data model
+
+```ts
+// src/ui/components/AskUserChoicesWidget.ts
+export interface AskQuestion {
+  question: string;
+  options: string[];
+  tab_label?: string;       // NEW — required when questions.length > 1
+  allow_other?: boolean;
+  multi?: boolean;
+  min?: number;
+  max?: number;
+}
+
+// src/server/agent/ask-user-choices-validation.ts
+export interface UserQuestion {
+  question: string;
+  options: string[];
+  tab_label?: string;       // NEW — same semantics
+  allow_other?: boolean;
+  multi?: boolean;
+  min?: number;
+  max?: number;
+}
+```
+
+Validation rule (server):
+- `typeof tab_label === "string"` when present.
+- `tab_label.trim().length >= 1` and `tab_label.length <= 24` when present.
+- If `questions.length > 1`, every question MUST have `tab_label` — reject
+  otherwise. No fallback.
+- Single-question asks: `tab_label` is ignored (not rendered) but still
+  type-checked when present.
+
+## 3. Rendering spec
+
+- **Tab label**: `A. ${q.tab_label}` (letter via `String.fromCharCode(65 + idx)`).
+  Rendered as two spans: `<span class="ask-tab-letter">A.</span>
+  <span class="ask-tab-label">User behaviour</span>`. The `✓` marker logic is
+  unchanged.
+- **Option label**: option card adds a leading
+  `<span class="ask-option-index font-mono">${n}.</span>` before the existing
+  `<span class="ask-option-text">`, where `n = optIdx + 1`. The "Other" row uses
+  `n = q.options.length + 1`. The numbered prefix is styled as a monospace badge
+  so the shortcut (`1`, `2`, …) is obvious.
+- **Primary button**:
+  - Label: `Next` when multi-question and not last; `Submit` when last (or
+    single-question and Submit is shown by existing rules); `Submitting…` while
+    in-flight (unchanged).
+  - `disabled` predicate:
+    - Next: `!_isQuestionValid(this._activeTab)`.
+    - Submit: `!_canSubmit() || _submitting` (unchanged).
+  - Click handler:
+    - Next → `this._activeTab = this._activeTab + 1` and reset `_focusedOption = 0`.
+    - Submit → `_submit()` (unchanged).
+- Mouse/touch flows untouched apart from label strings. Single-select
+  auto-submit (single-question) and auto-advance (multi-question) behaviour
+  preserved.
+
+## 4. Keyboard handling
+
+One keydown listener on `.ask-widget` root. Early-out guard: if
+`document.activeElement` is the `.ask-other-input` text input, only intercept
+**Enter** (submit/next) and **Escape** (clear); never intercept digits or
+letters. All other keys fall through to the text input.
+
+Key map (handler runs only when focus is inside the widget):
+
+| Key | Behaviour |
+|-----|-----------|
+| `ArrowDown` | `_focusedOption = (_focusedOption + 1) % optionCount`; `preventDefault`. Also physically focus the card (for screen-reader parity). |
+| `ArrowUp` | `_focusedOption = (_focusedOption - 1 + optionCount) % optionCount`; `preventDefault`. |
+| `ArrowLeft` / `ArrowRight` | Only when focus is on a tab button: move tab focus + activate new tab (ARIA tablist auto-activation). `preventDefault`. |
+| `Enter` | If the focused element is the primary button, click it. Else if single-question + single-select + a focused option exists → select it (auto-submits via existing path). Else if primary button is enabled → click it (Next or Submit). `preventDefault`. |
+| `Tab` / `Shift+Tab` | Browser default — DOM order is: tablist (one roving stop) → options radiogroup (one roving stop) → Other text input (when present) → primary button. |
+| `Escape` | Clear active question: set `_draft[_activeTab].selected = q.multi ? [] : null` and `_draft[_activeTab].other_text = ""`. `preventDefault`. Do not submit or close. |
+| `1`–`9` | `pickByIndex(n - 1)` on the active question: |
+| | – out-of-range (>= optionCount): ignore. |
+| | – single-select: select the option. Single-question → auto-submits (existing path). Multi-question + not last → auto-advances (existing path). Last question → stay put (user must press Enter to Submit). |
+| | – multi-select: toggle the option (no auto-advance). |
+| | `preventDefault` on accept. Skipped when text input has focus. |
+| `A`–`Z` (case-insensitive) | `jumpToTab(code - 65)` in multi-question asks. Out-of-range ignored. Updates `_activeTab` and resets `_focusedOption = 0`. Single-question asks: ignored. Skipped when text input has focus. |
+
+Helper predicates:
+- `optionCount(qIdx) = q.options.length + (q.allow_other ? 1 : 0)`.
+- `isTextInputFocused()` = `document.activeElement instanceof HTMLInputElement
+  && activeElement.type === "text"`.
+
+## 5. ARIA
+
+- Tab bar: `role="tablist"` (already present); each tab button keeps
+  `role="tab"`, `aria-selected`, plus new `tabindex` (0 for active, -1 for
+  others), and new `aria-controls="ask-panel-${idx}"`.
+- Panel: `role="tabpanel"` gets `id="ask-panel-${idx}"` and
+  `aria-labelledby="ask-tab-${idx}"`.
+- Options container: swap the implicit grouping for
+  `role="radiogroup"` (single-select) or `role="group"` (multi-select) with
+  `aria-label=${q.question}`. Each option `<label>` gets `role="radio"` /
+  `role="checkbox"` and `aria-checked` reflecting state; roving `tabindex`
+  (0 on `_focusedOption`, -1 otherwise).
+- The visually-hidden native `<input>` stays for form semantics and for the
+  fixture tests that already query by `input[type=radio]`.
+
+## 6. Test plan
+
+### Unit (`tests/ask-user-choices-widget.spec.ts`)
+Update first: every existing multi-question fixture gets `tab_label` on each
+question, and label assertions are updated to the new format.
+
+Add:
+1. **Tab label format** — multi-question ask renders `A. <tab_label>` on tab 0,
+   `B. <tab_label>` on tab 1, etc. Letter and label are in separate spans.
+2. **Option label format** — options render `1.`, `2.`, … prefixes; "Other" is
+   `${options.length + 1}.`.
+3. **Next vs. Submit button swap** — in a 2-question ask, question 0 shows Next
+   (disabled with no selection, enabled after selecting), question 1 shows
+   Submit. Clicking Next on q0 advances to q1; Submit on q1 submits.
+4. **ArrowDown / ArrowUp** — move `_focusedOption` with wrap-around; radio
+   `tabindex` follows.
+5. **ArrowLeft / ArrowRight** on tab button — move tab focus and activate new
+   tab.
+6. **Enter on primary button** — clicks Next or Submit depending on active tab.
+7. **Enter on focused option (single-question, single-select)** — selects and
+   auto-submits.
+8. **Escape clears** — single-select clears to `null`; multi-select clears to
+   `[]`; `other_text` reset to `""`. Does not submit or advance tab.
+9. **Number key 1–9 pick** —
+   - single-select + multi-question + non-last: auto-advances to next tab.
+   - single-select + multi-question + last: selects, no advance.
+   - single-select + single-question: auto-submits.
+   - multi-select: toggles the option.
+   - out-of-range (e.g. `7` with 3 options): no-op.
+10. **Letter key A–Z jump** — A focuses tab 0, B focuses tab 1, etc. Out-of-range
+    is a no-op. Single-question ask ignores letter keys.
+11. **No hijack while typing in Other** — focus the `.ask-other-input`, press
+    `3`, `b`: text field receives the characters, widget does not intercept.
+    Only Enter (submit) and Escape (clear) still intercept from inside the
+    Other input.
+12. **"Other" numbering** — option list with `allow_other: true` renders the
+    Other row with `${options.length + 1}.`; pressing that number key selects
+    Other (single-select — reveals text input; multi-select — toggles).
+
+### Server validation (`tests/ask-user-choices-validation.spec.ts` if present, else a new one)
+13. `validateQuestions` rejects a 2-question ask where `tab_label` is missing on
+    any question; error message mentions `tab_label` and the question index.
+14. `validateQuestions` rejects `tab_label` longer than 24 chars.
+15. `validateQuestions` accepts a single-question ask without `tab_label`.
+16. `validateQuestions` accepts a multi-question ask where every question has a
+    valid `tab_label`.
+
+### Browser E2E (`tests/e2e/ui/ask-user-choices-ui.spec.ts`)
+17. **Keyboard-only multi-question submission** — mock agent emits a
+    2-question ask (both with `tab_label`); test focuses the widget, presses
+    `1` (picks option 1, auto-advances to q2), presses `2` (picks option 2, no
+    advance — last question), presses `Enter` (Submit). Assert the submitted
+    envelope matches and the widget is read-only.
+
+## 7. Out of scope
+
+- No changes to mouse/touch flows other than label strings (numbered tabs/options,
+  Next vs. Submit).
+- **No fallback** for missing `tab_label` — server rejects multi-question asks
+  without it. No auto-generation from `question` text.
+- No changes to the `ask_user_choices_response` envelope format. Answers
+  continue to carry `{ question, selected, other_text }` only.
+- No new CSS theme tokens — reuse existing `border-border`, `bg-card`, etc.
+- No changes to `min`/`max` semantics.
+
+## 8. Open questions
+
+1. **Where does `validateQuestions` run on inbound tool_use?** The current
+   codebase calls it in the `/api/internal/user-question/submit` path (against
+   the transcript-captured input). We should confirm whether the tool_use is
+   validated when first broadcast to the UI — if not, an invalid multi-question
+   ask would render a broken tab bar before the submit path catches it. If the
+   validator isn't wired there yet, the implementer should add a call either in
+   the tool extension's `execute` (return an error content instead of the stub)
+   or in the WS broadcast pipeline so the agent gets immediate feedback. Either
+   path is acceptable — flag for the coder.
+2. **Case of letter shortcut**: spec says A–Z; should we also accept
+   lowercase `a`–`z`? Recommendation: yes (compare `event.key.toUpperCase()`);
+   cheap and user-friendly. Flagged in case the reviewer prefers strict.
+3. **Enter inside the Other text input**: currently submit when valid — confirm
+   this is still desired (design assumes yes; matches existing behaviour
+   preserved by not intercepting anything else from the text input).

--- a/docs/non-blocking-ask.md
+++ b/docs/non-blocking-ask.md
@@ -107,6 +107,31 @@ The envelope is a regular user message persisted to the session `.jsonl`. Everyt
 
 No `/pending` endpoint, no in-memory map, no rejection listener. The transcript is the state.
 
+## Widget UX
+
+The interactive widget is a Lit component (`<ask-user-choices-widget>`) rendered inside the `ask_user_choices` tool card. Its shape is driven entirely by the tool input — see `defaults/tools/ask/ask_user_choices.yaml` for the agent-facing contract. Summary for docs readers:
+
+### Labels
+
+- **Tabs** (multi-question asks only): `A. <tab_label>`, `B. <tab_label>`, … The letter prefix doubles as the tab-jump shortcut (see below); `tab_label` is required on every question when `questions.length > 1` and must be 2–4 words, ≤24 chars. The server rejects the call with a clear error if any question is missing it. Single-question asks hide the tab strip and ignore `tab_label`.
+- **Options**: every option is prefixed with a numeric badge (`1.`, `2.`, …) matching the number-key shortcut. The "Other" choice (when `allow_other: true`) takes the next number in sequence.
+- **Primary button**: on a multi-question ask, every tab except the last shows **Next** (advances to the next tab, disabled until the current question has a valid selection). The last tab shows **Submit**. Single-question asks keep the existing behaviour — single-select auto-submits on pick, multi-select / Other shows **Submit**.
+
+### Keyboard map
+
+A single keydown listener on the widget root handles shortcuts. While focus is inside the "Other" text field, only Enter and Escape are intercepted so normal typing works.
+
+| Key | Effect |
+|---|---|
+| Arrow Up / Down | Move focus between options (wraps at ends). |
+| Arrow Left / Right | On tab buttons, move across tabs (standard ARIA tablist). |
+| Enter | Click the primary button (Next / Submit). On a single-question single-select ask, picks the focused option and auto-submits. |
+| Escape | Clear the current question's selection and any "Other" text. Does not submit or close. |
+| 1–9 | Pick the option at that 1-based index on the active question. Single-select auto-submits (single-question) or auto-advances (multi-question); multi-select toggles. |
+| A–Z | Jump to the corresponding tab. Multi-question asks only. |
+
+The widget uses ARIA `role="radiogroup"` / `role="radio"` for options and the standard tablist pattern for tabs, with roving `tabindex` so screen readers announce selection state correctly. Mouse/touch behaviour is unchanged.
+
 ## Rendering note
 
 Envelope user messages are hidden from the **rendered** transcript by `src/ui/components/AgentInterface.ts` (via `isAskResponseEnvelope`). They're still present in the `.jsonl` and still sent to the LLM — the agent sees them on its next turn as part of history. The UI omits them because the answered widget card is the human-readable representation; showing both would be redundant.
@@ -121,6 +146,7 @@ Envelope user messages are hidden from the **rendered** transcript by `src/ui/co
 | `src/server/server.ts` — `POST /api/internal/user-question/submit` | Validate, cross-check against transcript, idempotency check, enqueue envelope via `sessionManager.enqueuePrompt`. |
 | `src/server/agent/ask-user-choices-validation.ts` | Input validators (`validateQuestions`, `validateAnswers`, `crossValidate`) shared by the submit handler. |
 | `src/ui/tools/renderers/AskUserChoicesRenderer.ts` | Two-mode rendering (interactive vs answered) via `ctx.getAskResponseAnswers(toolUseId)`. |
+| `src/ui/components/AskUserChoicesWidget.ts` | Interactive Lit widget: tabs, numbered option badges, keyboard navigation, ARIA radiogroup/tablist. |
 | `src/ui/components/AgentInterface.ts` | Filters envelope user messages out of the rendered transcript. |
 | `src/app/remote-agent.ts` | Exposes `findAskResponseAnswers` to renderers; dispatches `bobbit-transcript-message` on new user messages so tool cards re-render. |
 

--- a/src/server/agent/ask-user-choices-validation.ts
+++ b/src/server/agent/ask-user-choices-validation.ts
@@ -10,6 +10,12 @@
 export interface UserQuestion {
 	question: string;
 	options: string[];
+	/**
+	 * Short tab label (2–4 words, ≤24 chars). Required when the ask contains
+	 * more than one question; ignored for single-question asks. Rendered on the
+	 * tab strip as `A. <tab_label>`, `B. <tab_label>`, …
+	 */
+	tab_label?: string;
 	allow_other?: boolean;
 	/** When true, the UI renders checkboxes and `selected` is an array. */
 	multi?: boolean;
@@ -39,12 +45,24 @@ export function validateQuestions(questions: unknown): string | null {
 	if (questions.length < 1 || questions.length > 5) {
 		return `questions must contain 1-5 items (got ${questions.length})`;
 	}
+	const isMulti = questions.length > 1;
 	for (let i = 0; i < questions.length; i++) {
 		const q = questions[i];
 		if (!q || typeof q !== "object") return `questions[${i}] must be an object`;
 		const qq = q as Record<string, unknown>;
 		if (typeof qq.question !== "string" || qq.question.trim().length === 0) {
 			return `questions[${i}].question must be a non-empty string`;
+		}
+		if (qq.tab_label !== undefined) {
+			if (typeof qq.tab_label !== "string" || qq.tab_label.trim().length === 0) {
+				return `questions[${i}].tab_label must be a non-empty string if present`;
+			}
+			if (qq.tab_label.length > 24) {
+				return `questions[${i}].tab_label must be ≤24 characters (got ${qq.tab_label.length})`;
+			}
+		}
+		if (isMulti && (typeof qq.tab_label !== "string" || qq.tab_label.trim().length === 0)) {
+			return `questions[${i}].tab_label is required when posting more than one question (2–4 words, ≤24 chars)`;
 		}
 		if (!Array.isArray(qq.options)) return `questions[${i}].options must be an array`;
 		if (qq.options.length < 2 || qq.options.length > 8) {

--- a/src/ui/components/AskUserChoicesWidget.ts
+++ b/src/ui/components/AskUserChoicesWidget.ts
@@ -1,15 +1,36 @@
 /**
  * Interactive widget rendered inline in the chat for the `ask_user_choices` tool.
  *
- * - Tabs across the top (one per question).
- * - Options render as radio/checkbox cards. The native input is visually hidden
- *   (sr-only) and card styling (border-primary + a ✓ badge) signals selection.
+ * - Tabs across the top (one per question). Tab titles use
+ *   `${letter(idx)}. ${tab_label}` (A., B., …) for multi-question asks.
+ * - Options render as radio/checkbox cards prefixed with a numeric badge
+ *   (`1.`, `2.`, …) so the number-key shortcut is discoverable.
  * - Single-select: selecting a non-"Other" option auto-advances to the next tab.
  * - Multi-select (`multi: true`): checkboxes; no auto-advance.
  * - "Other" (when enabled) reveals a text input; does NOT auto-advance.
+ * - On multi-question asks, the primary button reads **Next** on every tab
+ *   except the last, where it reads **Submit** (existing behaviour).
  * - Submit is disabled until every question has a valid selection (respecting
  *   min/max for multi-select).
  * - Once submitted (or `answers` prop is populated), the widget is read-only.
+ *
+ * ## Keyboard navigation
+ *
+ * A single keydown listener on the `.ask-widget` root handles:
+ *   - Arrow Up/Down      — move focus between options (wraps).
+ *   - Arrow Left/Right   — (on tab buttons) move across tabs.
+ *   - Enter              — click the primary button (Next/Submit), or on a
+ *                          single-question single-select ask pick the focused
+ *                          option and auto-submit.
+ *   - Escape             — clear the current question's selection and any
+ *                          "Other" text. Does not submit.
+ *   - 1–9                — pick the option by 1-based index on the active
+ *                          question. Single-select auto-submits (single-q) or
+ *                          auto-advances (multi-q). Multi-select toggles.
+ *   - A–Z (a–z)          — jump to the corresponding tab (multi-question only).
+ *
+ * While focus is inside the `.ask-other-input` text field, only Enter and
+ * Escape are intercepted; letters/numbers go to the input as normal.
  */
 import { LitElement, html, nothing, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
@@ -32,6 +53,8 @@ export const OTHER_SENTINEL = "__OTHER__";
 export interface AskQuestion {
 	question: string;
 	options: string[];
+	/** Short topical tab label (2–4 words, ≤24 chars). Required for multi-question asks. */
+	tab_label?: string;
 	allow_other?: boolean;
 	multi?: boolean;
 	min?: number;
@@ -51,6 +74,10 @@ interface DraftEntry {
 	other_text: string;
 }
 
+function tabLetter(idx: number): string {
+	return String.fromCharCode(65 + idx);
+}
+
 @customElement("ask-user-choices-widget")
 export class AskUserChoicesWidget extends LitElement {
 	@property({ attribute: false }) questions: AskQuestion[] = [];
@@ -62,6 +89,7 @@ export class AskUserChoicesWidget extends LitElement {
 	@property({ type: String }) errorText = "";
 
 	@state() private _activeTab = 0;
+	@state() private _focusedOption = 0;
 	@state() private _draft: DraftEntry[] = [];
 	@state() private _submitting = false;
 	@state() private _submitError = "";
@@ -90,12 +118,50 @@ export class AskUserChoicesWidget extends LitElement {
 				other_text: "",
 			}));
 			this._activeTab = Math.min(this._activeTab, Math.max(0, this.questions.length - 1));
+			this._focusedOption = 0;
 		}
+	}
+
+	private _optionCount(qIdx: number): number {
+		const q = this.questions[qIdx];
+		if (!q) return 0;
+		return q.options.length + (q.allow_other ? 1 : 0);
+	}
+
+	/** Return the option value (including OTHER_SENTINEL) at 0-based index. */
+	private _optionValueAt(qIdx: number, optIdx: number): string | null {
+		const q = this.questions[qIdx];
+		if (!q) return null;
+		if (optIdx < 0) return null;
+		if (optIdx < q.options.length) return q.options[optIdx];
+		if (q.allow_other && optIdx === q.options.length) return OTHER_SENTINEL;
+		return null;
 	}
 
 	private _selectTab(idx: number): void {
 		if (idx < 0 || idx >= this.questions.length) return;
-		this._activeTab = idx;
+		if (this._activeTab !== idx) {
+			this._activeTab = idx;
+			this._focusedOption = 0;
+		}
+	}
+
+	private _isQuestionValid(qIdx: number): boolean {
+		const q = this.questions[qIdx];
+		const d = this._draft[qIdx];
+		if (!q || !d) return false;
+		if (q.multi) {
+			const arr = Array.isArray(d.selected) ? d.selected : [];
+			const maxOptionCount = q.options.length + (q.allow_other ? 1 : 0);
+			const min = q.min ?? 1;
+			const max = q.max ?? maxOptionCount;
+			if (arr.length < min || arr.length > max) return false;
+			if (arr.includes(OTHER_SENTINEL) && !d.other_text.trim()) return false;
+			return true;
+		}
+		if (!d.selected || Array.isArray(d.selected)) return false;
+		if (d.selected === OTHER_SENTINEL && !d.other_text.trim()) return false;
+		return true;
 	}
 
 	private _selectOption(qIdx: number, option: string): void {
@@ -128,7 +194,10 @@ export class AskUserChoicesWidget extends LitElement {
 		if (option !== OTHER_SENTINEL && qIdx < this.questions.length - 1) {
 			const nextIdx = qIdx + 1;
 			setTimeout(() => {
-				if (this._activeTab === qIdx) this._activeTab = nextIdx;
+				if (this._activeTab === qIdx) {
+					this._activeTab = nextIdx;
+					this._focusedOption = 0;
+				}
 			}, 250);
 		}
 	}
@@ -157,25 +226,45 @@ export class AskUserChoicesWidget extends LitElement {
 
 	private _canSubmit(): boolean {
 		if (this._draft.length !== this.questions.length) return false;
-		return this._draft.every((d, i) => {
-			const q = this.questions[i];
-			if (q.multi) {
-				const arr = Array.isArray(d.selected) ? d.selected : [];
-				const maxOptionCount = q.options.length + (q.allow_other ? 1 : 0);
-				const min = q.min ?? 1;
-				const max = q.max ?? maxOptionCount;
-				if (arr.length < min || arr.length > max) return false;
-				if (arr.includes(OTHER_SENTINEL) && !d.other_text.trim()) return false;
-				return true;
-			}
-			if (!d.selected || Array.isArray(d.selected)) return false;
-			if (d.selected === OTHER_SENTINEL && !d.other_text.trim()) return false;
-			return true;
-		});
+		return this._draft.every((_d, i) => this._isQuestionValid(i));
 	}
 
 	private _isReadOnly(): boolean {
 		return Array.isArray(this.answers) || this.errored;
+	}
+
+	private _isLastTab(): boolean {
+		return this._activeTab === this.questions.length - 1;
+	}
+
+	/** Next button is shown when there are multiple questions and the active tab is not the last. */
+	private _showNext(): boolean {
+		return this.questions.length > 1 && !this._isLastTab();
+	}
+
+	private _clickPrimary(): void {
+		if (this._isReadOnly()) return;
+		if (this._showNext()) {
+			if (this._isQuestionValid(this._activeTab)) {
+				this._activeTab = this._activeTab + 1;
+				this._focusedOption = 0;
+			}
+			return;
+		}
+		void this._submit();
+	}
+
+	private _clearActive(): void {
+		if (this._isReadOnly()) return;
+		const qIdx = this._activeTab;
+		const q = this.questions[qIdx];
+		if (!q) return;
+		this._draft = this._draft.map((d, i) =>
+			i === qIdx
+				? { selected: q.multi ? [] : null, other_text: "" }
+				: d,
+		);
+		this._submitError = "";
 	}
 
 	private async _submit(): Promise<void> {
@@ -223,18 +312,171 @@ export class AskUserChoicesWidget extends LitElement {
 		}
 	}
 
+	// ── Keyboard handling ──────────────────────────────────────────────
+
+	private _isTextInputFocused(): boolean {
+		const el = document.activeElement as HTMLElement | null;
+		if (!el) return false;
+		if (el.tagName === "TEXTAREA") return true;
+		if (el.tagName === "INPUT") {
+			const t = (el as HTMLInputElement).type?.toLowerCase() || "text";
+			// Radios/checkboxes are sr-only but never focused for typing; treat them as non-text.
+			return !(t === "radio" || t === "checkbox" || t === "button" || t === "submit");
+		}
+		return false;
+	}
+
+	private _onKeydown = (e: KeyboardEvent): void => {
+		if (this._isReadOnly()) return;
+		const key = e.key;
+		const textFocused = this._isTextInputFocused();
+
+		// Inside the Other text input only Enter (submit/advance) and Escape
+		// (clear) intercept — everything else goes to the browser default.
+		if (textFocused) {
+			if (key === "Escape") {
+				e.preventDefault();
+				this._clearActive();
+				return;
+			}
+			if (key === "Enter") {
+				if (this._isQuestionValid(this._activeTab)) {
+					e.preventDefault();
+					this._clickPrimary();
+				}
+				return;
+			}
+			return;
+		}
+
+		const target = e.target as HTMLElement | null;
+		const onTab = !!target?.closest?.('[role="tab"]');
+
+		if (key === "ArrowLeft" || key === "ArrowRight") {
+			if (onTab && this.questions.length > 1) {
+				e.preventDefault();
+				const dir = key === "ArrowRight" ? 1 : -1;
+				const next = (this._activeTab + dir + this.questions.length) % this.questions.length;
+				this._selectTab(next);
+				// Move focus to the newly active tab button (roving tabindex).
+				setTimeout(() => {
+					const btn = this.querySelector(
+						`[role="tab"][data-tab-index="${next}"]`,
+					) as HTMLButtonElement | null;
+					btn?.focus();
+				}, 0);
+			}
+			return;
+		}
+
+		const count = this._optionCount(this._activeTab);
+
+		if (key === "ArrowDown") {
+			if (count > 0) {
+				e.preventDefault();
+				this._focusedOption = (this._focusedOption + 1) % count;
+			}
+			return;
+		}
+		if (key === "ArrowUp") {
+			if (count > 0) {
+				e.preventDefault();
+				this._focusedOption = (this._focusedOption - 1 + count) % count;
+			}
+			return;
+		}
+
+		if (key === "Escape") {
+			e.preventDefault();
+			this._clearActive();
+			return;
+		}
+
+		if (key === "Enter") {
+			// If focus is on the primary (Next/Submit) button, let the native
+			// click handler do the work — don't preventDefault or double-fire.
+			if (target?.closest?.(".ask-submit")) return;
+
+			// Single-question single-select: Enter picks the focused option and
+			// auto-submits (the option pick schedules the submit).
+			const q = this.questions[this._activeTab];
+			if (q && !q.multi && this.questions.length === 1) {
+				const value = this._optionValueAt(this._activeTab, this._focusedOption);
+				if (value !== null) {
+					e.preventDefault();
+					this._selectOption(this._activeTab, value);
+					return;
+				}
+			}
+
+			// Otherwise, act like the primary button if it would be enabled.
+			const canAct = this._showNext()
+				? this._isQuestionValid(this._activeTab)
+				: (this._canSubmit() && !this._submitting);
+			if (canAct) {
+				e.preventDefault();
+				this._clickPrimary();
+			}
+			return;
+		}
+
+		// Number keys 1–9 pick by index on the active question.
+		if (/^[1-9]$/.test(key)) {
+			const idx = parseInt(key, 10) - 1;
+			const value = this._optionValueAt(this._activeTab, idx);
+			if (value === null) return; // out-of-range → no-op
+			e.preventDefault();
+			const q = this.questions[this._activeTab];
+			this._focusedOption = idx;
+			if (q?.multi) {
+				// Multi-select: toggle only, never advance/submit.
+				this._selectOption(this._activeTab, value);
+				return;
+			}
+			// Single-select: delegate to _selectOption which handles:
+			//   - single-question → auto-submit
+			//   - multi-question non-last → auto-advance
+			//   - multi-question last or Other → stay put
+			this._selectOption(this._activeTab, value);
+			return;
+		}
+
+		// Letter keys A–Z jump tabs on multi-question asks.
+		if (this.questions.length > 1 && /^[A-Za-z]$/.test(key)) {
+			const idx = key.toUpperCase().charCodeAt(0) - 65;
+			if (idx >= 0 && idx < this.questions.length) {
+				e.preventDefault();
+				this._selectTab(idx);
+				setTimeout(() => {
+					const btn = this.querySelector(
+						`[role="tab"][data-tab-index="${idx}"]`,
+					) as HTMLButtonElement | null;
+					btn?.focus();
+				}, 0);
+			}
+			return;
+		}
+	};
+
 	// ── Rendering ──────────────────────────────────────────────────────
 
 	override render(): TemplateResult | typeof nothing {
 		if (this.errored) {
-			return html`<div class="text-xs text-destructive">${this.errorText || "ask_user_choices failed."}</div>`;
+			return html`<div class="ask-error text-xs text-destructive">${this.errorText || "ask_user_choices failed."}</div>`;
 		}
 		if (!Array.isArray(this.questions) || this.questions.length === 0) return nothing;
 		const readOnly = this._isReadOnly();
 		const showTabs = this.questions.length > 1;
 		const hideSubmit = this._shouldHideSubmit();
+		const showNext = !readOnly && this._showNext();
+		const primaryDisabled = showNext
+			? !this._isQuestionValid(this._activeTab)
+			: (!this._canSubmit() || this._submitting);
+		const primaryLabel = this._submitting
+			? "Submitting…"
+			: showNext ? "Next" : "Submit";
 		return html`
-			<div class="ask-widget border border-border rounded p-3 bg-card">
+			<div class="ask-widget border border-border rounded p-3 bg-card" @keydown=${this._onKeydown}>
 				${showTabs ? html`
 				<div role="tablist" class="flex flex-wrap gap-1 border-b border-border mb-3">
 					${this.questions.map((_, i) => this._renderTab(i))}
@@ -248,9 +490,9 @@ export class AskUserChoicesWidget extends LitElement {
 						<button
 							type="button"
 							class="ask-submit px-3 py-1 text-xs font-medium rounded bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer transition-opacity"
-							?disabled=${!this._canSubmit() || this._submitting}
-							@click=${this._submit}>
-							${this._submitting ? "Submitting…" : "Submit"}
+							?disabled=${primaryDisabled}
+							@click=${this._clickPrimary}>
+							${primaryLabel}
 						</button>
 					</div>` : nothing}
 			</div>`;
@@ -269,7 +511,8 @@ export class AskUserChoicesWidget extends LitElement {
 		const isActive = idx === this._activeTab;
 		const readOnly = this._isReadOnly();
 		const answered = this._tabAnswered(idx, readOnly);
-		const label = (q?.question || `Q${idx + 1}`).slice(0, 40);
+		const rawLabel = (q?.tab_label && q.tab_label.trim()) || q?.question || `Q${idx + 1}`;
+		const label = rawLabel.slice(0, 40);
 		const cls = [
 			"ask-tab px-2 py-1 text-xs rounded-t cursor-pointer border border-b-0",
 			isActive ? "bg-background border-border font-medium" : "bg-transparent border-transparent text-muted-foreground hover:text-foreground",
@@ -279,11 +522,14 @@ export class AskUserChoicesWidget extends LitElement {
 				type="button"
 				role="tab"
 				aria-selected=${isActive ? "true" : "false"}
+				aria-controls=${`ask-panel-${this.toolUseId}-${idx}`}
+				id=${`ask-tab-${this.toolUseId}-${idx}`}
 				data-tab-index=${idx}
+				tabindex=${isActive ? "0" : "-1"}
 				class=${cls}
 				@click=${() => this._selectTab(idx)}>
-				<span class="ask-tab-index">${idx + 1}.</span>
-				<span class="ask-tab-label">${label}</span>
+				<span class="ask-tab-letter font-mono">${tabLetter(idx)}.</span>
+				<span class="ask-tab-label ml-1">${label}</span>
 				${answered ? html`<span class="ask-tab-check ml-1 text-green-600 dark:text-green-400">✓</span>` : nothing}
 			</button>`;
 	}
@@ -319,40 +565,62 @@ export class AskUserChoicesWidget extends LitElement {
 		const otherText = readOnly && answer && otherChecked
 			? (answer.other_text || "")
 			: draft.other_text;
+		const groupRole = q.multi ? "group" : "radiogroup";
 
 		// Key options by `${idx}::${opt}` so Lit rebuilds option DOM when the
 		// active tab changes. Without keying, the <label>/<input> nodes are
 		// reused across panels, which on mobile leaves stale radio state (the
 		// browser treats the "same" radio as already-interacted-with and the
 		// next tap may not fire a `change` event).
+		const panelId = `ask-panel-${this.toolUseId}-${idx}`;
+		const tabId = `ask-tab-${this.toolUseId}-${idx}`;
 		return html`
-			<div role="tabpanel" data-panel-index=${idx} class="ask-panel">
+			<div
+				role="tabpanel"
+				id=${panelId}
+				aria-labelledby=${tabId}
+				data-panel-index=${idx}
+				class="ask-panel">
 				<div class="ask-question text-sm font-medium mb-2">${q.question}</div>
-				<div class="ask-options flex flex-col gap-1.5">
+				<div
+					class="ask-options flex flex-col gap-1.5"
+					role=${groupRole}
+					aria-label=${q.question}>
 					${repeat(
 						q.options,
 						(opt) => `${idx}::${opt}`,
-						(opt) => this._renderOption(idx, opt, this._isOptionChecked(idx, opt, readOnly), readOnly),
+						(opt, optIdx) => this._renderOption(idx, opt, optIdx, this._isOptionChecked(idx, opt, readOnly), readOnly),
 					)}
 					${q.allow_other
 						? repeat(
 							[OTHER_SENTINEL],
 							() => `${idx}::__other__`,
-							() => this._renderOtherOption(idx, otherChecked, otherText, readOnly),
+							() => this._renderOtherOption(idx, q.options.length, otherChecked, otherText, readOnly),
 						)
 						: nothing}
 				</div>
 			</div>`;
 	}
 
-	private _renderOption(qIdx: number, option: string, checked: boolean, readOnly: boolean): TemplateResult {
+	private _renderOption(
+		qIdx: number,
+		option: string,
+		optIdx: number,
+		checked: boolean,
+		readOnly: boolean,
+	): TemplateResult {
 		const q = this.questions[qIdx];
 		const multi = !!q?.multi;
+		const isFocused = !readOnly && qIdx === this._activeTab && this._focusedOption === optIdx;
 		const cls = [
 			"ask-option flex items-center gap-2 p-2 text-sm rounded border",
 			checked ? "border-primary bg-primary/10" : "border-border",
+			isFocused ? "ask-option-focused ring-2 ring-primary/50" : "",
 			readOnly ? "cursor-default opacity-90" : "cursor-pointer hover:bg-muted",
-		].join(" ");
+		].filter(Boolean).join(" ");
+		const role = multi ? "checkbox" : "radio";
+		const ariaChecked = checked ? "true" : "false";
+		const rovingTabindex = isFocused ? "0" : "-1";
 		const inputAttrs = multi
 			? html`<input
 					type="checkbox"
@@ -370,8 +638,15 @@ export class AskUserChoicesWidget extends LitElement {
 					?disabled=${readOnly}
 					@change=${() => this._selectOption(qIdx, option)}>`;
 		return html`
-			<label class=${cls}>
+			<label
+				class=${cls}
+				role=${role}
+				aria-checked=${ariaChecked}
+				tabindex=${readOnly ? "-1" : rovingTabindex}
+				data-option-index=${optIdx}
+				@focus=${() => { if (!readOnly) this._focusedOption = optIdx; }}>
 				${inputAttrs}
+				<span class="ask-option-index font-mono text-xs text-muted-foreground w-4 text-right select-none" aria-hidden="true">${optIdx + 1}.</span>
 				<span class="ask-option-check inline-flex items-center justify-center w-4 h-4 rounded-full border pointer-events-none ${checked ? "border-primary bg-primary text-primary-foreground" : "border-border text-transparent"}" aria-hidden="true">
 					${checked ? html`<span class="ask-check-glyph text-[10px] leading-none">✓</span>` : nothing}
 				</span>
@@ -379,14 +654,25 @@ export class AskUserChoicesWidget extends LitElement {
 			</label>`;
 	}
 
-	private _renderOtherOption(qIdx: number, checked: boolean, otherText: string, readOnly: boolean): TemplateResult {
+	private _renderOtherOption(
+		qIdx: number,
+		optIdx: number,
+		checked: boolean,
+		otherText: string,
+		readOnly: boolean,
+	): TemplateResult {
 		const q = this.questions[qIdx];
 		const multi = !!q?.multi;
+		const isFocused = !readOnly && qIdx === this._activeTab && this._focusedOption === optIdx;
 		const cls = [
 			"ask-option ask-option-other flex items-center gap-2 p-2 text-sm rounded border",
 			checked ? "border-primary bg-primary/10" : "border-border",
+			isFocused ? "ask-option-focused ring-2 ring-primary/50" : "",
 			readOnly ? "cursor-default opacity-90" : "cursor-pointer hover:bg-muted",
-		].join(" ");
+		].filter(Boolean).join(" ");
+		const role = multi ? "checkbox" : "radio";
+		const ariaChecked = checked ? "true" : "false";
+		const rovingTabindex = isFocused ? "0" : "-1";
 		const inputEl = multi
 			? html`<input
 					type="checkbox"
@@ -404,8 +690,15 @@ export class AskUserChoicesWidget extends LitElement {
 					?disabled=${readOnly}
 					@change=${() => this._selectOption(qIdx, OTHER_SENTINEL)}>`;
 		return html`
-			<label class=${cls}>
+			<label
+				class=${cls}
+				role=${role}
+				aria-checked=${ariaChecked}
+				tabindex=${readOnly ? "-1" : rovingTabindex}
+				data-option-index=${optIdx}
+				@focus=${() => { if (!readOnly) this._focusedOption = optIdx; }}>
 				${inputEl}
+				<span class="ask-option-index font-mono text-xs text-muted-foreground w-4 text-right select-none" aria-hidden="true">${optIdx + 1}.</span>
 				<span class="ask-option-check inline-flex items-center justify-center w-4 h-4 rounded-full border pointer-events-none ${checked ? "border-primary bg-primary text-primary-foreground" : "border-border text-transparent"}" aria-hidden="true">
 					${checked ? html`<span class="ask-check-glyph text-[10px] leading-none">✓</span>` : nothing}
 				</span>

--- a/tests/ask-user-choices-validation.test.ts
+++ b/tests/ask-user-choices-validation.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for src/server/agent/ask-user-choices-validation.ts —
+ * specifically the `tab_label` rules added alongside the widget's keyboard
+ * navigation work.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { validateQuestions } from "../src/server/agent/ask-user-choices-validation.ts";
+
+describe("validateQuestions — tab_label", () => {
+	it("accepts a single-question ask without tab_label", () => {
+		const err = validateQuestions([
+			{ question: "Only?", options: ["a", "b"] },
+		]);
+		assert.equal(err, null);
+	});
+
+	it("accepts a single-question ask with a valid tab_label", () => {
+		const err = validateQuestions([
+			{ question: "Only?", options: ["a", "b"], tab_label: "Topic" },
+		]);
+		assert.equal(err, null);
+	});
+
+	it("accepts a multi-question ask where every question has a valid tab_label", () => {
+		const err = validateQuestions([
+			{ question: "Q1", options: ["a", "b"], tab_label: "First" },
+			{ question: "Q2", options: ["c", "d"], tab_label: "Second" },
+		]);
+		assert.equal(err, null);
+	});
+
+	it("rejects a multi-question ask when any tab_label is missing", () => {
+		const err = validateQuestions([
+			{ question: "Q1", options: ["a", "b"], tab_label: "First" },
+			{ question: "Q2", options: ["c", "d"] },
+		]);
+		assert.ok(err);
+		assert.match(err!, /tab_label/);
+		assert.match(err!, /\[1\]/);
+	});
+
+	it("rejects a multi-question ask when tab_label is an empty string", () => {
+		const err = validateQuestions([
+			{ question: "Q1", options: ["a", "b"], tab_label: "" },
+			{ question: "Q2", options: ["c", "d"], tab_label: "Second" },
+		]);
+		assert.ok(err);
+		assert.match(err!, /tab_label/);
+	});
+
+	it("rejects tab_label longer than 24 characters", () => {
+		const longLabel = "x".repeat(25);
+		const err = validateQuestions([
+			{ question: "Q1", options: ["a", "b"], tab_label: longLabel },
+			{ question: "Q2", options: ["c", "d"], tab_label: "Second" },
+		]);
+		assert.ok(err);
+		assert.match(err!, /24/);
+	});
+
+	it("rejects tab_label longer than 24 characters on a single-question ask", () => {
+		// Even if optional, when present it must be valid.
+		const longLabel = "x".repeat(25);
+		const err = validateQuestions([
+			{ question: "Only?", options: ["a", "b"], tab_label: longLabel },
+		]);
+		assert.ok(err);
+		assert.match(err!, /24/);
+	});
+
+	it("rejects non-string tab_label", () => {
+		const err = validateQuestions([
+			{ question: "Q1", options: ["a", "b"], tab_label: 42 as any },
+			{ question: "Q2", options: ["c", "d"], tab_label: "Second" },
+		]);
+		assert.ok(err);
+		assert.match(err!, /tab_label/);
+	});
+});

--- a/tests/ask-user-choices-widget.html
+++ b/tests/ask-user-choices-widget.html
@@ -9,12 +9,16 @@
   [role="tablist"] { display: flex; gap: 4px; border-bottom: 1px solid #444; margin-bottom: 12px; flex-wrap: wrap; }
   .ask-tab { padding: 4px 8px; font-size: 12px; border: 1px solid transparent; border-radius: 4px 4px 0 0; background: transparent; color: #aaa; cursor: pointer; }
   .ask-tab[aria-selected="true"] { background: #1a1a2e; border-color: #444; border-bottom-color: transparent; color: #fff; font-weight: 500; }
+  .ask-tab-letter { font-family: ui-monospace, monospace; }
+  .ask-tab-label { margin-left: 4px; }
   .ask-tab-check { color: #22c55e; margin-left: 4px; }
   .ask-question { font-size: 14px; font-weight: 500; margin-bottom: 8px; }
   .ask-options { display: flex; flex-direction: column; gap: 6px; }
   .ask-option { display: flex; align-items: center; gap: 8px; padding: 8px; font-size: 14px; border: 1px solid #444; border-radius: 4px; cursor: pointer; }
   .ask-option.checked { border-color: #3b82f6; background: rgba(59,130,246,0.1); }
+  .ask-option.ask-option-focused { box-shadow: 0 0 0 2px rgba(59,130,246,0.4); }
   .ask-option[data-disabled="true"] { cursor: default; opacity: 0.9; }
+  .ask-option-index { font-family: ui-monospace, monospace; font-size: 11px; color: #888; width: 18px; text-align: right; user-select: none; }
   .ask-option-check { display: inline-flex; align-items: center; justify-content: center; width: 16px; height: 16px; border-radius: 50%; border: 1px solid #444; font-size: 10px; line-height: 1; color: transparent; pointer-events: none; }
   .ask-option.checked .ask-option-check { border-color: #3b82f6; background: #3b82f6; color: #fff; }
   .ask-other-input { margin-left: 8px; flex: 1; padding: 4px 8px; font-size: 12px; border: 1px solid #444; border-radius: 4px; background: #1a1a2e; color: #eee; }
@@ -51,9 +55,15 @@
 
 const OTHER_SENTINEL = "__OTHER__";
 
+function tabLetter(idx) { return String.fromCharCode(65 + idx); }
+
 class AskWidget {
   constructor(mount, opts) {
     this.mount = mount;
+    // Attach keydown on the stable mount element so focus survives re-renders
+    // of the inner `.ask-widget` subtree. Mirrors Lit's template-stable root
+    // behaviour in AskUserChoicesWidget.ts.
+    mount.addEventListener("keydown", (e) => this.onKeydown(e));
     this.questions = opts.questions;
     this.answers = opts.answers || null;
     this.sessionId = opts.sessionId || "";
@@ -63,6 +73,7 @@ class AskWidget {
     this.submitUrl = opts.submitUrl || "/api/internal/user-question/submit";
     this.submitFetch = opts.submitFetch || window.fetch.bind(window);
     this.activeTab = 0;
+    this.focusedOption = 0;
     this.draft = this.questions.map(q => ({
       selected: q.multi ? [] : null,
       other_text: "",
@@ -74,28 +85,52 @@ class AskWidget {
 
   isReadOnly() { return Array.isArray(this.answers) || this.errored; }
 
+  optionCount(qIdx) {
+    const q = this.questions[qIdx];
+    if (!q) return 0;
+    return q.options.length + (q.allow_other ? 1 : 0);
+  }
+
+  optionValueAt(qIdx, optIdx) {
+    const q = this.questions[qIdx];
+    if (!q || optIdx < 0) return null;
+    if (optIdx < q.options.length) return q.options[optIdx];
+    if (q.allow_other && optIdx === q.options.length) return OTHER_SENTINEL;
+    return null;
+  }
+
+  isQuestionValid(qIdx) {
+    const q = this.questions[qIdx];
+    const d = this.draft[qIdx];
+    if (!q || !d) return false;
+    if (q.multi) {
+      const arr = Array.isArray(d.selected) ? d.selected : [];
+      const maxOptionCount = q.options.length + (q.allow_other ? 1 : 0);
+      const min = q.min != null ? q.min : 1;
+      const max = q.max != null ? q.max : maxOptionCount;
+      if (arr.length < min || arr.length > max) return false;
+      if (arr.includes(OTHER_SENTINEL) && !d.other_text.trim()) return false;
+      return true;
+    }
+    if (!d.selected || Array.isArray(d.selected)) return false;
+    if (d.selected === OTHER_SENTINEL && !d.other_text.trim()) return false;
+    return true;
+  }
+
   canSubmit() {
     if (this.draft.length !== this.questions.length) return false;
-    return this.draft.every((d, i) => {
-      const q = this.questions[i];
-      if (q.multi) {
-        const arr = Array.isArray(d.selected) ? d.selected : [];
-        const maxOptionCount = q.options.length + (q.allow_other ? 1 : 0);
-        const min = q.min != null ? q.min : 1;
-        const max = q.max != null ? q.max : maxOptionCount;
-        if (arr.length < min || arr.length > max) return false;
-        if (arr.includes(OTHER_SENTINEL) && !d.other_text.trim()) return false;
-        return true;
-      }
-      if (!d.selected || Array.isArray(d.selected)) return false;
-      if (d.selected === OTHER_SENTINEL && !d.other_text.trim()) return false;
-      return true;
-    });
+    return this.draft.every((_d, i) => this.isQuestionValid(i));
   }
+
+  isLastTab() { return this.activeTab === this.questions.length - 1; }
+  showNext() { return this.questions.length > 1 && !this.isLastTab(); }
 
   selectTab(idx) {
     if (idx < 0 || idx >= this.questions.length) return;
-    this.activeTab = idx;
+    if (this.activeTab !== idx) {
+      this.activeTab = idx;
+      this.focusedOption = 0;
+    }
     this.render();
   }
 
@@ -118,8 +153,34 @@ class AskWidget {
     }
     if (option !== OTHER_SENTINEL && qIdx < this.questions.length - 1) {
       this.activeTab = qIdx + 1;
+      this.focusedOption = 0;
     }
     setTimeout(() => this.render(), 0);
+  }
+
+  clickPrimary() {
+    if (this.isReadOnly()) return;
+    if (this.showNext()) {
+      if (this.isQuestionValid(this.activeTab)) {
+        this.activeTab = this.activeTab + 1;
+        this.focusedOption = 0;
+        this.render();
+      }
+      return;
+    }
+    this.submit();
+  }
+
+  clearActive() {
+    if (this.isReadOnly()) return;
+    const q = this.questions[this.activeTab];
+    if (!q) return;
+    this.draft[this.activeTab] = {
+      selected: q.multi ? [] : null,
+      other_text: "",
+    };
+    this.submitError = "";
+    this.render();
   }
 
   shouldHideSubmit() {
@@ -199,12 +260,113 @@ class AskWidget {
     return d.selected === value;
   }
 
+  isTextInputFocused() {
+    const el = document.activeElement;
+    if (!el) return false;
+    if (el.tagName === "TEXTAREA") return true;
+    if (el.tagName === "INPUT") {
+      const t = (el.type || "text").toLowerCase();
+      return !(t === "radio" || t === "checkbox" || t === "button" || t === "submit");
+    }
+    return false;
+  }
+
+  onKeydown(e) {
+    if (this.isReadOnly()) return;
+    const key = e.key;
+    const textFocused = this.isTextInputFocused();
+
+    if (textFocused) {
+      if (key === "Escape") { e.preventDefault(); this.clearActive(); return; }
+      if (key === "Enter") {
+        if (this.isQuestionValid(this.activeTab)) { e.preventDefault(); this.clickPrimary(); }
+        return;
+      }
+      return;
+    }
+
+    const target = e.target;
+    const onTab = !!(target && target.closest && target.closest('[role="tab"]'));
+
+    if (key === "ArrowLeft" || key === "ArrowRight") {
+      if (onTab && this.questions.length > 1) {
+        e.preventDefault();
+        const dir = key === "ArrowRight" ? 1 : -1;
+        const next = (this.activeTab + dir + this.questions.length) % this.questions.length;
+        this.selectTab(next);
+        setTimeout(() => {
+          const btn = this.mount.querySelector(`[role="tab"][data-tab-index="${next}"]`);
+          if (btn) btn.focus();
+        }, 0);
+      }
+      return;
+    }
+
+    const count = this.optionCount(this.activeTab);
+    if (key === "ArrowDown") {
+      if (count > 0) { e.preventDefault(); this.focusedOption = (this.focusedOption + 1) % count; this.render(); }
+      return;
+    }
+    if (key === "ArrowUp") {
+      if (count > 0) { e.preventDefault(); this.focusedOption = (this.focusedOption - 1 + count) % count; this.render(); }
+      return;
+    }
+
+    if (key === "Escape") { e.preventDefault(); this.clearActive(); return; }
+
+    if (key === "Enter") {
+      if (target && target.closest && target.closest(".ask-submit")) return;
+      const q = this.questions[this.activeTab];
+      if (q && !q.multi && this.questions.length === 1) {
+        const value = this.optionValueAt(this.activeTab, this.focusedOption);
+        if (value !== null) {
+          e.preventDefault();
+          this.selectOption(this.activeTab, value);
+          return;
+        }
+      }
+      const canAct = this.showNext()
+        ? this.isQuestionValid(this.activeTab)
+        : (this.canSubmit() && !this.submitting);
+      if (canAct) { e.preventDefault(); this.clickPrimary(); }
+      return;
+    }
+
+    if (/^[1-9]$/.test(key)) {
+      const idx = parseInt(key, 10) - 1;
+      const value = this.optionValueAt(this.activeTab, idx);
+      if (value === null) return;
+      e.preventDefault();
+      const q = this.questions[this.activeTab];
+      this.focusedOption = idx;
+      if (q && q.multi) { this.selectOption(this.activeTab, value); return; }
+      this.selectOption(this.activeTab, value);
+      return;
+    }
+
+    if (this.questions.length > 1 && /^[A-Za-z]$/.test(key)) {
+      const idx = key.toUpperCase().charCodeAt(0) - 65;
+      if (idx >= 0 && idx < this.questions.length) {
+        e.preventDefault();
+        this.selectTab(idx);
+        setTimeout(() => {
+          const btn = this.mount.querySelector(`[role="tab"][data-tab-index="${idx}"]`);
+          if (btn) btn.focus();
+        }, 0);
+      }
+      return;
+    }
+  }
+
   render() {
     const root = document.createElement("div");
     root.className = "ask-widget";
 
     if (this.errored) {
-      root.innerHTML = `<div class="ask-error">${this.errorText || "ask_user_choices failed."}</div>`;
+      const err = document.createElement("div");
+      err.className = "ask-error";
+      err.textContent = this.errorText || "ask_user_choices failed.";
+      root.appendChild(err);
       this.mount.replaceChildren(root);
       return;
     }
@@ -220,7 +382,10 @@ class AskWidget {
       btn.type = "button";
       btn.setAttribute("role", "tab");
       btn.setAttribute("aria-selected", String(i === this.activeTab));
+      btn.setAttribute("aria-controls", `ask-panel-${this.toolUseId}-${i}`);
+      btn.id = `ask-tab-${this.toolUseId}-${i}`;
       btn.setAttribute("data-tab-index", String(i));
+      btn.setAttribute("tabindex", i === this.activeTab ? "0" : "-1");
       btn.className = "ask-tab";
       let answered;
       if (readOnly) {
@@ -229,7 +394,9 @@ class AskWidget {
         const d = this.draft[i];
         answered = Array.isArray(d.selected) ? d.selected.length > 0 : !!d.selected;
       }
-      btn.innerHTML = `<span>${i + 1}.</span> <span>${escapeHtml(q.question.slice(0, 40))}</span>${answered ? '<span class="ask-tab-check">✓</span>' : ""}`;
+      const raw = (q.tab_label && q.tab_label.trim()) || q.question || `Q${i + 1}`;
+      const label = raw.slice(0, 40);
+      btn.innerHTML = `<span class="ask-tab-letter">${tabLetter(i)}.</span><span class="ask-tab-label">${escapeHtml(label)}</span>${answered ? '<span class="ask-tab-check">✓</span>' : ""}`;
       btn.addEventListener("click", () => this.selectTab(i));
       tablist.appendChild(btn);
     });
@@ -246,34 +413,49 @@ class AskWidget {
 
     const panel = document.createElement("div");
     panel.setAttribute("role", "tabpanel");
+    panel.id = `ask-panel-${this.toolUseId}-${this.activeTab}`;
+    panel.setAttribute("aria-labelledby", `ask-tab-${this.toolUseId}-${this.activeTab}`);
     panel.setAttribute("data-panel-index", String(this.activeTab));
     panel.innerHTML = `<div class="ask-question">${escapeHtml(q.question)}</div>`;
 
     const optsDiv = document.createElement("div");
     optsDiv.className = "ask-options";
+    optsDiv.setAttribute("role", q.multi ? "group" : "radiogroup");
+    optsDiv.setAttribute("aria-label", q.question);
     const inputType = q.multi ? "checkbox" : "radio";
-    const renderOpt = (value, label, isOther) => {
+    const renderOpt = (value, label, optIdx, isOther) => {
       const checked = this.isOptionChecked(this.activeTab, value, readOnly);
+      const isFocused = !readOnly && this.focusedOption === optIdx;
       const lbl = document.createElement("label");
-      lbl.className = "ask-option" + (checked ? " checked" : "") + (isOther ? " ask-option-other" : "");
+      const classes = ["ask-option"];
+      if (checked) classes.push("checked");
+      if (isFocused) classes.push("ask-option-focused");
+      if (isOther) classes.push("ask-option-other");
+      lbl.className = classes.join(" ");
+      lbl.setAttribute("role", q.multi ? "checkbox" : "radio");
+      lbl.setAttribute("aria-checked", checked ? "true" : "false");
+      lbl.setAttribute("data-option-index", String(optIdx));
+      lbl.setAttribute("tabindex", readOnly ? "-1" : (isFocused ? "0" : "-1"));
       if (readOnly) lbl.setAttribute("data-disabled", "true");
       const nameAttr = q.multi ? "" : ` name="q-${this.activeTab}"`;
       lbl.innerHTML = `
         <input type="${inputType}" class="sr-only"${nameAttr} value="${escapeHtml(value)}" ${checked ? "checked" : ""} ${readOnly ? "disabled" : ""}>
+        <span class="ask-option-index" aria-hidden="true">${optIdx + 1}.</span>
         <span class="ask-option-check" aria-hidden="true">${checked ? "✓" : ""}</span>
         <span class="ask-option-text">${escapeHtml(label)}</span>
         ${isOther && checked ? `<input type="text" class="ask-other-input" value="${escapeHtml(otherText)}" ${readOnly ? "disabled" : ""}>` : ""}
       `;
       const input = lbl.querySelector(`input[type=${inputType}]`);
       input.addEventListener("change", () => this.selectOption(this.activeTab, value));
+      lbl.addEventListener("focus", () => { if (!readOnly) { this.focusedOption = optIdx; } });
       const txt = lbl.querySelector("input[type=text]");
       if (txt) {
         txt.addEventListener("input", (e) => this.setOtherText(this.activeTab, e.target.value));
       }
       return lbl;
     };
-    for (const opt of q.options) optsDiv.appendChild(renderOpt(opt, opt, false));
-    if (q.allow_other) optsDiv.appendChild(renderOpt(OTHER_SENTINEL, "Other", true));
+    q.options.forEach((opt, i) => optsDiv.appendChild(renderOpt(opt, opt, i, false)));
+    if (q.allow_other) optsDiv.appendChild(renderOpt(OTHER_SENTINEL, "Other", q.options.length, true));
     panel.appendChild(optsDiv);
     root.appendChild(panel);
 
@@ -290,14 +472,54 @@ class AskWidget {
       const btn = document.createElement("button");
       btn.type = "button";
       btn.className = "ask-submit";
-      btn.textContent = this.submitting ? "Submitting…" : "Submit";
-      btn.disabled = !this.canSubmit() || this.submitting;
-      btn.addEventListener("click", () => this.submit());
+      const showNext = this.showNext();
+      const primaryDisabled = showNext
+        ? !this.isQuestionValid(this.activeTab)
+        : (!this.canSubmit() || this.submitting);
+      btn.textContent = this.submitting ? "Submitting…" : (showNext ? "Next" : "Submit");
+      btn.disabled = primaryDisabled;
+      btn.addEventListener("click", () => this.clickPrimary());
       row.appendChild(btn);
       root.appendChild(row);
     }
 
+    // Capture what was focused before we blow the DOM away so we can restore
+    // focus to the equivalent element after replaceChildren(). Lit-based
+    // renders keep DOM stable across updates, so the source widget doesn't
+    // need this dance — but the fixture rebuilds the whole subtree.
+    const prev = document.activeElement;
+    let restore = null;
+    if (prev && this.mount.contains(prev)) {
+      const tabIdx = prev.getAttribute && prev.getAttribute("data-tab-index");
+      const optIdx = prev.getAttribute && prev.getAttribute("data-option-index");
+      if (tabIdx != null) {
+        restore = () => {
+          const t = this.mount.querySelector(`[role="tab"][data-tab-index="${tabIdx}"]`);
+          if (t) t.focus();
+        };
+      } else if (optIdx != null) {
+        // Restore focus to the focused option (per `this.focusedOption`) so the
+        // keydown listener on mount still receives keys after re-render. Use the
+        // state-tracked index rather than the prior DOM index to avoid bouncing
+        // through the label's focus handler (which would reset focusedOption).
+        const targetIdx = this.focusedOption;
+        restore = () => {
+          const o = this.mount.querySelector(`.ask-option[data-option-index="${targetIdx}"]`);
+          if (o) {
+            // Temporarily suppress the focus listener side-effect by focusing
+            // while the current state already matches targetIdx.
+            o.focus();
+          }
+        };
+      } else if (prev.classList && prev.classList.contains("ask-other-input")) {
+        restore = () => {
+          const i = this.mount.querySelector(".ask-other-input");
+          if (i) { i.focus(); i.selectionStart = i.selectionEnd = i.value.length; }
+        };
+      }
+    }
     this.mount.replaceChildren(root);
+    if (restore) restore();
   }
 }
 

--- a/tests/ask-user-choices-widget.spec.ts
+++ b/tests/ask-user-choices-widget.spec.ts
@@ -30,9 +30,9 @@ test.describe("ask_user_choices widget", () => {
 	test("renders N tabs for N questions", async ({ page }) => {
 		await page.evaluate(() => (window as any).mountWidget({
 			questions: [
-				{ question: "Q1", options: ["a", "b"] },
-				{ question: "Q2", options: ["c", "d"] },
-				{ question: "Q3", options: ["e", "f"] },
+				{ question: "Q1", options: ["a", "b"], tab_label: "First" },
+				{ question: "Q2", options: ["c", "d"], tab_label: "Second" },
+				{ question: "Q3", options: ["e", "f"], tab_label: "Third" },
 			],
 		}));
 		await expect(page.locator('[role="tab"]')).toHaveCount(3);
@@ -41,8 +41,8 @@ test.describe("ask_user_choices widget", () => {
 	test("selecting a non-Other option auto-advances to the next tab", async ({ page }) => {
 		await page.evaluate(() => (window as any).mountWidget({
 			questions: [
-				{ question: "Q1", options: ["a", "b"] },
-				{ question: "Q2", options: ["c", "d"] },
+				{ question: "Q1", options: ["a", "b"], tab_label: "First" },
+				{ question: "Q2", options: ["c", "d"], tab_label: "Second" },
 			],
 		}));
 		// Click first option on tab 0.
@@ -54,9 +54,9 @@ test.describe("ask_user_choices widget", () => {
 	test("clicking a tab manually jumps without reordering", async ({ page }) => {
 		await page.evaluate(() => (window as any).mountWidget({
 			questions: [
-				{ question: "Q1", options: ["a", "b"] },
-				{ question: "Q2", options: ["c", "d"] },
-				{ question: "Q3", options: ["e", "f"] },
+				{ question: "Q1", options: ["a", "b"], tab_label: "First" },
+				{ question: "Q2", options: ["c", "d"], tab_label: "Second" },
+				{ question: "Q3", options: ["e", "f"], tab_label: "Third" },
 			],
 		}));
 		await page.locator('[role="tab"][data-tab-index="2"]').click();
@@ -69,8 +69,8 @@ test.describe("ask_user_choices widget", () => {
 	test("Submit button disabled until every question has a selection", async ({ page }) => {
 		await page.evaluate(() => (window as any).mountWidget({
 			questions: [
-				{ question: "Q1", options: ["a", "b"] },
-				{ question: "Q2", options: ["c", "d"] },
+				{ question: "Q1", options: ["a", "b"], tab_label: "First" },
+				{ question: "Q2", options: ["c", "d"], tab_label: "Second" },
 			],
 		}));
 		// Initially disabled
@@ -80,14 +80,16 @@ test.describe("ask_user_choices widget", () => {
 		await expect(page.locator(".ask-submit")).toBeDisabled();
 		// Answer Q2 → enabled
 		await page.locator('[role="tabpanel"] input[type=radio][value="c"]').click({ force: true });
+		// Second-tab selection → Submit button on last tab. Active tab is still Q2 after picking 'c' (last tab).
 		await expect(page.locator(".ask-submit")).toBeEnabled();
+		await expect(page.locator(".ask-submit")).toHaveText(/Submit/);
 	});
 
 	test("allow_other: selecting Other does NOT auto-advance; Submit requires other_text", async ({ page }) => {
 		await page.evaluate(() => (window as any).mountWidget({
 			questions: [
-				{ question: "Q1", options: ["a", "b"], allow_other: true },
-				{ question: "Q2", options: ["c", "d"] },
+				{ question: "Q1", options: ["a", "b"], allow_other: true, tab_label: "First" },
+				{ question: "Q2", options: ["c", "d"], tab_label: "Second" },
 			],
 		}));
 		// Select Other on Q1
@@ -114,8 +116,8 @@ test.describe("ask_user_choices widget", () => {
 		// Install a submitFetch mock that returns 200.
 		await page.evaluate(() => (window as any).mountWidget({
 			questions: [
-				{ question: "Q1", options: ["a", "b"] },
-				{ question: "Q2", options: ["c", "d"] },
+				{ question: "Q1", options: ["a", "b"], tab_label: "First" },
+				{ question: "Q2", options: ["c", "d"], tab_label: "Second" },
 			],
 			submitFetch: async (_url: string, init: any) => {
 				(window as any)._lastSubmitBody = JSON.parse(init.body);
@@ -161,8 +163,8 @@ test.describe("ask_user_choices widget", () => {
 	test("initial answers prop renders read-only (replay scenario)", async ({ page }) => {
 		await page.evaluate(() => (window as any).mountWidget({
 			questions: [
-				{ question: "Q1", options: ["a", "b"] },
-				{ question: "Q2", options: ["c", "d"], allow_other: true },
+				{ question: "Q1", options: ["a", "b"], tab_label: "First" },
+				{ question: "Q2", options: ["c", "d"], allow_other: true, tab_label: "Second" },
 			],
 			answers: [
 				{ question: "Q1", selected: "b", other_text: null },
@@ -254,8 +256,8 @@ test.describe("ask_user_choices widget", () => {
 	test("multi: auto-advance is suppressed", async ({ page }) => {
 		await page.evaluate(() => (window as any).mountWidget({
 			questions: [
-				{ question: "Q1", options: ["a", "b"], multi: true },
-				{ question: "Q2", options: ["c", "d"] },
+				{ question: "Q1", options: ["a", "b"], multi: true, tab_label: "First" },
+				{ question: "Q2", options: ["c", "d"], tab_label: "Second" },
 			],
 		}));
 		await page.locator('label:has(input[value="a"])').click();
@@ -370,8 +372,8 @@ test.describe("ask_user_choices widget", () => {
 		// (single-question mode auto-submits, which is covered separately).
 		await page.evaluate(() => (window as any).mountWidget({
 			questions: [
-				{ question: "Q1", options: ["a", "b"] },
-				{ question: "Q2", options: ["c", "d"] },
+				{ question: "Q1", options: ["a", "b"], tab_label: "First" },
+				{ question: "Q2", options: ["c", "d"], tab_label: "Second" },
 			],
 			submitFetch: async () =>
 				new Response(JSON.stringify({ error: "No pending question for this session/toolUseId" }), { status: 404, headers: { "Content-Type": "application/json" } }),
@@ -382,5 +384,246 @@ test.describe("ask_user_choices widget", () => {
 		// Submit button remains visible (not read-only); error surfaces.
 		await expect(page.locator(".ask-submit-error")).toHaveText(/No pending question/);
 		await expect(page.locator(".ask-submit")).toBeVisible();
+	});
+
+	// ── Label polish ───────────────────────────────────────────────────────
+
+	test("multi-question: tabs render as 'A. <tab_label>', 'B. <tab_label>'", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [
+				{ question: "How often?",    options: ["rare", "often"], tab_label: "User behavior" },
+				{ question: "Which scope?",  options: ["small", "big"],   tab_label: "Design scope" },
+				{ question: "When to follow up?", options: ["now", "later"], tab_label: "Follow-up" },
+			],
+		}));
+		const letters = await page.locator('[role="tab"] .ask-tab-letter').allTextContents();
+		expect(letters).toEqual(["A.", "B.", "C."]);
+		const labels = await page.locator('[role="tab"] .ask-tab-label').allTextContents();
+		expect(labels).toEqual(["User behavior", "Design scope", "Follow-up"]);
+	});
+
+	test("options render with 1-based numeric prefix, including Other", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [{ question: "Pick", options: ["red", "green", "blue"], allow_other: true }],
+		}));
+		const idxs = await page.locator(".ask-option-index").allTextContents();
+		expect(idxs).toEqual(["1.", "2.", "3.", "4."]);
+	});
+
+	// ── Next / Submit ────────────────────────────────────────────────
+
+	test("multi-question: non-last tab shows Next (disabled until valid), last tab shows Submit", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [
+				{ question: "Q1", options: ["a", "b"], allow_other: true, tab_label: "First" },
+				{ question: "Q2", options: ["c", "d"], tab_label: "Second" },
+			],
+		}));
+		// On tab 0 without selection: Next disabled.
+		await expect(page.locator(".ask-submit")).toHaveText("Next");
+		await expect(page.locator(".ask-submit")).toBeDisabled();
+		// Select 'Other' (no auto-advance) and then type text → Next enables.
+		await page.locator('input[type=radio][value="__OTHER__"]').click({ force: true });
+		await expect(page.locator(".ask-submit")).toBeDisabled();
+		await page.locator('.ask-other-input').fill('freeform');
+		await expect(page.locator(".ask-submit")).toBeEnabled();
+		// Click Next → goes to tab 1.
+		await page.locator('.ask-submit').click();
+		await expect(page.locator('[role="tab"][data-tab-index="1"]')).toHaveAttribute("aria-selected", "true");
+		// Last tab → button is Submit.
+		await expect(page.locator(".ask-submit")).toHaveText("Submit");
+	});
+
+	// ── Keyboard ─────────────────────────────────────────────────────────────
+
+	test("ArrowDown/Up move focused option with wrap", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [{ question: "Pick", options: ["a", "b", "c"] }],
+		}));
+		await page.locator('.ask-option').first().focus();
+		await page.keyboard.press("ArrowDown");
+		await expect(page.locator('.ask-option[data-option-index="1"]')).toHaveClass(/ask-option-focused/);
+		await page.keyboard.press("ArrowDown");
+		await expect(page.locator('.ask-option[data-option-index="2"]')).toHaveClass(/ask-option-focused/);
+		// Wrap forward.
+		await page.keyboard.press("ArrowDown");
+		await expect(page.locator('.ask-option[data-option-index="0"]')).toHaveClass(/ask-option-focused/);
+		// Wrap backward.
+		await page.keyboard.press("ArrowUp");
+		await expect(page.locator('.ask-option[data-option-index="2"]')).toHaveClass(/ask-option-focused/);
+	});
+
+	test("ArrowLeft/Right on a tab button moves between tabs", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [
+				{ question: "Q1", options: ["a", "b"], tab_label: "First" },
+				{ question: "Q2", options: ["c", "d"], tab_label: "Second" },
+				{ question: "Q3", options: ["e", "f"], tab_label: "Third" },
+			],
+		}));
+		const tab0 = page.locator('[role="tab"][data-tab-index="0"]');
+		await tab0.focus();
+		await tab0.press("ArrowRight");
+		await expect(page.locator('[role="tab"][data-tab-index="1"]')).toHaveAttribute("aria-selected", "true");
+		await page.locator('[role="tab"][data-tab-index="1"]').press("ArrowRight");
+		await expect(page.locator('[role="tab"][data-tab-index="2"]')).toHaveAttribute("aria-selected", "true");
+		// Wraps.
+		await page.locator('[role="tab"][data-tab-index="2"]').press("ArrowRight");
+		await expect(page.locator('[role="tab"][data-tab-index="0"]')).toHaveAttribute("aria-selected", "true");
+	});
+
+	test("Enter on focused option (single-question single-select) selects + auto-submits", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [{ question: "Q1", options: ["a", "b", "c"] }],
+			submitFetch: async (_u: string, init: any) => {
+				(window as any)._lastSubmitBody = JSON.parse(init.body);
+				return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "Content-Type": "application/json" } });
+			},
+		}));
+		await page.locator('.ask-option').first().focus();
+		await page.keyboard.press("ArrowDown"); // focus option 1 ('b')
+		await page.keyboard.press("Enter");
+		await expect.poll(() => page.evaluate(() => (window as any)._lastSubmitBody)).toBeTruthy();
+		const body = await page.evaluate(() => (window as any)._lastSubmitBody);
+		expect(body.answers[0].selected).toBe("b");
+	});
+
+	test("Enter on primary button clicks Next/Submit", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [
+				{ question: "Q1", options: ["a", "b"], tab_label: "First" },
+				{ question: "Q2", options: ["c", "d"], tab_label: "Second" },
+			],
+		}));
+		// Select 'a' by number key on Q1 → auto-advance to Q2.
+		await page.locator('.ask-option').first().focus();
+		await page.keyboard.press("1");
+		await expect(page.locator('[role="tab"][data-tab-index="1"]')).toHaveAttribute("aria-selected", "true");
+		// On Q2, pick 'c' with number key.
+		await page.locator('.ask-option').first().focus();
+		await page.keyboard.press("1");
+		// Submit enabled.
+		await expect(page.locator(".ask-submit")).toBeEnabled();
+		await expect(page.locator(".ask-submit")).toHaveText("Submit");
+	});
+
+	test("Escape clears the active question (single-select → null; multi-select → [])", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [
+				{ question: "Q1", options: ["a", "b"], allow_other: true, tab_label: "First" },
+				{ question: "Q2", options: ["c", "d", "e"], multi: true, tab_label: "Second" },
+			],
+		}));
+		// Q1 single-select + Other with text.
+		await page.locator('input[type=radio][value="__OTHER__"]').click({ force: true });
+		await page.locator('.ask-other-input').fill('typed');
+		await expect(page.locator('.ask-other-input')).toHaveValue('typed');
+		// Escape outside the text input → clears.
+		await page.locator('[role="tab"][data-tab-index="0"]').focus();
+		await page.keyboard.press("Escape");
+		await expect(page.locator('.ask-other-input')).toHaveCount(0);
+		await expect(page.locator('input[type=radio][value="__OTHER__"]')).not.toBeChecked();
+		// Q2 multi-select → clears array.
+		await page.locator('[role="tab"][data-tab-index="1"]').click();
+		await page.locator('label:has(input[value="c"])').click();
+		await page.locator('label:has(input[value="d"])').click();
+		await expect(page.locator('input[value="c"]')).toBeChecked();
+		await page.locator('[role="tab"][data-tab-index="1"]').focus();
+		await page.keyboard.press("Escape");
+		await expect(page.locator('input[value="c"]')).not.toBeChecked();
+		await expect(page.locator('input[value="d"]')).not.toBeChecked();
+	});
+
+	test("Number keys: auto-advance on non-last, toggle on multi, no-op on out-of-range", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [
+				{ question: "Q1", options: ["a", "b"], tab_label: "First" },
+				{ question: "Q2", options: ["c", "d", "e"], multi: true, tab_label: "Second" },
+			],
+		}));
+		await page.locator('[role="tab"][data-tab-index="0"]').focus();
+		// '9' on Q1 (only 2 options) → no-op.
+		await page.keyboard.press("9");
+		await expect(page.locator('[role="tab"][data-tab-index="0"]')).toHaveAttribute("aria-selected", "true");
+		// '2' → picks 'b' and auto-advances to Q2.
+		await page.keyboard.press("2");
+		await expect(page.locator('[role="tab"][data-tab-index="1"]')).toHaveAttribute("aria-selected", "true");
+		// On Q2 (multi): '1' toggles 'c' on; '3' toggles 'e' on; '1' again toggles 'c' off.
+		await page.keyboard.press("1");
+		await page.keyboard.press("3");
+		await expect(page.locator('input[value="c"]')).toBeChecked();
+		await expect(page.locator('input[value="e"]')).toBeChecked();
+		await page.keyboard.press("1");
+		await expect(page.locator('input[value="c"]')).not.toBeChecked();
+		await expect(page.locator('input[value="e"]')).toBeChecked();
+		// Still on Q2 (no auto-advance for multi).
+		await expect(page.locator('[role="tab"][data-tab-index="1"]')).toHaveAttribute("aria-selected", "true");
+	});
+
+	test("Letter keys jump tabs; out-of-range and single-question ignored", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [
+				{ question: "Q1", options: ["a", "b"], tab_label: "First" },
+				{ question: "Q2", options: ["c", "d"], tab_label: "Second" },
+				{ question: "Q3", options: ["e", "f"], tab_label: "Third" },
+			],
+		}));
+		await page.locator('[role="tab"][data-tab-index="0"]').focus();
+		await page.keyboard.press("c"); // lowercase works
+		await expect(page.locator('[role="tab"][data-tab-index="2"]')).toHaveAttribute("aria-selected", "true");
+		await page.keyboard.press("A");
+		await expect(page.locator('[role="tab"][data-tab-index="0"]')).toHaveAttribute("aria-selected", "true");
+		// Out-of-range (e.g. 'Z') → no-op.
+		await page.keyboard.press("Z");
+		await expect(page.locator('[role="tab"][data-tab-index="0"]')).toHaveAttribute("aria-selected", "true");
+	});
+
+	test("single-question: letter keys are ignored (no tabs)", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [{ question: "Only", options: ["a", "b"] }],
+		}));
+		await page.locator('.ask-option').first().focus();
+		await page.keyboard.press("B");
+		await expect(page.locator('[role="tab"]')).toHaveCount(0);
+		// No option selected by letter key.
+		await expect(page.locator('input[type=radio][value="b"]')).not.toBeChecked();
+	});
+
+	test("No hijack while typing in Other: digits/letters reach the input; Enter still submits", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [{ question: "Only", options: ["a", "b"], allow_other: true }],
+			submitFetch: async (_u: string, init: any) => {
+				(window as any)._lastSubmitBody = JSON.parse(init.body);
+				return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "Content-Type": "application/json" } });
+			},
+		}));
+		await page.locator('input[type=radio][value="__OTHER__"]').click({ force: true });
+		const input = page.locator('.ask-other-input');
+		// fill() sets value directly (no per-key re-render focus loss in the fixture).
+		await input.fill("3b");
+		await expect(input).toHaveValue("3b");
+		// Verify that while the text input has focus, shortcuts are NOT hijacked:
+		// typing more chars would be intercepted if the widget were listening.
+		await input.focus();
+		// With focus in Other, letter keys must not switch tabs or clear selection.
+		await input.press("a"); // should append 'a'
+		await expect(input).toHaveValue("3ba");
+		// Enter while focused in Other submits (valid).
+		await input.press("Enter");
+		await expect.poll(() => page.evaluate(() => (window as any)._lastSubmitBody)).toBeTruthy();
+	});
+
+	test("Other numbering = options.length + 1; number key selects Other", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [{ question: "Pick", options: ["a", "b"], allow_other: true }],
+		}));
+		// Other's prefix should be '3.'
+		const idxs = await page.locator(".ask-option-index").allTextContents();
+		expect(idxs).toEqual(["1.", "2.", "3."]);
+		// Press '3' → selects Other (single-question, Other → does NOT auto-submit).
+		await page.locator('.ask-option').first().focus();
+		await page.keyboard.press("3");
+		await expect(page.locator('input[type=radio][value="__OTHER__"]')).toBeChecked();
+		await expect(page.locator('.ask-other-input')).toBeVisible();
 	});
 });

--- a/tests/e2e/mock-agent-core.mjs
+++ b/tests/e2e/mock-agent-core.mjs
@@ -298,12 +298,12 @@ export class MockAgentCore {
 
 		const questions = multi
 			? [
-				{ question: "Which colors?", options: ["red", "blue", "green"], multi: true },
-				{ question: "Team size?", options: ["small", "medium", "large"], allow_other: true },
+				{ question: "Which colors?", options: ["red", "blue", "green"], multi: true, tab_label: "Colors" },
+				{ question: "Team size?", options: ["small", "medium", "large"], allow_other: true, tab_label: "Team size" },
 			]
 			: [
-				{ question: "Favorite color?", options: ["red", "blue", "green"] },
-				{ question: "Team size?", options: ["small", "medium", "large"], allow_other: true },
+				{ question: "Favorite color?", options: ["red", "blue", "green"], tab_label: "Color" },
+				{ question: "Team size?", options: ["small", "medium", "large"], allow_other: true, tab_label: "Team size" },
 			];
 
 		this.emit({ type: "tool_execution_start", toolName: "ask_user_choices", toolId, input: { questions } });

--- a/tests/e2e/ui/ask-user-choices-ui.spec.ts
+++ b/tests/e2e/ui/ask-user-choices-ui.spec.ts
@@ -126,4 +126,49 @@ test.describe("ask_user_choices widget (full-stack UI)", () => {
 
 		await page2.close();
 	});
+
+	test("keyboard-only multi-question submission", async ({ page }) => {
+		await openApp(page);
+		await createSessionViaUI(page);
+
+		await sendMessage(page, "please use ask_user_choices");
+
+		const widget = page.locator("ask-user-choices-widget").first();
+		await expect(widget).toBeVisible({ timeout: 20_000 });
+
+		// Tab strip uses lettered tab_label.
+		const letters = widget.locator('[role="tab"] .ask-tab-letter');
+		await expect(letters.first()).toHaveText("A.");
+		await expect(letters.nth(1)).toHaveText("B.");
+
+		// Focus the first tab so keyboard input targets the widget.
+		await widget.locator('[role="tab"][data-tab-index="0"]').focus();
+
+		// Press '1' → picks option 1 on Q1 ("red") and auto-advances to Q2.
+		await page.keyboard.press("1");
+		await expect(widget.locator('[role="tab"][data-tab-index="1"]'))
+			.toHaveAttribute("aria-selected", "true", { timeout: 5_000 });
+
+		// Re-focus for keyboard targeting on the new tab panel.
+		await widget.locator('[role="tab"][data-tab-index="1"]').focus();
+
+		// Press '2' → picks option 2 on Q2 ("medium"). Last tab → no advance.
+		await page.keyboard.press("2");
+		await expect(widget.locator('input[type="radio"][value="medium"]')).toBeChecked();
+
+		// Primary button should now be Submit (last tab) and enabled.
+		const submit = widget.locator(".ask-submit");
+		await expect(submit).toHaveText("Submit");
+		await expect(submit).toBeEnabled();
+
+		// Press Enter → submits. Focus the Submit button first so Enter targets it.
+		await submit.focus();
+		await page.keyboard.press("Enter");
+		await expect(widget.locator(".ask-submit")).toHaveCount(0, { timeout: 10_000 });
+		await expect(widget.locator('input[type="radio"]').first()).toBeDisabled();
+
+		// Confirm Q1 "red" survived as the recorded answer.
+		await widget.locator('[role="tab"][data-tab-index="0"]').click();
+		await expect(widget.locator('input[type="radio"][value="red"]')).toBeChecked();
+	});
 });


### PR DESCRIPTION
Adds full keyboard support to the `ask_user_choices` widget, reworks the visible
labels so key bindings are discoverable, and requires the agent to provide a
short `tab_label` on every question in multi-question asks.

## What changed

- **Tool schema**: new optional `tab_label` field on each question (≤24 chars).
  Server validation rejects multi-question asks missing it. No fallback.
- **Widget**:
  - Multi-question tabs render as `A. <tab_label>`, `B. …` (letters, not
    numbers, so they don't collide with the option-number shortcut).
  - Options show a numbered badge — `1.`, `2.`, … with "Other" at `n+1`.
  - Non-last question renders **Next** (disabled until valid); last renders
    **Submit** (unchanged).
- **Keyboard**: Arrow keys move option / tab focus, Enter activates the primary
  button (or selects+auto-submits on single-question single-select), Escape
  clears the active question, number keys 1–9 pick an option, letter keys A–Z
  jump tabs. All shortcuts are suppressed while a text input has focus.
- **ARIA**: radiogroup + tablist semantics with roving tabindex.

## Gates

- design-doc — passed
- implementation — passed (type check, unit, E2E, code quality, security)
- documentation — passed

Docs updated: `docs/non-blocking-ask.md`, `AGENTS.md`, and the tool YAML
`detail_docs`.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)