### PR TITLE
Restrict team tools to team-lead via group policy

### DIFF
--- a/defaults/roles/team-lead.yaml
+++ b/defaults/roles/team-lead.yaml
@@ -12,6 +12,8 @@ toolPolicies:
   gate_signal: always-allow
   gate_status: always-allow
   gate_inspect: always-allow
+  # Re-enable the Team tool group (default policy is `never` for non-leads).
+  Team: allow
 createdAt: 1773875507369
 updatedAt: 1775088361805
 promptTemplate: |

--- a/defaults/tool-group-policies.yaml
+++ b/defaults/tool-group-policies.yaml
@@ -17,3 +17,11 @@ mcp__playwright: never
 # Banana/Gemini. The external nano-banana MCP hard-codes provider behavior and
 # can drift from the configured session image model.
 mcp__nano-banana: never
+# Team management tools (team_spawn, team_dismiss, team_prompt, team_steer,
+# team_abort, team_complete, team_list) are team-lead-only. The team-lead role
+# overrides this group default with `Team: allow`. For non-team-lead agents,
+# `never` strips the tools from their allowedTools (and from their tool-docs
+# system prompt), avoiding context bloat and removing the temptation to spawn
+# agents from a worker session — where the tool wouldn't work anyway because
+# the team extension is only loaded for the team-lead session.
+Team: never

--- a/tests/role-team-tools-policy.test.ts
+++ b/tests/role-team-tools-policy.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit test enforcing the team-tools group-policy invariant.
+ *
+ * Design: only the team lead may call team management tools (team_spawn,
+ * team_dismiss, team_prompt, team_steer, team_abort, team_complete, team_list).
+ * The shipping `defaults/tool-group-policies.yaml` therefore defaults the
+ * `Team` group to `never`, and `defaults/roles/team-lead.yaml` overrides it
+ * back to `allow` via `toolPolicies.Team`.
+ *
+ * Without this invariant, every contributor agent (coder, reviewer, tester …)
+ * gets the team tools' system-prompt docs even though the team extension is
+ * only loaded for the team-lead session — pure context bloat plus a footgun
+ * that leads workers to attempt spawns that fail at runtime.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import YAML from "yaml";
+
+const DEFAULTS_DIR = path.resolve(import.meta.dirname, "..", "defaults");
+const ROLES_DIR = path.join(DEFAULTS_DIR, "roles");
+const GROUP_POLICIES_FILE = path.join(DEFAULTS_DIR, "tool-group-policies.yaml");
+const TEAM_TOOLS_DIR = path.join(DEFAULTS_DIR, "tools", "team");
+
+function loadGroupPolicies(): Record<string, string> {
+	const text = fs.readFileSync(GROUP_POLICIES_FILE, "utf-8");
+	return (YAML.parse(text) ?? {}) as Record<string, string>;
+}
+
+function loadRole(name: string): { toolPolicies?: Record<string, string> } {
+	const text = fs.readFileSync(path.join(ROLES_DIR, `${name}.yaml`), "utf-8");
+	return YAML.parse(text) as { toolPolicies?: Record<string, string> };
+}
+
+describe("team-tools group policy invariant", () => {
+	it("defaults/tool-group-policies.yaml defaults Team group to never", () => {
+		const policies = loadGroupPolicies();
+		assert.equal(
+			policies.Team,
+			"never",
+			"defaults/tool-group-policies.yaml must declare `Team: never` so non-lead agents never see team tools",
+		);
+	});
+
+	it("team-lead.yaml re-enables the Team group via toolPolicies.Team: allow", () => {
+		const role = loadRole("team-lead");
+		assert.equal(
+			role.toolPolicies?.Team,
+			"allow",
+			"team-lead.yaml must override the group default with `Team: allow` so the lead can spawn members",
+		);
+	});
+
+	it("every Team-group tool actually declares group: Team", () => {
+		// Sanity-check the assumption the `Team: never` policy relies on:
+		// each YAML file in defaults/tools/team/ must opt into the Team group.
+		const files = fs
+			.readdirSync(TEAM_TOOLS_DIR)
+			.filter((f) => f.endsWith(".yaml"));
+		assert.ok(files.length > 0, "expected team tool YAMLs in defaults/tools/team/");
+		for (const file of files) {
+			const text = fs.readFileSync(path.join(TEAM_TOOLS_DIR, file), "utf-8");
+			const def = YAML.parse(text) as { group?: string };
+			assert.equal(
+				def.group,
+				"Team",
+				`${file} must declare \`group: Team\` so the group-policy default applies`,
+			);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Mirror the `gate_signal` precedent (#440): the entire **Team** tool group (`team_spawn`, `team_dismiss`, `team_prompt`, `team_steer`, `team_abort`, `team_complete`, `team_list`) now defaults to `never` in `defaults/tool-group-policies.yaml`. The `team-lead` role overrides this back to `allow` via `toolPolicies.Team`.

## Why

- **Context bloat** — every contributor agent (coder, reviewer, tester, architect, …) was getting the team tools' system-prompt docs even though the team extension is only loaded for the team-lead session. The cascade in `computeEffectiveAllowedTools` now strips them from non-lead `allowedTools`, removing the docs from their prompt entirely.
- **Footgun** — workers occasionally attempted `team_spawn`, which fails at runtime because the extension is not registered for them. The policy now matches reality.
- **Capability hygiene** — only the lead can spawn members, mirroring the existing `gate_signal` restriction.

## Changes

- `defaults/tool-group-policies.yaml`: add `Team: never` with explanatory comment
- `defaults/roles/team-lead.yaml`: add `toolPolicies.Team: allow`
- `tests/role-team-tools-policy.test.ts`: lock the invariant (3 assertions: group default, team-lead override, every team-tool YAML declares `group: Team`)

## Verification

- \`npm run check\` ✓
- \`npm run test:unit\` ✓ (1007 passed; one unrelated UI timeout flake in `settings-models-tab-redesign.spec.ts` — passes in isolation on both this branch and master)
- New test passes: 3/3

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)