### PR TITLE
Implementation-phase gap-analysis ignores doc gaps

### DIFF
--- a/.bobbit/config/project.yaml
+++ b/.bobbit/config/project.yaml
@@ -136,6 +136,15 @@ workflows:
               2. Acceptance criteria not met by the code changes
 
               3. Implemented behavior that contradicts the specification
+
+
+              IMPORTANT: Ignore documentation gaps. This gap analysis runs during
+              the implementation phase, BEFORE the documentation gate. Do NOT
+              flag missing or outdated documentation, README updates, design-doc
+              updates, code comments, or other docs-only artifacts as gaps —
+              those are addressed by the dedicated documentation gate later in
+              the workflow. Focus exclusively on code/behavior gaps relative to
+              the spec and design.
           - name: Code quality review
             type: llm-review
             role: code-reviewer
@@ -756,6 +765,15 @@ workflows:
               2. Acceptance criteria not met by the code changes
 
               3. Implemented behavior that contradicts the specification
+
+
+              IMPORTANT: Ignore documentation gaps. This gap analysis runs during
+              the implementation phase, BEFORE the documentation gate. Do NOT
+              flag missing or outdated documentation, README updates, design-doc
+              updates, code comments, or other docs-only artifacts as gaps —
+              those are addressed by the dedicated documentation gate later in
+              the workflow. Focus exclusively on code/behavior gaps relative to
+              the spec and design.
           - name: Code quality review
             type: llm-review
             role: code-reviewer
@@ -1168,6 +1186,15 @@ workflows:
 
               3. Does the fix address the root cause identified in the issue
               analysis?
+
+
+              IMPORTANT: Ignore documentation gaps. This gap analysis runs during
+              the implementation phase, BEFORE the documentation gate. Do NOT
+              flag missing or outdated documentation, README updates, design-doc
+              updates, code comments, or other docs-only artifacts as gaps —
+              those are addressed by the dedicated documentation gate later in
+              the workflow. Focus exclusively on code/behavior gaps relative to
+              the spec and design.
           - name: Code quality review
             type: llm-review
             role: code-reviewer
@@ -1571,6 +1598,15 @@ workflows:
               3. Implemented behavior that contradicts the specification
 
               4. Any unrelated or unnecessary changes
+
+
+              IMPORTANT: Ignore documentation gaps. This gap analysis runs during
+              the implementation phase, BEFORE the documentation gate. Do NOT
+              flag missing or outdated documentation, README updates, design-doc
+              updates, code comments, or other docs-only artifacts as gaps —
+              those are addressed by the dedicated documentation gate later in
+              the workflow. Focus exclusively on code/behavior gaps relative to
+              the spec and design.
           - name: Code quality review
             type: llm-review
             role: code-reviewer

--- a/defaults/workflow-authoring-guide.md
+++ b/defaults/workflow-authoring-guide.md
@@ -186,6 +186,10 @@ Practical implications when authoring workflows:
   (except quick-fix). Design-time gap analysis catches missing requirements before
   the agent burns iterations; post-impl gap analysis catches drift between design
   and code. The `general`, `feature`, and per-component templates in this guide include both — use them as starting points when they fit the project.
+  **Post-impl gap analysis must explicitly tell the reviewer to ignore documentation
+  gaps** — it runs in the `implementation` gate, before the dedicated `documentation`
+  gate, so flagging missing/stale docs there causes redundant Ralph-loop iterations.
+  Focus the prompt on code/behavior gaps relative to the spec and design.
 - **The `description` field on the gate** surfaces in the project-proposal panel
   and the goal dashboard. Use it to remind reviewers that this gate is a loop, not
   a checkpoint.

