### PR TITLE
fix(sessions): persist agentSessionFile before idle, flush recovery state synchronously

### DIFF
--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -768,6 +768,7 @@ export class SessionManager {
 			tryAutoSelectModel: (session) => this.tryAutoSelectModel(session),
 			tryApplyDefaultThinkingLevel: (session) => this.tryApplyDefaultThinkingLevel(session),
 			buildWorkflowList: (projectId?: string) => this._buildWorkflowList(projectId),
+			persistSessionMetadata: (session) => this.persistSessionMetadata(session),
 		};
 	}
 
@@ -2665,7 +2666,10 @@ export class SessionManager {
 			// Fire-and-forget: finish pipeline. If we got a pool worktree above,
 			// pass its path so executeWorktreeAsync skips createWorktree.
 			executeWorktreeAsync(plan, session, ctx, unnamed?.worktreePath).then(() => {
-				// Persist session metadata now that the agent is running (tracked for terminate)
+				// agentSessionFile is now persisted synchronously by spawnAgent before
+				// status flips to idle (see session-setup.ts). The post-resolve persist
+				// here is redundant but kept as a safety net for re-attempts where the
+				// agent may rotate its session file mid-run.
 				session.pendingMetadataPersist = this.persistSessionMetadata(session).catch((err) => {
 					console.warn(`[session-manager] Early persist failed for worktree session ${session.id}:`, err);
 				}).finally(() => { session.pendingMetadataPersist = undefined; });

--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -148,6 +148,12 @@ export interface PipelineContext {
 	tryAutoSelectModel: (session: SessionInfo) => Promise<void>;
 	tryApplyDefaultThinkingLevel: (session: SessionInfo) => Promise<void>;
 	buildWorkflowList: (projectId?: string) => string;
+	/**
+	 * Persist agentSessionFile + other live-state-derived fields. Optional —
+	 * tests may construct a context without this; in that case a hard restart
+	 * during the gap will lose the session, which is fine for unit tests.
+	 */
+	persistSessionMetadata?: (session: SessionInfo) => Promise<void>;
 }
 
 // ── Retry helper ───────────────────────────────────────────────────────────
@@ -665,6 +671,17 @@ export async function executeWorktreeAsync(
 		() => rpcClient.start(),
 		{ retries: 2, delays: [500, 1000], label: "rpcClient.start", sessionId: plan.id },
 	);
+
+	// Persist agentSessionFile to disk BEFORE flipping status to idle. Otherwise
+	// a kill (crash, taskkill, OS shutdown) in the gap between idle and the
+	// post-spawn fire-and-forget persist archives the session on next boot,
+	// because restoreOneSession() refuses to restore a session whose persisted
+	// agentSessionFile is empty. See tests/manual-integration/restart-minimal.spec.ts.
+	if (ctx.persistSessionMetadata) {
+		try { await ctx.persistSessionMetadata(session); }
+		catch (err) { console.warn(`[session-setup] persistSessionMetadata pre-idle failed for ${session.id}:`, err); }
+	}
+
 	session.status = "idle";
 
 	// Notify connected clients that the session is ready
@@ -744,9 +761,19 @@ async function spawnAgent(plan: SessionSetupPlan, ctx: PipelineContext): Promise
 		{ retries: 2, delays: [500, 1000], label: "rpcClient.start", sessionId: plan.id },
 	);
 	recordElapsed("spawnAgent.rpcStart", performance.now() - __t);
-	session.status = "idle";
 
+	// Add to live-sessions map so persistSessionMetadata can resolve via getState.
 	ctx.sessions.set(session.id, session);
+
+	// Persist agentSessionFile BEFORE flipping status to idle so the session
+	// survives a hard kill in the post-spawn window. See worktree path for
+	// the full rationale.
+	if (ctx.persistSessionMetadata) {
+		try { await ctx.persistSessionMetadata(session); }
+		catch (err) { console.warn(`[session-setup] persistSessionMetadata pre-idle failed for ${session.id}:`, err); }
+	}
+
+	session.status = "idle";
 
 	return session;
 }

--- a/src/server/agent/session-store.ts
+++ b/src/server/agent/session-store.ts
@@ -234,13 +234,44 @@ export class SessionStore {
 		return Array.from(this.sessions.values());
 	}
 
+	/**
+	 * Fields whose persistence is required for the session to survive a hard
+	 * restart (kill -9, OS crash, container OOM). When any of these change we
+	 * flush synchronously instead of going through the 1s save debounce —
+	 * otherwise the gateway can advertise the session as `idle` to the API
+	 * before the recovery-critical disk write has landed, and a kill in that
+	 * window archives the session on next boot.
+	 *
+	 * Lower-frequency by nature, so synchronous writes are not a perf concern.
+	 * `lastActivity` / `lastReadAt` are intentionally excluded — they fire on
+	 * every event and benefit from coalescing.
+	 */
+	private static RECOVERY_CRITICAL_FIELDS: ReadonlyArray<keyof UpdatableSessionFields> = [
+		"agentSessionFile", "branch", "worktreePath", "cwd", "repoPath",
+		"repoWorktrees", "poolId", "archived", "archivedAt",
+		"sandboxed", "projectId", "goalId", "delegateOf",
+		"role", "assistantType", "taskId", "staffId",
+		"teamGoalId", "teamLeadSessionId", "worktreeDegraded",
+		"modelProvider", "modelId",
+	];
+
 	/** Update a subset of fields for an existing session */
 	update(id: string, updates: Partial<UpdatableSessionFields>): void {
 		const existing = this.sessions.get(id);
 		if (!existing) return;
 		this.generation++;
 		Object.assign(existing, updates);
-		this.save(); // debounced — frequent field updates
+
+		// Recovery-critical fields must survive a hard kill — flush synchronously.
+		const critical = SessionStore.RECOVERY_CRITICAL_FIELDS.some(f => f in updates);
+		if (critical) {
+			// If a debounced save is pending, cancel it — saveNow supersedes it.
+			if (this.saveTimer) { clearTimeout(this.saveTimer); this.saveTimer = null; }
+			this.saveNow();
+		} else {
+			this.save(); // debounced — high-frequency, non-critical (lastActivity, lastReadAt, drafts, queue)
+		}
+
 		// Only notify on meaningful field changes (skip high-frequency activity updates)
 		if (updates.title !== undefined || updates.archived !== undefined || updates.role !== undefined || updates.goalId !== undefined) {
 			this.onIndexUpdate?.(existing);

--- a/tests/manual-integration/restart-minimal.spec.ts
+++ b/tests/manual-integration/restart-minimal.spec.ts
@@ -1,0 +1,277 @@
+/**
+ * Minimal restart-resilience test — fastest reproducer of "agents lost on restart".
+ *
+ * Creates one plain session and one worktree session, sends a prompt to each,
+ * hard-kills the gateway, restarts on a new port, and verifies both sessions
+ * survive (status reachable via API + browser can navigate to them).
+ *
+ * Use BOBBIT_TEST_GW_LOG=/path/to/log to capture full server logs across both
+ * gateway lifetimes — the file is appended to by both processes.
+ *
+ *   npm run build && npx playwright test --config playwright-manual.config.ts \
+ *     --grep "restart-minimal"
+ */
+import { test, expect } from "@playwright/test";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import { createServer } from "node:net";
+import {
+	mkdirSync, rmSync, readFileSync, writeFileSync, existsSync, readdirSync, openSync, writeSync,
+	cpSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
+const SERVER_CLI = join(PROJECT_ROOT, "dist", "server", "cli.js");
+
+interface GW { proc: ChildProcess; port: number; dir: string; token: string; base: string; defaultProjectId?: string; }
+
+async function freePort(): Promise<number> {
+	return new Promise((res, rej) => {
+		const s = createServer();
+		s.listen(0, "127.0.0.1", () => { const p = (s.address() as any).port; s.close(() => res(p)); });
+		s.on("error", rej);
+	});
+}
+
+async function startGW(dir: string, port: number, label: string): Promise<GW> {
+	mkdirSync(join(dir, ".bobbit", "state"), { recursive: true });
+	const proc = spawn(process.execPath, [
+		SERVER_CLI, "--host", "127.0.0.1", "--port", String(port),
+		"--no-tls", "--auth", "--cwd", dir,
+	], {
+		env: { ...process.env, BOBBIT_DIR: join(dir, ".bobbit"), NODE_ENV: "test" },
+		stdio: ["pipe", "pipe", "pipe"],
+	});
+	let stderr = "";
+	const logTap = process.env.BOBBIT_TEST_GW_LOG;
+	let logFh: number | null = null;
+	if (logTap) {
+		try { logFh = openSync(logTap, "a"); writeSync(logFh, `\n=== ${label} :${port} ===\n`); } catch {}
+	}
+	proc.stderr!.on("data", (c: Buffer) => { stderr += c; if (logFh !== null) { try { writeSync(logFh, c); } catch {} } });
+	proc.stdout!.on("data", (c: Buffer) => { if (logFh !== null) { try { writeSync(logFh, c); } catch {} } });
+	const deadline = Date.now() + 60_000;
+	while (Date.now() < deadline) {
+		if (proc.exitCode !== null) throw new Error(`Gateway exited (${proc.exitCode}):\n${stderr}`);
+		try {
+			const tp = join(dir, ".bobbit", "state", "token");
+			if (existsSync(tp)) {
+				const t = readFileSync(tp, "utf-8").trim();
+				if ((await fetch(`http://127.0.0.1:${port}/api/health`, { headers: { Authorization: `Bearer ${t}` } })).ok) break;
+			}
+		} catch {}
+		await new Promise(r => setTimeout(r, 200));
+	}
+	if (Date.now() >= deadline) { proc.kill(); throw new Error(`Not healthy:\n${stderr}`); }
+	const token = readFileSync(join(dir, ".bobbit", "state", "token"), "utf-8").trim();
+	return { proc, port, dir, token, base: `http://127.0.0.1:${port}` };
+}
+
+async function stopGW(gw: GW): Promise<void> {
+	if (gw.proc.exitCode === null) {
+		if (process.platform === "win32") {
+			try { execFileSync("taskkill", ["/PID", String(gw.proc.pid), "/T", "/F"], { stdio: "ignore", timeout: 10_000 }); } catch {}
+		} else { gw.proc.kill(); }
+	}
+	await new Promise<void>(r => {
+		if (gw.proc.exitCode !== null) return r();
+		gw.proc.on("exit", () => r());
+		setTimeout(() => { try { gw.proc.kill("SIGKILL"); } catch {} r(); }, 5_000);
+	});
+	await new Promise(r => setTimeout(r, 1_000));
+}
+
+function api(gw: GW, path: string, opts: RequestInit = {}) {
+	if ((opts.method || "GET").toUpperCase() === "POST" &&
+		(path === "/api/sessions" || path === "/api/goals") && gw.defaultProjectId) {
+		try {
+			const body = typeof opts.body === "string" && opts.body ? JSON.parse(opts.body) : {};
+			if (body && typeof body === "object" && !body.projectId) {
+				body.projectId = gw.defaultProjectId;
+				opts = { ...opts, body: JSON.stringify(body) };
+			}
+		} catch { /* leave alone */ }
+	}
+	return fetch(`${gw.base}${path}`, {
+		...opts,
+		headers: { "Content-Type": "application/json", Authorization: `Bearer ${gw.token}`, ...(opts.headers as Record<string, string> || {}) },
+	});
+}
+
+async function pollIdle(gw: GW, id: string, ms = 60_000) {
+	const t0 = Date.now();
+	while (Date.now() - t0 < ms) {
+		const res = await api(gw, `/api/sessions/${id}`);
+		if (res.status === 404) { await new Promise(r => setTimeout(r, 500)); continue; }
+		const s = await res.json();
+		if (s.status === "idle") return s;
+		if (s.status === "archived") throw new Error(`Session ${id} archived`);
+		if (s.status === "error" || s.status === "terminated") {
+			throw new Error(`Session ${id} ${s.status}${s.restoreError ? `\n  restoreError: ${s.restoreError}` : ""}`);
+		}
+		await new Promise(r => setTimeout(r, 500));
+	}
+	throw new Error(`Session ${id} not idle in ${ms}ms`);
+}
+
+function initRepo(dir: string) {
+	mkdirSync(dir, { recursive: true });
+	execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["symbolic-ref", "HEAD", "refs/heads/master"], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["config", "user.email", "t@t"], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["config", "user.name", "T"], { cwd: dir, stdio: "ignore" });
+	writeFileSync(join(dir, "README.md"), "# Test\n");
+	writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "p", version: "1.0.0" }, null, 2));
+	execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "ignore" });
+	const srcConfig = join(PROJECT_ROOT, ".bobbit", "config");
+	const dstConfig = join(dir, ".bobbit", "config");
+	if (existsSync(srcConfig)) {
+		cpSync(srcConfig, dstConfig, { recursive: true, filter: (src) => !src.endsWith("project.yaml") });
+	}
+}
+
+function cleanDirs(dir: string) {
+	const parent = resolve(dir, "..");
+	const base = dir.split(/[\\/]/).pop()!;
+	const dirs = [dir];
+	try { for (const e of readdirSync(parent)) if (e.startsWith(base)) dirs.push(join(parent, e)); } catch {}
+	for (const d of dirs) {
+		for (let i = 0; i < 3; i++) { try { rmSync(d, { recursive: true, force: true }); break; } catch {} }
+	}
+}
+
+test.describe.configure({ mode: "serial" });
+
+test("restart-minimal: plain + worktree session both survive a restart", async () => {
+	test.setTimeout(180_000);
+
+	const tmp = process.platform === "win32" ? (process.env.TEMP || "C:\\Temp") : "/tmp";
+	const port1 = await freePort();
+	const dir = join(tmp, `.bobbit-restart-min-${port1}`);
+	cleanDirs(dir);
+	initRepo(dir);
+	mkdirSync(join(dir, ".bobbit", "state"), { recursive: true });
+	writeFileSync(join(dir, ".bobbit", "state", "projects.json"), "[]");
+
+	let gw = await startGW(dir, port1, "BOOT");
+	console.log(`  [boot] gateway :${port1} cwd=${dir}`);
+
+	// Register the project
+	const regRes = await api(gw, "/api/projects", {
+		method: "POST",
+		body: JSON.stringify({ name: "Restart Min", rootPath: dir }),
+	});
+	expect(regRes.status).toBe(201);
+	const reg = await regRes.json() as any;
+	gw.defaultProjectId = reg.id;
+	console.log(`  [boot] project ${reg.id}`);
+
+	// Create plain session (no git repo — by passing a non-git cwd)
+	// Actually: a session in a git repo auto-gets a worktree. To get "plain",
+	// we use a sibling non-git tmp dir.
+	const plainCwd = join(tmp, `.bobbit-restart-min-plain-${port1}`);
+	mkdirSync(plainCwd, { recursive: true });
+	const plainRes = await api(gw, "/api/sessions", {
+		method: "POST",
+		body: JSON.stringify({ projectId: reg.id, cwd: plainCwd }),
+	});
+	expect(plainRes.status).toBe(201);
+	const plainId = (await plainRes.json() as any).id;
+	console.log(`  [boot] plain session ${plainId} cwd=${plainCwd}`);
+
+	// Create worktree session (cwd inside the registered git project root)
+	const wtRes = await api(gw, "/api/sessions", {
+		method: "POST",
+		body: JSON.stringify({ projectId: reg.id }),
+	});
+	expect(wtRes.status).toBe(201);
+	const wtId = (await wtRes.json() as any).id;
+	console.log(`  [boot] worktree session ${wtId}`);
+
+	// Wait both idle
+	const plainPre = await pollIdle(gw, plainId);
+	const wtPre = await pollIdle(gw, wtId);
+	console.log(`  [boot] plain idle. cwd=${plainPre.cwd} branch=${plainPre.branch ?? "(none)"}`);
+	console.log(`  [boot] wt idle.    cwd=${wtPre.cwd}    branch=${wtPre.branch ?? "(none)"}`);
+
+	// Send a prompt to the worktree session so it transitions off the pool branch.
+	// `setTitle` triggers `renameSessionFromPool` which renames pool/_pool-<id> →
+	// session/<slug>-<id> and moves the worktree dir. Sessions that have been
+	// renamed in this way must also survive a hard-kill restart.
+	const titleRes = await api(gw, `/api/sessions/${wtId}`, {
+		method: "PATCH",
+		body: JSON.stringify({ title: "Renamed Pool Worktree" }),
+	});
+	expect(titleRes.status).toBe(200);
+	// Give the rename a moment — it's fire-and-forget but very fast.
+	await new Promise(r => setTimeout(r, 1_500));
+	const wtAfterRename = await (await api(gw, `/api/sessions/${wtId}`)).json() as any;
+	console.log(`  [boot] wt post-rename. cwd=${wtAfterRename.cwd} branch=${wtAfterRename.branch}`);
+	expect(wtAfterRename.branch).not.toMatch(/^pool\//);
+
+	// No artificial wait — the gateway must guarantee that any session it
+	// reports as `idle` over the API has already had its recovery-critical
+	// metadata flushed to disk synchronously. This is the regression guard:
+	// previously we had to wait several seconds for a debounced save before
+	// it was safe to hard-kill the gateway. See spawnAgent / executeWorktreeAsync.
+	await api(gw, "/api/sessions");
+
+	// Read sessions.json snapshot for diagnosis
+	const sfPath = join(dir, ".bobbit", "state", "sessions.json");
+	const before = JSON.parse(readFileSync(sfPath, "utf-8")) as any[];
+	console.log(`  [boot] sessions.json has ${before.length} entries`);
+	for (const s of before) {
+		console.log(`         id=${s.id} title="${s.title}" branch=${s.branch} archived=${!!s.archived} agentSessionFile=${s.agentSessionFile ? "yes" : "MISSING"}`);
+	}
+
+	// Restart
+	console.log("  [restart] killing gateway");
+	await stopGW(gw);
+	const port2 = await freePort();
+	gw = await startGW(dir, port2, "RESTART");
+	gw.defaultProjectId = reg.id;
+	console.log(`  [restart] gateway :${port2}`);
+
+	// Wait a bit for restore-on-boot to catch up
+	await new Promise(r => setTimeout(r, 5_000));
+
+	// List all sessions and inspect
+	const listRes = await api(gw, "/api/sessions");
+	expect(listRes.status).toBe(200);
+	const list = await listRes.json() as any;
+	console.log(`  [restart] /api/sessions reports ${list.sessions?.length ?? 0} entries`);
+	for (const s of list.sessions || []) {
+		console.log(`         id=${s.id} status=${s.status} archived=${!!s.archived} cwd=${s.cwd}`);
+	}
+
+	const findInList = (id: string) => list.sessions?.find((s: any) => s.id === id);
+	const plainAfter = findInList(plainId);
+	const wtAfter = findInList(wtId);
+
+	const failures: string[] = [];
+	if (!plainAfter) failures.push(`plain session ${plainId} missing from /api/sessions after restart`);
+	else if (plainAfter.archived) failures.push(`plain session ${plainId} archived after restart (was idle before)`);
+	if (!wtAfter) failures.push(`worktree session ${wtId} missing from /api/sessions after restart`);
+	else if (wtAfter.archived) failures.push(`worktree session ${wtId} archived after restart (was idle before)`);
+
+	if (failures.length === 0) {
+		// Both still listed — try to bring them back to idle
+		try { await pollIdle(gw, plainId, 60_000); console.log(`  [restart] plain idle ✓`); }
+		catch (err) { failures.push(`plain ${plainId} not idle after restart: ${(err as Error).message}`); }
+		try { await pollIdle(gw, wtId, 60_000); console.log(`  [restart] wt idle ✓`); }
+		catch (err) { failures.push(`worktree ${wtId} not idle after restart: ${(err as Error).message}`); }
+	}
+
+	// Read the post-restart sessions.json for diagnosis
+	const after = JSON.parse(readFileSync(sfPath, "utf-8")) as any[];
+	console.log(`  [restart] sessions.json now has ${after.length} entries (${after.filter(s => s.archived).length} archived)`);
+
+	await stopGW(gw);
+	cleanDirs(dir);
+	cleanDirs(plainCwd);
+
+	if (failures.length) {
+		throw new Error(`Restart-minimal failures:\n  - ${failures.join("\n  - ")}`);
+	}
+});

--- a/tests/manual-integration/session-resilience.spec.ts
+++ b/tests/manual-integration/session-resilience.spec.ts
@@ -70,8 +70,24 @@ async function startGW(dir: string, port: number): Promise<GW> {
 		stdio: ["pipe", "pipe", "pipe"],
 	});
 	let stderr = "";
