### PR TITLE
test(manual): supply components+workflows in project registrations

### DIFF
--- a/tests/manual-integration/session-resilience.spec.ts
+++ b/tests/manual-integration/session-resilience.spec.ts
@@ -26,8 +26,34 @@ import {
 	cpSync,
 } from "node:fs";
 import { join, resolve, normalize } from "node:path";
+import { buildDefaultWorkflows } from "../../src/server/state-migration/seed-default-workflows.ts";
 
 const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
+
+/**
+ * Build a `propose_project`-style registration body that includes the
+ * canonical components + workflows. The server no longer seeds default
+ * workflows; the project assistant (or a registration call) is responsible.
+ * This helper mimics what `propose_project` would supply.
+ */
+function projectRegistrationBody(name: string, rootPath: string, opts: { upsert?: boolean } = {}) {
+	// Component must declare every command name referenced by the seeded
+	// workflows (build/check/unit/e2e), otherwise validateAllWorkflows rejects
+	// the registration. Stub them with `echo ok` — these tests never run them
+	// to completion, only check goal creation and team start.
+	const components = [{
+		name,
+		repo: ".",
+		commands: {
+			build: "echo build ok",
+			check: "echo check ok",
+			unit: "echo unit ok",
+			e2e: "echo e2e ok",
+		},
+	}];
+	const workflows = buildDefaultWorkflows(name);
+	return { name, rootPath, components, workflows, ...opts };
+}
 const SERVER_CLI = join(PROJECT_ROOT, "dist", "server", "cli.js");
 const RESULTS_DIR = join(PROJECT_ROOT, "test-results", "manual-integration");
 const WANT_SCREENSHOTS = !!process.env.SCREENSHOTS;
@@ -575,9 +601,11 @@ test.describe.serial("Integration — sessions, goals, sandboxed goals", () => {
 		console.log(`  Gateway :${port}  cwd=${dir}  docker=${HAS_DOCKER}`);
 
 		// Register a project at the gateway cwd — replaces the old auto-registration.
+		// Include components + workflows so workflowId:"feature" is resolvable
+		// (server no longer auto-seeds default workflows).
 		const regRes = await api(gw, "/api/projects", {
 			method: "POST",
-			body: JSON.stringify({ name: "default", rootPath: dir, upsert: true }),
+			body: JSON.stringify(projectRegistrationBody("default", dir, { upsert: true })),
 		});
 		if (regRes.status !== 201 && regRes.status !== 200) {
 			throw new Error(`Failed to register default project: ${regRes.status}`);
@@ -711,10 +739,12 @@ test.describe.serial("Integration — sessions, goals, sandboxed goals", () => {
 		execFileSync("git", ["add", "."], { cwd: proj2Dir, stdio: "ignore" });
 		execFileSync("git", ["commit", "-m", "init second project"], { cwd: proj2Dir, stdio: "ignore" });
 
-		// 2. Register the second project via API
+		// 2. Register the second project via API.
+		// Supply components + workflows the same way `propose_project` would, so
+		// the goal below can request workflowId:"feature".
 		const regRes = await api(gw, "/api/projects", {
 			method: "POST",
-			body: JSON.stringify({ name: "Second Project", rootPath: proj2Dir }),
+			body: JSON.stringify(projectRegistrationBody("Second Project", proj2Dir)),
 		});
 		expect(regRes.status).toBe(201);
 		const regBody = await regRes.json() as any;


### PR DESCRIPTION
## Summary

The "no default workflow scaffold" change (#413) made the server stop seeding default workflows on `POST /api/projects`. The manual integration tests still registered projects with bare `{name, rootPath}` bodies and then created goals with `workflowId: "feature"`, which now 400s.

This caused `session-resilience.spec.ts` test `A2. multi-project sessions and goal` to fail at goal creation, cascading to all downstream tests (B–F + restart verification) being skipped.

## Fix

Mirror what `propose_project` does: pass structured `components` + `workflows` in the registration body. Extracted a `projectRegistrationBody()` helper that:

1. Defines a single-component `{ name, repo: "." }` with stub `commands` for `build`/`check`/`unit`/`e2e` (required by the workflow validator — `type: command` steps must reference a command that exists on the component).
2. Calls `buildDefaultWorkflows(name)` from `src/server/state-migration/seed-default-workflows.ts` to produce the canonical four workflows (general, feature, bug-fix, refactor).
3. Returns the merged `{ name, rootPath, components, workflows, ...opts }` payload.

Both project registrations in `session-resilience.spec.ts` — the default project and the second project for A2 — now go through this helper.

## Verification

- `npm run check` clean
- `A2. multi-project sessions and goal` now passes in ~1.1 min (previously 400 at `POST /api/goals`)

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)