### PR TITLE
Fix tab-strip + historical proposal bugs from master

### DIFF
--- a/src/app/proposal-panels.ts
+++ b/src/app/proposal-panels.ts
@@ -1907,6 +1907,53 @@ let _proposalInitializedFrom: string | null = null;
 // `state.activeProposals[type]`, so the live current-proposal slot is never
 // clobbered when the user views an older snapshot.
 let _proposalOverride: { type: ProposalType; fields: Record<string, unknown>; rev: number } | null = null;
+// Tracks the raw source `fields` reference that the current `_proposalOverride`
+// was derived from, so the identity short-circuit in `proposalPanelContent`
+// still works when we project legacy top-level commands into a synthetic
+// `components` array for historical project-proposal snapshots.
+let _proposalOverrideSource: Record<string, unknown> | null = null;
+
+/**
+ * Project legacy top-level command keys (`build_command`, `test_command`, …) on
+ * a historical project-proposal snapshot into a synthetic `components[0]` so the
+ * editable project panel can surface them. Mirrors the server-side
+ * `LEGACY_KEY_MAP` fold in `src/server/server.ts` that runs for live proposals.
+ *
+ * Returns the input unchanged when `components` is already present and
+ * non-empty, or when no legacy keys are set. Never mutates `fields`.
+ */
+function projectLegacyToComponents(fields: Record<string, unknown>): Record<string, unknown> {
+	const existingComponents = fields.components;
+	if (Array.isArray(existingComponents) && existingComponents.length > 0) return fields;
+
+	const LEGACY_KEY_MAP: Record<string, string> = {
+		build_command: "build",
+		test_command: "test",
+		typecheck_command: "check",
+		test_unit_command: "unit",
+		test_e2e_command: "e2e",
+	};
+	const cmds: Record<string, string> = {};
+	for (const [legacyKey, newKey] of Object.entries(LEGACY_KEY_MAP)) {
+		const v = fields[legacyKey];
+		if (typeof v === "string" && v.trim().length > 0) cmds[newKey] = v.trim();
+	}
+	const setupHook = fields.worktree_setup_command;
+	const hasAnyLegacy = Object.keys(cmds).length > 0
+		|| (typeof setupHook === "string" && setupHook.trim().length > 0);
+	if (!hasAnyLegacy) return fields;
+
+	const name = (typeof fields.name === "string" && fields.name.trim()) || "default";
+	const component: Record<string, unknown> = {
+		name,
+		repo: ".",
+		commands: cmds,
+	};
+	if (typeof setupHook === "string" && setupHook.trim()) {
+		component.worktree_setup_command = setupHook.trim();
+	}
+	return { ...fields, components: [component] };
+}
 
 /** Sync module-level form state from the active goal proposal when it changes. */
 function syncProposalFormState(): void {
@@ -2118,8 +2165,10 @@ export function proposalPanelContent(
 		// current-proposal slot. Switching back to the current tab clears
 		// the override and the live slot's content is restored verbatim.
 		const rev = proposalRevisionFromPanelTab(tab) || 1;
-		if (!_proposalOverride || _proposalOverride.type !== type || _proposalOverride.fields !== fields || _proposalOverride.rev !== rev) {
-			_proposalOverride = { type, fields, rev };
+		if (!_proposalOverride || _proposalOverride.type !== type || _proposalOverrideSource !== fields || _proposalOverride.rev !== rev) {
+			const projected = type === "project" ? projectLegacyToComponents(fields) : fields;
+			_proposalOverride = { type, fields: projected, rev };
+			_proposalOverrideSource = fields;
 			_proposalInitializedFrom = null;
 		}
 		return proposalPanelForWorkspaceType(type, currentAssistantProposalType);
@@ -2128,6 +2177,7 @@ export function proposalPanelContent(
 		// Returning to the current tab: drop the override and force a
 		// re-hydration of the form from the live activeProposals slot.
 		_proposalOverride = null;
+		_proposalOverrideSource = null;
 		_proposalInitializedFrom = null;
 	}
 	return proposalPanelForWorkspaceType(type, currentAssistantProposalType);

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -62,13 +62,13 @@ import { renderGoalGroup, renderSessionRow, renderSandboxIndicator, INDENT, getP
 import { PROPOSAL_TYPES, type ProposalType } from "./proposal-registry.js";
 import {
 	CHAT_PANEL_TAB_ID,
-	LIVE_PREVIEW_PANEL_TAB_ID,
 	activeSidePanelTabIdForSession,
 	assistantProposalType,
 	buildPanelWorkspaceTabs,
 	findPanelTab,
 	isHistoricalPreviewTab,
 	isHistoricalProposalTab,
+	isLivePreviewTab,
 	isPinnedPanelTab,
 	nextActivePanelTabId,
 	normalizePreviewContentHash,
@@ -617,6 +617,18 @@ let mobileSelectedSideTabId = "";
 let panelSortable: Sortable | null = null;
 let panelSortableContainer: HTMLElement | null = null;
 let draggingPanelTabId = "";
+// When true, the current drag at any point tried to land on/before a pinned
+// tab. SortableJS's onMove returns false for that single candidate target, but
+// earlier non-pinned candidates in the same drag may have already swapped the
+// DOM. To honour the pinned invariant strictly, we cancel the entire drag on
+// drop and let lit-html restore the canonical order from state.
+let panelSortablePinnedBlocked = false;
+// Initial DOM order of tab ids captured at onStart. When a drag is cancelled
+// (e.g. pinned-blocked at any point), we restore this order manually because
+// SortableJS's DOM mutations during the drag have already diverged from state,
+// and lit-html's `repeat` reconciliation does not always restore element
+// positions after external DOM moves.
+let panelSortableStartIds: string[] = [];
 // rAF handle for the Y-axis lock loop that keeps the dragged clone glued to
 // its original vertical position (Chrome-style tab drag).
 let panelDragLockRaf = 0;
@@ -758,7 +770,7 @@ function restoreHistoricalPreviewTab(tab: PanelWorkspaceTab): void {
 	// preview tabs is instant (no POST restore round-trip, no iframe blanking).
 	// We skip this only for the canonical live tab id, which intentionally
 	// follows the live mount slot's changing bytes.
-	const isLiveTab = tab.id === LIVE_PREVIEW_PANEL_TAB_ID || tab.id.startsWith("preview:live");
+	const isLiveTab = isLivePreviewTab(tab);
 	if (!isLiveTab && tabArtifactIdEarly) {
 		if (state.previewPanelEntry === entry && state.previewPanelArtifactId === tabArtifactIdEarly && currentMountedPreviewTabId() === tab.id) {
 			clearPreviewTabRestoreError(sessionId, tab.id);
@@ -1184,6 +1196,24 @@ function samePanelTabOrder(a: PanelWorkspaceTab[], b: PanelWorkspaceTab[]): bool
 	return a.length === b.length && a.every((tab, index) => tab.id === b[index]?.id);
 }
 
+// Restore the DOM order of `.goal-tab-pill` children inside `host` to match
+// `expectedIds`. Used to revert SortableJS's drag DOM mutations when the
+// drop is rejected (e.g. pinned-blocked). Appending an already-attached node
+// moves it without re-creating it, so this is cheap and leaves event listeners
+// intact. Any pills not in `expectedIds` keep their relative tail position.
+function revertPanelTabDomOrder(host: HTMLElement, expectedIds: string[]): void {
+	if (!host || expectedIds.length === 0) return;
+	const pillsById = new Map<string, HTMLElement>();
+	for (const pill of Array.from(host.querySelectorAll<HTMLElement>(".goal-tab-pill"))) {
+		const id = pill.getAttribute("data-panel-tab-id") || "";
+		if (id) pillsById.set(id, pill);
+	}
+	for (const id of expectedIds) {
+		const pill = pillsById.get(id);
+		if (pill) host.appendChild(pill);
+	}
+}
+
 // Attach a SortableJS instance to the unified tab bar's inner container. Idempotent:
 // if the container DOM node is the same as last time, we keep the existing instance.
 // If the container was replaced (e.g. workspace switched sessions), we destroy the
@@ -1226,14 +1256,27 @@ function ensurePanelSortable(container: HTMLElement | null): void {
 		delay: 0,
 		onMove: (evt) => {
 			// Forbid dropping in front of (or onto) a pinned tab. Returning false
-			// cancels the move; SortableJS keeps trying as the cursor moves.
-			const related = evt.related as HTMLElement | null;
+			// cancels this candidate move; SortableJS keeps trying as the cursor
+			// moves. We also remember that the user *attempted* a pinned-blocked
+			// move so onEnd can cancel the whole drag — otherwise an earlier
+			// non-pinned swap during the same drag would silently commit.
+			const relatedRaw = evt.related as HTMLElement | null;
+			const related = relatedRaw?.closest(".goal-tab-pill") as HTMLElement | null;
 			if (!related) return true;
-			if (related.classList.contains("goal-tab-pill--pinned")) return false;
+			if (related.classList.contains("goal-tab-pill--pinned")) {
+				panelSortablePinnedBlocked = true;
+				return false;
+			}
 			return true;
 		},
 		onStart: (evt) => {
 			draggingPanelTabId = (evt.item as HTMLElement).getAttribute("data-panel-tab-id") || "";
+			panelSortablePinnedBlocked = false;
+			panelSortableStartIds = Array.from(
+				(evt.from as HTMLElement).querySelectorAll<HTMLElement>(".goal-tab-pill"),
+			)
+				.map((el) => el.getAttribute("data-panel-tab-id") || "")
+				.filter((id) => id.length > 0);
 			document.documentElement.classList.add("dragging-panel-tab");
 			setRenderSuppressed(true);
 			startPanelDragYLock();
@@ -1248,14 +1291,31 @@ function ensurePanelSortable(container: HTMLElement | null): void {
 			draggingPanelTabId = "";
 			document.documentElement.classList.remove("dragging-panel-tab");
 			stopPanelDragYLock();
+			const pinnedBlocked = panelSortablePinnedBlocked;
+			const startIds = panelSortableStartIds;
+			panelSortablePinnedBlocked = false;
+			panelSortableStartIds = [];
 			try {
 				const host = evt.from as HTMLElement;
+				const sid = workspaceSessionId();
+				const currentTabs = panelTabsForSession(state, sid);
+
+				// If the drag attempted a pinned-blocked move at any point,
+				// cancel the entire drag — otherwise an earlier non-pinned swap
+				// during the same drag would silently commit and the user would
+				// see tabs reorder despite SortableJS rejecting the final drop.
+				// Manually restore the DOM order from the snapshot captured at
+				// onStart: lit-html's `repeat` does not always reconcile element
+				// positions back to canonical when SortableJS has shuffled them.
+				if (pinnedBlocked) {
+					revertPanelTabDomOrder(host, startIds);
+					return;
+				}
+
 				// Read the new tab id order directly off the DOM children.
 				const newIds = Array.from(host.querySelectorAll<HTMLElement>(".goal-tab-pill"))
 					.map((el) => el.getAttribute("data-panel-tab-id") || "")
 					.filter((id) => id.length > 0);
-				const sid = workspaceSessionId();
-				const currentTabs = panelTabsForSession(state, sid);
 				const byId = new Map(currentTabs.map((tab) => [tab.id, tab]));
 				const reordered: PanelWorkspaceTab[] = [];
 				for (const id of newIds) {
@@ -1266,11 +1326,40 @@ function ensurePanelSortable(container: HTMLElement | null): void {
 				for (const tab of currentTabs) {
 					if (!newIds.includes(tab.id)) reordered.push(tab);
 				}
+
+				// Defense-in-depth: refuse to commit a reordering that places any
+				// non-pinned tab before any pinned tab. onMove should already have
+				// flagged such an attempt via panelSortablePinnedBlocked, but if a
+				// future change to SortableJS or our predicate misses an edge
+				// case, this guard ensures the pinned invariant still holds.
+				let seenNonPinned = false;
+				let pinnedAfterNonPinned = false;
+				for (const tab of reordered) {
+					if (isPinnedPanelTab(tab)) {
+						if (seenNonPinned) {
+							pinnedAfterNonPinned = true;
+							break;
+						}
+					} else {
+						seenNonPinned = true;
+					}
+				}
+				if (pinnedAfterNonPinned) {
+					revertPanelTabDomOrder(host, startIds);
+					return;
+				}
+
 				if (!samePanelTabOrder(currentTabs, reordered)) {
 					setPanelTabsForSession(state, sid, reordered);
 				}
 			} finally {
 				setRenderSuppressed(false);
+				// Always trigger a render: when we took an early `return` above
+				// (pinned-blocked or invariant-violation revert), state was not
+				// mutated and lit-html will restore the canonical DOM order.
+				// When we committed setPanelTabsForSession, it already triggers a
+				// render — an extra one here is harmless.
+				renderApp();
 			}
 		},
 	});
@@ -1776,7 +1865,7 @@ export function doRenderApp(): void {
 		if (activeTab && activeTab.kind === "preview") {
 			const tabState = (activeTab.state || {}) as Record<string, unknown>;
 			const source = activeTab.source as Record<string, unknown>;
-			const isLiveTab = activeTab.id === LIVE_PREVIEW_PANEL_TAB_ID || activeTab.id.startsWith("preview:live");
+			const isLiveTab = isLivePreviewTab(activeTab);
 			if (!isLiveTab) {
 				artifactId = recordValue(tabState, "artifactId") || recordValue(source, "artifactId");
 				const tabEntry = previewEntryFromTab(activeTab);

--- a/tests/e2e/ui/preview-happy-path.spec.ts
+++ b/tests/e2e/ui/preview-happy-path.spec.ts
@@ -29,7 +29,7 @@ test.describe("Preview panel iframe URL (WP-E)", () => {
 	//   122f76fc Editable historical proposal tabs + render-time override
 	//   dac36684 Update tests + docs for Chrome-style tab system
 	// Restore to `test(...)` once those bugs are fixed on master.
-	test.fixme("iframe src is /preview/<sid>/<entry>?mtime=<n>", async ({ page }) => {
+	test("iframe src is /preview/<sid>/<entry>?mtime=<n>", async ({ page }) => {
 		await openApp(page);
 		await createSessionViaUI(page);
 

--- a/tests/e2e/ui/proposal-revision-snapshots.spec.ts
+++ b/tests/e2e/ui/proposal-revision-snapshots.spec.ts
@@ -291,7 +291,7 @@ test.describe("Proposal revision snapshots", () => {
 	//   122f76fc Editable historical proposal tabs + render-time override
 	//   dac36684 Update tests + docs for Chrome-style tab system
 	// Restore to `test(...)` once those bugs are fixed on master.
-	test.fixme("propose + edit + open-old card opens a historical tab while the latest draft stays live", async ({ page }) => {
+	test("propose + edit + open-old card opens a historical tab while the latest draft stays live", async ({ page }) => {
 		const projectId = await getDefaultProjectId();
 		await apiFetch(`/api/projects/${projectId}/config`, {
 			method: "PUT",

--- a/tests/e2e/ui/side-panel-tabs.spec.ts
+++ b/tests/e2e/ui/side-panel-tabs.spec.ts
@@ -601,7 +601,7 @@ test.describe("Side-panel tab contract", () => {
 	//   122f76fc Editable historical proposal tabs + render-time override
 	//   dac36684 Update tests + docs for Chrome-style tab system
 	// Restore to `test(...)` once those bugs are fixed on master.
-	test.fixme("6. Desktop drag reorder persists and cannot move tabs before pinned Inbox", async ({ page }) => {
+	test("6. Desktop drag reorder persists and cannot move tabs before pinned Inbox", async ({ page }) => {
 		await page.setViewportSize({ width: 1280, height: 800 });
 		await openApp(page);
 		const sessionId = await createRegularSessionViaApi(page);


### PR DESCRIPTION
Fix three E2E test failures introduced by the recent master chain
(98f7f0ce Chrome-style tab strip, 122f76fc editable historical proposals,
dac36684 docs/test updates). All three were marked \`test.fixme\` by PR #637
to keep CI green; this PR restores them to \`test(...)\` and ships the
underlying fixes.

## Bugs fixed

### Bug 1 — Preview iframe URL uses artifact path for live tab
\`src/app/render.ts\` (\`restoreHistoricalPreviewTab\` and \`htmlPreviewContent\`)
computed the live-tab predicate as \`tab.id === LIVE_PREVIEW_PANEL_TAB_ID
|| tab.id.startsWith(\"preview:live\")\`, but the actual current-preview tab
id is \`preview:entry:<file>\`. Result: artifact-id was folded into the live
iframe URL. Replaced both sites with the canonical \`isLivePreviewTab()\`
helper from \`panel-workspace.ts\`.

### Bug 2 — Historical project proposal panel renders empty Components view
\`tab.state.fields\` for a historical \`propose_project\` snapshot has
\`build_command\` etc. at the top level but no synthesized \`components\`
array. The live wire path folds those server-side
(\`LEGACY_KEY_MAP\` in \`server.ts\`), but historical snapshots skip that step
and \`projectProposalPanel\` filters legacy keys out of its render loop.
\`proposalPanelContent\` now mirrors the server fold at the historical
override seam, synthesizing a single default component when the snapshot
has none. Identity short-circuit preserved via a new
\`_proposalOverrideSource\` ref so re-projection doesn't fire every render.

### Bug 3 — Drag-drop allows reordering past pinned tabs
SortableJS \`onMove\` returned \`false\` for the target candidate that would
land on/before a pinned tab, but intermediate non-pinned swaps during the
same sweep had already mutated the DOM. \`onMove\` now climbs to the
\`.goal-tab-pill\` ancestor (for child-element hits) and sets a
\`panelSortablePinnedBlocked\` flag across the whole drag; \`onEnd\` skips
the state commit AND restores the DOM order from an \`onStart\` snapshot
when the flag is set. Defense-in-depth: also revert if the final order
places any non-pinned tab before any pinned tab.

## Tests restored

The three \`test.fixme\` markers added by master commit 3b091a71 are
removed:
- \`tests/e2e/ui/preview-happy-path.spec.ts::\"iframe src is /preview/<sid>/<entry>?mtime=<n>\"\`
- \`tests/e2e/ui/proposal-revision-snapshots.spec.ts::\"propose + edit + open-old card opens a historical tab while the latest draft stays live\"\`
- \`tests/e2e/ui/side-panel-tabs.spec.ts::\"6. Desktop drag reorder persists and cannot move tabs before pinned Inbox\"\`

All three pass deterministically; full E2E suite is green.

## Validation

- \`npm run check\` ✓
- \`npm run test:unit\` ✓
- Targeted specs pass (15/15) ✓
- Full \`npm run test:e2e\` ✓ (no new regressions vs master baseline)

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)