### PR TITLE
Fix sandbox-recovery dropped events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ One-liner task → entry point. Follow links for walkthroughs. **Keep entries to
 ### Sessions, status, steer
 - **Mutate session status** → single writer `broadcastStatus()` in `src/server/agent/session-status.ts`. See [unify-session-status.md](docs/design/unify-session-status.md).
 - **Modify steer / queue dispatch** → single dispatch site `SessionManager._dispatchSteer()`; never reintroduce `PromptQueue.dispatched`. See [steer-subsystem-rewrite.md](docs/design/steer-subsystem-rewrite.md).
+- **Modify in-place agent respawn (clients stay attached)** → `SessionManager._respawnAgentInPlace()`; covers `restartAgent`, `_restartSessionWithUpdatedRole`, `recoverSandboxSessions`, in-memory branch of `ensureSessionAlive`. See [sandbox-recovery-frame-of-reference.md](docs/design/sandbox-recovery-frame-of-reference.md).
 - **Continue an archived session** → `POST /api/sessions/:archivedId/continue`. See [lossless-continue-archived.md](docs/design/lossless-continue-archived.md).
 - **Re-attempt a goal** → `POST /api/sessions { reattemptGoalId }` → `buildReattemptContext()`.
 - **Server-side read/unread** → `lastReadAt` on `PersistedSession`; `POST /api/sessions/:id/mark-read`.
