### PR TITLE
Fix archived session footer showing wrong model

### DIFF
--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -121,6 +121,38 @@ function sendImageModelState(ws: WebSocket, sessionManager: SessionManager, sess
 	if (imageModel) send(ws, { type: "state", data: { imageGenerationModel: imageModel } });
 }
 
+/**
+ * Build a `state` payload for an archived session: archived metadata plus the
+ * persisted model and image-generation model. Without this, the client falls
+ * back to its hardcoded default placeholder model (e.g. claude-opus-4-6) until
+ * the user reconnects, because archived sessions never receive a live
+ * `getState()` push.
+ */
+function buildArchivedStateData(
+	archived: { archivedAt?: number; title: string; modelProvider?: string; modelId?: string },
+	sessionManager: SessionManager,
+	sessionId: string,
+): Record<string, unknown> {
+	const data: Record<string, unknown> = {
+		archived: true,
+		archivedAt: archived.archivedAt,
+		title: archived.title,
+	};
+	if (archived.modelProvider && archived.modelId) {
+		const meta = inferMeta(archived.modelId);
+		data.model = {
+			provider: archived.modelProvider,
+			id: archived.modelId,
+			contextWindow: meta.contextWindow,
+			maxTokens: meta.maxTokens,
+			reasoning: meta.reasoning,
+		};
+	}
+	const imageModel = sessionManager.getImageModelForSession(sessionId);
+	if (imageModel) data.imageGenerationModel = imageModel;
+	return data;
+}
+
 function broadcast(clients: Set<WebSocket>, msg: ServerMessage): void {
 	const data = JSON.stringify(msg);
 	for (const client of clients) {
@@ -227,6 +259,12 @@ export function handleWebSocketConnection(
 					send(ws, { type: "auth_ok" });
 					send(ws, { type: "session_status", status: "archived", archivedAt: archived.archivedAt });
 					send(ws, { type: "session_title", sessionId, title: archived.title });
+					// Push persisted model + image model immediately. Without this, the
+					// client renders its hardcoded default model (claude-opus-4-6) in
+					// the footer picker until the user reconnects (which retriggers
+					// `get_state`). The archived `get_state` handler below produces
+					// the same payload — keep them in sync via buildArchivedStateData.
+					send(ws, { type: "state", data: buildArchivedStateData(archived, sessionManager, sessionId) });
 					return;
 				}
 				send(ws, { type: "error", message: "Session not found", code: "SESSION_NOT_FOUND" });
@@ -301,12 +339,7 @@ export function handleWebSocketConnection(
 				case "get_state": {
 					const archived = sessionManager.getArchivedSession(sessionId);
 					if (archived) {
-						const archivedData: Record<string, unknown> = { archived: true, archivedAt: archived.archivedAt, title: archived.title };
-						if (archived.modelProvider && archived.modelId) {
-							const archivedMeta = inferMeta(archived.modelId);
-							archivedData.model = { provider: archived.modelProvider, id: archived.modelId, reasoning: archivedMeta.reasoning };
-						}
-						send(ws, { type: "state", data: archivedData });
+						send(ws, { type: "state", data: buildArchivedStateData(archived, sessionManager, sessionId) });
 					}
 					break;
 				}

--- a/tests/e2e/archived-footer-model.spec.ts
+++ b/tests/e2e/archived-footer-model.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * Regression test: archived sessions must include the persisted model in the
+ * `state` frame on initial WebSocket connect, not just on `get_state`.
+ *
+ * Before the fix, the archived auth_ok branch in handler.ts sent only
+ * `auth_ok` / `session_status` / `session_title` and NO state frame. The
+ * client's hardcoded default in remote-agent.ts (claude-opus-4-6) leaked
+ * into the footer model picker, until the user reconnected (which fires
+ * `get_state`).
+ */
+import { test, expect } from "./in-process-harness.js";
+import {
+	apiFetch,
+	createSession,
+	connectWs,
+	agentEndPredicate,
+	type WsMsg,
+} from "./e2e-setup.js";
+import { pollUntil } from "./test-utils/cleanup.js";
+
+test.describe("archived session footer model", () => {
+	test("initial connect to archived session pushes persisted model in state frame", async () => {
+		// 1. Create a fresh session
+		const sessionId = await createSession();
+
+		// 2. Connect, set a non-default model, send a prompt to trigger persistence
+		const ws1 = await connectWs(sessionId);
+		ws1.send({ type: "set_model", provider: "anthropic", modelId: "claude-sonnet-4-20250514" });
+		ws1.send({ type: "prompt", text: "hello" });
+		await ws1.waitFor(agentEndPredicate(), 10_000);
+
+		// Wait for model + persistence
+		await pollUntil(async () => {
+			const resp = await apiFetch(`/api/sessions/${sessionId}`);
+			if (!resp.ok) return false;
+			const data = await resp.json();
+			return data.modelProvider === "anthropic" && data.modelId === "claude-sonnet-4-20250514";
+		}, { timeoutMs: 5_000, intervalMs: 50, label: "model persisted" });
+
+		const closed1 = new Promise<void>(r => ws1.ws.once("close", () => r()));
+		ws1.close();
+		await closed1;
+
+		// 3. Archive the session
+		const delResp = await apiFetch(`/api/sessions/${sessionId}`, { method: "DELETE" });
+		expect(delResp.ok).toBe(true);
+
+		// 4. Wait for archival to settle so reconnect routes through the archived branch
+		await pollUntil(async () => {
+			const resp = await apiFetch(`/api/sessions?include=archived`);
+			if (!resp.ok) return false;
+			const data = await resp.json();
+			return Array.isArray(data.sessions) &&
+				data.sessions.some((s: any) => s.id === sessionId && s.archived);
+		}, { timeoutMs: 5_000, intervalMs: 50, label: "session archived" });
+
+		// 5. Fresh connect — DO NOT send get_state. The fix requires the server
+		// to push the model state proactively on auth_ok.
+		const ws2 = await connectWs(sessionId);
+
+		// 6. Wait for a state frame carrying the persisted model
+		await ws2.waitFor(
+			(m: WsMsg) => {
+				if (m.type !== "state") return false;
+				const model = (m.data as any)?.model;
+				return model?.provider === "anthropic" && model?.id === "claude-sonnet-4-20250514";
+			},
+			5_000,
+		).catch(() => {});
+
+		const stateMessages = ws2.messages.filter((m: WsMsg) => m.type === "state");
+		const archivedStates = stateMessages.filter((m: WsMsg) => (m.data as any)?.archived === true);
+
+		// 7. There MUST be at least one state frame, and it MUST carry the model
+		const hasArchivedModelFrame = archivedStates.some((m: WsMsg) => {
+			const model = (m.data as any)?.model;
+			return model?.provider === "anthropic" && model?.id === "claude-sonnet-4-20250514";
+		});
+
+		expect(hasArchivedModelFrame,
+			`Expected an archived state frame with model anthropic/claude-sonnet-4-20250514 ` +
+			`on initial connect (no get_state sent). ` +
+			`Got ${stateMessages.length} state frames, ${archivedStates.length} archived. ` +
+			`State data: ${JSON.stringify(stateMessages.map(m => m.data))}`
+		).toBe(true);
+
+		ws2.close();
+	});
+});


### PR DESCRIPTION
## Problem

Loading an archived session in the UI showed the wrong model in the footer picker (e.g. `claude-opus-4-6`) regardless of which model the session actually ran on.

### Root cause

Two pieces:

1. **Client placeholder** (`src/app/remote-agent.ts:229`) seeds `_state.model` with a hardcoded default `{...getModel("anthropic", "claude-opus-4-6"), contextWindow: 0}`.
2. **Server archived auth path** (`src/server/ws/handler.ts`) sent only `auth_ok` / `session_status` / `session_title` on initial WS connect — **no `state` frame**. The model only shipped when the client sent `get_state`, which it does on reconnect but **not** on initial connect. So the placeholder was never replaced.

For live sessions the proactive `getState()` push at `handler.ts:253` overwrites the placeholder almost immediately. Archived sessions had no equivalent.

## Fix

Factor the archived state payload into a `buildArchivedStateData` helper and call it from both:
- the archived branch of `auth_ok` (new — this is the bug fix)
- the `get_state` handler (existing — now keeps both sites in sync)

The payload now also includes `contextWindow` / `maxTokens` / `imageGenerationModel`, matching the shape the live-session `getState` / `sendFallbackModelState` paths produce.

## Test

`tests/e2e/archived-footer-model.spec.ts` — creates a session with a non-default model, archives it, reconnects with a fresh WebSocket without sending `get_state`, and asserts an archived `state` frame carrying the persisted model arrives.

## Verification

- `npm run check` — clean
- `npm run test:unit` — 1008 passed
- `npx playwright test --config playwright-e2e.config.ts tests/e2e/archived-footer-model.spec.ts tests/e2e/context-bar-reconnect.spec.ts tests/e2e/continue-archived.spec.ts tests/e2e/archived-delegates-api.spec.ts tests/e2e/archived-session-merge.spec.ts` — 18 passed

## Out of scope

- The redundant `model_change` event at session start (covered by the linked goal — passing `--model` to the agent CLI for non-pool spawns).
- Removing the client-side `claude-opus-4-6` placeholder (would require auditing every consumer of `state.model`).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)