### PR TITLE
test(manual): fix sandbox-recovery-frame-continuity on Windows

### DIFF
--- a/tests/manual-integration/sandbox-recovery-frame-continuity.spec.ts
+++ b/tests/manual-integration/sandbox-recovery-frame-continuity.spec.ts
@@ -145,6 +145,15 @@ function initRepo(dir: string) {
 	writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "p", version: "1.0.0" }, null, 2));
 	execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore" });
 	execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "ignore" });
+	// Add a real origin so project-sandbox can clone the repo via https inside
+	// the Linux container. Without this, server.ts falls back to repoUrl =
+	// repoPath (a Windows host path like "C:/Users/..."), which git inside
+	// the container interprets as an ssh-style URL because of the colon and
+	// fails with "cannot run ssh: No such file or directory".
+	try {
+		const origin = execFileSync("git", ["remote", "get-url", "origin"], { cwd: PROJECT_ROOT, encoding: "utf-8", timeout: 5_000 }).trim();
+		execFileSync("git", ["remote", "add", "origin", origin], { cwd: dir, stdio: "ignore" });
+	} catch {}
 	const srcConfig = join(PROJECT_ROOT, ".bobbit", "config");
 	const dstConfig = join(dir, ".bobbit", "config");
 	if (existsSync(srcConfig)) {


### PR DESCRIPTION
## Problem

`tests/manual-integration/sandbox-recovery-frame-continuity.spec.ts` was failing on Windows with:

```
Error: Session <id> archived
  at pollIdle (sandbox-recovery-frame-continuity.spec.ts:129:38)
```

The sandboxed session was being archived ~8s after creation instead of reaching `idle`.

## Root cause

`initRepo` in this spec did not configure an `origin` remote on the fixture git repo. When the project sandbox tried to clone the repo into the container, `server.ts` fell back to using the project's host path as the clone URL (`repoUrl = repoPath`). On Windows that path looks like `C:/Users/jsubr/AppData/Local/Temp/.bobbit-recovery-frame-…`, and git inside the Linux container parses `C:/...` as an ssh-style URL because of the colon — then dies:

```
error: cannot run ssh: No such file or directory
fatal: unable to fork
```

That bubbles up as `[sandbox-manager] Failed to init sandbox` → `handleSetupFailure` → session archived → `pollIdle` throws.

## Fix

Mirror the working `initRepo` pattern from `session-resilience.spec.ts`: copy the bobbit project's own `origin` URL onto the test fixture so the sandbox clones over https inside the container.

## Verification

Re-ran the test in isolation — passes in 58.7s, recovery flow exercised end-to-end (pre-kill seq=23/statusVersion=5, post-recovery seq=33/statusVersion=7).

Server-side behaviour unchanged; this is a Windows-specific bug in the test fixture only.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)