### PR TITLE
Extract OS-portability hardening from PR #512

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -869,3 +869,31 @@ Fix path:
 - `src/server/server.ts` handler: convert `catch (err) { json({ error: String(err) }, status); }` to `catch (err) { jsonError(status, err); }`.
 - `<error-details>` (`src/ui/components/ErrorDetails.ts`) renders the message + optional code + collapsible stack disclosure when both halves are wired correctly.
 - The background polling site in `refreshSessions()` is intentionally silent and does NOT surface a modal — failures there are dropped on purpose.
+
+## Agent `fetch failed` against gateway when started with `--host 0.0.0.0`
+
+- **Symptoms**: under `./run --host 0.0.0.0 --port <port> --no-tls`, the
+  console shows `Listening: http://0.0.0.0:<port>` as expected, but every
+  same-host tool extension that calls back into the gateway (the `team_*`
+  tools, the `Children` tools, image generation, MCP discovery — anything
+  routed through `defaults/tools/_shared/gateway.ts::apiCall`) fails with an
+  opaque `fetch failed`. Under `npm run dev:harness` (which binds to
+  `localhost`) the same code path works.
+- **Why**: `0.0.0.0` and `::` are wildcard *listen* addresses. They tell the
+  kernel "accept connections on every interface" but they are not valid
+  *connect* peers — macOS / BSD reject `connect()` to `0.0.0.0`. If the
+  gateway-url file contains `http://0.0.0.0:<port>`, every agent on the same
+  host that reads it and tries to fetch the gateway hits the kernel rejection
+  before any HTTP frame is sent.
+- **Where the fix lives**: `src/server/cli-loopback.ts` exports the pure
+  helper `loopbackForBind(host)`. `0.0.0.0` → `127.0.0.1`, `::` / `[::]` →
+  `[::1]`, every other host (including `localhost`, LAN IPs, and hostnames)
+  is returned unchanged. `src/server/cli.ts` writes a loopback-normalised
+  `peerUrl` to `<stateDir>/gateway-url` while the human-readable
+  `Listening:` log line and the browser auto-open URL keep using the
+  literal `args.host`. The split is intentional: the operator wants to see
+  the bind address they passed; the agent needs a real connect peer.
+- **Quick checks**: `cat .bobbit/state/gateway-url` should never contain
+  `0.0.0.0` or `::`. If it does, the server is on a pre-fix build, or a new
+  CLI codepath is writing the file directly without routing through
+  `loopbackForBind`. Tests: `tests/cli-loopback-for-bind.test.ts`.

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -2548,7 +2548,7 @@ Only truly global state lives in the server's central state directory.
 | `preferences.json` | `PreferencesStore` | Key-value prefs |
 | `session-prompts/` | `system-prompt.ts` | Per-session prompts |
 | `tls/` | `tls.ts` | TLS certs |
-| `gateway-url` | `cli.ts` | Gateway base URL |
+| `gateway-url` | `cli.ts` | Gateway base URL used by same-host tool extensions for callbacks. Wildcard binds (`--host 0.0.0.0` / `--host ::`) are normalised to a loopback peer (`127.0.0.1` / `[::1]`) by `loopbackForBind` in `src/server/cli-loopback.ts` before the file is written — wildcards are valid listen addresses but not valid connect peers, and the agent's `apiCall` helper (`defaults/tools/_shared/gateway.ts`) reads this file. The human-readable `Listening:` console line keeps the literal bind host. |
 | `gateway-restart` | `harness.ts` | Dev restart sentinel |
 | `rpc-debug.log` | `rpc-bridge.ts` | RPC event log |
 | `mcp-extensions/` | `tool-activation.ts` | MCP proxy extensions |

--- a/src/server/agent/project-config-store.ts
+++ b/src/server/agent/project-config-store.ts
@@ -7,8 +7,17 @@ import yaml from "yaml";
 // `project.rootPath` to compute on-disk locations. Reject `..` segments and
 // absolute paths to prevent path traversal that would let an authenticated
 // caller create or clobber files outside the project's declared rootPath.
