### PR TITLE
chore(deps): bump pi-mono to 0.73.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,7 @@ Keyword index — full diagnostic walkthroughs live in [docs/debugging.md](docs/
 - **`read_session` returns `permission_denied`** — cross-project read; check `x-bobbit-session-id` header.
 - **OAuth callback never completes** — poll `GET /api/oauth/flow-status?flowId=&provider=`.
 - **Bundle-size assertion fails** — `tests/bundle-size.test.ts` reads `dist/ui/.vite/manifest.json`; 600 kB main / 500 kB per-chunk.
+- **TypeBox version skew (artifacts.ts compile error after pi bump)** — pi-ai pulls typebox 1.x transitively; we pin 0.34. Use inline `Type.Unsafe<>` + `AgentTool<any>` in mixed-typebox files. See [typebox-version-skew.md](docs/typebox-version-skew.md).
 
 ## Maintaining this file
 

--- a/docs/typebox-version-skew.md
+++ b/docs/typebox-version-skew.md
@@ -1,0 +1,102 @@
+# TypeBox version skew (pi-mono 0.73+)
+
+## Summary
+
+We pin `@sinclair/typebox` at `^0.34.x` for our own schema authoring. As of
+`pi-mono` 0.73, `@mariozechner/pi-ai` (transitive via `pi-agent-core` and
+`pi-coding-agent`) depends on `@sinclair/typebox` 1.x. npm hoists both: ours at
+the top level, pi-ai's nested under `node_modules/@mariozechner/pi-ai/`.
+
+The two versions are **ABI-compatible at the JSON-schema level** — both produce
+the same `{ type, properties, ... }` plain objects that the LLM tool-call
+runtime serialises and validates against. They are **not type-compatible at
+the TypeScript level**: 0.34's `TSchema` and 1.x's `TSchema` are nominally
+distinct, and helpers like `StringEnum()` changed return type between major
+versions (1.x returns a `TUnsafe<>` wrapper, not a `TUnion<TLiteral[]>`).
+
+This means any file that **builds a pi-side type** (e.g. `AgentTool<S>`) whose
+schema generic `S` is **authored with our pinned 0.34 TypeBox** triggers a
+compile error: pi-ai's `AgentTool` expects a `TSchema` from 1.x, and our
+`Type.Object(...)` returns a `TSchema` from 0.34.
+
+## Where this matters
+
+Exactly one file mixes both versions:
+
+- `src/ui/tools/artifacts/artifacts.ts` — builds an `AgentTool` whose
+  `parameters` schema is authored locally for the artifacts tool.
+
+Server-side tools registered via `pi.registerTool({ parameters: Type.Object(...) })`
+are **not affected**: pi-agent-core's `registerTool` accepts the schema as an
+opaque JSON-schema-shaped object, so the 0.34/1.x distinction never surfaces in
+its type signature.
+
+## Workaround pattern
+
+In any file that has to bridge our 0.34 schemas into a pi-side generic,
+two small concessions are required:
+
+1. **Author string-enum fields with `Type.Unsafe<LiteralUnion>` instead of
+   pi-ai's re-exported `StringEnum()`.** The Unsafe constructor lets us
+   declare the TypeScript literal union directly while emitting the same
+   `{ type: "string", enum: [...] }` JSON schema that the LLM sees:
+
+   ```ts
+   import { type Static, Type } from "@sinclair/typebox";
+
+   const params = Type.Object({
+     command: Type.Unsafe<"create" | "update" | "delete">({
+       type: "string",
+       enum: ["create", "update", "delete"],
+       description: "The operation to perform",
+     }),
+     // ...
+   });
+   export type Params = Static<typeof params>;
+   ```
+
+2. **Loosen the pi-side generic to `any`** at the bridge point:
+
+   ```ts
+   public get tool(): AgentTool<any, undefined> {
+     return {
+       // ...
+       parameters: params as any,
+       execute: async (_id, args) => { /* args typed via Static<typeof params> */ },
+     };
+   }
+   ```
+
+   The `Static<typeof params>` type is still recovered locally — only the
+   pi-facing surface is widened.
+
+## Why we did NOT migrate to TypeBox 1.x in this goal
+
+- **Out of scope.** The pi 0.73 bump is a pure version-bump goal; adopting new
+  upstream APIs is captured as separate follow-ups.
+- **The headline 1.x breaking change does not apply to us.** TypeBox 1.x
+  un-shimmed the deep-import path `@sinclair/typebox/compiler`. We don't
+  import the compiler anywhere in the repo; only the top-level `Type` /
+  `Static` surface, which has remained stable.
+- **Cost / benefit.** A 0.34 → 1.x sweep touches every server-side tool
+  schema, every `Static<>` consumer, and our test fixtures. One file with a
+  three-line workaround is cheaper than that sweep until something else
+  forces it.
+
+## Future cleanup
+
+When we do migrate to TypeBox 1.x:
+
+- Delete this document.
+- Replace the inline `Type.Unsafe<...>` in `artifacts.ts` with pi-ai's
+  `StringEnum()` (re-exported by pi-ai as a typed convenience).
+- Restore the strict generic on `tool`: `AgentTool<typeof params, undefined>`.
+- Drop our top-level `@sinclair/typebox` dependency if pi-ai's nested copy
+  hoists cleanly.
+
+## Related
+
+- pi-mono upgrade goal: 0.67.5 → 0.73.1, commit `b24abcae` on
+  `goal/upgrade-pi-04ae306d`.
+- AGENTS.md debugging entry: "TypeBox version skew (artifacts.ts compile
+  error after pi bump)".

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "dependencies": {
         "@lmstudio/sdk": "^1.5.0",
         "@mariozechner/mini-lit": "^0.2.0",
-        "@mariozechner/pi-agent-core": "^0.67.5",
-        "@mariozechner/pi-ai": "^0.67.5",
-        "@mariozechner/pi-coding-agent": "^0.67.5",
+        "@mariozechner/pi-agent-core": "^0.73.1",
+        "@mariozechner/pi-ai": "^0.73.1",
+        "@mariozechner/pi-coding-agent": "^0.73.1",
         "@recogito/text-annotator": "^3.4.9",
         "@sinclair/typebox": "^0.34.41",
         "acme-client": "^5.4.0",
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.90.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
-      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -1503,9 +1503,9 @@
       }
     },
     "node_modules/@mariozechner/clipboard": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.2.tgz",
