### PR TITLE
Minimal error widget on ask_user_choices failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ tests/fixtures/markdown-throttle-bundle.js
 tests/fixtures/markdown-throttle-bundle.css
 tests/fixtures/bash-renderer-bundle.js
 tests/fixtures/bash-renderer-bundle.css
+tests/fixtures/ask-user-choices-renderer-bundle.js
+tests/fixtures/ask-user-choices-renderer-bundle.css
 tests/fixtures/settings-models-tab-bundle.js
 tests/fixtures/settings-models-tab-bundle.css
 tests/fixtures/preview-renderer-bundle.js

--- a/defaults/tools/ask/extension.ts
+++ b/defaults/tools/ask/extension.ts
@@ -26,6 +26,14 @@ export default function (pi: ExtensionAPI) {
 		return { content: [{ type: "text" as const, text: JSON.stringify(data) }], details: undefined };
 	}
 
+	function errorResult(data: unknown) {
+		return {
+			content: [{ type: "text" as const, text: JSON.stringify(data) }],
+			isError: true,
+			details: undefined,
+		};
+	}
+
 	pi.registerTool({
 		name: "ask_user_choices",
 		label: "Ask User Choices",
@@ -74,12 +82,12 @@ export default function (pi: ExtensionAPI) {
 					const q = questions[i];
 					const label = q?.tab_label;
 					if (typeof label !== "string" || label.trim().length === 0) {
-						return ok({
+						return errorResult({
 							error: `ask_user_choices: questions[${i}].tab_label is required for multi-question asks (2–4 words, ≤24 chars).`,
 						});
 					}
 					if (label.length > 24) {
-						return ok({
+						return errorResult({
 							error: `ask_user_choices: questions[${i}].tab_label exceeds 24 chars (got ${label.length}).`,
 						});
 					}

--- a/docs/non-blocking-ask.md
+++ b/docs/non-blocking-ask.md
@@ -132,6 +132,28 @@ A single keydown listener on the widget root handles shortcuts. While focus is i
 
 The widget uses ARIA `role="radiogroup"` / `role="radio"` for options and the standard tablist pattern for tabs, with roving `tabindex` so screen readers announce selection state correctly. Mouse/touch behaviour is unchanged.
 
+## Error results render as a minimal chip
+
+The renderer distinguishes three tool-result envelope shapes from the extension and routes each to a different UI:
+
+| Result shape | UI |
+|---|---|
+| `{status:"posted", tool_use_id}` (synchronous stub) | Interactive widget — full tabs, options, Submit. |
+| `{answers:[...]}` (legacy / pre-non-blocking transcripts) | Read-only answered card. |
+| `isError: true` **or** any other completed-but-unknown shape | Minimal destructive-coloured chip (`<div class="ask-error">`), no clickable options. |
+
+The extension sets `isError: true` on its validation failures (currently the two `tab_label` rules — missing/empty, and >24 chars — on multi-question asks). The renderer also treats *any* completed result that is neither the posted stub nor a legacy answers payload as errored, as a defense-in-depth fallback against future failure paths that forget the flag.
+
+Why a chip instead of the full widget: when an ask call fails the agent typically retries with a corrected call, producing a second `tool_use_id`. Rendering the failed call as an interactive widget would leave two clickable question cards in the transcript and the user could not tell which one is live. Collapsing the failed call to a small inline error chip means only the retry is interactive.
+
+Invariants pinned by tests (treat these as the source of truth):
+
+- [`tests/ask-extension-execute.test.ts`](../tests/ask-extension-execute.test.ts) — the extension returns `isError: true` on each validation failure path.
+- [`tests/ask-user-choices-renderer.spec.ts`](../tests/ask-user-choices-renderer.spec.ts) — the renderer routes `isError: true` and unknown-shape completed results to the `ask-error` chip and never to the interactive widget.
+- [`tests/e2e/ui/ask-user-choices-ui.spec.ts`](../tests/e2e/ui/ask-user-choices-ui.spec.ts) — failure-then-retry scenario shows exactly one interactive widget, preceded by the minimal chip for the failed call.
+
+The `tab_label` validation rules themselves are documented in `defaults/tools/ask/ask_user_choices.yaml` (the agent-facing tool contract) and summarised in the [Widget UX → Labels](#labels) section above. This page intentionally does not duplicate them.
+
 ## Rendering note
 
 Envelope user messages are hidden from the **rendered** transcript by `src/ui/components/AgentInterface.ts` (via `isAskResponseEnvelope`). They're still present in the `.jsonl` and still sent to the LLM — the agent sees them on its next turn as part of history. The UI omits them because the answered widget card is the human-readable representation; showing both would be redundant.

--- a/src/ui/tools/renderers/AskUserChoicesRenderer.ts
+++ b/src/ui/tools/renderers/AskUserChoicesRenderer.ts
@@ -104,7 +104,6 @@ export class AskUserChoicesRenderer implements ToolRenderer {
 			};
 		}
 
-		const errored = Boolean(result?.isError);
 		const posted = isPostedStub(result);
 		// Preferred path: the tool returned the `{status:"posted"}` stub and the
 		// user has submitted; answers live in a later envelope user message.
@@ -114,6 +113,13 @@ export class AskUserChoicesRenderer implements ToolRenderer {
 		// Legacy path: pre-redesign sessions where the tool_result itself carried answers.
 		const legacy = posted ? null : extractLegacyAnswers(result);
 		const answers: AskAnswer[] | null = fromTranscript ?? legacy;
+		// Defense-in-depth: a completed tool result that is neither the posted stub
+		// nor carries legacy answers must be a failure — even if `isError` was not
+		// set on the result. This guards against tool extensions that forget to set
+		// `isError: true` on validation failures (would otherwise render the full
+		// interactive widget for a dead call).
+		const errored = Boolean(result?.isError)
+			|| (state !== "inprogress" && Boolean(result) && !posted && !legacy);
 
 		// Interactive mode: tool posted, no envelope yet, not errored.
 		//   - If `posted` is false but the tool has produced a non-stub result,

--- a/tests/ask-extension-execute.test.ts
+++ b/tests/ask-extension-execute.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Reproducing test for the "Minimal error widget on ask failure" bug.
+ *
+ * `defaults/tools/ask/extension.ts::execute()` validates `tab_label` on
+ * multi-question asks and, on failure, returns `ok({ error: "..." })`. The
+ * `ok()` helper does NOT set `isError: true`, so the UI renderer treats the
+ * result as a success and renders the full interactive widget instead of a
+ * minimal error chip.
+ *
+ * This test asserts that the two validation-failure paths return a result
+ * with `result.isError === true`. The failing-case assertions below WILL FAIL
+ * on master — that is the point of this reproducing test. They will pass once
+ * the extension is fixed to set `isError: true` on validation failures.
+ */
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import registerAskExtension from "../defaults/tools/ask/extension.ts";
+
+type ExecuteFn = (toolUseId: string, params: unknown) => Promise<any>;
+
+function makeStubApi(): { api: any; getExecute: () => ExecuteFn } {
+	let captured: ExecuteFn | null = null;
+	const api = {
+		registerTool(config: any) {
+			if (typeof config?.execute === "function") {
+				captured = config.execute.bind(config);
+			}
+		},
+	};
+	return {
+		api,
+		getExecute: () => {
+			if (!captured) throw new Error("execute was not registered");
+			return captured;
+		},
+	};
+}
+
+function textOf(result: any): string {
+	const item = result?.content?.[0];
+	return typeof item?.text === "string" ? item.text : "";
+}
+
+describe("ask extension execute — validation error shape", () => {
+	let execute: ExecuteFn;
+	let prevSessionId: string | undefined;
+
+	before(() => {
+		prevSessionId = process.env.BOBBIT_SESSION_ID;
+		process.env.BOBBIT_SESSION_ID = "test-session";
+		const { api, getExecute } = makeStubApi();
+		registerAskExtension(api);
+		execute = getExecute();
+	});
+
+	after(() => {
+		if (prevSessionId === undefined) delete process.env.BOBBIT_SESSION_ID;
+		else process.env.BOBBIT_SESSION_ID = prevSessionId;
+	});
+
+	it("returns a posted stub (not an error) for a valid multi-question ask", async () => {
+		const result = await execute("tool-use-id", {
+			questions: [
+				{ question: "Q1", options: ["a", "b"], tab_label: "First" },
+				{ question: "Q2", options: ["c", "d"], tab_label: "Second" },
+			],
+		});
+		assert.notEqual(result?.isError, true, "valid ask should not have isError:true");
+		const body = JSON.parse(textOf(result));
+		assert.deepEqual(body, { status: "posted", tool_use_id: "tool-use-id" });
+	});
+
+	it("sets isError:true when tab_label is missing on questions[1]", async () => {
+		const result = await execute("tool-use-id", {
+			questions: [
+				{ question: "Q1", options: ["a", "b"], tab_label: "First" },
+				{ question: "Q2", options: ["c", "d"] },
+			],
+		});
+		assert.equal(result?.isError, true, "missing tab_label should set isError:true");
+		const text = textOf(result);
+		assert.match(text, /tab_label/);
+		assert.match(text, /\[1\]/);
+	});
+
+	it("sets isError:true when tab_label exceeds 24 chars on questions[1]", async () => {
+		const longLabel = "x".repeat(25);
+		const result = await execute("tool-use-id", {
+			questions: [
+				{ question: "Q1", options: ["a", "b"], tab_label: "First" },
+				{ question: "Q2", options: ["c", "d"], tab_label: longLabel },
+			],
+		});
+		assert.equal(result?.isError, true, "overlong tab_label should set isError:true");
+		const text = textOf(result);
+		assert.match(text, /24/);
+	});
+});

--- a/tests/ask-user-choices-renderer.spec.ts
+++ b/tests/ask-user-choices-renderer.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Renderer-level unit test for AskUserChoicesRenderer.
+ *
+ * Pins the gating between the three completed-result shapes:
+ *   1. `isError: true`              → minimal `.ask-error` chip, no interactive widget chrome.
+ *   2. `{error:"..."}` w/o isError  → also minimal chip (defense-in-depth from
+ *                                     the renderer's `errored` derivation).
+ *   3. `{status:"posted"}` stub     → interactive widget renders (tabs + submit).
+ *
+ * Pattern mirrors tests/bash-renderer-description.spec.ts (file:// fixture +
+ * esbuild-on-demand bundle).
+ */
+import { test, expect } from "@playwright/test";
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const FIXTURE = path.resolve("tests/fixtures/ask-user-choices-renderer.html");
+const BUNDLE = path.resolve("tests/fixtures/ask-user-choices-renderer-bundle.js");
+const ENTRY = path.resolve("tests/fixtures/ask-user-choices-renderer-entry.ts");
+const RENDERER_SRC = path.resolve("src/ui/tools/renderers/AskUserChoicesRenderer.ts");
+const WIDGET_SRC = path.resolve("src/ui/components/AskUserChoicesWidget.ts");
+
+test.beforeAll(() => {
+	const entryMtime = Math.max(
+		fs.statSync(ENTRY).mtimeMs,
+		fs.statSync(RENDERER_SRC).mtimeMs,
+		fs.statSync(WIDGET_SRC).mtimeMs,
+	);
+	const bundleExists = fs.existsSync(BUNDLE);
+	const bundleStale = bundleExists && fs.statSync(BUNDLE).mtimeMs < entryMtime;
+	if (!bundleExists || bundleStale) {
+		execSync(
+			[
+				`npx esbuild ${ENTRY}`,
+				"--bundle --format=iife --target=es2022",
+				`--outfile=${BUNDLE}`,
+				"--tsconfig=tsconfig.web.json",
+				"--alias:pdfjs-dist=./tests/fixtures/empty-shim",
+				"--define:import.meta.url='\"http://localhost/\"'",
+			].join(" "),
+			{ stdio: "pipe" },
+		);
+	}
+});
+
+const PAGE = `file://${FIXTURE}`;
+
+const PARAMS = {
+	questions: [
+		{ question: "Q1", options: ["a", "b"], tab_label: "First" },
+		{ question: "Q2", options: ["c", "d"], tab_label: "Second" },
+	],
+};
+
+async function gotoAndWait(page: any) {
+	await page.goto(PAGE);
+	await page.waitForFunction(() => (window as any).__ready === true, null, { timeout: 10_000 });
+}
+
+test.describe("AskUserChoicesRenderer error-vs-interactive gating", () => {
+	test("isError:true result renders minimal error chip, not interactive widget", async ({ page }) => {
+		await gotoAndWait(page);
+		await page.evaluate((params) => {
+			const el = document.getElementById("container")!;
+			const result = {
+				isError: true,
+				content: [{
+					type: "text",
+					text: JSON.stringify({
+						error: "ask_user_choices: questions[1].tab_label is required when there are multiple questions.",
+					}),
+				}],
+			};
+			(window as any).__renderAsk(el, params, result, false);
+		}, PARAMS);
+
+		await expect(page.locator("#container .ask-error")).toHaveCount(1);
+		await expect(page.locator("#container [role=\"tab\"]")).toHaveCount(0);
+		await expect(page.locator("#container .ask-submit")).toHaveCount(0);
+	});
+
+	test("{error:'...'} content without isError flag also renders minimal error chip (defense-in-depth)", async ({ page }) => {
+		await gotoAndWait(page);
+		await page.evaluate((params) => {
+			const el = document.getElementById("container")!;
+			const result = {
+				// NO isError field — guards renderer's broadened `errored` derivation:
+				//   errored = state !== "inprogress" && result && !posted && !legacy
+				content: [{ type: "text", text: JSON.stringify({ error: "some failure" }) }],
+			};
+			(window as any).__renderAsk(el, params, result, false);
+		}, PARAMS);
+
+		await expect(page.locator("#container .ask-error")).toHaveCount(1);
+		await expect(page.locator("#container [role=\"tab\"]")).toHaveCount(0);
+		await expect(page.locator("#container .ask-submit")).toHaveCount(0);
+	});
+
+	test("{status:'posted'} stub renders interactive widget (tabs + submit)", async ({ page }) => {
+		await gotoAndWait(page);
+		await page.evaluate((params) => {
+			const el = document.getElementById("container")!;
+			const result = {
+				content: [{
+					type: "text",
+					text: JSON.stringify({ status: "posted", tool_use_id: "abc" }),
+				}],
+			};
+			(window as any).__renderAsk(el, params, result, false);
+		}, PARAMS);
+
+		// Two tabs (one per question) and one submit button.
+		await expect(page.locator("#container [role=\"tab\"]")).toHaveCount(2);
+		await expect(page.locator("#container .ask-submit")).toHaveCount(1);
+		await expect(page.locator("#container .ask-error")).toHaveCount(0);
+	});
+});

--- a/tests/e2e/mock-agent-core.mjs
+++ b/tests/e2e/mock-agent-core.mjs
@@ -422,6 +422,12 @@ export class MockAgentCore {
 			const filePath = MockAgentCore.extractFilePath(text);
 			return { tool: "Edit", input: { path: filePath, oldText: "ORIGINAL_VALUE", newText: "EDITED_VALUE" }, output: "Edited successfully" };
 		}
+		if (lower.includes("ask_user_choices with bad tab labels then retry")) {
+			// Simulates the failure-then-retry path: emits one ask_user_choices
+			// tool_use with questions[1] missing tab_label (rejected with isError:true)
+			// then a second, valid ask_user_choices with the {status:"posted"} stub.
+			return { askUserChoices: "errorThenRetry" };
+		}
 		if (lower.includes("ask_user_choices_multi")) {
 			return { askUserChoices: "multi" };
 		}
@@ -558,7 +564,11 @@ export class MockAgentCore {
 		if (toolAction && toolAction.toolDenied) {
 			await this._handleToolDenied(toolAction.toolDenied);
 		} else if (toolAction && toolAction.askUserChoices) {
-			await this._handleAskUserChoices(toolAction.askUserChoices === "multi");
+			if (toolAction.askUserChoices === "errorThenRetry") {
+				await this._handleAskUserChoicesErrorThenRetry();
+			} else {
+				await this._handleAskUserChoices(toolAction.askUserChoices === "multi");
+			}
 		} else if (toolAction && toolAction.liveUpdateProposal) {
 			await this._handleLiveUpdateProposal();
 		} else if (toolAction && toolAction.componentConfigProposal) {
@@ -1136,6 +1146,82 @@ export class MockAgentCore {
 		};
 		this.conversationMessages.push(toolResultMsg);
 		this.emit({ type: "message_end", message: toolResultMsg });
+	}
+
+	/**
+	 * Failure-then-retry path for the `ask_user_choices` widget. Emits two
+	 * tool calls back-to-back in the same turn:
+	 *   1. First call has questions[1] missing tab_label → tool_result is
+	 *      flagged isError:true with an `{error:"..."}` body, matching what
+	 *      the real `defaults/tools/ask/extension.ts` validation produces.
+	 *      The renderer must collapse this into a minimal `.ask-error` chip.
+	 *   2. Second call is a valid two-question ask with the normal
+	 *      `{status:"posted"}` stub, rendering the full interactive widget.
+	 *
+	 * After this turn the transcript should contain exactly ONE interactive
+	 * `<ask-user-choices-widget>` (tabs + .ask-submit) preceded by ONE
+	 * `.ask-error` chip. Drives tests/e2e/ui/ask-user-choices-ui.spec.ts's
+	 * error-then-retry case.
+	 */
+	async _handleAskUserChoicesErrorThenRetry() {
+		// ── First call — invalid (questions[1].tab_label missing) ──────────
+		const badToolId = `tool_ask_bad_${Date.now()}`;
+		const badQuestions = [
+			{ question: "Favorite color?", options: ["red", "blue", "green"], tab_label: "Color" },
+			// Intentionally missing tab_label — the real extension rejects this.
+			{ question: "Team size?", options: ["small", "medium", "large"] },
+		];
+		this.emit({ type: "tool_execution_start", toolName: "ask_user_choices", toolId: badToolId, input: { questions: badQuestions } });
+		const badAssistantMsg = {
+			role: "assistant",
+			content: [{ type: "toolCall", id: badToolId, name: "ask_user_choices", arguments: { questions: badQuestions }, input: { questions: badQuestions } }],
+		};
+		this.conversationMessages.push(badAssistantMsg);
+		this.emit({ type: "message_end", message: badAssistantMsg });
+
+		const errBody = JSON.stringify({
+			error: "ask_user_choices: questions[1].tab_label is required when there are multiple questions.",
+		});
+		this.emit({ type: "tool_execution_update", toolId: badToolId, toolName: "ask_user_choices", status: "complete", output: errBody });
+		this.emit({ type: "tool_execution_end", toolCallId: badToolId, toolName: "ask_user_choices", isError: true });
+		const badToolResultMsg = {
+			role: "toolResult",
+			toolCallId: badToolId,
+			toolName: "ask_user_choices",
+			isError: true,
+			content: [{ type: "text", text: errBody }],
+		};
+		this.conversationMessages.push(badToolResultMsg);
+		this.emit({ type: "message_end", message: badToolResultMsg });
+
+		await this.tick(20);
+
+		// ── Second call — valid, posted stub ────────────────────────────────
+		const goodToolId = `tool_ask_good_${Date.now()}`;
+		const goodQuestions = [
+			{ question: "Favorite color?", options: ["red", "blue", "green"], tab_label: "Color" },
+			{ question: "Team size?", options: ["small", "medium", "large"], tab_label: "Team size" },
+		];
+		this.emit({ type: "tool_execution_start", toolName: "ask_user_choices", toolId: goodToolId, input: { questions: goodQuestions } });
+		const goodAssistantMsg = {
+			role: "assistant",
+			content: [{ type: "toolCall", id: goodToolId, name: "ask_user_choices", arguments: { questions: goodQuestions }, input: { questions: goodQuestions } }],
+		};
+		this.conversationMessages.push(goodAssistantMsg);
+		this.emit({ type: "message_end", message: goodAssistantMsg });
+
+		const stub = JSON.stringify({ status: "posted", tool_use_id: goodToolId });
+		this.emit({ type: "tool_execution_update", toolId: goodToolId, toolName: "ask_user_choices", status: "complete", output: stub });
+		this.emit({ type: "tool_execution_end", toolCallId: goodToolId, toolName: "ask_user_choices", isError: false });
+		const goodToolResultMsg = {
+			role: "toolResult",
+			toolCallId: goodToolId,
+			toolName: "ask_user_choices",
+			isError: false,
+			content: [{ type: "text", text: stub }],
+		};
+		this.conversationMessages.push(goodToolResultMsg);
+		this.emit({ type: "message_end", message: goodToolResultMsg });
 	}
 
 	/**

--- a/tests/e2e/ui/ask-user-choices-ui.spec.ts
+++ b/tests/e2e/ui/ask-user-choices-ui.spec.ts
@@ -198,6 +198,51 @@ test.describe("ask_user_choices widget (full-stack UI)", () => {
 		await page2.close();
 	});
 
+	test("error path — failed ask renders minimal chip; retry shows exactly one interactive widget", async ({ page }) => {
+		// The bug: when ask_user_choices validation fails (e.g. missing tab_label
+		// on a multi-question ask) the renderer used to render the FULL interactive
+		// widget for the failed call, so after the agent retried the user saw two
+		// clickable widgets and couldn't tell which was live.
+		//
+		// Fix: extension returns isError:true; renderer's `errored` derivation
+		// also fires defensively when result is complete but neither posted-stub
+		// nor legacy-answers. The failed call collapses to a minimal `.ask-error`
+		// chip; only the retry renders an interactive widget.
+		//
+		// Mock-agent trigger emits both tool_uses back-to-back in the same turn:
+		// see `_handleAskUserChoicesErrorThenRetry` in tests/e2e/mock-agent-core.mjs.
+		await openApp(page);
+		await createSessionViaUI(page);
+		await sendMessage(page, "please use ask_user_choices with bad tab labels then retry");
+
+		// Wait for the retry's interactive widget to land.
+		const submit = page.locator(".ask-submit");
+		await expect(submit).toHaveCount(1, { timeout: 20_000 });
+
+		// Failed call collapsed into the minimal chip; retry rendered full chrome.
+		const errorChip = page.locator(".ask-error");
+		await expect(errorChip).toHaveCount(1);
+		await expect(errorChip).toBeVisible();
+		await expect(errorChip).toContainText("tab_label");
+
+		// DOM order: error chip precedes the interactive widget.
+		const widget = page.locator("ask-user-choices-widget").filter({ has: page.locator(".ask-submit") }).first();
+		await expect(widget).toBeVisible();
+		const order = await page.evaluate(() => {
+			const chip = document.querySelector(".ask-error");
+			const sub = document.querySelector(".ask-submit");
+			if (!chip || !sub) return null;
+			// DOCUMENT_POSITION_FOLLOWING (4) on `sub` means chip is before sub.
+			return chip.compareDocumentPosition(sub) & 4 ? "chip-before-widget" : "chip-after-widget";
+		});
+		expect(order).toBe("chip-before-widget");
+
+		// There are TWO ask-user-choices-widget elements (one per tool_use), but
+		// only ONE shows interactive chrome — the failed one is collapsed.
+		await expect(page.locator("[role=\"tab\"]")).toHaveCount(2); // two tabs on the live widget
+		await expect(page.locator(".ask-submit")).toHaveCount(1); // exactly one Submit button
+	});
+
 	test("keyboard-only multi-question submission", async ({ page }) => {
 		await openApp(page);
 		await createSessionViaUI(page);

--- a/tests/fixtures/ask-user-choices-renderer-entry.ts
+++ b/tests/fixtures/ask-user-choices-renderer-entry.ts
@@ -1,0 +1,25 @@
+// Test entry — bundles AskUserChoicesRenderer so we can render it in a file:// fixture.
+//
+// The renderer imports `AskUserChoicesWidget` for its custom-element side effect
+// (auto-registers <ask-user-choices-widget>). The explicit import below makes
+// that intent visible and resilient to tree-shaking.
+import { render } from "lit";
+import { AskUserChoicesRenderer } from "../../src/ui/tools/renderers/AskUserChoicesRenderer.js";
+import "../../src/ui/components/AskUserChoicesWidget.js";
+
+function renderAsk(
+	container: HTMLElement,
+	params: any,
+	result: any = undefined,
+	isStreaming = false,
+) {
+	const r = new AskUserChoicesRenderer();
+	// ctx is undefined — the fixture does not exercise the envelope-answer
+	// lookup path; only the renderer's gating between interactive / posted-stub /
+	// error states.
+	const out = r.render(params, result, isStreaming, undefined);
+	render(out.content, container);
+}
+
+(window as any).__renderAsk = renderAsk;
+(window as any).__ready = true;

--- a/tests/fixtures/ask-user-choices-renderer.html
+++ b/tests/fixtures/ask-user-choices-renderer.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>AskUserChoicesRenderer fixture</title>
+<style>
+	body { font-family: sans-serif; padding: 8px; }
+	.italic { font-style: italic; }
+	.font-mono { font-family: ui-monospace, monospace; }
+	.text-muted-foreground { color: #888; }
+	.text-destructive { color: #c00; }
+	.hidden { display: none; }
+</style>
+</head>
+<body>
+<div id="container"></div>
+<script src="./ask-user-choices-renderer-bundle.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

When the `ask_user_choices` tool fails `tab_label` validation, the UI rendered the **full interactive question widget** instead of a minimal error indicator. The agent then retried with a new `tool_use_id`, producing a **second** interactive widget — the user saw two clickable question widgets and could not tell which was live.

## Fix

- **`defaults/tools/ask/extension.ts`** — the two `tab_label` validation failure paths (missing/empty, >24 chars on multi-question asks) now return `isError: true` on the tool result envelope instead of a successful-shape `{error:"..."}` body. Error message strings unchanged.
- **`src/ui/tools/renderers/AskUserChoicesRenderer.ts`** — `errored` derivation broadened (defense-in-depth) so a completed tool result that is neither the `{status:"posted"}` stub nor a legacy answers payload also takes the error branch when `isError` is absent. The existing minimal `<div class="ask-error">` branch in `AskUserChoicesWidget` is now reached on failure.

Wire format and non-blocking flow unchanged.

## Tests

- `tests/ask-extension-execute.test.ts` — Node-runner unit test, pins that the extension returns `isError: true` on each validation failure path.
- `tests/ask-user-choices-renderer.spec.ts` (+ `tests/fixtures/ask-user-choices-renderer-{entry.ts,html}`) — Playwright file:// fixture test, pins that the renderer routes `isError: true` and unknown-shape completed results to the `.ask-error` chip, and that the `{status:"posted"}` stub still renders the interactive widget.
- `tests/e2e/ui/ask-user-choices-ui.spec.ts` — new E2E case driving failure-then-retry; asserts exactly one interactive widget and one preceding `.ask-error` chip. Required extending `tests/e2e/mock-agent-core.mjs` with a new trigger phrase.

## Docs

- `docs/non-blocking-ask.md` — added "Error results render as a minimal chip" section enumerating the three result envelope shapes (`{status:"posted"}` / `{answers:[...]}` / `isError:true`) and citing the three pinning tests as source-of-truth invariants. `AGENTS.md` untouched.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)