### PR TITLE
fix(tls): fix iOS PWA cert install flow

### DIFF
--- a/src/server/auth/tls.ts
+++ b/src/server/auth/tls.ts
@@ -114,10 +114,12 @@ async function generateMkcertCert(_host: string, allDomains: string[]): Promise<
 
 	// Generate a cert for all required domains signed by our CA
 	console.log(`  Generating mkcert TLS certificate for: ${allDomains.join(", ")}`);
+	// iOS/Safari rejects leaf certs with validity > 825 days (CERT_VALIDITY_TOO_LONG).
+	// Keep the CA long-lived (3650d) but the leaf short (397d, under the 398 public-CA limit too).
 	const cert = await createCert({
 		ca: { cert: caCert, key: caKey },
 		domains: allDomains,
-		validity: 3650,
+		validity: 397,
 	});
 
 	fs.writeFileSync(CERT_PATH, cert.cert);
@@ -151,7 +153,7 @@ function generateSelfSignedCert(_host: string, allDomains: string[]): TlsFiles {
 				"-newkey", "ec",
 				"-pkeyopt", "ec_paramgen_curve:prime256v1",
 				"-nodes",
-				"-days", "3650",
+				"-days", "397",
 				"-subj", `"/CN=bobbit"`,
 				"-addext", `"${san}"`,
 				"-keyout", `"${KEY_PATH}"`,
@@ -184,7 +186,7 @@ function generateSelfSignedCert(_host: string, allDomains: string[]): TlsFiles {
 					"-newkey", "ec",
 					"-pkeyopt", "ec_paramgen_curve:prime256v1",
 					"-nodes",
-					"-days", "3650",
+					"-days", "397",
 					"-config", `"${cnfPath}"`,
 					"-keyout", `"${KEY_PATH}"`,
 					"-out", `"${CERT_PATH}"`,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -555,9 +555,12 @@ export function createGateway(config: GatewayConfig) {
 				return;
 			}
 
+			// Public endpoints — no auth required (CA cert is inherently public).
+			const isPublicEndpoint = url.pathname === "/api/ca-cert" && req.method === "GET";
+
 			// Auth check — skipped in localhost mode (only local processes can connect)
 			let sandboxScope: SandboxScope | undefined;
-			if (!isLocalhostMode) {
+			if (!isLocalhostMode && !isPublicEndpoint) {
 				const authHeader = req.headers.authorization;
 				const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7)
 					: url.searchParams.get("token"); // Allow token in query param for links opened in new tabs
@@ -1331,7 +1334,8 @@ async function handleApiRoute(
 		}
 		const certData = fs.readFileSync(caCertPath);
 		res.writeHead(200, {
-			"Content-Type": "application/x-pem-file",
+			// iOS Safari needs this MIME type to offer the profile-install flow.
+			"Content-Type": "application/x-x509-ca-cert",
 			"Content-Disposition": "attachment; filename=\"bobbit-ca.crt\"",
 			"Content-Length": certData.length,
 		});


### PR DESCRIPTION
iOS Safari rejected our CA cert install flow for three reasons. This fixes all three so the PWA-on-iPhone onboarding works end-to-end.

## Changes

1. **`/api/ca-cert` is now public.** It required a bearer token, which meant Safari got `{"error":"Unauthorized"}` instead of the cert. The CA certificate is inherently public data (it's what you publish to trust signed certs) — safe to serve unauthenticated.

2. **MIME type `application/x-x509-ca-cert`** (was `application/x-pem-file`). iOS only offers the profile-install flow for the former; the latter downloads as a text file.

3. **Leaf cert validity 397 days** (was 3650). iOS enforces a hard 825-day limit on leaf certs (`CERT_VALIDITY_TOO_LONG`), and Safari in practice enforces 398. The CA itself stays at 3650 days.

## Install flow on iPhone

1. Open `https://<your-bobbit-host>/api/ca-cert` in Safari.
2. Settings → General → VPN & Device Management → Bobbit Local CA → Install.
3. Settings → General → About → Certificate Trust Settings → enable Bobbit Local CA.
4. Open Bobbit URL in Safari → Share → Add to Home Screen.

## Regenerating existing certs

Delete `.bobbit/state/tls/cert.pem` and `key.pem` and restart the server. The CA is preserved.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)