### PR TITLE
Upgrade pi packages to 0.73.1 + add tool-use canary spec

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -876,6 +876,14 @@ The HTML video-capture report is only emitted when `RECORDSCREEN=1`. If ffmpeg i
 
 If the popup window closes without the UI advancing, poll `GET /api/oauth/flow-status?flowId=&provider=` directly to see whether the server received the callback. Files: `src/server/auth/oauth.ts`; REST: `/api/oauth/*`.
 
+## 60+ TSchema errors / typebox flavor mismatch after pi upgrade
+
+- **Symptom**: after bumping `@mariozechner/pi-ai` (or any `@mariozechner/pi-*` package that re-exports schema helpers), `npm run check` floods with structurally-incompatible-type errors against `TSchema`, `TObject`, `TProperties`, `Static<...>`, etc. Errors typically point at a file that mixes `Type.Object(...)` / `Static<typeof X>` with a pi-ai-returning helper like `StringEnum` or a tool whose `parameters` schema is consumed by pi-ai.
+- **Root cause**: pi-ai 0.73+ re-exports `Type` and `Static` from typebox **v1**. Bobbit also has a direct dependency on `@sinclair/typebox` v0.34. The two packages publish structurally-different `TSchema` types, so a value built with `@sinclair/typebox`'s `Type.Object(...)` is no longer assignable to a slot that pi-ai expects to be a v1 `TObject`, even though the runtime JSON shape is identical.
+- **Rule**: in any file that combines pi-ai schema helpers (or hands a schema to a pi-ai-typed slot) with `Type.Object(...)` / `Static<typeof X>`, import `Type` and `Static` from `@mariozechner/pi-ai` — not from `@sinclair/typebox`. Mixing flavors in the same file is the bug; picking one and using it consistently is the fix.
+- **Reference**: `src/ui/tools/artifacts/artifacts.ts` is the canonical example — it imports `StringEnum, Static, ToolCall, Type` together from `@mariozechner/pi-ai`. Files that have no pi-ai schema interop can keep importing from `@sinclair/typebox` as before.
+- **Diagnosis tip**: if the error count is large (dozens to hundreds) and all variants of `TSchema is not assignable to TSchema` originate from the same module, you're looking at a flavor mismatch, not a real type bug. Switch the `Type` / `Static` import in that file and re-run `npm run check` before changing any schema definitions.
+
 ## Bundle-size assertion fails
 
 `tests/bundle-size.test.ts` reads `dist/ui/.vite/manifest.json` to find the entry chunk and asserts ≤ 600 kB gzipped, plus ≤ 500 kB gzipped for any non-worker chunk. Check `dist/ui/.vite/manifest.j

--- a/docs/testing-coverage.md
+++ b/docs/testing-coverage.md
@@ -49,6 +49,15 @@ User-facing contract: "if I am at the bottom when content arrives, I stay at the
 - **Production invariant** — `agent-interface .overflow-y-auto` ships with inline `overflow-anchor: none` so Chromium and Safari/iOS PWA execute the same JS pin path; CI on Chromium catches what Safari users would otherwise see in production. Contract in [docs/internals.md — Chat scroll lock invariant](internals.md#chat-scroll-lock-invariant).
 - **Lower-tier scroll specs** — unit-level coverage of the scroll lock primitives lives in `tests/agent-interface-scroll.spec.ts` (zero-delta vibration), `tests/agent-interface-scroll-hardening.spec.ts` (echo ring, sub-pixel rounding), `tests/scroll-anchor-shrink.spec.ts`, `tests/collapse-scroll-bugs.spec.ts`, `tests/mobile-scroll-keyboard.spec.ts`, `tests/e2e/ui/jump-to-bottom.spec.ts`.
 
+## Agent tool-use canary (manual integration)
+
+- **File**: `tests/manual-integration/agent-tool-use.spec.ts`. Runs under `npm run test:manual` only (real LLM + Docker sandbox).
+- **Why it exists**: an earlier upgrade of the upstream `@mariozechner/pi-*` packages silently broke all agent tool use; no test in the unit / API / browser layers exercised a real LLM-driven agent calling tools end-to-end, so the regression escaped the whole suite. This spec is the canary that fails fast on the next pi bump if the tool-call wiring breaks again.
+- **What it covers**: five scenarios, each in its own fresh sandboxed session — builtin `bash`, the `defaults/tools/filesystem/edit` MCP tool, the `defaults/tools/filesystem/find` MCP tool, mid-tool steer/interrupt (long-running bash, then pivot), and a tool error path (`edit` on a missing file). Together they exercise builtin shell, file-editing, MCP-backed tools, the steer/interrupt path, and tool-error surfacing.
+- **Sentinel-based assertions, not log scraping**: each scenario instructs the agent to emit a unique sentinel — `HELLO_<nonce>`, `DONE`, `COUNT=3`, `PIVOT_ACK`, `EDIT_FAILED:` — and the test asserts the sentinel appears in the rendered transcript (UI DOM) or in the filesystem state of the worktree. Assertions are deliberately on observable user-facing behavior rather than on internal session logs or pi-ai event shapes, so the test stays valid across pi-internal refactors.
+- **Runtime budget**: stays inside the existing `npm run test:manual` ~5-minute budget; scenarios run serially in fresh sessions to keep each one independent and the failure signal narrow.
+- **Gate on pi upgrades**: this spec must be green on the currently pinned pi line **before** any `@mariozechner/pi-*` version bump, and must stay green after. If it regresses after a bump, the bump is the bug — adapt Bobbit to pi's new API rather than relaxing the spec.
+
 ## Sidebar child auto-loading
 
 Ensures visible sidebar entries always have their children loaded.

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -516,6 +516,10 @@ This lane is opt-in (needs an API key) and is **not** part of `npm run test:e2e`
 
 **When to run**: After changes to session lifecycle, restore logic, sandbox wiring, worktree management, git status polling, or any server restart behavior. Not needed for UI-only or prompt-only changes.
 
+### Agent tool-use canary
+
+`tests/manual-integration/agent-tool-use.spec.ts` is the regression net for upstream `@mariozechner/pi-*` upgrades. A previous pi bump silently broke all agent tool use because nothing in the unit / API / browser layers exercised a real LLM-driven agent actually calling tools end-to-end. The spec spawns a real agent in a sandboxed session and drives five scenarios (builtin bash, MCP-backed edit and find, mid-tool steer/interrupt, tool error) that each assert on a unique sentinel string in the UI transcript or on filesystem state — never on internal session logs — so it stays valid across pi-internal refactors. Run before and after any `@mariozechner/pi-*` version bump; see [testing-coverage.md — Agent tool-use canary](testing-coverage.md#agent-tool-use-canary-manual-integration) for the scenario list and rationale.
+
 ## Target State
 
 | Layer | Tests | Runtime | Confidence |

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "dependencies": {
         "@lmstudio/sdk": "^1.5.0",
         "@mariozechner/mini-lit": "^0.2.0",
-        "@mariozechner/pi-agent-core": "^0.67.5",
-        "@mariozechner/pi-ai": "^0.67.5",
-        "@mariozechner/pi-coding-agent": "^0.67.5",
+        "@mariozechner/pi-agent-core": "^0.73.1",
+        "@mariozechner/pi-ai": "^0.73.1",
+        "@mariozechner/pi-coding-agent": "^0.73.1",
         "@recogito/text-annotator": "^3.4.9",
         "@sinclair/typebox": "^0.34.41",
         "acme-client": "^5.4.0",
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.90.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
-      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -1504,9 +1504,9 @@
       }
     },
     "node_modules/@mariozechner/clipboard": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.2.tgz",
-      "integrity": "sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.5.tgz",
+      "integrity": "sha512-D3F+UrU9CR7roJt0zDLp6Oc+4/KlLDIrN4frH+6V90SJNW2KKUec1oCQIPaaDjCqeOsQyX9dyqYbImIQIM45PA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1682,19 +1682,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@mariozechner/jiti": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
-      "integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
-      "license": "MIT",
-      "dependencies": {
-        "std-env": "^3.10.0",
-        "yoctocolors": "^2.1.2"
-      },
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
     "node_modules/@mariozechner/mini-lit": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@mariozechner/mini-lit/-/mini-lit-0.2.1.tgz",
@@ -1717,36 +1704,35 @@
       }
     },
     "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.67.68",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.67.68.tgz",
-      "integrity": "sha512-anwFuzeUL7Qjbyih4DWY7w1zrOTrBxaz1L6+duLUuuzpHOun0EiP4KWIGTXPT5oJA7ZaeRNTyXJ7PlWfGQG33g==",
+      "version": "0.73.1",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.73.1.tgz",
+      "integrity": "sha512-Y/KVOhuKSgRQgYBlwmRtO2gPkUcoavOSqGF9bpQIINvNZvc19k6Z1H3bFDTce3Vp5ApMmTsfLH3+tNvOg75fAQ==",
       "deprecated": "please use @earendil-works/pi-agent-core instead going forward",
       "license": "MIT",
       "dependencies": {
-        "@mariozechner/pi-ai": "^0.67.68"
+        "@mariozechner/pi-ai": "^0.73.1",
+        "typebox": "^1.1.24"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "node_modules/@mariozechner/pi-ai": {
-      "version": "0.67.68",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.67.68.tgz",
-      "integrity": "sha512-DWWQmcb3IV3mbGXmzYBScfKA6kA52n/stY029eiBikrIxVT7DGLG6n7KSvTA2R4qBSgi1iFL3nGHtwxmtIn6Lg==",
+      "version": "0.73.1",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.73.1.tgz",
+      "integrity": "sha512-Jh4lXawZYuC83HzSIYuVum9NBqJD49i4JOt3H96cGW/924cwJMOyUs1Mv/e4QPzTXnzrqMoGviNQnvGgSu1LSg==",
       "deprecated": "please use @earendil-works/pi-ai instead going forward",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.90.0",
+        "@anthropic-ai/sdk": "^0.91.1",
         "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
         "@google/genai": "^1.40.0",
         "@mistralai/mistralai": "^2.2.0",
-        "@sinclair/typebox": "^0.34.41",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
         "chalk": "^5.6.2",
         "openai": "6.26.0",
         "partial-json": "^0.1.7",
         "proxy-agent": "^6.5.0",
+        "typebox": "^1.1.24",
         "undici": "^7.19.1",
         "zod-to-json-schema": "^3.24.6"
       },
@@ -1770,18 +1756,16 @@
       }
     },
     "node_modules/@mariozechner/pi-coding-agent": {
-      "version": "0.67.68",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.67.68.tgz",
-      "integrity": "sha512-Bai2yUBpgjftqGvg3GNV9pxcMAatqJwQYsqM+7j39+tm+IpoW7hbMBnzXZQvykAwXIrTXpZFF5yp5ajeDI5Atg==",
+      "version": "0.73.1",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.73.1.tgz",
+      "integrity": "sha512-gXQh3SaZmWTfVMc4Ao5+LGbVeKvzyO7tolok0nLsZgq9nGjZx/EEU3NM8C+qUnB4Nvs2rswG5qOVgLzQkq0fHQ==",
       "deprecated": "please use @earendil-works/pi-coding-agent instead going forward",
       "license": "MIT",
       "dependencies": {
-        "@mariozechner/jiti": "^2.6.2",
-        "@mariozechner/pi-agent-core": "^0.67.68",
-        "@mariozechner/pi-ai": "^0.67.68",
-        "@mariozechner/pi-tui": "^0.67.68",
+        "@mariozechner/pi-agent-core": "^0.73.1",
+        "@mariozechner/pi-ai": "^0.73.1",
+        "@mariozechner/pi-tui": "^0.73.1",
         "@silvia-odwyer/photon-node": "^0.3.4",
-        "ajv": "^8.17.1",
         "chalk": "^5.5.0",
         "cli-highlight": "^2.1.11",
         "diff": "^8.0.2",
@@ -1790,12 +1774,14 @@
         "glob": "^13.0.1",
         "hosted-git-info": "^9.0.2",
         "ignore": "^7.0.5",
+        "jiti": "^2.7.0",
         "marked": "^15.0.12",
         "minimatch": "^10.2.3",
         "proper-lockfile": "^4.1.2",
         "strip-ansi": "^7.1.0",
+        "typebox": "^1.1.24",
         "undici": "^7.19.1",
-        "uuid": "^11.1.0",
+        "uuid": "^14.0.0",
         "yaml": "^2.8.2"
       },
       "bin": {
@@ -1805,7 +1791,7 @@
         "node": ">=20.6.0"
       },
       "optionalDependencies": {
-        "@mariozechner/clipboard": "^0.3.2"
+        "@mariozechner/clipboard": "^0.3.5"
       }
     },
     "node_modules/@mariozechner/pi-coding-agent/node_modules/chalk": {
@@ -1833,22 +1819,22 @@
       }
     },
     "node_modules/@mariozechner/pi-coding-agent/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/@mariozechner/pi-tui": {
-      "version": "0.67.68",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.67.68.tgz",
-      "integrity": "sha512-RhcMaGz88lNOm5+9yx+YCIfXZALLbMxB2cwsoHzyOzs+OZAItw8tz6xJZPAnX0RHY+ENQEGMMDY9TF6pxxnkbA==",
+      "version": "0.73.1",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.73.1.tgz",
+      "integrity": "sha512-ybVsRnUbzQRtbocltJ2OXb2QogrO67N2BlUyKjZz9BHcZYiDJtNkcKQockxDjsVvDc0uBCLDX6iZJoBElBd8fw==",
       "deprecated": "please use @earendil-works/pi-tui instead going forward",
       "license": "MIT",
       "dependencies": {
@@ -4523,39 +4509,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/alien-signals": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-2.0.8.tgz",
@@ -5579,12 +5532,6 @@
         "@types/yauzl": "^2.9.1"
       }
     },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -5601,22 +5548,6 @@
       "engines": {
         "node": ">=8.6.0"
       }
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
@@ -6491,10 +6422,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -6521,12 +6451,6 @@
       "engines": {
         "node": ">=16"
       }
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
     },
     "node_modules/jsonschema": {
       "version": "1.5.0",
@@ -7984,15 +7908,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -8461,12 +8376,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-      "license": "MIT"
-    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -8828,6 +8737,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/typebox": {
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -9298,18 +9213,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yoctocolors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   "dependencies": {
     "@lmstudio/sdk": "^1.5.0",
     "@mariozechner/mini-lit": "^0.2.0",
-    "@mariozechner/pi-agent-core": "^0.67.5",
-    "@mariozechner/pi-ai": "^0.67.5",
-    "@mariozechner/pi-coding-agent": "^0.67.5",
+    "@mariozechner/pi-agent-core": "^0.73.1",
+    "@mariozechner/pi-ai": "^0.73.1",
+    "@mariozechner/pi-coding-agent": "^0.73.1",
     "@recogito/text-annotator": "^3.4.9",
     "@sinclair/typebox": "^0.34.41",
     "acme-client": "^5.4.0",

--- a/src/ui/tools/artifacts/artifacts.ts
+++ b/src/ui/tools/artifacts/artifacts.ts
@@ -1,8 +1,7 @@
 import { icon } from "@mariozechner/mini-lit";
 import { Button } from "@mariozechner/mini-lit/dist/Button.js";
 import type { Agent, AgentMessage, AgentTool } from "@mariozechner/pi-agent-core";
-import { StringEnum, type ToolCall } from "@mariozechner/pi-ai";
-import { type Static, Type } from "@sinclair/typebox";
+import { StringEnum, type Static, type ToolCall, Type } from "@mariozechner/pi-ai";
 import { html, LitElement, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { createRef, type Ref, ref } from "lit/directives/ref.js";

--- a/tests/manual-integration/agent-tool-use.spec.ts
+++ b/tests/manual-integration/agent-tool-use.spec.ts
@@ -1,0 +1,542 @@
+/**
+ * Agent tool-use canary — proves end-to-end tool calls really work.
+ *
+ * This is the regression net for upstream `@mariozechner/pi-*` upgrades. A
+ * previous upgrade silently broke all agent tool use; no existing test
+ * exercised a real LLM-driven agent calling tools end-to-end. This file
+ * closes that gap.
+ *
+ * Five scenarios, each in its own fresh sandboxed session:
+ *   1. bash       — builtin shell, command echo produces sentinel HELLO_<nonce>
+ *   2. edit       — defaults/tools/filesystem/edit on a pre-created file, sentinel DONE
+ *   3. find       — defaults/tools/filesystem/find on pre-created files, sentinel COUNT=3
+ *   4. interrupt  — long-running bash, then steer to PIVOT_ACK
+ *   5. error      — edit on missing file, sentinel EDIT_FAILED:
+ *
+ * Helpers (`startGW`, `stopGW`, `api`, `pollIdle`, `browserSend`,
+ * `interruptAndSend`, `initRepo`, `projectRegistrationBody`, `getSession`,
+ * `freePort`, `appUrl`, `sessionUrl`, `takeScreenshot`,
+ * `RESULTS_DIR`/`WANT_SCREENSHOTS`) are copied verbatim from
+ * `session-resilience.spec.ts`. Per the design doc, helper extraction is out
+ * of scope for this PR — every existing manual spec inlines these.
+ *
+ *   npm run test:manual                  # headless browser
+ *   SCREENSHOTS=1 npm run test:manual    # + screenshots
+ *
+ * Prerequisites: `npm run build`, agent CLI in PATH, Docker for sandbox.
+ */
+import { test, expect, type Page } from "@playwright/test";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import { createServer } from "node:net";
+import { mkdirSync, rmSync, readFileSync, writeFileSync, existsSync, readdirSync, cpSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { buildDefaultWorkflows } from "../../src/server/state-migration/seed-default-workflows.ts";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
+const SERVER_CLI = join(PROJECT_ROOT, "dist", "server", "cli.js");
+const RESULTS_DIR = join(PROJECT_ROOT, "test-results", "manual-integration");
+const WANT_SCREENSHOTS = !!process.env.SCREENSHOTS;
+
+// ---------------------------------------------------------------------------
+// Docker
+// ---------------------------------------------------------------------------
+function hasDocker(): boolean {
+	try { execFileSync("docker", ["info"], { stdio: "ignore", timeout: 10_000 }); return true; } catch { return false; }
+}
+const HAS_DOCKER = hasDocker();
+
+// ---------------------------------------------------------------------------
+// Project registration body
+// ---------------------------------------------------------------------------
+function projectRegistrationBody(name: string, rootPath: string, opts: { upsert?: boolean } = {}) {
+	const components = [{
+		name,
+		repo: ".",
+		commands: {
+			build: "echo build ok",
+			check: "echo check ok",
+			unit: "echo unit ok",
+			e2e: "echo e2e ok",
+		},
+	}];
+	const workflows = buildDefaultWorkflows(name);
+	return { name, rootPath, components, workflows, ...opts };
+}
+
+// ---------------------------------------------------------------------------
+// Gateway
+// ---------------------------------------------------------------------------
+interface GW {
+	proc: ChildProcess; port: number; dir: string;
+	token: string; base: string;
+	defaultProjectId?: string;
+}
+
+const PROJECT_REQUIRED_POST = new Set(["/api/sessions", "/api/goals", "/api/staff"]);
+
+async function freePort(): Promise<number> {
+	return new Promise((res, rej) => {
+		const s = createServer();
+		s.listen(0, "127.0.0.1", () => { const p = (s.address() as any).port; s.close(() => res(p)); });
+		s.on("error", rej);
+	});
+}
+
+async function startGW(dir: string, port: number): Promise<GW> {
+	mkdirSync(join(dir, ".bobbit", "state"), { recursive: true });
+	const proc = spawn(process.execPath, [
+		SERVER_CLI, "--host", "127.0.0.1", "--port", String(port),
+		"--no-tls", "--auth", "--cwd", dir,
+	], {
+		env: { ...process.env, BOBBIT_DIR: join(dir, ".bobbit"), NODE_ENV: "test" },
+		stdio: ["pipe", "pipe", "pipe"],
+	});
+	let stderr = "";
+	proc.stderr!.on("data", (c: Buffer) => { stderr += c; });
+	proc.stdout!.on("data", () => {});
+	const deadline = Date.now() + 120_000;
+	while (Date.now() < deadline) {
+		if (proc.exitCode !== null) throw new Error(`Gateway exited (${proc.exitCode}):\n${stderr}`);
+		try {
+			const tp = join(dir, ".bobbit", "state", "token");
+			if (existsSync(tp)) {
+				const t = readFileSync(tp, "utf-8").trim();
+				if ((await fetch(`http://127.0.0.1:${port}/api/health`, { headers: { Authorization: `Bearer ${t}` } })).ok) break;
+			}
+		} catch {}
+		await new Promise(r => setTimeout(r, 300));
+	}
+	if (Date.now() >= deadline) { proc.kill(); throw new Error(`Not healthy:\n${stderr}`); }
+	const token = readFileSync(join(dir, ".bobbit", "state", "token"), "utf-8").trim();
+	return { proc, port, dir, token, base: `http://127.0.0.1:${port}` };
+}
+
+async function stopGW(gw: GW): Promise<void> {
+	if (gw.proc.exitCode === null) {
+		if (process.platform === "win32") {
+			try { execFileSync("taskkill", ["/PID", String(gw.proc.pid), "/T", "/F"], { stdio: "ignore", timeout: 10_000 }); } catch {}
+		} else { gw.proc.kill(); }
+	}
+	await new Promise<void>(r => {
+		if (gw.proc.exitCode !== null) return r();
+		gw.proc.on("exit", () => r());
+		setTimeout(() => { try { gw.proc.kill("SIGKILL"); } catch {} r(); }, 5_000);
+	});
+	await new Promise(r => setTimeout(r, 1_500));
+}
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+function api(gw: GW, path: string, opts: RequestInit = {}) {
+	if ((opts.method || "GET").toUpperCase() === "POST" && PROJECT_REQUIRED_POST.has(path) && gw.defaultProjectId) {
+		try {
+			const body = typeof opts.body === "string" && opts.body ? JSON.parse(opts.body) : {};
+			if (body && typeof body === "object" && !body.projectId) {
+				body.projectId = gw.defaultProjectId;
+				opts = { ...opts, body: JSON.stringify(body) };
+			}
+		} catch {}
+	}
+	return fetch(`${gw.base}${path}`, { ...opts, headers: { "Content-Type": "application/json", Authorization: `Bearer ${gw.token}`, ...(opts.headers as Record<string, string> || {}) } });
+}
+
+async function pollIdle(gw: GW, id: string, ms = 120_000) {
+	const t0 = Date.now();
+	while (Date.now() - t0 < ms) {
+		let res: Response;
+		try { res = await api(gw, `/api/sessions/${id}`); } catch { await new Promise(r => setTimeout(r, 1_000)); continue; }
+		if (res.status === 404) { await new Promise(r => setTimeout(r, 1_000)); continue; }
+		const s = await res.json();
+		if (s.status === "idle") return s;
+		if (s.status === "archived") throw new Error(`Session ${id} archived`);
+		if (s.status === "error" || s.status === "terminated") {
+			const extra = s.restoreError ? `\n  restoreError: ${s.restoreError}` : "";
+			throw new Error(`Session ${id} ${s.status}${extra}`);
+		}
+		await new Promise(r => setTimeout(r, 1_000));
+	}
+	throw new Error(`Session ${id} not idle in ${ms}ms`);
+}
+
+async function getSession(gw: GW, id: string) { return (await api(gw, `/api/sessions/${id}`)).json(); }
+
+// ---------------------------------------------------------------------------
+// Browser helpers
+// ---------------------------------------------------------------------------
+function appUrl(gw: GW) { return `${gw.base}/?token=${gw.token}`; }
+function sessionUrl(gw: GW, id: string) { return `${gw.base}/?token=${gw.token}#/session/${id}`; }
+
+async function interruptAndSend(page: Page, gw: GW, id: string, text: string, idleTimeoutMs = 120_000) {
+	await page.goto(sessionUrl(gw, id));
+	await page.waitForSelector("textarea", { timeout: 30_000 });
+	const sessInfo = await getSession(gw, id);
+	if (sessInfo.status === "streaming") {
+		const stopBtn = page.locator('button[title="Stop streaming"]');
+		await stopBtn.waitFor({ state: "visible", timeout: 10_000 });
+		await stopBtn.click();
+		await pollIdle(gw, id, 15_000);
+	}
+	await page.fill("textarea", text);
+	await page.press("textarea", "Enter");
+	await page.waitForTimeout(1_500);
+	await pollIdle(gw, id, idleTimeoutMs);
+	await page.waitForTimeout(2_000);
+}
+
+async function browserSend(page: Page, gw: GW, id: string, text: string, idleMs = 120_000) {
+	await page.goto(sessionUrl(gw, id));
+	await page.waitForSelector("textarea", { timeout: 30_000 });
+	try { await page.waitForSelector('[class*="tool"], [class*="Tool"], details, pre', { timeout: 8_000 }); } catch {}
+	await page.waitForTimeout(500);
+	await page.fill("textarea", text);
+	await page.press("textarea", "Enter");
+	await page.waitForTimeout(1_500);
+	await pollIdle(gw, id, idleMs);
+	await page.waitForTimeout(2_000);
+}
+
+async function takeScreenshot(page: Page, name: string) {
+	if (!WANT_SCREENSHOTS) return;
+	mkdirSync(RESULTS_DIR, { recursive: true });
+	await page.screenshot({ path: join(RESULTS_DIR, name), fullPage: true });
+}
+
+// ---------------------------------------------------------------------------
+// Setup helpers
+// ---------------------------------------------------------------------------
+function initRepo(dir: string) {
+	mkdirSync(dir, { recursive: true });
+	execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["symbolic-ref", "HEAD", "refs/heads/master"], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["config", "user.email", "t@t"], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["config", "user.name", "T"], { cwd: dir, stdio: "ignore" });
+	writeFileSync(join(dir, "README.md"), "# Test project\n");
+	writeFileSync(join(dir, "package.json"), JSON.stringify({
+		name: "test-project", version: "1.0.0",
+		scripts: { check: "echo ok", "test:unit": "echo ok" },
+	}, null, 2));
+	execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "ignore" });
+	try {
+		const origin = execFileSync("git", ["remote", "get-url", "origin"], { cwd: PROJECT_ROOT, encoding: "utf-8", timeout: 5_000 }).trim();
+		execFileSync("git", ["remote", "add", "origin", origin], { cwd: dir, stdio: "ignore" });
+	} catch {}
+	const srcConfig = join(PROJECT_ROOT, ".bobbit", "config");
+	const dstConfig = join(dir, ".bobbit", "config");
+	if (existsSync(srcConfig)) {
+		cpSync(srcConfig, dstConfig, { recursive: true, filter: (src) => !src.endsWith("project.yaml") });
+	}
+}
+
+function cleanDirs(dir: string) {
+	const parent = resolve(dir, "..");
+	const base = dir.split(/[\\/]/).pop()!;
+	const dirs = [dir];
+	try { for (const e of readdirSync(parent)) if (e.startsWith(base)) dirs.push(join(parent, e)); } catch {}
+	for (const d of dirs) { for (let i = 0; i < 3; i++) { try { rmSync(d, { recursive: true, force: true }); break; } catch {} } }
+}
+
+function cleanTestDockerContainers() {
+	try {
+		const ids = execFileSync("docker", [
+			"ps", "-aq", "--filter", "label=bobbit-project",
+		], { encoding: "utf-8", timeout: 10_000 }).trim();
+		if (!ids) return;
+		for (const id of ids.split(/\s+/).filter(Boolean)) {
+			try {
+				const binds = execFileSync("docker", [
+					"inspect", "--format", "{{json .HostConfig.Binds}}", id,
+				], { encoding: "utf-8", timeout: 5_000 }).trim();
+				if (/\.bobbit-manual|\.e2e-resilience/.test(binds)) {
+					const projectId = execFileSync("docker", [
+						"inspect", "--format", '{{index .Config.Labels "bobbit-project"}}', id,
+					], { encoding: "utf-8", timeout: 5_000 }).trim();
+					execFileSync("docker", ["rm", "-f", id], { timeout: 15_000, stdio: "ignore" });
+					if (projectId) {
+						for (const prefix of ["bobbit-workspace-", "bobbit-worktrees-"]) {
+							try {
+								execFileSync("docker", ["volume", "rm", "-f", `${prefix}${projectId}`], {
+									timeout: 10_000, stdio: "ignore",
+								});
+							} catch {}
+						}
+					}
+				}
+			} catch {}
+		}
+	} catch {}
+}
+
+// ---------------------------------------------------------------------------
+// Test-specific helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a fresh sandboxed session and wait for it to be idle.
+ * Returns the session id.
+ */
+async function createFreshSession(gw: GW): Promise<string> {
+	const res = await api(gw, "/api/sessions", {
+		method: "POST",
+		body: JSON.stringify({ worktree: true, sandboxed: true }),
+	});
+	expect(res.status).toBe(201);
+	const id = ((await res.json()) as any).id;
+	await pollIdle(gw, id, 180_000);
+	return id;
+}
+
+/**
+ * Locate a rendered tool-call card by matching multiple substrings against
+ * its text content. Tool calls render as `<div class="... bg-card ...">`
+ * wrappers (see `src/ui/components/Messages.ts` — there is no `<details>`
+ * element). We look for any tool-card div whose innerText contains every
+ * provided substring.
+ *
+ * Returns the count of matching cards (asserted > 0 by callers).
+ */
+async function countToolCardsMatching(page: Page, ...substrings: string[]): Promise<number> {
+	return page.evaluate((subs: string[]) => {
+		const cards = Array.from(document.querySelectorAll<HTMLElement>("div.bg-card"));
+		return cards.filter(c => {
+			const t = (c.innerText || c.textContent || "");
+			return subs.every(s => t.includes(s));
+		}).length;
+	}, substrings);
+}
+
+// ===================================================================
+// Test suite
+// ===================================================================
+test.describe.serial("Agent tool use", () => {
+	test.setTimeout(420_000); // 7 minutes per individual test — covers cold-start LLM latency.
+		// (Headline budget for the spec as a whole is ~5 min when warm; this ceiling
+		// just absorbs first-test cold-start variability without introducing flakes.)
+	test.skip(!HAS_DOCKER, "requires Docker — sandboxed sessions only");
+
+	let gw: GW;
+	let dir: string;
+	let port: number;
+	let sandboxAvailable = false;
+
+	test.beforeAll(async ({}, ti) => {
+		ti.setTimeout(180_000);
+		port = await freePort();
+		const tmp = process.platform === "win32" ? (process.env.TEMP || "C:\\Temp") : "/tmp";
+		dir = join(tmp, `.bobbit-manual-${port}`);
+		rmSync(dir, { recursive: true, force: true });
+		initRepo(dir);
+
+		mkdirSync(join(dir, ".bobbit", "config"), { recursive: true });
+		mkdirSync(join(dir, ".bobbit", "state"), { recursive: true });
+		const yaml = [
+			'worktree_pool_size: "6"',
+			'sandbox: "docker"',
+		].join("\n") + "\n";
+		writeFileSync(join(dir, ".bobbit", "config", "project.yaml"), yaml);
+		writeFileSync(join(dir, ".bobbit", "state", "projects.json"), "[]");
+
+		gw = await startGW(dir, port);
+		console.log(`  Gateway :${port}  cwd=${dir}`);
+
+		const regRes = await api(gw, "/api/projects", {
+			method: "POST",
+			body: JSON.stringify(projectRegistrationBody("default", dir, { upsert: true })),
+		});
+		if (regRes.status !== 201 && regRes.status !== 200) {
+			throw new Error(`Failed to register default project: ${regRes.status}`);
+		}
+		gw.defaultProjectId = (await regRes.json()).id;
+
+		// Wait for sandbox to be available
+		const ss0 = await (await api(gw, "/api/sandbox-status")).json();
+		sandboxAvailable = ss0.configured && ss0.available;
+		if (ss0.configured && !ss0.available) {
+			const deadline = Date.now() + 180_000;
+			while (Date.now() < deadline) {
+				const r = await (await api(gw, "/api/sandbox-status")).json();
+				if (r.available) { sandboxAvailable = true; break; }
+				await new Promise(r => setTimeout(r, 3_000));
+			}
+		}
+		console.log(`  Sandbox available: ${sandboxAvailable}`);
+		if (!sandboxAvailable) throw new Error("Sandbox unavailable — sandboxed sessions are required by this spec");
+	});
+
+	test.afterAll(async ({}, ti) => {
+		ti.setTimeout(120_000);
+		if (gw) await stopGW(gw);
+		cleanTestDockerContainers();
+		cleanDirs(dir);
+	});
+
+	// ---------------------------------------------------------------
+	// 1. Builtin shell — bash
+	// ---------------------------------------------------------------
+	test("1. bash tool — echo to marker.txt", async ({ page }) => {
+		const id = await createFreshSession(gw);
+		const nonce = Math.random().toString(36).slice(2, 10).toUpperCase();
+		const sentinel = `HELLO_${nonce}`;
+
+		await browserSend(page, gw, id,
+			`Run the bash tool exactly once with the command: echo ${sentinel} > marker.txt && cat marker.txt`,
+			240_000);
+		await takeScreenshot(page, `tooluse-1-bash-${nonce}.png`);
+
+		// DOM: the bash tool block must be rendered. Bash tool cards include
+		// the command text verbatim (see BashRenderer).
+		const bashCardCount = await countToolCardsMatching(page, "marker.txt", sentinel);
+		expect(bashCardCount).toBeGreaterThan(0);
+
+		// Full transcript text contains the sentinel (from the cat'd output)
+		const body = await page.locator("body").innerText();
+		expect(body).toContain(sentinel);
+	});
+
+	// ---------------------------------------------------------------
+	// 2. Filesystem builtin — edit
+	// ---------------------------------------------------------------
+	test("2. edit tool — exact-text replace", async ({ page }) => {
+		const id = await createFreshSession(gw);
+
+		// Setup: create target.txt with content "before" via the bash tool.
+		// We do this in a separate user turn so the second prompt is solely
+		// about exercising the edit tool.
+		await browserSend(page, gw, id,
+			`Use the bash tool to run: printf 'before' > target.txt && cat target.txt`,
+			240_000);
+
+		// Exercise: invoke the edit tool by name with explicit parameters.
+		await browserSend(page, gw, id,
+			`Use the "edit" tool with these exact parameters: path="target.txt", oldText="before", newText="after". Do not use any other tool. After the edit succeeds, reply with the single word DONE on its own line.`,
+			240_000);
+		await takeScreenshot(page, "tooluse-2-edit.png");
+
+		// DOM: edit tool card present, referencing target.txt
+		const editCardCount = await countToolCardsMatching(page, "target.txt");
+		expect(editCardCount).toBeGreaterThan(0);
+
+		// Assistant final message contains DONE
+		const body = await page.locator("body").innerText();
+		expect(body).toContain("DONE");
+
+		// Cross-check: a subsequent cat should show "after". Use bash to peek
+		// inside the container — this gives us a filesystem-level assertion
+		// even though we can't reach into the container directly from the host.
+		await browserSend(page, gw, id,
+			`Use the bash tool to run: cat target.txt`,
+			240_000);
+		const body2 = await page.locator("body").innerText();
+		expect(body2).toContain("after");
+	});
+
+	// ---------------------------------------------------------------
+	// 3. Filesystem builtin — find
+	// ---------------------------------------------------------------
+	test("3. find tool — glob pattern", async ({ page }) => {
+		const id = await createFreshSession(gw);
+		const nonce = Math.random().toString(36).slice(2, 10).toLowerCase();
+
+		// Setup: create three sentinel files under findme/
+		await browserSend(page, gw, id,
+			`Use the bash tool to run: mkdir -p findme && touch findme/a_${nonce}.txt findme/b_${nonce}.txt findme/c_${nonce}.txt && ls findme`,
+			240_000);
+
+		// Exercise: invoke find by name with explicit args
+		await browserSend(page, gw, id,
+			`Use the "find" tool with these exact parameters: pattern="*_${nonce}.txt", path="findme". After it returns, reply with a single line: COUNT=<n> where <n> is the number of files found by the tool.`,
+			240_000);
+		await takeScreenshot(page, `tooluse-3-find-${nonce}.png`);
+
+		// DOM: find tool card present
+		const findCardCount = await countToolCardsMatching(page, "findme", nonce);
+		expect(findCardCount).toBeGreaterThan(0);
+
+		// Assistant final message contains COUNT=3
+		const body = await page.locator("body").innerText();
+		expect(body).toContain("COUNT=3");
+	});
+
+	// ---------------------------------------------------------------
+	// 4. Steering / interrupt mid tool-use
+	// ---------------------------------------------------------------
+	test("4. interrupt mid tool-use — pivot", async ({ page }) => {
+		const id = await createFreshSession(gw);
+
+		// Kick off a long-running bash command. Use a portable node one-liner
+		// to avoid POSIX/Windows shell quoting traps inside the prompt.
+		await page.goto(sessionUrl(gw, id));
+		await page.waitForSelector("textarea", { timeout: 30_000 });
+		await page.waitForTimeout(500);
+		const longPrompt =
+			`Use the bash tool exactly once to run this command (do not modify it):\n` +
+			`bash -c 'node -e "let i=0;setInterval(()=>{require(\\"fs\\").writeFileSync(\\"step.txt\\",String(++i));console.log(\\"step\\",i)},1000)"'\n` +
+			`Do not reply or summarise until the command finishes.`;
+		await page.fill("textarea", longPrompt);
+		await page.press("textarea", "Enter");
+
+		// Wait until the agent is actually streaming (it has called the tool
+		// and the bash process is running). The session starts in `idle`; the
+		// initial transition to `streaming` happens after the gateway picks up
+		// the message (typically ~1-3s). We need a streaming sample before we
+		// can interrupt — otherwise interruptAndSend's stop button never fires.
+		const streamDeadline = Date.now() + 60_000;
+		let sawStreaming = false;
+		while (Date.now() < streamDeadline) {
+			const s = await getSession(gw, id);
+			if (s.status === "streaming") { sawStreaming = true; break; }
+			await new Promise(r => setTimeout(r, 500));
+		}
+		expect(sawStreaming, "agent never reached streaming status within 60s — tool invocation likely broken").toBe(true);
+
+		// Pivot via the stop-and-resend flow.
+		await interruptAndSend(page, gw, id,
+			`Forget that previous command. Reply with the literal token PIVOT_ACK on its own line and nothing else.`,
+			240_000);
+		await takeScreenshot(page, "tooluse-4-interrupt.png");
+
+		// PIVOT_ACK must appear in the page text — proof the agent honoured
+		// the pivot rather than continuing the previous tool call.
+		const body = await page.locator("body").innerText();
+		expect(body).toContain("PIVOT_ACK");
+	});
+
+	// ---------------------------------------------------------------
+	// 5. Tool error path — edit a missing file
+	// ---------------------------------------------------------------
+	test("5. edit error — missing file surfaces error", async ({ page }) => {
+		const id = await createFreshSession(gw);
+		const nonce = Math.random().toString(36).slice(2, 10).toLowerCase();
+
+		await browserSend(page, gw, id,
+			`Use the "edit" tool with these exact parameters: path="nonexistent_${nonce}.txt", oldText="x", newText="y". After the tool returns an error, do NOT retry. Reply with a single line starting EDIT_FAILED: followed by a short reason describing the error.`,
+			240_000);
+		await takeScreenshot(page, `tooluse-5-edit-error-${nonce}.png`);
+
+		// Session must remain healthy — not crashed.
+		const info = await getSession(gw, id);
+		expect(info.status).toBe("idle");
+
+		// Edit tool card present, referencing the bogus path.
+		const editCardCount = await countToolCardsMatching(page, `nonexistent_${nonce}.txt`);
+		expect(editCardCount).toBeGreaterThan(0);
+
+		// Assistant final message includes EDIT_FAILED:
+		const body = await page.locator("body").innerText();
+		expect(body).toContain("EDIT_FAILED:");
+
+		// Edit tool body contains some evidence of failure. The exact wording
+		// is produced by Bobbit's tool harness; accept a small set of variants.
+		const bodyLower = body.toLowerCase();
+		const failureEvidence = [
+			"enoent",
+			"no such file",
+			"not found",
+			"does not exist",
+			"could not find",
+		];
+		const sawFailure = failureEvidence.some(e => bodyLower.includes(e));
+		expect(sawFailure, `expected one of ${failureEvidence.join(", ")} in transcript`).toBe(true);
+	});
+});


