### PR TITLE
Fix preflight when directory picked via browser

### DIFF
--- a/docs/add-project-preflight.md
+++ b/docs/add-project-preflight.md
@@ -23,9 +23,11 @@ with structured `pass | warn | fail` checks the user can read and act on.
 
 ## End-user guide
 
-When you open Add Project and type a path, the dialog runs a pre-flight pass
-(debounced) and renders a list of checks below the input. Each check has one
-of three levels:
+When you open Add Project and supply a path — either by typing it into the
+input or picking one via the directory browser — the dialog runs a pre-flight
+pass and renders a list of checks below the input. Typing is debounced
+(400 ms); picking via the directory browser triggers the check immediately.
+Each check has one of three levels:
 
 | Level | Submit | Meaning |
 |-------|--------|---------|

--- a/docs/design/robust-add-project.md
+++ b/docs/design/robust-add-project.md
@@ -219,7 +219,7 @@ Partial archive failure is surfaced explicitly — we do NOT attempt rollback (t
 
 ## UI changes (`src/app/dialogs.ts`)
 
-The add-project dialog gains a `PreflightPanel` between the path input and the Submit button. Debounce 400 ms (matching existing `runDetection`). Layout:
+The add-project dialog gains a `PreflightPanel` between the path input and the Submit button. Preflight is debounced 400 ms when the user is typing (matching existing `runDetection`); other write sites to `pathValue` trigger preflight immediately (see Implementation notes). Layout:
 
 ```
 ┌── Add project ──────────────────────────────────┐
@@ -243,6 +243,18 @@ The add-project dialog gains a `PreflightPanel` between the path input and the S
   - "Will be preserved" list (only non-empty when `bobbit.gateway-owned` is true) with an explanatory note.
 - After archive, the preflight panel re-fetches. `bobbit.existing` should now report `pass`.
 - The existing `SymlinkRootError` confirm modal is kept as-is and triggered by the registration call path. The `path.symlink` preflight row is informational — clicking its remediation can open the confirm modal pre-emptively, but we don't reshape the established acceptCanonical flow.
+
+### Implementation notes: preflight trigger sites
+
+Preflight is **not** a reactive effect on `pathValue`. It is triggered explicitly from every code path that writes `pathValue`. As of this writing there are three such sites in `src/app/dialogs.ts`:
+
+1. **Text input `onInput`** — calls `debouncedDetect(pathValue)`, which fans out to both `runDetection` and `runPreflight` after the 400 ms debounce.
+2. **Directory browser `selectBrowsed()`** — the user has explicitly confirmed a directory pick, so preflight runs immediately (no debounce) alongside `runDetection`.
+3. **Defensive mount-time guard** — if the dialog opens with a prefilled `pathValue`, `runDetection` and `runPreflight` are kicked off on mount behind a `pathValue.trim()` guard.
+
+**Invariant**: any new code path that mutates `pathValue` must also trigger preflight, or the panel will silently stay empty. The original PR shipped with site (2) missing — `selectBrowsed()` set `pathValue` but called only `runDetection`, so users who picked a directory via the in-dialog browser never saw a preflight report. Reframing this as a reactive effect on `pathValue` changes would eliminate the foot-gun but is intentionally out of scope; the surgical fix preserves the explicit-trigger pattern.
+
+The 404 fallback (`preflightUnavailable = true`, silently hide the panel) is preserved for older gateways but logs a single `console.warn("[preflight] endpoint unavailable — hiding panel")` so dev/QA can distinguish "no panel because endpoint is missing" from "no panel because of a trigger-site regression".
 
 ## Server wiring
 

--- a/src/app/dialogs.ts
+++ b/src/app/dialogs.ts
@@ -1520,6 +1520,8 @@ export function showProjectDialog(): void {
 			if (token !== preflightToken) return; // stale
 			if (res.status === 404) {
 				// Older gateway without preflight — silently skip.
+				// Guarded by the `if (preflightUnavailable) return` above, so this warns at most once.
+				console.warn("[preflight] endpoint unavailable — hiding panel");
 				preflightUnavailable = true;
 				preflightReport = null;
 				preflightLoading = false;
@@ -1745,6 +1747,7 @@ export function showProjectDialog(): void {
 		browsing = false;
 		renderDialog();
 		runDetection(pathValue);
+		runPreflight(pathValue);
 	};
 
 	const renderDialog = () => {
@@ -1928,6 +1931,7 @@ export function showProjectDialog(): void {
 		});
 	};
 
+	if (pathValue.trim()) { runDetection(pathValue); runPreflight(pathValue); }
 	renderDialog();
 }
 

--- a/tests/e2e/ui/add-project-preflight-directory-picker.spec.ts
+++ b/tests/e2e/ui/add-project-preflight-directory-picker.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * Add Project — directory-picker → preflight panel (browser E2E).
+ *
+ * Reproducing test for the bug analysed in the "Issue Analysis" gate:
+ * when the user picks a directory via the in-dialog directory browser
+ * (Browse → Select), the preflight panel does not appear because
+ * `selectBrowsed()` in `src/app/dialogs.ts` calls only `runDetection`
+ * and skips `runPreflight`. Typing into the text input works (it goes
+ * through `debouncedDetect`, which fans out to both), but the
+ * directory-browser confirm path is the bug.
+ *
+ * Acceptance: this spec MUST fail on master @ c4e732da (timeout waiting
+ * for the preflight panel to become visible after Select), and pass
+ * after `selectBrowsed()` is fixed to also call `runPreflight(pathValue)`.
+ *
+ * Pattern mirrored from:
+ *   - tests/e2e/ui/add-project-preflight.spec.ts (panel assertions, skip-on-404)
+ *   - tests/e2e/ui/add-project-flow.spec.ts      (Browse → Select interactions)
+ */
+import { test, expect } from "../gateway-harness.js";
+import { apiFetch } from "../e2e-setup.js";
+import { openApp } from "./ui-helpers.js";
+import { tmpdir } from "node:os";
+
+async function preflightAvailable(): Promise<boolean> {
+	try {
+		const res = await apiFetch("/api/projects/preflight?path=" + encodeURIComponent(tmpdir()));
+		return res.status !== 404;
+	} catch {
+		return false;
+	}
+}
+
+test.describe("Add Project — preflight panel via directory picker", () => {
+	test.afterEach(async () => {
+		const res = await apiFetch("/api/projects");
+		const data = await res.json();
+		const projects = data.projects || data || [];
+		for (const p of projects) {
+			if (p.name === "default") continue;
+			await apiFetch(`/api/projects/${p.id}?force=1`, { method: "DELETE" }).catch(() => {});
+		}
+	});
+
+	test("Browse → Select triggers preflight panel (does not require typing the path)", async ({ page }, testInfo) => {
+		if (!(await preflightAvailable())) testInfo.skip(true, "preflight endpoint unavailable");
+
+		await openApp(page);
+
+		// Open the Add Project dialog.
+		await page.locator("button").filter({ hasText: "Add Project" }).first().click();
+		const pathInput = page.locator('input[placeholder="/path/to/project"]');
+		await expect(pathInput).toBeVisible({ timeout: 5_000 });
+
+		// Sanity: preflight panel is NOT visible yet (nothing typed, nothing picked).
+		await expect(page.locator('[data-testid="preflight-panel"]')).toHaveCount(0);
+
+		// Open the directory browser WITHOUT typing into the text input.
+		// (Typing would trigger preflight via debouncedDetect and hide the bug.)
+		await page.locator("button").filter({ hasText: "Browse" }).first().click();
+		await expect(page.locator('[data-testid="directory-browser"]')).toBeVisible({ timeout: 5_000 });
+
+		// Pick the current directory (whatever default the browser opened in).
+		const selectBtn = page.locator("button").filter({ hasText: "Select" }).first();
+		await expect(selectBtn).toBeEnabled({ timeout: 5_000 });
+		await selectBtn.click();
+
+		// Browser closes, text input is repopulated with the chosen path.
+		await expect(page.locator('[data-testid="directory-browser"]')).not.toBeVisible({ timeout: 5_000 });
+		const chosen = await pathInput.inputValue();
+		expect(chosen.length).toBeGreaterThan(0);
+
+		// THE BUG: on master, selectBrowsed() does not invoke runPreflight,
+		// so the panel never appears. This assertion is the reproducing
+		// signal — it must fail on master and pass after the fix.
+		const panel = page.locator('[data-testid="preflight-panel"]');
+		await expect(panel).toBeVisible({ timeout: 8_000 });
+
+		// And the panel should populate with at least one check row.
+		await expect.poll(
+			() => page.locator('[data-testid="preflight-check"]').count(),
+			{ timeout: 8_000 },
+		).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
Fix-up for the merged "Robust add-project validation" work (PR #550).

## The bug
After PR #550, the preflight panel did not appear when the user picked a directory via the in-dialog directory browser — only when they typed a path. `selectBrowsed()` in \`src/app/dialogs.ts\` mutated \`pathValue\` and called \`runDetection()\` but not \`runPreflight()\`, so the panel rendered nothing and \`hasFail\` was always false (Submit not blocked).

A silent 404-hide path in \`runPreflight\` masked this during QA: real regressions and "older gateway" both produced identical (empty) UI.

## Fix (4 lines in \`src/app/dialogs.ts\`)
1. \`selectBrowsed()\` now calls \`runPreflight(pathValue)\` immediately after \`runDetection(pathValue)\` (no debounce — deliberate user gesture).
2. Defensive mount-time guard: \`if (pathValue.trim()) { runDetection(pathValue); runPreflight(pathValue); }\` before the first \`renderDialog()\`. No-op today, future-proofing.
3. The 404 silent-hide branch now logs a single \`console.warn("[preflight] endpoint unavailable — hiding panel")\` so dev/QA can distinguish missing-endpoint from trigger-site regressions. Silent UI behaviour preserved.

## Tests
New browser E2E \`tests/e2e/ui/add-project-preflight-directory-picker.spec.ts\` covers the Browse → Select → preflight-panel flow. Verified to fail on \`c4e732da\` (master before fix) and pass after.

\`npm run check\`, \`npm run test:unit\`, \`npm run test:e2e\` all pass.

## Docs
- \`docs/design/robust-add-project.md\` — new "Implementation notes: preflight trigger sites" subsection enumerating the three \`pathValue\` write sites and stating the invariant that any future write site must trigger preflight.
- \`docs/add-project-preflight.md\` — end-user guide updated to mention the directory-picker trigger path.

## Out of scope
Re-architecting preflight as a reactive effect on \`pathValue\` changes (cleaner but larger; the surgical fix preserves the explicit-trigger pattern).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)