### PR TITLE
fix(cli): suppress auto-open-browser when NODE_ENV=test

### DIFF
--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -232,8 +232,13 @@ async function main() {
 	console.log(`  Keep it secret. Regenerate with --new-token.`);
 	console.log();
 
-	// Auto-open browser when serving the UI, passing token so the UI auto-connects
-	if (args.staticDir && !process.env.BOBBIT_NO_OPEN) {
+	// Auto-open browser when serving the UI, passing token so the UI auto-connects.
+	// Skipped when:
+	//   - BOBBIT_NO_OPEN is set (explicit opt-out)
+	//   - NODE_ENV === "test" (manual integration tests + any test harness; prevents
+	//     browser tab spam from per-test gateway spawns)
+	const suppressOpen = process.env.BOBBIT_NO_OPEN || process.env.NODE_ENV === "test";
+	if (args.staticDir && !suppressOpen) {
 		const cmd =
 			process.platform === "win32" ? "start" : process.platform === "darwin" ? "open" : "xdg-open";
 		import("node:child_process").then(({ exec }) => exec(`${cmd} ${fullUrl}`));


### PR DESCRIPTION
Manual integration tests spawn fresh gateways per test, each of which auto-opened a new tab in the developer's real Chrome. Across the suite that was ~10 stolen-focus tabs disrupting work.

Adds `NODE_ENV === "test"` as a default suppression alongside the existing `BOBBIT_NO_OPEN` opt-out. All manual specs already set `NODE_ENV=test` on the spawned gateway, so they're now silent automatically.

`npm run check` clean.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)