### PR TITLE
Refine docs prompts to stop overusing AGENTS.md

### DIFF
--- a/.bobbit/config/project.yaml
+++ b/.bobbit/config/project.yaml
@@ -302,6 +302,23 @@ workflows:
               {{goal_spec}}
 
 
+              **Documentation location rules:**
+
+              - Detailed feature behavior, architecture explanations,
+              workflows, and durable reference material should usually live in
+                `docs/*.md`.
+              - `README.md` should cover entrypoints, setup, and concise
+              high-level project orientation.
+              - `AGENTS.md` should only change when agent-operational guidance
+              changed: repo navigation,
+                architecture launchpad notes, common task recipes, debugging
+                index entries, verification flow, or other instructions an
+                agent needs in many sessions.
+              - Do NOT require an `AGENTS.md` update for routine product or
+              feature documentation when
+                `docs/` or `README.md` is the better home.
+
+
               **Check 1 — Every feature is documented:**
 
               - Every new user-facing feature, API endpoint, config option, or
@@ -309,8 +326,11 @@ workflows:
                 introduced in this branch must be documented somewhere.
               - If a feature is only described in code comments, that is NOT
               sufficient — it must
-                appear in a .md file (AGENTS.md, README.md, or a file in docs/).
+                appear in a .md file.
               - List any undocumented features.
+              - Also flag documentation placed in the wrong home when that
+              placement creates pressure
+                to grow `AGENTS.md` unnecessarily.
 
 
               **Check 2 — Existing documentation is updated:**
@@ -324,7 +344,17 @@ workflows:
               - List any stale documentation that was not updated.
 
 
-              **Check 3 — Documentation quality standards:**
+              **Check 3 — Documentation placement is appropriate:**
+
+              - Prefer `docs/` for detailed explanations.
+              - Prefer `README.md` for top-level orientation.
+              - Only require `AGENTS.md` changes for agent-facing operational
+                guidance.
+              - Flag branches that add routine feature detail to `AGENTS.md`
+                instead of the better destination.
+
+
+              **Check 4 — Documentation quality standards:**
 
               Evaluate all new or modified documentation against these
               standards:
@@ -998,6 +1028,23 @@ workflows:
               {{goal_spec}}
 
 
+              **Documentation location rules:**
+
+              - Detailed feature behavior, architecture explanations,
+              workflows, and durable reference material should usually live in
+                `docs/*.md`.
+              - `README.md` should cover entrypoints, setup, and concise
+              high-level project orientation.
+              - `AGENTS.md` should only change when agent-operational guidance
+              changed: repo navigation,
+                architecture launchpad notes, common task recipes, debugging
+                index entries, verification flow, or other instructions an
+                agent needs in many sessions.
+              - Do NOT require an `AGENTS.md` update for routine product or
+              feature documentation when
+                `docs/` or `README.md` is the better home.
+
+
               **Check 1 — Every feature is documented:**
 
               - Every new user-facing feature, API endpoint, config option, or
@@ -1005,8 +1052,11 @@ workflows:
                 introduced in this branch must be documented somewhere.
               - If a feature is only described in code comments, that is NOT
               sufficient — it must
-                appear in a .md file (AGENTS.md, README.md, or a file in docs/).
+                appear in a .md file.
               - List any undocumented features.
+              - Also flag documentation placed in the wrong home when that
+              placement creates pressure
+                to grow `AGENTS.md` unnecessarily.
 
 
               **Check 2 — Existing documentation is updated:**
@@ -1020,7 +1070,17 @@ workflows:
               - List any stale documentation that was not updated.
 
 
-              **Check 3 — Documentation quality standards:**
+              **Check 3 — Documentation placement is appropriate:**
+
+              - Prefer `docs/` for detailed explanations.
+              - Prefer `README.md` for top-level orientation.
+              - Only require `AGENTS.md` changes for agent-facing operational
+                guidance.
+              - Flag branches that add routine feature detail to `AGENTS.md`
+                instead of the better destination.
+
+
+              **Check 4 — Documentation quality standards:**
 
               Evaluate all new or modified documentation against these
               standards:
@@ -1462,6 +1522,23 @@ workflows:
               {{goal_spec}}
 
 
+              **Documentation location rules:**
+
+              - Detailed feature behavior, architecture explanations,
+              workflows, and durable reference material should usually live in
+                `docs/*.md`.
+              - `README.md` should cover entrypoints, setup, and concise
+              high-level project orientation.
+              - `AGENTS.md` should only change when agent-operational guidance
+              changed: repo navigation,
+                architecture launchpad notes, common task recipes, debugging
+                index entries, verification flow, or other instructions an
+                agent needs in many sessions.
+              - Do NOT require an `AGENTS.md` update for routine product or
+              feature documentation when
+                `docs/` or `README.md` is the better home.
+
+
               **Check 1 — Every feature is documented:**
 
               - Every new user-facing feature, API endpoint, config option, or
@@ -1469,8 +1546,11 @@ workflows:
                 introduced in this branch must be documented somewhere.
               - If a feature is only described in code comments, that is NOT
               sufficient — it must
-                appear in a .md file (AGENTS.md, README.md, or a file in docs/).
+                appear in a .md file.
               - List any undocumented features.
+              - Also flag documentation placed in the wrong home when that
+              placement creates pressure
+                to grow `AGENTS.md` unnecessarily.
 
 
               **Check 2 — Existing documentation is updated:**
@@ -1484,7 +1564,17 @@ workflows:
               - List any stale documentation that was not updated.
 
 
