### PR TITLE
fix(sandbox): bump fd to v10 and recreate stale containers after image rebuild

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,35 @@
 FROM node:20-slim
 
-# Install build tools, git, curl, gh CLI, fd-find
+# Install build tools, git, curl, gh CLI, ripgrep.
+#
+# NOTE: we deliberately do NOT install Debian's `fd-find` apt package — at the
+# time of writing it ships fd 8.6.0 (bookworm), which predates `--no-require-git`
+# (added in fd 9.0). pi-coding-agent 0.74+ passes `--no-require-git`
+# unconditionally, so the apt fd fails every `find` tool call inside the
+# sandbox. Instead we pull a fixed-version fd binary from sharkdp's GitHub
+# release below.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git curl ca-certificates build-essential python3 ripgrep fd-find \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* \
-    && ln -s $(which fdfind) /usr/local/bin/fd 2>/dev/null || true
+    git curl ca-certificates build-essential python3 ripgrep \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install fd from sharkdp/fd GitHub release (must be >= 9.0 for --no-require-git).
+# Pinned to a known-good version; bump as needed.
+ARG FD_VERSION=10.2.0
+RUN set -eu; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64) fd_arch="x86_64-unknown-linux-gnu" ;; \
+      arm64) fd_arch="aarch64-unknown-linux-gnu" ;; \
+      *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    tarball="fd-v${FD_VERSION}-${fd_arch}.tar.gz"; \
+    url="https://github.com/sharkdp/fd/releases/download/v${FD_VERSION}/${tarball}"; \
+    curl -fsSL "$url" -o /tmp/fd.tar.gz; \
+    tar -xzf /tmp/fd.tar.gz -C /tmp; \
+    install -m 0755 "/tmp/fd-v${FD_VERSION}-${fd_arch}/fd" /usr/local/bin/fd; \
+    ln -sf /usr/local/bin/fd /usr/local/bin/fdfind; \
+    rm -rf /tmp/fd.tar.gz "/tmp/fd-v${FD_VERSION}-${fd_arch}"; \
+    fd --version
 
 # gh CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/src/server/agent/project-sandbox.ts
+++ b/src/server/agent/project-sandbox.ts
@@ -532,13 +532,30 @@ export class ProjectSandbox {
 	// ── Private: Container lifecycle ───────────────────────────────────
 
 	private async _initContainer(): Promise<void> {
-		const { projectId } = this.options;
+		const { projectId, image } = this.options;
 		const label = `bobbit-project=${projectId}`;
 
 		// 1. Find existing container by label
 		const existingId = await this._findContainerByLabel(label);
 
 		if (existingId) {
+			// Stale-image check: if the container was created from an older image
+			// than the current tag (e.g. host upgraded pi-coding-agent and
+			// `ensureImageAgentVersion` rebuilt the image), the container still
+			// has the old binaries installed. Reconnecting would fail at first
+			// RPC invocation (MODULE_NOT_FOUND for pi-coding-agent cli.js, or
+			// version drift between host bridge and container agent). Recreate
+			// the container — named volumes preserve /workspace and /workspace-wt
+			// so worktrees survive.
+			const stale = await this._isContainerImageStale(existingId, image);
+			if (stale) {
+				console.warn(`[project-sandbox] Container ${existingId.substring(0, 12)} was created from a stale image (image "${image}" has been rebuilt since); recreating`);
+				await this._removeContainer(existingId);
+				await this._createContainer();
+				await this._runInitSequence();
+				return;
+			}
+
 			// Check if running
 			const running = await this._isContainerRunning(existingId);
 			if (running) {
@@ -835,6 +852,30 @@ export class ProjectSandbox {
 			return ids[0] ?? null;
 		} catch {
 			return null;
+		}
+	}
+
+	/**
+	 * Returns true if the container was created from an image whose ID no
+	 * longer matches the current image tag — i.e. the image has been rebuilt
+	 * (or retagged) since the container was created. Such containers still
+	 * have the *old* layers installed (e.g. older pi-coding-agent version),
+	 * so reconnecting would fail at first RPC invocation. Conservative: on
+	 * any inspect error, returns false (stick with reconnect attempt rather
+	 * than nuking a possibly-working container).
+	 */
+	private async _isContainerImageStale(containerId: string, imageTag: string): Promise<boolean> {
+		try {
+			const [containerImg, currentImg] = await Promise.all([
+				execFileAsync("docker", ["inspect", "--format", "{{.Image}}", containerId], { timeout: 5_000, env: DOCKER_ENV }),
+				execFileAsync("docker", ["inspect", "--format", "{{.Id}}", imageTag], { timeout: 5_000, env: DOCKER_ENV }),
+			]);
+			const a = containerImg.stdout.trim();
+			const b = currentImg.stdout.trim();
+			if (!a || !b) return false; // can't determine — don't nuke
+			return a !== b;
+		} catch {
+			return false;
 		}
 	}
 


### PR DESCRIPTION
Fixes two related sandbox bugs surfaced by `npm run test:manual`.

## 1. `find` tool broken inside sandbox (`4109a60c`)

The Docker sandbox image installed Debian's `fd-find` apt package, which is **fd 8.6.0** on bookworm. `pi-coding-agent` 0.74+ unconditionally passes `--no-require-git` (added in fd 9.0), so every `find` tool call inside the sandbox failed with:

```
error: Found argument '--no-require-git' which wasn't expected
       Did you mean '--no-ignore-parent'?
```

Caught by `tests/manual-integration/agent-tool-use.spec.ts` test 3 (`find tool — glob pattern`): the agent reported `COUNT=0`, the test expected `COUNT=3`.

**Fix**: replace the apt fd-find install with a pinned download of **fd v10.2.0** from `sharkdp/fd` GitHub releases. Architecture-aware (amd64 / arm64). Symlink `fdfind -> fd` for parity with the previous Debian binary name.

## 2. Stale sandbox container after image rebuild (`45c04549`)

When the host's `pi-coding-agent` version changes, the gateway rebuilds the `bobbit-agent` image via `ensureImageAgentVersion`. But `_initContainer` finds the existing labelled container, validates it with `echo ok`, and reconnects — even though that container was created from the **old** image and still has the old pi-coding-agent installed. The first RPC call then fails with:

```
Cannot find module '/node_modules/@earendil-works/pi-coding-agent/dist/cli.js'
```

**Fix**: before reconnecting, compare the container's image ID (`docker inspect --format {{.Image}} <container>`) with the current image-tag ID (`docker inspect --format {{.Id}} <image>`). If they differ, the image was rebuilt — remove and recreate the container. Named volumes preserve `/workspace` and `/workspace-wt`, so worktrees and clones survive. Conservative on inspect errors: returns `false` (don't nuke a possibly-working container).

## Verification

Full `npm run test:manual` run:

| | Passed | Failed | Skipped |
|---|---|---|---|
| Before | 26 | 2 | 4 |
| After | **30** | 1 | 4 |

Remaining failure is an unrelated `EADDRINUSE` flake in `agent-tool-use.spec.ts`'s `beforeAll` from a stray process holding port 50864.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
