### PR TITLE
fix(docker): install pi-coding-agent from @earendil-works scope

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,8 +22,13 @@ RUN npx -y playwright@1.52.0 install-deps chromium 2>/dev/null \
 # Install pi-coding-agent and its dependencies inside the image.
 # This avoids bind-mounting node_modules from the host, which is 20x slower
 # on Docker Desktop (Windows/macOS) due to cross-OS filesystem bridging.
-ARG PI_AGENT_VERSION=0.57.1
-RUN npm install -g @mariozechner/pi-coding-agent@${PI_AGENT_VERSION} --no-audit --no-fund 2>/dev/null \
+#
+# NOTE: package scope is @earendil-works (renamed from @mariozechner). The host
+# detects its own pi-coding-agent version from node_modules and passes it in via
+# --build-arg PI_AGENT_VERSION=<host-version>; the ARG default below is only a
+# fallback for manual `docker build docker/` invocations.
+ARG PI_AGENT_VERSION=0.74.0
+RUN npm install -g @earendil-works/pi-coding-agent@${PI_AGENT_VERSION} --no-audit --no-fund 2>/dev/null \
     && ln -sf $(npm root -g) /node_modules
 LABEL bobbit.pi-agent-version=${PI_AGENT_VERSION}
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -50,15 +50,19 @@ docker volume rm bobbit-nm-cache-<hash> bobbit-npm-cache-<hash>
 
 ## Design
 
-The agent CLI (`@mariozechner/pi-coding-agent`) is **not** installed in the image. It is bind-mounted from the host at runtime:
+The agent CLI (`@earendil-works/pi-coding-agent`) is installed **inside** the image — bind-mounting `node_modules` from a Windows/macOS host into a Linux container is ~20× slower than a native layer. The version is pinned to a build-arg and stamped onto the image as a `bobbit.pi-agent-version` label:
 
+```dockerfile
+ARG PI_AGENT_VERSION=0.74.0
+RUN npm install -g @earendil-works/pi-coding-agent@${PI_AGENT_VERSION} ...
+LABEL bobbit.pi-agent-version=${PI_AGENT_VERSION}
 ```
--v <hostNodeModules>:/node_modules:ro
-```
+
+At startup the gateway reads its own `pi-coding-agent` version from `node_modules`, compares it to the image's `bobbit.pi-agent-version` label, and rebuilds automatically when they drift — passing `--build-arg PI_AGENT_VERSION=<host-version>` so the image always matches the gateway. See `src/server/agent/sandbox-status.ts::ensureImageAgentVersion`.
 
 This ensures:
 - The container always uses the **same agent version** as the gateway
-- The image stays lightweight and doesn't need rebuilding on agent updates
+- Fast filesystem access for the agent runtime (no cross-OS bridge)
 - No version drift between sandboxed and non-sandboxed sessions
 
 Project `node_modules` (the project's own dependencies used for builds and tests) are handled separately by the entrypoint's cross-platform cache.


### PR DESCRIPTION
The package was renamed from `@mariozechner/pi-coding-agent` to `@earendil-works/pi-coding-agent`. The host (`package.json`, `sandbox-status.ts`, the rpc-bridge invocation path `/node_modules/@earendil-works/pi-coding-agent/dist/cli.js`) already uses the new scope at v0.74.0, but the Dockerfile still installed from the old scope where 0.74.0 doesn't exist (latest there is 0.73.1).

Symptoms from a live session:

```
[sandbox] Rebuilding image "bobbit-agent": image has v0.67.5, host has v0.74.0
[sandbox] Failed to rebuild image "bobbit-agent": ... npm ERR!
...
Error: Cannot find module '/node_modules/@earendil-works/pi-coding-agent/dist/cli.js'
[rpc-bridge] Agent process exited (code 1) cwd=/workspace-wt/session/s-011ffd3f
[session-manager] CRITICAL: persistSessionMetadata failed ... after 4 attempts
```

Auto-rebuild failed at the `npm install` step, leaving the stale v0.67.5 image. Sandboxed sessions then crashed with `MODULE_NOT_FOUND` because the rpc-bridge looks up the renamed path.

### Changes

- `docker/Dockerfile`: switch `RUN npm install` to `@earendil-works` scope; bump `ARG PI_AGENT_VERSION` default to `0.74.0` (host still overrides via `--build-arg`). Add a comment explaining the host-driven version pin so future scope/version churn is obvious.
- `docker/README.md`: refresh the stale Design section. The agent CLI is installed **inside** the image (not bind-mounted from the host as the old prose claimed) and pinned via the `bobbit.pi-agent-version` label; document the auto-rebuild reconciliation done by `ensureImageAgentVersion`.

### Verification

Local build with the new Dockerfile:

```
$ docker build --build-arg PI_AGENT_VERSION=0.74.0 -t bobbit-agent-test docker/
# ... succeeds ...
$ docker image inspect bobbit-agent-test --format '{{json .Config.Labels}}'
{"bobbit.pi-agent-version":"0.74.0"}
$ docker run --rm bobbit-agent-test node -e \
    "console.log(require('/node_modules/@earendil-works/pi-coding-agent/package.json').version)"
0.74.0
```

Label matches what `getImageAgentVersion` reads, and the CLI module resolves at the path the rpc-bridge invokes.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)