### PR TITLE
Fix multi-repo-pool E2E: handle v2 sessions.json shape

### DIFF
--- a/tests/e2e/multi-repo-pool.spec.ts
+++ b/tests/e2e/multi-repo-pool.spec.ts
@@ -212,7 +212,10 @@ test.describe.serial("multi-repo worktree pool E2E", () => {
 			persistedSearched = true;
 			const raw = fs.readFileSync(candidate, "utf-8");
 			if (raw.includes(sessionId)) {
-				const rows = JSON.parse(raw) as Array<Record<string, unknown>>;
+				const parsed = JSON.parse(raw) as
+					| Array<Record<string, unknown>>
+					| { sessions?: Array<Record<string, unknown>> };
+				const rows = Array.isArray(parsed) ? parsed : (parsed.sessions ?? []);
 				const row = rows.find(r => r.id === sessionId);
 				if (row) {
 					expect(row.branch).toBe(branch);


### PR DESCRIPTION
The `multi-repo-pool` E2E parsed `sessions.json` as a bare array, but `SessionStore` v2 wraps it as `{ version: 2, epoch, sessions: [...] }`. The test failed with `TypeError: rows.find is not a function` on every run.

Accept both shapes:

```ts
const parsed = JSON.parse(raw) as Array<…> | { sessions?: Array<…> };
const rows = Array.isArray(parsed) ? parsed : (parsed.sessions ?? []);
```

Verified: both tests in the file now pass (6.6s).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)