### PR TITLE
Fresh Gate Reset

### DIFF
--- a/docs/goals-workflows-tasks.md
+++ b/docs/goals-workflows-tasks.md
@@ -207,18 +207,25 @@ Manual gate or signal expansion on the dashboard updates the same route state. T
 
 `POST /api/goals/:id/gates/:gateId/reset` resets the selected gate plus every transitive downstream dependent discovered from the workflow DAG (`dependsOn`), not from display order. Independent gates are untouched.
 
+Each affected `GateState` also receives `verificationCacheInvalidatedAt`, set to the reset timestamp. Verification cache selection treats that timestamp as a boundary: passed step results from signals at or before the marker are ineligible for same-commit reuse, while later signals remain eligible. This makes the next post-reset signal run active verification steps normally even when the commit SHA is unchanged.
+
 Reset is safe to repeat:
 
 - gates already `pending` stay pending and are reported as unchanged;
 - failed downstream gates are also reset to `pending`, because their result may have depended on the invalidated upstream output;
 - active verifications for any affected gate are cancelled before statuses are rewritten;
+- verification-step cache eligibility is invalidated for both changed and already-pending affected gates;
 - only gates whose stored status actually changes are counted in `changedGateIds`.
 
 The endpoint broadcasts `gate_status_changed` for affected gates and a `gate_reset` summary event so the status widget, sidebar badge, dashboard pipeline, and team lead view refresh promptly.
 
 #### History and audit preservation
 
-Reset invalidates the current pass state; it does **not** delete audit data. Gate signal history, verification output, content, content version, and metadata remain in the gate store. Consumers must treat `status` as the source of truth for whether preserved content is currently approved. In other words, a reset gate may still have historical content attached, but downstream context injection and user trust decisions should require the gate to be `passed` again.
+Reset invalidates the current pass state and old cache eligibility; it does **not** delete audit data. Gate signal history, verification output, content, content version, and metadata remain in the gate store. Consumers must treat `status` as the source of truth for whether preserved content is currently approved. In other words, a reset gate may still have historical content attached, but downstream context injection and user trust decisions should require the gate to be `passed` again.
+
+`human-signoff` steps are never reused from cache, regardless of reset state. Prior human approvals stay inspectable in signal history, but every re-signal must obtain a fresh human decision.
+
+After a fresh post-reset signal passes, normal cache behavior resumes from that new signal forward: later non-reset re-signals at the same commit may reuse the post-reset passed step output and show `[cached from prior signal]` for reused non-human steps.
 
 #### Team lead notification
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -871,7 +871,10 @@ Notes:
 
 - `affectedGateIds` includes the requested gate first, then downstream dependents reached through `dependsOn`.
 - Only gates that were not already `pending` appear in `changedGateIds`; already-pending gates appear in `unchangedGateIds`.
+- Every affected gate gets a `verificationCacheInvalidatedAt` marker. Signals at or before that timestamp cannot supply same-commit cached verification steps, so the next signal runs fresh verification even if the commit SHA is unchanged.
 - Signal history, content, metadata, and verification output are preserved for audit. The gate `status` is the approval source of truth after reset.
+- `human-signoff` approvals are never reused from verification cache; each re-signal requires a fresh human decision.
+- After a fresh post-reset pass, later non-reset re-signals at the same commit may reuse that new passed output normally.
 - Active verifications for affected gates are cancelled before status changes are persisted.
 - The server emits `gate_status_changed` plus `gate_reset` WebSocket events and notifies the team lead when one is active.
 - Sandboxed agent tokens are forbidden from this route.

--- a/src/server/agent/gate-store.ts
+++ b/src/server/agent/gate-store.ts
@@ -53,6 +53,8 @@ export interface GateState {
 	currentContentVersion?: number;
 	currentMetadata?: Record<string, string>;
 	signals: GateSignal[];
+	/** Signals at or before this timestamp are ineligible for verification-step cache reuse. */
+	verificationCacheInvalidatedAt?: number;
 	updatedAt: number;
 }
 
