### PR TITLE
Settings Restart Button

### DIFF
--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -52,6 +52,8 @@ npm run restart-server
 
 This touches the sentinel file. The harness picks it up within ~500ms (polled on Windows, `fs.watch` elsewhere) and begins the restart cycle.
 
+When the gateway was launched by this harness, the Settings page also shows a top-right **Restart Server** button. The button is hidden in production and in `npm run dev` because those modes do not set `BOBBIT_DEV_HARNESS=1` and cannot be restarted safely by the harness. Clicking it calls `POST /api/harness/restart`, which is server-gated and touches the same `.bobbit/state/gateway-restart` sentinel as `npm run restart-server`.
+
 ---
 
 ## What changes require what

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -25,6 +25,17 @@ Client call sites use the shared helpers `errorFromResponse(res, fallback)` and 
 | `GET` | `/api/connection-info` | List network interface addresses for multi-device access |
 | `GET` | `/api/ca-cert` | Download the Bobbit CA certificate for device trust |
 
+### Dev harness
+
+These endpoints expose restart support only for gateways launched through `npm run dev:harness`. The harness marks the child gateway with `BOBBIT_DEV_HARNESS=1`; ordinary `npm start` and `npm run dev` runs do not set it.
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/harness-status` | Returns `{ restartAvailable: boolean }`. The Settings page uses this to decide whether to render the **Restart Server** button. |
+| `POST` | `/api/harness/restart` | Requests a harness rebuild/restart. Returns `202 { ok: true, restartRequested: true }` under the dev harness, and `403 { error: "Restart is only available under the dev harness" }` otherwise. |
+
+`POST /api/harness/restart` is gated on the server, not just hidden by the UI. On success it touches `.bobbit/state/gateway-restart`, the same sentinel used by `npm run restart-server`; the harness observes that file change, rebuilds the server, and relaunches the gateway.
+
 ### Sessions
 
 | Method | Path | Description |

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -1869,6 +1869,37 @@ export async function dismissSetup(): Promise<void> {
 }
 
 // ============================================================================
+// HARNESS STATUS API
+// ============================================================================
+
+export interface HarnessStatus {
+	restartAvailable: boolean;
+}
+
+export async function fetchHarnessStatus(): Promise<HarnessStatus> {
+	try {
+		const res = await gatewayFetch("/api/harness-status");
+		if (!res.ok) return { restartAvailable: false };
+		const data = await res.json().catch(() => null);
+		return { restartAvailable: data?.restartAvailable === true };
+	} catch {
+		return { restartAvailable: false };
+	}
+}
+
+export async function requestHarnessRestart(): Promise<{ ok: boolean; error?: string }> {
+	try {
+		const res = await gatewayFetch("/api/harness/restart", { method: "POST" });
+		if (res.ok) return { ok: true };
+		const data = await res.json().catch(() => null);
+		const error = typeof data?.error === "string" ? data.error : `Restart request failed: ${res.status}`;
+		return { ok: false, error };
+	} catch (err) {
+		return { ok: false, error: err instanceof Error ? err.message : "Restart request failed" };
+	}
+}
+
+// ============================================================================
 // SANDBOX STATUS API
 // ============================================================================
 

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -36,7 +36,7 @@ import {
 import { getRouteFromHash, setHashRoute, toggleConfigPage, type SettingsTabId } from "./routing.js";
 import { renderWorkflowPage, loadWorkflowPageData } from "./workflow-page.js";
 import { setConfigScope, getConfigScope } from "./config-scope.js";
-import { gatewayFetch, fetchSandboxStatus, removeProject, fetchProjects, searchStats, searchRebuild, orphanedIndexRows, cleanupOrphanedIndexRows, type SearchStats, type OrphanedIndexRows } from "./api.js";
+import { gatewayFetch, fetchSandboxStatus, fetchHarnessStatus, requestHarnessRestart, removeProject, fetchProjects, searchStats, searchRebuild, orphanedIndexRows, cleanupOrphanedIndexRows, type SearchStats, type OrphanedIndexRows } from "./api.js";
 import { applyProjectPalette } from "./session-manager.js";
 import { dispatchIndexEvent } from "./components/search-status-dot.js";
 import "./components/search-status-dot.js";
@@ -105,6 +105,10 @@ let _listening = false;
 let settingsShowTimestamps = false;
 let settingsShowTimestampsLoaded = false;
 let settingsPlayFinishSound = true;
+let harnessStatusLoaded = false;
+let harnessRestartAvailable = false;
+let harnessRestartState: "idle" | "requesting" | "requested" | "error" = "idle";
+let harnessRestartError = "";
 // Skills-catalog byte budget override. `null` means "use server default" (no preference set).
 let settingsSkillsCatalogBudget: number | null = null;
 
@@ -784,6 +788,56 @@ function resetRebindState(): void {
 
 export function toggleSettings(): void {
 	toggleConfigPage(["settings"], () => setHashRoute("settings"));
+}
+
+function loadHarnessStatus(): void {
+	if (harnessStatusLoaded) return;
+	harnessStatusLoaded = true;
+	fetchHarnessStatus().then(status => {
+		harnessRestartAvailable = status.restartAvailable;
+		renderApp();
+	});
+}
+
+async function requestSettingsRestart(): Promise<void> {
+	if (!harnessRestartAvailable) return;
+	if (harnessRestartState !== "idle" && harnessRestartState !== "error") return;
+	harnessRestartState = "requesting";
+	harnessRestartError = "";
+	renderApp();
+
+	const result = await requestHarnessRestart();
+	if (result.ok) {
+		harnessRestartState = "requested";
+		harnessRestartError = "";
+	} else {
+		harnessRestartState = "error";
+		harnessRestartError = result.error || "Restart request failed";
+	}
+	renderApp();
+}
+
+function renderHarnessRestartControl() {
+	if (!harnessRestartAvailable) return "";
+	const requesting = harnessRestartState === "requesting";
+	const requested = harnessRestartState === "requested";
+	const label = requesting ? "Requesting..." : requested ? "Restart Requested" : "Restart Server";
+	return html`
+		<div class="ml-auto flex items-center gap-2">
+			${harnessRestartState === "error" && harnessRestartError ? html`
+				<span class="text-xs text-destructive max-w-[40vw] sm:max-w-[18rem] truncate" title=${harnessRestartError}>${harnessRestartError}</span>
+			` : ""}
+			<button
+				class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border bg-background text-foreground hover:bg-secondary transition-colors disabled:opacity-60 disabled:pointer-events-none"
+				?disabled=${requesting || requested}
+				@click=${requestSettingsRestart}
+				title="Restart Server"
+			>
+				${requesting ? html`<span class="inline-flex animate-spin">${icon(Loader2, "xs")}</span>` : icon(RotateCcw, "xs")}
+				<span>${label}</span>
+			</button>
+		</div>
+	`;
 }
 
 function handleRebindKeydown(e: KeyboardEvent): void {
@@ -3717,6 +3771,7 @@ function renderMaintenanceTab() {
 export function renderSettingsPage() {
 	// Manage keydown listener lifecycle
 	updateKeydownListener();
+	loadHarnessStatus();
 
 	const currentScope = getActiveScope();
 	const tabs = getTabsForScope(currentScope);
@@ -3727,12 +3782,15 @@ export function renderSettingsPage() {
 		<div class="flex-1 flex flex-col min-h-0 overflow-hidden">
 			<!-- Header -->
 			<div class="shrink-0 flex items-center gap-3 px-4 py-3 border-b border-border">
-				<button
-					class="p-1.5 rounded-md hover:bg-secondary transition-colors text-muted-foreground hover:text-foreground"
-					@click=${() => { resetRebindState(); cleanupListener(); toggleSettings(); }}
-					title="Back"
-				>${icon(ArrowLeft, "sm")}</button>
-				<h1 class="text-lg font-semibold">Settings</h1>
+				<div class="flex items-center gap-3 min-w-0">
+					<button
+						class="p-1.5 rounded-md hover:bg-secondary transition-colors text-muted-foreground hover:text-foreground"
+						@click=${() => { resetRebindState(); cleanupListener(); toggleSettings(); }}
+						title="Back"
+					>${icon(ArrowLeft, "sm")}</button>
+					<h1 class="text-lg font-semibold truncate">Settings</h1>
+				</div>
+				${renderHarnessRestartControl()}
 			</div>
 			<!-- Scope row -->
 			${renderScopeRow(currentScope, tabs)}

--- a/src/server/harness-signal.ts
+++ b/src/server/harness-signal.ts
@@ -10,15 +10,26 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { bobbitStateDir } from "./bobbit-dir.js";
 
-const SENTINEL = path.join(bobbitStateDir(), "gateway-restart");
-
-const dir = path.dirname(SENTINEL);
-if (!fs.existsSync(dir)) {
-	fs.mkdirSync(dir, { recursive: true });
+export function restartSentinelPath(): string {
+	return path.join(bobbitStateDir(), "gateway-restart");
 }
 
-// Write a timestamp to change the mtime
-fs.writeFileSync(SENTINEL, Date.now().toString(), "utf-8");
-console.log("[restart-server] Signal sent — harness will rebuild and restart.");
+export function touchGatewayRestartSentinel(now = Date.now()): string {
+	const sentinel = restartSentinelPath();
+	const dir = path.dirname(sentinel);
+	if (!fs.existsSync(dir)) {
+		fs.mkdirSync(dir, { recursive: true });
+	}
+
+	// Write a timestamp to change the mtime
+	fs.writeFileSync(sentinel, now.toString(), "utf-8");
+	return sentinel;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+	touchGatewayRestartSentinel();
+	console.log("[restart-server] Signal sent — harness will rebuild and restart.");
+}

--- a/src/server/harness.ts
+++ b/src/server/harness.ts
@@ -22,7 +22,7 @@ import fs from "node:fs";
 import net from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { bobbitStateDir } from "./bobbit-dir.js";
+import { restartSentinelPath } from "./harness-signal.js";
 
 // ---------------------------------------------------------------------------
 // Paths
@@ -38,7 +38,7 @@ const PROJECT_ROOT = path.resolve(__dirname, "..", "..");
 const CLI_PATH = path.join(__dirname, "cli.js");
 
 /** Sentinel file — any write triggers a restart */
-const SENTINEL = path.join(bobbitStateDir(), "gateway-restart");
+const SENTINEL = restartSentinelPath();
 
 // Ensure the sentinel directory exists
 const sentinelDir = path.dirname(SENTINEL);
@@ -83,7 +83,7 @@ function launchServer(): void {
 	child = spawn(process.execPath, [CLI_PATH, ...forwardedArgs], {
 		cwd: PROJECT_ROOT,
 		stdio: "inherit",
-		env: { ...process.env },
+		env: { ...process.env, BOBBIT_DEV_HARNESS: "1" },
 	});
 
 	child.on("exit", (code, signal) => {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 
 import { fileURLToPath } from "node:url";
 import { bobbitStateDir, bobbitConfigDir, getProjectRoot } from "./bobbit-dir.js";
+import { touchGatewayRestartSentinel } from "./harness-signal.js";
 import { isSetupComplete } from "./setup-status.js";
 export { isSetupComplete };
 import { WebSocketServer } from "ws";
@@ -2058,6 +2059,23 @@ async function handleApiRoute(
 			if (task) return getTaskManagerForGoal(task.goalId);
 		}
 		throw new Error(`Task "${taskId}" not found in any project`);
+	}
+
+	// GET /api/harness-status — report whether the dev restart harness is active
+	if (url.pathname === "/api/harness-status" && req.method === "GET") {
+		json({ restartAvailable: process.env.BOBBIT_DEV_HARNESS === "1" });
+		return;
+	}
+
+	// POST /api/harness/restart — request a dev harness rebuild/restart
+	if (url.pathname === "/api/harness/restart" && req.method === "POST") {
+		if (process.env.BOBBIT_DEV_HARNESS !== "1") {
+			json({ error: "Restart is only available under the dev harness" }, 403);
+			return;
+		}
+		touchGatewayRestartSentinel();
+		json({ ok: true, restartRequested: true }, 202);
+		return;
 	}
 
 	// GET /api/health — unauthenticated so the client can probe localhost mode

--- a/tests/e2e/gateway-harness.ts
+++ b/tests/e2e/gateway-harness.ts
@@ -162,7 +162,7 @@ function _pushLog(line: string): void {
 	console.error = (...a: unknown[]) => { _pushLog(fmt("error", a)); origError(...a); };
 }
 
-export const test = base.extend<{ failureContext: void; restoreDefaultProject: void }, { enableMcp: boolean; enableWorktreePool: boolean; gateway: GatewayInfo }>({
+export const test = base.extend<{ failureContext: void; restoreDefaultProject: void }, { enableMcp: boolean; enableWorktreePool: boolean; enableDevHarnessRestart: boolean; gateway: GatewayInfo }>({
 	// Worker-scoped option. Default false — opt in with `test.use({ enableMcp: true })`
 	// at the top of a spec file. Playwright groups tests with matching option
 	// values onto the same worker, so each spec file effectively gets its own gateway.
@@ -171,7 +171,10 @@ export const test = base.extend<{ failureContext: void; restoreDefaultProject: v
 	// Worker-scoped option. Default false — opt in via `test.use({ enableWorktreePool: true })`.
 	enableWorktreePool: [false, { scope: "worker", option: true }],
 
-	gateway: [async ({ enableMcp, enableWorktreePool }, use, workerInfo) => {
+	// Worker-scoped option. Default false — opt in via `test.use({ enableDevHarnessRestart: true })`.
+	enableDevHarnessRestart: [false, { scope: "worker", option: true }],
+
+	gateway: [async ({ enableMcp, enableWorktreePool, enableDevHarnessRestart }, use, workerInfo) => {
 		mkdirSync(E2E_TEMP_ROOT, { recursive: true });
 		// Include pid + timestamp so retries don't collide with a previous
 		// worker's teardown that may still hold file handles on Windows.
@@ -215,6 +218,12 @@ export const test = base.extend<{ failureContext: void; restoreDefaultProject: v
 		// Set env BEFORE importing server modules. Playwright workers are
 		// separate Node processes, so module singletons are per-worker — no
 		// cross-contamination.
+		const previousDevHarness = process.env.BOBBIT_DEV_HARNESS;
+		if (enableDevHarnessRestart) {
+			process.env.BOBBIT_DEV_HARNESS = "1";
+		} else {
+			delete process.env.BOBBIT_DEV_HARNESS;
+		}
 		process.env.BOBBIT_DIR = bobbitDir;
 		process.env.BOBBIT_AGENT_DIR = agentDir;
 		process.env.BOBBIT_SKIP_NPM_CI = "1";
@@ -411,6 +420,8 @@ export const test = base.extend<{ failureContext: void; restoreDefaultProject: v
 				console.warn(`[gateway-harness] cleanup deferred for ${bobbitDir}: ${msg}`);
 			},
 		});
+		if (previousDevHarness === undefined) delete process.env.BOBBIT_DEV_HARNESS;
+		else process.env.BOBBIT_DEV_HARNESS = previousDevHarness;
 	}, { scope: "worker", auto: true, timeout: 60_000 }],
 
 	restoreDefaultProject: [async ({ gateway }, use) => {

--- a/tests/e2e/harness-restart-api.spec.ts
+++ b/tests/e2e/harness-restart-api.spec.ts
@@ -1,0 +1,80 @@
+import { existsSync, readFileSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { test, expect } from "./in-process-harness.js";
+import { apiFetch, rawApiFetch } from "./e2e-setup.js";
+
+function restartSentinelPath(bobbitDir: string): string {
+	return join(bobbitDir, "state", "gateway-restart");
+}
+
+async function readHarnessStatus(): Promise<{ restartAvailable: boolean }> {
+	const resp = await apiFetch("/api/harness-status");
+	expect(resp.status).toBe(200);
+	return await resp.json();
+}
+
+test.describe("harness restart API", () => {
+	test.describe.configure({ mode: "serial" });
+
+	test("reports restart unavailable and rejects direct restart outside the dev harness", async ({ gateway }) => {
+		const previous = process.env.BOBBIT_DEV_HARNESS;
+		const sentinel = restartSentinelPath(gateway.bobbitDir);
+		try {
+			rmSync(sentinel, { force: true });
+			delete process.env.BOBBIT_DEV_HARNESS;
+
+			await expect(readHarnessStatus()).resolves.toEqual({ restartAvailable: false });
+
+			const resp = await rawApiFetch("/api/harness/restart", {
+				method: "POST",
+				body: JSON.stringify({}),
+			});
+			expect(resp.status).toBe(403);
+			expect(await resp.json()).toMatchObject({
+				error: expect.stringMatching(/dev harness/i),
+			});
+			expect(existsSync(sentinel)).toBe(false);
+		} finally {
+			if (previous === undefined) delete process.env.BOBBIT_DEV_HARNESS;
+			else process.env.BOBBIT_DEV_HARNESS = previous;
+		}
+	});
+
+	test("reports restart available under the dev harness and touches the isolated sentinel", async ({ gateway }) => {
+		const previous = process.env.BOBBIT_DEV_HARNESS;
+		const sentinel = restartSentinelPath(gateway.bobbitDir);
+		try {
+			rmSync(sentinel, { force: true });
+			process.env.BOBBIT_DEV_HARNESS = "1";
+
+			await expect(readHarnessStatus()).resolves.toEqual({ restartAvailable: true });
+
+			const firstResp = await rawApiFetch("/api/harness/restart", {
+				method: "POST",
+				body: JSON.stringify({}),
+			});
+			expect(firstResp.status).toBe(202);
+			expect(await firstResp.json()).toMatchObject({ ok: true, restartRequested: true });
+			expect(existsSync(sentinel)).toBe(true);
+			const firstContent = readFileSync(sentinel, "utf-8").trim();
+			const firstMtime = statSync(sentinel).mtimeMs;
+			expect(Number(firstContent)).toBeGreaterThan(0);
+
+			await expect.poll(() => Date.now(), { timeout: 1_000 }).toBeGreaterThan(Number(firstContent));
+			const secondResp = await rawApiFetch("/api/harness/restart", {
+				method: "POST",
+				body: JSON.stringify({}),
+			});
+			expect(secondResp.status).toBe(202);
+			expect(await secondResp.json()).toMatchObject({ ok: true, restartRequested: true });
+			const secondContent = readFileSync(sentinel, "utf-8").trim();
+			const secondMtime = statSync(sentinel).mtimeMs;
+			expect(Number(secondContent)).toBeGreaterThanOrEqual(Number(firstContent));
+			expect(secondMtime).toBeGreaterThanOrEqual(firstMtime);
+			expect(secondContent === firstContent && secondMtime === firstMtime).toBe(false);
+		} finally {
+			if (previous === undefined) delete process.env.BOBBIT_DEV_HARNESS;
+			else process.env.BOBBIT_DEV_HARNESS = previous;
+		}
+	});
+});

--- a/tests/e2e/ui/settings-restart-button.spec.ts
+++ b/tests/e2e/ui/settings-restart-button.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect, type Page } from "../gateway-harness.js";
+import { openApp, navigateToHash } from "./ui-helpers.js";
+
+async function openSettings(page: Page): Promise<void> {
+	await openApp(page);
+	await navigateToHash(page, "#/settings/system/general");
+	await expect(page.locator("h1").filter({ hasText: "Settings" })).toBeVisible({ timeout: 10_000 });
+}
+
+async function expectRestartHidden(page: Page): Promise<void> {
+	await expect(page.getByRole("button", { name: /Restart Server|Restart Requested|Requesting/i })).toHaveCount(0);
+}
+
+test.describe("Settings restart button without dev harness", () => {
+	test("is hidden by default and remains hidden after reload and navigation", async ({ page }) => {
+		await openSettings(page);
+		await expectRestartHidden(page);
+
+		await page.reload();
+		await expect(page.locator("button").filter({ hasText: "Settings" }).first()).toBeVisible({ timeout: 15_000 });
+		await navigateToHash(page, "#/settings/system/general");
+		await expectRestartHidden(page);
+
+		await navigateToHash(page, "#/");
+		await navigateToHash(page, "#/settings/system/general");
+		await expectRestartHidden(page);
+	});
+});
+
+test.describe("Settings restart button with dev harness", () => {
+	test.use({ enableDevHarnessRestart: true });
+
+	test("is visible, requests restart with feedback, and remains visible after reload and navigation", async ({ page }) => {
+		let releaseRestart!: () => void;
+		const restartFulfilled = new Promise<void>((resolve) => {
+			releaseRestart = resolve;
+		});
+		let restartCalls = 0;
+		await page.route("**/api/harness/restart", async (route) => {
+			restartCalls += 1;
+			await restartFulfilled;
+			await route.fulfill({
+				status: 202,
+				contentType: "application/json",
+				body: JSON.stringify({ ok: true, restartRequested: true }),
+			});
+		});
+
+		await openSettings(page);
+		const restartButton = page.getByRole("button", { name: "Restart Server" });
+		await expect(restartButton).toBeVisible({ timeout: 10_000 });
+
+		await restartButton.click();
+		await expect(page.getByRole("button", { name: /Requesting/i })).toBeDisabled({ timeout: 5_000 });
+		expect(restartCalls).toBe(1);
+
+		releaseRestart();
+		await expect(page.getByRole("button", { name: "Restart Requested" })).toBeDisabled({ timeout: 10_000 });
+
+		await page.reload();
+		await expect(page.locator("button").filter({ hasText: "Settings" }).first()).toBeVisible({ timeout: 15_000 });
+		await navigateToHash(page, "#/settings/system/general");
+		await expect(page.getByRole("button", { name: "Restart Server" })).toBeVisible({ timeout: 10_000 });
+
+		await navigateToHash(page, "#/");
+		await navigateToHash(page, "#/settings/system/general");
+		await expect(page.getByRole("button", { name: "Restart Server" })).toBeVisible({ timeout: 10_000 });
+	});
+});

--- a/tests/e2e/ui/settings-restart-button.spec.ts
+++ b/tests/e2e/ui/settings-restart-button.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect, type Page } from "../gateway-harness.js";
+import { openApp, navigateToHash } from "./ui-helpers.js";
+
+const devHarnessTest = test.extend<{}, { enableDevHarnessRestart: boolean }>({
+	enableDevHarnessRestart: [true, { scope: "worker", option: true }],
+});
+
+async function openSettings(page: Page): Promise<void> {
+	await openApp(page);
+	await navigateToHash(page, "#/settings/system/general");
+	await expect(page.locator("h1").filter({ hasText: "Settings" })).toBeVisible({ timeout: 10_000 });
+}
+
+async function expectRestartHidden(page: Page): Promise<void> {
+	await expect(page.getByRole("button", { name: /Restart Server|Restart Requested|Requesting/i })).toHaveCount(0);
+}
+
+test.describe("Settings restart button without dev harness", () => {
+	test("is hidden by default and remains hidden after reload and navigation", async ({ page }) => {
+		await openSettings(page);
+		await expectRestartHidden(page);
+
+		await page.reload();
+		await expect(page.locator("button").filter({ hasText: "Settings" }).first()).toBeVisible({ timeout: 15_000 });
+		await navigateToHash(page, "#/settings/system/general");
+		await expectRestartHidden(page);
+
+		await navigateToHash(page, "#/");
+		await navigateToHash(page, "#/settings/system/general");
+		await expectRestartHidden(page);
+	});
+});
+
+devHarnessTest.describe("Settings restart button with dev harness", () => {
+	devHarnessTest("is visible, requests restart with feedback, and remains visible after reload and navigation", async ({ page }) => {
+		let releaseRestart!: () => void;
+		const restartFulfilled = new Promise<void>((resolve) => {
+			releaseRestart = resolve;
+		});
+		let restartCalls = 0;
+		await page.route("**/api/harness/restart", async (route) => {
+			restartCalls += 1;
+			await restartFulfilled;
+			await route.fulfill({
+				status: 202,
+				contentType: "application/json",
+				body: JSON.stringify({ ok: true, restartRequested: true }),
+			});
+		});
+
+		await openSettings(page);
+		const restartButton = page.getByRole("button", { name: "Restart Server" });
+		await expect(restartButton).toBeVisible({ timeout: 10_000 });
+
+		await restartButton.click();
+		await expect(page.getByRole("button", { name: /Requesting/i })).toBeDisabled({ timeout: 5_000 });
+		expect(restartCalls).toBe(1);
+
+		releaseRestart();
+		await expect(page.getByRole("button", { name: "Restart Requested" })).toBeDisabled({ timeout: 10_000 });
+
+		await page.reload();
+		await expect(page.locator("button").filter({ hasText: "Settings" }).first()).toBeVisible({ timeout: 15_000 });
+		await navigateToHash(page, "#/settings/system/general");
+		await expect(page.getByRole("button", { name: "Restart Server" })).toBeVisible({ timeout: 10_000 });
+
+		await navigateToHash(page, "#/");
+		await navigateToHash(page, "#/settings/system/general");
+		await expect(page.getByRole("button", { name: "Restart Server" })).toBeVisible({ timeout: 10_000 });
+	});
+});

--- a/tests/verification-sandbox-exec.test.ts
+++ b/tests/verification-sandbox-exec.test.ts
@@ -43,6 +43,7 @@ function createMockGoalStore(opts: { sandboxed?: boolean; branch?: string } = {}
 			branch: opts.branch,
 			enabledOptionalSteps: [],
 		}),
+		bumpGeneration: mock.fn(() => {}),
 	};
 }
 


### PR DESCRIPTION
## Summary
- Add dev-harness-gated restart status and restart REST endpoints.
- Show a Settings header Restart Server button only when the gateway reports harness restart support.
- Add API/browser E2E coverage and docs for the dev harness restart flow.

## Verification
- npm run check
- npm run test:unit
- npm run test:e2e (passed with 1 pre-existing flaky quarantine retry)

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)