### PR TITLE
Project Drag Reorder

### DIFF
--- a/docs/design/project-drag-reorder-research.md
+++ b/docs/design/project-drag-reorder-research.md
@@ -1,0 +1,185 @@
+# Project Drag Reorder — design research
+
+## Current shape
+
+- Server registry is `src/server/agent/project-registry.ts`.
+  - `RegisteredProject` has `id`, `name`, `rootPath`, `createdAt`, colors, `provisional?`, `hidden?`.
+  - `ProjectRegistry.list()` is the source of project order and currently sorts by `createdAt` ascending.
+  - `save()` writes `JSON.stringify(this.list())` to `<bobbit state>/projects.json`.
+  - `register()`, `registerProvisional()`, `registerSystemProject()`, `remove()`, `removeProvisional()` are the mutation points that must preserve ordering invariants.
+- Project REST routes live in `src/server/server.ts` under `// Project CRUD`.
+  - `GET /api/projects` returns `projectRegistry.list().filter(p => !p.hidden)`.
+  - `POST /api/projects` creates visible projects via `projectRegistry.register()`.
+  - `DELETE /api/projects/:id` removes visible or provisional projects; hidden `system` stays hidden from `GET`.
+- Client project list type/state lives in `src/app/state.ts`.
+  - `Project` mirrors server fields.
+  - `setProjects(projects)` preserves `activeProjectId` when possible.
+  - `getSidebarData()` exposes `projects: state.projects`; sidebar order follows this array.
+- Client project fetch/update helpers live in `src/app/api.ts`.
+  - `fetchProjects()` calls `GET /api/projects` and returns either `data.projects` or a raw array.
+  - Project changes are not polled after initial `refreshSessions()` except local add/remove paths that explicitly call `fetchProjects()`.
+- Desktop sidebar project rendering is in `src/app/sidebar.ts`.
+  - `renderProjectHeader(project, expanded)` renders chevron, folder, title, settings, new-goal.
+  - `renderSidebar()` builds a `projectMap`, then renders `state.projects.map(...)`.
+  - `renderCollapsedSidebar()` also iterates `state.projects.map(...)`; this already preserves whatever order `state.projects` has.
+- Mobile project rendering is in `src/app/render.ts::renderMobileLanding()`.
+  - It builds a `projectMap`, then renders `state.projects.map(...)` with an inline project header.
+- Relevant existing docs/tests:
+  - `docs/rest-api.md` documents project routes and should get the new reorder route.
+  - `docs/sidebar-keyboard-navigation.md` says DOM order is the sidebar navigation source of truth; reordering project DOM rows will automatically affect keyboard traversal.
+  - Registry tests are currently in `tests/multi-project.test.ts` and `tests/project-registry-symlink.test.ts`.
+  - Project API/UI patterns are in `tests/e2e/project-delete-last.spec.ts`, `tests/e2e/project-bugs.spec.ts`, `tests/e2e/ui/project-management.spec.ts`, `tests/e2e/ui/single-project-sidebar.spec.ts`, `tests/e2e/ui/remove-first-project.spec.ts`.
+
+## Proposed data model and migration
+
+Add an explicit visible-project position to the registry record:
+
+```ts
+// src/server/agent/project-registry.ts
+export interface RegisteredProject {
+  // existing fields...
+  position?: number; // visible project ordering, lower first; absent on legacy/hidden records
+}
+```
+
+Migration belongs in `ProjectRegistry.load()` via a private normalizer:
+
+- Add `private normalizeVisiblePositions(): boolean`.
+- Consider only `!p.hidden` projects.
+- Stable order for legacy records:
+  1. finite numeric `position`, if present;
+  2. `createdAt` ascending;
+  3. original on-disk array index as a tie-breaker.
+- Rewrite visible project positions to contiguous `0..n-1` when any position is missing, duplicated, non-finite, or non-contiguous.
+- Do not assign or validate positions for `hidden` projects; they remain hidden and unaffected.
+- If normalization changed visible records, `load()` should `save()` once after reading.
+
+Mutation invariants:
+
+- `ProjectRegistry.list()` sorts visible projects by `position` first, with `createdAt` fallback for unmigrated in-memory data; hidden projects can retain created-at ordering because UI filters them out.
+- `register()` and `registerProvisional()` set `position = max(visible.position) + 1`, so new visible projects append to the current custom order.
+- `registerSystemProject()` should not set `position` because `hidden: true` projects are not part of user order.
+- `remove()` and `removeProvisional()` should delete the record, then normalize remaining visible positions before `save()`; this preserves relative order and removes gaps.
+- Add `ProjectRegistry.setVisibleOrder(projectIds: string[]): RegisteredProject[]` to validate and persist a full visible order.
+
+## API contract
+
+Add the route before the existing `const projectGetMatch = url.pathname.match(/^\/api\/projects\/([^/]+)$/)` block so `order` is not treated as a project id.
+
+```http
+PUT /api/projects/order
+Content-Type: application/json
+
+{ "projectIds": ["id-c", "id-a", "id-b"] }
+```
+
+Success:
+
+```json
+{ "projects": [/* visible non-hidden projects in saved order */] }
+```
+
+Validation in `ProjectRegistry.setVisibleOrder()` or the route:
+
+- `projectIds` must be an array of strings.
+- IDs must be unique.
+- Every provided ID must exist.
+- No provided ID may reference `hidden: true` or `SYSTEM_PROJECT_ID`.
+- The provided set must exactly equal the current visible non-hidden project ID set.
+  - Missing visible IDs or stale extra IDs should fail without mutating order.
+- Recommended responses:
+  - `400 { error, code: "invalid_project_order" }` for malformed, duplicate, unknown, or hidden IDs.
+  - `409 { error, code: "stale_project_order", expectedProjectIds, receivedProjectIds }` when the visible project set changed since the client built its order.
+
+After a successful save:
+
+- Return the visible projects in new order.
+- Broadcast `broadcastToAll({ type: "projects_changed", projects })` so already-connected browsers can update without reload.
+- Update `docs/rest-api.md` Projects table with `PUT /api/projects/order`.
+
+Client helper:
+
+```ts
+// src/app/api.ts
+export async function saveProjectOrder(projectIds: string[]): Promise<Project[] | null>
+```
+
+It should `PUT /api/projects/order`, return `body.projects || body || []`, and surface errors through the existing connection-error dialog path.
+
+For cross-tab/browser freshness, also change `refreshSessions()` in `src/app/api.ts` to refresh projects on every poll or handle the `projects_changed` WS event in `src/app/remote-agent.ts` plus `src/app/session-manager.ts`. Polling projects is simplest and covers landing pages that have no active session WebSocket; compare IDs/positions before calling `setProjects()` to avoid unnecessary renders.
+
+## UI data flow
+
+Shared state should stay client-only and transient; do not persist expansion changes while dragging.
+
+Recommended helpers in `src/app/sidebar.ts` exported for mobile reuse:
+
+- `isProjectReordering(): boolean`
+- `projectOrderForRender(): Project[]`
+- `startProjectReorder(e: PointerEvent, projectId: string): void`
+- `handleProjectReorderMove(e: PointerEvent): void`
+- `finishProjectReorder(cancel?: boolean): Promise<void>`
+- `renderProjectReorderHandle(project: Project)`
+
+Implementation shape:
+
+- Add module-level reorder state:
+  - `activeId`, `pointerId`, `startProjectIds`, `visualProjectIds`, `dropIndex`, `suppressNextClick`.
+- The grab handle is the only drag start target.
+  - It sits between the chevron and folder icon in `renderProjectHeader()` and the mobile inline header.
+  - It calls `preventDefault()` and `stopPropagation()` on `pointerdown` and `click`, so dragging never toggles expansion.
+  - Existing settings/new-goal buttons keep their `stopPropagation()` and never start drag.
+- Use pointer events, not HTML5 drag-only APIs, so desktop mouse and mobile touch share the path.
+  - Set `touch-action: none` on the handle.
+  - Track movement with document-level `pointermove`/`pointerup`/`pointercancel` listeners after start.
+  - Hit-test rows with `[data-project-reorder-id]` and row midpoint Y to compute target index.
+- Temporary collapse:
+  - During reorder, render project rows header-only by using `effectiveExpanded = isProjectReordering() ? false : isProjectExpanded(project.id)`.
+  - Do not call `toggleProjectExpanded()` and do not write `bobbit-expanded-projects` during drag.
+  - On drop/cancel, clear transient reorder state; the next render restores the previous persisted expansion state.
+- Visual order:
+  - While dragging, render `projectOrderForRender()` instead of raw `state.projects` in `renderSidebar()` and `renderMobileLanding()`.
+  - On pointer movement, update `visualProjectIds` and `renderApp()`.
+  - On drop, optimistically `setProjects(reorderedProjects)`, call `saveProjectOrder(visualProjectIds)`, then replace with server-returned projects. On failure, re-fetch `fetchProjects()` and restore server order.
+- Desktop visibility:
+  - Add CSS in `src/app/app.css` for `.project-reorder-handle` hidden by default and visible on `.group:hover`, `.group:focus-within`, and `[data-project-reordering="true"]`.
+- Mobile visibility:
+  - Under `@media (max-width: 767px)`, keep `.project-reorder-handle` always visible and use at least a 32px touch target.
+- Collapsed sidebar:
+  - No drag affordance needed. `renderCollapsedSidebar()` already uses `state.projects.map(...)`, so persisted order is enough.
+
+Suggested test selectors:
+
+- `data-testid="project-header" data-project-id=${project.id}` on each header.
+- `data-testid="project-reorder-handle" data-project-id=${project.id}` on each handle.
+- `data-project-reorder-id=${project.id}` on the row wrapper used for hit-testing.
+- `data-project-reordering="true"` on the sidebar/mobile root while transient reorder mode is active.
+
+## Test targets
+
+Unit:
+
+- `tests/multi-project.test.ts` or new `tests/project-registry-order.test.ts`:
+  - legacy `projects.json` without `position` migrates in existing created-at/on-disk order;
+  - `list()` respects custom positions over `createdAt`;
+  - `setVisibleOrder()` persists and reloads;
+  - `register()` and `registerProvisional()` append after a custom order;
+  - `remove()` preserves remaining relative order and does not leave corrupt positions;
+  - `registerSystemProject()` remains hidden and excluded from visible order validation.
+
+API E2E:
+
+- New `tests/e2e/project-reorder-api.spec.ts`:
+  - create A/B/C, `PUT /api/projects/order` to C/A/B, then `GET /api/projects` returns C/A/B;
+  - reload/restart harness still returns persisted order;
+  - duplicate, unknown, hidden/system, missing visible, extra/stale IDs fail and leave order unchanged;
+  - deleting a project after reorder keeps remaining order;
+  - creating a new project after reorder appends at the end.
+
+Browser E2E:
+
+- New `tests/e2e/ui/project-drag-reorder.spec.ts`:
+  - desktop: handle hidden until project header hover/focus; dragging handle reorders; project contents collapse while dragging and restore after drop/cancel; reload persists;
+  - desktop: clicking header outside handle still toggles expansion; clicking settings/new-goal does not initiate reorder;
+  - collapsed desktop sidebar shows projects in persisted order and no reorder handle;
+  - mobile viewport: handle always visible; touch/pointer drag reorders; temporary collapse/restore and reload persistence match desktop.

