### PR TITLE
test(flake): fix project-assistant-saved-state Terminate-dialog flake

### DIFF
--- a/tests/e2e/ui/project-assistant-saved-state.spec.ts
+++ b/tests/e2e/ui/project-assistant-saved-state.spec.ts
@@ -233,15 +233,19 @@ test.describe("Project Assistant Saved State", () => {
 
 		const termBtn2 = page.getByRole("button", { name: "Terminate Project Assistant" });
 		await termBtn2.click();
-		// Confirm dialog — destructive button labelled EXACTLY "Terminate". Match by
-		// exact accessible name so we only ever resolve the dialog's confirm button,
-		// never the trigger "Terminate Project Assistant" (whose name contains
-		// "Terminate"). The old `{ name: "Terminate" }` was a substring match that
-		// also matched the trigger; `.last()` was a DOM-order gamble that
-		// intermittently resolved the re-rendering trigger button → "element not
-		// stable" click timeout (the flake). The confirm dialog is position:fixed
-		// and static, so once correctly targeted it is reliably clickable.
-		const confirmBtn = page.getByRole("button", { name: "Terminate", exact: true });
+		// Confirm dialog — destructive button labelled "Terminate". THREE buttons on
+		// the page share/contain that accessible name: the persistent toolbar
+		// "Terminate session" action (name "Terminate"), the panel trigger
+		// "Terminate Project Assistant", and this dialog's confirm. The old
+		// `{ name: "Terminate" }.last()` was a DOM-order gamble across them (the
+		// flake); `{ exact: true }` still matched two (toolbar + dialog) → strict
+		// violation. Scope to the confirm dialog via its unique Cancel + Terminate
+		// footer pair (the toolbar Terminate has no Cancel sibling) so we target
+		// ONLY the dialog confirm button, regardless of the others.
+		const confirmDialogFooter = page
+			.getByRole("button", { name: "Cancel", exact: true })
+			.locator("xpath=..");
+		const confirmBtn = confirmDialogFooter.getByRole("button", { name: "Terminate", exact: true });
 		await expect(confirmBtn).toBeVisible({ timeout: 5_000 });
 		await confirmBtn.click();
 


### PR DESCRIPTION
Pre-existing flaky test (failed ~3/4 in isolation; unrelated to #674, proven by bisect). Root cause: three buttons share/contain accessible name 'Terminate' (toolbar 'Terminate session', panel trigger, dialog confirm); the locator's .last() was a DOM-order gamble. Fix: scope to the confirm dialog via its unique Cancel+Terminate footer. Verified 8/8 isolation (was 0/6). Supersedes the interim exact:true commit 0d722ff1 already on master. Test-only.

Generated with Claude Code