### PR TITLE
Mobile Inbox Modal

### DIFF
--- a/docs/staff-inbox.md
+++ b/docs/staff-inbox.md
@@ -272,6 +272,30 @@ pane. It is mounted in `src/app/render.ts` whenever the active session has
 - **Per-session open state** is hydrated from `localStorage`. Reloading the
   page keeps the panel open or collapsed exactly as you left it.
 
+### Mobile add dialog scoping
+
+On mobile, `src/app/render.ts` renders chat and unified-panel tabs inside a
+horizontally translated `.preview-slider__track`. Because a transformed
+ancestor can become the containing block for positioned descendants, a
+viewport-fixed add dialog would size and center against the widened slider
+track instead of the visible inbox pane.
+
+The manual composer is therefore intentionally pane-scoped rather than
+viewport-scoped:
+
+- `InboxPanel` renders `<add-to-inbox-dialog>` inside its internal
+  `.inbox-panel` root, which is `position: relative` and clips overflow.
+- The dialog host and `.add-to-inbox-backdrop` use `position: absolute; inset: 0`
+  so the backdrop covers only the inbox pane and the dialog stays centered
+  within that pane at narrow widths.
+- Desktop uses the same pane-scoped dialog, preserving the existing behavior of
+  overlaying the inbox/unified panel rather than the whole browser viewport.
+
+The mobile regression is pinned in `tests/e2e/ui/staff-inbox.spec.ts`: the test
+opens the Inbox pane, opens "+ Add to inbox", verifies the transformed slider
+track is wider than the visible pane, and asserts both the dialog host and
+backdrop bounding boxes stay inside `[data-testid="inbox-panel-root"]`.
+
 There is **no sidebar badge** and no pending-count indicator anywhere in the
 sidebar. The staff session continues to appear as a normal staff-section
 entry; the only inbox UI surface is the panel attached to the session view.

