### PR TITLE
Fix worktree setup ENOENT on Windows without sh on PATH

### DIFF
--- a/src/server/agent/goal-manager.ts
+++ b/src/server/agent/goal-manager.ts
@@ -272,15 +272,13 @@ export class GoalManager {
 					// Non-fatal on failure (worktree is still usable). See worktree-setup.ts.
 					try {
 						const { runComponentSetups } = await import("../skills/worktree-setup.js");
-						const { execFile } = await import("node:child_process");
-						const { promisify } = await import("node:util");
-						const pExecFile = promisify(execFile);
+						const { execShellCommand } = await import("./shell-util.js");
 						await runComponentSetups({
 							components,
 							branchContainer: set.container,
 							primaryWorktreeRoot: goal.repoPath!,
 							exec: async (cmd, cwd, env) => {
-								await pExecFile("sh", ["-c", cmd], { cwd, env, timeout: 120_000 });
+								await execShellCommand(cmd, { cwd, env, timeout: 120_000 });
 							},
 						});
 					} catch (err) {
@@ -308,15 +306,13 @@ export class GoalManager {
 				if (components && components.length > 0) {
 					try {
 						const { runComponentSetups } = await import("../skills/worktree-setup.js");
-						const { execFile } = await import("node:child_process");
-						const { promisify } = await import("node:util");
-						const pExecFile = promisify(execFile);
+						const { execShellCommand } = await import("./shell-util.js");
 						await runComponentSetups({
 							components,
 							branchContainer: result.worktreePath,
 							primaryWorktreeRoot: goal.repoPath!,
 							exec: async (cmd, cwd, env) => {
-								await pExecFile("sh", ["-c", cmd], { cwd, env, timeout: 120_000 });
+								await execShellCommand(cmd, { cwd, env, timeout: 120_000 });
 							},
 						});
 					} catch (err) {

--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -574,15 +574,13 @@ export async function executeWorktreeAsync(
 		if (components.length > 0) {
 			try {
 				const { runComponentSetups } = await import("../skills/worktree-setup.js");
-				const { execFile } = await import("node:child_process");
-				const { promisify } = await import("node:util");
-				const pExecFile = promisify(execFile);
+				const { execShellCommand } = await import("./shell-util.js");
 				await runComponentSetups({
 					components,
 					branchContainer: worktreeCwd,
 					primaryWorktreeRoot: plan.repoPath!,
 					exec: async (cmd, cwd, env) => {
-						await pExecFile("sh", ["-c", cmd], { cwd, env, timeout: 120_000 });
+						await execShellCommand(cmd, { cwd, env, timeout: 120_000 });
 					},
 				});
 			} catch (err) {

--- a/src/server/agent/shell-util.ts
+++ b/src/server/agent/shell-util.ts
@@ -115,6 +115,9 @@ export function getVerificationShell(_command: string): ShellConfig {
  * installed). On Linux/macOS returns "sh".
  *
  * Use this instead of hardcoded "sh" for `execFile("sh", ["-c", cmd])` calls.
+ *
+ * Prefer `execShellCommand()` for new code — it handles cmd.exe's `/d /s /c`
+ * arg form when neither Git Bash nor `sh` is on PATH.
  */
 export function resolveShell(): string {
 	if (process.platform === "win32") {
@@ -129,4 +132,28 @@ export function resolveShell(): string {
 		}
 	}
 	return "sh";
+}
+
+/**
+ * Run a shell command via `execFile`, picking the right shell binary + args
+ * for the current platform via `getShellConfig()`. Use this in place of
+ * hardcoded `execFile("sh", ["-c", cmd], …)` calls — on Windows machines
+ * without Git Bash on PATH the literal "sh" binary doesn't exist and spawn
+ * fails with ENOENT (errno -4058), silently breaking pool / goal / staff /
+ * session worktree setup.
+ */
+export async function execShellCommand(
+	command: string,
+	opts: { cwd: string; env?: NodeJS.ProcessEnv; timeout?: number },
+): Promise<{ stdout: string; stderr: string }> {
+	const { execFile } = await import("node:child_process");
+	const { promisify } = await import("node:util");
+	const pExecFile = promisify(execFile);
+	const { shell, args } = getShellConfig();
+	return pExecFile(shell, [...args, command], {
+		cwd: opts.cwd,
+		env: opts.env,
+		timeout: opts.timeout,
+		windowsHide: true,
+	}) as Promise<{ stdout: string; stderr: string }>;
 }

--- a/src/server/agent/staff-manager.ts
+++ b/src/server/agent/staff-manager.ts
@@ -6,6 +6,7 @@ import type { SessionManager } from "./session-manager.js";
 import type { ProjectContextManager } from "./project-context-manager.js";
 import { createWorktree, cleanupWorktree } from "../skills/git.js";
 import { runComponentSetups } from "../skills/worktree-setup.js";
+import { execShellCommand } from "./shell-util.js";
 
 const execFile = promisify(execFileCb);
 
@@ -273,7 +274,7 @@ export class StaffManager {
 					branchContainer: wt,
 					primaryWorktreeRoot: staff.cwd,
 					exec: async (cmd, cwd, env) => {
-						await execFile("sh", ["-c", cmd], { cwd, env, timeout: 120_000 });
+						await execShellCommand(cmd, { cwd, env, timeout: 120_000 });
 					},
 				});
 			} catch (err) {

--- a/src/server/agent/worktree-pool.ts
+++ b/src/server/agent/worktree-pool.ts
@@ -31,6 +31,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { createWorktree, cleanupWorktree, shouldSkipRemotePush, createWorktreeSet, type WorktreeResult } from "../skills/git.js";
 import { runComponentSetups } from "../skills/worktree-setup.js";
+import { execShellCommand } from "./shell-util.js";
 import type { Component } from "./project-config-store.js";
 
 const execFile = promisify(execFileCb);
@@ -476,7 +477,7 @@ export class WorktreePool {
 							branchContainer: container,
 							primaryWorktreeRoot: this.repoPath,
 							exec: async (cmd, cwd, env) => {
-								await execFile("sh", ["-c", cmd], { cwd, env, timeout: 120_000 });
+								await execShellCommand(cmd, { cwd, env, timeout: 120_000 });
 							},
 						});
 					} catch (err) {


### PR DESCRIPTION
## Problem

When the worktree pool / goal manager / session setup / staff manager runs a component's `worktreeSetupCommand` (e.g. `npm ci --prefer-offline --no-audit --no-fund`), the spawn fails on Windows hosts that don't have Git Bash on PATH:

```
[harness] [worktree-setup] bobbit: failed (non-fatal): Error: spawn sh ENOENT
[harness]   errno: -4058,
[harness]   code: 'ENOENT',
[harness]   syscall: 'spawn sh',
[harness]   path: 'sh',
[harness]   spawnargs: [ '-c', 'npm ci --prefer-offline --no-audit --no-fund' ],
```

Because the failure is non-fatal, the pool still reports `Ready` — but freshly-claimed pool/goal/session/staff worktrees are missing `node_modules`, so the first command an agent runs hits `MODULE_NOT_FOUND` later.

## Root cause

Five sites hardcoded `execFile("sh", ["-c", cmd], …)`:

- `src/server/agent/worktree-pool.ts` (pool fill)
- `src/server/agent/session-setup.ts`
- `src/server/agent/goal-manager.ts` (single-repo + multi-repo branches)
- `src/server/agent/staff-manager.ts`

On Windows without Git Bash on PATH, the literal `sh` binary doesn't exist → `ENOENT (-4058)`. There's already a helper for this (`getShellConfig()` in `shell-util.ts`) but these call sites bypassed it.

## Fix

- Add `execShellCommand()` in `src/server/agent/shell-util.ts` — wraps `execFile` with `getShellConfig()` so the right shell + args are picked per platform (Git Bash with `-c` → `cmd.exe` with `/d /s /c` → `/bin/sh -c`).
- Route all five call sites through it.

## Verification

- `npm run check` — clean.
- `npm run test:unit` — 1359/1360 pass. The one failure (`tests/propose-project-validation.test.ts`) is a pre-existing flake unrelated to shell handling: passes when run individually.
- After restart on the affected Windows machine, `[worktree-setup] bobbit: ok` should appear instead of the ENOENT trace, and freshly-claimed worktrees will have `node_modules` populated.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)