### PR TITLE
Sync Gate Counts

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -135,8 +135,9 @@ The pill strip above the composer (`AgentInterface._renderPillStrip`, `_measureP
 
 ## Gate status stale
 
-- `state.gateStatusCache` refreshed via: (1) `refreshGateStatusCache()` on initial load, (2) `refreshGateStatusForGoal()` on WS events `gate_status_changed` / `gate_verification_complete`
-- Dashboard gate polling also syncs to this cache
+- `state.gateStatusCache` is the shared gate count source for sidebar badges and the goal status widget badge. Live updates should route through `invalidateGateStatusForGoal(goalId, reason)`, which debounces per goal and refetches `/api/goals/:id/gates?view=summary`.
+- Count-changing WS events include gate signal/status/reset and verification lifecycle events through step complete; `gate_verification_step_output` is detail-only and must not refresh summaries.
+- The dashboard keeps full gate detail locally but should not write partial entries into `state.gateStatusCache`. See [gate-status-sync.md](gate-status-sync.md) for the source-of-truth and regression-test contract.
 
 ## Context bar / model state
 

--- a/docs/design/gate-count-sync-issue-analysis.md
+++ b/docs/design/gate-count-sync-issue-analysis.md
@@ -1,0 +1,214 @@
+# Gate Count Sync — Issue Analysis
+
+## Scope audited
+
+Surfaces requested:
+
+- Sidebar goal rows and badges
+- Chat header goal status widget pill/popover
+- Goal dashboard pipeline and gate list
+- Goal status pages/surfaces that render gate counts
+
+Searches covered `docs/`, `tests/`, and `src/` for `gateStatusCache`, `refreshGateStatusForGoal`, `gate_signal_received`, `gate_status_changed`, `gate_reset`, `gate_verification_*`, human sign-off, and dashboard/widget/sidebar rendering paths.
+
+## Affected files and symbols
+
+| Area | File | Symbols / paths | Current role |
+|---|---|---|---|
+| Shared app cache | `src/app/state.ts` | `state.gateStatusCache` | Goal-id keyed summary: `{ passed, total, verifying, verifyingCount, awaitingSignoffCount, awaitingHumanSignoff }`. |
+| Shared cache refresh | `src/app/api.ts` | `fetchGoalGatesWithSignoffCount()`, `refreshGateStatusCache()`, `refreshGateStatusForGoal()` | Fetches `/api/goals/:id/gates?view=summary`, derives counts, writes `state.gateStatusCache`, renders app only when values changed. |
+| Initial/reload hydration | `src/app/api.ts` | `refreshSessions()` | On initial load or goals generation change, refreshes gate summaries for all workflow goals. |
+| Sidebar badge | `src/app/render-helpers.ts` | `renderGoalBadge()`, `renderGateProgressBadge()` | Sidebar falls back from PR badge to gate summary cache. Verifying state displays `passed + verifyingCount` in blue. |
+| Sidebar rows | `src/app/render-helpers.ts` | `renderGoalGroup()` | Renders goal row and calls `renderGoalBadge(goal.id)`. |
+| Goal status widget host | `src/ui/components/AgentInterface.ts` | `<goal-status-widget>` mount | Mounts widget for sessions with `goalId` or `teamGoalId`. |
+| Goal status widget local data | `src/ui/components/GoalStatusWidget.ts` | `_gates`, `_awaitingSignoffs`, `_fetchInitial()`, `_refreshGates()`, `_refreshActive()`, `_handleWsEvent()` | Maintains a separate per-widget gate list and active sign-off list. The pill/dropdown badge still calls shared `renderGateProgressBadge(this.goalId)`. |
+| Goal dashboard local data | `src/app/goal-dashboard.ts` | `gates`, `liveVerifications`, `loadDashboardData()`, `applyGateState()`, `refreshGatesFromWsEvent()`, `fetchActiveVerifications()`, `handleLiveVerificationEvent()` | Maintains page-local full gate list and live verification state. Also writes `state.gateStatusCache` from full `/gates`, preserving previous sign-off counters. |
+| Dashboard pipeline/list | `src/app/goal-dashboard.ts` | `computeGateDepthLevels()`, `renderGatePipeline()`, `renderWorkflowChecklist()` | Uses page-local `gates`; treats a gate as `running` when any signal has `verification.status === "running"`. |
+| Session WS event path | `src/app/remote-agent.ts` | `handleMessage()` cases for gate events | Updates shared gate cache for some events, dispatches verification events for live components. Currently lacks a `gate_reset` case and does not refresh the shared cache on phase/step events. |
+| Dashboard viewer WS path | `src/app/goal-dashboard.ts` | `connectDashboardWs()` | Subscribes to goal viewer WS. Refreshes dashboard gates only for `gate_signal_received` and `gate_status_changed`; dispatches all verification events. |
+| Verification event bus | `src/app/verification-event-bus.ts` | `dispatchVerificationEvent()` | Dedupe bridge for `gate_verification_*` CustomEvents consumed by dashboard/live verification components. It does not update shared gate summaries. |
+| Server gate summary | `src/server/server.ts` | `GET /api/goals/:goalId/gates?view=summary` | Returns slim gates plus goal-wide `awaitingSignoffCount` from active verifications. It does not include running status directly; clients infer it from signal verification fields when present. |
+| Server reset endpoint | `src/server/server.ts` | `POST /api/goals/:goalId/gates/:gateId/reset` | Cancels active verifications for selected/downstream gates, resets gate store, broadcasts `gate_status_changed` for affected gates then `gate_reset`. |
+| Re-signal reset path | `src/server/server.ts` | `POST /api/goals/:goalId/gates/:gateId/signal` | If re-signaling a passed gate, `cascadeReset()` resets downstream and broadcasts `gate_status_changed` for downstream gates, then records/broadcasts the new signal. |
+| Human sign-off | `src/server/server.ts`, `src/server/agent/verification-harness.ts` | `/signoff`, `resolveSignoff()`, `gate_verification_awaiting_human`, step complete/final complete events | Sign-off resolution itself returns HTTP 200 without a direct cache event; follow-up harness events must clear `awaitingSignoffCount` and update pass/fail counts. |
+| Pinning / related tests | `tests/e2e/ui/goal-status-widget.spec.ts`, `tests/sidebar-goal-rendering.spec.ts`, `tests/notification-policy.spec.ts`, `tests/e2e/human-signoff.spec.ts`, `tests/gate-signal-step-enumeration.test.ts`, `tests/e2e/gate-signal-progress.spec.ts` | Existing coverage for widget flow, reset, badge rendering, notification policy, sign-off REST, and signal step enumeration. No focused test currently asserts every surface receives the same active verification count/state on each verification phase/step event and after sign-off resolution. |
+
+## Current data flow
+
+### Server truth
+
+1. Gate persisted state lives in `GateStore` (`src/server/agent/gate-store.ts`). Stored gate status is `pending`, `passed`, or `failed`.
+2. In-flight verification state lives in `VerificationHarness.activeVerifications` and is persisted separately for restart recovery.
+3. `GET /api/goals/:goalId/gates` returns enriched gate store state with signal histories.
+4. `GET /api/goals/:goalId/gates?view=summary` returns slim gate rows and aggregates `awaitingSignoffCount` from active verifications.
+5. `GET /api/goals/:goalId/verifications/active` returns richer live verification state, including awaiting-human steps.
+
+### Sidebar/shared cache
+
+1. `refreshSessions()` hydrates goals/sessions.
+2. On initial load or goals generation change, it calls `refreshGateStatusCache(true)`.
+3. `refreshGateStatusCache()` and `refreshGateStatusForGoal(goalId)` fetch `?view=summary` and derive:
+   - `passed` from gate statuses,
+   - `total` from the workflow snapshot on `state.goals`,
+   - `verifying` / `verifyingCount` from `signals[].verification.status === "running"`,
+   - sign-off counters from `awaitingSignoffCount`.
+4. `renderGoalBadge()` and `renderGateProgressBadge()` read only `state.gateStatusCache`.
+
+### Goal status widget
+
+1. `<goal-status-widget>` fetches bare `/gates` into local `_gates` and `/verifications/active` into local `_awaitingSignoffs`.
+2. The dropdown gate list renders from local `_gates`.
+3. The pill/dropdown progress badge calls `renderGateProgressBadge(this.goalId)`, so its count comes from `state.gateStatusCache`, not `_gates`.
+4. The widget has its own viewer WS and refreshes local `_gates` / `_awaitingSignoffs` for several events.
+5. The widget does not write `state.gateStatusCache`; it relies on app-level event handling or polling to update the shared badge.
+
+### Dashboard
+
+1. `loadDashboardData()` fetches the goal and bare `/gates` into page-local `gates`.
+2. `fetchActiveVerifications()` separately seeds `liveVerifications` from `/verifications/active` for detailed live rows.
+3. `applyGateState()` writes page-local `gates` and also writes `state.gateStatusCache` using the bare `/gates` result, preserving previous sign-off counters.
+4. The pipeline and gate checklist render from page-local `gates`; they show `running` if a stored signal is `verification.status === "running"`.
+5. Dashboard viewer WS refreshes page-local gates on `gate_signal_received` and `gate_status_changed`; verification events update `liveVerifications`, and `gate_verification_complete` also refetches gates.
+
+## Stale-cache root causes
+
+1. **Three client-side gate sources are live at once.**
+   - Shared `state.gateStatusCache` powers sidebar and the widget badge.
+   - Widget `_gates` / `_awaitingSignoffs` powers the widget popover and sign-off pulse.
+   - Dashboard `gates` / `liveVerifications` powers pipeline/list/details.
+   These sources refresh through different event handlers and different REST endpoints.
+
+2. **`refreshGateStatusForGoal()` is not the single invalidation path.**
+   `RemoteAgent` calls it for `gate_signal_received`, `gate_status_changed`, `gate_verification_started`, `gate_verification_awaiting_human`, and `gate_verification_complete`, but not for `gate_reset`, `gate_verification_phase_started`, `gate_verification_step_started`, or `gate_verification_step_complete`.
+
+3. **Human sign-off resolution has no direct shared-cache invalidation.**
+   `/signoff` resolves a deferred verifier and returns `{ resolved: true }`. The shared cache must update from subsequent `gate_verification_step_complete` / `gate_verification_complete` / `gate_status_changed`. The current session WS path does not refresh on `gate_verification_step_complete`, so `awaitingHumanSignoff` can remain true until final completion, a status change, or polling/navigation. This contradicts the intent documented in `docs/design/human-signoff-gates.md`.
+
+4. **`gate_reset` is handled by the widget but not by `RemoteAgent`.**
+   The server broadcasts `gate_status_changed` for affected gates before `gate_reset`, so many reset cases eventually refresh via `gate_status_changed`. But the explicit reset event is not wired into the shared cache path, making reset correctness dependent on companion broadcasts and ordering.
+
+5. **Dashboard writes a partial shared cache.**
+   `applyGateState()` writes `state.gateStatusCache` from bare `/gates` and preserves old sign-off counters. If the dashboard refresh runs after a sign-off state transition but before the shared summary refresh, it can keep stale `awaitingSignoffCount` while updating passed/verifying counts.
+
+6. **Active verification state is split between persisted signal rows and active verification rows.**
+   The dashboard uses both `signals[].verification.status` and `liveVerifications`; sidebar/widget badge uses only the summary-derived cache. A verification phase/step event can visibly update dashboard live details while the sidebar/widget badge remains on the last summary-derived count.
+
+7. **The widget badge and widget popover can disagree internally.**
+   The popover `_gates` may refresh on a widget viewer WS event, while the badge reads shared `state.gateStatusCache`. If app-level cache invalidation misses the same event, the popover rows can be current while the pill badge is stale.
+
+8. **No debouncing/in-flight coalescing exists for per-goal gate summary refreshes.**
+   Adding every missing event directly to `refreshGateStatusForGoal()` would be correct but may fan out redundant REST calls during step-output-heavy verification unless coalesced. `gate_verification_step_output` should not refresh summary counts.
+
+## Required event invalidations
+
+Use one targeted per-goal summary refresh path for all events that can change any field in `state.gateStatusCache`.
+
+| Event / action | Shared summary fields affected | Required client invalidation |
+|---|---|---|
+| Initial load / reconnect / reload | all fields | Hydrate from `/api/goals/:id/gates?view=summary` for workflow goals. Existing `refreshSessions()` path mostly covers this. Viewer/dashboard reconnect should also force current-goal summary refresh. |
+| `gate_signal_received` | `verifying`, `verifyingCount`; sometimes downstream `passed` count after re-signal reset | Refresh summary for `goalId`. Existing `RemoteAgent` path does this. |
+| `gate_verification_started` | `verifying`, `verifyingCount` | Refresh or optimistically mark the specific gate running. Existing path refreshes; keep but debounce. |
+| `gate_verification_phase_started` | active/running presentation may begin for newly unblocked phase rows; pass count usually unchanged | Refresh summary if the summary derives running from persisted signal rows; otherwise update companion active-state cache. Do not rely on dashboard-only live state. |
+| `gate_verification_step_started` | same as phase started; important when a human-signoff step parks immediately after start | Refresh active summary or companion active-state cache. |
+| `gate_verification_awaiting_human` | `awaitingSignoffCount`, `awaitingHumanSignoff` | Refresh summary and active sign-off list. Existing `RemoteAgent` and widget local paths do this; keep and debounce. |
+| `gate_verification_step_complete` | `awaitingSignoffCount` may clear for human sign-off; running count can change if last running step in a phase completed; final status may still be running | Refresh summary. This is currently missing in `RemoteAgent` for shared cache. |
+| `gate_verification_complete` | `passed`, `verifying`, `verifyingCount`, sign-off counters | Refresh summary and full gate list. Existing paths refresh; keep and debounce. |
+| `gate_status_changed` | `passed` count, failed/pending state, sometimes reset consequences | Refresh summary. Existing `RemoteAgent` and dashboard paths handle this. |
+| `gate_reset` | selected and downstream `passed`, `verifying`, sign-off counters | Refresh summary for `goalId`; full dashboard/widget gate list should also refresh. Explicitly handle even though status-changed events are also emitted. |
+| Human sign-off approve/reject HTTP response | active sign-off count, later gate status | Either the caller should trigger a local summary refresh after successful POST, or the subsequent WS `gate_verification_step_complete` must do so. Prefer both: immediate optimistic/local refresh plus debounced WS truth refresh. |
+| Cancel verification | `verifying`, `verifyingCount`, possibly sign-off counters | Treat resulting `gate_verification_complete { status: "cancelled" }` as a summary invalidation and refetch active verifications. |
+
+`gate_verification_step_output` should not refresh gate summaries; it affects only detailed live output.
+
+## Active verification state handling
+
+Current behavior treats active verification as derived data:
+
+- Sidebar/widget badge: `state.gateStatusCache.verifying` and `verifyingCount` are derived from `/gates?view=summary` signal histories.
+- Dashboard pipeline/list: derives `running` from page-local full gate signal histories.
+- Dashboard detail: uses `liveVerifications` for per-step live rows and output.
+- Widget sign-off pulse: uses `_awaitingSignoffs` from `/verifications/active`, but the badge uses the shared cache.
+
+Recommendations:
+
+1. **Keep persisted gate status as pass/fail/pending, but make active state first-class in the client summary.** The summary should represent effective UI state: `passed`, `total`, `verifying`, `verifyingCount`, `awaitingSignoffCount`, and optionally `runningGateIds` / `awaitingSignoffGateIds`.
+2. **Derive all count badges from the same summary store.** Dashboard can keep full `gates` for details, but its count/progress should either use the shared summary or update it through the same helper that sidebar/widget use.
+3. **Do not count passed gates as verifying.** Current logic excludes passed gates from `verifyingCount`; preserve that so a just-passed gate does not display `(passed+1)/total`.
+4. **Treat awaiting-human as an active verification state.** A human-signoff step has no process/session but is legitimately running while parked. Summary refresh must include `/verifications/active`-derived sign-off counts, as the existing `?view=summary` endpoint does.
+5. **On reconnect, rehydrate both summary and live details.** `refreshGateStatusForGoal(goalId)` should be called for the current session goal/dashboard goal when a WS reconnects, and dashboard/widget should continue fetching `/verifications/active` for detailed rows.
+
+## Reset and downstream invalidation behavior
+
+Server behavior:
+
+- Explicit reset (`POST /reset`) computes selected gate plus transitive dependents, cancels active verifications for all affected gates, resets non-pending statuses to pending, broadcasts `gate_status_changed` for each affected gate, then broadcasts `gate_reset` with `affectedGateIds`, `changedGateIds`, and `unchangedGateIds`.
+- Re-signaling a passed gate calls `cascadeReset()` for downstream dependents and broadcasts `gate_status_changed` for downstream gates before recording/broadcasting the new signal.
+- `GateStore.resetGateAndDependents()` preserves signal history, content, metadata, and content version; it only clears current pass/fail state.
+
+Client implications:
+
+1. A reset must invalidate the selected gate and every affected downstream gate in page-local full lists (`GoalStatusWidget._gates`, dashboard `gates`) and in the shared summary cache.
+2. If any affected gate had an active verification or awaiting-human step, reset cancellation must clear `verifying`, `verifyingCount`, and `awaitingSignoffCount` without waiting for an 8-second dashboard poll or session poll.
+3. Because reset emits both `gate_status_changed` and `gate_reset`, clients should coalesce by `goalId` rather than fetch once per affected gate.
+4. The explicit `gate_reset` event should be treated as authoritative invalidation even if a future server change reduces per-gate `gate_status_changed` chatter.
+
+## Implementation recommendations
+
+1. **Create one client-side gate summary refresh module.**
+   - Move summary derivation out of `api.ts` into a small module, for example `src/app/gate-status-store.ts`.
+   - Export `refreshGateStatusForGoal(goalId, options?)`, `refreshGateStatusCache()`, and a debounced `invalidateGateStatusForGoal(goalId, reason)`.
+   - Keep the current `/api/goals/:id/gates?view=summary` endpoint as the authoritative summary fetch.
+
+2. **Debounce and coalesce per goal.**
+   - Maintain `pendingByGoal` and `inFlightByGoal` maps.
+   - Coalesce all invalidating events within a short window, e.g. 50-150 ms.
+   - If another invalidation arrives during an in-flight fetch, schedule one trailing fetch.
+   - Never refresh summaries on `gate_verification_step_output`.
+
+3. **Wire all shared-cache event handlers to the same invalidator.**
+   - In `RemoteAgent.handleMessage()`: invalidate on `gate_signal_received`, `gate_status_changed`, `gate_reset`, `gate_verification_started`, `gate_verification_phase_started`, `gate_verification_step_started`, `gate_verification_step_complete`, `gate_verification_awaiting_human`, and `gate_verification_complete`.
+   - Keep `dispatchVerificationEvent()` for live detail rendering, but do not make it the only side effect.
+
+4. **Make dashboard stop partially owning shared summary writes.**
+   - Replace `applyGateState()`'s direct `state.gateStatusCache.set(...)` with a call to the shared derivation helper or shared invalidator.
+   - If dashboard needs immediate local rendering, update page-local `gates` first, then schedule shared summary refresh. Do not preserve stale sign-off counters from an old cache entry after events that can change them.
+
+5. **Align widget pill and popover sources.**
+   - Option A: widget remains local for popover details but calls the shared invalidator for every event where it refreshes `_gates` or `_awaitingSignoffs`.
+   - Option B: widget consumes the shared gate summary directly for the pill and local `_gates` only for row-level details.
+   - In both options, after successful `_resetGate()` and sign-off review submission, perform an immediate shared summary invalidation in addition to local refresh.
+
+6. **Expose richer summary if needed.**
+   - If deriving `verifyingCount` from slim `?view=summary` gates is fragile, extend the summary response with `verifying`, `verifyingCount`, and optionally `runningGateIds` computed server-side from `GateStore` plus `VerificationHarness.activeVerifications`.
+   - This avoids every client reimplementing the same active-state merge.
+
+7. **Add focused coverage after implementation.**
+   - Unit coverage for the debounced invalidator/coalescer: multiple events for one goal produce one fetch plus a trailing fetch if needed.
+   - Browser E2E comparing sidebar badge, widget pill/popover, dashboard pipeline, and dashboard gate list after: signal received, verification started/running/completed, human sign-off approved/rejected, explicit reset, and reload.
+   - Include a case where a human sign-off is approved and assert the sign-off pulse and `awaitingHumanSignoff` clear before final navigation/reload.
+
+## Suggested target architecture
+
+```text
+server WS/REST events
+        │
+        ├─ RemoteAgent session WS ─────┐
+        ├─ dashboard viewer WS ────────┼─ invalidateGateStatusForGoal(goalId, reason)
+        └─ widget viewer WS ───────────┘
+                                           │ debounce/coalesce per goal
+                                           ▼
+                           GET /api/goals/:id/gates?view=summary
+                                           │
+                                           ▼
+                              state.gateStatusCache update
+                                           │
+             ┌─────────────────────────────┼─────────────────────────────┐
+             ▼                             ▼                             ▼
+      sidebar badge              goal widget pill badge          dashboard progress/counts
+
+Dashboard `gates` and widget `_gates` may remain local detail caches, but they should no longer be independent authorities for summary counts.
+```
+
+## Bottom line
+
+The stale-count bug is not a server truth problem; the server already broadcasts the relevant lifecycle events and exposes enough REST state. The client has multiple independent caches and event handlers. Fix by making per-goal gate summary invalidation a single debounced path and wiring every gate lifecycle event that can affect counts, active/running state, sign-off state, or reset/downstream state into that path.

--- a/docs/design/gate-count-sync-issue-analysis.md
+++ b/docs/design/gate-count-sync-issue-analysis.md
@@ -11,6 +11,43 @@ Surfaces requested:
 
 Searches covered `docs/`, `tests/`, and `src/` for `gateStatusCache`, `refreshGateStatusForGoal`, `gate_signal_received`, `gate_status_changed`, `gate_reset`, `gate_verification_*`, human sign-off, and dashboard/widget/sidebar rendering paths.
 
+## Mechanical reproduction scenarios
+
+These are the user-visible stale-count flows the fix and tests should reproduce before implementation and prove fixed afterward.
+
+### Scenario A: running verification count diverges
+
+1. Create or open a workflow goal with at least two gates and a session attached to the goal.
+2. Open three surfaces at once: the sidebar goal row, the chat header `<goal-status-widget>` pill/popover, and the goal dashboard pipeline/list.
+3. Signal the first pending gate so the server emits `gate_signal_received`, then `gate_verification_started`, `gate_verification_phase_started`, and `gate_verification_step_started`.
+4. Expected current truth while verification is running: `passed=0`, `total=N`, `verifying=true`, `verifyingCount=1`.
+5. Failure symptom: dashboard live verification rows update immediately, but sidebar/widget badge can remain at `0/N` without the running colour/count because the shared cache does not refresh on every active verification event.
+6. After `gate_verification_complete` and `gate_status_changed`, all surfaces should converge to `1/N` passed with no running indicator.
+
+### Scenario B: human sign-off pulse/count remains stale after resolution
+
+1. Use a workflow gate with a `human-signoff` verification step and signal it.
+2. Wait for `gate_verification_awaiting_human`; expected truth is `awaitingSignoffCount=1`, `awaitingHumanSignoff=true`, and the widget pulse plus sidebar attention state are visible.
+3. Approve or reject the sign-off through the review pane, which POSTs `/api/goals/:goalId/gates/:gateId/signoff`.
+4. The server resumes the harness, clears `awaitingHuman`, and emits `gate_verification_step_complete`, then eventually `gate_verification_complete` / `gate_status_changed`.
+5. Failure symptom: widget local `_awaitingSignoffs` or dashboard live rows may update, but sidebar/widget badge can keep `awaitingHumanSignoff=true` until final completion, navigation, or polling because `gate_verification_step_complete` is not a shared-cache invalidation.
+6. Expected fixed behavior: the sign-off pulse and shared `awaitingSignoffCount` clear after successful POST and/or the step-complete WS event, before any reload.
+
+### Scenario C: reset invalidates downstream gates inconsistently
+
+1. Start from a goal with gate 1 and at least one downstream dependent gate passed, so all surfaces show e.g. `2/3`.
+2. Reset gate 1 from the goal status widget or dashboard.
+3. The server broadcasts `gate_status_changed` for affected gates and then `gate_reset` with affected/downstream IDs.
+4. Expected truth: selected and downstream gates become pending, active verification/sign-off counts for affected gates clear, and all surfaces show the lower passed count, e.g. `0/3`.
+5. Failure symptom: widget popover/dash list may refresh from their local handlers while sidebar/widget pill remains stale because `RemoteAgent` does not explicitly handle `gate_reset`, and dashboard may preserve stale sign-off counters when it writes the shared cache.
+6. Expected fixed behavior: `gate_reset` is an authoritative shared-summary invalidation and all surfaces match without reload.
+
+### Scenario D: reload/reconnect rehydrates truth
+
+1. Produce any of the states above: running verification, awaiting human sign-off, completed gate, or post-reset pending downstream gates.
+2. Reload the browser or reconnect the viewer/session websocket.
+3. Expected fixed behavior: surfaces rehydrate from `/api/goals/:id/gates?view=summary` plus active verification data and agree before user navigation.
+
 ## Affected files and symbols
 
 | Area | File | Symbols / paths | Current role |
@@ -32,6 +69,27 @@ Searches covered `docs/`, `tests/`, and `src/` for `gateStatusCache`, `refreshGa
 | Re-signal reset path | `src/server/server.ts` | `POST /api/goals/:goalId/gates/:gateId/signal` | If re-signaling a passed gate, `cascadeReset()` resets downstream and broadcasts `gate_status_changed` for downstream gates, then records/broadcasts the new signal. |
 | Human sign-off | `src/server/server.ts`, `src/server/agent/verification-harness.ts` | `/signoff`, `resolveSignoff()`, `gate_verification_awaiting_human`, step complete/final complete events | Sign-off resolution itself returns HTTP 200 without a direct cache event; follow-up harness events must clear `awaitingSignoffCount` and update pass/fail counts. |
 | Pinning / related tests | `tests/e2e/ui/goal-status-widget.spec.ts`, `tests/sidebar-goal-rendering.spec.ts`, `tests/notification-policy.spec.ts`, `tests/e2e/human-signoff.spec.ts`, `tests/gate-signal-step-enumeration.test.ts`, `tests/e2e/gate-signal-progress.spec.ts` | Existing coverage for widget flow, reset, badge rendering, notification policy, sign-off REST, and signal step enumeration. No focused test currently asserts every surface receives the same active verification count/state on each verification phase/step event and after sign-off resolution. |
+
+## Root-cause evidence with source references
+
+- `src/app/state.ts:274` defines `state.gateStatusCache`, the shared summary cache read by sidebar badges, notification policy, and the goal status widget pill.
+- `src/app/api.ts:757` fetches `/api/goals/:id/gates?view=summary`; `src/app/api.ts:772` refreshes all workflow goals; `src/app/api.ts:807` refreshes one goal. These helpers derive `passed`, `verifying`, `verifyingCount`, `awaitingSignoffCount`, and `awaitingHumanSignoff` client-side.
+- `src/app/api.ts:250` hydrates gate summaries during `refreshSessions()` only on initial load or goal list generation changes, so live correctness depends on WS invalidation between reloads.
+- `src/app/render-helpers.ts:675` reads `state.gateStatusCache` in `renderGateProgressBadge()`; `src/app/render-helpers.ts:728` and `src/app/render-helpers.ts:755` make sidebar goal rows fall back to that same badge.
+- `src/ui/components/GoalStatusWidget.ts:180` and `src/ui/components/GoalStatusWidget.ts:189` fetch widget-local full gates and active sign-offs, while `src/ui/components/GoalStatusWidget.ts:688` renders the pill count via the shared `renderGateProgressBadge(this.goalId)`. This creates an internal split between popover details and pill count.
+- `src/ui/components/GoalStatusWidget.ts:339` handles widget viewer WS events; `src/ui/components/GoalStatusWidget.ts:344` refreshes local data on `gate_reset`, and `src/ui/components/GoalStatusWidget.ts:351` refreshes active state on step start/complete. These handlers do not update the shared cache used by the pill.
+- `src/ui/components/GoalStatusWidget.ts:527` POSTs reset and `src/ui/components/GoalStatusWidget.ts:549` refreshes only widget-local gates/active sign-offs afterward.
+- `src/app/remote-agent.ts:1510` refreshes the shared cache for `gate_signal_received`; `src/app/remote-agent.ts:1514` refreshes it for `gate_status_changed`; `src/app/remote-agent.ts:1521` refreshes for `gate_verification_started`; `src/app/remote-agent.ts:1532` refreshes for `gate_verification_awaiting_human`; and `src/app/remote-agent.ts:1542` refreshes for `gate_verification_complete`.
+- `src/app/remote-agent.ts:1525` through `src/app/remote-agent.ts:1529` dispatch `gate_verification_phase_started`, `gate_verification_step_started`, `gate_verification_step_complete`, and `gate_verification_step_output` to live components but do not refresh the shared cache. `gate_verification_step_output` should stay detail-only, but phase/step started and step complete can affect effective running/sign-off state.
+- `src/app/remote-agent.ts` has no `gate_reset` case near the gate-event switch, so shared cache invalidation after reset relies on companion `gate_status_changed` broadcasts and ordering rather than the explicit reset event.
+- `src/app/goal-dashboard.ts:184` opens a dashboard viewer WS; `src/app/goal-dashboard.ts:212` refreshes full gates only for `gate_signal_received` and `gate_status_changed`; other verification events go to `dispatchVerificationEvent()`.
+- `src/app/goal-dashboard.ts:565` stores dashboard-local gates, then `src/app/goal-dashboard.ts:567` syncs to the shared sidebar cache. `src/app/goal-dashboard.ts:576` through `src/app/goal-dashboard.ts:579` preserve old sign-off counters because bare `/gates` does not include active sign-off aggregates.
+- `src/app/goal-dashboard.ts:697` refreshes full gates on `gate_verification_complete`, but dashboard live detail updates for earlier phase/step events do not necessarily update shared summary counts.
+- `src/app/review-sources.ts:296` starts human sign-off submission, `src/app/review-sources.ts:304` POSTs `/signoff`, and `src/app/review-sources.ts:319` already refreshes shared gate status after the successful POST. This is good but insufficient alone because other surfaces still need the WS invalidation path and trailing truth refresh.
+- `src/server/server.ts:5138` aggregates active verification human sign-offs into the `?view=summary` response consumed by the shared cache.
+- `src/server/server.ts:5306` implements explicit reset; `src/server/server.ts:5352` broadcasts `gate_status_changed` for affected gates, then `src/server/server.ts:5355` broadcasts `gate_reset`.
+- `src/server/server.ts:5551` cascade-resets downstream gates when re-signaling a passed gate, and `src/server/server.ts:5557` broadcasts downstream `gate_status_changed` events.
+- `src/server/server.ts:5694` handles human sign-off resolution. `src/server/agent/verification-harness.ts:799` resolves the parked sign-off promise; `src/server/agent/verification-harness.ts:2247` marks a human step awaiting; `src/server/agent/verification-harness.ts:2259` broadcasts `gate_verification_awaiting_human`; `src/server/agent/verification-harness.ts:2282` clears `awaitingHuman`; and `src/server/agent/verification-harness.ts:2324` broadcasts `gate_verification_step_complete`.
 
 ## Current data flow
 
@@ -183,9 +241,28 @@ Client implications:
    - This avoids every client reimplementing the same active-state merge.
 
 7. **Add focused coverage after implementation.**
-   - Unit coverage for the debounced invalidator/coalescer: multiple events for one goal produce one fetch plus a trailing fetch if needed.
-   - Browser E2E comparing sidebar badge, widget pill/popover, dashboard pipeline, and dashboard gate list after: signal received, verification started/running/completed, human sign-off approved/rejected, explicit reset, and reload.
-   - Include a case where a human sign-off is approved and assert the sign-off pulse and `awaitingHumanSignoff` clear before final navigation/reload.
+   - Unit coverage for the debounced invalidator/coalescer:
+     - Given three invalidating events for the same goal within the debounce window (`gate_signal_received`, `gate_verification_started`, `gate_verification_step_started`), expect one summary fetch and one cache write.
+     - Given one invalidation while a fetch is in flight, expect exactly one trailing fetch after the first completes.
+     - Given `gate_verification_step_output`, expect no summary fetch.
+     - Given invalidations for two different goals, expect independent per-goal fetches.
+   - Browser E2E: running verification sync.
+     - Start with a workflow goal showing `0/N` in sidebar badge, widget pill, widget popover, dashboard pipeline, and dashboard list.
+     - Signal the first gate and wait for `gate_verification_started` / `gate_verification_step_started`.
+     - Assert every count surface shows the same effective progress (`0/N` plus one running gate indicator, or the canonical running display chosen by the implementation) before completion.
+     - Wait for completion and assert all surfaces show `1/N` and no running indicator.
+   - Browser E2E: human sign-off resolution.
+     - Signal a gate with one human sign-off step.
+     - Assert sidebar/widget/dashboard agree on awaiting sign-off state: widget pulse visible, popover sign-off card visible, and shared count/cache state reflected in the badge/attention UI.
+     - Approve the sign-off from the review pane.
+     - Assert the widget pulse, popover sign-off card, shared `awaitingHumanSignoff`, and any dashboard live awaiting label clear after POST/`gate_verification_step_complete`, without requiring navigation or reload.
+     - Repeat or parameterize rejection so failed sign-off clears awaiting state and surfaces agree on failed/pending counts.
+   - Browser E2E: reset/downstream invalidation.
+     - Start with at least two passed gates, e.g. `2/3`.
+     - Reset the first gate from the widget or dashboard.
+     - Assert sidebar badge, widget pill/popover, dashboard pipeline, and dashboard gate list all show the reset selected/downstream gates pending and the same lower passed count (for the example, `0/3`).
+   - Browser E2E: reload persistence.
+     - After each of running, awaiting-signoff, completed, and reset states, reload the page and assert the surfaces rehydrate from server truth and keep matching.
 
 ## Suggested target architecture
 

--- a/docs/design/human-signoff-gates.md
+++ b/docs/design/human-signoff-gates.md
@@ -139,15 +139,16 @@ predicate:
   endpoint does not include the count — only the summary view (which
   sidebar polling already used) carries it. The cache-refresh fetch in
   `src/app/api.ts` uses `?view=summary`.
-- **Client.** `src/app/remote-agent.ts` handles the new
-  `gate_verification_awaiting_human` WS event by calling
-  `refreshGateStatusForGoal()` so the cache picks up the bit on park.
-  Resolution clears it via the existing `gate_verification_step_complete`
-  handler that already refreshes the cache.
+- **Client.** `src/app/remote-agent.ts` handles
+  `gate_verification_awaiting_human` and the other count-changing gate
+  lifecycle events by calling the shared per-goal summary invalidator, so the
+  cache picks up the bit on park. Resolution clears it through the immediate
+  review-pane refresh after `/signoff` plus the follow-up
+  `gate_verification_step_complete` invalidation.
 
 Without both, the policy data path is dead — rule 2 stays dormant
-indefinitely. That was the regression that the implementation gate's gap
-analysis caught and signal #8 fixed (`a75ca58`).
+indefinitely. See [gate-status-sync.md](../gate-status-sync.md) for the current
+cross-surface cache contract.
 
 ## Key files
 
@@ -163,7 +164,7 @@ analysis caught and signal #8 fixed (`a75ca58`).
 | `src/ui/components/AgentInterface.ts` | Mounts `<goal-status-widget>` next to `<git-status-widget>` for any session with a `goalId` / `teamGoalId` |
 | `src/app/render-helpers.ts` | `renderGateProgressBadge` and `renderGateStatusIcon` — shared visual vocabulary between sidebar, widget, and dashboard |
 | `src/app/notification-policy.ts` | `needsHumanAttention` + `needsImmediateHumanAttention` predicates |
-| `src/app/api.ts` · `src/app/remote-agent.ts` | Cache refresh wiring (`?view=summary` fetch + WS handler for `gate_verification_awaiting_human`) |
+| `src/app/api.ts` · `src/app/remote-agent.ts` | Shared summary refresh, debounced gate status invalidation, and WS handlers for count-changing gate events |
 | `src/app/state.ts` | `gateStatusCache` value shape — `awaitingHumanSignoff: boolean`; review document/source state |
 
 ## Pinning tests

--- a/docs/gate-status-sync.md
+++ b/docs/gate-status-sync.md
@@ -1,0 +1,90 @@
+# Gate status synchronization
+
+Gate progress appears in several client surfaces at once: sidebar goal rows, the chat-header goal status widget, and the goal dashboard. These surfaces need to agree while verification is running, after human sign-off decisions, and after reset cascades. Bobbit keeps that agreement by treating the per-goal gate summary cache as the shared count source and invalidating it from every event that can change count or active-state fields.
+
+## Shared summary cache
+
+The shared client cache is `state.gateStatusCache`, keyed by goal id. Each entry stores:
+
+- `passed` and `total`
+- `verifying` and `verifyingCount`
+- `awaitingSignoffCount`
+- `awaitingHumanSignoff`
+
+`refreshGateStatusForGoal(goalId)` performs an immediate refresh for one goal. `invalidateGateStatusForGoal(goalId, reason)` is the live-event path: it debounces per goal, coalesces duplicate invalidations while a fetch is in flight, and schedules a trailing refresh if another invalidation arrives before the current fetch finishes.
+
+The refresh fetches `GET /api/goals/:id/gates?view=summary`, derives the cache entry, and writes only when the value changed. A changed write:
+
+1. updates `state.gateStatusCache`,
+2. dispatches `bobbit-gate-status-cache-updated` with the affected goal ids, and
+3. renders the app unless the caller batched rendering.
+
+This keeps bursts of verification events from causing broad polling or redundant REST calls while still converging on server truth quickly.
+
+## Event invalidation contract
+
+These WebSocket events are count-changing or active-state-changing and must invalidate the shared summary for their `goalId`:
+
+- `gate_signal_received`
+- `gate_status_changed`
+- `gate_reset`
+- `gate_verification_started`
+- `gate_verification_phase_started`
+- `gate_verification_step_started`
+- `gate_verification_awaiting_human`
+- `gate_verification_step_complete`
+- `gate_verification_complete`
+
+`gate_verification_step_output` is detail-only. It streams stdout/stderr or other step output to live verification renderers and output modals, but it does not change gate pass counts, running counts, or sign-off counts, so it must not refetch the summary cache.
+
+Human sign-off resolution has two paths to truth:
+
+- the review-pane submitter performs an immediate `refreshGateStatusForGoal()` after a successful `/signoff` POST;
+- the follow-up verification events, especially `gate_verification_step_complete` and `gate_verification_complete`, also invalidate the summary through the shared debounced path.
+
+The immediate refresh makes the UI clear pending sign-off state promptly; the WebSocket refresh keeps all other open surfaces consistent with server truth.
+
+## Surface ownership
+
+### Sidebar
+
+Sidebar goal rows do not fetch gate detail themselves. They render `renderGateProgressBadge(goalId)`, which reads `state.gateStatusCache`. The sidebar therefore updates whenever the shared cache changes and the app re-renders.
+
+### Goal status widget
+
+The widget has two data sources with different purposes:
+
+- the pill and popover progress badge use `renderGateProgressBadge(goalId)`, so their count comes from `state.gateStatusCache`, matching the sidebar;
+- the popover gate rows and sign-off cards use widget-local `/gates` and `/verifications/active` fetches because they need row-level detail and substituted human-signoff prompts.
+
+The widget refreshes local detail on relevant viewer WebSocket events and also refreshes the shared summary. It listens for `bobbit-gate-status-cache-updated` and re-renders when its `goalId` is included, so cache changes caused by the session socket, dashboard socket, or review pane update the widget pill even if the widget did not initiate the refresh.
+
+### Goal dashboard
+
+The dashboard keeps its own full gate list and live verification map for pipeline rows, expanded signal detail, and live step output. It no longer writes partial entries into `state.gateStatusCache` from the full `/gates` response. Instead, dashboard gate changes schedule the same shared summary invalidator used by the sidebar and widget.
+
+The dashboard viewer WebSocket refreshes full gate detail on `gate_signal_received`, `gate_status_changed`, and `gate_reset`. Verification lifecycle events still go through the verification event bus for live detail rendering, and the count-changing subset also invalidates the shared summary.
+
+## Reset and downstream invalidation
+
+A gate reset can affect the selected gate and every downstream dependent gate. The server broadcasts per-gate status changes and a `gate_reset` envelope with affected ids. Clients treat `gate_reset` as an authoritative summary invalidation even though companion `gate_status_changed` events may also arrive.
+
+On reset:
+
+- the dashboard refetches full gate detail for the current goal;
+- the widget refetches local gate rows and active verification/sign-off state;
+- the shared summary is invalidated once per goal and coalesced with companion events;
+- selected and downstream passed counts, running state, and awaiting-signoff state clear without requiring navigation or reload.
+
+## Reload and reconnect behavior
+
+Initial load and goal-list generation changes call the all-goal summary refresh for workflow goals. Dashboard viewer WebSocket authentication also schedules a current-goal summary refresh. These paths rehydrate from server truth after reload or reconnect instead of relying on stale client cache entries.
+
+## Regression coverage
+
+Pinning coverage lives in both unit/API-style tests and browser E2E:
+
+- `tests/gate-status-cache-invalidation.test.ts` checks that session WebSocket handling invalidates the shared cache for every count-changing gate event, excludes `gate_verification_step_output`, exposes the debounced per-goal invalidator, and prevents the dashboard from writing partial shared-cache entries.
+- `tests/e2e/ui/goal-status-widget.spec.ts` covers cross-surface reset synchronization: sidebar badge, widget pill/popover, dashboard counts, dashboard gate rows, widget rows, and reload truth all converge after downstream reset invalidation.
+
+See `docs/design/gate-count-sync-issue-analysis.md` for the pre-fix issue analysis and stale-cache reproduction scenarios that motivated this architecture.

--- a/docs/goals-workflows-tasks.md
+++ b/docs/goals-workflows-tasks.md
@@ -628,7 +628,7 @@ All mutations require `projectId` (400 otherwise). Reads without `projectId` ret
 | `POST` | `/api/goals/:id/gates/:gateId/cancel-verification` | Cancel a stuck running verification (idempotent) |
 | `GET` | `/api/goals/:id/verifications/active` | Get in-flight verification state (running steps, sessions) |
 
-The gate list, gate detail, and task list endpoints support `?view=summary` for slim agent-facing responses. See [rest-api.md — Summary views](rest-api.md#summary-views-viewsummary) for response shapes, the [Gate reset endpoint](rest-api.md#gate-reset-endpoint) for reset response details, and the [Gate inspect endpoint](rest-api.md#gate-inspect-endpoint) for the `/inspect` endpoint.
+The gate list, gate detail, and task list endpoints support `?view=summary` for slim agent-facing responses. See [rest-api.md — Summary views](rest-api.md#summary-views-viewsummary) for response shapes, the [Gate reset endpoint](rest-api.md#gate-reset-endpoint) for reset response details, and the [Gate inspect endpoint](rest-api.md#gate-inspect-endpoint) for the `/inspect` endpoint. Client-side gate count surfaces share the synchronization rules in [gate-status-sync.md](gate-status-sync.md).
 
 ### Tasks (gate-linked)
 
@@ -667,6 +667,8 @@ State is per-project — each project has its own copies of these files in `<pro
 | `src/server/agent/task-store.ts` | Task persistence with `workflowGateId` and `inputGateIds` |
 | `src/server/agent/team-manager.ts` | Context injection via `buildDependencyContext()` |
 | `src/server/agent/system-prompt.ts` | System prompt assembly including gate context |
+| `src/app/api.ts` | Shared gate summary refresh and debounced per-goal invalidation |
+| `src/app/remote-agent.ts` | Session WebSocket handling, including gate summary invalidation events |
 | `src/app/goal-dashboard.ts` | Goal dashboard gate pipeline, focused route state, expanded gate/signal sections |
 | `src/ui/components/GoalStatusWidget.ts` | Chat-header gate popover, passed-gate View/Reset controls, sign-off launcher |
 | `defaults/tools/tasks/extension.ts` | Agent tools: `gate_signal`, `gate_status`, `gate_list`, `gate_inspect`, `task_create` |

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -767,6 +767,13 @@ async function fetchGoalGatesWithSignoffCount(goalId: string): Promise<{ gates: 
 	}
 }
 
+export const GATE_STATUS_CACHE_UPDATED_EVENT = "bobbit-gate-status-cache-updated";
+
+function emitGateStatusCacheUpdated(goalIds: string[]): void {
+	if (goalIds.length === 0 || typeof window === "undefined") return;
+	window.dispatchEvent(new CustomEvent(GATE_STATUS_CACHE_UPDATED_EVENT, { detail: { goalIds } }));
+}
+
 /** Fetch gate statuses for all goals with workflows and update the cache.
  *  Returns true if any data changed. When skipRender is true, the caller is responsible for renderApp(). */
 async function refreshGateStatusCache(skipRender = false): Promise<boolean> {
@@ -784,7 +791,7 @@ async function refreshGateStatusCache(skipRender = false): Promise<boolean> {
 		})
 	);
 
-	let changed = false;
+	const changedGoalIds: string[] = [];
 	for (const { goalId, passed, total, verifying, verifyingCount, awaitingSignoffCount } of results) {
 		const awaitingHumanSignoff = awaitingSignoffCount > 0;
 		const prev = state.gateStatusCache.get(goalId);
@@ -796,11 +803,14 @@ async function refreshGateStatusCache(skipRender = false): Promise<boolean> {
 			|| prev.awaitingSignoffCount !== awaitingSignoffCount
 			|| prev.awaitingHumanSignoff !== awaitingHumanSignoff) {
 			state.gateStatusCache.set(goalId, { passed, total, verifying, verifyingCount, awaitingSignoffCount, awaitingHumanSignoff });
-			changed = true;
+			changedGoalIds.push(goalId);
 		}
 	}
-	if (changed && !skipRender) renderApp();
-	return changed;
+	if (changedGoalIds.length > 0) {
+		emitGateStatusCacheUpdated(changedGoalIds);
+		if (!skipRender) renderApp();
+	}
+	return changedGoalIds.length > 0;
 }
 
 /** Refresh gate status cache for a single goal (called from WS event handlers). */
@@ -822,6 +832,7 @@ export async function refreshGateStatusForGoal(goalId: string): Promise<void> {
 		|| prev.awaitingSignoffCount !== awaitingSignoffCount
 		|| prev.awaitingHumanSignoff !== awaitingHumanSignoff) {
 		state.gateStatusCache.set(goalId, { passed, total, verifying, verifyingCount, awaitingSignoffCount, awaitingHumanSignoff });
+		emitGateStatusCacheUpdated([goalId]);
 		renderApp();
 	}
 }

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -767,6 +767,53 @@ async function fetchGoalGatesWithSignoffCount(goalId: string): Promise<{ gates: 
 	}
 }
 
+type GateStatusSummary = {
+	passed: number;
+	total: number;
+	verifying: boolean;
+	verifyingCount: number;
+	awaitingSignoffCount: number;
+	awaitingHumanSignoff: boolean;
+};
+
+const GATE_STATUS_INVALIDATION_DEBOUNCE_MS = 75;
+const _gateStatusInvalidateTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const _gateStatusInFlight = new Set<string>();
+const _gateStatusTrailing = new Set<string>();
+
+function deriveGateStatusSummary(goalId: string, gates: GateState[], awaitingSignoffCount: number): GateStatusSummary | null {
+	const goal = state.goals.find(g => g.id === goalId);
+	if (!goal?.workflow?.gates.length) return null;
+	const passed = gates.filter(gs => gs.status === "passed").length;
+	const total = goal.workflow.gates.length;
+	const verifying = gates.some(gs => gs.signals?.some((s: any) => s.verification?.status === "running"));
+	const verifyingCount = gates.filter(gs => gs.status !== "passed" && gs.signals?.some((s: any) => s.verification?.status === "running")).length;
+	const awaitingHumanSignoff = awaitingSignoffCount > 0;
+	return { passed, total, verifying, verifyingCount, awaitingSignoffCount, awaitingHumanSignoff };
+}
+
+function applyGateStatusSummary(goalId: string, next: GateStatusSummary | null, skipRender = false): boolean {
+	if (!next) return false;
+	const prev = state.gateStatusCache.get(goalId);
+	if (prev
+		&& prev.passed === next.passed
+		&& prev.total === next.total
+		&& prev.verifying === next.verifying
+		&& prev.verifyingCount === next.verifyingCount
+		&& prev.awaitingSignoffCount === next.awaitingSignoffCount
+		&& prev.awaitingHumanSignoff === next.awaitingHumanSignoff) {
+		return false;
+	}
+	state.gateStatusCache.set(goalId, next);
+	if (!skipRender) renderApp();
+	return true;
+}
+
+async function refreshGateStatusForGoalInternal(goalId: string, skipRender = false): Promise<boolean> {
+	const { gates, awaitingSignoffCount } = await fetchGoalGatesWithSignoffCount(goalId);
+	return applyGateStatusSummary(goalId, deriveGateStatusSummary(goalId, gates, awaitingSignoffCount), skipRender);
+}
+
 /** Fetch gate statuses for all goals with workflows and update the cache.
  *  Returns true if any data changed. When skipRender is true, the caller is responsible for renderApp(). */
 async function refreshGateStatusCache(skipRender = false): Promise<boolean> {
@@ -776,54 +823,52 @@ async function refreshGateStatusCache(skipRender = false): Promise<boolean> {
 	const results = await Promise.all(
 		goalsWithWorkflow.map(async (g) => {
 			const { gates, awaitingSignoffCount } = await fetchGoalGatesWithSignoffCount(g.id);
-			const passed = gates.filter(gs => gs.status === "passed").length;
-			const total = g.workflow!.gates.length;
-			const verifying = gates.some(gs => gs.signals?.some(s => s.verification?.status === "running"));
-			const verifyingCount = gates.filter(gs => gs.status !== "passed" && gs.signals?.some(s => s.verification?.status === "running")).length;
-			return { goalId: g.id, passed, total, verifying, verifyingCount, awaitingSignoffCount };
+			return { goalId: g.id, summary: deriveGateStatusSummary(g.id, gates, awaitingSignoffCount) };
 		})
 	);
 
 	let changed = false;
-	for (const { goalId, passed, total, verifying, verifyingCount, awaitingSignoffCount } of results) {
-		const awaitingHumanSignoff = awaitingSignoffCount > 0;
-		const prev = state.gateStatusCache.get(goalId);
-		if (!prev
-			|| prev.passed !== passed
-			|| prev.total !== total
-			|| prev.verifying !== verifying
-			|| prev.verifyingCount !== verifyingCount
-			|| prev.awaitingSignoffCount !== awaitingSignoffCount
-			|| prev.awaitingHumanSignoff !== awaitingHumanSignoff) {
-			state.gateStatusCache.set(goalId, { passed, total, verifying, verifyingCount, awaitingSignoffCount, awaitingHumanSignoff });
-			changed = true;
-		}
+	for (const { goalId, summary } of results) {
+		changed = applyGateStatusSummary(goalId, summary, true) || changed;
 	}
 	if (changed && !skipRender) renderApp();
 	return changed;
 }
 
-/** Refresh gate status cache for a single goal (called from WS event handlers). */
+/** Refresh gate status cache for a single goal immediately. */
 export async function refreshGateStatusForGoal(goalId: string): Promise<void> {
-	const goal = state.goals.find(g => g.id === goalId);
-	if (!goal?.workflow?.gates.length) return;
-	const { gates, awaitingSignoffCount } = await fetchGoalGatesWithSignoffCount(goalId);
-	const passed = gates.filter(gs => gs.status === "passed").length;
-	const total = goal.workflow.gates.length;
-	const verifying = gates.some(gs => gs.signals?.some((s: any) => s.verification?.status === "running"));
-	const verifyingCount = gates.filter(gs => gs.status !== "passed" && gs.signals?.some((s: any) => s.verification?.status === "running")).length;
-	const awaitingHumanSignoff = awaitingSignoffCount > 0;
-	const prev = state.gateStatusCache.get(goalId);
-	if (!prev
-		|| prev.passed !== passed
-		|| prev.total !== total
-		|| prev.verifying !== verifying
-		|| prev.verifyingCount !== verifyingCount
-		|| prev.awaitingSignoffCount !== awaitingSignoffCount
-		|| prev.awaitingHumanSignoff !== awaitingHumanSignoff) {
-		state.gateStatusCache.set(goalId, { passed, total, verifying, verifyingCount, awaitingSignoffCount, awaitingHumanSignoff });
-		renderApp();
+	await refreshGateStatusForGoalInternal(goalId);
+}
+
+async function runInvalidatedGateStatusRefresh(goalId: string): Promise<void> {
+	if (_gateStatusInFlight.has(goalId)) {
+		_gateStatusTrailing.add(goalId);
+		return;
 	}
+	_gateStatusInFlight.add(goalId);
+	try {
+		await refreshGateStatusForGoalInternal(goalId);
+	} finally {
+		_gateStatusInFlight.delete(goalId);
+		if (_gateStatusTrailing.delete(goalId)) {
+			invalidateGateStatusForGoal(goalId, "trailing");
+		}
+	}
+}
+
+/** Schedule a debounced per-goal gate status summary refresh from live events. */
+export function invalidateGateStatusForGoal(goalId: string | null | undefined, _reason = "gate-summary-invalidated"): void {
+	if (!goalId) return;
+	if (_gateStatusInFlight.has(goalId)) {
+		_gateStatusTrailing.add(goalId);
+		return;
+	}
+	const existing = _gateStatusInvalidateTimers.get(goalId);
+	if (existing) clearTimeout(existing);
+	_gateStatusInvalidateTimers.set(goalId, setTimeout(() => {
+		_gateStatusInvalidateTimers.delete(goalId);
+		void runInvalidatedGateStatusRefresh(goalId);
+	}, GATE_STATUS_INVALIDATION_DEBOUNCE_MS));
 }
 
 /** Fetch PR status for all goals with branches and update the cache.

--- a/src/app/goal-dashboard.ts
+++ b/src/app/goal-dashboard.ts
@@ -6,7 +6,7 @@ import "../ui/components/CostPopover.js";
 import { ansiToHtml, hasAnsi } from "../ui/utils/ansi.js";
 import { Button } from "@mariozechner/mini-lit/dist/Button.js";
 import { state, renderApp, type Goal } from "./state.js";
-import { gatewayFetch, deleteGoal, startTeam, teardownTeam, getTeamState, fetchGoalGates, fetchRoles, refreshPrStatusCache, fetchArchivedSessions, archivedSessionsLoaded, fetchGoalGitStatus, type GateState, type GateSignal } from "./api.js";
+import { gatewayFetch, deleteGoal, startTeam, teardownTeam, getTeamState, fetchGoalGates, fetchRoles, refreshPrStatusCache, fetchArchivedSessions, archivedSessionsLoaded, fetchGoalGitStatus, invalidateGateStatusForGoal, type GateState, type GateSignal } from "./api.js";
 import { runGitStatusRefresh, abortableSleep } from "./git-status-refresh.js";
 import { dispatchVerificationEvent } from "./verification-event-bus.js";
 import { getRouteFromHash, setGoalDashboardRoute, setHashRoute, type DashboardTabId } from "./routing.js";
@@ -181,6 +181,22 @@ let roleDropdownOpen = false;
 // DASHBOARD EVENT WEBSOCKET
 // ============================================================================
 
+const GATE_SUMMARY_INVALIDATING_EVENTS = new Set([
+	"gate_signal_received",
+	"gate_status_changed",
+	"gate_reset",
+	"gate_verification_started",
+	"gate_verification_phase_started",
+	"gate_verification_step_started",
+	"gate_verification_awaiting_human",
+	"gate_verification_step_complete",
+	"gate_verification_complete",
+]);
+
+function scheduleSharedGateSummaryRefresh(goalId: string | null | undefined, reason: string): void {
+	invalidateGateStatusForGoal(goalId, reason);
+}
+
 function connectDashboardWs(): void {
 	dashboardWsIntentionalClose = false;
 	const protocol = location.protocol === "https:" ? "wss:" : "ws:";
@@ -206,10 +222,14 @@ function connectDashboardWs(): void {
 			const msg = JSON.parse(event.data as string);
 			if (msg?.type === "auth_ok") {
 				subscribeToCurrentGoal();
+				scheduleSharedGateSummaryRefresh(currentGoalId, "dashboard-ws-auth-ok");
 				return;
 			}
 			if (typeof msg?.goalId === "string" && msg.goalId !== currentGoalId) return;
-			if (msg?.type === "gate_signal_received" || msg?.type === "gate_status_changed") {
+			if (typeof msg?.goalId === "string" && GATE_SUMMARY_INVALIDATING_EVENTS.has(msg.type)) {
+				scheduleSharedGateSummaryRefresh(msg.goalId, msg.type);
+			}
+			if (msg?.type === "gate_signal_received" || msg?.type === "gate_status_changed" || msg?.type === "gate_reset") {
 				refreshGatesFromWsEvent(msg.goalId);
 			}
 			dispatchVerificationEvent(msg);
@@ -323,6 +343,7 @@ export async function loadDashboardData(goalId: string): Promise<void> {
 		}
 
 		gates = fetchedGates;
+		scheduleSharedGateSummaryRefresh(goalId, "dashboard-load");
 		applyDashboardRouteFocus(goalId);
 
 		if (gitStatusRes && gitStatusRes.ok) {
@@ -564,21 +585,7 @@ function stopAgentPolling(): void {
 
 function applyGateState(goalId: string, newGates: GateState[]): void {
 	gates = newGates;
-	// Sync to sidebar gate status cache
-	const goal = state.goals.find(g => g.id === goalId);
-	if (goal?.workflow?.gates.length) {
-		const passed = newGates.filter((g: any) => g.status === "passed").length;
-		const total = goal.workflow.gates.length;
-		const verifying = newGates.some((g: any) => g.signals?.some((s: any) => s.verification?.status === "running"));
-		const verifyingCount = newGates.filter((g: any) => g.status !== "passed" && g.signals?.some((s: any) => s.verification?.status === "running")).length;
-		// Preserve human-sign-off counters from the previous cache entry — the
-		// dashboard refresh path does not know about pending sign-offs; only
-		// `refreshGateStatusCache` / `refreshGateStatusForGoal` in api.ts do.
-		const prev = state.gateStatusCache.get(goalId);
-		const awaitingSignoffCount = prev?.awaitingSignoffCount ?? 0;
-		const awaitingHumanSignoff = prev?.awaitingHumanSignoff ?? false;
-		state.gateStatusCache.set(goalId, { passed, total, verifying, verifyingCount, awaitingSignoffCount, awaitingHumanSignoff });
-	}
+	scheduleSharedGateSummaryRefresh(goalId, "dashboard-gates-updated");
 }
 
 function refreshGatesFromWsEvent(goalId: string): void {

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -34,7 +34,7 @@ import { closeReviewWorkspaceTabs, selectReviewWorkspaceTab, selectSensiblePanel
 import { clearPersistedReviewDocuments, openMarkdownReviewDocument, removePersistedReviewDocument, restorePersistedReviewDocuments } from "./review-sources.js";
 import { showFaviconBadge } from "./favicon-badge.js";
 import { needsHumanAttention, needsImmediateHumanAttention } from "./notification-policy.js";
-import { refreshGateStatusForGoal } from "./api.js";
+import { invalidateGateStatusForGoal } from "./api.js";
 import { dispatchVerificationEvent } from "./verification-event-bus.js";
 import { createSystemNotification } from "./custom-messages.js";
 import { clearAnnotations, clearAllAnnotations, isReviewSubmitted, clearReviewSubmitted, initAnnotationStore } from "../ui/components/review/AnnotationStore.js";
@@ -1508,23 +1508,27 @@ export class RemoteAgent {
 			}
 
 			case "gate_signal_received":
-				refreshGateStatusForGoal((msg as any).goalId);
+				invalidateGateStatusForGoal((msg as any).goalId, "gate_signal_received");
 				break;
 
 			case "gate_status_changed": {
 				const gateCat = (msg as any).status === "failed" ? "error" as const : "task" as const;
 				this._appendNotification(`Gate "${(msg as any).gateId}" \u2192 ${(msg as any).status}`, gateCat);
-				refreshGateStatusForGoal((msg as any).goalId);
+				invalidateGateStatusForGoal((msg as any).goalId, "gate_status_changed");
 				break;
 			}
 
-			case "gate_verification_started":
-				dispatchVerificationEvent(msg);
-				refreshGateStatusForGoal((msg as any).goalId);
+			case "gate_reset":
+				invalidateGateStatusForGoal((msg as any).goalId, "gate_reset");
 				break;
+
+			case "gate_verification_started":
 			case "gate_verification_phase_started":
 			case "gate_verification_step_complete":
 			case "gate_verification_step_started":
+				dispatchVerificationEvent(msg);
+				invalidateGateStatusForGoal((msg as any).goalId, (msg as any).type);
+				break;
 			case "gate_verification_step_output":
 				dispatchVerificationEvent(msg);
 				break;
@@ -1536,14 +1540,14 @@ export class RemoteAgent {
 				// read-state-bypassing trigger for pending sign-offs) stays
 				// dormant until a sidebar poll catches up.
 				dispatchVerificationEvent(msg);
-				refreshGateStatusForGoal((msg as any).goalId);
+				invalidateGateStatusForGoal((msg as any).goalId, "gate_verification_awaiting_human");
 				break;
 
 			case "gate_verification_complete": {
 				const gateVerifCat = (msg as any).status === "failed" ? "error" as const : "task" as const;
 				this._appendNotification(`Gate "${(msg as any).gateId}" verification ${(msg as any).status}`, gateVerifCat);
 				dispatchVerificationEvent(msg);
-				refreshGateStatusForGoal((msg as any).goalId);
+				invalidateGateStatusForGoal((msg as any).goalId, "gate_verification_complete");
 				break;
 			}
 

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -1518,6 +1518,10 @@ export class RemoteAgent {
 				break;
 			}
 
+			case "gate_reset":
+				refreshGateStatusForGoal((msg as any).goalId);
+				break;
+
 			case "gate_verification_started":
 				dispatchVerificationEvent(msg);
 				refreshGateStatusForGoal((msg as any).goalId);
@@ -1525,6 +1529,9 @@ export class RemoteAgent {
 			case "gate_verification_phase_started":
 			case "gate_verification_step_complete":
 			case "gate_verification_step_started":
+				dispatchVerificationEvent(msg);
+				refreshGateStatusForGoal((msg as any).goalId);
+				break;
 			case "gate_verification_step_output":
 				dispatchVerificationEvent(msg);
 				break;

--- a/src/ui/components/GoalStatusWidget.ts
+++ b/src/ui/components/GoalStatusWidget.ts
@@ -34,6 +34,8 @@ import { ensureMarkdownBlock } from "../lazy/markdown-block.js";
 import { renderGateProgressBadge, renderGateStatusIcon } from "../../app/render-helpers.js";
 import { setHashRoute } from "../../app/routing.js";
 
+const GATE_STATUS_CACHE_UPDATED_EVENT = "bobbit-gate-status-cache-updated";
+
 type GateStatus = "pending" | "passed" | "failed" | "running";
 
 interface GateSummary {
@@ -82,6 +84,13 @@ export class GoalStatusWidget extends LitElement {
 		if (this._expanded) this._closeDropdown();
 	};
 
+	private _onGateStatusCacheUpdated = (event: Event) => {
+		const detail = (event as CustomEvent<{ goalIds?: string[] }>).detail;
+		if (!this.goalId || (Array.isArray(detail?.goalIds) && !detail.goalIds.includes(this.goalId))) return;
+		this.requestUpdate();
+		this._syncDropdown();
+	};
+
 	private _onDocumentClick = (e: MouseEvent) => {
 		const target = e.target as Node;
 		if (this._expanded && !this._closing && !this.contains(target) && !this._dropdownEl?.contains(target)) {
@@ -108,6 +117,7 @@ export class GoalStatusWidget extends LitElement {
 		document.addEventListener("click", this._onDocumentClick, true);
 		document.addEventListener("keydown", this._onEscapeKey, true);
 		window.addEventListener("hashchange", this._onHashChange);
+		window.addEventListener(GATE_STATUS_CACHE_UPDATED_EVENT, this._onGateStatusCacheUpdated);
 		this._ensureWidgetStyles();
 		if (this.goalId) {
 			void this._fetchInitial();
@@ -120,6 +130,7 @@ export class GoalStatusWidget extends LitElement {
 		document.removeEventListener("click", this._onDocumentClick, true);
 		document.removeEventListener("keydown", this._onEscapeKey, true);
 		window.removeEventListener("hashchange", this._onHashChange);
+		window.removeEventListener(GATE_STATUS_CACHE_UPDATED_EVENT, this._onGateStatusCacheUpdated);
 		this._closeToken++;
 		this._removeDropdown();
 		this._disconnectWs();
@@ -174,6 +185,7 @@ export class GoalStatusWidget extends LitElement {
 		} catch {
 			// non-fatal — WS events will rehydrate
 		}
+		await this._refreshSharedGateStatus();
 		this._loading = false;
 	}
 
@@ -196,6 +208,27 @@ export class GoalStatusWidget extends LitElement {
 				this._activeGateIds = this._extractActiveGateIds(data.verifications);
 			}
 		} catch { /* non-fatal */ }
+	}
+
+	private async _refreshSharedGateStatus(): Promise<void> {
+		if (!this.goalId) return;
+		try {
+			const { refreshGateStatusForGoal } = await import("../../app/api.js");
+			await refreshGateStatusForGoal(this.goalId);
+		} catch { /* non-fatal */ }
+		this.requestUpdate();
+		this._syncDropdown();
+	}
+
+	private async _refreshWidgetState(options: { gates?: boolean; active?: boolean; shared?: boolean } = {}): Promise<void> {
+		const { gates = false, active = false, shared = true } = options;
+		const tasks: Promise<void>[] = [];
+		if (gates) tasks.push(this._refreshGates());
+		if (active) tasks.push(this._refreshActive());
+		if (shared) tasks.push(this._refreshSharedGateStatus());
+		await Promise.all(tasks);
+		this.requestUpdate();
+		this._syncDropdown();
 	}
 
 	private async _fetch(path: string, init?: RequestInit): Promise<Response | null> {
@@ -344,19 +377,19 @@ export class GoalStatusWidget extends LitElement {
 			case "gate_reset":
 			case "gate_verification_complete":
 			case "gate_verification_phase_started":
-				void this._refreshGates();
-				void this._refreshActive();
+				void this._refreshWidgetState({ gates: true, active: true });
 				break;
 			case "gate_verification_step_started":
+				void this._refreshWidgetState({ active: true });
+				break;
 			case "gate_verification_step_complete":
-				void this._refreshActive();
-				if (t === "gate_verification_step_complete") void this._refreshGates();
+				void this._refreshWidgetState({ gates: true, active: true });
 				break;
 			case "gate_verification_awaiting_human": {
 				const signalId = typeof msg.signalId === "string" ? msg.signalId : null;
 				const gateId = typeof msg.gateId === "string" ? msg.gateId : null;
 				const stepName = typeof msg.stepName === "string" ? msg.stepName : null;
-				if (!signalId || !gateId || !stepName) { void this._refreshActive(); break; }
+				if (!signalId || !gateId || !stepName) { void this._refreshWidgetState({ active: true }); break; }
 				const label = typeof msg.label === "string" ? msg.label : stepName;
 				const prompt = typeof msg.prompt === "string" ? msg.prompt : "";
 				// Dedupe — replace any existing entry for the same key.
@@ -364,6 +397,7 @@ export class GoalStatusWidget extends LitElement {
 				const filtered = this._awaitingSignoffs.filter(s => signoffKey(s) !== key);
 				filtered.push({ signalId, gateId, stepName, label, prompt });
 				this._awaitingSignoffs = filtered;
+				void this._refreshSharedGateStatus();
 				break;
 			}
 			default:
@@ -546,7 +580,7 @@ export class GoalStatusWidget extends LitElement {
 			});
 			if (!resp) throw new Error("Unable to reset gate (network)");
 			if (!resp.ok) throw new Error(await this._resetErrorMessage(resp));
-			await Promise.all([this._refreshGates(), this._refreshActive()]);
+			await this._refreshWidgetState({ gates: true, active: true });
 		} catch (err) {
 			const next = new Map(this._resetErrors);
 			next.set(gate.id, err instanceof Error ? err.message : "Unable to reset gate");

--- a/tests/e2e/ui/goal-status-widget.spec.ts
+++ b/tests/e2e/ui/goal-status-widget.spec.ts
@@ -164,6 +164,39 @@ async function expectSidebarGateBadge(page: Page, goalId: string, passed: number
 		.toBeVisible({ timeout: 15_000 });
 }
 
+async function resetGoalGate(goalId: string, gateId: string): Promise<any> {
+	const res = await apiFetch(`/api/goals/${goalId}/gates/${gateId}/reset`, {
+		method: "POST",
+		body: JSON.stringify({ reason: "browser E2E gate reset sync coverage" }),
+	});
+	const text = await res.text();
+	expect(res.status, `reset ${gateId} failed: ${res.status} ${text}`).toBe(200);
+	return text ? JSON.parse(text) : null;
+}
+
+async function ensureGoalWidgetPopoverOpen(page: Page): Promise<void> {
+	const dropdown = page.locator("#goal-status-dropdown").first();
+	if (await dropdown.isVisible().catch(() => false)) return;
+	await page.locator("[data-testid='goal-status-widget-pill']").first().click();
+	await expect(dropdown).toBeVisible({ timeout: 10_000 });
+}
+
+async function expectWidgetGateSummary(page: Page, passed: number, total: number): Promise<void> {
+	const title = `${passed} of ${total} gates passed`;
+	const pill = page.locator("[data-testid='goal-status-widget-pill']").first();
+	await expect(pill).toBeVisible({ timeout: 15_000 });
+	await expect(pill, "widget-local pill title should match gate truth").toHaveAttribute("title", new RegExp(`Goal status: ${passed}/${total} gates passed`), { timeout: 15_000 });
+	await expect(pill.locator(`span[title="${title}"]`).first(), "widget pill shared badge should match sidebar badge").toBeVisible({ timeout: 15_000 });
+
+	await ensureGoalWidgetPopoverOpen(page);
+	await expect(page.locator(`#goal-status-dropdown span[title="${title}"]`).first(), "widget popover shared badge should match sidebar badge").toBeVisible({ timeout: 15_000 });
+}
+
+async function expectDashboardGateCount(page: Page, passed: number, total: number): Promise<void> {
+	await expect(page.locator(".wf-checklist-count").first()).toHaveText(`${passed}/${total} passed`, { timeout: 15_000 });
+	await expect(page.locator(".wf-progress-label").first()).toHaveText(`${passed}/${total} gates passed`, { timeout: 15_000 });
+}
+
 async function addInlineAnnotationToActiveReview(page: Page, comment: string): Promise<void> {
 	await page.evaluate(({ commentText, quoteText }) => {
 		const doc = document.querySelector("review-document") as any;
@@ -770,6 +803,86 @@ test.describe("<goal-status-widget>", () => {
 			await expect(page.locator(`[data-testid="goal-dashboard-signal-entry"][data-signal-id="${signalId}"]`)).toHaveAttribute("data-focused", "true", { timeout: 10_000 });
 		} finally {
 			if (sessionId) await deleteSession(sessionId).catch(() => { /* ignore */ });
+			await deleteGoal(goalId).catch(() => { /* ignore */ });
+		}
+	});
+
+	test("API gate_reset keeps sidebar badge, widget pill/popover, dashboard, and reload truth in sync", async ({ page, context }) => {
+		test.setTimeout(60_000);
+		const goal = await createGoal({
+			title: `Goal-Status-Widget Reset Sync ${Date.now()}`,
+			workflowId: "test-fast",
+			worktree: false,
+			team: true,
+			autoStartTeam: false,
+		});
+		const goalId = goal.id;
+		let teamLeadId: string | undefined;
+		let dashboardPage: Page | undefined;
+		try {
+			teamLeadId = await startTeam(goalId);
+			await waitForSessionStatus(teamLeadId, "idle", 30_000);
+
+			await signalGoalGate(goalId, "design-doc", "# Design Doc\n\nInitial pass for cross-surface reset sync.");
+			await waitForGateStatus(goalId, "design-doc", "passed", 20_000);
+			await signalGoalGate(goalId, "implementation", "# Implementation\n\nInitial downstream pass.");
+			await waitForGateStatus(goalId, "implementation", "passed", 20_000);
+			await signalGoalGate(goalId, "ready-to-merge", "# Ready\n\nInitial transitive pass.");
+			await waitForGateStatus(goalId, "ready-to-merge", "passed", 20_000);
+
+			dashboardPage = await context.newPage();
+			await openApp(dashboardPage);
+			await navigateToHash(dashboardPage, `#/goal/${goalId}?tab=gates`);
+			await expectDashboardGateCount(dashboardPage, 3, 3);
+			for (const gateId of ["design-doc", "implementation", "ready-to-merge"]) {
+				await expectDashboardGateStatus(dashboardPage, gateId, "passed");
+			}
+
+			await openApp(page);
+			await openSession(page, teamLeadId);
+			await expectSidebarGateBadge(page, goalId, 3, 3);
+			await expectWidgetGateSummary(page, 3, 3);
+			for (const gateId of ["design-doc", "implementation", "ready-to-merge"]) {
+				await ensureGoalWidgetGateVisible(page, gateId);
+				await expect(page.locator(`[data-testid="goal-widget-gate"][data-gate-id="${gateId}"]`))
+					.toHaveAttribute("data-gate-status", "passed", { timeout: 10_000 });
+			}
+
+			const resetBody = await resetGoalGate(goalId, "design-doc");
+			expect(resetBody.affectedGateIds).toEqual(expect.arrayContaining(["design-doc", "implementation", "ready-to-merge"]));
+			expect(resetBody.changedGateIds).toEqual(expect.arrayContaining(["design-doc", "implementation", "ready-to-merge"]));
+
+			await expectSidebarGateBadge(page, goalId, 0, 3);
+			await expectWidgetGateSummary(page, 0, 3);
+			await expectDashboardGateCount(dashboardPage, 0, 3);
+			for (const gateId of ["design-doc", "implementation", "ready-to-merge"]) {
+				await waitForGateStatus(goalId, gateId, "pending", 20_000);
+				await ensureGoalWidgetGateVisible(page, gateId);
+				await expect(page.locator(`[data-testid="goal-widget-gate"][data-gate-id="${gateId}"]`))
+					.toHaveAttribute("data-gate-status", "pending", { timeout: 15_000 });
+				await expectDashboardGateStatus(dashboardPage, gateId, "pending");
+			}
+
+			await page.reload();
+			await openSession(page, teamLeadId);
+			await expectSidebarGateBadge(page, goalId, 0, 3);
+			await expectWidgetGateSummary(page, 0, 3);
+			for (const gateId of ["design-doc", "implementation", "ready-to-merge"]) {
+				await ensureGoalWidgetGateVisible(page, gateId);
+				await expect(page.locator(`[data-testid="goal-widget-gate"][data-gate-id="${gateId}"]`))
+					.toHaveAttribute("data-gate-status", "pending", { timeout: 15_000 });
+			}
+
+			await dashboardPage.reload();
+			await navigateToHash(dashboardPage, `#/goal/${goalId}?tab=gates`);
+			await expectDashboardGateCount(dashboardPage, 0, 3);
+			for (const gateId of ["design-doc", "implementation", "ready-to-merge"]) {
+				await expectDashboardGateStatus(dashboardPage, gateId, "pending");
+			}
+		} finally {
+			if (dashboardPage) await dashboardPage.close().catch(() => { /* ignore */ });
+			if (teamLeadId) await deleteSession(teamLeadId).catch(() => { /* ignore */ });
+			await teardownTeam(goalId).catch(() => { /* ignore */ });
 			await deleteGoal(goalId).catch(() => { /* ignore */ });
 		}
 	});

--- a/tests/gate-status-cache-invalidation.test.ts
+++ b/tests/gate-status-cache-invalidation.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const REMOTE_AGENT_SOURCE = readFileSync(new URL("../src/app/remote-agent.ts", import.meta.url), "utf8");
+
+function stripComments(source: string): string {
+	return source
+		.replace(/\/\*[\s\S]*?\*\//g, "")
+		.replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+
+function caseStatements(source: string, eventType: string): string | null {
+	const withoutComments = stripComments(source);
+	const caseNeedle = `case "${eventType}":`;
+	const caseIndex = withoutComments.indexOf(caseNeedle);
+	if (caseIndex < 0) return null;
+
+	let labelEnd = caseIndex + caseNeedle.length;
+	let searchFrom = labelEnd;
+
+	// Consecutive `case` labels share the same statements. Skip forward until the
+	// first non-label text so grouped gate events are checked against the block
+	// they actually execute.
+	while (true) {
+		const remainder = withoutComments.slice(searchFrom);
+		const match = remainder.match(/^\s*case\s+"[^"]+"\s*:/);
+		if (!match) break;
+		labelEnd = searchFrom + match[0].length;
+		searchFrom = labelEnd;
+	}
+
+	const nextBreak = withoutComments.indexOf("break;", labelEnd);
+	assert.notEqual(nextBreak, -1, `Could not find break for ${eventType}`);
+	return withoutComments.slice(labelEnd, nextBreak);
+}
+
+function hasGateSummaryInvalidation(statements: string): boolean {
+	return /\b(?:refreshGateStatusForGoal|invalidateGateStatusForGoal)\s*\(/.test(statements);
+}
+
+test("RemoteAgent invalidates shared gate summary cache for every count-changing gate event", () => {
+	const eventsThatMustInvalidate = [
+		"gate_signal_received",
+		"gate_status_changed",
+		"gate_reset",
+		"gate_verification_started",
+		"gate_verification_phase_started",
+		"gate_verification_step_started",
+		"gate_verification_awaiting_human",
+		"gate_verification_step_complete",
+		"gate_verification_complete",
+	];
+
+	const missing = eventsThatMustInvalidate.filter((eventType) => {
+		const statements = caseStatements(REMOTE_AGENT_SOURCE, eventType);
+		return !statements || !hasGateSummaryInvalidation(statements);
+	});
+
+	assert.deepEqual(
+		missing,
+		[],
+		`Expected RemoteAgent to refresh gate summary cache for event(s): ${missing.join(", ")}`,
+	);
+});
+
+test("RemoteAgent does not refetch gate summaries for detail-only step output", () => {
+	const statements = caseStatements(REMOTE_AGENT_SOURCE, "gate_verification_step_output");
+	assert.ok(statements, "gate_verification_step_output case should exist");
+	assert.equal(
+		hasGateSummaryInvalidation(statements!),
+		false,
+		"gate_verification_step_output should not refresh gate summary cache",
+	);
+});

--- a/tests/gate-status-cache-invalidation.test.ts
+++ b/tests/gate-status-cache-invalidation.test.ts
@@ -3,6 +3,8 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 const REMOTE_AGENT_SOURCE = readFileSync(new URL("../src/app/remote-agent.ts", import.meta.url), "utf8");
+const API_SOURCE = readFileSync(new URL("../src/app/api.ts", import.meta.url), "utf8");
+const DASHBOARD_SOURCE = readFileSync(new URL("../src/app/goal-dashboard.ts", import.meta.url), "utf8");
 
 function stripComments(source: string): string {
 	return source
@@ -72,4 +74,39 @@ test("RemoteAgent does not refetch gate summaries for detail-only step output", 
 		false,
 		"gate_verification_step_output should not refresh gate summary cache",
 	);
+});
+
+test("api.ts exposes a debounced per-goal shared gate summary invalidator", () => {
+	assert.match(API_SOURCE, /export function invalidateGateStatusForGoal\s*\(/, "expected exported invalidator");
+	assert.match(API_SOURCE, /GATE_STATUS_INVALIDATION_DEBOUNCE_MS/, "expected debounce window");
+	assert.match(API_SOURCE, /_gateStatusInvalidateTimers/, "expected per-goal debounce timers");
+	assert.match(API_SOURCE, /_gateStatusInFlight/, "expected per-goal in-flight coalescing");
+	assert.match(API_SOURCE, /_gateStatusTrailing/, "expected trailing refresh coalescing");
+	assert.match(API_SOURCE, /setTimeout\s*\(/, "expected invalidations to be scheduled, not fetched inline");
+});
+
+test("Goal dashboard schedules shared summary refreshes without writing partial cache entries", () => {
+	assert.doesNotMatch(
+		DASHBOARD_SOURCE,
+		/state\.gateStatusCache\.set\s*\(/,
+		"dashboard must not write stale partial signoff counters into state.gateStatusCache",
+	);
+	assert.match(DASHBOARD_SOURCE, /invalidateGateStatusForGoal/, "dashboard should use the shared gate summary invalidator");
+
+	const eventSet = DASHBOARD_SOURCE.match(/GATE_SUMMARY_INVALIDATING_EVENTS\s*=\s*new Set\(\[([\s\S]*?)\]\)/)?.[1] ?? "";
+	const eventsThatMustInvalidate = [
+		"gate_signal_received",
+		"gate_status_changed",
+		"gate_reset",
+		"gate_verification_started",
+		"gate_verification_phase_started",
+		"gate_verification_step_started",
+		"gate_verification_awaiting_human",
+		"gate_verification_step_complete",
+		"gate_verification_complete",
+	];
+	for (const eventType of eventsThatMustInvalidate) {
+		assert.match(eventSet, new RegExp(`"${eventType}"`), `dashboard should invalidate on ${eventType}`);
+	}
+	assert.doesNotMatch(eventSet, /"gate_verification_step_output"/, "step output is detail-only and should not invalidate summaries");
 });


### PR DESCRIPTION
## Summary
- Added a debounced per-goal shared gate summary invalidation path for count/status-changing gate lifecycle events.
- Kept `gate_verification_step_output` detail-only while syncing sidebar, goal status widget, and dashboard state on signal, verification, sign-off, reset, reconnect, and reload flows.
- Added unit/static regression coverage, browser E2E reset/reload coverage, and documentation for the new synchronization contract.

## Validation
- `npx tsx --test --test-force-exit tests/gate-status-cache-invalidation.test.ts`
- `npm run check`
- `npm run test:unit`
- `npm run build --silent && npx playwright test --config playwright-e2e.config.ts --project=browser tests/e2e/ui/goal-status-widget.spec.ts -g "API gate_reset keeps sidebar badge"`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
