### PR TITLE
Hide Ask Envelopes

### DIFF
--- a/defaults/tools/ask/ask_user_choices.yaml
+++ b/defaults/tools/ask/ask_user_choices.yaml
@@ -79,9 +79,18 @@ detail_docs: |
 
   When you see a user message starting with `[ask_user_choices_response
   tool_use_id=...]`, parse the JSON on the following line(s) to get the
-  answers. Match `tool_use_id` to the tool call you previously made. If the
-  user sends an unrelated message instead, they chose not to answer — proceed
-  without the answers (or re-ask by calling the tool again).
+  answers. Match `tool_use_id` to the tool call you previously made. It is
+  opaque and may include the safe composite delimiter `|`, for example
+  `call_abc|fc_def`; do not split, trim, or normalize it. Whitespace and
+  newlines in IDs are invalid.
+
+  This envelope is an internal transcript control message. Bobbit persists it
+  and uses it to wake the agent, but hides it from normal chat rendering and
+  shows the answered ask card instead. The parser/format single source of truth
+  is `src/shared/ask-envelope.ts`.
+
+  If the user sends an unrelated message instead, they chose not to answer —
+  proceed without the answers (or re-ask by calling the tool again).
 
   **Never emit the `[ask_user_choices_response ...]` marker yourself** — it is
   reserved for the user/UI layer.

--- a/docs/design/unified-message-ordering-reducer.md
+++ b/docs/design/unified-message-ordering-reducer.md
@@ -394,7 +394,7 @@ on the resulting `messages.map(m => ({ id: m.id, _order: m._order, role: m.role 
 | 6 | Optimistic → echo (id) | `optimistic-prompt(id=opt1)`, `live(seq=1,id=opt1,role=user)` | `[opt1@1]` (replaced, no dup) |
 | 7 | Optimistic → echo (text) | `optimistic-prompt(id=opt1,text="hi")`, `live(seq=1,id=srv1,role=user,text="hi")` | `[srv1@1]` |
 | 8 | Proposal burst | `live(seq=1,id=a1,toolUse=propose_goal)`, `live(seq=2,id=a2,toolUse=propose_role)`, `live(seq=3,id=tr1,role=toolResult)` | `[a1@1, a2@2, tr1@3]` — both widgets present, no overwrite (kills Mode A) |
-| 9 | ask_user_choices envelope routing | `live(seq=1,id=a1,toolUse=ask_user_choices,toolUseId=auc1)`, `live(seq=2,id=u1,role=user,text="[ask_user_choices_response auc1] …")` | both rows present in order; envelope-scan helper finds row 2 by `auc1` |
+| 9 | ask_user_choices envelope routing | `live(seq=1,id=a1,toolUse=ask_user_choices,toolUseId=auc1)`, `live(seq=2,id=u1,role=user,text="[ask_user_choices_response tool_use_id=auc1]\n…")` | both rows present in order; envelope-scan helper finds row 2 by `auc1` |
 | 10 | Reconnect with gap | `live(seq=1,id=u1)`, `live(seq=2,id=a1)`, `snapshot([u1,a1,u2,a2])` (live tail follows) , then `live(seq=5,id=a3)` | snapshot block at `[-1e9..-1e9+3]`, `a3@5` after; no dups |
 | 11 | Permission insert + resolve | `live(seq=1,id=u1)`, `permission-needed(seq=2,id=p1)`, `permission-resolved(p1)` | `[u1@1]` — no slice-truncation of u1 |
 | 12 | Compaction placeholder + server marker | `compaction-placeholder` → row `compacting_placeholder@hi+0.5`; then `snapshot([{id:cs1,role:assistant,text:"Context compacted from 12k tokens."}])` | single compaction row from server, synthetic dropped |
@@ -407,7 +407,7 @@ Pass criterion: byte-equal output array of `(id, _order)` pairs.
 |---|---|
 | **ST-DEDUP-02 — Proposal burst** | Mock agent emits two consecutive `propose_*` assistant turns + a toolResult. Both `<proposal-…>` widgets must render in order. Click the first → it submits; click the second → it submits. Neither is unmounted/remounted (assertion: stable `data-msg-key` between the two screenshots). |
 | **ST-DEDUP-03 — Mid-burst reconnect** | While the proposal burst is mid-stream, kill the WS. Server resumes via `seq` replay. After reconnect, the widget appears **exactly once** in the transcript (assertion: `page.locator('proposal-goal').count() === 1`). |
-| **ST-DEDUP-04 — `ask_user_choices` envelope routing** | Two `ask_user_choices` cards on screen. Click answer on card B; `[ask_user_choices_response <toolUseId-B>]` user message arrives. Card B shows answer; card A unchanged (assertion: `findAskResponseAnswers` matches card B's `toolUseId`). |
+| **ST-DEDUP-04 — `ask_user_choices` envelope routing** | Two `ask_user_choices` cards on screen. Click answer on card B; `[ask_user_choices_response tool_use_id=<toolUseId-B>]` user message arrives. Card B shows answer; card A unchanged (assertion: `findAskResponseAnswers` matches card B's `toolUseId`). |
 
 ### 10.3 Regression guard
 

--- a/docs/non-blocking-ask.md
+++ b/docs/non-blocking-ask.md
@@ -55,9 +55,13 @@ When the UI submits answers, the server appends a `role: "user"` message whose t
 {"answers":[{"question":"...","selected":"...","other_text":null}, ...]}
 ```
 
