### PR TITLE
Update Preview Docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,10 +35,14 @@ per-session server mount views: `preview:live` is titled from the active entry
 `preview_open` tool cards and represent chat artifacts that can be selected or
 remounted later.
 
-Preview tabs also carry content identity when available. Matching live and
-historical previews collapse by `contentHash`, so users do not see duplicate tabs
-for the same mounted bytes. Different-content preview artifacts keep separate
-tabs and remain independently restorable through the one live server mount.
+Preview tabs also carry content identity when available. v3 historical previews
+use `contentHash` to collapse same-content artifacts into `preview:live`, so
+users do not see duplicate tabs for the same mounted bytes. If a v3 marker omits
+the hash to stay within its size cap, the remount response can supply it and the
+artifact can still collapse after the refresh. Different-content preview
+artifacts keep separate tabs and remain independently restorable through the one
+live server mount. Legacy v1/v2 snapshots remain historical even when their
+remount response includes a hash; they predate the v3 content-identity contract.
 Proposal tabs distinguish the live editable draft from read-only historical
 revisions, and review documents appear as top-level `Review: <title>` tabs.
 Review tab IDs encode the title, so titles with spaces, slashes, `?`, `#`, or

--- a/docs/preview-architecture.md
+++ b/docs/preview-architecture.md
@@ -58,10 +58,14 @@ Preview tab identity has two layers:
   `inline.html`. These tabs represent chat artifacts: opening them may remount
   the recorded snapshot into the one live server mount, or select the recorded
   v3 mount directly when no remount body is available.
-- Both live and historical preview tabs may carry `contentHash`. When a
-  historical tab's hash matches the current live hash, the workspace collapses
-  that artifact to `preview:live` instead of showing a duplicate tab. When hashes
-  differ, the tabs remain separate so each preview artifact can be restored.
+- The live tab and v3 historical preview tabs may carry `contentHash`. When a
+  v3 historical tab's hash matches the current live hash, the workspace
+  collapses that artifact to `preview:live` instead of showing a duplicate tab.
+  A v3 card whose marker omitted `contentHash` can still receive the hash from
+  the remount response and collapse after the refreshed mount proves identity.
+  When hashes differ, the tabs remain separate so each preview artifact can be
+  restored. Legacy v1/v2 tabs may record the remount hash for metadata, but they
+  stay historical and do not collapse into `preview:live`.
 - Desktop renders the content tabs in a horizontally scrollable strip. Mobile
   exposes the same tab set through the header tab bar and slider track; there is
   no desktop-only preview capability.
@@ -69,11 +73,14 @@ Preview tab identity has two layers:
 Opening a v3 historical card whose `contentHash` already matches the live mount
 selects the live tab and skips the remount POST. This avoids stale relative-file
 remounts and the false "File no longer available" state for content that is
-already mounted. Reopen failures stay local to the tab/card: missing file
-snapshots disable with "File no longer available", parse or fetch errors leave
-the button retryable and log `[PreviewRenderer] reopen failed`, and background
-tab-remount failures log `[panel-workspace] preview tab restore failed` without
-changing preview serving semantics.
+already mounted. If the v3 marker omitted `contentHash`, the renderer must
+remount from the original `html` / `file` params; the POST response then supplies
+the first usable hash and same-content tabs can collapse to `preview:live`.
+Reopen failures stay local to the tab/card: missing file snapshots disable with
+"File no longer available", parse or fetch errors leave the button retryable and
+log `[PreviewRenderer] reopen failed`, and background tab-remount failures log
+`[panel-workspace] preview tab restore failed` without changing preview serving
+semantics.
 
 ## Per-session mount
 
@@ -360,8 +367,11 @@ optional `contentHash`, and the original tool params to drive the **Open**
 button on tool cards. Opening a card selects a source-derived preview tab
 immediately. If the original call still carries `html` or `file`, the renderer
 can remount that snapshot into the live mount unless the v3 `contentHash` already
-matches the live mount. If no remount body is available, a v3 card selects the
-tab by recorded entry/mtime and points the iframe at the existing mount path.
+matches the live mount. When the marker omitted `contentHash` to preserve the
+250-byte cap, a successful remount `POST` returns the hash; the renderer attaches
+that hash to the v3 tab and can collapse it into `preview:live`. If no remount
+body is available, a v3 card selects the tab by recorded entry/mtime and points
+the iframe at the existing mount path.
 
 **`path` is host-invariant.** The field carries the project-root-relative
 `<sessionId>/<entry>` identifier (forward slashes on every OS), not the
