### PR TITLE
fix(e2e): WS no-deflate + buffer guard + session_removed broadcast + onReconnect hydration

### DIFF
--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -216,6 +216,16 @@ export class RemoteAgent {
 	onPreviewChanged?: (sessionId: string, preview: boolean) => void;
 	/** Callback fired when server detects PR creation and busts the cache. */
 	onPrStatusChanged?: (goalId: string) => void;
+	/** Called when ANY session anywhere is terminated/archived/purged —
+	 * server pushes a `session_removed` broadcast and we forward it here so
+	 * sidebars and dashboards can update without waiting for a polling tick. */
+	onSessionRemoved?: (sessionId: string, reason: string) => void;
+	/** Called after a NON-INITIAL WS reconnect's auth_ok. Use this to re-fire
+	 * session-scoped hydration that runs once on initial connect (annotations,
+	 * git status, bg processes, etc). Without it, a client whose WS dropped
+	 * during a streaming turn keeps its stale local copy of these caches —
+	 * the dominant 'badge stuck after Reconnecting' E2E flake. */
+	onReconnect?: () => void;
 	private _title = "New session";
 
 	constructor() {
@@ -383,6 +393,15 @@ export class RemoteAgent {
 								this.requestMessages();
 							}
 							this.send({ type: "get_state" });
+							// Re-fire session-scoped REST hydration that the initial
+							// connect ran. The `resume` path replays only buffered
+							// events and skips the snapshot-driven hydration in the
+							// 'messages' handler — so without this, caches like
+							// annotations, git status, and bg-processes go stale
+							// after a transient WS drop.
+							try { this.onReconnect?.(); } catch (err) {
+								console.warn("[RemoteAgent] onReconnect handler threw:", err);
+							}
 							// Retry get_state after 3s if we still don't have real model info
 							if (this._stateRetryTimer) clearTimeout(this._stateRetryTimer);
 							this._stateRetryTimer = setTimeout(() => {
@@ -1187,6 +1206,17 @@ export class RemoteAgent {
 			case "pr_status_changed":
 				if ((msg as any).goalId) this.onPrStatusChanged?.((msg as any).goalId);
 				break;
+
+			case "session_removed": {
+				// Server-pushed event: a session somewhere was terminated/archived/purged.
+				// Update local lists immediately so the sidebar / dashboard reflect it
+				// without waiting for the 5s refreshSessions polling tick.
+				const removedId = (msg as any).sessionId as string | undefined;
+				const reason = (msg as any).reason as string | undefined;
+				if (!removedId) break;
+				this.onSessionRemoved?.(removedId, reason ?? "archived");
+				break;
+			}
 
 			case "tool_permission_needed": {
 				const perm = msg as any;

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -900,6 +900,42 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 
 		remote.onWorkflowUpdate = () => { if (activeSessionId() === sessionId) renderApp(); };
 
+		// On WS reconnect, re-fire session-scoped REST hydration that ran on
+		// initial connect. Without this, caches like git status, bg processes,
+		// and review annotations go stale across a transient WS drop — the
+		// dominant 'badge stuck after Reconnecting' E2E flake cluster (RP-18,
+		// CT-01-d, S-02). Cheap, idempotent, runs only on non-initial connects.
+		remote.onReconnect = async () => {
+			try { refreshGitStatusForSession(sessionId); } catch { /* ignore */ }
+			try { refreshBgProcessesForSession(sessionId); } catch { /* ignore */ }
+			try {
+				const { initAnnotationStore } = await import("../ui/components/review/AnnotationStore.js");
+				initAnnotationStore(sessionId).catch(() => { /* best-effort */ });
+			} catch { /* AnnotationStore module load failed — keep going */ }
+		};
+
+		// Server broadcasts session_removed when ANY session is terminated/archived/
+		// purged. Update local lists instantly instead of waiting for the 5s
+		// refreshSessions tick. If the removed session is the one we're viewing,
+		// route to landing.
+		remote.onSessionRemoved = (removedId: string, _reason: string) => {
+			const beforeLen = state.gatewaySessions.length;
+			state.gatewaySessions = state.gatewaySessions.filter(s => s.id !== removedId);
+			const changed = state.gatewaySessions.length !== beforeLen;
+			if (activeSessionId() === removedId) {
+				setHashRoute("landing");
+				state.appView = "authenticated";
+				state.selectedSessionId = null;
+				if (state.remoteAgent) {
+					state.remoteAgent.disconnect();
+					state.remoteAgent = null;
+				}
+				renderApp();
+			} else if (changed) {
+				renderApp();
+			}
+		};
+
 		remote.onGoalSetupEvent = async () => {
 			// Refresh sessions and goals to pick up setupStatus changes
 			refreshSessions();

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -214,12 +214,39 @@ function rewriteUserMessageText(message: any, newText: string): any {
 	return { ...message, content: newText };
 }
 
+/**
+ * Threshold above which a client's outbound buffer is considered
+ * pathologically backed up. The `ws` library doesn't drop frames on its
+ * own — it just lets `bufferedAmount` grow until the kernel pushes back.
+ * On loopback under cross-worker FS contention we've seen short bursts
+ * push this past 1MB; beyond ~8MB the connection effectively stalls and
+ * is then closed by the OS, manifesting as the 'Reconnecting to server…'
+ * E2E flake. We log loudly when crossed and drop the client so the
+ * client-side reconnect path takes over cleanly instead of waiting for a
+ * TCP timeout.
+ */
+const WS_BUFFER_OVERFLOW_BYTES = 4 * 1024 * 1024; // 4 MiB
+const WS_BUFFER_WARN_BYTES = 1 * 1024 * 1024;     // 1 MiB — log only
+const _warnedClients = new WeakSet<WebSocket>();
+
 function broadcast(clients: Set<WebSocket>, msg: ServerMessage): void {
 	const data = JSON.stringify(msg);
 	for (const client of clients) {
-		if (client.readyState === 1) {
-			client.send(data);
+		if (client.readyState !== 1) continue;
+		const buffered = (client as any).bufferedAmount ?? 0;
+		if (buffered > WS_BUFFER_OVERFLOW_BYTES) {
+			console.warn(
+				`[ws] dropping client with bufferedAmount=${buffered}B > ${WS_BUFFER_OVERFLOW_BYTES}B threshold; ` +
+				`client will reconnect. Last msg type=${(msg as any).type}.`,
+			);
+			try { client.terminate(); } catch { /* ignore */ }
+			continue;
 		}
+		if (buffered > WS_BUFFER_WARN_BYTES && !_warnedClients.has(client)) {
+			_warnedClients.add(client);
+			console.warn(`[ws] client bufferedAmount=${buffered}B (warn threshold ${WS_BUFFER_WARN_BYTES}B); type=${(msg as any).type}`);
+		}
+		client.send(data);
 	}
 }
 
@@ -315,7 +342,7 @@ export class SessionManager {
 	configCascade: import("./config-cascade.js").ConfigCascade | null = null;
 	private _onPrCreationDetected?: (session: SessionInfo) => void;
 	private _verificationHarness?: import("./verification-harness.js").VerificationHarness;
-	private _terminationListeners: Array<(sessionId: string) => void> = [];
+	private _terminationListeners: Array<(sessionId: string, info: { projectId?: string; reason: "terminated" | "archived" | "purged" }) => void> = [];
 	/** @internal Non-PCM test path only. */
 	private _testGoalManager: GoalManager | null = null;
 	/** @internal Non-PCM test path only. */
@@ -334,7 +361,7 @@ export class SessionManager {
 	}
 
 	/** Subscribe to session termination events. Listeners are invoked synchronously. */
-	addTerminationListener(fn: (sessionId: string) => void): void {
+	addTerminationListener(fn: (sessionId: string, info: { projectId?: string; reason: "terminated" | "archived" | "purged" }) => void): void {
 		this._terminationListeners.push(fn);
 	}
 
@@ -3694,9 +3721,10 @@ export class SessionManager {
 			console.warn(`[session-manager] Eager remote-delete failed for ${id}:`, err);
 		});
 
-		// Notify termination listeners (e.g. user-question harness cleanup).
+	// Notify termination listeners (e.g. user-question harness cleanup, sidebar broadcast).
+		const projectIdForListeners = session.projectId;
 		for (const listener of this._terminationListeners) {
-			try { listener(id); } catch (err) {
+			try { listener(id, { projectId: projectIdForListeners, reason: "archived" }); } catch (err) {
 				console.error(`[session ${id}] termination listener failed:`, err);
 			}
 		}
@@ -3890,6 +3918,14 @@ export class SessionManager {
 
 		// Remove from store
 		this.resolveStoreForId(ps.id)?.purge(ps.id);
+
+		// Notify termination listeners (sidebar broadcast etc.) so cached UI lists
+		// drop the entry without waiting for a polling tick.
+		for (const listener of this._terminationListeners) {
+			try { listener(ps.id, { projectId: ps.projectId, reason: "purged" }); } catch (err) {
+				console.error(`[session ${ps.id}] purge listener failed:`, err);
+			}
+		}
 	}
 
 	/** Remove search index entries for a session. Used when removing a session from the store. */

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -825,8 +825,18 @@ export function createGateway(config: GatewayConfig) {
 	server.requestTimeout = 0;
 	server.headersTimeout = 0;
 
-	// WebSocket server (noServer mode — we handle upgrade manually)
-	const wss = new WebSocketServer({ noServer: true });
+	// WebSocket server (noServer mode — we handle upgrade manually).
+	//
+	// `perMessageDeflate: false` disables per-message compression. The `ws`
+	// library's default enables it, which on loopback (where bandwidth is
+	// not the bottleneck) can stall the server's WS write loop under bursty
+	// JSON event traffic — zlib serialises sends through a single thread,
+	// and during a streaming turn we emit dozens of small frames per second.
+	// Empirically this contributed to a 'Reconnecting to server…' E2E flake
+	// cluster (RP-18, CT-01-d, S-02) where the WS would briefly disconnect
+	// during high-volume mock-agent event bursts. Loopback never benefits
+	// from compression in production either, so this is a strict win.
+	const wss = new WebSocketServer({ noServer: true, perMessageDeflate: false });
 
 	// Broadcast a message to WebSocket clients belonging to a specific goal
 	function broadcastToGoal(goalId: string, event: any): void {
@@ -911,6 +921,18 @@ export function createGateway(config: GatewayConfig) {
 	}
 
 	teamManager.setBroadcastToGoal(broadcastToGoal);
+	// Push a session_removed broadcast to ALL clients on terminate/archive/purge
+	// so sidebars and dashboards update instantly. Replaces a 5s polling tick
+	// for a documented class of races (e.g. clicking a stale sidebar entry just
+	// after another tab archived the session).
+	sessionManager.addTerminationListener((sessionId, info) => {
+		try {
+			broadcastToAll({ type: "session_removed", sessionId, projectId: info.projectId, reason: info.reason });
+		} catch (err) {
+			console.error(`[broadcast] session_removed failed for ${sessionId}:`, err);
+		}
+	});
+
 	sessionManager.setOnPrCreationDetected((session) => {
 		const goalId = session.goalId || session.teamGoalId;
 		if (!goalId) return;

--- a/src/server/ws/protocol.ts
+++ b/src/server/ws/protocol.ts
@@ -55,6 +55,12 @@ export type ServerMessage =
 	| { type: "error"; message: string; code: string }
 	| { type: "session_status"; status: string; streamingStartedAt?: number; archivedAt?: number; /* status includes "aborting" */ }
 	| { type: "session_archived"; sessionId: string; archivedAt: number }
+	/** Sent to ALL authenticated clients (not just the session's own clients)
+	 * when a session is terminated/archived/purged. Lets sidebars and dashboards
+	 * react instantly instead of waiting for the 5s polling tick. The receiving
+	 * client should remove the session from local lists and, if the user is
+	 * currently viewing it, redirect to landing with a friendly toast. */
+	| { type: "session_removed"; sessionId: string; projectId?: string; reason: "terminated" | "archived" | "purged" }
 	| { type: "session_title"; sessionId: string; title: string }
 	| { type: "pong" }
 	| { type: "cost_update"; sessionId: string; goalId?: string; taskId?: string; cost: { inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheWriteTokens: number; totalCost: number } }


### PR DESCRIPTION
Implements the 'top 3 recommendations' triage from the post-PR-389 streak data. **80% clean-run rate (12/15)** in the post-fix browser streak, up from 40% (4/10) before.

## Fix 1 — disable WS perMessageDeflate

`server.ts`: `new WebSocketServer({ noServer: true, perMessageDeflate: false })`.

The `ws` library's per-message-deflate default serialises sends through zlib's single-thread pipeline. On loopback (where bandwidth isn't the bottleneck) this stalls the WS write loop during high-volume mock-agent event bursts, producing the 'Reconnecting to server…' E2E flake cluster (RP-18, CT-01-d, S-02 — 3 of 7 captured failures showed identical client-side state per PR #389's failure-context fixture). Loopback never benefits from compression in production either.

## Fix 2 — WS bufferedAmount guard

`session-manager.ts::broadcast()`: warn at 1 MiB, force-`terminate()` at 4 MiB. Belt-and-braces backstop for fix #1 — if a client's outbound buffer ever pathologically backs up, kill the socket so the client-side reconnect path runs cleanly instead of waiting for a TCP timeout.

## Fix 3 — `session_removed` WS broadcast

New `{type:"session_removed", sessionId, projectId, reason}` server message. Broadcast to ALL authed clients on terminate / archive / purge. Sidebars and dashboards update instantly instead of waiting for the 5s polling tick. Fixes RP-08 ('session not found post-reload') and the documented class of races where a stale link survives in the UI past server-side removal. Real product improvement — sidebars feel instant.

`SessionManager.addTerminationListener` now passes `{projectId, reason}` so listeners can broadcast targeted events. New listener wired in `server.ts` calls `broadcastToAll`. Client receives via `RemoteAgent.onSessionRemoved` callback; `session-manager.ts` (client) handles by removing from local lists and routing to landing if the user was viewing the removed session.

## Fix 4 — `onReconnect` hydration hook

New `RemoteAgent.onReconnect` callback fires after non-initial `auth_ok`. The resume path replays only buffered events and skips the snapshot-driven hydration in case 'messages', so caches like review annotations, git status, and bg-processes go stale across a transient WS drop. Client now re-fires `refreshGitStatusForSession` + `refreshBgProcessesForSession` + `initAnnotationStore` on reconnect. Cheap, idempotent, fires only on non-initial connects.

## Streak data (15 runs after these 4 fixes, retries:0)

| Run | Result | Wall-clock | Failure |
|-----|--------|-----------|---------|
| 1–8 | ✅ all clean | 2.4–2.9m | — |
| 9 | ❌ 1 fail | 2.5m | ST-DEDUP-01 (still 'Reconnecting' — under explicit replay-events test that stresses the WS hardest) |
| 10–11 | ✅ clean | 2.5m | — |
| 12 | ❌ 1 fail | 2.7m | workflow-editor optional checkbox (unrelated to WS) |
| 13 | ✅ clean | 2.7m | — |
| 14 | ❌ 1 fail | 2.8m | RP-16 (annotations second-context) |
| 15 | ✅ clean | 2.5m | — |

**12/15 clean = 80% clean-run rate.** Best consecutive streak: 8 (runs 1–8). Up from 40% (4/10) pre-PR-389-streak. Still doesn't hit the goal's 20-consecutive-clean target — the remaining 3 failures are rarer pre-existing race conditions in tests that exercise heavy WS replay or rapid form interactions, each ~1/15 frequency.

## Validation

- `npm run check`            green
- `npm run test:unit`        969 passed (no regressions)
- 15-run browser streak     12/15 clean

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)