### PR TITLE
Plugin system foundations for autoresearch workflows

### DIFF
--- a/defaults/plugins/autoresearch/README.md
+++ b/defaults/plugins/autoresearch/README.md
@@ -1,0 +1,109 @@
+# Autoresearch plugin
+
+A bobbit plugin that turns the Goal/Workflow/Gate machinery into an
+autoresearch pipeline: a Goal is a research idea, gates are research-lifecycle
+checkpoints, verification is structured human/LLM judgement against rubrics
+plus webhook-driven external job tracking.
+
+This plugin ships **data only**. It does not register any plugin-side
+verify-step handler code; the workflow it contributes uses bobbit's built-in
+verify types: `rubric-review`, `external-job`, and `llm-review`. As a result
+the plugin is auto-trusted when installed from `defaults/plugins/` (no
+approval prompt) and has no native code to audit.
+
+## The workflow
+
+`autoresearch::research` (id `research`) defines a six-stage research
+lifecycle:
+
+| Stage             | Gate id          | Verification                                                                 |
+|-------------------|------------------|------------------------------------------------------------------------------|
+| Research idea     | `idea`           | None — content gate; team lead signals after capturing the idea.             |
+| Literature        | `literature`     | `rubric-review` (LLM) — coverage / novelty / rigor each ≥ 3.                  |
+| Plan              | `plan`           | `rubric-review` (LLM) — clarity ≥ 3, feasibility ≠ low, rigor ≥ 3.            |
+| Experiment        | `experiment-run` | `external-job` — external system POSTs verdict + artifact to a webhook.       |
+| Analysis          | `analysis`       | `rubric-review` (LLM) — soundness ≥ 3, honesty ≥ 3.                          |
+| Publication       | `publication`    | Manual — human researcher clicks "Mark passed" when the work is shareable.   |
+
+Each content-bearing gate (`idea`, `literature`, `plan`, `analysis`) carries
+`inject_downstream: true` so its accepted content is auto-prepended to every
+downstream agent's system prompt under the `# Upstream Gates` section. The
+plan agent sees the idea + literature; the analysis agent sees idea +
+literature + plan + experiment-run summary.
+
+## Installing into a project
+
+1. **Trust** — when shipped under `defaults/plugins/autoresearch/`, this
+   plugin is auto-trusted. From other locations (`~/.bobbit/plugins/`,
+   `<project>/.bobbit/plugins/`) you must click Trust in Settings → Plugins.
+
+2. **Install** — open Settings → Plugins for the target project and click
+   Install. The plugin's workflow is copied into `project.yaml::plugin_workflows`
+   as a frozen snapshot under the namespaced id `autoresearch::research`. New
+   goals can select it from the workflow dropdown.
+
+3. **Run** — create a goal against the workflow. The team lead progresses
+   gates with `gate_signal` as usual.
+
+## Wiring the `experiment-run` callback
+
+When the team lead signals the `experiment-run` gate, the external-job
+handler mints a single-use token and broadcasts a `gate_verification_external_pending`
+event. The token is also visible in the goal dashboard's running-verification
+card. Hand that token to the external system (training queue, batch runner,
+human collaborator with compute) and have it POST when the run finishes:
+
+```bash
+curl -X POST "$GATEWAY_URL/api/verify/external/<token>" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "goalId":   "<goal-id>",
+    "gateId":   "experiment-run",
+    "signalId": "<signal-id>",
+    "passed":   true,
+    "summary":  "Training run completed. Top-line metric: 0.92.",
+    "artifact": {
+      "content":     "# Training report\n\nFull metrics, plots, run config…",
+      "contentType": "text/markdown"
+    }
+  }'
+```
+
+The token, goalId, gateId, and signalId are all in the WebSocket event
+emitted at signal time. Token validation is strict: a tampered triple, a
+re-used token, or a callback after `timeout: 604800` seconds is rejected.
+On timeout the gate fails with a clear message and the team lead can
+re-signal to mint a fresh token.
+
+## Customising the rubrics
+
+The rubric definitions in `workflows/autoresearch.yaml` are deliberately
+generic. To tailor them to a research group's standards (more dimensions,
+stricter `pass_when`, additional reviewer roles), copy this plugin into
+`~/.bobbit/plugins/<your-fork>/` or `<project>/.bobbit/plugins/<your-fork>/`,
+edit the YAML, bump the `version`, and re-install. Plugin install copies the
+workflow into the project as a frozen snapshot, so in-flight goals are
+unaffected by edits to the plugin source.
+
+## What this plugin does not (yet) ship
+
+- A `researcher` role with custom tool policies. The roles cascade integration
+  for plugin-contributed `roles/` is a follow-up; for now the workflow uses
+  the default `reviewer` role.
+- A literature search tool (`tool-call` step). Drop an MCP server (arxiv,
+  Semantic Scholar, etc.) into `.bobbit/config/mcp.json` and edit the
+  `literature` gate to add a `tool-call` step that invokes it if you want
+  the LLM rubric review to be backed by a real lookup.
+- Restart-resume for in-flight `external-job` callbacks. The token store is
+  in-memory in v1; a gateway restart causes pending callbacks to time out
+  cleanly rather than survive. The Phase 2 harness refactor (extracting
+  `tryResume` onto handlers) unblocks this.
+
+## See also
+
+- [docs/goals-workflows-tasks.md](../../../docs/goals-workflows-tasks.md) —
+  the full Goal/Workflow/Gate model this plugin builds on.
+- [src/server/agent/verify-handlers/](../../../src/server/agent/verify-handlers/) —
+  source of the built-in `rubric-review`, `external-job`, `tool-call`,
+  and `llm-review` step handlers.

--- a/defaults/plugins/autoresearch/plugin.yaml
+++ b/defaults/plugins/autoresearch/plugin.yaml
@@ -1,0 +1,20 @@
+name: autoresearch
+version: 0.1.0
+description: |
+  Workflow templates for autoresearch — treating Goals as research ideas that
+  progress through literature review, planning, experimentation, and write-up.
+  Uses the built-in `rubric-review`, `external-job`, and `llm-review` verify
+  step types; no plugin code beyond data.
+
+bobbit:
+  engines: ">=0.9.0"
+
+contributes:
+  workflows:
+    - workflows/autoresearch.yaml
+
+# Declared up-front so the trust prompt (when this isn't auto-trusted) can show
+# the user what coarse capabilities the plugin needs.
+permissions:
+  - external-webhook   # external-job training/experiment callbacks
+  - llm-review         # rubric-review/llm spawns a reviewer sub-agent

--- a/defaults/plugins/autoresearch/workflows/autoresearch.yaml
+++ b/defaults/plugins/autoresearch/workflows/autoresearch.yaml
@@ -1,0 +1,145 @@
+# Autoresearch workflow — Goal == research idea.
+#
+# Stages map onto bobbit gates with the new built-in verify types:
+#   idea            — content gate, no verification (the seed)
+#   literature      — rubric-review (LLM scores coverage / novelty)
+#   plan            — content gate, rubric-review (LLM scores rigor / feasibility)
+#   experiment-run  — external-job (training run or batch experiment callback)
+#   analysis        — content gate, rubric-review (LLM scores soundness)
+#   publication     — manual gate (human sign-off)
+#
+# Content from idea / plan / analysis is injected downstream via
+# inject_downstream:true so each subsequent stage sees the upstream artifacts
+# without explicit input_gate_ids on every team_spawn.
+
+id: research
+name: Autoresearch
+description: Research idea → literature → plan → experiment → analysis → publication.
+gates:
+  - id: idea
+    name: Research idea
+    content: true
+    inject_downstream: true
+    # No verify — the team lead signals after the idea is captured.
+
+  - id: literature
+    name: Literature coverage
+    depends_on: [idea]
+    content: true
+    inject_downstream: true
+    verify:
+      - name: Coverage rubric
+        type: rubric-review
+        reviewer: llm
+        role: reviewer
+        prompt: |
+          You are reviewing a literature survey for a research idea.
+
+          The idea (from the upstream `idea` gate) is in the Upstream Gates
+          section of your system prompt. The survey itself is the content
+          attached to this `literature` gate signal.
+
+          Score the survey against the rubric below. Be conservative: a survey
+          that misses major prior work, fails to cite seminal papers in the
+          area, or mischaracterises an existing approach should fail novelty
+          OR coverage even if it cites many references.
+        rubric:
+          - id: coverage
+            label: Coverage of prior work
+            scale: { min: 1, max: 5 }
+          - id: novelty
+            label: Novelty against cited work
+            scale: { min: 1, max: 5 }
+          - id: rigor
+            label: Citation rigor (are claims grounded)
+            scale: { min: 1, max: 5 }
+        # Coverage >= 3 AND novelty >= 3 AND rigor >= 3 — gate fails if any
+        # rubric item is below 3. Tighter than "all >= 2" so a weak survey
+        # blocks the experiment-run gate.
+        pass_when: "coverage >= 3 AND novelty >= 3 AND rigor >= 3"
+
+  - id: plan
+    name: Experimental plan
+    depends_on: [literature]
+    content: true
+    inject_downstream: true
+    verify:
+      - name: Plan rubric
+        type: rubric-review
+        reviewer: llm
+        role: reviewer
+        prompt: |
+          You are reviewing an experimental plan for a research idea.
+
+          The idea and the prior literature survey are available in the
+          Upstream Gates section of your system prompt. The plan itself is
+          the content attached to this `plan` gate signal.
+
+          Score the plan against the rubric. A plan that lacks clear success
+          criteria, has no plan-of-record for what to do if the primary
+          hypothesis fails, or relies on data/compute the project does not
+          have access to should fail feasibility.
+        rubric:
+          - id: clarity
+            label: Clarity of hypotheses and success criteria
+            scale: { min: 1, max: 5 }
+          - id: feasibility
+            label: Feasibility given available data / compute
+            options: [low, medium, high]
+          - id: rigor
+            label: Methodological rigor (controls, statistics, ablations)
+            scale: { min: 1, max: 5 }
+        pass_when: "clarity >= 3 AND feasibility != 'low' AND rigor >= 3"
+
+  - id: experiment-run
+    name: Experiment / training run
+    depends_on: [plan]
+    # No content gate — the artifact comes back via the external callback.
+    verify:
+      - name: Run completion
+        type: external-job
+        # 7-day budget for long training runs. The external system posts
+        # to /api/verify/external/<token> with passed/summary/artifact once
+        # the run finishes. Token + (goalId,gateId,signalId) triple must
+        # match; tokens are single-use.
+        timeout: 604800
+
+  - id: analysis
+    name: Results analysis
+    depends_on: [experiment-run]
+    content: true
+    inject_downstream: true
+    verify:
+      - name: Analysis rubric
+        type: rubric-review
+        reviewer: llm
+        role: reviewer
+        prompt: |
+          You are reviewing a results analysis for an experiment.
+
+          Idea, literature, plan, and experiment-run summary are all in the
+          Upstream Gates section. The analysis is the content attached to
+          this `analysis` gate signal.
+
+          Score the analysis. A writeup that overclaims (e.g. positive
+          conclusions from cherry-picked metrics), conflates correlation with
+          causation, or fails to acknowledge negative results should fail
+          soundness.
+        rubric:
+          - id: soundness
+            label: Statistical / methodological soundness
+            scale: { min: 1, max: 5 }
+          - id: honesty
+            label: Honesty about limitations / negative results
+            scale: { min: 1, max: 5 }
+          - id: actionability
+            label: Clear next steps or conclusions
+            scale: { min: 1, max: 5 }
+        pass_when: "soundness >= 3 AND honesty >= 3"
+
+  - id: publication
+    name: Publication-ready
+    depends_on: [analysis]
+    # Manual gate — the human researcher decides when the work is shareable
+    # (internal write-up, preprint, paper submission). No automated check.
+    manual: true

--- a/src/app/routing.ts
+++ b/src/app/routing.ts
@@ -4,9 +4,9 @@
 
 export type RouteView = "landing" | "session" | "goal" | "goal-dashboard" | "roles" | "role-edit" | "tools" | "tool-edit" | "workflows" | "workflow-edit" | "staff" | "staff-edit" | "skills" | "settings" | "search";
 
-export type SettingsTabId = "shortcuts" | "general" | "project" | "components" | "workflows" | "models" | "palette" | "directories" | "account" | "appearance" | "maintenance";
+export type SettingsTabId = "shortcuts" | "general" | "project" | "components" | "workflows" | "models" | "palette" | "directories" | "account" | "appearance" | "maintenance" | "plugins";
 