@@ -382,16 +392,18 @@ sessions:
 
 | Marker | Payload | Renderer behaviour |
 |---|---|---|
-| `__preview_snapshot_v1__` | raw inline HTML | Create/select a historical preview tab and remount via `POST /api/preview/mount {html}` |
-| `__preview_snapshot_v2__` | `{kind:"file",path}` | Create/select a historical preview tab and remount via `POST /api/preview/mount {file}` |
-| `__preview_snapshot_v3__` | `{kind:"preview",url,path,contentHash?}` | Create/select a historical preview tab; collapse to live and skip remount when `contentHash` already matches; otherwise remount from original `html`/`file` params when available or select by recorded entry/mtime |
+| `__preview_snapshot_v1__` | raw inline HTML | Create/select a historical preview tab and remount via `POST /api/preview/mount {html}`; the tab does not collapse into `preview:live` solely because the remount response includes `contentHash` |
+| `__preview_snapshot_v2__` | `{kind:"file",path}` | Create/select a historical preview tab and remount via `POST /api/preview/mount {file}`; the tab does not collapse into `preview:live` solely because the remount response includes `contentHash` |
+| `__preview_snapshot_v3__` | `{kind:"preview",url,path,contentHash?}` | Create/select a historical preview tab; collapse to live and skip remount when `contentHash` already matches; otherwise remount from original `html`/`file` params when available, using the POST response hash to collapse same-content remounts, or select by recorded entry/mtime |
 
 The v1/v2 builder functions have been deleted — no new code path emits them.
 The marker constants are tagged `Read-only legacy support … Do not extend`
 in both `snapshot.ts` and `PreviewRenderer.ts`. Reopen flows for v1/v2 in
 `PreviewRenderer.ts::onClick` route through the unified mount endpoint, so
 WP-G's deletion of `/api/preview/render` and `/api/preview/asset` doesn't
-break old archived sessions.
+break old archived sessions. Those legacy flows preserve historical-tab
+semantics even though the unified mount endpoint now returns `contentHash`.
+Only v3 markers opt into live-tab collapse by content identity.
 
 ## Theme-token snapshot for standalone tabs
 
@@ -522,9 +534,13 @@ back the preview tree sees the same bytes the gateway just wrote.
 - Opening a historical v3 card whose `contentHash` matches the live mount skips
   the remount POST, selects `preview:live`, and does not surface "File no longer
   available" for already-mounted content.
-- Live and historical preview tabs with the same `contentHash` collapse to one
-  visible preview tab for that content.
+- Opening a historical v3 card whose marker omitted `contentHash` remounts from
+  the original params; the POST response hash can still collapse same-content
+  history into `preview:live`.
+- Live and v3 historical preview tabs with the same `contentHash` collapse to
+  one visible preview tab for that content.
 - Historical preview artifacts with different `contentHash` values remain
   separate and independently restorable through the one live server mount.
-- Archived sessions with v1 / v2 markers continue to render an Open button
-  that re-stamps the mount via `POST /api/preview/mount`.
+- Archived sessions with v1 / v2 markers continue to render an Open button that
+  re-stamps the mount via `POST /api/preview/mount` but remains historical even
+  when that response includes `contentHash`.

--- a/src/ui/tools/renderers/PreviewRenderer.ts
+++ b/src/ui/tools/renderers/PreviewRenderer.ts
@@ -481,9 +481,11 @@ export class PreviewOpenRenderer implements ToolRenderer<PreviewOpenParams, any>
 						url: parsed.kind === "preview" ? parsed.url : undefined,
 						source: tabSource,
 						state: tabState,
