### PR TITLE
Open all proposal types

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -910,13 +910,13 @@ Session/goal/search endpoints accept optional `?projectId=` filter:
 
 ## Editable proposals
 
-Every `propose_*` payload (`goal`, `project`, `workflow`, `role`, `tool`, `staff`) is mirrored to a real file under `.bobbit/state/proposal-drafts/<sessionId>/<type>.{md,yaml}`. The file is the single source of truth; the in-memory `state.activeProposals[type]` slot is a parsed projection rebuilt on every change. Two new tools - `view_proposal(type)` and `edit_proposal(type, old_text, new_text)` - let the agent apply surgical changes via exact-string replacement, with structured rollback on parse failure.
+Every `propose_*` payload (`goal`, `project`, `role`, `tool`, `staff`) is mirrored to a real file under `.bobbit/state/proposal-drafts/<sessionId>/<type>.{md,yaml}`. The file is the single source of truth; the in-memory `state.activeProposals[type]` slot is a parsed projection rebuilt on every change. Two new tools - `view_proposal(type)` and `edit_proposal(type, old_text, new_text)` - let the agent apply surgical changes via exact-string replacement, with structured rollback on parse failure.
 
 ### Why
 
 Agents previously had to re-emit the entire payload via `propose_*` to tweak one field. For a fully-elaborated `propose_project` call (components, workflows, gate DAGs, verify steps) this meant streaming kilobytes of YAML to change a single command string - expensive in tokens and wall-clock time, and easy to drift between successive emissions. The file-on-disk model lets `edit_proposal` patch the draft in place using the same `old_text`/`new_text` contract the agent already uses for source code, with atomic rollback so a malformed edit cannot corrupt the stored form.
 