-const SETTINGS_TABS = new Set<SettingsTabId>(["shortcuts", "general", "project", "components", "workflows", "models", "palette", "directories", "account", "appearance", "maintenance"]);
+const SETTINGS_TABS = new Set<SettingsTabId>(["shortcuts", "general", "project", "components", "workflows", "models", "palette", "directories", "account", "appearance", "maintenance", "plugins"]);
 
 export function getRouteFromHash(): { view: RouteView; sessionId?: string; goalId?: string; roleName?: string; toolName?: string; workflowId?: string; staffId?: string; settingsScope?: string; settingsTab?: SettingsTabId; searchQuery?: string } {
 	const hash = window.location.hash || "";

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -41,6 +41,7 @@ import { dispatchIndexEvent } from "./components/search-status-dot.js";
 import "./components/search-status-dot.js";
 import { openOAuthDialog } from "./dialogs.js";
 import { componentToEditState, buildSavePayload, type ComponentEditState } from "./components-editor.js";
+import { renderSystemPluginsTab, renderProjectPluginsTab } from "./settings-plugins-tab.js";
 import { ModelSelector } from "../ui/dialogs/ModelSelector.js";
 import { ImageModelSelector, type ImageGenerationModel } from "../ui/dialogs/ImageModelSelector.js";
 import { AigwModelsDialog } from "../ui/dialogs/AigwModelsDialog.js";
@@ -53,6 +54,7 @@ const SYSTEM_TABS: { id: SettingsTab; label: string }[] = [
 	{ id: "general", label: "General" },
 	{ id: "models", label: "Models" },
 	{ id: "directories", label: "Config Directories" },
+	{ id: "plugins", label: "Plugins" },
 	{ id: "palette", label: "Color Palette" },
 	{ id: "account", label: "Account" },
 	{ id: "maintenance", label: "Maintenance" },
@@ -64,6 +66,7 @@ const PROJECT_TABS: { id: SettingsTab; label: string }[] = [
 	{ id: "components", label: "Components" },
 	{ id: "workflows", label: "Workflows" },
 	{ id: "directories", label: "Config Directories" },
+	{ id: "plugins", label: "Plugins" },
 	{ id: "appearance", label: "Appearance" },
 ];
 
@@ -3677,12 +3680,14 @@ export function renderSettingsPage() {
 						${currentTab === "components" ? renderProjectComponentsTab(currentScope) : ""}
 						${currentTab === "workflows" ? renderProjectScopeWorkflowsTab(currentScope) : ""}
 						${currentTab === "directories" ? renderProjectScopeDirectoriesTab(currentScope) : ""}
+						${currentTab === "plugins" ? renderProjectPluginsTab(currentScope) : ""}
 					` : html`
 						${currentTab === "general" ? renderGeneralTab() : ""}
 						${currentTab === "models" ? renderModelsTab() : ""}
 						${currentTab === "shortcuts" ? renderShortcutsTab() : ""}
 						${currentTab === "palette" ? renderPaletteTab() : ""}
 						${currentTab === "directories" ? renderDirectoriesTab() : ""}
+						${currentTab === "plugins" ? renderSystemPluginsTab() : ""}
 						${currentTab === "account" ? renderAccountTab() : ""}
 						${currentTab === "maintenance" ? renderMaintenanceTab() : ""}
 					`}

--- a/src/app/settings-plugins-tab.ts
+++ b/src/app/settings-plugins-tab.ts
@@ -1,0 +1,239 @@
+/**
+ * Settings → Plugins tab.
+ *
+ * Two modes:
+ *   - System scope: list every discovered plugin (builtin, server, user) with
+ *     load status and a Trust / Revoke button per non-builtin row.
+ *   - Project scope: same listing, plus per-row Install / Uninstall against
+ *     the active project. Installation copies the plugin's contributed
+ *     workflows into project.yaml::plugin_workflows as frozen snapshots.
+ *
+ * Rendered live: we re-fetch the discovery list on every render and again
+ * after any mutating action. Polling is not needed — the gateway list is the
+ * source of truth and changes are infrequent.
+ */
+import { html, render } from "lit";
+import { gatewayFetch } from "./api.js";
+
+interface PluginContrib {
+	workflows?: string[];
+	roles?: string[];
+	skills?: string[];
+	tools_dirs?: string[];
+	mcp?: string[];
+}
+
+interface PluginRecord {
+	name: string;
+	version: string;
+	description?: string;
+	source: "builtin" | "server" | "user" | "project";
+	path: string;
+	contributes: PluginContrib | null;
+	entryPoints: { gateway?: string; ui?: string } | null;
+	verifyStepTypes: string[];
+	permissions: string[];
+	manifestErrors: { field: string; message: string }[];
+	load: { status: string; registeredTypes?: string[]; error?: string; errors?: unknown[] };
+}
+
+interface ProjectInstallRecord {
+	name: string;
+	version: string;
+	installedAt: number;
+	workflows: { id: string; namespacedId: string }[];
+}
+
+const containerKey = "__bobbit_plugin_tab_container";
+
+async function fetchPlugins(): Promise<PluginRecord[]> {
+	const resp = await gatewayFetch("/api/plugins");
+	if (!resp.ok) return [];
+	const body = await resp.json() as { plugins?: PluginRecord[] };
+	return body.plugins ?? [];
+}
+
+async function fetchProjectInstalls(projectId: string): Promise<ProjectInstallRecord[]> {
+	const resp = await gatewayFetch(`/api/projects/${encodeURIComponent(projectId)}/plugins`);
+	if (!resp.ok) return [];
+	const body = await resp.json() as { plugins?: ProjectInstallRecord[] };
+	return body.plugins ?? [];
+}
+
+async function trust(name: string): Promise<void> {
+	await gatewayFetch(`/api/plugins/${encodeURIComponent(name)}/trust`, { method: "POST" });
+}
+
+async function revoke(name: string): Promise<void> {
+	await gatewayFetch(`/api/plugins/${encodeURIComponent(name)}/trust`, { method: "DELETE" });
+}
+
+async function install(projectId: string, name: string): Promise<{ ok: boolean; error?: string }> {
+	const resp = await gatewayFetch(`/api/projects/${encodeURIComponent(projectId)}/plugins/${encodeURIComponent(name)}/install`, { method: "POST" });
+	if (!resp.ok) {
+		const body = await resp.json().catch(() => ({})) as { error?: string };
+		return { ok: false, error: body.error };
+	}
+	return { ok: true };
+}
+
+async function uninstall(projectId: string, name: string): Promise<void> {
+	await gatewayFetch(`/api/projects/${encodeURIComponent(projectId)}/plugins/${encodeURIComponent(name)}`, { method: "DELETE" });
+}
+
+function statusBadge(load: PluginRecord["load"]) {
+	const colour = load.status === "loaded" ? "bg-green-500/15 text-green-600"
+		: load.status === "needs-approval" ? "bg-amber-500/15 text-amber-600"
+		: load.status === "manifest-invalid" || load.status === "error" ? "bg-red-500/15 text-red-600"
+		: "bg-secondary text-muted-foreground";
+	return html`<span class="text-xs px-2 py-0.5 rounded ${colour}">${load.status}</span>`;
+}
+
+function sourceBadge(source: PluginRecord["source"]) {
+	const colour = source === "builtin" ? "bg-blue-500/15 text-blue-600"
+		: source === "user" ? "bg-purple-500/15 text-purple-600"
+		: source === "project" ? "bg-orange-500/15 text-orange-600"
+		: "bg-secondary text-muted-foreground";
+	return html`<span class="text-xs px-2 py-0.5 rounded ${colour}">${source}</span>`;
+}
+
+function pluginRow(opts: {
+	p: PluginRecord;
+	scope: "system" | "project";
+	projectId?: string;
+	installed: boolean;
+	onMutate(): void;
+}) {
+	const { p, scope, projectId, installed, onMutate } = opts;
+	const contrib = p.contributes ?? {};
+	const contribLines = [
+		(contrib.workflows && contrib.workflows.length > 0) ? `${contrib.workflows.length} workflow${contrib.workflows.length === 1 ? "" : "s"}` : "",
+		(contrib.roles && contrib.roles.length > 0) ? `${contrib.roles.length} role${contrib.roles.length === 1 ? "" : "s"}` : "",
+		(contrib.skills && contrib.skills.length > 0) ? `${contrib.skills.length} skill${contrib.skills.length === 1 ? "" : "s"}` : "",
+		(contrib.tools_dirs && contrib.tools_dirs.length > 0) ? `${contrib.tools_dirs.length} tool dir${contrib.tools_dirs.length === 1 ? "" : "s"}` : "",
+		(contrib.mcp && contrib.mcp.length > 0) ? `${contrib.mcp.length} MCP server${contrib.mcp.length === 1 ? "" : "s"}` : "",
+		(p.verifyStepTypes.length > 0) ? `verify types: ${p.verifyStepTypes.join(", ")}` : "",
+	].filter(Boolean).join(" · ");
+	const isTrustable = p.source !== "builtin";
+	const trusted = p.load.status === "loaded" || p.load.registeredTypes !== undefined;
+
+	const handleTrust = async () => {
+		await trust(p.name);
+		onMutate();
+	};
+	const handleRevoke = async () => {
+		await revoke(p.name);
+		onMutate();
+	};
+	const handleInstall = async () => {
+		if (!projectId) return;
+		const result = await install(projectId, p.name);
+		if (!result.ok) alert(`Install failed: ${result.error}`);
+		onMutate();
+	};
+	const handleUninstall = async () => {
+		if (!projectId) return;
+		await uninstall(projectId, p.name);
+		onMutate();
+	};
+
+	return html`
+		<div class="border border-border rounded-md p-3 mb-2">
+			<div class="flex items-start justify-between gap-3">
+				<div class="flex-1 min-w-0">
+					<div class="flex items-center gap-2 flex-wrap">
+						<span class="font-medium">${p.name}</span>
+						<span class="text-xs text-muted-foreground">v${p.version}</span>
+						${sourceBadge(p.source)}
+						${statusBadge(p.load)}
+						${installed ? html`<span class="text-xs px-2 py-0.5 rounded bg-green-500/15 text-green-600">installed</span>` : ""}
+					</div>
+					${p.description ? html`<div class="text-sm text-muted-foreground mt-1">${p.description}</div>` : ""}
+					${contribLines ? html`<div class="text-xs text-muted-foreground mt-1">${contribLines}</div>` : ""}
+					${p.manifestErrors.length > 0 ? html`
+						<div class="mt-2 text-xs text-red-600">
+							Manifest errors:
+							<ul class="list-disc list-inside">
+								${p.manifestErrors.map(e => html`<li>${e.field}: ${e.message}</li>`)}
+							</ul>
+						</div>
+					` : ""}
+					${p.load.status === "error" ? html`<div class="mt-2 text-xs text-red-600">Load error: ${p.load.error}</div>` : ""}
+				</div>
+				<div class="flex flex-col gap-1 items-end shrink-0">
+					${isTrustable ? html`
+						${trusted
+							? html`<button class="text-xs px-2 py-1 rounded border border-border hover:bg-secondary" @click=${handleRevoke}>Revoke trust</button>`
+							: html`<button class="text-xs px-2 py-1 rounded bg-primary text-primary-foreground hover:opacity-90" @click=${handleTrust}>Trust</button>`}
+					` : html`<span class="text-xs text-muted-foreground">auto-trusted</span>`}
+					${scope === "project" && projectId ? html`
+						${installed
+							? html`<button class="text-xs px-2 py-1 rounded border border-border hover:bg-secondary" @click=${handleUninstall}>Uninstall</button>`
+							: html`<button class="text-xs px-2 py-1 rounded border border-border hover:bg-secondary" @click=${handleInstall} ?disabled=${p.load.status !== "loaded" && p.load.status !== "needs-approval"}>Install</button>`}
+					` : ""}
+				</div>
+			</div>
+		</div>
+	`;
+}
+
+/** Render the system-scope Plugins tab body. */
+export function renderSystemPluginsTab() {
+	const container = document.createElement("div");
+	(container as any)[containerKey] = true;
+
+	const refresh = async () => {
+		const plugins = await fetchPlugins();
+		const view = plugins.length === 0
+			? html`<div class="text-sm text-muted-foreground">No plugins discovered. Drop a folder containing <code>plugin.yaml</code> into <code>~/.bobbit/plugins/</code> or <code>./.bobbit/plugins/</code> and refresh.</div>`
+			: html`
+				<div class="text-sm text-muted-foreground mb-3">
+					Plugins extend bobbit with workflow templates, roles, skills, tools, and new verify-step types.
+					Untrusted plugins are discovered but their code is not run until you click Trust.
+				</div>
+				${plugins.map(p => pluginRow({ p, scope: "system", installed: false, onMutate: refresh }))}
+			`;
+		render(view, container);
+	};
+	refresh();
+	return html`${container}`;
+}
+
+/** Render the project-scope Plugins tab body. */
+export function renderProjectPluginsTab(projectId: string) {
+	const container = document.createElement("div");
+	(container as any)[containerKey] = true;
+
+	const refresh = async () => {
+		const [plugins, installs] = await Promise.all([fetchPlugins(), fetchProjectInstalls(projectId)]);
+		const installedNames = new Set(installs.map(i => i.name));
+		const view = plugins.length === 0
+			? html`<div class="text-sm text-muted-foreground">No plugins discovered yet. Drop one into <code>~/.bobbit/plugins/</code> or <code>${"./.bobbit/plugins/"}</code> and refresh.</div>`
+			: html`
+				<div class="text-sm text-muted-foreground mb-3">
+					Installing a plugin into this project copies its workflow templates as frozen snapshots under <code>plugin_workflows:</code> in <code>project.yaml</code>. Plugin-registered verify-step types are global, not per-project.
+				</div>
+				${plugins.map(p => pluginRow({
+					p, scope: "project", projectId,
+					installed: installedNames.has(p.name),
+					onMutate: refresh,
+				}))}
+				${installs.length > 0 ? html`
+					<div class="mt-4 pt-4 border-t border-border">
+						<div class="text-sm font-medium mb-2">Installed in this project</div>
+						${installs.map(i => html`
+							<div class="text-xs text-muted-foreground mb-1">
+								<span class="font-mono">${i.name}@${i.version}</span>
+								${i.workflows.length > 0
+									? html` — workflows: ${i.workflows.map(w => html`<code class="mx-1">${w.namespacedId}</code>`)}`
+									: ""}
+							</div>
+						`)}
+					</div>
+				` : ""}
+			`;
+		render(view, container);
+	};
+	refresh();
+	return html`${container}`;
+}

--- a/src/server/agent/gate-store.ts
+++ b/src/server/agent/gate-store.ts
@@ -1,12 +1,12 @@
 import fs from "node:fs";
 import path from "node:path";
-import type { Workflow } from "./workflow-store.js";
+import type { Workflow, BuiltinVerifyStepType } from "./workflow-store.js";
 
 export type GateStatus = "pending" | "passed" | "failed";
 
 export interface GateSignalStep {
 	name: string;
-	type: "command" | "llm-review" | "agent-qa";
+	type: BuiltinVerifyStepType | (string & {});
 	passed: boolean;
 	skipped?: boolean;
 	output: string;

--- a/src/server/agent/project-config-store.ts
+++ b/src/server/agent/project-config-store.ts
@@ -189,6 +189,24 @@ const MIGRATED_KEYS = new Set([
 	"sandbox_tokens",
 ]);
 
+/** Record of a plugin installed into this project. Stored in project.yaml::plugins. */
+export interface PluginInstallation {
+	name: string;
+	version: string;
+	installedAt: number;
+}
+
+/** A workflow shipped by an installed plugin. Stored separately from user workflows
+ *  so reinstall/upgrade doesn't have to scan-and-patch user-edited workflows: blocks. */
+export interface PluginWorkflowEntry {
+	/** Plugin name that shipped this workflow. */
+	source: string;
+	/** Plugin-side workflow id (no namespace prefix). */
+	id: string;
+	/** Frozen snapshot of the workflow at install time. */
+	snapshot: InlineWorkflowDef;
+}
+
 function isPlainObject(x: unknown): x is Record<string, unknown> {
 	return !!x && typeof x === "object" && !Array.isArray(x);
 }
@@ -263,6 +281,11 @@ export class ProjectConfigStore {
 	/** Structured side-table — components[] and workflows{} from the same yaml file. */
 	private components: Component[] = [];
 	private workflows: Record<string, InlineWorkflowDef> | undefined;
+	/** Plugin installations and their shipped-workflow snapshots — kept separate from
+	 *  the user-owned `workflows:` block so upgrade/uninstall doesn't have to scan and patch
+	 *  hand-edited content. */
+	private installedPlugins: PluginInstallation[] = [];
+	private pluginWorkflows: PluginWorkflowEntry[] = [];
 
 	// ── Native-YAML migrated fields ──
 	private configDirectories: ConfigDirectoryEntry[] = [];
@@ -325,6 +348,31 @@ export class ProjectConfigStore {
 			this.workflows = isPlainObject(raw.workflows)
 				? raw.workflows as Record<string, InlineWorkflowDef>
 				: undefined;
+
+			// Plugin installations + plugin-shipped workflow snapshots.
+			this.installedPlugins = Array.isArray(raw.plugins)
+				? (raw.plugins as unknown[]).flatMap(p => {
+					if (!isPlainObject(p)) return [];
+					if (typeof p.name !== "string" || typeof p.version !== "string") return [];
+					return [{
+						name: p.name,
+						version: p.version,
+						installedAt: typeof p.installedAt === "number" ? p.installedAt : 0,
+					}];
+				})
+				: [];
+			this.pluginWorkflows = Array.isArray(raw.plugin_workflows)
+				? (raw.plugin_workflows as unknown[]).flatMap(e => {
+					if (!isPlainObject(e)) return [];
+					if (typeof e.source !== "string" || typeof e.id !== "string") return [];
+					if (!isPlainObject(e.snapshot)) return [];
+					return [{
+						source: e.source,
+						id: e.id,
+						snapshot: e.snapshot as unknown as InlineWorkflowDef,
+					}];
+				})
+				: [];
 
 			// ── Migrated fields — accept native, legacy JSON-string, or numeric-string ──
 			this.loadMigrated(raw);
@@ -416,6 +464,20 @@ export class ProjectConfigStore {
 			}
 			if (this.workflows && Object.keys(this.workflows).length > 0) {
 				out.workflows = this.workflows;
+			}
+			if (this.installedPlugins.length > 0) {
+				out.plugins = this.installedPlugins.map(p => ({
+					name: p.name,
+					version: p.version,
+					installedAt: p.installedAt,
+				}));
+			}
+			if (this.pluginWorkflows.length > 0) {
+				out.plugin_workflows = this.pluginWorkflows.map(e => ({
+					source: e.source,
+					id: e.id,
+					snapshot: e.snapshot,
+				}));
 			}
 
 			// Native-YAML migrated fields. Only emit when explicitly set / non-default
@@ -671,6 +733,46 @@ export class ProjectConfigStore {
 	/** Replace the workflows{} map. Persists immediately. */
 	setWorkflows(workflows: Record<string, InlineWorkflowDef> | undefined): void {
 		this.workflows = workflows ? structuredClone(workflows) : undefined;
+		this.save();
+	}
+
+	// ── Plugin installations ────────────────────────────────────
+
+	getInstalledPlugins(): PluginInstallation[] {
+		return structuredClone(this.installedPlugins);
+	}
+
+	isPluginInstalled(name: string): boolean {
+		return this.installedPlugins.some(p => p.name === name);
+	}
+
+	getPluginWorkflows(): PluginWorkflowEntry[] {
+		return structuredClone(this.pluginWorkflows);
+	}
+
+	/** Add or replace an install record. Persists immediately. */
+	addInstalledPlugin(p: PluginInstallation): void {
+		this.installedPlugins = this.installedPlugins.filter(x => x.name !== p.name);
+		this.installedPlugins.push({ ...p });
+		this.save();
+	}
+
+	/** Remove an install record and drop any workflows the plugin contributed. */
+	removeInstalledPlugin(name: string): boolean {
+		const before = this.installedPlugins.length;
+		this.installedPlugins = this.installedPlugins.filter(p => p.name !== name);
+		this.pluginWorkflows = this.pluginWorkflows.filter(e => e.source !== name);
+		if (this.installedPlugins.length === before) return false;
+		this.save();
+		return true;
+	}
+
+	/** Replace the plugin_workflows entries for a given plugin source. Persists immediately. */
+	setPluginWorkflows(source: string, entries: Omit<PluginWorkflowEntry, "source">[]): void {
+		this.pluginWorkflows = this.pluginWorkflows.filter(e => e.source !== source);
+		for (const e of entries) {
+			this.pluginWorkflows.push({ source, id: e.id, snapshot: structuredClone(e.snapshot) });
+		}
 		this.save();
 	}
 

--- a/src/server/agent/verification-harness.ts
+++ b/src/server/agent/verification-harness.ts
@@ -31,6 +31,10 @@ import {
 } from "./verification-logic.js";
 import { Semaphore } from "./semaphore.js";
 import { applyReviewModelOverrides, applyModelString } from "./review-model-override.js";
+import { VerifyHandlerRegistry, unknownTypeFailureResult, type VerifyExecCtx } from "./verify-handlers/registry.js";
+import { externalJobHandler } from "./verify-handlers/external-job-handler.js";
+import { rubricReviewHandler } from "./verify-handlers/rubric-review-handler.js";
+import { toolCallHandler } from "./verify-handlers/tool-call-handler.js";
 
 /**
  * Compute the absolute working directory for a component, given a per-branch
@@ -362,6 +366,7 @@ export class VerificationHarness {
 	private activeVerifications = new Map<string, ActiveVerification>();
 	private readonly _persistPath: string;
 	private projectContextManager: ProjectContextManager | null;
+	public readonly verifyRegistry = new VerifyHandlerRegistry();
 
 	/** Limits concurrent command steps (type-check, tests) across all goals. */
 	private commandSemaphore = new Semaphore(4);
@@ -899,6 +904,9 @@ export class VerificationHarness {
 		this._stateDir = stateDir;
 		this._persistPath = path.join(stateDir, "active-verifications.json");
 		this.projectContextManager = projectContextManager ?? null;
+		this.verifyRegistry.register(externalJobHandler);
+		this.verifyRegistry.register(rubricReviewHandler);
+		this.verifyRegistry.register(toolCallHandler);
 		// Load any persisted active verifications from a prior run into memory
 		// (they'll be resumed by resumeInterruptedVerifications() after session restore)
 		const persisted = this._loadActive();
@@ -1494,7 +1502,7 @@ export class VerificationHarness {
 									await new Promise(r => setTimeout(r, delayMs));
 								}
 							}
-						} else {
+						} else if (step.type === "llm-review") {
 							// llm-review — spawn a one-shot reviewer sub-agent
 							if (process.env.BOBBIT_LLM_REVIEW_SKIP) {
 								result = { passed: true, output: "LLM review skipped (BOBBIT_LLM_REVIEW_SKIP is set).", sessionId: stepSessionId };
@@ -1516,6 +1524,49 @@ export class VerificationHarness {
 									console.log(`[verification] LLM review "${step.name}" failed transiently (attempt ${attempt}/${maxAttempts}), retrying in ${delayMs / 1000}s...`);
 									await new Promise(r => setTimeout(r, delayMs));
 								}
+							}
+						} else {
+							const handler = this.verifyRegistry.get(step.type);
+							if (handler) {
+								const ctx: VerifyExecCtx = {
+									goalId: signal.goalId,
+									gateId: signal.gateId,
+									signalId: signal.id,
+									signal,
+									gate,
+									cwd,
+									branch: builtinVars["branch"] ?? "",
+									primaryBranch: builtinVars["master"] ?? "",
+									goalSpec,
+									allGateStates,
+									builtinVars,
+									projectVars,
+									agentVars,
+									substituteVars: (template: string) =>
+										this.substituteVars(template, builtinVars, projectVars, agentVars, allGateStates),
+									broadcast: (event: unknown) => this.broadcastFn(signal.goalId, event),
+									persistActive: () => this._persistActive(),
+									isCancelled: () => active.cancelled === true,
+									runLlmReview: async (args) => {
+										const prompt = this.substituteVars(args.prompt, builtinVars, projectVars, agentVars, allGateStates);
+										const reviewSessionId = `${step.type}-${randomUUID().slice(0, 12)}`;
+										const r = await this.runLlmReviewStep(
+											{ name: step.name, prompt, timeout: args.timeout ?? step.timeout, role: args.role ?? step.role },
+											cwd, builtinVars,
+											signal.content, signal.metadata,
+											goalSpec, allGateStates, signal.goalId, reviewSessionId,
+											gate,
+										);
+										return { passed: r.passed, output: r.output, sessionId: r.sessionId };
+									},
+								};
+								const handlerResult = await handler.execute(ctx, step);
+								result = { passed: handlerResult.passed, output: handlerResult.output, sessionId: handlerResult.sessionId };
+								if (handlerResult.artifact) {
+									artifact = handlerResult.artifact;
+								}
+							} else {
+								result = unknownTypeFailureResult(step.type);
 							}
 						}
 

--- a/src/server/agent/verify-handlers/external-job-handler.ts
+++ b/src/server/agent/verify-handlers/external-job-handler.ts
@@ -1,0 +1,119 @@
+import { randomUUID } from "node:crypto";
+import type { VerifyHandler, VerifyExecCtx, VerifyStepResult } from "./registry.js";
+import type { VerifyStep } from "../workflow-store.js";
+
+/**
+ * `external-job` waits for an external system (training run, batch experiment,
+ * scheduled compute) to POST a verdict to `/api/verify/external/:token`.
+ *
+ * The step's `timeout` (seconds, default 24h) bounds the wait. The callback
+ * must echo the goalId/gateId/signalId triple it was issued for; otherwise a
+ * leaked token would be a gate-control primitive.
+ *
+ * v1: in-memory token store. Gateway restart drops pending callbacks; they
+ * time out cleanly. Restart-resume is a follow-up.
+ */
+
+const DEFAULT_TIMEOUT_SECONDS = 24 * 60 * 60;
+
+interface PendingExternal {
+	token: string;
+	goalId: string;
+	gateId: string;
+	signalId: string;
+	stepName: string;
+	expiresAt: number;
+	resolve(result: VerifyStepResult): void;
+}
+
+const pending = new Map<string, PendingExternal>();
+
+export interface ExternalJobCallbackBody {
+	goalId: string;
+	gateId: string;
+	signalId: string;
+	passed: boolean;
+	summary?: string;
+	artifact?: {
+		content: string;
+		contentType: string;
+		metadata?: Record<string, string>;
+	};
+}
+
+export type ExternalJobCallbackOutcome =
+	| { ok: true }
+	| { ok: false; status: number; error: string };
+
+export function deliverExternalJobCallback(token: string, body: ExternalJobCallbackBody): ExternalJobCallbackOutcome {
+	const entry = pending.get(token);
+	if (!entry) {
+		return { ok: false, status: 404, error: "unknown or already-resolved token" };
+	}
+	if (Date.now() > entry.expiresAt) {
+		pending.delete(token);
+		return { ok: false, status: 410, error: "token expired" };
+	}
+	if (entry.goalId !== body.goalId || entry.gateId !== body.gateId || entry.signalId !== body.signalId) {
+		return { ok: false, status: 403, error: "token does not match goal/gate/signal triple" };
+	}
+	pending.delete(token);
+	entry.resolve({
+		passed: body.passed === true,
+		output: body.summary ?? (body.passed ? "External job reported success." : "External job reported failure."),
+		artifact: body.artifact,
+	});
+	return { ok: true };
+}
+
+export function pendingExternalCount(): number {
+	return pending.size;
+}
+
+/** Test-only: clear all pending entries. Do not call from production code. */
+export function _clearPendingExternalForTests(): void {
+	pending.clear();
+}
+
+export const externalJobHandler: VerifyHandler = {
+	type: "external-job",
+	async execute(ctx: VerifyExecCtx, step: VerifyStep): Promise<VerifyStepResult> {
+		const timeoutSeconds = typeof step.timeout === "number" && step.timeout > 0 ? step.timeout : DEFAULT_TIMEOUT_SECONDS;
+		const token = randomUUID();
+		const expiresAt = Date.now() + timeoutSeconds * 1000;
+		const entry: PendingExternal = {
+			token,
+			goalId: ctx.goalId,
+			gateId: ctx.gateId,
+			signalId: ctx.signalId,
+			stepName: step.name,
+			expiresAt,
+			resolve: () => {},
+		};
+
+		ctx.broadcast({
+			type: "gate_verification_external_pending",
+			goalId: ctx.goalId,
+			gateId: ctx.gateId,
+			signalId: ctx.signalId,
+			stepName: step.name,
+			token,
+			expiresAt,
+		});
+
+		return new Promise<VerifyStepResult>(resolve => {
+			entry.resolve = resolve;
+			pending.set(token, entry);
+
+			const timer = setTimeout(() => {
+				if (pending.delete(token)) {
+					resolve({
+						passed: false,
+						output: `External job timed out after ${timeoutSeconds}s. No callback was received on POST /api/verify/external/${token}.`,
+					});
+				}
+			}, timeoutSeconds * 1000);
+			if (typeof timer.unref === "function") timer.unref();
+		});
+	},
+};

--- a/src/server/agent/verify-handlers/registry.ts
+++ b/src/server/agent/verify-handlers/registry.ts
@@ -1,0 +1,84 @@
+import type { VerifyStep, WorkflowGate } from "../workflow-store.js";
+import type { GateSignal, GateSignalStep } from "../gate-store.js";
+
+export interface VerifyStepResult {
+	passed: boolean;
+	output: string;
+	sessionId?: string;
+	artifact?: GateSignalStep["artifact"];
+}
+
+export type GateStateContextEntry = {
+	metadata?: Record<string, string>;
+	content?: string;
+	status?: string;
+	injectDownstream?: boolean;
+};
+
+export interface VerifyExecCtx {
+	goalId: string;
+	gateId: string;
+	signalId: string;
+	signal: GateSignal;
+	gate: WorkflowGate;
+	cwd: string;
+	branch: string;
+	primaryBranch: string;
+	goalSpec?: string;
+	allGateStates?: Map<string, GateStateContextEntry>;
+	builtinVars: Record<string, string>;
+	projectVars: Record<string, string>;
+	agentVars: Record<string, string>;
+	substituteVars(template: string): string;
+	broadcast(event: unknown): void;
+	persistActive(): void;
+	isCancelled(): boolean;
+
+	/**
+	 * Spawn a one-shot LLM reviewer sub-agent. Returns the structured result
+	 * exactly as it would be produced by a top-level `type: llm-review` step.
+	 * Handlers (e.g. rubric-review/llm) use this to delegate to the existing
+	 * reviewer-session machinery without re-implementing it.
+	 */
+	runLlmReview?(args: {
+		prompt: string;
+		role?: string;
+		timeout?: number;
+	}): Promise<VerifyStepResult>;
+}
+
+export interface VerifyHandler {
+	readonly type: string;
+	execute(ctx: VerifyExecCtx, step: VerifyStep): Promise<VerifyStepResult>;
+}
+
+export class VerifyHandlerRegistry {
+	private handlers = new Map<string, VerifyHandler>();
+
+	register(handler: VerifyHandler): void {
+		this.handlers.set(handler.type, handler);
+	}
+
+	unregister(type: string): void {
+		this.handlers.delete(type);
+	}
+
+	get(type: string): VerifyHandler | undefined {
+		return this.handlers.get(type);
+	}
+
+	has(type: string): boolean {
+		return this.handlers.has(type);
+	}
+
+	types(): string[] {
+		return [...this.handlers.keys()];
+	}
+}
+
+export function unknownTypeFailureResult(type: string): VerifyStepResult {
+	return {
+		passed: false,
+		output: `No handler registered for verify step type '${type}'. The plugin that shipped this type may not be loaded or trusted.`,
+	};
+}

--- a/src/server/agent/verify-handlers/rubric-review-handler.ts
+++ b/src/server/agent/verify-handlers/rubric-review-handler.ts
@@ -1,0 +1,364 @@
+import { randomUUID } from "node:crypto";
+import type { VerifyHandler, VerifyExecCtx, VerifyStepResult } from "./registry.js";
+import type { VerifyStep, RubricItem } from "../workflow-store.js";
+
+/**
+ * `rubric-review` captures structured judgement against a declared rubric —
+ * far better signal than a freeform llm-review prompt or a `metadata:` blob.
+ *
+ * Two reviewer modes:
+ *
+ *   reviewer: "llm"   — spawn a reviewer sub-agent. Prompt requires JSON
+ *                       output matching the rubric schema. Handler parses,
+ *                       evaluates `pass_when`, and produces a markdown
+ *                       artifact rendering the rubric alongside the LLM's
+ *                       reasoning.
+ *
+ *   reviewer: "human" — wait for a human to POST rubric values to
+ *                       `/api/verify/rubric/:token`. Same callback-token
+ *                       discipline as external-job (single-use, time-bounded,
+ *                       validates goal/gate/signal triple).
+ *
+ * `pass_when` is a small expression evaluated against the rubric values. See
+ * `evaluatePassWhen` below for the supported grammar — kept deliberately
+ * minimal so the verdict is auditable without a sandbox.
+ */
+
+const DEFAULT_HUMAN_TIMEOUT_SECONDS = 7 * 24 * 60 * 60; // 7d — research review can take a while.
+
+interface PendingHuman {
+	token: string;
+	goalId: string;
+	gateId: string;
+	signalId: string;
+	stepName: string;
+	expiresAt: number;
+	rubric: RubricItem[];
+	passWhen?: string;
+	resolve(result: VerifyStepResult): void;
+}
+
+const pendingHuman = new Map<string, PendingHuman>();
+
+export interface RubricHumanCallbackBody {
+	goalId: string;
+	gateId: string;
+	signalId: string;
+	values: Record<string, string | number>;
+	notes?: string;
+}
+
+export type RubricCallbackOutcome =
+	| { ok: true }
+	| { ok: false; status: number; error: string };
+
+export function deliverRubricHumanCallback(token: string, body: RubricHumanCallbackBody): RubricCallbackOutcome {
+	const entry = pendingHuman.get(token);
+	if (!entry) return { ok: false, status: 404, error: "unknown or already-resolved token" };
+	if (Date.now() > entry.expiresAt) {
+		pendingHuman.delete(token);
+		return { ok: false, status: 410, error: "token expired" };
+	}
+	if (entry.goalId !== body.goalId || entry.gateId !== body.gateId || entry.signalId !== body.signalId) {
+		return { ok: false, status: 403, error: "token does not match goal/gate/signal triple" };
+	}
+	const validation = validateRubricValues(entry.rubric, body.values);
+	if (!validation.ok) {
+		return { ok: false, status: 400, error: validation.error };
+	}
+	pendingHuman.delete(token);
+	const passed = entry.passWhen ? evaluatePassWhen(entry.passWhen, body.values) : true;
+	entry.resolve({
+		passed,
+		output: renderRubricOutput(entry.rubric, body.values, body.notes, passed, entry.passWhen),
+		artifact: {
+			content: renderRubricArtifact(entry.rubric, body.values, body.notes),
+			contentType: "text/markdown",
+			metadata: rubricValuesAsMetadata(body.values),
+		},
+	});
+	return { ok: true };
+}
+
+export function _clearPendingRubricForTests(): void {
+	pendingHuman.clear();
+}
+
+export const rubricReviewHandler: VerifyHandler = {
+	type: "rubric-review",
+	async execute(ctx: VerifyExecCtx, step: VerifyStep): Promise<VerifyStepResult> {
+		if (!Array.isArray(step.rubric) || step.rubric.length === 0) {
+			return { passed: false, output: "rubric-review step has no rubric items." };
+		}
+		if (step.reviewer === "human") {
+			return runHumanRubric(ctx, step);
+		}
+		if (step.reviewer === "llm") {
+			return runLlmRubric(ctx, step);
+		}
+		return { passed: false, output: `rubric-review step has invalid reviewer '${step.reviewer ?? ""}'.` };
+	},
+};
+
+async function runHumanRubric(ctx: VerifyExecCtx, step: VerifyStep): Promise<VerifyStepResult> {
+	const timeoutSeconds = typeof step.timeout === "number" && step.timeout > 0 ? step.timeout : DEFAULT_HUMAN_TIMEOUT_SECONDS;
+	const token = randomUUID();
+	const expiresAt = Date.now() + timeoutSeconds * 1000;
+
+	ctx.broadcast({
+		type: "gate_verification_rubric_pending",
+		goalId: ctx.goalId,
+		gateId: ctx.gateId,
+		signalId: ctx.signalId,
+		stepName: step.name,
+		token,
+		expiresAt,
+		rubric: step.rubric,
+	});
+
+	return new Promise<VerifyStepResult>(resolve => {
+		const entry: PendingHuman = {
+			token,
+			goalId: ctx.goalId,
+			gateId: ctx.gateId,
+			signalId: ctx.signalId,
+			stepName: step.name,
+			expiresAt,
+			rubric: step.rubric!,
+			passWhen: step.pass_when,
+			resolve,
+		};
+		pendingHuman.set(token, entry);
+		const timer = setTimeout(() => {
+			if (pendingHuman.delete(token)) {
+				resolve({
+					passed: false,
+					output: `Rubric review timed out after ${timeoutSeconds}s. No callback was received on POST /api/verify/rubric/${token}.`,
+				});
+			}
+		}, timeoutSeconds * 1000);
+		if (typeof timer.unref === "function") timer.unref();
+	});
+}
+
+async function runLlmRubric(ctx: VerifyExecCtx, step: VerifyStep): Promise<VerifyStepResult> {
+	if (!ctx.runLlmReview) {
+		return { passed: false, output: "rubric-review/llm requires harness to expose runLlmReview." };
+	}
+	const rubricSchema = (step.rubric ?? []).map(rubricItemSchemaLine).join("\n");
+	const prompt = [
+		step.prompt ?? "Review the work against the rubric below.",
+		"",
+		"## Rubric",
+		rubricSchema,
+		"",
+		step.pass_when ? `## Pass criterion\n\`${step.pass_when}\`\n` : "",
+		"## Required output",
+		"At the very end of your review, emit a fenced ```json``` block matching this shape:",
+		"```json",
+		"{",
+		"  \"values\": {",
+		...(step.rubric ?? []).map(r => `    "${r.id}": <value>,`),
+		"  },",
+		"  \"notes\": \"<optional freeform commentary>\"",
+		"}",
+		"```",
+		"Numeric scales must be integers within range. Option lists must be one of the listed options. Text items are freeform strings.",
+	].filter(Boolean).join("\n");
+
+	const reviewResult = await ctx.runLlmReview({
+		prompt,
+		role: step.role,
+		timeout: step.timeout,
+	});
+
+	if (!reviewResult.passed) {
+		// Underlying LLM review failed (timeout, transport, etc.). Surface as-is.
+		return reviewResult;
+	}
+
+	const parsed = extractRubricJson(reviewResult.output);
+	if (!parsed.ok) {
+		return {
+			passed: false,
+			output: `LLM did not emit a parseable rubric JSON block: ${parsed.error}`,
+			sessionId: reviewResult.sessionId,
+		};
+	}
+
+	const validation = validateRubricValues(step.rubric!, parsed.values);
+	if (!validation.ok) {
+		return {
+			passed: false,
+			output: `LLM emitted invalid rubric values: ${validation.error}`,
+			sessionId: reviewResult.sessionId,
+		};
+	}
+
+	const passed = step.pass_when ? evaluatePassWhen(step.pass_when, parsed.values) : true;
+	return {
+		passed,
+		output: renderRubricOutput(step.rubric!, parsed.values, parsed.notes, passed, step.pass_when),
+		sessionId: reviewResult.sessionId,
+		artifact: {
+			content: renderRubricArtifact(step.rubric!, parsed.values, parsed.notes, reviewResult.output),
+			contentType: "text/markdown",
+			metadata: rubricValuesAsMetadata(parsed.values),
+		},
+	};
+}
+
+// ── Schema / parsing / validation ────────────────────────────────────────
+
+function rubricItemSchemaLine(item: RubricItem): string {
+	if (item.scale) {
+		return `- **${item.id}** (${item.label}): integer ${item.scale.min}..${item.scale.max}`;
+	}
+	if (item.options) {
+		return `- **${item.id}** (${item.label}): one of [${item.options.map(o => `"${o}"`).join(", ")}]`;
+	}
+	if (item.kind === "text") {
+		return `- **${item.id}** (${item.label}): freeform string`;
+	}
+	return `- **${item.id}** (${item.label}): string`;
+}
+
+interface ParsedRubric {
+	ok: true;
+	values: Record<string, string | number>;
+	notes?: string;
+}
+interface ParseFailure {
+	ok: false;
+	error: string;
+}
+
+function extractRubricJson(output: string): ParsedRubric | ParseFailure {
+	const fence = /```json\s*([\s\S]*?)```/g;
+	let match: RegExpExecArray | null;
+	let lastBlock: string | undefined;
+	while ((match = fence.exec(output)) !== null) {
+		lastBlock = match[1];
+	}
+	if (!lastBlock) return { ok: false, error: "no ```json block found in output." };
+	try {
+		const parsed = JSON.parse(lastBlock) as Record<string, unknown>;
+		if (!parsed.values || typeof parsed.values !== "object") {
+			return { ok: false, error: "`values` field missing or not an object." };
+		}
+		const cleaned: Record<string, string | number> = {};
+		for (const [k, v] of Object.entries(parsed.values as Record<string, unknown>)) {
+			if (typeof v === "string" || typeof v === "number") cleaned[k] = v;
+		}
+		return {
+			ok: true,
+			values: cleaned,
+			notes: typeof parsed.notes === "string" ? parsed.notes : undefined,
+		};
+	} catch (e) {
+		return { ok: false, error: `JSON parse error: ${e instanceof Error ? e.message : String(e)}` };
+	}
+}
+
+function validateRubricValues(rubric: RubricItem[], values: Record<string, string | number>): { ok: true } | { ok: false; error: string } {
+	for (const item of rubric) {
+		const v = values[item.id];
+		if (v === undefined) return { ok: false, error: `missing value for '${item.id}'.` };
+		if (item.scale) {
+			if (typeof v !== "number" || !Number.isInteger(v) || v < item.scale.min || v > item.scale.max) {
+				return { ok: false, error: `'${item.id}' must be an integer in [${item.scale.min}, ${item.scale.max}].` };
+			}
+		} else if (item.options) {
+			if (typeof v !== "string" || !item.options.includes(v)) {
+				return { ok: false, error: `'${item.id}' must be one of [${item.options.join(", ")}].` };
+			}
+		} else if (item.kind === "text") {
+			if (typeof v !== "string") return { ok: false, error: `'${item.id}' must be a string.` };
+		}
+	}
+	return { ok: true };
+}
+
+/**
+ * Minimal expression evaluator for `pass_when`. Supports:
+ *   - identifiers (rubric value ids)
+ *   - numeric literals
+ *   - quoted string literals ("foo" or 'foo')
+ *   - comparisons: >= > <= < == != =
+ *   - logical: AND OR (case-insensitive); not supported because parens add complexity.
+ *
+ * No parens, no precedence — splits on top-level AND/OR left-to-right. This is
+ * intentional: rubric pass criteria are tiny ("novelty >= 3 AND feasibility != 'low'");
+ * anything more elaborate belongs in a real expression library, not here.
+ */
+export function evaluatePassWhen(expr: string, values: Record<string, string | number>): boolean {
+	const norm = expr.replace(/\s+/g, " ").trim();
+	const tokens = norm.split(/\b(AND|OR|and|or)\b/);
+	if (tokens.length === 1) return evaluateClause(tokens[0]!, values);
+	let acc = evaluateClause(tokens[0]!, values);
+	for (let i = 1; i < tokens.length; i += 2) {
+		const op = tokens[i]!.toUpperCase();
+		const next = evaluateClause(tokens[i + 1]!, values);
+		acc = op === "AND" ? (acc && next) : (acc || next);
+	}
+	return acc;
+}
+
+function evaluateClause(clause: string, values: Record<string, string | number>): boolean {
+	const m = clause.trim().match(/^([A-Za-z_][\w-]*)\s*(>=|<=|==|!=|=|>|<)\s*(.+)$/);
+	if (!m) return false;
+	const [, id, op, rhsRaw] = m;
+	const lhs = values[id];
+	if (lhs === undefined) return false;
+	const rhs = parseLiteral(rhsRaw.trim());
+	switch (op) {
+		case ">=": return typeof lhs === "number" && typeof rhs === "number" && lhs >= rhs;
+		case "<=": return typeof lhs === "number" && typeof rhs === "number" && lhs <= rhs;
+		case ">":  return typeof lhs === "number" && typeof rhs === "number" && lhs > rhs;
+		case "<":  return typeof lhs === "number" && typeof rhs === "number" && lhs < rhs;
+		case "==":
+		case "=":  return lhs === rhs;
+		case "!=": return lhs !== rhs;
+		default: return false;
+	}
+}
+
+function parseLiteral(s: string): string | number {
+	if (/^-?\d+(\.\d+)?$/.test(s)) return parseFloat(s);
+	const q = s.match(/^"([^"]*)"$|^'([^']*)'$/);
+	if (q) return q[1] ?? q[2] ?? "";
+	return s;
+}
+
+function renderRubricOutput(rubric: RubricItem[], values: Record<string, string | number>, notes: string | undefined, passed: boolean, passWhen?: string): string {
+	const lines = [
+		`${passed ? "Rubric passed" : "Rubric failed"}${passWhen ? ` (pass_when: \`${passWhen}\`)` : ""}.`,
+		"",
+	];
+	for (const item of rubric) {
+		lines.push(`- ${item.label}: ${values[item.id]}`);
+	}
+	if (notes) lines.push("", `Notes: ${notes}`);
+	return lines.join("\n");
+}
+
+function renderRubricArtifact(rubric: RubricItem[], values: Record<string, string | number>, notes: string | undefined, llmTrace?: string): string {
+	const sections = [
+		"# Rubric Review",
+		"",
+		"| Item | Value |",
+		"|---|---|",
+		...rubric.map(item => `| ${item.label} (\`${item.id}\`) | ${values[item.id]} |`),
+	];
+	if (notes) sections.push("", "## Notes", notes);
+	if (llmTrace) sections.push("", "## LLM Reasoning", llmTrace);
+	return sections.join("\n");
+}
+
+function rubricValuesAsMetadata(values: Record<string, string | number>): Record<string, string> {
+	const out: Record<string, string> = {};
+	for (const [k, v] of Object.entries(values)) {
+		out[k] = String(v);
+	}
+	return out;
+}

