### PR TITLE
Project-colored plus icons on New goal buttons

### DIFF
--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -263,7 +263,7 @@ function renderMobileLanding() {
 															<span class="relative inline-flex items-center justify-center" style="width:16px;height:16px;">
 																${icon(GoalIcon, "sm")}
 																<svg viewBox="0 0 10 10" style="position:absolute;bottom:0px;right:-1px;width:9px;height:9px;filter:drop-shadow(0 0 1.5px var(--background));">
-																	<path d="M5 1V9M1 5H9" stroke="var(--primary)" stroke-width="2.5" stroke-linecap="round"/>
+																	<path d="M5 1V9M1 5H9" stroke="${color}" stroke-width="2.5" stroke-linecap="round"/>
 																</svg>
 															</span>
 														</button>

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -812,7 +812,7 @@ function renderProjectHeader(project: Project, expanded: boolean) {
 				<span class="relative inline-flex" style="width:12px;height:12px;">
 					${icon(GoalIcon, "xs")}
 					<svg viewBox="0 0 10 10" style="position:absolute;bottom:0px;right:-1px;width:7px;height:7px;filter:drop-shadow(0 0 1.5px var(--background));">
-						<path d="M5 1V9M1 5H9" stroke="var(--primary)" stroke-width="2.5" stroke-linecap="round"/>
+						<path d="M5 1V9M1 5H9" stroke="${color}" stroke-width="2.5" stroke-linecap="round"/>
 					</svg>
 				</span>
 			</button>


### PR DESCRIPTION
## Summary

The "+" overlay on the "New goal" button next to each project header in the sidebar now uses the project's own accent color (matching its folder icon and project name) instead of the global theme `var(--primary)`.

## Changes

- `src/app/sidebar.ts` (~L815, desktop sidebar): plus stroke uses `${color}` (the existing `getProjectAccentColor(project)` value).
- `src/app/render.ts` (~L266, mobile multi-project header): same change.

Projects without a custom color fall back to `var(--muted-foreground)` (consistent with the rest of the row), instead of the theme accent. The Sessions sub-row "New session" plus is unchanged.

## Verification

- `npm run check` passes.
- Implementation gate verification passed (build, type-check, unit, e2e, LLM gap + quality review).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)