-The marker line is at position 0. The newline separates it from a JSON body with an `answers` array. For multi-select questions `selected` is an array; for single-select it's a string (including the literal `"Other"` when the user picked the free-text option, with `other_text` carrying the typed value).
+The marker line must be at position 0; if any text precedes it, the message is not an envelope. The newline separates it from a JSON body with an `answers` array. For multi-select questions `selected` is an array; for single-select it's a string (including the literal `"Other"` when the user picked the free-text option, with `other_text` carrying the typed value).
 
-The format is the single source of truth and lives in [`src/shared/ask-envelope.ts`](../src/shared/ask-envelope.ts), shared between server and UI:
+`tool_use_id` is an opaque exact-match value. It may be a simple ID such as `tool-abc_123` or a composite live-tool ID using the safe `|` delimiter, for example `call_abc|fc_def`. The canonical safe charset is letters, digits, `_`, `-`, and `|`; whitespace and newlines in IDs are invalid. Consumers should never split, trim, or normalize the ID before matching.
+
+The envelope is an internal transcript control message. It is persisted as a regular user message and enqueued through the normal prompt path so it wakes the agent and survives restarts, but normal chat rendering hides it. The answered ask card is the human-readable representation.
+
+The parser/formatter and accepted ID charset are the single source of truth and live in [`src/shared/ask-envelope.ts`](../src/shared/ask-envelope.ts), shared between server and UI:
 
 - `ASK_ENVELOPE_REGEX` — full match, captures `tool_use_id` and JSON body.
 - `ASK_ENVELOPE_PREFIX_REGEX` — cheap prefix test (used by the render filter).
@@ -81,12 +85,13 @@ without appending a second envelope. This handles two realistic cases:
 
 ## Prompt-injection guard
 
-The envelope format is reserved for the user/UI layer. Two guards prevent an agent from spoofing an answer:
+The envelope format is reserved for the user/UI layer. Three guards prevent an agent from spoofing an answer:
 
 1. **Role check.** `isAskResponseEnvelope` and `findAskResponseAnswers` in `ask-envelope.ts` only accept messages whose role is `user` or `user-with-attachments`. An assistant message whose text happens to contain the marker is ignored.