--- a/src/ui/inbox/AddToInboxDialog.ts
+++ b/src/ui/inbox/AddToInboxDialog.ts
@@ -31,7 +31,7 @@ export class AddToInboxDialog extends LitElement {
 		// so layout has to be set inline on the host. Without this, the custom
 		// element defaults to display:inline with a zero bounding box and
 		// Playwright's toBeVisible() reports it as hidden.
-		this.style.position = "fixed";
+		this.style.position = "absolute";
 		this.style.inset = "0";
 		this.style.zIndex = "100";
 		this.style.display = "block";
@@ -84,14 +84,14 @@ export class AddToInboxDialog extends LitElement {
 			<div
 				class="add-to-inbox-backdrop"
 				@click=${this._close}
-				style="position:fixed;inset:0;background:color-mix(in oklch, var(--background) 50%, transparent);backdrop-filter:blur(2px);display:flex;align-items:center;justify-content:center;z-index:100;"
+				style="position:absolute;inset:0;background:color-mix(in oklch, var(--background) 50%, transparent);backdrop-filter:blur(2px);display:flex;align-items:center;justify-content:center;z-index:100;"
 			>
 				<div
 					class="add-to-inbox-dialog"
 					role="dialog"
 					aria-label="Add to inbox"
 					@click=${(e: Event) => e.stopPropagation()}
-					style="background:var(--card,var(--background));color:var(--foreground);border:1px solid var(--border);border-radius:8px;padding:18px;width:min(520px, 90vw);box-shadow:0 8px 24px color-mix(in oklch, var(--foreground) 12%, transparent);display:flex;flex-direction:column;gap:12px;"
+					style="background:var(--card,var(--background));color:var(--foreground);border:1px solid var(--border);border-radius:8px;padding:18px;width:min(520px, calc(100% - 24px));max-height:calc(100% - 24px);overflow:auto;box-sizing:border-box;box-shadow:0 8px 24px color-mix(in oklch, var(--foreground) 12%, transparent);display:flex;flex-direction:column;gap:12px;"
 				>
 					<div style="display:flex;align-items:center;justify-content:space-between;">
 						<h2 style="margin:0;font-size:14px;font-weight:600;">Add to inbox</h2>
@@ -110,7 +110,7 @@ export class AddToInboxDialog extends LitElement {
 							.value=${this._title}
 							@input=${(e: Event) => { this._title = (e.target as HTMLInputElement).value; }}
 							placeholder="e.g. Investigate slow queries"
-							style="width:100%;padding:6px 8px;border-radius:4px;border:1px solid var(--border);background:var(--background);color:var(--foreground);font-size:13px;"
+							style="width:100%;box-sizing:border-box;padding:6px 8px;border-radius:4px;border:1px solid var(--border);background:var(--background);color:var(--foreground);font-size:13px;"
 						/>
 					</div>
 					<div>
@@ -121,7 +121,7 @@ export class AddToInboxDialog extends LitElement {
 							.value=${this._prompt}
 							@input=${(e: Event) => { this._prompt = (e.target as HTMLTextAreaElement).value; }}
 							placeholder="What should the agent do?"
-							style="width:100%;padding:6px 8px;border-radius:4px;border:1px solid var(--border);background:var(--background);color:var(--foreground);font-size:13px;font-family:inherit;resize:vertical;min-height:120px;"
+							style="width:100%;box-sizing:border-box;padding:6px 8px;border-radius:4px;border:1px solid var(--border);background:var(--background);color:var(--foreground);font-size:13px;font-family:inherit;resize:vertical;min-height:120px;"
 						></textarea>
 					</div>
 					${this._error

--- a/src/ui/inbox/InboxPanel.ts
+++ b/src/ui/inbox/InboxPanel.ts
@@ -111,7 +111,7 @@ export class InboxPanel extends LitElement {
 		const isEmpty = pending.length === 0 && terminal.length === 0;
 
 		return html`
-			<div class="inbox-panel" style="display:flex;flex-direction:column;height:100%;min-height:0;">
+			<div class="inbox-panel" style="position:relative;overflow:hidden;display:flex;flex-direction:column;height:100%;min-height:0;">
 				<div class="inbox-panel-header" style="display:flex;align-items:center;justify-content:space-between;padding:8px 12px;border-bottom:1px solid var(--border);flex-shrink:0;">
 					<div style="font-size:13px;font-weight:600;color:var(--foreground);">Inbox</div>
 					<button

--- a/tests/e2e/ui/staff-inbox.spec.ts
+++ b/tests/e2e/ui/staff-inbox.spec.ts
@@ -82,10 +82,10 @@ test.describe("Staff inbox panel", () => {
 	}
 
 	test("mobile add-to-inbox dialog/backdrop stay within inbox pane", async ({ page }) => {
-		await page.setViewportSize({ width: 375, height: 667 });
 		const staff = await createStaff(`InboxBot-${Date.now()}`);
 
 		await openApp(page);
+		await page.setViewportSize({ width: 375, height: 667 });
 		await navigateToStaffSession(page, staff.id);
 
 		const inboxTab = page.locator("[data-testid='inbox-tab-pill']").first();

--- a/tests/e2e/ui/staff-inbox.spec.ts
+++ b/tests/e2e/ui/staff-inbox.spec.ts
@@ -68,6 +68,73 @@ test.describe("Staff inbox panel", () => {
 		return sid;
 	}
 
+	type Box = { x: number; y: number; width: number; height: number };
+
+	function formatBox(box: Box): string {
+		return `x=${Math.round(box.x)} y=${Math.round(box.y)} w=${Math.round(box.width)} h=${Math.round(box.height)}`;
+	}
+
+	function containsBox(outer: Box, inner: Box, tolerance = 1): boolean {
+		return inner.x >= outer.x - tolerance
+			&& inner.y >= outer.y - tolerance
+			&& inner.x + inner.width <= outer.x + outer.width + tolerance
+			&& inner.y + inner.height <= outer.y + outer.height + tolerance;
+	}
+
+	test("mobile add-to-inbox dialog/backdrop stay within inbox pane", async ({ page }) => {
+		await page.setViewportSize({ width: 375, height: 667 });
+		const staff = await createStaff(`InboxBot-${Date.now()}`);
+
+		await openApp(page);
+		await navigateToStaffSession(page, staff.id);
+
+		const inboxTab = page.locator("[data-testid='inbox-tab-pill']").first();
+		await expect(inboxTab, "mobile inbox tab should appear for staff sessions").toBeVisible({ timeout: 20_000 });
+		await inboxTab.click();
+
+		const inboxPane = page.locator("[data-testid='inbox-panel-root']").first();
+		await expect(inboxPane).toBeVisible({ timeout: 5_000 });
+		await expect.poll(async () => {
+			const box = await inboxPane.boundingBox();
+			const viewport = page.viewportSize();
+			if (!box || !viewport) return false;
+			return Math.abs(box.x) <= 2 && Math.abs(box.x + box.width - viewport.width) <= 2;
+		}, { timeout: 5_000, intervals: [50, 100, 200] }).toBe(true);
+
+		await inboxPane.locator("button.inbox-add-btn").click();
+		const dialogHost = page.locator("add-to-inbox-dialog");
+		const backdrop = page.locator(".add-to-inbox-backdrop");
+		await expect(dialogHost).toBeVisible({ timeout: 5_000 });
+		await expect(backdrop).toBeVisible({ timeout: 5_000 });
+
+		const paneBox = await inboxPane.boundingBox();
+		const hostBox = await dialogHost.boundingBox();
+		const backdropBox = await backdrop.boundingBox();
+		const trackBox = await page.locator(".preview-slider__track").boundingBox();
+		expect(paneBox, "inbox pane should have a bounding box").not.toBeNull();
+		expect(hostBox, "dialog host should have a bounding box").not.toBeNull();
+		expect(backdropBox, "dialog backdrop should have a bounding box").not.toBeNull();
+		expect(trackBox, "mobile preview slider track should have a bounding box").not.toBeNull();
+
+		expect(
+			trackBox!.width,
+			"mobile preview slider track should be wider than the visible inbox pane for this regression check",
+		).toBeGreaterThan(paneBox!.width + 10);
+
+		const debug = `pane=${formatBox(paneBox!)} host=${formatBox(hostBox!)} backdrop=${formatBox(backdropBox!)} track=${formatBox(trackBox!)}`;
+		expect(
+			containsBox(paneBox!, hostBox!),
+			`dialog/backdrop should stay within mobile inbox pane: host escaped; ${debug}`,
+		).toBe(true);
+		expect(
+			containsBox(paneBox!, backdropBox!),
+			`dialog/backdrop should stay within mobile inbox pane: backdrop escaped; ${debug}`,
+		).toBe(true);
+
+		await page.mouse.click(paneBox!.x + 8, paneBox!.y + 8);
+		await expect(dialogHost).toHaveCount(0, { timeout: 5_000 });
+	});
+
 	test("inbox panel renders on staff session, manual enqueue appears in Pending, persists across reload", async ({ page }) => {
 		const staff = await createStaff(`InboxBot-${Date.now()}`);
 


### PR DESCRIPTION
## Summary
- Pane-scope the manual Add-to-inbox dialog/backdrop to the inbox panel so mobile slider transforms cannot make it span chat + inbox panes.
- Add a mobile browser E2E regression for dialog/backdrop bounds.
- Document the mobile dialog scoping behavior in staff inbox docs.

## Verification
- npm run check
- npm run test:unit
- npm run build --silent 2>/dev/null && npx playwright test --config playwright-e2e.config.ts tests/e2e/ui/staff-inbox.spec.ts --grep "mobile" --reporter=line

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
