### PR TITLE
Fix session deep links

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,6 +21,17 @@ Bobbit has three layers:
 
 3. **UI components** (`src/ui/`) — Lit-based component library (forked from pi-web-ui). Message rendering, specialised tool call renderers, model selection, settings, and more.
 
+## Client routing
+
+Bobbit's browser UI is primarily hash-routed so it can run as a static single-page app behind the gateway, Vite, or a remote reverse proxy. Session routes support both forms:
+
+- `#/session/<session-id>` — the normal in-app route used by sidebar and hash navigation.
+- `/session/<session-id>` — a path-style deep link used by the session header's copy-link action.
+
+Path-style session links are intentionally valid entrypoints. Opening or reloading `/session/<session-id>` after a full page load selects the same session as the hash route, so copied links continue to work when pasted into a fresh browser tab. Auth query parameters remain on the URL while routing is resolved; for example, `/session/<id>?token=...` can authenticate the browser and still open `<id>`.
+
+Hash routes take precedence over the path-style session fallback once the app has loaded. This keeps in-app navigation meaningful even from a copied path URL: `/session/old#/session/new` opens `new`, not `old`. The standalone `/walkthrough?...` pathname route is handled separately, and non-session pathnames are not treated as session deep links.
+
 ## Side-panel workspace
 
 Every chat session owns a dynamic side-panel workspace. The workspace is shared

--- a/docs/sidebar-keyboard-navigation.md
+++ b/docs/sidebar-keyboard-navigation.md
@@ -50,8 +50,8 @@ attribute on the rendered element.
 `getActiveNavId()` in `sidebar-nav.ts` returns the `data-nav-id` of the active
 row, computed from:
 
-1. The current hash route (`getRouteFromHash()`):
-   - `#/session/<id>` → `session:<id>`
+1. The current app route (`getRouteFromHash()`):
+   - `#/session/<id>` or `/session/<id>` → `session:<id>`
    - `#/goal/<id>` → `goal:<id>`
    - `#/settings/<projectId>/<tab>` → `project:<projectId>`
 2. `state.selectedSessionId` as a fallback.

--- a/src/app/routing.ts
+++ b/src/app/routing.ts
@@ -38,10 +38,6 @@ export function getRouteFromHash(): AppRoute {
 			walkthroughTabId: params.get("tab") || undefined,
 		};
 	}
-	const pathSessionMatch = path.match(/^\/session\/([a-zA-Z0-9_-]+)$/i);
-	if (pathSessionMatch) {
-		return { view: "session", sessionId: pathSessionMatch[1] };
-	}
 	const hash = window.location.hash || "";
 	if (hash === "#/search" || hash.startsWith("#/search?")) {
 		const qIdx = hash.indexOf("?");
@@ -119,6 +115,13 @@ export function getRouteFromHash(): AppRoute {
 		// #/settings/<scope>/<tab> or #/settings/<scope>
 		const tab = second as SettingsTabId | undefined;
 		return { view: "settings", settingsScope: first, settingsTab: tab && SETTINGS_TABS.has(tab) ? tab : undefined };
+	}
+	if (hash) {
+		return { view: "landing" };
+	}
+	const pathSessionMatch = path.match(/^\/session\/([a-zA-Z0-9_-]+)$/i);
+	if (pathSessionMatch) {
+		return { view: "session", sessionId: pathSessionMatch[1] };
 	}
 	return { view: "landing" };
 }

--- a/src/app/routing.ts
+++ b/src/app/routing.ts
@@ -38,6 +38,10 @@ export function getRouteFromHash(): AppRoute {
 			walkthroughTabId: params.get("tab") || undefined,
 		};
 	}
