### PR TITLE
fix(review): guard review_open/close against background sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ tests/fixtures/settings-models-tab-bundle.js
 tests/fixtures/settings-models-tab-bundle.css
 tests/fixtures/preview-renderer-bundle.js
 tests/fixtures/preview-renderer-bundle.css
+tests/fixtures/review-tool-active-guard-bundle.js
+tests/fixtures/review-tool-active-guard-bundle.css
 tests/fixtures/components-editor-bundle.js
 tests/fixtures/components-editor-bundle.css
 tests/fixtures/project-proposal-views-bundle.js

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -1308,8 +1308,25 @@ export class RemoteAgent {
 	 * Check if a message contains review tool results (from the review_open/review_close
 	 * extension) and update the review pane state accordingly. Scans message text content
 	 * for JSON payloads with action "review_open" or "review_close".
+	 *
+	 * Active-session guard: `state.review*` is global, but every connected session
+	 * (including cached/background ones whose RemoteAgent is kept alive in
+	 * `sessionCache` — see session-manager.ts::selectSession) routes its
+	 * `message_end` events through here. Without this gate, a `review_open`
+	 * emitted by a background session would mutate the globally-shared review
+	 * state and land on whichever session the user is currently viewing.
+	 *
+	 * We compare `_sessionId` against `state.selectedSessionId` (set
+	 * synchronously in `selectSession()` before `connectToSession()` runs),
+	 * not `state.remoteAgent`, because the latter is assigned only AFTER
+	 * `remote.connect()` returns — and the initial `auth_ok` handler replays
+	 * message history through this method during connect, so a
+	 * `state.remoteAgent`-based check would no-op the initial review-pane
+	 * hydration. Mirrors the active-session check in `_onVisibilityChange`.
 	 */
 	private _checkReviewToolResult(msg: any): void {
+		if (this._sessionId && state.selectedSessionId !== this._sessionId) return;
+
 		// Extract text content from the message
 		const texts: string[] = [];
 		if (typeof msg.content === "string") texts.push(msg.content);

--- a/tests/fixtures/review-tool-active-guard-entry.ts
+++ b/tests/fixtures/review-tool-active-guard-entry.ts
@@ -1,0 +1,55 @@
+// Test entry — bundles RemoteAgent for the review-tool active-guard fixture.
+//
+// Regression coverage: when an agent in a *background/cached* session emits a
+// `review_open` (or `review_close`) tool result, its `_checkReviewToolResult`
+// must NOT mutate the globally-shared `state.review*` fields (which would
+// land on whichever session the user is currently viewing).
+//
+// We can't easily construct a real connected RemoteAgent in a file:// fixture,
+// so we instantiate two and drive `_checkReviewToolResult` directly with
+// synthetic tool-result messages. `state.selectedSessionId` is the canonical
+// "active session" pointer (set synchronously in selectSession before any
+// agent connects) — the production code under test must consult it before
+// mutating global review state.
+
+import { RemoteAgent } from "../../src/app/remote-agent.js";
+import { state } from "../../src/app/state.js";
+
+(window as any).__state = state;
+(window as any).__makeAgent = (sessionId: string) => {
+	const a = new RemoteAgent();
+	// _sessionId is private; assign for test purposes so the production code
+	// path that consults it (e.g. localStorage.removeItem keying) is exercised.
+	(a as any)._sessionId = sessionId;
+	return a;
+};
+(window as any).__setActive = (a: any) => {
+	state.remoteAgent = a;
+	state.selectedSessionId = (a as any)._sessionId;
+};
+(window as any).__clearReviewState = () => {
+	state.reviewDocuments = new Map();
+	state.reviewActiveTab = "";
+	state.reviewPanelOpen = false;
+};
+(window as any).__getReviewState = () => ({
+	open: state.reviewPanelOpen,
+	activeTab: state.reviewActiveTab,
+	docCount: state.reviewDocuments.size,
+	docTitles: [...state.reviewDocuments.keys()],
+});
+(window as any).__deliverReviewToolResult = (a: any, action: string, payload: any) => {
+	// Build a tool-result-shaped message that matches what the review tool
+	// extension produces — a content block whose text is a JSON envelope.
+	const json = JSON.stringify({ action, ...payload });
+	const msg = {
+		role: "toolResult",
+		content: [
+			{ type: "text", text: "(tool ack)" },
+			{ type: "text", text: json },
+		],
+	};
+	(a as any)._checkReviewToolResult(msg);
+};
+
+(window as any).__ready = true;

--- a/tests/fixtures/review-tool-active-guard.html
+++ b/tests/fixtures/review-tool-active-guard.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>review-tool active-guard fixture</title>
+</head>
+<body>
+<div id="root"></div>
+<script>
+	try { localStorage.setItem("bobbit_gateway_url", "http://127.0.0.1:1/"); } catch {}
+	try { localStorage.setItem("bobbit_gateway_token", "test"); } catch {}
+</script>
+<script src="./review-tool-active-guard-bundle.js"></script>
+</body>
+</html>

--- a/tests/review-tool-active-guard.spec.ts
+++ b/tests/review-tool-active-guard.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect } from "@playwright/test";
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Regression test for: an agent calling `review_open` from a background
+ * (cached) session must not open the review pane on whichever session the
+ * user is currently viewing.
+ *
+ * `RemoteAgent._checkReviewToolResult` writes directly to global
+ * `state.review*` fields. Because `selectSession` keeps the outgoing
+ * session's RemoteAgent alive in `sessionCache`, message_end events from the
+ * background session still flow into that handler. The fix is to gate every
+ * mutation on the agent being the active one (`this === state.remoteAgent`).
+ */
+
+const FIXTURE = path.resolve("tests/fixtures/review-tool-active-guard.html");
+const BUNDLE = path.resolve("tests/fixtures/review-tool-active-guard-bundle.js");
+const ENTRY = path.resolve("tests/fixtures/review-tool-active-guard-entry.ts");
+const REMOTE_AGENT_SRC = path.resolve("src/app/remote-agent.ts");
+
+test.beforeAll(() => {
+	const entryMtime = Math.max(
+		fs.statSync(ENTRY).mtimeMs,
+		fs.statSync(REMOTE_AGENT_SRC).mtimeMs,
+	);
+	const bundleExists = fs.existsSync(BUNDLE);
+	const bundleStale = bundleExists && fs.statSync(BUNDLE).mtimeMs < entryMtime;
+	if (!bundleExists || bundleStale) {
+		execSync(
+			[
+				`npx esbuild ${ENTRY}`,
+				"--bundle --format=iife --target=es2022",
+				`--outfile=${BUNDLE}`,
+				"--tsconfig=tsconfig.web.json",
+				"--alias:pdfjs-dist=./tests/fixtures/empty-shim",
+				"--define:import.meta.url='\"http://localhost/\"'",
+			].join(" "),
+			{ stdio: "pipe" },
+		);
+	}
+});
+
+const PAGE = `file://${FIXTURE}`;
+
+async function gotoAndWait(page: any) {
+	await page.goto(PAGE);
+	await page.waitForFunction(() => (window as any).__ready === true, null, { timeout: 10_000 });
+}
+
+test.describe("review tool active-session guard", () => {
+	test("background session's review_open does NOT mutate global review state", async ({ page }) => {
+		await gotoAndWait(page);
+		const result = await page.evaluate(() => {
+			const w = window as any;
+			const active = w.__makeAgent("active-session");
+			const background = w.__makeAgent("background-session");
+			w.__setActive(active);
+			w.__clearReviewState();
+
+			// Simulate the bug: background session's agent emits review_open.
+			w.__deliverReviewToolResult(background, "review_open", {
+				title: "PR-from-background",
+				markdown: "# Should not appear",
+			});
+
+			return w.__getReviewState();
+		});
+
+		expect(result.open).toBe(false);
+		expect(result.activeTab).toBe("");
+		expect(result.docCount).toBe(0);
+	});
+
+	test("active session's review_open DOES open the review pane", async ({ page }) => {
+		await gotoAndWait(page);
+		const result = await page.evaluate(() => {
+			const w = window as any;
+			const active = w.__makeAgent("active-session");
+			w.__setActive(active);
+			w.__clearReviewState();
+
+			w.__deliverReviewToolResult(active, "review_open", {
+				title: "PR-from-active",
+				markdown: "# Welcome",
+			});
+
+			return w.__getReviewState();
+		});
+
+		expect(result.open).toBe(true);
+		expect(result.activeTab).toBe("PR-from-active");
+		expect(result.docCount).toBe(1);
+		expect(result.docTitles).toEqual(["PR-from-active"]);
+	});
+
+	test("background session's review_close does NOT clear active session's documents", async ({ page }) => {
+		await gotoAndWait(page);
+		const result = await page.evaluate(() => {
+			const w = window as any;
+			const active = w.__makeAgent("active-session");
+			const background = w.__makeAgent("background-session");
+			w.__setActive(active);
+			w.__clearReviewState();
+
+			// Active session opens a review.
+			w.__deliverReviewToolResult(active, "review_open", {
+				title: "Active-PR",
+				markdown: "# Important",
+			});
+			const before = w.__getReviewState();
+
+			// Background session emits review_close — must NOT clear the active doc.
+			w.__deliverReviewToolResult(background, "review_close", {});
+			const after = w.__getReviewState();
+
+			return { before, after };
+		});
+
+		expect(result.before.open).toBe(true);
+		expect(result.before.docCount).toBe(1);
+		expect(result.after.open).toBe(true);
+		expect(result.after.docCount).toBe(1);
+		expect(result.after.activeTab).toBe("Active-PR");
+	});
+});


### PR DESCRIPTION
## Problem

When an agent called `review_open` or `review_close`, the review pane opened on whichever session the user was currently viewing — not the session the agent belonged to.

## Root cause

`RemoteAgent._checkReviewToolResult` (in `src/app/remote-agent.ts`) wrote directly to the globally-shared `state.review*` fields and called `renderApp()`, with no check that the agent was for the active session. Because `selectSession` keeps the outgoing session's `RemoteAgent` alive in `sessionCache`, `message_end` events from background/cached sessions still flowed through this handler.

## Fix

One-line guard at the top of `_checkReviewToolResult`:

```ts
if (this._sessionId && state.selectedSessionId !== this._sessionId) return;
```

Compares against `state.selectedSessionId` (not ``state.remoteAgent === this``) because `state.remoteAgent` is assigned only **after** `remote.connect()` returns, and the `auth_ok` handler replays message history through this method during connect — a `state.remoteAgent`-based check would no-op the initial review-pane hydration. Mirrors the active-session check already in `_onVisibilityChange`.

## Test

`tests/review-tool-active-guard.spec.ts` — file:// fixture that bundles `RemoteAgent` and instantiates two agents directly. Covers:

- background session's `review_open` does NOT mutate global review state
- active session's `review_open` DOES open the pane
- background session's `review_close` does NOT clear the active session's docs

Verified all three fail without the fix and pass with it.

## Verification

- `npm run check` — clean
- `npm run test:unit` — 1014/1014 pass

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)