### PR TITLE
Make BgProcessManager.waitForExit tests deterministic

### DIFF
--- a/src/server/agent/bg-process-manager.ts
+++ b/src/server/agent/bg-process-manager.ts
@@ -9,6 +9,38 @@ import type { WebSocket } from "ws";
 import type { ServerMessage } from "../ws/protocol.js";
 import { getShellConfig } from "./shell-util.js";
 
+/**
+ * Function used to spawn the underlying child process. Injected via the
+ * constructor so unit tests can supply a fake EventEmitter-backed child
+ * without touching the OS. Production wiring uses {@link defaultSpawn}.
+ */
+export type SpawnFn = (command: string, cwd: string, containerId: string | undefined) => ChildProcess;
+
+function defaultSpawn(command: string, cwd: string, containerId: string | undefined): ChildProcess {
+	const { shell: hostShell, args: hostArgs } = getShellConfig();
+	// Inside the container: always /bin/sh, use the caller's cwd
+	// (which is the container-internal worktree path for sandboxed sessions)
+	const shell = containerId ? "/bin/sh" : hostShell;
+	const args = containerId ? ["-c"] : hostArgs;
+	const containerCwd = cwd;
+
+	if (containerId) {
+		console.log(`[bg-process] Docker exec in container ${containerId.substring(0, 12)}, cwd=${containerCwd}`);
+	}
+	return containerId
+		? spawn("docker", ["exec", "-w", containerCwd, containerId, shell, ...args, command], {
+			stdio: ["ignore", "pipe", "pipe"],
+			detached: false, // docker exec manages the process
+			env: { ...process.env, MSYS_NO_PATHCONV: "1", MSYS2_ARG_CONV_EXCL: "*" },
+		})
+		: spawn(shell, [...args, command], {
+			cwd,
+			stdio: ["ignore", "pipe", "pipe"],
+			detached: true,
+			env: process.env,
+		});
+}
+
 export interface LogEntry {
 	ts: number;
 	text: string;
@@ -31,6 +63,13 @@ export interface BgProcess {
 	cwd: string;
 	/** If set, process was spawned inside this Docker container */
 	containerId?: string;
+	/**
+	 * Resolves once the child has emitted `exit` AND `status`/`exitCode` have
+	 * been updated. Awaiters are guaranteed to observe the post-exit snapshot.
+	 * This eliminates the previous "50ms slack" between the exit event and
+	 * `status === 'exited'" — and removes a long-standing flake source.
+	 */
+	exited: Promise<void>;
 }
 
 export interface BgProcessInfo {
@@ -47,8 +86,6 @@ export interface BgProcessInfo {
 const MAX_LOG_LINES = 5000;
 const MAX_LOG_BYTES = 512 * 1024; // 512KB per process
 
-let nextId = 1;
-
 // Shell config is provided by the shared shell-util module
 
 export class BgProcessManager {
@@ -58,9 +95,17 @@ export class BgProcessManager {
 	private clientsProvider: (sessionId: string) => Set<WebSocket> | undefined;
 	/** sessionId → in-flight wait AbortControllers. Aborted when a steer arrives. */
 	private waits = new Map<string, Set<AbortController>>();
+	/** Per-instance id sequence — keeps test runs isolated from each other. */
+	private nextId = 1;
+	/** Spawner — overridable in tests so unit tests don't touch the OS. */
+	private spawnFn: SpawnFn;
 
-	constructor(clientsProvider: (sessionId: string) => Set<WebSocket> | undefined) {
+	constructor(
+		clientsProvider: (sessionId: string) => Set<WebSocket> | undefined,
+		spawnFn: SpawnFn = defaultSpawn,
+	) {
 		this.clientsProvider = clientsProvider;
+		this.spawnFn = spawnFn;
 	}
 
 	private broadcast(sessionId: string, msg: ServerMessage): void {
@@ -78,33 +123,14 @@ export class BgProcessManager {
 		if (sandboxed && !containerId) {
 			throw new Error("Sandboxed session without containerId — refusing host-side execution");
 		}
-		const id = `bg-${nextId++}`;
-		const { shell: hostShell, args: hostArgs } = getShellConfig();
-
-		// Inside the container: always /bin/sh, use the caller's cwd
-		// (which is the container-internal worktree path for sandboxed sessions)
-		const shell = containerId ? "/bin/sh" : hostShell;
-		const args = containerId ? ["-c"] : hostArgs;
-		const containerCwd = cwd;
-
-		if (containerId) {
-			console.log(`[bg-process] Docker exec in container ${containerId.substring(0, 12)}, cwd=${containerCwd}`);
-		}
-		const child = containerId
-			? spawn("docker", ["exec", "-w", containerCwd, containerId, shell, ...args, command], {
-				stdio: ["ignore", "pipe", "pipe"],
-				detached: false, // docker exec manages the process
-				env: { ...process.env, MSYS_NO_PATHCONV: "1", MSYS2_ARG_CONV_EXCL: "*" },
-			})
-			: spawn(shell, [...args, command], {
-				cwd,
-				stdio: ["ignore", "pipe", "pipe"],
-				detached: true,
-				env: process.env,
-			});
+		const id = `bg-${this.nextId++}`;
+		const child = this.spawnFn(command, cwd, containerId);
 
 		// Unref so bg process doesn't prevent gateway from exiting (host spawns only)
-		if (!containerId) child.unref();
+		if (!containerId && typeof child.unref === "function") child.unref();
+
+		let resolveExited!: () => void;
+		const exited = new Promise<void>((res) => { resolveExited = res; });
 
 		const bg: BgProcess = {
 			id,
@@ -120,6 +146,7 @@ export class BgProcessManager {
 			startTime: Date.now(),
 			cwd,
 			containerId,
+			exited,
 		};
 
 		let logBytes = 0;
@@ -183,6 +210,9 @@ export class BgProcessManager {
 		child.on("exit", (code) => {
 			bg.status = "exited";
 			bg.exitCode = code;
+			// Resolve BEFORE broadcast/destroy so any awaiter on `bg.exited`
+			// observes status === 'exited' the moment they're scheduled.
+			resolveExited();
 			// Destroy pipes to avoid lingering from grandchild processes
 			child.stdout?.destroy();
 			child.stderr?.destroy();
@@ -360,42 +390,34 @@ export class BgProcessManager {
 		if (bg.status === "exited") return { info: this.toInfo(bg), timedOut: false, aborted: false };
 		if (signal?.aborted) return { info: this.toInfo(bg), timedOut: false, aborted: true };
 
-		return new Promise((resolve) => {
-			let settled = false;
-			let timer: ReturnType<typeof setTimeout> | null = null;
+		// Race exit / timeout / abort. We do NOT attach an "exit" listener to the
+		// child — instead we await `bg.exited`, which is resolved by the single
+		// listener installed in create() AFTER status/exitCode are updated. That
+		// removes both the "50 ms slack" hack and the per-call exit-listener leak.
+		let timer: ReturnType<typeof setTimeout> | null = null;
+		let onAbort: (() => void) | null = null;
 
-			const cleanup = () => {
-				if (timer) { clearTimeout(timer); timer = null; }
-				bg.child.removeListener("exit", onExit);
-				if (signal) signal.removeEventListener("abort", onAbort);
-			};
-
-			const onExit = () => {
-				if (settled) return;
-				settled = true;
-				cleanup();
-				// Small delay to let the exit handler update status
-				setTimeout(() => resolve({ info: this.toInfo(bg), timedOut: false, aborted: false }), 50);
-			};
-
-			const onTimeout = () => {
-				if (settled) return;
-				settled = true;
-				cleanup();
-				resolve({ info: this.toInfo(bg), timedOut: true, aborted: false });
-			};
-
-			const onAbort = () => {
-				if (settled) return;
-				settled = true;
-				cleanup();
-				resolve({ info: this.toInfo(bg), timedOut: false, aborted: true });
-			};
-
-			timer = setTimeout(onTimeout, timeoutMs);
-			bg.child.once("exit", onExit);
-			if (signal) signal.addEventListener("abort", onAbort, { once: true });
+		const timeoutP = new Promise<"timeout">((res) => {
+			timer = setTimeout(() => res("timeout"), timeoutMs);
 		});
+		const abortP = new Promise<"abort">((res) => {
+			if (!signal) return; // never resolves — Promise.race ignores it
+			onAbort = () => res("abort");
+			signal.addEventListener("abort", onAbort, { once: true });
+		});
+		const exitP = bg.exited.then(() => "exit" as const);
+
+		try {
+			const winner = await Promise.race([exitP, timeoutP, abortP]);
+			return {
+				info: this.toInfo(bg),
+				timedOut: winner === "timeout",
+				aborted: winner === "abort",
+			};
+		} finally {
+			if (timer) clearTimeout(timer);
+			if (onAbort && signal) signal.removeEventListener("abort", onAbort);
+		}
 	}
 
 	/** Remove exited processes from the map */

--- a/tests/bg-process-manager.test.ts
+++ b/tests/bg-process-manager.test.ts
@@ -1,111 +1,223 @@
 /**
- * Unit tests for BgProcessManager.waitForExit — abort-signal behaviour.
+ * Unit tests for BgProcessManager.waitForExit \u2014 deterministic state-machine
+ * coverage.
  *
- * Spawns real short-running child processes via the public `create()` API
- * (so all the listeners & broadcast plumbing is exercised) and exercises
- * the new AbortController path.
+ * Previously these tests spawned real child processes (sleep/ping/cmd /c exit)
+ * and asserted on wall-clock elapsed times. That made them flaky on loaded CI
+ * runners and forced ordering hacks (50 ms slack, polling loops, "give
+ * listeners a tick" sleeps).
+ *
+ * The class now accepts an injected `SpawnFn`. Tests pass a fake child built
+ * on EventEmitter so `exit` is fired by the test, not by the OS scheduler.
+ * Combined with `node:test` mock timers this gives us byte-deterministic
+ * coverage of the abort / timeout / exit race without touching processes.
  */
-import { describe, it } from "node:test";
+import { describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { randomUUID } from "node:crypto";
 import os from "node:os";
+import type { ChildProcess } from "node:child_process";
 
-import { BgProcessManager } from "../src/server/agent/bg-process-manager.ts";
+import { BgProcessManager, type SpawnFn } from "../src/server/agent/bg-process-manager.ts";
 
-const SESSION = "sess-bg-test";
-// Use a command that works on both POSIX + Windows shells. getShellConfig picks
-// cmd.exe on win32 so `ping` works; on POSIX the default shell runs `sleep`.
-const SLEEP_CMD = process.platform === "win32"
-	? "ping -n 30 127.0.0.1 >NUL"
-	: "sleep 30";
+// --- Fake child plumbing --------------------------------------------------
 
-function makeManager(): BgProcessManager {
-	// clientsProvider returns undefined — no websocket broadcast side effects.
-	return new BgProcessManager(() => undefined);
+interface FakeChild extends EventEmitter {
+	pid: number;
+	stdout: EventEmitter & { destroy(): void };
+	stderr: EventEmitter & { destroy(): void };
+	kill(_sig?: string): boolean;
+	unref(): void;
+	__killed: string[];
 }
 
-describe("BgProcessManager.waitForExit — AbortSignal", () => {
+function makeFakeChild(): FakeChild {
+	const child = new EventEmitter() as FakeChild;
+	child.pid = Math.floor(Math.random() * 1_000_000) + 1000;
+	child.__killed = [];
+	const mkStream = () => Object.assign(new EventEmitter(), { destroy() { /* noop */ } });
+	child.stdout = mkStream();
+	child.stderr = mkStream();
+	child.kill = (sig = "SIGTERM") => { child.__killed.push(sig); return true; };
+	child.unref = () => { /* noop */ };
+	return child;
+}
+
+/** SpawnFn that returns a fresh fake and exposes it via the returned ref. */
+function fakeSpawner(): { spawn: SpawnFn; last: () => FakeChild } {
+	let last: FakeChild | null = null;
+	const spawn: SpawnFn = () => {
+		last = makeFakeChild();
+		return last as unknown as ChildProcess;
+	};
+	return { spawn, last: () => { if (!last) throw new Error("spawn not called"); return last; } };
+}
+
+function makeManager() {
+	const spawner = fakeSpawner();
+	const mgr = new BgProcessManager(() => undefined, spawner.spawn);
+	return { mgr, last: spawner.last };
+}
+
+// Each test gets its own session id so a leaked entry can't bleed across cases.
+function freshSession() { return `s-${randomUUID()}`; }
+
+// --- Tests ----------------------------------------------------------------
+
+describe("BgProcessManager.waitForExit \u2014 state machine", () => {
 	it("abort before exit resolves with aborted:true and leaves process running", async () => {
-		const mgr = makeManager();
-		const info = mgr.create(SESSION, SLEEP_CMD, os.tmpdir());
+		const { mgr, last } = makeManager();
+		const SESSION = freshSession();
+		const info = mgr.create(SESSION, "sleep 30", os.tmpdir());
 		assert.equal(info.status, "running");
 
 		const controller = new AbortController();
 		mgr.registerWait(SESSION, controller);
 
-		const start = Date.now();
 		const waitPromise = mgr.waitForExit(SESSION, info.id, 10_000, controller.signal);
-		// Abort on the next tick.
-		setImmediate(() => mgr.abortAllWaits(SESSION));
+		mgr.abortAllWaits(SESSION);
 		const result = await waitPromise;
-		const elapsed = Date.now() - start;
 		mgr.unregisterWait(SESSION, controller);
 
 		assert.ok(result, "result should not be null");
 		assert.equal(result!.aborted, true);
 		assert.equal(result!.timedOut, false);
 		assert.equal(result!.info.status, "running", "process must still be running after abort");
-		assert.ok(elapsed < 500, `abort should resolve quickly, was ${elapsed}ms`);
 
-		// Process is still alive — verify via list.
+		// No bg-process side effect from the abort itself.
+		assert.deepEqual(last().__killed, [], "abort must not kill the underlying child");
+
+		// Process is still tracked & running.
 		const still = mgr.list(SESSION).find(p => p.id === info.id);
-		assert.ok(still, "process should still be tracked");
+		assert.ok(still);
 		assert.equal(still!.status, "running");
 
-		// Cleanup — kill the bg process so the test doesn't leak.
+		// No listener leaks on the abort signal.
+		assert.equal(controller.signal.aborted, true);
+
 		mgr.cleanup(SESSION);
 	});
 
-	it("abort after exit is a no-op (exit wins)", async () => {
-		const mgr = makeManager();
-		const cmd = process.platform === "win32" ? "cmd /c exit 0" : "true";
-		const info = mgr.create(SESSION, cmd, os.tmpdir());
+	it("exit resolves immediately and reflects exited status (no 50ms slack)", async () => {
+		const { mgr, last } = makeManager();
+		const SESSION = freshSession();
+		const info = mgr.create(SESSION, "noop", os.tmpdir());
 
-		// Poll until the bg process is observed as exited (Windows cmd.exe spawn
-		// + exit handler can take longer than a fixed 100ms sleep under load).
-		const pollDeadline = Date.now() + 5000;
-		while (Date.now() < pollDeadline) {
-			const tracked = mgr.list(SESSION).find(p => p.id === info.id);
-			if (tracked?.status === "exited") break;
-			await new Promise((resolve) => setTimeout(resolve, 25));
-		}
+		const controller = new AbortController();
+		const waitPromise = mgr.waitForExit(SESSION, info.id, 10_000, controller.signal);
+
+		// Drive the exit on a microtask boundary so the awaiter is already parked.
+		queueMicrotask(() => last().emit("exit", 0));
+
+		const result = await waitPromise;
+		assert.ok(result);
+		assert.equal(result!.timedOut, false);
+		assert.equal(result!.aborted, false);
+		// The critical invariant: the snapshot returned to the caller already
+		// shows status === "exited". Previously this required a 50 ms slack
+		// timeout to be reliable.
+		assert.equal(result!.info.status, "exited");
+		assert.equal(result!.info.exitCode, 0);
+
+		mgr.cleanup(SESSION);
+	});
+
+	it("already-exited short-circuit returns aborted:false even with a fresh signal", async () => {
+		const { mgr, last } = makeManager();
+		const SESSION = freshSession();
+		const info = mgr.create(SESSION, "noop", os.tmpdir());
+
+		// Synchronously exit before any waiter attaches.
+		last().emit("exit", 0);
 
 		const controller = new AbortController();
 		const result = await mgr.waitForExit(SESSION, info.id, 1000, controller.signal);
-		// Process already exited — should short-circuit with aborted:false.
 		assert.ok(result);
 		assert.equal(result!.timedOut, false);
 		assert.equal(result!.aborted, false);
 		assert.equal(result!.info.status, "exited");
 
-		// Firing abort now should not produce an extra resolution or throw.
+		// Aborting after the fact must not throw or produce side effects.
 		controller.abort();
+		assert.deepEqual(last().__killed, []);
+
 		mgr.cleanup(SESSION);
 	});
 
-	it("abort after timeout is a no-op (timeout already settled)", async () => {
-		const mgr = makeManager();
-		const info = mgr.create(SESSION, SLEEP_CMD, os.tmpdir());
+	it("timeout fires deterministically under fake timers", (t) => {
+		t.mock.timers.enable({ apis: ["setTimeout"] });
+
+		const { mgr } = makeManager();
+		const SESSION = freshSession();
+		const info = mgr.create(SESSION, "sleep 30", os.tmpdir());
 
 		const controller = new AbortController();
 		mgr.registerWait(SESSION, controller);
 
-		const result = await mgr.waitForExit(SESSION, info.id, 50, controller.signal);
-		assert.ok(result);
-		assert.equal(result!.timedOut, true);
-		assert.equal(result!.aborted, false);
+		const waitPromise = mgr.waitForExit(SESSION, info.id, 50, controller.signal);
 
-		// Abort after the fact — must be a no-op, no extra resolution or listener leak.
-		controller.abort();
-		// Give listeners a tick to fire if incorrectly still attached.
-		await new Promise((r) => setTimeout(r, 20));
+		// Advance by the exact timeout \u2014 zero wall-clock involvement.
+		t.mock.timers.tick(50);
 
-		mgr.unregisterWait(SESSION, controller);
+		return waitPromise.then((result) => {
+			assert.ok(result);
+			assert.equal(result!.timedOut, true);
+			assert.equal(result!.aborted, false);
+
+			// Aborting after timeout must not produce a second resolution.
+			controller.abort();
+			mgr.unregisterWait(SESSION, controller);
+			mgr.cleanup(SESSION);
+		});
+	});
+
+	it("does not leak abort listeners across many cycles", async (t) => {
+		t.mock.timers.enable({ apis: ["setTimeout"] });
+		const { mgr, last } = makeManager();
+		const SESSION = freshSession();
+		const info = mgr.create(SESSION, "sleep 30", os.tmpdir());
+
+		// AbortSignal has no public listener-count API — wrap add/remove so the
+		// test can assert structurally that every wait that didn't fire abort
+		// still cleaned up the listener it added.
+		const controller = new AbortController();
+		const signal = controller.signal;
+		let active = 0;
+		let peak = 0;
+		const origAdd = signal.addEventListener.bind(signal);
+		const origRemove = signal.removeEventListener.bind(signal);
+		signal.addEventListener = ((type: string, listener: any, opts?: any) => {
+			if (type === "abort") { active++; peak = Math.max(peak, active); }
+			return origAdd(type, listener, opts);
+		}) as any;
+		signal.removeEventListener = ((type: string, listener: any, opts?: any) => {
+			if (type === "abort") active = Math.max(0, active - 1);
+			return origRemove(type, listener, opts);
+		}) as any;
+
+		// 200 wait/timeout cycles re-using the same signal. If we leak a listener
+		// per cycle, `active` grows without bound.
+		for (let i = 0; i < 200; i++) {
+			const p = mgr.waitForExit(SESSION, info.id, 1, signal);
+			// Drain microtasks so the wait has parked, then fire its timer.
+			await Promise.resolve();
+			t.mock.timers.tick(1);
+			await p;
+		}
+
+		assert.equal(active, 0, "abort listener must be removed when wait settles via timeout");
+		assert.ok(peak <= 1, `at most one abort listener should be live at a time, peak=${peak}`);
+		// And no listener accumulated on the underlying child either.
+		assert.equal(last().listenerCount("exit"), 1, "only the manager's create() listener should remain");
+
 		mgr.cleanup(SESSION);
 	});
 
 	it("multiple concurrent waits all abort on abortAllWaits()", async () => {
-		const mgr = makeManager();
-		const info = mgr.create(SESSION, SLEEP_CMD, os.tmpdir());
+		const { mgr, last } = makeManager();
+		const SESSION = freshSession();
+		const info = mgr.create(SESSION, "sleep 30", os.tmpdir());
 
 		const c1 = new AbortController();
 		const c2 = new AbortController();
@@ -118,7 +230,7 @@ describe("BgProcessManager.waitForExit — AbortSignal", () => {
 		const p2 = mgr.waitForExit(SESSION, info.id, 10_000, c2.signal);
 		const p3 = mgr.waitForExit(SESSION, info.id, 10_000, c3.signal);
 
-		setImmediate(() => mgr.abortAllWaits(SESSION));
+		mgr.abortAllWaits(SESSION);
 		const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
 
 		for (const r of [r1, r2, r3]) {
@@ -126,6 +238,7 @@ describe("BgProcessManager.waitForExit — AbortSignal", () => {
 			assert.equal(r!.aborted, true);
 			assert.equal(r!.info.status, "running");
 		}
+		assert.deepEqual(last().__killed, [], "abortAllWaits must not kill the bg child");
 
 		mgr.unregisterWait(SESSION, c1);
 		mgr.unregisterWait(SESSION, c2);
@@ -133,21 +246,56 @@ describe("BgProcessManager.waitForExit — AbortSignal", () => {
 		mgr.cleanup(SESSION);
 	});
 
-	it("cleanup() aborts in-flight waits so HTTP handlers resolve", async () => {
-		const mgr = makeManager();
-		const info = mgr.create(SESSION, SLEEP_CMD, os.tmpdir());
+	it("cleanup() aborts in-flight waits (separate from kill)", async () => {
+		const { mgr, last } = makeManager();
+		const SESSION = freshSession();
+		const info = mgr.create(SESSION, "sleep 30", os.tmpdir());
 
 		const controller = new AbortController();
 		mgr.registerWait(SESSION, controller);
 		const waitPromise = mgr.waitForExit(SESSION, info.id, 10_000, controller.signal);
 
-		// Terminate path calls cleanup, which must abort waits.
 		mgr.cleanup(SESSION);
 
 		const result = await waitPromise;
 		assert.ok(result);
-		// Either aborted (abort fired first) or exit (cleanup's SIGTERM fired first)
-		// is acceptable — the important thing is that the wait resolves quickly.
-		assert.ok(result!.aborted || result!.info.status === "exited");
+		// cleanup() calls abortAllWaits() FIRST, so the abort branch must win
+		// regardless of what happens to the child afterwards.
+		assert.equal(result!.aborted, true, "cleanup must abort the pending wait");
+
+		// And cleanup must also have signalled the child.
+		assert.ok(last().__killed.includes("SIGTERM"), "cleanup must SIGTERM running children");
+	});
+
+	it("waitForExit on unknown processId returns null", async () => {
+		const { mgr } = makeManager();
+		const result = await mgr.waitForExit(freshSession(), "bg-does-not-exist", 100);
+		assert.equal(result, null);
+	});
+
+	it("pre-aborted signal returns immediately without arming the timer", (t) => {
+		t.mock.timers.enable({ apis: ["setTimeout"] });
+
+		const { mgr } = makeManager();
+		const SESSION = freshSession();
+		const info = mgr.create(SESSION, "sleep 30", os.tmpdir());
+
+		const controller = new AbortController();
+		controller.abort(); // abort BEFORE waitForExit is invoked
+
+		// If waitForExit incorrectly armed the timer it would still be pending;
+		// we can detect that via t.mock.timers.runAll() having work to do.
+		return mgr.waitForExit(SESSION, info.id, 10_000, controller.signal).then((result) => {
+			assert.ok(result);
+			assert.equal(result!.aborted, true);
+			assert.equal(result!.timedOut, false);
+			// Running all pending timers must not produce any extra resolution
+			// or unhandled rejection \u2014 this assertion is purely structural.
+			t.mock.timers.runAll();
+			mgr.cleanup(SESSION);
+		});
 	});
 });
+
+// Make sure no global mock timer state leaks between describe blocks.
+mock.timers.reset();


### PR DESCRIPTION
## Summary

The `BgProcessManager.waitForExit` unit tests were structurally flaky: they spawned real `sleep`/`ping`/`cmd /c exit` children and asserted on wall-clock timings (`elapsed < 500ms`, a 50 ms slack timer inside the production code, 20 ms "give listeners a tick" sleeps, a 5 s polling loop for `cmd /c exit`). On loaded CI runners this produced intermittent failures, and a thrown assertion could leave detached `sleep 30` children behind.

This PR removes the flakiness vectors instead of papering over them with retries or longer timeouts.

## Production changes (`src/server/agent/bg-process-manager.ts`)

- **Injected `SpawnFn`.** `BgProcessManager` now takes an optional `spawnFn` constructor argument. Production wiring is unchanged — `defaultSpawn` (extracted from the previous inline logic) is the default. Tests pass a fake `EventEmitter`-backed child so no OS process is involved.
- **`bg.exited: Promise<void>`.** Resolved by the single `child.on('exit', ...)` listener installed in `create()`, **after** `status` and `exitCode` are updated. Awaiters are guaranteed to see `status === 'exited'`.
- **Rewrote `waitForExit`** as `Promise.race` over `bg.exited` / timeout / abort. The 50 ms slack hack is gone, and we no longer attach a per-call `exit` listener to the child (eliminates the listener-leak vector).
- **`nextId`** moved from module scope to instance scope (per-instance isolation).

## Test rewrite (`tests/bg-process-manager.test.ts`)

- Fake child via `EventEmitter` — no real processes, no shell branching, no zombies.
- Per-test `crypto.randomUUID()` session id — no cross-test contamination.
- `node:test` mock timers drive the timeout and listener-leak tests deterministically.
- New deterministic regression tests:
  - **exit reflects `status: "exited"` immediately** — pins down the no-50ms-slack invariant.
  - **does not leak abort listeners across 200 cycles** — wraps `add/removeEventListener` to count live listeners; asserts `peak <= 1` and `active === 0`. Replaces the old "sleep 20 ms and hope nothing fires" proxy.
  - **pre-aborted signal returns immediately** — covers the synchronous short-circuit.
  - **unknown `processId` returns null** — explicit contract.
  - **`cleanup()` test split** into two deterministic assertions (abort wins + child SIGTERM'd) instead of "either is fine".

## Verification

- `npm run check` — clean.
- `npm run test:unit` — 969 passed, 1 skipped, 0 failed. Run twice in a row to confirm determinism.
- `tests/bg-process-manager.test.ts` itself: 9/9 pass in ~8 ms (vs ~30 s previously).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)