### PR TITLE
Send Bobbit User-Agent to AI Gateway

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,7 +55,57 @@ RUN npx -y playwright@1.52.0 install-deps chromium 2>/dev/null \
 ARG PI_AGENT_VERSION=0.74.0
 RUN npm install -g @earendil-works/pi-coding-agent@${PI_AGENT_VERSION} --no-audit --no-fund 2>/dev/null \
     && ln -sf $(npm root -g) /node_modules
+RUN node --input-type=module <<'NODE'
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { execSync } from "node:child_process";
+const marker = "bobbit-pi-ai-bedrock-headers-patch-v1";
+const helper = `
+const BOBBIT_PI_AI_BEDROCK_HEADERS_PATCH = "${marker}";
+function applyBobbitBedrockRequestHeaders(client, model, options) {
+    if (model?.provider !== "aigw") return;
+    const headerSource = options?.headers;
+    if (!headerSource || typeof headerSource !== "object") return;
+    const headerEntries = Object.entries(headerSource).filter((entry) => typeof entry[1] === "string" && entry[1].length > 0);
+    if (headerEntries.length === 0) return;
+    const middleware = (next) => async (args) => {
+        const requestHeaders = args?.request?.headers;
+        if (requestHeaders && typeof requestHeaders === "object") {
+            for (const [key, value] of headerEntries) {
+                const lowerKey = key.toLowerCase();
+                for (const existingKey of Object.keys(requestHeaders)) {
+                    if (existingKey.toLowerCase() === lowerKey) delete requestHeaders[existingKey];
+                }
+                requestHeaders[key] = value;
+            }
+        }
+        return next(args);
+    };
+    try {
+        client.middlewareStack.addRelativeTo(middleware, { relation: "after", toMiddleware: "getUserAgentMiddleware", name: "bobbitBedrockRequestHeadersMiddleware", override: true });
+    }
+    catch {
+        client.middlewareStack.add(middleware, { step: "build", priority: "low", name: "bobbitBedrockRequestHeadersMiddleware", override: true });
+    }
+}
+`;
+const npmRoot = execSync("npm root -g", { encoding: "utf8" }).trim();
+const candidates = [
+  path.join(npmRoot, "@earendil-works", "pi-ai", "dist", "providers", "amazon-bedrock.js"),
+  path.join(npmRoot, "@earendil-works", "pi-coding-agent", "node_modules", "@earendil-works", "pi-ai", "dist", "providers", "amazon-bedrock.js"),
+];
+for (const file of candidates) {
+  if (!existsSync(file)) continue;
+  const source = readFileSync(file, "utf8");
+  if (source.includes(marker)) continue;
+  const importAnchor = `import { transformMessages } from "./transform-messages.js";\n`;
+  const clientAnchor = `            const client = new BedrockRuntimeClient(config);\n`;
+  if (!source.includes(importAnchor) || !source.includes(clientAnchor)) throw new Error(`Unsupported pi-ai Bedrock provider shape: ${file}`);
+  writeFileSync(file, source.replace(importAnchor, `${importAnchor}${helper}`).replace(clientAnchor, `${clientAnchor}            applyBobbitBedrockRequestHeaders(client, model, options);\n`));
+}
+NODE
 LABEL bobbit.pi-agent-version=${PI_AGENT_VERSION}