--- a/docs/design/project-drag-reorder-ux.md
+++ b/docs/design/project-drag-reorder-ux.md
@@ -1,0 +1,107 @@
+# Project drag reorder UX
+
+Design guidance for reordering project sections in the expanded desktop sidebar and mobile sidebar.
+
+## Core behavior
+
+- Project order is a global preference: every visible, non-hidden project appears in the persisted order across reloads and browser sessions.
+- Reordering is available only from expanded sidebar surfaces: desktop expanded sidebar and mobile sidebar. The collapsed icon-only sidebar follows the saved order but has no drag affordance.
+- Dragging is scoped to project headers only. Settings, new-goal, staff/session controls, and project content rows must never start a project drag.
+- Clicking/tapping the project header outside the grab handle keeps the current expand/collapse behavior.
+
+## Header anatomy
+
+Project header order:
+
+1. Expand/collapse chevron.
+2. Reorder grab handle.
+3. Project folder icon.
+4. Project name and status badge, if present.
+5. Header actions such as settings and new goal.
+
+Use a six-dot or grip icon for the handle. Keep it visually lighter than the project name so it reads as an affordance, not content.
+
+## Handle visibility
+
+### Desktop
+
+- Default: handle space is reserved but the icon is visually hidden to preserve sidebar calm and density.
+- Header hover, handle hover, keyboard focus within the header, or active reorder mode: show the handle.
+- Focused handle must have a visible focus ring and not rely on hover.
+- When the handle is visible, it should not shift the folder icon or project text.
+
+### Mobile/touch
+
+- Handle is always visible because hover does not exist and the feature must be discoverable.
+- Minimum touch target: 44px high by 36-44px wide, while preserving the current row rhythm.
+- Touch interaction begins only from the handle. The rest of the header remains a normal expand/collapse target.
+
+## Interaction states
+
+| State | Visual treatment | Behavior |
+|---|---|---|
+| Default | Normal project row; desktop handle hidden, mobile handle visible. | Header click toggles expansion. |
+| Hover | Desktop row background matches existing sidebar hover; handle fades in. | No reorder until the handle is dragged. |
+| Focus | Focus ring on handle; row may show subtle active background. | Keyboard reorder controls become available. |
+| Pressed | Handle shows active background and `grabbing` cursor. | Prevent project toggle. |
+| Dragging | Dragged row becomes a raised ghost; original slot is reserved or dimmed. | Pointer controls candidate position. |
+| Drop target | Thin insertion line between project headers; target row may nudge by 2-4px. | Shows exactly where the project will land. |
+| Saving | Optional small muted spinner or "Saving order…" live status. | Keep local order optimistic. |
+| Error | Revert to last server-confirmed order; show compact toast/banner. | Do not leave reorder mode stuck. |
+
+## Transient reorder mode
+
+- Enter reorder mode automatically once a pointer drag starts from a handle after a small movement threshold.
+- Reorder mode is temporary and exits on drop, cancel, route change, or lost pointer capture.
+- While active:
+  - Show every project as a header-only row, regardless of current expansion.
+  - Hide project body content visually only; do not mutate persisted expansion state or localStorage.
+  - Keep header actions visible but inert for drag start; users should not accidentally open settings or create goals mid-drag.
+  - Keep the project list in one continuous vertical stack with separators reduced or hidden so drop targets are clear.
+
+## Temporary visual collapse and restore
+
+- Before entering reorder mode, snapshot each project's expanded/collapsed state.
+- During reorder mode, render all project contents as collapsed for visual clarity.
+- On successful drop, restore the exact snapshot immediately after applying the new project order.
+- On cancel or failed save, restore both the prior order and the prior expansion snapshot.
+- Never call the normal project toggle path as part of drag start, drag move, drop, or cancel.
+
+## Drag, drop, and cancel semantics
+
+- Drag starts only from the grab handle, not the whole header.
+- Use pointer capture so drag remains stable if the pointer leaves the narrow sidebar.
+- A click/tap on the handle without meaningful movement should do nothing except focus the handle.
+- Reorder by insertion position, not by swapping rows. The preview should answer: "drop before/after this project".
+- Dropping outside the project list cancels and restores the previous order.
+- Pressing Escape cancels and restores the previous order.
+- Unknown, hidden, or stale project IDs should be ignored by the client UI and rejected gracefully by the server; the user should see the last valid order.
+- New visible projects append to the end of the saved order. Removed projects disappear without leaving gaps or corrupting the saved order.
+
+## Mobile touch details
+
+- Use Pointer Events rather than HTML5 drag-and-drop so touch, stylus, and mouse share behavior.
+- Apply `touch-action: none` only on the handle; the rest of the sidebar must keep normal vertical scrolling.
+- While dragging near the top or bottom of the mobile list, auto-scroll slowly after a short dwell.
+- Keep the dragged row under the finger with a slight horizontal offset so the insertion line remains visible.
+- Do not require long-press. The visible handle is the explicit permission to drag.
+
+## Accessibility cues
+
+- Render the handle as a focusable button with an accessible name such as `Reorder <project name>`.
+- Provide keyboard reorder parity:
+  - Space or Enter lifts the focused project.
+  - Arrow Up/Down moves the project one position while lifted.
+  - Space or Enter drops.
+  - Escape cancels.
+- Announce state changes through a polite live region: "Picked up Bobbit", "Moved before Sandbox", "Dropped Bobbit at position 2 of 4", or "Reorder cancelled".
+- Use visible focus rings and non-color cues for drop targets; the insertion line should have shape/spacing, not color alone.
+- Respect reduced motion by disabling row lift/nudge animation while keeping the insertion line.
+- Ensure the handle remains reachable in sidebar keyboard navigation order without trapping focus.
+
+## Implementation notes for visual polish
+
+- Use existing sidebar tokens and patterns: `var(--sidebar)`, `var(--secondary)`, `var(--muted-foreground)`, `var(--border)`, project accent color, and current rounded row styling.
+- Prefer short transitions: 120-160ms opacity for handle reveal, 80-120ms transform for row nudge. Avoid springy motion in the dense sidebar.
+- Preserve scroll position when entering and exiting reorder mode.
+- If search/filtering is active, reorder only among the currently visible non-hidden project headers but persist a complete order that keeps non-visible projects in their relative positions.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -241,13 +241,64 @@ For the user-facing model (lifecycle, immutable sandbox mode, legacy records) se
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/api/projects` | List all registered projects. |
+| `GET` | `/api/projects` | List visible registered projects in persisted project order. Hidden projects, including the synthetic `system` project, are excluded. |
 | `POST` | `/api/projects` | Register a project (`{ name, rootPath, color?, upsert?, acceptCanonical? }`). With `upsert: true`, returns the existing project if one already exists at `rootPath`. When `rootPath` is a symlink, returns 400 `{ error, code: "symlink_root", rootPath, canonical }` unless `acceptCanonical: true` is set — the caller should prompt the user with both paths and re-submit with `acceptCanonical: true` to register the canonical path (see [internals.md — Symlinked project rootPath handling](internals.md#symlinked-project-rootpath-handling)). Also returns 400 `{ error, code: "preflight_failed", report }` when the server-side pre-flight surfaces any `fail` check (see [add-project-preflight.md](add-project-preflight.md)). |
+| `PUT` | `/api/projects/order` | Persist the full visible project ID order for sidebar project drag reorder. Returns `{ projects }` in the saved order and broadcasts `projects_changed`. See [Project order](#project-order). |
 | `GET` | `/api/projects/preflight?path=<absolute>` | Run the [pre-flight validation pass](add-project-preflight.md) for a candidate `rootPath`. Always 200 with a `PreflightReport` when `path` is supplied — failures are the response, not an error. 400 only when `path` is missing. |
 | `POST` | `/api/projects/archive-bobbit` | Move existing `<rootPath>/.bobbit/` contents aside into `<rootPath>/.bobbit-archive-NNN/`, preserving `GATEWAY_OWNED_FILES` when the path is gateway-owned. Body: `{ rootPath }`. Does not mutate the registry. Returns 200 with `ArchiveResult`, 400 for bad input (`code: "bad-path"`), or 409 when `.bobbit/` is missing/empty (`code: "no-bobbit-dir"` / `"empty-bobbit-dir"`). See [add-project-preflight.md](add-project-preflight.md). |
 | `GET` | `/api/projects/:id` | Get a single project. |
 | `PUT` | `/api/projects/:id` | Update name/color. |
 | `DELETE` | `/api/projects/:id` | Unregister (does not delete files on disk). Any project may be removed, including the last visible one — when zero non-hidden projects remain, the UI falls back to the existing zero-project first-run state. The hidden "system" project is unaffected by this flow. |
+
+#### Project order
+
+`GET /api/projects` returns only visible, non-system projects in the server-persisted order. Use the returned array order as the source of truth for sidebar grouping; visible project records may include a `position` field, but clients should not need to sort by it.
+
+`PUT /api/projects/order` saves a new global order for visible projects:
+
+```http
+PUT /api/projects/order
+Content-Type: application/json
+
+{ "projectIds": ["project-c", "project-a", "project-b"] }
+```
+
+`projectIds` must be the complete current list of visible, non-system project IDs in the requested order. On success, the server stores contiguous positions, returns the visible projects in saved order, and broadcasts `projects_changed` with the same ordered `projects` array so connected clients can sync without a reload.
+
+Project objects include the normal project fields; this example is truncated to the fields relevant to ordering:
+
+```json
+{
+  "projects": [
+    { "id": "project-c", "name": "Gamma", "rootPath": "/repo/gamma", "position": 0 },
+    { "id": "project-a", "name": "Alpha", "rootPath": "/repo/alpha", "position": 1 },
+    { "id": "project-b", "name": "Beta", "rootPath": "/repo/beta", "position": 2 }
+  ]
+}
+```
+
+Invalid requests return `400` and do not mutate the registry:
+
+```json
+{ "error": "projectIds must be an array of strings", "code": "invalid_project_order" }
+```
+
+`invalid_project_order` covers malformed bodies, non-string IDs, duplicate IDs, unknown IDs, hidden project IDs, and the synthetic `system` project ID. Hidden/system projects do not participate in ordering and are never returned by `GET /api/projects`.
+
+Stale complete-order mismatches return `409` and do not mutate the registry:
+
+```json
+{
+  "error": "Project order is stale",
+  "code": "stale_project_order",
+  "expectedProjectIds": ["project-a", "project-b", "project-c"],
+  "receivedProjectIds": ["project-a", "project-b"]
+}
+```
+
+A stale error means the submitted IDs were otherwise valid visible projects, but the submitted set no longer exactly matched the server's visible project set. The usual client recovery is to re-fetch `GET /api/projects`, apply the returned order, and let the user retry.
+
+For the user-facing sidebar behavior, see [Sidebar project drag reorder](sidebar-project-reorder.md).
 
 ### Project resolution contract
 

--- a/docs/sidebar-project-reorder.md
+++ b/docs/sidebar-project-reorder.md
@@ -1,0 +1,92 @@
+# Sidebar project drag reorder
+
+Project drag reorder lets users choose the order of project sections in the sidebar. The order is server-side project registry state, not per-browser UI state, so the same order appears after reloads and in other connected browser sessions.
+
+This feature sits between the project registry/API and the sidebar render paths:
+
+- The server stores visible-project order as contiguous project positions.
+- `GET /api/projects` returns visible projects in that persisted order.
+- The desktop sidebar and mobile landing page render projects in `state.projects` order.
+- `PUT /api/projects/order` saves a complete visible-project order and broadcasts `projects_changed` so other clients can update without a reload.
+
+See [REST API — Projects](rest-api.md#projects) for the wire contract.
+
+## User model
+
+### Where the handle appears
+
+Project headers are ordered as:
+
+1. expand/collapse chevron;
+2. reorder grab handle;
+3. folder icon;
+4. project name/status;
+5. project actions such as settings and new goal.
+
+Desktop keeps the normal sidebar density by reserving the handle slot but hiding the icon until the project header is hovered, the header has focus within it, the handle itself is focused, or a reorder is active.
+
+Mobile and other non-hover inputs always show the handle with a larger touch target so the affordance is discoverable.
+
+The collapsed desktop sidebar does not render reorder handles, but it still follows the persisted project order when grouping visible items.
+
+### Pointer and touch drag
+
+Dragging starts only from the project reorder handle. The header itself still toggles expansion, and project action buttons stop propagation so settings/new-goal clicks do not begin a drag.
+
+On pointer movement past the drag threshold, Bobbit enters transient reorder mode:
+
+- all project sections collapse visually to header-only rows;
+- the active row is highlighted;
+- pointer position against row midpoints determines the insertion point;
+- dropping inside the project list saves the new order;
+- dropping before a real drag starts, dropping outside the list, pointer cancel, or `Escape` cancels.
+
+The temporary collapse is visual-only. Bobbit does not change the persisted expanded/collapsed project set while reordering, so every project restores to its previous expansion state after drop or cancel.
+
+### Keyboard and announcements
+
+The handle is a focusable button labelled `Reorder <project name>`. Keyboard users can:
+
+- press `Space` or `Enter` to lift the focused project;
+- press `ArrowUp` or `ArrowDown` to move it;
+- press `Space` or `Enter` again to drop;
+- press `Escape` to cancel.
+
+A polite live region announces pickup, moves, drop positions, and cancellation. The active handle also exposes pressed/grabbed state for assistive technology.
+
+## Persistence and sync
+
+The server treats the ordered array returned by `GET /api/projects` as the source of truth. Clients should preserve that array order rather than recomputing from timestamps.
+
+When a reorder completes:
+
+1. the client optimistically applies the reordered project array;
+2. it sends the full visible project ID list to `PUT /api/projects/order`;
+3. on success, it replaces local projects with the server-returned `projects` array;
+4. the server broadcasts `projects_changed` with the same ordered project array;
+5. connected clients apply the broadcast if the project array changed.
+
+The regular session refresh path also fetches projects, so tabs without an active session WebSocket still converge on the saved order.
+
+New visible projects append to the end of the current custom order. Removing a visible project compacts the remaining positions without changing their relative order.
+
+## Validation and edge cases
+
+Only visible, non-system projects participate in user ordering. Hidden projects, including the synthetic `system` project, remain hidden from `GET /api/projects` and must not be sent to the reorder endpoint.
+
+`PUT /api/projects/order` requires a complete, duplicate-free list of the current visible project IDs:
+
+- malformed bodies, non-string IDs, duplicate IDs, unknown IDs, and hidden/system IDs return `400` with `code: "invalid_project_order"`;
+- otherwise valid lists that do not exactly match the current visible project set return `409` with `code: "stale_project_order"` plus the expected and received IDs;
+- failed saves do not mutate the registry.
+
+On save failure, the client shows the connection/error dialog and re-fetches projects. If the refetch returns no projects but there were projects before the drag, the client restores the original local order as a fallback.
+
+## Implementation map
+
+- Server registry: `src/server/agent/project-registry.ts` owns position migration, append/delete compaction, hidden/system exclusion, and `setVisibleOrder()` validation.
+- REST route: `src/server/server.ts` handles `PUT /api/projects/order` before project-id routes, returns structured validation errors, and emits `projects_changed` on success.
+- Client API/state: `src/app/api.ts` saves project order and refreshes projects during the session polling loop; `src/app/state.ts` gates project-array updates through equality checks.
+- Desktop sidebar: `src/app/sidebar.ts` owns shared reorder state, pointer/keyboard handling, live-region rendering, optimistic save/restore, and expanded-sidebar rendering.
+- Mobile landing: `src/app/render.ts` reuses the shared handle and reorder helpers while always showing the touch handle.
+- Styling: `src/app/app.css` contains handle visibility, focus, touch target, active row, and live-region styles.

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -436,6 +436,23 @@ export async function fetchProjects(): Promise<Project[]> {
   }
 }
 
+export async function saveProjectOrder(projectIds: string[]): Promise<Project[] | null> {
+  try {
+    const res = await gatewayFetch("/api/projects/order", {
+      method: "PUT",
+      body: JSON.stringify({ projectIds }),
+    });
+    if (!res.ok) throw await errorFromResponse(res, `Failed: ${res.status}`);
+    const data = await res.json().catch(() => null);
+    return data?.projects || data || [];
+  } catch (err) {
+    const { showConnectionError } = await import("./dialogs.js");
+    const { message, code, stack } = errorDetails(err);
+    showConnectionError("Failed to save project order", message, { code, stack });
+    return null;
+  }
+}
+
 export async function detectProject(dirPath: string): Promise<{
   exists: boolean;
   hasBobbit: boolean;

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -1,7 +1,7 @@
 import {
 	state,
 	renderApp,
-	setProjects,
+	setProjectsIfChanged,
 	expandedGoals,
 	saveExpandedGoals,
 	type GatewaySession,
@@ -107,6 +107,7 @@ export async function refreshSessions(): Promise<void> {
 
 	let sessionsChanged = false;
 	let goalsChanged = false;
+	let projectsChanged = false;
 
 	try {
 		// Build URLs with generation params for conditional fetch
@@ -121,14 +122,15 @@ export async function refreshSessions(): Promise<void> {
 			gatewayFetch(sessionsUrl),
 			gatewayFetch(goalsUrl),
 			// Fetch projects alongside sessions/goals so project grouping is
-			// available on the very first render — prevents sessions briefly
-			// appearing under the wrong project.
-			isInitial ? fetchProjects().catch((): null => null) : Promise.resolve(null),
+			// available on the very first render and landing/mobile pages without
+			// an active session still pick up cross-tab project reorder changes.
+			fetchProjectsSnapshot(),
 		]);
-		// Apply projects before processing sessions so the first renderApp()
-		// already has the correct project list for sidebar grouping.
-		if (projectsResult) {
-			setProjects(projectsResult);
+		// Apply projects before processing sessions so renderApp() already has
+		// the correct project list for sidebar grouping. The equality gate avoids
+		// repainting every 5s polling tick when order/content is unchanged.
+		if (projectsResult !== null) {
+			projectsChanged = setProjectsIfChanged(projectsResult);
 		}
 		// background polling: failures are silent (caller does not show a modal)
 		if (!sessionsRes.ok) throw new Error(`Failed to fetch sessions: ${sessionsRes.status}`);
@@ -236,7 +238,7 @@ export async function refreshSessions(): Promise<void> {
 		}
 	} finally {
 		state.sessionsLoading = false;
-		if (sessionsChanged || goalsChanged || isInitial) {
+		if (sessionsChanged || goalsChanged || projectsChanged || isInitial) {
 			renderApp();
 		}
 	}
@@ -425,15 +427,20 @@ export async function cleanupOrphanedIndexRows(projectId?: string): Promise<numb
 // PROJECT API
 // ============================================================================
 
-export async function fetchProjects(): Promise<Project[]> {
+async function fetchProjectsSnapshot(): Promise<Project[] | null> {
   try {
     const res = await gatewayFetch("/api/projects");
-    if (!res.ok) return [];
+    if (!res.ok) return null;
     const data = await res.json();
-    return data.projects || data || [];
+    if (Array.isArray(data?.projects)) return data.projects;
+    return Array.isArray(data) ? data : [];
   } catch {
-    return [];
+    return null;
   }
+}
+
+export async function fetchProjects(): Promise<Project[]> {
+  return (await fetchProjectsSnapshot()) ?? [];
 }
 
 export async function saveProjectOrder(projectIds: string[]): Promise<Project[] | null> {

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -154,6 +154,106 @@ details.wf-proposal-workflow .wf-proposal-gates {
 }
 
 /* ============================================================================
+ * SIDEBAR — project drag reorder
+ * ============================================================================ */
+.project-header {
+	position: relative;
+}
+
+.project-reorder-handle {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 18px;
+	min-width: 18px;
+	height: 20px;
+	padding: 0;
+	border-radius: 5px;
+	color: var(--muted-foreground, var(--color-muted-foreground));
+	background: transparent;
+	opacity: 0;
+	transform: scale(0.96);
+	cursor: grab;
+	touch-action: none;
+	user-select: none;
+	-webkit-user-select: none;
+	transition: opacity 140ms ease, transform 140ms ease, background-color 120ms ease, color 120ms ease;
+}
+
+.project-reorder-handle svg {
+	width: 12px;
+	height: 12px;
+	pointer-events: none;
+}
+
+.project-header:hover .project-reorder-handle,
+.project-header:focus-within .project-reorder-handle,
+.project-reorder-handle:focus,
+.project-reorder-handle:focus-visible,
+[data-project-reordering="true"] .project-reorder-handle {
+	opacity: 1;
+	transform: scale(1);
+}
+
+.project-reorder-handle:hover,
+.project-reorder-handle:focus-visible {
+	background: var(--secondary, var(--color-secondary));
+	color: var(--foreground, var(--color-foreground));
+	outline: none;
+}
+
+.project-reorder-handle:focus-visible {
+	box-shadow: 0 0 0 2px color-mix(in oklch, var(--primary) 45%, transparent);
+}
+
+.project-reorder-handle:active,
+.project-reorder-handle-active {
+	cursor: grabbing;
+	background: color-mix(in oklch, var(--primary) 16%, transparent);
+	color: var(--foreground, var(--color-foreground));
+}
+
+.project-reorder-active {
+	background: color-mix(in oklch, var(--primary) 12%, var(--sidebar)) !important;
+	outline: 1px solid color-mix(in oklch, var(--primary) 35%, transparent);
+	box-shadow: 0 2px 8px color-mix(in oklch, var(--foreground) 8%, transparent);
+}
+
+[data-project-reordering="true"] .project-reorder-section {
+	margin-block: 1px;
+}
+
+[data-project-reordering="true"] .project-reorder-separator {
+	opacity: 0.35;
+	margin-top: 2px;
+	margin-bottom: 2px;
+}
+
+.project-reorder-live {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+@media (max-width: 767px), (hover: none) {
+	.project-reorder-handle {
+		width: 36px;
+		min-width: 36px;
+		height: 36px;
+		margin-left: -6px;
+		margin-right: -6px;
+		opacity: 1;
+		transform: scale(1);
+	}
+}
+
+/* ============================================================================
  * SIDEBAR — right edge border + glow
  * ============================================================================ */
 .sidebar-edge {

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -1,7 +1,7 @@
 import { getModel } from "@earendil-works/pi-ai";
 import { PROPOSAL_PARSERS } from "./proposal-parsers.js";
 import { isProposalType, type ProposalType } from "./proposal-registry.js";
-import { state, renderApp } from "./state.js";
+import { state, renderApp, setProjectsIfChanged } from "./state.js";
 import { closeReviewWorkspaceTabs, selectReviewWorkspaceTab, selectSensiblePanelWorkspaceTab } from "./preview-panel.js";
 import { showFaviconBadge } from "./favicon-badge.js";
 import { needsHumanAttention } from "./notification-policy.js";
@@ -1537,6 +1537,12 @@ export class RemoteAgent {
 			case "preferences_changed":
 				this._applyPreferences(msg.preferences);
 				break;
+
+			case "projects_changed": {
+				const projects = Array.isArray((msg as any).projects) ? (msg as any).projects : null;
+				if (projects && setProjectsIfChanged(projects)) renderApp();
+				break;
+			}
 
 			case "preview_changed":
 				this.onPreviewChanged?.(msg.sessionId, msg.preview);

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -433,7 +433,7 @@ function renderMobileLanding() {
 										const allStandaloneArchivedAll = state.showArchived ? state.archivedSessions.filter(s => !s.teamGoalId && !s.delegateOf) : [];
 										const filteredStandaloneArchivedAll = filterArchivedSessionsByQuery(allStandaloneArchivedAll, state.searchQuery);
 										const archivedByProject = bucketArchivedByProject(archivedGoals, filteredStandaloneArchivedAll, projectsForRender);
-										return html`${projectsForRender.map((project, i) => {
+										return html`<div data-project-reorder-list>${projectsForRender.map((project, i) => {
 											const data = projectMap.get(project.id) || { goals: [], sessions: [], staff: [] };
 											const expanded = isProjectExpanded(project.id);
 											const effectiveExpanded = isProjectReordering() ? false : expanded;
@@ -526,7 +526,7 @@ function renderMobileLanding() {
 												${state.archivedGoalsHasMore ? html`<button class="text-primary hover:underline text-left py-1" @click=${() => { fetchArchivedGoalsPaginated(50, state.archivedGoalsCursor ?? undefined); }}>Load more archived goals…</button>` : ""}
 												${state.archivedSessionsHasMore ? html`<button class="text-primary hover:underline text-left py-1" @click=${() => { fetchArchivedSessionsPaginated(50, state.archivedSessionsCursor ?? undefined); }}>Load more archived sessions…</button>` : ""}
 											</div>
-										` : ""}`;
+										` : ""}</div>`;
 								})()}
 							`}
 			</div>

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -44,7 +44,7 @@ function isSessionArchived(sessionId: string | null | undefined): boolean {
 }
 import { openGatewayDialog, showQrCodeDialog, showRenameDialog, showGoalDialog, showProjectDialog, showConnectionError } from "./dialogs.js";
 import { startNewGoalFlow } from "./goal-entry.js";
