### PR TITLE
Complete PR Walkthrough

### DIFF
--- a/docs/pr-walkthrough-panel.md
+++ b/docs/pr-walkthrough-panel.md
@@ -1,145 +1,265 @@
 # PR Walkthrough Panel
 
-The PR walkthrough panel is Bobbit's guided review surface for pull requests and local changesets. It opens in the side panel beside chat, not as embedded chat cards, so the transcript stays available for questions while the review UI owns navigation, comments, and the draft review state.
+The PR walkthrough panel is Bobbit's guided review surface for pull requests and local changesets. It opens beside chat so the transcript stays available while the walkthrough owns review navigation, line comments, card decisions, the audit draft, and GitHub export preview.
 
-The panel is intentionally changeset-oriented rather than GitHub-specific. The MVP renders fixture-generated logical cards, but the core component only needs a changeset reference, cards, diffs, comments, and decisions. GitHub lookup and export belong in adapters around that model.
+The product is intentionally changeset-oriented rather than GitHub-specific. Local SHA pairs, GitHub PRs, and test fixtures all resolve into the same model: a changeset reference, diff blocks with hunks and line anchors, logical review cards, warnings, and export capability metadata. GitHub lookup and submission are adapters around that model, not assumptions inside the UI.
 
-The checked-in prototype in [`docs/design/pr-walkthrough-panel-prototype.html`](design/pr-walkthrough-panel-prototype.html) is the source of truth for UX unless a deviation is explicitly reviewed and accepted. Treat the prose docs as implementation notes around that prototype, not a replacement for it.
+The checked-in prototype in [`docs/design/pr-walkthrough-panel-prototype.html`](design/pr-walkthrough-panel-prototype.html) remains the UX reference. This document describes the production ingestion, persistence, export, and troubleshooting behavior around that UI.
 
 ## Launch paths and surfaces
 
 Users can open the walkthrough from these entry points:
 
-- **Slash command** — type `/walkthrough-pr <url|number>` in chat.
-  - URLs become external PR changesets.
-  - Numbers, with or without `#`, become PR-number changesets.
-  - Empty invocations fall back to the fixture changeset.
-- **Git Status Widget** — click **Walkthrough** on the git status widget. The widget emits branch, PR, summary, insertion, deletion, and file-count metadata, and the app opens or focuses the matching walkthrough side-panel tab.
-- **PR/GitHub metadata** — when a launch source includes PR URL/number/title metadata, the walkthrough header and toolbar expose a GitHub-style PR link pill that opens the provider URL externally.
+- **Slash command** — `/walkthrough-pr <url|number>` in chat.
+  - GitHub PR URLs resolve directly from the owner, repository, and PR number in the URL.
+  - Numbers, with or without `#`, resolve against the selected session's `origin` remote.
+  - Empty invocations use the fixture walkthrough for development and compatibility.
+- **Git Status Widget / custom event** — the UI listens for `open-pr-walkthrough` events and accepts PR metadata, file stats, and local `baseSha` / `headSha` values.
+- **Standalone route** — `/walkthrough?session=<id>&tab=<walkthrough-tab-id>` opens the same walkthrough tab in a wide review surface.
 
-Launches create a side-panel tab with a canonical `walkthrough:<changeset-id>` id. Reopening the same changeset focuses and updates that tab instead of duplicating it.
+Launches create or focus a side-panel tab with a canonical `walkthrough:<changeset-id>` id. When the resolver returns the canonical changeset id, the tab is renamed to that id so reopening the same PR or SHA pair focuses the existing tab instead of duplicating state.
 
-The same walkthrough tab can be reviewed in multiple surfaces:
+The same walkthrough can be used in:
 
 - the normal Bobbit side panel beside chat;
-- the fullscreen/wide review surface from the side-panel toolbar;
-- a standalone `/walkthrough?session=<id>&tab=<walkthrough-tab-id>` route, opened by the toolbar's new-tab action.
+- the fullscreen / wide review surface from the side-panel toolbar;
+- the standalone `/walkthrough?...` route opened from the toolbar.
+
+## Resolution pipeline
+
+All real walkthroughs resolve through `POST /api/pr-walkthrough/resolve`. The client normally sends the active `sessionId`; callers may also pass an explicit `cwd` for tests or integrations.
+
+### CWD and worktree selection
+
+Resolution is session-aware:
+
+1. An explicit request `cwd` wins.
+2. Otherwise the server uses the live or persisted session worktree path.
+3. If the session has no worktree, it uses the session cwd.
+4. If no session path is available, it falls back to the gateway default cwd.
+
+This matters because local SHAs and PR numbers are interpreted in the selected session's checkout, not in the primary project worktree. PR-number resolution also uses that checkout's `origin` remote to infer the GitHub owner and repository.
+
+### Local SHA walkthroughs
+
+Local walkthroughs require `baseSha` and `headSha`. The server verifies both refs, reads git shortstat and name-status metadata, and parses a unified diff with rename/copy detection enabled.
+
+The result includes:
+
+- full base/head SHAs and local provider metadata;
+- changed file, addition, and deletion counts;
+- one diff block per parsed file, with status, old path when applicable, hunk headers, stable line ids, old-line numbers, and new-line numbers;
+- warnings for truncation, generated files, binary files, omitted files, and other parse limitations.
+
+Local walkthroughs can produce review drafts and export previews, but they cannot submit to GitHub because there is no provider review target.
+
+### GitHub PR walkthroughs
+
+GitHub walkthroughs accept either a PR URL or a PR number:
+
+- A URL carries owner, repository, host, and PR number.
+- A number requires a GitHub `origin` remote in the resolved cwd so Bobbit can infer owner and repository.
+
+The adapter fetches PR metadata and changed files from the GitHub API. If the base and head commits are available locally in the session worktree, Bobbit prefers local per-file patches so review hunks contain richer context than the GitHub files API often returns. Otherwise it uses the patch content returned by GitHub.
+
+`GITHUB_TOKEN` or `GH_TOKEN` is optional for public PR resolution, but unauthenticated requests have lower rate limits and cannot submit reviews. Private PRs and review submission require a token with permission to read the repository and create pull request reviews.
+
+For GitHub Enterprise or test environments, the adapter also honors the configured API base URL and trusted host allowlist. Untrusted hosts are rejected before any external request is made.
+
+### GitHub metadata with local SHAs
+
+If a request includes both GitHub metadata and local `baseSha` / `headSha`, Bobbit resolves the diff locally and decorates the changeset as GitHub. This is useful when the commits are already present in the worktree or when an integration provides PR metadata but export credentials are unavailable. Submission remains preview-only unless a real GitHub adapter target and credentials are available.
+
+## Changeset and card model
+
+The shared walkthrough model lives under `src/shared/pr-walkthrough/` and is consumed by both server and UI.
+
+Key concepts:
+
+- **Changeset** — provider, base/head SHAs, title, PR URL/number/title when present, and summary stats.
+- **Diff block** — one reviewable file block with `filePath`, optional `oldPath`, status, generated/binary/truncated flags, external links, and hunks.
+- **Hunk** — original hunk header plus ordered line records.
+- **Line** — stable id, kind (`context`, `add`, `del`), side (`context`, `new`, `old`), text, and old/new line numbers for review anchors.
+- **Card** — a logical review unit in one of the walkthrough phases. A card can contain multiple diff blocks across one or more files.
+- **Warning** — visible ingestion or export issue with a severity, code, message, and optional file path.
+
+The UI never needs to know whether a diff came from local git or GitHub. It renders the same cards, warnings, comments, decisions, draft review, and export preview for every provider.
+
+## Logical card synthesis
+
+After resolving files and diff blocks, the server attempts to create logical cards.
+
+1. **Model-backed LLM attempt** — when a synthesis adapter or configured review/session model is available, Bobbit sends a bounded JSON description of the changeset, files, warnings, and diff block ids. The model must return JSON cards that reference only known diff block ids and valid line ids.
+2. **Validation** — invalid phases, missing titles/summaries, unknown diff blocks, duplicate block assignments, and bad suggested-comment anchors are discarded.
+3. **Deterministic fallback** — if the model is unavailable, times out, or returns no valid cards, Bobbit groups cards deterministically by path area, change weight, and special file category.
+
+The fallback always starts with an orientation card. It then assigns representative diff blocks to design, significant, other, and audit phases where possible. Generated, binary, renamed, deleted, copied, and truncated files are grouped into lower-signal or edge-case cards so they are visible without overwhelming the main review path. Empty diffs resolve to an orientation-only walkthrough instead of a broken panel.
 
 ## Review flow
 
 The walkthrough is organised into five phases:
 
-1. **Orientation** — establishes scope and review framing.
-2. **Key design choices** — explains the main design decisions the reviewer should understand before scanning code.
-3. **Significant changes** — walks through the most important implementation details and diffs.
-4. **Other + omissions** — calls out smaller changes, known MVP omissions, and follow-up boundaries.
-5. **Audit** — reviews remaining lines as a normal diff-backed card and then shows the final draft review section.
+1. **Orientation** — confirms scope, refs, provider metadata, stats, and warnings.
+2. **Key design choices** — highlights the largest or most architecture-relevant path group.
+3. **Significant changes** — reviews high-signal implementation diffs.
+4. **Other + omissions** — covers smaller changes and special files.
+5. **Audit** — checks remaining coverage and renders the final draft review.
 
-Every phase contains one or more logical cards, including Audit. A card is an LLM-synthesised review unit: title, summary, optional rationale/checklist, optional suggested comments, and one or more diff blocks. A single logical card can span multiple files or diff blocks when that better matches the reviewer story. Audit cards use the same line comments, card comments, suggestions, diff expansion, and Like/Dislike controls as other cards; their extra responsibility is to render the copyable draft review after the diff-backed audit content.
-
-## Navigation rail
-
-The rail adapts to the available side-panel width:
-
-- **Wide layout** shows labelled phase sections and card buttons. Phase buttons jump to the first card in that phase; card buttons jump directly to the card.
-- **Narrow layout** collapses to a thin rail. Phase pips remain clickable, and each card is represented by a clickable dot with an accessible label and tooltip. Completed cards show decision glyphs.
-
-This keeps the same review model usable in both the half-width Bobbit side panel and wider review surfaces.
+Every phase can contain normal diff-backed cards. A card can span multiple files or hunks when that better matches the reviewer story. Audit cards use the same line comments, card comments, suggestions, diff expansion, and Like/Dislike controls as other cards, then render the copyable draft review.
 
 ## Diff behaviour
 
-Diffs render from the same card/block/hunk model in two modes:
+Diffs render from the card/block/hunk model in two modes:
 
 - **Split** — side-by-side old/new columns. This is the default in wide layouts.
 - **Inline** — a single column. This is the default in narrow layouts.
 
-The user can toggle either mode at any width. Split diffs wrap both sides in one shared horizontal overflow container, so each diff widget has one horizontal scrollbar instead of competing scrollbars per column.
+The user can toggle either mode at any width. Split diffs use one shared horizontal overflow container per diff widget, so old and new columns scroll together.
 
-Split mode renders line details for both sides of a paired row. Deleted old-side lines and added new-side lines can each show their own suggestions, saved comments, and active editor below the row; context rows share a single detail area because both columns represent the same logical line.
+Deleted old-side lines and added new-side lines each have their own suggestions, saved comments, and active editor below the row. Context rows share a single detail area because both columns represent the same logical line.
 
-## Comments and decisions
+## Comments, decisions, and draft review
 
 Review state is built from comments plus per-card decisions.
 
 ### Line comments
 
-Diff lines are interactive. Hovering or clicking a line reveals the comment affordance; keyboard users can open it from the focused line. Line comments are anchored by card id, diff block id, and logical line id, with file and line information resolved later for the audit draft.
+Diff lines are interactive. Hovering or clicking a line reveals the comment affordance; keyboard users can open it from the focused line. Line comments are anchored by card id, diff block id, and line id. Export mapping later resolves those anchors to provider-specific file/side/line coordinates.
 
-LLM-suggested line comments can appear beside matching lines. The reviewer can:
-
-- accept the suggestion as a queued line comment;
-- accept and edit it;
-- delete/dismiss it.
-
-Suggested comments become normal queued comments after acceptance and can then be edited or deleted.
+Suggested line comments can appear beside matching lines. The reviewer can accept, accept and edit, or dismiss them. Accepted suggestions become normal queued comments.
 
 ### Card comments
 
-Every card also has a card-level comment area for broad concerns that do not belong on a specific line. This is always available, even when the card has no useful line anchor.
+Every card has a card-level comment area for broad concerns that do not belong on a specific line. Card-level comments are included in the audit/export body rather than submitted as GitHub line comments.
 
 ### Like, Dislike, and Prev
 
-- **Like** is always enabled, uses primary button styling, records a liked decision, and advances to the next card.
-- **Dislike** is disabled until the active card has at least one non-empty line or card comment. When enabled, it stays visually neutral at rest and uses the negative theme colour on hover/focus. Clicking it records a disliked decision with supporting comment ids and advances.
-- **Prev** moves back to the previous card so the reviewer can revise comments or change the decision.
+- **Like** records an approval decision and advances.
+- **Dislike** is disabled until the card has at least one non-empty supporting line or card comment.
+- **Prev** moves back so reviewers can revise comments or decisions.
 
-If the last supporting comment for a disliked card is deleted, the component clears the invalid disliked decision and removes that card from the completed set. This keeps the audit draft from containing unsupported change requests.
+If the last supporting comment for a disliked card is deleted, the invalid disliked decision is cleared. This prevents unsupported change requests from appearing in the audit draft.
 
-## Audit draft
+### Audit draft
 
-The Audit phase is a regular diff-backed review card followed by a copyable draft review assembled from current state:
+The audit draft is assembled from current state:
 
 - changeset title and base/head metadata;
 - liked cards under approved context;
-- disliked cards and their supporting comments under concerns;
+- disliked cards and supporting comments under concerns;
 - queued line comments grouped with file/line anchors;
 - broad card-level comments.
 
-The MVP is copy-only. It does not submit to GitHub or another provider. A future export adapter should consume the same draft state and translate it into provider-specific review comments or final review actions.
+The draft can always be copied, even when provider export is unavailable.
 
-## Persistence and tab isolation
+## Persistence and reload
 
-The panel persists interaction state by walkthrough tab id using a browser-storage key derived from `bobbit:pr-walkthrough:<tab-id>`. Persisted state includes:
+Persistence has two layers:
 
-- active card;
-- diff mode override;
-- comments;
-- decisions;
-- completed card ids;
-- dismissed suggestion ids;
-- collapsed diff block ids.
+- **Resolved walkthrough payload** — the server stores resolved changeset/cards/warnings/export metadata under Bobbit state by `changesetId`. Stored payloads are schema-versioned and sanitized so auth tokens or raw headers are not persisted.
+- **Reviewer interaction state** — the browser stores active card, diff mode, comments, decisions, completed cards, dismissed suggestions, and collapsed diff blocks under `bobbit:pr-walkthrough:<tab-id>`.
 
-Because the persistence key is the side-panel tab id, each walkthrough tab is isolated. Opening `/walkthrough-pr 123` and `/walkthrough-pr 456` creates independent state; comments, decisions, active card, and Dislike enablement do not leak between tabs. Reloading the app restores the active walkthrough tab and its persisted audit state.
+When the app reloads, Bobbit restores the side-panel tab. If the tab has no cards yet, it calls `GET /api/pr-walkthrough/<changeset-id>` to reload the server payload. The component then restores browser interaction state only when the card checksum still matches, which avoids applying old comments to a changed diff.
 
-## MVP adapter boundary
+Because side panel, fullscreen, and standalone route all refer to the same tab id and persistence key, comments and decisions survive tab switching, wide review, standalone routing, and reload. Browser-local interaction state is not shared across browsers or devices.
 
-The production slice is fixture-driven. `PrWalkthroughPanel` receives `changeset`, `cards`, and `persistenceKey` and does not call GitHub APIs. App-level launch code maps slash-command, Git Status Widget input, or PR-link metadata into a changeset ref and side-panel tab. Fixture cards then stand in for future card synthesis.
+## GitHub export
 
-Walkthrough stats prefer explicit changeset values (`filesChanged`, `additions`, `deletions`). If a launch path does not provide them, the panel derives file, addition, and deletion counts from the rendered cards' diff blocks. The Git Status Widget path supplies insertions, deletions, and file counts when available so the header can reflect the real branch summary before server-side card synthesis exists.
+GitHub export is deliberately two-step:
 
-Keep future work on the same boundary:
+1. **Preview** — `POST /api/pr-walkthrough/<changeset-id>/export/preview` maps the current draft to a review body and per-line GitHub review comments.
+2. **Confirmed submit** — `POST /api/pr-walkthrough/<changeset-id>/export/submit` requires `confirm: true`. The UI only sends this after the reviewer clicks **Confirm submit to GitHub** in the preview dialog.
 
-- **Core model** — changeset ref, logical cards, diff blocks, suggested comments, reviewer comments, decisions, and draft review.
-- **Generation adapter** — turns two SHAs or provider metadata into logical cards.
-- **Provider adapter** — resolves GitHub PR metadata and exports final comments/review actions.
+Bobbit never submits comments to GitHub during resolution or preview.
 
-This separation keeps local SHA walkthroughs first-class and avoids coupling the review UI to GitHub before the core interaction model is stable.
+Preview behavior:
+
+- Line comments with valid diff anchors map to GitHub `path`, `side`, and `line`.
+- Deleted-side comments map to `LEFT`; added/context comments map to `RIGHT` when a new line number exists.
+- Card-level comments are folded into the review body.
+- Empty comments, missing anchors, binary files, and unreviewable/truncated lines are marked unmappable and shown in the preview warnings.
+
+Submit behavior:
+
+- Requires a GitHub walkthrough target and an available export capability.
+- Requires `GITHUB_TOKEN` or `GH_TOKEN` at submit time.
+- Uses the current draft event as **Request changes** when there are comments or disliked cards; otherwise it submits an approval.
+- Returns the GitHub review URL when GitHub provides one.
+
+Unavailable cases still show a safe preview/copy path. Local changesets, unauthenticated GitHub walkthroughs, missing adapters, invalid tokens, insufficient permissions, and unmappable-only drafts do not silently submit.
+
+## Edge states and warnings
+
+The panel renders loading, error, empty, and warning states instead of falling back to broken UI.
+
+Common warning/error categories:
+
+- **Missing PR** — GitHub `404` responses return a structured error and the panel shows the resolver failure.
+- **Authentication failure** — GitHub `401` indicates the configured token was rejected.
+- **Permission failure** — GitHub `403` with remaining rate limit usually means the token cannot access the repository or PR.
+- **Rate limit** — GitHub `403` with no remaining quota reports rate limiting; configure a token or retry later.
+- **Large/truncated diffs** — local diff output, GitHub patch bytes, per-file line counts, or changed-file pages can be truncated. Warnings identify the affected files when possible.
+- **Generated files** — generated-looking paths are flagged as low-signal and grouped into edge-case cards.
+- **Binary files** — binary changes have no reviewable text hunks and cannot receive GitHub line comments.
+- **Renamed/deleted/copied files** — status and old paths are preserved so reviewers can understand the file movement and export can map valid line anchors.
+- **Empty diffs** — resolve to an orientation-only walkthrough with zero changed files.
+- **Untrusted PR hosts** — non-allowlisted hosts are rejected before fetching metadata or rendering clickable URLs.
+
+Warnings are shown at the top of the panel and again in export preview when they affect submission.
+
+## API summary
+
+The walkthrough API is internal to the Bobbit UI but useful for tests and integrations:
+
+- `POST /api/pr-walkthrough/resolve` — resolve a fixture, local SHA pair, GitHub PR, or GitHub metadata plus local SHAs. Stores the resolved payload.
+- `GET /api/pr-walkthrough/<changeset-id>` — reload a stored walkthrough payload.
+- `POST /api/pr-walkthrough/<changeset-id>/export/preview` — build a provider review preview from a draft.
+- `POST /api/pr-walkthrough/<changeset-id>/export/submit` — submit a provider review only when `confirm: true` and export is available.
+
+Important request fields for resolve:
+
+- `sessionId` — lets the server use the selected session worktree/cwd and session model.
+- `cwd` — explicit repository path, mainly for tests and integrations.
+- `baseSha`, `headSha` — required for local SHA resolution.
+- `prUrl`, `prNumber`, `provider` — GitHub resolution inputs.
+- `fixture` — explicit fixture fallback.
+
+## Credentials and configuration
+
+- `GITHUB_TOKEN` / `GH_TOKEN` — used for GitHub API requests and required for review submission.
+- `BOBBIT_GITHUB_API_BASE_URL` — overrides the GitHub API base URL, useful for GitHub Enterprise or tests.
+- `BOBBIT_GITHUB_TRUSTED_HOSTS` — comma-separated allowlist for additional trusted GitHub hosts.
+- `BOBBIT_PR_WALKTHROUGH_SYNTHESIS_ADAPTER` — optional module path for a custom synthesis adapter.
+
+For model-backed synthesis without a custom adapter, Bobbit uses the selected session model when available, then the default review model, then the default session model. If none are configured or the model output is invalid, deterministic fallback cards are used.
+
+## Limitations
+
+- Browser interaction state is local to the browser storage for the tab id; it is not synchronized between devices.
+- GitHub line-comment export can only submit comments with valid GitHub review anchors. Card-level and unmappable comments remain in the review body/preview.
+- Binary files and files without text patches cannot receive line comments on GitHub.
+- Large diffs may show representative hunks and truncation warnings rather than every changed line.
+- PR-number-only launch depends on the session worktree having a GitHub `origin` remote.
+- Unauthenticated public PR resolution is best-effort and subject to GitHub's lower anonymous API rate limits.
+
+## Troubleshooting
+
+- **`/walkthrough-pr 123` cannot find the repository** — select a session whose worktree has a GitHub `origin` remote, or use the full PR URL.
+- **Invalid base/head ref** — make sure both SHAs exist in the session worktree. Fetch the branch or use the correct session.
+- **Private PR fails or shows permission errors** — set `GITHUB_TOKEN` or `GH_TOKEN` with repository read and pull request review permissions, then retry.
+- **Rate limited** — configure a token or wait for GitHub's rate limit reset.
+- **Export button only shows copy/preview** — the walkthrough is local, unauthenticated, missing a GitHub target, or export capability was disabled by the resolver.
+- **Some comments are unmappable** — check whether the comment is card-level, attached to a binary/truncated file, or anchored to a line GitHub cannot review.
+- **Reload loses comments after a PR update** — the card checksum changed, so Bobbit intentionally avoids restoring comments onto a different diff. Re-resolve and review the updated cards.
+- **GitHub Enterprise URL is rejected** — add the host to the trusted host allowlist and configure the matching API base URL.
 
 ## Testing notes
 
-Browser coverage lives in `tests/e2e/ui/pr-walkthrough-panel.spec.ts`. The suite verifies the user-facing contract:
+Coverage is split across unit, API E2E, and browser E2E tests:
 
-- slash-command launch opens a side-panel walkthrough tab, not chat cards;
-- wide layout shows the labelled rail and defaults to split diff mode;
-- narrow layout shows clickable card-dot navigation and defaults to inline diff mode;
-- the diff mode toggle can switch back to split and keeps one horizontal scrollbar per diff;
-- line comments can be created, edited, and deleted;
-- Dislike is gated by comments and invalid disliked decisions are cleared when comments are removed;
-- Prev supports decision revision;
-- Audit is a normal diff-backed card with line/card comments plus a final draft section;
-- Audit draft reflects liked cards, disliked concerns, and queued comments;
-- reload restores persisted state;
-- separate walkthrough tabs keep state isolated;
-- fixture suggested comments can be accepted, edited, and deleted.
+- diff parsing and changeset ids;
+- card synthesis, LLM validation, deterministic fallback, and store sanitization;
+- local SHA resolution, persisted reload, large diff warnings, empty diffs, GitHub errors, and export confirmation enforcement;
+- browser behavior for loading states, real resolved cards, warning banners, persistence across reload/fullscreen/standalone, export preview, confirmed submit, error states, responsive layout, and the original MVP interaction contract.
 
-Use this test as the pinning contract when changing panel behaviour or replacing fixture generation with real changeset synthesis.
+Use these tests as the pinning contract when changing resolver behavior, card synthesis, persistence, or panel UX.

--- a/src/app/pr-walkthrough.ts
+++ b/src/app/pr-walkthrough.ts
@@ -2,13 +2,42 @@ import {
 	panelTabsForSession,
 	setActivePanelTabIdForSession,
 	setPanelTabsForSession,
+	walkthroughChangesetIdFromPanelTabId,
 	walkthroughPanelTabId,
 	type PanelWorkspaceTab,
 } from "./panel-workspace.js";
+import { gatewayFetch } from "./gateway-fetch.js";
+import { renderApp } from "./state.js";
 import type { state as appState } from "./state.js";
-import type { PrWalkthroughChangesetRef } from "../ui/components/pr-walkthrough/types.js";
+import type { PrWalkthroughCard, PrWalkthroughChangesetRef } from "../ui/components/pr-walkthrough/types.js";
 
 export type AppState = typeof appState;
+
+export type PrWalkthroughStatus = "fixture" | "loading" | "ready" | "error";
+
+export interface WalkthroughWarning {
+	code: string;
+	severity: "info" | "warning" | "error";
+	message: string;
+	filePath?: string;
+}
+
+interface WalkthroughResolveResult {
+	changesetId: string;
+	changeset: PrWalkthroughChangesetRef;
+	cards: PrWalkthroughCard[];
+	warnings?: WalkthroughWarning[];
+	limits?: unknown;
+	export?: unknown;
+	exportCapability?: unknown;
+}
+
+interface WalkthroughApiError extends Error {
+	status?: number;
+	body?: unknown;
+	plainText?: string;
+	missingRoute?: boolean;
+}
 
 export interface OpenPrWalkthroughInput {
 	baseSha?: string;
@@ -158,6 +187,196 @@ export function prWalkthroughStandaloneHref(sessionId: string, tabId: string): s
 	return `/walkthrough?${params.toString()}`;
 }
 
+function shouldResolveInput(input: OpenPrWalkthroughInput): boolean {
+	return Boolean(cleanString(input.prUrl) || cleanString(input.url) || normalizePrNumber(input.prNumber) || (cleanString(input.baseSha) && cleanString(input.headSha)));
+}
+
+function resolveRequestForInput(sessionId: string, input: OpenPrWalkthroughInput): Record<string, unknown> {
+	return {
+		sessionId: sessionId || undefined,
+		baseSha: cleanString(input.baseSha),
+		headSha: cleanString(input.headSha),
+		prUrl: cleanString(input.prUrl) || cleanString(input.url),
+		prNumber: normalizePrNumber(input.prNumber),
+		provider: cleanString(input.provider),
+		fixture: !shouldResolveInput(input) || undefined,
+	};
+}
+
+function isResolveResult(value: unknown): value is WalkthroughResolveResult {
+	const result = value as Partial<WalkthroughResolveResult> | null;
+	return Boolean(result && typeof result === "object" && typeof result.changesetId === "string" && result.changeset && typeof result.changeset === "object" && Array.isArray(result.cards));
+}
+
+async function readJsonOrText(response: Response): Promise<{ body: unknown; text: string }> {
+	const text = await response.text().catch(() => "");
+	if (!text) return { body: undefined, text };
+	try {
+		return { body: JSON.parse(text), text };
+	} catch {
+		return { body: undefined, text };
+	}
+}
+
+function errorMessageFromBody(body: unknown, fallback: string): string {
+	if (body && typeof body === "object") {
+		const record = body as Record<string, unknown>;
+		for (const key of ["message", "error", "detail"]) {
+			const value = record[key];
+			if (typeof value === "string" && value.trim()) return value.trim();
+		}
+	}
+	return fallback;
+}
+
+async function fetchWalkthroughJson(path: string, options?: RequestInit): Promise<unknown> {
+	const response = await gatewayFetch(path, options);
+	const contentType = response.headers.get("content-type") || "";
+	const { body, text } = await readJsonOrText(response);
+	if (!response.ok) {
+		const err = new Error(errorMessageFromBody(body, text || `Request failed with ${response.status}`)) as WalkthroughApiError;
+		err.status = response.status;
+		err.body = body;
+		err.plainText = text;
+		err.missingRoute = response.status === 404 && !contentType.includes("application/json") && /^not found$/i.test(text.trim());
+		throw err;
+	}
+	return body;
+}
+
+function patchWalkthroughTab(
+	state: AppState,
+	sessionId: string,
+	tabId: string,
+	patch: Record<string, unknown>,
+	result?: WalkthroughResolveResult,
+): string {
+	const canonicalChangesetId = typeof patch.changesetId === "string" && patch.changesetId ? patch.changesetId : undefined;
+	const nextTabId = canonicalChangesetId ? walkthroughPanelTabId(canonicalChangesetId) : tabId;
+	let updatedTabId = tabId;
+	let replaced = false;
+	const tabs = panelTabsForSession(state, sessionId);
+	const nextTabs = tabs.map((tab) => {
+		if (tab.id !== tabId && tab.id !== nextTabId) return tab;
+		if (tab.id === nextTabId && tab.id !== tabId) return tab;
+		replaced = true;
+		updatedTabId = nextTabId;
+		const source = (tab.source || {}) as Record<string, unknown>;
+		const tabState = (tab.state || {}) as Record<string, unknown>;
+		const changeset = result?.changeset || (patch.changeset as PrWalkthroughChangesetRef | undefined) || (tabState.changeset as PrWalkthroughChangesetRef | undefined);
+		const title = changeset?.title || (typeof patch.title === "string" ? patch.title : undefined) || tab.title;
+		return {
+			...tab,
+			id: nextTabId,
+			title,
+			label: tab.label || "Walkthrough",
+			source: {
+				...source,
+				type: "walkthrough",
+				sessionId,
+				...(canonicalChangesetId ? { changesetId: canonicalChangesetId } : {}),
+				...(changeset ? {
+					title,
+					baseSha: changeset.baseSha,
+					headSha: changeset.headSha,
+					provider: changeset.provider,
+					externalUrl: changeset.externalUrl,
+					prUrl: changeset.prUrl || changeset.externalUrl,
+					prNumber: changeset.prNumber,
+					prTitle: changeset.prTitle,
+					filesChanged: changeset.filesChanged,
+					additions: changeset.additions,
+					deletions: changeset.deletions,
+				} : {}),
+			} as PanelWorkspaceTab["source"],
+			state: { ...tabState, ...patch },
+		} as PanelWorkspaceTab;
+	});
+
+	const deduped = nextTabId !== tabId ? nextTabs.filter((tab, index, all) => tab.id !== nextTabId || all.findIndex((candidate) => candidate.id === nextTabId) === index) : nextTabs;
+	if (replaced) {
+		setPanelTabsForSession(state, sessionId, deduped);
+		if (nextTabId !== tabId) setActivePanelTabIdForSession(state, sessionId, nextTabId);
+	}
+	return updatedTabId;
+}
+
+export async function resolvePrWalkthrough(state: AppState, sessionId: string, tabId: string, input: OpenPrWalkthroughInput): Promise<void> {
+	try {
+		const data = await fetchWalkthroughJson("/api/pr-walkthrough/resolve", {
+			method: "POST",
+			body: JSON.stringify(resolveRequestForInput(sessionId, input)),
+		});
+		if (!isResolveResult(data)) throw new Error("PR walkthrough resolver returned an invalid response");
+		patchWalkthroughTab(state, sessionId, tabId, {
+			status: "ready",
+			changesetId: data.changesetId,
+			changeset: data.changeset,
+			cards: data.cards,
+			warnings: data.warnings || [],
+			limits: data.limits,
+			exportCapability: data.exportCapability ?? data.export,
+		}, data);
+	} catch (error) {
+		const err = error as WalkthroughApiError;
+		patchWalkthroughTab(state, sessionId, tabId, err.missingRoute
+			? {
+				status: "fixture",
+				warnings: [{ code: "resolver_unavailable", severity: "info", message: "Using fixture walkthrough because the resolver API is unavailable." }],
+			}
+			: {
+				status: "error",
+				error: err.message || "Failed to resolve PR walkthrough",
+				warnings: [],
+			});
+	} finally {
+		renderApp();
+	}
+}
+
+const restoreInFlight = new Set<string>();
+
+export function restorePrWalkthroughPanel(state: AppState, sessionId: string, tabId: string): void {
+	const tabs = panelTabsForSession(state, sessionId);
+	const tab = tabs.find((candidate) => candidate.id === tabId);
+	if (!tab || tab.kind !== "walkthrough") return;
+	const tabState = (tab.state || {}) as Record<string, unknown>;
+	if (Array.isArray(tabState.cards) || tabState.status === "loading") return;
+	const changesetId = typeof tabState.changesetId === "string" && tabState.changesetId
+		? tabState.changesetId
+		: walkthroughChangesetIdFromPanelTabId(tab.id);
+	if (!changesetId || changesetId === "fixture") return;
+	const key = `${sessionId}:${tab.id}:${changesetId}`;
+	if (restoreInFlight.has(key)) return;
+	restoreInFlight.add(key);
+	patchWalkthroughTab(state, sessionId, tab.id, { status: "loading" });
+	renderApp();
+	void fetchWalkthroughJson(`/api/pr-walkthrough/${encodeURIComponent(changesetId)}`)
+		.then((data) => {
+			if (!isResolveResult(data)) throw new Error("PR walkthrough store returned an invalid response");
+			patchWalkthroughTab(state, sessionId, tab.id, {
+				status: "ready",
+				changesetId: data.changesetId,
+				changeset: data.changeset,
+				cards: data.cards,
+				warnings: data.warnings || [],
+				limits: data.limits,
+				exportCapability: data.exportCapability ?? data.export,
+			}, data);
+		})
+		.catch((error: WalkthroughApiError) => {
+			patchWalkthroughTab(state, sessionId, tab.id, {
+				status: error.missingRoute ? "fixture" : "error",
+				error: error.missingRoute ? undefined : error.message || "Failed to restore PR walkthrough",
+				warnings: error.missingRoute ? [{ code: "resolver_unavailable", severity: "info", message: "Using fixture walkthrough because the resolver API is unavailable." }] : [],
+			});
+		})
+		.finally(() => {
+			restoreInFlight.delete(key);
+			renderApp();
+		});
+}
+
 export function openPrWalkthroughPanel(state: AppState, sessionId: string, rawInput: OpenPrWalkthroughInput): PanelWorkspaceTab {
 	const input = normalizeInput(state, rawInput);
 	const changeset = changesetRefForWalkthrough(input);
@@ -167,6 +386,7 @@ export function openPrWalkthroughPanel(state: AppState, sessionId: string, rawIn
 	const prUrl = cleanString(input.prUrl) || cleanString(input.url) || changeset.externalUrl;
 	const prTitle = cleanString(input.prTitle) || cleanString(input.title);
 	const title = changeset.title || titleForInput(input);
+	const shouldResolve = shouldResolveInput(input);
 	const source = {
 		type: "walkthrough" as const,
 		sessionId,
@@ -190,7 +410,20 @@ export function openPrWalkthroughPanel(state: AppState, sessionId: string, rawIn
 		label: "Walkthrough",
 		legacyTab: "walkthrough",
 		source,
-		state: { changesetId, changeset, prUrl, prNumber, prTitle, baseSha: changeset.baseSha, headSha: changeset.headSha, filesChanged: changeset.filesChanged, additions: changeset.additions, deletions: changeset.deletions },
+		state: {
+			status: shouldResolve ? "loading" : "fixture",
+			changesetId,
+			changeset,
+			warnings: [],
+			prUrl,
+			prNumber,
+			prTitle,
+			baseSha: changeset.baseSha,
+			headSha: changeset.headSha,
+			filesChanged: changeset.filesChanged,
+			additions: changeset.additions,
+			deletions: changeset.deletions,
+		},
 	};
 
 	const existing = panelTabsForSession(state, sessionId);
@@ -210,5 +443,6 @@ export function openPrWalkthroughPanel(state: AppState, sessionId: string, rawIn
 	(state as any).previewPanelTab = "walkthrough";
 	(state as any).previewPanelActiveTab = "walkthrough";
 	if ((state as any).assistantType) (state as any).assistantTab = "preview";
+	if (shouldResolve) void resolvePrWalkthrough(state, sessionId, tabId, input);
 	return tab;
 }

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -5,7 +5,7 @@ import { icon } from "@mariozechner/mini-lit";
 import { Button } from "@mariozechner/mini-lit/dist/Button.js";
 import { html, render } from "lit";
 import { repeat } from "lit/directives/repeat.js";
-import type { PrWalkthroughChangesetRef } from "../ui/components/pr-walkthrough/types.js";
+import type { PrWalkthroughCard, PrWalkthroughChangesetRef } from "../ui/components/pr-walkthrough/types.js";
 import Sortable from "sortablejs";
 import { shortcutHint } from "./shortcut-registry.js";
 import { Archive, ArrowLeft, ExternalLink, FileText, FolderOpen, FolderPlus, Link, Maximize2, MessagesSquare, ChevronDown, Goal as GoalIcon, PanelRightClose, PanelRightOpen, Pencil, Plus, QrCode, RotateCw, Server, Settings, Trash2, Unplug, Users, Workflow as WorkflowIcon, Wrench, X, Zap } from "lucide";
@@ -92,11 +92,13 @@ import {
 	reviewPanelTabId,
 	reviewTitleFromPanelTab,
 	setActivePanelTabIdForSession,
+	walkthroughChangesetIdFromPanelTabId,
 	walkthroughPanelTabId,
 	setPanelTabsForSession,
 	type PanelWorkspaceTab,
 } from "./panel-workspace.js";
 import type { OpenPrWalkthroughInput } from "./pr-walkthrough.js";
+import { restorePrWalkthroughPanel } from "./pr-walkthrough.js";
 import { ensurePrWalkthroughPanel } from "./pr-walkthrough-lazy.js";
 
 const bobbitIcon = html`<img src="/favicon.svg" alt="" style="width:20px;height:18px;image-rendering:pixelated;" />`;
@@ -2199,12 +2201,34 @@ export function doRenderApp(): void {
 		if (tab.kind !== "walkthrough") return "";
 		void ensurePrWalkthroughPanel();
 		const changeset = walkthroughChangesetFromTab(tab);
+		const tabState = (tab.state || {}) as Record<string, unknown>;
+		const cards = Array.isArray(tabState.cards) ? tabState.cards as PrWalkthroughCard[] : undefined;
+		const status = typeof tabState.status === "string" ? tabState.status : "fixture";
+		const warnings = Array.isArray(tabState.warnings) ? tabState.warnings : [];
+		const error = typeof tabState.error === "string" ? tabState.error : undefined;
+		const exportCapability = tabState.exportCapability;
 		return html`
-			<div class="flex-1 min-h-0 overflow-hidden" data-testid="pr-walkthrough-panel-root" data-panel-tab-id=${tab.id}>
-				<pr-walkthrough-panel
-					.changeset=${changeset}
-					.persistenceKey=${tab.id}
-				></pr-walkthrough-panel>
+			<div class="flex-1 min-h-0 overflow-hidden" data-testid="pr-walkthrough-panel-root" data-panel-tab-id=${tab.id} data-walkthrough-status=${status}>
+				${cards ? html`
+					<pr-walkthrough-panel
+						.changeset=${changeset}
+						.cards=${cards}
+						.status=${status}
+						.warnings=${warnings}
+						.error=${error}
+						.exportCapability=${exportCapability}
+						.persistenceKey=${tab.id}
+					></pr-walkthrough-panel>
+				` : html`
+					<pr-walkthrough-panel
+						.changeset=${changeset}
+						.status=${status}
+						.warnings=${warnings}
+						.error=${error}
+						.exportCapability=${exportCapability}
+						.persistenceKey=${tab.id}
+					></pr-walkthrough-panel>
+				`}
 			</div>
 		`;
 	};
@@ -2218,17 +2242,25 @@ export function doRenderApp(): void {
 			: rawTabId;
 		const tabCandidates = [tabId, rawTabId].filter(Boolean);
 		const storedTab = panelTabsForSession(state, sid).find((candidate) => tabCandidates.includes(candidate.id) && candidate.kind === "walkthrough") as UnifiedContentTab | undefined;
+		const fallbackTabId = tabId && tabId.startsWith("walkthrough:") ? tabId : "walkthrough:fixture";
+		const fallbackChangesetId = walkthroughChangesetIdFromPanelTabId(fallbackTabId);
 		const tab = storedTab
 			? (tabId && storedTab.id !== tabId ? { ...storedTab, id: tabId } as UnifiedContentTab : storedTab)
 			: {
-				id: tabId && tabId.startsWith("walkthrough:") ? tabId : "walkthrough:fixture",
+				id: fallbackTabId,
 				kind: "walkthrough" as const,
 				title: "PR Walkthrough",
 				label: "Walkthrough",
 				legacyTab: "walkthrough" as const,
-				source: { type: "walkthrough" as const, sessionId: sid, title: "PR Walkthrough" },
-				state: {},
+				source: { type: "walkthrough" as const, sessionId: sid, title: "PR Walkthrough", changesetId: fallbackChangesetId },
+				state: { changesetId: fallbackChangesetId },
 			} as UnifiedContentTab;
+		if (storedTab) {
+			restorePrWalkthroughPanel(state, sid, storedTab.id);
+		} else if (fallbackChangesetId && fallbackChangesetId !== "fixture") {
+			setPanelTabsForSession(state, sid, [...panelTabsForSession(state, sid), tab as PanelWorkspaceTab]);
+			restorePrWalkthroughPanel(state, sid, tab.id);
+		}
 		return html`
 			<div class="flex-1 min-h-0 flex flex-col overflow-hidden" data-testid="pr-walkthrough-standalone" data-panel-tab-id=${tab.id}>
 				<div class="flex items-center justify-between gap-3 px-4 py-2 border-b border-border shrink-0" style="background:var(--background);">

--- a/src/server/agent/bobbit-archive.ts
+++ b/src/server/agent/bobbit-archive.ts
@@ -57,6 +57,7 @@ export const GATEWAY_OWNED_FILES: readonly string[] = [
 	"state/mcp-extensions/",      // src/server/agent/tool-activation.ts, rpc-bridge.ts
 	"state/html-snapshots/",      // server.ts
 	"state/proposal-drafts/",     // server.ts / session-manager.ts
+	"state/pr-walkthrough/",      // src/server/pr-walkthrough/routes.ts persisted walkthrough payloads
 	"state/model-name-*",         // src/server/agent/session-manager.ts per-session model-name files
 	"state/sessions/",            // per-session JSONL transcripts (rpc-bridge.ts container mount)
 	"state/session-prompts/",     // per-session prompt scratch (rpc-bridge.ts)

--- a/src/server/pr-walkthrough/card-synthesis.ts
+++ b/src/server/pr-walkthrough/card-synthesis.ts
@@ -1,0 +1,498 @@
+// The shared PR walkthrough model is produced by the upstream model task. Keep this
+// import pointed at that contract while retaining local structural types so this
+// module can be validated independently when the shared file is not present yet.
+// @ts-ignore Upstream shared model may be absent on this parallel task branch.
+import type { PrWalkthroughCard as SharedPrWalkthroughCard, PrWalkthroughChangesetRef as SharedPrWalkthroughChangesetRef, PrWalkthroughDiffBlock as SharedPrWalkthroughDiffBlock, PrWalkthroughDiffLine as SharedPrWalkthroughDiffLine, PrWalkthroughHunk as SharedPrWalkthroughHunk, PrWalkthroughPhaseId as SharedPrWalkthroughPhaseId, PrWalkthroughSuggestedComment as SharedPrWalkthroughSuggestedComment, WalkthroughWarning as SharedWalkthroughWarning } from "../../shared/pr-walkthrough/types.js";
+
+type PreserveShared<T> = unknown extends T ? unknown : T;
+type LocalPhaseId = "orientation" | "design" | "significant" | "other" | "audit";
+type PrWalkthroughPhaseId = LocalPhaseId & PreserveShared<SharedPrWalkthroughPhaseId>;
+
+type PrWalkthroughDiffLine = {
+	id: string;
+	side: "old" | "new" | "context";
+	oldLine?: number;
+	newLine?: number;
+	text: string;
+	kind: "context" | "add" | "del";
+} & PreserveShared<SharedPrWalkthroughDiffLine>;
+
+type PrWalkthroughHunk = {
+	id: string;
+	header: string;
+	lines: PrWalkthroughDiffLine[];
+} & PreserveShared<SharedPrWalkthroughHunk>;
+
+type PrWalkthroughDiffBlock = {
+	id: string;
+	filePath: string;
+	oldPath?: string;
+	hunks: PrWalkthroughHunk[];
+} & PreserveShared<SharedPrWalkthroughDiffBlock>;
+
+type PrWalkthroughSuggestedComment = {
+	id: string;
+	cardId: string;
+	diffBlockId: string;
+	lineId: string;
+	body: string;
+} & PreserveShared<SharedPrWalkthroughSuggestedComment>;
+
+type PrWalkthroughCard = {
+	id: string;
+	phaseId: PrWalkthroughPhaseId;
+	title: string;
+	summary: string;
+	rationale?: string;
+	diffBlocks: PrWalkthroughDiffBlock[];
+	suggestedComments?: PrWalkthroughSuggestedComment[];
+	cardSuggestions?: string[];
+	checklist?: string[];
+} & PreserveShared<SharedPrWalkthroughCard>;
+
+type PrWalkthroughChangesetRef = {
+	baseSha: string;
+	headSha: string;
+	provider?: string;
+	externalUrl?: string;
+	prUrl?: string;
+	prNumber?: string | number;
+	prTitle?: string;
+	title?: string;
+	filesChanged?: number;
+	additions?: number;
+	deletions?: number;
+} & PreserveShared<SharedPrWalkthroughChangesetRef>;
+
+type WalkthroughWarning = {
+	code: string;
+	severity: "info" | "warning" | "error";
+	message: string;
+	filePath?: string;
+} & PreserveShared<SharedWalkthroughWarning>;
+
+export type WalkthroughFileStatus = "added" | "modified" | "deleted" | "renamed" | "copied" | "binary";
+
+export interface WalkthroughParsedFile {
+	filePath: string;
+	oldPath?: string;
+	status?: WalkthroughFileStatus | string;
+	diffBlocks?: PrWalkthroughDiffBlock[];
+	warnings?: WalkthroughWarning[];
+	isGenerated?: boolean;
+	isTruncated?: boolean;
+	isBinary?: boolean;
+}
+
+export interface WalkthroughLlmCardCandidate {
+	id?: unknown;
+	phaseId?: unknown;
+	title?: unknown;
+	summary?: unknown;
+	rationale?: unknown;
+	diffBlockIds?: unknown;
+	diffBlocks?: unknown;
+	suggestedComments?: unknown;
+	cardSuggestions?: unknown;
+	checklist?: unknown;
+}
+
+export interface WalkthroughCardSynthesisOptions {
+	warnings?: WalkthroughWarning[];
+	allowLlm?: boolean;
+	maxLlmInputBytes?: number;
+	llm?: ((input: WalkthroughLlmInput) => Promise<unknown> | unknown) | { synthesiseWalkthroughCards(input: WalkthroughLlmInput): Promise<unknown> | unknown };
+	maxCards?: number;
+}
+
+export interface WalkthroughLlmInput {
+	changeset: PrWalkthroughChangesetRef;
+	files: WalkthroughParsedFile[];
+	warnings: WalkthroughWarning[];
+	diffBlockIds: string[];
+}
+
+const PHASES = new Set<PrWalkthroughPhaseId>(["orientation", "design", "significant", "other", "audit"]);
+const DEFAULT_MAX_LLM_INPUT_BYTES = 48_000;
+const DEFAULT_MAX_CARDS = 12;
+const MAX_BLOCKS_PER_FALLBACK_CARD = 6;
+
+interface WeightedBlock {
+	block: PrWalkthroughDiffBlock;
+	file: WalkthroughParsedFile;
+	weight: number;
+	category: "generated" | "truncated" | "deleted" | "renamed" | "binary" | "normal";
+	topLevel: string;
+}
+
+interface DiffHunkForSynthesis {
+	lines: PrWalkthroughDiffLine[];
+}
+
+interface DiffBlockForSynthesis {
+	hunks: DiffHunkForSynthesis[];
+}
+
+interface BlockGroup {
+	key: string;
+	label: string;
+	blocks: WeightedBlock[];
+	weight: number;
+}
+
+export async function synthesiseWalkthroughCards(
+	changeset: PrWalkthroughChangesetRef,
+	files: WalkthroughParsedFile[],
+	options: WalkthroughCardSynthesisOptions = {},
+): Promise<PrWalkthroughCard[]> {
+	const warnings = options.warnings ?? collectFileWarnings(files);
+	const llmCards = await tryLlmSynthesis(changeset, files, warnings, options);
+	if (llmCards.length > 0) return limitCards(llmCards, options.maxCards);
+	return limitCards(buildFallbackCards(changeset, files, warnings), options.maxCards);
+}
+
+export function validateSynthesisedCards(raw: unknown, files: WalkthroughParsedFile[]): PrWalkthroughCard[] {
+	const candidates = extractCardCandidates(raw);
+	const blockById = new Map<string, PrWalkthroughDiffBlock>();
+	const lineIdsByBlock = new Map<string, Set<string>>();
+	for (const block of flattenBlocks(files)) {
+		blockById.set(block.id, block);
+		lineIdsByBlock.set(block.id, new Set(lineIdsForBlock(block)));
+	}
+
+	const cards: PrWalkthroughCard[] = [];
+	const seen = new Set<string>();
+	const usedBlockIds = new Set<string>();
+	for (const candidate of candidates) {
+		if (!isRecord(candidate)) continue;
+		const phaseId = typeof candidate.phaseId === "string" && PHASES.has(candidate.phaseId as PrWalkthroughPhaseId) ? candidate.phaseId as PrWalkthroughPhaseId : undefined;
+		const title = stringValue(candidate.title);
+		const summary = stringValue(candidate.summary);
+		if (!phaseId || !title || !summary) continue;
+
+		const blockIds = unique(candidateBlockIds(candidate)).filter(blockId => !usedBlockIds.has(blockId));
+		const diffBlocks = blockIds.map(id => blockById.get(id)).filter((block): block is PrWalkthroughDiffBlock => Boolean(block));
+		if (diffBlocks.length === 0) continue;
+		for (const block of diffBlocks) usedBlockIds.add(block.id);
+
+		const id = stableCardId(`${phaseId}-${title}`, seen);
+		const suggestedComments = validateSuggestedComments(candidate.suggestedComments, id, diffBlocks, lineIdsByBlock);
+		cards.push({
+			id,
+			phaseId,
+			title,
+			summary,
+			rationale: stringValue(candidate.rationale),
+			diffBlocks,
+			...(suggestedComments.length > 0 ? { suggestedComments } : {}),
+			...stringArrayProp("cardSuggestions", candidate.cardSuggestions),
+			...stringArrayProp("checklist", candidate.checklist),
+		});
+	}
+	return cards;
+}
+
+function buildFallbackCards(
+	changeset: PrWalkthroughChangesetRef,
+	files: WalkthroughParsedFile[],
+	warnings: WalkthroughWarning[],
+): PrWalkthroughCard[] {
+	const weighted = flattenWeightedBlocks(files);
+	const cards: PrWalkthroughCard[] = [buildOrientationCard(changeset, files, warnings)];
+	if (weighted.length === 0) {
+		cards.push({
+			id: "audit-empty-diff",
+			phaseId: "audit",
+			title: "No diff blocks to audit",
+			summary: "The resolved changeset did not include reviewable hunks. Confirm the base/head refs and any truncation warnings before submitting a review.",
+			diffBlocks: [],
+			checklist: ["Verify the changeset refs", "Confirm no files were omitted unexpectedly"],
+		});
+		return cards;
+	}
+
+	const special = weighted.filter(block => block.category !== "normal");
+	const normal = weighted.filter(block => block.category === "normal");
+	const groups = groupByTopLevel(normal).sort((a, b) => b.weight - a.weight || a.key.localeCompare(b.key));
+	const assigned = new Set<string>();
+
+	const designGroup = groups.shift();
+	if (designGroup) cards.push(buildGroupCard("design", designGroup, assigned));
+
+	const significantGroups = groups.splice(0, 1);
+	for (const group of significantGroups) cards.push(buildGroupCard("significant", group, assigned));
+
+	const specialGroup = buildSpecialGroup(special);
+	if (specialGroup) cards.push(buildGroupCard("other", specialGroup, assigned));
+
+	const smallGroups: BlockGroup[] = [];
+	while (groups.length > 0 && totalBlocks(smallGroups) < MAX_BLOCKS_PER_FALLBACK_CARD && (groups.length > 1 || (smallGroups.length === 0 && cards.length < 4))) {
+		smallGroups.push(groups.pop() as BlockGroup);
+	}
+	if (smallGroups.length > 0) cards.push(buildOtherSmallChangesCard(smallGroups, assigned));
+
+	const remaining = weighted.filter(item => !assigned.has(item.block.id));
+	cards.push(buildAuditCard(remaining));
+	return cards;
+}
+
+function buildOrientationCard(
+	changeset: PrWalkthroughChangesetRef,
+	files: WalkthroughParsedFile[],
+	warnings: WalkthroughWarning[],
+): PrWalkthroughCard {
+	const title = changeset.title ?? changeset.prTitle ?? "Review changeset";
+	const stats = [
+		formatCount(changeset.filesChanged ?? files.length, "file"),
+		changeset.additions !== undefined ? `${changeset.additions} additions` : undefined,
+		changeset.deletions !== undefined ? `${changeset.deletions} deletions` : undefined,
+	].filter(Boolean).join(", ");
+	const range = `${shortRef(changeset.baseSha)}..${shortRef(changeset.headSha)}`;
+	const warningSummary = warnings.length > 0 ? ` ${warnings.length} warning${warnings.length === 1 ? "" : "s"} need attention before export.` : "";
+	return {
+		id: "orientation-summary",
+		phaseId: "orientation",
+		title,
+		summary: `Review ${range}${stats ? ` across ${stats}` : ""}.${warningSummary}`,
+		rationale: "Start by confirming scope, refs, provider metadata, and any ingestion warnings before inspecting individual hunks.",
+		diffBlocks: [],
+		checklist: ["Confirm base/head refs", "Scan warnings", "Review generated cards in order"],
+		cardSuggestions: warnings.slice(0, 3).map(warning => warning.filePath ? `${warning.filePath}: ${warning.message}` : warning.message),
+	};
+}
+
+function buildGroupCard(phaseId: PrWalkthroughPhaseId, group: BlockGroup, assigned: Set<string>): PrWalkthroughCard {
+	const blocks = selectBlocks(group.blocks, MAX_BLOCKS_PER_FALLBACK_CARD);
+	for (const item of blocks) assigned.add(item.block.id);
+	const fileList = unique(blocks.map(item => item.file.filePath));
+	const titlePrefix = phaseId === "design" ? "Review architecture changes" : phaseId === "other" ? "Review edge-case files" : "Review significant changes";
+	return {
+		id: stableCardId(`${phaseId}-${group.key}`),
+		phaseId,
+		title: `${titlePrefix} in ${group.label}`,
+		summary: `${formatCount(blocks.length, "diff block")} covering ${formatCount(fileList.length, "file")} with ${group.weight} changed lines.`,
+		rationale: phaseId === "design"
+			? "This top-level area carries the largest change weight and should be checked for design-level implications."
+			: "These hunks are grouped by path and change weight so related concerns can be reviewed together.",
+		diffBlocks: blocks.map(item => item.block),
+		checklist: ["Check behavior changes", "Verify tests or safeguards", "Leave line comments where needed"],
+	};
+}
+
+function buildOtherSmallChangesCard(groups: BlockGroup[], assigned: Set<string>): PrWalkthroughCard {
+	const blocks = groups.flatMap(group => selectBlocks(group.blocks, MAX_BLOCKS_PER_FALLBACK_CARD)).slice(0, MAX_BLOCKS_PER_FALLBACK_CARD);
+	for (const item of blocks) assigned.add(item.block.id);
+	return {
+		id: "other-small-changes",
+		phaseId: "other",
+		title: "Review smaller remaining files",
+		summary: `${formatCount(blocks.length, "diff block")} from lower-risk or smaller path groups.`,
+		rationale: "Small changes are grouped together to keep the walkthrough concise while preserving review anchors.",
+		diffBlocks: blocks.map(item => item.block),
+		checklist: ["Check for incidental regressions", "Confirm generated/low-risk classification is appropriate"],
+	};
+}
+
+function buildAuditCard(remaining: WeightedBlock[]): PrWalkthroughCard {
+	const blocks = selectBlocks(remaining, MAX_BLOCKS_PER_FALLBACK_CARD);
+	return {
+		id: "audit-remaining-hunks",
+		phaseId: "audit",
+		title: blocks.length > 0 ? "Audit remaining representative hunks" : "Audit walkthrough coverage",
+		summary: blocks.length > 0
+			? `${formatCount(blocks.length, "remaining diff block")} were not assigned to earlier logical cards and should receive a final pass.`
+			: "All reviewable diff blocks were assigned to earlier cards; use this step to verify decisions and draft review output.",
+		rationale: "The audit phase catches omissions without duplicating blocks already reviewed in earlier fallback cards.",
+		diffBlocks: blocks.map(item => item.block),
+		checklist: ["Confirm all phases are complete", "Review unresolved warnings", "Prepare final draft"],
+	};
+}
+
+function buildSpecialGroup(blocks: WeightedBlock[]): BlockGroup | undefined {
+	if (blocks.length === 0) return undefined;
+	return {
+		key: "special-files",
+		label: "generated, binary, renamed, or deleted files",
+		blocks: [...blocks].sort((a, b) => categoryOrder(a.category) - categoryOrder(b.category) || b.weight - a.weight || a.block.id.localeCompare(b.block.id)),
+		weight: blocks.reduce((sum, item) => sum + item.weight, 0),
+	};
+}
+
+function categoryOrder(category: WeightedBlock["category"]): number {
+	return ["generated", "truncated", "binary", "deleted", "renamed", "normal"].indexOf(category);
+}
+
+function groupByTopLevel(blocks: WeightedBlock[]): BlockGroup[] {
+	const groups = new Map<string, BlockGroup>();
+	for (const block of blocks) {
+		const existing = groups.get(block.topLevel) ?? { key: block.topLevel, label: block.topLevel, blocks: [], weight: 0 };
+		existing.blocks.push(block);
+		existing.weight += block.weight;
+		groups.set(block.topLevel, existing);
+	}
+	return [...groups.values()];
+}
+
+function flattenWeightedBlocks(files: WalkthroughParsedFile[]): WeightedBlock[] {
+	const weighted: WeightedBlock[] = [];
+	for (const file of files) {
+		for (const block of file.diffBlocks ?? []) {
+			weighted.push({
+				block,
+				file,
+				weight: blockWeight(block),
+				category: blockCategory(file),
+				topLevel: topLevelPath(file.filePath || block.filePath),
+			});
+		}
+	}
+	return weighted.sort((a, b) => b.weight - a.weight || a.block.id.localeCompare(b.block.id));
+}
+
+function flattenBlocks(files: WalkthroughParsedFile[]): PrWalkthroughDiffBlock[] {
+	return files.flatMap(file => file.diffBlocks ?? []);
+}
+
+function blockWeight(block: PrWalkthroughDiffBlock): number {
+	let total = 0;
+	for (const hunk of hunksForBlock(block)) {
+		for (const line of hunk.lines) total += lineWeight(line);
+	}
+	return total;
+}
+
+function lineIdsForBlock(block: PrWalkthroughDiffBlock): string[] {
+	return hunksForBlock(block).flatMap(hunk => hunk.lines.map(line => line.id));
+}
+
+function hunksForBlock(block: PrWalkthroughDiffBlock): DiffHunkForSynthesis[] {
+	return (block as PrWalkthroughDiffBlock & DiffBlockForSynthesis).hunks;
+}
+
+function lineWeight(line: PrWalkthroughDiffLine): number {
+	return line.kind === "context" ? 0 : 1;
+}
+
+function blockCategory(file: WalkthroughParsedFile): WeightedBlock["category"] {
+	if (file.isBinary || file.status === "binary") return "binary";
+	if (file.isGenerated || (file.warnings ?? []).some(warning => /generated/i.test(warning.code) || /generated/i.test(warning.message))) return "generated";
+	if (file.isTruncated || (file.warnings ?? []).some(warning => /truncat/i.test(warning.code) || /truncat/i.test(warning.message))) return "truncated";
+	if (file.status === "deleted") return "deleted";
+	if (file.status === "renamed" || file.status === "copied") return "renamed";
+	return "normal";
+}
+
+function topLevelPath(filePath: string): string {
+	const normalised = filePath.replaceAll("\\", "/");
+	const [first, second] = normalised.split("/");
+	if (!second) return first || "root";
+	if (first === "src" || first === "tests" || first === "docs") return `${first}/${second}`;
+	return first;
+}
+
+function selectBlocks(blocks: WeightedBlock[], max: number): WeightedBlock[] {
+	return blocks.slice(0, max);
+}
+
+function totalBlocks(groups: BlockGroup[]): number {
+	return groups.reduce((sum, group) => sum + group.blocks.length, 0);
+}
+
+async function tryLlmSynthesis(
+	changeset: PrWalkthroughChangesetRef,
+	files: WalkthroughParsedFile[],
+	warnings: WalkthroughWarning[],
+	options: WalkthroughCardSynthesisOptions,
+): Promise<PrWalkthroughCard[]> {
+	if (!options.allowLlm || !options.llm) return [];
+	const input: WalkthroughLlmInput = { changeset, files, warnings, diffBlockIds: flattenBlocks(files).map(block => block.id) };
+	if (byteLength(input) > (options.maxLlmInputBytes ?? DEFAULT_MAX_LLM_INPUT_BYTES)) return [];
+	try {
+		const raw = typeof options.llm === "function" ? await options.llm(input) : await options.llm.synthesiseWalkthroughCards(input);
+		return validateSynthesisedCards(raw, files);
+	} catch {
+		return [];
+	}
+}
+
+function extractCardCandidates(raw: unknown): unknown[] {
+	if (Array.isArray(raw)) return raw;
+	if (isRecord(raw) && Array.isArray(raw.cards)) return raw.cards;
+	return [];
+}
+
+function candidateBlockIds(candidate: Record<string, unknown>): string[] {
+	const fromIds = Array.isArray(candidate.diffBlockIds) ? candidate.diffBlockIds.filter((id): id is string => typeof id === "string") : [];
+	const fromBlocks = Array.isArray(candidate.diffBlocks)
+		? candidate.diffBlocks.flatMap(block => isRecord(block) && typeof block.id === "string" ? [block.id] : typeof block === "string" ? [block] : [])
+		: [];
+	return [...fromIds, ...fromBlocks];
+}
+
+function validateSuggestedComments(
+	raw: unknown,
+	cardId: string,
+	diffBlocks: PrWalkthroughDiffBlock[],
+	lineIdsByBlock: Map<string, Set<string>>,
+): PrWalkthroughSuggestedComment[] {
+	if (!Array.isArray(raw)) return [];
+	const validBlocks = new Set(diffBlocks.map(block => block.id));
+	const comments: PrWalkthroughSuggestedComment[] = [];
+	const seen = new Set<string>();
+	for (const item of raw) {
+		if (!isRecord(item)) continue;
+		const diffBlockId = stringValue(item.diffBlockId);
+		const lineId = stringValue(item.lineId);
+		const body = stringValue(item.body);
+		if (!diffBlockId || !lineId || !body || !validBlocks.has(diffBlockId) || !lineIdsByBlock.get(diffBlockId)?.has(lineId)) continue;
+		comments.push({ id: stableCardId(`suggest-${cardId}-${diffBlockId}-${lineId}`, seen), cardId, diffBlockId, lineId, body });
+	}
+	return comments;
+}
+
+function stringArrayProp(key: "cardSuggestions" | "checklist", raw: unknown): Partial<Pick<PrWalkthroughCard, "cardSuggestions" | "checklist">> {
+	const values = Array.isArray(raw) ? raw.filter((value): value is string => typeof value === "string" && value.trim().length > 0) : [];
+	return values.length > 0 ? { [key]: values } : {};
+}
+
+function collectFileWarnings(files: WalkthroughParsedFile[]): WalkthroughWarning[] {
+	return files.flatMap(file => file.warnings ?? []);
+}
+
+function byteLength(value: unknown): number {
+	return Buffer.byteLength(JSON.stringify(value), "utf-8");
+}
+
+function formatCount(count: number, singular: string): string {
+	return `${count} ${singular}${count === 1 ? "" : "s"}`;
+}
+
+function shortRef(ref: string | undefined): string {
+	return ref ? ref.slice(0, 12) : "unknown";
+}
+
+function stringValue(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function unique<T>(values: T[]): T[] {
+	return [...new Set(values)];
+}
+
+function stableCardId(input: string, seen?: Set<string>): string {
+	const base = input.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 64) || "card";
+	if (!seen) return base;
+	let candidate = base;
+	let suffix = 2;
+	while (seen.has(candidate)) candidate = `${base}-${suffix++}`;
+	seen.add(candidate);
+	return candidate;
+}
+
+function limitCards(cards: PrWalkthroughCard[], maxCards = DEFAULT_MAX_CARDS): PrWalkthroughCard[] {
+	return cards.slice(0, Math.max(1, maxCards));
+}

--- a/src/server/pr-walkthrough/card-synthesis.ts
+++ b/src/server/pr-walkthrough/card-synthesis.ts
@@ -199,17 +199,7 @@ function buildFallbackCards(
 ): PrWalkthroughCard[] {
 	const weighted = flattenWeightedBlocks(files);
 	const cards: PrWalkthroughCard[] = [buildOrientationCard(changeset, files, warnings)];
-	if (weighted.length === 0) {
-		cards.push({
-			id: "audit-empty-diff",
-			phaseId: "audit",
-			title: "No diff blocks to audit",
-			summary: "The resolved changeset did not include reviewable hunks. Confirm the base/head refs and any truncation warnings before submitting a review.",
-			diffBlocks: [],
-			checklist: ["Verify the changeset refs", "Confirm no files were omitted unexpectedly"],
-		});
-		return cards;
-	}
+	if (weighted.length === 0) return cards;
 
 	const special = weighted.filter(block => block.category !== "normal");
 	const normal = weighted.filter(block => block.category === "normal");
@@ -336,7 +326,7 @@ function groupByTopLevel(blocks: WeightedBlock[]): BlockGroup[] {
 function flattenWeightedBlocks(files: WalkthroughParsedFile[]): WeightedBlock[] {
 	const weighted: WeightedBlock[] = [];
 	for (const file of files) {
-		for (const block of file.diffBlocks ?? []) {
+		for (const block of blocksForFile(file)) {
 			weighted.push({
 				block,
 				file,
@@ -350,7 +340,13 @@ function flattenWeightedBlocks(files: WalkthroughParsedFile[]): WeightedBlock[] 
 }
 
 function flattenBlocks(files: WalkthroughParsedFile[]): PrWalkthroughDiffBlock[] {
-	return files.flatMap(file => file.diffBlocks ?? []);
+	return files.flatMap(file => blocksForFile(file));
+}
+
+function blocksForFile(file: WalkthroughParsedFile): PrWalkthroughDiffBlock[] {
+	if (Array.isArray(file.diffBlocks)) return file.diffBlocks;
+	const maybeBlock = file as WalkthroughParsedFile & Partial<PrWalkthroughDiffBlock>;
+	return typeof maybeBlock.id === "string" && Array.isArray(maybeBlock.hunks) ? [maybeBlock as PrWalkthroughDiffBlock] : [];
 }
 
 function blockWeight(block: PrWalkthroughDiffBlock): number {

--- a/src/server/pr-walkthrough/card-synthesis.ts
+++ b/src/server/pr-walkthrough/card-synthesis.ts
@@ -405,9 +405,22 @@ async function tryLlmSynthesis(
 	if (byteLength(input) > (options.maxLlmInputBytes ?? DEFAULT_MAX_LLM_INPUT_BYTES)) return [];
 	try {
 		const raw = typeof options.llm === "function" ? await options.llm(input) : await options.llm.synthesiseWalkthroughCards(input);
-		return validateSynthesisedCards(raw, files);
+		return validateSynthesisedCards(parseLlmJson(raw), files);
 	} catch {
 		return [];
+	}
+}
+
+function parseLlmJson(raw: unknown): unknown {
+	if (typeof raw !== "string") return raw;
+	const trimmed = raw.trim().replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/i, "").trim();
+	try {
+		return JSON.parse(trimmed);
+	} catch {
+		const start = trimmed.indexOf("{");
+		const end = trimmed.lastIndexOf("}");
+		if (start >= 0 && end > start) return JSON.parse(trimmed.slice(start, end + 1));
+		return raw;
 	}
 }
 

--- a/src/server/pr-walkthrough/diff-parser.ts
+++ b/src/server/pr-walkthrough/diff-parser.ts
@@ -1,0 +1,239 @@
+import type { PrWalkthroughDiffBlock, PrWalkthroughDiffLine, PrWalkthroughHunk, WalkthroughWarning } from "../../shared/pr-walkthrough/types.js";
+import { diffBlockIdForFile, hunkIdForBlock, lineIdForHunk } from "../../shared/pr-walkthrough/ids.js";
+
+export type WalkthroughFileStatus = "added" | "modified" | "deleted" | "renamed" | "copied" | "binary";
+
+export interface ParsedWalkthroughDiffFile extends PrWalkthroughDiffBlock {
+	status: WalkthroughFileStatus;
+	isBinary: boolean;
+	isGenerated: boolean;
+	truncated: boolean;
+	warnings: WalkthroughWarning[];
+	additions: number;
+	deletions: number;
+}
+
+export interface ParseUnifiedDiffOptions {
+	maxFiles?: number;
+	maxLinesPerFile?: number;
+	generatedPathMatcher?: (filePath: string) => boolean;
+}
+
+export interface ParseUnifiedDiffResult {
+	files: ParsedWalkthroughDiffFile[];
+	warnings: WalkthroughWarning[];
+}
+
+interface MutableDiffFile extends ParsedWalkthroughDiffFile {
+	currentHunk?: PrWalkthroughHunk;
+	oldLineCursor: number;
+	newLineCursor: number;
+	lineCount: number;
+}
+
+const HUNK_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$/;
+
+export function parseUnifiedDiff(diff: string, options: ParseUnifiedDiffOptions = {}): ParseUnifiedDiffResult {
+	const warnings: WalkthroughWarning[] = [];
+	const files: MutableDiffFile[] = [];
+	let current: MutableDiffFile | undefined;
+	let omittedForFileLimit = false;
+
+	const lines = diff.replace(/\r\n/g, "\n").split("\n");
+	for (const rawLine of lines) {
+		if (rawLine.startsWith("diff --git ")) {
+			if (options.maxFiles !== undefined && files.length >= options.maxFiles) {
+				if (!omittedForFileLimit) {
+					warnings.push({ code: "max-files-exceeded", severity: "warning", message: `Diff contains more than ${options.maxFiles} files; remaining files were omitted.` });
+					omittedForFileLimit = true;
+				}
+				current = undefined;
+				continue;
+			}
+			current = createFileFromDiffGit(rawLine, files.length, options.generatedPathMatcher);
+			files.push(current);
+			continue;
+		}
+
+		if (!current) continue;
+
+		if (rawLine.startsWith("new file mode ")) {
+			current.status = "added";
+			continue;
+		}
+		if (rawLine.startsWith("deleted file mode ")) {
+			current.status = "deleted";
+			continue;
+		}
+		if (rawLine.startsWith("rename from ")) {
+			current.status = "renamed";
+			current.oldPath = rawLine.slice("rename from ".length);
+			continue;
+		}
+		if (rawLine.startsWith("rename to ")) {
+			current.status = "renamed";
+			current.filePath = rawLine.slice("rename to ".length);
+			continue;
+		}
+		if (rawLine.startsWith("copy from ")) {
+			current.status = "copied";
+			current.oldPath = rawLine.slice("copy from ".length);
+			continue;
+		}
+		if (rawLine.startsWith("copy to ")) {
+			current.status = "copied";
+			current.filePath = rawLine.slice("copy to ".length);
+			continue;
+		}
+		if (rawLine.startsWith("Binary files ") || rawLine === "GIT binary patch") {
+			markBinary(current);
+			continue;
+		}
+		if (rawLine.startsWith("@@ ")) {
+			const hunk = parseHunkHeader(rawLine, current);
+			current.hunks.push(hunk);
+			current.currentHunk = hunk;
+			continue;
+		}
+		if (!current.currentHunk || rawLine.startsWith("\\ No newline at end of file")) continue;
+
+		if (rawLine.startsWith("+") || rawLine.startsWith("-") || rawLine.startsWith(" ")) {
+			appendDiffLine(current, rawLine, options.maxLinesPerFile);
+		}
+	}
+
+	for (const file of files) {
+		delete file.currentHunk;
+		if (file.isGenerated) {
+			file.warnings.push({ code: "generated-file", severity: "info", message: `${file.filePath} looks generated and may be low-signal for review.`, filePath: file.filePath });
+		}
+	}
+
+	return { files, warnings: [...warnings, ...files.flatMap(file => file.warnings)] };
+}
+
+function createFileFromDiffGit(line: string, index: number, generatedPathMatcher?: (filePath: string) => boolean): MutableDiffFile {
+	const [oldPath, newPath] = parseDiffGitPaths(line);
+	const filePath = newPath === "/dev/null" ? oldPath : newPath;
+	const blockId = diffBlockIdForFile(filePath, index);
+	return {
+		id: blockId,
+		filePath,
+		oldPath: oldPath !== filePath && oldPath !== "/dev/null" ? oldPath : undefined,
+		status: "modified",
+		hunks: [],
+		isBinary: false,
+		isGenerated: generatedPathMatcher?.(filePath) ?? false,
+		truncated: false,
+		warnings: [],
+		additions: 0,
+		deletions: 0,
+		oldLineCursor: 0,
+		newLineCursor: 0,
+		lineCount: 0,
+	};
+}
+
+function parseDiffGitPaths(line: string): [string, string] {
+	const rest = line.slice("diff --git ".length);
+	const tokens = tokenizeGitPathPair(rest);
+	const oldPath = stripGitPrefix(tokens[0] ?? "unknown");
+	const newPath = stripGitPrefix(tokens[1] ?? oldPath);
+	return [oldPath, newPath];
+}
+
+function tokenizeGitPathPair(input: string): string[] {
+	const tokens: string[] = [];
+	let i = 0;
+	while (i < input.length && tokens.length < 2) {
+		while (input[i] === " ") i += 1;
+		if (input[i] === '"') {
+			let token = "";
+			i += 1;
+			while (i < input.length) {
+				const char = input[i++];
+				if (char === '"') break;
+				if (char === "\\" && i < input.length) token += input[i++];
+				else token += char;
+			}
+			tokens.push(token);
+		} else {
+			let token = "";
+			while (i < input.length && input[i] !== " ") token += input[i++];
+			tokens.push(token);
+		}
+	}
+	return tokens;
+}
+
+function stripGitPrefix(path: string): string {
+	if (path === "/dev/null") return path;
+	return path.replace(/^[ab]\//, "");
+}
+
+function parseHunkHeader(header: string, file: MutableDiffFile): PrWalkthroughHunk {
+	const match = HUNK_RE.exec(header);
+	if (match) {
+		file.oldLineCursor = Number(match[1]);
+		file.newLineCursor = Number(match[3]);
+	}
+	return {
+		id: hunkIdForBlock(file.id, file.hunks.length),
+		header,
+		lines: [],
+	};
+}
+
+function appendDiffLine(file: MutableDiffFile, rawLine: string, maxLinesPerFile: number | undefined): void {
+	if (maxLinesPerFile !== undefined && file.lineCount >= maxLinesPerFile) {
+		if (!file.truncated) {
+			file.truncated = true;
+			file.warnings.push({ code: "file-lines-truncated", severity: "warning", message: `${file.filePath} was truncated after ${maxLinesPerFile} diff lines.`, filePath: file.filePath });
+		}
+		advanceCounters(file, rawLine);
+		return;
+	}
+
+	const hunk = file.currentHunk;
+	if (!hunk) return;
+	const kind: PrWalkthroughDiffLine["kind"] = rawLine[0] === "+" ? "add" : rawLine[0] === "-" ? "del" : "context";
+	const line: PrWalkthroughDiffLine = {
+		id: lineIdForHunk(file.id, file.hunks.length - 1, hunk.lines.length),
+		side: kind === "add" ? "new" : kind === "del" ? "old" : "context",
+		text: rawLine.slice(1),
+		kind,
+	};
+	if (kind === "add") {
+		line.newLine = file.newLineCursor;
+		file.newLineCursor += 1;
+		file.additions += 1;
+	} else if (kind === "del") {
+		line.oldLine = file.oldLineCursor;
+		file.oldLineCursor += 1;
+		file.deletions += 1;
+	} else {
+		line.oldLine = file.oldLineCursor;
+		line.newLine = file.newLineCursor;
+		file.oldLineCursor += 1;
+		file.newLineCursor += 1;
+	}
+	file.lineCount += 1;
+	hunk.lines.push(line);
+}
+
+function advanceCounters(file: MutableDiffFile, rawLine: string): void {
+	if (rawLine.startsWith("+")) file.newLineCursor += 1;
+	else if (rawLine.startsWith("-")) file.oldLineCursor += 1;
+	else if (rawLine.startsWith(" ")) {
+		file.oldLineCursor += 1;
+		file.newLineCursor += 1;
+	}
+}
+
+function markBinary(file: MutableDiffFile): void {
+	file.status = "binary";
+	file.isBinary = true;
+	if (!file.warnings.some(warning => warning.code === "binary-file")) {
+		file.warnings.push({ code: "binary-file", severity: "warning", message: `${file.filePath} is binary and has no reviewable text hunks.`, filePath: file.filePath });
+	}
+}

--- a/src/server/pr-walkthrough/diff-parser.ts
+++ b/src/server/pr-walkthrough/diff-parser.ts
@@ -8,6 +8,7 @@ export interface ParsedWalkthroughDiffFile extends PrWalkthroughDiffBlock {
 	isBinary: boolean;
 	isGenerated: boolean;
 	truncated: boolean;
+	isTruncated?: boolean;
 	warnings: WalkthroughWarning[];
 	additions: number;
 	deletions: number;
@@ -125,6 +126,7 @@ function createFileFromDiffGit(line: string, index: number, generatedPathMatcher
 		isBinary: false,
 		isGenerated: generatedPathMatcher?.(filePath) ?? false,
 		truncated: false,
+		isTruncated: false,
 		warnings: [],
 		additions: 0,
 		deletions: 0,
@@ -188,6 +190,7 @@ function appendDiffLine(file: MutableDiffFile, rawLine: string, maxLinesPerFile:
 	if (maxLinesPerFile !== undefined && file.lineCount >= maxLinesPerFile) {
 		if (!file.truncated) {
 			file.truncated = true;
+			file.isTruncated = true;
 			file.warnings.push({ code: "file-lines-truncated", severity: "warning", message: `${file.filePath} was truncated after ${maxLinesPerFile} diff lines.`, filePath: file.filePath });
 		}
 		advanceCounters(file, rawLine);

--- a/src/server/pr-walkthrough/export-mapper.ts
+++ b/src/server/pr-walkthrough/export-mapper.ts
@@ -1,0 +1,409 @@
+export type GithubReviewEvent = "COMMENT" | "REQUEST_CHANGES" | "APPROVE";
+export type GithubReviewSide = "RIGHT" | "LEFT";
+
+export interface PrWalkthroughChangesetRef {
+	baseSha: string;
+	headSha: string;
+	provider?: string;
+	externalUrl?: string;
+	prUrl?: string;
+	prNumber?: string | number;
+	prTitle?: string;
+	title?: string;
+	owner?: string;
+	repo?: string;
+	repository?: string;
+}
+
+export interface PrWalkthroughDiffLine {
+	id: string;
+	side: "old" | "new" | "context";
+	oldLine?: number;
+	newLine?: number;
+	text: string;
+	kind: "context" | "add" | "del";
+}
+
+export interface PrWalkthroughHunk {
+	id: string;
+	header: string;
+	lines: PrWalkthroughDiffLine[];
+}
+
+export interface PrWalkthroughDiffBlock {
+	id: string;
+	filePath: string;
+	oldPath?: string;
+	hunks: PrWalkthroughHunk[];
+	status?: string;
+}
+
+export interface PrWalkthroughCard {
+	id: string;
+	phaseId: string;
+	title: string;
+	summary: string;
+	diffBlocks: PrWalkthroughDiffBlock[];
+}
+
+export interface PrWalkthroughComment {
+	id: string;
+	cardId: string;
+	diffBlockId?: string;
+	lineId?: string;
+	body: string;
+	source: "custom" | "suggested";
+	createdAt: string;
+	updatedAt?: string;
+}
+
+export interface PrWalkthroughDecision {
+	cardId: string;
+	value: "liked" | "disliked";
+	commentIds: string[];
+	updatedAt: string;
+}
+
+export interface PrWalkthroughReviewDraft {
+	changeset: PrWalkthroughChangesetRef;
+	decisions: Record<string, PrWalkthroughDecision>;
+	comments: PrWalkthroughComment[];
+	completedCardIds: string[];
+	updatedAt: string;
+}
+
+export interface WalkthroughExportWarning {
+	code: string;
+	severity: "info" | "warning" | "error";
+	message: string;
+	commentId?: string;
+}
+
+export interface GithubReviewTarget {
+	provider: "github";
+	owner: string;
+	repo: string;
+	prNumber: number;
+	prUrl?: string;
+	headSha?: string;
+}
+
+export interface GithubReviewPreviewRow {
+	id: string;
+	commentId: string;
+	cardId: string;
+	cardTitle?: string;
+	diffBlockId?: string;
+	lineId?: string;
+	path?: string;
+	side?: GithubReviewSide;
+	line?: number;
+	body: string;
+	valid: boolean;
+	reason?: string;
+}
+
+export interface GithubReviewPreview {
+	provider: "github";
+	target?: GithubReviewTarget;
+	body: string;
+	rows: GithubReviewPreviewRow[];
+	validCommentCount: number;
+	unmappableCommentCount: number;
+	warnings: WalkthroughExportWarning[];
+	generatedAt: string;
+}
+
+export interface SubmitGithubReviewConfirmation {
+	confirm?: boolean;
+	event?: GithubReviewEvent;
+	token?: string;
+}
+
+export interface SubmitGithubReviewOptions {
+	fetch?: FetchLike;
+	apiBaseUrl?: string;
+	token?: string;
+}
+
+export interface GithubReviewSubmitResult {
+	ok: boolean;
+	status: number;
+	submitted: boolean;
+	message: string;
+	reviewUrl?: string;
+	response?: unknown;
+	warnings?: WalkthroughExportWarning[];
+}
+
+interface IndexedLine {
+	card: PrWalkthroughCard;
+	block: PrWalkthroughDiffBlock;
+	line: PrWalkthroughDiffLine;
+}
+
+interface FetchHeadersLike {
+	get(name: string): string | null;
+}
+
+interface FetchResponseLike {
+	ok: boolean;
+	status: number;
+	statusText: string;
+	headers?: FetchHeadersLike;
+	json(): Promise<unknown>;
+	text(): Promise<string>;
+}
+
+type FetchLike = (url: string, init?: {
+	method?: string;
+	headers?: Record<string, string>;
+	body?: string;
+	signal?: AbortSignal;
+}) => Promise<FetchResponseLike>;
+
+export function buildGithubReviewPreview(
+	draft: PrWalkthroughReviewDraft,
+	cards: PrWalkthroughCard[],
+	changeset: PrWalkthroughChangesetRef = draft.changeset,
+): GithubReviewPreview {
+	const target = githubTargetFromChangeset(changeset);
+	const warnings: WalkthroughExportWarning[] = [];
+	if (!target) {
+		warnings.push({ code: "github_target_missing", severity: "error", message: "This walkthrough is not linked to a GitHub pull request." });
+	}
+
+	const lineIndex = indexDiffLines(cards);
+	const cardById = new Map(cards.map(card => [card.id, card]));
+	const cardLevelComments: PrWalkthroughComment[] = [];
+	const rows: GithubReviewPreviewRow[] = [];
+
+	for (const comment of draft.comments) {
+		const trimmedBody = comment.body.trim();
+		if (!comment.diffBlockId && !comment.lineId) {
+			if (trimmedBody) cardLevelComments.push({ ...comment, body: trimmedBody });
+			continue;
+		}
+		const card = cardById.get(comment.cardId);
+		const mapped = mapLineComment(comment, lineIndex, card);
+		rows.push(mapped);
+		if (!mapped.valid) {
+			warnings.push({ code: "github_comment_unmappable", severity: "warning", message: mapped.reason ?? "Comment cannot be mapped to a GitHub review line.", commentId: comment.id });
+		}
+	}
+
+	const validCommentCount = rows.filter(row => row.valid).length;
+	const unmappableCommentCount = rows.length - validCommentCount;
+	if (unmappableCommentCount > 0) {
+		warnings.push({
+			code: "github_unmappable_comments",
+			severity: "warning",
+			message: `${unmappableCommentCount} line comment${unmappableCommentCount === 1 ? "" : "s"} cannot be submitted to GitHub and will stay in the draft body/preview.`,
+		});
+	}
+
+	return {
+		provider: "github",
+		target,
+		body: buildReviewBody(draft, cards, cardLevelComments, rows),
+		rows,
+		validCommentCount,
+		unmappableCommentCount,
+		warnings,
+		generatedAt: new Date().toISOString(),
+	};
+}
+
+export async function submitGithubReview(
+	preview: GithubReviewPreview,
+	confirmation: SubmitGithubReviewConfirmation,
+	options: SubmitGithubReviewOptions = {},
+): Promise<GithubReviewSubmitResult> {
+	if (confirmation.confirm !== true) {
+		return { ok: false, status: 400, submitted: false, message: "Explicit confirm=true is required before submitting a GitHub review." };
+	}
+	if (!preview.target) {
+		return { ok: false, status: 400, submitted: false, message: "No GitHub pull request target is available for this review preview.", warnings: preview.warnings };
+	}
+
+	const token = cleanString(confirmation.token) ?? cleanString(options.token) ?? cleanString(process.env.GITHUB_TOKEN) ?? cleanString(process.env.GH_TOKEN);
+	if (!token) {
+		return { ok: false, status: 401, submitted: false, message: "Set GITHUB_TOKEN or GH_TOKEN before submitting a GitHub review.", warnings: preview.warnings };
+	}
+
+	const payload = createGithubReviewPayload(preview, confirmation.event ?? "COMMENT");
+	const apiBaseUrl = cleanString(options.apiBaseUrl) ?? "https://api.github.com";
+	const url = `${apiBaseUrl}/repos/${encodeURIComponent(preview.target.owner)}/${encodeURIComponent(preview.target.repo)}/pulls/${preview.target.prNumber}/reviews`;
+	const response = await (options.fetch ?? fetch)(url, {
+		method: "POST",
+		headers: {
+			Accept: "application/vnd.github+json",
+			"Content-Type": "application/json",
+			"User-Agent": "bobbit-pr-walkthrough",
+			"X-GitHub-Api-Version": "2022-11-28",
+			Authorization: `Bearer ${token}`,
+		},
+		body: JSON.stringify(payload),
+		signal: AbortSignal.timeout(20_000),
+	});
+
+	if (!response.ok) {
+		const text = await response.text().catch(() => response.statusText);
+		return { ok: false, status: response.status, submitted: false, message: `GitHub review submission failed (${response.status}): ${text || response.statusText}`, warnings: preview.warnings };
+	}
+
+	const json = await response.json().catch(() => ({}));
+	return {
+		ok: true,
+		status: response.status,
+		submitted: true,
+		message: "GitHub review submitted.",
+		reviewUrl: reviewUrlFromResponse(json),
+		response: json,
+		warnings: preview.warnings,
+	};
+}
+
+export function createGithubReviewPayload(preview: GithubReviewPreview, event: GithubReviewEvent = "COMMENT"): Record<string, unknown> {
+	const comments = preview.rows
+		.filter(row => row.valid && row.path && row.side && Number.isInteger(row.line) && (row.line ?? 0) > 0)
+		.map(row => ({ path: row.path, side: row.side, line: row.line, body: row.body }));
+	return {
+		body: preview.body,
+		event,
+		...(preview.target?.headSha ? { commit_id: preview.target.headSha } : {}),
+		comments,
+	};
+}
+
+function mapLineComment(comment: PrWalkthroughComment, lineIndex: Map<string, IndexedLine>, card: PrWalkthroughCard | undefined): GithubReviewPreviewRow {
+	const base = {
+		id: `row:${comment.id}`,
+		commentId: comment.id,
+		cardId: comment.cardId,
+		cardTitle: card?.title,
+		diffBlockId: comment.diffBlockId,
+		lineId: comment.lineId,
+		body: comment.body.trim(),
+	};
+	if (!base.body) return { ...base, valid: false, reason: "Comment body is empty." };
+	if (!comment.diffBlockId || !comment.lineId) return { ...base, valid: false, reason: "Line comments need both a diff block and line anchor." };
+	const indexed = lineIndex.get(lineKey(comment.cardId, comment.diffBlockId, comment.lineId));
+	if (!indexed) return { ...base, valid: false, reason: "Diff line anchor was not found in the current walkthrough cards." };
+	if (isUnreviewableBlock(indexed.block)) return { ...base, path: indexed.block.filePath, valid: false, reason: "This file has no GitHub-reviewable text diff." };
+	const sideAndLine = githubSideAndLine(indexed.line);
+	if (!sideAndLine) return { ...base, path: indexed.block.filePath, valid: false, reason: "Diff line has no old or new line number for GitHub." };
+	return {
+		...base,
+		path: indexed.block.filePath,
+		side: sideAndLine.side,
+		line: sideAndLine.line,
+		valid: true,
+	};
+}
+
+function githubSideAndLine(line: PrWalkthroughDiffLine): { side: GithubReviewSide; line: number } | undefined {
+	if (line.side !== "old" && typeof line.newLine === "number" && line.newLine > 0) return { side: "RIGHT", line: line.newLine };
+	if (typeof line.oldLine === "number" && line.oldLine > 0) return { side: "LEFT", line: line.oldLine };
+	return undefined;
+}
+
+function indexDiffLines(cards: PrWalkthroughCard[]): Map<string, IndexedLine> {
+	const index = new Map<string, IndexedLine>();
+	for (const card of cards) {
+		for (const block of card.diffBlocks) {
+			for (const hunk of block.hunks) {
+				for (const line of hunk.lines) {
+					index.set(lineKey(card.id, block.id, line.id), { card, block, line });
+				}
+			}
+		}
+	}
+	return index;
+}
+
+function lineKey(cardId: string, diffBlockId: string, lineId: string): string {
+	return `${cardId}\u0000${diffBlockId}\u0000${lineId}`;
+}
+
+function buildReviewBody(
+	draft: PrWalkthroughReviewDraft,
+	cards: PrWalkthroughCard[],
+	cardLevelComments: PrWalkthroughComment[],
+	rows: GithubReviewPreviewRow[],
+): string {
+	const cardById = new Map(cards.map(card => [card.id, card]));
+	const liked = Object.values(draft.decisions).filter(decision => decision.value === "liked").length;
+	const disliked = Object.values(draft.decisions).filter(decision => decision.value === "disliked").length;
+	const lines = ["Bobbit PR walkthrough draft", ""];
+	if (draft.changeset.title) lines.push(`Changeset: ${draft.changeset.title}`);
+	if (draft.changeset.externalUrl || draft.changeset.prUrl) lines.push(`Source: ${draft.changeset.externalUrl ?? draft.changeset.prUrl}`);
+	lines.push(`Reviewed cards: ${draft.completedCardIds.length}`);
+	lines.push(`Decisions: ${liked} liked, ${disliked} disliked`);
+	lines.push(`GitHub line comments ready: ${rows.filter(row => row.valid).length}`);
+
+	const unmappableRows = rows.filter(row => !row.valid);
+	if (unmappableRows.length > 0) {
+		lines.push("", "Unmappable line comments:");
+		for (const row of unmappableRows) lines.push(`- ${row.cardTitle ?? row.cardId}: ${row.body}${row.reason ? ` (${row.reason})` : ""}`);
+	}
+
+	if (cardLevelComments.length > 0) {
+		lines.push("", "Card-level comments:");
+		for (const comment of cardLevelComments) {
+			const title = cardById.get(comment.cardId)?.title ?? comment.cardId;
+			lines.push(`- ${title}: ${comment.body}`);
+		}
+	}
+
+	return lines.join("\n").trim();
+}
+
+function githubTargetFromChangeset(changeset: PrWalkthroughChangesetRef): GithubReviewTarget | undefined {
+	const url = cleanString(changeset.prUrl) ?? cleanString(changeset.externalUrl);
+	const fromUrl = url ? parseGithubPullUrl(url) : undefined;
+	const repoParts = splitRepository(cleanString(changeset.repository));
+	const owner = cleanString(changeset.owner) ?? fromUrl?.owner ?? repoParts?.owner;
+	const repo = cleanString(changeset.repo) ?? fromUrl?.repo ?? repoParts?.repo;
+	const prNumber = normalizePrNumber(changeset.prNumber) ?? fromUrl?.number;
+	if (!owner || !repo || !prNumber) return undefined;
+	return { provider: "github", owner, repo, prNumber, prUrl: url, headSha: cleanString(changeset.headSha) };
+}
+
+function parseGithubPullUrl(value: string): { owner: string; repo: string; number: number } | undefined {
+	try {
+		const url = new URL(value);
+		const match = /^\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:\/|$)/i.exec(url.pathname);
+		if (!match) return undefined;
+		return { owner: decodeURIComponent(match[1]), repo: decodeURIComponent(match[2]).replace(/\.git$/i, ""), number: Number(match[3]) };
+	} catch {
+		return undefined;
+	}
+}
+
+function splitRepository(repository: string | undefined): { owner: string; repo: string } | undefined {
+	if (!repository) return undefined;
+	const [owner, repo] = repository.split("/");
+	return owner && repo ? { owner, repo } : undefined;
+}
+
+function normalizePrNumber(value: string | number | undefined): number | undefined {
+	const raw = typeof value === "number" ? String(Math.trunc(value)) : cleanString(value);
+	if (!raw) return undefined;
+	const normalized = raw.replace(/^#/, "").trim();
+	return /^\d+$/.test(normalized) ? Number(normalized) : undefined;
+}
+
+function isUnreviewableBlock(block: PrWalkthroughDiffBlock): boolean {
+	return /^(binary|truncated)$/i.test(block.status ?? "") || block.hunks.length === 0;
+}
+
+function reviewUrlFromResponse(value: unknown): string | undefined {
+	if (!value || typeof value !== "object") return undefined;
+	const htmlUrl = (value as { html_url?: unknown }).html_url;
+	return typeof htmlUrl === "string" ? htmlUrl : undefined;
+}
+
+function cleanString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}

--- a/src/server/pr-walkthrough/export-mapper.ts
+++ b/src/server/pr-walkthrough/export-mapper.ts
@@ -36,6 +36,8 @@ export interface PrWalkthroughDiffBlock {
 	oldPath?: string;
 	hunks: PrWalkthroughHunk[];
 	status?: string;
+	isBinary?: boolean;
+	isTruncated?: boolean;
 }
 
 export interface PrWalkthroughCard {
@@ -395,7 +397,7 @@ function normalizePrNumber(value: string | number | undefined): number | undefin
 }
 
 function isUnreviewableBlock(block: PrWalkthroughDiffBlock): boolean {
-	return /^(binary|truncated)$/i.test(block.status ?? "") || block.hunks.length === 0;
+	return block.isBinary === true || block.isTruncated === true || /^(binary|truncated)$/i.test(block.status ?? "") || block.hunks.length === 0;
 }
 
 function reviewUrlFromResponse(value: unknown): string | undefined {

--- a/src/server/pr-walkthrough/export-mapper.ts
+++ b/src/server/pr-walkthrough/export-mapper.ts
@@ -232,7 +232,7 @@ export async function submitGithubReview(
 	}
 
 	const payload = createGithubReviewPayload(preview, confirmation.event ?? "COMMENT");
-	const apiBaseUrl = cleanString(options.apiBaseUrl) ?? "https://api.github.com";
+	const apiBaseUrl = cleanString(options.apiBaseUrl) ?? cleanString(process.env.BOBBIT_GITHUB_API_BASE_URL) ?? "https://api.github.com";
 	const url = `${apiBaseUrl}/repos/${encodeURIComponent(preview.target.owner)}/${encodeURIComponent(preview.target.repo)}/pulls/${preview.target.prNumber}/reviews`;
 	const response = await (options.fetch ?? fetch)(url, {
 		method: "POST",

--- a/src/server/pr-walkthrough/git-changeset.ts
+++ b/src/server/pr-walkthrough/git-changeset.ts
@@ -1,3 +1,5 @@
+import { spawn } from "node:child_process";
+
 import { execFileSafe } from "../exec-file-safe.js";
 import type { PrWalkthroughChangesetRef, WalkthroughLimits, WalkthroughWarning } from "../../shared/pr-walkthrough/types.js";
 import { changesetIdForLocal } from "../../shared/pr-walkthrough/ids.js";
@@ -39,17 +41,17 @@ export async function resolveLocalChangeset(request: ResolveLocalChangesetReques
 		verifyCommit(request.cwd, request.headSha, "headSha"),
 	]);
 
-	const [shortstatRaw, nameStatusRaw, diffRaw] = await Promise.all([
+	const [shortstatRaw, nameStatusRaw, diffCapture] = await Promise.all([
 		runGit(request.cwd, ["diff", "--shortstat", `${baseSha}..${headSha}`]),
 		runGit(request.cwd, ["diff", "--name-status", "-M", "-C", `${baseSha}..${headSha}`]),
-		runGit(request.cwd, ["diff", "--no-ext-diff", "--find-renames", "--find-copies", "--binary", "--unified=80", `${baseSha}..${headSha}`], Math.max(limits.maxDiffBytes * 2, 1_000_000)),
+		runGitLimited(request.cwd, ["diff", "--no-ext-diff", "--find-renames", "--find-copies", "--binary", "--unified=80", `${baseSha}..${headSha}`], limits.maxDiffBytes + 64_000),
 	]);
 
 	const warnings: WalkthroughWarning[] = [];
 	const nameStatus = parseNameStatus(nameStatusRaw);
-	let diffForParsing = diffRaw;
-	if (Buffer.byteLength(diffRaw, "utf8") > limits.maxDiffBytes) {
-		diffForParsing = truncateUtf8(diffRaw, limits.maxDiffBytes);
+	let diffForParsing = diffCapture.stdout;
+	if (diffCapture.truncated || Buffer.byteLength(diffCapture.stdout, "utf8") > limits.maxDiffBytes) {
+		diffForParsing = truncateUtf8(diffCapture.stdout, limits.maxDiffBytes);
 		warnings.push({ code: "diff-truncated", severity: "warning", message: `Diff output exceeded ${limits.maxDiffBytes} bytes and was truncated.` });
 	}
 
@@ -137,6 +139,50 @@ async function runGit(cwd: string, args: readonly string[], maxBuffer = 10_000_0
 		maxBuffer,
 	});
 	return result.stdout;
+}
+
+async function runGitLimited(cwd: string, args: readonly string[], maxBytes: number): Promise<{ stdout: string; truncated: boolean }> {
+	return new Promise((resolve, reject) => {
+		const child = spawn("git", args, { cwd, windowsHide: true, stdio: ["ignore", "pipe", "pipe"] });
+		const chunks: Buffer[] = [];
+		const stderr: Buffer[] = [];
+		let capturedBytes = 0;
+		let truncated = false;
+		let settled = false;
+		const timer = setTimeout(() => {
+			truncated = true;
+			child.kill();
+		}, GIT_TIMEOUT_MS);
+		child.stdout.on("data", (chunk: Buffer) => {
+			if (capturedBytes < maxBytes) {
+				const remaining = maxBytes - capturedBytes;
+				chunks.push(chunk.length > remaining ? chunk.subarray(0, remaining) : chunk);
+				capturedBytes += Math.min(chunk.length, remaining);
+			}
+			if (chunk.length > 0 && capturedBytes >= maxBytes) {
+				truncated = true;
+				child.kill();
+			}
+		});
+		child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+		child.on("error", error => {
+			clearTimeout(timer);
+			if (!settled) {
+				settled = true;
+				reject(error);
+			}
+		});
+		child.on("close", code => {
+			clearTimeout(timer);
+			if (settled) return;
+			settled = true;
+			if (code && !truncated) {
+				reject(new Error(Buffer.concat(stderr).toString("utf8") || `git ${args.join(" ")} exited with ${code}`));
+				return;
+			}
+			resolve({ stdout: Buffer.concat(chunks).toString("utf8"), truncated });
+		});
+	});
 }
 
 function mergeNameStatus(files: ParsedWalkthroughDiffFile[], records: NameStatusRecord[]): ParsedWalkthroughDiffFile[] {

--- a/src/server/pr-walkthrough/git-changeset.ts
+++ b/src/server/pr-walkthrough/git-changeset.ts
@@ -1,0 +1,178 @@
+import { execFileSafe } from "../exec-file-safe.js";
+import type { PrWalkthroughChangesetRef, WalkthroughLimits, WalkthroughWarning } from "../../shared/pr-walkthrough/types.js";
+import { changesetIdForLocal } from "../../shared/pr-walkthrough/ids.js";
+import { parseUnifiedDiff, type ParsedWalkthroughDiffFile } from "./diff-parser.js";
+
+export interface ResolveLocalChangesetRequest {
+	cwd: string;
+	baseSha: string;
+	headSha: string;
+	limits?: Partial<WalkthroughLimits>;
+}
+
+export interface LocalChangesetResolveResult {
+	changesetId: string;
+	changeset: PrWalkthroughChangesetRef;
+	files: ParsedWalkthroughDiffFile[];
+	warnings: WalkthroughWarning[];
+	limits: WalkthroughLimits;
+}
+
+export interface NameStatusRecord {
+	status: string;
+	filePath: string;
+	oldPath?: string;
+}
+
+const DEFAULT_LIMITS: WalkthroughLimits = {
+	maxFiles: 200,
+	maxDiffBytes: 3_000_000,
+	maxLinesPerFile: 2_000,
+};
+
+const GIT_TIMEOUT_MS = 30_000;
+
+export async function resolveLocalChangeset(request: ResolveLocalChangesetRequest): Promise<LocalChangesetResolveResult> {
+	const limits = { ...DEFAULT_LIMITS, ...request.limits };
+	const [baseSha, headSha] = await Promise.all([
+		verifyCommit(request.cwd, request.baseSha, "baseSha"),
+		verifyCommit(request.cwd, request.headSha, "headSha"),
+	]);
+
+	const [shortstatRaw, nameStatusRaw, diffRaw] = await Promise.all([
+		runGit(request.cwd, ["diff", "--shortstat", `${baseSha}..${headSha}`]),
+		runGit(request.cwd, ["diff", "--name-status", "-M", "-C", `${baseSha}..${headSha}`]),
+		runGit(request.cwd, ["diff", "--no-ext-diff", "--find-renames", "--find-copies", "--binary", "--unified=80", `${baseSha}..${headSha}`], Math.max(limits.maxDiffBytes * 2, 1_000_000)),
+	]);
+
+	const warnings: WalkthroughWarning[] = [];
+	const nameStatus = parseNameStatus(nameStatusRaw);
+	let diffForParsing = diffRaw;
+	if (Buffer.byteLength(diffRaw, "utf8") > limits.maxDiffBytes) {
+		diffForParsing = truncateUtf8(diffRaw, limits.maxDiffBytes);
+		warnings.push({ code: "diff-truncated", severity: "warning", message: `Diff output exceeded ${limits.maxDiffBytes} bytes and was truncated.` });
+	}
+
+	const parsed = parseUnifiedDiff(diffForParsing, {
+		maxFiles: limits.maxFiles,
+		maxLinesPerFile: limits.maxLinesPerFile,
+		generatedPathMatcher: isLikelyGeneratedPath,
+	});
+	const files = mergeNameStatus(parsed.files, nameStatus);
+	const omittedFiles = nameStatus.slice(files.length).map(record => record.filePath);
+	const truncatedFiles = files.filter(file => file.truncated).map(file => file.filePath);
+	if (omittedFiles.length > 0) {
+		warnings.push({ code: "files-omitted", severity: "warning", message: `${omittedFiles.length} changed file(s) were omitted because the file limit was reached.` });
+	}
+
+	const stats = parseShortstat(shortstatRaw);
+	const changeset: PrWalkthroughChangesetRef = {
+		baseSha,
+		headSha,
+		provider: "local",
+		title: `Local changes ${baseSha.slice(0, 8)}..${headSha.slice(0, 8)}`,
+		filesChanged: stats.filesChanged || nameStatus.length || files.length,
+		additions: stats.additions,
+		deletions: stats.deletions,
+	};
+
+	const finalLimits: WalkthroughLimits = { ...limits, truncatedFiles, omittedFiles };
+	return {
+		changesetId: changesetIdForLocal(baseSha, headSha),
+		changeset,
+		files,
+		warnings: dedupeWarnings([...warnings, ...parsed.warnings, ...generatedWarnings(files)]),
+		limits: finalLimits,
+	};
+}
+
+export function parseShortstat(raw: string): { filesChanged: number; additions: number; deletions: number } {
+	return {
+		filesChanged: numberFrom(/(\d+)\s+files? changed/.exec(raw)),
+		additions: numberFrom(/(\d+)\s+insertions?\(\+\)/.exec(raw)),
+		deletions: numberFrom(/(\d+)\s+deletions?\(-\)/.exec(raw)),
+	};
+}
+
+export function parseNameStatus(raw: string): NameStatusRecord[] {
+	return raw.split(/\r?\n/).filter(Boolean).map(line => {
+		const parts = line.split("\t");
+		const status = parts[0] ?? "";
+		if (status.startsWith("R") || status.startsWith("C")) {
+			return { status, oldPath: parts[1], filePath: parts[2] ?? parts[1] ?? "unknown" };
+		}
+		return { status, filePath: parts[1] ?? "unknown" };
+	});
+}
+
+export function isLikelyGeneratedPath(filePath: string): boolean {
+	const normalized = filePath.replace(/\\/g, "/").toLowerCase();
+	return normalized.startsWith("dist/")
+		|| normalized.includes("/dist/")
+		|| normalized.includes("/generated/")
+		|| normalized.includes("__snapshots__/")
+		|| normalized.endsWith(".snap")
+		|| normalized.endsWith("package-lock.json")
+		|| normalized.endsWith("pnpm-lock.yaml")
+		|| normalized.endsWith("yarn.lock")
+		|| normalized.endsWith("bun.lockb")
+		|| normalized.endsWith(".min.js")
+		|| normalized.endsWith(".min.css");
+}
+
+async function verifyCommit(cwd: string, ref: string, label: string): Promise<string> {
+	try {
+		return (await runGit(cwd, ["rev-parse", "--verify", `${ref}^{commit}`])).trim();
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(`Invalid ${label} ref "${ref}": ${message}`);
+	}
+}
+
+async function runGit(cwd: string, args: readonly string[], maxBuffer = 10_000_000): Promise<string> {
+	const result = await execFileSafe("git", args, {
+		cwd,
+		encoding: "utf8",
+		timeout: GIT_TIMEOUT_MS,
+		maxBuffer,
+	});
+	return result.stdout;
+}
+
+function mergeNameStatus(files: ParsedWalkthroughDiffFile[], records: NameStatusRecord[]): ParsedWalkthroughDiffFile[] {
+	const byPath = new Map(records.map(record => [record.filePath, record]));
+	for (const file of files) {
+		const record = byPath.get(file.filePath);
+		if (!record) continue;
+		file.oldPath = record.oldPath ?? file.oldPath;
+		if (record.status.startsWith("A")) file.status = file.isBinary ? "binary" : "added";
+		else if (record.status.startsWith("D")) file.status = file.isBinary ? "binary" : "deleted";
+		else if (record.status.startsWith("R")) file.status = file.isBinary ? "binary" : "renamed";
+		else if (record.status.startsWith("C")) file.status = file.isBinary ? "binary" : "copied";
+	}
+	return files;
+}
+
+function generatedWarnings(files: ParsedWalkthroughDiffFile[]): WalkthroughWarning[] {
+	return files
+		.filter(file => file.isGenerated)
+		.map(file => ({ code: "generated-file", severity: "info" as const, message: `${file.filePath} looks generated and may be low-signal for review.`, filePath: file.filePath }));
+}
+
+function dedupeWarnings(warnings: WalkthroughWarning[]): WalkthroughWarning[] {
+	const seen = new Set<string>();
+	return warnings.filter(warning => {
+		const key = `${warning.code}:${warning.filePath ?? ""}:${warning.message}`;
+		if (seen.has(key)) return false;
+		seen.add(key);
+		return true;
+	});
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+	return Buffer.from(value, "utf8").subarray(0, maxBytes).toString("utf8");
+}
+
+function numberFrom(match: RegExpExecArray | null): number {
+	return match ? Number(match[1]) : 0;
+}

--- a/src/server/pr-walkthrough/git-changeset.ts
+++ b/src/server/pr-walkthrough/git-changeset.ts
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import { execFileSafe } from "../exec-file-safe.js";
 import type { PrWalkthroughChangesetRef, WalkthroughLimits, WalkthroughWarning } from "../../shared/pr-walkthrough/types.js";
 import { changesetIdForLocal } from "../../shared/pr-walkthrough/ids.js";
+import { isLikelyGeneratedPath } from "../../shared/pr-walkthrough/generated-path.js";
 import { parseUnifiedDiff, type ParsedWalkthroughDiffFile } from "./diff-parser.js";
 
 export interface ResolveLocalChangesetRequest {
@@ -107,20 +108,7 @@ export function parseNameStatus(raw: string): NameStatusRecord[] {
 	});
 }
 
-export function isLikelyGeneratedPath(filePath: string): boolean {
-	const normalized = filePath.replace(/\\/g, "/").toLowerCase();
-	return normalized.startsWith("dist/")
-		|| normalized.includes("/dist/")
-		|| normalized.includes("/generated/")
-		|| normalized.includes("__snapshots__/")
-		|| normalized.endsWith(".snap")
-		|| normalized.endsWith("package-lock.json")
-		|| normalized.endsWith("pnpm-lock.yaml")
-		|| normalized.endsWith("yarn.lock")
-		|| normalized.endsWith("bun.lockb")
-		|| normalized.endsWith(".min.js")
-		|| normalized.endsWith(".min.css");
-}
+export { isLikelyGeneratedPath } from "../../shared/pr-walkthrough/generated-path.js";
 
 async function verifyCommit(cwd: string, ref: string, label: string): Promise<string> {
 	try {

--- a/src/server/pr-walkthrough/github-adapter.ts
+++ b/src/server/pr-walkthrough/github-adapter.ts
@@ -1,3 +1,4 @@
+import { isLikelyGeneratedPath } from "../../shared/pr-walkthrough/generated-path.js";
 import { safeExternalUrl, trustedHostsFromEnv } from "../../shared/pr-walkthrough/url-safety.js";
 import { execFileSafe } from "../exec-file-safe.js";
 
@@ -19,10 +20,16 @@ export interface GithubDiffHunk {
 	lines: GithubDiffLine[];
 }
 
+export type GithubWalkthroughFileStatus = "added" | "modified" | "deleted" | "renamed" | "copied" | "binary";
+
 export interface GithubDiffBlock {
 	id: string;
 	filePath: string;
 	oldPath?: string;
+	status?: GithubWalkthroughFileStatus;
+	isBinary?: boolean;
+	isGenerated?: boolean;
+	isTruncated?: boolean;
 	hunks: GithubDiffHunk[];
 	externalUrl?: string;
 	blobUrl?: string;
@@ -49,7 +56,7 @@ export interface GithubWalkthroughChangesetRef {
 export interface GithubWalkthroughFile {
 	filePath: string;
 	oldPath?: string;
-	status: "added" | "modified" | "deleted" | "renamed" | "copied" | "binary";
+	status: GithubWalkthroughFileStatus;
 	additions: number;
 	deletions: number;
 	changes: number;
@@ -57,6 +64,10 @@ export interface GithubWalkthroughFile {
 	blobUrl?: string;
 	rawUrl?: string;
 	contentsUrl?: string;
+	isBinary?: boolean;
+	isGenerated?: boolean;
+	isTruncated?: boolean;
+	warnings?: GithubWalkthroughWarning[];
 	diffBlocks: GithubDiffBlock[];
 }
 
@@ -103,6 +114,8 @@ export interface ResolveGithubPrOptions {
 	fetch?: FetchLike;
 	apiBaseUrl?: string;
 	maxFiles?: number;
+	maxPatchBytes?: number;
+	maxLinesPerFile?: number;
 }
 
 export interface ParsedGithubPrReference {
@@ -156,6 +169,9 @@ type FetchLike = (url: string, init?: {
 	body?: string;
 	signal?: AbortSignal;
 }) => Promise<FetchResponseLike>;
+
+const DEFAULT_MAX_PATCH_BYTES = 1_000_000;
+const DEFAULT_MAX_LINES_PER_FILE = 2_000;
 
 export class GithubPrAdapterError extends Error {
 	readonly status: number;
@@ -255,7 +271,15 @@ export async function resolveGithubPr(options: ResolveGithubPrOptions): Promise<
 	const prApiUrl = `${apiBaseUrl}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${number}`;
 	const pr = await fetchGithubJson<GithubApiPullRequest>(fetchImpl, prApiUrl, headers, warnings);
 	const files = await fetchGithubFiles(fetchImpl, prApiUrl, headers, options.maxFiles ?? 300, warnings);
-	const resolvedFiles = await enrichFilesWithDiffs({ cwd: options.cwd, baseSha: pr.base.sha, headSha: pr.head.sha, files, warnings });
+	const resolvedFiles = await enrichFilesWithDiffs({
+		cwd: options.cwd,
+		baseSha: pr.base.sha,
+		headSha: pr.head.sha,
+		files,
+		warnings,
+		maxPatchBytes: options.maxPatchBytes ?? DEFAULT_MAX_PATCH_BYTES,
+		maxLinesPerFile: options.maxLinesPerFile ?? DEFAULT_MAX_LINES_PER_FILE,
+	});
 	const prUrl = safeGithubUrl(pr.html_url) ?? parsed.url ?? safeGithubUrl(`https://${host}/${owner}/${repo}/pull/${number}`) ?? `https://github.com/${owner}/${repo}/pull/${number}`;
 	const changesetId = changesetIdForGithub(owner, repo, number, pr.head.sha);
 	const exportAvailable = Boolean(token);
@@ -362,32 +386,44 @@ async function enrichFilesWithDiffs(input: {
 	headSha: string;
 	files: GithubApiChangedFile[];
 	warnings: GithubWalkthroughWarning[];
+	maxPatchBytes: number;
+	maxLinesPerFile: number;
 }): Promise<GithubWalkthroughFile[]> {
 	const localDiffAvailable = await hasLocalCommit(input.cwd, input.baseSha) && await hasLocalCommit(input.cwd, input.headSha);
 	const enriched: GithubWalkthroughFile[] = [];
 	for (const file of input.files) {
-		const patch = localDiffAvailable
+		const rawPatch = localDiffAvailable
 			? await readLocalPatchForFile(input.cwd, input.baseSha, input.headSha, file).catch(() => cleanString(file.patch))
 			: cleanString(file.patch);
-		const status = normalizeGithubFileStatus(file.status, patch);
+		const normalized = normalizeGithubPatch(rawPatch, input.maxPatchBytes);
+		const patch = normalized.patch;
+		const status = normalizeGithubFileStatus(file.status);
+		const isGenerated = isLikelyGeneratedPath(file.filename) || Boolean(file.previous_filename && isLikelyGeneratedPath(file.previous_filename));
 		const block = parsePatchToDiffBlock({
 			filePath: file.filename,
 			oldPath: file.previous_filename,
 			patch,
 			status,
+			isGenerated,
+			maxLinesPerFile: input.maxLinesPerFile,
 			externalUrl: safeGithubUrl(file.blob_url),
 			blobUrl: safeGithubUrl(file.blob_url),
 			rawUrl: safeGithubUrl(file.raw_url),
 			contentsUrl: safeGithubUrl(file.contents_url),
 		});
-		if (!patch) {
-			input.warnings.push({
-				code: status === "binary" ? "github_binary_file" : "github_file_without_patch",
-				severity: status === "binary" ? "warning" : "info",
-				message: status === "binary" ? "Binary file has no reviewable text diff." : "GitHub did not provide a text patch for this file.",
-				filePath: file.filename,
-			});
-		}
+		const likelyTruncated = isPatchLikelyTruncated(file, block, patch);
+		if (normalized.truncated || likelyTruncated || block.truncated) block.isTruncated = true;
+		const fileWarnings = githubFileWarnings(file, {
+			status,
+			isGenerated,
+			patch,
+			block,
+			patchByteTruncated: normalized.truncated,
+			patchLikelyTruncated: likelyTruncated,
+			maxPatchBytes: input.maxPatchBytes,
+			maxLinesPerFile: input.maxLinesPerFile,
+		});
+		input.warnings.push(...fileWarnings);
 		enriched.push({
 			filePath: file.filename,
 			oldPath: file.previous_filename,
@@ -399,6 +435,10 @@ async function enrichFilesWithDiffs(input: {
 			blobUrl: safeGithubUrl(file.blob_url),
 			rawUrl: safeGithubUrl(file.raw_url),
 			contentsUrl: safeGithubUrl(file.contents_url),
+			isBinary: status === "binary",
+			isGenerated,
+			isTruncated: block.isTruncated === true,
+			warnings: fileWarnings,
 			diffBlocks: block.hunks.length > 0 ? [block] : [],
 		});
 	}
@@ -427,13 +467,15 @@ async function readLocalPatchForFile(cwd: string | undefined, baseSha: string, h
 	return extractPatchBody(stdout) || undefined;
 }
 
-function parsePatchToDiffBlock(input: { filePath: string; oldPath?: string; patch?: string; status: GithubWalkthroughFile["status"]; externalUrl?: string; blobUrl?: string; rawUrl?: string; contentsUrl?: string }): GithubDiffBlock {
+function parsePatchToDiffBlock(input: { filePath: string; oldPath?: string; patch?: string; status: GithubWalkthroughFile["status"]; isGenerated?: boolean; maxLinesPerFile?: number; externalUrl?: string; blobUrl?: string; rawUrl?: string; contentsUrl?: string }): GithubDiffBlock & { truncated?: boolean } {
 	const blockId = stableBlockId(input.filePath, input.oldPath);
 	const hunks: GithubDiffHunk[] = [];
 	const lines = (input.patch ?? "").split(/\r?\n/);
 	let current: GithubDiffHunk | undefined;
 	let oldLine = 0;
 	let newLine = 0;
+	let diffLineCount = 0;
+	let truncated = false;
 	for (const rawLine of lines) {
 		const hunkMatch = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@.*$/.exec(rawLine);
 		if (hunkMatch) {
@@ -446,6 +488,19 @@ function parsePatchToDiffBlock(input: { filePath: string; oldPath?: string; patc
 		if (!current || rawLine === "" || rawLine.startsWith("\\ No newline")) continue;
 		const prefix = rawLine[0];
 		const text = rawLine.slice(1);
+		if (prefix === "+" || prefix === "-" || prefix === " ") {
+			if (input.maxLinesPerFile !== undefined && diffLineCount >= input.maxLinesPerFile) {
+				truncated = true;
+				if (prefix === "+") newLine += 1;
+				else if (prefix === "-") oldLine += 1;
+				else {
+					oldLine += 1;
+					newLine += 1;
+				}
+				continue;
+			}
+			diffLineCount += 1;
+		}
 		const lineIndex = current.lines.length;
 		if (prefix === "+") {
 			current.lines.push({ id: `${current.id}:l${lineIndex}`, side: "new", newLine, kind: "add", text });
@@ -463,12 +518,85 @@ function parsePatchToDiffBlock(input: { filePath: string; oldPath?: string; patc
 		id: blockId,
 		filePath: input.filePath,
 		oldPath: input.oldPath,
+		status: input.status,
+		isBinary: input.status === "binary",
+		isGenerated: input.isGenerated,
+		isTruncated: truncated,
 		hunks,
 		externalUrl: input.externalUrl,
 		blobUrl: input.blobUrl,
 		rawUrl: input.rawUrl,
 		contentsUrl: input.contentsUrl,
+		...(truncated ? { truncated } : {}),
 	};
+}
+
+function normalizeGithubPatch(patch: string | undefined, maxPatchBytes: number): { patch?: string; truncated: boolean } {
+	if (!patch) return { patch, truncated: false };
+	const bytes = Buffer.byteLength(patch, "utf8");
+	if (bytes <= maxPatchBytes) return { patch, truncated: false };
+	return {
+		patch: Buffer.from(patch, "utf8").subarray(0, maxPatchBytes).toString("utf8"),
+		truncated: true,
+	};
+}
+
+function githubFileWarnings(file: GithubApiChangedFile, input: {
+	status: GithubWalkthroughFileStatus;
+	isGenerated: boolean;
+	patch?: string;
+	block: GithubDiffBlock & { truncated?: boolean };
+	patchByteTruncated: boolean;
+	patchLikelyTruncated: boolean;
+	maxPatchBytes: number;
+	maxLinesPerFile: number;
+}): GithubWalkthroughWarning[] {
+	const warnings: GithubWalkthroughWarning[] = [];
+	if (input.isGenerated) {
+		warnings.push({ code: "github_generated_file", severity: "info", message: `${file.filename} looks generated and may be low-signal for review.`, filePath: file.filename });
+	}
+	if (!input.patch) {
+		warnings.push({
+			code: input.status === "binary" ? "github_binary_file" : "github_patch_unavailable",
+			severity: input.status === "binary" ? "warning" : "warning",
+			message: input.status === "binary" ? "Binary file has no reviewable text diff." : "GitHub did not provide a text patch for this file; it may be too large or truncated.",
+			filePath: file.filename,
+		});
+	}
+	if (input.patchByteTruncated) {
+		warnings.push({ code: "github_patch_truncated", severity: "warning", message: `${file.filename} patch exceeded ${input.maxPatchBytes} bytes and was truncated.`, filePath: file.filename });
+	}
+	if (input.block.truncated) {
+		warnings.push({ code: "github_file_lines_truncated", severity: "warning", message: `${file.filename} was truncated after ${input.maxLinesPerFile} diff lines.`, filePath: file.filename });
+	}
+	if (!input.patchByteTruncated && !input.block.truncated && input.patchLikelyTruncated) {
+		warnings.push({ code: "github_patch_truncated", severity: "warning", message: `${file.filename} patch appears truncated compared with GitHub changed-line counts.`, filePath: file.filename });
+	}
+	return dedupeGithubWarnings(warnings);
+}
+
+function isPatchLikelyTruncated(file: GithubApiChangedFile, block: GithubDiffBlock, patch?: string): boolean {
+	if (!patch) return (file.changes ?? ((file.additions ?? 0) + (file.deletions ?? 0))) > 0;
+	const expectedAdditions = file.additions ?? 0;
+	const expectedDeletions = file.deletions ?? 0;
+	if (expectedAdditions === 0 && expectedDeletions === 0) return false;
+	let additions = 0;
+	let deletions = 0;
+	for (const line of block.hunks.flatMap(hunk => hunk.lines)) {
+		if (line.kind === "add") additions += 1;
+		else if (line.kind === "del") deletions += 1;
+	}
+	return additions < expectedAdditions || deletions < expectedDeletions;
+}
+
+function dedupeGithubWarnings(warnings: GithubWalkthroughWarning[]): GithubWalkthroughWarning[] {
+	const seen = new Set<string>();
+	return warnings.filter(warning => {
+		const key = `${warning.code}:${warning.filePath ?? ""}:${warning.message}`;
+		if (seen.has(key)) return false;
+		seen.add(key);
+		return true;
+	});
 }
 
 function extractPatchBody(diff: string): string {
@@ -477,17 +605,18 @@ function extractPatchBody(diff: string): string {
 	return firstHunk >= 0 ? lines.slice(firstHunk).join("\n") : "";
 }
 
-function normalizeGithubFileStatus(status: string, patch?: string): GithubWalkthroughFile["status"] {
-	if (!patch && /binary/i.test(status)) return "binary";
+function normalizeGithubFileStatus(status: string): GithubWalkthroughFile["status"] {
+	if (/binary/i.test(status)) return "binary";
 	switch (status) {
 		case "added": return "added";
-		case "removed": return "deleted";
+		case "removed":
+		case "deleted": return "deleted";
 		case "renamed": return "renamed";
 		case "copied": return "copied";
 		case "modified":
 		case "changed":
 		default:
-			return patch ? "modified" : "binary";
+			return "modified";
 	}
 }
 

--- a/src/server/pr-walkthrough/github-adapter.ts
+++ b/src/server/pr-walkthrough/github-adapter.ts
@@ -1,3 +1,4 @@
+import { safeExternalUrl, trustedHostsFromEnv } from "../../shared/pr-walkthrough/url-safety.js";
 import { execFileSafe } from "../exec-file-safe.js";
 
 export type GithubDiffLineSide = "old" | "new" | "context";
@@ -197,7 +198,7 @@ export function parseGithubPrReference(input: { prUrl?: string; prNumber?: strin
 		repo: stripGitSuffix(decodeURIComponent(match[2])),
 		number: Number(match[3]),
 		host,
-		url: prUrl,
+		url: safeGithubUrl(prUrl),
 	};
 }
 
@@ -255,7 +256,7 @@ export async function resolveGithubPr(options: ResolveGithubPrOptions): Promise<
 	const pr = await fetchGithubJson<GithubApiPullRequest>(fetchImpl, prApiUrl, headers, warnings);
 	const files = await fetchGithubFiles(fetchImpl, prApiUrl, headers, options.maxFiles ?? 300, warnings);
 	const resolvedFiles = await enrichFilesWithDiffs({ cwd: options.cwd, baseSha: pr.base.sha, headSha: pr.head.sha, files, warnings });
-	const prUrl = pr.html_url || parsed.url || `https://${host}/${owner}/${repo}/pull/${number}`;
+	const prUrl = safeGithubUrl(pr.html_url) ?? parsed.url ?? safeGithubUrl(`https://${host}/${owner}/${repo}/pull/${number}`) ?? `https://github.com/${owner}/${repo}/pull/${number}`;
 	const changesetId = changesetIdForGithub(owner, repo, number, pr.head.sha);
 	const exportAvailable = Boolean(token);
 
@@ -318,13 +319,18 @@ async function fetchGithubFiles(
 	warnings: GithubWalkthroughWarning[],
 ): Promise<GithubApiChangedFile[]> {
 	const result: GithubApiChangedFile[] = [];
-	for (let page = 1; result.length < maxFiles; page++) {
+	let maybeMorePages = false;
+	for (let page = 1; result.length <= maxFiles; page++) {
 		const pageUrl = `${prApiUrl}/files?per_page=100&page=${page}`;
 		const batch = await fetchGithubJson<GithubApiChangedFile[]>(fetchImpl, pageUrl, headers, warnings);
 		result.push(...batch);
 		if (batch.length < 100) break;
+		if (result.length >= maxFiles) {
+			maybeMorePages = true;
+			break;
+		}
 	}
-	if (result.length > maxFiles) {
+	if (result.length > maxFiles || maybeMorePages) {
 		warnings.push({ code: "github_files_truncated", severity: "warning", message: `GitHub changed files were truncated at ${maxFiles} files.` });
 	}
 	return result.slice(0, maxFiles);
@@ -369,10 +375,10 @@ async function enrichFilesWithDiffs(input: {
 			oldPath: file.previous_filename,
 			patch,
 			status,
-			externalUrl: file.blob_url,
-			blobUrl: file.blob_url,
-			rawUrl: file.raw_url,
-			contentsUrl: file.contents_url,
+			externalUrl: safeGithubUrl(file.blob_url),
+			blobUrl: safeGithubUrl(file.blob_url),
+			rawUrl: safeGithubUrl(file.raw_url),
+			contentsUrl: safeGithubUrl(file.contents_url),
 		});
 		if (!patch) {
 			input.warnings.push({
@@ -390,9 +396,9 @@ async function enrichFilesWithDiffs(input: {
 			deletions: file.deletions ?? 0,
 			changes: file.changes ?? ((file.additions ?? 0) + (file.deletions ?? 0)),
 			patch,
-			blobUrl: file.blob_url,
-			rawUrl: file.raw_url,
-			contentsUrl: file.contents_url,
+			blobUrl: safeGithubUrl(file.blob_url),
+			rawUrl: safeGithubUrl(file.raw_url),
+			contentsUrl: safeGithubUrl(file.contents_url),
 			diffBlocks: block.hunks.length > 0 ? [block] : [],
 		});
 	}
@@ -549,6 +555,10 @@ function normalizePrNumber(value: string | number | undefined): number | undefin
 
 function cleanString(value: unknown): string | undefined {
 	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function safeGithubUrl(value: unknown): string | undefined {
+	return safeExternalUrl(value, trustedHostsFromEnv(process.env.BOBBIT_GITHUB_TRUSTED_HOSTS));
 }
 
 function stripGitSuffix(repo: string): string {

--- a/src/server/pr-walkthrough/github-adapter.ts
+++ b/src/server/pr-walkthrough/github-adapter.ts
@@ -1,0 +1,509 @@
+import { execFileSafe } from "../exec-file-safe.js";
+
+export type GithubDiffLineSide = "old" | "new" | "context";
+export type GithubDiffLineKind = "context" | "add" | "del";
+
+export interface GithubDiffLine {
+	id: string;
+	side: GithubDiffLineSide;
+	oldLine?: number;
+	newLine?: number;
+	text: string;
+	kind: GithubDiffLineKind;
+}
+
+export interface GithubDiffHunk {
+	id: string;
+	header: string;
+	lines: GithubDiffLine[];
+}
+
+export interface GithubDiffBlock {
+	id: string;
+	filePath: string;
+	oldPath?: string;
+	hunks: GithubDiffHunk[];
+}
+
+export interface GithubWalkthroughChangesetRef {
+	baseSha: string;
+	headSha: string;
+	provider: "github";
+	externalUrl: string;
+	prUrl: string;
+	prNumber: number;
+	prTitle: string;
+	title: string;
+	filesChanged?: number;
+	additions?: number;
+	deletions?: number;
+	owner: string;
+	repo: string;
+}
+
+export interface GithubWalkthroughFile {
+	filePath: string;
+	oldPath?: string;
+	status: "added" | "modified" | "deleted" | "renamed" | "copied" | "binary";
+	additions: number;
+	deletions: number;
+	changes: number;
+	patch?: string;
+	blobUrl?: string;
+	rawUrl?: string;
+	contentsUrl?: string;
+	diffBlocks: GithubDiffBlock[];
+}
+
+export interface GithubWalkthroughWarning {
+	code: string;
+	severity: "info" | "warning" | "error";
+	message: string;
+	filePath?: string;
+}
+
+export interface GithubWalkthroughExportCapability {
+	provider: "github";
+	available: boolean;
+	owner: string;
+	repo: string;
+	prNumber: number;
+	url: string;
+	reason?: string;
+}
+
+export interface GithubResolvedPr {
+	changesetId: string;
+	changeset: GithubWalkthroughChangesetRef;
+	files: GithubWalkthroughFile[];
+	warnings: GithubWalkthroughWarning[];
+	export: GithubWalkthroughExportCapability;
+	provider: {
+		name: "github";
+		owner: string;
+		repo: string;
+		prNumber: number;
+		prUrl: string;
+		apiUrl: string;
+		baseSha: string;
+		headSha: string;
+	};
+}
+
+export interface ResolveGithubPrOptions {
+	cwd?: string;
+	prUrl?: string;
+	prNumber?: string | number;
+	token?: string;
+	fetch?: FetchLike;
+	apiBaseUrl?: string;
+	maxFiles?: number;
+}
+
+export interface ParsedGithubPrReference {
+	owner?: string;
+	repo?: string;
+	number?: number;
+	host?: string;
+	url?: string;
+}
+
+interface GithubApiPullRequest {
+	number: number;
+	title: string;
+	html_url: string;
+	base: { sha: string };
+	head: { sha: string };
+	changed_files?: number;
+	additions?: number;
+	deletions?: number;
+}
+
+interface GithubApiChangedFile {
+	filename: string;
+	previous_filename?: string;
+	status: string;
+	additions?: number;
+	deletions?: number;
+	changes?: number;
+	blob_url?: string;
+	raw_url?: string;
+	contents_url?: string;
+	patch?: string;
+}
+
+interface FetchHeadersLike {
+	get(name: string): string | null;
+}
+
+interface FetchResponseLike {
+	ok: boolean;
+	status: number;
+	statusText: string;
+	headers: FetchHeadersLike;
+	json(): Promise<unknown>;
+	text(): Promise<string>;
+}
+
+type FetchLike = (url: string, init?: {
+	method?: string;
+	headers?: Record<string, string>;
+	body?: string;
+	signal?: AbortSignal;
+}) => Promise<FetchResponseLike>;
+
+export class GithubPrAdapterError extends Error {
+	readonly status: number;
+	readonly code: string;
+	readonly warnings: GithubWalkthroughWarning[];
+
+	constructor(message: string, options: { status?: number; code?: string; warnings?: GithubWalkthroughWarning[] } = {}) {
+		super(message);
+		this.name = "GithubPrAdapterError";
+		this.status = options.status ?? 500;
+		this.code = options.code ?? "github_pr_error";
+		this.warnings = options.warnings ?? [];
+	}
+}
+
+export function parseGithubPrReference(input: { prUrl?: string; prNumber?: string | number }): ParsedGithubPrReference {
+	const number = normalizePrNumber(input.prNumber);
+	const prUrl = cleanString(input.prUrl);
+	if (!prUrl) return { number };
+
+	let parsed: URL;
+	try {
+		parsed = new URL(prUrl);
+	} catch {
+		throw new GithubPrAdapterError(`Invalid GitHub PR URL: ${prUrl}`, { status: 400, code: "invalid_github_pr_url" });
+	}
+
+	const match = /^\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:\/|$)/i.exec(parsed.pathname);
+	if (!match) {
+		throw new GithubPrAdapterError(`URL is not a GitHub pull request: ${prUrl}`, { status: 400, code: "not_github_pull_request" });
+	}
+
+	return {
+		owner: decodeURIComponent(match[1]),
+		repo: stripGitSuffix(decodeURIComponent(match[2])),
+		number: Number(match[3]),
+		host: parsed.hostname,
+		url: prUrl,
+	};
+}
+
+export function parseGithubRemoteUrl(remoteUrl: string): { owner: string; repo: string; host: string } | null {
+	const trimmed = remoteUrl.trim();
+	const scpLike = /^(?:git@)?([^:]+):([^/]+)\/(.+?)(?:\.git)?$/i.exec(trimmed);
+	if (scpLike) return { host: scpLike[1], owner: scpLike[2], repo: stripGitSuffix(scpLike[3]) };
+
+	try {
+		const url = new URL(trimmed);
+		const parts = url.pathname.replace(/^\/+/, "").split("/").filter(Boolean);
+		if (parts.length >= 2) return { host: url.hostname, owner: parts[0], repo: stripGitSuffix(parts[1]) };
+	} catch {
+		return null;
+	}
+	return null;
+}
+
+export async function resolveGithubPr(options: ResolveGithubPrOptions): Promise<GithubResolvedPr> {
+	const warnings: GithubWalkthroughWarning[] = [];
+	const parsed = parseGithubPrReference(options);
+	const inferred = parsed.owner && parsed.repo ? undefined : await inferGithubRepository(options.cwd);
+	const owner = parsed.owner ?? inferred?.owner;
+	const repo = parsed.repo ?? inferred?.repo;
+	const host = parsed.host ?? inferred?.host ?? "github.com";
+	const number = parsed.number;
+
+	if (!owner || !repo) {
+		throw new GithubPrAdapterError("A GitHub PR number requires a GitHub origin remote to infer owner/repo", {
+			status: 400,
+			code: "github_repository_required",
+		});
+	}
+	if (!number) {
+		throw new GithubPrAdapterError("GitHub PR number is required", { status: 400, code: "github_pr_number_required" });
+	}
+
+	const token = cleanString(options.token) ?? cleanString(process.env.GITHUB_TOKEN) ?? cleanString(process.env.GH_TOKEN);
+	if (!token) {
+		warnings.push({
+			code: "github_unauthenticated",
+			severity: "info",
+			message: "No GITHUB_TOKEN/GH_TOKEN configured; using unauthenticated GitHub API requests with lower rate limits.",
+		});
+	}
+
+	const apiBaseUrl = cleanString(options.apiBaseUrl) ?? apiBaseUrlForHost(host);
+	const fetchImpl = options.fetch ?? fetch;
+	const headers = githubHeaders(token);
+	const prApiUrl = `${apiBaseUrl}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${number}`;
+	const pr = await fetchGithubJson<GithubApiPullRequest>(fetchImpl, prApiUrl, headers, warnings);
+	const files = await fetchGithubFiles(fetchImpl, prApiUrl, headers, options.maxFiles ?? 300, warnings);
+	const resolvedFiles = await enrichFilesWithDiffs({ cwd: options.cwd, baseSha: pr.base.sha, headSha: pr.head.sha, files, warnings });
+	const prUrl = pr.html_url || parsed.url || `https://${host}/${owner}/${repo}/pull/${number}`;
+	const changesetId = changesetIdForGithub(owner, repo, number, pr.head.sha);
+	const exportAvailable = Boolean(token);
+
+	return {
+		changesetId,
+		changeset: {
+			baseSha: pr.base.sha,
+			headSha: pr.head.sha,
+			provider: "github",
+			externalUrl: prUrl,
+			prUrl,
+			prNumber: pr.number,
+			prTitle: pr.title,
+			title: `PR #${pr.number}: ${pr.title}`,
+			filesChanged: pr.changed_files,
+			additions: pr.additions,
+			deletions: pr.deletions,
+			owner,
+			repo,
+		},
+		files: resolvedFiles,
+		warnings,
+		export: {
+			provider: "github",
+			available: exportAvailable,
+			owner,
+			repo,
+			prNumber: pr.number,
+			url: prUrl,
+			reason: exportAvailable ? undefined : "Set GITHUB_TOKEN or GH_TOKEN to submit a review back to GitHub.",
+		},
+		provider: {
+			name: "github",
+			owner,
+			repo,
+			prNumber: pr.number,
+			prUrl,
+			apiUrl: prApiUrl,
+			baseSha: pr.base.sha,
+			headSha: pr.head.sha,
+		},
+	};
+}
+
+async function inferGithubRepository(cwd: string | undefined): Promise<{ owner: string; repo: string; host: string } | undefined> {
+	if (!cwd) return undefined;
+	try {
+		const { stdout } = await execFileSafe("git", ["remote", "get-url", "origin"], { cwd, timeout: 5_000, encoding: "utf8" });
+		return parseGithubRemoteUrl(stdout) ?? undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+async function fetchGithubFiles(
+	fetchImpl: FetchLike,
+	prApiUrl: string,
+	headers: Record<string, string>,
+	maxFiles: number,
+	warnings: GithubWalkthroughWarning[],
+): Promise<GithubApiChangedFile[]> {
+	const result: GithubApiChangedFile[] = [];
+	for (let page = 1; result.length < maxFiles; page++) {
+		const pageUrl = `${prApiUrl}/files?per_page=100&page=${page}`;
+		const batch = await fetchGithubJson<GithubApiChangedFile[]>(fetchImpl, pageUrl, headers, warnings);
+		result.push(...batch);
+		if (batch.length < 100) break;
+	}
+	if (result.length > maxFiles) {
+		warnings.push({ code: "github_files_truncated", severity: "warning", message: `GitHub changed files were truncated at ${maxFiles} files.` });
+	}
+	return result.slice(0, maxFiles);
+}
+
+async function fetchGithubJson<T>(
+	fetchImpl: FetchLike,
+	url: string,
+	headers: Record<string, string>,
+	warnings: GithubWalkthroughWarning[],
+): Promise<T> {
+	const response = await fetchImpl(url, { method: "GET", headers, signal: AbortSignal.timeout(20_000) });
+	if (!response.ok) {
+		const message = await response.text().catch(() => response.statusText);
+		const warning = warningForGithubHttpFailure(response.status, response.headers);
+		if (warning) warnings.push(warning);
+		throw new GithubPrAdapterError(`GitHub API request failed (${response.status}): ${message || response.statusText}`, {
+			status: response.status,
+			code: response.status === 404 ? "github_pr_not_found" : "github_api_error",
+			warnings,
+		});
+	}
+	return await response.json() as T;
+}
+
+async function enrichFilesWithDiffs(input: {
+	cwd?: string;
+	baseSha: string;
+	headSha: string;
+	files: GithubApiChangedFile[];
+	warnings: GithubWalkthroughWarning[];
+}): Promise<GithubWalkthroughFile[]> {
+	const localDiffAvailable = await hasLocalCommit(input.cwd, input.baseSha) && await hasLocalCommit(input.cwd, input.headSha);
+	const enriched: GithubWalkthroughFile[] = [];
+	for (const file of input.files) {
+		const patch = localDiffAvailable
+			? await readLocalPatchForFile(input.cwd, input.baseSha, input.headSha, file).catch(() => cleanString(file.patch))
+			: cleanString(file.patch);
+		const status = normalizeGithubFileStatus(file.status, patch);
+		const block = parsePatchToDiffBlock({ filePath: file.filename, oldPath: file.previous_filename, patch, status });
+		if (!patch) {
+			input.warnings.push({
+				code: status === "binary" ? "github_binary_file" : "github_file_without_patch",
+				severity: status === "binary" ? "warning" : "info",
+				message: status === "binary" ? "Binary file has no reviewable text diff." : "GitHub did not provide a text patch for this file.",
+				filePath: file.filename,
+			});
+		}
+		enriched.push({
+			filePath: file.filename,
+			oldPath: file.previous_filename,
+			status,
+			additions: file.additions ?? 0,
+			deletions: file.deletions ?? 0,
+			changes: file.changes ?? ((file.additions ?? 0) + (file.deletions ?? 0)),
+			patch,
+			blobUrl: file.blob_url,
+			rawUrl: file.raw_url,
+			contentsUrl: file.contents_url,
+			diffBlocks: block.hunks.length > 0 ? [block] : [],
+		});
+	}
+	return enriched;
+}
+
+async function hasLocalCommit(cwd: string | undefined, sha: string): Promise<boolean> {
+	if (!cwd || !sha) return false;
+	try {
+		await execFileSafe("git", ["rev-parse", "--verify", `${sha}^{commit}`], { cwd, timeout: 5_000, encoding: "utf8" });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function readLocalPatchForFile(cwd: string | undefined, baseSha: string, headSha: string, file: GithubApiChangedFile): Promise<string | undefined> {
+	if (!cwd) return undefined;
+	const paths = file.previous_filename && file.previous_filename !== file.filename ? [file.previous_filename, file.filename] : [file.filename];
+	const { stdout } = await execFileSafe("git", ["diff", "--no-ext-diff", "--find-renames", "--find-copies", "--binary", "--unified=80", baseSha, headSha, "--", ...paths], {
+		cwd,
+		timeout: 20_000,
+		maxBuffer: 10 * 1024 * 1024,
+		encoding: "utf8",
+	});
+	return extractPatchBody(stdout) || undefined;
+}
+
+function parsePatchToDiffBlock(input: { filePath: string; oldPath?: string; patch?: string; status: GithubWalkthroughFile["status"] }): GithubDiffBlock {
+	const blockId = stableBlockId(input.filePath, input.oldPath);
+	const hunks: GithubDiffHunk[] = [];
+	const lines = (input.patch ?? "").split(/\r?\n/);
+	let current: GithubDiffHunk | undefined;
+	let oldLine = 0;
+	let newLine = 0;
+	for (const rawLine of lines) {
+		const hunkMatch = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@.*$/.exec(rawLine);
+		if (hunkMatch) {
+			oldLine = Number(hunkMatch[1]);
+			newLine = Number(hunkMatch[2]);
+			current = { id: `${blockId}:h${hunks.length}`, header: rawLine, lines: [] };
+			hunks.push(current);
+			continue;
+		}
+		if (!current || rawLine === "" || rawLine.startsWith("\\ No newline")) continue;
+		const prefix = rawLine[0];
+		const text = rawLine.slice(1);
+		const lineIndex = current.lines.length;
+		if (prefix === "+") {
+			current.lines.push({ id: `${current.id}:l${lineIndex}`, side: "new", newLine, kind: "add", text });
+			newLine += 1;
+		} else if (prefix === "-") {
+			current.lines.push({ id: `${current.id}:l${lineIndex}`, side: "old", oldLine, kind: "del", text });
+			oldLine += 1;
+		} else {
+			current.lines.push({ id: `${current.id}:l${lineIndex}`, side: "context", oldLine, newLine, kind: "context", text: prefix === " " ? text : rawLine });
+			oldLine += 1;
+			newLine += 1;
+		}
+	}
+	return { id: blockId, filePath: input.filePath, oldPath: input.oldPath, hunks };
+}
+
+function extractPatchBody(diff: string): string {
+	const lines = diff.split(/\r?\n/);
+	const firstHunk = lines.findIndex(line => line.startsWith("@@ "));
+	return firstHunk >= 0 ? lines.slice(firstHunk).join("\n") : "";
+}
+
+function normalizeGithubFileStatus(status: string, patch?: string): GithubWalkthroughFile["status"] {
+	if (!patch && /binary/i.test(status)) return "binary";
+	switch (status) {
+		case "added": return "added";
+		case "removed": return "deleted";
+		case "renamed": return "renamed";
+		case "copied": return "copied";
+		case "modified":
+		case "changed":
+		default:
+			return patch ? "modified" : "binary";
+	}
+}
+
+function warningForGithubHttpFailure(status: number, headers: FetchHeadersLike): GithubWalkthroughWarning | undefined {
+	if (status === 401) return { code: "github_auth_failed", severity: "error", message: "GitHub rejected the configured token. Check GITHUB_TOKEN/GH_TOKEN." };
+	if (status === 403) {
+		const remaining = headers.get("x-ratelimit-remaining");
+		return remaining === "0"
+			? { code: "github_rate_limited", severity: "error", message: "GitHub API rate limit exceeded. Configure a token or retry after the reset time." }
+			: { code: "github_permission_denied", severity: "error", message: "GitHub denied access to this pull request or repository." };
+	}
+	return undefined;
+}
+
+function githubHeaders(token: string | undefined): Record<string, string> {
+	return {
+		Accept: "application/vnd.github+json",
+		"User-Agent": "bobbit-pr-walkthrough",
+		"X-GitHub-Api-Version": "2022-11-28",
+		...(token ? { Authorization: `Bearer ${token}` } : {}),
+	};
+}
+
+function apiBaseUrlForHost(host: string): string {
+	return host.toLowerCase() === "github.com" ? "https://api.github.com" : `https://${host}/api/v3`;
+}
+
+function changesetIdForGithub(owner: string, repo: string, number: number, headSha?: string): string {
+	return `github:${owner}/${repo}#${number}:${shortSha(headSha) ?? "unknown"}`;
+}
+
+function stableBlockId(filePath: string, oldPath: string | undefined): string {
+	const raw = oldPath && oldPath !== filePath ? `${oldPath}->${filePath}` : filePath;
+	return `github:${raw.replace(/[^A-Za-z0-9_.-]+/g, "-").replace(/^-+|-+$/g, "") || "file"}`;
+}
+
+function shortSha(value: string | undefined): string | undefined {
+	const cleaned = cleanString(value);
+	return cleaned ? cleaned.slice(0, 7) : undefined;
+}
+
+function normalizePrNumber(value: string | number | undefined): number | undefined {
+	const raw = typeof value === "number" ? String(Math.trunc(value)) : cleanString(value);
+	if (!raw) return undefined;
+	const normalized = raw.replace(/^#/, "").trim();
+	if (!/^\d+$/.test(normalized)) return undefined;
+	return Number(normalized);
+}
+
+function cleanString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function stripGitSuffix(repo: string): string {
+	return repo.replace(/\.git$/i, "");
+}

--- a/src/server/pr-walkthrough/github-adapter.ts
+++ b/src/server/pr-walkthrough/github-adapter.ts
@@ -23,6 +23,10 @@ export interface GithubDiffBlock {
 	filePath: string;
 	oldPath?: string;
 	hunks: GithubDiffHunk[];
+	externalUrl?: string;
+	blobUrl?: string;
+	rawUrl?: string;
+	contentsUrl?: string;
 }
 
 export interface GithubWalkthroughChangesetRef {
@@ -178,6 +182,11 @@ export function parseGithubPrReference(input: { prUrl?: string; prNumber?: strin
 		throw new GithubPrAdapterError(`Invalid GitHub PR URL: ${prUrl}`, { status: 400, code: "invalid_github_pr_url" });
 	}
 
+	const host = normalizeHost(parsed.hostname);
+	if (!isTrustedGithubHost(host)) {
+		throw new GithubPrAdapterError(`Untrusted GitHub PR host: ${host}`, { status: 400, code: "untrusted_github_host" });
+	}
+
 	const match = /^\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:\/|$)/i.exec(parsed.pathname);
 	if (!match) {
 		throw new GithubPrAdapterError(`URL is not a GitHub pull request: ${prUrl}`, { status: 400, code: "not_github_pull_request" });
@@ -187,7 +196,7 @@ export function parseGithubPrReference(input: { prUrl?: string; prNumber?: strin
 		owner: decodeURIComponent(match[1]),
 		repo: stripGitSuffix(decodeURIComponent(match[2])),
 		number: Number(match[3]),
-		host: parsed.hostname,
+		host,
 		url: prUrl,
 	};
 }
@@ -213,8 +222,12 @@ export async function resolveGithubPr(options: ResolveGithubPrOptions): Promise<
 	const inferred = parsed.owner && parsed.repo ? undefined : await inferGithubRepository(options.cwd);
 	const owner = parsed.owner ?? inferred?.owner;
 	const repo = parsed.repo ?? inferred?.repo;
-	const host = parsed.host ?? inferred?.host ?? "github.com";
+	const host = normalizeHost(parsed.host ?? inferred?.host ?? "github.com");
 	const number = parsed.number;
+
+	if (!isTrustedGithubHost(host)) {
+		throw new GithubPrAdapterError(`Untrusted GitHub PR host: ${host}`, { status: 400, code: "untrusted_github_host" });
+	}
 
 	if (!owner || !repo) {
 		throw new GithubPrAdapterError("A GitHub PR number requires a GitHub origin remote to infer owner/repo", {
@@ -235,7 +248,7 @@ export async function resolveGithubPr(options: ResolveGithubPrOptions): Promise<
 		});
 	}
 
-	const apiBaseUrl = cleanString(options.apiBaseUrl) ?? apiBaseUrlForHost(host);
+	const apiBaseUrl = cleanString(options.apiBaseUrl) ?? cleanString(process.env.BOBBIT_GITHUB_API_BASE_URL) ?? apiBaseUrlForHost(host);
 	const fetchImpl = options.fetch ?? fetch;
 	const headers = githubHeaders(token);
 	const prApiUrl = `${apiBaseUrl}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${number}`;
@@ -330,7 +343,7 @@ async function fetchGithubJson<T>(
 		if (warning) warnings.push(warning);
 		throw new GithubPrAdapterError(`GitHub API request failed (${response.status}): ${message || response.statusText}`, {
 			status: response.status,
-			code: response.status === 404 ? "github_pr_not_found" : "github_api_error",
+			code: response.status === 404 ? "github_pr_not_found" : warning?.code ?? "github_api_error",
 			warnings,
 		});
 	}
@@ -351,7 +364,16 @@ async function enrichFilesWithDiffs(input: {
 			? await readLocalPatchForFile(input.cwd, input.baseSha, input.headSha, file).catch(() => cleanString(file.patch))
 			: cleanString(file.patch);
 		const status = normalizeGithubFileStatus(file.status, patch);
-		const block = parsePatchToDiffBlock({ filePath: file.filename, oldPath: file.previous_filename, patch, status });
+		const block = parsePatchToDiffBlock({
+			filePath: file.filename,
+			oldPath: file.previous_filename,
+			patch,
+			status,
+			externalUrl: file.blob_url,
+			blobUrl: file.blob_url,
+			rawUrl: file.raw_url,
+			contentsUrl: file.contents_url,
+		});
 		if (!patch) {
 			input.warnings.push({
 				code: status === "binary" ? "github_binary_file" : "github_file_without_patch",
@@ -399,7 +421,7 @@ async function readLocalPatchForFile(cwd: string | undefined, baseSha: string, h
 	return extractPatchBody(stdout) || undefined;
 }
 
-function parsePatchToDiffBlock(input: { filePath: string; oldPath?: string; patch?: string; status: GithubWalkthroughFile["status"] }): GithubDiffBlock {
+function parsePatchToDiffBlock(input: { filePath: string; oldPath?: string; patch?: string; status: GithubWalkthroughFile["status"]; externalUrl?: string; blobUrl?: string; rawUrl?: string; contentsUrl?: string }): GithubDiffBlock {
 	const blockId = stableBlockId(input.filePath, input.oldPath);
 	const hunks: GithubDiffHunk[] = [];
 	const lines = (input.patch ?? "").split(/\r?\n/);
@@ -431,7 +453,16 @@ function parsePatchToDiffBlock(input: { filePath: string; oldPath?: string; patc
 			newLine += 1;
 		}
 	}
-	return { id: blockId, filePath: input.filePath, oldPath: input.oldPath, hunks };
+	return {
+		id: blockId,
+		filePath: input.filePath,
+		oldPath: input.oldPath,
+		hunks,
+		externalUrl: input.externalUrl,
+		blobUrl: input.blobUrl,
+		rawUrl: input.rawUrl,
+		contentsUrl: input.contentsUrl,
+	};
 }
 
 function extractPatchBody(diff: string): string {
@@ -476,6 +507,22 @@ function githubHeaders(token: string | undefined): Record<string, string> {
 
 function apiBaseUrlForHost(host: string): string {
 	return host.toLowerCase() === "github.com" ? "https://api.github.com" : `https://${host}/api/v3`;
+}
+
+function normalizeHost(host: string | undefined): string {
+	return (host ?? "github.com").trim().replace(/\.$/, "").toLowerCase();
+}
+
+function isTrustedGithubHost(host: string): boolean {
+	const trusted = new Set(["github.com", ...trustedGithubHostAllowlist()]);
+	return trusted.has(normalizeHost(host));
+}
+
+function trustedGithubHostAllowlist(): string[] {
+	return (process.env.BOBBIT_GITHUB_TRUSTED_HOSTS ?? "")
+		.split(",")
+		.map(host => normalizeHost(host))
+		.filter(Boolean);
 }
 
 function changesetIdForGithub(owner: string, repo: string, number: number, headSha?: string): string {

--- a/src/server/pr-walkthrough/routes.ts
+++ b/src/server/pr-walkthrough/routes.ts
@@ -6,6 +6,9 @@ import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 
 import { bobbitStateDir } from "../bobbit-dir.js";
+import { completeModelText as defaultCompleteModelText } from "../agent/model-completion.js";
+import { getAvailableModels as defaultGetAvailableModels, type ApiModel } from "../agent/model-registry.js";
+import { safeExternalUrl, trustedHostsFromEnv } from "../../shared/pr-walkthrough/url-safety.js";
 
 const execFile = promisify(execFileCb);
 const STORE_SCHEMA_VERSION = 1;
@@ -82,9 +85,16 @@ type StoredWalkthrough = {
 export type PrWalkthroughRouteDeps = {
 	defaultCwd: string;
 	readBody: JsonReader;
+	resolveSessionCwd?: (sessionId: string) => string | undefined | Promise<string | undefined>;
+	resolveSessionModel?: (sessionId: string) => string | { provider?: string; id?: string; modelId?: string } | undefined | Promise<string | { provider?: string; id?: string; modelId?: string } | undefined>;
+	preferencesStore?: { get(key: string): unknown };
+	getAvailableModels?: (preferencesStore: { get(key: string): unknown }) => Promise<ApiModel[]>;
+	completeModelText?: typeof defaultCompleteModelText;
+	createSynthesisAdapter?: (context: WalkthroughSynthesisContext) => WalkthroughLlmAdapter | undefined | Promise<WalkthroughLlmAdapter | undefined>;
 };
 
 type WalkthroughLlmAdapter = (input: Record<string, unknown>) => Promise<unknown> | unknown;
+type WalkthroughSynthesisContext = { sessionId?: string; cwd: string; changeset?: WalkthroughChangeset };
 let synthesisAdapterForTesting: WalkthroughLlmAdapter | undefined;
 let configuredSynthesisAdapter: WalkthroughLlmAdapter | undefined | null;
 
@@ -115,7 +125,7 @@ export async function handlePrWalkthroughApiRoute(
 				fail(400, "Invalid resolve request");
 				return true;
 			}
-			const result = await resolveWalkthrough(body, deps);
+			const result = sanitizeResolveResult(await resolveWalkthrough(body, deps));
 			await storeWalkthrough(result);
 			json(result);
 			return true;
@@ -186,7 +196,9 @@ export async function handlePrWalkthroughApiRoute(
 async function resolveWalkthrough(body: Record<string, unknown>, deps: PrWalkthroughRouteDeps): Promise<WalkthroughResolveResult> {
 	if (body.fixture === true) return fixtureWalkthrough();
 
-	const cwd = typeof body.cwd === "string" && body.cwd.trim() ? body.cwd : deps.defaultCwd;
+	const sessionId = stringValue(body.sessionId);
+	const cwd = await resolveRequestCwd(body, deps, sessionId);
+	const context: WalkthroughSynthesisContext = { sessionId, cwd };
 	const baseSha = stringValue(body.baseSha);
 	const headSha = stringValue(body.headSha);
 	const prUrl = stringValue(body.prUrl);
@@ -194,7 +206,7 @@ async function resolveWalkthrough(body: Record<string, unknown>, deps: PrWalkthr
 	const wantsGithub = Boolean(prUrl || prNumber || body.provider === "github");
 
 	if (wantsGithub && baseSha && headSha) {
-		const local = await resolveLocalWithDelegation(cwd, baseSha, headSha);
+		const local = await resolveLocalWithDelegation(cwd, baseSha, headSha, deps, context);
 		const gh = parseGithubRef(prUrl, prNumber, cwd);
 		const head = shortSha(local.changeset.headSha);
 		const changesetId = gh ? changesetIdForGithub(gh.owner, gh.repo, gh.number, head) : `github:unknown#${prNumber ?? "unknown"}:${head}`;
@@ -204,9 +216,9 @@ async function resolveWalkthrough(body: Record<string, unknown>, deps: PrWalkthr
 			changeset: {
 				...local.changeset,
 				provider: "github",
-				prUrl: prUrl || gh?.url,
+				prUrl: gh?.url,
 				prNumber: prNumber ?? gh?.number,
-				externalUrl: prUrl || gh?.url,
+				externalUrl: gh?.url,
 				title: gh ? `PR #${gh.number}: ${local.changeset.title ?? "Walkthrough"}` : local.changeset.title,
 			},
 			export: { provider: "github", available: false, previewOnly: true, reason: "GitHub submission requires adapter credentials; preview is available." },
@@ -214,22 +226,31 @@ async function resolveWalkthrough(body: Record<string, unknown>, deps: PrWalkthr
 	}
 
 	if (wantsGithub) {
-		const delegated = await tryResolveGithubWithDelegation({ cwd, prUrl, prNumber });
+		const delegated = await tryResolveGithubWithDelegation({ cwd, prUrl, prNumber }, deps, context);
 		if (delegated) return delegated;
 		throw new Error("GitHub PR resolution is unavailable without local baseSha/headSha or the GitHub adapter");
 	}
 
 	if (!baseSha || !headSha) throw new Error("baseSha and headSha are required for local walkthrough resolution");
-	return resolveLocalWithDelegation(cwd, baseSha, headSha);
+	return resolveLocalWithDelegation(cwd, baseSha, headSha, deps, context);
 }
 
-async function resolveLocalWithDelegation(cwd: string, baseSha: string, headSha: string): Promise<WalkthroughResolveResult> {
-	const delegated = await tryResolveLocalWithModules(cwd, baseSha, headSha);
+async function resolveRequestCwd(body: Record<string, unknown>, deps: PrWalkthroughRouteDeps, sessionId: string | undefined): Promise<string> {
+	if (typeof body.cwd === "string" && body.cwd.trim()) return body.cwd.trim();
+	if (sessionId && deps.resolveSessionCwd) {
+		const sessionCwd = await deps.resolveSessionCwd(sessionId);
+		if (typeof sessionCwd === "string" && sessionCwd.trim()) return sessionCwd.trim();
+	}
+	return deps.defaultCwd;
+}
+
+async function resolveLocalWithDelegation(cwd: string, baseSha: string, headSha: string, deps: PrWalkthroughRouteDeps, context: WalkthroughSynthesisContext): Promise<WalkthroughResolveResult> {
+	const delegated = await tryResolveLocalWithModules(cwd, baseSha, headSha, deps, context);
 	if (delegated) return delegated;
 	return resolveLocalFallback(cwd, baseSha, headSha);
 }
 
-async function tryResolveLocalWithModules(cwd: string, baseSha: string, headSha: string): Promise<WalkthroughResolveResult | undefined> {
+async function tryResolveLocalWithModules(cwd: string, baseSha: string, headSha: string, deps: PrWalkthroughRouteDeps, context: WalkthroughSynthesisContext): Promise<WalkthroughResolveResult | undefined> {
 	const gitModule = await optionalPrModule("git-changeset");
 	const resolveLocalChangeset = gitModule?.resolveLocalChangeset;
 	if (typeof resolveLocalChangeset !== "function") return undefined;
@@ -241,7 +262,7 @@ async function tryResolveLocalWithModules(cwd: string, baseSha: string, headSha:
 	const warnings = Array.isArray(resolved?.warnings) ? resolved.warnings : [];
 	const changesetId = typeof resolved?.changesetId === "string" ? resolved.changesetId : changesetIdForLocal(changeset?.baseSha ?? baseSha, changeset?.headSha ?? headSha);
 	let cards = Array.isArray(resolved?.cards) ? resolved.cards : undefined;
-	cards ??= await synthesizeCardsForResolver(changeset, files, warnings);
+	cards ??= await synthesizeCardsForResolver(changeset, files, warnings, deps, { ...context, changeset });
 	return {
 		changesetId,
 		changeset,
@@ -252,22 +273,23 @@ async function tryResolveLocalWithModules(cwd: string, baseSha: string, headSha:
 	};
 }
 
-async function tryResolveGithubWithDelegation(input: Record<string, unknown>): Promise<WalkthroughResolveResult | undefined> {
+async function tryResolveGithubWithDelegation(input: Record<string, unknown>, deps: PrWalkthroughRouteDeps, context: WalkthroughSynthesisContext): Promise<WalkthroughResolveResult | undefined> {
 	const module = await optionalPrModule("github-adapter");
 	const resolveGithubPr = module?.resolveGithubPr;
 	if (typeof resolveGithubPr !== "function") return undefined;
 	const resolved = await resolveGithubPr(input);
-	return normalizeGithubResolvedWalkthrough(resolved);
+	return normalizeGithubResolvedWalkthrough(resolved, deps, context);
 }
 
-export async function normalizeGithubResolvedWalkthrough(resolved: any): Promise<WalkthroughResolveResult | undefined> {
+export async function normalizeGithubResolvedWalkthrough(resolved: any, deps?: Partial<PrWalkthroughRouteDeps>, context?: Partial<WalkthroughSynthesisContext>): Promise<WalkthroughResolveResult | undefined> {
 	if (isResolveResult(resolved)) return resolved;
 	if (!resolved?.changeset) return undefined;
 	const warnings = Array.isArray(resolved.warnings) ? resolved.warnings : [];
 	const files = Array.isArray(resolved.files) ? resolved.files : [];
+	const routeDeps = deps ? { ...deps, defaultCwd: deps.defaultCwd ?? "", readBody: deps.readBody ?? (async () => ({})) } as PrWalkthroughRouteDeps : undefined;
 	const cards = Array.isArray(resolved.cards)
 		? resolved.cards
-		: await synthesizeCardsForResolver(resolved.changeset, files, warnings);
+		: await synthesizeCardsForResolver(resolved.changeset, files, warnings, routeDeps, { cwd: context?.cwd ?? "", sessionId: context?.sessionId, changeset: resolved.changeset });
 	return {
 		changesetId: typeof resolved.changesetId === "string" ? resolved.changesetId : changesetIdForLocal(resolved.changeset.baseSha, resolved.changeset.headSha),
 		changeset: resolved.changeset,
@@ -278,19 +300,36 @@ export async function normalizeGithubResolvedWalkthrough(resolved: any): Promise
 	};
 }
 
-async function synthesizeCardsForResolver(changeset: WalkthroughChangeset, files: any[], warnings: WalkthroughWarning[]): Promise<WalkthroughCard[]> {
+async function synthesizeCardsForResolver(
+	changeset: WalkthroughChangeset,
+	files: any[],
+	warnings: WalkthroughWarning[],
+	deps?: PrWalkthroughRouteDeps,
+	context: WalkthroughSynthesisContext = { cwd: "" },
+): Promise<WalkthroughCard[]> {
 	const synthesisModule = await optionalPrModule("card-synthesis");
 	const synthesize = synthesisModule?.synthesiseWalkthroughCards ?? synthesisModule?.synthesizeWalkthroughCards;
 	if (typeof synthesize === "function") {
-		const llm = await resolveConfiguredSynthesisAdapter();
+		const llm = await resolveConfiguredSynthesisAdapter(deps, { ...context, changeset });
 		const cards = await synthesize(changeset, files, { warnings, ...(llm ? { allowLlm: true, llm } : {}) });
 		if (Array.isArray(cards) && cards.length > 0) return cards;
 	}
 	return synthesizeFallbackCards(changeset, flattenDiffBlocks(files), warnings);
 }
 
-async function resolveConfiguredSynthesisAdapter(): Promise<WalkthroughLlmAdapter | undefined> {
+async function resolveConfiguredSynthesisAdapter(deps: PrWalkthroughRouteDeps | undefined, context: WalkthroughSynthesisContext): Promise<WalkthroughLlmAdapter | undefined> {
 	if (synthesisAdapterForTesting) return synthesisAdapterForTesting;
+	if (deps?.createSynthesisAdapter) {
+		const adapter = await deps.createSynthesisAdapter(context);
+		if (adapter) return adapter;
+	}
+	const envAdapter = await resolveEnvSynthesisAdapter();
+	if (envAdapter) return envAdapter;
+	if (deps) return createModelBackedSynthesisAdapter(deps, context);
+	return undefined;
+}
+
+async function resolveEnvSynthesisAdapter(): Promise<WalkthroughLlmAdapter | undefined> {
 	if (configuredSynthesisAdapter !== undefined) return configuredSynthesisAdapter ?? undefined;
 	const modulePath = stringValue(process.env.BOBBIT_PR_WALKTHROUGH_SYNTHESIS_ADAPTER);
 	if (!modulePath) {
@@ -301,6 +340,69 @@ async function resolveConfiguredSynthesisAdapter(): Promise<WalkthroughLlmAdapte
 	const adapter = module.default ?? module.synthesiseWalkthroughCards ?? module.synthesizeWalkthroughCards ?? module.synthesise;
 	configuredSynthesisAdapter = typeof adapter === "function" ? adapter : null;
 	return configuredSynthesisAdapter ?? undefined;
+}
+
+export async function createModelBackedSynthesisAdapter(deps: PrWalkthroughRouteDeps, context: WalkthroughSynthesisContext): Promise<WalkthroughLlmAdapter | undefined> {
+	const prefs = deps.preferencesStore;
+	if (!prefs) return undefined;
+	const modelPref = await resolveSynthesisModelPref(deps, context.sessionId);
+	if (!modelPref) return undefined;
+	const slash = modelPref.indexOf("/");
+	if (slash <= 0 || slash >= modelPref.length - 1) return undefined;
+	const provider = modelPref.slice(0, slash);
+	const modelId = modelPref.slice(slash + 1);
+	const models = await (deps.getAvailableModels ?? defaultGetAvailableModels)(prefs as any);
+	const model = models.find(item => item.provider === provider && item.id === modelId);
+	if (!model) return undefined;
+	const complete = deps.completeModelText ?? defaultCompleteModelText;
+	return async input => {
+		const text = await complete(model, prefs as any, {
+			systemPrompt: PR_WALKTHROUGH_SYNTHESIS_SYSTEM_PROMPT,
+			userPrompt: buildSynthesisUserPrompt(input),
+			maxTokens: 2400,
+			thinkingLevel: "off",
+			timeoutMs: 30_000,
+		});
+		return parseJsonFromModelText(text);
+	};
+}
+
+const PR_WALKTHROUGH_SYNTHESIS_SYSTEM_PROMPT = `You synthesize concise PR walkthrough review cards from parsed diffs. Return only JSON with a top-level "cards" array. Each card must include phaseId (orientation, design, significant, other, or audit), title, summary, and diffBlockIds referencing only provided IDs. Suggested comments may include diffBlockId, lineId, and body. Do not invent file paths, block ids, or line ids.`;
+
+async function resolveSynthesisModelPref(deps: PrWalkthroughRouteDeps, sessionId: string | undefined): Promise<string | undefined> {
+	if (sessionId && deps.resolveSessionModel) {
+		const sessionModel = await deps.resolveSessionModel(sessionId);
+		const normalized = normalizeModelPref(sessionModel);
+		if (normalized) return normalized;
+	}
+	const reviewModel = normalizeModelPref(deps.preferencesStore?.get("default.reviewModel"));
+	if (reviewModel) return reviewModel;
+	return normalizeModelPref(deps.preferencesStore?.get("default.sessionModel"));
+}
+
+function normalizeModelPref(value: unknown): string | undefined {
+	if (typeof value === "string" && value.includes("/")) return value.trim();
+	if (!value || typeof value !== "object") return undefined;
+	const record = value as { provider?: unknown; id?: unknown; modelId?: unknown };
+	const provider = typeof record.provider === "string" ? record.provider.trim() : "";
+	const id = typeof record.id === "string" ? record.id.trim() : typeof record.modelId === "string" ? record.modelId.trim() : "";
+	return provider && id ? `${provider}/${id}` : undefined;
+}
+
+function buildSynthesisUserPrompt(input: Record<string, unknown>): string {
+	return JSON.stringify(input, null, 2);
+}
+
+function parseJsonFromModelText(text: string): unknown {
+	const trimmed = text.trim().replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/i, "").trim();
+	try {
+		return JSON.parse(trimmed);
+	} catch {
+		const start = trimmed.indexOf("{");
+		const end = trimmed.lastIndexOf("}");
+		if (start >= 0 && end > start) return JSON.parse(trimmed.slice(start, end + 1));
+		return text;
+	}
 }
 
 function flattenDiffBlocks(files: any[]): DiffBlock[] {
@@ -540,6 +642,48 @@ async function submitExport(changesetId: string, payload: WalkthroughResolveResu
 
 export const submitExportForTesting = submitExport;
 
+function sanitizeResolveResult(payload: WalkthroughResolveResult): WalkthroughResolveResult {
+	return {
+		...payload,
+		changeset: sanitizeChangesetUrls(payload.changeset),
+		cards: payload.cards.map(card => ({
+			...card,
+			diffBlocks: card.diffBlocks.map(sanitizeDiffBlockUrls),
+		})),
+		export: payload.export ? sanitizeExportUrls(payload.export) : payload.export,
+	};
+}
+
+function sanitizeChangesetUrls(changeset: WalkthroughChangeset): WalkthroughChangeset {
+	const externalUrl = safeExternalUrl(changeset.externalUrl, trustedHostsFromEnv(process.env.BOBBIT_GITHUB_TRUSTED_HOSTS));
+	const prUrl = safeExternalUrl(changeset.prUrl, trustedHostsFromEnv(process.env.BOBBIT_GITHUB_TRUSTED_HOSTS));
+	return {
+		...changeset,
+		...(externalUrl ? { externalUrl } : { externalUrl: undefined }),
+		...(prUrl ? { prUrl } : { prUrl: undefined }),
+	};
+}
+
+function sanitizeDiffBlockUrls(block: DiffBlock): DiffBlock {
+	const extraHosts = trustedHostsFromEnv(process.env.BOBBIT_GITHUB_TRUSTED_HOSTS);
+	return {
+		...block,
+		externalUrl: safeExternalUrl(block.externalUrl, extraHosts),
+		blobUrl: safeExternalUrl(block.blobUrl, extraHosts),
+		rawUrl: safeExternalUrl(block.rawUrl, extraHosts),
+		contentsUrl: safeExternalUrl(block.contentsUrl, extraHosts),
+	};
+}
+
+function sanitizeExportUrls(exportCapability: WalkthroughExportCapability): WalkthroughExportCapability {
+	const extraHosts = trustedHostsFromEnv(process.env.BOBBIT_GITHUB_TRUSTED_HOSTS);
+	const sanitized: WalkthroughExportCapability = { ...exportCapability };
+	for (const key of ["url", "previewUrl", "submitUrl"] as const) {
+		if (typeof sanitized[key] === "string") sanitized[key] = safeExternalUrl(sanitized[key], extraHosts);
+	}
+	return sanitized;
+}
+
 async function storeWalkthrough(payload: WalkthroughResolveResult): Promise<void> {
 	const module = await optionalPrModule("walkthrough-store");
 	const store = module?.storeWalkthrough ?? module?.saveWalkthrough;
@@ -642,12 +786,23 @@ function stringValue(value: unknown): string | undefined {
 
 function parseGithubRef(prUrl: string | undefined, prNumber: string | number | undefined, cwd: string): { owner: string; repo: string; number: string | number; url: string } | undefined {
 	if (prUrl) {
-		const match = prUrl.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/i);
-		if (match) return { owner: match[1], repo: match[2], number: prNumber ?? match[3], url: prUrl };
+		let parsed: URL;
+		try {
+			parsed = new URL(prUrl);
+		} catch {
+			return undefined;
+		}
+		const safeUrl = safeExternalUrl(prUrl, trustedHostsFromEnv(process.env.BOBBIT_GITHUB_TRUSTED_HOSTS));
+		const match = /^\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:\/|$)/i.exec(parsed.pathname);
+		if (safeUrl && parsed.hostname.replace(/\.$/, "").toLowerCase() === "github.com" && match) {
+			return { owner: decodeURIComponent(match[1]), repo: decodeURIComponent(match[2]).replace(/\.git$/i, ""), number: prNumber ?? match[3], url: safeUrl };
+		}
 	}
 	void cwd;
 	return undefined;
 }
+
+export const resolveWalkthroughForTesting = resolveWalkthrough;
 
 function fixtureWalkthrough(): WalkthroughResolveResult {
 	const changeset: WalkthroughChangeset = {

--- a/src/server/pr-walkthrough/routes.ts
+++ b/src/server/pr-walkthrough/routes.ts
@@ -2,6 +2,7 @@ import { execFile as execFileCb } from "node:child_process";
 import { promises as fs } from "node:fs";
 import http from "node:http";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 
 import { bobbitStateDir } from "../bobbit-dir.js";
@@ -28,7 +29,7 @@ type DiffLine = {
 };
 
 type DiffHunk = { id: string; header: string; lines: DiffLine[] };
-type DiffBlock = { id: string; filePath: string; oldPath?: string; status?: string; hunks: DiffHunk[] };
+type DiffBlock = { id: string; filePath: string; oldPath?: string; status?: string; hunks: DiffHunk[]; externalUrl?: string; blobUrl?: string; rawUrl?: string; contentsUrl?: string };
 type WalkthroughCard = {
 	id: string;
 	phaseId: "orientation" | "design" | "significant" | "other" | "audit";
@@ -69,6 +70,7 @@ type WalkthroughExportCapability = {
 	available: boolean;
 	reason?: string;
 	previewOnly?: boolean;
+	[key: string]: unknown;
 };
 
 type StoredWalkthrough = {
@@ -81,6 +83,14 @@ export type PrWalkthroughRouteDeps = {
 	defaultCwd: string;
 	readBody: JsonReader;
 };
+
+type WalkthroughLlmAdapter = (input: Record<string, unknown>) => Promise<unknown> | unknown;
+let synthesisAdapterForTesting: WalkthroughLlmAdapter | undefined;
+let configuredSynthesisAdapter: WalkthroughLlmAdapter | undefined | null;
+
+export function setPrWalkthroughSynthesisAdapterForTesting(adapter: WalkthroughLlmAdapter | undefined): void {
+	synthesisAdapterForTesting = adapter;
+}
 
 export async function handlePrWalkthroughApiRoute(
 	url: URL,
@@ -146,7 +156,7 @@ export async function handlePrWalkthroughApiRoute(
 				return true;
 			}
 			const result = await submitExport(changesetId, stored.payload, body);
-			json(result, result.ok ? 200 : 400);
+			json(result, result.ok ? 200 : typeof result.status === "number" ? result.status : 400);
 			return true;
 		}
 
@@ -166,8 +176,9 @@ export async function handlePrWalkthroughApiRoute(
 		return true;
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
-		const status = /not found|unknown|invalid|missing|required/i.test(message) ? 400 : 500;
-		fail(status, message);
+		const typed = typedRouteError(err);
+		const status = typed?.status ?? (/not found|unknown|invalid|missing|required/i.test(message) ? 400 : 500);
+		fail(status, message, typed?.extra);
 		return true;
 	}
 }
@@ -230,12 +241,7 @@ async function tryResolveLocalWithModules(cwd: string, baseSha: string, headSha:
 	const warnings = Array.isArray(resolved?.warnings) ? resolved.warnings : [];
 	const changesetId = typeof resolved?.changesetId === "string" ? resolved.changesetId : changesetIdForLocal(changeset?.baseSha ?? baseSha, changeset?.headSha ?? headSha);
 	let cards = Array.isArray(resolved?.cards) ? resolved.cards : undefined;
-	if (!cards) {
-		const synthesisModule = await optionalPrModule("card-synthesis");
-		const synthesize = synthesisModule?.synthesiseWalkthroughCards ?? synthesisModule?.synthesizeWalkthroughCards;
-		if (typeof synthesize === "function") cards = await synthesize(changeset, files, { warnings });
-	}
-	cards ??= synthesizeFallbackCards(changeset, files, warnings);
+	cards ??= await synthesizeCardsForResolver(changeset, files, warnings);
 	return {
 		changesetId,
 		changeset,
@@ -251,12 +257,17 @@ async function tryResolveGithubWithDelegation(input: Record<string, unknown>): P
 	const resolveGithubPr = module?.resolveGithubPr;
 	if (typeof resolveGithubPr !== "function") return undefined;
 	const resolved = await resolveGithubPr(input);
+	return normalizeGithubResolvedWalkthrough(resolved);
+}
+
+export async function normalizeGithubResolvedWalkthrough(resolved: any): Promise<WalkthroughResolveResult | undefined> {
 	if (isResolveResult(resolved)) return resolved;
 	if (!resolved?.changeset) return undefined;
 	const warnings = Array.isArray(resolved.warnings) ? resolved.warnings : [];
+	const files = Array.isArray(resolved.files) ? resolved.files : [];
 	const cards = Array.isArray(resolved.cards)
 		? resolved.cards
-		: synthesizeFallbackCards(resolved.changeset, Array.isArray(resolved.files) ? resolved.files : [], warnings);
+		: await synthesizeCardsForResolver(resolved.changeset, files, warnings);
 	return {
 		changesetId: typeof resolved.changesetId === "string" ? resolved.changesetId : changesetIdForLocal(resolved.changeset.baseSha, resolved.changeset.headSha),
 		changeset: resolved.changeset,
@@ -265,6 +276,44 @@ async function tryResolveGithubWithDelegation(input: Record<string, unknown>): P
 		limits: resolved.limits,
 		export: resolved.export,
 	};
+}
+
+async function synthesizeCardsForResolver(changeset: WalkthroughChangeset, files: any[], warnings: WalkthroughWarning[]): Promise<WalkthroughCard[]> {
+	const synthesisModule = await optionalPrModule("card-synthesis");
+	const synthesize = synthesisModule?.synthesiseWalkthroughCards ?? synthesisModule?.synthesizeWalkthroughCards;
+	if (typeof synthesize === "function") {
+		const llm = await resolveConfiguredSynthesisAdapter();
+		const cards = await synthesize(changeset, files, { warnings, ...(llm ? { allowLlm: true, llm } : {}) });
+		if (Array.isArray(cards) && cards.length > 0) return cards;
+	}
+	return synthesizeFallbackCards(changeset, flattenDiffBlocks(files), warnings);
+}
+
+async function resolveConfiguredSynthesisAdapter(): Promise<WalkthroughLlmAdapter | undefined> {
+	if (synthesisAdapterForTesting) return synthesisAdapterForTesting;
+	if (configuredSynthesisAdapter !== undefined) return configuredSynthesisAdapter ?? undefined;
+	const modulePath = stringValue(process.env.BOBBIT_PR_WALKTHROUGH_SYNTHESIS_ADAPTER);
+	if (!modulePath) {
+		configuredSynthesisAdapter = null;
+		return undefined;
+	}
+	const module = await import(path.isAbsolute(modulePath) ? pathToFileURL(modulePath).href : modulePath);
+	const adapter = module.default ?? module.synthesiseWalkthroughCards ?? module.synthesizeWalkthroughCards ?? module.synthesise;
+	configuredSynthesisAdapter = typeof adapter === "function" ? adapter : null;
+	return configuredSynthesisAdapter ?? undefined;
+}
+
+function flattenDiffBlocks(files: any[]): DiffBlock[] {
+	const blocks: DiffBlock[] = [];
+	for (const file of files) {
+		if (Array.isArray(file?.diffBlocks)) blocks.push(...file.diffBlocks.filter(isDiffBlock));
+		else if (isDiffBlock(file)) blocks.push(file);
+	}
+	return blocks;
+}
+
+function isDiffBlock(value: any): value is DiffBlock {
+	return typeof value?.id === "string" && typeof value?.filePath === "string" && Array.isArray(value?.hunks);
 }
 
 async function resolveLocalFallback(cwd: string, baseSha: string, headSha: string): Promise<WalkthroughResolveResult> {
@@ -475,16 +524,21 @@ function mapComment(comment: any, cards: WalkthroughCard[]): Record<string, unkn
 }
 
 async function submitExport(changesetId: string, payload: WalkthroughResolveResult, body: any): Promise<Record<string, unknown>> {
+	void changesetId;
 	if (payload.export?.provider !== "github" || payload.export.available !== true) {
 		return { ok: false, error: "GitHub review submission is unavailable for this walkthrough", code: "EXPORT_UNAVAILABLE" };
 	}
 	const module = await optionalPrModule("export-mapper");
+	const buildGithubReviewPreview = module?.buildGithubReviewPreview;
 	const submitGithubReview = module?.submitGithubReview;
-	if (typeof submitGithubReview === "function") {
-		return submitGithubReview({ changesetId, draft: body.draft, event: body.event, cards: payload.cards, changeset: payload.changeset }, { confirm: true });
+	if (typeof buildGithubReviewPreview === "function" && typeof submitGithubReview === "function") {
+		const preview = buildGithubReviewPreview(body.draft, payload.cards, payload.changeset);
+		return submitGithubReview(preview, { confirm: true, event: body.event });
 	}
 	return { ok: false, error: "GitHub review submission adapter is unavailable", code: "EXPORT_ADAPTER_UNAVAILABLE" };
 }
+
+export const submitExportForTesting = submitExport;
 
 async function storeWalkthrough(payload: WalkthroughResolveResult): Promise<void> {
 	const module = await optionalPrModule("walkthrough-store");
@@ -523,6 +577,20 @@ function storeDir(): string {
 
 function storePath(changesetId: string): string {
 	return path.join(storeDir(), `${Buffer.from(changesetId).toString("base64url")}.json`);
+}
+
+function typedRouteError(err: unknown): { status: number; extra: Record<string, unknown> } | undefined {
+	if (!err || typeof err !== "object") return undefined;
+	const candidate = err as { status?: unknown; code?: unknown; warnings?: unknown };
+	const status = typeof candidate.status === "number" && candidate.status >= 400 && candidate.status < 600 ? candidate.status : undefined;
+	if (!status && typeof candidate.code !== "string" && !Array.isArray(candidate.warnings)) return undefined;
+	return {
+		status: status ?? 500,
+		extra: {
+			...(typeof candidate.code === "string" ? { code: candidate.code } : {}),
+			...(Array.isArray(candidate.warnings) ? { warnings: candidate.warnings } : {}),
+		},
+	};
 }
 
 async function optionalPrModule(name: string): Promise<any | undefined> {

--- a/src/server/pr-walkthrough/routes.ts
+++ b/src/server/pr-walkthrough/routes.ts
@@ -1,0 +1,606 @@
+import { execFile as execFileCb } from "node:child_process";
+import { promises as fs } from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { bobbitStateDir } from "../bobbit-dir.js";
+
+const execFile = promisify(execFileCb);
+const STORE_SCHEMA_VERSION = 1;
+
+type JsonReader = (req: http.IncomingMessage) => Promise<any>;
+
+type WalkthroughWarning = {
+	code: string;
+	severity: "info" | "warning" | "error";
+	message: string;
+	filePath?: string;
+};
+
+type DiffLine = {
+	id: string;
+	side: "old" | "new" | "context";
+	oldLine?: number;
+	newLine?: number;
+	text: string;
+	kind: "context" | "add" | "del";
+};
+
+type DiffHunk = { id: string; header: string; lines: DiffLine[] };
+type DiffBlock = { id: string; filePath: string; oldPath?: string; status?: string; hunks: DiffHunk[] };
+type WalkthroughCard = {
+	id: string;
+	phaseId: "orientation" | "design" | "significant" | "other" | "audit";
+	title: string;
+	summary: string;
+	rationale?: string;
+	diffBlocks: DiffBlock[];
+	checklist?: string[];
+	cardSuggestions?: string[];
+	suggestedComments?: Array<{ id: string; cardId: string; diffBlockId: string; lineId: string; body: string }>;
+};
+
+type WalkthroughChangeset = {
+	baseSha: string;
+	headSha: string;
+	provider?: string;
+	externalUrl?: string;
+	prUrl?: string;
+	prNumber?: string | number;
+	prTitle?: string;
+	title?: string;
+	filesChanged?: number;
+	additions?: number;
+	deletions?: number;
+};
+
+type WalkthroughResolveResult = {
+	changesetId: string;
+	changeset: WalkthroughChangeset;
+	cards: WalkthroughCard[];
+	warnings: WalkthroughWarning[];
+	limits?: Record<string, unknown>;
+	export?: WalkthroughExportCapability;
+};
+
+type WalkthroughExportCapability = {
+	provider?: string;
+	available: boolean;
+	reason?: string;
+	previewOnly?: boolean;
+};
+
+type StoredWalkthrough = {
+	schemaVersion: number;
+	updatedAt: string;
+	payload: WalkthroughResolveResult;
+};
+
+export type PrWalkthroughRouteDeps = {
+	defaultCwd: string;
+	readBody: JsonReader;
+};
+
+export async function handlePrWalkthroughApiRoute(
+	url: URL,
+	req: http.IncomingMessage,
+	res: http.ServerResponse,
+	deps: PrWalkthroughRouteDeps,
+): Promise<boolean> {
+	if (!url.pathname.startsWith("/api/pr-walkthrough")) return false;
+
+	const json = (data: unknown, status = 200) => {
+		res.writeHead(status, { "Content-Type": "application/json", "Cache-Control": "no-store" });
+		res.end(JSON.stringify(data));
+	};
+	const fail = (status: number, message: string, extra?: Record<string, unknown>) => {
+		json({ error: message, ...extra }, status);
+	};
+
+	try {
+		if (url.pathname === "/api/pr-walkthrough/resolve" && req.method === "POST") {
+			const body = await deps.readBody(req);
+			if (!body || typeof body !== "object") {
+				fail(400, "Invalid resolve request");
+				return true;
+			}
+			const result = await resolveWalkthrough(body, deps);
+			await storeWalkthrough(result);
+			json(result);
+			return true;
+		}
+
+		const previewMatch = url.pathname.match(/^\/api\/pr-walkthrough\/(.+)\/export\/preview$/);
+		if (previewMatch && req.method === "POST") {
+			const changesetId = decodeURIComponent(previewMatch[1]);
+			const stored = await loadWalkthrough(changesetId);
+			if (!stored) {
+				fail(404, `Walkthrough not found: ${changesetId}`);
+				return true;
+			}
+			const draft = await deps.readBody(req);
+			if (!draft || typeof draft !== "object") {
+				fail(400, "Invalid review draft");
+				return true;
+			}
+			json(await buildExportPreview(changesetId, stored.payload, draft));
+			return true;
+		}
+
+		const submitMatch = url.pathname.match(/^\/api\/pr-walkthrough\/(.+)\/export\/submit$/);
+		if (submitMatch && req.method === "POST") {
+			const changesetId = decodeURIComponent(submitMatch[1]);
+			const stored = await loadWalkthrough(changesetId);
+			if (!stored) {
+				fail(404, `Walkthrough not found: ${changesetId}`);
+				return true;
+			}
+			const body = await deps.readBody(req);
+			if (!body || typeof body !== "object") {
+				fail(400, "Invalid export submit request");
+				return true;
+			}
+			if (body.confirm !== true) {
+				fail(400, "Explicit confirmation is required before submitting a GitHub review", { code: "CONFIRMATION_REQUIRED" });
+				return true;
+			}
+			const result = await submitExport(changesetId, stored.payload, body);
+			json(result, result.ok ? 200 : 400);
+			return true;
+		}
+
+		const getMatch = url.pathname.match(/^\/api\/pr-walkthrough\/(.+)$/);
+		if (getMatch && req.method === "GET") {
+			const changesetId = decodeURIComponent(getMatch[1]);
+			const stored = await loadWalkthrough(changesetId);
+			if (!stored) {
+				fail(404, `Walkthrough not found: ${changesetId}`);
+				return true;
+			}
+			json({ ...stored.payload, updatedAt: stored.updatedAt, schemaVersion: stored.schemaVersion });
+			return true;
+		}
+
+		fail(405, "Unsupported PR walkthrough route");
+		return true;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		const status = /not found|unknown|invalid|missing|required/i.test(message) ? 400 : 500;
+		fail(status, message);
+		return true;
+	}
+}
+
+async function resolveWalkthrough(body: Record<string, unknown>, deps: PrWalkthroughRouteDeps): Promise<WalkthroughResolveResult> {
+	if (body.fixture === true) return fixtureWalkthrough();
+
+	const cwd = typeof body.cwd === "string" && body.cwd.trim() ? body.cwd : deps.defaultCwd;
+	const baseSha = stringValue(body.baseSha);
+	const headSha = stringValue(body.headSha);
+	const prUrl = stringValue(body.prUrl);
+	const prNumber = typeof body.prNumber === "number" || typeof body.prNumber === "string" ? body.prNumber : undefined;
+	const wantsGithub = Boolean(prUrl || prNumber || body.provider === "github");
+
+	if (wantsGithub && baseSha && headSha) {
+		const local = await resolveLocalWithDelegation(cwd, baseSha, headSha);
+		const gh = parseGithubRef(prUrl, prNumber, cwd);
+		const head = shortSha(local.changeset.headSha);
+		const changesetId = gh ? changesetIdForGithub(gh.owner, gh.repo, gh.number, head) : `github:unknown#${prNumber ?? "unknown"}:${head}`;
+		return {
+			...local,
+			changesetId,
+			changeset: {
+				...local.changeset,
+				provider: "github",
+				prUrl: prUrl || gh?.url,
+				prNumber: prNumber ?? gh?.number,
+				externalUrl: prUrl || gh?.url,
+				title: gh ? `PR #${gh.number}: ${local.changeset.title ?? "Walkthrough"}` : local.changeset.title,
+			},
+			export: { provider: "github", available: false, previewOnly: true, reason: "GitHub submission requires adapter credentials; preview is available." },
+		};
+	}
+
+	if (wantsGithub) {
+		const delegated = await tryResolveGithubWithDelegation({ cwd, prUrl, prNumber });
+		if (delegated) return delegated;
+		throw new Error("GitHub PR resolution is unavailable without local baseSha/headSha or the GitHub adapter");
+	}
+
+	if (!baseSha || !headSha) throw new Error("baseSha and headSha are required for local walkthrough resolution");
+	return resolveLocalWithDelegation(cwd, baseSha, headSha);
+}
+
+async function resolveLocalWithDelegation(cwd: string, baseSha: string, headSha: string): Promise<WalkthroughResolveResult> {
+	const delegated = await tryResolveLocalWithModules(cwd, baseSha, headSha);
+	if (delegated) return delegated;
+	return resolveLocalFallback(cwd, baseSha, headSha);
+}
+
+async function tryResolveLocalWithModules(cwd: string, baseSha: string, headSha: string): Promise<WalkthroughResolveResult | undefined> {
+	const gitModule = await optionalPrModule("git-changeset");
+	const resolveLocalChangeset = gitModule?.resolveLocalChangeset;
+	if (typeof resolveLocalChangeset !== "function") return undefined;
+	const resolved = await resolveLocalChangeset({ cwd, baseSha, headSha });
+	if (isResolveResult(resolved)) return resolved;
+
+	const changeset = resolved?.changeset ?? resolved?.metadata ?? resolved;
+	const files = Array.isArray(resolved?.files) ? resolved.files : [];
+	const warnings = Array.isArray(resolved?.warnings) ? resolved.warnings : [];
+	const changesetId = typeof resolved?.changesetId === "string" ? resolved.changesetId : changesetIdForLocal(changeset?.baseSha ?? baseSha, changeset?.headSha ?? headSha);
+	let cards = Array.isArray(resolved?.cards) ? resolved.cards : undefined;
+	if (!cards) {
+		const synthesisModule = await optionalPrModule("card-synthesis");
+		const synthesize = synthesisModule?.synthesiseWalkthroughCards ?? synthesisModule?.synthesizeWalkthroughCards;
+		if (typeof synthesize === "function") cards = await synthesize(changeset, files, { warnings });
+	}
+	cards ??= synthesizeFallbackCards(changeset, files, warnings);
+	return {
+		changesetId,
+		changeset,
+		cards,
+		warnings,
+		limits: resolved?.limits,
+		export: resolved?.export ?? { available: false, reason: "Local changesets can be previewed but not submitted to GitHub." },
+	};
+}
+
+async function tryResolveGithubWithDelegation(input: Record<string, unknown>): Promise<WalkthroughResolveResult | undefined> {
+	const module = await optionalPrModule("github-adapter");
+	const resolveGithubPr = module?.resolveGithubPr;
+	if (typeof resolveGithubPr !== "function") return undefined;
+	const resolved = await resolveGithubPr(input);
+	if (isResolveResult(resolved)) return resolved;
+	if (!resolved?.changeset) return undefined;
+	const warnings = Array.isArray(resolved.warnings) ? resolved.warnings : [];
+	const cards = Array.isArray(resolved.cards)
+		? resolved.cards
+		: synthesizeFallbackCards(resolved.changeset, Array.isArray(resolved.files) ? resolved.files : [], warnings);
+	return {
+		changesetId: typeof resolved.changesetId === "string" ? resolved.changesetId : changesetIdForLocal(resolved.changeset.baseSha, resolved.changeset.headSha),
+		changeset: resolved.changeset,
+		cards,
+		warnings,
+		limits: resolved.limits,
+		export: resolved.export,
+	};
+}
+
+async function resolveLocalFallback(cwd: string, baseSha: string, headSha: string): Promise<WalkthroughResolveResult> {
+	const base = await git(cwd, ["rev-parse", "--verify", `${baseSha}^{commit}`]).catch(() => {
+		throw new Error(`Invalid baseSha: ${baseSha}`);
+	});
+	const head = await git(cwd, ["rev-parse", "--verify", `${headSha}^{commit}`]).catch(() => {
+		throw new Error(`Invalid headSha: ${headSha}`);
+	});
+	const fullBase = base.trim();
+	const fullHead = head.trim();
+	const diff = await git(cwd, ["diff", "--no-ext-diff", "--find-renames", "--find-copies", "--binary", "--unified=80", fullBase, fullHead]);
+	const nameStatus = await git(cwd, ["diff", "--name-status", "-M", "-C", fullBase, fullHead]);
+	const shortstat = await git(cwd, ["diff", "--shortstat", fullBase, fullHead]).catch(() => "");
+	const warnings: WalkthroughWarning[] = [];
+	const blocks = parseUnifiedDiff(diff, warnings);
+	applyNameStatus(blocks, nameStatus);
+	const stats = parseShortstat(shortstat, blocks.length);
+	const changeset: WalkthroughChangeset = {
+		baseSha: fullBase,
+		headSha: fullHead,
+		provider: "local",
+		title: `${shortSha(fullBase)}..${shortSha(fullHead)}`,
+		filesChanged: stats.filesChanged,
+		additions: stats.additions,
+		deletions: stats.deletions,
+	};
+	const cards = synthesizeFallbackCards(changeset, blocks, warnings);
+	return {
+		changesetId: changesetIdForLocal(fullBase, fullHead),
+		changeset,
+		cards,
+		warnings,
+		export: { available: false, reason: "Local changesets can be previewed but not submitted to GitHub." },
+	};
+}
+
+function parseUnifiedDiff(diff: string, warnings: WalkthroughWarning[]): DiffBlock[] {
+	const lines = diff.split(/\r?\n/);
+	const blocks: DiffBlock[] = [];
+	let block: DiffBlock | undefined;
+	let hunk: DiffHunk | undefined;
+	let oldLine = 0;
+	let newLine = 0;
+	let hunkIndex = -1;
+
+	for (const raw of lines) {
+		if (raw.startsWith("diff --git ")) {
+			const match = raw.match(/^diff --git a\/(.+) b\/(.+)$/);
+			const filePath = match?.[2] ?? raw.replace(/^diff --git\s+/, "");
+			block = { id: `block-${blocks.length + 1}-${slug(filePath)}`, filePath, oldPath: match?.[1], status: "modified", hunks: [] };
+			blocks.push(block);
+			hunk = undefined;
+			hunkIndex = -1;
+			continue;
+		}
+		if (!block) continue;
+		if (raw.startsWith("new file mode")) block.status = "added";
+		else if (raw.startsWith("deleted file mode")) block.status = "deleted";
+		else if (raw.startsWith("rename from ")) { block.oldPath = raw.slice("rename from ".length); block.status = "renamed"; }
+		else if (raw.startsWith("rename to ")) { block.filePath = raw.slice("rename to ".length); block.id = block.id.replace(/-[^-]*$/, `-${slug(block.filePath)}`); }
+		else if (raw.startsWith("copy from ")) { block.oldPath = raw.slice("copy from ".length); block.status = "copied"; }
+		else if (raw.startsWith("Binary files ")) {
+			block.status = "binary";
+			warnings.push({ code: "binary-file", severity: "warning", message: `Binary file cannot be rendered: ${block.filePath}`, filePath: block.filePath });
+		}
+		else if (raw.startsWith("--- ")) {
+			const p = raw.slice(4).trim();
+			if (p.startsWith("a/")) block.oldPath = p.slice(2);
+		}
+		else if (raw.startsWith("+++ ")) {
+			const p = raw.slice(4).trim();
+			if (p.startsWith("b/")) block.filePath = p.slice(2);
+		}
+		else if (raw.startsWith("@@ ")) {
+			const match = raw.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+			oldLine = match ? Number(match[1]) : 0;
+			newLine = match ? Number(match[2]) : 0;
+			hunkIndex += 1;
+			hunk = { id: `${block.id}-h${hunkIndex + 1}`, header: raw, lines: [] };
+			block.hunks.push(hunk);
+		}
+		else if (hunk && (raw.startsWith(" ") || raw.startsWith("+") || raw.startsWith("-"))) {
+			const lineIndex = hunk.lines.length;
+			const prefix = raw[0];
+			const text = raw.slice(1);
+			if (prefix === " ") {
+				hunk.lines.push({ id: `${block.id}:h${hunkIndex}:l${lineIndex}`, side: "context", oldLine, newLine, kind: "context", text });
+				oldLine += 1;
+				newLine += 1;
+			} else if (prefix === "+") {
+				hunk.lines.push({ id: `${block.id}:h${hunkIndex}:l${lineIndex}`, side: "new", newLine, kind: "add", text });
+				newLine += 1;
+			} else {
+				hunk.lines.push({ id: `${block.id}:h${hunkIndex}:l${lineIndex}`, side: "old", oldLine, kind: "del", text });
+				oldLine += 1;
+			}
+		}
+	}
+	return blocks;
+}
+
+function applyNameStatus(blocks: DiffBlock[], nameStatus: string): void {
+	for (const line of nameStatus.split(/\r?\n/)) {
+		if (!line.trim()) continue;
+		const parts = line.split("\t");
+		const code = parts[0];
+		const status = code.startsWith("R") ? "renamed"
+			: code.startsWith("C") ? "copied"
+			: code === "A" ? "added"
+			: code === "D" ? "deleted"
+			: code === "M" ? "modified"
+			: undefined;
+		const filePath = parts.at(-1);
+		const block = blocks.find(item => item.filePath === filePath || item.oldPath === filePath);
+		if (block && status) {
+			block.status = block.status === "binary" ? "binary" : status;
+			if ((status === "renamed" || status === "copied") && parts[1]) block.oldPath = parts[1];
+		}
+	}
+}
+
+function synthesizeFallbackCards(changeset: WalkthroughChangeset, files: DiffBlock[], warnings: WalkthroughWarning[]): WalkthroughCard[] {
+	const cards: WalkthroughCard[] = [{
+		id: "orientation-summary",
+		phaseId: "orientation",
+		title: changeset.title ? `Review ${changeset.title}` : "Review changeset",
+		summary: `${changeset.filesChanged ?? files.length} files changed with ${changeset.additions ?? 0} additions and ${changeset.deletions ?? 0} deletions.`,
+		rationale: warnings.length ? `${warnings.length} warnings need reviewer attention.` : "Generated from the resolved changeset.",
+		diffBlocks: files.slice(0, 1),
+		checklist: ["Confirm scope", "Check generated warnings", "Review changed files"],
+	}];
+	if (files.length > 0) {
+		const reviewBlocks = files.filter(file => file.status !== "binary");
+		cards.push({
+			id: "significant-files",
+			phaseId: "significant",
+			title: "Changed files",
+			summary: `Review ${reviewBlocks.length || files.length} diff-backed file${(reviewBlocks.length || files.length) === 1 ? "" : "s"}.`,
+			diffBlocks: reviewBlocks.length ? reviewBlocks : files,
+		});
+		cards.push({
+			id: "audit-coverage",
+			phaseId: "audit",
+			title: "Audit remaining coverage",
+			summary: "Final pass over the resolved diff and any unreviewable files.",
+			diffBlocks: files,
+			cardSuggestions: warnings.map(warning => warning.message),
+		});
+	}
+	return cards;
+}
+
+async function buildExportPreview(changesetId: string, payload: WalkthroughResolveResult, draft: any): Promise<Record<string, unknown>> {
+	const delegated = await tryBuildExportPreview(changesetId, payload, draft);
+	if (delegated) return delegated;
+
+	const comments = Array.isArray(draft.comments) ? draft.comments : [];
+	const rows = comments.map((comment: any) => mapComment(comment, payload.cards));
+	const cardComments = comments.filter((comment: any) => !comment.diffBlockId && !comment.lineId);
+	const body = [
+		`Review draft for ${payload.changeset.title ?? changesetId}`,
+		...cardComments.map((comment: any) => {
+			const card = payload.cards.find(item => item.id === comment.cardId);
+			return `- ${card?.title ?? comment.cardId}: ${comment.body ?? ""}`;
+		}),
+	].join("\n");
+	return {
+		changesetId,
+		provider: payload.changeset.provider,
+		available: payload.export?.available ?? false,
+		canSubmit: Boolean(payload.export?.available && payload.export.provider === "github" && rows.some((row: any) => row.valid)),
+		body,
+		rows,
+		warnings: rows.filter((row: any) => !row.valid).map((row: any) => ({ code: "unmappable-comment", severity: "warning", message: row.reason, commentId: row.commentId })),
+	};
+}
+
+async function tryBuildExportPreview(changesetId: string, payload: WalkthroughResolveResult, draft: any): Promise<Record<string, unknown> | undefined> {
+	const module = await optionalPrModule("export-mapper");
+	const buildGithubReviewPreview = module?.buildGithubReviewPreview;
+	if (typeof buildGithubReviewPreview !== "function") return undefined;
+	return buildGithubReviewPreview(draft, payload.cards, payload.changeset, { changesetId, export: payload.export });
+}
+
+function mapComment(comment: any, cards: WalkthroughCard[]): Record<string, unknown> {
+	if (!comment?.diffBlockId || !comment?.lineId) {
+		return { commentId: comment?.id, body: comment?.body ?? "", valid: false, reason: "Card-level comments are included in the review body." };
+	}
+	const card = cards.find(item => item.id === comment.cardId);
+	const block = card?.diffBlocks.find(item => item.id === comment.diffBlockId);
+	const line = block?.hunks.flatMap(hunk => hunk.lines).find(item => item.id === comment.lineId);
+	if (!card || !block || !line) {
+		return { commentId: comment.id, body: comment.body ?? "", valid: false, reason: "Comment anchor no longer maps to a resolved diff line." };
+	}
+	const lineNumber = line.newLine ?? line.oldLine;
+	if (!lineNumber) {
+		return { commentId: comment.id, path: block.filePath, body: comment.body ?? "", valid: false, reason: "Diff line has no GitHub-reviewable line number." };
+	}
+	return {
+		commentId: comment.id,
+		path: block.filePath,
+		side: line.side === "old" ? "LEFT" : "RIGHT",
+		line: lineNumber,
+		body: comment.body ?? "",
+		valid: true,
+	};
+}
+
+async function submitExport(changesetId: string, payload: WalkthroughResolveResult, body: any): Promise<Record<string, unknown>> {
+	const module = await optionalPrModule("export-mapper");
+	const submitGithubReview = module?.submitGithubReview;
+	if (typeof submitGithubReview === "function") {
+		return submitGithubReview({ changesetId, draft: body.draft, event: body.event, cards: payload.cards, changeset: payload.changeset }, { confirm: true });
+	}
+	if (payload.export?.provider !== "github" || payload.export.available !== true) {
+		return { ok: false, error: "GitHub review submission is unavailable for this walkthrough", code: "EXPORT_UNAVAILABLE" };
+	}
+	return { ok: false, error: "GitHub review submission adapter is unavailable", code: "EXPORT_ADAPTER_UNAVAILABLE" };
+}
+
+async function storeWalkthrough(payload: WalkthroughResolveResult): Promise<void> {
+	const module = await optionalPrModule("walkthrough-store");
+	const store = module?.storeWalkthrough ?? module?.saveWalkthrough;
+	if (typeof store === "function") {
+		await store(payload);
+		return;
+	}
+	const stored: StoredWalkthrough = { schemaVersion: STORE_SCHEMA_VERSION, updatedAt: new Date().toISOString(), payload };
+	await fs.mkdir(storeDir(), { recursive: true });
+	await fs.writeFile(storePath(payload.changesetId), JSON.stringify(stored, null, 2), "utf-8");
+}
+
+async function loadWalkthrough(changesetId: string): Promise<StoredWalkthrough | undefined> {
+	const module = await optionalPrModule("walkthrough-store");
+	const load = module?.loadWalkthrough ?? module?.getWalkthrough;
+	if (typeof load === "function") {
+		const loaded = await load(changesetId);
+		if (loaded?.payload) return loaded;
+		if (loaded?.changesetId) return { schemaVersion: STORE_SCHEMA_VERSION, updatedAt: loaded.updatedAt ?? new Date().toISOString(), payload: loaded };
+	}
+	try {
+		const raw = await fs.readFile(storePath(changesetId), "utf-8");
+		const parsed = JSON.parse(raw) as StoredWalkthrough;
+		if (parsed.schemaVersion !== STORE_SCHEMA_VERSION) return undefined;
+		return parsed;
+	} catch (err: any) {
+		if (err?.code === "ENOENT") return undefined;
+		throw err;
+	}
+}
+
+function storeDir(): string {
+	return path.join(bobbitStateDir(), "pr-walkthrough");
+}
+
+function storePath(changesetId: string): string {
+	return path.join(storeDir(), `${Buffer.from(changesetId).toString("base64url")}.json`);
+}
+
+async function optionalPrModule(name: string): Promise<any | undefined> {
+	try {
+		return await import(`./${name}.js`);
+	} catch (err: any) {
+		if (err?.code === "ERR_MODULE_NOT_FOUND" || /Cannot find module|module not found/i.test(String(err?.message))) return undefined;
+		throw err;
+	}
+}
+
+function isResolveResult(value: any): value is WalkthroughResolveResult {
+	return typeof value?.changesetId === "string" && value?.changeset && Array.isArray(value?.cards) && Array.isArray(value?.warnings);
+}
+
+async function git(cwd: string, args: string[]): Promise<string> {
+	const { stdout } = await execFile("git", args, { cwd, maxBuffer: 20 * 1024 * 1024 });
+	return stdout;
+}
+
+function parseShortstat(shortstat: string, fallbackFiles: number): { filesChanged: number; additions: number; deletions: number } {
+	return {
+		filesChanged: Number(shortstat.match(/(\d+) files? changed/)?.[1] ?? fallbackFiles),
+		additions: Number(shortstat.match(/(\d+) insertions?\(\+\)/)?.[1] ?? 0),
+		deletions: Number(shortstat.match(/(\d+) deletions?\(-\)/)?.[1] ?? 0),
+	};
+}
+
+function changesetIdForLocal(baseSha: string, headSha: string): string {
+	return `${shortSha(baseSha)}..${shortSha(headSha)}`;
+}
+
+function changesetIdForGithub(owner: string, repo: string, number: string | number, headSha?: string): string {
+	return `github:${owner}/${repo}#${number}:${headSha || "unknown"}`;
+}
+
+function shortSha(sha: string): string {
+	return sha.slice(0, 7);
+}
+
+function slug(value: string): string {
+	const clean = value.replace(/[^a-z0-9._-]+/gi, "-").replace(/^-+|-+$/g, "").slice(0, 48);
+	return clean || "file";
+}
+
+function stringValue(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function parseGithubRef(prUrl: string | undefined, prNumber: string | number | undefined, cwd: string): { owner: string; repo: string; number: string | number; url: string } | undefined {
+	if (prUrl) {
+		const match = prUrl.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/i);
+		if (match) return { owner: match[1], repo: match[2], number: prNumber ?? match[3], url: prUrl };
+	}
+	void cwd;
+	return undefined;
+}
+
+function fixtureWalkthrough(): WalkthroughResolveResult {
+	const changeset: WalkthroughChangeset = {
+		baseSha: "fixture-base",
+		headSha: "fixture-head",
+		provider: "fixture",
+		title: "Fixture PR walkthrough",
+		filesChanged: 1,
+		additions: 1,
+		deletions: 0,
+	};
+	const block: DiffBlock = {
+		id: "fixture-block",
+		filePath: "README.md",
+		hunks: [{ id: "fixture-block-h1", header: "@@ -0,0 +1 @@", lines: [{ id: "fixture-block:h0:l0", side: "new", newLine: 1, kind: "add", text: "Fixture walkthrough" }] }],
+	};
+	return {
+		changesetId: "fixture-base..fixture-head",
+		changeset,
+		cards: [{ id: "orientation-summary", phaseId: "orientation", title: "Fixture walkthrough", summary: "Fixture-backed walkthrough for tests and development.", diffBlocks: [block] }],
+		warnings: [],
+		export: { available: false, reason: "Fixture walkthroughs cannot be submitted." },
+	};
+}

--- a/src/server/pr-walkthrough/routes.ts
+++ b/src/server/pr-walkthrough/routes.ts
@@ -475,13 +475,13 @@ function mapComment(comment: any, cards: WalkthroughCard[]): Record<string, unkn
 }
 
 async function submitExport(changesetId: string, payload: WalkthroughResolveResult, body: any): Promise<Record<string, unknown>> {
+	if (payload.export?.provider !== "github" || payload.export.available !== true) {
+		return { ok: false, error: "GitHub review submission is unavailable for this walkthrough", code: "EXPORT_UNAVAILABLE" };
+	}
 	const module = await optionalPrModule("export-mapper");
 	const submitGithubReview = module?.submitGithubReview;
 	if (typeof submitGithubReview === "function") {
 		return submitGithubReview({ changesetId, draft: body.draft, event: body.event, cards: payload.cards, changeset: payload.changeset }, { confirm: true });
-	}
-	if (payload.export?.provider !== "github" || payload.export.available !== true) {
-		return { ok: false, error: "GitHub review submission is unavailable for this walkthrough", code: "EXPORT_UNAVAILABLE" };
 	}
 	return { ok: false, error: "GitHub review submission adapter is unavailable", code: "EXPORT_ADAPTER_UNAVAILABLE" };
 }

--- a/src/server/pr-walkthrough/walkthrough-store.ts
+++ b/src/server/pr-walkthrough/walkthrough-store.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { bobbitStateDir } from "../bobbit-dir.js";
+
 // The shared PR walkthrough model is produced by the upstream model task. Keep this
 // import pointed at that contract while retaining local structural types so this
 // module can be validated independently when the shared file is not present yet.
@@ -69,6 +71,22 @@ interface StoredWalkthroughFile {
 }
 
 const STORE_DIR = "pr-walkthrough";
+
+export function storeWalkthrough(payload: WalkthroughStorePayload, stateDir = bobbitStateDir()): StoredWalkthroughPayload {
+	return new WalkthroughStore(stateDir).save(payload);
+}
+
+export function saveWalkthrough(payload: WalkthroughStorePayload, stateDir = bobbitStateDir()): StoredWalkthroughPayload {
+	return storeWalkthrough(payload, stateDir);
+}
+
+export function loadWalkthrough(changesetId: string, stateDir = bobbitStateDir()): StoredWalkthroughPayload | null {
+	return new WalkthroughStore(stateDir).get(changesetId);
+}
+
+export function getWalkthrough(changesetId: string, stateDir = bobbitStateDir()): StoredWalkthroughPayload | null {
+	return loadWalkthrough(changesetId, stateDir);
+}
 
 export class WalkthroughStore {
 	private readonly rootDir: string;

--- a/src/server/pr-walkthrough/walkthrough-store.ts
+++ b/src/server/pr-walkthrough/walkthrough-store.ts
@@ -1,0 +1,192 @@
+import fs from "node:fs";
+import path from "node:path";
+
+// The shared PR walkthrough model is produced by the upstream model task. Keep this
+// import pointed at that contract while retaining local structural types so this
+// module can be validated independently when the shared file is not present yet.
+// @ts-ignore Upstream shared model may be absent on this parallel task branch.
+import type { PrWalkthroughCard as SharedPrWalkthroughCard, PrWalkthroughChangesetRef as SharedPrWalkthroughChangesetRef, WalkthroughExportCapability as SharedWalkthroughExportCapability, WalkthroughLimits as SharedWalkthroughLimits, WalkthroughWarning as SharedWalkthroughWarning } from "../../shared/pr-walkthrough/types.js";
+
+type PreserveShared<T> = unknown extends T ? unknown : T;
+
+type PrWalkthroughChangesetRef = {
+	baseSha: string;
+	headSha: string;
+	provider?: string;
+	externalUrl?: string;
+	prUrl?: string;
+	prNumber?: string | number;
+	prTitle?: string;
+	title?: string;
+	filesChanged?: number;
+	additions?: number;
+	deletions?: number;
+} & PreserveShared<SharedPrWalkthroughChangesetRef>;
+
+type PrWalkthroughCard = {
+	id: string;
+	phaseId: string;
+	title: string;
+	summary: string;
+	diffBlocks: unknown[];
+} & PreserveShared<SharedPrWalkthroughCard>;
+
+type WalkthroughWarning = {
+	code: string;
+	severity: "info" | "warning" | "error";
+	message: string;
+	filePath?: string;
+} & PreserveShared<SharedWalkthroughWarning>;
+
+type WalkthroughLimits = Record<string, unknown> & PreserveShared<SharedWalkthroughLimits>;
+type WalkthroughExportCapability = Record<string, unknown> & PreserveShared<SharedWalkthroughExportCapability>;
+
+export const WALKTHROUGH_STORE_SCHEMA_VERSION = 1;
+
+export interface WalkthroughStorePayload {
+	changesetId: string;
+	changeset: PrWalkthroughChangesetRef;
+	cards: PrWalkthroughCard[];
+	warnings: WalkthroughWarning[];
+	limits?: WalkthroughLimits;
+	export?: WalkthroughExportCapability;
+}
+
+export interface StoredWalkthroughPayload extends WalkthroughStorePayload {
+	schemaVersion: typeof WALKTHROUGH_STORE_SCHEMA_VERSION;
+	updatedAt: string;
+}
+
+interface StoredWalkthroughFile {
+	schemaVersion?: unknown;
+	updatedAt?: unknown;
+	changesetId?: unknown;
+	changeset?: unknown;
+	cards?: unknown;
+	warnings?: unknown;
+	limits?: unknown;
+	export?: unknown;
+}
+
+const STORE_DIR = "pr-walkthrough";
+
+export class WalkthroughStore {
+	private readonly rootDir: string;
+
+	constructor(stateDir: string) {
+		this.rootDir = path.join(stateDir, STORE_DIR, `v${WALKTHROUGH_STORE_SCHEMA_VERSION}`);
+	}
+
+	save(payload: WalkthroughStorePayload): StoredWalkthroughPayload {
+		const stored: StoredWalkthroughPayload = sanitizePayload({
+			...payload,
+			warnings: payload.warnings ?? [],
+			schemaVersion: WALKTHROUGH_STORE_SCHEMA_VERSION,
+			updatedAt: new Date().toISOString(),
+		});
+		this.ensureDir();
+		fs.writeFileSync(this.filePath(payload.changesetId), `${JSON.stringify(stored, null, 2)}\n`, "utf-8");
+		return stored;
+	}
+
+	get(changesetId: string): StoredWalkthroughPayload | null {
+		try {
+			const raw = JSON.parse(fs.readFileSync(this.filePath(changesetId), "utf-8")) as StoredWalkthroughFile;
+			return parseStoredPayload(raw, changesetId);
+		} catch (error) {
+			if (isNodeError(error) && error.code === "ENOENT") return null;
+			return null;
+		}
+	}
+
+	delete(changesetId: string): boolean {
+		try {
+			fs.unlinkSync(this.filePath(changesetId));
+			return true;
+		} catch (error) {
+			if (isNodeError(error) && error.code === "ENOENT") return false;
+			return false;
+		}
+	}
+
+	list(): StoredWalkthroughPayload[] {
+		try {
+			return fs.readdirSync(this.rootDir, { withFileTypes: true })
+				.filter(entry => entry.isFile() && entry.name.endsWith(".json"))
+				.map(entry => this.readFile(path.join(this.rootDir, entry.name)))
+				.filter((payload): payload is StoredWalkthroughPayload => payload !== null)
+				.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+		} catch (error) {
+			if (isNodeError(error) && error.code === "ENOENT") return [];
+			return [];
+		}
+	}
+
+	private readFile(filePath: string): StoredWalkthroughPayload | null {
+		try {
+			const raw = JSON.parse(fs.readFileSync(filePath, "utf-8")) as StoredWalkthroughFile;
+			return parseStoredPayload(raw);
+		} catch {
+			return null;
+		}
+	}
+
+	private ensureDir(): void {
+		fs.mkdirSync(this.rootDir, { recursive: true });
+	}
+
+	private filePath(changesetId: string): string {
+		return path.join(this.rootDir, `${storageKeyForChangesetId(changesetId)}.json`);
+	}
+}
+
+export function storageKeyForChangesetId(changesetId: string): string {
+	return Buffer.from(changesetId, "utf-8").toString("base64url");
+}
+
+function parseStoredPayload(raw: StoredWalkthroughFile, expectedChangesetId?: string): StoredWalkthroughPayload | null {
+	if (raw.schemaVersion !== WALKTHROUGH_STORE_SCHEMA_VERSION) return null;
+	if (typeof raw.updatedAt !== "string" || typeof raw.changesetId !== "string") return null;
+	if (expectedChangesetId && raw.changesetId !== expectedChangesetId) return null;
+	if (!isRecord(raw.changeset) || !Array.isArray(raw.cards)) return null;
+	const warnings = Array.isArray(raw.warnings) ? raw.warnings : [];
+	return sanitizePayload({
+		changesetId: raw.changesetId,
+		changeset: raw.changeset as PrWalkthroughChangesetRef,
+		cards: raw.cards as PrWalkthroughCard[],
+		warnings: warnings as WalkthroughWarning[],
+		limits: isRecord(raw.limits) ? raw.limits as WalkthroughLimits : undefined,
+		export: isRecord(raw.export) ? raw.export as WalkthroughExportCapability : undefined,
+		schemaVersion: WALKTHROUGH_STORE_SCHEMA_VERSION,
+		updatedAt: raw.updatedAt,
+	});
+}
+
+function sanitizePayload(payload: StoredWalkthroughPayload): StoredWalkthroughPayload {
+	const sanitized = sanitizeValue(payload) as StoredWalkthroughPayload;
+	return sanitized;
+}
+
+function sanitizeValue(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(item => sanitizeValue(item));
+	if (!isRecord(value)) return value;
+	const out: Record<string, unknown> = {};
+	for (const [key, entry] of Object.entries(value)) {
+		if (isSensitiveKey(key)) continue;
+		out[key] = sanitizeValue(entry);
+	}
+	return out;
+}
+
+function isSensitiveKey(key: string): boolean {
+	return /(^|[-_])(token|secret|authorization|auth[-_]?header|auth[-_]?headers|raw[-_]?headers|headers?)($|[-_])/i.test(key)
+		|| /^(token|secret|authorization|auth|headers)$/i.test(key);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+	return error instanceof Error && "code" in error;
+}

--- a/src/server/pr-walkthrough/walkthrough-store.ts
+++ b/src/server/pr-walkthrough/walkthrough-store.ts
@@ -152,11 +152,11 @@ function parseStoredPayload(raw: StoredWalkthroughFile, expectedChangesetId?: st
 	const warnings = Array.isArray(raw.warnings) ? raw.warnings : [];
 	return sanitizePayload({
 		changesetId: raw.changesetId,
-		changeset: raw.changeset as PrWalkthroughChangesetRef,
-		cards: raw.cards as PrWalkthroughCard[],
-		warnings: warnings as WalkthroughWarning[],
-		limits: isRecord(raw.limits) ? raw.limits as WalkthroughLimits : undefined,
-		export: isRecord(raw.export) ? raw.export as WalkthroughExportCapability : undefined,
+		changeset: raw.changeset as unknown as PrWalkthroughChangesetRef,
+		cards: raw.cards as unknown as PrWalkthroughCard[],
+		warnings: warnings as unknown as WalkthroughWarning[],
+		limits: isRecord(raw.limits) ? raw.limits as unknown as WalkthroughLimits : undefined,
+		export: isRecord(raw.export) ? raw.export as unknown as WalkthroughExportCapability : undefined,
 		schemaVersion: WALKTHROUGH_STORE_SCHEMA_VERSION,
 		updatedAt: raw.updatedAt,
 	});

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1994,7 +1994,20 @@ async function handleApiRoute(
 		json({ error: e.message, stack: e.stack, ...extra }, status);
 	};
 
-	if (await handlePrWalkthroughApiRoute(url, req, res, { defaultCwd: config.defaultCwd, readBody })) return;
+	if (await handlePrWalkthroughApiRoute(url, req, res, {
+		defaultCwd: config.defaultCwd,
+		readBody,
+		resolveSessionCwd: (sessionId: string) => {
+			const live = sessionManager.getSession(sessionId);
+			const persisted = sessionManager.getPersistedSession(sessionId);
+			return live?.worktreePath || persisted?.worktreePath || live?.cwd || persisted?.cwd;
+		},
+		resolveSessionModel: (sessionId: string) => {
+			const persisted = sessionManager.getPersistedSession(sessionId);
+			return persisted?.modelProvider && persisted.modelId ? `${persisted.modelProvider}/${persisted.modelId}` : undefined;
+		},
+		preferencesStore,
+	})) return;
 
 	// ── Cross-project helper functions ─────────────────────────────
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -145,6 +145,7 @@ import { validateSandboxMounts } from "./agent/sandbox-mounts.js";
 import { SandboxTokenStore, type SandboxScope } from "./auth/sandbox-token.js";
 import { CookieStore, issueIfMissing as issueCookieIfMissing, tryAuth as cookieTryAuth } from "./auth/cookie.js";
 import { handlePreviewRequest } from "./preview/content-route.js";
+import { handlePrWalkthroughApiRoute } from "./pr-walkthrough/routes.js";
 import { progressBus as searchProgressBus } from "./search/progress-bus.js";
 import { isSandboxAllowed } from "./auth/sandbox-guard.js";
 import * as previewMount from "./preview/mount.js";
@@ -1992,6 +1993,8 @@ async function handleApiRoute(
 		const e = err instanceof Error ? err : new Error(String(err));
 		json({ error: e.message, stack: e.stack, ...extra }, status);
 	};
+
+	if (await handlePrWalkthroughApiRoute(url, req, res, { defaultCwd: config.defaultCwd, readBody })) return;
 
 	// ── Cross-project helper functions ─────────────────────────────
 

--- a/src/shared/pr-walkthrough/draft.ts
+++ b/src/shared/pr-walkthrough/draft.ts
@@ -1,0 +1,67 @@
+import type {
+	PrWalkthroughCard,
+	PrWalkthroughChangesetRef,
+	PrWalkthroughComment,
+	PrWalkthroughDiffLine,
+	PrWalkthroughDraftState,
+	PrWalkthroughReviewDraft,
+} from "./types.js";
+
+export interface PrWalkthroughCommentAnchor {
+	comment: PrWalkthroughComment;
+	card: PrWalkthroughCard;
+	filePath?: string;
+	oldPath?: string;
+	line?: PrWalkthroughDiffLine;
+	side?: "LEFT" | "RIGHT";
+	lineNumber?: number;
+}
+
+export function buildPrWalkthroughDraft(state: PrWalkthroughDraftState): PrWalkthroughReviewDraft {
+	return {
+		changeset: state.changeset ?? fixtureDraftChangeset(),
+		decisions: { ...state.decisions },
+		comments: state.comments.map(comment => ({ ...comment })),
+		completedCardIds: [...state.completedCardIds],
+		updatedAt: new Date().toISOString(),
+	};
+}
+
+export function cardRequiresCommentForDislike(state: Pick<PrWalkthroughDraftState, "comments">, cardId: string): boolean {
+	return !state.comments.some(comment => comment.cardId === cardId && comment.body.trim().length > 0);
+}
+
+export function defaultDiffModeForWidth(width: number): "split" | "inline" {
+	return width >= 760 ? "split" : "inline";
+}
+
+export function mapDraftCommentsToAnchors(draft: PrWalkthroughReviewDraft, cards: PrWalkthroughCard[]): PrWalkthroughCommentAnchor[] {
+	void draft;
+	const cardsById = new Map(cards.map(card => [card.id, card]));
+	return draft.comments.flatMap(comment => {
+		const card = cardsById.get(comment.cardId);
+		if (!card) return [];
+		const block = comment.diffBlockId ? card.diffBlocks.find(candidate => candidate.id === comment.diffBlockId) : undefined;
+		const line = block && comment.lineId
+			? block.hunks.flatMap(hunk => hunk.lines).find(candidate => candidate.id === comment.lineId)
+			: undefined;
+		const side = line?.kind === "del" ? "LEFT" : line ? "RIGHT" : undefined;
+		return [{
+			comment,
+			card,
+			filePath: block?.filePath,
+			oldPath: block?.oldPath,
+			line,
+			side,
+			lineNumber: side === "LEFT" ? line?.oldLine : line?.newLine,
+		}];
+	});
+}
+
+function fixtureDraftChangeset(): PrWalkthroughChangesetRef {
+	return {
+		baseSha: "fixture-base",
+		headSha: "fixture-head",
+		title: "Fixture PR walkthrough",
+	};
+}

--- a/src/shared/pr-walkthrough/generated-path.ts
+++ b/src/shared/pr-walkthrough/generated-path.ts
@@ -1,0 +1,14 @@
+export function isLikelyGeneratedPath(filePath: string): boolean {
+	const normalized = filePath.replace(/\\/g, "/").toLowerCase();
+	return normalized.startsWith("dist/")
+		|| normalized.includes("/dist/")
+		|| normalized.includes("/generated/")
+		|| normalized.includes("__snapshots__/")
+		|| normalized.endsWith(".snap")
+		|| normalized.endsWith("package-lock.json")
+		|| normalized.endsWith("pnpm-lock.yaml")
+		|| normalized.endsWith("yarn.lock")
+		|| normalized.endsWith("bun.lockb")
+		|| normalized.endsWith(".min.js")
+		|| normalized.endsWith(".min.css");
+}

--- a/src/shared/pr-walkthrough/ids.ts
+++ b/src/shared/pr-walkthrough/ids.ts
@@ -1,0 +1,42 @@
+const SHORT_SHA_LENGTH = 8;
+
+export function shortSha(value: string | undefined, length = SHORT_SHA_LENGTH): string {
+	const trimmed = (value ?? "").trim();
+	if (!trimmed) return "unknown";
+	return trimmed.slice(0, Math.min(length, trimmed.length));
+}
+
+export function changesetIdForLocal(baseSha: string, headSha: string): string {
+	return `${shortSha(baseSha)}..${shortSha(headSha)}`;
+}
+
+export function changesetIdForGithub(owner: string, repo: string, number: string | number, headSha?: string): string {
+	return `github:${owner.trim()}/${repo.trim()}#${String(number).trim()}:${headSha ? shortSha(headSha) : "unknown"}`;
+}
+
+export function stableSlug(value: string): string {
+	return value
+		.trim()
+		.replace(/\\/g, "/")
+		.replace(/[^a-zA-Z0-9._/-]+/g, "-")
+		.replace(/\/+/g, "/")
+		.replace(/^-+|-+$/g, "")
+		.replace(/\//g, "__")
+		.slice(0, 96) || "item";
+}
+
+export function walkthroughCardId(phaseId: string, title: string, index = 0): string {
+	return `${phaseId}-${stableSlug(title).toLowerCase()}-${index + 1}`;
+}
+
+export function diffBlockIdForFile(filePath: string, index = 0): string {
+	return `block:${index + 1}:${stableSlug(filePath)}`;
+}
+
+export function hunkIdForBlock(blockId: string, hunkIndex: number): string {
+	return `${blockId}:h${hunkIndex}`;
+}
+
+export function lineIdForHunk(blockId: string, hunkIndex: number, lineIndex: number): string {
+	return `${blockId}:h${hunkIndex}:l${lineIndex}`;
+}

--- a/src/shared/pr-walkthrough/ids.ts
+++ b/src/shared/pr-walkthrough/ids.ts
@@ -1,4 +1,4 @@
-const SHORT_SHA_LENGTH = 8;
+const SHORT_SHA_LENGTH = 7;
 
 export function shortSha(value: string | undefined, length = SHORT_SHA_LENGTH): string {
 	const trimmed = (value ?? "").trim();

--- a/src/shared/pr-walkthrough/index.ts
+++ b/src/shared/pr-walkthrough/index.ts
@@ -1,0 +1,3 @@
+export * from "./types.js";
+export * from "./ids.js";
+export * from "./draft.js";

--- a/src/shared/pr-walkthrough/index.ts
+++ b/src/shared/pr-walkthrough/index.ts
@@ -1,3 +1,4 @@
 export * from "./types.js";
 export * from "./ids.js";
 export * from "./draft.js";
+export * from "./generated-path.js";

--- a/src/shared/pr-walkthrough/types.ts
+++ b/src/shared/pr-walkthrough/types.ts
@@ -1,0 +1,175 @@
+export interface PrWalkthroughChangesetRef {
+	baseSha: string;
+	headSha: string;
+	provider?: string;
+	externalUrl?: string;
+	prUrl?: string;
+	prNumber?: string | number;
+	prTitle?: string;
+	title?: string;
+	filesChanged?: number;
+	additions?: number;
+	deletions?: number;
+}
+
+export type PrWalkthroughPhaseId = "orientation" | "design" | "significant" | "other" | "audit";
+
+export type PrWalkthroughDiffLineSide = "old" | "new" | "context";
+export type PrWalkthroughDiffLineKind = "context" | "add" | "del";
+export type PrWalkthroughDiffMode = "split" | "inline";
+
+export interface PrWalkthroughDiffLine {
+	id: string;
+	side: PrWalkthroughDiffLineSide;
+	oldLine?: number;
+	newLine?: number;
+	text: string;
+	kind: PrWalkthroughDiffLineKind;
+}
+
+export interface PrWalkthroughHunk {
+	id: string;
+	header: string;
+	lines: PrWalkthroughDiffLine[];
+}
+
+export interface PrWalkthroughDiffBlock {
+	id: string;
+	filePath: string;
+	oldPath?: string;
+	hunks: PrWalkthroughHunk[];
+}
+
+export interface PrWalkthroughSuggestedComment {
+	id: string;
+	cardId: string;
+	diffBlockId: string;
+	lineId: string;
+	body: string;
+}
+
+export interface PrWalkthroughCard {
+	id: string;
+	phaseId: PrWalkthroughPhaseId;
+	title: string;
+	summary: string;
+	rationale?: string;
+	diffBlocks: PrWalkthroughDiffBlock[];
+	suggestedComments?: PrWalkthroughSuggestedComment[];
+	cardSuggestions?: string[];
+	checklist?: string[];
+}
+
+export interface PrWalkthroughComment {
+	id: string;
+	cardId: string;
+	diffBlockId?: string;
+	lineId?: string;
+	body: string;
+	source: "custom" | "suggested";
+	createdAt: string;
+	updatedAt?: string;
+}
+
+export interface PrWalkthroughDecision {
+	cardId: string;
+	value: "liked" | "disliked";
+	commentIds: string[];
+	updatedAt: string;
+}
+
+export interface PrWalkthroughReviewDraft {
+	changeset: PrWalkthroughChangesetRef;
+	decisions: Record<string, PrWalkthroughDecision>;
+	comments: PrWalkthroughComment[];
+	completedCardIds: string[];
+	updatedAt: string;
+}
+
+export interface PrWalkthroughDraftState {
+	changeset?: PrWalkthroughChangesetRef;
+	decisions: Record<string, PrWalkthroughDecision>;
+	comments: PrWalkthroughComment[];
+	completedCardIds: string[];
+}
+
+export type WalkthroughWarningSeverity = "info" | "warning" | "error";
+
+export interface WalkthroughWarning {
+	code: string;
+	severity: WalkthroughWarningSeverity;
+	message: string;
+	filePath?: string;
+}
+
+export interface WalkthroughLimits {
+	maxFiles: number;
+	maxDiffBytes: number;
+	maxLinesPerFile: number;
+	truncatedFiles?: string[];
+	omittedFiles?: string[];
+}
+
+export interface WalkthroughExportCapability {
+	provider: "github" | string;
+	available: boolean;
+	reason?: string;
+	previewUrl?: string;
+	submitUrl?: string;
+}
+
+export interface WalkthroughResolveRequest {
+	sessionId?: string;
+	cwd?: string;
+	baseSha?: string;
+	headSha?: string;
+	prUrl?: string;
+	prNumber?: string | number;
+	provider?: "github" | "local" | string;
+	fixture?: boolean;
+}
+
+export interface WalkthroughResolveResult {
+	changesetId: string;
+	changeset: PrWalkthroughChangesetRef;
+	cards: PrWalkthroughCard[];
+	warnings: WalkthroughWarning[];
+	limits?: WalkthroughLimits;
+	export?: WalkthroughExportCapability;
+}
+
+export interface WalkthroughExportPreviewRow {
+	commentId: string;
+	cardId: string;
+	path?: string;
+	side?: "LEFT" | "RIGHT";
+	line?: number;
+	body: string;
+	valid: boolean;
+	reason?: string;
+}
+
+export interface WalkthroughExportPreview {
+	provider: "github" | string;
+	changesetId: string;
+	body: string;
+	comments: WalkthroughExportPreviewRow[];
+	warnings: WalkthroughWarning[];
+	canSubmit: boolean;
+}
+
+export interface WalkthroughExportRequest {
+	draft: PrWalkthroughReviewDraft;
+	confirm?: boolean;
+	event?: "COMMENT" | "REQUEST_CHANGES" | "APPROVE";
+}
+
+export interface WalkthroughExportResult {
+	ok: boolean;
+	provider: "github" | string;
+	submitted?: boolean;
+	reviewUrl?: string;
+	preview?: WalkthroughExportPreview;
+	warnings?: WalkthroughWarning[];
+	error?: string;
+}

--- a/src/shared/pr-walkthrough/types.ts
+++ b/src/shared/pr-walkthrough/types.ts
@@ -38,6 +38,10 @@ export interface PrWalkthroughDiffBlock {
 	filePath: string;
 	oldPath?: string;
 	hunks: PrWalkthroughHunk[];
+	externalUrl?: string;
+	blobUrl?: string;
+	rawUrl?: string;
+	contentsUrl?: string;
 }
 
 export interface PrWalkthroughSuggestedComment {

--- a/src/shared/pr-walkthrough/types.ts
+++ b/src/shared/pr-walkthrough/types.ts
@@ -17,6 +17,7 @@ export type PrWalkthroughPhaseId = "orientation" | "design" | "significant" | "o
 export type PrWalkthroughDiffLineSide = "old" | "new" | "context";
 export type PrWalkthroughDiffLineKind = "context" | "add" | "del";
 export type PrWalkthroughDiffMode = "split" | "inline";
+export type PrWalkthroughDiffBlockStatus = "added" | "modified" | "deleted" | "renamed" | "copied" | "binary";
 
 export interface PrWalkthroughDiffLine {
 	id: string;
@@ -37,6 +38,10 @@ export interface PrWalkthroughDiffBlock {
 	id: string;
 	filePath: string;
 	oldPath?: string;
+	status?: PrWalkthroughDiffBlockStatus;
+	isBinary?: boolean;
+	isGenerated?: boolean;
+	isTruncated?: boolean;
 	hunks: PrWalkthroughHunk[];
 	externalUrl?: string;
 	blobUrl?: string;

--- a/src/shared/pr-walkthrough/url-safety.ts
+++ b/src/shared/pr-walkthrough/url-safety.ts
@@ -1,0 +1,32 @@
+const DEFAULT_TRUSTED_HOSTS = new Set([
+	"github.com",
+	"www.github.com",
+	"api.github.com",
+	"raw.githubusercontent.com",
+	"gist.githubusercontent.com",
+]);
+
+export function safeExternalUrl(value: unknown, extraTrustedHosts: string[] = []): string | undefined {
+	if (typeof value !== "string" || !value.trim()) return undefined;
+	let parsed: URL;
+	try {
+		parsed = new URL(value.trim());
+	} catch {
+		return undefined;
+	}
+	if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return undefined;
+	const host = parsed.hostname.replace(/\.$/, "").toLowerCase();
+	if (!isTrustedExternalHost(host, extraTrustedHosts)) return undefined;
+	parsed.hash = parsed.hash || "";
+	return parsed.toString();
+}
+
+export function isTrustedExternalHost(host: string, extraTrustedHosts: string[] = []): boolean {
+	const normalized = host.replace(/\.$/, "").toLowerCase();
+	if (DEFAULT_TRUSTED_HOSTS.has(normalized)) return true;
+	return extraTrustedHosts.map(item => item.replace(/\.$/, "").toLowerCase()).includes(normalized);
+}
+
+export function trustedHostsFromEnv(value: string | undefined): string[] {
+	return (value ?? "").split(",").map(host => host.trim()).filter(Boolean);
+}

--- a/src/ui/components/pr-walkthrough/PrWalkthroughPanel.ts
+++ b/src/ui/components/pr-walkthrough/PrWalkthroughPanel.ts
@@ -3,6 +3,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import { buildPrWalkthroughDraft, cardRequiresCommentForDislike, defaultDiffModeForWidth, type PrWalkthroughCard, type PrWalkthroughChangesetRef, type PrWalkthroughComment, type PrWalkthroughDecision, type PrWalkthroughDiffBlock, type PrWalkthroughDiffLine, type PrWalkthroughDiffMode, type PrWalkthroughPhaseId, type PrWalkthroughReviewDraft, type PrWalkthroughSuggestedComment } from "./types.js";
 import { fixturePrWalkthroughChangeset, getFixturePrWalkthroughCards } from "./fixtures.js";
 import { gatewayFetch } from "../../../app/gateway-fetch.js";
+import { safeExternalUrl } from "../../../shared/pr-walkthrough/url-safety.js";
 
 const PHASES: Array<{ id: PrWalkthroughPhaseId; label: string }> = [
 	{ id: "orientation", label: "Orientation" },
@@ -674,14 +675,17 @@ export class PrWalkthroughPanel extends LitElement {
 	private get apiChangesetId(): string {
 		if (this.changesetId.trim()) return this.changesetId.trim();
 		const key = this.persistenceKey.replace(/^walkthrough:/, "").trim();
-		if (key) return key;
+		if (key) {
+			try { return decodeURIComponent(key); }
+			catch { return key; }
+		}
 		const changeset = this.effectiveChangeset;
 		return `${changeset.baseSha}..${changeset.headSha}`;
 	}
 
 	private get prIdentity(): { kicker: string; title: string; linkLabel: string; url: string } {
 		const changeset = this.effectiveChangeset;
-		const url = changeset.prUrl || changeset.externalUrl || "";
+		const url = safeExternalUrl(changeset.prUrl) || safeExternalUrl(changeset.externalUrl) || "";
 		const urlNumber = url ? /\/pull\/(\d+)(?:\/|$)/i.exec(url)?.[1] : undefined;
 		const titleNumber = changeset.title ? /^PR\s+#(\d+)/i.exec(changeset.title)?.[1] : undefined;
 		const number = changeset.prNumber != null && String(changeset.prNumber).trim() ? String(changeset.prNumber) : urlNumber ?? titleNumber;
@@ -1028,7 +1032,7 @@ export class PrWalkthroughPanel extends LitElement {
 
 	private externalFileUrl(block: PrWalkthroughDiffBlock): string | undefined {
 		const linked = block as PrWalkthroughDiffBlock & { externalUrl?: string; blobUrl?: string; rawUrl?: string; contentsUrl?: string };
-		return linked.externalUrl || linked.blobUrl || linked.rawUrl || linked.contentsUrl;
+		return safeExternalUrl(linked.externalUrl) || safeExternalUrl(linked.blobUrl) || safeExternalUrl(linked.rawUrl) || safeExternalUrl(linked.contentsUrl);
 	}
 
 	private renderDiffLine(card: PrWalkthroughCard, block: PrWalkthroughDiffBlock, line: PrWalkthroughDiffLine | null, column: "old" | "new" | "inline"): TemplateResult {
@@ -1194,6 +1198,7 @@ export class PrWalkthroughPanel extends LitElement {
 		const invalidRows = rows.length - validRows.length;
 		const canSubmit = this.canUseExportApi && !this._exportPreviewLoading && !this._exportSubmitting && !!preview && (preview.canSubmit !== false);
 		const body = preview?.body || preview?.reviewBody || this.buildAuditText();
+		const reviewUrl = safeExternalUrl(this._exportResult?.url);
 		return html`
 			<div class="export-backdrop" data-testid="pr-walkthrough-export-preview" role="dialog" aria-modal="true" aria-label="Review export preview">
 				<section class="export-dialog">
@@ -1205,7 +1210,7 @@ export class PrWalkthroughPanel extends LitElement {
 					<div class="export-body">
 						${!this.canUseExportApi ? html`<div class="banner info" data-testid="pr-walkthrough-export-unavailable"><strong>Export unavailable</strong><div>${this.exportUnavailableReason}</div></div>` : nothing}
 						${this._exportError ? html`<div class="banner error" data-testid="pr-walkthrough-export-error"><strong>Export preview failed</strong><div>${this._exportError}</div></div>` : nothing}
-						${this._exportResult ? html`<div class="banner ${this._exportResult.ok === false ? "error" : "info"}" data-testid="pr-walkthrough-export-result"><strong>${this._exportResult.ok === false ? "Submission failed" : "Submitted"}</strong><div>${this._exportResult.message || this._exportResult.error || "GitHub review submitted."}</div>${this._exportResult.url ? html`<div><a href=${this._exportResult.url} target="_blank" rel="noopener noreferrer">Open review ↗</a></div>` : nothing}</div>` : nothing}
+						${this._exportResult ? html`<div class="banner ${this._exportResult.ok === false ? "error" : "info"}" data-testid="pr-walkthrough-export-result"><strong>${this._exportResult.ok === false ? "Submission failed" : "Submitted"}</strong><div>${this._exportResult.message || this._exportResult.error || "GitHub review submitted."}</div>${reviewUrl ? html`<div><a href=${reviewUrl} target="_blank" rel="noopener noreferrer">Open review ↗</a></div>` : nothing}</div>` : nothing}
 						${this._exportPreviewLoading ? this.renderLoadingState() : html`
 							<div class="export-summary" data-testid="pr-walkthrough-export-summary">
 								<span>${validRows.length} mapped comment${validRows.length === 1 ? "" : "s"}</span>

--- a/src/ui/components/pr-walkthrough/PrWalkthroughPanel.ts
+++ b/src/ui/components/pr-walkthrough/PrWalkthroughPanel.ts
@@ -515,6 +515,7 @@ export class PrWalkthroughPanel extends LitElement {
 		.diff-path { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: var(--muted-foreground, GrayText); }
 		.diff-path b { color: var(--foreground, CanvasText); }
 		.diff-kind { margin-left: auto; font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; padding: 2px 7px; border-radius: 4px; color: var(--chart-1, var(--primary, Highlight)); background: color-mix(in oklch, var(--chart-1, var(--primary, Highlight)) 16%, transparent); }
+		.diff-status { flex: 0 0 auto; font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; padding: 2px 7px; border-radius: 999px; color: var(--chart-2, var(--primary, Highlight)); background: color-mix(in oklch, var(--chart-2, var(--primary, Highlight)) 14%, transparent); border: 1px solid color-mix(in oklch, var(--chart-2, var(--primary, Highlight)) 26%, var(--border, ButtonBorder)); }
 		.diff-comment-count { font-size: 11px; color: var(--negative, red); background: color-mix(in oklch, var(--negative, red) 12%, transparent); border-radius: 999px; padding: 2px 7px; font-weight: 800; }
 		.split-grid { min-width: 980px; }
 		.split-row .diff-line:first-child { border-right: 1px solid var(--border, ButtonBorder); }
@@ -977,6 +978,17 @@ export class PrWalkthroughPanel extends LitElement {
 		`;
 	}
 
+	private diffStatusLabel(block: PrWalkthroughDiffBlock): string {
+		const status = block.status;
+		if (status === "added") return "Added";
+		if (status === "modified") return "Modified";
+		if (status === "deleted") return "Deleted";
+		if (status === "renamed") return "Renamed";
+		if (status === "copied") return "Copied";
+		if (status === "binary") return "Binary";
+		return "";
+	}
+
 	private renderDiffBlock(card: PrWalkthroughCard, block: PrWalkthroughDiffBlock): TemplateResult {
 		const collapsed = this._collapsedDiffBlockIds.includes(block.id);
 		const comments = this._comments.filter(comment => comment.cardId === card.id && comment.diffBlockId === block.id).length;
@@ -985,6 +997,7 @@ export class PrWalkthroughPanel extends LitElement {
 				<div class="diff-file-header-row">
 					<button class="diff-file-header" data-testid="pr-walkthrough-diff-toggle" type="button" aria-expanded=${!collapsed} @click=${() => this.toggleDiffBlock(block.id)}>
 						<span class="caret">▸</span>
+						${this.diffStatusLabel(block) ? html`<span class="diff-status" data-testid="pr-walkthrough-diff-status">${this.diffStatusLabel(block)}</span>` : nothing}
 						<span class="diff-path"><b>${block.oldPath && block.oldPath !== block.filePath ? `${block.oldPath} → ${block.filePath}` : block.filePath}</b></span>
 						${comments ? html`<span class="diff-comment-count">${comments} comment${comments === 1 ? "" : "s"}</span>` : nothing}
 						<span class="diff-kind">${block.hunks.length} hunk${block.hunks.length === 1 ? "" : "s"}</span>
@@ -1307,7 +1320,7 @@ export class PrWalkthroughPanel extends LitElement {
 		const record = data as Record<string, unknown>;
 		return {
 			ok: typeof record.ok === "boolean" ? record.ok : true,
-			url: typeof record.url === "string" ? record.url : undefined,
+			url: typeof record.url === "string" ? record.url : typeof record.reviewUrl === "string" ? record.reviewUrl : undefined,
 			message: typeof record.message === "string" ? record.message : "GitHub review submitted.",
 			error: typeof record.error === "string" ? record.error : undefined,
 		};

--- a/src/ui/components/pr-walkthrough/PrWalkthroughPanel.ts
+++ b/src/ui/components/pr-walkthrough/PrWalkthroughPanel.ts
@@ -504,8 +504,11 @@ export class PrWalkthroughPanel extends LitElement {
 		.body.narrow .narrow-note { display: inline; }
 		.diff-block { margin: 12px 0; border-radius: 9px; }
 		.diff-block.closed .diff-overflow { display: none; }
-		.diff-file-header { display: flex; align-items: center; gap: 9px; width: 100%; padding: 9px 12px; border: 0; border-bottom: 1px solid var(--border, ButtonBorder); font: inherit; color: inherit; text-align: left; cursor: pointer; }
-		.diff-block.closed .diff-file-header { border-bottom: 0; }
+		.diff-file-header-row { display: flex; align-items: stretch; border-bottom: 1px solid var(--border, ButtonBorder); }
+		.diff-block.closed .diff-file-header-row { border-bottom: 0; }
+		.diff-file-header { display: flex; align-items: center; gap: 9px; flex: 1 1 auto; min-width: 0; padding: 9px 12px; border: 0; font: inherit; color: inherit; text-align: left; cursor: pointer; }
+		.diff-external-link { display: inline-flex; align-items: center; flex: 0 0 auto; padding: 0 12px; border-left: 1px solid var(--border, ButtonBorder); font-size: 11px; font-weight: 800; color: var(--primary, Highlight); text-decoration: none; }
+		.diff-external-link:hover { background: color-mix(in oklch, var(--primary, Highlight) 7%, transparent); text-decoration: underline; }
 		.caret { width: 12px; color: var(--muted-foreground, GrayText); transition: transform 140ms ease; font-family: ui-monospace, monospace; }
 		.diff-block.open .caret { transform: rotate(90deg); }
 		.diff-path { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: var(--muted-foreground, GrayText); }
@@ -975,12 +978,15 @@ export class PrWalkthroughPanel extends LitElement {
 		const comments = this._comments.filter(comment => comment.cardId === card.id && comment.diffBlockId === block.id).length;
 		return html`
 			<section class="diff-block ${collapsed ? "closed" : "open"}" data-testid="pr-walkthrough-diff-block" data-diff-block-id=${block.id} data-file-path=${block.filePath} data-diff-mode=${this.effectiveDiffMode} data-expanded=${collapsed ? "false" : "true"}>
-				<button class="diff-file-header" data-testid="pr-walkthrough-diff-toggle" type="button" aria-expanded=${!collapsed} @click=${() => this.toggleDiffBlock(block.id)}>
-					<span class="caret">▸</span>
-					<span class="diff-path"><b>${block.oldPath && block.oldPath !== block.filePath ? `${block.oldPath} → ${block.filePath}` : block.filePath}</b></span>
-					${comments ? html`<span class="diff-comment-count">${comments} comment${comments === 1 ? "" : "s"}</span>` : nothing}
-					<span class="diff-kind">${block.hunks.length} hunk${block.hunks.length === 1 ? "" : "s"}</span>
-				</button>
+				<div class="diff-file-header-row">
+					<button class="diff-file-header" data-testid="pr-walkthrough-diff-toggle" type="button" aria-expanded=${!collapsed} @click=${() => this.toggleDiffBlock(block.id)}>
+						<span class="caret">▸</span>
+						<span class="diff-path"><b>${block.oldPath && block.oldPath !== block.filePath ? `${block.oldPath} → ${block.filePath}` : block.filePath}</b></span>
+						${comments ? html`<span class="diff-comment-count">${comments} comment${comments === 1 ? "" : "s"}</span>` : nothing}
+						<span class="diff-kind">${block.hunks.length} hunk${block.hunks.length === 1 ? "" : "s"}</span>
+					</button>
+					${this.externalFileUrl(block) ? html`<a class="diff-external-link" href=${this.externalFileUrl(block)!} target="_blank" rel="noreferrer" data-testid="pr-walkthrough-external-file-link">Open file</a>` : nothing}
+				</div>
 				${collapsed ? nothing : this.effectiveDiffMode === "split" ? this.renderSplitDiff(card, block) : this.renderInlineDiff(card, block)}
 			</section>
 		`;
@@ -1018,6 +1024,11 @@ export class PrWalkthroughPanel extends LitElement {
 				</div>
 			</div>
 		`;
+	}
+
+	private externalFileUrl(block: PrWalkthroughDiffBlock): string | undefined {
+		const linked = block as PrWalkthroughDiffBlock & { externalUrl?: string; blobUrl?: string; rawUrl?: string; contentsUrl?: string };
+		return linked.externalUrl || linked.blobUrl || linked.rawUrl || linked.contentsUrl;
 	}
 
 	private renderDiffLine(card: PrWalkthroughCard, block: PrWalkthroughDiffBlock, line: PrWalkthroughDiffLine | null, column: "old" | "new" | "inline"): TemplateResult {

--- a/src/ui/components/pr-walkthrough/PrWalkthroughPanel.ts
+++ b/src/ui/components/pr-walkthrough/PrWalkthroughPanel.ts
@@ -767,7 +767,7 @@ export class PrWalkthroughPanel extends LitElement {
 	}
 
 	private renderRail(): TemplateResult {
-		if (this.status === "loading" || this.status === "error" || (this.status === "ready" && this.cards.length === 0)) return this.renderPlaceholderRail();
+		if (!this.cards.length && (this.status === "loading" || this.status === "error" || this.status === "ready")) return this.renderPlaceholderRail();
 		return this.isNarrowLayout ? this.renderCollapsedRail() : this.renderLabelledRail();
 	}
 
@@ -857,7 +857,9 @@ export class PrWalkthroughPanel extends LitElement {
 	}
 
 	private renderMainContent(active: PrWalkthroughCard | undefined): TemplateResult {
+		if (this.status === "loading" && active) return html`${this.renderWarningBanners()}${this.renderLoadingState()}${this.renderCard(active)}`;
 		if (this.status === "loading") return html`${this.renderWarningBanners()}${this.renderLoadingState()}`;
+		if (this.status === "error" && active) return html`${this.renderWarningBanners()}${this.renderErrorState()}${this.renderCard(active)}`;
 		if (this.status === "error") return html`${this.renderWarningBanners()}${this.renderErrorState()}`;
 		if (this.status === "ready" && this.cards.length === 0) return html`${this.renderWarningBanners()}${this.renderEmptyState()}`;
 		if (!active) return html`${this.renderWarningBanners()}<div class="state-card" data-testid="pr-walkthrough-empty-state"><h2>No walkthrough cards are available.</h2><p>There are no logical review cards for this changeset.</p></div>`;
@@ -882,7 +884,8 @@ export class PrWalkthroughPanel extends LitElement {
 
 	private renderLoadingState(): TemplateResult {
 		return html`
-			<section class="state-card" data-testid="pr-walkthrough-loading-state" aria-live="polite">
+			<section class="state-card" data-testid="pr-walkthrough-loading" aria-live="polite">
+				<span data-testid="pr-walkthrough-loading-state" hidden></span>
 				<h2>Resolving walkthrough…</h2>
 				<p>Loading PR metadata, changed files, diff hunks, and logical review cards.</p>
 				<div class="skeleton" aria-hidden="true">
@@ -894,14 +897,24 @@ export class PrWalkthroughPanel extends LitElement {
 		`;
 	}
 
+	private retryWalkthroughResolve(): void {
+		this.dispatchEvent(new CustomEvent("open-pr-walkthrough", {
+			bubbles: true,
+			composed: true,
+			detail: { ...(this.changeset || {}), changesetId: this.changesetId || undefined },
+		}));
+	}
+
 	private renderErrorState(): TemplateResult {
 		const message = this.error || "Unable to resolve this walkthrough.";
 		const isAuth = /auth|permission|rate|token/i.test(message);
 		return html`
-			<section class="state-card" data-testid="pr-walkthrough-error-state" role="alert">
+			<section class="state-card" data-testid="pr-walkthrough-error" role="alert">
+				<span data-testid="pr-walkthrough-error-state" hidden></span>
 				<h2>${/not found/i.test(message) ? "Pull request not found" : "Walkthrough unavailable"}</h2>
 				<p>${message}</p>
 				${isAuth ? html`<p>Check GitHub credentials or repository permissions, then retry from the walkthrough command.</p>` : nothing}
+				<button type="button" class="copy-button" @click=${this.retryWalkthroughResolve}>Retry</button>
 			</section>
 		`;
 	}

--- a/src/ui/components/pr-walkthrough/PrWalkthroughPanel.ts
+++ b/src/ui/components/pr-walkthrough/PrWalkthroughPanel.ts
@@ -2,6 +2,7 @@ import { css, html, LitElement, nothing, type PropertyValues, type TemplateResul
 import { customElement, property, state } from "lit/decorators.js";
 import { buildPrWalkthroughDraft, cardRequiresCommentForDislike, defaultDiffModeForWidth, type PrWalkthroughCard, type PrWalkthroughChangesetRef, type PrWalkthroughComment, type PrWalkthroughDecision, type PrWalkthroughDiffBlock, type PrWalkthroughDiffLine, type PrWalkthroughDiffMode, type PrWalkthroughPhaseId, type PrWalkthroughReviewDraft, type PrWalkthroughSuggestedComment } from "./types.js";
 import { fixturePrWalkthroughChangeset, getFixturePrWalkthroughCards } from "./fixtures.js";
+import { gatewayFetch } from "../../../app/gateway-fetch.js";
 
 const PHASES: Array<{ id: PrWalkthroughPhaseId; label: string }> = [
 	{ id: "orientation", label: "Orientation" },
@@ -16,7 +17,58 @@ interface SideBySidePair {
 	right: PrWalkthroughDiffLine | null;
 }
 
+type PrWalkthroughStatus = "fixture" | "loading" | "ready" | "error";
+
+type WalkthroughWarningSeverity = "info" | "warning" | "error";
+
+interface WalkthroughWarning {
+	code: string;
+	severity: WalkthroughWarningSeverity;
+	message: string;
+	filePath?: string;
+}
+
+interface WalkthroughExportCapability {
+	provider?: string;
+	available?: boolean;
+	canSubmit?: boolean;
+	enabled?: boolean;
+	reason?: string;
+	message?: string;
+}
+
+interface WalkthroughExportPreviewRow {
+	path?: string;
+	filePath?: string;
+	side?: string;
+	line?: number;
+	body?: string;
+	valid?: boolean;
+	reason?: string;
+	kind?: string;
+}
+
+interface WalkthroughExportPreview {
+	body?: string;
+	reviewBody?: string;
+	rows?: WalkthroughExportPreviewRow[];
+	comments?: WalkthroughExportPreviewRow[];
+	warnings?: WalkthroughWarning[];
+	validCount?: number;
+	invalidCount?: number;
+	canSubmit?: boolean;
+}
+
+interface WalkthroughExportResult {
+	ok?: boolean;
+	url?: string;
+	message?: string;
+	error?: string;
+}
+
 interface PersistedPrWalkthroughState {
+	schemaVersion?: number;
+	cardsChecksum?: string;
 	activeCardId?: string;
 	diffModeOverride?: PrWalkthroughDiffMode;
 	comments?: PrWalkthroughComment[];
@@ -30,6 +82,11 @@ interface PersistedPrWalkthroughState {
 export class PrWalkthroughPanel extends LitElement {
 	@property({ attribute: false }) changeset?: PrWalkthroughChangesetRef;
 	@property({ attribute: false }) cards: PrWalkthroughCard[] = getFixturePrWalkthroughCards();
+	@property({ attribute: false }) status: PrWalkthroughStatus = "fixture";
+	@property({ attribute: false }) warnings: WalkthroughWarning[] = [];
+	@property({ attribute: false }) error?: string;
+	@property({ attribute: false }) exportCapability?: WalkthroughExportCapability;
+	@property({ attribute: "changeset-id" }) changesetId = "";
 	@property({ type: Boolean, reflect: true }) narrow = false;
 	@property({ attribute: "persistence-key" }) persistenceKey = "";
 
@@ -47,6 +104,12 @@ export class PrWalkthroughPanel extends LitElement {
 	@state() private _dismissedSuggestionIds: string[] = [];
 	@state() private _collapsedDiffBlockIds: string[] = [];
 	@state() private _copied = false;
+	@state() private _exportPreviewOpen = false;
+	@state() private _exportPreviewLoading = false;
+	@state() private _exportPreview?: WalkthroughExportPreview;
+	@state() private _exportError = "";
+	@state() private _exportSubmitting = false;
+	@state() private _exportResult?: WalkthroughExportResult;
 
 	private _resizeObserver?: ResizeObserver;
 	private _loadedPersistenceKey = "";
@@ -104,6 +167,41 @@ export class PrWalkthroughPanel extends LitElement {
 		.progress-fill { height: 100%; border-radius: inherit; background: var(--primary, Highlight); transition: width 160ms ease; }
 		.submit-button { border: 0; border-radius: 7px; padding: 7px 12px; font-weight: 700; background: var(--primary, Highlight); color: var(--primary-foreground, HighlightText); white-space: nowrap; }
 		.submit-button:disabled { background: color-mix(in oklch, var(--muted-foreground, GrayText) 18%, transparent); color: var(--muted-foreground, GrayText); opacity: 1; }
+		.status-pill { border-radius: 999px; padding: 2px 7px; font-size: 10px; font-weight: 800; letter-spacing: 0.05em; text-transform: uppercase; background: color-mix(in oklch, var(--info, var(--primary, Highlight)) 12%, transparent); color: var(--info, var(--primary, Highlight)); }
+		.status-pill.error { background: color-mix(in oklch, var(--negative, red) 12%, transparent); color: var(--negative, red); }
+
+		.banner-stack { display: grid; gap: 8px; margin: 0 auto 14px; max-width: 1120px; }
+		.banner { padding: 10px 12px; border: 1px solid var(--border, ButtonBorder); border-radius: 10px; background: var(--card, Canvas); color: var(--foreground, CanvasText); }
+		.banner strong { display: block; margin-bottom: 2px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; }
+		.banner.info { border-color: color-mix(in oklch, var(--info, var(--primary, Highlight)) 28%, var(--border, ButtonBorder)); background: color-mix(in oklch, var(--info, var(--primary, Highlight)) 7%, transparent); }
+		.banner.warning { border-color: color-mix(in oklch, var(--warning, orange) 34%, var(--border, ButtonBorder)); background: color-mix(in oklch, var(--warning, orange) 8%, transparent); }
+		.banner.error { border-color: color-mix(in oklch, var(--negative, red) 32%, var(--border, ButtonBorder)); background: color-mix(in oklch, var(--negative, red) 7%, transparent); }
+		.banner .file { margin-top: 3px; color: var(--muted-foreground, GrayText); font: 11px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+
+		.state-card { max-width: 760px; margin: 32px auto; padding: 24px; border: 1px solid var(--border, ButtonBorder); border-radius: 16px; background: var(--card, Canvas); box-shadow: 0 10px 30px color-mix(in oklch, var(--foreground, CanvasText) 7%, transparent); }
+		.state-card h2 { margin: 0 0 8px; font-size: 20px; }
+		.state-card p { margin: 0; color: var(--muted-foreground, GrayText); }
+		.skeleton { display: grid; gap: 12px; }
+		.skeleton-line { height: 12px; border-radius: 999px; background: linear-gradient(90deg, color-mix(in oklch, var(--muted-foreground, GrayText) 10%, transparent), color-mix(in oklch, var(--muted-foreground, GrayText) 20%, transparent), color-mix(in oklch, var(--muted-foreground, GrayText) 10%, transparent)); background-size: 220% 100%; animation: pr-walkthrough-pulse 1.4s ease-in-out infinite; }
+		.skeleton-line.short { width: 45%; }
+		.skeleton-line.medium { width: 72%; }
+		.skeleton-box { height: 180px; border-radius: 12px; background: color-mix(in oklch, var(--muted-foreground, GrayText) 10%, transparent); animation: pr-walkthrough-pulse 1.4s ease-in-out infinite; }
+		@keyframes pr-walkthrough-pulse { from { background-position: 0 0; } to { background-position: -220% 0; } }
+
+		.export-backdrop { position: fixed; inset: 0; z-index: 40; display: grid; place-items: center; padding: 18px; background: color-mix(in oklch, var(--background, Canvas) 72%, transparent); backdrop-filter: blur(2px); }
+		.export-dialog { width: min(920px, 96vw); max-height: min(780px, 92vh); display: grid; grid-template-rows: auto 1fr auto; border: 1px solid var(--border, ButtonBorder); border-radius: 16px; background: var(--background, Canvas); box-shadow: 0 20px 80px color-mix(in oklch, var(--foreground, CanvasText) 20%, transparent); overflow: hidden; }
+		.export-head, .export-actions { display: flex; align-items: center; gap: 10px; padding: 14px 16px; border-bottom: 1px solid var(--border, ButtonBorder); background: var(--card, Canvas); }
+		.export-head h2 { margin: 0; font-size: 16px; }
+		.export-actions { justify-content: flex-end; border-top: 1px solid var(--border, ButtonBorder); border-bottom: 0; }
+		.export-body { overflow: auto; padding: 16px; display: grid; gap: 14px; }
+		.export-body pre { margin: 0; max-height: 220px; overflow: auto; padding: 12px; border: 1px solid var(--border, ButtonBorder); border-radius: 10px; background: var(--card, Canvas); white-space: pre-wrap; font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+		.export-summary { display: flex; gap: 8px; flex-wrap: wrap; color: var(--muted-foreground, GrayText); }
+		.export-row { display: grid; gap: 5px; padding: 10px; border: 1px solid var(--border, ButtonBorder); border-radius: 10px; background: var(--card, Canvas); }
+		.export-row.invalid { border-color: color-mix(in oklch, var(--negative, red) 32%, var(--border, ButtonBorder)); background: color-mix(in oklch, var(--negative, red) 6%, transparent); }
+		.export-row .anchor { font: 11px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: var(--muted-foreground, GrayText); }
+		.export-row .reason { color: var(--negative, red); font-size: 12px; }
+		.export-actions button { padding: 8px 12px; border: 1px solid var(--border, ButtonBorder); border-radius: 8px; background: var(--card, Canvas); color: inherit; }
+		.export-actions .primary { border-color: var(--primary, Highlight); background: var(--primary, Highlight); color: var(--primary-foreground, HighlightText); font-weight: 700; }
 
 		.mode-toggle {
 			display: inline-flex;
@@ -461,9 +559,14 @@ export class PrWalkthroughPanel extends LitElement {
 			this.restorePersistedState();
 			return;
 		}
-		if (changed.has("cards") && this.persistenceKey && this._loadedPersistenceKey !== this.persistenceKey) {
+		if (changed.has("cards") && this.persistenceKey) {
 			this.restorePersistedState();
 			return;
+		}
+		if (changed.has("status") && (this.status === "loading" || this.status === "error")) {
+			this._exportPreviewOpen = false;
+			this._exportPreview = undefined;
+			this._exportError = "";
 		}
 		if (changed.has("cards") || !this._activeCardId) {
 			const firstCard = this.reviewCards[0] ?? this.cards[0];
@@ -510,6 +613,12 @@ export class PrWalkthroughPanel extends LitElement {
 		this._dismissedSuggestionIds = [];
 		this._collapsedDiffBlockIds = [];
 		this._copied = false;
+		this._exportPreviewOpen = false;
+		this._exportPreviewLoading = false;
+		this._exportPreview = undefined;
+		this._exportError = "";
+		this._exportSubmitting = false;
+		this._exportResult = undefined;
 	}
 
 	private reconcileDecisionCommentInvariants(): void {
@@ -547,6 +656,24 @@ export class PrWalkthroughPanel extends LitElement {
 
 	private get currentDraftHasConcerns(): boolean {
 		return Object.values(this._decisions).some(decision => decision.value === "disliked") || this._comments.length > 0;
+	}
+
+	private get canUseExportApi(): boolean {
+		if (!this.exportCapability) return false;
+		if (this.exportCapability.available === false || this.exportCapability.enabled === false || this.exportCapability.canSubmit === false) return false;
+		return true;
+	}
+
+	private get exportUnavailableReason(): string {
+		return this.exportCapability?.reason || this.exportCapability?.message || "GitHub export is not available for this walkthrough. You can copy the draft review instead.";
+	}
+
+	private get apiChangesetId(): string {
+		if (this.changesetId.trim()) return this.changesetId.trim();
+		const key = this.persistenceKey.replace(/^walkthrough:/, "").trim();
+		if (key) return key;
+		const changeset = this.effectiveChangeset;
+		return `${changeset.baseSha}..${changeset.headSha}`;
 	}
 
 	private get prIdentity(): { kicker: string; title: string; linkLabel: string; url: string } {
@@ -588,17 +715,15 @@ export class PrWalkthroughPanel extends LitElement {
 
 	override render(): TemplateResult {
 		const active = this.activeCard;
-		if (!active) {
-			return html`<section class="shell" data-testid="pr-walkthrough-panel"><div class="empty">No walkthrough cards are available.</div></section>`;
-		}
-
+		const activeCardId = this.status === "ready" && !this.cards.length ? "empty" : active?.id ?? this.status;
 		return html`
-			<section class="shell" data-testid="pr-walkthrough-panel" data-active-card-id=${active.id} data-diff-mode=${this.effectiveDiffMode}>
+			<section class="shell" data-testid="pr-walkthrough-panel" data-active-card-id=${activeCardId} data-diff-mode=${this.effectiveDiffMode} data-status=${this.status}>
 				${this.renderHeader()}
 				<div class="body ${this.isNarrowLayout ? "narrow" : ""}">
 					${this.renderRail()}
-					<main class="content">${this.renderCard(active)}</main>
+					<main class="content">${this.renderMainContent(active)}</main>
 				</div>
+				${this._exportPreviewOpen ? this.renderExportDialog() : nothing}
 			</section>
 		`;
 	}
@@ -612,6 +737,9 @@ export class PrWalkthroughPanel extends LitElement {
 		const submitLabel = completed < this.reviewCards.length
 			? `Submit review (${completed}/${this.reviewCards.length})`
 			: this.currentDraftHasConcerns ? "Submit review · request changes" : "Submit review · approve";
+		const submitTitle = completed < this.reviewCards.length
+			? "Review every non-audit card before export."
+			: this.canUseExportApi ? "Preview GitHub review comments before submitting." : this.exportUnavailableReason;
 		return html`
 			<header class="header" data-testid="pr-walkthrough-header" data-legacy-testid="pr-walkthrough-review-header">
 				<div class="title-wrap" data-testid="pr-walkthrough-pr-title">
@@ -632,13 +760,32 @@ export class PrWalkthroughPanel extends LitElement {
 					<div class="progress-label">${completed} / ${this.reviewCards.length} reviewed</div>
 					<div class="progress-track"><div class="progress-fill" style="width: ${percent}%"></div></div>
 				</div>
-				<button class="submit-button" data-testid="pr-walkthrough-submit-review" type="button" ?disabled=${completed < this.reviewCards.length}>${submitLabel}</button>
+				${this.status !== "fixture" ? html`<span class="status-pill ${this.status === "error" ? "error" : ""}">${this.status}</span>` : nothing}
+				<button class="submit-button" data-testid="pr-walkthrough-submit-review" type="button" title=${submitTitle} ?disabled=${completed < this.reviewCards.length || this.status === "loading" || this.status === "error"} @click=${this.openExportPreview}>${submitLabel}</button>
 			</header>
 		`;
 	}
 
 	private renderRail(): TemplateResult {
+		if (this.status === "loading" || this.status === "error" || (this.status === "ready" && this.cards.length === 0)) return this.renderPlaceholderRail();
 		return this.isNarrowLayout ? this.renderCollapsedRail() : this.renderLabelledRail();
+	}
+
+	private renderPlaceholderRail(): TemplateResult {
+		const identity = this.prIdentity;
+		const stats = this.changesetStats;
+		return html`
+			<nav class="rail ${this.isNarrowLayout ? "collapsed" : ""}" data-testid=${this.isNarrowLayout ? "pr-walkthrough-collapsed-rail" : "pr-walkthrough-labelled-rail"} aria-label="PR walkthrough phases">
+				${this.isNarrowLayout ? html`<span class="phase-pip ${this.status === "error" ? "error" : "active"}" title=${this.status}>!</span>` : html`
+					<div class="rail-prbox">
+						<div class="num">${identity.kicker}</div>
+						<div class="prtitle">${identity.title}</div>
+						<div class="meta"><span>${stats.files} files</span><span class="stat-add">+${this.formatNumber(stats.additions)}</span><span class="stat-del">-${this.formatNumber(stats.deletions)}</span></div>
+					</div>
+					<div class="empty">${this.status === "loading" ? "Resolving changeset…" : this.status === "error" ? "Walkthrough unavailable" : "No changed files"}</div>
+				`}
+			</nav>
+		`;
 	}
 
 	private renderLabelledRail(): TemplateResult {
@@ -706,6 +853,65 @@ export class PrWalkthroughPanel extends LitElement {
 				<span class="card-title">${card.title}</span>
 				${comments ? html`<span class="card-decision">${comments}</span>` : html`<span class="card-decision">${decision ? decision : card.phaseId === "audit" ? "draft" : "pending"}</span>`}
 			</button>
+		`;
+	}
+
+	private renderMainContent(active: PrWalkthroughCard | undefined): TemplateResult {
+		if (this.status === "loading") return html`${this.renderWarningBanners()}${this.renderLoadingState()}`;
+		if (this.status === "error") return html`${this.renderWarningBanners()}${this.renderErrorState()}`;
+		if (this.status === "ready" && this.cards.length === 0) return html`${this.renderWarningBanners()}${this.renderEmptyState()}`;
+		if (!active) return html`${this.renderWarningBanners()}<div class="state-card" data-testid="pr-walkthrough-empty-state"><h2>No walkthrough cards are available.</h2><p>There are no logical review cards for this changeset.</p></div>`;
+		return html`${this.renderWarningBanners()}${this.renderCard(active)}`;
+	}
+
+	private renderWarningBanners(extraWarnings: WalkthroughWarning[] = []): TemplateResult | typeof nothing {
+		const warnings = [...this.warnings, ...extraWarnings].filter(warning => warning && warning.message);
+		if (!warnings.length) return nothing;
+		return html`
+			<div class="banner-stack" data-testid="pr-walkthrough-warning-list">
+				${warnings.map(warning => html`
+					<div class="banner ${warning.severity}" data-testid="pr-walkthrough-warning" data-warning-code=${warning.code}>
+						<strong>${warning.severity === "error" ? "Error" : warning.severity === "warning" ? "Warning" : "Notice"}${warning.code ? ` · ${warning.code}` : ""}</strong>
+						<div>${warning.message}</div>
+						${warning.filePath ? html`<div class="file">${warning.filePath}</div>` : nothing}
+					</div>
+				`)}
+			</div>
+		`;
+	}
+
+	private renderLoadingState(): TemplateResult {
+		return html`
+			<section class="state-card" data-testid="pr-walkthrough-loading-state" aria-live="polite">
+				<h2>Resolving walkthrough…</h2>
+				<p>Loading PR metadata, changed files, diff hunks, and logical review cards.</p>
+				<div class="skeleton" aria-hidden="true">
+					<div class="skeleton-line short"></div>
+					<div class="skeleton-line medium"></div>
+					<div class="skeleton-box"></div>
+				</div>
+			</section>
+		`;
+	}
+
+	private renderErrorState(): TemplateResult {
+		const message = this.error || "Unable to resolve this walkthrough.";
+		const isAuth = /auth|permission|rate|token/i.test(message);
+		return html`
+			<section class="state-card" data-testid="pr-walkthrough-error-state" role="alert">
+				<h2>${/not found/i.test(message) ? "Pull request not found" : "Walkthrough unavailable"}</h2>
+				<p>${message}</p>
+				${isAuth ? html`<p>Check GitHub credentials or repository permissions, then retry from the walkthrough command.</p>` : nothing}
+			</section>
+		`;
+	}
+
+	private renderEmptyState(): TemplateResult {
+		return html`
+			<section class="state-card" data-testid="pr-walkthrough-empty-state">
+				<h2>No changed files</h2>
+				<p>This changeset resolved successfully but there are no diff hunks to review. Use Submit review to preview or copy a draft summary without publishing anything.</p>
+			</section>
 		`;
 	}
 
@@ -918,6 +1124,219 @@ export class PrWalkthroughPanel extends LitElement {
 				</div>
 			</section>
 		`;
+	}
+
+	private openExportPreview = (): void => {
+		this._exportPreviewOpen = true;
+		this._exportResult = undefined;
+		this._exportError = "";
+		if (this.canUseExportApi) {
+			void this.loadExportPreview();
+			return;
+		}
+		this._exportPreview = this.buildLocalExportPreview();
+	};
+
+	private closeExportPreview = (): void => {
+		this._exportPreviewOpen = false;
+		this._exportPreviewLoading = false;
+		this._exportSubmitting = false;
+	};
+
+	private async loadExportPreview(): Promise<void> {
+		this._exportPreviewLoading = true;
+		this._exportError = "";
+		try {
+			const res = await gatewayFetch(`/api/pr-walkthrough/${encodeURIComponent(this.apiChangesetId)}/export/preview`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(this.currentDraft),
+			});
+			const data = await this.readJsonResponse(res);
+			if (!res.ok) throw new Error(this.errorMessageFromResponse(data, `Preview failed (${res.status})`));
+			this._exportPreview = this.normalizeExportPreview(data);
+		} catch (err) {
+			this._exportError = err instanceof Error ? err.message : "Failed to build export preview.";
+			this._exportPreview = this.buildLocalExportPreview();
+		} finally {
+			this._exportPreviewLoading = false;
+		}
+	}
+
+	private renderExportDialog(): TemplateResult {
+		const preview = this._exportPreview;
+		const rows = this.previewRows(preview);
+		const validRows = rows.filter(row => row.valid !== false);
+		const invalidRows = rows.length - validRows.length;
+		const canSubmit = this.canUseExportApi && !this._exportPreviewLoading && !this._exportSubmitting && !!preview && (preview.canSubmit !== false);
+		const body = preview?.body || preview?.reviewBody || this.buildAuditText();
+		return html`
+			<div class="export-backdrop" data-testid="pr-walkthrough-export-preview" role="dialog" aria-modal="true" aria-label="Review export preview">
+				<section class="export-dialog">
+					<header class="export-head">
+						<h2>Review export preview</h2>
+						<span class="header-spacer"></span>
+						<button class="copy-button" type="button" @click=${() => this.copyAudit(body)}>${this._copied ? "Copied" : "Copy draft"}</button>
+					</header>
+					<div class="export-body">
+						${!this.canUseExportApi ? html`<div class="banner info" data-testid="pr-walkthrough-export-unavailable"><strong>Export unavailable</strong><div>${this.exportUnavailableReason}</div></div>` : nothing}
+						${this._exportError ? html`<div class="banner error" data-testid="pr-walkthrough-export-error"><strong>Export preview failed</strong><div>${this._exportError}</div></div>` : nothing}
+						${this._exportResult ? html`<div class="banner ${this._exportResult.ok === false ? "error" : "info"}" data-testid="pr-walkthrough-export-result"><strong>${this._exportResult.ok === false ? "Submission failed" : "Submitted"}</strong><div>${this._exportResult.message || this._exportResult.error || "GitHub review submitted."}</div>${this._exportResult.url ? html`<div><a href=${this._exportResult.url} target="_blank" rel="noopener noreferrer">Open review ↗</a></div>` : nothing}</div>` : nothing}
+						${this._exportPreviewLoading ? this.renderLoadingState() : html`
+							<div class="export-summary" data-testid="pr-walkthrough-export-summary">
+								<span>${validRows.length} mapped comment${validRows.length === 1 ? "" : "s"}</span>
+								<span>${invalidRows} unmappable</span>
+								<span>${this.currentDraftHasConcerns ? "Request changes" : "Approve"}</span>
+							</div>
+							${this.renderWarningBanners(preview?.warnings ?? [])}
+							<section>
+								<h3>Review body</h3>
+								<pre data-testid="pr-walkthrough-export-body">${body}</pre>
+							</section>
+							<section>
+								<h3>Line comments</h3>
+								${rows.length ? rows.map(row => this.renderExportRow(row)) : html`<div class="empty">No line comments are queued.</div>`}
+							</section>
+						`}
+					</div>
+					<footer class="export-actions">
+						<button type="button" @click=${this.closeExportPreview}>Close</button>
+						<button class="primary" type="button" data-testid="pr-walkthrough-export-submit" ?disabled=${!canSubmit} title=${canSubmit ? "Submit this review to GitHub." : "Preview must be ready and GitHub export must be available."} @click=${this.submitExportReview}>${this._exportSubmitting ? "Submitting…" : "Confirm submit to GitHub"}</button>
+					</footer>
+				</section>
+			</div>
+		`;
+	}
+
+	private renderExportRow(row: WalkthroughExportPreviewRow): TemplateResult {
+		const path = row.path || row.filePath || "Unmapped comment";
+		const anchor = row.line != null ? `${path}:${row.line}` : path;
+		return html`
+			<div class="export-row ${row.valid === false ? "invalid" : ""}" data-testid="pr-walkthrough-export-row" data-valid=${row.valid === false ? "false" : "true"}>
+				<div class="anchor">${row.kind || "line"} · ${anchor}${row.side ? ` · ${row.side}` : ""}</div>
+				<div>${row.body || "No comment body."}</div>
+				${row.valid === false && row.reason ? html`<div class="reason">${row.reason}</div>` : nothing}
+			</div>
+		`;
+	}
+
+	private async submitExportReview(): Promise<void> {
+		if (!this.canUseExportApi || !this._exportPreview || this._exportSubmitting) return;
+		this._exportSubmitting = true;
+		this._exportError = "";
+		this._exportResult = undefined;
+		try {
+			const res = await gatewayFetch(`/api/pr-walkthrough/${encodeURIComponent(this.apiChangesetId)}/export/submit`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ draft: this.currentDraft, confirm: true, event: this.currentDraftHasConcerns ? "REQUEST_CHANGES" : "APPROVE" }),
+			});
+			const data = await this.readJsonResponse(res);
+			if (!res.ok) throw new Error(this.errorMessageFromResponse(data, `Submit failed (${res.status})`));
+			this._exportResult = this.normalizeExportResult(data);
+		} catch (err) {
+			this._exportResult = { ok: false, error: err instanceof Error ? err.message : "Failed to submit GitHub review." };
+		} finally {
+			this._exportSubmitting = false;
+		}
+	}
+
+	private async readJsonResponse(res: Response): Promise<unknown> {
+		try {
+			return await res.json();
+		} catch {
+			return null;
+		}
+	}
+
+	private errorMessageFromResponse(data: unknown, fallback: string): string {
+		if (data && typeof data === "object") {
+			const record = data as Record<string, unknown>;
+			const message = record.message || record.error || record.reason;
+			if (typeof message === "string" && message.trim()) return message.trim();
+		}
+		return fallback;
+	}
+
+	private normalizeExportPreview(data: unknown): WalkthroughExportPreview {
+		if (!data || typeof data !== "object") return this.buildLocalExportPreview();
+		const record = data as Record<string, unknown>;
+		return {
+			body: typeof record.body === "string" ? record.body : undefined,
+			reviewBody: typeof record.reviewBody === "string" ? record.reviewBody : undefined,
+			rows: Array.isArray(record.rows) ? record.rows.map(row => this.normalizeExportRow(row)) : undefined,
+			comments: Array.isArray(record.comments) ? record.comments.map(row => this.normalizeExportRow(row)) : undefined,
+			warnings: Array.isArray(record.warnings) ? record.warnings.map(warning => this.normalizeWarning(warning)).filter((warning): warning is WalkthroughWarning => !!warning) : undefined,
+			validCount: typeof record.validCount === "number" ? record.validCount : undefined,
+			invalidCount: typeof record.invalidCount === "number" ? record.invalidCount : undefined,
+			canSubmit: typeof record.canSubmit === "boolean" ? record.canSubmit : undefined,
+		};
+	}
+
+	private normalizeExportResult(data: unknown): WalkthroughExportResult {
+		if (!data || typeof data !== "object") return { ok: true, message: "GitHub review submitted." };
+		const record = data as Record<string, unknown>;
+		return {
+			ok: typeof record.ok === "boolean" ? record.ok : true,
+			url: typeof record.url === "string" ? record.url : undefined,
+			message: typeof record.message === "string" ? record.message : "GitHub review submitted.",
+			error: typeof record.error === "string" ? record.error : undefined,
+		};
+	}
+
+	private normalizeWarning(data: unknown): WalkthroughWarning | undefined {
+		if (!data || typeof data !== "object") return undefined;
+		const record = data as Record<string, unknown>;
+		const message = typeof record.message === "string" ? record.message : "Walkthrough warning";
+		const severity = record.severity === "error" || record.severity === "info" || record.severity === "warning" ? record.severity : "warning";
+		return {
+			code: typeof record.code === "string" ? record.code : "warning",
+			severity,
+			message,
+			filePath: typeof record.filePath === "string" ? record.filePath : undefined,
+		};
+	}
+
+	private normalizeExportRow(data: unknown): WalkthroughExportPreviewRow {
+		if (!data || typeof data !== "object") return { valid: false, reason: "Invalid preview row" };
+		const record = data as Record<string, unknown>;
+		return {
+			path: typeof record.path === "string" ? record.path : undefined,
+			filePath: typeof record.filePath === "string" ? record.filePath : undefined,
+			side: typeof record.side === "string" ? record.side : undefined,
+			line: typeof record.line === "number" ? record.line : undefined,
+			body: typeof record.body === "string" ? record.body : undefined,
+			valid: typeof record.valid === "boolean" ? record.valid : undefined,
+			reason: typeof record.reason === "string" ? record.reason : undefined,
+			kind: typeof record.kind === "string" ? record.kind : undefined,
+		};
+	}
+
+	private previewRows(preview: WalkthroughExportPreview | undefined): WalkthroughExportPreviewRow[] {
+		return preview?.rows ?? preview?.comments ?? [];
+	}
+
+	private buildLocalExportPreview(): WalkthroughExportPreview {
+		const draft = this.currentDraft;
+		const rows: WalkthroughExportPreviewRow[] = draft.comments
+			.filter(comment => comment.diffBlockId && comment.lineId)
+			.map(comment => {
+				const anchor = this.findLineAnchor(comment);
+				const valid = anchor.filePath !== "Card-level" && typeof anchor.line === "number";
+				return {
+					path: anchor.filePath,
+					line: typeof anchor.line === "number" ? anchor.line : undefined,
+					body: comment.body,
+					valid,
+					reason: valid ? undefined : "This comment does not map to a changed GitHub line.",
+				};
+			});
+		return {
+			body: this.buildAuditText(),
+			rows,
+			warnings: this.canUseExportApi ? [] : [{ code: "export-unavailable", severity: "info", message: this.exportUnavailableReason }],
+			canSubmit: false,
+		};
 	}
 
 	private cardsForPhase(phaseId: PrWalkthroughPhaseId): PrWalkthroughCard[] {
@@ -1143,6 +1562,10 @@ export class PrWalkthroughPanel extends LitElement {
 		return this.persistenceKey ? `bobbit:pr-walkthrough:${this.persistenceKey}` : "";
 	}
 
+	private cardsChecksum(): string {
+		return this.cards.map(card => `${card.id}:${card.phaseId}:${card.diffBlocks.map(block => `${block.id}:${block.filePath}:${block.hunks.length}`).join("|")}`).join(";");
+	}
+
 	private restorePersistedState(): void {
 		this.resetInteractionState();
 		const key = this.persistenceStorageKey();
@@ -1152,6 +1575,7 @@ export class PrWalkthroughPanel extends LitElement {
 			const raw = localStorage.getItem(key);
 			if (!raw) return;
 			const parsed = JSON.parse(raw) as PersistedPrWalkthroughState;
+			if (this.status !== "fixture" && parsed.cardsChecksum !== this.cardsChecksum()) return;
 			if (parsed.activeCardId && this.cards.some(card => card.id === parsed.activeCardId)) this._activeCardId = parsed.activeCardId;
 			if (parsed.diffModeOverride === "split" || parsed.diffModeOverride === "inline") this._diffModeOverride = parsed.diffModeOverride;
 			if (Array.isArray(parsed.comments)) this._comments = parsed.comments.filter(comment => comment && typeof comment.id === "string" && typeof comment.cardId === "string" && typeof comment.body === "string");
@@ -1169,6 +1593,8 @@ export class PrWalkthroughPanel extends LitElement {
 		const key = this.persistenceStorageKey();
 		if (!key || this._loadedPersistenceKey !== this.persistenceKey || typeof localStorage === "undefined") return;
 		const persisted: PersistedPrWalkthroughState = {
+			schemaVersion: 2,
+			cardsChecksum: this.cardsChecksum(),
 			activeCardId: this._activeCardId,
 			diffModeOverride: this._diffModeOverride,
 			comments: this._comments,

--- a/src/ui/components/pr-walkthrough/types.ts
+++ b/src/ui/components/pr-walkthrough/types.ts
@@ -17,6 +17,7 @@ export type PrWalkthroughPhaseId = "orientation" | "design" | "significant" | "o
 export type PrWalkthroughDiffLineSide = "old" | "new" | "context";
 export type PrWalkthroughDiffLineKind = "context" | "add" | "del";
 export type PrWalkthroughDiffMode = "split" | "inline";
+export type PrWalkthroughDiffBlockStatus = "added" | "modified" | "deleted" | "renamed" | "copied" | "binary";
 
 export interface PrWalkthroughDiffLine {
 	id: string;
@@ -37,6 +38,10 @@ export interface PrWalkthroughDiffBlock {
 	id: string;
 	filePath: string;
 	oldPath?: string;
+	status?: PrWalkthroughDiffBlockStatus;
+	isBinary?: boolean;
+	isGenerated?: boolean;
+	isTruncated?: boolean;
 	hunks: PrWalkthroughHunk[];
 }
 

--- a/tests/e2e/pr-walkthrough-api.spec.ts
+++ b/tests/e2e/pr-walkthrough-api.spec.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { createServer } from "node:http";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -42,6 +43,23 @@ async function resolveLocal(fixture: GitFixture): Promise<any> {
 	});
 	expect(resp.status).toBe(200);
 	return resp.json();
+}
+
+async function startMockGithubApi(status: number, body: unknown, headers: Record<string, string> = {}): Promise<{ baseUrl: string; requests: Array<{ url?: string; authorization?: string }>; close: () => Promise<void> }> {
+	const requests: Array<{ url?: string; authorization?: string }> = [];
+	const server = createServer((req, res) => {
+		requests.push({ url: req.url, authorization: req.headers.authorization });
+		res.writeHead(status, { "Content-Type": "application/json", ...headers });
+		res.end(JSON.stringify(body));
+	});
+	await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+	const address = server.address();
+	if (!address || typeof address !== "object") throw new Error("mock GitHub API did not bind a TCP port");
+	return {
+		baseUrl: `http://127.0.0.1:${address.port}`,
+		requests,
+		close: () => new Promise<void>((resolve, reject) => server.close(err => err ? reject(err) : resolve())),
+	};
 }
 
 function firstLineAnchor(result: any): { cardId: string; diffBlockId: string; lineId: string } {
@@ -147,6 +165,49 @@ test.describe("PR walkthrough REST API", () => {
 			expect(result.cards[0].phaseId).toBe("orientation");
 		} finally {
 			fixture.cleanup();
+		}
+	});
+
+	test("GitHub PR resolve rejects untrusted hosts with typed errors", async () => {
+		const previousToken = process.env.GITHUB_TOKEN;
+		process.env.GITHUB_TOKEN = "must-not-leak";
+		try {
+			const resp = await apiFetch("/api/pr-walkthrough/resolve", {
+				method: "POST",
+				body: JSON.stringify({ prUrl: "https://evil.example/acme/widgets/pull/42" }),
+			});
+			expect(resp.status).toBe(400);
+			const body = await resp.json();
+			expect(body.code).toBe("untrusted_github_host");
+			expect(body.error).toContain("Untrusted GitHub PR host");
+		} finally {
+			if (previousToken === undefined) delete process.env.GITHUB_TOKEN;
+			else process.env.GITHUB_TOKEN = previousToken;
+		}
+	});
+
+	test("GitHub adapter auth and permission errors preserve status, code, and warnings", async () => {
+		const mock = await startMockGithubApi(403, { message: "Forbidden" }, { "x-ratelimit-remaining": "5" });
+		const previousApiBase = process.env.BOBBIT_GITHUB_API_BASE_URL;
+		const previousToken = process.env.GITHUB_TOKEN;
+		process.env.BOBBIT_GITHUB_API_BASE_URL = mock.baseUrl;
+		process.env.GITHUB_TOKEN = "mock-token";
+		try {
+			const resp = await apiFetch("/api/pr-walkthrough/resolve", {
+				method: "POST",
+				body: JSON.stringify({ prUrl: "https://github.com/acme/widgets/pull/42" }),
+			});
+			expect(resp.status).toBe(403);
+			const body = await resp.json();
+			expect(body.code).toBe("github_permission_denied");
+			expect(body.warnings.some((warning: any) => warning.code === "github_permission_denied")).toBe(true);
+			expect(mock.requests[0]?.authorization).toBe("Bearer mock-token");
+		} finally {
+			await mock.close();
+			if (previousApiBase === undefined) delete process.env.BOBBIT_GITHUB_API_BASE_URL;
+			else process.env.BOBBIT_GITHUB_API_BASE_URL = previousApiBase;
+			if (previousToken === undefined) delete process.env.GITHUB_TOKEN;
+			else process.env.GITHUB_TOKEN = previousToken;
 		}
 	});
 

--- a/tests/e2e/pr-walkthrough-api.spec.ts
+++ b/tests/e2e/pr-walkthrough-api.spec.ts
@@ -151,6 +151,33 @@ test.describe("PR walkthrough REST API", () => {
 		}
 	});
 
+	test("large local diffs return truncation warnings instead of maxBuffer failures", async () => {
+		const cwd = mkdtempSync(join(tmpdir(), "bobbit-pr-walkthrough-large-"));
+		try {
+			git(cwd, ["init"]);
+			git(cwd, ["config", "user.name", "Bobbit E2E"]);
+			git(cwd, ["config", "user.email", "bobbit-e2e@example.test"]);
+			writeFileSync(join(cwd, "large.txt"), "base\n", "utf-8");
+			git(cwd, ["add", "."]);
+			git(cwd, ["commit", "-m", "base"]);
+			const baseSha = git(cwd, ["rev-parse", "HEAD"]);
+			writeFileSync(join(cwd, "large.txt"), Array.from({ length: 220_000 }, (_, index) => `line ${index} ${"x".repeat(16)}`).join("\n"), "utf-8");
+			git(cwd, ["add", "."]);
+			git(cwd, ["commit", "-m", "large"]);
+			const headSha = git(cwd, ["rev-parse", "HEAD"]);
+
+			const resp = await apiFetch("/api/pr-walkthrough/resolve", {
+				method: "POST",
+				body: JSON.stringify({ cwd, baseSha, headSha }),
+			});
+			expect(resp.status).toBe(200);
+			const result = await resp.json();
+			expect(result.warnings.some((warning: any) => warning.code === "diff-truncated")).toBe(true);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
 	test("empty local diffs resolve to an orientation-only walkthrough instead of a broken response", async () => {
 		const fixture = makeGitFixture();
 		try {
@@ -224,6 +251,7 @@ test.describe("PR walkthrough REST API", () => {
 			expect(result.changesetId).toBe(`github:acme/widgets#42:${fixture.headSha.slice(0, 7)}`);
 			expect(result.changeset.provider).toBe("github");
 			expect(result.changeset.prUrl).toBe(prUrl);
+			expect(result.changeset.externalUrl).toBe(prUrl);
 			expect(result.export.previewOnly).toBe(true);
 
 			const submitResp = await apiFetch(`/api/pr-walkthrough/${encodeURIComponent(result.changesetId)}/export/submit`, {
@@ -232,6 +260,23 @@ test.describe("PR walkthrough REST API", () => {
 			});
 			expect(submitResp.status).toBe(400);
 			expect((await submitResp.json()).code).toBe("EXPORT_UNAVAILABLE");
+		} finally {
+			fixture.cleanup();
+		}
+	});
+
+	test("local SHA plus unsafe PR metadata does not persist clickable external URLs", async () => {
+		const fixture = makeGitFixture();
+		try {
+			const resp = await apiFetch("/api/pr-walkthrough/resolve", {
+				method: "POST",
+				body: JSON.stringify({ cwd: fixture.cwd, prUrl: "javascript:alert(1)", prNumber: 42, baseSha: fixture.baseSha, headSha: fixture.headSha }),
+			});
+			expect(resp.status).toBe(200);
+			const result = await resp.json();
+			expect(result.changeset.provider).toBe("github");
+			expect(result.changeset.prUrl).toBeUndefined();
+			expect(result.changeset.externalUrl).toBeUndefined();
 		} finally {
 			fixture.cleanup();
 		}

--- a/tests/e2e/pr-walkthrough-api.spec.ts
+++ b/tests/e2e/pr-walkthrough-api.spec.ts
@@ -1,0 +1,178 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { test, expect } from "./in-process-harness.js";
+import { apiFetch } from "./e2e-setup.js";
+
+type GitFixture = {
+	cwd: string;
+	baseSha: string;
+	headSha: string;
+	cleanup: () => void;
+};
+
+function git(cwd: string, args: string[]): string {
+	return execFileSync("git", args, { cwd, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+}
+
+function makeGitFixture(): GitFixture {
+	const cwd = mkdtempSync(join(tmpdir(), "bobbit-pr-walkthrough-"));
+	git(cwd, ["init"]);
+	git(cwd, ["config", "user.name", "Bobbit E2E"]);
+	git(cwd, ["config", "user.email", "bobbit-e2e@example.test"]);
+	writeFileSync(join(cwd, "README.md"), "# Demo\n\nFirst line\n", "utf-8");
+	git(cwd, ["add", "."]);
+	git(cwd, ["commit", "-m", "base"]);
+	const baseSha = git(cwd, ["rev-parse", "HEAD"]);
+	mkdirSync(join(cwd, "src"));
+	writeFileSync(join(cwd, "README.md"), "# Demo\n\nFirst line\nSecond line\n", "utf-8");
+	writeFileSync(join(cwd, "src", "feature.ts"), "export const answer = 42;\n", "utf-8");
+	git(cwd, ["add", "."]);
+	git(cwd, ["commit", "-m", "head"]);
+	const headSha = git(cwd, ["rev-parse", "HEAD"]);
+	return { cwd, baseSha, headSha, cleanup: () => rmSync(cwd, { recursive: true, force: true }) };
+}
+
+async function resolveLocal(fixture: GitFixture): Promise<any> {
+	const resp = await apiFetch("/api/pr-walkthrough/resolve", {
+		method: "POST",
+		body: JSON.stringify({ cwd: fixture.cwd, baseSha: fixture.baseSha, headSha: fixture.headSha }),
+	});
+	expect(resp.status).toBe(200);
+	return resp.json();
+}
+
+function firstLineAnchor(result: any): { cardId: string; diffBlockId: string; lineId: string } {
+	for (const card of result.cards ?? []) {
+		for (const block of card.diffBlocks ?? []) {
+			for (const hunk of block.hunks ?? []) {
+				const line = (hunk.lines ?? []).find((item: any) => item.newLine || item.oldLine);
+				if (line) return { cardId: card.id, diffBlockId: block.id, lineId: line.id };
+			}
+		}
+	}
+	throw new Error("resolved walkthrough had no line anchors");
+}
+
+test.describe("PR walkthrough REST API", () => {
+	test("POST resolve returns real local diff cards and GET returns persisted state", async () => {
+		const fixture = makeGitFixture();
+		try {
+			const result = await resolveLocal(fixture);
+			expect(result.changesetId).toBe(`${fixture.baseSha.slice(0, 7)}..${fixture.headSha.slice(0, 7)}`);
+			expect(result.changeset.provider).toBe("local");
+			expect(result.changeset.filesChanged).toBe(2);
+			expect(result.cards.length).toBeGreaterThanOrEqual(2);
+			expect(result.cards.flatMap((card: any) => card.diffBlocks).some((block: any) => block.filePath === "src/feature.ts")).toBe(true);
+
+			const getResp = await apiFetch(`/api/pr-walkthrough/${encodeURIComponent(result.changesetId)}`);
+			expect(getResp.status).toBe(200);
+			const persisted = await getResp.json();
+			expect(persisted.changesetId).toBe(result.changesetId);
+			expect(persisted.schemaVersion).toBe(1);
+			expect(persisted.cards.length).toBe(result.cards.length);
+		} finally {
+			fixture.cleanup();
+		}
+	});
+
+	test("export preview maps line comments and submit rejects without explicit confirmation", async () => {
+		const fixture = makeGitFixture();
+		try {
+			const result = await resolveLocal(fixture);
+			const anchor = firstLineAnchor(result);
+			const draft = {
+				changeset: result.changeset,
+				decisions: {},
+				completedCardIds: [anchor.cardId],
+				updatedAt: new Date().toISOString(),
+				comments: [
+					{ id: "line-1", ...anchor, body: "Please double-check this line.", source: "custom", createdAt: new Date().toISOString() },
+					{ id: "card-1", cardId: anchor.cardId, body: "Card-level concern", source: "custom", createdAt: new Date().toISOString() },
+				],
+			};
+
+			const previewResp = await apiFetch(`/api/pr-walkthrough/${encodeURIComponent(result.changesetId)}/export/preview`, {
+				method: "POST",
+				body: JSON.stringify(draft),
+			});
+			expect(previewResp.status).toBe(200);
+			const preview = await previewResp.json();
+			expect(preview.rows.some((row: any) => row.commentId === "line-1" && row.valid && row.path)).toBe(true);
+			expect(preview.body).toContain("Card-level concern");
+
+			const submitResp = await apiFetch(`/api/pr-walkthrough/${encodeURIComponent(result.changesetId)}/export/submit`, {
+				method: "POST",
+				body: JSON.stringify({ draft }),
+			});
+			expect(submitResp.status).toBe(400);
+			const submitBody = await submitResp.json();
+			expect(submitBody.code).toBe("CONFIRMATION_REQUIRED");
+		} finally {
+			fixture.cleanup();
+		}
+	});
+
+	test("invalid refs and missing persisted walkthroughs return structured errors", async () => {
+		const fixture = makeGitFixture();
+		try {
+			const invalidResp = await apiFetch("/api/pr-walkthrough/resolve", {
+				method: "POST",
+				body: JSON.stringify({ cwd: fixture.cwd, baseSha: "not-a-sha", headSha: fixture.headSha }),
+			});
+			expect(invalidResp.status).toBe(400);
+			expect((await invalidResp.json()).error).toContain("Invalid baseSha");
+
+			const missingResp = await apiFetch(`/api/pr-walkthrough/${encodeURIComponent("missing..walkthrough")}`);
+			expect(missingResp.status).toBe(404);
+			expect((await missingResp.json()).error).toContain("Walkthrough not found");
+		} finally {
+			fixture.cleanup();
+		}
+	});
+
+	test("empty local diffs resolve to an orientation-only walkthrough instead of a broken response", async () => {
+		const fixture = makeGitFixture();
+		try {
+			const resp = await apiFetch("/api/pr-walkthrough/resolve", {
+				method: "POST",
+				body: JSON.stringify({ cwd: fixture.cwd, baseSha: fixture.headSha, headSha: fixture.headSha }),
+			});
+			expect(resp.status).toBe(200);
+			const result = await resp.json();
+			expect(result.changeset.filesChanged).toBe(0);
+			expect(result.cards).toHaveLength(1);
+			expect(result.cards[0].phaseId).toBe("orientation");
+		} finally {
+			fixture.cleanup();
+		}
+	});
+
+	test("GitHub PR resolve can be faked from local SHAs and remains preview-only without credentials", async () => {
+		const fixture = makeGitFixture();
+		try {
+			const prUrl = "https://github.com/acme/widgets/pull/42";
+			const resp = await apiFetch("/api/pr-walkthrough/resolve", {
+				method: "POST",
+				body: JSON.stringify({ cwd: fixture.cwd, prUrl, baseSha: fixture.baseSha, headSha: fixture.headSha }),
+			});
+			expect(resp.status).toBe(200);
+			const result = await resp.json();
+			expect(result.changesetId).toBe(`github:acme/widgets#42:${fixture.headSha.slice(0, 7)}`);
+			expect(result.changeset.provider).toBe("github");
+			expect(result.changeset.prUrl).toBe(prUrl);
+			expect(result.export.previewOnly).toBe(true);
+
+			const submitResp = await apiFetch(`/api/pr-walkthrough/${encodeURIComponent(result.changesetId)}/export/submit`, {
+				method: "POST",
+				body: JSON.stringify({ draft: { comments: [] }, confirm: true }),
+			});
+			expect(submitResp.status).toBe(400);
+			expect((await submitResp.json()).code).toBe("EXPORT_UNAVAILABLE");
+		} finally {
+			fixture.cleanup();
+		}
+	});
+});

--- a/tests/e2e/ui/pr-walkthrough-panel.spec.ts
+++ b/tests/e2e/ui/pr-walkthrough-panel.spec.ts
@@ -9,6 +9,45 @@ const PANEL_TAB_SELECTOR = ".goal-preview-panel .goal-tab-pill[data-panel-tab-ki
 
 const tid = (id: string) => `[data-testid="${id}"]`;
 
+function resolvedWalkthroughPayload(prNumber: string | number, title = "Resolved Walkthrough PR") {
+	return {
+		changesetId: `github:SuuBro/bobbit#${prNumber}:abc1234`,
+		changeset: {
+			baseSha: "base1234",
+			headSha: "abc1234",
+			provider: "github",
+			externalUrl: `https://github.com/SuuBro/bobbit/pull/${prNumber}`,
+			prUrl: `https://github.com/SuuBro/bobbit/pull/${prNumber}`,
+			prNumber,
+			prTitle: title,
+			title: `PR #${prNumber}: ${title}`,
+			filesChanged: 1,
+			additions: 2,
+			deletions: 1,
+		},
+		cards: [{
+			id: "resolved-card",
+			phaseId: "orientation",
+			title: "Resolved logical card",
+			summary: "This card came from the resolver API, not the fixture fallback.",
+			diffBlocks: [{
+				id: "resolved-block",
+				filePath: "src/app/pr-walkthrough.ts",
+				hunks: [{
+					id: "resolved-hunk",
+					header: "@@ -1,1 +1,2 @@",
+					lines: [
+						{ id: "resolved-line-1", side: "context", oldLine: 1, newLine: 1, kind: "context", text: "export const existing = true;" },
+						{ id: "resolved-line-2", side: "new", newLine: 2, kind: "add", text: "export const resolved = true;" },
+					],
+				}],
+			}],
+		}],
+		warnings: [{ code: "test-warning", severity: "info", message: "Resolver warning surfaced." }],
+		export: { provider: "github", available: true },
+	};
+}
+
 function walkthroughPanel(page: Page): Locator {
 	return page.getByTestId("pr-walkthrough-panel");
 }
@@ -387,6 +426,37 @@ test.describe("PR walkthrough panel", () => {
 		await expect(walkthroughPanel(standalone), "standalone tab should render the same walkthrough component").toBeVisible({ timeout: 15_000 });
 		await expectActiveDiffMode(standalone, "split");
 		await standalone.close();
+	});
+
+	test("slash command opens immediately, calls resolver, and applies resolved cards", async ({ page }) => {
+		let releaseResolve!: () => void;
+		const waitForRelease = new Promise<void>((resolve) => { releaseResolve = resolve; });
+		let requestBody: Record<string, unknown> | undefined;
+		await page.route("**/api/pr-walkthrough/resolve", async (route) => {
+			requestBody = JSON.parse(route.request().postData() || "{}") as Record<string, unknown>;
+			await waitForRelease;
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				body: JSON.stringify(resolvedWalkthroughPayload("789", "Resolved Real PR")),
+			});
+		});
+
+		await page.setViewportSize({ width: 1920, height: 1080 });
+		await openApp(page);
+		await createSessionViaUI(page);
+		await sendMessage(page, "/walkthrough-pr 789");
+
+		const root = page.getByTestId("pr-walkthrough-panel-root");
+		await expect(page.locator(PANEL_TAB_SELECTOR).first(), "walkthrough tab should open before the resolver returns").toBeVisible({ timeout: 15_000 });
+		await expect(root, "new resolver-backed tabs should expose loading state while resolving").toHaveAttribute("data-walkthrough-status", "loading");
+		await expect.poll(() => requestBody?.prNumber, { timeout: 5_000 }).toBe("789");
+
+		releaseResolve();
+		await expect(root, "resolved payload should update the existing walkthrough render path").toHaveAttribute("data-walkthrough-status", "ready", { timeout: 10_000 });
+		await expect(page.locator(".goal-preview-panel .goal-tab-pill.goal-tab-pill--active[data-panel-tab-kind='walkthrough']").first()).toHaveAttribute("data-panel-tab-id", /github%3ASuuBro%2Fbobbit%23789%3Aabc1234/);
+		await expect(walkthroughPanel(page).locator(".title"), "header should switch from launch placeholder to resolved PR metadata").toContainText("PR #789: Resolved Real PR");
+		await expect(activeCard(page).getByTestId("pr-walkthrough-card-title"), "cards should come from the resolver response").toContainText("Resolved logical card");
 	});
 
 	test("URL launches expose an external GitHub/PR link in the walkthrough header", async ({ page }) => {

--- a/tests/e2e/ui/pr-walkthrough-real.spec.ts
+++ b/tests/e2e/ui/pr-walkthrough-real.spec.ts
@@ -31,6 +31,7 @@ const realChangeset = {
 const diffBlock = {
 	id: "src-app-pr-walkthrough-ts",
 	filePath: "src/app/pr-walkthrough.ts",
+	externalUrl: "https://github.com/SuuBro/bobbit/blob/2222222/src/app/pr-walkthrough.ts",
 	hunks: [{
 		id: "src-app-pr-walkthrough-ts:h0",
 		header: "@@ -120,6 +120,12 @@ export async function resolvePrWalkthrough",
@@ -259,6 +260,7 @@ test.describe("real PR walkthrough browser UX", () => {
 		await expect(activeCard(page).getByTestId("pr-walkthrough-card-title"), "resolved cards should replace the fixture fallback").toContainText("Resolved changeset overview", { timeout: 10_000 });
 		await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-pr-title")).toContainText("Real-ish walkthrough cards");
 		await expect(activeCard(page)).toContainText("src/app/pr-walkthrough.ts");
+		await expect(activeCard(page).getByTestId("pr-walkthrough-external-file-link").first()).toHaveAttribute("href", "https://github.com/SuuBro/bobbit/blob/2222222/src/app/pr-walkthrough.ts");
 		await expect(activeCard(page)).toContainText("gatewayFetch('/api/pr-walkthrough/resolve'");
 		await expect.poll(() => state.resolveCalls.length, { timeout: 5_000 }).toBe(1);
 		expect(JSON.stringify(state.resolveCalls[0])).toContain(REAL_PR_URL);

--- a/tests/e2e/ui/pr-walkthrough-real.spec.ts
+++ b/tests/e2e/ui/pr-walkthrough-real.spec.ts
@@ -31,6 +31,7 @@ const realChangeset = {
 const diffBlock = {
 	id: "src-app-pr-walkthrough-ts",
 	filePath: "src/app/pr-walkthrough.ts",
+	status: "modified",
 	externalUrl: "https://github.com/SuuBro/bobbit/blob/2222222/src/app/pr-walkthrough.ts",
 	hunks: [{
 		id: "src-app-pr-walkthrough-ts:h0",
@@ -46,6 +47,8 @@ const diffBlock = {
 const persistedBlock = {
 	id: "src-server-store-ts",
 	filePath: "src/server/pr-walkthrough/walkthrough-store.ts",
+	oldPath: "src/server/pr-walkthrough/store.ts",
+	status: "renamed",
 	hunks: [{
 		id: "src-server-store-ts:h0",
 		header: "@@ -30,7 +30,11 @@ export async function saveWalkthroughState",
@@ -260,6 +263,7 @@ test.describe("real PR walkthrough browser UX", () => {
 		await expect(activeCard(page).getByTestId("pr-walkthrough-card-title"), "resolved cards should replace the fixture fallback").toContainText("Resolved changeset overview", { timeout: 10_000 });
 		await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-pr-title")).toContainText("Real-ish walkthrough cards");
 		await expect(activeCard(page)).toContainText("src/app/pr-walkthrough.ts");
+		await expect(activeCard(page).getByTestId("pr-walkthrough-diff-status").first()).toContainText("Modified");
 		await expect(activeCard(page).getByTestId("pr-walkthrough-external-file-link").first()).toHaveAttribute("href", "https://github.com/SuuBro/bobbit/blob/2222222/src/app/pr-walkthrough.ts");
 		await expect(activeCard(page)).toContainText("gatewayFetch('/api/pr-walkthrough/resolve'");
 		await expect.poll(() => state.resolveCalls.length, { timeout: 5_000 }).toBe(1);
@@ -300,6 +304,7 @@ test.describe("real PR walkthrough browser UX", () => {
 		await saveLineComment(page, "Persisted line comment from browser test");
 		await walkthroughPanel(page).getByTestId("pr-walkthrough-dislike").first().click();
 		await expect(activeCard(page).getByTestId("pr-walkthrough-card-title")).toContainText("Persist walkthrough state");
+		await expect(activeCard(page).getByTestId("pr-walkthrough-diff-status").filter({ hasText: "Renamed" }).first(), "renamed file status should be explicit in diff headers").toBeVisible();
 		await saveCardComment(page, "Card-level export concern from browser test");
 		await walkthroughPanel(page).getByTestId("pr-walkthrough-like").first().click();
 		await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-audit")).toBeVisible({ timeout: 10_000 });

--- a/tests/e2e/ui/pr-walkthrough-real.spec.ts
+++ b/tests/e2e/ui/pr-walkthrough-real.spec.ts
@@ -1,0 +1,335 @@
+import type { Locator, Page, Route } from "@playwright/test";
+import { test, expect } from "../gateway-harness.js";
+import { openApp, createSessionViaUI, sendMessage } from "./ui-helpers.js";
+
+const PANEL_TAB_SELECTOR = ".goal-preview-panel .goal-tab-pill[data-panel-tab-kind='walkthrough']";
+const REAL_PR_URL = "https://github.com/SuuBro/bobbit/pull/999";
+const tid = (id: string) => `[data-testid="${id}"]`;
+
+interface MockWalkthroughState {
+	mode: "success" | "missing" | "warnings";
+	resolveCalls: unknown[];
+	previewCalls: unknown[];
+	submitCalls: unknown[];
+	resolveDelay?: Promise<void>;
+}
+
+const realChangeset = {
+	baseSha: "1111111111111111111111111111111111111111",
+	headSha: "2222222222222222222222222222222222222222",
+	provider: "github",
+	prUrl: REAL_PR_URL,
+	externalUrl: REAL_PR_URL,
+	prNumber: 999,
+	prTitle: "Real-ish walkthrough cards",
+	title: "PR #999: Real-ish walkthrough cards",
+	filesChanged: 3,
+	additions: 41,
+	deletions: 12,
+};
+
+const diffBlock = {
+	id: "src-app-pr-walkthrough-ts",
+	filePath: "src/app/pr-walkthrough.ts",
+	hunks: [{
+		id: "src-app-pr-walkthrough-ts:h0",
+		header: "@@ -120,6 +120,12 @@ export async function resolvePrWalkthrough",
+		lines: [
+			{ id: "src-app-pr-walkthrough-ts:h0:l0", side: "context", oldLine: 120, newLine: 120, text: "\tconst request = normalizeWalkthroughInput(input);", kind: "context" },
+			{ id: "src-app-pr-walkthrough-ts:h0:l1", side: "new", newLine: 121, text: "\tconst resolved = await gatewayFetch('/api/pr-walkthrough/resolve', request);", kind: "add" },
+			{ id: "src-app-pr-walkthrough-ts:h0:l2", side: "new", newLine: 122, text: "\tupdateWalkthroughTab(tabId, resolved);", kind: "add" },
+		],
+	}],
+};
+
+const persistedBlock = {
+	id: "src-server-store-ts",
+	filePath: "src/server/pr-walkthrough/walkthrough-store.ts",
+	hunks: [{
+		id: "src-server-store-ts:h0",
+		header: "@@ -30,7 +30,11 @@ export async function saveWalkthroughState",
+		lines: [
+			{ id: "src-server-store-ts:h0:l0", side: "context", oldLine: 30, newLine: 30, text: "\tconst key = storageKey(changesetId);", kind: "context" },
+			{ id: "src-server-store-ts:h0:l1", side: "old", oldLine: 31, text: "\tawait writeJson(key, state);", kind: "del" },
+			{ id: "src-server-store-ts:h0:l2", side: "new", newLine: 31, text: "\tawait writeJson(key, { schemaVersion: 1, ...state });", kind: "add" },
+		],
+	}],
+};
+
+const realCards = [
+	{
+		id: "real-orientation",
+		phaseId: "orientation",
+		title: "Resolved changeset overview",
+		summary: "These cards were generated from a mocked resolver response rather than the fixture fallback.",
+		diffBlocks: [diffBlock],
+		checklist: ["Confirm the resolver request uses the PR URL", "Keep GitHub data at the adapter boundary"],
+	},
+	{
+		id: "real-design",
+		phaseId: "design",
+		title: "Persist walkthrough state across routes",
+		summary: "The server payload includes multiple diff blocks and should survive side panel, fullscreen, reload, and standalone usage.",
+		diffBlocks: [diffBlock, persistedBlock],
+		suggestedComments: [{
+			id: "suggest-persist-schema",
+			cardId: "real-design",
+			diffBlockId: "src-server-store-ts",
+			lineId: "src-server-store-ts:h0:l2",
+			body: "Good call versioning the persisted walkthrough payload before restoring comments.",
+		}],
+		cardSuggestions: ["Call out the schema migration behavior in the final review."],
+	},
+	{
+		id: "real-audit",
+		phaseId: "audit",
+		title: "Audit and export",
+		summary: "Audit card summarises the review draft and export preview.",
+		diffBlocks: [persistedBlock],
+	},
+];
+
+const successPayload = {
+	changesetId: "github:SuuBro/bobbit#999:2222222",
+	changeset: realChangeset,
+	cards: realCards,
+	warnings: [],
+	export: {
+		provider: "github",
+		available: true,
+		canSubmit: true,
+		reason: "GitHub token available in test mock",
+	},
+};
+
+const warningPayload = {
+	...successPayload,
+	changesetId: "github:SuuBro/bobbit#1000:3333333",
+	changeset: {
+		...realChangeset,
+		prNumber: 1000,
+		prTitle: "Large private walkthrough",
+		title: "PR #1000: Large private walkthrough",
+		filesChanged: 48,
+		additions: 1200,
+		deletions: 300,
+	},
+	warnings: [
+		{ code: "github-auth", severity: "warning", message: "GitHub token is required to load private review metadata." },
+		{ code: "diff-truncated", severity: "warning", message: "Large diff truncated after 20 files; omitted generated snapshots.", filePath: "src/generated/snapshot.json" },
+	],
+};
+
+function walkthroughPanel(page: Page): Locator {
+	return page.getByTestId("pr-walkthrough-panel");
+}
+
+function activeCard(page: Page): Locator {
+	return walkthroughPanel(page).locator(`${tid("pr-walkthrough-card")}[data-active="true"]`).first();
+}
+
+async function installMockWalkthroughApi(page: Page, state: MockWalkthroughState) {
+	await page.context().route("**/api/pr-walkthrough/**", async (route: Route) => {
+		const request = route.request();
+		const url = new URL(request.url());
+		const method = request.method();
+		let body: unknown;
+		if (method !== "GET") {
+			try {
+				body = request.postDataJSON();
+			} catch {
+				body = undefined;
+			}
+		}
+
+		if (url.pathname.endsWith("/export/preview") && method === "POST") {
+			state.previewCalls.push(body);
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				body: JSON.stringify({
+					changesetId: successPayload.changesetId,
+					body: "Review preview for PR #999",
+					comments: [
+						{ path: "src/app/pr-walkthrough.ts", side: "RIGHT", line: 121, body: "Persisted line comment from browser test", valid: true },
+						{ path: "dist/generated.bundle.js", side: "RIGHT", line: 1, body: "Generated files are not exported as line comments", valid: false, reason: "Generated or truncated file cannot be mapped to GitHub" },
+					],
+					warnings: [{ code: "unmappable-comment", message: "1 comment cannot be mapped to GitHub." }],
+					canSubmit: true,
+				}),
+			});
+			return;
+		}
+
+		if (url.pathname.endsWith("/export/submit") && method === "POST") {
+			state.submitCalls.push(body);
+			const confirmed = Boolean((body as { confirm?: boolean } | undefined)?.confirm);
+			await route.fulfill({
+				status: confirmed ? 200 : 400,
+				contentType: "application/json",
+				body: JSON.stringify(confirmed
+					? { ok: true, submitted: true, reviewUrl: `${REAL_PR_URL}#pullrequestreview-1` }
+					: { ok: false, error: "Explicit confirmation is required before submitting a GitHub review." }),
+			});
+			return;
+		}
+
+		if (url.pathname === "/api/pr-walkthrough/resolve" && method === "POST") {
+			state.resolveCalls.push(body);
+			if (state.resolveDelay) await state.resolveDelay;
+			if (state.mode === "missing") {
+				await route.fulfill({
+					status: 404,
+					contentType: "application/json",
+					body: JSON.stringify({ code: "not_found", error: "Pull request not found: #404" }),
+				});
+				return;
+			}
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				body: JSON.stringify(state.mode === "warnings" ? warningPayload : successPayload),
+			});
+			return;
+		}
+
+		if (method === "GET") {
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				body: JSON.stringify(state.mode === "warnings" ? warningPayload : successPayload),
+			});
+			return;
+		}
+
+		await route.fallback();
+	});
+}
+
+async function setupSession(page: Page) {
+	await page.setViewportSize({ width: 1600, height: 940 });
+	await openApp(page);
+	await createSessionViaUI(page);
+}
+
+async function openRealWalkthrough(page: Page, state: MockWalkthroughState, command = `/walkthrough-pr ${REAL_PR_URL}`) {
+	await installMockWalkthroughApi(page, state);
+	await setupSession(page);
+	await sendMessage(page, command);
+	await expect(page.locator(PANEL_TAB_SELECTOR).first(), "walkthrough side-panel tab should open immediately").toBeVisible({ timeout: 15_000 });
+}
+
+async function saveLineComment(page: Page, body: string) {
+	const line = activeCard(page).locator(`${tid("pr-walkthrough-diff-line")}[data-line-id="src-app-pr-walkthrough-ts:h0:l1"]`).first();
+	await expect(line).toBeVisible({ timeout: 10_000 });
+	await line.hover();
+	await line.getByTestId("pr-walkthrough-line-comment-button").click();
+	const editor = page.getByTestId("pr-walkthrough-comment-editor");
+	await expect(editor).toBeVisible();
+	await editor.getByTestId("pr-walkthrough-comment-input").fill(body);
+	await editor.getByTestId("pr-walkthrough-comment-save").click();
+	await expect(editor).toBeHidden({ timeout: 5_000 });
+	await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-comment").filter({ hasText: body })).toBeVisible();
+}
+
+async function saveCardComment(page: Page, body: string) {
+	await activeCard(page).getByTestId("pr-walkthrough-add-card-comment").click();
+	const editor = page.getByTestId("pr-walkthrough-comment-editor");
+	await editor.getByTestId("pr-walkthrough-comment-input").fill(body);
+	await editor.getByTestId("pr-walkthrough-comment-save").click();
+	await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-comment").filter({ hasText: body })).toBeVisible();
+}
+
+
+test.describe("real PR walkthrough browser UX", () => {
+	test("loads mocked resolved cards and preserves comments through reload, fullscreen, and standalone", async ({ page, context }) => {
+		let releaseResolve!: () => void;
+		const state: MockWalkthroughState = {
+			mode: "success",
+			resolveCalls: [],
+			previewCalls: [],
+			submitCalls: [],
+			resolveDelay: new Promise<void>((resolve) => { releaseResolve = resolve; }),
+		};
+
+		await openRealWalkthrough(page, state);
+		await expect(page.getByTestId("pr-walkthrough-loading"), "real resolver launches should show a loading state instead of fixture cards while the API is pending").toBeVisible({ timeout: 10_000 });
+		releaseResolve();
+
+		await expect(activeCard(page).getByTestId("pr-walkthrough-card-title"), "resolved cards should replace the fixture fallback").toContainText("Resolved changeset overview", { timeout: 10_000 });
+		await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-pr-title")).toContainText("Real-ish walkthrough cards");
+		await expect(activeCard(page)).toContainText("src/app/pr-walkthrough.ts");
+		await expect(activeCard(page)).toContainText("gatewayFetch('/api/pr-walkthrough/resolve'");
+		await expect.poll(() => state.resolveCalls.length, { timeout: 5_000 }).toBe(1);
+		expect(JSON.stringify(state.resolveCalls[0])).toContain(REAL_PR_URL);
+
+		const commentBody = `persisted-real-comment-${Date.now()}`;
+		await saveLineComment(page, commentBody);
+
+		const fullscreen = page.getByTestId("pr-walkthrough-fullscreen");
+		await expect(fullscreen).toBeVisible();
+		await fullscreen.click();
+		await expect(page.locator(`${tid("side-panel-fullscreen-root")}, ${tid("pr-walkthrough-fullscreen-root")}, .preview-fullscreen-prompt`).first()).toBeVisible({ timeout: 10_000 });
+		await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-comment").filter({ hasText: commentBody })).toBeVisible();
+		await page.locator(`${tid("side-panel-collapse-fullscreen")}, button[title*="Collapse preview"], button[title*="Collapse walkthrough"]`).first().click();
+
+		await page.reload();
+		await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-card-title"), "resolved card identity should survive full reload").toContainText("Resolved changeset overview", { timeout: 15_000 });
+		await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-comment").filter({ hasText: commentBody }), "draft line comments should survive reload against real cards").toBeVisible();
+
+		const openStandalone = page.getByTestId("pr-walkthrough-open-in-new-tab");
+		const [standalone] = await Promise.all([
+			context.waitForEvent("page"),
+			openStandalone.click(),
+		]);
+		await standalone.setViewportSize({ width: 1700, height: 1000 });
+		await standalone.waitForLoadState("domcontentloaded");
+		await expect(standalone).toHaveURL(/walkthrough/);
+		await expect(walkthroughPanel(standalone).getByTestId("pr-walkthrough-card-title"), "standalone route should render the same resolved cards").toContainText("Resolved changeset overview", { timeout: 15_000 });
+		await expect(walkthroughPanel(standalone).getByTestId("pr-walkthrough-comment").filter({ hasText: commentBody }), "standalone route should restore the same in-progress draft").toBeVisible();
+		await standalone.close();
+	});
+
+	test("previews GitHub export and submits only after the explicit confirmation click", async ({ page }) => {
+		const state: MockWalkthroughState = { mode: "success", resolveCalls: [], previewCalls: [], submitCalls: [] };
+		await openRealWalkthrough(page, state);
+		await expect(activeCard(page).getByTestId("pr-walkthrough-card-title")).toContainText("Resolved changeset overview", { timeout: 10_000 });
+
+		await saveLineComment(page, "Persisted line comment from browser test");
+		await walkthroughPanel(page).getByTestId("pr-walkthrough-dislike").first().click();
+		await expect(activeCard(page).getByTestId("pr-walkthrough-card-title")).toContainText("Persist walkthrough state");
+		await saveCardComment(page, "Card-level export concern from browser test");
+		await walkthroughPanel(page).getByTestId("pr-walkthrough-like").first().click();
+		await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-audit")).toBeVisible({ timeout: 10_000 });
+
+		await walkthroughPanel(page).getByTestId("pr-walkthrough-submit-review").click();
+		const preview = page.getByTestId("pr-walkthrough-export-preview");
+		await expect(preview, "first submit click should open a safe preview rather than mutate GitHub").toBeVisible({ timeout: 10_000 });
+		await expect(preview).toContainText("src/app/pr-walkthrough.ts");
+		await expect(preview).toContainText("Persisted line comment from browser test");
+		await expect(preview).toContainText(/Generated or truncated file cannot be mapped/i);
+		await expect.poll(() => state.previewCalls.length, { timeout: 5_000 }).toBe(1);
+		expect(state.submitCalls, "opening the preview must not call the submit endpoint").toHaveLength(0);
+
+		await preview.getByTestId("pr-walkthrough-export-submit").click();
+		await expect.poll(() => state.submitCalls.length, { timeout: 5_000 }).toBe(1);
+		expect((state.submitCalls[0] as { confirm?: boolean }).confirm).toBe(true);
+		await expect(page.getByTestId("pr-walkthrough-export-result")).toContainText(/submitted|success/i, { timeout: 10_000 });
+	});
+
+	test("renders visible resolver errors and warning banners for missing, auth, and large diff states", async ({ page }) => {
+		const state: MockWalkthroughState = { mode: "missing", resolveCalls: [], previewCalls: [], submitCalls: [] };
+		await openRealWalkthrough(page, state, "/walkthrough-pr 404");
+		await expect(walkthroughPanel(page), "error walkthrough should keep the header/panel mounted").toBeVisible({ timeout: 10_000 });
+		await expect(page.getByTestId("pr-walkthrough-error")).toContainText(/Pull request not found|#404/i, { timeout: 10_000 });
+		await expect(page.getByRole("button", { name: /retry/i })).toBeVisible();
+
+		state.mode = "warnings";
+		await sendMessage(page, "/walkthrough-pr 1000");
+		await expect(activeCard(page).getByTestId("pr-walkthrough-card-title")).toContainText("Resolved changeset overview", { timeout: 10_000 });
+		const warnings = page.getByTestId("pr-walkthrough-warning");
+		await expect(warnings.filter({ hasText: /GitHub token is required/i })).toBeVisible({ timeout: 10_000 });
+		await expect(warnings.filter({ hasText: /Large diff truncated/i })).toBeVisible();
+		await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-stat-files")).toContainText("48 files");
+	});
+});

--- a/tests/pr-walkthrough-card-synthesis.test.ts
+++ b/tests/pr-walkthrough-card-synthesis.test.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import { synthesiseWalkthroughCards, validateSynthesisedCards } from "../src/server/pr-walkthrough/card-synthesis.ts";
+import { WALKTHROUGH_STORE_SCHEMA_VERSION, WalkthroughStore } from "../src/server/pr-walkthrough/walkthrough-store.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("PR walkthrough card synthesis", () => {
+	it("builds deterministic fallback phases and groups multiple diff blocks by path", async () => {
+		const cards = await synthesiseWalkthroughCards(changeset(), [
+			file("src/server/routes.ts", "modified", [block("server-a", "src/server/routes.ts", 8), block("server-b", "src/server/routes.ts", 5)]),
+			file("src/ui/panel.ts", "modified", [block("ui-a", "src/ui/panel.ts", 6)]),
+			file("docs/pr.md", "modified", [block("docs-a", "docs/pr.md", 2)]),
+		]);
+
+		assert.deepEqual(cards.map(card => card.phaseId), ["orientation", "design", "significant", "other", "audit"]);
+		const design = cards.find(card => card.phaseId === "design");
+		assert.ok(design);
+		assert.deepEqual(design.diffBlocks.map(block => block.id), ["server-a", "server-b"]);
+		assert.equal(new Set(cards.flatMap(card => card.phaseId === "orientation" || card.phaseId === "audit" ? [] : card.diffBlocks.map(block => block.id))).size, 4);
+	});
+
+	it("puts generated, renamed, deleted, and binary blocks into other review cards", async () => {
+		const cards = await synthesiseWalkthroughCards(changeset(), [
+			file("src/core.ts", "modified", [block("core", "src/core.ts", 10)]),
+			file("dist/bundle.js", "modified", [block("generated", "dist/bundle.js", 20)], { isGenerated: true }),
+			file("assets/logo.png", "binary", [block("binary", "assets/logo.png", 1)], { isBinary: true }),
+			file("src/old.ts", "deleted", [block("deleted", "src/old.ts", 3)]),
+			file("src/new-name.ts", "renamed", [block("renamed", "src/new-name.ts", 3)]),
+		]);
+
+		const other = cards.find(card => card.phaseId === "other");
+		assert.ok(other);
+		assert.deepEqual(other.diffBlocks.map(block => block.id), ["generated", "binary", "deleted", "renamed"]);
+	});
+
+	it("falls back when LLM synthesis is unavailable or invalid", async () => {
+		const cards = await synthesiseWalkthroughCards(changeset(), [file("src/a.ts", "modified", [block("a", "src/a.ts", 2)])], {
+			allowLlm: true,
+			llm: () => ({ cards: [{ phaseId: "not-a-phase", title: "Bad", summary: "Bad", diffBlockIds: ["a"] }] }),
+		});
+
+		assert.equal(cards[0].phaseId, "orientation");
+		assert.ok(cards.some(card => card.diffBlocks.some(diffBlock => diffBlock.id === "a")));
+	});
+
+	it("validates LLM card schema and drops suggested comments with bad anchors", () => {
+		const files = [file("src/a.ts", "modified", [block("a", "src/a.ts", 2)])];
+		const cards = validateSynthesisedCards({
+			cards: [
+				{
+					phaseId: "significant",
+					title: "Check resolver",
+					summary: "Resolver behavior changed.",
+					diffBlockIds: ["a", "missing"],
+					suggestedComments: [
+						{ diffBlockId: "a", lineId: "a-l1", body: "Valid anchor" },
+						{ diffBlockId: "a", lineId: "missing-line", body: "Invalid line" },
+						{ diffBlockId: "missing", lineId: "a-l1", body: "Invalid block" },
+					],
+				},
+				{ phaseId: "audit", title: "No blocks", summary: "Rejected", diffBlockIds: ["missing"] },
+			],
+		}, files);
+
+		assert.equal(cards.length, 1);
+		assert.equal(cards[0].phaseId, "significant");
+		assert.deepEqual(cards[0].diffBlocks.map(diffBlock => diffBlock.id), ["a"]);
+		assert.equal(cards[0].suggestedComments?.length, 1);
+		assert.equal(cards[0].suggestedComments?.[0]?.body, "Valid anchor");
+	});
+
+	it("reserves unassigned blocks for audit coverage without duplicating earlier cards", async () => {
+		const files = Array.from({ length: 8 }, (_, index) => file(`pkg${index}/file.ts`, "modified", [block(`b${index}`, `pkg${index}/file.ts`, 10 - index)]));
+		const cards = await synthesiseWalkthroughCards(changeset(), files);
+		const audit = cards.find(card => card.phaseId === "audit");
+		assert.ok(audit);
+		assert.ok(audit.diffBlocks.length > 0);
+
+		const nonAuditIds = new Set(cards.filter(card => card.phaseId !== "audit").flatMap(card => card.diffBlocks.map(diffBlock => diffBlock.id)));
+		for (const diffBlock of audit.diffBlocks) assert.equal(nonAuditIds.has(diffBlock.id), false);
+	});
+});
+
+describe("WalkthroughStore", () => {
+	it("persists schema-versioned walkthrough payloads by changeset id", async () => {
+		const dir = makeTempDir();
+		const store = new WalkthroughStore(dir);
+		const cards = await synthesiseWalkthroughCards(changeset(), [file("src/a.ts", "modified", [block("a", "src/a.ts", 2)])]);
+
+		const saved = store.save({ changesetId: "github:owner/repo#12:abcdef", changeset: changeset(), cards, warnings: [] });
+		const loaded = store.get("github:owner/repo#12:abcdef");
+
+		assert.equal(saved.schemaVersion, WALKTHROUGH_STORE_SCHEMA_VERSION);
+		assert.equal(loaded?.changesetId, "github:owner/repo#12:abcdef");
+		assert.equal(loaded?.cards.length, cards.length);
+		assert.match(saved.updatedAt, /^\d{4}-\d{2}-\d{2}T/);
+	});
+
+	it("ignores stale schema files and never persists auth tokens or raw headers", async () => {
+		const dir = makeTempDir();
+		const store = new WalkthroughStore(dir);
+		store.save({
+			changesetId: "local-a..b",
+			changeset: changeset(),
+			cards: [],
+			warnings: [],
+			export: {
+				enabled: true,
+				provider: "github",
+				token: "ghp_secret",
+				headers: { authorization: "Bearer secret" },
+				nested: { authHeaders: { authorization: "Bearer secret" } },
+			} as never,
+		});
+
+		const raw = JSON.stringify(store.get("local-a..b"));
+		assert.equal(raw.includes("ghp_secret"), false);
+		assert.equal(raw.includes("Bearer secret"), false);
+
+		const file = path.join(dir, "pr-walkthrough", `v${WALKTHROUGH_STORE_SCHEMA_VERSION}`, `${Buffer.from("stale", "utf-8").toString("base64url")}.json`);
+		fs.mkdirSync(path.dirname(file), { recursive: true });
+		fs.writeFileSync(file, JSON.stringify({ schemaVersion: 0, changesetId: "stale", updatedAt: new Date().toISOString(), changeset: {}, cards: [], warnings: [] }), "utf-8");
+		assert.equal(store.get("stale"), null);
+	});
+});
+
+function changeset() {
+	return {
+		baseSha: "1234567890abcdef",
+		headSha: "abcdef1234567890",
+		title: "Complete walkthrough",
+		filesChanged: 8,
+		additions: 80,
+		deletions: 20,
+	};
+}
+
+function file(filePath: string, status: string, diffBlocks: ReturnType<typeof block>[], extra: Record<string, unknown> = {}) {
+	return { filePath, status, diffBlocks, ...extra };
+}
+
+function block(id: string, filePath: string, changedLines: number) {
+	return {
+		id,
+		filePath,
+		hunks: [
+			{
+				id: `${id}-h1`,
+				header: "@@ -1,1 +1,1 @@",
+				lines: Array.from({ length: changedLines }, (_, index) => ({
+					id: `${id}-l${index + 1}`,
+					side: "new",
+					newLine: index + 1,
+					kind: "add",
+					text: `line ${index + 1}`,
+				})),
+			},
+		],
+	};
+}
+
+function makeTempDir(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-pr-walkthrough-store-"));
+	tempDirs.push(dir);
+	return dir;
+}

--- a/tests/pr-walkthrough-card-synthesis.test.ts
+++ b/tests/pr-walkthrough-card-synthesis.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, describe, it } from "node:test";
 
 import { synthesiseWalkthroughCards, validateSynthesisedCards } from "../src/server/pr-walkthrough/card-synthesis.ts";
+import { normalizeGithubResolvedWalkthrough, setPrWalkthroughSynthesisAdapterForTesting } from "../src/server/pr-walkthrough/routes.ts";
 import { WALKTHROUGH_STORE_SCHEMA_VERSION, WalkthroughStore } from "../src/server/pr-walkthrough/walkthrough-store.ts";
 
 const tempDirs: string[] = [];
@@ -76,6 +77,53 @@ describe("PR walkthrough card synthesis", () => {
 		assert.deepEqual(cards[0].diffBlocks.map(diffBlock => diffBlock.id), ["a"]);
 		assert.equal(cards[0].suggestedComments?.length, 1);
 		assert.equal(cards[0].suggestedComments?.[0]?.body, "Valid anchor");
+	});
+
+	it("normalizes adapter-style GitHub files into real diff blocks for resolver synthesis", async () => {
+		const result = await normalizeGithubResolvedWalkthrough({
+			changesetId: "github:SuuBro/bobbit#42:abcdef1",
+			changeset: { ...changeset(), provider: "github", prUrl: "https://github.com/SuuBro/bobbit/pull/42", prNumber: 42 },
+			files: [file("src/a.ts", "modified", [block("adapter-block", "src/a.ts", 2)])],
+			warnings: [],
+			export: { provider: "github", available: false },
+		});
+
+		assert.ok(result);
+		const diffBlocks = result.cards.flatMap(card => card.diffBlocks);
+		assert.ok(diffBlocks.some(diffBlock => diffBlock.id === "adapter-block" && Array.isArray(diffBlock.hunks)));
+		assert.equal(diffBlocks.some(diffBlock => (diffBlock as any).diffBlocks), false);
+	});
+
+	it("resolver synthesis invokes configured LLM adapter and falls back when it returns invalid output", async () => {
+		let calls = 0;
+		setPrWalkthroughSynthesisAdapterForTesting(() => {
+			calls += 1;
+			return { cards: [{ phaseId: "significant", title: "LLM card", summary: "Validated output", diffBlockIds: ["llm-block"] }] };
+		});
+		try {
+			const result = await normalizeGithubResolvedWalkthrough({
+				changesetId: "github:SuuBro/bobbit#42:abcdef1",
+				changeset: { ...changeset(), provider: "github", prUrl: "https://github.com/SuuBro/bobbit/pull/42", prNumber: 42 },
+				files: [file("src/llm.ts", "modified", [block("llm-block", "src/llm.ts", 2)])],
+				warnings: [],
+				export: { provider: "github", available: false },
+			});
+			assert.equal(calls, 1);
+			assert.equal(result?.cards[0]?.title, "LLM card");
+
+			setPrWalkthroughSynthesisAdapterForTesting(() => ({ cards: [{ phaseId: "bad", title: "Bad", summary: "Bad", diffBlockIds: ["llm-block"] }] }));
+			const fallback = await normalizeGithubResolvedWalkthrough({
+				changesetId: "github:SuuBro/bobbit#42:abcdef1",
+				changeset: { ...changeset(), provider: "github", prUrl: "https://github.com/SuuBro/bobbit/pull/42", prNumber: 42 },
+				files: [file("src/llm.ts", "modified", [block("llm-block", "src/llm.ts", 2)])],
+				warnings: [],
+				export: { provider: "github", available: false },
+			});
+			assert.ok(fallback?.cards.some(card => card.phaseId === "orientation"));
+			assert.ok(fallback?.cards.some(card => card.diffBlocks.some(diffBlock => diffBlock.id === "llm-block")));
+		} finally {
+			setPrWalkthroughSynthesisAdapterForTesting(undefined);
+		}
 	});
 
 	it("reserves unassigned blocks for audit coverage without duplicating earlier cards", async () => {

--- a/tests/pr-walkthrough-card-synthesis.test.ts
+++ b/tests/pr-walkthrough-card-synthesis.test.ts
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, it } from "node:test";
 
 import { synthesiseWalkthroughCards, validateSynthesisedCards } from "../src/server/pr-walkthrough/card-synthesis.ts";
-import { normalizeGithubResolvedWalkthrough, setPrWalkthroughSynthesisAdapterForTesting } from "../src/server/pr-walkthrough/routes.ts";
+import { normalizeGithubResolvedWalkthrough, resolveWalkthroughForTesting, setPrWalkthroughSynthesisAdapterForTesting } from "../src/server/pr-walkthrough/routes.ts";
 import { WALKTHROUGH_STORE_SCHEMA_VERSION, WalkthroughStore } from "../src/server/pr-walkthrough/walkthrough-store.ts";
 
 const tempDirs: string[] = [];
@@ -94,6 +95,26 @@ describe("PR walkthrough card synthesis", () => {
 		assert.equal(diffBlocks.some(diffBlock => (diffBlock as any).diffBlocks), false);
 	});
 
+	it("normal route deps use the configured model-backed synthesis adapter", async () => {
+		const repo = makeGitRepo("model");
+		let completionCalls = 0;
+		const result = await resolveWalkthroughForTesting({ cwd: repo.cwd, baseSha: repo.baseSha, headSha: repo.headSha }, {
+			defaultCwd: "/repo",
+			readBody: async () => ({}),
+			preferencesStore: { get: key => key === "default.reviewModel" ? "test/model" : undefined },
+			getAvailableModels: async () => [{ provider: "test", id: "model", name: "Model", api: "openai-completions", baseUrl: "http://127.0.0.1", contextWindow: 128_000, maxTokens: 4096, reasoning: false, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, authenticated: true }],
+			completeModelText: async (_model, _prefs, args) => {
+				completionCalls += 1;
+				const input = JSON.parse(args.userPrompt) as { diffBlockIds: string[] };
+				assert.ok(input.diffBlockIds.length > 0);
+				return JSON.stringify({ cards: [{ phaseId: "significant", title: "Model card", summary: "Synthesised through configured model", diffBlockIds: [input.diffBlockIds[0]] }] });
+			},
+		});
+
+		assert.equal(completionCalls, 1);
+		assert.equal(result.cards[0]?.title, "Model card");
+	});
+
 	it("resolver synthesis invokes configured LLM adapter and falls back when it returns invalid output", async () => {
 		let calls = 0;
 		setPrWalkthroughSynthesisAdapterForTesting(() => {
@@ -124,6 +145,19 @@ describe("PR walkthrough card synthesis", () => {
 		} finally {
 			setPrWalkthroughSynthesisAdapterForTesting(undefined);
 		}
+	});
+
+	it("resolver uses session cwd before default cwd", async () => {
+		const defaultRepo = makeGitRepo("default");
+		const sessionRepo = makeGitRepo("session");
+		const result = await resolveWalkthroughForTesting({ sessionId: "s1", baseSha: sessionRepo.baseSha, headSha: sessionRepo.headSha }, {
+			defaultCwd: defaultRepo.cwd,
+			readBody: async () => ({}),
+			resolveSessionCwd: sessionId => sessionId === "s1" ? sessionRepo.cwd : undefined,
+		});
+
+		assert.equal(result.changeset.baseSha, sessionRepo.baseSha);
+		assert.ok(result.cards.flatMap(card => card.diffBlocks).some(diffBlock => diffBlock.filePath === "session.txt"));
 	});
 
 	it("reserves unassigned blocks for audit coverage without duplicating earlier cards", async () => {
@@ -220,4 +254,24 @@ function makeTempDir(): string {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-pr-walkthrough-store-"));
 	tempDirs.push(dir);
 	return dir;
+}
+
+function makeGitRepo(label: string): { cwd: string; baseSha: string; headSha: string } {
+	const cwd = makeTempDir();
+	git(cwd, ["init"]);
+	git(cwd, ["config", "user.name", "Bobbit Test"]);
+	git(cwd, ["config", "user.email", "bobbit-test@example.test"]);
+	fs.writeFileSync(path.join(cwd, `${label}.txt`), "base\n", "utf-8");
+	git(cwd, ["add", "."]);
+	git(cwd, ["commit", "-m", "base"]);
+	const baseSha = git(cwd, ["rev-parse", "HEAD"]);
+	fs.writeFileSync(path.join(cwd, `${label}.txt`), "base\nhead\n", "utf-8");
+	git(cwd, ["add", "."]);
+	git(cwd, ["commit", "-m", "head"]);
+	const headSha = git(cwd, ["rev-parse", "HEAD"]);
+	return { cwd, baseSha, headSha };
+}
+
+function git(cwd: string, args: string[]): string {
+	return execFileSync("git", args, { cwd, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }).trim();
 }

--- a/tests/pr-walkthrough-changeset-id.test.ts
+++ b/tests/pr-walkthrough-changeset-id.test.ts
@@ -16,11 +16,11 @@ const HEAD_SHA = "fedcba9876543210fedcba9876543210fedcba98";
 
 describe("PR walkthrough stable ids", () => {
 	it("uses readable short SHA ids for local changesets", () => {
-		assert.equal(changesetIdForLocal(BASE_SHA, HEAD_SHA), "01234567..fedcba98");
+		assert.equal(changesetIdForLocal(BASE_SHA, HEAD_SHA), "0123456..fedcba9");
 	});
 
 	it("uses readable GitHub ids without storage sanitisation", () => {
-		assert.equal(changesetIdForGithub("SuuBro", "bobbit", 1842, HEAD_SHA), "github:SuuBro/bobbit#1842:fedcba98");
+		assert.equal(changesetIdForGithub("SuuBro", "bobbit", 1842, HEAD_SHA), "github:SuuBro/bobbit#1842:fedcba9");
 		assert.equal(changesetIdForGithub("SuuBro", "bobbit", "1842"), "github:SuuBro/bobbit#1842:unknown");
 	});
 

--- a/tests/pr-walkthrough-changeset-id.test.ts
+++ b/tests/pr-walkthrough-changeset-id.test.ts
@@ -1,0 +1,39 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+	changesetIdForGithub,
+	changesetIdForLocal,
+	diffBlockIdForFile,
+	hunkIdForBlock,
+	lineIdForHunk,
+	shortSha,
+	stableSlug,
+	walkthroughCardId,
+} from "../src/shared/pr-walkthrough/ids.ts";
+
+const BASE_SHA = "0123456789abcdef0123456789abcdef01234567";
+const HEAD_SHA = "fedcba9876543210fedcba9876543210fedcba98";
+
+describe("PR walkthrough stable ids", () => {
+	it("uses readable short SHA ids for local changesets", () => {
+		assert.equal(changesetIdForLocal(BASE_SHA, HEAD_SHA), "01234567..fedcba98");
+	});
+
+	it("uses readable GitHub ids without storage sanitisation", () => {
+		assert.equal(changesetIdForGithub("SuuBro", "bobbit", 1842, HEAD_SHA), "github:SuuBro/bobbit#1842:fedcba98");
+		assert.equal(changesetIdForGithub("SuuBro", "bobbit", "1842"), "github:SuuBro/bobbit#1842:unknown");
+	});
+
+	it("builds stable block, hunk, and line ids", () => {
+		const blockId = diffBlockIdForFile("src/ui/foo bar.ts", 2);
+		assert.equal(blockId, "block:3:src__ui__foo-bar.ts");
+		assert.equal(hunkIdForBlock(blockId, 1), "block:3:src__ui__foo-bar.ts:h1");
+		assert.equal(lineIdForHunk(blockId, 1, 9), "block:3:src__ui__foo-bar.ts:h1:l9");
+	});
+
+	it("normalises slugs and card ids deterministically", () => {
+		assert.equal(shortSha("abc"), "abc");
+		assert.equal(stableSlug(" src\\server/a b !.ts "), "src__server__a-b-.ts");
+		assert.equal(walkthroughCardId("design", "Model & Adapter", 4), "design-model-adapter-5");
+	});
+});

--- a/tests/pr-walkthrough-diff-parser.test.ts
+++ b/tests/pr-walkthrough-diff-parser.test.ts
@@ -1,0 +1,138 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parseUnifiedDiff } from "../src/server/pr-walkthrough/diff-parser.ts";
+import { resolveLocalChangeset } from "../src/server/pr-walkthrough/git-changeset.ts";
+
+const SAMPLE_DIFF = `diff --git a/src/a.ts b/src/a.ts
+index 1111111..2222222 100644
+--- a/src/a.ts
++++ b/src/a.ts
+@@ -1,4 +1,5 @@
+ line one
+-old two
++new two
+ line three
++new four
+@@ -20,2 +21,2 @@ function x()
+-old twenty
++new twenty-one
+diff --git a/old name.ts b/new name.ts
+similarity index 90%
+rename from old name.ts
+rename to new name.ts
+--- a/old name.ts
++++ b/new name.ts
+@@ -1 +1 @@
+-export const oldName = true;
++export const newName = true;
+diff --git a/assets/logo.png b/assets/logo.png
+new file mode 100644
+index 0000000..1111111
+Binary files /dev/null and b/assets/logo.png differ
+diff --git a/src/removed.ts b/src/removed.ts
+deleted file mode 100644
+index 3333333..0000000
+--- a/src/removed.ts
++++ /dev/null
+@@ -1,2 +0,0 @@
+-export const removed = true;
+-goodbye
+`;
+
+describe("parseUnifiedDiff", () => {
+	it("parses additions, deletions, multiple hunks, line numbers, and stable line ids", () => {
+		const result = parseUnifiedDiff(SAMPLE_DIFF);
+		const file = result.files[0];
+		assert.equal(file.filePath, "src/a.ts");
+		assert.equal(file.status, "modified");
+		assert.equal(file.hunks.length, 2);
+		assert.equal(file.additions, 3);
+		assert.equal(file.deletions, 2);
+		assert.deepEqual(file.hunks[0].lines.map(line => [line.kind, line.oldLine, line.newLine, line.text]), [
+			["context", 1, 1, "line one"],
+			["del", 2, undefined, "old two"],
+			["add", undefined, 2, "new two"],
+			["context", 3, 3, "line three"],
+			["add", undefined, 4, "new four"],
+		]);
+		assert.equal(file.hunks[1].lines[0].id, `${file.id}:h1:l0`);
+	});
+
+	it("preserves renamed file paths", () => {
+		const result = parseUnifiedDiff(SAMPLE_DIFF);
+		const file = result.files[1];
+		assert.equal(file.status, "renamed");
+		assert.equal(file.oldPath, "old name.ts");
+		assert.equal(file.filePath, "new name.ts");
+	});
+
+	it("marks binary files with warnings instead of failing", () => {
+		const result = parseUnifiedDiff(SAMPLE_DIFF);
+		const file = result.files[2];
+		assert.equal(file.status, "binary");
+		assert.equal(file.isBinary, true);
+		assert.equal(file.hunks.length, 0);
+		assert.ok(result.warnings.some(warning => warning.code === "binary-file" && warning.filePath === "assets/logo.png"));
+	});
+
+	it("preserves deleted files and old-side anchors", () => {
+		const result = parseUnifiedDiff(SAMPLE_DIFF);
+		const file = result.files[3];
+		assert.equal(file.status, "deleted");
+		assert.equal(file.filePath, "src/removed.ts");
+		assert.deepEqual(file.hunks[0].lines.map(line => [line.kind, line.side, line.oldLine, line.newLine]), [
+			["del", "old", 1, undefined],
+			["del", "old", 2, undefined],
+		]);
+	});
+
+	it("truncates large file hunks with a warning", () => {
+		const result = parseUnifiedDiff(SAMPLE_DIFF, { maxLinesPerFile: 3 });
+		const file = result.files[0];
+		assert.equal(file.truncated, true);
+		assert.equal(file.hunks[0].lines.length, 3);
+		assert.ok(result.warnings.some(warning => warning.code === "file-lines-truncated" && warning.filePath === "src/a.ts"));
+	});
+});
+
+describe("resolveLocalChangeset", () => {
+	it("resolves real local git metadata and parsed diff files", async () => {
+		const cwd = mkdtempSync(join(tmpdir(), "bobbit-pr-walkthrough-"));
+		try {
+			git(cwd, "init");
+			git(cwd, "config", "user.email", "test@example.com");
+			git(cwd, "config", "user.name", "Test User");
+			git(cwd, "config", "core.autocrlf", "false");
+			mkdirSync(join(cwd, "src"), { recursive: true });
+			writeFileSync(join(cwd, "src", "file.ts"), "one\ntwo\nthree\n");
+			git(cwd, "add", ".");
+			git(cwd, "commit", "-m", "base");
+			const baseSha = git(cwd, "rev-parse", "HEAD");
+
+			writeFileSync(join(cwd, "src", "file.ts"), "one\nTWO\nthree\nfour\n");
+			mkdirSync(join(cwd, "dist"), { recursive: true });
+			writeFileSync(join(cwd, "dist", "bundle.js"), "console.log('generated');\n");
+			git(cwd, "add", ".");
+			git(cwd, "commit", "-m", "head");
+			const headSha = git(cwd, "rev-parse", "HEAD");
+
+			const result = await resolveLocalChangeset({ cwd, baseSha, headSha, limits: { maxLinesPerFile: 100, maxFiles: 10 } });
+			assert.equal(result.changesetId, `${baseSha.slice(0, 8)}..${headSha.slice(0, 8)}`);
+			assert.equal(result.changeset.provider, "local");
+			assert.equal(result.changeset.filesChanged, 2);
+			assert.ok(result.changeset.additions && result.changeset.additions >= 2);
+			assert.ok(result.files.some(file => file.filePath === "src/file.ts" && file.hunks.length === 1));
+			assert.ok(result.warnings.some(warning => warning.code === "generated-file" && warning.filePath === "dist/bundle.js"));
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+});
+
+function git(cwd: string, ...args: string[]): string {
+	return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}

--- a/tests/pr-walkthrough-diff-parser.test.ts
+++ b/tests/pr-walkthrough-diff-parser.test.ts
@@ -121,7 +121,7 @@ describe("resolveLocalChangeset", () => {
 			const headSha = git(cwd, "rev-parse", "HEAD");
 
 			const result = await resolveLocalChangeset({ cwd, baseSha, headSha, limits: { maxLinesPerFile: 100, maxFiles: 10 } });
-			assert.equal(result.changesetId, `${baseSha.slice(0, 8)}..${headSha.slice(0, 8)}`);
+			assert.equal(result.changesetId, `${baseSha.slice(0, 7)}..${headSha.slice(0, 7)}`);
 			assert.equal(result.changeset.provider, "local");
 			assert.equal(result.changeset.filesChanged, 2);
 			assert.ok(result.changeset.additions && result.changeset.additions >= 2);

--- a/tests/pr-walkthrough-export-mapper.test.ts
+++ b/tests/pr-walkthrough-export-mapper.test.ts
@@ -289,6 +289,45 @@ describe("PR walkthrough GitHub adapter", () => {
 		assert.equal(resolved.files[0].diffBlocks[0].externalUrl, "https://github.com/SuuBro/bobbit/blob/bbbbbbbbbbbb/src/example.ts");
 	});
 
+	it("marks generated and truncated GitHub patches with warnings and block status", async () => {
+		const longPatch = ["@@ -1,1 +1,10 @@", " context", ...Array.from({ length: 10 }, (_, index) => `+generated ${index}`)].join("\n");
+		const resolved = await resolveGithubPr({
+			prUrl: "https://github.com/SuuBro/bobbit/pull/42",
+			token: "token",
+			apiBaseUrl: "https://api.github.test",
+			maxLinesPerFile: 3,
+			fetch: async (url) => {
+				if (url.endsWith("/pulls/42")) {
+					return response(200, {
+						number: 42,
+						title: "Generated bundle",
+						html_url: "https://github.com/SuuBro/bobbit/pull/42",
+						base: { sha: "aaaaaaaaaaaa" },
+						head: { sha: "bbbbbbbbbbbb" },
+						changed_files: 1,
+					});
+				}
+				return response(200, [{
+					filename: "dist/generated.bundle.js",
+					status: "added",
+					additions: 10,
+					deletions: 0,
+					changes: 10,
+					patch: longPatch,
+				}]);
+			},
+		});
+
+		const file = resolved.files[0];
+		assert.equal(file.isGenerated, true);
+		assert.equal(file.isTruncated, true);
+		assert.equal(file.status, "added");
+		assert.equal(file.diffBlocks[0].status, "added");
+		assert.equal(file.diffBlocks[0].isGenerated, true);
+		assert.ok(resolved.warnings.some(warning => warning.code === "github_generated_file" && warning.filePath === "dist/generated.bundle.js"));
+		assert.ok(resolved.warnings.some(warning => /truncated/i.test(warning.code) && warning.filePath === "dist/generated.bundle.js"));
+	});
+
 	it("warns when GitHub changed-file pagination lands exactly on the max-files boundary", async () => {
 		const resolved = await resolveGithubPr({
 			prUrl: "https://github.com/SuuBro/bobbit/pull/42",

--- a/tests/pr-walkthrough-export-mapper.test.ts
+++ b/tests/pr-walkthrough-export-mapper.test.ts
@@ -1,0 +1,250 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+	buildGithubReviewPreview,
+	createGithubReviewPayload,
+	submitGithubReview,
+	type PrWalkthroughCard,
+	type PrWalkthroughReviewDraft,
+} from "../src/server/pr-walkthrough/export-mapper.ts";
+import {
+	parseGithubPrReference,
+	parseGithubRemoteUrl,
+	resolveGithubPr,
+} from "../src/server/pr-walkthrough/github-adapter.ts";
+
+const cards: PrWalkthroughCard[] = [
+	{
+		id: "card-1",
+		phaseId: "significant",
+		title: "Review exported comments",
+		summary: "Maps walkthrough line comments to GitHub review rows.",
+		diffBlocks: [
+			{
+				id: "block-1",
+				filePath: "src/example.ts",
+				hunks: [
+					{
+						id: "hunk-1",
+						header: "@@ -10,2 +10,3 @@",
+						lines: [
+							{ id: "line-old", side: "old", oldLine: 10, text: "old value", kind: "del" },
+							{ id: "line-new", side: "new", newLine: 11, text: "new value", kind: "add" },
+							{ id: "line-context", side: "context", oldLine: 12, newLine: 12, text: "context", kind: "context" },
+						],
+					},
+				],
+			},
+			{
+				id: "block-binary",
+				filePath: "assets/logo.png",
+				status: "binary",
+				hunks: [
+					{
+						id: "binary-hunk",
+						header: "Binary files differ",
+						lines: [{ id: "binary-line", side: "new", text: "binary", kind: "add" }],
+					},
+				],
+			},
+		],
+	},
+];
+
+function draft(): PrWalkthroughReviewDraft {
+	return {
+		changeset: {
+			baseSha: "aaaaaaa",
+			headSha: "bbbbbbb",
+			provider: "github",
+			prUrl: "https://github.com/SuuBro/bobbit/pull/42",
+			externalUrl: "https://github.com/SuuBro/bobbit/pull/42",
+			prNumber: 42,
+			prTitle: "Complete review export",
+			title: "PR #42: Complete review export",
+		},
+		decisions: {
+			"card-1": { cardId: "card-1", value: "disliked", commentIds: ["c1"], updatedAt: "2026-01-01T00:00:00.000Z" },
+		},
+		comments: [
+			{ id: "c1", cardId: "card-1", diffBlockId: "block-1", lineId: "line-new", body: "Please tighten this new branch.", source: "custom", createdAt: "2026-01-01T00:00:00.000Z" },
+			{ id: "c2", cardId: "card-1", diffBlockId: "block-1", lineId: "line-old", body: "Deleted line note.", source: "custom", createdAt: "2026-01-01T00:00:00.000Z" },
+			{ id: "c3", cardId: "card-1", body: "Card-level concern stays in the review body.", source: "custom", createdAt: "2026-01-01T00:00:00.000Z" },
+			{ id: "c4", cardId: "card-1", diffBlockId: "block-1", lineId: "missing", body: "Missing anchor remains visible.", source: "custom", createdAt: "2026-01-01T00:00:00.000Z" },
+			{ id: "c5", cardId: "card-1", diffBlockId: "block-binary", lineId: "binary-line", body: "Binary cannot be reviewed inline.", source: "custom", createdAt: "2026-01-01T00:00:00.000Z" },
+		],
+		completedCardIds: ["card-1"],
+		updatedAt: "2026-01-01T00:00:00.000Z",
+	};
+}
+
+describe("PR walkthrough GitHub export mapper", () => {
+	it("maps line comments to GitHub preview rows and card comments to the review body", () => {
+		const preview = buildGithubReviewPreview(draft(), cards);
+
+		assert.deepEqual(preview.target, {
+			provider: "github",
+			owner: "SuuBro",
+			repo: "bobbit",
+			prNumber: 42,
+			prUrl: "https://github.com/SuuBro/bobbit/pull/42",
+			headSha: "bbbbbbb",
+		});
+		assert.equal(preview.validCommentCount, 2);
+		assert.equal(preview.unmappableCommentCount, 2);
+		assert.match(preview.body, /Card-level concern stays in the review body/);
+		assert.match(preview.body, /Missing anchor remains visible/);
+
+		const newRow = preview.rows.find(row => row.commentId === "c1");
+		assert.ok(newRow);
+		assert.equal(newRow.valid, true);
+		assert.equal(newRow.path, "src/example.ts");
+		assert.equal(newRow.side, "RIGHT");
+		assert.equal(newRow.line, 11);
+
+		const oldRow = preview.rows.find(row => row.commentId === "c2");
+		assert.ok(oldRow);
+		assert.equal(oldRow.valid, true);
+		assert.equal(oldRow.side, "LEFT");
+		assert.equal(oldRow.line, 10);
+
+		const missingRow = preview.rows.find(row => row.commentId === "c4");
+		assert.ok(missingRow);
+		assert.equal(missingRow.valid, false);
+		assert.match(missingRow.reason ?? "", /anchor was not found/);
+
+		const binaryRow = preview.rows.find(row => row.commentId === "c5");
+		assert.ok(binaryRow);
+		assert.equal(binaryRow.valid, false);
+		assert.match(binaryRow.reason ?? "", /no GitHub-reviewable text diff/);
+	});
+
+	it("builds a GitHub review payload from only valid preview rows", () => {
+		const preview = buildGithubReviewPreview(draft(), cards);
+		const payload = createGithubReviewPayload(preview, "REQUEST_CHANGES");
+
+		assert.equal(payload.event, "REQUEST_CHANGES");
+		assert.equal(payload.commit_id, "bbbbbbb");
+		const comments = payload.comments as Array<{ path: string; side: string; line: number; body: string }>;
+		assert.equal(comments.length, 2);
+		assert.deepEqual(comments.map(comment => [comment.path, comment.side, comment.line]), [
+			["src/example.ts", "RIGHT", 11],
+			["src/example.ts", "LEFT", 10],
+		]);
+	});
+
+	it("never submits without explicit confirmation", async () => {
+		const preview = buildGithubReviewPreview(draft(), cards);
+		let calls = 0;
+		const result = await submitGithubReview(preview, { confirm: false, token: "token" }, {
+			fetch: async () => {
+				calls += 1;
+				throw new Error("fetch must not be called");
+			},
+		});
+
+		assert.equal(result.ok, false);
+		assert.equal(result.status, 400);
+		assert.equal(result.submitted, false);
+		assert.equal(calls, 0);
+	});
+
+	it("submits only after confirm=true with credentials", async () => {
+		const preview = buildGithubReviewPreview(draft(), cards);
+		let requestedUrl = "";
+		let requestedBody = "";
+		const result = await submitGithubReview(preview, { confirm: true, token: "token", event: "COMMENT" }, {
+			apiBaseUrl: "https://api.github.test",
+			fetch: async (url, init) => {
+				requestedUrl = url;
+				requestedBody = init?.body ?? "";
+				return response(200, { html_url: "https://github.com/SuuBro/bobbit/pull/42#pullrequestreview-1" });
+			},
+		});
+
+		assert.equal(result.ok, true);
+		assert.equal(result.submitted, true);
+		assert.equal(result.reviewUrl, "https://github.com/SuuBro/bobbit/pull/42#pullrequestreview-1");
+		assert.equal(requestedUrl, "https://api.github.test/repos/SuuBro/bobbit/pulls/42/reviews");
+		const body = JSON.parse(requestedBody) as { comments: unknown[]; event: string };
+		assert.equal(body.event, "COMMENT");
+		assert.equal(body.comments.length, 2);
+	});
+});
+
+describe("PR walkthrough GitHub adapter", () => {
+	it("parses GitHub PR URLs and origin remotes", () => {
+		assert.deepEqual(parseGithubPrReference({ prUrl: "https://github.com/SuuBro/bobbit/pull/1842" }), {
+			owner: "SuuBro",
+			repo: "bobbit",
+			number: 1842,
+			host: "github.com",
+			url: "https://github.com/SuuBro/bobbit/pull/1842",
+		});
+		assert.deepEqual(parseGithubRemoteUrl("git@github.com:SuuBro/bobbit.git"), {
+			host: "github.com",
+			owner: "SuuBro",
+			repo: "bobbit",
+		});
+	});
+
+	it("resolves PR metadata and file patches through the GitHub API adapter", async () => {
+		const calls: string[] = [];
+		const resolved = await resolveGithubPr({
+			prUrl: "https://github.com/SuuBro/bobbit/pull/42",
+			token: "token",
+			apiBaseUrl: "https://api.github.test",
+			fetch: async (url) => {
+				calls.push(url);
+				if (url.endsWith("/pulls/42")) {
+					return response(200, {
+						number: 42,
+						title: "Complete review export",
+						html_url: "https://github.com/SuuBro/bobbit/pull/42",
+						base: { sha: "aaaaaaaaaaaa" },
+						head: { sha: "bbbbbbbbbbbb" },
+						changed_files: 1,
+						additions: 1,
+						deletions: 0,
+					});
+				}
+				return response(200, [
+					{
+						filename: "src/example.ts",
+						status: "modified",
+						additions: 1,
+						deletions: 0,
+						changes: 1,
+						blob_url: "https://github.com/SuuBro/bobbit/blob/bbbbbbbbbbbb/src/example.ts",
+						patch: "@@ -1,1 +1,2 @@\n context\n+added",
+					},
+				]);
+			},
+		});
+
+		assert.deepEqual(calls, [
+			"https://api.github.test/repos/SuuBro/bobbit/pulls/42",
+			"https://api.github.test/repos/SuuBro/bobbit/pulls/42/files?per_page=100&page=1",
+		]);
+		assert.equal(resolved.changesetId, "github:SuuBro/bobbit#42:bbbbbbb");
+		assert.equal(resolved.changeset.prTitle, "Complete review export");
+		assert.equal(resolved.export.available, true);
+		assert.equal(resolved.files[0].filePath, "src/example.ts");
+		assert.equal(resolved.files[0].diffBlocks[0].hunks[0].lines[1].newLine, 2);
+	});
+});
+
+function response(status: number, body: unknown) {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		statusText: status >= 200 && status < 300 ? "OK" : "Error",
+		headers: { get: () => null },
+		async json() {
+			return body;
+		},
+		async text() {
+			return typeof body === "string" ? body : JSON.stringify(body);
+		},
+	};
+}

--- a/tests/pr-walkthrough-export-mapper.test.ts
+++ b/tests/pr-walkthrough-export-mapper.test.ts
@@ -288,6 +288,35 @@ describe("PR walkthrough GitHub adapter", () => {
 		assert.equal(resolved.files[0].diffBlocks[0].hunks[0].lines[1].newLine, 2);
 		assert.equal(resolved.files[0].diffBlocks[0].externalUrl, "https://github.com/SuuBro/bobbit/blob/bbbbbbbbbbbb/src/example.ts");
 	});
+
+	it("warns when GitHub changed-file pagination lands exactly on the max-files boundary", async () => {
+		const resolved = await resolveGithubPr({
+			prUrl: "https://github.com/SuuBro/bobbit/pull/42",
+			token: "token",
+			apiBaseUrl: "https://api.github.test",
+			maxFiles: 100,
+			fetch: async (url) => {
+				if (url.endsWith("/pulls/42")) {
+					return response(200, {
+						number: 42,
+						title: "Many files",
+						html_url: "https://github.com/SuuBro/bobbit/pull/42",
+						base: { sha: "aaaaaaaaaaaa" },
+						head: { sha: "bbbbbbbbbbbb" },
+						changed_files: 101,
+					});
+				}
+				return response(200, Array.from({ length: 100 }, (_, index) => ({
+					filename: `src/file-${index}.ts`,
+					status: "modified",
+					patch: "@@ -1,1 +1,2 @@\n context\n+added",
+				})));
+			},
+		});
+
+		assert.equal(resolved.files.length, 100);
+		assert.ok(resolved.warnings.some(warning => warning.code === "github_files_truncated"));
+	});
 });
 
 async function startMockGithubReviewServer(): Promise<{ baseUrl: string; requests: Array<{ url?: string; authorization?: string; body: any }>; close: () => Promise<void> }> {

--- a/tests/pr-walkthrough-export-mapper.test.ts
+++ b/tests/pr-walkthrough-export-mapper.test.ts
@@ -1,3 +1,4 @@
+import { createServer } from "node:http";
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
@@ -8,10 +9,12 @@ import {
 	type PrWalkthroughReviewDraft,
 } from "../src/server/pr-walkthrough/export-mapper.ts";
 import {
+	GithubPrAdapterError,
 	parseGithubPrReference,
 	parseGithubRemoteUrl,
 	resolveGithubPr,
 } from "../src/server/pr-walkthrough/github-adapter.ts";
+import { submitExportForTesting } from "../src/server/pr-walkthrough/routes.ts";
 
 const cards: PrWalkthroughCard[] = [
 	{
@@ -170,9 +173,61 @@ describe("PR walkthrough GitHub export mapper", () => {
 		assert.equal(body.event, "COMMENT");
 		assert.equal(body.comments.length, 2);
 	});
+
+	it("route submit builds a preview before mocked GitHub submission", async () => {
+		const server = await startMockGithubReviewServer();
+		const previousToken = process.env.GITHUB_TOKEN;
+		const previousApiBase = process.env.BOBBIT_GITHUB_API_BASE_URL;
+		process.env.GITHUB_TOKEN = "route-token";
+		process.env.BOBBIT_GITHUB_API_BASE_URL = server.baseUrl;
+		try {
+			const result = await submitExportForTesting("github:SuuBro/bobbit#42:bbbbbbb", {
+				changesetId: "github:SuuBro/bobbit#42:bbbbbbb",
+				changeset: draft().changeset,
+				cards,
+				warnings: [],
+				export: { provider: "github", available: true },
+			}, { draft: draft(), event: "REQUEST_CHANGES" });
+
+			assert.equal(result.ok, true);
+			assert.equal(result.submitted, true);
+			assert.equal(server.requests.length, 1);
+			assert.equal(server.requests[0]?.url, "/repos/SuuBro/bobbit/pulls/42/reviews");
+			assert.equal(server.requests[0]?.authorization, "Bearer route-token");
+			assert.equal(server.requests[0]?.body.event, "REQUEST_CHANGES");
+			assert.equal(server.requests[0]?.body.comments.length, 2);
+		} finally {
+			await server.close();
+			if (previousToken === undefined) delete process.env.GITHUB_TOKEN;
+			else process.env.GITHUB_TOKEN = previousToken;
+			if (previousApiBase === undefined) delete process.env.BOBBIT_GITHUB_API_BASE_URL;
+			else process.env.BOBBIT_GITHUB_API_BASE_URL = previousApiBase;
+		}
+	});
 });
 
 describe("PR walkthrough GitHub adapter", () => {
+	it("rejects untrusted PR URL hosts before adding credentials or fetching", async () => {
+		assert.throws(
+			() => parseGithubPrReference({ prUrl: "https://evil.example/SuuBro/bobbit/pull/1842" }),
+			(error: unknown) => error instanceof GithubPrAdapterError && error.status === 400 && error.code === "untrusted_github_host",
+		);
+
+		let calls = 0;
+		await assert.rejects(
+			resolveGithubPr({
+				prUrl: "https://evil.example/SuuBro/bobbit/pull/1842",
+				token: "secret-token",
+				fetch: async () => {
+					calls += 1;
+					throw new Error("fetch must not be called for untrusted hosts");
+				},
+			}),
+			(error: unknown) => error instanceof GithubPrAdapterError && error.code === "untrusted_github_host",
+		);
+		assert.equal(calls, 0);
+	});
+
 	it("parses GitHub PR URLs and origin remotes", () => {
 		assert.deepEqual(parseGithubPrReference({ prUrl: "https://github.com/SuuBro/bobbit/pull/1842" }), {
 			owner: "SuuBro",
@@ -231,8 +286,34 @@ describe("PR walkthrough GitHub adapter", () => {
 		assert.equal(resolved.export.available, true);
 		assert.equal(resolved.files[0].filePath, "src/example.ts");
 		assert.equal(resolved.files[0].diffBlocks[0].hunks[0].lines[1].newLine, 2);
+		assert.equal(resolved.files[0].diffBlocks[0].externalUrl, "https://github.com/SuuBro/bobbit/blob/bbbbbbbbbbbb/src/example.ts");
 	});
 });
+
+async function startMockGithubReviewServer(): Promise<{ baseUrl: string; requests: Array<{ url?: string; authorization?: string; body: any }>; close: () => Promise<void> }> {
+	const requests: Array<{ url?: string; authorization?: string; body: any }> = [];
+	const server = createServer((req, res) => {
+		const chunks: Buffer[] = [];
+		req.on("data", chunk => chunks.push(Buffer.from(chunk)));
+		req.on("end", () => {
+			requests.push({
+				url: req.url,
+				authorization: req.headers.authorization,
+				body: JSON.parse(Buffer.concat(chunks).toString("utf-8") || "{}"),
+			});
+			res.writeHead(200, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ html_url: "https://github.com/SuuBro/bobbit/pull/42#pullrequestreview-route" }));
+		});
+	});
+	await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+	const address = server.address();
+	assert.ok(address && typeof address === "object");
+	return {
+		baseUrl: `http://127.0.0.1:${address.port}`,
+		requests,
+		close: () => new Promise<void>((resolve, reject) => server.close(err => err ? reject(err) : resolve())),
+	};
+}
 
 function response(status: number, body: unknown) {
 	return {


### PR DESCRIPTION
## Summary

- Replaces fixture-only PR walkthrough generation with real local SHA and GitHub PR changeset ingestion.
- Adds shared walkthrough model, diff parsing, logical card synthesis with model-backed LLM hook and deterministic fallback, persistence, and robust edge-state warnings.
- Wires resolver-backed side panel/fullscreen/standalone UX, export preview, and explicit confirmed GitHub submit.
- Expands unit, API E2E, browser E2E coverage, and updates docs for ingestion/export/troubleshooting.

## Validation

- `npm run check`
- `npm run test:unit`
- `npm run build --silent && npm run test:e2e:run -- tests/e2e/pr-walkthrough-api.spec.ts tests/e2e/ui/pr-walkthrough-panel.spec.ts tests/e2e/ui/pr-walkthrough-real.spec.ts`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