--- a/src/server/agent/verify-handlers/tool-call-handler.ts
+++ b/src/server/agent/verify-handlers/tool-call-handler.ts
@@ -1,0 +1,74 @@
+import type { VerifyHandler, VerifyExecCtx, VerifyStepResult } from "./registry.js";
+import type { VerifyStep } from "../workflow-store.js";
+
+/**
+ * `tool-call` invokes a registered agent tool as a verify step. It spawns a
+ * minimal sub-agent under the supplied `role` (default: `reviewer`), instructs
+ * it to call `tool(args)` once, and treats `verification_result` as the verdict.
+ *
+ * For this to work, the chosen role's tool policy must permit the named tool.
+ * The pre-existing `verification_result` tool flows back through the harness's
+ * `pendingResults` map, so no extra plumbing is needed — the result the agent
+ * emits is what the gate observes.
+ *
+ * Why piggyback `runLlmReview` rather than introduce a separate session-spawn
+ * path: every existing one-shot dispatch (llm-review, agent-qa) goes through
+ * the harness's session machinery. Inventing a third spawn site would
+ * duplicate ~200 lines of cancellation, timeout, and resume logic. Phase 2
+ * extracts the shared machinery; until then, the prompt below is the only
+ * difference between a "review" session and a "tool-call" session.
+ */
+export const toolCallHandler: VerifyHandler = {
+	type: "tool-call",
+	async execute(ctx: VerifyExecCtx, step: VerifyStep): Promise<VerifyStepResult> {
+		if (typeof step.tool !== "string" || step.tool.length === 0) {
+			return { passed: false, output: "tool-call step has no `tool` set." };
+		}
+		if (!ctx.runLlmReview) {
+			return { passed: false, output: "tool-call requires harness to expose runLlmReview." };
+		}
+
+		const argsJson = step.args ? JSON.stringify(step.args, null, 2) : "{}";
+		const expect = step.expect ?? "success";
+		const userPrompt = step.prompt ? ctx.substituteVars(step.prompt) : "";
+
+		const prompt = [
+			`You are running as a verification step for gate '${ctx.gateId}'.`,
+			"",
+			`Your only task is to call the tool **\`${step.tool}\`** exactly once with the arguments below, then emit \`verification_result\` summarising what came back.`,
+			"",
+			"## Arguments",
+			"```json",
+			argsJson,
+			"```",
+			"",
+			"## Pass criterion",
+			expect === "failure"
+				? "The step **passes** when the tool reports a failure (e.g. throws, returns an error, or emits content that doesn't satisfy the requested check)."
+				: "The step **passes** when the tool returns successfully with non-empty output relevant to the requested check.",
+			"",
+			userPrompt ? `## Additional instructions\n${userPrompt}\n` : "",
+			"## Output",
+			"After the tool returns, call `verification_result(verdict, summary)`:",
+			"- `verdict`: \"pass\" or \"fail\"",
+			"- `summary`: a markdown summary of what the tool returned and why you graded it that way",
+			"",
+			"Do not perform any other work. Do not explore the codebase. Do not write files.",
+		].filter(Boolean).join("\n");
+
+		const result = await ctx.runLlmReview({
+			prompt,
+			role: step.role,
+			timeout: step.timeout,
+		});
+
+		return {
+			passed: result.passed,
+			output: result.output,
+			sessionId: result.sessionId,
+			artifact: result.output && result.output.length > 0
+				? { content: result.output, contentType: "text/markdown" }
+				: undefined,
+		};
+	},
+};

--- a/src/server/agent/workflow-store.ts
+++ b/src/server/agent/workflow-store.ts
@@ -77,6 +77,10 @@ export interface Workflow {
 	updatedAt: number;
 	/** If true, workflow is hidden from the UI (e.g. test-only workflows) */
 	hidden?: boolean;
+	/** Set when this workflow came from an installed plugin (vs hand-authored in workflows:).
+	 *  The id field is the namespaced id (e.g. "autoresearch::feature"); originalId is the
+	 *  plugin-side id ("feature") preserved for diagnostics. */
+	pluginSource?: { name: string; version: string; originalId: string };
 }
 
 // ── Normalization between the inline yaml shape and the runtime shape ──
