### PR TITLE
fix(sw): stamp BUILD_ID per build so service worker self-updates

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,75 +1,86 @@
-// Bobbit Service Worker — minimal, for PWA installability + app shell caching
-const CACHE_NAME = 'bobbit-v1';
+// Bobbit Service Worker — PWA installability + offline fallback only.
+//
+// Design:
+//   * Network-first for EVERYTHING (HTML, assets, manifest, icons).
+//     Cache is consulted only when the network fetch fails — i.e. true
+//     offline / gateway-down fallback. This guarantees that as long as
+//     the user is online, they always see the latest deploy and a hard
+//     refresh (Ctrl+Shift+R) will always reach the gateway.
+//   * `BUILD_ID` is replaced at build time by the `bobbit-sw-version`
+//     Vite plugin (and stamped to a fresh value on every dev request).
+//     A new BUILD_ID -> new CACHE_NAME -> activate handler purges every
+//     cache that isn't the current one. Combined with `skipWaiting()` +
+//     `clients.claim()` this means: deploy a new build, the next page
+//     load activates the new SW, and the old caches are wiped before
+//     the user notices.
+//
+// Why we no longer cache `/assets/*` aggressively: the cache-first asset
+// path was the proximate cause of the "stuck UI after server restart"
+// bug. The browser would render an old `index.html` (kept by the
+// network-first HTML fallback) referencing immutable hashed bundles
+// from the SW cache, and no amount of Ctrl+Shift+R would dislodge it
+// because the SW intercepted every subresource fetch. Network-first
+// for assets too removes that failure mode entirely while still
+// allowing offline use of the last-seen build.
+const BUILD_ID = "__BOBBIT_BUILD_ID__";
+const CACHE_NAME = `bobbit-${BUILD_ID}`;
 
