### PR TITLE
Fix Compact Cost

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -5,9 +5,9 @@ window, Bobbit can fold older turns into a shorter summary — *compaction*.
 The transcript keeps moving forward, the user keeps their conversation
 history in the UI, and the agent stops bleeding tokens on every turn.
 
-This page documents the **client-facing** surface: the two triggers, the
+This page documents the **client-facing** surface: the three triggers, the
 rich summary card that appears in the transcript, how it round-trips across
-navigation and reload, and the two test entrypoints. Server-side mechanics
+navigation and reload, and the test entrypoints. Server-side mechanics
 (how the agent subprocess actually compacts, refresh-after-compaction RPC)
 live in [internals.md](internals.md).
 
@@ -148,6 +148,22 @@ refresh has not landed yet, `tokensAfter` stays `null` and the card shows
 fill on the usage bar a moment later. A follow-up amend-action could
 back-fill the field, but v1 accepts the null and keeps the reducer simple.
 
+## Cost display after compaction
+
+Compaction changes the visible transcript, not the cumulative session spend.
+After a compacted snapshot lands, the remaining assistant messages may carry
+only the post-compaction visible usage. Bobbit therefore treats persisted
+`CostTracker` data as the authoritative cost display source when present.
+
+`SessionManager.refreshAfterCompaction()` broadcasts the cumulative
+`cost_update` before the compacted `messages` snapshot, then sends a `state`
+frame with `serverCost` merged in. This ordering primes the client before the
+reduced transcript replaces the old one, so the footer and context popover do
+not fall back to a lower visible-message sum.
+
+Full source-of-truth, hydration, and regression-test details live in
+[session-cost.md](session-cost.md).
+
 ## Round-tripping across navigation and reload
 
 Compaction events are persisted server-side in a per-session sidecar
