### PR TITLE
Fix preview reopen filename tabs

### DIFF
--- a/src/ui/tools/renderers/PreviewRenderer.ts
+++ b/src/ui/tools/renderers/PreviewRenderer.ts
@@ -424,9 +424,11 @@ export class PreviewOpenRenderer implements ToolRenderer<PreviewOpenParams, any>
 					}
 					const mtime = mtimeFromPost ?? Date.now();
 					const mountedContentHash = contentHashFromPost || snapshotContentHash;
-					// Older transcript cards should open as versioned tabs. Only keep the
-					// current filename tab when the live mount already has the same snapshot.
-					const shouldKeepCurrentPreviewTab = liveAlreadyHasSnapshot;
+					// Explicit Open clicks refresh the current filename tab. Historical
+					// versioned tabs are created during transcript/workspace hydration; the
+					// button should not fork a second tab for the same filename.
+					const shouldKeepCurrentPreviewTab = true;
+					void liveAlreadyHasSnapshot;
 					const version = workspace.registerPreviewVersion(appState, sessionId, entry || "inline.html", mountedContentHash, { current: shouldKeepCurrentPreviewTab });
 					if (entry) (appState as any).previewPanelEntry = entry;
 					(appState as any).previewPanelMtime = mtime;


### PR DESCRIPTION
## Summary
- Keep explicit preview Open clicks on the current filename tab instead of creating versioned duplicates
- Preserve historical/versioned tabs for transcript and workspace hydration paths

## Tests
- npm run check
- npx playwright test --config tests/playwright.config.ts tests/preview-renderer.spec.ts --workers=1
- node .bobbit/state/guardian/run.mjs
- npx playwright test --config tests/playwright.config.ts tests/search/files-source-stub.spec.ts tests/search/flex-store.spec.ts tests/search/indexer.spec.ts tests/search/lexical-parity.spec.ts --workers=1

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)