### PR TITLE
test: fix silent unit-test-discovery (0 specs running) and parallelise Playwright

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mariozechner/pi-ai": "^0.67.5",
         "@mariozechner/pi-coding-agent": "^0.67.5",
         "@recogito/text-annotator": "^3.4.9",
+        "@sinclair/typebox": "^0.34.41",
         "acme-client": "^5.4.0",
         "docx-preview": "^0.3.7",
         "flexsearch": "0.8.158",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "restart-server": "node dist/server/harness-signal.js",
     "start": "node dist/server/cli.js --cwd .",
     "check": "tsc -p tsconfig.server.json --noEmit && tsc -p tsconfig.web.json --noEmit",
+    "pretest:unit": "node -e \"require('fs').existsSync('dist/server')||require('child_process').execSync('npm run build:server',{stdio:'inherit'})\"",
     "test:unit": "npx tsx --import ./tests/helpers/css-stub-loader.mjs --test --test-force-exit tests/*.test.ts && npx playwright test --config tests/playwright.config.ts",
     "test:e2e": "npm run build --silent 2>/dev/null && npx playwright test --config playwright-e2e.config.ts 2>/dev/null",
     "test:e2e:smoke": "npm run build --silent 2>/dev/null && npx playwright test --config playwright-e2e-smoke.config.ts",