-						// Collapse v3 history into live only when live already matched before this click,
-						// or when this click remounted restorable content and the server hash proves it now matches.
-						dedupeWithLive: !snapshotContentHash || liveHasSnapshotAfterOpen,
+						// Collapse only v3 history into live, and only when content identity proves
+						// the historical artifact and current live mount are identical. Legacy
+						// v1/v2 snapshots predate content hashes and must remain distinct even
+						// when a remount response returns a hash for the newly written live mount.
+						dedupeWithLive: parsed.kind === "preview" && liveHasSnapshotAfterOpen,
 						select: true,
 					});
 					if (liveAlreadyHasSnapshot || remountMatchedSnapshot) {

--- a/src/ui/tools/renderers/PreviewRenderer.ts
+++ b/src/ui/tools/renderers/PreviewRenderer.ts
@@ -453,11 +453,14 @@ export class PreviewOpenRenderer implements ToolRenderer<PreviewOpenParams, any>
 					}
 					const mtime = mtimeFromPost ?? Date.now();
 					const mountedContentHash = contentHashFromPost || snapshotContentHash;
-					const remountMatchedSnapshot = !!postBody
-						&& !!snapshotContentHash
+					// v3 snapshot blocks may omit contentHash to stay under the marker cap.
+					// In that case, the remount response is the first usable content identity
+					// for collapsing the historical v3 card into the refreshed live preview.
+					const remountProducedV3LiveContent = !!postBody
+						&& parsed.kind === "preview"
 						&& !!contentHashFromPost
-						&& contentHashFromPost === snapshotContentHash;
-					const liveHasSnapshotAfterOpen = liveAlreadyHasSnapshot || remountMatchedSnapshot;
+						&& (!snapshotContentHash || contentHashFromPost === snapshotContentHash);
+					const liveHasSnapshotAfterOpen = liveAlreadyHasSnapshot || remountProducedV3LiveContent;
 					archiveCurrentLivePreview(appState, sessionId, mountedContentHash);
 					if (entry) (appState as any).previewPanelEntry = entry;
 					(appState as any).previewPanelMtime = mtime;
@@ -488,7 +491,7 @@ export class PreviewOpenRenderer implements ToolRenderer<PreviewOpenParams, any>
 						dedupeWithLive: parsed.kind === "preview" && liveHasSnapshotAfterOpen,
 						select: true,
 					});
