### PR TITLE
Fix preparing UX & boot delay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ One-liner task → entry point. Follow links for walkthroughs.
 - **Re-attempt a goal** → `POST /api/sessions { reattemptGoalId }` → `buildReattemptContext()`.
 - **Server-side read/unread state** → `lastReadAt` on `PersistedSession`; `POST /api/sessions/:id/mark-read`.
 - **Read another session's transcript (`read_session` tool)** → parser `src/server/agent/transcript-reader.ts`; `GET /api/sessions/:id/transcript`; same-project auth via `x-bobbit-session-id` header.
+- **Initialise / read client-side session status on a fresh attach** → `_lastStatusVersion` starts at `-1` in `src/app/remote-agent.ts`; first `session_status` frame is always applied. Both `case "state"` and `case "session_status"` may write `_state.status`. UI re-renders for `preparing`/`starting`/`aborting`/`idle` via explicit `requestUpdate()` in `src/app/session-manager.ts::onStatusChange`.
 
 ### UI
 - **Add a UI component** → `src/ui/components/`, export from `src/ui/index.ts`.
@@ -138,6 +139,7 @@ Keyword index — full diagnostic walkthroughs live in [docs/debugging.md](docs/
 - **Session persistence** — `.bobbit/state/sessions.json`; missing `.jsonl` skips restore.
 - **`lastActivity` reads "just now" after restart** — `isUserVisibleActivity` filter in `session-manager.ts`.
 - **Stale draft resurrection** — `SessionStore.setDraft()` rejects older `gen`.
+- **"Setting up worktree…" banner missing for first session / preparing UX absent** — `_lastStatusVersion` must initialise to `-1` so the first `session_status` frame (server uses `statusVersion: 0`) is applied; `case "session_status"` only writes `_state.status`, but `RemoteAgent.onStatusChange` must also call `agentInterface.requestUpdate()` for `"preparing"`/`"starting"` (Lit reference-equality misses same-object mutations). See `src/app/remote-agent.ts`, `src/app/session-manager.ts`.
 
 ### Worktree / sandbox / projects
 - **Worktree setup not running** — single source of truth `runComponentSetups()` in `src/server/skills/worktree-setup.ts`.
@@ -148,6 +150,7 @@ Keyword index — full diagnostic walkthroughs live in [docs/debugging.md](docs/
 - **Monorepo subprojects not detected** — `src/server/agent/monorepo-scan.ts`; cap 30 candidates.
 - **Legacy JSON-string `project.yaml` field rejected (HTTP 400)** — send structured arrays.
 - **400 "projectId required"** — splash buttons gated on `state.projects.length`; system tool-assistants pass `projectId: "system"`.
+- **Slow first-session worktree creation on cold boot** — `runBootBackgroundTasks` in `src/server/server.ts` runs sweeper and pool init concurrently (`Promise.all`); they operate on disjoint branch sets (sweeper skips `isPoolBranch`; `WorktreePool.reclaimOrphaned` only touches pool branches). Boot timing logs prefixed `[boot]`. `BOBBIT_SKIP_WORKTREE_POOL=1` still bypasses pool entirely.
 
 ### MCP
 - **MCP server unavailable / partial outage** — stub meta extension at `<stateDir>/mcp-extensions/…`.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -149,6 +149,23 @@ See [docs/internals.md — Archived-session state push on auth](internals.md#arc
   3. Team-lead nudges to an errored worker: no longer suppressed in `team-manager.ts` (the old `if (teamLeadSession.lastTurnErrored) return;` guard was removed). SessionManager is now the single source of truth for error-state policy.
 - **Related**: previous mitigation was pattern-matching on error text via `TRANSIENT_ERROR_PATTERNS` + bounded auto-retry (`transientRetryAttempts`, `maybeAutoRetryTransient`). That path still exists for quick in-band recovery; the implicit-unstick path is the structural fallback when the whitelist doesn't match.
 
+## "Setting up worktree…" banner missing on a brand-new session / preparing UX absent
+
+- **Symptom**: user creates a new session before the worktree pool has filled (typical on cold boot). The chat panel mounts but no "Setting up worktree…" banner appears, the message editor stays enabled, the user types and clicks send, and the message lands silently in the prompt queue. The system-prompt viewer shows the project root as `cwd`, not a worktree path — confirming the session is still preparing while the UI claims it's ready.
+- **Why this happens (two compounding bugs)**:
+  1. **Version-gate dropped the first frame.** The server creates new sessions with `statusVersion: 0` and immediately broadcasts `session_status: "preparing"`. The client tracks `_lastStatusVersion` on `RemoteAgent` and ignores any frame whose version is `<= _lastStatusVersion`. Pre-fix `_lastStatusVersion` initialised to `0`, so the very first frame failed the `0 <= 0` gate and `_state.status` was never written. The server-stamped baseline from `case "state"` *did* set the status correctly on attach, but only on the next reload — not on the live new-session path where `state` arrives with the same `statusVersion: 0` it raced.
+  2. **`requestUpdate()` was too narrow.** Even when `_state.status` flipped correctly, the UI didn't repaint. `RemoteAgent.onStatusChange` (in `src/app/session-manager.ts`) only called `agentInterface.requestUpdate()` for `"aborting"` and `"idle"`; `"preparing"` and `"starting"` fell through to the global `renderApp()` debounce. Lit's reference-equality short-circuit then refused to re-render the freshly-mounted `<agent-interface>` because `state` was the same object — the status mutation lived inside it. Net effect: even with bug 1 fixed, the banner wouldn't show on the new session.
+- **Fix invariants** (do not regress):
+  - `_lastStatusVersion` initialises to `-1` (uninitialised sentinel). The version-gate semantics for subsequent frames are unchanged — only the bootstrap is loosened.
+  - `RemoteAgent.onStatusChange` calls `agentInterface.requestUpdate()` for `preparing` / `starting` / `aborting` / `idle`. Do not narrow this list back to aborting/idle. The Lit reference-equality issue applies to *every* status change because `_state` is the same object.
+  - `case "session_status"` remains the sole client writer of `_state.status` (plus `case "state"` on attach and `reset()` on navigate, per [unify-session-status.md](design/unify-session-status.md)). The fix did not introduce a new writer.
+- **How to diagnose if it regresses**:
+  1. In DevTools → Network → WS, watch the inbound frames after creating a new session. There should be exactly one `session_status` frame with `status: "preparing"` and `statusVersion: 0`, followed later by another with `idle`.
+  2. Add a `console.log` at the top of `case "session_status"` in `src/app/remote-agent.ts`. If the preparing frame arrives but the log fires only once (for `idle`), the version gate is wrong — inspect `_lastStatusVersion` initial value.
+  3. If the log fires twice but the banner never paints, the `onStatusChange` re-render branch is the culprit. Confirm `agentInterface` is non-null at the call site (the new chat panel may finish its first paint *after* the frame; the `requestUpdate` call is a no-op then, but the next render pass picks up `state.isPreparing` correctly — no race in practice).
+  4. Reload during preparing. The server replays current status on `auth_ok` (`src/server/ws/handler.ts`). If the banner still appears, the live-path bug is the regression; if it doesn't, the replay path also broke — inspect the `auth_ok` write path.
+- **Regression test**: `tests/e2e/ui/preparing-ux.spec.ts` (browser E2E). It artificially extends the preparing window so the banner is observable, asserts visibility + editor disabled, then asserts both clear once the session goes idle.
+
 ## Compaction
 
 - Check `_isCompacting` and `_usageStaleAfterCompaction` in `remote-agent.ts`. The compaction placeholder is now a reducer action (`compaction-placeholder` / `compaction-result`) — see `src/app/message-reducer.ts`.
@@ -511,6 +528,24 @@ See [docs/internals.md — Skill chip rendering & autonomous activation](interna
 - Quick check: open the QA session's transcript and inspect a `browser_screenshot` tool result. Post-fix results contain `[screenshot_file]<absolute-path>[/screenshot_file]`. If you still see `[screenshot_base64]data:image/...[/screenshot_base64]`, the browser tool extension is stale — rebuild and restart the server.
 - Spilled files live under `<session-cwd>/.bobbit-qa/screenshots/`. The directory is gitignored and deleted on session shutdown. If stale dirs remain after a crash, they are safe to `rm -rf`.
 - Reports referencing screenshots via `<img src="file://...">` are inlined to base64 by the server when the agent submits via `report_html_file` (20 MB cumulative cap, session-cwd-scoped). See [qa-testing.md — Screenshots in QA reports](qa-testing.md#screenshots-in-qa-reports).
+
+## Slow first-session preparing window on cold boot
+
+- **Symptom**: the first session created after `npm run dev:harness` (or any fresh server start) sits in `preparing` for tens of seconds to minutes; subsequent sessions in the same server lifetime are fast. Server stdout shows `[worktree-setup] bobbit: ok` only after a long delay; until that line, every new session falls through to the cold-path `createWorktree` + per-component `runComponentSetups()` (e.g. `npm ci`).
+- **Why this happens (pre-fix)**: `runBootBackgroundTasks()` in `src/server/server.ts` awaited the orphan-worktree sweeper across **all** registered projects sequentially before starting **any** pool init. With even a handful of stale session worktrees on disk the sweeper invoked multiple `git worktree list` / `git worktree repair` calls per repo, each with 10–15 s timeouts (especially slow on Windows). Pool init for project N didn't begin until projects 1…N−1 had finished sweeping, so the pool was empty for the entire window — every new session paid the full cold-path cost.
+- **What changed**: sweeper and pool init now run concurrently via `Promise.all`. Per-project pool init is also parallelised across projects. Boot timing is logged with the `[boot]` prefix:
+  - `[boot] sweeper start`
+  - `[boot] sweeper done in Xms`
+  - `[boot] pool ready: project=Y in Zms`
+  - `[boot] background tasks complete in Wms`
+  Reading these lines lets you attribute the wait empirically (sweeper vs per-project pool fill vs `npm ci`).
+- **Why parallelising sweeper + pool init is safe**: the two operate on disjoint branch sets. The sweeper explicitly skips pool branches (`isPoolBranch` filter in `src/server/agent/worktree-sweeper.ts`), and `WorktreePool.reclaimOrphaned` only inspects pool branches. The historical comment in `server.ts` claiming a strict ordering invariant between sweeper and pool was over-stated — there is no shared mutation point. If you reintroduce a sequential await for some unrelated reason, verify the disjoint-set invariant still holds first.
+- **How to diagnose**:
+  1. Read the `[boot]` lines in server stdout (or `.bobbit/state/server.log` if redirected). Sweeper time and per-project pool time are reported separately. If `[boot] sweeper done` is the dominant cost, the sweeper itself needs follow-up work (per-project parallelism inside it; parallel per-repo `git worktree list`). If `[boot] pool ready: project=X in Yms` dominates, the cost is in the pool fill (`createWorktree` + setup hook).
+  2. Confirm pool fill actually started before the sweeper finished by comparing timestamps on `[boot] sweeper start` vs the first `[worktree-pool] _fill` log line.
+  3. If the dev server is being smoke-tested against a clean checkout and you want to skip the pool entirely (e.g. CI), set `BOBBIT_SKIP_WORKTREE_POOL=1`. Sessions then always take the cold path — useful as a baseline measurement.
+- **Mitigations not yet applied (follow-up candidates)**: per-project parallelism *inside* the sweeper itself; parallel per-repo `git worktree list` invocations; pre-warming `node_modules` outside the per-session window so the cold path is cheap.
+- **Test-only knob**: a deterministic preparing-window extension hook exists in `src/server/agent/session-setup.ts` for the regression E2E (`tests/e2e/ui/preparing-ux.spec.ts`). It is intentionally undocumented in user-facing material; do not surface it as a tuning option.
 
 ## Worktree setup hook not running
 

--- a/docs/design/unify-session-status.md
+++ b/docs/design/unify-session-status.md
@@ -646,3 +646,10 @@ The landing diff matches the design above. A few small deviations from the as-de
 - **`_isAborting` mirror retained.** Section §8's optional further deletion (collapse `_isAborting` into a getter) was deferred — the field is updated in lock-step with `_state.status` inside the single `session_status` writer, so it cannot drift, and keeping it avoids touching every `isAborting` reader in this PR.
 
 The four client writers of `_state.isStreaming` collapsed to a single canonical-status writer, and the ~14 server transition sites collapsed to `broadcastStatus()` calls. Acceptance criteria 1–4 are covered by `tests/remote-agent-status.spec.ts`, `tests/session-manager-status.test.ts`, and `tests/e2e/ui/session-status-recovery.spec.ts`. AC #5 ("net code reduction") landed as the writer-count reduction described in §8 — raw LOC is roughly neutral once the heartbeat, gap-detection branch, and JSDoc are accounted for.
+
+### Follow-up: preparing-UX bootstrap fix (`goal/fix-prepar-0d718a5c`)
+
+The original implementation initialised `_lastStatusVersion` to `0`, which silently dropped the very first `session_status` frame on a brand-new session (server creates sessions with `statusVersion: 0`, so the version gate `n <= _lastStatusVersion` rejected `0 <= 0` as a duplicate). Two small adjustments were made; the unify-session-status invariants (single server writer `broadcastStatus()`; sole client writers `case "session_status"`, `case "state"`, `reset()`) are unchanged.
+
+- **`_lastStatusVersion` initialises to `-1`** (uninitialised sentinel) so the first frame is always applied. The version-gate semantics for subsequent frames are unchanged.
+- **`RemoteAgent.onStatusChange` triggers `requestUpdate()` for `preparing` / `starting` / `aborting` / `idle`.** The Lit reference-equality issue applies to all status changes that don't change object identity — `state` is the same object across mutations, so the global `renderApp()` debounce can short-circuit and refuse to repaint a freshly-mounted `<agent-interface>`. Explicit `requestUpdate()` on every meaningful status edge sidesteps this.

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -140,8 +140,13 @@ export class RemoteAgent {
 	/** Monotonic statusVersion of the last applied `session_status` frame.
 	 *  Used to drop heartbeats / duplicates (`<=` lastApplied), apply normal
 	 *  increments (`==` last+1), and request a `status_resync` on gaps (`>` last+1).
-	 *  Reset to 0 on `reset()`. See docs/design/unify-session-status.md §4.2. */
-	private _lastStatusVersion = 0;
+	 *  Initialised to -1 (and reset to -1 on `reset()`) so the FIRST frame on a
+	 *  fresh connection is always applied — the server creates worktree-backed
+	 *  sessions with `statusVersion: 0`, and treating `0 <= 0` as a duplicate
+	 *  would leave `_state.status` stuck at the constructor default "idle",
+	 *  preventing the preparing-UX banner from ever rendering.
+	 *  See docs/design/unify-session-status.md §4.2. */
+	private _lastStatusVersion = -1;
 
 	// Auto-reconnect state
 	private _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -781,7 +786,7 @@ export class RemoteAgent {
 		this._state.streamingMessage = null;
 		this.streamingMessageId = undefined;
 		this._state.status = "idle";
-		this._lastStatusVersion = 0;
+		this._lastStatusVersion = -1;
 		this._isAborting = false;
 		this._state.pendingToolCalls = new Set();
 		this._state.error = undefined;

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -398,6 +398,7 @@ export function renderSessionRow(session: GatewaySession) {
 	const mobile = !isDesktop();
 	const active = activeSessionId() === session.id;
 	const connecting = state.connectingSessionId === session.id;
+	const preparing = session.status === "preparing" || session.status === "starting";
 	const displayTitle = active && state.remoteAgent ? state.remoteAgent.title : session.title;
 	const isActive = session.status === "streaming" || session.status === "busy" || session.isCompacting;
 
@@ -437,12 +438,12 @@ export function renderSessionRow(session: GatewaySession) {
 				@click=${(e: Event) => { e.stopPropagation(); toggleArchivedParentExpanded(session.id); renderApp(); }}
 			>${childrenExpanded ? "▾" : "▸"}</span>` : ""}
 			<div class="shrink-0 flex items-center justify-center">
-				${connecting
+				${connecting || preparing
 					? html`<svg class="animate-spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>`
 					: statusBobbit(session.status, session.isCompacting, session.id, active, session.isAborting, session.role === "team-lead", session.role === "coder", session.accessory)}
 			</div>
 			<div class="flex-1 min-w-0 flex flex-col justify-center">
-				<div class="${mobile ? "flex items-center gap-1 min-w-0" : ""} font-normal"><span class="truncate" style="${mobile ? "font-size: 1.3333em;" : ""}">${renderSessionTitle(displayTitle, isActive, state.searchQuery)}</span>${mobile ? html`<span class="shrink-0 text-muted-foreground/40" style="font-size: 0.9167em;">·</span>${renderSessionTime(session)}` : ""}</div>
+				<div class="${mobile ? "flex items-center gap-1 min-w-0" : ""} font-normal"><span class="truncate" style="${mobile ? "font-size: 1.3333em;" : ""}">${renderSessionTitle(displayTitle, isActive, state.searchQuery)}</span>${preparing ? html`<span class="shrink-0 text-muted-foreground/60 italic ml-1" style="font-size: 0.8333em;">preparing…</span>` : ""}${mobile ? html`<span class="shrink-0 text-muted-foreground/40" style="font-size: 0.9167em;">·</span>${renderSessionTime(session)}` : ""}</div>
 			</div>
 			${mobile
 				? buttons

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -2678,7 +2678,7 @@ export function doRenderApp(): void {
 					<div class="flex items-center w-full pr-0.5 gap-1" style="min-height:40px;">
 						<div class="shrink-0">${backBtn}</div>
 						<div class="flex-1 min-w-0 flex flex-col justify-center">
-							<span class="mobile-header-title font-medium text-foreground inline-flex items-center gap-1 min-w-0" title=${headerTitle}><span class="truncate">${headerTitle}</span>${activeSession?.sandboxed ? renderSandboxIndicator(activeSession.status) : ""}</span>
+							<span class="mobile-header-title font-medium text-foreground inline-flex items-center gap-1 min-w-0" title=${headerTitle}><span class="truncate">${headerTitle}</span>${activeSession?.sandboxed ? renderSandboxIndicator(activeSession.status) : ""}${(activeSession?.status === "preparing" || activeSession?.status === "starting") ? html`<span class="shrink-0 text-muted-foreground/70 italic" style="font-size:0.75em;">preparing…</span>` : ""}</span>
 							${goalTitle ? html`<span class="text-[10px] text-muted-foreground/60 truncate uppercase tracking-wider">${goalTitle}</span>` : ""}
 						</div>
 						<div class="shrink-0">${editDeleteBtns}</div>
@@ -2691,7 +2691,7 @@ export function doRenderApp(): void {
 			return html`
 				<div class="flex items-center gap-2 px-3 min-w-0 flex-1">
 					<div class="flex flex-col min-w-0 py-1">
-						<span class="text-sm font-medium text-foreground inline-flex items-center gap-1 min-w-0" title=${headerTitle}><span class="truncate">${headerTitle}</span>${deskSession?.sandboxed ? renderSandboxIndicator(deskSession.status) : ""}</span>
+						<span class="text-sm font-medium text-foreground inline-flex items-center gap-1 min-w-0" title=${headerTitle}><span class="truncate">${headerTitle}</span>${deskSession?.sandboxed ? renderSandboxIndicator(deskSession.status) : ""}${(deskSession?.status === "preparing" || deskSession?.status === "starting") ? html`<span class="shrink-0 text-muted-foreground/70 italic" style="font-size:0.85em;">preparing…</span>` : ""}</span>
 						${deskGoalTitle ? html`<span class="text-[10px] text-muted-foreground/60 truncate uppercase tracking-wider">${deskGoalTitle}</span>` : ""}
 					</div>
 				</div>

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -1037,7 +1037,13 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 				}
 				// Trigger Lit re-render for aborting indicator — isAborting is read
 				// from the session object (same reference), so Lit won't detect the change.
-				if ((status === "aborting" || status === "idle") && state.chatPanel?.agentInterface) {
+				if (
+					(status === "aborting" ||
+						status === "idle" ||
+						status === "preparing" ||
+						status === "starting") &&
+					state.chatPanel?.agentInterface
+				) {
 					state.chatPanel.agentInterface.requestUpdate();
 				}
 			}

--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -579,6 +579,18 @@ export async function executeWorktreeAsync(
 	ctx: PipelineContext,
 	preBuiltWorktreePath?: string,
 ): Promise<void> {
+	// Test-only knob: deterministically extend the "preparing" window so the
+	// preparing-UX banner is observable to the client. Status is already set to
+	// "preparing" by SessionManager.createSession before this fn is invoked, so
+	// sleeping here keeps the session visibly preparing without changing
+	// production behaviour (gated on the env var being set).
+	if (process.env.BOBBIT_TEST_PREPARING_DELAY_MS) {
+		const delayMs = Number(process.env.BOBBIT_TEST_PREPARING_DELAY_MS);
+		if (Number.isFinite(delayMs) && delayMs > 0) {
+			await new Promise(resolve => setTimeout(resolve, delayMs));
+		}
+	}
+
 	// Use pre-built worktree from pool, or create one from scratch
 	let worktreeCwd: string;
 	if (preBuiltWorktreePath) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1151,56 +1151,68 @@ export function createGateway(config: GatewayConfig) {
 			// per project. Doing them before listen used to leave the gateway
 			// unreachable for many seconds on installs with stale worktrees.
 			//
-			// Ordering invariant preserved: the sweeper still runs before
-			// `initWorktreePoolForProject`, so the pool's `reclaimOrphaned`
-			// can't race against the sweeper. Requests that arrive during this
-			// window fall through the non-pool session path (the same path used
-			// before the pool ever fills).
+			// Concurrency note: the sweeper and the pool init operate on DISJOINT
+			// branch sets — `worktree-sweeper.ts` explicitly skips pool branches
+			// (`isPoolBranch`), and `WorktreePool.reclaimOrphaned` only inspects
+			// pool branches. So the two phases are run concurrently via
+			// `Promise.all`, and project-level pool init is also parallelised
+			// across projects (each project's pool is independent). This avoids
+			// the previous serial chain that left the pool empty for minutes on
+			// installs with many stale worktrees, forcing every new session
+			// through the cold path (full createWorktree + npm ci).
 			const runBootBackgroundTasks = async (): Promise<void> => {
-				try {
-					const { sweepOrphanedWorktrees } = await import("./agent/worktree-sweeper.js");
-					const sweepProjects: Array<{ id: string; rootPath: string; repos?: string[] }> = [];
-					const sweepGoals: Array<{ id: string; branch?: string; worktreePath?: string; archived?: boolean; repoWorktrees?: Record<string, string> }> = [];
-					const sweepSessions: Array<{ id: string; branch?: string; worktreePath?: string; archived?: boolean; repoWorktrees?: Record<string, string> }> = [];
-					const sweepStaff: Array<{ id: string; branch?: string; worktreePath?: string }> = [];
-					for (const ctx of projectContextManager.all()) {
-						const repoNames = ctx.projectConfigStore.repoNames();
-						sweepProjects.push({
-							id: ctx.project.id,
-							rootPath: ctx.project.rootPath,
-							repos: repoNames.length > 0 ? repoNames : undefined,
-						});
-						for (const g of ctx.goalStore.getAll()) {
-							sweepGoals.push({
-								id: g.id, branch: g.branch, worktreePath: g.worktreePath, archived: !!g.archived,
-								repoWorktrees: (g as { repoWorktrees?: Record<string, string> }).repoWorktrees,
-							});
-						}
-						for (const s of ctx.sessionStore.getAll()) {
-							sweepSessions.push({
-								id: s.id, branch: s.branch, worktreePath: s.worktreePath, archived: !!s.archived,
-								repoWorktrees: s.repoWorktrees,
-							});
-						}
-						for (const st of ctx.staffStore.getAll()) {
-							sweepStaff.push({ id: st.id, branch: (st as any).branch, worktreePath: (st as any).worktreePath });
-						}
-					}
-					const result = await sweepOrphanedWorktrees({
-						projects: sweepProjects,
-						goals: sweepGoals,
-						sessions: sweepSessions,
-						staff: sweepStaff,
-					});
-					if (result.reclaimed || result.cleaned || result.repaired) {
-						console.log(`[sweeper] reclaimed ${result.reclaimed}, cleaned ${result.cleaned}, repaired ${result.repaired}`);
-					}
-				} catch (err) {
-					console.warn("[server] Worktree sweeper failed (non-fatal):", err);
-				}
+				const t0 = Date.now();
 
-				if (!process.env.BOBBIT_SKIP_WORKTREE_POOL) {
-					for (const ctx of projectContextManager.all()) {
+				const sweeperTask = (async () => {
+					const tStart = Date.now();
+					try {
+						const { sweepOrphanedWorktrees } = await import("./agent/worktree-sweeper.js");
+						const sweepProjects: Array<{ id: string; rootPath: string; repos?: string[] }> = [];
+						const sweepGoals: Array<{ id: string; branch?: string; worktreePath?: string; archived?: boolean; repoWorktrees?: Record<string, string> }> = [];
+						const sweepSessions: Array<{ id: string; branch?: string; worktreePath?: string; archived?: boolean; repoWorktrees?: Record<string, string> }> = [];
+						const sweepStaff: Array<{ id: string; branch?: string; worktreePath?: string }> = [];
+						for (const ctx of projectContextManager.all()) {
+							const repoNames = ctx.projectConfigStore.repoNames();
+							sweepProjects.push({
+								id: ctx.project.id,
+								rootPath: ctx.project.rootPath,
+								repos: repoNames.length > 0 ? repoNames : undefined,
+							});
+							for (const g of ctx.goalStore.getAll()) {
+								sweepGoals.push({
+									id: g.id, branch: g.branch, worktreePath: g.worktreePath, archived: !!g.archived,
+									repoWorktrees: (g as { repoWorktrees?: Record<string, string> }).repoWorktrees,
+								});
+							}
+							for (const s of ctx.sessionStore.getAll()) {
+								sweepSessions.push({
+									id: s.id, branch: s.branch, worktreePath: s.worktreePath, archived: !!s.archived,
+									repoWorktrees: s.repoWorktrees,
+								});
+							}
+							for (const st of ctx.staffStore.getAll()) {
+								sweepStaff.push({ id: st.id, branch: (st as any).branch, worktreePath: (st as any).worktreePath });
+							}
+						}
+						console.log(`[boot] sweeper start (${sweepProjects.length} projects)`);
+						const result = await sweepOrphanedWorktrees({
+							projects: sweepProjects,
+							goals: sweepGoals,
+							sessions: sweepSessions,
+							staff: sweepStaff,
+						});
+						console.log(`[boot] sweeper done in ${Date.now() - tStart}ms (reclaimed=${result.reclaimed} cleaned=${result.cleaned} repaired=${result.repaired})`);
+					} catch (err) {
+						console.warn(`[boot] sweeper failed in ${Date.now() - tStart}ms (non-fatal):`, err);
+					}
+				})();
+
+				const poolInitTask = (async () => {
+					if (process.env.BOBBIT_SKIP_WORKTREE_POOL) return;
+					const contexts = Array.from(projectContextManager.all());
+					console.log(`[boot] pool init start (${contexts.length} projects)`);
+					await Promise.all(contexts.map(async (ctx) => {
+						const tStart = Date.now();
 						try {
 							const repoPath = ctx.project.rootPath;
 							const components = ctx.projectConfigStore.getComponents();
@@ -1225,10 +1237,18 @@ export function createGateway(config: GatewayConfig) {
 								// pool entries land under <gitRoot>-wt/, not <projectDir>-wt/.
 								const poolRepoPath = isMulti ? repoPath : await getRepoRoot(repoPath);
 								sessionManager.initWorktreePoolForProject(ctx.project.id, poolRepoPath, () => pcs.getComponents(), poolSize, wtRoot);
+								console.log(`[boot] pool ready: project=${ctx.project.id} in ${Date.now() - tStart}ms`);
+							} else {
+								console.log(`[boot] pool skipped (not a git repo): project=${ctx.project.id} in ${Date.now() - tStart}ms`);
 							}
-						} catch { /* best-effort */ }
-					}
-				}
+						} catch (err) {
+							console.warn(`[boot] pool init failed: project=${ctx.project.id} in ${Date.now() - tStart}ms (non-fatal):`, err);
+						}
+					}));
+				})();
+
+				await Promise.all([sweeperTask, poolInitTask]);
+				console.log(`[boot] background tasks complete in ${Date.now() - t0}ms`);
 			};
 
 			// Wire goal-manager resolvers so goals claim through the pool first and

--- a/tests/e2e/ui/preparing-ux.spec.ts
+++ b/tests/e2e/ui/preparing-ux.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Preparing UX — reproducing test for the "Setting up worktree…" banner bug.
+ *
+ * Bug: when a brand-new worktree-backed session is created via the UI, the
+ * "Setting up worktree…" banner does NOT appear in the chat panel and the
+ * message editor stays enabled. Reload masks the bug because the status frame
+ * lands before <agent-interface> is constructed.
+ *
+ * Root cause: src/app/session-manager.ts::RemoteAgent.onStatusChange only
+ * calls agentInterface.requestUpdate() for "aborting"/"idle". For "preparing"
+ * it falls through to renderApp(), which doesn't re-render the existing
+ * <agent-interface> instance (Lit reference-equality misses the change).
+ *
+ * This spec deterministically extends the preparing window by setting
+ * BOBBIT_TEST_PREPARING_DELAY_MS and asserts the banner is visible.
+ * Pre-fix this assertion fails. Post-fix all three phases (banner visible,
+ * editor hidden, banner clears + editor shows) pass.
+ */
+import { test, expect } from "../gateway-harness.js";
+import { apiFetch } from "../e2e-setup.js";
+import { openApp } from "./ui-helpers.js";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+const PREPARING_DELAY_MS = 3000;
+
+test.describe("Preparing UX (worktree-backed session)", () => {
+	let repoPath: string;
+	let projectId: string;
+
+	test.beforeAll(async () => {
+		// Set the test-only env-var hook so the server-side worktree pipeline
+		// sleeps after status="preparing" is broadcast and before the worktree
+		// is actually created. Read at call-time inside executeWorktreeAsync;
+		// the worker process is the same one the gateway boots in, so setting
+		// it here is sufficient.
+		process.env.BOBBIT_TEST_PREPARING_DELAY_MS = String(PREPARING_DELAY_MS);
+
+		// Real git repo so worktree creation runs.
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-prep-ux-"));
+		repoPath = path.join(root, "repo");
+		fs.mkdirSync(repoPath, { recursive: true });
+		execFileSync("git", ["init", "--initial-branch=master"], { cwd: repoPath });
+		execFileSync("git", ["config", "user.email", "test@bobbit.local"], { cwd: repoPath });
+		execFileSync("git", ["config", "user.name", "test"], { cwd: repoPath });
+		fs.writeFileSync(path.join(repoPath, "README.md"), "fixture\n");
+		execFileSync("git", ["add", "."], { cwd: repoPath });
+		execFileSync("git", ["commit", "-m", "init"], { cwd: repoPath });
+
+		const reg = await apiFetch("/api/projects", {
+			method: "POST",
+			body: JSON.stringify({ name: `prep-ux-${Date.now()}`, rootPath: repoPath }),
+		});
+		expect(reg.status).toBe(201);
+		projectId = (await reg.json()).id;
+	});
+
+	test.afterAll(async () => {
+		delete process.env.BOBBIT_TEST_PREPARING_DELAY_MS;
+		if (projectId) {
+			await apiFetch(`/api/projects/${projectId}?force=1`, { method: "DELETE" }).catch(() => {});
+		}
+	});
+
+	test("banner is visible and editor is hidden while preparing, then clears", async ({ page }) => {
+		await openApp(page);
+
+		// Click "New session in <project-name>" for our test project. The title
+		// carries a timestamp suffix; match by prefix.
+		await page.locator(`button[title^="New session in prep-ux-"]`).first().click();
+
+		// PRIMARY ASSERTION — fails pre-fix. The banner must appear within ~1s
+		// of session creation. Generous timeout so a slow CI doesn't false-fail
+		// on infra latency, but well under PREPARING_DELAY_MS so we're still
+		// inside the preparing window.
+		const banner = page.getByText("Setting up worktree…");
+		await expect(banner).toBeVisible({ timeout: 2000 });
+
+		// Editor is hidden while preparing — the AgentInterface gate at line
+		// 1642 hides <message-editor> when state.isPreparing.
+		await expect(page.locator("message-editor")).toHaveCount(0);
+
+		// After the preparing window elapses, banner clears and editor mounts.
+		await expect(banner).toBeHidden({ timeout: PREPARING_DELAY_MS + 10_000 });
+		await expect(page.locator("textarea").first()).toBeVisible({ timeout: 5000 });
+	});
+
+});


### PR DESCRIPTION
## Summary

Fixes two regressions that surface together when a user creates a new session before the worktree pool has filled:

1. **"Setting up worktree…" banner never appeared** for brand-new sessions — message editor stayed enabled, prompts landed silently in the queue.
2. **First session could sit in \`preparing\` for tens of seconds** on a cold boot with stale orphan worktrees on disk.

## Root causes

**Banner missing** — two compounding bugs:
- Server creates new sessions with \`statusVersion: 0\`. Client \`_lastStatusVersion\` was initialised to \`0\`, so the version gate \`n <= _lastStatusVersion\` (\`0 <= 0\`) treated the very first \`session_status: preparing\` frame as a duplicate and never wrote \`_state.status\`.
- Even when status mutated, \`RemoteAgent.onStatusChange\` only called \`agentInterface.requestUpdate()\` for \`aborting\`/\`idle\` — Lit reference-equality misses same-object mutations, so the existing \`<agent-interface>\` instance never re-rendered the banner gate.

**Slow boot** — \`runBootBackgroundTasks\` in \`src/server/server.ts\` ran the orphan-worktree sweeper across all projects to completion before starting any pool init. Until pool init kicked in, every new session fell through to the cold path (full \`createWorktree\` + per-component \`runComponentSetups\`, e.g. \`npm ci\`). The "ordering invariant" in the existing comment was over-stated: the sweeper explicitly skips pool branches (\`isPoolBranch\` in \`worktree-sweeper.ts\`) and \`WorktreePool.reclaimOrphaned\` only inspects pool branches — they operate on disjoint sets and can run concurrently.

## Changes

### Client (\`src/app/\`)
- \`remote-agent.ts\` — initialise \`_lastStatusVersion = -1\` so the first \`session_status\` frame is always applied. Updated JSDoc.
- \`session-manager.ts\` — \`onStatusChange\` calls \`agentInterface.requestUpdate()\` for \`preparing\` and \`starting\` too.
- \`render.ts\`, \`render-helpers.ts\` — sidebar list rows and header chip show a small spinner + "preparing…" label while \`session.status === "preparing" || "starting"\`.

### Server (\`src/server/\`)
- \`server.ts\` — \`runBootBackgroundTasks\`: sweeper and per-project pool init now run concurrently via \`Promise.all\`. Per-project pool init parallelised. Updated invariant comment to reflect disjoint-set reasoning.
- \`server.ts\` — added \`[boot]\` timing logs: \`sweeper start\`, \`sweeper done in Xms\`, \`pool ready: project=Y in Zms\`, \`background tasks complete in Wms\`.
- \`session-setup.ts\` — minimal test-only env-var hook \`BOBBIT_TEST_PREPARING_DELAY_MS\` for deterministic E2E. No-op when unset.

### Tests
- \`tests/e2e/ui/preparing-ux.spec.ts\` — new browser E2E asserting banner visibility, editor hidden during preparing, and that both clear once the session goes idle.

### Documentation
- \`AGENTS.md\` — three new index entries (recipes + two debugging keywords).
- \`docs/debugging.md\` — two full walkthroughs (banner-missing, slow-boot).
- \`docs/design/unify-session-status.md\` — follow-up note on \`_lastStatusVersion = -1\` and the expanded \`requestUpdate\` set.

## Invariants preserved
- \`broadcastStatus()\` remains the **sole server writer** of \`session.status\`.
- \`case "session_status"\` remains the **sole client writer** of \`_state.status\`.
- Steer / queue invariants — prompts sent during \`preparing\` continue to land in \`promptQueue\` and drain on idle.
- \`BOBBIT_SKIP_WORKTREE_POOL=1\` skip path still works.

## Verification

- \`npm run check\` clean.
- New reproducing test fails on the pre-fix HEAD with the expected \`expect(banner).toBeVisible()\` timeout, passes on the fix HEAD.
- Full E2E suite passes (\`973/985 + 12 skipped + 5 flaky-recovered\`).
- Implementation gate verification passed across build, type-check, repro test, E2E, gap analysis, code quality review, regression coverage, security review.
- Manual: banner visible on brand-new session creation; \`[boot]\` log lines now attribute boot time empirically.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)