### PR TITLE
Compaction widget polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ tests/fixtures/markdown-throttle-bundle.js
 tests/fixtures/markdown-throttle-bundle.css
 tests/fixtures/bash-renderer-bundle.js
 tests/fixtures/bash-renderer-bundle.css
+tests/fixtures/compaction-widget-bundle.js
+tests/fixtures/compaction-widget-bundle.css
 tests/fixtures/ask-user-choices-renderer-bundle.js
 tests/fixtures/ask-user-choices-renderer-bundle.css
 tests/fixtures/settings-models-tab-bundle.js

--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -13,21 +13,31 @@ live in [internals.md](internals.md).
 
 ## Triggers
 
-Compaction has two entrypoints on the client:
+Compaction has three entrypoints on the client, distinguished by the
+upstream event's `reason` field:
 
-- **Manual** — the user types `/compact` in the prompt box. The slash
-  command appends a `compact_cmd_*` user message, starts the blob squash
-  animation, and RPC-calls the server's `compactRpc`. Wired in
-  `src/ui/components/AgentInterface.ts` (`/compact` handler) and
-  `src/server/agent/rpc-bridge.ts` (`compactRpc`).
-- **Auto** — the agent subprocess emits `auto_compaction_start` when its
-  pre-turn budget check decides another turn would blow the context window.
-  Handled in `src/app/remote-agent.ts` alongside the manual path; the client
-  normalises `auto_compaction_*` events into the same `compaction_start` /
-  `compaction_end` shape so downstream code does not have to fork.
+- **Manual** (`reason: "manual"`) — the user types `/compact` in the prompt
+  box. The slash command appends a `compact_cmd_*` user message, starts
+  the blob squash animation, and RPC-calls the server's `compactRpc`.
+  Wired in `src/ui/components/AgentInterface.ts` (`/compact` handler) and
+  `src/server/agent/rpc-bridge.ts` (`compactRpc`). The server's WS
+  handler stamps `reason: "manual"` on both `compaction_start` and
+  `compaction_end` broadcasts so the client distinguishes this path from
+  the auto / overflow paths uniformly.
+- **Auto** (`reason: "threshold"`) — the agent subprocess decides on its
+  own that another turn would blow the context window and emits
+  `compaction_start` with `reason: "threshold"`. Maps to `trigger: "auto"`
+  on the card.
+- **Overflow** (`reason: "overflow"`) — the agent ran a turn anyway and
+  the model returned a context-limit error (e.g. Anthropic's
+  `prompt is too long: N tokens > M maximum`). The agent auto-compacts to
+  recover and emits `reason: "overflow"`. Maps to `trigger: "overflow"` on
+  the card, displayed as the `context limit` pill.
 
-Both paths end with the same `compaction_end` event carrying
-`tokensBefore`, a `success` flag, and (on failure) an `error` string.
+Both paths end with the same `compaction_end` event carrying `reason`,
+an optional `result.tokensBefore`, an `aborted` / `success` flag, and
+(on failure) an `errorMessage` string. The client maps `reason` to the
+payload's `trigger` field in `src/app/remote-agent.ts::_triggerFromEvent`.
 
 ## The rich summary card
 
@@ -69,7 +79,8 @@ emits these stable selectors so e2e tests do not have to match on text:
 | `[data-test="tokens-before"]` | Before-token value. |
 | `[data-test="tokens-after"]` | After-token value (or em-dash). |
 | `[data-test="reduction-pct"]` | Reduction badge (when known). |
-| `[data-test="trigger"]` | Trigger pill — text content is `manual` or `auto`. |
+| `[data-test="trigger"]` | Trigger pill — text content is `manual`, `auto`, or `context limit` (overflow). |
+| `[data-state]` (on card root) | Lifecycle state — `in-progress`, `complete`, or `error`. Same DOM node carries the card across the entire lifecycle (see *Single-card lifecycle* below). |
 | `[data-test="verdict"]` | Tick or cross icon. |
 
 ### Payload shape
@@ -80,7 +91,11 @@ The payload type and envelope builder live in
 ```ts
 interface CompactionSummaryPayload {
   schemaVersion: 1;
-  trigger: "manual" | "auto";
+  trigger: "manual" | "auto" | "overflow";
+  state?: "in-progress" | "complete" | "error";  // drives renderer branch;
+                                                 // older payloads omit it —
+                                                 // renderer falls back to
+                                                 // deriving from `success`
   success: boolean;
   timestamp: string;            // ISO-8601
   tokensBefore: number | null;
@@ -90,6 +105,34 @@ interface CompactionSummaryPayload {
   error?: string;               // failure detail
 }
 ```
+
+### Single-card lifecycle
+
+The card transitions in place across `in-progress → complete | error`
+rather than being torn down and rebuilt. The synthetic assistant message
+uses a fixed id, `COMPACTION_ACTIVE_ID = "compact_active"` (exported from
+`compaction-types.ts`), and the reducer's `compaction-placeholder` and
+`compaction-result` cases both filter out any prior row with that id
+before appending. Lit then diffs to the same DOM node, repainting only
+the card body — there is never a plaintext `"Compacting context…"` row
+in the transcript. Pinned by `tests/message-reducer.test.ts` case 12d
+and `tests/e2e/ui/compaction-widget.spec.ts`.
+
+### Overflow `tokensBefore` resolution
+
+`remote-agent.ts`'s `compaction_end` handler resolves `tokensBefore` in
+priority order — first non-null wins:
+
+1. `event.result.tokensBefore` — agent-emitted on auto / overflow end.
+2. `event.tokensBefore` — server-emitted on the manual `/compact` path.
+3. `parseOverflowTokenCount(event.errorMessage)` — extracts the leading
+   integer from an Anthropic-shaped error via `/(\d{4,})\s*tokens\s*>/i`.
+4. `this._lastKnownContextTokens` — last-seen live count, kept current
+   as the in-progress payload is built.
+
+This means `reductionPct` now resolves for overflow as well, where v1
+left it uniformly `null`. Pinned by `tests/compaction-types.test.ts`
+and reducer case 12e.
 
 `schemaVersion: 1` is reserved for forward compatibility — bump it if a
 future renderer adds fields that older snapshots cannot supply.
@@ -142,9 +185,10 @@ row preserves position and id while attaching whatever structure can be
 recovered from the text.
 
 These invariants are pinned by `tests/message-reducer.test.ts` cases 12,
-12b, and 12c. The text-prefix parser is intentionally coupled to the
-pi-coding-agent transcript format; case 12c's token-value assertion is
-the regression sentinel if that format ever changes.
+12b, 12c, 12d (in-place lifecycle transition), and 12e (overflow trigger
++ tokensBefore propagation). The text-prefix parser is intentionally
+coupled to the pi-coding-agent transcript format; case 12c's token-value
+assertion is the regression sentinel if that format ever changes.
 
 ## Tests
 
@@ -199,11 +243,14 @@ npm run test:manual
 | Concern | File |
 | --- | --- |
 | Payload type + envelope builder + reload-upgrade helpers | `src/app/compaction-types.ts` |
-| Live emission (manual + auto) | `src/app/remote-agent.ts` — `compaction_end` / `auto_compaction_end` |
-| Reducer (placeholder, result, snapshot dedup, reload upgrade) | `src/app/message-reducer.ts` — `compaction-result` and `snapshot` cases |
-| Renderer | `src/ui/tools/renderers/CompactionSummaryRenderer.ts` |
+| Live emission (manual / auto / overflow) | `src/app/remote-agent.ts` — `compaction_start` / `compaction_end` handlers, `_triggerFromEvent`, `_lastKnownContextTokens` |
+| Server-side manual broadcast | `src/server/ws/handler.ts` — emits `reason: "manual"` on the manual `/compact` path |
+| Reducer (in-progress, result, snapshot dedup, reload upgrade) | `src/app/message-reducer.ts` — `compaction-placeholder`, `compaction-result`, and `snapshot` cases |
+| Renderer (three states + adjacent layout + overflow pill) | `src/ui/tools/renderers/CompactionSummaryRenderer.ts` |
 | Renderer registration | `src/ui/tools/index.ts` — `__compaction_summary` |
