### PR TITLE
Staff click loading feedback

### DIFF
--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -519,6 +519,9 @@ export function reloadStaffList(): Promise<void> {
 
 async function createStaffAssistantSession(e: Event): Promise<void> {
 	e.stopPropagation();
+	if (state.creatingSession) return;
+	state.creatingSession = true;
+	renderApp();
 	const { gatewayFetch } = await import("./api.js");
 	try {
 		const res = await gatewayFetch("/api/sessions", {
@@ -526,11 +529,20 @@ async function createStaffAssistantSession(e: Event): Promise<void> {
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ assistantType: "staff" }),
 		});
-		if (!res.ok) throw new Error(`Failed: ${res.status}`);
+		if (!res.ok) {
+			const { errorFromResponse } = await import("./error-helpers.js");
+			throw await errorFromResponse(res, `Session creation failed: ${res.status}`);
+		}
 		const { id } = await res.json();
 		await connectToSession(id, false, { isStaffAssistant: true, assistantType: "staff" });
 	} catch (err) {
-		console.error("[staff] Failed to create staff assistant session:", err);
+		const { showConnectionError } = await import("./dialogs.js");
+		const { errorDetails } = await import("./error-helpers.js");
+		const { message, code, stack } = errorDetails(err);
+		showConnectionError("Failed to create staff assistant", message, { code, stack });
+	} finally {
+		state.creatingSession = false;
+		renderApp();
 	}
 }
 

--- a/tests/e2e/ui/sidebar-staff-loading.spec.ts
+++ b/tests/e2e/ui/sidebar-staff-loading.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * Sidebar "+ Staff" button — loading feedback.
+ *
+ * Pins the fix for: clicking "+ Staff" felt unresponsive because the
+ * session-creation flow didn't set state.creatingSession before the fetch,
+ * so the [data-testid="bobbit-loader"] gate in render.ts::mainArea never
+ * fired until after the round-trip.
+ *
+ * This test asserts the loader appears before navigation completes,
+ * mirroring the behaviour of the "+ New Goal" / "+ Role" buttons.
+ */
+import { test, expect } from "../gateway-harness.js";
+import { apiFetch } from "../e2e-setup.js";
+import { openApp } from "./ui-helpers.js";
+
+test.describe("Sidebar +Staff loading feedback", () => {
+	test("shows bobbit-loader immediately on click", async ({ page }) => {
+		await openApp(page);
+
+		// The Staff section header is always rendered, and the "+" button
+		// inside it has title="New staff agent".
+		const newStaffBtn = page.locator("button[title='New staff agent']").first();
+		await expect(newStaffBtn).toBeVisible({ timeout: 10_000 });
+
+		// Click and immediately assert the loader is visible — must appear
+		// within one render frame (before navigation completes).
+		await newStaffBtn.click();
+		await expect(page.locator("[data-testid='bobbit-loader']")).toBeVisible({
+			timeout: 2_000,
+		});
+
+		// Wait for navigation to complete and verify a staff assistant session was created.
+		await expect(page.locator("textarea").first()).toBeVisible({ timeout: 20_000 });
+		await expect(async () => {
+			const hash = await page.evaluate(() => window.location.hash);
+			expect(hash).toMatch(/#\/session\/[a-f0-9-]+/i);
+		}).toPass({ timeout: 10_000 });
+
+		// Clean up the created session.
+		const hash = await page.evaluate(() => window.location.hash);
+		const m = hash.match(/#\/session\/([a-f0-9-]+)/i);
+		if (m) await apiFetch(`/api/sessions/${m[1]}`, { method: "DELETE" }).catch(() => {});
+	});
+});


### PR DESCRIPTION
Clicking the sidebar **+ Staff** button felt unresponsive: nothing changed in the UI until the `POST /api/sessions` round-trip completed. By contrast, **+ New Goal** and **+ Role** feel instant because they set `state.creatingSession = true` and call `renderApp()` before the fetch, which trips the existing `bobbitLoadingAnimation()` gate in `src/app/render.ts::mainArea()` (`state.creatingSession || state.connectingSessionId`).

## Fix

`src/app/sidebar.ts::createStaffAssistantSession` now mirrors `src/app/role-manager-page.ts::createRoleAssistantSession`:

- Early-return when `state.creatingSession` is already true.
- Set `state.creatingSession = true` and call `renderApp()` **before** the fetch — this is what makes the bouncing-bobbit loader appear within one frame.
- Wrap the body in `try/catch/finally`; `finally` clears the flag and re-renders.
- Replace the bare `console.error` with `showConnectionError("Failed to create staff assistant", …)` using `errorDetails(err)`, matching role/tool/goal behaviour (pinned by `tests/consistent-error-modals.spec.ts`).
- Preserve `e.stopPropagation()` and the existing `connectToSession(..., { isStaffAssistant: true, assistantType: "staff" })` call.

No new flags or loader components — reuses the existing `data-testid="bobbit-loader"` gate.

## Out-of-scope check

`src/app/staff-page.ts` does NOT have its own session-creation flow (verified via grep — no `assistantType: "staff"` / `isStaffAssistant` references). The sidebar "+" button is the only entry point.

## Tests

- New browser E2E `tests/e2e/ui/sidebar-staff-loading.spec.ts` clicks `button[title='New staff agent']` and asserts `[data-testid='bobbit-loader']` becomes visible within 2 s (before navigation completes), then verifies a staff-assistant session lands at `#/session/…` and cleans up.
- `npm run check` and `npm run test:unit` pass.
- Verification gate (build, typecheck, unit, e2e, LLM gap + quality review) passed.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)