-	proc.stderr!.on("data", (c: Buffer) => { stderr += c; });
-	proc.stdout!.on("data", () => {});
+	let stdout = "";
+	const logTap = process.env.BOBBIT_TEST_GW_LOG;
+	let logFh: number | null = null;
+	if (logTap) {
+		try {
+			const { openSync } = require("node:fs");
+			logFh = openSync(logTap, "a");
+		} catch {}
+	}
+	proc.stderr!.on("data", (c: Buffer) => {
+		stderr += c;
+		if (logFh !== null) { try { require("node:fs").writeSync(logFh, c); } catch {} }
+	});
+	proc.stdout!.on("data", (c: Buffer) => {
+		stdout += c;
+		if (logFh !== null) { try { require("node:fs").writeSync(logFh, c); } catch {} }
+	});
+	void stdout;
 	const deadline = Date.now() + 120_000;
 	while (Date.now() < deadline) {
 		if (proc.exitCode !== null) throw new Error(`Gateway exited (${proc.exitCode}):\n${stderr}`);


### PR DESCRIPTION
## Summary

Sessions reported as `idle` over the API could be silently archived after a hard-kill gateway restart because the field that drives recovery (`agentSessionFile`) was being persisted via a **1-second debounced disk write** that never flushed on `SIGKILL` / `taskkill /F` / OS crash / OOM / container restart.

Worst affected: **worktree sessions** — the post-spawn persist runs in a fire-and-forget `.then()` chain *after* `session.status` flips to idle, so a kill in that gap loses the session forever. Plain (non-worktree) sessions had the same race with a smaller window.

## The race

| t | event |
|---|---|
| 0 ms | `POST /api/sessions` returns 201 (worktree pipeline running async) |
| ~900 ms | `executeWorktreeAsync`: `session.status = "idle"` ← API now reports idle |
| ~900 ms | Test / client moves on |
| ~900 ms | `.then()` in `createSession` fires `persistSessionMetadata(session)` |
| ~910 ms | `getState()` returns `sessionFile` |
| ~910 ms | `store.update(id, { agentSessionFile })` → schedules a 1 s debounced save |
| ~1000 ms | gateway killed |
| — | debounced save never lands; `agentSessionFile` on disk is still `""` |

On the next boot, `restoreOneSession()` sees `agentSessionFile === ""`, runs the recovery scan, fails to match a `.jsonl`, and archives the session.

## Fix

1. **`SessionStore.update()` flushes recovery-critical fields synchronously** instead of going through the 1 s save debounce. High-frequency non-critical updates (`lastActivity`, drafts, queue) keep the existing debounced behaviour.

   ```ts
   private static RECOVERY_CRITICAL_FIELDS = [
     "agentSessionFile", "branch", "worktreePath", "cwd", "repoPath",
     "repoWorktrees", "poolId", "archived", "archivedAt",
     "sandboxed", "projectId", "goalId", "delegateOf",
     "role", "assistantType", "taskId", "staffId",
     "teamGoalId", "teamLeadSessionId", "worktreeDegraded",
     "modelProvider", "modelId",
   ];
   ```

2. **Persist before `status = "idle"`** in both `spawnAgent` and `executeWorktreeAsync`, wired through a new optional `PipelineContext.persistSessionMetadata` hook. The API can never advertise a session whose recovery state isn't on disk.

   ```ts
   await rpcClient.start();
   await ctx.persistSessionMetadata?.(session);   // ← new
   session.status = "idle";
   ctx.broadcast(session.clients, { type: "session_status", status: "idle" });
   ```

The redundant fire-and-forget persists in `createSession` and the worktree `.then()` are kept as safety nets (for sessions that rotate their `.jsonl` mid-run) but are no longer load-bearing for restart correctness.

## Why this matters in production

The race triggers in any scenario where the gateway dies without running its graceful shutdown:

- OS reboot / lock-screen-induced power events
- OOM kill of the Node process
- Container restart (k8s, Docker Desktop, dev harness restart)
- `kill -9` or `taskkill /F` from any tool / IDE
- `npm run restart-server` shortly after creating a session

Symptom users would see: "I created a session 30 seconds ago, my laptop crashed, now Bobbit shows it as archived." After the fix, recovery state is on disk before the API ever advertises the session as ready.

## Tests

- New `tests/manual-integration/restart-minimal.spec.ts`: creates one plain + one worktree session (one of which is renamed off the pool branch via `setTitle`), hard-kills via `taskkill /F /T` (no graceful shutdown), restarts on a fresh port and asserts both survive. ~22 s wall clock, no LLM calls. Reliably reproduces the original bug without these fixes and passes with them.
- `tests/manual-integration/session-resilience.spec.ts` gains a `BOBBIT_TEST_GW_LOG=<path>` env-var tap so future restart investigations can capture spawned-gateway logs across both lifetimes (pure dev-experience improvement, no test-behaviour change).
- `npm run check` ✓
- `npm run test:unit` ✓ (1008 passed, 1 skipped — same as master baseline)

## Out of scope (follow-up)

- The full `session-resilience.spec.ts` suite (A2/B/C/D/E) is still blocked on a pre-existing test bug: `A2` POSTs a goal with `workflowId: "feature"` against a freshly-registered second project, but workflows are no longer auto-seeded after #413, so it 400s. That's unrelated to restart correctness and will be a separate PR (probably driving the project-proposal assistant or `PUT /api/projects/:id/config` to seed workflows first).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
