### PR TITLE
test(manual): handle v2 sessions.json shape

### DIFF
--- a/tests/manual-integration/restart-minimal.spec.ts
+++ b/tests/manual-integration/restart-minimal.spec.ts
@@ -237,7 +237,8 @@ test("restart-minimal: plain + worktree session both survive a restart", async (
 
 	// Read sessions.json snapshot for diagnosis
 	const sfPath = join(dir, ".bobbit", "state", "sessions.json");
-	const before = JSON.parse(readFileSync(sfPath, "utf-8")) as any[];
+	const beforeRaw = JSON.parse(readFileSync(sfPath, "utf-8")) as any;
+	const before: any[] = Array.isArray(beforeRaw) ? beforeRaw : (beforeRaw?.sessions ?? []);
 	console.log(`  [boot] sessions.json has ${before.length} entries`);
 	for (const s of before) {
 		console.log(`         id=${s.id} title="${s.title}" branch=${s.branch} archived=${!!s.archived} agentSessionFile=${s.agentSessionFile ? "yes" : "MISSING"}`);
@@ -282,7 +283,8 @@ test("restart-minimal: plain + worktree session both survive a restart", async (
 	}
 
 	// Read the post-restart sessions.json for diagnosis
-	const after = JSON.parse(readFileSync(sfPath, "utf-8")) as any[];
+	const afterRaw = JSON.parse(readFileSync(sfPath, "utf-8")) as any;
+	const after: any[] = Array.isArray(afterRaw) ? afterRaw : (afterRaw?.sessions ?? []);
 	console.log(`  [restart] sessions.json now has ${after.length} entries (${after.filter(s => s.archived).length} archived)`);
 
 	// UI visibility assertion: a real user verifies sessions survive by

--- a/tests/manual-integration/session-resilience.spec.ts
+++ b/tests/manual-integration/session-resilience.spec.ts
@@ -495,7 +495,9 @@ async function waitForFile(gw: GW, id: string, ms = 30_000) {
 	while (Date.now() - t0 < ms) {
 		const sf = join(gw.dir, ".bobbit", "state", "sessions.json");
 		if (existsSync(sf)) {
-			const mine = JSON.parse(readFileSync(sf, "utf-8")).find((s: any) => s.id === id);
+			const raw = JSON.parse(readFileSync(sf, "utf-8"));
+			const arr: any[] = Array.isArray(raw) ? raw : (raw?.sessions ?? []);
+			const mine = arr.find((s: any) => s.id === id);
 			if (mine?.agentSessionFile && existsSync(mine.agentSessionFile)) return true;
 		}
 		await new Promise(r => setTimeout(r, 2_000));


### PR DESCRIPTION
Two manual-integration tests parsed `.bobbit/state/sessions.json` as a raw array. The store has since moved to v2 `{version: 2, epoch, sessions: [...]}` (see `SessionStore.saveNow`), so every run failed with:

- `restart-minimal.spec.ts`: `TypeError: before is not iterable`
- `session-resilience.spec.ts` `waitForFile()`: `TypeError: JSON.parse(...).find is not a function`

Tolerate both shapes (array = legacy v1, `{sessions}` = v2) at all three call sites. No production code touched.

Verified by re-running both specs:
- `restart-minimal` passes
- `session-resilience` "A. create sessions" passes (the previous failure was a separate slow-sandbox flake unrelated to this fix)

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)