### PR TITLE
Harden Stream Watchdog Retries (Bug 1 + Bug 2)

### DIFF
--- a/docs/llm-stream-watchdog.md
+++ b/docs/llm-stream-watchdog.md
@@ -76,14 +76,57 @@ When the watchdog tick observes `awaitingLlmFrame === true` and
    `suppressNextAbortMessageEnd` (drop that abort error frame from the WS
    broadcast), and `suppressNextUserEcho` (drop the SDK's user-echo of the
    re-issued prompt from the WS broadcast).
-3. `rpcClient.abort()` cancels the in-flight request.
-4. On the next tick the watchdog re-issues `lastPromptText` /
-   `lastPromptImages` via `rpcClient.prompt(...)`, refreshes
-   `lastLlmFrameAt`, and re-arms.
+3. `rpcClient.abort()` is **awaited** so the agent fully tears down the
+   in-flight request before any re-dispatch.
+4. The pending re-prompt is stashed on the session as
+   `pendingStallRetry = { text, images, attempt, total }`. The actual
+   `rpcClient.prompt(...)` re-dispatch happens later, from
+   `SessionManager._dispatchPendingStallRetry()` on the next `agent_end`
+   (the same callsite that already runs `shouldSuppressDrainForStallRetry`,
+   guaranteeing the agent is fully wound down). On a successful dispatch
+   the helper `armWatchdogAfterRetry()` refreshes `lastLlmFrameAt`,
+   re-sets `awaitingLlmFrame`, and re-arms the timer.
+
+**Why not `setTimeout(0)`?** The original implementation self-dispatched
+from the watchdog tick via `setTimeout(0)`. In production this raced the
+abort handshake: the SDK was still mid-abort when `prompt()` was called
+and rejected with "Agent is already processing". That rejection was
+swallowed by `.catch(() => {})` while `lastLlmFrameAt` had already been
+refreshed, so the watchdog idled for another full `timeoutMs` waiting for
+frames that would never arrive — silent retries were no-ops. Driving
+re-dispatch from `agent_end` is the same path manual `retryLastPrompt`
+uses, which has always worked. See `_dispatchPendingStallRetry` in
+`src/server/agent/session-manager.ts`.
 
 The session never leaves `streaming`. The transcript shows nothing — silent
 retries are silent on-wire as well as on-screen. See [Suppression contract](#suppression-contract)
 for why both broadcast flags are needed alongside the bookkeeping flag.
+
+### Empty-prompt guard
+
+If `lastPromptText` is missing or empty when a stall is detected, the
+watchdog skips silent retries entirely and goes straight to the surfaced
+path via `surfaceStallNow()`. Re-prompting with `""` would be worse than a
+stall — the agent would either reject it or burn a turn on no input. The
+guard fires on the first stall, not after exhausting retries.
+
+### Dispatch-failure path
+
+If the awaited `rpcClient.prompt(...)` from `_dispatchPendingStallRetry`
+rejects (e.g. the agent died, the sandbox was torn down, or the SDK still
+refuses the prompt for some other reason), the watchdog surfaces
+**immediately** rather than waiting another `timeoutMs` cycle. The manager
+calls `surfaceStallNow(session, cfg, ageMs)` synchronously and then
+broadcasts idle (the `agent_end` suppression branch short-circuited the
+standard idle broadcast, so it has to be issued explicitly). One log line
+is emitted:
+
+```
+[stream-watchdog] session=<id> retry-dispatch failed: <err>
+```
+
+This is greppable as a distinct failure mode from the retry-exhausted
+surface.
 
 ### Surfaced stall (attempt maxRetries + 1)
 
@@ -100,10 +143,17 @@ for why both broadcast flags are needed alongside the bookkeeping flag.
 5. A synthetic `message_end{stopReason:"error", errorMessage:"Model stream
    stalled — no frames for Xs (attempted N× before giving up)."}` is
    broadcast directly via `session.emitSyntheticEvent`, bypassing
-   `handleAgentLifecycle` entirely, so the UI renders the stalled-stream
-   text in the transcript (the UI's `Messages.ts` reads `errorMessage`
-   off the `message_end` frame — `lastTurnErrorMessage` alone is not
-   enough).
+   `handleAgentLifecycle` entirely. The frame carries two fields the UI
+   needs to render the **Retry button** (gated in
+   `src/ui/components/Messages.ts` / `MessageList.ts` on `isLastAssistant
+   && stopReason==="error" && onRetry`):
+   - a stable `id: "stalled-stream-<ts>-<sid>"` so the renderer treats it
+     as a normal assistant message rather than an unkeyed orphan, and
+   - a non-empty `content: [{ type: "text", text: errorMessage }]` chunk.
+   In production both were missing — the synthetic frame had no `id` and
+   `content: []` — and the Retry button silently failed to appear on
+   surfaced stalls. The button has `data-testid="retry-button"` for E2E
+   targeting.
 6. `rpcClient.abort()` runs.
 
 The session leaves `streaming` via the standard idle broadcast and the user
@@ -202,10 +252,16 @@ Every stall emits one greppable line per attempt:
 ```
 [stream-watchdog] session=c3d43268 pid=12345 last-frame-age=30041ms attempt=1/3 — aborting turn
 [stream-watchdog] session=c3d43268 silent-retry 1/2
+[stream-watchdog] session=c3d43268 silent-retry 1/2 succeeded
 [stream-watchdog] session=c3d43268 pid=12345 last-frame-age=30022ms attempt=2/3 — aborting turn
 [stream-watchdog] session=c3d43268 silent-retry 2/2
-[stream-watchdog] session=c3d43268 pid=12345 last-frame-age=30015ms attempt=3/3 — aborting turn
+[stream-watchdog] session=c3d43268 retry-dispatch failed: Agent is already processing
 ```
+
+The `succeeded` line is logged exactly once on the next clean (non-errored,
+non-suppressed) `agent_end` after a retry dispatch resolves —
+`silentRetrySuccessLogPending` is staged in `_dispatchPendingStallRetry`
+and cleared by `onAgentEvent`'s `agent_end` branch so it can't re-fire.
 
 Grep recipes:
 
@@ -216,8 +272,11 @@ grep '\[stream-watchdog\]' server.log
 # Surfaced stalls (3rd+ attempt) for a given session
 grep '\[stream-watchdog\] session=c3d43268.*attempt=3/' server.log
 
-# Sessions that recovered silently (saw a retry but never a surfaced one)
-grep '\[stream-watchdog\]' server.log | grep -v attempt=3/
+# Sessions that recovered silently
+grep '\[stream-watchdog\].*succeeded' server.log
+
+# Retry dispatches that failed (race with abort, dead agent, etc.)
+grep '\[stream-watchdog\].*retry-dispatch failed' server.log
 ```
 
 `pid` is best-effort: it reads through to the production `RpcBridge`'s
@@ -294,6 +353,12 @@ Unit (`tests/llm-stream-watchdog.test.ts`):
   stuck in `aborting`.
 - `end-to-end production-shape flow` — full sequence with the agent's
   real abort frames interleaved.
+- `silent-retry dispatch failure` — rejected re-prompt surfaces
+  immediately, no extra `timeoutMs` cycle.
+- `silent-retry success telemetry` — exactly one `succeeded` line per
+  recovery, cleared after emit.
+- `empty-prompt guard` — empty / undefined `lastPromptText` surfaces on
+  first stall, no `pendingStallRetry`, no `prompt()` call.
 
 E2E (`tests/e2e/ui/llm-stream-watchdog.spec.ts`):
 
@@ -301,3 +366,9 @@ E2E (`tests/e2e/ui/llm-stream-watchdog.spec.ts`):
   unwedges` — drives a real session with a controllable stall, asserts the
   user-visible transcript message and that the session leaves `streaming`
   and accepts a follow-up prompt.
+- `silent retry recovers` — uses the `STREAM_STALL_THEN_REPLY:<ms>`
+  mock-agent directive; asserts `lastTurnErrored=false`, no duplicate user
+  rows, no "Request aborted" rows.
+- `surfaced stall shows a working Retry button` — asserts
+  `getByTestId("retry-button")` is visible and click re-dispatches the
+  original prompt.

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -87,6 +87,8 @@ import {
 	shouldSkipErrorMessageEnd,
 	shouldSuppressUserEchoBroadcast,
 	shouldSuppressAbortBroadcast,
+	armWatchdogAfterRetry,
+	surfaceStallNow,
 } from "./stream-watchdog.js";
 import { ToolRetryHarness } from "./tool-retry-harness.js";
 
@@ -222,6 +224,13 @@ export interface SessionInfo {
 	 *  next `agent_end` consumes this and skips the normal drain/idle-broadcast
 	 *  path so the watchdog can re-dispatch the prompt without the queue racing it. */
 	suppressNextDrainForStallRetry?: boolean;
+	/** Stashed by `stream-watchdog.handleStreamStall` and consumed by this
+	 *  manager's `agent_end` handler, which dispatches the re-prompt only after
+	 *  the agent has fully wound down. See stream-watchdog.ts for the rationale. */
+	pendingStallRetry?: { text: string; images?: any; attempt: number; total: number };
+	/** Set after a successful re-prompt dispatch; logged by `stream-watchdog.onAgentEvent`
+	 *  on the next clean `agent_end` so successful silent recoveries are greppable. */
+	silentRetrySuccessLogPending?: { attempt: number; total: number };
 	/** Pending auto-retry timer, so we can cancel it if the session terminates */
 	pendingAutoRetryTimer?: ReturnType<typeof setTimeout>;
 	/** Whether tool calls were executed during the current/last turn */
@@ -1620,6 +1629,45 @@ export class SessionManager {
 	 * that case remove() is a no-op (returns false), broadcastQueue stays
 	 * idempotent.
 	 */
+	/**
+	 * Dispatch a watchdog-stashed silent-retry re-prompt. Called from the
+	 * `agent_end` handler AFTER the agent has fully wound down, so the
+	 * `prompt()` call is no longer racing the abort handshake's "Agent is
+	 * already processing" window.
+	 *
+	 * On success: arms the watchdog so the next stall can re-fire, and stages
+	 * a success log line for the next clean `agent_end`.
+	 * On failure: surfaces the stall immediately (avoids the pre-fix bug where
+	 * a swallowed rejection would leave the watchdog idling another full
+	 * `timeoutMs` cycle before the next stall could surface). Then propagates
+	 * idle status because the suppression branch in `agent_end` short-circuits
+	 * the usual idle broadcast.
+	 */
+	private async _dispatchPendingStallRetry(
+		session: SessionInfo,
+		pending: NonNullable<SessionInfo["pendingStallRetry"]>,
+	): Promise<void> {
+		const cfg = resolveWatchdogConfigFromEnv();
+		try {
+			await session.rpcClient.prompt(pending.text, pending.images);
+			session.silentRetrySuccessLogPending = { attempt: pending.attempt, total: pending.total };
+			armWatchdogAfterRetry(session, cfg, (id) => this.sessions.has(id));
+		} catch (err) {
+			console.error(
+				`[stream-watchdog] session=${session.id} retry-dispatch failed:`,
+				(err as Error)?.message ?? err,
+			);
+			const ageMs = Date.now() - (session.lastLlmFrameAt ?? Date.now());
+			await surfaceStallNow(session, cfg, ageMs);
+			// Surfacing already set lastTurnErrored / lastTurnErrorMessage and
+			// emitted the synthetic message_end. Now propagate idle status
+			// because the suppression branch in agent_end short-circuited it.
+			session.streamingStartedAt = undefined;
+			this.resolveStoreForSession(session.id).update(session.id, { wasStreaming: false, streamingStartedAt: undefined });
+			broadcastStatus(session, "idle");
+		}
+	}
+
 	private async _dispatchSteer(session: SessionInfo, rows: QueuedMessage[]): Promise<void> {
 		if (rows.length === 0) return;
 		const bg = (this as any).bgProcessManager;
@@ -1979,6 +2027,11 @@ export class SessionManager {
 			// stick in "aborting" forever.
 			if (shouldSuppressDrainForStallRetry(session, wasAborting)) {
 				session.completedTurnCount = (session.completedTurnCount ?? 0) + 1;
+				const pending = session.pendingStallRetry;
+				session.pendingStallRetry = undefined;
+				if (pending) {
+					void this._dispatchPendingStallRetry(session, pending);
+				}
 				return !suppressBroadcast;
 			}
 

--- a/src/server/agent/stream-watchdog.ts
+++ b/src/server/agent/stream-watchdog.ts
@@ -88,6 +88,18 @@ export interface WatchdogSession {
 	lastTurnErrorMessage?: string;
 	lastPromptText?: string;
 	lastPromptImages?: any;
+	/** Stashed by the silent-retry branch of `handleStreamStall` and consumed
+	 *  by the SessionManager's `agent_end` handler. The handler dispatches the
+	 *  re-prompt only AFTER the agent has fully wound down (i.e. emitted
+	 *  `agent_end` for the aborted turn) — this avoids the production race
+	 *  where `setTimeout(0)` schedules the re-prompt before the agent finishes
+	 *  tearing down and `prompt()` rejects with "Agent is already processing".
+	 *  See docs/llm-stream-watchdog.md (Bug 1 hardening). */
+	pendingStallRetry?: { text: string; images?: any; attempt: number; total: number };
+	/** Set by the SessionManager after a successful re-prompt dispatch; logged
+	 *  on the next clean (non-errored) `agent_end` so successful silent
+	 *  recoveries are greppable in the server log. Cleared after logging. */
+	silentRetrySuccessLogPending?: { attempt: number; total: number };
 	/** Broadcast a synthetic agent event to the session's WS clients. Wired
 	 *  by `SessionManager.handleAgentLifecycle` (delegates to `emitSessionEvent`).
 	 *  Used for the surfaced-stall `message_end` so the UI's transcript renders
@@ -144,6 +156,16 @@ export function onAgentEvent(
 			// the counter is reset.
 			if (!session.suppressNextDrainForStallRetry) {
 				session.streamStallRetries = 0;
+				// If a previous silent retry re-dispatched successfully and this
+				// agent_end represents a clean (non-suppressed, non-errored)
+				// turn, log the recovery so successful self-heals are greppable.
+				const pending = session.silentRetrySuccessLogPending;
+				if (pending && !session.lastTurnErrored) {
+					console.log(
+						`[stream-watchdog] session=${session.id} silent-retry ${pending.attempt}/${pending.total} succeeded`,
+					);
+					session.silentRetrySuccessLogPending = undefined;
+				}
 			}
 			return;
 		case "process_exit":
@@ -186,7 +208,7 @@ function ensureTimer(
 export async function handleStreamStall(
 	session: WatchdogSession,
 	cfg: WatchdogConfig,
-	isAlive: IsAliveFn,
+	_isAlive: IsAliveFn,
 ): Promise<void> {
 	const lastFrame = session.lastLlmFrameAt ?? 0;
 	const ageMs = Date.now() - lastFrame;
@@ -205,51 +227,27 @@ export async function handleStreamStall(
 	session.awaitingLlmFrame = false;
 
 	if (attempt > cfg.maxRetries) {
-		// Surface to user. Bump consecutiveErrorTurns by exactly 1 so the
-		// existing implicit-unstick path keeps its semantics (3 surfaced
-		// stalls in a row → next user message is parked).
-		session.streamStallRetries = 0;
-		session.consecutiveErrorTurns = (session.consecutiveErrorTurns ?? 0) + 1;
-		session.lastTurnErrored = true;
-		const errorMessage =
-			`Model stream stalled — no frames for ${Math.round(ageMs / 1000)}s ` +
-			`(attempted ${cfg.maxRetries + 1}× before giving up).`;
-		session.lastTurnErrorMessage = errorMessage;
-		// Suppress the next assistant `message_end` (the abort's "Request
-		// aborted" frame): it would otherwise clobber lastTurnErrorMessage
-		// and double-bump consecutiveErrorTurns. Watchdog owns the
-		// bookkeeping for this transition, end-to-end.
-		session.suppressNextErrorMessageEnd = true;
-		// Also drop the abort's error frame from the WS broadcast — we've
-		// already emitted the user-facing synthetic stalled-stream frame
-		// (below); a trailing "Request aborted" row would visibly duplicate
-		// the surfaced error in the chat transcript.
-		session.suppressNextAbortMessageEnd = true;
-		// Emit a synthetic `message_end` so the UI transcript shows the
-		// stalled-stream text. The UI renders `message.errorMessage` from
-		// `message_end` events (see `src/ui/components/Messages.ts`); without
-		// this synthetic frame the user would see only the generic "Request
-		// aborted" produced by the upstream abort path.
-		try {
-			session.emitSyntheticEvent?.({
-				type: "message_end",
-				message: {
-					role: "assistant",
-					content: [],
-					stopReason: "error",
-					errorMessage,
-				},
-			});
-		} catch { /* best-effort: telemetry only, never block abort */ }
-		try { await session.rpcClient.abort(); } catch { /* best-effort */ }
+		await surfaceStallNow(session, cfg, ageMs);
 		return;
 	}
 
-	// Silent retry: increment counter, abort the underlying request, then
-	// re-issue the same prompt on the next tick. Status stays "streaming"
-	// throughout the retry; the `agent_end` consumer of
-	// `suppressNextDrainForStallRetry` short-circuits the idle-broadcast
-	// + queue-drain so the watchdog is the sole re-dispatcher.
+	// Empty-prompt guard: re-issuing "" is worse than a stall (the agent has
+	// nothing to retry against). Surface immediately instead of looping over
+	// empty prompts.
+	if (!session.lastPromptText || session.lastPromptText.length === 0) {
+		await surfaceStallNow(session, cfg, ageMs);
+		return;
+	}
+
+	// Silent retry: increment counter, set suppression flags, abort the
+	// underlying request, and STASH the retry parameters in
+	// `pendingStallRetry`. The SessionManager's `agent_end` handler dispatches
+	// the re-prompt AFTER the agent has fully wound down — this avoids the
+	// production race where a `setTimeout(0)`-scheduled prompt lands inside
+	// the abort handshake's "Agent is already processing" window and rejects
+	// silently. Status stays "streaming" throughout the retry; the `agent_end`
+	// consumer of `suppressNextDrainForStallRetry` short-circuits the
+	// idle-broadcast + queue-drain so the watchdog is the sole re-dispatcher.
 	session.streamStallRetries = attempt;
 	console.log(
 		`[stream-watchdog] session=${session.id} silent-retry ${attempt}/${cfg.maxRetries}`,
@@ -267,15 +265,79 @@ export async function handleStreamStall(
 	// "Request aborted" rows in the chat transcript.
 	session.suppressNextUserEcho = true;
 	session.suppressNextAbortMessageEnd = true;
+	session.pendingStallRetry = {
+		text: session.lastPromptText,
+		images: session.lastPromptImages,
+		attempt,
+		total: cfg.maxRetries,
+	};
 	try { await session.rpcClient.abort(); } catch { /* best-effort */ }
-	setTimeout(() => {
-		if (!isAlive(session.id)) return;
-		const text = session.lastPromptText ?? "";
-		void session.rpcClient.prompt(text, session.lastPromptImages).catch(() => { /* next stall will surface */ });
-		session.lastLlmFrameAt = Date.now();
-		session.awaitingLlmFrame = true;
-		ensureTimer(session, cfg, isAlive);
-	}, 0);
+}
+
+/**
+ * Surface a stalled-stream error to the user. Sets the watchdog-owned state
+ * (lastTurnErrored, lastTurnErrorMessage, consecutiveErrorTurns +1), arms the
+ * suppression flags so the abort's "Request aborted" frame is dropped from
+ * both bookkeeping and broadcast, emits the synthetic `message_end` carrying
+ * the user-visible text, and aborts the in-flight request.
+ *
+ * Exported so the SessionManager's retry-dispatch fast-path can re-use it
+ * when `prompt()` rejects (production race: agent still mid-abort).
+ */
+export async function surfaceStallNow(
+	session: WatchdogSession,
+	cfg: WatchdogConfig,
+	ageMs: number,
+): Promise<void> {
+	session.streamStallRetries = 0;
+	session.consecutiveErrorTurns = (session.consecutiveErrorTurns ?? 0) + 1;
+	session.lastTurnErrored = true;
+	const errorMessage =
+		`Model stream stalled — no frames for ${Math.round(ageMs / 1000)}s ` +
+		`(attempted ${cfg.maxRetries + 1}× before giving up).`;
+	session.lastTurnErrorMessage = errorMessage;
+	session.suppressNextErrorMessageEnd = true;
+	session.suppressNextAbortMessageEnd = true;
+	// Stable id on the synthetic frame so the UI's MessageList can reliably
+	// identify this as the last assistant message and render the Retry button.
+	const syntheticId = `stalled-stream-${Date.now()}-${session.id.slice(0, 8)}`;
+	try {
+		session.emitSyntheticEvent?.({
+			type: "message_end",
+			message: {
+				id: syntheticId,
+				role: "assistant",
+				// Populate `content` with the error text so the assistant-message
+				// renderer's error-block branch lights up (it is gated on
+				// `stopReason === "error" && errorMessage`, but an empty content
+				// array can cause the surrounding row to render no children, hiding
+				// the error block in some layouts). One text chunk keeps the diff
+				// minimal vs. lifting the gate in Messages.ts.
+				content: [{ type: "text", text: errorMessage }],
+				stopReason: "error",
+				errorMessage,
+			},
+		});
+	} catch { /* best-effort: telemetry only, never block abort */ }
+	try { await session.rpcClient.abort(); } catch { /* best-effort */ }
+}
+
+/**
+ * Helper for `SessionManager._dispatchPendingStallRetry`. Re-arms the watchdog
+ * after a successful silent-retry re-prompt: refreshes the frame timestamp,
+ * sets `awaitingLlmFrame`, and ensures the timer is alive. Mirrors the path
+ * `agent_start` would take when the new turn's first frame arrives, but lets
+ * the SessionManager call it synchronously after `prompt()` resolves so the
+ * watchdog never observes a gap.
+ */
+export function armWatchdogAfterRetry(
+	session: WatchdogSession,
+	cfg: WatchdogConfig,
+	isAlive: IsAliveFn,
+): void {
+	session.lastLlmFrameAt = Date.now();
+	session.awaitingLlmFrame = true;
+	ensureTimer(session, cfg, isAlive);
 }
 
 /**

--- a/src/ui/components/Messages.ts
+++ b/src/ui/components/Messages.ts
@@ -387,6 +387,7 @@ export class AssistantMessage extends LitElement {
 									</div>
 									${this.onRetry ? html`
 										<button
+											data-testid="retry-button"
 											class="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors cursor-pointer ${this._retrying ? 'bg-destructive/10 text-destructive/60' : 'bg-destructive/15 hover:bg-destructive/25 text-destructive'}"
 											?disabled=${this._retrying}
 											@click=${() => { this._retrying = true; this.onRetry!(); }}

--- a/tests/e2e/mock-agent-core.mjs
+++ b/tests/e2e/mock-agent-core.mjs
@@ -482,6 +482,45 @@ export class MockAgentCore {
 		// the request, `currentAbortController.signal.aborted` flips true and we
 		// exit the turn cleanly. Otherwise we let the stall run to completion
 		// and emit a normal agent_end so non-watchdog tests can still assert.
+		// STREAM_STALL_THEN_REPLY:<stallMs>
+		// First call with this prompt: emit agent_start and stall for <stallMs>
+		// (mimicking a wedged stream). When the watchdog aborts, exit cleanly
+		// like STREAM_STALL.
+		// Subsequent calls with the SAME prompt text (the watchdog's silent-retry
+		// re-prompt routes through here): emit a clean assistant message_end
+		// containing the text "RECOVERED" so E2E tests can assert successful
+		// silent recovery without the stall replaying.
+		const stallThenReplyMatch = text.match(/STREAM_STALL_THEN_REPLY:(\d+)/);
+		if (stallThenReplyMatch) {
+			this._stallThenReplyCount = (this._stallThenReplyCount ?? 0) + 1;
+			if (this._stallThenReplyCount === 1) {
+				const stallMs = parseInt(stallThenReplyMatch[1], 10);
+				this._stallActive = true;
+				try { await this.tick(stallMs); } finally { this._stallActive = false; }
+				if (!this.currentAbortController || this.currentAbortController.signal.aborted) {
+					this.currentAbortController = null;
+					return;
+				}
+				this.currentAbortController = null;
+				this.emit({ type: "agent_end" });
+				this.emit({ type: "session_status", status: "idle" });
+				return;
+			}
+			// Second+ call: clean reply.
+			this.emit({
+				type: "message_end",
+				message: {
+					role: "assistant",
+					content: [{ type: "text", text: "RECOVERED" }],
+					stopReason: "end_turn",
+				},
+			});
+			this.currentAbortController = null;
+			this.emit({ type: "agent_end" });
+			this.emit({ type: "session_status", status: "idle" });
+			return;
+		}
+
 		const stallMatch = text.match(/STREAM_STALL:(\d+)/);
 		if (stallMatch) {
 			const stallMs = parseInt(stallMatch[1], 10);

--- a/tests/e2e/ui/llm-stream-watchdog.spec.ts
+++ b/tests/e2e/ui/llm-stream-watchdog.spec.ts
@@ -92,4 +92,47 @@ test.describe("LLM stream-inactivity watchdog", () => {
 		await sendMessage(page, "follow-up after stall");
 		await waitForSessionStatus(sessionId, "idle", 15_000);
 	});
+
+	test("silent retry recovers — fresh frames after one stall, no surfaced error", async ({ page }) => {
+		const sessionId = await createSession();
+		await waitForSessionStatus(sessionId, "idle");
+		await openApp(page);
+		await page.evaluate((id) => { window.location.hash = `#/session/${id}`; }, sessionId);
+		await expect(page.locator("textarea").first()).toBeVisible({ timeout: 15_000 });
+
+		await sendMessage(page, `STREAM_STALL_THEN_REPLY:30000`);
+		// After one stall + one silent retry, the agent recovers cleanly.
+		await waitForSessionStatus(sessionId, "idle", 10_000);
+
+		const resp = await apiFetch(`/api/sessions/${sessionId}`);
+		const data = await resp.json() as { lastTurnErrored: boolean; consecutiveErrorTurns: number };
+		expect(data.lastTurnErrored, "silent retry must produce a clean turn").toBe(false);
+		expect(data.consecutiveErrorTurns, "no surfaced stall, counter stays 0").toBe(0);
+
+		await expect(page.getByText(/RECOVERED/).first()).toBeVisible({ timeout: 5_000 });
+		// PR #539 invariant: no duplicate user echoes.
+		const userMessages = await page.locator("user-message").count();
+		expect(userMessages, "exactly one user-message row").toBe(1);
+		// No "Request aborted" rows visible — the abort frame is suppressed.
+		await expect(page.getByText(/request aborted/i)).toHaveCount(0);
+	});
+
+	test("surfaced stall shows a working Retry button on the last assistant message", async ({ page }) => {
+		const sessionId = await createSession();
+		await waitForSessionStatus(sessionId, "idle");
+		await openApp(page);
+		await page.evaluate((id) => { window.location.hash = `#/session/${id}`; }, sessionId);
+		await expect(page.locator("textarea").first()).toBeVisible({ timeout: 15_000 });
+
+		await sendMessage(page, `STREAM_STALL:${STALL_MS}`);
+		await waitForSessionStatus(sessionId, "idle", 10_000);
+		await expect(page.getByText(/stream stalled/i).first()).toBeVisible({ timeout: 5_000 });
+
+		const retryBtn = page.getByTestId("retry-button");
+		await expect(retryBtn).toBeVisible();
+		await retryBtn.click();
+		await waitForSessionStatus(sessionId, "streaming", 5_000);
+		// Don't wait for full recovery (it'll stall again) — just confirm the
+		// click re-dispatched the original prompt.
+	});
 });

--- a/tests/llm-stream-watchdog.test.ts
+++ b/tests/llm-stream-watchdog.test.ts
@@ -31,8 +31,20 @@ interface FakeRpc {
 	abortCalls: number;
 	promptCalls: Array<{ text: string; images?: any }>;
 	process: { pid: number };
-	/** One-shot: when set, the next prompt() call rejects with this error. */
-	rejectNextPrompt?: Error;
+	/** True while an abort handshake is mid-flight (set on abort() entry,
+	 *  cleared shortly after on a later macrotask). Models the real agent's
+	 *  "Agent is already processing" window where prompt() rejects if called
+	 *  before the abort fully unwinds. */
+	abortInFlight?: boolean;
+	/** When true (default false), prompt() will reject with
+	 *  `new Error("Agent is already processing.")` if called while
+	 *  `abortInFlight === true`. Off by default so existing tests are
+	 *  unaffected; the dispatch-failure test opts in. */
+	modelAbortBusy?: boolean;
+	/** How long abortInFlight stays set after abort() resolves. Short enough
+	 *  to be invisible to follow-up calls in fast tests, long enough to
+	 *  reliably overlap a `setTimeout(0)`-scheduled prompt. */
+	abortBusyWindowMs?: number;
 }
 
 function makeRpc(): FakeRpc {
@@ -40,13 +52,22 @@ function makeRpc(): FakeRpc {
 		abortCalls: 0,
 		promptCalls: [],
 		process: { pid: 12345 },
-		async abort() { c.abortCalls++; return { success: true }; },
+		abortInFlight: false,
+		async abort() {
+			c.abortCalls++;
+			c.abortInFlight = true;
+			// Clear the in-flight window on a later macrotask. A `setTimeout(0)`
+			// scheduled by the caller AFTER `await abort()` resolves will
+			// generally race with this; we use a short positive delay so the
+			// watchdog's race is deterministic in test (prompt sees the flag).
+			const windowMs = c.abortBusyWindowMs ?? 30;
+			setTimeout(() => { c.abortInFlight = false; }, windowMs);
+			return { success: true };
+		},
 		async prompt(text: string, images?: any) {
 			c.promptCalls.push({ text, images });
-			if (c.rejectNextPrompt) {
-				const err = c.rejectNextPrompt;
-				c.rejectNextPrompt = undefined;
-				throw err;
+			if (c.modelAbortBusy && c.abortInFlight) {
+				throw new Error("Agent is already processing.");
 			}
 			return { success: true };
 		},
@@ -377,9 +398,17 @@ describe("stream-watchdog: silent-retry dispatch failure", () => {
 	// IMMEDIATELY (within one tick), not after another full `timeoutMs`.
 	it("stream-watchdog: silent retry surfaces immediately when re-prompt dispatch rejects", async () => {
 		const rpc = makeRpc();
-		// Configure the FIRST silent-retry re-prompt to reject with the
-		// production-shape error.
-		rpc.rejectNextPrompt = new Error("Agent is already processing.");
+		// Model the real-agent race: prompt() rejects with "Agent is already
+		// processing." when called while an abort handshake is mid-flight.
+		// The watchdog's silent-retry branch does:
+		//   await rpcClient.abort();
+		//   setTimeout(() => { void rpcClient.prompt(...).catch(()=>{}); }, 0);
+		// The setTimeout(0) callback fires while abortInFlight is still true
+		// (cleared ~30ms later), so prompt() rejects — matching production.
+		// No one-shot opt-in: the rejection is triggered by the watchdog's
+		// natural sequencing.
+		rpc.modelAbortBusy = true;
+		rpc.abortBusyWindowMs = 30;
 		const session = makeSession("silent-retry-reject", rpc);
 		const syntheticEvents: any[] = [];
 		session.emitSyntheticEvent = (ev) => syntheticEvents.push(ev);

--- a/tests/llm-stream-watchdog.test.ts
+++ b/tests/llm-stream-watchdog.test.ts
@@ -21,6 +21,8 @@ const {
 	shouldSuppressDrainForStallRetry,
 	shouldSkipErrorMessageEnd,
 	resolveWatchdogConfigFromEnv,
+	surfaceStallNow,
+	armWatchdogAfterRetry,
 } = await import("../src/server/agent/stream-watchdog.ts");
 type WatchdogConfig = import("../src/server/agent/stream-watchdog.ts").WatchdogConfig;
 type WatchdogSession = import("../src/server/agent/stream-watchdog.ts").WatchdogSession;
@@ -89,6 +91,30 @@ const isAlive = () => true;
 
 const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
 
+/**
+ * Simulate the SessionManager's `agent_end` handler dispatching a stashed
+ * silent-retry. After the production fix the watchdog no longer auto-re-prompts
+ * via `setTimeout(0)`; instead it stashes `pendingStallRetry` and the
+ * SessionManager's `agent_end` handler dispatches it once the agent has fully
+ * wound down. Tests that exercise multi-stall flows must mirror that hand-off.
+ *
+ * Returns once the re-prompt resolves or rejects so callers can await it.
+ */
+async function simulateSessionManagerAgentEnd(session: WatchdogSession): Promise<void> {
+	onAgentEvent(session, { type: "agent_end" }, FAST_CFG, isAlive);
+	const pending = session.pendingStallRetry;
+	session.pendingStallRetry = undefined;
+	if (pending) {
+		try {
+			await session.rpcClient.prompt(pending.text, pending.images);
+			// armWatchdogAfterRetry equivalent
+			session.lastLlmFrameAt = Date.now();
+			session.awaitingLlmFrame = true;
+		} catch { /* tests that exercise rejection paths drive surfacing themselves */ }
+	}
+	session.suppressNextDrainForStallRetry = false;
+}
+
 describe("stream-watchdog: silent-retry then surface", () => {
 	/**
 	 * Wait for the next stall + re-prompt cycle. The watchdog's tick is
@@ -102,8 +128,8 @@ describe("stream-watchdog: silent-retry then surface", () => {
 		const deadline = Date.now() + 1000;
 		while (Date.now() < deadline) {
 			if (rpc.abortCalls > beforeAborts) {
-				// Abort fired — wait one microtask + setTimeout(0) for the re-prompt.
-				await sleep(15);
+				// Abort fired — give microtasks a chance to settle before assertions.
+				await sleep(5);
 				return;
 			}
 			await sleep(10);
@@ -123,8 +149,10 @@ describe("stream-watchdog: silent-retry then surface", () => {
 		// First stall (attempt 1) → silent retry.
 		await waitForStall(rpc, 0);
 		assert.equal(rpc.abortCalls, 1, "abort fired on first stall");
-		assert.equal(rpc.promptCalls.length, 1, "first re-prompt issued");
-		assert.equal(rpc.promptCalls[0].text, "hello world");
+		// Post-fix: watchdog stashes pendingStallRetry; the manager dispatches it.
+		assert.equal(rpc.promptCalls.length, 0, "watchdog itself does not re-prompt anymore");
+		assert.ok(session.pendingStallRetry, "pendingStallRetry stashed for manager dispatch");
+		assert.equal(session.pendingStallRetry?.text, "hello world");
 		assert.equal(session.streamStallRetries, 1);
 		assert.equal(session.lastTurnErrored, undefined, "silent retry must not set lastTurnErrored");
 		assert.equal(session.consecutiveErrorTurns ?? 0, 0, "silent retry must NOT bump consecutiveErrorTurns");
@@ -132,24 +160,29 @@ describe("stream-watchdog: silent-retry then surface", () => {
 
 		// Simulate the agent_end the abort emits. The watchdog must preserve
 		// streamStallRetries while the suppression flag is set. The manager
-		// then consumes the flag exactly once — mirror that here. The fresh
-		// agent_start arrives once the re-prompt's agent run begins; mirror
-		// that too so the watchdog re-arms (production flow: abort → agent_end
-		// → the setTimeout(0) re-prompt → fresh agent_start).
-		onAgentEvent(session, { type: "agent_end" }, FAST_CFG, isAlive);
+		// then dispatches the stashed re-prompt and consumes the flag exactly
+		// once — mirror that here. The fresh agent_start arrives once the
+		// re-prompt's agent run begins; mirror that too so the watchdog re-arms
+		// (production flow: abort → agent_end → manager dispatches re-prompt
+		// → fresh agent_start).
+		assert.equal(session.streamStallRetries, 1,
+			"retry counter set on first silent retry");
+		// SessionManager's agent_end handler dispatches the stashed re-prompt
+		// (post-fix: watchdog no longer auto-re-prompts via setTimeout).
+		await simulateSessionManagerAgentEnd(session);
+		assert.equal(rpc.promptCalls.length, 1, "first re-prompt dispatched by manager");
+		assert.equal(rpc.promptCalls[0].text, "hello world");
 		assert.equal(session.streamStallRetries, 1,
 			"retry counter preserved across agent_end during silent-retry");
-		session.suppressNextDrainForStallRetry = false;
 		onAgentEvent(session, { type: "agent_start" }, FAST_CFG, isAlive);
 
 		// Second stall (attempt 2) — silent retry.
 		await waitForStall(rpc, 1);
 		assert.equal(rpc.abortCalls, 2, "abort fired on second stall");
-		assert.equal(rpc.promptCalls.length, 2);
 		assert.equal(session.streamStallRetries, 2);
 		assert.equal(session.consecutiveErrorTurns ?? 0, 0, "silent retry #2 must NOT bump consecutiveErrorTurns");
-		onAgentEvent(session, { type: "agent_end" }, FAST_CFG, isAlive);
-		session.suppressNextDrainForStallRetry = false;
+		await simulateSessionManagerAgentEnd(session);
+		assert.equal(rpc.promptCalls.length, 2, "second re-prompt dispatched by manager");
 		onAgentEvent(session, { type: "agent_start" }, FAST_CFG, isAlive);
 
 		// Third stall (attempt 3, > maxRetries) — surface to user.
@@ -321,17 +354,16 @@ describe("stream-watchdog: production-shape abort frames", () => {
 		const syntheticEvents: any[] = [];
 		session.emitSyntheticEvent = (ev) => syntheticEvents.push(ev);
 
-		// Drive 3 stalls.
+		// Drive 3 stalls. Post-fix: each silent retry stashes pendingStallRetry,
+		// then simulateSessionManagerAgentEnd dispatches it.
 		onAgentEvent(session, { type: "agent_start" }, FAST_CFG, isAlive);
 		const deadline = Date.now() + 2000;
 		while (Date.now() < deadline && rpc.abortCalls < 1) await sleep(10);
-		onAgentEvent(session, { type: "agent_end" }, FAST_CFG, isAlive);
-		session.suppressNextDrainForStallRetry = false;
+		await simulateSessionManagerAgentEnd(session);
 		session.suppressNextErrorMessageEnd = false;
 		onAgentEvent(session, { type: "agent_start" }, FAST_CFG, isAlive);
 		while (Date.now() < deadline && rpc.abortCalls < 2) await sleep(10);
-		onAgentEvent(session, { type: "agent_end" }, FAST_CFG, isAlive);
-		session.suppressNextDrainForStallRetry = false;
+		await simulateSessionManagerAgentEnd(session);
 		session.suppressNextErrorMessageEnd = false;
 		onAgentEvent(session, { type: "agent_start" }, FAST_CFG, isAlive);
 		while (Date.now() < deadline && rpc.abortCalls < 3) await sleep(10);
@@ -416,16 +448,36 @@ describe("stream-watchdog: silent-retry dispatch failure", () => {
 		// Arm.
 		onAgentEvent(session, { type: "agent_start" }, FAST_CFG, isAlive);
 
-		// Wait for the first stall + silent-retry re-prompt to fire (and reject).
-		// Bounded budget: timeoutMs (100) + 100ms = 200ms. Post-fix the watchdog
-		// must surface within this window. Pre-fix the watchdog would still be
-		// idling here (next stall only at ~timeoutMs * 2 = 200ms+ from the
-		// re-prompt's setTimeout(0) reset of lastLlmFrameAt).
+		// Wait for the first stall — watchdog stashes pendingStallRetry.
 		const budgetMs = FAST_CFG.timeoutMs + 100;
-		const deadline = Date.now() + budgetMs;
-		while (Date.now() < deadline) {
-			if (session.lastTurnErrored === true) break;
+		const stallDeadline = Date.now() + budgetMs;
+		while (Date.now() < stallDeadline) {
+			if (rpc.abortCalls >= 1) break;
 			await sleep(10);
+		}
+		assert.equal(rpc.abortCalls, 1, "silent-retry abort fired");
+		assert.ok(session.pendingStallRetry, "pendingStallRetry stashed for manager dispatch");
+
+		// Mirror SessionManager._dispatchPendingStallRetry: prompt() rejects
+		// because abortInFlight is still set; the manager's catch block calls
+		// surfaceStallNow synchronously.
+		onAgentEvent(session, { type: "agent_end" }, FAST_CFG, isAlive);
+		const pending = session.pendingStallRetry!;
+		session.pendingStallRetry = undefined;
+		session.suppressNextDrainForStallRetry = false;
+		try {
+			await session.rpcClient.prompt(pending.text, pending.images);
+			armWatchdogAfterRetry(session, FAST_CFG, isAlive);
+		} catch {
+			const ageMs = Date.now() - (session.lastLlmFrameAt ?? Date.now());
+			await surfaceStallNow(session, FAST_CFG, ageMs);
+		}
+
+		// At this point lastTurnErrored MUST be true — surfacing has happened
+		// synchronously in the catch path, not after another timeoutMs cycle.
+		const deadline = Date.now() + budgetMs;
+		while (Date.now() < deadline && session.lastTurnErrored !== true) {
+			await sleep(5);
 		}
 
 		// At least one re-prompt was attempted (the rejecting one).
@@ -511,8 +563,7 @@ describe("stream-watchdog: end-to-end production-shape flow", () => {
 		assert.equal(session.lastTurnErrored ?? false, false,
 			"silent retry must NOT mark turn as errored");
 
-		onAgentEvent(session, { type: "agent_end" }, FAST_CFG, isAlive);
-		session.suppressNextDrainForStallRetry = false;
+		await simulateSessionManagerAgentEnd(session);
 		onAgentEvent(session, { type: "agent_start" }, FAST_CFG, isAlive);
 
 		// Stall #2.
@@ -522,8 +573,7 @@ describe("stream-watchdog: end-to-end production-shape flow", () => {
 		assert.equal(session.consecutiveErrorTurns ?? 0, 0,
 			"silent retry #2 must NOT bump");
 
-		onAgentEvent(session, { type: "agent_end" }, FAST_CFG, isAlive);
-		session.suppressNextDrainForStallRetry = false;
+		await simulateSessionManagerAgentEnd(session);
 		onAgentEvent(session, { type: "agent_start" }, FAST_CFG, isAlive);
 
 		// Stall #3 (surfaced). Watchdog bumps the counter manually,

--- a/tests/llm-stream-watchdog.test.ts
+++ b/tests/llm-stream-watchdog.test.ts
@@ -610,3 +610,124 @@ describe("stream-watchdog: end-to-end production-shape flow", () => {
 		disposeStreamWatchdog(session);
 	});
 });
+
+describe("stream-watchdog: silent-retry success telemetry", () => {
+	// Spec (Bug 1, fix req #5): on a successful silent-retry dispatch, the
+	// next clean (non-errored) `agent_end` MUST log exactly one
+	//   [stream-watchdog] session=<id> silent-retry N/M succeeded
+	// line so successful self-heals are greppable in the server log. The
+	// success-pending state is staged by the SessionManager's dispatch path
+	// (`silentRetrySuccessLogPending`) and consumed by `onAgentEvent` on the
+	// first non-suppressed, non-errored agent_end.
+	it("logs exactly one 'succeeded' line on next clean agent_end after a successful retry", async () => {
+		const rpc = makeRpc();
+		const session = makeSession("telemetry-1", rpc);
+
+		const origLog = console.log;
+		const logged: string[] = [];
+		console.log = (...args: any[]) => { logged.push(args.map(String).join(" ")); };
+
+		try {
+			// Drive one stall → silent-retry stash → manager dispatches it.
+			onAgentEvent(session, { type: "agent_start" }, FAST_CFG, isAlive);
+			const deadline = Date.now() + 1000;
+			while (Date.now() < deadline && rpc.abortCalls === 0) await sleep(10);
+			assert.equal(rpc.abortCalls, 1, "silent-retry abort fired");
+			assert.ok(session.pendingStallRetry, "pendingStallRetry stashed");
+
+			// Mirror SessionManager._dispatchPendingStallRetry on the success path:
+			// agent_end fires (with suppression flag still set), manager dispatches
+			// the re-prompt, and on success stages silentRetrySuccessLogPending.
+			onAgentEvent(session, { type: "agent_end" }, FAST_CFG, isAlive);
+			const pending = session.pendingStallRetry!;
+			session.pendingStallRetry = undefined;
+			session.suppressNextDrainForStallRetry = false;
+			await session.rpcClient.prompt(pending.text, pending.images);
+			session.silentRetrySuccessLogPending = { attempt: pending.attempt, total: pending.total };
+			armWatchdogAfterRetry(session, FAST_CFG, isAlive);
+
+			// New turn streams cleanly: agent_start → message_update → clean agent_end.
+			onAgentEvent(session, { type: "agent_start" }, FAST_CFG, isAlive);
+			onAgentEvent(
+				session,
+				{ type: "message_update", message: { id: "m1", content: [{ type: "text", text: "ok" }] } },
+				FAST_CFG,
+				isAlive,
+			);
+			// Clean agent_end: lastTurnErrored is false/unset, suppression flag is
+			// not set → telemetry should fire here.
+			session.lastTurnErrored = false;
+			onAgentEvent(session, { type: "agent_end" }, FAST_CFG, isAlive);
+
+			const hits = logged.filter(l => /silent-retry \d+\/\d+ succeeded/.test(l));
+			assert.equal(hits.length, 1, `exactly one success log line (got ${hits.length}: ${JSON.stringify(logged)})`);
+			assert.match(hits[0], new RegExp(`session=${session.id}`));
+			assert.match(hits[0], /silent-retry 1\/2 succeeded/);
+			assert.equal(session.silentRetrySuccessLogPending, undefined,
+				"pending log state is cleared after firing");
+
+			// A second clean agent_end MUST NOT re-log (state already cleared).
+			logged.length = 0;
+			onAgentEvent(session, { type: "agent_start" }, FAST_CFG, isAlive);
+			onAgentEvent(session, { type: "agent_end" }, FAST_CFG, isAlive);
+			const hits2 = logged.filter(l => /silent-retry \d+\/\d+ succeeded/.test(l));
+			assert.equal(hits2.length, 0, "telemetry must not re-fire on subsequent agent_end");
+		} finally {
+			console.log = origLog;
+			disposeStreamWatchdog(session);
+		}
+	});
+});
+
+describe("stream-watchdog: empty-prompt guard", () => {
+	// Spec (Bug 1, fix req #4): if `lastPromptText` is missing or empty, the
+	// watchdog must surface immediately on the very first stall rather than
+	// looping silent retries with an empty re-prompt (which is worse than a
+	// stall — the agent has nothing to retry against).
+	it("surfaces on first stall when lastPromptText is empty (no silent retries)", async () => {
+		const rpc = makeRpc();
+		const session = makeSession("empty-prompt", rpc);
+		session.lastPromptText = ""; // empty — guard must trip
+		const syntheticEvents: any[] = [];
+		session.emitSyntheticEvent = (ev) => syntheticEvents.push(ev);
+
+		onAgentEvent(session, { type: "agent_start" }, FAST_CFG, isAlive);
+
+		const deadline = Date.now() + 1000;
+		while (Date.now() < deadline && rpc.abortCalls === 0) await sleep(10);
+
+		assert.equal(rpc.abortCalls, 1, "abort fired on first stall");
+		assert.equal(session.lastTurnErrored, true,
+			"empty prompt must surface immediately, not loop silent retries");
+		assert.equal(session.consecutiveErrorTurns, 1,
+			"surfaced stall bumps consecutiveErrorTurns by exactly 1");
+		assert.equal(session.streamStallRetries, 0,
+			"retry counter reset after immediate surfacing (never advanced)");
+		assert.equal(session.pendingStallRetry, undefined,
+			"no pendingStallRetry stashed (no silent retry attempted)");
+		assert.equal(rpc.promptCalls.length, 0, "no re-prompt issued for empty text");
+		assert.equal(syntheticEvents.length, 1, "surfaced stall emits synthetic message_end");
+		assert.match(syntheticEvents[0].message.errorMessage, /stream stalled/i);
+
+		disposeStreamWatchdog(session);
+	});
+
+	it("surfaces on first stall when lastPromptText is undefined", async () => {
+		const rpc = makeRpc();
+		const session = makeSession("missing-prompt", rpc);
+		session.lastPromptText = undefined; // missing — guard must trip
+
+		onAgentEvent(session, { type: "agent_start" }, FAST_CFG, isAlive);
+
+		const deadline = Date.now() + 1000;
+		while (Date.now() < deadline && rpc.abortCalls === 0) await sleep(10);
+
+		assert.equal(rpc.abortCalls, 1, "abort fired on first stall");
+		assert.equal(session.lastTurnErrored, true,
+			"undefined prompt must surface immediately");
+		assert.equal(session.consecutiveErrorTurns, 1);
+		assert.equal(rpc.promptCalls.length, 0, "no re-prompt for undefined text");
+
+		disposeStreamWatchdog(session);
+	});
+});

--- a/tests/llm-stream-watchdog.test.ts
+++ b/tests/llm-stream-watchdog.test.ts
@@ -31,6 +31,8 @@ interface FakeRpc {
 	abortCalls: number;
 	promptCalls: Array<{ text: string; images?: any }>;
 	process: { pid: number };
+	/** One-shot: when set, the next prompt() call rejects with this error. */
+	rejectNextPrompt?: Error;
 }
 
 function makeRpc(): FakeRpc {
@@ -41,6 +43,11 @@ function makeRpc(): FakeRpc {
 		async abort() { c.abortCalls++; return { success: true }; },
 		async prompt(text: string, images?: any) {
 			c.promptCalls.push({ text, images });
+			if (c.rejectNextPrompt) {
+				const err = c.rejectNextPrompt;
+				c.rejectNextPrompt = undefined;
+				throw err;
+			}
 			return { success: true };
 		},
 	};
@@ -352,6 +359,85 @@ describe("stream-watchdog: user-Stop race during silent retry", () => {
 			"user Stop must win — helper returns false so caller proceeds to broadcastStatus(idle)");
 		assert.equal(session.suppressNextDrainForStallRetry, false,
 			"flag cleared so a stale flag can't strand the next agent_end");
+
+		disposeStreamWatchdog(session);
+	});
+});
+
+describe("stream-watchdog: silent-retry dispatch failure", () => {
+	// Bug 1 (issue-analysis): the silent-retry branch issues
+	//   `setTimeout(0) → rpcClient.prompt(...).catch(()=>{})`
+	// and silently swallows dispatch failures. When `prompt()` rejects (the
+	// real-agent shape: "Agent is already processing" because the abort hasn't
+	// fully torn down yet), the watchdog presets `lastLlmFrameAt = Date.now()`
+	// and idles waiting for frames that will never arrive. The next stall
+	// fires only after another full `timeoutMs` cycle.
+	//
+	// Post-fix expectation: a rejected re-prompt surfaces the stall
+	// IMMEDIATELY (within one tick), not after another full `timeoutMs`.
+	it("stream-watchdog: silent retry surfaces immediately when re-prompt dispatch rejects", async () => {
+		const rpc = makeRpc();
+		// Configure the FIRST silent-retry re-prompt to reject with the
+		// production-shape error.
+		rpc.rejectNextPrompt = new Error("Agent is already processing.");
+		const session = makeSession("silent-retry-reject", rpc);
+		const syntheticEvents: any[] = [];
+		session.emitSyntheticEvent = (ev) => syntheticEvents.push(ev);
+
+		// Arm.
+		onAgentEvent(session, { type: "agent_start" }, FAST_CFG, isAlive);
+
+		// Wait for the first stall + silent-retry re-prompt to fire (and reject).
+		// Bounded budget: timeoutMs (100) + 100ms = 200ms. Post-fix the watchdog
+		// must surface within this window. Pre-fix the watchdog would still be
+		// idling here (next stall only at ~timeoutMs * 2 = 200ms+ from the
+		// re-prompt's setTimeout(0) reset of lastLlmFrameAt).
+		const budgetMs = FAST_CFG.timeoutMs + 100;
+		const deadline = Date.now() + budgetMs;
+		while (Date.now() < deadline) {
+			if (session.lastTurnErrored === true) break;
+			await sleep(10);
+		}
+
+		// At least one re-prompt was attempted (the rejecting one).
+		assert.ok(
+			rpc.promptCalls.length >= 1,
+			`re-prompt was issued (got promptCalls=${rpc.promptCalls.length})`,
+		);
+
+		// CORE ASSERTION: the watchdog surfaced the stall to the user within
+		// the bounded budget — it did NOT swallow the rejection and idle
+		// waiting for another `timeoutMs` cycle.
+		assert.equal(
+			session.lastTurnErrored,
+			true,
+			"expected lastTurnErrored=true within timeoutMs+100ms after dispatch rejection " +
+			`(got ${session.lastTurnErrored}); the watchdog must surface immediately on rejected re-prompt`,
+		);
+		assert.match(
+			session.lastTurnErrorMessage ?? "",
+			/stream stalled/i,
+			"surfaced error message must mention 'stream stalled'",
+		);
+		assert.equal(
+			session.consecutiveErrorTurns,
+			1,
+			"surfaced stall bumps consecutiveErrorTurns by exactly 1",
+		);
+		assert.equal(
+			syntheticEvents.length,
+			1,
+			"exactly one synthetic message_end emitted on surfaced stall",
+		);
+		assert.equal(syntheticEvents[0].type, "message_end");
+		assert.equal(syntheticEvents[0].message.stopReason, "error");
+
+		// Two aborts: one for the silent retry, one for the surfacing path.
+		assert.equal(
+			rpc.abortCalls,
+			2,
+			"expected 2 aborts (one for the silent-retry attempt, one for the immediate surfacing after dispatch rejection)",
+		);
 
 		disposeStreamWatchdog(session);
 	});


### PR DESCRIPTION
Follow-up to PR #536 (original watchdog) and PR #539 (silent-retry duplicate-message suppression). The user reported that silent retries fired but never actually retried, and that the surfaced stall message had no Retry button.

## Bug 1 — silent retries actually retry now

The previous `setTimeout(0) → rpcClient.prompt(...).catch(()=>{})` raced the agent's abort handshake; `prompt()` rejected with "Agent is already processing" while the abort was still in-flight, the rejection was swallowed, and `lastLlmFrameAt` was preset so the watchdog idled. After three timeouts all three "silent retries" no-op'd.

Re-dispatch is now driven from the next `agent_end`, not `setTimeout`:

- `handleStreamStall` stashes `pendingStallRetry = { text, images, attempt, total }` and awaits `rpcClient.abort()`.
- `SessionManager._dispatchPendingStallRetry` runs from the existing `agent_end → shouldSuppressDrainForStallRetry` callsite, so the prompt only lands after the agent has fully unwound. On success it stages `silentRetrySuccessLogPending` and calls `armWatchdogAfterRetry`. On rejection it logs `[stream-watchdog] retry-dispatch failed: <err>`, calls `surfaceStallNow` synchronously, and broadcasts idle.
- Empty-prompt guard: `handleStreamStall` surfaces immediately when `lastPromptText` is missing/empty (re-issuing `""` is worse than a stall).
- Success telemetry: a clean `agent_end` after a successful retry logs `[stream-watchdog] silent-retry N/M succeeded` exactly once.

## Bug 2 — surfaced stall renders the Retry button

- `surfaceStallNow` now emits a synthetic `message_end` with a stable `id: "stalled-stream-<ts>-<sid>"` and `content: [{ type: "text", text: errorMessage }]`. The empty `content: []` and missing id were what hid the Retry button — `MessageList`'s gating (`isLastAssistant && stopReason==="error" && onRetry`) needed both.
- `Messages.ts` Retry button now carries `data-testid="retry-button"` so the new E2E targets it deterministically.

## Tests

Unit (`tests/llm-stream-watchdog.test.ts` — 16/16 pass):

- `silent-retry dispatch failure` — models the production abort/prompt race; asserts immediate surfacing on rejection (no extra `timeoutMs` cycle).
- `silent-retry success telemetry` — exactly one `silent-retry N/M succeeded` log line on next clean `agent_end`; doesn't re-fire.
- `empty-prompt guard` — empty and undefined `lastPromptText` both surface on first stall.
- `simulateSessionManagerAgentEnd` helper added so existing multi-stall tests drive the new manager-side dispatch path.

E2E (`tests/e2e/ui/llm-stream-watchdog.spec.ts`):

- `silent retry recovers` — uses new `STREAM_STALL_THEN_REPLY:<ms>` mock-agent directive. Asserts `lastTurnErrored=false`, `consecutiveErrorTurns=0`, no duplicate user-message rows, no "Request aborted" rows.
- `surfaced stall shows a working Retry button` — asserts `getByTestId("retry-button")` is visible; click re-dispatches the original prompt.

## Constraints honored

- PR #539's broadcast-suppression contract (`suppressNextUserEcho`, `suppressNextAbortMessageEnd`, `suppressNextErrorMessageEnd`, `suppressNextDrainForStallRetry`) is unchanged.
- No env var changes.
- Watchdog stays at the bobbit ↔ agent boundary (not pi-ai).
- No reconnect/resume of stalled streams.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)