@@ -138,6 +139,7 @@ Keyword index — full diagnostic walkthroughs live in [docs/debugging.md](docs/
 - **Continued session missing earlier transcript** — confirm cloned `.jsonl` at `agentSessionFile` path.
 - **Resumed reviewer terminated ~46ms after restart** — await `waitForStreaming` before `waitForIdle`.
 - **Duplicate `model_change` event at session startup** — spawn site must route through `resolveBridgeOptions`.
+- **UI freezes after Docker container recreated / sandbox respawn drops events** — single in-place respawn helper `_respawnAgentInPlace` in `src/server/agent/session-manager.ts`; snapshot lastSeq + statusVersion after `unsubscribe()` so client dedup gates keep advancing. See [docs/design/sandbox-recovery-frame-of-reference.md](docs/design/sandbox-recovery-frame-of-reference.md).
 
 ### Worktree / sandbox / projects
 - **Worktree setup not running** — single source of truth `runComponentSetups()` in `src/server/skills/worktree-setup.ts`.

--- a/docs/design/sandbox-recovery-frame-of-reference.md
+++ b/docs/design/sandbox-recovery-frame-of-reference.md
@@ -1,0 +1,81 @@
+# Sandbox-Recovery Frame-of-Reference Carry-Over
+
+**Status**: shipped
+**Related**: [`unify-session-status.md`](unify-session-status.md), [`streaming-dedup-reorder.md`](streaming-dedup-reorder.md)
+**Code**: `src/server/agent/session-manager.ts` — `_respawnAgentInPlace`, `_snapshotStreamingFrameOfReference`, `EventBuffer.seedNextSeq`
+
+---
+
+## Why this exists
+
+The client gates every applied frame on two monotonic counters:
+
+- `_highestSeq` — any frame with `seq <= _highestSeq` is silently dropped.
+- `_lastStatusVersion` — any status mutation with `version <= _lastStatusVersion` is dropped.
+
+These counters live on `RemoteAgent` and are **never reset while the WebSocket stays open**. They were introduced by [`unify-session-status`](unify-session-status.md) (status dedup) and the streaming-dedup envelope (seq dedup) to make replays and reconnects idempotent.
+
+That correctness property has a sharp edge: any server-side path that **rebuilds `SessionInfo` + `EventBuffer` while the client's WS stays attached** must seed the new counters from the old high-water marks. Otherwise the fresh `EventBuffer` starts at `seq=1` and the fresh `SessionInfo` at `statusVersion=0`, every post-respawn frame fails the client's `>` check, and the UI freezes until the user reloads.
+
+The original PR (`restart-preserves-streaming-frame`) wired this carry-over into the two restart sites it knew about. **One production caller was missed**: `recoverSandboxSessions` (Docker container recreation). The symptom — "UI receives no events from the agent after a sandbox respawn, clears on reload" — was the same bug, same root cause, third site.
+
+This doc consolidates the invariant so the next person who adds a fourth in-place respawn path doesn't re-hit it.
+
+## The invariant
+
+> **If the WebSocket stays open across an agent respawn, the new `EventBuffer.lastSeq` and `SessionInfo.statusVersion` MUST be seeded from the pre-respawn high-water marks.**
+
+Concretely:
+
+1. Snapshot `{ lastSeq, lastStatusVersion }` from the existing `SessionInfo` via `_snapshotStreamingFrameOfReference()`.
+2. Stash on the `PersistedSession` as the private `_restartFrameOfReference` field.
+3. `restoreSession()` reads it, primes `EventBuffer.seedNextSeq(lastSeq + 1)`, and constructs the new `SessionInfo` with `statusVersion: lastStatusVersion`.
+4. The very next live frame lands at `seq = lastSeq + 1` / `version = lastStatusVersion + 1` and advances the client's trackers naturally.
+
+The carry-over field is private (no protocol change) and unconditionally cleared in a `finally` so it never leaks into a later boot path.
+
+## The four in-place respawn sites
+
+All routed through `SessionManager._respawnAgentInPlace(session, ps, opts?)`:
+
+| Caller | Trigger | Carry-over option |
+|---|---|---|
+| `restartAgent` | Manual restart, dead-process recovery | `mutatePs` stashes saved `allowedTools` |
+| `_restartSessionWithUpdatedRole` | Tool-grant or role change requires fresh process | `mutatePs` stashes role override |
+| `recoverSandboxSessions` | Docker container recreated (the bug fix) | none |
+| `ensureSessionAlive` (in-memory branch) | Terminated `SessionInfo` still has attached clients | none |
+
+The helper owns the full dance: save-clients → unsubscribe → snapshot frame-of-reference → stop RPC client → delete from `sessions` map → stash carry-over on `ps` → `restoreSession(ps)` → re-attach saved clients (filtered by `readyState === 1`) → `broadcastStatus(restored, finalStatus ?? "idle")`. The cleanup of `_restartFrameOfReference` and `_overrideAllowedTools` is centralised in one `finally`, replacing three duplicated cleanups in the prior shape.
+
+## Why timing matters: snapshot AFTER `unsubscribe()`
+
+The original two sites snapshotted **before** `unsubscribe()`. That left a narrow window where a final in-flight event (e.g. an `agent_end` frame already enqueued on the event bus) could write `eventBuffer.lastSeq + 1` between the snapshot and the unsubscribe. The carry-over would be one short, and that one frame's worth of `seq` space would be replayed under the new buffer — invisible most of the time, but a real ordering hazard.
+
+Snapshotting **after** `unsubscribe()` closes the window: by the time we read `lastSeq`, no further events can be appended. The fix is baked into the helper, which means it tightens the two pre-existing sites for free.
+
+## Sites correctly NOT routed through the helper
+
+Two paths rebuild `SessionInfo` + `EventBuffer` but do **not** need carry-over, because they have **no live WS clients** and therefore no client-side `_highestSeq` to outrun:
+
+- **`restoreOneSession`** (boot) — runs before any WS connects. Fresh `_highestSeq=0` on the client side too.
+- **`addClient` dormant-revive** — when a client attaches to a session whose agent process exited cleanly, the client begins from `_highestSeq=0` for that session id (it's a fresh `RemoteAgent`).
+
+Routing these through the helper would seed off a zero `lastSeq` and add cost without value. The helper is intentionally for "WS stays open across respawn" only.
+
+## Test coverage
+
+- `tests/restart-preserves-streaming-frame.test.ts` — pins the original two sites; unchanged.
+- `tests/sandbox-recovery-respawn-helper.test.ts` — drives `_respawnAgentInPlace` against a fake `SessionInfo` + fake client, asserts `_highestSeq` and `_lastStatusVersion` carry-over for the sandbox-recovery shape (no `_overrideAllowedTools`).
+- `tests/sandbox-recovery-preserves-streaming-frame.test.ts` — end-to-end on the `recoverSandboxSessions` path.
+- `tests/manual-integration/sandbox-recovery-frame-continuity.spec.ts` — real Docker: starts a sandboxed session, advances `seq` / `statusVersion`, `docker rm -f`s the project container, drives one more turn, asserts post-recovery events reach the client.
+
+## When to extend this
+
+If you add a new code path that rebuilds `SessionInfo` while clients stay attached:
+
+1. Route it through `_respawnAgentInPlace`. Don't reimplement the dance.
+2. Pass a `mutatePs` callback if you need to thread overrides (saved tools, role change) into `restoreSession`.
+3. Optionally pass `finalStatus` if "idle" isn't the right post-respawn status.
+4. Add an entry to the table above.
+
+If you add a path where clients are NOT attached (boot, dormant revive, archive replay), call `restoreSession` directly. The helper is not a general-purpose wrapper.

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -597,12 +597,6 @@ export class SessionManager {
 					}
 				}
 
-				// Stop old RPC client gracefully (it's dead, but clean up listeners)
-				try {
-					session.unsubscribe();
-					await session.rpcClient.stop();
-				} catch { /* already dead — ignore */ }
-
 				// Get persisted session data for restore
 				const store = this.getSessionStore(session.projectId);
 				const ps = store.get(session.id);
@@ -611,21 +605,11 @@ export class SessionManager {
 					continue;
 				}
 
-				// Save connected WebSocket clients before removing session
+				// Save connected WebSocket clients in case respawn fails and we need
+				// to re-attach them to the original (now terminated) session.
 				const savedClients = new Set(session.clients);
-
-				// Remove from map so restoreSession can re-add it
-				this.sessions.delete(session.id);
 				try {
-					await this.restoreSession(ps);
-					// Re-attach WebSocket clients to the restored session
-					const restored = this.sessions.get(session.id);
-					if (restored) {
-						for (const ws of savedClients) {
-							if ((ws as any).readyState === 1) restored.clients.add(ws);
-						}
-						broadcastStatus(restored, "idle");
-					}
+					await this._respawnAgentInPlace(session, ps);
 					console.log(`[session-manager] Session ${session.id} recovered successfully`);
 				} catch (err) {
 					console.warn(`[session-manager] Failed to restore session ${session.id} after container recreation:`, err);
@@ -2203,53 +2187,21 @@ export class SessionManager {
 		const ps = this.resolveStoreForSession(session.id).get(session.id);
 		if (!ps) return;
 
-		// Save state that must survive the restart
-		const clients = new Set(session.clients);
+		// Save in-memory grant state that restoreSession doesn't persist.
 		const savedAllowedTools = session.allowedTools ? [...session.allowedTools] : undefined;
 		const savedOneTimeGrantedTools = session.oneTimeGrantedTools ? [...session.oneTimeGrantedTools] : undefined;
-		// CRITICAL: snapshot the streaming frame-of-reference so the client's
-		// `_highestSeq` and `_lastStatusVersion` trackers stay in sync after the
-		// in-place restart. The clients keep their WS open across the respawn,
-		// so a fresh seq-1 / version-1 frame would be silently dropped by their
-		// dedup gates. See preserveStreamingFrameOfReference() below.
-		const frameOfRef = this._snapshotStreamingFrameOfReference(session);
 
-		// Stop the current agent process
-		session.unsubscribe();
-		await session.rpcClient.stop();
+		const restored = await this._respawnAgentInPlace(session, ps, {
+			mutatePs: p => {
+				// restoreSession normally derives allowedTools from role YAML; session-only
+				// and one-time grants need the augmented list to round-trip.
+				(p as any)._overrideAllowedTools = savedAllowedTools;
+			},
+		});
 
-		// Remove from sessions map — restoreSession will re-add it
-		this.sessions.delete(session.id);
-
-		// Temporarily store overridden allowedTools so restoreSession can use them.
-		// restoreSession normally derives allowedTools from the role YAML, but for
-		// session-only and one-time grants the in-memory list includes extra tools.
-		(ps as any)._overrideAllowedTools = savedAllowedTools;
-		// Carry the streaming frame-of-reference into the new SessionInfo built
-		// inside restoreSession. Consumed and deleted there.
-		(ps as any)._restartFrameOfReference = frameOfRef;
-
-		// Restore the session (re-launches with correct tool activation)
-		try {
-			await this.restoreSession(ps);
-		} finally {
-			// Clean up the temporary override even if restoreSession fails
-			delete (ps as any)._overrideAllowedTools;
-			delete (ps as any)._restartFrameOfReference;
-		}
-
-		// Re-attach the saved clients and carry over grant state
-		const restored = this.sessions.get(session.id);
 		if (restored) {
-			for (const ws of clients) {
-				if ((ws as any).readyState === 1) {
-					restored.clients.add(ws);
-				}
-			}
-			// Restore in-memory grant state that restoreSession doesn't know about
 			if (savedAllowedTools) restored.allowedTools = savedAllowedTools;
 			if (savedOneTimeGrantedTools) restored.oneTimeGrantedTools = savedOneTimeGrantedTools;
-			broadcastStatus(restored, "idle");
 		}
 	}
 
@@ -2277,6 +2229,49 @@ export class SessionManager {
 	}
 
 	/**
+	 * Respawn a session's agent process in-place while WS clients stay attached.
+	 *
+	 * Owns the snapshot/unsubscribe/stop/restore/re-attach/broadcast dance shared
+	 * by `restartAgent`, `_restartSessionWithUpdatedRole`, `recoverSandboxSessions`,
+	 * and the in-memory branch of `ensureSessionAlive`.
+	 *
+	 * The streaming frame-of-reference is snapshotted AFTER `unsubscribe()` so a
+	 * final in-flight `agent_end`-style event cannot race past `lastSeq`. The
+	 * carry-over fields (`_restartFrameOfReference`, `_overrideAllowedTools`)
+	 * are stashed on the persisted-session record for `restoreSession()` to
+	 * consume, then unconditionally cleared in `finally`.
+	 */
+	private async _respawnAgentInPlace(
+		session: SessionInfo,
+		ps: PersistedSession,
+		opts?: { mutatePs?: (ps: PersistedSession) => void; finalStatus?: SessionStatus },
+	): Promise<SessionInfo | undefined> {
+		const savedClients = new Set(session.clients);
+		// Snapshot AFTER unsubscribe so no in-flight event races past lastSeq.
+		session.unsubscribe();
+		const frameOfRef = this._snapshotStreamingFrameOfReference(session);
+		try { await session.rpcClient.stop(); } catch { /* already dead */ }
+
+		this.sessions.delete(session.id);
+		(ps as any)._restartFrameOfReference = frameOfRef;
+		opts?.mutatePs?.(ps);
+		try {
+			await this.restoreSession(ps);
+		} finally {
+			delete (ps as any)._restartFrameOfReference;
+			delete (ps as any)._overrideAllowedTools;
+		}
+		const restored = this.sessions.get(session.id);
+		if (restored) {
+			for (const ws of savedClients) {
+				if ((ws as any).readyState === 1) restored.clients.add(ws);
+			}
+			broadcastStatus(restored, opts?.finalStatus ?? "idle");
+		}
+		return restored;
+	}
+
+	/**
 	 * Restart the agent process for a session whose process has died.
 	 * Stops any remnant process, then restores from persisted state.
 	 * Re-attaches existing WS clients so the user can keep working.
@@ -2288,41 +2283,16 @@ export class SessionManager {
 		const ps = this.resolveStoreForSession(session.id).get(session.id);
 		if (!ps) throw new Error("No persisted session data");
 
-		// Save state that must survive the restart
-		const clients = new Set(session.clients);
 		const savedAllowedTools = session.allowedTools ? [...session.allowedTools] : undefined;
 		const savedOneTimeGrantedTools = session.oneTimeGrantedTools ? [...session.oneTimeGrantedTools] : undefined;
-		// Snapshot streaming frame-of-reference — see
-		// `_restartSessionWithUpdatedRole` for the full rationale.
-		const frameOfRef = this._snapshotStreamingFrameOfReference(session);
 
-		// Stop remnant process (may already be dead)
-		session.unsubscribe();
-		try { await session.rpcClient.stop(); } catch { /* already dead */ }
+		const restored = await this._respawnAgentInPlace(session, ps, {
+			mutatePs: p => { (p as any)._overrideAllowedTools = savedAllowedTools; },
+		});
 
-		// Remove from sessions map — restoreSession will re-add it
-		this.sessions.delete(sessionId);
-
-		(ps as any)._overrideAllowedTools = savedAllowedTools;
-		(ps as any)._restartFrameOfReference = frameOfRef;
-		try {
-			await this.restoreSession(ps);
-		} finally {
-			delete (ps as any)._overrideAllowedTools;
-			delete (ps as any)._restartFrameOfReference;
-		}
-
-		// Re-attach saved clients and carry over grant state
-		const restored = this.sessions.get(sessionId);
 		if (restored) {
-			for (const ws of clients) {
-				if ((ws as any).readyState === 1) {
-					restored.clients.add(ws);
-				}
-			}
 			if (savedAllowedTools) restored.allowedTools = savedAllowedTools;
 			if (savedOneTimeGrantedTools) restored.oneTimeGrantedTools = savedOneTimeGrantedTools;
-			broadcastStatus(restored, "idle");
 		} else {
 			throw new Error("Failed to restore session after restart");
 		}
@@ -4186,7 +4156,17 @@ export class SessionManager {
 		if (!persisted) {
 			throw new Error(`Cannot restore session ${sessionId}: no persisted data found`);
 		}
-		await this.restoreSession(persisted);
+		if (existing) {
+			// In-memory SessionInfo present (terminated, possibly with attached WS
+			// clients). Route through the in-place respawn helper so the streaming
+			// frame-of-reference carries over and post-restore frames aren't dropped
+			// by the client's dedup gates.
+			await this._respawnAgentInPlace(existing, persisted);
+		} else {
+			// Cold restore — no in-memory session, no live clients, fresh
+			// `_highestSeq=0` baseline on whoever connects next.
+			await this.restoreSession(persisted);
+		}
 		console.log(`[session-manager] Restored session ${sessionId} via ensureSessionAlive`);
 	}
 

--- a/tests/manual-integration/sandbox-recovery-frame-continuity.spec.ts
+++ b/tests/manual-integration/sandbox-recovery-frame-continuity.spec.ts
@@ -1,0 +1,411 @@
+/**
+ * Manual-integration test for the sandbox-recovery dropped-events fix.
+ *
+ * Pins the regression behind the goal "Fix sandbox-recovery dropped events":
+ * after a sandboxed session's project container is force-removed, the server
+ * recovers by respawning the agent in place (`SessionManager.recoverSandboxSessions`).
+ * That respawn rebuilds `SessionInfo` + `EventBuffer` while the client's WebSocket
+ * stays open. Without seeding the new buffers from the old high-water marks,
+ * every post-recovery `event` and `session_status` frame would arrive at
+ * `seq=1` / `statusVersion=1` and be silently dropped by the client's monotonic
+ * dedup gates.
+ *
+ * The fix routes `recoverSandboxSessions` through `_respawnAgentInPlace`, which
+ * snapshots `EventBuffer.lastSeq` + `SessionInfo.statusVersion` BEFORE the
+ * respawn and seeds the fresh buffers from those values. This test is the
+ * end-to-end regression guard.
+ *
+ * Test flow (Docker-only — auto-skips otherwise):
+ *   1. Boot a gateway, register a project, create a sandboxed session.
+ *   2. Open a WebSocket and capture the highest `seq` and `statusVersion`
+ *      observed during the initial turn(s). Assert both > 0.
+ *   3. `docker rm -f` the project container (matches E-4's mechanism).
+ *   4. Poll sandbox-status until it reports available again.
+ *   5. Drive ONE more user turn AFTER recovery — over the SAME WebSocket.
+ *   6. Assert: the WS received `event` frames with seq > preKillMaxSeq AND
+ *      a `session_status` frame with statusVersion > preKillMaxStatusVersion.
+ *      Without the fix, the client would receive frames stamped seq=1+,
+ *      statusVersion=1+, and although they would arrive on the wire, the
+ *      *server-side* counters would be stale relative to the old high-water
+ *      mark — so the regression manifests as the post-recovery frames'
+ *      seq/version values being LOWER THAN OR EQUAL TO the pre-kill values.
+ *
+ *   npm run test:manual -- --grep "sandbox-recovery-frame-continuity"
+ */
+import { test, expect } from "@playwright/test";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import { createServer } from "node:net";
+import {
+	mkdirSync, rmSync, readFileSync, writeFileSync, existsSync, readdirSync,
+	cpSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import WebSocket from "ws";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
+const SERVER_CLI = join(PROJECT_ROOT, "dist", "server", "cli.js");
+
+function hasDocker(): boolean {
+	try { execFileSync("docker", ["info"], { stdio: "ignore", timeout: 10_000 }); return true; } catch { return false; }
+}
+const HAS_DOCKER = hasDocker();
+
+interface GW { proc: ChildProcess; port: number; dir: string; token: string; base: string; defaultProjectId?: string; }
+
+async function freePort(): Promise<number> {
+	return new Promise((res, rej) => {
+		const s = createServer();
+		s.listen(0, "127.0.0.1", () => { const p = (s.address() as any).port; s.close(() => res(p)); });
+		s.on("error", rej);
+	});
+}
+
+async function startGW(dir: string, port: number): Promise<GW> {
+	mkdirSync(join(dir, ".bobbit", "state"), { recursive: true });
+	const proc = spawn(process.execPath, [
+		SERVER_CLI, "--host", "127.0.0.1", "--port", String(port),
+		"--no-tls", "--auth", "--cwd", dir,
+	], {
+		env: { ...process.env, BOBBIT_DIR: join(dir, ".bobbit"), NODE_ENV: "test" },
+		stdio: ["pipe", "pipe", "pipe"],
+	});
+	let stderr = "";
+	proc.stderr!.on("data", (c: Buffer) => { stderr += c; });
+	proc.stdout!.on("data", () => { /* discard */ });
+	const deadline = Date.now() + 120_000;
+	while (Date.now() < deadline) {
+		if (proc.exitCode !== null) throw new Error(`Gateway exited (${proc.exitCode}):\n${stderr}`);
+		try {
+			const tp = join(dir, ".bobbit", "state", "token");
+			if (existsSync(tp)) {
+				const t = readFileSync(tp, "utf-8").trim();
+				if ((await fetch(`http://127.0.0.1:${port}/api/health`, { headers: { Authorization: `Bearer ${t}` } })).ok) break;
+			}
+		} catch {}
+		await new Promise(r => setTimeout(r, 300));
+	}
+	if (Date.now() >= deadline) { proc.kill(); throw new Error(`Not healthy:\n${stderr}`); }
+	const token = readFileSync(join(dir, ".bobbit", "state", "token"), "utf-8").trim();
+	return { proc, port, dir, token, base: `http://127.0.0.1:${port}` };
+}
+
+async function stopGW(gw: GW): Promise<void> {
+	if (gw.proc.exitCode === null) {
+		if (process.platform === "win32") {
+			try { execFileSync("taskkill", ["/PID", String(gw.proc.pid), "/T", "/F"], { stdio: "ignore", timeout: 10_000 }); } catch {}
+		} else { gw.proc.kill(); }
+	}
+	await new Promise<void>(r => {
+		if (gw.proc.exitCode !== null) return r();
+		gw.proc.on("exit", () => r());
+		setTimeout(() => { try { gw.proc.kill("SIGKILL"); } catch {} r(); }, 5_000);
+	});
+	await new Promise(r => setTimeout(r, 1_000));
+}
+
+function api(gw: GW, path: string, opts: RequestInit = {}) {
+	if ((opts.method || "GET").toUpperCase() === "POST" && path === "/api/sessions" && gw.defaultProjectId) {
+		try {
+			const body = typeof opts.body === "string" && opts.body ? JSON.parse(opts.body) : {};
+			if (body && typeof body === "object" && !body.projectId) {
+				body.projectId = gw.defaultProjectId;
+				opts = { ...opts, body: JSON.stringify(body) };
+			}
+		} catch {}
+	}
+	return fetch(`${gw.base}${path}`, {
+		...opts,
+		headers: { "Content-Type": "application/json", Authorization: `Bearer ${gw.token}`, ...(opts.headers as Record<string, string> || {}) },
+	});
+}
+
+async function pollIdle(gw: GW, id: string, ms = 180_000) {
+	const t0 = Date.now();
+	while (Date.now() - t0 < ms) {
+		const res = await api(gw, `/api/sessions/${id}`);
+		if (res.status === 404) { await new Promise(r => setTimeout(r, 500)); continue; }
+		const s = await res.json();
+		if (s.status === "idle") return s;
+		if (s.status === "archived") throw new Error(`Session ${id} archived`);
+		if (s.status === "error" || s.status === "terminated") {
+			throw new Error(`Session ${id} ${s.status}${s.restoreError ? `: ${s.restoreError}` : ""}`);
+		}
+		await new Promise(r => setTimeout(r, 1_000));
+	}
+	throw new Error(`Session ${id} not idle in ${ms}ms`);
+}
+
+function initRepo(dir: string) {
+	mkdirSync(dir, { recursive: true });
+	execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["symbolic-ref", "HEAD", "refs/heads/master"], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["config", "user.email", "t@t"], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["config", "user.name", "T"], { cwd: dir, stdio: "ignore" });
+	writeFileSync(join(dir, "README.md"), "# Test\n");
+	writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "p", version: "1.0.0" }, null, 2));
+	execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "ignore" });
+	const srcConfig = join(PROJECT_ROOT, ".bobbit", "config");
+	const dstConfig = join(dir, ".bobbit", "config");
+	if (existsSync(srcConfig)) {
+		cpSync(srcConfig, dstConfig, { recursive: true, filter: (src) => !src.endsWith("project.yaml") });
+	}
+}
+
+function cleanDirs(dir: string) {
+	const parent = resolve(dir, "..");
+	const base = dir.split(/[\\/]/).pop()!;
+	const dirs = [dir];
+	try { for (const e of readdirSync(parent)) if (e.startsWith(base)) dirs.push(join(parent, e)); } catch {}
+	for (const d of dirs) { for (let i = 0; i < 3; i++) { try { rmSync(d, { recursive: true, force: true }); break; } catch {} } }
+}
+
+function cleanTestDockerContainers() {
+	if (!HAS_DOCKER) return;
+	try {
+		const ids = execFileSync("docker", ["ps", "-aq", "--filter", "label=bobbit-project"], {
+			encoding: "utf-8", timeout: 10_000,
+		}).trim();
+		if (!ids) return;
+		for (const id of ids.split(/\s+/).filter(Boolean)) {
+			try {
+				const binds = execFileSync("docker", [
+					"inspect", "--format", "{{json .HostConfig.Binds}}", id,
+				], { encoding: "utf-8", timeout: 5_000 }).trim();
+				if (/\.bobbit-recovery-frame/.test(binds)) {
+					const projectId = execFileSync("docker", [
+						"inspect", "--format", '{{index .Config.Labels "bobbit-project"}}', id,
+					], { encoding: "utf-8", timeout: 5_000 }).trim();
+					execFileSync("docker", ["rm", "-f", id], { timeout: 15_000, stdio: "ignore" });
+					if (projectId) {
+						for (const prefix of ["bobbit-workspace-", "bobbit-worktrees-"]) {
+							try {
+								execFileSync("docker", ["volume", "rm", "-f", `${prefix}${projectId}`], {
+									timeout: 10_000, stdio: "ignore",
+								});
+							} catch {}
+						}
+					}
+				}
+			} catch {}
+		}
+	} catch {}
+}
+
+interface WsClient {
+	ws: WebSocket;
+	messages: any[];
+	maxEventSeq: () => number;
+	maxStatusVersion: () => number;
+	send: (m: any) => void;
+	waitFor: (pred: (m: any) => boolean, timeoutMs?: number) => Promise<any>;
+	close: () => void;
+}
+
+async function connectWs(gw: GW, sessionId: string): Promise<WsClient> {
+	return new Promise((resolve, reject) => {
+		const wsUrl = gw.base.replace(/^http/, "ws") + `/ws/${sessionId}`;
+		const ws = new WebSocket(wsUrl);
+		const messages: any[] = [];
+		const waiters: Array<{ pred: (m: any) => boolean; res: (m: any) => void }> = [];
+
+		ws.on("message", (raw) => {
+			let msg: any;
+			try { msg = JSON.parse(raw.toString()); } catch { return; }
+			messages.push(msg);
+			for (let i = waiters.length - 1; i >= 0; i--) {
+				if (waiters[i].pred(msg)) { waiters[i].res(msg); waiters.splice(i, 1); }
+			}
+		});
+		ws.on("open", () => ws.send(JSON.stringify({ type: "auth", token: gw.token })));
+		ws.on("error", reject);
+
+		const iv = setInterval(() => {
+			if (messages.some(m => m.type === "auth_ok")) {
+				clearInterval(iv);
+				resolve({
+					ws, messages,
+					maxEventSeq: () => messages.reduce(
+						(mx, m) => (m.type === "event" && typeof m.seq === "number" && m.seq > mx ? m.seq : mx), 0),
+					maxStatusVersion: () => messages.reduce(
+						(mx, m) => (m.type === "session_status" && typeof m.statusVersion === "number" && m.statusVersion > mx ? m.statusVersion : mx), 0),
+					send: (m) => ws.send(JSON.stringify(m)),
+					waitFor: (pred, timeoutMs = 60_000) => {
+						const existing = messages.find(pred);
+						if (existing) return Promise.resolve(existing);
+						return new Promise((res, rej) => {
+							const t = setTimeout(() => rej(new Error(`waitFor timed out (${timeoutMs}ms)`)), timeoutMs);
+							waiters.push({ pred, res: (m) => { clearTimeout(t); res(m); } });
+						});
+					},
+					close: () => { try { ws.close(); } catch {} },
+				});
+			}
+		}, 50);
+		setTimeout(() => { clearInterval(iv); reject(new Error("WS auth timeout")); }, 15_000);
+	});
+}
+
+/** Send a prompt over WS and wait for the turn to settle (session_status idle with bumped version). */
+async function wsPromptAndWaitIdle(client: WsClient, text: string, timeoutMs = 240_000) {
+	// Capture the current statusVersion floor before sending — we need to wait
+	// for a session_status:idle frame STRICTLY GREATER than this.
+	const versionBefore = client.maxStatusVersion();
+	client.send({ type: "prompt", text });
+	// Wait for an idle status with version > versionBefore (post-turn settle).
+	await client.waitFor(
+		(m) => m.type === "session_status" && m.status === "idle"
+			&& typeof m.statusVersion === "number" && m.statusVersion > versionBefore,
+		timeoutMs,
+	);
+}
+
+test.describe.configure({ mode: "serial" });
+
+test("sandbox-recovery preserves WS frame continuity (seq + statusVersion carry over)", async () => {
+	test.skip(!HAS_DOCKER, "Docker not available");
+	test.setTimeout(600_000); // 10 min — sandbox boot + recovery + 3 LLM turns
+
+	const tmp = process.platform === "win32" ? (process.env.TEMP || "C:\\Temp") : "/tmp";
+	const port = await freePort();
+	const dir = join(tmp, `.bobbit-recovery-frame-${port}`);
+	cleanDirs(dir);
+	initRepo(dir);
+
+	mkdirSync(join(dir, ".bobbit", "config"), { recursive: true });
+	mkdirSync(join(dir, ".bobbit", "state"), { recursive: true });
+	writeFileSync(join(dir, ".bobbit", "config", "project.yaml"),
+		'worktree_pool_size: "2"\nsandbox: "docker"\n');
+	writeFileSync(join(dir, ".bobbit", "state", "projects.json"), "[]");
+
+	const gw = await startGW(dir, port);
+	console.log(`  Gateway :${port} cwd=${dir}`);
+
+	// Auto-skip if the sandbox isn't actually available even with Docker installed
+	let sandboxAvailable = false;
+	{
+		const deadline = Date.now() + 120_000;
+		while (Date.now() < deadline) {
+			const r = await (await api(gw, "/api/sandbox-status")).json();
+			if (r.configured && r.available) { sandboxAvailable = true; break; }
+			await new Promise(r => setTimeout(r, 2_000));
+		}
+	}
+	if (!sandboxAvailable) {
+		console.log("  Sandbox not available — skipping");
+		await stopGW(gw);
+		cleanDirs(dir);
+		test.skip(true, "Sandbox not available");
+		return;
+	}
+
+	let client: WsClient | null = null;
+	let sessionId: string | null = null;
+
+	try {
+		// 1. Register the project
+		const regRes = await api(gw, "/api/projects", {
+			method: "POST",
+			body: JSON.stringify({ name: "Recovery Frame", rootPath: dir }),
+		});
+		expect(regRes.status).toBe(201);
+		gw.defaultProjectId = ((await regRes.json()) as any).id;
+
+		// 2. Create a sandboxed session
+		const sessRes = await api(gw, "/api/sessions", {
+			method: "POST",
+			body: JSON.stringify({ sandboxed: true }),
+		});
+		expect(sessRes.status).toBe(201);
+		sessionId = ((await sessRes.json()) as any).id as string;
+		console.log(`  Sandboxed session: ${sessionId}`);
+
+		await pollIdle(gw, sessionId, 240_000);
+		console.log("  Session idle ✓");
+
+		// 3. Open a WS and keep it open across the whole test
+		client = await connectWs(gw, sessionId);
+		console.log("  WebSocket connected + authenticated ✓");
+
+		// 4. Drive two user turns to advance seq + statusVersion
+		await wsPromptAndWaitIdle(client, "Reply with exactly the text: turn-one-ack");
+		console.log(`  Turn 1 done. maxSeq=${client.maxEventSeq()} maxStatusVersion=${client.maxStatusVersion()}`);
+		await wsPromptAndWaitIdle(client, "Reply with exactly the text: turn-two-ack");
+		const preKillSeq = client.maxEventSeq();
+		const preKillStatusVersion = client.maxStatusVersion();
+		console.log(`  Turn 2 done. preKillSeq=${preKillSeq} preKillStatusVersion=${preKillStatusVersion}`);
+
+		// Both must be > 0 — proves the WS actually saw real frames pre-kill.
+		expect(preKillSeq).toBeGreaterThan(0);
+		expect(preKillStatusVersion).toBeGreaterThan(0);
+
+		// 5. Find and force-remove the project container
+		const containerId = execFileSync("docker", [
+			"ps", "-q", "--filter", "label=bobbit-project",
+		], { encoding: "utf-8", timeout: 10_000 }).trim();
+		expect(containerId).toBeTruthy();
+		console.log(`  Killing container ${containerId.substring(0, 12)} …`);
+		execFileSync("docker", ["rm", "-f", containerId], { timeout: 15_000, stdio: "ignore" });
+
+		// 6. Wait for sandbox-status to report available again (server respawns container)
+		{
+			const t0 = Date.now();
+			let recovered = false;
+			while (Date.now() - t0 < 180_000) {
+				try {
+					const r = await (await api(gw, "/api/sandbox-status")).json();
+					if (r.available) { recovered = true; break; }
+				} catch {}
+				await new Promise(r => setTimeout(r, 2_000));
+			}
+			expect(recovered).toBe(true);
+			console.log(`  Sandbox container recovered in ${Math.round((Date.now() - t0))}ms`);
+		}
+
+		// 7. Wait for the session to come back to idle. recoverSandboxSessions
+		//    respawns the agent and broadcasts a fresh "idle" status — this is
+		//    EXACTLY the frame the bug used to drop.
+		await pollIdle(gw, sessionId, 180_000);
+		console.log("  Session API status: idle (post-recovery) ✓");
+
+		// Brief settle so any post-recovery status frames have a chance to arrive.
+		await new Promise(r => setTimeout(r, 2_000));
+
+		// 8. Drive ONE more user turn AFTER recovery — over the SAME WebSocket.
+		//    Critical: this is what the regression silently dropped.
+		await wsPromptAndWaitIdle(client, "Reply with exactly the text: post-recovery-ack");
+		const postRecoverySeq = client.maxEventSeq();
+		const postRecoveryStatusVersion = client.maxStatusVersion();
+		console.log(`  Post-recovery turn done. seq=${postRecoverySeq} statusVersion=${postRecoveryStatusVersion}`);
+
+		// 9. The fix asserts: post-recovery seq AND statusVersion must
+		//    monotonically advance past the pre-kill high-water marks. Without
+		//    the fix, the server's fresh EventBuffer would emit seq=1.. and
+		//    fresh SessionInfo would emit statusVersion=1.. — both <= the
+		//    pre-kill values — and the client's monotonic dedup gates would
+		//    drop them. (Here we observe what the server actually wrote on the
+		//    wire; the seedNextSeq / statusVersion carry-over makes the
+		//    server-emitted values strictly greater.)
+		expect(postRecoverySeq).toBeGreaterThan(preKillSeq);
+		expect(postRecoveryStatusVersion).toBeGreaterThan(preKillStatusVersion);
+
+		// 10. Sanity: there should be at least one `event` frame stamped with a
+		//     seq strictly greater than preKillSeq, AND at least one
+		//     `session_status` frame with statusVersion strictly greater than
+		//     preKillStatusVersion. (Implied by step 9, but assert explicitly
+		//     to catch the case where one path advances and the other doesn't.)
+		const newEvents = client.messages.filter(m =>
+			m.type === "event" && typeof m.seq === "number" && m.seq > preKillSeq);
+		const newStatuses = client.messages.filter(m =>
+			m.type === "session_status" && typeof m.statusVersion === "number"
+			&& m.statusVersion > preKillStatusVersion);
+		expect(newEvents.length).toBeGreaterThan(0);
+		expect(newStatuses.length).toBeGreaterThan(0);
+		console.log(`  Post-recovery: ${newEvents.length} new event frames, ${newStatuses.length} new session_status frames ✓`);
+	} finally {
+		try { client?.close(); } catch {}
+		await stopGW(gw);
+		cleanTestDockerContainers();
+		cleanDirs(dir);
+	}
+});

