### PR TITLE
Fix Accept Project leaving assistant session in sidebar

### DIFF
--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -1726,6 +1726,7 @@ export async function acceptProjectProposal(): Promise<void> {
 		deleteRoleDraft(propSessionId);
 		deletePersonalityDraft(propSessionId);
 		deleteProjectDraft(propSessionId);
+		await refreshSessions();
 		setHashRoute("landing");
 	} catch (err) {
 		console.error('[project-proposal] Failed to terminate assistant session:', err);

--- a/tests/e2e/ui/project-assistant.spec.ts
+++ b/tests/e2e/ui/project-assistant.spec.ts
@@ -148,6 +148,9 @@ test.describe("Project assistant UX (consolidated)", () => {
 		// Sidebar should no longer show "(setting up)"
 		await expect(sidebar.getByText("Test Project").first()).toBeVisible({ timeout: 15_000 });
 
+		// Project assistant session should be removed from the sidebar immediately
+		await expect(sidebar.getByText("Project Assistant")).toHaveCount(0, { timeout: 10_000 });
+
 		// Cleanup
 		await deleteSession(sessionId);
 		await cleanupProject(projectId);


### PR DESCRIPTION
Fixes stale project assistant session lingering in the sidebar after clicking **Accept Project**.

## Root cause
`acceptProjectProposal()` in `src/app/session-manager.ts` terminated the assistant session but never called `refreshSessions()`, so `state.gatewaySessions` kept rendering the terminated session until some other event refreshed the list.

## Fix
Add `await refreshSessions()` after the terminate call — mirroring the regular `terminateSession` flow.

## Test
Extended `tests/e2e/ui/project-assistant.spec.ts` "accept proposal promotes project" test to assert the assistant session disappears from `.sidebar-edge` after Accept.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)