### PR TITLE
Let Ctrl+Left/Right do native word-jump in text inputs

### DIFF
--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -544,17 +544,20 @@ async function initApp() {
 		handler: () => { navigateSidebar("down"); },
 	});
 
+	// Ctrl+→ / Ctrl+←: allowInInput is FALSE so native word-jump wins inside
+	// the prompt editor and other text inputs. The sidebar only captures these
+	// keys when focus is outside any input (e.g. on the sidebar itself).
 	registerShortcut({
 		id: "sidebar-expand", label: "Expand sidebar group", category: "Sessions",
 		defaultBindings: [{ key: "ArrowRight", ctrlOrMeta: true, shift: false, alt: false }],
-		allowInInput: true,
+		allowInInput: false,
 		handler: () => { expandActiveSidebarItem(true); },
 	});
 
 	registerShortcut({
 		id: "sidebar-collapse", label: "Collapse sidebar group", category: "Sessions",
 		defaultBindings: [{ key: "ArrowLeft", ctrlOrMeta: true, shift: false, alt: false }],
-		allowInInput: true,
+		allowInInput: false,
 		handler: () => { expandActiveSidebarItem(false); },
 	});
 

--- a/src/app/shortcut-registry.ts
+++ b/src/app/shortcut-registry.ts
@@ -219,8 +219,19 @@ function handleKeydown(e: KeyboardEvent): void {
 	for (const entry of shortcuts.values()) {
 		for (const binding of entry.currentBindings) {
 			if (matchesBinding(e, binding)) {
-				// Allow in input if: explicitly flagged, or the binding uses a modifier key
-				if (inputFocused && !entry.allowInInput && !binding.ctrlOrMeta && !binding.alt) continue;
+				// Input guard:
+				//   allowInInput === true   → always fire, even in inputs
+				//   allowInInput === false  → never fire in inputs (even with modifiers).
+				//                             Use this for shortcuts whose keystroke
+				//                             has a meaningful native input behaviour
+				//                             (e.g. Ctrl+ArrowLeft = word-jump).
+				//   allowInInput === undefined → fire only if the binding uses a
+				//                             ctrl/alt modifier (the modifier-escape
+				//                             hatch used by most shortcuts).
+				if (inputFocused) {
+					if (entry.allowInInput === false) continue;
+					if (entry.allowInInput === undefined && !binding.ctrlOrMeta && !binding.alt) continue;
+				}
 				e.preventDefault();
 				entry.handler();
 				return;

--- a/tests/fixtures/shortcut-registry.html
+++ b/tests/fixtures/shortcut-registry.html
@@ -166,9 +166,12 @@ function handleKeydown(e) {
 	if (["Control", "Meta", "Shift", "Alt"].includes(e.key)) return;
 	const inputFocused = isInputFocused();
 	for (const entry of shortcuts.values()) {
-		if (inputFocused && !entry.allowInInput) continue;
 		for (const binding of entry.currentBindings) {
 			if (matchesBinding(e, binding)) {
+				if (inputFocused) {
+					if (entry.allowInInput === false) continue;
+					if (entry.allowInInput === undefined && !binding.ctrlOrMeta && !binding.alt) continue;
+				}
 				e.preventDefault();
 				entry.handler();
 				return;

--- a/tests/shortcut-registry.spec.ts
+++ b/tests/shortcut-registry.spec.ts
@@ -420,7 +420,7 @@ test.describe("Shortcut Registry", () => {
 				label: "No Input",
 				category: "T",
 				defaultBindings: [{ key: "g", ctrlOrMeta: false, shift: false, alt: true }],
-				// allowInInput defaults to undefined/false
+				allowInInput: false,
 				handler: () => { called = true; },
 			});
 			r.startListening();
@@ -475,6 +475,7 @@ test.describe("Shortcut Registry", () => {
 				label: "No TA",
 				category: "T",
 				defaultBindings: [{ key: "g", ctrlOrMeta: false, shift: false, alt: true }],
+				allowInInput: false,
 				handler: () => { called = true; },
 			});
 			r.startListening();
@@ -501,6 +502,7 @@ test.describe("Shortcut Registry", () => {
 				label: "No CE",
 				category: "T",
 				defaultBindings: [{ key: "g", ctrlOrMeta: false, shift: false, alt: true }],
+				allowInInput: false,
 				handler: () => { called = true; },
 			});
 			r.startListening();
@@ -610,6 +612,61 @@ test.describe("Shortcut Registry", () => {
 			return count;
 		});
 		expect(result).toBe(2);
+	});
+
+	// ========================================================================
+	// Explicit allowInInput:false strictly blocks in inputs, even for
+	// ctrl/alt-modified bindings (e.g. Ctrl+ArrowLeft must passthrough to
+	// native word-jump in the prompt editor).
+	// ========================================================================
+	test("allowInInput:false blocks ctrl-modified shortcut in textarea (word-jump passthrough)", async ({ page }) => {
+		const result = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			let called = false;
+			let defaultPrevented = false;
+			r.registerShortcut({
+				id: "sidebar-left",
+				label: "Sidebar Left",
+				category: "T",
+				defaultBindings: [{ key: "ArrowLeft", ctrlOrMeta: true, shift: false, alt: false }],
+				allowInInput: false,
+				handler: () => { called = true; },
+			});
+			r.startListening();
+
+			(document.getElementById("test-textarea") as HTMLTextAreaElement).focus();
+			const ev = new KeyboardEvent("keydown", {
+				key: "ArrowLeft", ctrlKey: true, bubbles: true, cancelable: true,
+			});
+			document.dispatchEvent(ev);
+			defaultPrevented = ev.defaultPrevented;
+			return { called, defaultPrevented };
+		});
+		expect(result.called).toBe(false);
+		expect(result.defaultPrevented).toBe(false);
+	});
+
+	test("allowInInput:false still fires when no input is focused", async ({ page }) => {
+		const result = await page.evaluate(() => {
+			const r = (window as any).__registry;
+			let called = false;
+			r.registerShortcut({
+				id: "sidebar-left-2",
+				label: "Sidebar Left 2",
+				category: "T",
+				defaultBindings: [{ key: "ArrowLeft", ctrlOrMeta: true, shift: false, alt: false }],
+				allowInInput: false,
+				handler: () => { called = true; },
+			});
+			r.startListening();
+
+			(document.body as HTMLElement).focus();
+			document.dispatchEvent(new KeyboardEvent("keydown", {
+				key: "ArrowLeft", ctrlKey: true, bubbles: true,
+			}));
+			return called;
+		});
+		expect(result).toBe(true);
 	});
 
 	// ========================================================================


### PR DESCRIPTION
## Problem

The sidebar's `Ctrl+←` / `Ctrl+→` (expand/collapse group) shortcut was being captured globally — including while the user was typing in the prompt editor. This broke native word-jump navigation, making it awkward to edit prompts.

The shortcut should only act when a tree grouping element in the sidebar is the active target; in text inputs it should fall through to the browser's native word-jump.

## Fix

- **`shortcut-registry.ts`**: explicit `allowInInput: false` now strictly blocks a shortcut in inputs, even for ctrl/alt-modified bindings. `allowInInput: undefined` keeps the existing modifier-escape hatch, so other modifier shortcuts (`Alt+G` new-goal, `Ctrl+Shift+D` terminate, etc.) still fire while typing.
- **`main.ts`**: `sidebar-expand` / `sidebar-collapse` are now registered with `allowInInput: false`. `Ctrl+←` / `Ctrl+→` passes through to native word-jump inside textareas, inputs and contenteditables, while still firing when focus is on the sidebar or body. The existing `expandActiveSidebarItem` already no-ops on leaf rows, so the shortcut only ever toggles a tree grouping element.

## Tests

- Added two pinning tests: `Ctrl+ArrowLeft` with `allowInInput:false` does not fire and does not `preventDefault` when a textarea is focused; still fires when focus is on the body.
- Fixed three pre-existing tests that conflated `undefined` with `false` — the test fixture's input-guard was simpler than the real impl, masking this gap. The fixture has been re-aligned to the real implementation.
- Full `shortcut-registry.spec.ts` suite (25 tests) passes; `npm run check` is clean.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)