### PR DESCRIPTION
Upgrades `@mariozechner/pi-agent-core`, `pi-ai`, `pi-coding-agent` from `^0.67.5` → `^0.73.1`, plus a new tool-use canary spec that catches silent regressions in the agent tool-call pipeline.

## Background

A previous pi upgrade silently broke all agent tool use because no manual-integration test exercised a real agent calling tools end-to-end. The fix is *both* a new canary AND the upgrade itself — in that strict order.

## What changed

**Phase 1 — canary spec (proven green on pinned `^0.67.5` before any upgrade):**
- `tests/manual-integration/agent-tool-use.spec.ts` (new, 542 lines).
- Five scenarios in one `describe.serial` block, each with a fresh sandboxed session and sentinel-based assertions: `bash` (`HELLO_<nonce>`), `edit` (`DONE`), `find` (`COUNT=3`), interrupt/steer (`PIVOT_ACK`), tool-error path (`EDIT_FAILED:`).
- Asserts on observable behaviour (filesystem state + DOM tool cards), never on internal logs.
- Total runtime ~3.1 min, under the 5-min budget.

**Phase 2 — pi upgrade to 0.73.1:**
- `package.json` + `package-lock.json` bumped (0.73.1 was the latest stable at upgrade time per `npm view ... dist-tags.latest`).
- `src/ui/tools/artifacts/artifacts.ts` — pi-ai 0.73 migrated from `@sinclair/typebox` v0.34 to `typebox` v1 and re-exports `Type`/`Static` from there. Mixing TSchema flavors broke 62 type checks. Fix: import `Type`/`Static` from `@mariozechner/pi-ai` so all schemas in the file share one flavor. No `as any`.

**Phase 3 — verification (all required layers):**

| Command | Result |
|---|---|
| `npm run check` | clean |
| `npm run test:unit` | 1 skipped / 1031 passed (1.2m) |
| `npm run test:e2e` | 11 flaky / 6 skipped / 1020 passed (6.5m) — all flakes pre-existing |
| `npm run test:manual` | canary spec all 5 scenarios green on 0.73.1; pre-existing `session-resilience › A` load flake recovered on retry |

**Docs:** new entries in `docs/testing-coverage.md`, `docs/testing-strategy.md` (canary), `docs/debugging.md` (typebox-flavor pitfall).

## Follow-up (out of scope for this PR)

Upstream re-scoped after 0.73.1: `@mariozechner/pi-*` → `@earendil-works/pi-*`. A separate migration goal should move the imports.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
