### PR TITLE
test(manual): make multi-project sidebar assertion robust

### DIFF
--- a/tests/manual-integration/session-resilience.spec.ts
+++ b/tests/manual-integration/session-resilience.spec.ts
@@ -844,12 +844,12 @@ test.describe.serial("Integration — sessions, goals, sandboxed goals", () => {
 
 		// 7. Verify sidebar grouping via browser
 		await page.goto(appUrl(gw));
-		await page.waitForSelector("button", { timeout: 15_000 });
-		// Wait for sessions to load in the sidebar
-		await page.waitForTimeout(3_000);
+		await page.waitForSelector('[data-testid="sidebar-expanded"]', { timeout: 15_000 });
+		// Wait for the project header to actually render in the sidebar
+		await page.locator('[data-testid="sidebar-expanded"]').getByText("Second Project").first().waitFor({ timeout: 10_000 });
 
 		// The sidebar should show "Second Project" as a separate project group
-		const sidebarText = await page.locator('[class*="sidebar"], nav').first().textContent() || "";
+		const sidebarText = await page.locator('[data-testid="sidebar-expanded"]').textContent() || "";
 		expect(sidebarText).toContain("Second Project");
 		console.log(`  Sidebar contains "Second Project" ✓`);
 		await takeScreenshot(page, "multi-project-sidebar.png");
@@ -1330,9 +1330,9 @@ test.describe.serial("Integration — sessions, goals, sandboxed goals", () => {
 
 		// Verify sidebar still shows both projects
 		await page.goto(appUrl(gw));
-		await page.waitForSelector("button", { timeout: 15_000 });
-		await page.waitForTimeout(3_000);
-		const sidebarText = await page.locator('[class*="sidebar"], nav').first().textContent() || "";
+		await page.waitForSelector('[data-testid="sidebar-expanded"]', { timeout: 15_000 });
+		await page.locator('[data-testid="sidebar-expanded"]').getByText("Second Project").first().waitFor({ timeout: 10_000 });
+		const sidebarText = await page.locator('[data-testid="sidebar-expanded"]').textContent() || "";
 		expect(sidebarText).toContain("Second Project");
 		await takeScreenshot(page, "multi-project-sidebar-after-restart.png");
 		console.log(`  Sidebar still shows "Second Project" after restart ✓`);


### PR DESCRIPTION
## What

Fixes a flaky assertion in the manual integration suite (`session-resilience.spec.ts` → *A2. multi-project sessions and goal*).

## Why it was failing

The assertion used:

```ts
const sidebarText = await page.locator('[class*="sidebar"], nav').first().textContent() || "";
expect(sidebarText).toContain("Second Project");
```

`[class*="sidebar"]` is too loose — the sidebar renders many descendants whose class names contain `sidebar` (`sidebar-edge`, `sidebar-resize-handle`, `sidebar-active-dot`, `sidebar-actions`, `sidebar-session-active`, …). `.first()` doesn't reliably hit the outer container; in the failing run it picked an inner element whose textContent was just 35 × U+00B7 middle-dot separators.

Compounding it, `waitForSelector("button")` + a fixed `waitForTimeout(3_000)` is a race — the sidebar shell renders fast, but project group headers depend on async session/goal data, so 3 s wasn't a guarantee.

## Fix

Anchor on the canonical `data-testid="sidebar-expanded"` (set on the outer expanded sidebar in `src/app/sidebar.ts`) and explicitly wait for the "Second Project" text before reading textContent.

Applied at both call sites:
- A2 pre-restart (~line 853)
- E-3b post-restart (~line 1335)

```ts
await page.waitForSelector('[data-testid="sidebar-expanded"]');
await page.getByText("Second Project").waitFor({ timeout: 10_000 });
const sidebarText = await page.locator('[data-testid="sidebar-expanded"]').textContent() || "";
expect(sidebarText).toContain("Second Project");
```

## Verification

`npm run test:manual` — **20 passed, 4 skipped** (docker-e2e sandbox-recovery auto-skip when no Docker container present), 0 failed. Total runtime 8.5 min.

Log line confirming the previously-failing assertion now passes:
```
Sidebar contains "Second Project" ✓
✓  10 [manual-integration] › tests\manual-integration\session-resilience.spec.ts:721:2 › A2. multi-project sessions and goal (38.2s)
```

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)