### PR TITLE
Fix per-project 'None (use global)' palette card

### DIFF
--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -37,6 +37,7 @@ import { getRouteFromHash, setHashRoute, toggleConfigPage, type SettingsTabId } 
 import { renderWorkflowPage, loadWorkflowPageData } from "./workflow-page.js";
 import { setConfigScope, getConfigScope } from "./config-scope.js";
 import { gatewayFetch, fetchSandboxStatus, removeProject, fetchProjects, searchStats, searchRebuild, orphanedIndexRows, cleanupOrphanedIndexRows, type SearchStats, type OrphanedIndexRows } from "./api.js";
+import { applyProjectPalette } from "./session-manager.js";
 import { dispatchIndexEvent } from "./components/search-status-dot.js";
 import "./components/search-status-dot.js";
 import { openOAuthDialog } from "./dialogs.js";
@@ -3091,7 +3092,8 @@ function renderAppearanceTab(projectId: string) {
 			if (res.ok) {
 				const updated = await res.json();
 				const idx = state.projects.findIndex((p: any) => p.id === projectId);
-				if (idx >= 0) state.projects[idx] = { ...state.projects[idx], ...updated };
+				if (idx >= 0) state.projects[idx] = updated;
+				applyProjectPalette(projectId);
 				renderApp();
 			}
 		} catch { /* ignore */ }
@@ -3106,7 +3108,8 @@ function renderAppearanceTab(projectId: string) {
 			if (res.ok) {
 				const updated = await res.json();
 				const idx = state.projects.findIndex((p: any) => p.id === projectId);
-				if (idx >= 0) state.projects[idx] = { ...state.projects[idx], ...updated };
+				if (idx >= 0) state.projects[idx] = updated;
+				applyProjectPalette(projectId);
 				renderApp();
 			}
 		} catch { /* ignore */ }