-The refactor also unified the six per-type proposal slots into one keyed map and lifted the goal-proposal UX behaviours (draft persistence, dismissal stickiness, "Open proposal" reopen, first-emit auto-select, streaming shallow-merge, per-session scoping) so every type inherits them. Bespoke per-type renderers (project's Components/Workflows/Diff, workflow's gate graph, goal's spec markdown) are unchanged - only the surrounding plumbing was rewritten.
+The refactor also unified the per-type proposal slots into one keyed map and lifted the goal-proposal UX behaviours (draft persistence, dismissal stickiness, "Open proposal" reopen, first-emit auto-select, streaming shallow-merge, per-session scoping) so every supported type inherits them. Bespoke per-type renderers (project's Components/Workflows/Diff, role/tool/staff preview forms, goal's spec markdown) are unchanged - only the surrounding plumbing was rewritten.
 
 Full spec: [docs/design/editable-proposals.md](design/editable-proposals.md).
 
@@ -927,13 +927,12 @@ Full spec: [docs/design/editable-proposals.md](design/editable-proposals.md).
   <sessionId>/
     goal.md         # markdown body + YAML frontmatter (title/cwd/workflow/options)
     project.yaml    # native YAML matching the propose_project arg shape
-    workflow.yaml
     role.yaml
     tool.yaml
     staff.yaml
 ```
 
-Goal is the only markdown format; the body after the frontmatter is the goal `spec`. The other five files are native YAML (no JSON-stringified structured fields - see [Native-YAML project.yaml fields](#native-yaml-projectyaml-fields)). Per-session directories are created lazily on first write. Cleanup is deferred to `purgeOneSession` at the 7-day mark (alongside the `.jsonl` purge) rather than session archive — the [archived-proposal-reopen flows](archived-proposal-reopen.md) (Path A in-place resubmit, Path B continue-assistant) read drafts off disk for archived sessions, so the directory must outlive the live session.
+Goal is the only markdown format; the body after the frontmatter is the goal `spec`. The other four files are native YAML (no JSON-stringified structured fields - see [Native-YAML project.yaml fields](#native-yaml-projectyaml-fields)). Per-session directories are created lazily on first write. Cleanup is deferred to `purgeOneSession` at the 7-day mark (alongside the `.jsonl` purge) rather than session archive — the [archived-proposal-reopen flows](archived-proposal-reopen.md) (Path A in-place resubmit, Path B continue-assistant) read drafts off disk for archived sessions, so the directory must outlive the live session.
 
 Path safety: `sessionId` is validated against `/^[A-Za-z0-9_-]+$/` and `type` against the union literal, so no traversal is possible.
 
@@ -964,7 +963,7 @@ Per-type metadata lives in `src/server/proposals/proposal-types.ts`: `filename`,
 
 ### Unified client state
 
-The six legacy slots (`activeGoalProposal`, `activeProjectProposal`, `activeRoleProposal`, `activeStaffProposal`, plus the implicit slots for `tool`/`workflow`) are collapsed into one map in `src/app/state.ts`:
+The legacy per-type slots (`activeGoalProposal`, `activeProjectProposal`, `activeRoleProposal`, `activeStaffProposal`, plus the implicit `tool` slot) are collapsed into one map in `src/app/state.ts`:
 
 ```ts
 activeProposals: Partial<Record<ProposalType, ProposalSlot>>;
@@ -983,7 +982,7 @@ interface ProposalSlot {
 - `mergeFields(prev, incoming)` - streaming shallow-merge. Project carries `components` and `workflows` forward when the partial omits them; goal carries the markdown body across frontmatter-only deltas; the others use a plain spread.
 - `onFirstEmit(slot, opts)` - tab auto-select on the first emit (e.g. project flips `previewPanelActiveTab="project"`, mobile flips the assistant tab).
 - `validate(fields)` - returns blocking errors that disable the submit button.
-- `accept(slot)` - reserved hook; current accept paths (`createGoal`, `acceptProjectProposal`, role/staff/tool/workflow accept endpoints) are unchanged.
+- `accept(slot)` - reserved hook; current accept paths (`createGoal`, `acceptProjectProposal`, role/tool/staff save flows) are unchanged.
 
 Unified draft + dismissal helpers in `src/app/proposal-helpers.ts` replace the per-type ad-hoc managers:
 
@@ -991,6 +990,16 @@ Unified draft + dismissal helpers in `src/app/proposal-helpers.ts` replace the p
 - `markProposalDismissed(sid, type, fields)` / `isProposalDismissed(sid, type, fields)` / `clearProposalDismissed(sid, type)`
 
 LocalStorage key for dismissal is `bobbit-${type}-proposal-dismissed-${sessionId}`; the legacy `bobbit-goal-proposal-dismissed-<sid>` key is migrated once on first read.
+
+### Panel routing and tabs
+
+`state.activeProposals[type]` is the routing source for every proposal surface. A proposal is openable when the active session has a slot for one of the supported `ProposalType`s (`goal`, `project`, `role`, `tool`, `staff`); `assistantType` does not filter the slot.
+
+Normal sessions render active slots in the unified panel. Tab order is deterministic: `Chat`, then `Preview`, `Review`, and `Inbox` when those surfaces are present, then active proposal tabs in `PROPOSAL_TYPES` order. Proposal labels are `Goal`, `Project`, `Role`, `Tool`, and `Staff`; each proposal tab shows the existing proposal dot. Desktop tabs and the mobile slider use the same tab list.
+
+Assistant sessions keep the split chat/preview UX, but the preview pane can render any active proposal slot. Matching assistant types use their normal preview surface; non-matching active slots route through `proposalPanelForType(type)`. `role`, `tool`, and `staff` therefore reuse `rolePreviewPanel()`, `toolPreviewPanel()`, and `staffPreviewPanel()` outside assistant sessions instead of introducing duplicate forms.
+
+The `ProposalRenderer` "Open proposal" button dispatches `proposal-open { type, rev | fields }`. `session-manager.ts` clears any dismissal fingerprint, reveals the same tab/pane routing, then either restores the requested snapshot (`rev`) or replays legacy `fields`. Rehydrated drafts (`proposal_update { source: "rehydrate" }`) and archived-session resubmit/continue flows feed the same `remote.onProposal(type, fields, ...)` path, so restored sessions do not need type-specific reopen code.
 
 ### Flow: `propose_*` → file-seed → broadcast → parsed projection
 
@@ -1022,7 +1031,7 @@ Session purge cleans the directory: `session-manager.ts::purgeOneSession` fire-a
 
 ### Accept lifecycle
 
-The per-type accept handlers (`createGoal`, `acceptProjectProposal`, etc.) are unchanged. After a successful accept, the client fires `DELETE /api/sessions/:id/proposal/:type` which deletes the file and broadcasts `proposal_cleared`; the unified callback then drops the slot from `state.activeProposals`. The matching `deleteProposalDraft(sid, type)` clears the local-draft side state.
+The per-type submit/completion handlers (`createGoal`, `acceptProjectProposal`, role/staff save flows, the tool completion flow, etc.) are unchanged and render from the same panel implementations outside assistant sessions. When a handler accepts or saves a proposal, the client fires `DELETE /api/sessions/:id/proposal/:type` which deletes the file and broadcasts `proposal_cleared`; the unified callback then drops the slot from `state.activeProposals`. The matching `deleteProposalDraft(sid, type)` clears the local-draft side state.
 
 ### Tool surface
 
@@ -1080,15 +1089,17 @@ The Preview-mode markdown body of goal, role, and staff proposals is mounted via
 |---|---|
 | `src/server/proposals/proposal-files.ts` | Atomic file API (`writeProposalFile`, `editProposalFile`, `parseProposalFile`, `deleteProposalFile`). |
 | `src/server/proposals/proposal-types.ts` | Per-type plugins: filename, serialize, parse, requiredFields. |
-| `src/server/server.ts` | Four REST handlers (regex-routed at `/api/sessions/:id/proposal/:type[/edit\|/seed]`). |
+| `src/server/server.ts` | Proposal-draft REST handlers (regex-routed at `/api/sessions/:id/proposal/:type[...]`). |
 | `src/server/ws/protocol.ts` | `proposal_update` / `proposal_cleared` server messages. |
 | `src/server/ws/handler.ts` | Rehydrate-on-attach. |
 | `src/server/agent/session-manager.ts::terminateSession` | Per-session directory cleanup. |
 | `src/app/proposal-registry.ts` | `ProposalType`, `ProposalSlot`, `ProposalTypePlugin`, `PROPOSAL_TYPE_REGISTRY`. |
 | `src/app/proposal-helpers.ts` | Unified draft + dismissal helpers. |
 | `src/app/state.ts::activeProposals` | Unified slot map. |
-| `src/app/session-manager.ts::remote.onProposal` | Unified WS-driven callback. |
+| `src/app/render.ts` | Unified panel tabs and `proposalPanelForType(type)` routing. |
+| `src/app/session-manager.ts::remote.onProposal` | Unified WS-driven callback and `proposal-open` handling. |
 | `src/app/remote-agent.ts` | WS dispatch + legacy `_checkToolProposals` dual-fire. |
+| `src/ui/tools/renderers/ProposalRenderer.ts` | `propose_*` cards and the generic "Open proposal" event. |
 | `defaults/tools/proposals/{view,edit}_proposal.yaml` | Tool descriptors. |
 | `defaults/tools/proposals/extension.ts` | Tool registration; `propose_*` `execute()` POSTs to `/seed`. |
 
@@ -1099,7 +1110,8 @@ The Preview-mode markdown body of goal, role, and staff proposals is mounted via
 - `tests/proposal-helpers.test.ts` - unit: unified draft + dismissal.
 - `tests/e2e/proposal-edit-api.spec.ts` - API E2E: edit-before-propose, restart survival, malformed-edit rollback (SHA-256 byte-equal pre/post).
 - `tests/e2e/ui/proposal-edit-flow.spec.ts` - browser E2E: project propose → edit → accept happy path.
-- `tests/e2e/ui/proposal-types-uX-parity.spec.ts` - parametrised across all six types: dismissal stickiness, "Open proposal" reopen, first-emit auto-select, streaming shallow-merge, restart survival.
+- `tests/e2e/ui/proposal-types-uX-parity.spec.ts` - parametrised proposal UX parity: dismissal stickiness, "Open proposal" reopen, first-emit auto-select, streaming shallow-merge, restart survival.
+- `tests/e2e/ui/proposal-open-all-types.spec.ts` - browser E2E proving every supported proposal type opens, rehydrates, dismisses, and exposes its tab from a normal session.
 
 ---
 
@@ -2439,7 +2451,7 @@ Each was added to fix a symptom but masked a deeper race introduced by an earlie
 
 ### Proposal panel scroll lock invariant
 
-The six proposal panels (`goal`, `project`, `role`, `tool`, `staff`, `workflow` in `src/app/render.ts`) re-render on every streamed delta of a `propose_*` tool_use block. Lit's `.value=` rewrite of the spec/prompt `<textarea>` and the markdown-block parent `<div>` resets `scrollTop` and the textarea's selection range on each commit, so without intervention a user who scrolls up to read mid-spec gets snapped back to the top on the next delta and an in-progress textarea edit loses its caret. The fix mirrors the chat scroll lock invariant rather than refactoring `AgentInterface` - the chat path has subtle invariants and the regression risk of a shared helper outweighs the duplication cost.
+The five proposal panels (`goal`, `project`, `role`, `tool`, `staff` in `src/app/render.ts`) re-render on every streamed delta of a `propose_*` tool_use block. Lit's `.value=` rewrite of the spec/prompt `<textarea>` and the markdown-block parent `<div>` resets `scrollTop` and the textarea's selection range on each commit, so without intervention a user who scrolls up to read mid-spec gets snapped back to the top on the next delta and an in-progress textarea edit loses its caret. The fix mirrors the chat scroll lock invariant rather than refactoring `AgentInterface` - the chat path has subtle invariants and the regression risk of a shared helper outweighs the duplication cost.
 
 The logic lives in **`src/app/follow-tail.ts`** (`reconcileFollowTail(el)`), called from a `queueMicrotask` at the end of each panel's render so it fires after the synchronous DOM commit but before paint. The same three rules apply:
 
@@ -2451,7 +2463,7 @@ Lock state is stored in a module-private `WeakMap<HTMLElement, LockState>` keyed
 
 Textarea selection (`selectionStart` / `selectionEnd`) is captured on `select`, `keyup`, and `click`, then re-applied via `setSelectionRange(...)` after every reconcile branch (positive delta, zero delta, and shrink) - `setSelectionRange` is a state mutation per the WHATWG spec and applies even when the textarea is not the active element, so the caret is in the right place when focus returns. The DOMException some browsers throw on detached/hidden inputs is swallowed.
 
-**Timing choice.** Reconciliation runs in a `queueMicrotask` scheduled by each panel function, not via the parent `LitElement`'s `updateComplete` Promise. The six panels are plain functions returning `html\`\`` templates, so they have no `updateComplete` of their own; the microtask runs after the parent's synchronous render commit and before paint, which is the tightest deterministic hook available. A `ResizeObserver` would also work but adds an asynchronous tick before the first reconcile after stream-start - exactly when the user would perceive a snap.
+**Timing choice.** Reconciliation runs in a `queueMicrotask` scheduled by each panel function, not via the parent `LitElement`'s `updateComplete` Promise. Proposal panels are plain functions returning `html\`\`` templates, so they have no `updateComplete` of their own; the microtask runs after the parent's synchronous render commit and before paint, which is the tightest deterministic hook available. A `ResizeObserver` would also work but adds an asynchronous tick before the first reconcile after stream-start - exactly when the user would perceive a snap.
 
 When modifying proposal-panel scroll behaviour: route through `reconcileFollowTail` rather than touching `scrollTop` or `setSelectionRange` directly; do not introduce timer-based intent heuristics; do not widen the 5px tail. See `src/app/follow-tail.ts` and the panel render functions in `src/app/render.ts`. Behavioural twin test: `tests/follow-tail.spec.ts`.
 
@@ -2459,11 +2471,11 @@ When modifying proposal-panel scroll behaviour: route through `reconcileFollowTa
 
 `state.proposalStreamingByTag: Record<string, boolean>` (in `src/app/state.ts`) tracks whether each proposal panel is currently receiving streamed deltas. Keyed by the `tag` from `PROPOSAL_PARSERS` - `goal_proposal`, `project_proposal`, `role_proposal`, `tool_proposal`, `staff_proposal`. Read via the `isProposalStreaming(tag)` accessor.
 
-A per-tag map rather than a single boolean because the six panels can be in independent lifecycle states (e.g. an active `goal_proposal` and `project_proposal` simultaneously) and a scalar would force them to share a flag. The map also makes bulk-clear on session change cheap.
+A per-tag map rather than a single boolean because proposal panels can be in independent lifecycle states (e.g. an active `goal_proposal` and `project_proposal` simultaneously) and a scalar would force them to share a flag. The map also makes bulk-clear on session change cheap.
 
 **Why the flag exists.** Without it the Create / Apply / Save buttons are clickable mid-stream and a user can submit before the spec/title has finished streaming, producing a goal/role/tool with truncated content. The flag drives (a) the `disabled` state of each panel's primary submit, (b) the `streamingBadge()` + `STREAMING_BORDER` indicator, and (c) consumers in `session-manager.ts` that may want to suppress destructive side-effects on streaming-mode fires.
 
-**Writer (single owner): `RemoteAgent` in `src/app/remote-agent.ts`.** Set to `true` inside `_checkToolProposals(message, streaming=true)` immediately before the per-tag `callback(input, streaming)` fan-out. Cleared on the matching block-finish branch (`!streaming && blockId` - the `_processedProposalIds.add(blockId)` site, reached on `case "message_end"` and on full re-scans), and bulk-cleared on `case "agent_end"` and `RemoteAgent.reset()` so an aborted/errored turn never leaves the flag stuck on. Readers are the seven panel render functions in `src/app/render.ts`; they call `isProposalStreaming("<tag>_proposal")` once at the top.
+**Writer (single owner): `RemoteAgent` in `src/app/remote-agent.ts`.** Set to `true` inside `_checkToolProposals(message, streaming=true)` immediately before the per-tag `callback(input, streaming)` fan-out. Cleared on the matching block-finish branch (`!streaming && blockId` - the `_processedProposalIds.add(blockId)` site, reached on `case "message_end"` and on full re-scans), and bulk-cleared on `case "agent_end"` and `RemoteAgent.reset()` so an aborted/errored turn never leaves the flag stuck on. Readers are the proposal panel render functions in `src/app/render.ts`; they call `isProposalStreaming("<tag>_proposal")` once at the top.
 
 **WebSocket reconnect.** The resume path (`{type:"resume", fromSeq}`) replays missed events through the same handler, so a replayed `message_update` re-sets the flag and a replayed `message_end` clears it - no extra logic. The resume-gap fallback (`get_messages`) re-scans the snapshot with `_checkToolProposals(m, false)`, which hits the block-finish branch for any propose_* block in the snapshot and clears any stale flag. The `agent_end` / `reset()` bulk-clears are the final safety net on hard disconnect or session change. Cross-session isolation: `state.proposalStreamingByTag` is a singleton on the global `state` object cleared on `reset()`, which fires on session switch.
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -51,7 +51,7 @@ Client call sites use the shared helpers `errorFromResponse(res, fallback)` and 
 
 In-flight `propose_*` payloads are mirrored to `.bobbit/state/proposal-drafts/<sessionId>/<type>.{md,yaml}` so the agent can tweak them via `view_proposal` / `edit_proposal` without re-emitting the full payload. The file is the single source of truth; the in-memory client slot (`state.activeProposals[type]`) is a parsed projection. See [docs/internals.md — Editable proposals](internals.md#editable-proposals) and [docs/design/editable-proposals.md](design/editable-proposals.md).
 
-`<type>` is one of `goal | project | workflow | role | tool | staff`. `goal` files are markdown with YAML frontmatter; the others are native YAML.
+`<type>` is one of `goal | project | role | tool | staff`. `goal` files are markdown with YAML frontmatter; the others are native YAML.
 
 | Method | Path | Description |
 |---|---|---|

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -26,6 +26,7 @@ import { getRouteFromHash, setHashRoute } from "./routing.js";
 import { authenticateGateway, connectToSession, createAndConnectSession, terminateSession, applyProjectPalette, flushAndTeardownDraft } from "./session-manager.js";
 import { migrateLegacyVisitedMap } from "./render-helpers.js";
 import { doRenderApp } from "./render.js";
+import { PROPOSAL_TYPES } from "./proposal-registry.js";
 // goal-dashboard is dynamic-imported lazily to keep it out of the main chunk.
 // See docs/design/ui-bundle-size-reduction.md (Task A).
 let _goalDashboardModule: typeof import("./goal-dashboard.js") | null = null;
@@ -56,6 +57,10 @@ setRenderApp(doRenderApp);
 // state.goals can also force them into the expanded state (the normal
 // auto-expand path only fires for goals the server has confirmed).
 (window as any).__bobbitExpandedGoals = expandedGoals;
+
+function hasActiveProposalPanel(): boolean {
+	return PROPOSAL_TYPES.some((type) => state.activeProposals[type] != null);
+}
 
 // ============================================================================
 // GATEWAY STARTUP POLLING
@@ -546,7 +551,7 @@ async function initApp() {
 		allowInInput: true,
 		handler: () => {
 			const canFullscreen = !state.assistantType && (state.isPreviewSession || state.reviewPanelOpen || state.inboxPanelOpen);
-			const hasPanel = canFullscreen || (!state.assistantType && state.activeProposals.goal != null);
+			const hasPanel = canFullscreen || (!state.assistantType && hasActiveProposalPanel());
 			if (hasPanel) {
 				const key = `bobbit-preview-collapsed-${activeSessionId()}`;
 				const collapsed = localStorage.getItem(key) === "true";
@@ -605,7 +610,7 @@ async function initApp() {
 		defaultBindings: [{ key: "]", ctrlOrMeta: true, shift: false, alt: false }],
 		allowInInput: true,
 		handler: () => {
-			const hasPanel = !state.assistantType && (state.isPreviewSession || state.activeProposals.goal != null || state.reviewPanelOpen || state.inboxPanelOpen);
+			const hasPanel = !state.assistantType && (state.isPreviewSession || state.reviewPanelOpen || state.inboxPanelOpen || hasActiveProposalPanel());
 			if (!hasPanel) return;
 			const key = `bobbit-preview-collapsed-${activeSessionId()}`;
 			if (state.previewPanelFullscreen) {
@@ -629,7 +634,7 @@ async function initApp() {
 		defaultBindings: [{ key: "#", ctrlOrMeta: true, shift: false, alt: false }],
 		allowInInput: true,
 		handler: () => {
-			const hasPanel = !state.assistantType && (state.isPreviewSession || state.reviewPanelOpen || state.inboxPanelOpen);
+			const hasPanel = !state.assistantType && (state.isPreviewSession || state.reviewPanelOpen || state.inboxPanelOpen || hasActiveProposalPanel());
 			if (hasPanel) {
 				const key = `bobbit-preview-collapsed-${activeSessionId()}`;
 				if (state.previewPanelFullscreen) {
@@ -637,10 +642,14 @@ async function initApp() {
 					state.previewPanelFullscreen = false;
 					localStorage.setItem(key, "true");
 					sessionStorage.removeItem("bobbit-pre-fullscreen-collapsed");
-				} else {
+				} else if (state.isPreviewSession) {
 					// any non-fullscreen level → 2: jump to fullscreen
 					localStorage.setItem(key, "false");
 					state.previewPanelFullscreen = true;
+				} else {
+					// Proposal/review/inbox-only panels have no fullscreen surface.
+					const collapsed = localStorage.getItem(key) === "true";
+					localStorage.setItem(key, collapsed ? "false" : "true");
 				}
 				renderApp();
 			}

--- a/src/app/proposal-helpers.ts
+++ b/src/app/proposal-helpers.ts
@@ -74,20 +74,27 @@ function migrateLegacyDismissalKeyIfGoal(sessionId: string, type: ProposalType):
 }
 
 /**
- * Normalise per-type fields so the fingerprint is stable across the
- * file-on-disk round-trip (Slice B). The goal serializer appends a
- * trailing newline to `spec` (markdown body); the parser returns it
- * verbatim. Without this normalisation a dismissal recorded pre-reload
- * (in-memory "Body.") wouldn't match the post-rehydrate fingerprint
- * ("Body.\n") and dismissal stickiness silently breaks for goal.
+ * Normalise per-type body fields so the fingerprint is stable across the
+ * file-on-disk / snapshot round-trip. Body serializers may preserve or append
+ * trailing whitespace while tool-card fields often omit it; dismissal should
+ * stay sticky for the same proposal body without weakening metadata fields.
  */
+const TRAILING_BODY_FIELDS: Partial<Record<ProposalType, readonly string[]>> = {
+	goal: ["spec"],
+	role: ["prompt"],
+	staff: ["prompt"],
+};
+
 function normaliseFieldsForFingerprint(
 	type: ProposalType,
 	fields: Record<string, unknown>,
 ): Record<string, unknown> {
-	if (type !== "goal") return fields;
+	const bodyFields = TRAILING_BODY_FIELDS[type];
+	if (!bodyFields) return fields;
 	const out: Record<string, unknown> = { ...fields };
-	if (typeof out.spec === "string") out.spec = out.spec.replace(/\s+$/u, "");
+	for (const field of bodyFields) {
+		if (typeof out[field] === "string") out[field] = out[field].replace(/\s+$/u, "");
+	}
 	return out;
 }
 

--- a/src/app/proposal-registry.ts
+++ b/src/app/proposal-registry.ts
@@ -116,40 +116,28 @@ function getState(): any {
 	return (globalThis as any).bobbitState ?? {};
 }
 
-function goalFirstEmit(slot: ProposalSlot, opts: ProposalFirstEmitOpts): void {
+/**
+ * Reveal the UI surface for a proposal slot. Assistant sessions keep the
+ * existing split-preview UX; normal sessions select the matching unified tab
+ * and uncollapse the panel.
+ */
+export function revealProposalPanel(type: ProposalType, slot: Pick<ProposalSlot, "sessionId">, opts: ProposalFirstEmitOpts): void {
 	const s = getState();
 	if (opts.isAssistant) {
 		s.assistantHasProposal = true;
 		if (s.assistantTab === "chat" && opts.isMobile) {
 			s.assistantTab = "preview";
 		}
-	} else {
-		s.previewPanelActiveTab = "goal";
-		clearCollapseKey(slot.sessionId);
-		if (opts.isMobile) s.previewPanelTab = "goal";
+		return;
 	}
+
+	s.previewPanelActiveTab = type;
+	s.previewPanelTab = type;
+	clearCollapseKey(slot.sessionId);
 }
 
-function projectFirstEmit(slot: ProposalSlot, opts: ProposalFirstEmitOpts): void {
-	const s = getState();
-	if (opts.isAssistant) {
-		s.assistantHasProposal = true;
-		if (s.assistantTab === "chat" && opts.isMobile) {
-			s.assistantTab = "preview";
-		}
-	} else {
-		s.previewPanelActiveTab = "project";
-		clearCollapseKey(slot.sessionId);
-		if (opts.isMobile) s.previewPanelTab = "project";
-	}
-}
-
-function assistantOnlyFirstEmit(_slot: ProposalSlot, opts: ProposalFirstEmitOpts): void {
-	const s = getState();
-	s.assistantHasProposal = true;
-	if (s.assistantTab === "chat" && opts.isMobile) {
-		s.assistantTab = "preview";
-	}
+function proposalFirstEmit(type: ProposalType): ProposalTypePlugin["onFirstEmit"] {
+	return (slot, opts) => revealProposalPanel(type, slot, opts);
 }
 
 // ---- validators ----
@@ -211,11 +199,11 @@ function makePlugin(type: ProposalType, cfg: PluginConfig): ProposalTypePlugin {
 }
 
 export const PROPOSAL_TYPE_REGISTRY: Record<ProposalType, ProposalTypePlugin> = {
-	goal: makePlugin("goal", { mergeFields: goalMerge, onFirstEmit: goalFirstEmit, validate: goalValidate }),
-	project: makePlugin("project", { mergeFields: projectMerge, onFirstEmit: projectFirstEmit, validate: projectValidate }),
-	role: makePlugin("role", { mergeFields: defaultMerge, onFirstEmit: assistantOnlyFirstEmit, validate: roleValidate }),
-	tool: makePlugin("tool", { mergeFields: defaultMerge, onFirstEmit: assistantOnlyFirstEmit, validate: toolValidate }),
-	staff: makePlugin("staff", { mergeFields: defaultMerge, onFirstEmit: assistantOnlyFirstEmit, validate: staffValidate }),
+	goal: makePlugin("goal", { mergeFields: goalMerge, onFirstEmit: proposalFirstEmit("goal"), validate: goalValidate }),
+	project: makePlugin("project", { mergeFields: projectMerge, onFirstEmit: proposalFirstEmit("project"), validate: projectValidate }),
+	role: makePlugin("role", { mergeFields: defaultMerge, onFirstEmit: proposalFirstEmit("role"), validate: roleValidate }),
+	tool: makePlugin("tool", { mergeFields: defaultMerge, onFirstEmit: proposalFirstEmit("tool"), validate: toolValidate }),
+	staff: makePlugin("staff", { mergeFields: defaultMerge, onFirstEmit: proposalFirstEmit("staff"), validate: staffValidate }),
 };
 
 export function isProposalType(s: unknown): s is ProposalType {

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -53,6 +53,71 @@ const TYPE_TO_LEGACY_CALLBACK: Record<ProposalType, string> = {
 	project: "onProjectProposal",
 };
 
+function parseToolPayload(value: unknown): Record<string, unknown> | null {
+	if (!value) return null;
+	if (typeof value === "object" && !Array.isArray(value)) return value as Record<string, unknown>;
+	if (typeof value === "string") {
+		try {
+			const parsed = JSON.parse(value);
+			return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+				? parsed as Record<string, unknown>
+				: null;
+		} catch {
+			return null;
+		}
+	}
+	return null;
+}
+
+function mergeToolPayloads(...payloads: Array<Record<string, unknown> | null | undefined>): Record<string, unknown> | null {
+	let merged: Record<string, unknown> | null = null;
+	for (const payload of payloads) {
+		if (!payload) continue;
+		if (!merged) {
+			merged = { ...payload };
+			continue;
+		}
+		for (const [key, value] of Object.entries(payload)) {
+			const current = merged[key];
+			if ((current === undefined || current === null || current === "") && value !== undefined && value !== null && value !== "") {
+				merged[key] = value;
+			} else if (value !== undefined && value !== null && value !== "") {
+				merged[key] = value;
+			}
+		}
+	}
+	return merged;
+}
+
+function normalizeProposalToolCallInputs(message: any, inputByToolId?: (id: string) => unknown): any {
+	if (!message || !Array.isArray(message.content)) return message;
+	let changed = false;
+	const content = message.content.map((block: any) => {
+		if (block?.type !== "toolCall" && block?.type !== "tool_use") return block;
+		const toolName = block.name || block.toolName;
+		if (typeof toolName !== "string" || !toolName.startsWith("propose_")) return block;
+		const blockId = typeof block.id === "string" ? block.id : (typeof block.toolCallId === "string" ? block.toolCallId : "");
+		const merged = mergeToolPayloads(
+			blockId ? parseToolPayload(inputByToolId?.(blockId)) : null,
+			parseToolPayload(block.input),
+			parseToolPayload(block.arguments),
+		);
+		if (!merged) return block;
+		changed = true;
+		return {
+			...block,
+			input: merged,
+			arguments: merged,
+		};
+	});
+	return changed ? { ...message, content } : message;
+}
+
+function toolEventId(event: any): string | undefined {
+	const id = event?.toolCallId ?? event?.toolId;
+	return typeof id === "string" && id.length > 0 ? id : undefined;
+}
+
 /**
  * A remote agent adapter that connects to the Bobbit Gateway via WebSocket.
  * Duck-types the Agent interface from pi-agent-core so it can be used
@@ -85,6 +150,7 @@ export class RemoteAgent {
 	private _gatewayUrl = "";
 	private _authToken = "";
 	private _sessionId = "";
+	private _toolCallInputsById = new Map<string, unknown>();
 	// Server-authoritative prompt queue
 	private _serverQueue: QueuedMessage[] = [];
 	// Reducer-owned message state. The reducer is the single source of truth
@@ -1946,10 +2012,12 @@ export class RemoteAgent {
 
 			case "message_update":
 				if (event.message) {
+					const normalizedMessage = normalizeProposalToolCallInputs(event.message, (id) => this._toolCallInputsById.get(id));
+					event = { ...event, message: normalizedMessage };
 					// Throttle stream updates when content has truncated blocks
 					// to reduce Lit re-render pressure (2x/sec instead of every token).
-					const hasTruncated = Array.isArray(event.message.content) &&
-						event.message.content.some((c: any) =>
+					const hasTruncated = Array.isArray(normalizedMessage.content) &&
+						normalizedMessage.content.some((c: any) =>
 							c.type === "toolCall" &&
 							typeof c.arguments?.content === "object" &&
 							c.arguments?.content?._truncated === true,
@@ -1962,18 +2030,18 @@ export class RemoteAgent {
 						this._lastTruncatedStreamUpdate = now;
 					}
 
-					this._state.streamingMessage = event.message;
+					this._state.streamingMessage = normalizedMessage;
 					// Check for proposals during streaming so preview syncs live.
 					// Pass streaming=true so blocks are NOT marked as processed —
 					// the final fire on message_end marks them.
-					this._checkToolProposals(event.message, /* streaming */ true);
-					this._checkProposals(event.message);
+					this._checkToolProposals(normalizedMessage, /* streaming */ true);
+					this._checkProposals(normalizedMessage);
 				}
 				break;
 
 			case "message_end":
 				if (event.message) {
-					let msg = event.message;
+					let msg = normalizeProposalToolCallInputs(event.message, (id) => this._toolCallInputsById.get(id));
 					if (msg.role === "assistant") {
 						// Overflow-recovery suppression: when pi-coding-agent auto-compacts
 						// on overflow, it sometimes fires a retry from the still-in-flight
@@ -2091,14 +2159,23 @@ export class RemoteAgent {
 				}
 				break;
 
-			case "tool_execution_start":
-				if (event.toolCallId) {
+			case "tool_execution_start": {
+				const id = toolEventId(event);
+				if (id) {
 					this._state.pendingToolCalls = new Set(this._state.pendingToolCalls);
-					this._state.pendingToolCalls.add(event.toolCallId);
+					this._state.pendingToolCalls.add(id);
+					const input = parseToolPayload(event.input) ?? parseToolPayload(event.arguments);
+					if (input) this._toolCallInputsById.set(id, input);
 				}
 				break;
+			}
 
-			case "tool_execution_update":
+			case "tool_execution_update": {
+				const id = toolEventId(event);
+				if (id) {
+					const input = parseToolPayload(event.input) ?? parseToolPayload(event.arguments);
+					if (input) this._toolCallInputsById.set(id, input);
+				}
 				// Store partial results from long-running tools (e.g., skill invocations)
 				// so the UI can show real-time progress.
 				if (event.toolCallId && event.partialResult) {
@@ -2115,6 +2192,7 @@ export class RemoteAgent {
 					return; // skip default emit at end
 				}
 				break;
+			}
 
 			case "tool_execution_end":
 				if (event.toolCallId) {

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -58,6 +58,7 @@ import "../ui/inbox/InboxPanel.js";
 
 import { renderGoalGroup, renderSessionRow, renderSandboxIndicator, INDENT, getProjectAccentColor, filterArchivedGoalsByQuery, filterArchivedSessionsByQuery, bucketArchivedByProject, renderProjectArchivedSection, passesSidebarFilters } from "./render-helpers.js";
 import { viewTabs as projectViewTabs, componentsView as projectComponentsView, workflowsView as projectWorkflowsView, type ViewMode as ProjectViewMode, type ProposalComponent, type ProposalWorkflow } from "./project-proposal-views.js";
+import { PROPOSAL_TYPES, type ProposalType } from "./proposal-registry.js";
 
 const bobbitIcon = html`<img src="/favicon.svg" alt="" style="width:20px;height:18px;image-rendering:pixelated;" />`;
 
@@ -717,6 +718,44 @@ export function resetProposalAnnCount(type: "goal" | "role" | "staff"): void {
 	else if (type === "staff") _staffAnnCount = 0;
 }
 
+function recomputeAssistantHasProposal(): void {
+	state.assistantHasProposal = PROPOSAL_TYPES.some((type) => state.activeProposals[type] != null);
+}
+
+function clearProposalReviewState(sessionId: string | null | undefined, type: ProposalType): void {
+	if (!sessionId) return;
+	if (type === "goal" || type === "role" || type === "staff") {
+		clearProposalAnnotations(sessionId, type);
+		resetProposalAnnCount(type);
+	}
+}
+
+function clampUnifiedTabsAfterProposalRemoved(type: ProposalType): void {
+	const mobileTabs = unifiedPanelTabs();
+	if (!mobileTabs.includes(state.previewPanelTab as UnifiedPanelTab)) {
+		setUnifiedMobileTab(mobileTabs.includes("preview") ? "preview" : "chat");
+	} else if ((state.previewPanelTab as UnifiedPanelTab) === type) {
+		setUnifiedMobileTab(mobileTabs.includes("preview") ? "preview" : "chat");
+	}
+
+	const contentTabs = unifiedPanelContentTabs();
+	if ((state.previewPanelActiveTab as UnifiedContentTab) === type || !contentTabs.includes(state.previewPanelActiveTab as UnifiedContentTab)) {
+		setUnifiedDesktopTab(contentTabs[0] ?? "preview");
+	}
+}
+
+function dismissTypedProposal(type: ProposalType): void {
+	const slot = state.activeProposals[type];
+	const sessionId = slot?.sessionId ?? activeSessionId();
+	clearProposalReviewState(sessionId, type);
+	if (sessionId && slot?.fields) markProposalDismissed(sessionId, type, slot.fields);
+	delete state.activeProposals[type];
+	recomputeAssistantHasProposal();
+	clampUnifiedTabsAfterProposalRemoved(type);
+	if (sessionId) void deleteProposalFile(sessionId, type);
+	renderApp();
+}
+
 /** Render the "comments cleared" toast above a proposal panel, if active. */
 function proposalToast() {
 	if (!_proposalToastText) return "";
@@ -1288,21 +1327,8 @@ function rolePreviewPanel() {
 		const trimmedName = state.rolePreviewName.trim();
 		const trimmedLabel = state.rolePreviewLabel.trim();
 		if (!trimmedName || !trimmedLabel) return;
-		const sessionId = activeSessionId();
-		if (state.remoteAgent) {
-			state.remoteAgent.disconnect();
-			state.remoteAgent = null;
-			state.connectionStatus = "disconnected";
-		}
-		state.assistantType = null;
-		if (sessionId) clearProposalAnnotations(sessionId, "role");
-		resetProposalAnnCount("role");
-		delete state.activeProposals.role;
-		// Clean up persisted draft
-		if (sessionId) {
-			deleteRoleDraft(sessionId);
-		}
-		localStorage.removeItem("gateway.sessionId");
+		const proposalSessionId = state.activeProposals.role?.sessionId ?? activeSessionId();
+		const isRoleAssistant = state.assistantType === "role";
 
 		// Parse tools: comma-separated string -> array
 		const toolsList = state.rolePreviewTools
@@ -1314,20 +1340,36 @@ function rolePreviewPanel() {
 		const toolPolicies: Record<string, string> = {};
 		for (const t of toolsList) toolPolicies[t] = "allow";
 
-		await createRole({
+		const created = await createRole({
 			name: trimmedName,
 			label: trimmedLabel,
 			promptTemplate: state.rolePreviewPrompt,
 			toolPolicies: Object.keys(toolPolicies).length > 0 ? toolPolicies : undefined,
 			accessory: state.rolePreviewAccessory,
 		});
+		if (!created) return;
 
-		// Slice E: drop the on-disk proposal file once accepted.
-		if (sessionId) void deleteProposalFile(sessionId, "role");
+		clearProposalReviewState(proposalSessionId, "role");
+		delete state.activeProposals.role;
+		recomputeAssistantHasProposal();
+		clampUnifiedTabsAfterProposalRemoved("role");
+		if (proposalSessionId) {
+			deleteRoleDraft(proposalSessionId);
+			void deleteProposalFile(proposalSessionId, "role");
+		}
 
-		if (sessionId && !isSessionArchived(sessionId)) {
-			await gatewayFetch(`/api/sessions/${sessionId}`, { method: "DELETE" });
-			clearSessionModel(sessionId);
+		if (isRoleAssistant) {
+			if (state.remoteAgent) {
+				state.remoteAgent.disconnect();
+				state.remoteAgent = null;
+				state.connectionStatus = "disconnected";
+			}
+			state.assistantType = null;
+			localStorage.removeItem("gateway.sessionId");
+			if (proposalSessionId && !isSessionArchived(proposalSessionId)) {
+				await gatewayFetch(`/api/sessions/${proposalSessionId}`, { method: "DELETE" });
+				clearSessionModel(proposalSessionId);
+			}
 		}
 
 		// Navigate to the roles page
@@ -1496,6 +1538,7 @@ function rolePreviewPanel() {
 					},
 					children: html`<span data-testid="proposal-send-feedback">Send feedback (${_roleAnnCount})</span>`,
 				}) : ""}
+				${!state.assistantType ? Button({ variant: "ghost", onClick: () => dismissTypedProposal("role"), children: "Dismiss" }) : ""}
 				<span data-testid="proposal-primary-submit">${Button({
 					variant: "default",
 					onClick: handleCreateRole,
@@ -1520,7 +1563,11 @@ function toolPreviewPanel() {
 		reconcileFollowTail(toolOuterScrollRef.value);
 	});
 	const handleDone = () => {
-		backToSessions();
+		if (state.assistantType === "tool") {
+			backToSessions();
+			return;
+		}
+		dismissTypedProposal("tool");
 	};
 
 	const handleViewTool = async () => {
@@ -1605,7 +1652,7 @@ function toolPreviewPanel() {
 			<!-- Footer -->
 			<div class="shrink-0 flex items-center justify-end gap-2 px-5 py-3 border-t border-border">
 				${streaming ? streamingBadge() : ""}
-				${Button({ variant: "ghost", onClick: handleDone, children: "Close" })}
+				${Button({ variant: "ghost", onClick: handleDone, children: state.assistantType === "tool" ? "Close" : "Dismiss" })}
 				${state.toolPreviewName ? html`<span data-testid="proposal-primary-submit">${Button({
 					variant: "default",
 					onClick: handleViewTool,
@@ -1828,19 +1875,8 @@ function staffPreviewPanel() {
 	const handleCreateStaff = async () => {
 		const trimmedName = state.staffPreviewName.trim();
 		if (!trimmedName) return;
-		const sessionId = activeSessionId();
-		if (state.remoteAgent) {
-			state.remoteAgent.disconnect();
-			state.remoteAgent = null;
-			state.connectionStatus = "disconnected";
-		}
-		state.assistantType = null;
-		if (sessionId) clearProposalAnnotations(sessionId, "staff");
-		resetProposalAnnCount("staff");
-		delete state.activeProposals.staff;
-		localStorage.removeItem("gateway.sessionId");
-		setHashRoute("landing");
-		state.appView = "authenticated";
+		const proposalSessionId = state.activeProposals.staff?.sessionId ?? activeSessionId();
+		const isStaffAssistant = state.assistantType === "staff";
 
 		let triggers: any[] = [];
 		try {
@@ -1848,7 +1884,6 @@ function staffPreviewPanel() {
 		} catch { /* keep empty */ }
 
 		const sandboxed = _staffSandboxed;
-		_staffSandboxed = false;
 		const result = await createStaffAgent({
 			name: trimmedName,
 			description: state.staffPreviewDescription,
@@ -1858,12 +1893,31 @@ function staffPreviewPanel() {
 			projectId: state.activeProjectId || undefined,
 			sandboxed,
 		});
-		// Slice E: drop the on-disk proposal file once accepted.
-		if (sessionId) void deleteProposalFile(sessionId, "staff");
-		if (sessionId && !isSessionArchived(sessionId)) {
-			await gatewayFetch(`/api/sessions/${sessionId}`, { method: "DELETE" });
-			clearSessionModel(sessionId);
+		if (!result) return;
+
+		_staffSandboxed = false;
+		clearProposalReviewState(proposalSessionId, "staff");
+		delete state.activeProposals.staff;
+		recomputeAssistantHasProposal();
+		clampUnifiedTabsAfterProposalRemoved("staff");
+		if (proposalSessionId) void deleteProposalFile(proposalSessionId, "staff");
+
+		if (isStaffAssistant) {
+			if (state.remoteAgent) {
+				state.remoteAgent.disconnect();
+				state.remoteAgent = null;
+				state.connectionStatus = "disconnected";
+			}
+			state.assistantType = null;
+			localStorage.removeItem("gateway.sessionId");
+			setHashRoute("landing");
+			state.appView = "authenticated";
+			if (proposalSessionId && !isSessionArchived(proposalSessionId)) {
+				await gatewayFetch(`/api/sessions/${proposalSessionId}`, { method: "DELETE" });
+				clearSessionModel(proposalSessionId);
+			}
 		}
+
 		reloadStaffList();
 		await refreshSessions();
 		if (result?.currentSessionId) {
@@ -2001,6 +2055,7 @@ function staffPreviewPanel() {
 					},
 					children: html`<span data-testid="proposal-send-feedback">Send feedback (${_staffAnnCount})</span>`,
 				}) : ""}
+				${!state.assistantType ? Button({ variant: "ghost", onClick: () => dismissTypedProposal("staff"), children: "Dismiss" }) : ""}
 				<span data-testid="proposal-primary-submit">${Button({
 					variant: "default",
 					onClick: handleCreateStaff,
@@ -2163,9 +2218,7 @@ function projectProposalPanel() {
 
 	const handleDismiss = () => {
 		if (proposal?.sessionId) deleteProjectDraft(proposal.sessionId);
-		delete state.activeProposals.project;
-		state.assistantHasProposal = false;
-		renderApp();
+		dismissTypedProposal("project");
 	};
 
 	const onFieldInput = (key: string, value: string) => {
@@ -2278,7 +2331,22 @@ function projectProposalPanel() {
 	`;
 }
 
+function proposalPanelForType(type: ProposalType) {
+	switch (type) {
+		case "goal": return goalProposalPanel();
+		case "project": return projectProposalPanel();
+		case "role": return rolePreviewPanel();
+		case "tool": return toolPreviewPanel();
+		case "staff": return staffPreviewPanel();
+		default: return "";
+	}
+}
+
 function getAssistantPreviewPanel(type: string) {
+	const requested = state.previewPanelTab as ProposalType;
+	if (PROPOSAL_TYPES.includes(requested) && state.activeProposals[requested] != null && !(requested === "goal" && type === "goal")) {
+		return proposalPanelForType(requested);
+	}
 	switch (type) {
 		case "goal": return goalPreviewPanel();
 		case "role": return rolePreviewPanel();
@@ -2434,7 +2502,11 @@ function goalProposalPanel() {
 		_proposalAutoStartTeam = true;
 		// Persist dismiss so it survives reconnect
 		const sid = activeSessionId();
-		if (sid && dismissed) markProposalDismissed(sid, dismissed);
+		if (sid && dismissed) {
+			markProposalDismissed(sid, dismissed);
+			void deleteProposalFile(sid, "goal");
+		}
+		recomputeAssistantHasProposal();
 		// If preview tab still available, switch to it; otherwise back to chat
 		if (state.isPreviewSession) {
 			state.previewPanelActiveTab = "preview";
@@ -2491,34 +2563,64 @@ function goalProposalPanel() {
 // the inline `srcdoc=` iframe are gone. The gateway now injects them
 // server-side on text/html responses through the `/preview/<sid>/` mount.
 
+type UnifiedPanelTab = "chat" | "preview" | "review" | "inbox" | ProposalType;
+type UnifiedContentTab = Exclude<UnifiedPanelTab, "chat">;
+
+const PROPOSAL_TAB_LABELS: Record<ProposalType, string> = {
+	goal: "Goal",
+	project: "Project",
+	role: "Role",
+	tool: "Tool",
+	staff: "Staff",
+};
+
+function activeProposalTypes(): ProposalType[] {
+	return PROPOSAL_TYPES.filter((type) => state.activeProposals[type] != null);
+}
+
+function hasActiveProposalPanel(): boolean {
+	return activeProposalTypes().length > 0;
+}
+
 /** Whether the unified panel is active for the current non-assistant session. */
 function hasUnifiedPanel(): boolean {
 	return !state.assistantType && (
 		state.isPreviewSession ||
-		state.activeProposals.goal != null ||
-		state.activeProposals.project != null ||
 		state.reviewPanelOpen ||
-		state.inboxPanelOpen
+		state.inboxPanelOpen ||
+		hasActiveProposalPanel()
 	);
 }
 
 /** Ordered list of available unified panel tabs for the current session. */
-function unifiedPanelTabs(): Array<"chat" | "preview" | "goal" | "review" | "project" | "inbox"> {
-	const tabs: Array<"chat" | "preview" | "goal" | "review" | "project" | "inbox"> = ["chat"];
+function unifiedPanelTabs(): UnifiedPanelTab[] {
+	const tabs: UnifiedPanelTab[] = ["chat"];
 	if (state.isPreviewSession) tabs.push("preview");
 	if (state.reviewPanelOpen) tabs.push("review");
-	if (state.activeProposals.goal != null) tabs.push("goal");
-	if (state.activeProposals.project != null) tabs.push("project");
 	if (state.inboxPanelOpen) tabs.push("inbox");
+	tabs.push(...activeProposalTypes());
 	return tabs;
+}
+
+function unifiedPanelContentTabs(): UnifiedContentTab[] {
+	return unifiedPanelTabs().filter((tab): tab is UnifiedContentTab => tab !== "chat");
+}
+
+function setUnifiedMobileTab(tab: UnifiedPanelTab): void {
+	(state as any).previewPanelTab = tab;
+}
+
+function setUnifiedDesktopTab(tab: UnifiedContentTab): void {
+	(state as any).previewPanelActiveTab = tab;
 }
 
 /** Index of the current previewPanelTab within unifiedPanelTabs(). Clamps to valid range. */
 function unifiedTabIndex(): number {
 	const tabs = unifiedPanelTabs();
-	const idx = tabs.indexOf(state.previewPanelTab);
+	const current = state.previewPanelTab as UnifiedPanelTab;
+	const idx = tabs.indexOf(current);
 	if (idx >= 0) return idx;
-	state.previewPanelTab = tabs[tabs.length - 1];
+	setUnifiedMobileTab(tabs[tabs.length - 1]);
 	return tabs.length - 1;
 }
 
@@ -2563,7 +2665,7 @@ function setupPreviewSwipe(): void {
 			let newIdx = curIdx;
 			if (dx > threshold && curIdx > 0) newIdx = curIdx - 1;
 			else if (dx < -threshold && curIdx < count - 1) newIdx = curIdx + 1;
-			state.previewPanelTab = tabs[newIdx];
+			setUnifiedMobileTab(tabs[newIdx]);
 			track.style.transform = `translateX(${unifiedSlideX(newIdx, count)}%)`;
 			renderApp();
 		}
@@ -2627,7 +2729,7 @@ function setupPreviewSwipe(): void {
 			let newIdx = curIdx;
 			if (dx < -threshold && curIdx < count - 1) newIdx = curIdx + 1;
 			else if (dx > threshold && curIdx > 0) newIdx = curIdx - 1;
-			state.previewPanelTab = tabs[newIdx];
+			setUnifiedMobileTab(tabs[newIdx]);
 			track.style.transform = `translateX(${unifiedSlideX(newIdx, count)}%)`;
 		}
 		captured = false;
@@ -2934,51 +3036,33 @@ export function doRenderApp(): void {
 		`;
 	};
 
+	const unifiedTabLabel = (tab: UnifiedPanelTab): string => {
+		if (tab === "chat") return "Chat";
+		if (tab === "preview") return "Preview";
+		if (tab === "review") return "Review";
+		if (tab === "inbox") return "Inbox";
+		return PROPOSAL_TAB_LABELS[tab];
+	};
+
+	const unifiedMobileTabButton = (tab: UnifiedPanelTab) => {
+		const label = unifiedTabLabel(tab);
+		const isProposalTab = PROPOSAL_TYPES.includes(tab as ProposalType);
+		const inboxDot = tab === "inbox" && state.inboxEntries.some((e) => e.state === "pending");
+		return html`
+			<button
+				class="goal-tab-pill ${(state.previewPanelTab as UnifiedPanelTab) === tab ? "goal-tab-pill--active" : ""}"
+				title=${label}
+				data-testid=${tab === "inbox" ? "inbox-tab-pill" : ""}
+				@click=${() => { setUnifiedMobileTab(tab); renderApp(); }}
+			>${label}${isProposalTab || inboxDot ? html` <span class="goal-tab-dot"></span>` : ""}</button>
+		`;
+	};
+
 	const unifiedTabBar = () => {
 		if (!hasUnifiedPanel()) return "";
 		return html`
 			<div class="goal-tab-bar shrink-0 flex items-center gap-1 px-3 py-2 border-b border-border bg-background">
-				<button
-					class="goal-tab-pill ${state.previewPanelTab === "chat" ? "goal-tab-pill--active" : ""}"
-					title="Chat"
-					@click=${() => { state.previewPanelTab = "chat"; renderApp(); }}
-				>Chat</button>
-				${state.isPreviewSession ? html`
-					<button
-						class="goal-tab-pill ${state.previewPanelTab === "preview" ? "goal-tab-pill--active" : ""}"
-						title="Preview"
-						@click=${() => { state.previewPanelTab = "preview"; renderApp(); }}
-					>Preview</button>
-				` : ""}
-				${state.reviewPanelOpen ? html`
-					<button
-						class="goal-tab-pill ${state.previewPanelTab === "review" ? "goal-tab-pill--active" : ""}"
-						title="Review"
-						@click=${() => { state.previewPanelTab = "review"; renderApp(); }}
-					>Review</button>
-				` : ""}
-				${state.activeProposals.goal != null ? html`
-					<button
-						class="goal-tab-pill ${state.previewPanelTab === "goal" ? "goal-tab-pill--active" : ""}"
-						title="Goal"
-						@click=${() => { state.previewPanelTab = "goal"; renderApp(); }}
-					>Goal <span class="goal-tab-dot"></span></button>
-				` : ""}
-				${state.activeProposals.project != null ? html`
-					<button
-						class="goal-tab-pill ${state.previewPanelTab === "project" ? "goal-tab-pill--active" : ""}"
-						title="Project"
-						@click=${() => { state.previewPanelTab = "project"; renderApp(); }}
-					>Project <span class="goal-tab-dot"></span></button>
-				` : ""}
-				${state.inboxPanelOpen ? html`
-					<button
-						class="goal-tab-pill ${state.previewPanelTab === "inbox" ? "goal-tab-pill--active" : ""}"
-						title="Inbox"
-						@click=${() => { state.previewPanelTab = "inbox"; renderApp(); }}
-						data-testid="inbox-tab-pill"
-					>Inbox${state.inboxEntries.filter((e) => e.state === "pending").length > 0 ? html` <span class="goal-tab-dot"></span>` : ""}</button>
-				` : ""}
+				${unifiedPanelTabs().map((tab) => unifiedMobileTabButton(tab))}
 			</div>
 		`;
 	};
@@ -3108,77 +3192,58 @@ export function doRenderApp(): void {
 		`;
 	};
 
+	const proposalPanelContent = (type: ProposalType) => {
+		if (state.activeProposals[type] == null) return "";
+		return proposalPanelForType(type);
+	};
+
+	const unifiedPanelContent = (tab: UnifiedContentTab) => {
+		if (tab === "preview" && state.isPreviewSession) return htmlPreviewContent();
+		if (tab === "review" && state.reviewPanelOpen) return reviewPaneContent();
+		if (tab === "inbox" && state.inboxPanelOpen) return inboxPaneContent();
+		return proposalPanelContent(tab as ProposalType);
+	};
+
+	const unifiedDesktopTabButton = (tab: UnifiedContentTab) => {
+		const label = unifiedTabLabel(tab);
+		const isProposalTab = PROPOSAL_TYPES.includes(tab as ProposalType);
+		const inboxDot = tab === "inbox" && state.inboxEntries.some((e) => e.state === "pending");
+		return html`
+			<button
+				class="goal-tab-pill ${(state.previewPanelActiveTab as UnifiedContentTab) === tab ? "goal-tab-pill--active" : ""}"
+				title=${label}
+				data-testid=${tab === "inbox" ? "inbox-tab-unified" : ""}
+				@click=${() => { setUnifiedDesktopTab(tab); setUnifiedMobileTab(tab); renderApp(); }}
+			>${label}${isProposalTab || inboxDot ? html` <span class="goal-tab-dot"></span>` : ""}</button>
+		`;
+	};
+
 	const unifiedPreviewPanel = () => {
-		// Auto-correct tab if the active tab's content is no longer available
-		if (state.previewPanelActiveTab === "review" && !state.reviewPanelOpen) {
-			state.previewPanelActiveTab = state.isPreviewSession ? "preview" : (state.activeProposals.goal != null ? "goal" : (state.activeProposals.project != null ? "project" : (state.inboxPanelOpen ? "inbox" : "preview")));
-		} else if (state.previewPanelActiveTab === "preview" && !state.isPreviewSession && state.activeProposals.goal != null) {
-			state.previewPanelActiveTab = "goal";
-		} else if (state.previewPanelActiveTab === "preview" && !state.isPreviewSession && state.inboxPanelOpen) {
-			state.previewPanelActiveTab = "inbox";
-		} else if (state.previewPanelActiveTab === "goal" && state.activeProposals.goal == null && state.isPreviewSession) {
-			state.previewPanelActiveTab = "preview";
-		} else if (state.previewPanelActiveTab === "project" && state.activeProposals.project == null) {
-			state.previewPanelActiveTab = state.isPreviewSession ? "preview"
-				: (state.activeProposals.goal != null ? "goal"
-				: (state.reviewPanelOpen ? "review"
-				: (state.inboxPanelOpen ? "inbox" : "preview")));
-		} else if (state.previewPanelActiveTab === "inbox" && !state.inboxPanelOpen) {
-			state.previewPanelActiveTab = state.isPreviewSession ? "preview"
-				: (state.reviewPanelOpen ? "review"
-				: (state.activeProposals.goal != null ? "goal" : "preview"));
+		const contentTabs = unifiedPanelContentTabs();
+		if (contentTabs.length === 0) return "";
+
+		// Archived/resubmit flows historically set previewPanelTab. Honour that
+		// request on desktop too, then clamp if the requested tab is unavailable.
+		const requestedMobileTab = state.previewPanelTab as UnifiedPanelTab;
+		if (requestedMobileTab !== "chat" && contentTabs.includes(requestedMobileTab as UnifiedContentTab)) {
+			setUnifiedDesktopTab(requestedMobileTab as UnifiedContentTab);
+		}
+		if (!contentTabs.includes(state.previewPanelActiveTab as UnifiedContentTab)) {
+			setUnifiedDesktopTab(contentTabs[0]);
 		}
 
-		const showPreviewTab = state.isPreviewSession;
-		const showGoalTab = state.activeProposals.goal != null;
-		const showReviewTab = state.reviewPanelOpen;
-		const showProjectTab = state.activeProposals.project != null;
-		const showInboxTab = state.inboxPanelOpen;
+		const activeTab = state.previewPanelActiveTab as UnifiedContentTab;
+		const showPreviewTab = contentTabs.includes("preview");
 
 		return html`
 			<div class="goal-preview-panel flex-1 flex flex-col border-l border-border min-h-0">
 				<!-- Tab header -->
 				<div class="flex items-center justify-between px-3 py-2 border-b border-border shrink-0">
 					<div class="flex items-center gap-1">
-						${showPreviewTab ? html`
-							<button
-								class="goal-tab-pill ${state.previewPanelActiveTab === "preview" ? "goal-tab-pill--active" : ""}"
-								title="Preview"
-								@click=${() => { state.previewPanelActiveTab = "preview"; renderApp(); }}
-							>Preview</button>
-						` : ""}
-						${showReviewTab ? html`
-							<button
-								class="goal-tab-pill ${state.previewPanelActiveTab === "review" ? "goal-tab-pill--active" : ""}"
-								title="Review"
-								@click=${() => { state.previewPanelActiveTab = "review"; renderApp(); }}
-							>Review</button>
-						` : ""}
-						${showGoalTab ? html`
-							<button
-								class="goal-tab-pill ${state.previewPanelActiveTab === "goal" ? "goal-tab-pill--active" : ""}"
-								title="Goal"
-								@click=${() => { state.previewPanelActiveTab = "goal"; renderApp(); }}
-							>Goal <span class="goal-tab-dot"></span></button>
-						` : ""}
-						${showProjectTab ? html`
-							<button
-								class="goal-tab-pill ${state.previewPanelActiveTab === "project" ? "goal-tab-pill--active" : ""}"
-								title="Project"
-								@click=${() => { state.previewPanelActiveTab = "project"; renderApp(); }}
-							>Project <span class="goal-tab-dot"></span></button>
-						` : ""}
-						${showInboxTab ? html`
-							<button
-								class="goal-tab-pill ${state.previewPanelActiveTab === "inbox" ? "goal-tab-pill--active" : ""}"
-								title="Inbox"
-								data-testid="inbox-tab-unified"
-								@click=${() => { state.previewPanelActiveTab = "inbox"; renderApp(); }}
-							>Inbox${state.inboxEntries.filter((e) => e.state === "pending").length > 0 ? html` <span class="goal-tab-dot"></span>` : ""}</button>
-						` : ""}
+						${contentTabs.map((tab) => unifiedDesktopTabButton(tab))}
 					</div>
 					<div class="flex items-center gap-0.5">
-						${showPreviewTab && state.previewPanelActiveTab === "preview" && state.previewPanelEntry ? previewControlButtons() : ""}
+						${activeTab === "preview" && state.previewPanelEntry ? previewControlButtons() : ""}
 						${showPreviewTab ? html`
 						<button @click=${() => { state.previewPanelFullscreen = true; renderApp(); }} class="text-muted-foreground hover:text-foreground" style="background:none;border:none;cursor:pointer;padding:2px;flex-shrink:0;" title=${`Fullscreen preview${shortcutHint("toggle-sidebar")}`}>
 							${icon(Maximize2, "sm")}
@@ -3189,17 +3254,7 @@ export function doRenderApp(): void {
 					</div>
 				</div>
 				<!-- Tab content -->
-				${state.previewPanelActiveTab === "review" && showReviewTab
-					? reviewPaneContent()
-					: state.previewPanelActiveTab === "preview" && showPreviewTab
-						? htmlPreviewContent()
-						: state.previewPanelActiveTab === "goal" && showGoalTab
-							? goalProposalPanel()
-							: state.previewPanelActiveTab === "project" && showProjectTab
-								? projectProposalPanel()
-								: state.previewPanelActiveTab === "inbox" && showInboxTab
-									? inboxPaneContent()
-									: ""}
+				${unifiedPanelContent(activeTab)}
 			</div>
 		`;
 	};
@@ -3210,24 +3265,10 @@ export function doRenderApp(): void {
 		</button>
 	`;
 	/** Render individual pane content for mobile slider. */
-	const mobilePaneContent = (tab: "chat" | "preview" | "goal" | "review" | "project" | "inbox") => {
+	const mobilePaneContent = (tab: UnifiedPanelTab) => {
 		if (tab === "chat") return state.chatPanel;
-		if (tab === "preview" && state.isPreviewSession) {
-			return html`<div class="goal-preview-panel flex-1 flex flex-col min-h-0">${htmlPreviewContent()}</div>`;
-		}
-		if (tab === "review" && state.reviewPanelOpen) {
-			return html`<div class="goal-preview-panel flex-1 flex flex-col min-h-0">${reviewPaneContent()}</div>`;
-		}
-		if (tab === "goal" && state.activeProposals.goal != null) {
-			return html`<div class="goal-preview-panel flex-1 flex flex-col min-h-0">${goalProposalPanel()}</div>`;
-		}
-		if (tab === "project" && state.activeProposals.project != null) {
-			return html`<div class="goal-preview-panel flex-1 flex flex-col min-h-0">${projectProposalPanel()}</div>`;
-		}
-		if (tab === "inbox" && state.inboxPanelOpen) {
-			return html`<div class="goal-preview-panel flex-1 flex flex-col min-h-0">${inboxPaneContent()}</div>`;
-		}
-		return html``;
+		const content = unifiedPanelContent(tab as UnifiedContentTab);
+		return html`<div class="goal-preview-panel flex-1 flex flex-col min-h-0">${content}</div>`;
 	};
 
 	const mainArea = () => {

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -37,7 +37,7 @@ import {
 	markProposalDismissed as markProposalDismissedTyped,
 	clearProposalDismissed as clearProposalDismissedTyped,
 } from "./proposal-helpers.js";
-import { PROPOSAL_TYPE_REGISTRY, PROPOSAL_TYPES, isProposalType, type ProposalType, type ProposalSlot } from "./proposal-registry.js";
+import { PROPOSAL_TYPE_REGISTRY, PROPOSAL_TYPES, isProposalType, revealProposalPanel, type ProposalType, type ProposalSlot } from "./proposal-registry.js";
 
 /**
  * Extract the markdown body field from a proposal's fields object.
@@ -141,6 +141,22 @@ function resolveProjectMode(sessionId: string): "provisional" | "registered" {
 	const session = state.gatewaySessions.find(s => s.id === sessionId);
 	const project = state.projects.find(p => p.id === session?.projectId);
 	return project?.provisional ? "provisional" : "registered";
+}
+
+function isAssistantProposalType(type: ProposalType): boolean {
+	return state.assistantType === type || (type === "project" && state.assistantType === "project-scaffolding");
+}
+
+function revealActiveProposalPanel(type: ProposalType, sessionId: string): void {
+	const isMatchingAssistant = isAssistantProposalType(type);
+	revealProposalPanel(type, { sessionId }, {
+		isAssistant: isMatchingAssistant,
+		isMobile: !isDesktop(),
+	});
+	if (state.assistantType && !isMatchingAssistant) {
+		state.assistantHasProposal = true;
+		if (!isDesktop()) state.assistantTab = "preview";
+	}
 }
 
 /**
@@ -745,15 +761,17 @@ export function selectSession(sessionId: string, replaceHistory?: boolean): void
 
 	state.selectedSessionId = sessionId;
 
-	// Project proposal is scoped to the session that emitted it. Clear it the
-	// moment the user navigates away so it never bleeds into other sessions.
-	// connectToSession() rehydrates from the persisted draft if the user comes
-	// back to the originating session.
-	if (state.activeProposals.project && state.activeProposals.project.sessionId !== sessionId) {
-		delete state.projectProposalAcceptedBySessionId[state.activeProposals.project.sessionId];
-		delete state.activeProposals.project;
-		state.assistantHasProposal = false;
+	// Proposals are scoped to the session that emitted them. Clear stale slots
+	// the moment the user navigates away so they never bleed into other sessions.
+	// connectToSession() rehydrates from persisted proposal files when returning.
+	for (const type of PROPOSAL_TYPES) {
+		const slot = state.activeProposals[type];
+		if (slot && slot.sessionId !== sessionId) {
+			if (type === "project") delete state.projectProposalAcceptedBySessionId[slot.sessionId];
+			delete state.activeProposals[type];
+		}
 	}
+	state.assistantHasProposal = PROPOSAL_TYPES.some((type) => state.activeProposals[type]?.sessionId === sessionId);
 
 	// Fade out the current chat panel instantly
 	if (state.chatPanel) {
@@ -839,18 +857,14 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 		// annotations re-anchoring as orphans because their referenced text
 		// disappeared). Mirrors the slow-path guard at the bottom of
 		// connectToSession (~line 1675).
-		for (const t of ["goal", "role", "staff"] as const) {
+		for (const t of PROPOSAL_TYPES) {
 			const slot = state.activeProposals[t];
 			if (slot && slot.sessionId !== sessionId) {
 				delete state.activeProposals[t];
 			}
 		}
 		// Recompute hasProposal from what's left.
-		state.assistantHasProposal =
-			(state.activeProposals.goal != null && state.activeProposals.goal.sessionId === sessionId)
-			|| (state.activeProposals.role != null && state.activeProposals.role.sessionId === sessionId)
-			|| (state.activeProposals.staff != null && state.activeProposals.staff.sessionId === sessionId)
-			|| (state.activeProposals.project != null && state.activeProposals.project.sessionId === sessionId);
+		state.assistantHasProposal = PROPOSAL_TYPES.some((t) => state.activeProposals[t]?.sessionId === sessionId);
 		state.previewTitle = "";
 		state.previewSpec = "";
 		state.previewCwd = "";
@@ -1351,7 +1365,7 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 				}
 				delete state.activeProposals[type];
 				// Recompute assistantHasProposal across remaining slots.
-				state.assistantHasProposal = Object.keys(state.activeProposals).length > 0;
+				state.assistantHasProposal = PROPOSAL_TYPES.some((t) => state.activeProposals[t] != null);
 				renderApp();
 				return;
 			}
@@ -1399,10 +1413,14 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 				delete state.projectProposalAcceptedBySessionId[sessionId];
 			}
 			if (isFirstEmit) {
+				const isMatchingAssistant = isAssistantProposalType(type);
 				plugin.onFirstEmit(slot, {
-					isAssistant: state.assistantType === type,
+					isAssistant: isMatchingAssistant,
 					isMobile: !isDesktop(),
 				});
+				if (state.assistantType && !isMatchingAssistant && !isDesktop()) {
+					state.assistantTab = "preview";
+				}
 			}
 			renderApp();
 		};
@@ -1417,6 +1435,7 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			// Slice E: clear per-type dismissal for ALL types so "Open proposal"
 			// always re-opens the panel (the user explicitly clicked it).
 			clearProposalDismissedTyped(sessionId, type);
+			revealActiveProposalPanel(type, sessionId);
 
 			// Snapshot-restore branch — server is authoritative; the broadcast
 			// rebuilds the slot via remote.onProposal. We also fan out to the
@@ -1730,27 +1749,14 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			// Mirror the project-slot pattern below: keep the slot when it's
 			// scoped to this session, drop it only when it's left over from a
 			// different session.
-			if (state.assistantType !== "goal") {
-				const slot = state.activeProposals.goal;
-				if (slot && slot.sessionId !== sessionId) delete state.activeProposals.goal;
+			for (const type of PROPOSAL_TYPES) {
+				const slot = state.activeProposals[type];
+				if (slot && slot.sessionId !== sessionId) {
+					if (type === "project") delete state.projectProposalAcceptedBySessionId[slot.sessionId];
+					delete state.activeProposals[type];
+				}
 			}
-			if (state.assistantType !== "role") {
-				const slot = state.activeProposals.role;
-				if (slot && slot.sessionId !== sessionId) delete state.activeProposals.role;
-			}
-			if (state.assistantType !== "staff") {
-				const slot = state.activeProposals.staff;
-				if (slot && slot.sessionId !== sessionId) delete state.activeProposals.staff;
-			}
-			// Project proposal is scoped to the originating session and transient
-			// for non-assistant sessions — mirrors the goal-proposal model. The
-			// project-assistant branch below handles persistence for that session
-			// type only (its session is dedicated to building the proposal).
-			if (state.activeProposals.project && state.activeProposals.project.sessionId !== sessionId) {
-				delete state.projectProposalAcceptedBySessionId[state.activeProposals.project.sessionId];
-				delete state.activeProposals.project;
-				state.assistantHasProposal = false;
-			}
+			state.assistantHasProposal = PROPOSAL_TYPES.some((type) => state.activeProposals[type]?.sessionId === sessionId);
 
 			if (state.assistantType === "goal") {
 				const restored = await restoreGoalDraft(sessionId);
@@ -2015,9 +2021,9 @@ export async function terminateSession(sessionId: string, opts?: { goalId?: stri
 		}
 	}
 
-	// Clear project proposal if it belonged to this session
-	if (state.activeProposals.project?.sessionId === sessionId) {
-		delete state.activeProposals.project;
+	// Clear proposal slots if they belonged to this session.
+	for (const type of PROPOSAL_TYPES) {
+		if (state.activeProposals[type]?.sessionId === sessionId) delete state.activeProposals[type];
 	}
 	delete state.projectProposalAcceptedBySessionId[sessionId];
 

--- a/src/ui/components/Messages.ts
+++ b/src/ui/components/Messages.ts
@@ -614,7 +614,12 @@ export class ToolMessage extends LitElement {
 			this.toolCall.arguments,
 			result,
 			!this.aborted && (this.isStreaming || this.pending),
-			{ toolUseId: this.toolCall.id, sessionId: sessionIdCtx, getAskResponseAnswers },
+			{
+				toolUseId: this.toolCall.id,
+				toolCallInput: (this.toolCall as any).input,
+				sessionId: sessionIdCtx,
+				getAskResponseAnswers,
+			},
 		);
 
 		// Handle custom rendering (no card wrapper)

--- a/src/ui/tools/renderers/ProposalRenderer.ts
+++ b/src/ui/tools/renderers/ProposalRenderer.ts
@@ -6,7 +6,7 @@ import type { ToolResultMessage } from "@earendil-works/pi-ai";
 import { html } from "lit";
 import { FileText } from "lucide";
 import { renderHeader, getToolState } from "../renderer-registry.js";
-import type { ToolRenderer, ToolRenderResult } from "../types.js";
+import type { ToolRenderer, ToolRenderContext, ToolRenderResult } from "../types.js";
 import "../../../ui/components/ExpandableSection.js";
 import { parseRevFromResult } from "./proposal-rev-marker.js";
 export { parseRevFromResult } from "./proposal-rev-marker.js";
@@ -25,9 +25,28 @@ function truncate(s: string, max = 150): string {
 	return s.length > max ? s.slice(0, max) + "…" : s;
 }
 
+function mergeParamFields(
+	primary: Record<string, any> | null,
+	fallback: Record<string, any> | null,
+): Record<string, any> | null {
+	if (!primary) return fallback;
+	if (!fallback) return primary;
+	const merged: Record<string, any> = { ...fallback, ...primary };
+	for (const [key, value] of Object.entries(fallback)) {
+		const current = primary[key];
+		if ((current === undefined || current === null || current === "") && value !== undefined && value !== null && value !== "") {
+			merged[key] = value;
+		}
+	}
+	return merged;
+}
+
 function parseParams(params: any): Record<string, any> | null {
 	if (!params) return null;
-	if (typeof params === "object" && params !== null && !Array.isArray(params)) return params;
+	if (typeof params === "object" && params !== null && !Array.isArray(params)) {
+		const nested = mergeParamFields(parseParams(params.arguments), parseParams(params.input));
+		return nested ?? params;
+	}
 	if (typeof params === "string") {
 		try { return JSON.parse(params); } catch { return null; }
 	}
@@ -48,10 +67,10 @@ export class ProposalRenderer implements ToolRenderer {
 		return new ProposalRenderer(name);
 	}
 
-	render(params: any | undefined, result: ToolResultMessage | undefined, isStreaming?: boolean): ToolRenderResult {
+	render(params: any | undefined, result: ToolResultMessage | undefined, isStreaming?: boolean, ctx?: ToolRenderContext): ToolRenderResult {
 		const state = getToolState(result, isStreaming);
 		const meta = PROPOSAL_LABELS[this._toolName] || PROPOSAL_LABELS.propose_goal;
-		const fields = parseParams(params);
+		const fields = mergeParamFields(parseParams(params), parseParams(ctx?.toolCallInput));
 
 		// Streaming with no complete fields yet
 		if (!fields && isStreaming) {

--- a/src/ui/tools/types.ts
+++ b/src/ui/tools/types.ts
@@ -10,6 +10,8 @@ export interface ToolRenderResult {
 export interface ToolRenderContext {
 	/** The tool_use ID from the assistant message block. */
 	toolUseId?: string;
+	/** Raw `input` payload from tool_use/toolCall blocks, when present. */
+	toolCallInput?: unknown;
 	/** The gateway session ID that issued the tool call. */
 	sessionId?: string;
 	/**

--- a/tests/e2e/ui/proposal-open-all-types.spec.ts
+++ b/tests/e2e/ui/proposal-open-all-types.spec.ts
@@ -1,31 +1,53 @@
 /**
- * Reproducing coverage for proposal-tab routing in normal chat sessions.
+ * Browser E2E coverage for opening every proposal type from a normal chat session.
  *
- * Role/tool/staff proposals already reach state.activeProposals and render an
- * Open proposal action in the transcript. Normal sessions must also surface a
- * visible proposal tab and pane for each type.
+ * The proposal transport is type-generic; ordinary sessions must surface a
+ * tab/pane for every active proposal slot, not just goal/project.
  */
 import { test, expect } from "../gateway-harness.js";
-import type { Page } from "@playwright/test";
+import { apiFetch } from "../e2e-setup.js";
+import type { Locator, Page } from "@playwright/test";
 import { openApp, createSessionViaUI, sendMessage } from "./ui-helpers.js";
 
-type ProposalType = "role" | "tool" | "staff";
+type ProposalType = "goal" | "project" | "role" | "tool" | "staff";
+type ProposalLabel = "Goal" | "Project" | "Role" | "Tool" | "Staff";
 
 interface ProposalCase {
 	type: ProposalType;
-	label: "Role" | "Tool" | "Staff";
+	label: ProposalLabel;
 	trigger: string;
 	toolCardLabel: string;
-	panel: string;
+	panel?: string;
+	fieldKey: string;
+	fieldValue: string;
 }
 
 const CASES: ProposalCase[] = [
+	{
+		type: "goal",
+		label: "Goal",
+		trigger: "GOAL_PROPOSAL_PARITY",
+		toolCardLabel: "Goal Proposal",
+		fieldKey: "title",
+		fieldValue: "Parity Goal A",
+	},
+	{
+		type: "project",
+		label: "Project",
+		trigger: "PROJECT_PROPOSAL_PARITY",
+		toolCardLabel: "Project Proposal",
+		panel: "project-proposal",
+		fieldKey: "name",
+		fieldValue: "Parity Project",
+	},
 	{
 		type: "role",
 		label: "Role",
 		trigger: "ROLE_PROPOSAL_PARITY",
 		toolCardLabel: "Role Proposal",
 		panel: "role-proposal",
+		fieldKey: "name",
+		fieldValue: "parity-role",
 	},
 	{
 		type: "tool",
@@ -33,6 +55,8 @@ const CASES: ProposalCase[] = [
 		trigger: "TOOL_PROPOSAL_PARITY",
 		toolCardLabel: "Tool Proposal",
 		panel: "tool-proposal",
+		fieldKey: "tool",
+		fieldValue: "parity-tool",
 	},
 	{
 		type: "staff",
@@ -40,8 +64,12 @@ const CASES: ProposalCase[] = [
 		trigger: "STAFF_PROPOSAL_PARITY",
 		toolCardLabel: "Staff Proposal",
 		panel: "staff-proposal",
+		fieldKey: "name",
+		fieldValue: "parity-staff",
 	},
 ];
+
+const STAFF_ACCEPT_NAME = "parity-staff";
 
 async function waitForProposalSlot(page: Page, type: ProposalType): Promise<void> {
 	await page.waitForFunction(
@@ -55,6 +83,30 @@ async function waitForProposalSlot(page: Page, type: ProposalType): Promise<void
 	);
 }
 
+async function waitForProposalSlotAbsent(page: Page, type: ProposalType): Promise<void> {
+	await page.waitForFunction(
+		(t) => {
+			const state = (window as any).bobbitState ?? (window as any).__bobbitState;
+			return !!state && !state.activeProposals?.[t];
+		},
+		type,
+		{ timeout: 10_000 },
+	);
+}
+
+async function selectedSessionId(page: Page): Promise<string | null> {
+	return page.evaluate(() => {
+		const state = (window as any).bobbitState ?? (window as any).__bobbitState;
+		return state?.selectedSessionId ?? null;
+	});
+}
+
+async function activeSessionId(page: Page): Promise<string> {
+	const sid = await selectedSessionId(page);
+	expect(sid, "active session id must be set").toBeTruthy();
+	return sid as string;
+}
+
 async function expectNormalChatSession(page: Page): Promise<void> {
 	const assistantType = await page.evaluate(() => {
 		const state = (window as any).bobbitState ?? (window as any).__bobbitState;
@@ -63,37 +115,194 @@ async function expectNormalChatSession(page: Page): Promise<void> {
 	expect(assistantType, "test must use a normal chat session, not an assistant session").toBeFalsy();
 }
 
+async function expectSlotField(page: Page, proposal: ProposalCase): Promise<void> {
+	await expect
+		.poll(
+			async () => page.evaluate(
+				({ type, fieldKey }) => {
+					const state = (window as any).bobbitState ?? (window as any).__bobbitState;
+					return state?.activeProposals?.[type]?.fields?.[fieldKey] ?? null;
+				},
+				{ type: proposal.type, fieldKey: proposal.fieldKey },
+			),
+			{ timeout: 10_000 },
+		)
+		.toBe(proposal.fieldValue);
+}
+
+async function otherProposalSlots(page: Page, type: ProposalType): Promise<Record<string, unknown>> {
+	return page.evaluate((t) => {
+		const state = (window as any).bobbitState ?? (window as any).__bobbitState;
+		const out: Record<string, unknown> = {};
+		for (const [key, slot] of Object.entries(state?.activeProposals ?? {})) {
+			if (key === t) continue;
+			out[key] = JSON.parse(JSON.stringify((slot as any)?.fields ?? slot));
+		}
+		return out;
+	}, type);
+}
+
+function proposalTab(page: Page, proposal: ProposalCase): Locator {
+	return page.locator(`button.goal-tab-pill[title="${proposal.label}"]`).first();
+}
+
+function chatTab(page: Page): Locator {
+	return page.locator('button.goal-tab-pill[title="Chat"]').first();
+}
+
+function proposalPane(page: Page, proposal: ProposalCase): Locator {
+	if (proposal.type === "goal") {
+		return page
+			.locator(".goal-preview-panel")
+			.filter({ has: page.locator('input[placeholder="Goal title"]') })
+			.first();
+	}
+	return page.locator(`[data-panel="${proposal.panel}"]`).first();
+}
+
+async function expectProposalTabAndPane(page: Page, proposal: ProposalCase): Promise<void> {
+	const tab = proposalTab(page, proposal);
+	await expect(
+		tab,
+		`${proposal.label} proposal tab should be visible in normal sessions`,
+	).toBeVisible({ timeout: 5_000 });
+	await expect(
+		tab.locator(".goal-tab-dot"),
+		`${proposal.label} proposal tab should show the proposal dot`,
+	).toBeVisible({ timeout: 5_000 });
+	await tab.click();
+	await expect(
+		proposalPane(page, proposal),
+		`${proposal.label} proposal pane should be visible in normal sessions`,
+	).toBeVisible({ timeout: 5_000 });
+	await expectSlotField(page, proposal);
+}
+
+async function expectProposalToolCard(page: Page, proposal: ProposalCase): Promise<Locator> {
+	await expect(page.getByText(proposal.toolCardLabel).first()).toBeVisible({ timeout: 15_000 });
+	const openButton = page.locator('[data-testid="proposal-open-button"]').last();
+	await expect(openButton).toBeVisible({ timeout: 15_000 });
+	await expect(openButton).toHaveText(/Open proposal/);
+	return openButton;
+}
+
+async function switchToMobileChatAndBack(page: Page, proposal: ProposalCase): Promise<void> {
+	await page.setViewportSize({ width: 390, height: 800 });
+	await expectProposalTabAndPane(page, proposal);
+
+	const firstTab = page.locator(".goal-tab-bar button.goal-tab-pill").first();
+	await expect(firstTab, "Chat tab should be first on the mobile unified panel").toHaveAttribute("title", "Chat", { timeout: 5_000 });
+	const chat = chatTab(page);
+	await expect(chat).toBeVisible({ timeout: 5_000 });
+	await chat.click();
+	await expect(chat).toHaveClass(/goal-tab-pill--active/);
+	await expect(page.locator("textarea").first()).toBeVisible({ timeout: 5_000 });
+
+	await proposalTab(page, proposal).click();
+	await expect(proposalTab(page, proposal)).toHaveClass(/goal-tab-pill--active/);
+	await expect(proposalPane(page, proposal)).toBeVisible({ timeout: 5_000 });
+	await expectSlotField(page, proposal);
+}
+
+async function reloadAndOpenProposal(page: Page, proposal: ProposalCase, sessionId: string): Promise<void> {
+	await page.reload();
+	await page.waitForFunction(
+		(sid) => {
+			const state = (window as any).bobbitState ?? (window as any).__bobbitState;
+			return state?.selectedSessionId === sid && state?.connectionStatus === "connected";
+		},
+		sessionId,
+		{ timeout: 20_000 },
+	);
+	await waitForProposalSlot(page, proposal.type);
+
+	await expect(chatTab(page)).toBeVisible({ timeout: 5_000 });
+	await chatTab(page).click();
+	const openButton = await expectProposalToolCard(page, proposal);
+	await openButton.scrollIntoViewIfNeeded();
+	await openButton.click();
+	await expectProposalTabAndPane(page, proposal);
+}
+
+async function dismissProposal(page: Page, proposal: ProposalCase, sessionId: string): Promise<void> {
+	const beforeOtherSlots = await otherProposalSlots(page, proposal.type);
+	const panel = proposalPane(page, proposal);
+	await expect(panel).toBeVisible({ timeout: 5_000 });
+	const dismiss = panel.getByRole("button", { name: "Dismiss" }).first();
+	await expect(
+		dismiss,
+		`${proposal.label} proposal pane should expose a Dismiss action in normal sessions`,
+	).toBeVisible({ timeout: 5_000 });
+	await dismiss.click();
+
+	await waitForProposalSlotAbsent(page, proposal.type);
+	await expect(proposalTab(page, proposal)).toHaveCount(0, { timeout: 5_000 });
+	await expect.poll(() => selectedSessionId(page), { timeout: 5_000 }).toBe(sessionId);
+	await expect(page.locator("textarea").first()).toBeVisible({ timeout: 5_000 });
+	expect(await otherProposalSlots(page, proposal.type)).toEqual(beforeOtherSlots);
+}
+
+async function staffByName(name: string): Promise<any[]> {
+	const res = await apiFetch("/api/staff");
+	expect(res.ok, "GET /api/staff should succeed").toBe(true);
+	const body = await res.json();
+	const staff = Array.isArray(body) ? body : (body.staff ?? []);
+	return staff.filter((entry: any) => entry?.name === name);
+}
+
+async function deleteStaffByName(name: string): Promise<void> {
+	for (const staff of await staffByName(name)) {
+		await apiFetch(`/api/staff/${staff.id}`, { method: "DELETE" }).catch(() => {});
+	}
+}
+
 test.describe("Proposal tabs open all proposal types in normal sessions", () => {
-	test.describe.configure({ timeout: 75_000 });
+	test.describe.configure({ timeout: 90_000 });
 
 	for (const proposal of CASES) {
-		test(`${proposal.label} proposal card opens a ${proposal.label} tab`, async ({ page }) => {
+		test(`${proposal.label} proposal is openable, rehydrates, and dismisses from a normal session`, async ({ page }) => {
+			await openApp(page);
+			await createSessionViaUI(page);
+			await expectNormalChatSession(page);
+			const sessionId = await activeSessionId(page);
+
+			await sendMessage(page, proposal.trigger);
+			const openButton = await expectProposalToolCard(page, proposal);
+			await waitForProposalSlot(page, proposal.type);
+			await expectSlotField(page, proposal);
+
+			await openButton.click();
+			await expectProposalTabAndPane(page, proposal);
+			await switchToMobileChatAndBack(page, proposal);
+			await reloadAndOpenProposal(page, proposal, sessionId);
+			await dismissProposal(page, proposal, sessionId);
+		});
+	}
+
+	test("Staff proposal accept creates a staff agent from a normal session", async ({ page }) => {
+		await deleteStaffByName(STAFF_ACCEPT_NAME);
+		try {
+			const proposal = CASES.find((c) => c.type === "staff")!;
 			await openApp(page);
 			await createSessionViaUI(page);
 			await expectNormalChatSession(page);
 
 			await sendMessage(page, proposal.trigger);
-			await expect(page.getByText(proposal.toolCardLabel).first()).toBeVisible({ timeout: 15_000 });
-			await waitForProposalSlot(page, proposal.type);
-
-			const openButton = page.locator('[data-testid="proposal-open-button"]').first();
-			await expect(openButton).toBeVisible({ timeout: 15_000 });
+			const openButton = await expectProposalToolCard(page, proposal);
+			await waitForProposalSlot(page, "staff");
 			await openButton.click();
+			await expectProposalTabAndPane(page, proposal);
 
-			const tab = page
-				.locator("button.goal-tab-pill")
-				.filter({ hasText: new RegExp(`^${proposal.label}\\b`) })
-				.first();
-			await expect(
-				tab,
-				`${proposal.label} proposal tab should be visible in normal sessions`,
-			).toBeVisible({ timeout: 5_000 });
+			const panel = proposalPane(page, proposal);
+			const createButton = panel.getByRole("button", { name: /Create Staff/ }).first();
+			await expect(createButton).toBeEnabled({ timeout: 5_000 });
+			await createButton.click();
 
-			await tab.click();
-			await expect(
-				page.locator(`[data-panel="${proposal.panel}"]`).first(),
-				`${proposal.label} proposal pane should be visible in normal sessions`,
-			).toBeVisible({ timeout: 5_000 });
-		});
-	}
+			await expect
+				.poll(async () => (await staffByName(STAFF_ACCEPT_NAME)).length, { timeout: 20_000 })
+				.toBeGreaterThan(0);
+		} finally {
+			await deleteStaffByName(STAFF_ACCEPT_NAME);
+		}
+	});
 });

--- a/tests/e2e/ui/proposal-open-all-types.spec.ts
+++ b/tests/e2e/ui/proposal-open-all-types.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * Reproducing coverage for proposal-tab routing in normal chat sessions.
+ *
+ * Role/tool/staff proposals already reach state.activeProposals and render an
+ * Open proposal action in the transcript. Normal sessions must also surface a
+ * visible proposal tab and pane for each type.
+ */
+import { test, expect } from "../gateway-harness.js";
+import type { Page } from "@playwright/test";
+import { openApp, createSessionViaUI, sendMessage } from "./ui-helpers.js";
+
+type ProposalType = "role" | "tool" | "staff";
+
+interface ProposalCase {
+	type: ProposalType;
+	label: "Role" | "Tool" | "Staff";
+	trigger: string;
+	toolCardLabel: string;
+	panel: string;
+}
+
+const CASES: ProposalCase[] = [
+	{
+		type: "role",
+		label: "Role",
+		trigger: "ROLE_PROPOSAL_PARITY",
+		toolCardLabel: "Role Proposal",
+		panel: "role-proposal",
+	},
+	{
+		type: "tool",
+		label: "Tool",
+		trigger: "TOOL_PROPOSAL_PARITY",
+		toolCardLabel: "Tool Proposal",
+		panel: "tool-proposal",
+	},
+	{
+		type: "staff",
+		label: "Staff",
+		trigger: "STAFF_PROPOSAL_PARITY",
+		toolCardLabel: "Staff Proposal",
+		panel: "staff-proposal",
+	},
+];
+
+async function waitForProposalSlot(page: Page, type: ProposalType): Promise<void> {
+	await page.waitForFunction(
+		(t) => {
+			const state = (window as any).bobbitState ?? (window as any).__bobbitState;
+			const fields = state?.activeProposals?.[t]?.fields;
+			return fields && typeof fields === "object" && Object.keys(fields).length > 0;
+		},
+		type,
+		{ timeout: 15_000 },
+	);
+}
+
+async function expectNormalChatSession(page: Page): Promise<void> {
+	const assistantType = await page.evaluate(() => {
+		const state = (window as any).bobbitState ?? (window as any).__bobbitState;
+		return state?.assistantType ?? null;
+	});
+	expect(assistantType, "test must use a normal chat session, not an assistant session").toBeFalsy();
+}
+
+test.describe("Proposal tabs open all proposal types in normal sessions", () => {
+	test.describe.configure({ timeout: 75_000 });
+
+	for (const proposal of CASES) {
+		test(`${proposal.label} proposal card opens a ${proposal.label} tab`, async ({ page }) => {
+			await openApp(page);
+			await createSessionViaUI(page);
+			await expectNormalChatSession(page);
+
+			await sendMessage(page, proposal.trigger);
+			await expect(page.getByText(proposal.toolCardLabel).first()).toBeVisible({ timeout: 15_000 });
+			await waitForProposalSlot(page, proposal.type);
+
+			const openButton = page.locator('[data-testid="proposal-open-button"]').first();
+			await expect(openButton).toBeVisible({ timeout: 15_000 });
+			await openButton.click();
+
+			const tab = page
+				.locator("button.goal-tab-pill")
+				.filter({ hasText: new RegExp(`^${proposal.label}\\b`) })
+				.first();
+			await expect(
+				tab,
+				`${proposal.label} proposal tab should be visible in normal sessions`,
+			).toBeVisible({ timeout: 5_000 });
+
+			await tab.click();
+			await expect(
+				page.locator(`[data-panel="${proposal.panel}"]`).first(),
+				`${proposal.label} proposal pane should be visible in normal sessions`,
+			).toBeVisible({ timeout: 5_000 });
+		});
+	}
+});

--- a/tests/e2e/ui/proposal-open-all-types.spec.ts
+++ b/tests/e2e/ui/proposal-open-all-types.spec.ts
@@ -260,7 +260,10 @@ test.describe("Proposal tabs open all proposal types in normal sessions", () => 
 	test.describe.configure({ timeout: 90_000 });
 
 	for (const proposal of CASES) {
-		test(`${proposal.label} proposal is openable, rehydrates, and dismisses from a normal session`, async ({ page }) => {
+		const title = proposal.type === "staff"
+			? "Staff proposal card opens a Staff tab, rehydrates, and dismisses from a normal session"
+			: `${proposal.label} proposal is openable, rehydrates, and dismisses from a normal session`;
+		test(title, async ({ page }) => {
 			await openApp(page);
 			await createSessionViaUI(page);
 			await expectNormalChatSession(page);

--- a/tests/e2e/ui/proposal-open-all-types.spec.ts
+++ b/tests/e2e/ui/proposal-open-all-types.spec.ts
@@ -5,7 +5,7 @@
  * tab/pane for every active proposal slot, not just goal/project.
  */
 import { test, expect } from "../gateway-harness.js";
-import { apiFetch } from "../e2e-setup.js";
+import { apiFetch, gitCwd } from "../e2e-setup.js";
 import type { Locator, Page } from "@playwright/test";
 import { openApp, createSessionViaUI, sendMessage } from "./ui-helpers.js";
 
@@ -228,7 +228,7 @@ async function dismissProposal(page: Page, proposal: ProposalCase, sessionId: st
 	const beforeOtherSlots = await otherProposalSlots(page, proposal.type);
 	const panel = proposalPane(page, proposal);
 	await expect(panel).toBeVisible({ timeout: 5_000 });
-	const dismiss = panel.getByRole("button", { name: "Dismiss" }).first();
+	const dismiss = panel.getByRole("button", { name: /^Dismiss$/ }).first();
 	await expect(
 		dismiss,
 		`${proposal.label} proposal pane should expose a Dismiss action in normal sessions`,
@@ -294,6 +294,7 @@ test.describe("Proposal tabs open all proposal types in normal sessions", () => 
 			await expectProposalTabAndPane(page, proposal);
 
 			const panel = proposalPane(page, proposal);
+			await panel.locator('input[type="text"]').nth(1).fill(gitCwd());
 			const createButton = panel.getByRole("button", { name: /Create Staff/ }).first();
 			await expect(createButton).toBeEnabled({ timeout: 5_000 });
 			await createButton.click();


### PR DESCRIPTION
## Summary
- Route all proposal types through the unified proposal tab system for normal sessions
- Reuse role/tool/staff proposal panels outside assistant sessions and preserve assistant UX
- Add browser E2E coverage for open/reload/dismiss and staff accept flows
- Document generic proposal routing and rehydration behavior

## Validation
- npm run check
- npm run test:unit
- npm run test:e2e
- Targeted proposal-open-all-types and transcript-fidelity specs

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)