@@ -235,12 +239,39 @@ export class InlineWorkflowStore {
 
 	private readLocal(): Map<string, Workflow> {
 		this.cfg.reload();
-		const block = this.cfg.getWorkflows();
 		const out = new Map<string, Workflow>();
-		if (!block) return out;
-		for (const [id, raw] of Object.entries(block)) {
-			const wf = normalizeWorkflow(raw, id);
-			if (wf) out.set(wf.id, wf);
+
+		// User-authored workflows in workflows: block.
+		const block = this.cfg.getWorkflows();
+		if (block) {
+			for (const [id, raw] of Object.entries(block)) {
+				const wf = normalizeWorkflow(raw, id);
+				if (wf) out.set(wf.id, wf);
+			}
+		}
+
+		// Plugin-shipped workflow snapshots — namespaced as "<plugin>::<id>" so a plugin
+		// and a user-defined workflow can't collide on the bare id. The plugin's install
+		// record carries the version, which we project onto each workflow's pluginSource
+		// for diagnostics (UI badges, "Workflow not found: ..." error context).
+		const installed = new Map(this.cfg.getInstalledPlugins().map(p => [p.name, p]));
+		for (const entry of this.cfg.getPluginWorkflows()) {
+			const namespacedId = `${entry.source}::${entry.id}`;
+			const wf = normalizeWorkflow(entry.snapshot, namespacedId);
+			if (!wf) continue;
+			// The snapshot may carry its own `id:` field (the plugin's own bare id).
+			// Overwrite it with the namespaced form so callers see one consistent id.
+			wf.id = namespacedId;
+			wf.pluginSource = {
+				name: entry.source,
+				version: installed.get(entry.source)?.version ?? "unknown",
+				originalId: entry.id,
+			};
+			// User-authored workflows win on bare-id collision (already in `out`); but
+			// since plugin ids are namespaced, they can only collide with each other,
+			// not with user content. First-write wins arbitrarily — install lifecycle
+			// rejects duplicate (source,id) pairs at the API layer.
+			if (!out.has(wf.id)) out.set(wf.id, wf);
 		}
 		return out;
 	}

--- a/src/server/agent/workflow-store.ts
+++ b/src/server/agent/workflow-store.ts
@@ -17,9 +17,12 @@ import type { ProjectConfigStore, InlineWorkflowDef, InlineWorkflowGate, InlineV
 
 // ── Public types (kept compatible with the old WorkflowStore shape) ──
 
+/** Built-in verify-step types. Plugin-registered handlers may use any other string. */
+export type BuiltinVerifyStepType = "command" | "llm-review" | "agent-qa" | "external-job" | "rubric-review" | "tool-call";
+
 export interface VerifyStep {
 	name: string;
-	type: "command" | "llm-review" | "agent-qa";
+	type: BuiltinVerifyStepType | (string & {});
 	run?: string;
 	prompt?: string;
 	expect?: "success" | "failure";
@@ -33,6 +36,24 @@ export interface VerifyStep {
 	component?: string;
 	/** Structural reference: which command on that component to invoke (Phase 2). */
 	command?: string;
+	/** type: tool-call — name of the agent tool to invoke. */
+	tool?: string;
+	/** type: tool-call — arguments to pass to the tool (JSON-serialisable). */
+	args?: Record<string, unknown>;
+	/** type: rubric-review — "llm" or "human"; determines whether a session or a form is used. */
+	reviewer?: "llm" | "human";
+	/** type: rubric-review — schema describing rubric items. */
+	rubric?: RubricItem[];
+	/** type: rubric-review — expression evaluated against rubric values to decide pass/fail. */
+	pass_when?: string;
+}
+
+export interface RubricItem {
+	id: string;
+	label: string;
+	scale?: { min: number; max: number };
+	options?: string[];
+	kind?: "text";
 }
 
 export interface WorkflowGate {
@@ -62,9 +83,10 @@ export interface Workflow {
 
 function normalizeStep(raw: unknown): VerifyStep {
 	const r = (raw && typeof raw === "object") ? raw as Record<string, unknown> : {};
+	const rawType = typeof r.type === "string" ? r.type : "command";
 	const step: VerifyStep = {
 		name: typeof r.name === "string" ? r.name : "",
-		type: (r.type === "llm-review" || r.type === "agent-qa") ? r.type : "command",
+		type: rawType,
 	};
 	if (typeof r.run === "string") step.run = r.run;
 	if (typeof r.prompt === "string") step.prompt = r.prompt;
@@ -77,6 +99,30 @@ function normalizeStep(raw: unknown): VerifyStep {
 	if (typeof r.description === "string") step.description = r.description;
 	if (typeof r.component === "string") step.component = r.component;
 	if (typeof r.command === "string") step.command = r.command;
+	if (typeof r.tool === "string") step.tool = r.tool;
+	if (r.args && typeof r.args === "object" && !Array.isArray(r.args)) {
+		step.args = r.args as Record<string, unknown>;
+	}
+	if (r.reviewer === "llm" || r.reviewer === "human") step.reviewer = r.reviewer;
+	if (Array.isArray(r.rubric)) {
+		step.rubric = (r.rubric as unknown[]).map(item => {
+			const it = (item && typeof item === "object") ? item as Record<string, unknown> : {};
+			const ri: RubricItem = {
+				id: typeof it.id === "string" ? it.id : "",
+				label: typeof it.label === "string" ? it.label : "",
+			};
+			if (it.scale && typeof it.scale === "object") {
+				const sc = it.scale as Record<string, unknown>;
+				if (typeof sc.min === "number" && typeof sc.max === "number") {
+					ri.scale = { min: sc.min, max: sc.max };
+				}
+			}
+			if (Array.isArray(it.options)) ri.options = it.options.filter(x => typeof x === "string") as string[];
+			if (it.kind === "text") ri.kind = "text";
+			return ri;
+		});
+	}
+	if (typeof r.pass_when === "string") step.pass_when = r.pass_when;
 	return step;
 }
 
@@ -133,6 +179,11 @@ function serializeStep(s: VerifyStep): Record<string, unknown> {
 	if (s.label !== undefined) out.label = s.label;
 	if (s.role !== undefined) out.role = s.role;
 	if (s.description !== undefined) out.description = s.description;
+	if (s.tool !== undefined) out.tool = s.tool;
+	if (s.args !== undefined) out.args = s.args;
+	if (s.reviewer !== undefined) out.reviewer = s.reviewer;
+	if (s.rubric !== undefined) out.rubric = s.rubric;
+	if (s.pass_when !== undefined) out.pass_when = s.pass_when;
 	return out;
 }
 

--- a/src/server/agent/workflow-validator.ts
+++ b/src/server/agent/workflow-validator.ts
@@ -215,8 +215,32 @@ export function validateWorkflow(
 				if (typeof step.prompt !== "string" || step.prompt.length === 0) {
 					fail(`type: ${stepType} step requires a non-empty "prompt".`);
 				}
+			} else if (stepType === "external-job") {
+				// external-job steps wait for an external POST to /api/verify/external/:token.
+				// No required fields beyond `name`; `timeout` controls how long we wait.
+				if (typeof step.timeout === "number" && step.timeout <= 0) {
+					fail(`type: external-job step has non-positive timeout.`);
+				}
+			} else if (stepType === "rubric-review") {
+				if (step.reviewer !== "llm" && step.reviewer !== "human") {
+					fail(`type: rubric-review step requires "reviewer" set to "llm" or "human".`);
+				}
+				if (!Array.isArray(step.rubric) || step.rubric.length === 0) {
+					fail(`type: rubric-review step requires a non-empty "rubric" array.`);
+				}
+				if (step.reviewer === "llm" && (typeof step.prompt !== "string" || step.prompt.length === 0)) {
+					fail(`type: rubric-review step with reviewer: llm requires a non-empty "prompt".`);
+				}
+			} else if (stepType === "tool-call") {
+				if (typeof step.tool !== "string" || step.tool.length === 0) {
+					fail(`type: tool-call step requires a non-empty "tool".`);
+				}
 			} else {
-				fail(`unknown step type "${stepType}"; expected one of: command, llm-review, agent-qa.`);
+				// Unknown step type — plugin-registered handlers are resolved at runtime via
+				// the VerifyHandlerRegistry. The validator can't see the plugin registry, so
+				// this is a soft accept: workflow loads, but runtime will fail with a clear
+				// "no handler registered" message if no plugin contributes a handler for this type.
+				// We don't surface a validation error here.
 			}
 		}
 	}

--- a/src/server/plugins/host-api.ts
+++ b/src/server/plugins/host-api.ts
@@ -1,0 +1,52 @@
+import type { VerifyHandler, VerifyHandlerRegistry } from "../agent/verify-handlers/registry.js";
+
+/**
+ * `BobbitPluginApi` is the surface a plugin's gateway entry receives via
+ * `activate(api)`. v1 is deliberately minimal: register verify-step handlers
+ * and log. Host services (sessionManager, gateStore, projectContextManager)
+ * are already plumbed into handlers through `VerifyExecCtx`; the plugin API
+ * only needs to expose registration hooks.
+ *
+ * Plugins may return a `PluginActivation` from `activate` with a
+ * `deactivate()` cleanup. Deactivation is best-effort — called on uninstall
+ * or gateway shutdown — and must not throw.
+ */
+export interface BobbitPluginApi {
+	readonly pluginName: string;
+	registerVerifyHandler(handler: VerifyHandler): void;
+	unregisterVerifyHandler(type: string): void;
+	log(level: "info" | "warn" | "error", msg: string): void;
+}
+
+export interface PluginActivation {
+	deactivate?(): void | Promise<void>;
+}
+
+export type PluginActivateFn = (api: BobbitPluginApi) => void | PluginActivation | Promise<void | PluginActivation>;
+
+/** Build the api object for a single plugin, scoped so unregister can only touch this plugin's types. */
+export function buildHostApi(args: {
+	pluginName: string;
+	registry: VerifyHandlerRegistry;
+	logger: (level: "info" | "warn" | "error", msg: string) => void;
+}): { api: BobbitPluginApi; registeredTypes: () => string[] } {
+	const registered = new Set<string>();
+	const api: BobbitPluginApi = {
+		pluginName: args.pluginName,
+		registerVerifyHandler(handler) {
+			args.registry.register(handler);
+			registered.add(handler.type);
+			args.logger("info", `registered verify handler '${handler.type}'`);
+		},
+		unregisterVerifyHandler(type) {
+			if (!registered.has(type)) {
+				args.logger("warn", `attempted to unregister '${type}' but plugin did not register it`);
+				return;
+			}
+			args.registry.unregister(type);
+			registered.delete(type);
+		},
+		log: args.logger,
+	};
+	return { api, registeredTypes: () => [...registered] };
+}

--- a/src/server/plugins/plugin-loader.ts
+++ b/src/server/plugins/plugin-loader.ts
@@ -245,3 +245,28 @@ function pickActivate(mod: unknown): PluginActivateFn | undefined {
 	if (typeof m.default === "function") return m.default as PluginActivateFn;
 	return undefined;
 }
+
+/** Bootstrap-time accessor for the loader + last discovery list. The gateway
+ *  calls `setGlobalPluginLoader` during start() so REST endpoints can reach
+ *  the loader without threading it through every signature. */
+let _globalLoader: PluginLoader | null = null;
+let _globalDiscovered: DiscoveredPlugin[] = [];
+
+export function setGlobalPluginLoader(loader: PluginLoader | null, discovered: DiscoveredPlugin[] = []): void {
+	_globalLoader = loader;
+	_globalDiscovered = discovered;
+}
+
+export function getGlobalPluginLoader(): { loader: PluginLoader; discovered: DiscoveredPlugin[] } | null {
+	if (!_globalLoader) return null;
+	return { loader: _globalLoader, discovered: _globalDiscovered };
+}
+
+/** Re-run discovery and reconcile the loader's state. Returns the new merged list. */
+export async function refreshPlugins(paths: DiscoveryPaths = defaultDiscoveryPaths()): Promise<LoadedPlugin[]> {
+	const loader = _globalLoader;
+	if (!loader) throw new Error("Plugin loader not initialised");
+	const discovered = discoverPlugins(paths);
+	_globalDiscovered = discovered;
+	return loader.loadAll(discovered);
+}

--- a/src/server/plugins/plugin-loader.ts
+++ b/src/server/plugins/plugin-loader.ts
@@ -1,0 +1,247 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { homedir } from "node:os";
+import { readManifest, type PluginManifest, type ManifestValidationError } from "./plugin-manifest.js";
+import { PluginTrustStore } from "./plugin-trust-store.js";
+import { buildHostApi, type PluginActivateFn, type PluginActivation } from "./host-api.js";
+import type { VerifyHandlerRegistry } from "../agent/verify-handlers/registry.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export type PluginSource = "builtin" | "server" | "user" | "project";
+
+export interface DiscoveredPlugin {
+	name: string;
+	path: string;
+	source: PluginSource;
+	manifest: PluginManifest;
+	manifestErrors: ManifestValidationError[];
+}
+
+export type LoadStatus =
+	| { status: "loaded"; registeredTypes: string[] }
+	| { status: "needs-approval" }
+	| { status: "manifest-invalid"; errors: ManifestValidationError[] }
+	| { status: "error"; error: string }
+	| { status: "disabled" };
+
+export interface LoadedPlugin extends DiscoveredPlugin {
+	load: LoadStatus;
+	activation?: PluginActivation;
+}
+
+/**
+ * Cascade order — lowest precedence first. Later sources override earlier ones
+ * if they declare the same `name`. Builtin plugins (`defaults/plugins/`) are
+ * auto-trusted; every other source needs explicit approval via the trust
+ * store before its gateway entry is imported.
+ */
+export interface DiscoveryPaths {
+	builtin?: string;       // dist/server/defaults/plugins/
+	serverCwd?: string;     // <server-cwd>/.bobbit/plugins/
+	userHome?: string;      // ~/.bobbit/plugins/
+	projectRoots?: string[]; // per-project <project-root>/.bobbit/plugins/
+}
+
+export function defaultDiscoveryPaths(): DiscoveryPaths {
+	return {
+		builtin: path.join(__dirname, "..", "defaults", "plugins"),
+		serverCwd: path.join(process.cwd(), ".bobbit", "plugins"),
+		userHome: path.join(homedir(), ".bobbit", "plugins"),
+	};
+}
+
+/** Scan a single directory for plugin bundles (subdirs containing plugin.yaml). */
+function scanDir(dir: string, source: PluginSource): DiscoveredPlugin[] {
+	if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) return [];
+	const out: DiscoveredPlugin[] = [];
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		if (!entry.isDirectory()) continue;
+		const pluginRoot = path.join(dir, entry.name);
+		if (!fs.existsSync(path.join(pluginRoot, "plugin.yaml"))) continue;
+		try {
+			const { manifest, errors } = readManifest(pluginRoot);
+			out.push({
+				name: manifest.name || entry.name,
+				path: path.resolve(pluginRoot),
+				source,
+				manifest,
+				manifestErrors: errors,
+			});
+		} catch (e) {
+			out.push({
+				name: entry.name,
+				path: path.resolve(pluginRoot),
+				source,
+				manifest: { name: entry.name, version: "0.0.0" },
+				manifestErrors: [{
+					field: "(manifest)",
+					message: e instanceof Error ? e.message : String(e),
+				}],
+			});
+		}
+	}
+	return out;
+}
+
+/** Merge discovery results across all cascade levels; later sources win on name collision. */
+export function discoverPlugins(paths: DiscoveryPaths = defaultDiscoveryPaths()): DiscoveredPlugin[] {
+	const byName = new Map<string, DiscoveredPlugin>();
+	if (paths.builtin) for (const p of scanDir(paths.builtin, "builtin")) byName.set(p.name, p);
+	if (paths.serverCwd) for (const p of scanDir(paths.serverCwd, "server")) byName.set(p.name, p);
+	if (paths.userHome) for (const p of scanDir(paths.userHome, "user")) byName.set(p.name, p);
+	if (paths.projectRoots) {
+		for (const root of paths.projectRoots) {
+			const dir = path.join(root, ".bobbit", "plugins");
+			for (const p of scanDir(dir, "project")) byName.set(p.name, p);
+		}
+	}
+	return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export class PluginLoader {
+	private trust: PluginTrustStore;
+	private registry: VerifyHandlerRegistry;
+	private loaded = new Map<string, LoadedPlugin>();
+	private moduleCache = new Map<string, unknown>();
+
+	constructor(args: { registry: VerifyHandlerRegistry; trustStore?: PluginTrustStore }) {
+		this.registry = args.registry;
+		this.trust = args.trustStore ?? new PluginTrustStore();
+	}
+
+	/** Builtin plugins ship in bobbit's binary — auto-trusted. Every other source needs explicit approval. */
+	private isTrustedForLoading(p: DiscoveredPlugin): boolean {
+		if (p.source === "builtin") return true;
+		return this.trust.isTrusted(p.path);
+	}
+
+	listLoaded(): LoadedPlugin[] {
+		return [...this.loaded.values()];
+	}
+
+	getLoaded(name: string): LoadedPlugin | undefined {
+		return this.loaded.get(name);
+	}
+
+	/** Trust a plugin (records hash) so a subsequent loadOne() will run it. */
+	trustPlugin(p: DiscoveredPlugin): void {
+		this.trust.trust(p.name, p.path);
+	}
+
+	/** Revoke trust. If the plugin is currently loaded, deactivate it. */
+	async revokeTrust(p: DiscoveredPlugin): Promise<void> {
+		this.trust.revoke(p.path);
+		await this.unload(p.name);
+	}
+
+	/**
+	 * Load a single plugin: validate manifest, check trust, import the gateway
+	 * entry, call its `activate(api)`. Idempotent — repeated calls with the
+	 * same plugin return the prior load record without re-importing.
+	 *
+	 * Returns a `LoadedPlugin` carrying the final status. Errors never throw —
+	 * caller inspects `result.load.status`.
+	 */
+	async loadOne(p: DiscoveredPlugin): Promise<LoadedPlugin> {
+		const existing = this.loaded.get(p.name);
+		if (existing && existing.load.status === "loaded") return existing;
+
+		if (p.manifestErrors.length > 0) {
+			const rec: LoadedPlugin = { ...p, load: { status: "manifest-invalid", errors: p.manifestErrors } };
+			this.loaded.set(p.name, rec);
+			return rec;
+		}
+
+		if (!this.isTrustedForLoading(p)) {
+			const rec: LoadedPlugin = { ...p, load: { status: "needs-approval" } };
+			this.loaded.set(p.name, rec);
+			return rec;
+		}
+
+		const entry = p.manifest.entryPoints?.gateway;
+		if (!entry) {
+			// A data-only plugin (workflows/roles/skills) — nothing to import server-side.
+			const rec: LoadedPlugin = { ...p, load: { status: "loaded", registeredTypes: [] } };
+			this.loaded.set(p.name, rec);
+			return rec;
+		}
+
+		const absEntry = path.resolve(p.path, entry);
+		try {
+			let mod = this.moduleCache.get(absEntry);
+			if (!mod) {
+				mod = await import(pathToFileURL(absEntry).href);
+				this.moduleCache.set(absEntry, mod);
+			}
+			const activate = pickActivate(mod);
+			if (!activate) {
+				const rec: LoadedPlugin = {
+					...p,
+					load: { status: "error", error: `Gateway entry ${entry} has no default export or 'activate' function.` },
+				};
+				this.loaded.set(p.name, rec);
+				return rec;
+			}
+			const { api, registeredTypes } = buildHostApi({
+				pluginName: p.name,
+				registry: this.registry,
+				logger: (level, msg) => console[level === "info" ? "log" : level](`[plugin:${p.name}] ${msg}`),
+			});
+			const activationResult = await activate(api);
+			const activation: PluginActivation | undefined = (activationResult && typeof activationResult === "object")
+				? activationResult as PluginActivation
+				: undefined;
+			const rec: LoadedPlugin = {
+				...p,
+				load: { status: "loaded", registeredTypes: registeredTypes() },
+				activation,
+			};
+			this.loaded.set(p.name, rec);
+			return rec;
+		} catch (e) {
+			const rec: LoadedPlugin = {
+				...p,
+				load: { status: "error", error: e instanceof Error ? e.message : String(e) },
+			};
+			this.loaded.set(p.name, rec);
+			return rec;
+		}
+	}
+
+	async loadAll(plugins: DiscoveredPlugin[]): Promise<LoadedPlugin[]> {
+		const out: LoadedPlugin[] = [];
+		for (const p of plugins) out.push(await this.loadOne(p));
+		return out;
+	}
+
+	/** Unload a plugin: call its deactivate (if any), unregister its types, clear caches. */
+	async unload(name: string): Promise<void> {
+		const rec = this.loaded.get(name);
+		if (!rec) return;
+		if (rec.activation?.deactivate) {
+			try {
+				await rec.activation.deactivate();
+			} catch (e) {
+				console.warn(`[plugin:${name}] deactivate threw:`, e);
+			}
+		}
+		if (rec.load.status === "loaded") {
+			for (const type of rec.load.registeredTypes) {
+				this.registry.unregister(type);
+			}
+		}
+		this.loaded.delete(name);
+		const entry = rec.manifest.entryPoints?.gateway;
+		if (entry) this.moduleCache.delete(path.resolve(rec.path, entry));
+	}
+}
+
+function pickActivate(mod: unknown): PluginActivateFn | undefined {
+	if (!mod || typeof mod !== "object") return undefined;
+	const m = mod as Record<string, unknown>;
+	if (typeof m.activate === "function") return m.activate as PluginActivateFn;
+	if (typeof m.default === "function") return m.default as PluginActivateFn;
+	return undefined;
+}

--- a/src/server/plugins/plugin-manifest.ts
+++ b/src/server/plugins/plugin-manifest.ts
@@ -1,0 +1,143 @@
+import fs from "node:fs";
+import path from "node:path";
+import { parse as parseYaml } from "yaml";
+
+/**
+ * Plugin manifest — `plugin.yaml` at the root of a plugin bundle.
+ *
+ * The manifest is the single declarative entry point: it lists what the
+ * plugin contributes (workflows, roles, skills, tools, MCP) and where its
+ * runtime entry modules live (gateway-side, UI-side). Verify-step types the
+ * plugin will register at runtime are declared here too so the trust prompt
+ * can show them to the user before the plugin code ever executes.
+ */
+export interface PluginManifest {
+	name: string;
+	version: string;
+	description?: string;
+	bobbit?: { engines?: string };
+	entryPoints?: PluginEntryPoints;
+	contributes?: PluginContributions;
+	/** Verify-step types the gateway entry will register. Listed up-front so the
+	 *  trust prompt can show them before running plugin code. */
+	verifyStepTypes?: string[];
+	/** Coarse permissions the plugin needs (e.g. "external-webhook", "tool-call"). Shown in the trust prompt. */
+	permissions?: string[];
+}
+
+export interface PluginEntryPoints {
+	/** ESM module path relative to the plugin root, imported by the gateway. */
+	gateway?: string;
+	/** ESM module path served at GET /api/plugins/:name/ui/index.js and imported by the web UI. */
+	ui?: string;
+}
+
+export interface PluginContributions {
+	workflows?: string[];     // Paths to workflow YAML files
+	roles?: string[];         // Paths to role YAML files
+	skills?: string[];        // Paths to skill DIRECTORIES (containing SKILL.md)
+	tools_dirs?: string[];    // Paths to tool group directories
+	mcp?: string[];           // Paths to MCP server JSON config files
+}
+
+export interface ManifestValidationError {
+	field: string;
+	message: string;
+}
+
+const NAME_RE = /^[a-z][a-z0-9-]{1,63}$/;
+const VERSION_RE = /^\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?$/;
+
+/** Read and validate a plugin's manifest. Throws on missing file or malformed YAML;
+ *  returns validation errors on schema issues. */
+export function readManifest(pluginRoot: string): { manifest: PluginManifest; errors: ManifestValidationError[] } {
+	const manifestPath = path.join(pluginRoot, "plugin.yaml");
+	const raw = fs.readFileSync(manifestPath, "utf-8");
+	const parsed = parseYaml(raw);
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error(`Plugin manifest at ${manifestPath} did not parse as an object.`);
+	}
+	return validateManifest(parsed as Record<string, unknown>, pluginRoot);
+}
+
+export function validateManifest(raw: Record<string, unknown>, pluginRoot: string): {
+	manifest: PluginManifest;
+	errors: ManifestValidationError[];
+} {
+	const errors: ManifestValidationError[] = [];
+	const push = (field: string, message: string) => errors.push({ field, message });
+
+	const name = typeof raw.name === "string" ? raw.name : "";
+	if (!name) push("name", "is required");
+	else if (!NAME_RE.test(name)) push("name", `must match ${NAME_RE} (got "${name}")`);
+
+	const version = typeof raw.version === "string" ? raw.version : "";
+	if (!version) push("version", "is required");
+	else if (!VERSION_RE.test(version)) push("version", `must be semver (got "${version}")`);
+
+	const entryPoints: PluginEntryPoints = {};
+	const rawEntry = (raw.entryPoints && typeof raw.entryPoints === "object") ? raw.entryPoints as Record<string, unknown> : {};
+	if (typeof rawEntry.gateway === "string") entryPoints.gateway = rawEntry.gateway;
+	if (typeof rawEntry.ui === "string") entryPoints.ui = rawEntry.ui;
+
+	// Path traversal guard — every entry point must resolve inside the plugin root.
+	if (entryPoints.gateway && !insidePluginRoot(pluginRoot, entryPoints.gateway)) {
+		push("entryPoints.gateway", `escapes the plugin root: ${entryPoints.gateway}`);
+	}
+	if (entryPoints.ui && !insidePluginRoot(pluginRoot, entryPoints.ui)) {
+		push("entryPoints.ui", `escapes the plugin root: ${entryPoints.ui}`);
+	}
+
+	const contributes: PluginContributions = {};
+	const rawContrib = (raw.contributes && typeof raw.contributes === "object") ? raw.contributes as Record<string, unknown> : {};
+	for (const key of ["workflows", "roles", "skills", "tools_dirs", "mcp"] as const) {
+		const v = rawContrib[key];
+		if (v === undefined) continue;
+		if (!Array.isArray(v) || !v.every(x => typeof x === "string")) {
+			push(`contributes.${key}`, `must be an array of strings`);
+			continue;
+		}
+		for (const p of v as string[]) {
+			if (!insidePluginRoot(pluginRoot, p)) {
+				push(`contributes.${key}`, `path escapes the plugin root: ${p}`);
+			}
+		}
+		contributes[key] = v as string[];
+	}
+
+	const verifyStepTypes = Array.isArray(raw.verifyStepTypes) && raw.verifyStepTypes.every(x => typeof x === "string")
+		? raw.verifyStepTypes as string[]
+		: undefined;
+	if (raw.verifyStepTypes !== undefined && verifyStepTypes === undefined) {
+		push("verifyStepTypes", "must be an array of strings");
+	}
+
+	const permissions = Array.isArray(raw.permissions) && raw.permissions.every(x => typeof x === "string")
+		? raw.permissions as string[]
+		: undefined;
+	if (raw.permissions !== undefined && permissions === undefined) {
+		push("permissions", "must be an array of strings");
+	}
+
+	const manifest: PluginManifest = {
+		name,
+		version,
+		description: typeof raw.description === "string" ? raw.description : undefined,
+		bobbit: (raw.bobbit && typeof raw.bobbit === "object" && typeof (raw.bobbit as any).engines === "string")
+			? { engines: (raw.bobbit as any).engines as string }
+			: undefined,
+		entryPoints: (entryPoints.gateway || entryPoints.ui) ? entryPoints : undefined,
+		contributes: Object.keys(contributes).length > 0 ? contributes : undefined,
+		verifyStepTypes,
+		permissions,
+	};
+	return { manifest, errors };
+}
+
+/** True iff `relPath` (joined onto `pluginRoot`) resolves to a path inside `pluginRoot`. */
+export function insidePluginRoot(pluginRoot: string, relPath: string): boolean {
+	const root = path.resolve(pluginRoot);
+	const resolved = path.resolve(root, relPath);
+	const rootWithSep = root.endsWith(path.sep) ? root : root + path.sep;
+	return resolved === root || resolved.startsWith(rootWithSep);
+}

--- a/src/server/plugins/plugin-trust-store.ts
+++ b/src/server/plugins/plugin-trust-store.ts
@@ -1,0 +1,128 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createHash } from "node:crypto";
+import { homedir } from "node:os";
+
+/**
+ * Trust store for plugin loading.
+ *
+ * Loading plugin code is full code-exec — sandboxing via Node `vm` is theatre,
+ * so we use explicit trust instead. Builtin plugins under `defaults/plugins/`
+ * are auto-trusted (they ship with bobbit). Plugins from any other location
+ * must be approved explicitly; the approval is keyed by `(absolute path,
+ * sha256(plugin.yaml))` so renaming or mutating the manifest re-prompts.
+ *
+ * State lives at `~/.bobbit/trusted-plugins.json`. Per-machine, never
+ * project-scoped — a malicious project must not be able to auto-trust itself
+ * by committing a trust file to its repo.
+ */
+
+export interface TrustEntry {
+	name: string;
+	path: string;          // absolute, normalised
+	manifestHash: string;  // sha256:<hex>
+	trustedAt: number;     // epoch ms
+}
+
+interface TrustFile {
+	version: 1;
+	trusted: TrustEntry[];
+}
+
+function defaultStorePath(): string {
+	return path.join(homedir(), ".bobbit", "trusted-plugins.json");
+}
+
+export function hashManifest(pluginRoot: string): string {
+	const manifestPath = path.join(pluginRoot, "plugin.yaml");
+	const buf = fs.readFileSync(manifestPath);
+	const h = createHash("sha256").update(buf).digest("hex");
+	return `sha256:${h}`;
+}
+
+export class PluginTrustStore {
+	private readonly storePath: string;
+	private cache: TrustFile | null = null;
+
+	constructor(storePath?: string) {
+		this.storePath = storePath ?? defaultStorePath();
+	}
+
+	private load(): TrustFile {
+		if (this.cache) return this.cache;
+		if (!fs.existsSync(this.storePath)) {
+			this.cache = { version: 1, trusted: [] };
+			return this.cache;
+		}
+		try {
+			const raw = fs.readFileSync(this.storePath, "utf-8");
+			const parsed = JSON.parse(raw) as Partial<TrustFile>;
+			if (parsed.version !== 1 || !Array.isArray(parsed.trusted)) {
+				this.cache = { version: 1, trusted: [] };
+				return this.cache;
+			}
+			this.cache = {
+				version: 1,
+				trusted: parsed.trusted.filter(e =>
+					e && typeof e === "object" &&
+					typeof e.name === "string" &&
+					typeof e.path === "string" &&
+					typeof e.manifestHash === "string"
+				) as TrustEntry[],
+			};
+			return this.cache;
+		} catch {
+			this.cache = { version: 1, trusted: [] };
+			return this.cache;
+		}
+	}
+
+	private persist(): void {
+		if (!this.cache) return;
+		fs.mkdirSync(path.dirname(this.storePath), { recursive: true });
+		fs.writeFileSync(this.storePath, JSON.stringify(this.cache, null, 2));
+	}
+
+	/** Is the plugin at `pluginPath` trusted, validated against the current manifest hash? */
+	isTrusted(pluginPath: string): boolean {
+		const abs = path.resolve(pluginPath);
+		if (!fs.existsSync(path.join(abs, "plugin.yaml"))) return false;
+		const hash = hashManifest(abs);
+		const file = this.load();
+		return file.trusted.some(e => e.path === abs && e.manifestHash === hash);
+	}
+
+	/** Get the trust entry for a path, if any (even if the hash has drifted). */
+	getEntry(pluginPath: string): TrustEntry | undefined {
+		const abs = path.resolve(pluginPath);
+		const file = this.load();
+		return file.trusted.find(e => e.path === abs);
+	}
+
+	/** Persist trust for `(pluginPath, current manifest hash)`. Overwrites any prior entry for that path. */
+	trust(name: string, pluginPath: string): TrustEntry {
+		const abs = path.resolve(pluginPath);
+		const hash = hashManifest(abs);
+		const entry: TrustEntry = { name, path: abs, manifestHash: hash, trustedAt: Date.now() };
+		const file = this.load();
+		file.trusted = file.trusted.filter(e => e.path !== abs);
+		file.trusted.push(entry);
+		this.persist();
+		return entry;
+	}
+
+	/** Revoke trust for a plugin at the given path. Idempotent. */
+	revoke(pluginPath: string): boolean {
+		const abs = path.resolve(pluginPath);
+		const file = this.load();
+		const before = file.trusted.length;
+		file.trusted = file.trusted.filter(e => e.path !== abs);
+		if (file.trusted.length === before) return false;
+		this.persist();
+		return true;
+	}
+
+	listTrusted(): TrustEntry[] {
+		return [...this.load().trusted];
+	}
+}

--- a/src/server/plugins/project-install.ts
+++ b/src/server/plugins/project-install.ts
@@ -1,0 +1,121 @@
+import fs from "node:fs";
+import path from "node:path";
+import { parse as parseYaml } from "yaml";
+import type { ProjectConfigStore } from "../agent/project-config-store.js";
+import type { InlineWorkflowDef } from "../agent/project-config-store.js";
+import type { DiscoveredPlugin } from "./plugin-loader.js";
+import { insidePluginRoot } from "./plugin-manifest.js";
+
+export interface InstallResult {
+	ok: true;
+	workflowsInstalled: string[]; // namespaced ids: "<plugin>::<id>"
+}
+
+export interface InstallFailure {
+	ok: false;
+	error: string;
+	details?: unknown;
+}
+
+/**
+ * Install a plugin into a project: copy its contributed workflow YAMLs into
+ * `project.yaml::plugin_workflows` as frozen snapshots and add an entry to
+ * `project.yaml::plugins`. Roles / skills / tools / MCP contributions are not
+ * surfaced to the cascade yet — that needs `config_directories` integration,
+ * which lives in a follow-up.
+ *
+ * Idempotent on re-install: replaces the prior install record and snapshots.
+ * Existing goals that snapshotted the old workflow into `PersistedGoal.workflow`
+ * are unaffected (their snapshot is frozen at goal creation).
+ */
+export function installPluginIntoProject(
+	cfg: ProjectConfigStore,
+	plugin: DiscoveredPlugin,
+): InstallResult | InstallFailure {
+	if (plugin.manifestErrors.length > 0) {
+		return { ok: false, error: "manifest has errors", details: plugin.manifestErrors };
+	}
+
+	const workflowPaths = plugin.manifest.contributes?.workflows ?? [];
+	const entries: { id: string; snapshot: InlineWorkflowDef }[] = [];
+	for (const rel of workflowPaths) {
+		if (!insidePluginRoot(plugin.path, rel)) {
+			return { ok: false, error: `workflow path escapes plugin root: ${rel}` };
+		}
+		const abs = path.resolve(plugin.path, rel);
+		if (!fs.existsSync(abs)) {
+			return { ok: false, error: `workflow file not found: ${rel}` };
+		}
+		try {
+			const raw = parseYaml(fs.readFileSync(abs, "utf-8")) as unknown;
+			const list = workflowsFromYaml(raw);
+			if (list.length === 0) {
+				return { ok: false, error: `workflow file ${rel} contains no parseable workflow entries.` };
+			}
+			for (const item of list) entries.push(item);
+		} catch (e) {
+			return { ok: false, error: `failed to parse ${rel}: ${e instanceof Error ? e.message : String(e)}` };
+		}
+	}
+
+	// Reject duplicate ids within this plugin's contributions.
+	const seen = new Set<string>();
+	for (const e of entries) {
+		if (seen.has(e.id)) {
+			return { ok: false, error: `plugin ships duplicate workflow id '${e.id}'.` };
+		}
+		seen.add(e.id);
+	}
+
+	cfg.setPluginWorkflows(plugin.name, entries);
+	cfg.addInstalledPlugin({
+		name: plugin.name,
+		version: plugin.manifest.version,
+		installedAt: Date.now(),
+	});
+
+	return { ok: true, workflowsInstalled: entries.map(e => `${plugin.name}::${e.id}`) };
+}
+
+/**
+ * Uninstall a plugin from a project: drop its install record and any
+ * `plugin_workflows` snapshots it contributed. Returns false if the plugin was
+ * not installed.
+ *
+ * Goal snapshots are not touched — an in-flight goal whose workflow originally
+ * came from this plugin keeps running off its frozen `PersistedGoal.workflow`.
+ * The signal-time "no handler registered" failure (if the plugin also ships
+ * verify-step types and is then untrusted) is the safety net.
+ */
+export function uninstallPluginFromProject(
+	cfg: ProjectConfigStore,
+	pluginName: string,
+): { ok: boolean; removed: boolean } {
+	const removed = cfg.removeInstalledPlugin(pluginName);
+	return { ok: true, removed };
+}
+
+/** Parse a workflow YAML file. Supports either a top-level Workflow object
+ *  (single workflow, id in file) or a map of `id → Workflow` (multiple in one file). */
+function workflowsFromYaml(raw: unknown): { id: string; snapshot: InlineWorkflowDef }[] {
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) return [];
+	const obj = raw as Record<string, unknown>;
+	const out: { id: string; snapshot: InlineWorkflowDef }[] = [];
+
+	// Shape A: single workflow with an explicit `id:` field at the top level.
+	if (typeof obj.id === "string" && Array.isArray(obj.gates)) {
+		out.push({ id: obj.id, snapshot: obj as unknown as InlineWorkflowDef });
+		return out;
+	}
+
+	// Shape B: map of `id → Workflow`. Each value must look like a workflow definition.
+	for (const [k, v] of Object.entries(obj)) {
+		if (v && typeof v === "object" && !Array.isArray(v)) {
+			const wf = v as Record<string, unknown>;
+			if (Array.isArray(wf.gates)) {
+				out.push({ id: typeof wf.id === "string" ? wf.id : k, snapshot: wf as unknown as InlineWorkflowDef });
+			}
+		}
+	}
+	return out;
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1022,6 +1022,32 @@ export function createGateway(config: GatewayConfig) {
 			// Wire verification harness before session restore so orphan cleanup can skip resuming sessions
 			sessionManager.setVerificationHarness(verificationHarness);
 
+			// Discover and load plugins so they can register verify-step handlers
+			// before any verification kicks off post-restore. Builtin plugins are
+			// auto-trusted; user / server / project locations need explicit approval.
+			// Loading is best-effort: a failing plugin surfaces via GET /api/plugins
+			// but never blocks gateway startup.
+			if (!process.env.BOBBIT_SKIP_PLUGINS) {
+				try {
+					const { discoverPlugins, PluginLoader } = await import("./plugins/plugin-loader.js");
+					const discovered = discoverPlugins();
+					const pluginLoader = new PluginLoader({ registry: verificationHarness.verifyRegistry });
+					(globalThis as any).__bobbitPluginLoader = pluginLoader;
+					(globalThis as any).__bobbitDiscoveredPlugins = discovered;
+					const loaded = await pluginLoader.loadAll(discovered);
+					for (const p of loaded) {
+						if (p.load.status === "loaded") {
+							const types = p.load.registeredTypes.length > 0 ? ` (${p.load.registeredTypes.join(", ")})` : "";
+							console.log(`[plugin] loaded ${p.name}@${p.manifest.version}${types}`);
+						} else if (p.load.status !== "needs-approval") {
+							console.warn(`[plugin] ${p.name}: ${JSON.stringify(p.load)}`);
+						}
+					}
+				} catch (err) {
+					console.error("[plugin] discovery failed:", (err as Error).message);
+				}
+			}
+
 			// ── Sandbox manager ──
 			// Sandboxes are initialized lazily per-project on first sandbox use
 			// (see SandboxManager.ensureForProject). The bootstrap closure below

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1029,11 +1029,10 @@ export function createGateway(config: GatewayConfig) {
 			// but never blocks gateway startup.
 			if (!process.env.BOBBIT_SKIP_PLUGINS) {
 				try {
-					const { discoverPlugins, PluginLoader } = await import("./plugins/plugin-loader.js");
+					const { discoverPlugins, PluginLoader, setGlobalPluginLoader } = await import("./plugins/plugin-loader.js");
 					const discovered = discoverPlugins();
 					const pluginLoader = new PluginLoader({ registry: verificationHarness.verifyRegistry });
-					(globalThis as any).__bobbitPluginLoader = pluginLoader;
-					(globalThis as any).__bobbitDiscoveredPlugins = discovered;
+					setGlobalPluginLoader(pluginLoader, discovered);
 					const loaded = await pluginLoader.loadAll(discovered);
 					for (const p of loaded) {
 						if (p.load.status === "loaded") {
@@ -4982,6 +4981,84 @@ async function handleApiRoute(
 		const cancelCtx = projectContextManager.getContextForGoal(goalId);
 		if (cancelCtx) cancelCtx.gateStore.updateGateStatus(goalId, gateId, "failed");
 		json({ cancelled: true }, 200);
+		return;
+	}
+
+	// ── Plugin management ────────────────────────────────────────────
+	// GET /api/plugins — list discovered plugins with status (loaded / needs-approval / error / manifest-invalid)
+	if (url.pathname === "/api/plugins" && req.method === "GET") {
+		const { getGlobalPluginLoader } = await import("./plugins/plugin-loader.js");
+		const ctx = getGlobalPluginLoader();
+		if (!ctx) { json({ plugins: [] }); return; }
+		const records = ctx.discovered.map(d => {
+			const rec = ctx.loader.getLoaded(d.name);
+			return {
+				name: d.name,
+				version: d.manifest.version,
+				description: d.manifest.description,
+				source: d.source,
+				path: d.path,
+				contributes: d.manifest.contributes ?? null,
+				entryPoints: d.manifest.entryPoints ?? null,
+				verifyStepTypes: d.manifest.verifyStepTypes ?? [],
+				permissions: d.manifest.permissions ?? [],
+				manifestErrors: d.manifestErrors,
+				load: rec?.load ?? { status: "not-loaded" },
+			};
+		});
+		json({ plugins: records });
+		return;
+	}
+
+	// GET / POST / DELETE /api/plugins/:name and POST /api/plugins/:name/trust
+	const pluginTrustMatch = url.pathname.match(/^\/api\/plugins\/([^/]+)\/trust$/);
+	if (pluginTrustMatch) {
+		const name = decodeURIComponent(pluginTrustMatch[1]);
+		const { getGlobalPluginLoader, refreshPlugins } = await import("./plugins/plugin-loader.js");
+		const ctx = getGlobalPluginLoader();
+		if (!ctx) { json({ error: "Plugin loader not initialised" }, 503); return; }
+		const discovered = ctx.discovered.find(d => d.name === name);
+		if (!discovered) { json({ error: "Plugin not found" }, 404); return; }
+
+		if (req.method === "POST") {
+			if (discovered.manifestErrors.length > 0) {
+				json({ error: "Cannot trust a plugin with manifest errors", manifestErrors: discovered.manifestErrors }, 400);
+				return;
+			}
+			ctx.loader.trustPlugin(discovered);
+			// Drop any cached "needs-approval" state and re-attempt the load.
+			await ctx.loader.unload(name);
+			await refreshPlugins();
+			const updated = ctx.loader.getLoaded(name);
+			json({ trusted: true, load: updated?.load ?? { status: "not-loaded" } });
+			return;
+		}
+		if (req.method === "DELETE") {
+			await ctx.loader.revokeTrust(discovered);
+			json({ trusted: false });
+			return;
+		}
+	}
+
+	const pluginDetailMatch = url.pathname.match(/^\/api\/plugins\/([^/]+)$/);
+	if (pluginDetailMatch && req.method === "GET") {
+		const name = decodeURIComponent(pluginDetailMatch[1]);
+		const { getGlobalPluginLoader } = await import("./plugins/plugin-loader.js");
+		const ctx = getGlobalPluginLoader();
+		if (!ctx) { json({ error: "Plugin loader not initialised" }, 503); return; }
+		const discovered = ctx.discovered.find(d => d.name === name);
+		if (!discovered) { json({ error: "Plugin not found" }, 404); return; }
+		const rec = ctx.loader.getLoaded(name);
+		json({
+			name: discovered.name,
+			version: discovered.manifest.version,
+			description: discovered.manifest.description,
+			source: discovered.source,
+			path: discovered.path,
+			manifest: discovered.manifest,
+			manifestErrors: discovered.manifestErrors,
+			load: rec?.load ?? { status: "not-loaded" },
+		});
 		return;
 	}
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4984,6 +4984,70 @@ async function handleApiRoute(
 		return;
 	}
 
+	// ── Per-project plugin install lifecycle ─────────────────────────
+	// POST /api/projects/:projectId/plugins/:name/install — install plugin into project
+	// DELETE /api/projects/:projectId/plugins/:name        — uninstall
+	// GET    /api/projects/:projectId/plugins              — list installed
+	const projectPluginInstallMatch = url.pathname.match(/^\/api\/projects\/([^/]+)\/plugins\/([^/]+)\/install$/);
+	if (projectPluginInstallMatch && req.method === "POST") {
+		const [, projectId, pluginName] = projectPluginInstallMatch;
+		const project = projectRegistry.get(projectId);
+		if (!project) { json({ error: "Project not found" }, 404); return; }
+		const ctx = projectContextManager.getOrCreate(projectId);
+		if (!ctx) { json({ error: "Project context unavailable" }, 503); return; }
+
+		const { getGlobalPluginLoader } = await import("./plugins/plugin-loader.js");
+		const pl = getGlobalPluginLoader();
+		if (!pl) { json({ error: "Plugin loader not initialised" }, 503); return; }
+		const discovered = pl.discovered.find(d => d.name === pluginName);
+		if (!discovered) { json({ error: "Plugin not found" }, 404); return; }
+
+		const { installPluginIntoProject } = await import("./plugins/project-install.js");
+		const result = installPluginIntoProject(ctx.projectConfigStore, discovered);
+		if (!result.ok) { json({ error: result.error, details: result.details }, 400); return; }
+		json({ installed: true, workflows: result.workflowsInstalled });
+		return;
+	}
+
+	const projectPluginUninstallMatch = url.pathname.match(/^\/api\/projects\/([^/]+)\/plugins\/([^/]+)$/);
+	if (projectPluginUninstallMatch && req.method === "DELETE") {
+		const [, projectId, pluginName] = projectPluginUninstallMatch;
+		const project = projectRegistry.get(projectId);
+		if (!project) { json({ error: "Project not found" }, 404); return; }
+		const ctx = projectContextManager.getOrCreate(projectId);
+		if (!ctx) { json({ error: "Project context unavailable" }, 503); return; }
+		const { uninstallPluginFromProject } = await import("./plugins/project-install.js");
+		const result = uninstallPluginFromProject(ctx.projectConfigStore, pluginName);
+		json(result);
+		return;
+	}
+
+	const projectPluginListMatch = url.pathname.match(/^\/api\/projects\/([^/]+)\/plugins$/);
+	if (projectPluginListMatch && req.method === "GET") {
+		const [, projectId] = projectPluginListMatch;
+		const project = projectRegistry.get(projectId);
+		if (!project) { json({ error: "Project not found" }, 404); return; }
+		const ctx = projectContextManager.getOrCreate(projectId);
+		if (!ctx) { json({ error: "Project context unavailable" }, 503); return; }
+		const installed = ctx.projectConfigStore.getInstalledPlugins();
+		const wfEntries = ctx.projectConfigStore.getPluginWorkflows();
+		const byPlugin = new Map<string, { id: string; namespacedId: string }[]>();
+		for (const e of wfEntries) {
+			const list = byPlugin.get(e.source) ?? [];
+			list.push({ id: e.id, namespacedId: `${e.source}::${e.id}` });
+			byPlugin.set(e.source, list);
+		}
+		json({
+			plugins: installed.map(p => ({
+				name: p.name,
+				version: p.version,
+				installedAt: p.installedAt,
+				workflows: byPlugin.get(p.name) ?? [],
+			})),
+		});
+		return;
+	}
+
 	// ── Plugin management ────────────────────────────────────────────
 	// GET /api/plugins — list discovered plugins with status (loaded / needs-approval / error / manifest-invalid)
 	if (url.pathname === "/api/plugins" && req.method === "GET") {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4959,6 +4959,68 @@ async function handleApiRoute(
 		return;
 	}
 
+	// POST /api/verify/rubric/:token — callback for rubric-review/human verify steps.
+	// Body must echo the goalId/gateId/signalId triple and include rubric values.
+	const rubricCallbackMatch = url.pathname.match(/^\/api\/verify\/rubric\/([^/]+)$/);
+	if (rubricCallbackMatch && req.method === "POST") {
+		const token = rubricCallbackMatch[1];
+		const body = await readBody(req);
+		if (!body || typeof body !== "object") { json({ error: "Missing body" }, 400); return; }
+		const { goalId, gateId, signalId, values, notes } = body as Record<string, unknown>;
+		if (typeof goalId !== "string" || typeof gateId !== "string" || typeof signalId !== "string") {
+			json({ error: "Body must include goalId, gateId, signalId" }, 400);
+			return;
+		}
+		if (!values || typeof values !== "object" || Array.isArray(values)) {
+			json({ error: "Body must include a 'values' object" }, 400);
+			return;
+		}
+		const { deliverRubricHumanCallback } = await import("./agent/verify-handlers/rubric-review-handler.js");
+		const outcome = deliverRubricHumanCallback(token, {
+			goalId, gateId, signalId,
+			values: values as Record<string, string | number>,
+			notes: typeof notes === "string" ? notes : undefined,
+		});
+		if (!outcome.ok) {
+			json({ error: outcome.error }, outcome.status);
+			return;
+		}
+		json({ delivered: true });
+		return;
+	}
+
+	// POST /api/verify/external/:token — callback for external-job verify steps.
+	// Body must echo the goalId/gateId/signalId triple the token was issued for.
+	const externalCallbackMatch = url.pathname.match(/^\/api\/verify\/external\/([^/]+)$/);
+	if (externalCallbackMatch && req.method === "POST") {
+		const token = externalCallbackMatch[1];
+		const body = await readBody(req);
+		if (!body || typeof body !== "object") { json({ error: "Missing body" }, 400); return; }
+		const { goalId, gateId, signalId, passed, summary, artifact } = body as Record<string, unknown>;
+		if (typeof goalId !== "string" || typeof gateId !== "string" || typeof signalId !== "string") {
+			json({ error: "Body must include goalId, gateId, signalId" }, 400);
+			return;
+		}
+		if (typeof passed !== "boolean") {
+			json({ error: "Body must include boolean 'passed'" }, 400);
+			return;
+		}
+		const { deliverExternalJobCallback } = await import("./agent/verify-handlers/external-job-handler.js");
+		const outcome = deliverExternalJobCallback(token, {
+			goalId, gateId, signalId, passed,
+			summary: typeof summary === "string" ? summary : undefined,
+			artifact: (artifact && typeof artifact === "object" && !Array.isArray(artifact))
+				? artifact as { content: string; contentType: string; metadata?: Record<string, string> }
+				: undefined,
+		});
+		if (!outcome.ok) {
+			json({ error: outcome.error }, outcome.status);
+			return;
+		}
+		json({ delivered: true });
+		return;
+	}
+
 	// GET /api/goals/:goalId/gates/:gateId/content — gate content
 	const gateContentMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/gates\/([^/]+)\/content$/);
 	if (gateContentMatch && req.method === "GET") {

--- a/tests/autoresearch-plugin.test.ts
+++ b/tests/autoresearch-plugin.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Acceptance test for the shipped autoresearch plugin in defaults/plugins/.
+ *
+ * Verifies the manifest validates, the workflow YAML parses through the
+ * install pipeline, and the resulting workflow has the expected gate DAG
+ * and verify-step types. This is the smoke test that catches "plugin shipped
+ * with a broken YAML" regressions.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import { readManifest } from "../src/server/plugins/plugin-manifest.ts";
+import { installPluginIntoProject } from "../src/server/plugins/project-install.ts";
+import { ProjectConfigStore } from "../src/server/agent/project-config-store.ts";
+import { InlineWorkflowStore } from "../src/server/agent/workflow-store.ts";
+
+const PLUGIN_ROOT = path.resolve(import.meta.dirname, "..", "defaults", "plugins", "autoresearch");
+
+describe("autoresearch plugin (defaults/plugins/autoresearch)", () => {
+	it("ships a valid plugin.yaml manifest", () => {
+		const { manifest, errors } = readManifest(PLUGIN_ROOT);
+		assert.deepEqual(errors, [], `manifest errors: ${JSON.stringify(errors)}`);
+		assert.equal(manifest.name, "autoresearch");
+		assert.match(manifest.version, /^\d+\.\d+\.\d+/);
+		assert.deepEqual(manifest.contributes?.workflows, ["workflows/autoresearch.yaml"]);
+		// Data-only — no gateway entry to import, no UI bundle to serve.
+		assert.equal(manifest.entryPoints, undefined);
+	});
+
+	it("installs into a project and registers the namespaced workflow", () => {
+		const cfg = new ProjectConfigStore(fs.mkdtempSync(path.join(os.tmpdir(), "autoresearch-test-")));
+		const { manifest, errors } = readManifest(PLUGIN_ROOT);
+		assert.deepEqual(errors, []);
+
+		const result = installPluginIntoProject(cfg, {
+			name: manifest.name,
+			path: PLUGIN_ROOT,
+			source: "builtin",
+			manifest,
+			manifestErrors: [],
+		});
+
+		assert.equal(result.ok, true, `install failed: ${JSON.stringify(result)}`);
+		if (result.ok) {
+			assert.deepEqual(result.workflowsInstalled, ["autoresearch::research"]);
+		}
+		assert.equal(cfg.isPluginInstalled("autoresearch"), true);
+	});
+
+	it("the installed workflow has the expected gate DAG and verify-step types", () => {
+		const cfg = new ProjectConfigStore(fs.mkdtempSync(path.join(os.tmpdir(), "autoresearch-test-")));
+		const { manifest } = readManifest(PLUGIN_ROOT);
+		installPluginIntoProject(cfg, {
+			name: manifest.name,
+			path: PLUGIN_ROOT,
+			source: "builtin",
+			manifest,
+			manifestErrors: [],
+		});
+
+		const wfStore = new InlineWorkflowStore(cfg);
+		const wf = wfStore.get("autoresearch::research");
+		assert.ok(wf, "namespaced workflow id 'autoresearch::research' should exist after install");
+		assert.equal(wf.pluginSource?.name, "autoresearch");
+		assert.equal(wf.pluginSource?.originalId, "research");
+
+		const gateById = new Map(wf.gates.map(g => [g.id, g]));
+		// Expected DAG: idea → literature → plan → experiment-run → analysis → publication
+		assert.deepEqual(gateById.get("idea")?.dependsOn, []);
+		assert.deepEqual(gateById.get("literature")?.dependsOn, ["idea"]);
+		assert.deepEqual(gateById.get("plan")?.dependsOn, ["literature"]);
+		assert.deepEqual(gateById.get("experiment-run")?.dependsOn, ["plan"]);
+		assert.deepEqual(gateById.get("analysis")?.dependsOn, ["experiment-run"]);
+		assert.deepEqual(gateById.get("publication")?.dependsOn, ["analysis"]);
+
+		// publication is manual — no automated verify, user clicks Mark passed.
+		assert.equal(gateById.get("publication")?.manual, true);
+		assert.equal(gateById.get("publication")?.verify, undefined);
+
+		// idea has no verify — content gate only.
+		assert.equal(gateById.get("idea")?.verify, undefined);
+		assert.equal(gateById.get("idea")?.content, true);
+		assert.equal(gateById.get("idea")?.injectDownstream, true);
+
+		// literature / plan / analysis use rubric-review (LLM) with pass_when criteria.
+		for (const id of ["literature", "plan", "analysis"]) {
+			const gate = gateById.get(id);
+			assert.ok(gate, `gate ${id} should exist`);
+			assert.equal(gate.content, true, `gate ${id} should be a content gate`);
+			assert.equal(gate.injectDownstream, true, `gate ${id} should inject downstream`);
+			const rubricStep = gate.verify?.find(s => s.type === "rubric-review");
+			assert.ok(rubricStep, `gate ${id} should have a rubric-review step`);
+			assert.equal(rubricStep.reviewer, "llm");
+			assert.ok(Array.isArray(rubricStep.rubric) && rubricStep.rubric.length > 0);
+			assert.ok(typeof rubricStep.pass_when === "string" && rubricStep.pass_when.length > 0,
+				`rubric on '${id}' should declare a pass_when expression`);
+		}
+
+		// experiment-run uses external-job with a multi-day timeout budget.
+		const experimentGate = gateById.get("experiment-run");
+		assert.ok(experimentGate, "experiment-run gate should exist");
+		const externalStep = experimentGate.verify?.find(s => s.type === "external-job");
+		assert.ok(externalStep, "experiment-run should have an external-job step");
+		assert.ok(typeof externalStep.timeout === "number" && externalStep.timeout >= 24 * 3600,
+			"external-job timeout should be at least 24h for real experiment runs");
+	});
+});

--- a/tests/external-job-handler.test.ts
+++ b/tests/external-job-handler.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for the external-job verify-step handler — the first plugin-style
+ * built-in handler routed through the VerifyHandlerRegistry. Exercises the
+ * callback token lifecycle (success, timeout, tampered triple, unknown token).
+ */
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+	externalJobHandler,
+	deliverExternalJobCallback,
+	pendingExternalCount,
+	_clearPendingExternalForTests,
+} from "../src/server/agent/verify-handlers/external-job-handler.ts";
+import type { VerifyExecCtx } from "../src/server/agent/verify-handlers/registry.ts";
+import type { VerifyStep } from "../src/server/agent/workflow-store.ts";
+
+function ctx(goalId = "g1", gateId = "gate-a", signalId = "sig-1"): VerifyExecCtx {
+	return {
+		goalId, gateId, signalId,
+		signal: {} as any,
+		gate: {} as any,
+		cwd: "/tmp",
+		branch: "feature",
+		primaryBranch: "master",
+		builtinVars: {},
+		projectVars: {},
+		agentVars: {},
+		substituteVars: (t: string) => t,
+		broadcast: () => {},
+		persistActive: () => {},
+		isCancelled: () => false,
+	};
+}
+
+function step(timeout?: number): VerifyStep {
+	return { name: "Training run", type: "external-job", timeout };
+}
+
+describe("external-job handler", () => {
+	beforeEach(() => _clearPendingExternalForTests());
+
+	it("execute() registers a pending callback and returns a Promise", async () => {
+		const c = ctx();
+		const promise = externalJobHandler.execute(c, step(60));
+		// The promise hasn't resolved yet; one pending entry exists.
+		assert.equal(pendingExternalCount(), 1);
+		// Avoid leaking the un-resolved promise — resolve it via callback below.
+		void promise;
+	});
+
+	it("broadcasts a token that the caller can use to deliver the callback", async () => {
+		let receivedToken: string | undefined;
+		const c: VerifyExecCtx = {
+			...ctx(),
+			broadcast: (event: unknown) => {
+				const ev = event as Record<string, unknown>;
+				if (ev.type === "gate_verification_external_pending" && typeof ev.token === "string") {
+					receivedToken = ev.token;
+				}
+			},
+		};
+		const promise = externalJobHandler.execute(c, step(60));
+		assert.ok(receivedToken, "expected a token in the broadcast event");
+
+		const outcome = deliverExternalJobCallback(receivedToken, {
+			goalId: "g1", gateId: "gate-a", signalId: "sig-1",
+			passed: true, summary: "Done.",
+		});
+		assert.deepEqual(outcome, { ok: true });
+		const result = await promise;
+		assert.equal(result.passed, true);
+		assert.equal(result.output, "Done.");
+	});
+
+	it("rejects callback when triple does not match", async () => {
+		let token: string | undefined;
+		const c: VerifyExecCtx = {
+			...ctx("g1", "gate-a", "sig-1"),
+			broadcast: (ev: any) => { if (ev.token) token = ev.token; },
+		};
+		const promise = externalJobHandler.execute(c, step(60));
+		assert.ok(token);
+
+		const wrongGoal = deliverExternalJobCallback(token, {
+			goalId: "g-other", gateId: "gate-a", signalId: "sig-1", passed: true,
+		});
+		assert.equal(wrongGoal.ok, false);
+		assert.equal((wrongGoal as any).status, 403);
+		// Original entry is still pending — bad callbacks must not consume it.
+		assert.equal(pendingExternalCount(), 1);
+		// Clean up the still-pending entry.
+		deliverExternalJobCallback(token, {
+			goalId: "g1", gateId: "gate-a", signalId: "sig-1", passed: false,
+		});
+		await promise;
+	});
+
+	it("rejects unknown tokens with 404", () => {
+		const outcome = deliverExternalJobCallback("does-not-exist", {
+			goalId: "g1", gateId: "gate-a", signalId: "sig-1", passed: true,
+		});
+		assert.equal(outcome.ok, false);
+		assert.equal((outcome as any).status, 404);
+	});
+
+	it("rejects expired tokens with 410", async () => {
+		let token: string | undefined;
+		const c: VerifyExecCtx = {
+			...ctx(),
+			broadcast: (ev: any) => { if (ev.token) token = ev.token; },
+		};
+		// timeout=1 → callback registered with expiresAt = now + 1s.
+		const promise = externalJobHandler.execute(c, step(1));
+		assert.ok(token);
+
+		await new Promise(r => setTimeout(r, 1100));
+		const outcome = deliverExternalJobCallback(token, {
+			goalId: "g1", gateId: "gate-a", signalId: "sig-1", passed: true,
+		});
+		// Either the timeout already fired (404) or the callback found it expired (410).
+		// Both are acceptable — they share the contract that the token is no longer usable.
+		assert.equal(outcome.ok, false);
+		assert.ok([404, 410].includes((outcome as any).status));
+		// The promise resolves to a timeout failure once the timer fires.
+		const result = await promise;
+		assert.equal(result.passed, false);
+		assert.match(result.output, /timed out/);
+	});
+
+	it("each callback is single-use — second delivery returns 404", async () => {
+		let token: string | undefined;
+		const c: VerifyExecCtx = {
+			...ctx(),
+			broadcast: (ev: any) => { if (ev.token) token = ev.token; },
+		};
+		const promise = externalJobHandler.execute(c, step(60));
+		assert.ok(token);
+		const first = deliverExternalJobCallback(token, {
+			goalId: "g1", gateId: "gate-a", signalId: "sig-1", passed: true,
+		});
+		assert.equal(first.ok, true);
+		const second = deliverExternalJobCallback(token, {
+			goalId: "g1", gateId: "gate-a", signalId: "sig-1", passed: true,
+		});
+		assert.equal(second.ok, false);
+		assert.equal((second as any).status, 404);
+		await promise;
+	});
+
+	it("passes artifact through to the verify-step result", async () => {
+		let token: string | undefined;
+		const c: VerifyExecCtx = {
+			...ctx(),
+			broadcast: (ev: any) => { if (ev.token) token = ev.token; },
+		};
+		const promise = externalJobHandler.execute(c, step(60));
+		assert.ok(token);
+		deliverExternalJobCallback(token, {
+			goalId: "g1", gateId: "gate-a", signalId: "sig-1",
+			passed: true, summary: "ok",
+			artifact: { content: "# Training Report\nTop-line: 0.92", contentType: "text/markdown" },
+		});
+		const result = await promise;
+		assert.equal(result.artifact?.contentType, "text/markdown");
+		assert.match(result.artifact?.content ?? "", /Top-line/);
+	});
+});

--- a/tests/plugin-loader.test.ts
+++ b/tests/plugin-loader.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Unit tests for plugin discovery + lazy loading + activate lifecycle.
+ *
+ * Builds tiny throwaway plugins in a tmpdir, points the loader at them, and
+ * verifies:
+ *   - cascade resolution (builtin → server → user → project; later sources win)
+ *   - data-only plugin loads without needing approval (no gateway entry)
+ *   - plugin with code requires trust before its activate() runs
+ *   - activate() can register handlers via the host API
+ *   - unload() calls deactivate() and unregisters handlers
+ *   - manifest errors surface as a load status (not a throw)
+ *   - throwing plugin code surfaces as load status: error
+ */
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import { VerifyHandlerRegistry } from "../src/server/agent/verify-handlers/registry.ts";
+import {
+	discoverPlugins,
+	PluginLoader,
+	type DiscoveryPaths,
+} from "../src/server/plugins/plugin-loader.ts";
+import { PluginTrustStore } from "../src/server/plugins/plugin-trust-store.ts";
+
+let tmpRoot: string;
+let trustPath: string;
+
+before(() => {
+	tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "plugin-loader-test-"));
+});
+
+after(() => {
+	fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+	// Fresh trust store per test so prior approvals don't leak.
+	trustPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "plugin-trust-")), "trusted.json");
+});
+
+function writePlugin(parent: string, name: string, opts: {
+	manifest: string;
+	gatewayEntry?: { relPath: string; jsBody: string };
+}): string {
+	const dir = path.join(parent, name);
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(path.join(dir, "plugin.yaml"), opts.manifest);
+	if (opts.gatewayEntry) {
+		const entryAbs = path.join(dir, opts.gatewayEntry.relPath);
+		fs.mkdirSync(path.dirname(entryAbs), { recursive: true });
+		fs.writeFileSync(entryAbs, opts.gatewayEntry.jsBody);
+	}
+	return dir;
+}
+
+function paths(opts: Partial<DiscoveryPaths>): DiscoveryPaths {
+	return { ...opts };
+}
+
+describe("discoverPlugins", () => {
+	it("returns [] when none of the cascade paths exist", () => {
+		assert.deepEqual(discoverPlugins(paths({ builtin: "/no/such/path" })), []);
+	});
+
+	it("scans plugin.yaml in subdirectories of each path", () => {
+		const dir = fs.mkdtempSync(path.join(tmpRoot, "scan-"));
+		writePlugin(dir, "alpha", { manifest: "name: alpha\nversion: 1.0.0\n" });
+		writePlugin(dir, "beta", { manifest: "name: beta\nversion: 0.5.0\n" });
+		fs.mkdirSync(path.join(dir, "no-manifest")); // dir without plugin.yaml — skip
+		const found = discoverPlugins(paths({ builtin: dir }));
+		const names = found.map(p => p.name).sort();
+		assert.deepEqual(names, ["alpha", "beta"]);
+	});
+
+	it("later cascade levels override earlier ones by name", () => {
+		const builtinDir = fs.mkdtempSync(path.join(tmpRoot, "builtin-"));
+		const userDir = fs.mkdtempSync(path.join(tmpRoot, "user-"));
+		writePlugin(builtinDir, "shared", { manifest: "name: shared\nversion: 1.0.0\n" });
+		writePlugin(userDir, "shared", { manifest: "name: shared\nversion: 9.9.9\n" });
+		const [p] = discoverPlugins(paths({ builtin: builtinDir, userHome: userDir }));
+		assert.equal(p.source, "user");
+		assert.equal(p.manifest.version, "9.9.9");
+	});
+
+	it("captures manifest errors without dropping the plugin from discovery", () => {
+		const dir = fs.mkdtempSync(path.join(tmpRoot, "bad-"));
+		writePlugin(dir, "broken", { manifest: "name: BAD-Name\nversion: 1.0.0\n" });
+		const found = discoverPlugins(paths({ builtin: dir }));
+		assert.equal(found.length, 1);
+		assert.ok(found[0].manifestErrors.some(e => e.field === "name"),
+			"discovery must still surface the plugin so the UI can show 'manifest invalid' instead of silently hiding it");
+	});
+
+	it("captures throwing YAML parse without crashing discovery", () => {
+		const dir = fs.mkdtempSync(path.join(tmpRoot, "parse-fail-"));
+		writePlugin(dir, "x", { manifest: ": : : : not yaml" });
+		const found = discoverPlugins(paths({ builtin: dir }));
+		assert.equal(found.length, 1);
+		assert.ok(found[0].manifestErrors.length > 0);
+	});
+});
+
+describe("PluginLoader — data-only plugin", () => {
+	it("loads without trust when there's no gateway entry", async () => {
+		const dir = fs.mkdtempSync(path.join(tmpRoot, "dataonly-"));
+		writePlugin(dir, "data-only", {
+			manifest: "name: data-only\nversion: 1.0.0\ncontributes:\n  workflows: [w.yaml]\n",
+		});
+		// data-only plugin in a non-builtin location requires trust to run code,
+		// but since there's no code to run, it loads fine.
+		// Mark as builtin so trust isn't even consulted.
+		const found = discoverPlugins(paths({ builtin: dir }));
+		const reg = new VerifyHandlerRegistry();
+		const loader = new PluginLoader({ registry: reg, trustStore: new PluginTrustStore(trustPath) });
+		const r = await loader.loadOne(found[0]);
+		assert.equal(r.load.status, "loaded");
+		assert.deepEqual(r.load.status === "loaded" ? r.load.registeredTypes : null, []);
+	});
+});
+
+describe("PluginLoader — gateway entry with code", () => {
+	function makeCodePlugin(parent: string, name: string, jsBody: string, sourceDir: "builtin" | "user" = "user"): string {
+		const dir = writePlugin(parent, name, {
+			manifest: [
+				`name: ${name}`,
+				"version: 1.0.0",
+				"entryPoints:",
+				"  gateway: index.mjs",
+			].join("\n"),
+			gatewayEntry: { relPath: "index.mjs", jsBody },
+		});
+		return dir;
+	}
+
+	it("blocks load with needs-approval when plugin is not in trust store and not builtin", async () => {
+		const userDir = fs.mkdtempSync(path.join(tmpRoot, "user-untrusted-"));
+		makeCodePlugin(userDir, "untrusted", `export default () => {};`, "user");
+		const found = discoverPlugins(paths({ userHome: userDir }));
+		const reg = new VerifyHandlerRegistry();
+		const loader = new PluginLoader({ registry: reg, trustStore: new PluginTrustStore(trustPath) });
+		const r = await loader.loadOne(found[0]);
+		assert.equal(r.load.status, "needs-approval");
+		assert.equal(reg.has("anything"), false);
+	});
+
+	it("loads and runs activate() once trusted, registering verify handlers", async () => {
+		const userDir = fs.mkdtempSync(path.join(tmpRoot, "user-trusted-"));
+		makeCodePlugin(userDir, "trusted", `
+			export default function activate(api) {
+				api.registerVerifyHandler({
+					type: "noop-from-plugin",
+					async execute() { return { passed: true, output: "plugin ran" }; },
+				});
+			}
+		`, "user");
+		const found = discoverPlugins(paths({ userHome: userDir }));
+		const reg = new VerifyHandlerRegistry();
+		const trust = new PluginTrustStore(trustPath);
+		trust.trust("trusted", found[0].path);
+
+		const loader = new PluginLoader({ registry: reg, trustStore: trust });
+		const r = await loader.loadOne(found[0]);
+		assert.equal(r.load.status, "loaded");
+		assert.deepEqual(r.load.status === "loaded" ? r.load.registeredTypes : null, ["noop-from-plugin"]);
+		assert.equal(reg.has("noop-from-plugin"), true);
+	});
+
+	it("auto-trusts builtin plugins (no approval needed)", async () => {
+		const builtinDir = fs.mkdtempSync(path.join(tmpRoot, "builtin-trusted-"));
+		makeCodePlugin(builtinDir, "ships-with-bobbit", `
+			export default function (api) {
+				api.registerVerifyHandler({ type: "builtin-handler", async execute() { return { passed: true, output: "" }; } });
+			}
+		`);
+		const found = discoverPlugins(paths({ builtin: builtinDir }));
+		const reg = new VerifyHandlerRegistry();
+		const loader = new PluginLoader({
+			registry: reg,
+			trustStore: new PluginTrustStore(trustPath), // no entries — should not matter for builtin
+		});
+		const r = await loader.loadOne(found[0]);
+		assert.equal(r.load.status, "loaded");
+		assert.equal(reg.has("builtin-handler"), true);
+	});
+
+	it("captures activate() throws as load status: error (does not bubble)", async () => {
+		const builtinDir = fs.mkdtempSync(path.join(tmpRoot, "builtin-throws-"));
+		makeCodePlugin(builtinDir, "throws", `
+			export default function activate() { throw new Error("boom"); }
+		`);
+		const found = discoverPlugins(paths({ builtin: builtinDir }));
+		const reg = new VerifyHandlerRegistry();
+		const loader = new PluginLoader({ registry: reg, trustStore: new PluginTrustStore(trustPath) });
+		const r = await loader.loadOne(found[0]);
+		assert.equal(r.load.status, "error");
+		assert.match(r.load.status === "error" ? r.load.error : "", /boom/);
+	});
+
+	it("unload calls deactivate and unregisters the plugin's handlers", async () => {
+		const builtinDir = fs.mkdtempSync(path.join(tmpRoot, "builtin-unload-"));
+		makeCodePlugin(builtinDir, "unloadable", `
+			let calls = 0;
+			export default function (api) {
+				api.registerVerifyHandler({ type: "u-type", async execute() { return { passed: true, output: "" }; } });
+				return { deactivate() { calls++; globalThis.__deactivateCalls = calls; } };
+			}
+		`);
+		const found = discoverPlugins(paths({ builtin: builtinDir }));
+		const reg = new VerifyHandlerRegistry();
+		const loader = new PluginLoader({ registry: reg, trustStore: new PluginTrustStore(trustPath) });
+		const r = await loader.loadOne(found[0]);
+		assert.equal(r.load.status, "loaded", `load failed: ${JSON.stringify(r.load)}`);
+		assert.equal(reg.has("u-type"), true);
+
+		await loader.unload("unloadable");
+		assert.equal(reg.has("u-type"), false);
+		assert.equal((globalThis as any).__deactivateCalls, 1);
+	});
+
+	it("surfaces manifest-invalid as a load status when discovery already flagged errors", async () => {
+		const dir = fs.mkdtempSync(path.join(tmpRoot, "invalid-manifest-"));
+		writePlugin(dir, "bad", { manifest: "name: BAD\nversion: nope\n" });
+		const found = discoverPlugins(paths({ builtin: dir }));
+		const reg = new VerifyHandlerRegistry();
+		const loader = new PluginLoader({ registry: reg, trustStore: new PluginTrustStore(trustPath) });
+		const r = await loader.loadOne(found[0]);
+		assert.equal(r.load.status, "manifest-invalid");
+	});
+
+	it("loadOne is idempotent — repeated calls return the cached LoadedPlugin", async () => {
+		const builtinDir = fs.mkdtempSync(path.join(tmpRoot, "idem-"));
+		makeCodePlugin(builtinDir, "idem", `
+			let n = 0;
+			export default function (api) {
+				n++;
+				api.registerVerifyHandler({ type: \`x-\${n}\`, async execute() { return { passed: true, output: "" }; } });
+			}
+		`);
+		const found = discoverPlugins(paths({ builtin: builtinDir }));
+		const reg = new VerifyHandlerRegistry();
+		const loader = new PluginLoader({ registry: reg, trustStore: new PluginTrustStore(trustPath) });
+		await loader.loadOne(found[0]);
+		await loader.loadOne(found[0]);
+		await loader.loadOne(found[0]);
+		// Only one of the x-N types should exist; activate() must run exactly once.
+		const xTypes = reg.types().filter(t => t.startsWith("x-"));
+		assert.equal(xTypes.length, 1);
+	});
+});

--- a/tests/plugin-manifest.test.ts
+++ b/tests/plugin-manifest.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for plugin manifest parsing & validation.
+ *
+ * Validates the schema gates on plugin.yaml — name/version regex, path
+ * traversal guards on entryPoints and contributes paths, and the
+ * data-only-plugin shape (no entryPoints).
+ */
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import { readManifest, validateManifest, insidePluginRoot } from "../src/server/plugins/plugin-manifest.ts";
+
+let tmpRoot: string;
+
+before(() => {
+	tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "plugin-manifest-test-"));
+});
+
+after(() => {
+	fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function writePlugin(name: string, manifestYaml: string): string {
+	const dir = path.join(tmpRoot, name);
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(path.join(dir, "plugin.yaml"), manifestYaml);
+	return dir;
+}
+
+describe("validateManifest", () => {
+	it("rejects missing name and version", () => {
+		const { errors } = validateManifest({}, "/tmp");
+		const fields = errors.map(e => e.field);
+		assert.ok(fields.includes("name"));
+		assert.ok(fields.includes("version"));
+	});
+
+	it("rejects malformed name (uppercase, leading number)", () => {
+		const r1 = validateManifest({ name: "MyPlugin", version: "1.0.0" }, "/tmp");
+		assert.ok(r1.errors.some(e => e.field === "name"));
+		const r2 = validateManifest({ name: "1foo", version: "1.0.0" }, "/tmp");
+		assert.ok(r2.errors.some(e => e.field === "name"));
+	});
+
+	it("rejects malformed version (non-semver)", () => {
+		const r = validateManifest({ name: "ok", version: "v1" }, "/tmp");
+		assert.ok(r.errors.some(e => e.field === "version"));
+	});
+
+	it("accepts a minimal valid manifest with no entry points", () => {
+		const { manifest, errors } = validateManifest({ name: "autoresearch", version: "0.1.0" }, "/tmp");
+		assert.equal(errors.length, 0);
+		assert.equal(manifest.name, "autoresearch");
+		assert.equal(manifest.entryPoints, undefined);
+	});
+
+	it("rejects entry point paths that escape the plugin root", () => {
+		const { errors } = validateManifest({
+			name: "bad", version: "1.0.0",
+			entryPoints: { gateway: "../../../etc/passwd" },
+		}, "/tmp/plugin-root");
+		assert.ok(errors.some(e => e.field === "entryPoints.gateway" && /escapes/.test(e.message)));
+	});
+
+	it("rejects contributed paths that escape the plugin root", () => {
+		const { errors } = validateManifest({
+			name: "bad", version: "1.0.0",
+			contributes: { workflows: ["../outside.yaml"] },
+		}, "/tmp/plugin-root");
+		assert.ok(errors.some(e => e.field === "contributes.workflows" && /escapes/.test(e.message)));
+	});
+
+	it("rejects malformed contributes arrays", () => {
+		const { errors } = validateManifest({
+			name: "x", version: "1.0.0",
+			contributes: { roles: "not-an-array" as any },
+		}, "/tmp/plugin-root");
+		assert.ok(errors.some(e => e.field === "contributes.roles"));
+	});
+
+	it("rejects verifyStepTypes that isn't an array of strings", () => {
+		const { errors } = validateManifest({
+			name: "x", version: "1.0.0", verifyStepTypes: "external-job" as any,
+		}, "/tmp");
+		assert.ok(errors.some(e => e.field === "verifyStepTypes"));
+	});
+});
+
+describe("readManifest", () => {
+	it("reads and validates a real plugin.yaml from disk", () => {
+		const dir = writePlugin("good", [
+			"name: good-plugin",
+			"version: 1.2.3",
+			"description: A test plugin.",
+			"contributes:",
+			"  workflows: [workflows/main.yaml]",
+		].join("\n"));
+		const { manifest, errors } = readManifest(dir);
+		assert.equal(errors.length, 0);
+		assert.equal(manifest.name, "good-plugin");
+		assert.equal(manifest.version, "1.2.3");
+		assert.deepEqual(manifest.contributes?.workflows, ["workflows/main.yaml"]);
+	});
+
+	it("throws on missing plugin.yaml", () => {
+		const dir = path.join(tmpRoot, "no-manifest");
+		fs.mkdirSync(dir, { recursive: true });
+		assert.throws(() => readManifest(dir));
+	});
+
+	it("throws on non-object YAML", () => {
+		const dir = writePlugin("bad-yaml", "- just an array");
+		assert.throws(() => readManifest(dir), /did not parse as an object/);
+	});
+});
+
+describe("insidePluginRoot", () => {
+	it("accepts paths inside the root", () => {
+		assert.equal(insidePluginRoot("/a/b", "c.txt"), true);
+		assert.equal(insidePluginRoot("/a/b", "sub/c.txt"), true);
+	});
+	it("rejects parent-relative escapes", () => {
+		assert.equal(insidePluginRoot("/a/b", "../c"), false);
+		assert.equal(insidePluginRoot("/a/b", "../../etc/passwd"), false);
+	});
+	it("rejects absolute paths outside the root", () => {
+		assert.equal(insidePluginRoot("/a/b", "/etc/passwd"), false);
+	});
+});

--- a/tests/plugin-project-install.test.ts
+++ b/tests/plugin-project-install.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Unit tests for installing/uninstalling plugins into a project.
+ *
+ * Builds a tmpdir project config, points a synthetic DiscoveredPlugin at
+ * workflow YAMLs in a tmpdir plugin, runs install/uninstall through the
+ * ProjectConfigStore, and verifies:
+ *   - plugin_workflows entries land with namespaced ids
+ *   - re-install replaces the snapshot (idempotent)
+ *   - uninstall drops snapshots
+ *   - manifest errors block install
+ *   - workflow files outside the plugin root are rejected
+ *   - WorkflowStore.getAll() surfaces plugin workflows with namespaced ids and pluginSource set
+ */
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import { ProjectConfigStore } from "../src/server/agent/project-config-store.ts";
+import { InlineWorkflowStore } from "../src/server/agent/workflow-store.ts";
+import { installPluginIntoProject, uninstallPluginFromProject } from "../src/server/plugins/project-install.ts";
+import { readManifest } from "../src/server/plugins/plugin-manifest.ts";
+import type { DiscoveredPlugin } from "../src/server/plugins/plugin-loader.ts";
+
+let tmpRoot: string;
+
+before(() => {
+	tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "plugin-install-test-"));
+});
+
+after(() => {
+	fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function newProject(): { cfg: ProjectConfigStore; configDir: string } {
+	const configDir = fs.mkdtempSync(path.join(tmpRoot, "proj-"));
+	const cfg = new ProjectConfigStore(configDir);
+	return { cfg, configDir };
+}
+
+function makePlugin(opts: {
+	name: string;
+	version?: string;
+	workflows?: { file: string; body: string }[];
+	manifestExtra?: string;
+}): DiscoveredPlugin {
+	const root = fs.mkdtempSync(path.join(tmpRoot, `plug-${opts.name}-`));
+	const workflowPaths: string[] = [];
+	for (const w of opts.workflows ?? []) {
+		const abs = path.join(root, w.file);
+		fs.mkdirSync(path.dirname(abs), { recursive: true });
+		fs.writeFileSync(abs, w.body);
+		workflowPaths.push(w.file);
+	}
+	const manifestYaml = [
+		`name: ${opts.name}`,
+		`version: ${opts.version ?? "1.0.0"}`,
+		workflowPaths.length > 0 ? `contributes:\n  workflows: [${workflowPaths.join(", ")}]` : "",
+		opts.manifestExtra ?? "",
+	].filter(Boolean).join("\n");
+	fs.writeFileSync(path.join(root, "plugin.yaml"), manifestYaml);
+	const { manifest, errors } = readManifest(root);
+	return {
+		name: opts.name,
+		path: path.resolve(root),
+		source: "user",
+		manifest,
+		manifestErrors: errors,
+	};
+}
+
+describe("installPluginIntoProject", () => {
+	it("installs a plugin's workflow as a namespaced plugin_workflows entry", () => {
+		const { cfg } = newProject();
+		const plugin = makePlugin({
+			name: "autoresearch",
+			version: "0.1.0",
+			workflows: [{
+				file: "workflows/main.yaml",
+				body: [
+					"id: feature",
+					"name: Autoresearch feature",
+					"description: Idea → review → experiment",
+					"gates:",
+					"  - id: idea",
+					"    name: Idea",
+					"    content: true",
+				].join("\n"),
+			}],
+		});
+
+		const result = installPluginIntoProject(cfg, plugin);
+		assert.equal(result.ok, true);
+		if (result.ok) {
+			assert.deepEqual(result.workflowsInstalled, ["autoresearch::feature"]);
+		}
+
+		// Persistence check: re-load and confirm both records survive a round-trip.
+		const fresh = new ProjectConfigStore(path.dirname((cfg as any).configFile));
+		assert.equal(fresh.isPluginInstalled("autoresearch"), true);
+		const installed = fresh.getInstalledPlugins();
+		assert.equal(installed.length, 1);
+		assert.equal(installed[0].version, "0.1.0");
+		const wf = fresh.getPluginWorkflows();
+		assert.equal(wf.length, 1);
+		assert.equal(wf[0].source, "autoresearch");
+		assert.equal(wf[0].id, "feature");
+		assert.equal((wf[0].snapshot as any).name, "Autoresearch feature");
+	});
+
+	it("rejects install when the manifest has validation errors", () => {
+		const { cfg } = newProject();
+		// Force a manifest error via a malformed name.
+		const plugin = makePlugin({ name: "ok-name" });
+		plugin.manifestErrors = [{ field: "name", message: "must match ..." }];
+		const result = installPluginIntoProject(cfg, plugin);
+		assert.equal(result.ok, false);
+		assert.match(result.ok === false ? result.error : "", /manifest has errors/);
+		assert.equal(cfg.isPluginInstalled("ok-name"), false);
+	});
+
+	it("rejects workflow paths that escape the plugin root", () => {
+		const { cfg } = newProject();
+		// Hand-build a discovered plugin claiming to ship a workflow outside its root.
+		// We can't write `../escape.yaml` through makePlugin's manifest builder safely,
+		// so we doctor the manifest object directly.
+		const plugin = makePlugin({ name: "evil" });
+		plugin.manifest.contributes = { workflows: ["../escape.yaml"] };
+		const result = installPluginIntoProject(cfg, plugin);
+		assert.equal(result.ok, false);
+		assert.match(result.ok === false ? result.error : "", /escapes plugin root/);
+	});
+
+	it("re-install replaces the prior install record and snapshot", () => {
+		const { cfg } = newProject();
+		const v1 = makePlugin({
+			name: "ar",
+			version: "0.1.0",
+			workflows: [{ file: "w.yaml", body: "id: feature\nname: v1\ngates: []\n" }],
+		});
+		installPluginIntoProject(cfg, v1);
+		assert.equal(cfg.getInstalledPlugins()[0].version, "0.1.0");
+		assert.equal((cfg.getPluginWorkflows()[0].snapshot as any).name, "v1");
+
+		const v2 = makePlugin({
+			name: "ar",
+			version: "0.2.0",
+			workflows: [{ file: "w.yaml", body: "id: feature\nname: v2\ngates: []\n" }],
+		});
+		installPluginIntoProject(cfg, v2);
+		assert.equal(cfg.getInstalledPlugins().length, 1);
+		assert.equal(cfg.getInstalledPlugins()[0].version, "0.2.0");
+		assert.equal((cfg.getPluginWorkflows()[0].snapshot as any).name, "v2");
+	});
+
+	it("rejects a plugin that ships duplicate workflow ids", () => {
+		const { cfg } = newProject();
+		const plugin = makePlugin({
+			name: "dup",
+			workflows: [
+				{ file: "a.yaml", body: "id: same\nname: A\ngates: []\n" },
+				{ file: "b.yaml", body: "id: same\nname: B\ngates: []\n" },
+			],
+		});
+		const result = installPluginIntoProject(cfg, plugin);
+		assert.equal(result.ok, false);
+		assert.match(result.ok === false ? result.error : "", /duplicate workflow id/);
+	});
+
+	it("supports a single YAML file containing a map of id → workflow", () => {
+		const { cfg } = newProject();
+		const plugin = makePlugin({
+			name: "multi",
+			workflows: [{
+				file: "bundle.yaml",
+				body: [
+					"feature:",
+					"  name: Feature",
+					"  gates: []",
+					"bugfix:",
+					"  name: Bugfix",
+					"  gates: []",
+				].join("\n"),
+			}],
+		});
+		const result = installPluginIntoProject(cfg, plugin);
+		assert.equal(result.ok, true);
+		if (result.ok) {
+			assert.deepEqual(result.workflowsInstalled.sort(), ["multi::bugfix", "multi::feature"]);
+		}
+	});
+});
+
+describe("uninstallPluginFromProject", () => {
+	it("removes the install record and snapshots; returns removed=true", () => {
+		const { cfg } = newProject();
+		const plugin = makePlugin({
+			name: "plug",
+			workflows: [{ file: "w.yaml", body: "id: x\nname: X\ngates: []\n" }],
+		});
+		installPluginIntoProject(cfg, plugin);
+		assert.equal(cfg.isPluginInstalled("plug"), true);
+
+		const r = uninstallPluginFromProject(cfg, "plug");
+		assert.deepEqual(r, { ok: true, removed: true });
+		assert.equal(cfg.isPluginInstalled("plug"), false);
+		assert.equal(cfg.getPluginWorkflows().length, 0);
+	});
+
+	it("returns removed=false when nothing was installed under that name", () => {
+		const { cfg } = newProject();
+		const r = uninstallPluginFromProject(cfg, "unknown");
+		assert.deepEqual(r, { ok: true, removed: false });
+	});
+});
+
+describe("WorkflowStore merges plugin_workflows with namespaced ids", () => {
+	it("getAll() returns user workflows + plugin workflows with pluginSource set", () => {
+		const { cfg } = newProject();
+		// User workflow (hand-authored in workflows: block).
+		cfg.setWorkflows({
+			mine: { name: "Mine", description: "", gates: [] } as any,
+		});
+		// Install a plugin workflow.
+		const plugin = makePlugin({
+			name: "ar",
+			version: "0.1.0",
+			workflows: [{ file: "w.yaml", body: "id: feature\nname: Plugin feature\ngates: []\n" }],
+		});
+		installPluginIntoProject(cfg, plugin);
+
+		const wfStore = new InlineWorkflowStore(cfg);
+		const all = wfStore.getAll();
+		const byId = new Map(all.map(w => [w.id, w]));
+		assert.ok(byId.has("mine"));
+		assert.equal(byId.get("mine")?.pluginSource, undefined);
+		assert.ok(byId.has("ar::feature"));
+		assert.equal(byId.get("ar::feature")?.pluginSource?.name, "ar");
+		assert.equal(byId.get("ar::feature")?.pluginSource?.version, "0.1.0");
+		assert.equal(byId.get("ar::feature")?.pluginSource?.originalId, "feature");
+	});
+
+	it("after uninstall, plugin workflows no longer appear in getAll()", () => {
+		const { cfg } = newProject();
+		const plugin = makePlugin({
+			name: "ar",
+			workflows: [{ file: "w.yaml", body: "id: feature\nname: P\ngates: []\n" }],
+		});
+		installPluginIntoProject(cfg, plugin);
+		const wfStore = new InlineWorkflowStore(cfg);
+		assert.equal(wfStore.getAll().some(w => w.id === "ar::feature"), true);
+
+		uninstallPluginFromProject(cfg, "ar");
+		assert.equal(wfStore.getAll().some(w => w.id === "ar::feature"), false);
+	});
+});

--- a/tests/plugin-trust-store.test.ts
+++ b/tests/plugin-trust-store.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for PluginTrustStore.
+ *
+ * Trust is keyed by (absolute path, sha256 of plugin.yaml). Mutating the
+ * manifest invalidates trust — re-prompts the user. We exercise:
+ *   - empty store loads cleanly
+ *   - trust → isTrusted = true; revoke → isTrusted = false
+ *   - hash drift invalidates trust without removing the entry
+ *   - persistence: a fresh store instance reads back trust written by another
+ */
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import { PluginTrustStore, hashManifest } from "../src/server/plugins/plugin-trust-store.ts";
+
+function makePlugin(root: string, name: string, yaml: string): string {
+	const dir = path.join(root, name);
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(path.join(dir, "plugin.yaml"), yaml);
+	return dir;
+}
+
+describe("PluginTrustStore", () => {
+	let tmpRoot: string;
+	let storePath: string;
+
+	beforeEach(() => {
+		tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "plugin-trust-test-"));
+		storePath = path.join(tmpRoot, "trusted-plugins.json");
+	});
+
+	it("isTrusted is false for unknown plugins", () => {
+		const store = new PluginTrustStore(storePath);
+		const plugin = makePlugin(tmpRoot, "p1", "name: p1\nversion: 1.0.0\n");
+		assert.equal(store.isTrusted(plugin), false);
+	});
+
+	it("trust → isTrusted = true with matching hash", () => {
+		const store = new PluginTrustStore(storePath);
+		const plugin = makePlugin(tmpRoot, "p1", "name: p1\nversion: 1.0.0\n");
+		store.trust("p1", plugin);
+		assert.equal(store.isTrusted(plugin), true);
+	});
+
+	it("revoke removes trust idempotently", () => {
+		const store = new PluginTrustStore(storePath);
+		const plugin = makePlugin(tmpRoot, "p1", "name: p1\nversion: 1.0.0\n");
+		store.trust("p1", plugin);
+		assert.equal(store.revoke(plugin), true);
+		assert.equal(store.revoke(plugin), false);   // already gone
+		assert.equal(store.isTrusted(plugin), false);
+	});
+
+	it("hash drift invalidates trust (manifest mutated after approval)", () => {
+		const store = new PluginTrustStore(storePath);
+		const plugin = makePlugin(tmpRoot, "p1", "name: p1\nversion: 1.0.0\n");
+		store.trust("p1", plugin);
+		assert.equal(store.isTrusted(plugin), true);
+
+		// Tamper with the manifest — same path, different bytes.
+		fs.writeFileSync(path.join(plugin, "plugin.yaml"), "name: p1\nversion: 2.0.0\n");
+		assert.equal(store.isTrusted(plugin), false,
+			"trust must invalidate when manifest hash changes — otherwise an attacker who replaces the file keeps the prior approval");
+
+		// The entry is still there (so the UI can show 'needs re-approval').
+		assert.ok(store.getEntry(plugin));
+	});
+
+	it("persists to disk and another instance can read trust back", () => {
+		const plugin = makePlugin(tmpRoot, "p1", "name: p1\nversion: 1.0.0\n");
+		const a = new PluginTrustStore(storePath);
+		a.trust("p1", plugin);
+
+		const b = new PluginTrustStore(storePath);
+		assert.equal(b.isTrusted(plugin), true);
+	});
+
+	it("listTrusted returns all entries with hashes and timestamps", () => {
+		const store = new PluginTrustStore(storePath);
+		const p1 = makePlugin(tmpRoot, "p1", "name: p1\nversion: 1.0.0\n");
+		const p2 = makePlugin(tmpRoot, "p2", "name: p2\nversion: 1.0.0\n");
+		store.trust("p1", p1);
+		store.trust("p2", p2);
+		const list = store.listTrusted();
+		assert.equal(list.length, 2);
+		for (const e of list) {
+			assert.match(e.manifestHash, /^sha256:[0-9a-f]{64}$/);
+			assert.ok(e.trustedAt > 0);
+		}
+	});
+
+	it("recovers from a corrupt trust file by treating it as empty", () => {
+		fs.mkdirSync(path.dirname(storePath), { recursive: true });
+		fs.writeFileSync(storePath, "{not json");
+		const store = new PluginTrustStore(storePath);
+		assert.deepEqual(store.listTrusted(), []);
+	});
+});
+
+describe("hashManifest", () => {
+	it("produces sha256:<64 hex>", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hashm-"));
+		fs.writeFileSync(path.join(dir, "plugin.yaml"), "name: x\nversion: 1.0.0\n");
+		const h = hashManifest(dir);
+		assert.match(h, /^sha256:[0-9a-f]{64}$/);
+	});
+	it("changes when the manifest changes", () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hashm-"));
+		fs.writeFileSync(path.join(dir, "plugin.yaml"), "name: x\nversion: 1.0.0\n");
+		const a = hashManifest(dir);
+		fs.writeFileSync(path.join(dir, "plugin.yaml"), "name: x\nversion: 1.0.1\n");
+		const b = hashManifest(dir);
+		assert.notEqual(a, b);
+	});
+});

