### PR TITLE
Fix HTML preview UX bugs (fullscreen controls, refresh, standalone theme, mountFile)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ One-liner task → entry point. Follow links for walkthroughs.
 - **Pool worktree placed under `<projectDir>-wt/` instead of `<repoRoot>-wt/`** → `WorktreePool` constructor in `src/server/agent/worktree-pool.ts` resolves `opts.repoPath` to git toplevel; both `initWorktreePoolForProject` sites in `src/server/server.ts` also resolve. Pinned by `tests/worktree-pool-nested-rootpath.test.ts`.
 
 ### Preview / HTML / images
-- **Preview HTML with sibling assets** → `preview_open({ html | file, assets?, manifest? })`. **Explicit opt-in**: bare `file` copies only the entry HTML; siblings declared via `assets: [...]` or a `manifest` JSON. Snapshot marker: `__preview_snapshot_v3__`. See [docs/preview-architecture.md](docs/preview-architecture.md).
+- **Preview HTML with sibling assets** → `preview_open({ html | file, assets?, manifest? })`. **Explicit opt-in**: bare `file` copies only the entry HTML; siblings declared via `assets: [...]` or a `manifest` JSON. Snapshot marker: `__preview_snapshot_v3__`. Re-opening the same `file` (including paths that resolve inside the mount itself) is safe — `mountFile()` stages into a sibling tmp dir and atomically swaps. See [docs/preview-architecture.md](docs/preview-architecture.md).
 - **Author HTML output** → [`defaults/docs/html-rendering.md`](defaults/docs/html-rendering.md). One artefact, one surface. Use theme tokens (`--background`, `--card`, `--chart-1..6`, `--positive`/`--negative`/`--warning`/`--info`).
 - **Generate an image** → `generate_image` → `POST /api/image-generation/generate`.
 