-					if (liveAlreadyHasSnapshot || remountMatchedSnapshot) {
+					if (liveHasSnapshotAfterOpen) {
 						rememberRestorableLivePreview(sessionId, mountedContentHash, {
 							id: tabId,
 							kind: "preview",

--- a/tests/e2e/ui/dynamic-chat-tabs.spec.ts
+++ b/tests/e2e/ui/dynamic-chat-tabs.spec.ts
@@ -6,6 +6,8 @@
  * model because the assistant "Preview" tab is actually the proposal pane and
  * the HTML iframe is never exposed.
  */
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
 import { test, expect } from "../gateway-harness.js";
 import type { Page } from "@playwright/test";
 import { apiFetch, nonGitCwd } from "../e2e-setup.js";
@@ -504,6 +506,19 @@ function v3PreviewToolCardMessages(toolId: string, mounted: PreviewMountSnapshot
 	return previewToolCardMessages(toolId, { html: previewHtmlForBodyText(bodyText) }, v3SnapshotBlock(mounted));
 }
 
+function legacyV1InlinePreviewToolCardMessages(toolId: string, bodyText: string): any[] {
+	const html = previewHtmlForBodyText(bodyText);
+	return previewToolCardMessages(toolId, { html }, `__preview_snapshot_v1__\n${html}`);
+}
+
+function legacyV2FilePreviewToolCardMessages(toolId: string, filePath: string): any[] {
+	return previewToolCardMessages(
+		toolId,
+		{ file: filePath },
+		`__preview_snapshot_v2__\n${JSON.stringify({ kind: "file", path: filePath })}\n`,
+	);
+}
+
 async function setMockTranscript(gateway: any, sessionId: string, messages: any[]): Promise<void> {
 	const session = gateway.sessionManager?.getSession(sessionId);
 	if (!session) throw new Error(`session ${sessionId} not found`);
@@ -553,6 +568,44 @@ async function expectAtLeastPreviewTabCount(page: Page, expectedCount: number, e
 		timeout: 10_000,
 		message: `${errorPrefix}: expected at least ${expectedCount} visible preview tabs`,
 	}).toBeGreaterThanOrEqual(expectedCount);
+}
+
+async function expectLegacyPreviewTabsRemainSeparate(page: Page, expectedTexts: string[], errorPrefix: string): Promise<void> {
+	await expect.poll(async () => (await visiblePanelTabs(page))
+		.filter((tab) => tab.kind === "preview" && tab.id !== "preview:live").length, {
+		timeout: 10_000,
+		message: `${errorPrefix}: legacy preview snapshots should remain historical tabs, not collapse into only preview:live`,
+	}).toBeGreaterThanOrEqual(expectedTexts.length);
+	const previewTabs = (await visiblePanelTabs(page)).filter((tab) => tab.kind === "preview");
+	expect(
+		previewTabs.map((tab) => tab.id),
+		`${errorPrefix}: legacy preview tabs collapsed incorrectly; tabs=${JSON.stringify(previewTabs)}`,
+	).not.toEqual(["preview:live"]);
+	const previewTabTexts = await collectAllPreviewTabTexts(page, errorPrefix);
+	for (const expectedText of expectedTexts) {
+		expect(
+			previewTabTexts.some((text) => text.includes(expectedText)),
+			`${errorPrefix}: no legacy preview tab restored ${expectedText}; texts=${JSON.stringify(previewTabTexts)}`,
+		).toBe(true);
+	}
+}
+
+async function openLegacyPreviewToolCardAndExpectMountHash(page: Page, ordinal: number, expectedText: string, errorPrefix: string): Promise<string> {
+	const button = page.locator(PREVIEW_OPEN_BUTTON_SELECTOR).nth(ordinal);
+	await button.scrollIntoViewIfNeeded();
+	await expect(button, `${errorPrefix}: legacy preview_open tool card ${ordinal + 1} Open button should be enabled`).toBeEnabled({ timeout: 5_000 });
+	const responsePromise = page.waitForResponse(
+		(response) => response.url().includes("/api/preview/mount") && response.request().method() === "POST" && response.ok(),
+		{ timeout: 15_000 },
+	);
+	await button.click();
+	const response = await responsePromise;
+	const body = await response.json() as { contentHash?: unknown };
+	const contentHash = typeof body.contentHash === "string" ? body.contentHash : "";
+	expect(contentHash, `${errorPrefix}: legacy remount POST should still return contentHash`).toMatch(/^[a-f0-9]{64}$/);
+	await expect(button, `${errorPrefix}: clicking legacy preview_open tool card ${ordinal + 1} should acknowledge that it opened`).toHaveText(/Opened/, { timeout: 5_000 });
+	await expectPreviewContains(page, expectedText, `${errorPrefix}: opening legacy preview_open tool card ${ordinal + 1} should select that snapshot immediately`);
+	return contentHash;
 }
 
 async function collectAllPreviewTabTexts(page: Page, errorPrefix: string): Promise<string[]> {
@@ -885,6 +938,42 @@ test.describe("Dynamic chat tabs", () => {
 		expect(labels, `DYNAMIC_CHAT_TABS_PREVIEW_DUPLICATE_LABEL_BUG: preview labels were ${JSON.stringify(labels)}`).toContain("Preview: inline.html");
 		expect(labels, `DYNAMIC_CHAT_TABS_PREVIEW_DUPLICATE_LABEL_BUG: preview labels were ${JSON.stringify(labels)}`).toContain("Preview: inline.html (snapshot)");
 		expect(new Set(labels).size, `DYNAMIC_CHAT_TABS_PREVIEW_DUPLICATE_LABEL_BUG: duplicate preview labels: ${JSON.stringify(labels)}`).toBe(labels.length);
+	});
+
+	test("legacy v1 and v2 preview_open snapshots remain distinct across reload", async ({ page, gateway }, testInfo) => {
+		test.setTimeout(120_000);
+		await page.setViewportSize({ width: 1280, height: 800 });
+
+		await openApp(page);
+		const sessionId = await createRegularSessionViaApi(page);
+		const legacyInlineText = "Legacy V1 Inline Preview Content";
+		const legacyFileText = "Legacy V2 File Preview Content";
+		const legacyFilePath = testInfo.outputPath("legacy-v2-preview.html");
+		await mkdir(dirname(legacyFilePath), { recursive: true });
+		await writeFile(legacyFilePath, previewHtmlForBodyText(legacyFileText), "utf8");
+
+		await setMockTranscript(gateway, sessionId, [
+			...legacyV1InlinePreviewToolCardMessages("tool-legacy-v1-inline", legacyInlineText),
+			...legacyV2FilePreviewToolCardMessages("tool-legacy-v2-file", legacyFilePath),
+		]);
+		await refreshTranscriptFromGateway(page, 2, "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG");
+
+		const firstHash = await openLegacyPreviewToolCardAndExpectMountHash(page, 0, legacyInlineText, "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG");
+		const secondHash = await openLegacyPreviewToolCardAndExpectMountHash(page, 1, legacyFileText, "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG");
+		expect(firstHash, "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG: fixtures should produce distinct legacy remount hashes").not.toBe(secondHash);
+		await expectLegacyPreviewTabsRemainSeparate(page, [legacyInlineText, legacyFileText], "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG");
+
+		await reloadAndNavigateToSession(page, sessionId);
+		await refreshTranscriptFromGateway(page, 2, "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG: after reload");
+		await openLegacyPreviewToolCardAndExpectMountHash(page, 0, legacyInlineText, "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG: after reload");
+		await openLegacyPreviewToolCardAndExpectMountHash(page, 1, legacyFileText, "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG: after reload");
+		await expectLegacyPreviewTabsRemainSeparate(page, [legacyInlineText, legacyFileText], "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG: after reload");
+
+		// Preview tabs currently have no per-tab close affordance. Switching away
+		// and back is the available cleanup/non-collapse path for legacy history.
+		await ensureChatInput(page, "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG: cleanup/no-collapse check");
+		await selectTopLevelTab(page, PREVIEW_TAB_RE, "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG: Preview should remain selectable for cleanup check");
+		await expectLegacyPreviewTabsRemainSeparate(page, [legacyInlineText, legacyFileText], "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG: cleanup/no-collapse check");
 	});
 
 	test("same-content historical v3 first-open collapses to the live preview tab", async ({ page, gateway }) => {

--- a/tests/preview-renderer.spec.ts
+++ b/tests/preview-renderer.spec.ts
@@ -40,6 +40,16 @@ function makeResultWithSnapshot(html: string) {
 }
 
 function makePreviewResultWithSnapshot(entry = "inline.html", contentHash = HASH) {
+	return makePreviewResult(entry, contentHash);
+}
+
+function makePreviewResultWithoutSnapshotHash(entry = "inline.html") {
+	return makePreviewResult(entry);
+}
+
+function makePreviewResult(entry: string, contentHash?: string) {
+	const snapshot: Record<string, string> = { kind: "preview", url: `/preview/${SESSION_ID}/${entry}`, path: `${SESSION_ID}/${entry}` };
+	if (contentHash) snapshot.contentHash = contentHash;
 	return {
 		role: "toolResult",
 		toolCallId: TOOL_USE_ID,
@@ -47,7 +57,7 @@ function makePreviewResultWithSnapshot(entry = "inline.html", contentHash = HASH
 		isError: false,
 		content: [
 			{ type: "text", text: "Preview panel is open and will auto-update." },
-			{ type: "text", text: MARKER_V3 + JSON.stringify({ kind: "preview", url: `/preview/${SESSION_ID}/${entry}`, path: `${SESSION_ID}/${entry}`, contentHash }) + "\n" },
+			{ type: "text", text: MARKER_V3 + JSON.stringify(snapshot) + "\n" },
 		],
 		timestamp: Date.now(),
 	};
@@ -286,6 +296,45 @@ test.describe("PreviewOpenRenderer", () => {
 		expect(previewState.panelWorkspaceActiveBySession[SESSION_ID]).toBe("preview:tool:tool-1:1");
 	});
 
+	test("legacy v1/v2 markers: matching remount hash remains a historical tab", async ({ page }) => {
+		await gotoAndWait(page);
+		const filePath = "/abs/path/to/report.html";
+		const cases = [
+			{ params: { html: "<p>legacy inline</p>" }, result: makeResultWithSnapshot("<p>legacy inline</p>") },
+			{ params: { file: filePath }, result: makeFileResultWithSnapshot(filePath) },
+		];
+
+		for (const legacy of cases) {
+			await page.evaluate(async ([sessionId, hash, params, result]) => {
+				await (window as any).__resetPreviewState();
+				await (window as any).__setPreviewWorkspace(sessionId, hash);
+				(window as any).__renderPreview(document.getElementById("container")!, params, result, false);
+				(window as any).__setFetchResponse((url: string, init: any) => {
+					if (init?.method === "POST" && String(url).includes("/api/preview/mount")) {
+						return { status: 200, body: { entry: "inline.html", mtime: 456, contentHash: hash } };
+					}
+					return { status: 200, body: { ok: true } };
+				});
+				(window as any).__resetFetchCalls();
+			}, [SESSION_ID, HASH, legacy.params, legacy.result] as any);
+
+			const btn = page.locator("[data-preview-open-btn]");
+			await btn.click();
+			await expect(btn).toHaveText(/Opened/, { timeout: 3000 });
+
+			const calls = await page.evaluate(() => (window as any).__getFetchCalls());
+			expect(calls.map((call: any) => call.method)).toEqual(["PATCH", "POST"]);
+			const previewState = await page.evaluate(async () => (window as any).__getPreviewState());
+			const tabs = previewState.panelTabsBySession[SESSION_ID];
+			expect(tabs.map((tab: any) => tab.id)).toEqual(["preview:live", "preview:tool:tool-1:1"]);
+			expect(tabs[0].state.contentHash).toBe(HASH);
+			expect(tabs[1].state.contentHash).toBe(HASH);
+			expect(tabs[1].source.dedupeWithLive).toBe(false);
+			expect(tabs[1].state.dedupeWithLive).toBe(false);
+			expect(previewState.panelWorkspaceActiveBySession[SESSION_ID]).toBe("preview:tool:tool-1:1");
+		}
+	});
+
 	test("v3 marker: identical content reuses the live preview tab without remounting relative files", async ({ page }) => {
 		await gotoAndWait(page);
 		await page.evaluate(async ([hash, sessionId, result]) => {
@@ -342,6 +391,37 @@ test.describe("PreviewOpenRenderer", () => {
 		const tabs = previewState.panelTabsBySession[SESSION_ID];
 		expect(tabs.map((tab: any) => tab.id)).toEqual(["preview:live"]);
 		expect(tabs[0].state.contentHash).toBe(HASH);
+		expect(previewState.panelWorkspaceActiveBySession[SESSION_ID]).toBe("preview:live");
+	});
+
+	test("v3 marker: no marker hash collapses to live after remount returns content hash", async ({ page }) => {
+		await gotoAndWait(page);
+		const oldHash = "c".repeat(64);
+		await page.evaluate(async ([oldHash, sessionId, result, hash]) => {
+			await (window as any).__resetPreviewState();
+			await (window as any).__setPreviewWorkspace(sessionId, oldHash);
+			(window as any).__renderPreview(document.getElementById("container")!, { html: "<p>new</p>" }, result, false);
+			(window as any).__setFetchResponse((url: string, init: any) => {
+				if (init?.method === "POST" && String(url).includes("/api/preview/mount")) {
+					return { status: 200, body: { entry: "inline.html", mtime: 456, contentHash: hash } };
+				}
+				return { status: 200, body: { ok: true } };
+			});
+			(window as any).__resetFetchCalls();
+		}, [oldHash, SESSION_ID, makePreviewResultWithoutSnapshotHash("inline.html"), HASH] as any);
+
+		const btn = page.locator("[data-preview-open-btn]");
+		await btn.click();
+		await expect(btn).toHaveText(/Opened/, { timeout: 3000 });
+		await expect(btn).not.toHaveText(/File no longer available/);
+
+		const calls = await page.evaluate(() => (window as any).__getFetchCalls());
+		expect(calls.map((call: any) => call.method)).toEqual(["PATCH", "POST"]);
+		const previewState = await page.evaluate(async () => (window as any).__getPreviewState());
+		const tabs = previewState.panelTabsBySession[SESSION_ID];
+		expect(tabs.map((tab: any) => tab.id)).toEqual(["preview:live"]);
+		expect(tabs[0].state.contentHash).toBe(HASH);
+		expect(previewState.previewPanelContentHash).toBe(HASH);
 		expect(previewState.panelWorkspaceActiveBySession[SESSION_ID]).toBe("preview:live");
 	});
 

--- a/tests/preview-renderer.spec.ts
+++ b/tests/preview-renderer.spec.ts
@@ -168,11 +168,17 @@ test.describe("PreviewOpenRenderer", () => {
 		await gotoAndWait(page);
 		const html = "<p>hello-world</p>";
 		await page.evaluate(
-			([params, result]) => {
+			([params, result, hash]) => {
 				(window as any).__renderPreview(document.getElementById("container")!, params, result, false);
+				(window as any).__setFetchResponse((url: string, init: any) => {
+					if (init?.method === "POST" && String(url).includes("/api/preview/mount")) {
+						return { status: 200, body: { entry: "inline.html", mtime: 234, contentHash: hash } };
+					}
+					return { status: 200, body: { ok: true } };
+				});
 				(window as any).__resetFetchCalls();
 			},
-			[{ html }, makeResultWithSnapshot(html)],
+			[{ html }, makeResultWithSnapshot(html), HASH],
 		);
 
 		await page.locator("[data-preview-open-btn]").click();
@@ -191,6 +197,14 @@ test.describe("PreviewOpenRenderer", () => {
 		const postBody = JSON.parse(calls[1].body);
 		expect(postBody.html).toBe(html);
 		expect(postBody.html).not.toContain("__preview_snapshot_v1__");
+
+		const previewState = await page.evaluate(async () => (window as any).__getPreviewState());
+		const tabs = previewState.panelTabsBySession[SESSION_ID];
+		expect(tabs.map((tab: any) => tab.id)).toEqual(["preview:tool:tool-1:1"]);
+		expect(tabs[0].state.contentHash).toBe(HASH);
+		expect(tabs[0].source.dedupeWithLive).toBe(false);
+		expect(tabs[0].state.dedupeWithLive).toBe(false);
+		expect(previewState.panelWorkspaceActiveBySession[SESSION_ID]).toBe("preview:tool:tool-1:1");
 	});
 
 	test("click with truncated snapshot: GET tool-content then PATCH then POST", async ({ page }) => {
@@ -237,11 +251,17 @@ test.describe("PreviewOpenRenderer", () => {
 		await gotoAndWait(page);
 		const filePath = "/abs/path/to/report.html";
 		await page.evaluate(
-			([params, result]) => {
+			([params, result, hash]) => {
 				(window as any).__renderPreview(document.getElementById("container")!, params, result, false);
+				(window as any).__setFetchResponse((url: string, init: any) => {
+					if (init?.method === "POST" && String(url).includes("/api/preview/mount")) {
+						return { status: 200, body: { entry: "report.html", mtime: 345, contentHash: hash } };
+					}
+					return { status: 200, body: { ok: true } };
+				});
 				(window as any).__resetFetchCalls();
 			},
-			[{ file: filePath }, makeFileResultWithSnapshot(filePath)],
+			[{ file: filePath }, makeFileResultWithSnapshot(filePath), HASH],
 		);
 
 		await page.locator("[data-preview-open-btn]").click();
@@ -256,6 +276,14 @@ test.describe("PreviewOpenRenderer", () => {
 		expect(postBody.file).toBe(filePath);
 		expect(postBody.html).toBeUndefined();
 		expect(postBody.kind).toBeUndefined();
+
+		const previewState = await page.evaluate(async () => (window as any).__getPreviewState());
+		const tabs = previewState.panelTabsBySession[SESSION_ID];
+		expect(tabs.map((tab: any) => tab.id)).toEqual(["preview:tool:tool-1:1"]);
+		expect(tabs[0].state.contentHash).toBe(HASH);
+		expect(tabs[0].source.dedupeWithLive).toBe(false);
+		expect(tabs[0].state.dedupeWithLive).toBe(false);
+		expect(previewState.panelWorkspaceActiveBySession[SESSION_ID]).toBe("preview:tool:tool-1:1");
 	});
 
 	test("v3 marker: identical content reuses the live preview tab without remounting relative files", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Document v3 preview `contentHash` contracts across mount responses, SSE/bootstrap events, snapshot markers, and workspace tab dedupe.
- Update HTML/mockup agent guidance for live previews, file-backed previews, explicit assets/manifests, and single-surface usage.
- Fix and pin preview tab behavior for same-content v3 collapse, hash-omitted v3 remount collapse, different-content restore, and legacy v1/v2 non-collapse.

## Verification
- `npm run check`
- `tests/preview-renderer.spec.ts`
- `tests/preview-extension.test.ts`
- `tests/e2e/preview-mount-route.spec.ts`
- `tests/e2e/preview-token-cost.spec.ts`
- `tests/e2e/ui/dynamic-chat-tabs.spec.ts` focused preview journeys
- Workflow implementation and documentation gates passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