+	const pathSessionMatch = path.match(/^\/session\/([a-zA-Z0-9_-]+)$/i);
+	if (pathSessionMatch) {
+		return { view: "session", sessionId: pathSessionMatch[1] };
+	}
 	const hash = window.location.hash || "";
 	if (hash === "#/search" || hash.startsWith("#/search?")) {
 		const qIdx = hash.indexOf("?");

--- a/tests/e2e/ui/copy-session-link.spec.ts
+++ b/tests/e2e/ui/copy-session-link.spec.ts
@@ -9,8 +9,24 @@
  *      present and click still copies.
  */
 import { test, expect } from "../gateway-harness.js";
-import { createSession, deleteSession, waitForSessionStatus } from "../e2e-setup.js";
+import { base, createSession, deleteSession, readE2ETokenAsync, waitForSessionStatus } from "../e2e-setup.js";
 import { openApp } from "./ui-helpers.js";
+
+async function openSessionByHash(page: import("@playwright/test").Page, sessionId: string): Promise<void> {
+	await page.evaluate((id) => { window.location.hash = `#/session/${id}`; }, sessionId);
+	await expect(page.locator("textarea").first()).toBeVisible({ timeout: 15_000 });
+}
+
+async function expectSessionComposer(page: import("@playwright/test").Page, sessionId: string, label: string): Promise<void> {
+	await expect(
+		page.locator("textarea").first(),
+		`${label}: ROUTE_VIEW_SESSION_MISMATCH expected /session/${sessionId} to open the session composer`,
+	).toBeVisible({ timeout: 15_000 });
+	await expect(
+		page.locator('[data-testid="copy-session-link"] button').first(),
+		`${label}: ROUTE_VIEW_SESSION_MISMATCH expected session header actions for ${sessionId}`,
+	).toBeVisible({ timeout: 10_000 });
+}
 
 // Grant clipboard read/write permissions so navigator.clipboard works in
 // headless Chromium.
@@ -24,8 +40,7 @@ test.describe("Copy session link button (UI)", () => {
 		try {
 			await openApp(page);
 			// Navigate to the session.
-			await page.evaluate((id) => { window.location.hash = `#/session/${id}`; }, sessionId);
-			await expect(page.locator("textarea").first()).toBeVisible({ timeout: 15_000 });
+			await openSessionByHash(page, sessionId);
 
 			// Button is present.
 			const btn = page.locator('[data-testid="copy-session-link"] button').first();
@@ -60,6 +75,47 @@ test.describe("Copy session link button (UI)", () => {
 				expect(clip).toBe(expectedUrl);
 			}).toPass({ timeout: 5_000 });
 		} finally {
+			await deleteSession(sessionId).catch(() => { /* best-effort */ });
+		}
+	});
+
+	test("direct /session path deep link opens the session and survives reload", async ({ page }) => {
+		const sessionId = await createSession();
+		await waitForSessionStatus(sessionId, "idle");
+
+		try {
+			const token = await readE2ETokenAsync();
+			await page.goto(`${base()}/session/${sessionId}?token=${encodeURIComponent(token)}`);
+			await expectSessionComposer(page, sessionId, "direct path load");
+
+			await page.reload();
+			await expectSessionComposer(page, sessionId, "direct path reload");
+		} finally {
+			await deleteSession(sessionId).catch(() => { /* best-effort */ });
+		}
+	});
+
+	test("copied path-style session link opens in a fresh full-page load", async ({ page, browser }) => {
+		const sessionId = await createSession();
+		await waitForSessionStatus(sessionId, "idle");
+		const freshContext = await browser.newContext({ permissions: ["clipboard-read", "clipboard-write"] });
+		const freshPage = await freshContext.newPage();
+
+		try {
+			await openApp(page);
+			await openSessionByHash(page, sessionId);
+
+			const btn = page.locator('[data-testid="copy-session-link"] button').first();
+			await expect(btn).toBeVisible({ timeout: 10_000 });
+			await btn.click();
+			const copiedUrl = await page.evaluate(() => navigator.clipboard.readText());
+			expect(copiedUrl, "copy action should produce the path-style session URL being fixed").toBe(`${base()}/session/${sessionId}`);
+
+			const token = await readE2ETokenAsync();
+			await freshPage.goto(`${copiedUrl}?token=${encodeURIComponent(token)}`);
+			await expectSessionComposer(freshPage, sessionId, "copied path link fresh load");
+		} finally {
+			await freshContext.close().catch(() => { /* best-effort */ });
 			await deleteSession(sessionId).catch(() => { /* best-effort */ });
 		}
 	});

--- a/tests/session-path-routing.test.ts
+++ b/tests/session-path-routing.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { getRouteFromHash } from "../src/app/routing.ts";
+
+type FakeLocation = {
+	pathname: string;
+	search?: string;
+	hash?: string;
+};
+
+function routeWithLocation(location: FakeLocation): ReturnType<typeof getRouteFromHash> {
+	const originalWindow = (globalThis as any).window;
+	(globalThis as any).window = {
+		location: {
+			pathname: location.pathname,
+			search: location.search ?? "",
+			hash: location.hash ?? "",
+		},
+	};
+	try {
+		return getRouteFromHash();
+	} finally {
+		if (originalWindow === undefined) {
+			delete (globalThis as any).window;
+		} else {
+			(globalThis as any).window = originalWindow;
+		}
+	}
+}
+
+test("hash session route still parses as a session route", () => {
+	const sessionId = "session_hash-123";
+	const route = routeWithLocation({ pathname: "/", hash: `#/session/${sessionId}` });
+	assert.deepEqual(
+		route,
+		{ view: "session", sessionId },
+		`ROUTE_MISMATCH: #/session/${sessionId} should parse as a session route, got ${JSON.stringify(route)}`,
+	);
+});
+
+test("path session deep link parses as the same session route as the hash form", () => {
+	const sessionId = "session_path-123";
+	const route = routeWithLocation({ pathname: `/session/${sessionId}` });
+	assert.deepEqual(
+		route,
+		{ view: "session", sessionId },
+		`ROUTE_MISMATCH: /session/${sessionId} should parse as a session route instead of landing, got ${JSON.stringify(route)}`,
+	);
+});
+
+test("path session deep link with auth token query still parses as a session route", () => {
+	const sessionId = "session_token-123";
+	const route = routeWithLocation({ pathname: `/session/${sessionId}`, search: "?token=e2e-token" });
+	assert.deepEqual(
+		route,
+		{ view: "session", sessionId },
+		`ROUTE_MISMATCH: /session/${sessionId}?token=... should parse as a session route without consuming auth query, got ${JSON.stringify(route)}`,
+	);
+});
+
+test("walkthrough pathname route remains unchanged", () => {
+	const route = routeWithLocation({ pathname: "/walkthrough", search: "?session=abc&tab=review" });
+	assert.deepEqual(route, {
+		view: "walkthrough",
+		walkthroughSessionId: "abc",
+		walkthroughTabId: "review",
+	});
+});

--- a/tests/session-path-routing.test.ts
+++ b/tests/session-path-routing.test.ts
@@ -58,6 +58,24 @@ test("path session deep link with auth token query still parses as a session rou
 	);
 });
 
