### PR TITLE
Tighten tool descriptions (-32.5% tools[] JSON)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ One-liner task → entry point. Follow links for walkthroughs. **Keep entries to
 ### Server / API
 - **Add a REST endpoint** → `handleApiRoute()` in `src/server/server.ts`. See [rest-api.md](docs/rest-api.md).
 - **Add a WebSocket command** → `ClientMessage` in `ws/protocol.ts`, handle in `ws/handler.ts`, `RpcBridge` method.
-- **Add a tool** → `defaults/tools/<group>/` (or project override `.bobbit/config/tools/<group>/`); MCP auto-discovered from `.mcp.json`. See [internals.md#mcp-tool-documentation](docs/internals.md#mcp-tool-documentation).
+- **Add a tool** → `defaults/tools/<group>/` (or project override `.bobbit/config/tools/<group>/`); MCP auto-discovered from `.mcp.json`. **On-wire budget** — `pi.registerTool({ description })` ≤ 150 chars / ≤ 15 words (no examples, no anti-patterns); per-parameter `description` inside `Type.Object({...})` ≤ 80 chars sentence fragment, drop entirely when the name is self-explanatory. Detail belongs in **off-wire** YAML `docs` / `detail_docs`. Pinned by `tests/tool-description-budget.test.ts`. See [internals.md#mcp-tool-documentation](docs/internals.md#mcp-tool-documentation).
 - **Add a slash skill** → `SKILL.md` in `.claude/skills/<name>/`. See [skill-ux-and-autonomous-activation.md](docs/design/skill-ux-and-autonomous-activation.md).
 - **Add a blocking tool** → [docs/blocking-tools.md](docs/blocking-tools.md). (`ask_user_choices` is non-blocking — [docs/non-blocking-ask.md](docs/non-blocking-ask.md).)
 - **Modify a store constructor** → stores take `stateDir`/`configDir` params; resolve via `ProjectContextManager`.
@@ -156,6 +156,7 @@ Keyword index — full diagnostic walkthroughs live in [docs/debugging.md](docs/
 - **MCP gateway server collapses sub-namespaces into one tool** — callsite parsing names with own `indexOf("__", …)` instead of `parseMcpToolName()`. Check `(server, sub)` aggregation in `tool-activation.ts`.
 - **MCP server dropdown reads "Allow (default)" but agent denied** — historical bug from `mcp__playwright`/`mcp__nano-banana` builtin denials; removed in policy parity.
 - **Tools page "MCP" section missing/empty** — `GET /api/mcp-servers`; `renderMcpSection()`.
+- **Tool / parameter description budget regressed** — `tests/tool-description-budget.test.ts` pins ≤150 char tool descriptions, ≤80 char param descriptions, ≤150 char MCP meta-tool descriptions (`buildMetaToolDescription` in `src/server/mcp/mcp-meta.ts`, no comma-joined op enumeration); on-wire bytes paid in `tools[]` JSON every uncached LLM turn. Detail belongs in YAML `docs` / `detail_docs` (off-wire).
 
 ### Models / AI gateway
 - **Review/naming models under AI Gateway** — `applyReviewModelOverrides`; failures throw, no silent fallback.

--- a/defaults/tools/agent/extension.ts
+++ b/defaults/tools/agent/extension.ts
@@ -259,10 +259,7 @@ const extension: ExtensionFactory = (pi) => {
 	pi.registerTool({
 		name: "read_session",
 		label: "Read Session",
-		description:
-			"Read the conversation transcript of another Bobbit session (peer agent, delegate, or archived). " +
-			"Paginated and regex-filterable. Returns compact summaries by default; use `verbose: true` for full content blocks. " +
-			"Negative `offset` indexes from end (Python-style). `pattern` + `context` filters to matches with ±N neighbours.",
+		description: "Read another session's transcript. Paginated, regex-filterable.",
 		promptSnippet:
 			"read_session - Read another session's transcript with pagination and regex filtering.",
 		promptGuidelines: [
@@ -272,13 +269,13 @@ const extension: ExtensionFactory = (pi) => {
 			"Use context:1..5 to expand each pattern match by ±N neighbours",
 		],
 		parameters: Type.Object({
-			session_id: Type.String({ description: "Target session ID." }),
-			offset: Type.Optional(Type.Number({ description: "Starting index. Default 0. Negative indexes from the end." })),
-			limit: Type.Optional(Type.Number({ description: "Max messages to return. Default 20, clamped to [1, 200]." })),
-			pattern: Type.Optional(Type.String({ description: "Regex filter applied to message text + tool blocks." })),
-			case_sensitive: Type.Optional(Type.Boolean({ description: "Default false." })),
-			context: Type.Optional(Type.Number({ description: "Expand each match by ±N neighbours (0..5). Only with `pattern`." })),
-			verbose: Type.Optional(Type.Boolean({ description: "Return full content blocks instead of compact summaries." })),
+			session_id: Type.String(),
+			offset: Type.Optional(Type.Number({ description: "Default 0. Negative indexes from end." })),
+			limit: Type.Optional(Type.Number({ description: "Default 20, clamped to [1, 200]." })),
+			pattern: Type.Optional(Type.String({ description: "Regex filter on message text and tool blocks." })),
+			case_sensitive: Type.Optional(Type.Boolean()),
+			context: Type.Optional(Type.Number({ description: "Expand each match by ±N neighbours (0..5)." })),
+			verbose: Type.Optional(Type.Boolean({ description: "Return full content blocks instead of summaries." })),
 		}),
 
 		async execute(_toolCallId, params) {
@@ -324,11 +321,7 @@ const extension: ExtensionFactory = (pi) => {
 	pi.registerTool({
 		name: "delegate",
 		label: "Delegate",
-		description:
-			"Run a task in a separate agent process. The delegate agent has full tool access (bash, read, write, edit) " +
-			"but receives only the instructions you provide — it does not see this conversation. " +
-			"Use this when you need isolated execution, parallel work, or an independent perspective. " +
-			"The tool blocks until the delegate finishes and returns its output.",
+		description: "Run a task in an isolated agent subprocess. Blocks until it returns output.",
 		promptSnippet:
 			"delegate - Run a task in a separate agent process with isolated context. Blocks until complete.",
 		promptGuidelines: [
@@ -338,16 +331,16 @@ const extension: ExtensionFactory = (pi) => {
 			"Use the 'parallel' parameter to run multiple delegates concurrently",
 		],
 		parameters: Type.Object({
-			instructions: Type.Optional(Type.String({ description: "Task instructions for the delegate agent. Be specific and self-contained. Required for single delegate, optional when using parallel." })),
+			instructions: Type.Optional(Type.String({ description: "Required for single delegate; optional with parallel." })),
 			parallel: Type.Optional(Type.Array(
 				Type.Object({
-					instructions: Type.String({ description: "Instructions for this parallel delegate" }),
-					context: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "Additional context key-values" })),
+					instructions: Type.String(),
+					context: Type.Optional(Type.Record(Type.String(), Type.String())),
 				}),
-				{ description: "Run multiple delegates in parallel instead. Each gets its own instructions." },
+				{ description: "Run multiple delegates concurrently." },
 			)),
-			context: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "Additional context key-values passed to the delegate" })),
-			timeout_minutes: Type.Optional(Type.Number({ description: "Timeout in minutes (default: 10)" })),
+			context: Type.Optional(Type.Record(Type.String(), Type.String())),
+			timeout_minutes: Type.Optional(Type.Number({ description: "Default 10." })),
 		}),
 
 		async execute(_toolCallId, params, signal, onUpdate, ctx) {

--- a/defaults/tools/ask/extension.ts
+++ b/defaults/tools/ask/extension.ts
@@ -29,11 +29,7 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "ask_user_choices",
 		label: "Ask User Choices",
-		description: [
-			"Post 1–5 multiple-choice questions to the user as an inline widget.",
-			"Non-blocking: the tool returns immediately; the user's answers arrive later as a separate user message.",
-			"Calling this tool ends your current turn.",
-		].join(" "),
+		description: "Post 1–5 multiple-choice questions to the user. Non-blocking; ends your turn.",
 		promptSnippet: [
 			"Post multiple-choice questions to the user. The tool returns immediately and ends your turn.",
 			"Answers arrive later as a user message prefixed with `[ask_user_choices_response tool_use_id=<id>]`",
@@ -42,30 +38,30 @@ export default function (pi: ExtensionAPI) {
 		parameters: Type.Object({
 			questions: Type.Array(
 				Type.Object({
-					question: Type.String({ minLength: 1, description: "The question prompt" }),
+					question: Type.String({ minLength: 1 }),
 					options: Type.Array(Type.String({ minLength: 1 }), {
 						minItems: 2,
 						maxItems: 8,
-						description: "2–8 answer options",
+						description: "2–8 answer options.",
 					}),
 					tab_label: Type.Optional(Type.String({
 						minLength: 1,
 						maxLength: 24,
-						description: "Short 2–4 word tab label (≤24 chars) summarizing the question. REQUIRED when posting more than one question — used as the tab title so users can jump between questions without reading full prompts.",
+						description: "2–4 word tab label. Required for multi-question asks.",
 					})),
 					multi: Type.Optional(Type.Boolean({
-						description: "If true, user may select multiple options; selected is returned as a string[].",
+						description: "Allow multiple selections; returns string[].",
 					})),
 					min: Type.Optional(Type.Integer({
 						minimum: 1,
-						description: "Minimum selections when multi:true (default 1).",
+						description: "Min selections when multi:true. Default 1.",
 					})),
 					max: Type.Optional(Type.Integer({
 						minimum: 1,
-						description: "Maximum selections when multi:true (default = options.length).",
+						description: "Max selections when multi:true. Default options.length.",
 					})),
 				}, { additionalProperties: true }),
-				{ minItems: 1, maxItems: 5, description: "1–5 multiple-choice questions" },
+				{ minItems: 1, maxItems: 5 },
 			),
 		}),
 		async execute(toolUseId, params) {

--- a/defaults/tools/browser/extension.ts
+++ b/defaults/tools/browser/extension.ts
@@ -128,9 +128,9 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "browser_navigate",
 		label: "Browser Navigate",
-		description: "Navigate the browser to a URL. Launches a headless browser if needed.",
+		description: "Navigate the browser to a URL. Launches headless browser lazily.",
 		parameters: Type.Object({
-			url: Type.String({ description: "URL to navigate to" }),
+			url: Type.String(),
 		}),
 		async execute(_toolCallId, params, signal) {
 			const p = await withAbort(ensurePage(), signal);
@@ -147,16 +147,14 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "browser_screenshot",
 		label: "Browser Screenshot",
-		description:
-			"Take a screenshot of the current browser page (or a specific element). " +
-			"Returns the image so you can see it. Optionally saves to a file.",
+		description: "Screenshot the page or an element; optionally save to a file.",
 		parameters: Type.Object({
-			selector: Type.Optional(Type.String({ description: "CSS selector to screenshot a specific element. Omit for full page." })),
-			savePath: Type.Optional(Type.String({ description: "File path to save the screenshot to (png/jpg). Optional." })),
-			fullPage: Type.Optional(Type.Boolean({ description: "Capture the full scrollable page. Default false." })),
-			includeBase64: Type.Optional(Type.Boolean({ description: "Spill the screenshot to <cwd>/.bobbit-qa/screenshots/<uuid>.png and return a [screenshot_file]<path>[/screenshot_file] text block. Reference via <img src=\"file:///<path>\"> in HTML reports. Default false." })),
-			format: Type.Optional(Type.Union([Type.Literal("png"), Type.Literal("jpeg")], { description: "Image format. Default 'png'. 'jpeg' is ~5x smaller at quality 75." })),
-			quality: Type.Optional(Type.Number({ description: "JPEG quality (1-100). Only applies to format='jpeg'. Default 80." })),
+			selector: Type.Optional(Type.String({ description: "CSS selector for an element; omit for full page." })),
+			savePath: Type.Optional(Type.String({ description: "File path to save the screenshot." })),
+			fullPage: Type.Optional(Type.Boolean({ description: "Capture the full scrollable page." })),
+			includeBase64: Type.Optional(Type.Boolean({ description: "Spill to .bobbit-qa/screenshots/ and emit [screenshot_file] block." })),
+			format: Type.Optional(Type.Union([Type.Literal("png"), Type.Literal("jpeg")], { description: "Image format. Default png." })),
+			quality: Type.Optional(Type.Number({ description: "JPEG quality 1-100. Default 80." })),
 		}),
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 			const p = await withAbort(ensurePage(), signal);
@@ -232,9 +230,9 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "browser_click",
 		label: "Browser Click",
-		description: "Click an element on the page by CSS selector.",
+		description: "Click an element by CSS selector.",
 		parameters: Type.Object({
-			selector: Type.String({ description: "CSS selector of the element to click" }),
+			selector: Type.String(),
 		}),
 		async execute(_toolCallId, params, signal) {
 			const p = await withAbort(ensurePage(), signal);
@@ -250,11 +248,11 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "browser_type",
 		label: "Browser Type",
-		description: "Type text into an input element identified by CSS selector.",
+		description: "Type text into an input by CSS selector.",
 		parameters: Type.Object({
-			selector: Type.String({ description: "CSS selector of the input element" }),
-			text: Type.String({ description: "Text to type" }),
-			clear: Type.Optional(Type.Boolean({ description: "Clear the field before typing. Default true." })),
+			selector: Type.String(),
+			text: Type.String(),
+			clear: Type.Optional(Type.Boolean({ description: "Clear field before typing. Default true." })),
 		}),
 		async execute(_toolCallId, params, signal) {
 			const p = await withAbort(ensurePage(), signal);
@@ -275,9 +273,9 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "browser_eval",
 		label: "Browser Evaluate",
-		description: "Execute JavaScript in the browser page and return the result.",
+		description: "Evaluate a JavaScript expression in the page and return the result.",
 		parameters: Type.Object({
-			expression: Type.String({ description: "JavaScript expression to evaluate in the page context" }),
+			expression: Type.String(),
 		}),
 		async execute(_toolCallId, params, signal) {
 			const p = await withAbort(ensurePage(), signal);
@@ -294,10 +292,10 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "browser_wait",
 		label: "Browser Wait",
-		description: "Wait for an element matching the selector to appear on the page.",
+		description: "Wait for an element matching the selector to become visible.",
 		parameters: Type.Object({
-			selector: Type.String({ description: "CSS selector to wait for" }),
-			timeout: Type.Optional(Type.Number({ description: "Max wait time in milliseconds. Default 10000." })),
+			selector: Type.String(),
+			timeout: Type.Optional(Type.Number({ description: "Max wait in ms. Default 10000." })),
 		}),
 		async execute(_toolCallId, params, signal) {
 			const p = await withAbort(ensurePage(), signal);
@@ -319,7 +317,7 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "browser_snapshot",
 		label: "Browser Snapshot",
-		description: "Capture accessibility snapshot of the current page. Returns the ARIA accessibility tree as structured YAML text.",
+		description: "Capture the page's ARIA accessibility tree as YAML text.",
 		parameters: Type.Object({}),
 		async execute(_toolCallId, _params, signal) {
 			const p = await withAbort(ensurePage(), signal);
@@ -335,10 +333,10 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "browser_console_messages",
 		label: "Browser Console Messages",
-		description: "Returns console messages (errors, warnings, info, logs) captured from the current page.",
+		description: "Return console messages captured from the current page.",
 		parameters: Type.Object({
-			level: Type.Optional(Type.String({ description: 'Filter by message level: "log", "error", "warning", "info", "debug", "trace"' })),
-			clear: Type.Optional(Type.Boolean({ description: "Clear the message buffer after returning. Default false." })),
+			level: Type.Optional(Type.String({ description: "Filter by level: log, error, warning, info, debug, trace." })),
+			clear: Type.Optional(Type.Boolean({ description: "Clear buffer after returning." })),
 		}),
 		async execute(_toolCallId, params, _signal) {
 			// Ensure page exists so listener is attached, but don't need the page ref
@@ -361,9 +359,9 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "browser_press_key",
 		label: "Browser Press Key",
-		description: "Press a key on the keyboard.",
+		description: "Press a keyboard key (e.g. Enter, Tab, Control+A).",
 		parameters: Type.Object({
-			key: Type.String({ description: 'Key to press, e.g. "Enter", "Tab", "Escape", "Control+A"' }),
+			key: Type.String(),
 		}),
 		async execute(_toolCallId, params, signal) {
 			const p = await withAbort(ensurePage(), signal);
@@ -379,9 +377,9 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "browser_hover",
 		label: "Browser Hover",
-		description: "Hover over an element on the page by CSS selector.",
+		description: "Hover an element by CSS selector.",
 		parameters: Type.Object({
-			selector: Type.String({ description: "CSS selector of the element to hover over" }),
+			selector: Type.String(),
 		}),
 		async execute(_toolCallId, params, signal) {
 			const p = await withAbort(ensurePage(), signal);
@@ -397,10 +395,10 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "browser_select_option",
 		label: "Browser Select Option",
-		description: "Select an option in a <select> dropdown by value.",
+		description: "Select option(s) in a <select> dropdown by value.",
 		parameters: Type.Object({
-			selector: Type.String({ description: "CSS selector of the <select> element" }),
-			values: Type.Array(Type.String(), { description: "Option values to select" }),
+			selector: Type.String(),
+			values: Type.Array(Type.String()),
 		}),
 		async execute(_toolCallId, params, signal) {
 			const p = await withAbort(ensurePage(), signal);
@@ -421,8 +419,8 @@ export default function (pi: ExtensionAPI) {
 		label: "Browser Resize",
 		description: "Resize the browser viewport.",
 		parameters: Type.Object({
-			width: Type.Number({ description: "Viewport width in pixels" }),
-			height: Type.Number({ description: "Viewport height in pixels" }),
+			width: Type.Number(),
+			height: Type.Number(),
 		}),
 		async execute(_toolCallId, params, signal) {
 			const p = await withAbort(ensurePage(), signal);

--- a/defaults/tools/html/extension.ts
+++ b/defaults/tools/html/extension.ts
@@ -68,14 +68,12 @@ const extension: ExtensionFactory = (pi) => {
 	pi.registerTool({
 		name: "preview_open",
 		label: "Preview Open",
-		description:
-			"Open an HTML preview panel in the Bobbit UI. Provide raw HTML content or a path to an HTML file. " +
-			"The preview panel appears alongside the chat and auto-updates when you call this tool again.",
+		description: "Open or update the HTML preview panel. Auto-refreshes on re-call.",
 		parameters: Type.Object({
-			html: Type.Optional(Type.String({ description: "Raw HTML content to preview. Takes priority over 'file' if both are provided." })),
-			file: Type.Optional(Type.String({ description: "Path to an HTML file to load and preview. Only the entry file is copied unless `assets`/`manifest` declare siblings." })),
-			assets: Type.Optional(Type.Array(Type.String(), { description: "Optional list of sibling asset paths (relative to the entry file's directory) to copy into the preview mount. Supports literal paths and single-segment globs (e.g. 'styles.css', 'img/*.png'). '**' is not supported." })),
-			manifest: Type.Optional(Type.String({ description: "Optional path (relative to the entry file's directory) to a JSON manifest of the form { \"assets\": [...] }. Concatenated with inline `assets`." })),
+			html: Type.Optional(Type.String({ description: "Raw HTML. Takes priority over `file`." })),
+			file: Type.Optional(Type.String({ description: "Path to an HTML entry file." })),
+			assets: Type.Optional(Type.Array(Type.String(), { description: "Sibling asset paths relative to entry. Supports single-segment globs." })),
+			manifest: Type.Optional(Type.String({ description: "Path to JSON manifest { assets: [...] } relative to entry." })),
 		}),
 
 		async execute(_toolCallId, params) {

--- a/defaults/tools/images/extension.ts
+++ b/defaults/tools/images/extension.ts
@@ -55,7 +55,7 @@ const extension: ExtensionFactory = (pi) => {
 	pi.registerTool({
 		name: "generate_image",
 		label: "Generate Image",
-		description: "Generate images using GPT Image 2, DALL-E, Nano Banana/Gemini, or another configured image generation model.",
+		description: "Generate images via the configured image model (GPT Image, DALL-E, Gemini, etc.).",
 		promptSnippet: "generate_image: Generate raster images. Supports GPT Image 2 via model=\"openai/gpt-image-2\" and uses the configured session image model by default.",
 		promptGuidelines: [
 			"Use generate_image when the user asks for AI image generation or bitmap visual assets.",
@@ -67,11 +67,11 @@ const extension: ExtensionFactory = (pi) => {
 			"If the selected or requested model fails because of auth or provider availability, report the failure and ask before switching to another provider.",
 		],
 		parameters: Type.Object({
-			prompt: Type.String({ description: "Detailed image prompt" }),
-			outputPath: Type.Optional(Type.String({ description: "Optional path to save the generated image" })),
-			model: Type.Optional(Type.String({ description: "Optional override as provider/modelId" })),
-			size: Type.Optional(Type.String({ description: "OpenAI size, e.g. 1024x1024, 1536x1024, 1024x1536, or auto" })),
-			quality: Type.Optional(Type.String({ description: "OpenAI quality, e.g. auto, low, medium, high, standard, or hd" })),
+			prompt: Type.String(),
+			outputPath: Type.Optional(Type.String({ description: "Path to save the image." })),
+			model: Type.Optional(Type.String({ description: "Override as provider/modelId." })),
+			size: Type.Optional(Type.String({ description: "OpenAI size, e.g. 1024x1024 or auto." })),
+			quality: Type.Optional(Type.String({ description: "OpenAI quality, e.g. auto, low, high, hd." })),
 			background: Type.Optional(Type.Union([
 				Type.Literal("auto"),
 				Type.Literal("transparent"),
@@ -82,9 +82,9 @@ const extension: ExtensionFactory = (pi) => {
 				Type.Literal("jpeg"),
 				Type.Literal("webp"),
 			])),
-			aspectRatio: Type.Optional(Type.String({ description: "Gemini aspect ratio, e.g. 1:1, 16:9, 9:16" })),
-			imageSize: Type.Optional(Type.String({ description: "Provider-specific image size" })),
-			n: Type.Optional(Type.Number({ description: "Number of images to generate", minimum: 1, maximum: 4 })),
+			aspectRatio: Type.Optional(Type.String({ description: "Gemini aspect ratio, e.g. 1:1, 16:9." })),
+			imageSize: Type.Optional(Type.String({ description: "Provider-specific image size." })),
+			n: Type.Optional(Type.Number({ description: "Number of images.", minimum: 1, maximum: 4 })),
 		}),
 		async execute(_toolCallId, params) {
 			let baseUrl: string;

--- a/defaults/tools/mcp/extension.ts
+++ b/defaults/tools/mcp/extension.ts
@@ -104,11 +104,7 @@ const extension: ExtensionFactory = (pi) => {
 	pi.registerTool({
 		name: "mcp_describe",
 		label: "MCP Describe",
-		description:
-			"Return the JSON Schema for an MCP server's operations. " +
-			"If `operation` is omitted, lists all operations on the server with their descriptions and input schemas. " +
-			"If `operation` is provided, returns just that one operation's schema. " +
-			"Use this to discover argument shapes before calling `mcp_<server>(operation, args)`.",
+		description: "Return JSON Schema for MCP server operations. Omit `operation` to list all.",
 		promptSnippet:
 			"mcp_describe(server, operation?) - Fetch operation schemas for an MCP server on demand.",
 		promptGuidelines: [
@@ -117,8 +113,8 @@ const extension: ExtensionFactory = (pi) => {
 			"After describing, invoke the operation via the `mcp_<server>` meta-tool.",
 		],
 		parameters: Type.Object({
-			server: Type.String({ description: "MCP server name (the `<server>` part of `mcp__<server>__<op>`)." }),
-			operation: Type.Optional(Type.String({ description: "If provided, return just this operation's schema. If omitted, list all operations on the server." })),
+			server: Type.String(),
+			operation: Type.Optional(Type.String()),
 		}),
 
 		async execute(_toolCallId, params) {

--- a/defaults/tools/proposals/extension.ts
+++ b/defaults/tools/proposals/extension.ts
@@ -84,7 +84,7 @@ const PROPOSAL_TYPE_ENUM = Type.Union([
 	Type.Literal("role"),
 	Type.Literal("tool"),
 	Type.Literal("staff"),
-], { description: "Proposal type" });
+]);
 
 export default function (pi: ExtensionAPI) {
 	function ack(rev?: number) {
@@ -100,14 +100,14 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "propose_goal",
 		label: "Propose Goal",
-		description: "Submit a goal proposal for user review. Call this when you have gathered enough information to propose a goal.",
+		description: "Submit a goal proposal for user review.",
 		promptSnippet: "Propose a goal with title, spec, workflow, and optional fields.",
 		parameters: Type.Object({
-			title: Type.String({ description: "Short 2-5 word title (must be under 29 characters)" }),
-			spec: Type.String({ description: "Markdown spec content. Include: brief description, key requirements, constraints, technical approach" }),
-			cwd: Type.Optional(Type.String({ description: "Working directory override path" })),
-			workflow: Type.Optional(Type.String({ description: "Workflow ID (e.g. \"general\", \"feature\", \"bug-fix\")" })),
-			options: Type.Optional(Type.String({ description: "Comma-separated step names for optional steps (e.g. \"QA testing\")" })),
+			title: Type.String({ description: "Short 2-5 word title, under 29 characters." }),
+			spec: Type.String({ description: "Markdown spec: description, requirements, constraints, approach." }),
+			cwd: Type.Optional(Type.String({ description: "Working directory override." })),
+			workflow: Type.Optional(Type.String({ description: "Workflow ID, e.g. general, feature, bug-fix." })),
+			options: Type.Optional(Type.String({ description: "Comma-separated optional step names." })),
 		}),
 		async execute(_id, args) { const rev = await seedProposal("goal", args); return ack(rev); },
 	});
@@ -116,14 +116,14 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "propose_role",
 		label: "Propose Role",
-		description: "Submit a role proposal for user review. Call this when you have designed a custom agent role.",
+		description: "Submit a custom agent role proposal for user review.",
 		promptSnippet: "Propose a role with name, label, prompt, and optional fields.",
 		parameters: Type.Object({
-			name: Type.String({ description: "Role identifier (lowercase, hyphens)" }),
-			label: Type.String({ description: "Human-readable display name" }),
-			prompt: Type.String({ description: "System prompt for the role" }),
-			tools: Type.Optional(Type.String({ description: "Comma-separated list of allowed tools" })),
-			accessory: Type.Optional(Type.String({ description: "Accessory configuration" })),
+			name: Type.String({ description: "Role identifier, lowercase with hyphens." }),
+			label: Type.String({ description: "Human-readable display name." }),
+			prompt: Type.String(),
+			tools: Type.Optional(Type.String({ description: "Comma-separated allowed tools." })),
+			accessory: Type.Optional(Type.String()),
 		}),
 		async execute(_id, args) { const rev = await seedProposal("role", args); return ack(rev); },
 	});
@@ -132,12 +132,12 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "propose_tool",
 		label: "Propose Tool",
-		description: "Submit a tool proposal for user review. Call this when you have designed a custom tool.",
+		description: "Submit a custom tool proposal for user review.",
 		promptSnippet: "Propose a tool with tool name, action, and content.",
 		parameters: Type.Object({
-			tool: Type.String({ description: "Tool name" }),
-			action: Type.String({ description: "Action type (e.g. \"create\", \"update\")" }),
-			content: Type.String({ description: "Tool definition content (YAML)" }),
+			tool: Type.String(),
+			action: Type.String({ description: "e.g. create, update." }),
+			content: Type.String({ description: "Tool definition YAML." }),
 		}),
 		async execute(_id, args) { const rev = await seedProposal("tool", args); return ack(rev); },
 	});
@@ -146,14 +146,14 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "propose_staff",
 		label: "Propose Staff",
-		description: "Submit a staff member proposal for user review. Call this when you have designed a custom staff configuration.",
+		description: "Submit a staff member proposal for user review.",
 		promptSnippet: "Propose a staff member with name, prompt, and optional fields.",
 		parameters: Type.Object({
-			name: Type.String({ description: "Staff member name" }),
-			description: Type.Optional(Type.String({ description: "Short description of the staff member" })),
-			prompt: Type.String({ description: "System prompt for the staff member" }),
-			triggers: Type.Optional(Type.String({ description: "Trigger conditions" })),
-			cwd: Type.Optional(Type.String({ description: "Working directory" })),
+			name: Type.String(),
+			description: Type.Optional(Type.String()),
+			prompt: Type.String(),
+			triggers: Type.Optional(Type.String()),
+			cwd: Type.Optional(Type.String()),
 		}),
 		async execute(_id, args) { const rev = await seedProposal("staff", args); return ack(rev); },
 	});
@@ -162,40 +162,40 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "propose_project",
 		label: "Propose Project",
-		description: "Submit a project proposal for user review. Call this when you have detected or configured a project.",
+		description: "Submit a project proposal for user review.",
 		promptSnippet: "Propose a project with name, root_path, and optional command fields.",
 		parameters: Type.Object({
-			name: Type.String({ description: "Project name" }),
-			root_path: Type.String({ description: "Root path of the project directory" }),
-			build_command: Type.Optional(Type.String({ description: "Build command" })),
-			test_command: Type.Optional(Type.String({ description: "Test command" })),
-			typecheck_command: Type.Optional(Type.String({ description: "Type-check command" })),
-			test_unit_command: Type.Optional(Type.String({ description: "Unit test command" })),
-			test_e2e_command: Type.Optional(Type.String({ description: "E2E test command" })),
-			worktree_setup_command: Type.Optional(Type.String({ description: "Worktree setup command" })),
-			sandbox: Type.Optional(Type.String({ description: "Sandbox mode (e.g. 'docker')" })),
-			session_model: Type.Optional(Type.String({ description: "Default session model (provider/model-id)" })),
-			review_model: Type.Optional(Type.String({ description: "Reviewer model (provider/model-id)" })),
-			naming_model: Type.Optional(Type.String({ description: "Naming model (provider/model-id)" })),
-			worktree_root: Type.Optional(Type.String({ description: "Custom parent dir for worktrees (absolute or relative to root_path). Default: <rootPath>-wt/" })),
+			name: Type.String(),
+			root_path: Type.String({ description: "Project root directory." }),
+			build_command: Type.Optional(Type.String()),
+			test_command: Type.Optional(Type.String()),
+			typecheck_command: Type.Optional(Type.String()),
+			test_unit_command: Type.Optional(Type.String()),
+			test_e2e_command: Type.Optional(Type.String()),
+			worktree_setup_command: Type.Optional(Type.String()),
+			sandbox: Type.Optional(Type.String({ description: "e.g. 'docker'." })),
+			session_model: Type.Optional(Type.String({ description: "provider/model-id." })),
+			review_model: Type.Optional(Type.String({ description: "provider/model-id." })),
+			naming_model: Type.Optional(Type.String({ description: "provider/model-id." })),
+			worktree_root: Type.Optional(Type.String({ description: "Worktree parent dir. Default <rootPath>-wt/." })),
 			components: Type.Optional(Type.Array(Type.Object({
-				name: Type.String({ description: "Component name (unique within project)" }),
-				repo: Type.String({ description: "\".\" for single-repo, else a subfolder of rootPath" }),
-				relative_path: Type.Optional(Type.String({ description: "Optional sub-path inside the repo" })),
-				worktree_setup_command: Type.Optional(Type.String({ description: "Per-component setup hook" })),
-				commands: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "Flat name → shell. Absent ⇒ data-only." })),
-				config: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "Per-component opaque key→string config (max 100 entries; consumed by skills like /qa-test, e.g. qa_start_command, qa_health_check, qa_browser_entry, qa_max_duration_minutes, qa_max_scenarios)." })),
-			}), { description: "Project components. Single-repo: one component with repo='.'." })),
-			workflows: Type.Optional(Type.Record(Type.String(), Type.Any(), { description: "Inline workflows keyed by id; structurally validated server-side." })),
+				name: Type.String({ description: "Unique within project." }),
+				repo: Type.String({ description: "'.' for single-repo, else subfolder of rootPath." }),
+				relative_path: Type.Optional(Type.String({ description: "Sub-path inside the repo." })),
+				worktree_setup_command: Type.Optional(Type.String()),
+				commands: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "name → shell. Absent ⇒ data-only." })),
+				config: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "Opaque key→string config, max 100 entries." })),
+			}), { description: "Single-repo: one component with repo='.'." })),
+			workflows: Type.Optional(Type.Record(Type.String(), Type.Any(), { description: "Inline workflows keyed by id." })),
 			config_directories: Type.Optional(Type.Array(Type.Object({
 				path: Type.String(),
 				types: Type.Array(Type.String()),
-			}), { description: "Custom config directories scanned for skills/mcp/tools/agents." })),
+			}), { description: "Dirs scanned for skills/mcp/tools/agents." })),
 			sandbox_tokens: Type.Optional(Type.Array(Type.Object({
 				key: Type.String(),
 				enabled: Type.Boolean(),
 				value: Type.Optional(Type.String()),
-			}), { description: "Sandbox token list. Server strips `value` to SecretsStore on PUT." })),
+			}), { description: "Server strips value to SecretsStore on PUT." })),
 		}),
 		async execute(_id, args) { const rev = await seedProposal("project", args); return ack(rev); },
 	});
@@ -204,7 +204,7 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "view_proposal",
 		label: "View Proposal",
-		description: "Read the current draft of a proposal file for the active session.",
+		description: "Read the current proposal draft for the active session.",
 		promptSnippet: "View the current proposal draft (markdown for goal, YAML for the rest).",
 		parameters: Type.Object({
 			type: PROPOSAL_TYPE_ENUM,
@@ -255,12 +255,12 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "edit_proposal",
 		label: "Edit Proposal",
-		description: "Surgically edit the current proposal draft via exact-string replacement. Same semantics as the builtin edit tool.",
+		description: "Edit the current proposal draft via exact-string replacement.",
 		promptSnippet: "Edit a proposal draft by replacing old_text with new_text (exact, unique match).",
 		parameters: Type.Object({
 			type: PROPOSAL_TYPE_ENUM,
-			old_text: Type.String({ description: "Exact text to find in the draft. Must match uniquely." }),
-			new_text: Type.String({ description: "Replacement text. Empty string deletes the matched span." }),
+			old_text: Type.String({ description: "Must match uniquely in the draft." }),
+			new_text: Type.String({ description: "Empty string deletes the matched span." }),
 		}),
 		async execute(_id, args) {
 			const { type, old_text, new_text } = args as { type: ProposalType; old_text: string; new_text: string };

--- a/defaults/tools/review/extension.ts
+++ b/defaults/tools/review/extension.ts
@@ -17,14 +17,12 @@ const extension: ExtensionFactory = (pi) => {
 	pi.registerTool({
 		name: "review_open",
 		label: "Review Open",
-		description:
-			"Open a markdown document in the review pane for inline commenting and annotation. " +
-			"Pass `markdown` for inline content or `file` to load from disk.",
+		description: "Open a markdown document in the review pane for inline commenting.",
 		parameters: Type.Object({
-			title: Type.Optional(Type.String({ description: "Tab label. Defaults to filename or \"Review\"." })),
-			markdown: Type.Optional(Type.String({ description: "Inline markdown content." })),
-			file: Type.Optional(Type.String({ description: "Path to a markdown file on disk." })),
-			replace: Type.Optional(Type.Boolean({ description: "Replace existing tab content (default: true)." })),
+			title: Type.Optional(Type.String({ description: "Tab label. Defaults to filename or 'Review'." })),
+			markdown: Type.Optional(Type.String()),
+			file: Type.Optional(Type.String()),
+			replace: Type.Optional(Type.Boolean({ description: "Replace existing tab content. Default true." })),
 		}),
 
 		async execute(_toolCallId, params) {
@@ -95,7 +93,7 @@ const extension: ExtensionFactory = (pi) => {
 		label: "Review Close",
 		description: "Close a review document tab or all review tabs.",
 		parameters: Type.Object({
-			title: Type.Optional(Type.String({ description: "Close specific tab. Omit to close all tabs." })),
+			title: Type.Optional(Type.String({ description: "Specific tab. Omit to close all." })),
 		}),
 
 		async execute(_toolCallId, params) {

--- a/defaults/tools/shell/extension.ts
+++ b/defaults/tools/shell/extension.ts
@@ -153,11 +153,11 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "bash",
 		label: "Bash",
-		description: "Execute a bash command. Returns stdout+stderr. Output truncated to last 2000 lines / 50KB.",
+		description: "Run a bash command. Output truncated to last 2000 lines / 50KB.",
 		parameters: Type.Object({
-			command: Type.String({ description: "The bash command to execute" }),
-			timeout: Type.Optional(Type.Number({ description: "Timeout in seconds (default: 300)" })),
-			description: Type.Optional(Type.String({ description: "Short human-readable label (3–6 words) for the command. Strongly recommended for multi-line commands, heredocs, and non-obvious one-liners. Example: 'sum agent-qa costs from session-costs.json'." })),
+			command: Type.String(),
+			timeout: Type.Optional(Type.Number({ description: "Seconds. Default 300." })),
+			description: Type.Optional(Type.String({ description: "Short label (3-6 words); recommended for multi-line or non-obvious commands." })),
 		}),
 		async execute(_toolCallId, { command, timeout }, abortSignal, onUpdate) {
 			return new Promise((resolve) => {
@@ -276,7 +276,7 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "bash_bg",
 		label: "Background Process",
-		description: "Manage background shell processes. Actions: create, logs, grep, head, slice, kill, list.",
+		description: "Manage background shell processes: create, logs, grep, head, slice, kill, list, wait.",
 		parameters: Type.Object({
 			action: Type.Union([
 				Type.Literal("create"),
@@ -287,18 +287,18 @@ export default function (pi: ExtensionAPI) {
 				Type.Literal("kill"),
 				Type.Literal("list"),
 				Type.Literal("wait"),
-			], { description: "Action to perform" }),
-			command: Type.Optional(Type.String({ description: "Shell command to run (for 'create')" })),
-			name: Type.Optional(Type.String({ description: "Short name for the process (max 3 words, required for 'create'). Example: 'dev server', 'color echo loop', 'test runner'" })),
-			id: Type.Optional(Type.String({ description: "Background process ID (for 'logs', 'grep', 'head', 'slice', 'kill', 'wait')" })),
-			timeout: Type.Optional(Type.Number({ description: "Max seconds to wait (default: 300, for 'wait')" })),
-			tail: Type.Optional(Type.Number({ description: "Number of log lines to return from end (default: 200, for 'logs')" })),
-			pattern: Type.Optional(Type.String({ description: "Search pattern — string or regex (for 'grep')" })),
-			context: Type.Optional(Type.Number({ description: "Lines of context around each match (default: 0, for 'grep')" })),
-			max_results: Type.Optional(Type.Number({ description: "Max matches to return (default: 50, for 'grep')" })),
-			lines: Type.Optional(Type.Number({ description: "Number of lines (default: 50, for 'head')" })),
-			from: Type.Optional(Type.Number({ description: "Start line, 1-indexed (for 'slice')" })),
-			to: Type.Optional(Type.Number({ description: "End line, inclusive (for 'slice')" })),
+			]),
+			command: Type.Optional(Type.String({ description: "Shell command (create)." })),
+			name: Type.Optional(Type.String({ description: "Short process name, max 3 words (create)." })),
+			id: Type.Optional(Type.String({ description: "Background process ID." })),
+			timeout: Type.Optional(Type.Number({ description: "Max seconds to wait. Default 300 (wait)." })),
+			tail: Type.Optional(Type.Number({ description: "Lines from end. Default 200 (logs)." })),
+			pattern: Type.Optional(Type.String({ description: "Search pattern, string or regex (grep)." })),
+			context: Type.Optional(Type.Number({ description: "Lines of context around match. Default 0 (grep)." })),
+			max_results: Type.Optional(Type.Number({ description: "Max matches. Default 50 (grep)." })),
+			lines: Type.Optional(Type.Number({ description: "Number of lines. Default 50 (head)." })),
+			from: Type.Optional(Type.Number({ description: "Start line, 1-indexed (slice)." })),
+			to: Type.Optional(Type.Number({ description: "End line, inclusive (slice)." })),
 		}),
 		async execute(_toolCallId, { action, command, name, id, tail, timeout, pattern, context, max_results, lines, from, to }) {
 			const text = (t: string) => ({ content: [{ type: "text" as const, text: t }], details: {} });

--- a/defaults/tools/skills/extension.ts
+++ b/defaults/tools/skills/extension.ts
@@ -45,11 +45,11 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "activate_skill",
 		label: "Activate Skill",
-		description: "Activate a discovered skill by name. Returns the skill's instructions as the tool result; follow them as if the user had typed /<name> <args>.",
+		description: "Activate a discovered slash skill by name. Returns its instructions.",
 		promptSnippet: "Activate a discovered slash skill autonomously.",
 		parameters: Type.Object({
-			name: Type.String({ description: "Skill name (without leading slash)" }),
-			args: Type.Optional(Type.String({ description: "Optional argument string passed to the skill" })),
+			name: Type.String({ description: "Skill name without leading slash." }),
+			args: Type.Optional(Type.String()),
 		}),
 		async execute(input: { name: string; args?: string }) {
 			try {

--- a/defaults/tools/tasks/extension.ts
+++ b/defaults/tools/tasks/extension.ts
@@ -75,7 +75,7 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "task_list",
 		label: "List Tasks",
-		description: "List all tasks for the current goal with their state, type, assignment, and dependencies. Returns a slim summary — use task detail for full spec or result.",
+		description: "List all tasks for the current goal as a slim summary.",
 		promptSnippet: "List all tasks for the goal.",
 		parameters: Type.Object({}),
 		async execute() {
@@ -88,16 +88,13 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "task_create",
 		label: "Create Task",
-		description: [
-			"Create a new task for the goal.",
-			"Types: implementation, code-review, testing, bug-fix, refactor, custom.",
-		].join(" "),
+		description: "Create a new task. Types: implementation, code-review, testing, bug-fix, refactor, custom.",
 		promptSnippet: "Create a task with title, type, optional spec, and dependencies.",
 		parameters: Type.Object({
-			title: Type.String({ description: "Short task title" }),
-			type: Type.String({ description: "Task type: implementation, code-review, testing, bug-fix, refactor, or custom" }),
-			spec: Type.Optional(Type.String({ description: "Detailed specification for the task" })),
-			depends_on: Type.Optional(Type.Array(Type.String(), { description: "Task IDs this task depends on" })),
+			title: Type.String(),
+			type: Type.String({ description: "implementation, code-review, testing, bug-fix, refactor, or custom." }),
+			spec: Type.Optional(Type.String()),
+			depends_on: Type.Optional(Type.Array(Type.String(), { description: "Task IDs this task depends on." })),
 		}),
 		async execute(_id, params) {
 			try {
@@ -112,21 +109,16 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "task_update",
 		label: "Update Task",
-		description: [
-			"Update a task's fields, assignment, and/or state in a single call.",
-			"Provide any combination: field updates (title, spec, result_summary, head_sha),",
-			"assignment (assigned_to session ID), and/or state transition (state).",
-			"States: todo, in-progress, blocked, complete, skipped.",
-		].join(" "),
+		description: "Update task fields, assignment, and/or state. States: todo, in-progress, blocked, complete, skipped.",
 		promptSnippet: "Update task fields, assign to a session, and/or transition state.",
 		parameters: Type.Object({
-			task_id: Type.String({ description: "Task ID" }),
-			title: Type.Optional(Type.String({ description: "New title" })),
-			spec: Type.Optional(Type.String({ description: "New spec" })),
-			result_summary: Type.Optional(Type.String({ description: "Summary of results" })),
-			head_sha: Type.Optional(Type.String({ description: "HEAD commit SHA of your finished work" })),
-			assigned_to: Type.Optional(Type.String({ description: "Session ID to assign task to" })),
-			state: Type.Optional(Type.String({ description: "Transition to: todo, in-progress, blocked, complete, skipped" })),
+			task_id: Type.String(),
+			title: Type.Optional(Type.String()),
+			spec: Type.Optional(Type.String()),
+			result_summary: Type.Optional(Type.String()),
+			head_sha: Type.Optional(Type.String({ description: "HEAD commit SHA of finished work." })),
+			assigned_to: Type.Optional(Type.String({ description: "Session ID to assign to." })),
+			state: Type.Optional(Type.String({ description: "todo, in-progress, blocked, complete, or skipped." })),
 		}),
 		async execute(_id, params) {
 			try {
@@ -155,7 +147,7 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "gate_list",
 		label: "List Gates",
-		description: "List all gates for the current goal — status, dependencies, signal count, and failed step names. Slim summary with no content bodies.",
+		description: "List all gates for the current goal as a slim summary.",
 		promptSnippet: "List all gates for the goal with status.",
 		parameters: Type.Object({}),
 		async execute() {
@@ -168,10 +160,10 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "gate_status",
 		label: "Gate Status",
-		description: "Get latest signal details for a specific gate — verdict, truncated failed-step output, and metadata. Use gate_inspect for full content or history.",
+		description: "Get latest signal details for a gate. Use gate_inspect for full content or history.",
 		promptSnippet: "Get gate status, latest verification results, and metadata.",
 		parameters: Type.Object({
-			gate_id: Type.String({ description: "Gate ID (e.g. 'issue-analysis', 'implementation')" }),
+			gate_id: Type.String(),
 		}),
 		async execute(_id, params) {
 			try {
@@ -183,17 +175,12 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "gate_signal",
 		label: "Signal Gate",
-		description: [
-			"Signal that a gate is ready for verification.",
-			"For content gates, provide markdown content.",
-			"For metadata gates, provide key-value metadata.",
-			"Triggers async verification. Returns signal info.",
-		].join(" "),
+		description: "Signal a gate ready for verification. Triggers async verification.",
 		promptSnippet: "Signal a gate for verification with optional content and metadata.",
 		parameters: Type.Object({
-			gate_id: Type.String({ description: "Gate ID to signal (e.g. 'issue-analysis', 'reproducing-test')" }),
-			content: Type.Optional(Type.String({ description: "Markdown content for content gates" })),
-			metadata: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "Key-value metadata (e.g. { test_command: 'npm test' })" })),
+			gate_id: Type.String(),
+			content: Type.Optional(Type.String({ description: "Markdown for content gates." })),
+			metadata: Type.Optional(Type.Record(Type.String(), Type.String(), { description: "Key-value metadata for metadata gates." })),
 		}),
 		async execute(_id, params) {
 			try {
@@ -208,21 +195,16 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "gate_inspect",
 		label: "Inspect Gate",
-		description: [
-			"Read gate content, verification output, or signal history.",
-			"section='content': returns the markdown content from a signal.",
-			"section='verification': returns full verification step output.",
-			"section='signals': returns summary list of all signals (no content bodies).",
-		].join(" "),
+		description: "Read gate content, verification output, or signal history.",
 		promptSnippet: "Read detailed gate data: content, verification output, or signal history.",
 		parameters: Type.Object({
-			gate_id: Type.String({ description: "Gate ID" }),
+			gate_id: Type.String(),
 			section: Type.Union([
 				Type.Literal("content"),
 				Type.Literal("verification"),
 				Type.Literal("signals"),
-			], { description: "What to read: 'content', 'verification', or 'signals'" }),
-			signal_index: Type.Optional(Type.Number({ description: "Which signal (0-based, negative from end, default: -1 = latest)" })),
+			]),
+			signal_index: Type.Optional(Type.Number({ description: "0-based, negative from end. Default -1 (latest)." })),
 		}),
 		async execute(_id, params) {
 			try {
@@ -237,13 +219,13 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "verification_result",
 		label: "Verification Result",
-		description: "Submit your verification result when your review or QA testing is complete. The verification system receives your results through this tool.",
+		description: "Submit verification result when review or QA testing is complete.",
 		promptSnippet: "Submit verification verdict, summary, and optional HTML report.",
 		parameters: Type.Object({
-			verdict: Type.Union([Type.Literal("pass"), Type.Literal("fail")], { description: "Whether verification passed or failed" }),
-			summary: Type.String({ description: "Detailed markdown summary of findings — what was reviewed, specific issues found (with file:line references), and verdict rationale" }),
-			report_html: Type.Optional(Type.String({ description: "Self-contained HTML report with embedded screenshots (for QA agents). For large reports, use report_html_file instead. Cannot be combined with report_html_file." })),
-			report_html_file: Type.Optional(Type.String({ description: "Absolute path to an HTML report file on disk. The server reads it directly — use this for large reports with embedded base64 screenshots that exceed tool output limits. Cannot be combined with report_html." })),
+			verdict: Type.Union([Type.Literal("pass"), Type.Literal("fail")]),
+			summary: Type.String({ description: "Markdown findings: what was reviewed, issues with file:line, rationale." }),
+			report_html: Type.Optional(Type.String({ description: "Self-contained HTML report. Mutually exclusive with report_html_file." })),
+			report_html_file: Type.Optional(Type.String({ description: "Absolute path to HTML report file. Use for large reports." })),
 		}),
 		async execute(_id, params) {
 			if (params.report_html && params.report_html_file) {

--- a/defaults/tools/team/extension.ts
+++ b/defaults/tools/team/extension.ts
@@ -75,13 +75,13 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "team_spawn",
 		label: "Spawn Team Agent",
-		description: "Spawn a new role agent with its own git worktree. Returns the new session ID and worktree path. Returns 409 if workflowGateId is provided and its upstream dependency gates have not all passed.",
+		description: "Spawn a role agent in its own worktree. Returns session ID and worktree path.",
 		promptSnippet: "Spawn a coder, reviewer, or tester agent with a task description.",
 		parameters: Type.Object({
-			role: Type.String({ description: "Agent role: 'coder', 'reviewer', or 'tester'" }),
-			task: Type.String({ description: "Task description sent as the agent's first prompt" }),
-			workflowGateId: Type.Optional(Type.String({ description: "Gate ID this agent is working toward. If inputGateIds is not set, content from upstream passed gates is auto-injected as context." })),
-			inputGateIds: Type.Optional(Type.Array(Type.String(), { description: "Gate IDs whose passed content should be injected into the agent's context. Overrides automatic DAG resolution." })),
+			role: Type.String({ description: "'coder', 'reviewer', or 'tester'." }),
+			task: Type.String(),
+			workflowGateId: Type.Optional(Type.String({ description: "Gate the agent works toward; auto-injects upstream gate content." })),
+			inputGateIds: Type.Optional(Type.Array(Type.String(), { description: "Override DAG: gate IDs whose content to inject as context." })),
 		}),
 		async execute(_id, params) {
 			try {
@@ -96,7 +96,7 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "team_list",
 		label: "List Team Agents",
-		description: "List all active agents in the team with their role, status, worktree path, and task.",
+		description: "List active team agents with role, status, worktree, and task.",
 		promptSnippet: "List all agents in the team with their status.",
 		parameters: Type.Object({}),
 		async execute() {
@@ -109,10 +109,10 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "team_dismiss",
 		label: "Dismiss Team Agent",
-		description: "Terminate a role agent and clean up its git worktree.",
+		description: "Terminate a role agent and clean up its worktree.",
 		promptSnippet: "Dismiss (terminate) a team agent by session ID.",
 		parameters: Type.Object({
-			session_id: Type.String({ description: "Session ID of the agent to dismiss" }),
+			session_id: Type.String(),
 		}),
 		async execute(_id, params) {
 			try {
@@ -124,7 +124,7 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "team_complete",
 		label: "Complete Team",
-		description: "Dismiss all role agents and mark the goal as complete. The team lead stays active to present a report.",
+		description: "Dismiss all role agents and mark the goal complete; team lead stays active.",
 		promptSnippet: "Complete the team: dismiss all agents, keep team lead active.",
 		parameters: Type.Object({}),
 		async execute() {
@@ -137,11 +137,11 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "team_steer",
 		label: "Steer Team Agent",
-		description: "Send an urgent mid-turn redirect to a running agent. Only works when the agent is actively streaming (between tool calls). Use this for course corrections, clarifications, or priority changes that can't wait until the agent finishes. Fails if the agent is idle — use team_prompt instead.",
+		description: "Send an urgent mid-turn redirect to a streaming agent. Fails if idle; use team_prompt.",
 		promptSnippet: "Steer a running team agent with an urgent message (mid-turn only).",
 		parameters: Type.Object({
-			session_id: Type.String({ description: "Session ID of the agent to steer" }),
-			message: Type.String({ description: "Steering message — the agent sees this between tool calls" }),
+			session_id: Type.String(),
+			message: Type.String(),
 		}),
 		async execute(_id, params) {
 			try {
@@ -153,10 +153,10 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "team_abort",
 		label: "Abort Team Agent",
-		description: "Force-abort a stuck team agent that won't respond to steering. Use this when an agent is stuck in a long-running tool call and team_steer has no effect. The agent's process will be killed and restarted, and it will be ready for new prompts.",
+		description: "Force-abort a stuck team agent; kills and restarts its process.",
 		promptSnippet: "Force-abort a stuck team agent by session ID.",
 		parameters: Type.Object({
-			session_id: Type.String({ description: "The session ID of the agent to abort" }),
+			session_id: Type.String(),
 		}),
 		async execute(_id, params) {
 			try {
@@ -168,13 +168,13 @@ export default function (pi: ExtensionAPI) {
 	pi.registerTool({
 		name: "team_prompt",
 		label: "Prompt Team Agent",
-		description: "Send a prompt to a team agent. If the agent is idle, it starts working immediately. If the agent is busy, the message is queued and dispatched when the current turn ends. Use this to assign follow-up work, nudge idle agents, or queue instructions. Returns 409 if workflowGateId is provided and its upstream dependency gates have not all passed.",
+		description: "Prompt a team agent. Runs immediately if idle, else queues for next turn.",
 		promptSnippet: "Send a prompt to a team agent (immediate if idle, queued if busy).",
 		parameters: Type.Object({
-			session_id: Type.String({ description: "Session ID of the agent to prompt" }),
-			message: Type.String({ description: "Prompt message for the agent" }),
-			workflowGateId: Type.Optional(Type.String({ description: "Gate ID this agent is working toward. If inputGateIds is not set, content from upstream passed gates is auto-injected as context." })),
-			inputGateIds: Type.Optional(Type.Array(Type.String(), { description: "Gate IDs whose passed content should be injected into the agent's context. Overrides automatic DAG resolution." })),
+			session_id: Type.String(),
+			message: Type.String(),
+			workflowGateId: Type.Optional(Type.String({ description: "Gate the agent works toward; auto-injects upstream gate content." })),
+			inputGateIds: Type.Optional(Type.Array(Type.String(), { description: "Override DAG: gate IDs whose content to inject as context." })),
 		}),
 		async execute(_id, params) {
 			try {

--- a/defaults/tools/web/extension.ts
+++ b/defaults/tools/web/extension.ts
@@ -114,9 +114,7 @@ const extension: ExtensionFactory = (pi) => {
 	pi.registerTool({
 		name: "web_search",
 		label: "Web Search",
-		description:
-			"Search the web using DuckDuckGo. Returns titles, URLs, and snippets. " +
-			"No API key needed. Use this when you need current information, documentation, or answers.",
+		description: "Search the web via DuckDuckGo. Returns titles, URLs, snippets.",
 		promptSnippet:
 			"web_search: Search the web (DuckDuckGo). Fast, no API key. Returns titles, URLs, snippets.",
 		promptGuidelines: [
@@ -125,10 +123,10 @@ const extension: ExtensionFactory = (pi) => {
 			"After searching, use web_fetch to read full page content of the most promising result.",
 		],
 		parameters: Type.Object({
-			query: Type.String({ description: "Search query" }),
+			query: Type.String(),
 			maxResults: Type.Optional(
 				Type.Number({
-					description: "Max results to return (default 10)",
+					description: "Max results. Default 10.",
 					minimum: 1,
 					maximum: 20,
 				}),
@@ -191,19 +189,17 @@ const extension: ExtensionFactory = (pi) => {
 	pi.registerTool({
 		name: "web_fetch",
 		label: "Web Fetch",
-		description:
-			"Fetch a web page via curl and extract readable text. " +
-			"Use after web_search to read full content of a specific page.",
+		description: "Fetch a URL and extract readable text.",
 		promptSnippet: "web_fetch: Fetch a URL and extract readable text (via curl, fast).",
 		promptGuidelines: [
 			"Use web_fetch to read full page content after finding relevant URLs via web_search.",
 			"For very long pages the output is truncated. Focus on the most relevant URL.",
 		],
 		parameters: Type.Object({
-			url: Type.String({ description: "URL to fetch" }),
+			url: Type.String(),
 			maxLength: Type.Optional(
 				Type.Number({
-					description: "Max characters of extracted text to return (default 20000)",
+					description: "Max characters returned. Default 20000.",
 				}),
 			),
 		}),

--- a/src/server/mcp/mcp-meta.ts
+++ b/src/server/mcp/mcp-meta.ts
@@ -13,8 +13,8 @@ export const MCP_META_PREFIX = "mcp_";
 /** Anthropic API tool-name max length. */
 const MAX_TOOL_NAME_LEN = 64;
 
-/** Cap meta-tool description size to keep per-server context overhead tiny. */
-const MAX_DESCRIPTION_LEN = 400;
+/** Hard cap on meta-tool description length (single short line). */
+const MAX_DESCRIPTION_LEN = 150;
 
 /** Sentinel op name surfaced when a server has no usable operations. */
 const UNAVAILABLE_OP = "__unavailable__";
@@ -168,9 +168,10 @@ export function buildMetaToolInputSchema(ops: McpToolDef[]): Record<string, unkn
 }
 
 /**
- * Build the ~80-token meta-tool description: server label, comma-separated op
- * names, plus a pointer at the auto-generated docs file. Capped at ~400 chars;
- * overflow trims the op list and appends `... (N more)`.
+ * Build the meta-tool description: a single short line with the server name,
+ * operation count, and a pointer at the auto-generated docs file. Op names
+ * are NOT inlined — per-op detail lives in the off-wire docs file fetched
+ * via `mcp_describe`. Hard-capped at 150 chars.
  */
 export function buildMetaToolDescription(
 	serverName: string,
@@ -178,26 +179,12 @@ export function buildMetaToolDescription(
 	docsRelPath: string,
 ): string {
 	const valid = (ops ?? []).filter(isValidOperationSchema);
-	const head = `${serverName} MCP server. Operations: `;
-	const tail = `. See ${docsRelPath} for full schemas.`;
-	const opNames = valid.map(op => op.name);
-
-	if (opNames.length === 0) {
-		return `${serverName} MCP server. No operations available.${tail}`.slice(0, MAX_DESCRIPTION_LEN);
-	}
-
-	// Try the full list first.
-	const full = `${head}${opNames.join(", ")}${tail}`;
-	if (full.length <= MAX_DESCRIPTION_LEN) return full;
-
-	// Trim from the end — find the largest N such that head + first-N + ", ... (M more)" + tail fits.
-	for (let n = opNames.length - 1; n >= 1; n--) {
-		const more = opNames.length - n;
-		const candidate = `${head}${opNames.slice(0, n).join(", ")}, ... (${more} more)${tail}`;
-		if (candidate.length <= MAX_DESCRIPTION_LEN) return candidate;
-	}
-
-	// Fallback: even one op blows the budget — emit minimum and hard-truncate.
-	const minimum = `${head}... (${opNames.length} more)${tail}`;
-	return minimum.length <= MAX_DESCRIPTION_LEN ? minimum : minimum.slice(0, MAX_DESCRIPTION_LEN);
+	const n = valid.length;
+	const docsRef = docsRelPath ? ` See ${docsRelPath}.` : "";
+	const body =
+		n === 0 ? "No operations available."
+		: n === 1 ? "1 operation."
+		: `${n} operations.`;
+	const out = `${serverName} MCP server. ${body}${docsRef}`;
+	return out.length <= MAX_DESCRIPTION_LEN ? out : out.slice(0, MAX_DESCRIPTION_LEN);
 }

--- a/tests/mcp-meta-schema.test.ts
+++ b/tests/mcp-meta-schema.test.ts
@@ -121,41 +121,53 @@ describe("buildMetaToolInputSchema", () => {
 });
 
 describe("buildMetaToolDescription", () => {
-	it("formats server, operations, and docs path under 400 chars", () => {
+	it("emits single short line with server, op count, and docs path", () => {
 		const ops = [validOp("get-direct-reports"), validOp("list-employees"), validOp("get-entity-by-ref")];
 		const desc = buildMetaToolDescription("gr-halo", ops, "tool-docs/mcp-gr-halo.md");
-		assert.ok(desc.length < 400);
+		assert.ok(desc.length <= 150, `length was ${desc.length}: ${desc}`);
 		assert.ok(desc.includes("gr-halo"));
-		assert.ok(desc.includes("get-direct-reports"));
-		assert.ok(desc.includes("list-employees"));
+		assert.ok(desc.includes("3 operations"));
 		assert.ok(desc.includes("tool-docs/mcp-gr-halo.md"));
+		// Op names must NOT be inlined.
+		assert.ok(!desc.includes("get-direct-reports"));
+		assert.ok(!desc.includes("list-employees"));
 	});
 
-	it("trims to '... (N more)' when full op list overflows 400 chars", () => {
+	it("stays under 150 chars even with 100 ops, no op-name enumeration", () => {
 		const ops = Array.from({ length: 100 }, (_, i) => validOp(`operation_with_a_long_name_${i}`));
 		const desc = buildMetaToolDescription("big-server", ops, "tool-docs/mcp-big-server.md");
-		assert.ok(desc.length <= 400, `length was ${desc.length}: ${desc}`);
+		assert.ok(desc.length <= 150, `length was ${desc.length}: ${desc}`);
 		assert.ok(desc.includes("big-server"));
-		assert.ok(/\.\.\. \(\d+ more\)/.test(desc), `missing "... (N more)" in: ${desc}`);
-		assert.ok(desc.includes("tool-docs/mcp-big-server.md"));
+		assert.ok(desc.includes("100 operations"));
+		assert.ok(!/\.\.\. \(\d+ more\)/.test(desc), `should not contain "... (N more)": ${desc}`);
+		assert.ok(!desc.includes("operation_with_a_long_name_0"));
 	});
 
 	it("handles zero valid ops gracefully", () => {
 		const desc = buildMetaToolDescription("empty", [], "tool-docs/mcp-empty.md");
-		assert.ok(desc.length <= 400);
+		assert.ok(desc.length <= 150);
 		assert.ok(desc.includes("empty"));
+		assert.ok(desc.includes("No operations available"));
 		assert.ok(desc.includes("tool-docs/mcp-empty.md"));
 	});
 
-	it("filters invalid ops out of the listed names", () => {
+	it("uses singular form for exactly one op", () => {
+		const desc = buildMetaToolDescription("solo", [validOp("only")], "tool-docs/mcp-solo.md");
+		assert.ok(desc.includes("1 operation."));
+		assert.ok(!desc.includes("1 operations"));
+		assert.ok(!desc.includes("only"), "op name must not be inlined");
+	});
+
+	it("counts only valid ops (filters invalid)", () => {
 		const ops: McpToolDef[] = [
 			validOp("alpha"),
 			{ name: "bogus", inputSchema: { type: "string" } },
 			validOp("beta"),
 		];
 		const desc = buildMetaToolDescription("srv", ops, "tool-docs/mcp-srv.md");
-		assert.ok(desc.includes("alpha"));
-		assert.ok(desc.includes("beta"));
+		assert.ok(desc.includes("2 operations"));
+		assert.ok(!desc.includes("alpha"));
+		assert.ok(!desc.includes("beta"));
 		assert.ok(!desc.includes("bogus"));
 	});
 });

--- a/tests/tool-description-budget.test.ts
+++ b/tests/tool-description-budget.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tool description byte-budget — pinning test for the "Tighten tool descriptions"
+ * goal. Every byte in `tool.description` and every nested JSON Schema property
+ * `description` is paid on every uncached LLM turn (multiplied by the number of
+ * tools the role enables, often 30+). This test caps the bleed so we don't
+ * regress.
+ *
+ * Limits:
+ *   - tool.description.length            ≤ 150 chars
+ *   - JSON Schema property description   ≤  80 chars (recursive)
+ *   - buildMetaToolDescription output    ≤ 150 chars, no inlined op enumeration
+ *
+ * The first two are checked by importing each `defaults/tools/<group>/extension.ts`
+ * with a fake `pi` that captures every `registerTool({...})` invocation. The
+ * third hits `buildMetaToolDescription` directly with a synthetic 50-op list of
+ * long names.
+ */
+
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+import { pathToFileURL } from "node:url";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { mkdtempSync } from "node:fs";
+
+import { buildMetaToolDescription } from "../src/server/mcp/mcp-meta.ts";
+import type { McpToolDef } from "../src/server/mcp/mcp-types.ts";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+
+const EXTENSION_FILES = [
+	"agent",
+	"ask",
+	"browser",
+	"html",
+	"images",
+	"mcp",
+	"proposals",
+	"review",
+	"shell",
+	"skills",
+	"tasks",
+	"team",
+	"web",
+];
+
+const TOOL_DESC_MAX = 150;
+const PARAM_DESC_MAX = 80;
+
+interface CapturedTool {
+	name: string;
+	description?: string;
+	parameters?: unknown;
+	source: string;
+}
+
+const captured: CapturedTool[] = [];
+
+before(async () => {
+	// Ensure tool extensions that read state on import have a directory to look at.
+	if (!process.env.BOBBIT_DIR) {
+		process.env.BOBBIT_DIR = mkdtempSync(path.join(tmpdir(), "bobbit-tool-budget-"));
+	}
+
+	for (const group of EXTENSION_FILES) {
+		const file = path.join(REPO_ROOT, "defaults/tools", group, "extension.ts");
+		const url = pathToFileURL(file).href;
+		const mod: any = await import(url);
+		const factory = typeof mod.default === "function" ? mod.default : mod.default?.default;
+		assert.ok(typeof factory === "function", `${group}/extension.ts has no callable default export`);
+
+		const pi = {
+			registerTool(def: any) {
+				captured.push({
+					name: def?.name ?? "<unnamed>",
+					description: def?.description,
+					parameters: def?.parameters,
+					source: `${group}/extension.ts`,
+				});
+			},
+			on() {
+				// no-op — we don't drive the lifecycle in this test
+			},
+		};
+		factory(pi);
+	}
+
+	assert.ok(captured.length >= 13, `expected at least 13 tools registered, got ${captured.length}`);
+});
+
+/** Walk a TypeBox / JSON Schema tree and collect every `description` string with a path. */
+function collectAllDescriptions(
+	schema: any,
+	p: string = "$",
+	out: Array<{ path: string; text: string }> = [],
+): Array<{ path: string; text: string }> {
+	if (!schema || typeof schema !== "object") return out;
+	if (typeof schema.description === "string") {
+		out.push({ path: p, text: schema.description });
+	}
+	if (schema.properties && typeof schema.properties === "object") {
+		for (const [k, v] of Object.entries(schema.properties)) {
+			collectAllDescriptions(v, `${p}.properties.${k}`, out);
+		}
+	}
+	if (schema.items) {
+		if (Array.isArray(schema.items)) {
+			schema.items.forEach((it: any, i: number) =>
+				collectAllDescriptions(it, `${p}.items[${i}]`, out),
+			);
+		} else {
+			collectAllDescriptions(schema.items, `${p}.items`, out);
+		}
+	}
+	for (const key of ["oneOf", "anyOf", "allOf"] as const) {
+		const arr = schema[key];
+		if (Array.isArray(arr)) {
+			arr.forEach((sub: any, i: number) =>
+				collectAllDescriptions(sub, `${p}.${key}[${i}]`, out),
+			);
+		}
+	}
+	if (schema.additionalProperties && typeof schema.additionalProperties === "object") {
+		collectAllDescriptions(schema.additionalProperties, `${p}.additionalProperties`, out);
+	}
+	if (schema.patternProperties && typeof schema.patternProperties === "object") {
+		for (const [k, v] of Object.entries(schema.patternProperties)) {
+			collectAllDescriptions(v, `${p}.patternProperties[${k}]`, out);
+		}
+	}
+	return out;
+}
+
+describe("tool description budget", () => {
+	it("every registered tool has description.length <= 150", () => {
+		const violations: string[] = [];
+		for (const t of captured) {
+			const d = t.description ?? "";
+			if (d.length > TOOL_DESC_MAX) {
+				violations.push(
+					`  ${t.source} :: ${t.name} — ${d.length} chars (max ${TOOL_DESC_MAX})\n    ${JSON.stringify(d.slice(0, 200))}`,
+				);
+			}
+		}
+		assert.equal(
+			violations.length,
+			0,
+			`${violations.length} tool description(s) exceed ${TOOL_DESC_MAX} chars:\n${violations.join("\n")}`,
+		);
+	});
+
+	it("every tool has a non-empty description", () => {
+		for (const t of captured) {
+			assert.ok(
+				typeof t.description === "string" && t.description.length > 0,
+				`tool ${t.source}::${t.name} is missing a description`,
+			);
+		}
+	});
+
+	it("every parameter description is <= 80 chars (recursive)", () => {
+		const violations: string[] = [];
+		for (const t of captured) {
+			const descs = collectAllDescriptions(t.parameters);
+			for (const d of descs) {
+				if (d.text.length > PARAM_DESC_MAX) {
+					violations.push(
+						`  ${t.source} :: ${t.name} ${d.path} — ${d.text.length} chars (max ${PARAM_DESC_MAX})\n    ${JSON.stringify(d.text.slice(0, 200))}`,
+					);
+				}
+			}
+		}
+		assert.equal(
+			violations.length,
+			0,
+			`${violations.length} parameter description(s) exceed ${PARAM_DESC_MAX} chars:\n${violations.join("\n")}`,
+		);
+	});
+
+	it("records on-wire tools[] JSON byte size for visibility", () => {
+		// Decoration only — never asserts a number, just prints. Helps catch
+		// future bloat at PR review time.
+		const onWire = captured.map((t) => ({
+			name: t.name,
+			description: t.description,
+			parameters: t.parameters,
+		}));
+		const bytes = JSON.stringify(onWire).length;
+		// eslint-disable-next-line no-console
+		console.log(
+			`[tool-description-budget] ${captured.length} tools, JSON.stringify(tools).length = ${bytes} bytes`,
+		);
+		// Sanity: the tightened tree should comfortably fit under 50 KB. If this
+		// ever fails the tightening regressed badly enough that a hard cap helps.
+		assert.ok(bytes < 50_000, `tools[] JSON exceeds 50KB sanity cap: ${bytes}`);
+	});
+});
+
+describe("buildMetaToolDescription budget", () => {
+	function makeOps(n: number): McpToolDef[] {
+		const longName = "very_long_operation_name_with_many_words_indeed";
+		const ops: McpToolDef[] = [];
+		for (let i = 0; i < n; i++) {
+			ops.push({
+				name: `${longName}_${i}`,
+				description: `Operation ${i}`,
+				inputSchema: { type: "object", properties: {} },
+			});
+		}
+		return ops;
+	}
+
+	it("returns <= 150 chars even for 50 long-named ops", () => {
+		const out = buildMetaToolDescription("playwright", makeOps(50), "mcp-tool-docs/playwright.md");
+		assert.ok(
+			out.length <= TOOL_DESC_MAX,
+			`description is ${out.length} chars (max ${TOOL_DESC_MAX}): ${JSON.stringify(out)}`,
+		);
+	});
+
+	it("does NOT inline a comma-separated op enumeration > 80 chars", () => {
+		const ops = makeOps(50);
+		const out = buildMetaToolDescription("playwright", ops, "mcp-tool-docs/playwright.md");
+
+		// Look for any comma-joined run of identifier-like tokens. The longest
+		// such run must be ≤ 80 chars; otherwise the description is pasting op
+		// names back in.
+		const enumRuns = out.match(/[A-Za-z_][A-Za-z0-9_]*(?:\s*,\s*[A-Za-z_][A-Za-z0-9_]*){2,}/g) ?? [];
+		const longest = enumRuns.reduce((m, s) => Math.max(m, s.length), 0);
+		assert.ok(
+			longest <= 80,
+			`buildMetaToolDescription appears to inline an op-name enumeration ` +
+				`(${longest} chars). Output: ${JSON.stringify(out)}`,
+		);
+		// Also assert no individual op name we synthesised is present — the
+		// design contract is that op detail lives off-wire.
+		assert.ok(
+			!out.includes(ops[0].name),
+			`op name leaked into description: ${JSON.stringify(out)}`,
+		);
+	});
+
+	it("handles 0 / 1 op edge cases without exceeding budget", () => {
+		const zero = buildMetaToolDescription("playwright", [], "mcp-tool-docs/playwright.md");
+		const one = buildMetaToolDescription("playwright", makeOps(1), "mcp-tool-docs/playwright.md");
+		assert.ok(zero.length <= TOOL_DESC_MAX);
+		assert.ok(one.length <= TOOL_DESC_MAX);
+	});
+});


### PR DESCRIPTION
## Summary

Trimmed every `description` field on the wire in `tools[]` JSON across all 13 builtin tool extensions and the MCP meta-tool builder. Added a unit test that pins the budget so it can't regress.

## Why

Every uncached LLM turn ships the full `tools[]` JSON Schema array. Top-level tool `description` and per-parameter `description` strings were exceeding the project's ≤15-word guideline — multi-sentence prose with examples and anti-patterns that belong in off-wire `docs` / `detail_docs` YAML fields.

## Measured impact

| Metric | Before (`844381ff`) | After | Reduction |
|---|---|---|---|
| Default-role `tools[]` count | 35 | 35 | — |
| `JSON.stringify(tools).length` | 25,167 B | 16,986 B | **−32.5%** |

Above the 30% target stated in the goal spec. Per-turn savings on every uncached LLM request × every model.

## Changes

**`defaults/tools/*/extension.ts` (all 13 groups):** trimmed every `pi.registerTool({ description, parameters })` top-level description and every nested `Type.Object({ x: Type.String({ description }) })` parameter description.

**`src/server/mcp/mcp-meta.ts`:** `buildMetaToolDescription` now returns a single short line (`"<server> MCP server. <N> operation(s). See <docs>."`) instead of pasting all op names with a `... (M more)` fallback. Op-by-op detail is already written off-wire to `<stateDir>/mcp-tool-docs/<server>.md`.

**`tests/tool-description-budget.test.ts` (new):** pins the budget — tool descriptions ≤ 150 chars, parameter descriptions ≤ 80 chars (recursive), MCP meta-tool descriptions ≤ 150 chars with no comma-joined op enumeration. Records `JSON.stringify(tools).length` for visibility.

**`tests/mcp-meta-schema.test.ts`:** assertions updated to the new short MCP meta-tool form.

**`AGENTS.md`:** "Add a tool" recipe extended to make the on-wire vs off-wire split explicit and record the hard caps; one debugging-index line added so future authors discover the budget test.

## Out of scope

- YAML `summary` / `docs` / `detail_docs` were intentionally left alone — they're already off-wire.
- Default-role `allowedTools` slimming and `# Tools` system-prompt section reformat — separate goals.

## Verification

- `npm run check` clean.
- `npm run test:unit` — new `tool-description-budget` suite contributes 7 passing assertions.
- Sanity-checked: temporarily reverting `defaults/tools/` + `mcp-meta.ts` to `844381ff` makes the new test fail, confirming the budget bites.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)