### PR TITLE
fix(client): treat transient oauth/status failures as authenticated

### DIFF
--- a/src/app/dialogs.ts
+++ b/src/app/dialogs.ts
@@ -122,11 +122,45 @@ export function showConnectionError(title: string, message: string): void {
 // OAUTH DIALOG
 // ============================================================================
 
+/**
+ * Returns the OAuth authentication status for `provider`.
+ *
+ * IMPORTANT: a transient HTTP failure (network blip, gateway restart in
+ * flight, server overload) must NOT be reported as "not authenticated" —
+ * doing so causes `authenticateGateway()` to spuriously open the OAuth
+ * dialog over a perfectly valid session, which is a confusing UX bug in
+ * production and a long-tail E2E flake (the dialog steals focus and
+ * subsequent assertions on sidebar/page elements time out).
+ *
+ * Distinguish:
+ *   - HTTP 200 + `authenticated: false`  → genuinely not authenticated
+ *   - any other response (non-2xx, JSON parse failure, network error)
+ *     → status indeterminate; retry once. If still indeterminate, treat as
+ *     authenticated (best-effort) — the actual gateway endpoints will
+ *     reject if the credential really is missing.
+ */
 export async function checkOAuthStatus(provider = "anthropic"): Promise<boolean> {
-	const res = await gatewayFetch(`/api/oauth/status?provider=${encodeURIComponent(provider)}`);
-	if (!res.ok) return false;
-	const data = await res.json();
-	return data.authenticated === true;
+	const attempt = async (): Promise<{ ok: boolean; auth: boolean | null }> => {
+		try {
+			const res = await gatewayFetch(`/api/oauth/status?provider=${encodeURIComponent(provider)}`);
+			if (!res.ok) return { ok: false, auth: null };
+			const data = await res.json();
+			return { ok: true, auth: data.authenticated === true };
+		} catch {
+			return { ok: false, auth: null };
+		}
+	};
+	const first = await attempt();
+	if (first.ok) return first.auth === true;
+	// Indeterminate — retry once after a short delay.
+	await new Promise((r) => setTimeout(r, 250));
+	const second = await attempt();
+	if (second.ok) return second.auth === true;
+	// Still indeterminate after a retry. Assume authenticated rather than
+	// stealing the user's flow with a spurious OAuth dialog. The first real
+	// authenticated request will fail-closed if the credential truly is
+	// missing, and the dialog will surface there.
+	return true;
 }
 
 export function openOAuthDialog(provider = "anthropic"): Promise<boolean> {


### PR DESCRIPTION
## Problem

A transient gateway failure (network blip, gateway restart in flight, server overload, FS contention on Windows) was causing `checkOAuthStatus()` to return `false`, which then opened the OAuth dialog over a perfectly valid authenticated session. This stole focus and timed out downstream sidebar/page assertions in unrelated E2E tests.

## Evidence

Two captured E2E flake artifacts in this session showed the **Anthropic Login dialog** spuriously appearing on tests that never touch OAuth:
- `tests/e2e/ui/sidebar-goal-staff.spec.ts:127`
- `tests/e2e/ui/review-annotations-persistence.spec.ts`

Both showed the OAuth modal in the failed-test page snapshot despite `auth.json` being seeded with valid creds in the harness.

## Fix

Distinguish HTTP-200-with-`authenticated:false` (genuinely logged out) from any non-2xx / parse failure / network error (indeterminate). On indeterminate, retry once after 250 ms; if still indeterminate, return `true` rather than spuriously stealing the user's flow. The first real authenticated request will fail-closed if the credential really is missing, and the OAuth dialog will surface there instead.

## Streak measurement

Before fix (retries=3, 10 runs): 5/10 had retried-flaky tests, including the OAuth-dialog symptom in 2 captured artifacts.

After fix (retries=0, 10 runs): **7/10 fully clean** — failures in run 1 (`stories-streaming` WS reconnect), run 7 (`per-project-native-yaml` UI race), run 8 (`search-result-navigation` already `@quarantine`). The OAuth-dialog symptom no longer appears in any captured artifact.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)