-import { renderSidebar, toggleRolePicker, renderRolePickerDropdown, isProjectExpanded, toggleProjectExpanded, filterStaffByQuery, renderStaffSidebarSection, isProjectReordering, projectOrderForRender, renderProjectReorderHandle } from "./sidebar.js";
+import { renderSidebar, toggleRolePicker, renderRolePickerDropdown, isProjectExpanded, toggleProjectExpanded, filterStaffByQuery, renderStaffSidebarSection, isProjectReordering, projectOrderForRender, renderProjectReorderHandle, renderProjectReorderLiveRegion } from "./sidebar.js";
 import { fetchArchivedGoalsPaginated, fetchArchivedSessionsPaginated } from "./api.js";
 // Register search web components
 import "../ui/components/SearchBox.js";
@@ -311,6 +311,7 @@ function renderMobileLanding() {
 
 	return html`
 		<div class="flex-1 flex flex-col overflow-y-auto sidebar-root" data-project-reordering=${isProjectReordering() ? "true" : "false"}>
+			${renderProjectReorderLiveRegion()}
 			<div class="w-full max-w-xl mx-auto px-2 py-4 pb-16 flex flex-col gap-1">
 				<div class="flex flex-col gap-1 px-1 pb-2 mb-1 border-b border-border/30">
 					${(() => {

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -44,7 +44,7 @@ function isSessionArchived(sessionId: string | null | undefined): boolean {
 }
 import { openGatewayDialog, showQrCodeDialog, showRenameDialog, showGoalDialog, showProjectDialog, showConnectionError } from "./dialogs.js";
 import { startNewGoalFlow } from "./goal-entry.js";
-import { renderSidebar, toggleRolePicker, renderRolePickerDropdown, isProjectExpanded, toggleProjectExpanded, filterStaffByQuery, renderStaffSidebarSection } from "./sidebar.js";
+import { renderSidebar, toggleRolePicker, renderRolePickerDropdown, isProjectExpanded, toggleProjectExpanded, filterStaffByQuery, renderStaffSidebarSection, isProjectReordering, projectOrderForRender, renderProjectReorderHandle } from "./sidebar.js";
 import { fetchArchivedGoalsPaginated, fetchArchivedSessionsPaginated } from "./api.js";
 // Register search web components
 import "../ui/components/SearchBox.js";
@@ -310,7 +310,7 @@ function renderMobileLanding() {
 		passesSidebarFilters(s, s.id === activeSessionId(), bypassFilters));
 
 	return html`
-		<div class="flex-1 flex flex-col overflow-y-auto sidebar-root">
+		<div class="flex-1 flex flex-col overflow-y-auto sidebar-root" data-project-reordering=${isProjectReordering() ? "true" : "false"}>
 			<div class="w-full max-w-xl mx-auto px-2 py-4 pb-16 flex flex-col gap-1">
 				<div class="flex flex-col gap-1 px-1 pb-2 mb-1 border-b border-border/30">
 					${(() => {
@@ -405,8 +405,9 @@ function renderMobileLanding() {
 										const q = state.searchQuery.toLowerCase();
 										staffList = filterStaffByQuery(staffList, q);
 									}
+									const projectsForRender = projectOrderForRender();
 									const projectMap = new Map<string, { goals: typeof liveGoals; sessions: typeof ungroupedSessions; staff: typeof staffList }>();
-										for (const p of state.projects) projectMap.set(p.id, { goals: [], sessions: [], staff: [] });
+										for (const p of projectsForRender) projectMap.set(p.id, { goals: [], sessions: [], staff: [] });
 										for (const g of liveGoals) {
 											if (!g.projectId) { console.warn("[mobile] orphaned goal with no projectId — skipping", g.id); continue; }
 											const bucket = projectMap.get(g.projectId);
@@ -431,17 +432,23 @@ function renderMobileLanding() {
 										// Bucket archived goals + standalone archived sessions per project.
 										const allStandaloneArchivedAll = state.showArchived ? state.archivedSessions.filter(s => !s.teamGoalId && !s.delegateOf) : [];
 										const filteredStandaloneArchivedAll = filterArchivedSessionsByQuery(allStandaloneArchivedAll, state.searchQuery);
-										const archivedByProject = bucketArchivedByProject(archivedGoals, filteredStandaloneArchivedAll, state.projects);
-										return html`${state.projects.map((project, i) => {
+										const archivedByProject = bucketArchivedByProject(archivedGoals, filteredStandaloneArchivedAll, projectsForRender);
+										return html`${projectsForRender.map((project, i) => {
 											const data = projectMap.get(project.id) || { goals: [], sessions: [], staff: [] };
 											const expanded = isProjectExpanded(project.id);
+											const effectiveExpanded = isProjectReordering() ? false : expanded;
 											const color = getProjectAccentColor(project);
 											return html`
 												${i > 0 ? html`<div class="border-t border-border/30 my-1 mx-2"></div>` : ""}
-												<div class="flex items-center gap-1.5 pl-0.5 pr-2 py-0.5 rounded-md cursor-pointer active:bg-secondary/50 transition-colors"
-													@click=${() => { toggleProjectExpanded(project.id); renderApp(); }}>
-													<span class="text-muted-foreground shrink-0 select-none" style="width:14px;text-align:center;font-size: 1.1667em;">${expanded ? "▾" : "▸"}</span>
-													<span class="shrink-0" style="color:${color};">${icon(FolderOpen, "sm")}</span>
+												<div data-project-reorder-id=${project.id} data-project-id=${project.id}>
+													<div
+														data-testid="project-header"
+														data-project-id=${project.id}
+														class="flex items-center gap-1.5 pl-0.5 pr-2 py-0.5 rounded-md cursor-pointer active:bg-secondary/50 transition-colors"
+														@click=${() => { if (isProjectReordering()) return; toggleProjectExpanded(project.id); renderApp(); }}>
+														<span class="text-muted-foreground shrink-0 select-none" style="width:14px;text-align:center;font-size: 1.1667em;">${effectiveExpanded ? "▾" : "▸"}</span>
+														${renderProjectReorderHandle(project)}
+														<span class="shrink-0" style="color:${color};">${icon(FolderOpen, "sm")}</span>
 													<span class="flex-1 text-muted-foreground uppercase tracking-wider font-medium" style="color:${color};font-size: 1.1667em;">${project.name}</span>
 													<div class="flex items-center gap-2 shrink-0">
 														<button
@@ -463,7 +470,7 @@ function renderMobileLanding() {
 														</button>
 													</div>
 												</div>
-												${expanded ? html`<div class="flex flex-col gap-0.5" style="padding-left:${INDENT}px;">
+												${effectiveExpanded ? html`<div class="flex flex-col gap-0.5" style="padding-left:${INDENT}px;">
 													${data.goals.map((goal, gi) => html`
 														${gi > 0 ? html`<div class="border-t border-border/30 mx-2"></div>` : ""}
 														${renderGoalGroup(goal)}
@@ -510,6 +517,7 @@ function renderMobileLanding() {
 														return renderProjectArchivedSection(project, ab.archivedGoals, ab.standaloneArchivedSessions, "mobile");
 													})()}
 												</div>` : ""}
+												</div>
 											`;
 										})}
 										${state.showArchived && !state.searchQuery && (state.archivedGoalsHasMore || state.archivedSessionsHasMore) ? html`

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -1,6 +1,6 @@
 import { icon } from "@mariozechner/mini-lit";
 import { html } from "lit";
-import { Bot, ChevronDown, FolderOpen, Goal as GoalIcon, List, MessagesSquare, PanelLeftClose, PanelLeftOpen, Pencil, Plus, Settings, Users, Workflow, Wrench, Zap } from "lucide";
+import { Bot, ChevronDown, FolderOpen, Goal as GoalIcon, GripVertical, List, MessagesSquare, PanelLeftClose, PanelLeftOpen, Pencil, Plus, Settings, Users, Workflow, Wrench, Zap } from "lucide";
 // Register search web components (self-registering via @customElement)
 import "../ui/components/SearchBox.js";
 import "../ui/components/SearchResults.js";
@@ -8,6 +8,7 @@ import "./components/search-status-dot.js";
 import {
 	state,
 	renderApp,
+	setProjects,
 	activeSessionId,
 	isDesktop,
 	setSidebarWidth,
@@ -28,7 +29,7 @@ import { createAndConnectSession, connectToSession } from "./session-manager.js"
 import { cwdCombobox } from "./cwd-combobox.js";
 import { showGoalDialog, showProjectDialog } from "./dialogs.js";
 import { startNewGoalFlow } from "./goal-entry.js";
-import { refreshSessions, fetchRoles, fetchStaff, fetchOrphanedStaff, reassignStaffProject, enqueueInboxManual, fetchArchivedSessions, archivedSessionsLoaded, archivedGoalsLoaded, fetchSandboxStatus, fetchArchivedGoalsPaginated, fetchArchivedSessionsPaginated } from "./api.js";
+import { refreshSessions, fetchRoles, fetchStaff, fetchOrphanedStaff, reassignStaffProject, enqueueInboxManual, fetchArchivedSessions, archivedSessionsLoaded, archivedGoalsLoaded, fetchSandboxStatus, fetchArchivedGoalsPaginated, fetchArchivedSessionsPaginated, fetchProjects, saveProjectOrder } from "./api.js";
 import { statusBobbit, sessionAcronym } from "./session-colors.js";
 import { renderGoalGroup, renderSessionRow, SESSION_ROW_PY, INDENT, CHEVRON_W, HEADER_CHEVRON_W, terseRelativeTime, hasUnseenActivity, formatSessionAge, renderSessionTitle, getProjectAccentColor, filterArchivedGoalsByQuery, filterArchivedSessionsByQuery, renderProjectArchivedSection as renderSharedProjectArchivedSection, passesSidebarFilters } from "./render-helpers.js";
 import { renderFiltersButton } from "../ui/components/sidebar-filters.js";
@@ -57,6 +58,353 @@ export function toggleProjectExpanded(projectId: string): void {
 	if (_expandedProjects.has(key)) _expandedProjects.delete(key);
 	else _expandedProjects.add(key);
 	localStorage.setItem(EXPANDED_PROJECTS_KEY, JSON.stringify([..._expandedProjects]));
+}
+
+// ============================================================================
+// PROJECT REORDER STATE
+// ============================================================================
+
+type ProjectReorderState = {
+	activeId: string;
+	pointerId: number;
+	startProjectIds: string[];
+	visualProjectIds: string[];
+	dropIndex: number;
+	suppressNextClick: boolean;
+	startX: number;
+	startY: number;
+	dragging: boolean;
+	keyboard: boolean;
+};
+
+const PROJECT_REORDER_DRAG_THRESHOLD_PX = 4;
+let _projectReorderState: ProjectReorderState | null = null;
+let _projectReorderMessage = "";
+let _suppressProjectHeaderClick = false;
+let _suppressProjectHeaderClickTimer: number | null = null;
+
+function currentProjectIds(): string[] {
+	return state.projects.map((project) => project.id);
+}
+
+function completeProjectOrderIds(projectIds: string[]): string[] {
+	const currentIds = new Set(currentProjectIds());
+	const seen = new Set<string>();
+	const complete: string[] = [];
+	for (const id of projectIds) {
+		if (!currentIds.has(id) || seen.has(id)) continue;
+		seen.add(id);
+		complete.push(id);
+	}
+	for (const project of state.projects) {
+		if (seen.has(project.id)) continue;
+		seen.add(project.id);
+		complete.push(project.id);
+	}
+	return complete;
+}
+
+function orderProjectsByIds(projects: Project[], projectIds: string[]): Project[] {
+	const byId = new Map(projects.map((project) => [project.id, project]));
+	const seen = new Set<string>();
+	const ordered: Project[] = [];
+	for (const id of projectIds) {
+		const project = byId.get(id);
+		if (!project || seen.has(id)) continue;
+		seen.add(id);
+		ordered.push(project);
+	}
+	for (const project of projects) {
+		if (seen.has(project.id)) continue;
+		seen.add(project.id);
+		ordered.push(project);
+	}
+	return ordered;
+}
+
+function projectOrdersDiffer(a: string[], b: string[]): boolean {
+	if (a.length !== b.length) return true;
+	return a.some((id, index) => id !== b[index]);
+}
+
+function projectNameForId(projectId: string): string {
+	return state.projects.find((project) => project.id === projectId)?.name || "project";
+}
+
+function setProjectReorderMessage(message: string): void {
+	_projectReorderMessage = message;
+}
+
+function renderProjectReorderLiveRegion() {
+	return html`<div class="project-reorder-live" aria-live="polite" aria-atomic="true">${_projectReorderMessage}</div>`;
+}
+
+function suppressNextProjectHeaderClick(): void {
+	_suppressProjectHeaderClick = true;
+	if (_suppressProjectHeaderClickTimer !== null) window.clearTimeout(_suppressProjectHeaderClickTimer);
+	_suppressProjectHeaderClickTimer = window.setTimeout(() => {
+		_suppressProjectHeaderClick = false;
+		_suppressProjectHeaderClickTimer = null;
+	}, 200);
+}
+
+function consumeProjectHeaderReorderClick(): boolean {
+	if (!_suppressProjectHeaderClick && !_projectReorderState?.suppressNextClick) return false;
+	_suppressProjectHeaderClick = false;
+	if (_suppressProjectHeaderClickTimer !== null) {
+		window.clearTimeout(_suppressProjectHeaderClickTimer);
+		_suppressProjectHeaderClickTimer = null;
+	}
+	if (_projectReorderState) _projectReorderState.suppressNextClick = false;
+	return true;
+}
+
+function addProjectReorderDocumentListeners(): void {
+	document.addEventListener("pointermove", handleProjectReorderMove);
+	document.addEventListener("pointerup", handleProjectReorderPointerUp);
+	document.addEventListener("pointercancel", handleProjectReorderPointerCancel);
+}
+
+function removeProjectReorderDocumentListeners(): void {
+	document.removeEventListener("pointermove", handleProjectReorderMove);
+	document.removeEventListener("pointerup", handleProjectReorderPointerUp);
+	document.removeEventListener("pointercancel", handleProjectReorderPointerCancel);
+}
+
+function focusProjectReorderHandle(projectId: string): void {
+	requestAnimationFrame(() => {
+		const handle = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-testid="project-reorder-handle"]'))
+			.find((el) => el.dataset.projectId === projectId);
+		handle?.focus();
+	});
+}
+
+export function isProjectReordering(): boolean {
+	return _projectReorderState?.dragging === true;
+}
+
+export function projectOrderForRender(): Project[] {
+	if (!isProjectReordering() || !_projectReorderState) return state.projects;
+	return orderProjectsByIds(state.projects, _projectReorderState.visualProjectIds);
+}
+
+function beginProjectReorder(): void {
+	const reorder = _projectReorderState;
+	if (!reorder || reorder.dragging) return;
+	reorder.dragging = true;
+	reorder.visualProjectIds = completeProjectOrderIds(reorder.visualProjectIds);
+	reorder.dropIndex = reorder.visualProjectIds.indexOf(reorder.activeId);
+	setProjectReorderMessage(`Picked up ${projectNameForId(reorder.activeId)}.`);
+	renderApp();
+}
+
+export function startProjectReorder(e: PointerEvent, projectId: string): void {
+	if (e.pointerType === "mouse" && e.button !== 0) return;
+	e.preventDefault();
+	e.stopPropagation();
+	if (_projectReorderState) return;
+	const projectIds = currentProjectIds();
+	if (!projectIds.includes(projectId)) return;
+	_projectReorderState = {
+		activeId: projectId,
+		pointerId: e.pointerId,
+		startProjectIds: projectIds,
+		visualProjectIds: projectIds,
+		dropIndex: projectIds.indexOf(projectId),
+		suppressNextClick: true,
+		startX: e.clientX,
+		startY: e.clientY,
+		dragging: false,
+		keyboard: false,
+	};
+	addProjectReorderDocumentListeners();
+	try {
+		(e.currentTarget as HTMLElement | null)?.setPointerCapture?.(e.pointerId);
+	} catch {
+		// Pointer capture can fail when the handle is removed during a re-render.
+	}
+}
+
+function updateProjectReorderFromPointer(clientY: number): void {
+	const reorder = _projectReorderState;
+	if (!reorder) return;
+	const rows = Array.from(document.querySelectorAll<HTMLElement>("[data-project-reorder-id]"))
+		.filter((row) => row.dataset.projectReorderId && row.dataset.projectReorderId !== reorder.activeId && row.getClientRects().length > 0);
+	let dropIndex = rows.length;
+	for (let i = 0; i < rows.length; i++) {
+		const rect = rows[i].getBoundingClientRect();
+		if (clientY < rect.top + rect.height / 2) {
+			dropIndex = i;
+			break;
+		}
+	}
+	const withoutActive = completeProjectOrderIds(reorder.visualProjectIds).filter((id) => id !== reorder.activeId);
+	dropIndex = Math.max(0, Math.min(dropIndex, withoutActive.length));
+	const nextIds = [...withoutActive];
+	nextIds.splice(dropIndex, 0, reorder.activeId);
+	reorder.dropIndex = dropIndex;
+	if (!projectOrdersDiffer(nextIds, reorder.visualProjectIds)) return;
+	reorder.visualProjectIds = nextIds;
+	const beforeId = nextIds[dropIndex + 1];
+	setProjectReorderMessage(beforeId
+		? `Moved ${projectNameForId(reorder.activeId)} before ${projectNameForId(beforeId)}.`
+		: `Moved ${projectNameForId(reorder.activeId)} to the end.`);
+	renderApp();
+}
+
+export function handleProjectReorderMove(e: PointerEvent): void {
+	const reorder = _projectReorderState;
+	if (!reorder || reorder.keyboard || reorder.pointerId !== e.pointerId) return;
+	e.preventDefault();
+	if (!reorder.dragging) {
+		const dx = e.clientX - reorder.startX;
+		const dy = e.clientY - reorder.startY;
+		if (Math.hypot(dx, dy) < PROJECT_REORDER_DRAG_THRESHOLD_PX) return;
+		beginProjectReorder();
+	}
+	updateProjectReorderFromPointer(e.clientY);
+}
+
+function handleProjectReorderPointerUp(e: PointerEvent): void {
+	const reorder = _projectReorderState;
+	if (!reorder || reorder.keyboard || reorder.pointerId !== e.pointerId) return;
+	e.preventDefault();
+	e.stopPropagation();
+	const target = document.elementFromPoint(e.clientX, e.clientY) as HTMLElement | null;
+	const droppedInsideList = !!target?.closest("[data-project-reorder-list]");
+	void finishProjectReorder(!reorder.dragging || !droppedInsideList);
+}
+
+function handleProjectReorderPointerCancel(e: PointerEvent): void {
+	const reorder = _projectReorderState;
+	if (!reorder || reorder.keyboard || reorder.pointerId !== e.pointerId) return;
+	e.preventDefault();
+	e.stopPropagation();
+	void finishProjectReorder(true);
+}
+
+function moveKeyboardProject(projectId: string, delta: number): void {
+	const reorder = _projectReorderState;
+	if (!reorder || reorder.activeId !== projectId) return;
+	const ids = completeProjectOrderIds(reorder.visualProjectIds);
+	const from = ids.indexOf(projectId);
+	if (from < 0) return;
+	const to = Math.max(0, Math.min(ids.length - 1, from + delta));
+	if (to === from) return;
+	ids.splice(from, 1);
+	ids.splice(to, 0, projectId);
+	reorder.visualProjectIds = ids;
+	reorder.dropIndex = to;
+	setProjectReorderMessage(`Moved ${projectNameForId(projectId)} to position ${to + 1} of ${ids.length}.`);
+	renderApp();
+	focusProjectReorderHandle(projectId);
+}
+
+function beginKeyboardProjectReorder(projectId: string): void {
+	const projectIds = currentProjectIds();
+	if (!projectIds.includes(projectId)) return;
+	_projectReorderState = {
+		activeId: projectId,
+		pointerId: -1,
+		startProjectIds: projectIds,
+		visualProjectIds: projectIds,
+		dropIndex: projectIds.indexOf(projectId),
+		suppressNextClick: true,
+		startX: 0,
+		startY: 0,
+		dragging: true,
+		keyboard: true,
+	};
+	setProjectReorderMessage(`Picked up ${projectNameForId(projectId)}.`);
+	renderApp();
+	focusProjectReorderHandle(projectId);
+}
+
+export function handleProjectReorderKeyDown(e: KeyboardEvent, projectId: string): void {
+	if (![" ", "Enter", "ArrowUp", "ArrowDown", "Escape"].includes(e.key)) return;
+	const reorder = _projectReorderState;
+	if (!reorder) {
+		if (e.key !== " " && e.key !== "Enter") return;
+		e.preventDefault();
+		e.stopPropagation();
+		beginKeyboardProjectReorder(projectId);
+		return;
+	}
+	if (reorder.activeId !== projectId) return;
+	e.preventDefault();
+	e.stopPropagation();
+	if (e.key === "Escape") {
+		void finishProjectReorder(true);
+	} else if (e.key === "ArrowUp") {
+		moveKeyboardProject(projectId, -1);
+	} else if (e.key === "ArrowDown") {
+		moveKeyboardProject(projectId, 1);
+	} else if (e.key === " " || e.key === "Enter") {
+		void finishProjectReorder(false);
+	}
+}
+
+function handleProjectReorderDocumentKeyDown(e: KeyboardEvent): void {
+	if (e.key !== "Escape" || !_projectReorderState) return;
+	e.preventDefault();
+	e.stopPropagation();
+	void finishProjectReorder(true);
+}
+
+document.addEventListener("keydown", handleProjectReorderDocumentKeyDown, true);
+
+export async function finishProjectReorder(cancel = false): Promise<void> {
+	const reorder = _projectReorderState;
+	if (!reorder) return;
+	removeProjectReorderDocumentListeners();
+	const wasDragging = reorder.dragging;
+	const startIds = completeProjectOrderIds(reorder.startProjectIds);
+	const finalIds = completeProjectOrderIds(reorder.visualProjectIds);
+	const originalProjects = orderProjectsByIds(state.projects, startIds);
+	const optimisticProjects = orderProjectsByIds(state.projects, finalIds);
+	const changed = projectOrdersDiffer(startIds, finalIds);
+	if (reorder.suppressNextClick) suppressNextProjectHeaderClick();
+	_projectReorderState = null;
+
+	if (cancel || !wasDragging || !changed) {
+		setProjectReorderMessage(cancel && wasDragging ? "Project reorder cancelled." : "");
+		renderApp();
+		return;
+	}
+
+	setProjects(optimisticProjects);
+	setProjectReorderMessage(`Dropped ${projectNameForId(reorder.activeId)} at position ${finalIds.indexOf(reorder.activeId) + 1} of ${finalIds.length}.`);
+	renderApp();
+
+	const savedProjects = await saveProjectOrder(finalIds);
+	if (savedProjects) {
+		setProjects(savedProjects);
+	} else {
+		const restored = await fetchProjects();
+		setProjects(restored.length > 0 || originalProjects.length === 0 ? restored : originalProjects);
+	}
+	renderApp();
+}
+
+export function renderProjectReorderHandle(project: Project) {
+	const active = _projectReorderState?.activeId === project.id && _projectReorderState.dragging;
+	return html`
+		<button
+			type="button"
+			class="project-reorder-handle ${active ? "project-reorder-handle-active" : ""}"
+			data-testid="project-reorder-handle"
+			data-project-id=${project.id}
+			aria-label=${`Reorder ${project.name}`}
+			aria-pressed=${active ? "true" : "false"}
+			aria-grabbed=${active ? "true" : "false"}
+			title=${`Reorder ${project.name}`}
+			@pointerdown=${(e: PointerEvent) => startProjectReorder(e, project.id)}
+			@click=${(e: MouseEvent) => { e.preventDefault(); e.stopPropagation(); consumeProjectHeaderReorderClick(); }}
+			@keydown=${(e: KeyboardEvent) => handleProjectReorderKeyDown(e, project.id)}
+		>
+			${icon(GripVertical, "xs")}
+		</button>
+	`;
 }
 
 // ============================================================================
@@ -856,22 +1204,40 @@ function renderProjectHeader(project: Project, expanded: boolean) {
 	const isProvisional = !!project.provisional;
 	const navId = `project:${project.id}`;
 	const navActive = getActiveNavId() === navId;
+	const reordering = isProjectReordering();
+	const reorderActive = _projectReorderState?.activeId === project.id && _projectReorderState.dragging;
 	return html`
-		<div class="group flex items-center gap-1 pr-1 py-0.5 pl-0.5 rounded-md cursor-pointer ${navActive ? "bg-secondary text-foreground sidebar-session-active" : "hover:bg-secondary/30"} transition-colors"
+		<div class="group project-header flex items-center gap-1 pr-1 py-0.5 pl-0.5 rounded-md ${reordering ? "cursor-default" : "cursor-pointer"} ${reorderActive ? "project-reorder-active" : ""} ${navActive ? "bg-secondary text-foreground sidebar-session-active" : "hover:bg-secondary/30"} transition-colors"
+			data-testid="project-header"
+			data-project-id=${project.id}
+			data-project-reorder-id=${project.id}
+			data-project-reordering=${reordering ? "true" : "false"}
+			data-project-reorder-active=${reorderActive ? "true" : "false"}
 			data-nav-id=${navId}
 			data-nav-active=${navActive ? "true" : "false"}
-			@click=${() => { toggleProjectExpanded(project.id); renderApp(); }}>
+			@click=${(e: Event) => {
+				if (consumeProjectHeaderReorderClick() || isProjectReordering()) {
+					e.preventDefault();
+					e.stopPropagation();
+					return;
+				}
+				toggleProjectExpanded(project.id);
+				renderApp();
+			}}>
 			<span class="text-muted-foreground shrink-0 select-none" style="width:12px;text-align:center;font-size: 1.1667em;">${expanded ? "▾" : "▸"}</span>
+			${renderProjectReorderHandle(project)}
 			<span class="shrink-0" style="color:${color};">${icon(FolderOpen, "xs")}</span>
 			<span class="flex-1 text-muted-foreground uppercase tracking-wider font-medium" style="color:${color};font-size: 0.75em;">${project.name}</span>
 			${isProvisional ? html`<span class="text-muted-foreground italic shrink-0" style="font-size: 0.75em;">(setting up)</span>` : html`
 			<button
+				type="button"
 				class="rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors ${isDesktop() ? "opacity-0 group-hover:opacity-100" : ""}"
 				style="padding:0;line-height:0;"
 				@click=${(e: Event) => { e.stopPropagation(); setHashRoute("settings", `${project.id}/general`); }}
 				title="Project settings"
 			>${icon(Settings, "xs")}</button>
 			<button
+				type="button"
 				class="rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors relative shrink-0"
 				style="padding:0 2px;line-height:0;"
 				@click=${(e: Event) => { e.stopPropagation(); showGoalDialog(undefined, project.id); }}
@@ -980,7 +1346,8 @@ export function renderSidebar() {
 	const isSkillsActive = isRouteActive("skills");
 
 	return html`
-		<div class="shrink-0 h-full flex flex-col sidebar-edge sidebar-root relative" data-testid="sidebar-expanded" style="background: var(--sidebar); width: var(--sidebar-w, 240px);">
+		<div class="shrink-0 h-full flex flex-col sidebar-edge sidebar-root relative" data-testid="sidebar-expanded" data-project-reordering=${isProjectReordering() ? "true" : "false"} style="background: var(--sidebar); width: var(--sidebar-w, 240px);">
+			${renderProjectReorderLiveRegion()}
 			<div class="sidebar-resize-handle" @pointerdown=${onSidebarResizePointerDown} @dblclick=${onSidebarResizeDoubleClick} title="Drag to resize (double-click to reset)"></div>
 			<div class="flex flex-col border-b border-border/50 px-0.5 py-1 gap-0.5">
 				<div class="flex items-center">
@@ -1043,7 +1410,7 @@ export function renderSidebar() {
 				></search-box>
 				<search-status-dot></search-status-dot>
 			</div>
-			<div class="flex-1 overflow-y-auto flex flex-col gap-0.5 py-2 px-0.5">
+			<div class="flex-1 overflow-y-auto flex flex-col gap-0.5 py-2 px-0.5" data-project-reorder-list>
 				${renderOrphanedStaffBanner()}
 				${state.sessionsLoading
 					? html`<div class="text-center py-6 text-muted-foreground">Loading…</div>`
@@ -1131,15 +1498,18 @@ export function renderSidebar() {
 							}
 
 							return html`
-							${state.projects.map((project, i) => {
+							${projectOrderForRender().map((project, i) => {
 								const data = projectMap.get(project.id) || { goals: [], sessions: [], staff: [], archivedGoals: [], standaloneArchivedSessions: [] };
 								const expanded = isProjectExpanded(project.id);
+								const effectiveExpanded = isProjectReordering() ? false : expanded;
 								return html`
-									${i > 0 ? html`<div class="border-t border-border/30 my-1 mx-2"></div>` : ""}
-									${renderProjectHeader(project, expanded)}
-									${expanded ? html`<div class="flex flex-col gap-0.5" style="padding-left:${INDENT}px;">
-										${renderProjectContent(project, data.goals, data.sessions, data.staff, data.archivedGoals, data.standaloneArchivedSessions)}
-									</div>` : ""}
+									${i > 0 ? html`<div class="project-reorder-separator border-t border-border/30 my-1 mx-2"></div>` : ""}
+									<div class="project-reorder-section" data-project-id=${project.id}>
+										${renderProjectHeader(project, effectiveExpanded)}
+										${effectiveExpanded ? html`<div class="flex flex-col gap-0.5" style="padding-left:${INDENT}px;">
+											${renderProjectContent(project, data.goals, data.sessions, data.staff, data.archivedGoals, data.standaloneArchivedSessions)}
+										</div>` : ""}
+									</div>
 								`;
 							})}
 

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -135,8 +135,8 @@ function setProjectReorderMessage(message: string): void {
 	_projectReorderMessage = message;
 }
 
-function renderProjectReorderLiveRegion() {
-	return html`<div class="project-reorder-live" aria-live="polite" aria-atomic="true">${_projectReorderMessage}</div>`;
+export function renderProjectReorderLiveRegion() {
+	return html`<div class="project-reorder-live" data-testid="project-reorder-live-region" aria-live="polite" aria-atomic="true">${_projectReorderMessage}</div>`;
 }
 
 function suppressNextProjectHeaderClick(): void {

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -564,6 +564,30 @@ export function setProjects(projects: Project[]): void {
 	}
 }
 
+function projectSignature(project: Project): string {
+	const record = project as unknown as Record<string, unknown>;
+	const sorted: Record<string, unknown> = {};
+	for (const key of Object.keys(record).sort()) {
+		sorted[key] = record[key];
+	}
+	return JSON.stringify(sorted);
+}
+
+export function projectsEqual(a: Project[], b: Project[]): boolean {
+	if (a.length !== b.length) return false;
+	for (let i = 0; i < a.length; i++) {
+		if (a[i].id !== b[i].id) return false;
+		if (projectSignature(a[i]) !== projectSignature(b[i])) return false;
+	}
+	return true;
+}
+
+export function setProjectsIfChanged(projects: Project[]): boolean {
+	if (projectsEqual(state.projects, projects)) return false;
+	setProjects(projects);
+	return true;
+}
+
 // ============================================================================
 // HELPERS
 // ============================================================================

--- a/src/server/agent/project-registry.ts
+++ b/src/server/agent/project-registry.ts
@@ -18,6 +18,7 @@ export interface RegisteredProject {
   palette?: string;     // One of 10 palette IDs or undefined
   colorLight: string;   // Accent color for light mode (always present)
   colorDark: string;    // Accent color for dark mode (always present)
+  position?: number;    // Visible project ordering; hidden/system projects do not participate
   provisional?: boolean; // True while a project assistant is setting up this project
   /**
    * True for synthetic projects that should be filtered out of UI listings
@@ -30,6 +31,19 @@ export interface RegisteredProject {
 
 /** Stable id for the synthetic system project. */
 export const SYSTEM_PROJECT_ID = "system";
+
+export type ProjectOrderErrorCode = "invalid_project_order" | "stale_project_order";
+
+export class ProjectOrderError extends Error {
+  constructor(
+    public readonly code: ProjectOrderErrorCode,
+    message: string,
+    public readonly details: { expectedProjectIds?: string[]; receivedProjectIds?: string[] } = {},
+  ) {
+    super(message);
+    this.name = "ProjectOrderError";
+  }
+}
 
 /**
  * Detect whether `rootPath` resolves through a symlink to a different
@@ -91,8 +105,63 @@ export class ProjectRegistry {
     this.load();
   }
 
+  private participatesInVisibleOrder(project: RegisteredProject): boolean {
+    return !project.hidden && project.id !== SYSTEM_PROJECT_ID;
+  }
+
+  private positionSortValue(project: RegisteredProject): number {
+    return Number.isFinite(project.position) ? project.position! : Number.POSITIVE_INFINITY;
+  }
+
+  private compareVisibleOrderEntries(
+    a: { project: RegisteredProject; index: number },
+    b: { project: RegisteredProject; index: number },
+  ): number {
+    const posA = this.positionSortValue(a.project);
+    const posB = this.positionSortValue(b.project);
+    if (posA !== posB) return posA - posB;
+    if (a.project.createdAt !== b.project.createdAt) return a.project.createdAt - b.project.createdAt;
+    return a.index - b.index;
+  }
+
+  private normalizeVisiblePositions(): boolean {
+    const entries = [...this.projects.values()].map((project, index) => ({ project, index }));
+    let changed = false;
+
+    for (const { project } of entries) {
+      if (!this.participatesInVisibleOrder(project) && project.position !== undefined) {
+        delete project.position;
+        changed = true;
+      }
+    }
+
+    const visible = entries
+      .filter(entry => this.participatesInVisibleOrder(entry.project))
+      .sort((a, b) => this.compareVisibleOrderEntries(a, b));
+
+    for (let i = 0; i < visible.length; i++) {
+      const project = visible[i].project;
+      if (project.position !== i) {
+        project.position = i;
+        changed = true;
+      }
+    }
+
+    return changed;
+  }
+
+  private nextVisiblePosition(): number {
+    this.normalizeVisiblePositions();
+    const positions = [...this.projects.values()]
+      .filter(project => this.participatesInVisibleOrder(project))
+      .map(project => project.position)
+      .filter((position): position is number => Number.isFinite(position));
+    return positions.length > 0 ? Math.max(...positions) + 1 : 0;
+  }
+
   /** Read projects from disk. Missing file is treated as empty registry. */
   load(): void {
+    let changed = false;
     try {
       const raw = fs.readFileSync(this.storePath, "utf-8");
       const arr: any[] = JSON.parse(raw);
@@ -107,12 +176,19 @@ export class ProjectRegistry {
             p.colorLight = p.colorLight || DEFAULT_PROJECT_COLOR_LIGHT;
             p.colorDark = p.colorDark || DEFAULT_PROJECT_COLOR_DARK;
           }
+          changed = true;
         }
         this.projects.set(p.id, p as RegisteredProject);
       }
     } catch {
       // File missing or corrupt — start empty
       this.projects.clear();
+      return;
+    }
+
+    if (this.normalizeVisiblePositions()) changed = true;
+    if (changed) {
+      try { this.save(); } catch (err) { console.warn(`[project-registry] failed to persist migrations: ${err}`); }
     }
   }
 
@@ -125,9 +201,60 @@ export class ProjectRegistry {
     fs.renameSync(tmp, this.storePath);
   }
 
-  /** Return all registered projects, ordered by createdAt ascending. */
+  /** Return all registered projects. Visible projects are ordered by position; hidden projects are appended by createdAt. */
   list(): RegisteredProject[] {
-    return [...this.projects.values()].sort((a, b) => a.createdAt - b.createdAt);
+    return [...this.projects.values()]
+      .map((project, index) => ({ project, index }))
+      .sort((a, b) => {
+        const visibleA = this.participatesInVisibleOrder(a.project);
+        const visibleB = this.participatesInVisibleOrder(b.project);
+        if (visibleA && visibleB) return this.compareVisibleOrderEntries(a, b);
+        if (visibleA !== visibleB) return visibleA ? -1 : 1;
+        if (a.project.createdAt !== b.project.createdAt) return a.project.createdAt - b.project.createdAt;
+        return a.index - b.index;
+      })
+      .map(entry => entry.project);
+  }
+
+  setVisibleOrder(projectIds: string[]): RegisteredProject[] {
+    if (!Array.isArray(projectIds) || projectIds.some(id => typeof id !== "string")) {
+      throw new ProjectOrderError("invalid_project_order", "projectIds must be an array of strings");
+    }
+
+    const seen = new Set<string>();
+    for (const id of projectIds) {
+      if (seen.has(id)) {
+        throw new ProjectOrderError("invalid_project_order", `Duplicate project id in order: ${id}`);
+      }
+      seen.add(id);
+    }
+
+    const expectedProjectIds = this.list()
+      .filter(project => this.participatesInVisibleOrder(project))
+      .map(project => project.id);
+    const receivedProjectIds = [...projectIds];
+
+    for (const id of receivedProjectIds) {
+      const project = this.projects.get(id);
+      if (!project || !this.participatesInVisibleOrder(project)) {
+        throw new ProjectOrderError("invalid_project_order", `Invalid project id in order: ${id}`);
+      }
+    }
+
+    const expectedSet = new Set(expectedProjectIds);
+    if (receivedProjectIds.length !== expectedProjectIds.length || receivedProjectIds.some(id => !expectedSet.has(id))) {
+      throw new ProjectOrderError("stale_project_order", "Project order is stale", {
+        expectedProjectIds,
+        receivedProjectIds,
+      });
+    }
+
+    receivedProjectIds.forEach((id, position) => {
+      const project = this.projects.get(id)!;
+      project.position = position;
+    });
+    this.save();
+    return this.list().filter(project => this.participatesInVisibleOrder(project));
   }
 
   /** Lookup by project ID. */
@@ -264,6 +391,7 @@ export class ProjectRegistry {
       name,
       rootPath,
       createdAt: Date.now(),
+      position: this.nextVisiblePosition(),
       color: colorLight, // backward compat
       colorLight,
       colorDark,
@@ -331,6 +459,7 @@ export class ProjectRegistry {
       throw new Error(`Project not found: ${id}`);
     }
     this.projects.delete(id);
+    this.normalizeVisiblePositions();
     this.save();
   }
 
@@ -344,7 +473,22 @@ export class ProjectRegistry {
    */
   registerSystemProject(rootPath: string): RegisteredProject {
     const existing = this.projects.get(SYSTEM_PROJECT_ID);
-    if (existing) return existing;
+    if (existing) {
+      let changed = false;
+      if (!existing.hidden) {
+        existing.hidden = true;
+        changed = true;
+      }
+      if (existing.position !== undefined) {
+        delete existing.position;
+        changed = true;
+      }
+      if (changed) {
+        this.normalizeVisiblePositions();
+        this.save();
+      }
+      return existing;
+    }
     if (!path.isAbsolute(rootPath)) {
       throw new Error(`rootPath must be absolute, got: ${rootPath}`);
     }
@@ -417,6 +561,7 @@ export class ProjectRegistry {
       name,
       rootPath,
       createdAt: Date.now(),
+      position: this.nextVisiblePosition(),
       colorLight: DEFAULT_PROJECT_COLOR_LIGHT,
       colorDark: DEFAULT_PROJECT_COLOR_DARK,
       provisional: true,
@@ -460,6 +605,7 @@ export class ProjectRegistry {
     if (!project) throw new Error(`Project not found: ${id}`);
     if (!project.provisional) throw new Error(`Cannot remove non-provisional project ${id} via removeProvisional()`);
     this.projects.delete(id);
+    this.normalizeVisiblePositions();
     this.save();
   }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -96,7 +96,7 @@ import { ReviewAnnotationStore, type ReviewAnnotation } from "./review-annotatio
 import { getAvailableModels, discoverModelsForConfig, invalidateModelCache } from "./agent/model-registry.js";
 import type { CustomProviderConfig } from "./agent/model-registry.js";
 import { canonicalImageModelPref, defaultImageModelPref, generateImage, getAvailableImageModels, imageModelMentionedInText } from "./agent/image-generation.js";
-import { ProjectRegistry, SymlinkProjectRootError, PreflightFailedError, SYSTEM_PROJECT_ID } from "./agent/project-registry.js";
+import { ProjectRegistry, SymlinkProjectRootError, PreflightFailedError, SYSTEM_PROJECT_ID, ProjectOrderError } from "./agent/project-registry.js";
 import { runPreflight } from "./agent/project-preflight.js";
 import { archiveProjectBobbitDir, ArchiveError } from "./agent/bobbit-archive.js";
 import { ProjectContextManager } from "./agent/project-context-manager.js";
@@ -2165,7 +2165,7 @@ async function handleApiRoute(
 	if (url.pathname === "/api/projects" && req.method === "GET") {
 		// Filter out hidden projects (e.g. the synthetic "system" project) so
 		// they never appear in the client's state.projects.
-		json(projectRegistry.list().filter(p => !p.hidden));
+		json(projectRegistry.list().filter(p => !p.hidden && p.id !== SYSTEM_PROJECT_ID));
 		return;
 	}
 
@@ -2343,6 +2343,30 @@ async function handleApiRoute(
 			json(project, 201);
 		} catch (err: any) {
 			jsonError(400, err);
+		}
+		return;
+	}
+
+	// PUT /api/projects/order
+	if (url.pathname === "/api/projects/order" && req.method === "PUT") {
+		const body = await readBody(req);
+		try {
+			const projects = projectRegistry.setVisibleOrder(body?.projectIds);
+			broadcastToAll({ type: "projects_changed", projects });
+			json({ projects });
+		} catch (err: any) {
+			if (err instanceof ProjectOrderError || err?.code === "invalid_project_order" || err?.code === "stale_project_order") {
+				const code = err?.code === "stale_project_order" ? "stale_project_order" : "invalid_project_order";
+				const payload: Record<string, unknown> = {
+					error: err?.message || "Invalid project order",
+					code,
+				};
+				if (Array.isArray(err?.details?.expectedProjectIds)) payload.expectedProjectIds = err.details.expectedProjectIds;
+				if (Array.isArray(err?.details?.receivedProjectIds)) payload.receivedProjectIds = err.details.receivedProjectIds;
+				json(payload, code === "stale_project_order" ? 409 : 400);
+			} else {
+				jsonError(400, err);
+			}
 		}
 		return;
 	}

--- a/tests/e2e/project-reorder-api.spec.ts
+++ b/tests/e2e/project-reorder-api.spec.ts
@@ -1,0 +1,186 @@
+import { test, expect } from "./in-process-harness.js";
+import { apiFetch, bobbitDir } from "./e2e-setup.js";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+interface ProjectSummary {
+	id: string;
+	name: string;
+	hidden?: boolean;
+	position?: number;
+}
+
+async function listProjects(): Promise<ProjectSummary[]> {
+	const res = await apiFetch("/api/projects");
+	expect(res.status).toBe(200);
+	return await res.json();
+}
+
+async function listVisibleProjects(): Promise<ProjectSummary[]> {
+	return (await listProjects()).filter(project => !project.hidden);
+}
+
+async function clearVisibleProjects(): Promise<void> {
+	for (const project of await listVisibleProjects()) {
+		await apiFetch(`/api/projects/${project.id}`, { method: "DELETE" }).catch(() => {});
+	}
+	expect(await listVisibleProjects()).toEqual([]);
+}
+
+async function registerTmpProject(name: string): Promise<ProjectSummary> {
+	const rootPath = mkdtempSync(join(bobbitDir(), `bobbit-reorder-${name}-`));
+	const res = await apiFetch("/api/projects", {
+		method: "POST",
+		body: JSON.stringify({ name, rootPath, __e2e_seed_skip__: true }),
+	});
+	expect(res.status).toBe(201);
+	return await res.json();
+}
+
+async function seedProjects(names: string[]): Promise<ProjectSummary[]> {
+	const projects: ProjectSummary[] = [];
+	for (const name of names) {
+		projects.push(await registerTmpProject(name));
+	}
+	return projects;
+}
+
+function projectNames(projects: ProjectSummary[]): string[] {
+	return projects.map(project => project.name);
+}
+
+async function expectVisibleOrder(expectedIds: string[]): Promise<void> {
+	expect((await listVisibleProjects()).map(project => project.id)).toEqual(expectedIds);
+}
+
+test.describe("PUT /api/projects/order", () => {
+	test.describe.configure({ mode: "serial" });
+
+	test.beforeEach(async () => {
+		await clearVisibleProjects();
+	});
+
+	test.afterEach(async () => {
+		await clearVisibleProjects();
+	});
+
+	test("saves C/A/B order, returns it from GET, and persists reloadable positions", async ({ gateway }) => {
+		const projects = await seedProjects(["A", "B", "C"]);
+		try {
+			const [a, b, c] = projects;
+			const order = [c.id, a.id, b.id];
+
+			const putRes = await apiFetch("/api/projects/order", {
+				method: "PUT",
+				body: JSON.stringify({ projectIds: order }),
+			});
+			expect(putRes.status).toBe(200);
+			const putBody = await putRes.json();
+			expect(projectNames(putBody.projects)).toEqual(["C", "A", "B"]);
+			expect(putBody.projects.map((project: ProjectSummary) => project.position)).toEqual([0, 1, 2]);
+
+			const getProjects = await listVisibleProjects();
+			expect(projectNames(getProjects)).toEqual(["C", "A", "B"]);
+			expect(getProjects.map(project => project.position)).toEqual([0, 1, 2]);
+
+			const stored = JSON.parse(readFileSync(join(gateway.bobbitDir, "state", "projects.json"), "utf-8")) as ProjectSummary[];
+			const storedVisible = stored.filter(project => order.includes(project.id));
+			expect(storedVisible.map(project => project.id)).toEqual(order);
+			expect(storedVisible.map(project => project.position)).toEqual([0, 1, 2]);
+
+			const { ProjectRegistry } = await import("../../dist/server/agent/project-registry.js");
+			const reloaded = new ProjectRegistry(join(gateway.bobbitDir, "state"));
+			expect(reloaded.list().filter((project: ProjectSummary) => order.includes(project.id)).map((project: ProjectSummary) => project.id)).toEqual(order);
+		} finally {
+			await clearVisibleProjects();
+		}
+	});
+
+	test("rejects malformed, duplicate, unknown, hidden/system, and stale orders without mutation", async () => {
+		const projects = await seedProjects(["A", "B", "C"]);
+		try {
+			const [a, b, c] = projects;
+			const original = [a.id, b.id, c.id];
+			expect((await listProjects()).some(project => project.id === "system")).toBe(false);
+
+			const malformed = await apiFetch("/api/projects/order", {
+				method: "PUT",
+				body: JSON.stringify({ projectIds: "not-an-array" }),
+			});
+			expect(malformed.status).toBe(400);
+			expect(await malformed.json()).toMatchObject({ code: "invalid_project_order" });
+			await expectVisibleOrder(original);
+
+			const nonString = await apiFetch("/api/projects/order", {
+				method: "PUT",
+				body: JSON.stringify({ projectIds: [a.id, b.id, 123] }),
+			});
+			expect(nonString.status).toBe(400);
+			expect(await nonString.json()).toMatchObject({ code: "invalid_project_order" });
+			await expectVisibleOrder(original);
+
+			const duplicate = await apiFetch("/api/projects/order", {
+				method: "PUT",
+				body: JSON.stringify({ projectIds: [a.id, b.id, b.id] }),
+			});
+			expect(duplicate.status).toBe(400);
+			expect(await duplicate.json()).toMatchObject({ code: "invalid_project_order" });
+			await expectVisibleOrder(original);
+
+			const unknown = await apiFetch("/api/projects/order", {
+				method: "PUT",
+				body: JSON.stringify({ projectIds: [a.id, b.id, "missing-project"] }),
+			});
+			expect(unknown.status).toBe(400);
+			expect(await unknown.json()).toMatchObject({ code: "invalid_project_order" });
+			await expectVisibleOrder(original);
+
+			const system = await apiFetch("/api/projects/order", {
+				method: "PUT",
+				body: JSON.stringify({ projectIds: [a.id, b.id, c.id, "system"] }),
+			});
+			expect(system.status).toBe(400);
+			expect(await system.json()).toMatchObject({ code: "invalid_project_order" });
+			await expectVisibleOrder(original);
+
+			const stale = await apiFetch("/api/projects/order", {
+				method: "PUT",
+				body: JSON.stringify({ projectIds: [a.id, b.id] }),
+			});
+			expect(stale.status).toBe(409);
+			expect(await stale.json()).toMatchObject({
+				code: "stale_project_order",
+				expectedProjectIds: original,
+				receivedProjectIds: [a.id, b.id],
+			});
+			await expectVisibleOrder(original);
+		} finally {
+			await clearVisibleProjects();
+		}
+	});
+
+	test("delete compacts remaining order and newly-created projects append", async () => {
+		const projects = await seedProjects(["A", "B", "C"]);
+		try {
+			const [a, b, c] = projects;
+			const reordered = await apiFetch("/api/projects/order", {
+				method: "PUT",
+				body: JSON.stringify({ projectIds: [c.id, a.id, b.id] }),
+			});
+			expect(reordered.status).toBe(200);
+
+			const del = await apiFetch(`/api/projects/${a.id}`, { method: "DELETE" });
+			expect(del.status).toBe(200);
+			let visible = await listVisibleProjects();
+			expect(visible.map(project => project.id)).toEqual([c.id, b.id]);
+			expect(visible.map(project => project.position)).toEqual([0, 1]);
+
+			const d = await registerTmpProject("D");
+			visible = await listVisibleProjects();
+			expect(visible.map(project => project.id)).toEqual([c.id, b.id, d.id]);
+			expect(visible.map(project => project.position)).toEqual([0, 1, 2]);
+		} finally {
+			await clearVisibleProjects();
+		}
+	});
+});

--- a/tests/e2e/ui/project-drag-reorder.spec.ts
+++ b/tests/e2e/ui/project-drag-reorder.spec.ts
@@ -10,7 +10,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test, expect } from "../gateway-harness.js";
 import { apiFetch, createSession, deleteSession, registerProject, waitForHealth } from "../e2e-setup.js";
-import { openApp } from "./ui-helpers.js";
+import { navigateToHash, openApp } from "./ui-helpers.js";
 
 const DESKTOP = { width: 1280, height: 800 };
 const MOBILE = { width: 375, height: 667 };
@@ -44,6 +44,10 @@ function projectReorderRow(page: Page, projectId: string): Locator {
 
 function reorderMode(page: Page): Locator {
 	return page.locator('[data-project-reordering="true"]');
+}
+
+function projectReorderLiveRegion(page: Page): Locator {
+	return page.locator('[data-testid="project-reorder-live-region"][aria-live="polite"][aria-atomic="true"]');
 }
 
 function uniqueRootPath(label: string): string {
@@ -245,6 +249,29 @@ async function collapseDesktopSidebar(page: Page): Promise<void> {
 	await expect(page.locator('[data-testid="sidebar-collapsed"]')).toBeVisible({ timeout: 20_000 });
 }
 
+async function waitForRemoteAgentConnected(page: Page, sessionId: string): Promise<void> {
+	await page.waitForFunction(
+		(sid) => {
+			const appState = (window as any).__bobbitState ?? (window as any).bobbitState;
+			return appState?.selectedSessionId === sid
+				&& appState?.remoteAgent?.connected === true
+				&& appState?.connectionStatus === "connected";
+		},
+		sessionId,
+		{ timeout: 20_000 },
+	);
+}
+
+async function blockProjectListFetches(page: Page): Promise<void> {
+	await page.route("**/api/projects", async (route) => {
+		if (route.request().method() === "GET") {
+			await route.abort();
+			return;
+		}
+		await route.continue();
+	});
+}
+
 test.describe("Project drag reorder (browser E2E)", () => {
 	test.beforeEach(async () => {
 		createdProjects = [];
@@ -342,6 +369,38 @@ test.describe("Project drag reorder (browser E2E)", () => {
 		}).toEqual(expectedTitles);
 	});
 
+	test("connected second page updates from projects_changed without reload", async ({ page }) => {
+		test.setTimeout(120_000);
+		const alpha = await createProjectFixture("live-sync-alpha");
+		const beta = await createProjectFixture("live-sync-beta");
+		const gamma = await createProjectFixture("live-sync-gamma");
+
+		await openDesktop(page);
+		await waitForProjects(page, [alpha, beta, gamma]);
+		await expectRenderedOrder(page, [alpha, beta, gamma]);
+
+		const peer = await page.context().newPage();
+		try {
+			await openDesktop(peer);
+			await waitForProjects(peer, [alpha, beta, gamma]);
+			await expectRenderedOrder(peer, [alpha, beta, gamma]);
+			await navigateToHash(peer, `#/session/${alpha.sessionId}`);
+			await waitForRemoteAgentConnected(peer, alpha.sessionId);
+			await expectRenderedOrder(peer, [alpha, beta, gamma]);
+
+			// Prove the live update comes from the WebSocket broadcast, not the
+			// fallback project polling path used when no session WebSocket exists.
+			await blockProjectListFetches(peer);
+
+			await startProjectDrag(page, gamma);
+			await dropProjectOn(page, alpha, "before");
+			await expectPersistedOrder([gamma, alpha, beta]);
+			await expectRenderedOrder(peer, [gamma, alpha, beta]);
+		} finally {
+			await peer.close().catch(() => {});
+		}
+	});
+
 	test("mobile handle is always visible; pointer drag reorders with temporary collapse/restore and reload persistence", async ({ page }) => {
 		test.setTimeout(120_000);
 		const alpha = await createProjectFixture("mobile-alpha");
@@ -349,6 +408,7 @@ test.describe("Project drag reorder (browser E2E)", () => {
 		const gamma = await createProjectFixture("mobile-gamma");
 
 		await openMobile(page);
+		await expect(projectReorderLiveRegion(page), "mobile reorder UI should render a polite live region").toBeAttached({ timeout: 20_000 });
 		await waitForProjects(page, [alpha, beta, gamma]);
 		await expectRenderedOrder(page, [alpha, beta, gamma]);
 		await expectSessionContentsVisible(page, [alpha, beta, gamma]);

--- a/tests/e2e/ui/project-drag-reorder.spec.ts
+++ b/tests/e2e/ui/project-drag-reorder.spec.ts
@@ -1,0 +1,374 @@
+/**
+ * Browser E2E coverage for Project Drag Reorder.
+ *
+ * Expected command:
+ *   npm run build && npx playwright test --config playwright-e2e.config.ts --project=browser tests/e2e/ui/project-drag-reorder.spec.ts
+ */
+import type { Locator, Page } from "@playwright/test";
+import { mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test, expect } from "../gateway-harness.js";
+import { apiFetch, createSession, deleteSession, registerProject, waitForHealth } from "../e2e-setup.js";
+import { openApp } from "./ui-helpers.js";
+
+const DESKTOP = { width: 1280, height: 800 };
+const MOBILE = { width: 375, height: 667 };
+
+type ProjectFixture = {
+	id: string;
+	name: string;
+	rootPath: string;
+	sessionId: string;
+	sessionTitle: string;
+};
+
+let createdProjects: ProjectFixture[] = [];
+let projectCounter = 0;
+
+function attr(value: string): string {
+	return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function projectHeader(page: Page, projectId: string): Locator {
+	return page.locator(`[data-testid="project-header"][data-project-id="${attr(projectId)}"]`);
+}
+
+function projectHandle(page: Page, projectId: string): Locator {
+	return page.locator(`[data-testid="project-reorder-handle"][data-project-id="${attr(projectId)}"]`);
+}
+
+function projectReorderRow(page: Page, projectId: string): Locator {
+	return page.locator(`[data-project-reorder-id="${attr(projectId)}"]`);
+}
+
+function reorderMode(page: Page): Locator {
+	return page.locator('[data-project-reordering="true"]');
+}
+
+function uniqueRootPath(label: string): string {
+	const safe = label.replace(/[^a-z0-9]+/gi, "-").toLowerCase().slice(0, 24);
+	const dir = join(tmpdir(), `bobbit-e2e-drag-${process.env.E2E_PORT || "p"}-${Date.now()}-${++projectCounter}-${safe}`);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+function uniqueName(label: string): string {
+	return `drag-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+async function createProjectFixture(label: string): Promise<ProjectFixture> {
+	const name = uniqueName(label);
+	const rootPath = uniqueRootPath(name);
+	const project = await registerProject({ name, rootPath, seedWorkflows: false });
+	const sessionId = await createSession({ cwd: rootPath, projectId: project.id });
+	const sessionTitle = `session-${name}`;
+	const renameResp = await apiFetch(`/api/sessions/${sessionId}`, {
+		method: "PATCH",
+		body: JSON.stringify({ title: sessionTitle }),
+	});
+	expect(renameResp.status).toBe(200);
+	const fixture: ProjectFixture = { id: project.id, name, rootPath, sessionId, sessionTitle };
+	createdProjects.push(fixture);
+	return fixture;
+}
+
+async function resetSidebarState(page: Page): Promise<void> {
+	await page.evaluate(() => {
+		try {
+			localStorage.removeItem("bobbit-sidebar-collapsed");
+			localStorage.removeItem("bobbit-expanded-projects");
+			localStorage.removeItem("bobbit-collapsed-ungrouped");
+			localStorage.removeItem("bobbit-collapsed-staff");
+			localStorage.removeItem("bobbit-archived-collapsed-projects");
+			localStorage.setItem("bobbit-show-archived", "false");
+		} catch {}
+	});
+}
+
+async function openDesktop(page: Page): Promise<void> {
+	await page.setViewportSize(DESKTOP);
+	await openApp(page);
+	await resetSidebarState(page);
+	await page.reload();
+	await expect(page.locator("button").filter({ hasText: "Settings" }).first()).toBeVisible({ timeout: 20_000 });
+}
+
+async function openMobile(page: Page): Promise<void> {
+	await page.setViewportSize(MOBILE);
+	await openApp(page);
+	await resetSidebarState(page);
+	await page.reload();
+	await page.waitForSelector("input[data-search]", { timeout: 20_000 });
+}
+
+async function waitForProjects(page: Page, projects: ProjectFixture[]): Promise<void> {
+	for (const project of projects) {
+		await expect(projectHeader(page, project.id), `project header for ${project.name}`).toBeVisible({ timeout: 20_000 });
+		await expect(projectReorderRow(page, project.id), `reorder row for ${project.name}`).toBeAttached({ timeout: 20_000 });
+		await expect(projectHandle(page, project.id), `reorder handle for ${project.name}`).toBeAttached({ timeout: 20_000 });
+	}
+}
+
+async function handleIsVisuallyShown(handle: Locator): Promise<boolean> {
+	return handle.evaluate((el: HTMLElement) => {
+		const style = getComputedStyle(el);
+		const rect = el.getBoundingClientRect();
+		return style.display !== "none"
+			&& style.visibility !== "hidden"
+			&& Number.parseFloat(style.opacity || "1") > 0.75
+			&& rect.width > 0
+			&& rect.height > 0;
+	});
+}
+
+async function handleIsVisuallyHidden(handle: Locator): Promise<boolean> {
+	return handle.evaluate((el: HTMLElement) => {
+		const style = getComputedStyle(el);
+		const rect = el.getBoundingClientRect();
+		return style.display === "none"
+			|| style.visibility === "hidden"
+			|| Number.parseFloat(style.opacity || "1") < 0.2
+			|| rect.width === 0
+			|| rect.height === 0;
+	});
+}
+
+async function expectHandleHidden(handle: Locator, message: string): Promise<void> {
+	await expect.poll(() => handleIsVisuallyHidden(handle), { message, timeout: 5_000 }).toBe(true);
+}
+
+async function expectHandleShown(handle: Locator, message: string): Promise<void> {
+	await expect.poll(() => handleIsVisuallyShown(handle), { message, timeout: 5_000 }).toBe(true);
+}
+
+async function renderedProjectOrder(page: Page, projectIds: string[]): Promise<string[]> {
+	return page.locator("[data-project-reorder-id]").evaluateAll((els, ids) => {
+		const wanted = new Set(ids as string[]);
+		const seen = new Set<string>();
+		const order: string[] = [];
+		for (const el of els) {
+			const id = el.getAttribute("data-project-reorder-id");
+			if (!id || !wanted.has(id) || seen.has(id)) continue;
+			seen.add(id);
+			order.push(id);
+		}
+		return order;
+	}, projectIds);
+}
+
+async function apiProjectOrder(projectIds: string[]): Promise<string[]> {
+	const resp = await apiFetch("/api/projects");
+	expect(resp.status).toBe(200);
+	const body = await resp.json();
+	const projects = Array.isArray(body) ? body : body.projects || [];
+	const wanted = new Set(projectIds);
+	return projects.map((p: { id?: string }) => p.id).filter((id: string | undefined): id is string => !!id && wanted.has(id));
+}
+
+async function expectRenderedOrder(page: Page, expected: ProjectFixture[]): Promise<void> {
+	const expectedIds = expected.map(p => p.id);
+	await expect.poll(() => renderedProjectOrder(page, expectedIds), {
+		message: `rendered project order should be ${expected.map(p => p.name).join(" → ")}`,
+		timeout: 10_000,
+	}).toEqual(expectedIds);
+}
+
+async function expectPersistedOrder(expected: ProjectFixture[]): Promise<void> {
+	const expectedIds = expected.map(p => p.id);
+	await expect.poll(() => apiProjectOrder(expectedIds), {
+		message: `persisted project order should be ${expected.map(p => p.name).join(" → ")}`,
+		timeout: 10_000,
+	}).toEqual(expectedIds);
+}
+
+async function expectSessionContentsVisible(page: Page, projects: ProjectFixture[]): Promise<void> {
+	for (const project of projects) {
+		await expect(page.getByText(project.sessionTitle, { exact: true }), `session content for ${project.name}`).toBeVisible({ timeout: 10_000 });
+	}
+}
+
+async function expectSessionContentsCollapsed(page: Page, projects: ProjectFixture[]): Promise<void> {
+	for (const project of projects) {
+		await expect(page.getByText(project.sessionTitle, { exact: true }), `session content should collapse for ${project.name}`).toBeHidden({ timeout: 5_000 });
+	}
+}
+
+async function centerOf(locator: Locator): Promise<{ x: number; y: number }> {
+	await locator.scrollIntoViewIfNeeded();
+	const box = await locator.boundingBox();
+	if (!box) throw new Error("locator has no bounding box");
+	return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+}
+
+async function startProjectDrag(page: Page, project: ProjectFixture): Promise<void> {
+	const start = await centerOf(projectHandle(page, project.id));
+	await page.mouse.move(start.x, start.y);
+	await page.mouse.down();
+	await page.mouse.move(start.x, start.y + 12, { steps: 4 });
+	await expect(reorderMode(page).first(), "dragging a handle should enter temporary project reorder mode").toBeAttached({ timeout: 5_000 });
+}
+
+async function dropProjectOn(page: Page, target: ProjectFixture, placement: "before" | "after"): Promise<void> {
+	await projectReorderRow(page, target.id).scrollIntoViewIfNeeded();
+	const box = await projectReorderRow(page, target.id).boundingBox();
+	if (!box) throw new Error(`target project ${target.name} has no bounding box`);
+	const x = box.x + box.width / 2;
+	const y = placement === "before"
+		? box.y + Math.min(6, Math.max(2, box.height / 4))
+		: box.y + box.height - Math.min(6, Math.max(2, box.height / 4));
+	await page.mouse.move(x, y, { steps: 8 });
+	await page.mouse.up();
+	await expect(reorderMode(page), "drop should exit temporary project reorder mode").toHaveCount(0, { timeout: 10_000 });
+}
+
+async function cancelProjectDrag(page: Page): Promise<void> {
+	await page.keyboard.press("Escape");
+	await page.mouse.up().catch(() => {});
+	await expect(reorderMode(page), "Escape should cancel project reorder mode").toHaveCount(0, { timeout: 10_000 });
+}
+
+async function collapsedSessionTitleOrder(page: Page, sessionTitles: string[]): Promise<string[]> {
+	return page.locator('[data-testid="sidebar-collapsed"] button[title]').evaluateAll((els, titles) => {
+		const wanted = new Set(titles as string[]);
+		return els
+			.map(el => el.getAttribute("title") || "")
+			.filter(title => wanted.has(title));
+	}, sessionTitles);
+}
+
+async function collapseDesktopSidebar(page: Page): Promise<void> {
+	await page.evaluate(() => {
+		try { localStorage.setItem("bobbit-sidebar-collapsed", "true"); } catch {}
+	});
+	await page.reload();
+	await expect(page.locator('[data-testid="sidebar-collapsed"]')).toBeVisible({ timeout: 20_000 });
+}
+
+test.describe("Project drag reorder (browser E2E)", () => {
+	test.beforeEach(async () => {
+		createdProjects = [];
+		await waitForHealth();
+	});
+
+	test.afterEach(async () => {
+		for (const project of [...createdProjects].reverse()) {
+			await deleteSession(project.sessionId).catch(() => {});
+			await apiFetch(`/api/projects/${project.id}`, { method: "DELETE" }).catch(() => {});
+		}
+		createdProjects = [];
+	});
+
+	test("desktop handle is hidden until hover/focus; header and action clicks do not start reorder", async ({ page }) => {
+		test.setTimeout(120_000);
+		const alpha = await createProjectFixture("desktop-affordance-alpha");
+		const beta = await createProjectFixture("desktop-affordance-beta");
+
+		await openDesktop(page);
+		await waitForProjects(page, [alpha, beta]);
+		await expectSessionContentsVisible(page, [alpha, beta]);
+
+		const header = projectHeader(page, alpha.id);
+		const handle = projectHandle(page, alpha.id);
+
+		await page.mouse.move(900, 760);
+		await expectHandleHidden(handle, "desktop reorder handle should be visually hidden before hover/focus");
+
+		await header.hover();
+		await expectHandleShown(handle, "desktop reorder handle should show when the project header is hovered");
+
+		await page.mouse.move(900, 760);
+		await expectHandleHidden(handle, "desktop reorder handle should hide again after hover leaves");
+
+		await handle.focus();
+		await expectHandleShown(handle, "desktop reorder handle should show when focused");
+		await page.keyboard.press("Escape");
+
+		await header.getByText(alpha.name, { exact: true }).click();
+		await expect(page.getByText(alpha.sessionTitle, { exact: true }), "clicking the project header outside the handle should collapse the project").toBeHidden({ timeout: 5_000 });
+		await expect(reorderMode(page), "header click should not start reorder mode").toHaveCount(0);
+
+		await header.getByText(alpha.name, { exact: true }).click();
+		await expect(page.getByText(alpha.sessionTitle, { exact: true }), "clicking the project header again should restore expansion").toBeVisible({ timeout: 5_000 });
+
+		await header.hover();
+		await header.locator('button[title="Project settings"]').click();
+		await expect(reorderMode(page), "project settings click should not start reorder mode").toHaveCount(0);
+		await expectRenderedOrder(page, [alpha, beta]);
+
+		await header.locator('button[title^="New goal in"]').click();
+		await expect(reorderMode(page), "project new-goal click should not start reorder mode").toHaveCount(0);
+		await expectRenderedOrder(page, [alpha, beta]);
+		await page.keyboard.press("Escape");
+	});
+
+	test("desktop drag reorders, temporarily collapses contents, restores on drop/cancel, persists, and collapsed sidebar follows order", async ({ page }) => {
+		test.setTimeout(120_000);
+		const alpha = await createProjectFixture("desktop-alpha");
+		const beta = await createProjectFixture("desktop-beta");
+		const gamma = await createProjectFixture("desktop-gamma");
+
+		await openDesktop(page);
+		await waitForProjects(page, [alpha, beta, gamma]);
+		await expectRenderedOrder(page, [alpha, beta, gamma]);
+		await expectSessionContentsVisible(page, [alpha, beta, gamma]);
+
+		await startProjectDrag(page, gamma);
+		await expectSessionContentsCollapsed(page, [alpha, beta, gamma]);
+		await dropProjectOn(page, alpha, "before");
+
+		await expectRenderedOrder(page, [gamma, alpha, beta]);
+		await expectPersistedOrder([gamma, alpha, beta]);
+		await expectSessionContentsVisible(page, [alpha, beta, gamma]);
+
+		await startProjectDrag(page, alpha);
+		await expectSessionContentsCollapsed(page, [alpha, beta, gamma]);
+		await cancelProjectDrag(page);
+		await expectRenderedOrder(page, [gamma, alpha, beta]);
+		await expectPersistedOrder([gamma, alpha, beta]);
+		await expectSessionContentsVisible(page, [alpha, beta, gamma]);
+
+		await page.reload();
+		await waitForProjects(page, [alpha, beta, gamma]);
+		await expectRenderedOrder(page, [gamma, alpha, beta]);
+		await expectSessionContentsVisible(page, [alpha, beta, gamma]);
+
+		await collapseDesktopSidebar(page);
+		await expect(page.locator('[data-testid="project-reorder-handle"]'), "collapsed sidebar should not render project reorder handles").toHaveCount(0);
+		const expectedTitles = [gamma.sessionTitle, alpha.sessionTitle, beta.sessionTitle];
+		await expect.poll(() => collapsedSessionTitleOrder(page, expectedTitles), {
+			message: "collapsed sidebar should render sessions grouped in persisted project order",
+			timeout: 10_000,
+		}).toEqual(expectedTitles);
+	});
+
+	test("mobile handle is always visible; pointer drag reorders with temporary collapse/restore and reload persistence", async ({ page }) => {
+		test.setTimeout(120_000);
+		const alpha = await createProjectFixture("mobile-alpha");
+		const beta = await createProjectFixture("mobile-beta");
+		const gamma = await createProjectFixture("mobile-gamma");
+
+		await openMobile(page);
+		await waitForProjects(page, [alpha, beta, gamma]);
+		await expectRenderedOrder(page, [alpha, beta, gamma]);
+		await expectSessionContentsVisible(page, [alpha, beta, gamma]);
+
+		for (const project of [alpha, beta, gamma]) {
+			await expectHandleShown(projectHandle(page, project.id), `mobile reorder handle for ${project.name} should always be visible without hover`);
+		}
+
+		await startProjectDrag(page, gamma);
+		await expectSessionContentsCollapsed(page, [alpha, beta, gamma]);
+		await dropProjectOn(page, alpha, "before");
+
+		await expectRenderedOrder(page, [gamma, alpha, beta]);
+		await expectPersistedOrder([gamma, alpha, beta]);
+		await expectSessionContentsVisible(page, [alpha, beta, gamma]);
+
+		await page.reload();
+		await page.waitForSelector("input[data-search]", { timeout: 20_000 });
+		await waitForProjects(page, [alpha, beta, gamma]);
+		await expectRenderedOrder(page, [gamma, alpha, beta]);
+		await expectSessionContentsVisible(page, [alpha, beta, gamma]);
+	});
+});

--- a/tests/project-registry-order.test.ts
+++ b/tests/project-registry-order.test.ts
@@ -1,0 +1,212 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  ProjectOrderError,
+  ProjectRegistry,
+  SYSTEM_PROJECT_ID,
+  type RegisteredProject,
+} from "../src/server/agent/project-registry.js";
+
+function makeStateDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-project-order-state-"));
+}
+
+function cleanup(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function project(id: string, overrides: Partial<RegisteredProject> = {}): RegisteredProject {
+  return {
+    id,
+    name: id,
+    rootPath: path.join(os.tmpdir(), `bobbit-project-order-${id}`),
+    createdAt: 1_000,
+    colorLight: "#fff",
+    colorDark: "#000",
+    ...overrides,
+  };
+}
+
+function writeProjects(stateDir: string, projects: RegisteredProject[]): void {
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(path.join(stateDir, "projects.json"), JSON.stringify(projects, null, 2), "utf-8");
+}
+
+function readProjects(stateDir: string): RegisteredProject[] {
+  return JSON.parse(fs.readFileSync(path.join(stateDir, "projects.json"), "utf-8"));
+}
+
+function ids(projects: RegisteredProject[]): string[] {
+  return projects.map(p => p.id);
+}
+
+test("ProjectRegistry order migration assigns visible positions by createdAt and on-disk tie-break", () => {
+  const stateDir = makeStateDir();
+  try {
+    writeProjects(stateDir, [
+      project("late", { createdAt: 300 }),
+      project("tie-first", { createdAt: 100 }),
+      project("early", { createdAt: 50 }),
+      project("tie-second", { createdAt: 100 }),
+      project("hidden", { createdAt: 1, hidden: true, position: 99 }),
+    ]);
+
+    const registry = new ProjectRegistry(stateDir);
+    assert.deepEqual(ids(registry.list().filter(p => !p.hidden)), ["early", "tie-first", "tie-second", "late"]);
+
+    const stored = readProjects(stateDir);
+    const visible = stored.filter(p => !p.hidden);
+    assert.deepEqual(ids(visible), ["early", "tie-first", "tie-second", "late"]);
+    assert.deepEqual(visible.map(p => p.position), [0, 1, 2, 3]);
+    assert.equal(stored.find(p => p.id === "hidden")?.position, undefined);
+  } finally {
+    cleanup(stateDir);
+  }
+});
+
+test("ProjectRegistry.list respects custom positions over createdAt", () => {
+  const stateDir = makeStateDir();
+  try {
+    writeProjects(stateDir, [
+      project("oldest", { createdAt: 1, position: 2 }),
+      project("newest", { createdAt: 3, position: 0 }),
+      project("middle", { createdAt: 2, position: 1 }),
+    ]);
+
+    const registry = new ProjectRegistry(stateDir);
+    assert.deepEqual(ids(registry.list()), ["newest", "middle", "oldest"]);
+  } finally {
+    cleanup(stateDir);
+  }
+});
+
+test("ProjectRegistry.setVisibleOrder persists contiguous positions and reloads in saved order", () => {
+  const stateDir = makeStateDir();
+  try {
+    writeProjects(stateDir, [
+      project("a", { createdAt: 1, position: 0 }),
+      project("b", { createdAt: 2, position: 1 }),
+      project("c", { createdAt: 3, position: 2 }),
+    ]);
+
+    const registry = new ProjectRegistry(stateDir);
+    const saved = registry.setVisibleOrder(["c", "a", "b"]);
+    assert.deepEqual(ids(saved), ["c", "a", "b"]);
+
+    const stored = readProjects(stateDir);
+    assert.deepEqual(ids(stored), ["c", "a", "b"]);
+    assert.deepEqual(stored.map(p => p.position), [0, 1, 2]);
+
+    const reloaded = new ProjectRegistry(stateDir);
+    assert.deepEqual(ids(reloaded.list()), ["c", "a", "b"]);
+  } finally {
+    cleanup(stateDir);
+  }
+});
+
+test("ProjectRegistry register and registerProvisional append after a custom order", () => {
+  const stateDir = makeStateDir();
+  const roots: string[] = [];
+  const makeRoot = (name: string) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), `bobbit-project-order-${name}-`));
+    roots.push(root);
+    return root;
+  };
+  try {
+    writeProjects(stateDir, [
+      project("first", { rootPath: makeRoot("first"), createdAt: 1, position: 1 }),
+      project("second", { rootPath: makeRoot("second"), createdAt: 2, position: 0 }),
+    ]);
+
+    const registry = new ProjectRegistry(stateDir);
+    const third = registry.register("third", makeRoot("third"));
+    const fourth = registry.registerProvisional("fourth", makeRoot("fourth"));
+
+    assert.equal(third.position, 2);
+    assert.equal(fourth.position, 3);
+    assert.deepEqual(ids(registry.list()), ["second", "first", third.id, fourth.id]);
+  } finally {
+    for (const root of roots) fs.rmSync(root, { recursive: true, force: true });
+    cleanup(stateDir);
+  }
+});
+
+test("ProjectRegistry remove and removeProvisional preserve relative order and compact positions", () => {
+  const stateDir = makeStateDir();
+  try {
+    writeProjects(stateDir, [
+      project("a", { createdAt: 1, position: 0 }),
+      project("b", { createdAt: 2, position: 1 }),
+      project("c", { createdAt: 3, position: 2, provisional: true }),
+      project("d", { createdAt: 4, position: 3 }),
+    ]);
+
+    const registry = new ProjectRegistry(stateDir);
+    registry.remove("b");
+    assert.deepEqual(ids(registry.list()), ["a", "c", "d"]);
+    assert.deepEqual(registry.list().map(p => p.position), [0, 1, 2]);
+
+    registry.removeProvisional("c");
+    assert.deepEqual(ids(registry.list()), ["a", "d"]);
+    assert.deepEqual(registry.list().map(p => p.position), [0, 1]);
+  } finally {
+    cleanup(stateDir);
+  }
+});
+
+test("ProjectRegistry setVisibleOrder excludes hidden and system projects from validation", () => {
+  const stateDir = makeStateDir();
+  try {
+    writeProjects(stateDir, [
+      project("a", { createdAt: 1, position: 0 }),
+      project("b", { createdAt: 2, position: 1 }),
+      project("hidden", { createdAt: 3, hidden: true }),
+      project(SYSTEM_PROJECT_ID, { name: "System", createdAt: 4, hidden: true }),
+    ]);
+
+    const registry = new ProjectRegistry(stateDir);
+    assert.deepEqual(ids(registry.setVisibleOrder(["b", "a"])), ["b", "a"]);
+    assert.equal(registry.get("hidden")?.position, undefined);
+    assert.equal(registry.get(SYSTEM_PROJECT_ID)?.position, undefined);
+
+    assert.throws(
+      () => registry.setVisibleOrder(["b", "a", "hidden"]),
+      (err: unknown) => err instanceof ProjectOrderError && err.code === "invalid_project_order",
+    );
+    assert.throws(
+      () => registry.setVisibleOrder(["b", "a", SYSTEM_PROJECT_ID]),
+      (err: unknown) => err instanceof ProjectOrderError && err.code === "invalid_project_order",
+    );
+    assert.deepEqual(ids(registry.list().filter(p => !p.hidden)), ["b", "a"]);
+  } finally {
+    cleanup(stateDir);
+  }
+});
+
+test("ProjectRegistry setVisibleOrder reports stale complete-order mismatches without mutation", () => {
+  const stateDir = makeStateDir();
+  try {
+    writeProjects(stateDir, [
+      project("a", { createdAt: 1, position: 0 }),
+      project("b", { createdAt: 2, position: 1 }),
+      project("c", { createdAt: 3, position: 2 }),
+    ]);
+
+    const registry = new ProjectRegistry(stateDir);
+    assert.throws(
+      () => registry.setVisibleOrder(["a", "b"]),
+      (err: unknown) => err instanceof ProjectOrderError
+        && err.code === "stale_project_order"
+        && JSON.stringify(err.details.expectedProjectIds) === JSON.stringify(["a", "b", "c"])
+        && JSON.stringify(err.details.receivedProjectIds) === JSON.stringify(["a", "b"]),
+    );
+    assert.deepEqual(ids(registry.list()), ["a", "b", "c"]);
+    assert.deepEqual(registry.list().map(p => p.position), [0, 1, 2]);
+  } finally {
+    cleanup(stateDir);
+  }
+});


### PR DESCRIPTION
## Summary
- Add persisted server-side project ordering with migration, validation, append/delete compaction, and `PUT /api/projects/order`.
- Add desktop and mobile sidebar drag reorder UI with transient collapse/restore, keyboard support, live announcements, and cross-session sync.
- Add registry unit tests, API/browser E2E coverage, and docs for the API and sidebar behavior.

## Tests
- `npm run check`
- `npm run test:unit`
- `npm run build`
- `npx tsx --test --test-force-exit tests/project-registry-order.test.ts`
- `npx playwright test --config playwright-e2e.config.ts --project=api tests/e2e/project-reorder-api.spec.ts`
- `npx playwright test --config playwright-e2e.config.ts --project=browser tests/e2e/ui/project-drag-reorder.spec.ts`
- `npm run test:e2e`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