@@ -35,6 +36,7 @@
   },
   "dependencies": {
     "@lmstudio/sdk": "^1.5.0",
+    "@sinclair/typebox": "^0.34.41",
     "@mariozechner/mini-lit": "^0.2.0",
     "@mariozechner/pi-agent-core": "^0.67.5",
     "@mariozechner/pi-ai": "^0.67.5",

--- a/tests/container-path-translation.test.ts
+++ b/tests/container-path-translation.test.ts
@@ -21,7 +21,7 @@ const TEST_BOBBIT_DIR = process.platform === "win32"
 process.env.PI_CODING_AGENT_DIR = TEST_AGENT_DIR;
 process.env.BOBBIT_DIR = TEST_BOBBIT_DIR;
 
-const { containerPathToHost, hostPathToContainer } = await import("../dist/server/agent/rpc-bridge.js");
+const { containerPathToHost, hostPathToContainer } = await import("../src/server/agent/rpc-bridge.ts");
 
 describe("containerPathToHost (bind-mount fallback)", () => {
 	it("translates agent sessions path", () => {

--- a/tests/docker-args-sanitize.test.ts
+++ b/tests/docker-args-sanitize.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { buildDockerRunArgs, type DockerRunConfig } from "../dist/server/agent/docker-args.js";
+import { buildDockerRunArgs, type DockerRunConfig } from "../src/server/agent/docker-args.ts";
 
 /** Minimal config that exercises all code paths. */
 function baseConfig(overrides: Partial<DockerRunConfig> = {}): DockerRunConfig {

--- a/tests/grant-policy.test.ts
+++ b/tests/grant-policy.test.ts
@@ -6,7 +6,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-const { computeEffectiveAllowedTools, computeToolActivationArgs, resolveGrantPolicy, writeMcpProxyExtensions } = await import("../dist/server/agent/tool-activation.js");
+const { computeEffectiveAllowedTools, computeToolActivationArgs, resolveGrantPolicy, writeMcpProxyExtensions } = await import("../src/server/agent/tool-activation.ts");
 
 // Minimal mock ToolManager — only needs getToolByName()
 function mockToolManager(tools: Record<string, { grantPolicy?: string }>) {

--- a/tests/idle-nudge-timer.spec.ts
+++ b/tests/idle-nudge-timer.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { formatElapsed } from "../dist/server/agent/team-manager.js";
+import { formatElapsed } from "../src/server/agent/team-manager.ts";
 
 test.describe("formatElapsed", () => {
 	test("returns 0m for timestamps just now", () => {

--- a/tests/mcp-policy-prefix.test.ts
+++ b/tests/mcp-policy-prefix.test.ts
@@ -6,7 +6,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-const { mcpPolicyPrefix } = await import("../dist/server/agent/tool-activation.js");
+const { mcpPolicyPrefix } = await import("../src/server/agent/tool-activation.ts");
 
 describe("mcpPolicyPrefix", () => {
 	it("extracts mcp__<server> for canonical mcp__<server>__<tool> names", () => {

--- a/tests/model-utils.test.ts
+++ b/tests/model-utils.test.ts
@@ -7,8 +7,8 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { inferMeta } from "../dist/server/agent/aigw-manager.js";
-import { modelRecencyRank } from "../dist/server/agent/model-registry.js";
+import { inferMeta } from "../src/server/agent/aigw-manager.ts";
+import { modelRecencyRank } from "../src/server/agent/model-registry.ts";
 
 // ── inferMeta tests ────────────────────────────────────────────────
 

--- a/tests/no-dist-imports.test.ts
+++ b/tests/no-dist-imports.test.ts
@@ -1,0 +1,36 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const TESTS_DIR = new URL(".", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1");
+const SELF = "no-dist-imports.test.ts";
+const EXCLUDED_DIRS = new Set(["e2e", "fullstack", "manual-integration"]);
+const PATTERN = /from\s+["']\.\.\/(\.\.\/)?dist\//;
+
+function collect(dir: string, out: string[] = []): string[] {
+	for (const name of readdirSync(dir)) {
+		const full = join(dir, name);
+		const st = statSync(full);
+		if (st.isDirectory()) {
+			if (EXCLUDED_DIRS.has(name)) continue;
+			collect(full, out);
+			continue;
+		}
+		if (!st.isFile()) continue;
+		if (!/\.(test|spec)\.ts$/.test(name)) continue;
+		if (name === SELF) continue;
+		out.push(full);
+	}
+	return out;
+}
+
+test("no test file imports from ../dist/", () => {
+	const files = collect(TESTS_DIR);
+	const offenders: string[] = [];
+	for (const f of files) {
+		const src = readFileSync(f, "utf8");
+		if (PATTERN.test(src)) offenders.push(f);
+	}
+	assert.deepEqual(offenders, [], `Test files importing from ../dist/:\n${offenders.join("\n")}`);
+});

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -5,4 +5,6 @@ export default defineConfig({
 	testMatch: "**/*.spec.ts",
 	testIgnore: ["e2e/**", "fullstack/**", "manual-integration/**"],
 	timeout: 15_000,
+	fullyParallel: true,
+	workers: process.env.CI ? 2 : "50%",
 });

--- a/tests/prompt-queue.spec.ts
+++ b/tests/prompt-queue.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { PromptQueue } from "../dist/server/agent/prompt-queue.js";
+import { PromptQueue } from "../src/server/agent/prompt-queue.ts";
 
 test.describe("PromptQueue", () => {
 	test("enqueue basics: adds messages, toArray returns in order, length/isEmpty correct", () => {

--- a/tests/queue-dispatch.spec.ts
+++ b/tests/queue-dispatch.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
-import { PromptQueue } from "../dist/server/agent/prompt-queue.js";
-import type { QueuedMessage } from "../dist/server/ws/protocol.js";
+import { PromptQueue } from "../src/server/agent/prompt-queue.ts";
+import type { QueuedMessage } from "../src/server/ws/protocol.ts";
 
 const MAX_CONSECUTIVE_ERROR_TURNS = 3;
 const SYSTEM_PREFIX_RE = /^\[SYSTEM: previous turn failed with: .+\. Ignore the incomplete last turn and handle the following\.\]\n\n/;

--- a/tests/strip-token-git-url.test.ts
+++ b/tests/strip-token-git-url.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { stripTokenFromGitUrl } from "../dist/server/skills/git.js";
+import { stripTokenFromGitUrl } from "../src/server/skills/git.ts";
 
 describe("stripTokenFromGitUrl", () => {
 	it("strips token from https URL with username", () => {

--- a/tests/team-manager-reviewer-resume.test.ts
+++ b/tests/team-manager-reviewer-resume.test.ts
@@ -22,7 +22,7 @@ import path from "node:path";
 const TEST_PI_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-reviewer-resume-test-"));
 process.env.BOBBIT_DIR = TEST_PI_DIR;
 
-const { TeamManager } = await import("../dist/server/agent/team-manager.js");
+const { TeamManager } = await import("../src/server/agent/team-manager.ts");
 const TEAM_STORE_FILE = path.join(TEST_PI_DIR, "state", "team-state.json");
 
 function clearTeamStore() {

--- a/tests/team-manager.test.ts
+++ b/tests/team-manager.test.ts
@@ -10,7 +10,7 @@ const TEST_PI_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-team-test-"));
 process.env.BOBBIT_DIR = TEST_PI_DIR;
 
 // Import AFTER setting env var so bobbitDir() picks it up
-const { TeamManager } = await import("../dist/server/agent/team-manager.js");
+const { TeamManager } = await import("../src/server/agent/team-manager.ts");
 
 const TEAM_STORE_FILE = path.join(TEST_PI_DIR, "state", "team-state.json");
 function clearTeamStore() { try { fs.unlinkSync(TEAM_STORE_FILE); } catch { /* ignore */ } }

--- a/tests/tool-activation.spec.ts
+++ b/tests/tool-activation.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
-import { computeToolActivationArgs } from "../dist/server/agent/tool-activation.js";
-import type { ToolProvider } from "../dist/server/agent/tool-manager.js";
+import { computeToolActivationArgs } from "../src/server/agent/tool-activation.ts";
+import type { ToolProvider } from "../src/server/agent/tool-manager.ts";
 
 /**
  * Unit tests for computeToolActivationArgs — the logic that maps role tool

--- a/tests/tool-group-policy-store.test.ts
+++ b/tests/tool-group-policy-store.test.ts
@@ -13,7 +13,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-const { ToolGroupPolicyStore } = await import("../dist/server/agent/tool-group-policy-store.js");
+const { ToolGroupPolicyStore } = await import("../src/server/agent/tool-group-policy-store.ts");
 
 let tmpDir: string;
 

--- a/tests/tool-policy-resolution.test.ts
+++ b/tests/tool-policy-resolution.test.ts
@@ -12,8 +12,8 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
-const { resolveGrantPolicy } = await import("../dist/server/agent/tool-activation.js");
-const { ToolGroupPolicyStore } = await import("../dist/server/agent/tool-group-policy-store.js");
+const { resolveGrantPolicy } = await import("../src/server/agent/tool-activation.ts");
+const { ToolGroupPolicyStore } = await import("../src/server/agent/tool-group-policy-store.ts");
 
 // ── Helpers ──────────────────────────────────────────────────────────
 

--- a/tests/verification-logic.test.ts
+++ b/tests/verification-logic.test.ts
@@ -22,7 +22,7 @@ import {
 	TRANSIENT_ERROR_REGEXES,
 	QA_NON_TRANSIENT_PATTERNS,
 	detectJsonValidationError,
-} from "../dist/server/agent/verification-logic.js";
+} from "../src/server/agent/verification-logic.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers — minimal objects satisfying the VerifyStep / GateSignal shapes

--- a/tests/verification-result-tool.test.ts
+++ b/tests/verification-result-tool.test.ts
@@ -8,7 +8,7 @@ import assert from "node:assert";
 
 describe("VERIFICATION_RESULT_REMINDER", () => {
   it("includes verification_result tool reference", async () => {
-    const { VERIFICATION_RESULT_REMINDER } = await import("../dist/server/agent/verification-harness.js");
+    const { VERIFICATION_RESULT_REMINDER } = await import("../src/server/agent/verification-harness.ts");
     assert.ok(typeof VERIFICATION_RESULT_REMINDER === "string");
     assert.ok(VERIFICATION_RESULT_REMINDER.includes("verification_result"));
   });
@@ -16,17 +16,17 @@ describe("VERIFICATION_RESULT_REMINDER", () => {
 
 describe("isTransientReviewError after cleanup", () => {
   it("does not treat verification_result failure as transient", async () => {
-    const { isTransientReviewError } = await import("../dist/server/agent/verification-harness.js");
+    const { isTransientReviewError } = await import("../src/server/agent/verification-harness.ts");
     assert.ok(!isTransientReviewError("Agent did not call verification_result after reminder."));
   });
 
   it("still treats timeout as transient", async () => {
-    const { isTransientReviewError } = await import("../dist/server/agent/verification-harness.js");
+    const { isTransientReviewError } = await import("../src/server/agent/verification-harness.ts");
     assert.ok(isTransientReviewError("Agent timed out waiting for response"));
   });
 
   it("still treats connection reset as transient", async () => {
-    const { isTransientReviewError } = await import("../dist/server/agent/verification-harness.js");
+    const { isTransientReviewError } = await import("../src/server/agent/verification-harness.ts");
     assert.ok(isTransientReviewError("ECONNRESET"));
   });
 });

--- a/tests/verification-sandbox-exec.test.ts
+++ b/tests/verification-sandbox-exec.test.ts
@@ -21,7 +21,7 @@ const TEST_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "verif-sandbox-test-"));
 fs.mkdirSync(path.join(TEST_DIR, "state"), { recursive: true });
 process.env.BOBBIT_DIR = TEST_DIR;
 
-const { VerificationHarness } = await import("../dist/server/agent/verification-harness.js");
+const { VerificationHarness } = await import("../src/server/agent/verification-harness.ts");
 
 // ---------------------------------------------------------------------------
 // Mock helpers


### PR DESCRIPTION
## Summary

Fixes a silent test-discovery bug: `npm run test:unit` was reporting "Total: 0 tests in 0 files" for the Playwright unit phase on any clean checkout (no prior `npm run build`). 17 test files imported from `../dist/server/*.js`, so they failed to load when `dist/` was stale or absent.

## Changes

- **17 import rewrites** — `tests/*.{test,spec}.ts` now import from `../src/server/*.ts` directly. No assertion or behavior changes.
- **`@sinclair/typebox` ^0.34.41** added as an explicit dep (was implicit transitive; needed by `src/server/agent/tool-activation.ts`).
- **`tests/playwright.config.ts`** — `fullyParallel: true`, `workers: process.env.CI ? 2 : "50%"`.
- **`pretest:unit`** build guard added to `package.json` scripts (defense-in-depth; no-op once Step 1 lands).
- **`tests/no-dist-imports.test.ts`** — regression guard that fails CI if any test file re-introduces a `../dist/` import.

## Results

### BEFORE (clean checkout, master)
- Playwright unit phase: `Total: 0 tests in 0 files` — **195+ specs silently skipped**.
- Node phase: 17 test files fail to load (missing `dist/`).

### AFTER (this PR, clean `npm ci` only)
```
Node:       tests 1204, pass 1204, fail 0, duration_ms 46827
Playwright: 1008 passed (2.2m)
real        ~3m17s
```

`npm run check` passes. `grep -RE "from ['\"]\.\.\/(\.\.\/)?dist\/" tests/` returns empty.

## Wall-time target not hit

The goal targeted `<60s` wall. After all 6 mechanical steps the run is `~3m17s`. Per the goal's own escape hatch, I stopped rather than speculatively split tests. The dominant contributors:

| Suite | Time |
|---|---|
| `TeamManager` | 37.4s |
| `runBatchGitStatusNative — fixtures` | 16.4s |
| `createWorktree idempotency` | 8.0s |
| `WorktreePool — multi-repo prebuild + claim` | 6.9s |
| `WorktreePool — Phase 3 claim sequence` | 5.9s |
| `WorktreePool — components[*].worktreeSetupCommand…` | 4.0s |
| `getDockerResourceLimits` | 3.4s |
| `browser_screenshot does not duplicate base64…` | 2.9s |
| `runCommandStep spawn behavior` | 2.1s |
| `verification reminder race — Bug 2` | 1.3s |

Hitting `<60s` requires either splitting the heavy Node suites or moving the 1008 Playwright specs to a single-process runner (jsdom/happy-dom). Out of scope for this PR — the *correctness* failure (0 specs running) is fixed and that's the real win.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