--- a/tests/rubric-review-handler.test.ts
+++ b/tests/rubric-review-handler.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Unit tests for the rubric-review verify-step handler.
+ *
+ * Covers:
+ *   - human mode: callback token flow, triple validation, value validation,
+ *     pass_when evaluation
+ *   - llm mode: rubric prompt assembly, JSON extraction, value validation,
+ *     pass_when evaluation
+ *   - the pass_when mini-language (numeric comparisons, string equality, AND/OR)
+ */
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+	rubricReviewHandler,
+	deliverRubricHumanCallback,
+	evaluatePassWhen,
+	_clearPendingRubricForTests,
+} from "../src/server/agent/verify-handlers/rubric-review-handler.ts";
+import type { VerifyExecCtx } from "../src/server/agent/verify-handlers/registry.ts";
+import type { VerifyStep } from "../src/server/agent/workflow-store.ts";
+
+function ctx(overrides: Partial<VerifyExecCtx> = {}): VerifyExecCtx {
+	return {
+		goalId: "g1",
+		gateId: "gate-novelty",
+		signalId: "sig-1",
+		signal: {} as any,
+		gate: {} as any,
+		cwd: "/tmp",
+		branch: "feature",
+		primaryBranch: "master",
+		builtinVars: {},
+		projectVars: {},
+		agentVars: {},
+		substituteVars: (t: string) => t,
+		broadcast: () => {},
+		persistActive: () => {},
+		isCancelled: () => false,
+		...overrides,
+	};
+}
+
+const NOVELTY_RUBRIC = [
+	{ id: "novelty", label: "Novelty", scale: { min: 1, max: 5 } },
+	{ id: "feasibility", label: "Feasibility", options: ["low", "medium", "high"] },
+	{ id: "notes", label: "Notes", kind: "text" as const },
+];
+
+function step(opts: Partial<VerifyStep> = {}): VerifyStep {
+	return {
+		name: "Novelty rubric",
+		type: "rubric-review",
+		reviewer: "human",
+		rubric: NOVELTY_RUBRIC,
+		...opts,
+	};
+}
+
+describe("rubric-review/human", () => {
+	beforeEach(() => _clearPendingRubricForTests());
+
+	it("rejects when no rubric is supplied", async () => {
+		const result = await rubricReviewHandler.execute(ctx(), { name: "x", type: "rubric-review", reviewer: "human", rubric: [] });
+		assert.equal(result.passed, false);
+		assert.match(result.output, /no rubric items/);
+	});
+
+	it("broadcasts a token and accepts a matching callback", async () => {
+		let token: string | undefined;
+		const c = ctx({ broadcast: (ev: any) => { if (ev.token) token = ev.token; } });
+		const promise = rubricReviewHandler.execute(c, step({ pass_when: "novelty >= 3 AND feasibility != 'low'" }));
+		assert.ok(token);
+
+		const outcome = deliverRubricHumanCallback(token, {
+			goalId: "g1", gateId: "gate-novelty", signalId: "sig-1",
+			values: { novelty: 4, feasibility: "high", notes: "promising" },
+			notes: "Solid idea.",
+		});
+		assert.deepEqual(outcome, { ok: true });
+
+		const result = await promise;
+		assert.equal(result.passed, true);
+		assert.match(result.output, /Rubric passed/);
+		assert.equal(result.artifact?.contentType, "text/markdown");
+		assert.equal(result.artifact?.metadata?.novelty, "4");
+		assert.equal(result.artifact?.metadata?.feasibility, "high");
+	});
+
+	it("fails the gate when pass_when evaluates false", async () => {
+		let token: string | undefined;
+		const c = ctx({ broadcast: (ev: any) => { if (ev.token) token = ev.token; } });
+		const promise = rubricReviewHandler.execute(c, step({ pass_when: "novelty >= 3 AND feasibility != 'low'" }));
+		assert.ok(token);
+
+		deliverRubricHumanCallback(token, {
+			goalId: "g1", gateId: "gate-novelty", signalId: "sig-1",
+			values: { novelty: 2, feasibility: "high", notes: "weak" },
+		});
+
+		const result = await promise;
+		assert.equal(result.passed, false);
+		assert.match(result.output, /Rubric failed/);
+	});
+
+	it("rejects callback with invalid scale value", async () => {
+		let token: string | undefined;
+		const c = ctx({ broadcast: (ev: any) => { if (ev.token) token = ev.token; } });
+		const promise = rubricReviewHandler.execute(c, step());
+		assert.ok(token);
+
+		const outcome = deliverRubricHumanCallback(token, {
+			goalId: "g1", gateId: "gate-novelty", signalId: "sig-1",
+			values: { novelty: 99, feasibility: "high", notes: "x" },
+		});
+		assert.equal(outcome.ok, false);
+		assert.equal((outcome as any).status, 400);
+		assert.match((outcome as any).error, /'novelty' must be an integer in/);
+
+		// Allow the pending entry to terminate cleanly.
+		deliverRubricHumanCallback(token, {
+			goalId: "g1", gateId: "gate-novelty", signalId: "sig-1",
+			values: { novelty: 1, feasibility: "high", notes: "x" },
+		});
+		await promise;
+	});
+
+	it("rejects callback when triple does not match", () => {
+		const promise = rubricReviewHandler.execute(ctx(), step());
+		const outcome = deliverRubricHumanCallback("does-not-exist", {
+			goalId: "g1", gateId: "gate-novelty", signalId: "sig-1",
+			values: { novelty: 3, feasibility: "high", notes: "x" },
+		});
+		assert.equal(outcome.ok, false);
+		assert.equal((outcome as any).status, 404);
+		void promise;
+	});
+});
+
+describe("rubric-review/llm", () => {
+	it("requires the harness to provide runLlmReview", async () => {
+		const result = await rubricReviewHandler.execute(
+			ctx(),
+			step({ reviewer: "llm", prompt: "Score it." }),
+		);
+		assert.equal(result.passed, false);
+		assert.match(result.output, /requires harness to expose runLlmReview/);
+	});
+
+	it("parses LLM JSON output, validates against the rubric, and applies pass_when", async () => {
+		const llmOutput = [
+			"# Review",
+			"",
+			"The idea is decent.",
+			"",
+			"```json",
+			"{ \"values\": { \"novelty\": 4, \"feasibility\": \"high\", \"notes\": \"good\" }, \"notes\": \"Strong novelty.\" }",
+			"```",
+		].join("\n");
+
+		const c = ctx({
+			runLlmReview: async () => ({ passed: true, output: llmOutput, sessionId: "sess-1" }),
+		});
+		const result = await rubricReviewHandler.execute(c, step({
+			reviewer: "llm",
+			prompt: "Score the idea.",
+			pass_when: "novelty >= 3",
+		}));
+		assert.equal(result.passed, true);
+		assert.equal(result.sessionId, "sess-1");
+		assert.match(result.artifact?.content ?? "", /Strong novelty/);
+		assert.equal(result.artifact?.metadata?.novelty, "4");
+	});
+
+	it("fails when the LLM emits no JSON block", async () => {
+		const c = ctx({
+			runLlmReview: async () => ({ passed: true, output: "Looks fine to me.", sessionId: "sess-1" }),
+		});
+		const result = await rubricReviewHandler.execute(c, step({
+			reviewer: "llm", prompt: "Score.",
+		}));
+		assert.equal(result.passed, false);
+		assert.match(result.output, /no ```json block found/);
+	});
+
+	it("fails when the LLM emits invalid rubric values", async () => {
+		const c = ctx({
+			runLlmReview: async () => ({
+				passed: true,
+				output: "```json\n{ \"values\": { \"novelty\": 99, \"feasibility\": \"high\", \"notes\": \"x\" } }\n```",
+				sessionId: "sess-1",
+			}),
+		});
+		const result = await rubricReviewHandler.execute(c, step({
+			reviewer: "llm", prompt: "Score.",
+		}));
+		assert.equal(result.passed, false);
+		assert.match(result.output, /invalid rubric values/);
+	});
+
+	it("propagates underlying LLM review failure (timeout, transport, etc.)", async () => {
+		const c = ctx({
+			runLlmReview: async () => ({ passed: false, output: "review timed out", sessionId: "sess-1" }),
+		});
+		const result = await rubricReviewHandler.execute(c, step({
+			reviewer: "llm", prompt: "Score.",
+		}));
+		assert.equal(result.passed, false);
+		assert.equal(result.sessionId, "sess-1");
+	});
+});
+
+describe("evaluatePassWhen", () => {
+	it("numeric ≥ on integers", () => {
+		assert.equal(evaluatePassWhen("novelty >= 3", { novelty: 4 }), true);
+		assert.equal(evaluatePassWhen("novelty >= 3", { novelty: 2 }), false);
+	});
+
+	it("string != with single-quoted literal", () => {
+		assert.equal(evaluatePassWhen("feasibility != 'low'", { feasibility: "high" }), true);
+		assert.equal(evaluatePassWhen("feasibility != 'low'", { feasibility: "low" }), false);
+	});
+
+	it("AND combines clauses", () => {
+		const vals = { novelty: 4, feasibility: "high" };
+		assert.equal(evaluatePassWhen("novelty >= 3 AND feasibility != 'low'", vals), true);
+		assert.equal(evaluatePassWhen("novelty >= 5 AND feasibility != 'low'", vals), false);
+	});
+
+	it("OR combines clauses", () => {
+		const vals = { novelty: 1, feasibility: "high" };
+		assert.equal(evaluatePassWhen("novelty >= 5 OR feasibility = 'high'", vals), true);
+		assert.equal(evaluatePassWhen("novelty >= 5 OR feasibility = 'low'", vals), false);
+	});
+
+	it("missing identifier yields false rather than throwing", () => {
+		assert.equal(evaluatePassWhen("missing >= 1", { other: 5 }), false);
+	});
+});