+test("hash session route wins over path session fallback", () => {
+	const route = routeWithLocation({ pathname: "/session/old", hash: "#/session/new" });
+	assert.deepEqual(
+		route,
+		{ view: "session", sessionId: "new" },
+		`ROUTE_MISMATCH: /session/old#/session/new should parse the hash session route, got ${JSON.stringify(route)}`,
+	);
+});
+
+test("hash settings route wins over path session fallback", () => {
+	const route = routeWithLocation({ pathname: "/session/old", hash: "#/settings" });
+	assert.deepEqual(
+		route,
+		{ view: "settings" },
+		`ROUTE_MISMATCH: /session/old#/settings should parse the hash settings route, got ${JSON.stringify(route)}`,
+	);
+});
+
 test("walkthrough pathname route remains unchanged", () => {
 	const route = routeWithLocation({ pathname: "/walkthrough", search: "?session=abc&tab=review" });
 	assert.deepEqual(route, {


### PR DESCRIPTION
## Summary
- Support direct path-style session deep links at `/session/<session-id>` while keeping existing `#/session/<session-id>` routes working.
- Preserve auth query handling for `/session/<id>?token=...` and keep meaningful hash routes winning after path-link entry.
- Add route parsing unit coverage, browser E2E coverage for direct/copied path links, and client-routing docs.

## Tests
- `npx tsx --test --test-force-exit tests/session-path-routing.test.ts`
- Workflow implementation gate passed: build, typecheck, repro test, unit tests, E2E tests, reviews, QA.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
