### PR TITLE
Fix staff worktree provisioning in poly-repo projects

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -271,6 +271,12 @@ See [docs/archived-proposal-reopen.md](archived-proposal-reopen.md) for the full
   4. Reload during preparing. The server replays current status on `auth_ok` (`src/server/ws/handler.ts`). If the banner still appears, the live-path bug is the regression; if it doesn't, the replay path also broke — inspect the `auth_ok` write path.
 - **Regression test**: `tests/e2e/ui/preparing-ux.spec.ts` (browser E2E). It artificially extends the preparing window so the banner is observable, asserts visibility + editor disabled, then asserts both clear once the session goes idle.
 
+## Staff/session creation in a poly-repo fails with `git worktree add ... fatal: not a git repository`, or staff silently gets no worktree
+
+- **Symptom**: creating a **staff** member (or session) in a **poly-repo** project — root is *not* a git repo, but contains git sub-repos registered as components with `repo != "."` — fails with a raw `Command failed: git worktree add -b ...` / `fatal: not a git repository`, or the staff agent silently lands with no worktree while a regular session for the same project gets one.
+- **Root cause**: worktree-capability resolution had diverged across the three creation paths. The staff path required **every** declared repo (including a non-git `.` container) to pass `isGitRepo`, so a poly-repo either bailed to unsupported or ran `git worktree add` against the non-git container root.
+- **Fix / where to look**: capability is now decided by the single source of truth `src/server/agent/worktree-support.ts::resolveWorktreeSupport(components, projectRoot, cwd)`, used identically by the session (`server.ts` `POST /api/sessions`), staff (`staff-manager.ts::projectSupportsWorktree`), and goal (`goal-manager.ts::createGoal`) paths. `createWorktreeSet` (`src/server/skills/git.ts`) keeps only component dirs that are git repo **roots** (via `isGitRepoRoot`, which distinguishes "is a repo root" from "inside a repo" — avoiding the nested-parent false positive), skipping the non-git container, data-only and missing dirs; if none remain it returns an empty set and callers fall back to no-worktree instead of throwing. Full rationale in [docs/design/multi-repo-components.md §4.4–4.5](design/multi-repo-components.md).
+
 ## Compaction
 
 - Check `_isCompacting` and `_usageStaleAfterCompaction` in `remote-agent.ts`. The compaction placeholder is a reducer action (`compaction-placeholder` / `compaction-result`) — see `src/app/message-reducer.ts`.

--- a/docs/design/multi-repo-components.md
+++ b/docs/design/multi-repo-components.md
@@ -44,6 +44,8 @@ multi-repo:    <rootPath>/                 ← container dir (NOT a repo)
 
 The agent's cwd in multi-repo is `<branchSlug>/` (the per-branch container), mirroring `rootPath`'s structure exactly.
 
+A single resolver — `worktree-support.ts::resolveWorktreeSupport` — decides worktree capability for the session, staff, and goal paths alike, and `createWorktreeSet` only worktrees component dirs that are real git repo roots (skipping the non-git poly-repo container). See §4.4 / §4.5.
+
 ---
 
 ## 1. Project model — components as first-class
@@ -463,6 +465,41 @@ In multi-repo, the container directory is created (`mkdir -p`) but is not itself
 ### 4.3 Existing call sites to refactor
 
 All paths in `src/server/agent/{goal-manager,session-manager,session-setup,worktree-pool}.ts` and `src/server/skills/git.ts` that currently compute `<repoPath>-wt/<branchSlug>` must call `branchContainer()` / `repoWorktreePath()` instead. Search guard: grep for `-wt`, `path.basename(repoPath)`, `path.resolve(repoPath, "..")` — replace with helpers.
+
+### 4.4 Worktree-capability resolution — single source of truth
+
+**Problem.** "Does this project support a worktree, and what is the container `repoPath`?" was answered in three places with three different rules — the session REST path (`server.ts` `POST /api/sessions`), the staff path (`staff-manager.ts`), and the goal path (`goal-manager.ts::createGoal`). The staff rule was the buggy outlier: it iterated `repoNames()` and required **every** declared repo — including a non-git `.` container in a poly-repo — to pass `isGitRepo`. In a poly-repo (a project whose root is *not* a git repo but contains git sub-repos as components), that either bailed to `supported:false` or, worse, drove `git worktree add` against the non-git container root and failed with `fatal: not a git repository`. Staff creation diverged from session creation for the same project — the opposite of the stated staff↔session parity premise.
+
+**Fix.** `src/server/agent/worktree-support.ts::resolveWorktreeSupport(components, projectRoot, cwd)` is now the single source of truth. It returns `{ supported, repoPath?, multiRepo }` and is called identically by all three paths (session, staff, goal). Centralising the decision is the whole point: a poly-repo now resolves the same way no matter who asks, so staff behaves exactly like a regular session.
+
+The decision rule:
+
+- **Multi-repo** (any component `repo !== "."`): worktrees anchor at `projectRoot` **only**. `supported` is true iff `projectRoot` is known **and** at least one distinct component repo resolves to a git repo **root** beneath it (probed with `isGitRepoRoot`, see §4.5). On success: `repoPath = projectRoot`, `multiRepo: true`. Multi-repo **never** falls through to a `cwd`/ancestor probe — doing so would let a non-git container nested inside an *unrelated* parent git repo resolve to that parent and reintroduce the bug.
+- **Single-repo** (no component `repo !== "."`): if `cwd` is inside a git repo, `repoPath = getRepoRoot(cwd)`, `multiRepo: false`, `supported: true`; otherwise unsupported.
+- **Otherwise unsupported** → callers proceed with **no worktree** (run in the original `cwd`), never throw.
+
+Call sites: `server.ts` (session) sets `worktreeOpts.repoPath` from `support.repoPath` when supported; `staff-manager.ts::projectSupportsWorktree` delegates wholesale and forwards `components`; `goal-manager.ts::createGoal` sets `repoPath` from it.
+
+### 4.5 `createWorktreeSet` skips non-git component dirs; graceful no-worktree fallback
+
+**`isGitRepoRoot` vs `isGitRepo` (`src/server/skills/git.ts`).** `isGitRepo(dir)` runs `git rev-parse --is-inside-work-tree`, which returns true for **any** path *inside* a repo — including a non-git poly-repo container that merely happens to sit under an unrelated parent git repo (the "nested-parent false positive"). `isGitRepoRoot(dir)` instead compares the canonicalized `git rev-parse --show-toplevel` against the canonicalized input dir, so it is true **only when `dir` is itself a repo root** (canonicalization is win32 case-insensitive). The distinction matters because acting on the false positive would run `git worktree add` against a directory that is not a worktree-able repo.
+
+**Skip rule.** In multi-repo mode, `createWorktreeSet(rootPath, components, branch, …)` now keeps a distinct repo only if its source dir (`<rootPath>/<repo>`) passes `isGitRepoRoot`. One rule covers four cases that must all be skipped:
+
+- the non-git `.` container in a poly-repo (the original `fatal: not a git repository` crash),
+- the nested-parent false positive (non-git container under an unrelated parent git repo),
+- non-git, data-only components, and
+- components whose source dir is missing.
+
+A `.` entry whose source *is* a git repo root (a genuine single-repo / container-root component) is still kept, so single-repo and normal all-git multi-repo behaviour is unchanged.
+
+**Graceful no-worktree fallback.** If no worktree-able git repo remains after the skip pass, `createWorktreeSet` short-circuits and returns an empty `worktrees: []` **without creating the container directory** — it never runs `git worktree add` against the non-git root. Each caller treats an empty set (or `supported:false` from §4.4) as "no worktree": run in the original `cwd`, leave `worktreePath` / `repoWorktrees` unset.
+
+- `staff-manager.ts::provisionStaffWorktree` → returns `{ sessionCwd: cwd }`.
+- `session-setup.ts::executeWorktreeAsync` → sets `noWorktreeFallback`, skips per-component setup and sandbox-branch wiring, leaves `plan.cwd` unchanged.
+- `goal-manager.ts::_doSetupWorktree` → calls `_restoreNoWorktree`, which clears the precomputed `worktreePath`/`repoWorktrees` and resets the goal `cwd` to its original (un-offset) project path.
+
+**Net effect.** Staff creation in a poly-repo now produces one worktree per git sub-repo under the branch container — byte-for-byte the same shape a regular session produces for the same project. Projects with no worktree-able git repo fall back to no-worktree instead of throwing.
 
 ---
 

--- a/src/server/agent/goal-manager.ts
+++ b/src/server/agent/goal-manager.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { GoalStore, type GoalState, type PersistedGoal } from "./goal-store.js";
 import { createWorktree, createWorktreeSet, isGitRepo, getRepoRoot } from "../skills/git.js";
+import { resolveWorktreeSupport } from "./worktree-support.js";
 import type { WorkflowStore, Workflow } from "./workflow-store.js";
 import type { WorktreePool } from "./worktree-pool.js";
 import type { Component } from "./project-config-store.js";
