### PR TITLE
Project Onboarding Prototype: new Add Project dialog + DirectoryPicker + subset handoff fix

### DIFF
--- a/docs/design/project-onboarding-ux.md
+++ b/docs/design/project-onboarding-ux.md
@@ -1,0 +1,244 @@
+# Project onboarding UX — decision record
+
+Status: shipped. V2 Add Project dialog is the default; legacy in-dialog browser
+removed.
+
+Tracked in goal `goal/project-onboar-c34ea1c5` (Tasks A–D shipped, this doc =
+Task E).
+
+Companion artefacts:
+
+- Reusable picker: [`src/ui/components/DirectoryPicker.ts`](../../src/ui/components/DirectoryPicker.ts)
+- Add Project dialog: [`src/app/dialogs.ts::showProjectDialog`](../../src/app/dialogs.ts)
+- Auto-prompt formatter: [`src/app/project-assistant-autoprompt.ts`](../../src/app/project-assistant-autoprompt.ts)
+- Server-side first-turn contract: [`src/server/agent/project-assistant.ts`](../../src/server/agent/project-assistant.ts)
+- Pinning tests: [`tests/project-assistant-autoprompt.test.ts`](../../tests/project-assistant-autoprompt.test.ts), [`tests/e2e/ui/add-project-*.spec.ts`](../../tests/e2e/ui/)
+
+This document records the **decisions** that survived implementation — not a
+spec, not an implementation rehash. Read the linked source for "how"; read this
+for "why".
+
+## Background
+
+The previous attempt (`goal/project-on-d860d29e`, never merged) built a static
+story fixture for an interaction model the user could look at but not actually
+use. The user found this unsatisfying — the experience was a mockup, not a
+prototype against real APIs. This re-attempt deliberately started fresh on
+`master` and built a **functional prototype wired into the live app**,
+iterating on the running thing rather than on a 400-line design doc.
+
+## Decisions
+
+### D1. Prototype-first, design doc last
+
+The previous attempt produced a long design doc and an interactive story
+backed by mocked API boundaries; the user wanted to *drive* the flow against
+real endpoints. This time the order was: build a working V2 dialog behind the
+existing UI entry points → ship it as default → write a short decision record
+(this doc). No upfront framing doc, no story fixture, no developer toggle —
+the existing E2E suite is the safety net for "still works after promotion".
+
+**Why:** Design docs solidify too early. Most of the interesting choices below
+(browse-modal vs. inline, single-payload handoff, fallback `repo:.` item)
+became obvious only once a real user could click through real preflight and
+real scan output. Capturing them after the fact keeps the doc honest.
+
+### D2. `DirectoryPicker` is a reusable light-DOM primitive
+
+A new `<directory-picker>` Lit element owns the typeahead input, suggestion
+list, keyboard navigation, and debounce. It does **not** import
+`gatewayFetch`, does **not** open a browse modal, and does **not** run
+detection/preflight. The caller injects a `browseDirectory` callback and
+listens for path events.
+
+Reasoning:
+
+- **Light DOM** (`createRenderRoot() { return this }`) keeps Tailwind tokens
+  and app CSS applicable. A shadow-bound variant would have forced a styling
+  fork.
+- **No API import** keeps the component testable in isolation and reusable
+  for future surfaces (settings picker, goal-cwd field) without dragging the
+  gateway client along.
+- **Browse is an event, not a child component.** The picker emits
+  `directory-browse-request`; the Add Project dialog composes the dedicated
+  browse modal on top of itself. Future surfaces can provide an inline panel,
+  a sheet, or no browse affordance at all without forking the input/suggestion
+  logic.
+
+Event surface (stable): `directory-input`, `directory-select`,
+`directory-commit`, `directory-browse-request`, `directory-cancel`.
+
+### D3. Browse is a dedicated modal, not an in-dialog list
+
+The legacy dialog showed browse results in a `max-h-[200px]` panel beneath
+the input. This was cramped, made the footer move, and on small viewports
+left no room to actually browse.
+
+The V2 dialog opens `openProjectBrowseDialog()` as a separate modal **on top
+of** the Add Project dialog when the user clicks Browse. The parent dialog
+stays mounted with its footer in place; the modal owns its own breadcrumb,
+scrollable list, Up affordance, and Select-current button.
+
+**Why a modal beats inline:** the original "near the input" intuition is
+satisfied by the typeahead suggestion list; full directory browsing wants
+significantly more vertical space and stable controls. Trying to do both in
+one pane led directly to the footer-instability bug class.
+
+### D4. Footer position is invariant — pinned by test
+
+The V2 dialog has a fixed shell (`min(720px, 94vw)` × `min(720px, 92vh)`) with
+sticky header, scrollable body, and a persistent footer container that is
+identical across every state — empty input, typed path, preflight loading,
+preflight pass/warn/fail, browse modal open, suggestions open, scan checklist,
+error row, archiving.
+
+Status-line and preflight regions are **reserved slots** (`min-h-[20px]`,
+internal `overflow-y-auto`), not content-sized panes. Suggestions are
+absolutely positioned by `DirectoryPicker` so they overlay rather than push.
+
+This is pinned by [`add-project-footer-stability.spec.ts`](../../tests/e2e/ui/add-project-footer-stability.spec.ts),
+which captures the footer bounding box before and after every transition and
+fails with the offending state + pixel delta. Any future content addition
+that wants to live in the body must use one of the existing reserved slots
+or reserve its own.
+
+### D5. Wording: "repo/subdirectory", not "component"
+
+The scan checklist uses "repo/subdirectory candidates" everywhere
+(header, count, body copy, assistant handoff). "Component" is reserved for
+the registered `propose_project.components[]` shape.
+
+The distinction matters: at scan time the user has not yet decided which
+candidates become components. Calling them components in the UI made early
+testers assume their selection was irrevocable. The current wording makes
+clear that unselected entries are *excluded from the initial proposal* but
+can be added back later by the assistant.
+
+### D6. Subset handoff = auto-prompt block + fenced JSON, not a server field
+
+The user-confirmed scan subset reaches the project assistant via the existing
+client-built auto-prompt sent on session creation. The prompt contains both:
+
+1. An English bullet summary (Selected N of M, Not selected, instructions).
+2. A fenced ```` ```json ```` block carrying the full
+   `{ rootPath, items, selectedIds }` payload verbatim.
+
+The server's project-assistant first-turn instructions
+([`project-assistant.ts`](../../src/server/agent/project-assistant.ts) under
+"User-confirmed initial repo/subdirectory selection") teach the model to
+treat `selectedIds` as authoritative for the **first**
+`propose_project.components` call, map each item's `repo` / `relativePath` /
+`detectedCommands` verbatim, and mention excluded entries in chat.
+
+**Why client-side prompt, not server session field:**
+
+- Zero `/api/sessions` contract change — the existing `initialPrompt` path
+  already carries arbitrary text, and the assistant runtime already replays
+  it on reconnect.
+- Two consumers (the English summary and the JSON) share **one** payload,
+  removing the format-drift class of bugs.
+- Pinned at two levels: [`tests/project-assistant-autoprompt.test.ts`](../../tests/project-assistant-autoprompt.test.ts)
+  golden-output checks the formatter; [`add-project-multi-repo-subset.spec.ts`](../../tests/e2e/ui/add-project-multi-repo-subset.spec.ts)
+  asserts the WebSocket frame the live dialog sends.
+
+If a future use case needs the subset to survive a failed first WebSocket
+connection, promote it to a real session field then. Today it does not.
+
+### D7. One normalized `ProjectScanItem[]` + a `Set<id>` for selection
+
+The dialog and the auto-prompt formatter share a single shape
+([`ProjectScanItem`](../../src/app/project-assistant-autoprompt.ts)) built
+once from the `/api/projects/scan` response. Selection state is a
+`Set<string>` of `item.id` values, never a separate authoritative
+`selected/unselected/allRepos/monorepo` payload.
+
+`item.id` is `repo:<folder>` for multi-repo entries and
+`workspace:<relativePath>` for monorepo workspaces, giving a stable string
+key that survives JSON round-tripping into the assistant prompt without
+collisions.
+
+**Fallback `repo:.`:** when both `repos` and `monorepo.candidates` come back
+empty, the dialog synthesizes a single `repo:.` item labeled `(root)` so the
+single-repo path still routes through the assistant with a non-empty
+`selectedIds`. This removed a class of "scan came back empty" UI dead ends.
+
+### D8. `scanProject` vs `scanProjectRepos`
+
+`scanProject(dirPath): Promise<{ repos, monorepo }>` was added to
+[`src/app/api.ts`](../../src/app/api.ts) to expose the monorepo block the
+V2 dialog needs. The legacy `scanProjectRepos()` is preserved as a
+compatibility wrapper that drops `monorepo` and returns `repos[]`, so
+existing call sites (settings rescan, post-archive flow) continue to
+compile and behave identically.
+
+### D9. Escape key layering: suggestions → browse → dialog
+
+Escape closes the topmost layer only:
+
+1. Open suggestions → Escape closes suggestions, focus stays in the input.
+2. Browse modal open → Escape closes the modal, focus returns to the picker
+   input.
+3. Neither open → Escape closes the Add Project dialog.
+
+This was the most-cited usability fix from Task D part 2 review. Each layer
+owns its own `keydown` capture with a clean teardown so closing a child
+layer never bubbles into closing the parent.
+
+### D10. Sidebar `ProjectPickerPopover` was deliberately untouched
+
+The legacy `ProjectPickerPopover` is the **project switcher** (jump between
+already-registered projects from the sidebar), not the Add Project flow.
+It stays as-is — fast, keyboard-driven, folder-only. The "delete legacy
+dialog code" acceptance bullet referred to the in-dialog browser inside
+`showProjectDialog`, which was replaced wholesale, not to the switcher.
+
+See the comment block at the top of
+[`src/ui/components/ProjectPickerPopover.ts`](../../src/ui/components/ProjectPickerPopover.ts)
+for the boundary.
+
+## Where it lives
+
+| Concern | File |
+|---|---|
+| Reusable picker primitive | `src/ui/components/DirectoryPicker.ts` |
+| Dialog orchestration + browse modal | `src/app/dialogs.ts::showProjectDialog`, `openProjectBrowseDialog` |
+| Auto-prompt formatter + types | `src/app/project-assistant-autoprompt.ts` |
+| Session wiring | `src/app/session-manager.ts::connectToSession` (`projectInitialScanContext` option) |
+| Assistant first-turn contract | `src/server/agent/project-assistant.ts` (First message → User-confirmed initial selection) |
+| Scan API helper | `src/app/api.ts::scanProject` (+ `scanProjectRepos` shim) |
+
+## Verification
+
+Pinning tests (run on every check-in):
+
+- `tests/project-assistant-autoprompt.test.ts` — formatter golden output,
+  selected/unselected ordering, scaffolding/edit/new modes.
+- `tests/e2e/ui/add-project-typeahead.spec.ts` — typeahead happy path.
+- `tests/e2e/ui/add-project-browse-modal.spec.ts` — modal open/close, select
+  current, focus return.
+- `tests/e2e/ui/add-project-footer-stability.spec.ts` — bounding-box
+  invariant across all state transitions.
+- `tests/e2e/ui/add-project-multi-repo-subset.spec.ts` — WebSocket frame
+  contains the derived bullet summary + JSON payload.
+- `tests/e2e/ui/add-project-select-all.spec.ts` — select/deselect-all,
+  Continue disabled when count = 0.
+- Preserved: `add-project-flow.spec.ts`, `add-project-preflight.spec.ts`,
+  `add-project-post-archive.spec.ts`, `add-project-symlink.spec.ts`,
+  `project-detect-browse.spec.ts`.
+
+If a future change to the auto-prompt format is required, update the
+formatter, the server-side instructions in `project-assistant.ts`, **and**
+both pinning tests in the same commit.
+
+## Non-goals (kept out, on purpose)
+
+- **Richer server-side suggestion endpoint.** Existing `/api/browse-directory`
+  + recent paths cover the prototype review. A `mode=suggest&path=...` knob
+  is left for a future need-driven change.
+- **Shadow-DOM variant of the picker.** Light DOM was a deliberate choice
+  (see D2); a shadow variant would fork the styling story.
+- **Persisting the subset across a failed first WebSocket.** See D6 — add a
+  real `initialPrompt` server field if and only if a concrete user-visible
+  failure demands it.
+- **Refactor of detect / preflight / scan server logic.** Only the
+  `scanProject` client helper was added; server endpoints are unchanged.

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -481,14 +481,60 @@ export interface DetectedRepo {
   detectedCommands: Record<string, string>;
 }
 
-export async function scanProjectRepos(dirPath: string): Promise<DetectedRepo[]> {
+/**
+ * Monorepo workspace frameworks detected at `rootPath`. Mirrors the server-
+ * side `MonorepoFramework` union (see `src/server/agent/monorepo-scan.ts`).
+ */
+export type MonorepoFramework =
+  | "pnpm"
+  | "npm-yarn-workspaces"
+  | "nx"
+  | "turbo"
+  | "lerna"
+  | "cargo"
+  | "go"
+  | "gradle";
+
+export interface MonorepoCandidate {
+  relativePath: string;
+  frameworks: MonorepoFramework[];
+  packageName?: string;
+}
+
+export interface MonorepoScanResult {
+  frameworks: MonorepoFramework[];
+  candidates: MonorepoCandidate[];
+  truncated: boolean;
+  totalCount: number;
+}
+
+export interface ProjectScanResult {
+  repos: DetectedRepo[];
+  monorepo?: MonorepoScanResult;
+}
+
+/**
+ * Full server payload from POST /api/projects/scan — `{ repos, monorepo }`.
+ * Use this when you need the monorepo block (V2 Add-Project flow); legacy
+ * call sites that only want `repos` should keep using `scanProjectRepos`.
+ */
+export async function scanProject(dirPath: string): Promise<ProjectScanResult> {
   const res = await gatewayFetch(`/api/projects/scan?path=${encodeURIComponent(dirPath)}`, {
     method: 'POST',
     body: JSON.stringify({ path: dirPath }),
   });
   if (!res.ok) throw new Error(`Scan failed (${res.status})`);
   const data = await res.json();
-  return Array.isArray(data?.repos) ? data.repos as DetectedRepo[] : [];
+  const repos = Array.isArray(data?.repos) ? data.repos as DetectedRepo[] : [];
+  const monorepo = data?.monorepo && typeof data.monorepo === "object"
+    ? data.monorepo as MonorepoScanResult
+    : undefined;
+  return { repos, monorepo };
+}
+
+export async function scanProjectRepos(dirPath: string): Promise<DetectedRepo[]> {
+  const { repos } = await scanProject(dirPath);
+  return repos;
 }
 
 export async function browseDirectory(dirPath?: string): Promise<{

--- a/src/app/dialogs-lazy.ts
+++ b/src/app/dialogs-lazy.ts
@@ -46,8 +46,35 @@ export function showGoalDialog(existingGoal?: Goal, projectId?: string): void {
 	void load().then((m) => m.showGoalDialog(existingGoal, projectId));
 }
 
+/**
+ * Developer-only toggle for the V2 Add Project dialog. While the prototype
+ * is under review:
+ *   - `?addProjectV2=1` in the URL enables V2 and persists to localStorage.
+ *   - `?addProjectV2=0` disables V2 and clears the localStorage flag.
+ *   - With no query param, the flag is read from localStorage (`"1"` → on).
+ *
+ * Once the user signs off, this toggle is removed and V2 becomes the default.
+ */
+function isV2Enabled(): boolean {
+	try {
+		const url = new URL(window.location.href);
+		const v = url.searchParams.get("addProjectV2");
+		if (v === "1") {
+			window.localStorage.setItem("addProjectV2", "1");
+			return true;
+		}
+		if (v === "0") {
+			window.localStorage.removeItem("addProjectV2");
+			return false;
+		}
+		return window.localStorage.getItem("addProjectV2") === "1";
+	} catch {
+		return false;
+	}
+}
+
 export function showProjectDialog(): void {
-	void load().then((m) => m.showProjectDialog());
+	void load().then((m) => (isV2Enabled() ? m.showProjectDialogV2() : m.showProjectDialog()));
 }
 
 // \u2500\u2500 Async wrappers \u2014 propagate the returned promise.  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500

--- a/src/app/dialogs-lazy.ts
+++ b/src/app/dialogs-lazy.ts
@@ -46,35 +46,8 @@ export function showGoalDialog(existingGoal?: Goal, projectId?: string): void {
 	void load().then((m) => m.showGoalDialog(existingGoal, projectId));
 }
 
-/**
- * Developer-only toggle for the V2 Add Project dialog. While the prototype
- * is under review:
- *   - `?addProjectV2=1` in the URL enables V2 and persists to localStorage.
- *   - `?addProjectV2=0` disables V2 and clears the localStorage flag.
- *   - With no query param, the flag is read from localStorage (`"1"` → on).
- *
- * Once the user signs off, this toggle is removed and V2 becomes the default.
- */
-function isV2Enabled(): boolean {
-	try {
-		const url = new URL(window.location.href);
-		const v = url.searchParams.get("addProjectV2");
-		if (v === "1") {
-			window.localStorage.setItem("addProjectV2", "1");
-			return true;
-		}
-		if (v === "0") {
-			window.localStorage.removeItem("addProjectV2");
-			return false;
-		}
-		return window.localStorage.getItem("addProjectV2") === "1";
-	} catch {
-		return false;
-	}
-}
-
 export function showProjectDialog(): void {
-	void load().then((m) => (isV2Enabled() ? m.showProjectDialogV2() : m.showProjectDialog()));
+	void load().then((m) => m.showProjectDialog());
 }
 
 // \u2500\u2500 Async wrappers \u2014 propagate the returned promise.  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500

--- a/src/app/dialogs.ts
+++ b/src/app/dialogs.ts
@@ -1673,7 +1673,7 @@ function openProjectBrowseDialog(initialPath: string): Promise<string | null> {
 		let highlight = -1;
 
 		const close = (result: string | null) => {
-			document.removeEventListener("keydown", onKeyDown);
+			document.removeEventListener("keydown", onKeyDown, true);
 			render(html``, container);
 			container.remove();
 			resolve(result);
@@ -1703,7 +1703,14 @@ function openProjectBrowseDialog(initialPath: string): Promise<string | null> {
 
 		const onKeyDown = (e: KeyboardEvent) => {
 			if (e.key === "Escape") {
+				// Capture-phase + stopImmediatePropagation so the parent Add Project
+				// dialog's Mini-lit Dialog (which also listens to `document` keydown
+				// for Esc) does not also close when the user dismisses the browse
+				// overlay. Design doc invariant: "Esc closes suggestions → browse →
+				// dialog (in that order)". Pinned by
+				// tests/e2e/ui/add-project-browse-modal.spec.ts.
 				e.preventDefault();
+				e.stopImmediatePropagation();
 				close(null);
 				return;
 			}
@@ -1814,7 +1821,7 @@ function openProjectBrowseDialog(initialPath: string): Promise<string | null> {
 			);
 		};
 
-		document.addEventListener("keydown", onKeyDown);
+		document.addEventListener("keydown", onKeyDown, true);
 		renderDialog();
 		void navigate(initialPath?.trim() || undefined);
 	});

--- a/src/app/dialogs.ts
+++ b/src/app/dialogs.ts
@@ -17,7 +17,17 @@ import {
 	type GoalState,
 	type Project,
 } from "./state.js";
-import { gatewayFetch, updateGoal, SymlinkRootError } from "./api.js";
+import { gatewayFetch, updateGoal, SymlinkRootError, type DetectedRepo, type MonorepoScanResult } from "./api.js";
+import "../ui/components/DirectoryPicker.js";
+import type {
+	DirectoryPicker as DirectoryPickerEl,
+	DirectoryPickerPathDetail,
+	DirectoryBrowseResult,
+} from "../ui/components/DirectoryPicker.js";
+import type {
+	ProjectScanItem,
+	ProjectAssistantScanContext,
+} from "./project-assistant-autoprompt.js";
 import { errorDetails } from "./error-helpers.js";
 import "../ui/components/ErrorDetails.js";
 import { updateLocalSessionTitle } from "./api.js";
@@ -1943,7 +1953,24 @@ export function showProjectDialog(): void {
 	renderDialog();
 }
 
-export async function createProjectAssistantSession(dirPath: string, scaffolding: boolean, opts?: { projectId?: string; existingProjectName?: string }): Promise<void> {
+export async function createProjectAssistantSession(
+	dirPath: string,
+	scaffolding: boolean,
+	opts?: {
+		projectId?: string;
+		existingProjectName?: string;
+		/**
+		 * User-confirmed initial repo/subdirectory selection from the V2 Add
+		 * Project scan checklist. Forwarded to the project-assistant's first
+		 * turn via `connectToSession`'s `projectInitialScanContext` option so
+		 * the assistant treats the selected ids as authoritative starting
+		 * candidates for `propose_project.components`. Only meaningful when
+		 * `scaffolding === false` (new-project registration); ignored
+		 * otherwise. See `src/app/project-assistant-autoprompt.ts`.
+		 */
+		initialScanContext?: import("./project-assistant-autoprompt.js").ProjectAssistantScanContext;
+	},
+): Promise<void> {
 	if (state.creatingSession) return;
 	state.creatingSession = true;
 	renderApp();
@@ -1978,12 +2005,871 @@ export async function createProjectAssistantSession(dirPath: string, scaffolding
 		const projectEditContext = opts?.projectId
 			? { name: opts.existingProjectName || opts.projectId, rootPath: dirPath }
 			: undefined;
-		await connectToSession(id, false, { assistantType: actualType, projectDirPath: dirPath, projectEditContext });
+		// Forward the optional user-confirmed initial scan subset to the
+		// project-assistant's first turn. Only applies to new-project
+		// registration (not scaffolding, not edit-mode) — the V2 Add Project
+		// scan checklist is the only caller that supplies it.
+		const projectInitialScanContext =
+			!scaffolding && !opts?.projectId ? opts?.initialScanContext : undefined;
+		await connectToSession(id, false, {
+			assistantType: actualType,
+			projectDirPath: dirPath,
+			projectEditContext,
+			projectInitialScanContext,
+		});
 	} catch (err) {
 		const { message, code, stack } = errorDetails(err);
 		showConnectionError("Failed to create project assistant", message, { code, stack });
 	} finally {
 		state.creatingSession = false;
 		renderApp();
+	}
+}
+
+// ============================================================================
+// V2 PROJECT REGISTRATION DIALOG
+// ----------------------------------------------------------------------------
+// Modern Add Project dialog gated behind `localStorage.addProjectV2 === "1"`
+// (also settable via `?addProjectV2=1`). The legacy `showProjectDialog` above
+// remains the default until the user signs off on the prototype.
+//
+// Design source of truth: gate `design-doc` on the goal. Key differences from
+// the legacy dialog:
+//   - Reusable `<directory-picker>` element (typeahead + browse trigger) in
+//     place of the inline Input + Browse layout. Suggestions are
+//     absolutely-positioned by the picker so the footer never shifts.
+//   - Dedicated browse modal (`openProjectBrowseDialog`) on top of the dialog
+//     instead of swapping the input out for an in-dialog list view.
+//   - Fixed dialog shell (`min(720px, 94vw)` x `min(720px, 92vh)`) with
+//     sticky header, scrollable body, and persistent footer. The footer
+//     container is identical across all states (path/scan + loading + error)
+//     so its bounding box is invariant.
+//   - Scan checklist surfaces every detected repo *and* monorepo workspace
+//     candidate as a normalized `ProjectScanItem` and forwards the
+//     user-confirmed subset into the project-assistant's first turn via
+//     `createProjectAssistantSession({ initialScanContext })`. This is the
+//     bug fix: legacy `confirmScanAndContinue` built `scanSelection` and
+//     dropped it on the floor.
+// ============================================================================
+
+/**
+ * Normalize the `scanProject` payload into a flat `ProjectScanItem[]` for the
+ * V2 scan checklist. Mirrors the spec in `project-assistant-autoprompt.ts`:
+ *
+ *   - One item per `repos[]` entry (`id = "repo:<folder>"`).
+ *   - One item per `monorepo.candidates[]` entry (`id = "workspace:<rel>"`).
+ *   - Fallback single-component candidate (`id = "repo:."`, label "(root)")
+ *     when both arrays are empty, so the legacy single-repo path still
+ *     routes through the assistant with a non-empty `selectedIds`.
+ *
+ * `absolutePath` is the on-disk path of the item; `joinPath` picks the
+ * separator from the root so Windows roots stay Windows-y.
+ */
+function joinScanPath(root: string, rel: string): string {
+	if (!rel || rel === ".") return root;
+	const looksWindows = /^[A-Za-z]:[\\/]/.test(root) || (root.includes("\\") && !root.startsWith("/"));
+	const sep = looksWindows ? "\\" : "/";
+	const trimmedRoot = root.replace(/[\\/]+$/, "");
+	const trimmedRel = rel.replace(/^[\\/]+/, "");
+	return `${trimmedRoot}${sep}${trimmedRel}`;
+}
+
+function buildScanItems(
+	rootPath: string,
+	scan: { repos: DetectedRepo[]; monorepo?: MonorepoScanResult },
+): ProjectScanItem[] {
+	const out: ProjectScanItem[] = [];
+	const repos = Array.isArray(scan.repos) ? scan.repos : [];
+	for (const r of repos) {
+		if (!r || typeof r.folder !== "string") continue;
+		out.push({
+			id: `repo:${r.folder}`,
+			kind: "repo",
+			label: r.folder === "." ? "(root)" : r.folder,
+			repo: r.folder,
+			absolutePath: joinScanPath(rootPath, r.folder),
+			hasGit: !!r.hasGit,
+			detectedCommands: { ...(r.detectedCommands || {}) },
+		});
+	}
+	const candidates = scan.monorepo?.candidates ?? [];
+	for (const w of candidates) {
+		if (!w || typeof w.relativePath !== "string") continue;
+		const wAny = w as unknown as { detectedCommands?: Record<string, string> };
+		out.push({
+			id: `workspace:${w.relativePath}`,
+			kind: "workspace",
+			label: w.relativePath,
+			repo: ".",
+			relativePath: w.relativePath,
+			absolutePath: joinScanPath(rootPath, w.relativePath),
+			hasGit: false,
+			// MonorepoCandidate has no detectedCommands on the wire today; the
+			// autoprompt helper only requires the field to be present.
+			detectedCommands: wAny.detectedCommands ? { ...wAny.detectedCommands } : {},
+		});
+	}
+	if (out.length === 0) {
+		out.push({
+			id: "repo:.",
+			kind: "repo",
+			label: "(root)",
+			repo: ".",
+			absolutePath: rootPath,
+			hasGit: false,
+			detectedCommands: {},
+		});
+	}
+	return out;
+}
+
+/**
+ * Standalone browse modal. Opens on top of the V2 Add Project dialog when the
+ * user clicks the picker's Browse button. Resolves with the selected absolute
+ * path or `null` on cancel. Mirrors the legacy in-dialog browser semantics
+ * (directory-only entries; skips hidden / `node_modules` / symlinks — that
+ * filtering is done server-side by `/api/browse-directory`), but in a
+ * dedicated overlay so the parent dialog's footer stays put.
+ */
+function openProjectBrowseDialog(initialPath: string): Promise<string | null> {
+	return new Promise((resolve) => {
+		const container = document.createElement("div");
+		document.body.appendChild(container);
+
+		let current = "";
+		let parent: string | null = null;
+		let entries: Array<{ name: string; path: string }> = [];
+		let truncated = false;
+		let loading = true;
+		let errorMessage = "";
+		let highlight = -1;
+
+		const close = (result: string | null) => {
+			document.removeEventListener("keydown", onKeyDown);
+			render(html``, container);
+			container.remove();
+			resolve(result);
+		};
+
+		const navigate = async (dirPath: string | undefined) => {
+			loading = true;
+			errorMessage = "";
+			renderDialog();
+			try {
+				const { browseDirectory } = await import("./api.js");
+				const result = await browseDirectory(dirPath) as DirectoryBrowseResult & { truncated?: boolean };
+				current = result.current;
+				parent = result.parent;
+				entries = result.entries ?? [];
+				truncated = !!result.truncated;
+				highlight = entries.length > 0 ? 0 : -1;
+			} catch (err) {
+				errorMessage = err instanceof Error ? err.message : String(err);
+				// Keep `current` so the user can still hit Select if they had a
+				// valid path before the error.
+			} finally {
+				loading = false;
+				renderDialog();
+			}
+		};
+
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key === "Escape") {
+				e.preventDefault();
+				close(null);
+				return;
+			}
+			if (e.key === "ArrowDown") {
+				if (entries.length === 0) return;
+				e.preventDefault();
+				highlight = highlight < 0 ? 0 : (highlight + 1) % entries.length;
+				renderDialog();
+				return;
+			}
+			if (e.key === "ArrowUp") {
+				if (entries.length === 0) return;
+				e.preventDefault();
+				highlight = highlight <= 0 ? entries.length - 1 : highlight - 1;
+				renderDialog();
+				return;
+			}
+			if (e.key === "Enter") {
+				e.preventDefault();
+				if (highlight >= 0 && highlight < entries.length) {
+					const target = entries[highlight];
+					if (target) void navigate(target.path);
+				} else if (current) {
+					close(current);
+				}
+				return;
+			}
+		};
+
+		const renderDialog = () => {
+			render(
+				Dialog({
+					isOpen: true,
+					onClose: () => close(null),
+					width: "min(640px, 92vw)",
+					height: "min(560px, 88vh)",
+					backdropClassName: "bg-black/60 backdrop-blur-sm",
+					children: html`
+						<div class="flex flex-col h-full" data-testid="add-project-browse-dialog">
+							<div class="shrink-0 px-6 pt-6 pb-2">
+								${DialogHeader({ title: "Browse for directory" })}
+								<div class="flex items-center gap-2 mt-3 min-h-[28px]">
+									<button
+										type="button"
+										class="px-2 py-1 text-xs rounded border border-border text-foreground hover:bg-secondary/50 transition-colors disabled:opacity-40 disabled:pointer-events-none"
+										?disabled=${parent == null || loading}
+										@click=${() => parent != null && void navigate(parent)}
+										data-testid="add-project-browse-up"
+									>Up</button>
+									<span
+										class="text-xs text-muted-foreground flex-1 min-w-0 truncate font-mono"
+										title=${current}
+										data-testid="add-project-browse-current"
+									>${current || "Loading…"}</span>
+								</div>
+							</div>
+							<div class="flex-1 min-h-0 px-6 overflow-hidden flex flex-col gap-2">
+								<div class="text-[11px] min-h-[16px] ${errorMessage ? "text-red-500" : "text-muted-foreground"}" data-testid="add-project-browse-status">
+									${loading
+										? "Loading…"
+										: errorMessage
+											? `Error: ${errorMessage}`
+											: entries.length === 0
+												? "No subdirectories."
+												: truncated
+													? `Showing first ${entries.length} directories.`
+													: ""}
+								</div>
+								<div class="flex-1 min-h-0 overflow-y-auto border border-border rounded" data-testid="add-project-browse-list">
+									${entries.length === 0 && !loading && !errorMessage
+										? html`<div class="px-3 py-2 text-xs text-muted-foreground">No subdirectories</div>`
+										: entries.map((entry, idx) => {
+											const active = idx === highlight;
+											const rowClass = active
+												? "bg-accent text-accent-foreground"
+												: "text-foreground hover:bg-secondary/50";
+											return html`
+												<button
+													type="button"
+													class="w-full text-left px-3 py-1.5 text-sm transition-colors flex items-center gap-2 border-b border-border last:border-0 ${rowClass}"
+													data-testid="add-project-browse-entry"
+													data-path=${entry.path}
+													@click=${() => void navigate(entry.path)}
+													@mouseenter=${() => { highlight = idx; renderDialog(); }}
+												>
+													<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="shrink-0 text-muted-foreground"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+													<span class="truncate">${entry.name}</span>
+												</button>
+											`;
+										})}
+								</div>
+							</div>
+							<div class="shrink-0 px-6 py-4 border-t border-border" data-testid="add-project-browse-footer">
+								<div class="flex gap-2 justify-end">
+									${Button({ variant: "ghost", onClick: () => close(null), children: "Cancel" })}
+									${Button({
+										variant: "default",
+										onClick: () => close(current || null),
+										disabled: !current || loading,
+										children: "Select current",
+									})}
+								</div>
+							</div>
+						</div>
+					`,
+				}),
+				container,
+			);
+		};
+
+		document.addEventListener("keydown", onKeyDown);
+		renderDialog();
+		void navigate(initialPath?.trim() || undefined);
+	});
+}
+
+/**
+ * V2 Add Project dialog — see header comment for design rationale. Reachable
+ * from any existing `showProjectDialog()` call site when
+ * `localStorage.addProjectV2 === "1"` (or `?addProjectV2=1`). The toggle
+ * lives in `src/app/dialogs-lazy.ts::showProjectDialog`.
+ */
+export function showProjectDialogV2(): void {
+	const container = document.createElement("div");
+	document.body.appendChild(container);
+
+	type Step = "path" | "scan";
+	let step: Step = "path";
+	let pathValue = "";
+
+	let detectionResult: { exists: boolean; hasBobbit: boolean; isEmpty: boolean; name: string } | null = null;
+	let detectionToken = 0;
+
+	let preflightReport: PreflightReport | null = null;
+	let preflightLoading = false;
+	let preflightError = "";
+	let preflightToken = 0;
+	let preflightUnavailable = false;
+	let archiving = false;
+
+	let scanItems: ProjectScanItem[] = [];
+	let scanSelection = new Set<string>();
+
+	let busy = false;
+	let errorMessage: string | null = null;
+	let detectDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+	// Single picker instance reused across renders so its internal state
+	// (focus, suggestion list, etc.) is preserved.
+	const pickerEl = document.createElement("directory-picker") as DirectoryPickerEl;
+	pickerEl.placeholder = "/path/to/project";
+	pickerEl.setAttribute("data-testid", "add-project-picker-v2");
+
+	const recentPaths = (): Array<{ path: string; source: string }> => {
+		const seen = new Set<string>();
+		const out: Array<{ path: string; source: string }> = [];
+		for (const p of state.projects ?? []) {
+			if (!p?.rootPath || seen.has(p.rootPath)) continue;
+			seen.add(p.rootPath);
+			out.push({ path: p.rootPath, source: "registered" });
+		}
+		return out;
+	};
+
+	const cleanup = () => {
+		if (detectDebounceTimer) {
+			clearTimeout(detectDebounceTimer);
+			detectDebounceTimer = null;
+		}
+		render(html``, container);
+		container.remove();
+	};
+
+	const runDetection = async (dirPath: string) => {
+		const trimmed = dirPath.trim();
+		if (!trimmed) {
+			detectionResult = null;
+			renderDialog();
+			return;
+		}
+		const token = ++detectionToken;
+		try {
+			const { detectProject } = await import("./api.js");
+			const result = await detectProject(trimmed);
+			if (token !== detectionToken) return;
+			detectionResult = result;
+		} catch {
+			if (token !== detectionToken) return;
+			detectionResult = null;
+		}
+		renderDialog();
+	};
+
+	const runPreflight = async (dirPath: string) => {
+		const trimmed = dirPath.trim();
+		if (!trimmed) {
+			preflightReport = null;
+			preflightLoading = false;
+			preflightError = "";
+			renderDialog();
+			return;
+		}
+		if (preflightUnavailable) return;
+		const token = ++preflightToken;
+		preflightLoading = true;
+		preflightError = "";
+		renderDialog();
+		try {
+			const res = await gatewayFetch(`/api/projects/preflight?path=${encodeURIComponent(trimmed)}`);
+			if (token !== preflightToken) return;
+			if (res.status === 404) {
+				console.warn("[preflight] endpoint unavailable — hiding panel");
+				preflightUnavailable = true;
+				preflightReport = null;
+				preflightLoading = false;
+				renderDialog();
+				return;
+			}
+			if (!res.ok) {
+				preflightError = `Preflight failed (${res.status})`;
+				preflightReport = null;
+			} else {
+				preflightReport = (await res.json()) as PreflightReport;
+			}
+		} catch (err) {
+			if (token !== preflightToken) return;
+			preflightError = err instanceof Error ? err.message : String(err);
+			preflightReport = null;
+		} finally {
+			if (token === preflightToken) {
+				preflightLoading = false;
+				renderDialog();
+			}
+		}
+	};
+
+	const onEffectivePathChange = (next: string, immediate: boolean): void => {
+		pathValue = next;
+		// Any path change drops us back to the path step and clears scan state.
+		if (step !== "path") {
+			step = "path";
+			scanItems = [];
+			scanSelection = new Set();
+		}
+		errorMessage = null;
+		// Bump tokens immediately so stale in-flight responses for the previous
+		// path can't overwrite the new path's state.
+		detectionToken++;
+		preflightToken++;
+		if (detectDebounceTimer) {
+			clearTimeout(detectDebounceTimer);
+			detectDebounceTimer = null;
+		}
+		if (!next.trim()) {
+			detectionResult = null;
+			preflightReport = null;
+			preflightLoading = false;
+			preflightError = "";
+			renderDialog();
+			return;
+		}
+		const run = () => {
+			void runDetection(pathValue);
+			void runPreflight(pathValue);
+		};
+		if (immediate) {
+			run();
+		} else {
+			detectDebounceTimer = setTimeout(run, 350);
+		}
+		renderDialog();
+	};
+
+	pickerEl.addEventListener("directory-input", (e: Event) => {
+		const detail = (e as CustomEvent<DirectoryPickerPathDetail>).detail;
+		onEffectivePathChange(detail.path, false);
+	});
+	pickerEl.addEventListener("directory-select", (e: Event) => {
+		const detail = (e as CustomEvent<DirectoryPickerPathDetail>).detail;
+		onEffectivePathChange(detail.path, true);
+	});
+	pickerEl.addEventListener("directory-commit", () => {
+		// Enter with no highlighted suggestion → treat as Continue.
+		void doContinue();
+	});
+	pickerEl.addEventListener("directory-browse-request", () => {
+		void openBrowseModal();
+	});
+	pickerEl.addEventListener("directory-cancel", () => {
+		cleanup();
+	});
+
+	const openBrowseModal = async () => {
+		const selected = await openProjectBrowseDialog(pathValue);
+		if (selected != null) {
+			pickerEl.value = selected;
+			onEffectivePathChange(selected, true);
+		}
+		// Focus returns to the picker regardless of outcome.
+		pickerEl.focusInput();
+	};
+
+	const openArchiveConfirm = async () => {
+		if (!preflightReport) return;
+		const rootPath = preflightReport.rootPath;
+		const gatewayOwned = preflightReport.checks.some(
+			(c) => c.id === "bobbit.gateway-owned" && c.level !== "pass",
+		);
+		const existingDetail = preflightReport.checks.find((c) => c.id === "bobbit.existing")?.detail || "";
+		const confirmed = await promptArchiveConfirm({ rootPath, gatewayOwned, existingDetail });
+		if (!confirmed) return;
+		archiving = true;
+		renderDialog();
+		try {
+			const res = await gatewayFetch("/api/projects/archive-bobbit", {
+				method: "POST",
+				body: JSON.stringify({ rootPath }),
+			});
+			if (!res.ok) {
+				const data = (await res.json().catch(() => ({}))) as any;
+				showConnectionError(
+					"Failed to archive .bobbit/",
+					data?.error || `Failed: ${res.status}`,
+					{ code: data?.code, stack: data?.stack },
+				);
+			}
+		} catch (err) {
+			const { message, code, stack } = errorDetails(err);
+			showConnectionError("Failed to archive .bobbit/", message, { code, stack });
+		} finally {
+			archiving = false;
+			void runDetection(pathValue);
+			void runPreflight(pathValue);
+		}
+	};
+
+	const doContinue = async () => {
+		if (busy) return;
+		const trimmed = pathValue.trim();
+		if (!trimmed) return;
+		if (step === "scan") {
+			void confirmScanAndContinue();
+			return;
+		}
+		// Block when preflight reports a hard fail (matches legacy behavior).
+		if (preflightReport?.hasFail) return;
+		busy = true;
+		errorMessage = null;
+		renderDialog();
+		try {
+			const { detectProject, registerProject, fetchProjects, scanProject } = await import("./api.js");
+			const detection = await detectProject(trimmed);
+
+			if (detection.hasBobbit) {
+				// Auto-import existing project.
+				try {
+					const project = await registerProject(detection.name, trimmed, undefined);
+					if (project) {
+						setProjects(await fetchProjects());
+						renderApp();
+						cleanup();
+					} else {
+						busy = false;
+						renderDialog();
+					}
+				} catch (e) {
+					if (e instanceof SymlinkRootError) {
+						await promptSymlinkConfirm(
+							detection.name,
+							trimmed,
+							e.canonical,
+							async (canonical) => {
+								try {
+									const p2 = await registerProject(
+										detection.name,
+										canonical,
+										undefined,
+										false,
+										true,
+									);
+									if (p2) {
+										setProjects(await fetchProjects());
+										renderApp();
+										cleanup();
+									} else {
+										busy = false;
+										renderDialog();
+									}
+								} catch (err2) {
+									const { message, code, stack } = errorDetails(err2);
+									showConnectionError("Failed to register project", message, { code, stack });
+									busy = false;
+									renderDialog();
+								}
+							},
+							() => {
+								busy = false;
+								errorMessage = null;
+								renderDialog();
+							},
+						);
+						return;
+					}
+					throw e;
+				}
+				return;
+			}
+
+			const scaffolding = !(detection.exists && !detection.isEmpty);
+			if (scaffolding) {
+				// Empty / new directory → scaffolding mode, no scan checklist.
+				cleanup();
+				await createProjectAssistantSession(trimmed, true);
+				return;
+			}
+
+			// Non-bobbit, non-empty: scan to surface repo/subdirectory candidates.
+			let scan: { repos: DetectedRepo[]; monorepo?: MonorepoScanResult } = { repos: [], monorepo: undefined };
+			try {
+				scan = await scanProject(trimmed);
+			} catch {
+				// Scan failure is non-fatal — fall back to a single-component item.
+				scan = { repos: [], monorepo: undefined };
+			}
+			const items = buildScanItems(trimmed, scan);
+			if (items.length <= 1) {
+				const initialScanContext: ProjectAssistantScanContext | undefined =
+					items.length === 1 && items[0]
+						? { rootPath: trimmed, items, selectedIds: [items[0].id] }
+						: undefined;
+				cleanup();
+				await createProjectAssistantSession(trimmed, false, { initialScanContext });
+				return;
+			}
+			scanItems = items;
+			scanSelection = new Set(items.map((it) => it.id));
+			step = "scan";
+			busy = false;
+			renderDialog();
+		} catch (err) {
+			errorMessage = err instanceof Error ? err.message : String(err);
+			busy = false;
+			renderDialog();
+		}
+	};
+
+	const confirmScanAndContinue = async () => {
+		if (busy) return;
+		const trimmed = pathValue.trim();
+		if (!trimmed) return;
+		if (scanSelection.size === 0) return;
+		const initialScanContext: ProjectAssistantScanContext = {
+			rootPath: trimmed,
+			items: scanItems,
+			selectedIds: scanItems.filter((it) => scanSelection.has(it.id)).map((it) => it.id),
+		};
+		busy = true;
+		renderDialog();
+		cleanup();
+		await createProjectAssistantSession(trimmed, false, { initialScanContext });
+	};
+
+	const goBackToPath = () => {
+		if (busy) return;
+		step = "path";
+		scanItems = [];
+		scanSelection = new Set();
+		renderDialog();
+		pickerEl.focusInput();
+	};
+
+	const toggleScanItem = (id: string, checked: boolean) => {
+		if (checked) scanSelection.add(id);
+		else scanSelection.delete(id);
+		renderDialog();
+	};
+
+	const selectAll = () => {
+		scanSelection = new Set(scanItems.map((it) => it.id));
+		renderDialog();
+	};
+	const deselectAll = () => {
+		scanSelection = new Set();
+		renderDialog();
+	};
+
+	// --- detection-status one-liner (reserved height) -----------------------
+	const renderStatusLine = () => {
+		const trimmed = pathValue.trim();
+		if (errorMessage) {
+			return html`<span class="text-red-500 text-xs">${errorMessage}</span>`;
+		}
+		if (!trimmed) {
+			return html`<span class="text-muted-foreground text-xs">Type a path or click Browse to pick a directory.</span>`;
+		}
+		if (!detectionResult) {
+			return html`<span class="text-muted-foreground text-xs">Checking directory…</span>`;
+		}
+		if (detectionResult.hasBobbit) {
+			return html`<span class="text-green-600 dark:text-green-400 text-xs">An existing Bobbit project was found. Click <strong>Continue</strong> to register it.</span>`;
+		}
+		if (detectionResult.exists && !detectionResult.isEmpty) {
+			return html`<span class="text-muted-foreground text-xs">This directory will be set up as a new Bobbit project.</span>`;
+		}
+		return html`<span class="text-muted-foreground text-xs">A new project will be scaffolded in this directory.</span>`;
+	};
+
+	// --- path step body -----------------------------------------------------
+	const renderPathBody = () => html`
+		<div class="flex flex-col gap-3 h-full min-h-0">
+			<label class="text-xs text-muted-foreground block shrink-0">Project Directory</label>
+			<div class="shrink-0">${pickerEl}</div>
+			<div class="shrink-0 min-h-[20px]" data-testid="add-project-status-slot">${renderStatusLine()}</div>
+			<div class="flex-1 min-h-0 overflow-y-auto" data-testid="add-project-preflight-slot">
+				${pathValue.trim() && !preflightUnavailable
+					? renderPreflightPanel({
+						report: preflightReport,
+						loading: preflightLoading,
+						error: preflightError,
+						archiving,
+						onArchive: openArchiveConfirm,
+					})
+					: ""}
+			</div>
+		</div>
+	`;
+
+	// --- scan step body -----------------------------------------------------
+	const renderScanBody = () => {
+		const total = scanItems.length;
+		const selected = scanSelection.size;
+		return html`
+			<div class="flex flex-col gap-3 h-full min-h-0" data-testid="add-project-scan-checklist">
+				<p class="text-xs text-muted-foreground shrink-0">
+					Detected ${total} repo/subdirectory candidate${total === 1 ? "" : "s"} in
+					<code class="font-mono">${pathValue.trim()}</code>.
+				</p>
+				<div class="flex items-center gap-3 shrink-0 text-xs">
+					<span data-testid="add-project-selected-count" class="text-foreground font-medium">
+						Selected ${selected} of ${total}
+					</span>
+					<button
+						type="button"
+						class="px-2 py-1 rounded border border-border text-foreground hover:bg-secondary/50 transition-colors disabled:opacity-40 disabled:pointer-events-none"
+						?disabled=${selected === total}
+						@click=${selectAll}
+						data-testid="add-project-select-all"
+					>Select all</button>
+					<button
+						type="button"
+						class="px-2 py-1 rounded border border-border text-foreground hover:bg-secondary/50 transition-colors disabled:opacity-40 disabled:pointer-events-none"
+						?disabled=${selected === 0}
+						@click=${deselectAll}
+						data-testid="add-project-deselect-all"
+					>Deselect all</button>
+				</div>
+				<div class="flex-1 min-h-0 overflow-y-auto border border-border rounded">
+					${scanItems.map((item) => {
+						const checked = scanSelection.has(item.id);
+						const cmdCount = Object.keys(item.detectedCommands || {}).length;
+						return html`
+							<label
+								class="flex items-start gap-2 px-3 py-2 text-sm border-b border-border last:border-0 cursor-pointer hover:bg-secondary/40"
+								data-testid="add-project-scan-row-${item.id}"
+								data-scan-id=${item.id}
+							>
+								<input
+									type="checkbox"
+									class="mt-1 shrink-0"
+									.checked=${checked}
+									data-testid="add-project-scan-checkbox-${item.id}"
+									@change=${(e: Event) => toggleScanItem(item.id, (e.target as HTMLInputElement).checked)}
+								/>
+								<div class="flex flex-col min-w-0 flex-1">
+									<div class="flex items-center gap-2 flex-wrap">
+										<code class="font-mono text-foreground">${item.label}</code>
+										<span class="text-[10px] uppercase tracking-wider text-muted-foreground">${item.kind === "workspace" ? "workspace" : item.hasGit ? "git" : "manifest"}</span>
+										${cmdCount > 0
+											? html`<span class="text-[10px] text-muted-foreground">${cmdCount} cmd${cmdCount === 1 ? "" : "s"}</span>`
+											: html`<span class="text-[10px] text-amber-600 dark:text-amber-400 italic">data-only</span>`}
+									</div>
+									${cmdCount > 0
+										? html`<div class="text-[10px] text-muted-foreground font-mono truncate" title=${Object.keys(item.detectedCommands).join(", ")}>${Object.keys(item.detectedCommands).join(", ")}</div>`
+										: ""}
+								</div>
+							</label>
+						`;
+					})}
+				</div>
+				<p class="text-[11px] text-muted-foreground shrink-0">
+					Unchecked repos/subdirectories will not be considered for the initial component proposal.
+					The assistant can still add or remove components later.
+				</p>
+			</div>
+		`;
+	};
+
+	// --- footer (sticky, position-invariant across all states) --------------
+	const renderFooter = () => {
+		if (step === "scan") {
+			return html`
+				<div class="flex gap-2 justify-end">
+					${Button({ variant: "ghost", onClick: goBackToPath, children: "Back", disabled: busy })}
+					${Button({
+						variant: "default",
+						onClick: confirmScanAndContinue,
+						disabled: busy || scanSelection.size === 0,
+						children: html`<span data-testid="add-project-continue">Continue with assistant</span>`,
+					})}
+				</div>
+			`;
+		}
+		const trimmed = pathValue.trim();
+		const continueDisabled =
+			busy || archiving || !trimmed || (preflightReport?.hasFail === true);
+		const continueLabel = busy ? "Detecting…" : archiving ? "Archiving…" : "Continue";
+		return html`
+			<div class="flex gap-2 justify-end">
+				${Button({ variant: "ghost", onClick: cleanup, children: "Cancel" })}
+				${Button({
+					variant: "default",
+					onClick: doContinue,
+					disabled: continueDisabled,
+					children: html`<span data-testid="add-project-continue">${continueLabel}</span>`,
+				})}
+			</div>
+		`;
+	};
+
+	const renderDialog = () => {
+		// Keep picker props in sync with current state. Properties are set
+		// imperatively because the picker element is created once and embedded
+		// as a stable DOM node, not via Lit's property bindings.
+		pickerEl.value = pathValue;
+		pickerEl.recentPaths = recentPaths();
+		// Lazily wire the browseDirectory callback (avoids importing the API
+		// module before the dialog is opened).
+		const pickerAny = pickerEl as unknown as { __browseWired?: boolean };
+		if (!pickerAny.__browseWired) {
+			void import("./api.js").then((m) => {
+				pickerEl.browseDirectory = m.browseDirectory;
+				pickerAny.__browseWired = true;
+			});
+		}
+		pickerEl.disabled = busy;
+
+		render(
+			Dialog({
+				isOpen: true,
+				onClose: cleanup,
+				width: "min(720px, 94vw)",
+				height: "min(720px, 92vh)",
+				backdropClassName: "bg-black/50 backdrop-blur-sm",
+				children: html`
+					<div class="flex flex-col h-full" data-testid="add-project-dialog-v2">
+						<div class="shrink-0 px-6 pt-6 pb-2">
+							${DialogHeader({
+								title: step === "scan"
+									? "Confirm repos/subdirectories"
+									: detectionResult?.hasBobbit
+										? "Register Project"
+										: "Add Project",
+							})}
+							<span class="hidden" data-testid="add-project-step">${step}</span>
+						</div>
+						<div class="flex-1 min-h-0 px-6 pb-2 overflow-hidden">
+							${step === "scan" ? renderScanBody() : renderPathBody()}
+						</div>
+						<div
+							class="shrink-0 px-6 py-4 border-t border-border"
+							data-testid="add-project-footer-v2"
+						>
+							${renderFooter()}
+						</div>
+					</div>
+				`,
+			}),
+			container,
+		);
+
+		// Focus the picker input when sitting on the path step (initial open and
+		// when returning from the scan step).
+		if (step === "path") {
+			requestAnimationFrame(() => {
+				if (document.activeElement?.tagName !== "INPUT") pickerEl.focusInput();
+			});
+		}
+	};
+
+	renderDialog();
+	// First-paint kick: if the user opened the dialog with a non-empty pathValue
+	// (e.g. via future deep-link), run detection eagerly. Otherwise the picker
+	// drives everything via events.
+	if (pathValue.trim()) {
+		onEffectivePathChange(pathValue, true);
 	}
 }

--- a/src/app/dialogs.ts
+++ b/src/app/dialogs.ts
@@ -15,7 +15,6 @@ import {
 	GOAL_STATE_LABELS,
 	type Goal,
 	type GoalState,
-	type Project,
 } from "./state.js";
 import { gatewayFetch, updateGoal, SymlinkRootError, type DetectedRepo, type MonorepoScanResult } from "./api.js";
 import "../ui/components/DirectoryPicker.js";
@@ -1486,473 +1485,6 @@ function showGoalEditDialog(existingGoal: Goal): void {
 // PROJECT REGISTRATION DIALOG
 // ============================================================================
 
-export function showProjectDialog(): void {
-	const container = document.createElement("div");
-	document.body.appendChild(container);
-
-	let pathValue = "";
-	let loading = false;
-	let error = "";
-	let browsing = false;
-	let browseEntries: Array<{ name: string; path: string }> = [];
-	let browseCurrent = "";
-	let browseParent: string | null = null;
-	let browseLoading = false;
-	let browseError = "";
-
-	// Live detection state — updated as the user types/selects a path
-	let detectionResult: { exists: boolean; hasBobbit: boolean; isEmpty: boolean; name: string } | null = null;
-	let detectTimer: ReturnType<typeof setTimeout> | null = null;
-
-	// Preflight validation state — runs alongside detection. See
-	// docs/design/robust-add-project.md. Surfaces pass/warn/fail checks before
-	// the user can submit; a fail blocks submission. Renders between path input
-	// and footer; gracefully degrades when the server endpoint is missing
-	// (older gateway) by hiding the panel entirely.
-	let preflightReport: PreflightReport | null = null;
-	let preflightLoading = false;
-	let preflightError = "";
-	let preflightToken = 0;
-	let archiving = false;
-	let preflightUnavailable = false;
-
-	const runPreflight = async (dirPath: string) => {
-		const trimmed = dirPath.trim();
-		if (!trimmed) {
-			preflightReport = null;
-			preflightLoading = false;
-			preflightError = "";
-			renderDialog();
-			return;
-		}
-		if (preflightUnavailable) return;
-		const token = ++preflightToken;
-		preflightLoading = true;
-		preflightError = "";
-		renderDialog();
-		try {
-			const res = await gatewayFetch(`/api/projects/preflight?path=${encodeURIComponent(trimmed)}`);
-			if (token !== preflightToken) return; // stale
-			if (res.status === 404) {
-				// Older gateway without preflight — silently skip.
-				// Guarded by the `if (preflightUnavailable) return` above, so this warns at most once.
-				console.warn("[preflight] endpoint unavailable — hiding panel");
-				preflightUnavailable = true;
-				preflightReport = null;
-				preflightLoading = false;
-				renderDialog();
-				return;
-			}
-			if (!res.ok) {
-				preflightError = `Preflight failed (${res.status})`;
-				preflightReport = null;
-			} else {
-				preflightReport = await res.json() as PreflightReport;
-			}
-		} catch (err) {
-			if (token !== preflightToken) return;
-			preflightError = err instanceof Error ? err.message : String(err);
-			preflightReport = null;
-		} finally {
-			if (token === preflightToken) {
-				preflightLoading = false;
-				renderDialog();
-			}
-		}
-	};
-
-	// Multi-repo scan checklist state — surfaced as an intermediate step when
-	// the chosen path resolves to more than one detected repo. Single-repo
-	// projects skip this step entirely. The selection is informational
-	// (transparency before routing to the assistant); the project assistant
-	// re-runs `scanRepos` server-side and uses it as ground truth, but this
-	// step gives the user a chance to confirm + understand what's coming
-	// without typing anything in chat.
-	interface DetectedRepo { folder: string; hasGit: boolean; detectedCommands: Record<string, string> }
-	let scanResults: DetectedRepo[] | null = null;
-	let scanSelection: Set<string> = new Set();
-	let showingScan = false;
-	let scanScaffolding = false;
-
-	const runDetection = async (dirPath: string) => {
-		if (!dirPath.trim()) { detectionResult = null; renderDialog(); return; }
-		try {
-			const { detectProject } = await import("./api.js");
-			detectionResult = await detectProject(dirPath.trim());
-		} catch {
-			detectionResult = null;
-		}
-		renderDialog();
-	};
-
-	const debouncedDetect = (dirPath: string) => {
-		if (detectTimer) clearTimeout(detectTimer);
-		detectTimer = setTimeout(() => {
-			runDetection(dirPath);
-			runPreflight(dirPath);
-		}, 400);
-	};
-
-	const openArchiveConfirm = async () => {
-		if (!preflightReport) return;
-		const rootPath = preflightReport.rootPath;
-		const gatewayOwned = preflightReport.checks.some(c => c.id === "bobbit.gateway-owned" && c.level !== "pass");
-		const existingDetail = preflightReport.checks.find(c => c.id === "bobbit.existing")?.detail || "";
-		const confirmed = await promptArchiveConfirm({ rootPath, gatewayOwned, existingDetail });
-		if (!confirmed) return;
-		archiving = true;
-		renderDialog();
-		try {
-			const res = await gatewayFetch("/api/projects/archive-bobbit", {
-				method: "POST",
-				body: JSON.stringify({ rootPath }),
-			});
-			if (!res.ok) {
-				const data = await res.json().catch(() => ({} as any));
-				showConnectionError(
-					"Failed to archive .bobbit/",
-					data?.error || `Failed: ${res.status}`,
-					{ code: data?.code, stack: data?.stack },
-				);
-			}
-		} catch (err) {
-			const { message, code, stack } = errorDetails(err);
-			showConnectionError("Failed to archive .bobbit/", message, { code, stack });
-		} finally {
-			archiving = false;
-			// Re-run preflight + detection to reflect the new on-disk state.
-			runDetection(pathValue);
-			runPreflight(pathValue);
-		}
-	};
-
-	const cleanup = () => {
-		render(html``, container);
-		container.remove();
-	};
-
-	const doContinue = async () => {
-		const trimmedPath = pathValue.trim();
-		if (!trimmedPath) return;
-		loading = true;
-		error = "";
-		renderDialog();
-
-		try {
-			const { detectProject, registerProject, fetchProjects, scanProjectRepos } = await import("./api.js");
-			const detection = await detectProject(trimmedPath);
-
-			if (detection.hasBobbit) {
-				// Path A: Auto-import
-				let project: Project | null = null;
-				try {
-					project = await registerProject(detection.name, trimmedPath, undefined);
-				} catch (e) {
-					if (e instanceof SymlinkRootError) {
-						await promptSymlinkConfirm(detection.name, trimmedPath, e.canonical, async (canonical) => {
-							try {
-								const p2 = await registerProject(detection.name, canonical, undefined, false, true);
-								if (p2) {
-									setProjects(await fetchProjects());
-									renderApp();
-									cleanup();
-								} else {
-									loading = false;
-									renderDialog();
-								}
-							} catch (err2) {
-								const { message, code, stack } = errorDetails(err2);
-								showConnectionError("Failed to register project", message, { code, stack });
-								loading = false;
-								renderDialog();
-							}
-						}, () => {
-							loading = false;
-							error = "";
-							renderDialog();
-						});
-						return;
-					}
-					throw e;
-				}
-				if (project) {
-					setProjects(await fetchProjects());
-					renderApp();
-					cleanup();
-				} else {
-					loading = false;
-					renderDialog();
-				}
-				return;
-			}
-
-			const scaffolding = !(detection.exists && !detection.isEmpty);
-			// Run a multi-repo scan for non-scaffolding paths so we can surface
-			// detected sibling repos as a checklist before routing to the
-			// assistant. Scaffolding (empty dir / new path) skips the scan.
-			if (!scaffolding) {
-				try {
-					const repos = await scanProjectRepos(trimmedPath);
-					const hasMulti = repos.length > 1 || repos.some(r => r.folder !== ".");
-					if (hasMulti) {
-						scanResults = repos;
-						scanSelection = new Set(repos.map(r => r.folder));
-						showingScan = true;
-						scanScaffolding = false;
-						loading = false;
-						renderDialog();
-						return;
-					}
-				} catch {
-					// Scan failure is non-fatal — fall through to the standard flow.
-				}
-			}
-
-			// Single-repo (or scan failed / scaffolding): existing flow.
-			cleanup();
-			await createProjectAssistantSession(trimmedPath, scaffolding);
-		} catch (err) {
-			error = err instanceof Error ? err.message : String(err);
-			loading = false;
-			renderDialog();
-		}
-	};
-
-	const confirmScanAndContinue = async () => {
-		const trimmedPath = pathValue.trim();
-		if (!trimmedPath) return;
-		cleanup();
-		await createProjectAssistantSession(trimmedPath, scanScaffolding);
-	};
-
-	const openBrowser = async () => {
-		browsing = true;
-		browseLoading = true;
-		browseError = "";
-		renderDialog();
-		try {
-			const { browseDirectory } = await import("./api.js");
-			const result = await browseDirectory(pathValue.trim() || undefined);
-			browseEntries = result.entries;
-			browseCurrent = result.current;
-			browseParent = result.parent;
-		} catch (err) {
-			browseError = err instanceof Error ? err.message : String(err);
-		}
-		browseLoading = false;
-		renderDialog();
-	};
-
-	const navigateBrowse = async (dirPath: string) => {
-		browseLoading = true;
-		browseError = "";
-		renderDialog();
-		try {
-			const { browseDirectory } = await import("./api.js");
-			const result = await browseDirectory(dirPath);
-			browseEntries = result.entries;
-			browseCurrent = result.current;
-			browseParent = result.parent;
-		} catch (err) {
-			browseError = err instanceof Error ? err.message : String(err);
-		}
-		browseLoading = false;
-		renderDialog();
-	};
-
-	const selectBrowsed = () => {
-		pathValue = browseCurrent;
-		browsing = false;
-		renderDialog();
-		runDetection(pathValue);
-		runPreflight(pathValue);
-	};
-
-	const renderDialog = () => {
-		const browseContent = browsing ? html`
-			<div class="flex flex-col gap-2" data-testid="directory-browser">
-				<div class="flex items-center gap-2">
-					${browseParent != null ? html`
-						<button
-							class="px-2 py-1 text-xs text-foreground rounded border border-border hover:bg-secondary/50 transition-colors"
-							@click=${() => navigateBrowse(browseParent!)}
-							data-testid="browse-up"
-						>Up</button>
-					` : ""}
-					<span class="text-xs text-muted-foreground truncate flex-1" title="${browseCurrent}">${browseCurrent}</span>
-				</div>
-				${browseLoading ? html`<p class="text-xs text-muted-foreground">Loading…</p>` : ""}
-				${browseError ? html`<p class="text-xs text-red-500">${browseError}</p>` : ""}
-				${!browseLoading && !browseError ? html`
-					<div class="max-h-[200px] overflow-y-auto border border-border rounded">
-						${browseEntries.length === 0
-							? html`<div class="px-3 py-2 text-xs text-muted-foreground">No subdirectories</div>`
-							: browseEntries.map(entry => html`
-								<button
-									class="w-full text-left px-3 py-1.5 text-sm text-foreground hover:bg-secondary/50 transition-colors flex items-center gap-2 border-b border-border last:border-0"
-									@click=${() => navigateBrowse(entry.path)}
-									data-testid="browse-entry"
-								>
-									<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="shrink-0 text-muted-foreground"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
-									<span class="truncate">${entry.name}</span>
-								</button>
-							`)}
-					</div>
-				` : ""}
-				<div class="flex gap-2 justify-end">
-					${Button({ variant: "ghost", size: "sm" as any, onClick: () => { browsing = false; renderDialog(); }, children: "Cancel" })}
-					${Button({ variant: "default", size: "sm" as any, onClick: selectBrowsed, children: "Select", disabled: !browseCurrent })}
-				</div>
-			</div>
-		` : "";
-
-		const scanContent = showingScan && scanResults ? html`
-			<div class="flex flex-col gap-3" data-testid="project-scan-checklist">
-				<p class="text-xs text-muted-foreground">
-					Detected ${scanResults.length} repo${scanResults.length === 1 ? "" : "s"} in <code class="font-mono">${pathValue.trim()}</code>.
-					The project assistant will use this as a starting point — you can refine
-					the selection in the chat.
-				</p>
-				<div class="max-h-[260px] overflow-y-auto border border-border rounded" data-testid="scan-repo-list">
-					${scanResults.length === 0
-						? html`<div class="px-3 py-2 text-xs text-muted-foreground">No repos detected.</div>`
-						: scanResults.map(r => {
-							const checked = scanSelection.has(r.folder);
-							const cmdCount = Object.keys(r.detectedCommands || {}).length;
-							return html`
-								<label class="flex items-start gap-2 px-3 py-2 text-sm border-b border-border last:border-0 cursor-pointer hover:bg-secondary/40" data-testid="scan-repo-row" data-repo-folder=${r.folder}>
-									<input type="checkbox" class="mt-1 shrink-0" .checked=${checked}
-										data-testid="scan-repo-toggle"
-										@change=${(e: Event) => {
-											if ((e.target as HTMLInputElement).checked) scanSelection.add(r.folder);
-											else scanSelection.delete(r.folder);
-											renderDialog();
-										}}/>
-									<div class="flex flex-col min-w-0 flex-1">
-										<div class="flex items-center gap-2">
-											<code class="font-mono text-foreground">${r.folder === "." ? "(root)" : r.folder}</code>
-											<span class="text-[10px] text-muted-foreground uppercase tracking-wider">${r.hasGit ? "git" : "manifest"}</span>
-											<span class="text-[10px] text-muted-foreground">${cmdCount} cmd${cmdCount === 1 ? "" : "s"}</span>
-											${cmdCount === 0
-												? html`<span class="text-[10px] text-amber-600 dark:text-amber-400 italic" data-testid="scan-repo-data-only">data-only</span>`
-												: ""}
-										</div>
-										${cmdCount > 0 ? html`<div class="text-[10px] text-muted-foreground font-mono truncate" title=${Object.keys(r.detectedCommands).join(", ")}>${Object.keys(r.detectedCommands).join(", ")}</div>` : ""}
-									</div>
-								</label>
-							`;
-						})}
-				</div>
-				<p class="text-[11px] text-muted-foreground">
-					Unchecked repos won't be added as components. The project assistant
-					will scaffold workflows for the checked ones, or you can preview
-					and edit later in <strong>Settings → Components</strong>.
-				</p>
-			</div>
-		` : "";
-
-		render(
-			Dialog({
-				isOpen: true,
-				onClose: cleanup,
-				width: "min(480px, 92vw)",
-				height: "auto",
-				backdropClassName: "bg-black/50 backdrop-blur-sm",
-				children: html`
-					${DialogContent({
-						children: html`
-							${DialogHeader({ title: showingScan ? "Detected repos" : (detectionResult?.hasBobbit ? "Register Project" : "Add Project") })}
-							<div class="mt-4 flex flex-col gap-4">
-								${showingScan ? scanContent : !browsing ? html`
-									<div>
-										<label class="text-xs text-muted-foreground mb-1 block">Project Directory</label>
-										<div class="flex items-center gap-2">
-											<div class="flex-1">
-												${Input({
-													type: "text",
-													placeholder: "/path/to/project",
-													value: pathValue,
-													onInput: (e: Event) => {
-														pathValue = (e.target as HTMLInputElement).value;
-														debouncedDetect(pathValue);
-														renderDialog();
-													},
-													onKeyDown: (e: KeyboardEvent) => {
-														if (e.key === "Enter") { e.preventDefault(); doContinue(); }
-														if (e.key === "Escape") cleanup();
-													},
-												})}
-											</div>
-											${Button({
-												variant: "ghost",
-												onClick: openBrowser,
-												children: "Browse",
-											})}
-										</div>
-										${detectionResult && pathValue.trim() ? html`
-											<p class="text-xs mt-1.5 ${detectionResult.hasBobbit ? "text-green-600 dark:text-green-400" : "text-muted-foreground"}">
-												${detectionResult.hasBobbit
-													? html`An existing Bobbit project was found in this directory. Click <strong>Continue</strong> to register it.`
-													: detectionResult.exists && !detectionResult.isEmpty
-														? "This directory will be set up as a new Bobbit project."
-														: "A new project will be scaffolded in this directory."}
-											</p>
-										` : ""}
-										${pathValue.trim() && !preflightUnavailable ? renderPreflightPanel({
-											report: preflightReport,
-											loading: preflightLoading,
-											error: preflightError,
-											archiving,
-											onArchive: openArchiveConfirm,
-										}) : ""}
-									</div>
-								` : browseContent}
-								${error ? html`<p class="text-xs text-red-500">${error}</p>` : ""}
-							</div>
-						`,
-					})}
-					${showingScan ? DialogFooter({
-						className: "px-6 pb-4",
-						children: html`
-							<div class="flex gap-2 justify-end">
-								${Button({ variant: "ghost", onClick: () => { showingScan = false; scanResults = null; renderDialog(); }, children: "Back" })}
-								${Button({
-									variant: "default",
-									onClick: confirmScanAndContinue,
-									disabled: scanSelection.size === 0,
-									children: "Continue with assistant",
-								})}
-							</div>
-						`,
-					}) : !browsing ? DialogFooter({
-						className: "px-6 pb-4",
-						children: html`
-							<div class="flex gap-2 justify-end">
-								${Button({ variant: "ghost", onClick: cleanup, children: "Cancel" })}
-								${Button({
-									variant: "default",
-									onClick: doContinue,
-									disabled: !pathValue.trim() || loading || archiving || (preflightReport?.hasFail === true),
-									children: loading ? "Detecting…" : (archiving ? "Archiving…" : "Continue"),
-								})}
-							</div>
-						`,
-					}) : ""}
-				`,
-			}),
-			container,
-		);
-
-		requestAnimationFrame(() => {
-			const input = container.querySelector("input");
-			if (input && !browsing) input.focus();
-		});
-	};
-
-	if (pathValue.trim()) { runDetection(pathValue); runPreflight(pathValue); }
-	renderDialog();
-}
-
 export async function createProjectAssistantSession(
 	dirPath: string,
 	scaffolding: boolean,
@@ -1960,7 +1492,7 @@ export async function createProjectAssistantSession(
 		projectId?: string;
 		existingProjectName?: string;
 		/**
-		 * User-confirmed initial repo/subdirectory selection from the V2 Add
+		 * User-confirmed initial repo/subdirectory selection from the Add
 		 * Project scan checklist. Forwarded to the project-assistant's first
 		 * turn via `connectToSession`'s `projectInitialScanContext` option so
 		 * the assistant treats the selected ids as authoritative starting
@@ -2007,7 +1539,7 @@ export async function createProjectAssistantSession(
 			: undefined;
 		// Forward the optional user-confirmed initial scan subset to the
 		// project-assistant's first turn. Only applies to new-project
-		// registration (not scaffolding, not edit-mode) — the V2 Add Project
+		// registration (not scaffolding, not edit-mode) — the Add Project
 		// scan checklist is the only caller that supplies it.
 		const projectInitialScanContext =
 			!scaffolding && !opts?.projectId ? opts?.initialScanContext : undefined;
@@ -2027,34 +1559,30 @@ export async function createProjectAssistantSession(
 }
 
 // ============================================================================
-// V2 PROJECT REGISTRATION DIALOG
+// PROJECT REGISTRATION DIALOG
 // ----------------------------------------------------------------------------
-// Modern Add Project dialog gated behind `localStorage.addProjectV2 === "1"`
-// (also settable via `?addProjectV2=1`). The legacy `showProjectDialog` above
-// remains the default until the user signs off on the prototype.
-//
-// Design source of truth: gate `design-doc` on the goal. Key differences from
-// the legacy dialog:
-//   - Reusable `<directory-picker>` element (typeahead + browse trigger) in
-//     place of the inline Input + Browse layout. Suggestions are
-//     absolutely-positioned by the picker so the footer never shifts.
-//   - Dedicated browse modal (`openProjectBrowseDialog`) on top of the dialog
-//     instead of swapping the input out for an in-dialog list view.
+// Add Project dialog. Design source of truth: `design-doc` gate on the goal.
+// Key invariants:
+//   - Reusable `<directory-picker>` element (typeahead + browse trigger) for
+//     the path input. Suggestions are absolutely-positioned by the picker so
+//     the surrounding layout (in particular the footer) never shifts.
+//   - Dedicated browse modal (`openProjectBrowseDialog`) opens on top of the
+//     Add Project dialog when the user clicks Browse — the parent dialog
+//     stays mounted with its footer in place.
 //   - Fixed dialog shell (`min(720px, 94vw)` x `min(720px, 92vh)`) with
 //     sticky header, scrollable body, and persistent footer. The footer
 //     container is identical across all states (path/scan + loading + error)
-//     so its bounding box is invariant.
+//     so its bounding box is invariant. Pinned by
+//     `tests/e2e/ui/add-project-footer-stability.spec.ts`.
 //   - Scan checklist surfaces every detected repo *and* monorepo workspace
 //     candidate as a normalized `ProjectScanItem` and forwards the
 //     user-confirmed subset into the project-assistant's first turn via
-//     `createProjectAssistantSession({ initialScanContext })`. This is the
-//     bug fix: legacy `confirmScanAndContinue` built `scanSelection` and
-//     dropped it on the floor.
+//     `createProjectAssistantSession({ initialScanContext })`.
 // ============================================================================
 
 /**
  * Normalize the `scanProject` payload into a flat `ProjectScanItem[]` for the
- * V2 scan checklist. Mirrors the spec in `project-assistant-autoprompt.ts`:
+ * scan checklist. Mirrors the spec in `project-assistant-autoprompt.ts`:
  *
  *   - One item per `repos[]` entry (`id = "repo:<folder>"`).
  *   - One item per `monorepo.candidates[]` entry (`id = "workspace:<rel>"`).
@@ -2124,7 +1652,7 @@ function buildScanItems(
 }
 
 /**
- * Standalone browse modal. Opens on top of the V2 Add Project dialog when the
+ * Standalone browse modal. Opens on top of the Add Project dialog when the
  * user clicks the picker's Browse button. Resolves with the selected absolute
  * path or `null` on cancel. Mirrors the legacy in-dialog browser semantics
  * (directory-only entries; skips hidden / `node_modules` / symlinks — that
@@ -2293,12 +1821,10 @@ function openProjectBrowseDialog(initialPath: string): Promise<string | null> {
 }
 
 /**
- * V2 Add Project dialog — see header comment for design rationale. Reachable
- * from any existing `showProjectDialog()` call site when
- * `localStorage.addProjectV2 === "1"` (or `?addProjectV2=1`). The toggle
- * lives in `src/app/dialogs-lazy.ts::showProjectDialog`.
+ * Add Project dialog — see header comment above for design rationale.
+ * Single entry point invoked from `src/app/dialogs-lazy.ts::showProjectDialog`.
  */
-export function showProjectDialogV2(): void {
+export function showProjectDialog(): void {
 	const container = document.createElement("div");
 	document.body.appendChild(container);
 
@@ -2327,7 +1853,7 @@ export function showProjectDialogV2(): void {
 	// (focus, suggestion list, etc.) is preserved.
 	const pickerEl = document.createElement("directory-picker") as DirectoryPickerEl;
 	pickerEl.placeholder = "/path/to/project";
-	pickerEl.setAttribute("data-testid", "add-project-picker-v2");
+	pickerEl.setAttribute("data-testid", "add-project-picker");
 
 	const recentPaths = (): Array<{ path: string; source: string }> => {
 		const seen = new Set<string>();
@@ -2830,7 +2356,7 @@ export function showProjectDialogV2(): void {
 				height: "min(720px, 92vh)",
 				backdropClassName: "bg-black/50 backdrop-blur-sm",
 				children: html`
