### PR TITLE
fix(steer): abort active bash_bg waits when promoting queued message

### DIFF
--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -1436,6 +1436,18 @@ export class SessionManager {
 		// arrive seconds apart. The dispatch is triggered by the tool_result
 		// event handler in _handleAgentEvent().
 		// If the agent is idle, they'll drain normally via drainQueue.
+		//
+		// SPECIAL CASE: bash_bg.wait. A wait long-poll has no natural tool
+		// boundary — it sits indefinitely until the bg process exits or the
+		// wait is aborted. Without intervention, a steer-on-queue while the
+		// agent is parked in wait would be deferred for the entire wait
+		// duration. Mirror deliverLiveSteer's behaviour: when the session is
+		// streaming and there is at least one active wait, abort all waits so
+		// the agent unblocks at once. The underlying bg process keeps
+		// running; only the wait long-poll is cancelled, which is exactly
+		// what the user expects from the Steer button.
+		const bg = (this as any).bgProcessManager;
+		if (bg && session.status === "streaming") bg.abortAllWaits(session.id);
 
 		this.broadcastQueue(session);
 		return true;

--- a/tests/e2e/ui/bg-wait-steer-flow.spec.ts
+++ b/tests/e2e/ui/bg-wait-steer-flow.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * Browser E2E — full user flow: send-while-`bash_bg wait`-is-blocking + steer.
+ *
+ * Closes the gap between the two existing specs:
+ *   - tests/e2e/bg-wait-steer-abort.spec.ts  — server-only: pokes
+ *     `bgProcessManager.abortAllWaits()` directly, no UI.
+ *   - tests/e2e/ui/queue-ui.spec.ts (PI-10)  — UI steer pill flow, but no bg
+ *     process and no wait-abort assertion.
+ *
+ * This test exercises the real user flow end-to-end:
+ *   1. Open the app, send a prompt that puts the agent into a long tool call.
+ *   2. Spawn a real background process via REST and start a long-poll wait
+ *      (the same wait that an in-agent `bash_bg wait` call would issue).
+ *   3. While the agent is busy and the wait is parked, the user types a
+ *      follow-up in the textarea, presses Enter (queued pill appears), and
+ *      clicks the Steer button.
+ *   4. At the next tool boundary the server batches the steered message and
+ *      dispatches it via `rpcClient.steer()`. Just before that dispatch,
+ *      `_dispatchSteeredMessages()` calls `bgProcessManager.abortAllWaits()`
+ *      so any in-flight `bash_bg wait` long-poll is unblocked with
+ *      `aborted:true` — the bg process itself is left running.
+ *   5. The mock agent emits `[STEER_RECEIVED]` on receiving the steer,
+ *      proving the steer text actually reached the agent.
+ *
+ * Together the assertions guarantee that:
+ *   - The UI steer button reaches the server (sent-indicator appears).
+ *   - The bash_bg-wait abort hook on the steer-dispatch path actually fires
+ *     (wait returns aborted:true within the timeout, bg proc still running).
+ *   - The steer is delivered to the agent (STEER_RECEIVED in chat).
+ *
+ * If any of those wires regress in isolation — e.g. someone removes the
+ * `bg.abortAllWaits` call from `_dispatchSteeredMessages`, or the steer pill
+ * stops dispatching at tool boundaries — this single test catches it.
+ */
+import { test, expect } from "../gateway-harness.js";
+import {
+	createSession,
+	waitForHealth,
+	waitForSessionStatus,
+	apiFetch,
+} from "../e2e-setup.js";
+import { openApp, sendMessage } from "./ui-helpers.js";
+
+// Long-running bg command — must outlive the entire test so we can assert it
+// is still running after the wait is aborted.
+const SLEEP_CMD = process.platform === "win32"
+	? "ping -n 60 127.0.0.1 >NUL"
+	: "sleep 60";
+
+test.describe("bash_bg wait + steer — end-to-end user flow", () => {
+	test.beforeAll(async () => {
+		await waitForHealth();
+	});
+
+	test("queue + steer while bg-wait is parked aborts the wait and delivers the steer mid-turn", async ({ page }) => {
+		const sessionId = await createSession();
+		await waitForSessionStatus(sessionId, "idle");
+
+		await openApp(page);
+		await page.evaluate((id) => { window.location.hash = `#/session/${id}`; }, sessionId);
+		await expect(page.locator("textarea").first()).toBeVisible({ timeout: 15_000 });
+
+		// 1. Make the agent busy. STAY_BUSY:<ms> emits tool_execution_start
+		//    ("Bash sleep"), ticks for <ms>, then emits tool_execution_end.
+		//    The steered message is batched and dispatched on that _end event,
+		//    so the busy window has to be long enough for us to (a) start the
+		//    bg wait, (b) queue a message, (c) click Steer — comfortably ~5s.
+		await sendMessage(page, "STAY_BUSY:5000 working");
+		await expect(page.locator("button[title='Stop streaming']")).toBeVisible({ timeout: 10_000 });
+
+		// 2. Spawn a real long-running bg process attached to this session,
+		//    then start a long-poll wait with a generous timeout. Don't await
+		//    the wait yet — it should park inside the BgProcessManager until
+		//    the steer dispatch unblocks it.
+		const bgRes = await apiFetch(`/api/sessions/${sessionId}/bg-processes`, {
+			method: "POST",
+			body: JSON.stringify({ command: SLEEP_CMD, name: "sleeper-steer" }),
+		});
+		expect(bgRes.status).toBe(201);
+		const bg = await bgRes.json();
+
+		const waitStart = Date.now();
+		const waitPromise = apiFetch(
+			`/api/sessions/${sessionId}/bg-processes/${bg.id}/wait?timeout=60`,
+		).then(async (r) => ({ status: r.status, body: await r.json() as {
+			aborted: boolean;
+			timedOut: boolean;
+			info: { status: string };
+		} }));
+
+		// 3. Queue a follow-up message via the UI textarea (the real user path).
+		const textarea = page.locator("textarea").first();
+		await textarea.fill("steer-during-bg-wait");
+		await textarea.press("Enter");
+		await expect(page.locator(".queue-pill").first()).toBeVisible({ timeout: 5_000 });
+		await expect(page.locator(".steer-btn")).toHaveCount(1);
+
+		// 4. Click the Steer pill → server marks isSteered, then batches and
+		//    dispatches at the next tool boundary (mock agent's busy
+		//    tool_execution_end ~5s after the initial prompt).
+		await page.locator(".steer-btn").first().click();
+		await expect(page.locator(".sent-indicator")).toBeVisible({ timeout: 5_000 });
+		await expect(page.locator(".sent-indicator")).toContainText("Sent");
+
+		// 5. `steerQueued` calls `bgProcessManager.abortAllWaits(sessionId)`
+		//    synchronously when the session is streaming, so the parked wait
+		//    resolves with `aborted:true` immediately on the click — NOT after
+		//    the busy tool's 5000ms `tool_execution_end` fires. The bg process
+		//    itself keeps running. Without this, a steer-on-queue while the
+		//    agent is parked in bash_bg.wait would be deferred until the wait
+		//    completed naturally (could be minutes). See the `steerQueued`
+		//    method in src/server/agent/session-manager.ts.
+		const result = await waitPromise;
+		const elapsed = Date.now() - waitStart;
+		expect(result.status).toBe(200);
+		expect(result.body.aborted).toBe(true);
+		expect(result.body.timedOut).toBe(false);
+		expect(result.body.info.status).toBe("running");
+		// The wait must abort well before the 5000ms busy-tool boundary. 3000ms
+		// is a generous ceiling: slow CI takes ~500ms wall-time end-to-end for
+		// the click → ws → steerQueued → abortAllWaits chain. A regression that
+		// reverts the steerQueued fix would push elapsed past 5000ms (waiting
+		// for the busy tool's _end event) which this assertion catches.
+		expect(elapsed).toBeLessThan(3_000);
+
+		// 6. Steer text actually reached the agent — mock agent emits
+		//    [STEER_RECEIVED] on rpcClient.steer().
+		await expect(
+			page.getByText("STEER_RECEIVED").first(),
+		).toBeVisible({ timeout: 15_000 });
+
+		// 7. After all the dust settles, the bg process is still running.
+		const listRes = await apiFetch(`/api/sessions/${sessionId}/bg-processes`);
+		const list = await listRes.json();
+		const proc = (list.processes as Array<{ id: string; status: string }>).find(
+			(p) => p.id === bg.id,
+		);
+		expect(proc).toBeTruthy();
+		expect(proc!.status).toBe("running");
+
+		// Cleanup: kill the bg process so the worker doesn't leak it.
+		await apiFetch(`/api/sessions/${sessionId}/bg-processes/${bg.id}`, {
+			method: "DELETE",
+		}).catch(() => { /* best-effort */ });
+	});
+});


### PR DESCRIPTION
## Problem

When a user clicks the **Steer** button on a queued message while the agent is parked in a `bash_bg.wait`, the steered message sits in the queue until the wait completes naturally — could be minutes.

The wait long-poll has no natural tool boundary, so the existing `tool_execution_end`-driven dispatch in `_dispatchSteeredMessages` never fires. `deliverLiveSteer` (the free-typed-text path) already aborts active waits via `bg.abortAllWaits()`; the queue-pill `steerQueued` path didn't.

## Fix

In `steerQueued`, when promoting a message and the session is `streaming`, call `bgProcessManager.abortAllWaits(sessionId)` — same as `deliverLiveSteer`. The underlying bash_bg process keeps running; only the wait long-poll is cancelled, freeing the agent to handle the steered prompt immediately.

## Test

New browser E2E `tests/e2e/ui/bg-wait-steer-flow.spec.ts`:

1. Send a busy prompt (`STAY_BUSY:5000`) → agent enters streaming, busy tool running.
2. Spawn a real bg process via REST + start its wait long-poll (timeout 60s).
3. Queue a follow-up via the textarea, click the Steer pill.
4. Assert: the wait resolves with `aborted: true` in **< 3s** (well before the 5s busy-tool `_end` event), the bg process is still `running`, and `STEER_RECEIVED` reaches the agent.

Without the fix, the assertion fails with `elapsed=4890ms` because the wait drains the busy-tool boundary instead of aborting on click. The 3000ms ceiling catches a regression cleanly.

## Verification

- \`npm run check\` ✅
- \`npm run build:server\` ✅
- New E2E spec passes (8.8s) with the fix; fails with elapsed=4890ms without it.
- Full \`npm run test:e2e\` suite: **837 passed**, 0 new failures (3 pre-existing flaky tests are unrelated — \`@quarantine\` and \`search-orphan-filter\`).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)