### PR TITLE
docs(AGENTS.md): re-trim 10.7k → 6.8k tokens (−36%) + prevent re-bloat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ See [docs/testing-strategy.md](docs/testing-strategy.md), [docs/testing-coverage
 
 ## Recipes
 
-One-liner task → entry point. Follow links for walkthroughs.
+One-liner task → entry point. Follow links for walkthroughs. **Keep entries to one line each — detail belongs in the linked doc.**
 
 ### Tests
 - **Add an API E2E test** → `tests/e2e/`, import `./in-process-harness.js`. See `gates-api.spec.ts`.
@@ -47,38 +47,34 @@ One-liner task → entry point. Follow links for walkthroughs.
 ### Server / API
 - **Add a REST endpoint** → `handleApiRoute()` in `src/server/server.ts`. See [docs/rest-api.md](docs/rest-api.md).
 - **Add a WebSocket command** → `ClientMessage` in `ws/protocol.ts`, handle in `ws/handler.ts`, add `RpcBridge` method.
-- **Add a tool** → builtin: `defaults/tools/<group>/`. Project override: `.bobbit/config/tools/<group>/`. MCP auto-discovered from `.mcp.json`. YAML fields driving the per-turn `# Tools` section in the system prompt:
-  - `params: [name, name?, ...]` (optional) — renders as `name(params) — summary`. Trailing `?` marks an optional parameter. Omit the field to render as `name — summary` with no parens.
-  - `summary` — ≤ 10 words, sentence-fragment OK; this is the only prose shown per-turn.
-  - `description` (function-schema field) — ≤ 15 words; what the model sees alongside the JSON-schema params.
-  - `docs` and `detail_docs` are **not** inlined into the prompt. They are folded (in that order) into `<stateDir>/tool-docs/<group>.md` by `generateDetailDocs()`, and the prompt's per-group header points at that file (`## <Group> — see <path>`). Put any prose, examples, anti-patterns there. See [docs/internals.md — MCP tool documentation](docs/internals.md#mcp-tool-documentation) for the full prompt layout.
+- **Add a tool** → builtin: `defaults/tools/<group>/`. Project override: `.bobbit/config/tools/<group>/`. MCP auto-discovered from `.mcp.json`. YAML fields and prompt layout: see [docs/internals.md — MCP tool documentation](docs/internals.md#mcp-tool-documentation).
 - **Add a slash skill** → `SKILL.md` in `.claude/skills/<name>/` with YAML frontmatter. See [docs/design/skill-ux-and-autonomous-activation.md](docs/design/skill-ux-and-autonomous-activation.md).
 - **Add a blocking tool** → harness parks Promise keyed by `(sessionId, toolUseId)`. See [docs/blocking-tools.md](docs/blocking-tools.md). (`ask_user_choices` is non-blocking — see [docs/non-blocking-ask.md](docs/non-blocking-ask.md).)
 - **Modify a store constructor** → stores take `stateDir`/`configDir` params; never module-level globals. All resolution via `ProjectContextManager` (`src/server/agent/project-context-manager.ts`).
 - **Add/modify session creation** → `session-setup.ts`, wrappers in `session-manager.ts`. See [docs/internals.md — Session worktrees](docs/internals.md#session-worktrees).
 - **Add a goal feature** → `goal-manager.ts` / `goal-store.ts`, REST in `server.ts`, assistant in `goal-assistant.ts`. See [docs/goals-workflows-tasks.md](docs/goals-workflows-tasks.md).
 - **Add a verification reminder site** → `src/server/agent/verification-harness.ts`. Await `waitForStreaming(...).catch(()=>{})` before `waitForIdle`.
-- **Return errors from a server handler** → use `jsonError(status, err, extra?)` in `src/server/server.ts` for any caught exception so `stack` flows to the client modal. Validation responses with literal strings stay as `json({ error: "..." }, ...)`. See [docs/rest-api.md — Error response shape](docs/rest-api.md#error-response-shape).
+- **Return errors from a server handler** → use `jsonError(status, err, extra?)` in `src/server/server.ts` so `stack` flows to the client modal. Validation responses with literal strings stay as `json({ error: "..." }, ...)`. See [docs/rest-api.md — Error response shape](docs/rest-api.md#error-response-shape).
 
 ### Sessions, status, steer
-- **Mutate session status** → `broadcastStatus()` in `src/server/agent/session-status.ts` is the **single writer** for `session.status`. Client: `_state.status` on `RemoteAgent` is canonical; `isStreaming`/`isArchived`/`isPreparing` are derived getters. `case "session_status"` is the sole writer (plus `case "state"` on attach, `reset()` on navigate). `agent_start`/`agent_end`/`error` are signals only. See [docs/design/unify-session-status.md](docs/design/unify-session-status.md).
+- **Mutate session status** → `broadcastStatus()` in `src/server/agent/session-status.ts` is the **single writer** for `session.status`. Client: `_state.status` on `RemoteAgent` is canonical; `isStreaming`/`isArchived`/`isPreparing` are derived getters. `case "session_status"` is the sole writer (plus `case "state"` on attach, `reset()` on navigate). See [docs/design/unify-session-status.md](docs/design/unify-session-status.md).
 - **Modify steer / queue dispatch** → single dispatch site `SessionManager._dispatchSteer()` in `src/server/agent/session-manager.ts`. Rows leave `promptQueue` *before* `rpcClient.steer()`, then enter shadow ledger `inFlightSteerTexts`. Never reintroduce `PromptQueue.dispatched`. See [docs/design/steer-subsystem-rewrite.md](docs/design/steer-subsystem-rewrite.md).
 - **Continue an archived session** → `POST /api/sessions/:archivedId/continue`. See [docs/design/lossless-continue-archived.md](docs/design/lossless-continue-archived.md).
 - **Re-attempt a goal** → `POST /api/sessions { reattemptGoalId }` → `buildReattemptContext()`.
 - **Server-side read/unread state** → `lastReadAt` on `PersistedSession`; `POST /api/sessions/:id/mark-read`.
-- **Read another session's transcript (`read_session` tool)** → parser `src/server/agent/transcript-reader.ts`; `GET /api/sessions/:id/transcript`; same-project auth via `x-bobbit-session-id` header.
-- **Initialise / read client-side session status on a fresh attach** → `_lastStatusVersion` starts at `-1` in `src/app/remote-agent.ts`; first `session_status` frame is always applied. Both `case "state"` and `case "session_status"` may write `_state.status`. UI re-renders for `preparing`/`starting`/`aborting`/`idle` via explicit `requestUpdate()` in `src/app/session-manager.ts::onStatusChange`.
+- **Read another session's transcript** → `read_session` tool; parser `src/server/agent/transcript-reader.ts`; `GET /api/sessions/:id/transcript`; same-project auth via `x-bobbit-session-id` header.
+- **Initialise client-side status on fresh attach** → `_lastStatusVersion` starts at `-1` in `src/app/remote-agent.ts`; `RemoteAgent.onStatusChange` calls `requestUpdate()` for `preparing`/`starting`/`aborting`/`idle` (Lit reference-equality misses same-object mutations).
 
 ### UI
 - **Add a UI component** → `src/ui/components/`, export from `src/ui/index.ts`.
 - **Add a tool renderer** → `src/ui/tools/renderers/`, register in `src/ui/tools/index.ts`. See `ProposalRenderer.ts`.
-- **Show a server error in a modal** → `<error-details>` (`src/ui/components/ErrorDetails.ts`) renders message + optional code + collapsible stack. API wrappers in `src/app/api.ts` parse `await res.json()`, attach `code`/`stack` to the thrown `Error`, and forward both to `showConnectionError(title, message, { code, stack })` in `src/app/dialogs.ts`. The background polling site in `refreshSessions()` (`src/app/api.ts`) is intentionally silent.
+- **Show a server error in a modal** → `<error-details>` (`src/ui/components/ErrorDetails.ts`); API wrappers in `src/app/api.ts` parse `code`/`stack` and forward to `showConnectionError(...)` in `src/app/dialogs.ts`. Background polling in `refreshSessions()` is intentionally silent.
 - **Add a route-level page (lazy-loaded)** → add a `lazyPage(...)` branch in `mainArea()` in `src/app/render.ts`. See [docs/design/ui-bundle-size-reduction.md](docs/design/ui-bundle-size-reduction.md).
 - **Add a heavy tool renderer (lazy)** → `registerLazyToolRenderer()` in `src/ui/tools/index.ts`; placeholder + `TOOL_RENDERER_LOADED_EVENT` swap.
 - **Defer a heavy library (lazy load)** → `src/ui/lazy/markdown-block.ts::ensureMarkdownBlock()` pattern; or `await import()` for value imports.
 - **Change message rendering** → `src/ui/components/Messages.ts` (standard); `message-renderer-registry.ts` (custom).
 - **Modify message transcript ordering** → all transcript mutations route through `reduce(state, action)` in `src/app/message-reducer.ts`. Never push directly into `state.messages`. See [docs/design/unified-message-ordering-reducer.md](docs/design/unified-message-ordering-reducer.md).
-- **Modify snapshot ↔ live merge / `getMessages` splice** → server holds the in-flight `message_update` payload on `SessionInfo.latestMessageUpdate` (set on `message_update`, cleared on `message_end` / `agent_end` / `process_exit`) and every snapshot-return site (`get_messages`, `refreshAfterCompaction`, role-switch refresh, title generation) splices via `spliceInFlightMessage()` in `src/server/agent/splice-inflight-message.ts` — without this a snapshot taken mid-stream drops the in-flight row because the agent flushes to `.jsonl` only on `message_end`. Client survivor filter in `case "snapshot"` enforces the structural invariant: live rows with `_order > snapshotMaxOrder` survive (the H3 guard, scoped to `_order > 0`); plain-text dedup is multiset (`Map<key,count>`), not Set, so N identical-text rows aren't collapsed; prior-snapshot artifacts (`_origin: "server"` with `_order <= 0` not represented by the new snapshot) are dropped — handles abandoned-partial pivots from streaming text to `tool_use` without a closing `message_end`. See [docs/design/snapshot-live-race-fix.md](docs/design/snapshot-live-race-fix.md).
+- **Modify snapshot ↔ live merge / `getMessages` splice** → server splices in-flight `message_update` via `spliceInFlightMessage()` in `src/server/agent/splice-inflight-message.ts`; client survivor filter in `case "snapshot"` enforces `_order > snapshotMaxOrder` guard + multiset plain-text dedup. See [docs/design/snapshot-live-race-fix.md](docs/design/snapshot-live-race-fix.md).
 - **Modify proposal panel streaming UX** → flag in `state.proposalStreamingByTag`; scroll preserved via `reconcileFollowTail` in `src/app/follow-tail.ts`.
 - **Large content truncation** → `truncate-large-content.ts` (>32 KB). Lazy-load via `GET /api/sessions/:id/tool-content/:mi/:bi`.
 - **Copy session link button** → header ghost icon in `src/app/render.ts`. `showHeaderToast()` (`data-testid="header-toast"`, distinct from `proposal-toast`); `CopyLinkFallbackDialog` on clipboard reject.
@@ -111,96 +107,120 @@ One-liner task → entry point. Follow links for walkthroughs.
 ### Proposals
 - **Edit a proposal mid-session** → `view_proposal(type)` / `edit_proposal(type, old, new)`. Per-rev snapshots under `<stateDir>/proposal-drafts/<sessionId>/<type>.history/`. See [docs/design/editable-proposals.md](docs/design/editable-proposals.md).
 - **Dismiss/restore invariant for proposal panels** → `goalDraft.restore`/`roleDraft.restore`/`projectDraft.restore` in `src/app/session-manager.ts` gate rehydration on `isProposalDismissedTyped`. Dismiss does NOT delete the on-disk draft. Only `goal`/`role`/`project` persist drafts; `staff`/`tool`/`workflow` are transient.
-- **Header toast vs proposal toast testid collision** → `header-toast` vs `proposal-toast`; two slots in `src/app/render.ts`.
-- **Project-proposal "Changes Saved" state after Apply Changes (registered mode)** → `state.projectProposalAcceptedBySessionId` flag, set in `acceptRegisteredProjectProposal()`, persisted via `projectDraft.serialize/restore`, cleared in the unified `onProposal` callback and all `activeProposals.project` cleanup sites. Terminate button shares `terminateProjectAssistantSession()` with the provisional path. See [docs/design/project-proposal-saved-state.md](docs/design/project-proposal-saved-state.md).
+- **Project-proposal "Changes Saved" state (registered mode)** → `state.projectProposalAcceptedBySessionId` flag, set in `acceptRegisteredProjectProposal()`, persisted via `projectDraft.serialize/restore`. See [docs/design/project-proposal-saved-state.md](docs/design/project-proposal-saved-state.md).
 
 ### Worktree (operational)
 - **Pool worktree placed under `<projectDir>-wt/` instead of `<repoRoot>-wt/`** → `WorktreePool` constructor in `src/server/agent/worktree-pool.ts` resolves `opts.repoPath` to git toplevel; both `initWorktreePoolForProject` sites in `src/server/server.ts` also resolve. Pinned by `tests/worktree-pool-nested-rootpath.test.ts`.
 
 ### Preview / HTML / images
-- **Preview HTML with sibling assets** → `preview_open({ html | file, assets?, manifest? })`. **Explicit opt-in**: bare `file` copies only the entry HTML; siblings declared via `assets: [...]` or a `manifest` JSON. Snapshot marker: `__preview_snapshot_v3__`. Re-opening the same `file` (including paths that resolve inside the mount itself) is safe — `mountFile()` stages into a sibling tmp dir and atomically swaps. See [docs/preview-architecture.md](docs/preview-architecture.md).
+- **Preview HTML with sibling assets** → `preview_open({ html | file, assets?, manifest? })`. **Explicit opt-in**: bare `file` copies only the entry HTML; siblings declared via `assets: [...]` or a `manifest` JSON. Snapshot marker: `__preview_snapshot_v3__`. Re-opening the same `file` is safe (`mountFile()` stages into a sibling tmp dir and atomically swaps). See [docs/preview-architecture.md](docs/preview-architecture.md).
 - **Author HTML output** → [`defaults/docs/html-rendering.md`](defaults/docs/html-rendering.md). One artefact, one surface. Use theme tokens (`--background`, `--card`, `--chart-1..6`, `--positive`/`--negative`/`--warning`/`--info`).
 - **Generate an image** → `generate_image` → `POST /api/image-generation/generate`.
 
 ## Debugging
 
-Keyword index — full diagnostic walkthroughs live in [docs/debugging.md](docs/debugging.md). All entries below: see `debugging.md` (or the named design doc) for the full checklist.
+Keyword index — full diagnostic walkthroughs live in [docs/debugging.md](docs/debugging.md). **One line per entry.** All entries: see `debugging.md` (or named design doc) for the checklist.
 
 ### Session / status / steer
 - **Session persistence** — `.bobbit/state/sessions.json`; missing `.jsonl` skips restore.
-- **`system-prompt.md` customisation not taking effect** — `resolveSystemPromptPath()` in `src/server/agent/system-prompt.ts`. See [debugging.md#system-promptmd-not-customised](docs/debugging.md#system-promptmd-not-customised).
-- **`lastActivity` reads "just now" after restart** — `isUserVisibleActivity` filter in `session-manager.ts`. See [debugging.md#lastactivity-reads-just-now-after-restart](docs/debugging.md#lastactivity-reads-just-now-after-restart).
-- **Sandbox status / project container** — `GET /api/sandbox-status`; label `bobbit-project=<projectId>`. See [debugging.md#sandbox-sessions](docs/debugging.md#sandbox-sessions).
-- **Stop button stuck visible while sprite is idle / duplicate user message on second send** — symptom of the legacy two-flag divergence between `_state.isStreaming` and `gatewaySessions[i].status`. Fixed by the canonical-status refactor: divergence is now structurally impossible because `isStreaming` is a derived getter over `_state.status`, and `_state.status` is healed within ≤15s by the server-side heartbeat (`broadcastStatus`-shaped frame re-emitted WITHOUT bumping `statusVersion`). If you see this regression, check that no new code path writes `_state.status` outside `case "session_status"` / `case "state"` / `reset()` on the client, and that no server site writes `session.status` outside `broadcastStatus()` in `src/server/agent/session-status.ts`. See [docs/design/unify-session-status.md](docs/design/unify-session-status.md) and `tests/e2e/ui/session-status-recovery.spec.ts`.
-- **Stuck gate verification** — `POST /api/goals/:id/gates/:gateId/cancel-verification`. See [debugging.md#gates](docs/debugging.md#gates).
-- **Worktree setup not running** — single source of truth `runComponentSetups()` in `src/server/skills/worktree-setup.ts`. See [debugging.md#worktree-setup-hook-not-running](docs/debugging.md#worktree-setup-hook-not-running).
-- **"Setting up worktree…" banner missing for first session / preparing UX absent** — `_lastStatusVersion` must initialise to `-1` so the first `session_status` frame (server uses `statusVersion: 0`) is applied; `case "session_status"` only writes `_state.status`, but `RemoteAgent.onStatusChange` must also call `agentInterface.requestUpdate()` for `"preparing"`/`"starting"` (Lit reference-equality misses same-object mutations). See `src/app/remote-agent.ts`, `src/app/session-manager.ts`.
-- **Slow first-session worktree creation on cold boot** — `runBootBackgroundTasks` in `src/server/server.ts` runs sweeper and pool init concurrently (`Promise.all`); they operate on disjoint branch sets (sweeper skips `isPoolBranch`; `WorktreePool.reclaimOrphaned` only touches pool branches). Boot timing logs prefixed `[boot]`. `BOBBIT_SKIP_WORKTREE_POOL=1` still bypasses pool entirely.
-- **Pool worktree placed under `<projectDir>-wt/` instead of `<repoRoot>-wt/`** — symptom of the nested-rootPath bug fixed in `WorktreePool` constructor. If you see this regression, check that `resolveRepoToplevel` in `src/server/agent/worktree-pool.ts` is intact and that both `initWorktreePoolForProject` call sites in `server.ts` still resolve via `getRepoRoot()` on the single-repo branch. Pinned by `tests/worktree-pool-nested-rootpath.test.ts`.
-- **Gate verification baselines** — pre-impl gates don't diff; impl+ diff against `origin/<primary>...HEAD`. See [debugging.md#gate-verification-baselines](docs/debugging.md#gate-verification-baselines).
-- **Gate/task tool bloat** — use `?view=summary`; drill via `gate_inspect`. See [debugging.md#gate--task-tool-bloat](docs/debugging.md#gate--task-tool-bloat).
-- **Dead/ghost search results** — `ProjectContextManager.searchAll()` post-filters orphans. See [debugging.md#search-index](docs/debugging.md#search-index).
-- **Search index location** — FlexSearch at `.bobbit/state/search.flex/`; delete to rebuild. See [debugging.md#search-index-location](docs/debugging.md#search-index-location).
-- **Sidebar child loading** — server BFS enrichment; archived-goals `archivedSessions`. See [debugging.md#sidebar-child-loading](docs/debugging.md#sidebar-child-loading).
-- **QA screenshot token bloat** — extension must emit `[screenshot_file]` not `[screenshot_base64]`. See [debugging.md#qa-screenshot-token-bloat](docs/debugging.md#qa-screenshot-token-bloat).
-- **Stale project-proposal panel** — shallow-merge in `onProjectProposal`. See [debugging.md#stale-project-proposal-panel-after-propose_project](docs/debugging.md#stale-project-proposal-panel-after-propose_project).
-- **Monorepo subprojects not detected** — `src/server/agent/monorepo-scan.ts`; cap 30 candidates. See [debugging.md#monorepo-subprojects-not-detected](docs/debugging.md#monorepo-subprojects-not-detected).
-- **Legacy JSON-string `project.yaml` field rejected (HTTP 400)** — send structured arrays. See [debugging.md#legacy-json-string-projectyaml-field-rejected](docs/debugging.md#legacy-json-string-projectyaml-field-rejected).
-- **Skill chip / autonomous activation / resource manifest** — `src/server/skills/`. See [debugging.md#skill-chip--autonomous-activation--resource-manifest](docs/debugging.md#skill-chip--autonomous-activation--resource-manifest).
-- **Tool-guard extension ParseError** — quoting slip in template-literal generator. See [debugging.md#tool-guard-extension-parseerror-new-sessions-crash](docs/debugging.md#tool-guard-extension-parseerror-new-sessions-crash).
-- **MCP server unavailable / partial outage** — stub meta extension at `<stateDir>/mcp-extensions/…`. See [debugging.md#mcp-server-unavailable--partial-outage](docs/debugging.md#mcp-server-unavailable--partial-outage).
-- **MCP per-op `never` policy not enforced** — two layers: `mcpPolicyKeys` (returns `{group, tool}`, used at Layer A) + server-side `resolveGrantPolicy` (Layer B, `/api/internal/mcp-call`). `mcpPolicyPrefix` is the legacy group-only wrapper. See [debugging.md#mcp-per-op-never-policy-not-enforced](docs/debugging.md#mcp-per-op-never-policy-not-enforced).
-- **MCP server dropdown reads "Allow (default)" but agent is denied** — historical bug from `mcp__playwright`/`mcp__nano-banana` builtin denials; removed in MCP policy parity. See [debugging.md#mcp-server-dropdown-reads-allow-default-but-agent-is-denied](docs/debugging.md#mcp-server-dropdown-reads-allow-default-but-agent-is-denied).
-- **Tools page "MCP" section missing/empty** — `GET /api/mcp-servers`; `renderMcpSection()`. See [debugging.md#tools-page-mcp-section-missing-or-empty](docs/debugging.md#tools-page-mcp-section-missing-or-empty).
-- **MCP gateway server collapses sub-namespaces into one tool** — a gateway emitting `mcp__gr__ai-adoption__list-articles` etc. should surface as ONE server row + one tool row per sub-namespace on the Tools page; the agent should see one meta-tool per sub-namespace (`mcp_gr__ai-adoption`, `mcp_gr__jira`). Single source of truth is `parseMcpToolName()` in `src/server/mcp/mcp-meta.ts` — a callsite parsing the name with its own `indexOf("__", …)` instead of routing through this helper breaks sub-namespace grouping at that callsite. Symptom: one giant `mcp_gr` meta-tool with a flat enum like `ai-adoption__list-articles, jira__get-queue, …`. Check the `(server, sub)` aggregation in `tool-activation.ts` and the two ad-hoc parse sites in `server.ts` (must call `parseMcpToolName`).
-- **Auto-nudge flooding** — `nudgePending` guard in `TeamManager`. See [debugging.md#auto-nudge-flooding](docs/debugging.md#auto-nudge-flooding).
-- **Reviewer spuriously nudges team-lead** — `kind: "reviewer"` filter in `resubscribeTeamEvents` / `notifyTeamLead`. See [debugging.md#reviewer-session-triggers-spurious-agent-finished-team-lead-nudge-after-restart](docs/debugging.md#reviewer-session-triggers-spurious-agent-finished-team-lead-nudge-after-restart).
-- **Duplicate `model_change` event at session startup** — spawn site must route through `resolveBridgeOptions`. See [debugging.md#duplicate-model_change-event-at-session-startup](docs/debugging.md#duplicate-model_change-event-at-session-startup).
-- **Archived session footer shows placeholder model** — `buildArchivedStateData` must run after `session_title`. See [debugging.md#archived-session-footer-shows-placeholder-model](docs/debugging.md#archived-session-footer-shows-placeholder-model).
-- **Resumed reviewer terminated ~46ms after restart** — await `waitForStreaming` before `waitForIdle`. See [debugging.md#resumed-reviewer-terminated-46ms-after-server-restart-before-reminder-is-acted-on](docs/debugging.md#resumed-reviewer-terminated-46ms-after-server-restart-before-reminder-is-acted-on).
-- **`x-opencode-session` header / `models.json`** — `writeAigwModelsJson`, `BOBBIT_SESSION_ID` env, `startupAigwCheck`. See [debugging.md#x-opencode-session-header--modelsjson](docs/debugging.md#x-opencode-session-header--modelsjson).
-- **Review/naming models under AI Gateway** — `applyReviewModelOverrides`; failures throw, no silent fallback. See [debugging.md#reviewnaming-model-mismatch-under-ai-gateway](docs/debugging.md#reviewnaming-model-mismatch-under-ai-gateway).
-- **Live-steer lost / duplicated after Stop** — single `_dispatchSteer()` + shadow ledger `inFlightSteerTexts`; never re-add `PromptQueue.dispatched`. See [debugging.md#abort-steer--queue](docs/debugging.md#abort-steer--queue).
-- **Session wedged after errored turn** — implicit unstick; capped at `MAX_CONSECUTIVE_ERROR_TURNS = 3`. See [debugging.md#session-wedged-after-errored-turn](docs/debugging.md#session-wedged-after-errored-turn).
-- **`bash_bg wait` not interrupted by steer** — `BgProcessManager.waits` registry; `abortAllWaits()` from `deliverLiveSteer`. See [debugging.md#bash_bg-wait-not-interrupted-by-steer](docs/debugging.md#bash_bg-wait-not-interrupted-by-steer).
-- **Large file writes freezing** — `truncateLargeToolContent()` at >32 KB; check `.jsonl` exists. See [debugging.md#large-file-writes-agent-writes-32kb](docs/debugging.md#large-file-writes-agent-writes-32kb).
-- **Preview Open button broken / v1/v2 markers** — `tool_result` must carry `__preview_snapshot_v3__`. See [preview-architecture.md#snapshot-v3-marker](docs/preview-architecture.md#snapshot-v3-marker).
-- **Preview iframe shows broken images / 404 on assets** — first check: did the agent declare the asset in `preview_open`'s `assets[]` or `manifest`? Bare `file` copies *only* the entry HTML; undeclared siblings are not in the mount and will 404. Then check cookie auth, MIME, path-guard. See [preview-architecture.md#explicit-asset-opt-in-file-form](docs/preview-architecture.md#explicit-asset-opt-in-file-form) and [preview-architecture.md#content-origin-previewsidrel-path](docs/preview-architecture.md#content-origin-previewsidrel-path).
-- **`/preview/<sid>/...` returns 401 in a new tab** — `bobbit_session` cookie missing/scoped wrong. See [preview-architecture.md#cookie-auth](docs/preview-architecture.md#cookie-auth).
-- **Preview iframe shows 'No preview yet' indefinitely** — SSE event must carry `entry`. See [preview-architecture.md#sse--get-apisessionssidpreview-events](docs/preview-architecture.md#sse--get-apisessionssidpreview-events).
-- **Streaming dedup/reorder** — `seq`+`ts` envelope, `{type:"resume", fromSeq}` on reconnect. See [debugging.md#streaming-dedup--reorder](docs/debugging.md#streaming-dedup--reorder).
-- **WS overflow guard** — `decideOverflowAction` in `src/server/ws/ws-overflow-guard.ts`. See [debugging.md#ws-overflow-guard](docs/debugging.md#ws-overflow-guard).
-- **Verification log Nx duplication** — funnel through `src/app/verification-event-bus.ts`. See [debugging.md#verification-log-duplicated-nx-multi-listener](docs/debugging.md#verification-log-duplicated-nx-multi-listener).
-- **Scroll snaps back / tail-chat lost / false-positive Jump** — `AgentInterface` ports `use-stick-to-bottom`; two-flag `_isAtBottom`/`_escapedFromLock`; never re-add `_programmaticEchoes`/`_settleWindow*`/`_suppressJumpUntilTs`. See [design/tail-chat-redesign.md](docs/design/tail-chat-redesign.md#outcome-of-the-use-stick-to-bottom-port).
-- **Proposal panel button enabled mid-stream** — `state.proposalStreamingByTag` flag. See [debugging.md#proposal-panel-button-enabled-mid-stream--scroll-resets-on-delta](docs/debugging.md#proposal-panel-button-enabled-mid-stream--scroll-resets-on-delta).
-- **Inline-comment annotations on proposals missing** — ephemeral `proposalBackend` in `src/ui/components/review/proposal-annotations.ts`. See [debugging.md#inline-comment-annotations-on-goalrolestaff-proposals](docs/debugging.md#inline-comment-annotations-on-goalrolestaff-proposals).
-- **"Send feedback" button missing on a proposal panel** — gated on annotation count > 0 AND not streaming. See [debugging.md#send-feedback-button-missing-on-a-proposal-panel](docs/debugging.md#send-feedback-button-missing-on-a-proposal-panel).
-- **"Open proposal" on old card destroys later edits** — check `__proposal_rev_v1__:<n>` marker. See [debugging.md#open-proposal-on-old-card-destroys-later-edits](docs/debugging.md#open-proposal-on-old-card-destroys-later-edits).
-- **Proposal panel doesn't update after `edit_proposal`** — check WS `proposal_update` frame + structured error code. See [debugging.md#proposal-panel-doesnt-update-after-edit_proposal](docs/debugging.md#proposal-panel-doesnt-update-after-edit_proposal).
-- **"No project selected for this goal" toast in re-attempt assistant** — `goalProposalPanel()` / `goalPreviewPanel()` in `src/app/render.ts`. See [debugging.md#re-attempt-project-binding](docs/debugging.md#re-attempt-project-binding).
-- **Dismissed proposal reappears after reload** — `goalDraft.restore` / `roleDraft.restore` must consult `isProposalDismissedTyped`. See [debugging.md#dismissed-proposal-restored-on-reload](docs/debugging.md#dismissed-proposal-restored-on-reload).
+- **Stop button stuck visible / duplicate user message on second send** — divergence between `_state.isStreaming` and `gatewaySessions[i].status`. Check no write to `_state.status` outside `case "session_status"`/`case "state"`/`reset()`; no server write to `session.status` outside `broadcastStatus()`. See [docs/design/unify-session-status.md](docs/design/unify-session-status.md).
+- **`lastActivity` reads "just now" after restart** — `isUserVisibleActivity` filter in `session-manager.ts`.
+- **Live-steer lost / duplicated after Stop** — single `_dispatchSteer()` + shadow ledger `inFlightSteerTexts`; never re-add `PromptQueue.dispatched`. See [docs/design/steer-subsystem-rewrite.md](docs/design/steer-subsystem-rewrite.md).
+- **Session wedged after errored turn** — implicit unstick; capped at `MAX_CONSECUTIVE_ERROR_TURNS = 3`.
+- **`bash_bg wait` not interrupted by steer** — `BgProcessManager.waits` registry; `abortAllWaits()` from `deliverLiveSteer`.
+- **Streaming dedup/reorder** — `seq`+`ts` envelope, `{type:"resume", fromSeq}` on reconnect.
+- **WS overflow guard** — `decideOverflowAction` in `src/server/ws/ws-overflow-guard.ts`.
 - **Stale messages / dups / out-of-order widgets on session navigate** — reducer in `src/app/message-reducer.ts`.
-- **Messages disappear from chat transcript and reappear after sending another prompt** — H3 snapshot/live race. Symptom most reliable on WS drop+reconnect mid-stream and on two-tab visibility resync (both tabs converge on the same missing rows — diagnostic that the snapshot itself is missing data, not a per-client display glitch). Root cause: agent flushes to `.jsonl` only on `message_end`, so `getMessages` snapshots taken mid-turn don't represent in-flight rows; client survivor filter previously stripped them. Fixed by server-side `spliceInFlightMessage()` + reducer `_order > snapshotMaxOrder` guard + multiset plain-text dedup + `_order <= 0` prior-artifact drop. Regression test: `tests/e2e/ui/repro-h3-snapshot-live-interleave.spec.ts`. See [docs/design/snapshot-live-race-fix.md](docs/design/snapshot-live-race-fix.md).
-- **Continue-Archived button missing** — only when archived AND no `goalId` AND no `delegateOf` AND project still registered. See [debugging.md#continue-archived-button-missing](docs/debugging.md#continue-archived-button-missing).
-- **Continued session missing earlier transcript** — confirm cloned `.jsonl` at `agentSessionFile` path. See [debugging.md#continued-session-missing-earlier-transcript](docs/debugging.md#continued-session-missing-earlier-transcript).
-- **Archived session footer shows wrong model** — archived `auth_ok` must push `state` via `buildArchivedStateData()`. See [debugging.md#archived-session-footer-shows-placeholder-model](docs/debugging.md#archived-session-footer-shows-placeholder-model).
-- **Stale draft resurrection** — `SessionStore.setDraft()` rejects older `gen`. See [debugging.md#stale-draft-resurrection](docs/debugging.md#stale-draft-resurrection).
-- **400 "projectId required"** — splash buttons gated on `state.projects.length`; system tool-assistants pass `projectId: "system"`. See [debugging.md#multi-project--per-project-state](docs/debugging.md#multi-project--per-project-state).
-- **Synthetic system project / `projectId: "system"`** — registered at startup; `hidden: true`; anchored at `<bobbitStateDir>/system-project/`. See [internals.md#synthetic-system-project](docs/internals.md#synthetic-system-project).
-- **Symlinked project root rejected with `code: symlink_root`** — `POST /api/projects` returns 400 `{ code: "symlink_root", rootPath, canonical }` when `rootPath` is a symlink. UI auto-prompts and re-submits with `acceptCanonical: true`; CLI/scripted callers must do the same or pass the canonical path directly. See `detectSymlinkRoot()` in `src/server/agent/project-registry.ts` and [debugging.md#symlinked-project-root-rejected-with-code-symlink_root](docs/debugging.md#symlinked-project-root-rejected-with-code-symlink_root).
-- **`findByCwd` returns undefined for a symlinked cwd** — should not happen post-fix; `findByCwd()` canonicalises both sides via `realpathSync` with a try/catch fallback (Windows EPERM falls back to the textual path). If you see this regression, verify the canonicalisation block in `src/server/agent/project-registry.ts::findByCwd` is intact and that `getByPath()` is still NOT canonicalised (it's the duplicate-path guard). See [debugging.md#findbycwd-returns-undefined-for-a-symlinked-cwd](docs/debugging.md#findbycwd-returns-undefined-for-a-symlinked-cwd).
-- **Orphan remote branches** — `deleteRemoteGoalBranches` (goals); `session-eager-branch-delete.ts` (sessions). See [design/orphan-remote-branch-cleanup.md](docs/design/orphan-remote-branch-cleanup.md).
-- **Bundle-size assertion fails** — `tests/bundle-size.test.ts` reads `dist/ui/.vite/manifest.json`; budget 600 kB main / 500 kB per-chunk. See [debugging.md#bundle-size-assertion-fails](docs/debugging.md#bundle-size-assertion-fails).
-- **Markdown not rendering in chat / proposal panel** — call `ensureMarkdownBlock()` from `src/ui/lazy/markdown-block.ts`. See [debugging.md#markdown-not-rendering-in-chat--proposal-panel](docs/debugging.md#markdown-not-rendering-in-chat--proposal-panel).
-- **Page chunk fails to load on first navigation** — `lazyPage()` in `src/app/render.ts`. See [debugging.md#page-chunk-fails-to-load-on-first-navigation](docs/debugging.md#page-chunk-fails-to-load-on-first-navigation).
-- **Lazy tool renderer placeholder sticks / Open button never appears** — `TOOL_RENDERER_LOADED_EVENT` in `src/ui/tools/renderer-registry.ts`; listener in `<tool-message>` / `<tool-group>`. See [debugging.md#lazy-tool-renderer-placeholder-sticks](docs/debugging.md#lazy-tool-renderer-placeholder-sticks).
-- **Proposal panel empty after reload** — `_bufferedProposalEvents` in `src/app/remote-agent.ts`. See [debugging.md#proposal-panel-empty-after-reload](docs/debugging.md#proposal-panel-empty-after-reload).
-- **Image generation failure** — `400` malformed input, `500 { error }` provider-side; never `502`/`503`. See [debugging.md#image-generation-failure](docs/debugging.md#image-generation-failure).
-- **Header toast vs proposal toast testid collision** — `header-toast` vs `proposal-toast`; two slots in `src/app/render.ts`. See [debugging.md#header-toast-vs-proposal-toast-testid-collision](docs/debugging.md#header-toast-vs-proposal-toast-testid-collision).
-- **`read_session` returns `permission_denied`** — cross-project read; check `x-bobbit-session-id` header. See [debugging.md#read_session-returns-permission_denied](docs/debugging.md#read_session-returns-permission_denied).
-- **Mobile annotation popover doesn't open** — `_onMobileAddComment` must set `_popoverReferenceRect` before mount. See [debugging.md#mobile-annotation-popover-doesnt-open-after-tapping-add-comment](docs/debugging.md#mobile-annotation-popover-doesnt-open-after-tapping-add-comment).
-- **Tier 2.5 report missing / ffmpeg failed** — set `FFMPEG_PATH` or install ffmpeg; only when `RECORDSCREEN=1`. See [debugging.md#tier-25-report-missing--ffmpeg-failed](docs/debugging.md#tier-25-report-missing--ffmpeg-failed).
+- **Messages disappear from chat and reappear after another prompt** — H3 snapshot/live race. Server splices via `spliceInFlightMessage()`; client `_order > snapshotMaxOrder` guard. See [docs/design/snapshot-live-race-fix.md](docs/design/snapshot-live-race-fix.md).
+- **Stale draft resurrection** — `SessionStore.setDraft()` rejects older `gen`.
+- **Continue-Archived button missing** — needs archived + no `goalId` + no `delegateOf` + project still registered.
+- **Continued session missing earlier transcript** — confirm cloned `.jsonl` at `agentSessionFile` path.
+- **Resumed reviewer terminated ~46ms after restart** — await `waitForStreaming` before `waitForIdle`.
+- **Duplicate `model_change` event at session startup** — spawn site must route through `resolveBridgeOptions`.
+
+### Worktree / sandbox / projects
+- **Worktree setup not running** — single source of truth `runComponentSetups()` in `src/server/skills/worktree-setup.ts`.
+- **"Setting up worktree…" banner missing for first session / preparing UX absent** — `_lastStatusVersion` must start at `-1`; `RemoteAgent.onStatusChange` must call `agentInterface.requestUpdate()` for `preparing`/`starting`.
+- **Slow first-session worktree on cold boot** — `runBootBackgroundTasks` runs sweeper and pool init concurrently. `BOBBIT_SKIP_WORKTREE_POOL=1` bypasses pool.
+- **Pool worktree placed under `<projectDir>-wt/` instead of `<repoRoot>-wt/`** — nested-rootPath bug; `WorktreePool` must resolve repo toplevel. Pinned by `tests/worktree-pool-nested-rootpath.test.ts`.
+- **Sandbox status / project container** — `GET /api/sandbox-status`; label `bobbit-project=<projectId>`.
+- **Synthetic system project / `projectId: "system"`** — registered at startup; `hidden: true`; anchored at `<bobbitStateDir>/system-project/`.
+- **Symlinked project root rejected with `code: symlink_root`** — `POST /api/projects` returns 400; UI re-submits with `acceptCanonical: true`. CLI/scripted callers must do the same or pass canonical path.
+- **`findByCwd` returns undefined for symlinked cwd** — `findByCwd()` canonicalises both sides via `realpathSync`. `getByPath()` is intentionally NOT canonicalised.
+- **Monorepo subprojects not detected** — `src/server/agent/monorepo-scan.ts`; cap 30 candidates.
+- **Legacy JSON-string `project.yaml` field rejected (HTTP 400)** — send structured arrays.
+- **400 "projectId required"** — splash buttons gated on `state.projects.length`; system tool-assistants pass `projectId: "system"`.
+- **Orphan remote branches** — `deleteRemoteGoalBranches` (goals); `session-eager-branch-delete.ts` (sessions). See [docs/design/orphan-remote-branch-cleanup.md](docs/design/orphan-remote-branch-cleanup.md).
+
+### MCP
+- **MCP server unavailable / partial outage** — stub meta extension at `<stateDir>/mcp-extensions/…`.
+- **MCP per-op `never` policy not enforced** — two layers: `mcpPolicyKeys` (Layer A) + `resolveGrantPolicy` (Layer B, `/api/internal/mcp-call`).
+- **MCP gateway server collapses sub-namespaces into one tool** — callsite parsing names with own `indexOf("__", …)` instead of `parseMcpToolName()`. Check `(server, sub)` aggregation in `tool-activation.ts`.
+- **MCP server dropdown reads "Allow (default)" but agent denied** — historical bug from `mcp__playwright`/`mcp__nano-banana` builtin denials; removed in policy parity.
+- **Tools page "MCP" section missing/empty** — `GET /api/mcp-servers`; `renderMcpSection()`.
+
+### Models / AI gateway
+- **Review/naming models under AI Gateway** — `applyReviewModelOverrides`; failures throw, no silent fallback.
+- **`x-opencode-session` header / `models.json`** — `writeAigwModelsJson`, `BOBBIT_SESSION_ID` env, `startupAigwCheck`.
+- **Archived session footer shows placeholder model** — `buildArchivedStateData` must run after `session_title`.
+
+### Gates / verification / team
+- **Stuck gate verification** — `POST /api/goals/:id/gates/:gateId/cancel-verification`.
+- **Gate verification baselines** — pre-impl gates don't diff; impl+ diff against `origin/<primary>...HEAD`.
+- **Gate/task tool bloat** — use `?view=summary`; drill via `gate_inspect`.
+- **Auto-nudge flooding** — `nudgePending` guard in `TeamManager`.
+- **Reviewer spuriously nudges team-lead** — `kind: "reviewer"` filter in `resubscribeTeamEvents` / `notifyTeamLead`.
+- **Verification log Nx duplication** — funnel through `src/app/verification-event-bus.ts`.
+
+### Search / config / skills
+- **Dead/ghost search results** — `ProjectContextManager.searchAll()` post-filters orphans.
+- **Search index location** — FlexSearch at `.bobbit/state/search.flex/`; delete to rebuild.
+- **`system-prompt.md` customisation not taking effect** — `resolveSystemPromptPath()` in `src/server/agent/system-prompt.ts`.
+- **Tool-guard extension ParseError** — quoting slip in template-literal generator.
+- **Skill chip / autonomous activation / resource manifest** — `src/server/skills/`.
+- **Sidebar child loading** — server BFS enrichment; archived-goals `archivedSessions`.
+
+### UI / scroll / proposals
+- **Scroll snaps back / tail-chat lost / false-positive Jump** — `AgentInterface` ports `use-stick-to-bottom`; two-flag `_isAtBottom`/`_escapedFromLock`; never re-add `_programmaticEchoes`/`_settleWindow*`/`_suppressJumpUntilTs`. See [docs/design/tail-chat-redesign.md](docs/design/tail-chat-redesign.md#outcome-of-the-use-stick-to-bottom-port).
+- **Proposal panel button enabled mid-stream** — `state.proposalStreamingByTag` flag.
+- **Proposal panel empty after reload** — `_bufferedProposalEvents` in `src/app/remote-agent.ts`.
+- **Proposal panel doesn't update after `edit_proposal`** — check WS `proposal_update` frame + structured error code.
+- **Inline-comment annotations on proposals missing** — ephemeral `proposalBackend` in `src/ui/components/review/proposal-annotations.ts`.
+- **"Send feedback" button missing on proposal panel** — gated on annotation count > 0 AND not streaming.
+- **"Open proposal" on old card destroys later edits** — check `__proposal_rev_v1__:<n>` marker.
+- **Stale project-proposal panel** — shallow-merge in `onProjectProposal`.
+- **Dismissed proposal reappears after reload** — `goalDraft.restore` / `roleDraft.restore` must consult `isProposalDismissedTyped`.
+- **"No project selected for this goal" toast in re-attempt assistant** — `goalProposalPanel()` / `goalPreviewPanel()` in `src/app/render.ts`.
+- **Page chunk fails to load on first navigation** — `lazyPage()` in `src/app/render.ts`.
+- **Lazy tool renderer placeholder sticks / Open button never appears** — `TOOL_RENDERER_LOADED_EVENT` in `src/ui/tools/renderer-registry.ts`.
+- **Markdown not rendering in chat / proposal panel** — call `ensureMarkdownBlock()` from `src/ui/lazy/markdown-block.ts`.
+- **Header toast vs proposal toast testid collision** — `header-toast` vs `proposal-toast`; two slots in `src/app/render.ts`.
+- **Mobile annotation popover doesn't open** — `_onMobileAddComment` must set `_popoverReferenceRect` before mount.
+
+### QA / preview / tier-2.5 / images
+- **QA screenshot token bloat** — extension must emit `[screenshot_file]` not `[screenshot_base64]`.
+- **Preview Open button broken / v1/v2 markers** — `tool_result` must carry `__preview_snapshot_v3__`.
+- **Preview iframe shows broken images / 404 on assets** — first check: did the agent declare the asset in `preview_open`'s `assets[]` or `manifest`? Bare `file` copies only the entry HTML.
+- **`/preview/<sid>/...` returns 401 in a new tab** — `bobbit_session` cookie missing/scoped wrong.
+- **Preview iframe shows 'No preview yet' indefinitely** — SSE event must carry `entry`.
+- **Tier 2.5 report missing / ffmpeg failed** — set `FFMPEG_PATH` or install ffmpeg; only when `RECORDSCREEN=1`.
+- **Image generation failure** — `400` malformed input, `500 { error }` provider-side; never `502`/`503`.
+- **Large file writes freezing** — `truncateLargeToolContent()` at >32 KB; check `.jsonl` exists.
+
+### Misc
+- **`read_session` returns `permission_denied`** — cross-project read; check `x-bobbit-session-id` header.
 - **OAuth callback never completes** — poll `GET /api/oauth/flow-status?flowId=&provider=`.
+- **Bundle-size assertion fails** — `tests/bundle-size.test.ts` reads `dist/ui/.vite/manifest.json`; 600 kB main / 500 kB per-chunk.
+
+## Maintaining this file
+
+AGENTS.md is loaded into **every** agent turn. It must stay a keyword index, not a knowledge base. Rules for edits:
+
+- **One line per entry.** If a Recipe or Debugging item needs more than one sentence, the detail goes in the linked `docs/` page; the entry here is just the keyword + symbol + link.
+- **Don't duplicate** a Recipe and a Debugging entry for the same fix. Pick one (Recipe = "how to do X", Debugging = "X is broken").
+- **Don't inline schema, code, or step-by-step prose.** YAML field semantics, error-shape walkthroughs, race-condition explanations all belong in `docs/`.
+- **Per-section size budget:** if a Debugging subsection grows past ~12 entries, split it; don't let the section blur into a continuous wall.
+- New Recipe/Debugging entries should be net-zero: replace or extend an existing entry where possible.
 
 ## Git conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,82 +39,80 @@ See [docs/testing-strategy.md](docs/testing-strategy.md), [docs/testing-coverage
 One-liner task → entry point. Follow links for walkthroughs. **Keep entries to one line each — detail belongs in the linked doc.**
 
 ### Tests
-- **Add an API E2E test** → `tests/e2e/`, import `./in-process-harness.js`. See `gates-api.spec.ts`.
-- **Add a UI E2E test** → `tests/e2e/ui/`, import `../gateway-harness.js`. See `session-interactions.spec.ts`.
+- **Add an API E2E test** → `tests/e2e/`, import `./in-process-harness.js`; see `gates-api.spec.ts`.
+- **Add a UI E2E test** → `tests/e2e/ui/`, import `../gateway-harness.js`; see `session-interactions.spec.ts`.
 - **Add a Tier 2.5 video-capturing E2E test** → [docs/testing-tier-2-5.md](docs/testing-tier-2-5.md).
-- **Assert tail-chat / scroll-pin in an E2E test** → helpers in `tests/e2e/ui/tail-chat-helpers.ts`. Outcome-only — never assert on `_stickToBottom` / private fields. See [docs/design/tail-chat-redesign.md](docs/design/tail-chat-redesign.md#outcome-of-the-use-stick-to-bottom-port).
+- **Assert tail-chat / scroll-pin** → helpers in `tests/e2e/ui/tail-chat-helpers.ts`; outcome-only. See [tail-chat-redesign.md](docs/design/tail-chat-redesign.md).
 
 ### Server / API
-- **Add a REST endpoint** → `handleApiRoute()` in `src/server/server.ts`. See [docs/rest-api.md](docs/rest-api.md).
-- **Add a WebSocket command** → `ClientMessage` in `ws/protocol.ts`, handle in `ws/handler.ts`, add `RpcBridge` method.
-- **Add a tool** → builtin: `defaults/tools/<group>/`. Project override: `.bobbit/config/tools/<group>/`. MCP auto-discovered from `.mcp.json`. YAML fields and prompt layout: see [docs/internals.md — MCP tool documentation](docs/internals.md#mcp-tool-documentation).
-- **Add a slash skill** → `SKILL.md` in `.claude/skills/<name>/` with YAML frontmatter. See [docs/design/skill-ux-and-autonomous-activation.md](docs/design/skill-ux-and-autonomous-activation.md).
-- **Add a blocking tool** → harness parks Promise keyed by `(sessionId, toolUseId)`. See [docs/blocking-tools.md](docs/blocking-tools.md). (`ask_user_choices` is non-blocking — see [docs/non-blocking-ask.md](docs/non-blocking-ask.md).)
-- **Modify a store constructor** → stores take `stateDir`/`configDir` params; never module-level globals. All resolution via `ProjectContextManager` (`src/server/agent/project-context-manager.ts`).
-- **Add/modify session creation** → `session-setup.ts`, wrappers in `session-manager.ts`. See [docs/internals.md — Session worktrees](docs/internals.md#session-worktrees).
-- **Add a goal feature** → `goal-manager.ts` / `goal-store.ts`, REST in `server.ts`, assistant in `goal-assistant.ts`. See [docs/goals-workflows-tasks.md](docs/goals-workflows-tasks.md).
-- **Add a verification reminder site** → `src/server/agent/verification-harness.ts`. Await `waitForStreaming(...).catch(()=>{})` before `waitForIdle`.
-- **Return errors from a server handler** → use `jsonError(status, err, extra?)` in `src/server/server.ts` so `stack` flows to the client modal. Validation responses with literal strings stay as `json({ error: "..." }, ...)`. See [docs/rest-api.md — Error response shape](docs/rest-api.md#error-response-shape).
+- **Add a REST endpoint** → `handleApiRoute()` in `src/server/server.ts`. See [rest-api.md](docs/rest-api.md).
+- **Add a WebSocket command** → `ClientMessage` in `ws/protocol.ts`, handle in `ws/handler.ts`, `RpcBridge` method.
+- **Add a tool** → `defaults/tools/<group>/` (or project override `.bobbit/config/tools/<group>/`); MCP auto-discovered from `.mcp.json`. See [internals.md#mcp-tool-documentation](docs/internals.md#mcp-tool-documentation).
+- **Add a slash skill** → `SKILL.md` in `.claude/skills/<name>/`. See [skill-ux-and-autonomous-activation.md](docs/design/skill-ux-and-autonomous-activation.md).
+- **Add a blocking tool** → [docs/blocking-tools.md](docs/blocking-tools.md). (`ask_user_choices` is non-blocking — [docs/non-blocking-ask.md](docs/non-blocking-ask.md).)
+- **Modify a store constructor** → stores take `stateDir`/`configDir` params; resolve via `ProjectContextManager`.
+- **Add/modify session creation** → `session-setup.ts`, `session-manager.ts`. See [internals.md#session-worktrees](docs/internals.md#session-worktrees).
+- **Add a goal feature** → `goal-manager.ts` / `goal-store.ts`, `server.ts`, `goal-assistant.ts`. See [goals-workflows-tasks.md](docs/goals-workflows-tasks.md).
+- **Add a verification reminder site** → `src/server/agent/verification-harness.ts`; await `waitForStreaming(...).catch(()=>{})` before `waitForIdle`.
+- **Return errors from a server handler** → `jsonError(status, err, extra?)` in `src/server/server.ts`. See [rest-api.md#error-response-shape](docs/rest-api.md#error-response-shape).
 
 ### Sessions, status, steer
-- **Mutate session status** → `broadcastStatus()` in `src/server/agent/session-status.ts` is the **single writer** for `session.status`. Client: `_state.status` on `RemoteAgent` is canonical; `isStreaming`/`isArchived`/`isPreparing` are derived getters. `case "session_status"` is the sole writer (plus `case "state"` on attach, `reset()` on navigate). See [docs/design/unify-session-status.md](docs/design/unify-session-status.md).
-- **Modify steer / queue dispatch** → single dispatch site `SessionManager._dispatchSteer()` in `src/server/agent/session-manager.ts`. Rows leave `promptQueue` *before* `rpcClient.steer()`, then enter shadow ledger `inFlightSteerTexts`. Never reintroduce `PromptQueue.dispatched`. See [docs/design/steer-subsystem-rewrite.md](docs/design/steer-subsystem-rewrite.md).
-- **Continue an archived session** → `POST /api/sessions/:archivedId/continue`. See [docs/design/lossless-continue-archived.md](docs/design/lossless-continue-archived.md).
+- **Mutate session status** → single writer `broadcastStatus()` in `src/server/agent/session-status.ts`. See [unify-session-status.md](docs/design/unify-session-status.md).
+- **Modify steer / queue dispatch** → single dispatch site `SessionManager._dispatchSteer()`; never reintroduce `PromptQueue.dispatched`. See [steer-subsystem-rewrite.md](docs/design/steer-subsystem-rewrite.md).
+- **Continue an archived session** → `POST /api/sessions/:archivedId/continue`. See [lossless-continue-archived.md](docs/design/lossless-continue-archived.md).
 - **Re-attempt a goal** → `POST /api/sessions { reattemptGoalId }` → `buildReattemptContext()`.
-- **Server-side read/unread state** → `lastReadAt` on `PersistedSession`; `POST /api/sessions/:id/mark-read`.
-- **Read another session's transcript** → `read_session` tool; parser `src/server/agent/transcript-reader.ts`; `GET /api/sessions/:id/transcript`; same-project auth via `x-bobbit-session-id` header.
-- **Initialise client-side status on fresh attach** → `_lastStatusVersion` starts at `-1` in `src/app/remote-agent.ts`; `RemoteAgent.onStatusChange` calls `requestUpdate()` for `preparing`/`starting`/`aborting`/`idle` (Lit reference-equality misses same-object mutations).
+- **Server-side read/unread** → `lastReadAt` on `PersistedSession`; `POST /api/sessions/:id/mark-read`.
+- **Read another session's transcript** → `read_session` tool; `transcript-reader.ts`; `x-bobbit-session-id` header for same-project auth.
 
 ### UI
 - **Add a UI component** → `src/ui/components/`, export from `src/ui/index.ts`.
-- **Add a tool renderer** → `src/ui/tools/renderers/`, register in `src/ui/tools/index.ts`. See `ProposalRenderer.ts`.
-- **Show a server error in a modal** → `<error-details>` (`src/ui/components/ErrorDetails.ts`); API wrappers in `src/app/api.ts` parse `code`/`stack` and forward to `showConnectionError(...)` in `src/app/dialogs.ts`. Background polling in `refreshSessions()` is intentionally silent.
-- **Add a route-level page (lazy-loaded)** → add a `lazyPage(...)` branch in `mainArea()` in `src/app/render.ts`. See [docs/design/ui-bundle-size-reduction.md](docs/design/ui-bundle-size-reduction.md).
-- **Add a heavy tool renderer (lazy)** → `registerLazyToolRenderer()` in `src/ui/tools/index.ts`; placeholder + `TOOL_RENDERER_LOADED_EVENT` swap.
-- **Defer a heavy library (lazy load)** → `src/ui/lazy/markdown-block.ts::ensureMarkdownBlock()` pattern; or `await import()` for value imports.
-- **Change message rendering** → `src/ui/components/Messages.ts` (standard); `message-renderer-registry.ts` (custom).
-- **Modify message transcript ordering** → all transcript mutations route through `reduce(state, action)` in `src/app/message-reducer.ts`. Never push directly into `state.messages`. See [docs/design/unified-message-ordering-reducer.md](docs/design/unified-message-ordering-reducer.md).
-- **Modify snapshot ↔ live merge / `getMessages` splice** → server splices in-flight `message_update` via `spliceInFlightMessage()` in `src/server/agent/splice-inflight-message.ts`; client survivor filter in `case "snapshot"` enforces `_order > snapshotMaxOrder` guard + multiset plain-text dedup. See [docs/design/snapshot-live-race-fix.md](docs/design/snapshot-live-race-fix.md).
-- **Modify proposal panel streaming UX** → flag in `state.proposalStreamingByTag`; scroll preserved via `reconcileFollowTail` in `src/app/follow-tail.ts`.
-- **Large content truncation** → `truncate-large-content.ts` (>32 KB). Lazy-load via `GET /api/sessions/:id/tool-content/:mi/:bi`.
-- **Copy session link button** → header ghost icon in `src/app/render.ts`. `showHeaderToast()` (`data-testid="header-toast"`, distinct from `proposal-toast`); `CopyLinkFallbackDialog` on clipboard reject.
-- **Git-status widget** → `src/ui/components/GitStatusWidget.ts`, `src/server/skills/git-status-native.ts`. See [docs/design/git-status-widget-reliability.md](docs/design/git-status-widget-reliability.md).
+- **Add a tool renderer** → `src/ui/tools/renderers/`, register in `src/ui/tools/index.ts`; see `ProposalRenderer.ts`.
+- **Show a server error in a modal** → `<error-details>` + `showConnectionError(...)` in `src/app/dialogs.ts`; API wrappers in `src/app/api.ts` attach `code`/`stack`.
+- **Add a route-level page (lazy)** → `lazyPage(...)` branch in `mainArea()` in `src/app/render.ts`. See [ui-bundle-size-reduction.md](docs/design/ui-bundle-size-reduction.md).
+- **Add a heavy tool renderer (lazy)** → `registerLazyToolRenderer()`; placeholder + `TOOL_RENDERER_LOADED_EVENT` swap.
+- **Defer a heavy library** → `ensureMarkdownBlock()` pattern in `src/ui/lazy/`; or `await import()` for values.
+- **Change message rendering** → `src/ui/components/Messages.ts`; custom via `message-renderer-registry.ts`.
+- **Modify message transcript ordering** → all mutations through `reduce()` in `src/app/message-reducer.ts`; never push to `state.messages`. See [unified-message-ordering-reducer.md](docs/design/unified-message-ordering-reducer.md).
+- **Modify snapshot ↔ live merge** → server `spliceInFlightMessage()`; client `_order > snapshotMaxOrder` guard + multiset dedup. See [snapshot-live-race-fix.md](docs/design/snapshot-live-race-fix.md).
+- **Modify proposal panel streaming UX** → `state.proposalStreamingByTag`; `reconcileFollowTail` in `src/app/follow-tail.ts`.
+- **Large content truncation** → `truncate-large-content.ts` (>32 KB); lazy-load via `GET /api/sessions/:id/tool-content/:mi/:bi`.
+- **Copy session link button** → header ghost icon in `src/app/render.ts`; `showHeaderToast()` (testid `header-toast`); `CopyLinkFallbackDialog` on clipboard reject.
+- **Git-status widget** → `GitStatusWidget.ts`, `git-status-native.ts`. See [git-status-widget-reliability.md](docs/design/git-status-widget-reliability.md).
 
 ### Projects, config, sandbox
-- **Add a project** → `POST /api/projects`. Key: `src/server/agent/project-registry.ts`, `project-context-manager.ts`. Project assistant designs all workflows. See [docs/internals.md](docs/internals.md#project-assistant).
-- **Splash-screen new-session gating** → buttons in `src/app/render.ts` gated on `state.projects.length` (0 → "New Project" CTA; 1 → bound session; ≥2 → splash project picker via `state.splashProjectPickerOpen`). System-scope tool-assistants pass `projectId: "system"`. See [docs/internals.md — Synthetic system project](docs/internals.md#synthetic-system-project).
-- **Remove a project** → settings → General → Remove. `DELETE /api/projects/:id`.
-- **Symlink-aware project registration** → `detectSymlinkRoot()` in `src/server/agent/project-registry.ts`. `POST /api/projects` returns 400 `{ code: "symlink_root", canonical }`; UI re-submits with `acceptCanonical: true`. `findByCwd()` canonicalises both sides; `getByPath()` does NOT.
-- **Per-project settings** → Settings → project tab. `GET/PUT /api/projects/:id/config`. See [docs/internals.md — Per-project config](docs/internals.md#per-project-config).
-- **Mid-session project-config edits** → any agent may call `propose_project`; user accepts via `PUT /api/projects/:id/config`. See [docs/design/mid-session-project-proposals.md](docs/design/mid-session-project-proposals.md).
-- **Add a multi-repo project / components / inline workflows** → `project.yaml::components[]` and `project.yaml::workflows`. See [docs/internals.md](docs/internals.md#multi-repo--components), [`defaults/workflow-authoring-guide.md`](defaults/workflow-authoring-guide.md).
-- **Modify sandbox behavior** → `sandbox: "docker"` in `project.yaml`. Key: `project-sandbox.ts`, `sandbox-manager.ts`, `docker-args.ts`. See [docs/internals.md](docs/internals.md#docker-sandbox).
-- **Add QA testing** → `qa_start_command` etc. on the component's `config:` map in `project.yaml`. See [docs/qa-testing.md](docs/qa-testing.md).
-- **Config cascade** → builtin → server → project, for roles, tools, tool-group-policies, and `system-prompt.md` (resolves via `resolveSystemPromptPath()`; user override at `.bobbit/config/system-prompt.md` wins). Workflows are project-scoped, not cascaded. See [docs/internals.md](docs/internals.md#config-cascade).
-- **Change tool access policy** → `defaults/tool-group-policies.yaml` or `.bobbit/config/tool-group-policies.yaml`. Per-role: role YAML `toolPolicies`. Values: `allow`/`ask`/`never`. `gate_signal` is team-lead-only. MCP groups default to `allow`.
-- **Per-role model / thinking override** → role YAML `model: "<provider>/<modelId>"` and `thinkingLevel`. See [docs/design/per-role-model-overrides.md](docs/design/per-role-model-overrides.md).
-- **Pin agent model at spawn time** → `RpcBridgeOptions.initialModel`/`initialThinkingLevel` → `--model`/`--thinking` flags via `buildAgentArgs`. Resolution: role override → `default.sessionModel` (or `default.reviewModel`) → undefined.
-- **Archived session footer model** → `buildArchivedStateData()` in `src/server/ws/handler.ts` sent on archived `auth_ok`.
+- **Add / remove a project** → `POST` / `DELETE /api/projects`; key files `project-registry.ts`, `project-context-manager.ts`. See [internals.md#project-assistant](docs/internals.md#project-assistant).
+- **Splash-screen new-session gating** → buttons gated on `state.projects.length` (0/1/≥2); system tool-assistants pass `projectId: "system"`. See [internals.md#synthetic-system-project](docs/internals.md#synthetic-system-project).
+- **Symlink-aware project registration** → `detectSymlinkRoot()`; UI re-submits with `acceptCanonical: true`. `findByCwd()` canonicalises both sides; `getByPath()` does NOT.
+- **Per-project settings** → `GET/PUT /api/projects/:id/config`. See [internals.md#per-project-config](docs/internals.md#per-project-config).
+- **Mid-session project-config edits** → `propose_project` → user `PUT /api/projects/:id/config`. See [mid-session-project-proposals.md](docs/design/mid-session-project-proposals.md).
+- **Multi-repo / components / inline workflows** → `project.yaml::components[]` and `::workflows`. See [internals.md#multi-repo--components](docs/internals.md#multi-repo--components), [`workflow-authoring-guide.md`](defaults/workflow-authoring-guide.md).
+- **Sandbox behavior** → `sandbox: "docker"`; `project-sandbox.ts`, `sandbox-manager.ts`, `docker-args.ts`. See [internals.md#docker-sandbox](docs/internals.md#docker-sandbox).
+- **QA testing** → `qa_start_command` etc. in component `config:` map. See [qa-testing.md](docs/qa-testing.md).
+- **Config cascade** → builtin → server → project (roles, tools, tool-group-policies, `system-prompt.md`); workflows are project-scoped. See [internals.md#config-cascade](docs/internals.md#config-cascade).
+- **Tool access policy** → `tool-group-policies.yaml` (cascaded) or role YAML `toolPolicies`. Values `allow`/`ask`/`never`; `gate_signal` is team-lead-only.
+- **Per-role model / thinking override** → role YAML `model` + `thinkingLevel`. See [per-role-model-overrides.md](docs/design/per-role-model-overrides.md).
+- **Pin agent model at spawn** → `RpcBridgeOptions.initialModel`/`initialThinkingLevel` → `--model`/`--thinking` via `buildAgentArgs`.
+- **Archived session footer model** → `buildArchivedStateData()` on archived `auth_ok`.
 
 ### MCP
-- **MCP meta-tool aggregation (server → sub-namespace → op)** → single source of truth `parseMcpToolName()` in `src/server/mcp/mcp-meta.ts`. Aggregation in `src/server/agent/tool-activation.ts` keyed by `(server, sub)`. Policy keys via `mcpPolicyKeys(name) → {group, tool}`; tool-key beats group-key. See [docs/mcp-meta-tools.md](docs/mcp-meta-tools.md).
+- **MCP meta-tool aggregation (server → sub-namespace → op)** → `parseMcpToolName()` in `src/server/mcp/mcp-meta.ts`; aggregation in `tool-activation.ts` keyed by `(server, sub)`; `mcpPolicyKeys(name) → {group, tool}` (tool-key wins). See [mcp-meta-tools.md](docs/mcp-meta-tools.md).
 
 ### Goals, workflows, gates
-- **Inter-agent git handoff** → tasks carry `baseSha`, `headSha`, `branch`. See [docs/goals-workflows-tasks.md](docs/goals-workflows-tasks.md#git-handoff-fields).
-- **Archive a goal (UI)** → sidebar/dashboard trash funnels through `deleteGoal()` in `src/app/api.ts`; detects active team, runs `teardownTeam()` before `DELETE /api/goals/:id`.
-- **Cleanup remote branches on archive** → `deleteRemoteGoalBranches` (goals); `session-eager-branch-delete.ts` (sessions). See [docs/design/orphan-remote-branch-cleanup.md](docs/design/orphan-remote-branch-cleanup.md).
+- **Inter-agent git handoff** → tasks carry `baseSha`, `headSha`, `branch`. See [goals-workflows-tasks.md#git-handoff-fields](docs/goals-workflows-tasks.md#git-handoff-fields).
+- **Archive a goal (UI)** → `deleteGoal()` in `src/app/api.ts`; runs `teardownTeam()` before `DELETE /api/goals/:id`.
+- **Cleanup remote branches on archive** → `deleteRemoteGoalBranches`; `session-eager-branch-delete.ts`. See [orphan-remote-branch-cleanup.md](docs/design/orphan-remote-branch-cleanup.md).
 
 ### Proposals
-- **Edit a proposal mid-session** → `view_proposal(type)` / `edit_proposal(type, old, new)`. Per-rev snapshots under `<stateDir>/proposal-drafts/<sessionId>/<type>.history/`. See [docs/design/editable-proposals.md](docs/design/editable-proposals.md).
-- **Dismiss/restore invariant for proposal panels** → `goalDraft.restore`/`roleDraft.restore`/`projectDraft.restore` in `src/app/session-manager.ts` gate rehydration on `isProposalDismissedTyped`. Dismiss does NOT delete the on-disk draft. Only `goal`/`role`/`project` persist drafts; `staff`/`tool`/`workflow` are transient.
-- **Project-proposal "Changes Saved" state (registered mode)** → `state.projectProposalAcceptedBySessionId` flag, set in `acceptRegisteredProjectProposal()`, persisted via `projectDraft.serialize/restore`. See [docs/design/project-proposal-saved-state.md](docs/design/project-proposal-saved-state.md).
+- **Edit a proposal mid-session** → `view_proposal` / `edit_proposal`; per-rev snapshots under `<stateDir>/proposal-drafts/<sessionId>/<type>.history/`. See [editable-proposals.md](docs/design/editable-proposals.md).
+- **Dismiss/restore invariant** → `{goal,role,project}Draft.restore` gate on `isProposalDismissedTyped`; dismiss does NOT delete the draft. `staff`/`tool`/`workflow` proposals are transient.
+- **Project-proposal "Changes Saved" (registered mode)** → `state.projectProposalAcceptedBySessionId`; set in `acceptRegisteredProjectProposal()`; persisted via `projectDraft`. See [project-proposal-saved-state.md](docs/design/project-proposal-saved-state.md).
 
 ### Worktree (operational)
-- **Pool worktree placed under `<projectDir>-wt/` instead of `<repoRoot>-wt/`** → `WorktreePool` constructor in `src/server/agent/worktree-pool.ts` resolves `opts.repoPath` to git toplevel; both `initWorktreePoolForProject` sites in `src/server/server.ts` also resolve. Pinned by `tests/worktree-pool-nested-rootpath.test.ts`.
+- **Pool worktree under `<projectDir>-wt/` instead of `<repoRoot>-wt/`** → `WorktreePool` ctor must resolve `repoPath` to git toplevel; ditto both `initWorktreePoolForProject` sites. Pinned by `tests/worktree-pool-nested-rootpath.test.ts`.
 
 ### Preview / HTML / images
-- **Preview HTML with sibling assets** → `preview_open({ html | file, assets?, manifest? })`. **Explicit opt-in**: bare `file` copies only the entry HTML; siblings declared via `assets: [...]` or a `manifest` JSON. Snapshot marker: `__preview_snapshot_v3__`. Re-opening the same `file` is safe (`mountFile()` stages into a sibling tmp dir and atomically swaps). See [docs/preview-architecture.md](docs/preview-architecture.md).
-- **Author HTML output** → [`defaults/docs/html-rendering.md`](defaults/docs/html-rendering.md). One artefact, one surface. Use theme tokens (`--background`, `--card`, `--chart-1..6`, `--positive`/`--negative`/`--warning`/`--info`).
+- **Preview HTML with sibling assets** → `preview_open({ html | file, assets?, manifest? })`; bare `file` copies only the entry HTML; snapshot marker `__preview_snapshot_v3__`. See [preview-architecture.md](docs/preview-architecture.md).
+- **Author HTML output** → [`defaults/docs/html-rendering.md`](defaults/docs/html-rendering.md). Use theme tokens (`--background`, `--card`, `--chart-1..6`, `--positive`/`--negative`/`--warning`/`--info`).
 - **Generate an image** → `generate_image` → `POST /api/image-generation/generate`.
 
 ## Debugging
@@ -123,7 +121,7 @@ Keyword index — full diagnostic walkthroughs live in [docs/debugging.md](docs/
 
 ### Session / status / steer
 - **Session persistence** — `.bobbit/state/sessions.json`; missing `.jsonl` skips restore.
-- **Stop button stuck visible / duplicate user message on second send** — divergence between `_state.isStreaming` and `gatewaySessions[i].status`. Check no write to `_state.status` outside `case "session_status"`/`case "state"`/`reset()`; no server write to `session.status` outside `broadcastStatus()`. See [docs/design/unify-session-status.md](docs/design/unify-session-status.md).
+- **Stop button stuck visible / duplicate user message on second send** — `_state.status` write outside `case "session_status"`/`"state"`/`reset()`, or server `session.status` write outside `broadcastStatus()`. See [unify-session-status.md](docs/design/unify-session-status.md).
 - **`lastActivity` reads "just now" after restart** — `isUserVisibleActivity` filter in `session-manager.ts`.
 - **Live-steer lost / duplicated after Stop** — single `_dispatchSteer()` + shadow ledger `inFlightSteerTexts`; never re-add `PromptQueue.dispatched`. See [docs/design/steer-subsystem-rewrite.md](docs/design/steer-subsystem-rewrite.md).
 - **Session wedged after errored turn** — implicit unstick; capped at `MAX_CONSECUTIVE_ERROR_TURNS = 3`.
@@ -145,8 +143,8 @@ Keyword index — full diagnostic walkthroughs live in [docs/debugging.md](docs/
 - **Pool worktree placed under `<projectDir>-wt/` instead of `<repoRoot>-wt/`** — nested-rootPath bug; `WorktreePool` must resolve repo toplevel. Pinned by `tests/worktree-pool-nested-rootpath.test.ts`.
 - **Sandbox status / project container** — `GET /api/sandbox-status`; label `bobbit-project=<projectId>`.
 - **Synthetic system project / `projectId: "system"`** — registered at startup; `hidden: true`; anchored at `<bobbitStateDir>/system-project/`.
-- **Symlinked project root rejected with `code: symlink_root`** — `POST /api/projects` returns 400; UI re-submits with `acceptCanonical: true`. CLI/scripted callers must do the same or pass canonical path.
-- **`findByCwd` returns undefined for symlinked cwd** — `findByCwd()` canonicalises both sides via `realpathSync`. `getByPath()` is intentionally NOT canonicalised.
+- **Symlinked project root rejected with `code: symlink_root`** — `POST /api/projects` returns 400; re-submit with `acceptCanonical: true`.
+- **`findByCwd` returns undefined for symlinked cwd** — must canonicalise via `realpathSync`. `getByPath()` is intentionally NOT canonicalised.
 - **Monorepo subprojects not detected** — `src/server/agent/monorepo-scan.ts`; cap 30 candidates.
 - **Legacy JSON-string `project.yaml` field rejected (HTTP 400)** — send structured arrays.
 - **400 "projectId required"** — splash buttons gated on `state.projects.length`; system tool-assistants pass `projectId: "system"`.
@@ -181,7 +179,7 @@ Keyword index — full diagnostic walkthroughs live in [docs/debugging.md](docs/
 - **Sidebar child loading** — server BFS enrichment; archived-goals `archivedSessions`.
 
 ### UI / scroll / proposals
-- **Scroll snaps back / tail-chat lost / false-positive Jump** — `AgentInterface` ports `use-stick-to-bottom`; two-flag `_isAtBottom`/`_escapedFromLock`; never re-add `_programmaticEchoes`/`_settleWindow*`/`_suppressJumpUntilTs`. See [docs/design/tail-chat-redesign.md](docs/design/tail-chat-redesign.md#outcome-of-the-use-stick-to-bottom-port).
+- **Scroll snaps back / tail-chat lost / false-positive Jump** — two-flag `_isAtBottom`/`_escapedFromLock` in `AgentInterface`; never re-add `_programmaticEchoes`/`_settleWindow*`/`_suppressJumpUntilTs`. See [tail-chat-redesign.md](docs/design/tail-chat-redesign.md).
 - **Proposal panel button enabled mid-stream** — `state.proposalStreamingByTag` flag.
 - **Proposal panel empty after reload** — `_bufferedProposalEvents` in `src/app/remote-agent.ts`.
 - **Proposal panel doesn't update after `edit_proposal`** — check WS `proposal_update` frame + structured error code.
@@ -200,7 +198,7 @@ Keyword index — full diagnostic walkthroughs live in [docs/debugging.md](docs/
 ### QA / preview / tier-2.5 / images
 - **QA screenshot token bloat** — extension must emit `[screenshot_file]` not `[screenshot_base64]`.
 - **Preview Open button broken / v1/v2 markers** — `tool_result` must carry `__preview_snapshot_v3__`.
-- **Preview iframe shows broken images / 404 on assets** — first check: did the agent declare the asset in `preview_open`'s `assets[]` or `manifest`? Bare `file` copies only the entry HTML.
+- **Preview iframe shows broken images / 404 on assets** — asset must be declared in `preview_open`'s `assets[]` / `manifest` (bare `file` copies only the entry HTML).
 - **`/preview/<sid>/...` returns 401 in a new tab** — `bobbit_session` cookie missing/scoped wrong.
 - **Preview iframe shows 'No preview yet' indefinitely** — SSE event must carry `entry`.
 - **Tier 2.5 report missing / ffmpeg failed** — set `FFMPEG_PATH` or install ffmpeg; only when `RECORDSCREEN=1`.

--- a/defaults/roles/code-reviewer.yaml
+++ b/defaults/roles/code-reviewer.yaml
@@ -42,6 +42,11 @@ promptTemplate: |
   - **Performance**: Unnecessary allocations, O(n²) where O(n) suffices, missing caching for expensive operations.
   - **Style Consistency**: Violations of existing codebase patterns, inconsistent formatting, mixed conventions.
   - **Type Safety**: `any` casts, missing type guards, unsafe assertions, incomplete discriminated unions.
+  - **AGENTS.md discipline**: AGENTS.md is loaded into every agent turn, so growth = direct token cost on every session. If the diff modifies AGENTS.md, flag any of the following as `[high]`:
+    - Multi-sentence entries (Recipe or Debugging items must be one line each — detail belongs in `docs/`).
+    - Inlined schemas, code blocks, or step-by-step walkthroughs.
+    - A new entry that duplicates an existing one (recipe↔debug pair for the same fix, or topic already covered).
+    - Net adds where a replace/extend of an existing entry would have worked.
 
   ## Output Format
   Report findings with severity levels:

--- a/defaults/roles/coder.yaml
+++ b/defaults/roles/coder.yaml
@@ -44,6 +44,15 @@ promptTemplate: |
   - Commit frequently with descriptive messages.
   - Push your branch when done — do NOT merge to the goal branch yourself.
 
+  ## Editing AGENTS.md
+  AGENTS.md is loaded into **every** agent turn in this project — it is a keyword index, not a knowledge base. If your fix tempts you to add an entry:
+
+  - **One line, no exceptions.** `**Topic** — symbol/file. See [docs/...](...).` Do not paste design-doc summary text, schemas, code blocks, or multi-sentence walkthroughs.
+  - **Prefer replace/extend over add.** Look for an existing Recipe or Debugging entry on the same topic and update it; net adds drive bloat.
+  - **Detail goes in `docs/`**, not here. If a fix introduces a new architectural invariant or recurrent symptom worth documenting in depth, write the design/debugging doc in `docs/`, then add only a one-line pointer to AGENTS.md.
+  - **Do not duplicate** a Recipe and a Debugging entry for the same fix. Pick one (Recipe = how to do X; Debugging = X is broken).
+  - If you're unsure whether the entry belongs in AGENTS.md at all, the answer is almost always no — leave the design doc and skip the AGENTS.md entry.
+
   ## Gates
   You do NOT call `gate_signal`. Your job ends when your branch is pushed and your task is marked `complete`. The team lead merges your branch into the goal branch and signals any verification gate (test-results, reproducing-test, implementation, …) from there. If your task involves writing a reproducing test, include the exact shell command and the expected `error_pattern` regex in your `result_summary` so the team lead can use them when signalling.
 

--- a/defaults/roles/docs-writer.yaml
+++ b/defaults/roles/docs-writer.yaml
@@ -65,6 +65,13 @@ promptTemplate: |-
      and link to specific docs/*.md files for detail. Don't cram detailed explanations into AGENTS.md.
      Add cross-references between related docs.
 
+     **AGENTS.md edit format (strict — it is loaded every agent turn):**
+     - One line per Recipe or Debugging entry: `**Topic** — symbol/file. See [docs/...](...).` No multi-sentence prose, no inlined schemas, no code blocks, no step lists.
+     - Prefer **replace/extend** over **add**. New entries should be net-zero where possible — find the existing entry on the same topic and update it.
+     - Never duplicate a Recipe and a Debugging entry for the same fix. Pick one.
+     - If you're tempted to write more than one line, the detail belongs in the linked `docs/` page, not in AGENTS.md.
+     - Per-section size budget: if a Debugging subsection passes ~12 entries, split it; don't let categorical structure blur into a flat wall.
+
   2. **Resilience to future changes** — Documentation must NOT be fragile. Never use:
      - Hardcoded line numbers (e.g. "see line 42 of server.ts")
      - Hardcoded counts that will drift (e.g. "the 15 tool groups")

--- a/src/server/state-migration/seed-default-workflows.ts
+++ b/src/server/state-migration/seed-default-workflows.ts
@@ -97,6 +97,14 @@ The goal spec is:
 - Only require \`AGENTS.md\` changes for agent-facing operational guidance.
 - Flag branches that add routine feature detail to \`AGENTS.md\` instead of the better destination.
 
+**Check 4 — AGENTS.md edit discipline (only if this branch modifies AGENTS.md):**
+AGENTS.md is loaded into every agent turn — its size is a direct per-turn token cost on every session. FAIL this check if the diff:
+- Adds a Recipe or Debugging entry that spans more than one line. Multi-sentence prose, inlined schemas, code blocks, and step-by-step walkthroughs all belong in \`docs/\`, not AGENTS.md.
+- Adds a new entry where extending or replacing an existing entry on the same topic would have worked (net adds drive bloat).
+- Adds both a Recipe and a Debugging entry for the same fix (pick one).
+- Adds a categorical subsection past ~12 entries without splitting it.
+If the diff fixes any of the above (e.g. it shortens long entries, dedupes recipe↔debug pairs, splits a large subsection), say so and PASS.
+
 Summarize with PASS/FAIL for each check and specific items to address.`;
 
 export const DESIGN_REVIEW_PROMPT = `Review this design document for structure, clarity, and completeness. Verify:


### PR DESCRIPTION
## Why

After the 14k→5.9k token trim landed in #508 (May 1, AGENTS.md = 6,227 tokens), the file grew back to 10,672 tokens / 40.7 KB across 7 commits. Three regression patterns:

1. **Debugging lost categorical subsections.** #508 split it into 8 size-bounded subsections. #520 (snapshot/live race) flattened them. With no per-section size budget, every later commit (#521, #516, #515, #513, #511) just appended.
2. **Recipes grew inline detail.** Worst offenders: 6-line snapshot-live splice recipe (#520), 5 sub-bullets on tool YAML schema (#513), long inline project-proposal saved-state walkthrough (#516).
3. **Recipe ↔ Debugging duplication.** Same fix described twice (e.g. preparing-UX recipe + "Setting up worktree banner missing" debug, both from #521).

## What

### Commit 1 — restore Debugging structure, collapse worst offenders
- Restore 7 categorical Debugging subsections, each with a visible size budget (~5–12 entries).
- Collapse the longest multi-sentence entries; detail moves to existing `docs/` pages.
- Dedupe recipe↔debug pairs.
- Push tool-YAML-schema sub-bullets into `docs/internals.md#mcp-tool-documentation`.
- Strip redundant trailing `See [debugging.md#anchor]` from every Debugging entry.
- Add `## Maintaining this file` codifying the rules in the always-loaded scaffold.

### Commit 2 — defence in depth via role + workflow prompts

Bloat root cause: edit-discipline rules only existed in the `docs-writer` prompt, but bloat came from *coders* tacking on entries while fixing bugs. They never see docs-writer's prompt.

- **`defaults/roles/coder.yaml`** — new "Editing AGENTS.md" section.
- **`defaults/roles/code-reviewer.yaml`** — new criterion flagging multi-sentence entries / inlined schemas / duplicates / net adds as `[high]`.
- **`defaults/roles/docs-writer.yaml`** — strict edit-format block.
- **`src/server/state-migration/seed-default-workflows.ts`** (`DOC_PROMPT`) — Check 4 in the documentation-coverage gate, evaluated whenever the branch modifies AGENTS.md.

### Commit 3 — tighten Recipes to true one-liners

The first pass left Recipes largely intact. This pass applies the same one-liner discipline used on Debugging: drop redundant rules already in linked docs, collapse multi-clause file references, strip duplicate cross-refs.

## Numbers

Token counts via `tiktoken` (cl100k_base):

| | Lines | Bytes | Tokens |
|---|---|---|---|
| Pre-trim baseline (#508, May 1) | 216 | 23,043 | **6,227** |
| Pre-this-PR (HEAD~3) | 235 | 40,724 | **10,672** |
| **This PR** | **253** | **25,292** | **6,830** |
| Reduction vs HEAD~3 | +18 | −15,432 (−38%) | **−3,842 (−36.0%)** |

Now within ~600 tokens of the all-time floor. AGENTS.md is loaded into every agent turn, so this is a per-turn token saving on every session in every project.

## Why this should stick longer than the last trim

- **Categorical subsections** create a visible size budget that makes inline-detail entries look obviously misplaced.
- **`## Maintaining this file`** is now in the file the agents load — every turn.
- **Coder/code-reviewer prompts** now contain the rules — the agents that do the editing see them at edit time.
- **Documentation-coverage gate** (Check 4) will FAIL the PR if the AGENTS.md diff regresses on any of the rules.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)