-              **Check 3 — Documentation quality standards:**
+              **Check 3 — Documentation placement is appropriate:**
+
+              - Prefer `docs/` for detailed explanations.
+              - Prefer `README.md` for top-level orientation.
+              - Only require `AGENTS.md` changes for agent-facing operational
+                guidance.
+              - Flag branches that add routine feature detail to `AGENTS.md`
+                instead of the better destination.
+
+
+              **Check 4 — Documentation quality standards:**
 
               Evaluate all new or modified documentation against these
               standards:

--- a/defaults/roles/docs-writer.yaml
+++ b/defaults/roles/docs-writer.yaml
@@ -43,6 +43,20 @@ promptTemplate: |-
   - Use headings to create scannable structure.
   - Write for developers who are already familiar with the tech stack but new to this project.
 
+  ## Documentation routing rules
+
+  Choose the right home for each doc change:
+
+  1. **Default to `docs/*.md`** for detailed feature behavior, architecture explanations, workflows,
+     API semantics, and other durable reference material.
+  2. **Use `README.md`** for entrypoints, setup, dev workflow orientation, and concise top-level
+     project overview.
+  3. **Only update `AGENTS.md` when agent-operational guidance changed** — repo map, architecture
+     launchpad notes, common task recipes, debugging index entries, verification flow, or other
+     instructions an agent needs in many sessions.
+  4. **Do not treat `AGENTS.md` as the default destination** for routine feature documentation.
+     If the information mainly helps a human understand a feature, prefer `docs/`.
+
   ## Documentation quality standards
 
   Your documentation will be verified against these standards. Follow them strictly:

--- a/defaults/roles/team-lead.yaml
+++ b/defaults/roles/team-lead.yaml
@@ -185,7 +185,13 @@ promptTemplate: |
 
   - Spawn a **docs-writer** agent with `workflowGateId="documentation"` to handle this gate.
   - The docs-writer will receive upstream gate content (design doc, implementation) automatically.
-  - The docs-writer should update AGENTS.md, README.md, and/or files in docs/ as needed.
+  - Tell the docs-writer to **prefer `docs/*.md` for detailed feature/behavior documentation** and
+    use `README.md` for entrypoints, setup, and high-level developer orientation.
+  - **Only update `AGENTS.md` when the change affects agent-operational guidance**: repo navigation,
+    architecture launchpad notes, recipes, debugging index entries, verification flow, or other
+    instructions an agent needs in nearly every session.
+  - Do NOT ask for an `AGENTS.md` update for routine feature documentation when `docs/` or
+    `README.md` is the better home.
   - Do NOT skip this gate or try to write docs yourself — delegate to a docs-writer.
   - After the docs-writer finishes and you merge its branch, signal the documentation gate.
 

--- a/defaults/workflow-authoring-guide.md
+++ b/defaults/workflow-authoring-guide.md
@@ -391,7 +391,7 @@ workflows:
         name: Documentation
         depends_on: [implementation]
         verify:
-          - { name: "Documentation coverage", type: llm-review, prompt: "Confirm every user-facing change is documented in AGENTS.md / docs/." }
+          - { name: "Documentation coverage", type: llm-review, prompt: "Confirm every user-facing change is documented. Prefer docs/ for detailed behavior and architecture, README.md for top-level orientation, and AGENTS.md only for agent-operational guidance such as repo navigation, recipes, debugging, and verification flow." }
 
       - id: ready-to-merge
         name: Ready to Merge

--- a/src/server/state-migration/seed-default-workflows.ts
+++ b/src/server/state-migration/seed-default-workflows.ts
@@ -74,15 +74,28 @@ Read the key documentation files: AGENTS.md, README.md, and files in docs/.
 The goal spec is:
 {{goal_spec}}
 
+**Documentation location rules:**
+- Detailed feature behavior, architecture explanations, workflows, and durable reference material should usually live in \`docs/*.md\`.
+- \`README.md\` should cover entrypoints, setup, and concise high-level project orientation.
+- \`AGENTS.md\` should only change when agent-operational guidance changed: repo navigation, architecture launchpad notes, common task recipes, debugging index entries, verification flow, or other instructions an agent needs in many sessions.
+- Do NOT require an \`AGENTS.md\` update for routine product or feature documentation when \`docs/\` or \`README.md\` is the better home.
+
 **Check 1 — Every feature is documented:**
 - Every new user-facing feature, API endpoint, config option, or behavioral change introduced in this branch must be documented somewhere.
-- If a feature is only described in code comments, that is NOT sufficient — it must appear in a .md file (AGENTS.md, README.md, or a file in docs/).
+- If a feature is only described in code comments, that is NOT sufficient — it must appear in a .md file.
 - List any undocumented features.
+- Also flag documentation placed in the wrong home when that placement creates pressure to grow \`AGENTS.md\` unnecessarily.
 
 **Check 2 — Existing documentation is updated:**
 - If the changes modify behavior that is already documented, the documentation must be updated to reflect the new behavior.
 - Check for stale references: old API signatures, removed config options, renamed files, changed defaults, altered workflows.
 - List any stale documentation that was not updated.
+
+**Check 3 — Documentation placement is appropriate:**
+- Prefer \`docs/\` for detailed explanations.
+- Prefer \`README.md\` for top-level orientation.
+- Only require \`AGENTS.md\` changes for agent-facing operational guidance.
+- Flag branches that add routine feature detail to \`AGENTS.md\` instead of the better destination.
 
 Summarize with PASS/FAIL for each check and specific items to address.`;
 


### PR DESCRIPTION
## Summary
- tighten the docs-writer and team-lead role guidance so AGENTS.md is only updated for agent-operational guidance
- rewrite documentation gate prompts to prefer docs/ for detailed behavior and README.md for top-level orientation
- update the workflow authoring guide and current project config so live workflows follow the same routing rules

## Testing
- npm run check

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)