### PR TITLE
test(manual-integration): drive user actions via UI; add opt-in video

### DIFF
--- a/playwright-manual.config.ts
+++ b/playwright-manual.config.ts
@@ -8,6 +8,13 @@
  */
 import { defineConfig } from "@playwright/test";
 
+// Opt-in per-test video capture. Tier-2.5-style — always-off by default,
+// enable with RECORDVIDEO=1 to get a webm per test under test-results/.
+// The Tier 2.5 reporter (`./tests/e2e/report/tier-2-5-reporter.ts`) is not
+// used here — manual specs talk to real agents, not the mock-agent contract
+// the reporter assumes; Playwright's built-in recorder is sufficient.
+const WANT_VIDEO = !!process.env.RECORDVIDEO;
+
 export default defineConfig({
 	timeout: 300_000,     // 5 minutes per test — real LLM calls are slow
 	retries: 0,           // no retries — manual tests should be deterministic
@@ -15,6 +22,8 @@ export default defineConfig({
 	use: {
 		headless: true,
 		screenshot: "off",    // we capture manually
+		video: WANT_VIDEO ? { mode: "on", size: { width: 1280, height: 720 } } : "off",
+		trace: WANT_VIDEO ? "on" : "off",
 	},
 	projects: [
 		{

--- a/tests/manual-integration/multi-repo-docker.spec.ts
+++ b/tests/manual-integration/multi-repo-docker.spec.ts
@@ -282,7 +282,7 @@ test.describe("Multi-repo & components — integration", () => {
 	});
 
 	// 1.  Project registration with a 3-component (2 normal + 1 data-only) set.
-	test("registers a two-repo project + one data-only repo via POST /api/projects", async () => {
+	test("registers a two-repo project + one data-only repo via POST /api/projects", async ({ page }) => {
 		expect(projectId).toBeTruthy();
 
 		const yamlPath = join(rootPath, ".bobbit", "config", "project.yaml");
@@ -299,6 +299,12 @@ test.describe("Multi-repo & components — integration", () => {
 		expect(Array.isArray(cfg.components)).toBe(true);
 		expect(cfg.components).toHaveLength(3);
 		expect(cfg.components.map((c: any) => c.name).sort()).toEqual(["api", "shared", "web"]);
+
+		// UI visibility: the user sees the project in the sidebar.
+		await page.goto(`${gw.base}/?token=${gw.token}`);
+		const sidebar = page.locator('[data-testid="sidebar-expanded"]');
+		await sidebar.waitFor({ timeout: 15_000 });
+		await sidebar.getByText(`mr-${port}`).first().waitFor({ timeout: 10_000 });
 	});
 
 	// 2.  Inline workflows block persisted via PUT /config.
@@ -385,13 +391,37 @@ test.describe("Multi-repo & components — integration", () => {
 	// 6.  Archive cleanup tears down all per-repo worktrees and (when remote
 	//     pushes are enabled) deletes the matching remote branches. We run
 	//     with BOBBIT_TEST_NO_PUSH=1 so we assert local cleanup only.
-	test("archive cleanup tears down all per-repo worktrees", async ({}, ti) => {
-		ti.setTimeout(60_000);
+	test("archive cleanup tears down all per-repo worktrees", async ({ page }, ti) => {
+		ti.setTimeout(120_000);
 		expect(goalId).toBeTruthy();
 		expect(Object.keys(goalRepoWorktrees)).toHaveLength(3);
 
-		const archiveRes = await api(gw, `/api/goals/${goalId}`, { method: "DELETE" });
-		expect([200, 204]).toContain(archiveRes.status);
+		// UI baseline: project is visible in the sidebar before archive.
+		await page.goto(`${gw.base}/?token=${gw.token}`);
+		const sidebar = page.locator('[data-testid="sidebar-expanded"]');
+		await sidebar.waitFor({ timeout: 15_000 });
+		await sidebar.getByText(`mr-${port}`).first().waitFor({ timeout: 10_000 });
+
+		// Drive the archive through the UI — click Archive on the goal
+		// dashboard and confirm the modal.
+		await page.goto(`${gw.base}/?token=${gw.token}#/goal/${goalId}`);
+		// Use the goal-dashboard nav archive button (`btn-icon` class). The
+		// sidebar has a hidden hover-revealed archive button with the same
+		// title — disambiguate by class.
+		const archiveBtn = page.locator('.nav button[title="Archive goal"]').first();
+		await archiveBtn.waitFor({ timeout: 15_000 });
+		await archiveBtn.click();
+		await page.locator('text=Archive Goal').first().waitFor({ timeout: 5_000 });
+		await page.keyboard.press("Enter");
+
+		const archDeadline = Date.now() + 30_000;
+		let archivedFlag = false;
+		while (Date.now() < archDeadline) {
+			const g = await (await api(gw, `/api/goals/${goalId}`)).json();
+			if (g.archived) { archivedFlag = true; break; }
+			await new Promise(r => setTimeout(r, 250));
+		}
+		expect(archivedFlag, "goal not archived after UI click").toBe(true);
 
 		// Wait for fire-and-forget per-repo cleanup to finish.
 		const deadline = Date.now() + 30_000;

--- a/tests/manual-integration/nested-project-root.spec.ts
+++ b/tests/manual-integration/nested-project-root.spec.ts
@@ -226,7 +226,7 @@ test.describe("Nested project root — integration", () => {
 	});
 
 	// 1.  Project registers at the nested folder (not normalized to repo root).
-	test("project registers with rootPath = nested subdirectory", async () => {
+	test("project registers with rootPath = nested subdirectory", async ({ page }) => {
 		expect(projectId).toBeTruthy();
 
 		const res = await api(gw, `/api/projects/${projectId}`);
@@ -243,10 +243,16 @@ test.describe("Nested project root — integration", () => {
 		expect(Array.isArray(cfg.components)).toBe(true);
 		expect(cfg.components).toHaveLength(1);
 		expect(cfg.components[0].name).toBe("Nested Project");
+
+		// UI visibility: the user sees the project listed in the sidebar.
+		await page.goto(`${gw.base}/?token=${gw.token}`);
+		const sidebar = page.locator('[data-testid="sidebar-expanded"]');
+		await sidebar.waitFor({ timeout: 15_000 });
+		await sidebar.getByText("Nested Project").first().waitFor({ timeout: 10_000 });
 	});
 
 	// 2.  A session creates a worktree at the GIT-REPO level and offsets cwd correctly.
-	test("session worktree is at the repo level; cwd is offset into x/project-root", async ({}, ti) => {
+	test("session worktree is at the repo level; cwd is offset into x/project-root", async ({ page }, ti) => {
 		ti.setTimeout(120_000);
 
 		const sessRes = await api(gw, "/api/sessions", {
@@ -299,6 +305,12 @@ test.describe("Nested project root — integration", () => {
 		}).trim();
 		expect(branch).not.toBe("master");
 		expect(branch.length).toBeGreaterThan(0);
+
+		// UI visibility: the user can navigate to the session and see the chat
+		// composer ready. This proves the offset cwd produced a usable session
+		// from an end-user perspective, not just on disk.
+		await page.goto(`${gw.base}/?token=${gw.token}#/session/${sessionId}`);
+		await page.waitForSelector("textarea", { timeout: 15_000 });
 	});
 
 	// 3.  A goal on this project provisions its worktree the same way.
@@ -348,14 +360,34 @@ test.describe("Nested project root — integration", () => {
 	// 4.  Archive marks the goal as archived (single-repo + autoStartTeam=false:
 	//     worktree cleanup is owned by session purge, not goal archive — see
 	//     archiveGoal() in goal-manager.ts).
-	test("archiving the goal succeeds and marks it archived", async ({}, ti) => {
-		ti.setTimeout(30_000);
+	test("archiving the goal succeeds and marks it archived", async ({ page }, ti) => {
+		ti.setTimeout(90_000);
 		expect(goalId).toBeTruthy();
 
-		const archiveRes = await api(gw, `/api/goals/${goalId}`, { method: "DELETE" });
-		expect([200, 204]).toContain(archiveRes.status);
+		// Drive the archive through the UI — a real user clicks the Archive
+		// button on the goal dashboard and confirms the modal.
+		await page.goto(`${gw.base}/?token=${gw.token}#/goal/${goalId}`);
+		const archiveBtn = page.locator('.nav button[title="Archive goal"]').first();
+		await archiveBtn.waitFor({ timeout: 15_000 });
+		await archiveBtn.click();
+		// Confirm dialog: Enter accepts the default destructive action.
+		await page.locator('text=Archive Goal').first().waitFor({ timeout: 5_000 });
+		await page.keyboard.press("Enter");
 
-		const after = await (await api(gw, `/api/goals/${goalId}`)).json();
-		expect(after.archived).toBe(true);
+		// Server-side state pinned via API: archived flag must flip.
+		const deadline = Date.now() + 30_000;
+		let archived = false;
+		while (Date.now() < deadline) {
+			const after = await (await api(gw, `/api/goals/${goalId}`)).json();
+			if (after.archived) { archived = true; break; }
+			await new Promise(r => setTimeout(r, 250));
+		}
+		expect(archived, "goal not marked archived after UI Archive click").toBe(true);
+
+		// UI visibility: project still renders (no broken state after archive).
+		await page.goto(`${gw.base}/?token=${gw.token}`);
+		const sidebar = page.locator('[data-testid="sidebar-expanded"]');
+		await sidebar.waitFor({ timeout: 15_000 });
+		await sidebar.getByText("Nested Project").first().waitFor({ timeout: 10_000 });
 	});
 });

--- a/tests/manual-integration/poly-repo.spec.ts
+++ b/tests/manual-integration/poly-repo.spec.ts
@@ -274,7 +274,7 @@ test.describe("Poly Repo — integration", () => {
 	});
 
 	// 1.  Project registration is poly-repo with two component repos.
-	test("registers a poly-repo project (container + 2 sibling git repos)", async () => {
+	test("registers a poly-repo project (container + 2 sibling git repos)", async ({ page }) => {
 		expect(projectId).toBeTruthy();
 
 		const projRes = await api(gw, `/api/projects/${projectId}`);
@@ -293,6 +293,12 @@ test.describe("Poly Repo — integration", () => {
 		expect(yaml).toContain("name: repo1");
 		expect(yaml).toContain("name: repo2");
 		expect(yaml).toContain("workflows:");
+
+		// UI visibility: the user sees the project in the sidebar.
+		await page.goto(`${gw.base}/?token=${gw.token}`);
+		const sidebar = page.locator('[data-testid="sidebar-expanded"]');
+		await sidebar.waitFor({ timeout: 15_000 });
+		await sidebar.getByText("Poly Repo").first().waitFor({ timeout: 10_000 });
 	});
 
 	// 2.  A session creates worktrees for BOTH repos at the branch-container level.
@@ -429,13 +435,27 @@ test.describe("Poly Repo — integration", () => {
 	});
 
 	// 4.  Archive marks the goal archived AND tears down per-repo worktrees.
-	test("archive tears down per-repo worktrees and marks the goal archived", async ({}, ti) => {
-		ti.setTimeout(60_000);
+	test("archive tears down per-repo worktrees and marks the goal archived", async ({ page }, ti) => {
+		ti.setTimeout(90_000);
 		expect(goalId).toBeTruthy();
 		expect(Object.keys(goalRepoWorktrees)).toHaveLength(2);
 
-		const archiveRes = await api(gw, `/api/goals/${goalId}`, { method: "DELETE" });
-		expect([200, 204]).toContain(archiveRes.status);
+		// Drive the archive through the UI — a real user clicks Archive on the
+		// goal dashboard and confirms the modal.
+		await page.goto(`${gw.base}/?token=${gw.token}#/goal/${goalId}`);
+		const archiveBtn = page.locator('.nav button[title="Archive goal"]').first();
+		await archiveBtn.waitFor({ timeout: 15_000 });
+		await archiveBtn.click();
+		await page.locator('text=Archive Goal').first().waitFor({ timeout: 5_000 });
+		await page.keyboard.press("Enter");
+
+		// Wait for archived flag (the API call is fired off the click handler).
+		const archDeadline = Date.now() + 30_000;
+		while (Date.now() < archDeadline) {
+			const g = await (await api(gw, `/api/goals/${goalId}`)).json();
+			if (g.archived) break;
+			await new Promise(r => setTimeout(r, 250));
+		}
 
 		// Per-repo cleanup is fire-and-forget; poll up to 30s.
 		const deadline = Date.now() + 30_000;
@@ -450,5 +470,11 @@ test.describe("Poly Repo — integration", () => {
 
 		const after = await (await api(gw, `/api/goals/${goalId}`)).json();
 		expect(after.archived).toBe(true);
+
+		// UI visibility: project still renders after archive (no broken state).
+		await page.goto(`${gw.base}/?token=${gw.token}`);
+		const sidebar = page.locator('[data-testid="sidebar-expanded"]');
+		await sidebar.waitFor({ timeout: 15_000 });
+		await sidebar.getByText("Poly Repo").first().waitFor({ timeout: 10_000 });
 	});
 });

--- a/tests/manual-integration/restart-minimal.spec.ts
+++ b/tests/manual-integration/restart-minimal.spec.ts
@@ -143,8 +143,8 @@ function cleanDirs(dir: string) {
 
 test.describe.configure({ mode: "serial" });
 
-test("restart-minimal: plain + worktree session both survive a restart", async () => {
-	test.setTimeout(180_000);
+test("restart-minimal: plain + worktree session both survive a restart", async ({ page }) => {
+	test.setTimeout(240_000);
 
 	const tmp = process.platform === "win32" ? (process.env.TEMP || "C:\\Temp") : "/tmp";
 	const port1 = await freePort();
@@ -202,15 +202,29 @@ test("restart-minimal: plain + worktree session both survive a restart", async (
 	const wtPreTitle = await (await api(gw, `/api/sessions/${wtId}`)).json() as any;
 	const branchBeforeTitle = wtPreTitle.branch;
 	expect(branchBeforeTitle).toMatch(/^session\/[a-f0-9]{8}$/);
-	const titleRes = await api(gw, `/api/sessions/${wtId}`, {
-		method: "PATCH",
-		body: JSON.stringify({ title: "Renamed Pool Worktree" }),
-	});
-	expect(titleRes.status).toBe(200);
-	// Give any (unwanted) async work a moment to land before re-asserting.
-	await new Promise(r => setTimeout(r, 1_500));
+
+	// Drive the rename through the UI — a real user clicks the pencil button
+	// in the sidebar, edits the title, and presses Save. This exercises the
+	// real PATCH path the user goes through, not just the bare REST endpoint.
+	await page.goto(`${gw.base}/?token=${gw.token}#/session/${wtId}`);
+	await page.waitForSelector("textarea", { timeout: 30_000 });
+	const sidebar = page.locator('[data-testid="sidebar-expanded"]');
+	await sidebar.waitFor({ timeout: 15_000 });
+	const sessionRow = sidebar.locator(`[data-session-id="${wtId}"]`);
+	await sessionRow.waitFor({ timeout: 10_000 });
+	await sessionRow.hover();
+	await sessionRow.locator('button[title="Modify"]').click();
+	const titleInput = page.locator('input[placeholder="Session title…"]').first();
+	await titleInput.waitFor({ timeout: 5_000 });
+	await titleInput.fill("Renamed Pool Worktree");
+	// Press Enter — the dialog handles Enter as Save and avoids selector
+	// ambiguity with other "Save" buttons in the page (e.g. role pickers).
+	await titleInput.press("Enter");
+	// Give the patch round-trip + sidebar refresh time to land.
+	await new Promise(r => setTimeout(r, 2_000));
 	const wtAfterRename = await (await api(gw, `/api/sessions/${wtId}`)).json() as any;
-	console.log(`  [boot] wt post-title. cwd=${wtAfterRename.cwd} branch=${wtAfterRename.branch}`);
+	console.log(`  [boot] wt post-title. title=${wtAfterRename.title} branch=${wtAfterRename.branch}`);
+	expect(wtAfterRename.title).toBe("Renamed Pool Worktree");
 	expect(wtAfterRename.branch).toBe(branchBeforeTitle);
 	expect(wtAfterRename.branch).not.toMatch(/^pool\//);
 
@@ -270,6 +284,23 @@ test("restart-minimal: plain + worktree session both survive a restart", async (
 	// Read the post-restart sessions.json for diagnosis
 	const after = JSON.parse(readFileSync(sfPath, "utf-8")) as any[];
 	console.log(`  [restart] sessions.json now has ${after.length} entries (${after.filter(s => s.archived).length} archived)`);
+
+	// UI visibility assertion: a real user verifies sessions survive by
+	// reloading the app and seeing them in the sidebar. The renamed worktree
+	// session must show its new title; both sessions must be present.
+	if (failures.length === 0) {
+		try {
+			await page.goto(`${gw.base}/?token=${gw.token}`);
+			const sidebar = page.locator('[data-testid="sidebar-expanded"]');
+			await sidebar.waitFor({ timeout: 15_000 });
+			await sidebar.getByText("Renamed Pool Worktree").first().waitFor({ timeout: 10_000 });
+			const sidebarText = (await sidebar.textContent()) || "";
+			expect(sidebarText).toContain("Renamed Pool Worktree");
+			console.log(`  [restart] sidebar shows renamed worktree session ✓`);
+		} catch (err) {
+			failures.push(`UI sidebar assertion failed: ${(err as Error).message}`);
+		}
+	}
 
 	await stopGW(gw);
 	cleanDirs(dir);

--- a/tests/manual-integration/session-resilience.spec.ts
+++ b/tests/manual-integration/session-resilience.spec.ts
@@ -323,16 +323,18 @@ async function createGoalViaBrowser(
 	gw: GW,
 	title: string,
 	spec: string,
-	opts?: { workflowId?: string; sandboxed?: boolean },
+	opts?: { workflowId?: string; sandboxed?: boolean; projectName?: string },
 ): Promise<string> {
 	await page.goto(appUrl(gw));
 	// Wait for sidebar to fully load
 	await page.waitForSelector("button", { timeout: 15_000 });
 
-	// Click "New Goal". Prefer the per-project "+ goal" button (title `New goal in <name>`) —
-	// unambiguous in multi-project installs. Fall back to toolbar "+ New Goal" + picker for
-	// single-project runs where the per-project button may not exist.
-	const perProjectBtn = page.locator("button[title^='New goal in']").first();
+	// Click "New Goal". When `projectName` is supplied, target that project's
+	// per-project "+ goal" button (title `New goal in <name>`); otherwise prefer
+	// the first per-project button. Fall back to toolbar "+ New Goal" + picker.
+	const perProjectBtn = opts?.projectName
+		? page.locator(`button[title="New goal in ${opts.projectName}"]`).first()
+		: page.locator("button[title^='New goal in']").first();
 	if (await perProjectBtn.count() > 0) {
 		await expect(perProjectBtn).toBeVisible({ timeout: 10_000 });
 		await perProjectBtn.click();
@@ -340,12 +342,15 @@ async function createGoalViaBrowser(
 		const toolbarBtn = page.locator("button[title='New goal (Alt+G)']").first();
 		await expect(toolbarBtn).toBeVisible({ timeout: 10_000 });
 		await toolbarBtn.click();
-		// If the project-picker popover opened (multi-project install), pick the first project.
+		// If the project-picker popover opened (multi-project install), pick the
+		// requested project (or the first if none specified).
 		const popover = page.locator("project-picker-popover");
 		if (await popover.count() > 0) {
-			const firstRow = popover.locator(".bobbit-project-picker-row").first();
-			await expect(firstRow).toBeVisible({ timeout: 5_000 });
-			await firstRow.click();
+			const row = opts?.projectName
+				? popover.locator(".bobbit-project-picker-row", { hasText: opts.projectName }).first()
+				: popover.locator(".bobbit-project-picker-row").first();
+			await expect(row).toBeVisible({ timeout: 5_000 });
+			await row.click();
 		}
 	}
 
@@ -792,25 +797,21 @@ test.describe.serial("Integration — sessions, goals, sandboxed goals", () => {
 			console.log(`  Proj2 session ${label}: message sent`);
 		}
 
-		// 6. Create a goal in the second project via API
+		// 6. Create a goal in the second project via the UI (parity with goals
+		// B and C; was previously API-only). Real users go through the goal
+		// assistant / form, so the test should too — even for the second
+		// project.
 		t0 = performance.now();
-		const goalRes = await api(gw, "/api/goals", {
-			method: "POST",
-			body: JSON.stringify({
-				title: "Proj2 Feature",
-				cwd: proj2Dir,
-				spec: "Add a feature to the second project. Create src/proj2-feature.ts.",
-				workflowId: "feature",
-				projectId: proj2Id,
-				autoStartTeam: true,
-			}),
-		});
-		expect(goalRes.status).toBe(201);
-		const goalBody = await goalRes.json() as any;
-		proj2GoalId = goalBody.id;
 		proj2GoalTitle = "Proj2 Feature";
-		expect(goalBody.projectId).toBe(proj2Id);
-		console.log(`  Proj2 goal created: id=${proj2GoalId} (${Math.round(performance.now() - t0)}ms)`);
+		proj2GoalId = await createGoalViaBrowser(
+			page, gw,
+			proj2GoalTitle,
+			"Add a feature to the second project. Create src/proj2-feature.ts.",
+			{ workflowId: "feature", projectName: "Second Project" },
+		);
+		const createdGoal = await (await api(gw, `/api/goals/${proj2GoalId}`)).json() as any;
+		expect(createdGoal.projectId).toBe(proj2Id);
+		console.log(`  Proj2 goal created via UI: id=${proj2GoalId} (${Math.round(performance.now() - t0)}ms)`);
 
 		// Wait for worktree setup
 		await pollGoalSetup(gw, proj2GoalId, 120_000);
@@ -842,16 +843,17 @@ test.describe.serial("Integration — sessions, goals, sandboxed goals", () => {
 		expect(normalize(leadInfo.cwd)).not.toBe(normalize(dir));
 		console.log(`  Proj2 team lead cwd=${leadInfo.cwd} projectId=${leadInfo.projectId}`);
 
-		// 7. Verify sidebar grouping via browser
+		// 7. Verify sidebar grouping via browser — the user sees "Second Project"
+		// AND the proj2 goal title rendered as text in the goal-row.
 		await page.goto(appUrl(gw));
-		await page.waitForSelector('[data-testid="sidebar-expanded"]', { timeout: 15_000 });
-		// Wait for the project header to actually render in the sidebar
-		await page.locator('[data-testid="sidebar-expanded"]').getByText("Second Project").first().waitFor({ timeout: 10_000 });
-
-		// The sidebar should show "Second Project" as a separate project group
-		const sidebarText = await page.locator('[data-testid="sidebar-expanded"]').textContent() || "";
+		const sidebar = page.locator('[data-testid="sidebar-expanded"]');
+		await sidebar.waitFor({ timeout: 15_000 });
+		await sidebar.getByText("Second Project").first().waitFor({ timeout: 10_000 });
+		await sidebar.getByText(proj2GoalTitle).first().waitFor({ timeout: 10_000 });
+		const sidebarText = (await sidebar.textContent()) || "";
 		expect(sidebarText).toContain("Second Project");
-		console.log(`  Sidebar contains "Second Project" ✓`);
+		expect(sidebarText).toContain(proj2GoalTitle);
+		console.log(`  Sidebar shows "Second Project" + goal "${proj2GoalTitle}" ✓`);
 		await takeScreenshot(page, "multi-project-sidebar.png");
 
 		// 8. Verify API lists sessions and goals with correct projectId


### PR DESCRIPTION
Convert deterministic user-action affordances in manual integration tests to drive through the real UI instead of API calls, per the principle that end-user-facing tests should exercise what users actually see and do.

## Changes

- **Goal archive** (multi-repo, nested-project-root, poly-repo): click the goal-dashboard `Archive` button + Enter to confirm, instead of `DELETE /api/goals/:id`. Disambiguated selector via `.nav` (the sidebar has a hidden hover-revealed Archive button with the same title).
- **Session rename** (restart-minimal): click sidebar `Modify` pencil, fill rename dialog, press Enter, instead of `PATCH /api/sessions/:id`.
- **proj2 goal** (session-resilience A2): create via `createGoalViaBrowser` (new `projectName` option) — parity with goals B/C; was the only API-driven goal create remaining.
- **Sidebar visibility assertions**: verify renamed session, project, and goal title appear in the sidebar after relevant operations — closes the gap where server-state was pinned but the user-facing rendering was not.

## Tier-2.5-style video capture

Adds `RECORDVIDEO=1` opt-in to `playwright-manual.config.ts`: built-in Playwright per-test `video.webm` + `trace.zip` under `test-results/`. Default off — zero overhead when unset. The Tier 2.5 reporter is not used here because it assumes the mock-agent contract; for real-agent suites Playwright's built-in recorder is sufficient.

## API still used (justified)

No UI affordance exists for: inline workflow YAML, hard-kill gateway / docker `rm -f`, or session create with explicit `cwd`/`worktree`/`sandbox` flags outside a registered project.

## Pitfalls discovered & fixed during conversion

- Hash route is `#/goal/<id>`, not `#/goal-dashboard/<id>` (3 sites).
- Two `button[title="Archive goal"]` exist in DOM: sidebar hover-revealed (`p-0.5`) + dashboard nav (`btn-icon`). Disambiguated via `.nav button[...]`.
- `button:has-text("Save")` matched a disabled Save & Restart button — replaced with Enter keypress (the dialog binds Enter → save).
- Goal title is not in a `title=` attribute on expanded sidebar rows — only as text via `renderHighlightedText`. Use `getByText`.

## Verification

- `npm run check` clean.
- 3 sequential full-suite runs: runs 1+2 `28 passed` each; run 3 hit pre-existing flake in real-LLM phase A (same flake rate as pre-edit baseline; unrelated to these changes).
- Final clean run after fixes: **28 passed (10.4m)**.
- Test A in isolation passes (`bg-6`).

## Follow-ups (out of scope)

- Real-LLM phase-A / E-1 flake (~1-in-6) appears to be a `pollIdle` / `waitForFile` race or LLM cold-start variance. Consider `retries: 1` for manual-integration in a separate change.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)