### PR TITLE
Fix GPT-5.5 context metadata drift

### DIFF
--- a/src/server/agent/aigw-manager.ts
+++ b/src/server/agent/aigw-manager.ts
@@ -96,14 +96,17 @@ const INFER_RULES: InferRule[] = [
 	{ test: /claude-haiku/, meta: { contextWindow: 200_000, maxTokens: 8_192, reasoning: false, input: ["text", "image"] } },
 	{ test: /claude/, meta: { contextWindow: 200_000, maxTokens: 16_384, reasoning: false, input: ["text", "image"] } },
 
-	// ── OpenAI GPT-5.x (pro first so it doesn't match the bare 5.5) ─
+	// ── OpenAI GPT-5.x (pro first so it doesn't match base variants) ─
 	{ test: /gpt-5\.5-pro/, meta: { contextWindow: 1_050_000, maxTokens: 128_000, reasoning: true, input: ["text", "image"] } },
-	{ test: /gpt-5\.5/, meta: { contextWindow: 1_000_000, maxTokens: 128_000, reasoning: true, input: ["text", "image"] } },
+	{ test: /gpt-5\.5/, meta: { contextWindow: 272_000, maxTokens: 128_000, reasoning: true, input: ["text", "image"] } },
+	{ test: /gpt-5\.4-pro/, meta: { contextWindow: 1_050_000, maxTokens: 128_000, reasoning: true, input: ["text", "image"] } },
 	// gpt-5.1-codex-max and gpt-5.2* / gpt-5.4* are reasoning models (and
 	// xhigh-capable per src/shared/thinking-levels.ts). They must be classified
 	// as reasoning so server-side clamping does not collapse xhigh to off for
-	// aigw-routed users.
-	{ test: /gpt-5\.4/, meta: { contextWindow: 1_050_000, maxTokens: 128_000, reasoning: true, input: ["text", "image"] } },
+	// aigw-routed users. Base gpt-5.4/5.5 currently advertise a 272k active
+	// window in pi-ai; using the old speculative 1M here makes compaction look
+	// far too early and can defer threshold compaction until provider overflow.
+	{ test: /gpt-5\.4/, meta: { contextWindow: 272_000, maxTokens: 128_000, reasoning: true, input: ["text", "image"] } },
 	{ test: /gpt-5\.2/, meta: { contextWindow: 400_000, maxTokens: 128_000, reasoning: true, input: ["text", "image"] } },
 	{ test: /gpt-5\.1-codex-max/, meta: { contextWindow: 400_000, maxTokens: 128_000, reasoning: true, input: ["text", "image"] } },
 	{ test: /gpt-5/, meta: { contextWindow: 400_000, maxTokens: 32_768, reasoning: false, input: ["text", "image"] } },

--- a/src/server/agent/model-registry.ts
+++ b/src/server/agent/model-registry.ts
@@ -104,6 +104,20 @@ function getPrefsVersion(prefs: PreferencesStore): number {
 
 // ── Model Assembly ─────────────────────────────────────────────────
 
+function shouldRaiseBuiltInMeta(modelId: string, explicitValue: number | undefined, inferredValue: number): boolean {
+	if (!explicitValue || inferredValue <= explicitValue) return false;
+	// Bobbit intentionally patches stale Claude Sonnet/Opus metadata upward (see
+	// writeContextWindowOverrides). Do not use generic inference to inflate newer
+	// OpenAI built-ins; pi-ai's provider-specific metadata is authoritative there.
+	return /claude-(?:opus|sonnet)/i.test(modelId);
+}
+
+function builtInNumber(modelId: string, explicitValue: unknown, inferredValue: number): number {
+	const explicit = typeof explicitValue === "number" && explicitValue > 0 ? explicitValue : undefined;
+	if (shouldRaiseBuiltInMeta(modelId, explicit, inferredValue)) return inferredValue;
+	return explicit ?? inferredValue;
+}
+
 async function assembleModels(prefs: PreferencesStore): Promise<ApiModel[]> {
 	const results: ApiModel[] = [];
 	const aigwUrl = getAigwUrl(prefs);
@@ -138,8 +152,8 @@ async function assembleModels(prefs: PreferencesStore): Promise<ApiModel[]> {
 						provider: providerId as string,
 						api: m.api as string,
 						baseUrl: m.baseUrl,
-						contextWindow: Math.max(meta.contextWindow, m.contextWindow || 0),
-						maxTokens: Math.max(meta.maxTokens, m.maxTokens || 0),
+						contextWindow: builtInNumber(m.id, m.contextWindow, meta.contextWindow),
+						maxTokens: builtInNumber(m.id, m.maxTokens, meta.maxTokens),
 						reasoning: meta.reasoning || m.reasoning || false,
 						...(m.thinkingLevelMap ? { thinkingLevelMap: m.thinkingLevelMap as Record<string, string | null> } : {}),
 						input: (meta.input && meta.input.length > (m.input?.length || 0)) ? meta.input : (m.input || ["text"]) as ("text" | "image")[],

--- a/src/server/agent/openai-model-additions.ts
+++ b/src/server/agent/openai-model-additions.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { getModels } from "@earendil-works/pi-ai";
+
 import { globalAgentDir } from "../bobbit-dir.js";
 import type { ApiModel } from "./model-registry.js";
 
@@ -9,16 +11,17 @@ type OpenAIAddition = Omit<ApiModel, "authenticated">;
 /**
  * ── OpenAI / OpenAI-Codex model additions ─────────────────────────
  *
- * These entries are merged into the user's `models.json` so that pi-ai's
- * model registry surfaces speculative future-flagship OpenAI models (GPT-5.5
- * variants) under both the `openai` and `openai-codex` providers.
+ * These entries are merged into the user's `models.json` only when pi-ai does
+ * not already ship the same provider/model pair. Once pi-ai adds a model,
+ * `writeOpenAIModelAdditions` removes Bobbit-owned duplicate custom entries so
+ * stale speculative metadata cannot shadow the built-in registry.
  *
- * Cost values below are best-guess placeholders. `writeOpenAIModelAdditions`
- * is conservative: when an entry already exists in `models.json`, it only
- * overwrites a specific field if that field still equals the value Bobbit
- * previously emitted as the default (tracked in `PREV_DEFAULTS`). This
- * preserves user-edited fields across upgrades — if you tweaked the cost
- * locally, future Bobbit versions won't clobber it.
+ * Cost values below are best-guess placeholders. The merge is conservative:
+ * when an entry already exists in `models.json`, it only overwrites a specific
+ * field if that field still equals the value Bobbit previously emitted as the
+ * default (tracked in `PREV_DEFAULTS`). This preserves user-edited fields
+ * across upgrades — if you tweaked the cost locally, future Bobbit versions
+ * won't clobber it.
  *
  * Adding a new revision: when you change a field's default below, append the
  * *previous* default to `PREV_DEFAULTS` (keyed by `${provider}::${id}::${field}`)
@@ -142,6 +145,14 @@ function valuesEqual(a: unknown, b: unknown): boolean {
 	return false;
 }
 
+function getBuiltInModel(provider: string, id: string): Record<string, unknown> | undefined {
+	try {
+		return (getModels(provider as any) as unknown as Array<Record<string, unknown>>).find((m) => m.id === id);
+	} catch {
+		return undefined;
+	}
+}
+
 function isBobbitOwned(provider: string, id: string, field: string, currentValue: unknown, currentDefault: unknown): boolean {
 	if (valuesEqual(currentValue, currentDefault)) return true;
 	const key = `${provider}::${id}::${field}`;
@@ -167,6 +178,72 @@ const ADDITION_FIELD_SAMPLE: Record<keyof Omit<OpenAIAddition, "id" | "provider"
 };
 const ADDITION_FIELDS: Array<keyof OpenAIAddition> = Object.keys(ADDITION_FIELD_SAMPLE) as Array<keyof OpenAIAddition>;
 
+function hasUserEditedField(provider: string, model: OpenAIAddition, existing: Record<string, unknown>): boolean {
+	const knownKeys = new Set<string>(["id", ...ADDITION_FIELDS.map(String)]);
+	if (Object.keys(existing).some((key) => !knownKeys.has(key))) return true;
+	return ADDITION_FIELDS.some((field) => {
+		const current = existing[field];
+		if (current === undefined) return false;
+		const defaultValue = (model as Record<string, unknown>)[field];
+		return !isBobbitOwned(provider, model.id, field, current, defaultValue);
+	});
+}
+
+function syncOrRemoveBuiltInDuplicate(
+	provider: string,
+	model: OpenAIAddition,
+	builtIn: Record<string, unknown>,
+	models: Array<Record<string, unknown>>,
+	existing: Record<string, unknown>,
+): boolean {
+	const index = models.indexOf(existing);
+	if (index === -1) return false;
+
+	// Pure Bobbit additions should disappear once pi-ai ships the model. Leaving
+	// them in `models.json` shadows the built-in entry because pi-coding-agent's
+	// custom-model merge is provider+id-last-wins.
+	if (!hasUserEditedField(provider, model, existing)) {
+		models.splice(index, 1);
+		return true;
+	}
+
+	// If the user edited one field (for example pricing), keep the custom entry
+	// but migrate any still-Bobbit-owned fields to the now-authoritative built-in
+	// values so stale context windows do not survive indefinitely.
+	let changed = false;
+	for (const field of ADDITION_FIELDS) {
+		const builtInValue = builtIn[field];
+		if (builtInValue === undefined) continue;
+		const current = existing[field];
+		const defaultValue = (model as Record<string, unknown>)[field];
+		if (current === undefined || isBobbitOwned(provider, model.id, field, current, defaultValue)) {
+			if (!valuesEqual(current, builtInValue)) {
+				existing[field] = builtInValue;
+				changed = true;
+			}
+		}
+	}
+	return changed;
+}
+
+function pruneEmptyProviderBlocks(data: Record<string, any>): boolean {
+	let changed = false;
+	for (const [provider, config] of Object.entries(data.providers ?? {})) {
+		if (
+			config &&
+			typeof config === "object" &&
+			!Array.isArray(config) &&
+			Object.keys(config).length === 1 &&
+			Array.isArray((config as any).models) &&
+			(config as any).models.length === 0
+		) {
+			delete data.providers[provider];
+			changed = true;
+		}
+	}
+	return changed;
+}
+
 export function writeOpenAIModelAdditions(): void {
 	const data = readModelsJson();
 	if (!data.providers) data.providers = {};
@@ -174,11 +251,19 @@ export function writeOpenAIModelAdditions(): void {
 	let changed = false;
 	for (const model of OPENAI_MODEL_ADDITIONS) {
 		const provider = model.provider;
+		const builtIn = getBuiltInModel(provider, model.id);
+		if (builtIn && !data.providers[provider]) continue;
+
 		if (!data.providers[provider]) data.providers[provider] = {};
 		if (!Array.isArray(data.providers[provider].models)) data.providers[provider].models = [];
 
 		const models = data.providers[provider].models as Array<Record<string, unknown>>;
 		const existing = models.find((m) => m.id === model.id) as Record<string, unknown> | undefined;
+
+		if (builtIn) {
+			if (existing && syncOrRemoveBuiltInDuplicate(provider, model, builtIn, models, existing)) changed = true;
+			continue;
+		}
 
 		if (!existing) {
 			// Entry missing entirely — write the full default payload.
@@ -217,5 +302,6 @@ export function writeOpenAIModelAdditions(): void {
 		}
 	}
 
+	if (pruneEmptyProviderBlocks(data)) changed = true;
 	if (changed) writeModelsJson(data);
 }

--- a/tests/model-utils.test.ts
+++ b/tests/model-utils.test.ts
@@ -68,17 +68,17 @@ describe("inferMeta()", () => {
 		assert.equal(meta.contextWindow, 400_000);
 	});
 
-	it("GPT-5.4 → reasoning=true so xhigh does not clamp to off", () => {
+	it("GPT-5.4 → 272K context and reasoning=true so xhigh does not clamp to off", () => {
 		const meta = inferMeta("gpt-5.4");
-		assert.equal(meta.contextWindow, 1_050_000);
+		assert.equal(meta.contextWindow, 272_000);
 		assert.equal(meta.maxTokens, 128_000);
 		assert.equal(meta.reasoning, true);
 		assert.ok(meta.input!.includes("image"));
 	});
 
-	it("GPT-5.5 → 1M context, 128K max, reasoning=true", () => {
+	it("GPT-5.5 → 272K context, 128K max, reasoning=true", () => {
 		const meta = inferMeta("gpt-5.5");
-		assert.equal(meta.contextWindow, 1_000_000);
+		assert.equal(meta.contextWindow, 272_000);
 		assert.equal(meta.maxTokens, 128_000);
 		assert.equal(meta.reasoning, true);
 		assert.ok(meta.input!.includes("image"));

--- a/tests/models-api.test.ts
+++ b/tests/models-api.test.ts
@@ -78,6 +78,12 @@ describe("Model registry", () => {
 			}
 		}
 	});
+
+	it("OpenAI-Codex gpt-5.5 uses pi-ai's provider-specific 272K window", () => {
+		const model = models.find((m) => m.provider === "openai-codex" && m.id === "gpt-5.5");
+		assert.ok(model, "openai-codex/gpt-5.5 should be available");
+		assert.equal(model.contextWindow, 272_000);
+	});
 });
 
 // Cleanup

--- a/tests/openai-model-additions-merge.test.ts
+++ b/tests/openai-model-additions-merge.test.ts
@@ -16,6 +16,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { getModels } from "@earendil-works/pi-ai";
 
 let tmp: string;
 let previousAgentDir: string | undefined;
@@ -46,26 +47,43 @@ function readModels(): any {
 	return JSON.parse(readFileSync(f, "utf-8"));
 }
 
-function findEntry(data: any, provider: string, id: string): any {
+function findOptionalEntry(data: any, provider: string, id: string): any | undefined {
 	const list = data?.providers?.[provider]?.models;
-	assert.ok(Array.isArray(list), `expected models array for provider ${provider}`);
-	const e = list.find((m: any) => m.id === id);
+	if (!Array.isArray(list)) return undefined;
+	return list.find((m: any) => m.id === id);
+}
+
+function findEntry(data: any, provider: string, id: string): any {
+	const e = findOptionalEntry(data, provider, id);
 	assert.ok(e, `expected entry ${provider}/${id} in models.json`);
 	return e;
 }
 
+function hasBuiltIn(provider: string, id: string): boolean {
+	return getModels(provider as any).some((m: any) => m.id === id);
+}
+
+function customAdditionSample(): (typeof OPENAI_MODEL_ADDITIONS)[number] {
+	const sample = OPENAI_MODEL_ADDITIONS.find((m) => !hasBuiltIn(m.provider, m.id));
+	assert.ok(sample, "test requires at least one Bobbit-only OpenAI model addition");
+	return sample;
+}
+
 describe("writeOpenAIModelAdditions merge policy", () => {
-	it("empty file → all defaults written", () => {
+	it("empty file → only additions missing from pi-ai built-ins are written", () => {
 		writeOpenAIModelAdditions();
 		const data = readModels();
-		assert.ok(data, "models.json should exist after the call");
-		// Every entry from OPENAI_MODEL_ADDITIONS must be present.
-		for (const m of OPENAI_MODEL_ADDITIONS) {
+		const expected = OPENAI_MODEL_ADDITIONS.filter((m) => !hasBuiltIn(m.provider, m.id));
+		if (expected.length > 0) assert.ok(data, "models.json should exist after the call");
+		for (const m of expected) {
 			const e = findEntry(data, m.provider, m.id);
 			assert.equal(e.name, m.name);
 			assert.equal(e.api, m.api);
 			assert.equal(e.baseUrl, m.baseUrl);
 			assert.deepEqual(e.cost, m.cost);
+		}
+		for (const m of OPENAI_MODEL_ADDITIONS.filter((m) => hasBuiltIn(m.provider, m.id))) {
+			assert.equal(findOptionalEntry(data, m.provider, m.id), undefined, `${m.provider}/${m.id} should use pi-ai's built-in metadata`);
 		}
 	});
 
@@ -74,7 +92,7 @@ describe("writeOpenAIModelAdditions merge policy", () => {
 		writeOpenAIModelAdditions();
 		// 2) user edits a field — change `name` away from the default.
 		const data1 = readModels();
-		const sample = OPENAI_MODEL_ADDITIONS[0];
+		const sample = customAdditionSample();
 		const entry = findEntry(data1, sample.provider, sample.id);
 		entry.name = "User Custom Name";
 		writeFileSync(path.join(tmp, "models.json"), JSON.stringify(data1, null, 2));
@@ -95,7 +113,7 @@ describe("writeOpenAIModelAdditions merge policy", () => {
 		// handles. We then mutate the `cost` field to something else and
 		// verify mutation survives, while `name` is left undisturbed (because
 		// it already matched the default).
-		const sample = OPENAI_MODEL_ADDITIONS[0];
+		const sample = customAdditionSample();
 		const seeded = {
 			providers: {
 				[sample.provider]: {
@@ -125,9 +143,72 @@ describe("writeOpenAIModelAdditions merge policy", () => {
 		assert.equal(e.name, sample.name);
 	});
 
+	it("Bobbit-owned duplicate is removed once pi-ai ships the same model", () => {
+		const sample = OPENAI_MODEL_ADDITIONS.find((m) => m.provider === "openai-codex" && m.id === "gpt-5.5");
+		assert.ok(sample && hasBuiltIn(sample.provider, sample.id), "expected openai-codex/gpt-5.5 to be a pi-ai built-in");
+		const seeded = {
+			providers: {
+				[sample.provider]: {
+					models: [
+						{
+							id: sample.id,
+							name: sample.name,
+							api: sample.api,
+							baseUrl: sample.baseUrl,
+							cost: sample.cost,
+							contextWindow: sample.contextWindow,
+							maxTokens: sample.maxTokens,
+							reasoning: sample.reasoning,
+							thinkingLevelMap: sample.thinkingLevelMap,
+							input: sample.input,
+						},
+					],
+				},
+			},
+		};
+		writeFileSync(path.join(tmp, "models.json"), JSON.stringify(seeded, null, 2));
+		writeOpenAIModelAdditions();
+		const data = readModels();
+		assert.equal(findOptionalEntry(data, sample.provider, sample.id), undefined);
+	});
+
+	it("user-edited duplicate keeps edits but migrates Bobbit-owned fields to built-in metadata", () => {
+		const sample = OPENAI_MODEL_ADDITIONS.find((m) => m.provider === "openai-codex" && m.id === "gpt-5.5");
+		assert.ok(sample, "expected legacy openai-codex/gpt-5.5 addition");
+		const builtIn = getModels(sample.provider as any).find((m: any) => m.id === sample.id) as any;
+		assert.ok(builtIn, "expected pi-ai built-in metadata");
+		const seeded = {
+			providers: {
+				[sample.provider]: {
+					models: [
+						{
+							id: sample.id,
+							name: "User Custom Name",
+							api: sample.api,
+							baseUrl: sample.baseUrl,
+							cost: sample.cost,
+							contextWindow: sample.contextWindow,
+							maxTokens: sample.maxTokens,
+							reasoning: sample.reasoning,
+							thinkingLevelMap: sample.thinkingLevelMap,
+							input: sample.input,
+						},
+					],
+				},
+			},
+		};
+		writeFileSync(path.join(tmp, "models.json"), JSON.stringify(seeded, null, 2));
+		writeOpenAIModelAdditions();
+		const data = readModels();
+		const e = findEntry(data, sample.provider, sample.id);
+		assert.equal(e.name, "User Custom Name");
+		assert.equal(e.contextWindow, builtIn.contextWindow);
+		assert.deepEqual(e.thinkingLevelMap, builtIn.thinkingLevelMap);
+	});
+
 	it("missing fields are filled in from defaults", () => {
 		// Seed a sparse entry that lacks `cost` and `baseUrl`.
-		const sample = OPENAI_MODEL_ADDITIONS[0];
+		const sample = customAdditionSample();
 		const seeded = {
 			providers: {
 				[sample.provider]: {


### PR DESCRIPTION
## Summary
- Use pi-ai's provider-specific 272K context metadata for base GPT-5.4/GPT-5.5 instead of stale speculative 1M values.
- Stop Bobbit OpenAI additions from shadowing pi-ai built-ins, while preserving user-edited custom fields.
- Add regression coverage for GPT-5.5 metadata and OpenAI addition merge behavior.

## Tests
- `npm run check`
- `npm run test:unit`
- `npx playwright test --config playwright-e2e.config.ts`

Note: `npm run test:e2e` hit a Windows file-lock before Playwright startup; the direct Playwright E2E run passed.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
