### PR TITLE
Pin LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,6 @@
-# Normalize all text files to LF in the repo, native on checkout
-* text=auto
+* text=auto eol=lf
 
-# Force specific line endings where required
-run        text eol=lf
+*.cmd      text eol=crlf
+*.bat      text eol=crlf
+*.ps1      text eol=crlf
 run.cmd    text eol=crlf
-*.sh       text eol=lf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,18 @@ Keyword index — full diagnostic walkthroughs live in [docs/debugging.md](docs/
 
 Primary branch is **`master`** (not `main`). Never create a `main` branch.
 
+### Line endings
+
+All text files in this repo are stored and checked out with **LF** line endings, pinned via `.gitattributes` (`* text=auto eol=lf`). Windows-native script files (`*.cmd`, `*.bat`, `*.ps1`) are the only exception and are checked out with CRLF.
+
+**Windows contributors:** the Git for Windows installer defaults to `core.autocrlf=true`, which can override `.gitattributes` and cause phantom "modified" entries in `git status` plus "LF will be replaced by CRLF" warnings. Disable it once globally:
+
+```bash
+git config --global core.autocrlf false
+```
+
+If you've already accumulated CRLF in your working tree, run `git checkout -- .` (or re-clone) to restore LF after changing the setting.
+
 ### Committing with a dirty working copy
 
 When asked to commit, other unstaged/staged changes may exist from another agent or the user. **Never discard, stash, or reset those changes.** Stage only the files you modified (`git add <your-files>`) and commit. If your changes overlap and can't be cleanly separated, ask the user.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,15 +165,24 @@ Primary branch is **`master`** (not `main`). Never create a `main` branch.
 
 ### Line endings
 
-All text files in this repo are stored and checked out with **LF** line endings, pinned via `.gitattributes` (`* text=auto eol=lf`). Windows-native script files (`*.cmd`, `*.bat`, `*.ps1`) are the only exception and are checked out with CRLF.
+All text files in this repo are stored and checked out with **LF** line endings, pinned via `.gitattributes` (`* text=auto eol=lf`). Windows-native script files (`*.cmd`, `*.bat`, `*.ps1`) are the only exception and are checked out with CRLF. LF everywhere else keeps diffs, hashes, and tooling output identical across Linux, macOS, Windows, and Docker — and avoids spurious "modified" churn when the same file is touched from different platforms.
 
-**Windows contributors:** the Git for Windows installer defaults to `core.autocrlf=true`, which can override `.gitattributes` and cause phantom "modified" entries in `git status` plus "LF will be replaced by CRLF" warnings. Disable it once globally:
+**Windows contributors:** the Git for Windows installer defaults to `core.autocrlf=true`, which rewrites LF→CRLF on checkout and overrides `.gitattributes`. Symptoms: phantom "modified" entries in `git status` even on a fresh checkout, and "LF will be replaced by CRLF" warnings on `git add`. Disable it once globally:
 
 ```bash
 git config --global core.autocrlf false
+# verify — should print `false` (or nothing)
+git config --get core.autocrlf
 ```
 
-If you've already accumulated CRLF in your working tree, run `git checkout -- .` (or re-clone) to restore LF after changing the setting.
+If you already have CRLF in your working tree from a previous checkout, renormalize after fixing the setting:
+
+```bash
+git rm --cached -r .
+git reset --hard
+```
+
+(or simply re-clone). A plain `git checkout -- .` is usually enough if `git status` is clean.
 
 ### Committing with a dirty working copy
 

--- a/tests/gitattributes-lf.test.ts
+++ b/tests/gitattributes-lf.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Guard test for `.gitattributes` line-ending policy.
+ *
+ * Motivation: on Windows with the Git for Windows default `core.autocrlf=true`,
+ * a bare `* text=auto` rule defers EOL policy to per-user config, producing
+ * CRLF in the working tree against LF blobs in the index. That causes phantom
+ * `git status` modifications and "LF will be replaced by CRLF" warnings.
+ *
+ * The fix pins `eol=lf` globally and opts Windows-script files (`.cmd`,
+ * `.bat`, `.ps1`) into CRLF explicitly. This test guards that policy.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const gitattributesPath = path.resolve(__dirname, "..", ".gitattributes");
+
+describe("gitattributes-lf-policy", () => {
+	const content = fs.readFileSync(gitattributesPath, "utf8");
+
+	it("contains global '* text=auto eol=lf' rule", () => {
+		assert.match(
+			content,
+			/^\s*\*\s+text=auto\s+eol=lf\s*$/m,
+			"gitattributes missing global eol=lf: expected a line matching `* text=auto eol=lf` to pin LF on checkout across all platforms",
+		);
+	});
+
+	it("does NOT contain a bare '* text=auto' line lacking eol=lf", () => {
+		assert.doesNotMatch(
+			content,
+			/^\s*\*\s+text=auto\s*$/m,
+			"gitattributes has bare '* text=auto' without eol=lf: this defers EOL policy to per-user core.autocrlf and causes phantom CRLF diffs on Windows",
+		);
+	});
+
+	it("contains explicit CRLF rule for *.cmd", () => {
+		assert.match(
+			content,
+			/^\s*\*\.cmd\s+text\s+eol=crlf\s*$/m,
+			"gitattributes missing CRLF rule for *.cmd: expected a line `*.cmd text eol=crlf`",
+		);
+	});
+
+	it("contains explicit CRLF rule for *.bat", () => {
+		assert.match(
+			content,
+			/^\s*\*\.bat\s+text\s+eol=crlf\s*$/m,
+			"gitattributes missing CRLF rule for *.bat: expected a line `*.bat text eol=crlf`",
+		);
+	});
+
+	it("contains explicit CRLF rule for *.ps1", () => {
+		assert.match(
+			content,
+			/^\s*\*\.ps1\s+text\s+eol=crlf\s*$/m,
+			"gitattributes missing CRLF rule for *.ps1: expected a line `*.ps1 text eol=crlf`",
+		);
+	});
+
+	it("does NOT contain legacy '*.sh text eol=lf' line", () => {
+		assert.doesNotMatch(
+			content,
+			/^\s*\*\.sh\s+text\s+eol=lf\s*$/m,
+			"gitattributes has redundant legacy '*.sh text eol=lf' line: now covered by the global '* text=auto eol=lf' rule",
+		);
+	});
+});


### PR DESCRIPTION
Fixes phantom \`git status\` modifications and \"LF will be replaced by CRLF\" warnings on Windows by pinning LF on checkout globally and explicitly opting Windows-script files into CRLF.

## Changes

- **`.gitattributes`**: replace `* text=auto` with `* text=auto eol=lf`; add explicit CRLF rules for `*.cmd`, `*.bat`, `*.ps1`, `run.cmd`; drop legacy `run text eol=lf` and `*.sh text eol=lf` (now covered by the global rule).
- **`tests/gitattributes-lf.test.ts`**: 6-assertion guard test that fails if the policy regresses.
- **`AGENTS.md`**: new \"Line endings\" section under \"Git conventions\" — explains the policy, tells Windows contributors to set \`git config --global core.autocrlf false\`, and documents recovery for already-CRLF working trees.

## Verification

- Build, type-check, unit tests, E2E tests: all pass.
- Guard test: 6/6 pass on the fix; failed on pre-fix `.gitattributes` (used as the reproducing test).
- Manual `git status` on Windows after fresh checkout: clean.
- `*.cmd` / `*.bat` / `*.ps1` retain CRLF on disk on Windows; all other text files are LF on every OS.

## Risk

Low. The renormalization commit produced no extra blob changes (repo was already mostly LF). Existing contributors with local checkouts may see a one-time diff on pull; \`git checkout -- .\` resolves it.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)