### PR TITLE
Fix PR walkthrough tab and diff restoration

### DIFF
--- a/src/app/pr-walkthrough.ts
+++ b/src/app/pr-walkthrough.ts
@@ -371,7 +371,8 @@ export function upsertPrWalkthroughJobPanel(
 	const sessionId = job.childSessionId;
 	const changeset = targetChangesetFromJob(job);
 	const changesetId = job.changesetId;
-	const tabId = job.tabId || walkthroughPanelTabId(changesetId);
+	const rawTabId = cleanString(job.tabId);
+	const tabId = rawTabId && walkthroughChangesetIdFromPanelTabId(rawTabId) ? rawTabId : walkthroughPanelTabId(changesetId);
 	const status: PrWalkthroughStatus = job.status === "starting" ? "waiting_for_yaml" : job.status;
 	const target = job.target || {};
 	const errorMessage = job.error?.message || (status === "validation_failed" ? validationMessage(job.lastValidationError) : undefined);

--- a/src/server/pr-walkthrough/walkthrough-agent-manager.ts
+++ b/src/server/pr-walkthrough/walkthrough-agent-manager.ts
@@ -189,7 +189,7 @@ export class WalkthroughAgentManager {
 			cwd,
 			target,
 			changesetId,
-			tabId: `walkthrough:${changesetId}`,
+			tabId: `walkthrough:${encodeURIComponent(changesetId)}`,
 			status: "starting",
 			title,
 			submissionProofHash: hashSubmissionProof(jobId, childSessionId, submissionProof),

--- a/tests/panel-workspace.test.ts
+++ b/tests/panel-workspace.test.ts
@@ -26,6 +26,8 @@ import {
 	reorderSidePanelTab,
 	reviewPanelTabId,
 	setActivePanelTabIdForSession,
+	walkthroughChangesetIdFromPanelTabId,
+	walkthroughPanelTabId,
 	type PanelWorkspaceTab,
 } from "../src/app/panel-workspace.ts";
 
@@ -181,6 +183,24 @@ describe("panel workspace side-pane tab contract", () => {
 
 		assert.equal(activePanelTabIdForSession(state, "s1"), previewEntryTabId("legacy.html"));
 		assert.equal(state.panelWorkspaceActiveBySession.s1, previewEntryTabId("legacy.html"));
+	});
+
+	it("walkthrough tab ids encode PR changeset ids before activation", () => {
+		const changesetId = "github:SuuBro/bobbit#666";
+		const encodedTabId = walkthroughPanelTabId(changesetId);
+		const rawTabId = `walkthrough:${changesetId}`;
+		const state = {
+			selectedSessionId: "s1",
+			panelTabsBySession: { s1: [{ id: encodedTabId, kind: "walkthrough" }] },
+			panelWorkspaceActiveBySession: { s1: rawTabId },
+		};
+
+		assert.equal(encodedTabId, "walkthrough:github%3ASuuBro%2Fbobbit%23666");
+		assert.equal(walkthroughChangesetIdFromPanelTabId(encodedTabId), changesetId);
+		assert.equal(walkthroughChangesetIdFromPanelTabId(rawTabId), "");
+		assert.equal(activePanelTabIdForSession(state, "s1"), "");
+		setActivePanelTabIdForSession(state, "s1", encodedTabId);
+		assert.equal(activePanelTabIdForSession(state, "s1"), encodedTabId);
 	});
 
 	it("normalizeSidePanelTabs drops legacy chat/invalid rows, normalizes live preview, merges metadata, dedupes, and pins Inbox", () => {

--- a/tests/pr-walkthrough-agent-manager.test.ts
+++ b/tests/pr-walkthrough-agent-manager.test.ts
@@ -706,6 +706,8 @@ describe("WalkthroughAgentManager", () => {
 		assert.equal(res.status, 201);
 		const body = JSON.parse(res.body ?? "{}");
 		assert.equal(body.status, "waiting_for_yaml");
+		assert.equal(body.tabId, `walkthrough:${encodeURIComponent(body.changesetId)}`);
+		assert.equal(body.job.tabId, `walkthrough:${encodeURIComponent(body.changesetId)}`);
 		assert.ok(sessionManager.sessions.get(body.childSessionId));
 		assert.ok(events.some(event => event.type === "pr_walkthrough_job_updated"));
 	});


### PR DESCRIPTION
## Summary
- Encode PR walkthrough tab ids when creating child walkthrough jobs.
- Normalize legacy/raw walkthrough job tab ids in the UI so existing ready jobs restore their panel.
- Restore the persisted walkthrough payload when a ready tab has only job metadata, avoiding the misleading 0-file/0-diff empty state.
- Reduce noisy unmapped-hunk warnings when the file diff is available via fallback, while preserving true missing-file warnings.
- Make SHA-mismatch retry feedback explicitly require re-fetching/regenerating hunk and anchor references, not only patching SHA fields.
- Add regression coverage for walkthrough tab activation, manager responses, hunk/file fallback mapping, and SHA mismatch guidance.

## Tests
- npx tsx --import ./tests/helpers/css-stub-loader.mjs --test --test-force-exit tests/pr-walkthrough-yaml-schema.test.ts tests/panel-workspace.test.ts tests/pr-walkthrough-agent-manager.test.ts
- npm run check
- npm run test:unit
- npm run test:e2e

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)