--- a/tests/e2e/ui/project-palette-none.spec.ts
+++ b/tests/e2e/ui/project-palette-none.spec.ts
@@ -1,0 +1,182 @@
+/**
+ * Reproducing test: per-project "None (use global)" palette card has no effect.
+ *
+ * Bug:
+ *   In Settings → <project> → Appearance, clicking the "None (use global)" card
+ *   after a named palette is already selected does NOT clear the override:
+ *     - the previously-selected card stays Active,
+ *     - the "None" card never gains the Active indicator,
+ *     - `<html data-palette>` does not revert to the global default.
+ *
+ * Root cause is documented in the Issue Analysis gate for goal
+ * "Fix project None palette" — a client-side state-merge bug in
+ * settings-page.ts::savePaletteAndColors() plus a missing
+ * applyProjectPalette() call after the PUT.
+ *
+ * This test MUST FAIL on master and pass once the fix lands. Do not touch
+ * production code from this commit.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { test, expect } from "../gateway-harness.js";
+import { apiFetch } from "../e2e-setup.js";
+import { openApp, navigateToHash } from "./ui-helpers.js";
+
+test.describe('Per-project palette "None (use global)" card', () => {
+	let projectId: string | undefined;
+	let projectDir: string | undefined;
+
+	test.afterEach(async () => {
+		if (projectId) {
+			await apiFetch(`/api/projects/${projectId}`, { method: "DELETE" }).catch(() => {});
+		}
+		if (projectDir) {
+			try { rmSync(projectDir, { recursive: true, force: true }); } catch { /* Windows EPERM */ }
+		}
+		projectId = undefined;
+		projectDir = undefined;
+	});
+
+	test("clicking None clears the per-project palette override", async ({ page }) => {
+		projectDir = mkdtempSync(join(tmpdir(), "bobbit-palette-none-"));
+
+		// Create a project with no palette override.
+		const createResp = await apiFetch("/api/projects", {
+			method: "POST",
+			body: JSON.stringify({ name: "palette-none-test", rootPath: projectDir }),
+		});
+		expect(createResp.status).toBe(201);
+		const project = await createResp.json();
+		projectId = project.id;
+
+		await openApp(page);
+
+		// Snapshot the *global* palette so we know what to revert to.
+		// Settings page (no session active) reflects the user's global palette.
+		const globalPalette = await page.evaluate(
+			() => document.documentElement.dataset.palette || "",
+		);
+
+		await navigateToHash(page, `#/settings/${projectId}/appearance`);
+
+		// Appearance tab content should load — wait for the "Color Palette" heading
+		// inside the per-project appearance pane.
+		await expect(
+			page.locator("h3").filter({ hasText: "Color Palette" }),
+		).toBeVisible({ timeout: 10_000 });
+
+		// Locate the named palette cards by their title attribute, and the
+		// "None (use global)" card by its label text.
+		const oceanBtn = page.locator('button[title="Select Ocean palette"]');
+		const noneBtn = page.locator("button").filter({ hasText: "None (use global)" });
+
+		await expect(oceanBtn).toBeVisible({ timeout: 5_000 });
+		await expect(noneBtn).toBeVisible({ timeout: 5_000 });
+
+		// Initially "None" is active (project has no palette override).
+		await expect(noneBtn.locator("text=Active")).toBeVisible({ timeout: 5_000 });
+		await expect(oceanBtn.locator("text=Active")).toHaveCount(0);
+
+		// --- Step 1: click "Ocean". Expect Active indicator + data-palette === "ocean".
+		let putResponse = page.waitForResponse(
+			(resp) =>
+				resp.url().includes(`/api/projects/${projectId}`) &&
+				resp.request().method() === "PUT" &&
+				resp.status() === 200,
+		);
+		await oceanBtn.click();
+		await putResponse;
+
+		await expect(
+			oceanBtn.locator("text=Active"),
+			'expected the "Ocean" palette card to show Active after clicking it',
+		).toBeVisible({ timeout: 5_000 });
+		await expect(
+			noneBtn.locator("text=Active"),
+			'expected the "None (use global)" card to NOT show Active after picking Ocean',
+		).toHaveCount(0);
+
+		await expect
+			.poll(
+				() => page.evaluate(() => document.documentElement.dataset.palette ?? null),
+				{
+					message:
+						'expected <html data-palette> to be "ocean" after clicking the Ocean palette card',
+					timeout: 5_000,
+				},
+			)
+			.toBe("ocean");
+
+		// --- Step 2: click "None (use global)". Reproduces the bug.
+		putResponse = page.waitForResponse(
+			(resp) =>
+				resp.url().includes(`/api/projects/${projectId}`) &&
+				resp.request().method() === "PUT" &&
+				resp.status() === 200,
+		);
+		await noneBtn.click();
+		await putResponse;
+
+		// Bug repro: previously the "Ocean" card stayed Active and "None" never lit
+		// up. After the fix, "None" gains Active and "Ocean" loses it.
+		await expect(
+			noneBtn.locator("text=Active"),
+			'expected the "None (use global)" card to show Active after clicking it',
+		).toBeVisible({ timeout: 5_000 });
+		await expect(
+			oceanBtn.locator("text=Active"),
+			'expected the "Ocean" card to no longer show Active after clicking None',
+		).toHaveCount(0);
+
+		// `<html data-palette>` should revert to the global default. When the
+		// global palette is "forest" the attribute is removed entirely; otherwise
+		// it equals the global palette value.
+		await expect
+			.poll(
+				() => page.evaluate(() => document.documentElement.dataset.palette ?? ""),
+				{
+					message:
+						"expected <html data-palette> to revert to the global default after clicking None (attribute cleared when global is forest, else equal to global)",
+					timeout: 5_000,
+				},
+			)
+			.toBe(globalPalette);
+
+		// Server should report the project with no palette override.
+		const after = await (await apiFetch(`/api/projects/${projectId}`)).json();
+		expect(
+			after.palette === undefined || after.palette === null || after.palette === "",
+			`expected GET /api/projects/${projectId} to return no palette field after clearing override, got ${JSON.stringify(after.palette)}`,
+		).toBe(true);
+
+		// --- Step 3: reload — "None" should still be Active and DOM still global.
+		await page.reload();
+		await expect(
+			page.locator("button").filter({ hasText: "Settings" }).first(),
+		).toBeVisible({ timeout: 20_000 });
+		await navigateToHash(page, `#/settings/${projectId}/appearance`);
+		await expect(
+			page.locator("h3").filter({ hasText: "Color Palette" }),
+		).toBeVisible({ timeout: 10_000 });
+
+		const noneBtnAfter = page.locator("button").filter({ hasText: "None (use global)" });
+		const oceanBtnAfter = page.locator('button[title="Select Ocean palette"]');
+		await expect(
+			noneBtnAfter.locator("text=Active"),
+			'expected the "None (use global)" card to still be Active after reload',
+		).toBeVisible({ timeout: 5_000 });
+		await expect(oceanBtnAfter.locator("text=Active")).toHaveCount(0);
+
+		await expect
+			.poll(
+				() => page.evaluate(() => document.documentElement.dataset.palette ?? ""),
+				{
+					message:
+						"expected <html data-palette> to still reflect the global default after reload",
+					timeout: 5_000,
+				},
+			)
+			.toBe(globalPalette);
+	});
+});


### PR DESCRIPTION
## Summary
Fixes a client-side state-merge bug where clicking the **"None (use global)"** palette card in per-project Settings → Appearance had no effect. The card never highlighted, the previously-selected palette stayed active, and the DOM palette didn't revert.

## Root cause
`savePaletteAndColors()` / `saveColor()` in `src/app/settings-page.ts` merged the server's PUT response over the local snapshot using object spread:

```ts
state.projects[idx] = { ...state.projects[idx], ...updated };
```

The server clears the project's palette by setting it to `undefined`. `JSON.stringify` omits keys whose value is `undefined`, so the response body had no `palette` field. Object spread only overwrites keys present in the source — the stale `palette: "ocean"` from the local snapshot survived.

## Fix
- Replace the merge with direct assignment: `state.projects[idx] = updated`. The server returns the full canonical `RegisteredProject`, so absent keys correctly mean "cleared".
- After updating local state, call `applyProjectPalette(projectId)` so `<html data-palette>` reflects the change immediately without navigation.

## Tests
- New regression test: `tests/e2e/ui/project-palette-none.spec.ts` — clicks a named palette, then clicks "None", verifies the Active indicator switches, `<html data-palette>` reverts to the global default, the server reports the project with `palette` cleared, and the state persists across reload. Fails on master, passes after the fix.

## Workflow gates
All workflow gates passed: `issue-analysis` → `reproducing-test` → `implementation` → `documentation`.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
