### PR TITLE
Preserve prompt delivery and transcript order

### DIFF
--- a/src/app/message-reducer.ts
+++ b/src/app/message-reducer.ts
@@ -185,8 +185,25 @@ export function reduce(state: ReducerState, action: Action): ReducerState {
 			});
 
 			const serverIds = new Set<string>();
+			const optimisticTextCredits = new Map<string, number>();
 			for (const m of snapshotRows) {
 				if (typeof m.id === "string" && m.id.length > 0) serverIds.add(m.id);
+				if (m.role === "user" || m.role === "user-with-attachments") {
+					const text = extractText(m);
+					optimisticTextCredits.set(text, (optimisticTextCredits.get(text) ?? 0) + 1);
+				}
+			}
+			// Text fallback is multiplicity-aware. If the snapshot merely re-states
+			// user messages already present as server rows in local state, those rows
+			// consume the text credits first so a new optimistic repeat of the same
+			// text is not accidentally hidden.
+			for (const m of state.messages) {
+				if (m._origin !== "server") continue;
+				if (m.role !== "user" && m.role !== "user-with-attachments") continue;
+				if (typeof m.id !== "string" || !serverIds.has(m.id)) continue;
+				const text = extractText(m);
+				const count = optimisticTextCredits.get(text) ?? 0;
+				if (count > 0) optimisticTextCredits.set(text, count - 1);
 			}
 			const serverHasCompactionMarker = snapshotRows.some((m) => {
 				if (m.role !== "assistant") return false;
@@ -208,9 +225,20 @@ export function reduce(state: ReducerState, action: Action): ReducerState {
 					continue;
 				}
 				if (m._origin === "optimistic") {
-					// Optimistic prompts/steers always survive — server echo will
-					// reconcile via id/text on a later live-event.
+					// Optimistic prompts/steers survive only until the server snapshot
+					// represents them. Snapshots often arrive after reconnect/tab wake
+					// without a matching live echo, so reconcile by id and by user text
+					// here too; otherwise the optimistic row stays at the tail and the
+					// transcript appears out of order.
 					if (typeof m.id === "string" && serverIds.has(m.id)) continue;
+					if (m.role === "user" || m.role === "user-with-attachments") {
+						const text = extractText(m);
+						const count = optimisticTextCredits.get(text) ?? 0;
+						if (count > 0) {
+							optimisticTextCredits.set(text, count - 1);
+							continue;
+						}
+					}
 					survivors.push(m);
 					continue;
 				}

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -102,6 +102,10 @@ export class RemoteAgent {
 	 *  event frames — it sends a state snapshot instead). */
 	private _seqInitialized = false;
 	private _pendingEvents: Array<{ seq: number; ts?: number; data: any }> = [];
+	/** Outbound user-intent frames waiting for an authenticated WebSocket.
+	 *  Prompts/steers must be at-least-once delivered; silently dropping them
+	 *  while reconnecting is worse than a duplicate. */
+	private _outbox: any[] = [];
 	/** Defensive cap — if we ever buffer more than this while waiting for a
 	 *  gap to fill, fall back to a snapshot refresh instead of growing forever. */
 	private readonly _pendingEventsMax = 500;
@@ -406,6 +410,7 @@ export class RemoteAgent {
 								}
 							}, 3000);
 						}