@@ -177,6 +177,8 @@ Keyword index — full diagnostic walkthroughs live in [docs/debugging.md](docs/
 ### QA / preview / tier-2.5
 - **QA screenshot token bloat** — extension must emit `[screenshot_file]` not `[screenshot_base64]`.
 - **Tier 2.5 report missing / ffmpeg failed** — set `FFMPEG_PATH` or install ffmpeg; only when `RECORDSCREEN=1`.
+- **Preview standalone tab unstyled / `--background` empty** — inline `<style data-bobbit-preview-theme="snapshot">` injected by `src/server/preview/content-route.ts` from `src/server/preview/theme-snapshot.ts`; `PREVIEW_THEME_BRIDGE` early-returns when `parent === window`. See [docs/preview-architecture.md](docs/preview-architecture.md#theme-token-snapshot-for-standalone-tabs).
+- **Preview Refresh button does nothing / SSE bumps don't reload** — iframe cache-buster must be `?mtime=` (query string, triggers reload), not `#mtime=` (hash, same-document). See `htmlPreviewContent()` in `src/app/render.ts`.
 
 ### Misc
 - **OAuth callback never completes** — poll `GET /api/oauth/flow-status?flowId=&provider=`.

--- a/docs/preview-architecture.md
+++ b/docs/preview-architecture.md
@@ -311,6 +311,79 @@ in both `snapshot.ts` and `PreviewRenderer.ts`. Reopen flows for v1/v2 in
 WP-G's deletion of `/api/preview/render` and `/api/preview/asset` doesn't
 break old archived sessions.
 
+## Theme-token snapshot for standalone tabs
+
+Single source of truth: `src/server/preview/theme-snapshot.ts`.
+
+Every preview HTML response carries an inline `<style>` block of the host
+app's theme tokens, injected into `<head>` alongside the `<base>` tag by
+`injectBaseAndScripts()` in `content-route.ts` (the pure-string contract is
+preserved — no HTML parser).
+
+**Why.** The runtime theme bridge in `src/shared/preview-bridge-scripts.ts`
+(`PREVIEW_THEME_BRIDGE`) reads CSS custom properties from
+`parent.document.documentElement`. Inside the embedded panel iframe that
+works; in a standalone tab opened via "Open in new tab", `parent === window`
+and the preview document has no theme vars of its own, so every
+`var(--background)` / `var(--chart-N)` resolved to empty and the page
+rendered unstyled.
+
+**How.** At server startup `theme-snapshot.ts` parses the `:root` and `.dark`
+blocks of `src/ui/app.css` once, extracts every `--*` declaration, and caches
+a ready-to-emit `<style data-bobbit-preview-theme="snapshot">…</style>`
+string. `content-route.ts` injects this snapshot for every served HTML
+response — the `data-bobbit-preview-theme="snapshot"` marker is the debugging
+handle (open devtools → Elements → search the `<head>`).
+
+**Two semantics, one mechanism:**
+
+| Surface | Behaviour |
+|---|---|
+| Standalone tab (`parent === window`) | `PREVIEW_THEME_BRIDGE` early-returns. The inline snapshot governs — colours and fonts are fixed at the moment the request was served. Live host-app theme toggles do **not** propagate. This is an explicit, accepted trade: standalone tabs are snapshots. |
+| Embedded panel iframe (`parent !== window`) | Snapshot supplies defaults; the bridge runs and live-mirrors the host-app's `documentElement` custom properties on every theme toggle. |
+
+No per-request CSS parsing in the hot path — the snapshot string is built
+once and reused for every response.
+
+## Atomic-swap mount lifecycle
+
+Single source of truth: `mountFile()` in `src/server/preview/mount.ts`.
+
+**Why.** The previous flow was wipe-then-copy: `wipeContents(destRoot)` ran
+before the entry copy. Any source path whose realpath resolved inside
+`destRoot` (e.g. an agent re-opening a file the previous `preview_open`
+call had materialised into the mount) was deleted before being read —
+`fs.copyFileSync` then ENOENT'd, or the OS short-circuited same-inode
+operations and threw "cannot copy a file onto itself". Wipe-then-copy also
+left a half-empty mount visible to any `/preview/<sid>/<entry>` GET that
+hit during the window between wipe and final copy.
+
+**How.** Stage everything into a sibling tmp directory under
+`previewRoot()` first, then atomically swap:
+
+1. Create `<previewRoot>/.<sid>.tmp-<pid>-<ms>-<rand6>/`.
+2. Resolve and copy the entry plus all declared `assets[]` (literals and
+   single-segment globs) into the tmp dir. **All source data is read
+   before `destRoot` is touched** — the same-mount-source race is gone.
+3. On staging error: `rmSync(tmp, { recursive: true, force: true })` and
+   leave `destRoot` untouched.
+4. On success: `wipeContents(destRoot)` (see inode note below) followed
+   by per-entry `renameSync` from tmp into `destRoot`. The tmp dir is
+   removed once empty.
+
+**Inode preservation.** The wipe step deliberately uses `wipeContents`
+(remove the contents of `destRoot`) rather than `rmSync(destRoot)`
+(remove the directory itself). The directory's inode survives, so the
+long-lived `fs.watch` handle held by `watchMount()` keeps firing for SSE
+consumers across mount swaps.
+
+**`writeInline()` is unaffected.** It already writes the single entry to
+a sibling tmp file and `renameSync`s into place — atomic by construction.
+
+**SSE.** `broadcastPreviewChanged()` still fires on every successful
+mount, including identical re-opens, so the iframe reload path (`?mtime=`
+cache-buster) sees every call.
+
 ## Sandbox integration
 
 Single source of truth: `src/server/agent/docker-args.ts`.

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -2818,7 +2818,7 @@ export function doRenderApp(): void {
 					class="w-full border-0"
 					style="position:absolute;inset:0;height:100%;"
 					sandbox="allow-scripts allow-same-origin"
-					src=${`/preview/${encodeURIComponent(sid)}/${encodeURIComponent(entry)}#mtime=${v}`}
+					src=${`/preview/${encodeURIComponent(sid)}/${encodeURIComponent(entry)}?mtime=${v}`}
 				></iframe>
 			</div>
 		`;
@@ -2872,6 +2872,24 @@ export function doRenderApp(): void {
 			></review-pane>
 		</div>
 	`;
+
+	const previewControlButtons = () => {
+		const sid = activeSessionId() || "";
+		const entry = state.previewPanelEntry || "";
+		return html`
+			<a
+				href=${`/preview/${encodeURIComponent(sid)}/${encodeURIComponent(entry)}`}
+				target="_blank"
+				rel="noopener noreferrer"
+				class="text-muted-foreground hover:text-foreground"
+				style="background:none;border:none;cursor:pointer;padding:2px;flex-shrink:0;display:inline-flex;align-items:center;"
+				title="Open preview in new tab"
+			>${icon(ExternalLink, "sm")}</a>
+			<button @click=${() => { state.previewPanelMtime = Date.now(); renderApp(); }} class="text-muted-foreground hover:text-foreground" style="background:none;border:none;cursor:pointer;padding:2px;flex-shrink:0;" title="Refresh preview">
+				${icon(RotateCw, "sm")}
+			</button>
+		`;
+	};
 
 	const unifiedPreviewPanel = () => {
 		// Auto-correct tab if the active tab's content is no longer available
@@ -2927,18 +2945,7 @@ export function doRenderApp(): void {
 						` : ""}
 					</div>
 					<div class="flex items-center gap-0.5">
-						${showPreviewTab && state.previewPanelActiveTab === "preview" && state.previewPanelEntry ? html`
-						<a
-							href=${`/preview/${encodeURIComponent(activeSessionId() || "")}/${encodeURIComponent(state.previewPanelEntry)}`}
-							target="_blank"
-							rel="noopener noreferrer"
-							class="text-muted-foreground hover:text-foreground"
-							style="background:none;border:none;cursor:pointer;padding:2px;flex-shrink:0;display:inline-flex;align-items:center;"
-							title="Open preview in new tab"
-						>${icon(ExternalLink, "sm")}</a>
-						<button @click=${() => { state.previewPanelMtime = Date.now(); renderApp(); }} class="text-muted-foreground hover:text-foreground" style="background:none;border:none;cursor:pointer;padding:2px;flex-shrink:0;" title="Refresh preview">
-							${icon(RotateCw, "sm")}
-						</button>` : ""}
+						${showPreviewTab && state.previewPanelActiveTab === "preview" && state.previewPanelEntry ? previewControlButtons() : ""}
 						${showPreviewTab ? html`
 						<button @click=${() => { state.previewPanelFullscreen = true; renderApp(); }} class="text-muted-foreground hover:text-foreground" style="background:none;border:none;cursor:pointer;padding:2px;flex-shrink:0;" title="Fullscreen preview">
 							${icon(Maximize2, "sm")}
@@ -3061,9 +3068,12 @@ export function doRenderApp(): void {
 						<!-- Fullscreen preview header -->
 						<div class="flex items-center justify-between px-3 py-1.5 border-b border-border shrink-0" style="background:var(--color-background, hsl(var(--background)));">
 							<span class="text-xs font-medium text-muted-foreground">Preview</span>
-							<button @click=${() => { state.previewPanelFullscreen = false; renderApp(); }} class="text-muted-foreground hover:text-foreground" style="background:none;border:none;cursor:pointer;padding:2px;" title="Exit fullscreen (Esc)">
-								${icon(Minimize2, "sm")}
-							</button>
+							<div class="flex items-center gap-0.5">
+								${state.previewPanelEntry ? previewControlButtons() : ""}
+								<button @click=${() => { state.previewPanelFullscreen = false; renderApp(); }} class="text-muted-foreground hover:text-foreground" style="background:none;border:none;cursor:pointer;padding:2px;" title="Exit fullscreen (Esc)">
+									${icon(Minimize2, "sm")}
+								</button>
+							</div>
 						</div>
 						<!-- Preview iframe fills available space -->
 						${htmlPreviewContent()}

--- a/src/server/preview/content-route.ts
+++ b/src/server/preview/content-route.ts
@@ -22,6 +22,7 @@ import { resolveAssetPath } from "./path-guard.js";
 import { mimeTypeFor } from "./mime.js";
 import { tryAuth as cookieTryAuth, type CookieStore } from "../auth/cookie.js";
 import { injectBaseAndScripts, PREVIEW_BRIDGE_SCRIPTS } from "../../shared/preview-bridge-scripts.js";
+import { getPreviewThemeSnapshot } from "./theme-snapshot.js";
 
 const VALID_SESSION_ID = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
 
@@ -164,7 +165,12 @@ export async function handlePreviewRequest(
 			send(res, 404, JSON.stringify({ error: "File not found" }));
 			return true;
 		}
-		const baseTag = `<base href="/preview/${sid}/">`;
+		// `<base>` + inline theme-token snapshot. Both land inside <head> via
+		// injectBaseAndScripts; the snapshot defines `:root`/`.dark` defaults so
+		// standalone-tab opens (where the runtime parent-pull bridge no-ops) still
+		// resolve `var(--background)` etc. The runtime bridge continues to flow
+		// live theme toggles into embedded iframes where `parent !== window`.
+		const baseTag = `<base href="/preview/${sid}/">` + getPreviewThemeSnapshot();
 		const rewritten = injectBaseAndScripts(body, baseTag, PREVIEW_BRIDGE_SCRIPTS);
 		res.writeHead(200, {
 			"Content-Type": contentType,

--- a/src/server/preview/mount.ts
+++ b/src/server/preview/mount.ts
@@ -26,6 +26,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import * as crypto from "node:crypto";
 import { bobbitStateDir } from "../bobbit-dir.js";
 
 /** Same shape as `VALID_SESSION_ID` in `server.ts` (UUID v4-style). */
@@ -217,13 +218,21 @@ export function writeInline(sessionId: string, html: string, entry?: string): Mo
  * Mount the entry HTML file plus a caller-declared list of assets.
  *
  * Behaviour:
- *   - Wipes the mount directory.
+ *   - Stages the entry + resolved assets into a sibling tmp directory first,
+ *     reading ALL source data before touching `destRoot`. This is what makes
+ *     re-opening a path that lives inside the existing mount safe (Bug 4):
+ *     sources are captured before the wipe runs.
+ *   - Then wipes `destRoot`'s contents (preserving its inode so any active
+ *     `watchMount()` handle stays valid) and renames each staged entry into
+ *     place.
  *   - Copies only `srcFile` plus the resolved `assets` (literals + globs).
  *   - Globs may use `*` and `?` in a single path segment; `**`/`[...]`/`{a,b}`
  *     are rejected.
  *   - Symlink escape: any resolved asset whose realpath is not contained in
  *     the entry's source dir is rejected with 403.
  *   - Unmatched literal asset → 404.
+ *   - On any staging error, the tmp dir is deleted and `destRoot` is left
+ *     untouched (previous mount preserved).
  *
  * No size cap — the agent is responsible for declaring only what it needs.
  */
@@ -262,9 +271,12 @@ export function mountFile(
 	validateEntry(entry);
 
 	const destRoot = mountDir(sessionId);
-	wipeContents(destRoot);
 
-	// Copy the entry file.
+	const list = Array.isArray(assets) ? assets : [];
+	// Pre-validate all asset specs first so we fail fast before any extra work.
+	const specs = list.map(validateAssetSpec);
+
+	// Resolve the entry's realpath up-front so we can detect symlink escape.
 	const entryReal = (() => {
 		try { return fs.realpathSync(srcFile); } catch { return srcFile; }
 	})();
@@ -272,72 +284,97 @@ export function mountFile(
 		// Entry's realpath escapes its declared dir (symlink escape on the entry).
 		throw new PreviewMountError(403, "Entry symlink escapes source tree");
 	}
-	const entryDst = path.join(destRoot, entry);
-	copyOneFile(entryReal, entryDst);
+
+	// ── Stage into a sibling tmp dir ─────────────────────────────────────
+	// Sibling of `destRoot` so the swap is same-filesystem. The randomised
+	// suffix avoids collisions between concurrent mountFile() calls for the
+	// same sid (we accept last-writer-wins; no cross-call locking).
+	const tmpName = `.${sessionId}.tmp-${process.pid}-${Date.now()}-${crypto.randomBytes(6).toString("hex")}`;
+	const tmpRoot = path.join(previewRoot(), tmpName);
+	fs.mkdirSync(tmpRoot, { recursive: true });
 
 	const resolvedAssets: Set<string> = new Set();
-	const list = Array.isArray(assets) ? assets : [];
 
-	// Pre-validate all asset specs first so we fail fast before any extra work.
-	const specs = list.map(validateAssetSpec);
+	try {
+		// Copy entry into tmp. Reading from `entryReal` BEFORE we touch
+		// destRoot is what makes "srcFile inside destRoot" safe.
+		copyOneFile(entryReal, path.join(tmpRoot, entry));
 
-	for (const spec of specs) {
-		if (isGlob(spec)) {
-			const matches = expandGlob(srcRoot, spec);
-			// A glob that matches nothing is OK (agent may speculatively list
-			// `img/*.png` even when none exist yet). It's not a hard error —
-			// matches the design doc which only specifies 404 for *literal*
-			// missing assets.
-			for (const rel of matches) {
-				const abs = path.join(srcRoot, rel);
+		for (const spec of specs) {
+			if (isGlob(spec)) {
+				const matches = expandGlob(srcRoot, spec);
+				// A glob that matches nothing is OK (agent may speculatively list
+				// `img/*.png` even when none exist yet). It's not a hard error —
+				// matches the design doc which only specifies 404 for *literal*
+				// missing assets.
+				for (const rel of matches) {
+					const abs = path.join(srcRoot, rel);
+					let real: string;
+					try { real = fs.realpathSync(abs); } catch { continue; }
+					if (!isContained(real, srcRoot)) {
+						throw new PreviewMountError(403, `Asset escapes source tree: ${rel}`);
+					}
+					let st: fs.Stats;
+					try { st = fs.statSync(real); } catch { continue; }
+					if (!st.isFile()) continue;
+					const dst = path.join(tmpRoot, rel);
+					fs.mkdirSync(path.dirname(dst), { recursive: true });
+					copyOneFile(real, dst);
+					resolvedAssets.add(rel.split(path.sep).join("/"));
+				}
+			} else {
+				// Literal — must exist.
+				const rel = spec; // already forward-slash, no `..`, not absolute
+				const abs = path.resolve(srcRoot, rel);
+				// Containment check against the unresolved path first (file may
+				// not exist as a symlink yet).
+				if (!isContained(abs, srcRoot)) {
+					throw new PreviewMountError(400, `Asset escapes source tree: ${rel}`);
+				}
 				let real: string;
-				try { real = fs.realpathSync(abs); } catch { continue; }
+				try {
+					real = fs.realpathSync(abs);
+				} catch {
+					throw new PreviewMountError(404, `Asset '${rel}' not found`);
+				}
 				if (!isContained(real, srcRoot)) {
-					throw new PreviewMountError(403, `Asset escapes source tree: ${rel}`);
+					throw new PreviewMountError(403, `Asset symlink escapes source tree: ${rel}`);
 				}
 				let st: fs.Stats;
-				try { st = fs.statSync(real); } catch { continue; }
-				if (!st.isFile()) continue;
-				const dst = path.join(destRoot, rel);
+				try { st = fs.statSync(real); } catch {
+					throw new PreviewMountError(404, `Asset '${rel}' not found`);
+				}
+				if (!st.isFile()) {
+					throw new PreviewMountError(404, `Asset '${rel}' is not a regular file`);
+				}
+				const dst = path.join(tmpRoot, rel);
 				fs.mkdirSync(path.dirname(dst), { recursive: true });
 				copyOneFile(real, dst);
-				resolvedAssets.add(rel.split(path.sep).join("/"));
+				resolvedAssets.add(rel);
 			}
-		} else {
-			// Literal — must exist.
-			const rel = spec; // already forward-slash, no `..`, not absolute
-			const abs = path.resolve(srcRoot, rel);
-			// Containment check against the unresolved path first (file may
-			// not exist as a symlink yet).
-			if (!isContained(abs, srcRoot)) {
-				throw new PreviewMountError(400, `Asset escapes source tree: ${rel}`);
-			}
-			let real: string;
-			try {
-				real = fs.realpathSync(abs);
-			} catch {
-				throw new PreviewMountError(404, `Asset '${rel}' not found`);
-			}
-			if (!isContained(real, srcRoot)) {
-				throw new PreviewMountError(403, `Asset symlink escapes source tree: ${rel}`);
-			}
-			let st: fs.Stats;
-			try { st = fs.statSync(real); } catch {
-				throw new PreviewMountError(404, `Asset '${rel}' not found`);
-			}
-			if (!st.isFile()) {
-				throw new PreviewMountError(404, `Asset '${rel}' is not a regular file`);
-			}
-			const dst = path.join(destRoot, rel);
-			fs.mkdirSync(path.dirname(dst), { recursive: true });
-			copyOneFile(real, dst);
-			resolvedAssets.add(rel);
 		}
+
+		// ── Atomic swap ─────────────────────────────────────────────────
+		// All sources are now captured under tmpRoot. Wipe destRoot's
+		// contents (preserving its inode so the existing fs.watch handle in
+		// `watchMount()` stays valid) and rename each staged entry into
+		// place. This also fixes the half-wiped-mount race a concurrent GET
+		// could otherwise hit between wipe and copy.
+		wipeContents(destRoot);
+		moveContents(tmpRoot, destRoot);
+	} catch (err) {
+		// Staging failed — destRoot is untouched if we hadn't reached the
+		// swap yet. Either way, drop the tmp dir.
+		try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch { /* ignore */ }
+		throw err;
 	}
+
+	// Clean up the now-empty tmp dir.
+	try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch { /* ignore */ }
 
 	const target = path.join(destRoot, entry);
 	if (!fs.existsSync(target)) {
-		throw new PreviewMountError(404, "Entry file missing after copy");
+		throw new PreviewMountError(500, "Entry file missing after swap");
 	}
 
 	return {
@@ -347,6 +384,37 @@ export function mountFile(
 		mtime: Math.floor(fs.statSync(target).mtimeMs),
 		assets: Array.from(resolvedAssets).sort(),
 	};
+}
+
+/**
+ * Move every entry from `srcDir` into `dstDir` via `fs.renameSync`. Recurses
+ * into directories so we preserve `dstDir`'s inode (renaming the staged
+ * subdirectories into place rather than replacing the parent).
+ *
+ * Falls back to copy+unlink if rename fails (cross-device — shouldn't happen
+ * for sibling tmp/dest, but be defensive).
+ */
+function moveContents(srcDir: string, dstDir: string): void {
+	let entries: fs.Dirent[];
+	try { entries = fs.readdirSync(srcDir, { withFileTypes: true }); } catch { return; }
+	for (const ent of entries) {
+		const from = path.join(srcDir, ent.name);
+		const to = path.join(dstDir, ent.name);
+		try {
+			fs.renameSync(from, to);
+		} catch {
+			// Cross-device or destination clash — copy then remove source.
+			try { fs.rmSync(to, { recursive: true, force: true }); } catch { /* ignore */ }
+			if (ent.isDirectory()) {
+				fs.mkdirSync(to, { recursive: true });
+				moveContents(from, to);
+				try { fs.rmdirSync(from); } catch { /* ignore */ }
+			} else {
+				copyOneFile(from, to);
+				try { fs.unlinkSync(from); } catch { /* ignore */ }
+			}
+		}
+	}
 }
 
 export function removeMount(sessionId: string): void {

--- a/src/server/preview/theme-snapshot.ts
+++ b/src/server/preview/theme-snapshot.ts
@@ -1,0 +1,230 @@
+/**
+ * Inline theme-token snapshot for preview HTML served at `/preview/<sid>/...`.
+ *
+ * Why: the runtime `PREVIEW_THEME_BRIDGE` reads CSS custom properties from
+ * `parent.document.documentElement`. In a standalone tab `parent === window`,
+ * so the bridge silently no-ops and the preview document has no theme vars
+ * defined — `var(--background)` etc. resolve to empty.
+ *
+ * Fix: snapshot the canonical `:root` and `.dark` `--*` declarations from
+ * `src/ui/app.css` once at startup and inject them as an inline `<style>`
+ * block into every served HTML preview document. The runtime bridge still
+ * runs in embedded iframes (where `parent !== window`) so live theme toggles
+ * continue to flow into already-mounted previews; in standalone tabs the
+ * inline snapshot governs.
+ *
+ * Approach: forgiving line-by-line scan over `app.css`. We track block depth
+ * with a brace counter and capture every `--name: value;` declaration inside
+ * any top-level `:root { ... }` or `.dark { ... }` block. Multiple `:root`
+ * blocks (the file has several — palette overrides, notification colours,
+ * etc.) all merge into a single emitted `:root { ... }` and similarly for
+ * `.dark`. Comments are stripped. No HTML-parser, no CSS-parser dependency.
+ *
+ * On parse failure we return an empty string and `console.warn` — the
+ * preview route stays functional, just without a theme snapshot.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+let cached: string | null = null;
+
+/**
+ * Walk up from `start` looking for `package.json` to find the repo root.
+ * Works equally for `src/server/preview/` (ts-node / dev) and
+ * `dist/server/preview/` (built). Stops at filesystem root.
+ */
+function findRepoRoot(start: string): string | null {
+	let dir = start;
+	for (let i = 0; i < 16; i++) {
+		const pkg = path.join(dir, "package.json");
+		if (fs.existsSync(pkg)) return dir;
+		const parent = path.dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+	return null;
+}
+
+/**
+ * Strip C-style block comments and `//` line comments. CSS doesn't actually
+ * support `//` but we tolerate it. Block comments span lines.
+ */
+function stripComments(css: string): string {
+	return css.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+/**
+ * Parse `:root` and `.dark` blocks at depth 1 (i.e. top-level), collecting
+ * `--name: value;` declarations from each. Nested at-rules are skipped.
+ *
+ * Returns `{ root, dark }` — each a record of token name → declared value.
+ * Later declarations override earlier ones (last-wins, matching CSS).
+ */
+export function parseThemeBlocks(css: string): { root: Record<string, string>; dark: Record<string, string> } {
+	const cleaned = stripComments(css);
+	const root: Record<string, string> = {};
+	const dark: Record<string, string> = {};
+
+	// Match selector + body of every top-level rule. We use a hand-rolled
+	// scanner to track brace depth, since regex alone can't balance braces.
+	let i = 0;
+	const N = cleaned.length;
+	while (i < N) {
+		// Find the next selector start: skip whitespace and at-rules.
+		// Skip whitespace.
+		while (i < N && /\s/.test(cleaned[i]!)) i++;
+		if (i >= N) break;
+
+		// At-rules like `@media`, `@import`, `@source`, `@keyframes` may be
+		// terminated by `;` (no body) or contain a brace block. We need to
+		// skip them entirely without recursing into their body.
+		if (cleaned[i] === "@") {
+			// Find first `{` or `;`. If `;` first → simple at-rule, skip past.
+			// If `{` first → block at-rule, skip the matching `}`.
+			let j = i + 1;
+			while (j < N && cleaned[j] !== "{" && cleaned[j] !== ";") j++;
+			if (j >= N) break;
+			if (cleaned[j] === ";") {
+				i = j + 1;
+				continue;
+			}
+			// Block — find matching `}`.
+			let depth = 1;
+			j++;
+			while (j < N && depth > 0) {
+				if (cleaned[j] === "{") depth++;
+				else if (cleaned[j] === "}") depth--;
+				j++;
+			}
+			i = j;
+			continue;
+		}
+
+		// Capture selector until `{` (or end).
+		const selStart = i;
+		while (i < N && cleaned[i] !== "{" && cleaned[i] !== ";") i++;
+		if (i >= N || cleaned[i] === ";") {
+			// Stray `;` at top level — skip.
+			if (i < N) i++;
+			continue;
+		}
+		const selector = cleaned.slice(selStart, i).trim();
+		// Skip past `{`, capture body until matching `}`.
+		i++;
+		const bodyStart = i;
+		let depth = 1;
+		while (i < N && depth > 0) {
+			if (cleaned[i] === "{") depth++;
+			else if (cleaned[i] === "}") depth--;
+			if (depth > 0) i++;
+		}
+		const body = cleaned.slice(bodyStart, i);
+		// Past the closing `}`.
+		if (i < N) i++;
+
+		// Selector list may be e.g. `:root, [data-foo]`. Match if any segment
+		// is exactly `:root` or `.dark`.
+		const segments = selector.split(",").map(s => s.trim());
+		const isRoot = segments.some(s => s === ":root");
+		const isDark = segments.some(s => s === ".dark");
+		if (!isRoot && !isDark) continue;
+
+		// Extract `--name: value;` pairs from body. Tolerate values that
+		// contain `:` (e.g. `url(...)`) — we split on the FIRST colon.
+		// Skip nested rules inside the body (shouldn't appear but be safe).
+		const decls = body.replace(/\{[^{}]*\}/g, "");
+		// Split on `;` at depth 0 (parens balanced) to keep e.g.
+		// `oklch(0.21 0.008 145)` intact.
+		const parts: string[] = [];
+		let buf = "";
+		let parenDepth = 0;
+		for (let k = 0; k < decls.length; k++) {
+			const ch = decls[k]!;
+			if (ch === "(") parenDepth++;
+			else if (ch === ")") parenDepth = Math.max(0, parenDepth - 1);
+			if (ch === ";" && parenDepth === 0) {
+				parts.push(buf);
+				buf = "";
+			} else {
+				buf += ch;
+			}
+		}
+		if (buf.trim().length > 0) parts.push(buf);
+
+		for (const part of parts) {
+			const trimmed = part.trim();
+			if (!trimmed.startsWith("--")) continue;
+			const colon = trimmed.indexOf(":");
+			if (colon < 0) continue;
+			const name = trimmed.slice(0, colon).trim();
+			const value = trimmed.slice(colon + 1).trim();
+			if (!/^--[a-zA-Z0-9_-]+$/.test(name)) continue;
+			if (!value) continue;
+			if (isRoot) root[name] = value;
+			if (isDark) dark[name] = value;
+		}
+	}
+
+	return { root, dark };
+}
+
+/**
+ * Build the inline `<style>` block string. Returns "" on parse failure.
+ */
+function buildSnapshot(): string {
+	const repoRoot = findRepoRoot(__dirname);
+	if (!repoRoot) {
+		console.warn("[preview/theme-snapshot] could not locate repo root from", __dirname);
+		return "";
+	}
+	const cssPath = path.join(repoRoot, "src", "ui", "app.css");
+	let css: string;
+	try {
+		css = fs.readFileSync(cssPath, "utf-8");
+	} catch (e) {
+		console.warn(`[preview/theme-snapshot] failed to read ${cssPath}:`, e);
+		return "";
+	}
+
+	let parsed: { root: Record<string, string>; dark: Record<string, string> };
+	try {
+		parsed = parseThemeBlocks(css);
+	} catch (e) {
+		console.warn("[preview/theme-snapshot] parse failed:", e);
+		return "";
+	}
+
+	const rootEntries = Object.entries(parsed.root);
+	const darkEntries = Object.entries(parsed.dark);
+	if (rootEntries.length === 0 && darkEntries.length === 0) {
+		console.warn("[preview/theme-snapshot] no --* declarations found in :root or .dark");
+		return "";
+	}
+
+	const fmt = (entries: Array<[string, string]>) =>
+		entries.map(([k, v]) => `\t${k}: ${v};`).join("\n");
+
+	const blocks: string[] = [];
+	if (rootEntries.length > 0) blocks.push(`:root {\n${fmt(rootEntries)}\n}`);
+	if (darkEntries.length > 0) blocks.push(`.dark {\n${fmt(darkEntries)}\n}`);
+
+	return `<style data-bobbit-preview-theme="snapshot">\n${blocks.join("\n")}\n</style>`;
+}
+
+/**
+ * Cached accessor — parses on first call, returns the cached string thereafter.
+ */
+export function getPreviewThemeSnapshot(): string {
+	if (cached !== null) return cached;
+	cached = buildSnapshot();
+	return cached;
+}
+
+/** Reset the cache. Test-only. */
+export function _resetPreviewThemeSnapshotCache(): void {
+	cached = null;
+}

--- a/src/shared/preview-bridge-scripts.ts
+++ b/src/shared/preview-bridge-scripts.ts
@@ -15,6 +15,12 @@
 export const PREVIEW_THEME_BRIDGE = `<script>
 (function() {
 	try {
+		/* Standalone tab (Open-in-new-tab): parent === window, so there is no
+		   host-app document to mirror. The server-injected inline <style data-bobbit-preview-theme>
+		   snapshot defines :root/.dark defaults — early return and let it govern.
+		   Embedded iframes (parent !== window) continue past this guard so live
+		   theme toggles in the host app flow through. */
+		if (parent === window) return;
 		var root = document.documentElement;
 		var parentRoot = parent.document.documentElement;
 		var parentStyles = parent.getComputedStyle(parentRoot);

--- a/tests/e2e/ui/preview-fullscreen-controls.spec.ts
+++ b/tests/e2e/ui/preview-fullscreen-controls.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * Reproducing test for Bug 1 — Fullscreen header missing controls.
+ *
+ * The half-panel header renders Open-in-new-tab → Refresh → Fullscreen → Collapse.
+ * The fullscreen header (when state.previewPanelFullscreen === true) currently
+ * only renders the Exit-fullscreen button. After the fix it should also expose
+ * "Open preview in new tab" and "Refresh preview".
+ *
+ * This test will FAIL on master because the fullscreen header does not contain
+ * those controls.
+ */
+import { test, expect } from "../gateway-harness.js";
+import { openApp, createSessionViaUI } from "./ui-helpers.js";
+
+test.describe("Preview fullscreen header controls (Bug 1)", () => {
+	test("fullscreen header exposes Open-in-new-tab and Refresh buttons", async ({ page }) => {
+		await openApp(page);
+		await createSessionViaUI(page);
+
+		await page.waitForFunction(() => /#\/session\/[\w-]+/.test(location.hash), null, { timeout: 10_000 });
+		const sessionId = await page.evaluate(() => {
+			const m = location.hash.match(/#\/session\/([\w-]+)/);
+			return m?.[1] ?? "";
+		});
+		expect(sessionId).toMatch(/^[a-f0-9-]{36}$/);
+
+		const baseUrl = new URL(page.url()).origin;
+
+		// Enable preview mode on the session.
+		const patchResp = await page.evaluate(async ({ baseUrl, sessionId }) => {
+			const r = await fetch(`${baseUrl}/api/sessions/${sessionId}`, {
+				method: "PATCH",
+				credentials: "include",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ preview: true }),
+			});
+			return { status: r.status, text: await r.text() };
+		}, { baseUrl, sessionId });
+		expect(patchResp.status).toBe(200);
+
+		await expect.poll(
+			async () => await page.evaluate(() => {
+				const s: any = (window as any).bobbitState ?? (window as any).__bobbitState ?? {};
+				return s.isPreviewSession === true;
+			}),
+			{ timeout: 10_000 },
+		).toBe(true);
+
+		await page.evaluate(() => {
+			const s: any = (window as any).bobbitState ?? (window as any).__bobbitState ?? {};
+			s.previewPanelActiveTab = "preview";
+		});
+
+		// Mount a preview so the entry exists and Fullscreen button is rendered.
+		const mountResp = await page.evaluate(async ({ baseUrl, sessionId }) => {
+			const r = await fetch(`${baseUrl}/api/preview/mount?sessionId=${sessionId}`, {
+				method: "POST",
+				credentials: "include",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ html: "<!DOCTYPE html><body>fs-test</body>", entry: "report.html" }),
+			});
+			return { status: r.status, text: await r.text() };
+		}, { baseUrl, sessionId });
+		expect(mountResp.status).toBe(200);
+
+		// Half-panel: Fullscreen button should be visible.
+		const fullscreenBtn = page.locator('button[title="Fullscreen preview"]').first();
+		await expect(fullscreenBtn).toBeVisible({ timeout: 10_000 });
+		await fullscreenBtn.click();
+
+		// Wait for fullscreen mode.
+		await expect.poll(
+			async () => await page.evaluate(() => {
+				const s: any = (window as any).bobbitState ?? (window as any).__bobbitState ?? {};
+				return s.previewPanelFullscreen === true;
+			}),
+			{ timeout: 5_000 },
+		).toBe(true);
+
+		// Exit-fullscreen button must be visible (sanity).
+		const exitBtn = page.locator('button[title="Exit fullscreen (Esc)"]').first();
+		await expect(exitBtn).toBeVisible({ timeout: 5_000 });
+
+		// THE BUG: in fullscreen mode the Open-in-new-tab and Refresh controls
+		// are missing. After the fix they must be present.
+		const openLink = page.locator('a[title="Open preview in new tab"]').first();
+		const refreshBtn = page.locator('button[title="Refresh preview"]').first();
+		await expect(openLink, "Open-in-new-tab anchor must be visible in fullscreen header").toBeVisible({ timeout: 5_000 });
+		await expect(refreshBtn, "Refresh button must be visible in fullscreen header").toBeVisible({ timeout: 5_000 });
+	});
+});

--- a/tests/e2e/ui/preview-happy-path.spec.ts
+++ b/tests/e2e/ui/preview-happy-path.spec.ts
@@ -75,7 +75,7 @@ test.describe("Preview panel iframe URL (WP-E)", () => {
 		expect(src).not.toBeNull();
 		expect(src).toContain(`/preview/${encodeURIComponent(sessionId)}/`);
 		expect(src).toContain("report.html");
-		expect(src).toMatch(/#mtime=\d+$/);
+		expect(src).toMatch(/\?mtime=\d+$/);
 		expect(src).not.toContain("/api/preview/render");
 
 		// Open-in-new-tab anchor renders with matching href.
@@ -96,6 +96,6 @@ test.describe("Preview panel iframe URL (WP-E)", () => {
 		}).not.toEqual(src);
 		const src2 = await iframe.getAttribute("src");
 		expect(src2).not.toBeNull();
-		expect(src2).toMatch(/#mtime=\d+$/);
+		expect(src2).toMatch(/\?mtime=\d+$/);
 	});
 });

--- a/tests/e2e/ui/preview-new-tab.spec.ts
+++ b/tests/e2e/ui/preview-new-tab.spec.ts
@@ -115,4 +115,90 @@ test.describe("Preview Open-in-new-tab (criterion 5)", () => {
 		expect(verify.body).toContain("new-tab-target");
 		expect(verify.body).toContain(`<base href="/preview/${sessionId}/">`);
 	});
+
+	/**
+	 * Reproducing test for Bug 3 — Standalone tab loses CSS theme tokens.
+	 *
+	 * In the embedded iframe the PREVIEW_THEME_BRIDGE pulls --background etc.
+	 * from parent.document.documentElement. In a standalone tab parent === window,
+	 * so the bridge silently no-ops and the served HTML has no inline theme
+	 * snapshot — `var(--background)` resolves to empty.
+	 *
+	 * After the fix the served HTML must carry an inline <style> block defining
+	 * the canonical theme tokens, so getComputedStyle reports a non-empty colour.
+	 */
+	test("standalone tab document has --background defined (Bug 3)", async ({ page, context }) => {
+		await openApp(page);
+		await createSessionViaUI(page);
+
+		await page.waitForFunction(() => /#\/session\/[\w-]+/.test(location.hash), null, { timeout: 10_000 });
+		const sessionId = await page.evaluate(() => {
+			const m = location.hash.match(/#\/session\/([\w-]+)/);
+			return m?.[1] ?? "";
+		});
+		expect(sessionId).toMatch(/^[a-f0-9-]{36}$/);
+		const baseUrl = new URL(page.url()).origin;
+
+		const patchResp = await page.evaluate(async ({ baseUrl, sessionId }) => {
+			const r = await fetch(`${baseUrl}/api/sessions/${sessionId}`, {
+				method: "PATCH",
+				credentials: "include",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ preview: true }),
+			});
+			return { status: r.status };
+		}, { baseUrl, sessionId });
+		expect(patchResp.status).toBe(200);
+
+		await expect.poll(
+			async () => await page.evaluate(() => {
+				const s: any = (window as any).bobbitState ?? (window as any).__bobbitState ?? {};
+				return s.isPreviewSession === true;
+			}),
+			{ timeout: 10_000 },
+		).toBe(true);
+
+		await page.evaluate(() => {
+			const s: any = (window as any).bobbitState ?? (window as any).__bobbitState ?? {};
+			s.previewPanelActiveTab = "preview";
+		});
+
+		const mountResp = await page.evaluate(async ({ baseUrl, sessionId }) => {
+			const r = await fetch(`${baseUrl}/api/preview/mount?sessionId=${sessionId}`, {
+				method: "POST",
+				credentials: "include",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					html: `<!DOCTYPE html><html><head></head><body><div id="box" style="background:var(--background);color:var(--foreground);">themed</div></body></html>`,
+					entry: "report.html",
+				}),
+			});
+			return { status: r.status };
+		}, { baseUrl, sessionId });
+		expect(mountResp.status).toBe(200);
+
+		const link = page.locator('a[title="Open preview in new tab"]').first();
+		await expect.poll(async () => link.count(), { timeout: 15_000 }).toBeGreaterThan(0);
+		await expect(link).toBeVisible({ timeout: 10_000 });
+
+		const [newPage] = await Promise.all([
+			context.waitForEvent("page", { timeout: 10_000 }),
+			link.click(),
+		]);
+		await newPage.waitForLoadState("domcontentloaded");
+		await newPage.waitForLoadState("load");
+
+		// Read the standalone document's --background custom property.
+		const bg = await newPage.evaluate(() =>
+			getComputedStyle(document.documentElement).getPropertyValue("--background").trim(),
+		);
+		const fg = await newPage.evaluate(() =>
+			getComputedStyle(document.documentElement).getPropertyValue("--foreground").trim(),
+		);
+
+		expect(bg, "--background must be defined in the standalone preview document").not.toEqual("");
+		expect(fg, "--foreground must be defined in the standalone preview document").not.toEqual("");
+		// Sanity: the resolved value should look like a colour (oklch / rgb / hsl / # / color()).
+		expect(bg).toMatch(/^(oklch|rgb|rgba|hsl|hsla|color)\(|^#[0-9a-fA-F]{3,8}$/);
+	});
 });

--- a/tests/e2e/ui/preview-refresh.spec.ts
+++ b/tests/e2e/ui/preview-refresh.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * Reproducing test for Bug 2 — Refresh button does not reload the iframe.
+ *
+ * The current Refresh handler bumps state.previewPanelMtime and re-renders,
+ * which only changes the iframe `src` URL fragment (#mtime=<n>). A fragment-
+ * only change is a same-document navigation; the browser does NOT reload the
+ * iframe. So the document inside the iframe never re-runs its inline scripts.
+ *
+ * We seed an HTML document whose inline script writes a per-load counter into
+ * a #count div. After clicking Refresh, the counter must increment to "2".
+ * On master it stays at "1" → test fails.
+ */
+import { test, expect } from "../gateway-harness.js";
+import { openApp, createSessionViaUI } from "./ui-helpers.js";
+
+const COUNTING_HTML = `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>count</title></head>
+<body>
+<div id="count">?</div>
+<script>
+(function(){
+	try {
+		var k = 'preview-load-count-' + location.pathname;
+		var n = parseInt(sessionStorage.getItem(k) || '0', 10) + 1;
+		sessionStorage.setItem(k, String(n));
+		document.getElementById('count').textContent = String(n);
+	} catch (e) {
+		document.getElementById('count').textContent = 'err:' + e.message;
+	}
+})();
+</script>
+</body></html>`;
+
+test.describe("Preview Refresh button reloads iframe (Bug 2)", () => {
+	test("clicking Refresh causes the iframe document to re-execute", async ({ page }) => {
+		await openApp(page);
+		await createSessionViaUI(page);
+
+		await page.waitForFunction(() => /#\/session\/[\w-]+/.test(location.hash), null, { timeout: 10_000 });
+		const sessionId = await page.evaluate(() => {
+			const m = location.hash.match(/#\/session\/([\w-]+)/);
+			return m?.[1] ?? "";
+		});
+		expect(sessionId).toMatch(/^[a-f0-9-]{36}$/);
+		const baseUrl = new URL(page.url()).origin;
+
+		const patchResp = await page.evaluate(async ({ baseUrl, sessionId }) => {
+			const r = await fetch(`${baseUrl}/api/sessions/${sessionId}`, {
+				method: "PATCH",
+				credentials: "include",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ preview: true }),
+			});
+			return { status: r.status, text: await r.text() };
+		}, { baseUrl, sessionId });
+		expect(patchResp.status).toBe(200);
+
+		await expect.poll(
+			async () => await page.evaluate(() => {
+				const s: any = (window as any).bobbitState ?? (window as any).__bobbitState ?? {};
+				return s.isPreviewSession === true;
+			}),
+			{ timeout: 10_000 },
+		).toBe(true);
+
+		await page.evaluate(() => {
+			const s: any = (window as any).bobbitState ?? (window as any).__bobbitState ?? {};
+			s.previewPanelActiveTab = "preview";
+		});
+
+		const mountResp = await page.evaluate(async ({ baseUrl, sessionId, html }) => {
+			const r = await fetch(`${baseUrl}/api/preview/mount?sessionId=${sessionId}`, {
+				method: "POST",
+				credentials: "include",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ html, entry: "report.html" }),
+			});
+			return { status: r.status, text: await r.text() };
+		}, { baseUrl, sessionId, html: COUNTING_HTML });
+		expect(mountResp.status).toBe(200);
+
+		const iframe = page.locator(".goal-preview-panel iframe").first();
+		await expect(iframe).toBeVisible({ timeout: 10_000 });
+
+		const frame = page.frameLocator(".goal-preview-panel iframe").first();
+		const countDiv = frame.locator("#count");
+		await expect(countDiv).toHaveText("1", { timeout: 10_000 });
+
+		// Click Refresh — should cause the iframe to actually reload, re-running
+		// the inline script and incrementing the counter.
+		const refreshBtn = page.locator('button[title="Refresh preview"]').first();
+		await expect(refreshBtn).toBeVisible();
+		await refreshBtn.click();
+
+		await expect(countDiv, "iframe must reload after Refresh — counter should increment to 2").toHaveText("2", { timeout: 5_000 });
+	});
+});

--- a/tests/preview-bridge-standalone-guard.test.ts
+++ b/tests/preview-bridge-standalone-guard.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Unit-level smoke check for the `parent === window` guard inside
+ * `PREVIEW_THEME_BRIDGE`.
+ *
+ * A faithful runtime simulation would need a real browser context (parent
+ * frame + cross-origin checks), which is the territory of the existing
+ * Playwright `tests/e2e/ui/preview-new-tab.spec.ts` "standalone tab" test.
+ * Here we just pin two structural invariants that the runtime guard depends
+ * on:
+ *
+ *   1. The bridge string contains the `parent === window` early-return.
+ *   2. The early-return appears *before* any `parent.document...` access.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { PREVIEW_THEME_BRIDGE } from "../src/shared/preview-bridge-scripts.ts";
+
+describe("PREVIEW_THEME_BRIDGE — standalone-tab guard", () => {
+	it("contains the parent === window early-return", () => {
+		assert.match(PREVIEW_THEME_BRIDGE, /if\s*\(\s*parent\s*===\s*window\s*\)\s*return\s*;/);
+	});
+
+	it("guard appears before any parent.document access", () => {
+		const guardIdx = PREVIEW_THEME_BRIDGE.search(/if\s*\(\s*parent\s*===\s*window\s*\)/);
+		const accessIdx = PREVIEW_THEME_BRIDGE.indexOf("parent.document");
+		assert.ok(guardIdx >= 0, "guard must be present");
+		assert.ok(accessIdx >= 0, "bridge must still access parent.document for embedded iframes");
+		assert.ok(guardIdx < accessIdx, "guard must precede every parent.document access");
+	});
+
+	it("evaluates without throwing when parent === window", () => {
+		// Strip the <script>...</script> wrapper to get the raw IIFE body.
+		const openIdx = PREVIEW_THEME_BRIDGE.indexOf("<script>");
+		const closeIdx = PREVIEW_THEME_BRIDGE.indexOf("</script>");
+		assert.ok(openIdx >= 0 && closeIdx > openIdx, "bridge must wrap an IIFE in <script> tags");
+		const code = PREVIEW_THEME_BRIDGE.slice(openIdx + "<script>".length, closeIdx);
+		// Minimal browser-shaped globals for the early-return path. The guard
+		// hits BEFORE any DOM access, so we only need `parent` to equal `this`
+		// (which we use as `window`).
+		const fn = new Function("parent", "document", code);
+		// In a standalone tab, parent === window. Pass the same object for both
+		// `parent` and the function's `this` (via .call) — we only care that
+		// the guard executes and the function returns cleanly.
+		const fakeWindow = {} as Record<string, unknown>;
+		assert.doesNotThrow(() => fn.call(fakeWindow, fakeWindow, {}));
+	});
+});

--- a/tests/preview-content-route.test.ts
+++ b/tests/preview-content-route.test.ts
@@ -217,6 +217,20 @@ describe("handlePreviewRequest — bridge injection", () => {
 		assert.match(txt, /preview-swipe-start|MutationObserver|preview-swipe-move/);
 	});
 
+	it("injects inline theme snapshot inside <head> on text/html", async () => {
+		const o = makeOpts(true);
+		const res = fakeRes();
+		await handlePreviewRequest(fakeReq({ url: `/preview/${SID}/index.html` }), res as any, `/preview/${SID}/index.html`, o);
+		const txt = bodyText(res);
+		// The snapshot lands inside the <head> (alongside <base>).
+		const headMatch = txt.match(/<head\b[^>]*>([\s\S]*?)<\/head>/i);
+		assert.ok(headMatch, "expected a <head> block in served HTML");
+		const headInner = headMatch![1]!;
+		assert.match(headInner, /data-bobbit-preview-theme="snapshot"/);
+		assert.match(headInner, /--background:/);
+		assert.match(headInner, /\.dark\s*\{/);
+	});
+
 	it("does NOT inject bridge into non-html (css)", async () => {
 		const o = makeOpts(true);
 		const res = fakeRes();

--- a/tests/preview-mount.test.ts
+++ b/tests/preview-mount.test.ts
@@ -366,6 +366,77 @@ describe("mountFile \u2014 re-open same source file (Bug 4)", () => {
 	});
 });
 
+describe("mountFile \u2014 atomic stage-then-swap (Bug 4 follow-ups)", () => {
+	it("leaves no .<sid>.tmp-* dir behind after a successful mountFile", () => {
+		const src = mkdtempSync(path.join(tmpdir(), "bobbit-mount-cleanup-"));
+		try {
+			writeFileSync(path.join(src, "report.html"), "<h1>x</h1>");
+			writeFileSync(path.join(src, "styles.css"), "body{}");
+			mountFile(SID_B, path.join(src, "report.html"), ["styles.css"]);
+			const leftovers = readdirSync(root).filter(n => n.startsWith(`.${SID_B}.tmp-`));
+			assert.deepEqual(leftovers, [], `no tmp dirs should remain, found: ${leftovers.join(", ")}`);
+		} finally {
+			rmSync(src, { recursive: true, force: true });
+			removeMount(SID_B);
+		}
+	});
+
+	it("on staging failure, prior mount contents are preserved", () => {
+		const src = mkdtempSync(path.join(tmpdir(), "bobbit-mount-rollback-"));
+		try {
+			writeFileSync(path.join(src, "report.html"), "<h1>v1</h1>");
+			writeFileSync(path.join(src, "styles.css"), "original-css");
+			// Initial successful mount.
+			mountFile(SID_B, path.join(src, "report.html"), ["styles.css"]);
+			assert.ok(existsSync(path.join(mountDir(SID_B), "report.html")));
+			assert.ok(existsSync(path.join(mountDir(SID_B), "styles.css")));
+			const priorListing = listMount(SID_B);
+
+			// Second call: missing literal asset → 404 during staging.
+			assert.throws(
+				() => mountFile(SID_B, path.join(src, "report.html"), ["missing.css"]),
+				(err: any) => err instanceof PreviewMountError && err.statusCode === 404,
+			);
+
+			// destRoot must be unchanged.
+			assert.deepEqual(listMount(SID_B), priorListing);
+			// And no tmp dirs left behind.
+			const leftovers = readdirSync(root).filter(n => n.startsWith(`.${SID_B}.tmp-`));
+			assert.deepEqual(leftovers, []);
+		} finally {
+			rmSync(src, { recursive: true, force: true });
+			removeMount(SID_B);
+		}
+	});
+
+	it("watcher fires after a re-mount (handle survives the swap)", async () => {
+		const { watchMount } = await import("../src/server/preview/mount.ts");
+		const src = mkdtempSync(path.join(tmpdir(), "bobbit-mount-watch-"));
+		let calls = 0;
+		const unsubscribe = watchMount(SID_B, () => { calls++; });
+		try {
+			writeFileSync(path.join(src, "report.html"), "<h1>v1</h1>");
+			mountFile(SID_B, path.join(src, "report.html"));
+			// Wait past the 50ms watcher debounce + filesystem propagation.
+			await new Promise(r => setTimeout(r, 200));
+			const callsAfterFirst = calls;
+
+			writeFileSync(path.join(src, "report.html"), "<h1>v2-longer</h1>");
+			mountFile(SID_B, path.join(src, "report.html"));
+			await new Promise(r => setTimeout(r, 250));
+
+			assert.ok(
+				calls > callsAfterFirst,
+				`watcher should fire after re-mount; calls=${calls} after-first=${callsAfterFirst}`,
+			);
+		} finally {
+			unsubscribe();
+			rmSync(src, { recursive: true, force: true });
+			removeMount(SID_B);
+		}
+	});
+});
+
 describe("removeMount", () => {
 	it("is idempotent", () => {
 		writeInline(SID, "x", "z.html");

--- a/tests/preview-mount.test.ts
+++ b/tests/preview-mount.test.ts
@@ -308,6 +308,64 @@ describe("mountFile — explicit asset opt-in", () => {
 	});
 });
 
+describe("mountFile \u2014 re-open same source file (Bug 4)", () => {
+	/**
+	 * Reproducing tests for Bug 4: mountFile() wipes destRoot before copying.
+	 * If the source file's realpath lives inside destRoot, the wipe deletes it
+	 * and the subsequent copy throws ("cannot copy a file onto itself" / ENOENT).
+	 *
+	 * Both tests must FAIL on master and pass after the atomic stage-then-swap fix.
+	 */
+	it("two consecutive mountFile() calls with the same external source succeed", () => {
+		const src = mkdtempSync(path.join(tmpdir(), "bobbit-mount-bug4a-"));
+		try {
+			const entry = path.join(src, "report.html");
+			writeFileSync(entry, "<h1>v1</h1>");
+			const r1 = mountFile(SID_B, entry);
+			const t1 = statSync(r1.path).mtimeMs;
+			// Ensure mtime can move forward across platforms with coarse granularity.
+			const sleep = Date.now() + 25;
+			while (Date.now() < sleep) { /* busy-wait — short, deterministic */ }
+			writeFileSync(entry, "<h1>v2-longer</h1>");
+			const r2 = mountFile(SID_B, entry);
+			const t2 = statSync(r2.path).mtimeMs;
+			assert.equal(r2.entry, "report.html");
+			assert.ok(t2 >= t1, `second mtime (${t2}) should be >= first (${t1})`);
+			assert.equal(statSync(r2.path).size, "<h1>v2-longer</h1>".length);
+		} finally {
+			rmSync(src, { recursive: true, force: true });
+			removeMount(SID_B);
+		}
+	});
+
+	it("mountFile() succeeds when srcFile is a path inside the existing mount", () => {
+		const src = mkdtempSync(path.join(tmpdir(), "bobbit-mount-bug4b-"));
+		try {
+			const originalEntry = path.join(src, "report.html");
+			writeFileSync(originalEntry, "<h1>seed</h1>");
+			const r1 = mountFile(SID_B, originalEntry);
+			// r1.path now points inside mountDir(SID_B). Simulate the agent passing
+			// that very path back into preview_open(file=...).
+			const insideMount = r1.path;
+			assert.ok(
+				insideMount.startsWith(mountDir(SID_B)),
+				`expected ${insideMount} to be inside ${mountDir(SID_B)}`,
+			);
+			assert.ok(existsSync(insideMount));
+
+			// Currently: wipeContents(destRoot) deletes insideMount before the copy,
+			// so this throws or produces an empty/stale file.
+			const r2 = mountFile(SID_B, insideMount);
+			assert.equal(r2.entry, "report.html");
+			assert.ok(existsSync(r2.path), "mount entry must exist after re-mount from inside-mount source");
+			assert.equal(statSync(r2.path).size, "<h1>seed</h1>".length, "entry contents must be preserved");
+		} finally {
+			rmSync(src, { recursive: true, force: true });
+			removeMount(SID_B);
+		}
+	});
+});
+
 describe("removeMount", () => {
 	it("is idempotent", () => {
 		writeInline(SID, "x", "z.html");

--- a/tests/preview-theme-snapshot.test.ts
+++ b/tests/preview-theme-snapshot.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for `src/server/preview/theme-snapshot.ts`.
+ *
+ * The snapshot reads `src/ui/app.css` from the live source tree at module
+ * load and caches the result. We verify (a) the parser, (b) the public
+ * `getPreviewThemeSnapshot()` shape against the real app.css.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+	getPreviewThemeSnapshot,
+	parseThemeBlocks,
+	_resetPreviewThemeSnapshotCache,
+} from "../src/server/preview/theme-snapshot.ts";
+
+describe("parseThemeBlocks", () => {
+	it("captures top-level :root and .dark declarations", () => {
+		const css = `
+:root {
+	--background: oklch(0.9 0 0);
+	--foreground: #111;
+}
+.dark {
+	--background: #000;
+	--foreground: oklch(0.95 0 0);
+}
+`;
+		const { root, dark } = parseThemeBlocks(css);
+		assert.equal(root["--background"], "oklch(0.9 0 0)");
+		assert.equal(root["--foreground"], "#111");
+		assert.equal(dark["--background"], "#000");
+		assert.equal(dark["--foreground"], "oklch(0.95 0 0)");
+	});
+
+	it("merges multiple :root blocks (last-wins)", () => {
+		const css = `
+:root { --a: 1; --b: 2; }
+:root { --a: 3; --c: 4; }
+`;
+		const { root } = parseThemeBlocks(css);
+		assert.equal(root["--a"], "3");
+		assert.equal(root["--b"], "2");
+		assert.equal(root["--c"], "4");
+	});
+
+	it("ignores non-custom-property declarations", () => {
+		const css = `:root { color: red; --x: 1; font-size: 12px; }`;
+		const { root } = parseThemeBlocks(css);
+		assert.deepEqual(Object.keys(root).sort(), ["--x"]);
+	});
+
+	it("strips block comments", () => {
+		const css = `:root { /* --hidden: x; */ --visible: y; }`;
+		const { root } = parseThemeBlocks(css);
+		assert.equal(root["--visible"], "y");
+		assert.equal(root["--hidden"], undefined);
+	});
+
+	it("handles selector lists like ':root, .foo'", () => {
+		const css = `:root, [data-x] { --a: 1; }`;
+		const { root } = parseThemeBlocks(css);
+		assert.equal(root["--a"], "1");
+	});
+
+	it("skips at-rule blocks (e.g. @media)", () => {
+		const css = `
+@media (min-width: 1px) {
+	:root { --inside-media: nope; }
+}
+:root { --top: yes; }
+`;
+		const { root } = parseThemeBlocks(css);
+		assert.equal(root["--top"], "yes");
+		assert.equal(root["--inside-media"], undefined);
+	});
+
+	it("skips simple at-rules (e.g. @import; @source)", () => {
+		const css = `
+@import "x.css";
+@source "../foo";
+:root { --a: 1; }
+`;
+		const { root } = parseThemeBlocks(css);
+		assert.equal(root["--a"], "1");
+	});
+
+	it("preserves balanced parens in values (oklch with spaces)", () => {
+		const css = `:root { --c: oklch(0.21 0.008 145); --d: rgb(1, 2, 3); }`;
+		const { root } = parseThemeBlocks(css);
+		assert.equal(root["--c"], "oklch(0.21 0.008 145)");
+		assert.equal(root["--d"], "rgb(1, 2, 3)");
+	});
+
+	it("rejects malformed token names", () => {
+		const css = `:root { --good: 1; --bad name: 2; }`;
+		const { root } = parseThemeBlocks(css);
+		assert.equal(root["--good"], "1");
+		// "--bad name" should not be captured.
+		assert.equal(Object.keys(root).filter(k => k.includes(" ")).length, 0);
+	});
+});
+
+describe("getPreviewThemeSnapshot (live app.css)", () => {
+	it("returns a single <style> block wrapping :root and .dark blocks", () => {
+		_resetPreviewThemeSnapshotCache();
+		const snap = getPreviewThemeSnapshot();
+		assert.ok(snap.length > 0, "snapshot must be non-empty");
+		// One opening + one closing style tag.
+		assert.equal((snap.match(/<style\b/g) || []).length, 1);
+		assert.equal((snap.match(/<\/style>/g) || []).length, 1);
+		assert.match(snap, /data-bobbit-preview-theme="snapshot"/);
+		assert.match(snap, /:root\s*\{/);
+		assert.match(snap, /\.dark\s*\{/);
+	});
+
+	it("contains canonical theme tokens", () => {
+		const snap = getPreviewThemeSnapshot();
+		// Spot-check the headline tokens used in the design-system contract.
+		for (const tok of [
+			"--background",
+			"--foreground",
+			"--card",
+			"--muted-foreground",
+			"--border",
+			"--primary",
+			"--chart-1",
+			"--positive",
+			"--negative",
+			"--warning",
+			"--info",
+		]) {
+			assert.ok(snap.includes(`${tok}:`), `expected ${tok} in snapshot`);
+		}
+	});
+
+	it("is cached on subsequent calls (same instance)", () => {
+		const a = getPreviewThemeSnapshot();
+		const b = getPreviewThemeSnapshot();
+		assert.equal(a, b);
+	});
+});


### PR DESCRIPTION
Fixes four bugs in the embedded HTML preview surface (`/preview/<sid>/...` iframe + standalone tab).

## Bug 1 — Fullscreen header missing controls
`unifiedPreviewPanel()` now extracts a `previewControlButtons()` inline helper rendering Open-in-new-tab + Refresh, used in BOTH the half-panel header and the fullscreen header (alongside Exit-fullscreen).

## Bug 2 — Refresh button did nothing
Iframe `src` cache-buster moved from `#mtime=` (URL hash, same-document) to `?mtime=` (query string, triggers iframe reload). Same code path fixes SSE-driven same-entry mtime bumps.

## Bug 3 — "Open in new tab" lost all CSS
- New `src/server/preview/theme-snapshot.ts` parses `:root`/`.dark` `--*` declarations from `src/ui/app.css` once at startup; returns a cached `<style data-bobbit-preview-theme=\"snapshot\">…</style>` block.
- `content-route.ts` injects the snapshot into `<head>` of every served preview alongside `<base>` (existing pure-string `injectBaseAndScripts()` contract preserved).
- `PREVIEW_THEME_BRIDGE` early-returns when `parent === window` so standalone tabs use the snapshot; embedded iframes still pull live theme toggles.

## Bug 4 — `preview_open(file=…)` re-open of in-mount path
`mountFile()` refactored to stage-then-swap: sources read into sibling tmp dir BEFORE touching `destRoot`, then `wipeContents(destRoot)` (preserves the inode so `watchMount()` handles stay valid) → per-entry `renameSync` from tmp into `destRoot` → cleanup tmp. On error, tmp is removed and `destRoot` left untouched.

## Tests
- 4 reproducing tests added (failing on master, passing post-fix).
- 5 new unit tests (theme-snapshot parser, bridge guard, content-route injection, mount rollback, watcher continuity).
- All 13 preview E2E tests pass; full unit suite (1022 passed) and `npm run check` green.

## Docs
- `AGENTS.md` — extended `preview_open` recipe + 2 new debugging bullets.
- `docs/preview-architecture.md` — new sections `Theme-token snapshot for standalone tabs` and `Atomic-swap mount lifecycle`.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)