### PR TITLE
fix(mcp): send Accept: application/json, text/event-stream on HTTP transport

### DIFF
--- a/src/server/mcp/mcp-client.ts
+++ b/src/server/mcp/mcp-client.ts
@@ -324,6 +324,8 @@ export class McpClient {
     const url = this._config!.url!;
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
+      // Streamable HTTP transport spec: client MUST advertise both response shapes.
+      Accept: 'application/json, text/event-stream',
       ...this._config!.headers,
     };
 
@@ -378,6 +380,7 @@ export class McpClient {
     const url = this._config!.url!;
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
       ...this._config!.headers,
     };
 


### PR DESCRIPTION
## Problem

A user reported that the Bobbit MCP client doesn't send `Accept: application/json, text/event-stream` when calling MCP servers over HTTP. The [Streamable HTTP MCP transport spec](https://spec.modelcontextprotocol.io/specification/basic/transports/) requires clients to advertise both response shapes in the `Accept` header. Servers that strictly conform to the spec reject our requests (e.g. with `406 Not Acceptable`).

## Fix

Add `Accept: application/json, text/event-stream` to both outbound HTTP paths in \`src/server/mcp/mcp-client.ts\`:

- \`_sendHttpRequest\` (JSON-RPC requests)
- \`_sendHttpNotification\` (JSON-RPC notifications)

Existing logic already handles either response shape (\`content-type: text/event-stream\` is parsed as SSE \`data:\` lines; otherwise JSON).

## Verification

- \`npm run check\` passes.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)