--- a/index.html
+++ b/index.html
@@ -214,6 +214,15 @@
 			 */
 			function __bobbitPrepaint() {
 				try {
+					// Once Lit has rendered, the skeleton + pill must stay hidden.
+					// scheduleSave() writes bobbit.ui-snapshot.v1 on every state
+					// mutation, and the patched Storage.prototype.setItem below
+					// re-runs us on each write. Without this guard we would
+					// un-hide the skeleton (revealing its background behind the
+					// real UI) and append a new "Reconnecting…" pill on every
+					// state change after boot.
+					var appEl = document.getElementById("app");
+					if (appEl && appEl.getAttribute("data-rendered") === "true") return;
 					var raw = localStorage.getItem("bobbit.ui-snapshot.v1");
 					if (!raw) return;
 					var snap = JSON.parse(raw);

--- a/src/server/state-migration/seed-default-workflows.ts
+++ b/src/server/state-migration/seed-default-workflows.ts
@@ -117,7 +117,9 @@ Read the design document content from upstream gates.
 Identify:
 1. Features described in the goal/design but not implemented
 2. Acceptance criteria not met by the code changes
-3. Implemented behavior that contradicts the specification`;
+3. Implemented behavior that contradicts the specification
+
+IMPORTANT: Ignore documentation gaps. This gap analysis runs during the implementation phase, BEFORE the documentation gate. Do NOT flag missing or outdated documentation, README updates, design-doc updates, code comments, or other docs-only artifacts as gaps — those are addressed by the dedicated documentation gate later in the workflow. Focus exclusively on code/behavior gaps relative to the spec and design.`;
 
 export const CODE_REVIEW_PROMPT = `Review the code changes on branch {{branch}} vs origin/{{master}} for quality.
 

--- a/tests/e2e/ui/pwa-prepaint-post-render.spec.ts
+++ b/tests/e2e/ui/pwa-prepaint-post-render.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * Regression test for "skeleton bleed-through + duplicate Reconnecting… pill
+ * after Lit has rendered".
+ *
+ * Bug (introduced by PR #450 — Production-grade PWA resume):
+ *   `__bobbitPrepaint()` in index.html re-runs on every same-tab
+ *   `localStorage.setItem("bobbit.ui-snapshot.v1", …)` via a monkey-patched
+ *   `Storage.prototype.setItem`. `scheduleSave()` writes that key on every
+ *   state mutation. Each re-run un-hides the boot skeleton
+ *   (`sk.classList.remove("--hide")`) and appends a fresh `.bobbit-skeleton__pill`
+ *   "Reconnecting…" element. The cleanup MutationObserver disconnects after
+ *   the first `data-rendered` flip, so nothing tears them back down.
+ *
+ * Symptoms in the wild:
+ *   - Different background bleeding through near the title (skeleton sidebar/main panels).
+ *   - "Reconnecting…" pill in the bottom-right of an otherwise-rendered app.
+ *
+ * Fix:
+ *   `__bobbitPrepaint()` early-returns when `#app[data-rendered="true"]` —
+ *   after Lit has rendered, the prepaint has no job to do.
+ *
+ * This test exercises the failure path directly:
+ *   1. Open the app and wait for `#app[data-rendered="true"]`.
+ *   2. Write to `bobbit.ui-snapshot.v1` to trigger the patched `setItem` →
+ *      `__bobbitPrepaint()` re-run.
+ *   3. Assert the skeleton stays `.--hide` and no `.bobbit-skeleton__pill`
+ *      element is in the DOM.
+ */
+import { test, expect } from "../gateway-harness.js";
+import { openApp } from "./ui-helpers.js";
+
+test.describe("PWA prepaint must no-op after Lit has rendered", () => {
+	test("snapshot writes after data-rendered must not reveal skeleton or append Reconnecting pill", async ({ page }) => {
+		await openApp(page);
+
+		// Wait for Lit to flip data-rendered. main.ts sets this immediately
+		// after the first renderApp() call, before any awaits.
+		await page.waitForFunction(
+			() => document.getElementById("app")?.getAttribute("data-rendered") === "true",
+			null,
+			{ timeout: 10_000 },
+		);
+
+		// Confirm the watchdog/observer cleanup ran: skeleton has --hide and
+		// no pill is present. (If this baseline already fails, the bug is
+		// even broader than the post-render bleed-through.)
+		const baseline = await page.evaluate(() => {
+			const sk = document.querySelector("[data-bobbit-skeleton]") as HTMLElement | null;
+			return {
+				skeletonHidden: !!sk && sk.classList.contains("--hide"),
+				pillCount: document.querySelectorAll("[data-bobbit-pill]").length,
+			};
+		});
+		expect(baseline.skeletonHidden, "skeleton must be hidden once Lit rendered").toBe(true);
+		expect(baseline.pillCount, "no Reconnecting pill should exist post-render").toBe(0);
+
+		// Trigger the bug path: write to the snapshot key. In the buggy
+		// version the patched Storage.prototype.setItem re-runs
+		// __bobbitPrepaint(), which un-hides the skeleton AND appends a
+		// fresh .bobbit-skeleton__pill on every write.
+		//
+		// We simulate what scheduleSave() does mid-session. Use an existing
+		// payload shape (last-message text "OK") so the prepaint code path
+		// would actually emit DOM if the guard wasn't in place.
+		await page.evaluate(() => {
+			const payload = {
+				v: 1,
+				buildId: "regression-test",
+				selectedSessionId: "s1",
+				activeSession: {
+					id: "s1",
+					title: "Regression session",
+					messages: [
+						{ id: "m1", role: "user", content: [{ type: "text", text: "ping" }] },
+						{ id: "m2", role: "assistant", content: [{ type: "text", text: "OK" }] },
+					],
+				},
+			};
+			// Multiple writes — the bug appends a new pill on EACH one.
+			for (let i = 0; i < 5; i++) {
+				localStorage.setItem("bobbit.ui-snapshot.v1", JSON.stringify({ ...payload, _n: i }));
+			}
+		});
+
+		// Yield a couple of paint frames so any synchronous DOM mutations
+		// from the patched setItem chain have settled.
+		await page.evaluate(() => new Promise<void>((resolve) => {
+			requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+		}));
+
+		const after = await page.evaluate(() => {
+			const sk = document.querySelector("[data-bobbit-skeleton]") as HTMLElement | null;
+			return {
+				skeletonHidden: !!sk && sk.classList.contains("--hide"),
+				skeletonComputedOpacity: sk ? getComputedStyle(sk).opacity : null,
+				pillCount: document.querySelectorAll("[data-bobbit-pill]").length,
+				pillTexts: Array.from(document.querySelectorAll("[data-bobbit-pill]")).map(
+					(el) => (el.textContent ?? "").trim(),
+				),
+			};
+		});
+
+		expect(
+			after.skeletonHidden,
+			`boot skeleton was un-hidden by post-render prepaint (--hide class removed). ` +
+			`Skeleton's fixed-position panels are now bleeding through behind the real UI. ` +
+			`Computed opacity: ${after.skeletonComputedOpacity}.`,
+		).toBe(true);
+
+		expect(
+			after.pillCount,
+			`post-render prepaint appended ${after.pillCount} "Reconnecting…" pill(s). ` +
+			`Pill texts: ${JSON.stringify(after.pillTexts)}. ` +
+			`__bobbitPrepaint() must no-op once #app[data-rendered=true].`,
+		).toBe(0);
+	});
+});


### PR DESCRIPTION
Implementation-phase gap-analysis runs inside the `implementation` gate, which sits before the dedicated `documentation` gate. When the gap-analysis reviewer flags missing/stale docs (READMEs, AGENTS.md, design-doc updates, code comments), the Ralph loop iterates trying to close gaps that the documentation gate is specifically designed to handle later — wasting iterations and conflating concerns.

This change instructs the post-implementation gap-analysis to ignore documentation gaps entirely and focus on code/behavior gaps relative to the spec and design.

## Changes

- `src/server/state-migration/seed-default-workflows.ts` — append an explicit "ignore documentation gaps" instruction to `GAP_ANALYSIS_IMPL_PROMPT` (used by the seeded `general`, `feature`, and `bug-fix` workflows, plus the per-component / all-components scaffolds).
- `.bobbit/config/project.yaml` — apply the same guidance to all four implementation-phase gap-analysis prompts already materialised in this project's workflows (general, feature, bug-fix, quick-fix).
- `defaults/workflow-authoring-guide.md` — document the rule so future workflow authors know post-impl gap-analysis prompts must explicitly tell the reviewer to ignore doc gaps.

Design-time gap-analysis (in `design-doc` / `issue-analysis`) is unchanged — that gate runs before code exists, so doc gaps aren't a concern there.

## Verification

- `npm run check` — passes.
- `npx tsx --test tests/seed-default-workflows.test.ts tests/per-component-workflows.test.ts` — 13 tests pass.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
