### PR TITLE
Fix session create race

### DIFF
--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -118,6 +118,18 @@ See `tests/e2e/sandbox-recovery-docker.spec.ts` for the same pattern in API-leve
 
 **Limitations.** The `gateway` fixture is worker-scoped, so a crash/restart in test N affects every later test on that worker. Tests should assert only on entities they own (sessions/projects/goals they created in this test) and avoid global state assumptions. Playwright groups tests with matching `enableMcp` / `enableWorktreePool` options onto the same worker, so each spec file in practice gets its own gateway lifecycle.
 
+#### Worker-scoped project state and helper self-healing
+
+Every E2E worker starts with its own temp `BOBBIT_DIR`, token, port, project registry, and gateway state. The harnesses seed `projects.json` as empty and then register one visible project named `default` through the REST API. That project is test scaffolding only: production still has no implicit user default project, and `POST /api/sessions` / `POST /api/goals` still require an explicit `projectId` or a `cwd` matching a registered project (see [rest-api.md — Project resolution contract](rest-api.md#project-resolution-contract)). Tests must not depend on the developer's real `.bobbit/` state or on a global fallback project.
+
+The shared helpers in `tests/e2e/e2e-setup.ts` keep this worker default healthy for high-level test setup:
+
+- `defaultProjectId()` reads the live project list for the current worker before returning an id. If the cached id disappeared, the visible project list is empty, or the `default` project was deleted, it re-registers the worker default with `upsert: true` and `acceptCanonical: true`.
+- `createSession()` and `createGoal()` inject that ensured id when the caller does not pass `projectId`. This makes helper setup resilient after specs that intentionally delete every visible project to exercise the zero-project UI state.
+- Non-201 helper failures include the response body plus request, port/base, `bobbitDir`, cached default id, and live project list. A `POST /api/sessions` 400 should therefore identify the actual server rejection instead of reporting `body=<empty>`.
+
+Keep the self-healing targeted. Do not add broad sleeps or weaken server validation when a later helper follows a project-deletion spec; the helper should restore only the worker default prerequisite it owns. API validation specs should issue their own direct `apiFetch()` calls and continue asserting intentional 4xx responses. Use `rawApiFetch()` only when the test must bypass harness request shaping, such as missing-`projectId` coverage or symlink-root rejection.
+
 **Framework extensions** added to `tests/e2e/ui/spec-framework.ts` to support these stories:
 
 - `ProjectHandle` — entity handle for asserting against projects.

--- a/tests/e2e/default-project-loss-repro.spec.ts
+++ b/tests/e2e/default-project-loss-repro.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * Reproducing E2E for the worker-scoped default-project loss flake.
+ *
+ * Current behavior: after a test deletes all visible projects in the same
+ * worker, createSession()/createGoal() omit projectId and fail with the
+ * project-resolution 400. After the harness fix, these helpers should
+ * re-create or re-resolve the default project and succeed.
+ */
+import { test, expect } from "./in-process-harness.js";
+import { apiFetch, createGoal, createSession, deleteGoal, deleteSession } from "./e2e-setup.js";
+
+async function listVisibleProjects(): Promise<Array<{ id: string; hidden?: boolean }>> {
+	const resp = await apiFetch("/api/projects");
+	expect(resp.status).toBe(200);
+	const body = await resp.json();
+	const projects: Array<{ id: string; hidden?: boolean }> = Array.isArray(body)
+		? body
+		: (body.projects ?? []);
+	return projects.filter(p => !p.hidden);
+}
+
+async function drainVisibleProjects(): Promise<void> {
+	for (const project of await listVisibleProjects()) {
+		const resp = await apiFetch(`/api/projects/${project.id}`, { method: "DELETE" });
+		expect(resp.status, `delete project ${project.id}`).toBe(200);
+	}
+	expect(await listVisibleProjects(), "visible projects after drain").toEqual([]);
+}
+
+test("createSession without explicit projectId survives default project deletion", async () => {
+	await drainVisibleProjects();
+
+	let sessionId: string | undefined;
+	try {
+		sessionId = await createSession();
+		expect(sessionId).toBeTruthy();
+	} finally {
+		if (sessionId) await deleteSession(sessionId);
+	}
+});
+
+test("createGoal without explicit projectId survives default project deletion", async () => {
+	await drainVisibleProjects();
+
+	let goalId: string | undefined;
+	try {
+		const goal = await createGoal({ title: "Default Project Loss Repro" });
+		goalId = goal.id as string;
+		expect(goalId).toBeTruthy();
+	} finally {
+		if (goalId) await deleteGoal(goalId);
+	}
+});

--- a/tests/e2e/e2e-setup.ts
+++ b/tests/e2e/e2e-setup.ts
@@ -13,7 +13,6 @@ import { readFileSync, mkdirSync, writeFileSync, realpathSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { expect } from "@playwright/test";
 import WebSocket from "ws";
 
 // ---------------------------------------------------------------------------
@@ -428,8 +427,131 @@ export async function apiFetch(path: string, opts: RequestInit = {}): Promise<Re
 	throw new Error("apiFetch: unreachable");
 }
 
+type ProjectSummary = {
+	id?: string;
+	name?: string;
+	rootPath?: string;
+	hidden?: boolean;
+};
+
+type LiveProjectState =
+	| { ok: true; status: number; projects: ProjectSummary[]; rawKind: string }
+	| { ok: false; status?: number; body?: string; error?: string };
+
+function safeJson(value: unknown): string {
+	try { return JSON.stringify(value); } catch { return String(value); }
+}
+
+async function responseText(resp: Response): Promise<string> {
+	try {
+		const text = await resp.text();
+		return text || "<empty>";
+	} catch (err) {
+		return `<failed to read body: ${err instanceof Error ? err.message : String(err)}>`;
+	}
+}
+
+async function readLiveProjectState(): Promise<LiveProjectState> {
+	try {
+		const resp = await fetch(`${base()}/api/projects`, {
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${token()}`,
+			},
+		});
+		const text = await resp.text().catch(() => "<failed to read body>");
+		if (!resp.ok) return { ok: false, status: resp.status, body: text };
+		let parsed: unknown;
+		try { parsed = text ? JSON.parse(text) : []; } catch {
+			return { ok: false, status: resp.status, body: `invalid JSON: ${text}` };
+		}
+		const list = Array.isArray(parsed)
+			? parsed
+			: Array.isArray((parsed as any)?.projects)
+				? (parsed as any).projects
+				: undefined;
+		if (!Array.isArray(list)) {
+			return { ok: false, status: resp.status, body: `unexpected project list shape: ${text}` };
+		}
+		return {
+			ok: true,
+			status: resp.status,
+			rawKind: Array.isArray(parsed) ? "array" : "object.projects",
+			projects: list.map((p: any) => ({
+				id: typeof p?.id === "string" ? p.id : undefined,
+				name: typeof p?.name === "string" ? p.name : undefined,
+				rootPath: typeof p?.rootPath === "string" ? p.rootPath : undefined,
+				hidden: typeof p?.hidden === "boolean" ? p.hidden : undefined,
+			})),
+		};
+	} catch (err) {
+		return { ok: false, error: err instanceof Error ? err.message : String(err) };
+	}
+}
+
+function formatLiveProjectState(state: LiveProjectState): string {
+	if (!state.ok) {
+		return safeJson({ ok: false, status: state.status, body: state.body, error: state.error });
+	}
+	return safeJson({ ok: true, status: state.status, rawKind: state.rawKind, projects: state.projects });
+}
+
+async function registerHarnessDefaultProject(reason: string): Promise<ProjectSummary> {
+	const p = port();
+	const request = { name: "default", rootPath: bobbitDir(), upsert: true, acceptCanonical: true };
+	let resp: Response;
+	try {
+		resp = await fetch(`${base()}/api/projects`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${token()}`,
+			},
+			body: JSON.stringify(request),
+		});
+	} catch (err) {
+		delete _defaultProjectIdCache[p];
+		throw new Error(
+			`E2E default project registration failed (${reason}): ${err instanceof Error ? err.message : String(err)} ` +
+			`request=${safeJson(request)} port=${p} bobbitDir=${bobbitDir()}`,
+		);
+	}
+	const text = await resp.text().catch(() => "<failed to read body>");
+	if (resp.status < 200 || resp.status >= 300) {
+		delete _defaultProjectIdCache[p];
+		throw new Error(
+			`E2E default project registration failed (${reason}): ${resp.status} ${resp.statusText} ` +
+			`body=${text || "<empty>"} request=${safeJson(request)} port=${p} bobbitDir=${bobbitDir()}`,
+		);
+	}
+	let project: ProjectSummary;
+	try { project = JSON.parse(text) as ProjectSummary; } catch {
+		delete _defaultProjectIdCache[p];
+		throw new Error(
+			`E2E default project registration returned invalid JSON (${reason}): body=${text || "<empty>"} ` +
+			`request=${safeJson(request)} port=${p} bobbitDir=${bobbitDir()}`,
+		);
+	}
+	if (!project?.id) {
+		delete _defaultProjectIdCache[p];
+		throw new Error(
+			`E2E default project registration returned no id (${reason}): body=${text || "<empty>"} ` +
+			`request=${safeJson(request)} port=${p} bobbitDir=${bobbitDir()}`,
+		);
+	}
+	_defaultProjectIdCache[p] = project.id;
+	return project;
+}
+
+async function requestDiagnosticContext(request: Record<string, unknown>): Promise<string> {
+	const liveProjects = await readLiveProjectState();
+	return `request=${safeJson(request)} port=${port()} base=${base()} bobbitDir=${bobbitDir()} ` +
+		`cachedDefaultProjectId=${_defaultProjectIdCache[port()] ?? "<none>"} liveProjects=${formatLiveProjectState(liveProjects)}`;
+}
+
 /**
- * Look up the harness-registered "default" project id.
+ * Look up the harness-registered "default" project id, re-registering it when
+ * a shared worker was drained to zero projects or our cached id was deleted.
  *
  * The gateway harness (see gateway-harness.ts / in-process-harness.ts) registers
  * a single project named "default" at the server CWD after startup. The server
@@ -441,36 +563,33 @@ export async function apiFetch(path: string, opts: RequestInit = {}): Promise<Re
  * cached here would then point at a deleted project and the next
  * `createSession()` would 500 with "Cannot resolve session store". To stay
  * robust under shared-worker harness reuse, every call re-checks the live
- * project list and re-derives the cache from it; the caller still gets
- * O(1)-ish behaviour because /api/projects is in-memory and dirt cheap.
+ * project list and re-derives the cache from the live "default" project;
+ * the caller still gets O(1)-ish behaviour because /api/projects is
+ * in-memory and dirt cheap.
  */
 const _defaultProjectIdCache: Record<string, string> = {};
 export async function defaultProjectId(): Promise<string | undefined> {
 	const p = port();
-	try {
-		const resp = await apiFetch("/api/projects");
-		if (!resp.ok) {
-			delete _defaultProjectIdCache[p];
-			return undefined;
-		}
-		const list = await resp.json() as Array<{ id: string; name: string }>;
-		if (!Array.isArray(list)) {
-			delete _defaultProjectIdCache[p];
-			return undefined;
-		}
-		// If a previously-cached id still exists in the live list, keep using
-		// it (stable across calls). Otherwise pick the "default" project, or
-		// fall back to the first registered project.
-		const cachedId = _defaultProjectIdCache[p];
-		if (cachedId && list.some(pr => pr.id === cachedId)) return cachedId;
-		const match = list.find(pr => pr.name === "default") ?? list[0];
-		if (match?.id) {
-			_defaultProjectIdCache[p] = match.id;
-			return match.id;
-		}
+	const state = await readLiveProjectState();
+	if (!state.ok) {
 		delete _defaultProjectIdCache[p];
-	} catch { /* zero-project harnesses are a valid state (see GR-09) */ }
-	return undefined;
+		throw new Error(`defaultProjectId failed to list projects: ${formatLiveProjectState(state)} port=${p} bobbitDir=${bobbitDir()}`);
+	}
+	const visibleProjects = state.projects.filter(pr => !pr.hidden);
+	const cachedId = _defaultProjectIdCache[p];
+	if (cachedId && visibleProjects.some(pr => pr.id === cachedId && pr.name === "default")) return cachedId;
+	if (cachedId && !visibleProjects.some(pr => pr.id === cachedId)) {
+		return (await registerHarnessDefaultProject(`cached project ${cachedId} missing from live list`)).id;
+	}
+	const match = visibleProjects.find(pr => pr.name === "default");
+	if (match?.id) {
+		_defaultProjectIdCache[p] = match.id;
+		return match.id;
+	}
+	delete _defaultProjectIdCache[p];
+	return (await registerHarnessDefaultProject(
+		visibleProjects.length === 0 ? "live visible project list is empty" : "default project missing from live list",
+	)).id;
 }
 
 /**
@@ -493,9 +612,8 @@ export async function createSession(opts?: { cwd?: string; goalId?: string; proj
 		// project). Auto-inject the harness default projectId whenever the
 		// caller didn't specify one — safe because the server prefers
 		// projectId over cwd. Tests that deliberately exercise the 400 path
-		// call apiFetch("/api/sessions", ...) directly and bypass this helper.
-		const pid = await defaultProjectId();
-		if (pid) body.projectId = pid;
+		// call rawApiFetch("/api/sessions", ...) and bypass this helper.
+		body.projectId = await defaultProjectId();
 	}
 	// Retry on transient server 500s. Under heavy parallel test load the
 	// server occasionally fails session creation with a 500 (e.g. worktree
@@ -505,18 +623,16 @@ export async function createSession(opts?: { cwd?: string; goalId?: string; proj
 	//
 	// Bumped from 3 to 5 attempts with backoff to absorb persistent FS
 	// contention under heavy parallel browser load, and we now capture and
-	// surface the server's error body so a failed retry tells us *why*
-	// instead of just "got 500".
+	// surface the server's final error body and live project context so a
+	// failed retry tells us *why* instead of just "got 500".
 	let resp: Response | undefined;
-	let lastBody: string | undefined;
 	for (let attempt = 0; attempt < 5; attempt++) {
 		resp = await apiFetch("/api/sessions", {
 			method: "POST",
 			body: JSON.stringify(body),
 		});
-		if (resp.status !== 500) break;
-		try { lastBody = await resp.clone().text(); } catch { /* ignore */ }
-		if (attempt === 4) break;
+		if (resp.status !== 500 || attempt === 4) break;
+		await responseText(resp).catch(() => "<ignored>");
 		try {
 			const { mkdirSync } = await import("node:fs");
 			mkdirSync(join(bobbitDir(), "state", "session-prompts"), { recursive: true });
@@ -524,10 +640,9 @@ export async function createSession(opts?: { cwd?: string; goalId?: string; proj
 		await new Promise(r => setTimeout(r, 500 * (attempt + 1)));
 	}
 	if (resp!.status !== 201) {
-		// Surface the server-side error body in the assertion message so flaky
-		// 500s can be diagnosed without a separate log dive.
+		const finalBody = await responseText(resp!);
 		throw new Error(
-			`createSession expected 201, got ${resp!.status}. body=${lastBody ?? "<empty>"}`,
+			`createSession expected 201, got ${resp!.status}. body=${finalBody}. ${await requestDiagnosticContext(body)}`,
 		);
 	}
 	return (await resp!.json()).id;
@@ -609,15 +724,19 @@ export async function createGoal(opts: {
 	if (!body.projectId) {
 		// Auto-inject harness default projectId when caller didn't specify one.
 		// Server prefers projectId over cwd. Tests that exercise the 400 path
-		// call apiFetch("/api/goals", ...) directly and bypass this helper.
-		const pid = await defaultProjectId();
-		if (pid) body.projectId = pid;
+		// call rawApiFetch("/api/goals", ...) and bypass this helper.
+		body.projectId = await defaultProjectId();
 	}
 	const resp = await apiFetch("/api/goals", {
 		method: "POST",
 		body: JSON.stringify(body),
 	});
-	expect(resp.status).toBe(201);
+	if (resp.status !== 201) {
+		const finalBody = await responseText(resp);
+		throw new Error(
+			`createGoal expected 201, got ${resp.status}. body=${finalBody}. ${await requestDiagnosticContext(body)}`,
+		);
+	}
 	return resp.json();
 }
 

--- a/tests/e2e/gateway-harness.ts
+++ b/tests/e2e/gateway-harness.ts
@@ -266,22 +266,27 @@ export const test = base.extend<{ failureContext: void }, { enableMcp: boolean; 
 		// Register the server CWD as a default project via REST. The server no
 		// longer does this implicitly — see "eliminate default project" refactor.
 		// Workflows already seeded above via direct project.yaml write.
-		try {
-			await fetch(`http://127.0.0.1:${port}/api/projects`, {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-					"Authorization": `Bearer ${token}`,
-				},
-				// acceptCanonical=true is needed on macOS, where TMPDIR
-				// (/var/folders/...) is a symlink to /private/var/folders/...
-				// Without it, the server rejects the register with a
-				// SymlinkProjectRootError 400 and the harness silently runs
-				// with zero registered projects — every POST /api/sessions
-				// or /api/goals then 400s with "projectId required".
-				body: JSON.stringify({ name: "default", rootPath: bobbitDir, upsert: true, acceptCanonical: true }),
-			});
-		} catch { /* best-effort */ }
+		const defaultProjectRegister = await fetch(`http://127.0.0.1:${port}/api/projects`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"Authorization": `Bearer ${token}`,
+			},
+			// acceptCanonical=true is needed on macOS, where TMPDIR
+			// (/var/folders/...) is a symlink to /private/var/folders/...
+			// Without it, the server rejects the register with a
+			// SymlinkProjectRootError 400 and the harness must fail loudly;
+			// otherwise every POST /api/sessions or /api/goals then 400s with
+			// "projectId required".
+			body: JSON.stringify({ name: "default", rootPath: bobbitDir, upsert: true, acceptCanonical: true }),
+		});
+		if (!defaultProjectRegister.ok) {
+			const body = await defaultProjectRegister.text().catch(() => "<failed to read body>");
+			throw new Error(
+				`[gateway-harness] default project registration failed: ` +
+				`${defaultProjectRegister.status} ${defaultProjectRegister.statusText} body=${body || "<empty>"}`,
+			);
+		}
 
 		const info: GatewayInfo = {
 			port,

--- a/tests/e2e/in-process-harness.ts
+++ b/tests/e2e/in-process-harness.ts
@@ -182,22 +182,27 @@ export const test = base.extend<{}, { enableWorktreePool: boolean; gateway: Gate
 		// rely on a pre-existing "default" project at projects[0] keep working.
 		// The server no longer auto-registers one — see server.ts startup block.
 		// Workflows already seeded above via direct project.yaml write.
-		try {
-			await fetch(`http://127.0.0.1:${port}/api/projects`, {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-					"Authorization": `Bearer ${token}`,
-				},
-				// acceptCanonical=true is needed on macOS, where TMPDIR
-				// (/var/folders/...) is a symlink to /private/var/folders/...
-				// Without it, the server rejects the register with a
-				// SymlinkProjectRootError 400 and the harness silently runs
-				// with zero registered projects — every POST /api/sessions
-				// or /api/goals then 400s with "projectId required".
-				body: JSON.stringify({ name: "default", rootPath: bobbitDir, upsert: true, acceptCanonical: true }),
-			});
-		} catch { /* best-effort */ }
+		const defaultProjectRegister = await fetch(`http://127.0.0.1:${port}/api/projects`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"Authorization": `Bearer ${token}`,
+			},
+			// acceptCanonical=true is needed on macOS, where TMPDIR
+			// (/var/folders/...) is a symlink to /private/var/folders/...
+			// Without it, the server rejects the register with a
+			// SymlinkProjectRootError 400 and the harness must fail loudly;
+			// otherwise every POST /api/sessions or /api/goals then 400s with
+			// "projectId required".
+			body: JSON.stringify({ name: "default", rootPath: bobbitDir, upsert: true, acceptCanonical: true }),
+		});
+		if (!defaultProjectRegister.ok) {
+			const body = await defaultProjectRegister.text().catch(() => "<failed to read body>");
+			throw new Error(
+				`[in-process-harness] default project registration failed: ` +
+				`${defaultProjectRegister.status} ${defaultProjectRegister.statusText} body=${body || "<empty>"}`,
+			);
+		}
 
 		// Write gateway-url so agent subprocesses (including the mock agent) can
 		// read it for callbacks to internal endpoints.


### PR DESCRIPTION
## Summary
- Identify E2E session-create 400 flakes as worker-scoped zero-project pollution after specs delete all visible projects.
- Add a focused repro covering default project loss before helper-created sessions.
- Make E2E helpers re-register the worker default project before `createSession()` / `createGoal()` setup, while preserving strict production validation and raw API 400 coverage.
- Improve harness diagnostics so non-201 helper failures include response body and project/request context.
- Document E2E worker project state and helper self-healing guidance.

## Validation
- `npm run check`
- `npx playwright test --config playwright-e2e.config.ts --project=api --workers=1 --retries=0 tests/e2e/default-project-loss-repro.spec.ts`
- `npm run test:e2e` ×3: all exited 0 with no Category B symptoms (`createSession expected 201, got 400`, `body=<empty>`, or `Goal "undefined" not found in any project`)

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)