+LABEL bobbit.pi-ai-bedrock-ua-patch=1
 
 # TypeScript compiler — needed for `npm run check` in worktrees.
 # Must run as root (before USER node) to write to /usr/local/lib/node_modules/.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -803,15 +803,15 @@ git ls-remote origin | grep -oE 'refs/heads/(session|goal|staff)[^[:space:]]*' |
 
 Full design + bug archaeology in [docs/design/orphan-remote-branch-cleanup.md](design/orphan-remote-branch-cleanup.md). Architecture summary: [docs/internals.md — Remote branch cleanup](internals.md#remote-branch-cleanup).
 
-## `models.json` stale / missing `x-opencode-session` header after gateway upgrade
+## `models.json` stale / missing AI Gateway headers after gateway upgrade
 
-Symptom: a new aigw-side model isn't selectable, or per-session header partitioning isn't happening for users whose `~/.bobbit/agent/models.json` predates the `x-opencode-session` feature.
+Symptom: a new aigw-side model isn't selectable, gateway operators don't see `User-Agent: Bobbit/<version>`, or per-session header partitioning isn't happening for users whose `~/.bobbit/agent/models.json` predates the generated header block.
 
-Resolution: restart the gateway. `startupAigwCheck` in `src/server/agent/aigw-manager.ts` now re-discovers models and rewrites `~/.bobbit/agent/models.json` on every startup when aigw is configured, preserving non-aigw providers and user `modelOverrides`. Look for `[aigw] re-discovered <N> models on startup, refreshed models.json` in the gateway log to confirm. If you instead see `[aigw] gateway unreachable on startup (<msg>), keeping existing models.json`, the gateway HTTP probe failed and the file was deliberately left as-is — fix gateway connectivity and restart again.
+Resolution: restart the gateway. `startupAigwCheck` in `src/server/agent/aigw-manager.ts` now re-discovers models and rewrites `~/.bobbit/agent/models.json` on every startup when aigw is configured, preserving non-aigw providers and user `modelOverrides` while refreshing `providers.aigw.headers`. Look for `[aigw] re-discovered <N> models on startup, refreshed models.json` in the gateway log to confirm. If you instead see `[aigw] gateway unreachable on startup (<msg>), keeping existing models.json`, the gateway HTTP probe failed and the file was deliberately left as-is — fix gateway connectivity and restart again.
 
 `BOBBIT_SKIP_AIGW_DISCOVERY=1` semantics shifted with this change: it now skips only the network call. When aigw is already configured, Bedrock env vars are still applied and the existing `models.json` is kept untouched. Previously this flag short-circuited everything pre-config; the post-config refresh path is the new behaviour.
 
-See [docs/internals.md — Startup refresh of models.json](internals.md#startup-refresh-of-modelsjson).
+See [docs/internals.md — Startup refresh behavior](internals.md#startup-refresh-behavior).
 
 ## Review/naming model mismatch under AI Gateway
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1414,53 +1414,84 @@ The worktree pool (`src/server/agent/worktree-pool.ts`) pre-creates **git worktr
 
 ---
 
-## AI Gateway per-session header (`x-opencode-session`)
+## AI Gateway request headers (`User-Agent`, `x-opencode-session`)
 
-When Bobbit talks to an on-prem model through the AI Gateway, the gateway's token caches are keyed per upstream caller. Without a per-session discriminator every Bobbit session would share one cache bucket, so cache hits collapse and the gen-AI team's routing loses its signal. To partition cleanly, every aigw request carries an `x-opencode-session: <bobbit-session-id>` header - or, when no session id is available, **no header at all**. A constant fallback would defeat the whole point: it would re-collapse buckets onto a single key.
+Bobbit can route model traffic through a configured AI Gateway instead of directly to public providers. Gateway operators need to identify Bobbit-originated traffic for routing, analytics, and support, while Bobbit sessions still need per-session cache partitioning. Two headers cover those concerns:
 
-### Where it's emitted
+- `User-Agent: Bobbit/<version>` identifies the Bobbit build. The `<version>` comes from Bobbit's current `package.json`, not a duplicated literal.
+- `x-opencode-session: <session-id>` partitions agent inference cache/routing per Bobbit session. It is emitted only when an agent subprocess has `BOBBIT_SESSION_ID` set.
 
-`writeAigwModelsJson` in `src/server/agent/aigw-manager.ts` writes `~/.bobbit/agent/models.json`. The `aigw` provider entry now carries a provider-level `headers` block:
+The canonical user-agent string lives in `src/server/agent/aigw-user-agent.ts` as `BOBBIT_AIGW_USER_AGENT`. The direct AI Gateway request paths covered here attach it through `aigwUserAgentHeaders()`, which removes any incoming `user-agent` key case-insensitively and then writes exactly one `User-Agent` key with the canonical `Bobbit/<version>` value. This keeps the format stable on version bumps and prevents accidental overrides or duplicate user-agent variants.
 
-- Key: `x-opencode-session`.
-- Value: a pi-coding-agent `!cmd` resolver expression that runs `node -e "process.stdout.write(process.env.BOBBIT_SESSION_ID || '')"`.
+### Covered request paths
 
-Provider-level (not per-model) is deliberate - it covers every `openai-completions` model the aigw exposes without the file having to enumerate them. Claude entries in the same file use `api: "bedrock-converse-stream"`, whose pi-ai 0.67.5 driver does not honour `model.headers`; that's fine, on-prem routing only matters for the openai-completions path.
+The Bobbit AI Gateway user agent is sent only on requests whose target is the configured or tested AI Gateway URL:
 
-### Startup refresh of `models.json`
+| Path | How the header is applied |
+|---|---|
+| Model discovery | `discoverAigwModels()` calls the gateway `/v1/models` endpoint through `httpGet()`, which uses `aigwUserAgentHeaders()`. |
+| `/api/aigw/status` | If a gateway is configured, the route discovers fresh models, so the discovery request carries the header. |
+| `/api/aigw/test` | Tests the submitted URL by running discovery against that URL with the header. |
+| `/api/aigw/configure` | Runs discovery with the header, persists `aigw.url`, and rewrites `models.json`. |
+| `/api/aigw/refresh` | Re-runs the configure flow for the stored gateway URL, so discovery and the generated provider config are refreshed together. |
+| Startup refresh / auto-detect | `startupAigwCheck()` uses discovery for existing gateway refreshes and local gateway probing; reachable configured gateways are rewritten with the current headers. |
+| `/api/aigw/v1/*` proxy | `proxyRequest()` forwards to the configured gateway with `User-Agent: Bobbit/<version>` alongside content headers. |
+| Direct title / goal-summary generation | The gateway title paths in `title-generator.ts` use `aigwUserAgentHeaders()` for both `/v1/models` model-id resolution and `/v1/chat/completions` generation calls. |
+| Agent inference | `writeAigwModelsJson()` writes provider-level `providers.aigw.headers`, so pi-coding-agent sends the header on inference traffic routed through the generated `aigw` provider. |
 
-On every gateway startup, `startupAigwCheck` in `src/server/agent/aigw-manager.ts` re-runs the aigw setup so `~/.bobbit/agent/models.json` doesn't drift between restarts. When aigw is already configured, it sets the Bedrock env vars and then calls `discoverAigwModels(existingUrl)` followed by `writeAigwModelsJson(existingUrl, models)` - which rewrites the file with the freshly-discovered model list and the provider-level `x-opencode-session` `headers` block, while preserving user `modelOverrides` and any non-aigw providers (the writer already merges these). The practical effect: new gateway-side models, and the header block for users whose `models.json` predates that feature, are picked up automatically without anyone having to re-configure aigw from Settings.
+### Generated `providers.aigw.headers`
 
-If the gateway is unreachable at startup (network error / HTTP failure / timeout), the function logs `[aigw] gateway unreachable on startup (<msg>), keeping existing models.json` and leaves the file untouched - staleness is preferred to wiping a working file with a stub. The `BOBBIT_SKIP_AIGW_DISCOVERY=1` test/CI escape hatch skips only the network call: when aigw is already configured, the Bedrock env vars are still applied and the existing `models.json` is kept as-is. The not-configured branch (auto-probing for a local gateway) is unchanged.
+`writeAigwModelsJson()` writes the AI Gateway provider into `~/.bobbit/agent/models.json` and preserves existing non-aigw providers and user `modelOverrides`. The generated provider-level header block contains both headers:
 
-### Resolver semantics (pi-coding-agent contract surface)
+```json
+{
+  "providers": {
+    "aigw": {
+      "headers": {
+        "User-Agent": "Bobbit/<version>",
+        "x-opencode-session": "!node -e \"process.stdout.write(process.env.BOBBIT_SESSION_ID || '')\""
+      }
+    }
+  }
+}
+```
 
-The pi-coding-agent CLI evaluates header values via `resolveConfigValue` (in `dist/core/resolve-config-value.js`):
+Provider-level headers are deliberate: they cover every model exposed through `providers.aigw` without duplicating fields on each model entry. The `User-Agent` value is a plain string because it is build-wide. The `x-opencode-session` value remains the existing pi-coding-agent `!cmd` resolver literal; pi-coding-agent executes it inside the agent subprocess, trims stdout, and drops the header when stdout is empty. That preserves the exact old behavior: sessions with `BOBBIT_SESSION_ID` send their session id, while non-session calls do not fall back to a shared constant.
 
-- A plain string `"X"` falls back to `process.env["X"] || "X"` - i.e. it can leak the literal key name. **Unsafe for our requirement.**
-- A `"!cmd"` string runs `cmd` via `child_process.exec` (shell-interpreted) and returns the trimmed stdout, or `undefined` when stdout is empty.
-- `resolveHeaders` (in `dist/core/model-registry.js`) drops any header whose resolved value is falsy.
+Every agent session gets its own subprocess environment with `BOBBIT_SESSION_ID=<sessionId>`, so the shell-resolved header is naturally partitioned per session. The command result is cached inside that subprocess, so only the first inference request in a session pays the resolver cost.
 
-So the `!node -e ...` form gives us exactly "send the header iff `BOBBIT_SESSION_ID` is set to a non-empty value, otherwise omit it." That is the only behaviour we want.
+### Bedrock-routed Claude models
 
-### Per-session env injection
+Claude models exposed by the gateway are stored under `providers.aigw` but routed through `api: "bedrock-converse-stream"` for Bedrock Converse feature parity. Those model entries also get a per-model `baseUrl` pointing at the gateway `/aws` subtree, while the provider `baseUrl` stays on the OpenAI-compatible root for non-Claude models.
 
-Every agent-CLI spawn path (`session-setup.ts`, `session-manager.ts`, the rpc-bridge child spawn) injects `BOBBIT_SESSION_ID=<sessionId>` into the subprocess env. Each Bobbit session owns its own subprocess with its own env, so values are correctly partitioned at the OS level and never leak across sessions.
+pi-ai's Bedrock provider does not normally forward provider-level `headers` into the AWS SDK request. Bobbit applies a narrow compatibility patch before model-completion and agent subprocess startup: `ensurePiAiBedrockHeadersPatch()` injects a middleware hook into pi-ai's Bedrock provider that copies `options.headers` into the outgoing Bedrock request **only when `model.provider === "aigw"`**. The hook is intentionally not global:
 
-### Performance: one shell exec per session, not per request
+- aigw-routed Claude/Bedrock traffic receives `User-Agent: Bobbit/<version>` and the resolved `x-opencode-session` when present.
+- Public Amazon Bedrock providers, Anthropic providers, and other non-aigw providers are left untouched.
+- Existing AWS user-agent middleware is not globally replaced; the Bobbit headers are applied only to the specific aigw Bedrock client request.
 
-`resolveConfigValue` caches `!cmd` results in a module-level `commandResultCache` `Map` keyed by the command string. The first LLM request in a session pays a one-time ~50 ms `node -e` startup; every subsequent request in that same subprocess reuses the cached value. Because each Bobbit session spawns its own agent subprocess, the cache is naturally per-session - no cross-contamination, no repeated process spawns within a session.
+### Startup refresh behavior
 
-### Cross-shell quoting
+On gateway startup, `startupAigwCheck()` checks whether `aigw.url` is already configured. If it is, Bobbit sets the Bedrock environment variables for subprocesses and, unless `BOBBIT_SKIP_AIGW_DISCOVERY=1` is set, re-discovers models from the configured gateway. A successful refresh rewrites `~/.bobbit/agent/models.json` with:
 
-`child_process.exec` runs the command through `cmd.exe` on Windows and `/bin/sh` on POSIX. The chosen quoting - outer `"` for the JS argument, inner `'` for the empty-string default - is interpreted identically by both shells (cmd.exe and sh both treat `''` as an empty string literal in this position). The JSON-encoded value in `models.json` is `"!node -e \"process.stdout.write(process.env.BOBBIT_SESSION_ID || '')\""`.
+- the current gateway model list,
+- the current canonical `User-Agent: Bobbit/<version>`,
+- the unchanged `x-opencode-session` resolver literal,
+- existing non-aigw providers and user `modelOverrides` preserved.
 
-### Out of scope
+This means users with older `models.json` files pick up the user-agent header after restart or manual refresh without reconfiguring the gateway. If the configured gateway is unreachable, Bobbit logs the startup warning and leaves the existing file untouched rather than replacing a working cached configuration with a partial one. With `BOBBIT_SKIP_AIGW_DISCOVERY=1`, Bobbit skips only the network discovery call; it still applies Bedrock environment variables and keeps the existing file as-is.
 
-- The `/api/aigw/v1/*` passthrough proxy used for UI model-list/test calls - it never carries a session id and isn't on the request path that needs cache routing.
-- The title generator and other one-shot gateway calls - single-call, no cache benefit.
-- Bedrock/Claude routing - driver ignores `model.headers`, and on-prem models don't route to Bedrock anyway.
-- Custom local providers configured outside the aigw block - the `headers` block is scoped to the `aigw` provider entry only.
+### No-leakage boundaries
+
+The Bobbit AI Gateway user agent is not a process-wide default HTTP header. It is attached only by AI Gateway-specific helpers or by the generated `providers.aigw` entry:
+
+- `aigwUserAgentHeaders()` is used for AI Gateway discovery, proxying, and gateway title/goal-summary calls.
+- `writeAigwModelsJson()` writes headers only under `providers.aigw`; non-aigw providers are preserved as-is.
+- `removeAigwModelsJson()` removes the entire `aigw` provider block and leaves no orphan AI Gateway headers on other providers.
+- Direct public-provider paths, such as Anthropic title fallback or non-aigw model completion, do not use the Bobbit AI Gateway user-agent helper.
+- The Bedrock patch exits immediately for any model whose provider is not `aigw`.
+
+These boundaries are why the same Bobbit process can talk to an AI Gateway and public providers without leaking `User-Agent: Bobbit/<version>` to public endpoints unless that request is actually routed through the configured gateway.
 
 ---
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -494,6 +494,8 @@ Used by the Settings → Models tab per-row Test button. See [AGENTS.md — Debu
 | `POST` | `/api/aigw/refresh` | Re-discover models from configured gateway |
 | `*` | `/api/aigw/v1/*` | Proxy requests to configured AI gateway |
 
+Outbound requests that these endpoints make to the configured/tested AI Gateway carry Bobbit's canonical AI Gateway user agent. See [AI Gateway request headers](internals.md#ai-gateway-request-headers-user-agent-x-opencode-session).
+
 ### OAuth
 
 Provider-aware. Bobbit can hold OAuth credentials for several providers concurrently (currently `anthropic` and `openai-codex`); every endpoint takes a `provider` discriminator so the same flow IDs and credential rows do not bleed across providers.

--- a/src/server/agent/aigw-manager.ts
+++ b/src/server/agent/aigw-manager.ts
@@ -18,6 +18,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { globalAgentDir } from "../bobbit-dir.js";
+import { BOBBIT_AIGW_USER_AGENT, aigwUserAgentHeaders } from "./aigw-user-agent.js";
 import type { PreferencesStore } from "./preferences-store.js";
 
 // ── Types ──────────────────────────────────────────────────────────
@@ -342,6 +343,7 @@ export function writeAigwModelsJson(aigwUrl: string, models: AigwModel[]): void 
 		// The literal here JSON-encodes to:
 		//   "!node -e \"process.stdout.write(process.env.BOBBIT_SESSION_ID || '')\""
 		headers: {
+			"User-Agent": BOBBIT_AIGW_USER_AGENT,
 			"x-opencode-session": `!node -e "process.stdout.write(process.env.BOBBIT_SESSION_ID || '')"`,
 		},
 		models: models.map(m => {
@@ -550,7 +552,7 @@ function httpGet(url: string, timeoutMs = 10_000): Promise<any> {
 		const parsedUrl = new URL(url);
 		const transport = parsedUrl.protocol === "https:" ? https : http;
 
-		const req = transport.request(parsedUrl, { method: "GET", timeout: timeoutMs }, (res) => {
+		const req = transport.request(parsedUrl, { method: "GET", headers: aigwUserAgentHeaders(), timeout: timeoutMs }, (res) => {
 			const chunks: Buffer[] = [];
 			res.on("data", (c: Buffer) => chunks.push(c));
 			res.on("end", () => {
@@ -585,8 +587,10 @@ export function proxyRequest(
 	incomingReq.on("data", (c: Buffer) => chunks.push(c));
 	incomingReq.on("end", () => {
 		const body = Buffer.concat(chunks);
-		const headers: Record<string, string> = { "Content-Type": "application/json" };
-		if (body.length > 0) headers["Content-Length"] = String(body.length);
+		const headers = aigwUserAgentHeaders({
+			"Content-Type": "application/json",
+			...(body.length > 0 ? { "Content-Length": String(body.length) } : {}),
+		});
 
 		const RESPONSE_TIMEOUT_MS = 120_000;
 		let responseTimer: ReturnType<typeof setTimeout> | undefined;

--- a/src/server/agent/aigw-user-agent.ts
+++ b/src/server/agent/aigw-user-agent.ts
@@ -1,0 +1,39 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+function loadBobbitPackageVersion(): string {
+	const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+	const candidates = [
+		path.resolve(moduleDir, "../../../package.json"),
+	];
+
+	for (const candidate of candidates) {
+		if (!fs.existsSync(candidate)) continue;
+		try {
+			const parsed = JSON.parse(fs.readFileSync(candidate, "utf-8")) as { version?: unknown };
+			if (typeof parsed.version === "string" && parsed.version.trim()) {
+				return parsed.version;
+			}
+			throw new Error(`missing string version field in ${candidate}`);
+		} catch (err) {
+			throw new Error(`Failed to read Bobbit package version from ${candidate}: ${err instanceof Error ? err.message : String(err)}`);
+		}
+	}
+
+	throw new Error(`Failed to locate Bobbit package.json for AI Gateway User-Agent. Tried: ${candidates.join(", ")}`);
+}
+
+const bobbitPackageVersion = loadBobbitPackageVersion();
+
+export const BOBBIT_AIGW_USER_AGENT = `Bobbit/${bobbitPackageVersion}`;
+
+export function aigwUserAgentHeaders(extra?: Record<string, string>): Record<string, string> {
+	const headers: Record<string, string> = {};
+	for (const [key, value] of Object.entries(extra || {})) {
+		if (key.toLowerCase() === "user-agent") continue;
+		headers[key] = value;
+	}
+	headers["User-Agent"] = BOBBIT_AIGW_USER_AGENT;
+	return headers;
+}

--- a/src/server/agent/model-completion.ts
+++ b/src/server/agent/model-completion.ts
@@ -6,6 +6,9 @@ import { refreshOAuthToken } from "../auth/oauth.js";
 import { globalAgentDir, globalAuthPath } from "../bobbit-dir.js";
 import type { PreferencesStore } from "./preferences-store.js";
 import { getAvailableModels, type ApiModel, type CustomProviderConfig } from "./model-registry.js";
+import { ensurePiAiBedrockHeadersPatch } from "./pi-ai-bedrock-headers-patch.js";
+
+ensurePiAiBedrockHeadersPatch();
 
 interface AuthCredentials {
 	type: string;
@@ -69,6 +72,19 @@ function resolveConfigValue(value: unknown): string | undefined {
 	const envValue = process.env[trimmed];
 	if (envValue) return envValue;
 	return trimmed;
+}
+
+function resolveProviderHeaders(provider: string): Record<string, string> | undefined {
+	if (provider !== "aigw") return undefined;
+	const rawHeaders = readModelsJsonProvider(provider)?.headers;
+	if (!rawHeaders || typeof rawHeaders !== "object") return undefined;
+	const headers: Record<string, string> = {};
+	for (const [key, value] of Object.entries(rawHeaders)) {
+		if (typeof key !== "string" || !key.trim()) continue;
+		const resolved = resolveConfigValue(value);
+		if (resolved) headers[key] = resolved;
+	}
+	return Object.keys(headers).length > 0 ? headers : undefined;
 }
 
 async function resolveProviderApiKey(prefs: PreferencesStore | undefined, provider: string): Promise<string | undefined> {
@@ -135,12 +151,14 @@ export async function completeModelText(
 	completeFn: CompleteSimpleFn = completeSimple,
 ): Promise<string> {
 	const apiKey = await resolveProviderApiKey(prefs, model.provider);
+	const providerHeaders = resolveProviderHeaders(model.provider);
 	const options: Record<string, any> = {
 		maxTokens: args.maxTokens ?? 500,
 		timeoutMs: args.timeoutMs ?? 30_000,
 		maxRetries: 0,
 		cacheRetention: "none",
 		...(apiKey ? { apiKey } : {}),
+		...(providerHeaders ? { headers: providerHeaders } : {}),
 	};
 	if (args.thinkingLevel && args.thinkingLevel !== "off") {
 		options.reasoning = args.thinkingLevel;

--- a/src/server/agent/pi-ai-bedrock-headers-patch.ts
+++ b/src/server/agent/pi-ai-bedrock-headers-patch.ts
@@ -1,0 +1,142 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+
+export const PI_AI_BEDROCK_HEADERS_PATCH_LABEL = "1";
+
+const PATCH_MARKER = "bobbit-pi-ai-bedrock-headers-patch-v1";
+
+const PATCH_HELPER = `
+const BOBBIT_PI_AI_BEDROCK_HEADERS_PATCH = "${PATCH_MARKER}";
+function applyBobbitBedrockRequestHeaders(client, model, options) {
+    if (model?.provider !== "aigw") return;
+    const headerSource = options?.headers;
+    if (!headerSource || typeof headerSource !== "object") return;
+    const headerEntries = Object.entries(headerSource).filter((entry) => typeof entry[1] === "string" && entry[1].length > 0);
+    if (headerEntries.length === 0) return;
+    const middleware = (next) => async (args) => {
+        const request = args?.request;
+        const requestHeaders = request?.headers;
+        if (requestHeaders && typeof requestHeaders === "object") {
+            for (const [key, value] of headerEntries) {
+                const lowerKey = key.toLowerCase();
+                for (const existingKey of Object.keys(requestHeaders)) {
+                    if (existingKey.toLowerCase() === lowerKey) delete requestHeaders[existingKey];
+                }
+                requestHeaders[key] = value;
+            }
+        }
+        return next(args);
+    };
+    try {
+        client.middlewareStack.addRelativeTo(middleware, {
+            relation: "after",
+            toMiddleware: "getUserAgentMiddleware",
+            name: "bobbitBedrockRequestHeadersMiddleware",
+            override: true,
+        });
+    }
+    catch {
+        client.middlewareStack.add(middleware, {
+            step: "build",
+            priority: "low",
+            name: "bobbitBedrockRequestHeadersMiddleware",
+            override: true,
+        });
+    }
+}
+`;
+
+function uniqueExisting(paths: string[]): string[] {
+	return Array.from(new Set(paths.filter((candidate) => {
+		try { return fs.statSync(candidate).isFile(); }
+		catch { return false; }
+	})));
+}
+
+function packageSegments(specifier: string): string[] {
+	return specifier.startsWith("@") ? specifier.split("/").slice(0, 2) : [specifier.split("/")[0]];
+}
+
+function findPackageRoot(specifier: string): string | undefined {
+	const segments = packageSegments(specifier);
+	const starts = [path.dirname(fileURLToPath(import.meta.url)), process.cwd()];
+	for (const start of starts) {
+		let dir = path.resolve(start);
+		while (true) {
+			const candidate = path.join(dir, "node_modules", ...segments);
+			try {
+				if (fs.statSync(path.join(candidate, "package.json")).isFile()) return candidate;
+			} catch { /* keep walking */ }
+			const parent = path.dirname(dir);
+			if (parent === dir) break;
+			dir = parent;
+		}
+	}
+	return undefined;
+}
+
+function packageRootFromMain(specifier: string): string | undefined {
+	try {
+		const resolve = import.meta.resolve?.bind(import.meta);
+		if (resolve) {
+			const mainPath = fileURLToPath(resolve(specifier));
+			return path.resolve(path.dirname(mainPath), "..");
+		}
+	} catch { /* fall back below */ }
+	try {
+		const mainPath = require.resolve(specifier);
+		return path.resolve(path.dirname(mainPath), "..");
+	} catch {
+		return findPackageRoot(specifier);
+	}
+}
+
+function piAiBedrockCandidates(): string[] {
+	const candidates: string[] = [];
+	const piAiRoot = packageRootFromMain("@earendil-works/pi-ai");
+	if (piAiRoot) candidates.push(path.join(piAiRoot, "dist", "providers", "amazon-bedrock.js"));
+
+	const piCodingAgentRoot = packageRootFromMain("@earendil-works/pi-coding-agent");
+	if (piCodingAgentRoot) {
+		candidates.push(path.join(piCodingAgentRoot, "node_modules", "@earendil-works", "pi-ai", "dist", "providers", "amazon-bedrock.js"));
+	}
+
+	return uniqueExisting(candidates);
+}
+
+function patchPiAiBedrockFile(filePath: string): "patched" | "already" | "skipped" {
+	const source = fs.readFileSync(filePath, "utf-8");
+	if (source.includes(PATCH_MARKER)) return "already";
+
+	const importAnchor = `import { transformMessages } from "./transform-messages.js";\n`;
+	const clientAnchor = `            const client = new BedrockRuntimeClient(config);\n`;
+	if (!source.includes(importAnchor) || !source.includes(clientAnchor)) return "skipped";
+
+	const patched = source
+		.replace(importAnchor, `${importAnchor}${PATCH_HELPER}`)
+		.replace(clientAnchor, `${clientAnchor}            applyBobbitBedrockRequestHeaders(client, model, options);\n`);
+	fs.writeFileSync(filePath, patched, "utf-8");
+	return "patched";
+}
+
+let didEnsure = false;
+
+export function ensurePiAiBedrockHeadersPatch(): void {
+	if (didEnsure) return;
+	didEnsure = true;
+
+	for (const candidate of piAiBedrockCandidates()) {
+		try {
+			const result = patchPiAiBedrockFile(candidate);
+			if (result === "skipped") {
+				console.warn(`[aigw] Could not patch pi-ai Bedrock headers hook; unsupported file shape: ${candidate}`);
+			}
+		} catch (err: any) {
+			console.warn(`[aigw] Failed to patch pi-ai Bedrock headers hook at ${candidate}: ${err?.message || err}`);
+		}
+	}
+}

--- a/src/server/agent/rpc-bridge.ts
+++ b/src/server/agent/rpc-bridge.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { bobbitDir, bobbitStateDir, globalAgentDir } from "../bobbit-dir.js";
 import { TOOLS_DIR, type ToolManager } from "./tool-manager.js";
 import { THINKING_LEVELS } from "../../shared/thinking-levels.js";
+import { ensurePiAiBedrockHeadersPatch } from "./pi-ai-bedrock-headers-patch.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 /** Builtin tools directory — dist/server/defaults/tools/ (read-only, shipped with Bobbit). */
@@ -159,6 +160,7 @@ export class RpcBridge {
 	}
 
 	async start(): Promise<void> {
+		ensurePiAiBedrockHeadersPatch();
 		const cliPath = this.options.cliPath || findAgentCli();
 		const args = buildAgentArgs(this.options);
 

--- a/src/server/agent/sandbox-status.ts
+++ b/src/server/agent/sandbox-status.ts
@@ -3,6 +3,7 @@ import { promisify } from "node:util";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { PI_AI_BEDROCK_HEADERS_PATCH_LABEL } from "./pi-ai-bedrock-headers-patch.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -55,6 +56,19 @@ export async function getImageAgentVersion(imageName: string): Promise<string | 
 	}
 }
 
+export async function getImageBedrockHeadersPatchLabel(imageName: string): Promise<string | null> {
+	try {
+		const { stdout } = await execFileAsync(
+			"docker", ["inspect", "--format", "{{index .Config.Labels \"bobbit.pi-ai-bedrock-ua-patch\"}}", imageName],
+			{ timeout: 5000 },
+		);
+		const label = stdout.trim();
+		return label && label !== "<no value>" ? label : null;
+	} catch {
+		return null;
+	}
+}
+
 /** Get the host's installed pi-coding-agent version. */
 export function getHostAgentVersion(): string | null {
 	try {
@@ -81,13 +95,16 @@ export async function ensureImageAgentVersion(imageName: string, projectDir: str
 	}
 
 	const imageVersion = await getImageAgentVersion(imageName);
-	if (imageVersion === hostVersion) {
-		console.log(`[sandbox] Image "${imageName}" has pi-coding-agent@${imageVersion} (matches host)`);
+	const imagePatchLabel = await getImageBedrockHeadersPatchLabel(imageName);
+	if (imageVersion === hostVersion && imagePatchLabel === PI_AI_BEDROCK_HEADERS_PATCH_LABEL) {
+		console.log(`[sandbox] Image "${imageName}" has pi-coding-agent@${imageVersion} and Bedrock headers patch ${imagePatchLabel} (matches host)`);
 		return true;
 	}
 
 	const reason = imageVersion
-		? `image has v${imageVersion}, host has v${hostVersion}`
+		? imagePatchLabel === PI_AI_BEDROCK_HEADERS_PATCH_LABEL
+			? `image has v${imageVersion}, host has v${hostVersion}`
+			: `image missing Bedrock headers patch ${PI_AI_BEDROCK_HEADERS_PATCH_LABEL}, host has v${hostVersion}`
 		: `image missing version label, host has v${hostVersion}`;
 	console.log(`[sandbox] Rebuilding image "${imageName}": ${reason}`);
 
@@ -98,7 +115,7 @@ export async function ensureImageAgentVersion(imageName: string, projectDir: str
 			["build", "--build-arg", `PI_AGENT_VERSION=${hostVersion}`, "-t", imageName, "docker/"],
 			{ cwd: projectDir, timeout: 180_000 },
 		);
-		console.log(`[sandbox] Image "${imageName}" rebuilt with pi-coding-agent@${hostVersion}`);
+		console.log(`[sandbox] Image "${imageName}" rebuilt with pi-coding-agent@${hostVersion} and Bedrock headers patch ${PI_AI_BEDROCK_HEADERS_PATCH_LABEL}`);
 		return true;
 	} catch (err: any) {
 		const errorMsg = err.stderr || err.message || String(err);

--- a/src/server/agent/title-generator.ts
+++ b/src/server/agent/title-generator.ts
@@ -10,6 +10,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { refreshOAuthToken } from "../auth/oauth.js";
 import { globalAuthPath } from "../bobbit-dir.js";
 import { discoverAigwModels } from "./aigw-manager.js";
+import { aigwUserAgentHeaders } from "./aigw-user-agent.js";
 import { completeModelText } from "./model-completion.js";
 import { getAvailableModels, modelRecencyRank, type ApiModel } from "./model-registry.js";
 import type { PreferencesStore } from "./preferences-store.js";
@@ -206,7 +207,7 @@ export function cleanTitle(raw: string): string {
 async function resolveGatewayModelId(baseUrl: string, strippedId: string): Promise<string> {
 	try {
 		const modelsUrl = baseUrl.endsWith("/v1") ? `${baseUrl}/models` : `${baseUrl}/v1/models`;
-		const res = await fetch(modelsUrl, { signal: AbortSignal.timeout(5000) });
+		const res = await fetch(modelsUrl, { headers: aigwUserAgentHeaders(), signal: AbortSignal.timeout(5000) });
 		if (!res.ok) return strippedId;
 		const data = await res.json() as { data?: Array<{ id: string }> };
 		if (!Array.isArray(data.data)) return strippedId;
@@ -267,7 +268,7 @@ async function generateViaGateway(aigwUrl: string, modelId: string, preview: str
 	try {
 		const response = await fetch(url, {
 			method: "POST",
-			headers: { "Content-Type": "application/json" },
+			headers: aigwUserAgentHeaders({ "Content-Type": "application/json" }),
 			body: JSON.stringify(body),
 		});
 
@@ -520,7 +521,7 @@ async function generateGoalSummaryViaGateway(aigwUrl: string, modelId: string, g
 	try {
 		const response = await fetch(url, {
 			method: "POST",
-			headers: { "Content-Type": "application/json" },
+			headers: aigwUserAgentHeaders({ "Content-Type": "application/json" }),
 			body: JSON.stringify(body),
 		});
 

--- a/tests/aigw-headers.test.ts
+++ b/tests/aigw-headers.test.ts
@@ -20,6 +20,7 @@ import path from "node:path";
 
 const EXPECTED_HEADER_VALUE =
 	`!node -e "process.stdout.write(process.env.BOBBIT_SESSION_ID || '')"`;
+const EXPECTED_USER_AGENT = `Bobbit/${JSON.parse(readFileSync(path.resolve("package.json"), "utf-8")).version}`;
 
 let tmp: string;
 let previousAgentDir: string | undefined;
@@ -70,13 +71,18 @@ const CLAUDE_MODEL = {
 	maxTokens: 16_384,
 };
 
-describe("writeAigwModelsJson — provider-level x-opencode-session header", () => {
-	it("emits the documented header literal at provider level (non-Claude models)", () => {
+describe("writeAigwModelsJson — provider-level AI Gateway headers", () => {
+	it("emits the documented header literals at provider level (non-Claude models)", () => {
 		writeAigwModelsJson("https://aigw.example/v1", [NON_CLAUDE_MODEL]);
 		const data = readModels();
 		assert.ok(data?.providers?.aigw, "providers.aigw must exist");
 		const aigw = data.providers.aigw;
 		assert.ok(aigw.headers, "providers.aigw.headers must exist");
+		assert.equal(
+			aigw.headers["User-Agent"],
+			EXPECTED_USER_AGENT,
+			"User-Agent must use the current package version",
+		);
 		assert.equal(
 			aigw.headers["x-opencode-session"],
 			EXPECTED_HEADER_VALUE,
@@ -100,6 +106,7 @@ describe("writeAigwModelsJson — provider-level x-opencode-session header", () 
 		// shape uniform regardless of which models the gateway exposes.
 		writeAigwModelsJson("https://aigw.example/v1", [CLAUDE_MODEL]);
 		const data = readModels();
+		assert.equal(data.providers.aigw.headers["User-Agent"], EXPECTED_USER_AGENT);
 		assert.equal(
 			data.providers.aigw.headers["x-opencode-session"],
 			EXPECTED_HEADER_VALUE,
@@ -133,23 +140,29 @@ describe("writeAigwModelsJson — provider-level x-opencode-session header", () 
 		removeAigwModelsJson();
 		const data = readModels();
 		assert.equal(data.providers.aigw, undefined, "aigw provider must be gone");
-		// anthropic provider untouched + has no x-opencode-session leak.
+		// anthropic provider untouched + has no AI Gateway header leak.
 		assert.ok(data.providers.anthropic, "anthropic provider must survive");
 		assert.equal(data.providers.anthropic.headers, undefined, "no orphan headers on other providers");
 	});
 
-	it("does not leak `headers` onto non-aigw providers when re-written", () => {
+	it("does not leak AI Gateway headers onto non-aigw providers when re-written", () => {
 		// Seed an anthropic provider, then run aigw write. Confirm anthropic is
-		// left alone — no provider-level headers block synthesised on it.
+		// left alone — no AI Gateway headers synthesised on it.
 		const seeded = {
 			providers: {
-				anthropic: { apiKey: "sk-test" },
+				anthropic: {
+					apiKey: "sk-test",
+					headers: { "X-Existing": "keep-me" },
+				},
 			},
 		};
 		writeFileSync(path.join(tmp, "models.json"), JSON.stringify(seeded, null, 2));
 		writeAigwModelsJson("https://aigw.example/v1", [NON_CLAUDE_MODEL]);
 		const data = readModels();
-		assert.equal(data.providers.anthropic.headers, undefined);
+		assert.deepEqual(data.providers.anthropic.headers, { "X-Existing": "keep-me" });
+		assert.equal(data.providers.anthropic.headers["User-Agent"], undefined);
+		assert.equal(data.providers.anthropic.headers["x-opencode-session"], undefined);
+		assert.equal(data.providers.aigw.headers["User-Agent"], EXPECTED_USER_AGENT);
 		assert.equal(
 			data.providers.aigw.headers["x-opencode-session"],
 			EXPECTED_HEADER_VALUE,

--- a/tests/aigw-startup-refresh.test.ts
+++ b/tests/aigw-startup-refresh.test.ts
@@ -22,6 +22,7 @@ import path from "node:path";
 
 const EXPECTED_HEADER_VALUE =
 	`!node -e "process.stdout.write(process.env.BOBBIT_SESSION_ID || '')"`;
+const EXPECTED_USER_AGENT = `Bobbit/${JSON.parse(readFileSync(path.resolve("package.json"), "utf-8")).version}`;
 
 let tmp: string;
 let stateDir: string;
@@ -108,6 +109,11 @@ describe("startupAigwCheck — models.json refresh on startup", () => {
 
 			const data = readModels();
 			assert.ok(data?.providers?.aigw, "providers.aigw must exist");
+			assert.equal(
+				data.providers.aigw.headers["User-Agent"],
+				EXPECTED_USER_AGENT,
+				"provider-level User-Agent must use the current package version",
+			);
 			assert.equal(
 				data.providers.aigw.headers["x-opencode-session"],
 				EXPECTED_HEADER_VALUE,

--- a/tests/aigw-user-agent.test.ts
+++ b/tests/aigw-user-agent.test.ts
@@ -1,0 +1,39 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { BOBBIT_AIGW_USER_AGENT, aigwUserAgentHeaders } from "../src/server/agent/aigw-user-agent.js";
+
+const EXPECTED_USER_AGENT = `Bobbit/${JSON.parse(readFileSync(path.resolve("package.json"), "utf-8")).version}`;
+
+describe("AI Gateway User-Agent single source of truth", () => {
+	it("formats the shared constant from the current package version", () => {
+		assert.equal(BOBBIT_AIGW_USER_AGENT, EXPECTED_USER_AGENT);
+	});
+
+	it("adds the canonical User-Agent and preserves unrelated extra headers", () => {
+		const headers = aigwUserAgentHeaders({
+			"Content-Type": "application/json",
+			"X-Test": "keep-me",
+		});
+
+		assert.equal(headers["User-Agent"], EXPECTED_USER_AGENT);
+		assert.equal(headers["Content-Type"], "application/json");
+		assert.equal(headers["X-Test"], "keep-me");
+	});
+
+	it("prevents User-Agent overrides and duplicate user-agent keys", () => {
+		const headers = aigwUserAgentHeaders({
+			"User-Agent": "BadClient/1.0",
+			"user-agent": "bad-lowercase",
+			"USER-AGENT": "bad-uppercase",
+			Accept: "application/json",
+		});
+
+		const userAgentKeys = Object.keys(headers).filter(key => key.toLowerCase() === "user-agent");
+		assert.deepEqual(userAgentKeys, ["User-Agent"]);
+		assert.equal(headers["User-Agent"], EXPECTED_USER_AGENT);
+		assert.equal(headers.Accept, "application/json");
+	});
+});

--- a/tests/e2e/aigw-configure.spec.ts
+++ b/tests/e2e/aigw-configure.spec.ts
@@ -7,7 +7,15 @@
 
 import { test, expect } from "./in-process-harness.js";
 import http from "node:http";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { apiFetch } from "./e2e-setup.js";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const PROJECT_ROOT = resolve(__dirname, "..", "..");
+const PACKAGE_VERSION = JSON.parse(readFileSync(resolve(PROJECT_ROOT, "package.json"), "utf-8")).version;
+const EXPECTED_USER_AGENT = `Bobbit/${PACKAGE_VERSION}`;
 
 const MOCK_MODELS = {
 	data: [
@@ -17,11 +25,49 @@ const MOCK_MODELS = {
 	],
 };
 
+interface RecordedRequest {
+	method?: string;
+	url?: string;
+	headers: http.IncomingHttpHeaders;
+	rawHeaders: string[];
+}
+
 let mockServer: http.Server;
 let mockPort: number;
+let recordedRequests: RecordedRequest[] = [];
+
+function resetRecordedRequests(): void {
+	recordedRequests = [];
+}
+
+function userAgentValues(record: RecordedRequest): string[] {
+	const values: string[] = [];
+	for (let i = 0; i < record.rawHeaders.length; i += 2) {
+		if (record.rawHeaders[i]?.toLowerCase() === "user-agent") {
+			values.push(record.rawHeaders[i + 1] || "");
+		}
+	}
+	return values;
+}
+
+function expectSingleBobbitUserAgent(record: RecordedRequest | undefined): void {
+	expect(record, "mock gateway should have recorded a matching request").toBeTruthy();
+	expect(record!.headers["user-agent"]).toBe(EXPECTED_USER_AGENT);
+	expect(userAgentValues(record!)).toEqual([EXPECTED_USER_AGENT]);
+}
+
+function lastRecordedRequest(path: string): RecordedRequest | undefined {
+	return [...recordedRequests].reverse().find((record) => record.url === path);
+}
 
 test.beforeAll(async () => {
-	mockServer = http.createServer((_req, res) => {
+	mockServer = http.createServer((req, res) => {
+		recordedRequests.push({
+			method: req.method,
+			url: req.url,
+			headers: req.headers,
+			rawHeaders: [...req.rawHeaders],
+		});
 		res.writeHead(200, { "Content-Type": "application/json" });
 		res.end(JSON.stringify(MOCK_MODELS));
 	});
@@ -39,10 +85,12 @@ test.afterAll(async () => {
 
 test.afterEach(async () => {
 	await apiFetch("/api/aigw/configure", { method: "DELETE" });
+	resetRecordedRequests();
 });
 
 test.describe("AI Gateway Configure Flow", () => {
 	test("test connection discovers models without saving", async () => {
+		resetRecordedRequests();
 		const res = await apiFetch("/api/aigw/test", {
 			method: "POST",
 			body: JSON.stringify({ url: `http://127.0.0.1:${mockPort}` }),
@@ -51,6 +99,7 @@ test.describe("AI Gateway Configure Flow", () => {
 		const data = await res.json();
 		expect(data.ok).toBe(true);
 		expect(data.models).toHaveLength(3);
+		expectSingleBobbitUserAgent(lastRecordedRequest("/v1/models"));
 
 		// Should NOT be configured after test
 		const status = await apiFetch("/api/aigw/status");
@@ -59,6 +108,7 @@ test.describe("AI Gateway Configure Flow", () => {
 	});
 
 	test("configure discovers models and persists config", async () => {
+		resetRecordedRequests();
 		const res = await apiFetch("/api/aigw/configure", {
 			method: "POST",
 			body: JSON.stringify({ url: `http://127.0.0.1:${mockPort}` }),
@@ -67,6 +117,7 @@ test.describe("AI Gateway Configure Flow", () => {
 		const data = await res.json();
 		expect(data.ok).toBe(true);
 		expect(data.models).toHaveLength(3);
+		expectSingleBobbitUserAgent(lastRecordedRequest("/v1/models"));
 
 		// Verify model IDs — Claude models get prefix stripped (Bedrock API)
 		const ids = data.models.map((m: any) => m.id);
@@ -81,6 +132,7 @@ test.describe("AI Gateway Configure Flow", () => {
 			method: "POST",
 			body: JSON.stringify({ url: `http://127.0.0.1:${mockPort}` }),
 		});
+		resetRecordedRequests();
 
 		const res = await apiFetch("/api/aigw/status");
 		expect(res.status).toBe(200);
@@ -88,6 +140,21 @@ test.describe("AI Gateway Configure Flow", () => {
 		expect(data.configured).toBe(true);
 		expect(data.url).toBe(`http://127.0.0.1:${mockPort}`);
 		expect(data.models).toHaveLength(3);
+		expectSingleBobbitUserAgent(lastRecordedRequest("/v1/models"));
+	});
+
+	test("refresh re-discovers models with the Bobbit User-Agent", async () => {
+		await apiFetch("/api/aigw/configure", {
+			method: "POST",
+			body: JSON.stringify({ url: `http://127.0.0.1:${mockPort}` }),
+		});
+		resetRecordedRequests();
+
+		const res = await apiFetch("/api/aigw/refresh", { method: "POST" });
+		expect(res.status).toBe(200);
+		const data = await res.json();
+		expect(data.models).toHaveLength(3);
+		expectSingleBobbitUserAgent(lastRecordedRequest("/v1/models"));
 	});
 
 	test("model metadata is inferred correctly", async () => {
@@ -135,12 +202,17 @@ test.describe("AI Gateway Configure Flow", () => {
 			method: "POST",
 			body: JSON.stringify({ url: `http://127.0.0.1:${mockPort}` }),
 		});
+		resetRecordedRequests();
 
-		// Proxy request
-		const res = await apiFetch("/api/aigw/v1/models");
+		// Proxy request with a deliberately wrong incoming User-Agent. The server
+		// must replace it with Bobbit/<version>, not forward the client header.
+		const res = await apiFetch("/api/aigw/v1/models", {
+			headers: { "User-Agent": "WrongClient/9.9" },
+		});
 		expect(res.status).toBe(200);
 		const data = await res.json();
 		expect(data.data).toHaveLength(3);
+		expectSingleBobbitUserAgent(lastRecordedRequest("/v1/models"));
 	});
 
 	test("preferences reflect aigw config", async () => {

--- a/tests/e2e/aigw-startup-refresh.spec.ts
+++ b/tests/e2e/aigw-startup-refresh.spec.ts
@@ -37,6 +37,8 @@ const E2E_TEMP_ROOT = existsSync("/.dockerenv")
 
 const EXPECTED_HEADER_VALUE =
 	`!node -e "process.stdout.write(process.env.BOBBIT_SESSION_ID || '')"`;
+const PACKAGE_VERSION = JSON.parse(readFileSync(resolve(PROJECT_ROOT, "package.json"), "utf-8")).version;
+const EXPECTED_USER_AGENT = `Bobbit/${PACKAGE_VERSION}`;
 
 interface SeedOpts {
 	aigwUrl?: string;
@@ -142,16 +144,47 @@ async function startSeededGateway(opts: SeedOpts): Promise<StartedGateway> {
 	};
 }
 
+interface RecordedRequest {
+	method?: string;
+	url?: string;
+	headers: http.IncomingHttpHeaders;
+	rawHeaders: string[];
+}
+
 interface MockGateway {
 	url: string;
 	hits: () => number;
+	requests: () => RecordedRequest[];
 	close: () => Promise<void>;
+}
+
+function userAgentValues(record: RecordedRequest): string[] {
+	const values: string[] = [];
+	for (let i = 0; i < record.rawHeaders.length; i += 2) {
+		if (record.rawHeaders[i]?.toLowerCase() === "user-agent") {
+			values.push(record.rawHeaders[i + 1] || "");
+		}
+	}
+	return values;
+}
+
+function expectSingleBobbitUserAgent(record: RecordedRequest | undefined): void {
+	expect(record, "mock gateway should have recorded startup discovery").toBeTruthy();
+	expect(record!.headers["user-agent"]).toBe(EXPECTED_USER_AGENT);
+	expect(userAgentValues(record!)).toEqual([EXPECTED_USER_AGENT]);
 }
 
 function startMockAigw(modelIds: string[]): Promise<MockGateway> {
 	let hits = 0;
+	const requests: RecordedRequest[] = [];
 	const server = http.createServer((req, res) => {
 		hits++;
+		requests.push({
+			method: req.method,
+			url: req.url,
+			headers: req.headers,
+			rawHeaders: [...req.rawHeaders],
+		});
 		if (req.url?.endsWith("/v1/models")) {
 			res.writeHead(200, { "Content-Type": "application/json" });
 			res.end(JSON.stringify({
@@ -168,6 +201,7 @@ function startMockAigw(modelIds: string[]): Promise<MockGateway> {
 			resolve({
 				url: `http://127.0.0.1:${port}`,
 				hits: () => hits,
+				requests: () => [...requests],
 				close: () => new Promise<void>((r) => server.close(() => r())),
 			});
 		});
@@ -193,11 +227,13 @@ test.describe("startupAigwCheck — refresh models.json on startup (E2E)", () =>
 			const data = JSON.parse(readFileSync(gw.modelsJsonPath, "utf-8"));
 			expect(data?.providers?.aigw, "aigw provider must exist after startup refresh").toBeTruthy();
 			expect(data.providers.aigw.headers["x-opencode-session"]).toBe(EXPECTED_HEADER_VALUE);
+			expect(data.providers.aigw.headers["User-Agent"]).toBe(EXPECTED_USER_AGENT);
 
 			const ids = data.providers.aigw.models.map((m: any) => m.id);
 			expect(ids).toContain("openai/gpt-5.2");
 			expect(ids).toContain("us.anthropic.claude-sonnet-4-6"); // Claude prefix stripped
 			expect(mock.hits()).toBeGreaterThan(0);
+			expectSingleBobbitUserAgent(mock.requests().find((record) => record.url === "/v1/models"));
 		} finally {
 			await gw?.shutdown();
 			await mock.close();

--- a/tests/e2e/aigw-title-generator.spec.ts
+++ b/tests/e2e/aigw-title-generator.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from "@playwright/test";
+import http from "node:http";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const PROJECT_ROOT = resolve(__dirname, "..", "..");
+const PACKAGE_VERSION = JSON.parse(readFileSync(resolve(PROJECT_ROOT, "package.json"), "utf-8")).version;
+const EXPECTED_USER_AGENT = `Bobbit/${PACKAGE_VERSION}`;
+
+interface RecordedRequest {
+	method?: string;
+	url?: string;
+	headers: http.IncomingHttpHeaders;
+	rawHeaders: string[];
+}
+
+interface MockGateway {
+	url: string;
+	requests: () => RecordedRequest[];
+	close: () => Promise<void>;
+}
+
+function userAgentValues(record: RecordedRequest): string[] {
+	const values: string[] = [];
+	for (let i = 0; i < record.rawHeaders.length; i += 2) {
+		if (record.rawHeaders[i]?.toLowerCase() === "user-agent") {
+			values.push(record.rawHeaders[i + 1] || "");
+		}
+	}
+	return values;
+}
+
+function expectSingleBobbitUserAgent(record: RecordedRequest | undefined): void {
+	expect(record, "mock gateway should have recorded goal-summary request").toBeTruthy();
+	expect(record!.headers["user-agent"]).toBe(EXPECTED_USER_AGENT);
+	expect(userAgentValues(record!)).toEqual([EXPECTED_USER_AGENT]);
+}
+
+function startMockAigw(): Promise<MockGateway> {
+	const requests: RecordedRequest[] = [];
+	const server = http.createServer((req, res) => {
+		requests.push({
+			method: req.method,
+			url: req.url,
+			headers: req.headers,
+			rawHeaders: [...req.rawHeaders],
+		});
+
+		if (req.url === "/v1/models") {
+			res.writeHead(200, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({
+				data: [
+					{ id: "aws/us.anthropic.claude-haiku-4-5", object: "model", created: 1700000000, owned_by: "system" },
+				],
+			}));
+			return;
+		}
+
+		if (req.url === "/v1/chat/completions") {
+			res.writeHead(200, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({
+				choices: [
+					{ message: { content: "<title>Gateway Summary</title>" } },
+				],
+			}));
+			return;
+		}
+
+		res.writeHead(404, { "Content-Type": "application/json" });
+		res.end(JSON.stringify({ error: "not found" }));
+	});
+
+	return new Promise((resolve) => {
+		server.listen(0, "127.0.0.1", () => {
+			const port = (server.address() as any).port;
+			resolve({
+				url: `http://127.0.0.1:${port}`,
+				requests: () => [...requests],
+				close: () => new Promise<void>((r) => server.close(() => r())),
+			});
+		});
+	});
+}
+
+test.describe("AI Gateway title-generator User-Agent", () => {
+	test("direct goal-summary gateway path sends Bobbit User-Agent", async () => {
+		const mock = await startMockAigw();
+		const previousSkipTitleGen = process.env.BOBBIT_SKIP_TITLE_GEN;
+		delete process.env.BOBBIT_SKIP_TITLE_GEN;
+		try {
+			const { generateGoalSummaryTitle } = await import("../../dist/server/agent/title-generator.js");
+			const title = await generateGoalSummaryTitle("Add AI Gateway user agent", {
+				namingModel: "aigw/us.anthropic.claude-haiku-4-5",
+				aigwUrl: mock.url,
+			});
+
+			expect(title).toBe("Gateway Summary");
+			expectSingleBobbitUserAgent(
+				mock.requests().find((record) => record.method === "POST" && record.url === "/v1/chat/completions"),
+			);
+		} finally {
+			if (previousSkipTitleGen === undefined) delete process.env.BOBBIT_SKIP_TITLE_GEN;
+			else process.env.BOBBIT_SKIP_TITLE_GEN = previousSkipTitleGen;
+			await mock.close();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- Adds a canonical `Bobbit/<version>` AI Gateway User-Agent helper and sends it on discovery, configure/status/test/refresh, proxy, direct gateway title/summary, and generated `providers.aigw` paths.
- Preserves `x-opencode-session` behavior while adding AIGW-only Bedrock/Claude support via an idempotent pi-ai Bedrock header patch that avoids non-aigw leakage.
- Adds unit, E2E/API, and documentation coverage for the new header behavior.

## Verification

- `npm run check`
- `npm run test:unit`
- `npm run test:e2e -- tests/e2e/aigw-configure.spec.ts tests/e2e/aigw-startup-refresh.spec.ts tests/e2e/aigw-title-generator.spec.ts`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
