### PR TITLE
fix(pwa): dynamic manifest works in dev mode

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -603,13 +603,12 @@ export function createGateway(config: GatewayConfig) {
 
 		// Dynamic PWA manifest — when launched from a tokenized URL, bake the token
 		// into start_url so the PWA can relaunch authenticated.
-		// Only does so for a *valid* token; invalid tokens fall through to the plain
-		// manifest (no token baked in).
-		if (url.pathname === "/manifest.json" && req.method === "GET" && config.staticDir) {
+		// Only does so for a *valid* token; invalid tokens fall through to a plain
+		// manifest (no token baked in). Works in both dev mode (Vite proxies
+		// /manifest.json to us) and prod (staticDir serves public/).
+		if (url.pathname === "/manifest.json" && req.method === "GET") {
 			try {
-				const manifestPath = path.join(path.resolve(config.staticDir), "manifest.json");
-				const raw = fs.readFileSync(manifestPath, "utf-8");
-				const manifest = JSON.parse(raw);
+				const manifest = loadManifest(config.staticDir);
 				const providedToken = url.searchParams.get("token");
 				if (providedToken && validateToken(providedToken, config.authToken)) {
 					manifest.start_url = `/?token=${encodeURIComponent(providedToken)}`;
@@ -6770,6 +6769,20 @@ const MIME_TYPES: Record<string, string> = {
 	".ttf": "font/ttf",
 	".wasm": "application/wasm",
 };
+
+/**
+ * Load the PWA manifest JSON. In prod the UI is embedded under `staticDir`;
+ * in dev mode (--no-ui) the Vite public/ folder is used instead.
+ */
+function loadManifest(staticDir: string | undefined): { start_url?: string;[k: string]: unknown } {
+	const candidates: string[] = [];
+	if (staticDir) candidates.push(path.join(path.resolve(staticDir), "manifest.json"));
+	candidates.push(path.resolve(process.cwd(), "public", "manifest.json"));
+	for (const p of candidates) {
+		if (fs.existsSync(p)) return JSON.parse(fs.readFileSync(p, "utf-8"));
+	}
+	throw new Error("manifest.json not found");
+}
 
 function serveStatic(pathname: string, staticDir: string, res: http.ServerResponse) {
 	const resolvedStaticDir = path.resolve(staticDir);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -154,7 +154,11 @@ function dynamicGatewayProxy(): Plugin {
 		configureServer(server) {
 			// --- HTTP proxy for /api/* ----------------------------------
 			server.middlewares.use((req, res, next) => {
-				if (!req.url?.startsWith("/api")) return next();
+				// Proxy /api/* and /manifest.json (the gateway serves a dynamic manifest
+				// that bakes the auth token into start_url for PWA installs).
+				const u = req.url || "";
+				const isManifest = u === "/manifest.json" || u.startsWith("/manifest.json?");
+				if (!u.startsWith("/api") && !isManifest) return next();
 				const target = new URL(readGatewayUrl());
 				const opts: http.RequestOptions = {
 					hostname: target.hostname,


### PR DESCRIPTION
Follow-up to #348. The dynamic manifest handler didn't run in dev mode (`npm run dev:harness`) because Vite only proxied /api/* to the gateway and the gateway itself has no staticDir in that mode. Now:

- Vite proxies /manifest.json to the gateway.
- The gateway loads the manifest from `public/manifest.json` as a fallback when staticDir is not set.

🤖 Generated with [Bobbit](https://github.com/SuuBro/gw-bobbit)