### PR TITLE
Simplify Re-attempt loader: drop inline sidebar text

### DIFF
--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -2468,7 +2468,6 @@ export async function startReattempt(goalId: string): Promise<void> {
 	const goal = state.goals.find(g => g.id === goalId);
 	const project = goal ? state.projects.find(p => p.id === goal.projectId) : undefined;
 	state.creatingSession = true;
-	state.creatingSessionForGoalId = goalId;
 	if (goal && goal.projectId) state.previewProjectId = goal.projectId;
 	if (project && !state.previewCwdEdited) state.previewCwd = project.rootPath;
 	renderApp();
@@ -2486,14 +2485,12 @@ export async function startReattempt(goalId: string): Promise<void> {
 		// own loading state via connectingSessionId, and we want the user to see
 		// the chat panel (with textarea) immediately, not a loading spinner.
 		state.creatingSession = false;
-		state.creatingSessionForGoalId = null;
 		await connectToSession(id, false, { assistantType: "goal" });
 	} catch (err) {
 		const msg = err instanceof Error ? err.message : String(err);
 		showConnectionError("Failed to re-attempt goal", msg);
 	} finally {
 		state.creatingSession = false;
-		state.creatingSessionForGoalId = null;
 		renderApp();
 	}
 }


### PR DESCRIPTION
Follow-up to #489. That PR made Re-attempt feel instant via a full-screen bouncing-bobbit loader, but also added an inline 'Creating…' text row under the goal in the sidebar via `state.creatingSessionForGoalId`. The inline text is redundant (the full-screen loader already provides clear feedback), easy to miss, and inconsistent with the + New Goal flow which only sets `creatingSession`.

Re-attempt navigates away to a fresh assistant session — same as + New Goal — so it should behave the same. This drops the three `creatingSessionForGoalId` assignments in `startReattempt()` so it structurally matches `createGoalAssistantSession`.

The flag stays in state and is still used by `createAndConnectSession` (sidebar '+' button on existing goal), which is the correct pattern there because the user stays in current context.

## Changes
- `src/app/session-manager.ts` — 3 deletions in `startReattempt()`

## Verification
- `npm run check` passes
- Build, type check, unit tests, E2E tests all pass under gate verification

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)