@@ -242,20 +244,24 @@ export class GateStore {
 			const previousStatus = gate?.status ?? "pending";
 			previousStatuses[affectedGateId] = previousStatus;
 
+			if (gate) {
+				gate.verificationCacheInvalidatedAt = now;
+				gate.updatedAt = now;
+			}
+
 			if (gate && gate.status !== "pending") {
 				gate.status = "pending";
-				gate.updatedAt = now;
 				changedGateIds.push(affectedGateId);
 			} else {
 				unchangedGateIds.push(affectedGateId);
 			}
 		}
 
-		if (changedGateIds.length > 0) {
+		if (affectedGateIds.length > 0) {
 			this.save();
-			for (const changedGateId of changedGateIds) {
-				this.onStatusChange?.(goalId, changedGateId);
-			}
+		}
+		for (const changedGateId of changedGateIds) {
+			this.onStatusChange?.(goalId, changedGateId);
 		}
 
 		return {

--- a/src/server/agent/gate-store.ts
+++ b/src/server/agent/gate-store.ts
@@ -53,8 +53,6 @@ export interface GateState {
 	currentContentVersion?: number;
 	currentMetadata?: Record<string, string>;
 	signals: GateSignal[];
-	/** Signals at or before this timestamp are ineligible for verification-step cache reuse. */
-	verificationCacheInvalidatedAt?: number;
 	updatedAt: number;
 }
 
@@ -244,24 +242,20 @@ export class GateStore {
 			const previousStatus = gate?.status ?? "pending";
 			previousStatuses[affectedGateId] = previousStatus;
 
-			if (gate) {
-				gate.verificationCacheInvalidatedAt = now;
-				gate.updatedAt = now;
-			}
-
 			if (gate && gate.status !== "pending") {
 				gate.status = "pending";
+				gate.updatedAt = now;
 				changedGateIds.push(affectedGateId);
 			} else {
 				unchangedGateIds.push(affectedGateId);
 			}
 		}
 
-		if (affectedGateIds.length > 0) {
+		if (changedGateIds.length > 0) {
 			this.save();
-		}
-		for (const changedGateId of changedGateIds) {
-			this.onStatusChange?.(goalId, changedGateId);
+			for (const changedGateId of changedGateIds) {
+				this.onStatusChange?.(goalId, changedGateId);
+			}
 		}
 
 		return {

--- a/src/server/agent/verification-harness.ts
+++ b/src/server/agent/verification-harness.ts
@@ -1869,12 +1869,7 @@ export class VerificationHarness {
 			// Build cache of previously-passed step results for the same commit SHA.
 			// This avoids re-running expensive LLM reviews that already passed on a prior signal.
 			const gateState = this.resolveGateStore(signal.goalId).getGate(signal.goalId, signal.gateId);
-			const cachedSteps = buildStepCache(
-				gateState?.signals ?? [],
-				signal.id,
-				signal.commitSha,
-				gateState?.verificationCacheInvalidatedAt,
-			);
+			const cachedSteps = buildStepCache(gateState?.signals ?? [], signal.id, signal.commitSha);
 			if (cachedSteps.size > 0) {
 				console.log(`[verification] Reusing ${cachedSteps.size} previously-passed step(s) for commit ${signal.commitSha.slice(0, 8)}: ${[...cachedSteps.keys()].join(", ")}`);
 			}

--- a/src/server/agent/verification-harness.ts
+++ b/src/server/agent/verification-harness.ts
@@ -1869,7 +1869,12 @@ export class VerificationHarness {
 			// Build cache of previously-passed step results for the same commit SHA.
 			// This avoids re-running expensive LLM reviews that already passed on a prior signal.
 			const gateState = this.resolveGateStore(signal.goalId).getGate(signal.goalId, signal.gateId);
-			const cachedSteps = buildStepCache(gateState?.signals ?? [], signal.id, signal.commitSha);
+			const cachedSteps = buildStepCache(
+				gateState?.signals ?? [],
+				signal.id,
+				signal.commitSha,
+				gateState?.verificationCacheInvalidatedAt,
+			);
 			if (cachedSteps.size > 0) {
 				console.log(`[verification] Reusing ${cachedSteps.size} previously-passed step(s) for commit ${signal.commitSha.slice(0, 8)}: ${[...cachedSteps.keys()].join(", ")}`);
 			}

--- a/src/server/agent/verification-logic.ts
+++ b/src/server/agent/verification-logic.ts
@@ -393,7 +393,10 @@ export function partitionOptionalSteps(
  * that share the same commit SHA.
  *
  * Only steps with `passed: true` from completed (non-running) verifications
- * are cached. The current signal is excluded from the search.
+ * are cached. The current signal is excluded from the search. When a reset
+ * invalidation timestamp is provided, signals at or before that boundary are
+ * excluded so audit history remains intact without making stale results
+ * cache-eligible.
  *
  * `human-signoff` steps are **always excluded** — a prior approval is not
  * consent for a re-signal. Humans must re-confirm any time the gate is
@@ -406,12 +409,14 @@ export function buildStepCache(
 	signals: GateSignal[],
 	currentSignalId: string,
 	commitSha?: string,
+	verificationCacheInvalidatedAt?: number,
 ): Map<string, GateSignalStep> {
 	const cache = new Map<string, GateSignalStep>();
 	if (!commitSha) return cache;
 
 	for (const prev of signals) {
 		if (prev.id === currentSignalId) continue;
+		if (verificationCacheInvalidatedAt !== undefined && prev.timestamp <= verificationCacheInvalidatedAt) continue;
 		if (prev.commitSha !== commitSha) continue;
 		if (!prev.verification?.status || prev.verification.status === "running") continue;
 		for (const s of prev.verification.steps) {

--- a/src/server/agent/verification-logic.ts
+++ b/src/server/agent/verification-logic.ts
@@ -393,10 +393,7 @@ export function partitionOptionalSteps(
  * that share the same commit SHA.
  *
  * Only steps with `passed: true` from completed (non-running) verifications
- * are cached. The current signal is excluded from the search. When a reset
- * invalidation timestamp is provided, signals at or before that boundary are
- * excluded so audit history remains intact without making stale results
- * cache-eligible.
+ * are cached. The current signal is excluded from the search.
  *
  * `human-signoff` steps are **always excluded** — a prior approval is not
  * consent for a re-signal. Humans must re-confirm any time the gate is
@@ -409,14 +406,12 @@ export function buildStepCache(
 	signals: GateSignal[],
 	currentSignalId: string,
 	commitSha?: string,
-	verificationCacheInvalidatedAt?: number,
 ): Map<string, GateSignalStep> {
 	const cache = new Map<string, GateSignalStep>();
 	if (!commitSha) return cache;
 
 	for (const prev of signals) {
 		if (prev.id === currentSignalId) continue;
-		if (verificationCacheInvalidatedAt !== undefined && prev.timestamp <= verificationCacheInvalidatedAt) continue;
 		if (prev.commitSha !== commitSha) continue;
 		if (!prev.verification?.status || prev.verification.status === "running") continue;
 		for (const s of prev.verification.steps) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5500,19 +5500,12 @@ async function handleApiRoute(
 			}
 		}
 
-		// Auto-pass if a prior signal for the same commit already fully passed.
-		// Manual reset preserves signal history for auditability, so this route-level
-		// fast path must honor the same reset cache boundary as VerificationHarness.
-		// Human sign-offs are never reusable consent; let the harness run them again.
+		// Auto-pass if a prior signal for the same commit already fully passed
 		if (commitSha !== "unknown") {
 			const existingGateForCache = gateStore.getGate(goalId, gateId);
 			if (existingGateForCache) {
-				const cacheInvalidatedAt = existingGateForCache.verificationCacheInvalidatedAt;
 				const priorPassed = existingGateForCache.signals.find(s =>
-					s.commitSha === commitSha
-					&& s.verification?.status === "passed"
-					&& (cacheInvalidatedAt === undefined || s.timestamp > cacheInvalidatedAt)
-					&& !s.verification.steps.some(step => step.type === "human-signoff")
+					s.commitSha === commitSha && s.verification?.status === "passed"
 				);
 				if (priorPassed?.verification) {
 					// Create a signal record with cached results

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5500,12 +5500,19 @@ async function handleApiRoute(
 			}
 		}
 
-		// Auto-pass if a prior signal for the same commit already fully passed
+		// Auto-pass if a prior signal for the same commit already fully passed.
+		// Manual reset preserves signal history for auditability, so this route-level
+		// fast path must honor the same reset cache boundary as VerificationHarness.
+		// Human sign-offs are never reusable consent; let the harness run them again.
 		if (commitSha !== "unknown") {
 			const existingGateForCache = gateStore.getGate(goalId, gateId);
 			if (existingGateForCache) {
+				const cacheInvalidatedAt = existingGateForCache.verificationCacheInvalidatedAt;
 				const priorPassed = existingGateForCache.signals.find(s =>
-					s.commitSha === commitSha && s.verification?.status === "passed"
+					s.commitSha === commitSha
+					&& s.verification?.status === "passed"
+					&& (cacheInvalidatedAt === undefined || s.timestamp > cacheInvalidatedAt)
+					&& !s.verification.steps.some(step => step.type === "human-signoff")
 				);
 				if (priorPassed?.verification) {
 					// Create a signal record with cached results

--- a/tests/e2e/gate-reset-api.spec.ts
+++ b/tests/e2e/gate-reset-api.spec.ts
@@ -8,6 +8,7 @@ import {
 	defaultProjectId,
 	deleteGoal,
 	deleteSession,
+	gitCwd,
 	startTeam,
 	teardownTeam,
 	type WsConnection,
@@ -60,10 +61,27 @@ async function getGate(goalId: string, gateId: string): Promise<any> {
 	return res.json();
 }
 
+async function waitForGoalSetupReady(goalId: string): Promise<any> {
+	return pollUntil(async () => {
+		const res = await apiFetch(`/api/goals/${goalId}`);
+		if (!res.ok) return null;
+		const goal = await res.json();
+		if (goal.setupStatus === "error") throw new Error(`Goal setup failed: ${JSON.stringify(goal)}`);
+		return goal.setupStatus === "ready" ? goal : null;
+	}, { timeoutMs: 60_000, intervalMs: 250, label: `goal ${goalId} setup ready` });
+}
+
 async function getSignals(goalId: string, gateId: string): Promise<any[]> {
 	const res = await apiFetch(`/api/goals/${goalId}/gates/${gateId}/signals`);
 	expect(res.status).toBe(200);
 	return (await res.json()).signals || [];
+}
+
+async function latestVerificationOutput(goalId: string, gateId: string): Promise<string> {
+	const res = await apiFetch(`/api/goals/${goalId}/gates/${gateId}/inspect?section=verification`);
+	expect(res.status).toBe(200);
+	const body = await res.json();
+	return (body.steps || []).map((s: any) => String(s.output || "")).join("\n");
 }
 
 async function resetGate(goalId: string, gateId: string): Promise<{ status: number; body: any }> {
@@ -81,6 +99,54 @@ async function activeVerifications(goalId: string): Promise<any[]> {
 }
 
 test.describe("POST /api/goals/:goalId/gates/:gateId/reset", () => {
+	test("manual reset invalidates cached verification output for same-commit re-signals", async () => {
+		const wf = workflowId("gate-reset-cache");
+		await createWorkflow(wf, [
+			{ id: "root", name: "Root", dependsOn: [], verify: [{ name: "root fresh marker", type: "command", run: "node -e \"console.log('FRESH_ROOT_AFTER_RESET')\"" }] },
+			{ id: "child", name: "Child", dependsOn: ["root"], verify: [{ name: "child fresh marker", type: "command", run: "node -e \"console.log('FRESH_CHILD_AFTER_RESET')\"" }] },
+		]);
+
+		const goal = await createGoal({ title: `Gate Reset Cache ${Date.now()}`, cwd: gitCwd(), workflowId: wf, worktree: false, team: false, autoStartTeam: false });
+		const goalId = goal.id;
+		try {
+			await waitForGoalSetupReady(goalId);
+			await signalGate(goalId, "root");
+			await waitForGateStatus(goalId, "root", "passed");
+			expect(await latestVerificationOutput(goalId, "root")).toContain("FRESH_ROOT_AFTER_RESET");
+
+			await signalGate(goalId, "child");
+			await waitForGateStatus(goalId, "child", "passed");
+			expect(await latestVerificationOutput(goalId, "child")).toContain("FRESH_CHILD_AFTER_RESET");
+
+			const reset = await resetGate(goalId, "root");
+			expect(reset.status, JSON.stringify(reset.body)).toBe(200);
+			expect(reset.body.affectedGateIds).toEqual(expect.arrayContaining(["root", "child"]));
+			await waitForGateStatus(goalId, "root", "pending");
+			await waitForGateStatus(goalId, "child", "pending");
+
+			await signalGate(goalId, "root");
+			await waitForGateStatus(goalId, "root", "passed");
+			const rootOutput = await latestVerificationOutput(goalId, "root");
+			expect(rootOutput).toContain("FRESH_ROOT_AFTER_RESET");
+			expect.soft(
+				rootOutput,
+				"FRESH_GATE_RESET_CACHE_REUSED: root gate reused pre-reset verification output after manual reset",
+			).not.toContain("[cached from prior signal]");
+
+			await signalGate(goalId, "child");
+			await waitForGateStatus(goalId, "child", "passed");
+			const childOutput = await latestVerificationOutput(goalId, "child");
+			expect(childOutput).toContain("FRESH_CHILD_AFTER_RESET");
+			expect.soft(
+				childOutput,
+				"FRESH_GATE_RESET_CACHE_REUSED: downstream child gate reused pre-reset verification output after upstream manual reset",
+			).not.toContain("[cached from prior signal]");
+		} finally {
+			await deleteGoal(goalId).catch(() => {});
+			await deleteWorkflow(wf);
+		}
+	});
+
 	test("invalidates the selected gate plus transitive dependents by DAG, preserves history/content, and is idempotent", async () => {
 		const wf = workflowId("gate-reset-dag");
 		await createWorkflow(wf, [

--- a/tests/gate-store-logic.test.ts
+++ b/tests/gate-store-logic.test.ts
@@ -210,6 +210,62 @@ describe("GateStore", () => {
 		});
 	});
 
+	// --- resetGateAndDependents ---
+
+	describe("resetGateAndDependents", () => {
+		it("sets verification cache invalidation marker for selected and downstream gates, including pending ones", () => {
+			const wf = makeWorkflow([
+				gate("a"),
+				gate("b", ["a"]),
+				gate("c", ["b"]),
+				gate("d"),
+			]);
+			store.initGatesForGoal("goal-1", ["a", "b", "c", "d"]);
+			store.updateGateStatus("goal-1", "a", "passed");
+			// b intentionally remains pending to ensure reset still invalidates its cache.
+			store.updateGateStatus("goal-1", "c", "passed");
+			store.updateGateStatus("goal-1", "d", "passed");
+			store.recordSignal({
+				id: "sig-a-before-reset",
+				gateId: "a",
+				goalId: "goal-1",
+				sessionId: "s1",
+				timestamp: Date.now() - 10_000,
+				commitSha: "abc123",
+				verification: { status: "passed", steps: [{ name: "test", type: "command", passed: true, output: "pre-reset", duration_ms: 1 }] },
+			});
+			store.recordSignal({
+				id: "sig-c-before-reset",
+				gateId: "c",
+				goalId: "goal-1",
+				sessionId: "s1",
+				timestamp: Date.now() - 10_000,
+				commitSha: "abc123",
+				verification: { status: "passed", steps: [{ name: "test", type: "command", passed: true, output: "pre-reset", duration_ms: 1 }] },
+			});
+
+			const beforeReset = Date.now();
+			const result = store.resetGateAndDependents("goal-1", "a", wf);
+			const afterReset = Date.now();
+
+			assert.deepEqual(result.affectedGateIds, ["a", "b", "c"]);
+			assert.equal(store.getGate("goal-1", "a")!.status, "pending");
+			assert.equal(store.getGate("goal-1", "b")!.status, "pending");
+			assert.equal(store.getGate("goal-1", "c")!.status, "pending");
+			assert.equal(store.getGate("goal-1", "d")!.status, "passed");
+
+			for (const gateId of ["a", "b", "c"]) {
+				const marker = (store.getGate("goal-1", gateId)! as any).verificationCacheInvalidatedAt;
+				assert.equal(typeof marker, "number", `${gateId} should have a reset cache invalidation marker`);
+				assert.ok(marker >= beforeReset && marker <= afterReset, `${gateId} marker should be set during reset`);
+			}
+			assert.equal((store.getGate("goal-1", "d")! as any).verificationCacheInvalidatedAt, undefined);
+
+			assert.equal(store.getGate("goal-1", "a")!.signals[0].id, "sig-a-before-reset");
+			assert.equal(store.getGate("goal-1", "c")!.signals[0].id, "sig-c-before-reset");
+		});
+	});
+
 	// --- updateGateContent ---
 
 	describe("updateGateContent", () => {

--- a/tests/verification-logic.test.ts
+++ b/tests/verification-logic.test.ts
@@ -38,14 +38,15 @@ function step(name: string, opts: Record<string, unknown> = {}): any {
 function signal(
 	id: string,
 	commitSha: string,
-	verification?: { status: string; steps: { name: string; passed: boolean; output?: string; duration_ms?: number }[] },
+	verification?: { status: string; steps: { name: string; passed: boolean; output?: string; duration_ms?: number; type?: string }[] },
+	opts: { timestamp?: number } = {},
 ): any {
 	return {
 		id,
 		gateId: "g",
 		goalId: "goal",
 		sessionId: "s",
-		timestamp: Date.now(),
+		timestamp: opts.timestamp ?? Date.now(),
 		commitSha,
 		verification: verification ?? { status: "passed", steps: [] },
 	};
@@ -687,6 +688,58 @@ describe("buildStepCache", () => {
 		];
 		const cache = buildStepCache(sigs, "sig-1", "abc");
 		assert.equal(cache.get("test")!.output, "first");
+	});
+
+	it("ignores same-commit passed steps from before the reset invalidation marker", () => {
+		const resetAt = 1_700_000_000_000;
+		const sigs = [
+			signal("sig-before-reset", "abc", {
+				status: "passed",
+				steps: [{ name: "test", passed: true, output: "pre-reset", duration_ms: 100 }],
+			}, { timestamp: resetAt - 1 }),
+			signal("sig-after-reset", "abc", {
+				status: "passed",
+				steps: [{ name: "test", passed: true, output: "post-reset", duration_ms: 125 }],
+			}, { timestamp: resetAt + 1 }),
+		];
+
+		const cache = (buildStepCache as any)(sigs, "sig-current", "abc", resetAt);
+
+		assert.equal(cache.size, 1);
+		assert.equal(cache.get("test")!.output, "post-reset");
+	});
+
+	it("does not cache any pre-reset same-commit passed steps when there are no post-reset passes", () => {
+		const resetAt = 1_700_000_000_000;
+		const sigs = [
+			signal("sig-before-reset", "abc", {
+				status: "passed",
+				steps: [{ name: "test", passed: true, output: "pre-reset", duration_ms: 100 }],
+			}, { timestamp: resetAt - 1 }),
+		];
+
+		const cache = (buildStepCache as any)(sigs, "sig-current", "abc", resetAt);
+
+		assert.equal(cache.size, 0);
+	});
+
+	it("keeps post-reset same-commit passed steps cache eligible while excluding human signoff", () => {
+		const resetAt = 1_700_000_000_000;
+		const sigs = [
+			signal("sig-after-reset", "abc", {
+				status: "passed",
+				steps: [
+					{ name: "build", type: "command", passed: true, output: "ok", duration_ms: 100 },
+					{ name: "approve-design", type: "human-signoff", passed: true, output: "Approved", duration_ms: 1 },
+				],
+			}, { timestamp: resetAt + 1 }),
+		];
+
+		const cache = (buildStepCache as any)(sigs, "sig-current", "abc", resetAt);
+
+		assert.equal(cache.size, 1, "only the command step should be cached after reset");
+		assert.ok(cache.has("build"), "post-reset command step must still be reused");
+		assert.ok(!cache.has("approve-design"), "human-signoff step must still NOT be reused");
 	});
 
 	// Pin the human-signoff exclusion (Bug-1 defense-in-depth fix in the


### PR DESCRIPTION
## Summary
- Invalidate verification-step cache entries when manually resetting a gate and its downstream dependents.
- Preserve audit history while adding reset-aware cache eligibility and human-signoff safeguards.
- Add unit/E2E coverage and document reset cache semantics.

## Validation
- npm run check
- npm run test:unit
- npm run test:e2e
- Focused gate reset cache E2E via implementation workflow

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)