### PR TITLE
Reduce bash_bg logs default tail

### DIFF
--- a/defaults/tools/shell/bash_bg.yaml
+++ b/defaults/tools/shell/bash_bg.yaml
@@ -8,7 +8,7 @@ provider:
 group: Shell
 renderer: src/ui/tools/renderers/BgProcessRenderer.ts
 docs: |-
-  Actions: create, logs, grep, head, slice, kill, list, wait. bash_bg does not notify on completion. If you need to take follow up actions, use bash_bg wait. Use `bash_bg` instead of `bash` for any command that might take longer than 2 minutes or produce large output you may not need to read in full. Parameters: `command` (for create), `name` (required for create — a short max-3-word label like "dev server" or "test runner"), `id` (for logs/grep/head/slice/kill/wait), `tail` (log lines, default 200), `pattern` (for grep — string or regex), `context` (grep context lines, default 0), `max_results` (grep max matches, default 50), `lines` (for head, default 50), `from`/`to` (1-indexed line range for slice), `timeout` (for wait, default 300).
+  Actions: create, logs, grep, head, slice, kill, list, wait. bash_bg does not notify on completion. If you need to take follow up actions, use bash_bg wait. Use `bash_bg` instead of `bash` for any command that might take longer than 2 minutes or produce large output you may not need to read in full. Parameters: `command` (for create), `name` (required for create — a short max-3-word label like "dev server" or "test runner"), `id` (for logs/grep/head/slice/kill/wait), `tail` (log lines, default 15), `pattern` (for grep — string or regex), `context` (grep context lines, default 0), `max_results` (grep max matches, default 50), `lines` (for head, default 50), `from`/`to` (1-indexed line range for slice), `timeout` (for wait, default 300).
 detail_docs: |
   Manage background shell processes that don't block the agent.
 
@@ -62,7 +62,7 @@ detail_docs: |
   - `command` (for create): Shell command to run in the background
   - `name` (required for create): Short descriptive name, max 3 words (e.g. "dev server", "test runner", "color echo loop")
   - `id` (for logs/grep/head/slice/kill): Background process ID (e.g. "bg-1")
-  - `tail` (for logs): Number of log lines to return from end (default: 200)
+  - `tail` (for logs): Number of log lines to return from end (default: 15)
   - `pattern` (for grep): Search pattern — string or regex, case-insensitive
   - `context` (for grep): Lines of context around each match (default: 0)
   - `max_results` (for grep): Max matches to return (default: 50)

--- a/defaults/tools/shell/extension.ts
+++ b/defaults/tools/shell/extension.ts
@@ -292,7 +292,7 @@ export default function (pi: ExtensionAPI) {
 			name: Type.Optional(Type.String({ description: "Short process name, max 3 words (create)." })),
 			id: Type.Optional(Type.String({ description: "Background process ID." })),
 			timeout: Type.Optional(Type.Number({ description: "Max seconds to wait. Default 300 (wait)." })),
-			tail: Type.Optional(Type.Number({ description: "Lines from end. Default 200 (logs)." })),
+			tail: Type.Optional(Type.Number({ description: "Lines from end. Default 15 (logs)." })),
 			pattern: Type.Optional(Type.String({ description: "Search pattern, string or regex (grep)." })),
 			context: Type.Optional(Type.Number({ description: "Lines of context around match. Default 0 (grep)." })),
 			max_results: Type.Optional(Type.Number({ description: "Max matches. Default 50 (grep)." })),
@@ -333,7 +333,7 @@ export default function (pi: ExtensionAPI) {
 					case "logs": {
 						if (!id) return text("Error: 'id' is required for logs");
 						const [logs, hdr] = await Promise.all([
-							api("GET", `/api/sessions/${sessionId}/bg-processes/${id}/logs?tail=${tail || 200}`) as any,
+							api("GET", `/api/sessions/${sessionId}/bg-processes/${id}/logs?tail=${tail ?? 15}`) as any,
 							header(id),
 						]);
 						const output = logs.log?.map((e: any) => typeof e === "string" ? e : e.text ?? String(e)).join("\n") || "(no output)";

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -8157,7 +8157,7 @@ async function handleApiRoute(
 		const [, sessionId, processId] = bgLogsMatch;
 		const logs = bgProcessManager.getLogs(sessionId, processId);
 		if (!logs) { json({ error: "Process not found" }, 404); return; }
-		const tail = parseInt(url.searchParams.get("tail") || "200", 10);
+		const tail = parseInt(url.searchParams.get("tail") || "15", 10);
 		json({
 			log: logs.log.slice(-tail),
 			stdout: logs.stdout.slice(-tail),

--- a/tests/e2e/bg-wait-steer-abort.spec.ts
+++ b/tests/e2e/bg-wait-steer-abort.spec.ts
@@ -32,7 +32,39 @@ const SLEEP_CMD = process.platform === "win32"
 	: "sleep 60";
 
 test.describe("bash_bg wait — steer abort", () => {
-	test("abortAllWaits resolves long-poll wait with aborted:true, process keeps running", async ({ gateway }) => {
+	test("logs endpoint defaults to the last 15 lines", async ({ gateway }) => {
+		let sessionId: string | undefined;
+		try {
+			const res = await adminFetch(gateway.baseURL, "/api/sessions", {
+				method: "POST",
+				body: JSON.stringify({ cwd: nonGitCwd() }),
+			});
+			expect(res.status).toBe(201);
+			({ id: sessionId } = await res.json());
+
+			const command = `node -e "for (let i = 1; i <= 20; i++) console.log('line-' + i); setTimeout(() => {}, 100)"`;
+			const bgRes = await adminFetch(gateway.baseURL, `/api/sessions/${sessionId}/bg-processes`, {
+				method: "POST",
+				body: JSON.stringify({ command, name: "log tail" }),
+			});
+			expect(bgRes.status).toBe(201);
+			const bg = await bgRes.json();
+
+			const waitRes = await adminFetch(gateway.baseURL, `/api/sessions/${sessionId}/bg-processes/${bg.id}/wait?timeout=5`);
+			expect(waitRes.status).toBe(200);
+
+			const logsRes = await adminFetch(gateway.baseURL, `/api/sessions/${sessionId}/bg-processes/${bg.id}/logs`);
+			expect(logsRes.status).toBe(200);
+			const logs = await logsRes.json();
+			const expected = Array.from({ length: 15 }, (_, i) => `line-${i + 6}`);
+			expect(logs.log.map((entry: { text: string }) => entry.text)).toEqual(expected);
+			expect(logs.stdout).toEqual(expected);
+		} finally {
+			if (sessionId) await adminFetch(gateway.baseURL, `/api/sessions/${sessionId}`, { method: "DELETE" });
+		}
+	});
+
+	test("abortAllWaits resolves long-poll wait with aborted:true and leaves process running", async ({ gateway }) => {
 		// Create session
 		const res = await adminFetch(gateway.baseURL, "/api/sessions", {
 			method: "POST",


### PR DESCRIPTION
## Summary
- Reduce the default `bash_bg logs` tail from 200 lines to 15 lines.
- Update tool schema/docs and REST API fallback to match.
- Add E2E coverage for the default logs tail behavior.

## Testing
- `npx playwright test --config playwright-e2e.config.ts --project=api tests/e2e/bg-wait-steer-abort.spec.ts`
- `npx tsx --test tests/tool-description-budget.test.ts`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
