### PR TITLE
Allow removing all projects

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -28,7 +28,7 @@ Key behaviors:
 - **No default project.** Bobbit has no "default" project concept. On startup, the registry loads `projects.json` as-is - whatever is on disk, including zero projects. A fresh install is a valid state: the sidebar shows an Add Project CTA, and the toolbar **+ New Goal** button is disabled with tooltip "Add a project first" until at least one project is registered. Bobbit never implicitly registers a project based on the server CWD. `ProjectRegistry.ensureDefaultProject()` has been removed.
 - `register()` validates `rootPath` is absolute and exists on disk, checks for duplicate paths, and scaffolds `.bobbit/config/` and `.bobbit/state/` in the project directory if needed. `POST /api/projects` supports `upsert: true` - if a project already exists at the same `rootPath`, the existing project is returned (200) instead of a 400 error. This makes project registration idempotent.
 - `remove()` only unregisters - it does not delete files.
-- **Delete protection:** `DELETE /api/projects/:id` returns `400 {"error":"Cannot delete the last remaining project - add another project first"}` when deleting would leave zero projects. There is no hidden carve-out for a "first" or "CWD" project - every project can be removed as long as at least one other project remains. Under `BOBBIT_E2E=1`, `?force=1` bypasses the last-project guard for tests that need to exercise the zero-project UX.
+- **Removal:** `DELETE /api/projects/:id` always succeeds for non-hidden projects — there is no last-project guard, and there is no carve-out for a "first" or "CWD" project. When the last visible project is removed, the UI falls back to the existing zero-project first-run state. The hidden "system" project is unaffected by this flow.
 - The per-project settings page General tab exposes a "Remove Project" button in a Danger Zone section for every registered project. On confirmation, it calls `DELETE /api/projects/:id`, which invokes `remove()` and navigates the user back to system settings.
 - Persistence is atomic (write to `.tmp` then rename).
 
@@ -821,7 +821,7 @@ The per-project "+ goal" button on each project row bypasses the popover - the p
 | `POST` | `/api/projects` | Register a project (body: `name`, `rootPath`, optional `color`) |
 | `GET` | `/api/projects/:id` | Get a single project |
 | `PUT` | `/api/projects/:id` | Update name/color |
-| `DELETE` | `/api/projects/:id` | Unregister (blocked when it would leave zero projects; `?force=1` under `BOBBIT_E2E=1` bypasses) |
+| `DELETE` | `/api/projects/:id` | Unregister (does not delete files on disk); any project may be removed, including the last visible one |
 | `GET` | `/api/projects/:id/config` | Raw project-level config overrides |
 | `GET` | `/api/projects/:id/config/defaults` | Built-in defaults |
 | `PUT` | `/api/projects/:id/config` | Set/clear project config fields |

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -233,7 +233,7 @@ Routes accept both `/team/` and legacy `/swarm/` paths.
 | `POST` | `/api/projects/archive-bobbit` | Move existing `<rootPath>/.bobbit/` contents aside into `<rootPath>/.bobbit-archive-NNN/`, preserving `GATEWAY_OWNED_FILES` when the path is gateway-owned. Body: `{ rootPath }`. Does not mutate the registry. Returns 200 with `ArchiveResult`, 400 for bad input (`code: "bad-path"`), or 409 when `.bobbit/` is missing/empty (`code: "no-bobbit-dir"` / `"empty-bobbit-dir"`). See [add-project-preflight.md](add-project-preflight.md). |
 | `GET` | `/api/projects/:id` | Get a single project. |
 | `PUT` | `/api/projects/:id` | Update name/color. |