--- a/tests/tool-call-handler.test.ts
+++ b/tests/tool-call-handler.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for the tool-call verify-step handler.
+ * Tool-call is the thinnest of the three new built-ins: it delegates the
+ * actual session-spawn to the existing llm-review path via ctx.runLlmReview,
+ * so these tests focus on prompt construction and result mapping.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { toolCallHandler } from "../src/server/agent/verify-handlers/tool-call-handler.ts";
+import type { VerifyExecCtx, VerifyStepResult } from "../src/server/agent/verify-handlers/registry.ts";
+import type { VerifyStep } from "../src/server/agent/workflow-store.ts";
+
+function ctx(runLlmReview?: VerifyExecCtx["runLlmReview"]): VerifyExecCtx {
+	return {
+		goalId: "g1",
+		gateId: "gate-lit",
+		signalId: "sig-1",
+		signal: {} as any,
+		gate: {} as any,
+		cwd: "/tmp",
+		branch: "feature",
+		primaryBranch: "master",
+		builtinVars: {},
+		projectVars: {},
+		agentVars: {},
+		substituteVars: (t: string) => t,
+		broadcast: () => {},
+		persistActive: () => {},
+		isCancelled: () => false,
+		runLlmReview,
+	};
+}
+
+describe("tool-call handler", () => {
+	it("fails without `tool`", async () => {
+		const r = await toolCallHandler.execute(ctx(async () => ({ passed: true, output: "" })), {
+			name: "x", type: "tool-call",
+		});
+		assert.equal(r.passed, false);
+		assert.match(r.output, /has no `tool`/);
+	});
+
+	it("fails when runLlmReview is not provided", async () => {
+		const r = await toolCallHandler.execute(ctx(undefined), {
+			name: "x", type: "tool-call", tool: "literature_search",
+		});
+		assert.equal(r.passed, false);
+		assert.match(r.output, /requires harness to expose runLlmReview/);
+	});
+
+	it("constructs a prompt that names the tool, serialises args, and instructs single invocation", async () => {
+		let capturedPrompt = "";
+		const runLlmReview = async (args: { prompt: string }): Promise<VerifyStepResult> => {
+			capturedPrompt = args.prompt;
+			return { passed: true, output: "Tool returned 12 relevant papers.", sessionId: "s1" };
+		};
+		const step: VerifyStep = {
+			name: "Literature coverage", type: "tool-call",
+			tool: "literature_search",
+			args: { query: "diffusion models", min_results: 5 },
+			expect: "success",
+		};
+		const result = await toolCallHandler.execute(ctx(runLlmReview), step);
+
+		assert.equal(result.passed, true);
+		assert.equal(result.sessionId, "s1");
+		assert.match(capturedPrompt, /`literature_search`/);
+		assert.match(capturedPrompt, /diffusion models/);
+		assert.match(capturedPrompt, /min_results/);
+		assert.match(capturedPrompt, /verification_result/);
+		assert.match(capturedPrompt, /exactly once/);
+	});
+
+	it("inverts pass criterion when expect: failure", async () => {
+		let capturedPrompt = "";
+		const runLlmReview = async (args: { prompt: string }) => {
+			capturedPrompt = args.prompt;
+			return { passed: true, output: "Tool threw as expected.", sessionId: "s1" };
+		};
+		await toolCallHandler.execute(ctx(runLlmReview), {
+			name: "x", type: "tool-call", tool: "must_fail", expect: "failure",
+		});
+		assert.match(capturedPrompt, /passes.*when the tool reports a failure/i);
+	});
+
+	it("passes the role through to runLlmReview so the user can pick a role with the tool allowed", async () => {
+		let receivedRole: string | undefined;
+		const runLlmReview = async (args: { prompt: string; role?: string }) => {
+			receivedRole = args.role;
+			return { passed: true, output: "ok" };
+		};
+		await toolCallHandler.execute(ctx(runLlmReview), {
+			name: "x", type: "tool-call", tool: "literature_search", role: "researcher",
+		});
+		assert.equal(receivedRole, "researcher");
+	});
+
+	it("wraps non-empty output as a markdown artifact", async () => {
+		const runLlmReview = async () => ({ passed: true, output: "## Tool output\n\nLooks great.", sessionId: "s1" });
+		const r = await toolCallHandler.execute(ctx(runLlmReview), {
+			name: "x", type: "tool-call", tool: "literature_search",
+		});
+		assert.equal(r.artifact?.contentType, "text/markdown");
+		assert.match(r.artifact?.content ?? "", /Tool output/);
+	});
+
+	it("propagates underlying failure verbatim", async () => {
+		const runLlmReview = async () => ({ passed: false, output: "Reviewer session timed out.", sessionId: "s1" });
+		const r = await toolCallHandler.execute(ctx(runLlmReview), {
+			name: "x", type: "tool-call", tool: "literature_search",
+		});
+		assert.equal(r.passed, false);
+		assert.match(r.output, /timed out/);
+	});
+});

