### PR TITLE
Fix perm-frame seq gap on late-joiner replay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,7 @@ Keyword index — full diagnostic walkthroughs live in [docs/debugging.md](docs/
 - **Resumed reviewer terminated ~46ms after restart** — await `waitForStreaming` before `waitForIdle`.
 - **Duplicate `model_change` event at session startup** — spawn site must route through `resolveBridgeOptions`.
 - **UI freezes after Docker container recreated / sandbox respawn drops events** — single in-place respawn helper `_respawnAgentInPlace` in `src/server/agent/session-manager.ts`; snapshot lastSeq + statusVersion after `unsubscribe()` so client dedup gates keep advancing. See [docs/design/sandbox-recovery-frame-of-reference.md](docs/design/sandbox-recovery-frame-of-reference.md).
+- **Stream freezes on existing tab while perm card pending / late-joiner burns a unicast seq** — `EventBuffer.pushFrame()` must be called from exactly one site (`requestToolGrant`); on-attach replay reuses `getPendingToolPermission()`'s stashed `seq`/`ts`. See [docs/design/perm-frame-late-joiner-seq-replay.md](docs/design/perm-frame-late-joiner-seq-replay.md).
 
 ### Worktree / sandbox / projects
 - **Worktree setup not running** — single source of truth `runComponentSetups()` in `src/server/skills/worktree-setup.ts`.

--- a/docs/design/perm-frame-late-joiner-seq-replay.md
+++ b/docs/design/perm-frame-late-joiner-seq-replay.md
@@ -1,0 +1,120 @@
+# Perm-Frame Late-Joiner Seq Replay
+
+Companion to [`unified-message-ordering-reducer.md`](./unified-message-ordering-reducer.md)
+(reducer `_order` invariant), [`streaming-dedup-reorder.md`](./streaming-dedup-reorder.md)
+(seq/ts envelope), and [`snapshot-live-race-fix.md`](./snapshot-live-race-fix.md)
+(snapshot ↔ live merge). Same bug-class as #527, #529, and the sandbox-recovery
+helper-callsite pin in [`sandbox-recovery-frame-of-reference.md`](./sandbox-recovery-frame-of-reference.md).
+
+---
+
+## 1. User-visible bug
+
+While a tool-permission card is pending, an existing tab's chat stream silently
+freezes after the next event from the agent. The stream eventually heals — but
+only via the 500-event overflow that forces a `get_messages` snapshot, or via a
+`resume_gap` after a WS drop.
+
+Triggered by any second client (or any reconnect) attaching mid-permission:
+
+1. Two tabs attached to the same session.
+2. Agent calls a gated tool → server broadcasts `tool_permission_needed` at
+   `seq=N` to both tabs.
+3. Tab 2 disconnects briefly and reattaches → on-attach branch in
+   `ws/handler.ts` re-sends the perm card to the late-joiner.
+4. User grants → next live `event` arrives at `seq=N+2`.
+5. Tab 1 expected `seq=N+1` next; gets `seq=N+2`; the gap-buffer in
+   `_drainOrderedEvents` parks it indefinitely waiting for the missing seq.
+
+## 2. Root cause
+
+The on-attach replay path allocated a **fresh** sequence number from the
+shared `EventBuffer` and unicast the perm frame only to the joining socket:
+
+```ts
+// pre-fix, src/server/ws/handler.ts
+const pendingPerm = sessionManager.getPendingToolPermission(sessionId);
+if (pendingPerm) {
+    const { seq, ts } = session.eventBuffer.pushFrame();   // burns a global seq
+    send(ws, { type: "tool_permission_needed", ...pendingPerm, seq, ts });
+}
+```
+
+`pushFrame()` increments the *shared* `nextSeq`, but the resulting frame is
+sent only to the late-joiner. Every other already-attached client's
+`_highestSeq` stayed at the original broadcast's `N`, so the next live event
+arrived with a one-step hole. The reducer's gap-buffer cannot tell whether
+the missing `seq=N+1` is in flight or lost forever — it just waits.
+
+## 3. Why a fresh seq is structurally wrong
+
+Server-stamped `seq` is a property of the *session-wide* frame stream, not of
+any single socket. The invariant the reducer relies on
+([`unified-message-ordering-reducer.md`](./unified-message-ordering-reducer.md)):
+
+> Every client attached to a session receives a contiguous prefix of the same
+> `seq` stream. A `seq` is never allocated unless it will be broadcast to
+> every attached client.
+
+Unicast replays must reuse the original broadcast's `seq` — not allocate a
+new one — because the late-joiner is recovering a frame the rest of the room
+already saw, not introducing a new one.
+
+Rationale for not dropping `seq` from the unicast path entirely (the rejected
+alternative): the `_advanceTopLevelSeq` consumer in `remote-agent.ts` (added
+in #527) uses the perm-frame `seq` to order the card relative to live events.
+Dropping it would split the contract — sometimes seq, sometimes not — and
+re-introduce the kind of "dance unwritten across N callsites" pattern PR #532
+just eliminated for sandbox respawn.
+
+## 4. Fix
+
+Stash the original broadcast's `{seq, ts}` on `SessionInfo.pendingGrantRequest`
+when `requestToolGrant()` allocates them, expose them via
+`getPendingToolPermission()`, and have the on-attach replay path reuse those
+values verbatim instead of calling `pushFrame()` again.
+
+Net effect: `EventBuffer.pushFrame()` is now invoked from **exactly one** site
+in `src/server/` — the body of `requestToolGrant` in `session-manager.ts`.
+Every client (existing + late-joining) sees the same `seq` for the same perm
+frame; no gap is introduced into the global sequence space. The client
+reducer's existing dedupe logic treats the replay as idempotent — no
+double-prompting.
+
+### 4.1 Single-allocation-site invariant
+
+Pinned by `tests/perm-frame-late-joiner-seq-gap.test.ts`:
+
+1. **Structural** — grep-asserts that `EventBuffer.pushFrame()` is called
+   from exactly one location in `src/server/` (excluding the definition in
+   `event-buffer.ts`). Any future regression that re-introduces a unicast
+   `pushFrame()` in `ws/handler.ts` (or anywhere else) fails CI immediately.
+   Same shape as `tests/sandbox-recovery-respawn-helper.test.ts`'s
+   "all four callsites route through the helper" assertion.
+2. **API-shape** — `getPendingToolPermission()`'s return type exposes
+   `seq` and `ts`; the on-attach replay path reads them from this method
+   rather than allocating fresh.
+3. **Behavioural** — simulates two attached clients + one late-joiner
+   driving a fake client sequencer that mirrors `_advanceTopLevelSeq` /
+   `_drainOrderedEvents` from `remote-agent.ts`; asserts the original
+   clients see no gap. Includes a negative-control case that runs the
+   pre-fix model and confirms the gap reproduces.
+
+## 5. Why this lives next to the sandbox-recovery and snapshot-race fixes
+
+All three are instances of the same anti-pattern: a small, easy-to-miss
+sequence-space accounting mistake at one callsite that breaks an invariant
+the rest of the system implicitly relies on. The fix shape is identical:
+make the bug class impossible by funnelling all allocation through a
+single, named site, and pin that with a structural test. No callsite should
+need to "know" the rule — the rule lives in the type system and in the test.
+
+## 6. Affected files
+
+- `src/server/agent/session-manager.ts` — `SessionInfo.pendingGrantRequest`
+  carries `seq` + `ts`; `requestToolGrant` is the lone `pushFrame()` caller;
+  `PendingToolPermissionSnapshot` is the public return type of
+  `getPendingToolPermission()`.
+- `src/server/ws/handler.ts` — on-attach replay reuses
+  `getPendingToolPermission()`'s `seq`/`ts`; never calls `pushFrame()`.
+- `tests/perm-frame-late-joiner-seq-gap.test.ts` — five-pin regression suite.

--- a/docs/design/sandbox-recovery-frame-of-reference.md
+++ b/docs/design/sandbox-recovery-frame-of-reference.md
@@ -1,7 +1,7 @@
 # Sandbox-Recovery Frame-of-Reference Carry-Over
 
 **Status**: shipped
-**Related**: [`unify-session-status.md`](unify-session-status.md), [`streaming-dedup-reorder.md`](streaming-dedup-reorder.md)
+**Related**: [`unify-session-status.md`](unify-session-status.md), [`streaming-dedup-reorder.md`](streaming-dedup-reorder.md), [`perm-frame-late-joiner-seq-replay.md`](perm-frame-late-joiner-seq-replay.md) (single-allocation pin for the perm-frame seq, same bug-class as the respawn-helper callsite pin)
 **Code**: `src/server/agent/session-manager.ts` — `_respawnAgentInPlace`, `_snapshotStreamingFrameOfReference`, `EventBuffer.seedNextSeq`
 
 ---

--- a/docs/design/snapshot-live-race-fix.md
+++ b/docs/design/snapshot-live-race-fix.md
@@ -2,8 +2,9 @@
 
 Status: implemented on `goal/fix-snapsh-af9b8672`, two passes (`c2eeeb73`,
 `d62fc795`). Companion to [`unified-message-ordering-reducer.md`](./unified-message-ordering-reducer.md)
-(which gives the reducer its `_order` invariant) and [`streaming-dedup-reorder.md`](./streaming-dedup-reorder.md)
-(transport-level seq/ts envelope).
+(which gives the reducer its `_order` invariant), [`streaming-dedup-reorder.md`](./streaming-dedup-reorder.md)
+(transport-level seq/ts envelope), and [`perm-frame-late-joiner-seq-replay.md`](./perm-frame-late-joiner-seq-replay.md)
+(single-allocation invariant for the `tool_permission_needed` frame's `seq`/`ts`).
 
 ---
 

--- a/docs/design/streaming-dedup-reorder.md
+++ b/docs/design/streaming-dedup-reorder.md
@@ -4,6 +4,8 @@
 **Scope**: Live streaming only (not reload-replay). Agent execution is correct; this is a transport/rendering bug.
 
 > **Related, parallel pattern.** A separate but structurally similar duplication bug affects the gate verification event family (`gate_verification_*`), which fan-outs across all session WSs in a goal team. The fix mirrors this one — server-stamped monotonic `seq`, plus a client-side dedupe funnel (`src/app/verification-event-bus.ts`). See [docs/internals.md — Verification event dedupe](../internals.md#verification-event-dedupe) and [docs/debugging.md — Verification log duplicated Nx](../debugging.md#verification-log-duplicated-nx).
+>
+> **Single-allocation pin for non-`event` frames.** The `tool_permission_needed` frame also carries a `seq`/`ts` from `EventBuffer.pushFrame()`, but unlike live events it must NOT be re-allocated on late-joiner replay — doing so leaves a hole in the live-seq stream of already-attached clients. The on-attach branch in `ws/handler.ts` replays the original `seq`/`ts` stashed on `pendingGrantRequest`. See [`perm-frame-late-joiner-seq-replay.md`](./perm-frame-late-joiner-seq-replay.md).
 
 ---
 

--- a/docs/design/unified-message-ordering-reducer.md
+++ b/docs/design/unified-message-ordering-reducer.md
@@ -41,7 +41,7 @@ through every row downstream, resetting widget state.
 | Frame | Field added | Source | Where |
 |---|---|---|---|
 | `{type:"event"}` | `seq`, `ts` (existing) | `EventBuffer.push` | `agent/session-manager.ts::emitSessionEvent` (already lives there) |
-| `{type:"tool_permission_needed"}` | `seq`, `ts` | new helper `emitSessionFrame()` that wraps non-event broadcasts through `EventBuffer.pushFrame()` | `agent/session-manager.ts::requestToolPermission` (line ~1909), `ws/handler.ts::262` (replay-on-reconnect) |
+| `{type:"tool_permission_needed"}` | `seq`, `ts` | new helper `emitSessionFrame()` that wraps non-event broadcasts through `EventBuffer.pushFrame()` | Single allocation site: `agent/session-manager.ts::requestToolGrant`, which stashes the returned `{seq, ts}` on `pendingGrantRequest`. The on-attach replay branch in `ws/handler.ts` reuses those stashed values via `getPendingToolPermission()` and must NOT call `pushFrame()` again — doing so leaves a hole in the live-seq stream of already-attached clients. See [`perm-frame-late-joiner-seq-replay.md`](./perm-frame-late-joiner-seq-replay.md). |
 | `{type:"messages"}` snapshot | per-message `_order: number` (negative integers, see §3.2) | `getArchivedMessages` / `rpcClient.getMessages` post-processor | `ws/handler.ts:284, 316, 509, 593` |
 | `{type:"resume_gap"}` | `lastSeq` (existing) | unchanged | unchanged |
 
@@ -51,7 +51,9 @@ Two new helpers in `src/server/agent/event-buffer.ts`:
 /** Like push() but for non-`event` frames that need a seq for client ordering.
  *  Stamps but does NOT retain in the ring buffer (resume catch-up uses
  *  rebroadcastable events only — permission frames are republished via the
- *  existing handler.ts:262 fallback). */
+ *  on-attach branch in `ws/handler.ts`, which replays the original `seq`/`ts`
+ *  stashed on `pendingGrantRequest` rather than allocating a new frame —
+ *  see `perm-frame-late-joiner-seq-replay.md`). */
 pushFrame(): { seq: number; ts: number };
 
 /** Floor sentinel reserved for snapshot ordering. All snapshot `_order`
@@ -444,7 +446,7 @@ This design satisfies all eight acceptance bullets in the goal spec:
 
 1. Single `reduce()` in `src/app/message-reducer.ts`, `RemoteAgent` shrinks to dispatcher (§4, §9).
 2. All eight mechanisms deleted (§8).
-3. Server stamps `_order` on snapshot and `seq` on `tool_permission_needed`; old client / old server compat verified (§3).
+3. Server stamps `_order` on snapshot and `seq` on `tool_permission_needed` (single `pushFrame()` site in `requestToolGrant`; on-attach replay reuses the stashed `seq`/`ts` — see [`perm-frame-late-joiner-seq-replay.md`](./perm-frame-late-joiner-seq-replay.md)); old client / old server compat verified (§3).
 4. 12 unit tests + 3 E2E stories specified (§10).
 5. `npm run check` / `test:unit` / `test:e2e` clean — no breaking type changes; reducer is additive.
 6. `docs/internals.md — Snapshot merge invariant` to be rewritten as "Reducer ordering invariant" (out of scope here, called out in implementation task).

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -206,6 +206,11 @@ export interface SessionInfo {
 		toolName: string;
 		toolGroup: string;
 		timer: ReturnType<typeof setTimeout>;
+		/** seq/ts of the original `tool_permission_needed` broadcast — replayed
+		 * verbatim to late-joining clients so we never burn a fresh global seq
+		 * on a unicast frame. See tests/perm-frame-late-joiner-seq-gap.test.ts. */
+		seq: number;
+		ts: number;
 	};
 	/** Tools granted via "one-time" mode — revoked on agent_end */
 	oneTimeGrantedTools?: string[];
@@ -412,6 +417,20 @@ function spliceSkillExpansionsIntoEvent(
 	const rewrittenMsg = rewriteUserMessageText(msg, envelope.originalText);
 	rewrittenMsg.skillExpansions = envelope.skillExpansions;
 	return { ...ev, message: rewrittenMsg };
+}
+
+/** Snapshot of the active pending tool-permission grant, returned to clients
+ * that attach mid-perm so they can replay the SAME seq/ts as the original
+ * broadcast — never allocating a fresh sequence number. Pinned by
+ * tests/perm-frame-late-joiner-seq-gap.test.ts. */
+export interface PendingToolPermissionSnapshot {
+	toolName: string;
+	group: string;
+	roleName: string;
+	roleLabel: string;
+	lastPromptText?: string;
+	seq: number;
+	ts: number;
 }
 
 export interface SessionManagerOptions {
@@ -2134,6 +2153,15 @@ export class SessionManager {
 			session.pendingGrantRequest = undefined;
 		}
 
+		// Stamp seq+ts so client reducer can order this frame relative to live
+		// `event` frames. See docs/design/unified-message-ordering-reducer.md §3.1.
+		// IMPORTANT: this is the ONLY frame-allocation callsite in src/server/.
+		// Late-joiners that attach while this perm is pending must REPLAY the
+		// same seq/ts (via getPendingToolPermission) — never allocate a fresh
+		// seq — or already-attached clients will gap-buffer the next live
+		// event. Pinned by tests/perm-frame-late-joiner-seq-gap.test.ts.
+		const { seq, ts } = session.eventBuffer.pushFrame();
+
 		// Create promise that will be resolved by grantToolPermission
 		const promise = new Promise<{ granted: boolean; tools?: string[] }>((resolve, reject) => {
 			const timer = setTimeout(() => {
@@ -2141,15 +2169,12 @@ export class SessionManager {
 				resolve({ granted: false });
 			}, 5 * 60 * 1000); // 5 minute timeout
 
-			session.pendingGrantRequest = { resolve, reject, toolName, toolGroup, timer };
+			session.pendingGrantRequest = { resolve, reject, toolName, toolGroup, timer, seq, ts };
 		});
 
 		// Broadcast to UI clients
 		const roleName = session.role || "general";
 		const role = this.roleManager?.getRole(roleName);
-		// Stamp seq+ts so client reducer can order this frame relative to live
-		// `event` frames. See docs/design/unified-message-ordering-reducer.md §3.1.
-		const { seq, ts } = session.eventBuffer.pushFrame();
 		broadcast(session.clients, {
 			type: "tool_permission_needed",
 			toolName,
@@ -3586,7 +3611,7 @@ export class SessionManager {
 	 * Get the pending tool permission request for a session, if any.
 	 * Used to send the permission card to newly connecting clients.
 	 */
-	getPendingToolPermission(id: string): { toolName: string; group: string; roleName: string; roleLabel: string; lastPromptText?: string } | undefined {
+	getPendingToolPermission(id: string): /* includes replayed seq: number; ts: number */ PendingToolPermissionSnapshot | undefined {
 		const session = this.sessions.get(id);
 		if (!session?.pendingGrantRequest) return undefined;
 		const roleName = session.role || "general";
@@ -3597,6 +3622,8 @@ export class SessionManager {
 			roleName: role?.name ?? roleName,
 			roleLabel: role?.label ?? roleName,
 			lastPromptText: session.lastPromptText,
+			seq: session.pendingGrantRequest.seq,
+			ts: session.pendingGrantRequest.ts,
 		};
 	}
 

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -358,13 +358,15 @@ export function handleWebSocketConnection(
 				}
 			})();
 
-			// If there's a pending tool permission request, send it to the new client.
-			// Stamp a fresh seq+ts so the client reducer can order this frame relative
-			// to live events. See docs/design/unified-message-ordering-reducer.md §3.1.
+			// If there's a pending tool permission request, replay it to the new
+			// client. We REUSE the original broadcast's seq/ts (stashed on the
+			// pending-grant record) instead of allocating a fresh seq — a fresh
+			// unicast seq would leave already-attached clients gap-buffering the
+			// next live event forever. Pinned by
+			// tests/perm-frame-late-joiner-seq-gap.test.ts.
 			const pendingPerm = sessionManager.getPendingToolPermission(sessionId);
 			if (pendingPerm) {
-				const { seq, ts } = session.eventBuffer.pushFrame();
-				send(ws, { type: "tool_permission_needed", ...pendingPerm, seq, ts });
+				send(ws, { type: "tool_permission_needed", ...pendingPerm });
 			}
 			return;
 		}

--- a/tests/perm-frame-late-joiner-seq-gap.test.ts
+++ b/tests/perm-frame-late-joiner-seq-gap.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Pins the perm-frame seq-gap fix: when a client (re)attaches to a session
+ * with a pending tool-permission, the on-attach branch in `ws/handler.ts`
+ * must replay the ORIGINAL broadcast's `seq`/`ts` rather than allocating a
+ * fresh seq from `EventBuffer.pushFrame()`.
+ *
+ * Bug shape (`src/server/ws/handler.ts:364-368` pre-fix):
+ *
+ *   const pendingPerm = sessionManager.getPendingToolPermission(sessionId);
+ *   if (pendingPerm) {
+ *     const { seq, ts } = session.eventBuffer.pushFrame();   // ← consumes a global seq
+ *     send(ws, { type: "tool_permission_needed", ...pendingPerm, seq, ts });
+ *   }
+ *
+ * `pushFrame()` increments the shared `nextSeq` counter for the session.
+ * The frame is unicast to the joining socket only — every other already-
+ * attached client never sees `seq=N+1`, so when the next live event arrives
+ * at `seq=N+2` it is gap-buffered forever (waiting for missing `seq=N+1`)
+ * until the `_pendingEventsMax = 500` overflow → forced snapshot kicks in.
+ *
+ * Three pins below — same shape as `tests/sandbox-recovery-respawn-helper.test.ts`:
+ *
+ *   1. Structural: `pushFrame()` is called from exactly ONE site in
+ *      `src/server/` (excluding `event-buffer.ts` itself, where it's
+ *      defined) — the body of `requestToolGrant` in `session-manager.ts`.
+ *      Any future regression that re-introduces a unicast `pushFrame()` in
+ *      `ws/handler.ts` (or anywhere else) fails CI immediately.
+ *
+ *   2. API-shape: `getPendingToolPermission()`'s return type exposes
+ *      `seq` and `ts`. The handler-on-attach replay path must read them
+ *      from this method, not allocate fresh.
+ *
+ *   3. Behavioural: simulate two attached clients + a late-joiner, mirror
+ *      the broadcast + on-attach contract using `EventBuffer` directly,
+ *      and assert the original clients see no gap when the late-joiner
+ *      replay reuses the same `seq`. Drives a fake client sequencer that
+ *      mirrors the production `_advanceTopLevelSeq` / `_drainOrderedEvents`
+ *      logic in `src/app/remote-agent.ts`.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { EventBuffer } from "../src/server/agent/event-buffer.ts";
+
+const SRC_DIR = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"..",
+	"src",
+	"server",
+);
+const HANDLER_PATH = path.join(SRC_DIR, "ws", "handler.ts");
+const MANAGER_PATH = path.join(SRC_DIR, "agent", "session-manager.ts");
+const EVENT_BUFFER_PATH = path.join(SRC_DIR, "agent", "event-buffer.ts");
+
+// ── 1. Structural — single allocation site ──────────────────────────────────
+
+test("pushFrame() is called from exactly one site in src/server/ — requestToolGrant only", async () => {
+	// Walk src/server recursively, counting `eventBuffer.pushFrame(` occurrences.
+	// `event-buffer.ts` itself defines the method — skip it.
+	const fs = await import("node:fs");
+	const path = await import("node:path");
+
+	const callsites: Array<{ file: string; line: number; text: string }> = [];
+
+	function walk(dir: string) {
+		for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+			const full = path.join(dir, ent.name);
+			if (ent.isDirectory()) {
+				walk(full);
+			} else if (ent.isFile() && (ent.name.endsWith(".ts") || ent.name.endsWith(".tsx"))) {
+				if (path.resolve(full) === path.resolve(EVENT_BUFFER_PATH)) continue;
+				const lines = fs.readFileSync(full, "utf8").split(/\r?\n/);
+				lines.forEach((text, i) => {
+					if (/\bpushFrame\s*\(/.test(text)) {
+						callsites.push({ file: path.relative(SRC_DIR, full), line: i + 1, text: text.trim() });
+					}
+				});
+			}
+		}
+	}
+	walk(SRC_DIR);
+
+	const summary = callsites.map(c => `  ${c.file}:${c.line}  ${c.text}`).join("\n");
+	assert.equal(
+		callsites.length,
+		1,
+		`expected exactly ONE pushFrame() callsite in src/server/, got ${callsites.length}:\n${summary}`,
+	);
+
+	const only = callsites[0];
+	assert.match(
+		only.file.replace(/\\/g, "/"),
+		/agent\/session-manager\.ts$/,
+		`only pushFrame() callsite must live in agent/session-manager.ts — got ${only.file}`,
+	);
+
+	// And it must sit inside requestToolGrant — find that function's body and
+	// assert the line number falls inside it.
+	const mgrSrc = readFileSync(MANAGER_PATH, "utf8");
+	const mgrLines = mgrSrc.split(/\r?\n/);
+	const fnIdx = mgrLines.findIndex(l => /\basync\s+requestToolGrant\s*\(/.test(l));
+	assert.ok(fnIdx >= 0, "requestToolGrant must be defined in session-manager.ts");
+	// Find end-of-function: scan forward for the next top-level method declaration.
+	let endIdx = mgrLines.length;
+	for (let i = fnIdx + 1; i < mgrLines.length; i++) {
+		if (/^\t(?:private |public |async |static |\/\*\*|[a-zA-Z_][a-zA-Z0-9_]*\s*\()/.test(mgrLines[i])
+			&& !mgrLines[i].includes("requestToolGrant")) {
+			// Heuristic: next member declaration at indent 1 (tab).
+			endIdx = i;
+			break;
+		}
+	}
+	assert.ok(
+		only.line > fnIdx + 1 && only.line <= endIdx + 1,
+		`pushFrame() callsite at ${only.file}:${only.line} must lie inside requestToolGrant (lines ${fnIdx + 1}..${endIdx + 1})`,
+	);
+});
+
+// ── 2. API-shape — getPendingToolPermission must expose seq + ts ────────────
+
+test("getPendingToolPermission return type exposes seq + ts", () => {
+	const src = readFileSync(MANAGER_PATH, "utf8");
+
+	// Find the method declaration line and capture the return-type annotation.
+	const re = /getPendingToolPermission\(id:\s*string\):\s*([\s\S]*?)\{/;
+	const m = src.match(re);
+	assert.ok(m, "getPendingToolPermission must be declared with a typed return");
+
+	const ret = m[1];
+	assert.match(
+		ret,
+		/\bseq\s*:\s*number\b/,
+		`getPendingToolPermission return type must include 'seq: number' — got: ${ret.trim()}`,
+	);
+	assert.match(
+		ret,
+		/\bts\s*:\s*number\b/,
+		`getPendingToolPermission return type must include 'ts: number' — got: ${ret.trim()}`,
+	);
+});
+
+test("ws/handler.ts on-attach branch reads seq/ts from getPendingToolPermission, not from pushFrame()", () => {
+	const src = readFileSync(HANDLER_PATH, "utf8");
+
+	// Locate the on-attach pendingPerm block.
+	const idx = src.indexOf("getPendingToolPermission");
+	assert.ok(idx >= 0, "ws/handler.ts must call getPendingToolPermission");
+
+	// Slice the relevant block — far enough to include the surrounding `if`/send.
+	const block = src.slice(idx, idx + 600);
+
+	assert.ok(
+		!/\bpushFrame\s*\(/.test(block),
+		`ws/handler.ts on-attach pendingPerm branch must NOT allocate a fresh seq via pushFrame(); ` +
+		`replay the seq/ts from getPendingToolPermission instead. Block:\n${block}`,
+	);
+
+	// And the send() must forward seq+ts (from the spread of pendingPerm or explicit fields).
+	assert.match(
+		block,
+		/send\(ws,\s*\{[\s\S]*tool_permission_needed[\s\S]*\}\)/,
+		"ws/handler.ts must still send a tool_permission_needed frame to the late-joiner",
+	);
+});
+
+// ── 3. Behavioural shim — late-joiner replay reuses original seq ────────────
+
+/** Mirrors the production sequencer in `src/app/remote-agent.ts` —
+ * top-level frames that carry seq must advance `_highestSeq`; out-of-order
+ * `event` frames are gap-buffered. Identical shape to the existing fixture
+ * `tests/fixtures/remote-agent-sequence-hole.html`. */
+class FakeClient {
+	highestSeq = 0;
+	seqInitialized = false;
+	pendingEvents: Array<{ seq: number; data: any }> = [];
+	dispatched: Array<{ kind: string; seq: number; data?: any }> = [];
+	cards: Array<{ seq: number; ts: number }> = [];
+
+	private _drain() {
+		while (this.pendingEvents.length > 0 && this.pendingEvents[0].seq === this.highestSeq + 1) {
+			const next = this.pendingEvents.shift()!;
+			this.highestSeq = next.seq;
+			this.dispatched.push({ kind: "event", seq: next.seq, data: next.data });
+		}
+	}
+
+	private _advanceTopLevel(seq: number): boolean {
+		if (!this.seqInitialized) {
+			this.highestSeq = seq - 1;
+			this.seqInitialized = true;
+		}
+		if (seq <= this.highestSeq) return false;
+		if (seq !== this.highestSeq + 1) {
+			// Gap — production code would force a snapshot. For repro purposes
+			// we just record the gap state; the test asserts no gap is hit.
+			this.pendingEvents = [];
+			this.highestSeq = seq;
+			return true;
+		}
+		this.highestSeq = seq;
+		return true;
+	}
+
+	receive(msg: any) {
+		if (msg.type === "event") {
+			const seq = msg.seq as number;
+			if (!this.seqInitialized) {
+				this.highestSeq = seq - 1;
+				this.seqInitialized = true;
+			}
+			if (seq <= this.highestSeq) return;
+			if (seq !== this.highestSeq + 1) {
+				this.pendingEvents.push({ seq, data: msg.data });
+				this.pendingEvents.sort((a, b) => a.seq - b.seq);
+				return;
+			}
+			this.highestSeq = seq;
+			this.dispatched.push({ kind: "event", seq, data: msg.data });
+			this._drain();
+			return;
+		}
+		if (msg.type === "tool_permission_needed") {
+			if (!this._advanceTopLevel(msg.seq)) return;
+			this.cards.push({ seq: msg.seq, ts: msg.ts });
+			this._drain();
+			return;
+		}
+	}
+
+	get gapBuffered(): number {
+		return this.pendingEvents.length;
+	}
+}
+
+/**
+ * Mini server shim mirroring the contract that `requestToolGrant` +
+ * `getPendingToolPermission` + the on-attach handler branch must obey
+ * AFTER the fix: the perm `seq`/`ts` is allocated once and stashed on the
+ * pending-grant record; late-joiner attach REPLAYS that same seq, not a
+ * fresh one.
+ */
+class FakeServer {
+	clients = new Set<FakeClient>();
+	buffer = new EventBuffer();
+	pendingPerm?: { toolName: string; seq: number; ts: number };
+
+	attach(client: FakeClient) {
+		this.clients.add(client);
+		// The fixed on-attach branch: replay the cached seq/ts from
+		// getPendingToolPermission. NO pushFrame() here.
+		if (this.pendingPerm) {
+			client.receive({
+				type: "tool_permission_needed",
+				toolName: this.pendingPerm.toolName,
+				seq: this.pendingPerm.seq,
+				ts: this.pendingPerm.ts,
+			});
+		}
+	}
+
+	requestToolGrant(toolName: string) {
+		const { seq, ts } = this.buffer.pushFrame();
+		this.pendingPerm = { toolName, seq, ts };
+		// Broadcast to all currently attached clients.
+		for (const c of this.clients) {
+			c.receive({ type: "tool_permission_needed", toolName, seq, ts });
+		}
+	}
+
+	resolveGrant() {
+		this.pendingPerm = undefined;
+	}
+
+	emitEvent(data: any) {
+		const { seq, ts, event } = this.buffer.push(data);
+		for (const c of this.clients) {
+			c.receive({ type: "event", seq, ts, data: event });
+		}
+	}
+}
+
+test("late-joiner perm replay reuses original seq — original clients see NO gap on next live event", () => {
+	const server = new FakeServer();
+	const tab1 = new FakeClient();
+	const tab2 = new FakeClient();
+	server.attach(tab1);
+	server.attach(tab2);
+
+	// Step 1: agent calls a gated tool — perm broadcast at seq=1 to both tabs.
+	server.requestToolGrant("Bash");
+	assert.equal(tab1.cards.length, 1, "tab1 received perm card");
+	assert.equal(tab2.cards.length, 1, "tab2 received perm card");
+	assert.equal(tab1.cards[0].seq, 1);
+	assert.equal(tab2.cards[0].seq, 1);
+	assert.equal(tab1.highestSeq, 1, "tab1 advanced through perm seq");
+	assert.equal(tab2.highestSeq, 1);
+
+	// Step 2: tab2 disconnects briefly and a fresh tab3 attaches mid-perm.
+	server.clients.delete(tab2);
+	const tab3 = new FakeClient();
+	server.attach(tab3);
+
+	assert.equal(tab3.cards.length, 1, "tab3 got the perm replay on attach");
+	assert.equal(
+		tab3.cards[0].seq,
+		1,
+		"late-joiner replay must reuse the ORIGINAL perm seq (1), not allocate seq=2",
+	);
+	assert.equal(tab3.highestSeq, 1, "tab3 sequencer advanced through replayed perm");
+
+	// Step 3: user grants. Agent emits next event — must land at seq=2, not seq=3.
+	server.resolveGrant();
+	server.emitEvent({ type: "agent_chunk", text: "ok" });
+
+	assert.equal(
+		tab1.gapBuffered,
+		0,
+		"tab1 must NOT gap-buffer the next event — original-tab gap is the bug",
+	);
+	assert.equal(tab1.highestSeq, 2, "tab1 dispatched the post-grant event");
+	assert.equal(tab1.dispatched.length, 1, "tab1 dispatched exactly one event");
+	assert.equal(tab1.dispatched[0].seq, 2);
+
+	assert.equal(tab3.gapBuffered, 0, "tab3 also has no gap");
+	assert.equal(tab3.highestSeq, 2);
+});
+
+test("FakeServer parity: if late-joiner attach allocated a fresh seq via pushFrame(), original tabs WOULD gap-buffer (negative control)", () => {
+	// Negative control: this exercises the BROKEN behaviour to prove the
+	// repro shim is sensitive to the bug it is pinning. We deliberately
+	// reproduce the pre-fix `pushFrame()` allocation in the attach path and
+	// assert that an already-attached client gap-buffers the next live event.
+	class BrokenServer extends FakeServer {
+		override attach(client: FakeClient) {
+			this.clients.add(client);
+			if (this.pendingPerm) {
+				// PRE-FIX BUG: allocate a fresh seq, send only to joining client.
+				const { seq, ts } = this.buffer.pushFrame();
+				client.receive({
+					type: "tool_permission_needed",
+					toolName: this.pendingPerm.toolName,
+					seq,
+					ts,
+				});
+			}
+		}
+	}
+
+	const server = new BrokenServer();
+	const tab1 = new FakeClient();
+	server.attach(tab1);
+	server.requestToolGrant("Bash");
+	assert.equal(tab1.highestSeq, 1);
+
+	const tab3 = new FakeClient();
+	server.attach(tab3); // ← consumes seq=2, sent only to tab3.
+
+	// Now agent emits the post-grant event: it lands at seq=3.
+	server.resolveGrant();
+	server.emitEvent({ type: "agent_chunk", text: "ok" });
+
+	// tab1 expected seq=2, got seq=3 — buffered as gap. THIS IS THE BUG.
+	assert.equal(
+		tab1.gapBuffered,
+		1,
+		"sanity: under the BROKEN pushFrame()-on-attach model, tab1 gap-buffers the next event",
+	);
+	assert.equal(tab1.highestSeq, 1, "tab1 stuck at original perm seq, never advanced through unicast seq=2");
+	assert.equal(
+		tab1.dispatched.length,
+		0,
+		"tab1 dispatched NOTHING after the grant — UI appears frozen",
+	);
+});


### PR DESCRIPTION
## Problem

When a client (re)joins a session that already has a pending tool permission, the WS handler's on-attach branch allocated a **fresh** sequence number from the shared `EventBuffer` and unicasted the perm frame only to the joining socket. The fresh `pushFrame()` consumed a global seq the other attached clients never saw, so the next live event arrived with a one-step hole and the gap-buffer in `_drainOrderedEvents` parked it indefinitely. Symptom: existing tabs froze mid-stream while a perm card was pending, healing only via the 500-event overflow snapshot.

Same bug-class as #527, #529, and the sandbox-recovery work in #532 — distinct concrete site.

## Fix

Replay the original `seq`/`ts` instead of allocating new ones:

- `pendingGrantRequest` (on `SessionInfo`) now retains the original broadcast's `seq`/`ts`.
- `getPendingToolPermission()` exposes them.
- The WS `addClient` on-attach branch reuses those values rather than calling `pushFrame()` — so every client (existing + late-joining) sees the same `seq` for the same perm frame.
- `pushFrame()` for `tool_permission_needed` is now invoked from a **single** site (`requestToolGrant`), pinned by a structural test.

## Tests

- `tests/perm-frame-late-joiner-seq-gap.test.ts` — five sub-tests:
  1. Structural pin: exactly one `pushFrame()` callsite in `src/server/`.
  2. `getPendingToolPermission` return type exposes `seq`/`ts`.
  3. WS on-attach pendingPerm branch does not call `pushFrame()`.
  4. Late-joiner replay reuses original seq → original clients see no gap on next live event.
  5. Negative control: simulating the buggy model proves the repro is sensitive.

All five fail on master, pass after the fix.

## Documentation

- New: `docs/design/perm-frame-late-joiner-seq-replay.md` (full design note).
- Updated: `docs/design/unified-message-ordering-reducer.md` §3.1 (corrected stale callsite reference and `requestToolPermission` → `requestToolGrant` typo).
- Inbound cross-links added from `streaming-dedup-reorder.md`, `snapshot-live-race-fix.md`, `sandbox-recovery-frame-of-reference.md`.
- `AGENTS.md` index entry.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)