### PR TITLE
test(e2e): failure-context fixture + send_message poll rate tuning

### DIFF
--- a/tests/e2e/gateway-harness.ts
+++ b/tests/e2e/gateway-harness.ts
@@ -66,9 +66,43 @@ export interface GatewayInfo {
 	wsBase: string;
 	bobbitDir: string;
 	sessionManager?: any;
+	/** Server-side log ring buffer (last 200 lines), populated by the harness's
+	 * console.{log,warn,error} hook. Failure-context fixture below dumps the
+	 * tail of this buffer into the test artifact directory. */
+	logs: { ring: string[]; capacity: number };
 }
 
-export const test = base.extend<{}, { enableMcp: boolean; enableWorktreePool: boolean; gateway: GatewayInfo }>({
+// Server log ring buffer — module-scoped so the gateway worker fixture and
+// the per-test failure-context fixture can both reach it without juggling a
+// shared object through Playwright fixture chains.
+const _serverLogs: { ring: string[]; capacity: number } = { ring: [], capacity: 500 };
+function _pushLog(line: string): void {
+	_serverLogs.ring.push(line);
+	if (_serverLogs.ring.length > _serverLogs.capacity) {
+		_serverLogs.ring.splice(0, _serverLogs.ring.length - _serverLogs.capacity);
+	}
+}
+{
+	// Tap console once per worker process. Calls are still passed through to
+	// the original console so existing log inspection (and Playwright's
+	// stdout/stderr piping) keeps working.
+	const origLog = console.log.bind(console);
+	const origWarn = console.warn.bind(console);
+	const origError = console.error.bind(console);
+	const fmt = (level: string, args: unknown[]): string => {
+		const ts = new Date().toISOString();
+		const msg = args.map(a => {
+			if (typeof a === "string") return a;
+			try { return JSON.stringify(a); } catch { return String(a); }
+		}).join(" ");
+		return `${ts} [${level}] ${msg}`;
+	};
+	console.log = (...a: unknown[]) => { _pushLog(fmt("log", a)); origLog(...a); };
+	console.warn = (...a: unknown[]) => { _pushLog(fmt("warn", a)); origWarn(...a); };
+	console.error = (...a: unknown[]) => { _pushLog(fmt("error", a)); origError(...a); };
+}
+
+export const test = base.extend<{ failureContext: void }, { enableMcp: boolean; enableWorktreePool: boolean; gateway: GatewayInfo }>({
 	// Worker-scoped option. Default false — opt in with `test.use({ enableMcp: true })`
 	// at the top of a spec file. Playwright groups tests with matching option
 	// values onto the same worker, so each spec file effectively gets its own gateway.
@@ -200,6 +234,7 @@ export const test = base.extend<{}, { enableMcp: boolean; enableWorktreePool: bo
 			wsBase: `ws://127.0.0.1:${port}`,
 			bobbitDir,
 			sessionManager: gw.sessionManager,
+			logs: _serverLogs,
 		};
 
 		await use(info);
@@ -219,6 +254,60 @@ export const test = base.extend<{}, { enableMcp: boolean; enableWorktreePool: bo
 			},
 		});
 	}, { scope: "worker", auto: true, timeout: 60_000 }],