+//
+// `path.isAbsolute()` is OS-aware (a Windows path on POSIX is "relative" to
+// node), so we ALSO reject Windows-style absolute paths explicitly. This keeps
+// the predicate identical on macOS, Linux, and Windows — a project.yaml
+// authored on Windows must be rejected on Linux too.
 export function isSafeRelPath(p: string): boolean {
 	if (path.isAbsolute(p)) return false;
+	// Windows drive-letter absolute (e.g. "C:\Windows", "c:/Users/x").
+	if (/^[a-zA-Z]:[\\/]/.test(p) || /^[a-zA-Z]:$/.test(p)) return false;
+	// Windows UNC path (e.g. "\\server\share\file").
+	if (/^[\\/]{2}/.test(p)) return false;
 	if (p.includes("\0")) return false;
 	const parts = p.split(/[\\/]+/).filter(s => s.length > 0);
 	return !parts.some(seg => seg === "..");

--- a/src/server/agent/repo-scan.ts
+++ b/src/server/agent/repo-scan.ts
@@ -169,6 +169,12 @@ export async function scanRepos(
 
 	if (!fs.existsSync(rootAbs)) return out;
 
+	// Resolve the root once so the symlink check below tolerates ancestor-level
+	// symlinks (e.g. macOS `/tmp` → `/private/tmp`). We only want to reject
+	// symlinks that escape the rootPath, not those introduced by the OS itself.
+	let rootReal = rootAbs;
+	try { rootReal = fs.realpathSync(rootAbs); } catch { /* leave as rootAbs */ }
+
 	const rootHasGit = hasGit(rootAbs);
 	if (rootHasGit) {
 		out.push({ folder: ".", hasGit: true, detectedCommands: detectCommands(rootAbs) });
@@ -186,11 +192,14 @@ export async function scanRepos(
 		if (SKIP_NAMES.has(name)) continue;
 
 		const absChild = path.join(rootAbs, name);
-		// Symlink protection: warn + skip if realpath doesn't match.
+		// Symlink protection: skip only if the child's realpath escapes the
+		// root's realpath. Ancestor-level symlinks (e.g. /tmp → /private/tmp)
+		// are tolerated because `realChild` will share `rootReal` as a prefix.
 		try {
-			const real = fs.realpathSync(absChild);
-			if (real !== absChild) {
-				console.warn(`[repo-scan] Skipping symlinked entry: ${absChild} -> ${real}`);
+			const realChild = fs.realpathSync(absChild);
+			const expected = path.join(rootReal, name);
+			if (realChild !== expected) {
+				console.warn(`[repo-scan] Skipping symlinked entry: ${absChild} -> ${realChild}`);
 				continue;
 			}
 		} catch { /* realpath may fail on dangling symlink */ continue; }

--- a/src/server/agent/rpc-bridge.ts
+++ b/src/server/agent/rpc-bridge.ts
@@ -259,7 +259,7 @@ export class RpcBridge {
 			const tlsEnv = fs.existsSync(caCertPath)
 				? { NODE_EXTRA_CA_CERTS: caCertPath }
 				: { NODE_TLS_REJECT_UNAUTHORIZED: "0" };
-			this.process = spawn("node", [cliPath, ...args], {
+			this.process = spawn(process.execPath, [cliPath, ...args], {
 				stdio: ["pipe", "pipe", "pipe"],
 				cwd: this.options.cwd,
 				env: {

--- a/src/server/cli-loopback.ts
+++ b/src/server/cli-loopback.ts
@@ -1,0 +1,14 @@
+/** Normalise a bind address to a same-host loopback peer for callbacks.
+ *
+ * Wildcard bind addresses (`0.0.0.0`, `::`) are valid LISTEN addresses but not
+ * valid CONNECT addresses on macOS / BSD — a same-host agent fetching the
+ * gateway-url must use a real loopback peer instead.
+ *
+ * Non-wildcard hosts (`localhost`, `127.0.0.1`, LAN IPs, hostnames) are
+ * returned unchanged.
+ */
+export function loopbackForBind(host: string): string {
+	if (host === "0.0.0.0") return "127.0.0.1";
+	if (host === "::" || host === "[::]") return "[::1]";
+	return host;
+}

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -11,6 +11,9 @@ import { loadOrCreateToken, readToken } from "./auth/token.js";
 import { ensureTlsCert } from "./auth/tls.js";
 import { loadDesecConfig, updateDesecIp } from "./auth/desec.js";
 import { createGateway } from "./server.js";
+import { loopbackForBind } from "./cli-loopback.js";
+
+export { loopbackForBind };
 
 interface CliArgs {
 	host: string;
@@ -207,11 +210,15 @@ async function main() {
 
 	const proto = args.tls ? "https" : "http";
 	const baseUrl = `${proto}://${args.host}:${actualPort}`;
+	// peerUrl is what same-host agents use to call back into the gateway. For a
+	// wildcard bind (`0.0.0.0` / `::`), normalise to loopback so the connect side
+	// has a real peer address (the wildcard is a listen-only address).
+	const peerUrl = `${proto}://${loopbackForBind(args.host)}:${actualPort}`;
 	const fullUrl = `${baseUrl}/?token=${encodeURIComponent(authToken)}`;
 
 	// Write gateway URL to a discoverable file so Vite proxy and extensions can find it.
 	const gatewayUrlPath = path.join(bobbitStateDir(), "gateway-url");
-	fs.writeFileSync(gatewayUrlPath, baseUrl, "utf-8");
+	fs.writeFileSync(gatewayUrlPath, peerUrl, "utf-8");
 
 	const __cliDir = path.dirname(fileURLToPath(import.meta.url));
 	const pkgVersion = JSON.parse(fs.readFileSync(path.resolve(__cliDir, "../../package.json"), "utf-8")).version;

--- a/src/server/harness.ts
+++ b/src/server/harness.ts
@@ -80,7 +80,7 @@ let restarting = false;
 
 function launchServer(): void {
 	console.log(`\n[harness] Launching server (port ${PORT})...`);
-	child = spawn("node", [CLI_PATH, ...forwardedArgs], {
+	child = spawn(process.execPath, [CLI_PATH, ...forwardedArgs], {
 		cwd: PROJECT_ROOT,
 		stdio: "inherit",
 		env: { ...process.env },

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2945,7 +2945,7 @@ async function handleApiRoute(
 		}
 
 		// Guard against stale cwd (e.g. re-attempting a goal whose worktree was deleted,
-		// or a project whose rootPath is gone). spawn("node", { cwd }) on Windows
+		// or a project whose rootPath is gone). spawn(process.execPath, { cwd }) on Windows
 		// reports a missing cwd as ENOENT, masquerading as if the `node` binary was missing.
 		// Fall back to the project rootPath when we have a resolved project to anchor the
 		// fallback. If no project is resolved yet, leave cwd alone — the resolver below

--- a/src/server/watchdog.ts
+++ b/src/server/watchdog.ts
@@ -171,7 +171,7 @@ function probeHealth(): Promise<boolean> {
 function launchHarness(): void {
 	console.log(`\n[watchdog] Launching harness (port ${PORT})...`);
 
-	harnessChild = spawn("node", [HARNESS_PATH, ...forwardedArgs], {
+	harnessChild = spawn(process.execPath, [HARNESS_PATH, ...forwardedArgs], {
 		cwd: PROJECT_ROOT,
 		stdio: "inherit",
 		env: { ...process.env },

--- a/tests/cli-loopback-for-bind.test.ts
+++ b/tests/cli-loopback-for-bind.test.ts
@@ -1,0 +1,31 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { loopbackForBind } from "../src/server/cli-loopback.js";
+
+test("loopbackForBind: IPv4 wildcard 0.0.0.0 -> 127.0.0.1", () => {
+	assert.equal(loopbackForBind("0.0.0.0"), "127.0.0.1");
+});
+
+test("loopbackForBind: IPv6 wildcard :: -> [::1]", () => {
+	assert.equal(loopbackForBind("::"), "[::1]");
+});
+
+test("loopbackForBind: IPv6 wildcard [::] -> [::1]", () => {
+	assert.equal(loopbackForBind("[::]"), "[::1]");
+});
+
+test("loopbackForBind: localhost is identity", () => {
+	assert.equal(loopbackForBind("localhost"), "localhost");
+});
+
+test("loopbackForBind: 127.0.0.1 is identity", () => {
+	assert.equal(loopbackForBind("127.0.0.1"), "127.0.0.1");
+});
+
+test("loopbackForBind: LAN IP is identity", () => {
+	assert.equal(loopbackForBind("192.168.1.50"), "192.168.1.50");
+});
+
+test("loopbackForBind: hostname is identity", () => {
+	assert.equal(loopbackForBind("bobbit.example.com"), "bobbit.example.com");
+});

--- a/tests/spawn-node-execpath-invariant.test.ts
+++ b/tests/spawn-node-execpath-invariant.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Lesson 4.5 invariant — every node-process spawn site under `src/server/`
+ * must use `process.execPath`, never the bare string `"node"`.
+ *
+ * Bare `spawn("node", ...)` fails under sanitised PATH (e.g. when the
+ * dev harness scrubs PATH for child processes) because the child has no
+ * way to find the node binary. `process.execPath` is the absolute path
+ * to the running node binary, which is always correct.
+ *
+ * If this test fails, replace `spawn("node", [...])` with
+ * `spawn(process.execPath, [...])` at the offending site. See the
+ * "Lesson 4.5" entry in `docs/design/subgoals-retro-audit.md` §4.2.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const SERVER_DIR = path.resolve(import.meta.dirname, "..", "src", "server");
+
+/** Recursively collect *.ts files (excluding *.d.ts). */
+function collectTsFiles(dir: string, out: string[] = []): string[] {
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			collectTsFiles(full, out);
+		} else if (entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts")) {
+			out.push(full);
+		}
+	}
+	return out;
+}
+
+describe("spawn-node-execpath invariant", () => {
+	it("no `spawn(\"node\"` callsites under src/server/", () => {
+		const files = collectTsFiles(SERVER_DIR);
+		const offenders: { file: string; line: number; text: string }[] = [];
+		// Match `spawn("node"` or `spawn('node'` as a function call.
+		// Allow whitespace between `spawn` and `(`. Comments are allowed
+		// (only callsites are flagged).
+		const pattern = /\bspawn\s*\(\s*["']node["']/;
+		for (const file of files) {
+			const text = fs.readFileSync(file, "utf8");
+			const lines = text.split(/\r?\n/);
+			for (let i = 0; i < lines.length; i++) {
+				const line = lines[i];
+				// Skip comment-only lines (// or * inside block comment) — comments
+				// referencing the historical `spawn("node", { cwd })` shape are fine.
+				const trimmed = line.trim();
+				if (trimmed.startsWith("//") || trimmed.startsWith("*")) continue;
+				if (pattern.test(line)) {
+					offenders.push({ file: path.relative(SERVER_DIR, file), line: i + 1, text: line.trim() });
+				}
+			}
+		}
+		assert.deepEqual(
+			offenders,
+			[],
+			`Found ${offenders.length} bare \`spawn("node", ...)\` callsite(s) under src/server/. ` +
+				`Replace each with \`spawn(process.execPath, ...)\`. Offenders:\n` +
+				offenders.map((o) => `  ${o.file}:${o.line}  ${o.text}`).join("\n"),
+		);
+	});
+});


### PR DESCRIPTION
Extracted from #512 to enable independent review/merge. Once this merges, those four commits will drop out of #512 on rebase.

## Three OS-portability themes

### 1. Windows/macOS path predicates (`856cd795`)
`isSafeRelPath("C:\Windows")` returned `true` on POSIX because `path.isAbsolute()` is OS-aware. Hard-codes Windows drive-letter + UNC detection so the predicate is identical on every OS. Also fixes the `repo-scan` symlink-escape check which rejected all of `/tmp` on macOS (because `/tmp` → `/private/tmp`) — `realpath` the root once, compare child `realpath` against `path.join(rootReal, name)`.

### 2. `process.execPath` invariant at all node-spawn sites (`9d0e0db6`)
Bare `spawn("node", …)` failed under sanitised PATH (e.g. `npm run dev:harness`) because the child couldn't locate the node binary. Replaces three remaining sites (`rpc-bridge.ts`, `harness.ts`, `watchdog.ts`) and adds `tests/spawn-node-execpath-invariant.test.ts` — a guard walking `src/server/**/*.ts` asserting zero `spawn("node"` callsites remain (skips comments).

### 3. Gateway-url loopback normalisation (`b6f6a000` + `9966daf8`)
`--host 0.0.0.0` (or `::`) wrote `http://0.0.0.0:<port>` to `.bobbit/state/gateway-url`. Wildcard addresses are valid LISTEN addresses but **not valid CONNECT peers on macOS/BSD**, so agent tool extensions failed with `fetch failed`. Splits the write into `baseUrl` (human-readable, used for log + browser auto-open) vs `peerUrl` (loopback-normalised, written to disk). Identity for non-wildcard hosts. New `src/server/cli-loopback.ts` + `tests/cli-loopback-for-bind.test.ts`. Companion docs commit updates `AGENTS.md`, `docs/debugging.md`, `docs/internals.md`.

## Note on PR #512

PR #512 will lose these four commits on rebase once this PR merges. No other extracts, no new code, no scope creep.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)