### PR TITLE
fix(steer): drain queued+steered rows after user-initiated abort

### DIFF
--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -1703,6 +1703,20 @@ export class SessionManager {
 				// case the queue was mutated mid-abort.
 				this._reconcileAfterAbort(session);
 				this.broadcastQueue(session);
+
+				// User-initiated abort: clear lastTurnErrored so the queue
+				// drains. The error stopReason on the aborted assistant
+				// message_end is a side-effect of the user pressing Stop, NOT
+				// a model malfunction. Queued steered messages represent fresh
+				// user intent that should dispatch immediately — leaving the
+				// flag set would park them until the next enqueuePrompt's
+				// implicit unstick, which is exactly the bug repro'd by
+				// tests/e2e/ui/steer-during-bash-tool.spec.ts (MOCK_ABORT_AS_ERROR).
+				// Reset the consecutive-error counter too — a Stop click is a
+				// successful user-controlled exit, not a streak of failures.
+				session.lastTurnErrored = false;
+				session.lastTurnErrorMessage = undefined;
+				session.consecutiveErrorTurns = 0;
 			}
 
 			session.status = "idle";

--- a/tests/e2e/mock-agent-core.mjs
+++ b/tests/e2e/mock-agent-core.mjs
@@ -1749,6 +1749,26 @@ export class MockAgentCore {
 				// In-process listeners are effectively ordered, so emitting here
 				// delivers events to all currently-subscribed handlers without
 				// racing a subsequent prompt's new abortController.
+				//
+				// Real-agent fidelity: when the user aborts an in-flight turn, the
+				// real Claude bridge surfaces the abort by emitting an assistant
+				// `message_end` with `stopReason:"error"` (rendered as "Request
+				// aborted" in the UI) BEFORE the terminal `agent_end`. This is the
+				// signal that flips `session.lastTurnErrored=true` in the server,
+				// which then gates `drainQueue` off in the `agent_end` handler.
+				// The MOCK_ABORT_AS_ERROR opt-in switches the mock to that shape so
+				// tests can exercise the error-gated drain path without changing
+				// the default abort behaviour for tests that rely on the clean
+				// (non-errored) abort.
+				if (this.env.MOCK_ABORT_AS_ERROR === "1") {
+					const abortedMsg = {
+						role: "assistant",
+						content: [],
+						stopReason: "error",
+						errorMessage: "Request aborted",
+					};
+					this.emit({ type: "message_end", message: abortedMsg });
+				}
 				this.emit({ type: "agent_end" });
 				this.emit({ type: "session_status", status: "idle" });
 				return { success: true };

--- a/tests/e2e/report/tier-2-5-reporter.ts
+++ b/tests/e2e/report/tier-2-5-reporter.ts
@@ -173,7 +173,7 @@ function renderReport(tests: CapturedTest[], ffmpegMissing: boolean): string {
 	const totalBeats = tests.reduce((a, t) => a + t.beats.length, 0);
 	const totalBytes = tests.reduce((a, t) => a + (t.videoBytes ?? 0), 0);
 	const banner = ffmpegMissing
-		? `<div style="background:#fff3cd;border:1px solid #ffe69c;border-radius:6px;padding:12px 16px;margin-bottom:18px;color:#664d03">
+		? `<div style="background:color-mix(in oklch, var(--warning) 18%, transparent);border:1px solid color-mix(in oklch, var(--warning) 45%, transparent);border-radius:6px;padding:12px 16px;margin-bottom:18px;color:var(--foreground)">
     <strong>ffmpeg not found.</strong> Videos and per-beat thumbnails were skipped.
     Install ffmpeg (<code>apt install ffmpeg</code> / <code>brew install ffmpeg</code> / <code>choco install ffmpeg</code>)
     or set <code>FFMPEG_PATH</code> to the binary path, then re-run with <code>RECORDSCREEN=1</code>.
@@ -183,37 +183,48 @@ function renderReport(tests: CapturedTest[], ffmpegMissing: boolean): string {
 <html><head><meta charset="utf-8"/>
 <title>Tier 2.5 — beat report</title>
 <style>
-  :root { --fg: #1a1a1a; --muted: #666; --bg: #f6f7fa; --card: #fff; --border: #dcdde2; --accent: #2256d1; }
-  body { font: 14px/1.45 system-ui, -apple-system, sans-serif; max-width: 1180px; margin: 24px auto; padding: 0 16px; color: var(--fg); background: var(--bg); }
+  /* Theme tokens are injected by Bobbit's preview bridge. Defensive fallbacks
+     for standalone open (file://) — kept light/neutral and overridden by
+     :root values from the bridge. See defaults/docs/html-rendering.md. */
+  :root {
+    --background: #f6f7fa;
+    --foreground: #1a1a1a;
+    --card: #ffffff;
+    --muted-foreground: #666;
+    --border: #dcdde2;
+    --primary: #2256d1;
+    --warning: #b58105;
+  }
+  body { font: 14px/1.45 system-ui, -apple-system, sans-serif; max-width: 1180px; margin: 24px auto; padding: 0 16px; color: var(--foreground); background: var(--background); }
   h1 { margin-top: 0; }
   .summary, .scenario { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 18px 20px; margin-bottom: 22px; }
   .summary table { border-collapse: collapse; width: 100%; }
-  .summary td { padding: 6px 12px; border-bottom: 1px solid #eee; }
-  .summary td:first-child { color: var(--muted); }
+  .summary td { padding: 6px 12px; border-bottom: 1px solid var(--border); }
+  .summary td:first-child { color: var(--muted-foreground); }
   .summary tr:last-child td { border-bottom: 0; }
   .scenario h2 { margin: 0 0 4px; font-size: 18px; }
-  .scenario .meta { color: var(--muted); font-size: 12px; margin-bottom: 12px; font-variant-numeric: tabular-nums; }
-  video { display: block; width: 100%; max-width: 100%; height: auto; background: #000; border-radius: 4px; border: 1px solid #ccc; }
+  .scenario .meta { color: var(--muted-foreground); font-size: 12px; margin-bottom: 12px; font-variant-numeric: tabular-nums; }
+  video { display: block; width: 100%; max-width: 100%; height: auto; background: #000; border-radius: 4px; border: 1px solid var(--border); }
   .num { font-variant-numeric: tabular-nums; }
-  .missing { color: #b00; font-weight: 600; }
+  .missing { color: var(--negative, #b00); font-weight: 600; }
   .toc { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 20px; }
-  .toc a { padding: 4px 10px; border: 1px solid var(--border); border-radius: 999px; background: var(--card); color: var(--accent); text-decoration: none; font-size: 12px; }
-  .toc a:hover { border-color: var(--accent); }
-  kbd { background: #eee; border: 1px solid #ccc; border-bottom-width: 2px; border-radius: 3px; padding: 1px 5px; font-family: ui-monospace, monospace; font-size: 0.85em; }
-  .player-tip { color: var(--muted); font-size: 12px; margin-top: 6px; }
+  .toc a { padding: 4px 10px; border: 1px solid var(--border); border-radius: 999px; background: var(--card); color: var(--primary); text-decoration: none; font-size: 12px; }
+  .toc a:hover { border-color: var(--primary); }
+  kbd { background: color-mix(in oklch, var(--foreground) 10%, transparent); border: 1px solid var(--border); border-bottom-width: 2px; border-radius: 3px; padding: 1px 5px; font-family: ui-monospace, monospace; font-size: 0.85em; }
+  .player-tip { color: var(--muted-foreground); font-size: 12px; margin-top: 6px; }
   .beats { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 12px; margin-top: 14px; }
-  .beat { border: 1px solid var(--border); border-radius: 6px; background: #fafafa; cursor: pointer; padding: 6px; transition: border-color 100ms, transform 100ms; }
-  .beat:hover { border-color: var(--accent); transform: translateY(-1px); }
-  .beat.active { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(34,86,209,0.18); }
+  .beat { border: 1px solid var(--border); border-radius: 6px; background: color-mix(in oklch, var(--card) 70%, var(--background)); cursor: pointer; padding: 6px; transition: border-color 100ms, transform 100ms; }
+  .beat:hover { border-color: var(--primary); transform: translateY(-1px); }
+  .beat.active { border-color: var(--primary); box-shadow: 0 0 0 2px color-mix(in oklch, var(--primary) 35%, transparent); }
   .beat img { display: block; width: 100%; height: auto; border-radius: 3px; }
-  .beat .lbl { font-size: 12px; color: var(--fg); margin-top: 6px; line-height: 1.3; }
-  .beat .nt { font-variant-numeric: tabular-nums; color: var(--muted); margin-right: 4px; }
+  .beat .lbl { font-size: 12px; color: var(--foreground); margin-top: 6px; line-height: 1.3; }
+  .beat .nt { font-variant-numeric: tabular-nums; color: var(--muted-foreground); margin-right: 4px; }
 </style>
 </head>
 <body>
 <h1>Tier 2.5 — beat report</h1>
 ${banner}
-<p style="color:var(--muted);max-width:780px">
+<p style="color:var(--muted-foreground);max-width:780px">
   Each test below captures a labeled <em>beat</em> at every meaningful UX moment.
   The video holds each beat for ${BEAT_HOLD_MS} ms so you can read the labels
   and observe each state. Click any thumbnail to seek the video to that beat.

--- a/tests/e2e/ui/steer-during-bash-tool.spec.ts
+++ b/tests/e2e/ui/steer-during-bash-tool.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * Browser E2E (Tier 2.5) — repro for the bug observed on master after the
+ * steer-subsystem rewrite (commit 08dd4424).
+ *
+ * Real-session symptom: user runs a long bash, queues two messages, marks
+ * them as steered, clicks Stop. The agent appears to receive nothing — the
+ * steered texts only get processed once a fresh prompt is sent.
+ *
+ * Why the default mock path passes (and why this test wires MOCK_ABORT_AS_ERROR=1):
+ * the real Claude bridge surfaces an aborted in-flight turn as an assistant
+ * `message_end` with `stopReason:"error"` BEFORE the terminal `agent_end`.
+ * That sets `session.lastTurnErrored=true`, which gates `drainQueue` off in
+ * the `agent_end` handler (session-manager.ts ~line 1715). Steered rows
+ * sitting in `promptQueue` therefore stay parked until the next user prompt
+ * implicitly unsticks the session.
+ *
+ * The default mock emits a clean `agent_end` on abort (no error stopReason),
+ * so existing tests don't exercise this path. The MOCK_ABORT_AS_ERROR=1 env
+ * switches the mock to real-agent-shape abort behaviour.
+ *
+ * Run with capture on:
+ *   RECORDSCREEN=1 npm run test:e2e -- steer-during-bash-tool.spec.ts
+ */
+import { test, expect } from "./fixtures.js";
+import {
+	createSession,
+	waitForHealth,
+	waitForSessionStatus,
+} from "../e2e-setup.js";
+import { openApp, sendMessage } from "./ui-helpers.js";
+
+test.describe("steer subsystem — queue + steer + abort with errored agent_end", () => {
+	test.beforeAll(async () => {
+		// Switch the in-process mock bridge to real-agent-shape abort: the
+		// abort handler emits a `message_end` with `stopReason:"error"` before
+		// `agent_end`, mirroring what the real Claude bridge does.
+		process.env.MOCK_ABORT_AS_ERROR = "1";
+		await waitForHealth();
+	});
+
+	test.afterAll(() => {
+		delete process.env.MOCK_ABORT_AS_ERROR;
+	});
+
+	test("queued+steered messages must drain after Stop without requiring a fresh user prompt", async ({ page, rec }) => {
+		const sessionId = await createSession();
+		await waitForSessionStatus(sessionId, "idle");
+
+		await openApp(page);
+		await page.evaluate((id) => { window.location.hash = `#/session/${id}`; }, sessionId);
+		await expect(page.locator("textarea").first()).toBeVisible({ timeout: 15_000 });
+		await rec.capture("Empty composer ready");
+
+		// 1. Long busy bash.
+		await sendMessage(page, "STAY_BUSY:30000 working");
+		await expect(page.locator("button[title='Stop streaming']")).toBeVisible({ timeout: 10_000 });
+		await rec.capture("Agent busy — bash tool running");
+
+		// 2. Queue two messages.
+		const textarea = page.locator("textarea").first();
+		await textarea.fill("Steer1");
+		await textarea.press("Enter");
+		await expect(page.locator(".queue-pill")).toHaveCount(1, { timeout: 5_000 });
+		await textarea.fill("Steer2");
+		await textarea.press("Enter");
+		await expect(page.locator(".queue-pill")).toHaveCount(2, { timeout: 5_000 });
+		await rec.capture("Two messages queued");
+
+		// 3. Mark both as steered.
+		await page.locator(".queue-pill .steer-btn").first().click();
+		await expect(page.locator(".sent-indicator")).toHaveCount(1, { timeout: 5_000 });
+		await page.locator(".queue-pill .steer-btn").first().click();
+		await expect(page.locator(".sent-indicator")).toHaveCount(2, { timeout: 5_000 });
+		await rec.capture("Both pills steered");
+
+		// 4. Stop.
+		await page.locator("button[title='Stop streaming']").click();
+		await rec.capture("Stop clicked — abort with error stopReason");
+
+		// 5. Both steered texts must reach the agent without any further user
+		//    input. Queued+steered rows that sat in promptQueue while the
+		//    abort fired must be drained automatically once the bridge settles.
+		//    A failure here means: lastTurnErrored=true is gating drainQueue
+		//    off, and the rows stay parked until a fresh enqueuePrompt does
+		//    the implicit unstick.
+		await expect(
+			page.locator("user-message").filter({ hasText: "Steer1" }).first(),
+		).toBeVisible({ timeout: 15_000 });
+		await rec.capture("Steer1 user-message rendered");
+
+		await expect(
+			page.locator("user-message").filter({ hasText: "Steer2" }).first(),
+		).toBeVisible({ timeout: 5_000 });
+		await rec.capture("Steer2 user-message rendered");
+
+		await expect(page.locator(".queue-pill")).toHaveCount(0, { timeout: 10_000 });
+		await rec.capture("Queue drained — bug not present");
+	});
+});


### PR DESCRIPTION
## Bug

After the steer-subsystem rewrite (#473) merged, queued + steered messages stayed parked in the prompt queue when the user pressed **Stop** during a long-running bash tool. They only got delivered to the agent once the user typed and sent a fresh prompt. User-visible symptom: "I had to send another message before my steered messages reached the agent."

## Root cause

The real Claude bridge surfaces an aborted in-flight turn as an assistant `message_end` with `stopReason:"error"` (rendered as *Request aborted*) **before** the terminal `agent_end`. That sets `session.lastTurnErrored=true`, which gated `drainQueue` off in the `agent_end` handler — by design, to avoid replaying a queue against a model that just failed.

But a user-initiated abort isn't a model failure. The user pressed Stop deliberately, and any queued + steered messages represent fresh intent that should dispatch immediately.

Existing tests passed because the in-process mock emitted a clean (non-errored) `agent_end` on abort, so the gating branch was never exercised.

## Fix

In the `agent_end` handler, when `wasAborting` is true, clear:
- `session.lastTurnErrored`
- `session.lastTurnErrorMessage`
- `session.consecutiveErrorTurns`

This lets `drainQueue` run on the same tick, picking up any queued steered rows and dispatching them as a batch via `_dispatchSteer`.

## Tests

- **New mock opt-in** `MOCK_ABORT_AS_ERROR=1` switches the in-process mock's abort handler to emit the real-agent shape (`message_end` with `stopReason:"error"` before `agent_end`). Default behaviour is unchanged so existing tests are unaffected.
- **New Tier 2.5 regression test** `tests/e2e/ui/steer-during-bash-tool.spec.ts` drives the exact user flow: long bash + queue 2 + Steer both + Stop, asserts both `<user-message>` rows render and the queue drains without further user input. Fails on master (pills stuck with "Sent" badge, no user-messages), passes with the fix.
- All other steer / abort E2E tests still pass: `queue-ui.spec.ts` (PI-10, PI-10b), `bg-wait-steer-flow.spec.ts`, `bg-wait-steer-stop-flow.spec.ts`, `abort-status-e2e.spec.ts` (PI-25, PI-25b, PI-25c).
- `npm run check` clean.

## Drive-by

`tests/e2e/report/tier-2-5-reporter.ts` previously hardcoded a light-only `--fg` / `--bg` / `--accent` palette and ignored the preview-pane theme bridge — the beat report was unreadable in dark mode. Now consumes Bobbit's standard theme tokens (`--background`, `--foreground`, `--card`, `--muted-foreground`, `--border`, `--primary`, `--warning`) per [`defaults/docs/html-rendering.md`](defaults/docs/html-rendering.md), with defensive `:root` fallbacks for standalone `file://` opens.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)