### PR TITLE
Fix PR walkthrough analysis bundle and UI regressions

### DIFF
--- a/defaults/tools/pr-walkthrough/extension.ts
+++ b/defaults/tools/pr-walkthrough/extension.ts
@@ -273,6 +273,47 @@ const extension: ExtensionFactory = (pi) => {
 	});
 
 	pi.registerTool({
+		name: "read_pr_walkthrough_bundle",
+		label: "Read PR Walkthrough Bundle",
+		description: "Read the scoped persisted launch-time PR metadata and diff bundle for this walkthrough job with bounded output.",
+		promptSnippet: "Start PR walkthrough analysis by reading the authoritative persisted bundle. Use manifest/summary first, then read individual files by path or index with limits.",
+		parameters: Type.Object({
+			mode: Type.Optional(Type.Union([Type.Literal("summary"), Type.Literal("manifest"), Type.Literal("files"), Type.Literal("file")], { description: "Bounded read mode. Default manifest." })),
+			path: Type.Optional(Type.String({ description: "File path for mode=file." })),
+			index: Type.Optional(Type.Number({ description: "File index for mode=file when path is omitted." })),
+			offset: Type.Optional(Type.Number({ description: "File or hunk offset. Default 0." })),
+			limit: Type.Optional(Type.Number({ description: "Maximum files/hunks to return. Default 50; capped by gateway." })),
+			hunkOffset: Type.Optional(Type.Number({ description: "Hunk offset for mode=file." })),
+			hunkLimit: Type.Optional(Type.Number({ description: "Maximum hunks for mode=file." })),
+		}),
+		async execute(_toolCallId, args) {
+			let baseUrl: string;
+			let token: string;
+			try {
+				baseUrl = getGatewayUrl();
+				token = getGatewayToken();
+			} catch {
+				return toolText("read_pr_walkthrough_bundle failed: missing Bobbit gateway credentials.", true);
+			}
+
+			try {
+				const response = await fetch(`${baseUrl}/api/internal/pr-walkthrough/bundle`, {
+					method: "POST",
+					headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+					body: JSON.stringify({ sessionId, jobId, ...args }),
+				});
+				const text = await response.text();
+				let data: unknown = text;
+				try { data = JSON.parse(text); } catch { /* keep text */ }
+				if (!response.ok) return toolText(formatGatewayResponse(data), true, data);
+				return toolText(formatGatewayResponse(data), false, data);
+			} catch (err: any) {
+				return toolText(`read_pr_walkthrough_bundle failed: ${err?.message || err}`, true);
+			}
+		},
+	});
+
+	pi.registerTool({
 		name: "submit_pr_walkthrough_yaml",
 		label: "Submit PR Walkthrough YAML",
 		description: "Submit the completed PR walkthrough YAML document for validation and panel publishing.",

--- a/defaults/tools/pr-walkthrough/extension.ts
+++ b/defaults/tools/pr-walkthrough/extension.ts
@@ -285,7 +285,7 @@ const extension: ExtensionFactory = (pi) => {
 			limit: Type.Optional(Type.Number({ description: "Maximum files/hunks to return. Default 50; capped by gateway." })),
 			hunkOffset: Type.Optional(Type.Number({ description: "Hunk offset for mode=file." })),
 			hunkLimit: Type.Optional(Type.Number({ description: "Maximum hunks for mode=file." })),
-		}),
+		}, { additionalProperties: false }),
 		async execute(_toolCallId, args) {
 			let baseUrl: string;
 			let token: string;
@@ -296,11 +296,21 @@ const extension: ExtensionFactory = (pi) => {
 				return toolText("read_pr_walkthrough_bundle failed: missing Bobbit gateway credentials.", true);
 			}
 
+			const readArgs = {
+				mode: args.mode,
+				path: args.path,
+				index: args.index,
+				offset: args.offset,
+				limit: args.limit,
+				hunkOffset: args.hunkOffset,
+				hunkLimit: args.hunkLimit,
+			};
+
 			try {
 				const response = await fetch(`${baseUrl}/api/internal/pr-walkthrough/bundle`, {
 					method: "POST",
 					headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-					body: JSON.stringify({ sessionId, jobId, ...args }),
+					body: JSON.stringify({ ...readArgs, sessionId, jobId }),
 				});
 				const text = await response.text();
 				let data: unknown = text;

--- a/defaults/tools/pr-walkthrough/read_pr_walkthrough_bundle.yaml
+++ b/defaults/tools/pr-walkthrough/read_pr_walkthrough_bundle.yaml
@@ -1,0 +1,11 @@
+name: read_pr_walkthrough_bundle
+group: PR Walkthrough
+description: Read the scoped persisted launch-time PR metadata and diff bundle for this walkthrough job. Output is bounded; start with manifest/summary, then request files by path or index.
+params: [mode, file, path, index, offset, limit, hunkOffset, hunkLimit]
+examples:
+  - read_pr_walkthrough_bundle mode=manifest limit=50
+  - read_pr_walkthrough_bundle mode=file path=src/example.ts hunkOffset=0 hunkLimit=20
+notes:
+  - The gateway validates BOBBIT_SESSION_ID and BOBBIT_WALKTHROUGH_JOB_ID ownership.
+  - Does not read arbitrary filesystem paths and does not loosen readonly_bash.
+  - Large bundles are truncated by limit/offset; use mode=files or mode=file for bounded follow-up reads.

--- a/docs/design/pr-walkthrough-agent-session.md
+++ b/docs/design/pr-walkthrough-agent-session.md
@@ -394,7 +394,9 @@ The extension registers only when `BOBBIT_WALKTHROUGH_JOB_ID` and `BOBBIT_SESSIO
 
 Internal endpoint:
 
-`POST /api/internal/pr-walkthrough/bundle`
+`GET /api/internal/pr-walkthrough/bundle` / `POST /api/internal/pr-walkthrough/bundle`
+
+Compatibility alias: `/api/internal/pr-walkthrough/analysis-bundle`.
 
 Request parameters:
 
@@ -669,7 +671,7 @@ Reload cases:
 - Submitted successfully: `GET /api/pr-walkthrough/:changesetId` restores cards; job says `ready`.
 - Bundle missing after launch: bundle reads or YAML submission return retryable `PR_WALKTHROUGH_BUNDLE_MISSING`; the UI should direct the user to relaunch instead of retrying hidden PR diff fetches.
 - Server restarted while agent running: `WalkthroughAgentManager.restore()` scans job records, reconnects idle listeners for live sessions, and does not create duplicate sessions.
-- Child archived/terminated: job remains for historical lookup; launcher dedupe should not reuse terminated children unless explicitly requested.
+- Child archived/terminated: job remains for historical lookup; launcher dedupe should not reuse terminated children unless explicitly requested. Sidebar filtering hides terminated/archived walkthrough children while **Show Archived** is off and shows them nested under the parent when it is on.
 
 Existing draft review state, comments, decisions, and standalone route should remain keyed by `sessionId + walkthrough tab id` in the current UI stores.
 

--- a/docs/design/pr-walkthrough-agent-session.md
+++ b/docs/design/pr-walkthrough-agent-session.md
@@ -2,22 +2,22 @@
 
 ## Summary
 
-Launching a PR walkthrough should create a first-class, read-only child agent session instead of resolving cards silently in the launching session. The child session owns the walkthrough side panel, reports progress in chat, submits one validated YAML document through a walkthrough-only tool, then stays alive for follow-up questions with the PR context loaded.
+Launching a PR walkthrough creates a first-class, read-only child agent session instead of resolving cards silently in the launching session. Before that child starts, the server resolves the PR metadata and diff once, sanitizes it, and persists a versioned analysis bundle for the job. The child session owns the walkthrough side panel, reports progress in chat, reads the persisted bundle through a scoped tool, submits one validated YAML document through a walkthrough-only tool, then stays alive for follow-up questions.
 
-This design replaces the current `POST /api/pr-walkthrough/resolve` model-backed synthesis path with an asynchronous session-hosted workflow while preserving the existing walkthrough panel, persistence, standalone route, and explicit GitHub export flow.
+This design replaces the old `POST /api/pr-walkthrough/resolve` model-backed synthesis path with an asynchronous session-hosted workflow while preserving the existing walkthrough panel, persistence, standalone route, and explicit GitHub export flow. The launch-time analysis bundle is the authoritative source for YAML hunk mapping and final payload construction; submission-time PR diff re-fetch is not part of the model.
 
-## Current state
+## Relevant modules
 
-Relevant current implementation:
+The session-hosted walkthrough path is split between launch/session ownership, launch-time bundle persistence, YAML mapping, and final payload/export storage:
 
 - `src/app/pr-walkthrough.ts`
-  - `parseWalkthroughPrCommand()` parses `/walkthrough-pr`.
-  - `openPrWalkthroughPanel()` immediately creates a `walkthrough:<changesetId>` tab in the active session and calls `resolvePrWalkthrough()`.
-  - `resolvePrWalkthrough()` calls `POST /api/pr-walkthrough/resolve` and patches the same tab to `ready` or `error`.
-  - `restorePrWalkthroughPanel()` reloads stored payloads with `GET /api/pr-walkthrough/:changesetId`.
+  - Parses `/walkthrough-pr`, launches or focuses the child session, restores job-backed panels, and reloads final payloads with `GET /api/pr-walkthrough/:changesetId`.
 - `src/server/pr-walkthrough/routes.ts`
-  - `handlePrWalkthroughApiRoute()` handles resolve, get, export preview, and export submit.
-  - `resolveWalkthrough()` fetches GitHub/local diff data, parses diff blocks, then calls `synthesiseWalkthroughCards()` through `card-synthesis.ts`.
+  - Handles launch, job/session restore, scoped bundle reads, YAML submission, legacy resolve compatibility, and export preview/submit routes.
+- `src/server/pr-walkthrough/walkthrough-agent-manager.ts`
+  - Owns job launch, duplicate detection, child session creation, bundle-first prompts, YAML submission, and job state transitions.
+- `src/server/pr-walkthrough/walkthrough-analysis-bundle.ts`
+  - Stores the sanitized launch-time analysis bundle and serves bounded `read_pr_walkthrough_bundle` reads for the owning job/session.
 - `src/server/pr-walkthrough/walkthrough-store.ts`
   - Stores final `WalkthroughStorePayload` as JSON under `.bobbit/state/pr-walkthrough/v1/` keyed by `changesetId`.
 - `src/shared/pr-walkthrough/types.ts`
@@ -37,10 +37,11 @@ Goals:
 
 1. `/walkthrough-pr <url|number>` or equivalent actions create or focus a dedicated PR walkthrough child session beneath the launching session.
 2. The child session opens with chat plus an empty waiting walkthrough panel.
-3. The agent can only perform read-only PR investigation and must submit valid YAML via `submit_pr_walkthrough_yaml` to populate the panel.
-4. Invalid YAML gives actionable retry feedback; no partial cards are rendered.
-5. Successful submission persists a YAML-derived payload, switches the child to fullscreen review mode, and leaves the agent alive.
-6. Existing final review export remains explicit and user-confirmed.
+3. Launch resolves and persists a sanitized, versioned analysis bundle before the analysis child session is created or prompted.
+4. The agent can only perform read-only PR investigation, starts from `read_pr_walkthrough_bundle`, and must submit valid YAML via `submit_pr_walkthrough_yaml` to populate the panel.
+5. Invalid YAML gives actionable retry feedback; no partial cards are rendered.
+6. Successful submission maps against the stored bundle, persists a YAML-derived payload, switches the child to fullscreen review mode, and leaves the agent alive.
+7. Existing final review export remains explicit and user-confirmed.
 
 Non-goals:
 
@@ -59,10 +60,13 @@ Add a small PR walkthrough job/session layer under `src/server/pr-walkthrough/`:
   - Owns job lifecycle state, dedupe, idle reminder, and event broadcasts.
   - Wraps `SessionManager.createSession()` rather than `createDelegateSession()`.
 - `walkthrough-agent-store.ts`
-  - Persists job/session metadata and validation state separately from final card payloads.
+  - Persists job/session metadata, analysis bundle metadata, and validation state separately from final card payloads.
+- `walkthrough-analysis-bundle.ts`
+  - Persists the sanitized launch-time PR metadata and parsed diff bundle under a versioned artifact path.
+  - Serves bounded bundle reads for the scoped analysis tool and adapts the bundle back to the YAML mapper's parsed-diff shape.
 - `walkthrough-yaml-schema.ts`
   - Parses and validates the submitted YAML document.
-  - Maps validated YAML plus parsed diff blocks into existing `WalkthroughStorePayload`.
+  - Maps validated YAML plus parsed diff data from the stored bundle into existing `WalkthroughStorePayload`.
 - `walkthrough-readonly-policy.ts`
   - Shared command/tool allow/deny checks for the walkthrough role and tests.
 
@@ -108,10 +112,18 @@ export interface PrWalkthroughJobRecord {
   payloadUpdatedAt?: string;
   warnings?: WalkthroughWarning[];
   error?: { code: string; message: string; retryable?: boolean };
+  analysisBundle?: {
+    schemaVersion: 1;
+    kind: "pr_walkthrough_analysis_bundle";
+    artifactId: string;
+    checksum: string;
+    generatedAt: string;
+    files: number;
+  };
 }
 ```
 
-Persist under `.bobbit/state/pr-walkthrough-agents/v1/<jobId>.json`, plus an index by `(parentSessionId, canonicalKey)` for duplicate prevention. The record should be sanitized with the same sensitive-key discipline as `walkthrough-store.ts`.
+Persist under `.bobbit/state/pr-walkthrough-agents/v1/<jobId>.json`, plus an index by `(parentSessionId, canonicalKey)` for duplicate prevention. The record should be sanitized with the same sensitive-key discipline as `walkthrough-store.ts`. `analysisBundle` is metadata only; the full bundle lives in the bundle store and must not include tokens, auth headers, submission proofs, raw request headers, or other sensitive values.
 
 Add `walkthroughAgent` metadata to persisted session info through `SessionManager.updateSessionMeta()`:
 
@@ -128,6 +140,65 @@ Add `walkthroughAgent` metadata to persisted session info through `SessionManage
 ```
 
 This implementation must add a first-class `parentSessionId` / `childKind: "pr-walkthrough"` relationship for visible child sessions. `delegateOf` and `createDelegateSession()` are explicitly out of scope for PR walkthrough launch, sidebar nesting, lifecycle, cleanup, and persistence. Existing delegate rendering may be used only as a visual reference when implementing the new generic child-session renderer.
+
+### Launch-time analysis bundle
+
+Each job has one authoritative analysis bundle. Launch resolves the PR metadata, body, file stats, export capability, warnings, limits, and parsed diff/hunks once, then persists the sanitized bundle before the child session exists. This removes network and GitHub-rate-limit dependency from YAML submission, prevents diff drift between agent analysis and server mapping, and lets launch fail early before a waiting agent is created without usable input.
+
+Bundle artifacts are versioned separately from the final walkthrough payload:
+
+```ts
+export interface PrWalkthroughAnalysisBundle {
+  schema_version: 1;
+  kind: "pr_walkthrough_analysis_bundle";
+  generated_at: string;
+  job_id: string;
+  target: {
+    provider: "github" | string;
+    owner?: string;
+    repo?: string;
+    number?: number;
+    url?: string;
+  };
+  changeset: {
+    base_sha?: string;
+    head_sha?: string;
+    title?: string;
+    body?: string;
+    files_changed?: number;
+    additions?: number;
+    deletions?: number;
+  };
+  limits?: Record<string, unknown>;
+  warnings: WalkthroughWarning[];
+  export?: { provider: string; available: boolean; [key: string]: unknown };
+  files: Array<{
+    path: string;
+    old_path?: string;
+    status?: string;
+    additions?: number;
+    deletions?: number;
+    is_binary?: boolean;
+    is_generated?: boolean;
+    is_truncated?: boolean;
+    hunks: Array<{
+      header: string;
+      old_start?: number;
+      old_lines?: number;
+      new_start?: number;
+      new_lines?: number;
+      lines: Array<{
+        kind: "context" | "add" | "del";
+        old_line?: number;
+        new_line?: number;
+        text: string;
+      }>;
+    }>;
+  }>;
+}
+```
+
+The implementation may store the bundle as one JSON artifact or split very large jobs into a manifest plus per-file artifacts, but the agent-facing contract stays versioned and bounded. `WalkthroughStorePayload` remains the final renderable/exportable review format and is still written only after valid YAML maps successfully.
 
 ## Launch API
 
@@ -211,23 +282,27 @@ For compatibility during migration, `resolve` can remain for fixture/local tests
    - GitHub number without URL: `github:<parent repo owner>/<parent repo>#<number>` when inferable; otherwise `pr:<number>` scoped by parent.
    - Local sha pair: `local:<baseSha>..<headSha>`.
 4. Check the job index for an active child with same `(parentSessionId, canonicalKey)` and return it if found.
-5. Pre-generate `jobId` and `childSessionId` so the submission tool resolver exists before the agent starts.
+5. Pre-generate `jobId` and `childSessionId` so scoped bundle and submission tool resolvers can bind to stable ids before the agent starts.
 6. Persist a `starting` job record.
-7. Create a normal session with `SessionManager.createSession(cwd, undefined, undefined, undefined, opts)`:
+7. Resolve the full PR metadata and diff for the launch target, sanitize it, persist a versioned analysis bundle, and attach bundle metadata to the job record. If this resolution fails, return the existing structured launch error before creating or prompting the child session; do not leave a waiting agent with no bundle.
+8. Create a normal session with `SessionManager.createSession(cwd, undefined, undefined, undefined, opts)`:
    - `sessionId: childSessionId`
    - `projectId`, `sandboxed`, and sandbox cwd inherited from the parent
    - `roleName: "pr-walkthrough"`, `role: "pr-walkthrough"`, `accessory: "review"`
-   - `allowedTools` set to the explicit read-only list plus `submit_pr_walkthrough_yaml`
-   - `rolePrompt` containing the analysis instructions and YAML contract
+   - `allowedTools` set to the explicit read-only list plus `read_pr_walkthrough_bundle` and `submit_pr_walkthrough_yaml`
+   - `rolePrompt` containing the bundle-first analysis instructions and YAML contract
    - `skipAutoModel`/`initialModel` inherited from parent when appropriate
-8. Set title to `PR #123 Walkthrough` / `PR Walkthrough` and persist metadata.
-9. Create/update the child session panel tab to waiting state by broadcasting a WebSocket event.
-10. Send the first prompt asynchronously with target details, allowed operations, required progress chat, and the YAML schema.
-11. Subscribe to `agent_end` or session status transitions. If no successful submission exists, enqueue a reminder prompt instead of marking complete.
+9. Set title to `PR #123 Walkthrough` / `PR Walkthrough` and persist metadata.
+10. Create/update the child session panel tab to waiting state by broadcasting a WebSocket event.
+11. Send the first prompt asynchronously with target details, allowed operations, required progress chat, bundle-read instructions, and the YAML schema.
+12. Subscribe to `agent_end` or session status transitions. If no successful submission exists, enqueue a reminder prompt instead of marking complete.
 
 The first prompt should explicitly say:
 
-- Investigate using read-only commands and tools only.
+- Start by calling `read_pr_walkthrough_bundle` in `manifest` or `summary` mode.
+- Treat the persisted bundle as authoritative for PR body, base/head SHA, stats, files, hunks, warnings, limits, and export capability.
+- Use bounded `mode=file` reads by path or index for detailed hunk inspection.
+- Use `readonly_bash` only for additional read-only investigation; never as a way to read arbitrary bundle files.
 - Do not edit files, run tests/builds/checks, install dependencies, start servers, commit, push, or submit GitHub reviews/comments.
 - Report rough percentage progress in chat.
 - Finish only by calling `submit_pr_walkthrough_yaml` with one YAML document.
@@ -307,6 +382,44 @@ Add a first-class child relationship to session metadata and rendering:
 
 
 
+## Bundle read tool
+
+### Tool registration
+
+The walkthrough-only tool group includes `read_pr_walkthrough_bundle` alongside the YAML submit tool.
+
+Tool name: `read_pr_walkthrough_bundle`.
+
+The extension registers only when `BOBBIT_WALKTHROUGH_JOB_ID` and `BOBBIT_SESSION_ID` are present. It calls the internal bundle endpoint with those environment-derived ids and ignores caller-supplied identity fields. The gateway validates that the session owns the job before returning data.
+
+Internal endpoint:
+
+`POST /api/internal/pr-walkthrough/bundle`
+
+Request parameters:
+
+```json
+{
+  "sessionId": "child-session-id",
+  "jobId": "prw_...",
+  "mode": "manifest",
+  "path": "src/example.ts",
+  "index": 0,
+  "offset": 0,
+  "limit": 50,
+  "hunkOffset": 0,
+  "hunkLimit": 50
+}
+```
+
+Read modes:
+
+- `summary` / `manifest`: return bundle header, changeset, limits, warnings, export capability, and a bounded file manifest.
+- `files`: return a bounded page of file manifests.
+- `file`: return one file by `path`, `old_path`, or `index`, with bounded hunk output.
+
+The tool does not read arbitrary filesystem paths, does not expose raw artifact paths, and does not loosen `readonly_bash`. Large PRs should be explored by reading the manifest first, then bounded per-file/hunk slices.
+
 ## YAML submission tool
 
 ### Tool registration
@@ -361,7 +474,20 @@ Response on retryable validation failure should be a tool error with field-level
 }
 ```
 
-Allow this internal endpoint in `src/server/auth/sandbox-guard.ts` only for the submitting session/job. This mirrors `verification_result` but must not be goal-scoped.
+If the stored launch-time bundle is missing, corrupt, schema-incompatible, or otherwise unusable, submission returns a deterministic retryable error instead of fetching the PR diff again:
+
+```json
+{
+  "ok": false,
+  "code": "PR_WALKTHROUGH_BUNDLE_MISSING",
+  "message": "PR walkthrough analysis bundle is missing or unusable. Relaunch the walkthrough so the PR diff can be resolved before analysis.",
+  "retryable": true
+}
+```
+
+The correct user action is to relaunch the walkthrough. The server must not silently recover by re-fetching GitHub/local diff data at submit time, because that can drift from the agent's analysis input.
+
+Allow these internal endpoints in `src/server/auth/sandbox-guard.ts` only for the owning session/job. This mirrors `verification_result` but must not be goal-scoped.
 
 ### Validation implementation
 
@@ -438,16 +564,17 @@ mapYamlToWalkthroughPayload(document, parsedDiff, job): WalkthroughStorePayload;
 
 Mapping strategy:
 
-1. Re-fetch or load the PR diff blocks read-only on submission using the same GitHub/local parsing utilities currently used by `resolveWalkthrough()`.
-2. Build an Orientation card from `walkthrough.context`, `merge_assessment`, and `pr.original_description.body`.
-3. Build Design cards from `design_decisions`.
-4. Build review cards from `review_chunks`, using `phase` to choose `phaseId`.
-5. Build Other cards from `omissions_and_followups` where they are not already represented by a chunk.
-6. Build Audit card from `walkthrough.audit`.
-7. Map `relevant_hunks` to existing `PrWalkthroughDiffBlock`/`PrWalkthroughHunk` by file path and exact or normalized hunk header.
-8. For unmapped hunks, keep visible warnings in `warnings` and a card-level note instead of dropping them.
-9. Map `suggested_concerns[*].anchors` to `PrWalkthroughSuggestedComment` when file+hunk+line can be resolved; otherwise demote to `cardSuggestions` with an `unmapped_anchor` warning.
-10. Preserve `pr.original_description.body` in `changeset.prBody` and optionally in card metadata so Orientation can show/collapse original PR text.
+1. Load the stored launch-time analysis bundle for the job and adapt it to the existing parsed-diff mapper input. Do not fetch GitHub/local diff data during YAML submission.
+2. If the bundle is missing or unusable, fail with retryable `PR_WALKTHROUGH_BUNDLE_MISSING` and tell the user to relaunch.
+3. Build an Orientation card from `walkthrough.context`, `merge_assessment`, and the bundle's original PR body.
+4. Build Design cards from `design_decisions`.
+5. Build review cards from `review_chunks`, using `phase` to choose `phaseId`.
+6. Build Other cards from `omissions_and_followups` where they are not already represented by a chunk.
+7. Build Audit card from `walkthrough.audit`.
+8. Map `relevant_hunks` to existing `PrWalkthroughDiffBlock`/`PrWalkthroughHunk` by file path and exact or normalized hunk header from the bundle.
+9. For unmapped hunks, keep visible warnings in `warnings` and a card-level note instead of dropping them.
+10. Map `suggested_concerns[*].anchors` to `PrWalkthroughSuggestedComment` when file+hunk+line can be resolved; otherwise demote to `cardSuggestions` with an `unmapped_anchor` warning.
+11. Preserve the bundle's original PR body in `changeset.prBody` and optionally in card metadata so Orientation can show/collapse original PR text.
 
 The existing `card-synthesis.ts` should remain as fallback/fixture code during migration but should not be the primary path for agent-hosted walkthroughs.
 
@@ -459,10 +586,11 @@ Prompt-only restrictions are insufficient. Enforce with both allowlisted tools a
 
 The walkthrough session should receive an explicit `allowedTools` list:
 
+- primary PR input: `read_pr_walkthrough_bundle`;
 - read/search/navigation: `read`, `grep`, `find`, `ls`, `read_session` only if needed;
 - shell: dedicated `readonly_bash` only; do not register unrestricted `bash` for walkthrough sessions;
 - web/GitHub read APIs if already available: `web_fetch`, `web_search`, `mcp_describe`, selected read-only GitHub MCP operations if configured;
-- required: `submit_pr_walkthrough_yaml`.
+- required publisher: `submit_pr_walkthrough_yaml`.
 
 Do not allow:
 
@@ -513,11 +641,12 @@ After success, disable reminders but keep the session running.
 
 ## Persistence and reload
 
-Persist three layers:
+Persist four layers:
 
 1. Session metadata through the existing session store.
-2. Job status through `walkthrough-agent-store.ts`.
-3. Final renderable payload through `walkthrough-store.ts`.
+2. Job status and bundle metadata through `walkthrough-agent-store.ts`.
+3. Launch-time PR metadata/diff through the analysis bundle store.
+4. Final renderable payload through `walkthrough-store.ts`.
 
 Detailed ownership:
 
@@ -526,6 +655,7 @@ Detailed ownership:
 | Child relationship and read-only identity | Session store fields `parentSessionId`, `childKind`, `readOnly`, `walkthroughJobId` | `GET /api/sessions` and sidebar render |
 | Waiting/error/validation/ready lifecycle | `walkthrough-agent-store.ts` job record | `/api/pr-walkthrough/session/:childSessionId` |
 | Latest validation error details | Job record `lastValidationError` | Child panel job restore and chat tool result |
+| Launch-time PR metadata, parsed files/hunks, limits, warnings, and export capability | Analysis bundle store plus job `analysisBundle` metadata | `read_pr_walkthrough_bundle` and YAML mapper |
 | Final cards, parsed diff blocks, warnings, export capability | Existing `walkthrough-store.ts` payload | `GET /api/pr-walkthrough/:changesetId` |
 | Original PR body | Final payload `changeset.prBody` plus Orientation card metadata | Existing payload restore |
 | Active tab, fullscreen-on-ready intent | Panel workspace state plus job/session UI metadata | Session switch/job restore |
@@ -537,6 +667,7 @@ Reload cases:
 - Child exists, no YAML yet: UI selects child and calls `GET /api/pr-walkthrough/session/:childSessionId`; panel restores `waiting_for_yaml`.
 - Last submission invalid: job record includes `lastValidationError`; panel restores `validation_failed` banner.
 - Submitted successfully: `GET /api/pr-walkthrough/:changesetId` restores cards; job says `ready`.
+- Bundle missing after launch: bundle reads or YAML submission return retryable `PR_WALKTHROUGH_BUNDLE_MISSING`; the UI should direct the user to relaunch instead of retrying hidden PR diff fetches.
 - Server restarted while agent running: `WalkthroughAgentManager.restore()` scans job records, reconnects idle listeners for live sessions, and does not create duplicate sessions.
 - Child archived/terminated: job remains for historical lookup; launcher dedupe should not reuse terminated children unless explicitly requested.
 
@@ -575,8 +706,8 @@ Update `src/app/render-helpers.ts` and session types to render `parentSessionId`
 
 ### `src/server/pr-walkthrough/routes.ts`
 
-- Add `/launch`, `/jobs/:jobId`, `/session/:childSessionId`, and internal `/api/internal/pr-walkthrough/submit-yaml` handling or delegate the internal route from `server.ts` to the manager.
-- Keep export routes unchanged.
+- Add `/launch`, `/jobs/:jobId`, `/session/:childSessionId`, and internal `/api/internal/pr-walkthrough/bundle` plus `/api/internal/pr-walkthrough/submit-yaml` handling, or delegate the internal routes from `server.ts` to the manager.
+- Keep export routes unchanged; export preview/submit continue to read the final `WalkthroughStorePayload`, not the analysis bundle.
 - Move direct `resolveWalkthrough()` use behind a compatibility/fallback flag.
 
 ### `src/server/pr-walkthrough/walkthrough-store.ts`
@@ -617,7 +748,7 @@ Update `src/app/render-helpers.ts` and session types to render `parentSessionId`
 - **Model unavailable before first prompt:** create the child/session record first when practical, then transition `starting` to `error` with code `MODEL_UNAVAILABLE`, provider/model name when safe, and guidance to select another model or retry. If session creation itself fails, return `502` to the launcher.
 - **Agent startup/runtime crash:** transition `waiting_for_yaml` to `error` with code `AGENT_RUNTIME_FAILED`, keep transcript/panel available, and allow the user to prompt/retry in the same child after the runtime recovers.
 - **Prompt dispatch failure:** transition `starting` to `error` with code `PROMPT_DISPATCH_FAILED`; the child remains visible and retrying launch focuses the existing child and resends the first prompt after clearing the error.
-- **GitHub auth/rate limit/private PR:** use explicit error codes (`GITHUB_AUTH_REQUIRED`, `GITHUB_FORBIDDEN`, `GITHUB_RATE_LIMITED`, `GITHUB_NOT_FOUND_OR_PRIVATE`). The panel must state whether a token is missing, permissions are insufficient, the PR may be private, or the reset time from GitHub rate-limit headers when available. These errors are retryable in the same child after auth/permission/rate-limit changes.
+- **GitHub auth/rate limit/private PR during launch:** use explicit error codes (`GITHUB_AUTH_REQUIRED`, `GITHUB_FORBIDDEN`, `GITHUB_RATE_LIMITED`, `GITHUB_NOT_FOUND_OR_PRIVATE`). The panel must state whether a token is missing, permissions are insufficient, the PR may be private, or the reset time from GitHub rate-limit headers when available. These errors surface before the analysis child session starts; after auth/permission/rate-limit recovery, the user relaunches.
 - **Invalid YAML:** tool returns retryable field errors, transitions or remains `validation_failed`, and keeps the panel unpopulated with a validation banner. A later valid tool call transitions to `ready`.
 - **Large PR/truncation:** submission can succeed with `warnings` and `limits`; panel shows warnings in Orientation/Audit and the agent explains prioritization in chat.
 - **Policy violation:** blocked tool/command result is visible in chat; manager does not fail the job unless the agent cannot recover. Repeated policy violations can trigger a reminder prompt that restates allowed read-only operations.
@@ -627,22 +758,23 @@ Status transitions and retry semantics:
 
 | From | Event | To | Retry/reuse behavior |
 | --- | --- | --- | --- |
-| `starting` | session and first prompt created | `waiting_for_yaml` | Existing child is active. |
+| `starting` | analysis bundle resolved and persisted, then session and first prompt created | `waiting_for_yaml` | Existing child is active. |
+| `starting` | metadata/diff resolution fails before child exists | `error` / launch error | User relaunches after auth/network/rate-limit recovery; no waiting child is created. |
 | `starting` | session creation fails before child exists | no job / launch `502` | User retries launch; no child to reuse. |
 | `starting` | model unavailable or prompt dispatch fails after child persisted | `error` | Reuse existing child; retry can resend prompt after config/auth fix. |
 | `waiting_for_yaml` | invalid YAML tool call | `validation_failed` | Same child; agent retries tool call. |
 | `validation_failed` | another invalid YAML tool call | `validation_failed` | Update latest summary and reminder context. |
 | `waiting_for_yaml` or `validation_failed` | valid YAML tool call | `ready` | Persist payload, fullscreen review, keep agent alive. |
 | `waiting_for_yaml` or `validation_failed` | agent idle without successful tool call | same status | Enqueue rate-limited reminder; no cards rendered. |
-| any non-terminal state | GitHub auth/private/rate-limit prevents required metadata/diff | `error` | Same child is reused after credentials or rate limit recover. |
+| `waiting_for_yaml` or `validation_failed` | stored analysis bundle is missing or unusable during bundle read or YAML submission | `error` with `PR_WALKTHROUGH_BUNDLE_MISSING` | Retryable, but requires relaunch; no submit-time diff re-fetch. |
 | `error` | duplicate launch of same parent/target | `error` or `waiting_for_yaml` after explicit retry | Focus existing child; do not create duplicate. |
 | `ready` | duplicate launch of same parent/target | `ready` | Focus existing child and existing panel. |
 
 ## Migration plan
 
-1. Add job store, schema validator, and mapper with unit coverage.
-2. Add `submit_pr_walkthrough_yaml` tool and internal endpoint.
-3. Add `WalkthroughAgentManager.launch()` and launch API.
+1. Add job store, analysis bundle store, schema validator, and mapper with unit coverage.
+2. Add `read_pr_walkthrough_bundle` and `submit_pr_walkthrough_yaml` tools plus internal endpoints.
+3. Add `WalkthroughAgentManager.launch()` and launch API with launch-time bundle resolution before child creation.
 4. Update UI launch flow to create/focus child and show waiting panel.
 5. Add sidebar child-session metadata/rendering.
 6. Add idle reminder and fullscreen-on-success behavior.
@@ -656,6 +788,10 @@ Unit tests:
 - YAML parser rejects syntax errors, multiple docs, missing fields, bad enums, mismatched PR identity, and oversized docs.
 - YAML parser accepts a minimal valid document and normalizes optional arrays to empty arrays.
 - Mapper creates Orientation, Design, Review, Other, and Audit cards.
+- Launch persists a sanitized versioned analysis bundle before child session creation.
+- YAML submission maps from the stored analysis bundle and does not call submit-time GitHub/local diff resolution.
+- Missing or unusable bundle returns retryable `PR_WALKTHROUGH_BUNDLE_MISSING`.
+- Bundle read tool enforces owning `BOBBIT_SESSION_ID` / `BOBBIT_WALKTHROUGH_JOB_ID` and supports bounded manifest/file reads.
 - Hunk mapping preserves unmapped references as warnings.
 - Suggested comment anchors map to line ids when possible and demote cleanly when not.
 - Read-only command policy allows `gh pr view`, `gh pr diff`, `gh api` read calls, `git diff/show/log/grep`, and read-only search/read commands.
@@ -665,14 +801,15 @@ Unit tests:
 API E2E:
 
 - `POST /api/pr-walkthrough/launch` creates a child session, returns `childSessionId`, and persists a waiting job.
-- Private PR, missing token, forbidden token, not-found/private ambiguity, and GitHub rate-limit responses produce structured job errors with actionable messages and retryability.
+- Private PR, missing token, forbidden token, not-found/private ambiguity, and GitHub rate-limit responses produce structured launch errors before child session creation.
 - Model unavailable, prompt dispatch failure, and agent runtime failure transition to deterministic `error` states without losing the child when one was persisted.
 - Duplicate launch from same parent/target returns the existing child.
 - Same target from a different parent creates a separate child.
 - Invalid `submit_pr_walkthrough_yaml` returns structured errors and leaves job/panel unpopulated.
 - Valid submission stores `WalkthroughStorePayload`, returns ready, and leaves the child session alive.
+- Missing analysis bundle on read/submission returns `PR_WALKTHROUGH_BUNDLE_MISSING` and does not re-fetch PR diff data.
 - `GET /api/pr-walkthrough/session/:childSessionId` restores waiting, failed, and ready states.
-- Sandbox token cannot submit YAML for another session/job.
+- Sandbox token cannot submit YAML or read a bundle for another session/job.
 - Existing export preview/submit still requires explicit confirmation and works from final payloads.
 
 Browser E2E:
@@ -697,8 +834,8 @@ Regression tests:
 - **Tool leaks through extensions:** pass explicit `allowedTools`, keep `tool-guard-extension.ts`, and add regression tests that intentionally attempt forbidden tools.
 - **Shell command parsing bypasses:** use the dedicated `readonly_bash` extension with argv parsing and reject shell metacharacters/inline interpreters before execution; unrestricted `bash` must not be registered for walkthrough sessions.
 - **Sidebar relationship ambiguity:** implement `parentSessionId`/`childKind` as mandatory session metadata and add tests proving PR walkthrough rows do not depend on `delegateOf`.
-- **Large PRs exceed YAML/tool limits:** enforce byte limits, instruct prioritization, and allow warnings/omissions rather than failing the whole job.
-- **Stale diff mapping:** re-fetch diff at submission and compare `base_sha/head_sha` to launch metadata; warn or reject on mismatch depending on severity.
+- **Large PRs exceed YAML/tool limits:** enforce byte limits, instruct prioritization, and allow warnings/omissions rather than failing the whole job. Use bounded `read_pr_walkthrough_bundle` manifest/file reads so the agent does not need broad filesystem access.
+- **Stale diff mapping:** persist the launch-time bundle and map YAML against it. If it is missing or unusable, return `PR_WALKTHROUGH_BUNDLE_MISSING` and require relaunch rather than silently re-fetching a potentially different diff.
 - **Model finishes in prose:** idle reminder must be driven by missing successful tool call, not by chat content.
 - **User loses child on reload:** persist job metadata before sending the first prompt and restore panel tabs from session/job metadata.
 
@@ -707,4 +844,4 @@ Regression tests:
 1. Implement generic `parentSessionId` / `childKind` session nesting immediately. Do not use `delegateOf`, `createDelegateSession()`, delegate cleanup, or delegate hidden-session semantics for PR walkthroughs.
 2. Expose a dedicated `readonly_bash` tool for walkthrough sessions instead of registering unrestricted `bash`. The tool parses argv, applies `walkthrough-readonly-policy.ts`, and rejects shell metacharacters/inline interpreters before execution.
 3. Do not persist raw invalid YAML. Persist the latest validation summary, a content hash for diagnostics, and the final sanitized YAML-derived payload. If raw successful YAML is needed for debugging, store it in a separate sanitized job artifact behind an explicit debug flag, never in `walkthrough-store.ts`.
-4. Fetch lightweight PR metadata at launch for prompt context and error surfacing; fetch the authoritative diff again at YAML submission for hunk mapping and `base_sha`/`head_sha` validation.
+4. Resolve and persist the authoritative PR metadata/diff bundle at launch before child creation; YAML submission maps only from that stored bundle, and missing/unusable bundles return retryable `PR_WALKTHROUGH_BUNDLE_MISSING` with relaunch guidance.

--- a/docs/design/pr-walkthrough-agent-ux.md
+++ b/docs/design/pr-walkthrough-agent-ux.md
@@ -15,10 +15,12 @@ Launching a walkthrough should feel like inviting a senior reviewer into the cur
 
 1. User launches from `/walkthrough-pr <url|number>`, Git Status **Walkthrough**, or PR-link action.
 2. The launching session keeps its transcript; it does not receive the walkthrough panel.
-3. Bobbit creates or focuses a dedicated walkthrough child session for the resolved PR target.
-4. The launcher shows a short system/chat notice: `PR walkthrough started in “PR #123 Walkthrough”.` Include a primary inline action: `Open walkthrough`.
-5. If creation takes more than a moment, show the target child row in `starting/preparing` state immediately so the user sees that work began.
-6. If the user stays in the launcher, the sidebar child row should show activity/unread state as the walkthrough agent posts progress.
+3. Bobbit resolves the PR target, metadata, and diff, then persists the launch-time analysis bundle before creating any child session.
+4. If launch-time resolution fails, the launcher shows the structured error and retry guidance; no walkthrough child row is created.
+5. If resolution succeeds, Bobbit creates or focuses a dedicated walkthrough child session for the resolved PR target.
+6. The launcher shows a short system/chat notice: `PR walkthrough started in “PR #123 Walkthrough”.` Include a primary inline action: `Open walkthrough`.
+7. If child creation takes more than a moment after bundle resolution, show the target child row in `starting/preparing` state so the user sees that work began.
+8. If the user stays in the launcher, the sidebar child row should show activity/unread state as the walkthrough agent posts progress.
 
 ## Sidebar placement and identity
 
@@ -27,6 +29,7 @@ Launching a walkthrough should feel like inviting a senior reviewer into the cur
 - Title format: `PR #123 Walkthrough` when a number is known; otherwise `PR Walkthrough` or `Changeset Walkthrough`.
 - The row should use a distinct review/walkthrough accessory and a read-only affordance in tooltip or secondary metadata: `Read-only PR walkthrough agent`.
 - The session is selectable like any other session and remains listed until explicitly terminated/archived.
+- Terminated or archived walkthrough children are hidden when **Show Archived** is off and reappear nested under their parent when **Show Archived** is on.
 
 ## Child session initial layout
 
@@ -47,10 +50,12 @@ Waiting panel copy:
 
 The agent should report rough investigation progress in chat at meaningful milestones, for example:
 
-- `10% — fetched PR metadata and description.`
-- `35% — grouped changed files into review areas.`
-- `70% — checking omissions and follow-up risks.`
+- `10% — read the launch-time bundle manifest and PR description.`
+- `35% — grouped bundled changed files into review areas.`
+- `70% — checking omissions and follow-up risks against bundle hunks.`
 - `90% — validating walkthrough YAML before publishing.`
+
+The server has already resolved the authoritative input at launch. The agent starts from `read_pr_walkthrough_bundle` and uses `readonly_bash` only for extra read-only investigation, not to fetch a second authoritative PR diff.
 
 Progress is intentionally approximate. It should help the user trust the process without introducing a second panel-level loader.
 
@@ -101,10 +106,11 @@ Deduplicate by canonical target within the launching session:
 
 ## Failure states
 
-Failure should be visible in the child session and actionable from the launcher.
+Failure should be visible and actionable from the launcher or child, depending on when it occurs.
 
-- **Creation/model failure:** create the child if possible, show an error panel and chat explanation. Launcher notice links to the failed child.
-- **GitHub auth/permission/rate limit:** child panel shows a structured error with retry guidance; chat states what access is missing.
+- **Launch metadata/diff resolution failure:** return the structured launch error before child creation; the launcher shows retry guidance and no child row is created.
+- **Creation/model failure after bundle resolution:** create the child if possible, show an error panel and chat explanation. Launcher notice links to the failed child.
+- **GitHub auth/permission/rate limit during launch:** return a structured launch error with retry guidance before creating a waiting child.
 - **Read-only policy violation blocked:** tool result explains the blocked action; panel remains waiting unless the agent can continue safely.
 - **Large/truncated PR:** walkthrough can still publish with visible warnings and prioritized chunks; warnings appear in Orientation and Audit.
 - **Agent timeout/idle:** keep the child session alive, mark panel as waiting with reminder, and let the user prompt the agent again.

--- a/docs/pr-walkthrough-panel.md
+++ b/docs/pr-walkthrough-panel.md
@@ -19,7 +19,9 @@ Users can open a walkthrough from these entry points:
 - **Standalone route** — `/walkthrough?session=<id>&tab=<walkthrough-tab-id>` opens an already-created walkthrough tab in a wide review surface.
 - **Compatibility resolver** — fixture and local SHA walkthroughs can still be resolved directly into a tab by the standalone/local resolver paths. Session-hosted walkthrough agents currently support GitHub PR targets only.
 
-For GitHub PR launches, the tab belongs to the child walkthrough session, not the launcher. The UI switches/focuses the child session, expands the needed sidebar containers, and shows the child underneath the launching session using first-class `parentSessionId` / `childKind: "pr-walkthrough"` metadata, not delegate-session metadata. This nesting applies to ordinary sessions, goal sessions, team member sessions, and team-lead rows, and it is restored after reload from persisted session metadata and sidebar expansion state.
+For GitHub PR launches, the tab belongs to the child walkthrough session, not the launcher. Before that child exists, launch resolves and persists a sanitized analysis bundle containing the PR metadata, body, stats, diff hunks, warnings, limits, and export capability. The stored launch-time bundle is authoritative for the job; YAML submission maps against that bundle instead of re-fetching PR diff data.
+
+The UI switches/focuses the child session, expands the needed sidebar containers, and shows the child underneath the launching session using first-class `parentSessionId` / `childKind: "pr-walkthrough"` metadata, not delegate-session metadata. This nesting applies to ordinary sessions, goal sessions, team member sessions, and team-lead rows, and it is restored after reload from persisted session metadata and sidebar expansion state. Terminated or archived walkthrough children are hidden while **Show Archived** is off and reappear nested under their parent when it is on.
 
 The same ready walkthrough can be reviewed in:
 
@@ -36,11 +38,12 @@ The same ready walkthrough can be reviewed in:
 1. resolves the parent session and cwd;
 2. canonicalizes the GitHub target;
 3. checks for an existing job for the same `(parentSessionId, canonicalKey)`;
-4. creates a normal read-only child session with role `pr-walkthrough`;
-5. persists a walkthrough job with status `starting`, then `waiting_for_yaml`;
-6. opens the walkthrough tab in the child session and prompts the agent to investigate.
+4. creates a `starting` job record with stable job and child-session ids;
+5. resolves PR metadata and diff data, sanitizes it, and persists the launch-time analysis bundle;
+6. creates a normal read-only child session with role `pr-walkthrough` only after the bundle is usable;
+7. marks the job `waiting_for_yaml`, opens the walkthrough tab in the child session, and prompts the agent to investigate.
 
-The child title is `PR #<number> Walkthrough` when the PR number is known. If launch preflight fails, the failure is surfaced in the child transcript and panel as a structured job error.
+The child title is `PR #<number> Walkthrough` when the PR number is known. If launch-time target or bundle resolution fails, Bobbit returns the structured job error before child creation/focus so no waiting child is left without input.
 
 ### 2. Empty waiting panel
 
@@ -52,8 +55,11 @@ Progress is reported in chat by the agent, not by a panel progress bar. The pane
 
 Walkthrough sessions receive a narrow tool set:
 
-- `readonly_bash` for read-only PR/diff/file inspection;
+- `read_pr_walkthrough_bundle` for bounded reads of the scoped persisted launch-time PR metadata and diff bundle;
+- `readonly_bash` for additional read-only PR/diff/file inspection;
 - `submit_pr_walkthrough_yaml` for publishing the completed walkthrough.
+
+The agent prompt tells the agent to start with `read_pr_walkthrough_bundle` in manifest mode, then request bounded file/hunk reads as needed. The bundle tool validates the current `sessionId` and job id, reads only that walkthrough job's artifact, and does not loosen `readonly_bash` path or command policy.
 
 They do not receive unrestricted `bash`, file write/edit tools, build/test/install commands, commit/push tools, or GitHub review/comment submission tools.
 
@@ -77,9 +83,9 @@ The tool posts to the internal submit endpoint with the child `sessionId`, job i
 - YAML syntax and single-document shape;
 - required fields, enum values, size limits, and cross-field target consistency;
 - authoritative PR identity against the launched target;
-- hunk/file references against the fetched or local diff where possible.
+- hunk/file references against the stored launch-time analysis bundle where possible.
 
-On validation failure, the job moves to `validation_failed`, the panel remains unpopulated, and the tool returns field-level retry feedback such as `path` plus `message`. The agent can fix the YAML and call the tool again. If the agent becomes idle without a valid submission, Bobbit steers it to call `submit_pr_walkthrough_yaml`; after a failed submission, the reminder includes the last validation errors.
+On validation failure, the job moves to `validation_failed`, the panel remains unpopulated, and the tool returns field-level retry feedback such as `path` plus `message`. The agent can fix the YAML and call the tool again. If the stored bundle is missing, corrupt, or unusable, submission fails deterministically with retryable `PR_WALKTHROUGH_BUNDLE_MISSING`; Bobbit does not silently re-fetch the PR at submit time. Relaunch the walkthrough so launch can resolve and persist a fresh bundle. If the agent becomes idle without a valid submission, Bobbit steers it to call `submit_pr_walkthrough_yaml`; after a failed submission, the reminder includes the last validation errors.
 
 On success, Bobbit maps the YAML into the existing `WalkthroughStorePayload`, persists it, marks the job `ready`, broadcasts the update, selects the child walkthrough tab, and enters fullscreen review mode when the child is active. The tool response tells the agent to stay available for follow-up questions.
 
@@ -200,16 +206,17 @@ The draft can always be copied, even when provider export is unavailable.
 
 ## Persistence and reload
 
-Persistence has four layers:
+Persistence has five layers:
 
-- **Child session metadata** — the session store persists `parentSessionId`, `childKind: "pr-walkthrough"`, `readOnly`, `walkthroughJobId`, `walkthroughChangesetId`, and `walkthroughTargetKey` so reloads restore the visible child relationship and read-only tool identity. The sidebar renders these first-class children under their parent even when the parent is a team lead or the goal/team session list filters out child sessions from the top-level roster.
-- **Walkthrough job record** — the PR walkthrough agent store persists status (`starting`, `waiting_for_yaml`, `validation_failed`, `ready`, or `error`), target, tab id, last validation error, warnings, submitted timestamp, payload timestamp, and a submit-proof hash. Sensitive values such as tokens and raw submit proofs are sanitized.
+- **Child session metadata** — the session store persists `parentSessionId`, `childKind: "pr-walkthrough"`, `readOnly`, `walkthroughJobId`, `walkthroughChangesetId`, and `walkthroughTargetKey` so reloads restore the visible child relationship and read-only tool identity. The sidebar renders these first-class children under their parent even when the parent is a team lead or the goal/team session list filters out child sessions from the top-level roster. Terminated or archived children are filtered out while **Show Archived** is off and shown again in the same nested location when it is on.
+- **Walkthrough job record** — the PR walkthrough agent store persists status (`starting`, `waiting_for_yaml`, `validation_failed`, `ready`, or `error`), target, tab id, last validation error, warnings, submitted timestamp, payload timestamp, an `analysisBundle` metadata block, and a submit-proof hash. Sensitive values such as tokens and raw submit proofs are sanitized.
+- **Analysis bundle store** — launch persists the sanitized, versioned PR metadata/diff bundle as a job artifact. The job's `analysisBundle` metadata records the artifact identity, schema/kind, checksum, generated timestamp, and file count; the full bundle remains separate from the final renderable payload.
 - **Resolved walkthrough payload** — after valid YAML, the existing walkthrough store persists final changeset/cards/diff blocks/warnings/export metadata under the `changesetId`.
 - **Reviewer interaction state** — the browser stores active card, diff mode, comments, decisions, completed cards, dismissed suggestions, and collapsed diff blocks under `bobbit:pr-walkthrough:<tab-id>`.
 
 When the app reloads or the user selects a walkthrough child, the UI calls `GET /api/pr-walkthrough/session/<childSessionId>` to restore waiting, validation-failed, ready, or error job state. Ready tabs then call `GET /api/pr-walkthrough/<changeset-id>` if cards are not already loaded.
 
-When a PR walkthrough child session is restored, Bobbit rotates the submit proof and rehydrates the tool environment with `BOBBIT_SESSION_ID`, `BOBBIT_WALKTHROUGH_JOB_ID`, `BOBBIT_WALKTHROUGH_SUBMIT_PROOF`, and target-scoping variables. This lets an interrupted waiting session continue to use `submit_pr_walkthrough_yaml` without persisting the raw proof.
+When a PR walkthrough child session is restored, Bobbit rotates the submit proof and rehydrates the tool environment with `BOBBIT_SESSION_ID`, `BOBBIT_WALKTHROUGH_JOB_ID`, `BOBBIT_WALKTHROUGH_SUBMIT_PROOF`, and target-scoping variables. Restored waiting sessions retain scoped `read_pr_walkthrough_bundle` access for their own job and can continue to use `submit_pr_walkthrough_yaml` without persisting the raw proof.
 
 Because side panel, fullscreen, and standalone route all refer to the same tab id and persistence key, comments and decisions survive tab switching, wide review, standalone routing, and reload. Browser-local interaction state is not shared across browsers or devices.
 
@@ -249,6 +256,7 @@ Common warning/error categories:
 - **Permission failure** — GitHub `403` with remaining rate limit usually means the token cannot access the repository or PR.
 - **Rate limit** — GitHub `403` with no remaining quota reports rate limiting; configure a token or retry later.
 - **Validation failure** — invalid YAML keeps the panel empty and returns retryable field-level errors.
+- **Missing or unusable analysis bundle** — missing, corrupt, or unreadable launch bundle artifacts return retryable `PR_WALKTHROUGH_BUNDLE_MISSING`; relaunch the walkthrough so launch resolves a fresh bundle before analysis.
 - **Agent runtime failure** — launch or runtime failures before YAML publication become job errors shown in the child session and panel.
 - **Large/truncated diffs** — local diff output, GitHub patch bytes, per-file line counts, or changed-file pages can be truncated. Warnings identify the affected files when possible.
 - **Generated files** — generated-looking paths are flagged as low-signal and grouped into edge-case cards.
@@ -263,10 +271,11 @@ Warnings are shown at the top of the panel and again in export preview when they
 
 The walkthrough API is internal to the Bobbit UI but useful for tests and integrations:
 
-- `POST /api/pr-walkthrough/launch` — create or focus a session-hosted GitHub PR walkthrough child. Returns the job, `childSessionId`, `changesetId`, tab id, status, and whether the job was newly created.
-- `GET /api/pr-walkthrough/jobs/<jobId>` — return the sanitized persisted job record.
+- `POST /api/pr-walkthrough/launch` — create or focus a session-hosted GitHub PR walkthrough child. For new GitHub jobs, launch resolves and persists the analysis bundle before child creation/focus; if resolution fails, the response contains the structured job error and no waiting child is created. Returns the job, `childSessionId`, `changesetId`, tab id, status, and whether the job was newly created.
+- `GET /api/pr-walkthrough/jobs/<jobId>` — return the sanitized persisted job record, including `analysisBundle` metadata when a bundle artifact exists.
 - `GET /api/pr-walkthrough/session/<childSessionId>` — return the sanitized job for a child session so the UI can restore waiting/failed/ready/error state.
-- `POST /api/internal/pr-walkthrough/submit-yaml` — internal tool endpoint used only by `submit_pr_walkthrough_yaml`; requires scoped session access and submit proof.
+- `GET /api/internal/pr-walkthrough/bundle` / `POST /api/internal/pr-walkthrough/bundle` — internal endpoint used only by `read_pr_walkthrough_bundle`; requires scoped session/job access and returns bounded manifest/file reads from the persisted launch bundle. `/api/internal/pr-walkthrough/analysis-bundle` is the compatibility alias.
+- `POST /api/internal/pr-walkthrough/submit-yaml` — internal tool endpoint used only by `submit_pr_walkthrough_yaml`; requires scoped session access and submit proof and maps against the stored launch bundle.
 - `POST /api/pr-walkthrough/resolve` — compatibility resolver for fixture/local/direct walkthrough payloads. Stores the resolved payload.
 - `GET /api/pr-walkthrough/<changeset-id>` — reload a stored ready payload.
 - `POST /api/pr-walkthrough/<changeset-id>/export/preview` — build a provider review preview from a draft.
@@ -306,6 +315,7 @@ For compatibility resolver model synthesis without a custom adapter, Bobbit uses
 - **Local changeset launch is unsupported** — use the standalone/local resolver flow for `baseSha` / `headSha` walkthroughs; session-hosted agents are GitHub-only.
 - **Panel stays empty** — the agent has not successfully called `submit_pr_walkthrough_yaml`; check the child transcript and validation state.
 - **YAML validation failed** — fix the field-level errors returned by the tool and call `submit_pr_walkthrough_yaml` again from the same child session.
+- **`PR_WALKTHROUGH_BUNDLE_MISSING` or unusable bundle** — the launch-time analysis bundle artifact is missing, corrupt, or no longer readable. This is retryable, but submission will not re-fetch the diff; relaunch the walkthrough so Bobbit resolves and persists a fresh bundle before creating a new waiting child.
 - **Private PR fails or shows permission errors** — set `GITHUB_TOKEN` or `GH_TOKEN` with repository read and pull request review permissions, then retry.
 - **Rate limited** — configure a token or wait for GitHub's rate limit reset.
 - **Export button only shows copy/preview** — the walkthrough is local, unauthenticated, missing a GitHub target, or export capability was disabled by the resolver.

--- a/src/app/pr-walkthrough.ts
+++ b/src/app/pr-walkthrough.ts
@@ -372,7 +372,15 @@ export function upsertPrWalkthroughJobPanel(
 	const changeset = targetChangesetFromJob(job);
 	const changesetId = job.changesetId;
 	const rawTabId = cleanString(job.tabId);
-	const tabId = rawTabId && walkthroughChangesetIdFromPanelTabId(rawTabId) ? rawTabId : walkthroughPanelTabId(changesetId);
+	const requestedTabId = rawTabId && walkthroughChangesetIdFromPanelTabId(rawTabId) ? rawTabId : walkthroughPanelTabId(changesetId);
+	const existing = panelTabsForSession(state, sessionId);
+	const existingJobTab = existing.find((candidate) => {
+		if (candidate.kind !== "walkthrough") return false;
+		const source = (candidate.source || {}) as Record<string, unknown>;
+		const candidateState = (candidate.state || {}) as Record<string, unknown>;
+		return source.jobId === job.jobId || candidateState.jobId === job.jobId;
+	});
+	const tabId = existingJobTab?.id || requestedTabId;
 	const status: PrWalkthroughStatus = job.status === "starting" ? "waiting_for_yaml" : job.status;
 	const target = job.target || {};
 	const errorMessage = job.error?.message || (status === "validation_failed" ? validationMessage(job.lastValidationError) : undefined);
@@ -419,16 +427,25 @@ export function upsertPrWalkthroughJobPanel(
 		},
 	};
 
-	const existing = panelTabsForSession(state, sessionId);
 	const next = existing.some((candidate) => candidate.id === tabId)
-		? existing.map((candidate) => candidate.id === tabId
-			? {
+		? existing.map((candidate) => {
+			if (candidate.id !== tabId) return candidate;
+			const candidateState = (candidate.state || {}) as Record<string, unknown>;
+			const tabState = (tab.state || {}) as Record<string, unknown>;
+			const mergedState = { ...candidateState, ...tabState };
+			if (status === "ready" && Array.isArray(candidateState.cards) && !Array.isArray(tabState.cards)) {
+				mergedState.cards = candidateState.cards;
+				if (candidateState.changeset) mergedState.changeset = candidateState.changeset;
+				if (candidateState.exportCapability && !tabState.exportCapability) mergedState.exportCapability = candidateState.exportCapability;
+				if (candidateState.limits && !tabState.limits) mergedState.limits = candidateState.limits;
+			}
+			return {
 				...candidate,
 				...tab,
 				source: { ...(candidate.source as Record<string, unknown>), ...(tab.source as Record<string, unknown>) } as PanelWorkspaceTab["source"],
-				state: { ...(candidate.state || {}), ...(tab.state || {}) },
-			}
-			: candidate)
+				state: mergedState,
+			};
+		})
 		: [...existing, tab];
 	setPanelTabsForSession(state, sessionId, next);
 	if (options.select) setActivePanelTabIdForSession(state, sessionId, tabId);

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -526,20 +526,27 @@ export function renderSessionRow(session: GatewaySession) {
 					</div>
 				</div>`}
 		</div>
-		${childrenExpanded ? html`${renderLiveDelegates(session.id)}${renderArchivedDelegates(session.id, true)}` : ""}
+		${childrenExpanded ? html`${renderLiveDelegates(session.id)}${state.showArchived ? renderArchivedDelegates(session.id, true) : ""}` : ""}
 	`;
+}
+
+function isArchivedOrTerminalSession(session: GatewaySession): boolean {
+	return session.archived === true || session.status === "terminated" || session.status === "archived";
 }
 
 function visibleLiveChildrenForParent(parentSessionId: string): GatewaySession[] {
 	const bypassFilters = !!state.searchQuery.trim();
 	return state.gatewaySessions.filter(s =>
 		sessionParentId(s) === parentSessionId
-		&& (state.showArchived || s.status !== "terminated")
+		&& (state.showArchived || !isArchivedOrTerminalSession(s))
 		&& (isFirstClassChildSession(s) || passesSidebarFilters(s, s.id === activeSessionId(), bypassFilters)));
 }
 
 function archivedChildrenForParent(parentSessionId: string): GatewaySession[] {
-	return state.archivedSessions.filter(s => sessionParentId(s) === parentSessionId);
+	const gatewayChildIds = new Set(state.gatewaySessions
+		.filter(s => sessionParentId(s) === parentSessionId)
+		.map(s => s.id));
+	return state.archivedSessions.filter(s => sessionParentId(s) === parentSessionId && !gatewayChildIds.has(s.id));
 }
 
 /** Render live delegate sessions nested under a parent session. */
@@ -547,8 +554,8 @@ function renderLiveDelegates(parentSessionId: string): TemplateResult | string {
 	const children = visibleLiveChildrenForParent(parentSessionId);
 	if (children.length === 0) return "";
 	return html`<div class="flex flex-col gap-0.5" style="padding-left:${INDENT}px;">
-		${children.map(s => s.status === "terminated"
-			? html`${renderArchivedSessionRow(s)}${renderArchivedDelegates(s.id)}`
+		${children.map(s => isArchivedOrTerminalSession(s)
+			? html`${renderArchivedSessionRow(s)}${state.showArchived ? renderArchivedDelegates(s.id) : ""}`
 			: renderSessionRow(s))}
 	</div>`;
 }
@@ -561,7 +568,7 @@ export function renderArchivedSessionRow(session: GatewaySession, extraChildren 
 	const mobile = !isDesktop();
 	const active = activeSessionId() === session.id;
 	const displayTitle = active && state.remoteAgent ? state.remoteAgent.title : session.title;
-	const delegates = state.archivedSessions.filter(s => sessionParentId(s) === session.id);
+	const delegates = archivedChildrenForParent(session.id);
 	const hasChildren = delegates.length > 0 || extraChildren;
 	const expanded = hasChildren && isArchivedParentExpanded(session.id);
 	const rowPy = mobile ? "py-1" : SESSION_ROW_PY;
@@ -593,6 +600,7 @@ export function renderArchivedSessionRow(session: GatewaySession, extraChildren 
 
 /** Render any archived delegate sessions nested under a parent session. */
 export function renderArchivedDelegates(parentSessionId: string, forceExpanded = false): TemplateResult | string {
+	if (!state.showArchived) return "";
 	if (!forceExpanded && !isArchivedParentExpanded(parentSessionId)) return "";
 	const delegates = archivedChildrenForParent(parentSessionId);
 	if (delegates.length === 0) return "";
@@ -924,7 +932,7 @@ export function renderGoalGroup(goal: Goal) {
 			|| isArchivedParentExpanded(teamLead.id);
 		return html`
 			${renderTeamLeadRow(teamLead, teamChildren.length + archivedForLiveLead.length + liveLeadChildren.length + archivedLeadChildren.length, tlExpanded)}
-			${leadChildRowsExpanded ? html`${renderLiveDelegates(teamLead.id)}${renderArchivedDelegates(teamLead.id, true)}` : ""}
+			${leadChildRowsExpanded ? html`${renderLiveDelegates(teamLead.id)}${state.showArchived ? renderArchivedDelegates(teamLead.id, true) : ""}` : ""}
 			${tlExpanded ? html`
 				<div class="flex flex-col gap-0.5" style="padding-left:${INDENT}px;">
 					${teamChildren.map(renderSessionRow)}

--- a/src/server/pr-walkthrough/routes.ts
+++ b/src/server/pr-walkthrough/routes.ts
@@ -11,6 +11,7 @@ import { completeModelText as defaultCompleteModelText } from "../agent/model-co
 import { getAvailableModels as defaultGetAvailableModels, type ApiModel } from "../agent/model-registry.js";
 import { safeExternalUrl, trustedHostsFromEnv } from "../../shared/pr-walkthrough/url-safety.js";
 import { WalkthroughAgentManager, type LaunchWalkthroughRequest, type SubmitWalkthroughYamlRequest, type WalkthroughAgentManagerDeps, type WalkthroughSessionManagerLike } from "./walkthrough-agent-manager.js";
+import type { ReadPrWalkthroughBundleRequest } from "./walkthrough-analysis-bundle.js";
 
 const execFile = promisify(execFileCb);
 const STORE_SCHEMA_VERSION = 1;
@@ -149,17 +150,30 @@ export async function handlePrWalkthroughApiRoute(
 ): Promise<boolean> {
 	const isPublicWalkthroughRoute = url.pathname.startsWith("/api/pr-walkthrough");
 	const isInternalSubmitRoute = url.pathname === "/api/internal/pr-walkthrough/submit-yaml";
-	if (!isPublicWalkthroughRoute && !isInternalSubmitRoute) return false;
+	const isInternalBundleRoute = url.pathname === "/api/internal/pr-walkthrough/bundle" || url.pathname === "/api/internal/pr-walkthrough/analysis-bundle";
+	if (!isPublicWalkthroughRoute && !isInternalSubmitRoute && !isInternalBundleRoute) return false;
 
 	const json = (data: unknown, status = 200) => {
 		res.writeHead(status, { "Content-Type": "application/json", "Cache-Control": "no-store" });
 		res.end(JSON.stringify(data));
 	};
 	const fail = (status: number, message: string, extra?: Record<string, unknown>) => {
-		json({ error: message, ...extra }, status);
+		json({ error: message, message, ...extra }, status);
 	};
 
 	try {
+		if (isInternalBundleRoute && (req.method === "GET" || req.method === "POST")) {
+			const body = req.method === "POST" ? await deps.readBody(req) : undefined;
+			const input = bundleReadRequestFrom(url, body);
+			if (deps.sandboxScope && (!input.sessionId || !deps.sandboxScope.sessionIds.has(input.sessionId))) {
+				fail(403, "Forbidden: PR walkthrough bundle read session is outside sandbox scope", { code: "SANDBOX_SESSION_OUT_OF_SCOPE" });
+				return true;
+			}
+			const manager = getWalkthroughAgentManager(deps);
+			json(manager.readBundle(input));
+			return true;
+		}
+
 		if (url.pathname === "/api/internal/pr-walkthrough/submit-yaml" && req.method === "POST") {
 			const body = await deps.readBody(req);
 			if (!body || typeof body !== "object") {
@@ -889,10 +903,31 @@ function stringValue(value: unknown): string | undefined {
 	return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
+function numberValue(value: unknown): number | undefined {
+	if (typeof value === "number" && Number.isFinite(value)) return value;
+	if (typeof value === "string" && value.trim() && Number.isFinite(Number(value))) return Number(value);
+	return undefined;
+}
+
 function headerValue(req: http.IncomingMessage, name: string): string | undefined {
 	const value = req.headers[name.toLowerCase()];
 	if (Array.isArray(value)) return stringValue(value[0]);
 	return stringValue(value);
+}
+
+function bundleReadRequestFrom(url: URL, body: unknown): ReadPrWalkthroughBundleRequest {
+	const record = body && typeof body === "object" && !Array.isArray(body) ? body as Record<string, unknown> : {};
+	return {
+		sessionId: stringValue(record.sessionId) ?? stringValue(url.searchParams.get("sessionId")) ?? "",
+		jobId: stringValue(record.jobId) ?? stringValue(url.searchParams.get("jobId")) ?? "",
+		mode: (stringValue(record.mode) ?? stringValue(url.searchParams.get("mode"))) as ReadPrWalkthroughBundleRequest["mode"],
+		path: stringValue(record.path) ?? stringValue(record.file) ?? stringValue(url.searchParams.get("path")) ?? stringValue(url.searchParams.get("file")),
+		index: numberValue(record.index) ?? numberValue(url.searchParams.get("index")),
+		offset: numberValue(record.offset) ?? numberValue(url.searchParams.get("offset")),
+		limit: numberValue(record.limit) ?? numberValue(url.searchParams.get("limit")),
+		hunkOffset: numberValue(record.hunkOffset) ?? numberValue(url.searchParams.get("hunkOffset")),
+		hunkLimit: numberValue(record.hunkLimit) ?? numberValue(url.searchParams.get("hunkLimit")),
+	};
 }
 
 function parseGithubRef(prUrl: string | undefined, prNumber: string | number | undefined, cwd: string): { owner: string; repo: string; number: string | number; url: string } | undefined {

--- a/src/server/pr-walkthrough/walkthrough-agent-manager.ts
+++ b/src/server/pr-walkthrough/walkthrough-agent-manager.ts
@@ -4,6 +4,13 @@ import { bobbitStateDir } from "../bobbit-dir.js";
 import { execFileSafe } from "../exec-file-safe.js";
 import { resolveGithubPr, GithubPrAdapterError, parseGithubRemoteUrl } from "./github-adapter.js";
 import { resolveLocalChangeset } from "./git-changeset.js";
+import {
+	WalkthroughAnalysisBundleStore,
+	analysisBundleToParsedDiff,
+	createAnalysisBundleFromParsedDiff,
+	missingBundleError,
+	type ReadPrWalkthroughBundleRequest,
+} from "./walkthrough-analysis-bundle.js";
 import { saveWalkthrough, type WalkthroughStorePayload } from "./walkthrough-store.js";
 import {
 	mapYamlToWalkthroughPayload as defaultMapYamlToWalkthroughPayload,
@@ -131,18 +138,21 @@ class WalkthroughYamlValidationFailure extends Error {
 
 export const WALKTHROUGH_ALLOWED_TOOLS = [
 	"readonly_bash",
+	"read_pr_walkthrough_bundle",
 	"submit_pr_walkthrough_yaml",
 ];
 
 export class WalkthroughAgentManager {
 	private readonly stateDir: string;
 	private readonly store: WalkthroughAgentStore;
+	private readonly bundleStore: WalkthroughAnalysisBundleStore;
 	private readonly reminderUnsubscribers = new Map<string, () => void>();
 	private readonly launchInFlight = new Map<string, Promise<LaunchWalkthroughResponse>>();
 
 	constructor(private readonly deps: WalkthroughAgentManagerDeps) {
 		this.stateDir = deps.stateDir ?? bobbitStateDir();
 		this.store = deps.store ?? new WalkthroughAgentStore(this.stateDir);
+		this.bundleStore = new WalkthroughAnalysisBundleStore(this.stateDir);
 	}
 
 	async launch(input: LaunchWalkthroughRequest): Promise<LaunchWalkthroughResponse> {
@@ -209,6 +219,15 @@ export class WalkthroughAgentManager {
 			return { ...responseFromJob(job), created: true };
 		}
 
+		try {
+			job = await this.resolveAndPersistLaunchBundle(job);
+		} catch (error) {
+			const typed = classifyDiffResolutionError(error);
+			job = this.store.update(jobId, { status: "error", error: typed }) ?? job;
+			this.broadcastJob(job);
+			return { ...responseFromJob(job), created: true };
+		}
+
 		const targetEnv = walkthroughTargetEnvForJob(job);
 		const initialModel = await this.resolveParentInitialModel(parentSessionId, parent);
 		let child: SessionLike;
@@ -252,16 +271,6 @@ export class WalkthroughAgentManager {
 		this.applySessionMetadata(child, job);
 		this.deps.sessionManager.setTitle?.(childSessionId, title, { markGenerated: true });
 
-		try {
-			await this.preflightLaunch(job);
-		} catch (error) {
-			const typed = classifyDiffResolutionError(error);
-			job = this.store.update(jobId, { status: "error", error: typed }) ?? job;
-			this.broadcastJob(job);
-			await this.notifyChildOfError(child, typed, "launch preflight");
-			return { ...responseFromJob(job), created: true };
-		}
-
 		job = this.store.update(jobId, { status: "waiting_for_yaml" }) ?? job;
 		this.broadcastJob(job);
 		this.attachRuntimeListeners(childSessionId, jobId, child.rpcClient);
@@ -297,6 +306,18 @@ export class WalkthroughAgentManager {
 
 	getJobForSession(childSessionId: string): PrWalkthroughJobRecord | null {
 		return publicJob(this.store.getByChildSession(childSessionId));
+	}
+
+	readBundle(input: ReadPrWalkthroughBundleRequest): Record<string, unknown> {
+		if (!input.sessionId || !input.jobId) {
+			throw routeError(400, "Missing required fields: sessionId and jobId", { code: "INVALID_BUNDLE_READ_REQUEST", retryable: false });
+		}
+		const job = this.store.get(input.jobId);
+		if (!job) throw routeError(404, "No PR walkthrough job found for this jobId", { code: "JOB_NOT_FOUND", retryable: false });
+		if (job.childSessionId !== input.sessionId) {
+			throw routeError(403, "Session is not allowed to read the analysis bundle for this walkthrough job", { code: "WALKTHROUGH_JOB_SESSION_MISMATCH", retryable: false });
+		}
+		return this.bundleStore.read(job, input);
 	}
 
 	async submitYaml(input: SubmitWalkthroughYamlRequest): Promise<SubmitWalkthroughYamlResponse> {
@@ -377,22 +398,66 @@ export class WalkthroughAgentManager {
 		}
 	}
 
-	private async preflightLaunch(job: PrWalkthroughJobRecord): Promise<void> {
-		if (job.target.provider !== "github") return;
-		if (job.target.baseSha && job.target.headSha) return;
-		if (!this.deps.preflightGithubLaunch) return;
+	private async resolveAndPersistLaunchBundle(job: PrWalkthroughJobRecord): Promise<PrWalkthroughJobRecord> {
+		const parsedDiff = await this.resolveLaunchDiffForBundle(job);
+		if (!parsedDiff) return job;
+		const bundle = createAnalysisBundleFromParsedDiff(job, parsedDiff);
+		const { metadata } = this.bundleStore.save(job.jobId, bundle);
+		const baseSha = bundle.changeset.base_sha;
+		const headSha = bundle.changeset.head_sha;
+		return this.store.update(job.jobId, {
+			analysisBundle: metadata,
+			target: {
+				...job.target,
+				...(baseSha ? { baseSha } : {}),
+				...(headSha ? { headSha } : {}),
+			},
+			warnings: bundle.warnings,
+		}) ?? job;
+	}
+
+	private async resolveLaunchDiffForBundle(job: PrWalkthroughJobRecord): Promise<WalkthroughParsedDiffForYamlMapping | undefined> {
+		if (job.target.provider !== "github") return undefined;
+		if (job.target.baseSha && job.target.headSha) {
+			if (typeof this.deps.preflightGithubLaunch === "function") return undefined;
+			let local: WalkthroughParsedDiffForYamlMapping;
+			try {
+				local = await localDiffForYaml(job.cwd, job.target.baseSha, job.target.headSha);
+			} catch (error) {
+				if (this.deps.preflightGithubLaunch) return undefined;
+				throw error;
+			}
+			return {
+				...local,
+				changeset: {
+					...local.changeset,
+					provider: "github",
+					externalUrl: job.target.prUrl,
+					prUrl: job.target.prUrl,
+					prNumber: job.target.number,
+					prTitle: job.title,
+					prBody: "",
+					title: job.title,
+				},
+				export: { provider: "github", available: false, previewOnly: true, reason: "GitHub submission requires launch-time GitHub metadata; preview is available." },
+			};
+		}
+		if (!this.deps.preflightGithubLaunch) return undefined;
 		if (typeof this.deps.preflightGithubLaunch === "function") {
 			await this.deps.preflightGithubLaunch(job);
-			return;
+			return undefined;
 		}
-		await resolveGithubPr({
+		const resolved = await resolveGithubPr({
 			cwd: job.cwd,
 			prUrl: job.target.prUrl,
 			prNumber: job.target.number,
-			maxFiles: 1,
-			maxPatchBytes: 1,
-			maxLinesPerFile: 1,
 		});
+		return {
+			changeset: resolved.changeset,
+			files: resolved.files,
+			warnings: resolved.warnings,
+			export: resolved.export as unknown as WalkthroughParsedDiffForYamlMapping["export"],
+		};
 	}
 
 	private async validateYaml(yamlText: string, job: PrWalkthroughJobRecord): Promise<WalkthroughYamlValidationResult> {
@@ -417,6 +482,11 @@ export class WalkthroughAgentManager {
 	}
 
 	private async resolveDiffForYamlMapping(document: Record<string, unknown>, job: PrWalkthroughJobRecord): Promise<WalkthroughParsedDiffForYamlMapping> {
+		if (job.analysisBundle) {
+			const bundle = this.bundleStore.load(job.jobId);
+			if (!bundle) throw missingBundleError(job.jobId);
+			return analysisBundleToParsedDiff(bundle);
+		}
 		if (this.deps.resolveDiffForYamlMapping) return this.deps.resolveDiffForYamlMapping(document, job);
 		const yaml = document as unknown as PrWalkthroughYamlDocument;
 		const baseSha = job.target.baseSha;
@@ -792,6 +862,7 @@ function buildRolePrompt(target: PrWalkthroughTarget): string {
 	return [
 		"You are a read-only PR walkthrough agent.",
 		"Investigate the PR using only read-only tools and report rough percentage progress in chat.",
+		"Start from read_pr_walkthrough_bundle; it is the authoritative launch-time PR metadata and diff bundle for this job. Use readonly_bash only for additional read-only investigation.",
 		"Do not edit files, run tests/builds, install dependencies, push, commit, or submit GitHub reviews/comments.",
 		"When complete, call submit_pr_walkthrough_yaml with exactly one YAML document matching the schema below. The panel will remain empty until that tool succeeds.",
 		`Target: ${target.canonicalKey}`,
@@ -804,7 +875,8 @@ function buildKickoffPrompt(job: PrWalkthroughJobRecord): string {
 		`Review target: ${job.target.canonicalKey}`,
 		job.target.prUrl ? `PR URL: ${job.target.prUrl}` : undefined,
 		job.target.baseSha && job.target.headSha ? `Range: ${job.target.baseSha}..${job.target.headSha}` : undefined,
-		"Start by saying you are beginning the investigation with an approximate progress percentage.",
+		"Start by calling read_pr_walkthrough_bundle in manifest mode, then say you are beginning the investigation with an approximate progress percentage.",
+		"Treat the persisted bundle as authoritative for PR body, SHAs, stats, files, hunks, warnings, and limits.",
 		"Populate the panel only by calling submit_pr_walkthrough_yaml with valid YAML. Stay available after success.",
 		REQUIRED_YAML_SCHEMA_PROMPT,
 	].filter(Boolean).join("\n");
@@ -869,6 +941,9 @@ function classifyAgentError(error: unknown, fallbackCode: string): PrWalkthrough
 }
 
 function classifyDiffResolutionError(error: unknown): PrWalkthroughJobError {
+	if (isRecord(error) && isRecord(error.extra) && typeof error.extra.code === "string") {
+		return { code: error.extra.code, message: error instanceof Error ? error.message : String(error), retryable: error.extra.retryable !== false };
+	}
 	if (error instanceof GithubPrAdapterError) {
 		if (error.status === 401 || error.code === "github_auth_failed") {
 			return { code: "GITHUB_AUTH_REQUIRED", message: "GitHub rejected the configured credentials. Check GITHUB_TOKEN/GH_TOKEN or run gh auth status, then retry the walkthrough.", retryable: true };
@@ -897,6 +972,7 @@ function statusForJobError(error: PrWalkthroughJobError): number {
 		case "GITHUB_FORBIDDEN": return 403;
 		case "GITHUB_RATE_LIMITED": return 429;
 		case "GITHUB_NOT_FOUND_OR_PRIVATE": return 404;
+		case "PR_WALKTHROUGH_BUNDLE_MISSING": return 409;
 		default: return 502;
 	}
 }

--- a/src/server/pr-walkthrough/walkthrough-agent-manager.ts
+++ b/src/server/pr-walkthrough/walkthrough-agent-manager.ts
@@ -419,14 +419,7 @@ export class WalkthroughAgentManager {
 	private async resolveLaunchDiffForBundle(job: PrWalkthroughJobRecord): Promise<WalkthroughParsedDiffForYamlMapping | undefined> {
 		if (job.target.provider !== "github") return undefined;
 		if (job.target.baseSha && job.target.headSha) {
-			if (typeof this.deps.preflightGithubLaunch === "function") return undefined;
-			let local: WalkthroughParsedDiffForYamlMapping;
-			try {
-				local = await localDiffForYaml(job.cwd, job.target.baseSha, job.target.headSha);
-			} catch (error) {
-				if (this.deps.preflightGithubLaunch) return undefined;
-				throw error;
-			}
+			const local = await localDiffForYaml(job.cwd, job.target.baseSha, job.target.headSha);
 			return {
 				...local,
 				changeset: {
@@ -442,11 +435,7 @@ export class WalkthroughAgentManager {
 				export: { provider: "github", available: false, previewOnly: true, reason: "GitHub submission requires launch-time GitHub metadata; preview is available." },
 			};
 		}
-		if (!this.deps.preflightGithubLaunch) return undefined;
-		if (typeof this.deps.preflightGithubLaunch === "function") {
-			await this.deps.preflightGithubLaunch(job);
-			return undefined;
-		}
+		if (typeof this.deps.preflightGithubLaunch === "function") await this.deps.preflightGithubLaunch(job);
 		const resolved = await resolveGithubPr({
 			cwd: job.cwd,
 			prUrl: job.target.prUrl,
@@ -487,51 +476,14 @@ export class WalkthroughAgentManager {
 			if (!bundle) throw missingBundleError(job.jobId);
 			return analysisBundleToParsedDiff(bundle);
 		}
+		if (job.target.provider === "github") throw missingBundleError(job.jobId);
 		if (this.deps.resolveDiffForYamlMapping) return this.deps.resolveDiffForYamlMapping(document, job);
-		const yaml = document as unknown as PrWalkthroughYamlDocument;
 		const baseSha = job.target.baseSha;
 		const headSha = job.target.headSha;
 
 		if (job.target.provider === "local") {
 			if (!baseSha || !headSha) throw new Error("Local walkthrough diff resolution requires baseSha and headSha.");
 			return localDiffForYaml(job.cwd, baseSha, headSha);
-		}
-
-		if (job.target.provider === "github") {
-			if (baseSha && headSha) {
-				try {
-					const local = await localDiffForYaml(job.cwd, baseSha, headSha);
-					return {
-						...local,
-						changeset: {
-							...local.changeset,
-							provider: "github",
-							externalUrl: yaml.pr.url,
-							prUrl: yaml.pr.url,
-							prNumber: yaml.pr.number,
-							prTitle: yaml.pr.title,
-							prBody: yaml.pr.original_description.body,
-							title: yaml.pr.title,
-						},
-						export: { provider: "github", available: false, previewOnly: true, reason: "GitHub submission requires adapter credentials; preview is available." },
-					};
-				} catch {
-					// Fall through to the GitHub adapter so inaccessible/private/rate-limit
-					// failures become deterministic job errors instead of empty diff mapping.
-				}
-			}
-
-			const resolved = await resolveGithubPr({
-				cwd: job.cwd,
-				prUrl: job.target.prUrl ?? yaml.pr.url,
-				prNumber: job.target.number ?? yaml.pr.number,
-			});
-			return {
-				changeset: resolved.changeset,
-				files: resolved.files,
-				warnings: resolved.warnings,
-				export: resolved.export as unknown as WalkthroughParsedDiffForYamlMapping["export"],
-			};
 		}
 
 		throw new Error(`Unsupported PR walkthrough target provider: ${job.target.provider}`);

--- a/src/server/pr-walkthrough/walkthrough-agent-store.ts
+++ b/src/server/pr-walkthrough/walkthrough-agent-store.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { bobbitStateDir } from "../bobbit-dir.js";
+import type { PrWalkthroughAnalysisBundleMetadata } from "./walkthrough-analysis-bundle.js";
 import { storageKeyForChangesetId } from "./walkthrough-store.js";
 
 export const PR_WALKTHROUGH_AGENT_STORE_SCHEMA_VERSION = 1;
@@ -67,6 +68,7 @@ export interface PrWalkthroughJobRecord {
 	error?: PrWalkthroughJobError;
 	reminderCount?: number;
 	submissionProofHash?: string;
+	analysisBundle?: PrWalkthroughAnalysisBundleMetadata;
 }
 
 type StoredJobFile = Partial<PrWalkthroughJobRecord> & Record<string, unknown>;
@@ -230,6 +232,7 @@ function parseStoredJob(raw: StoredJobFile, expectedJobId?: string): PrWalkthrou
 		error: isRecord(raw.error) ? raw.error as PrWalkthroughJobError : undefined,
 		reminderCount: typeof raw.reminderCount === "number" ? raw.reminderCount : undefined,
 		submissionProofHash: typeof raw.submissionProofHash === "string" ? raw.submissionProofHash : undefined,
+		analysisBundle: isRecord(raw.analysisBundle) ? raw.analysisBundle as PrWalkthroughAnalysisBundleMetadata : undefined,
 	});
 }
 

--- a/src/server/pr-walkthrough/walkthrough-analysis-bundle.ts
+++ b/src/server/pr-walkthrough/walkthrough-analysis-bundle.ts
@@ -1,0 +1,426 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import type { PrWalkthroughChangesetRef, PrWalkthroughDiffBlock, PrWalkthroughDiffLine, PrWalkthroughHunk } from "../../shared/pr-walkthrough/types.js";
+import { bobbitStateDir } from "../bobbit-dir.js";
+import { storageKeyForChangesetId } from "./walkthrough-store.js";
+import type { PrWalkthroughJobRecord, PrWalkthroughTarget, WalkthroughWarning } from "./walkthrough-agent-store.js";
+import type { WalkthroughParsedDiffForYamlMapping } from "./walkthrough-yaml-schema.js";
+
+export const PR_WALKTHROUGH_ANALYSIS_BUNDLE_SCHEMA_VERSION = 1;
+export const PR_WALKTHROUGH_ANALYSIS_BUNDLE_KIND = "pr_walkthrough_analysis_bundle";
+const STORE_DIR = "pr-walkthrough-analysis-bundles";
+
+export type PrWalkthroughAnalysisBundleTarget = {
+	provider: "github" | string;
+	owner?: string;
+	repo?: string;
+	number?: number;
+	url?: string;
+};
+
+export type PrWalkthroughAnalysisBundleChangeset = {
+	base_sha?: string;
+	head_sha?: string;
+	title?: string;
+	body?: string;
+	files_changed?: number;
+	additions?: number;
+	deletions?: number;
+};
+
+export type PrWalkthroughAnalysisBundleLine = {
+	id?: string;
+	kind: "context" | "add" | "del";
+	side?: "old" | "new" | "context";
+	old_line?: number;
+	new_line?: number;
+	text: string;
+};
+
+export type PrWalkthroughAnalysisBundleHunk = {
+	id?: string;
+	header: string;
+	old_start?: number;
+	old_lines?: number;
+	new_start?: number;
+	new_lines?: number;
+	lines: PrWalkthroughAnalysisBundleLine[];
+};
+
+export type PrWalkthroughAnalysisBundleFile = {
+	id?: string;
+	path: string;
+	old_path?: string | null;
+	status?: string;
+	additions?: number;
+	deletions?: number;
+	is_binary: boolean;
+	is_generated: boolean;
+	is_truncated: boolean;
+	external_url?: string;
+	blob_url?: string;
+	raw_url?: string;
+	contents_url?: string;
+	hunks: PrWalkthroughAnalysisBundleHunk[];
+};
+
+export type PrWalkthroughAnalysisBundleExport = { provider: string; available: boolean; [key: string]: unknown };
+
+export type PrWalkthroughAnalysisBundle = {
+	schema_version: typeof PR_WALKTHROUGH_ANALYSIS_BUNDLE_SCHEMA_VERSION;
+	kind: typeof PR_WALKTHROUGH_ANALYSIS_BUNDLE_KIND;
+	generated_at: string;
+	job_id: string;
+	target: PrWalkthroughAnalysisBundleTarget;
+	changeset: PrWalkthroughAnalysisBundleChangeset;
+	limits?: Record<string, unknown>;
+	warnings: WalkthroughWarning[];
+	export?: PrWalkthroughAnalysisBundleExport;
+	files: PrWalkthroughAnalysisBundleFile[];
+};
+
+export type PrWalkthroughAnalysisBundleMetadata = {
+	schemaVersion: typeof PR_WALKTHROUGH_ANALYSIS_BUNDLE_SCHEMA_VERSION;
+	kind: typeof PR_WALKTHROUGH_ANALYSIS_BUNDLE_KIND;
+	artifactId: string;
+	checksum: string;
+	generatedAt: string;
+	files: number;
+};
+
+export type ReadPrWalkthroughBundleRequest = {
+	sessionId: string;
+	jobId: string;
+	mode?: "summary" | "manifest" | "files" | "file";
+	path?: string;
+	index?: number;
+	offset?: number;
+	limit?: number;
+	hunkOffset?: number;
+	hunkLimit?: number;
+};
+
+export class WalkthroughAnalysisBundleStore {
+	private readonly rootDir: string;
+
+	constructor(stateDir = bobbitStateDir()) {
+		this.rootDir = path.join(stateDir, STORE_DIR, `v${PR_WALKTHROUGH_ANALYSIS_BUNDLE_SCHEMA_VERSION}`);
+	}
+
+	save(jobId: string, bundle: PrWalkthroughAnalysisBundle): { bundle: PrWalkthroughAnalysisBundle; metadata: PrWalkthroughAnalysisBundleMetadata } {
+		const stored = sanitizeBundle({ ...bundle, job_id: jobId });
+		fs.mkdirSync(this.rootDir, { recursive: true });
+		const json = `${JSON.stringify(stored, null, 2)}\n`;
+		fs.writeFileSync(this.filePath(jobId), json, "utf-8");
+		return { bundle: stored, metadata: metadataForBundle(jobId, stored, json) };
+	}
+
+	load(jobId: string): PrWalkthroughAnalysisBundle | null {
+		try {
+			const parsed = JSON.parse(fs.readFileSync(this.filePath(jobId), "utf-8"));
+			return parseBundle(parsed, jobId);
+		} catch {
+			return null;
+		}
+	}
+
+	read(job: PrWalkthroughJobRecord, request: Omit<ReadPrWalkthroughBundleRequest, "sessionId" | "jobId"> = {}): Record<string, unknown> {
+		const bundle = this.load(job.jobId);
+		if (!bundle) throw missingBundleError(job.jobId);
+		const mode = request.mode ?? "manifest";
+		const limit = clampInteger(request.limit, 1, 200, 50);
+		const offset = clampInteger(request.offset, 0, Number.MAX_SAFE_INTEGER, 0);
+		if (mode === "summary" || mode === "manifest") return manifestForBundle(bundle, mode, offset, limit);
+		if (mode === "files") return { ...manifestForBundle(bundle, "files", offset, limit), files: bundle.files.slice(offset, offset + limit).map(fileManifest) };
+		if (mode === "file") {
+			const file = selectFile(bundle, request.path, request.index);
+			if (!file) throw bundleReadError(404, "PR walkthrough bundle file not found", { code: "PR_WALKTHROUGH_BUNDLE_FILE_NOT_FOUND", retryable: false });
+			const hunkOffset = clampInteger(request.hunkOffset ?? request.offset, 0, Number.MAX_SAFE_INTEGER, 0);
+			const hunkLimit = clampInteger(request.hunkLimit ?? request.limit, 1, 200, 50);
+			const hunks = file.hunks.slice(hunkOffset, hunkOffset + hunkLimit);
+			return { bundle: bundleHeader(bundle), file: { ...file, hunks }, hunkOffset, hunkLimit, totalHunks: file.hunks.length, truncated: hunkOffset > 0 || hunkOffset + hunkLimit < file.hunks.length };
+		}
+		throw bundleReadError(400, "Unsupported PR walkthrough bundle read mode", { code: "INVALID_BUNDLE_READ_REQUEST", retryable: false });
+	}
+
+	private filePath(jobId: string): string {
+		return path.join(this.rootDir, `${storageKeyForChangesetId(jobId)}.json`);
+	}
+}
+
+export function createAnalysisBundleFromParsedDiff(job: PrWalkthroughJobRecord, parsedDiff: WalkthroughParsedDiffForYamlMapping): PrWalkthroughAnalysisBundle {
+	const changeset = parsedDiff.changeset ?? {};
+	const files = diffBlocksFromParsedDiff(parsedDiff).map((block, index) => bundleFileFromDiffBlock(block, parsedDiff.files?.[index]));
+	return sanitizeBundle({
+		schema_version: PR_WALKTHROUGH_ANALYSIS_BUNDLE_SCHEMA_VERSION,
+		kind: PR_WALKTHROUGH_ANALYSIS_BUNDLE_KIND,
+		generated_at: new Date().toISOString(),
+		job_id: job.jobId,
+		target: targetForBundle(job.target, changeset),
+		changeset: {
+			base_sha: stringValue(changeset.baseSha) ?? job.target.baseSha,
+			head_sha: stringValue(changeset.headSha) ?? job.target.headSha,
+			title: stringValue(changeset.prTitle) ?? stringValue(changeset.title) ?? job.title,
+			body: stringValue(changeset.prBody) ?? "",
+			files_changed: numberValue(changeset.filesChanged) ?? files.length,
+			additions: numberValue(changeset.additions) ?? sum(files, "additions"),
+			deletions: numberValue(changeset.deletions) ?? sum(files, "deletions"),
+		},
+		limits: (parsedDiff.limits as Record<string, unknown> | undefined) ?? { max_files: 300, max_patch_bytes_per_file: 1_000_000, max_lines_per_file: 2_000 },
+		warnings: [...(parsedDiff.warnings ?? [])],
+		export: parsedDiff.export && typeof parsedDiff.export.provider === "string" ? parsedDiff.export as PrWalkthroughAnalysisBundleExport : undefined,
+		files,
+	});
+}
+
+export function analysisBundleToParsedDiff(bundle: PrWalkthroughAnalysisBundle): WalkthroughParsedDiffForYamlMapping {
+	return {
+		changeset: {
+			baseSha: bundle.changeset.base_sha,
+			headSha: bundle.changeset.head_sha,
+			provider: bundle.target.provider,
+			externalUrl: bundle.target.url,
+			prUrl: bundle.target.url,
+			prNumber: bundle.target.number,
+			prTitle: bundle.changeset.title,
+			prBody: bundle.changeset.body,
+			title: bundle.changeset.title,
+			filesChanged: bundle.changeset.files_changed,
+			additions: bundle.changeset.additions,
+			deletions: bundle.changeset.deletions,
+		},
+		diffBlocks: bundle.files.map(diffBlockFromBundleFile),
+		warnings: bundle.warnings,
+		limits: bundle.limits as WalkthroughParsedDiffForYamlMapping["limits"],
+		export: bundle.export as WalkthroughParsedDiffForYamlMapping["export"],
+	};
+}
+
+export function missingBundleError(jobId: string): Error & { status?: number; extra?: Record<string, unknown> } {
+	return bundleReadError(409, `PR walkthrough analysis bundle is missing or unusable for job ${jobId}. Relaunch the walkthrough so the PR diff can be resolved before analysis.`, {
+		code: "PR_WALKTHROUGH_BUNDLE_MISSING",
+		retryable: true,
+	});
+}
+
+function diffBlocksFromParsedDiff(parsedDiff: WalkthroughParsedDiffForYamlMapping): PrWalkthroughDiffBlock[] {
+	if (Array.isArray(parsedDiff.diffBlocks)) return parsedDiff.diffBlocks.filter(isDiffBlock);
+	const blocks: PrWalkthroughDiffBlock[] = [];
+	for (const file of parsedDiff.files ?? []) {
+		if (!isRecord(file)) continue;
+		if (Array.isArray(file.diffBlocks)) blocks.push(...file.diffBlocks.filter(isDiffBlock));
+		else if (isDiffBlock(file)) blocks.push(file);
+	}
+	return blocks;
+}
+
+function bundleFileFromDiffBlock(block: PrWalkthroughDiffBlock, source: unknown): PrWalkthroughAnalysisBundleFile {
+	const record = isRecord(source) ? source : {};
+	return {
+		id: block.id,
+		path: block.filePath,
+		old_path: block.oldPath ?? null,
+		status: block.status,
+		additions: numberValue(record.additions),
+		deletions: numberValue(record.deletions),
+		is_binary: Boolean(block.isBinary ?? record.isBinary),
+		is_generated: Boolean(block.isGenerated ?? record.isGenerated),
+		is_truncated: Boolean(block.isTruncated ?? record.isTruncated ?? record.truncated),
+		external_url: block.externalUrl,
+		blob_url: block.blobUrl,
+		raw_url: block.rawUrl,
+		contents_url: block.contentsUrl,
+		hunks: block.hunks.map(bundleHunkFromDiffHunk),
+	};
+}
+
+function bundleHunkFromDiffHunk(hunk: PrWalkthroughHunk): PrWalkthroughAnalysisBundleHunk {
+	const parsed = parseHunkHeader(hunk.header);
+	return {
+		id: hunk.id,
+		header: hunk.header,
+		...parsed,
+		lines: hunk.lines.map(line => ({
+			id: line.id,
+			kind: line.kind,
+			side: line.side,
+			old_line: line.oldLine,
+			new_line: line.newLine,
+			text: line.text,
+		})),
+	};
+}
+
+function diffBlockFromBundleFile(file: PrWalkthroughAnalysisBundleFile): PrWalkthroughDiffBlock {
+	return {
+		id: file.id ?? `bundle-${hashText(file.path).slice(0, 12)}`,
+		filePath: file.path,
+		oldPath: file.old_path ?? undefined,
+		status: file.status as PrWalkthroughDiffBlock["status"],
+		isBinary: file.is_binary,
+		isGenerated: file.is_generated,
+		isTruncated: file.is_truncated,
+		externalUrl: file.external_url,
+		blobUrl: file.blob_url,
+		rawUrl: file.raw_url,
+		contentsUrl: file.contents_url,
+		hunks: file.hunks.map(hunk => ({
+			id: hunk.id ?? `hunk-${hashText(`${file.path}\0${hunk.header}`).slice(0, 12)}`,
+			header: hunk.header,
+			lines: hunk.lines.map((line, index): PrWalkthroughDiffLine => ({
+				id: line.id ?? `line-${hashText(`${file.path}\0${hunk.header}\0${index}`).slice(0, 12)}`,
+				side: line.side ?? (line.kind === "add" ? "new" : line.kind === "del" ? "old" : "context"),
+				oldLine: line.old_line,
+				newLine: line.new_line,
+				text: line.text,
+				kind: line.kind,
+			})),
+		})),
+	};
+}
+
+function parseBundle(value: unknown, expectedJobId: string): PrWalkthroughAnalysisBundle | null {
+	if (!isRecord(value)) return null;
+	if (value.schema_version !== PR_WALKTHROUGH_ANALYSIS_BUNDLE_SCHEMA_VERSION || value.kind !== PR_WALKTHROUGH_ANALYSIS_BUNDLE_KIND) return null;
+	if (value.job_id !== expectedJobId || !isRecord(value.target) || !isRecord(value.changeset) || !Array.isArray(value.files)) return null;
+	return sanitizeBundle(value as PrWalkthroughAnalysisBundle);
+}
+
+function sanitizeBundle(bundle: PrWalkthroughAnalysisBundle): PrWalkthroughAnalysisBundle {
+	return sanitizeValue(bundle) as PrWalkthroughAnalysisBundle;
+}
+
+function sanitizeValue(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(sanitizeValue);
+	if (!isRecord(value)) return value;
+	const out: Record<string, unknown> = {};
+	for (const [key, entry] of Object.entries(value)) {
+		if (isSensitiveKey(key)) continue;
+		out[key] = sanitizeValue(entry);
+	}
+	return out;
+}
+
+function isSensitiveKey(key: string): boolean {
+	if (/proof/i.test(key) && !/hash$/i.test(key)) return true;
+	if (key === "header") return false; // diff hunk headers are required for anchor mapping and are not HTTP/auth headers.
+	return /(^|[-_])(token|secret|authorization|auth[-_]?header|auth[-_]?headers|raw[-_]?headers|headers?)($|[-_])/i.test(key)
+		|| /^(token|secret|authorization|auth|headers)$/i.test(key);
+}
+
+function metadataForBundle(jobId: string, bundle: PrWalkthroughAnalysisBundle, json?: string): PrWalkthroughAnalysisBundleMetadata {
+	return {
+		schemaVersion: PR_WALKTHROUGH_ANALYSIS_BUNDLE_SCHEMA_VERSION,
+		kind: PR_WALKTHROUGH_ANALYSIS_BUNDLE_KIND,
+		artifactId: storageKeyForChangesetId(jobId),
+		checksum: createHash("sha256").update(json ?? JSON.stringify(bundle)).digest("hex"),
+		generatedAt: bundle.generated_at,
+		files: bundle.files.length,
+	};
+}
+
+function targetForBundle(target: PrWalkthroughTarget, changeset: Partial<PrWalkthroughChangesetRef>): PrWalkthroughAnalysisBundleTarget {
+	return {
+		provider: target.provider,
+		owner: target.owner,
+		repo: target.repo,
+		number: target.number,
+		url: target.prUrl ?? stringValue(changeset.prUrl) ?? stringValue(changeset.externalUrl),
+	};
+}
+
+function manifestForBundle(bundle: PrWalkthroughAnalysisBundle, mode: string, offset: number, limit: number): Record<string, unknown> {
+	return {
+		mode,
+		bundle: bundleHeader(bundle),
+		changeset: bundle.changeset,
+		limits: bundle.limits,
+		warnings: bundle.warnings,
+		export: bundle.export,
+		fileOffset: offset,
+		fileLimit: limit,
+		totalFiles: bundle.files.length,
+		files: bundle.files.slice(offset, offset + limit).map(fileManifest),
+		truncated: offset > 0 || offset + limit < bundle.files.length,
+	};
+}
+
+function bundleHeader(bundle: PrWalkthroughAnalysisBundle): Record<string, unknown> {
+	return {
+		schema_version: bundle.schema_version,
+		kind: bundle.kind,
+		generated_at: bundle.generated_at,
+		job_id: bundle.job_id,
+		target: bundle.target,
+	};
+}
+
+function fileManifest(file: PrWalkthroughAnalysisBundleFile): Record<string, unknown> {
+	return {
+		path: file.path,
+		old_path: file.old_path,
+		status: file.status,
+		additions: file.additions,
+		deletions: file.deletions,
+		is_binary: file.is_binary,
+		is_generated: file.is_generated,
+		is_truncated: file.is_truncated,
+		hunks: file.hunks.length,
+	};
+}
+
+function selectFile(bundle: PrWalkthroughAnalysisBundle, filePath: string | undefined, index: number | undefined): PrWalkthroughAnalysisBundleFile | undefined {
+	if (filePath) return bundle.files.find(file => file.path === filePath || file.old_path === filePath);
+	if (Number.isInteger(index) && index! >= 0) return bundle.files[index!];
+	return bundle.files[0];
+}
+
+function bundleReadError(status: number, message: string, extra: Record<string, unknown>): Error & { status?: number; extra?: Record<string, unknown> } {
+	const error = new Error(message) as Error & { status?: number; extra?: Record<string, unknown> };
+	error.status = status;
+	error.extra = extra;
+	return error;
+}
+
+function parseHunkHeader(header: string): Pick<PrWalkthroughAnalysisBundleHunk, "old_start" | "old_lines" | "new_start" | "new_lines"> {
+	const match = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/.exec(header);
+	if (!match) return {};
+	return {
+		old_start: Number(match[1]),
+		old_lines: Number(match[2] ?? 1),
+		new_start: Number(match[3]),
+		new_lines: Number(match[4] ?? 1),
+	};
+}
+
+function clampInteger(value: unknown, min: number, max: number, fallback: number): number {
+	const n = typeof value === "number" ? value : typeof value === "string" ? Number(value) : Number.NaN;
+	if (!Number.isFinite(n)) return fallback;
+	return Math.max(min, Math.min(max, Math.trunc(n)));
+}
+
+function sum(files: PrWalkthroughAnalysisBundleFile[], key: "additions" | "deletions"): number {
+	return files.reduce((total, file) => total + (file[key] ?? 0), 0);
+}
+
+function hashText(text: string): string {
+	return createHash("sha1").update(text).digest("hex");
+}
+
+function stringValue(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function isDiffBlock(value: unknown): value is PrWalkthroughDiffBlock {
+	return isRecord(value) && typeof value.id === "string" && typeof value.filePath === "string" && Array.isArray(value.hunks);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}

--- a/src/server/pr-walkthrough/walkthrough-analysis-bundle.ts
+++ b/src/server/pr-walkthrough/walkthrough-analysis-bundle.ts
@@ -152,7 +152,7 @@ export class WalkthroughAnalysisBundleStore {
 
 export function createAnalysisBundleFromParsedDiff(job: PrWalkthroughJobRecord, parsedDiff: WalkthroughParsedDiffForYamlMapping): PrWalkthroughAnalysisBundle {
 	const changeset = parsedDiff.changeset ?? {};
-	const files = diffBlocksFromParsedDiff(parsedDiff).map((block, index) => bundleFileFromDiffBlock(block, parsedDiff.files?.[index]));
+	const files = bundleFilesFromParsedDiff(parsedDiff);
 	return sanitizeBundle({
 		schema_version: PR_WALKTHROUGH_ANALYSIS_BUNDLE_SCHEMA_VERSION,
 		kind: PR_WALKTHROUGH_ANALYSIS_BUNDLE_KIND,
@@ -191,7 +191,21 @@ export function analysisBundleToParsedDiff(bundle: PrWalkthroughAnalysisBundle):
 			additions: bundle.changeset.additions,
 			deletions: bundle.changeset.deletions,
 		},
-		diffBlocks: bundle.files.map(diffBlockFromBundleFile),
+		files: bundle.files.map(file => ({
+			filePath: file.path,
+			oldPath: file.old_path ?? undefined,
+			status: file.status,
+			additions: file.additions,
+			deletions: file.deletions,
+			isBinary: file.is_binary,
+			isGenerated: file.is_generated,
+			isTruncated: file.is_truncated,
+			externalUrl: file.external_url,
+			blobUrl: file.blob_url,
+			rawUrl: file.raw_url,
+			contentsUrl: file.contents_url,
+			diffBlocks: [diffBlockFromBundleFile(file)],
+		})),
 		warnings: bundle.warnings,
 		limits: bundle.limits as WalkthroughParsedDiffForYamlMapping["limits"],
 		export: bundle.export as WalkthroughParsedDiffForYamlMapping["export"],
@@ -205,6 +219,12 @@ export function missingBundleError(jobId: string): Error & { status?: number; ex
 	});
 }
 
+function bundleFilesFromParsedDiff(parsedDiff: WalkthroughParsedDiffForYamlMapping): PrWalkthroughAnalysisBundleFile[] {
+	const sourceFiles = Array.isArray(parsedDiff.files) ? parsedDiff.files.filter(isRecord) : [];
+	if (sourceFiles.length > 0) return sourceFiles.map(bundleFileFromParsedFile).filter((file): file is PrWalkthroughAnalysisBundleFile => Boolean(file));
+	return diffBlocksFromParsedDiff(parsedDiff).map(block => bundleFileFromDiffBlock(block));
+}
+
 function diffBlocksFromParsedDiff(parsedDiff: WalkthroughParsedDiffForYamlMapping): PrWalkthroughDiffBlock[] {
 	if (Array.isArray(parsedDiff.diffBlocks)) return parsedDiff.diffBlocks.filter(isDiffBlock);
 	const blocks: PrWalkthroughDiffBlock[] = [];
@@ -216,18 +236,44 @@ function diffBlocksFromParsedDiff(parsedDiff: WalkthroughParsedDiffForYamlMappin
 	return blocks;
 }
 
-function bundleFileFromDiffBlock(block: PrWalkthroughDiffBlock, source: unknown): PrWalkthroughAnalysisBundleFile {
-	const record = isRecord(source) ? source : {};
+function bundleFileFromParsedFile(file: Record<string, unknown>): PrWalkthroughAnalysisBundleFile | null {
+	const blocks = Array.isArray(file.diffBlocks)
+		? file.diffBlocks.filter(isDiffBlock)
+		: isDiffBlock(file)
+			? [file]
+			: [];
+	const primary = blocks[0];
+	const filePath = stringValue(file.filePath) ?? stringValue(file.path) ?? primary?.filePath;
+	if (!filePath) return null;
+	return {
+		id: stringValue(file.id) ?? primary?.id,
+		path: filePath,
+		old_path: stringValue(file.oldPath) ?? stringValue(file.old_path) ?? primary?.oldPath ?? null,
+		status: stringValue(file.status) ?? primary?.status,
+		additions: numberValue(file.additions),
+		deletions: numberValue(file.deletions),
+		is_binary: Boolean(file.isBinary ?? file.is_binary ?? primary?.isBinary),
+		is_generated: Boolean(file.isGenerated ?? file.is_generated ?? primary?.isGenerated),
+		is_truncated: Boolean(file.isTruncated ?? file.is_truncated ?? file.truncated ?? primary?.isTruncated),
+		external_url: stringValue(file.externalUrl) ?? stringValue(file.external_url) ?? primary?.externalUrl,
+		blob_url: stringValue(file.blobUrl) ?? stringValue(file.blob_url) ?? primary?.blobUrl,
+		raw_url: stringValue(file.rawUrl) ?? stringValue(file.raw_url) ?? primary?.rawUrl,
+		contents_url: stringValue(file.contentsUrl) ?? stringValue(file.contents_url) ?? primary?.contentsUrl,
+		hunks: blocks.flatMap(block => block.hunks.map(bundleHunkFromDiffHunk)),
+	};
+}
+
+function bundleFileFromDiffBlock(block: PrWalkthroughDiffBlock): PrWalkthroughAnalysisBundleFile {
 	return {
 		id: block.id,
 		path: block.filePath,
 		old_path: block.oldPath ?? null,
 		status: block.status,
-		additions: numberValue(record.additions),
-		deletions: numberValue(record.deletions),
-		is_binary: Boolean(block.isBinary ?? record.isBinary),
-		is_generated: Boolean(block.isGenerated ?? record.isGenerated),
-		is_truncated: Boolean(block.isTruncated ?? record.isTruncated ?? record.truncated),
+		additions: undefined,
+		deletions: undefined,
+		is_binary: Boolean(block.isBinary),
+		is_generated: Boolean(block.isGenerated),
+		is_truncated: Boolean(block.isTruncated),
 		external_url: block.externalUrl,
 		blob_url: block.blobUrl,
 		raw_url: block.rawUrl,

--- a/src/ui/components/pr-walkthrough/PrWalkthroughPanel.ts
+++ b/src/ui/components/pr-walkthrough/PrWalkthroughPanel.ts
@@ -2130,6 +2130,33 @@ export class PrWalkthroughPanel extends LitElement {
 		return this.cards.map(card => `${card.id}:${card.phaseId}:${card.diffBlocks.map(block => `${block.id}:${block.filePath}:${block.hunks.length}`).join("|")}`).join(";");
 	}
 
+	private hasCard(cardId: string | undefined): boolean {
+		return !!cardId && this.cards.some(card => card.id === cardId);
+	}
+
+	private hasLineAnchor(cardId: string, diffBlockId: string, lineId: string): boolean {
+		const card = this.cards.find(candidate => candidate.id === cardId);
+		return !!card?.diffBlocks.some(block => block.id === diffBlockId && block.hunks.some(hunk => hunk.lines.some(line => line.id === lineId)));
+	}
+
+	private canRestorePersistedState(parsed: PersistedPrWalkthroughState): boolean {
+		if (this.status === "fixture" || parsed.cardsChecksum === this.cardsChecksum()) return true;
+		const decisionIds = parsed.decisions && typeof parsed.decisions === "object" ? Object.keys(parsed.decisions) : [];
+		const completedIds = Array.isArray(parsed.completedCardIds) ? parsed.completedCardIds : [];
+		const commentCardIds = Array.isArray(parsed.comments) ? parsed.comments.map(comment => comment?.cardId) : [];
+		return [parsed.activeCardId, ...decisionIds, ...completedIds, ...commentCardIds].some(id => this.hasCard(id));
+	}
+
+	private restoreComments(parsed: PersistedPrWalkthroughState, checksumMatches: boolean): PrWalkthroughComment[] {
+		if (!Array.isArray(parsed.comments)) return [];
+		return parsed.comments.filter(comment => {
+			if (!comment || typeof comment.id !== "string" || typeof comment.cardId !== "string" || typeof comment.body !== "string") return false;
+			if (!this.hasCard(comment.cardId)) return false;
+			if (checksumMatches || !comment.diffBlockId || !comment.lineId) return true;
+			return this.hasLineAnchor(comment.cardId, comment.diffBlockId, comment.lineId);
+		});
+	}
+
 	private restorePersistedState(): void {
 		this.resetInteractionState();
 		const key = this.persistenceStorageKey();
@@ -2139,14 +2166,17 @@ export class PrWalkthroughPanel extends LitElement {
 			const raw = localStorage.getItem(key);
 			if (!raw) return;
 			const parsed = JSON.parse(raw) as PersistedPrWalkthroughState;
-			if (this.status !== "fixture" && parsed.cardsChecksum !== this.cardsChecksum()) return;
-			if (parsed.activeCardId && this.cards.some(card => card.id === parsed.activeCardId)) this._activeCardId = parsed.activeCardId;
+			if (!this.canRestorePersistedState(parsed)) return;
+			const checksumMatches = this.status === "fixture" || parsed.cardsChecksum === this.cardsChecksum();
+			if (this.hasCard(parsed.activeCardId)) this._activeCardId = parsed.activeCardId!;
 			if (parsed.diffModeOverride === "split" || parsed.diffModeOverride === "inline") this._diffModeOverride = parsed.diffModeOverride;
-			if (Array.isArray(parsed.comments)) this._comments = parsed.comments.filter(comment => comment && typeof comment.id === "string" && typeof comment.cardId === "string" && typeof comment.body === "string");
-			if (parsed.decisions && typeof parsed.decisions === "object") this._decisions = parsed.decisions;
-			if (Array.isArray(parsed.completedCardIds)) this._completedCardIds = parsed.completedCardIds.filter(id => this.cards.some(card => card.id === id));
+			this._comments = this.restoreComments(parsed, checksumMatches);
+			if (parsed.decisions && typeof parsed.decisions === "object") {
+				this._decisions = Object.fromEntries(Object.entries(parsed.decisions).filter(([cardId, decision]) => this.hasCard(cardId) && (decision?.value === "liked" || decision?.value === "disliked")));
+			}
+			if (Array.isArray(parsed.completedCardIds)) this._completedCardIds = parsed.completedCardIds.filter(id => this.hasCard(id));
 			if (Array.isArray(parsed.dismissedSuggestionIds)) this._dismissedSuggestionIds = parsed.dismissedSuggestionIds.filter(id => typeof id === "string");
-			if (Array.isArray(parsed.collapsedDiffBlockIds)) this._collapsedDiffBlockIds = parsed.collapsedDiffBlockIds.filter(id => typeof id === "string");
+			if (Array.isArray(parsed.collapsedDiffBlockIds)) this._collapsedDiffBlockIds = parsed.collapsedDiffBlockIds.filter(id => typeof id === "string" && this.cards.some(card => card.diffBlocks.some(block => block.id === id)));
 			this.reconcileDecisionCommentInvariants();
 		} catch (err) {
 			console.warn("[pr-walkthrough] failed to restore persisted state", err);

--- a/tests/e2e/ui/pr-walkthrough-real.spec.ts
+++ b/tests/e2e/ui/pr-walkthrough-real.spec.ts
@@ -13,6 +13,7 @@ interface MockWalkthroughState {
 	previewCalls: unknown[];
 	submitCalls: unknown[];
 	resolveDelay?: Promise<void>;
+	unstableJobTabId?: boolean;
 	jobsByChildSession?: Map<string, Record<string, any>>;
 	jobsById?: Map<string, Record<string, any>>;
 }
@@ -135,6 +136,43 @@ function activeCard(page: Page): Locator {
 	return walkthroughPanel(page).locator(`${tid("pr-walkthrough-card")}[data-active="true"]`).first();
 }
 
+async function activeCardId(page: Page): Promise<string> {
+	return activeCard(page).getAttribute("data-card-id").then(value => value || "");
+}
+
+function railCard(page: Page, title: string): Locator {
+	return walkthroughPanel(page).locator(`${tid("pr-walkthrough-card-step")}[title="${title}"], ${tid("pr-walkthrough-card-dot")}[title*="${title}"]`).first();
+}
+
+async function recordWalkthroughDraftEvents(page: Page) {
+	await page.evaluate(() => {
+		(window as any).__walkthroughDraftEvents = [];
+		(window as any).__walkthroughCompleteEvents = [];
+		document.addEventListener("pr-walkthrough-draft-change", (event) => {
+			(window as any).__walkthroughDraftEvents.push((event as CustomEvent).detail);
+		});
+		document.addEventListener("pr-walkthrough-complete", (event) => {
+			(window as any).__walkthroughCompleteEvents.push((event as CustomEvent).detail);
+		});
+	});
+}
+
+async function submitAgentYamlForJob(page: Page, job: Record<string, any>) {
+	const response = await page.evaluate(async ({ sessionId, jobId }) => {
+		const resp = await fetch("/api/internal/pr-walkthrough/submit-yaml", {
+			method: "POST",
+			headers: { "Content-Type": "application/json", "Authorization": `Bearer ${localStorage.getItem("gateway.token") || "localhost"}` },
+			body: JSON.stringify({
+				sessionId,
+				jobId,
+				yaml: "schema_version: 1\nwalkthrough:\n  review_chunks: []\n",
+			}),
+		});
+		return { ok: resp.ok, status: resp.status, text: await resp.text().catch(() => "") };
+	}, { sessionId: job.childSessionId, jobId: job.jobId });
+	expect(response.ok, `agent-produced YAML submit should succeed: ${response.status} ${response.text}`).toBe(true);
+}
+
 async function installMockWalkthroughApi(page: Page, state: MockWalkthroughState) {
 	state.jobsByChildSession = new Map();
 	state.jobsById = new Map();
@@ -182,7 +220,7 @@ async function installMockWalkthroughApi(page: Page, state: MockWalkthroughState
 				cwd: "",
 				target: { provider: "github", owner: "SuuBro", repo: "bobbit", number: Number(prNumber), prUrl: requestBody.prUrl || REAL_PR_URL, canonicalKey: targetKey },
 				changesetId,
-				tabId: `walkthrough:${encodeURIComponent(changesetId)}`,
+				tabId: state.unstableJobTabId ? `walkthrough:${encodeURIComponent(targetKey)}` : `walkthrough:${encodeURIComponent(changesetId)}`,
 				status: state.mode === "missing" ? "error" : "waiting_for_yaml",
 				title: childTitle,
 				createdAt: new Date().toISOString(),
@@ -293,7 +331,7 @@ async function focusChildWalkthroughSession(page: Page, childSessionId: string) 
 	await expect.poll(() => selectedSessionId(page), { timeout: 10_000 }).toBe(childSessionId);
 }
 
-async function publishWalkthroughJobUpdate(page: Page, state: MockWalkthroughState, childSessionId: string) {
+async function publishWalkthroughJobUpdate(page: Page, state: MockWalkthroughState, childSessionId: string, options: { injectTab?: boolean } = {}) {
 	const job = state.jobsByChildSession?.get(childSessionId);
 	expect(job, `expected mock job for child session ${childSessionId}`).toBeTruthy();
 	const payload = job!.status === "ready" ? (state.mode === "warnings" ? warningPayload : successPayload) : undefined;
@@ -316,10 +354,10 @@ async function publishWalkthroughJobUpdate(page: Page, state: MockWalkthroughSta
 			errorCode: job!.error?.code,
 		},
 	};
-	await page.evaluate(({ detail, tab }) => {
+	await page.evaluate(({ detail, tab, injectTab }) => {
 		document.dispatchEvent(new CustomEvent("pr-walkthrough-job-updated", { detail: { job: detail } }));
 		const s = (window as any).__bobbitState ?? (window as any).bobbitState;
-		if (s) {
+		if (injectTab && s) {
 			s.panelTabsBySession ||= {};
 			s.panelWorkspaceActiveBySession ||= {};
 			s.panelTabsBySession[detail.childSessionId] = [tab];
@@ -328,7 +366,7 @@ async function publishWalkthroughJobUpdate(page: Page, state: MockWalkthroughSta
 			s.activePanelTabId = tab.id;
 		}
 		(window as any).__bobbitRenderApp?.();
-	}, { detail: job, tab });
+	}, { detail: job, tab, injectTab: options.injectTab !== false });
 }
 
 async function markWalkthroughReady(page: Page, state: MockWalkthroughState, childSessionId: string) {
@@ -444,6 +482,74 @@ test.describe("real PR walkthrough browser UX", () => {
 		await expect(walkthroughPanel(standalone).getByTestId("pr-walkthrough-card-title"), "standalone route should render the same resolved cards").toContainText("Resolved changeset overview", { timeout: 15_000 });
 		await expect(walkthroughPanel(standalone).getByTestId("pr-walkthrough-comment").filter({ hasText: commentBody }), "standalone route should restore the same in-progress draft").toBeVisible();
 		await standalone.close();
+	});
+
+	test("agent-produced ready panel records Like decisions through reload and export", async ({ page }) => {
+		const state: MockWalkthroughState = {
+			mode: "success",
+			resolveCalls: [],
+			previewCalls: [],
+			submitCalls: [],
+			resolveDelay: new Promise<void>(() => undefined),
+			unstableJobTabId: true,
+		};
+		const job = await openRealWalkthrough(page, state);
+		await expect(page.getByTestId("pr-walkthrough-waiting"), "session-hosted walkthrough should remain waiting until the analysis agent submits YAML").toBeVisible({ timeout: 10_000 });
+
+		await submitAgentYamlForJob(page, job);
+		await publishWalkthroughJobUpdate(page, state, String(job.childSessionId), { injectTab: false });
+		await expect(activeCard(page).getByTestId("pr-walkthrough-card-title"), "agent-produced cards should open after submit_pr_walkthrough_yaml publishes the panel").toContainText("Resolved changeset overview", { timeout: 10_000 });
+		await expect.poll(() => activeCardId(page), { timeout: 5_000 }).toBe("real-orientation");
+		await recordWalkthroughDraftEvents(page);
+
+		await walkthroughPanel(page).getByTestId("pr-walkthrough-like").first().click();
+		await expect.poll(() => activeCardId(page), {
+			timeout: 5_000,
+			message: "Like should advance the session-hosted walkthrough to the next card",
+		}).toBe("real-design");
+
+		await publishWalkthroughJobUpdate(page, state, String(job.childSessionId), { injectTab: false });
+		await expect.poll(() => activeCardId(page), {
+			timeout: 5_000,
+			message: "repeat ready job updates should keep the canonical panel and liked draft active",
+		}).toBe("real-design");
+
+		const firstRailStep = railCard(page, "Resolved changeset overview");
+		await expect(firstRailStep, "liked rail dot should mark the first agent-produced card as liked").toHaveClass(/liked/);
+		await expect(firstRailStep.locator(".card-dot-rail svg, svg.dot-icon"), "liked rail dot should render the thumbs-up status icon").toBeVisible();
+		await firstRailStep.click();
+		await expect.poll(() => activeCardId(page), { timeout: 5_000 }).toBe("real-orientation");
+		await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-like"), "Like should mark the card selected after returning to it").toHaveClass(/decision-selected/);
+		await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-like")).toHaveAttribute("aria-pressed", "true");
+		await expect.poll(() => page.evaluate(() => (window as any).__walkthroughDraftEvents?.some((draft: any) => draft?.decisions?.["real-orientation"]?.value === "liked") ?? false), {
+			timeout: 5_000,
+			message: "Like should emit a draft-change event containing the liked decision",
+		}).toBe(true);
+
+		await walkthroughPanel(page).getByTestId("pr-walkthrough-like").first().click();
+		await expect.poll(() => activeCardId(page), { timeout: 5_000 }).toBe("real-design");
+		await walkthroughPanel(page).getByTestId("pr-walkthrough-like").first().click();
+		await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-audit"), "liking every review card should complete into the audit draft").toBeVisible({ timeout: 10_000 });
+		await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-draft"), "audit draft should include accepted/liked context").toContainText(/approved|liked|accepted/i);
+		await expect.poll(() => page.evaluate(() => (window as any).__walkthroughCompleteEvents?.length ?? 0), {
+			timeout: 5_000,
+			message: "completing the agent-produced card set should emit a complete event",
+		}).toBeGreaterThan(0);
+
+		await page.reload();
+		await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-card-title"), "agent-produced walkthrough should restore after reload").toContainText("Audit and export", { timeout: 15_000 });
+		const restoredFirstRailStep = railCard(page, "Resolved changeset overview");
+		await expect(restoredFirstRailStep, "liked rail state should survive reload").toHaveClass(/liked/);
+		await restoredFirstRailStep.click();
+		await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-like"), "liked decision selection should survive reload").toHaveClass(/decision-selected/);
+		await expect(walkthroughPanel(page).getByTestId("pr-walkthrough-like")).toHaveAttribute("aria-pressed", "true");
+
+		await railCard(page, "Audit and export").click();
+		await walkthroughPanel(page).getByTestId("pr-walkthrough-submit-review").click();
+		await expect(page.getByTestId("pr-walkthrough-export-preview"), "export preview should remain usable with the persisted liked draft").toBeVisible({ timeout: 10_000 });
+		await expect.poll(() => state.previewCalls.length, { timeout: 5_000 }).toBe(1);
+		expect((state.previewCalls[0] as any)?.decisions?.["real-orientation"]?.value, "export draft should include the persisted first-card Like decision").toBe("liked");
+		expect((state.previewCalls[0] as any)?.decisions?.["real-design"]?.value, "export draft should include the completed second-card Like decision").toBe("liked");
 	});
 
 	test("previews GitHub export and submits only after the explicit confirmation click", async ({ page }) => {

--- a/tests/e2e/ui/pr-walkthrough-session-ux.spec.ts
+++ b/tests/e2e/ui/pr-walkthrough-session-ux.spec.ts
@@ -2,6 +2,7 @@ import type { Page, Route } from "@playwright/test";
 import { test, expect } from "../gateway-harness.js";
 import { apiFetch, createGoal, deleteGoal, startTeam, teardownTeam, waitForSessionStatus } from "../e2e-setup.js";
 import { openApp, createSessionViaUI, sendMessage, navigateToHash } from "./ui-helpers.js";
+import { filtersButton, clickShowArchivedToggle } from "./utils/sidebar-filters.js";
 
 type LaunchJob = {
 	jobId: string;
@@ -195,6 +196,46 @@ async function ensureTeamLeadRole() {
 	expect([200, 201, 409], `team-lead role fixture should be creatable: ${roleResponse.status}`).toContain(roleResponse.status);
 }
 
+async function markWalkthroughChildArchivedInClient(page: Page, job: LaunchJob) {
+	await page.evaluate((input) => {
+		const appState = (window as any).bobbitState ?? (window as any).__bobbitState;
+		if (!appState) throw new Error("bobbit state unavailable");
+		const now = Date.now();
+		const parent = appState.gatewaySessions.find((session: any) => session.id === input.parentSessionId);
+		let child = appState.gatewaySessions.find((session: any) => session.id === input.childSessionId);
+		if (!child) {
+			child = {
+				id: input.childSessionId,
+				title: input.title,
+				cwd: parent?.cwd || "",
+				projectId: parent?.projectId,
+				createdAt: now,
+				lastActivity: now,
+				clientCount: 0,
+			};
+			appState.gatewaySessions.push(child);
+		}
+		Object.assign(child, {
+			title: input.title,
+			status: "terminated",
+			archived: true,
+			archivedAt: now,
+			parentSessionId: input.parentSessionId,
+			childKind: "pr-walkthrough",
+			readOnly: true,
+			walkthroughJobId: input.jobId,
+			walkthroughChangesetId: input.changesetId,
+		});
+		appState.archivedSessions = [
+			...appState.archivedSessions.filter((session: any) => session.id !== input.childSessionId),
+			{ ...child },
+		];
+		appState.showArchived = false;
+		localStorage.setItem("bobbit-show-archived", "false");
+		(window as any).__bobbitRenderApp?.();
+	}, job);
+}
+
 test.describe("Session-hosted PR walkthrough UX regressions", () => {
 	test("normal session advertises walkthrough slash command and intercepts it in the UI", async ({ page }) => {
 		await installWalkthroughLaunchFixture(page);
@@ -273,13 +314,44 @@ test.describe("Session-hosted PR walkthrough UX regressions", () => {
 		}
 	});
 
+	test("terminated walkthrough child is hidden until Show Archived is enabled", async ({ page }) => {
+		await installWalkthroughLaunchFixture(page);
+		await page.addInitScript(() => localStorage.setItem("bobbit-show-archived", "false"));
+		await page.setViewportSize({ width: 1600, height: 900 });
+		await openApp(page);
+		await createSessionViaUI(page);
+		const parentSessionId = await activeSessionId(page);
+
+		const job = await launchWalkthroughFromActiveSession(page, "779");
+		const childRow = page.locator(`[data-session-id="${job.childSessionId}"]`);
+		await expect(childRow, "live walkthrough child should initially be visible").toHaveCount(1, { timeout: 10_000 });
+
+		const deleteResponse = await apiFetch(`/api/sessions/${encodeURIComponent(job.childSessionId)}`, { method: "DELETE" });
+		expect(deleteResponse.ok, `walkthrough child should terminate cleanly: ${deleteResponse.status}`).toBe(true);
+		await navigateToHash(page, `#/session/${parentSessionId}`);
+		await markWalkthroughChildArchivedInClient(page, job);
+
+		await expect(childRow, "terminated walkthrough child should be hidden when Show Archived is off").toHaveCount(0, { timeout: 5_000 });
+
+		const archivedToggle = filtersButton(page);
+		await expect(archivedToggle).toBeVisible({ timeout: 10_000 });
+		await clickShowArchivedToggle(page);
+		await expect.poll(() => page.evaluate(() => (window as any).bobbitState?.showArchived === true), { timeout: 10_000 }).toBe(true);
+		await expect(childRow, "terminated walkthrough child should appear when Show Archived is on").toHaveCount(1, { timeout: 10_000 });
+		await expectChildNestedUnderParent(page, parentSessionId, job.childSessionId, "archived walkthrough child");
+
+		await clickShowArchivedToggle(page);
+		await expect.poll(() => page.evaluate(() => (window as any).bobbitState?.showArchived === false), { timeout: 10_000 }).toBe(true);
+		await expect(childRow, "terminated walkthrough child should hide again when Show Archived is toggled off").toHaveCount(0, { timeout: 5_000 });
+	});
+
 	test("terminated walkthrough child remains archived read-only", async ({ page }) => {
 		await installWalkthroughLaunchFixture(page);
 		await page.setViewportSize({ width: 1600, height: 900 });
 		await openApp(page);
 		await createSessionViaUI(page);
 
-		const job = await launchWalkthroughFromActiveSession(page, "779");
+		const job = await launchWalkthroughFromActiveSession(page, "780");
 		const deleteResponse = await apiFetch(`/api/sessions/${encodeURIComponent(job.childSessionId)}`, { method: "DELETE" });
 		expect(deleteResponse.ok, `walkthrough child should terminate cleanly: ${deleteResponse.status}`).toBe(true);
 

--- a/tests/pr-walkthrough-agent-manager.test.ts
+++ b/tests/pr-walkthrough-agent-manager.test.ts
@@ -10,6 +10,7 @@ let tempDir = "";
 
 const { WalkthroughAgentStore, rotateSubmissionProofForRestoredJob, verifySubmissionProof } = await import("../src/server/pr-walkthrough/walkthrough-agent-store.ts");
 const { WalkthroughAgentManager } = await import("../src/server/pr-walkthrough/walkthrough-agent-manager.ts");
+const { createAnalysisBundleFromParsedDiff } = await import("../src/server/pr-walkthrough/walkthrough-analysis-bundle.ts");
 const { evaluateWalkthroughReadonlyCommand } = await import("../src/server/pr-walkthrough/walkthrough-readonly-policy.ts");
 const { handlePrWalkthroughApiRoute } = await import("../src/server/pr-walkthrough/routes.ts");
 const { getWalkthrough } = await import("../src/server/pr-walkthrough/walkthrough-store.ts");
@@ -241,10 +242,11 @@ describe("WalkthroughAgentManager", () => {
 	});
 
 	it("launch creates a waiting child job and dedupes by parent plus target", async () => {
+		const fixture = createGitDiffFixture();
 		const sessionManager = makeSessionManager();
 		const manager = new WalkthroughAgentManager({ defaultCwd: tempDir, stateDir: tempDir, sessionManager, store: new WalkthroughAgentStore(tempDir) });
 
-		const first = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42" });
+		const first = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42", baseSha: fixture.baseSha, headSha: fixture.headSha });
 		assert.equal(first.created, true);
 		assert.equal(first.status, "waiting_for_yaml");
 		assert.equal(first.job.parentSessionId, "parent");
@@ -255,17 +257,18 @@ describe("WalkthroughAgentManager", () => {
 		assert.equal(child.readOnly, true);
 		assert.deepEqual(child.allowedTools, ["readonly_bash", "read_pr_walkthrough_bundle", "submit_pr_walkthrough_yaml"]);
 
-		const second = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42" });
+		const second = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42", baseSha: fixture.baseSha, headSha: fixture.headSha });
 		assert.equal(second.created, false);
 		assert.equal(second.childSessionId, first.childSessionId);
 	});
 
 	it("number-only GitHub launches infer owner/repo before child env and persistence", async () => {
+		const fixture = createGitDiffFixture();
 		addGithubOrigin("acme", "widgets");
 		const sessionManager = makeSessionManager();
 		const manager = new WalkthroughAgentManager({ defaultCwd: tempDir, stateDir: tempDir, sessionManager, store: new WalkthroughAgentStore(tempDir) });
 
-		const launch = await manager.launch({ sessionId: "parent", prNumber: 42 });
+		const launch = await manager.launch({ sessionId: "parent", prNumber: 42, baseSha: fixture.baseSha, headSha: fixture.headSha });
 
 		assert.equal(launch.job.target.canonicalKey, "github:acme/widgets#42");
 		assert.equal(launch.job.target.owner, "acme");
@@ -322,6 +325,37 @@ describe("WalkthroughAgentManager", () => {
 		assert.match(`${child.rolePrompt}\n${sessionManager.prompts.join("\n")}`, /read_pr_walkthrough_bundle/);
 	});
 
+	it("analysis bundle preserves parsed files without diff blocks and avoids metadata index drift", () => {
+		const bundle = createAnalysisBundleFromParsedDiff({
+			jobId: "job-bundle-files",
+			parentSessionId: "parent",
+			childSessionId: "child",
+			cwd: tempDir,
+			target: { provider: "github", canonicalKey: "github:acme/widgets#42", owner: "acme", repo: "widgets", number: 42, prUrl: "https://github.com/acme/widgets/pull/42" },
+			changesetId: "github:acme/widgets#42",
+			tabId: "walkthrough:github:acme/widgets#42",
+			status: "waiting_for_yaml",
+			title: "PR #42 Walkthrough",
+		}, {
+			changeset: { baseSha: "base", headSha: "head", provider: "github", filesChanged: 2, additions: 8, deletions: 2 },
+			files: [
+				{ filePath: "assets/logo.png", status: "modified", additions: 0, deletions: 0, isBinary: true, isGenerated: false, isTruncated: true, blobUrl: "https://example.test/blob", rawUrl: "https://example.test/raw", contentsUrl: "https://example.test/contents", diffBlocks: [] },
+				{ filePath: "src/demo.ts", status: "modified", additions: 8, deletions: 2, isBinary: false, isGenerated: true, isTruncated: false, externalUrl: "https://example.test/diff", diffBlocks: [{ id: "block-demo", filePath: "src/demo.ts", status: "modified", isGenerated: true, hunks: [{ id: "hunk-demo", header: "@@ -1,1 +1,2 @@", lines: [{ id: "line-demo", kind: "add", side: "new", newLine: 2, text: "export const value = 2;" }] }] }] },
+			],
+		});
+
+		assert.equal(bundle.files.length, 2);
+		assert.deepEqual(bundle.files.map(file => file.path), ["assets/logo.png", "src/demo.ts"]);
+		assert.equal(bundle.files[0].hunks.length, 0, "files without diff blocks must remain in the launch bundle");
+		assert.equal(bundle.files[0].is_binary, true);
+		assert.equal(bundle.files[0].is_truncated, true);
+		assert.equal(bundle.files[0].blob_url, "https://example.test/blob");
+		assert.equal(bundle.files[1].additions, 8, "metadata must come from its own parsed file, not flattened diff-block index");
+		assert.equal(bundle.files[1].deletions, 2);
+		assert.equal(bundle.files[1].is_generated, true);
+		assert.equal(bundle.files[1].hunks.length, 1);
+	});
+
 	it("launch-time diff resolution failure returns a structured job error without creating a waiting child agent", async () => {
 		const sessionManager = makeSessionManager();
 		const store = new WalkthroughAgentStore(tempDir);
@@ -357,6 +391,7 @@ describe("WalkthroughAgentManager", () => {
 	});
 
 	it("launch spawn-pins the walkthrough child to the parent session model", async () => {
+		const fixture = createGitDiffFixture();
 		const sessionManager = makeSessionManager();
 		const seenOpts: Record<string, unknown>[] = [];
 		const originalCreateSession = sessionManager.createSession.bind(sessionManager);
@@ -372,7 +407,7 @@ describe("WalkthroughAgentManager", () => {
 			resolveSessionModel: sessionId => sessionId === "parent" ? { provider: "anthropic", modelId: "claude-opus-4-1" } : undefined,
 		});
 
-		await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42" });
+		await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42", baseSha: fixture.baseSha, headSha: fixture.headSha });
 
 		assert.equal(seenOpts[0].initialModel, "anthropic/claude-opus-4-1");
 	});
@@ -426,6 +461,7 @@ describe("WalkthroughAgentManager", () => {
 	});
 
 	it("concurrent duplicate launches share one child job", async () => {
+		const fixture = createGitDiffFixture();
 		const sessionManager = makeSessionManager();
 		const originalCreateSession = sessionManager.createSession.bind(sessionManager);
 		let createCount = 0;
@@ -438,7 +474,7 @@ describe("WalkthroughAgentManager", () => {
 		};
 		const manager = new WalkthroughAgentManager({ defaultCwd: tempDir, stateDir: tempDir, sessionManager, store: new WalkthroughAgentStore(tempDir) });
 
-		const launches = Array.from({ length: 8 }, () => manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42" }));
+		const launches = Array.from({ length: 8 }, () => manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42", baseSha: fixture.baseSha, headSha: fixture.headSha }));
 		await new Promise(resolve => setTimeout(resolve, 0));
 		releaseCreate?.();
 		const results = await Promise.all(launches);
@@ -466,10 +502,11 @@ describe("WalkthroughAgentManager", () => {
 	});
 
 	it("launch prompts include the required YAML schema fields and enums", async () => {
+		const fixture = createGitDiffFixture();
 		const sessionManager = makeSessionManager();
 		const manager = new WalkthroughAgentManager({ defaultCwd: tempDir, stateDir: tempDir, sessionManager, store: new WalkthroughAgentStore(tempDir) });
 
-		const launch = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42" });
+		const launch = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42", baseSha: fixture.baseSha, headSha: fixture.headSha });
 		const child = sessionManager.sessions.get(launch.childSessionId);
 		const promptText = `${child.rolePrompt}\n${sessionManager.prompts.join("\n")}`;
 		assert.match(promptText, /schema_version: 1/);
@@ -481,6 +518,7 @@ describe("WalkthroughAgentManager", () => {
 	});
 
 	it("launch with local SHAs skips GitHub preflight and waits for YAML", async () => {
+		const fixture = createGitDiffFixture();
 		const sessionManager = makeSessionManager();
 		const manager = new WalkthroughAgentManager({
 			defaultCwd: tempDir,
@@ -490,7 +528,7 @@ describe("WalkthroughAgentManager", () => {
 			preflightGithubLaunch: () => { throw new Error("should not hit network when local SHAs are supplied"); },
 		});
 
-		const launch = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42", baseSha: "abcdef1", headSha: "1234567" });
+		const launch = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42", baseSha: fixture.baseSha, headSha: fixture.headSha });
 		assert.equal(launch.status, "waiting_for_yaml");
 		assert.equal(launch.job.target.canonicalKey, "github:acme/widgets#42");
 	});
@@ -514,17 +552,19 @@ describe("WalkthroughAgentManager", () => {
 	});
 
 	it("launch kickoff failures are surfaced in the child transcript", async () => {
+		const fixture = createGitDiffFixture();
 		const sessionManager = makeSessionManager();
 		sessionManager.enqueuePrompt = () => ({ success: false, error: "dispatch exploded" });
 		const manager = new WalkthroughAgentManager({ defaultCwd: tempDir, stateDir: tempDir, sessionManager, store: new WalkthroughAgentStore(tempDir) });
 
-		const launch = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42" });
+		const launch = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42", baseSha: fixture.baseSha, headSha: fixture.headSha });
 		assert.equal(launch.status, "error");
 		assert.equal(launch.job.error?.code, "PROMPT_DISPATCH_FAILED");
 		assert.match(sessionManager.prompts.at(-1) ?? "", /kickoff prompt dispatch failed|PROMPT_DISPATCH_FAILED|dispatch exploded/i);
 	});
 
 	it("runtime failures before YAML transition the job to AGENT_RUNTIME_FAILED", async () => {
+		const fixture = createGitDiffFixture();
 		const sessionManager = makeSessionManager();
 		const events: Record<string, unknown>[] = [];
 		const manager = new WalkthroughAgentManager({
@@ -534,7 +574,7 @@ describe("WalkthroughAgentManager", () => {
 			store: new WalkthroughAgentStore(tempDir),
 			broadcast: event => events.push(event),
 		});
-		const launch = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42" });
+		const launch = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42", baseSha: fixture.baseSha, headSha: fixture.headSha });
 		const promptCountAfterLaunch = sessionManager.prompts.length;
 
 		sessionManager.sessions.get(launch.childSessionId).emit({ type: "message_end", message: { role: "assistant", stopReason: "error", errorMessage: "model stream crashed" } });
@@ -553,6 +593,7 @@ describe("WalkthroughAgentManager", () => {
 	});
 
 	it("retry after pre-child createSession failure creates a fresh child job", async () => {
+		const fixture = createGitDiffFixture();
 		const sessionManager = makeSessionManager();
 		const store = new WalkthroughAgentStore(tempDir);
 		const originalCreateSession = sessionManager.createSession.bind(sessionManager);
@@ -567,14 +608,14 @@ describe("WalkthroughAgentManager", () => {
 		const manager = new WalkthroughAgentManager({ defaultCwd: tempDir, stateDir: tempDir, sessionManager, store });
 
 		await assert.rejects(
-			() => manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42" }),
+			() => manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42", baseSha: fixture.baseSha, headSha: fixture.headSha }),
 			/create failed before child persisted/,
 		);
 		const failedJob = store.findByParentAndTarget("parent", "github:acme/widgets#42");
 		assert.equal(failedJob?.status, "error");
 		assert.equal(sessionManager.sessions.has(failedJob!.childSessionId), false);
 
-		const retry = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42" });
+		const retry = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42", baseSha: fixture.baseSha, headSha: fixture.headSha });
 		assert.equal(retry.created, true);
 		assert.equal(retry.status, "waiting_for_yaml");
 		assert.notEqual(retry.childSessionId, failedJob?.childSessionId);
@@ -582,9 +623,10 @@ describe("WalkthroughAgentManager", () => {
 	});
 
 	it("internal submit stores validation failures without publishing cards", async () => {
+		const fixture = createGitDiffFixture();
 		const sessionManager = makeSessionManager();
 		const manager = new WalkthroughAgentManager({ defaultCwd: tempDir, stateDir: tempDir, sessionManager, store: new WalkthroughAgentStore(tempDir) });
-		const launch = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42" });
+		const launch = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42", baseSha: fixture.baseSha, headSha: fixture.headSha });
 
 		const result = await manager.submitYaml({ sessionId: launch.childSessionId, jobId: launch.jobId, yaml: "schema_version: 1\n", submissionProof: submitProof(sessionManager, launch.childSessionId) });
 		assert.equal(result.ok, false);
@@ -613,46 +655,34 @@ describe("WalkthroughAgentManager", () => {
 		assert.equal(job?.payloadUpdatedAt, publishedAt);
 	});
 
-	it("submit-yaml rejects SHA mismatches against authoritative resolved PR metadata", async () => {
-		const authoritativeBase = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-		const authoritativeHead = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+	it("submit-yaml rejects SHA mismatches against authoritative launch bundle metadata", async () => {
+		const fixture = createGitDiffFixture();
 		const sessionManager = makeSessionManager();
-		const manager = new WalkthroughAgentManager({
-			defaultCwd: tempDir,
-			stateDir: tempDir,
-			sessionManager,
-			store: new WalkthroughAgentStore(tempDir),
-			resolveDiffForYamlMapping: () => ({
-				changeset: { baseSha: authoritativeBase, headSha: authoritativeHead, provider: "github" },
-				files: [],
-			}),
-		});
-		const launch = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42" });
+		const manager = new WalkthroughAgentManager({ defaultCwd: tempDir, stateDir: tempDir, sessionManager, store: new WalkthroughAgentStore(tempDir) });
+		const launch = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42", baseSha: fixture.baseSha, headSha: fixture.headSha });
 
 		const mismatch = await manager.submitYaml({
 			sessionId: launch.childSessionId,
 			jobId: launch.jobId,
-			yaml: validYaml(42, { baseSha: "ccccccc", headSha: authoritativeHead.slice(0, 7) }),
+			yaml: validYaml(42, { baseSha: "ccccccc", headSha: fixture.headSha.slice(0, 7) }),
 			submissionProof: submitProof(sessionManager, launch.childSessionId),
 		});
 		assert.equal(mismatch.ok, false);
 		assert.equal(mismatch.status, "validation_failed");
 		const mismatchMessage = mismatch.validation.errors.map(error => `${error.path}: ${error.message}`).join("\n");
-		assert.match(mismatchMessage, /\$\.pr\.base_sha: Must match the authoritative PR base SHA/);
-		assert.match(mismatchMessage, /regenerate all hunk_header, line_range, and anchor references/);
-		assert.match(mismatchMessage, /do not only patch this SHA/);
+		assert.match(mismatchMessage, /\$\.pr\.base_sha: Must match (the authoritative PR|launch target) base SHA/);
 		assert.equal(fs.existsSync(path.join(tempDir, "pr-walkthrough", "v1")), false);
 
 		const accepted = await manager.submitYaml({
 			sessionId: launch.childSessionId,
 			jobId: launch.jobId,
-			yaml: validYaml(42, { baseSha: authoritativeBase.slice(0, 7), headSha: authoritativeHead.slice(0, 7) }),
+			yaml: validYaml(42, { baseSha: fixture.baseSha.slice(0, 7), headSha: fixture.headSha.slice(0, 7) }),
 			submissionProof: submitProof(sessionManager, launch.childSessionId),
 		});
 		assert.equal(accepted.ok, true);
 		const stored = getWalkthrough(launch.changesetId, tempDir);
-		assert.equal(stored?.changeset.baseSha, authoritativeBase);
-		assert.equal(stored?.changeset.headSha, authoritativeHead);
+		assert.equal(stored?.changeset.baseSha, fixture.baseSha);
+		assert.equal(stored?.changeset.headSha, fixture.headSha);
 	});
 
 	it("internal submit accepts valid YAML with the real schema mapper and keeps the child session alive", async () => {
@@ -735,31 +765,46 @@ describe("WalkthroughAgentManager", () => {
 		assert.match(result.body.message, /bundle/i);
 	});
 
-	it("submit-yaml converts diff resolution failures into structured job errors", async () => {
+	it("github submit without analysis bundle metadata fails before custom or submit-time diff fallback", async () => {
 		const sessionManager = makeSessionManager();
+		const store = new WalkthroughAgentStore(tempDir);
+		const proof = "scoped-proof";
+		store.create({
+			jobId: "job-no-bundle-metadata",
+			parentSessionId: "parent",
+			childSessionId: "child-no-bundle-metadata",
+			cwd: tempDir,
+			target: { provider: "github", canonicalKey: "github:acme/widgets#42", owner: "acme", repo: "widgets", number: 42, prUrl: "https://github.com/acme/widgets/pull/42", baseSha: "abcdef1", headSha: "1234567" },
+			changesetId: "github:acme/widgets#42",
+			tabId: "walkthrough:github:acme/widgets#42",
+			status: "waiting_for_yaml",
+			title: "PR #42 Walkthrough",
+			submissionProofHash: submitProofHash("job-no-bundle-metadata", "child-no-bundle-metadata", proof),
+		});
+		sessionManager.sessions.set("child-no-bundle-metadata", { id: "child-no-bundle-metadata", cwd: tempDir, status: "idle" });
 		const manager = new WalkthroughAgentManager({
 			defaultCwd: tempDir,
 			stateDir: tempDir,
 			sessionManager,
-			store: new WalkthroughAgentStore(tempDir),
-			resolveDiffForYamlMapping: () => { throw new Error("GitHub API rate limit exceeded"); },
+			store,
+			resolveDiffForYamlMapping: () => { throw new Error("custom submit-time resolver should not be called"); },
 		});
-		const launch = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42" });
 
 		await assert.rejects(
-			() => manager.submitYaml({ sessionId: launch.childSessionId, jobId: launch.jobId, yaml: validYaml(), submissionProof: submitProof(sessionManager, launch.childSessionId) }),
-			/GitHub API rate limit exceeded/,
+			() => manager.submitYaml({ sessionId: "child-no-bundle-metadata", jobId: "job-no-bundle-metadata", yaml: validYaml(), submissionProof: proof }),
+			/PR walkthrough analysis bundle is missing or unusable/,
 		);
-		const job = manager.getJob(launch.jobId);
+		const job = manager.getJob("job-no-bundle-metadata");
 		assert.equal(job?.status, "error");
-		assert.equal(job?.error?.code, "GITHUB_RATE_LIMITED");
+		assert.equal(job?.error?.code, "PR_WALKTHROUGH_BUNDLE_MISSING");
 		assert.equal(job?.error?.retryable, true);
 	});
 
 	it("internal submit validates YAML identity against the launch target", async () => {
+		const fixture = createGitDiffFixture();
 		const sessionManager = makeSessionManager();
 		const manager = new WalkthroughAgentManager({ defaultCwd: tempDir, stateDir: tempDir, sessionManager, store: new WalkthroughAgentStore(tempDir) });
-		const launch = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42" });
+		const launch = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42", baseSha: fixture.baseSha, headSha: fixture.headSha });
 
 		const result = await manager.submitYaml({ sessionId: launch.childSessionId, jobId: launch.jobId, yaml: validYaml(43), submissionProof: submitProof(sessionManager, launch.childSessionId) });
 		assert.equal(result.ok, false);
@@ -804,8 +849,9 @@ describe("WalkthroughAgentManager", () => {
 	});
 
 	it("route constructs a stable manager across fresh dependency objects", async () => {
+		const fixture = createGitDiffFixture();
 		const sessionManager = makeSessionManager();
-		const body = { sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42" };
+		const body = { sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42", baseSha: fixture.baseSha, headSha: fixture.headSha };
 		const first = await callRoute(undefined as any, "POST", "/api/pr-walkthrough/launch", body, { sessionManager, broadcast: () => undefined });
 		const second = await callRoute(undefined as any, "POST", "/api/pr-walkthrough/launch", body, { sessionManager, broadcast: () => undefined });
 		assert.equal(first.status, 201);
@@ -814,10 +860,11 @@ describe("WalkthroughAgentManager", () => {
 	});
 
 	it("restore reattaches idle-reminder listeners for non-ready jobs", async () => {
+		const fixture = createGitDiffFixture();
 		const sessionManager = makeSessionManager();
 		const store = new WalkthroughAgentStore(tempDir);
 		const manager = new WalkthroughAgentManager({ defaultCwd: tempDir, stateDir: tempDir, sessionManager, store });
-		const launch = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42" });
+		const launch = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42", baseSha: fixture.baseSha, headSha: fixture.headSha });
 		const restoredManager = new WalkthroughAgentManager({ defaultCwd: tempDir, stateDir: tempDir, sessionManager, store });
 		restoredManager.restore();
 		sessionManager.sessions.get(launch.childSessionId).emit({ type: "agent_end" });
@@ -826,13 +873,14 @@ describe("WalkthroughAgentManager", () => {
 	});
 
 	it("route constructs the production manager with SessionManager and broadcast dependencies", async () => {
+		const fixture = createGitDiffFixture();
 		const sessionManager = makeSessionManager();
 		const events: Record<string, unknown>[] = [];
 		const res = makeResponse();
 		const handled = await handlePrWalkthroughApiRoute(new URL("http://localhost/api/pr-walkthrough/launch"), { method: "POST" } as any, res as any, {
 			defaultCwd: tempDir,
 			stateDir: tempDir,
-			readBody: async () => ({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42" }),
+			readBody: async () => ({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42", baseSha: fixture.baseSha, headSha: fixture.headSha }),
 			sessionManager,
 			broadcast: event => events.push(event),
 		});
@@ -880,9 +928,10 @@ describe("WalkthroughAgentManager", () => {
 	});
 
 	it("sandbox submit-yaml rejects child sessions outside the caller scope", async () => {
+		const fixture = createGitDiffFixture();
 		const sessionManager = makeSessionManager();
 		const manager = new WalkthroughAgentManager({ defaultCwd: tempDir, stateDir: tempDir, sessionManager, store: new WalkthroughAgentStore(tempDir) });
-		const launch = await callRoute(manager, "POST", "/api/pr-walkthrough/launch", { sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42" });
+		const launch = await callRoute(manager, "POST", "/api/pr-walkthrough/launch", { sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42", baseSha: fixture.baseSha, headSha: fixture.headSha });
 
 		const result = await callRoute(
 			manager,
@@ -898,9 +947,10 @@ describe("WalkthroughAgentManager", () => {
 	});
 
 	it("submit-yaml rejects a different child session for the same job", async () => {
+		const fixture = createGitDiffFixture();
 		const sessionManager = makeSessionManager();
 		const manager = new WalkthroughAgentManager({ defaultCwd: tempDir, stateDir: tempDir, sessionManager, store: new WalkthroughAgentStore(tempDir) });
-		const launch = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42" });
+		const launch = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42", baseSha: fixture.baseSha, headSha: fixture.headSha });
 		await assert.rejects(
 			() => manager.submitYaml({ sessionId: "other-session", jobId: launch.jobId, yaml: validYaml(), submissionProof: submitProof(sessionManager, launch.childSessionId) }),
 			/error|not allowed/i,

--- a/tests/pr-walkthrough-agent-manager.test.ts
+++ b/tests/pr-walkthrough-agent-manager.test.ts
@@ -191,6 +191,34 @@ function yamlReviewChunkFor(fixture: { hunkHeader: string; filePath: string }): 
 	};
 }
 
+function jsonFilesUnder(root: string): string[] {
+	if (!fs.existsSync(root)) return [];
+	const files: string[] = [];
+	for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+		const fullPath = path.join(root, entry.name);
+		if (entry.isDirectory()) files.push(...jsonFilesUnder(fullPath));
+		else if (entry.isFile() && entry.name.endsWith(".json")) files.push(fullPath);
+	}
+	return files;
+}
+
+function readAnalysisBundleArtifacts(): Array<Record<string, any>> {
+	return jsonFilesUnder(tempDir)
+		.map(file => {
+			try { return JSON.parse(fs.readFileSync(file, "utf-8")); } catch { return null; }
+		})
+		.filter((value): value is Record<string, any> => value?.kind === "pr_walkthrough_analysis_bundle");
+}
+
+function removeAnalysisBundleArtifacts(): void {
+	for (const file of jsonFilesUnder(tempDir)) {
+		try {
+			const parsed = JSON.parse(fs.readFileSync(file, "utf-8"));
+			if (parsed?.kind === "pr_walkthrough_analysis_bundle") fs.rmSync(file, { force: true });
+		} catch { /* ignore non-bundle JSON */ }
+	}
+}
+
 async function callRoute(manager: InstanceType<typeof WalkthroughAgentManager>, method: string, pathname: string, body?: unknown, extraDeps: Record<string, unknown> = {}, headers: Record<string, string> = {}) {
 	const res = makeResponse();
 	const handled = await handlePrWalkthroughApiRoute(new URL(`http://localhost${pathname}`), { method, headers } as any, res as any, {
@@ -225,7 +253,7 @@ describe("WalkthroughAgentManager", () => {
 		assert.equal(child.parentSessionId, "parent");
 		assert.equal(child.childKind, "pr-walkthrough");
 		assert.equal(child.readOnly, true);
-		assert.deepEqual(child.allowedTools, ["readonly_bash", "submit_pr_walkthrough_yaml"]);
+		assert.deepEqual(child.allowedTools, ["readonly_bash", "read_pr_walkthrough_bundle", "submit_pr_walkthrough_yaml"]);
 
 		const second = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42" });
 		assert.equal(second.created, false);
@@ -249,6 +277,71 @@ describe("WalkthroughAgentManager", () => {
 		assert.equal(child.env.BOBBIT_WALKTHROUGH_TARGET_OWNER, "acme");
 		assert.equal(child.env.BOBBIT_WALKTHROUGH_TARGET_REPO, "widgets");
 		assert.equal(child.env.BOBBIT_WALKTHROUGH_TARGET_NUMBER, "42");
+	});
+
+	it("launch resolves and persists a full versioned analysis bundle before child creation", async () => {
+		const fixture = createGitDiffFixture();
+		const sessionManager = makeSessionManager();
+		const originalCreateSession = sessionManager.createSession.bind(sessionManager);
+		let bundleCountAtCreate = -1;
+		let bundleCountAtEnqueue = -1;
+		sessionManager.createSession = async (...args: Parameters<typeof sessionManager.createSession>) => {
+			bundleCountAtCreate = readAnalysisBundleArtifacts().length;
+			return originalCreateSession(...args);
+		};
+		const originalEnqueuePrompt = sessionManager.enqueuePrompt.bind(sessionManager);
+		sessionManager.enqueuePrompt = (...args: Parameters<typeof sessionManager.enqueuePrompt>) => {
+			bundleCountAtEnqueue = readAnalysisBundleArtifacts().length;
+			return originalEnqueuePrompt(...args);
+		};
+		const manager = new WalkthroughAgentManager({ defaultCwd: tempDir, stateDir: tempDir, sessionManager, store: new WalkthroughAgentStore(tempDir) });
+
+		const launch = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42", baseSha: fixture.baseSha, headSha: fixture.headSha });
+
+		assert.equal(launch.status, "waiting_for_yaml");
+		assert.ok(bundleCountAtCreate > 0, "analysis bundle must be persisted before child session creation");
+		assert.ok(bundleCountAtEnqueue > 0, "analysis bundle must be persisted before kickoff prompt enqueue");
+		const [bundle] = readAnalysisBundleArtifacts();
+		assert.ok(bundle, "expected a persisted pr_walkthrough_analysis_bundle artifact");
+		assert.equal(bundle.schema_version, 1);
+		assert.equal(bundle.kind, "pr_walkthrough_analysis_bundle");
+		assert.deepEqual(bundle.target, {
+			provider: "github",
+			owner: "acme",
+			repo: "widgets",
+			number: 42,
+			url: "https://github.com/acme/widgets/pull/42",
+		});
+		assert.equal(bundle.changeset.base_sha, fixture.baseSha);
+		assert.equal(bundle.changeset.head_sha, fixture.headSha);
+		assert.equal(bundle.changeset.files_changed, 1);
+		assert.ok(Array.isArray(bundle.files), "bundle.files must contain the authoritative launch-time diff files");
+		assert.ok(bundle.files.some((file: any) => file.path === fixture.filePath && Array.isArray(file.hunks) && file.hunks.length > 0), "bundle must include parsed hunks for the changed file");
+		const child = sessionManager.sessions.get(launch.childSessionId);
+		assert.ok(child.allowedTools.includes("read_pr_walkthrough_bundle"), "walkthrough child must be allowed to read its scoped persisted bundle");
+		assert.match(`${child.rolePrompt}\n${sessionManager.prompts.join("\n")}`, /read_pr_walkthrough_bundle/);
+	});
+
+	it("launch-time diff resolution failure returns a structured job error without creating a waiting child agent", async () => {
+		const sessionManager = makeSessionManager();
+		const store = new WalkthroughAgentStore(tempDir);
+		const manager = new WalkthroughAgentManager({
+			defaultCwd: tempDir,
+			stateDir: tempDir,
+			sessionManager,
+			store,
+			preflightGithubLaunch: () => { throw new Error("GitHub API rate limit exceeded"); },
+		});
+
+		const launch = await manager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42" });
+
+		assert.equal(launch.status, "error");
+		assert.equal(launch.job.error?.code, "GITHUB_RATE_LIMITED");
+		assert.equal(launch.job.error?.retryable, true);
+		assert.equal(store.list().length, 1);
+		assert.equal(store.list()[0].status, "error");
+		assert.equal(sessionManager.sessions.size, 1, "expected no child session when launch-time bundle resolution fails");
+		assert.equal(sessionManager.prompts.length, 0, "expected no waiting/kickoff prompt when launch-time bundle resolution fails");
 	});
 
 	it("local changeset launches are rejected before creating an agent job", async () => {
@@ -602,6 +695,45 @@ describe("WalkthroughAgentManager", () => {
 		assert.ok(reviewCard.diffBlocks.length > 0, "expected relevant_hunks to map to non-empty diffBlocks");
 		assert.equal(reviewCard.diffBlocks[0].filePath, fixture.filePath);
 		assert.equal(stored.warnings.some((warning: any) => warning.code === "unmapped_hunk"), false);
+	});
+
+	it("submit-yaml maps against the stored launch bundle without submit-time diff resolution", async () => {
+		const fixture = createGitDiffFixture();
+		const sessionManager = makeSessionManager();
+		const store = new WalkthroughAgentStore(tempDir);
+		const launchManager = new WalkthroughAgentManager({ defaultCwd: tempDir, stateDir: tempDir, sessionManager, store });
+		const launch = await launchManager.launch({ sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42", baseSha: fixture.baseSha, headSha: fixture.headSha });
+		const proof = submitProof(sessionManager, launch.childSessionId);
+		const submitManager = new WalkthroughAgentManager({
+			defaultCwd: tempDir,
+			stateDir: tempDir,
+			sessionManager,
+			store,
+			resolveDiffForYamlMapping: () => { throw new Error("submit-time resolver called; expected stored PR walkthrough analysis bundle"); },
+		});
+
+		const result = await submitManager.submitYaml({ sessionId: launch.childSessionId, jobId: launch.jobId, yaml: validYaml(42, { baseSha: fixture.baseSha, headSha: fixture.headSha }), submissionProof: proof });
+
+		assert.equal(result.ok, true);
+		const stored = getWalkthrough(launch.changesetId, tempDir);
+		assert.equal(stored?.changeset.baseSha, fixture.baseSha);
+		assert.equal(stored?.changeset.headSha, fixture.headSha);
+	});
+
+	it("missing stored analysis bundle returns a deterministic retryable submission error instead of re-resolving diff data", async () => {
+		const fixture = createGitDiffFixture();
+		const sessionManager = makeSessionManager();
+		const manager = new WalkthroughAgentManager({ defaultCwd: tempDir, stateDir: tempDir, sessionManager, store: new WalkthroughAgentStore(tempDir) });
+		const launch = await callRoute(manager, "POST", "/api/pr-walkthrough/launch", { sessionId: "parent", prUrl: "https://github.com/acme/widgets/pull/42", baseSha: fixture.baseSha, headSha: fixture.headSha });
+		const proof = submitProof(sessionManager, launch.body.childSessionId);
+		removeAnalysisBundleArtifacts();
+
+		const result = await callRoute(manager, "POST", "/api/internal/pr-walkthrough/submit-yaml", { sessionId: launch.body.childSessionId, jobId: launch.body.jobId, yaml: validYaml(42, { baseSha: fixture.baseSha, headSha: fixture.headSha }) }, {}, { "x-bobbit-walkthrough-submit-proof": proof });
+
+		assert.notEqual(result.status, 200, "missing bundle must not be silently recovered by submit-time GitHub/local diff resolution");
+		assert.equal(result.body.code, "PR_WALKTHROUGH_BUNDLE_MISSING");
+		assert.equal(result.body.retryable, true);
+		assert.match(result.body.message, /bundle/i);
 	});
 
 	it("submit-yaml converts diff resolution failures into structured job errors", async () => {

--- a/tests/pr-walkthrough-agent-manager.test.ts
+++ b/tests/pr-walkthrough-agent-manager.test.ts
@@ -509,9 +509,8 @@ describe("WalkthroughAgentManager", () => {
 		assert.equal(launch.status, "error");
 		assert.equal(launch.job.error?.code, "GITHUB_RATE_LIMITED");
 		assert.equal(launch.job.error?.retryable, true);
-		assert.equal(sessionManager.prompts.length, 1, "child transcript should receive a launch failure notice");
-		assert.match(sessionManager.prompts[0], /launch preflight failed|GITHUB_RATE_LIMITED|rate limit/i);
-		assert.doesNotMatch(sessionManager.prompts[0], /schema_version: 1/, "kickoff schema prompt should not be sent for inaccessible PRs");
+		assert.equal(sessionManager.sessions.size, 1, "launch-time bundle failures should not create a child analysis session");
+		assert.equal(sessionManager.prompts.length, 0, "kickoff schema prompt should not be sent for inaccessible PRs");
 	});
 
 	it("launch kickoff failures are surfaced in the child transcript", async () => {

--- a/tests/pr-walkthrough-bundle-tool-metadata.test.ts
+++ b/tests/pr-walkthrough-bundle-tool-metadata.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { WALKTHROUGH_ALLOWED_TOOLS } from "../src/server/pr-walkthrough/walkthrough-agent-manager.ts";
+
+const groupDir = path.resolve("defaults/tools/pr-walkthrough");
+
+function readToolText(file: string): string {
+	return fs.readFileSync(path.join(groupDir, file), "utf-8");
+}
+
+function field(text: string, name: string): string | undefined {
+	return text.match(new RegExp(`^${name}:\\s*(.+)$`, "m"))?.[1]?.trim();
+}
+
+describe("PR walkthrough bundle access tool metadata", () => {
+	it("allows the session-hosted analysis agent to read only its persisted bundle", () => {
+		assert.ok(
+			WALKTHROUGH_ALLOWED_TOOLS.includes("read_pr_walkthrough_bundle"),
+			"WALKTHROUGH_ALLOWED_TOOLS must include read_pr_walkthrough_bundle",
+		);
+	});
+
+	it("defines read_pr_walkthrough_bundle as a bounded scoped PR walkthrough tool", () => {
+		const toolPath = path.join(groupDir, "read_pr_walkthrough_bundle.yaml");
+		assert.ok(fs.existsSync(toolPath), "read_pr_walkthrough_bundle.yaml should define the bundle read tool");
+		const text = readToolText("read_pr_walkthrough_bundle.yaml");
+		assert.equal(field(text, "name"), "read_pr_walkthrough_bundle");
+		assert.equal(field(text, "group"), "PR Walkthrough");
+		assert.match(text, /params:\s*\[(mode|file|path|index|offset|limit|hunks?)/i);
+		assert.match(text, /manifest|summary|file/i);
+		assert.match(text, /bounded|limit|truncat/i);
+	});
+
+	it("registers read_pr_walkthrough_bundle through the gateway instead of broad filesystem reads", () => {
+		const source = readToolText("extension.ts");
+		assert.match(source, /name:\s*"read_pr_walkthrough_bundle"/);
+		assert.match(source, /BOBBIT_SESSION_ID/);
+		assert.match(source, /BOBBIT_WALKTHROUGH_JOB_ID/);
+		assert.match(source, /api\/internal\/pr-walkthrough\/(bundle|analysis-bundle)/);
+		assert.doesNotMatch(source, /readFileSync\([^)]*BOBBIT_WALKTHROUGH/i, "bundle tool must not read arbitrary env-provided paths from disk");
+	});
+});

--- a/tests/pr-walkthrough-bundle-tool-metadata.test.ts
+++ b/tests/pr-walkthrough-bundle-tool-metadata.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 
+import extension from "../defaults/tools/pr-walkthrough/extension.ts";
 import { WALKTHROUGH_ALLOWED_TOOLS } from "../src/server/pr-walkthrough/walkthrough-agent-manager.ts";
 
 const groupDir = path.resolve("defaults/tools/pr-walkthrough");
@@ -40,6 +41,45 @@ describe("PR walkthrough bundle access tool metadata", () => {
 		assert.match(source, /BOBBIT_SESSION_ID/);
 		assert.match(source, /BOBBIT_WALKTHROUGH_JOB_ID/);
 		assert.match(source, /api\/internal\/pr-walkthrough\/(bundle|analysis-bundle)/);
+		assert.match(source, /JSON\.stringify\(\{ \.\.\.readArgs, sessionId, jobId \}\)/, "env-scoped IDs must be appended after whitelisted read args");
+		assert.doesNotMatch(source, /JSON\.stringify\(\{ sessionId, jobId, \.\.\.args \}\)/, "tool args must not override scoped session/job IDs");
 		assert.doesNotMatch(source, /readFileSync\([^)]*BOBBIT_WALKTHROUGH/i, "bundle tool must not read arbitrary env-provided paths from disk");
+	});
+
+	it("read_pr_walkthrough_bundle ignores caller-supplied identity fields at execution", async () => {
+		const previousEnv = { ...process.env };
+		const previousFetch = globalThis.fetch;
+		let postedBody: any;
+		try {
+			process.env.BOBBIT_SESSION_ID = "env-session";
+			process.env.BOBBIT_WALKTHROUGH_JOB_ID = "env-job";
+			process.env.BOBBIT_WALKTHROUGH_SUBMIT_PROOF = "proof";
+			process.env.BOBBIT_GATEWAY_URL = "https://gateway.test";
+			process.env.BOBBIT_TOKEN = "token";
+			globalThis.fetch = (async (_url: string, init?: any) => {
+				postedBody = JSON.parse(String(init?.body ?? "{}"));
+				return new Response(JSON.stringify({ ok: true }), { status: 200 });
+			}) as any;
+			let bundleTool: any;
+			extension({ registerTool(tool: any) { if (tool.name === "read_pr_walkthrough_bundle") bundleTool = tool; } } as any);
+			assert.ok(bundleTool, "expected read_pr_walkthrough_bundle to be registered");
+
+			await bundleTool.execute("call-1", { mode: "file", path: "src/demo.ts", index: 3, offset: 4, limit: 5, hunkOffset: 6, hunkLimit: 7, sessionId: "attacker-session", jobId: "attacker-job", extra: "ignored" });
+
+			assert.deepEqual(postedBody, {
+				mode: "file",
+				path: "src/demo.ts",
+				index: 3,
+				offset: 4,
+				limit: 5,
+				hunkOffset: 6,
+				hunkLimit: 7,
+				sessionId: "env-session",
+				jobId: "env-job",
+			});
+		} finally {
+			globalThis.fetch = previousFetch;
+			process.env = previousEnv;
+		}
 	});
 });


### PR DESCRIPTION
## Summary
- Persist launch-time PR walkthrough analysis bundles and map YAML submissions from the stored bundle
- Add scoped read_pr_walkthrough_bundle access for analysis agents
- Restore live walkthrough decision persistence and archived child filtering
- Update PR walkthrough docs for the new bundle model

## Verification
- npm run check
- backend PR walkthrough unit tests
- implementation/documentation workflow gates passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)