### PR TITLE
Fix PR walkthrough UX and mapping regressions

### DIFF
--- a/docs/pr-walkthrough-panel.md
+++ b/docs/pr-walkthrough-panel.md
@@ -11,14 +11,15 @@ The checked-in prototype in [`docs/design/pr-walkthrough-panel-prototype.html`](
 Users can open a walkthrough from these entry points:
 
 - **Slash command** — `/walkthrough-pr <url|number>` in chat.
+  - The composer exposes `/walkthrough-pr` as a built-in slash-command autocomplete entry with the hint `<GitHub PR URL or #>`.
   - GitHub PR URLs carry the owner, repository, host, and PR number.
   - Numbers, with or without `#`, resolve against the launching session's GitHub `origin` remote.
   - Re-launching the same PR from the same parent focuses the existing walkthrough child when it is still usable.
-- **Git Status Widget / custom event** — the UI listens for `open-pr-walkthrough` events and accepts PR metadata, file stats, and local `baseSha` / `headSha` values.
+- **Git Status Widget / custom event** — when the widget has PR metadata/status, its expanded Pull Request section shows a **Walkthrough** button. Clicking it dispatches `open-pr-walkthrough` with the detected PR number/URL/title/status plus branch, file stats, and local base/head metadata.
 - **Standalone route** — `/walkthrough?session=<id>&tab=<walkthrough-tab-id>` opens an already-created walkthrough tab in a wide review surface.
 - **Compatibility resolver** — fixture and local SHA walkthroughs can still be resolved directly into a tab by the standalone/local resolver paths. Session-hosted walkthrough agents currently support GitHub PR targets only.
 
-For GitHub PR launches, the tab belongs to the child walkthrough session, not the launcher. The UI switches/focuses the child session, and the sidebar shows the child underneath the launching session using first-class `parentSessionId` / `childKind: "pr-walkthrough"` metadata, not delegate-session metadata.
+For GitHub PR launches, the tab belongs to the child walkthrough session, not the launcher. The UI switches/focuses the child session, expands the needed sidebar containers, and shows the child underneath the launching session using first-class `parentSessionId` / `childKind: "pr-walkthrough"` metadata, not delegate-session metadata. This nesting applies to ordinary sessions, goal sessions, team member sessions, and team-lead rows, and it is restored after reload from persisted session metadata and sidebar expansion state.
 
 The same ready walkthrough can be reviewed in:
 
@@ -60,14 +61,16 @@ They do not receive unrestricted `bash`, file write/edit tools, build/test/insta
 
 - `gh pr view` and `gh pr diff` for the launched PR;
 - scoped `gh api` reads for the launched repository and PR;
-- read-only `git diff`, `git show`, `git log`, `git rev-parse`, and `git status`;
+- read-only `git diff`, `git show`, `git log`, `git rev-parse`, `git status`, and `git for-each-ref` for ref inspection;
 - bounded file/search commands such as `rg`, `grep`, `find`, `ls`, `cat`, `head`, `tail`, `pwd`, and `sed`.
 
-It blocks mutating commands, tests/builds, dependency installs, server starts, shell chaining/redirection, long-running follow modes, hidden/ignore override flags, sensitive path reads, repo-local executable spoofing, cross-repository or cross-PR GitHub reads, and `gh` actions that would create reviews or comments.
+It blocks mutating commands, tests/builds, dependency installs, server starts, shell chaining/redirection, long-running follow modes, hidden/ignore override flags, sensitive path reads, repo-local executable spoofing, cross-repository or cross-PR GitHub reads, and `gh` actions that would create reviews or comments. `git for-each-ref` is allowed only as read-only ref inspection; escape/output flags such as `--git-dir`, `--work-tree`, `--output`, `--shell`, `--perl`, `--python`, and `--tcl` remain blocked.
 
 ### 4. YAML submission is the completion path
 
 The walkthrough panel is populated only through `submit_pr_walkthrough_yaml`. The agent must submit exactly one YAML document matching the PR walkthrough schema. A final chat answer is never treated as completion.
+
+The agent prompt includes the schema as a fenced `yaml` block for readability. That fence is documentation only: the `submit_pr_walkthrough_yaml` tool argument must be raw YAML with no Markdown fences, backticks, blockquotes, commentary, or extra YAML documents.
 
 The tool posts to the internal submit endpoint with the child `sessionId`, job id, YAML text, and a scoped submit proof. The gateway validates:
 
@@ -82,7 +85,7 @@ On success, Bobbit maps the YAML into the existing `WalkthroughStorePayload`, pe
 
 ### 5. Follow-up chat remains live
 
-A successful YAML submission does not terminate the child session. The user can ask follow-up questions in the walkthrough chat while the PR context, previous investigation, and tool results remain loaded. Further `submit_pr_walkthrough_yaml` calls are rejected once the job is `ready`; the published payload is immutable for that job.
+A successful YAML submission does not terminate the child session. The user can ask follow-up questions in the walkthrough chat while the PR context, previous investigation, and tool results remain loaded. The child session may carry `readOnly: true` metadata for tool/file policy, but live walkthrough children are still promptable; only archived or terminated walkthrough sessions render as non-interactive. Further `submit_pr_walkthrough_yaml` calls are rejected once the job is `ready`; the published payload is immutable for that job.
 
 ## Target scoping and canonicalization
 
@@ -134,7 +137,7 @@ Validated YAML is mapped into the existing card model:
 - `audit` feeds the final Audit card and draft reviewer checklist.
 - `display.phase_order` and `display.chunk_order` influence visible ordering while preserving the known phase set.
 
-Hunk references are best-effort mapped to parsed diff blocks by file path and hunk header. Unmapped references are preserved as warnings or card suggestions rather than silently disappearing.
+Hunk references are best-effort mapped to parsed diff blocks by normalized file path and hunk identity. Exact hunk-header matches are preferred, but Bobbit also maps by the numeric old/new hunk ranges when either side includes, omits, or changes the trailing context text after the closing `@@`. Unmapped references are preserved as warnings or card suggestions rather than silently disappearing, and fallback file-level mapping avoids duplicating diff blocks.
 
 The older model-backed synthesis and deterministic grouping remain compatibility behavior for direct resolver paths. The session-hosted GitHub flow does not populate cards from chat text or from silent model synthesis in the launcher.
 
@@ -199,7 +202,7 @@ The draft can always be copied, even when provider export is unavailable.
 
 Persistence has four layers:
 
-- **Child session metadata** — the session store persists `parentSessionId`, `childKind: "pr-walkthrough"`, `readOnly`, `walkthroughJobId`, `walkthroughChangesetId`, and `walkthroughTargetKey` so reloads restore the visible child relationship and read-only identity.
+- **Child session metadata** — the session store persists `parentSessionId`, `childKind: "pr-walkthrough"`, `readOnly`, `walkthroughJobId`, `walkthroughChangesetId`, and `walkthroughTargetKey` so reloads restore the visible child relationship and read-only tool identity. The sidebar renders these first-class children under their parent even when the parent is a team lead or the goal/team session list filters out child sessions from the top-level roster.
 - **Walkthrough job record** — the PR walkthrough agent store persists status (`starting`, `waiting_for_yaml`, `validation_failed`, `ready`, or `error`), target, tab id, last validation error, warnings, submitted timestamp, payload timestamp, and a submit-proof hash. Sensitive values such as tokens and raw submit proofs are sanitized.
 - **Resolved walkthrough payload** — after valid YAML, the existing walkthrough store persists final changeset/cards/diff blocks/warnings/export metadata under the `changesetId`.
 - **Reviewer interaction state** — the browser stores active card, diff mode, comments, decisions, completed cards, dismissed suggestions, and collapsed diff blocks under `bobbit:pr-walkthrough:<tab-id>`.

--- a/src/app/pr-walkthrough.ts
+++ b/src/app/pr-walkthrough.ts
@@ -354,6 +354,11 @@ function isLiveSessionHostedWalkthrough(state: AppState, sessionId: string): boo
 
 function collapseLiveWalkthroughPanel(state: AppState, sessionId: string): void {
 	setActivePanelTabIdForSession(state, sessionId, "");
+	const tabs = panelTabsForSession(state, sessionId);
+	const nextTabs = tabs.map((tab) => tab.kind === "walkthrough" && tab.state?.fullscreenOnReady === true
+		? { ...tab, state: { ...tab.state, fullscreenOnReady: false } }
+		: tab);
+	if (nextTabs.some((tab, index) => tab !== tabs[index])) setPanelTabsForSession(state, sessionId, nextTabs);
 	(state as any).previewPanelFullscreen = false;
 	try { localStorage.setItem(`bobbit-preview-collapsed-${sessionId}`, "true"); } catch { /* non-browser/test */ }
 }
@@ -429,7 +434,7 @@ export function upsertPrWalkthroughJobPanel(
 	if (status === "ready") {
 		if (liveSessionHosted) collapseLiveWalkthroughPanel(state, sessionId);
 		else setActivePanelTabIdForSession(state, sessionId, tabId);
-		if (fullscreenOnReady) (state as any).previewPanelFullscreen = true;
+		if (fullscreenOnReady && !liveSessionHosted) (state as any).previewPanelFullscreen = true;
 		if (!liveSessionHosted) restorePrWalkthroughPanel(state, sessionId, tabId);
 	}
 	return tab;

--- a/src/app/pr-walkthrough.ts
+++ b/src/app/pr-walkthrough.ts
@@ -632,8 +632,20 @@ async function focusWalkthroughChildSession(childSessionId: string): Promise<voi
 	}
 }
 
