### PR TITLE
Canonicalize session deep-link URLs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,9 +26,11 @@ Bobbit has three layers:
 Bobbit's browser UI is primarily hash-routed so it can run as a static single-page app behind the gateway, Vite, or a remote reverse proxy. Session routes support both forms:
 
 - `#/session/<session-id>` — the normal in-app route used by sidebar and hash navigation.
-- `/session/<session-id>` — a path-style deep link used by the session header's copy-link action.
+- `/session/<session-id>` — a path-style external/shareable deep link used by the session header's copy-link action.
 
-Path-style session links are intentionally valid entrypoints. Opening or reloading `/session/<session-id>` after a full page load selects the same session as the hash route, so copied links continue to work when pasted into a fresh browser tab. Auth query parameters remain on the URL while routing is resolved; for example, `/session/<id>?token=...` can authenticate the browser and still open `<id>`.
+Path-style session links are intentionally valid entrypoints. Opening or reloading `/session/<session-id>` after a full page load selects the same session as the hash route, so copied links continue to work when pasted into a fresh browser tab. Auth query parameters are also supported; for example, `/session/<id>?token=...` can authenticate the browser and still open `<id>`.
+
+After the app resolves and connects a path-style session route, the visible in-app URL is canonicalized to `/#/session/<id>`. The cleanup uses history replacement rather than dispatching hash or route changes, so it does not restart or race the active `connectToSession()` flow.
 
 Hash routes take precedence over the path-style session fallback once the app has loaded. This keeps in-app navigation meaningful even from a copied path URL: `/session/old#/session/new` opens `new`, not `old`. The standalone `/walkthrough?...` pathname route is handled separately, and non-session pathnames are not treated as session deep links.
 

--- a/src/app/routing.ts
+++ b/src/app/routing.ts
@@ -148,6 +148,14 @@ export function setGoalDashboardRoute(
 	}
 }
 
+export function canonicalizePathSessionRoute(sessionId: string): void {
+	const expectedPath = `/session/${sessionId}`;
+	const expectedHash = `#/session/${sessionId}`;
+	if (window.location.pathname !== expectedPath || window.location.hash !== expectedHash) return;
+	// replaceState avoids a hashchange while cleaning up path-style deep links.
+	history.replaceState(history.state ?? {}, "", `/#/session/${sessionId}`);
+}
+
 export function setHashRoute(view: RouteView, id?: string, replace?: boolean): void {
 	let newHash: string;
 	if (view === "session" && id) {

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -18,7 +18,7 @@ import { formatProjectAssistantAutoPrompt } from "./project-assistant-autoprompt
 import { errorDetails } from "./error-helpers.js";
 import { runGitStatusRefresh, abortableSleep } from "./git-status-refresh.js";
 import { startTimeRefresh } from "./render-helpers.js";
-import { getRouteFromHash, setHashRoute, saveSessionModel, loadSessionModel, clearSessionModel, isConfigPageRoute } from "./routing.js";
+import { getRouteFromHash, setHashRoute, canonicalizePathSessionRoute, saveSessionModel, loadSessionModel, clearSessionModel, isConfigPageRoute } from "./routing.js";
 import { sessionHueRotation, ACCESSORY_IDS } from "./session-colors.js";
 import { showConnectionError, confirmAction, checkOAuthStatus, openOAuthDialog } from "./dialogs-lazy.js";
 import { teardownMobileScrollTracking } from "./mobile-header.js";
@@ -1053,6 +1053,7 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 
 		// Mark as visited so unseen indicators clear
 		markSessionVisited(sessionId);
+		canonicalizePathSessionRoute(sessionId);
 
 		// Refresh scope-gate fields + archived readOnly on the restored
 		// AgentInterface. Between disconnect and reconnect the session may
@@ -1712,6 +1713,7 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 		state.remoteAgent = remote;
 		state.appView = "authenticated";
 		markSessionVisited(sessionId);
+		canonicalizePathSessionRoute(sessionId);
 
 		// Detect assistant type from cached session data. The cache may lag the
 		// gateway when a session was just created via a back-channel API call;

--- a/tests/e2e/ui/copy-session-link.spec.ts
+++ b/tests/e2e/ui/copy-session-link.spec.ts
@@ -28,6 +28,18 @@ async function expectSessionComposer(page: import("@playwright/test").Page, sess
 	).toBeVisible({ timeout: 10_000 });
 }
 
+async function expectCanonicalSessionHashUrl(page: import("@playwright/test").Page, sessionId: string, label: string): Promise<void> {
+	await expect
+		.poll(
+			() => page.evaluate(() => window.location.href),
+			{
+				message: `${label}: CANONICAL_SESSION_URL expected path-style entrypoint to settle as /#/session/${sessionId}`,
+				timeout: 5_000,
+			},
+		)
+		.toBe(`${base()}/#/session/${sessionId}`);
+}
+
 // Grant clipboard read/write permissions so navigator.clipboard works in
 // headless Chromium.
 test.use({ permissions: ["clipboard-read", "clipboard-write"] });
@@ -79,7 +91,7 @@ test.describe("Copy session link button (UI)", () => {
 		}
 	});
 