@@ -127,16 +128,16 @@ export class GoalManager {
 		let setupStatus: "ready" | "preparing" = "ready";
 
 		// Detect git repo root — needed for team operations even without a worktree.
-		// Multi-repo: override `repoPath` with the project's container root so the
-		// per-repo worktrees land beneath one shared `<rootPath>-wt/<branch>/`.
+		// Single source of truth shared with the session path (server.ts) and the
+		// staff path (staff-manager.ts): a multi-repo project resolves to its
+		// container root as `repoPath` (per-repo worktrees land beneath one shared
+		// `<rootPath>-wt/<branch>/`) ONLY when at least one component is a git repo
+		// root; otherwise it falls back to the single-repo `isGitRepo(cwd)` probe,
+		// and to no-worktree when that also fails (never throws).
 		const components = projectId && this.componentsResolver ? this.componentsResolver(projectId) : undefined;
-		const isMulti = !!components && components.some(c => c.repo !== ".");
 		const projectRoot = projectId && this.projectRootResolver ? this.projectRootResolver(projectId) : undefined;
-		if (isMulti && projectRoot) {
-			repoPath = projectRoot;
-		} else if (await isGitRepo(cwd)) {
-			repoPath = await getRepoRoot(cwd);
-		}
+		const support = await resolveWorktreeSupport(components ?? [], projectRoot, cwd);
+		if (support.supported) repoPath = support.repoPath;
 
 		// Compute worktree path and branch (but don't create yet)
 		if (worktree && repoPath) {
@@ -287,6 +288,17 @@ export class GoalManager {
 					? this.baseRefResolver(goal.projectId) : undefined;
 				if (isMulti && components) {
 					const set = await createWorktreeSet(goal.repoPath!, components, goal.branch!, undefined, { worktreeRoot: worktreeRootOverride, configuredBaseRef });
+					// Defense-in-depth: if no worktree-able git sub-repo remained
+					// (createWorktreeSet skips the non-git container and non-git
+					// sub-repos), fall back gracefully to no-worktree — mark ready
+					// with cwd unchanged rather than throwing. resolveWorktreeSupport
+					// normally prevents reaching here (repoPath stays unset, so
+					// setupWorktree isn't called), but guard anyway.
+					if (set.worktrees.length === 0) {
+						this.store.update(goal.id, { setupStatus: "ready", setupError: undefined });
+						console.warn(`[goal-manager] No worktree-able repo for goal "${goal.title}" — proceeding without a worktree`);
+						return;
+					}
 					// Per-component setup commands run after the worktree set lands.
 					// Non-fatal on failure (worktree is still usable). See worktree-setup.ts.
 					try {

--- a/src/server/agent/goal-manager.ts
+++ b/src/server/agent/goal-manager.ts
@@ -290,12 +290,16 @@ export class GoalManager {
 					const set = await createWorktreeSet(goal.repoPath!, components, goal.branch!, undefined, { worktreeRoot: worktreeRootOverride, configuredBaseRef });
 					// Defense-in-depth: if no worktree-able git sub-repo remained
 					// (createWorktreeSet skips the non-git container and non-git
-					// sub-repos), fall back gracefully to no-worktree — mark ready
-					// with cwd unchanged rather than throwing. resolveWorktreeSupport
-					// normally prevents reaching here (repoPath stays unset, so
+					// sub-repos), fall back gracefully to no-worktree. The goal
+					// should run in its ORIGINAL project cwd with no worktree —
+					// the precomputed worktreePath/cwd point at a branch container
+					// that was never created, so restore the no-worktree state:
+					// clear worktreePath/repoWorktrees and reset cwd to the
+					// un-offset project cwd. resolveWorktreeSupport normally
+					// prevents reaching here (repoPath stays unset, so
 					// setupWorktree isn't called), but guard anyway.
 					if (set.worktrees.length === 0) {
-						this.store.update(goal.id, { setupStatus: "ready", setupError: undefined });
+						this._restoreNoWorktree(goal, preliminaryOffset);
 						console.warn(`[goal-manager] No worktree-able repo for goal "${goal.title}" — proceeding without a worktree`);
 						return;
 					}
@@ -379,6 +383,34 @@ export class GoalManager {
 			setupError: String(lastError),
 		});
 		throw lastError;
+	}
+
+	/**
+	 * Restore a goal to a no-worktree state when worktree setup produced no
+	 * worktree (e.g. createWorktreeSet skipped every non-git sub-repo). The
+	 * precomputed worktreePath/cwd (set in createGoal) point at a branch
+	 * container that was never created, so we must:
+	 *   - clear worktreePath + repoWorktrees, and
+	 *   - reset cwd to the ORIGINAL project cwd (the un-offset goal cwd, before
+	 *     the worktree offset was applied) = repoPath + the same subdirectory
+	 *     offset that createGoal computed via path.relative(repoPath, cwd).
+	 * setupStatus becomes "ready" with no setupError. The goal then runs in its
+	 * original project cwd with no worktree — mirroring resolveWorktreeSupport
+	 * returning unsupported.
+	 *
+	 * `store.update` strips undefined values (so it can't clear fields); mutate
+	 * the live goal reference directly to delete worktreePath/repoWorktrees.
+	 */
+	private _restoreNoWorktree(goal: PersistedGoal, preliminaryOffset: string): void {
+		const originalCwd = preliminaryOffset && preliminaryOffset !== "."
+			? path.join(goal.repoPath!, preliminaryOffset)
+			: goal.repoPath!;
+		const live = this.store.get(goal.id);
+		if (live) {
+			delete live.worktreePath;
+			delete live.repoWorktrees;
+		}
+		this.store.update(goal.id, { cwd: originalCwd, setupStatus: "ready", setupError: undefined });
 	}
 
 	/**

--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -706,7 +706,12 @@ export async function executeWorktreeAsync(
 	}
 
 	// Use pre-built worktree from pool, or create one from scratch
-	let worktreeCwd: string;
+	let worktreeCwd: string = plan.cwd;
+	// Defense-in-depth: set when no worktree-able repo remained (multi-repo
+	// declaration whose sub-repos aren't git repos). resolveWorktreeSupport
+	// normally prevents reaching here, but if it does we run the session in the
+	// original cwd with no worktree rather than pointing at a missing container.
+	let noWorktreeFallback = false;
 	if (preBuiltWorktreePath) {
 		worktreeCwd = preBuiltWorktreePath;
 		console.log(`[session-setup] Using pre-built worktree for session ${session.id}: ${worktreeCwd}`);
@@ -728,13 +733,19 @@ export async function executeWorktreeAsync(
 				async () => createWorktreeSet(plan.repoPath!, components, plan.branch!, undefined, { worktreeRoot, configuredBaseRef }),
 				{ retries: 2, delays: [1000, 2000], label: "createWorktreeSet", sessionId: plan.id },
 			);
-			worktreeCwd = result.container;
-			// Mirror the pool-claim path: record per-repo worktrees for archive cleanup.
-			session.repoWorktrees = result.worktrees.map(w => ({
-				repo: w.repo,
-				repoPath: w.repoPath,
-				worktreePath: w.worktreePath,
-			}));
+			if (result.worktrees.length === 0) {
+				// No worktree-able git sub-repo remained — fall back to no-worktree.
+				noWorktreeFallback = true;
+				console.warn(`[session-setup] No worktree-able repo for session ${session.id}; running without a worktree in ${plan.cwd}`);
+			} else {
+				worktreeCwd = result.container;
+				// Mirror the pool-claim path: record per-repo worktrees for archive cleanup.
+				session.repoWorktrees = result.worktrees.map(w => ({
+					repo: w.repo,
+					repoPath: w.repoPath,
+					worktreePath: w.worktreePath,
+				}));
+			}
 		} else {
 			worktreeCwd = await withRetry(
 				async () => {
@@ -746,8 +757,9 @@ export async function executeWorktreeAsync(
 		}
 
 		// Per-component setup — non-fatal on failure. Routes through the canonical
-		// resolver so component.relativePath is honored.
-		if (components.length > 0) {
+		// resolver so component.relativePath is honored. Skipped entirely in the
+		// no-worktree fallback (there is no branch container to set up).
+		if (!noWorktreeFallback && components.length > 0) {
 			try {
 				const { runComponentSetups } = await import("../skills/worktree-setup.js");
 				const { execShellCommand } = await import("./shell-util.js");
@@ -765,36 +777,44 @@ export async function executeWorktreeAsync(
 		}
 	}
 
-	// For sandboxed sessions, set sandboxBranch so applySandboxWiring() creates
-	// the worktree inside the container (via ProjectSandbox.createWorktree).
-	// The host worktree is still kept for server-side bookkeeping (worktreePath).
-	if (plan.sandboxed && !plan.sandboxBranch && plan.branch) {
-		plan.sandboxBranch = plan.branch;
-		// No baseBranch for regular sessions — they branch from HEAD
-	}
+	if (noWorktreeFallback) {
+		// No worktree was created — run the session in its original cwd exactly
+		// like a no-worktree session. Do NOT set worktreePath/repoWorktrees and
+		// skip the sandbox-branch wiring that assumes a real branch container.
+		// plan.cwd / session.cwd are left unchanged (the original project cwd).
+		console.log(`[session-setup] Session ${session.id} running without a worktree in ${plan.cwd}`);
+	} else {
+		// For sandboxed sessions, set sandboxBranch so applySandboxWiring() creates
+		// the worktree inside the container (via ProjectSandbox.createWorktree).
+		// The host worktree is still kept for server-side bookkeeping (worktreePath).
+		if (plan.sandboxed && !plan.sandboxBranch && plan.branch) {
+			plan.sandboxBranch = plan.branch;
+			// No baseBranch for regular sessions — they branch from HEAD
+		}
 
-	// Apply subdirectory offset: if the session's original CWD (project rootPath) is a
-	// subdirectory of the repo, offset the working directory within the worktree.
-	const originalCwd = plan.cwd;
-	const relativeOffset = plan.repoPath ? path.relative(plan.repoPath, originalCwd) : "";
-	const sandboxCwdOffset = normalizeSandboxCwdOffset(relativeOffset);
-	if (sandboxCwdOffset) plan.sandboxCwdOffset = sandboxCwdOffset;
-	const offsetCwd = relativeOffset && relativeOffset !== "."
-		? path.join(worktreeCwd, relativeOffset)
-		: worktreeCwd;
+		// Apply subdirectory offset: if the session's original CWD (project rootPath) is a
+		// subdirectory of the repo, offset the working directory within the worktree.
+		const originalCwd = plan.cwd;
+		const relativeOffset = plan.repoPath ? path.relative(plan.repoPath, originalCwd) : "";
+		const sandboxCwdOffset = normalizeSandboxCwdOffset(relativeOffset);
+		if (sandboxCwdOffset) plan.sandboxCwdOffset = sandboxCwdOffset;
+		const offsetCwd = relativeOffset && relativeOffset !== "."
+			? path.join(worktreeCwd, relativeOffset)
+			: worktreeCwd;
 
-	// Update session and plan with worktree CWD (offset applied)
-	session.cwd = offsetCwd;
-	session.worktreePath = worktreeCwd;
-	plan.cwd = offsetCwd;
-	const persistFields: Record<string, unknown> = { cwd: offsetCwd, worktreePath: worktreeCwd };
-	if (session.repoWorktrees && session.repoWorktrees.length > 0) {
-		persistFields.repoWorktrees = Object.fromEntries(
-			session.repoWorktrees.map(w => [w.repo, w.worktreePath]),
-		);
+		// Update session and plan with worktree CWD (offset applied)
+		session.cwd = offsetCwd;
+		session.worktreePath = worktreeCwd;
+		plan.cwd = offsetCwd;
+		const persistFields: Record<string, unknown> = { cwd: offsetCwd, worktreePath: worktreeCwd };
+		if (session.repoWorktrees && session.repoWorktrees.length > 0) {
+			persistFields.repoWorktrees = Object.fromEntries(
+				session.repoWorktrees.map(w => [w.repo, w.worktreePath]),
+			);
+		}
+		ctx.store.update(session.id, persistFields);
+		console.log(`[session-setup] Worktree ready for session ${session.id}: ${worktreeCwd} (branch: ${plan.branch})`);
 	}
-	ctx.store.update(session.id, persistFields);
-	console.log(`[session-setup] Worktree ready for session ${session.id}: ${worktreeCwd} (branch: ${plan.branch})`);
 
 	// Run remaining pipeline steps on the worktree CWD
 	resolveBridgeOptions(plan, ctx);

--- a/src/server/agent/staff-manager.ts
+++ b/src/server/agent/staff-manager.ts
@@ -9,10 +9,11 @@ import type { ProjectContextManager } from "./project-context-manager.js";
 import type { InboxManager } from "./inbox-manager.js";
 import { SYSTEM_PROJECT_ID } from "./project-registry.js";
 import type { Component } from "./project-config-store.js";
-import { createWorktree, createWorktreeSet, cleanupWorktree, resolveBaseRef, isGitRepo, getRepoRoot } from "../skills/git.js";
+import { createWorktree, createWorktreeSet, cleanupWorktree, resolveBaseRef } from "../skills/git.js";
 import { runComponentSetups } from "../skills/worktree-setup.js";
 import { execShellCommand } from "./shell-util.js";
 import { shouldCreateWorktree } from "./worktree-decision.js";
+import { resolveWorktreeSupport } from "./worktree-support.js";
 
 const execFile = promisify(execFileCb);
 
@@ -195,25 +196,13 @@ export class StaffManager {
 		const ctx = this.pcm.getOrCreate(projectId);
 		if (!ctx) return { supported: false, multiRepo: false, components: [] };
 		const components = ctx.projectConfigStore.getComponents();
-		const multiRepo = ctx.projectConfigStore.isMultiRepo();
-		if (multiRepo) {
-			const repos = ctx.projectConfigStore.repoNames();
-			if (repos.length === 0) return { supported: false, multiRepo, components };
-			for (const repo of repos) {
-				const repoPath = path.join(ctx.project.rootPath, repo === "." ? "" : repo);
-				if (!await isGitRepo(repoPath)) {
-					return { supported: false, multiRepo, components };
-				}
-			}
-			return { supported: true, repoPath: ctx.project.rootPath, multiRepo, components };
-		}
-
-		try {
-			if (!await isGitRepo(cwd)) return { supported: false, multiRepo, components };
-			return { supported: true, repoPath: await getRepoRoot(cwd), multiRepo, components };
-		} catch {
-			return { supported: false, multiRepo, components };
-		}
+		// Single source of truth shared with the session path (server.ts) and the
+		// goal path (goal-manager.ts). A poly-repo (non-git container + git
+		// sub-repos) resolves `supported:true`, `repoPath = projectRoot`,
+		// `multiRepo:true` — identical to a regular session. A project with no
+		// worktree-able git repo resolves `supported:false` (graceful no-worktree).
+		const support = await resolveWorktreeSupport(components, ctx.project.rootPath, cwd);
+		return { ...support, components };
 	}
 
 	private async provisionStaffWorktree(projectId: string, name: string, id: string, cwd: string, worktree?: boolean): Promise<StaffWorktreePlan> {
@@ -236,6 +225,11 @@ export class StaffManager {
 
 		if (support.multiRepo) {
 			const set = await createWorktreeSet(support.repoPath, support.components, branchName, undefined, { worktreeRoot, configuredBaseRef });
+			// createWorktreeSet skips a non-git `.` container entry; if NO git
+			// sub-repo remained it returns an empty set (no container created).
+			// Fall back to no-worktree (session cwd unchanged) rather than pointing
+			// at a non-existent container.
+			if (set.worktrees.length === 0) return { sessionCwd: cwd };
 			worktreePath = set.container;
 			repoWorktrees = Object.fromEntries(set.worktrees.map(w => [w.repo, w.worktreePath]));
 		} else {

--- a/src/server/agent/worktree-support.ts
+++ b/src/server/agent/worktree-support.ts
@@ -11,13 +11,16 @@
  * goal used a different rule. This helper unifies them.
  *
  * Decision (identical for session, staff, and goal):
- *   1. Multi-repo (any component `repo !== "."`) AND a known project root ⇒
- *      `supported`, `repoPath = projectRoot`, `multiRepo:true`. The root need
- *      NOT itself be a git repo — per-repo worktrees land beneath it and
- *      `createWorktreeSet` skips any non-git `.` container entry.
- *   2. Else, if `cwd` is inside a git repo ⇒ `supported`, `repoPath =
- *      getRepoRoot(cwd)`, `multiRepo:false`.
- *   3. Else ⇒ not supported (caller proceeds with no worktree — never throws).
+ *   - Multi-repo (any component `repo !== "."`): worktrees anchor at
+ *     `projectRoot` ONLY. Supported iff a known `projectRoot` exists AND at
+ *     least one distinct component repo resolves to a git repo ROOT beneath it.
+ *     `repoPath = projectRoot`, `multiRepo:true`. Multi-repo NEVER falls
+ *     through to the `cwd`/ancestor probe — otherwise a non-git container
+ *     nested inside an UNRELATED parent git repo would resolve to that parent
+ *     and `createWorktreeSet` could run `git worktree add` against it.
+ *   - Single-repo (no component `repo !== "."`): if `cwd` is inside a git repo
+ *     ⇒ `supported`, `repoPath = getRepoRoot(cwd)`, `multiRepo:false`; else not
+ *     supported (caller proceeds with no worktree — never throws).
  *
  * See docs/design/multi-repo-components.md §4 + §5.
  */
@@ -62,24 +65,31 @@ export async function resolveWorktreeSupport(
 ): Promise<WorktreeSupport> {
 	const multiRepo = components.some(c => c.repo !== ".");
 
-	if (multiRepo && projectRoot) {
-		// Poly-repo: the container root IS the repoPath even when it isn't itself
-		// a git repo. `createWorktreeSet` worktrees each git sub-repo and skips a
-		// non-git `.` container entry. BUT only claim multi-repo support if at
-		// least one distinct component repo actually resolves to a git repo ROOT
-		// under projectRoot — otherwise there is nothing to worktree and claiming
-		// support would make `createWorktreeSet` (and downstream callers) operate
-		// on a non-existent container. Fall through to the single-repo probe.
-		const distinct = new Set<string>();
-		for (const c of components) {
-			if (distinct.has(c.repo)) continue;
-			distinct.add(c.repo);
-			const repoSrc = path.join(projectRoot, c.repo === "." ? "" : c.repo);
-			if (await deps.isGitRepoRoot(repoSrc)) {
-				return { supported: true, repoPath: projectRoot, multiRepo: true };
+	if (multiRepo) {
+		// Multi-repo worktrees anchor at `projectRoot` ONLY. Supported iff at
+		// least one distinct component repo resolves to a git repo ROOT beneath
+		// projectRoot. `createWorktreeSet` worktrees each such git sub-repo and
+		// skips a non-git `.` container entry. Multi-repo NEVER probes
+		// `cwd`/ancestor — probing it would let a non-git container nested inside
+		// an unrelated parent git repo resolve to that parent and reintroduce the
+		// nested-parent false positive (acceptance criterion 3).
+		try {
+			if (projectRoot) {
+				const distinct = new Set<string>();
+				for (const c of components) {
+					if (distinct.has(c.repo)) continue;
+					distinct.add(c.repo);
+					const repoSrc = path.join(projectRoot, c.repo === "." ? "" : c.repo);
+					if (await deps.isGitRepoRoot(repoSrc)) {
+						return { supported: true, repoPath: projectRoot, multiRepo: true };
+					}
+				}
 			}
+		} catch {
+			return { supported: false, multiRepo: true };
 		}
-		// No git repo root among the declared components — fall through.
+		// No projectRoot, or no git repo root among the declared components.
+		return { supported: false, multiRepo: true };
 	}
 
 	try {

--- a/src/server/agent/worktree-support.ts
+++ b/src/server/agent/worktree-support.ts
@@ -1,0 +1,68 @@
+/**
+ * Single source of truth for "does this project support a git worktree, and
+ * what is the container repoPath?".
+ *
+ * Shared by the session path (`server.ts` POST /api/sessions), the staff path
+ * (`staff-manager.ts::projectSupportsWorktree`), and the goal path
+ * (`goal-manager.ts::createGoal`). Before this helper existed, staff iterated
+ * `repoNames()` and required EVERY repo — including a non-git `.` container in a
+ * poly-repo — to pass `isGitRepo`, bailing to `supported:false` (or, worse,
+ * running `git worktree add` against the non-git container root). Session and
+ * goal used a different rule. This helper unifies them.
+ *
+ * Decision (identical for session, staff, and goal):
+ *   1. Multi-repo (any component `repo !== "."`) AND a known project root ⇒
+ *      `supported`, `repoPath = projectRoot`, `multiRepo:true`. The root need
+ *      NOT itself be a git repo — per-repo worktrees land beneath it and
+ *      `createWorktreeSet` skips any non-git `.` container entry.
+ *   2. Else, if `cwd` is inside a git repo ⇒ `supported`, `repoPath =
+ *      getRepoRoot(cwd)`, `multiRepo:false`.
+ *   3. Else ⇒ not supported (caller proceeds with no worktree — never throws).
+ *
+ * See docs/design/multi-repo-components.md §4 + §5.
+ */
+
+import type { Component } from "./project-config-store.js";
+import { isGitRepo as defaultIsGitRepo, getRepoRoot as defaultGetRepoRoot } from "../skills/git.js";
+
+export interface WorktreeSupport {
+	supported: boolean;
+	repoPath?: string;
+	multiRepo: boolean;
+}
+
+export interface WorktreeSupportDeps {
+	isGitRepo: (cwd: string) => Promise<boolean>;
+	getRepoRoot: (cwd: string) => Promise<string>;
+}
+
+/**
+ * Resolve worktree capability from `(components, projectRoot, cwd)`.
+ *
+ * @param components  The project's declared components (drives multi-repo detection).
+ * @param projectRoot The project's root directory (poly-repo container).
+ * @param cwd         The launch cwd (used for the single-repo `isGitRepo` probe).
+ * @param deps        Injectable git probes (defaults to the real git helpers).
+ */
+export async function resolveWorktreeSupport(
+	components: Component[],
+	projectRoot: string | undefined,
+	cwd: string,
+	deps: WorktreeSupportDeps = { isGitRepo: defaultIsGitRepo, getRepoRoot: defaultGetRepoRoot },
+): Promise<WorktreeSupport> {
+	const multiRepo = components.some(c => c.repo !== ".");
+
+	if (multiRepo && projectRoot) {
+		// Poly-repo: the container root IS the repoPath even when it isn't itself
+		// a git repo. `createWorktreeSet` worktrees each git sub-repo and skips a
+		// non-git `.` container entry.
+		return { supported: true, repoPath: projectRoot, multiRepo: true };
+	}
+
+	try {
+		if (!(await deps.isGitRepo(cwd))) return { supported: false, multiRepo };
+		return { supported: true, repoPath: await deps.getRepoRoot(cwd), multiRepo };
+	} catch {
+		return { supported: false, multiRepo };
+	}
+}

--- a/src/server/agent/worktree-support.ts
+++ b/src/server/agent/worktree-support.ts
@@ -22,8 +22,13 @@
  * See docs/design/multi-repo-components.md §4 + §5.
  */
 
+import path from "node:path";
 import type { Component } from "./project-config-store.js";
-import { isGitRepo as defaultIsGitRepo, getRepoRoot as defaultGetRepoRoot } from "../skills/git.js";
+import {
+	isGitRepo as defaultIsGitRepo,
+	getRepoRoot as defaultGetRepoRoot,
+	isGitRepoRoot as defaultIsGitRepoRoot,
+} from "../skills/git.js";
 
 export interface WorktreeSupport {
 	supported: boolean;
@@ -34,6 +39,7 @@ export interface WorktreeSupport {
 export interface WorktreeSupportDeps {
 	isGitRepo: (cwd: string) => Promise<boolean>;
 	getRepoRoot: (cwd: string) => Promise<string>;
+	isGitRepoRoot: (dir: string) => Promise<boolean>;
 }
 
 /**
@@ -48,15 +54,32 @@ export async function resolveWorktreeSupport(
 	components: Component[],
 	projectRoot: string | undefined,
 	cwd: string,
-	deps: WorktreeSupportDeps = { isGitRepo: defaultIsGitRepo, getRepoRoot: defaultGetRepoRoot },
+	deps: WorktreeSupportDeps = {
+		isGitRepo: defaultIsGitRepo,
+		getRepoRoot: defaultGetRepoRoot,
+		isGitRepoRoot: defaultIsGitRepoRoot,
+	},
 ): Promise<WorktreeSupport> {
 	const multiRepo = components.some(c => c.repo !== ".");
 
 	if (multiRepo && projectRoot) {
 		// Poly-repo: the container root IS the repoPath even when it isn't itself
 		// a git repo. `createWorktreeSet` worktrees each git sub-repo and skips a
-		// non-git `.` container entry.
-		return { supported: true, repoPath: projectRoot, multiRepo: true };
+		// non-git `.` container entry. BUT only claim multi-repo support if at
+		// least one distinct component repo actually resolves to a git repo ROOT
+		// under projectRoot — otherwise there is nothing to worktree and claiming
+		// support would make `createWorktreeSet` (and downstream callers) operate
+		// on a non-existent container. Fall through to the single-repo probe.
+		const distinct = new Set<string>();
+		for (const c of components) {
+			if (distinct.has(c.repo)) continue;
+			distinct.add(c.repo);
+			const repoSrc = path.join(projectRoot, c.repo === "." ? "" : c.repo);
+			if (await deps.isGitRepoRoot(repoSrc)) {
+				return { supported: true, repoPath: projectRoot, multiRepo: true };
+			}
+		}
+		// No git repo root among the declared components — fall through.
 	}
 
 	try {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -24,6 +24,7 @@ import { discoverSlashSkills, getSkillDirectories, getSlashSkill, buildSlashSkil
 import { TeamManager, GateDependencyError } from "./agent/team-manager.js";
 import { checkGateDependencies } from "./agent/gate-dependency-check.js";
 import { shouldCreateWorktree } from "./agent/worktree-decision.js";
+import { resolveWorktreeSupport } from "./agent/worktree-support.js";
 import { RoleStore } from "./agent/role-store.js";
 import { RoleManager } from "./agent/role-manager.js";
 import { ToolManager, copyDirRecursive } from "./agent/tool-manager.js";
@@ -3803,12 +3804,12 @@ async function handleApiRoute(
 			try {
 				const projCtx = resolvedProjectId ? projectContextManager.getOrCreate(resolvedProjectId) : undefined;
 				const proj = resolvedProjectId ? projectRegistry.get(resolvedProjectId) : undefined;
-				const isMulti = !!projCtx?.projectConfigStore.isMultiRepo();
-				if (isMulti && proj?.rootPath) {
-					worktreeOpts = { repoPath: proj.rootPath };
-				} else if (await isGitRepo(cwd)) {
-					const repoPath = await getRepoRoot(cwd);
-					worktreeOpts = { repoPath };
+				// Single source of truth shared with the staff path
+				// (staff-manager.ts) and goal path (goal-manager.ts).
+				const components = projCtx?.projectConfigStore.getComponents() ?? [];
+				const support = await resolveWorktreeSupport(components, proj?.rootPath, cwd);
+				if (support.supported && support.repoPath) {
+					worktreeOpts = { repoPath: support.repoPath };
 				}
 			} catch {
 				// Not a git repo or git not available — silently ignore

--- a/src/server/skills/git.ts
+++ b/src/server/skills/git.ts
@@ -224,6 +224,47 @@ export async function getRepoRoot(cwd: string): Promise<string> {
 	return stdout.toString().trim();
 }
 
+/**
+ * Canonicalize a path for robust equality comparison: resolve to absolute,
+ * follow symlinks via `realpathSync.native` where possible (no-op when the
+ * path doesn't exist), and lowercase on win32 where the filesystem is
+ * case-insensitive. Mirrors the comparison style of
+ * `worktree-pool.ts::resolveRepoToplevel`.
+ */
+function canonicalizePath(p: string): string {
+	let resolved = path.resolve(p);
+	try {
+		resolved = fs.realpathSync.native(resolved);
+	} catch {
+		// realpath fails when the path doesn't exist — fall back to resolve().
+	}
+	return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+/**
+ * Whether `dir` is the TOPLEVEL of a git working tree (i.e. a git repo ROOT),
+ * NOT merely a directory nested somewhere inside one.
+ *
+ * `isGitRepo` (which runs `git rev-parse --is-inside-work-tree`) returns true
+ * for ANY path inside a repo — including a non-git container that happens to be
+ * nested under an unrelated parent git repo. That false-positive would cause
+ * `createWorktreeSet` to run `git worktree add` against the container root. This
+ * helper distinguishes the two by comparing the canonicalized
+ * `git rev-parse --show-toplevel` against the canonicalized input dir.
+ *
+ * Returns false on any error (not a git repo, missing dir, git failure).
+ */
+export async function isGitRepoRoot(dir: string): Promise<boolean> {
+	try {
+		const { stdout } = await execGit(["rev-parse", "--show-toplevel"], { cwd: dir });
+		const toplevel = stdout.toString().trim();
+		if (!toplevel) return false;
+		return canonicalizePath(toplevel) === canonicalizePath(dir);
+	} catch {
+		return false;
+	}
+}
+
 export interface WorktreeResult {
 	worktreePath: string;
 	branchName: string;
@@ -449,16 +490,19 @@ export async function createWorktreeSet(
 		};
 	}
 
-	// Multi-repo: drop a non-git `.` container entry. In a poly-repo (non-git
-	// container root + git sub-repos) the component list may still carry a
-	// `repo: "."` entry pointing at the non-git container `rootPath`. Running
-	// `git worktree add` there fails with `fatal: not a git repository`, so it
-	// must never reach worktree creation. A `.` entry whose source IS a git repo
-	// (genuine container-root component) is kept. See docs/design/multi-repo-components.md.
+	// Multi-repo: keep a distinct repo ONLY if its source dir is itself a git
+	// repo ROOT. This skips, in one rule:
+	//   • the non-git `.` container in a poly-repo (running `git worktree add`
+	//     there fails with `fatal: not a git repository`),
+	//   • the nested-parent false-positive — a non-git container nested under an
+	//     UNRELATED parent git repo (where `isGitRepo` would return true), and
+	//   • non-git sub-repos and missing source dirs (graceful no-worktree).
+	// A `.` entry whose source IS a git repo root (genuine container-root
+	// component) is kept. See docs/design/multi-repo-components.md.
 	const repoList: string[] = [];
 	for (const repo of repos) {
-		if (repo === "." && !(await isGitRepo(rootPath))) continue;
-		repoList.push(repo);
+		const repoSrc = path.join(rootPath, repo === "." ? "" : repo);
+		if (await isGitRepoRoot(repoSrc)) repoList.push(repo);
 	}
 
 	// Multi-repo: container at `<wtRoot>/<branchSlug>/`, per-repo worktrees underneath.

--- a/src/server/skills/git.ts
+++ b/src/server/skills/git.ts
@@ -449,11 +449,31 @@ export async function createWorktreeSet(
 		};
 	}
 
+	// Multi-repo: drop a non-git `.` container entry. In a poly-repo (non-git
+	// container root + git sub-repos) the component list may still carry a
+	// `repo: "."` entry pointing at the non-git container `rootPath`. Running
+	// `git worktree add` there fails with `fatal: not a git repository`, so it
+	// must never reach worktree creation. A `.` entry whose source IS a git repo
+	// (genuine container-root component) is kept. See docs/design/multi-repo-components.md.
+	const repoList: string[] = [];
+	for (const repo of repos) {
+		if (repo === "." && !(await isGitRepo(rootPath))) continue;
+		repoList.push(repo);
+	}
+
 	// Multi-repo: container at `<wtRoot>/<branchSlug>/`, per-repo worktrees underneath.
 	// `worktreeRoot` honors the project-level `worktree_root` override; falls back
 	// to `<rootPath>-wt/` when unset.
 	const wtRoot = wtRootHelper({ rootPath, worktreeRoot: opts?.worktreeRoot });
 	const container = path.join(wtRoot, slug);
+
+	// If no worktree-able repo remains after skipping the non-git container,
+	// short-circuit WITHOUT creating the container directory. Callers treat an
+	// empty `worktrees[]` as "no worktree-able repo" (graceful no-worktree).
+	if (repoList.length === 0) {
+		return { container, worktrees: [] };
+	}
+
 	if (!fs.existsSync(container)) {
 		fs.mkdirSync(container, { recursive: true });
 	}
@@ -461,7 +481,7 @@ export async function createWorktreeSet(
 	const configuredBaseRefTrimmed = (opts?.configuredBaseRef ?? "").trim();
 
 	const out: Array<{ repo: string; repoPath: string; worktreePath: string }> = [];
-	for (const repo of repos) {
+	for (const repo of repoList) {
 		const repoSrc = path.join(rootPath, repo);
 		const wtPath = path.join(container, repo);
 		if (!fs.existsSync(repoSrc)) {

--- a/tests/e2e/multi-repo-flow-api.spec.ts
+++ b/tests/e2e/multi-repo-flow-api.spec.ts
@@ -121,11 +121,10 @@ test.describe("multi-repo flow API/data paths", () => {
 			const goal = await goalRes.json();
 			goalId = goal.id;
 
-			// Wait for setupStatus to settle — success or error. Phase 4a wiring
-			// for multi-repo goal worktrees is in progress; if the server didn't
-			// produce `repoWorktrees`, we just confirm the goal was created and
-			// move on (the API-level test in tests/e2e/multi-repo-goal.spec.ts
-			// will tighten once Phase 4a lands).
+			// Wait for setupStatus to settle — success or error. Multi-repo goal
+			// worktrees are wired: only git sub-repos get a worktree, while non-git
+			// data-only components are skipped. If the server didn't produce
+			// `repoWorktrees`, we just confirm the goal was created and move on.
 			const goalRecord: any = await pollUntil(
 				async () => {
 					const r = await apiFetch(`/api/goals/${goal.id}`);
@@ -137,8 +136,10 @@ test.describe("multi-repo flow API/data paths", () => {
 			expect(goalRecord.id).toBeTruthy();
 
 			if (goalRecord.repoWorktrees && Object.keys(goalRecord.repoWorktrees).length > 1) {
-				// Phase 4a has wired multi-repo goal worktrees — assert per-repo paths exist.
-				expect(Object.keys(goalRecord.repoWorktrees)).toEqual(expect.arrayContaining(["api", "web", "shared"]));
+				// Multi-repo goal worktrees are wired — only the git sub-repos get a
+				// worktree; the non-git data-only `shared` component is skipped.
+				expect(Object.keys(goalRecord.repoWorktrees).sort()).toEqual(["api", "web"]);
+				expect(goalRecord.repoWorktrees.shared).toBeUndefined();
 				for (const [, wtPath] of Object.entries(goalRecord.repoWorktrees as Record<string, string>)) {
 					expect(fs.existsSync(wtPath as string)).toBe(true);
 				}

--- a/tests/e2e/staff-cwd-parity.spec.ts
+++ b/tests/e2e/staff-cwd-parity.spec.ts
@@ -1,10 +1,11 @@
 import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test, expect } from "./in-process-harness.js";
-import { apiFetch, rawApiFetch, registerProject } from "./e2e-setup.js";
+import { apiFetch, rawApiFetch, registerProject, deleteSession } from "./e2e-setup.js";
+import { pollSessionUntil } from "./test-utils/pool-polling.mjs";
 
 type ProjectRecord = { id: string; rootPath: string; [key: string]: unknown };
 
@@ -59,6 +60,67 @@ async function createProject(name: string, rootPath: string): Promise<ProjectRec
 		rootPath,
 		seedWorkflows: false,
 	});
+}
+
+/**
+ * Register a multi-repo (poly-repo) project: a NON-git container `rootPath`
+ * with one git sub-repo per component. `components` declares the `repo`
+ * sub-directory names; a `repo: "."` container component may be included to
+ * exercise the exact poly-repo bug trigger.
+ */
+async function createMultiRepoProject(
+	name: string,
+	rootPath: string,
+	components: Array<{ name: string; repo: string }>,
+): Promise<ProjectRecord> {
+	return registerProject({
+		name,
+		rootPath,
+		components,
+		seedWorkflows: false,
+	});
+}
+
+async function getSession(id: string): Promise<any> {
+	const res = await apiFetch(`/api/sessions/${id}`);
+	expect(res.status, `session ${id} should be readable`).toBe(200);
+	return res.json();
+}
+
+/**
+ * Poll a session until its worktree set has actually been provisioned ON DISK.
+ *
+ * `worktreePath`/`branch` are assigned synchronously at session creation (the
+ * container path is pre-computed before `executeWorktreeAsync` runs), so they
+ * are NOT a reliable readiness signal. The async cold path only materialises
+ * the per-repo worktrees a moment later. We therefore poll until at least one
+ * expected sub-repo worktree directories exist on disk. Uses the canonical
+ * `pollSessionUntil` harness helper so the polling sleep stays in
+ * tests/e2e/test-utils/ (exempt from the no-new-sleeps lint).
+ */
+async function waitForSessionWorktree(id: string, expectedRepos: string[], timeoutMs = 30_000): Promise<any> {
+	const last = await pollSessionUntil(
+		id,
+		(row: any) => !!(row.worktreePath && row.branch)
+			&& expectedRepos.every(repo => existsSync(join(row.worktreePath, repo, ".git"))),
+		timeoutMs,
+	);
+	if (!last?.worktreePath || !last?.branch) {
+		throw new Error(`session ${id} did not provision a worktree within ${timeoutMs}ms (last=${JSON.stringify({ worktreePath: last?.worktreePath, branch: last?.branch, status: last?.status })})`);
+	}
+	return last;
+}
+
+/**
+ * The set of git sub-repos actually worktree'd under a branch container, as
+ * observed on disk. A worktree exists when `<container>/<repo>/.git` is
+ * present. The non-git container itself must NEVER carry a top-level `.git`
+ * (that would mean `git worktree add` ran against the container root).
+ */
+function worktreedReposOnDisk(container: string, candidateRepos: string[]): string[] {
+	return candidateRepos
+		.filter(repo => existsSync(join(container, repo, ".git")))
+		.sort();
 }
 
 async function postStaff(body: Record<string, unknown>): Promise<StaffCreateResult> {
@@ -117,12 +179,16 @@ function seedLegacySystemStaff(gateway: any, patch: Partial<any> = {}): any {
 
 test.describe("staff cwd parity regressions", () => {
 	let cleanupStaffIds: string[] = [];
+	let cleanupSessionIds: string[] = [];
 	let cleanupProjectIds: string[] = [];
 	let cleanupDirs: string[] = [];
 
 	test.afterEach(async () => {
 		for (const id of cleanupStaffIds.splice(0).reverse()) {
 			await deleteStaff(id);
+		}
+		for (const id of cleanupSessionIds.splice(0).reverse()) {
+			await deleteSession(id);
 		}
 		for (const id of cleanupProjectIds.splice(0).reverse()) {
 			await deleteProject(id);
@@ -384,6 +450,142 @@ test.describe("staff cwd parity regressions", () => {
 				`STAFF_CWD_PARITY_UPDATE_GUARD_PRESERVE: rejected ${label} must not mutate stored cwd`,
 			).toBe(normalisePath(originalCwd));
 		}
+	});
+
+	test("poly-repo staff creation matches session worktree shape and never worktrees the non-git container", async () => {
+		// ── Build a poly-repo project ──────────────────────────────────────
+		// A NON-git container root with two git sub-repos one level deep.
+		const root = makeTempRoot("polyrepo");
+		cleanupDirs.push(root);
+		cleanupDirs.push(`${root}-wt`);
+		makeGitRepo(root, "repo-a");
+		makeGitRepo(root, "repo-b");
+		// The container root itself is deliberately NOT a git repo.
+		expect(
+			existsSync(join(root, ".git")),
+			"STAFF_CWD_PARITY_POLYREPO: container root must NOT be a git repo (poly-repo precondition)",
+		).toBe(false);
+
+		// Register the project with the EXACT bug trigger: a `repo: "."` container
+		// component alongside the two git sub-repo components (multi-repo).
+		const project = await createMultiRepoProject(
+			`staff-cwd-polyrepo-${Date.now()}`,
+			root,
+			[
+				{ name: "container", repo: "." },
+				{ name: "a", repo: "repo-a" },
+				{ name: "b", repo: "repo-b" },
+			],
+		);
+		cleanupProjectIds.push(project.id);
+		const projectRoot = project.rootPath;
+		const wtRoot = `${projectRoot}-wt`;
+		const candidateRepos = ["repo-a", "repo-b"];
+
+		// ── Criterion 1 + 2: STAFF worktree shape ──────────────────────────
+		const created = await postStaff({
+			name: "Poly-repo staff",
+			systemPrompt: "Worktree each git sub-repo, never the non-git container.",
+			projectId: project.id,
+		});
+		if (created.status === 201 && created.json?.id) cleanupStaffIds.push(created.json.id);
+
+		expect(
+			created.status,
+			`STAFF_CWD_PARITY_POLYREPO: staff creation in a poly-repo must succeed (must not throw 'git worktree add' / 'not a git repository'). body=${created.text}`,
+		).toBe(201);
+
+		const staff = created.json;
+		expect(
+			staff.worktreePath,
+			"STAFF_CWD_PARITY_POLYREPO: poly-repo staff must allocate a branch container worktreePath",
+		).toBeTruthy();
+		expect(
+			isSameOrUnder(staff.worktreePath, wtRoot),
+			`STAFF_CWD_PARITY_POLYREPO: staff worktreePath=${staff.worktreePath} must be under the project worktree root ${wtRoot}`,
+		).toBe(true);
+
+		// Per-repo worktrees recorded on the staff record: exactly the two git
+		// sub-repos, NEVER the non-git "." container.
+		const staffRepoKeys = Object.keys((staff.repoWorktrees ?? {}) as Record<string, string>).sort();
+		expect(
+			staffRepoKeys,
+			`STAFF_CWD_PARITY_POLYREPO: staff.repoWorktrees must cover exactly the git sub-repos. got=${JSON.stringify(staff.repoWorktrees)}`,
+		).toEqual(["repo-a", "repo-b"]);
+		expect(
+			staffRepoKeys.includes("."),
+			"STAFF_CWD_PARITY_POLYREPO: the non-git '.' container must never appear in staff.repoWorktrees",
+		).toBe(false);
+
+		// On disk: each git sub-repo is worktree'd under the staff container; the
+		// container root was never worktree'd (no top-level .git).
+		const staffReposOnDisk = worktreedReposOnDisk(staff.worktreePath, candidateRepos);
+		expect(
+			staffReposOnDisk,
+			`STAFF_CWD_PARITY_POLYREPO: on-disk staff worktrees must be exactly the git sub-repos under ${staff.worktreePath}`,
+		).toEqual(["repo-a", "repo-b"]);
+		expect(
+			existsSync(join(staff.worktreePath, ".git")),
+			`STAFF_CWD_PARITY_POLYREPO: the non-git container ${staff.worktreePath} must never be worktree'd (no top-level .git)`,
+		).toBe(false);
+
+		// The permanent staff session runs inside the branch container.
+		const staffSession = await getSession(staff.currentSessionId);
+		expect(
+			isSameOrUnder(staffSession.cwd, staff.worktreePath),
+			`STAFF_CWD_PARITY_POLYREPO: staff session cwd=${staffSession.cwd} must run inside the staff branch container ${staff.worktreePath}`,
+		).toBe(true);
+
+		// ── Criterion 1 + 3: SESSION worktree shape (parity) ───────────────
+		const sessionRes = await rawApiFetch("/api/sessions", {
+			method: "POST",
+			body: JSON.stringify({
+				projectId: project.id,
+				worktree: true,
+			}),
+		});
+		const sessionCreate = await sessionRes.json();
+		if (sessionRes.status === 201 && sessionCreate?.id) cleanupSessionIds.push(sessionCreate.id);
+		expect(
+			sessionRes.status,
+			`STAFF_CWD_PARITY_POLYREPO: regular session creation in the same poly-repo must succeed. body=${JSON.stringify(sessionCreate)}`,
+		).toBe(201);
+
+		const session = await waitForSessionWorktree(sessionCreate.id, candidateRepos);
+		expect(
+			isSameOrUnder(session.worktreePath, wtRoot),
+			`STAFF_CWD_PARITY_POLYREPO: session worktreePath=${session.worktreePath} must be under the same project worktree root ${wtRoot}`,
+		).toBe(true);
+
+		const sessionReposOnDisk = worktreedReposOnDisk(session.worktreePath, candidateRepos);
+		expect(
+			sessionReposOnDisk,
+			`STAFF_CWD_PARITY_POLYREPO: on-disk session worktrees must be exactly the git sub-repos under ${session.worktreePath}`,
+		).toEqual(["repo-a", "repo-b"]);
+		expect(
+			existsSync(join(session.worktreePath, ".git")),
+			`STAFF_CWD_PARITY_POLYREPO: the non-git container ${session.worktreePath} must never be worktree'd for a session either`,
+		).toBe(false);
+
+		// ── Parity assertion ───────────────────────────────────────────────
+		// Staff and session must agree on WHICH repos get worktrees. They run on
+		// distinct branches (distinct containers under the same `<root>-wt/`), so
+		// parity is over the SET of worktree'd repos, not the absolute paths.
+		expect(
+			staffReposOnDisk,
+			`STAFF_CWD_PARITY_POLYREPO: staff and session must worktree the SAME set of repos. staff=${JSON.stringify(staffReposOnDisk)} session=${JSON.stringify(sessionReposOnDisk)}`,
+		).toEqual(sessionReposOnDisk);
+		expect(
+			staffRepoKeys,
+			"STAFF_CWD_PARITY_POLYREPO: staff.repoWorktrees keys must match the session's on-disk worktree set",
+		).toEqual(sessionReposOnDisk);
+
+		// Criterion 2 (belt-and-braces): the non-git container root itself was
+		// never turned into a git worktree by EITHER path.
+		expect(
+			existsSync(join(projectRoot, ".git")),
+			`STAFF_CWD_PARITY_POLYREPO: the registered non-git container root ${projectRoot} must remain non-git after staff + session creation`,
+		).toBe(false);
 	});
 
 	test("PUT /api/staff/:id accepts cwd inside the staff project", async () => {

--- a/tests/worktree-set-polyrepo.test.ts
+++ b/tests/worktree-set-polyrepo.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCb);
+
+// Skip push + npm ci / setup commands in tests. Must be set BEFORE importing git.js.
+process.env.BOBBIT_TEST_NO_PUSH = "1";
+process.env.BOBBIT_SKIP_NPM_CI = "1";
+
+import { createWorktreeSet } from "../src/server/skills/git.js";
+
+/** Run git in a given cwd */
+async function git(args: string[], cwd: string): Promise<string> {
+	const { stdout } = await execFile("git", args, { cwd });
+	return stdout.trim();
+}
+
+/** Build a real git sub-repo with an initial commit under `parent/<name>`. */
+async function makeGitRepo(parent: string, name: string): Promise<string> {
+	const repoDir = path.join(parent, name);
+	fs.mkdirSync(repoDir, { recursive: true });
+	await git(["-c", "init.defaultBranch=master", "init", repoDir], parent);
+	fs.writeFileSync(path.join(repoDir, "README.md"), `# ${name}\n`);
+	await git(["add", "."], repoDir);
+	await git(
+		["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "initial commit"],
+		repoDir,
+	);
+	return repoDir;
+}
+
+/**
+ * Reproducing test for the poly-repo staff worktree bug.
+ *
+ * A poly-repo project has a NON-git container `rootPath` containing git
+ * sub-repos one level deep, each registered as a component with `repo != "."`.
+ * The component list also includes the non-git container as `repo: "."`.
+ *
+ * `createWorktreeSet` (the single source of truth) must NOT run
+ * `git worktree add` against the non-git container — it should skip the
+ * `repo: "."` entry in multi-repo mode and produce exactly one worktree per
+ * git sub-repo.
+ *
+ * On CURRENT (buggy) code this test FAILS: the multi-repo loop runs
+ * `git worktree add -b <branch> <wt> HEAD` with cwd = the non-git container,
+ * throwing `createWorktreeSet: git worktree add failed for repo "."` /
+ * `fatal: not a git repository`.
+ */
+describe("createWorktreeSet poly-repo (non-git container + git sub-repos)", () => {
+	let root: string;
+	let wtRoot: string;
+	const branch = "staff-test-abcdef12";
+
+	before(async () => {
+		// Non-git container directory (deliberately NOT a git repo).
+		root = fs.mkdtempSync(path.join(os.tmpdir(), "wt-polyrepo-"));
+		// Two real git sub-repos one level deep.
+		await makeGitRepo(root, "repo-a");
+		await makeGitRepo(root, "repo-b");
+		wtRoot = path.resolve(path.dirname(root), path.basename(root) + "-wt");
+	});
+
+	after(() => {
+		fs.rmSync(root, { recursive: true, force: true });
+		fs.rmSync(wtRoot, { recursive: true, force: true });
+	});
+
+	it("skips the non-git '.' container and worktrees only the git sub-repos", async () => {
+		const components = [
+			{ name: "container", repo: "." },
+			{ name: "a", repo: "repo-a" },
+			{ name: "b", repo: "repo-b" },
+		];
+
+		// 1. The call must resolve (must NOT throw). On buggy code this throws
+		//    `git worktree add failed for repo "."` / `not a git repository`.
+		const set = await createWorktreeSet(root, components, branch);
+
+		// 2. Exactly the two git sub-repos are worktree'd — never the "." container.
+		const repos = set.worktrees.map((w) => w.repo).sort();
+		assert.deepStrictEqual(repos, ["repo-a", "repo-b"], "should worktree exactly the two git sub-repos");
+		assert.ok(
+			!set.worktrees.some((w) => w.repo === "."),
+			'no worktree entry should exist for the non-git "." container',
+		);
+
+		// 3. Each sub-repo worktree dir exists under <root>-wt/<branch>/<repo>/ with a .git.
+		for (const repo of ["repo-a", "repo-b"]) {
+			const expected = path.join(wtRoot, branch, repo);
+			const entry = set.worktrees.find((w) => w.repo === repo);
+			assert.ok(entry, `worktree entry for ${repo} should exist`);
+			assert.strictEqual(entry!.worktreePath, expected, `worktree path for ${repo} should be under the branch container`);
+			assert.ok(fs.existsSync(expected), `worktree dir for ${repo} should exist`);
+			assert.ok(fs.existsSync(path.join(expected, ".git")), `.git should exist in ${repo} worktree`);
+		}
+
+		// 4. The non-git container itself was never worktree'd — the branch
+		//    container directory must hold no top-level `.git` (which would mean
+		//    `git worktree add` ran against the container root).
+		const container = path.join(wtRoot, branch);
+		assert.ok(
+			!fs.existsSync(path.join(container, ".git")),
+			"the non-git container root must never be worktree'd",
+		);
+	});
+});

--- a/tests/worktree-set-polyrepo.test.ts
+++ b/tests/worktree-set-polyrepo.test.ts
@@ -109,3 +109,111 @@ describe("createWorktreeSet poly-repo (non-git container + git sub-repos)", () =
 		);
 	});
 });
+
+/**
+ * Regression (acceptance criterion 2): nested-parent container false-positive.
+ *
+ * A non-git poly-repo container nested INSIDE an unrelated parent git repo.
+ * `git rev-parse --is-inside-work-tree` (used by `isGitRepo`) returns TRUE for
+ * the container because of the parent repo, so the old skip rule kept the
+ * `repo: "."` entry and ran `git worktree add` against the container root.
+ * `isGitRepoRoot` must distinguish "inside a repo" from "is a repo root" so the
+ * `.` entry is still skipped.
+ */
+describe("createWorktreeSet poly-repo nested under an unrelated parent git repo", () => {
+	let parent: string;
+	let container: string;
+	let wtRoot: string;
+	const branch = "staff-nested-12345678";
+
+	before(async () => {
+		// Unrelated PARENT git repo.
+		parent = fs.mkdtempSync(path.join(os.tmpdir(), "wt-parent-"));
+		await git(["-c", "init.defaultBranch=master", "init", parent], path.dirname(parent));
+		fs.writeFileSync(path.join(parent, "README.md"), "# parent\n");
+		await git(["add", "."], parent);
+		await git(
+			["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "initial commit"],
+			parent,
+		);
+		// Non-git container INSIDE the parent working tree, with two git sub-repos.
+		container = path.join(parent, "polyrepo-container");
+		fs.mkdirSync(container, { recursive: true });
+		await makeGitRepo(container, "repo-a");
+		await makeGitRepo(container, "repo-b");
+		wtRoot = path.resolve(path.dirname(container), path.basename(container) + "-wt");
+	});
+
+	after(() => {
+		fs.rmSync(parent, { recursive: true, force: true });
+		fs.rmSync(wtRoot, { recursive: true, force: true });
+	});
+
+	it("skips the '.' container even though it is inside the parent repo", async () => {
+		const components = [
+			{ name: "container", repo: "." },
+			{ name: "a", repo: "repo-a" },
+			{ name: "b", repo: "repo-b" },
+		];
+
+		const set = await createWorktreeSet(container, components, branch);
+
+		const repos = set.worktrees.map((w) => w.repo).sort();
+		assert.deepStrictEqual(repos, ["repo-a", "repo-b"], "should worktree exactly the two git sub-repos");
+		assert.ok(
+			!set.worktrees.some((w) => w.repo === "."),
+			'the nested non-git "." container must be skipped (not a git repo ROOT)',
+		);
+
+		// The branch container must hold no top-level `.git` — proof that
+		// `git worktree add` never ran against the non-git container root.
+		const branchContainer = path.join(wtRoot, branch);
+		assert.ok(
+			!fs.existsSync(path.join(branchContainer, ".git")),
+			"the non-git container root must never be worktree'd",
+		);
+	});
+});
+
+/**
+ * Regression (acceptance criterion 3): multi-repo declaration with NO git
+ * sub-repos must fall back to no-worktree gracefully (empty set) rather than
+ * throwing `source repo not found` / `git worktree add` failures.
+ */
+describe("createWorktreeSet multi-repo with no git sub-repos", () => {
+	let root: string;
+	let wtRoot: string;
+	const branch = "staff-nogit-12345678";
+
+	before(() => {
+		// Non-git container with two NON-git sub-dirs.
+		root = fs.mkdtempSync(path.join(os.tmpdir(), "wt-nogit-"));
+		fs.mkdirSync(path.join(root, "repo-a"), { recursive: true });
+		fs.mkdirSync(path.join(root, "repo-b"), { recursive: true });
+		fs.writeFileSync(path.join(root, "repo-a", "file.txt"), "a\n");
+		fs.writeFileSync(path.join(root, "repo-b", "file.txt"), "b\n");
+		wtRoot = path.resolve(path.dirname(root), path.basename(root) + "-wt");
+	});
+
+	after(() => {
+		fs.rmSync(root, { recursive: true, force: true });
+		fs.rmSync(wtRoot, { recursive: true, force: true });
+	});
+
+	it("returns an empty worktree set and does not throw", async () => {
+		const components = [
+			{ name: "container", repo: "." },
+			{ name: "a", repo: "repo-a" },
+			{ name: "b", repo: "repo-b" },
+		];
+
+		const set = await createWorktreeSet(root, components, branch);
+		assert.deepStrictEqual(set.worktrees, [], "no git sub-repo ⇒ empty worktree set");
+
+		// No container directory should have been created for an empty set.
+		assert.ok(
+			!fs.existsSync(path.join(wtRoot, branch, ".git")),
+			"no worktree should have been created",
+		);
+	});
+});

--- a/tests/worktree-support.test.ts
+++ b/tests/worktree-support.test.ts
@@ -1,0 +1,99 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import path from "node:path";
+
+import { resolveWorktreeSupport, type WorktreeSupportDeps } from "../src/server/agent/worktree-support.js";
+import type { Component } from "../src/server/agent/project-config-store.js";
+
+/**
+ * Unit coverage for the single-source-of-truth worktree-support resolver,
+ * exercised through injected git probes (no real git). Pins the four decision
+ * branches that session, staff, and goal all share:
+ *   1. multi-repo with ≥1 git repo root ⇒ supported, repoPath = projectRoot.
+ *   2. multi-repo with NO git repo root ⇒ falls through to the single-repo probe.
+ *   3. single-repo git cwd ⇒ supported, repoPath = getRepoRoot(cwd).
+ *   4. non-git ⇒ unsupported (graceful no-worktree, never throws).
+ */
+function comp(repo: string): Component {
+	return { name: repo === "." ? "root" : repo, repo } as Component;
+}
+
+/** Build deps where only the listed dirs are git repo roots / git repos. */
+function makeDeps(opts: {
+	gitRoots?: string[];
+	gitRepos?: string[];
+	repoRoot?: string;
+}): WorktreeSupportDeps {
+	const roots = new Set((opts.gitRoots ?? []).map(p => path.resolve(p)));
+	const repos = new Set((opts.gitRepos ?? []).map(p => path.resolve(p)));
+	return {
+		isGitRepoRoot: async (dir: string) => roots.has(path.resolve(dir)),
+		isGitRepo: async (dir: string) => repos.has(path.resolve(dir)),
+		getRepoRoot: async (_dir: string) => opts.repoRoot ?? _dir,
+	};
+}
+
+describe("resolveWorktreeSupport", () => {
+	const projectRoot = "/proj/root";
+	const cwd = "/proj/root";
+
+	it("multi-repo with ≥1 git repo root ⇒ supported, repoPath = projectRoot", async () => {
+		const components = [comp("."), comp("repo-a"), comp("repo-b")];
+		const deps = makeDeps({ gitRoots: [path.join(projectRoot, "repo-a"), path.join(projectRoot, "repo-b")] });
+		const support = await resolveWorktreeSupport(components, projectRoot, cwd, deps);
+		assert.deepStrictEqual(support, { supported: true, repoPath: projectRoot, multiRepo: true });
+	});
+
+	it("multi-repo where ONLY the '.' entry is a git root ⇒ supported via the '.' root", async () => {
+		const components = [comp("."), comp("repo-a")];
+		const deps = makeDeps({ gitRoots: [projectRoot] });
+		const support = await resolveWorktreeSupport(components, projectRoot, cwd, deps);
+		assert.deepStrictEqual(support, { supported: true, repoPath: projectRoot, multiRepo: true });
+	});
+
+	it("multi-repo with NO git repo root ⇒ falls through to single-repo probe (unsupported when cwd non-git)", async () => {
+		const components = [comp("."), comp("repo-a"), comp("repo-b")];
+		const deps = makeDeps({ gitRoots: [], gitRepos: [] });
+		const support = await resolveWorktreeSupport(components, projectRoot, cwd, deps);
+		assert.deepStrictEqual(support, { supported: false, multiRepo: true });
+	});
+
+	it("multi-repo with NO git repo root but cwd IS a git repo ⇒ single-repo support", async () => {
+		const components = [comp("."), comp("repo-a")];
+		const deps = makeDeps({ gitRoots: [], gitRepos: [cwd], repoRoot: "/git/toplevel" });
+		const support = await resolveWorktreeSupport(components, projectRoot, cwd, deps);
+		assert.deepStrictEqual(support, { supported: true, repoPath: "/git/toplevel", multiRepo: true });
+	});
+
+	it("single-repo git cwd ⇒ supported, repoPath = getRepoRoot(cwd)", async () => {
+		const components = [comp(".")];
+		const deps = makeDeps({ gitRepos: [cwd], repoRoot: "/git/toplevel" });
+		const support = await resolveWorktreeSupport(components, projectRoot, cwd, deps);
+		assert.deepStrictEqual(support, { supported: true, repoPath: "/git/toplevel", multiRepo: false });
+	});
+
+	it("non-git single-repo ⇒ unsupported (graceful no-worktree)", async () => {
+		const components = [comp(".")];
+		const deps = makeDeps({ gitRepos: [] });
+		const support = await resolveWorktreeSupport(components, projectRoot, cwd, deps);
+		assert.deepStrictEqual(support, { supported: false, multiRepo: false });
+	});
+
+	it("multi-repo but no projectRoot ⇒ falls through to single-repo probe", async () => {
+		const components = [comp("."), comp("repo-a")];
+		const deps = makeDeps({ gitRoots: [], gitRepos: [cwd], repoRoot: "/git/toplevel" });
+		const support = await resolveWorktreeSupport(components, undefined, cwd, deps);
+		assert.deepStrictEqual(support, { supported: true, repoPath: "/git/toplevel", multiRepo: true });
+	});
+
+	it("never throws when a dep rejects — returns unsupported", async () => {
+		const components = [comp(".")];
+		const deps: WorktreeSupportDeps = {
+			isGitRepoRoot: async () => false,
+			isGitRepo: async () => { throw new Error("git boom"); },
+			getRepoRoot: async () => { throw new Error("git boom"); },
+		};
+		const support = await resolveWorktreeSupport(components, projectRoot, cwd, deps);
+		assert.deepStrictEqual(support, { supported: false, multiRepo: false });
+	});
+});

--- a/tests/worktree-support.test.ts
+++ b/tests/worktree-support.test.ts
@@ -7,10 +7,13 @@ import type { Component } from "../src/server/agent/project-config-store.js";
 
 /**
  * Unit coverage for the single-source-of-truth worktree-support resolver,
- * exercised through injected git probes (no real git). Pins the four decision
+ * exercised through injected git probes (no real git). Pins the decision
  * branches that session, staff, and goal all share:
  *   1. multi-repo with ≥1 git repo root ⇒ supported, repoPath = projectRoot.
- *   2. multi-repo with NO git repo root ⇒ falls through to the single-repo probe.
+ *   2. multi-repo with NO git repo root (or no projectRoot) ⇒ unsupported,
+ *      multiRepo:true — and NEVER probes cwd/ancestor (no isGitRepo/getRepoRoot
+ *      calls). Probing cwd would let a non-git container nested inside an
+ *      unrelated parent git repo resolve to that parent (acceptance criterion 3).
  *   3. single-repo git cwd ⇒ supported, repoPath = getRepoRoot(cwd).
  *   4. non-git ⇒ unsupported (graceful no-worktree, never throws).
  */
@@ -33,36 +36,79 @@ function makeDeps(opts: {
 	};
 }
 
+/**
+ * Build deps whose single-repo probes (isGitRepo/getRepoRoot) THROW if called.
+ * Used to pin that the multi-repo branch never falls through to a cwd/ancestor
+ * probe. `isGitRepoRoot` resolves from `gitRoots` as usual.
+ */
+function makeMultiRepoOnlyDeps(gitRoots: string[]): {
+	deps: WorktreeSupportDeps;
+	cwdProbeCalls: () => number;
+} {
+	const roots = new Set(gitRoots.map(p => path.resolve(p)));
+	let cwdProbeCalls = 0;
+	const deps: WorktreeSupportDeps = {
+		isGitRepoRoot: async (dir: string) => roots.has(path.resolve(dir)),
+		isGitRepo: async () => {
+			cwdProbeCalls++;
+			throw new Error("isGitRepo(cwd) must NOT be called for the multi-repo branch");
+		},
+		getRepoRoot: async () => {
+			cwdProbeCalls++;
+			throw new Error("getRepoRoot(cwd) must NOT be called for the multi-repo branch");
+		},
+	};
+	return { deps, cwdProbeCalls: () => cwdProbeCalls };
+}
+
 describe("resolveWorktreeSupport", () => {
 	const projectRoot = "/proj/root";
 	const cwd = "/proj/root";
 
 	it("multi-repo with ≥1 git repo root ⇒ supported, repoPath = projectRoot", async () => {
 		const components = [comp("."), comp("repo-a"), comp("repo-b")];
-		const deps = makeDeps({ gitRoots: [path.join(projectRoot, "repo-a"), path.join(projectRoot, "repo-b")] });
+		const { deps, cwdProbeCalls } = makeMultiRepoOnlyDeps([
+			path.join(projectRoot, "repo-a"),
+			path.join(projectRoot, "repo-b"),
+		]);
 		const support = await resolveWorktreeSupport(components, projectRoot, cwd, deps);
 		assert.deepStrictEqual(support, { supported: true, repoPath: projectRoot, multiRepo: true });
+		assert.strictEqual(cwdProbeCalls(), 0, "multi-repo must not probe cwd/ancestor");
 	});
 
 	it("multi-repo where ONLY the '.' entry is a git root ⇒ supported via the '.' root", async () => {
 		const components = [comp("."), comp("repo-a")];
-		const deps = makeDeps({ gitRoots: [projectRoot] });
+		const { deps, cwdProbeCalls } = makeMultiRepoOnlyDeps([projectRoot]);
 		const support = await resolveWorktreeSupport(components, projectRoot, cwd, deps);
 		assert.deepStrictEqual(support, { supported: true, repoPath: projectRoot, multiRepo: true });
+		assert.strictEqual(cwdProbeCalls(), 0, "multi-repo must not probe cwd/ancestor");
 	});
 
-	it("multi-repo with NO git repo root ⇒ falls through to single-repo probe (unsupported when cwd non-git)", async () => {
+	it("multi-repo with NO git repo root ⇒ unsupported, multiRepo:true, never probes cwd", async () => {
 		const components = [comp("."), comp("repo-a"), comp("repo-b")];
-		const deps = makeDeps({ gitRoots: [], gitRepos: [] });
+		const { deps, cwdProbeCalls } = makeMultiRepoOnlyDeps([]);
 		const support = await resolveWorktreeSupport(components, projectRoot, cwd, deps);
 		assert.deepStrictEqual(support, { supported: false, multiRepo: true });
+		assert.strictEqual(cwdProbeCalls(), 0, "multi-repo must not probe cwd/ancestor");
 	});
 
-	it("multi-repo with NO git repo root but cwd IS a git repo ⇒ single-repo support", async () => {
+	it("multi-repo with NO git repo root but cwd IS a git repo ⇒ STILL unsupported (no cwd/ancestor probe)", async () => {
+		// Regression pin: a non-git project container nested inside an UNRELATED
+		// parent git repo must NOT resolve to that parent. Even though cwd would
+		// pass isGitRepo here, the multi-repo branch must never consult it.
 		const components = [comp("."), comp("repo-a")];
-		const deps = makeDeps({ gitRoots: [], gitRepos: [cwd], repoRoot: "/git/toplevel" });
+		const { deps, cwdProbeCalls } = makeMultiRepoOnlyDeps([]);
 		const support = await resolveWorktreeSupport(components, projectRoot, cwd, deps);
-		assert.deepStrictEqual(support, { supported: true, repoPath: "/git/toplevel", multiRepo: true });
+		assert.deepStrictEqual(support, { supported: false, multiRepo: true });
+		assert.strictEqual(cwdProbeCalls(), 0, "multi-repo must not probe cwd/ancestor");
+	});
+
+	it("multi-repo but no projectRoot ⇒ unsupported, multiRepo:true, never probes cwd", async () => {
+		const components = [comp("."), comp("repo-a")];
+		const { deps, cwdProbeCalls } = makeMultiRepoOnlyDeps([]);
+		const support = await resolveWorktreeSupport(components, undefined, cwd, deps);
+		assert.deepStrictEqual(support, { supported: false, multiRepo: true });
+		assert.strictEqual(cwdProbeCalls(), 0, "multi-repo must not probe cwd/ancestor");
 	});
 
 	it("single-repo git cwd ⇒ supported, repoPath = getRepoRoot(cwd)", async () => {
@@ -79,14 +125,7 @@ describe("resolveWorktreeSupport", () => {
 		assert.deepStrictEqual(support, { supported: false, multiRepo: false });
 	});
 
-	it("multi-repo but no projectRoot ⇒ falls through to single-repo probe", async () => {
-		const components = [comp("."), comp("repo-a")];
-		const deps = makeDeps({ gitRoots: [], gitRepos: [cwd], repoRoot: "/git/toplevel" });
-		const support = await resolveWorktreeSupport(components, undefined, cwd, deps);
-		assert.deepStrictEqual(support, { supported: true, repoPath: "/git/toplevel", multiRepo: true });
-	});
-
-	it("never throws when a dep rejects — returns unsupported", async () => {
+	it("never throws when a single-repo dep rejects — returns unsupported", async () => {
 		const components = [comp(".")];
 		const deps: WorktreeSupportDeps = {
 			isGitRepoRoot: async () => false,
@@ -95,5 +134,16 @@ describe("resolveWorktreeSupport", () => {
 		};
 		const support = await resolveWorktreeSupport(components, projectRoot, cwd, deps);
 		assert.deepStrictEqual(support, { supported: false, multiRepo: false });
+	});
+
+	it("never throws when a multi-repo dep rejects — returns unsupported, multiRepo:true", async () => {
+		const components = [comp("."), comp("repo-a")];
+		const deps: WorktreeSupportDeps = {
+			isGitRepoRoot: async () => { throw new Error("git boom"); },
+			isGitRepo: async () => { throw new Error("must not reach cwd probe"); },
+			getRepoRoot: async () => { throw new Error("must not reach cwd probe"); },
+		};
+		const support = await resolveWorktreeSupport(components, projectRoot, cwd, deps);
+		assert.deepStrictEqual(support, { supported: false, multiRepo: true });
 	});
 });


### PR DESCRIPTION
## Summary

Fixes **staff member creation failing in poly-repo projects** (a project whose root is *not* a git repo but contains git sub-repos registered as components with `repo != "."`). Staff creation previously diverged from regular session creation: it either failed with `git worktree add ... fatal: not a git repository` or silently landed with no worktree, while a session for the same project got one.

## Root cause

Worktree-capability resolution had diverged across the three creation paths (session, staff, goal). The staff path required **every** declared repo — including the non-git `.` container — to pass `isGitRepo`, and `createWorktreeSet` ran `git worktree add` against the non-git container root.

## Fix (single source of truth)

- **`src/server/agent/worktree-support.ts`** (new): `resolveWorktreeSupport(components, projectRoot, cwd)` → `{ supported, repoPath, multiRepo }`, now used identically by session (`server.ts` POST /api/sessions), staff (`staff-manager.ts`), and goal (`goal-manager.ts`). Multi-repo anchors at `projectRoot` and is supported iff ≥1 component is a git repo **root** beneath it; it never probes `cwd`/an ancestor. Otherwise → graceful no-worktree.
- **`src/server/skills/git.ts`**: new `isGitRepoRoot(dir)` (distinguishes "is a repo root" from "inside a repo" — avoids the nested-parent false positive). `createWorktreeSet` skips non-git component dirs (the `.` container, nested-parent, data-only, missing) in multi-repo mode and never runs `git worktree add` against a non-git container; returns an empty set when no git sub-repo remains.
- **Callers** (`staff-manager`, `session-setup::executeWorktreeAsync`, `goal-manager::_doSetupWorktree`/`_restoreNoWorktree`) treat unsupported/empty-set as graceful no-worktree (original cwd, no `worktreePath`/`repoWorktrees`).

Net effect: staff creation in a poly-repo now produces one worktree per git sub-repo — identical to a regular session; non-git/data-only components are skipped; projects with no worktree-able git repo fall back to no-worktree instead of throwing.

## Acceptance criteria

1. ✅ Staff in a poly-repo produces one worktree per git sub-repo, matching a session.
2. ✅ `git worktree add` never runs against the non-git container; non-git `repo:"."` entries skipped (incl. nested-parent case).
3. ✅ Projects with no worktree-able repo fall back to no-worktree, never throw.
4. ✅ Single-repo and normal all-git multi-repo behavior unchanged.

## Tests

- `tests/worktree-set-polyrepo.test.ts` — reproducer + nested-parent + no-git-sub-repos cases.
- `tests/worktree-support.test.ts` — `resolveWorktreeSupport` contract (multi-repo never probes cwd/ancestor).
- `tests/e2e/staff-cwd-parity.spec.ts` — poly-repo staff↔session worktree parity.
- Build, type-check, unit (1252 passed), full E2E, and LLM reviews (gap/quality/regression/security) all green.

## Docs

- `docs/design/multi-repo-components.md` §4.4–4.5; `docs/debugging.md` symptom entry.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