@@ -247,6 +263,7 @@ npm run test:manual
 | Helper unit tests | `tests/compaction-types.test.ts` — `parseOverflowTokenCount`, in-progress builder, stable id |
 | Reducer unit tests | `tests/message-reducer.test.ts` — cases 12, 12b, 12c, 12d, 12e |
 | Browser E2E (renderer lifecycle, file:// harness) | `tests/e2e/ui/compaction-widget.spec.ts`, `tests/fixtures/compaction-widget.html` |
+| Compact-cost regression | `tests/e2e/compact-cost-ws.spec.ts`, `tests/e2e/ui/compact-cost.spec.ts`, `tests/context-cost-stats.spec.ts` |
 | Real-LLM e2e | `tests/compaction.spec.ts`, `tests/playwright-e2e.config.ts` |
 | Manual-integration pressure test | `tests/manual-integration/compaction-pressure.spec.ts` |
 | Full design rationale | `docs/design/compaction-e2e-rich-summary.md` |

--- a/docs/features.md
+++ b/docs/features.md
@@ -61,8 +61,11 @@ Slash-command skills discovered from Claude Code-compatible `SKILL.md` files.
 Per-session token usage and cost tracking, aggregated to goal and task level.
 
 - Tracks input tokens, output tokens, cache read/write tokens, and total cost.
-- Updated via `cost_update` WebSocket events broadcast to connected clients.
+- Persists cumulative session totals through `CostTracker`; this is the authoritative display source when present.
+- Hydrates clients via `cost_update` WebSocket events and `state.serverCost`, including reconnect and post-compaction refresh paths.
 - Query via `GET /api/sessions/:id/cost`, `GET /api/goals/:id/cost`, or `GET /api/tasks/:id/cost`.
+
+See [session-cost.md](session-cost.md) for source-of-truth, hydration, and compaction behavior.
 
 ## Prompt Queue
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -76,8 +76,8 @@ Each registered project is a self-contained unit on disk. State (goals, sessions
     team-state.json # Team state
     gates.json     # Gate state and signals
     staff.json     # Staff agents
-    search.flex/   # Lexical search index for THIS project (FlexSearch JSON)
-    costs/         # Cost tracking
+    search.flex/       # Lexical search index for THIS project (FlexSearch JSON)
+    session-costs.json # Cost tracking (see session-cost.md)
 
 <server-cwd>/.bobbit/
   state/
@@ -2640,7 +2640,7 @@ Each registered project has its own state directory. All store data is scoped to
 | `team-state.json` | `TeamStore` | Team agents/roles |
 | `staff.json` | `StaffStore` | Staff agents |
 | `search.flex/` | `SearchService` | FlexSearch index (JSON files under `index/` plus `meta.json`). See [Semantic search](#semantic-search). |
-| `costs/` | `CostTracker` | Token/cost data |
+| `session-costs.json` | `CostTracker` | Token/cost data. See [Session cost display](session-cost.md). |
 | `mcp-tool-docs/` | `McpManager` | Auto-generated MCP tool docs + summary caches |
 
 ### `<server-cwd>/.bobbit/state/` - global, gitignored

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -41,7 +41,8 @@ Client call sites use the shared helpers `errorFromResponse(res, fallback)` and 
 | `GET` | `/api/sessions/:id/output` | Get final assistant output from the last turn |
 | `GET` | `/api/sessions/:id/git-status` | Git status for session's working directory (branch, ahead/behind, dirty files) |
 | `GET` | `/api/sessions/:id/pr-status` | PR status for session's branch (via `gh pr view`) |
-| `GET` | `/api/sessions/:id/cost` | Token usage and cost for a single session |
+| `GET` | `/api/sessions/:id/cost` | Persisted cumulative token usage and cost for a single session. Returns 404 when no cost record exists. See [session-cost.md](session-cost.md). |
+| `GET` | `/api/sessions/:id/cost/breakdown` | Session cost plus delegate-session breakdown, used by the session cost popover |
 | `GET` | `/api/sessions/:id/tool-content/:messageIndex/:blockIndex` | Lazy-load full tool input content for a truncated block (see [Large content truncation](#large-content-truncation)) |
 | `GET` | `/api/sessions/:id/transcript` | Paginated, regex-filterable transcript reader. Backs the `read_session` tool. Query params: `offset` (negative = from end), `limit` (default 20, clamped 1..200), `pattern`, `case_sensitive`, `context` (±5 max), `verbose`. Same-project authorization via the `x-bobbit-session-id` request header. Errors: `session_not_found` (404), `transcript_unavailable` (404), `invalid_regex` / `invalid_params` (400), `permission_denied` (403). Pure parser lives in `src/server/agent/transcript-reader.ts`. |
 | `GET` | `/api/sessions/:id/transcript/before-compaction` | Paginated read of the orphaned pre-compaction entries for a single compaction event. Query params: `compactionId` (required, sidecar entry id), `cursor` (from previous response's `nextCursor`), `limit` (default 50, clamped 1..200). Response envelope `{ total, returned, nextCursor, messages[] }`. Same-project authorization via the `x-bobbit-session-id` header. Errors: `session_not_found` (404), `transcript_unavailable` (404), `compaction_not_found` (404), `invalid_params` (400), `permission_denied` (403). Branch-split via the sidecar's `firstKeptEntryId`; legacy fallback scans the JSONL for an inline `type:"compaction"` marker. Reader: `readOrphanedBeforeCompaction` in `src/server/agent/transcript-reader.ts`. See [docs/compaction-history.md](compaction-history.md). |
@@ -128,6 +129,7 @@ Per-session review annotations are stored server-side so they survive browser cl
 | `GET` | `/api/goals/:id/commits` | Commit history for goal branch (excludes primary branch commits) |
 | `GET` | `/api/goals/:id/git-status` | Git status for goal worktree (branch, ahead/behind primary, clean) |
 | `GET` | `/api/goals/:id/cost` | Aggregate cost across all sessions linked to a goal |
+| `GET` | `/api/goals/:id/cost/breakdown` | Goal aggregate plus per-session breakdown, used by the goal cost popover |
 | `GET` | `/api/goals/:id/pr-status` | PR status for goal branch (cached, via `gh pr view`) |
 | `POST` | `/api/goals/:id/pr-merge` | Merge PR for goal branch (`{ method? }`) |
 

--- a/docs/session-cost.md
+++ b/docs/session-cost.md
@@ -1,0 +1,90 @@
+# Session cost display
+
+Bobbit tracks model spend per session so the footer, stats popovers, and goal/task cost views can show cumulative usage across long-running work. The important constraint is that the chat transcript is not a reliable cost ledger: compaction can replace a long visible history with a short post-compaction snapshot, while the money already spent remains real.
+
+## Source of truth
+
+`CostTracker` is the authoritative display source when a session has persisted cost data. It is scoped to the session's project and persists cumulative totals in the project's state directory as `session-costs.json`.
+
+A session cost snapshot contains:
+
+```ts
+{
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  totalCost: number;
+}
+```
+
+The client stores this snapshot as `state.serverCost`. When `state.serverCost.totalCost` is present and greater than zero, the footer cost and the context popover's **Session → Total cost** row use it. Visible assistant-message `usage.cost.total` is not used as a fallback for the dollar display, because visible messages may be only the compacted tail of the session.
+
+Sessions without persisted cost keep `serverCost` absent/null and show no footer cost. Bobbit intentionally does not fabricate a zero-cost server snapshot, because "no cost has been recorded" is different from "the authoritative cost is exactly zero".
+
+## Recording vs hydration
+
+There are two separate operations:
+
+- **Recording** mutates `CostTracker`. `SessionManager.trackCostFromEvent()` records only completed assistant turns: `message_end` events with `role: "assistant"` and a numeric usage cost. Streaming `message_update` frames are ignored because the same usage object can appear repeatedly while a message streams.
+- **Hydration** reads `CostTracker` and sends the existing cumulative snapshot to clients. Hydration never calls `recordUsage()`.
+
+This separation prevents double-counting when Bobbit restores a session, replays buffered events, sends a message snapshot, merges synthetic compaction-summary rows, or reconnects a client. Only a new live completed assistant turn adds to the persisted total; every attach/reconnect/refresh path just re-sends the cumulative value already on disk.
+
+## WebSocket hydration paths
+
+The WebSocket protocol hydrates persisted cost through both a dedicated `cost_update` frame and `state.serverCost` when a `state` snapshot is sent. Both carry the same cumulative snapshot from `CostTracker`.
+
+Hydration happens on these paths:
+
+- **Active attach / reconnect** — after `auth_ok`, the server sends `cost_update` when persisted cost exists. The async live `getState()` push and persisted fallback state are also wrapped with `serverCost`.
+- **`get_state`** — sends `cost_update` first, then a `state` frame with `serverCost` merged into the agent state or persisted fallback state.
+- **`get_messages`** — sends `cost_update` before the message snapshot, for both live and archived sessions.
+- **`resume` fallback** — sends `cost_update` before replaying buffered events or returning `resume_gap`. If the client falls back to `get_messages`, that request sends the cost again before the snapshot.
+- **Archived sessions** — initial archived attach, archived `get_state`, and archived `get_messages` all hydrate cost. Archived `state` uses the same helper that injects persisted model/image-model data, so the initial connect and later `get_state` response stay in sync.
+- **Preparing/starting sessions** — safe read-only responses for `get_state`/`get_messages` still hydrate cost if a persisted record exists.
+- **`refreshAfterCompaction()`** — broadcasts `cost_update` before the compacted `messages` snapshot, then broadcasts `state` with `serverCost` merged in.
+
+`SessionManager.getSessionCost()` resolves cost from the live session's project first, then persisted session metadata, then a cross-project scan when needed. It returns `undefined` if no persisted record exists.
+
+## Compaction ordering
+
+Compaction is the path that made visible-message cost unsafe. After compaction, the agent's `getMessages()` response may include only the summary/tail and the next visible assistant turn. If the UI summed only those rows, the footer could appear to drop even though the cumulative spend did not.
+
+`refreshAfterCompaction()` therefore sends frames in this order:
+
+1. `cost_update` with the persisted cumulative session cost.
+2. `messages` with the compacted transcript snapshot.
+3. `state` with `serverCost` merged into the agent state.
+
+The first frame primes `RemoteAgent.state.serverCost` before the reduced transcript lands, so the footer and stats popover never need to fall back to the compacted visible-message sum.
+
+## UI and REST surfaces
+
+- `RemoteAgent` writes `state.serverCost` from either `cost_update` frames or `state.serverCost`.
+- `AgentInterface.renderStats()` uses `state.serverCost.totalCost` for the footer and context popover total cost row.
+- `<cost-popover>` fetches authoritative persisted data from `/api/sessions/:id/cost/breakdown` for session breakdowns and `/api/goals/:id/cost/breakdown` for goal breakdowns.
+- `/api/sessions/:id/cost` returns the same persisted session total used for hydration. It returns 404 when the session exists but has no cost record.
+- Goal and task cost APIs continue to aggregate from `CostTracker`; this fix does not change their accounting semantics.
+
+## Regression coverage
+
+Relevant tests pin the behavior:
+
+- `tests/context-cost-stats.spec.ts` — fixture-level UI coverage that visible-message cost alone is hidden, and `serverCost` wins in the footer and session stats popover.
+- `tests/e2e/compact-cost-ws.spec.ts` — WebSocket/API coverage for active attach, `get_state`, resume fallback, archived attach/state, no-cost sessions, and `refreshAfterCompaction()` cost-before-messages ordering.
+- `tests/e2e/ui/compact-cost.spec.ts` — browser regression that seeds persisted cumulative cost, shrinks the visible transcript with a compaction-like refresh, and verifies the footer, context popover, and session cost API agree.
+- `tests/cost-tracker.test.ts` — persistence and accumulation coverage for `CostTracker` itself.
+
+## Implementation map
+
+| Concern | Primary module |
+| --- | --- |
+| Persist cumulative session cost | `src/server/agent/cost-tracker.ts` |
+| Record live completed assistant usage | `src/server/agent/session-manager.ts` (`trackCostFromEvent`) |
+| Resolve and inject persisted cost | `src/server/agent/session-manager.ts` (`getSessionCost`, `withSessionCostInState`, `getSessionCostUpdate`) |
+| WS hydration and archived state | `src/server/ws/handler.ts` |
+| Client cost state | `src/app/remote-agent.ts` |
+| Footer and context popover display | `src/ui/components/AgentInterface.ts` |
+| Session/goal cost popover | `src/ui/components/CostPopover.ts` |
+| REST cost endpoints | `src/server/server.ts` |

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -45,7 +45,7 @@ Connect to `wss://<host>:<port>/ws/<session-id>`. First message must be `{ "type
 | `client_left` | `clientId` | A client disconnected |
 | `error` | `message`, `code` | Error message |
 | `pong` | — | Keepalive response |
-| `cost_update` | `sessionId`, `goalId?`, `taskId?`, `cost` | Token usage and cost update |
+| `cost_update` | `sessionId`, `goalId?`, `taskId?`, `cost` | Cumulative persisted session cost snapshot. Sent after live completed assistant usage and during hydration paths when persisted cost exists. |
 | `queue_update` | `sessionId`, `queue` | Prompt queue changed |
 | `task_changed` | `task` | A task was created, updated, or deleted |
 | `tasks_list` | `tasks` | Full task list for a goal |
@@ -73,6 +73,14 @@ Connect to `wss://<host>:<port>/ws/<session-id>`. First message must be `{ "type
 | `inbox.entry.added` | `staffId`, `entry` | A new inbox entry was enqueued for a staff agent (trigger fire, `POST /api/staff/:id/inbox`, or UI "+ Add to inbox"). See [staff-inbox.md](staff-inbox.md). |
 | `inbox.entry.updated` | `staffId`, `entry` | A staff agent transitioned an inbox entry via `inbox_complete` / `inbox_dismiss`. |
 | `inbox.entry.removed` | `staffId`, `entryId` | An inbox entry was pruned (`DELETE /api/staff/:id/inbox/:entryId`). Entry body not echoed — clients reconcile by id. |
+
+### Session cost hydration
+
+`cost_update.cost` has the same shape as `state.serverCost`: cumulative input/output/cache token totals plus `totalCost`. The payload is read from persisted `CostTracker` data and is not a delta; clients should replace their cached cost snapshot, not add it locally.
+
+When persisted cost exists, the server hydrates it on active attach/reconnect, `get_state`, `get_messages`, resume/replay fallback, archived attach/state/messages, and `refreshAfterCompaction()`. `refreshAfterCompaction()` sends `cost_update` before the compacted `messages` snapshot so the UI keeps showing cumulative spend instead of recalculating from the reduced visible transcript.
+
+See [session-cost.md](session-cost.md) for the source-of-truth and no-double-counting rules.
 
 ### Streaming resume
 

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -1250,6 +1250,12 @@ export class RemoteAgent {
 				if (msg.data?.imageGenerationModel) {
 					this._state.imageGenerationModel = msg.data.imageGenerationModel;
 				}
+				if (msg.data && Object.prototype.hasOwnProperty.call(msg.data, "serverCost")) {
+					this._state.serverCost = msg.data.serverCost ?? null;
+					if (this._state.serverCost) {
+						this.emit({ type: "cost_update" as any, cost: this._state.serverCost });
+					}
+				}
 				this.emit({ type: "state_update", data: msg.data });
 				break;
 

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -32,7 +32,7 @@ import { buildReattemptContext } from "./goal-assistant.js";
 import { assembleSystemPrompt, cleanupSessionPrompt, persistPromptSections, purgePromptSectionsJson, type PromptParts } from "./system-prompt.js";
 import { profile } from "./profiling.js";
 import { generateSessionTitle, generateGoalSummaryTitle } from "./title-generator.js";
-import { CostTracker } from "./cost-tracker.js";
+import { CostTracker, type SessionCost } from "./cost-tracker.js";
 import type { ColorStore } from "./color-store.js";
 import type { RoleManager } from "./role-manager.js";
 import type { ToolManager } from "./tool-manager.js";
@@ -1146,7 +1146,84 @@ export class SessionManager {
 		throw new Error("No cost tracker available");
 	}
 
+	/** Return persisted cumulative cost for a session, without creating a zero-cost record. */
+	getSessionCost(sessionId: string): SessionCost | undefined {
+		const live = this.sessions.get(sessionId);
+		if (live) {
+			try {
+				const cost = this.resolveCostTracker(live).getSessionCost(sessionId);
+				if (cost) return cost;
+			} catch {
+				// Fall through to persisted/store scans below.
+			}
+		}
 
+		const persisted = this.getPersistedSession(sessionId);
+		if (persisted?.projectId || !this.projectContextManager) {
+			try {
+				const cost = this.getCostTracker(persisted?.projectId).getSessionCost(sessionId);
+				if (cost) return cost;
+			} catch {
+				// Fall through to cross-project scan.
+			}
+		}
+
+		if (this.projectContextManager) {
+			for (const ctx of this.projectContextManager.all()) {
+				const cost = ctx.costTracker.getSessionCost(sessionId);
+				if (cost) return cost;
+			}
+		}
+		return undefined;
+	}
+
+	/** Merge authoritative persisted cost into a state snapshot when cost exists. */
+	withSessionCostInState(sessionId: string, data: unknown): unknown {
+		const cost = this.getSessionCost(sessionId);
+		if (!cost) return data;
+		if (data && typeof data === "object" && !Array.isArray(data)) {
+			return { ...(data as Record<string, unknown>), serverCost: cost };
+		}
+		return { serverCost: cost };
+	}
+
+	/** Build the cumulative cost_update payload used for attach/reconnect hydration. */
+	getSessionCostUpdate(sessionId: string): Extract<ServerMessage, { type: "cost_update" }> | null {
+		const cost = this.getSessionCost(sessionId);
+		if (!cost) return null;
+		const live = this.sessions.get(sessionId);
+		const persisted = live ? undefined : this.getPersistedSession(sessionId);
+		return {
+			type: "cost_update",
+			sessionId,
+			goalId: live?.goalId ?? persisted?.goalId,
+			taskId: this.resolveTaskIdForSession(sessionId),
+			cost,
+		};
+	}
+
+	/** Broadcast cumulative persisted cost to connected clients, if this session has cost data. */
+	broadcastSessionCost(session: SessionInfo): void {
+		const update = this.getSessionCostUpdate(session.id);
+		if (update) broadcast(session.clients, update);
+	}
+
+	private resolveTaskIdForSession(sessionId: string): string | undefined {
+		const live = this.sessions.get(sessionId);
+		if (live?.taskId) return live.taskId;
+		const persisted = this.getPersistedSession(sessionId);
+		if (persisted?.taskId) return persisted.taskId;
+		if (this.projectContextManager) {
+			for (const ctx of this.projectContextManager.all()) {
+				const tm = new TaskManager(ctx.taskStore);
+				const tasks = tm.getTasksForSession(sessionId);
+				if (tasks.length > 0) return tasks[0].id;
+			}
+			return undefined;
+		}
+		const tasks = this._testTaskManager?.getTasksForSession(sessionId) ?? [];
+		return tasks.length > 0 ? tasks[0].id : undefined;
+	}
 
 	getMcpManager(): McpManager | null {
 		return this.mcpManager;
@@ -3523,6 +3600,10 @@ export class SessionManager {
 	/** After compaction, refresh messages and state for all connected clients. */
 	async refreshAfterCompaction(session: SessionInfo): Promise<void> {
 		try {
+			// Send the authoritative cumulative cost before the compacted messages
+			// snapshot so clients never fall back to the reduced visible transcript.
+			this.broadcastSessionCost(session);
+
 			const msgs = await session.rpcClient.getMessages();
 			if (msgs.success) {
 				const raw: any = msgs.data;
@@ -3549,7 +3630,7 @@ export class SessionManager {
 			}
 			const st = await session.rpcClient.getState();
 			if (st.success) {
-				broadcast(session.clients, { type: "state", data: st.data });
+				broadcast(session.clients, { type: "state", data: this.withSessionCostInState(session.id, st.data) });
 			}
 		} catch (err) {
 			console.error(`[session-manager] Failed to refresh after compaction for ${session.id}:`, err);

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -120,14 +120,24 @@ function sendFallbackModelState(ws: WebSocket, sessionManager: SessionManager, s
 	if (imageModel) {
 		data.imageGenerationModel = imageModel;
 	}
-	if (Object.keys(data).length > 0) {
-		send(ws, { type: "state", data });
+	const withCost = sessionManager.withSessionCostInState(sessionId, data) as Record<string, unknown>;
+	if (Object.keys(withCost).length > 0) {
+		send(ws, { type: "state", data: withCost });
 	}
 }
 
 function sendImageModelState(ws: WebSocket, sessionManager: SessionManager, sessionId: string): void {
 	const imageModel = sessionManager.getImageModelForSession(sessionId);
-	if (imageModel) send(ws, { type: "state", data: { imageGenerationModel: imageModel } });
+	if (imageModel) sendStateWithCost(ws, sessionManager, sessionId, { imageGenerationModel: imageModel });
+}
+
+function sendStateWithCost(ws: WebSocket, sessionManager: SessionManager, sessionId: string, data: unknown): void {
+	send(ws, { type: "state", data: sessionManager.withSessionCostInState(sessionId, data) });
+}
+
+function sendSessionCostUpdate(ws: WebSocket, sessionManager: SessionManager, sessionId: string): void {
+	const update = sessionManager.getSessionCostUpdate(sessionId);
+	if (update) send(ws, update);
 }
 
 /**
@@ -161,7 +171,7 @@ function buildArchivedStateData(
 	}
 	const imageModel = sessionManager.getImageModelForSession(sessionId);
 	if (imageModel) data.imageGenerationModel = imageModel;
-	return data;
+	return sessionManager.withSessionCostInState(sessionId, data) as Record<string, unknown>;
 }
 
 function broadcast(clients: Set<WebSocket>, msg: ServerMessage): void {
@@ -268,6 +278,7 @@ export function handleWebSocketConnection(
 					(ws as any).sessionId = sessionId;
 					(ws as any).isArchived = true;
 					send(ws, { type: "auth_ok" });
+					sendSessionCostUpdate(ws, sessionManager, sessionId);
 					send(ws, { type: "session_status", status: "archived", statusVersion: 0, archivedAt: archived.archivedAt });
 					send(ws, { type: "session_title", sessionId, title: archived.title });
 					// Push persisted model + image model immediately. Without this, the
@@ -287,6 +298,7 @@ export function handleWebSocketConnection(
 			sessionManager.addClient(sessionId, ws);
 
 			send(ws, { type: "auth_ok" });
+			sendSessionCostUpdate(ws, sessionManager, sessionId);
 
 			// Notify about compaction immediately (before any awaits) so the
 			// client sets _isCompacting before a racing get_messages response.
@@ -305,7 +317,7 @@ export function handleWebSocketConnection(
 						// Splice canonical session status + version so the client's `case "state"`
 						// can prime `_lastStatusVersion` from the snapshot.
 						const spliced = { ...(stateResponse.data as Record<string, unknown> | undefined ?? {}), status: session.status, statusVersion: session.statusVersion ?? 0 };
-						send(ws, { type: "state", data: spliced });
+						sendStateWithCost(ws, sessionManager, sessionId, spliced);
 						sendImageModelState(ws, sessionManager, sessionId);
 						// If agent state lacks model info, supplement with persisted data
 						const data = stateResponse.data as Record<string, unknown> | undefined;
@@ -380,6 +392,7 @@ export function handleWebSocketConnection(
 		if ((ws as any).isArchived) {
 			switch (msg.type) {
 				case "get_state": {
+					sendSessionCostUpdate(ws, sessionManager, sessionId);
 					const archived = sessionManager.getArchivedSession(sessionId);
 					if (archived) {
 						send(ws, { type: "state", data: buildArchivedStateData(archived, sessionManager, sessionId) });
@@ -387,6 +400,7 @@ export function handleWebSocketConnection(
 					break;
 				}
 				case "get_messages": {
+					sendSessionCostUpdate(ws, sessionManager, sessionId);
 					const messages = await sessionManager.getArchivedMessages(sessionId);
 					send(ws, { type: "messages", data: stampSnapshotOrder(messages) as unknown[] });
 					break;
@@ -417,9 +431,11 @@ export function handleWebSocketConnection(
 					send(ws, { type: "pong" });
 					return;
 				case "get_state":
-					send(ws, { type: "state", data: { preparing: true } });
+					sendSessionCostUpdate(ws, sessionManager, sessionId);
+					sendStateWithCost(ws, sessionManager, sessionId, { preparing: true });
 					return;
 				case "get_messages":
+					sendSessionCostUpdate(ws, sessionManager, sessionId);
 					send(ws, { type: "messages", data: stampSnapshotOrder([]) as unknown[] });
 					return;
 				case "prompt":
@@ -638,6 +654,7 @@ export function handleWebSocketConnection(
 					break;
 				}
 				case "get_state": {
+					sendSessionCostUpdate(ws, sessionManager, sessionId);
 					try {
 						const stateResp = await session.rpcClient.getState();
 						if (stateResp.success) {
@@ -645,7 +662,7 @@ export function handleWebSocketConnection(
 							// the client's `case "state"` can prime `_lastStatusVersion` from
 							// the snapshot path (e.g. on reconnect via get_state).
 							const spliced = { ...(stateResp.data as Record<string, unknown> | undefined ?? {}), status: session.status, statusVersion: session.statusVersion ?? 0 };
-							send(ws, { type: "state", data: spliced });
+							sendStateWithCost(ws, sessionManager, sessionId, spliced);
 							sendImageModelState(ws, sessionManager, sessionId);
 							// If agent state lacks model info, supplement with persisted data
 							const data = stateResp.data as Record<string, unknown> | undefined;
@@ -673,6 +690,7 @@ export function handleWebSocketConnection(
 					break;
 				}
 				case "get_messages": {
+					sendSessionCostUpdate(ws, sessionManager, sessionId);
 					const msgsResp = await session.rpcClient.getMessages();
 					if (msgsResp.success) {
 						const raw = msgsResp.data as any;
@@ -794,6 +812,7 @@ export function handleWebSocketConnection(
 					send(ws, { type: "pong" });
 					break;
 				case "resume": {
+					sendSessionCostUpdate(ws, sessionManager, sessionId);
 					// Client requesting resume-from-seq. If the requested seq is
 					// still in the EventBuffer window, replay buffered entries as
 					// individual {type:"event"} frames with their original seq/ts

--- a/src/server/ws/protocol.ts
+++ b/src/server/ws/protocol.ts
@@ -33,6 +33,14 @@ export interface QueuedMessage {
 	createdAt: number;
 }
 
+export interface SessionCostSnapshot {
+	inputTokens: number;
+	outputTokens: number;
+	cacheReadTokens: number;
+	cacheWriteTokens: number;
+	totalCost: number;
+}
+
 /** Client → Server messages over WebSocket */
 export type ClientMessage =
 	| { type: "auth"; token: string }
@@ -93,7 +101,7 @@ export type ServerMessage =
 	| { type: "session_removed"; sessionId: string; projectId?: string; reason: "terminated" | "archived" | "purged" }
 	| { type: "session_title"; sessionId: string; title: string }
 	| { type: "pong" }
-	| { type: "cost_update"; sessionId: string; goalId?: string; taskId?: string; cost: { inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheWriteTokens: number; totalCost: number } }
+	| { type: "cost_update"; sessionId: string; goalId?: string; taskId?: string; cost: SessionCostSnapshot }
 	| { type: "queue_update"; sessionId: string; queue: QueuedMessage[] }
 	| { type: "task_changed"; task: unknown }
 	| { type: "tasks_list"; tasks: unknown[] }

--- a/src/ui/components/AgentInterface.ts
+++ b/src/ui/components/AgentInterface.ts
@@ -1406,10 +1406,13 @@ export class AgentInterface extends LitElement {
 				} satisfies Usage,
 			);
 
-		// Prefer server-authoritative cost when available (via cost_update WS messages)
+		// Server-authoritative cumulative cost is the only session-cost source of truth.
+		// Visible message usage is a compacted-window subset and must not drive the footer.
 		const serverCost = (this.session as any)?.state?.serverCost;
-		const costValue = serverCost?.totalCost ?? totals.cost?.total;
-		const costText = costValue ? formatCost(costValue) : "";
+		const serverCostTotal = typeof serverCost?.totalCost === "number" && Number.isFinite(serverCost.totalCost)
+			? serverCost.totalCost
+			: undefined;
+		const costText = serverCostTotal && serverCostTotal > 0 ? formatCost(serverCostTotal) : "";
 
 		// Compute context usage from the last assistant message's usage
 		let contextHtml = html``;
@@ -1637,7 +1640,7 @@ export class AgentInterface extends LitElement {
 						<div style="font-weight:600;margin-bottom:6px;">Session</div>
 						${row("Messages", msgCount)}
 						${row("Turns", turnCount)}
-						${row("Total cost", totals.cost?.total ? formatCost(totals.cost.total) : "—")}
+						${row("Total cost", serverCostTotal && serverCostTotal > 0 ? formatCost(serverCostTotal) : "—")}
 						${row("Total input", formatTokenCount(totals.input))}
 						${row("Total output", formatTokenCount(totals.output))}
 						${totals.cacheRead ? row("Total cache read", formatTokenCount(totals.cacheRead)) : nothing}

--- a/tests/context-cost-stats.html
+++ b/tests/context-cost-stats.html
@@ -22,13 +22,15 @@
   }
   .context-area { cursor: pointer; }
   .cost-area { cursor: pointer; position: relative; }
-  .cost-popover {
+  .cost-popover,
+  .context-popover {
     position: absolute; bottom: 100%; right: 0; margin-bottom: 6px; z-index: 50;
     background: var(--popover); color: var(--popover-foreground);
     border: 1px solid var(--border); border-radius: 8px;
     padding: 12px 14px; min-width: 260px;
     box-shadow: 0 4px 12px rgba(0,0,0,0.15); font-size: 12px;
   }
+  .stats-bar { position: relative; }
 </style>
 </head>
 <body>
@@ -60,10 +62,12 @@ function formatTokenCount(count) {
 // ---- State ----
 let _contextTokens = 0;
 let _contextWindow = 0;
-let _costValue = 0;
+let _visibleCostValue = 0;
+let _serverCost = null;
 let _stale = false;
 let _modelId = 'claude-sonnet-4-20250514';
 let _costPopoverOpen = false;
+let _contextPopoverOpen = false;
 
 // ---- Rendering ----
 function renderContextBar() {
@@ -97,13 +101,23 @@ function renderContextBar() {
     </span>`;
 }
 
+function authoritativeCostValue() {
+  return _serverCost && Number.isFinite(_serverCost.totalCost) ? _serverCost.totalCost : undefined;
+}
+
+function sessionCostText() {
+  const costValue = authoritativeCostValue();
+  return costValue && costValue > 0 ? formatCost(costValue) : '\u2014';
+}
+
 function renderCost() {
   const el = document.getElementById('cost-area');
-  if (!_costValue) {
+  const costValue = authoritativeCostValue();
+  if (!costValue || costValue <= 0) {
     el.innerHTML = '';
     return;
   }
-  const costText = formatCost(_costValue);
+  const costText = formatCost(costValue);
   el.innerHTML = `<span id="cost-text">${costText}</span>`;
   if (_costPopoverOpen) {
     el.innerHTML += `<div id="cost-popover" class="cost-popover">
@@ -121,17 +135,39 @@ function renderModel() {
   el.innerHTML = _modelId ? `<button id="model-button">${_modelId}</button>` : '';
 }
 
+function renderContextPopover() {
+  document.getElementById('context-popover')?.remove();
+  if (!_contextPopoverOpen) return;
+  document.getElementById('stats-bar').insertAdjacentHTML('beforeend', `<div id="context-popover" class="context-popover">
+    <div style="font-weight:600;margin-bottom:6px;">Session</div>
+    <div style="display:flex;justify-content:space-between;align-items:center;padding:3px 0;">
+      <span style="color:var(--muted-foreground)">Total cost</span>
+      <span id="context-total-cost" style="font-weight:500;font-variant-numeric:tabular-nums">${sessionCostText()}</span>
+    </div>
+    <div style="opacity:0.6">Visible message cost: ${formatCost(_visibleCostValue)}</div>
+  </div>`);
+}
+
 function renderAll() {
   renderModel();
   renderContextBar();
   renderCost();
+  renderContextPopover();
 }
 
 // ---- Click handlers ----
+document.getElementById('context-area').addEventListener('click', (e) => {
+  e.stopPropagation();
+  _contextPopoverOpen = !_contextPopoverOpen;
+  _costPopoverOpen = false;
+  renderAll();
+});
+
 document.getElementById('cost-area').addEventListener('click', (e) => {
   e.stopPropagation();
   _costPopoverOpen = !_costPopoverOpen;
-  renderCost();
+  _contextPopoverOpen = false;
+  renderAll();
 });
 
 // ---- Public test API ----
@@ -143,7 +179,22 @@ window.setUsage = function(input, output, contextWindow) {
 };
 
 window.setCost = function(total) {
-  _costValue = total;
+  window.setServerCost(total);
+};
+
+window.setVisibleCost = function(total) {
+  _visibleCostValue = total;
+  renderAll();
+};
+
+window.setServerCost = function(total) {
+  _serverCost = total === null || total === undefined ? null : {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    totalCost: total,
+  };
   renderAll();
 };
 
@@ -182,6 +233,11 @@ window.getCostText = function() {
 
 window.isPopoverOpen = function() {
   return !!document.getElementById('cost-popover');
+};
+
+window.getContextTotalCostText = function() {
+  const el = document.getElementById('context-total-cost');
+  return el ? el.textContent : '';
 };
 
 window.getPctText = function() {

--- a/tests/context-cost-stats.spec.ts
+++ b/tests/context-cost-stats.spec.ts
@@ -134,6 +134,32 @@ test.describe("PI-18: Cost display", () => {
 		expect(text).toBe("");
 	});
 
+	test("visible-message cost alone is not shown without authoritative server cost", async ({ page }) => {
+		await page.evaluate(() => {
+			(window as any).setUsage(5000, 3000, 200000);
+			(window as any).setVisibleCost(0.4);
+			(window as any).setServerCost(null);
+		});
+
+		expect(await page.evaluate(() => (window as any).getCostText())).toBe("");
+
+		await page.click("#context-area");
+		expect(await page.evaluate(() => (window as any).getContextTotalCostText())).toBe("—");
+	});
+
+	test("server cost wins over reduced visible-message cost in footer and session popover", async ({ page }) => {
+		await page.evaluate(() => {
+			(window as any).setUsage(5000, 3000, 200000);
+			(window as any).setVisibleCost(0.4);
+			(window as any).setServerCost(2.5);
+		});
+
+		expect(await page.evaluate(() => (window as any).getCostText())).toBe("$3");
+
+		await page.click("#context-area");
+		expect(await page.evaluate(() => (window as any).getContextTotalCostText())).toBe("$3");
+	});
+
 	test("click toggles cost popover open", async ({ page }) => {
 		await page.evaluate(() => (window as any).setCost(1.5));
 		expect(await page.evaluate(() => (window as any).isPopoverOpen())).toBe(false);

--- a/tests/e2e/compact-cost-ws.spec.ts
+++ b/tests/e2e/compact-cost-ws.spec.ts
@@ -1,3 +1,7 @@
+import { execSync } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { test, expect } from "./in-process-harness.js";
 import {
 	apiFetch,
@@ -9,6 +13,36 @@ import {
 	type WsMsg,
 } from "./e2e-setup.js";
 import { pollUntil } from "./test-utils/cleanup.js";
+
+const PROJECT_ROOT = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+
+/**
+ * This spec exercises server WS hydration through the in-process harness,
+ * which imports compiled files from dist/server. The shared E2E global setup
+ * only builds when dist is missing, so a persistent worktree can otherwise run
+ * these regression tests against a stale pre-hydration server build.
+ */
+function ensureFreshServerBuild(): void {
+	const sourceFiles = [
+		"src/server/agent/session-manager.ts",
+		"src/server/ws/handler.ts",
+		"src/server/ws/protocol.ts",
+	].map((p) => resolve(PROJECT_ROOT, p));
+	const outputFiles = [
+		"dist/server/agent/session-manager.js",
+		"dist/server/ws/handler.js",
+		"dist/server/ws/protocol.js",
+	].map((p) => resolve(PROJECT_ROOT, p));
+
+	const missingOutput = outputFiles.some((p) => !existsSync(p));
+	const newestSource = Math.max(...sourceFiles.map((p) => statSync(p).mtimeMs));
+	const oldestOutput = missingOutput ? 0 : Math.min(...outputFiles.map((p) => statSync(p).mtimeMs));
+	if (!missingOutput && oldestOutput >= newestSource) return;
+
+	execSync("npm run build:server", { cwd: PROJECT_ROOT, stdio: "inherit" });
+}
+
+ensureFreshServerBuild();
 
 const TOTAL_COST = 2.5;
 

--- a/tests/e2e/compact-cost-ws.spec.ts
+++ b/tests/e2e/compact-cost-ws.spec.ts
@@ -1,0 +1,163 @@
+import { test, expect } from "./in-process-harness.js";
+import {
+	apiFetch,
+	connectWs,
+	createSession,
+	deleteSession,
+	waitForSessionStatus,
+	type WsConnection,
+	type WsMsg,
+} from "./e2e-setup.js";
+import { pollUntil } from "./test-utils/cleanup.js";
+
+const TOTAL_COST = 2.5;
+
+function costUpdateFor(sessionId: string, totalCost = TOTAL_COST) {
+	return (m: WsMsg) =>
+		m.type === "cost_update" &&
+		m.sessionId === sessionId &&
+		m.cost?.totalCost === totalCost;
+}
+
+function stateCost(totalCost = TOTAL_COST) {
+	return (m: WsMsg) =>
+		m.type === "state" &&
+		m.data?.serverCost?.totalCost === totalCost;
+}
+
+async function seedPersistedCost(gateway: any, sessionId: string, totalCost = TOTAL_COST) {
+	await waitForSessionStatus(sessionId, "idle");
+	const session = gateway.sessionManager.getSession(sessionId);
+	if (!session) throw new Error(`session ${sessionId} not found`);
+	const cost = gateway.sessionManager.getCostTracker(session.projectId).recordUsage(sessionId, {
+		inputTokens: 9_000,
+		outputTokens: 1_000,
+		cacheReadTokens: 0,
+		cacheWriteTokens: 0,
+		cost: totalCost,
+	});
+	expect(cost.totalCost).toBe(totalCost);
+	return session;
+}
+
+function setMockTranscript(gateway: any, sessionId: string, messages: any[]) {
+	const session = gateway.sessionManager.getSession(sessionId);
+	if (!session) throw new Error(`session ${sessionId} not found`);
+	const mockAgent = session.rpcClient?._agent;
+	if (!mockAgent || !Array.isArray(mockAgent.conversationMessages)) {
+		throw new Error("expected in-process mock agent with conversationMessages");
+	}
+	mockAgent.conversationMessages = messages;
+	return session;
+}
+
+async function closeWs(ws: WsConnection) {
+	const closed = new Promise<void>((resolve) => ws.ws.once("close", () => resolve()));
+	ws.close();
+	await closed.catch(() => {});
+}
+
+test.setTimeout(30_000);
+
+test.describe("compact cost WS hydration", () => {
+	test("hydrates persisted cumulative cost on active attach, get_state, resume fallback, and compaction refresh", async ({ gateway }) => {
+		const sessionId = await createSession();
+		try {
+			await seedPersistedCost(gateway, sessionId);
+
+			const ws = await connectWs(sessionId);
+			try {
+				await ws.waitFor(costUpdateFor(sessionId), 5_000);
+				await ws.waitFor(stateCost(), 5_000);
+
+				const getStateCursor = ws.messageCount();
+				ws.send({ type: "get_state" });
+				await ws.waitForFrom(getStateCursor, costUpdateFor(sessionId), 5_000);
+				await ws.waitForFrom(getStateCursor, stateCost(), 5_000);
+
+				const resumeCursor = ws.messageCount();
+				ws.send({ type: "resume", fromSeq: -999 });
+				await ws.waitForFrom(resumeCursor, costUpdateFor(sessionId), 5_000);
+				await ws.waitForFrom(resumeCursor, (m) => m.type === "resume_gap", 5_000);
+
+				const compactedTranscript = [
+					{ id: "u-after", role: "user", content: [{ type: "text", text: "after compaction" }] },
+					{
+						id: "a-after",
+						role: "assistant",
+						content: [{ type: "text", text: "visible post-compaction response" }],
+						usage: { cost: { total: 0.4 } },
+					},
+				];
+				const session = setMockTranscript(gateway, sessionId, compactedTranscript);
+				const refreshCursor = ws.messageCount();
+				await gateway.sessionManager.refreshAfterCompaction(session);
+
+				const costFrame = await ws.waitForFrom(refreshCursor, costUpdateFor(sessionId), 5_000);
+				const messagesFrame = await ws.waitForFrom(
+					refreshCursor,
+					(m) => m.type === "messages" && Array.isArray(m.data) && m.data.length === compactedTranscript.length,
+					5_000,
+				);
+				await ws.waitForFrom(refreshCursor, stateCost(), 5_000);
+
+				const costIdx = ws.messages.indexOf(costFrame);
+				const messagesIdx = ws.messages.indexOf(messagesFrame);
+				expect(costIdx).toBeGreaterThanOrEqual(refreshCursor);
+				expect(messagesIdx).toBeGreaterThan(costIdx);
+			} finally {
+				await closeWs(ws);
+			}
+		} finally {
+			await deleteSession(sessionId);
+		}
+	});
+
+	test("hydrates archived session state and cost_update when persisted cost exists", async ({ gateway }) => {
+		const sessionId = await createSession();
+		try {
+			await seedPersistedCost(gateway, sessionId);
+
+			const delResp = await apiFetch(`/api/sessions/${sessionId}`, { method: "DELETE" });
+			expect(delResp.ok).toBe(true);
+			await pollUntil(async () => {
+				const resp = await apiFetch("/api/sessions?include=archived");
+				if (!resp.ok) return false;
+				const data = await resp.json();
+				return Array.isArray(data.sessions) && data.sessions.some((s: any) => s.id === sessionId && s.archived);
+			}, { timeoutMs: 5_000, intervalMs: 50, label: "session archived" });
+
+			const ws = await connectWs(sessionId);
+			try {
+				await ws.waitFor(costUpdateFor(sessionId), 5_000);
+				await ws.waitFor((m) => m.type === "state" && m.data?.archived === true && m.data?.serverCost?.totalCost === TOTAL_COST, 5_000);
+
+				const cursor = ws.messageCount();
+				ws.send({ type: "get_state" });
+				await ws.waitForFrom(cursor, costUpdateFor(sessionId), 5_000);
+				await ws.waitForFrom(cursor, (m) => m.type === "state" && m.data?.archived === true && m.data?.serverCost?.totalCost === TOTAL_COST, 5_000);
+			} finally {
+				await closeWs(ws);
+			}
+		} finally {
+			await deleteSession(sessionId).catch(() => {});
+		}
+	});
+
+	test("does not add serverCost to state when no persisted cost exists", async () => {
+		const sessionId = await createSession();
+		try {
+			const ws = await connectWs(sessionId);
+			try {
+				const cursor = ws.messageCount();
+				ws.send({ type: "get_state" });
+				const state = await ws.waitForFrom(cursor, (m) => m.type === "state", 5_000);
+				expect(state.data?.serverCost).toBeUndefined();
+			} finally {
+				await closeWs(ws);
+			}
+		} finally {
+			await deleteSession(sessionId);
+		}
+	});
+});

--- a/tests/e2e/ui/compact-cost.spec.ts
+++ b/tests/e2e/ui/compact-cost.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * Reproducer: compacted transcripts must not make the footer/session stats cost drop.
+ *
+ * The server already has cumulative CostTracker data, but a post-compaction
+ * messages snapshot contains only the reduced visible transcript. The UI must
+ * keep using the persisted cumulative cost, not the reduced visible-message sum.
+ */
+import { test, expect } from "../gateway-harness.js";
+import { apiFetch, createSession, deleteSession, waitForSessionStatus } from "../e2e-setup.js";
+import { openApp } from "./ui-helpers.js";
+
+const BUG_MARKER = "COMPACT_COST_PERSISTED_COST_BUG";
+
+function formatCost(cost: number): string {
+	if (cost < 1) return `$${cost.toFixed(1).replace(/\.0$/, "")}`;
+	return `$${Math.round(cost)}`;
+}
+
+function assistantMessage(id: string, text: string, cost: number, totalTokens: number) {
+	return {
+		id,
+		role: "assistant",
+		content: [{ type: "text", text }],
+		usage: {
+			input: Math.max(0, totalTokens - 100),
+			output: Math.min(100, totalTokens),
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens,
+			cost: {
+				input: cost / 2,
+				output: cost / 2,
+				cacheRead: 0,
+				cacheWrite: 0,
+				total: cost,
+			},
+		},
+	};
+}
+
+function sumVisibleAssistantCost(messages: any[]): number {
+	const total = messages
+		.filter((msg) => msg?.role === "assistant")
+		.reduce((sum, msg) => sum + (typeof msg?.usage?.cost?.total === "number" ? msg.usage.cost.total : 0), 0);
+	return Math.round(total * 1_000_000) / 1_000_000;
+}
+
+async function setMockTranscript(gateway: any, sessionId: string, messages: any[]) {
+	const session = gateway.sessionManager?.getSession(sessionId);
+	if (!session) throw new Error(`session ${sessionId} not found`);
+	const mockAgent = session.rpcClient?._agent;
+	if (!mockAgent || !Array.isArray(mockAgent.conversationMessages)) {
+		throw new Error("expected in-process mock agent with conversationMessages");
+	}
+	mockAgent.conversationMessages = messages;
+	return session;
+}
+
+async function readCostSnapshot(page: import("@playwright/test").Page) {
+	return page.evaluate(() => {
+		const agentInterface = document.querySelector("agent-interface");
+		const text = agentInterface?.textContent ?? "";
+		const dollarTexts = text.match(/\$\d+(?:\.\d+)?/g) ?? [];
+		const remote = (window as any).__bobbitState?.remoteAgent;
+		const messages = remote?.state?.messages ?? [];
+		const visibleCost = messages
+			.filter((msg: any) => msg?.role === "assistant")
+			.reduce((sum: number, msg: any) => sum + (typeof msg?.usage?.cost?.total === "number" ? msg.usage.cost.total : 0), 0);
+		return {
+			footerCost: dollarTexts[dollarTexts.length - 1] ?? "",
+			dollarTexts,
+			messageCount: messages.length,
+			visibleCost: Math.round(visibleCost * 1_000_000) / 1_000_000,
+			serverCost: remote?.state?.serverCost ?? null,
+		};
+	});
+}
+
+async function readContextPopoverTotalCost(page: import("@playwright/test").Page): Promise<string> {
+	return page.evaluate(() => {
+		const popover = document.querySelector("agent-interface .context-popover");
+		if (!popover) return "";
+		const label = Array.from(popover.querySelectorAll("span"))
+			.find((span) => span.textContent?.trim() === "Total cost");
+		return label?.nextElementSibling?.textContent?.trim() ?? "";
+	});
+}
+
+test.describe("Compact cost regression", () => {
+	test(`${BUG_MARKER}: footer and session stats keep persisted cumulative cost after compaction-like snapshot shrink`, async ({ page, gateway }) => {
+		const sessionId = await createSession();
+		try {
+			await waitForSessionStatus(sessionId, "idle");
+
+			const persistedTotal = 2.5;
+			const fullTranscript = [
+				{ id: "u1", role: "user", content: [{ type: "text", text: "first" }] },
+				assistantMessage("a1", "first assistant turn", 1.2, 48_000),
+				{ id: "u2", role: "user", content: [{ type: "text", text: "second" }] },
+				assistantMessage("a2", "second assistant turn", 1.3, 52_000),
+			];
+			const compactedTranscript = [
+				{ id: "u3", role: "user", content: [{ type: "text", text: "after compaction" }] },
+				assistantMessage("a3", "post-compaction visible assistant turn", 0.4, 18_000),
+			];
+
+			const liveSession = await setMockTranscript(gateway, sessionId, fullTranscript);
+			const projectId = liveSession.projectId;
+			const persisted = gateway.sessionManager.getCostTracker(projectId).recordUsage(sessionId, {
+				inputTokens: 9_000,
+				outputTokens: 1_000,
+				cacheReadTokens: 0,
+				cacheWriteTokens: 0,
+				cost: persistedTotal,
+			});
+			expect(persisted.totalCost, `${BUG_MARKER}: test setup should seed persisted cumulative cost`).toBe(persistedTotal);
+
+			await openApp(page);
+			await page.evaluate((id) => { window.location.hash = `#/session/${id}`; }, sessionId);
+			await expect(page.locator("textarea").first()).toBeVisible({ timeout: 15_000 });
+
+			// Ensure the real model/context state is present so the stats popover can open.
+			await page.evaluate(() => (window as any).__bobbitState.remoteAgent.send({ type: "get_state" }));
+			await expect.poll(async () => (await readCostSnapshot(page)).messageCount, {
+				message: `${BUG_MARKER}: full transcript should hydrate before compaction simulation`,
+				timeout: 10_000,
+			}).toBe(fullTranscript.length);
+
+			const before = await readCostSnapshot(page);
+			expect(before.footerCost, `${BUG_MARKER}: baseline full transcript should display cumulative cost`).toBe(formatCost(persistedTotal));
+
+			const sessionForRefresh = await setMockTranscript(gateway, sessionId, compactedTranscript);
+			await gateway.sessionManager.refreshAfterCompaction(sessionForRefresh);
+
+			await expect.poll(async () => (await readCostSnapshot(page)).messageCount, {
+				message: `${BUG_MARKER}: compacted transcript snapshot should replace visible messages`,
+				timeout: 10_000,
+			}).toBe(compactedTranscript.length);
+
+			const after = await readCostSnapshot(page);
+			await expect(page.locator('agent-interface span[title^="Context:"]').first()).toBeVisible({ timeout: 10_000 });
+			await page.locator('agent-interface span[title^="Context:"]').first().click();
+			await expect(page.locator("agent-interface .context-popover")).toBeVisible({ timeout: 5_000 });
+			const contextTotalCost = await readContextPopoverTotalCost(page);
+
+			const apiCostResp = await apiFetch(`/api/sessions/${sessionId}/cost`);
+			expect(apiCostResp.ok, `${BUG_MARKER}: test setup should expose persisted cost through the session cost API`).toBe(true);
+			const apiCost = await apiCostResp.json();
+
+			const result = {
+				persistedApiCost: apiCost.totalCost,
+				persistedApiCostText: formatCost(apiCost.totalCost),
+				fullVisibleCost: sumVisibleAssistantCost(fullTranscript),
+				compactedVisibleCost: sumVisibleAssistantCost(compactedTranscript),
+				beforeFooterCost: before.footerCost,
+				afterFooterCost: after.footerCost,
+				contextPopoverTotalCost: contextTotalCost,
+				afterServerCost: after.serverCost?.totalCost ?? null,
+			};
+
+			expect(result,
+				`${BUG_MARKER}: persisted cumulative cost must win after a compaction-like messages snapshot shrink; ` +
+				`the footer/session stats must not fall back to the reduced visible transcript cost.`
+			).toMatchObject({
+				persistedApiCost: persistedTotal,
+				persistedApiCostText: formatCost(persistedTotal),
+				fullVisibleCost: persistedTotal,
+				compactedVisibleCost: 0.4,
+				beforeFooterCost: formatCost(persistedTotal),
+				afterFooterCost: formatCost(persistedTotal),
+				contextPopoverTotalCost: formatCost(persistedTotal),
+			});
+		} finally {
+			await deleteSession(sessionId).catch(() => {});
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- Hydrate persisted `CostTracker` session cost into WebSocket state and `cost_update` frames on attach/reconnect/get_state/get_messages/resume/archived/compaction refresh paths.
- Use `state.serverCost.totalCost` as the UI source of truth for footer and context stats cost, avoiding compacted visible-message fallback.
- Add compact-cost browser and WS/API regressions plus session-cost documentation.

## Validation
- `npm run check`
- `npm run test:unit`
- `npm run build`
- `npx playwright test --config playwright-e2e.config.ts tests/e2e/compact-cost-ws.spec.ts --project=api --workers=1 --retries=0 --reporter=line`
- `npx playwright test --config playwright-e2e.config.ts --project=browser tests/e2e/ui/compact-cost.spec.ts --grep COMPACT_COST_PERSISTED_COST_BUG --retries=0 --reporter=line`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
