### PR TITLE
Fix preview reopen stale panel

### DIFF
--- a/src/ui/tools/renderers/PreviewRenderer.ts
+++ b/src/ui/tools/renderers/PreviewRenderer.ts
@@ -179,12 +179,10 @@ export class PreviewOpenRenderer implements ToolRenderer<PreviewOpenParams, any>
 				});
 				if (!patchResp.ok) throw new Error(`PATCH failed: ${patchResp.status}`);
 
-				// 4. v3: mount is already populated server-side; the side panel
-				//        will pick it up via SSE. Nothing else to push.
-				//    v1/v2: re-stamp the per-session preview mount via the new
-				//        unified endpoint (`/api/preview/mount`). WP-G's deletion
-				//        of the legacy `/api/preview` route doesn't break this
-				//        path because we're already on the new endpoint.
+				// 4. v3: mount is already populated server-side; v1/v2: re-stamp
+				//    the per-session preview mount via `/api/preview/mount`.
+				let entryFromPost: string | undefined;
+				let mtimeFromPost: number | undefined;
 				if (parsed.kind !== "preview") {
 					const postBody: Record<string, unknown> = parsed.kind === "file"
 						? { file: parsed.path }
@@ -201,6 +199,34 @@ export class PreviewOpenRenderer implements ToolRenderer<PreviewOpenParams, any>
 						}
 						throw new Error(`POST failed: ${postResp.status}`);
 					}
+					try {
+						const data = await postResp.json();
+						if (typeof data?.entry === "string" && data.entry) entryFromPost = data.entry;
+						if (typeof data?.mtime === "number") mtimeFromPost = data.mtime;
+					} catch { /* ignore — body parse is best-effort */ }
+				}
+
+				// 5. Imperatively refresh the preview side-panel client-side.
+				//    SSE only fires on new mount writes — for v3 reopens the
+				//    mount already exists so no SSE arrives. Bump the mtime to
+				//    force the iframe to reload (its src includes `#mtime=<n>`
+				//    as a cache buster) and set the entry from the snapshot URL.
+				try {
+					const { state: appState, renderApp } = await import("../../../app/state.js");
+					let entry = entryFromPost;
+					if (!entry && parsed.kind === "preview") {
+						entry = parsed.entry;
+						if (!entry && typeof parsed.url === "string") {
+							// parsed.url is `/preview/<sid>/<entry>` — extract <entry>.
+							const m = /^\/preview\/[^/]+\/(.+)$/.exec(parsed.url);
+							if (m) entry = m[1];
+						}
+					}
+					if (entry) (appState as any).previewPanelEntry = entry;
+					(appState as any).previewPanelMtime = mtimeFromPost ?? Date.now();
+					renderApp();
+				} catch {
+					/* state import failure shouldn't block the success animation */
 				}
 
 				btn.textContent = "Opened ✓";

