### PR TITLE
Fix PR walkthrough panel resize controls

### DIFF
--- a/docs/design/walkthrough-panel-resize-fix.md
+++ b/docs/design/walkthrough-panel-resize-fix.md
@@ -1,0 +1,214 @@
+# PR Walkthrough panel-resize controls — verified root-cause analysis
+
+Status: investigation complete (no production code changed in this task).
+Scope: diagnose why the PR walkthrough panel's fullscreen, collapse, and
+keyboard-shortcut affordances are all non-functional, and pin the exact
+reproduction surface for the follow-up reproducing test + fix.
+
+## TL;DR
+
+All three sizing affordances die **at once on the standalone `/walkthrough`
+route** because that route is rendered by a *different code path*
+(`standaloneWalkthroughPanel()`) than the in-app unified panel:
+
+1. **Fullscreen / collapse buttons are never rendered** on the standalone
+   route — `standaloneWalkthroughPanel()` returns only the walkthrough body
+   and omits the resize toolbar entirely, and it does not honor
+   `state.previewPanelFullscreen` / the collapse flag.
+2. **Keyboard shortcuts no-op** on the standalone route — the shortcut gate
+   `hasActiveWalkthroughPanel()` and the collapse localStorage key both key off
+   the bare `activeSessionId()`, which is `undefined` on the standalone route
+   (no session is connected). The panel tab, however, lives under
+   `route.walkthroughSessionId`. The two session keys diverge, so detection
+   resolves to the `__no-session__` bucket, finds no walkthrough tab, and every
+   shortcut falls through to a no-op.
+
+There is a **second, latent fault** in the in-app unified panel: the
+`isLiveSessionHostedWalkthroughActive()` predicate's fallback clause
+(`source?.sessionId === activeId`) classifies *any* walkthrough viewed in its
+owning session as "live", so fullscreen is suppressed even for a **terminated
+(done) walkthrough child** that is not actually live. This is masked for *idle*
+children (correctly kept split per constraint #3) but bites a terminated child
+that has not yet moved into `state.archivedSessions`.
+
+The unifying root cause matches the goal hypothesis: **panel-tab detection uses
+`panelWorkspaceSessionKey(activeSessionId())` / `workspaceSessionId()`, but the
+resize controls, the collapse localStorage key, and the live-detection
+predicate use the bare `activeSessionId()` (or `source.sessionId === activeId`).
+When those session keys diverge — exactly what happens on the standalone route
+and for a not-yet-archived terminated child — the controls read/write the wrong
+key (or short-circuit), making every affordance a silent no-op.**
+
+## Reproduction evidence (verified in a real browser)
+
+A temporary Playwright spec drove the live `gateway-harness` build, injected a
+`status: "ready"` walkthrough tab into the active session's panel state, varied
+the host-session classification, clicked the fullscreen control, and observed
+whether the app entered fullscreen (`.preview-fullscreen-prompt` present). The
+spec was removed after capturing results; numbers below are the observed output.
+
+### In-app unified panel — fullscreen button present, click result
+
+| Case | host `childKind` | host `status` | `source.sessionId` vs active | Fullscreen button | Entered fullscreen on click |
+|------|------------------|---------------|------------------------------|-------------------|-----------------------------|
+| A | (none / regular) | idle | **same** | visible | **no** |
+| B | pr-walkthrough | idle (live) | same | visible | no *(intended — constraint #3)* |
+| C | pr-walkthrough | **terminated** | same | visible | **no — BUG** |
+| D | (none / regular) | idle | **different** | visible | **yes** |
+| E | pr-walkthrough | idle, `gs.archived=true` | same | visible | no |
+| F (collapse) | regular | idle | same | collapse visible | **collapsed = yes** |
+
+Reading: fullscreen is suppressed **iff `source.sessionId === activeSessionId()`**
+(A/B/C/E suppressed; only D, where the owner differs from the viewer, enters
+fullscreen). Collapse (F) works in a static in-app scenario. Case E shows the
+`archived` guard checks `state.archivedSessions`, *not* the gateway session's
+own `archived`/`status`, so a terminated-but-not-archived child stays
+"live"-classified.
+
+### Standalone `/walkthrough` route
+
+Navigated to `#/walkthrough?session=<sid>&tab=walkthrough:<id>` with the tab
+seeded in `localStorage`:
+
+```
+standaloneVisible=true  panelVisible=true
+fullscreenButtons=0  collapseButtons=0  expandButtons=0
+state.selectedSessionId=null  remoteAgent.gatewaySessionId=null
+panelWorkspaceActive["__no-session__"]=""   panelTabsBySession keys=["<sid>"]
+```
+
+The walkthrough renders, but **no resize controls exist**, and the shortcut
+detection bucket (`__no-session__`) does not contain the tab (it lives under
+`<sid>`). This is all three affordances dead simultaneously — the shared-root
+symptom described in the goal.
+
+## Code map (file:line)
+
+### Standalone route (primary surface)
+
+- `src/app/render.ts` `mainArea()` early-returns the standalone route before the
+  unified-panel layout that owns the resize controls:
+  - `if (route.view === "walkthrough") return standaloneWalkthroughPanel();` (~L2398).
+- `src/app/render.ts` `standaloneWalkthroughPanel()` (~L2274–2308):
+  - Looks up the tab with `const sid = route.walkthroughSessionId || workspaceSessionId();`
+    (correct — uses the route's walkthrough session id), then returns only
+    `walkthroughPanelContent(tab)` wrapped in a div. **No fullscreen/collapse
+    toolbar, and no `previewPanelFullscreen` / `isPreviewCollapsed()` branch.**
+- `src/app/render.ts` standalone topbar (~L2511–2526) renders just the Bobbit
+  mark + `<theme-toggle>` — no resize controls.
+
+### Shortcut detection + collapse key (session-key divergence)
+
+- `src/app/main.ts` `hasActiveWalkthroughPanel()` (~L77–79):
+  `panelWorkspaceSessionKey(activeSessionId())` → `__no-session__` on the
+  standalone route, where the tab is stored under `route.walkthroughSessionId`.
+- `src/app/main.ts` shortcut handlers gate on `hasActiveWalkthroughPanel()` and
+  read/write `bobbit-preview-collapsed-${activeSessionId()}`:
+  - `toggle-sidebar` (~L585–595), `toggle-preview` (~L646–663),
+    `toggle-fullscreen-preview` (~L666–690).
+- `src/app/render.ts` collapse key + reader use the same bare id:
+  - `previewCollapseKey = () => `bobbit-preview-collapsed-${activeSessionId()}`` (~L1969),
+    `isPreviewCollapsed()`, `togglePreviewCollapse()` (~L1970–1975).
+- `src/app/state.ts` `activeSessionId()` (~L740–749) returns `undefined` when no
+  session is connected (the standalone route sets `selectedSessionId = null` and
+  disconnects — `src/app/main.ts` ~L200, ~L471).
+
+### In-app fullscreen suppression (secondary, latent)
+
+- `src/app/render.ts` `isLiveSessionHostedWalkthroughActive()` (~L2226–2237):
+  - First clause correctly catches a live child:
+    `session?.childKind === "pr-walkthrough" && !session.archived && status !== "terminated" && status !== "archived"`.
+  - **Over-broad fallback:** `return !archived && tab?.kind === "walkthrough"
+    && activeId.length > 0 && source?.sessionId === activeId;` — true for *every*
+    walkthrough viewed in its owner session. `archived` here is
+    `state.archivedSessions.some(...)`, so a terminated child still listed in
+    `gatewaySessions` (not yet archived) is misclassified as live.
+- `src/app/render.ts` fullscreen render gate (~L2437–2439):
+  `suppressFullscreenForLiveWalkthrough = isLiveSessionHostedWalkthroughActive(fullscreenTab) && kind === "walkthrough"`
+  → force-resets `state.previewPanelFullscreen = false`.
+
+## Why "all three at once" ⇒ shared cause
+
+The standalone route is a single render branch that bypasses the unified panel.
+Because it neither renders the toolbar nor honors the fullscreen/collapse state,
+and because the shortcut/collapse plumbing reads a session key
+(`activeSessionId()` → empty) that never matches the key the tab is stored under
+(`route.walkthroughSessionId`), fullscreen + collapse + shortcuts are all
+simultaneously inert. A single reconciliation — make the standalone route honor
+the same fullscreen/collapse state and toolbar, and key detection/collapse off
+the route's walkthrough session id (or `workspaceSessionId()`), not bare
+`activeSessionId()` — fixes all three.
+
+## Proposed fix direction (for the implementation task — not done here)
+
+1. **Single source of truth for the session key.** Drive the collapse
+   localStorage key and `hasActiveWalkthroughPanel()`/`canFullscreen` from the
+   same key used for the panel-tab lookup (`workspaceSessionId()` /
+   `route.walkthroughSessionId`), not bare `activeSessionId()`. On the standalone
+   route, `activeSessionId()` is `undefined`; the walkthrough session id must be
+   sourced from the route.
+2. **Standalone route honors resize state.** `standaloneWalkthroughPanel()` (or
+   its caller) should render the fullscreen/collapse toolbar and branch on the
+   fullscreen/collapse flags, the same way `unifiedPreviewPanel()` /
+   `mainArea()` do for the in-app panel.
+3. **Tighten in-app live detection.** Replace the over-broad
+   `source?.sessionId === activeId` fallback so it only treats a walkthrough as
+   "live" when its host session is genuinely live (e.g. reuse
+   `isLiveSessionHostedWalkthrough(state, source.sessionId)`, and treat
+   terminated/archived sessions — by `gatewaySessions` status *and*
+   `archivedSessions` — as not-live), so a terminated/ready walkthrough child
+   can be fullscreened.
+
+## Constraints to preserve (pinned by existing tests — do NOT regress)
+
+- Live child-session walkthroughs must stay in split/promptable view and must
+  NOT enter fullscreen (chat prompt visible):
+  - `tests/e2e/ui/pr-walkthrough-panel.spec.ts` — "fullscreen toolbar control
+    keeps live child walkthroughs in split promptable view" (~L1114).
+  - `tests/e2e/ui/pr-walkthrough-real.spec.ts` (~L462–467).
+- Standalone preview panel fullscreen/collapse behavior unchanged:
+  `tests/e2e/ui/preview-fullscreen-controls.spec.ts`.
+- Standalone route still renders the walkthrough in wide/split chrome:
+  `tests/e2e/ui/pr-walkthrough-panel.spec.ts` — "open-in-new-tab toolbar control
+  renders the same walkthrough in a standalone wide route".
+
+## Proposed reproducing test (for the tester / reproducing-test gate)
+
+Add a browser E2E in `tests/e2e/ui/pr-walkthrough-panel.spec.ts` (reuse
+`setupWalkthrough` + the `open-in-new-tab` flow to reach the standalone route,
+or seed `localStorage` and navigate to `#/walkthrough?session=<sid>&tab=<id>`).
+Assert, on the standalone (ready) walkthrough:
+
+1. A fullscreen control is present and clicking it enters fullscreen
+   (`.preview-fullscreen-prompt` / fullscreen root visible).
+2. A collapse control is present and collapses the panel (expand control
+   appears), and the collapsed state persists across reload.
+3. At least one keyboard shortcut (`toggle-fullscreen-preview` Ctrl+#, or
+   `toggle-preview` Ctrl+]) operates on the walkthrough panel.
+4. Guard: a *live* child-session walkthrough stays in split view (does not enter
+   fullscreen) — re-asserts constraint #3.
+
+**Suggested run command** (browser project only):
+
+```
+node scripts/run-playwright-e2e.mjs pr-walkthrough-panel --project=browser --workers=1
+```
+
+(or, full E2E: `npm run test:e2e`.)
+
+**Expected failure on master (before fix), error pattern regex** — any of:
+
+```
+(pr-walkthrough-fullscreen.*not.*visible|preview-fullscreen-prompt.*(hidden|not visible|0)|Expected.*visible.*received.*hidden|toBeVisible)
+```
+
+On the standalone route specifically, the fullscreen/collapse locators resolve
+to **count 0** (controls absent), so an `expect(locator).toBeVisible()` /
+`toHaveCount(1)` assertion fails on master and passes after the fix.
+
+## Notes / verification method
+
+- Reproduction was run against a real build via
+  `node scripts/run-playwright-e2e.mjs ... --project=browser`. `node_modules`
+  were installed in this worktree to build; `package-lock.json` left unchanged.
+- No production `.ts` files were modified by this investigation task.

--- a/docs/pr-walkthrough-panel.md
+++ b/docs/pr-walkthrough-panel.md
@@ -29,6 +29,74 @@ The same ready walkthrough can be reviewed in:
 - fullscreen / wide review mode from the side-panel toolbar;
 - the standalone `/walkthrough?...` route opened from the toolbar.
 
+## Panel sizing: fullscreen, collapse, and shortcuts
+
+The walkthrough panel shares the preview panel's three sizing affordances — a
+fullscreen (wide review) button, a collapse button, and the resize keyboard
+shortcuts (`toggle-sidebar`, `toggle-preview`, `toggle-fullscreen-preview`) —
+across both the in-app side panel and the standalone `/walkthrough` route. The
+standalone route is rendered by its own branch (`standaloneWalkthroughPanel()`
+in `src/app/render.ts`) rather than the unified preview panel, so it renders the
+same fullscreen/collapse toolbar itself and honors `state.previewPanelFullscreen`
+and the collapse flag.
+
+### Single-source-of-truth session key (never bare `activeSessionId()`)
+
+Three pieces of plumbing must all agree on which session id the panel tab is
+stored under: the shortcut/detection gate (`hasActiveWalkthroughPanel()` in
+`src/app/main.ts`), the collapse `localStorage` key
+(`bobbit-preview-collapsed-<id>`), and the `canFullscreen` predicate. The single
+source of truth is **`workspaceSessionId()`** (in `src/app/render.ts`), which is
+route-aware: on the standalone `/walkthrough` route there is no connected session
+so `activeSessionId()` is `undefined`, and the walkthrough's owning session id is
+taken from the route (`route.walkthroughSessionId`) instead.
+
+The bug this guards against: if detection keys off `workspaceSessionId()` /
+`route.walkthroughSessionId` but the collapse key or `canFullscreen` predicate
+key off the bare `activeSessionId()`, the two keys diverge on the standalone
+route (`__no-session__` vs the real session id). Detection then finds no
+walkthrough tab and every affordance silently no-ops — the fullscreen button,
+the collapse button, and all three keyboard shortcuts die at once. **Always
+derive the walkthrough panel's session key from `workspaceSessionId()`, never
+from a bare `activeSessionId()`.**
+
+### Intentional live-child split-view exception
+
+Live child-session walkthroughs (a genuinely running `pr-walkthrough` child
+viewed beside its parent chat) must stay in split / promptable view and must
+**not** enter fullscreen, so the chat prompt for follow-up questions stays
+visible. This is enforced in-app by `keepLiveWalkthroughPanelPromptable()` (in
+`src/app/pr-walkthrough.ts`), which forces split view and clears the collapse
+flag. `isLiveSessionHostedWalkthroughActive()` (in `src/app/render.ts`) decides
+whether to suppress fullscreen, and it suppresses **only** when the host session
+is a genuinely live `pr-walkthrough` child — a terminated, archived, or absent
+host (including the disconnected standalone route) is not live, so its ready
+walkthrough can be fullscreened.
+
+The standalone route is exempt from the split-view reset:
+`keepLiveWalkthroughPanelPromptable()` returns early on the
+`/walkthrough` route because there is no chat prompt to protect, and the route
+owns its own fullscreen/collapse state. Skipping the reset matters because the
+per-render job restore would otherwise bounce the user out of fullscreen and wipe
+the persisted collapse flag on every paint.
+
+### Pinning tests
+
+These invariants are pinned by browser E2E and must not regress:
+
+- **Standalone resize controls work** — `tests/e2e/ui/pr-walkthrough-panel.spec.ts`
+  covers the standalone (ready) walkthrough: the fullscreen button enters
+  fullscreen, the collapse button collapses the panel (and the collapsed state
+  persists across reload), and a resize keyboard shortcut operates on the panel.
+- **Live child stays split / promptable** — `tests/e2e/ui/pr-walkthrough-panel.spec.ts`
+  ("fullscreen toolbar control keeps live child walkthroughs in split promptable
+  view") and `tests/e2e/ui/pr-walkthrough-real.spec.ts`.
+- **Standalone preview panel sizing unchanged** —
+  `tests/e2e/ui/preview-fullscreen-controls.spec.ts`.
+
+See [docs/design/walkthrough-panel-resize-fix.md](design/walkthrough-panel-resize-fix.md)
+for the verified root-cause analysis behind this fix.
+
 ## Session-hosted GitHub PR flow
 
 ### 1. Launch or focus a child session
@@ -337,6 +405,7 @@ Coverage is split across unit, API E2E, and browser E2E tests:
 - session child metadata, submit proof restore, job persistence, and duplicate launch behavior;
 - launch API, invalid/valid YAML submission, keeping the child alive after success, and job restore;
 - browser behavior for child session launch/focus, empty waiting panel, validation retry state, final cards, fullscreen on success, reload persistence, standalone route, and explicit export confirmation;
+- panel sizing on the standalone route (fullscreen, collapse, persistence across reload, resize shortcuts) and the live-child split-view guard (see "Panel sizing");
 - compatibility resolver coverage for local SHA resolution, stored payload reload, large diff warnings, empty diffs, GitHub errors, and export mapping.
 
 Use these tests as the pinning contract when changing walkthrough launch, resolver compatibility, YAML mapping, persistence, readonly policy, or panel UX.

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -31,7 +31,7 @@ import { gatewayFetch, refreshSessions, resetPrPollThrottle } from "./api.js";
 import { getRouteFromHash, setHashRoute } from "./routing.js";
 import { authenticateGateway, connectToSession, createAndConnectSession, terminateSession, applyProjectPalette, flushAndTeardownDraft } from "./session-manager.js";
 import { migrateLegacyVisitedMap } from "./render-helpers.js";
-import { doRenderApp } from "./render.js";
+import { doRenderApp, workspaceSessionId } from "./render.js";
 import { PROPOSAL_TYPES } from "./proposal-registry.js";
 // goal-dashboard is dynamic-imported lazily to keep it out of the main chunk.
 // See docs/design/ui-bundle-size-reduction.md (Task A).
@@ -46,7 +46,7 @@ function clearDashboardState(): void {
 	if (_goalDashboardModule) _goalDashboardModule.clearDashboardState();
 }
 import { registerShortcut, startListening, loadSavedBindings } from "./shortcut-registry.js";
-import { activeSidePanelTabIdForSession, loadPersistedPanelWorkspace, panelWorkspaceSessionKey } from "./panel-workspace.js";
+import { activeSidePanelTabIdForSession, loadPersistedPanelWorkspace } from "./panel-workspace.js";
 
 // ============================================================================
 // WIRE UP RENDER
@@ -75,8 +75,17 @@ function hasActiveProposalPanel(): boolean {
 }
 
 function hasActiveWalkthroughPanel(): boolean {
-	const sid = panelWorkspaceSessionKey(activeSessionId());
-	return activeSidePanelTabIdForSession(state, sid).startsWith("walkthrough:");
+	// On the standalone `/walkthrough` route there is no connected session, so
+	// the panel tab lives under the route's walkthrough session id (also carried
+	// in the URL `tab` param). Key detection off the same id the panel tab is
+	// stored under — not the bare (undefined) `activeSessionId()` — so the resize
+	// shortcuts find the walkthrough tab instead of falling through to a no-op.
+	const route = getRouteFromHash();
+	if (route.view === "walkthrough") {
+		const tabId = route.walkthroughTabId || activeSidePanelTabIdForSession(state, route.walkthroughSessionId);
+		return typeof tabId === "string" && tabId.startsWith("walkthrough:");
+	}
+	return activeSidePanelTabIdForSession(state, workspaceSessionId()).startsWith("walkthrough:");
 }
 
 // ============================================================================
@@ -586,7 +595,7 @@ async function initApp() {
 			const canFullscreen = !state.assistantType && (state.isPreviewSession || state.reviewPanelOpen || state.inboxPanelOpen || hasActiveWalkthroughPanel());
 			const hasPanel = canFullscreen || (!state.assistantType && hasActiveProposalPanel());
 			if (hasPanel) {
-				const key = `bobbit-preview-collapsed-${activeSessionId()}`;
+				const key = `bobbit-preview-collapsed-${workspaceSessionId()}`;
 				const collapsed = localStorage.getItem(key) === "true";
 				if (collapsed) {
 					// level 0 → 1: uncollapse to half view
@@ -645,7 +654,7 @@ async function initApp() {
 		handler: () => {
 			const hasPanel = !state.assistantType && (state.isPreviewSession || state.reviewPanelOpen || state.inboxPanelOpen || hasActiveWalkthroughPanel() || hasActiveProposalPanel());
 			if (!hasPanel) return;
-			const key = `bobbit-preview-collapsed-${activeSessionId()}`;
+			const key = `bobbit-preview-collapsed-${workspaceSessionId()}`;
 			if (state.previewPanelFullscreen) {
 				// level 2 → 1: exit fullscreen, keep half view
 				state.previewPanelFullscreen = false;
@@ -670,7 +679,7 @@ async function initApp() {
 			const hasWalkthroughPanel = hasActiveWalkthroughPanel();
 			const hasPanel = !state.assistantType && (state.isPreviewSession || state.reviewPanelOpen || state.inboxPanelOpen || hasWalkthroughPanel || hasActiveProposalPanel());
 			if (hasPanel) {
-				const key = `bobbit-preview-collapsed-${activeSessionId()}`;
+				const key = `bobbit-preview-collapsed-${workspaceSessionId()}`;
 				if (state.previewPanelFullscreen) {
 					// level 2 → 0: exit fullscreen and collapse
 					state.previewPanelFullscreen = false;

--- a/src/app/pr-walkthrough.ts
+++ b/src/app/pr-walkthrough.ts
@@ -7,6 +7,7 @@ import {
 	type PanelWorkspaceTab,
 } from "./panel-workspace.js";
 import { gatewayFetch } from "./gateway-fetch.js";
+import { getRouteFromHash } from "./routing.js";
 import {
 	expandedGoals,
 	renderApp,
@@ -352,6 +353,11 @@ function isLiveSessionHostedWalkthrough(state: AppState, sessionId: string): boo
 	return session?.childKind === "pr-walkthrough" && !session.archived && session.status !== "terminated" && session.status !== "archived";
 }
 
+/** True when the dedicated, prompt-less standalone `/walkthrough` route is active. */
+function isStandaloneWalkthroughRoute(): boolean {
+	try { return getRouteFromHash().view === "walkthrough"; } catch { return false; }
+}
+
 function keepLiveWalkthroughPanelPromptable(state: AppState, sessionId: string, tabId?: string): void {
 	if (tabId) setActivePanelTabIdForSession(state, sessionId, tabId);
 	const tabs = panelTabsForSession(state, sessionId);
@@ -359,6 +365,12 @@ function keepLiveWalkthroughPanelPromptable(state: AppState, sessionId: string, 
 		? { ...tab, state: { ...tab.state, fullscreenOnReady: false } }
 		: tab);
 	if (nextTabs.some((tab, index) => tab !== tabs[index])) setPanelTabsForSession(state, sessionId, nextTabs);
+	// Forcing split + clearing the collapse flag keeps the in-app chat prompt
+	// visible for a live child. The standalone /walkthrough route has no prompt
+	// and owns its own fullscreen/collapse state, so skip the reset there —
+	// otherwise the per-render job restore bounces the user out of fullscreen
+	// and wipes the persisted collapse flag on every paint.
+	if (isStandaloneWalkthroughRoute()) return;
 	(state as any).previewPanelFullscreen = false;
 	try { localStorage.removeItem(`bobbit-preview-collapsed-${sessionId}`); } catch { /* non-browser/test */ }
 }

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -722,6 +722,16 @@ function currentAssistantProposalType(): ProposalType | null {
 }
 
 export function workspaceSessionId(): string {
+	// On the standalone `/walkthrough` route there is no connected session
+	// (`activeSessionId()` is undefined), but the walkthrough's owning session
+	// is carried in the URL. Detection, the collapse localStorage key, and the
+	// canFullscreen predicate must all key off the SAME session id the panel
+	// tab is stored under — otherwise the resize controls read/write a key the
+	// renderer never sees and every affordance silently no-ops.
+	const route = getRouteFromHash();
+	if (route.view === "walkthrough" && route.walkthroughSessionId) {
+		return panelWorkspaceSessionKey(route.walkthroughSessionId);
+	}
 	return panelWorkspaceSessionKey(activeSessionId());
 }
 
@@ -1966,7 +1976,7 @@ export function doRenderApp(): void {
 		`;
 	};
 
-	const previewCollapseKey = () => `bobbit-preview-collapsed-${activeSessionId()}`;
+	const previewCollapseKey = () => `bobbit-preview-collapsed-${workspaceSessionId()}`;
 	const isPreviewCollapsed = () => localStorage.getItem(previewCollapseKey()) === "true";
 	const togglePreviewCollapse = () => {
 		const next = !isPreviewCollapsed();
@@ -2222,13 +2232,24 @@ export function doRenderApp(): void {
 		};
 	};
 
+	// A walkthrough is "live" — and so must stay in split/promptable view rather
+	// than entering fullscreen — only while its HOST session is genuinely a
+	// running pr-walkthrough child. A terminated/archived host (or one absent
+	// from gatewaySessions, e.g. the disconnected standalone route) is NOT live,
+	// so its ready walkthrough can be fullscreened. The previous fallback
+	// (`source.sessionId === activeId`) wrongly classified ANY walkthrough viewed
+	// in its owner session as live, suppressing fullscreen for terminated/ready
+	// children too.
 	const isLiveSessionHostedWalkthroughActive = (tab?: UnifiedContentTab) => {
 		const activeId = activeSessionId();
-		const session = state.gatewaySessions.find((candidate) => candidate.id === activeId);
-		if (session?.childKind === "pr-walkthrough" && !session.archived && session.status !== "terminated" && session.status !== "archived") return true;
-		const archived = state.archivedSessions.some((candidate) => candidate.id === activeId || (candidate.parentSessionId === activeId && candidate.status === "terminated"));
 		const source = tab?.source as Record<string, unknown> | undefined;
-		return !archived && tab?.kind === "walkthrough" && typeof activeId === "string" && activeId.length > 0 && source?.sessionId === activeId;
+		const hostId = (typeof source?.sessionId === "string" && source.sessionId) ? source.sessionId : activeId;
+		if (typeof hostId !== "string" || !hostId) return false;
+		if (tab && tab.kind !== "walkthrough") return false;
+		const archived = state.archivedSessions.some((candidate) => candidate.id === hostId || (candidate.parentSessionId === hostId && candidate.status === "terminated"));
+		if (archived) return false;
+		const session = state.gatewaySessions.find((candidate) => candidate.id === hostId);
+		return !!session && session.childKind === "pr-walkthrough" && !session.archived && session.status !== "terminated" && session.status !== "archived";
 	};
 
 	const walkthroughPanelContent = (tab: UnifiedContentTab) => {
@@ -2300,8 +2321,47 @@ export function doRenderApp(): void {
 			setPanelTabsForSession(state, sid, [...panelTabsForSession(state, sid), tab as PanelWorkspaceTab]);
 			restorePrWalkthroughPanel(state, sid, tab.id);
 		}
+		// The standalone route is rendered by this branch instead of the unified
+		// panel, so it must surface the same resize affordances and honor the
+		// fullscreen/collapse state itself. There is no chat prompt to protect
+		// here, so (unlike the in-app panel) fullscreen is never suppressed for a
+		// live child — the standalone view is always fully promptless.
+		const collapsed = isPreviewCollapsed();
+		if (collapsed) {
+			return html`
+				<div class="flex-1 min-h-0 flex overflow-hidden" data-testid="pr-walkthrough-standalone" data-panel-tab-id=${tab.id}>
+					<div class="flex-1 min-w-0"></div>
+					${previewExpandButton()}
+				</div>
+			`;
+		}
+		const controlBar = (children: unknown) => html`
+			<div class="flex items-center justify-end gap-0.5 px-3 pt-1 pb-1 shrink-0 min-w-0" style="background: var(--muted, var(--color-muted));">
+				${children}
+			</div>
+		`;
+		if (state.previewPanelFullscreen) {
+			return html`
+				<div class="flex-1 min-h-0 flex flex-col overflow-hidden" data-testid="pr-walkthrough-standalone" data-panel-tab-id=${tab.id}>
+					${controlBar(html`
+						<button @click=${() => { state.previewPanelFullscreen = false; renderApp(); }} class="text-muted-foreground hover:text-foreground" style="background:none;border:none;cursor:pointer;padding:2px;flex-shrink:0;" title=${`Collapse preview${shortcutHint("toggle-preview")}`}>
+							${icon(PanelRightClose, "sm")}
+						</button>
+					`)}
+					${walkthroughPanelContent(tab)}
+				</div>
+			`;
+		}
 		return html`
 			<div class="flex-1 min-h-0 flex flex-col overflow-hidden" data-testid="pr-walkthrough-standalone" data-panel-tab-id=${tab.id}>
+				${controlBar(html`
+					<button @click=${() => { state.previewPanelFullscreen = true; renderApp(); }} class="text-muted-foreground hover:text-foreground" style="background:none;border:none;cursor:pointer;padding:2px;flex-shrink:0;" title=${`Fullscreen walkthrough${shortcutHint("toggle-sidebar")}`} data-testid="pr-walkthrough-fullscreen">
+						${icon(PanelRightOpen, "sm")}
+					</button>
+					<button @click=${togglePreviewCollapse} class="text-muted-foreground hover:text-foreground" style="background:none;border:none;cursor:pointer;padding:2px;flex-shrink:0;" title=${`Collapse preview${shortcutHint("toggle-preview")}`}>
+						${icon(PanelRightClose, "sm")}
+					</button>
+				`)}
 				${walkthroughPanelContent(tab)}
 			</div>
 		`;

--- a/tests/e2e/ui/pr-walkthrough-panel.spec.ts
+++ b/tests/e2e/ui/pr-walkthrough-panel.spec.ts
@@ -1148,6 +1148,64 @@ This is the author's source description with **markdown**.
 		await standalone.close();
 	});
 
+	test("standalone ready walkthrough exposes working fullscreen, collapse, and keyboard resize controls", async ({ page, context }) => {
+		// Reproduces the panel-resize bug: on the standalone (ready) walkthrough
+		// route the fullscreen button, the collapse button, and the panel
+		// keyboard shortcuts are all silent no-ops simultaneously (see
+		// docs/design/walkthrough-panel-resize-fix.md). The standalone route is
+		// rendered by a different code path that omits the resize toolbar, and
+		// the shortcut/collapse plumbing keys off the bare activeSessionId()
+		// (undefined here) instead of the route's walkthrough session id.
+		await setupWalkthrough(page, { width: 1600, height: 900 });
+
+		const openStandalone = page.locator(`${tid("side-panel-open-in-new-tab")}, ${tid("pr-walkthrough-open-in-new-tab")}, a[title*="Open walkthrough"], button[title*="Open walkthrough"]`).first();
+		await expect(openStandalone, "active walkthrough tabs should expose an open-in-new-tab toolbar affordance").toBeVisible({ timeout: 10_000 });
+		const [standalone] = await Promise.all([
+			context.waitForEvent("page"),
+			openStandalone.click(),
+		]);
+		await standalone.setViewportSize({ width: 1700, height: 1000 });
+		await standalone.waitForLoadState("domcontentloaded");
+		await expect(standalone, "standalone URL should preserve walkthrough/tab identity").toHaveURL(/walkthrough|pr-walkthrough/);
+		await expect(walkthroughPanel(standalone), "standalone route should render the ready walkthrough component").toBeVisible({ timeout: 15_000 });
+
+		const fullscreenState = () => standalone.evaluate(() => {
+			const s = (window as any).bobbitState ?? (window as any).__bobbitState;
+			return s?.previewPanelFullscreen === true;
+		});
+		const expandButton = () => standalone.locator(`${tid("preview-expand")}, button[title*="Expand preview"], button[title*="Expand walkthrough"]`).first();
+		const collapseButton = () => standalone.locator(`button[title*="Collapse preview"], button[title*="Collapse walkthrough"]`).first();
+
+		// (1) Fullscreen control is present and clicking it enters fullscreen.
+		const fullscreenButton = standalone.locator(`${tid("pr-walkthrough-fullscreen")}, ${tid("side-panel-fullscreen")}, button[title*="Fullscreen"]`).first();
+		await expect(fullscreenButton, "standalone ready walkthrough must expose a fullscreen resize control").toBeVisible({ timeout: 10_000 });
+		await fullscreenButton.click();
+		await expect.poll(fullscreenState, { timeout: 10_000, message: "clicking the standalone fullscreen control must enter fullscreen" }).toBe(true);
+
+		// (2) A keyboard shortcut operates on the standalone walkthrough panel.
+		// toggle-preview (Ctrl+]) steps fullscreen → split.
+		await standalone.keyboard.press("Control+]");
+		await expect.poll(fullscreenState, { timeout: 10_000, message: "the toggle-preview keyboard shortcut must exit fullscreen on the standalone walkthrough panel" }).toBe(false);
+		await expect(walkthroughPanel(standalone), "exiting fullscreen should keep the standalone walkthrough in split view").toBeVisible({ timeout: 10_000 });
+
+		// (3) Collapse control is present and collapses the panel.
+		await expect(collapseButton(), "standalone ready walkthrough must expose a collapse resize control").toBeVisible({ timeout: 10_000 });
+		await collapseButton().click();
+		await expect(expandButton(), "collapsing the standalone walkthrough must reveal an expand control").toBeVisible({ timeout: 10_000 });
+		await expect(walkthroughPanel(standalone), "collapsed standalone walkthrough should hide the panel body").toBeHidden({ timeout: 10_000 });
+
+		// Collapsed state persists across reload.
+		await standalone.reload();
+		await standalone.waitForLoadState("domcontentloaded");
+		await expect(expandButton(), "collapsed standalone walkthrough state must persist across reload").toBeVisible({ timeout: 15_000 });
+
+		// Expanding restores the panel body.
+		await expandButton().click();
+		await expect(walkthroughPanel(standalone), "expanding should restore the standalone walkthrough panel body").toBeVisible({ timeout: 10_000 });
+
+		await standalone.close();
+	});
+
 	test("slash command creates a child session, waits for YAML, then applies interactive ready cards", async ({ page, context }) => {
 		const waiting = await setupWaitingWalkthrough(page, { width: 1920, height: 1080 }, "/walkthrough-pr 789");
 		await expect(page.getByTestId("pr-walkthrough-panel-root"), "child should remain in waiting state until YAML submission succeeds").toHaveAttribute("data-walkthrough-status", "waiting_for_yaml");


### PR DESCRIPTION
## Problem
On the PR walkthrough panel the expand-to-fullscreen button, the collapse button, and the panel keyboard shortcuts (`toggle-sidebar`, `toggle-preview`, `toggle-fullscreen-preview`) were all non-functional for walkthroughs at once.

## Root cause
A divergent session-key / render-path problem. Panel-tab **detection** used `panelWorkspaceSessionKey(activeSessionId())` / `workspaceSessionId()`, but the resize **controls**, the collapse localStorage key, and the in-app live-detection predicate used bare `activeSessionId()` — which is `undefined` on the standalone `/walkthrough` route. The standalone route also rendered no resize toolbar and ignored the fullscreen/collapse state, and `isLiveSessionHostedWalkthroughActive()` over-matched (treating any walkthrough viewed in its owner session as "live").

## Fix
- **`src/app/render.ts`**: `workspaceSessionId()` is route-aware (uses `route.walkthroughSessionId` on the standalone route); `previewCollapseKey()` keys off it. `standaloneWalkthroughPanel()` renders the fullscreen + collapse toolbar and honors `previewPanelFullscreen` / `isPreviewCollapsed()`. `isLiveSessionHostedWalkthroughActive()` narrowed to only treat a genuinely-running pr-walkthrough host as live (via `gatewaySessions` status AND `archivedSessions`).
- **`src/app/main.ts`**: `hasActiveWalkthroughPanel()` route-aware; the three resize shortcut handlers key the collapse localStorage key off `workspaceSessionId()`.
- **`src/app/pr-walkthrough.ts`**: `keepLiveWalkthroughPanelPromptable()` skips the fullscreen reset / collapse-key removal on the standalone route.

## Behavior preserved
Live child-session walkthroughs stay in split/promptable view and never enter fullscreen; standalone preview-panel behavior unchanged; open-in-new-tab standalone-wide route unchanged.

## Tests
New browser E2E in `tests/e2e/ui/pr-walkthrough-panel.spec.ts` ("standalone ready walkthrough exposes working fullscreen, collapse, and keyboard resize controls") — fails on master, passes after the fix; covers fullscreen + collapse + keyboard shortcut + persistence across reload, with a live-child split-view guard. Full `pr-walkthrough-panel` (20), `preview-fullscreen-controls`, and `pr-walkthrough-real` (4) specs pass. Docs added in `docs/pr-walkthrough-panel.md`; analysis in `docs/design/walkthrough-panel-resize-fix.md`.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)