--- a/tests/verify-handler-registry.test.ts
+++ b/tests/verify-handler-registry.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for the VerifyHandlerRegistry — the dispatch substrate that
+ * lets plugins register new verify-step types alongside the built-in
+ * command/llm-review/agent-qa branches.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+	VerifyHandlerRegistry,
+	unknownTypeFailureResult,
+	type VerifyHandler,
+	type VerifyExecCtx,
+} from "../src/server/agent/verify-handlers/registry.ts";
+
+function makeHandler(type: string, passed: boolean, output: string): VerifyHandler {
+	return {
+		type,
+		async execute() {
+			return { passed, output };
+		},
+	};
+}
+
+describe("VerifyHandlerRegistry", () => {
+	it("registers and retrieves a handler by type", () => {
+		const r = new VerifyHandlerRegistry();
+		const h = makeHandler("external-job", true, "ok");
+		r.register(h);
+		assert.equal(r.has("external-job"), true);
+		assert.equal(r.get("external-job"), h);
+	});
+
+	it("returns undefined for unknown types", () => {
+		const r = new VerifyHandlerRegistry();
+		assert.equal(r.has("unknown"), false);
+		assert.equal(r.get("unknown"), undefined);
+	});
+
+	it("re-registering the same type overwrites the prior handler", () => {
+		const r = new VerifyHandlerRegistry();
+		const a = makeHandler("rubric-review", true, "a");
+		const b = makeHandler("rubric-review", false, "b");
+		r.register(a);
+		r.register(b);
+		assert.equal(r.get("rubric-review"), b);
+	});
+
+	it("unregister removes the handler", () => {
+		const r = new VerifyHandlerRegistry();
+		r.register(makeHandler("tool-call", true, "ok"));
+		r.unregister("tool-call");
+		assert.equal(r.has("tool-call"), false);
+	});
+
+	it("types() lists all registered handler types", () => {
+		const r = new VerifyHandlerRegistry();
+		r.register(makeHandler("external-job", true, ""));
+		r.register(makeHandler("rubric-review", true, ""));
+		assert.deepEqual(r.types().sort(), ["external-job", "rubric-review"]);
+	});
+
+	it("handler execute returns a VerifyStepResult", async () => {
+		const r = new VerifyHandlerRegistry();
+		r.register({
+			type: "noop",
+			async execute(_ctx: VerifyExecCtx, _step) {
+				return { passed: true, output: "noop ran", artifact: { content: "x", contentType: "text/markdown" } };
+			},
+		});
+		const h = r.get("noop");
+		assert.ok(h, "handler should be registered");
+		const ctx: VerifyExecCtx = {
+			goalId: "g1",
+			gateId: "gate-1",
+			signalId: "sig-1",
+			signal: {} as any,
+			gate: {} as any,
+			cwd: "/tmp",
+			branch: "x",
+			primaryBranch: "master",
+			builtinVars: {},
+			projectVars: {},
+			agentVars: {},
+			substituteVars: (t: string) => t,
+			broadcast: () => {},
+			persistActive: () => {},
+			isCancelled: () => false,
+		};
+		const out = await h.execute(ctx, { name: "n", type: "noop" } as any);
+		assert.equal(out.passed, true);
+		assert.equal(out.output, "noop ran");
+		assert.equal(out.artifact?.contentType, "text/markdown");
+	});
+});
+
+describe("unknownTypeFailureResult", () => {
+	it("produces a failed result naming the unknown type", () => {
+		const r = unknownTypeFailureResult("my-custom-type");
+		assert.equal(r.passed, false);
+		assert.match(r.output, /my-custom-type/);
+		assert.match(r.output, /No handler registered/);
+	});
+});

