### PR TITLE
Fix BG Timer

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -364,6 +364,7 @@ The existing guard remains as a last-line safety net for genuinely unbindable pr
 
 - **Dropdown renders via portal**: `BgProcessPill` appends its log dropdown to `document.body` instead of rendering it inline. This is necessary because the "More" overflow popover uses `backdrop-filter: blur()`, which creates a new CSS containing block — `position: fixed` children behave like `position: absolute` and `mask-image` clips them. If the dropdown appears mispositioned or clipped inside a popover, check that the portal is working (the `#bg-process-dropdown` element should be a direct child of `document.body`, not nested inside the pill or popover).
 - **Dismiss for popover pills skips animation**: Pills inside the "More" popover lack the animation wrapper that visible pills have. `_handlePillDismiss` in `AgentInterface` detects hidden (popover) pills and calls `onBgProcessDismiss()` directly instead of waiting for a `pill-fade-out` animation. If dismiss stops working for popover pills, check that the hidden-set detection still matches the overflow logic in `_renderPillStrip()`.
+- **Exited duration keeps growing**: exited process snapshots must include numeric `BgProcessInfo.endTime`; the UI renders `endTime - startTime`, while legacy missing/null `endTime` renders `—` rather than `Date.now() - startTime`. See [docs/internals.md — Background process runtime snapshots](internals.md#background-process-runtime-snapshots).
 
 ## Gates
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -2331,6 +2331,28 @@ For the parallel pattern on the agent stream (different event family, same shape
 
 ---
 
+## Background process runtime snapshots
+
+Background process pills render live state from `BgProcessManager` snapshots, not from browser-local assumptions. This matters because an exited process may remain visible for hours, survive reconnects, or be rehydrated through REST; using `Date.now() - startTime` after exit makes old processes look like they ran until the current page render.
+
+**Contract.** `BgProcessInfo` includes `startTime: number` and `endTime: number | null` as epoch-millisecond timestamps.
+
+- While `status === "running"`, `endTime` is `null` and the UI may render a live elapsed timer from `startTime`.
+- On child `exit`, the server updates `status`, `exitCode`, and `endTime` once before resolving waiters or broadcasting the exit event.
+- Exited processes with a numeric `endTime` render fixed runtime as `endTime - startTime`; the value must not grow after re-render, reconnect, REST hydration, or page reload.
+- Legacy exited snapshots with missing/null/invalid `endTime` render runtime as unavailable (`—`) instead of falling back to time-since-start.
+
+### Surfaces
+
+- `GET /api/sessions/:id/bg-processes` returns `{ processes: BgProcessInfo[] }` for initial hydration and reconnect refresh.
+- `GET /api/sessions/:id/bg-processes/:pid/wait` returns `{ info, timedOut, aborted }`; `info.endTime` is numeric only when the snapshot is exited.
+- `bg_process_created` carries the full running `process` snapshot with `endTime: null`.
+- `bg_process_exited` carries `processId`, `exitCode`, and `endTime` so the client can freeze an existing pill immediately.
+
+The REST and WS contracts are additive for older clients, but new clients must treat missing `endTime` as unknown rather than deriving a misleading final duration from the current clock.
+
+---
+
 ## Steer-interruptible bash_bg wait
 
 `bash_bg` action `wait` blocks the agent for up to 300 s (default) while the server long-polls `BgProcessManager.waitForExit()`. Without special handling, a steer (user or `team_steer`) arriving during that window would be accepted by the WebSocket handler but could not take effect until the wait resolved - the agent is stuck mid tool-call and the steer feels ignored.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -41,12 +41,39 @@ Client call sites use the shared helpers `errorFromResponse(res, fallback)` and 
 | `GET` | `/api/sessions/:id/output` | Get final assistant output from the last turn |
 | `GET` | `/api/sessions/:id/git-status` | Git status for session's working directory (branch, ahead/behind, dirty files) |
 | `GET` | `/api/sessions/:id/pr-status` | PR status for session's branch (via `gh pr view`) |
+| `POST` | `/api/sessions/:id/bg-processes` | Start a background process and return its `BgProcessInfo` snapshot |
+| `GET` | `/api/sessions/:id/bg-processes` | List active/exited background process snapshots for REST hydration |
+| `GET` | `/api/sessions/:id/bg-processes/:pid/wait` | Long-poll until a background process exits, times out, or is interrupted |
 | `GET` | `/api/sessions/:id/cost` | Persisted cumulative token usage and cost for a single session. Returns 404 when no cost record exists. See [session-cost.md](session-cost.md). |
 | `GET` | `/api/sessions/:id/cost/breakdown` | Session cost plus delegate-session breakdown, used by the session cost popover |
 | `GET` | `/api/sessions/:id/tool-content/:messageIndex/:blockIndex` | Lazy-load full tool input content for a truncated block (see [Large content truncation](#large-content-truncation)) |
 | `GET` | `/api/sessions/:id/transcript` | Paginated, regex-filterable transcript reader. Backs the `read_session` tool. Query params: `offset` (negative = from end), `limit` (default 20, clamped 1..200), `pattern`, `case_sensitive`, `context` (±5 max), `verbose`. Same-project authorization via the `x-bobbit-session-id` request header. Errors: `session_not_found` (404), `transcript_unavailable` (404), `invalid_regex` / `invalid_params` (400), `permission_denied` (403). Pure parser lives in `src/server/agent/transcript-reader.ts`. |
 | `GET` | `/api/sessions/:id/transcript/before-compaction` | Paginated read of the orphaned pre-compaction entries for a single compaction event. Query params: `compactionId` (required, sidecar entry id), `cursor` (from previous response's `nextCursor`), `limit` (default 50, clamped 1..200). Response envelope `{ total, returned, nextCursor, messages[] }`. Same-project authorization via the `x-bobbit-session-id` header. Errors: `session_not_found` (404), `transcript_unavailable` (404), `compaction_not_found` (404), `invalid_params` (400), `permission_denied` (403). Branch-split via the sidecar's `firstKeptEntryId`; legacy fallback scans the JSONL for an inline `type:"compaction"` marker. Reader: `readOrphanedBeforeCompaction` in `src/server/agent/transcript-reader.ts`. See [docs/compaction-history.md](compaction-history.md). |
 
+### Background processes
+
+Background process snapshots use epoch-millisecond timestamps so clients can render runtime without depending on page load time:
+
+```ts
+type BgProcessInfo = {
+  id: string;
+  name: string;
+  command: string;
+  pid: number;
+  status: "running" | "exited";
+  exitCode: number | null;
+  startTime: number;
+  endTime: number | null;
+};
+```
+
+`endTime` is `null` while `status === "running"`. On child exit the server sets `endTime` once, and list / wait snapshots preserve that final value so reloads and reconnects keep showing the fixed `endTime - startTime` runtime.
+
+- `POST /api/sessions/:id/bg-processes` returns `201 BgProcessInfo` for the created process.
+- `GET /api/sessions/:id/bg-processes` returns `{ processes: BgProcessInfo[] }` for UI hydration.
+- `GET /api/sessions/:id/bg-processes/:pid/wait` returns `{ info: BgProcessInfo, timedOut: boolean, aborted: boolean }`; `info.endTime` is numeric after exit and remains `null` for running timeout/abort snapshots.
+
+Older exited snapshots may omit `endTime` or set it to `null`. Clients must render those runtimes as unknown/non-growing instead of substituting `Date.now()` for an exit timestamp.
 
 ### Proposal drafts
 

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -68,9 +68,9 @@ Goal-scoped broadcasts (`gate_*`, `team_*`, `goal_*`) reach viewer sockets only 
 | `tasks_list` | `tasks` | Full task list for a goal |
 | `session_archived` | `sessionId`, `archivedAt` | Session was archived |
 | `preferences_changed` | `preferences` | Server preferences were updated |
-| `bg_process_created` | `process` | Background process started |
+| `bg_process_created` | `process` (`BgProcessInfo`) | Background process started; `process.endTime` is `null` |
 | `bg_process_output` | `processId`, `stream`, `text` | Output from a background process |
-| `bg_process_exited` | `processId`, `exitCode` | Background process terminated |
+| `bg_process_exited` | `processId`, `exitCode`, `endTime` | Background process terminated; `endTime` is the fixed exit timestamp |
 | `gate_signal_received` | `goalId`, `gateId`, `signalId` | Gate signal received |
 | `gate_verification_started` | `goalId`, `gateId`, `signalId` | Gate verification began |
 | `gate_verification_step_started` | `goalId`, `gateId`, `stepIndex`, `stepName` | A verification step began |
@@ -90,6 +90,12 @@ Goal-scoped broadcasts (`gate_*`, `team_*`, `goal_*`) reach viewer sockets only 
 | `inbox.entry.added` | `staffId`, `entry` | A new inbox entry was enqueued for a staff agent (trigger fire, `POST /api/staff/:id/inbox`, or UI "+ Add to inbox"). See [staff-inbox.md](staff-inbox.md). |
 | `inbox.entry.updated` | `staffId`, `entry` | A staff agent transitioned an inbox entry via `inbox_complete` / `inbox_dismiss`. |
 | `inbox.entry.removed` | `staffId`, `entryId` | An inbox entry was pruned (`DELETE /api/staff/:id/inbox/:entryId`). Entry body not echoed — clients reconcile by id. |
+
+### Background process events
+
+`BgProcessInfo` snapshots carry `{ id, name, command, pid, status, exitCode, startTime, endTime }`, where timestamps are epoch milliseconds. Running processes have `endTime: null`; exited processes set `endTime` once at child exit.
+
+`bg_process_created` sends the full running snapshot. `bg_process_exited` sends `{ processId, exitCode, endTime }` so clients can update an existing pill without waiting for REST hydration. Missing legacy `endTime` values mean the final runtime is unknown; clients should keep the display non-growing rather than deriving elapsed time from `Date.now()`.
 
 ### Session cost hydration
 

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -436,7 +436,7 @@ export class RemoteAgent {
 	onGoalSetupEvent?: () => void;
 	/** Callback fired when compaction state changes (start/end). */
 	onCompactionChange?: (isCompacting: boolean) => void;
-	onBgProcessEvent?: (msg: { type: string; processId?: string; stream?: string; text?: string; ts?: number; exitCode?: number | null; process?: any }) => void;
+	onBgProcessEvent?: (msg: { type: string; processId?: string; stream?: string; text?: string; ts?: number; exitCode?: number | null; endTime?: number | null; process?: any }) => void;
 	/** Callback fired when preview panel flag changes for a session. */
 	onPreviewChanged?: (sessionId: string, preview: boolean) => void;
 	/** Callback fired when server detects PR creation and busts the cache. */

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -1290,9 +1290,12 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 				const pill = ai.querySelector(`bg-process-pill[data-id="${msg.processId}"]`) as any;
 				if (pill?.appendOutput) pill.appendOutput(msg.text, msg.ts);
 			} else if (msg.type === "bg_process_exited" && msg.processId) {
-				// Update status in the process list
+				// Update status in the process list. Older servers may omit endTime;
+				// preserve a non-growing null fallback instead of implying Date.now().
 				ai.bgProcesses = ai.bgProcesses.map((p) =>
-					p.id === msg.processId ? { ...p, status: "exited" as const, exitCode: msg.exitCode ?? null } : p
+					p.id === msg.processId
+						? { ...p, status: "exited" as const, exitCode: msg.exitCode ?? null, endTime: typeof msg.endTime === "number" ? msg.endTime : p.endTime ?? null }
+						: p
 				);
 			}
 		};

--- a/src/server/agent/bg-process-manager.ts
+++ b/src/server/agent/bg-process-manager.ts
@@ -60,6 +60,7 @@ export interface BgProcess {
 	status: "running" | "exited";
 	exitCode: number | null;
 	startTime: number;
+	endTime: number | null;
 	cwd: string;
 	/** If set, process was spawned inside this Docker container */
 	containerId?: string;
@@ -81,6 +82,7 @@ export interface BgProcessInfo {
 	status: "running" | "exited";
 	exitCode: number | null;
 	startTime: number;
+	endTime: number | null;
 }
 
 const MAX_LOG_LINES = 5000;
@@ -144,6 +146,7 @@ export class BgProcessManager {
 			status: "running",
 			exitCode: null,
 			startTime: Date.now(),
+			endTime: null,
 			cwd,
 			containerId,
 			exited,
@@ -210,6 +213,7 @@ export class BgProcessManager {
 		child.on("exit", (code) => {
 			bg.status = "exited";
 			bg.exitCode = code;
+			bg.endTime = Date.now();
 			// Resolve BEFORE broadcast/destroy so any awaiter on `bg.exited`
 			// observes status === 'exited' the moment they're scheduled.
 			resolveExited();
@@ -221,6 +225,7 @@ export class BgProcessManager {
 				type: "bg_process_exited",
 				processId: id,
 				exitCode: code,
+				endTime: bg.endTime,
 			} as any);
 		});
 
@@ -439,6 +444,7 @@ export class BgProcessManager {
 			status: bg.status,
 			exitCode: bg.exitCode,
 			startTime: bg.startTime,
+			endTime: bg.endTime,
 		};
 	}
 }

--- a/src/server/ws/protocol.ts
+++ b/src/server/ws/protocol.ts
@@ -105,9 +105,9 @@ export type ServerMessage =
 	| { type: "queue_update"; sessionId: string; queue: QueuedMessage[] }
 	| { type: "task_changed"; task: unknown }
 	| { type: "tasks_list"; tasks: unknown[] }
-	| { type: "bg_process_created"; process: { id: string; name: string; command: string; pid: number; status: string; exitCode: number | null; startTime: number } }
+	| { type: "bg_process_created"; process: { id: string; name: string; command: string; pid: number; status: "running" | "exited"; exitCode: number | null; startTime: number; endTime: number | null } }
 	| { type: "bg_process_output"; processId: string; stream: "stdout" | "stderr"; text: string; ts: number }
-	| { type: "bg_process_exited"; processId: string; exitCode: number | null }
+	| { type: "bg_process_exited"; processId: string; exitCode: number | null; endTime: number | null }
 	| { type: "gate_signal_received"; goalId: string; gateId: string; signalId: string }
 	| { type: "gate_verification_started"; goalId: string; gateId: string; signalId: string; startedAt?: number; steps?: Array<{ name: string; type: string; phase?: number }>; seq?: number }
 	| { type: "gate_verification_phase_started"; goalId: string; gateId: string; signalId: string; phase: number; stepIndices: number[]; seq?: number }

--- a/src/ui/components/BgProcessPill.ts
+++ b/src/ui/components/BgProcessPill.ts
@@ -13,6 +13,8 @@ export interface BgProcessInfo {
 	status: "running" | "exited";
 	exitCode: number | null;
 	startTime: number;
+	/** Null while running; optional for legacy hydrated processes. */
+	endTime?: number | null;
 }
 
 /**
@@ -184,6 +186,20 @@ export class BgProcessPill extends LitElement {
 					: html`<span class="inline-block w-1.5 h-1.5 rounded-full bg-muted-foreground shrink-0"></span>`;
 	}
 
+	private _hasValidEndTime(p: BgProcessInfo): p is BgProcessInfo & { endTime: number } {
+		return typeof p.endTime === "number" && Number.isFinite(p.endTime) && p.endTime >= p.startTime;
+	}
+
+	private _runtimeTemplate(p: BgProcessInfo, isRunning: boolean) {
+		if (isRunning) {
+			return html`<live-timer .startTime=${p.startTime} .running=${true}></live-timer>`;
+		}
+		if (this._hasValidEndTime(p)) {
+			return html`<live-timer .startTime=${p.startTime} .endTime=${p.endTime} .running=${false}></live-timer>`;
+		}
+		return html`<span title="Runtime unavailable for legacy process">—</span>`;
+	}
+
 	private _dropdownTemplate() {
 		const p = this.process;
 		const isRunning = p.status === "running";
@@ -221,8 +237,8 @@ export class BgProcessPill extends LitElement {
 						${!isRunning && p.exitCode !== null
 							? html`<span class="font-mono text-sm font-semibold ${p.exitCode === 0 ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400'}">exit ${p.exitCode}</span>`
 							: nothing}
-						<span class="font-mono text-[11px] text-muted-foreground" title="Elapsed since process started">
-							<live-timer .startTime=${p.startTime} .running=${isRunning}></live-timer>
+						<span class="font-mono text-[11px] text-muted-foreground" title=${isRunning || this._hasValidEndTime(p) ? "Elapsed since process started" : "Runtime unavailable for legacy process"}>
+							${this._runtimeTemplate(p, isRunning)}
 						</span>
 						${isRunning
 							? html`<button

--- a/src/ui/components/LiveTimer.ts
+++ b/src/ui/components/LiveTimer.ts
@@ -5,10 +5,12 @@ import { property } from "lit/decorators.js";
  * A tiny element that counts up from a start time, updating every second.
  * Usage: <live-timer .startTime=${Date.now()}></live-timer>
  * Displays: "0s", "1s", "2s", ... "1m30s", etc.
- * Stops updating when `running` is set to false.
+ * Stops updating when `running` is set to false. When `endTime` is provided,
+ * non-running timers render the fixed start-to-end duration.
  */
 export class LiveTimer extends LitElement {
 	@property({ type: Number }) startTime: number = Date.now();
+	@property({ type: Number }) endTime: number | null = null;
 	@property({ type: Boolean }) running: boolean = true;
 
 	private _interval: ReturnType<typeof setInterval> | null = null;
@@ -52,7 +54,11 @@ export class LiveTimer extends LitElement {
 	}
 
 	override render() {
-		const elapsed = Math.max(0, Math.round((Date.now() - this.startTime) / 1000));
+		const referenceTime = !this.running && typeof this.endTime === "number" && Number.isFinite(this.endTime)
+			? this.endTime
+			: Date.now();
+		const elapsed = Math.max(0, Math.round((referenceTime - this.startTime) / 1000));
+		if (!Number.isFinite(elapsed)) return html`—`;
 		const display = elapsed < 60 ? `${elapsed}s` : `${Math.floor(elapsed / 60)}m ${String(elapsed % 60).padStart(2, '0')}s`;
 		return html`${display}`;
 	}

--- a/tests/bg-process-manager.test.ts
+++ b/tests/bg-process-manager.test.ts
@@ -297,5 +297,45 @@ describe("BgProcessManager.waitForExit \u2014 state machine", () => {
 	});
 });
 
+describe("BgProcessManager endTime snapshots", () => {
+	it("created/running process info exposes endTime null", () => {
+		const { mgr } = makeManager();
+		const SESSION = freshSession();
+		const info = mgr.create(SESSION, "sleep 30", os.tmpdir());
+
+		try {
+			assert.equal((info as { endTime?: unknown }).endTime, null, "running BgProcessInfo must include endTime: null");
+		} finally {
+			mgr.cleanup(SESSION);
+		}
+	});
+
+	it("list() and waitForExit() expose numeric endTime after child exit", async () => {
+		const { mgr, last } = makeManager();
+		const SESSION = freshSession();
+		const info = mgr.create(SESSION, "noop", os.tmpdir());
+
+		try {
+			const waitPromise = mgr.waitForExit(SESSION, info.id, 10_000);
+			queueMicrotask(() => last().emit("exit", 0));
+
+			const result = await waitPromise;
+			assert.ok(result);
+			const listed = mgr.list(SESSION).find((p) => p.id === info.id);
+			assert.ok(listed);
+
+			const listEndTime = (listed as { endTime?: unknown }).endTime;
+			const waitEndTime = (result!.info as { endTime?: unknown }).endTime;
+
+			assert.equal(typeof listEndTime, "number", "exited list() snapshot must include numeric endTime");
+			assert.equal(typeof waitEndTime, "number", "waitForExit() snapshot must include numeric endTime");
+			assert.ok((listEndTime as number) >= info.startTime, "list() endTime must be at or after startTime");
+			assert.equal(waitEndTime, listEndTime, "waitForExit() and list() should report the same final endTime");
+		} finally {
+			mgr.cleanup(SESSION);
+		}
+	});
+});
+
 // Make sure no global mock timer state leaks between describe blocks.
 mock.timers.reset();

--- a/tests/bg-process-states.spec.ts
+++ b/tests/bg-process-states.spec.ts
@@ -5,9 +5,26 @@
  * kill/dismiss buttons, outside-click close, Escape close, exit code display.
  */
 import { test, expect, type Page } from "@playwright/test";
+import fs from "node:fs";
 import path from "node:path";
+import { buildBundle } from "./fixtures/build-bundle.js";
 
 const FIXTURE = `file://${path.resolve("tests/bg-process-states.html").replace(/\\/g, "/")}`;
+const TIMER_FIXTURE_PATH = path.resolve("tests/fixtures/bg-process-timer.html");
+const TIMER_FIXTURE = `file://${TIMER_FIXTURE_PATH.replace(/\\/g, "/")}`;
+const TIMER_ENTRY = path.resolve("tests/fixtures/bg-process-timer-entry.ts");
+const TIMER_BUNDLE = path.resolve("test-results/bg-process-timer-bundle.js");
+const BG_PROCESS_PILL_SRC = path.resolve("src/ui/components/BgProcessPill.ts");
+const LIVE_TIMER_SRC = path.resolve("src/ui/components/LiveTimer.ts");
+
+test.beforeAll(() => {
+	fs.mkdirSync(path.dirname(TIMER_BUNDLE), { recursive: true });
+	buildBundle({
+		entry: TIMER_ENTRY,
+		outfile: TIMER_BUNDLE,
+		deps: [TIMER_ENTRY, BG_PROCESS_PILL_SRC, LIVE_TIMER_SRC],
+	});
+});
 
 const RUNNING_PROCESS = {
 	id: "bg-run-1",
@@ -52,6 +69,28 @@ async function createPill(page: Page, processInfo: typeof RUNNING_PROCESS) {
 
 async function cleanup(page: Page) {
 	await page.evaluate(() => (window as any).clearPills());
+}
+
+async function readyTimerFixture(page: Page) {
+	await page.waitForFunction(() => (window as any).__bgTimerReady === true);
+}
+
+async function gotoTimerFixture(page: Page) {
+	await page.goto(TIMER_FIXTURE);
+	await page.addScriptTag({ path: TIMER_BUNDLE });
+	await readyTimerFixture(page);
+}
+
+async function createTimerPill(page: Page, processInfo: Record<string, unknown>) {
+	return page.evaluate((p) => {
+		const pill = (window as any).createPill(p);
+		return pill !== null;
+	}, processInfo);
+}
+
+async function openTimerDropdown(page: Page) {
+	await page.locator("bg-process-pill button").first().click();
+	await expect(page.locator("#bg-process-dropdown")).toBeVisible();
 }
 
 test.describe("BgProcessPill status indicators", () => {
@@ -383,5 +422,86 @@ test.describe("BgProcessPill exit code display", () => {
 		const dropdown = page.locator("#bg-process-dropdown");
 		await expect(dropdown).toContainText("bg-run-1");
 		await expect(dropdown).toContainText("pid 12345");
+	});
+});
+
+test.describe("BG timer regression", () => {
+	test.beforeEach(async ({ page }) => {
+		await gotoTimerFixture(page);
+	});
+
+	test.afterEach(async ({ page }) => {
+		await page.evaluate(() => (window as any).clearPills());
+	});
+
+	test("exited process uses endTime runtime and stays fixed after re-render and reload", async ({ page }) => {
+		const startTime = Date.now() - 24 * 60 * 60 * 1000;
+		const processInfo = {
+			id: "bg-fixed-runtime",
+			name: "finished build",
+			command: "npm run build",
+			pid: 22222,
+			status: "exited" as const,
+			exitCode: 0,
+			startTime,
+			endTime: startTime + 120_000,
+		};
+
+		await createTimerPill(page, processInfo);
+		await openTimerDropdown(page);
+
+		const dropdown = page.locator("#bg-process-dropdown");
+		await expect(dropdown).toContainText(/\b2m 00s\b/);
+		const before = await dropdown.innerText();
+
+		await page.waitForTimeout(1100);
+		await page.evaluate(() => (window as any).forceBgTimerRerender());
+		await expect(dropdown).toContainText(/\b2m 00s\b/);
+		expect(await dropdown.innerText()).toBe(before);
+
+		await page.reload();
+		await page.addScriptTag({ path: TIMER_BUNDLE });
+		await readyTimerFixture(page);
+		await createTimerPill(page, processInfo);
+		await openTimerDropdown(page);
+		await expect(page.locator("#bg-process-dropdown")).toContainText(/\b2m 00s\b/);
+	});
+
+	test("legacy exited process without endTime does not show time since start", async ({ page }) => {
+		const processInfo = {
+			id: "bg-legacy-runtime",
+			name: "legacy build",
+			command: "npm run build",
+			pid: 22223,
+			status: "exited" as const,
+			exitCode: 0,
+			startTime: Date.now() - 24 * 60 * 60 * 1000,
+		};
+
+		await createTimerPill(page, processInfo);
+		await openTimerDropdown(page);
+
+		const text = await page.locator("#bg-process-dropdown").innerText();
+		expect(text).not.toMatch(/\b(?:\d{3,}m\s+\d{2}s|\d+h\b|\d+d\b)/i);
+	});
+
+	test("running process timer increments while running", async ({ page }) => {
+		const processInfo = {
+			id: "bg-running-runtime",
+			name: "dev server",
+			command: "npm run dev",
+			pid: 22224,
+			status: "running" as const,
+			exitCode: null,
+			startTime: Date.now() - 1000,
+			endTime: null,
+		};
+
+		await createTimerPill(page, processInfo);
+		await openTimerDropdown(page);
+
+		const timer = page.locator("#bg-process-dropdown live-timer");
+		const initial = ((await timer.textContent()) || "").trim();
+		await expect.poll(async () => ((await timer.textContent()) || "").trim(), { timeout: 2500 }).not.toBe(initial);
 	});
 });

--- a/tests/fixtures/bg-process-timer-entry.ts
+++ b/tests/fixtures/bg-process-timer-entry.ts
@@ -1,0 +1,78 @@
+import "../../src/ui/components/BgProcessPill.js";
+import type { BgProcessPill, BgProcessInfo } from "../../src/ui/components/BgProcessPill.js";
+
+type BgProcessInfoWithEndTime = BgProcessInfo & { endTime?: number | null };
+
+const fetchCalls: Array<{ url: string; method: string; headers?: HeadersInit }> = [];
+let mockLogs: Array<{ ts: number; text: string }> = [];
+
+const originalFetch = window.fetch.bind(window);
+window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+	const url = String(input);
+	fetchCalls.push({ url, method: init?.method || "GET", headers: init?.headers });
+
+	if (url.includes("/logs")) {
+		return new Response(JSON.stringify({ log: mockLogs }), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+	}
+
+	if (url.includes("/kill")) {
+		return new Response(JSON.stringify({ success: true }), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+	}
+
+	return originalFetch(input, init);
+};
+
+function container(): HTMLElement {
+	const el = document.getElementById("pill-container");
+	if (!el) throw new Error("missing #pill-container");
+	return el;
+}
+
+function createPill(processInfo: BgProcessInfoWithEndTime, sessionId = "test-session"): BgProcessPill {
+	const pill = document.createElement("bg-process-pill") as BgProcessPill;
+	pill.sessionId = sessionId;
+	pill.process = processInfo as BgProcessInfo;
+	container().appendChild(pill);
+	return pill;
+}
+
+function clearPills(): void {
+	container().innerHTML = "";
+	document.querySelectorAll("[data-bg-portal], #bg-process-dropdown").forEach((el) => el.remove());
+	fetchCalls.length = 0;
+	mockLogs = [];
+}
+
+async function forceBgTimerRerender(): Promise<void> {
+	const pill = document.querySelector("bg-process-pill") as (BgProcessPill & { _renderPortal?: () => void }) | null;
+	pill?.requestUpdate?.();
+	await pill?.updateComplete;
+	pill?._renderPortal?.();
+
+	const timer = document.querySelector("#bg-process-dropdown live-timer") as (HTMLElement & { requestUpdate?: () => void; updateComplete?: Promise<unknown> }) | null;
+	timer?.requestUpdate?.();
+	await timer?.updateComplete;
+}
+
+function setMockLogs(logs: Array<{ ts: number; text: string }>): void {
+	mockLogs = logs;
+}
+
+function getFetchCalls(): Array<{ url: string; method: string; headers?: HeadersInit }> {
+	return [...fetchCalls];
+}
+
+Object.assign(window, {
+	createPill,
+	clearPills,
+	forceBgTimerRerender,
+	setMockLogs,
+	getFetchCalls,
+	__bgTimerReady: true,
+});

--- a/tests/fixtures/bg-process-timer.html
+++ b/tests/fixtures/bg-process-timer.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>BgProcessPill timer fixture</title>
+<style>
+	body {
+		font-family: system-ui, sans-serif;
+		font-size: 14px;
+		padding: 20px;
+	}
+	#pill-container {
+		display: flex;
+		gap: 12px;
+		align-items: center;
+	}
+	.font-mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+	.fixed { position: fixed; }
+	.flex { display: flex; }
+	.inline-flex { display: inline-flex; }
+	.items-center { align-items: center; }
+	.justify-between { justify-content: space-between; }
+	.gap-1 { gap: 0.25rem; }
+	.gap-1\.5 { gap: 0.375rem; }
+	.gap-2 { gap: 0.5rem; }
+	.p-2 { padding: 0.5rem; }
+	.px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
+	.px-1\.5 { padding-left: 0.375rem; padding-right: 0.375rem; }
+	.px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+	.py-0\.5 { padding-top: 0.125rem; padding-bottom: 0.125rem; }
+	.py-1\.5 { padding-top: 0.375rem; padding-bottom: 0.375rem; }
+	.mb-1\.5 { margin-bottom: 0.375rem; }
+	.rounded { border-radius: 0.25rem; }
+	.rounded-full { border-radius: 9999px; }
+	.rounded-lg { border-radius: 0.5rem; }
+	.rounded-l-full { border-radius: 9999px 0 0 9999px; }
+	.rounded-r-full { border-radius: 0 9999px 9999px 0; }
+	.border { border: 1px solid #d1d5db; }
+	.border-l { border-left: 1px solid #d1d5db; }
+	.text-xs { font-size: 12px; }
+	.text-sm { font-size: 14px; }
+	.text-\[10px\] { font-size: 10px; }
+	.text-\[11px\] { font-size: 11px; }
+	.leading-tight { line-height: 1.25; }
+	.leading-snug { line-height: 1.375; }
+	.font-medium { font-weight: 500; }
+	.font-semibold { font-weight: 600; }
+	.font-normal { font-weight: 400; }
+	.min-w-0 { min-width: 0; }
+	.truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+	.break-all { word-break: break-all; }
+	.whitespace-pre-wrap { white-space: pre-wrap; }
+	.overflow-y-auto { overflow-y: auto; }
+	.shrink-0 { flex-shrink: 0; }
+	.cursor-pointer { cursor: pointer; }
+	.select-none { user-select: none; }
+	.w-1\.5 { width: 6px; }
+	.h-1\.5 { height: 6px; }
+	.h-\[180px\] { height: 180px; }
+	.bg-card { background: #fff; }
+	.bg-background { background: #f9fafb; }
+	.bg-muted { background: #f3f4f6; }
+	.bg-blue-600 { background: #2563eb; }
+	.bg-green-600 { background: #16a34a; }
+	.text-muted-foreground { color: #6b7280; }
+	.text-foreground { color: #111827; }
+	.text-green-700 { color: #15803d; }
+	.text-red-700, .text-red-600 { color: #b91c1c; }
+</style>
+</head>
+<body>
+<div id="pill-container"></div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add server-side `endTime` for background processes and publish it through REST/WS payloads
- Render exited background-process runtimes as fixed start-to-exit durations, with a safe legacy fallback
- Add regression coverage and update REST/WS/internal docs

## Verification
- npm run check
- Targeted bg-process endTime unit + Playwright regression tests
- Workflow implementation gate passed full verification

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)