### PR TITLE
Respect direct naming models

### DIFF
--- a/src/server/agent/model-completion.ts
+++ b/src/server/agent/model-completion.ts
@@ -1,0 +1,140 @@
+import { completeSimple, type Api, type Model, type ModelThinkingLevel } from "@earendil-works/pi-ai";
+import { existsSync, readFileSync } from "node:fs";
+import { refreshOAuthToken } from "../auth/oauth.js";
+import { globalAuthPath } from "../bobbit-dir.js";
+import type { PreferencesStore } from "./preferences-store.js";
+import { getAvailableModels, type ApiModel, type CustomProviderConfig } from "./model-registry.js";
+
+interface AuthCredentials {
+	type: string;
+	access: string;
+	refresh?: string;
+	expires?: number;
+}
+
+function loadAnthropicAuth(): AuthCredentials | null {
+	const authPath = globalAuthPath();
+	if (!existsSync(authPath)) return null;
+	try {
+		const data = JSON.parse(readFileSync(authPath, "utf-8"));
+		const cred = data.anthropic;
+		if (!cred) return null;
+		if (cred.type === "oauth" && cred.access) return cred;
+		if (cred.type === "api-key" && cred.key) return { type: "api-key", access: cred.key };
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+async function resolveProviderApiKey(prefs: PreferencesStore | undefined, provider: string): Promise<string | undefined> {
+	const stored = prefs?.get(`providerKey.${provider}`);
+	if (typeof stored === "string" && stored.trim()) return stored.trim();
+
+	if (provider === "anthropic") {
+		const auth = loadAnthropicAuth();
+		if (auth?.type === "oauth" && auth.expires && Date.now() > auth.expires) {
+			const refreshed = await refreshOAuthToken();
+			if (refreshed) return refreshed;
+		}
+		if (auth?.access) return auth.access;
+	}
+
+	const configs = (prefs?.get("customProviders") as CustomProviderConfig[] | undefined) || [];
+	const custom = configs.find(c => (c.name || c.id) === provider || c.id === provider);
+	if (custom) return custom.apiKey?.trim() || "none";
+
+	return undefined;
+}
+
+export function toPiModel(model: ApiModel): Model<Api> {
+	return {
+		id: model.id,
+		name: model.name || model.id,
+		api: model.api as Api,
+		provider: model.provider,
+		baseUrl: model.baseUrl || "",
+		reasoning: !!model.reasoning,
+		...(model.thinkingLevelMap ? { thinkingLevelMap: model.thinkingLevelMap as any } : {}),
+		input: model.input || ["text"],
+		cost: model.cost || { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: model.contextWindow || 8192,
+		maxTokens: model.maxTokens || 4096,
+		...((model as any).headers ? { headers: (model as any).headers } : {}),
+		...((model as any).compat ? { compat: (model as any).compat } : {}),
+	};
+}
+
+function assistantText(message: any): string {
+	return (message?.content || [])
+		.filter((c: any) => c?.type === "text")
+		.map((c: any) => c.text || "")
+		.join("")
+		.trim();
+}
+
+export async function completeModelText(
+	model: ApiModel,
+	prefs: PreferencesStore | undefined,
+	args: {
+		systemPrompt: string;
+		userPrompt: string;
+		maxTokens?: number;
+		thinkingLevel?: ModelThinkingLevel;
+		timeoutMs?: number;
+	},
+): Promise<string> {
+	const apiKey = await resolveProviderApiKey(prefs, model.provider);
+	const options: Record<string, any> = {
+		maxTokens: args.maxTokens ?? 500,
+		timeoutMs: args.timeoutMs ?? 30_000,
+		maxRetries: 0,
+		cacheRetention: "none",
+		...(apiKey ? { apiKey } : {}),
+	};
+	if (args.thinkingLevel && args.thinkingLevel !== "off") {
+		options.reasoning = args.thinkingLevel;
+	}
+
+	const result = await completeSimple(toPiModel(model) as any, {
+		systemPrompt: args.systemPrompt,
+		messages: [{ role: "user", content: args.userPrompt, timestamp: Date.now() }],
+	}, options);
+
+	if ((result as any).stopReason === "error") {
+		throw new Error((result as any).errorMessage || "Model returned an error");
+	}
+	return assistantText(result);
+}
+
+export async function testModelPreference(
+	prefs: PreferencesStore,
+	pref: string,
+	completer: typeof completeModelText = completeModelText,
+): Promise<{ ok: boolean; modelResolved?: string; latencyMs?: number; error?: string; status?: number }> {
+	const slash = pref.indexOf("/");
+	if (slash <= 0 || slash >= pref.length - 1) {
+		return { ok: false, status: 400, error: "Malformed pref — expected 'provider/modelId'" };
+	}
+	const provider = pref.slice(0, slash);
+	const modelId = pref.slice(slash + 1);
+	const models = await getAvailableModels(prefs);
+	const model = models.find((m) => m.provider === provider && m.id === modelId);
+	if (!model) {
+		return { ok: false, status: 404, error: `Model "${pref}" is not in the current available-models list. It may be a stale preference.` };
+	}
+
+	const started = Date.now();
+	try {
+		await completer(model, prefs, {
+			systemPrompt: "You are a connection test. Reply with OK.",
+			userPrompt: "Reply with OK",
+			maxTokens: 5,
+			thinkingLevel: "off",
+			timeoutMs: 15_000,
+		});
+		return { ok: true, modelResolved: model.id, latencyMs: Date.now() - started };
+	} catch (err: any) {
+		return { ok: false, modelResolved: model.id, latencyMs: Date.now() - started, error: err?.message || "Request failed" };
+	}
+}

--- a/src/server/agent/model-registry.ts
+++ b/src/server/agent/model-registry.ts
@@ -32,6 +32,8 @@ export interface ApiModel {
 	thinkingLevelMap?: Record<string, string | null>;
 	input: ("text" | "image")[];
 	cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
+	headers?: Record<string, string>;
+	compat?: unknown;
 	authenticated: boolean;
 }
 
@@ -158,6 +160,8 @@ async function assembleModels(prefs: PreferencesStore): Promise<ApiModel[]> {
 						...(m.thinkingLevelMap ? { thinkingLevelMap: m.thinkingLevelMap as Record<string, string | null> } : {}),
 						input: (meta.input && meta.input.length > (m.input?.length || 0)) ? meta.input : (m.input || ["text"]) as ("text" | "image")[],
 						cost: m.cost || { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						...((m as any).headers ? { headers: (m as any).headers } : {}),
+						...((m as any).compat ? { compat: (m as any).compat } : {}),
 						authenticated: isAuth,
 					});
 				}

--- a/src/server/agent/openai-model-additions.ts
+++ b/src/server/agent/openai-model-additions.ts
@@ -180,6 +180,8 @@ const ADDITION_FIELD_SAMPLE: Record<keyof Omit<OpenAIAddition, "id" | "provider"
 	cost: true,
 	contextWindow: true,
 	maxTokens: true,
+	headers: true,
+	compat: true,
 };
 const ADDITION_FIELDS: Array<keyof OpenAIAddition> = Object.keys(ADDITION_FIELD_SAMPLE) as Array<keyof OpenAIAddition>;
 

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -4607,8 +4607,7 @@ export class SessionManager {
 	private getTitleGenOptions(): import("./title-generator.js").TitleGenOptions {
 		const namingModel = this.preferencesStore?.get("default.namingModel") as string | undefined;
 		const aigwUrl = this.preferencesStore ? getAigwUrl(this.preferencesStore) : undefined;
-		const namingThinking = this.preferencesStore?.get("default.namingThinkingLevel") as string | undefined;
-		return { namingModel: namingModel || undefined, aigwUrl, thinkingLevel: namingThinking || undefined };
+		return { namingModel: namingModel || undefined, aigwUrl, thinkingLevel: "off", preferencesStore: this.preferencesStore };
 	}
 
 	private async autoGenerateTitleFromText(session: SessionInfo, userText: string): Promise<void> {

--- a/src/server/agent/title-generator.ts
+++ b/src/server/agent/title-generator.ts
@@ -10,7 +10,9 @@ import { existsSync, readFileSync } from "node:fs";
 import { refreshOAuthToken } from "../auth/oauth.js";
 import { globalAuthPath } from "../bobbit-dir.js";
 import { discoverAigwModels } from "./aigw-manager.js";
-import { modelRecencyRank } from "./model-registry.js";
+import { completeModelText } from "./model-completion.js";
+import { getAvailableModels, modelRecencyRank, type ApiModel } from "./model-registry.js";
+import type { PreferencesStore } from "./preferences-store.js";
 
 /** Cache for the fallback naming model id, keyed by gateway URL. TTL ~60s. */
 let _fallbackCache: { url: string; modelId: string | null; expiresAt: number } | null = null;
@@ -69,6 +71,12 @@ export interface TitleGenOptions {
 	aigwUrl?: string;
 	/** Thinking level for title generation: "off"|"minimal"|"low"|"medium"|"high"|"xhigh" */
 	thinkingLevel?: string;
+	/** Preferences are needed to resolve and authenticate non-AI-Gateway naming models. */
+	preferencesStore?: PreferencesStore;
+	/** Test hook: supplies available models without reading preferences. */
+	availableModels?: ApiModel[] | (() => Promise<ApiModel[]>);
+	/** Test hook: performs the direct-model completion. */
+	directModelCompleter?: (model: ApiModel, args: { systemPrompt: string; userPrompt: string; maxTokens: number; thinkingLevel: "off" }) => Promise<string | null>;
 }
 
 interface AuthCredentials {
@@ -283,7 +291,41 @@ async function generateViaGateway(aigwUrl: string, modelId: string, preview: str
 /**
  * Generate title via direct Anthropic API call.
  */
-async function generateViaAnthropic(preview: string, thinkingLevel?: string): Promise<string | null> {
+async function getOptionModels(options: TitleGenOptions): Promise<ApiModel[]> {
+	if (Array.isArray(options.availableModels)) return options.availableModels;
+	if (typeof options.availableModels === "function") return options.availableModels();
+	if (options.preferencesStore) return getAvailableModels(options.preferencesStore);
+	return [];
+}
+
+async function findConfiguredModel(pref: string, options: TitleGenOptions): Promise<{ provider: string; modelId: string; model?: ApiModel } | null> {
+	const slash = pref.indexOf("/");
+	if (slash <= 0 || slash >= pref.length - 1) {
+		console.warn(`[title-gen] Malformed namingModel preference: "${pref}", ignoring`);
+		return null;
+	}
+	const provider = pref.slice(0, slash);
+	const modelId = pref.slice(slash + 1);
+	const models = await getOptionModels(options);
+	return { provider, modelId, model: models.find(m => m.provider === provider && m.id === modelId) };
+}
+
+async function generateViaConfiguredDirectModel(model: ApiModel, userPrompt: string, systemPrompt: string, options: TitleGenOptions): Promise<string | null> {
+	try {
+		const text = options.directModelCompleter
+			? await options.directModelCompleter(model, { systemPrompt, userPrompt, maxTokens: 500, thinkingLevel: "off" })
+			: await completeModelText(model, options.preferencesStore, { systemPrompt, userPrompt, maxTokens: 500, thinkingLevel: "off" });
+		if (!text) return null;
+		const title = cleanTitle(text);
+		console.log(`[title-gen] Generated title: "${title}"`);
+		return title || null;
+	} catch (err) {
+		console.error(`[title-gen] Direct model "${model.provider}/${model.id}" failed:`, err);
+		return null;
+	}
+}
+
+async function generateViaAnthropic(preview: string, thinkingLevel?: string, modelId = DEFAULT_TITLE_MODEL): Promise<string | null> {
 	let auth = loadAuth();
 	if (!auth) return null;
 
@@ -315,7 +357,7 @@ async function generateViaAnthropic(preview: string, thinkingLevel?: string): Pr
 		: coreInstruction;
 
 	const body: any = {
-		model: DEFAULT_TITLE_MODEL,
+		model: modelId,
 		// Bumped from 12 → 500 to tolerate brief reasoning preamble (see gateway path).
 		max_tokens: 500,
 		system: auth.type === "oauth"
@@ -339,7 +381,7 @@ async function generateViaAnthropic(preview: string, thinkingLevel?: string): Pr
 		}
 	}
 
-	console.log(`[title-gen] Requesting title via ${DEFAULT_TITLE_MODEL}…`);
+	console.log(`[title-gen] Requesting title via ${modelId}…`);
 
 	try {
 		let response = await fetch(ANTHROPIC_API_URL, {
@@ -399,14 +441,25 @@ export async function generateSessionTitle(messages: any[], options?: TitleGenOp
 		return null;
 	}
 
-	// If a naming model is configured and we have a gateway, use it
-	if (options?.namingModel && options.aigwUrl) {
-		const slash = options.namingModel.indexOf("/");
-		if (slash > 0 && slash < options.namingModel.length - 1) {
-			const modelId = options.namingModel.slice(slash + 1);
-			return generateViaGateway(options.aigwUrl, modelId, preview, options.thinkingLevel);
+	// If a naming model is configured, respect its provider. AI Gateway models
+	// still use the gateway path; direct/custom models use pi-ai. Title
+	// generation is intentionally forced to thinking=off for cost and latency.
+	if (options?.namingModel) {
+		const configured = await findConfiguredModel(options.namingModel, options);
+		if (configured) {
+			if (configured.provider === "aigw" && options.aigwUrl) {
+				return generateViaGateway(options.aigwUrl, configured.modelId, preview, "off");
+			}
+			if (configured.model) {
+				const userPrompt = `Conversation:\n\n---\n${preview}\n---\n\nReply with ONLY <title>YOUR LABEL</title>:`;
+				const systemPrompt = "Output a 2-3 word label for this conversation. MAXIMUM 3 words. Wrap the label in <title>…</title> tags, e.g. <title>Fix Login Bug</title>. No quotes, no markdown, no explanation outside the tags. No emojis. Do NOT reason, think, or plan — emit the <title> tag as your very first tokens.";
+				return generateViaConfiguredDirectModel(configured.model, userPrompt, systemPrompt, options);
+			}
+			if (configured.provider === "anthropic") {
+				return generateViaAnthropic(preview, "off", configured.modelId);
+			}
+			console.warn(`[title-gen] Naming model "${options.namingModel}" is not available; falling back`);
 		}
-		console.warn(`[title-gen] Malformed namingModel preference: "${options.namingModel}", ignoring`);
 	}
 
 	// Gateway configured but no explicit naming model - auto-select a low-cost
@@ -416,14 +469,14 @@ export async function generateSessionTitle(messages: any[], options?: TitleGenOp
 		const fallbackId = await pickFallbackAigwNamingModel(options.aigwUrl);
 		if (fallbackId) {
 			console.log(`[title-gen] Using fallback gateway naming model "${fallbackId}"`);
-			return generateViaGateway(options.aigwUrl, fallbackId, preview, options.thinkingLevel);
+			return generateViaGateway(options.aigwUrl, fallbackId, preview, "off");
 		}
 		console.warn("[title-gen] Gateway configured but no suitable Claude naming model found; falling back to direct Anthropic API");
 	}
 
 	// Default: direct Anthropic API (works for public, gateway-less, and
 	// gateway-but-no-Claude setups).
-	return generateViaAnthropic(preview, options?.thinkingLevel);
+	return generateViaAnthropic(preview, "off");
 }
 
 // ── Goal title summarization ──────────────────────────────────────────
@@ -479,7 +532,7 @@ async function generateGoalSummaryViaGateway(aigwUrl: string, modelId: string, g
 /**
  * Generate a 3-word summary of a goal title via direct Anthropic API.
  */
-async function generateGoalSummaryViaAnthropic(goalTitle: string): Promise<string | null> {
+async function generateGoalSummaryViaAnthropic(goalTitle: string, modelId = DEFAULT_TITLE_MODEL): Promise<string | null> {
 	let auth = loadAuth();
 	if (!auth) return null;
 
@@ -510,7 +563,7 @@ async function generateGoalSummaryViaAnthropic(goalTitle: string): Promise<strin
 		: GOAL_SUMMARY_SYSTEM;
 
 	const body = {
-		model: DEFAULT_TITLE_MODEL,
+		model: modelId,
 		// Bumped from 12 → 500 to tolerate brief reasoning preamble.
 		max_tokens: 500,
 		system: auth.type === "oauth"
@@ -521,7 +574,7 @@ async function generateGoalSummaryViaAnthropic(goalTitle: string): Promise<strin
 		],
 	};
 
-	console.log(`[title-gen] Requesting goal summary via ${DEFAULT_TITLE_MODEL}…`);
+	console.log(`[title-gen] Requesting goal summary via ${modelId}…`);
 
 	try {
 		let response = await fetch(ANTHROPIC_API_URL, {
@@ -579,13 +632,21 @@ export async function generateGoalSummaryTitle(goalTitle: string, options?: Titl
 		return null;
 	}
 
-	if (options?.namingModel && options.aigwUrl) {
-		const slash = options.namingModel.indexOf("/");
-		if (slash > 0 && slash < options.namingModel.length - 1) {
-			const modelId = options.namingModel.slice(slash + 1);
-			return generateGoalSummaryViaGateway(options.aigwUrl, modelId, goalTitle);
+	if (options?.namingModel) {
+		const configured = await findConfiguredModel(options.namingModel, options);
+		if (configured) {
+			if (configured.provider === "aigw" && options.aigwUrl) {
+				return generateGoalSummaryViaGateway(options.aigwUrl, configured.modelId, goalTitle);
+			}
+			if (configured.model) {
+				const userPrompt = `Goal title:\n\n---\n${goalTitle}\n---\n\nReply with ONLY <title>YOUR 3-WORD SUMMARY</title>:`;
+				return generateViaConfiguredDirectModel(configured.model, userPrompt, GOAL_SUMMARY_SYSTEM, options);
+			}
+			if (configured.provider === "anthropic") {
+				return generateGoalSummaryViaAnthropic(goalTitle, configured.modelId);
+			}
+			console.warn(`[title-gen] Naming model "${options.namingModel}" is not available for goal summary; falling back`);
 		}
-		console.warn(`[title-gen] Malformed namingModel preference: "${options.namingModel}", ignoring`);
 	}
 
 	// Gateway configured but no explicit naming model - auto-select a low-cost

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -142,6 +142,7 @@ import { configureAigw, removeAigw, getAigwUrl, discoverAigwModels, proxyRequest
 import { writeOpenAIModelAdditions } from "./agent/openai-model-additions.js";
 import { ReviewAnnotationStore, type ReviewAnnotation } from "./review-annotation-store.js";
 import { getAvailableModels, discoverModelsForConfig, invalidateModelCache } from "./agent/model-registry.js";
+import { testModelPreference } from "./agent/model-completion.js";
 import type { CustomProviderConfig } from "./agent/model-registry.js";
 import { canonicalImageModelPref, defaultImageModelPref, generateImage, getAvailableImageModels, imageModelMentionedInText } from "./agent/image-generation.js";
 import { ProjectRegistry, SymlinkProjectRootError, PreflightFailedError, SYSTEM_PROJECT_ID, ProjectOrderError } from "./agent/project-registry.js";
@@ -4720,11 +4721,8 @@ async function handleApiRoute(
 				return;
 			}
 			if (provider !== "aigw") {
-				json({
-					ok: false,
-					modelResolved: resolved.id,
-					error: "Test not supported for this provider yet — only AI Gateway models can be tested from here.",
-				}, 422);
+				const result = await testModelPreference(preferencesStore, pref);
+				json(result, result.status || (result.ok ? 200 : 502));
 				return;
 			}
 			const aigwUrl = getAigwUrl(preferencesStore);

--- a/tests/title-generator-direct-model.test.ts
+++ b/tests/title-generator-direct-model.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+import { PreferencesStore } from "../src/server/agent/preferences-store.js";
+import { invalidateModelCache, type ApiModel } from "../src/server/agent/model-registry.js";
+import { generateSessionTitle } from "../src/server/agent/title-generator.js";
+import { testModelPreference } from "../src/server/agent/model-completion.js";
+
+const previousSkipTitleGen = process.env.BOBBIT_SKIP_TITLE_GEN;
+const directModel: ApiModel = {
+	id: "direct-title-model",
+	name: "Direct Title Model",
+	provider: "direct",
+	api: "openai-completions",
+	baseUrl: "http://127.0.0.1:9/v1",
+	contextWindow: 8192,
+	maxTokens: 4096,
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	authenticated: true,
+};
+
+afterEach(() => {
+	if (previousSkipTitleGen === undefined) delete process.env.BOBBIT_SKIP_TITLE_GEN;
+	else process.env.BOBBIT_SKIP_TITLE_GEN = previousSkipTitleGen;
+	invalidateModelCache();
+});
+
+function prefsWithManualProvider(): { prefs: PreferencesStore; dir: string } {
+	const dir = mkdtempSync(path.join(tmpdir(), "bobbit-title-direct-"));
+	const prefs = new PreferencesStore(dir);
+	prefs.set("customProviders", [{
+		id: "direct",
+		name: "direct",
+		type: "manual",
+		baseUrl: "http://127.0.0.1:9",
+		apiKey: "sk-test",
+		models: [{ id: "direct-title-model", name: "Direct Title Model" }],
+	}]);
+	return { prefs, dir };
+}
+
+describe("title generation with non-AI-Gateway naming models", () => {
+	it("uses the configured direct naming model and forces thinking off", async () => {
+		delete process.env.BOBBIT_SKIP_TITLE_GEN;
+		const calls: any[] = [];
+		const title = await generateSessionTitle(
+			[{ role: "user", content: "Please fix the direct model title path." }],
+			{
+				namingModel: "direct/direct-title-model",
+				thinkingLevel: "high",
+				availableModels: [directModel],
+				directModelCompleter: async (model, args) => {
+					calls.push({ model, args });
+					return "<title>Direct Works</title>";
+				},
+			},
+		);
+		assert.equal(title, "Direct Works");
+		assert.equal(calls.length, 1);
+		assert.equal(calls[0].model.provider, "direct");
+		assert.equal(calls[0].model.id, "direct-title-model");
+		assert.equal(calls[0].args.thinkingLevel, "off");
+	});
+
+	it("model test helper works for non-AI-Gateway models", async () => {
+		const { prefs, dir } = prefsWithManualProvider();
+		const calls: any[] = [];
+		try {
+			const result = await testModelPreference(prefs, "direct/direct-title-model", async (model, _prefs, args) => {
+				calls.push({ model, args });
+				return "OK";
+			});
+			assert.equal(result.ok, true);
+			assert.equal(result.modelResolved, "direct-title-model");
+			assert.equal(calls.length, 1);
+			assert.equal(calls[0].model.provider, "direct");
+			assert.equal(calls[0].model.id, "direct-title-model");
+			assert.equal(calls[0].args.thinkingLevel, "off");
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- Respect non-AI-Gateway naming models for title generation
- Force title generation thinking level off
- Enable Settings model Test for direct/custom providers via shared completion helper
- Add regression coverage for direct naming models and model tests

## Verification
- npm run check
- npx tsx --test --test-force-exit tests/title-generator-direct-model.test.ts
- npm run test:unit

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)