### PR TITLE
Reuse chat auth for model tests

### DIFF
--- a/src/server/agent/model-completion.ts
+++ b/src/server/agent/model-completion.ts
@@ -1,50 +1,97 @@
 import { completeSimple, type Api, type Model, type ModelThinkingLevel } from "@earendil-works/pi-ai";
+import { execSync } from "node:child_process";
+import path from "node:path";
 import { existsSync, readFileSync } from "node:fs";
 import { refreshOAuthToken } from "../auth/oauth.js";
-import { globalAuthPath } from "../bobbit-dir.js";
+import { globalAgentDir, globalAuthPath } from "../bobbit-dir.js";
 import type { PreferencesStore } from "./preferences-store.js";
 import { getAvailableModels, type ApiModel, type CustomProviderConfig } from "./model-registry.js";
 
 interface AuthCredentials {
 	type: string;
-	access: string;
+	access?: string;
+	key?: string;
 	refresh?: string;
 	expires?: number;
 }
 
-function loadAnthropicAuth(): AuthCredentials | null {
+const PROVIDER_ENV_KEYS: Record<string, string[]> = {
+	anthropic: ["ANTHROPIC_API_KEY", "ANTHROPIC_OAUTH_TOKEN"],
+	openai: ["OPENAI_API_KEY"],
+	"openai-codex": ["OPENAI_API_KEY"],
+	google: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+	"google-gemini-cli": ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+	xai: ["XAI_API_KEY"],
+	groq: ["GROQ_API_KEY"],
+	mistral: ["MISTRAL_API_KEY"],
+	openrouter: ["OPENROUTER_API_KEY"],
+};
+
+function loadAuthData(): Record<string, any> | null {
 	const authPath = globalAuthPath();
 	if (!existsSync(authPath)) return null;
+	try { return JSON.parse(readFileSync(authPath, "utf-8")); }
+	catch { return null; }
+}
+
+function authCredentialForProvider(provider: string): AuthCredentials | null {
+	const cred = loadAuthData()?.[provider];
+	if (!cred) return null;
+	if (cred.type === "oauth" && cred.access) return { type: "oauth", access: cred.access, refresh: cred.refresh, expires: cred.expires };
+	if ((cred.type === "api-key" || cred.type === "api_key") && cred.key) return { type: "api-key", key: cred.key };
+	if (typeof cred.key === "string" && cred.key.trim()) return { type: "api-key", key: cred.key };
+	if (typeof cred.access === "string" && cred.access.trim()) return { type: cred.type || "oauth", access: cred.access, expires: cred.expires };
+	return null;
+}
+
+function readModelsJsonProvider(provider: string): any | undefined {
 	try {
-		const data = JSON.parse(readFileSync(authPath, "utf-8"));
-		const cred = data.anthropic;
-		if (!cred) return null;
-		if (cred.type === "oauth" && cred.access) return cred;
-		if (cred.type === "api-key" && cred.key) return { type: "api-key", access: cred.key };
-		return null;
+		const p = path.join(globalAgentDir(), "models.json");
+		if (!existsSync(p)) return undefined;
+		const data = JSON.parse(readFileSync(p, "utf-8"));
+		return data?.providers?.[provider];
 	} catch {
-		return null;
+		return undefined;
 	}
+}
+
+function resolveConfigValue(value: unknown): string | undefined {
+	if (typeof value !== "string" || !value.trim()) return undefined;
+	const trimmed = value.trim();
+	if (trimmed === "none") return trimmed;
+	if (trimmed.startsWith("!")) {
+		try {
+			return execSync(trimmed.slice(1), { encoding: "utf-8", timeout: 15_000, windowsHide: true }).trim() || undefined;
+		} catch {
+			return undefined;
+		}
+	}
+	const envValue = process.env[trimmed];
+	if (envValue) return envValue;
+	return trimmed;
 }
 
 async function resolveProviderApiKey(prefs: PreferencesStore | undefined, provider: string): Promise<string | undefined> {
 	const stored = prefs?.get(`providerKey.${provider}`);
 	if (typeof stored === "string" && stored.trim()) return stored.trim();
 
-	if (provider === "anthropic") {
-		const auth = loadAnthropicAuth();
-		if (auth?.type === "oauth" && auth.expires && Date.now() > auth.expires) {
-			const refreshed = await refreshOAuthToken();
-			if (refreshed) return refreshed;
-		}
-		if (auth?.access) return auth.access;
+	for (const key of PROVIDER_ENV_KEYS[provider] || []) {
+		if (process.env[key]) return process.env[key];
 	}
+
+	const auth = authCredentialForProvider(provider);
+	if (auth?.type === "oauth" && provider === "anthropic" && auth.expires && Date.now() > auth.expires) {
+		const refreshed = await refreshOAuthToken();
+		if (refreshed) return refreshed;
+	}
+	if (auth?.access) return auth.access;
+	if (auth?.key) return auth.key;
 
 	const configs = (prefs?.get("customProviders") as CustomProviderConfig[] | undefined) || [];
 	const custom = configs.find(c => (c.name || c.id) === provider || c.id === provider);
 	if (custom) return custom.apiKey?.trim() || "none";
 
-	return undefined;
+	return resolveConfigValue(readModelsJsonProvider(provider)?.apiKey);
 }
 
 export function toPiModel(model: ApiModel): Model<Api> {
@@ -73,6 +120,8 @@ function assistantText(message: any): string {
 		.trim();
 }
 
+type CompleteSimpleFn = typeof completeSimple;
+
 export async function completeModelText(
 	model: ApiModel,
 	prefs: PreferencesStore | undefined,
@@ -83,6 +132,7 @@ export async function completeModelText(
 		thinkingLevel?: ModelThinkingLevel;
 		timeoutMs?: number;
 	},
+	completeFn: CompleteSimpleFn = completeSimple,
 ): Promise<string> {
 	const apiKey = await resolveProviderApiKey(prefs, model.provider);
 	const options: Record<string, any> = {
@@ -96,7 +146,7 @@ export async function completeModelText(
 		options.reasoning = args.thinkingLevel;
 	}
 
-	const result = await completeSimple(toPiModel(model) as any, {
+	const result = await completeFn(toPiModel(model) as any, {
 		systemPrompt: args.systemPrompt,
 		messages: [{ role: "user", content: args.userPrompt, timestamp: Date.now() }],
 	}, options);

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -4606,8 +4606,9 @@ export class SessionManager {
 
 	private getTitleGenOptions(): import("./title-generator.js").TitleGenOptions {
 		const namingModel = this.preferencesStore?.get("default.namingModel") as string | undefined;
+		const sessionModel = this.preferencesStore?.get("default.sessionModel") as string | undefined;
 		const aigwUrl = this.preferencesStore ? getAigwUrl(this.preferencesStore) : undefined;
-		return { namingModel: namingModel || undefined, aigwUrl, thinkingLevel: "off", preferencesStore: this.preferencesStore };
+		return { namingModel: namingModel || undefined, fallbackModel: sessionModel || undefined, aigwUrl, thinkingLevel: "off", preferencesStore: this.preferencesStore };
 	}
 
 	private async autoGenerateTitleFromText(session: SessionInfo, userText: string): Promise<void> {

--- a/src/server/agent/title-generator.ts
+++ b/src/server/agent/title-generator.ts
@@ -71,6 +71,8 @@ export interface TitleGenOptions {
 	aigwUrl?: string;
 	/** Thinking level for title generation: "off"|"minimal"|"low"|"medium"|"high"|"xhigh" */
 	thinkingLevel?: string;
+	/** Model to try when no explicit naming model is configured (usually default.sessionModel). */
+	fallbackModel?: string;
 	/** Preferences are needed to resolve and authenticate non-AI-Gateway naming models. */
 	preferencesStore?: PreferencesStore;
 	/** Test hook: supplies available models without reading preferences. */
@@ -471,11 +473,23 @@ export async function generateSessionTitle(messages: any[], options?: TitleGenOp
 			console.log(`[title-gen] Using fallback gateway naming model "${fallbackId}"`);
 			return generateViaGateway(options.aigwUrl, fallbackId, preview, "off");
 		}
-		console.warn("[title-gen] Gateway configured but no suitable Claude naming model found; falling back to direct Anthropic API");
+		console.warn("[title-gen] Gateway configured but no suitable Claude naming model found; falling back");
 	}
 
-	// Default: direct Anthropic API (works for public, gateway-less, and
-	// gateway-but-no-Claude setups).
+	// No explicit naming model and no usable gateway fallback. Try the session
+	// default before the legacy Haiku path so OpenAI-only installations still
+	// auto-rename sessions after switching away from Anthropic.
+	if (options?.fallbackModel) {
+		const configured = await findConfiguredModel(options.fallbackModel, options);
+		if (configured?.model) {
+			const userPrompt = `Conversation:\n\n---\n${preview}\n---\n\nReply with ONLY <title>YOUR LABEL</title>:`;
+			const systemPrompt = "Output a 2-3 word label for this conversation. MAXIMUM 3 words. Wrap the label in <title>…</title> tags, e.g. <title>Fix Login Bug</title>. No quotes, no markdown, no explanation outside the tags. No emojis. Do NOT reason, think, or plan — emit the <title> tag as your very first tokens.";
+			console.log(`[title-gen] Using session default fallback naming model "${options.fallbackModel}"`);
+			return generateViaConfiguredDirectModel(configured.model, userPrompt, systemPrompt, options);
+		}
+	}
+
+	// Legacy default: direct Anthropic API.
 	return generateViaAnthropic(preview, "off");
 }
 
@@ -657,7 +671,16 @@ export async function generateGoalSummaryTitle(goalTitle: string, options?: Titl
 			console.log(`[title-gen] Using fallback gateway naming model "${fallbackId}" for goal summary`);
 			return generateGoalSummaryViaGateway(options.aigwUrl, fallbackId, goalTitle);
 		}
-		console.warn("[title-gen] Gateway configured but no suitable Claude naming model found for goal summary; falling back to direct Anthropic API");
+		console.warn("[title-gen] Gateway configured but no suitable Claude naming model found for goal summary; falling back");
+	}
+
+	if (options?.fallbackModel) {
+		const configured = await findConfiguredModel(options.fallbackModel, options);
+		if (configured?.model) {
+			const userPrompt = `Goal title:\n\n---\n${goalTitle}\n---\n\nReply with ONLY <title>YOUR 3-WORD SUMMARY</title>:`;
+			console.log(`[title-gen] Using session default fallback naming model "${options.fallbackModel}" for goal summary`);
+			return generateViaConfiguredDirectModel(configured.model, userPrompt, GOAL_SUMMARY_SYSTEM, options);
+		}
 	}
 
 	return generateGoalSummaryViaAnthropic(goalTitle);

--- a/tests/title-generator-direct-model.test.ts
+++ b/tests/title-generator-direct-model.test.ts
@@ -1,15 +1,16 @@
 import { afterEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { tmpdir } from "node:os";
 
 import { PreferencesStore } from "../src/server/agent/preferences-store.js";
 import { invalidateModelCache, type ApiModel } from "../src/server/agent/model-registry.js";
 import { generateSessionTitle } from "../src/server/agent/title-generator.js";
-import { testModelPreference } from "../src/server/agent/model-completion.js";
+import { completeModelText, testModelPreference } from "../src/server/agent/model-completion.js";
 
 const previousSkipTitleGen = process.env.BOBBIT_SKIP_TITLE_GEN;
+const previousAgentDir = process.env.BOBBIT_AGENT_DIR;
 const directModel: ApiModel = {
 	id: "direct-title-model",
 	name: "Direct Title Model",
@@ -27,6 +28,8 @@ const directModel: ApiModel = {
 afterEach(() => {
 	if (previousSkipTitleGen === undefined) delete process.env.BOBBIT_SKIP_TITLE_GEN;
 	else process.env.BOBBIT_SKIP_TITLE_GEN = previousSkipTitleGen;
+	if (previousAgentDir === undefined) delete process.env.BOBBIT_AGENT_DIR;
+	else process.env.BOBBIT_AGENT_DIR = previousAgentDir;
 	invalidateModelCache();
 });
 
@@ -65,6 +68,45 @@ describe("title generation with non-AI-Gateway naming models", () => {
 		assert.equal(calls[0].model.provider, "direct");
 		assert.equal(calls[0].model.id, "direct-title-model");
 		assert.equal(calls[0].args.thinkingLevel, "off");
+	});
+
+	it("uses the session model as fallback when no naming model is set", async () => {
+		delete process.env.BOBBIT_SKIP_TITLE_GEN;
+		const calls: any[] = [];
+		const title = await generateSessionTitle(
+			[{ role: "user", content: "Please diagnose why automatic names stopped changing." }],
+			{
+				fallbackModel: "openai-codex/direct-title-model",
+				availableModels: [{ ...directModel, provider: "openai-codex" }],
+				directModelCompleter: async (model, args) => {
+					calls.push({ model, args });
+					return "<title>Rename Diagnosis</title>";
+				},
+			},
+		);
+		assert.equal(title, "Rename Diagnosis");
+		assert.equal(calls.length, 1);
+		assert.equal(calls[0].model.provider, "openai-codex");
+		assert.equal(calls[0].args.thinkingLevel, "off");
+	});
+
+	it("model completions reuse OpenAI Codex OAuth credentials, matching chat auth", async () => {
+		const dir = mkdtempSync(path.join(tmpdir(), "bobbit-title-auth-"));
+		process.env.BOBBIT_AGENT_DIR = dir;
+		writeFileSync(path.join(dir, "auth.json"), JSON.stringify({ "openai-codex": { type: "oauth", access: "codex-oauth-token" } }));
+		const calls: any[] = [];
+		try {
+			await completeModelText({ ...directModel, provider: "openai-codex", api: "openai-codex-responses" }, undefined, {
+				systemPrompt: "test",
+				userPrompt: "test",
+			}, async (model, _context, options) => {
+				calls.push({ model, options });
+				return { role: "assistant", content: [{ type: "text", text: "OK" }], stopReason: "stop" } as any;
+			});
+			assert.equal(calls[0].options.apiKey, "codex-oauth-token");
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
 	});
 
 	it("model test helper works for non-AI-Gateway models", async () => {


### PR DESCRIPTION
## Summary
- Make Settings model Test reuse the same auth sources chat uses: provider prefs, env aliases, auth.json, custom providers, and models.json apiKey values
- Support OpenAI Codex OAuth for direct title/model test calls
- When no explicit Naming model is configured, fall back to default.sessionModel before legacy Anthropic Haiku so OpenAI-only setups still auto-rename sessions
- Add regression coverage for Codex OAuth auth and session-model fallback title generation

## Verification
- npm run check
- npx tsx --test --test-force-exit tests/title-generator-direct-model.test.ts
- npm run test:unit

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)