### PR TITLE
Speed up Re-attempt flow

### DIFF
--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -2461,14 +2461,39 @@ async function refreshPrStatusForSession(sessionId: string): Promise<void> {
 // ============================================================================
 
 export async function startReattempt(goalId: string): Promise<void> {
-	const res = await gatewayFetch("/api/sessions", {
-		method: "POST",
-		body: JSON.stringify({
-			assistantType: "goal",
-			reattemptGoalId: goalId,
-		}),
-	});
-	if (!res.ok) throw new Error(`Failed: ${res.status}`);
-	const { id } = await res.json();
-	await connectToSession(id, false, { assistantType: "goal" });
+	if (state.creatingSession) return;
+	// Pre-fill preview project/cwd from the original goal so the proposal panel
+	// binds to the correct project immediately and avoids a brief
+	// "No project selected for this goal" flash on connect.
+	const goal = state.goals.find(g => g.id === goalId);
+	const project = goal ? state.projects.find(p => p.id === goal.projectId) : undefined;
+	state.creatingSession = true;
+	state.creatingSessionForGoalId = goalId;
+	if (goal && goal.projectId) state.previewProjectId = goal.projectId;
+	if (project && !state.previewCwdEdited) state.previewCwd = project.rootPath;
+	renderApp();
+	try {
+		const res = await gatewayFetch("/api/sessions", {
+			method: "POST",
+			body: JSON.stringify({
+				assistantType: "goal",
+				reattemptGoalId: goalId,
+			}),
+		});
+		if (!res.ok) throw new Error(`Session creation failed: ${res.status}`);
+		const { id } = await res.json();
+		// Clear creatingSession before connecting — connectToSession handles its
+		// own loading state via connectingSessionId, and we want the user to see
+		// the chat panel (with textarea) immediately, not a loading spinner.
+		state.creatingSession = false;
+		state.creatingSessionForGoalId = null;
+		await connectToSession(id, false, { assistantType: "goal" });
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		showConnectionError("Failed to re-attempt goal", msg);
+	} finally {
+		state.creatingSession = false;
+		state.creatingSessionForGoalId = null;
+		renderApp();
+	}
 }


### PR DESCRIPTION
Speeds up the **Re-attempt Goal** flow so that clicking the button (sidebar trash-button neighbour or goal dashboard) feels as instant as **+ New Goal**. Previously the user stayed on the previous screen with no feedback until the POST round-trip completed.

## Fix

`startReattempt()` in `src/app/session-manager.ts` now mirrors the loading-state pattern of `createGoalAssistantSession()`:

1. **Re-entry guard** on `state.creatingSession` — no double POST on rapid clicks.
2. **Loading flag set BEFORE the POST** (`state.creatingSession = true; renderApp()`) — main pane immediately swaps to the bouncing-bobbit loading animation.
3. **Preview pre-fill** — resolves the original goal and sets `state.previewProjectId` from `goal.projectId` (and `previewCwd` from the project's `rootPath`) so the proposal panel binds correctly on connect, eliminating a brief 'No project selected for this goal' flash.
4. **try/catch/finally** — failures surface via `showConnectionError` instead of an unhandled rejection; `creatingSession` always cleared.

No server changes — `POST /api/sessions { reattemptGoalId }` already inherits cwd/projectId from the original goal.

## Verification

- `npm run check` — passes
- `npm run test:unit` — 1573 Node tests + 1013 Playwright tests pass
- Build + type-check + unit + E2E + gap-analysis + code-quality LLM review (implementation gate) — all passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)