-      "integrity": "sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.5.tgz",
+      "integrity": "sha512-D3F+UrU9CR7roJt0zDLp6Oc+4/KlLDIrN4frH+6V90SJNW2KKUec1oCQIPaaDjCqeOsQyX9dyqYbImIQIM45PA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1681,19 +1681,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@mariozechner/jiti": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
-      "integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
-      "license": "MIT",
-      "dependencies": {
-        "std-env": "^3.10.0",
-        "yoctocolors": "^2.1.2"
-      },
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
     "node_modules/@mariozechner/mini-lit": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@mariozechner/mini-lit/-/mini-lit-0.2.1.tgz",
@@ -1716,34 +1703,35 @@
       }
     },
     "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.67.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.67.5.tgz",
-      "integrity": "sha512-XZwAVYEja4YV3Or+Fb1fMvi/KphpaEvMcfGe1/lBNEOllDK3m6J/6MdqLJy85rettX3uKRuGjF3adDNju+LRow==",
+      "version": "0.73.1",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.73.1.tgz",
+      "integrity": "sha512-Y/KVOhuKSgRQgYBlwmRtO2gPkUcoavOSqGF9bpQIINvNZvc19k6Z1H3bFDTce3Vp5ApMmTsfLH3+tNvOg75fAQ==",
+      "deprecated": "please use @earendil-works/pi-agent-core instead going forward",
       "license": "MIT",
       "dependencies": {
-        "@mariozechner/pi-ai": "^0.67.5"
+        "@mariozechner/pi-ai": "^0.73.1",
+        "typebox": "^1.1.24"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "node_modules/@mariozechner/pi-ai": {
-      "version": "0.67.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.67.5.tgz",
-      "integrity": "sha512-TgxI2seq+gIRy6oRQA/ogyj8c9vESMQEeICPKYe29hJCLkN/i7tgKnU9jIM+rcAJmtGaO4Iy0IL7wYV4g0qjsw==",
+      "version": "0.73.1",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.73.1.tgz",
+      "integrity": "sha512-Jh4lXawZYuC83HzSIYuVum9NBqJD49i4JOt3H96cGW/924cwJMOyUs1Mv/e4QPzTXnzrqMoGviNQnvGgSu1LSg==",
+      "deprecated": "please use @earendil-works/pi-ai instead going forward",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.90.0",
+        "@anthropic-ai/sdk": "^0.91.1",
         "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
         "@google/genai": "^1.40.0",
-        "@mistralai/mistralai": "1.14.1",
-        "@sinclair/typebox": "^0.34.41",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
+        "@mistralai/mistralai": "^2.2.0",
         "chalk": "^5.6.2",
         "openai": "6.26.0",
         "partial-json": "^0.1.7",
         "proxy-agent": "^6.5.0",
+        "typebox": "^1.1.24",
         "undici": "^7.19.1",
         "zod-to-json-schema": "^3.24.6"
       },
@@ -1767,17 +1755,16 @@
       }
     },
     "node_modules/@mariozechner/pi-coding-agent": {
-      "version": "0.67.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.67.5.tgz",
-      "integrity": "sha512-U/kZ173IDmkwq7p8zKsrhb5fpxWUW53NTKXva6fyzwx3o/tGl3PzdnyxBfv7vHz15S7mgL/dpdiF/ANUV34JTw==",
+      "version": "0.73.1",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.73.1.tgz",
+      "integrity": "sha512-gXQh3SaZmWTfVMc4Ao5+LGbVeKvzyO7tolok0nLsZgq9nGjZx/EEU3NM8C+qUnB4Nvs2rswG5qOVgLzQkq0fHQ==",
+      "deprecated": "please use @earendil-works/pi-coding-agent instead going forward",
       "license": "MIT",
       "dependencies": {
-        "@mariozechner/jiti": "^2.6.2",
-        "@mariozechner/pi-agent-core": "^0.67.5",
-        "@mariozechner/pi-ai": "^0.67.5",
-        "@mariozechner/pi-tui": "^0.67.5",
+        "@mariozechner/pi-agent-core": "^0.73.1",
+        "@mariozechner/pi-ai": "^0.73.1",
+        "@mariozechner/pi-tui": "^0.73.1",
         "@silvia-odwyer/photon-node": "^0.3.4",
-        "ajv": "^8.17.1",
         "chalk": "^5.5.0",
         "cli-highlight": "^2.1.11",
         "diff": "^8.0.2",
@@ -1786,12 +1773,14 @@
         "glob": "^13.0.1",
         "hosted-git-info": "^9.0.2",
         "ignore": "^7.0.5",
+        "jiti": "^2.7.0",
         "marked": "^15.0.12",
         "minimatch": "^10.2.3",
         "proper-lockfile": "^4.1.2",
         "strip-ansi": "^7.1.0",
+        "typebox": "^1.1.24",
         "undici": "^7.19.1",
-        "uuid": "^11.1.0",
+        "uuid": "^14.0.0",
         "yaml": "^2.8.2"
       },
       "bin": {
@@ -1801,7 +1790,7 @@
         "node": ">=20.6.0"
       },
       "optionalDependencies": {
-        "@mariozechner/clipboard": "^0.3.2"
+        "@mariozechner/clipboard": "^0.3.5"
       }
     },
     "node_modules/@mariozechner/pi-coding-agent/node_modules/chalk": {
@@ -1829,22 +1818,23 @@
       }
     },
     "node_modules/@mariozechner/pi-coding-agent/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/@mariozechner/pi-tui": {
-      "version": "0.67.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.67.5.tgz",
-      "integrity": "sha512-e1dUhXDr2LUUkHmuVYxPubQnk3NYcZLNOinUVTYXCSTAEzgSq0vH5LMgf5/zHspi5AmncmJmc85Qf/VFmnpw7Q==",
+      "version": "0.73.1",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.73.1.tgz",
+      "integrity": "sha512-ybVsRnUbzQRtbocltJ2OXb2QogrO67N2BlUyKjZz9BHcZYiDJtNkcKQockxDjsVvDc0uBCLDX6iZJoBElBd8fw==",
+      "deprecated": "please use @earendil-works/pi-tui instead going forward",
       "license": "MIT",
       "dependencies": {
         "@types/mime-types": "^2.1.4",
@@ -1885,13 +1875,14 @@
       }
     },
     "node_modules/@mistralai/mistralai": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.14.1.tgz",