-	test("direct /session path deep link opens the session and survives reload", async ({ page }) => {
+	test("direct /session path deep link opens the session, canonicalizes, and survives reload", async ({ page }) => {
 		const sessionId = await createSession();
 		await waitForSessionStatus(sessionId, "idle");
 
@@ -87,9 +99,11 @@ test.describe("Copy session link button (UI)", () => {
 			const token = await readE2ETokenAsync();
 			await page.goto(`${base()}/session/${sessionId}?token=${encodeURIComponent(token)}`);
 			await expectSessionComposer(page, sessionId, "direct path load");
+			await expectCanonicalSessionHashUrl(page, sessionId, "direct path load");
 
 			await page.reload();
-			await expectSessionComposer(page, sessionId, "direct path reload");
+			await expectSessionComposer(page, sessionId, "canonical hash reload");
+			await expectCanonicalSessionHashUrl(page, sessionId, "canonical hash reload");
 		} finally {
 			await deleteSession(sessionId).catch(() => { /* best-effort */ });
 		}
@@ -114,9 +128,46 @@ test.describe("Copy session link button (UI)", () => {
 			const token = await readE2ETokenAsync();
 			await freshPage.goto(`${copiedUrl}?token=${encodeURIComponent(token)}`);
 			await expectSessionComposer(freshPage, sessionId, "copied path link fresh load");
+			await expectCanonicalSessionHashUrl(freshPage, sessionId, "copied path link fresh load");
 		} finally {
 			await freshContext.close().catch(() => { /* best-effort */ });
 			await deleteSession(sessionId).catch(() => { /* best-effort */ });
+		}
+	});
+
+	test("hash session route takes precedence over conflicting path-style session entrypoint", async ({ page }) => {
+		const oldSessionId = await createSession();
+		const newSessionId = await createSession();
+		await waitForSessionStatus(oldSessionId, "idle");
+		await waitForSessionStatus(newSessionId, "idle");
+
+		try {
+			const token = await readE2ETokenAsync();
+			await page.goto(`${base()}/session/${oldSessionId}?token=${encodeURIComponent(token)}#/session/${newSessionId}`);
+			await expectSessionComposer(page, newSessionId, "hash precedence load");
+			await expect
+				.poll(
+					() => page.evaluate(() => window.location.hash),
+					{
+						message: `hash precedence load: HASH_PRECEDENCE_SESSION_URL expected hash route /session/${newSessionId} to remain active instead of old path session ${oldSessionId}`,
+						timeout: 5_000,
+					},
+				)
+				.toBe(`#/session/${newSessionId}`);
+			expect(
+				page.url(),
+				`hash precedence load: HASH_PRECEDENCE_SESSION_URL must not canonicalize conflicting path session ${oldSessionId}`,
+			).not.toBe(`${base()}/#/session/${oldSessionId}`);
+
+			const btn = page.locator('[data-testid="copy-session-link"] button').first();
+			await btn.click();
+			await expect(async () => {
+				const clip = await page.evaluate(() => navigator.clipboard.readText());
+				expect(clip).toBe(`${base()}/session/${newSessionId}`);
+			}).toPass({ timeout: 5_000 });
+		} finally {
+			await deleteSession(oldSessionId).catch(() => { /* best-effort */ });
+			await deleteSession(newSessionId).catch(() => { /* best-effort */ });
 		}
 	});
 });


### PR DESCRIPTION
## Summary
- canonicalize path-style session deep links to `/#/session/<id>` after connection
- preserve copied `/session/<id>` entrypoints and hash-route precedence
- add browser E2E coverage and update routing docs

## Tests
- npm run check
- npm run test:e2e -- tests/e2e/ui/copy-session-link.spec.ts --retries=0
- workflow verification: build, typecheck, unit, focused repro, full E2E, reviews

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)