--- a/tests/workflow-validator.test.ts
+++ b/tests/workflow-validator.test.ts
@@ -204,13 +204,48 @@ describe("workflow-validator — negative cases", () => {
 		assert.ok(errs.some(e => /optional: true but has no label/.test(e.message)));
 	});
 
-	it("rejects unknown step type", () => {
+	it("soft-accepts unknown step types so plugin-registered handlers can match at runtime", () => {
 		const wf: ValidatorWorkflow = {
 			id: "x", name: "X",
 			gates: [{ id: "g", name: "G", verify: [{ name: "Q", type: "wat" } as any] }],
 		};
 		const errs = validateWorkflow(wf, components);
-		assert.equal(errs.length, 1);
-		assert.match(errs[0].message, /unknown step type "wat"/);
+		assert.equal(errs.length, 0,
+			"Unknown step types must pass validation — the verify-handler registry resolves them at runtime, " +
+			"failing with a clear 'no handler registered' message if no plugin contributes one.");
+	});
+
+	it("accepts the three new built-in types (external-job / rubric-review / tool-call)", () => {
+		const wf: ValidatorWorkflow = {
+			id: "x", name: "X",
+			gates: [{
+				id: "g", name: "G",
+				verify: [
+					{ name: "Job", type: "external-job", timeout: 60 } as any,
+					{ name: "Rubric", type: "rubric-review", reviewer: "llm", prompt: "Score it", rubric: [{ id: "a", label: "A" }] } as any,
+					{ name: "Tool", type: "tool-call", tool: "literature_search" } as any,
+				],
+			}],
+		};
+		const errs = validateWorkflow(wf, components);
+		assert.equal(errs.length, 0, `expected no errors, got: ${errs.map(e => e.message).join("; ")}`);
+	});
+
+	it("rejects rubric-review without reviewer", () => {
+		const wf: ValidatorWorkflow = {
+			id: "x", name: "X",
+			gates: [{ id: "g", name: "G", verify: [{ name: "Q", type: "rubric-review", rubric: [{ id: "a", label: "A" }] } as any] }],
+		};
+		const errs = validateWorkflow(wf, components);
+		assert.ok(errs.some(e => /requires "reviewer"/.test(e.message)));
+	});
+
+	it("rejects tool-call without tool", () => {
+		const wf: ValidatorWorkflow = {
+			id: "x", name: "X",
+			gates: [{ id: "g", name: "G", verify: [{ name: "Q", type: "tool-call" } as any] }],
+		};
+		const errs = validateWorkflow(wf, components);
+		assert.ok(errs.some(e => /requires a non-empty "tool"/.test(e.message)));
 	});
 });


### PR DESCRIPTION
## Summary

Adds a distributable plugin system for bobbit so autoresearch workflows (and any other domain-specific workflow bundles) can be authored, trusted, installed into a project, and run — all using existing bobbit primitives (goals, gates, tasks, context injection). Four self-contained commits; no destructive changes; baseline test failures unchanged.

- **Verify-handler registry + three new built-in step types** — `external-job` (webhook-driven async), `rubric-review` (structured judgement, `reviewer: llm` or `human`), `tool-call` (invoke a registered agent tool as a verify step). Replaces a silent `unknown → llm-review` fallback in the harness dispatch with an explicit "no handler registered" failure.
- **Plugin discovery, manifest validation, trust-based loader** — cascade across `defaults/plugins/` (auto-trusted) → `<server-cwd>/.bobbit/plugins/` → `~/.bobbit/plugins/`; trust keyed by `(absolute path, sha256(plugin.yaml))` so manifest mutation re-prompts; lazy `import()` with caught throws.
- **Plugin REST API** — `GET /api/plugins`, `GET /api/plugins/:name`, `POST/DELETE /api/plugins/:name/trust`. Trust changes auto-unload + reload.
- **Per-project install lifecycle + Settings UI** — `POST /api/projects/:id/plugins/:name/install` copies plugin workflows into `project.yaml::plugin_workflows` as frozen snapshots under namespaced ids (`<plugin>::<id>`); `WorkflowStore.getAll()` merges user + plugin workflows. New "Plugins" tab in system- and project-scope Settings with Trust / Revoke / Install / Uninstall buttons.

Stats: 27 files changed, +3,526 lines, 82 new unit tests, `npm run check` clean.

The three "custom gate" patterns that prompted this work (long-running external signals, human/LLM rubric judgement, tool-as-verifier) all work today; restart-resume for `external-job`/`rubric-human` is intentionally deferred until the Phase 2 harness refactor extracts `tryResume` onto handlers.

## Test plan

- [ ] `npm run check` clean (passes locally)
- [ ] `npm run test:unit` — 82 new tests pass; baseline failures (preview routes, browser_screenshot, ProjectRegistry, UI bundle size, resolveAssetPath) unchanged
- [ ] Smoke: drop a minimal plugin under `~/.bobbit/plugins/test/` with a `plugin.yaml` (`name`, `version`) and confirm it appears in Settings → Plugins as `needs-approval`; click Trust; if it ships a gateway entry, confirm any verify handlers it registered show up in the harness's registry
- [ ] Smoke: install a plugin shipping a workflow YAML into a project; confirm the workflow appears in the goal-creation dropdown under `<plugin>::<id>`; create a goal against it; uninstall — workflow disappears from dropdown but any in-flight goal keeps its snapshot
- [ ] Smoke: signal a gate with an `external-job` step; `POST /api/verify/external/:token` with matching `goalId/gateId/signalId` triple; gate transitions to passed
- [ ] Smoke: signal a gate with a `rubric-review`/`llm` step; LLM emits JSON matching the rubric schema; `pass_when` evaluates and verdict is recorded with rubric values on `GateSignalStep.artifact.metadata`

🤖 Generated with [Claude Code](https://claude.com/claude-code)