### PR TITLE
Fix flaky propose-project-validation test under suite contention

### DIFF
--- a/tests/propose-project-validation.test.ts
+++ b/tests/propose-project-validation.test.ts
@@ -12,6 +12,13 @@
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
 
+// Prevent seedProposal() from issuing real fetch() calls to a Bobbit gateway
+// when this test is run from inside a live Bobbit session (env-inherited).
+// In-flight fetches at --test-force-exit time trigger a Windows libuv
+// assertion (UV_HANDLE_CLOSING) that fails the file even though all
+// sub-tests pass. Must be set BEFORE the extension module is imported.
+delete process.env.BOBBIT_SESSION_ID;
+
 import extensionFactory from "../defaults/tools/proposals/extension.ts";
 
 type ToolReg = {


### PR DESCRIPTION
## Problem

`tests/propose-project-validation.test.ts` fails when run as part of the full unit suite on Windows, even though all 3 sub-tests pass:

```
✔ propose_project — happy path with no qa_ keys
✔ propose_project — pi-coding-agent calling convention (does not crash)
✔ propose_project — pi-coding-agent calling convention (legacy qa_*)
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 76
✖ tests\propose-project-validation.test.ts (3803.9824ms)
```

Standalone (`npx tsx --test tests/propose-project-validation.test.ts`) it passes 10/10. Under the full suite (with `--test-force-exit`) it fails 3/3.

## Cause

`seedProposal()` inside `defaults/tools/proposals/extension.ts` issues a real `fetch()` to the Bobbit gateway whenever `BOBBIT_SESSION_ID` is set. When the tests run from inside a live Bobbit session, that env var is inherited, so every `execute()` call leaks an in-flight fetch handle.

- Standalone: process exits fast, libuv never notices.
- Full suite: handles outlive `--test-force-exit` teardown → libuv aborts with `UV_HANDLE_CLOSING`.

This is why CI (where `BOBBIT_SESSION_ID` is unset) was always green.

## Fix

Delete `BOBBIT_SESSION_ID` before importing the extension. `seedProposal()` already has an early-return no-op path when the session id is missing, so all calls now short-circuit without opening a socket.

## Verification

- 10/10 standalone runs pass (~600ms).
- 3/3 full-suite runs pass (~23s, all 1359 tests green).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)