-self.addEventListener('install', (event) => {
-  // Skip waiting to activate immediately
-  self.skipWaiting();
+self.addEventListener("install", () => {
+	// Activate immediately so a new build replaces the old SW on the next
+	// navigation rather than waiting for every tab to close first.
+	self.skipWaiting();
 });
 
-self.addEventListener('activate', (event) => {
-  // Clean up old caches when cache name changes
-  event.waitUntil(
-    caches.keys().then((keys) =>
-      Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
-    )
-  );
-  self.clients.claim();
+self.addEventListener("activate", (event) => {
+	// Purge every cache that isn't the current build. This is what
+	// guarantees a fresh-deploy client never serves stale assets.
+	event.waitUntil(
+		(async () => {
+			const keys = await caches.keys();
+			await Promise.all(
+				keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)),
+			);
+			await self.clients.claim();
+		})(),
+	);
 });
 
-self.addEventListener('fetch', (event) => {
-  const url = new URL(event.request.url);
+self.addEventListener("fetch", (event) => {
+	const req = event.request;
 
-  // Only handle GET requests
-  if (event.request.method !== 'GET') return;
+	// Only GET is cacheable / fallback-able.
+	if (req.method !== "GET") return;
 
-  // Never cache API or WebSocket requests
-  if (url.pathname.startsWith('/api/') || url.pathname.startsWith('/ws')) return;
+	const url = new URL(req.url);
 
-  // Network-first for HTML (navigation requests) — always get fresh index.html
-  if (event.request.mode === 'navigate' || url.pathname === '/') {
-    event.respondWith(
-      fetch(event.request)
-        .then((response) => {
-          if (response.ok) {
-            const clone = response.clone();
-            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
-          }
-          return response;
-        })
-        .catch(() => caches.match(event.request))
-    );
-    return;
-  }
+	// Never touch API or WebSocket traffic — must always hit the gateway.
+	if (url.pathname.startsWith("/api/") || url.pathname.startsWith("/ws")) return;
 
-  // Cache-first for hashed static assets (Vite bundles with content hashes)
-  // These are immutable — the hash changes when content changes
-  if (url.pathname.startsWith('/assets/')) {
-    event.respondWith(
-      caches.match(event.request).then((cached) => {
-        if (cached) return cached;
-        return fetch(event.request).then((response) => {
-          if (response.ok) {
-            const clone = response.clone();
-            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
-          }
-          return response;
-        });
-      })
-    );
-    return;
-  }
-
-  // Network-first for other static files (manifest, icons, favicon)
-  // These don't have content hashes so we need fresh copies
-  event.respondWith(
-    fetch(event.request)
-      .then((response) => {
-        if (response.ok) {
-          const clone = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
-        }
-        return response;
-      })
-      .catch(() => caches.match(event.request))
-  );
+	// Network-first with offline cache fallback for every other GET.
+	event.respondWith(
+		fetch(req)
+			.then((response) => {
+				// Only cache successful, basic/cors responses. Opaque/error
+				// responses can poison the cache and serve garbage offline.
+				if (response.ok && (response.type === "basic" || response.type === "cors")) {
+					const clone = response.clone();
+					caches.open(CACHE_NAME).then((cache) => cache.put(req, clone)).catch(() => {});
+				}
+				return response;
+			})
+			.catch(async () => {
+				// Network failed — try the per-build cache.
+				const cached = await caches.match(req);
+				if (cached) return cached;
+				// Navigation requests should at least get *some* HTML rather
+				// than the browser's default failure page. Fall back to the
+				// cached root if we have one.
+				if (req.mode === "navigate") {
+					const root = await caches.match("/");
+					if (root) return root;
+				}
+				// Re-throw — browser shows offline error.
+				throw new Error("offline and no cached response");
+			}),
+	);
 });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7621,7 +7621,18 @@ function serveStatic(pathname: string, staticDir: string, res: http.ServerRespon
 		const contentType = MIME_TYPES[ext] || "application/octet-stream";
 		const content = fs.readFileSync(filePath);
 
-		res.writeHead(200, { "Content-Type": contentType });
+		const headers: Record<string, string> = { "Content-Type": contentType };
+		// Service-worker file: never cache. Browsers byte-compare SWs for
+		// updates, but an intermediate proxy/CDN serving a stale copy would
+		// silently keep users on the old build's CACHE_NAME. Same goes for
+		// the SPA shell (index.html) — it references hashed bundle names
+		// that change every build.
+		const basename = path.basename(filePath);
+		if (basename === "sw.js" || basename === "index.html") {
+			headers["Cache-Control"] = "no-cache, no-store, must-revalidate";
+		}
+
+		res.writeHead(200, headers);
 		res.end(content);
 	} catch {
 		res.writeHead(500);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -148,6 +148,58 @@ function localhostGuard(): Plugin {
 	};
 }
 
+/**
+ * Stamp `__BOBBIT_BUILD_ID__` in `public/sw.js` with a per-build identifier
+ * so the service worker's CACHE_NAME changes on every deploy. Without this,
+ * an in-flight client keeps the previous build's caches forever and a hard
+ * refresh can't escape stale hashed assets after a gateway restart.
+ *
+ * Dev: stamps the file on every request with a fresh timestamp so reloading
+ *      always activates a new SW (matches Vite's HMR mental model).
+ * Build: stamps once with a content hash + timestamp into the emitted asset.
+ */
+function bobbitSwVersion(): Plugin {
+	const PLACEHOLDER = "__BOBBIT_BUILD_ID__";
+	const stamp = (src: string, id: string): string => src.split(PLACEHOLDER).join(id);
+	return {
+		name: "bobbit-sw-version",
+		// Dev: intercept GET /sw.js and rewrite the placeholder per request.
+		configureServer(server) {
+			server.middlewares.use((req, res, next) => {
+				if (req.method !== "GET" || (req.url || "").split("?")[0] !== "/sw.js") return next();
+				const swPath = path.join(process.cwd(), "public", "sw.js");
+				let src: string;
+				try { src = fs.readFileSync(swPath, "utf-8"); } catch { return next(); }
+				const body = stamp(src, `dev-${Date.now()}`);
+				res.writeHead(200, {
+					"Content-Type": "application/javascript; charset=utf-8",
+					// Service workers should not be cached themselves — browsers
+					// already byte-compare on update, but explicit no-cache keeps
+					// proxies and CDNs from holding onto an old copy.
+					"Cache-Control": "no-cache, no-store, must-revalidate",
+				});
+				res.end(body);
+			});
+		},
+		// Build: Vite copies `public/sw.js` verbatim into outDir during
+		// `writeBundle`. Run after that copy and rewrite the placeholder
+		// in-place. `closeBundle` is the last hook so the on-disk file is
+		// guaranteed to exist by the time we get here.
+		closeBundle: {
+			order: "post",
+			handler() {
+				const outFile = path.join(process.cwd(), "dist", "ui", "sw.js");
+				if (!fs.existsSync(outFile)) return;
+				let src: string;
+				try { src = fs.readFileSync(outFile, "utf-8"); } catch { return; }
+				if (!src.includes(PLACEHOLDER)) return;
+				const id = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+				fs.writeFileSync(outFile, stamp(src, id));
+			},
+		},
+	};
+}
+
 function dynamicGatewayProxy(): Plugin {
 	return {
 		name: "dynamic-gateway-proxy",
@@ -222,7 +274,7 @@ function dynamicGatewayProxy(): Plugin {
 }
 
 export default defineConfig({
-	plugins: [tailwindcss(), blockDangerousGlobs(), localhostGuard(), dynamicGatewayProxy()],
+	plugins: [tailwindcss(), blockDangerousGlobs(), localhostGuard(), bobbitSwVersion(), dynamicGatewayProxy()],
 	build: {
 		outDir: "dist/ui",
 	},


### PR DESCRIPTION
## What

Fixes the "stuck UI after server restart that won't go away even with Ctrl+Shift+R" bug. Once a Chromium tab installed the service worker, it was effectively pinned to a single deploy until the entire browser was restarted.

## Root cause

`public/sw.js` had two compounding problems:

1. **`CACHE_NAME = 'bobbit-v1'` was a frozen literal.** The activate handler only purges caches whose key differs from `CACHE_NAME`, so once a client cached `bobbit-v1` nothing could ever evict it.
2. **The `sw.js` body was constant across deploys.** Browsers install a new SW only when they fetch `sw.js` and find byte-different content. Same bytes → no install → the old SW kept running and kept serving the cache-first `/assets/*` path. Old hashed bundles were pinned forever.

Hard reload didn't help because Chromium doesn't bypass an active SW for subresource fetches — only the navigation request. A full browser restart was the only escape.

## Fix

- **`public/sw.js`**: drop the cache-first `/assets/*` path. Network-first for every GET, cache used only when the network call fails (real offline fallback). Add a `BUILD_ID` placeholder baked into `CACHE_NAME` so each deploy gets a fresh cache key and the `activate` handler can purge every prior cache. PWA installability preserved.
- **`vite.config.ts`**: new `bobbit-sw-version` plugin stamps `__BOBBIT_BUILD_ID__`. Dev: per-request timestamp via middleware, plus `Cache-Control: no-cache, no-store, must-revalidate`. Build: once via `closeBundle` (post-order) rewriting `dist/ui/sw.js` in place after Vite copies `public/`.
- **`src/server/server.ts`**: `serveStatic` sends `sw.js` and `index.html` with `Cache-Control: no-cache, no-store, must-revalidate` so HTTP intermediaries can't keep an old SW or shell alive.

## Recovery for already-stuck clients

The next time their browser checks `sw.js` (it does this on navigation, byte-compared) it will see different content and install. The new `activate` handler runs `caches.delete()` on every key that isn't the current `CACHE_NAME`, calls `clients.claim()`, and from that point every fetch is network-first. Stuck users self-heal on the next page load — no incognito, no DevTools, no manual unregister.

## Testing

- `npm run check` passes.
- `npm run build:ui` confirmed the placeholder is replaced in `dist/ui/sw.js` (`const BUILD_ID = "momrplbk-qm8hv1";`).
- Unit tests pass.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