-| `DELETE` | `/api/projects/:id` | Unregister (does not delete files). Returns **400** `{"error":"Cannot delete the last remaining project — add another project first"}` when deleting would leave zero projects. Under `BOBBIT_E2E=1`, `?force=1` bypasses the guard for tests that need to exercise the zero-project UX. |
+| `DELETE` | `/api/projects/:id` | Unregister (does not delete files on disk). Any project may be removed, including the last visible one — when zero non-hidden projects remain, the UI falls back to the existing zero-project first-run state. The hidden "system" project is unaffected by this flow. |
 
 ### Project resolution contract
 

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -2662,7 +2662,6 @@ function renderProjectScopeTab(projectId: string) {
 
 function renderProjectGeneralTab(projectId: string) {
 	const project = (state.projects || []).find((p: any) => p.id === projectId);
-	const isDefault = state.projects?.[0]?.id === projectId;
 
 	// Reuse the per-project pending changes map for rootPath edits + sandbox config
 	if (!_projectScopePending.has(projectId)) _projectScopePending.set(projectId, {});
@@ -2737,29 +2736,27 @@ function renderProjectGeneralTab(projectId: string) {
 				</div>
 			` : ""}
 
-			${!isDefault ? html`
-				<hr class="border-border" />
-				<div class="flex flex-col gap-1">
-					<div class="text-[11px] text-muted-foreground uppercase tracking-wider font-medium">Danger Zone</div>
-				</div>
-				<div class="flex items-center gap-3">
-					<button
-						class="px-4 py-2 text-sm rounded-md border border-input bg-background text-foreground
-							hover:bg-destructive hover:text-destructive-foreground hover:border-destructive transition-colors"
-						@click=${async () => {
-							const ok = confirm("Remove project '" + (project?.name || "") + "' from this server? This won't delete any files on disk.");
-							if (!ok) return;
-							const success = await removeProject(projectId);
-							if (success) {
-								setProjects(await fetchProjects());
-								setHashRoute("settings", "system/general", true);
-								renderApp();
-							}
-						}}
-					>Remove Project</button>
-					<span class="text-xs text-muted-foreground">Unregister this project. No files will be deleted.</span>
-				</div>
-			` : ""}
+			<hr class="border-border" />
+			<div class="flex flex-col gap-1">
+				<div class="text-[11px] text-muted-foreground uppercase tracking-wider font-medium">Danger Zone</div>
+			</div>
+			<div class="flex items-center gap-3">
+				<button
+					class="px-4 py-2 text-sm rounded-md border border-input bg-background text-foreground
+						hover:bg-destructive hover:text-destructive-foreground hover:border-destructive transition-colors"
+					@click=${async () => {
+						const ok = confirm("Remove project '" + (project?.name || "") + "' from this server? This won't delete any files on disk.");
+						if (!ok) return;
+						const success = await removeProject(projectId);
+						if (success) {
+							setProjects(await fetchProjects());
+							setHashRoute("settings", "system/general", true);
+							renderApp();
+						}
+					}}
+				>Remove Project</button>
+				<span class="text-xs text-muted-foreground">Unregister this project. No files will be deleted.</span>
+			</div>
 		</div>
 	`;
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2240,19 +2240,13 @@ async function handleApiRoute(
 	}
 
 	// DELETE /api/projects/:id
+	//
+	// Any project may be removed, including the last visible one. When zero
+	// non-hidden projects remain the UI falls back to the existing
+	// zero-project first-run state (see GR-09 / splash-no-projects spec).
 	if (projectGetMatch && req.method === "DELETE") {
 		const projectId = projectGetMatch[1];
 		const project = projectRegistry.get(projectId);
-		// Test-only bypass: BOBBIT_E2E=1 + ?force=1 allows deleting the last
-		// project so GR-09 (zero-project first-run UX) can exercise the empty state.
-		const forceDelete = process.env.BOBBIT_E2E === "1" && url.searchParams.get("force") === "1";
-		// The synthetic "system" project (hidden) doesn't count toward the
-		// "at least one real project" guard.
-		const visibleCount = projectRegistry.list().filter(p => !p.hidden).length;
-		if (project && !project.hidden && visibleCount === 1 && !forceDelete) {
-			json({ error: "Cannot delete the last remaining project — add another project first" }, 400);
-			return;
-		}
 		try {
 			// Drain the project's worktree pool before removing
 			await sessionManager.removeWorktreePool(projectId);

--- a/tests/e2e/gateway-harness.ts
+++ b/tests/e2e/gateway-harness.ts
@@ -158,7 +158,7 @@ export const test = base.extend<{ failureContext: void }, { enableMcp: boolean; 
 		process.env.BOBBIT_AGENT_DIR = agentDir;
 		process.env.BOBBIT_SKIP_NPM_CI = "1";
 		process.env.BOBBIT_TEST_NO_PUSH = "1";
-		// Enable test-only bypass knobs (e.g. DELETE /api/projects/:id?force=1).
+		// Enable test-only bypass knobs used by various server paths.
 		process.env.BOBBIT_E2E = "1";
 		process.env.BOBBIT_LLM_REVIEW_SKIP = "1";
 		process.env.BOBBIT_NO_OPEN = "1";

--- a/tests/e2e/per-project-config-dirs.spec.ts
+++ b/tests/e2e/per-project-config-dirs.spec.ts
@@ -61,11 +61,10 @@ test.describe("Per-project Config Directories", () => {
 	// that assume a single-project state (e.g. the goal-form-tooltips spec
 	// reads `projects[0]` and the `startNewGoalFlow` button switches from
 	// auto-open to picker-popover when there's >1 project, breaking tests
-	// that don't handle the picker). Use `?force=1` because the test gateway
-	// runs with BOBBIT_E2E=1 which permits removing the last project.
+	// that don't handle the picker).
 	test.afterAll(async () => {
 		if (projectId) {
-			await apiFetch(`/api/projects/${projectId}?force=1`, { method: "DELETE" }).catch(() => {});
+			await apiFetch(`/api/projects/${projectId}`, { method: "DELETE" }).catch(() => {});
 		}
 	});
 

--- a/tests/e2e/project-config-api.spec.ts
+++ b/tests/e2e/project-config-api.spec.ts
@@ -37,7 +37,7 @@ async function registerTmpProject(name: string): Promise<{ id: string; cleanup: 
 	return {
 		id: proj.id,
 		cleanup: () => {
-			apiFetch(`/api/projects/${proj.id}?force=1`, { method: "DELETE" }).catch(() => {});
+			apiFetch(`/api/projects/${proj.id}`, { method: "DELETE" }).catch(() => {});
 			try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
 		},
 	};

--- a/tests/e2e/project-config-component-config.spec.ts
+++ b/tests/e2e/project-config-component-config.spec.ts
@@ -26,7 +26,7 @@ async function registerTmpProject(name: string): Promise<{ id: string; cleanup: 
 	return {
 		id: proj.id,
 		cleanup: () => {
-			apiFetch(`/api/projects/${proj.id}?force=1`, { method: "DELETE" }).catch(() => {});
+			apiFetch(`/api/projects/${proj.id}`, { method: "DELETE" }).catch(() => {});
 			try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
 		},
 	};
@@ -194,7 +194,7 @@ test.describe("Component config map (REST API)", () => {
 			expect(web, "component must be persisted on POST").toBeTruthy();
 			expect(web.config, "components[].config must round-trip through POST /api/projects").toEqual(components[0].config);
 		} finally {
-			if (projectId) await apiFetch(`/api/projects/${projectId}?force=1`, { method: "DELETE" }).catch(() => {});
+			if (projectId) await apiFetch(`/api/projects/${projectId}`, { method: "DELETE" }).catch(() => {});
 			try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
 		}
 	});

--- a/tests/e2e/project-config-native-yaml.spec.ts
+++ b/tests/e2e/project-config-native-yaml.spec.ts
@@ -35,7 +35,7 @@ async function registerTmpProject(name: string): Promise<{ id: string; rootPath:
 		id: proj.id,
 		rootPath: dir,
 		cleanup: () => {
-			apiFetch(`/api/projects/${proj.id}?force=1`, { method: "DELETE" }).catch(() => {});
+			apiFetch(`/api/projects/${proj.id}`, { method: "DELETE" }).catch(() => {});
 			try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
 		},
 	};
@@ -159,7 +159,7 @@ test.describe("Native-YAML project.yaml fields", () => {
 				const text = readFileSync(join(cfgDir, "project.yaml"), "utf-8");
 				expect(text).not.toMatch(/\[\{\\"/);
 			} finally {
-				await apiFetch(`/api/projects/${proj.id}?force=1`, { method: "DELETE" }).catch(() => {});
+				await apiFetch(`/api/projects/${proj.id}`, { method: "DELETE" }).catch(() => {});
 			}
 		} finally {
 			try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }

--- a/tests/e2e/project-delete-last.spec.ts
+++ b/tests/e2e/project-delete-last.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * API E2E — DELETE /api/projects/:id succeeds even when it is the last
+ * remaining (non-hidden) project.
+ *
+ * Previously the server returned 400 unless `BOBBIT_E2E=1 + ?force=1` was set.
+ * The guard has been removed: any project may be deleted; the UI falls back to
+ * the zero-project first-run state. This test pins the new behaviour.
+ */
+import { test, expect } from "./in-process-harness.js";
+import { apiFetch } from "./e2e-setup.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+async function listVisibleProjects(): Promise<Array<{ id: string; hidden?: boolean }>> {
+	const res = await apiFetch("/api/projects");
+	if (!res.ok) return [];
+	const body = await res.json();
+	const list: Array<{ id: string; hidden?: boolean }> = Array.isArray(body) ? body : (body.projects ?? []);
+	return list.filter(p => !p.hidden);
+}
+
+test.describe("DELETE /api/projects/:id — last project", () => {
+	test("plain DELETE (no ?force=1) succeeds even when it is the last visible project", async () => {
+		// Drain pre-existing visible projects so we set up a single-project state.
+		for (const p of await listVisibleProjects()) {
+			await apiFetch(`/api/projects/${p.id}`, { method: "DELETE" }).catch(() => {});
+		}
+		expect((await listVisibleProjects()).length, "drained to zero before seed").toBe(0);
+
+		// Seed exactly one fresh project.
+		const dir = mkdtempSync(join(tmpdir(), "bobbit-del-last-"));
+		try {
+			const createRes = await apiFetch("/api/projects", {
+				method: "POST",
+				body: JSON.stringify({ name: `del-last-${Date.now()}`, rootPath: dir }),
+			});
+			expect(createRes.status).toBe(201);
+			const proj = await createRes.json();
+
+			// One visible project now — exactly the case the old guard refused.
+			expect((await listVisibleProjects()).length).toBe(1);
+
+			// Plain DELETE with NO ?force=1. Must succeed.
+			const delRes = await apiFetch(`/api/projects/${proj.id}`, { method: "DELETE" });
+			expect(delRes.status).toBe(200);
+			const delBody = await delRes.json();
+			expect(delBody).toEqual({ ok: true });
+
+			// No non-hidden projects remain.
+			expect((await listVisibleProjects()).length).toBe(0);
+		} finally {
+			try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+		}
+	});
+});

--- a/tests/e2e/ui/add-project-flow.spec.ts
+++ b/tests/e2e/ui/add-project-flow.spec.ts
@@ -31,9 +31,9 @@ test.describe("Add Project flow (UI)", () => {
 		for (const p of projects) {
 			if (p.name === "default") continue;
 			// Some leaked projects are provisional (assistant sessions); some
-			// are promoted. force=1 bypasses the "can't remove last project"
-			// guard and is gated on BOBBIT_E2E=1 (set by the harness).
-			await apiFetch(`/api/projects/${p.id}?force=1`, { method: "DELETE" }).catch(() => {});
+			// are promoted. Plain DELETE works for any project, including the
+			// last visible one.
+			await apiFetch(`/api/projects/${p.id}`, { method: "DELETE" }).catch(() => {});
 		}
 	});
 

--- a/tests/e2e/ui/add-project-post-archive.spec.ts
+++ b/tests/e2e/ui/add-project-post-archive.spec.ts
@@ -56,7 +56,7 @@ test.describe("Add Project — post-archive routes to assistant", () => {
 		const projects = data.projects || data || [];
 		for (const p of projects) {
 			if (p.name === "default") continue;
-			await apiFetch(`/api/projects/${p.id}?force=1`, { method: "DELETE" }).catch(() => {});
+			await apiFetch(`/api/projects/${p.id}`, { method: "DELETE" }).catch(() => {});
 		}
 	});
 

--- a/tests/e2e/ui/add-project-preflight-directory-picker.spec.ts
+++ b/tests/e2e/ui/add-project-preflight-directory-picker.spec.ts
@@ -38,7 +38,7 @@ test.describe("Add Project — preflight panel via directory picker", () => {
 		const projects = data.projects || data || [];
 		for (const p of projects) {
 			if (p.name === "default") continue;
-			await apiFetch(`/api/projects/${p.id}?force=1`, { method: "DELETE" }).catch(() => {});
+			await apiFetch(`/api/projects/${p.id}`, { method: "DELETE" }).catch(() => {});
 		}
 	});
 

--- a/tests/e2e/ui/add-project-preflight.spec.ts
+++ b/tests/e2e/ui/add-project-preflight.spec.ts
@@ -81,7 +81,7 @@ test.describe("Add Project — preflight panel", () => {
 		const projects = data.projects || data || [];
 		for (const p of projects) {
 			if (p.name === "default") continue;
-			await apiFetch(`/api/projects/${p.id}?force=1`, { method: "DELETE" }).catch(() => {});
+			await apiFetch(`/api/projects/${p.id}`, { method: "DELETE" }).catch(() => {});
 		}
 	});
 

--- a/tests/e2e/ui/add-project-symlink.spec.ts
+++ b/tests/e2e/ui/add-project-symlink.spec.ts
@@ -67,7 +67,7 @@ test.describe("Add Project — symlink confirm flow", () => {
 		const projects = data.projects || data || [];
 		for (const p of projects) {
 			if (p.name === "default") continue;
-			await apiFetch(`/api/projects/${p.id}?force=1`, { method: "DELETE" }).catch(() => {});
+			await apiFetch(`/api/projects/${p.id}`, { method: "DELETE" }).catch(() => {});
 		}
 	});
 

--- a/tests/e2e/ui/multi-repo-flow.spec.ts
+++ b/tests/e2e/ui/multi-repo-flow.spec.ts
@@ -132,7 +132,7 @@ test.describe("multi-repo flow (UI)", () => {
 			await page.reload();
 			await expect(page.locator('[data-testid="component-card"]')).toHaveCount(3, { timeout: 10_000 });
 		} finally {
-			await apiFetch(`/api/projects/${project.id}?force=1`, { method: "DELETE" }).catch(() => {});
+			await apiFetch(`/api/projects/${project.id}`, { method: "DELETE" }).catch(() => {});
 			project.cleanup();
 		}
 	});
@@ -167,7 +167,7 @@ test.describe("multi-repo flow (UI)", () => {
 				.inputValue();
 			expect(reloadedValue).toBe("echo edited");
 		} finally {
-			await apiFetch(`/api/projects/${project.id}?force=1`, { method: "DELETE" }).catch(() => {});
+			await apiFetch(`/api/projects/${project.id}`, { method: "DELETE" }).catch(() => {});
 			project.cleanup();
 		}
 	});
@@ -197,7 +197,7 @@ test.describe("multi-repo flow (UI)", () => {
 			const data = await res.json();
 			expect(data.worktree_root).toBe(customRoot);
 		} finally {
-			await apiFetch(`/api/projects/${project.id}?force=1`, { method: "DELETE" }).catch(() => {});
+			await apiFetch(`/api/projects/${project.id}`, { method: "DELETE" }).catch(() => {});
 			project.cleanup();
 		}
 	});
@@ -229,7 +229,7 @@ test.describe("multi-repo flow (UI)", () => {
 			const data = await res.json();
 			expect(data.components.map((c: any) => c.name)).toEqual(["api", "web"]);
 		} finally {
-			await apiFetch(`/api/projects/${project.id}?force=1`, { method: "DELETE" }).catch(() => {});
+			await apiFetch(`/api/projects/${project.id}`, { method: "DELETE" }).catch(() => {});
 			project.cleanup();
 		}
 	});
@@ -298,7 +298,7 @@ test.describe("multi-repo flow (UI)", () => {
 				await apiFetch(`/api/goals/${goal.id}`, { method: "DELETE" });
 			}
 		} finally {
-			await apiFetch(`/api/projects/${project.id}?force=1`, { method: "DELETE" }).catch(() => {});
+			await apiFetch(`/api/projects/${project.id}`, { method: "DELETE" }).catch(() => {});
 			project.cleanup();
 		}
 	});
@@ -327,7 +327,7 @@ test.describe("multi-repo flow (UI)", () => {
 			// goal-form indicator in the same suite would duplicate that
 			// browser-render concern without adding signal.
 		} finally {
-			await apiFetch(`/api/projects/${project.id}?force=1`, { method: "DELETE" }).catch(() => {});
+			await apiFetch(`/api/projects/${project.id}`, { method: "DELETE" }).catch(() => {});
 			project.cleanup();
 		}
 	});

--- a/tests/e2e/ui/per-project-native-yaml-fields.spec.ts
+++ b/tests/e2e/ui/per-project-native-yaml-fields.spec.ts
@@ -44,7 +44,7 @@ async function registerProject(name: string): Promise<{ id: string; rootPath: st
 		id: project.id,
 		rootPath,
 		cleanup: () => {
-			apiFetch(`/api/projects/${project.id}?force=1`, { method: "DELETE" }).catch(() => {});
+			apiFetch(`/api/projects/${project.id}`, { method: "DELETE" }).catch(() => {});
 			try { rmSync(rootPath, { recursive: true, force: true }); } catch { /* ignore */ }
 		},
 	};

--- a/tests/e2e/ui/preparing-ux.spec.ts
+++ b/tests/e2e/ui/preparing-ux.spec.ts
@@ -60,7 +60,7 @@ test.describe("Preparing UX (worktree-backed session)", () => {
 	test.afterAll(async () => {
 		delete process.env.BOBBIT_TEST_PREPARING_DELAY_MS;
 		if (projectId) {
-			await apiFetch(`/api/projects/${projectId}?force=1`, { method: "DELETE" }).catch(() => {});
+			await apiFetch(`/api/projects/${projectId}`, { method: "DELETE" }).catch(() => {});
 		}
 	});
 

--- a/tests/e2e/ui/project-removal.spec.ts
+++ b/tests/e2e/ui/project-removal.spec.ts
@@ -1,8 +1,9 @@
 /**
  * E2E tests: Remove Project button in per-project settings.
  *
- * Tests that a non-default project can be removed via the settings page,
- * and that the default project does NOT show a remove button.
+ * Every project (including the first/"default" one) shows a Remove Project
+ * button. Verified more directly by `remove-first-project.spec.ts`; this
+ * spec covers the happy-path removal flow.
  */
 import { test, expect } from "../gateway-harness.js";
 import { apiFetch } from "../e2e-setup.js";
@@ -63,21 +64,4 @@ test.describe("Remove Project button", () => {
 		await expect(sidebar.getByText("Removable Project")).not.toBeVisible({ timeout: 3_000 });
 	});
 
-	test("default project does not show Remove Project button", async ({ page }) => {
-		// Get the default project (first in the list)
-		const res = await apiFetch("/api/projects");
-		const projects = await res.json();
-		const defaultProject = projects[0];
-		expect(defaultProject).toBeDefined();
-
-		await openApp(page);
-		await navigateToHash(page, `#/settings/${defaultProject.id}/general`);
-
-		// Wait for settings content to load
-		await expect(page.locator("h1").filter({ hasText: "Settings" })).toBeVisible({ timeout: 15_000 });
-
-		// Remove button should NOT be present for the default project
-		const removeBtn = page.getByRole("button", { name: "Remove Project" });
-		await expect(removeBtn).not.toBeVisible();
-	});
 });

--- a/tests/e2e/ui/remove-first-project.spec.ts
+++ b/tests/e2e/ui/remove-first-project.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * Browser E2E — the Remove Project button renders for every project in the
+ * Settings → (project) → General → Danger Zone, regardless of its position
+ * in the project list. Previously the project at index 0 was excluded.
+ *
+ * Pattern: navigate → happy path → assert removal in sidebar.
+ */
+import { test, expect } from "../gateway-harness.js";
+import { apiFetch } from "../e2e-setup.js";
+import { openApp, navigateToHash } from "./ui-helpers.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+async function listVisibleProjects(): Promise<Array<{ id: string; name: string; hidden?: boolean }>> {
+	const res = await apiFetch("/api/projects");
+	if (!res.ok) return [];
+	const body = await res.json();
+	const list: Array<{ id: string; name: string; hidden?: boolean }> = Array.isArray(body) ? body : (body.projects ?? []);
+	return list.filter(p => !p.hidden);
+}
+
+test.describe("Settings → Remove Project (any position)", () => {
+	test("first project in list shows Remove Project button and removing it succeeds", async ({ page }) => {
+		// Drain any pre-existing projects so we know the exact list ordering.
+		for (const p of await listVisibleProjects()) {
+			await apiFetch(`/api/projects/${p.id}`, { method: "DELETE" }).catch(() => {});
+		}
+
+		const tmpDirs: string[] = [];
+		try {
+			const dirA = mkdtempSync(join(tmpdir(), "bobbit-rm-first-a-"));
+			const dirB = mkdtempSync(join(tmpdir(), "bobbit-rm-first-b-"));
+			tmpDirs.push(dirA, dirB);
+
+			const nameA = `rm-first-A-${Date.now()}`;
+			const nameB = `rm-first-B-${Date.now()}`;
+			const projA = await apiFetch("/api/projects", {
+				method: "POST",
+				body: JSON.stringify({ name: nameA, rootPath: dirA }),
+			}).then(r => r.json());
+			const projB = await apiFetch("/api/projects", {
+				method: "POST",
+				body: JSON.stringify({ name: nameB, rootPath: dirB }),
+			}).then(r => r.json());
+
+			// Determine which project the client sees at index 0 — that is the
+			// one the old `isDefault` gate excluded. Server returns the registry
+			// list in insertion order; the client mirrors it.
+			const all = await listVisibleProjects();
+			const firstId = all[0]?.id;
+			expect(firstId, "projects[0].id should be present").toBeTruthy();
+			expect([projA.id, projB.id]).toContain(firstId);
+			const firstName = firstId === projA.id ? nameA : nameB;
+			const otherName = firstId === projA.id ? nameB : nameA;
+
+			await openApp(page);
+
+			// Navigate to the General tab of the first project.
+			await navigateToHash(page, `#/settings/${firstId}/general`);
+			await expect(page.locator("h1").filter({ hasText: "Settings" })).toBeVisible({ timeout: 10_000 });
+
+			// The Remove Project button must be visible and enabled — this is
+			// the regression: previously it was hidden for state.projects[0].
+			const removeBtn = page.locator("button").filter({ hasText: "Remove Project" });
+			await expect(removeBtn).toBeVisible({ timeout: 10_000 });
+			await expect(removeBtn).toBeEnabled();
+
+			// Stub window.confirm so the click proceeds.
+			await page.evaluate(() => { (window as any).confirm = () => true; });
+
+			// Watch for any error dialogs that would indicate a failed delete.
+			const errorDialogs: string[] = [];
+			page.on("dialog", async d => {
+				if (d.type() === "alert") errorDialogs.push(d.message());
+				await d.dismiss().catch(() => {});
+			});
+
+			await removeBtn.click();
+
+			// The deleted project disappears from /api/projects; the other remains.
+			await expect.poll(async () =>
+				(await listVisibleProjects()).map(p => p.name),
+				{ timeout: 10_000 },
+			).not.toContain(firstName);
+
+			const remaining = (await listVisibleProjects()).map(p => p.name);
+			expect(remaining).toContain(otherName);
+			expect(errorDialogs, "no error alerts should fire").toEqual([]);
+		} finally {
+			// Cleanup: remove anything still registered.
+			for (const p of await listVisibleProjects()) {
+				await apiFetch(`/api/projects/${p.id}`, { method: "DELETE" }).catch(() => {});
+			}
+			for (const d of tmpDirs) {
+				try { rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+			}
+		}
+	});
+});

--- a/tests/e2e/ui/splash-no-projects.spec.ts
+++ b/tests/e2e/ui/splash-no-projects.spec.ts
@@ -16,7 +16,7 @@ test.describe("Splash screen — 0 projects", () => {
 		// Remove the harness-registered "default" project so the splash sees zero projects.
 		const list = await apiFetch("/api/projects").then(r => r.json()) as Array<{ id: string }>;
 		for (const p of list) {
-			await apiFetch(`/api/projects/${p.id}?force=1`, { method: "DELETE" });
+			await apiFetch(`/api/projects/${p.id}`, { method: "DELETE" });
 		}
 
 		// Reload so the client picks up the empty project list.
@@ -55,7 +55,7 @@ test.describe("Splash screen — 0 projects", () => {
 		await openApp(page);
 		const list = await apiFetch("/api/projects").then(r => r.json()) as Array<{ id: string }>;
 		for (const p of list) {
-			await apiFetch(`/api/projects/${p.id}?force=1`, { method: "DELETE" });
+			await apiFetch(`/api/projects/${p.id}`, { method: "DELETE" });
 		}
 		await page.reload();
 

--- a/tests/e2e/ui/stories-goal-routing.spec.ts
+++ b/tests/e2e/ui/stories-goal-routing.spec.ts
@@ -56,18 +56,18 @@ async function registerProject(name: string, rootPath: string): Promise<TestProj
 	return { id: body.id, name: body.name, rootPath };
 }
 
-async function deleteProject(id: string, opts: { force?: boolean } = {}): Promise<void> {
-	const qs = opts.force ? "?force=1" : "";
-	await apiFetch(`/api/projects/${id}${qs}`, { method: "DELETE" }).catch(() => {});
+async function deleteProject(id: string, _opts: { force?: boolean } = {}): Promise<void> {
+	await apiFetch(`/api/projects/${id}`, { method: "DELETE" }).catch(() => {});
 }
 
 /**
- * Force-delete every registered project. Uses the BOBBIT_E2E=1 ?force=1 bypass
- * so it can also remove the last remaining project (needed for GR-09).
+ * Delete every registered project, including the last one. Plain DELETE
+ * works unconditionally; the GR-09 zero-project first-run UX is reached by
+ * simply removing all projects.
  */
 async function forceDeleteAllProjects(): Promise<void> {
 	const projects = await listProjects();
-	for (const p of projects) await deleteProject(p.id, { force: true });
+	for (const p of projects) await deleteProject(p.id);
 }
 
 async function listProjects(): Promise<Array<{ id: string; name: string; rootPath: string }>> {
@@ -468,8 +468,7 @@ test.describe("CT-19: First-run and single-project UX @quarantine", () => {
 	test("GR-09: First-run zero-project UX disables New Goal", async () => {
 		s.begin(STORY_GR09);
 
-		// Force-delete every project (uses BOBBIT_E2E=1 ?force=1 bypass) so we
-		// can exercise the literal zero-project state.
+		// Delete every project so we can exercise the literal zero-project state.
 		await forceDeleteAllProjects();
 
 		s.act();

--- a/tests/e2e/ui/tool-assistant-system-scope.spec.ts
+++ b/tests/e2e/ui/tool-assistant-system-scope.spec.ts
@@ -20,7 +20,7 @@ test.describe("Tools page — New Tool with system scope", () => {
 		// path doesn't depend on any real project being registered.
 		const list = await apiFetch("/api/projects").then(r => r.json()) as Array<{ id: string }>;
 		for (const p of list) {
-			await apiFetch(`/api/projects/${p.id}?force=1`, { method: "DELETE" });
+			await apiFetch(`/api/projects/${p.id}`, { method: "DELETE" });
 		}
 
 		await navigateToHash(page, "#/tools");


### PR DESCRIPTION
Fixes the inability to remove the first/last project. Two related bugs:

1. **UI** — Settings → (any project) → General → Danger Zone hid the "Remove Project" button on `state.projects[0]`, so the project that happened to sit first in the list was never removable.
2. **Server** — `DELETE /api/projects/:id` returned 400 when deleting would leave zero visible projects, with a `BOBBIT_E2E=1 + ?force=1` test bypass.

## Changes

- `src/app/settings-page.ts` — drop the `isDefault` gate; Remove Project renders for every non-hidden project.
- `src/server/server.ts` — drop the `visibleCount === 1` guard and the `BOBBIT_E2E`/`?force=1` bypass. `DELETE /api/projects/:id` now always succeeds for non-hidden projects; the existing zero-project first-run UI handles the empty state. Hidden "system" project handling unchanged.
- New API E2E: `tests/e2e/project-delete-last.spec.ts`.
- New browser E2E: `tests/e2e/ui/remove-first-project.spec.ts`.
- Removed `?force=1` from ~25 DELETE cleanup sites across 15 spec files; simplified `forceDeleteAllProjects` helper in `stories-goal-routing.spec.ts`. Dropped the stale "default project does not show Remove Project button" pinning test.
- Docs (`docs/internals.md`, `docs/rest-api.md`) updated to reflect the removed guard.

## Validation

- `npm run check`, `npm run build`, `npm run test:unit` pass.
- Full `npm run test:e2e` passes (1017/1024 passed, 6 skipped, 9 flaky-recovered, 0 failed on the final run).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)