### PR TITLE
feat(pwa): dynamic manifest with token-baked start_url for iOS persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<link rel="manifest" href="/manifest.json" />
+		<link rel="manifest" href="/manifest.json" id="pwa-manifest" />
 		<meta name="theme-color" content="#2b2d2b" />
 		<meta name="apple-mobile-web-app-capable" content="yes" />
 		<link rel="apple-touch-icon" href="/icons/icon-192.png" />
@@ -16,6 +16,17 @@
 			(function() {
 				var p = localStorage.getItem('palette');
 				if (p && p !== 'forest') document.documentElement.dataset.palette = p;
+				// Bake the auth token into the PWA manifest URL so iOS installs a
+				// tokenized start_url. The server validates the token before
+				// embedding it; invalid tokens are silently ignored.
+				try {
+					var params = new URLSearchParams(window.location.search);
+					var token = params.get('token') || localStorage.getItem('gateway.token');
+					if (token && token !== 'localhost') {
+						var link = document.getElementById('pwa-manifest');
+						if (link) link.href = '/manifest.json?token=' + encodeURIComponent(token);
+					}
+				} catch (e) { /* ignore */ }
 			})();
 		</script>
 		<script type="module" src="/src/app/main.ts"></script>

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -601,6 +601,33 @@ export function createGateway(config: GatewayConfig) {
 			return;
 		}
 
+		// Dynamic PWA manifest — when launched from a tokenized URL, bake the token
+		// into start_url so the PWA can relaunch authenticated.
+		// Only does so for a *valid* token; invalid tokens fall through to the plain
+		// manifest (no token baked in).
+		if (url.pathname === "/manifest.json" && req.method === "GET" && config.staticDir) {
+			try {
+				const manifestPath = path.join(path.resolve(config.staticDir), "manifest.json");
+				const raw = fs.readFileSync(manifestPath, "utf-8");
+				const manifest = JSON.parse(raw);
+				const providedToken = url.searchParams.get("token");
+				if (providedToken && validateToken(providedToken, config.authToken)) {
+					manifest.start_url = `/?token=${encodeURIComponent(providedToken)}`;
+				}
+				res.writeHead(200, {
+					"Content-Type": "application/manifest+json",
+					// Don't let the manifest be cached — token-validity may change.
+					"Cache-Control": "no-store",
+					// Prevent token leakage via Referer when the PWA makes cross-origin requests.
+					"Referrer-Policy": "no-referrer",
+				});
+				res.end(JSON.stringify(manifest));
+				return;
+			} catch {
+				// Fall through to static serving on any error.
+			}
+		}
+
 		// Static file serving
 		if (config.staticDir) {
 			serveStatic(url.pathname, config.staticDir, res);


### PR DESCRIPTION
## Problem

iOS PWAs installed via "Add to Home Screen" frequently lose their `localStorage` token — separate storage partitions, cache eviction, reinstalls, etc. Users end up unable to launch the PWA without manually re-entering the admin token, which defeats the point of the install.

## Fix

Serve `/manifest.json` dynamically. When the page requests the manifest with `?token=<valid-token>`, the server validates the token and returns a manifest with `start_url=/?token=<token>`. iOS snapshots this at install time, so every subsequent launch re-seeds the token via URL param — `main.ts` already handles the URL → localStorage path.

`index.html` adds a tiny inline script that appends `?token=<current>` to the manifest `<link>` (from URL param or localStorage, never the `localhost` sentinel).

## Security considerations

- **Server validates the token** before embedding. Invalid tokens fall through to the plain manifest.
- **`Referrer-Policy: no-referrer`** on the manifest response so the token can't leak via `Referer` if the PWA ever makes cross-origin requests.
- **`Cache-Control: no-store`** so a revoked/stale token isn't cached in the CDN/browser.
- The token ends up baked into the iOS PWA metadata (home-screen shortcut). This is strictly no worse than the current state (token in localStorage on the same device). The only meaningful attacker is someone with physical access to the unlocked phone, which the token has never defended against.
- Rotating the admin token now requires reinstalling the PWA (the baked `start_url` is stale).

🤖 Generated with [Bobbit](https://github.com/SuuBro/gw-bobbit)