--- a/tests/e2e/ui/preview-reopen.spec.ts
+++ b/tests/e2e/ui/preview-reopen.spec.ts
@@ -300,7 +300,6 @@ test.describe("Reopenable preview widgets (browser E2E)", () => {
 
 		// Idempotence: clicking Open on A again still keeps entry == A and bumps mtime.
 		const mtimeAfterA = st.previewPanelMtime;
-		await new Promise((r) => setTimeout(r, 5));
 		await page.locator("#slot-a [data-preview-open-btn]").click();
 		await expect(page.locator("#slot-a [data-preview-open-btn]")).toHaveText(/Opened/, { timeout: 3000 });
 		st = await page.evaluate(() => (window as any).__getPreviewState());

--- a/tests/e2e/ui/preview-reopen.spec.ts
+++ b/tests/e2e/ui/preview-reopen.spec.ts
@@ -40,6 +40,7 @@ test.beforeAll(() => {
 
 const PAGE = `file://${FIXTURE}`;
 const MARKER = "__preview_snapshot_v1__\n";
+const MARKER_V3 = "__preview_snapshot_v3__\n";
 
 async function gotoAndWait(page: any) {
 	await page.goto(PAGE);
@@ -189,6 +190,123 @@ test.describe("Reopenable preview widgets (browser E2E)", () => {
 		const post = calls.find((c: any) => c.method === "POST" && c.url.includes("/api/preview"));
 		expect(post).toBeTruthy();
 		expect(JSON.parse(post.body).html).toBe(htmlA);
+	});
+
+	test("v3 reopen imperatively refreshes preview panel state (stale-panel fix)", async ({ page }) => {
+		// Regression test: clicking Open on a v3-snapshot preview_open card must
+		// update state.previewPanelEntry / state.previewPanelMtime imperatively,
+		// because the SSE channel only fires on new mount writes — v3 reopens
+		// reuse the existing mount and would otherwise leave the panel stale.
+		await gotoAndWait(page);
+
+		const sid = "22222222-2222-2222-2222-222222222222";
+		const entryA = "index-A.html";
+		const entryB = "index-B.html";
+		const snapA = MARKER_V3 + JSON.stringify({ kind: "preview", url: `/preview/${sid}/${entryA}`, path: `/state/preview/${sid}/${entryA}`, entry: entryA });
+		const snapB = MARKER_V3 + JSON.stringify({ kind: "preview", url: `/preview/${sid}/${entryB}`, path: `/state/preview/${sid}/${entryB}`, entry: entryB });
+
+		function makeV3Result(text: string, toolCallId: string) {
+			return {
+				role: "toolResult",
+				toolCallId,
+				toolName: "preview_open",
+				isError: false,
+				content: [
+					{ type: "text", text: "Preview panel is open and will auto-update." },
+					{ type: "text", text },
+				],
+				timestamp: Date.now(),
+			};
+		}
+
+		await page.evaluate(() => {
+			const container = document.getElementById("container")!;
+			container.innerHTML = '<div id="slot-a"></div><div id="slot-b"></div>';
+		});
+
+		await page.evaluate(
+			([sid, snapA, snapB]) => {
+				const w = window as any;
+				w.__renderPreview(
+					document.getElementById("slot-a")!,
+					{ html: "<p>A</p>" },
+					{
+						role: "toolResult",
+						toolCallId: "tool-A",
+						toolName: "preview_open",
+						isError: false,
+						content: [
+							{ type: "text", text: "Preview panel is open and will auto-update." },
+							{ type: "text", text: snapA },
+						],
+						timestamp: Date.now(),
+					},
+					false,
+					{ sessionId: sid, toolUseId: "tool-A" },
+				);
+				w.__renderPreview(
+					document.getElementById("slot-b")!,
+					{ html: "<p>B</p>" },
+					{
+						role: "toolResult",
+						toolCallId: "tool-B",
+						toolName: "preview_open",
+						isError: false,
+						content: [
+							{ type: "text", text: "Preview panel is open and will auto-update." },
+							{ type: "text", text: snapB },
+						],
+						timestamp: Date.now(),
+					},
+					false,
+					{ sessionId: sid, toolUseId: "tool-B" },
+				);
+			},
+			[sid, snapA, snapB] as const,
+		);
+
+		await page.evaluate(async () => {
+			await (window as any).__resetPreviewState();
+			(window as any).__resetFetchCalls();
+		});
+
+		// Simulate the user already having previewed B (panel currently shows B).
+		await page.locator("#slot-b [data-preview-open-btn]").click();
+		await expect(page.locator("#slot-b [data-preview-open-btn]")).toHaveText(/Opened/, { timeout: 3000 });
+		let st = await page.evaluate(() => (window as any).__getPreviewState());
+		expect(st.previewPanelEntry).toBe(entryB);
+		const mtimeAfterB = st.previewPanelMtime;
+		expect(mtimeAfterB).toBeGreaterThan(0);
+
+		// v3 reopen MUST NOT POST to /api/preview/mount — server already has the mount.
+		let calls = await page.evaluate(() => (window as any).__getFetchCalls());
+		const postsB = calls.filter((c: any) => c.method === "POST" && c.url.includes("/api/preview/mount"));
+		expect(postsB.length).toBe(0);
+
+		// Now click Open on the FIRST card (A). Bug repro: panel state stays at B.
+		await page.evaluate(() => (window as any).__resetFetchCalls());
+		await page.locator("#slot-a [data-preview-open-btn]").click();
+		await expect(page.locator("#slot-a [data-preview-open-btn]")).toHaveText(/Opened/, { timeout: 3000 });
+
+		st = await page.evaluate(() => (window as any).__getPreviewState());
+		expect(st.previewPanelEntry).toBe(entryA);
+		expect(st.previewPanelMtime).toBeGreaterThanOrEqual(mtimeAfterB);
+
+		calls = await page.evaluate(() => (window as any).__getFetchCalls());
+		const postsA = calls.filter((c: any) => c.method === "POST" && c.url.includes("/api/preview/mount"));
+		expect(postsA.length).toBe(0);
+		const patchA = calls.filter((c: any) => c.method === "PATCH" && c.url.includes("/api/sessions/"));
+		expect(patchA.length).toBeGreaterThanOrEqual(1);
+
+		// Idempotence: clicking Open on A again still keeps entry == A and bumps mtime.
+		const mtimeAfterA = st.previewPanelMtime;
+		await new Promise((r) => setTimeout(r, 5));
+		await page.locator("#slot-a [data-preview-open-btn]").click();
+		await expect(page.locator("#slot-a [data-preview-open-btn]")).toHaveText(/Opened/, { timeout: 3000 });
+		st = await page.evaluate(() => (window as any).__getPreviewState());
+		expect(st.previewPanelEntry).toBe(entryA);
+		expect(st.previewPanelMtime).toBeGreaterThanOrEqual(mtimeAfterA);
+		void makeV3Result;
 	});
 
 	test("archived fallback: legacy single-block preview_open renders disabled button", async ({ page }) => {

--- a/tests/fixtures/preview-renderer-entry.ts
+++ b/tests/fixtures/preview-renderer-entry.ts
@@ -20,6 +20,18 @@ function renderPreview(
 	const { state } = await import("../../src/app/state.js");
 	(state as any).remoteAgent = { state: { messages } };
 };
+(window as any).__getPreviewState = async () => {
+	const { state } = await import("../../src/app/state.js");
+	return {
+		previewPanelEntry: (state as any).previewPanelEntry,
+		previewPanelMtime: (state as any).previewPanelMtime,
+	};
+};
+(window as any).__resetPreviewState = async () => {
+	const { state } = await import("../../src/app/state.js");
+	(state as any).previewPanelEntry = "";
+	(state as any).previewPanelMtime = 0;
+};
 (window as any).__getFetchCalls = () => (window as any).__fetchCalls || [];
 (window as any).__resetFetchCalls = () => {
 	(window as any).__fetchCalls = [];


### PR DESCRIPTION
## Problem

Clicking **Open** on a `preview_open` tool card in chat showed the success animation ("Opened ✓") but the preview side-panel did not refresh — it stayed empty (`No preview yet.`) or kept showing the previous HTML from an earlier `preview_open`. Navigating away from the session and back fixed it.

## Root cause

`src/ui/tools/renderers/PreviewRenderer.ts` `onClick` for v3 snapshots PATCHed `/api/sessions/:id { preview: true }` and then bailed out, expecting SSE `preview-changed` to refresh the panel. But the SSE channel only emits on **new mount writes** — v3 reopens reuse the existing mount, so no SSE fired and `startPreviewPolling()` short-circuited (`currentSid === sid && es`). The panel kept its stale `state.previewPanelEntry` / `previewPanelMtime`.

## Fix (approach A — minimal, client-only)

After the PATCH succeeds (v3), and after the v1/v2 POST to `/api/preview/mount` succeeds, imperatively refresh the panel:

- Parse the entry from `parsed.entry` / `parsed.url` / POST response.
- Set `state.previewPanelEntry = entry; state.previewPanelMtime = Date.now()`.
- Call `renderApp()` — the iframe `src` includes `#mtime=<n>` as a cache buster, so it reloads.

For v1/v2, the POST also writes the mount → SSE fires; the imperative set is idempotent.

No server-side changes; snapshot marker contract preserved (v3 only for new emissions; v1/v2 read-only).

## Files

- `src/ui/tools/renderers/PreviewRenderer.ts` — imperative refresh after PATCH / POST.
- `tests/e2e/ui/preview-reopen.spec.ts` — v3 stale-panel regression test (two cards, click B then A; assert state flips back; verify no POST to `/api/preview/mount` for v3 reopens; idempotence on repeat clicks).
- `tests/fixtures/preview-renderer-entry.ts` — exposed `__getPreviewState` / `__resetPreviewState` test helpers.

## Verification

- `npm run check`: pass
- `npm run test:unit`: 1014/1015 pass
- `npx playwright test tests/e2e/ui/preview-reopen.spec.ts`: 4/4 pass (verified the new test fails without the fix)

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)