-| Reducer unit tests | `tests/message-reducer.test.ts` — cases 12, 12b, 12c |
+| Helper unit tests | `tests/compaction-types.test.ts` — `parseOverflowTokenCount`, in-progress builder, stable id |
+| Reducer unit tests | `tests/message-reducer.test.ts` — cases 12, 12b, 12c, 12d, 12e |
+| Browser E2E (renderer lifecycle, file:// harness) | `tests/e2e/ui/compaction-widget.spec.ts`, `tests/fixtures/compaction-widget.html` |
 | Real-LLM e2e | `tests/compaction.spec.ts`, `tests/playwright-e2e.config.ts` |
 | Manual-integration pressure test | `tests/manual-integration/compaction-pressure.spec.ts` |
 | Full design rationale | `docs/design/compaction-e2e-rich-summary.md` |

--- a/docs/design/compaction-e2e-rich-summary.md
+++ b/docs/design/compaction-e2e-rich-summary.md
@@ -842,3 +842,132 @@ Edits required:
 
 No changes required in `src/server/` or `defaults/tools/`. No description
 budget impact. No new MCP / agent‑facing tool.
+
+---
+
+## 7. Polish revision (goal: compaction-ceff5514)
+
+Follow‑up to the merged PR #560. Real overflow‑triggered compactions exposed
+four defects in the v1 card; this revision is pure polish + a lifecycle
+upgrade. The payload schema and renderer registration are unchanged in
+shape — the type union widened and one field was added. No revert.
+
+### 7.1 Defects fixed
+
+1. **`tokensBefore` null on overflow.** The Anthropic 400 (`prompt is too
+   long: 202592 tokens > 200000 maximum`) carries the exact count we want
+   to display, but it was being discarded. Fixed via a resolution chain in
+   `src/app/remote-agent.ts` (see §7.3) plus a parser in
+   `src/app/compaction-types.ts::parseOverflowTokenCount`.
+2. **Label and value far apart.** The v1 card stretched each metric label
+   to the row start and its value to the row end, making the eye scan the
+   full card width. The grid in `CompactionSummaryRenderer.ts` was
+   tightened so label + value sit adjacent.
+3. **Overflow rendered as `manual`.** Trigger was hard‑coded from the
+   client event name. A third trigger value was added (see §7.2) and
+   plumbed from the server / agent event source through to the pill.
+4. **In‑progress was plaintext.** A synthetic assistant message containing
+   `"Compacting context…"` was inserted at compaction start. Replaced with
+   a rendered in‑progress card (spinner + indeterminate progress bar) that
+   transitions in place to `complete` or `error` (§7.4).
+
+### 7.2 Payload extensions
+
+`CompactionSummaryPayload` in `src/app/compaction-types.ts` gained:
+
+- `state?: "in-progress" | "complete" | "error"` — drives the renderer
+  branch. Older persisted payloads (pre‑polish snapshots) omit it; the
+  renderer falls back to deriving `complete | error` from `success`.
+- `trigger` union widened from `"manual" | "auto"` to add `"overflow"`.
+  The renderer pill displays `"context limit"` and tints with
+  `color-mix(in oklch, var(--warning) 14%, transparent)` / `var(--warning)`
+  for overflow (`CompactionSummaryRenderer.ts::triggerLabel` and
+  `triggerStyle`). `manual` and `auto` retain their existing styling.
+
+`success` is preserved as the boolean mirror of `state === "complete"` so
+the reload‑path upgrade adapter (case 12c) and any back‑compat snapshot
+readers keep working unchanged.
+
+### 7.3 `tokensBefore` resolution chain
+
+In `remote-agent.ts`'s `compaction_end` / `auto_compaction_end` handler
+the value is resolved in priority order — first non‑null wins:
+
+1. `event.result.tokensBefore` — agent‑emitted (auto / overflow end).
+2. `event.tokensBefore` — server‑emitted on the manual `/compact` path
+   (`src/server/ws/handler.ts`, `compaction_end` broadcast).
+3. `parseOverflowTokenCount(errMsg)` — extracts the leading integer from
+   the error string. Regex pinned to the Anthropic shape
+   `/(\d{4,})\s*tokens\s*>/i`.
+4. `this._lastKnownContextTokens` — last‑seen live context count,
+   maintained as the in‑progress payload is built so it survives even
+   when the server never broadcast a fresh count.
+
+This means `reductionPct` now resolves for overflow as well, where it was
+uniformly `null` before.
+
+### 7.4 Single‑card lifecycle via stable id
+
+UX invariant: one DOM node carries the compaction widget for its entire
+lifecycle (`in-progress → complete | error`). Pinned by two artefacts:
+
+- `COMPACTION_ACTIVE_ID = "compact_active"` exported from
+  `compaction-types.ts`. The in‑progress emission, the success replacement,
+  and the failure replacement all set `message.id` to this value and use
+  `compaction-summary:compact_active` for the inner `toolCall.id`.
+- The reducer's `compaction-result` case filters by
+  `m.id !== COMPACTION_ACTIVE_ID` before appending the new entry, so the
+  in‑progress row is removed and the completion row takes its slot in
+  the message list. Lit then diffs to the same DOM node and only re‑paints
+  the card body.
+
+The plaintext `"Compacting context…"` injection in `remote-agent.ts` is
+gone; the in‑progress emission now goes through
+`buildInProgressCompactionPayload(trigger, tokensBefore)` and routes the
+same `__compaction_summary` synthetic tool as completion.
+
+**Pinning tests** for this invariant:
+
+- `tests/message-reducer.test.ts` case (12d) — in‑progress synthetic
+  transitions in place on result; asserts exactly one row with id
+  `compact_active` survives across the two‑step sequence.
+- `tests/message-reducer.test.ts` case (12) — rich in‑progress placeholder
+  carries no plaintext (no `"Compacting context…"` string anywhere).
+- `tests/message-reducer.test.ts` case (12e) — overflow trigger survives
+  the reducer round‑trip with `tokensBefore` parsed from the error.
+- Browser E2E `tests/e2e/ui/compaction-widget.spec.ts` drives the renderer
+  through `in-progress → complete` and `in-progress → error (overflow)`,
+  asserting single‑card DOM identity, absence of the plaintext string in
+  the transcript at any point, and that the trigger pill text matches the
+  trigger value.
+
+### 7.5 Server‑side `reason` plumbing
+
+The manual `/compact` RPC handler in `src/server/ws/handler.ts` now tags
+both `compaction_start` and `compaction_end` broadcasts with
+`reason: "manual"`. The client (`remote-agent.ts`) maps the inbound
+`reason` to the payload's `trigger` — defaulting to `"manual"` on the
+manual path, `"auto"` on agent‑initiated `auto_compaction_*` events, and
+`"overflow"` when `reason === "overflow"` (or, defensively, when the
+error string matches the overflow shape).
+
+This makes the trigger source authoritative at the boundary it originates
+from, rather than being inferred from the event name. The previous code
+path at `remote-agent.ts` derived `trigger` from `event.type` alone, which
+is why overflow was misclassified as `manual`.
+
+### 7.6 Files touched
+
+| File | Edit |
+|---|---|
+| `src/app/compaction-types.ts` | `state` field; `"overflow"` trigger; `COMPACTION_ACTIVE_ID`; `buildInProgressCompactionPayload`; `parseOverflowTokenCount`. |
+| `src/app/remote-agent.ts` | Drop plaintext placeholder; emit in‑progress synthetic; tokensBefore resolution chain; trigger from `event.reason`. |
+| `src/app/message-reducer.ts` | `compaction-result` filters by stable id; in‑progress fold path. |
+| `src/ui/tools/renderers/CompactionSummaryRenderer.ts` | Three‑state branch (in‑progress / complete / error); tightened label+value layout; `overflow` pill styling via `--warning`. |
+| `src/server/ws/handler.ts` | `reason: "manual"` on `compaction_start` / `compaction_end` broadcasts. |
+| `tests/message-reducer.test.ts` | New cases (12), (12d), (12e); existing (12b), (12c) retained. |
+| `tests/e2e/ui/compaction-widget.spec.ts` | **New** — `file://` fixture driving both lifecycle paths. |
+
+No description‑budget impact (the renderer remains UI‑only synthetic
+per §2.7). No reducer action shape changes beyond the existing
+`compaction-result`.

--- a/src/app/compaction-types.ts
+++ b/src/app/compaction-types.ts
@@ -12,7 +12,7 @@
  * (`COMPACTION_ACTIVE_ID = "compact_active"`) across the whole lifecycle
  * (in-progress → complete | error). The reducer filters by that id so the
  * Lit render keeps the same DOM node and only re-paints the body. See
- * §2.1 of `docs/design/compaction-widget-polish.md`.
+ * §2.1 / §7 of `docs/design/compaction-e2e-rich-summary.md`.
  */
 
 /** "manual" → /compact slash; "auto" → threshold-driven; "overflow" → context-limit error. */

--- a/src/app/compaction-types.ts
+++ b/src/app/compaction-types.ts
@@ -8,25 +8,41 @@
  * (`remote-agent.ts::compaction_end`) and the reload-path upgrade adapter
  * (`message-reducer.ts::snapshot`) use the same shape.
  *
- * See `docs/design/compaction-e2e-rich-summary.md` §2.1, §2.2.
+ * Single DOM identity invariant: the synthetic message uses a STABLE id
+ * (`COMPACTION_ACTIVE_ID = "compact_active"`) across the whole lifecycle
+ * (in-progress → complete | error). The reducer filters by that id so the
+ * Lit render keeps the same DOM node and only re-paints the body. See
+ * §2.1 of `docs/design/compaction-widget-polish.md`.
  */
+
+/** "manual" → /compact slash; "auto" → threshold-driven; "overflow" → context-limit error. */
+export type CompactionTrigger = "manual" | "auto" | "overflow";
+
+/** Three lifecycle states the renderer branches on. */
+export type CompactionState = "in-progress" | "complete" | "error";
 
 export interface CompactionSummaryPayload {
 	/** v1 — bump if the renderer adds new fields that break older snapshots. */
 	schemaVersion: 1;
-	/** "manual" → /compact slash command; "auto" → agent auto-compaction. */
-	trigger: "manual" | "auto";
+	trigger: CompactionTrigger;
+	/** NEW — drives the renderer branch. Older persisted payloads may omit
+	 *  this; the renderer derives `complete | error` from `success` as a
+	 *  back-compat fallback. */
+	state?: CompactionState;
+	/** Mirrors `state === "complete"`. Kept so case (12c) upgrade adapter
+	 *  and back-compat snapshots stay intact. */
 	success: boolean;
-	/** ISO-8601 of compaction_end on the client. */
+	/** ISO-8601 of compaction_end (or compaction_start for in-progress). */
 	timestamp: string;
-	/** Token count reported in compaction_end.tokensBefore (may be null). */
+	/** Token count from compaction_end.tokensBefore (or
+	 *  parsed from the overflow error, or the last-known live context). */
 	tokensBefore: number | null;
 	/** Best-effort post-compaction usage from the latest assistant message
 	 *  with `usage`. Null when not known. */
 	tokensAfter: number | null;
 	/** Derived. Null if either count is null. Range 0–100, one decimal. */
 	reductionPct: number | null;
-	/** Failure detail; only set when success === false. */
+	/** Failure detail; only set when state === "error". */
 	error?: string;
 }
 
@@ -38,18 +54,23 @@ export interface CompactionSummaryMessages {
 /** Synthetic-tool name. Leading `__` keeps it off the real-tool registry. */
 export const COMPACTION_TOOL_NAME = "__compaction_summary";
 
+/** Stable id used across all lifecycle states for single-DOM-identity. */
+export const COMPACTION_ACTIVE_ID = "compact_active";
+export const COMPACTION_ACTIVE_TOOLCALL_ID = `compaction-summary:${COMPACTION_ACTIVE_ID}`;
+
 /**
  * Build the synthetic assistant message + paired toolResult that the reducer
- * pushes via the `compaction-result` action.
+ * pushes via the `compaction-result` (or `compaction-placeholder` for the
+ * in-progress state) action. Uses a STABLE id so the renderer keeps the same
+ * DOM node across in-progress → complete | error.
  */
 export function buildCompactionSummaryMessages(
 	payload: CompactionSummaryPayload,
 ): CompactionSummaryMessages {
 	const now = Date.now();
-	const id = payload.success
-		? `compact_done_${now}`
-		: `compact_err_${now}`;
-	const toolCallId = `compaction-summary:${id}`;
+	const id = COMPACTION_ACTIVE_ID;
+	const toolCallId = COMPACTION_ACTIVE_TOOLCALL_ID;
+	const isError = (payload.state ?? (payload.success ? "complete" : "error")) === "error";
 
 	const message = {
 		id,
@@ -69,11 +90,11 @@ export function buildCompactionSummaryMessages(
 		role: "toolResult" as const,
 		toolCallId,
 		toolName: COMPACTION_TOOL_NAME,
-		isError: !payload.success,
+		isError,
 		content: [
 			{
 				type: "text" as const,
-				text: payload.success ? "ok" : payload.error || "compaction failed",
+				text: isError ? (payload.error || "compaction failed") : "ok",
 			},
 		],
 		details: payload,
@@ -81,6 +102,44 @@ export function buildCompactionSummaryMessages(
 	};
 
 	return { message, toolResult };
+}
+
+/**
+ * Build the in-progress payload emitted on `compaction_start`. tokensBefore
+ * is best-effort (read from the latest usage row or, if forwarded, the
+ * server-side RPC result).
+ */
+export function buildInProgressCompactionPayload(
+	trigger: CompactionTrigger,
+	tokensBefore: number | null,
+): CompactionSummaryPayload {
+	return {
+		schemaVersion: 1,
+		trigger,
+		state: "in-progress",
+		// In-progress payloads carry success:true as a placeholder; the
+		// renderer drives off `state`, not `success`. Older readers that
+		// still check `success` see this as "not yet failed".
+		success: true,
+		timestamp: new Date().toISOString(),
+		tokensBefore,
+		tokensAfter: null,
+		reductionPct: null,
+	};
+}
+
+/**
+ * Parse the canonical Anthropic overflow error string into a token count.
+ *
+ * Matches "prompt is too long: 202592 tokens > 200000 maximum" and
+ * sibling shapes like "X tokens > Y". Returns null on miss.
+ */
+export function parseOverflowTokenCount(text: string | null | undefined): number | null {
+	if (!text) return null;
+	const m = /(\d{4,})\s*tokens\s*>/i.exec(text);
+	if (!m) return null;
+	const n = parseInt(m[1], 10);
+	return Number.isFinite(n) && n > 0 ? n : null;
 }
 
 /**
@@ -138,7 +197,10 @@ function extractTextFromMessage(m: any): string {
  * Upgrade a server plain-text compaction marker into a rich synthetic
  * carrying a `__compaction_summary` toolCall. Used by the snapshot path on
  * reload when no live synthetic exists yet. `tokensAfter` / `reductionPct`
- * stay null; trigger defaults to "manual" (we cannot tell from the row alone).
+ * stay null; trigger defaults to "manual" (we cannot tell from the row
+ * alone). NOTE: this uses the server-row's original id (NOT the stable
+ * `compact_active` id) — this is pre-existing reload-time data, not the
+ * live lifecycle, so we don't need DOM-identity continuity.
  */
 export function upgradeServerCompactionMarker(serverRow: any): any {
 	const text = extractTextFromMessage(serverRow);
@@ -146,6 +208,7 @@ export function upgradeServerCompactionMarker(serverRow: any): any {
 	const payload: CompactionSummaryPayload = {
 		schemaVersion: 1,
 		trigger: "manual",
+		state: "complete",
 		success: true,
 		timestamp:
 			typeof serverRow?.timestamp === "number"

--- a/src/app/message-reducer.ts
+++ b/src/app/message-reducer.ts
@@ -569,7 +569,7 @@ export function reduce(state: ReducerState, action: Action): ReducerState {
 			// Carries a RICH in-progress synthetic with stable id `compact_active`.
 			// Filter both the legacy plaintext id and the stable id so reconnect
 			// races / double-emission collapse to a single row. See
-			// `docs/design/compaction-widget-polish.md` §2.2.
+			// `docs/design/compaction-e2e-rich-summary.md` §7.4.
 			const tick = state.nextTick;
 			const order = state.highestSeq + 0.5;
 			const messages = state.messages.filter(

--- a/src/app/message-reducer.ts
+++ b/src/app/message-reducer.ts
@@ -145,6 +145,7 @@ function upgradeServerCompactionMarker(serverRow: any): any {
 	const payload = {
 		schemaVersion: 1 as const,
 		trigger: "manual" as const,
+		state: "complete" as const,
 		success: true,
 		timestamp:
 			typeof serverRow?.timestamp === "number"
@@ -565,9 +566,15 @@ export function reduce(state: ReducerState, action: Action): ReducerState {
 		}
 
 		case "compaction-placeholder": {
+			// Carries a RICH in-progress synthetic with stable id `compact_active`.
+			// Filter both the legacy plaintext id and the stable id so reconnect
+			// races / double-emission collapse to a single row. See
+			// `docs/design/compaction-widget-polish.md` §2.2.
 			const tick = state.nextTick;
 			const order = state.highestSeq + 0.5;
-			const messages = state.messages.filter((m) => m.id !== "compacting_placeholder");
+			const messages = state.messages.filter(
+				(m) => m.id !== "compacting_placeholder" && m.id !== "compact_active",
+			);
 			messages.push(stamp(action.message, "synthetic", order, tick));
 			return {
 				messages: sortMessages(messages),
@@ -577,10 +584,18 @@ export function reduce(state: ReducerState, action: Action): ReducerState {
 		}
 
 		case "compaction-result": {
+			// Drop the legacy plaintext placeholder id AND any rich in-progress
+			// row carrying the stable `compact_active` id (the in-place
+			// transition target) AND its paired toolResult. Then push the new
+			// rich row(s) under the same stable id. Single-DOM-identity
+			// invariant pinned by message-reducer.test.ts case 12d.
 			const tick = state.nextTick;
 			const order = state.highestSeq + 0.5;
 			const messages = state.messages.filter(
-				(m) => m.id !== "compacting_placeholder",
+				(m) =>
+					m.id !== "compacting_placeholder"
+					&& m.id !== "compact_active"
+					&& (m as any).toolCallId !== "compaction-summary:compact_active",
 			);
 			messages.push(stamp(action.message, "synthetic", order, tick));
 			if (action.toolResult) {

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -111,7 +111,7 @@ export class RemoteAgent {
 	private _isCompacting = false;
 	/** Best-effort cache of the most recently seen context-token count; used
 	 *  as the final fallback when resolving `tokensBefore` for a compaction
-	 *  end event. See `docs/design/compaction-widget-polish.md` §2.4. */
+	 *  end event. See `docs/design/compaction-e2e-rich-summary.md` §7.3. */
 	private _lastKnownContextTokens: number | null = null;
 	private _isAborting = false;
 

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -10,7 +10,13 @@ import { clearAnnotations, clearAllAnnotations, isReviewSubmitted, clearReviewSu
 import { findAskResponseAnswers as _findAskResponseAnswers, type AskResponseAnswer } from "../shared/ask-envelope.js";
 import { reduce, initialState, type ReducerState, type Action, type OrderedMessage } from "./message-reducer.js";
 import { computeStreamingMessageId } from "./streaming-message-id.js";
-import { buildCompactionSummaryMessages, type CompactionSummaryPayload } from "./compaction-types.js";
+import {
+	buildCompactionSummaryMessages,
+	buildInProgressCompactionPayload,
+	parseOverflowTokenCount,
+	type CompactionSummaryPayload,
+	type CompactionTrigger,
+} from "./compaction-types.js";
 
 /** Maps propose_* tool suffix → callback name on RemoteAgent (legacy path).
  *  Slice E will replace this lookup with a flat ProposalType allow-list and
@@ -103,6 +109,10 @@ export class RemoteAgent {
 	// Compaction tracking — persists across message refreshes.
 	// Exposed on state so the UI can queue messages during compact.
 	private _isCompacting = false;
+	/** Best-effort cache of the most recently seen context-token count; used
+	 *  as the final fallback when resolving `tokensBefore` for a compaction
+	 *  end event. See `docs/design/compaction-widget-polish.md` §2.4. */
+	private _lastKnownContextTokens: number | null = null;
 	private _isAborting = false;
 
 	// Proposal deferral — when set, incoming messages are stored but
@@ -751,9 +761,11 @@ export class RemoteAgent {
 					const u = m.usage;
 					const total = u.totalTokens
 						|| ((u.input ?? 0) + (u.output ?? 0) + (u.cacheRead ?? 0) + (u.cacheWrite ?? 0));
-					return typeof total === "number" && Number.isFinite(total) && total > 0
-						? total
-						: null;
+					if (typeof total === "number" && Number.isFinite(total) && total > 0) {
+						this._lastKnownContextTokens = total;
+						return total;
+					}
+					return null;
 				}
 			}
 		} catch {
@@ -762,17 +774,30 @@ export class RemoteAgent {
 		return null;
 	}
 
-	/** Add or re-add the "Compacting context…" placeholder to the message list. */
-	private _addCompactingPlaceholder(): void {
-		this.apply({
-			type: "compaction-placeholder",
-			message: {
-				role: "assistant",
-				content: [{ type: "text", text: "Compacting context…" }],
-				timestamp: Date.now(),
-				id: "compacting_placeholder",
-			},
-		});
+	/**
+	 * Inject a RICH in-progress compaction synthetic into the message list.
+	 * Replaces the legacy plaintext "Compacting context…" row — the renderer
+	 * now drives the in-progress state itself. Used by both the live
+	 * `compaction_start` path and the reconnect-path (~line 1109) when the
+	 * server tells us compaction is still in progress on resume.
+	 */
+	private _addCompactingPlaceholder(trigger: CompactionTrigger = "manual"): void {
+		const tokensBefore = this._readContextTokens() ?? this._lastKnownContextTokens;
+		if (tokensBefore != null) this._lastKnownContextTokens = tokensBefore;
+		const payload = buildInProgressCompactionPayload(trigger, tokensBefore);
+		const { message } = buildCompactionSummaryMessages(payload);
+		this.apply({ type: "compaction-placeholder", message });
+	}
+
+	/** Map upstream event `reason` (or legacy event-type) to a trigger. */
+	private _triggerFromEvent(event: any): CompactionTrigger {
+		const reason = event?.reason;
+		if (reason === "overflow") return "overflow";
+		if (reason === "threshold") return "auto";
+		if (reason === "manual") return "manual";
+		if (event?.type === "auto_compaction_start" || event?.type === "auto_compaction_end")
+			return "auto";
+		return "manual";
 	}
 
 	requestMessages(): void {
@@ -1885,8 +1910,8 @@ export class RemoteAgent {
 				// Don't set isStreaming — compaction uses its own blob animation
 				this._isCompacting = true;
 				this.onCompactionChange?.(true);
-				// Add a placeholder message so compaction is visible in chat history
-				this._addCompactingPlaceholder();
+				// Add a rich in-progress synthetic so compaction is visible in chat history
+				this._addCompactingPlaceholder(this._triggerFromEvent(event));
 				// Normalize to compaction_start for UI subscribers
 				if (event.type === "auto_compaction_start") {
 					this.emit({ type: "compaction_start" } as any);
@@ -1909,17 +1934,34 @@ export class RemoteAgent {
 				this._isCompacting = false;
 				this.onCompactionChange?.(false);
 				const success = event.type === "compaction_end" ? event.success : !event.aborted;
-				const tokensBefore: number | null = (event as any).tokensBefore ?? null;
+				const trigger = this._triggerFromEvent(event);
+				const errMsg: string | undefined =
+					(event as any).errorMessage || (event as any).error;
+				// tokensBefore resolution chain (see design doc §2.4):
+				//   1. event.result.tokensBefore  — agent-emitted auto/overflow end
+				//   2. event.tokensBefore         — server-emitted manual path
+				//   3. parseOverflowTokenCount(errMsg) when overflow error path
+				//   4. this._lastKnownContextTokens
+				let tokensBefore: number | null =
+					(event as any).result?.tokensBefore
+					?? (event as any).tokensBefore
+					?? null;
+				if (tokensBefore == null && errMsg) {
+					tokensBefore = parseOverflowTokenCount(errMsg);
+				}
+				if (tokensBefore == null) {
+					tokensBefore = this._lastKnownContextTokens;
+				}
 				const tokensAfter = this._readContextTokens();
+				if (tokensAfter != null) this._lastKnownContextTokens = tokensAfter;
 				const reductionPct =
 					tokensBefore && tokensAfter && tokensBefore > 0
 						? Math.round(((tokensBefore - tokensAfter) / tokensBefore) * 1000) / 10
 						: null;
-				const trigger: "manual" | "auto" =
-					event.type === "auto_compaction_end" ? "auto" : "manual";
 				const payload: CompactionSummaryPayload = {
 					schemaVersion: 1,
 					trigger,
+					state: success ? "complete" : "error",
 					success,
 					timestamp: new Date().toISOString(),
 					tokensBefore,
@@ -1927,8 +1969,7 @@ export class RemoteAgent {
 					reductionPct,
 					error: success
 						? undefined
-						: ((event as any).error
-							|| ((event as any).aborted ? "Compaction aborted" : "Unknown error")),
+						: (errMsg || ((event as any).aborted ? "Compaction aborted" : "Unknown error")),
 				};
 				const { message, toolResult } = buildCompactionSummaryMessages(payload);
 				this.apply({ type: "compaction-result", message, success, toolResult });

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -551,7 +551,7 @@ export function handleWebSocketConnection(
 					// Fire-and-forget: don't block the WS message loop.
 					// The async IIFE handles the full lifecycle.
 					session.isCompacting = true;
-					broadcast(session.clients, { type: "event", data: { type: "compaction_start" } });
+					broadcast(session.clients, { type: "event", data: { type: "compaction_start", reason: "manual" } });
 					(async () => {
 						try {
 							console.log(`[ws-handler] Starting manual compact for session ${sessionId}`);
@@ -563,13 +563,13 @@ export function handleWebSocketConnection(
 							// the placeholder when processing the refreshed messages.
 							// Include tokensBefore so the UI can show how much was saved.
 							const tokensBefore = compactResult?.data?.tokensBefore ?? null;
-							broadcast(session.clients, { type: "event", data: { type: "compaction_end", success: true, tokensBefore } });
+							broadcast(session.clients, { type: "event", data: { type: "compaction_end", reason: "manual", success: true, tokensBefore } });
 							// Refresh messages and state (updated context tokens)
 							await sessionManager.refreshAfterCompaction(session);
 						} catch (err: any) {
 							console.error(`[ws-handler] Compact failed for session ${sessionId}:`, err.message);
 							session.isCompacting = false;
-							broadcast(session.clients, { type: "event", data: { type: "compaction_end", success: false, error: err.message } });
+							broadcast(session.clients, { type: "event", data: { type: "compaction_end", reason: "manual", success: false, error: err.message } });
 						}
 					})().catch((err) => {
 						console.error(`[ws-handler] Unexpected compact error for session ${sessionId}:`, err);

--- a/src/ui/tools/renderers/CompactionSummaryRenderer.ts
+++ b/src/ui/tools/renderers/CompactionSummaryRenderer.ts
@@ -17,7 +17,7 @@ import type {
  * Renders three lifecycle states (in-progress | complete | error) from a
  * single payload shape. Single DOM identity is provided by the reducer
  * (stable id `compact_active`); the renderer just re-paints the body. See
- * `docs/design/compaction-widget-polish.md` §2.3.
+ * `docs/design/compaction-e2e-rich-summary.md` §7 (Polish revision).
  *
  * Stable test hooks:
  *   data-testid="compaction-summary-card"

--- a/src/ui/tools/renderers/CompactionSummaryRenderer.ts
+++ b/src/ui/tools/renderers/CompactionSummaryRenderer.ts
@@ -2,17 +2,27 @@ import { icon } from "@mariozechner/mini-lit";
 import type { ToolResultMessage } from "@mariozechner/pi-ai";
 import { html, nothing } from "lit";
 import { createRef, ref } from "lit/directives/ref.js";
-import { AlertTriangle, Check, PackageOpen, X } from "lucide";
+import { AlertTriangle, Check, Loader2, PackageOpen, X } from "lucide";
 import { renderCollapsibleHeader, getToolState } from "../renderer-registry.js";
 import type { ToolRenderer, ToolRenderResult } from "../types.js";
-import type { CompactionSummaryPayload } from "../../../app/compaction-types.js";
+import type {
+	CompactionState,
+	CompactionSummaryPayload,
+	CompactionTrigger,
+} from "../../../app/compaction-types.js";
 
 /**
  * Renderer for the synthetic `__compaction_summary` tool. Theme-token only.
  *
+ * Renders three lifecycle states (in-progress | complete | error) from a
+ * single payload shape. Single DOM identity is provided by the reducer
+ * (stable id `compact_active`); the renderer just re-paints the body. See
+ * `docs/design/compaction-widget-polish.md` §2.3.
+ *
  * Stable test hooks:
  *   data-testid="compaction-summary-card"
- *   data-test="tokens-before|tokens-after|reduction-pct|trigger|verdict"
+ *   data-state="in-progress|complete|error"  (on card root)
+ *   data-test="tokens-before|tokens-after|reduction-pct|trigger|verdict|error"
  */
 
 function formatTokens(n: number | null): string {
@@ -32,6 +42,25 @@ function formatTime(iso: string): string {
 	}
 }
 
+function resolveState(payload: CompactionSummaryPayload): CompactionState {
+	if (payload.state) return payload.state;
+	// Back-compat for payloads persisted before the `state` field existed.
+	return payload.success === false ? "error" : "complete";
+}
+
+function triggerLabel(trigger: CompactionTrigger): string {
+	if (trigger === "overflow") return "context limit";
+	if (trigger === "auto") return "auto";
+	return "manual";
+}
+
+function triggerStyle(trigger: CompactionTrigger): string {
+	if (trigger === "overflow") {
+		return "background: color-mix(in oklch, var(--warning) 14%, transparent); color: var(--warning);";
+	}
+	return "background: var(--muted); color: var(--muted-foreground);";
+}
+
 export class CompactionSummaryRenderer
 	implements ToolRenderer<CompactionSummaryPayload, CompactionSummaryPayload>
 {
@@ -42,7 +71,7 @@ export class CompactionSummaryRenderer
 	): ToolRenderResult {
 		const payload: CompactionSummaryPayload | undefined =
 			(result?.details as CompactionSummaryPayload | undefined) ?? params;
-		const state = getToolState(result, isStreaming);
+		const toolState = getToolState(result, isStreaming);
 		const contentRef = createRef<HTMLDivElement>();
 		const chevronRef = createRef<HTMLSpanElement>();
 
@@ -53,95 +82,142 @@ export class CompactionSummaryRenderer
 			};
 		}
 
-		const success = payload.success !== false;
-		const headerIcon = success ? PackageOpen : AlertTriangle;
-		const triggerLabel = payload.trigger === "auto" ? "auto" : "manual";
+		const state = resolveState(payload);
+		const trigger = payload.trigger;
+		const isInProgress = state === "in-progress";
+		const isError = state === "error";
+		const isComplete = state === "complete";
+
+		const headerIcon = isInProgress
+			? Loader2
+			: isError
+				? AlertTriangle
+				: PackageOpen;
+		const headerLabel = isInProgress ? "Compacting context…" : "Context compacted";
+
+		const triggerPill = html`
+			<span
+				class="ml-2 inline-flex items-center rounded-full px-2 py-0.5 text-xs"
+				style=${triggerStyle(trigger)}
+				data-test="trigger"
+				>${triggerLabel(trigger)}</span
+			>
+		`;
+
+		const verdictPill = isInProgress
+			? html`<span
+					class="ml-1 inline-flex items-center text-muted-foreground"
+					data-test="verdict"
+					data-verdict="pending"
+				>
+					${icon(Loader2, "sm", "animate-spin")}
+				</span>`
+			: isError
+				? html`<span
+						class="ml-1 inline-flex items-center text-destructive"
+						data-test="verdict"
+						data-verdict="fail"
+					>${icon(X, "sm")}</span>`
+				: html`<span
+						class="ml-1 inline-flex items-center text-green-600 dark:text-green-500"
+						data-test="verdict"
+						data-verdict="ok"
+					>${icon(Check, "sm")}</span>`;
 
 		const headerText = html`
-			<span>Context compacted</span>
-			<span
-				class="ml-2 inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
-				data-test="trigger"
-				>${triggerLabel}</span
-			>
-			<span
-				class="ml-1 inline-flex items-center"
-				data-test="verdict"
-				data-verdict=${success ? "ok" : "fail"}
-			>
-				${success
-					? html`<span class="inline-flex items-center text-green-600 dark:text-green-500"
-							>${icon(Check, "sm")}</span
-						>`
-					: html`<span class="inline-flex items-center text-destructive"
-							>${icon(X, "sm")}</span
-						>`}
+			<span>${headerLabel}</span>
+			${triggerPill}${verdictPill}
+		`;
+
+		const tokensBeforeBadge = (label: string) => html`
+			<span class="inline-flex items-baseline gap-1.5">
+				<span class="text-xs uppercase tracking-wide text-muted-foreground">${label}</span>
+				<span class="font-mono ${payload.tokensBefore === null ? "text-muted-foreground" : "text-foreground"}" data-test="tokens-before">
+					${payload.tokensBefore === null ? "—" : html`${formatTokens(payload.tokensBefore)} tok`}
+				</span>
 			</span>
 		`;
 
-		const reductionBar = (() => {
-			if (!success) return nothing;
+		const reductionInline = (() => {
+			if (!isComplete) return nothing;
 			const pct = payload.reductionPct;
 			if (pct === null || pct === undefined || !Number.isFinite(pct)) return nothing;
 			const clamped = Math.max(0, Math.min(100, pct));
 			return html`
-				<div class="flex items-center gap-2">
-					<div
-						class="h-1.5 w-32 overflow-hidden rounded"
+				<span class="inline-flex items-center gap-2">
+					<span
+						class="h-1.5 w-24 overflow-hidden rounded"
 						style="background: color-mix(in oklch, var(--chart-1) 14%, transparent);"
 					>
-						<div
-							class="h-full rounded"
+						<span
+							class="block h-full rounded"
 							style="width: ${clamped}%; background: var(--chart-1);"
-						></div>
-					</div>
+						></span>
+					</span>
 					<span
 						class="rounded-full px-2 py-0.5 text-xs font-medium"
 						style="background: color-mix(in oklch, var(--chart-1) 14%, transparent); color: var(--chart-1);"
 						data-test="reduction-pct"
 						>−${pct.toFixed(1)}%</span
 					>
-				</div>
+				</span>
 			`;
 		})();
 
-		const body = success
-			? html`
-					<div class="mt-2 space-y-1.5 text-sm">
-						<div class="flex items-center justify-between gap-4">
-							<span class="text-xs uppercase tracking-wide text-muted-foreground">before</span>
-							<span
-								class="font-mono text-foreground"
-								data-test="tokens-before"
-								>${formatTokens(payload.tokensBefore)} tok</span
-							>
-						</div>
-						<div class="flex items-center justify-between gap-4">
-							<span class="text-xs uppercase tracking-wide text-muted-foreground">after</span>
-							<span
-								class="font-mono ${payload.tokensAfter === null
-									? "text-muted-foreground"
-									: "text-foreground"}"
-								data-test="tokens-after"
-								>${payload.tokensAfter === null
-									? "—"
-									: html`${formatTokens(payload.tokensAfter)} tok`}</span
-							>
-						</div>
-						${reductionBar !== nothing
-							? html`<div class="pt-1">${reductionBar}</div>`
-							: payload.tokensAfter === null
-								? html`<div class="pt-1 text-xs text-muted-foreground">
-										reduction unknown
-									</div>`
-								: nothing}
-					</div>
-				`
-			: html`
-					<div class="mt-2 text-sm text-destructive" data-test="error">
-						${payload.error || "Compaction failed."}
-					</div>
-				`;
+		// In-progress body: indeterminate progress bar + (optional) before badge.
+		// No payload details disclosure during the active window.
+		const inProgressBody = html`
+			<div class="mt-3 space-y-3">
+				<div class="flex flex-wrap items-baseline gap-x-4 gap-y-1 text-sm">
+					${payload.tokensBefore !== null ? tokensBeforeBadge("before") : nothing}
+				</div>
+				<div
+					class="h-1.5 w-full overflow-hidden rounded"
+					style="background: color-mix(in oklch, var(--chart-1) 14%, transparent);"
+					data-test="progress-bar"
+				>
+					<div
+						class="h-full rounded compaction-indeterminate-bar"
+						style="background: var(--chart-1);"
+					></div>
+				</div>
+			</div>
+		`;
+
+		// Complete body: adjacent label/value pairs in a wrapping inline group.
+		const completeBody = html`
+			<div class="mt-2 flex flex-wrap items-baseline gap-x-4 gap-y-1 text-sm">
+				${tokensBeforeBadge("before")}
+				<span class="inline-flex items-baseline gap-1.5">
+					<span class="text-xs uppercase tracking-wide text-muted-foreground">after</span>
+					<span
+						class="font-mono ${payload.tokensAfter === null ? "text-muted-foreground" : "text-foreground"}"
+						data-test="tokens-after"
+						>${payload.tokensAfter === null ? "—" : html`${formatTokens(payload.tokensAfter)} tok`}</span
+					>
+				</span>
+				${reductionInline !== nothing
+					? reductionInline
+					: payload.tokensAfter === null
+						? html`<span class="text-xs text-muted-foreground">reduction unknown</span>`
+						: nothing}
+			</div>
+		`;
+
+		const errorBody = html`
+			<div class="mt-2 flex flex-wrap items-baseline gap-x-4 gap-y-1 text-sm">
+				${payload.tokensBefore !== null ? tokensBeforeBadge("before") : nothing}
+			</div>
+			<div class="mt-2 text-sm text-destructive" data-test="error">
+				${payload.error || "Compaction failed."}
+			</div>
+		`;
+
+		const body = isInProgress
+			? inProgressBody
+			: isError
+				? errorBody
+				: completeBody;
 
 		const footer = html`
 			<div class="mt-2 flex items-center justify-between text-xs text-muted-foreground">
@@ -149,14 +225,42 @@ export class CompactionSummaryRenderer
 			</div>
 		`;
 
+		const payloadDisclosure = isInProgress
+			? nothing
+			: html`<details class="mt-2">
+					<summary class="cursor-pointer text-xs text-muted-foreground">
+						payload
+					</summary>
+					<pre class="mt-1 overflow-x-auto rounded bg-muted/40 p-2 text-xs">
+${JSON.stringify(payload, null, 2)}</pre>
+				</details>`;
+
+		// One-time scoped style for the indeterminate bar (CSS-only animation).
+		// Inlined per-card; the engine de-dups identical <style> blocks.
+		const indeterminateStyle = isInProgress
+			? html`<style>
+					.compaction-indeterminate-bar {
+						width: 40%;
+						animation: compaction-indeterminate 1.4s ease-in-out infinite;
+					}
+					@keyframes compaction-indeterminate {
+						0%   { margin-left: -40%; }
+						50%  { margin-left: 50%; }
+						100% { margin-left: 100%; }
+					}
+				</style>`
+			: nothing;
+
 		return {
 			content: html`
 				<div
 					data-testid="compaction-summary-card"
+					data-state=${state}
 					class="rounded-md border border-border bg-card p-3"
 				>
+					${indeterminateStyle}
 					${renderCollapsibleHeader(
-						state,
+						toolState,
 						headerIcon,
 						headerText,
 						contentRef,
@@ -167,14 +271,7 @@ export class CompactionSummaryRenderer
 						${ref(contentRef)}
 						class="max-h-[2000px] mt-3 overflow-hidden transition-all duration-300"
 					>
-						${body} ${footer}
-						<details class="mt-2">
-							<summary class="cursor-pointer text-xs text-muted-foreground">
-								payload
-							</summary>
-							<pre class="mt-1 overflow-x-auto rounded bg-muted/40 p-2 text-xs">
-${JSON.stringify(payload, null, 2)}</pre>
-						</details>
+						${body} ${footer} ${payloadDisclosure}
 					</div>
 				</div>
 			`,

--- a/tests/compaction-types.test.ts
+++ b/tests/compaction-types.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Pure unit tests for compaction-types helpers — `parseOverflowTokenCount`,
+ * `buildInProgressCompactionPayload`, `buildCompactionSummaryMessages`
+ * stable-id invariant.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+	COMPACTION_ACTIVE_ID,
+	COMPACTION_ACTIVE_TOOLCALL_ID,
+	buildCompactionSummaryMessages,
+	buildInProgressCompactionPayload,
+	parseOverflowTokenCount,
+} from "../src/app/compaction-types.ts";
+
+describe("compaction-types", () => {
+	it("parseOverflowTokenCount: canonical Anthropic 400 string", () => {
+		assert.strictEqual(
+			parseOverflowTokenCount("prompt is too long: 202592 tokens > 200000 maximum"),
+			202_592,
+		);
+	});
+
+	it("parseOverflowTokenCount: handles wrapped / multi-line", () => {
+		const wrapped = "AnthropicError: 400 Bad Request\n  prompt is too long: 156789 tokens > 200000 maximum";
+		assert.strictEqual(parseOverflowTokenCount(wrapped), 156_789);
+	});
+
+	it("parseOverflowTokenCount: returns null for unrelated / empty input", () => {
+		assert.strictEqual(parseOverflowTokenCount(""), null);
+		assert.strictEqual(parseOverflowTokenCount(null), null);
+		assert.strictEqual(parseOverflowTokenCount(undefined), null);
+		assert.strictEqual(parseOverflowTokenCount("rate limited"), null);
+	});
+
+	it("buildInProgressCompactionPayload: shape is correct", () => {
+		const p = buildInProgressCompactionPayload("overflow", 202_592);
+		assert.strictEqual(p.trigger, "overflow");
+		assert.strictEqual(p.state, "in-progress");
+		assert.strictEqual(p.success, true);
+		assert.strictEqual(p.tokensBefore, 202_592);
+		assert.strictEqual(p.tokensAfter, null);
+		assert.strictEqual(p.reductionPct, null);
+		assert.match(p.timestamp, /^\d{4}-\d{2}-\d{2}T/);
+	});
+
+	it("buildCompactionSummaryMessages: stable id across all three states", () => {
+		const base = {
+			schemaVersion: 1 as const,
+			trigger: "overflow" as const,
+			success: true,
+			timestamp: "2026-05-12T00:00:00Z",
+			tokensBefore: 200_000,
+			tokensAfter: null,
+			reductionPct: null,
+		};
+		const { message: mInProg, toolResult: rInProg } = buildCompactionSummaryMessages({
+			...base, state: "in-progress",
+		});
+		const { message: mDone, toolResult: rDone } = buildCompactionSummaryMessages({
+			...base, state: "complete", tokensAfter: 100_000, reductionPct: 50,
+		});
+		const { message: mErr, toolResult: rErr } = buildCompactionSummaryMessages({
+			...base, state: "error", success: false, error: "boom",
+		});
+		assert.strictEqual(mInProg.id, COMPACTION_ACTIVE_ID);
+		assert.strictEqual(mDone.id, COMPACTION_ACTIVE_ID);
+		assert.strictEqual(mErr.id, COMPACTION_ACTIVE_ID);
+		const tcId = (m: any) => m.content[0].id;
+		assert.strictEqual(tcId(mInProg), COMPACTION_ACTIVE_TOOLCALL_ID);
+		assert.strictEqual(tcId(mDone), COMPACTION_ACTIVE_TOOLCALL_ID);
+		assert.strictEqual(tcId(mErr), COMPACTION_ACTIVE_TOOLCALL_ID);
+		// toolResult isError mirrors state
+		assert.strictEqual(rInProg.isError, false);
+		assert.strictEqual(rDone.isError, false);
+		assert.strictEqual(rErr.isError, true);
+	});
+});

--- a/tests/compaction.spec.ts
+++ b/tests/compaction.spec.ts
@@ -188,6 +188,11 @@ test("compaction — real LLM @real", async ({ page }) => {
 		await expect(card).toBeVisible({ timeout: 120_000 });
 		await expect(card.getByText("Context compacted")).toBeVisible();
 		await expect(card.locator("[data-test='trigger']")).toHaveText(/manual|auto/);
+		// Manual `/compact` path — server emits reason:"manual", so the pill
+		// MUST be exactly "manual" (sanity that reason plumbing works end-to-end).
+		await expect(card.locator("[data-test='trigger']")).toHaveText("manual");
+		// Card has reached a terminal state (not in-progress).
+		await expect(card).toHaveAttribute("data-state", /complete|error/);
 
 		// No error indicators in the transcript. Bobbit surfaces errors via
 		// <error-details> with data-testid='error-details-message' (see

--- a/tests/e2e/ui/compaction-widget.spec.ts
+++ b/tests/e2e/ui/compaction-widget.spec.ts
@@ -10,7 +10,7 @@
  *   - layout: tokens-before label is adjacent (≤ 24px) to its value.
  *
  * Pin for the single-DOM-identity invariant — see
- * `docs/design/compaction-widget-polish.md` §5 risk 1.
+ * `docs/design/compaction-e2e-rich-summary.md` §7.4 (single-card lifecycle).
  */
 import { test, expect } from "@playwright/test";
 import { execSync } from "node:child_process";

--- a/tests/e2e/ui/compaction-widget.spec.ts
+++ b/tests/e2e/ui/compaction-widget.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * Browser E2E for CompactionSummaryRenderer state transitions.
+ *
+ * file:// fixture — no gateway spawned. Drives the renderer directly through
+ * `(window as any).applyInProgress | applyComplete | applyError`. Asserts:
+ *   - in-progress → complete: card[data-state] flips, exactly one card on
+ *     the page, no plaintext "Compacting context…" appears.
+ *   - in-progress → error: overflow trigger pill renders "context limit",
+ *     error message is visible.
+ *   - layout: tokens-before label is adjacent (≤ 24px) to its value.
+ *
+ * Pin for the single-DOM-identity invariant — see
+ * `docs/design/compaction-widget-polish.md` §5 risk 1.
+ */
+import { test, expect } from "@playwright/test";
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const FIXTURE = path.resolve("tests/fixtures/compaction-widget.html");
+const BUNDLE = path.resolve("tests/fixtures/compaction-widget-bundle.js");
+const ENTRY = path.resolve("tests/fixtures/compaction-widget-entry.ts");
+const RENDERER_SRC = path.resolve("src/ui/tools/renderers/CompactionSummaryRenderer.ts");
+const TYPES_SRC = path.resolve("src/app/compaction-types.ts");
+
+test.beforeAll(() => {
+	const entryMtime = Math.max(
+		fs.statSync(ENTRY).mtimeMs,
+		fs.statSync(RENDERER_SRC).mtimeMs,
+		fs.statSync(TYPES_SRC).mtimeMs,
+	);
+	const bundleExists = fs.existsSync(BUNDLE);
+	const bundleStale = bundleExists && fs.statSync(BUNDLE).mtimeMs < entryMtime;
+	if (!bundleExists || bundleStale) {
+		execSync(
+			[
+				`npx esbuild ${ENTRY}`,
+				"--bundle --format=iife --target=es2022",
+				`--outfile=${BUNDLE}`,
+				"--tsconfig=tsconfig.web.json",
+				'--alias:pdfjs-dist=./tests/fixtures/empty-shim',
+				"--define:import.meta.url='\"http://localhost/\"'",
+			].join(" "),
+			{ stdio: "pipe" },
+		);
+	}
+});
+
+const PAGE = `file://${FIXTURE}`;
+
+async function gotoAndWait(page: any) {
+	await page.goto(PAGE);
+	await page.waitForFunction(() => (window as any).__ready === true, null, { timeout: 10_000 });
+}
+
+test.describe("CompactionSummaryRenderer (browser E2E)", () => {
+	test("in-progress → complete: same card, no plaintext placeholder", async ({ page }) => {
+		await gotoAndWait(page);
+		await page.evaluate(() => (window as any).applyInProgress("overflow", 202_592));
+
+		const card = page.locator("[data-testid='compaction-summary-card']");
+		await expect(card).toHaveCount(1);
+		await expect(card).toHaveAttribute("data-state", "in-progress");
+		await expect(card.locator("[data-test='trigger']")).toHaveText("context limit");
+		// Plaintext placeholder must NEVER appear in the rendered DOM.
+		await expect(page.getByText("Compacting context…")).toHaveCount(1); // header text
+		// And it must be inside the card (not a separate row).
+		const stray = await page.locator("body > :not(script):not(style)").evaluateAll((els) =>
+			els
+				.filter((el) => !el.querySelector("[data-testid='compaction-summary-card']"))
+				.filter((el) => /Compacting context/.test(el.textContent ?? ""))
+				.length,
+		);
+		expect(stray).toBe(0);
+
+		// Transition to complete.
+		await page.evaluate(() =>
+			(window as any).applyComplete({
+				tokensBefore: 202_592, tokensAfter: 180_000, reductionPct: 11.2,
+			}),
+		);
+		await expect(card).toHaveAttribute("data-state", "complete");
+		await expect(page.locator("[data-testid='compaction-summary-card']")).toHaveCount(1);
+		await expect(card.locator("[data-test='tokens-before']")).toContainText("tok");
+		await expect(card.locator("[data-test='tokens-after']")).toContainText("tok");
+		await expect(card.locator("[data-test='reduction-pct']")).toContainText("%");
+	});
+
+	test("in-progress → error: overflow trigger pill, error message visible", async ({ page }) => {
+		await gotoAndWait(page);
+		await page.evaluate(() => (window as any).applyInProgress("overflow", null));
+		const card = page.locator("[data-testid='compaction-summary-card']");
+		await expect(card).toHaveAttribute("data-state", "in-progress");
+
+		await page.evaluate(() => (window as any).applyError());
+		await expect(card).toHaveAttribute("data-state", "error");
+		await expect(card.locator("[data-test='trigger']")).toHaveText("context limit");
+		await expect(card.locator("[data-test='error']")).toContainText("202592 tokens");
+		// Still exactly one card on the page.
+		await expect(page.locator("[data-testid='compaction-summary-card']")).toHaveCount(1);
+	});
+
+	test("layout: tokens-before label sits adjacent to its value", async ({ page }) => {
+		await gotoAndWait(page);
+		await page.evaluate(() =>
+			(window as any).applyComplete({
+				tokensBefore: 12_500, tokensAfter: 3_000, reductionPct: 76,
+			}),
+		);
+		const gap = await page.evaluate(() => {
+			const value = document.querySelector("[data-test='tokens-before']") as HTMLElement | null;
+			if (!value) return -1;
+			// The label sits as the previous-sibling span inside the same wrapper.
+			const wrapper = value.parentElement!;
+			const label = wrapper.querySelector(".uppercase") as HTMLElement | null;
+			if (!label) return -1;
+			const lr = label.getBoundingClientRect();
+			const vr = value.getBoundingClientRect();
+			return Math.abs(vr.left - lr.right);
+		});
+		expect(gap).toBeGreaterThanOrEqual(0);
+		expect(gap).toBeLessThanOrEqual(24);
+	});
+
+	test("manual trigger pill renders 'manual', auto renders 'auto'", async ({ page }) => {
+		await gotoAndWait(page);
+		await page.evaluate(() => (window as any).applyComplete({ trigger: "manual" }));
+		await expect(page.locator("[data-test='trigger']")).toHaveText("manual");
+		await page.evaluate(() => (window as any).applyComplete({ trigger: "auto" }));
+		await expect(page.locator("[data-test='trigger']")).toHaveText("auto");
+	});
+});

--- a/tests/fixtures/compaction-widget-entry.ts
+++ b/tests/fixtures/compaction-widget-entry.ts
@@ -1,0 +1,58 @@
+// Test entry — bundles CompactionSummaryRenderer for a file:// fixture.
+import { render } from "lit";
+import { CompactionSummaryRenderer } from "../../src/ui/tools/renderers/CompactionSummaryRenderer.js";
+import {
+	buildCompactionSummaryMessages,
+	buildInProgressCompactionPayload,
+	type CompactionSummaryPayload,
+	type CompactionTrigger,
+} from "../../src/app/compaction-types.js";
+
+const container = document.getElementById("container")!;
+
+function renderPayload(payload: CompactionSummaryPayload) {
+	// Mirror how the renderer-registry invokes the renderer: pass the
+	// payload via the `result.details` slot so the renderer's primary
+	// `payload = result?.details ?? params` resolution path is exercised.
+	const { toolResult } = buildCompactionSummaryMessages(payload);
+	const r = new CompactionSummaryRenderer();
+	const out = r.render(payload, toolResult as any, false);
+	render(out.content, container);
+}
+
+(window as any).applyInProgress = (trigger: CompactionTrigger, tokensBefore: number | null = null) => {
+	renderPayload(buildInProgressCompactionPayload(trigger, tokensBefore));
+};
+
+(window as any).applyComplete = (extra: Partial<CompactionSummaryPayload> = {}) => {
+	const payload: CompactionSummaryPayload = {
+		schemaVersion: 1,
+		trigger: "overflow",
+		state: "complete",
+		success: true,
+		timestamp: "2026-05-12T00:00:01Z",
+		tokensBefore: 202_592,
+		tokensAfter: 180_000,
+		reductionPct: 11.2,
+		...extra,
+	};
+	renderPayload(payload);
+};
+
+(window as any).applyError = (extra: Partial<CompactionSummaryPayload> = {}) => {
+	const payload: CompactionSummaryPayload = {
+		schemaVersion: 1,
+		trigger: "overflow",
+		state: "error",
+		success: false,
+		timestamp: "2026-05-12T00:00:01Z",
+		tokensBefore: 202_592,
+		tokensAfter: null,
+		reductionPct: null,
+		error: "prompt is too long: 202592 tokens > 200000 maximum",
+		...extra,
+	};
+	renderPayload(payload);
+};
+
+(window as any).__ready = true;

--- a/tests/fixtures/compaction-widget.html
+++ b/tests/fixtures/compaction-widget.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>CompactionSummaryRenderer fixture</title>
+<style>
+	:root {
+		--background: #fff;
+		--foreground: #111;
+		--card: #fff;
+		--border: #e4e4e7;
+		--muted: #f4f4f5;
+		--muted-foreground: #71717a;
+		--chart-1: #3b82f6;
+		--warning: #d97706;
+		--destructive: #dc2626;
+	}
+	body { font-family: sans-serif; padding: 8px; color: var(--foreground); background: var(--background); }
+	.italic { font-style: italic; }
+	.font-mono { font-family: ui-monospace, monospace; }
+	.text-muted-foreground { color: var(--muted-foreground); }
+	.text-foreground { color: var(--foreground); }
+	.text-destructive { color: var(--destructive); }
+	.bg-card { background: var(--card); }
+	.bg-muted\/40 { background: color-mix(in oklch, var(--muted) 40%, transparent); }
+	.border-border { border-color: var(--border); }
+	.border { border-width: 1px; border-style: solid; }
+	.rounded { border-radius: 4px; }
+	.rounded-md { border-radius: 6px; }
+	.rounded-full { border-radius: 9999px; }
+	.p-3 { padding: 12px; }
+	.p-2 { padding: 8px; }
+	.px-2 { padding-left: 8px; padding-right: 8px; }
+	.py-0\.5 { padding-top: 2px; padding-bottom: 2px; }
+	.pt-1 { padding-top: 4px; }
+	.mt-1 { margin-top: 4px; }
+	.mt-2 { margin-top: 8px; }
+	.mt-3 { margin-top: 12px; }
+	.ml-1 { margin-left: 4px; }
+	.ml-2 { margin-left: 8px; }
+	.text-xs { font-size: 12px; }
+	.text-sm { font-size: 14px; }
+	.font-medium { font-weight: 500; }
+	.uppercase { text-transform: uppercase; }
+	.tracking-wide { letter-spacing: 0.025em; }
+	.inline-flex { display: inline-flex; }
+	.flex { display: flex; }
+	.flex-wrap { flex-wrap: wrap; }
+	.items-baseline { align-items: baseline; }
+	.items-center { align-items: center; }
+	.justify-between { justify-content: space-between; }
+	.gap-2 { gap: 8px; }
+	.gap-1\.5 { gap: 6px; }
+	.gap-x-4 { column-gap: 16px; }
+	.gap-y-1 { row-gap: 4px; }
+	.space-y-1\.5 > * + * { margin-top: 6px; }
+	.space-y-3 > * + * { margin-top: 12px; }
+	.h-1\.5 { height: 6px; }
+	.h-full { height: 100%; }
+	.w-24 { width: 96px; }
+	.w-32 { width: 128px; }
+	.w-full { width: 100%; }
+	.block { display: block; }
+	.cursor-pointer { cursor: pointer; }
+	.overflow-hidden { overflow: hidden; }
+	.overflow-x-auto { overflow-x: auto; }
+	.max-h-\[2000px\] { max-height: 2000px; }
+	.transition-all { transition: all 0.3s; }
+	.duration-300 { transition-duration: 0.3s; }
+	.text-green-600 { color: #16a34a; }
+	.animate-spin { animation: spin 1s linear infinite; }
+	@keyframes spin { to { transform: rotate(360deg); } }
+</style>
+</head>
+<body>
+<div id="container"></div>
+<script src="./compaction-widget-bundle.js"></script>
+</body>
+</html>

--- a/tests/manual-integration/compaction-pressure.spec.ts
+++ b/tests/manual-integration/compaction-pressure.spec.ts
@@ -250,7 +250,14 @@ test("compaction-pressure: auto-compaction triggers and agent recovers", async (
 		// sending text rather than the agent's pre-turn auto path — but the
 		// auto-compaction case is what we are exercising. Allow either, but
 		// prefer auto.
-		await expect(card.locator("[data-test='trigger']")).toHaveText(/auto|manual/);
+		await expect(card.locator("[data-test='trigger']")).toHaveText(/auto|manual|context limit/);
+		// Overflow-triggered compaction MUST surface as the "context limit" pill
+		// (NOT "manual"), reach the complete state, and carry parsed/non-null
+		// before+reduction values — pin for the four-defects design doc.
+		await expect(card).toHaveAttribute("data-state", "complete");
+		await expect(card.locator("[data-test='trigger']")).toHaveText("context limit");
+		await expect(card.locator("[data-test='tokens-before']")).toContainText(/\d/);
+		await expect(card.locator("[data-test='reduction-pct']")).toContainText(/-\d+(\.\d+)?%/);
 
 		// Post-compact turn succeeds.
 		await pollIdle(gw, sessionId, 240_000);

--- a/tests/message-reducer.test.ts
+++ b/tests/message-reducer.test.ts
@@ -246,57 +246,85 @@ describe("message-reducer", () => {
 		]);
 	});
 
-	it("(12) compaction placeholder + server marker — server wins, no double", () => {
-		const placeholder = {
-			id: "compacting_placeholder",
-			role: "assistant",
-			content: [{ type: "text", text: "Compacting context…" }],
-			timestamp: 0,
-		};
-		const clientResult = {
-			id: "compact_done_1",
-			role: "assistant",
-			content: [{ type: "text", text: "Context compacted from 12k tokens." }],
-			timestamp: 0,
-		};
-		const serverMarker = {
-			id: "asst_compact_server_1",
-			role: "assistant",
-			content: [{ type: "text", text: "Context compacted from 12k tokens." }],
-			timestamp: 0,
-		};
-		const s = applyAll([
-			{ type: "compaction-placeholder", message: placeholder },
-			{ type: "compaction-result", message: clientResult, success: true },
-			{ type: "snapshot", messages: [userMsg("u1", "x"), serverMarker] },
-		]);
-		const idList = s.messages.map((m) => m.id);
-		assert.ok(!idList.includes("compact_done_1"), `synthetic must be dropped, got ${idList.join(",")}`);
-		assert.ok(!idList.includes("compacting_placeholder"));
-		assert.ok(idList.includes("asst_compact_server_1"));
-		assert.strictEqual(s.messages.length, 2);
-	});
-
-	it("(12b) rich synthetic compaction wins over server text marker", () => {
-		const placeholder = {
-			id: "compacting_placeholder",
-			role: "assistant",
-			content: [{ type: "text", text: "Compacting context…" }],
-			timestamp: 0,
-		};
-		const richMsg = {
-			id: "compact_done_2",
+	it("(12) rich in-progress placeholder (stable id compact_active) carries no plaintext", () => {
+		// The placeholder is now a rich in-progress synthetic with stable id
+		// `compact_active` (not the legacy plaintext id `compacting_placeholder`).
+		// The reducer drops both ids defensively; assert no plaintext
+		// "Compacting context…" survives in the messages array.
+		const richInProgress = {
+			id: "compact_active",
 			role: "assistant",
 			timestamp: 0,
 			content: [{
 				type: "toolCall",
-				id: "compaction-summary:compact_done_2",
+				id: "compaction-summary:compact_active",
 				name: "__compaction_summary",
 				arguments: {
 					schemaVersion: 1,
 					trigger: "manual",
+					state: "in-progress",
 					success: true,
 					timestamp: "2026-05-12T00:00:00Z",
+					tokensBefore: null,
+					tokensAfter: null,
+					reductionPct: null,
+				},
+			}],
+		};
+		const s = applyAll([
+			{ type: "compaction-placeholder", message: richInProgress },
+		]);
+		const idList = s.messages.map((m) => m.id);
+		assert.ok(idList.includes("compact_active"), `rich in-progress must be present, got ${idList.join(",")}`);
+		assert.ok(!idList.includes("compacting_placeholder"), "legacy id must not leak in");
+		// No plaintext compaction row.
+		assert.ok(
+			!s.messages.some((m: any) => extractText(m).includes("Compacting context")),
+			"plaintext placeholder must not survive",
+		);
+		// Double-apply is idempotent (reconnect-race).
+		const s2 = reduce(s, { type: "compaction-placeholder", message: richInProgress });
+		const compactRows = s2.messages.filter((m) => m.id === "compact_active");
+		assert.strictEqual(compactRows.length, 1, "reconnect re-emission must collapse");
+	});
+
+	it("(12b) rich synthetic compaction (stable id compact_active) wins over server text marker", () => {
+		// Final rich row uses the STABLE id `compact_active` — the same id the
+		// in-progress placeholder carried. Single DOM identity invariant.
+		const richInProgress = {
+			id: "compact_active",
+			role: "assistant",
+			timestamp: 0,
+			content: [{
+				type: "toolCall",
+				id: "compaction-summary:compact_active",
+				name: "__compaction_summary",
+				arguments: {
+					schemaVersion: 1,
+					trigger: "manual",
+					state: "in-progress",
+					success: true,
+					timestamp: "2026-05-12T00:00:00Z",
+					tokensBefore: null,
+					tokensAfter: null,
+					reductionPct: null,
+				},
+			}],
+		};
+		const richMsg = {
+			id: "compact_active",
+			role: "assistant",
+			timestamp: 0,
+			content: [{
+				type: "toolCall",
+				id: "compaction-summary:compact_active",
+				name: "__compaction_summary",
+				arguments: {
+					schemaVersion: 1,
+					trigger: "manual",
+					state: "complete",
+					success: true,
+					timestamp: "2026-05-12T00:00:01Z",
 					tokensBefore: 12_000,
 					tokensAfter: 3_000,
 					reductionPct: 75,
@@ -305,7 +333,7 @@ describe("message-reducer", () => {
 		};
 		const richResult = {
 			role: "toolResult",
-			toolCallId: "compaction-summary:compact_done_2",
+			toolCallId: "compaction-summary:compact_active",
 			toolName: "__compaction_summary",
 			isError: false,
 			content: [{ type: "text", text: "ok" }],
@@ -318,18 +346,138 @@ describe("message-reducer", () => {
 			timestamp: 0,
 		};
 		const s = applyAll([
-			{ type: "compaction-placeholder", message: placeholder },
+			{ type: "compaction-placeholder", message: richInProgress },
 			{ type: "compaction-result", message: richMsg, toolResult: richResult, success: true },
 			{ type: "snapshot", messages: [userMsg("u1", "x"), serverText] },
 		]);
 		const idList = s.messages.map((m) => m.id);
-		assert.ok(idList.includes("compact_done_2"), `rich synthetic must survive, got ${idList.join(",")}`);
+		assert.ok(idList.includes("compact_active"), `rich synthetic must survive, got ${idList.join(",")}`);
 		assert.ok(!idList.includes("asst_compact_server_2"), `server text marker must be dropped, got ${idList.join(",")}`);
 		assert.ok(!idList.includes("compacting_placeholder"));
+		// Exactly ONE assistant row with the stable id — single DOM identity.
+		const stableRows = s.messages.filter((m) => m.id === "compact_active");
+		assert.strictEqual(stableRows.length, 1);
 		// Paired synthetic toolResult is also present.
 		assert.ok(
 			s.messages.some((m) => m.role === "toolResult" && (m as any).toolName === "__compaction_summary"),
 		);
+	});
+
+	it("(12d) in-progress synthetic transitions in place on result — single row, single id", () => {
+		const inProgress = {
+			id: "compact_active",
+			role: "assistant",
+			timestamp: 0,
+			content: [{
+				type: "toolCall",
+				id: "compaction-summary:compact_active",
+				name: "__compaction_summary",
+				arguments: {
+					schemaVersion: 1,
+					trigger: "overflow",
+					state: "in-progress",
+					success: true,
+					timestamp: "2026-05-12T00:00:00Z",
+					tokensBefore: 200_000,
+					tokensAfter: null,
+					reductionPct: null,
+				},
+			}],
+		};
+		const complete = {
+			id: "compact_active",
+			role: "assistant",
+			timestamp: 0,
+			content: [{
+				type: "toolCall",
+				id: "compaction-summary:compact_active",
+				name: "__compaction_summary",
+				arguments: {
+					schemaVersion: 1,
+					trigger: "overflow",
+					state: "complete",
+					success: true,
+					timestamp: "2026-05-12T00:00:01Z",
+					tokensBefore: 202_592,
+					tokensAfter: 180_000,
+					reductionPct: 11.2,
+				},
+			}],
+		};
+		const completeResult = {
+			role: "toolResult",
+			toolCallId: "compaction-summary:compact_active",
+			toolName: "__compaction_summary",
+			isError: false,
+			content: [{ type: "text", text: "ok" }],
+			timestamp: 0,
+		};
+		const s = applyAll([
+			{ type: "compaction-placeholder", message: inProgress },
+			{ type: "compaction-result", message: complete, toolResult: completeResult, success: true },
+		]);
+		const stableRows = s.messages.filter((m) => m.id === "compact_active");
+		assert.strictEqual(stableRows.length, 1, "exactly one assistant row carries the stable id");
+		const payload: any = (stableRows[0].content as any[])[0].arguments;
+		assert.strictEqual(payload.state, "complete", "state transitioned in place");
+		assert.strictEqual(payload.tokensBefore, 202_592);
+		assert.strictEqual(payload.trigger, "overflow");
+		// Paired toolResult on the same toolCallId, exactly one.
+		const tres = s.messages.filter(
+			(m: any) => m.role === "toolResult"
+				&& m.toolCallId === "compaction-summary:compact_active",
+		);
+		assert.strictEqual(tres.length, 1, "exactly one paired toolResult");
+	});
+
+	it("(12e) overflow trigger preserved end-to-end through reducer", () => {
+		// Asserts that an overflow-triggered compaction-result with a parsed
+		// tokensBefore lands as a single rich row carrying trigger="overflow"
+		// and tokensBefore from the canonical Anthropic error string. The
+		// parse itself is unit-tested against parseOverflowTokenCount in
+		// `tests/compaction-types.test.ts` (or inline below).
+		const PARSED = 202_592; // from "prompt is too long: 202592 tokens > 200000 maximum"
+		const inProgress = {
+			id: "compact_active",
+			role: "assistant",
+			timestamp: 0,
+			content: [{
+				type: "toolCall",
+				id: "compaction-summary:compact_active",
+				name: "__compaction_summary",
+				arguments: {
+					schemaVersion: 1, trigger: "overflow", state: "in-progress",
+					success: true, timestamp: "2026-05-12T00:00:00Z",
+					tokensBefore: null, tokensAfter: null, reductionPct: null,
+				},
+			}],
+		};
+		const errored = {
+			id: "compact_active",
+			role: "assistant",
+			timestamp: 0,
+			content: [{
+				type: "toolCall",
+				id: "compaction-summary:compact_active",
+				name: "__compaction_summary",
+				arguments: {
+					schemaVersion: 1, trigger: "overflow", state: "error",
+					success: false, timestamp: "2026-05-12T00:00:01Z",
+					tokensBefore: PARSED, tokensAfter: null, reductionPct: null,
+					error: "prompt is too long: 202592 tokens > 200000 maximum",
+				},
+			}],
+		};
+		const s = applyAll([
+			{ type: "compaction-placeholder", message: inProgress },
+			{ type: "compaction-result", message: errored, success: false },
+		]);
+		const row = s.messages.find((m) => m.id === "compact_active");
+		assert.ok(row, "compact_active row exists");
+		const payload: any = (row!.content as any[])[0].arguments;
+		assert.strictEqual(payload.trigger, "overflow");
+		assert.strictEqual(payload.state, "error");
+		assert.strictEqual(payload.tokensBefore, PARSED);
 	});
 
 	it("(12c) snapshot with only server text marker is upgraded to a rich synthetic", () => {


### PR DESCRIPTION
Polishes the rich compaction summary card from #560 to fix four production defects observed on real overflow-triggered compactions.

## Defects fixed

1. **`tokensBefore` populated on overflow.** Previously null because the count was only being read from the manual `/compact` RPC result. Now resolved via a four-step priority chain in `remote-agent.ts`: `event.result.tokensBefore` → `event.tokensBefore` → `parseOverflowTokenCount(errorMessage)` → `_lastKnownContextTokens` cache. The parser pulls the leading integer out of Anthropic's `prompt is too long: N tokens > M maximum` error.
2. **Compact label/value layout.** Replaced `flex justify-between` (label flush left, value flush right) with inline groups that keep the value adjacent to its label.
3. **Overflow trigger labeled correctly.** Payload `trigger` union extended to `"manual" | "auto" | "overflow"`. Derived from upstream `event.reason` (manual / threshold / overflow) emitted by pi-coding-agent. Renders as a `context limit` pill with `var(--warning)` tint. Server's manual `/compact` path now broadcasts `reason: "manual"` so the client unifies on `event.reason`.
4. **In-progress is a rendered widget, transitions in place.** The plaintext `"Compacting context…"` placeholder is gone. The in-progress state is now a rich card with a spinner and indeterminate progress bar, carrying the same stable id `compact_active` as the eventual completion / error state — Lit diffs the same DOM node, no second card.

## Single-card lifecycle invariant

The central UX invariant — one DOM node carries the widget across `in-progress → complete | error` — is pinned by:
- `tests/message-reducer.test.ts` case 12d (in-place transition).
- `tests/e2e/ui/compaction-widget.spec.ts` (browser E2E, file:// harness asserting card count stays at 1 and no plaintext placeholder ever appears).

## Test coverage

- `tests/compaction-types.test.ts` (new) — `parseOverflowTokenCount`, in-progress builder, stable id.
- `tests/message-reducer.test.ts` — cases 12 and 12b updated for new stable id; 12d and 12e added.
- `tests/e2e/ui/compaction-widget.spec.ts` (new) — 4 tests covering all state transitions and layout.
- `tests/manual-integration/compaction-pressure.spec.ts` — adds assertions that overflow-triggered compactions render non-null `tokensBefore`/`reductionPct` and the `context limit` trigger pill.
- `tests/compaction.spec.ts` — adds a `trigger="manual"` sanity assertion for the `/compact` slash command end-to-end.

`npm run check` + `npm run test:unit` + `npm run test:e2e -- --grep compaction` (new widget E2E) all green.

## Documentation

`docs/compaction.md` updated for the three-trigger model, new `state` field, single-card lifecycle, and overflow `tokensBefore` resolution. New §7 in `docs/design/compaction-e2e-rich-summary.md` documents the polish revision architecture.

## Files

| Area | Files |
|---|---|
| Schema + helpers | `src/app/compaction-types.ts` |
| Reducer | `src/app/message-reducer.ts` |
| Live emission | `src/app/remote-agent.ts` |
| Renderer | `src/ui/tools/renderers/CompactionSummaryRenderer.ts` |
| Server | `src/server/ws/handler.ts` |
| Tests | `tests/compaction-types.test.ts` (new), `tests/message-reducer.test.ts`, `tests/e2e/ui/compaction-widget.spec.ts` (new), `tests/fixtures/compaction-widget*.{html,ts}` (new), `tests/manual-integration/compaction-pressure.spec.ts`, `tests/compaction.spec.ts` |
| Docs | `docs/compaction.md`, `docs/design/compaction-e2e-rich-summary.md` |

Previous PR: #560 (merged). This is pure polish + lifecycle upgrade; no revert.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)