### PR TITLE
Unstick verification lock on restart

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -545,7 +545,15 @@ See [docs/internals.md — Skill chip rendering & autonomous activation](interna
 - Check `sessionManager` and `teamManager` passed to `VerificationHarness`
 - Inspect: `GET /api/goals/:goalId/verifications/active`
 - **Stuck verification?** Cancel manually via `POST /api/goals/:goalId/gates/:gateId/cancel-verification` (returns `{ cancelled: true }` or `{ cancelled: false }` if nothing was running). The goal dashboard also shows a Cancel button when a verification is in "running" state.
-- **Zombie detection**: On re-signal, the server checks `areVerificationSessionsAlive()` before returning 409. If all reviewer sessions are dead, the stale verification is auto-cancelled and the new signal proceeds. Command steps (no `sessionId`) and waiting steps are treated as alive.
+- **Zombie detection**: On re-signal, the server checks `areVerificationSessionsAlive()` before returning 409. Reviewer/agent steps are alive iff `sessionManager.getSession(step.sessionId)` resolves; command steps are alive iff `step.bootEpoch === harness.bootEpoch && isPidAlive(step.pid)` — a persisted `status: "running"` from a previous gateway lifetime never satisfies this and so cannot lock the gate.
+
+## HTTP 409 `Verification already in progress` after gateway restart
+
+- **Symptom**: after a gateway restart that killed an in-flight command-type verification, `POST /api/goals/:id/gates/:gateId/signal` on the same commit returns `409 { error: "Verification already in progress for this commit", existingSignalId: ... }` even though nothing is actually running. Pre-fix the only unstick was pushing an empty commit to change the SHA.
+- **Cause**: `areVerificationSessionsAlive` treated any persisted `status === "running"` command step (no `sessionId`) as proof of liveness. Persisted state survives restart; the spawned `npm run test:e2e` child does not. The in-memory map and the on-disk gate status drifted (gate looked failed, lock looked running).
+- **Fix**: command-step liveness now requires `step.bootEpoch === this.bootEpoch && isPidAlive(step.pid)`; `bootEpoch` is a per-`VerificationHarness`-instance UUID, so post-restart it can never match. `resumeInterruptedVerifications()` also synchronously deletes failed-on-resume entries from `activeVerifications` and rewrites `active-verifications.json` in a `finally`, so the duplicate-detection check has nothing to false-positive on. See [docs/verification-restart.md](verification-restart.md) for the full design.
+- **If it recurs**: grep server stdout for `[api] Rejecting gate_signal as duplicate` — that log line now dumps `signalId` + per-step `{ name, status, pid, bootEpoch, sessionId }` so you can tell at a glance whether a step is genuinely alive (matching bootEpoch + live pid) or a zombie. A zombie with the current `bootEpoch` means we kept the entry across an explicit `cancelStaleVerifications` — investigate that path. A zombie with a stale `bootEpoch` means the resume cleanup didn't run — check for exceptions during boot in `resumeInterruptedVerifications`.
+- **Pinning tests**: `tests/verification-harness-restart.test.ts` (zombie alive-check, pid-reuse safeguard, resume-removes-from-disk-and-memory); `tests/e2e/verification-restart-resignal.spec.ts` (full HTTP round-trip — seed a zombie, resume, re-signal, assert 200).
 
 ## Phased verification
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -200,6 +200,10 @@ The live llm-review path is not actually affected by the bug (the kickoff prompt
 
 Key files: `src/server/agent/session-manager.ts` (`waitForStreaming`), `src/server/agent/verification-harness.ts`. Tests: `tests/verification-reminder-race.test.ts` (unit), `tests/e2e/gate-verification-resume.spec.ts` (API E2E that drives a full restart cycle).
 
+#### Command-step restart survival
+
+Command-type steps (`npm run test:e2e`, type-check, etc.) survive a gateway restart via a detached-spawn + atomic exit-file scheme, with a `bootEpoch`-based correctness floor so a step from a previous gateway lifetime can never falsely lock the gate behind HTTP 409 `Verification already in progress`. Full design and the symbol-level map are in [docs/verification-restart.md](verification-restart.md); symptom→fix lookup in [debugging.md — HTTP 409 after gateway restart](debugging.md#http-409-verification-already-in-progress-after-gateway-restart). Pinned by `tests/verification-harness-restart.test.ts` and `tests/e2e/verification-restart-resignal.spec.ts`.
+
 ### Config resolution (3-tier hierarchy)
 
 `ConfigResolver` (`config-resolver.ts`) provides hierarchical config resolution across three tiers:

--- a/docs/verification-restart.md
+++ b/docs/verification-restart.md
@@ -1,0 +1,190 @@
+# Verification command steps survive a gateway restart
+
+When a gateway restart killed an in-flight gate verification, two cooperating
+bugs left the gate locked behind HTTP 409 `Verification already in progress
+for this commit` on every subsequent `gate_signal` for that SHA. The only
+workaround was pushing an empty commit to change the SHA — which (a) loses
+the right to retry a true environmental flake on the same SHA and (b)
+accumulates noise commits on the goal branch.
+
+This document explains the two-layer fix: command subprocesses now survive
+the parent gateway dying (Layer 1), and even when they don't, the
+duplicate-detection path correctly recognises a dead step from a previous
+server lifetime (Layer 2).
+
+See also [debugging.md — HTTP 409 after gateway restart](debugging.md#http-409-verification-already-in-progress-after-gateway-restart)
+for the symptom→fix lookup, and [internals.md — Verification architecture](internals.md#verification-architecture)
+for the broader verification context.
+
+## The original bugs
+
+Both lived in `src/server/agent/verification-harness.ts`.
+
+1. **`areVerificationSessionsAlive(signalId)`** treated command-only steps as
+   alive whenever their persisted `status === "running"` and `sessionId` was
+   absent. That assumption holds during a single server lifetime but not
+   across a restart: the persisted "running" flag survives in
+   `.bobbit/state/active-verifications.json` after the spawned child is long
+   dead. The zombie auto-cancel path in `server.ts` deferred to this method
+   and so never fired.
+
+2. **`resumeInterruptedVerifications()`** marked the gate signal as failed
+   on resume error but did not remove the entry from the in-memory
+   `activeVerifications` map. The gate-status endpoint read "failed"
+   (correct) while the duplicate-detection check read "running" (wrong) —
+   the two views drifted, and the gate was locked until the SHA changed.
+
+## Two-layer design
+
+### Layer 1 — command subprocesses outlive the gateway
+
+The cleanest fix is not to lose the running child at all. Command steps are
+now spawned `detached: true` with stdout/stderr redirected to files under
+`<stateDir>/verifications/<signalId>/<stepIndex>.{out,err}`. A small bash
+wrapper around the real command writes the exit code to
+`<stepIndex>.exit` via an atomic rename:
+
+```
+( <user command>
+); __ec=$?; printf %s "$__ec" > <stepIndex>.exit.tmp \
+   && mv <stepIndex>.exit.tmp <stepIndex>.exit; exit $__ec
+```
+
+Because the wrapper — not the gateway — owns the exit-file write, even
+SIGKILL of the gateway leaves the disk in one of two consistent states:
+either no exit file (child still running) or a complete exit file (child
+finished). There is no partial state to interpret.
+
+`runCommandStep` stamps the persisted `ActiveVerification.step` with `pid`,
+`startTimeMs`, `outFile`, `errFile`, `exitFile`, `bootEpoch`, `timeoutSec`,
+`expectFailure`, and `errorPattern` **before** the gateway has a chance to
+crash, then calls `child.unref()` so the surviving child does not keep the
+old gateway alive during a graceful shutdown.
+
+On boot, `_resumeCommandStep` handles three cases:
+
+- **(A) Exit file present** — the wrapper finished before we got back. Read
+  the recorded exit code plus the stdout/stderr tails and finalize via the
+  same `matchExpectFailure` / pass-fail logic the live path uses. No
+  difference in outcome from a non-interrupted run.
+- **(B) `pid` still alive and not stale** — the detached child outlived the
+  gateway. Re-attach a file tailer for live broadcast and poll for the exit
+  file until the remaining timeout budget (computed from `startedAt`) is
+  exhausted. If the deadline passes without an exit file, kill the child
+  and finalize as failed.
+- **(C) Process dead, no exit file** — the child was killed by something
+  other than the gateway (OOM, manual kill, antivirus). Finalize as failed.
+
+Live broadcast during resume uses `_startFileTailers`, which polls the out
+and err files at 200 ms and emits `gate_verification_step_output` events
+with the same shape the live-spawn path produces. UI clients that
+re-connect after the restart see the full output written so far; clients
+that were mid-stream across the restart may miss live tail between the
+last poll before the restart and resume re-attaching (the file content is
+captured in full either way).
+
+Reviewer/agent-QA steps already persisted via session state and resume via
+`_tryResumeFromSession`; nothing in Layer 1 changes that path.
+
+### Layer 2 — correctness floor if the child also dies
+
+Layer 1 covers the common case. It does not cover OS-level kills of the
+child (OOM, manual `taskkill`, antivirus quarantine) — in those cases the
+gate would still lock. Layer 2 ensures the duplicate-detection path
+correctly classifies any dead step as not-alive, regardless of why it
+died.
+
+The mechanism is a per-`VerificationHarness`-instance `bootEpoch`
+(`randomUUID()` at construction). Every step started by this instance is
+stamped with this `bootEpoch`. The alive-check is now:
+
+- `waiting` step → alive (phase-gated, hasn't started yet).
+- Reviewer / agent step → alive iff `sessionManager.getSession(step.sessionId)`
+  resolves.
+- Command step → alive iff `step.bootEpoch === this.bootEpoch &&
+  isPidAlive(step.pid)`.
+
+A persisted-running step loaded from disk after a restart always has a
+stale `bootEpoch`, so it is correctly read as not-alive — and the
+duplicate-detection path in `server.ts` falls through to
+`cancelStaleVerifications` and accepts the new signal.
+
+`resumeInterruptedVerifications` synchronously removes failed-on-resume
+entries from `activeVerifications` and rewrites
+`.bobbit/state/active-verifications.json` in a `finally` block, so even if
+the gate-store update throws (missing goal, deleted gate) the in-memory
+map and the persistence file are still consistent before the next
+`gate_signal` arrives.
+
+## PID-reuse safeguard
+
+Node does not expose a per-PID OS start time, so we cannot directly prove
+that a live PID belongs to the same process we spawned. As a pragmatic
+floor, `_resumeCommandStep` compares `Date.now() - step.startTimeMs`
+against `step.timeoutSec * 1000`. If the recorded spawn time is older than
+the step's own timeout, the original child must already have exited (its
+timeout would have killed it). A live PID at that point is almost
+certainly a recycled PID belonging to an unrelated process, so we skip
+Case B and finalize as failed.
+
+This is intentionally simple and cross-platform. A reused PID for an
+unrelated short-lived process within the timeout window will still appear
+"alive" in Case B, but it will not write to our exit file and the resume
+poll loop will time out and finalize as failed — never as passed.
+`isPidAlive(pid)` uses `process.kill(pid, 0)` which works identically on
+POSIX and Windows.
+
+Pinned by the second test in `tests/verification-harness-restart.test.ts`
+("resumeInterruptedVerifications finalizes a step as failed when pid is
+alive but startTimeMs indicates pid reuse").
+
+## Cross-platform notes
+
+The detached-survival path requires bash to run the exit-file wrapper. On
+POSIX systems this is always available. On Windows, the harness uses Git
+Bash via `GIT_BASH` from `shell-util.ts`. If Git Bash is not installed,
+the harness emits a one-time warning
+(`[verification] Git Bash not found on Windows — detached command mode
+disabled …`) and degrades to attached-pipe mode for all command steps in
+that gateway lifetime. Verifications still run; they just don't survive a
+restart. This is a deliberate trade-off — silently failing to spawn would
+be worse than running with degraded restart semantics.
+
+Docker-exec steps (`containerId` set) also stay on the attached-pipe path.
+Writing the exit file inside the container while persisting state on the
+host would require a host-mounted volume per signal and a wrapper inside
+the container; container survival across host gateway restart is
+explicitly out of scope (see below).
+
+## Out of scope
+
+- **Reviewer / agent-QA session resume.** Already handled by
+  `_tryResumeFromSession` and the team-store reviewer rebinding path; see
+  [internals.md — Reviewer `kind` & restart resume](internals.md#reviewer-kind--restart-resume).
+- **Host machine reboot.** Only same-host gateway restarts are covered. A
+  reboot will lose all detached children regardless of the wrapper.
+- **Mid-stream WS subscribers across the restart.** File content is
+  captured in full and bootstrap-served on the next attach, but a client
+  that was streaming live tail across the restart window may miss the
+  bytes written between the last 200 ms poll before the gateway died and
+  the resume re-attaching its tailer. The captured output reconciles on
+  the next bootstrap call.
+- **Docker-exec command steps.** Stay on the attached-pipe path. Their
+  exit code is lost across a host gateway restart; the signal will be
+  finalized as failed on resume.
+
+## Where the code lives
+
+| File | Symbol | Responsibility |
+|---|---|---|
+| `src/server/agent/verification-harness.ts` | `bootEpoch` (private field) | Per-instance UUID stamped on every step started by this harness. |
+| `src/server/agent/verification-harness.ts` | `isPidAlive(pid)` | Cross-platform PID-existence probe via `process.kill(pid, 0)`. |
+| `src/server/agent/verification-harness.ts` | `ActiveVerification.step` | Persisted shape now carries `pid`, `startTimeMs`, `outFile`, `errFile`, `exitFile`, `bootEpoch`, `timeoutSec`, `expectFailure`, `errorPattern`. |
+| `src/server/agent/verification-harness.ts` | `runCommandStep` | Spawns the detached child with the bash exit-file wrapper, stamps the persisted step, sets up file tailers. |
+| `src/server/agent/verification-harness.ts` | `_startFileTailers` | 200 ms polling tailer for out/err files; emits `gate_verification_step_output` events. |
+| `src/server/agent/verification-harness.ts` | `_resumeCommandStep` | Boot-time recovery: Case A (exit file present) / B (pid alive) / C (dead) finalization. |
+| `src/server/agent/verification-harness.ts` | `areVerificationSessionsAlive` | bootEpoch + `isPidAlive` liveness check. |
+| `src/server/agent/verification-harness.ts` | `resumeInterruptedVerifications` | Synchronous in-memory + on-disk cleanup of failed-on-resume entries in a `finally`. |
+| `src/server/server.ts` | duplicate-detection 409 path | Logs `[api] Rejecting gate_signal as duplicate` with per-step `{ name, status, pid, bootEpoch, sessionId }` so future false-positives are diagnosable from logs alone. |
+| `tests/verification-harness-restart.test.ts` | 3 unit tests | Pins zombie alive-check, pid-reuse safeguard, resume cleanup. |
+| `tests/e2e/verification-restart-resignal.spec.ts` | API E2E | Seeds a zombie verification, calls `resumeInterruptedVerifications`, asserts re-signal is accepted. |

--- a/src/server/agent/verification-harness.ts
+++ b/src/server/agent/verification-harness.ts
@@ -31,7 +31,7 @@ import { detectPrimaryBranch } from "../skills/git.js";
 import type { WorkflowGate, VerifyStep } from "./workflow-store.js";
 import type { ProjectConfigStore, Component } from "./project-config-store.js";
 import { WorkflowResolveError } from "./workflow-validator.js";
-import { getVerificationShell } from "./shell-util.js";
+import { getVerificationShell, GIT_BASH } from "./shell-util.js";
 import type { ProjectContextManager } from "./project-context-manager.js";
 import { generateTeamName } from "./team-names.js";
 import {
@@ -442,6 +442,9 @@ export class VerificationHarness {
 	 * zombie persisted from before restart".
 	 */
 	private readonly bootEpoch: string = randomUUID();
+
+	/** Flag for one-time cmd.exe detached-mode degradation warning. */
+	private static _warnedCmdExeDetached = false;
 
 	/** Limits concurrent command steps (type-check, tests) across all goals. */
 	private commandSemaphore = new Semaphore(4);
@@ -2637,6 +2640,18 @@ export class VerificationHarness {
 
 			// Decide execution mode.
 			let useDetached = !containerId && !!streamCtx;
+
+			// On Windows without Git Bash, the resolved shell is cmd.exe which
+			// cannot execute the bash exit-file wrapper. Silently degrade to
+			// attached mode so the verification still runs, and warn once so
+			// the missing restart-survival capability is visible in the logs.
+			if (useDetached && process.platform === "win32" && !GIT_BASH) {
+				if (!VerificationHarness._warnedCmdExeDetached) {
+					VerificationHarness._warnedCmdExeDetached = true;
+					console.warn("[verification] Git Bash not found on Windows — detached command mode disabled (cmd.exe cannot run the bash exit-file wrapper). Verification command steps will not survive a gateway restart.");
+				}
+				useDetached = false;
+			}
 			let outFile: string | undefined;
 			let errFile: string | undefined;
 			let exitFile: string | undefined;
@@ -2919,7 +2934,7 @@ export class VerificationHarness {
 	 * so the caller can fall through to the legacy "no session id" failure.
 	 */
 	private async _resumeCommandStep(
-		_v: ActiveVerification,
+		v: ActiveVerification,
 		step: ActiveVerification["steps"][number],
 	): Promise<{ name: string; type: string; passed: boolean; output: string; duration_ms: number } | null> {
 		if (!step.exitFile && !step.pid) return null;
@@ -2986,26 +3001,47 @@ export class VerificationHarness {
 			const timeoutMs = timeoutSec * 1000;
 			const deadline = step.startedAt + timeoutMs;
 			console.log(`[verification] Resume: pid ${step.pid} for "${step.name}" still alive — polling for exit file (deadline in ${Math.max(0, Math.round((deadline - Date.now()) / 1000))}s)`);
-			while (Date.now() < deadline) {
-				await new Promise(r => setTimeout(r, 500));
+
+			// Tail the surviving child's stdout/stderr files so UI clients see
+			// live output during the resume wait (and so subsequent gate_status
+			// calls show the streamed tail). Mirrors the live-spawn path.
+			let stopTail: (() => void) | undefined;
+			if (step.outFile && step.errFile) {
+				const stepIndex = v.steps.indexOf(step);
+				if (stepIndex >= 0) {
+					stopTail = this._startFileTailers(step.outFile, step.errFile, {
+						goalId: v.goalId,
+						gateId: v.gateId,
+						signalId: v.signalId,
+						stepIndex,
+					});
+				}
+			}
+
+			try {
+				while (Date.now() < deadline) {
+					await new Promise(r => setTimeout(r, 500));
+					if (step.exitFile && fs.existsSync(step.exitFile)) {
+						return finalize(readExitFile());
+					}
+					if (!isPidAlive(step.pid)) break;
+				}
+				// One last check after the loop
 				if (step.exitFile && fs.existsSync(step.exitFile)) {
 					return finalize(readExitFile());
 				}
-				if (!isPidAlive(step.pid)) break;
+				// Timed out or process died without writing the exit file
+				try { if (step.pid) process.kill(step.pid, "SIGKILL"); } catch { /* already dead */ }
+				return {
+					name: step.name,
+					type: step.type,
+					passed: false,
+					output: "Verification command did not produce an exit code (timeout or process died after restart).",
+					duration_ms: Date.now() - step.startedAt,
+				};
+			} finally {
+				if (stopTail) stopTail();
 			}
-			// One last check after the loop
-			if (step.exitFile && fs.existsSync(step.exitFile)) {
-				return finalize(readExitFile());
-			}
-			// Timed out or process died without writing the exit file
-			try { if (step.pid) process.kill(step.pid, "SIGKILL"); } catch { /* already dead */ }
-			return {
-				name: step.name,
-				type: step.type,
-				passed: false,
-				output: "Verification command did not produce an exit code (timeout or process died after restart).",
-				duration_ms: Date.now() - step.startedAt,
-			};
 		}
 
 		// Case C: process gone, no exit file — killed by something between our

--- a/src/server/agent/verification-harness.ts
+++ b/src/server/agent/verification-harness.ts
@@ -2,6 +2,26 @@ import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+
+/**
+ * Cross-platform check: is `pid` currently a live process?
+ *
+ * `process.kill(pid, 0)` sends signal 0, which performs the permission /
+ * existence check without delivering any signal. We treat both "no throw"
+ * and `EPERM` as alive — the latter happens when the pid exists but we
+ * don't own it, which on Windows can occur for detached children spawned
+ * across user sessions but still counts as "the process is alive". Any
+ * other error (notably `ESRCH`) means the process is gone.
+ */
+function isPidAlive(pid: number): boolean {
+	if (!Number.isFinite(pid) || pid <= 0) return false;
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err: any) {
+		return err?.code === "EPERM";
+	}
+}
 import type { GateStore, GateSignal, GateSignalStep } from "./gate-store.js";
 import type { PreferencesStore } from "./preferences-store.js";
 import type { RoleStore } from "./role-store.js";
@@ -175,12 +195,61 @@ function buildJsonRetryPrompt(quotedError: string): string {
 	);
 }
 
-/** In-flight verification state for REST bootstrapping */
+/**
+ * In-flight verification state for REST bootstrapping.
+ *
+ * Per-step fields used for the "command subprocess survives a gateway
+ * restart" scheme (Layer 1) and the duplicate-detection backstop (Layer 2):
+ *
+ * - `pid` / `startTimeMs` — child process id and spawn wall-clock time.
+ *   Together with `bootEpoch` they identify a process we ourselves started.
+ * - `outFile` / `errFile` / `exitFile` — files written by a small bash
+ *   wrapper around the real command. `exitFile` is renamed into place
+ *   atomically when the real command finishes, so even SIGKILL of the
+ *   gateway leaves either no exit file (still running) or a complete one
+ *   (finished). On resume we tail `outFile`/`errFile` and read `exitFile`
+ *   to finalize the step. Only non-container command steps use this path;
+ *   docker-exec steps stay on the simpler attached-pipe path because the
+ *   exit file would have to live inside the container.
+ * - `bootEpoch` — random UUID generated once per VerificationHarness
+ *   instance (i.e. per server process). A step whose bootEpoch matches the
+ *   current harness was started by THIS process and so its `pid`/file
+ *   layout are addressable here. A step whose bootEpoch differs (or is
+ *   absent) was started by a previous server lifetime and is treated as
+ *   dead unless `pid` + `process.kill(pid, 0)` proves otherwise.
+ */
 export interface ActiveVerification {
 	goalId: string;
 	gateId: string;
 	signalId: string;
-	steps: Array<{ name: string; type: string; status: "running" | "passed" | "failed" | "skipped" | "waiting"; phase?: number; durationMs?: number; output?: string; startedAt: number; sessionId?: string }>;
+	steps: Array<{
+		name: string;
+		type: string;
+		status: "running" | "passed" | "failed" | "skipped" | "waiting";
+		phase?: number;
+		durationMs?: number;
+		output?: string;
+		startedAt: number;
+		sessionId?: string;
+		/** OS process id of the spawned command (Layer 1). */
+		pid?: number;
+		/** Date.now() at spawn — tie-breaker against pid reuse. */
+		startTimeMs?: number;
+		/** Absolute path to detached child's stdout file (Layer 1). */
+		outFile?: string;
+		/** Absolute path to detached child's stderr file (Layer 1). */
+		errFile?: string;
+		/** Absolute path to detached child's exit-code file (Layer 1). */
+		exitFile?: string;
+		/** bootEpoch of the harness that started this step (Layer 2). */
+		bootEpoch?: string;
+		/** Step timeout in seconds — propagated for resume budget computation. */
+		timeoutSec?: number;
+		/** Whether the step expects a non-zero exit (for matchExpectFailure). */
+		expectFailure?: boolean;
+		/** Optional error-pattern regex for expectFailure matching. */
+		errorPattern?: string;
+	}>;
 	currentPhase?: number;
 	overallStatus: "running" | "passed" | "failed" | "cancelled";
 	startedAt: number;
@@ -363,6 +432,17 @@ export class VerificationHarness {
 	private readonly _persistPath: string;
 	private projectContextManager: ProjectContextManager | null;
 
+	/**
+	 * Per-process random UUID stamped on every step that this harness
+	 * instance starts (Layer 2 — see `ActiveVerification` jsdoc). On boot,
+	 * any persisted step whose `bootEpoch` does not match was started by a
+	 * previous server lifetime and its `pid`/file paths are not addressable
+	 * by this process. Used by `areVerificationSessionsAlive` and the
+	 * resume path to distinguish "we own this child" from "this is a
+	 * zombie persisted from before restart".
+	 */
+	private readonly bootEpoch: string = randomUUID();
+
 	/** Limits concurrent command steps (type-check, tests) across all goals. */
 	private commandSemaphore = new Semaphore(4);
 
@@ -388,19 +468,43 @@ export class VerificationHarness {
 	 * Also returns true if steps are still in "waiting" state (not yet started),
 	 * to avoid premature cancellation during phase transitions.
 	 */
+	/**
+	 * Check if any verification sessions for a given signalId are still alive.
+	 *
+	 * "Alive" means we have evidence the OS process / agent session is still
+	 * doing useful work — not merely that the persisted `status === "running"`
+	 * flag survives on disk after a restart.
+	 *
+	 * Rules:
+	 * - `waiting` steps → alive (haven't started yet, phase-gated).
+	 * - LLM/agent steps with `sessionId` → alive iff sessionManager has the
+	 *   session.
+	 * - Command steps → alive iff THIS process started the child
+	 *   (`step.bootEpoch === this.bootEpoch`) AND the recorded `pid` is
+	 *   still running. After a server restart, bootEpoch always differs,
+	 *   so persisted-running command steps correctly read as not-alive and
+	 *   the duplicate-detection path can reclaim the gate.
+	 */
 	areVerificationSessionsAlive(signalId: string): boolean {
 		const active = this.activeVerifications.get(signalId);
 		if (!active) return false;
 		// If any step is still waiting to start, the verification is not a zombie
 		if (active.steps.some(s => s.status === "waiting")) return true;
 		for (const step of active.steps) {
-			if (step.status === "running") {
-				// Command steps have no sessionId — if status is running, the process is alive
-				if (!step.sessionId) return true;
+			if (step.status !== "running") continue;
+			if (step.sessionId) {
 				// LLM/agent steps — check if session is still alive
 				const session = this.sessionManager?.getSession(step.sessionId);
 				if (session) return true;
+				continue;
 			}
+			// Command step. Only count as alive when we have positive evidence
+			// that THIS process started it AND its pid is still resolvable.
+			if (step.bootEpoch === this.bootEpoch && typeof step.pid === "number") {
+				if (isPidAlive(step.pid)) return true;
+			}
+			// Otherwise: persisted-running command step from a previous server
+			// lifetime — treat as dead so duplicate-detection can auto-cancel.
 		}
 		return false;
 	}
@@ -482,21 +586,38 @@ export class VerificationHarness {
 				await this._resumeOneVerification(v);
 			} catch (err) {
 				console.error(`[verification] Failed to resume verification ${v.signalId}:`, err);
-				// Mark as failed and update gate
-				this.resolveGateStore(v.goalId).updateSignalVerification(v.signalId, {
-					status: "failed",
-					steps: [{ name: "Resume Error", type: "command", passed: false, output: `Failed to resume after restart: ${(err as Error).message}`, duration_ms: 0 }],
-				});
-				this.resolveGateStore(v.goalId).updateGateStatus(v.goalId, v.gateId, "failed");
-				this.broadcastFn(v.goalId, {
-					type: "gate_verification_complete",
-					goalId: v.goalId, gateId: v.gateId, signalId: v.signalId, status: "failed",
-				});
-				this.broadcastFn(v.goalId, {
-					type: "gate_status_changed",
-					goalId: v.goalId, gateId: v.gateId, status: "failed",
-				});
-				this.notifyTeamLead(v.goalId, v.gateId, "failed");
+				// Best-effort: mark as failed and update gate. Wrap each external
+				// store call in try/catch so a missing goal/gate doesn't stop us
+				// from cleaning up the in-memory entry below — leaving it would
+				// reproduce the HTTP 409 lock-after-restart bug.
+				try {
+					this.resolveGateStore(v.goalId).updateSignalVerification(v.signalId, {
+						status: "failed",
+						steps: [{ name: "Resume Error", type: "command", passed: false, output: `Failed to resume after restart: ${(err as Error).message}`, duration_ms: 0 }],
+					});
+					this.resolveGateStore(v.goalId).updateGateStatus(v.goalId, v.gateId, "failed");
+				} catch (storeErr) {
+					console.error(`[verification] Failed to update gate store for ${v.signalId} during resume cleanup:`, storeErr);
+				}
+				try {
+					this.broadcastFn(v.goalId, {
+						type: "gate_verification_complete",
+						goalId: v.goalId, gateId: v.gateId, signalId: v.signalId, status: "failed",
+					});
+					this.broadcastFn(v.goalId, {
+						type: "gate_status_changed",
+						goalId: v.goalId, gateId: v.gateId, status: "failed",
+					});
+					this.notifyTeamLead(v.goalId, v.gateId, "failed");
+				} catch (bcastErr) {
+					console.error(`[verification] Failed to broadcast failure for ${v.signalId} during resume cleanup:`, bcastErr);
+				}
+			} finally {
+				// Synchronously drop the in-memory entry so subsequent
+				// gate_signal calls on the same SHA aren't rejected with HTTP 409
+				// by areVerificationSessionsAlive seeing a leftover "running" step
+				// from a previous server lifetime (Layer 2 acceptance criterion).
+				this.activeVerifications.delete(v.signalId);
 			}
 		}
 
@@ -583,8 +704,12 @@ export class VerificationHarness {
 				continue;
 			}
 
-			// Step was running — try to resume from the existing session first
-			let resumeResult = await this._tryResumeFromSession(v, step);
+			// Step was running — for command-type steps, try the file-based
+			// (Layer 1) resume path; for session-backed steps, re-attach to the
+			// restored reviewer session as before.
+			let resumeResult = step.type === "command"
+				? await this._resumeCommandStep(v, step)
+				: await this._tryResumeFromSession(v, step);
 
 			// If resume failed with a transient error and this is an llm-review or agent-qa step,
 			// re-run from scratch rather than giving up
@@ -2477,6 +2602,31 @@ export class VerificationHarness {
 		return _substituteVars(template, builtinVars, projectVars, agentVars, allGateStates);
 	}
 
+	/**
+	 * Spawn a command-type verification step.
+	 *
+	 * Two execution modes:
+	 *
+	 * 1. **Detached survival mode** (Layer 1 — default for non-container,
+	 *    streamed steps): the child is spawned with `detached: true` and
+	 *    stdout/stderr redirected to files under
+	 *    `<stateDir>/verifications/<signalId>/<stepIndex>.{out,err}`. A small
+	 *    shell wrapper writes the exit code to `<stepIndex>.exit` via an
+	 *    atomic `mv tmp → exit` so that even SIGKILL of the gateway leaves
+	 *    either no exit file (child still running) or a complete one. We
+	 *    `unref()` the child, stamp pid + bootEpoch + file paths onto the
+	 *    persisted `ActiveVerification.step`, and from the parent we tail
+	 *    the files for live broadcast. On gateway restart,
+	 *    `_resumeCommandStep` re-attaches by polling the exit file.
+	 *
+	 * 2. **Attached pipe mode** (fallback): used when running inside a docker
+	 *    container (`containerId` set) or when no `streamCtx` is available
+	 *    (i.e. no signal/step to anchor file paths on). Docker steps stay on
+	 *    this path because writing the exit file inside the container while
+	 *    persisting state on the host adds complexity that isn't required by
+	 *    the acceptance criteria — container survival across host gateway
+	 *    restart is intentionally out of scope.
+	 */
 	private runCommandStep(
 		command: string,
 		cwd: string,
@@ -2490,89 +2640,177 @@ export class VerificationHarness {
 			const normalizedCwd = cwd.replace(/\\/g, "/");
 			// Shell selection: default to plain bash (fast), use --login only for
 			// commands that need the full interactive PATH (npm, pytest, gh, etc.).
-			//
-			// On Windows, Git Bash with --login is ~3.7s per spawn (sources /etc/profile,
-			// ~/.bash_profile). Plain bash is ~150ms. 25× difference.
-			//
-			// Heuristic: commands that reference common tool names get --login.
-			// Everything else (echo, test, [], cat, grep, basic shell operators)
-			// runs in plain shell. This preserves backward compat for real workflows
-			// while making test workflows 25× faster.
 			const { shell: shellBin, args: shellArgs } = getVerificationShell(command);
-			// For sandboxed goals, run the command inside the project container
-			const child = containerId
-				? spawn("docker", ["exec", "-w", normalizedCwd, containerId, "/bin/sh", "-c", command], {
-					stdio: ["ignore", "pipe", "pipe"],
-					timeout: timeoutSec * 1000,
-					env: { ...process.env, MSYS_NO_PATHCONV: "1", MSYS2_ARG_CONV_EXCL: "*" },
-				})
-				: spawn(shellBin, [...shellArgs, command], {
-					cwd: normalizedCwd,
-					timeout: timeoutSec * 1000,
-					stdio: ["ignore", "pipe", "pipe"],
-					...(process.platform === "win32" ? { windowsHide: true } : {}),
-				});
+
+			// Decide execution mode.
+			let useDetached = !containerId && !!streamCtx;
+			let outFile: string | undefined;
+			let errFile: string | undefined;
+			let exitFile: string | undefined;
+			let outFd: number | undefined;
+			let errFd: number | undefined;
+
+			if (useDetached && streamCtx) {
+				try {
+					const stepDir = path.join(this._stateDir, "verifications", streamCtx.signalId);
+					fs.mkdirSync(stepDir, { recursive: true });
+					outFile = path.join(stepDir, `${streamCtx.stepIndex}.out`);
+					errFile = path.join(stepDir, `${streamCtx.stepIndex}.err`);
+					exitFile = path.join(stepDir, `${streamCtx.stepIndex}.exit`);
+					try { fs.unlinkSync(exitFile); } catch { /* not present */ }
+					try { fs.unlinkSync(exitFile + ".tmp"); } catch { /* not present */ }
+					outFd = fs.openSync(outFile, "w");
+					errFd = fs.openSync(errFile, "w");
+				} catch (err) {
+					console.warn(`[verification] Failed to set up survival files — falling back to attached mode: ${(err as Error).message}`);
+					if (outFd !== undefined) { try { fs.closeSync(outFd); } catch {} }
+					if (errFd !== undefined) { try { fs.closeSync(errFd); } catch {} }
+					useDetached = false;
+					outFile = errFile = exitFile = undefined;
+				}
+			}
+
+			// Build the command to actually run. In detached mode we wrap so
+			// the wrapper, not the gateway, owns writing the exit code atomically.
+			let cmdToRun = command;
+			if (useDetached && exitFile) {
+				const exitTmp = exitFile + ".tmp";
+				const sq = (s: string) => "'" + s.replace(/'/g, "'\\''") + "'";
+				// Run command in a subshell so its `exit` does not short-circuit our
+				// exit-file write; capture $?, write atomically, then propagate.
+				cmdToRun = `( ${command}\n); __ec=$?; printf %s "$__ec" > ${sq(exitTmp)} && mv ${sq(exitTmp)} ${sq(exitFile)}; exit $__ec`;
+			}
+
+			let child;
+			try {
+				child = containerId
+					? spawn("docker", ["exec", "-w", normalizedCwd, containerId, "/bin/sh", "-c", command], {
+						stdio: ["ignore", "pipe", "pipe"],
+						timeout: timeoutSec * 1000,
+						env: { ...process.env, MSYS_NO_PATHCONV: "1", MSYS2_ARG_CONV_EXCL: "*" },
+					})
+					: useDetached
+						? spawn(shellBin, [...shellArgs, cmdToRun], {
+							cwd: normalizedCwd,
+							detached: true,
+							stdio: ["ignore", outFd!, errFd!],
+							...(process.platform === "win32" ? { windowsHide: true } : {}),
+						})
+						: spawn(shellBin, [...shellArgs, cmdToRun], {
+							cwd: normalizedCwd,
+							timeout: timeoutSec * 1000,
+							stdio: ["ignore", "pipe", "pipe"],
+							...(process.platform === "win32" ? { windowsHide: true } : {}),
+						});
+			} finally {
+				// Once spawn has dup'd the FDs into the child, parent's copies are
+				// no longer needed. Closing them avoids leaks even if we don't
+				// reach the resolve path.
+				if (outFd !== undefined) { try { fs.closeSync(outFd); } catch {} }
+				if (errFd !== undefined) { try { fs.closeSync(errFd); } catch {} }
+			}
+
+			// Stamp the persisted step with everything needed for cross-restart
+			// recovery before doing anything else — if the gateway dies right
+			// now, the next boot must be able to find the child.
+			if (useDetached && streamCtx && child.pid != null) {
+				const av = this.activeVerifications.get(streamCtx.signalId);
+				if (av && av.steps[streamCtx.stepIndex]) {
+					const s = av.steps[streamCtx.stepIndex];
+					s.pid = child.pid;
+					s.startTimeMs = Date.now();
+					s.outFile = outFile;
+					s.errFile = errFile;
+					s.exitFile = exitFile;
+					s.bootEpoch = this.bootEpoch;
+					s.timeoutSec = timeoutSec;
+					s.expectFailure = expectFailure;
+					s.errorPattern = errorPattern;
+					this._persistActive();
+				}
+				// unref so the child does not keep the gateway alive during a
+				// graceful shutdown — we want it to survive past our exit.
+				try { child.unref(); } catch { /* ignore */ }
+			}
+
 			let stdout = "";
 			let stderr = "";
-			child.stdout.on("data", (d: Buffer) => {
-				const text = d.toString();
-				stdout += text;
-				if (stdout.length > 1024 * 1024) stdout = stdout.slice(-512 * 1024);
-				if (streamCtx) {
-					this.broadcastFn(streamCtx.goalId, {
-						type: "gate_verification_step_output",
-						goalId: streamCtx.goalId,
-						gateId: streamCtx.gateId,
-						signalId: streamCtx.signalId,
-						stepIndex: streamCtx.stepIndex,
-						stream: "stdout" as const,
-						text,
-						ts: Date.now(),
-					});
-					const av = this.activeVerifications.get(streamCtx.signalId);
-					if (av && av.steps[streamCtx.stepIndex]) {
-						const step = av.steps[streamCtx.stepIndex];
-						step.output = (step.output || "") + text;
-						if (step.output.length > 512 * 1024) {
-							step.output = step.output.slice(-512 * 1024);
+			let stopTail: (() => void) | undefined;
+
+			if (useDetached && streamCtx && outFile && errFile) {
+				stopTail = this._startFileTailers(outFile, errFile, streamCtx);
+			} else if (!useDetached) {
+				const onData = (text: string, stream: "stdout" | "stderr") => {
+					if (stream === "stdout") {
+						stdout += text;
+						if (stdout.length > 1024 * 1024) stdout = stdout.slice(-512 * 1024);
+					} else {
+						stderr += text;
+						if (stderr.length > 1024 * 1024) stderr = stderr.slice(-512 * 1024);
+					}
+					if (streamCtx) {
+						this.broadcastFn(streamCtx.goalId, {
+							type: "gate_verification_step_output",
+							goalId: streamCtx.goalId,
+							gateId: streamCtx.gateId,
+							signalId: streamCtx.signalId,
+							stepIndex: streamCtx.stepIndex,
+							stream,
+							text,
+							ts: Date.now(),
+						});
+						const av = this.activeVerifications.get(streamCtx.signalId);
+						if (av && av.steps[streamCtx.stepIndex]) {
+							const step = av.steps[streamCtx.stepIndex];
+							step.output = (step.output || "") + text;
+							if (step.output.length > 512 * 1024) {
+								step.output = step.output.slice(-512 * 1024);
+							}
 						}
 					}
-				}
-			});
-			child.stderr.on("data", (d: Buffer) => {
-				const text = d.toString();
-				stderr += text;
-				if (stderr.length > 1024 * 1024) stderr = stderr.slice(-512 * 1024);
-				if (streamCtx) {
-					this.broadcastFn(streamCtx.goalId, {
-						type: "gate_verification_step_output",
-						goalId: streamCtx.goalId,
-						gateId: streamCtx.gateId,
-						signalId: streamCtx.signalId,
-						stepIndex: streamCtx.stepIndex,
-						stream: "stderr" as const,
-						text,
-						ts: Date.now(),
-					});
-					const av = this.activeVerifications.get(streamCtx.signalId);
-					if (av && av.steps[streamCtx.stepIndex]) {
-						const step = av.steps[streamCtx.stepIndex];
-						step.output = (step.output || "") + text;
-						if (step.output.length > 512 * 1024) {
-							step.output = step.output.slice(-512 * 1024);
-						}
-					}
-				}
-			});
+				};
+				child.stdout?.on("data", (d: Buffer) => onData(d.toString(), "stdout"));
+				child.stderr?.on("data", (d: Buffer) => onData(d.toString(), "stderr"));
+			}
+
+			// Manual timeout for the detached path — spawn's `timeout` option
+			// kills only the immediate child; the detached subshell may outlive
+			// it on some platforms. Doing it ourselves keeps the semantics
+			// uniform across modes.
+			let timedOut = false;
+			let timeoutHandle: NodeJS.Timeout | undefined;
+			if (useDetached) {
+				timeoutHandle = setTimeout(() => {
+					timedOut = true;
+					try { if (child.pid) process.kill(child.pid, "SIGKILL"); } catch { /* already dead */ }
+				}, timeoutSec * 1000);
+			}
+
 			child.on("close", (code) => {
-				const output = (stdout + "\n" + stderr).trim().slice(-5000);
+				if (timeoutHandle) clearTimeout(timeoutHandle);
+				try { stopTail?.(); } catch { /* ignore */ }
+
+				let outText = stdout;
+				let errText = stderr;
+				if (useDetached && outFile && errFile) {
+					try { outText = fs.readFileSync(outFile, "utf8"); } catch { outText = stdout; }
+					try { errText = fs.readFileSync(errFile, "utf8"); } catch { errText = stderr; }
+				}
+				const output = (outText + "\n" + errText).trim().slice(-5000);
+				const effectiveCode: number | null = timedOut ? null : code;
 				if (expectFailure) {
-					resolve(matchExpectFailure(code, output, errorPattern));
+					resolve(matchExpectFailure(effectiveCode, output, errorPattern));
+					return;
+				}
+				if (timedOut) {
+					resolve({ passed: false, output: output || `command timed out after ${timeoutSec}s` });
 					return;
 				}
 				resolve({ passed: code === 0, output: output || `exit code ${code}` });
 			});
 			child.on("error", (err) => {
+				if (timeoutHandle) clearTimeout(timeoutHandle);
+				try { stopTail?.(); } catch { /* ignore */ }
 				if (expectFailure && errorPattern) {
 					try {
 						const regex = new RegExp(errorPattern, 'i');
@@ -2585,6 +2823,181 @@ export class VerificationHarness {
 				}
 			});
 		});
+	}
+
+	/**
+	 * Poll the per-step stdout/stderr files for new bytes and broadcast each
+	 * chunk as a `gate_verification_step_output` event, mirroring the live
+	 * UI broadcast path of the legacy attached-pipe mode. Returns a stop
+	 * function that does a final flush before clearing the interval.
+	 */
+	private _startFileTailers(
+		outFile: string,
+		errFile: string,
+		ctx: { goalId: string; gateId: string; signalId: string; stepIndex: number },
+	): () => void {
+		let outPos = 0;
+		let errPos = 0;
+		let stopped = false;
+
+		const readNew = (filePath: string, pos: number, stream: "stdout" | "stderr"): number => {
+			try {
+				const stat = fs.statSync(filePath);
+				if (stat.size <= pos) return pos;
+				const fd = fs.openSync(filePath, "r");
+				try {
+					const len = stat.size - pos;
+					const buf = Buffer.alloc(len);
+					fs.readSync(fd, buf, 0, len, pos);
+					const text = buf.toString("utf8");
+					this.broadcastFn(ctx.goalId, {
+						type: "gate_verification_step_output",
+						goalId: ctx.goalId,
+						gateId: ctx.gateId,
+						signalId: ctx.signalId,
+						stepIndex: ctx.stepIndex,
+						stream,
+						text,
+						ts: Date.now(),
+					});
+					const av = this.activeVerifications.get(ctx.signalId);
+					if (av && av.steps[ctx.stepIndex]) {
+						const s = av.steps[ctx.stepIndex];
+						s.output = (s.output || "") + text;
+						if (s.output.length > 512 * 1024) s.output = s.output.slice(-512 * 1024);
+					}
+					return stat.size;
+				} finally {
+					try { fs.closeSync(fd); } catch { /* ignore */ }
+				}
+			} catch {
+				return pos;
+			}
+		};
+
+		const interval = setInterval(() => {
+			if (stopped) return;
+			outPos = readNew(outFile, outPos, "stdout");
+			errPos = readNew(errFile, errPos, "stderr");
+		}, 200);
+
+		return () => {
+			if (stopped) return;
+			stopped = true;
+			clearInterval(interval);
+			// Final flush to catch the tail end of output written between the
+			// last poll and child exit.
+			outPos = readNew(outFile, outPos, "stdout");
+			errPos = readNew(errFile, errPos, "stderr");
+		};
+	}
+
+	/**
+	 * Resume a command-type step that was running when the gateway died.
+	 *
+	 * Strategy (see `ActiveVerification` jsdoc for context):
+	 *
+	 * 1. If `exitFile` already exists — the wrapper completed before we got
+	 *    back — read it plus the stdout/stderr tails and finalize via the
+	 *    same `matchExpectFailure` / pass-fail logic the live path uses.
+	 * 2. Else if `pid` is still alive — the detached child outlived the
+	 *    gateway and is still chugging away. Poll for the exit file with
+	 *    the remaining timeout budget computed from `startedAt`.
+	 * 3. Else — process is gone and there's no exit file. The child was
+	 *    killed (OOM, manual kill, antivirus). Finalize as failed.
+	 *
+	 * Returns null when there's nothing to resume (no exit file recorded,
+	 * e.g. the step pre-dates Layer 1 or used the attached-mode fallback)
+	 * so the caller can fall through to the legacy "no session id" failure.
+	 */
+	private async _resumeCommandStep(
+		_v: ActiveVerification,
+		step: ActiveVerification["steps"][number],
+	): Promise<{ name: string; type: string; passed: boolean; output: string; duration_ms: number } | null> {
+		if (!step.exitFile && !step.pid) return null;
+
+		const readFiles = (): { out: string; err: string } => {
+			let out = "";
+			let err = "";
+			try { if (step.outFile) out = fs.readFileSync(step.outFile, "utf8"); } catch { /* ignore */ }
+			try { if (step.errFile) err = fs.readFileSync(step.errFile, "utf8"); } catch { /* ignore */ }
+			return { out, err };
+		};
+		const readExitFile = (): number | null => {
+			if (!step.exitFile) return null;
+			try {
+				const raw = fs.readFileSync(step.exitFile, "utf8").trim();
+				const n = parseInt(raw, 10);
+				return Number.isFinite(n) ? n : null;
+			} catch {
+				return null;
+			}
+		};
+		const finalize = (code: number | null) => {
+			const { out, err } = readFiles();
+			const output = (out + "\n" + err).trim().slice(-5000);
+			let passed: boolean;
+			let displayOutput: string;
+			if (step.expectFailure) {
+				const m = matchExpectFailure(code, output, step.errorPattern);
+				passed = m.passed;
+				displayOutput = m.output;
+			} else {
+				passed = code === 0;
+				displayOutput = output || `exit code ${code}`;
+			}
+			return {
+				name: step.name,
+				type: step.type,
+				passed,
+				output: displayOutput,
+				duration_ms: Date.now() - step.startedAt,
+			};
+		};
+
+		// Case A: child already finished before we restarted.
+		if (step.exitFile && fs.existsSync(step.exitFile)) {
+			console.log(`[verification] Resume: exit file present for "${step.name}" — finalizing from disk`);
+			return finalize(readExitFile());
+		}
+
+		// Case B: child still running on the host.
+		if (typeof step.pid === "number" && isPidAlive(step.pid)) {
+			const timeoutMs = (step.timeoutSec ?? 300) * 1000;
+			const deadline = step.startedAt + timeoutMs;
+			console.log(`[verification] Resume: pid ${step.pid} for "${step.name}" still alive — polling for exit file (deadline in ${Math.max(0, Math.round((deadline - Date.now()) / 1000))}s)`);
+			while (Date.now() < deadline) {
+				await new Promise(r => setTimeout(r, 500));
+				if (step.exitFile && fs.existsSync(step.exitFile)) {
+					return finalize(readExitFile());
+				}
+				if (!isPidAlive(step.pid)) break;
+			}
+			// One last check after the loop
+			if (step.exitFile && fs.existsSync(step.exitFile)) {
+				return finalize(readExitFile());
+			}
+			// Timed out or process died without writing the exit file
+			try { if (step.pid) process.kill(step.pid, "SIGKILL"); } catch { /* already dead */ }
+			return {
+				name: step.name,
+				type: step.type,
+				passed: false,
+				output: "Verification command did not produce an exit code (timeout or process died after restart).",
+				duration_ms: Date.now() - step.startedAt,
+			};
+		}
+
+		// Case C: process gone, no exit file — killed by something between our
+		// last persist and now.
+		console.log(`[verification] Resume: pid/exit-file gone for "${step.name}" — marking failed`);
+		return {
+			name: step.name,
+			type: step.type,
+			passed: false,
+			output: "Verification command process died during gateway restart before producing an exit code.",
+			duration_ms: Date.now() - step.startedAt,
+		};
 	}
 }
 

--- a/src/server/agent/verification-harness.ts
+++ b/src/server/agent/verification-harness.ts
@@ -463,13 +463,6 @@ export class VerificationHarness {
 
 	/**
 	 * Check if any verification sessions for a given signalId are still alive.
-	 * Returns true if at least one running step has a live session.
-	 * Returns false (zombie) if no running sessions exist — safe to auto-cancel.
-	 * Also returns true if steps are still in "waiting" state (not yet started),
-	 * to avoid premature cancellation during phase transitions.
-	 */
-	/**
-	 * Check if any verification sessions for a given signalId are still alive.
 	 *
 	 * "Alive" means we have evidence the OS process / agent session is still
 	 * doing useful work — not merely that the persisted `status === "running"`
@@ -2681,7 +2674,24 @@ export class VerificationHarness {
 				cmdToRun = `( ${command}\n); __ec=$?; printf %s "$__ec" > ${sq(exitTmp)} && mv ${sq(exitTmp)} ${sq(exitFile)}; exit $__ec`;
 			}
 
+			// Resolve a synchronously-thrown spawn error the same way we'd
+			// handle child.on("error", ...) — surface the error text and honour
+			// expectFailure semantics. Without this, accessing child.pid below
+			// would throw TypeError and crash the verification pipeline.
+			const handleSpawnError = (err: Error): { passed: boolean; output: string } => {
+				if (expectFailure && errorPattern) {
+					try {
+						const regex = new RegExp(errorPattern, "i");
+						return { passed: regex.test(err.message), output: err.message };
+					} catch {
+						return { passed: false, output: `Invalid error_pattern regex when handling spawn error: ${err.message}` };
+					}
+				}
+				return { passed: expectFailure, output: err.message };
+			};
+
 			let child;
+			let spawnError: Error | undefined;
 			try {
 				child = containerId
 					? spawn("docker", ["exec", "-w", normalizedCwd, containerId, "/bin/sh", "-c", command], {
@@ -2702,12 +2712,19 @@ export class VerificationHarness {
 							stdio: ["ignore", "pipe", "pipe"],
 							...(process.platform === "win32" ? { windowsHide: true } : {}),
 						});
+			} catch (err) {
+				spawnError = err as Error;
 			} finally {
 				// Once spawn has dup'd the FDs into the child, parent's copies are
 				// no longer needed. Closing them avoids leaks even if we don't
 				// reach the resolve path.
 				if (outFd !== undefined) { try { fs.closeSync(outFd); } catch {} }
 				if (errFd !== undefined) { try { fs.closeSync(errFd); } catch {} }
+			}
+
+			if (spawnError || !child) {
+				resolve(handleSpawnError(spawnError ?? new Error("spawn returned no child")));
+				return;
 			}
 
 			// Stamp the persisted step with everything needed for cross-restart
@@ -2811,16 +2828,7 @@ export class VerificationHarness {
 			child.on("error", (err) => {
 				if (timeoutHandle) clearTimeout(timeoutHandle);
 				try { stopTail?.(); } catch { /* ignore */ }
-				if (expectFailure && errorPattern) {
-					try {
-						const regex = new RegExp(errorPattern, 'i');
-						resolve({ passed: regex.test(err.message), output: err.message });
-					} catch {
-						resolve({ passed: false, output: `Invalid error_pattern regex when handling spawn error: ${err.message}` });
-					}
-				} else {
-					resolve({ passed: expectFailure, output: err.message });
-				}
+				resolve(handleSpawnError(err));
 			});
 		});
 	}
@@ -2961,9 +2969,21 @@ export class VerificationHarness {
 			return finalize(readExitFile());
 		}
 
+		// Cross-platform PID-reuse safeguard: Node doesn't expose a per-PID OS
+		// start time, so we can't directly tie a live pid back to the same
+		// process we spawned. As a pragmatic floor: if the recorded
+		// startTimeMs is older than the step's own timeout, the original
+		// child must already have exited (timeout would have killed it),
+		// so a live `step.pid` here is almost certainly a reused/recycled
+		// pid belonging to an unrelated process. Skip Case B and fall
+		// through to Case C (finalize as failed).
+		const timeoutSec = step.timeoutSec ?? 300;
+		const pidLooksReused = typeof step.startTimeMs === "number"
+			&& (Date.now() - step.startTimeMs) > timeoutSec * 1000;
+
 		// Case B: child still running on the host.
-		if (typeof step.pid === "number" && isPidAlive(step.pid)) {
-			const timeoutMs = (step.timeoutSec ?? 300) * 1000;
+		if (!pidLooksReused && typeof step.pid === "number" && isPidAlive(step.pid)) {
+			const timeoutMs = timeoutSec * 1000;
 			const deadline = step.startedAt + timeoutMs;
 			console.log(`[verification] Resume: pid ${step.pid} for "${step.name}" still alive — polling for exit file (deadline in ${Math.max(0, Math.round((deadline - Date.now()) / 1000))}s)`);
 			while (Date.now() < deadline) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4805,6 +4805,16 @@ async function handleApiRoute(
 					await verificationHarness.cancelStaleVerifications(goalId, gateId);
 					// Fall through to create new signal
 				} else {
+					// Surface the step states so a future 409 is diagnosable from
+					// logs alone — see goal "Unstick verification lock on restart".
+					const stepSummary = runningDup.steps.map((s: any) => ({
+						name: s.name,
+						status: s.status,
+						pid: s.pid,
+						bootEpoch: s.bootEpoch,
+						sessionId: s.sessionId,
+					}));
+					console.warn(`[api] Rejecting gate_signal as duplicate: gate=${gateId} signalId=${runningDup.signalId} aliveCheck=true steps=${JSON.stringify(stepSummary)}`);
 					json({ error: "Verification already in progress for this commit", existingSignalId: runningDup.signalId }, 409);
 					return;
 				}

--- a/tests/e2e/verification-restart-resignal.spec.ts
+++ b/tests/e2e/verification-restart-resignal.spec.ts
@@ -1,0 +1,269 @@
+/**
+ * API E2E for the verification-lock-after-restart bug (AC#5).
+ *
+ * Scenario: a command-type verification step is mid-flight when the
+ * gateway is SIGKILLed. The persisted `active-verifications.json`
+ * survives with `status: "running"`. Pre-fix, the next `gate_signal` on
+ * the same commit SHA hit `areVerificationSessionsAlive()`, which
+ * fast-pathed to `true` for any persisted-running command step without a
+ * `sessionId`, locking the gate behind HTTP 409 forever (the only
+ * workaround was an empty commit to change the SHA).
+ *
+ * We can't truly kill+respawn the in-process gateway from inside a test
+ * (the harness is worker-scoped and the server has singletons), so we
+ * simulate the post-restart state directly against the live harness:
+ *
+ *   1. Seed a zombie `ActiveVerification` entry into both the
+ *      harness's in-memory map AND `active-verifications.json` on disk,
+ *      shaped exactly like what a constructor-load from a previous boot
+ *      would produce (no `sessionId`, no live `bootEpoch` match, dead
+ *      `pid`). This mirrors the boot sequence in `server.ts` ~line 1130
+ *      where `_loadActive()` populates the map.
+ *
+ *   2. Also seed a matching `GateSignal` in the gateStore with
+ *      `commitSha === HEAD` so the duplicate-detection path in
+ *      `server.ts:4792` will actually fire on re-signal.
+ *
+ *   3. Call `harness.resumeInterruptedVerifications()` — the same call
+ *      `server.ts` makes during boot. Assert the zombie is removed from
+ *      both memory and disk (Layer 2 acceptance criteria 3 & 4).
+ *
+ *   4. Re-signal the gate via POST /api/goals/:id/gates/:gateId/signal.
+ *      Assert: response is 201 (NOT 409), a brand-new signal id is
+ *      returned, and a fresh verification is in flight.
+ *
+ * Pre-fix, this fails at step 3 (zombie still in map, persistence still
+ * contains the signalId) and again at step 4 (HTTP 409
+ * "Verification already in progress for this commit").
+ */
+import { test, expect } from "./in-process-harness.js";
+import { apiFetch, createGoal, deleteGoal } from "./e2e-setup.js";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+const SLOW_WORKFLOW_ID = `test-restart-resignal-${Date.now()}`;
+
+/** Create a workflow with one slow command step. */
+async function createSlowWorkflow(): Promise<void> {
+	const res = await apiFetch("/api/workflows", {
+		method: "POST",
+		body: JSON.stringify({
+			id: SLOW_WORKFLOW_ID,
+			name: "Test Restart Resignal",
+			description: "Workflow with slow command for restart-resignal tests",
+			gates: [
+				{
+					id: "slow-gate",
+					name: "Slow Gate",
+					dependsOn: [],
+					verify: [
+						{
+							name: "Slow check",
+							type: "command",
+							// Long enough that we can intercept mid-flight if needed,
+							// but the actual restart-resignal path below never waits
+							// on this command — it seeds a fake zombie directly.
+							run: 'node -e "setTimeout(()=>{console.log(\'done\');process.exit(0)},5000)"',
+						},
+					],
+				},
+			],
+		}),
+	});
+	expect(res.status).toBe(201);
+}
+
+async function deleteSlowWorkflow(): Promise<void> {
+	await apiFetch(`/api/workflows/${SLOW_WORKFLOW_ID}`, { method: "DELETE" }).catch(() => {});
+}
+
+/** Initialize a git repo at `dir` and produce one commit; return HEAD SHA. */
+function gitInitWithCommit(dir: string): string {
+	fs.mkdirSync(dir, { recursive: true });
+	execFileSync("git", ["init", "--initial-branch=master"], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["config", "user.email", "test@bobbit.local"], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["config", "user.name", "test"], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: dir, stdio: "ignore" });
+	return execFileSync("git", ["rev-parse", "HEAD"], { cwd: dir }).toString().trim();
+}
+
+/** A pid that is overwhelmingly unlikely to be in use. */
+function deadPid(): number {
+	// 0x7ffffffe — well above any reasonable PID range on Linux/macOS/Windows.
+	return 0x7ffffffe;
+}
+
+test.describe("Verification lock after restart — re-signal is accepted", () => {
+	test.setTimeout(60_000);
+
+	test.beforeAll(async () => {
+		await createSlowWorkflow();
+	});
+
+	test.afterAll(async () => {
+		await deleteSlowWorkflow();
+	});
+
+	test("zombie command verification from previous boot is cleaned up; re-signal at same SHA returns 201", async ({ gateway }) => {
+		// 1. Real git repo so `git rev-parse HEAD` returns a real SHA — without
+		//    this the duplicate-detection block in server.ts:4792 is skipped
+		//    entirely and we wouldn't actually exercise the bug.
+		const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "verif-restart-repo-"));
+		const headSha = gitInitWithCommit(repoDir);
+
+		const goal = await createGoal({
+			title: `Restart Resignal ${Date.now()}`,
+			workflowId: SLOW_WORKFLOW_ID,
+			worktree: false,
+			cwd: repoDir,
+		});
+		const goalId = goal.id;
+		const gateId = "slow-gate";
+
+		const sm = gateway.sessionManager;
+		const harness = sm._verificationHarness;
+		expect(harness, "verification harness wired on session manager").toBeTruthy();
+
+		// Project-scoped gateStore — same one server.ts uses for duplicate detection.
+		const ctx = (sm.getProjectContextManager?.() ?? sm.projectContextManager).getContextForGoal(goalId);
+		expect(ctx, "project context for goal").toBeTruthy();
+		const gateStore = ctx.gateStore;
+
+		const zombieSignalId = `sig-zombie-${randomUUID()}`;
+		const startedAt = Date.now() - 60_000;
+
+		try {
+			// 2. Seed gateStore with a running signal at the current HEAD SHA.
+			//    This is what would have been persisted by the original (pre-kill)
+			//    gate_signal request.
+			gateStore.recordSignal({
+				id: zombieSignalId,
+				goalId,
+				gateId,
+				sessionId: "unknown",
+				timestamp: startedAt,
+				commitSha: headSha,
+				verification: {
+					status: "running",
+					startedAt,
+					steps: [{ name: "Slow check", type: "command", status: "running", startedAt }],
+				},
+			});
+
+			// 3. Seed the active-verifications.json file on disk shaped exactly
+			//    as the constructor-load path would produce on boot: command-
+			//    type step, `status: "running"`, no sessionId, no live pid
+			//    binding for THIS process.
+			const stateDir = path.join(gateway.bobbitDir, "state");
+			const persistPath = path.join(stateDir, "active-verifications.json");
+			const zombie = {
+				goalId,
+				gateId,
+				signalId: zombieSignalId,
+				overallStatus: "running",
+				startedAt,
+				currentPhase: 0,
+				steps: [
+					{
+						name: "Slow check",
+						type: "command",
+						status: "running",
+						startedAt,
+						// Note: NO sessionId (command steps never have one).
+						// pid + startTimeMs are present (production always writes them)
+						// but the pid is dead and bootEpoch doesn't match this process,
+						// so the alive-check must conclude the process is gone.
+						pid: deadPid(),
+						startTimeMs: startedAt,
+						bootEpoch: 1, // different from any plausible runtime bootEpoch
+						timeoutSec: 300,
+					},
+				],
+			};
+			// Merge with any existing persisted state (other tests in this worker
+			// may have unrelated entries — preserve them).
+			let existing: { verifications?: unknown[] } = { verifications: [] };
+			if (fs.existsSync(persistPath)) {
+				try { existing = JSON.parse(fs.readFileSync(persistPath, "utf-8")); } catch { /* ignore */ }
+			}
+			const merged = {
+				verifications: [...(existing.verifications ?? []).filter((v: any) => v?.signalId !== zombieSignalId), zombie],
+			};
+			fs.mkdirSync(stateDir, { recursive: true });
+			fs.writeFileSync(persistPath, JSON.stringify(merged, null, 2));
+
+			// 4. Mirror the constructor-load step: add the zombie to the live
+			//    in-memory map. This is what `new VerificationHarness(stateDir, ...)`
+			//    does at boot (verification-harness.ts ~line 1022).
+			harness.activeVerifications.set(zombieSignalId, zombie);
+
+			// Sanity: the duplicate-detection probe ALREADY sees this as dead
+			// thanks to the fix (areVerificationSessionsAlive layer-2 floor).
+			// Pre-fix, this would have returned true.
+			expect(
+				harness.areVerificationSessionsAlive(zombieSignalId),
+				"areVerificationSessionsAlive must NOT report a previous-boot zombie command step as alive",
+			).toBe(false);
+
+			// 5. Run the boot resume path. Post-fix, this synchronously removes
+			//    the zombie from `activeVerifications` AND rewrites the
+			//    persistence file with it gone.
+			await harness.resumeInterruptedVerifications();
+
+			expect(
+				harness.activeVerifications.has(zombieSignalId),
+				"resumeInterruptedVerifications must remove the zombie from the in-memory map",
+			).toBe(false);
+
+			if (fs.existsSync(persistPath)) {
+				const raw = fs.readFileSync(persistPath, "utf-8");
+				expect(
+					raw.includes(zombieSignalId),
+					`resumeInterruptedVerifications must purge the zombie from ${persistPath} — otherwise the next boot would reload it`,
+				).toBe(false);
+			}
+
+			// 6. Re-signal the same gate at the same SHA via the public HTTP API.
+			//    Pre-fix: HTTP 409 "Verification already in progress for this commit"
+			//    Post-fix: HTTP 201, a brand-new signalId, a fresh verification running.
+			const resignal = await apiFetch(`/api/goals/${goalId}/gates/${gateId}/signal`, {
+				method: "POST",
+				body: JSON.stringify({ content: "Re-signal after simulated restart" }),
+			});
+			if (resignal.status !== 201) {
+				const body = await resignal.text();
+				throw new Error(`re-signal expected 201, got ${resignal.status}: ${body}`);
+			}
+			const resignalBody = await resignal.json();
+			const newSignalId = resignalBody?.signal?.id;
+			expect(newSignalId, "new signal id returned").toBeTruthy();
+			expect(
+				newSignalId,
+				"re-signal must produce a fresh signal id, not echo the zombie",
+			).not.toBe(zombieSignalId);
+
+			// The zombie must not be reachable via the active verifications list
+			// any more — either the fresh verification replaced it, or both have
+			// already settled (the slow command is short enough that on fast
+			// machines it can complete before this assertion runs). What matters
+			// is that the zombie signal id is gone.
+			const liveActives = harness.getActiveVerifications(goalId);
+			expect(
+				liveActives.some((v: any) => v.signalId === zombieSignalId),
+				"zombie signal must not reappear in active verifications after re-signal",
+			).toBe(false);
+
+			// Clean up the slow verification we just kicked off so it doesn't
+			// keep running after the test.
+			await apiFetch(`/api/goals/${goalId}/gates/${gateId}/cancel-verification`, {
+				method: "POST",
+			}).catch(() => {});
+		} finally {
+			try { await deleteGoal(goalId); } catch { /* ignore */ }
+			try { fs.rmSync(repoDir, { recursive: true, force: true }); } catch { /* ignore */ }
+		}
+	});
+});

--- a/tests/e2e/verification-restart-resignal.spec.ts
+++ b/tests/e2e/verification-restart-resignal.spec.ts
@@ -178,7 +178,7 @@ test.describe("Verification lock after restart — re-signal is accepted", () =>
 						// so the alive-check must conclude the process is gone.
 						pid: deadPid(),
 						startTimeMs: startedAt,
-						bootEpoch: 1, // different from any plausible runtime bootEpoch
+						bootEpoch: "00000000-0000-0000-0000-000000000000", // different from any plausible runtime bootEpoch
 						timeoutSec: 300,
 					},
 				],

--- a/tests/verification-harness-restart.test.ts
+++ b/tests/verification-harness-restart.test.ts
@@ -144,6 +144,18 @@ test("resumeInterruptedVerifications removes failed-on-resume zombie entries fro
 		`zombie verification not cleaned up after resumeInterruptedVerifications — still present in activeVerifications: ${JSON.stringify(afterIds)}. This is the root cause of the HTTP 409 lock-after-restart bug.`,
 	);
 
+	// Pin the disk-side cleanup too: the persisted active-verifications.json
+	// must not still reference the zombie signal, or a subsequent boot would
+	// reload it and re-trigger the same HTTP 409 lock.
+	const persistPath = path.join(STATE_DIR, "active-verifications.json");
+	if (fs.existsSync(persistPath)) {
+		const raw = fs.readFileSync(persistPath, "utf-8");
+		assert.ok(
+			!raw.includes(SIGNAL_ID),
+			`zombie verification still present on disk in ${persistPath} after resumeInterruptedVerifications — next boot would reload it.`,
+		);
+	}
+
 	// And the duplicate-detection probe must now agree.
 	assert.strictEqual(
 		harness.areVerificationSessionsAlive(SIGNAL_ID),

--- a/tests/verification-harness-restart.test.ts
+++ b/tests/verification-harness-restart.test.ts
@@ -125,6 +125,81 @@ test("areVerificationSessionsAlive returns false for a zombie command step loade
 	);
 });
 
+test("resumeInterruptedVerifications finalizes a step as failed when pid is alive but startTimeMs indicates pid reuse", async () => {
+	// Pin the `pidLooksReused` safeguard inside _resumeCommandStep.
+	//
+	// Setup: persisted command step with this process's own pid (so the OS
+	// pid-existence probe in Case B says "alive"), bootEpoch matching the
+	// running harness (so `areVerificationSessionsAlive` would otherwise
+	// treat it as ours), and a `startTimeMs` so old that `Date.now() -
+	// startTimeMs > timeoutSec * 1000`. The original child cannot still be
+	// running — the step's own timeout would have killed it long ago — so
+	// the live pid must belong to a recycled, unrelated OS process. The
+	// resume path must finalize the step as failed (Case C), NOT enter
+	// Case B and poll until the deadline.
+	const persistPath = path.join(STATE_DIR, "active-verifications.json");
+	try { fs.unlinkSync(persistPath); } catch { /* ignore */ }
+
+	// First, construct a harness so we can read its bootEpoch.
+	const { harness } = makeHarness();
+	const bootEpoch = (harness as unknown as { bootEpoch: string }).bootEpoch;
+
+	const startedAt = Date.now() - 999_999; // ~16.6 min ago
+	const data = {
+		verifications: [
+			{
+				goalId: GOAL_ID,
+				gateId: GATE_ID,
+				signalId: SIGNAL_ID,
+				overallStatus: "running",
+				startedAt,
+				currentPhase: 0,
+				steps: [
+					{
+						name: "Recycled-pid check",
+						type: "command",
+						status: "running",
+						startedAt,
+						// `process.pid` is, by definition, a live OS pid (this test runner).
+						// It cannot be the original verification child — startTimeMs is
+						// older than the 300s step timeout — so it must be a recycled pid.
+						pid: process.pid,
+						startTimeMs: startedAt,
+						bootEpoch,
+						timeoutSec: 300,
+					},
+				],
+			},
+		],
+	};
+	fs.writeFileSync(persistPath, JSON.stringify(data, null, 2));
+
+	// Re-construct so the new disk fixture is loaded into activeVerifications.
+	const { harness: harness2 } = makeHarness();
+	// Use the same bootEpoch as the disk fixture so the resume path treats
+	// the persisted entry as something this process owns.
+	(harness2 as unknown as { bootEpoch: string }).bootEpoch = bootEpoch;
+
+	// Resume must finalize (not block until deadline). Wrap in a deadline
+	// guard so a regression doesn't hang the unit-test runner.
+	const resumePromise = harness2.resumeInterruptedVerifications();
+	const deadlineMs = 10_000;
+	const racer = new Promise<"timeout">(r => setTimeout(() => r("timeout"), deadlineMs));
+	const winner = await Promise.race([resumePromise.then(() => "ok" as const), racer]);
+	assert.notStrictEqual(
+		winner,
+		"timeout",
+		`resumeInterruptedVerifications did not finalize within ${deadlineMs}ms — pidLooksReused safeguard appears to be missing and Case B is polling for a live (recycled) pid until the step deadline.`,
+	);
+
+	// Verification must be cleaned up just like any other failed-on-resume zombie.
+	const remainingIds = harness2.getActiveVerifications().map(v => v.signalId);
+	assert.ok(
+		!remainingIds.includes(SIGNAL_ID),
+		`pid-reuse verification not cleaned up after resume — still present: ${JSON.stringify(remainingIds)}`,
+	);
+});
+
 test("resumeInterruptedVerifications removes failed-on-resume zombie entries from activeVerifications", async () => {
 	seedPersistedZombie();
 	const { harness } = makeHarness();

--- a/tests/verification-harness-restart.test.ts
+++ b/tests/verification-harness-restart.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Reproducing regression test for the verification-lock-after-restart bug.
+ *
+ * See goal "Unstick verification lock on restart" / Issue Analysis gate.
+ *
+ * Scenario: the gateway is killed while a command-type verification step is
+ * running. On restart, `.bobbit/state/active-verifications.json` is reloaded
+ * into `activeVerifications` with the step's persisted `status: "running"`
+ * and no `sessionId` (command steps don't have sessions). The next
+ * `gate_signal` on the same SHA then goes through the duplicate-detection
+ * path which calls `areVerificationSessionsAlive(signalId)`. That method
+ * currently treats `status === "running" && !sessionId` as "process is
+ * alive" and returns `true`, locking the gate behind HTTP 409 even though
+ * the child process is long dead.
+ *
+ * EXPECTED (post-fix):
+ *   - `areVerificationSessionsAlive(signalId) === false` for a zombie
+ *     command step loaded from disk in a brand-new harness process.
+ *   - After `resumeInterruptedVerifications()`, the entry is gone from the
+ *     in-memory `activeVerifications` map (`getActiveVerifications()`).
+ *
+ * CURRENT MASTER (failing): assertion 1 fails — the alive-check returns
+ * `true` because of the `!step.sessionId → return true` fast-path in
+ * `areVerificationSessionsAlive`.
+ *
+ * This test must FAIL on master and PASS once both bugs are fixed.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "verif-restart-test-"));
+const STATE_DIR = path.join(TEST_DIR, "state");
+fs.mkdirSync(STATE_DIR, { recursive: true });
+
+const { VerificationHarness } = await import("../src/server/agent/verification-harness.js");
+
+const SIGNAL_ID = "sig-zombie-1";
+const GOAL_ID = "goal-test";
+const GATE_ID = "implementation";
+
+/**
+ * Write a synthetic active-verifications.json containing one in-flight
+ * command-type verification with `status: "running"` and no `sessionId` —
+ * the exact shape a real gateway leaves on disk after being SIGKILLed
+ * mid-verification.
+ */
+function seedPersistedZombie(): void {
+	const persistPath = path.join(STATE_DIR, "active-verifications.json");
+	const startedAt = Date.now() - 60_000; // 1 min ago
+	const data = {
+		verifications: [
+			{
+				goalId: GOAL_ID,
+				gateId: GATE_ID,
+				signalId: SIGNAL_ID,
+				overallStatus: "running",
+				startedAt,
+				currentPhase: 0,
+				steps: [
+					{
+						name: "Long test",
+						type: "command",
+						status: "running",
+						startedAt,
+						// No sessionId — command steps never have one.
+					},
+				],
+			},
+		],
+	};
+	fs.writeFileSync(persistPath, JSON.stringify(data, null, 2));
+}
+
+/**
+ * Minimal stubs for the harness dependencies the resume/alive-check paths
+ * touch. We only need behaviour for: gate-store updates during resume (so
+ * resume doesn't throw) and project-context lookup (returns null so the
+ * resume path uses the non-PCM fallback gateStore).
+ */
+function makeHarness() {
+	const gateStoreCalls: any[] = [];
+	const stubGateStore = {
+		updateSignalVerification: (...args: any[]) => { gateStoreCalls.push({ kind: "updateSignalVerification", args }); },
+		updateGateStatus: (...args: any[]) => { gateStoreCalls.push({ kind: "updateGateStatus", args }); },
+		getGate: () => undefined,
+	} as any;
+
+	const roleStore = {
+		get: () => undefined,
+		getAll: () => [],
+	} as any;
+
+	const harness = new VerificationHarness(
+		STATE_DIR,
+		stubGateStore,                  // gateStore (fallback path)
+		() => {},                       // broadcastFn
+		roleStore,                      // roleStore
+		undefined,                      // preferencesStore
+		undefined,                      // sessionManager
+		undefined,                      // teamManager
+		undefined,                      // projectConfigStore
+		undefined,                      // projectContextManager (forces fallback gateStore)
+		undefined,                      // configCascade
+	);
+	return { harness, gateStoreCalls };
+}
+
+test("areVerificationSessionsAlive returns false for a zombie command step loaded from disk", () => {
+	seedPersistedZombie();
+	const { harness } = makeHarness();
+
+	// Constructor loads persisted entries into `activeVerifications` (see
+	// verification-harness.ts around line 904-906) so the alive-check sees
+	// the zombie immediately.
+	const alive = harness.areVerificationSessionsAlive(SIGNAL_ID);
+
+	assert.strictEqual(
+		alive,
+		false,
+		"areVerificationSessionsAlive should return false for a zombie command step loaded from a previous server lifetime — a persisted `status: \"running\"` flag with no sessionId is NOT proof the OS process is alive after restart.",
+	);
+});
+
+test("resumeInterruptedVerifications removes failed-on-resume zombie entries from activeVerifications", async () => {
+	seedPersistedZombie();
+	const { harness } = makeHarness();
+
+	// Sanity: the zombie is currently visible in the in-memory map.
+	const beforeIds = harness.getActiveVerifications().map(v => v.signalId);
+	assert.ok(
+		beforeIds.includes(SIGNAL_ID),
+		`pre-condition: zombie verification should be loaded into activeVerifications, got ${JSON.stringify(beforeIds)}`,
+	);
+
+	await harness.resumeInterruptedVerifications();
+
+	const afterIds = harness.getActiveVerifications().map(v => v.signalId);
+	assert.ok(
+		!afterIds.includes(SIGNAL_ID),
+		`zombie verification not cleaned up after resumeInterruptedVerifications — still present in activeVerifications: ${JSON.stringify(afterIds)}. This is the root cause of the HTTP 409 lock-after-restart bug.`,
+	);
+
+	// And the duplicate-detection probe must now agree.
+	assert.strictEqual(
+		harness.areVerificationSessionsAlive(SIGNAL_ID),
+		false,
+		"after resumeInterruptedVerifications, areVerificationSessionsAlive must return false for the cleaned-up signal",
+	);
+});


### PR DESCRIPTION
# Unstick verification lock on restart

## Problem

After a gateway restart killed an in-flight gate verification, subsequent `gate_signal` calls on the **same commit** were rejected with HTTP 409 `"Verification already in progress for this commit"` — even though nothing was actually running. The only workaround was `git commit --allow-empty --trailer "Co-Authored-By: Bobbit (Claude Opus 4 7) <bobbit@bobbit.ai>"&& git push && gate_signal`, which polluted goal branches with no-op commits and prevented a true retry on the same SHA.

Two cooperating bugs in `src/server/agent/verification-harness.ts`:
1. `areVerificationSessionsAlive` treated `status: "running" && !sessionId` as proof of liveness — true within one gateway lifetime, false after a restart.
2. `resumeInterruptedVerifications` marked the gate failed via the gate store but left the stale entry in `activeVerifications` and on disk, so the duplicate-detection check kept seeing a "running" verification.

## Fix — two layers

### Layer 1 — command subprocesses survive a gateway restart

- Command steps now spawn detached, with stdout/stderr redirected to per-step files (`<stepIdx>.out`, `<stepIdx>.err`) and a bash wrapper that atomically writes the exit code (`printf > .tmp && mv .tmp .exit`) so the exit file is durable even if the gateway is SIGKILLed.
- Each step persists `pid`, `startTimeMs`, `outFile`, `errFile`, `exitFile`, `bootEpoch`.
- New `_resumeCommandStep` covers three cases: (A) exit file present → finalize from recorded code, (B) pid alive + `startTimeMs` not stale → attach tail-follower (live `gate_verification_step_output` broadcast) and wait for exit file, (C) process dead → mark step failed.
- Cross-platform: Git Bash on Windows for the wrapper; docker-exec steps stay on attached pipe (no detached survival but safe fallback); `process.kill(pid, 0)` works on both POSIX and Windows.

### Layer 2 — correctness floor: if a step is truly dead, unstick the gate

- Per-harness-instance `bootEpoch = randomUUID()` stamped on each step at spawn.
- `areVerificationSessionsAlive` now requires `step.bootEpoch === this.bootEpoch && isPidAlive(step.pid)` for command steps. Persisted `running` from a previous process can never match.
- `resumeInterruptedVerifications` synchronously removes entries from `activeVerifications` AND rewrites/deletes the persistence file in a `finally` block before returning, so the duplicate-detection check has nothing stale to false-positive on.
- PID-reuse safeguard: cross-platform start-time tie-breaker — `Date.now() - step.startTimeMs > timeoutSec * 1000` ⇒ treat pid as reused/dead.
- 409 path in `server.ts` now logs signalId + per-step `bootEpoch`/`pid`/`sessionId` for future diagnosability.

## Tests

- **`tests/verification-harness-restart.test.ts`** — 3 unit tests pinning: (a) `areVerificationSessionsAlive` returns false for zombie from disk; (b) PID-reuse safety (alive pid + stale `startTimeMs` ⇒ finalize as failed); (c) `resumeInterruptedVerifications` removes failed entries from both memory and disk.
- **`tests/e2e/verification-restart-resignal.spec.ts`** — API E2E covering the HTTP round-trip: seed a zombie verification, fake a restart, re-signal the same SHA → assert HTTP 201 (not 409) and a fresh signal id.
- All existing unit + E2E tests pass.

## Documentation

- `docs/verification-restart.md` (new) — full design narrative (problem, two-layer fix, PID-reuse safeguard, cross-platform notes, out-of-scope items, code-location pointers).
- `docs/debugging.md` — new symptom→fix entry indexed by the 409 message.
- `docs/internals.md` — cross-link.

## Out of scope (intentional)

- Reviewer/agent-qa session resume (already worked via `_tryResumeFromSession`).
- Host reboot survival (only same-host gateway restart).
- Live WS broadcast for clients connected during the restart window — file content is captured but mid-stream WS subscribers may miss live tail before resume.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