+
+	// Per-test failure-context fixture (auto). On test failure, attaches a
+	// JSON snapshot of `window.bobbitState` (the read-only client state
+	// reference exposed for diagnostics) and the tail of the server-log
+	// ring buffer to the test result. Helps root-cause the long-tail flakes
+	// (e.g. "button visible:false but assertion expected visible") by
+	// preserving actual state at fail time instead of leaving us to guess
+	// from stack traces.
+	failureContext: [async ({ page }, use, testInfo) => {
+		// Mark where this test’s server logs start so the snapshot only
+		// includes lines emitted during this test’s execution, not the
+		// entire worker session.
+		const startIndex = _serverLogs.ring.length;
+		await use();
+		if (testInfo.status === testInfo.expectedStatus) return;
+		try {
+			const clientState = await page.evaluate(() => {
+				try {
+					const s = (window as any).bobbitState;
+					if (!s) return { __bobbitState: "missing" };
+					// Strip non-serialisable fields (DOM nodes, classes, event handlers).
+					return JSON.parse(JSON.stringify(s, (_k, v) => {
+						if (v instanceof Element) return `[Element ${v.tagName}]`;
+						if (typeof v === "function") return "[Function]";
+						if (v && typeof v === "object" && "nodeType" in v) return "[Node]";
+						return v;
+					}));
+				} catch (err) {
+					return { __bobbitStateError: String(err) };
+				}
+			});
+			await testInfo.attach("client-state.json", {
+				body: JSON.stringify(clientState, null, 2),
+				contentType: "application/json",
+			});
+			const hash = await page.evaluate(() => window.location.hash).catch(() => "<unavailable>");
+			await testInfo.attach("client-route.txt", {
+				body: `hash=${hash}`,
+				contentType: "text/plain",
+			});
+		} catch (err) {
+			await testInfo.attach("client-state-error.txt", {
+				body: `Failed to capture client state: ${err}`,
+				contentType: "text/plain",
+			}).catch(() => { /* best-effort */ });
+		}
+		try {
+			const recent = _serverLogs.ring.slice(Math.max(startIndex - 10, 0));
+			await testInfo.attach("server-logs.txt", {
+				body: recent.join("\n"),
+				contentType: "text/plain",
+			});
+		} catch { /* best-effort */ }
+	}, { auto: true }],
 });
 
 export { expect } from "@playwright/test";

--- a/tests/e2e/ui/spec-framework.ts
+++ b/tests/e2e/ui/spec-framework.ts
@@ -1094,7 +1094,7 @@ export class SpecContext {
 					return true;
 				}
 				return false;
-			}, { timeoutMs: 10_000, intervalMs: 30, label: `send_message ack ${activeId}` });
+			}, { timeoutMs: 10_000, intervalMs: 100, label: `send_message ack ${activeId}` });
 		}
 	}
 


### PR DESCRIPTION
Phase 2 diagnostics from goal 'E2E browser contention fix'. Two small follow-ups to PR #388.

## 1. Failure-context fixture (`gateway-harness.ts`)

When a browser test fails, attach three artifacts to the test result:

- `client-state.json` — `window.bobbitState` snapshot (DOM/Function values stripped) at fail time.
- `client-route.txt` — `window.location.hash`.
- `server-logs.txt` — gateway `console.{log,warn,error}` tail captured during this test only, via a worker-scoped console hook + 500-line ring buffer.

Zero work on success. The fixture short-circuits when `testInfo.status === testInfo.expectedStatus`.

This is what the goal spec called Phase 2 — diagnostic infrastructure to make the next iteration of flake-chasing cheap. Already paid for itself: a 10-run streak captured 7 failures, and the page-snapshot artifacts revealed that 3 of them shared a 'Reconnecting to server…' WS-disconnect pattern (RP-18, CT-01-d, S-02). That cluster wouldn't have been visible from stack traces alone.

## 2. `send_message` ack-poll rate: 30ms → 100ms

The 30ms interval (introduced in PR #388 to fix RE-07) generates ~100 REST polls/second across 3 concurrent browser workers. That's enough HTTP pressure on the in-process gateway to plausibly contribute to the 'Reconnecting' WS-disconnect cluster captured by the new fixture above.

100ms still resolves within 1–2 polls in practice (mock-agent's streaming-status flip + completedTurnCount increment both fire sub-100ms), so this doesn't slow the suite measurably while removing ~70% of REST traffic during multi-prompt tests.

Pure tuning — no behavioral change.

## What's NOT in this PR

The dominant 'Reconnecting' cluster itself is not yet root-caused. Hypothesis: WS write buffer overflow during high-volume mock-agent event bursts under cross-worker FS contention. Tracking that down is a follow-up — this PR ships the diagnostic infrastructure that makes that work feasible.

## Streak status

Latest 10-run browser streak (post fix-#1, fix-#2, post diagnostics): 4 clean / 6 with one rare failure each. Distinct failures: RP-18, CT-01-d, search-result, SB-04, S-02, RP-08, draft-loss Bug 2 — all independent rare flakes, none reproducing in repeat-each isolation.

The 20-consecutive-clean target from the goal spec is not yet met. The cluster originally targeted (cross-worker FS contention via tool-yaml rescan) is verified fixed; what remains is a long tail of independent rare UI race conditions that this diagnostic fixture is designed to help unblock one-by-one.

🤖 Generated with [Bobbit](https://github.com/SuuBro/secret-bobbit)