-2. **Causality check.** `findAskResponseAnswers` first locates the `ask_user_choices` tool_use block matching the `tool_use_id`. An envelope without a preceding tool_use with that id is rejected. This prevents a transcript-only attack where an earlier message claims to answer a question that was never asked.
+2. **Shape check.** The parser requires the marker at position 0, a newline, a JSON body, and an ID from the canonical safe charset. Composite IDs with `|` are accepted; whitespace and newlines are not.
+3. **Causality check.** `findAskResponseAnswers` first locates the `ask_user_choices` tool_use block matching the `tool_use_id`. An envelope without a preceding tool_use with that id is rejected. This prevents a transcript-only attack where an earlier message claims to answer a question that was never asked.
 
-The tool documentation (`defaults/tools/ask/ask_user_choices.yaml`) also instructs the LLM never to emit the marker itself. Combined with the role gate this makes spoofing a non-issue.
+The tool documentation (`defaults/tools/ask/ask_user_choices.yaml`) also instructs the LLM never to emit the marker itself. Combined with these guards this makes spoofing a non-issue.
 
 ## Multi-tab behavior
 
@@ -156,7 +161,7 @@ The `tab_label` validation rules themselves are documented in `defaults/tools/as
 
 ## Rendering note
 
-Envelope user messages are hidden from the **rendered** transcript by `src/ui/components/AgentInterface.ts` (via `isAskResponseEnvelope`). They're still present in the `.jsonl` and still sent to the LLM — the agent sees them on its next turn as part of history. The UI omits them because the answered widget card is the human-readable representation; showing both would be redundant.
+Envelope user messages are internal transcript control messages hidden from the **rendered** transcript by `src/ui/components/AgentInterface.ts` (via `isAskResponseEnvelope`). They must remain in the `.jsonl` and the LLM history — persistence preserves answered state across reloads, and enqueueing the user message wakes the agent. The UI omits them because the answered widget card is the human-readable representation; showing both would be redundant.
 
 ## File map
 

--- a/src/shared/ask-envelope.ts
+++ b/src/shared/ask-envelope.ts
@@ -24,15 +24,21 @@ export interface AskResponseAnswer {
 	other_text: string | null;
 }
 
+/** Canonical safe character set for envelope tool_use_id values.
+ *  Allows simple IDs plus the composite delimiter (`|`) used by live tool calls. */
+export const ASK_TOOL_USE_ID_PATTERN = "[A-Za-z0-9_|-]+";
+
 /** Regex that matches a well-formed envelope message text.
  *  Group 1 = tool_use_id; group 2 = JSON body (everything after the first newline). */
-export const ASK_ENVELOPE_REGEX =
-	/^\[ask_user_choices_response tool_use_id=([A-Za-z0-9_-]+)\]\n([\s\S]+)$/;
+export const ASK_ENVELOPE_REGEX = new RegExp(
+	`^\\[ask_user_choices_response tool_use_id=(${ASK_TOOL_USE_ID_PATTERN})\\]\\n([\\s\\S]+)$`,
+);
 
 /** Cheap prefix test — true for any text starting with the marker line (used by
  *  the transcript render-layer filter where we don't need to parse the body). */
-export const ASK_ENVELOPE_PREFIX_REGEX =
-	/^\[ask_user_choices_response tool_use_id=[A-Za-z0-9_-]+\]\n/;
+export const ASK_ENVELOPE_PREFIX_REGEX = new RegExp(
+	`^\\[ask_user_choices_response tool_use_id=${ASK_TOOL_USE_ID_PATTERN}\\]\\n`,
+);
 
 /** Build an envelope message body from a tool_use_id and answers. */
 export function buildAskResponseEnvelope(

--- a/tests/ask-envelope.test.ts
+++ b/tests/ask-envelope.test.ts
@@ -11,6 +11,8 @@ import {
 	parseAskResponseEnvelope,
 } from "../src/shared/ask-envelope.ts";
 
+const COMPOSITE_TOOL_USE_ID = "call_abc|fc_def";
+
 describe("ask-envelope — regex", () => {
 	it("matches a well-formed envelope", () => {
 		const text = `[ask_user_choices_response tool_use_id=toolu_abc123]\n{"answers":[]}`;
@@ -46,6 +48,14 @@ describe("ask-envelope — regex", () => {
 		assert.ok(m);
 		assert.equal(m![1], "tool-abc_123");
 	});
+
+	it("accepts composite ids with a pipe delimiter", () => {
+		const text = `[ask_user_choices_response tool_use_id=${COMPOSITE_TOOL_USE_ID}]\n{"answers":[]}`;
+		const m = ASK_ENVELOPE_REGEX.exec(text);
+		assert.ok(m, `composite ask envelope regex should accept tool_use_id=${COMPOSITE_TOOL_USE_ID}`);
+		assert.equal(m![1], COMPOSITE_TOOL_USE_ID);
+		assert.equal(m![2], `{"answers":[]}`);
+	});
 });
 
 describe("ask-envelope — build/parse round-trip", () => {
@@ -74,6 +84,15 @@ describe("ask-envelope — build/parse round-trip", () => {
 	it("parse rejects malformed answer entries", () => {
 		const text = `[ask_user_choices_response tool_use_id=t1]\n${JSON.stringify({ answers: [{ question: "x", selected: 42, other_text: null }] })}`;
 		assert.equal(parseAskResponseEnvelope(text), null);
+	});
+
+	it("parses composite ids with a pipe delimiter", () => {
+		const answers = [{ question: "Q", selected: "A", other_text: null }];
+		const text = buildAskResponseEnvelope(COMPOSITE_TOOL_USE_ID, answers);
+		const parsed = parseAskResponseEnvelope(text);
+		assert.ok(parsed, `parseAskResponseEnvelope should accept composite tool_use_id=${COMPOSITE_TOOL_USE_ID}`);
+		assert.equal(parsed!.toolUseId, COMPOSITE_TOOL_USE_ID);
+		assert.deepEqual(parsed!.answers, answers);
 	});
 });
 
@@ -106,6 +125,15 @@ describe("ask-envelope — isAskResponseEnvelope", () => {
 	it("false when marker is present but not at position 0", () => {
 		const msg = { role: "user", content: `prefix\n[ask_user_choices_response tool_use_id=t1]\n{"answers":[]}` };
 		assert.equal(isAskResponseEnvelope(msg), false);
+	});
+
+	it("true for composite-id user envelope text", () => {
+		const msg = { role: "user", content: buildAskResponseEnvelope(COMPOSITE_TOOL_USE_ID, []) };
+		assert.equal(
+			isAskResponseEnvelope(msg),
+			true,
+			`isAskResponseEnvelope should hide composite ask response envelope for tool_use_id=${COMPOSITE_TOOL_USE_ID}`,
+		);
 	});
 });
 
@@ -174,5 +202,21 @@ describe("ask-envelope — findAskResponseAnswers", () => {
 			{ role: "user", content: buildAskResponseEnvelope("t1", answers) },
 		];
 		assert.deepEqual(findAskResponseAnswers(messages, "t1"), answers);
+	});
+
+	it("routes answers for a matching composite tool_use id", () => {
+		const answers = [{ question: "Q", selected: "A", other_text: null }];
+		const messages = [
+			{
+				role: "assistant",
+				content: [{ type: "toolCall", id: COMPOSITE_TOOL_USE_ID, name: "ask_user_choices", input: { questions: [] } }],
+			},
+			{ role: "user", content: buildAskResponseEnvelope(COMPOSITE_TOOL_USE_ID, answers) },
+		];
+		assert.deepEqual(
+			findAskResponseAnswers(messages, COMPOSITE_TOOL_USE_ID),
+			answers,
+			`findAskResponseAnswers should route answers for composite tool_use_id=${COMPOSITE_TOOL_USE_ID}`,
+		);
 	});
 });

--- a/tests/ask-envelope.test.ts
+++ b/tests/ask-envelope.test.ts
@@ -4,6 +4,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
+	ASK_ENVELOPE_PREFIX_REGEX,
 	ASK_ENVELOPE_REGEX,
 	buildAskResponseEnvelope,
 	findAskResponseAnswers,
@@ -42,6 +43,11 @@ describe("ask-envelope — regex", () => {
 		assert.equal(ASK_ENVELOPE_REGEX.exec(text), null);
 	});
 
+	it("rejects bad charset in id (newlines)", () => {
+		const text = `[ask_user_choices_response tool_use_id=abc\ndef]\n{"answers":[]}`;
+		assert.equal(ASK_ENVELOPE_REGEX.exec(text), null);
+	});
+
 	it("accepts ids with letters, digits, underscore, hyphen", () => {
 		const text = `[ask_user_choices_response tool_use_id=tool-abc_123]\n{"answers":[]}`;
 		const m = ASK_ENVELOPE_REGEX.exec(text);
@@ -55,6 +61,27 @@ describe("ask-envelope — regex", () => {
 		assert.ok(m, `composite ask envelope regex should accept tool_use_id=${COMPOSITE_TOOL_USE_ID}`);
 		assert.equal(m![1], COMPOSITE_TOOL_USE_ID);
 		assert.equal(m![2], `{"answers":[]}`);
+	});
+});
+
+describe("ask-envelope — prefix regex", () => {
+	it("accepts composite ids with a pipe delimiter", () => {
+		const text = `[ask_user_choices_response tool_use_id=${COMPOSITE_TOOL_USE_ID}]\n{"answers":[]}`;
+		assert.equal(
+			ASK_ENVELOPE_PREFIX_REGEX.test(text),
+			true,
+			`prefix detection should accept composite ask response envelope for tool_use_id=${COMPOSITE_TOOL_USE_ID}`,
+		);
+	});
+
+	it("rejects unsafe whitespace in ids", () => {
+		const text = `[ask_user_choices_response tool_use_id=abc def]\n{"answers":[]}`;
+		assert.equal(ASK_ENVELOPE_PREFIX_REGEX.test(text), false);
+	});
+
+	it("rejects marker not at position 0", () => {
+		const text = `prefix [ask_user_choices_response tool_use_id=${COMPOSITE_TOOL_USE_ID}]\n{"answers":[]}`;
+		assert.equal(ASK_ENVELOPE_PREFIX_REGEX.test(text), false);
 	});
 });
 

--- a/tests/e2e/ask-user-choices.spec.ts
+++ b/tests/e2e/ask-user-choices.spec.ts
@@ -11,7 +11,8 @@
  *  1. Happy path: /submit appends the envelope; the mock agent wakes and
  *     echoes the answers as an assistant message.
  *  2. Idempotency: a second /submit for the same toolUseId returns
- *     `{ ok: true, alreadySubmitted: true }` and does not append again.
+ *     `{ ok: true, alreadySubmitted: true }` and does not append again,
+ *     including transcript-fallback detection for composite tool IDs.
  *  3. 404 when no matching tool_use is in the transcript.
  *  4. 400 on malformed answers.
  *  5. Legacy `POST /api/internal/user-question` endpoint is gone (404).
@@ -171,6 +172,64 @@ test.describe("ask_user_choices end-to-end via mock agent", () => {
 				expect(first.status).toBe(200);
 				expect(await first.json()).toEqual({ ok: true });
 
+				const second = await postSubmit(sessionId, toolUseId, answers);
+				expect(second.status).toBe(200);
+				expect(await second.json()).toEqual({ ok: true, alreadySubmitted: true });
+			} finally {
+				conn.close();
+			}
+		} finally {
+			await deleteSession(sessionId);
+		}
+	});
+
+	test("composite toolUseId transcript-fallback idempotency returns alreadySubmitted:true", async () => {
+		const sessionId = await createSession();
+		try {
+			const conn = await connectWs(sessionId);
+			try {
+				conn.send({ type: "prompt", text: "please use ask_user_choices_composite" });
+				await conn.waitFor(toolStartPredicate("ask_user_choices"), 10_000);
+				const stubResult = await conn.waitFor(
+					(m) => messageEndPredicate("toolResult")(m)
+						&& m.data?.message?.toolName === "ask_user_choices",
+					10_000,
+				);
+				const toolUseId = JSON.parse(stubResult.data.message.content[0].text).tool_use_id as string;
+				expect(toolUseId).toContain("|");
+
+				await conn.waitFor(
+					(m) => m.type === "session_status" && (m as any).status === "idle",
+					10_000,
+				);
+
+				const answers = [
+					{ question: "Favorite color?", selected: "green", other_text: null },
+					{ question: "Team size?", selected: "medium", other_text: null },
+				];
+				const envelope = `[ask_user_choices_response tool_use_id=${toolUseId}]\n${JSON.stringify({ answers })}`;
+				conn.send({ type: "prompt", text: envelope });
+
+				// The mock parser must also accept the composite id and echo it back.
+				const echo = await conn.waitFor(
+					(m) => {
+						if (!messageEndPredicate("assistant")(m)) return false;
+						const blocks = m.data?.message?.content || [];
+						const text = blocks.find((b: any) => b.type === "text")?.text || "";
+						return text.includes("gotAnswersFor") && text.includes(toolUseId);
+					},
+					10_000,
+				);
+				const echoText = echo.data?.message?.content?.find((b: any) => b.type === "text")?.text || "";
+				expect(JSON.parse(echoText).gotAnswersFor).toBe(toolUseId);
+
+				await conn.waitFor(
+					(m) => m.type === "session_status" && (m as any).status === "idle",
+					10_000,
+				);
+
+				// This submit has no in-memory dedup flag, so it must be caught by
+				// findAskResponseAnswers scanning the transcript envelope above.
 				const second = await postSubmit(sessionId, toolUseId, answers);
 				expect(second.status).toBe(200);
 				expect(await second.json()).toEqual({ ok: true, alreadySubmitted: true });

--- a/tests/e2e/mock-agent-core.mjs
+++ b/tests/e2e/mock-agent-core.mjs
@@ -61,6 +61,7 @@
  * UI primitives
  * -------------
  *  ask_user_choices         Single-select widget.
+ *  ask_user_choices_composite Single-select widget with composite tool_use_id.
  *  ask_user_choices_multi   Multi-select widget.
  *
  * Steer (RPC, not a prompt-text trigger)
@@ -90,6 +91,14 @@ import fs from "node:fs";
 import path from "node:path";
 import http from "node:http";
 import { execSync } from "node:child_process";
+
+// Keep explicitly aligned with src/shared/ask-envelope.ts. This file is .mjs
+// and is used directly by E2E mock-agent processes, so it cannot import the TS
+// shared module without extra loader wiring.
+const ASK_TOOL_USE_ID_PATTERN = "[A-Za-z0-9_|-]+";
+const ASK_RESPONSE_ENVELOPE_REGEX = new RegExp(
+	`^\\[ask_user_choices_response tool_use_id=(${ASK_TOOL_USE_ID_PATTERN})\\]\\n([\\s\\S]+)$`,
+);
 
 /**
  * @typedef {Object} MockAgentOptions
@@ -431,6 +440,9 @@ export class MockAgentCore {
 		if (lower.includes("ask_user_choices_multi")) {
 			return { askUserChoices: "multi" };
 		}
+		if (lower.includes("ask_user_choices_composite") || lower.includes("ask user choices composite")) {
+			return { askUserChoices: "composite" };
+		}
 		if (lower.includes("ask_user_choices") || lower.includes("ask user choices")) {
 			// Signals the mock agent to emit a non-blocking ask_user_choices tool_use.
 			// The tool returns {status:"posted", tool_use_id} synchronously; answers arrive
@@ -567,7 +579,10 @@ export class MockAgentCore {
 			if (toolAction.askUserChoices === "errorThenRetry") {
 				await this._handleAskUserChoicesErrorThenRetry();
 			} else {
-				await this._handleAskUserChoices(toolAction.askUserChoices === "multi");
+				await this._handleAskUserChoices(
+					toolAction.askUserChoices === "multi",
+					{ compositeId: toolAction.askUserChoices === "composite" },
+				);
 			}
 		} else if (toolAction && toolAction.liveUpdateProposal) {
 			await this._handleLiveUpdateProposal();
@@ -1101,12 +1116,14 @@ export class MockAgentCore {
 		}
 	}
 
-	async _handleAskUserChoices(multi = false) {
+	async _handleAskUserChoices(multi = false, { compositeId = false } = {}) {
 		// Non-blocking model: the ask_user_choices tool returns immediately with
 		// a `{status:"posted", tool_use_id}` stub and the turn ends. The user's
 		// answers arrive in a *later* prompt as an envelope user message — see
 		// `_handleAskResponseEnvelope` below.
-		const toolId = `tool_ask_${Date.now()}`;
+		const toolId = compositeId
+			? `tool_ask_${Date.now()}|fc_${Math.random().toString(36).slice(2, 8)}`
+			: `tool_ask_${Date.now()}`;
 
 		const questions = multi
 			? [
@@ -1230,7 +1247,7 @@ export class MockAgentCore {
 	 * text message so E2E tests can observe the round-trip.
 	 */
 	async _handleAskResponseEnvelope(text) {
-		const m = /^\[ask_user_choices_response tool_use_id=([A-Za-z0-9_-]+)\]\n([\s\S]+)$/.exec(text);
+		const m = ASK_RESPONSE_ENVELOPE_REGEX.exec(text);
 		if (!m) return;
 		const toolUseId = m[1];
 		let answers = null;

--- a/tests/e2e/ui/ask-user-choices-ui.spec.ts
+++ b/tests/e2e/ui/ask-user-choices-ui.spec.ts
@@ -16,17 +16,21 @@ import { test, expect } from "./fixtures.js";
 import { openApp, createSessionViaUI, sendMessage } from "./ui-helpers.js";
 
 test.describe("ask_user_choices widget (full-stack UI)", () => {
-	test("happy path — pick answers, submit, widget flips to read-only", async ({ page, rec }) => {
+	test("happy path — pick answers, submit, composite-id widget flips to read-only", async ({ page, rec }) => {
 		await openApp(page);
 		await createSessionViaUI(page);
 		await rec.capture("Empty session ready");
 
-		// Trigger the mock agent's ask_user_choices branch.
-		await sendMessage(page, "please use ask_user_choices");
+		// Trigger the mock agent's ask_user_choices branch with a composite tool_use_id.
+		await sendMessage(page, "please use ask_user_choices_composite");
 
 		// Widget appears.
 		const widget = page.locator("ask-user-choices-widget").first();
 		await expect(widget).toBeVisible({ timeout: 20_000 });
+		await expect.poll(
+			() => widget.evaluate((el) => (el as any).toolUseId as string),
+			{ timeout: 10_000 },
+		).toContain("|");
 		await rec.capture("Widget rendered");
 
 		// Two tabs.
@@ -62,6 +66,7 @@ test.describe("ask_user_choices widget (full-stack UI)", () => {
 		// Click Submit — widget should go read-only (no Submit button).
 		await submit.click();
 		await expect(widget.locator(".ask-submit")).toHaveCount(0, { timeout: 10_000 });
+		await expect(page.locator("user-message").filter({ hasText: "ask_user_choices_response" })).toHaveCount(0);
 		await rec.capture("Submitted — widget read-only");
 
 		// Radio inputs are disabled in read-only mode.


### PR DESCRIPTION
## Summary
- Accept composite `ask_user_choices` response envelope IDs containing `|` in the shared parser/filter.
- Keep envelopes hidden from chat rendering while preserving transcript persistence and answered-card routing.
- Add unit, API, UI, mock-agent, and docs coverage for composite IDs and safety guards.

## Verification
- `npm run check`
- `npm run test:unit`
- `npx playwright test --config playwright-e2e.config.ts --project=api tests/e2e/ask-user-choices.spec.ts`
- `npx playwright test --config playwright-e2e.config.ts --project=browser tests/e2e/ui/ask-user-choices-ui.spec.ts -g "composite-id widget"`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