+async function showWalkthroughLaunchToast(message: string): Promise<void> {
+	try {
+		const { showHeaderToast } = await import("./render.js");
+		showHeaderToast(message);
+	} catch { /* best-effort toast */ }
+}
+
 export async function launchPrWalkthroughAgent(state: AppState, sessionId: string, rawInput: OpenPrWalkthroughInput): Promise<PanelWorkspaceTab | undefined> {
 	const input = normalizeInput(state, rawInput);
+	if (!shouldResolveInput(input)) {
+		await showWalkthroughLaunchToast("Enter a PR URL or number: /walkthrough-pr <GitHub PR URL>");
+		renderApp();
+		return undefined;
+	}
 	try {
 		const data = await fetchWalkthroughJson("/api/pr-walkthrough/launch", {
 			method: "POST",
@@ -648,10 +660,7 @@ export async function launchPrWalkthroughAgent(state: AppState, sessionId: strin
 	} catch (error) {
 		const err = error as WalkthroughApiError;
 		console.error("[pr-walkthrough] launch failed", err);
-		try {
-			const { showHeaderToast } = await import("./render.js");
-			showHeaderToast(err.message || "Failed to launch PR walkthrough agent");
-		} catch { /* best-effort toast */ }
+		await showWalkthroughLaunchToast(err.message || "Failed to launch PR walkthrough agent");
 		renderApp();
 		return undefined;
 	}

--- a/src/app/pr-walkthrough.ts
+++ b/src/app/pr-walkthrough.ts
@@ -7,7 +7,14 @@ import {
 	type PanelWorkspaceTab,
 } from "./panel-workspace.js";
 import { gatewayFetch } from "./gateway-fetch.js";
-import { renderApp } from "./state.js";
+import {
+	expandedGoals,
+	renderApp,
+	saveExpandedGoals,
+	setArchivedParentExpanded,
+	setTeamLeadExpanded,
+	state as globalState,
+} from "./state.js";
 import type { state as appState } from "./state.js";
 import type { PrWalkthroughCard, PrWalkthroughChangesetRef } from "../ui/components/pr-walkthrough/types.js";
 
@@ -340,6 +347,17 @@ function labelForJob(job: WalkthroughJobRecord): string {
 	return labelForPrNumber(job.target?.number) || (job.target?.prUrl ? "PR" : "Walkthrough");
 }
 
+function isLiveSessionHostedWalkthrough(state: AppState, sessionId: string): boolean {
+	const session = state.gatewaySessions.find((candidate) => candidate.id === sessionId);
+	return session?.childKind === "pr-walkthrough" && !session.archived && session.status !== "terminated" && session.status !== "archived";
+}
+
+function collapseLiveWalkthroughPanel(state: AppState, sessionId: string): void {
+	setActivePanelTabIdForSession(state, sessionId, "");
+	(state as any).previewPanelFullscreen = false;
+	try { localStorage.setItem(`bobbit-preview-collapsed-${sessionId}`, "true"); } catch { /* non-browser/test */ }
+}
+
 export function upsertPrWalkthroughJobPanel(
 	state: AppState,
 	job: WalkthroughJobRecord,
@@ -352,6 +370,8 @@ export function upsertPrWalkthroughJobPanel(
 	const status: PrWalkthroughStatus = job.status === "starting" ? "waiting_for_yaml" : job.status;
 	const target = job.target || {};
 	const errorMessage = job.error?.message || (status === "validation_failed" ? validationMessage(job.lastValidationError) : undefined);
+	const liveSessionHosted = !!job.parentSessionId || isLiveSessionHostedWalkthrough(state, sessionId);
+	const fullscreenOnReady = !!options.fullscreenOnReady && !liveSessionHosted;
 	const tab: PanelWorkspaceTab = {
 		id: tabId,
 		kind: "walkthrough",
@@ -389,7 +409,7 @@ export function upsertPrWalkthroughJobPanel(
 			prTitle: changeset.prTitle,
 			baseSha: changeset.baseSha,
 			headSha: changeset.headSha,
-			fullscreenOnReady: status === "ready" || undefined,
+			fullscreenOnReady: status === "ready" && fullscreenOnReady || undefined,
 		},
 	};
 
@@ -405,11 +425,12 @@ export function upsertPrWalkthroughJobPanel(
 			: candidate)
 		: [...existing, tab];
 	setPanelTabsForSession(state, sessionId, next);
-	if (options.select) setActivePanelTabIdForSession(state, sessionId, tabId);
+	if (options.select && !(status === "ready" && liveSessionHosted)) setActivePanelTabIdForSession(state, sessionId, tabId);
 	if (status === "ready") {
-		setActivePanelTabIdForSession(state, sessionId, tabId);
-		if (options.fullscreenOnReady || (state as any).selectedSessionId === sessionId) (state as any).previewPanelFullscreen = true;
-		restorePrWalkthroughPanel(state, sessionId, tabId);
+		if (liveSessionHosted) collapseLiveWalkthroughPanel(state, sessionId);
+		else setActivePanelTabIdForSession(state, sessionId, tabId);
+		if (fullscreenOnReady) (state as any).previewPanelFullscreen = true;
+		if (!liveSessionHosted) restorePrWalkthroughPanel(state, sessionId, tabId);
 	}
 	return tab;
 }
@@ -467,10 +488,14 @@ function patchWalkthroughTab(
 	const deduped = nextTabId !== tabId ? nextTabs.filter((tab, index, all) => tab.id !== nextTabId || all.findIndex((candidate) => candidate.id === nextTabId) === index) : nextTabs;
 	if (replaced) {
 		setPanelTabsForSession(state, sessionId, deduped);
-		if (nextTabId !== tabId) setActivePanelTabIdForSession(state, sessionId, nextTabId);
+		const liveSessionHosted = isLiveSessionHostedWalkthrough(state, sessionId);
+		if (nextTabId !== tabId && !(patch.status === "ready" && liveSessionHosted)) setActivePanelTabIdForSession(state, sessionId, nextTabId);
 		if (patch.status === "ready") {
-			setActivePanelTabIdForSession(state, sessionId, nextTabId);
-			if ((state as any).selectedSessionId === sessionId) (state as any).previewPanelFullscreen = true;
+			if (liveSessionHosted) collapseLiveWalkthroughPanel(state, sessionId);
+			else {
+				setActivePanelTabIdForSession(state, sessionId, nextTabId);
+				if ((state as any).selectedSessionId === sessionId) (state as any).previewPanelFullscreen = true;
+			}
 		}
 	}
 	return updatedTabId;
@@ -558,6 +583,35 @@ function launchRequestForInput(sessionId: string, input: OpenPrWalkthroughInput)
 	return resolveRequestForInput(sessionId, input);
 }
 
+function expandWalkthroughSidebarContainers(childSessionId: string): void {
+	const sessions = [...globalState.gatewaySessions, ...globalState.archivedSessions];
+	const byId = new Map(sessions.map((session) => [session.id, session]));
+	const visited = new Set<string>();
+	let current = byId.get(childSessionId);
+	let savedGoalsChanged = false;
+
+	while (current && !visited.has(current.id)) {
+		visited.add(current.id);
+		const goalId = current.teamGoalId || current.goalId;
+		if (goalId && !expandedGoals.has(goalId)) {
+			expandedGoals.add(goalId);
+			savedGoalsChanged = true;
+		}
+
+		const teamLeadId = current.teamLeadSessionId;
+		if (teamLeadId) setTeamLeadExpanded(teamLeadId, true);
+
+		const parentId = current.parentSessionId || current.delegateOf;
+		if (!parentId) break;
+		setArchivedParentExpanded(parentId, true);
+		const parent = byId.get(parentId);
+		if (parent?.role === "team-lead") setTeamLeadExpanded(parentId, true);
+		current = parent;
+	}
+
+	if (savedGoalsChanged) saveExpandedGoals();
+}
+
 async function focusWalkthroughChildSession(childSessionId: string): Promise<void> {
 	try {
 		const [{ refreshSessions }, { connectToSession }] = await Promise.all([
@@ -565,7 +619,8 @@ async function focusWalkthroughChildSession(childSessionId: string): Promise<voi
 			import("./session-manager.js"),
 		]);
 		await refreshSessions();
-		await connectToSession(childSessionId, true, { readOnly: true });
+		expandWalkthroughSidebarContainers(childSessionId);
+		await connectToSession(childSessionId, true);
 	} catch {
 		// The launch already created the child tab state. Session polling will make
 		// the child visible if an immediate focus attempt races session refresh.
@@ -606,6 +661,7 @@ const jobRestoreLastAttempt = new Map<string, number>();
 
 export function restorePrWalkthroughJobForSession(state: AppState, childSessionId: string): void {
 	if (!childSessionId) return;
+	if (isLiveSessionHostedWalkthrough(state, childSessionId)) collapseLiveWalkthroughPanel(state, childSessionId);
 	const now = Date.now();
 	const last = jobRestoreLastAttempt.get(childSessionId) || 0;
 	if (jobRestoreInFlight.has(childSessionId) || now - last < 2_000) return;

--- a/src/app/pr-walkthrough.ts
+++ b/src/app/pr-walkthrough.ts
@@ -352,15 +352,15 @@ function isLiveSessionHostedWalkthrough(state: AppState, sessionId: string): boo
 	return session?.childKind === "pr-walkthrough" && !session.archived && session.status !== "terminated" && session.status !== "archived";
 }
 
-function collapseLiveWalkthroughPanel(state: AppState, sessionId: string): void {
-	setActivePanelTabIdForSession(state, sessionId, "");
+function keepLiveWalkthroughPanelPromptable(state: AppState, sessionId: string, tabId?: string): void {
+	if (tabId) setActivePanelTabIdForSession(state, sessionId, tabId);
 	const tabs = panelTabsForSession(state, sessionId);
 	const nextTabs = tabs.map((tab) => tab.kind === "walkthrough" && tab.state?.fullscreenOnReady === true
 		? { ...tab, state: { ...tab.state, fullscreenOnReady: false } }
 		: tab);
 	if (nextTabs.some((tab, index) => tab !== tabs[index])) setPanelTabsForSession(state, sessionId, nextTabs);
 	(state as any).previewPanelFullscreen = false;
-	try { localStorage.setItem(`bobbit-preview-collapsed-${sessionId}`, "true"); } catch { /* non-browser/test */ }
+	try { localStorage.removeItem(`bobbit-preview-collapsed-${sessionId}`); } catch { /* non-browser/test */ }
 }
 
 export function upsertPrWalkthroughJobPanel(
@@ -430,9 +430,9 @@ export function upsertPrWalkthroughJobPanel(
 			: candidate)
 		: [...existing, tab];
 	setPanelTabsForSession(state, sessionId, next);
-	if (options.select && !(status === "ready" && liveSessionHosted)) setActivePanelTabIdForSession(state, sessionId, tabId);
+	if (options.select) setActivePanelTabIdForSession(state, sessionId, tabId);
 	if (status === "ready") {
-		if (liveSessionHosted) collapseLiveWalkthroughPanel(state, sessionId);
+		if (liveSessionHosted) keepLiveWalkthroughPanelPromptable(state, sessionId, tabId);
 		else setActivePanelTabIdForSession(state, sessionId, tabId);
 		if (fullscreenOnReady && !liveSessionHosted) (state as any).previewPanelFullscreen = true;
 		if (!liveSessionHosted) restorePrWalkthroughPanel(state, sessionId, tabId);
@@ -494,9 +494,9 @@ function patchWalkthroughTab(
 	if (replaced) {
 		setPanelTabsForSession(state, sessionId, deduped);
 		const liveSessionHosted = isLiveSessionHostedWalkthrough(state, sessionId);
-		if (nextTabId !== tabId && !(patch.status === "ready" && liveSessionHosted)) setActivePanelTabIdForSession(state, sessionId, nextTabId);
+		if (nextTabId !== tabId) setActivePanelTabIdForSession(state, sessionId, nextTabId);
 		if (patch.status === "ready") {
-			if (liveSessionHosted) collapseLiveWalkthroughPanel(state, sessionId);
+			if (liveSessionHosted) keepLiveWalkthroughPanelPromptable(state, sessionId, nextTabId);
 			else {
 				setActivePanelTabIdForSession(state, sessionId, nextTabId);
 				if ((state as any).selectedSessionId === sessionId) (state as any).previewPanelFullscreen = true;
@@ -666,7 +666,7 @@ const jobRestoreLastAttempt = new Map<string, number>();
 
 export function restorePrWalkthroughJobForSession(state: AppState, childSessionId: string): void {
 	if (!childSessionId) return;
-	if (isLiveSessionHostedWalkthrough(state, childSessionId)) collapseLiveWalkthroughPanel(state, childSessionId);
+	if (isLiveSessionHostedWalkthrough(state, childSessionId)) keepLiveWalkthroughPanelPromptable(state, childSessionId);
 	const now = Date.now();
 	const last = jobRestoreLastAttempt.get(childSessionId) || 0;
 	if (jobRestoreInFlight.has(childSessionId) || now - last < 2_000) return;

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -464,12 +464,8 @@ export function renderSessionRow(session: GatewaySession) {
 	const isActive = session.status === "streaming" || session.status === "busy" || session.isCompacting;
 
 	// Check for children (live delegates + first-class child sessions + archived children)
-	const _bypassFilters = !!state.searchQuery.trim();
-	const liveChildren = state.gatewaySessions.filter(s =>
-		sessionParentId(s) === session.id
-		&& (state.showArchived || s.status !== "terminated")
-		&& passesSidebarFilters(s, s.id === activeSessionId(), _bypassFilters));
-	const archivedChildren = state.showArchived ? state.archivedSessions.filter(s => sessionParentId(s) === session.id) : [];
+	const liveChildren = visibleLiveChildrenForParent(session.id);
+	const archivedChildren = state.showArchived ? archivedChildrenForParent(session.id) : [];
 	const hasChildren = liveChildren.length > 0 || archivedChildren.length > 0;
 	const autoExpanded = liveChildren.some(isFirstClassChildSession);
 	const childrenExpanded = hasChildren && (autoExpanded || isArchivedParentExpanded(session.id));
@@ -530,17 +526,25 @@ export function renderSessionRow(session: GatewaySession) {
 					</div>
 				</div>`}
 		</div>
-		${childrenExpanded ? html`${renderLiveDelegates(session.id)}${renderArchivedDelegates(session.id)}` : ""}
+		${childrenExpanded ? html`${renderLiveDelegates(session.id)}${renderArchivedDelegates(session.id, true)}` : ""}
 	`;
+}
+
+function visibleLiveChildrenForParent(parentSessionId: string): GatewaySession[] {
+	const bypassFilters = !!state.searchQuery.trim();
+	return state.gatewaySessions.filter(s =>
+		sessionParentId(s) === parentSessionId
+		&& (state.showArchived || s.status !== "terminated")
+		&& (isFirstClassChildSession(s) || passesSidebarFilters(s, s.id === activeSessionId(), bypassFilters)));
+}
+
+function archivedChildrenForParent(parentSessionId: string): GatewaySession[] {
+	return state.archivedSessions.filter(s => sessionParentId(s) === parentSessionId);
 }
 
 /** Render live delegate sessions nested under a parent session. */
 function renderLiveDelegates(parentSessionId: string): TemplateResult | string {
-	const bypassFilters = !!state.searchQuery.trim();
-	const children = state.gatewaySessions.filter(s =>
-		sessionParentId(s) === parentSessionId
-		&& (state.showArchived || s.status !== "terminated")
-		&& passesSidebarFilters(s, s.id === activeSessionId(), bypassFilters));
+	const children = visibleLiveChildrenForParent(parentSessionId);
 	if (children.length === 0) return "";
 	return html`<div class="flex flex-col gap-0.5" style="padding-left:${INDENT}px;">
 		${children.map(s => s.status === "terminated"
@@ -588,9 +592,9 @@ export function renderArchivedSessionRow(session: GatewaySession, extraChildren 
 }
 
 /** Render any archived delegate sessions nested under a parent session. */
-export function renderArchivedDelegates(parentSessionId: string): TemplateResult | string {
-	if (!isArchivedParentExpanded(parentSessionId)) return "";
-	const delegates = state.archivedSessions.filter(s => sessionParentId(s) === parentSessionId);
+export function renderArchivedDelegates(parentSessionId: string, forceExpanded = false): TemplateResult | string {
+	if (!forceExpanded && !isArchivedParentExpanded(parentSessionId)) return "";
+	const delegates = archivedChildrenForParent(parentSessionId);
 	if (delegates.length === 0) return "";
 	return html`<div class="flex flex-col gap-0.5" style="padding-left:${INDENT}px;">
 		${delegates.map(s => html`
@@ -641,6 +645,7 @@ function renderTeamLeadRow(session: GatewaySession, childCount: number, expanded
 	const tlNavId = `session:${session.id}`;
 	return html`
 		<div
+			data-session-id="${session.id}"
 			data-nav-id=${tlNavId}
 			data-nav-active=${active ? "true" : "false"}
 			class="${mobile ? "" : "group relative"} relative flex items-center gap-1 pr-1 ${rowPy} rounded-md cursor-pointer transition-colors
@@ -912,8 +917,14 @@ export function renderGoalGroup(goal: Goal) {
 		const archivedForLiveLead = state.showArchived
 			? state.archivedSessions.filter(s => s.teamGoalId === goal.id && !isChildSession(s) && s.role !== "team-lead" && s.teamLeadSessionId === teamLead.id)
 			: [];
+		const liveLeadChildren = visibleLiveChildrenForParent(teamLead.id);
+		const archivedLeadChildren = state.showArchived ? archivedChildrenForParent(teamLead.id) : [];
+		const leadChildRowsExpanded = liveLeadChildren.some(isFirstClassChildSession)
+			|| archivedLeadChildren.length > 0
+			|| isArchivedParentExpanded(teamLead.id);
 		return html`
-			${renderTeamLeadRow(teamLead, teamChildren.length + archivedForLiveLead.length, tlExpanded)}
+			${renderTeamLeadRow(teamLead, teamChildren.length + archivedForLiveLead.length + liveLeadChildren.length + archivedLeadChildren.length, tlExpanded)}
+			${leadChildRowsExpanded ? html`${renderLiveDelegates(teamLead.id)}${renderArchivedDelegates(teamLead.id, true)}` : ""}
 			${tlExpanded ? html`
 				<div class="flex flex-col gap-0.5" style="padding-left:${INDENT}px;">
 					${teamChildren.map(renderSessionRow)}

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -2222,6 +2222,15 @@ export function doRenderApp(): void {
 		};
 	};
 
+	const isLiveSessionHostedWalkthroughActive = (tab?: UnifiedContentTab) => {
+		const activeId = activeSessionId();
+		const session = state.gatewaySessions.find((candidate) => candidate.id === activeId);
+		if (session?.childKind === "pr-walkthrough" && !session.archived && session.status !== "terminated" && session.status !== "archived") return true;
+		const archived = state.archivedSessions.some((candidate) => candidate.id === activeId || (candidate.parentSessionId === activeId && candidate.status === "terminated"));
+		const source = tab?.source as Record<string, unknown> | undefined;
+		return !archived && tab?.kind === "walkthrough" && typeof activeId === "string" && activeId.length > 0 && source?.sessionId === activeId;
+	};
+
 	const walkthroughPanelContent = (tab: UnifiedContentTab) => {
 		if (tab.kind !== "walkthrough") return "";
 		void ensurePrWalkthroughPanel();
@@ -2234,9 +2243,9 @@ export function doRenderApp(): void {
 		const exportCapability = tabState.exportCapability;
 		const validationError = tabState.validationError || tabState.lastValidationError;
 		const jobId = typeof tabState.jobId === "string" ? tabState.jobId : undefined;
-		if (status === "ready" && tabState.fullscreenOnReady === true && !state.previewPanelFullscreen) {
+		if (status === "ready" && tabState.fullscreenOnReady === true && !state.previewPanelFullscreen && !isLiveSessionHostedWalkthroughActive(tab)) {
 			queueMicrotask(() => {
-				if (activeSessionId() === workspaceSessionId()) {
+				if (activeSessionId() === workspaceSessionId() && !isLiveSessionHostedWalkthroughActive(tab)) {
 					state.previewPanelFullscreen = true;
 					renderApp();
 				}
@@ -2421,7 +2430,9 @@ export function doRenderApp(): void {
 			const fullscreenContent = fullscreenTab?.kind === "walkthrough"
 				? walkthroughPanelContent(fullscreenTab)
 				: htmlPreviewContent();
-			if (desktop && state.previewPanelFullscreen && (fullscreenTab?.kind === "preview" || fullscreenTab?.kind === "walkthrough")) {
+			const suppressFullscreenForLiveWalkthrough = isLiveSessionHostedWalkthroughActive(fullscreenTab) && fullscreenTab?.kind === "walkthrough";
+			if (suppressFullscreenForLiveWalkthrough && state.previewPanelFullscreen) state.previewPanelFullscreen = false;
+			if (desktop && state.previewPanelFullscreen && !suppressFullscreenForLiveWalkthrough && (fullscreenTab?.kind === "preview" || fullscreenTab?.kind === "walkthrough")) {
 				return html`
 					${reconnectBanner()}
 					<div class="flex-1 flex flex-col min-h-0 overflow-hidden">

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -571,13 +571,14 @@ export function saveExpandedGoals(): void {
 }
 
 
-export function toggleTeamLeadExpanded(sessionId: string): void {
-	if (collapsedTeamLeadSessions.has(sessionId)) {
-		collapsedTeamLeadSessions.delete(sessionId);
-	} else {
-		collapsedTeamLeadSessions.add(sessionId);
-	}
+export function setTeamLeadExpanded(sessionId: string, expanded: boolean): void {
+	if (expanded) collapsedTeamLeadSessions.delete(sessionId);
+	else collapsedTeamLeadSessions.add(sessionId);
 	localStorage.setItem(COLLAPSED_TEAM_LEADS_KEY, JSON.stringify([...collapsedTeamLeadSessions]));
+}
+
+export function toggleTeamLeadExpanded(sessionId: string): void {
+	setTeamLeadExpanded(sessionId, collapsedTeamLeadSessions.has(sessionId));
 }
 
 export function isTeamLeadExpanded(sessionId: string): boolean {
@@ -589,13 +590,14 @@ const expandedDelegateParents: Set<string> = new Set(
 	JSON.parse(localStorage.getItem(EXPANDED_DELEGATE_PARENTS_KEY) || "[]"),
 );
 
-export function toggleArchivedParentExpanded(sessionId: string): void {
-	if (expandedDelegateParents.has(sessionId)) {
-		expandedDelegateParents.delete(sessionId);
-	} else {
-		expandedDelegateParents.add(sessionId);
-	}
+export function setArchivedParentExpanded(sessionId: string, expanded: boolean): void {
+	if (expanded) expandedDelegateParents.add(sessionId);
+	else expandedDelegateParents.delete(sessionId);
 	localStorage.setItem(EXPANDED_DELEGATE_PARENTS_KEY, JSON.stringify([...expandedDelegateParents]));
+}
+
+export function toggleArchivedParentExpanded(sessionId: string): void {
+	setArchivedParentExpanded(sessionId, !expandedDelegateParents.has(sessionId));
 }
 
 export function isArchivedParentExpanded(sessionId: string): boolean {

--- a/src/server/pr-walkthrough/walkthrough-agent-manager.ts
+++ b/src/server/pr-walkthrough/walkthrough-agent-manager.ts
@@ -678,8 +678,11 @@ function publicJob(job: PrWalkthroughJobRecord | null): PrWalkthroughJobRecord |
 	return safeJob as PrWalkthroughJobRecord;
 }
 
-const REQUIRED_YAML_SCHEMA_PROMPT = `Required submit_pr_walkthrough_yaml YAML shape (submit exactly one YAML document; preserve these keys and enum values):
+const REQUIRED_YAML_SCHEMA_PROMPT = `Required submit_pr_walkthrough_yaml YAML shape (preserve these keys and enum values).
+You must call submit_pr_walkthrough_yaml with exactly one raw YAML document matching this schema.
+Do not include Markdown code fences, backticks, blockquotes, commentary, or multiple documents in the submit_pr_walkthrough_yaml tool argument.
 
+\`\`\`yaml
 schema_version: 1
 pr:
   provider: github
@@ -780,7 +783,10 @@ walkthrough:
       - other
       - audit
     chunk_order:
-      - review_chunk_id`;
+      - review_chunk_id
+\`\`\`
+
+The fenced block above is only a prompt example for readability; the submit_pr_walkthrough_yaml tool argument must be the raw YAML document without code fences.`;
 
 function buildRolePrompt(target: PrWalkthroughTarget): string {
 	return [

--- a/src/server/pr-walkthrough/walkthrough-readonly-policy.ts
+++ b/src/server/pr-walkthrough/walkthrough-readonly-policy.ts
@@ -35,7 +35,7 @@ const BLOCKED_EXECUTABLES = new Set([
 	"service", "systemctl", "nohup", "setsid",
 ]);
 
-const GIT_ALLOWED = new Set(["diff", "show", "log", "rev-parse", "status"]);
+const GIT_ALLOWED = new Set(["diff", "show", "log", "rev-parse", "status", "for-each-ref"]);
 const SEARCH_READ_ALLOWED = new Set(["rg", "grep", "ls", "cat", "head", "tail", "pwd"]);
 const PATH_READING_COMMANDS = new Set(["rg", "grep", "ls", "cat", "head", "tail", "find", "sed"]);
 const GH_PR_READ_ALLOWED = new Set(["view", "diff"]);
@@ -53,6 +53,7 @@ const RG_HIDDEN_OR_IGNORE_OVERRIDE_FLAGS = new Set([
 	"--follow",
 	"-L",
 ]);
+const GIT_FOR_EACH_REF_ESCAPE_FLAGS = new Set(["--shell", "--perl", "--python", "--tcl"]);
 
 const GH_API_BODY_FLAGS = new Set(["-f", "--field", "-F", "--raw-field", "--input"]);
 const GH_API_VALUE_FLAGS = new Set(["--jq", "-q", "--header", "-H"]);
@@ -395,6 +396,14 @@ function allowGit(argv: string[]): WalkthroughReadonlyDecision {
 		for (const arg of argv.slice(2)) {
 			if (!allowedStatusArgs.has(arg) && !arg.startsWith("--untracked-files=")) {
 				return block("git status is restricted to short/porcelain-style read-only flags", argv);
+			}
+		}
+	}
+	if (sub === "for-each-ref") {
+		for (const arg of argv.slice(2)) {
+			const flag = arg.includes("=") ? arg.slice(0, arg.indexOf("=")) : arg;
+			if (GIT_FOR_EACH_REF_ESCAPE_FLAGS.has(flag)) {
+				return block(`${flag} is not allowed in read-only PR walkthrough sessions because it emits shell/interpreter-quoted output`, argv);
 			}
 		}
 	}

--- a/src/server/pr-walkthrough/walkthrough-yaml-schema.ts
+++ b/src/server/pr-walkthrough/walkthrough-yaml-schema.ts
@@ -720,12 +720,43 @@ class DiffReferenceMapper {
 
 	findHunk(file: string, hunkHeader: string): { block: PrWalkthroughDiffBlock; hunk: PrWalkthroughHunk } | undefined {
 		const normalizedHeader = normalizeHunkHeader(hunkHeader);
+		const coordinates = parseHunkCoordinates(hunkHeader);
 		for (const block of this.byFile.get(normalizePath(file)) ?? []) {
 			const hunk = block.hunks.find(candidate => candidate.header === hunkHeader || normalizeHunkHeader(candidate.header) === normalizedHeader);
 			if (hunk) return { block, hunk };
+			if (coordinates) {
+				const coordinateMatch = block.hunks.find(candidate => hunkCoordinatesEqual(parseHunkCoordinates(candidate.header), coordinates));
+				if (coordinateMatch) return { block, hunk: coordinateMatch };
+			}
 		}
 		return undefined;
 	}
+}
+
+interface HunkCoordinates {
+	oldStart: number;
+	oldCount: number;
+	newStart: number;
+	newCount: number;
+}
+
+function parseHunkCoordinates(header: string): HunkCoordinates | undefined {
+	const match = /^@@\s*-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s*@@(?:\s.*)?$/.exec(normalizeHunkHeader(header));
+	if (!match) return undefined;
+	return {
+		oldStart: Number(match[1]),
+		oldCount: match[2] === undefined ? 1 : Number(match[2]),
+		newStart: Number(match[3]),
+		newCount: match[4] === undefined ? 1 : Number(match[4]),
+	};
+}
+
+function hunkCoordinatesEqual(left: HunkCoordinates | undefined, right: HunkCoordinates): boolean {
+	return Boolean(left
+		&& left.oldStart === right.oldStart
+		&& left.oldCount === right.oldCount
+		&& left.newStart === right.newStart
+		&& left.newCount === right.newCount);
 }
 
 function flattenDiffBlocks(parsedDiff: WalkthroughParsedDiffForYamlMapping): PrWalkthroughDiffBlock[] {

--- a/src/ui/components/MessageEditor.ts
+++ b/src/ui/components/MessageEditor.ts
@@ -18,7 +18,21 @@ interface SlashSkillInfo {
 	name: string;
 	description: string;
 	argumentHint?: string;
-	source: "project" | "personal" | "legacy";
+	source: "project" | "personal" | "legacy" | "built-in";
+}
+
+const BUILT_IN_SLASH_COMMANDS: SlashSkillInfo[] = [
+	{
+		name: "walkthrough-pr",
+		argumentHint: "<GitHub PR URL or #>",
+		description: "Launch a guided PR walkthrough child session.",
+		source: "built-in",
+	},
+];
+
+function mergeBuiltInSlashCommands(skills: SlashSkillInfo[]): SlashSkillInfo[] {
+	const names = new Set(skills.map((skill) => skill.name.toLowerCase()));
+	return [...BUILT_IN_SLASH_COMMANDS.filter((skill) => !names.has(skill.name.toLowerCase())), ...skills];
 }
 
 /** Server-authoritative queued message (mirrors server QueuedMessage from protocol.ts) */
@@ -89,7 +103,7 @@ export class MessageEditor extends LitElement {
 	private _savedDraft = ""; // draft saved when entering history mode
 
 	// Slash skill autocomplete state
-	@state() private _slashSkills: SlashSkillInfo[] = [];
+	@state() private _slashSkills: SlashSkillInfo[] = mergeBuiltInSlashCommands([]);
 	@state() private _slashFilteredSkills: SlashSkillInfo[] = [];
 	@state() private _slashMenuOpen = false;
 	@state() private _slashSelectedIndex = 0;
@@ -144,7 +158,10 @@ export class MessageEditor extends LitElement {
 	}
 
 	private async _loadSlashSkills() {
-		if (!this.cwd) return;
+		if (!this.cwd) {
+			this._slashSkills = mergeBuiltInSlashCommands([]);
+			return;
+		}
 		if (this._slashSkillsLoaded && this._slashSkillsCwd === this.cwd && this._slashSkillsProjectId === this.projectId) return;
 		try {
 			let url = `/api/slash-skills?cwd=${encodeURIComponent(this.cwd)}`;
@@ -152,10 +169,11 @@ export class MessageEditor extends LitElement {
 			const res = await gatewayFetch(url);
 			if (res.ok) {
 				const data = await res.json();
-				this._slashSkills = data.skills || [];
+				this._slashSkills = mergeBuiltInSlashCommands(data.skills || []);
 			}
 		} catch {
 			// Best effort
+			this._slashSkills = mergeBuiltInSlashCommands([]);
 		}
 		this._slashSkillsCwd = this.cwd;
 		this._slashSkillsProjectId = this.projectId;
@@ -857,6 +875,7 @@ export class MessageEditor extends LitElement {
 						${this._slashFilteredSkills.map((skill, i) => html`
 							<button
 								class="w-full text-left px-3 py-2 flex items-start gap-2 cursor-pointer transition-colors ${i === this._slashSelectedIndex ? "bg-accent text-accent-foreground" : "hover:bg-muted/50"}"
+								data-testid=${`slash-command-${skill.name}`}
 								@mousedown=${(e: Event) => { e.preventDefault(); this._selectSlashSkill(skill); }}
 								@mouseenter=${() => { this._slashSelectedIndex = i; }}
 							>

--- a/tests/e2e/ui/pr-walkthrough-panel.spec.ts
+++ b/tests/e2e/ui/pr-walkthrough-panel.spec.ts
@@ -404,7 +404,8 @@ async function submitValidWalkthroughYaml(page: Page, job: { childSessionId: str
 	expect(response.ok, `valid YAML submit should succeed: ${response.status} ${response.text}`).toBe(true);
 	await focusChildWalkthroughSession(page, job.childSessionId);
 	await publishWalkthroughJobUpdate(page, job.childSessionId);
-	await expect(page.locator(".preview-fullscreen-prompt").first(), "successful YAML submission should automatically promote the child walkthrough to fullscreen review mode").toBeVisible({ timeout: 10_000 });
+	await expect(page.locator(".preview-fullscreen-prompt"), "live walkthrough child should stay in split view so chat remains promptable").toHaveCount(0);
+	await expect(page.locator("textarea").first(), "live walkthrough child should keep the chat prompt visible after YAML submission").toBeVisible({ timeout: 10_000 });
 	return expectWalkthroughOpened(page);
 }
 
@@ -1110,7 +1111,7 @@ This is the author's source description with **markdown**.
 		await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-draft")).toContainText(revisedConcern);
 	});
 
-	test("fullscreen toolbar control promotes the active walkthrough tab to the wide review surface", async ({ page }) => {
+	test("fullscreen toolbar control keeps live child walkthroughs in split promptable view", async ({ page }) => {
 		await setupWalkthrough(page, { width: 1600, height: 900 }, WALKTHROUGH_URL_COMMAND);
 
 		const fullscreen = page.locator(`${tid("side-panel-fullscreen")}, ${tid("pr-walkthrough-fullscreen")}, button[title*="Fullscreen"]`).first();
@@ -1118,15 +1119,11 @@ This is the author's source description with **markdown**.
 		await fullscreen.click();
 
 		const fullscreenRoot = page.locator(`${tid("side-panel-fullscreen-root")}, ${tid("pr-walkthrough-fullscreen-root")}, .preview-fullscreen-prompt`).first();
-		await expect(fullscreenRoot, "fullscreen walkthrough should render inside the preview-pane fullscreen shell").toBeVisible({ timeout: 10_000 });
-		await expect(walkthroughPanel(page), "walkthrough content should remain mounted in fullscreen mode").toBeVisible();
-		await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-pr-link").locator("svg"), "fullscreen walkthrough GitHub button should include the GitHub mark").toBeVisible();
-		await expectActiveDiffMode(page, "split");
-
-		const collapse = page.locator(`${tid("side-panel-collapse-fullscreen")}, button[title*="Collapse preview"], button[title*="Collapse walkthrough"]`).first();
-		await expect(collapse).toBeVisible();
-		await collapse.click();
-		await expect(page.locator(".goal-split-layout"), "collapsing fullscreen should return to chat + side-panel split layout").toBeVisible({ timeout: 10_000 });
+		await expect(fullscreenRoot, "live walkthrough children should not enter fullscreen and hide the main chat prompt").toBeHidden({ timeout: 10_000 });
+		await expect(walkthroughPanel(page), "walkthrough content should remain mounted in the side panel").toBeVisible();
+		await expect(page.locator("textarea").first(), "live walkthrough child prompt should remain visible").toBeVisible({ timeout: 10_000 });
+		await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-pr-link").locator("svg"), "walkthrough GitHub button should include the GitHub mark").toBeVisible();
+		await expectActiveDiffMode(page, "inline");
 	});
 
 	test("open-in-new-tab toolbar control renders the same walkthrough in a standalone wide route", async ({ page, context }) => {

--- a/tests/e2e/ui/pr-walkthrough-real.spec.ts
+++ b/tests/e2e/ui/pr-walkthrough-real.spec.ts
@@ -311,6 +311,7 @@ async function publishWalkthroughJobUpdate(page: Page, state: MockWalkthroughSta
 			changeset: payload?.changeset ?? { ...realChangeset, prNumber: job!.target?.number, prUrl: job!.target?.prUrl, externalUrl: job!.target?.prUrl, title: job!.title },
 			cards: payload?.cards,
 			warnings: payload?.warnings || [],
+			exportCapability: payload?.exportCapability ?? payload?.export,
 			error: job!.error?.message,
 			errorCode: job!.error?.code,
 		},

--- a/tests/e2e/ui/pr-walkthrough-real.spec.ts
+++ b/tests/e2e/ui/pr-walkthrough-real.spec.ts
@@ -389,7 +389,7 @@ async function saveCardComment(page: Page, body: string) {
 
 
 test.describe("real PR walkthrough browser UX", () => {
-	test("loads mocked resolved cards and preserves comments through reload, fullscreen, and standalone", async ({ page, context }) => {
+	test("loads mocked resolved cards and preserves comments through reload, split panel, and standalone", async ({ page, context }) => {
 		let releaseResolve!: () => void;
 		const state: MockWalkthroughState = {
 			mode: "success",
@@ -421,15 +421,12 @@ test.describe("real PR walkthrough browser UX", () => {
 		await saveLineComment(page, commentBody);
 
 		const fullscreenRoot = page.locator(`${tid("side-panel-fullscreen-root")}, ${tid("pr-walkthrough-fullscreen-root")}, .preview-fullscreen-prompt`).first();
-		if (!await fullscreenRoot.isVisible().catch(() => false)) {
-			const fullscreen = page.locator(`${tid("side-panel-fullscreen")}, ${tid("pr-walkthrough-fullscreen")}, button[title*="Fullscreen"]`).first();
-			await expect(fullscreen).toBeVisible();
-			await fullscreen.click();
-		}
-		await expect(fullscreenRoot).toBeVisible({ timeout: 10_000 });
+		const fullscreen = page.locator(`${tid("side-panel-fullscreen")}, ${tid("pr-walkthrough-fullscreen")}, button[title*="Fullscreen"]`).first();
+		await expect(fullscreen).toBeVisible();
+		await fullscreen.click();
+		await expect(fullscreenRoot, "live walkthrough children should stay in split view so chat remains promptable").toBeHidden({ timeout: 10_000 });
+		await expect(page.locator("textarea").first(), "live walkthrough child prompt should remain visible after fullscreen click").toBeVisible({ timeout: 10_000 });
 		await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-comment").filter({ hasText: commentBody })).toBeVisible();
-		const collapseFullscreen = page.locator(`${tid("side-panel-collapse-fullscreen")}, button[title*="Collapse preview"], button[title*="Collapse walkthrough"]`).first();
-		if (await collapseFullscreen.isVisible().catch(() => false)) await collapseFullscreen.click();
 
 		await page.reload();
 		await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-card-title"), "resolved card identity should survive full reload").toContainText("Resolved changeset overview", { timeout: 15_000 });

--- a/tests/e2e/ui/pr-walkthrough-session-ux.spec.ts
+++ b/tests/e2e/ui/pr-walkthrough-session-ux.spec.ts
@@ -1,0 +1,255 @@
+import type { Page, Route } from "@playwright/test";
+import { test, expect } from "../gateway-harness.js";
+import { apiFetch, createGoal, deleteGoal, startTeam, teardownTeam, waitForSessionStatus } from "../e2e-setup.js";
+import { openApp, createSessionViaUI, sendMessage, navigateToHash } from "./ui-helpers.js";
+
+type LaunchJob = {
+	jobId: string;
+	childSessionId: string;
+	parentSessionId: string;
+	changesetId: string;
+	tabId: string;
+	status: string;
+	title: string;
+	target: { number: number; prUrl: string; canonicalKey: string };
+};
+
+const jobsByChildSession = new Map<string, LaunchJob>();
+const jobsById = new Map<string, LaunchJob>();
+
+function prUrl(prNumber: string | number): string {
+	return `https://github.com/SuuBro/bobbit/pull/${prNumber}`;
+}
+
+async function installWalkthroughLaunchFixture(page: Page) {
+	jobsByChildSession.clear();
+	jobsById.clear();
+
+	const handler = async (route: Route) => {
+		const request = route.request();
+		const url = new URL(request.url());
+		const method = request.method();
+
+		if (url.pathname === "/api/pr-walkthrough/launch" && method === "POST") {
+			const body = JSON.parse(request.postData() || "{}") as Record<string, unknown>;
+			const parentSessionId = String(body.sessionId || body.parentSessionId || "");
+			const prNumber = String(body.prNumber ?? /\/(\d+)$/.exec(String(body.prUrl || ""))?.[1] ?? "777");
+			const changesetId = `github:SuuBro/bobbit#${prNumber}:abc1234`;
+			const jobId = `prw-session-ux-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+			const title = `PR #${prNumber} Walkthrough`;
+
+			const createResponse = await apiFetch("/api/sessions", {
+				method: "POST",
+				body: JSON.stringify({
+					worktree: false,
+					parentSessionId,
+					childKind: "pr-walkthrough",
+					readOnly: true,
+					walkthroughJobId: jobId,
+					walkthroughChangesetId: changesetId,
+					walkthroughTargetKey: `github:SuuBro/bobbit#${prNumber}`,
+				}),
+			});
+			expect(createResponse.ok, `fixture child session should be created: ${createResponse.status}`).toBe(true);
+			const created = await createResponse.json() as { id: string };
+			await apiFetch(`/api/sessions/${encodeURIComponent(created.id)}`, {
+				method: "PATCH",
+				body: JSON.stringify({ title }),
+			}).catch(() => undefined);
+
+			const job: LaunchJob = {
+				jobId,
+				parentSessionId,
+				childSessionId: created.id,
+				changesetId,
+				tabId: `walkthrough:${encodeURIComponent(changesetId)}`,
+				status: "waiting_for_yaml",
+				title,
+				target: { number: Number(prNumber), prUrl: prUrl(prNumber), canonicalKey: `github:SuuBro/bobbit#${prNumber}` },
+			};
+			jobsByChildSession.set(created.id, job);
+			jobsById.set(jobId, job);
+			await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ...job, created: true, job }) });
+			return;
+		}
+
+		const sessionMatch = url.pathname.match(/^\/api\/pr-walkthrough\/session\/(.+)$/);
+		if (sessionMatch && method === "GET") {
+			const job = jobsByChildSession.get(decodeURIComponent(sessionMatch[1]));
+			await route.fulfill({ status: job ? 200 : 404, contentType: "application/json", body: JSON.stringify(job ? { job } : { error: "fixture job not found" }) });
+			return;
+		}
+
+		const jobMatch = url.pathname.match(/^\/api\/pr-walkthrough\/jobs\/(.+)$/);
+		if (jobMatch && method === "GET") {
+			const job = jobsById.get(decodeURIComponent(jobMatch[1]));
+			await route.fulfill({ status: job ? 200 : 404, contentType: "application/json", body: JSON.stringify(job ? { job } : { error: "fixture job not found" }) });
+			return;
+		}
+
+		if (url.pathname === "/api/internal/pr-walkthrough/submit-yaml" && method === "POST") {
+			const body = JSON.parse(request.postData() || "{}") as Record<string, unknown>;
+			const job = jobsById.get(String(body.jobId));
+			if (!job || job.childSessionId !== body.sessionId) {
+				await route.fulfill({ status: 403, contentType: "application/json", body: JSON.stringify({ error: "fixture job/session mismatch" }) });
+				return;
+			}
+			job.status = "ready";
+			await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, status: "ready", changesetId: job.changesetId, job }) });
+			return;
+		}
+
+		if (method === "GET" && url.pathname.startsWith("/api/pr-walkthrough/")) {
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				body: JSON.stringify({
+					changesetId: "github:SuuBro/bobbit#777:abc1234",
+					changeset: { provider: "github", prUrl: prUrl(777), externalUrl: prUrl(777), prNumber: 777, prTitle: "Fixture PR", title: "PR #777: Fixture PR", baseSha: "base", headSha: "head" },
+					cards: [],
+					warnings: [],
+					export: { provider: "github", available: true },
+				}),
+			});
+			return;
+		}
+
+		await route.fallback();
+	};
+
+	await page.route("**/api/pr-walkthrough/**", handler);
+	await page.route("**/api/internal/pr-walkthrough/submit-yaml", handler);
+}
+
+async function activeSessionId(page: Page): Promise<string> {
+	return page.evaluate(() => ((window as any).bobbitState ?? (window as any).__bobbitState)?.selectedSessionId ?? "");
+}
+
+async function launchWalkthroughFromActiveSession(page: Page, prNumber: string): Promise<LaunchJob> {
+	const launchResponse = page.waitForResponse((response) => response.url().includes("/api/pr-walkthrough/launch") && response.request().method() === "POST", { timeout: 20_000 });
+	await sendMessage(page, `/walkthrough-pr ${prNumber}`);
+	const launch = await (await launchResponse).json() as LaunchJob & { job?: LaunchJob };
+	const job = (launch.job && typeof launch.job === "object" ? launch.job : launch) as LaunchJob;
+	await expect.poll(() => activeSessionId(page), {
+		timeout: 15_000,
+		message: "walkthrough launch should focus the live child session without archiving the chat UI",
+	}).toBe(job.childSessionId);
+	return job;
+}
+
+async function expectChildNestedUnderParent(page: Page, parentSessionId: string, childSessionId: string, label: string) {
+	const parentRow = page.locator(`[data-session-id="${parentSessionId}"], [data-nav-id="session:${parentSessionId}"]`).first();
+	const childRow = page.locator(`[data-session-id="${childSessionId}"]`).first();
+	await expect(parentRow, `${label}: parent row should be visible`).toBeVisible({ timeout: 15_000 });
+	await expect(childRow, `${label}: walkthrough child should be visible under its launching parent`).toBeVisible({ timeout: 15_000 });
+	await expect(childRow, `${label}: child row should be labelled as a walkthrough`).toContainText(/Walkthrough/i);
+	await expect.poll(async () => {
+		const [parentBox, childBox] = await Promise.all([parentRow.boundingBox(), childRow.boundingBox()]);
+		return parentBox && childBox ? childBox.y > parentBox.y && childBox.x > parentBox.x : false;
+	}, { timeout: 10_000, message: `${label}: child row should be below and indented from parent row` }).toBe(true);
+}
+
+async function expectLivePromptAcceptsFollowup(page: Page, text: string) {
+	const prompt = page.locator("textarea").first();
+	await expect(prompt, "live walkthrough child should show a follow-up prompt editor").toBeVisible({ timeout: 10_000 });
+	await expect(prompt, "live walkthrough child prompt editor should be enabled").toBeEnabled();
+	await prompt.fill(text);
+	await expect(prompt, "live walkthrough child prompt editor should accept typed follow-up text").toHaveValue(text);
+	await prompt.press("Enter");
+	await expect(page.getByText(text, { exact: true }).first(), "submitted follow-up chat should appear in the walkthrough child transcript").toBeVisible({ timeout: 10_000 });
+}
+
+async function submitValidYaml(page: Page, job: LaunchJob) {
+	const response = await page.evaluate(async ({ sessionId, jobId }) => {
+		const resp = await fetch("/api/internal/pr-walkthrough/submit-yaml", {
+			method: "POST",
+			headers: { "Content-Type": "application/json", "Authorization": `Bearer ${localStorage.getItem("gateway.token") || "localhost"}` },
+			body: JSON.stringify({ sessionId, jobId, yaml: "schema_version: 1\nwalkthrough:\n  review_chunks: []\n" }),
+		});
+		return { ok: resp.ok, status: resp.status, text: await resp.text().catch(() => "") };
+	}, { sessionId: job.childSessionId, jobId: job.jobId });
+	expect(response.ok, `valid YAML submit should succeed: ${response.status} ${response.text}`).toBe(true);
+	await page.evaluate((childSessionId) => {
+		document.dispatchEvent(new CustomEvent("pr-walkthrough-job-updated", { detail: { job: { childSessionId, status: "ready" } } }));
+		(window as any).__bobbitRenderApp?.();
+	}, job.childSessionId);
+}
+
+async function ensureTeamLeadRole() {
+	const roleResponse = await apiFetch("/api/roles", {
+		method: "POST",
+		body: JSON.stringify({
+			name: "team-lead",
+			label: "Team Lead",
+			promptTemplate: "You are a test team lead. Reply with OK.",
+			toolPolicies: {},
+		}),
+	});
+	expect([200, 201, 409], `team-lead role fixture should be creatable: ${roleResponse.status}`).toContain(roleResponse.status);
+}
+
+test.describe("Session-hosted PR walkthrough UX regressions", () => {
+	test("normal session launch nests the live walkthrough child, survives reload, and keeps follow-up chat promptable", async ({ page }) => {
+		await installWalkthroughLaunchFixture(page);
+		await page.setViewportSize({ width: 1600, height: 900 });
+		await openApp(page);
+		await createSessionViaUI(page);
+		const parentSessionId = await activeSessionId(page);
+
+		const job = await launchWalkthroughFromActiveSession(page, "777");
+		await expectChildNestedUnderParent(page, parentSessionId, job.childSessionId, "normal session launch");
+		await expectLivePromptAcceptsFollowup(page, "Before YAML follow-up from browser E2E");
+
+		await submitValidYaml(page, job);
+		await expectLivePromptAcceptsFollowup(page, "After YAML follow-up from browser E2E");
+
+		await page.reload();
+		await expect(page.locator("button").filter({ hasText: "Settings" }).first()).toBeVisible({ timeout: 20_000 });
+		await expect.poll(() => activeSessionId(page), { timeout: 15_000 }).toBe(job.childSessionId);
+		await expectChildNestedUnderParent(page, parentSessionId, job.childSessionId, "normal session launch after reload");
+		await expectLivePromptAcceptsFollowup(page, "Reloaded walkthrough follow-up from browser E2E");
+	});
+
+	test("goal team lead launch nests the walkthrough child under the team lead and restores after reload", async ({ page }) => {
+		await installWalkthroughLaunchFixture(page);
+		await ensureTeamLeadRole();
+		const goal = await createGoal({ title: `Walkthrough team lead ${Date.now()}`, team: true, worktree: false });
+		try {
+			const teamLeadId = await startTeam(goal.id);
+			await waitForSessionStatus(teamLeadId, "idle");
+
+			await page.setViewportSize({ width: 1600, height: 900 });
+			await openApp(page);
+			await navigateToHash(page, `#/session/${teamLeadId}`);
+			await expect(page.locator("textarea").first()).toBeVisible({ timeout: 20_000 });
+
+			const job = await launchWalkthroughFromActiveSession(page, "778");
+			await expectChildNestedUnderParent(page, teamLeadId, job.childSessionId, "team lead launch");
+			await expectLivePromptAcceptsFollowup(page, "Team lead child follow-up from browser E2E");
+
+			await page.reload();
+			await expect(page.locator("button").filter({ hasText: "Settings" }).first()).toBeVisible({ timeout: 20_000 });
+			await expect.poll(() => activeSessionId(page), { timeout: 15_000 }).toBe(job.childSessionId);
+			await expectChildNestedUnderParent(page, teamLeadId, job.childSessionId, "team lead launch after reload");
+		} finally {
+			await teardownTeam(goal.id).catch(() => undefined);
+			await deleteGoal(goal.id).catch(() => undefined);
+		}
+	});
+
+	test("terminated walkthrough child remains archived read-only", async ({ page }) => {
+		await installWalkthroughLaunchFixture(page);
+		await page.setViewportSize({ width: 1600, height: 900 });
+		await openApp(page);
+		await createSessionViaUI(page);
+
+		const job = await launchWalkthroughFromActiveSession(page, "779");
+		const deleteResponse = await apiFetch(`/api/sessions/${encodeURIComponent(job.childSessionId)}`, { method: "DELETE" });
+		expect(deleteResponse.ok, `walkthrough child should terminate cleanly: ${deleteResponse.status}`).toBe(true);
+
+		await navigateToHash(page, "#/");
+		await navigateToHash(page, `#/session/${job.childSessionId}`);
+		await expect(page.locator(".bobbit-blob--archived").first(), "terminated walkthrough child should render as archived").toBeVisible({ timeout: 10_000 });
+		await expect(page.locator("textarea"), "terminated walkthrough child must not expose a prompt editor").toHaveCount(0);
+	});
+});

--- a/tests/e2e/ui/pr-walkthrough-session-ux.spec.ts
+++ b/tests/e2e/ui/pr-walkthrough-session-ux.spec.ts
@@ -196,6 +196,35 @@ async function ensureTeamLeadRole() {
 }
 
 test.describe("Session-hosted PR walkthrough UX regressions", () => {
+	test("normal session advertises walkthrough slash command and intercepts it in the UI", async ({ page }) => {
+		await installWalkthroughLaunchFixture(page);
+		await page.setViewportSize({ width: 1600, height: 900 });
+		await openApp(page);
+		await createSessionViaUI(page);
+		const parentSessionId = await activeSessionId(page);
+
+		const textarea = page.locator("textarea").first();
+		await textarea.fill("/walk");
+		const slashCommand = page.getByTestId("slash-command-walkthrough-pr");
+		await expect(slashCommand, "walkthrough slash command should be discoverable from composer autocomplete").toBeVisible({ timeout: 10_000 });
+		await expect(slashCommand).toContainText("/walkthrough-pr");
+		await expect(slashCommand).toContainText(/GitHub PR URL/i);
+		await slashCommand.click();
+		await expect(textarea).toHaveValue("/walkthrough-pr ");
+
+		const launchResponse = page.waitForResponse((response) => response.url().includes("/api/pr-walkthrough/launch") && response.request().method() === "POST", { timeout: 20_000 });
+		await textarea.fill(`/walkthrough-pr ${prUrl(780)}`);
+		await textarea.press("Enter");
+		const launch = await (await launchResponse).json() as LaunchJob & { job?: LaunchJob };
+		const job = (launch.job && typeof launch.job === "object" ? launch.job : launch) as LaunchJob;
+
+		await expect.poll(() => activeSessionId(page), {
+			timeout: 15_000,
+			message: "slash command should create and focus the live walkthrough child without prompting the agent",
+		}).toBe(job.childSessionId);
+		await expectChildNestedUnderParent(page, parentSessionId, job.childSessionId, "discoverable slash command");
+	});
+
 	test("normal session launch nests the live walkthrough child, survives reload, and keeps follow-up chat promptable", async ({ page }) => {
 		await installWalkthroughLaunchFixture(page);
 		await page.setViewportSize({ width: 1600, height: 900 });

--- a/tests/e2e/ui/pr-walkthrough-session-ux.spec.ts
+++ b/tests/e2e/ui/pr-walkthrough-session-ux.spec.ts
@@ -156,7 +156,14 @@ async function expectLivePromptAcceptsFollowup(page: Page, text: string) {
 	await prompt.fill(text);
 	await expect(prompt, "live walkthrough child prompt editor should accept typed follow-up text").toHaveValue(text);
 	await prompt.press("Enter");
-	await expect(page.getByText(text, { exact: true }).first(), "submitted follow-up chat should appear in the walkthrough child transcript").toBeVisible({ timeout: 10_000 });
+	await expect.poll(async () => page.evaluate((expected) => {
+		const session: any = (window as any).bobbitState?.chatPanel?.agentInterface?.session;
+		const messages = session?.state?.messages || [];
+		return messages.some((message: any) => {
+			const content = Array.isArray(message?.content) ? message.content : [];
+			return content.some((part: any) => part?.type === "text" && part.text === expected);
+		});
+	}, text), { timeout: 10_000 }).toBe(true);
 }
 
 async function submitValidYaml(page: Page, job: LaunchJob) {

--- a/tests/pr-walkthrough-readonly-policy.test.ts
+++ b/tests/pr-walkthrough-readonly-policy.test.ts
@@ -75,6 +75,9 @@ describe("PR walkthrough readonly command policy", () => {
 		allowed("git rev-parse HEAD");
 		allowed("git status --short");
 		allowed("git status --porcelain=v2 --branch");
+		allowed("git for-each-ref refs/heads");
+		allowed("git for-each-ref --format=%(refname:short) refs/remotes/origin");
+		allowed("git for-each-ref --sort=-committerdate --count=5 refs/heads");
 	});
 
 	it("blocks path-qualified executables before command allowlisting", () => {
@@ -107,6 +110,14 @@ describe("PR walkthrough readonly command policy", () => {
 		blocked("git diff --output=diff.patch", /--output/);
 		blocked("git diff -- src/../package.json", /parent-directory/);
 		blocked("git show HEAD -- ':(top)package.json'", /pathspec magic/);
+		blocked("git for-each-ref --git-dir=.git refs/heads", /--git-dir/);
+		blocked("git for-each-ref --work-tree=.. refs/heads", /--work-tree|parent-directory/);
+		blocked("git for-each-ref --output=refs.txt refs/heads", /--output/);
+		blocked("git for-each-ref --ext-diff refs/heads", /external diff/);
+		blocked("git for-each-ref --external-diff refs/heads", /external diff/);
+		blocked("git for-each-ref --shell refs/heads", /shell\/interpreter-quoted output/);
+		blocked("git for-each-ref --python refs/heads", /shell\/interpreter-quoted output/);
+		blocked("git for-each-ref --tcl=unexpected refs/heads", /shell\/interpreter-quoted output/);
 	});
 
 	it("allows read/search commands and bounded sed", () => {

--- a/tests/pr-walkthrough-yaml-schema.test.ts
+++ b/tests/pr-walkthrough-yaml-schema.test.ts
@@ -149,6 +149,72 @@ describe("PR walkthrough YAML schema", () => {
 		const review = payload.cards.find(card => card.id === "significant-chunk-api");
 		assert.ok(review?.cardSuggestions?.some(note => /Unmapped suggested comment anchor/.test(note)));
 	});
+
+	it("maps relevant hunks and anchors by numeric range when YAML omits trailing hunk context", () => {
+		const validation = validatePrWalkthroughYaml(hunkMappingYaml("@@ -10,2 +10,3 @@"));
+		assert.equal(validation.ok, true);
+		if (!validation.ok) return;
+
+		const payload = mapYamlToWalkthroughPayload(validation.document, { files: [contextDiffBlock("@@ -10,2 +10,3 @@ function renderExample")] });
+
+		assertNoUnmappedForFile(payload.warnings, "src/context.ts");
+		const design = payload.cards.find(card => card.id === "design-context-design");
+		assert.deepEqual(design?.diffBlocks.map(block => block.id), ["block-context"]);
+		const review = payload.cards.find(card => card.id === "significant-context-review");
+		assert.equal(review?.suggestedComments?.length, 1);
+		assert.equal(review?.suggestedComments?.[0]?.lineId, "block-context:h0:l1");
+	});
+
+	it("maps relevant hunks and anchors by numeric range when YAML includes stale trailing hunk context", () => {
+		const validation = validatePrWalkthroughYaml(hunkMappingYaml("@@ -10,2 +10,3 @@ staleRenderName"));
+		assert.equal(validation.ok, true);
+		if (!validation.ok) return;
+
+		const payload = mapYamlToWalkthroughPayload(validation.document, { files: [contextDiffBlock("@@ -10,2 +10,3 @@ actualRenderName")] });
+
+		assertNoUnmappedForFile(payload.warnings, "src/context.ts");
+		const review = payload.cards.find(card => card.id === "significant-context-review");
+		assert.equal(review?.suggestedComments?.length, 1);
+		assert.equal(review?.suggestedComments?.[0]?.lineId, "block-context:h0:l1");
+	});
+
+	it("maps relevant hunks and anchors by numeric range when parsed diff omits trailing hunk context", () => {
+		const validation = validatePrWalkthroughYaml(hunkMappingYaml("@@ -10,2 +10,3 @@ renderExample"));
+		assert.equal(validation.ok, true);
+		if (!validation.ok) return;
+
+		const payload = mapYamlToWalkthroughPayload(validation.document, { files: [contextDiffBlock("@@ -10,2 +10,3 @@")] });
+
+		assertNoUnmappedForFile(payload.warnings, "src/context.ts");
+		const review = payload.cards.find(card => card.id === "significant-context-review");
+		assert.equal(review?.suggestedComments?.length, 1);
+		assert.equal(review?.suggestedComments?.[0]?.lineId, "block-context:h0:l1");
+	});
+
+	it("keeps warning when hunk numeric ranges do not match", () => {
+		const validation = validatePrWalkthroughYaml(hunkMappingYaml("@@ -11,2 +10,3 @@ function renderExample"));
+		assert.equal(validation.ok, true);
+		if (!validation.ok) return;
+
+		const payload = mapYamlToWalkthroughPayload(validation.document, { files: [contextDiffBlock("@@ -10,2 +10,3 @@ function renderExample")] });
+
+		assert.ok(payload.warnings.some(warning => warning.code === "unmapped_hunk" && warning.filePath === "src/context.ts"));
+		assert.ok(payload.warnings.some(warning => warning.code === "unmapped_anchor" && warning.filePath === "src/context.ts"));
+		const review = payload.cards.find(card => card.id === "significant-context-review");
+		assert.equal(review?.suggestedComments?.length ?? 0, 0);
+	});
+
+	it("does not duplicate diff blocks when mapped hunks and file fallback overlap", () => {
+		const validation = validatePrWalkthroughYaml(hunkMappingYaml("@@ -10,2 +10,3 @@", "@@ -10,2 +10,3 @@", [{ header: "@@ -99,1 +99,1 @@", why: "Intentional fallback to the same file." }]));
+		assert.equal(validation.ok, true);
+		if (!validation.ok) return;
+
+		const payload = mapYamlToWalkthroughPayload(validation.document, { files: [contextDiffBlock("@@ -10,2 +10,3 @@")] });
+		const review = payload.cards.find(card => card.id === "significant-context-review");
+
+		assert.deepEqual(review?.diffBlocks.map(block => block.id), ["block-context"]);
+		assert.ok(payload.warnings.some(warning => warning.code === "unmapped_hunk" && warning.filePath === "src/context.ts"));
+	});
 });
 
 function assertError(errors: Array<{ path: string; message: string }>, path: string, message: RegExp): void {
@@ -183,6 +249,118 @@ function diffBlocks(): PrWalkthroughDiffBlock[] {
 			hunks: [{ id: "block-src-b:h0", header: "@@ -5,1 +5,2 @@", lines: [{ id: "block-src-b:h0:l0", side: "new", newLine: 5, text: "change", kind: "add" }] }],
 		},
 	];
+}
+
+function contextDiffBlock(header: string): PrWalkthroughDiffBlock {
+	return {
+		id: "block-context",
+		filePath: "src/context.ts",
+		status: "modified",
+		hunks: [{
+			id: "block-context:h0",
+			header,
+			lines: [
+				{ id: "block-context:h0:l0", side: "context", oldLine: 10, newLine: 10, text: "function renderExample() {", kind: "context" },
+				{ id: "block-context:h0:l1", side: "new", newLine: 11, text: "  return <Example />;", kind: "add" },
+			],
+		}],
+	};
+}
+
+function assertNoUnmappedForFile(warnings: Array<{ code: string; filePath?: string }>, filePath: string): void {
+	const matching = warnings.filter(warning => (warning.code === "unmapped_hunk" || warning.code === "unmapped_anchor") && warning.filePath === filePath);
+	assert.deepEqual(matching, []);
+}
+
+function hunkMappingYaml(hunkHeader: string, anchorHeader = hunkHeader, extraRelevantHunks: Array<{ header: string; why: string }> = []): string {
+	const relevantHunks = [
+		{ header: hunkHeader, why: "Primary mapped context change." },
+		...extraRelevantHunks,
+	].map(item => `        - file: src/context.ts
+          hunk_header: "${yamlDoubleQuoted(item.header)}"
+          why_relevant: ${item.why}`).join("\n");
+
+	return `schema_version: 1
+pr:
+  provider: github
+  owner: SuuBro
+  repo: bobbit
+  number: 42
+  title: Fix hunk mapping
+  url: https://github.com/SuuBro/bobbit/pull/42
+  base_sha: abcdef1234567890
+  head_sha: fedcba9876543210
+  original_description:
+    body: Test hunk mapping.
+    source: gh_api
+    fetched_at: "2026-05-30T00:00:00.000Z"
+  stats:
+    files_changed: 1
+    additions: 2
+    deletions: 1
+walkthrough:
+  context:
+    why_created: Fix noisy hunk mapping warnings.
+    problem_solved: Numeric hunk ranges should be authoritative.
+    why_worth_merging: It keeps walkthrough output actionable.
+    merge_concerns: Keep true misses visible.
+    author_intent: Match hunks despite unstable context labels.
+    reviewer_map: Review the context hunk.
+  merge_assessment:
+    recommendation: comment
+    confidence: high
+    summary: Hunk mapping should be stable.
+    blocking_concerns: []
+    non_blocking_concerns: []
+  design_decisions:
+    - id: context-design
+      title: Context mapping
+      explanation: Map a hunk reference to the parsed diff.
+      chosen_approach: Match file and numeric hunk coordinates.
+      alternatives_considered: []
+      tradeoffs: []
+      suggested_reviewer_concerns: []
+      relevant_hunks:
+${relevantHunks}
+  review_chunks:
+    - id: context-review
+      phase: significant
+      title: Context review
+      reviewer_goal: Check hunk references map without noisy warnings.
+      explanation: Suggested comments should anchor to the same hunk.
+      files:
+        - src/context.ts
+      relevant_hunks:
+${relevantHunks}
+      suggested_concerns:
+        - severity: question
+          concern: Is the hunk anchor stable?
+          suggested_comment: Please verify this anchor maps by numeric range.
+          anchors:
+            - file: src/context.ts
+              hunk_header: "${yamlDoubleQuoted(anchorHeader)}"
+              line: 11
+      positive_notes: []
+  omissions_and_followups: []
+  audit:
+    remaining_changed_areas: []
+    low_signal_or_mechanical_changes: []
+    generated_or_binary_files: []
+    reviewer_checklist:
+      - Confirm hunk mapping warnings are meaningful.
+  display:
+    phase_order:
+      - orientation
+      - design
+      - significant
+      - audit
+    chunk_order:
+      - context-review
+`;
+}
+
+function yamlDoubleQuoted(value: string): string {
+	return value.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
 }
 
 function validYaml(): string {


### PR DESCRIPTION
## Summary
- map PR walkthrough YAML hunk references by numeric ranges when trailing hunk context differs
- keep session-hosted walkthrough children visible under parent/team lead rows and live-chat promptable
- advertise `/walkthrough-pr` in slash autocomplete and document launch/read-only behavior
- harden YAML prompt formatting and allow safe `git for-each-ref` inspection

## Validation
- npm run check
- npm run test:unit
- targeted PR walkthrough unit and browser E2E suites

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)