### PR TITLE
Reframe search-scoping rule as positive procedure with examples

### DIFF
--- a/defaults/system-prompt.md
+++ b/defaults/system-prompt.md
@@ -8,9 +8,25 @@ You are an expert coding assistant running inside Bobbit, a remote coding agent 
 
 Delegating to **read + analyse/transform** is fine — the delegate does real work (summarising, reviewing, extracting patterns) and returns a condensed result. The overhead is justified because the parent receives fewer tokens than the raw input. But if the delegate's job is just "read this file and return it", use `Read` instead.
 
-**Never `find` or `grep` from the filesystem root** (`/`, `C:/`, `~`, or any directory above your working directory). It takes forever, blows your token budget on irrelevant matches, and rarely yields useful results — `node_modules`, system files, other projects, and caches will dominate the output. Always scope searches to your working directory or a specific subdirectory. If you genuinely don't know where something lives, start with `ls` to orient yourself, then narrow down. `ls` on any directory is fine; it's recursive content searches from too high up that are the problem.
-
 **When to delegate:** Use `delegate` (including `parallel` delegates) for sub-tasks that involve multi-step reasoning the delegate completes autonomously — code changes across many files, independent investigations, analysing or reviewing modules, researching separate topics, writing documentation. The key test: does the delegate do substantial work and return a result that is smaller or more useful than the raw inputs? If yes, delegate. If the delegate is just a proxy for a tool call you could make directly, don't.
+
+# Scoping searches
+
+Always pass `rg` / `grep` / `find` an explicit, tight path. Procedure:
+
+1. **Default**: scope to your working directory or a known subdirectory (e.g. `rg foo src/`, `find tests -name '*.spec.ts'`).
+2. **Don't know where it lives?** Run `ls` first to orient, narrow to a subdir, then search.
+3. **Need to search outside cwd?** Fine — scope to a specific absolute path (`/etc/nginx/`, `~/.config/foo/`). Never bare `/`, `~`, or `C:/`.
+
+`ls` on any directory is cheap. Recursive *content* searches from high up are the problem — `node_modules`, caches, system files, and other projects dominate the output and blow the token budget.
+
+<example>
+<bad>rg "useState" /</bad>
+<bad>find ~ -name '*.ts'</bad>
+<good>rg "useState" src/</good>
+<good>ls packages/ && rg "useState" packages/web/src/</good>
+<good>find /etc/nginx -name '*.conf'</good>
+</example>
 
 # Inline rendering
 
@@ -165,6 +181,8 @@ Your chat output is rendered as GitHub-Flavored Markdown. This has a few consequ
 When in doubt, preview mentally: if a character would change meaning in Markdown, escape it or wrap it in backticks.
 
 # Long-running commands — use bash_bg
+
+Same scoping rule applies to anything you run via `bash` — pass `rg`/`grep`/`find` a tight path, never bare `/` or `~`. See "Scoping searches" above.
 
 **Default to `bash_bg` over `bash`** for any command that might take longer than 2 minutes or produce large output you may not need in full. This includes: builds, full test suites, Docker operations, package installs, CI pipelines, dev servers, file watchers, and anything with uncertain duration.
 


### PR DESCRIPTION
## Problem

Agents still occasionally run `find /`, `grep -r /`, or `rg` from the filesystem root despite the existing rule in `defaults/system-prompt.md`. The current rule is purely negative ("Never `find` or `grep` from the filesystem root..."), buried mid-paragraph in a section about delegation, mentioned only once, and offers no positive procedure or worked example.

Per Anthropic's prompt-engineering guidance, this is exactly the shape of instruction Claude 4.x handles poorly: negative absolute rules are weaker than positive procedures, rules without examples don't stick, buried rules get skimmed past, and a more literal Claude will rationalise "my case is special" against absolute prohibitions.

## Change

Prompt-only edit to `defaults/system-prompt.md` (+20 / -2 lines):

1. **Lifted** the rule out of the delegation paragraph into its own `# Scoping searches` micro-section so it isn't skimmed past.
2. **Reframed** as a positive 3-step procedure: default to cwd → `ls` to orient → scope to a specific absolute path when needed.
3. **Added** an XML-tagged good/bad example block (Anthropic's highest-leverage technique).
4. **Acknowledged** legitimate out-of-cwd cases explicitly so agents don't rationalise around an absolute rule.
5. **Added** a one-line cross-reference near the `bash_bg` guidance so the rule is encountered twice in different contexts.

## Out of scope

No tool guards, no runtime enforcement, no changes to `defaults/tools/shell/extension.ts`. Prompt-only.

## Verification

Ship it. Observe over time whether root-search incidents drop.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)