### PR TITLE
Stack Settings → Shortcuts Tip below list on mobile

### DIFF
--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -937,7 +937,7 @@ function renderShortcutsTab() {
 	});
 
 	return html`
-		<div class="flex gap-6 items-start">
+		<div class="flex flex-col md:flex-row gap-4 md:gap-6 md:items-start">
 			<div class="flex-1 min-w-0 flex flex-col gap-4">
 				${sortedCategories.map(
 					([category, entries]) => html`
@@ -960,7 +960,7 @@ function renderShortcutsTab() {
 					})}
 				</div>
 			</div>
-			<div class="shrink-0 w-48 rounded-md border border-border/60 bg-secondary/30 p-3 text-xs text-muted-foreground leading-relaxed">
+			<div class="w-full md:w-48 md:shrink-0 rounded-md border border-border/60 bg-secondary/30 p-3 text-xs text-muted-foreground leading-relaxed">
 				<span class="font-medium text-foreground/80">Tip:</span> When running Bobbit as a browser tab, some shortcut combinations are intercepted by the browser. Install Bobbit as a PWA app to regain complete control.
 			</div>
 		</div>


### PR DESCRIPTION
On the Settings → Shortcuts tab, the Tip card was rendered in a fixed `w-48` column to the right of the shortcut list. On mobile viewports there isn't enough horizontal space, so the side-by-side layout squashed the shortcut rows.

## Fix

In `src/app/settings-page.ts::renderShortcutsTab()`:

- Outer wrapper: `flex gap-6 items-start` → `flex flex-col md:flex-row gap-4 md:gap-6 md:items-start`
- Tip aside: `shrink-0 w-48` → `w-full md:w-48 md:shrink-0`

Mobile (`< 768px`) now stacks the Tip below the list, full-width. Desktop (`≥ md`) is unchanged.

CSS-class-only tweak; no test changes (existing E2E coverage is sufficient per goal spec).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)