### PR TITLE
Fix PR walkthrough restore and retry guidance

### DIFF
--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -2243,6 +2243,9 @@ export function doRenderApp(): void {
 		const exportCapability = tabState.exportCapability;
 		const validationError = tabState.validationError || tabState.lastValidationError;
 		const jobId = typeof tabState.jobId === "string" ? tabState.jobId : undefined;
+		if (status === "ready" && !cards?.length) {
+			queueMicrotask(() => restorePrWalkthroughPanel(state, workspaceSessionId(), tab.id));
+		}
 		if (status === "ready" && tabState.fullscreenOnReady === true && !state.previewPanelFullscreen && !isLiveSessionHostedWalkthroughActive(tab)) {
 			queueMicrotask(() => {
 				if (activeSessionId() === workspaceSessionId() && !isLiveSessionHostedWalkthroughActive(tab)) {

--- a/src/server/pr-walkthrough/walkthrough-agent-manager.ts
+++ b/src/server/pr-walkthrough/walkthrough-agent-manager.ts
@@ -826,13 +826,13 @@ function validateYamlAgainstAuthoritativeChangeset(
 	if (authoritativeBaseSha && !shaMatches(authoritativeBaseSha, document.pr.base_sha)) {
 		errors.push({
 			path: "$.pr.base_sha",
-			message: `Must match the authoritative PR base SHA ${authoritativeBaseSha} resolved from the PR diff. Re-fetch the PR metadata/diff and retry; the walkthrough was not published.`,
+			message: `Must match the authoritative PR base SHA ${authoritativeBaseSha} resolved from the PR diff. Re-fetch the authoritative PR diff and regenerate all hunk_header, line_range, and anchor references before retrying; do not only patch this SHA. The walkthrough was not published.`,
 		});
 	}
 	if (authoritativeHeadSha && !shaMatches(authoritativeHeadSha, document.pr.head_sha)) {
 		errors.push({
 			path: "$.pr.head_sha",
-			message: `Must match the authoritative PR head SHA ${authoritativeHeadSha} resolved from the PR diff. Re-fetch the PR metadata/diff and retry; the walkthrough was not published.`,
+			message: `Must match the authoritative PR head SHA ${authoritativeHeadSha} resolved from the PR diff. Re-fetch the authoritative PR diff and regenerate all hunk_header, line_range, and anchor references before retrying; do not only patch this SHA. The walkthrough was not published.`,
 		});
 	}
 	return errors;

--- a/src/server/pr-walkthrough/walkthrough-yaml-schema.ts
+++ b/src/server/pr-walkthrough/walkthrough-yaml-schema.ts
@@ -657,14 +657,18 @@ function mapRelevantHunks(hunks: PrWalkthroughYamlRelevantHunk[], mapper: DiffRe
 	const blocks: PrWalkthroughDiffBlock[] = [];
 	const notes: string[] = [];
 	hunks.forEach((hunk, index) => {
-		const match = mapper.findHunk(hunk.file, hunk.hunk_header);
+		const match = mapper.findHunkLenient(hunk.file, hunk.hunk_header);
 		if (match) {
 			blocks.push(match.block);
 			return;
 		}
 		const fileBlock = mapper.blockForFile(hunk.file);
-		if (fileBlock) blocks.push(fileBlock);
 		const message = `${hunk.file} ${hunk.hunk_header}: ${hunk.why_relevant}`;
+		if (fileBlock) {
+			blocks.push(fileBlock);
+			notes.push(`File-level fallback for hunk: ${message}`);
+			return;
+		}
 		warnings.push({ code: "unmapped_hunk", severity: "warning", message: `Could not map hunk reference at ${path}[${index}]: ${message}`, filePath: hunk.file });
 		notes.push(`Unmapped hunk: ${message}`);
 	});
@@ -677,7 +681,7 @@ function mapSuggestedConcerns(chunk: PrWalkthroughYamlReviewChunk, cardId: strin
 	chunk.suggested_concerns.forEach((concern, concernIndex) => {
 		let mapped = false;
 		concern.anchors.forEach((anchor, anchorIndex) => {
-			const match = mapper.findHunk(anchor.file, anchor.hunk_header);
+			const match = anchor.line != null || anchor.line_range ? mapper.findHunkLenient(anchor.file, anchor.hunk_header) : mapper.findHunk(anchor.file, anchor.hunk_header);
 			const line = match ? selectLine(match.hunk, anchor) : undefined;
 			if (match && line) {
 				mapped = true;
@@ -690,7 +694,9 @@ function mapSuggestedConcerns(chunk: PrWalkthroughYamlReviewChunk, cardId: strin
 				});
 				return;
 			}
-			warnings.push({ code: "unmapped_anchor", severity: "warning", message: `Could not map suggested concern anchor for chunk ${chunk.id}: ${anchor.file} ${anchor.hunk_header}.`, filePath: anchor.file });
+			if (!mapper.blockForFile(anchor.file)) {
+				warnings.push({ code: "unmapped_anchor", severity: "warning", message: `Could not map suggested concern anchor for chunk ${chunk.id}: ${anchor.file} ${anchor.hunk_header}.`, filePath: anchor.file });
+			}
 			notes.push(`Unmapped suggested comment anchor (${concern.severity}): ${concern.concern} — ${concern.suggested_comment}`);
 		});
 		if (!mapped && concern.anchors.length === 0) notes.push(`${concern.severity}: ${concern.concern} — ${concern.suggested_comment}`);
@@ -729,6 +735,16 @@ class DiffReferenceMapper {
 				if (coordinateMatch) return { block, hunk: coordinateMatch };
 			}
 		}
+		return undefined;
+	}
+
+	findHunkLenient(file: string, hunkHeader: string): { block: PrWalkthroughDiffBlock; hunk: PrWalkthroughHunk } | undefined {
+		const strict = this.findHunk(file, hunkHeader);
+		if (strict) return strict;
+		const blocks = this.byFile.get(normalizePath(file)) ?? [];
+		const totalHunkCount = blocks.reduce((count, item) => count + item.hunks.length, 0);
+		const soleHunkBlock = totalHunkCount === 1 ? blocks.find(block => block.hunks.length === 1) : undefined;
+		if (soleHunkBlock?.hunks[0]) return { block: soleHunkBlock, hunk: soleHunkBlock.hunks[0] };
 		return undefined;
 	}
 }

--- a/tests/pr-walkthrough-agent-manager.test.ts
+++ b/tests/pr-walkthrough-agent-manager.test.ts
@@ -545,7 +545,10 @@ describe("WalkthroughAgentManager", () => {
 		});
 		assert.equal(mismatch.ok, false);
 		assert.equal(mismatch.status, "validation_failed");
-		assert.match(mismatch.validation.errors.map(error => `${error.path}: ${error.message}`).join("\n"), /\$\.pr\.base_sha: Must match the authoritative PR base SHA/);
+		const mismatchMessage = mismatch.validation.errors.map(error => `${error.path}: ${error.message}`).join("\n");
+		assert.match(mismatchMessage, /\$\.pr\.base_sha: Must match the authoritative PR base SHA/);
+		assert.match(mismatchMessage, /regenerate all hunk_header, line_range, and anchor references/);
+		assert.match(mismatchMessage, /do not only patch this SHA/);
 		assert.equal(fs.existsSync(path.join(tempDir, "pr-walkthrough", "v1")), false);
 
 		const accepted = await manager.submitYaml({

--- a/tests/pr-walkthrough-yaml-schema.test.ts
+++ b/tests/pr-walkthrough-yaml-schema.test.ts
@@ -134,7 +134,7 @@ describe("PR walkthrough YAML schema", () => {
 		assert.equal(payload.changeset.headSha, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
 	});
 
-	it("preserves unmapped hunk and anchor references as warnings and card suggestions", () => {
+	it("preserves truly unmapped hunk references as warnings and file-fallback anchors as card suggestions", () => {
 		const validation = validatePrWalkthroughYaml(validYaml());
 		assert.equal(validation.ok, true);
 		if (!validation.ok) return;
@@ -142,7 +142,7 @@ describe("PR walkthrough YAML schema", () => {
 		const payload = mapYamlToWalkthroughPayload(validation.document, { files: diffBlocks() });
 		const warningCodes = payload.warnings.map(warning => warning.code);
 		assert.ok(warningCodes.includes("unmapped_hunk"));
-		assert.ok(warningCodes.includes("unmapped_anchor"));
+		assert.equal(warningCodes.includes("unmapped_anchor"), false);
 
 		const design = payload.cards.find(card => card.phaseId === "design");
 		assert.ok(design?.cardSuggestions?.some(note => /Unmapped hunk/.test(note)));
@@ -191,16 +191,29 @@ describe("PR walkthrough YAML schema", () => {
 		assert.equal(review?.suggestedComments?.[0]?.lineId, "block-context:h0:l1");
 	});
 
-	it("keeps warning when hunk numeric ranges do not match", () => {
-		const validation = validatePrWalkthroughYaml(hunkMappingYaml("@@ -11,2 +10,3 @@ function renderExample"));
+	it("falls back to the only file hunk when YAML line coordinates are stale", () => {
+		const validation = validatePrWalkthroughYaml(hunkMappingYaml("@@ -371,7 +371,8 @@ stale location"));
 		assert.equal(validation.ok, true);
 		if (!validation.ok) return;
 
 		const payload = mapYamlToWalkthroughPayload(validation.document, { files: [contextDiffBlock("@@ -10,2 +10,3 @@ function renderExample")] });
 
-		assert.ok(payload.warnings.some(warning => warning.code === "unmapped_hunk" && warning.filePath === "src/context.ts"));
-		assert.ok(payload.warnings.some(warning => warning.code === "unmapped_anchor" && warning.filePath === "src/context.ts"));
+		assertNoUnmappedForFile(payload.warnings, "src/context.ts");
 		const review = payload.cards.find(card => card.id === "significant-context-review");
+		assert.equal(review?.suggestedComments?.length, 1);
+		assert.equal(review?.suggestedComments?.[0]?.lineId, "block-context:h0:l1");
+	});
+
+	it("uses file-level fallback without global warnings when hunk numeric ranges do not match", () => {
+		const validation = validatePrWalkthroughYaml(hunkMappingYaml("@@ -11,2 +10,3 @@ function renderExample"));
+		assert.equal(validation.ok, true);
+		if (!validation.ok) return;
+
+		const payload = mapYamlToWalkthroughPayload(validation.document, { files: [multiHunkContextDiffBlock()] });
+
+		assertNoUnmappedForFile(payload.warnings, "src/context.ts");
+		const review = payload.cards.find(card => card.id === "significant-context-review");
+		assert.deepEqual(review?.diffBlocks.map(block => block.id), ["block-context"]);
 		assert.equal(review?.suggestedComments?.length ?? 0, 0);
 	});
 
@@ -213,7 +226,7 @@ describe("PR walkthrough YAML schema", () => {
 		const review = payload.cards.find(card => card.id === "significant-context-review");
 
 		assert.deepEqual(review?.diffBlocks.map(block => block.id), ["block-context"]);
-		assert.ok(payload.warnings.some(warning => warning.code === "unmapped_hunk" && warning.filePath === "src/context.ts"));
+		assertNoUnmappedForFile(payload.warnings, "src/context.ts");
 	});
 });
 
@@ -264,6 +277,21 @@ function contextDiffBlock(header: string): PrWalkthroughDiffBlock {
 				{ id: "block-context:h0:l1", side: "new", newLine: 11, text: "  return <Example />;", kind: "add" },
 			],
 		}],
+	};
+}
+
+function multiHunkContextDiffBlock(): PrWalkthroughDiffBlock {
+	const block = contextDiffBlock("@@ -10,2 +10,3 @@ function renderExample");
+	return {
+		...block,
+		hunks: [
+			...block.hunks,
+			{
+				id: "block-context:h1",
+				header: "@@ -30,1 +31,2 @@ anotherChange",
+				lines: [{ id: "block-context:h1:l0", side: "new", newLine: 31, text: "another", kind: "add" }],
+			},
+		],
 	};
 }
 


### PR DESCRIPTION
## Summary
- Restore persisted walkthrough payloads when ready tabs only have job metadata, preventing the misleading 0-file/no-diff panel state.
- Reduce noisy unmapped-hunk warnings when a file-level diff fallback is available while preserving true missing-file warnings.
- Clarify SHA mismatch retry feedback so agents re-fetch/regenerate hunk and anchor references instead of only patching SHA fields.
- Add regression coverage for payload restoration, hunk/file fallback mapping, and SHA mismatch guidance.

## Tests
- npx tsx --import ./tests/helpers/css-stub-loader.mjs --test --test-force-exit tests/pr-walkthrough-yaml-schema.test.ts tests/panel-workspace.test.ts tests/pr-walkthrough-agent-manager.test.ts
- npm run check
- npm run test:unit
- npm run test:e2e

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)