### PR TITLE
Fork standard role:general sessions

### DIFF
--- a/docs/sidebar-actions-menu.md
+++ b/docs/sidebar-actions-menu.md
@@ -60,9 +60,29 @@ This avoids adding a redundant dense tap target on mobile, where the quick actio
 | `Terminate` | Quick + menu | Plain live session | Opens the existing terminate confirmation. |
 | `End team` | Quick + menu | Team-lead session | Opens the existing team-end confirmation with goal context. |
 | `Copy link` | Menu only | Live session / team-lead row | Copies an absolute hash route for the session. |
-| `Fork` | Menu only | Plain live, non-archived, non-child, non-team, non-read-only sessions | Clones the session's conversation history into a new session and connects to it. Carries an inline **New worktree** checkbox (see below). |
+| `Fork` | Menu only | Forkable live session (see [Forkability policy](#forkability-policy)) | Clones the session's conversation history into a new session and connects to it. Carries an inline **New worktree** checkbox (see below). |
 
 Archived sessions and unsupported live session kinds do not expose `Fork`. The server also enforces this with `422` responses so clients cannot bypass UI availability checks.
+
+#### Forkability policy
+
+Forkability is one policy enforced in two places, and they **must agree** — otherwise the UI offers a Fork that the server rejects with `422` (or hides one the server would accept):
+
+- **Client** — `canForkSidebarSession()` in `src/app/render-helpers.ts` decides whether the `Fork` menu item renders.
+- **Server** — `isUnsupportedForkSource()` in `src/server/server.ts` is the authority; the `POST /api/sessions/:id/fork` handler calls it and returns `422` for unsupported sources.
+
+A live session is forkable **unless** it is one of the genuinely non-forkable kinds:
+
+| Not forkable | Why |
+|---|---|
+| terminated / archived | No live transcript to clone. |
+| read-only / non-interactive | Not an interactive session the user can continue. |
+| delegate / child (`isChildSession`) | Owned by a parent turn, not independently forkable. |
+| team sessions (`teamGoalId`, `teamLeadSessionId`, `role === "team-lead"`) | Bound to a team's lifecycle. |
+
+Everything else is forkable. In particular, **standard `role: "general"` sessions and `assistant` sessions are forkable** — `role` is *not* a blanket disqualifier. Among role-based sessions only `team-lead` is excluded; the client guard mirrors the server by checking `session.role !== "team-lead"` rather than `!session.role`.
+
+> Historical note: an earlier client guard blocked Fork for *any* session carrying a `role` (`!session.role`). Because normal user-started sessions persist the default `role: "general"`, Fork was wrongly hidden for them even though the server's `isUnsupportedForkSource()` already permitted forking them. Aligning the client check to the server's actual policy (`role !== "team-lead"`) fixed the client/server mismatch.
 
 The `Fork` row has a trailing `New worktree` checkbox (`role="menuitemcheckbox"`, default checked) at its right edge:
 

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -685,7 +685,10 @@ function canForkSidebarSession(session: GatewaySession): boolean {
 		&& !session.readOnly
 		&& !session.nonInteractive
 		&& !isChildSession(session)
-		&& !session.role
+		// Mirror the server guard isUnsupportedForkSource() in src/server/server.ts:
+		// among role-based sessions, only "team-lead" is non-forkable; "general" and
+		// "assistant" are forkable. Keep client and server consistent.
+		&& session.role !== "team-lead"
 		&& !session.teamGoalId
 		&& !session.teamLeadSessionId;
 }

--- a/tests/e2e/ui/sidebar-actions-menu.spec.ts
+++ b/tests/e2e/ui/sidebar-actions-menu.spec.ts
@@ -566,6 +566,72 @@ test.describe("Sidebar actions menu", () => {
 		await expect.poll(() => page.evaluate(() => (window as any).__sidebarAnimateCalls)).toBe(0);
 	});
 
+	// Assign a role to an existing session via the real PATCH endpoint (which
+	// drives sessionManager.assignRole → respawn) and wait for the role to
+	// persist on the server session and the agent to return to idle. Mirrors
+	// how the product assigns roles; faithful to the bug because the sidebar
+	// Fork guard reads the persisted `session.role`.
+	async function assignSessionRole(sessionId: string, roleId: string): Promise<void> {
+		const resp = await apiFetch(`/api/sessions/${sessionId}`, {
+			method: "PATCH",
+			body: JSON.stringify({ roleId }),
+		});
+		expect(resp.ok, `PATCH roleId=${roleId} should succeed (got ${resp.status})`).toBeTruthy();
+		// assignRole kills + respawns the agent; wait for it to settle back to idle.
+		await waitForSessionStatus(sessionId, "idle");
+		// Confirm the role actually persisted on the session — otherwise the
+		// test would not be exercising the role-gated Fork path at all.
+		await expect.poll(async () => {
+			const get = await apiFetch(`/api/sessions/${sessionId}`);
+			if (!get.ok) return undefined;
+			return (await get.json()).role;
+		}, { timeout: 15_000 }).toBe(roleId);
+	}
+
+	// REPRODUCING TEST (must FAIL on current code, PASS once canForkSidebarSession
+	// stops gating on `!session.role`). A standard session carrying the default
+	// `role: "general"` must still expose Fork — the server's
+	// isUnsupportedForkSource() permits forking role:"general", so the client
+	// must not hide it. On current code the `!session.role` clause suppresses
+	// Fork for ANY truthy role, so the Fork menu item is absent here.
+	test("standard role:general session still shows Fork in the sidebar menu", async ({ page }) => {
+		const sessionId = await createSession();
+		sessionIds.push(sessionId);
+		await waitForSessionStatus(sessionId, "idle");
+		await assignSessionRole(sessionId, "general");
+
+		const row = await openSession(page, sessionId);
+		await openMenu(row, "session", sessionId);
+		// Sanity: the menu opened and lists the standard items.
+		await expect(menuItem(page, "copy-link")).toBeVisible();
+
+		const forkItem = menuItem(page, "fork");
+		await expect(
+			forkItem,
+			"Fork menu item must be VISIBLE for role:general sessions (server permits forking them; client must agree)",
+		).toBeVisible({ timeout: 5_000 });
+	});
+
+	// NEGATIVE (must PASS now and stay passing): a team-lead session is genuinely
+	// non-forkable — the server's isUnsupportedForkSource() rejects role:"team-lead"
+	// — so the client must hide Fork. This is the one role-based exclusion the fix
+	// must preserve.
+	test("role:team-lead session hides Fork in the sidebar menu", async ({ page }) => {
+		const sessionId = await createSession();
+		sessionIds.push(sessionId);
+		await waitForSessionStatus(sessionId, "idle");
+		await assignSessionRole(sessionId, "team-lead");
+
+		const row = await openSession(page, sessionId);
+		await openMenu(row, "session", sessionId);
+		// The menu opened (standard item present) but Fork must be absent.
+		await expect(menuItem(page, "copy-link")).toBeVisible();
+		await expect(
+			menuItem(page, "fork"),
+			"Fork must stay hidden for team-lead sessions",
+		).toHaveCount(0, { timeout: 5_000 });
+	});
+
 	test("mobile v1 hides hamburger while keeping existing inline quick actions visible", async ({ page }) => {
 		await page.setViewportSize({ width: 390, height: 820 });
 		const sessionId = await createSession();


### PR DESCRIPTION
## Summary

The sidebar **Fork** action was hidden for standard user-started sessions. `canForkSidebarSession()` in `src/app/render-helpers.ts` blocked Fork for any session carrying a `role`, and normal sessions persist the default `role: "general"` — so Fork never appeared for them. The presence of a worktree was a red herring; the `role` field was the discriminator.

The server's `isUnsupportedForkSource()` already permits forking `role: "general"` (and `assistant`) sessions, rejecting only `team-lead` among roles. The client guard was stricter than the server — that mismatch was the bug.

## Fix

In `canForkSidebarSession()`, replaced `!session.role` with `session.role !== "team-lead"`, mirroring the server guard. Standard `general`/`assistant` sessions now show Fork and fork successfully; genuinely non-forkable kinds (terminated, archived, read-only, non-interactive, delegate/child, team / team-lead) still hide it. Client and server now agree on forkability.

## Tests

- New reproducing browser E2E in `tests/e2e/ui/sidebar-actions-menu.spec.ts`: a `role: "general"` session must show Fork (failed before the fix), plus a negative `team-lead` case that still hides Fork.
- `npm run check`, build, unit, E2E, and QA all pass.

## Docs

- Added a **Forkability policy** section to `docs/sidebar-actions-menu.md` documenting the client/server parity invariant.

## Workflow gates

issue-analysis, reproducing-test, implementation, documentation all passed.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)