--- a/tests/sandbox-recovery-preserves-streaming-frame.test.ts
+++ b/tests/sandbox-recovery-preserves-streaming-frame.test.ts
@@ -218,9 +218,12 @@ test("recoverSandboxSessions — wired through _respawnAgentInPlace + frame-of-r
 	const startMarker = "private async recoverSandboxSessions(";
 	const startIdx = src.indexOf(startMarker);
 	assert.ok(startIdx >= 0, "recoverSandboxSessions method not found in session-manager.ts");
-	// Heuristic body slice: take ~2000 chars from the method start, which is
-	// well within its body and well clear of unrelated methods.
-	const body = src.slice(startIdx, startIdx + 2000);
+	// Heuristic body slice: take from the method start until the next top-level
+	// `\n\t/**` doc-comment OR `\n\tprivate ` / `\n\tasync ` declaration — i.e.
+	// the next sibling method. This survives the worktree-repair block growing.
+	const rest = src.slice(startIdx + startMarker.length);
+	const endRel = rest.search(/\n\t(?:\/\*\*|private |async |public |constructor)/);
+	const body = rest.slice(0, endRel >= 0 ? endRel : 4000);
 
 	const hasHelperDefinition = /private\s+(?:async\s+)?_respawnAgentInPlace\s*\(/.test(src);
 	const recoveryUsesHelper = body.includes("_respawnAgentInPlace");

--- a/tests/sandbox-recovery-preserves-streaming-frame.test.ts
+++ b/tests/sandbox-recovery-preserves-streaming-frame.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Reproducing test for the sandbox-recovery dropped-events bug.
+ *
+ * `SessionManager.recoverSandboxSessions` (`src/server/agent/session-manager.ts`
+ * ~L600–L630) is triggered by `SandboxManager.onContainerRecovered()` when a
+ * project's Docker container is recreated. It rebuilds the SessionInfo +
+ * EventBuffer in-place while the client's WebSocket stays open, but — unlike
+ * `restartAgent` and `_restartSessionWithUpdatedRole` (PR #529) — does NOT
+ * stash `_restartFrameOfReference` on the persisted session. The new
+ * EventBuffer therefore starts at seq=1 and the new SessionInfo at
+ * statusVersion=0; the client's `_highestSeq` / `_lastStatusVersion` trackers
+ * were advanced by the OLD session, so every post-recovery frame is silently
+ * dropped by the client's dedup gates.
+ *
+ * Companion to `tests/restart-preserves-streaming-frame.test.ts` (which pins
+ * the analogous fix for the other two restart paths). The fix shape is to
+ * extract `SessionManager._respawnAgentInPlace(session, ps, opts?)` and route
+ * `recoverSandboxSessions` (and the other two existing sites + the in-memory
+ * branch of `ensureSessionAlive`) through it.
+ *
+ * This test pins TWO things:
+ *
+ *  1. The pure dropped-events behaviour at the EventBuffer + broadcastStatus
+ *     level (currently passes — regression pin).
+ *  2. The existence of `SessionManager.prototype._respawnAgentInPlace` — the
+ *     private helper that the fix introduces. This currently FAILS on master
+ *     and is the explicit reproducer for the missing-fix state.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import { EventBuffer } from "../src/server/agent/event-buffer.ts";
+import { broadcastStatus } from "../src/server/agent/session-status.ts";
+
+// Resolve session-manager.ts path without importing it (the import chain pulls
+// in flexsearch and other heavy deps that don't work under tsx --test).
+const SESSION_MANAGER_PATH = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"..",
+	"src",
+	"server",
+	"agent",
+	"session-manager.ts",
+);
+
+// Minimal client-side mirror of the version + seq dedup gates in
+// src/app/remote-agent.ts. Mirrors the helper in
+// tests/restart-preserves-streaming-frame.test.ts.
+function makeFakeClient() {
+	const sent: any[] = [];
+	const applied: any[] = [];
+	let highestSeq = 0;
+	let lastStatusVersion = -1;
+	let seqInitialized = false;
+	function onEvent(seq: number, ev: any) {
+		if (!seqInitialized) {
+			highestSeq = seq - 1;
+			seqInitialized = true;
+		}
+		if (seq <= highestSeq) return; // dedup gate
+		if (seq !== highestSeq + 1) return; // out-of-order — drop
+		highestSeq = seq;
+		applied.push(ev);
+	}
+	function onStatus(frame: { status: string; statusVersion: number }) {
+		const v = frame.statusVersion;
+		if (v <= lastStatusVersion) return; // idempotent gate
+		lastStatusVersion = v;
+		applied.push({ type: "status", status: frame.status, v });
+	}
+	function makeWs() {
+		return {
+			readyState: 1,
+			bufferedAmount: 0,
+			send(data: string) {
+				const msg = JSON.parse(data);
+				if (msg.type === "session_status") onStatus(msg);
+				else if (msg.type === "event") onEvent(msg.seq, msg.data);
+				sent.push(msg);
+			},
+		};
+	}
+	return {
+		makeWs,
+		applied,
+		sent,
+		getHighestSeq: () => highestSeq,
+		getLastStatusVersion: () => lastStatusVersion,
+	};
+}
+
+test("recoverSandboxSessions — BROKEN path drops every post-recovery frame (regression pin)", () => {
+	// Reproduce the current behaviour: simulate the unfixed
+	// `recoverSandboxSessions` flow — fresh EventBuffer (no seedNextSeq) +
+	// fresh SessionInfo (statusVersion: 0) — and confirm the client's dedup
+	// gates silently drop every post-recovery frame.
+	const client = makeFakeClient();
+	const ws = client.makeWs();
+
+	// Old session — emit a few status flips + 10 live events.
+	const oldSession: any = { id: "s1", status: "idle", statusVersion: 0, clients: new Set([ws]) };
+	const oldBuf = new EventBuffer();
+
+	broadcastStatus(oldSession, "streaming", { streamingStartedAt: 1 });
+	for (let i = 1; i <= 10; i++) {
+		const entry = oldBuf.push({ type: "live", i });
+		ws.send(JSON.stringify({ type: "event", data: entry.event, seq: entry.seq, ts: entry.ts }));
+	}
+	broadcastStatus(oldSession, "idle");
+
+	const oldClientSeq = client.getHighestSeq();
+	const oldClientVersion = client.getLastStatusVersion();
+	assert.equal(oldClientSeq, 10);
+	assert.equal(oldClientVersion, 2); // streaming + idle
+
+	// === BROKEN sandbox-recovery: rebuild buffer + session WITHOUT seeding ===
+	const newBufNoSeed = new EventBuffer();
+	const newSessionNoSeed: any = {
+		id: "s1",
+		status: "starting",
+		statusVersion: 0,
+		clients: new Set([ws]),
+	};
+
+	const beforeApplied = client.applied.length;
+
+	// Step 6 in recoverSandboxSessions: broadcastStatus(restored, "idle").
+	// version bumps from 0 -> 1, but client's lastStatusVersion is already 2,
+	// so this is silently dropped.
+	broadcastStatus(newSessionNoSeed, "idle");
+
+	// Five post-recovery agent events. Each starts at seq 1..5 — all <= 10 —
+	// every one is silently dropped.
+	for (let i = 1; i <= 5; i++) {
+		const entry = newBufNoSeed.push({ type: "post-recovery", i });
+		ws.send(JSON.stringify({ type: "event", data: entry.event, seq: entry.seq, ts: entry.ts }));
+	}
+
+	const newlyApplied = client.applied.length - beforeApplied;
+	assert.equal(
+		newlyApplied,
+		0,
+		"BROKEN path: all 5 post-recovery events AND the post-recovery status flip are silently dropped",
+	);
+	assert.equal(client.getHighestSeq(), oldClientSeq, "client _highestSeq did not advance");
+	assert.equal(
+		client.getLastStatusVersion(),
+		oldClientVersion,
+		"client _lastStatusVersion did not advance",
+	);
+});
+
+test("recoverSandboxSessions — FIXED path: seedNextSeq + statusVersion carry-over keeps frames flowing", () => {
+	// Same setup, but this time apply the fix shape: snapshot lastSeq +
+	// statusVersion BEFORE building the new buffer/session, then seed the new
+	// EventBuffer and the new SessionInfo with the high-water marks.
+	const client = makeFakeClient();
+	const ws = client.makeWs();
+
+	const oldSession: any = { id: "s1", status: "idle", statusVersion: 0, clients: new Set([ws]) };
+	const oldBuf = new EventBuffer();
+
+	broadcastStatus(oldSession, "streaming", { streamingStartedAt: 1 });
+	for (let i = 1; i <= 10; i++) {
+		const entry = oldBuf.push({ type: "live", i });
+		ws.send(JSON.stringify({ type: "event", data: entry.event, seq: entry.seq, ts: entry.ts }));
+	}
+	broadcastStatus(oldSession, "idle");
+
+	const oldClientSeq = client.getHighestSeq();
+	const oldClientVersion = client.getLastStatusVersion();
+
+	// === FIXED sandbox-recovery: snapshot first, then seed ===
+	const snapshot = { lastSeq: oldBuf.lastSeq, lastStatusVersion: oldSession.statusVersion };
+	const newBuf = new EventBuffer();
+	newBuf.seedNextSeq(snapshot.lastSeq + 1);
+	const newSession: any = {
+		id: "s1",
+		status: "starting",
+		statusVersion: snapshot.lastStatusVersion,
+		clients: new Set([ws]),
+	};
+
+	broadcastStatus(newSession, "idle"); // bumps to 3 — accepted (3 > 2)
+	for (let i = 1; i <= 5; i++) {
+		const entry = newBuf.push({ type: "post-recovery", i });
+		ws.send(JSON.stringify({ type: "event", data: entry.event, seq: entry.seq, ts: entry.ts }));
+	}
+
+	const postRecoveryLive = client.applied.filter((m: any) => m.type === "post-recovery");
+	assert.equal(postRecoveryLive.length, 5, "all 5 post-recovery live events applied");
+	assert.equal(client.getHighestSeq(), 15, "11..15 = 5 new events on top of old 10");
+	assert.ok(client.getHighestSeq() > oldClientSeq);
+	assert.equal(client.getLastStatusVersion(), 3, "post-recovery idle bump applied");
+	assert.ok(client.getLastStatusVersion() > oldClientVersion);
+});
+
+test("recoverSandboxSessions — wired through _respawnAgentInPlace + frame-of-reference snapshot (pinned for fix)", () => {
+	// The fix extracts a private `_respawnAgentInPlace(session, ps, opts?)`
+	// helper that owns the snapshot/unsubscribe/stop/restore/re-attach/
+	// broadcast dance, and routes `restartAgent`,
+	// `_restartSessionWithUpdatedRole`, `recoverSandboxSessions`, and the
+	// in-memory branch of `ensureSessionAlive` through it.
+	//
+	// On master this assertion FAILS because:
+	//   - the helper `_respawnAgentInPlace` does not exist yet, AND
+	//   - `recoverSandboxSessions` does not call
+	//     `_snapshotStreamingFrameOfReference` and does not stash
+	//     `_restartFrameOfReference` on the persisted session.
+	//
+	// This is the explicit reproducer pin for the missing-fix state.
+	const src = readFileSync(SESSION_MANAGER_PATH, "utf8");
+
+	// Locate `recoverSandboxSessions`'s body so we only inspect that method.
+	const startMarker = "private async recoverSandboxSessions(";
+	const startIdx = src.indexOf(startMarker);
+	assert.ok(startIdx >= 0, "recoverSandboxSessions method not found in session-manager.ts");
+	// Heuristic body slice: take ~2000 chars from the method start, which is
+	// well within its body and well clear of unrelated methods.
+	const body = src.slice(startIdx, startIdx + 2000);
+
+	const hasHelperDefinition = /private\s+(?:async\s+)?_respawnAgentInPlace\s*\(/.test(src);
+	const recoveryUsesHelper = body.includes("_respawnAgentInPlace");
+	const recoverySnapshotsFrame = body.includes("_snapshotStreamingFrameOfReference")
+		|| body.includes("_restartFrameOfReference");
+
+	assert.ok(
+		hasHelperDefinition,
+		"SessionManager._respawnAgentInPlace helper is not defined — sandbox-recovery fix not applied",
+	);
+	assert.ok(
+		recoveryUsesHelper || recoverySnapshotsFrame,
+		"recoverSandboxSessions does not preserve streaming frame-of-reference — sandbox-recovery fix not applied",
+	);
+});

--- a/tests/sandbox-recovery-respawn-helper.test.ts
+++ b/tests/sandbox-recovery-respawn-helper.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Drives the `_respawnAgentInPlace` helper shape against a minimal
+ * SessionManager-like shim (the heavy import chain — flexsearch,
+ * pi-coding-agent, etc. — does not work under tsx --test, so we mirror the
+ * helper's exact body and pin its observable contract).
+ *
+ * What this asserts for the sandbox-recovery shape (NO `_overrideAllowedTools`):
+ *
+ *   1. The streaming frame-of-reference is snapshotted AFTER `unsubscribe()`
+ *      so a final in-flight event can't race past `lastSeq`. (This is the
+ *      "snapshot after unsubscribe" tightening from the goal spec.)
+ *   2. `_restartFrameOfReference` is stashed on the persisted-session record
+ *      before `restoreSession` is invoked.
+ *   3. The cleanup `delete (ps as any)._restartFrameOfReference` and
+ *      `delete (ps as any)._overrideAllowedTools` runs in `finally` even
+ *      when `restoreSession` throws.
+ *   4. Live WS clients are re-attached to the restored session and a
+ *      single `session_status` frame is broadcast — and the new buffer
+ *      seeded via `seedNextSeq(lastSeq + 1)` is what the client sees, so
+ *      `_highestSeq` / `_lastStatusVersion` carry over.
+ *
+ * The helper body in `src/server/agent/session-manager.ts::_respawnAgentInPlace`
+ * is mirrored here verbatim. If the real helper drifts, this test should be
+ * updated to match — the shape is the contract.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { EventBuffer } from "../src/server/agent/event-buffer.ts";
+import { broadcastStatus } from "../src/server/agent/session-status.ts";
+
+const SESSION_MANAGER_PATH = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"..",
+	"src",
+	"server",
+	"agent",
+	"session-manager.ts",
+);
+
+// ---------- Minimal SessionManager shim ----------
+// Mirrors `_respawnAgentInPlace` and the subset of `restoreSession` it needs.
+// Importantly: snapshot is captured AFTER `unsubscribe()` (the timing pin).
+
+interface FakeSession {
+	id: string;
+	status: string;
+	statusVersion: number;
+	clients: Set<any>;
+	eventBuffer: EventBuffer;
+	rpcClient: { stop: () => Promise<void> };
+	unsubscribe: () => void;
+	streamingStartedAt?: number;
+}
+
+interface FakePs {
+	id: string;
+	[k: string]: any;
+}
+
+class FakeManager {
+	sessions = new Map<string, FakeSession>();
+	restoreCalls: Array<{ frameOfRef: any; overrideAllowedTools: any }> = [];
+	restoreThrows = false;
+
+	private _snapshot(s: FakeSession) {
+		return { lastSeq: s.eventBuffer.lastSeq, lastStatusVersion: s.statusVersion ?? 0 };
+	}
+
+	async restoreSession(ps: FakePs): Promise<void> {
+		// Capture what the helper handed us.
+		this.restoreCalls.push({
+			frameOfRef: (ps as any)._restartFrameOfReference,
+			overrideAllowedTools: (ps as any)._overrideAllowedTools,
+		});
+		if (this.restoreThrows) throw new Error("synthetic restore failure");
+
+		// Mirror real restoreSession's seedNextSeq + initialStatusVersion behaviour.
+		const f = (ps as any)._restartFrameOfReference;
+		const buf = new EventBuffer();
+		if (f && Number.isFinite(f.lastSeq) && f.lastSeq > 0) buf.seedNextSeq(f.lastSeq + 1);
+		const statusVersion = f && Number.isFinite(f.lastStatusVersion) ? f.lastStatusVersion : 0;
+
+		const session: FakeSession = {
+			id: ps.id,
+			status: "starting",
+			statusVersion,
+			clients: new Set(),
+			eventBuffer: buf,
+			rpcClient: { stop: async () => {} },
+			unsubscribe: () => {},
+		};
+		this.sessions.set(ps.id, session);
+	}
+
+	async _respawnAgentInPlace(
+		session: FakeSession,
+		ps: FakePs,
+		opts?: { mutatePs?: (ps: FakePs) => void; finalStatus?: string },
+	): Promise<FakeSession | undefined> {
+		const savedClients = new Set(session.clients);
+		session.unsubscribe();
+		const frameOfRef = this._snapshot(session);
+		try { await session.rpcClient.stop(); } catch { /* ignore */ }
+
+		this.sessions.delete(session.id);
+		(ps as any)._restartFrameOfReference = frameOfRef;
+		opts?.mutatePs?.(ps);
+		try {
+			await this.restoreSession(ps);
+		} finally {
+			delete (ps as any)._restartFrameOfReference;
+			delete (ps as any)._overrideAllowedTools;
+		}
+		const restored = this.sessions.get(session.id);
+		if (restored) {
+			for (const ws of savedClients) {
+				if ((ws as any).readyState === 1) restored.clients.add(ws);
+			}
+			(broadcastStatus as any)(restored, opts?.finalStatus ?? "idle");
+		}
+		return restored;
+	}
+}
+
+// Client-side dedup-gate mirror (matches remote-agent.ts shape).
+function makeFakeClient() {
+	const applied: any[] = [];
+	let highestSeq = 0;
+	let lastStatusVersion = -1;
+	let seqInit = false;
+	function onStatus(f: { statusVersion: number; status: string }) {
+		if (f.statusVersion <= lastStatusVersion) return;
+		lastStatusVersion = f.statusVersion;
+		applied.push({ kind: "status", v: f.statusVersion, status: f.status });
+	}
+	function onEvent(seq: number, ev: any) {
+		if (!seqInit) { highestSeq = seq - 1; seqInit = true; }
+		if (seq <= highestSeq) return;
+		if (seq !== highestSeq + 1) return;
+		highestSeq = seq;
+		applied.push({ kind: "event", seq, ev });
+	}
+	function makeWs() {
+		return {
+			readyState: 1,
+			bufferedAmount: 0,
+			send(data: string) {
+				const m = JSON.parse(data);
+				if (m.type === "session_status") onStatus(m);
+				else if (m.type === "event") onEvent(m.seq, m.data);
+			},
+		};
+	}
+	return {
+		makeWs,
+		applied,
+		getHighestSeq: () => highestSeq,
+		getLastStatusVersion: () => lastStatusVersion,
+	};
+}
+
+test("_respawnAgentInPlace (sandbox-recovery shape) carries seq + statusVersion across respawn", async () => {
+	const client = makeFakeClient();
+	const ws = client.makeWs();
+
+	const mgr = new FakeManager();
+	const oldBuf = new EventBuffer();
+	const oldSession: FakeSession = {
+		id: "s1",
+		status: "idle",
+		statusVersion: 0,
+		clients: new Set([ws]),
+		eventBuffer: oldBuf,
+		rpcClient: { stop: async () => {} },
+		unsubscribe: () => {},
+	};
+	mgr.sessions.set("s1", oldSession);
+
+	// Drive the old session: 2 status flips + 10 events.
+	(broadcastStatus as any)(oldSession, "streaming", { streamingStartedAt: 1 });
+	for (let i = 1; i <= 10; i++) {
+		const e = oldBuf.push({ type: "live", i });
+		ws.send(JSON.stringify({ type: "event", data: e.event, seq: e.seq, ts: e.ts }));
+	}
+	(broadcastStatus as any)(oldSession, "idle");
+	assert.equal(client.getHighestSeq(), 10);
+	assert.equal(client.getLastStatusVersion(), 2);
+
+	// Sandbox-recovery shape: NO mutatePs, NO _overrideAllowedTools.
+	const ps: FakePs = { id: "s1" };
+	const restored = await mgr._respawnAgentInPlace(oldSession, ps);
+
+	assert.ok(restored, "restored session present");
+	assert.equal(mgr.restoreCalls.length, 1);
+	assert.deepEqual(
+		mgr.restoreCalls[0].frameOfRef,
+		{ lastSeq: 10, lastStatusVersion: 2 },
+		"frame-of-reference snapshotted from old session and stashed on ps",
+	);
+	assert.equal(
+		mgr.restoreCalls[0].overrideAllowedTools,
+		undefined,
+		"sandbox-recovery shape does not set _overrideAllowedTools",
+	);
+	// Cleanup invariant: both fields cleared in finally.
+	assert.equal((ps as any)._restartFrameOfReference, undefined);
+	assert.equal((ps as any)._overrideAllowedTools, undefined);
+
+	// Restored buffer/session must be primed so client gates keep advancing.
+	// statusVersion was seeded at 2 by restoreSession, then bumped to 3 by the
+	// helper's final `broadcastStatus(restored, "idle")`. Either way it must be
+	// >= the old client's high-water mark (2) so the next bump is accepted.
+	assert.ok(restored!.statusVersion >= 2, `statusVersion seeded from prior frame-of-reference, got ${restored!.statusVersion}`);
+	assert.equal(restored!.clients.has(ws), true, "live WS re-attached");
+
+	// `_respawnAgentInPlace` broadcasts a final "idle" — bumps version 2 -> 3.
+	assert.equal(client.getLastStatusVersion(), 3, "post-respawn idle status applied (3 > 2)");
+
+	// Drive 5 post-recovery events on the new buffer.
+	for (let i = 1; i <= 5; i++) {
+		const e = restored!.eventBuffer.push({ type: "post-recovery", i });
+		ws.send(JSON.stringify({ type: "event", data: e.event, seq: e.seq, ts: e.ts }));
+	}
+	const postEvents = client.applied.filter((m: any) => m.kind === "event" && m.ev.type === "post-recovery");
+	assert.equal(postEvents.length, 5, "all post-recovery events applied (no dropped frames)");
+	assert.equal(client.getHighestSeq(), 15, "11..15 = 5 new events on top of old 10");
+});
+
+test("_respawnAgentInPlace cleans up _restartFrameOfReference + _overrideAllowedTools when restoreSession throws", async () => {
+	const mgr = new FakeManager();
+	mgr.restoreThrows = true;
+	const oldBuf = new EventBuffer();
+	const oldSession: FakeSession = {
+		id: "s2",
+		status: "idle",
+		statusVersion: 0,
+		clients: new Set(),
+		eventBuffer: oldBuf,
+		rpcClient: { stop: async () => {} },
+		unsubscribe: () => {},
+	};
+	mgr.sessions.set("s2", oldSession);
+	const ps: FakePs = { id: "s2" };
+
+	await assert.rejects(
+		() => mgr._respawnAgentInPlace(oldSession, ps, {
+			mutatePs: p => { (p as any)._overrideAllowedTools = ["bash"]; },
+		}),
+		/synthetic restore failure/,
+	);
+
+	assert.equal(
+		(ps as any)._restartFrameOfReference,
+		undefined,
+		"_restartFrameOfReference cleared even when restoreSession throws",
+	);
+	assert.equal(
+		(ps as any)._overrideAllowedTools,
+		undefined,
+		"_overrideAllowedTools cleared even when restoreSession throws",
+	);
+});
+
+test("_respawnAgentInPlace snapshots streaming frame-of-reference AFTER unsubscribe (timing pin)", async () => {
+	// The goal spec tightens timing: snapshot must happen AFTER unsubscribe()
+	// so a final in-flight `agent_end`-style event cannot race past `lastSeq`.
+	// Verify by having `unsubscribe()` push one final event into the buffer
+	// and asserting the snapshot includes it.
+	const mgr = new FakeManager();
+	const oldBuf = new EventBuffer();
+	for (let i = 1; i <= 3; i++) oldBuf.push({ type: "live", i });
+
+	const oldSession: FakeSession = {
+		id: "s3",
+		status: "idle",
+		statusVersion: 0,
+		clients: new Set(),
+		eventBuffer: oldBuf,
+		rpcClient: { stop: async () => {} },
+		unsubscribe: () => {
+			// Simulate one in-flight event that lands during teardown.
+			oldBuf.push({ type: "trailing-end", inflight: true });
+		},
+	};
+	mgr.sessions.set("s3", oldSession);
+
+	const ps: FakePs = { id: "s3" };
+	await mgr._respawnAgentInPlace(oldSession, ps);
+
+	assert.equal(mgr.restoreCalls.length, 1);
+	assert.equal(
+		mgr.restoreCalls[0].frameOfRef.lastSeq,
+		4,
+		"snapshot taken AFTER unsubscribe — includes trailing in-flight event (lastSeq=4 not 3)",
+	);
+});
+
+test("real _respawnAgentInPlace exists in session-manager.ts and matches the shim's contract", () => {
+	// Sanity pin against the real source: the helper must be defined and the
+	// known callsites (restartAgent, _restartSessionWithUpdatedRole,
+	// recoverSandboxSessions, ensureSessionAlive) must route through it.
+	const src = readFileSync(SESSION_MANAGER_PATH, "utf8");
+
+	assert.ok(
+		/private\s+(?:async\s+)?_respawnAgentInPlace\s*\(/.test(src),
+		"SessionManager._respawnAgentInPlace must be defined",
+	);
+
+	for (const callsite of [
+		"private async _restartSessionWithUpdatedRole(",
+		"async restartAgent(",
+		"private async recoverSandboxSessions(",
+		"async ensureSessionAlive(",
+	]) {
+		const i = src.indexOf(callsite);
+		assert.ok(i >= 0, `callsite ${callsite} not found`);
+		const rest = src.slice(i + callsite.length);
+		const endRel = rest.search(/\n\t(?:\/\*\*|private |async |public |constructor)/);
+		const body = rest.slice(0, endRel >= 0 ? endRel : 4000);
+		assert.ok(
+			body.includes("_respawnAgentInPlace"),
+			`${callsite.trim()} must route through _respawnAgentInPlace`,
+		);
+	}
+});


### PR DESCRIPTION
## Summary

Fixes a silent UI freeze that occurred when a project's Docker container was recreated (daemon restart, OOM-kill, manual `docker rm -f`, or sandbox health-check respawn). The chat appeared frozen until the user reloaded the page.

## Root cause

PRs #500 (`unify-session-status`) and #529 (`restart-preserves-streaming-frame`) introduced two monotonic dedup gates on the client (`_highestSeq`, `_lastStatusVersion`) and a server-side carry-over mechanism (`_snapshotStreamingFrameOfReference` + `EventBuffer.seedNextSeq` + `SessionInfo.statusVersion`) for two in-place agent-respawn paths. `SessionManager.recoverSandboxSessions` is a **third** in-place respawn path that was missed — it called `restoreSession` without stashing `_restartFrameOfReference`, so the new buffer started at `seq=1` and every post-recovery frame was silently dropped by the still-attached client.

## Fix

Extracted `SessionManager._respawnAgentInPlace(session, ps, opts?)` — a single private helper that owns the snapshot/unsubscribe/stop/restore/re-attach/broadcast dance. Routed four call sites through it:

1. `restartAgent` — manual / dead-process restart.
2. `_restartSessionWithUpdatedRole` — tool-grant / role-change restart.
3. `recoverSandboxSessions` — Docker container recreation (the bug fix).
4. `ensureSessionAlive` — in-memory branch only; cold restore still calls `restoreSession` directly.

Bonus correctness improvement: the frame-of-reference is now snapshotted **after** `unsubscribe()` so a final in-flight `agent_end` cannot race past `lastSeq` and skip carry-over. This tightens the existing two patched sites too.

`restoreOneSession` (boot) and `addClient` dormant-revive correctly do NOT route through the helper — they have no live WS clients and a fresh `_highestSeq=0` baseline.

## Tests

- `tests/sandbox-recovery-preserves-streaming-frame.test.ts` — pure-unit regression pin (broken vs fixed paths).
- `tests/sandbox-recovery-respawn-helper.test.ts` — drives `_respawnAgentInPlace` against a fake `SessionInfo` + fake client; asserts seq + statusVersion carry-over for the sandbox-recovery shape; pins post-`unsubscribe()` snapshot timing and throw-cleanup.
- `tests/manual-integration/sandbox-recovery-frame-continuity.spec.ts` — end-to-end with real Docker; kills the project container mid-session and asserts the still-attached WS client receives post-recovery frames.
- Existing `tests/restart-preserves-streaming-frame.test.ts` unchanged and still passing.

## Docs

- `docs/design/sandbox-recovery-frame-of-reference.md` — design doc explaining the invariant, the four routed sites, why others are excluded, and the post-`unsubscribe()` snapshot timing.
- `AGENTS.md` — one-line debugging entry + one-line recipes entry.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)