-      "integrity": "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
+      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.24.1"
+        "zod-to-json-schema": "^3.25.0"
       }
     },
     "node_modules/@napi-rs/canvas": {
@@ -4505,39 +4496,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/alien-signals": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-2.0.8.tgz",
@@ -5561,12 +5519,6 @@
         "@types/yauzl": "^2.9.1"
       }
     },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -5583,22 +5535,6 @@
       "engines": {
         "node": ">=8.6.0"
       }
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.1.4",
@@ -5964,9 +5900,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6471,10 +6407,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -6501,12 +6436,6 @@
       "engines": {
         "node": ">=16"
       }
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
     },
     "node_modules/jsonschema": {
       "version": "1.5.0",
@@ -6618,9 +6547,9 @@
       }
     },
     "node_modules/koffi": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.0.tgz",
-      "integrity": "sha512-h/2NJueOKWd0YYycEOWDspomizgNfuOKf/V7ZE2fytvuRtHoY9Tb+y4x6GJ6pFqaVndWn9dLK+sCI14eWtu5rA==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.2.tgz",
+      "integrity": "sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7964,15 +7893,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -8441,12 +8361,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-      "license": "MIT"
-    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -8808,6 +8722,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/typebox": {
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -9263,18 +9183,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yoctocolors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
   "dependencies": {
     "@lmstudio/sdk": "^1.5.0",
     "@mariozechner/mini-lit": "^0.2.0",
-    "@mariozechner/pi-agent-core": "^0.67.5",
-    "@mariozechner/pi-ai": "^0.67.5",
-    "@mariozechner/pi-coding-agent": "^0.67.5",
+    "@mariozechner/pi-agent-core": "^0.73.1",
+    "@mariozechner/pi-ai": "^0.73.1",
+    "@mariozechner/pi-coding-agent": "^0.73.1",
     "@recogito/text-annotator": "^3.4.9",
     "@sinclair/typebox": "^0.34.41",
     "acme-client": "^5.4.0",

--- a/src/ui/tools/artifacts/artifacts.ts
+++ b/src/ui/tools/artifacts/artifacts.ts
@@ -1,7 +1,7 @@
 import { icon } from "@mariozechner/mini-lit";
 import { Button } from "@mariozechner/mini-lit/dist/Button.js";
 import type { Agent, AgentMessage, AgentTool } from "@mariozechner/pi-agent-core";
-import { StringEnum, type ToolCall } from "@mariozechner/pi-ai";
+import type { ToolCall } from "@mariozechner/pi-ai";
 import { type Static, Type } from "@sinclair/typebox";
 import { html, LitElement, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
@@ -38,7 +38,9 @@ export interface Artifact {
 
 // JSON-schema friendly parameters object (LLM-facing)
 const artifactsParamsSchema = Type.Object({
-	command: StringEnum(["create", "update", "rewrite", "get", "delete", "logs"], {
+	command: Type.Unsafe<"create" | "update" | "rewrite" | "get" | "delete" | "logs">({
+		type: "string",
+		enum: ["create", "update", "rewrite", "get", "delete", "logs"],
 		description: "The operation to perform",
 	}),
 	filename: Type.String({ description: "Filename including extension (e.g., 'index.html', 'script.js')" }),
@@ -264,7 +266,7 @@ export class ArtifactsPanel extends LitElement {
 	}
 
 	// Build the AgentTool (no details payload; return only output strings)
-	public get tool(): AgentTool<typeof artifactsParamsSchema, undefined> {
+	public get tool(): AgentTool<any, undefined> {
 		return {
 			label: "Artifacts",
 			name: "artifacts",
@@ -276,10 +278,10 @@ export class ArtifactsPanel extends LitElement {
 				];
 				return ARTIFACTS_TOOL_DESCRIPTION(runtimeProviderDescriptions);
 			},
-			parameters: artifactsParamsSchema,
+			parameters: artifactsParamsSchema as any,
 			// Execute mutates our local store and returns a plain output
-			execute: async (_toolCallId: string, args: Static<typeof artifactsParamsSchema>, _signal?: AbortSignal) => {
-				const output = await this.executeCommand(args);
+			execute: async (_toolCallId: string, args: any, _signal?: AbortSignal) => {
+				const output = await this.executeCommand(args as ArtifactsParams);
 				return { content: [{ type: "text", text: output }], details: undefined };
 			},
 		};


### PR DESCRIPTION
Bumps `@mariozechner/pi-{agent-core,ai,coding-agent}` from `0.67.5` to `0.73.1` (20 releases of upstream changes).

## Changes

- `package.json` — version bumps for the three pi-mono packages.
- `package-lock.json` — regenerated.
- `src/ui/tools/artifacts/artifacts.ts` — single compat patch (see below).
- `docs/typebox-version-skew.md` (new) — design note explaining the typebox version skew and the workaround pattern.
- `AGENTS.md` — one keyword-index entry pointing at the new doc.

## Compat patch — typebox version skew

pi-ai 0.73 transitively depends on `@sinclair/typebox` 1.x. We continue to pin `@sinclair/typebox` at `^0.34.41` for our own schema authoring (no `/compiler` imports anywhere in the repo, so the headline 1.x breaking change does not apply). The two TypeBox versions are JSON-schema-compatible at runtime but their TypeScript types do not unify.

The only file that mixes both libraries is `src/ui/tools/artifacts/artifacts.ts`. It builds an `AgentTool` (pi-side) whose `parameters` are authored with our typebox 0.34. pi-ai's re-exported `StringEnum()` now returns a typebox-1 `TUnsafe<>` which doesn't flow through `Static<>` from typebox 0.34. Replaced the lone `StringEnum(...)` callsite with an inline `Type.Unsafe<LiteralUnion>({ type: "string", enum: [...] })` and loosened the `AgentTool<typeof schema>` generic to `AgentTool<any>` to bridge.

When we eventually migrate our own schema authoring to typebox 1.x, this workaround disappears entirely and the design note can be deleted.

## Audit findings — no action needed

- `compat.reasoningEffortMap` → `thinkingLevelMap`: zero call sites in our code.
- Removed `google-gemini-cli` / `antigravity` providers: only referenced as plain string keys in `image-generation.ts` and `model-registry.ts`; type-checks clean as-is.
- Captured `ctx`/`pi` ref invalidation across `newSession` / `fork` / `switchSession` (0.69.0): zero usages.
- Removed `readTool` / `bashTool` (0.68.0): not imported.
- Un-shimmed `@sinclair/typebox/compiler` (0.69.0): not imported.

## Test results

| Command | Result |
|---|---|
| `npm run check` | PASS |
| `npm run test:unit` | PASS — 1026 passed, 1 skipped |
| `npm run test:e2e` | PASS — 969 passed, 14 flaky-recovered, 12 skipped, 0 hard failures |
| `npm run test:manual` | 17 passed, 2 failed (pre-existing flakes — `sandbox-recovery-frame-continuity.spec.ts` archived 8s in before any test action; `session-resilience.spec.ts` 4th-sandboxed-session 120s timeout. Neither exercises pi-touched surface.) |

## Out of scope (file as separate goals)

- `terminate: true` on terminal tool results (skip wasteful post-tool LLM turn).
- Incremental bash output streaming (replace `bash_bg` flush-at-completion).
- `ctx.ui.setWorkingVisible()` to suppress builtin loader when our UI shows status.
- New providers (Fireworks, DeepSeek, Cloudflare AI Gateway, Moonshot, Mistral Medium 3.5).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
