### PR TITLE
fix(e2e): 4 E2E failures — sidebar selectors & ask-submit race

### DIFF
--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -896,7 +896,7 @@ export function renderSidebar() {
 	const isSkillsActive = isRouteActive("skills");
 
 	return html`
-		<div class="shrink-0 h-full flex flex-col sidebar-edge relative" style="background: var(--sidebar); width: var(--sidebar-w, 240px);">
+		<div class="shrink-0 h-full flex flex-col sidebar-edge relative" data-testid="sidebar-expanded" style="background: var(--sidebar); width: var(--sidebar-w, 240px);">
 			<div class="sidebar-resize-handle" @pointerdown=${onSidebarResizePointerDown} @dblclick=${onSidebarResizeDoubleClick} title="Drag to resize (double-click to reset)"></div>
 			<div class="flex flex-col border-b border-border/50 px-0.5 py-1 gap-0.5">
 				<div class="flex items-center">
@@ -1182,7 +1182,7 @@ function renderCollapsedSidebar(sortedGoals: Goal[], _ungroupedSessions: Gateway
 	};
 
 	return html`
-		<div class="w-14 shrink-0 h-full flex flex-col items-center sidebar-edge" style="background: var(--sidebar);">
+		<div class="w-14 shrink-0 h-full flex flex-col items-center sidebar-edge" data-testid="sidebar-collapsed" style="background: var(--sidebar);">
 			<div class="flex-1 overflow-y-auto flex flex-col items-center gap-0.5 py-2 px-0.5">
 				${sortedGoals.map((goal, i) => {
 					const goalSessions = allSessions.filter((s) => (s.goalId === goal.id || s.teamGoalId === goal.id) && !s.delegateOf).sort((a, b) => a.createdAt - b.createdAt);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -38,6 +38,14 @@ import { isGitRepo, getRepoRoot, shouldSkipRemotePush, stripTokenFromGitUrl, det
 import { VerificationHarness } from "./agent/verification-harness.js";
 import { validateAnswers, crossValidate, type UserQuestion } from "./agent/ask-user-choices-validation.js";
 import { buildAskResponseEnvelope, findAskResponseAnswers } from "../shared/ask-envelope.js";
+
+// In-memory dedup guard for ask_user_choices /submit. Keyed by
+// `${sessionId}::${toolUseId}`. Populated synchronously before enqueuing the
+// response envelope so a concurrent duplicate /submit returns alreadySubmitted
+// even when the transcript hasn't yet reflected the first envelope.
+// Entries are also refilled from the transcript check, so survive process
+// restarts via the transcript fallback in findAskResponseAnswers.
+const askSubmittedToolUseIds = new Set<string>();
 import { inlineFileImages } from "./agent/inline-file-images.js";
 import { StaffManager } from "./agent/staff-manager.js";
 import { TriggerEngine } from "./agent/staff-trigger-engine.js";
@@ -6738,9 +6746,21 @@ async function handleApiRoute(
 		}
 
 		// Idempotency: if a response envelope for this toolUseId already exists,
-		// return success without appending again.
+		// return success without appending again. Check in-memory guard first
+		// (covers the race where a duplicate /submit arrives before the first
+		// envelope has propagated into the transcript), then the transcript
+		// (covers process restart / external writers).
+		const dedupKey = `${sessionId}::${toolUseId}`;
+		if (askSubmittedToolUseIds.has(dedupKey)) {
+			json({ ok: true, alreadySubmitted: true });
+			return;
+		}
 		const existing = findAskResponseAnswers(messages, toolUseId);
-		if (existing) { json({ ok: true, alreadySubmitted: true }); return; }
+		if (existing) {
+			askSubmittedToolUseIds.add(dedupKey);
+			json({ ok: true, alreadySubmitted: true });
+			return;
+		}
 
 		// Locate the ask_user_choices tool_use block; use its input to cross-validate.
 		let matchedQuestions: UserQuestion[] | null = null;
@@ -6768,9 +6788,14 @@ async function handleApiRoute(
 		if (crossErr) { json({ error: crossErr }, 400); return; }
 
 		const envelope = buildAskResponseEnvelope(toolUseId, answers);
+		// Mark as submitted BEFORE awaiting enqueuePrompt so a concurrent
+		// duplicate /submit is rejected deterministically.
+		askSubmittedToolUseIds.add(dedupKey);
 		try {
 			await sessionManager.enqueuePrompt(sessionId, envelope);
 		} catch (e: any) {
+			// Roll back the dedup flag so the caller can retry.
+			askSubmittedToolUseIds.delete(dedupKey);
 			json({ error: `Failed to enqueue response: ${e?.message || String(e)}` }, 500);
 			return;
 		}

--- a/tests/e2e/ui/sidebar-archived-layout.spec.ts
+++ b/tests/e2e/ui/sidebar-archived-layout.spec.ts
@@ -190,8 +190,8 @@ test.describe("SB-32: Collapsed sidebar", () => {
 	test("collapse button narrows sidebar, persists across reload, expand restores", async ({ page }) => {
 		await openApp(page);
 
-		// The sidebar should be ~240px wide initially (full width)
-		const sidebar = page.locator(".w-\\[240px\\]").first();
+		// The sidebar should be expanded initially
+		const sidebar = page.locator("[data-testid='sidebar-expanded']").first();
 		await expect(sidebar).toBeVisible({ timeout: 10_000 });
 
 		// Click the collapse button (PanelLeftClose icon button)
@@ -199,27 +199,27 @@ test.describe("SB-32: Collapsed sidebar", () => {
 		await expect(collapseBtn).toBeVisible({ timeout: 5_000 });
 		await collapseBtn.click();
 
-		// Sidebar should now be narrow (~56px / w-14)
-		const collapsedSidebar = page.locator(".w-14").first();
+		// Sidebar should now be collapsed (icon-only strip)
+		const collapsedSidebar = page.locator("[data-testid='sidebar-collapsed']").first();
 		await expect(collapsedSidebar).toBeVisible({ timeout: 5_000 });
-		// Full-width sidebar should be gone
-		await expect(page.locator(".w-\\[240px\\]")).toHaveCount(0, { timeout: 3_000 });
+		// Expanded sidebar should be gone
+		await expect(page.locator("[data-testid='sidebar-expanded']")).toHaveCount(0, { timeout: 3_000 });
 
 		// Reload — collapsed state should persist
 		await page.reload();
 		await expect(
-			page.locator(".w-14").first(),
+			page.locator("[data-testid='sidebar-collapsed']").first(),
 		).toBeVisible({ timeout: 15_000 });
-		// Full-width sidebar should still be gone after reload
-		await expect(page.locator(".w-\\[240px\\]")).toHaveCount(0, { timeout: 3_000 });
+		// Expanded sidebar should still be gone after reload
+		await expect(page.locator("[data-testid='sidebar-expanded']")).toHaveCount(0, { timeout: 3_000 });
 
 		// Click expand button to restore
 		const expandBtn = page.locator("button[title*='Expand sidebar']").first();
 		await expect(expandBtn).toBeVisible({ timeout: 5_000 });
 		await expandBtn.click();
 
-		// Full-width sidebar should be back
-		await expect(page.locator(".w-\\[240px\\]").first()).toBeVisible({ timeout: 5_000 });
+		// Expanded sidebar should be back
+		await expect(page.locator("[data-testid='sidebar-expanded']").first()).toBeVisible({ timeout: 5_000 });
 	});
 });
 

--- a/tests/e2e/ui/stories-sidebar.spec.ts
+++ b/tests/e2e/ui/stories-sidebar.spec.ts
@@ -307,9 +307,9 @@ test.describe("CT-03 & CT-04: Sidebar stories", () => {
 	test("SB-32: Sidebar collapses to icon-only mode and persists", async ({ page }) => {
 		s.begin(STORY_SB32);
 
-		// setup — verify sidebar is expanded (240px wide)
+		// setup — verify sidebar is expanded
 		await s.sidebar.is_visible();
-		const fullSidebar = page.locator(".w-\\[240px\\]").first();
+		const fullSidebar = page.locator("[data-testid='sidebar-expanded']").first();
 		await expect(fullSidebar).toBeVisible({ timeout: 10_000 });
 
 		// act — click the collapse button
@@ -318,23 +318,23 @@ test.describe("CT-03 & CT-04: Sidebar stories", () => {
 		await expect(collapseBtn).toBeVisible({ timeout: 5_000 });
 		await collapseBtn.click();
 
-		// Sidebar should now be narrow (w-14 = 56px)
-		await expect(page.locator(".w-14").first()).toBeVisible({ timeout: 5_000 });
-		await expect(page.locator(".w-\\[240px\\]")).toHaveCount(0, { timeout: 3_000 });
+		// Sidebar should now be collapsed (icon-only strip)
+		await expect(page.locator("[data-testid='sidebar-collapsed']").first()).toBeVisible({ timeout: 5_000 });
+		await expect(page.locator("[data-testid='sidebar-expanded']")).toHaveCount(0, { timeout: 3_000 });
 
 		// Reload — collapsed state should persist
 		await s.reload();
 
 		// assert — sidebar still collapsed after reload
 		s.assert();
-		await expect(page.locator(".w-14").first()).toBeVisible({ timeout: 15_000 });
-		await expect(page.locator(".w-\\[240px\\]")).toHaveCount(0, { timeout: 3_000 });
+		await expect(page.locator("[data-testid='sidebar-collapsed']").first()).toBeVisible({ timeout: 15_000 });
+		await expect(page.locator("[data-testid='sidebar-expanded']")).toHaveCount(0, { timeout: 3_000 });
 
 		// Expand to restore state for other tests
 		const expandBtn = page.locator("button[title*='Expand sidebar']").first();
 		await expect(expandBtn).toBeVisible({ timeout: 5_000 });
 		await expandBtn.click();
-		await expect(page.locator(".w-\\[240px\\]").first()).toBeVisible({ timeout: 5_000 });
+		await expect(page.locator("[data-testid='sidebar-expanded']").first()).toBeVisible({ timeout: 5_000 });
 	});
 
 	// ---------------------------------------------------------------
@@ -359,19 +359,19 @@ test.describe("CT-03 & CT-04: Sidebar stories", () => {
 		await page.waitForTimeout(300);
 
 		// Test Ctrl+[ toggles sidebar collapse
-		await expect(page.locator(".w-\\[240px\\]").first()).toBeVisible({ timeout: 5_000 });
+		await expect(page.locator("[data-testid='sidebar-expanded']").first()).toBeVisible({ timeout: 5_000 });
 		await page.keyboard.press("Control+[");
 		await page.waitForTimeout(500);
 
-		// Sidebar should be collapsed (w-14)
-		await expect(page.locator(".w-14").first()).toBeVisible({ timeout: 5_000 });
+		// Sidebar should be collapsed
+		await expect(page.locator("[data-testid='sidebar-collapsed']").first()).toBeVisible({ timeout: 5_000 });
 
 		// assert — keyboard shortcuts work
 		s.assert();
 		// Toggle back to expanded
 		await page.keyboard.press("Control+[");
 		await page.waitForTimeout(500);
-		await expect(page.locator(".w-\\[240px\\]").first()).toBeVisible({ timeout: 5_000 });
+		await expect(page.locator("[data-testid='sidebar-expanded']").first()).toBeVisible({ timeout: 5_000 });
 	});
 
 	// ---------------------------------------------------------------


### PR DESCRIPTION
Fixes the 4 hard E2E failures surfaced by `npm run test:e2e`.

## Failures addressed

1. `tests/e2e/ask-user-choices.spec.ts:152` — *duplicate /submit returns alreadySubmitted:true without re-appending*
2. `tests/e2e/ui/sidebar-archived-layout.spec.ts:190` — SB-32 collapse/persist/expand
3. `tests/e2e/ui/stories-sidebar.spec.ts:307` — SB-32 icon-only mode persistence
4. `tests/e2e/ui/stories-sidebar.spec.ts:344` — SB-34 sidebar keyboard shortcuts

## Root causes

**Sidebar (failures 2–4)** — commit `9ee4f72b` (user-resizable sidebar) replaced the hardcoded Tailwind class `w-[240px]` on the expanded sidebar with an inline `style="width: var(--sidebar-w, 240px)"` so the width is user-configurable and persisted. The three specs still queried `.w-\[240px\]`, which now has 0 matches. Test/code drift — the resize PR didn't re-run the SB-32/34 suites.

**ask_user_choices idempotency (failure 1)** — the `/api/internal/user-question/submit` dedup check relied solely on `findAskResponseAnswers(messages, toolUseId)` against the transcript. `enqueuePrompt` returns before the envelope has propagated into the transcript, so a concurrent duplicate `/submit` saw an empty result and appended a second envelope instead of returning `{ ok: true, alreadySubmitted: true }`.

## Fix

- `src/app/sidebar.ts`: stable `data-testid="sidebar-expanded"` / `sidebar-collapsed` hooks on both sidebar root elements.
- `tests/e2e/ui/sidebar-archived-layout.spec.ts` + `tests/e2e/ui/stories-sidebar.spec.ts`: switch from fragile Tailwind-class selectors to `data-testid`.
- `src/server/server.ts`: add an in-memory `Set<"sessionId::toolUseId">` dedup guard, populated **synchronously before** `enqueuePrompt` and rolled back only if enqueue fails. Transcript check remains as a fallback for process restarts.

## Verification

- `npm run check` — clean.
- `npx node --test tests/ask-envelope.test.ts` — 22/22 pass (no regression in envelope parsing).
- `npx playwright test --config=playwright-e2e.config.ts tests/e2e/ask-user-choices.spec.ts tests/e2e/ui/sidebar-archived-layout.spec.ts tests/e2e/ui/stories-sidebar.spec.ts` — **26/26 pass** (previously 4 failed).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