-					<div class="flex flex-col h-full" data-testid="add-project-dialog-v2">
+					<div class="flex flex-col h-full" data-testid="add-project-dialog">
 						<div class="shrink-0 px-6 pt-6 pb-2">
 							${DialogHeader({
 								title: step === "scan"
@@ -2846,7 +2372,7 @@ export function showProjectDialogV2(): void {
 						</div>
 						<div
 							class="shrink-0 px-6 py-4 border-t border-border"
-							data-testid="add-project-footer-v2"
+							data-testid="add-project-footer"
 						>
 							${renderFooter()}
 						</div>

--- a/src/app/project-assistant-autoprompt.ts
+++ b/src/app/project-assistant-autoprompt.ts
@@ -1,0 +1,141 @@
+/**
+ * Auto-prompt builder for the project-assistant first turn.
+ *
+ * This is the single source of truth for the text the Add-Project flow sends
+ * to the project-assistant on session creation. Previously this string was
+ * inlined in `src/app/session-manager.ts::connectToSession` (lines 1171–1182
+ * pre-refactor); pulling it out makes the format unit-testable and lets the
+ * Add-Project dialog forward a user-confirmed repo/subdirectory selection
+ * into the assistant's first turn.
+ *
+ * The "subset selection" block format below is **pinned by**
+ * `tests/project-assistant-autoprompt.test.ts`. Do not change the wording
+ * without updating the test AND
+ * `src/server/agent/project-assistant.ts`, which teaches the assistant to
+ * recognise this exact block and treat `selectedIds` as authoritative
+ * initial candidates for `propose_project.components`.
+ */
+
+/**
+ * One normalized scan item — the shared shape used by both the V2 Add Project
+ * scan checklist UI and the project-assistant handoff payload.
+ *
+ * Single source of truth: the V2 dialog builds these from the
+ * `/api/projects/scan` response (`{ repos, monorepo }`); the same array
+ * flows verbatim into `formatProjectAssistantAutoPrompt`'s machine-readable
+ * JSON block so the assistant sees exactly what the user saw.
+ */
+export interface ProjectScanItem {
+	/** Stable id used by the checklist + selectedIds. `repo:<folder>` or `workspace:<relativePath>`. */
+	id: string;
+	kind: "repo" | "workspace";
+	/** Display label, e.g. "api", "packages/web", "(root)". */
+	label: string;
+	/** Component repo value: "." for single/monorepo, folder name for multi-repo. */
+	repo: string;
+	/** Optional sub-path within the repo (monorepo workspaces). */
+	relativePath?: string;
+	/** Absolute path on disk. */
+	absolutePath: string;
+	hasGit: boolean;
+	detectedCommands: Record<string, string>;
+}
+
+export interface ProjectAssistantScanContext {
+	rootPath: string;
+	items: ProjectScanItem[];
+	/** Subset of `items[].id` the user confirmed, serialized in display order. */
+	selectedIds: string[];
+}
+
+export interface FormatProjectAssistantAutoPromptOptions {
+	/** Project directory path. Required for both new and scaffolding modes. */
+	dirPath: string;
+	/** True when the target directory is empty / does not exist yet. */
+	scaffolding?: boolean;
+	/** Set when re-opening the assistant against an already-registered project. */
+	editContext?: { name: string; rootPath: string };
+	/**
+	 * Optional user-confirmed repo/subdirectory selection from the Add Project
+	 * scan checklist. Only meaningful in new-project (non-scaffolding,
+	 * non-edit) mode. When present, the prompt is extended with a derived
+	 * English summary AND a fenced JSON block carrying the raw payload.
+	 */
+	initialScanContext?: ProjectAssistantScanContext;
+}
+
+function labelOf(items: readonly ProjectScanItem[], id: string): string {
+	const item = items.find(it => it.id === id);
+	return item?.label ?? id;
+}
+
+function formatList(items: readonly ProjectScanItem[], ids: readonly string[]): string {
+	return ids.map(id => `\`${labelOf(items, id)}\``).join(", ");
+}
+
+function formatScanSubsetBlock(ctx: ProjectAssistantScanContext): string {
+	const total = ctx.items.length;
+	const selectedSet = new Set(ctx.selectedIds);
+	// Preserve display order from items, not selection order.
+	const orderedSelected = ctx.items.filter(it => selectedSet.has(it.id)).map(it => it.id);
+	const orderedUnselected = ctx.items.filter(it => !selectedSet.has(it.id)).map(it => it.id);
+	const selectedLabels = formatList(ctx.items, orderedSelected);
+	const unselectedLabels = formatList(ctx.items, orderedUnselected);
+
+	// The JSON payload mirrors the input context exactly, with selectedIds
+	// re-serialized in display order so the assistant doesn't have to
+	// reconstruct it.
+	const payload: ProjectAssistantScanContext = {
+		rootPath: ctx.rootPath,
+		items: ctx.items,
+		selectedIds: orderedSelected,
+	};
+	const json = JSON.stringify(payload, null, 2);
+
+	const lines: string[] = [];
+	lines.push("");
+	lines.push("User-confirmed initial repo/subdirectory selection from Add Project:");
+	lines.push(`- Selected ${orderedSelected.length} of ${total} repo/subdirectory candidates: ${selectedLabels}`);
+	if (orderedUnselected.length > 0) {
+		lines.push(`- Not selected: ${unselectedLabels}`);
+	} else {
+		lines.push("- Not selected: (none — all candidates selected)");
+	}
+	lines.push("- Treat only the selected repos/subdirectories as candidates for the initial `propose_project.components`.");
+	lines.push("- Do not include unselected entries by default, but tell the user they can add them back.");
+	lines.push("");
+	lines.push("Machine-readable selection:");
+	lines.push("```json");
+	lines.push(json);
+	lines.push("```");
+	return lines.join("\n");
+}
+
+/**
+ * Build the auto-prompt sent to the project-assistant on its first turn.
+ *
+ * Modes (mutually exclusive in this order of precedence):
+ *   1. `editContext`           → "Edit the existing project ..."
+ *   2. `scaffolding`           → "Start the new project setup session ..."
+ *   3. `initialScanContext`    → "Start the project registration session ..." + subset block
+ *   4. default (plain new)     → "Start the project registration session ..."
+ */
+export function formatProjectAssistantAutoPrompt(
+	opts: FormatProjectAssistantAutoPromptOptions,
+): string {
+	const { dirPath, scaffolding, editContext, initialScanContext } = opts;
+
+	if (editContext) {
+		return `Edit the existing project '${editContext.name}' at ${editContext.rootPath}. Read its current \`.bobbit/config/project.yaml\` and propose it back as-is via \`propose_project\`, then ask the user what they want to change or add.`;
+	}
+
+	if (scaffolding) {
+		return `Start the new project setup session. The target directory is: ${dirPath}`;
+	}
+
+	const base = `Start the project registration session. The project directory is: ${dirPath}`;
+	if (initialScanContext && initialScanContext.items.length > 0) {
+		return `${base}\n${formatScanSubsetBlock(initialScanContext)}`;
+	}
+	return base;
+}

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -14,6 +14,7 @@ import {
 	GW_SESSION_KEY,
 } from "./state.js";
 import { gatewayFetch, saveDraftToServer, loadDraftFromServer, deleteDraftFromServer, refreshSessions, startSessionPolling, updateLocalSessionTitle, updateLocalSessionStatus, fetchGitStatus, refreshPrStatusCache, teardownTeam } from "./api.js";
+import { formatProjectAssistantAutoPrompt } from "./project-assistant-autoprompt.js";
 import { errorDetails } from "./error-helpers.js";
 import { runGitStatusRefresh, abortableSleep } from "./git-status-refresh.js";
 import { startTimeRefresh } from "./render-helpers.js";
@@ -952,7 +953,7 @@ export function selectSession(sessionId: string, replaceHistory?: boolean): void
 // CONNECT TO SESSION (select + hydrate)
 // ============================================================================
 
-export async function connectToSession(sessionId: string, isExisting: boolean, options?: { isGoalAssistant?: boolean; isRoleAssistant?: boolean; isToolAssistant?: boolean; isStaffAssistant?: boolean; isPreview?: boolean; assistantType?: string; readOnly?: boolean; projectDirPath?: string; projectEditContext?: { name: string; rootPath: string }; onMissing?: "toast" | "modal" }): Promise<void> {
+export async function connectToSession(sessionId: string, isExisting: boolean, options?: { isGoalAssistant?: boolean; isRoleAssistant?: boolean; isToolAssistant?: boolean; isStaffAssistant?: boolean; isPreview?: boolean; assistantType?: string; readOnly?: boolean; projectDirPath?: string; projectEditContext?: { name: string; rootPath: string }; projectInitialScanContext?: import("./project-assistant-autoprompt.js").ProjectAssistantScanContext; onMissing?: "toast" | "modal" }): Promise<void> {
 	// Capture the current route BEFORE selectSession changes the hash.
 	const startingRoute = getRouteFromHash();
 	const replaceHistory = startingRoute.view === "goal-dashboard";
@@ -1170,12 +1171,20 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 		if (options?.assistantType && !isExisting) {
 			let autoPrompt: string | undefined;
 			if (options.assistantType === "project" && options.projectEditContext) {
-				const pec = options.projectEditContext;
-				autoPrompt = `Edit the existing project '${pec.name}' at ${pec.rootPath}. Read its current \`.bobbit/config/project.yaml\` and propose it back as-is via \`propose_project\`, then ask the user what they want to change or add.`;
+				autoPrompt = formatProjectAssistantAutoPrompt({
+					dirPath: options.projectDirPath ?? options.projectEditContext.rootPath,
+					editContext: options.projectEditContext,
+				});
 			} else if (options.assistantType === "project" && options.projectDirPath) {
-				autoPrompt = `Start the project registration session. The project directory is: ${options.projectDirPath}`;
+				autoPrompt = formatProjectAssistantAutoPrompt({
+					dirPath: options.projectDirPath,
+					initialScanContext: options.projectInitialScanContext,
+				});
 			} else if (options.assistantType === "project-scaffolding" && options.projectDirPath) {
-				autoPrompt = `Start the new project setup session. The target directory is: ${options.projectDirPath}`;
+				autoPrompt = formatProjectAssistantAutoPrompt({
+					dirPath: options.projectDirPath,
+					scaffolding: true,
+				});
 			} else {
 				autoPrompt = AUTO_PROMPTS[options.assistantType];
 			}

--- a/src/server/agent/project-assistant.ts
+++ b/src/server/agent/project-assistant.ts
@@ -180,6 +180,13 @@ The user's first message tells you which mode you're in. Read it carefully:
 
 - **"Start the project registration session. The project directory is: <path>"** — NEW project. Acknowledge briefly (1–2 sentences) and immediately start exploring. Example: "I'll explore \`<path>\` and help you register it. Let me take a look...". Do NOT ask for the directory path.
 
+  **User-confirmed initial repo/subdirectory selection.** When the new-project opener is followed by a "User-confirmed initial repo/subdirectory selection from Add Project:" block + a fenced \`json\` block containing \`{ "rootPath", "items", "selectedIds" }\`, the user has already reviewed a scan of \`<path>\` and ticked the repos/subdirectories they want this project to start with. Treat \`selectedIds\` as authoritative for the initial \`propose_project.components\` list:
+  - Include only the selected items as components in your **first** \`propose_project\` call. Use each item's \`repo\` and (if present) \`relativePath\` verbatim; map \`detectedCommands\` into the component's \`commands\` map; default \`name\` from \`label\` (slugified to match \`[a-z0-9][a-z0-9-]*\`).
+  - Do NOT silently include unselected entries. Briefly mention in chat which entries were excluded and remind the user they can ask you to add any of them back later.
+  - Still explore the selected paths to fill in workflows, missing commands, monorepo manifests, etc. The selection trims candidates; it does not skip discovery.
+  - If the selection is empty or the JSON block is malformed, fall back to the normal new-project flow (treat all detected repos/workspaces as candidates).
+
+
 - **"Edit the existing project '<name>' at <path>. Read its current \`.bobbit/config/project.yaml\` and propose it back as-is via \`propose_project\`, then ask the user what they want to change or add."** — EDIT mode for an already-registered project. Do this exact sequence:
   1. Read \`<path>/.bobbit/config/project.yaml\` with the \`read\` tool. (If the file doesn't exist, fall back to the new-project flow.)
   2. Call \`propose_project\` immediately with the **current** project shape — \`name\`, \`root_path\`, every component verbatim (including \`commands\`, \`config\`, \`worktree_setup_command\`, \`relative_path\`), every workflow verbatim. This re-renders the panel with the current state so the user can see what they're editing.

--- a/src/ui/components/DirectoryPicker.ts
+++ b/src/ui/components/DirectoryPicker.ts
@@ -1,0 +1,512 @@
+/**
+ * DirectoryPicker — reusable light-DOM Lit component for typing or picking
+ * an absolute directory path.
+ *
+ * Data-driven and event-based:
+ *   - The component owns the input value, the suggestion list, keyboard
+ *     navigation, and a debounced typeahead.
+ *   - It does NOT call `gatewayFetch`. The caller injects a `browseDirectory`
+ *     function so the picker can be unit-tested or reused for non-server
+ *     surfaces (e.g. story fixtures).
+ *   - It does NOT open a browse modal — it fires `directory-browse-request`
+ *     and lets the parent dialog decide how to surface a browse UI.
+ *
+ * Usage:
+ * ```ts
+ * import "../ui/components/DirectoryPicker.js";
+ * import { browseDirectory } from "../app/api.js";
+ *
+ * html`
+ *   <directory-picker
+ *     .value=${pathValue}
+ *     .browseDirectory=${browseDirectory}
+ *     .recentPaths=${recent}
+ *     placeholder="/path/to/project"
+ *     @directory-input=${(e) => onTyped(e.detail.path)}
+ *     @directory-select=${(e) => onPicked(e.detail.path)}
+ *     @directory-commit=${(e) => onContinue(e.detail.path)}
+ *     @directory-browse-request=${() => openBrowseModal()}
+ *     @directory-cancel=${() => closeDialog()}
+ *   ></directory-picker>
+ * `;
+ * ```
+ *
+ * Layout invariant: the suggestion popover is `position: absolute` so it
+ * overlays the surrounding layout rather than pushing it. The picker root
+ * itself reserves a fixed height (input + browse button row) and does not
+ * change size when suggestions open/close.
+ */
+
+import { html, LitElement, nothing } from "lit";
+import { customElement, property, query, state } from "lit/decorators.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface DirectoryEntry {
+	name: string;
+	path: string;
+}
+
+export interface DirectoryBrowseResult {
+	current: string;
+	parent: string | null;
+	entries: DirectoryEntry[];
+	truncated?: boolean;
+}
+
+export interface DirectorySuggestion extends DirectoryEntry {
+	source: "browse" | "recent";
+	/** Optional muted label shown after the basename (e.g. "Recent"). */
+	hint?: string;
+}
+
+export type DirectoryPickerChangeSource = "typed" | "suggestion" | "browse";
+
+export interface DirectoryPickerPathDetail {
+	path: string;
+	source: DirectoryPickerChangeSource;
+}
+
+export interface DirectoryBrowseRequestDetail {
+	path: string;
+}
+
+export type BrowseDirectoryFn = (path?: string) => Promise<DirectoryBrowseResult>;
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+const SEPARATOR_REGEX = /[\\/]/;
+
+/**
+ * Split a typed path into `{ parent, basename }` for suggestion lookup.
+ *
+ *   "/foo/bar/ba"   → { parent: "/foo/bar", basename: "ba" }
+ *   "/foo/bar/"     → { parent: "/foo/bar", basename: "" }
+ *   "/foo/bar"      → { parent: "/foo",     basename: "bar" }
+ *   "C:\\Users\\j"  → { parent: "C:\\Users", basename: "j" }
+ *   "/"             → { parent: "/",         basename: "" }
+ *   ""              → { parent: null,        basename: "" }
+ */
+function splitPath(raw: string): { parent: string | null; basename: string } {
+	const value = raw ?? "";
+	if (!value) return { parent: null, basename: "" };
+
+	// Trailing separator → user is inside the directory, no basename filter.
+	if (SEPARATOR_REGEX.test(value[value.length - 1] ?? "")) {
+		// Strip exactly one trailing sep so `/foo/` → parent `/foo` (or root `/`).
+		const trimmed = value.replace(/[\\/]+$/, "");
+		return { parent: trimmed === "" ? "/" : trimmed, basename: "" };
+	}
+
+	// Find last separator.
+	let lastSep = -1;
+	for (let i = value.length - 1; i >= 0; i--) {
+		if (SEPARATOR_REGEX.test(value[i] ?? "")) {
+			lastSep = i;
+			break;
+		}
+	}
+	if (lastSep < 0) {
+		// No separator at all — typed bare word, no useful parent.
+		return { parent: null, basename: value };
+	}
+	const parent = lastSep === 0 ? "/" : value.slice(0, lastSep);
+	const basename = value.slice(lastSep + 1);
+	return { parent, basename };
+}
+
+@customElement("directory-picker")
+export class DirectoryPicker extends LitElement {
+	// --- public API --------------------------------------------------------
+
+	@property({ type: String }) value = "";
+	@property({ type: String }) placeholder = "/path/to/project";
+	@property({ attribute: false }) browseDirectory!: BrowseDirectoryFn;
+	@property({ attribute: false }) recentPaths: Array<{ path: string; source: string }> = [];
+	@property({ type: Number }) debounceMs = 200;
+	@property({ type: Number }) maxSuggestions = 12;
+	@property({ type: Boolean }) disabled = false;
+	@property({ type: Boolean }) showBrowseButton = true;
+
+	// --- internal state ---------------------------------------------------
+
+	@state() private _suggestions: DirectorySuggestion[] = [];
+	@state() private _open = false;
+	@state() private _highlight = -1;
+	@state() private _loading = false;
+
+	@query("input.directory-picker-input") private _inputEl?: HTMLInputElement;
+
+	private _debounceTimer: ReturnType<typeof setTimeout> | null = null;
+	/** Monotonic token to ignore stale browse responses. */
+	private _browseToken = 0;
+	/** Last `value` we ran a suggestion lookup against (avoid duplicate work). */
+	private _lastQueried: string | null = null;
+
+	protected override createRenderRoot(): this {
+		return this;
+	}
+
+	override disconnectedCallback(): void {
+		super.disconnectedCallback();
+		if (this._debounceTimer) {
+			clearTimeout(this._debounceTimer);
+			this._debounceTimer = null;
+		}
+		this._browseToken++; // invalidate any in-flight lookup
+	}
+
+	/** Public: focus the inner text input. */
+	focusInput(): void {
+		// Wait one microtask so the input exists if called immediately after render.
+		Promise.resolve().then(() => {
+			this._inputEl?.focus();
+		});
+	}
+
+	// --- event helpers ----------------------------------------------------
+
+	private _fire<T>(name: string, detail: T): void {
+		this.dispatchEvent(new CustomEvent<T>(name, {
+			bubbles: true,
+			composed: true,
+			detail,
+		}));
+	}
+
+	// --- suggestion lookup ------------------------------------------------
+
+	private _scheduleLookup(immediate = false): void {
+		if (this._debounceTimer) {
+			clearTimeout(this._debounceTimer);
+			this._debounceTimer = null;
+		}
+		const run = () => {
+			this._debounceTimer = null;
+			void this._runLookup();
+		};
+		if (immediate || this.debounceMs <= 0) {
+			run();
+		} else {
+			this._debounceTimer = setTimeout(run, this.debounceMs);
+		}
+	}
+
+	private _recentAsSuggestions(): DirectorySuggestion[] {
+		const seen = new Set<string>();
+		const out: DirectorySuggestion[] = [];
+		for (const r of this.recentPaths) {
+			if (!r?.path || seen.has(r.path)) continue;
+			seen.add(r.path);
+			// Derive a basename for display.
+			const parts = r.path.split(SEPARATOR_REGEX).filter(Boolean);
+			const name = parts.length > 0 ? (parts[parts.length - 1] ?? r.path) : r.path;
+			out.push({ name, path: r.path, source: "recent", hint: "Recent" });
+			if (out.length >= this.maxSuggestions) break;
+		}
+		return out;
+	}
+
+	private async _runLookup(): Promise<void> {
+		const value = this.value ?? "";
+		this._lastQueried = value;
+		const token = ++this._browseToken;
+
+		// Empty input → recent paths only.
+		if (value.trim() === "") {
+			const recents = this._recentAsSuggestions();
+			if (token !== this._browseToken) return;
+			this._suggestions = recents;
+			this._highlight = recents.length > 0 ? 0 : -1;
+			this._open = recents.length > 0;
+			this._loading = false;
+			return;
+		}
+
+		// Ask the injected browseDirectory.
+		const { parent, basename } = splitPath(value);
+		this._loading = true;
+
+		// Strategy: try the value as a directory first (covers the "existing dir"
+		// case from the spec). If that throws, fall back to the parent.
+		let result: DirectoryBrowseResult | null = null;
+		let basenameFilter = "";
+		try {
+			result = await this.browseDirectory(value);
+			// If browseDirectory returned with current === value (or close),
+			// treat as existing dir and show its children unfiltered.
+			basenameFilter = "";
+		} catch {
+			if (parent) {
+				try {
+					result = await this.browseDirectory(parent);
+					basenameFilter = basename;
+				} catch {
+					result = null;
+				}
+			}
+		}
+
+		if (token !== this._browseToken) return; // stale
+
+		const suggestions: DirectorySuggestion[] = [];
+		if (result && Array.isArray(result.entries)) {
+			const lowerFilter = basenameFilter.toLowerCase();
+			for (const entry of result.entries) {
+				if (!entry?.path || !entry?.name) continue;
+				if (lowerFilter && !entry.name.toLowerCase().startsWith(lowerFilter)) continue;
+				suggestions.push({
+					name: entry.name,
+					path: entry.path,
+					source: "browse",
+				});
+				if (suggestions.length >= this.maxSuggestions) break;
+			}
+		}
+
+		// If we got nothing useful and the input is empty after trimming, fall back to recents.
+		if (suggestions.length === 0 && this.recentPaths.length > 0) {
+			// Filter recents by typed substring (case-insensitive) so the user
+			// still sees something familiar even when browse fails.
+			const needle = value.toLowerCase();
+			for (const r of this.recentPaths) {
+				if (!r?.path) continue;
+				if (!r.path.toLowerCase().includes(needle)) continue;
+				const parts = r.path.split(SEPARATOR_REGEX).filter(Boolean);
+				const name = parts.length > 0 ? (parts[parts.length - 1] ?? r.path) : r.path;
+				suggestions.push({ name, path: r.path, source: "recent", hint: "Recent" });
+				if (suggestions.length >= this.maxSuggestions) break;
+			}
+		}
+
+		this._suggestions = suggestions;
+		this._highlight = suggestions.length > 0 ? 0 : -1;
+		this._open = suggestions.length > 0;
+		this._loading = false;
+	}
+
+	// --- DOM event handlers ----------------------------------------------
+
+	private _onInput = (e: Event): void => {
+		const next = (e.target as HTMLInputElement).value;
+		this.value = next;
+		this._fire<DirectoryPickerPathDetail>("directory-input", {
+			path: next,
+			source: "typed",
+		});
+		this._scheduleLookup();
+	};
+
+	private _onFocus = (): void => {
+		// Re-run lookup if the value changed since last query, otherwise just open.
+		if (this._lastQueried !== this.value) {
+			this._scheduleLookup(true);
+		} else if (this._suggestions.length > 0) {
+			this._open = true;
+		} else if ((this.value ?? "").trim() === "" && this.recentPaths.length > 0) {
+			this._scheduleLookup(true);
+		}
+	};
+
+	private _onBlur = (): void => {
+		// Delay so a click on a suggestion fires `_onPickSuggestion` first.
+		setTimeout(() => {
+			this._open = false;
+		}, 120);
+	};
+
+	private _onKeyDown = (e: KeyboardEvent): void => {
+		if (e.key === "ArrowDown") {
+			if (!this._open && this._suggestions.length === 0) {
+				// Open with whatever we have (e.g. recent paths) on demand.
+				this._scheduleLookup(true);
+				return;
+			}
+			if (this._suggestions.length === 0) return;
+			e.preventDefault();
+			this._open = true;
+			this._highlight = (this._highlight + 1) % this._suggestions.length;
+			return;
+		}
+		if (e.key === "ArrowUp") {
+			if (this._suggestions.length === 0) return;
+			e.preventDefault();
+			this._open = true;
+			this._highlight =
+				this._highlight <= 0
+					? this._suggestions.length - 1
+					: this._highlight - 1;
+			return;
+		}
+		if (e.key === "Enter") {
+			if (this._open && this._highlight >= 0 && this._highlight < this._suggestions.length) {
+				e.preventDefault();
+				const picked = this._suggestions[this._highlight];
+				if (picked) this._pickSuggestion(picked);
+				return;
+			}
+			// No highlight → commit current value.
+			e.preventDefault();
+			this._open = false;
+			this._fire<DirectoryPickerPathDetail>("directory-commit", {
+				path: this.value,
+				source: "typed",
+			});
+			return;
+		}
+		if (e.key === "Escape") {
+			if (this._open) {
+				e.preventDefault();
+				this._open = false;
+				this._highlight = -1;
+				return;
+			}
+			e.preventDefault();
+			this._fire<void>("directory-cancel", undefined as unknown as void);
+			return;
+		}
+		// Tab and other keys fall through normally.
+	};
+
+	private _pickSuggestion(s: DirectorySuggestion): void {
+		this.value = s.path;
+		this._lastQueried = s.path;
+		this._open = false;
+		this._highlight = -1;
+		this._suggestions = [];
+		this._fire<DirectoryPickerPathDetail>("directory-select", {
+			path: s.path,
+			source: "suggestion",
+		});
+		// Return focus to input.
+		this.focusInput();
+	}
+
+	private _onSuggestionMouseDown = (e: MouseEvent, s: DirectorySuggestion): void => {
+		// Use mousedown so we beat the input's blur handler.
+		e.preventDefault();
+		this._pickSuggestion(s);
+	};
+
+	private _onSuggestionHover = (idx: number): void => {
+		this._highlight = idx;
+	};
+
+	private _onBrowseClick = (): void => {
+		this._open = false;
+		this._fire<DirectoryBrowseRequestDetail>("directory-browse-request", {
+			path: this.value ?? "",
+		});
+	};
+
+	// --- render -----------------------------------------------------------
+
+	private _renderSuggestion(s: DirectorySuggestion, idx: number) {
+		const active = idx === this._highlight;
+		const baseRow =
+			"flex items-baseline gap-2 px-3 py-1.5 text-sm cursor-pointer select-none";
+		const stateRow = active
+			? "bg-accent text-accent-foreground"
+			: "text-foreground hover:bg-accent/60";
+		return html`
+			<li
+				role="option"
+				aria-selected=${active ? "true" : "false"}
+				class="${baseRow} ${stateRow}"
+				data-testid="directory-picker-suggestion"
+				data-path=${s.path}
+				@mousedown=${(e: MouseEvent) => this._onSuggestionMouseDown(e, s)}
+				@mouseenter=${() => this._onSuggestionHover(idx)}
+			>
+				<span class="font-medium truncate">${s.name}</span>
+				<span class="text-xs text-muted-foreground truncate flex-1" title=${s.path}>${s.path}</span>
+				${s.hint
+					? html`<span class="text-[10px] uppercase tracking-wide text-muted-foreground/80 shrink-0">${s.hint}</span>`
+					: nothing}
+			</li>
+		`;
+	}
+
+	protected override render() {
+		const inputClasses =
+			"directory-picker-input flex w-full min-w-0 h-9 px-3 py-1 rounded-md border bg-transparent text-sm text-foreground shadow-xs outline-none transition-[color,box-shadow] placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] dark:bg-input/30 border-input disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50";
+
+		const browseBtnClasses =
+			"shrink-0 h-9 px-3 inline-flex items-center justify-center rounded-md border border-border bg-transparent text-sm text-foreground hover:bg-secondary/50 transition-colors disabled:pointer-events-none disabled:opacity-50";
+
+		const showSuggestions = this._open && this._suggestions.length > 0;
+
+		return html`
+			<div
+				class="relative block w-full"
+				data-testid="directory-picker"
+				@focusout=${this._onBlur}
+			>
+				<div class="flex items-stretch gap-2">
+					<input
+						class=${inputClasses}
+						type="text"
+						spellcheck="false"
+						autocomplete="off"
+						autocapitalize="off"
+						autocorrect="off"
+						.value=${this.value}
+						placeholder=${this.placeholder}
+						?disabled=${this.disabled}
+						aria-autocomplete="list"
+						aria-expanded=${showSuggestions ? "true" : "false"}
+						aria-controls="directory-picker-suggestions"
+						aria-haspopup="listbox"
+						data-testid="directory-picker-input"
+						@input=${this._onInput}
+						@focus=${this._onFocus}
+						@keydown=${this._onKeyDown}
+					/>
+					${this.showBrowseButton
+						? html`
+							<button
+								type="button"
+								class=${browseBtnClasses}
+								?disabled=${this.disabled}
+								data-testid="directory-picker-browse"
+								@click=${this._onBrowseClick}
+							>
+								Browse…
+							</button>
+						`
+						: nothing}
+				</div>
+				${showSuggestions
+					? html`
+						<ul
+							id="directory-picker-suggestions"
+							role="listbox"
+							class="absolute left-0 right-0 top-full mt-1 z-30 max-h-64 overflow-y-auto rounded-md border border-border bg-popover text-popover-foreground shadow-lg"
+							data-testid="directory-picker-suggestions"
+						>
+							${this._suggestions.map((s, idx) => this._renderSuggestion(s, idx))}
+						</ul>
+					`
+					: nothing}
+				${this._loading && !showSuggestions
+					? html`
+						<div
+							class="absolute left-0 right-0 top-full mt-1 z-30 px-3 py-1.5 text-xs text-muted-foreground bg-popover border border-border rounded-md shadow-sm pointer-events-none"
+							data-testid="directory-picker-loading"
+						>Searching…</div>
+					`
+					: nothing}
+			</div>
+		`;
+	}
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		"directory-picker": DirectoryPicker;
+	}
+}

--- a/src/ui/components/DirectoryPicker.ts
+++ b/src/ui/components/DirectoryPicker.ts
@@ -360,11 +360,20 @@ export class DirectoryPicker extends LitElement {
 		}
 		if (e.key === "Escape") {
 			if (this._open) {
+				// Suggestions overlay open: swallow Esc so the surrounding dialog
+				// (Mini-lit Dialog listens for Esc on `document`) does not also
+				// close. Design doc: "Esc closes suggestions → browse → dialog
+				// (in that order)". Pinned by
+				// tests/e2e/ui/add-project-typeahead.spec.ts.
 				e.preventDefault();
+				e.stopPropagation();
 				this._open = false;
 				this._highlight = -1;
 				return;
 			}
+			// Overlay already closed — propagate cancel up; the surrounding dialog
+			// (parent dialog's onClose / directory-cancel listener) decides whether
+			// to close itself.
 			e.preventDefault();
 			this._fire<void>("directory-cancel", undefined as unknown as void);
 			return;

--- a/tests/e2e/ui/add-project-browse-modal.spec.ts
+++ b/tests/e2e/ui/add-project-browse-modal.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * Add Project — dedicated browse modal flow.
+ *
+ * Pins:
+ *   - Clicking Browse opens the standalone `add-project-browse-dialog`
+ *     overlay; the parent dialog stays mounted underneath.
+ *   - Clicking a directory entry navigates into it (current-path label
+ *     changes); Up navigates back.
+ *   - "Select current" closes the modal, copies the path into the picker,
+ *     and triggers detection + preflight on the new path.
+ *   - Re-opening the modal and pressing Esc closes it without mutating the
+ *     picker input, and focus returns to the picker input.
+ */
+import { test, expect } from "../gateway-harness.js";
+import { rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import {
+	ADD_PROJECT,
+	openAddProjectDialog,
+	uniqueDir,
+	clearProjects,
+	waitForPreflight,
+	preflightAvailable,
+} from "./add-project-helpers.js";
+
+test.describe("Add Project — browse modal", () => {
+	test.afterEach(async () => {
+		await clearProjects();
+	});
+
+	test("browse → navigate → select updates picker + preflight; Esc preserves picker + restores focus", async ({ page }, testInfo) => {
+		if (!(await preflightAvailable())) testInfo.skip(true, "preflight endpoint unavailable");
+		testInfo.setTimeout(60_000);
+
+		// parent contains "deeper-child" which itself has a "leaf" subdir we'll
+		// navigate into to exercise Up + entry click.
+		const parent = uniqueDir("browse-parent");
+		const deeper = join(parent, "deeper-child");
+		const leaf = join(deeper, "leaf");
+		mkdirSync(leaf, { recursive: true });
+		writeFileSync(join(leaf, "README.md"), "hi\n");
+
+		try {
+			await openAddProjectDialog(page);
+			const input = page.locator(ADD_PROJECT.pickerInput);
+
+			// Seed the input so the browse modal opens at a known starting point.
+			await input.fill(parent);
+			await expect(waitForPreflight(page)).resolves.toBe(true);
+
+			// --- happy path: browse → navigate down → Select current ---
+			await page.locator(ADD_PROJECT.pickerBrowse).click();
+			const modal = page.locator(ADD_PROJECT.browseDialog);
+			await expect(modal).toBeVisible({ timeout: 5_000 });
+			// Parent dialog stays mounted underneath.
+			await expect(page.locator(ADD_PROJECT.dialog)).toBeVisible();
+
+			const current = modal.locator(ADD_PROJECT.browseCurrent);
+			// Wait for the initial directory listing to land.
+			await expect.poll(
+				async () => (await current.textContent()) ?? "",
+				{ timeout: 5_000 },
+			).toContain(basename(parent));
+
+			// Click the "deeper-child" entry — current-path label should update.
+			const deeperEntry = modal
+				.locator(ADD_PROJECT.browseEntry)
+				.filter({ hasText: "deeper-child" })
+				.first();
+			await expect(deeperEntry).toBeVisible({ timeout: 5_000 });
+			await deeperEntry.click();
+			await expect.poll(
+				async () => (await current.textContent()) ?? "",
+				{ timeout: 5_000 },
+			).toContain("deeper-child");
+
+			// Click Up — current label should drop back to parent.
+			await modal.locator(ADD_PROJECT.browseUp).click();
+			await expect.poll(
+				async () => (await current.textContent()) ?? "",
+				{ timeout: 5_000 },
+			).not.toContain("deeper-child");
+
+			// Re-enter deeper-child and Select current.
+			await modal
+				.locator(ADD_PROJECT.browseEntry)
+				.filter({ hasText: "deeper-child" })
+				.first()
+				.click();
+			await expect.poll(
+				async () => (await current.textContent()) ?? "",
+				{ timeout: 5_000 },
+			).toContain("deeper-child");
+
+			const selectBtn = modal.locator("button").filter({ hasText: "Select current" }).first();
+			await expect(selectBtn).toBeEnabled({ timeout: 5_000 });
+			await selectBtn.click();
+			await expect(modal).toHaveCount(0, { timeout: 5_000 });
+
+			// Picker input updated to the selected path.
+			await expect.poll(
+				async () => await input.inputValue(),
+				{ timeout: 5_000 },
+			).toContain("deeper-child");
+			// Preflight re-ran for the new path. We assert the preflight panel
+			// shows the chosen folder by checking its `rootPath` data via the
+			// path-existence check row.
+			const rendered = await waitForPreflight(page);
+			expect(rendered).toBe(true);
+			await expect(
+				page.locator('[data-testid="preflight-check"][data-check-id="path.exists"]'),
+			).toBeVisible({ timeout: 8_000 });
+
+			// --- Esc closes modal, preserves picker, restores focus ---
+			const valueBeforeEsc = await input.inputValue();
+			await page.locator(ADD_PROJECT.pickerBrowse).click();
+			await expect(modal).toBeVisible({ timeout: 5_000 });
+			await page.keyboard.press("Escape");
+			await expect(modal).toHaveCount(0, { timeout: 5_000 });
+
+			// Picker value unchanged after Esc.
+			expect(await input.inputValue()).toBe(valueBeforeEsc);
+			// Focus returned to the picker's internal input.
+			await expect(input).toBeFocused();
+		} finally {
+			try { rmSync(parent, { recursive: true, force: true }); } catch { /* best-effort */ }
+		}
+	});
+});

--- a/tests/e2e/ui/add-project-flow.spec.ts
+++ b/tests/e2e/ui/add-project-flow.spec.ts
@@ -63,12 +63,16 @@ test.describe("Add Project flow (UI)", () => {
 		await expect(page.getByText("Project Name")).not.toBeVisible();
 		await expect(page.getByText("Color (optional)")).not.toBeVisible();
 
-		// Directory browser opens, Select closes it, and the chosen path is copied back.
-		await page.locator("button").filter({ hasText: "Browse" }).first().click();
-		await expect(page.locator('[data-testid="directory-browser"]')).toBeVisible({ timeout: 5_000 });
-		await expect(page.locator("button").filter({ hasText: "Select" }).first()).toBeVisible();
-		await page.locator("button").filter({ hasText: "Select" }).first().click();
-		await expect(page.locator('[data-testid="directory-browser"]')).not.toBeVisible({ timeout: 5_000 });
+		// Directory browser opens, Select current closes it, and the chosen path is copied back.
+		await page.locator('[data-testid="directory-picker-browse"]').click();
+		await expect(page.locator('[data-testid="add-project-browse-dialog"]')).toBeVisible({ timeout: 5_000 });
+		const selectBtn = page.locator("button").filter({ hasText: "Select current" }).first();
+		await expect(selectBtn).toBeVisible();
+		// Wait for the initial browse to populate so `current` is non-empty (Select current is
+		// disabled while the modal is still showing "Loading…").
+		await expect(selectBtn).toBeEnabled({ timeout: 5_000 });
+		await selectBtn.click();
+		await expect(page.locator('[data-testid="add-project-browse-dialog"]')).not.toBeVisible({ timeout: 5_000 });
 		await expect(pathInput).toBeVisible();
 		expect((await pathInput.inputValue()).length).toBeGreaterThan(0);
 	});

--- a/tests/e2e/ui/add-project-footer-stability.spec.ts
+++ b/tests/e2e/ui/add-project-footer-stability.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * Add Project — footer bounding-box stability invariant.
+ *
+ * Pins the design-doc requirement: `add-project-footer` must occupy the same
+ * screen rectangle across every state transition the dialog can be in —
+ * empty input, typed path triggering preflight, suggestion overlay open,
+ * browse modal open, scan step (multi-repo), and the error-row state.
+ *
+ * Failure prints the offending transition + which axis shifted by how many
+ * pixels so the regression source is obvious.
+ */
+import { test, expect, type Page } from "../gateway-harness.js";
+import { rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import {
+	ADD_PROJECT,
+	openAddProjectDialog,
+	uniqueDir,
+	makeMultiRepoFixture,
+	clearProjects,
+	waitForPreflight,
+	preflightAvailable,
+} from "./add-project-helpers.js";
+
+interface Rect { x: number; y: number; width: number; height: number }
+const TOL = 1; // sub-pixel rendering tolerance
+
+async function footerRect(page: Page): Promise<Rect> {
+	const handle = await page.locator(ADD_PROJECT.footer).first().elementHandle();
+	if (!handle) throw new Error("footer not found");
+	const box = await handle.boundingBox();
+	if (!box) throw new Error("footer has no bounding box");
+	return {
+		x: Math.round(box.x),
+		y: Math.round(box.y),
+		width: Math.round(box.width),
+		height: Math.round(box.height),
+	};
+}
+
+function shifted(a: Rect, b: Rect): string | null {
+	const dx = Math.abs(a.x - b.x);
+	const dy = Math.abs(a.y - b.y);
+	const dw = Math.abs(a.width - b.width);
+	const dh = Math.abs(a.height - b.height);
+	if (dx > TOL || dy > TOL || dw > TOL || dh > TOL) {
+		return `Δx=${dx} Δy=${dy} Δw=${dw} Δh=${dh} (tolerance=${TOL}). before=${JSON.stringify(a)} after=${JSON.stringify(b)}`;
+	}
+	return null;
+}
+
+test.describe("Add Project — footer position invariant", () => {
+	test.afterEach(async () => {
+		await clearProjects();
+	});
+
+	test("footer bounding box stays put across every state transition", async ({ page }, testInfo) => {
+		if (!(await preflightAvailable())) testInfo.skip(true, "preflight endpoint unavailable");
+		testInfo.setTimeout(60_000);
+
+		// Build fixtures used by individual transitions.
+		const parent = uniqueDir("footer-parent");
+		mkdirSync(join(parent, "alpha"), { recursive: true });
+		mkdirSync(join(parent, "alpha-two"), { recursive: true });
+		const empty = uniqueDir("footer-empty");
+		const multi = makeMultiRepoFixture("footer-multi");
+
+		try {
+			await openAddProjectDialog(page);
+			const input = page.locator(ADD_PROJECT.pickerInput);
+
+			// Reference snapshot: empty input, no suggestions, no preflight.
+			const baseline = await footerRect(page);
+
+			const assertNoShift = async (label: string) => {
+				const next = await footerRect(page);
+				const drift = shifted(baseline, next);
+				if (drift) {
+					throw new Error(`Footer shifted at transition "${label}": ${drift}`);
+				}
+			};
+
+			// 1. Type into the picker so the suggestion overlay opens.
+			await input.fill(join(parent, "alpha"));
+			await expect(page.locator(ADD_PROJECT.pickerSuggestions)).toBeVisible({ timeout: 5_000 });
+			await assertNoShift("suggestion overlay open");
+
+			// 2. Replace with an empty dir to force preflight to a 'Ready' state.
+			await input.fill(empty);
+			const rendered = await waitForPreflight(page);
+			expect(rendered).toBe(true);
+			await expect(page.locator(ADD_PROJECT.preflightPanel)).toBeVisible();
+			await assertNoShift("preflight panel populated");
+
+			// 3. Open the browse modal — separate overlay; the parent footer
+			// must not move beneath it.
+			await page.locator(ADD_PROJECT.pickerBrowse).click();
+			await expect(page.locator(ADD_PROJECT.browseDialog)).toBeVisible({ timeout: 5_000 });
+			await assertNoShift("browse modal open");
+
+			// Close the browse modal (Cancel).
+			await page
+				.locator(ADD_PROJECT.browseDialog)
+				.locator("button")
+				.filter({ hasText: "Cancel" })
+				.first()
+				.click();
+			await expect(page.locator(ADD_PROJECT.browseDialog)).toHaveCount(0, { timeout: 5_000 });
+			await assertNoShift("browse modal closed");
+
+			// 4. Trigger an error-ish status by typing a path that doesn't
+			// exist. The status slot has reserved height and the preflight
+			// pane scrolls — the footer must stay put.
+			await input.fill("/this/path/definitely/does/not/exist/x");
+			// Let preflight finish (one way or another) for that path.
+			await expect.poll(
+				async () => {
+					const panel = page.locator(ADD_PROJECT.preflightPanel);
+					if (await panel.count() === 0) return "missing";
+					return await panel.getAttribute("data-has-fail");
+				},
+				{ timeout: 8_000 },
+			).not.toBeNull();
+			await assertNoShift("nonexistent path / preflight error state");
+
+			// 5. Drive to the scan step via the multi-repo fixture. Continue
+			// must transition us from path → scan without footer movement.
+			await input.fill(multi.root);
+			await expect(page.locator(ADD_PROJECT.preflightPanel)).toBeVisible({ timeout: 8_000 });
+			// Wait for preflight to finish so Continue is enabled.
+			await expect.poll(
+				async () =>
+					(await page.locator(ADD_PROJECT.preflightPanel).getAttribute("data-has-fail")) ?? "loading",
+				{ timeout: 8_000 },
+			).toBe("0");
+			await assertNoShift("multi-repo path typed, preflight ready");
+
+			// Click Continue → moves to scan step (the multi-repo fixture
+			// produces 2 detected repos so this is the path → scan branch).
+			await page.locator("button").filter({ hasText: "Continue" }).first().click();
+			await expect(page.locator(ADD_PROJECT.scanChecklist)).toBeVisible({ timeout: 10_000 });
+			await expect(page.locator(ADD_PROJECT.step)).toHaveText("scan");
+			await assertNoShift("scan step displayed");
+		} finally {
+			for (const dir of [parent, empty, multi.root]) {
+				try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+			}
+		}
+	});
+});

--- a/tests/e2e/ui/add-project-helpers.ts
+++ b/tests/e2e/ui/add-project-helpers.ts
@@ -1,0 +1,174 @@
+/**
+ * Shared fixture/utility helpers for the Add Project browser E2E specs.
+ *
+ * The five `add-project-*.spec.ts` siblings that drive the V2 picker — typeahead,
+ * footer-stability, browse-modal, multi-repo-subset, and select-all — share the
+ * same dialog-opening sequence, temp-dir conventions, and assistant-prompt WS
+ * capture trick. Centralising those here keeps individual specs focused on what
+ * they verify.
+ */
+import { expect, type Page } from "../gateway-harness.js";
+import { apiFetch } from "../e2e-setup.js";
+import { openApp } from "./ui-helpers.js";
+import { mkdirSync, writeFileSync, realpathSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+/** Stable selectors exposed by the V2 Add Project dialog. */
+export const ADD_PROJECT = {
+	dialog: '[data-testid="add-project-dialog"]',
+	picker: '[data-testid="add-project-picker"]',
+	pickerInput: '[data-testid="directory-picker-input"]',
+	pickerBrowse: '[data-testid="directory-picker-browse"]',
+	pickerSuggestions: '[data-testid="directory-picker-suggestions"]',
+	pickerSuggestion: '[data-testid="directory-picker-suggestion"]',
+	statusSlot: '[data-testid="add-project-status-slot"]',
+	preflightSlot: '[data-testid="add-project-preflight-slot"]',
+	preflightPanel: '[data-testid="preflight-panel"]',
+	footer: '[data-testid="add-project-footer"]',
+	step: '[data-testid="add-project-step"]',
+	browseDialog: '[data-testid="add-project-browse-dialog"]',
+	browseUp: '[data-testid="add-project-browse-up"]',
+	browseCurrent: '[data-testid="add-project-browse-current"]',
+	browseEntry: '[data-testid="add-project-browse-entry"]',
+	browseList: '[data-testid="add-project-browse-list"]',
+	browseStatus: '[data-testid="add-project-browse-status"]',
+	browseFooter: '[data-testid="add-project-browse-footer"]',
+	selectAll: '[data-testid="add-project-select-all"]',
+	deselectAll: '[data-testid="add-project-deselect-all"]',
+	selectedCount: '[data-testid="add-project-selected-count"]',
+	scanChecklist: '[data-testid="add-project-scan-checklist"]',
+	scanCheckboxFor: (id: string) =>
+		`[data-testid="add-project-scan-checkbox-${id}"]`,
+	scanRowFor: (id: string) => `[data-testid="add-project-scan-row-${id}"]`,
+	continue: '[data-testid="add-project-continue"]',
+} as const;
+
+/** Build a unique temp dir under tmpdir(). Caller is responsible for cleanup. */
+export function uniqueDir(label: string): string {
+	const dir = join(
+		tmpdir(),
+		`bobbit-e2e-${label}-${process.env.E2E_PORT}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+	);
+	mkdirSync(dir, { recursive: true });
+	// Canonicalise so test assertions match the path the server stores after
+	// any symlink resolution on tmpdir() (e.g. macOS /var/folders → /private/var).
+	return realpathSync(dir);
+}
+
+/**
+ * Build a multi-repo fixture: a root dir containing two sibling subdirectories,
+ * each with its own `.git/`. `scanRepos()` returns one entry per child with
+ * `hasGit:true`. Returns the absolute paths so specs can assert against the
+ * canonical strings the server emits.
+ */
+export function makeMultiRepoFixture(
+	label: string,
+	names: readonly string[] = ["repo-a", "repo-b"],
+): { root: string; children: string[] } {
+	const root = uniqueDir(`multirepo-${label}`);
+	const children: string[] = [];
+	for (const name of names) {
+		const repo = join(root, name);
+		mkdirSync(join(repo, ".git"), { recursive: true });
+		// A README ensures the child is non-trivially populated; not required
+		// by scanRepos but it helps the directory listing make sense.
+		writeFileSync(join(repo, "README.md"), `# ${name}\n`);
+		children.push(repo);
+	}
+	return { root, children };
+}
+
+/** Open the app shell and trigger the Add Project dialog. */
+export async function openAddProjectDialog(page: Page): Promise<void> {
+	await openApp(page);
+	await page.locator("button").filter({ hasText: "Add Project" }).first().click();
+	await page.locator(ADD_PROJECT.dialog).waitFor({ state: "visible", timeout: 5_000 });
+	await page.locator(ADD_PROJECT.pickerInput).waitFor({ state: "visible", timeout: 5_000 });
+}
+
+/** Type a value into the picker input and wait for the value to settle. */
+export async function setPickerValue(page: Page, value: string): Promise<void> {
+	const input = page.locator(ADD_PROJECT.pickerInput);
+	await input.fill(value);
+	await expect(input).toHaveValue(value);
+}
+
+/**
+ * Wait for the preflight panel to render after typing a path. Returns true
+ * when it appears, false if the endpoint is unavailable (older gateway).
+ * Mirrors the same guard as the pre-existing preflight spec so the new
+ * specs degrade the same way.
+ */
+export async function waitForPreflight(page: Page, timeoutMs = 8_000): Promise<boolean> {
+	const panel = page.locator(ADD_PROJECT.preflightPanel);
+	try {
+		await panel.waitFor({ state: "visible", timeout: timeoutMs });
+	} catch {
+		return false;
+	}
+	return true;
+}
+
+/** True if the preflight endpoint exists (proxies the legacy availability probe). */
+export async function preflightAvailable(): Promise<boolean> {
+	try {
+		const res = await apiFetch(
+			"/api/projects/preflight?path=" + encodeURIComponent(tmpdir()),
+		);
+		return res.status !== 404;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Hook `page` and start collecting every WebSocket `prompt` frame sent from the
+ * page until the returned `stop()` is called. Returns a snapshot of all frames
+ * matching `type === "prompt"` (the envelope `RemoteAgent.prompt` sends).
+ *
+ * Set this up BEFORE any session is created so we don't miss the first
+ * connection's `framesent` events.
+ */
+export interface CapturedPrompt {
+	text: string;
+	ws: string;
+	raw: any;
+}
+export function captureAssistantPrompts(page: Page): {
+	prompts: CapturedPrompt[];
+	stop: () => void;
+} {
+	const prompts: CapturedPrompt[] = [];
+	const onWs = (ws: import("@playwright/test").WebSocket) => {
+		ws.on("framesent", (event) => {
+			try {
+				const payload = typeof event.payload === "string"
+					? event.payload
+					: event.payload.toString("utf-8");
+				const data = JSON.parse(payload);
+				if (data?.type === "prompt" && typeof data.text === "string") {
+					prompts.push({ text: data.text, ws: ws.url(), raw: data });
+				}
+			} catch {
+				/* non-JSON frame */
+			}
+		});
+	};
+	page.on("websocket", onWs);
+	return {
+		prompts,
+		stop: () => page.off("websocket", onWs),
+	};
+}
+
+/** Strip every registered (non-default) project from the gateway registry. */
+export async function clearProjects(): Promise<void> {
+	const res = await apiFetch("/api/projects");
+	const data = await res.json();
+	const projects = data.projects || data || [];
+	for (const p of projects) {
+		if (p.name === "default") continue;
+		await apiFetch(`/api/projects/${p.id}`, { method: "DELETE" }).catch(() => {});
+	}
+}

--- a/tests/e2e/ui/add-project-multi-repo-subset.spec.ts
+++ b/tests/e2e/ui/add-project-multi-repo-subset.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Add Project — multi-repo subset handoff to the project assistant.
+ *
+ * This is the bug fix the V2 dialog promotion shipped: the user-confirmed
+ * scan subset must reach the project assistant's first turn. Today both an
+ * English bullet summary AND a fenced ```json``` block containing
+ * `{ rootPath, items, selectedIds }` are sent as the autoPrompt — pinned by
+ * `tests/project-assistant-autoprompt.test.ts` at the formatter level and
+ * here at the WebSocket-frame level.
+ */
+import { test, expect } from "../gateway-harness.js";
+import { rmSync } from "node:fs";
+import { basename } from "node:path";
+import {
+	ADD_PROJECT,
+	openAddProjectDialog,
+	makeMultiRepoFixture,
+	clearProjects,
+	captureAssistantPrompts,
+	preflightAvailable,
+} from "./add-project-helpers.js";
+
+test.describe("Add Project — multi-repo subset handoff", () => {
+	test.afterEach(async () => {
+		await clearProjects();
+	});
+
+	test("deselect one sibling repo → assistant first prompt carries the subset (English + JSON)", async ({ page }, testInfo) => {
+		if (!(await preflightAvailable())) testInfo.skip(true, "preflight endpoint unavailable");
+		testInfo.setTimeout(90_000);
+
+		// Build a root with two sibling git repos. scanRepos should return one
+		// entry per child with hasGit:true → buildScanItems produces two items
+		// `repo:<folder>`.
+		const fixture = makeMultiRepoFixture("subset", ["alpha-svc", "beta-svc"]);
+
+		// Install the WS capture BEFORE opening the dialog so we never miss
+		// the first connection's `framesent` events.
+		const captured = captureAssistantPrompts(page);
+
+		try {
+			await openAddProjectDialog(page);
+
+			const input = page.locator(ADD_PROJECT.pickerInput);
+			await input.fill(fixture.root);
+
+			// Wait for preflight to settle (no fail expected for a clean dir).
+			const panel = page.locator(ADD_PROJECT.preflightPanel);
+			await expect(panel).toBeVisible({ timeout: 8_000 });
+			await expect.poll(
+				async () => (await panel.getAttribute("data-has-fail")) ?? "loading",
+				{ timeout: 8_000 },
+			).toBe("0");
+
+			// Click Continue → routes to the scan step (path → scan).
+			await page.locator("button").filter({ hasText: "Continue" }).first().click();
+			await expect(page.locator(ADD_PROJECT.scanChecklist)).toBeVisible({ timeout: 10_000 });
+			await expect(page.locator(ADD_PROJECT.step)).toHaveText("scan");
+
+			// Both rows present and pre-checked.
+			const alphaCheckbox = page.locator(ADD_PROJECT.scanCheckboxFor("repo:alpha-svc"));
+			const betaCheckbox = page.locator(ADD_PROJECT.scanCheckboxFor("repo:beta-svc"));
+			await expect(alphaCheckbox).toBeChecked();
+			await expect(betaCheckbox).toBeChecked();
+			await expect(page.locator(ADD_PROJECT.selectedCount)).toHaveText("Selected 2 of 2");
+
+			// Uncheck beta — selection drops to 1 of 2.
+			await betaCheckbox.uncheck();
+			await expect(betaCheckbox).not.toBeChecked();
+			await expect(page.locator(ADD_PROJECT.selectedCount)).toHaveText("Selected 1 of 2");
+
+			// Click "Continue with assistant" → confirmScanAndContinue() →
+			// createProjectAssistantSession(rootPath, false, { initialScanContext })
+			// → connectToSession → remote.prompt(autoPrompt) over WS.
+			await page.locator(ADD_PROJECT.continue).click();
+
+			// Wait until the URL hash flips to the new assistant session, then
+			// poll the captured prompts for the one containing our root path.
+			await expect.poll(
+				() => page.evaluate(() => window.location.hash),
+				{ timeout: 15_000, intervals: [100, 200, 500] },
+			).toMatch(/^#\/session\//);
+
+			const rootBase = basename(fixture.root);
+			await expect.poll(
+				() => captured.prompts.find((p) => p.text.includes(rootBase))?.text ?? null,
+				{ timeout: 15_000, intervals: [100, 200, 500] },
+			).not.toBeNull();
+
+			const promptText = captured.prompts.find((p) => p.text.includes(rootBase))!.text;
+
+			// English summary present.
+			expect(promptText).toContain(
+				"User-confirmed initial repo/subdirectory selection from Add Project",
+			);
+			expect(promptText).toContain("Selected 1 of 2 repo/subdirectory candidates");
+			expect(promptText).toContain("`alpha-svc`");
+			expect(promptText).toContain("`beta-svc`");
+			// "Not selected" bullet must surface the de-selected repo.
+			expect(promptText).toMatch(/Not selected:.*beta-svc/);
+
+			// Machine-readable JSON block round-trips and reflects the subset.
+			const jsonMatch = promptText.match(/```json\n([\s\S]*?)\n```/);
+			expect(jsonMatch, "autoprompt must contain a ```json block").not.toBeNull();
+			const parsed = JSON.parse(jsonMatch![1]!);
+			expect(parsed).toMatchObject({
+				rootPath: fixture.root,
+			});
+			expect(Array.isArray(parsed.items)).toBe(true);
+			expect(parsed.items).toHaveLength(2);
+			expect(Array.isArray(parsed.selectedIds)).toBe(true);
+			expect(parsed.selectedIds).toEqual(["repo:alpha-svc"]);
+		} finally {
+			captured.stop();
+			try { rmSync(fixture.root, { recursive: true, force: true }); } catch { /* best-effort */ }
+		}
+	});
+});

--- a/tests/e2e/ui/add-project-preflight.spec.ts
+++ b/tests/e2e/ui/add-project-preflight.spec.ts
@@ -113,13 +113,13 @@ test.describe("Add Project — preflight panel", () => {
 			await openAddProjectDialog(page);
 			const pathInput = page.locator('input[placeholder="/path/to/project"]');
 
-			// Nothing typed yet: Browse → Select must be the action that starts preflight.
+			// Nothing typed yet: Browse → Select current must be the action that starts preflight.
 			await expect(page.locator('[data-testid="preflight-panel"]')).toHaveCount(0);
-			await page.locator("button").filter({ hasText: "Browse" }).first().click();
-			const directoryBrowser = page.locator('[data-testid="directory-browser"]');
+			await page.locator('[data-testid="directory-picker-browse"]').click();
+			const directoryBrowser = page.locator('[data-testid="add-project-browse-dialog"]');
 			await expect(directoryBrowser).toBeVisible({ timeout: 5_000 });
 
-			const entry = directoryBrowser.locator('[data-testid="browse-entry"]').filter({ hasText: dirName }).first();
+			const entry = directoryBrowser.locator('[data-testid="add-project-browse-entry"]').filter({ hasText: dirName }).first();
 			await expect(entry).toBeVisible({ timeout: 5_000 });
 			const browseResponsePromise = page.waitForResponse((response) => {
 				try {
@@ -132,12 +132,12 @@ test.describe("Add Project — preflight panel", () => {
 			await entry.click();
 			await browseResponsePromise;
 			await expect.poll(
-				async () => (await directoryBrowser.locator("[title]").first().getAttribute("title")) ?? "",
+				async () => (await directoryBrowser.locator('[data-testid="add-project-browse-current"]').first().getAttribute("title")) ?? "",
 				{ timeout: 5_000 },
 			).toContain(dirName);
 
 			const preflightReportPromise = waitForNextPreflightReport(page);
-			const selectBtn = page.locator("button").filter({ hasText: "Select" }).first();
+			const selectBtn = page.locator("button").filter({ hasText: "Select current" }).first();
 			await expect(selectBtn).toBeEnabled({ timeout: 5_000 });
 			await selectBtn.click();
 			const report = await preflightReportPromise;

--- a/tests/e2e/ui/add-project-select-all.spec.ts
+++ b/tests/e2e/ui/add-project-select-all.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * Add Project — Select all / Deselect all checklist controls.
+ *
+ * Pins:
+ *   - `add-project-deselect-all` clears the selection; `add-project-selected-count`
+ *     drops to "Selected 0 of N"; the assistant Continue button becomes disabled.
+ *   - `add-project-select-all` re-checks every row; count returns to "N of N";
+ *     Continue re-enables.
+ */
+import { test, expect } from "../gateway-harness.js";
+import { rmSync } from "node:fs";
+import {
+	ADD_PROJECT,
+	openAddProjectDialog,
+	makeMultiRepoFixture,
+	clearProjects,
+	preflightAvailable,
+} from "./add-project-helpers.js";
+
+test.describe("Add Project — Select all / Deselect all", () => {
+	test.afterEach(async () => {
+		await clearProjects();
+	});
+
+	test("Deselect all disables Continue; Select all re-enables it", async ({ page }, testInfo) => {
+		if (!(await preflightAvailable())) testInfo.skip(true, "preflight endpoint unavailable");
+		testInfo.setTimeout(60_000);
+
+		const fixture = makeMultiRepoFixture("selectall", ["one", "two", "three"]);
+
+		try {
+			await openAddProjectDialog(page);
+			await page.locator(ADD_PROJECT.pickerInput).fill(fixture.root);
+
+			const preflight = page.locator(ADD_PROJECT.preflightPanel);
+			await expect(preflight).toBeVisible({ timeout: 8_000 });
+			await expect.poll(
+				async () => (await preflight.getAttribute("data-has-fail")) ?? "loading",
+				{ timeout: 8_000 },
+			).toBe("0");
+
+			// Path → scan.
+			await page.locator("button").filter({ hasText: "Continue" }).first().click();
+			await expect(page.locator(ADD_PROJECT.scanChecklist)).toBeVisible({ timeout: 10_000 });
+			await expect(page.locator(ADD_PROJECT.step)).toHaveText("scan");
+
+			const items = ["repo:one", "repo:two", "repo:three"] as const;
+			for (const id of items) {
+				await expect(page.locator(ADD_PROJECT.scanCheckboxFor(id))).toBeChecked();
+			}
+			await expect(page.locator(ADD_PROJECT.selectedCount)).toHaveText("Selected 3 of 3");
+
+			// Deselect all.
+			const continueBtn = page.locator(ADD_PROJECT.continue).locator("xpath=ancestor::button");
+			await page.locator(ADD_PROJECT.deselectAll).click();
+			for (const id of items) {
+				await expect(page.locator(ADD_PROJECT.scanCheckboxFor(id))).not.toBeChecked();
+			}
+			await expect(page.locator(ADD_PROJECT.selectedCount)).toHaveText("Selected 0 of 3");
+			await expect(continueBtn).toBeDisabled();
+			// Deselect all itself is now disabled (selected===0), Select all is enabled.
+			await expect(page.locator(ADD_PROJECT.deselectAll)).toBeDisabled();
+			await expect(page.locator(ADD_PROJECT.selectAll)).toBeEnabled();
+
+			// Select all.
+			await page.locator(ADD_PROJECT.selectAll).click();
+			for (const id of items) {
+				await expect(page.locator(ADD_PROJECT.scanCheckboxFor(id))).toBeChecked();
+			}
+			await expect(page.locator(ADD_PROJECT.selectedCount)).toHaveText("Selected 3 of 3");
+			await expect(continueBtn).toBeEnabled();
+			// Now Select all is disabled (everything already selected), Deselect all is enabled.
+			await expect(page.locator(ADD_PROJECT.selectAll)).toBeDisabled();
+			await expect(page.locator(ADD_PROJECT.deselectAll)).toBeEnabled();
+		} finally {
+			try { rmSync(fixture.root, { recursive: true, force: true }); } catch { /* best-effort */ }
+		}
+	});
+});

--- a/tests/e2e/ui/add-project-typeahead.spec.ts
+++ b/tests/e2e/ui/add-project-typeahead.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * Add Project — directory-picker typeahead (V2 default flow).
+ *
+ * Pins:
+ *   - Typing a parent path with multiple children renders the absolutely
+ *     positioned suggestion overlay populated by `/api/browse-directory`.
+ *   - ArrowDown highlights the first suggestion; Enter selects it; the picker
+ *     input updates and detection/preflight re-runs against the new path.
+ *   - Escape closes the open suggestion list without cancelling the dialog;
+ *     a second Escape closes the dialog.
+ */
+import { test, expect } from "../gateway-harness.js";
+import { rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import {
+	ADD_PROJECT,
+	openAddProjectDialog,
+	uniqueDir,
+	clearProjects,
+	waitForPreflight,
+	preflightAvailable,
+} from "./add-project-helpers.js";
+
+test.describe("Add Project — directory picker typeahead", () => {
+	test.afterEach(async () => {
+		await clearProjects();
+	});
+
+	test("type prefix → ArrowDown → Enter selects suggestion and runs preflight", async ({ page }, testInfo) => {
+		if (!(await preflightAvailable())) testInfo.skip(true, "preflight endpoint unavailable");
+
+		// Build a parent dir with a couple of named children that the suggestion
+		// query (filtered by typed basename) will hit.
+		const parent = uniqueDir("typeahead-parent");
+		mkdirSync(join(parent, "alpha-child"), { recursive: true });
+		mkdirSync(join(parent, "alpha-other"), { recursive: true });
+		mkdirSync(join(parent, "beta"), { recursive: true });
+		writeFileSync(join(parent, "alpha-child", "README.md"), "hello\n");
+
+		try {
+			await openAddProjectDialog(page);
+			const input = page.locator(ADD_PROJECT.pickerInput);
+			await expect(input).toBeFocused();
+
+			// Type the parent path + "/alpha" so the picker queries the parent
+			// and filters by basename "alpha".
+			await input.fill(join(parent, "alpha"));
+
+			// Wait for the absolutely-positioned suggestion overlay to render with
+			// at least one suggestion whose data-path comes from our fixture parent.
+			// The picker can briefly show a recents-derived list during the 200ms
+			// debounce; poll until the basename-filtered browse result lands so the
+			// arrow-down assertion isn't racing the lookup.
+			const overlay = page.locator(ADD_PROJECT.pickerSuggestions);
+			await expect(overlay).toBeVisible({ timeout: 5_000 });
+			await expect.poll(
+				async () => {
+					const paths = await overlay
+						.locator(ADD_PROJECT.pickerSuggestion)
+						.evaluateAll((els) => els.map((el) => el.getAttribute("data-path") ?? ""));
+					return paths.filter((p) => p.includes("alpha-")).length;
+				},
+				{ timeout: 8_000 },
+			).toBeGreaterThanOrEqual(1);
+
+			// ArrowDown moves to the next suggestion. The picker auto-highlights
+			// index 0 after a successful lookup, so ArrowDown bumps to index 1 if
+			// it exists. We don't care which alpha-* matches — just that the
+			// highlighted suggestion is one of our fixture children.
+			await input.press("ArrowDown");
+			const highlighted = overlay.locator('[role="option"][aria-selected="true"]').first();
+			await expect(highlighted).toBeVisible();
+			const pickedPath = await highlighted.getAttribute("data-path");
+			expect(pickedPath).toBeTruthy();
+			expect(pickedPath!).toContain("alpha-");
+
+			// Press Enter — picker should fire directory-select; input value
+			// updates to the chosen suggestion and the overlay closes.
+			await input.press("Enter");
+			await expect(overlay).toHaveCount(0, { timeout: 2_000 });
+			await expect(input).toHaveValue(pickedPath!);
+
+			// Preflight re-runs against the new path (source = "suggestion" runs
+			// immediate detection/preflight; not debounced).
+			const rendered = await waitForPreflight(page);
+			expect(rendered).toBe(true);
+			const panel = page.locator(ADD_PROJECT.preflightPanel);
+			await expect(panel).toBeVisible();
+			// The path.absolute / path.exists checks should be present for the
+			// chosen path.
+			await expect(
+				page.locator('[data-testid="preflight-check"][data-check-id="path.exists"]'),
+			).toBeVisible({ timeout: 5_000 });
+
+			// Re-open the suggestion list by typing a single character so we can
+			// exercise the Esc-closes-suggestions-then-Esc-closes-dialog branch.
+			await input.focus();
+			// Use keyboard so the picker re-runs its lookup. Re-fill to a
+			// prefix that still matches.
+			await input.fill(join(parent, "alpha"));
+			await expect(overlay).toBeVisible({ timeout: 5_000 });
+
+			// First Escape closes the suggestion overlay only.
+			await input.press("Escape");
+			await expect(overlay).toHaveCount(0, { timeout: 2_000 });
+			// Dialog still open.
+			await expect(page.locator(ADD_PROJECT.dialog)).toBeVisible();
+
+			// Second Escape bubbles directory-cancel → cleanup() closes dialog.
+			await input.press("Escape");
+			await expect(page.locator(ADD_PROJECT.dialog)).toHaveCount(0, { timeout: 5_000 });
+		} finally {
+			try { rmSync(parent, { recursive: true, force: true }); } catch { /* best-effort */ }
+		}
+	});
+});

--- a/tests/error-modal-call-sites.test.ts
+++ b/tests/error-modal-call-sites.test.ts
@@ -35,11 +35,10 @@ const REQUIRED_CALL_SITES: Site[] = [
 	{ file: "src/app/tool-manager-page.ts", title: "Failed to create tool assistant" },
 	{ file: "src/app/dialogs.ts", title: "Failed to create goal assistant" },
 	{ file: "src/app/dialogs.ts", title: "Failed to create project assistant" },
-	// 4 = 2 legacy `showProjectDialog` + 2 V2 `showProjectDialogV2`
-	// (each dialog handles both the !res.ok branch and the catch branch).
-	{ file: "src/app/dialogs.ts", title: "Failed to archive .bobbit/", count: 4 },
-	// 2 = 1 legacy + 1 V2 (symlink-confirm retry path in each).
-	{ file: "src/app/dialogs.ts", title: "Failed to register project", count: 2 },
+	// 2 = the !res.ok branch and the catch branch in showProjectDialog.
+	{ file: "src/app/dialogs.ts", title: "Failed to archive .bobbit/", count: 2 },
+	// 1 = the symlink-confirm retry path in showProjectDialog.
+	{ file: "src/app/dialogs.ts", title: "Failed to register project", count: 1 },
 	{ file: "src/app/proposal-panels.ts", title: "Failed to create goal", count: 2 },
 	{ file: "src/app/session-manager.ts", title: "Connection Failed" },
 ];

--- a/tests/error-modal-call-sites.test.ts
+++ b/tests/error-modal-call-sites.test.ts
@@ -35,8 +35,11 @@ const REQUIRED_CALL_SITES: Site[] = [
 	{ file: "src/app/tool-manager-page.ts", title: "Failed to create tool assistant" },
 	{ file: "src/app/dialogs.ts", title: "Failed to create goal assistant" },
 	{ file: "src/app/dialogs.ts", title: "Failed to create project assistant" },
-	{ file: "src/app/dialogs.ts", title: "Failed to archive .bobbit/", count: 2 },
-	{ file: "src/app/dialogs.ts", title: "Failed to register project" },
+	// 4 = 2 legacy `showProjectDialog` + 2 V2 `showProjectDialogV2`
+	// (each dialog handles both the !res.ok branch and the catch branch).
+	{ file: "src/app/dialogs.ts", title: "Failed to archive .bobbit/", count: 4 },
+	// 2 = 1 legacy + 1 V2 (symlink-confirm retry path in each).
+	{ file: "src/app/dialogs.ts", title: "Failed to register project", count: 2 },
 	{ file: "src/app/proposal-panels.ts", title: "Failed to create goal", count: 2 },
 	{ file: "src/app/session-manager.ts", title: "Connection Failed" },
 ];

--- a/tests/project-assistant-autoprompt.test.ts
+++ b/tests/project-assistant-autoprompt.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Golden-output tests for `formatProjectAssistantAutoPrompt`.
+ *
+ * This pins the exact text the Add-Project flow sends to the project-assistant
+ * on its first turn. The server-side prompt in
+ * `src/server/agent/project-assistant.ts` is taught to recognise the
+ * "User-confirmed initial repo/subdirectory selection" block by its literal
+ * header and the fenced ```json``` payload — if you change the format below,
+ * update that prompt + its tests at the same time.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+	formatProjectAssistantAutoPrompt,
+	type ProjectScanItem,
+	type ProjectAssistantScanContext,
+} from "../src/app/project-assistant-autoprompt.ts";
+
+const apiItem: ProjectScanItem = {
+	id: "repo:api",
+	kind: "repo",
+	label: "api",
+	repo: "api",
+	absolutePath: "/work/proj/api",
+	hasGit: true,
+	detectedCommands: { build: "npm run build", test: "npm test" },
+};
+const webItem: ProjectScanItem = {
+	id: "repo:web",
+	kind: "repo",
+	label: "web",
+	repo: "web",
+	absolutePath: "/work/proj/web",
+	hasGit: true,
+	detectedCommands: { build: "npm run build" },
+};
+const docsItem: ProjectScanItem = {
+	id: "repo:docs",
+	kind: "repo",
+	label: "docs",
+	repo: "docs",
+	absolutePath: "/work/proj/docs",
+	hasGit: false,
+	detectedCommands: {},
+};
+
+const mApi: ProjectScanItem = {
+	id: "workspace:packages/api",
+	kind: "workspace",
+	label: "packages/api",
+	repo: ".",
+	relativePath: "packages/api",
+	absolutePath: "/work/mono/packages/api",
+	hasGit: false,
+	detectedCommands: { build: "pnpm --filter api build" },
+};
+const mWeb: ProjectScanItem = {
+	id: "workspace:packages/web",
+	kind: "workspace",
+	label: "packages/web",
+	repo: ".",
+	relativePath: "packages/web",
+	absolutePath: "/work/mono/packages/web",
+	hasGit: false,
+	detectedCommands: { build: "pnpm --filter web build" },
+};
+
+describe("formatProjectAssistantAutoPrompt", () => {
+	it("(a) plain new-project path produces the historical opener", () => {
+		const out = formatProjectAssistantAutoPrompt({ dirPath: "/work/proj" });
+		assert.equal(out, "Start the project registration session. The project directory is: /work/proj");
+	});
+
+	it("(b) scaffolding switches to the new-project setup opener", () => {
+		const out = formatProjectAssistantAutoPrompt({ dirPath: "/work/new", scaffolding: true });
+		assert.equal(out, "Start the new project setup session. The target directory is: /work/new");
+	});
+
+	it("(c) edit-existing produces the verbatim edit-mode opener", () => {
+		const out = formatProjectAssistantAutoPrompt({
+			dirPath: "/work/proj",
+			editContext: { name: "my-api", rootPath: "/work/proj" },
+		});
+		assert.equal(
+			out,
+			"Edit the existing project 'my-api' at /work/proj. Read its current `.bobbit/config/project.yaml` and propose it back as-is via `propose_project`, then ask the user what they want to change or add.",
+		);
+	});
+
+	it("(c2) editContext takes precedence over scaffolding + initialScanContext", () => {
+		const out = formatProjectAssistantAutoPrompt({
+			dirPath: "/work/proj",
+			scaffolding: true,
+			editContext: { name: "x", rootPath: "/work/proj" },
+			initialScanContext: { rootPath: "/work/proj", items: [apiItem], selectedIds: ["repo:api"] },
+		});
+		assert.ok(out.startsWith("Edit the existing project 'x'"));
+	});
+
+	it("(d) subset selection with 2-of-3 multi-repo items emits English summary + JSON block", () => {
+		const ctx: ProjectAssistantScanContext = {
+			rootPath: "/work/proj",
+			items: [apiItem, webItem, docsItem],
+			selectedIds: ["repo:api", "repo:web"],
+		};
+		const out = formatProjectAssistantAutoPrompt({ dirPath: "/work/proj", initialScanContext: ctx });
+
+		// Opener line preserved verbatim.
+		assert.ok(out.startsWith("Start the project registration session. The project directory is: /work/proj\n"),
+			"prompt must start with the canonical new-project opener");
+
+		// English summary.
+		assert.ok(out.includes("User-confirmed initial repo/subdirectory selection from Add Project:"),
+			"prompt must include the literal header recognised by the server prompt");
+		assert.ok(out.includes("- Selected 2 of 3 repo/subdirectory candidates: `api`, `web`"));
+		assert.ok(out.includes("- Not selected: `docs`"));
+		assert.ok(out.includes("- Treat only the selected repos/subdirectories as candidates for the initial `propose_project.components`."));
+		assert.ok(out.includes("- Do not include unselected entries by default, but tell the user they can add them back."));
+
+		// Machine-readable JSON block.
+		assert.ok(out.includes("Machine-readable selection:"));
+		const fenceStart = out.indexOf("```json\n");
+		const fenceEnd = out.indexOf("\n```", fenceStart + 1);
+		assert.ok(fenceStart >= 0 && fenceEnd > fenceStart, "must contain a ```json ... ``` fenced block");
+		const json = out.slice(fenceStart + "```json\n".length, fenceEnd);
+		const parsed = JSON.parse(json) as ProjectAssistantScanContext;
+		assert.equal(parsed.rootPath, "/work/proj");
+		assert.deepEqual(parsed.selectedIds, ["repo:api", "repo:web"]);
+		assert.equal(parsed.items.length, 3);
+		assert.equal(parsed.items[0].id, "repo:api");
+		assert.equal(parsed.items[2].id, "repo:docs");
+		// Items must carry the full normalized shape so the assistant can lift them straight into components.
+		assert.deepEqual(parsed.items[0].detectedCommands, { build: "npm run build", test: "npm test" });
+	});
+
+	it("(e) subset with all selected uses the '(none ... all candidates selected)' wording", () => {
+		const ctx: ProjectAssistantScanContext = {
+			rootPath: "/work/proj",
+			items: [apiItem, webItem],
+			selectedIds: ["repo:api", "repo:web"],
+		};
+		const out = formatProjectAssistantAutoPrompt({ dirPath: "/work/proj", initialScanContext: ctx });
+		assert.ok(out.includes("- Selected 2 of 2 repo/subdirectory candidates: `api`, `web`"));
+		assert.ok(out.includes("- Not selected: (none — all candidates selected)"));
+	});
+
+	it("(f) subset with monorepo workspaces emits the workspace labels and preserves relativePath in JSON", () => {
+		const ctx: ProjectAssistantScanContext = {
+			rootPath: "/work/mono",
+			items: [mApi, mWeb],
+			selectedIds: ["workspace:packages/api"],
+		};
+		const out = formatProjectAssistantAutoPrompt({ dirPath: "/work/mono", initialScanContext: ctx });
+		assert.ok(out.includes("- Selected 1 of 2 repo/subdirectory candidates: `packages/api`"));
+		assert.ok(out.includes("- Not selected: `packages/web`"));
+		const fenceStart = out.indexOf("```json\n");
+		const fenceEnd = out.indexOf("\n```", fenceStart + 1);
+		const json = JSON.parse(out.slice(fenceStart + "```json\n".length, fenceEnd)) as ProjectAssistantScanContext;
+		assert.equal(json.items[0].relativePath, "packages/api");
+		assert.equal(json.items[0].kind, "workspace");
+		assert.equal(json.items[0].repo, ".");
+	});
+
+	it("empty items array falls back to the plain new-project opener (no subset block)", () => {
+		const ctx: ProjectAssistantScanContext = {
+			rootPath: "/work/proj",
+			items: [],
+			selectedIds: [],
+		};
+		const out = formatProjectAssistantAutoPrompt({ dirPath: "/work/proj", initialScanContext: ctx });
+		assert.equal(out, "Start the project registration session. The project directory is: /work/proj");
+	});
+
+	it("selectedIds order is normalized to items display order", () => {
+		// selectedIds passed in reverse order — re-serialized JSON must follow items[] order.
+		const ctx: ProjectAssistantScanContext = {
+			rootPath: "/work/proj",
+			items: [apiItem, webItem, docsItem],
+			selectedIds: ["repo:web", "repo:api"],
+		};
+		const out = formatProjectAssistantAutoPrompt({ dirPath: "/work/proj", initialScanContext: ctx });
+		// English summary lists in items order.
+		assert.ok(out.includes("- Selected 2 of 3 repo/subdirectory candidates: `api`, `web`"),
+			"English label list should follow items[] display order, not input selectedIds order");
+		// JSON selectedIds also re-serialized in display order.
+		const fenceStart = out.indexOf("```json\n");
+		const fenceEnd = out.indexOf("\n```", fenceStart + 1);
+		const json = JSON.parse(out.slice(fenceStart + "```json\n".length, fenceEnd)) as ProjectAssistantScanContext;
+		assert.deepEqual(json.selectedIds, ["repo:api", "repo:web"]);
+	});
+
+	it("unknown selectedId is rendered using the id itself as a fallback label", () => {
+		// Defensive: if a stale id slips into selectedIds the prompt still renders
+		// (with the id verbatim) instead of crashing.
+		const ctx: ProjectAssistantScanContext = {
+			rootPath: "/work/proj",
+			items: [apiItem],
+			selectedIds: ["repo:api", "repo:ghost"],
+		};
+		const out = formatProjectAssistantAutoPrompt({ dirPath: "/work/proj", initialScanContext: ctx });
+		// Ghost id is filtered out of orderedSelected (since it isn't in items),
+		// so the English list only mentions `api`.
+		assert.ok(out.includes("- Selected 1 of 1 repo/subdirectory candidates: `api`"));
+	});
+});


### PR DESCRIPTION
## Summary

Rewrites the Add Project flow with a reusable `<directory-picker>` primitive, a dedicated browse modal, and a stable-footer dialog shell. Fixes the multi-repo selection handoff bug: the user-confirmed repo/subdirectory subset now reaches the project assistant's first turn (previously dropped on the floor between `confirmScanAndContinue()` and `createProjectAssistantSession()`).

User drove the prototype against real APIs and signed off before promotion.

## What changed

- **New** `src/ui/components/DirectoryPicker.ts` — reusable light-DOM Lit primitive. Data-driven (caller injects `browseDirectory`), event-based (`directory-input`, `directory-select`, `directory-commit`, `directory-browse-request`, `directory-cancel`). Absolute-positioned typeahead overlay so suggestions don't shift surrounding layout. Suitable for future surfaces (settings, goal-cwd, etc.).
- **New** `src/app/project-assistant-autoprompt.ts` — pure `formatProjectAssistantAutoPrompt()` helper + `ProjectScanItem` / `ProjectAssistantScanContext` types. Single source of truth for the project-assistant first-turn prompt across plain / scaffolding / edit / subset cases.
- **Rewritten** `src/app/dialogs.ts::showProjectDialog` — fixed shell (`min(720px, 94vw)` × `min(720px, 92vh)`), persistent footer (byte-stable position across every state), two steps (`path` → `scan`), reserved slots for status + preflight, integrated `<directory-picker>`, new `openProjectBrowseDialog()` helper for the dedicated browse overlay, multi-repo subset handoff via `createProjectAssistantSession(path, false, { initialScanContext })`. Legacy ~465-line implementation deleted.
- **Extended** `src/app/api.ts::scanProject` — returns the full server `{ repos, monorepo }` payload. Legacy `scanProjectRepos` preserved as back-compat wrapper.
- **Extended** `src/app/session-manager.ts::connectToSession` — accepts `projectInitialScanContext?` and routes all three auto-prompt branches through the new formatter.
- **Extended** `src/server/agent/project-assistant.ts` — system prompt teaches the assistant to treat `selectedIds` as authoritative initial component candidates and to mention unselected entries in chat.

## Verification

- `npm run check` — passes.
- `npm run test:unit` — 2200 pass / 1 pre-existing fail (`preview-content-route.test.ts`, unrelated, confirmed on master) / 8 skip. New `tests/project-assistant-autoprompt.test.ts` — 10/10 green.
- Browser E2E for the full add-project surface (10 specs) — all pre-existing specs (`add-project-flow`, `add-project-preflight`, `add-project-post-archive`, `add-project-symlink`, `project-detect-browse`) still pass, plus five new specs pinning V2 invariants:
  - `add-project-typeahead.spec.ts` — overlay → arrow → Enter selects, re-runs preflight; Esc layering.
  - `add-project-footer-stability.spec.ts` — footer bounding box ±1px invariant across 6 state transitions.
  - `add-project-browse-modal.spec.ts` — navigate, Up, Select current, focus return.
  - `add-project-multi-repo-subset.spec.ts` — captures WebSocket frame; asserts both English bullet AND fenced JSON `{ rootPath, items, selectedIds }`.
  - `add-project-select-all.spec.ts` — counts and disabled-Continue invariant.
- Implementation gate passed all 8 verification steps (build, typecheck, unit, E2E, gap analysis, code quality review, security review, agent QA).
- Documentation gate passed (LLM coverage review).

## Design record

[`docs/design/project-onboarding-ux.md`](docs/design/project-onboarding-ux.md) — 10 decision records covering prototype-first sequencing, light-DOM primitive shape, browse-modal vs in-dialog list, footer stability strategy, repo/subdirectory wording, the auto-prompt + JSON handoff (zero `/api/sessions` contract change), normalized `ProjectScanItem` + `Set<id>` selection model, `scanProject` vs `scanProjectRepos` compatibility, Esc-layering invariant, and the `ProjectPickerPopover` boundary.

## Workflow

Tracked in goal `goal/project-onboar-c34ea1c5` (Tasks A–E). All four DAG gates (design-doc, implementation, documentation) passed verification cleanly.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