+						this._flushOutbox();
 					} else if (msg.type === "auth_failed") {
 						settled = true;
 						if (initial) {
@@ -581,6 +586,15 @@ export class RemoteAgent {
 			...(imageData?.length ? { images: imageData } : {}),
 			...(attachments?.length ? { attachments } : {}),
 		});
+
+		// Mirror the server's immediate transition for the first prompt. This
+		// prevents rapid follow-up sends from rendering as extra optimistic rows;
+		// the server queues them and the queue UI shows them in delivery order.
+		if (!this._state.isStreaming) {
+			this._state.isStreaming = true;
+			this._state.turnStartTime = this._state.turnStartTime ?? Date.now();
+			this.emit({ type: "state_update", data: { isStreaming: true } });
+		}
 	}
 
 	steer(message: any): void {
@@ -817,8 +831,31 @@ export class RemoteAgent {
 	private send(msg: any): void {
 		if (this.ws?.readyState === WebSocket.OPEN) {
 			this.ws.send(JSON.stringify(msg));
-		} else {
-			console.warn("[RemoteAgent] Message dropped (WS not open):", msg.type, "readyState:", this.ws?.readyState);
+			return;
+		}
+
+		if (this._isReliableOutbound(msg)) {
+			this._outbox.push(msg);
+			console.warn("[RemoteAgent] Queued outbound message until reconnect:", msg.type, "readyState:", this.ws?.readyState);
+			if (!this._intentionalDisconnect && !this._reconnectTimer && (!this.ws || this.ws.readyState >= WebSocket.CLOSING)) {
+				this._setConnectionStatus("reconnecting");
+				this._connectWs(false).catch(() => { /* onclose schedules retry */ });
+			}
+			return;
+		}
+
+		console.warn("[RemoteAgent] Message dropped (WS not open):", msg.type, "readyState:", this.ws?.readyState);
+	}
+
+	private _isReliableOutbound(msg: any): boolean {
+		return msg?.type === "prompt" || msg?.type === "steer";
+	}
+
+	private _flushOutbox(): void {
+		if (!this.ws || this.ws.readyState !== WebSocket.OPEN || this._outbox.length === 0) return;
+		const pending = this._outbox.splice(0);
+		for (const msg of pending) {
+			this.ws.send(JSON.stringify(msg));
 		}
 	}
 

--- a/src/server/agent/prompt-queue.ts
+++ b/src/server/agent/prompt-queue.ts
@@ -57,6 +57,13 @@ export class PromptQueue {
 		return true;
 	}
 
+	/** Put messages back at the front, preserving their order. */
+	prepend(messages: QueuedMessage | QueuedMessage[]): void {
+		const items = Array.isArray(messages) ? messages : [messages];
+		if (items.length === 0) return;
+		this.queue = [...items, ...this.queue];
+	}
+
 	/** Pop the next message from the front of the queue. Returns undefined if empty. */
 	dequeue(): QueuedMessage | undefined {
 		return this.queue.shift();

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -1318,12 +1318,35 @@ export class SessionManager {
 			return;
 		}
 
-		// If agent is idle and queue is empty, dispatch directly
+		// If agent is idle and queue is empty, dispatch directly. Flip status
+		// before touching the RPC pipeline so a rapid second prompt cannot also
+		// observe idle+empty and leapfrog into a concurrent dispatch.
 		if (session.status === "idle" && session.promptQueue.isEmpty) {
 			this.tryGenerateTitleFromPrompt(sessionId, text);
 			session.lastPromptText = dispatchText;
 			session.lastPromptImages = opts?.images;
-			await session.rpcClient.prompt(dispatchText, opts?.images);
+			session.status = "streaming";
+			session.streamingStartedAt = Date.now();
+			this.resolveStoreForSession(session.id).update(session.id, { wasStreaming: true, streamingStartedAt: session.streamingStartedAt });
+			broadcast(session.clients, { type: "session_status", status: "streaming", streamingStartedAt: session.streamingStartedAt });
+			try {
+				await session.rpcClient.prompt(dispatchText, opts?.images);
+			} catch (err) {
+				console.error(`[session-manager] Failed to dispatch prompt for ${session.id}; re-queueing:`, err);
+				session.promptQueue.prepend({
+					id: randomUUID(),
+					text: dispatchText,
+					...(opts?.images?.length ? { images: opts.images } : {}),
+					...(opts?.attachments?.length ? { attachments: opts.attachments } : {}),
+					isSteered: opts?.isSteered ?? false,
+					createdAt: Date.now(),
+				});
+				session.status = "idle";
+				session.streamingStartedAt = undefined;
+				this.resolveStoreForSession(session.id).update(session.id, { wasStreaming: false, streamingStartedAt: undefined });
+				broadcast(session.clients, { type: "session_status", status: "idle" });
+				this.broadcastQueue(session);
+			}
 			return;
 		}
 
@@ -1480,13 +1503,16 @@ export class SessionManager {
 		// Batch all steered messages at the front into a single prompt
 		const steered = session.promptQueue.dequeueAllSteered();
 		let next: QueuedMessage | undefined;
+		let dequeued: QueuedMessage[] = [];
 
 		if (steered.length > 0) {
 			const batchText = steered.map(m => m.text).join('\n');
 			next = { ...steered[0], text: batchText };
+			dequeued = steered;
 		} else {
 			// Skip already-dispatched messages (steered mid-turn), then pop the next
 			next = session.promptQueue.dequeueUndispatched();
+			if (next) dequeued = [next];
 		}
 
 		this.broadcastQueue(session);
@@ -1507,10 +1533,16 @@ export class SessionManager {
 
 		const dispatchPromise = session.rpcClient.prompt(next.text, next.images);
 		dispatchPromise.catch((err: any) => {
-			console.error(`[session-manager] Failed to dispatch queued prompt for ${session.id}:`, err);
+			console.error(`[session-manager] Failed to dispatch queued prompt for ${session.id}; re-queueing:`, err);
+			// Put the exact dequeued rows back so no user text is lost. For a
+			// steered batch this preserves the original individual queue items.
+			session.promptQueue.prepend(dequeued);
 			// Revert optimistic status on failure
 			session.status = "idle";
+			session.streamingStartedAt = undefined;
+			this.resolveStoreForSession(session.id).update(session.id, { wasStreaming: false, streamingStartedAt: undefined });
 			broadcast(session.clients, { type: "session_status", status: "idle" });
+			this.broadcastQueue(session);
 		});
 	}
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5234,8 +5234,10 @@ async function handleApiRoute(
 					message = ctx + "\n\n---\n\n" + message;
 				}
 			}
+			const willParkOnErrorCap = !!session.lastTurnErrored && (session.consecutiveErrorTurns ?? 0) >= 3;
+			const dispatchesImmediately = session.status === "idle" && !willParkOnErrorCap;
 			await sessionManager.enqueuePrompt(body.sessionId, message);
-			json({ ok: true, status: session.status === "idle" ? "dispatched" : "queued" });
+			json({ ok: true, status: dispatchesImmediately ? "dispatched" : "queued" });
 		} catch (err) {
 			json({ error: String(err) }, 500);
 		}

--- a/tests/message-reducer.test.ts
+++ b/tests/message-reducer.test.ts
@@ -140,6 +140,36 @@ describe("message-reducer", () => {
 		assert.strictEqual(s.messages[0]._order, 1);
 	});
 
+	it("(7b) optimistic → snapshot echo (text fallback)", () => {
+		const s = applyAll([
+			{ type: "optimistic-prompt", message: userMsg("optimistic_1", "hi") },
+			{
+				type: "snapshot",
+				messages: [
+					userMsg("srv1", "hi"),
+					assistantMsg("a1", "hello"),
+				],
+			},
+		]);
+		assert.deepStrictEqual(ids(s), [
+			{ id: "srv1", _order: SNAPSHOT_ORDER_FLOOR, role: "user" },
+			{ id: "a1", _order: SNAPSHOT_ORDER_FLOOR + 1, role: "assistant" },
+		]);
+	});
+
+	it("(7c) snapshot text fallback preserves a new repeated prompt", () => {
+		const existing = userMsg("srv-old", "again");
+		const s = applyAll([
+			liveMessageEnd(1, existing),
+			{ type: "optimistic-prompt", message: userMsg("optimistic_new", "again") },
+			{ type: "snapshot", messages: [existing] },
+		]);
+		assert.deepStrictEqual(ids(s), [
+			{ id: "srv-old", _order: SNAPSHOT_ORDER_FLOOR, role: "user" },
+			{ id: "optimistic_new", _order: Number.MAX_SAFE_INTEGER - 1_000_000_000 + 2, role: "user" },
+		]);
+	});
+
 	it("(8) proposal burst — two assistant turns + toolResult, all in order", () => {
 		const a1 = assistantMsg("a1", "", {
 			content: [

--- a/tests/prompt-queue.spec.ts
+++ b/tests/prompt-queue.spec.ts
@@ -40,6 +40,17 @@ test.describe("PromptQueue", () => {
 		expect(q.dequeue()).toBeUndefined();
 	});
 
+	test("prepend puts failed dispatches back at the front without reordering them", () => {
+		const q = new PromptQueue();
+		q.enqueue("C");
+		const a = { id: "a", text: "A", isSteered: false, createdAt: 1 };
+		const b = { id: "b", text: "B", isSteered: false, createdAt: 2 };
+
+		q.prepend([a, b]);
+
+		expect(q.toArray().map(m => m.text)).toEqual(["A", "B", "C"]);
+	});
+
 	test("steer reordering: steered messages sort before non-steered, stable within groups", () => {
 		const q = new PromptQueue();
 		const a = q.enqueue("A");


### PR DESCRIPTION
## Summary
- make prompt/steer sends reliable across WebSocket reconnects with a small client outbox
- close the idle direct-dispatch race by flipping sessions to streaming before RPC dispatch
- reconcile optimistic user messages during history snapshots and requeue failed dispatches instead of losing text

## Tests
- npm run check
- npx tsx --import ./tests/helpers/css-stub-loader.mjs --test --test-force-exit tests/message-reducer.test.ts
- npx playwright test --config tests/playwright.config.ts tests/prompt-queue.spec.ts tests/queue-dispatch.spec.ts
- npm run build:server && npx playwright test --config playwright-e2e.config.ts tests/e2e/team-abort.spec.ts
- npm run test:e2e (passed; 820 passed, 2 flaky, 9 skipped)

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)