### PR TITLE
Reset per-project accent colors on None palette

### DIFF
--- a/src/server/agent/project-registry.ts
+++ b/src/server/agent/project-registry.ts
@@ -297,6 +297,14 @@ export class ProjectRegistry {
         if (updates.colorDark === undefined) {
           project.colorDark = PALETTE_PRIMARY_COLORS[project.palette].dark;
         }
+      } else if (!project.palette) {
+        // Clearing palette → reset accents to defaults (unless caller supplied explicit overrides)
+        if (updates.colorLight === undefined) {
+          project.colorLight = DEFAULT_PROJECT_COLOR_LIGHT;
+        }
+        if (updates.colorDark === undefined) {
+          project.colorDark = DEFAULT_PROJECT_COLOR_DARK;
+        }
       }
     }
 

--- a/tests/e2e/ui/project-palette-none.spec.ts
+++ b/tests/e2e/ui/project-palette-none.spec.ts
@@ -22,6 +22,11 @@ import { tmpdir } from "node:os";
 import { test, expect } from "../gateway-harness.js";
 import { apiFetch } from "../e2e-setup.js";
 import { openApp, navigateToHash } from "./ui-helpers.js";
+import {
+	DEFAULT_PROJECT_COLOR_LIGHT,
+	DEFAULT_PROJECT_COLOR_DARK,
+	PALETTE_PRIMARY_COLORS,
+} from "../../../src/shared/palette-colors.js";
 
 test.describe('Per-project palette "None (use global)" card', () => {
 	let projectId: string | undefined;
@@ -88,6 +93,13 @@ test.describe('Per-project palette "None (use global)" card', () => {
 		await oceanBtn.click();
 		await putResponse;
 
+		// After picking Ocean, the server should have auto-seeded accent colors
+		// from the Ocean palette primaries.
+		const afterOcean = await (await apiFetch(`/api/projects/${projectId}`)).json();
+		expect(afterOcean.palette).toBe("ocean");
+		expect(afterOcean.colorLight).toBe(PALETTE_PRIMARY_COLORS.ocean.light);
+		expect(afterOcean.colorDark).toBe(PALETTE_PRIMARY_COLORS.ocean.dark);
+
 		await expect(
 			oceanBtn.locator("text=Active"),
 			'expected the "Ocean" palette card to show Active after clicking it',
@@ -143,12 +155,40 @@ test.describe('Per-project palette "None (use global)" card', () => {
 			)
 			.toBe(globalPalette);
 
-		// Server should report the project with no palette override.
+		// Server should report the project with no palette override AND
+		// accent colors reset to defaults (since the caller didn't supply
+		// explicit colorLight/colorDark in the PUT).
 		const after = await (await apiFetch(`/api/projects/${projectId}`)).json();
 		expect(
 			after.palette === undefined || after.palette === null || after.palette === "",
 			`expected GET /api/projects/${projectId} to return no palette field after clearing override, got ${JSON.stringify(after.palette)}`,
 		).toBe(true);
+		expect(
+			after.colorLight,
+			"expected colorLight to reset to default after clearing palette",
+		).toBe(DEFAULT_PROJECT_COLOR_LIGHT);
+		expect(
+			after.colorDark,
+			"expected colorDark to reset to default after clearing palette",
+		).toBe(DEFAULT_PROJECT_COLOR_DARK);
+
+		// The visible oklch swatch labels next to the color pickers should
+		// reflect the defaults too.
+		await expect
+			.poll(
+				() =>
+					page.evaluate(() =>
+						Array.from(document.querySelectorAll('input[type="color"]')).map(
+							(el) => (el.nextElementSibling?.textContent || "").trim(),
+						),
+					),
+				{
+					message:
+						"expected the oklch labels next to the color pickers to reflect the default accent colors after clicking None",
+					timeout: 5_000,
+				},
+			)
+			.toEqual([DEFAULT_PROJECT_COLOR_LIGHT, DEFAULT_PROJECT_COLOR_DARK]);
 
 		// --- Step 3: reload — "None" should still be Active and DOM still global.
 		await page.reload();
@@ -178,5 +218,25 @@ test.describe('Per-project palette "None (use global)" card', () => {
 				},
 			)
 			.toBe(globalPalette);
+
+		// Default accent colors should also persist across reload.
+		const afterReload = await (await apiFetch(`/api/projects/${projectId}`)).json();
+		expect(afterReload.colorLight).toBe(DEFAULT_PROJECT_COLOR_LIGHT);
+		expect(afterReload.colorDark).toBe(DEFAULT_PROJECT_COLOR_DARK);
+		await expect
+			.poll(
+				() =>
+					page.evaluate(() =>
+						Array.from(document.querySelectorAll('input[type="color"]')).map(
+							(el) => (el.nextElementSibling?.textContent || "").trim(),
+						),
+					),
+				{
+					message:
+						"expected default accent colors to persist across reload",
+					timeout: 5_000,
+				},
+			)
+			.toEqual([DEFAULT_PROJECT_COLOR_LIGHT, DEFAULT_PROJECT_COLOR_DARK]);
 	});
 });

--- a/tests/mobile-review-annotation.spec.ts
+++ b/tests/mobile-review-annotation.spec.ts
@@ -241,23 +241,59 @@ test.describe("Mobile review annotation — CSS", () => {
 		expect(parseInt(zIndex)).toBeGreaterThanOrEqual(200);
 	});
 
-	test("r6o-annotation has highlight styles", async ({ page }) => {
+	test("r6o-annotation highlight pipeline (inline style + blend-mode override)", async ({ page }) => {
+		// Since commit b20b1a00, the per-annotation background colour is no
+		// longer set by a stylesheet rule on `.r6o-annotation` — text-annotator
+		// writes it as an INLINE style on each span (see ReviewDocument.ts
+		// `_highlightStyle`). The only CSS-side piece of the fix that survives
+		// in review-pane.css is the `.r6o-span-highlight-layer` blend-mode
+		// override. This test pins both:
+		//   1. inline background-color on `.r6o-annotation` is not clobbered
+		//      by review-pane.css (so the library's inline styles win), and
+		//   2. `.r6o-span-highlight-layer` has mix-blend-mode: normal (the
+		//      library hard-codes `multiply` which on dark themes multiplies
+		//      the tint into near-black — this rule restores intended alpha).
 		await page.goto(TEST_PAGE);
 
-		// Create a mock annotation highlight
 		await page.evaluate(() => {
+			// Simulate what text-annotator does: write an inline background-color
+			// onto the .r6o-annotation span. The previous CSS used `!important`,
+			// which would have overridden this inline value — removing that rule
+			// is precisely what made the per-theme colour reach the DOM.
 			const span = document.createElement("span");
 			span.className = "r6o-annotation";
 			span.textContent = "highlighted";
-			document.getElementById("content")!.appendChild(span);
+			span.style.backgroundColor = "rgba(99, 102, 241, 0.45)";
+
+			// Wrap in the span-highlight-layer the library emits — this is the
+			// element our CSS override targets.
+			const layer = document.createElement("div");
+			layer.className = "r6o-span-highlight-layer";
+			layer.appendChild(span);
+			document.getElementById("content")!.appendChild(layer);
 		});
 
+		// (1) Inline background-color survives review-pane.css.
 		const bg = await page.locator(".r6o-annotation").evaluate(
 			(el: HTMLElement) => getComputedStyle(el).backgroundColor,
 		);
-		// Should have a purple-ish highlight background
 		expect(bg).not.toBe("rgba(0, 0, 0, 0)");
 		expect(bg).not.toBe("transparent");
+		// Should reflect the inline value we set, not anything from CSS.
+		expect(bg).toBe("rgba(99, 102, 241, 0.45)");
+
+		// (2) Cursor affordance on .r6o-annotation is preserved.
+		const cursor = await page.locator(".r6o-annotation").evaluate(
+			(el: HTMLElement) => getComputedStyle(el).cursor,
+		);
+		expect(cursor).toBe("pointer");
+
+		// (3) review-pane.css forces mix-blend-mode: normal on the highlight
+		// layer so the baked alpha renders correctly on dark themes.
+		const blend = await page.locator(".r6o-span-highlight-layer").evaluate(
+			(el: HTMLElement) => getComputedStyle(el).mixBlendMode,
+		);
+		expect(blend).toBe("normal");
 	});
 
 	test("bottom sheet has slide-up animation class applied", async ({ page }) => {


### PR DESCRIPTION
Selecting **None (use global)** for a project's palette now also resets the per-project accent colors (`colorLight` / `colorDark`) to the defaults — not just the palette field. This makes "None" feel like a full revert to global defaults instead of a half-overridden state.

Follow-up to #561 — a product-decision change on top of the merged palette-clearing fix.

## Changes

### Server — `src/server/agent/project-registry.ts::update()`
Extended the palette-change branch: when `updates.palette` is cleared and no explicit `colorLight`/`colorDark` are supplied in the same update, both accent fields reset to `DEFAULT_PROJECT_COLOR_LIGHT` / `DEFAULT_PROJECT_COLOR_DARK`. Explicit color-picker updates (which don't touch `palette`) are unaffected.

### Test — `tests/e2e/ui/project-palette-none.spec.ts`
Extended the existing "None palette" repro:
- Picking ocean seeds ocean primaries (API check).
- Clicking None resets both fields to defaults (API + DOM color-picker labels).
- Defaults persist across reload.

### No client changes
`src/app/settings-page.ts` already PUTs `{ palette: null }` with no color fields, and `applyProjectPalette()` picks up the server-reset values automatically.

### Drive-by fix
Fixed pre-existing failing test `tests/mobile-review-annotation.spec.ts` ("r6o-annotation has highlight styles") that broke on master in #b20b1a00 — the inline-style refactor made the static-CSS assertion obsolete. Test-only change.

## Verification
- \`npm run check\` — passes
- \`npm run test:unit\` — passes
- \`npm run test:e2e\` — passes (incl. extended `project-palette-none` spec)

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)