### PR TITLE
Walkthrough Phase 0 redesign: guided orientation + short nav labels

### DIFF
--- a/docs/design/pr-walkthrough-agent-ux.md
+++ b/docs/design/pr-walkthrough-agent-ux.md
@@ -65,6 +65,30 @@ The server has already resolved the authoritative input at launch. The agent sta
 
 Progress is intentionally approximate. It should help the user trust the process without introducing a second panel-level loader.
 
+## Compact navigation labels (`nav_label`)
+
+The review rail is narrow (~240px). Full descriptive card titles overflow and truncate there, so every rail entry uses a short label distinct from the title. The agent communicates that label through an optional `nav_label` field on each `design_decisions[]` and `review_chunks[]` entry in the submitted YAML.
+
+Contract (also stated in the schema prompt the agent receives):
+
+- `nav_label` is **optional**. Keep it **≤3 words and ≤24 characters** so it never truncates in the rail.
+- The full descriptive title stays in `title` (it is used for the card `<h2>` header).
+- **Omit it to auto-derive** a compact label from the title. The server derives one (text before the first `:`/`—`/` - ` separator, first ≤3 words, hard-truncated to 23 chars + `…` if needed).
+
+Server behaviour (`navLabelError` / `deriveNavLabel` in `src/shared/pr-walkthrough/nav-label.ts`, enforced in `walkthrough-yaml-schema.ts`):
+
+- A present `nav_label` that violates the ≤3-word / ≤24-char rule fails validation with `nav_label must be ≤3 words and ≤24 characters.`, so the agent gets actionable retry feedback.
+- An empty or whitespace-only `nav_label` is treated as omitted (it falls back to the derived label rather than failing), so the agent never produces a blank rail entry.
+- `nav_label` is optional and the fallback is graceful, so the `submit_pr_walkthrough_yaml` contract is unbroken for existing clients and partial/legacy YAML still renders.
+
+The orientation card does not take a `nav_label` from the agent — its rail label and per-beat labels are server-defined (see [Structured orientation beats](#structured-orientation-beats)).
+
+## Structured orientation beats
+
+The orientation card is rendered as a guided six-beat step-through (see [pr-walkthrough-panel.md](pr-walkthrough-panel.md) for the panel-side design). The beats are **server-derived from the existing YAML** — the agent does **not** author them and no new orientation fields are required. The server maps `walkthrough.context` + `merge_assessment` into the structured `sections` (At a glance, Why it exists, What it changes, Should it be merged?, What to scrutinise, Where to look). The merge beat is reframed to **"Should it be merged?"** with an answer-first line derived from `merge_assessment.recommendation` + `confidence`.
+
+Because the beats are derived server-side, the agent's job is unchanged: populate the existing `walkthrough.context` and `merge_assessment` fields accurately and the guided step-through follows automatically.
+
 ## YAML validation retry state
 
 Validation failures are part of the child session experience, not hidden infrastructure errors.

--- a/docs/design/pr-walkthrough-panel.md
+++ b/docs/design/pr-walkthrough-panel.md
@@ -32,6 +32,20 @@ Each walkthrough consists of phases:
 
 Cards are LLM-synthesised logical change sets, not raw files/hunks. A card may contain multiple code blocks, including the audit card.
 
+## Guided orientation beats (Phase 0 redesign)
+
+> This supersedes the original "single orientation card" treatment. The orientation card previously joined its structured context fields into two `\n`-joined paragraphs; CSS collapsed the newlines into one space, producing an intimidating wall of text with the verdict, concerns, and reviewer file-map all buried. Phase 0 is now a guided step-through of bite-size beats. The production reference is the validated mockup `guided.html`; see [pr-walkthrough-panel.md](../pr-walkthrough-panel.md#guided-orientation-step-through) for the shipped behaviour.
+
+**Structured `sections` model.** The orientation card carries an optional `sections: PrWalkthroughCardSection[]` array of single-idea "beats" (defined in `src/shared/pr-walkthrough/types.ts`). Each section has an `id`, a ≤3-word `navLabel`, a `heading`, optional `eyebrow`, `body`, and beat-specific payloads: `verdict` (recommendation + confidence + summary), `concerns` (severity-tagged rows), `fileRoles` (Core/Support/Verify/Docs), `showStats`, and `showOriginalDescription`. The server builds the six beats from the existing YAML `walkthrough.context` + `merge_assessment` — no new agent content is required — and the panel renders them as a stepper with Back/Next, a step counter, and per-beat rail circles (visited ✓ / current ring / upcoming hollow).
+
+The six server-defined beats: **At a glance** (verdict badge + summary + diff stats), **Why it exists** (`why_created`), **What it changes** (`problem_solved`), **Should it be merged?**, **What to scrutinise** (concerns), **Where to look** (reviewer map + collapsible original PR description).
+
+**Reframed merge beat.** The fourth beat is reframed from "Why it's worth merging" to the question **"Should it be merged?"** with answer-first copy: a recommendation line (`Yes — approve, medium confidence.` / `Not yet — request changes, …` / `Maybe — comment, …` / `Recommendation unclear.`) derived from `merge_assessment`, followed by `why_worth_merging`. The reviewer gets the verdict before the rationale.
+
+**Compact rail labels.** Every rail entry uses a short label (`card.navLabel ?? deriveNavLabel(card.title)`) so titles never truncate in the narrow rail; the full title stays in the card `<h2>` and the rail tooltip. The agent may supply an optional `nav_label` per card in YAML (≤3 words / ≤24 chars), with a graceful server-derived fallback — see [pr-walkthrough-agent-ux.md](pr-walkthrough-agent-ux.md#compact-navigation-labels-nav_label).
+
+`sections`, `navLabel`, and `nav_label` are all **optional and backward-compatible**: the `submit_pr_walkthrough_yaml` contract is unchanged and an orientation card without `sections` falls back to the legacy single-card body.
+
 ## Layout
 
 - Header:

--- a/docs/pr-walkthrough-panel.md
+++ b/docs/pr-walkthrough-panel.md
@@ -212,7 +212,7 @@ Validated YAML is mapped into the existing card model:
 - `walkthrough.context`, `merge_assessment`, and `pr.original_description.body` become the Orientation card, including the six structured guided `sections` (see [Guided orientation step-through](#guided-orientation-step-through)).
 - `design_decisions` become Key design choices cards with trade-offs, alternatives, suggested concerns, and linked hunks.
 - `review_chunks` become significant, other, or audit review cards with diff-backed hunks and suggested concerns.
-- Each card's `nav_label` (optional, supplied by the agent) becomes the card `navLabel`; when omitted or invalid the server derives a compact label from the title. See [Short navigation labels](#short-navigation-labels).
+- Each card's `nav_label` (optional, supplied by the agent) becomes the card `navLabel`; when missing or empty/whitespace-only the server derives a compact label from the title, whereas a non-empty over-cap label (>3 words / >24 chars) is rejected with a validation error. See [Short navigation labels](#short-navigation-labels).
 - `omissions_and_followups` feed Other + omissions guidance and card-level suggested comments.
 - `audit` feeds the final Audit card and draft reviewer checklist.
 - `display.phase_order` and `display.chunk_order` influence visible ordering while preserving the known phase set.

--- a/docs/pr-walkthrough-panel.md
+++ b/docs/pr-walkthrough-panel.md
@@ -259,7 +259,7 @@ Every sidebar rail entry uses a compact label distinct from the card's full desc
 
 - The rail renders `card.navLabel ?? deriveNavLabel(card.title)` for every card, and the beat's own `navLabel` for orientation circles.
 - `deriveNavLabel` and `navLabelError` live in `src/shared/pr-walkthrough/nav-label.ts` (shared by server and UI). The cap is `NAV_LABEL_MAX_WORDS = 3` and `NAV_LABEL_MAX_CHARS = 24`. `deriveNavLabel` takes the text before the first `:` / `—` / ` - ` separator (when non-empty), keeps the first ≤3 words, and hard-truncates to 23 chars + `…` if still over the char cap. `navLabelError` rejects empty/whitespace-only, >3-word, or >24-char labels.
-- The LLM review agent may supply an optional `nav_label` per card in its submitted YAML (see [PR walkthrough agent UX](design/pr-walkthrough-agent-ux.md)). The server validates it and falls back to a derived label when it is missing, empty, or invalid — so existing and partial YAML always render a non-truncating rail label.
+- The LLM review agent may supply an optional `nav_label` per card in its submitted YAML (see [PR walkthrough agent UX](design/pr-walkthrough-agent-ux.md)). In the `submit_pr_walkthrough_yaml` path the server derives a label from the title when `nav_label` is **missing or empty/whitespace-only**; a non-empty `nav_label` that exceeds the caps (>3 words or >24 chars) is **rejected with a validation error** rather than silently truncated, so the agent fixes it and resubmits. (The derive-on-invalid fallback applies only to the internal LLM card-synthesis path, not to submitted YAML.) Either way, existing and partial YAML always render a non-truncating rail label.
 
 ## Diff behaviour
 

--- a/docs/pr-walkthrough-panel.md
+++ b/docs/pr-walkthrough-panel.md
@@ -200,7 +200,7 @@ Key concepts:
 - **Diff block** — one reviewable file block with `filePath`, optional `oldPath`, status, generated/binary/truncated flags, external links, and hunks.
 - **Hunk** — original hunk header plus ordered line records.
 - **Line** — stable id, kind (`context`, `add`, `del`), side (`context`, `new`, `old`), text, and old/new line numbers for review anchors.
-- **Card** — a logical review unit in one of the walkthrough phases. A card can contain multiple diff blocks across one or more files.
+- **Card** — a logical review unit in one of the walkthrough phases. A card can contain multiple diff blocks across one or more files. Each card also carries an optional `navLabel` (a compact ≤3-word sidebar label distinct from the full `title`) and the Orientation card carries optional `sections` (the guided "beats" — see [Guided orientation step-through](#guided-orientation-step-through)). Both are optional, so legacy/partial payloads still render.
 - **Warning** — visible ingestion, mapping, validation, or export issue with a severity, code, message, and optional file path.
 
 The UI never needs to know whether cards came from the session-hosted YAML flow or the compatibility resolver. It renders the same cards, warnings, comments, decisions, draft review, and export preview for every provider.
@@ -209,9 +209,10 @@ The UI never needs to know whether cards came from the session-hosted YAML flow 
 
 Validated YAML is mapped into the existing card model:
 
-- `walkthrough.context`, `merge_assessment`, and `pr.original_description.body` become the Orientation card.
+- `walkthrough.context`, `merge_assessment`, and `pr.original_description.body` become the Orientation card, including the six structured guided `sections` (see [Guided orientation step-through](#guided-orientation-step-through)).
 - `design_decisions` become Key design choices cards with trade-offs, alternatives, suggested concerns, and linked hunks.
 - `review_chunks` become significant, other, or audit review cards with diff-backed hunks and suggested concerns.
+- Each card's `nav_label` (optional, supplied by the agent) becomes the card `navLabel`; when omitted or invalid the server derives a compact label from the title. See [Short navigation labels](#short-navigation-labels).
 - `omissions_and_followups` feed Other + omissions guidance and card-level suggested comments.
 - `audit` feeds the final Audit card and draft reviewer checklist.
 - `display.phase_order` and `display.chunk_order` influence visible ordering while preserving the known phase set.
@@ -224,13 +225,41 @@ The older model-backed synthesis and deterministic grouping remain compatibility
 
 The walkthrough is organised into five phases:
 
-1. **Orientation** — confirms scope, refs, provider metadata, stats, warnings, original PR body, inferred author intent, and merge assessment.
+1. **Orientation** — confirms scope, refs, provider metadata, stats, warnings, original PR body, inferred author intent, and merge assessment. Rendered as a guided six-beat step-through rather than a single card body (see [Guided orientation step-through](#guided-orientation-step-through)).
 2. **Key design choices** — highlights architecture or product decisions and their trade-offs.
 3. **Significant changes** — reviews high-signal implementation diffs.
 4. **Other + omissions** — covers smaller changes, expected artifacts, and follow-up concerns.
 5. **Audit** — checks remaining coverage and renders the final draft review.
 
 Every phase can contain normal diff-backed cards. A card can span multiple files or hunks when that better matches the reviewer story. Audit cards use the same line comments, card comments, suggestions, diff expansion, and Like/Dislike controls as other cards, then render the copyable draft review.
+
+## Guided orientation step-through
+
+Phase 0 (Orientation) is rendered as a **guided step-through** rather than a single card body. This exists because the orientation card previously joined the structured context fields (`why_created`, `problem_solved`, `why_worth_merging`, `author_intent`, `reviewer_map`, `merge_assessment`, `merge_concerns`) into two `\n`-joined `<p>` blobs. CSS collapses those newlines into a single space, so the reviewer faced an intimidating wall of text with the verdict, concerns, and reviewer file-map all buried. The redesign breaks orientation into six single-idea **beats**, each readable in under ~20 seconds, with Back/Next navigation and a step counter.
+
+The six beats are **server-defined** and sourced entirely from the existing YAML `walkthrough.context` + `merge_assessment` — no new agent fields are required:
+
+1. **At a glance** — a verdict badge (`recommendation` + `confidence`, e.g. `APPROVE · medium confidence`), the one-line summary, and the diff stats.
+2. **Why it exists** — `why_created` (eyebrow "The problem").
+3. **What it changes** — `problem_solved` (eyebrow "The change").
+4. **Should it be merged?** — reframed from "Why it's worth merging" to lead with the recommendation: an answer-first line (`Yes — approve, medium confidence.` / `Not yet — request changes, …` / `Maybe — comment, …` / `Recommendation unclear.`) followed by `why_worth_merging`.
+5. **What to scrutinise** — blocking and non-blocking concerns as severity-tagged rows, with a `N blocking, M non-blocking` tally. Blocking and non-blocking are counted by explicit `severity`; `question`/`nit` rows (e.g. a `merge_concerns` note) are excluded from the non-blocking count.
+6. **Where to look** — the reviewer map rendered as a file → role list (Core / Support / Verify / Docs, best-effort parsed from `reviewer_map` lines), plus the collapsible original PR description.
+
+Navigation:
+
+- **Back** is disabled on the first beat. **Next** advances one beat; on the last beat it reads **"Start review →"** and advances to the next card, marking the orientation card complete.
+- **Per-section rail circles.** Under the Phase 0 rail entry, the panel renders one circle per beat with the beat's ≤3-word label below it. Visited beats show a filled `✓`, the current beat a ringed primary dot, and upcoming beats a hollow circle. Clicking a circle jumps to that beat; Back/Next keep the rail circles in sync. When orientation is not the active card, all circles render done if it was completed, else hollow.
+
+Both `sections` and the per-beat model are **optional and backward-compatible**: an orientation card without `sections` (legacy or partial YAML) falls back to the legacy single card-button in the rail and the generic card body. The legacy `summary`/`rationale`/`checklist` fields are still populated so older renderers and stored payloads keep working; the redesigned panel prefers `sections`.
+
+## Short navigation labels
+
+Every sidebar rail entry uses a compact label distinct from the card's full descriptive title. This exists because full titles (e.g. `render.ts: fullscreen predicate and standalone panel simplification`) overflow and truncate badly in the ~240px rail. The full title is retained for the card `<h2>` header and the rail `title=` tooltip; the rail itself shows the short label.
+
+- The rail renders `card.navLabel ?? deriveNavLabel(card.title)` for every card, and the beat's own `navLabel` for orientation circles.
+- `deriveNavLabel` and `navLabelError` live in `src/shared/pr-walkthrough/nav-label.ts` (shared by server and UI). The cap is `NAV_LABEL_MAX_WORDS = 3` and `NAV_LABEL_MAX_CHARS = 24`. `deriveNavLabel` takes the text before the first `:` / `—` / ` - ` separator (when non-empty), keeps the first ≤3 words, and hard-truncates to 23 chars + `…` if still over the char cap. `navLabelError` rejects empty/whitespace-only, >3-word, or >24-char labels.
+- The LLM review agent may supply an optional `nav_label` per card in its submitted YAML (see [PR walkthrough agent UX](design/pr-walkthrough-agent-ux.md)). The server validates it and falls back to a derived label when it is missing, empty, or invalid — so existing and partial YAML always render a non-truncating rail label.
 
 ## Diff behaviour
 

--- a/src/server/pr-walkthrough/card-synthesis.ts
+++ b/src/server/pr-walkthrough/card-synthesis.ts
@@ -3,7 +3,7 @@
 // module can be validated independently when the shared file is not present yet.
 // @ts-ignore Upstream shared model may be absent on this parallel task branch.
 import type { PrWalkthroughCard as SharedPrWalkthroughCard, PrWalkthroughChangesetRef as SharedPrWalkthroughChangesetRef, PrWalkthroughDiffBlock as SharedPrWalkthroughDiffBlock, PrWalkthroughDiffLine as SharedPrWalkthroughDiffLine, PrWalkthroughHunk as SharedPrWalkthroughHunk, PrWalkthroughPhaseId as SharedPrWalkthroughPhaseId, PrWalkthroughSuggestedComment as SharedPrWalkthroughSuggestedComment, WalkthroughWarning as SharedWalkthroughWarning } from "../../shared/pr-walkthrough/types.js";
-import { deriveNavLabel } from "../../shared/pr-walkthrough/nav-label.js";
+import { deriveNavLabel, navLabelError } from "../../shared/pr-walkthrough/nav-label.js";
 
 type PreserveShared<T> = unknown extends T ? unknown : T;
 type LocalPhaseId = "orientation" | "design" | "significant" | "other" | "audit";
@@ -187,7 +187,7 @@ export function validateSynthesisedCards(raw: unknown, files: WalkthroughParsedF
 			id,
 			phaseId,
 			title,
-			navLabel: stringValue(candidate.navLabel) ?? deriveNavLabel(title),
+			navLabel: resolveNavLabel(candidate.navLabel, title),
 			summary,
 			rationale: stringValue(candidate.rationale),
 			diffBlocks,
@@ -537,6 +537,15 @@ function compactText(value: string | undefined, maxLength = 220): string {
 
 function stringValue(value: unknown): string | undefined {
 	return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+// Use an LLM/candidate-provided nav label only when it satisfies the ≤3-word /
+// ≤24-char invariant; otherwise (missing, empty, or overlong) derive a compact
+// label from the title so the rail never renders a blank or overflowing entry.
+function resolveNavLabel(candidate: unknown, title: string): string {
+	const provided = stringValue(candidate);
+	if (provided && navLabelError(provided) === null) return provided;
+	return deriveNavLabel(title);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/server/pr-walkthrough/card-synthesis.ts
+++ b/src/server/pr-walkthrough/card-synthesis.ts
@@ -3,6 +3,7 @@
 // module can be validated independently when the shared file is not present yet.
 // @ts-ignore Upstream shared model may be absent on this parallel task branch.
 import type { PrWalkthroughCard as SharedPrWalkthroughCard, PrWalkthroughChangesetRef as SharedPrWalkthroughChangesetRef, PrWalkthroughDiffBlock as SharedPrWalkthroughDiffBlock, PrWalkthroughDiffLine as SharedPrWalkthroughDiffLine, PrWalkthroughHunk as SharedPrWalkthroughHunk, PrWalkthroughPhaseId as SharedPrWalkthroughPhaseId, PrWalkthroughSuggestedComment as SharedPrWalkthroughSuggestedComment, WalkthroughWarning as SharedWalkthroughWarning } from "../../shared/pr-walkthrough/types.js";
+import { deriveNavLabel } from "../../shared/pr-walkthrough/nav-label.js";
 
 type PreserveShared<T> = unknown extends T ? unknown : T;
 type LocalPhaseId = "orientation" | "design" | "significant" | "other" | "audit";
@@ -89,6 +90,7 @@ export interface WalkthroughLlmCardCandidate {
 	id?: unknown;
 	phaseId?: unknown;
 	title?: unknown;
+	navLabel?: unknown;
 	summary?: unknown;
 	rationale?: unknown;
 	diffBlockIds?: unknown;
@@ -185,6 +187,7 @@ export function validateSynthesisedCards(raw: unknown, files: WalkthroughParsedF
 			id,
 			phaseId,
 			title,
+			navLabel: stringValue(candidate.navLabel) ?? deriveNavLabel(title),
 			summary,
 			rationale: stringValue(candidate.rationale),
 			diffBlocks,
@@ -246,10 +249,17 @@ function buildOrientationCard(
 		id: "orientation-summary",
 		phaseId: "orientation",
 		title: "PR context",
+		navLabel: "Orientation",
 		summary: `Why this PR was raised: ${why}${warningSummary}`,
 		rationale: `Context to understand the PR: ${context}`,
 		diffBlocks: [],
 		checklist: [`Testing strategy: ${testing}`, ...warnings.slice(0, 2).map(warning => warning.filePath ? `${warning.filePath}: ${warning.message}` : warning.message)],
+		sections: [
+			{ id: "at-a-glance", navLabel: "At a glance", heading: "At a glance", body: `Why this PR was raised: ${why}${warningSummary}`, showStats: true },
+			{ id: "why-it-exists", navLabel: "Why it exists", eyebrow: "The problem", heading: "Why it exists", body: why },
+			{ id: "what-it-changes", navLabel: "What it changes", eyebrow: "The change", heading: "What it changes", body: context },
+			{ id: "where-to-look", navLabel: "Where to look", heading: "Where to look", body: `Testing strategy: ${testing}`, showOriginalDescription: true },
+		],
 		cardSuggestions: warnings.slice(0, 3).map(warning => warning.filePath ? `${warning.filePath}: ${warning.message}` : warning.message),
 	};
 }
@@ -259,10 +269,12 @@ function buildGroupCard(phaseId: PrWalkthroughPhaseId, group: BlockGroup, assign
 	for (const item of blocks) assigned.add(item.block.id);
 	const fileList = unique(blocks.map(item => item.file.filePath));
 	const titlePrefix = phaseId === "design" ? "Review architecture changes" : phaseId === "other" ? "Review edge-case files" : "Review significant changes";
+	const title = `${titlePrefix} in ${group.label}`;
 	return {
 		id: stableCardId(`${phaseId}-${group.key}`),
 		phaseId,
-		title: `${titlePrefix} in ${group.label}`,
+		title,
+		navLabel: deriveNavLabel(title),
 		summary: `${formatCount(blocks.length, "diff block")} covering ${formatCount(fileList.length, "file")} with ${group.weight} changed lines.`,
 		rationale: phaseId === "design"
 			? "This top-level area carries the largest change weight and should be checked for design-level implications."
@@ -279,6 +291,7 @@ function buildOtherSmallChangesCard(groups: BlockGroup[], assigned: Set<string>)
 		id: "other-small-changes",
 		phaseId: "other",
 		title: "Review smaller remaining files",
+		navLabel: deriveNavLabel("Review smaller remaining files"),
 		summary: `${formatCount(blocks.length, "diff block")} from lower-risk or smaller path groups.`,
 		rationale: "Small changes are grouped together to keep the walkthrough concise while preserving review anchors.",
 		diffBlocks: blocks.map(item => item.block),
@@ -288,10 +301,12 @@ function buildOtherSmallChangesCard(groups: BlockGroup[], assigned: Set<string>)
 
 function buildAuditCard(remaining: WeightedBlock[]): PrWalkthroughCard {
 	const blocks = selectBlocks(remaining, MAX_BLOCKS_PER_FALLBACK_CARD);
+	const title = blocks.length > 0 ? "Audit remaining representative hunks" : "Audit walkthrough coverage";
 	return {
 		id: "audit-remaining-hunks",
 		phaseId: "audit",
-		title: blocks.length > 0 ? "Audit remaining representative hunks" : "Audit walkthrough coverage",
+		title,
+		navLabel: deriveNavLabel(title),
 		summary: blocks.length > 0
 			? `${formatCount(blocks.length, "remaining diff block")} were not assigned to earlier logical cards and should receive a final pass.`
 			: "All reviewable diff blocks were assigned to earlier cards; use this step to verify decisions and draft review output.",

--- a/src/server/pr-walkthrough/routes.ts
+++ b/src/server/pr-walkthrough/routes.ts
@@ -10,6 +10,8 @@ import type { SandboxScope } from "../auth/sandbox-token.js";
 import { completeModelText as defaultCompleteModelText } from "../agent/model-completion.js";
 import { getAvailableModels as defaultGetAvailableModels, type ApiModel } from "../agent/model-registry.js";
 import { safeExternalUrl, trustedHostsFromEnv } from "../../shared/pr-walkthrough/url-safety.js";
+import { deriveNavLabel } from "../../shared/pr-walkthrough/nav-label.js";
+import type { PrWalkthroughCardSection } from "../../shared/pr-walkthrough/types.js";
 import { WalkthroughAgentManager, type LaunchWalkthroughRequest, type SubmitWalkthroughYamlRequest, type WalkthroughAgentManagerDeps, type WalkthroughSessionManagerLike } from "./walkthrough-agent-manager.js";
 import type { ReadPrWalkthroughBundleRequest } from "./walkthrough-analysis-bundle.js";
 
@@ -46,6 +48,8 @@ type WalkthroughCard = {
 	checklist?: string[];
 	cardSuggestions?: string[];
 	suggestedComments?: Array<{ id: string; cardId: string; diffBlockId: string; lineId: string; body: string }>;
+	navLabel?: string;
+	sections?: PrWalkthroughCardSection[];
 };
 
 type WalkthroughChangeset = {
@@ -483,7 +487,7 @@ export async function createModelBackedSynthesisAdapter(deps: PrWalkthroughRoute
 	};
 }
 
-const PR_WALKTHROUGH_SYNTHESIS_SYSTEM_PROMPT = `You synthesize concise PR walkthrough review cards from parsed diffs. Return only JSON with a top-level "cards" array. Each card must include phaseId (orientation, design, significant, other, or audit), title, summary, and diffBlockIds referencing only provided IDs. The orientation card is special: it should explain PR context for reviewers (why the PR was raised, context/background needed to understand it, testing strategy, and useful PR-description details) and may use an empty diffBlockIds array. Do not make orientation a summary of the walkthrough process. Suggested comments may include diffBlockId, lineId, and body. Do not invent file paths, block ids, or line ids.`;
+const PR_WALKTHROUGH_SYNTHESIS_SYSTEM_PROMPT = `You synthesize concise PR walkthrough review cards from parsed diffs. Return only JSON with a top-level "cards" array. Each card must include phaseId (orientation, design, significant, other, or audit), title, summary, and diffBlockIds referencing only provided IDs. Each card may also include navLabel: a compact sidebar label of at most 3 words and 24 characters so the navigation rail never truncates; keep the full descriptive title in title. Omit navLabel to auto-derive it from the title. The orientation card is special: it should explain PR context for reviewers (why the PR was raised, context/background needed to understand it, testing strategy, and useful PR-description details) and may use an empty diffBlockIds array. Do not make orientation a summary of the walkthrough process. Suggested comments may include diffBlockId, lineId, and body. Do not invent file paths, block ids, or line ids.`;
 
 async function resolveSynthesisModelPref(deps: PrWalkthroughRouteDeps, sessionId: string | undefined): Promise<string | undefined> {
 	if (sessionId && deps.resolveSessionModel) {
@@ -661,14 +665,23 @@ function applyNameStatus(blocks: DiffBlock[], nameStatus: string): void {
 
 function synthesizeFallbackCards(changeset: WalkthroughChangeset, files: DiffBlock[], warnings: WalkthroughWarning[]): WalkthroughCard[] {
 	const prContext = stringValue(changeset.prBody);
+	const why = prContext ? prContext.replace(/\s+/g, " ").slice(0, 220) : changeset.prTitle ?? changeset.title ?? "No PR description was available.";
+	const context = changeset.prTitle ?? changeset.title ?? "No additional PR context was provided.";
 	const cards: WalkthroughCard[] = [{
 		id: "orientation-summary",
 		phaseId: "orientation",
 		title: "PR context",
-		summary: `Why this PR was raised: ${prContext ? prContext.replace(/\s+/g, " ").slice(0, 220) : changeset.prTitle ?? changeset.title ?? "No PR description was available."}`,
-		rationale: `Context to understand the PR: ${changeset.prTitle ?? changeset.title ?? "No additional PR context was provided."}`,
+		navLabel: "Orientation",
+		summary: `Why this PR was raised: ${why}`,
+		rationale: `Context to understand the PR: ${context}`,
 		diffBlocks: [],
 		checklist: ["Testing strategy: No testing strategy was specified in the PR description.", ...warnings.slice(0, 2).map(warning => warning.filePath ? `${warning.filePath}: ${warning.message}` : warning.message)],
+		sections: [
+			{ id: "at-a-glance", navLabel: "At a glance", heading: "At a glance", body: `Why this PR was raised: ${why}`, showStats: true },
+			{ id: "why-it-exists", navLabel: "Why it exists", eyebrow: "The problem", heading: "Why it exists", body: why },
+			{ id: "what-it-changes", navLabel: "What it changes", eyebrow: "The change", heading: "What it changes", body: context },
+			{ id: "where-to-look", navLabel: "Where to look", heading: "Where to look", body: context, showOriginalDescription: true },
+		],
 	}];
 	if (files.length > 0) {
 		const reviewBlocks = files.filter(file => file.status !== "binary");
@@ -676,6 +689,7 @@ function synthesizeFallbackCards(changeset: WalkthroughChangeset, files: DiffBlo
 			id: "significant-files",
 			phaseId: "significant",
 			title: "Changed files",
+			navLabel: deriveNavLabel("Changed files"),
 			summary: `Review ${reviewBlocks.length || files.length} diff-backed file${(reviewBlocks.length || files.length) === 1 ? "" : "s"}.`,
 			diffBlocks: reviewBlocks.length ? reviewBlocks : files,
 		});
@@ -683,6 +697,7 @@ function synthesizeFallbackCards(changeset: WalkthroughChangeset, files: DiffBlo
 			id: "audit-coverage",
 			phaseId: "audit",
 			title: "Audit remaining coverage",
+			navLabel: deriveNavLabel("Audit remaining coverage"),
 			summary: "Final pass over the resolved diff and any unreviewable files.",
 			diffBlocks: files,
 			cardSuggestions: warnings.map(warning => warning.message),

--- a/src/server/pr-walkthrough/walkthrough-agent-manager.ts
+++ b/src/server/pr-walkthrough/walkthrough-agent-manager.ts
@@ -742,6 +742,7 @@ walkthrough:
   design_decisions:
     - id: stable-id
       title: string
+      nav_label: short label (≤3 words, ≤24 chars)
       explanation: string
       chosen_approach: string
       alternatives_considered:
@@ -762,6 +763,7 @@ walkthrough:
     - id: stable-id
       phase: significant|other|audit
       title: string
+      nav_label: short label (≤3 words, ≤24 chars)
       reviewer_goal: string
       explanation: string
       files:
@@ -807,6 +809,8 @@ walkthrough:
     chunk_order:
       - review_chunk_id
 \`\`\`
+
+nav_label is the compact sidebar label; keep it ≤3 words / ≤24 chars so it never truncates. Omit to auto-derive from title.
 
 The fenced block above is only a prompt example for readability; the submit_pr_walkthrough_yaml tool argument must be the raw YAML document without code fences.`;
 

--- a/src/server/pr-walkthrough/walkthrough-yaml-schema.ts
+++ b/src/server/pr-walkthrough/walkthrough-yaml-schema.ts
@@ -1,12 +1,16 @@
 import { parseAllDocuments } from "yaml";
 
 import { changesetIdForGithub } from "../../shared/pr-walkthrough/ids.js";
+import { deriveNavLabel, navLabelError } from "../../shared/pr-walkthrough/nav-label.js";
 import type {
 	PrWalkthroughCard,
+	PrWalkthroughCardSection,
 	PrWalkthroughChangesetRef,
 	PrWalkthroughDiffBlock,
 	PrWalkthroughDiffLine,
 	PrWalkthroughHunk,
+	PrWalkthroughOrientationConcern,
+	PrWalkthroughOrientationFileRole,
 	PrWalkthroughPhaseId,
 	PrWalkthroughSuggestedComment,
 	WalkthroughWarning,
@@ -116,6 +120,7 @@ export interface PrWalkthroughYamlRelevantHunk {
 export interface PrWalkthroughYamlDesignDecision {
 	id: string;
 	title: string;
+	nav_label?: string;
 	explanation: string;
 	chosen_approach: string;
 	alternatives_considered: Array<{ option: string; pros: string[]; cons: string[] }>;
@@ -128,6 +133,7 @@ export interface PrWalkthroughYamlReviewChunk {
 	id: string;
 	phase: "significant" | "other" | "audit";
 	title: string;
+	nav_label?: string;
 	reviewer_goal: string;
 	explanation: string;
 	files: string[];
@@ -249,6 +255,7 @@ export function mapYamlToWalkthroughPayload(
 			id: uniqueCardId(`design-${decision.id}`, cards),
 			phaseId: "design",
 			title: decision.title,
+			navLabel: decision.nav_label ?? deriveNavLabel(decision.title),
 			summary: decision.explanation,
 			rationale: compactJoin([
 				`Chosen approach: ${decision.chosen_approach}`,
@@ -276,6 +283,7 @@ export function mapYamlToWalkthroughPayload(
 			id: cardId,
 			phaseId: chunk.phase,
 			title: chunk.title,
+			navLabel: chunk.nav_label ?? deriveNavLabel(chunk.title),
 			summary: chunk.explanation,
 			rationale: compactJoin([`Reviewer goal: ${chunk.reviewer_goal}`, formatList("Positive notes", chunk.positive_notes)]),
 			diffBlocks: diffBlocksForCard,
@@ -425,6 +433,7 @@ function parseDesignDecisions(items: unknown[], errors: PrWalkthroughValidationE
 		}
 		const id = requiredStableId(item, "id", errors, `${path}.`);
 		const title = requiredString(item, "title", errors, `${path}.`);
+		const navLabel = parseNavLabel(item, errors, `${path}.`);
 		const explanation = requiredString(item, "explanation", errors, `${path}.`);
 		const chosenApproach = requiredString(item, "chosen_approach", errors, `${path}.`);
 		const alternatives = parseAlternatives(requiredArray(item, "alternatives_considered", errors, `${path}.`) ?? [], errors, `${path}.alternatives_considered`);
@@ -432,7 +441,7 @@ function parseDesignDecisions(items: unknown[], errors: PrWalkthroughValidationE
 		const concerns = requiredStringArray(item, "suggested_reviewer_concerns", errors, `${path}.`);
 		const hunks = parseRelevantHunks(requiredArray(item, "relevant_hunks", errors, `${path}.`) ?? [], errors, `${path}.relevant_hunks`, false);
 		if (id && title && explanation && chosenApproach && alternatives && tradeoffs && concerns && hunks) {
-			out.push({ id, title, explanation, chosen_approach: chosenApproach, alternatives_considered: alternatives, tradeoffs, suggested_reviewer_concerns: concerns, relevant_hunks: hunks });
+			out.push({ id, title, ...(navLabel !== undefined ? { nav_label: navLabel } : {}), explanation, chosen_approach: chosenApproach, alternatives_considered: alternatives, tradeoffs, suggested_reviewer_concerns: concerns, relevant_hunks: hunks });
 		}
 	});
 	validateUniqueIds(out, "$.walkthrough.design_decisions", errors);
@@ -450,6 +459,7 @@ function parseReviewChunks(items: unknown[], errors: PrWalkthroughValidationErro
 		const id = requiredStableId(item, "id", errors, `${path}.`);
 		const phase = requiredEnum(item, "phase", REVIEW_PHASES, errors, `${path}.`) as PrWalkthroughYamlReviewChunk["phase"] | undefined;
 		const title = requiredString(item, "title", errors, `${path}.`);
+		const navLabel = parseNavLabel(item, errors, `${path}.`);
 		const reviewerGoal = requiredString(item, "reviewer_goal", errors, `${path}.`);
 		const explanation = requiredString(item, "explanation", errors, `${path}.`);
 		const files = requiredStringArray(item, "files", errors, `${path}.`);
@@ -457,7 +467,7 @@ function parseReviewChunks(items: unknown[], errors: PrWalkthroughValidationErro
 		const suggestedConcerns = parseSuggestedConcerns(requiredArray(item, "suggested_concerns", errors, `${path}.`) ?? [], errors, `${path}.suggested_concerns`);
 		const positiveNotes = requiredStringArray(item, "positive_notes", errors, `${path}.`);
 		if (id && phase && title && reviewerGoal && explanation && files && hunks && suggestedConcerns && positiveNotes) {
-			out.push({ id, phase, title, reviewer_goal: reviewerGoal, explanation, files, relevant_hunks: hunks, suggested_concerns: suggestedConcerns, positive_notes: positiveNotes });
+			out.push({ id, phase, title, ...(navLabel !== undefined ? { nav_label: navLabel } : {}), reviewer_goal: reviewerGoal, explanation, files, relevant_hunks: hunks, suggested_concerns: suggestedConcerns, positive_notes: positiveNotes });
 		}
 	});
 	validateUniqueIds(out, "$.walkthrough.review_chunks", errors);
@@ -599,11 +609,10 @@ function buildOrientationCard(document: PrWalkthroughYamlDocument): PrWalkthroug
 		id: "orientation-summary",
 		phaseId: "orientation",
 		title: "PR context",
-		summary: compactJoin([
-			`Why created: ${context.why_created}`,
-			`Problem solved: ${context.problem_solved}`,
-			`Why worth merging: ${context.why_worth_merging}`,
-		]),
+		navLabel: "Orientation",
+		// Back-compat: legacy renderers / stored payloads read summary/rationale/checklist.
+		// The redesigned panel prefers `sections` (the guided beats below).
+		summary: assessment.summary,
 		rationale: compactJoin([
 			`Author intent: ${context.author_intent}`,
 			`Reviewer map: ${context.reviewer_map}`,
@@ -616,8 +625,94 @@ function buildOrientationCard(document: PrWalkthroughYamlDocument): PrWalkthroug
 			...assessment.non_blocking_concerns.map(item => `Non-blocking concern: ${item}`),
 			`Original PR description source: ${document.pr.original_description.source} at ${document.pr.original_description.fetched_at}`,
 		]),
+		sections: buildOrientationSections(document),
 		cardSuggestions: compactArray([context.merge_concerns, ...assessment.blocking_concerns, ...assessment.non_blocking_concerns]),
 	};
+}
+
+function buildOrientationSections(document: PrWalkthroughYamlDocument): PrWalkthroughCardSection[] {
+	const context = document.walkthrough.context;
+	const assessment = document.walkthrough.merge_assessment;
+
+	const concerns: PrWalkthroughOrientationConcern[] = [
+		...assessment.blocking_concerns.map((text): PrWalkthroughOrientationConcern => ({ severity: "blocking", text })),
+		...assessment.non_blocking_concerns.map((text): PrWalkthroughOrientationConcern => ({ severity: "non_blocking", text })),
+	];
+	if (context.merge_concerns.trim().length > 0) concerns.push({ severity: "question", text: context.merge_concerns });
+
+	const fileRoles = parseReviewerMapRoles(context.reviewer_map);
+
+	return [
+		{
+			id: "at-a-glance",
+			navLabel: "At a glance",
+			heading: "At a glance",
+			body: assessment.summary,
+			verdict: { recommendation: assessment.recommendation, confidence: assessment.confidence, summary: assessment.summary },
+			showStats: true,
+		},
+		{
+			id: "why-it-exists",
+			navLabel: "Why it exists",
+			eyebrow: "The problem",
+			heading: "Why it exists",
+			body: context.why_created,
+		},
+		{
+			id: "what-it-changes",
+			navLabel: "What it changes",
+			eyebrow: "The change",
+			heading: "What it changes",
+			body: context.problem_solved,
+		},
+		{
+			id: "should-merge",
+			navLabel: "Should we merge",
+			eyebrow: "The decision",
+			heading: "Should it be merged?",
+			body: compactJoin([mergeAnswerLine(assessment.recommendation, assessment.confidence), context.why_worth_merging]),
+		},
+		{
+			id: "what-to-watch",
+			navLabel: "What to watch",
+			heading: "What to scrutinise",
+			concerns,
+		},
+		{
+			id: "where-to-look",
+			navLabel: "Where to look",
+			heading: "Where to look",
+			body: context.reviewer_map,
+			...(fileRoles.length > 0 ? { fileRoles } : {}),
+			showOriginalDescription: true,
+		},
+	];
+}
+
+function mergeAnswerLine(recommendation: PrWalkthroughYamlWalkthrough["merge_assessment"]["recommendation"], confidence: string): string {
+	switch (recommendation) {
+		case "approve": return `Yes — approve, ${confidence} confidence.`;
+		case "request_changes": return `Not yet — request changes, ${confidence} confidence.`;
+		case "comment": return `Maybe — comment, ${confidence} confidence.`;
+		default: return "Recommendation unclear.";
+	}
+}
+
+function parseReviewerMapRoles(reviewerMap: string): PrWalkthroughOrientationFileRole[] {
+	const roles: PrWalkthroughOrientationFileRole[] = [];
+	for (const rawLine of reviewerMap.split(/\r?\n/)) {
+		const match = /^\s*(core|support|verify|docs)\s*[:\-]\s*(.+)$/i.exec(rawLine);
+		if (!match) continue;
+		const role = match[1].toLowerCase() as PrWalkthroughOrientationFileRole["role"];
+		const rest = match[2].trim();
+		const noteSep = /\s[—-]\s/.exec(rest);
+		if (noteSep && rest.slice(0, noteSep.index).trim().length > 0) {
+			roles.push({ role, file: rest.slice(0, noteSep.index).trim(), note: rest.slice(noteSep.index + noteSep[0].length).trim() });
+		} else {
+			roles.push({ role, file: rest });
+		}
+	}
+	return roles;
 }
 
 function buildOmissionsCard(omissions: PrWalkthroughYamlOmission[], existingCards: PrWalkthroughCard[]): PrWalkthroughCard | null {
@@ -626,6 +721,7 @@ function buildOmissionsCard(omissions: PrWalkthroughYamlOmission[], existingCard
 		id: uniqueCardId("other-omissions-followups", existingCards),
 		phaseId: "other",
 		title: "Omissions and follow-ups",
+		navLabel: deriveNavLabel("Omissions and follow-ups"),
 		summary: omissions.map(item => `${item.category}: ${item.concern}`).join("\n"),
 		rationale: omissions.map(item => `${item.expected_artifact} — evidence checked: ${item.evidence_checked}`).join("\n"),
 		diffBlocks: [],
@@ -640,6 +736,7 @@ function buildAuditCard(document: PrWalkthroughYamlDocument, remainingBlocks: Pr
 		id: uniqueCardId("audit-checklist", existingCards),
 		phaseId: "audit",
 		title: "Audit and review checklist",
+		navLabel: deriveNavLabel("Audit and review checklist"),
 		summary: compactJoin([
 			formatList("Remaining changed areas", audit.remaining_changed_areas),
 			remainingBlocks.length > 0 ? `Unassigned diff blocks: ${remainingBlocks.map(block => block.filePath).join(", ")}` : undefined,
@@ -885,6 +982,17 @@ function optionalString(root: Record<string, unknown>, key: string, errors: PrWa
 	if (value === undefined) return undefined;
 	if (typeof value !== "string") {
 		addError(errors, `${prefix}${key}`, "Expected a string.");
+		return undefined;
+	}
+	return value;
+}
+
+function parseNavLabel(root: Record<string, unknown>, errors: PrWalkthroughValidationError[], prefix: string): string | undefined {
+	const value = optionalString(root, "nav_label", errors, prefix);
+	if (value === undefined) return undefined;
+	const error = navLabelError(value);
+	if (error) {
+		addError(errors, `${prefix}nav_label`, error);
 		return undefined;
 	}
 	return value;

--- a/src/server/pr-walkthrough/walkthrough-yaml-schema.ts
+++ b/src/server/pr-walkthrough/walkthrough-yaml-schema.ts
@@ -990,6 +990,9 @@ function optionalString(root: Record<string, unknown>, key: string, errors: PrWa
 function parseNavLabel(root: Record<string, unknown>, errors: PrWalkthroughValidationError[], prefix: string): string | undefined {
 	const value = optionalString(root, "nav_label", errors, prefix);
 	if (value === undefined) return undefined;
+	// An empty / whitespace-only nav_label is treated as omitted so the caller
+	// falls back to deriveNavLabel(title) instead of failing validation.
+	if (value.trim().length === 0) return undefined;
 	const error = navLabelError(value);
 	if (error) {
 		addError(errors, `${prefix}nav_label`, error);

--- a/src/shared/pr-walkthrough/index.ts
+++ b/src/shared/pr-walkthrough/index.ts
@@ -1,4 +1,5 @@
 export * from "./types.js";
+export * from "./nav-label.js";
 export * from "./ids.js";
 export * from "./draft.js";
 export * from "./generated-path.js";

--- a/src/shared/pr-walkthrough/nav-label.ts
+++ b/src/shared/pr-walkthrough/nav-label.ts
@@ -6,14 +6,18 @@ export const NAV_LABEL_MAX_WORDS = 3;
 export const NAV_LABEL_MAX_CHARS = 24;
 
 const NAV_LABEL_ERROR = `nav_label must be ≤${NAV_LABEL_MAX_WORDS} words and ≤${NAV_LABEL_MAX_CHARS} characters.`;
+const NAV_LABEL_EMPTY_ERROR = "nav_label must not be empty.";
 
 /**
- * Validate a nav label: ≤3 words AND ≤24 chars after trim.
- * Returns an actionable error string, or null when valid.
+ * Validate a nav label: non-empty after trim AND ≤3 words AND ≤24 chars.
+ * Returns an actionable error string, or null when valid. An empty or
+ * whitespace-only label is invalid so callers that validate-then-fallback
+ * derive a compact label from the title instead of rendering a blank rail entry.
  */
 export function navLabelError(value: string): string | null {
 	const trimmed = value.trim();
-	const wordCount = trimmed.length === 0 ? 0 : trimmed.split(/\s+/).length;
+	if (trimmed.length === 0) return NAV_LABEL_EMPTY_ERROR;
+	const wordCount = trimmed.split(/\s+/).length;
 	if (wordCount > NAV_LABEL_MAX_WORDS || trimmed.length > NAV_LABEL_MAX_CHARS) return NAV_LABEL_ERROR;
 	return null;
 }

--- a/src/shared/pr-walkthrough/nav-label.ts
+++ b/src/shared/pr-walkthrough/nav-label.ts
@@ -1,0 +1,42 @@
+// Compact sidebar ("nav") labels for PR walkthrough cards and orientation beats.
+// The rail is narrow (~240px); labels longer than a few words truncate badly, so
+// every sidebar entry uses a short label distinct from the full descriptive title.
+
+export const NAV_LABEL_MAX_WORDS = 3;
+export const NAV_LABEL_MAX_CHARS = 24;
+
+const NAV_LABEL_ERROR = `nav_label must be ≤${NAV_LABEL_MAX_WORDS} words and ≤${NAV_LABEL_MAX_CHARS} characters.`;
+
+/**
+ * Validate a nav label: ≤3 words AND ≤24 chars after trim.
+ * Returns an actionable error string, or null when valid.
+ */
+export function navLabelError(value: string): string | null {
+	const trimmed = value.trim();
+	const wordCount = trimmed.length === 0 ? 0 : trimmed.split(/\s+/).length;
+	if (wordCount > NAV_LABEL_MAX_WORDS || trimmed.length > NAV_LABEL_MAX_CHARS) return NAV_LABEL_ERROR;
+	return null;
+}
+
+/**
+ * Derive a compact rail label from a full title:
+ *   - take the text before the first ':' / '—' / ' - ' when that prefix is non-empty,
+ *     otherwise use the whole title;
+ *   - keep the first ≤3 words;
+ *   - if the result is still >24 chars, hard-truncate to 23 chars + '…'.
+ */
+export function deriveNavLabel(title: string): string {
+	const trimmed = (title ?? "").trim();
+	if (trimmed.length === 0) return "";
+
+	let head = trimmed;
+	const separator = /\s-\s|[:—]/.exec(trimmed);
+	if (separator) {
+		const prefix = trimmed.slice(0, separator.index).trim();
+		if (prefix.length > 0) head = prefix;
+	}
+
+	const label = head.split(/\s+/).slice(0, NAV_LABEL_MAX_WORDS).join(" ");
+	if (label.length > NAV_LABEL_MAX_CHARS) return `${label.slice(0, NAV_LABEL_MAX_CHARS - 1)}…`;
+	return label;
+}

--- a/src/shared/pr-walkthrough/types.ts
+++ b/src/shared/pr-walkthrough/types.ts
@@ -58,6 +58,40 @@ export interface PrWalkthroughSuggestedComment {
 	body: string;
 }
 
+export type PrWalkthroughOrientationConcernSeverity = "blocking" | "non_blocking" | "question" | "nit";
+export type PrWalkthroughOrientationFileRoleKind = "core" | "support" | "verify" | "docs";
+
+export interface PrWalkthroughOrientationConcern {
+	severity: PrWalkthroughOrientationConcernSeverity;
+	text: string;
+}
+
+export interface PrWalkthroughOrientationFileRole {
+	role: PrWalkthroughOrientationFileRoleKind;
+	file: string;
+	note?: string;
+}
+
+export interface PrWalkthroughOrientationVerdict {
+	recommendation: "approve" | "comment" | "request_changes" | "unknown";
+	confidence: "low" | "medium" | "high";
+	summary?: string;
+}
+
+/** A single-idea "beat" in the orientation guided step-through. */
+export interface PrWalkthroughCardSection {
+	id: string;
+	navLabel: string;
+	eyebrow?: string;
+	heading: string;
+	body?: string;
+	verdict?: PrWalkthroughOrientationVerdict;
+	concerns?: PrWalkthroughOrientationConcern[];
+	fileRoles?: PrWalkthroughOrientationFileRole[];
+	showStats?: boolean;
+	showOriginalDescription?: boolean;
+}
+
 export interface PrWalkthroughCard {
 	id: string;
 	phaseId: PrWalkthroughPhaseId;
@@ -68,6 +102,10 @@ export interface PrWalkthroughCard {
 	suggestedComments?: PrWalkthroughSuggestedComment[];
 	cardSuggestions?: string[];
 	checklist?: string[];
+	/** Compact (≤3-word) sidebar rail label; falls back to a derived label from `title`. */
+	navLabel?: string;
+	/** Orientation guided-step "beats"; only set on the orientation card. */
+	sections?: PrWalkthroughCardSection[];
 }
 
 export interface PrWalkthroughComment {

--- a/src/ui/components/pr-walkthrough/PrWalkthroughPanel.ts
+++ b/src/ui/components/pr-walkthrough/PrWalkthroughPanel.ts
@@ -2,10 +2,11 @@ import { icon } from "@mariozechner/mini-lit";
 import { css, html, LitElement, nothing, type PropertyValues, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { PanelLeftClose, PanelLeftOpen } from "lucide";
-import { buildPrWalkthroughDraft, cardRequiresCommentForDislike, defaultDiffModeForWidth, type PrWalkthroughCard, type PrWalkthroughChangesetRef, type PrWalkthroughComment, type PrWalkthroughDecision, type PrWalkthroughDiffBlock, type PrWalkthroughDiffLine, type PrWalkthroughDiffMode, type PrWalkthroughPhaseId, type PrWalkthroughReviewDraft, type PrWalkthroughSuggestedComment } from "./types.js";
+import { buildPrWalkthroughDraft, cardRequiresCommentForDislike, defaultDiffModeForWidth, type PrWalkthroughCard, type PrWalkthroughCardSection, type PrWalkthroughChangesetRef, type PrWalkthroughComment, type PrWalkthroughDecision, type PrWalkthroughDiffBlock, type PrWalkthroughDiffLine, type PrWalkthroughDiffMode, type PrWalkthroughOrientationConcern, type PrWalkthroughOrientationFileRole, type PrWalkthroughOrientationVerdict, type PrWalkthroughPhaseId, type PrWalkthroughReviewDraft, type PrWalkthroughSuggestedComment } from "./types.js";
 import { fixturePrWalkthroughChangeset, getFixturePrWalkthroughCards } from "./fixtures.js";
 import { gatewayFetch } from "../../../app/gateway-fetch.js";
 import { safeExternalUrl } from "../../../shared/pr-walkthrough/url-safety.js";
+import { deriveNavLabel } from "../../../shared/pr-walkthrough/nav-label.js";
 
 const PHASES: Array<{ id: PrWalkthroughPhaseId; label: string }> = [
 	{ id: "orientation", label: "Orientation" },
@@ -139,6 +140,7 @@ export class PrWalkthroughPanel extends LitElement {
 	@property({ attribute: "persistence-key" }) persistenceKey = "";
 
 	@state() private _activeCardId = "";
+	@state() private _orientationBeatIndex = 0;
 	@state() private _panelWidth = 1024;
 	@state() private _observedNarrow = false;
 	@state() private _railCollapsed = false;
@@ -671,12 +673,71 @@ export class PrWalkthroughPanel extends LitElement {
 		.body.narrow .actions { gap: 6px; justify-content: flex-end; }
 		.body.narrow .actions button { flex: 0 0 auto; padding-left: 9px; padding-right: 9px; }
 
+		/* ===== Orientation guided steps ===== */
+		.guide-card .inner { min-height: 100%; }
+		.guide { max-width: 720px; margin: 0 auto; min-height: 100%; display: flex; flex-direction: column; flex: 1 1 auto; }
+		.guide-top { display: flex; align-items: center; gap: 12px; }
+		.guide .eyebrow { display: inline-block; padding: 3px 9px; border-radius: 5px; background: color-mix(in oklch, var(--chart-1, var(--primary, Highlight)) 14%, transparent); color: var(--chart-1, var(--primary, Highlight)); font-size: 10.5px; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; }
+		.guide-count { margin-left: auto; color: var(--muted-foreground, GrayText); font-size: 11px; font-weight: 600; }
+		.guide-stage { flex: 1 1 auto; display: grid; align-content: start; gap: 14px; padding: 26px 2px 10px; }
+		.beat { display: grid; gap: 12px; animation: pr-walkthrough-beat-in 180ms ease; }
+		@keyframes pr-walkthrough-beat-in { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
+		.beat h2 { margin: 4px 0 0; font-size: 26px; line-height: 1.18; letter-spacing: -0.015em; }
+		.beat p { margin: 0; font-size: 15px; line-height: 1.7; color: color-mix(in oklch, var(--foreground, CanvasText) 88%, var(--muted-foreground, GrayText)); max-width: 640px; }
+		.beat-verdict { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+		.beat-stats { display: inline-flex; align-items: center; gap: 7px; color: var(--muted-foreground, GrayText); font-size: 12px; }
+		.beat-stats .stat-add { color: var(--positive, var(--chart-3, green)); font-weight: 700; }
+		.beat-stats .stat-del { color: var(--negative, var(--chart-5, red)); font-weight: 700; }
+		.verdict { display: inline-flex; align-items: center; gap: 10px; padding: 7px 12px 7px 10px; border: 1px solid color-mix(in oklch, var(--positive, green) 40%, var(--border, ButtonBorder)); border-radius: 999px; background: color-mix(in oklch, var(--positive, green) 12%, transparent); }
+		.verdict .dot { width: 9px; height: 9px; border-radius: 999px; background: var(--positive, green); }
+		.verdict b { color: var(--positive, green); font-weight: 800; letter-spacing: 0.04em; }
+		.verdict .conf { color: var(--muted-foreground, GrayText); font-size: 12px; }
+		.verdict.verdict-request_changes { border-color: color-mix(in oklch, var(--negative, red) 40%, var(--border, ButtonBorder)); background: color-mix(in oklch, var(--negative, red) 12%, transparent); }
+		.verdict.verdict-request_changes .dot, .verdict.verdict-request_changes b { background: var(--negative, red); color: var(--negative, red); }
+		.verdict.verdict-comment { border-color: color-mix(in oklch, var(--warning, orange) 40%, var(--border, ButtonBorder)); background: color-mix(in oklch, var(--warning, orange) 12%, transparent); }
+		.verdict.verdict-comment .dot, .verdict.verdict-comment b { background: var(--warning, orange); color: var(--warning, orange); }
+		.verdict.verdict-unknown { border-color: var(--border, ButtonBorder); background: color-mix(in oklch, var(--muted-foreground, GrayText) 10%, transparent); }
+		.verdict.verdict-unknown .dot { background: var(--muted-foreground, GrayText); }
+		.verdict.verdict-unknown b { color: var(--muted-foreground, GrayText); }
+		.sec-label { color: var(--muted-foreground, GrayText); font-size: 10.5px; font-weight: 800; letter-spacing: 0.07em; text-transform: uppercase; }
+		.concern-list { display: grid; gap: 8px; }
+		.filemap { display: grid; gap: 6px; }
+		.filerow { display: grid; grid-template-columns: auto 1fr; align-items: baseline; gap: 10px; padding: 8px 10px; border: 1px solid var(--border, ButtonBorder); border-radius: 9px; background: var(--card, Canvas); }
+		.filerow code { font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: var(--foreground, CanvasText); }
+		.filerow .role { font-size: 10px; font-weight: 800; letter-spacing: 0.05em; text-transform: uppercase; padding: 2px 7px; border-radius: 5px; white-space: nowrap; }
+		.filerow .role.core { color: var(--chart-1, var(--primary, Highlight)); background: color-mix(in oklch, var(--chart-1, var(--primary, Highlight)) 15%, transparent); }
+		.filerow .role.support { color: var(--chart-2, var(--info, Highlight)); background: color-mix(in oklch, var(--chart-2, var(--info, Highlight)) 16%, transparent); }
+		.filerow .role.verify { color: var(--chart-3, var(--positive, green)); background: color-mix(in oklch, var(--chart-3, var(--positive, green)) 16%, transparent); }
+		.filerow .role.docs { color: var(--muted-foreground, GrayText); background: color-mix(in oklch, var(--muted-foreground, GrayText) 14%, transparent); }
+		.filerow .note { grid-column: 2; color: var(--muted-foreground, GrayText); font-size: 12px; }
+		.concern { display: grid; grid-template-columns: auto 1fr; gap: 10px; padding: 10px 12px; border: 1px solid var(--border, ButtonBorder); border-left-width: 3px; border-radius: 8px; background: var(--card, Canvas); }
+		.concern.blocking { border-left-color: var(--negative, red); }
+		.concern.non-blocking { border-left-color: var(--info, var(--primary, Highlight)); }
+		.concern.q { border-left-color: var(--warning, orange); }
+		.concern.nit { border-left-color: var(--muted-foreground, GrayText); }
+		.concern .tag { align-self: start; margin-top: 1px; font-size: 9.5px; font-weight: 800; letter-spacing: 0.05em; text-transform: uppercase; padding: 2px 7px; border-radius: 5px; }
+		.concern.blocking .tag { color: var(--negative, red); background: color-mix(in oklch, var(--negative, red) 14%, transparent); }
+		.concern.non-blocking .tag { color: var(--info, var(--primary, Highlight)); background: color-mix(in oklch, var(--info, var(--primary, Highlight)) 16%, transparent); }
+		.concern.q .tag { color: var(--warning, orange); background: color-mix(in oklch, var(--warning, orange) 16%, transparent); }
+		.concern.nit .tag { color: var(--muted-foreground, GrayText); background: color-mix(in oklch, var(--muted-foreground, GrayText) 14%, transparent); }
+		.concern p { margin: 0; line-height: 1.55; }
+		.guide-nav { display: flex; align-items: center; gap: 10px; padding: 14px 0 4px; border-top: 1px solid var(--border, ButtonBorder); }
+		.guide-nav .spacer { flex: 1 1 auto; }
+		.guide-nav button { display: inline-flex; align-items: center; gap: 6px; min-height: 34px; padding: 7px 14px; border: 1px solid var(--border, ButtonBorder); border-radius: 9px; background: var(--card, Canvas); color: inherit; font: inherit; font-weight: 600; }
+		.guide-nav button:hover:not(:disabled) { background: color-mix(in oklch, var(--primary, Highlight) 10%, transparent); }
+		.guide-nav button:disabled { opacity: 0.45; cursor: not-allowed; }
+		.guide-nav .next { border-color: color-mix(in oklch, var(--primary, Highlight) 55%, var(--border, ButtonBorder)); background: var(--primary, Highlight); color: var(--primary-foreground, HighlightText); }
+		.guide-nav .ghost { border-color: transparent; background: transparent; color: var(--muted-foreground, GrayText); }
+		/* Per-beat orientation rail circles */
+		.rail:not(.collapsed) .card-dot.orientation-dot.done { background-color: color-mix(in oklch, var(--primary, Highlight) 60%, transparent); border-color: color-mix(in oklch, var(--primary, Highlight) 60%, transparent); color: var(--primary-foreground, HighlightText); opacity: 1; }
+
 		@media (max-width: 760px) {
 			.header { padding: 12px; }
 			.title-row { display: grid; }
 			.progress-wrap { min-width: 0; }
 			.progress-label { text-align: left; }
 			.content { padding: 12px; }
+			.beat h2 { font-size: 22px; }
 		}
 	`;
 
@@ -696,6 +757,9 @@ export class PrWalkthroughPanel extends LitElement {
 	}
 
 	protected override willUpdate(changed: PropertyValues<this>): void {
+		if (changed.has("jobId") || changed.has("cards")) {
+			this._orientationBeatIndex = 0;
+		}
 		if (changed.has("persistenceKey")) {
 			this.restorePersistedState();
 			return;
@@ -753,8 +817,65 @@ export class PrWalkthroughPanel extends LitElement {
 		return (this.reviewCards[0] ?? this.cards[0])?.id ?? "";
 	}
 
+	private get orientationCard(): PrWalkthroughCard | undefined {
+		return this.cards.find(card => card.phaseId === "orientation");
+	}
+
+	/** True when the orientation card uses the guided step-through (`sections`) model. */
+	private get isOrientationGuided(): boolean {
+		return !!this.orientationCard?.sections?.length;
+	}
+
+	private isGuidedOrientationCard(card: PrWalkthroughCard | undefined): boolean {
+		return !!card && card.phaseId === "orientation" && !!card.sections?.length;
+	}
+
+	private clampBeatIndex(index: number): number {
+		const count = this.orientationCard?.sections?.length ?? 0;
+		if (count <= 0) return 0;
+		return Math.max(0, Math.min(count - 1, index));
+	}
+
+	private selectOrientationBeat(index: number): void {
+		const orientation = this.orientationCard;
+		if (!orientation) return;
+		this._orientationBeatIndex = this.clampBeatIndex(index);
+		if (this._activeCardId !== orientation.id) {
+			this.selectCard(orientation.id);
+		} else {
+			this.persistState();
+		}
+	}
+
+	private goOrientationBack = (): void => {
+		this._orientationBeatIndex = this.clampBeatIndex(this._orientationBeatIndex - 1);
+	};
+
+	private goOrientationNext = (): void => {
+		const sections = this.orientationCard?.sections ?? [];
+		if (this._orientationBeatIndex >= sections.length - 1) {
+			this.completeOrientationAndAdvance();
+			return;
+		}
+		this._orientationBeatIndex = this.clampBeatIndex(this._orientationBeatIndex + 1);
+	};
+
+	private completeOrientationAndAdvance(): void {
+		const orientation = this.orientationCard;
+		if (!orientation) return;
+		if (!this._completedCardIds.includes(orientation.id)) {
+			this._completedCardIds = [...this._completedCardIds, orientation.id];
+			this.emitDraftChange();
+		}
+		this.persistState();
+		const next = this.nextCardId(orientation.id);
+		if (next) this.selectCard(next);
+		else this.emitComplete();
+	}
+
 	private resetInteractionState(): void {
 		this._activeCardId = this.firstAvailableCardId();
+		this._orientationBeatIndex = 0;
 		this._diffModeOverride = undefined;
 		this._comments = [];
 		this._decisions = {};
@@ -948,12 +1069,13 @@ export class PrWalkthroughPanel extends LitElement {
 					if (cards.length === 0) return nothing;
 					const phaseActive = cards.some(card => card.id === this.activeCard?.id);
 					const complete = cards.every(card => this._completedCardIds.includes(card.id) || card.phaseId === "audit");
+					const guidedOrientationPhase = phase.id === "orientation" && this.isOrientationGuided;
 					return html`
 						<section class="phase ${phaseActive ? "active" : ""} ${complete && !phaseActive ? "complete" : ""}" data-phase-id=${phase.id}>
-							<button class="phase-button ${phaseActive ? "active" : ""}" data-testid="pr-walkthrough-phase-button" type="button" @click=${() => this.selectCard(cards[0].id)} title=${`Phase ${index}: ${phase.label}`}>
+							<button class="phase-button ${phaseActive ? "active" : ""}" data-testid="pr-walkthrough-phase-button" type="button" @click=${() => guidedOrientationPhase ? this.selectOrientationBeat(0) : this.selectCard(cards[0].id)} title=${`Phase ${index}: ${phase.label}`}>
 								<span class="phase-pip ${phaseActive ? "active" : ""} ${complete && !phaseActive ? "complete" : ""}" aria-hidden="true">${index}</span><span class="phase-name">${phase.label}</span><span class="phase-count">${cards.filter(card => this._completedCardIds.includes(card.id)).length}/${cards.length}</span>
 							</button>
-							<div class="phase-cards">${cards.map(card => this.renderRailCardButton(card))}</div>
+							<div class="phase-cards">${guidedOrientationPhase ? this.renderOrientationRailCircles() : cards.map(card => this.renderRailCardButton(card))}</div>
 						</section>
 					`;
 				})}
@@ -1044,9 +1166,40 @@ export class PrWalkthroughPanel extends LitElement {
 		return html`
 			<button class="card-button ${card.id === this.activeCard?.id ? "active" : ""} ${this._completedCardIds.includes(card.id) ? "complete" : ""} ${decision === "liked" ? "liked" : ""} ${decision === "disliked" ? "disliked" : ""}" data-testid="pr-walkthrough-card-step" data-card-id=${card.id} type="button" title=${card.title} @click=${() => this.selectCard(card.id)}>
 				<span class="card-dot card-dot-rail ${card.id === this.activeCard?.id ? "active" : ""} ${decision === "liked" ? "liked" : ""} ${decision === "disliked" ? "disliked" : ""}" aria-hidden="true">${decision === "liked" ? html`<svg class="dot-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M7 10v12"></path><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2h0a3.13 3.13 0 0 1 3 3.88Z"></path></svg>` : decision === "disliked" ? html`<svg class="dot-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M17 14V2"></path><path d="M9 18.12 10 14H4.17a2 2 0 0 1-1.92-2.56l2.33-8A2 2 0 0 1 6.5 2H20a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-2.76a2 2 0 0 0-1.79 1.11L12 22h0a3.13 3.13 0 0 1-3-3.88Z"></path></svg>` : nothing}</span>
-				<span class="card-title">${card.title}</span>
+				<span class="card-title">${card.navLabel ?? deriveNavLabel(card.title)}</span>
 				<span class="card-decision">${comments ? comments : decision ? decision : card.phaseId === "audit" ? "draft" : "pending"}</span>
 			</button>
+		`;
+	}
+
+	private renderOrientationRailCircles(): TemplateResult | typeof nothing {
+		const orientation = this.orientationCard;
+		const sections = orientation?.sections ?? [];
+		if (!orientation || sections.length === 0) return nothing;
+		const orientationActive = this.activeCard?.id === orientation.id;
+		const orientationComplete = this._completedCardIds.includes(orientation.id);
+		const beatIndex = this.clampBeatIndex(this._orientationBeatIndex);
+		return html`
+			<div class="phase-cards orientation-steps" data-testid="pr-walkthrough-orientation-rail">
+				${sections.map((section, idx) => {
+					const current = orientationActive && idx === beatIndex;
+					const done = orientationActive ? idx < beatIndex : orientationComplete;
+					return html`
+						<button
+							class="card-button orientation-step ${current ? "active" : ""}"
+							data-testid="pr-walkthrough-orientation-step"
+							data-beat-index=${idx}
+							data-state=${current ? "current" : done ? "visited" : "upcoming"}
+							type="button"
+							title=${section.heading}
+							@click=${() => this.selectOrientationBeat(idx)}
+						>
+							<span class="card-dot orientation-dot ${current ? "active" : ""} ${done && !current ? "done" : ""}" aria-hidden="true">${done && !current ? html`<svg class="dot-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M20 6 9 17l-5-5"></path></svg>` : nothing}</span>
+							<span class="card-title">${section.navLabel}</span>
+						</button>
+					`;
+				})}
+			</div>
 		`;
 	}
 
@@ -1197,6 +1350,7 @@ export class PrWalkthroughPanel extends LitElement {
 	}
 
 	private renderCard(card: PrWalkthroughCard): TemplateResult {
+		if (this.isGuidedOrientationCard(card)) return this.renderOrientationGuideCard(card);
 		const phaseIndex = PHASES.findIndex(item => item.id === card.phaseId);
 		const phase = PHASES[phaseIndex]?.label ?? card.phaseId;
 		const dislikeDisabled = cardRequiresCommentForDislike({ comments: this._comments }, card.id);
@@ -1227,6 +1381,125 @@ export class PrWalkthroughPanel extends LitElement {
 					</div>
 				</div>
 			</article>
+		`;
+	}
+
+	private renderOrientationGuideCard(card: PrWalkthroughCard): TemplateResult {
+		const sections = card.sections ?? [];
+		const index = this.clampBeatIndex(this._orientationBeatIndex);
+		const section = sections[index];
+		const isLast = index >= sections.length - 1;
+		return html`
+			<article class="card guide-card" data-testid="pr-walkthrough-card" data-active="true" data-card-id=${card.id} data-phase-id=${card.phaseId}>
+				<div class="inner">
+					<div class="guide" data-testid="pr-walkthrough-orientation-guide">
+						<div class="guide-top">
+							<span class="eyebrow" data-testid="pr-walkthrough-guide-eyebrow">Phase 0 · Orientation</span>
+							<span class="guide-count" data-testid="pr-walkthrough-guide-counter">${index + 1} / ${sections.length}</span>
+						</div>
+						<div class="guide-stage">
+							${section ? this.renderOrientationBeat(card, section) : nothing}
+						</div>
+						<div class="guide-nav" data-testid="pr-walkthrough-guide-nav">
+							<button class="ghost" data-testid="pr-walkthrough-guide-back" type="button" ?disabled=${index === 0} @click=${this.goOrientationBack}>‹ Back</button>
+							<div class="spacer"></div>
+							<button class="next" data-testid="pr-walkthrough-guide-next" type="button" @click=${this.goOrientationNext}>${isLast ? "Start review →" : "Next →"}</button>
+						</div>
+					</div>
+				</div>
+			</article>
+		`;
+	}
+
+	private renderOrientationBeat(card: PrWalkthroughCard, section: PrWalkthroughCardSection): TemplateResult {
+		const paragraphs = (section.body ?? "").split(/\n{2,}|\n/).map(part => part.trim()).filter(Boolean);
+		return html`
+			<div class="beat show" data-testid="pr-walkthrough-beat" data-beat-id=${section.id}>
+				${section.verdict ? this.renderOrientationVerdict(section.verdict, section.showStats === true) : section.showStats ? html`<div class="beat-verdict">${this.renderOrientationStats()}</div>` : nothing}
+				${section.eyebrow ? html`<span class="sec-label" data-testid="pr-walkthrough-beat-eyebrow">${section.eyebrow}</span>` : nothing}
+				<h2 data-testid="pr-walkthrough-beat-heading">${section.heading}</h2>
+				${paragraphs.map(text => html`<p>${text}</p>`)}
+				${section.concerns?.length ? this.renderOrientationConcerns(section.concerns) : nothing}
+				${section.fileRoles?.length ? this.renderOrientationFileRoles(section.fileRoles) : nothing}
+				${section.showOriginalDescription ? this.renderOriginalPrDescription(card) : nothing}
+			</div>
+		`;
+	}
+
+	private renderOrientationVerdict(verdict: PrWalkthroughOrientationVerdict, showStats: boolean): TemplateResult {
+		const label = verdict.recommendation === "approve" ? "APPROVE"
+			: verdict.recommendation === "request_changes" ? "REQUEST CHANGES"
+			: verdict.recommendation === "comment" ? "COMMENT"
+			: "UNKNOWN";
+		return html`
+			<div class="beat-verdict">
+				<span class="verdict verdict-${verdict.recommendation}" data-testid="pr-walkthrough-beat-verdict">
+					<span class="dot" aria-hidden="true"></span>
+					<b>${label}</b>
+					<span class="conf">· ${verdict.confidence} confidence</span>
+				</span>
+				${showStats ? this.renderOrientationStats() : nothing}
+			</div>
+		`;
+	}
+
+	private renderOrientationStats(): TemplateResult {
+		const stats = this.changesetStats;
+		return html`
+			<span class="beat-stats" data-testid="pr-walkthrough-beat-stats">
+				<span class="stat-files">${stats.files} files</span>
+				<span class="stat-sep" aria-hidden="true">·</span>
+				<span class="stat-add">+${this.formatNumber(stats.additions)}</span>
+				<span class="stat-del">-${this.formatNumber(stats.deletions)}</span>
+			</span>
+		`;
+	}
+
+	private renderOrientationConcerns(concerns: PrWalkthroughOrientationConcern[]): TemplateResult {
+		const blocking = concerns.filter(concern => concern.severity === "blocking").length;
+		const nonBlocking = concerns.length - blocking;
+		const severityClass: Record<PrWalkthroughOrientationConcern["severity"], string> = {
+			blocking: "blocking",
+			non_blocking: "non-blocking",
+			question: "q",
+			nit: "nit",
+		};
+		const severityTag: Record<PrWalkthroughOrientationConcern["severity"], string> = {
+			blocking: "Blocking",
+			non_blocking: "Non-blocking",
+			question: "Question",
+			nit: "Nit",
+		};
+		return html`
+			<div class="concern-list" data-testid="pr-walkthrough-beat-concerns">
+				<span class="sec-label" data-testid="pr-walkthrough-beat-concern-count">${blocking} blocking, ${nonBlocking} non-blocking</span>
+				${concerns.map(concern => html`
+					<div class="concern ${severityClass[concern.severity]}" data-testid="pr-walkthrough-beat-concern" data-severity=${concern.severity}>
+						<span class="tag">${severityTag[concern.severity]}</span>
+						<p>${concern.text}</p>
+					</div>
+				`)}
+			</div>
+		`;
+	}
+
+	private renderOrientationFileRoles(fileRoles: PrWalkthroughOrientationFileRole[]): TemplateResult {
+		const roleLabel: Record<PrWalkthroughOrientationFileRole["role"], string> = {
+			core: "Core",
+			support: "Support",
+			verify: "Verify",
+			docs: "Docs",
+		};
+		return html`
+			<div class="filemap" data-testid="pr-walkthrough-beat-filemap">
+				${fileRoles.map(entry => html`
+					<div class="filerow" data-testid="pr-walkthrough-beat-filerow">
+						<span class="role ${entry.role}">${roleLabel[entry.role]}</span>
+						<code>${entry.file}</code>
+						${entry.note ? html`<span class="note">${entry.note}</span>` : nothing}
+					</div>
+				`)}
+			</div>
 		`;
 	}
 

--- a/src/ui/components/pr-walkthrough/PrWalkthroughPanel.ts
+++ b/src/ui/components/pr-walkthrough/PrWalkthroughPanel.ts
@@ -693,9 +693,11 @@ export class PrWalkthroughPanel extends LitElement {
 		.verdict b { color: var(--positive, green); font-weight: 800; letter-spacing: 0.04em; }
 		.verdict .conf { color: var(--muted-foreground, GrayText); font-size: 12px; }
 		.verdict.verdict-request_changes { border-color: color-mix(in oklch, var(--negative, red) 40%, var(--border, ButtonBorder)); background: color-mix(in oklch, var(--negative, red) 12%, transparent); }
-		.verdict.verdict-request_changes .dot, .verdict.verdict-request_changes b { background: var(--negative, red); color: var(--negative, red); }
+		.verdict.verdict-request_changes .dot { background: var(--negative, red); }
+		.verdict.verdict-request_changes b { color: var(--negative, red); }
 		.verdict.verdict-comment { border-color: color-mix(in oklch, var(--warning, orange) 40%, var(--border, ButtonBorder)); background: color-mix(in oklch, var(--warning, orange) 12%, transparent); }
-		.verdict.verdict-comment .dot, .verdict.verdict-comment b { background: var(--warning, orange); color: var(--warning, orange); }
+		.verdict.verdict-comment .dot { background: var(--warning, orange); }
+		.verdict.verdict-comment b { color: var(--warning, orange); }
 		.verdict.verdict-unknown { border-color: var(--border, ButtonBorder); background: color-mix(in oklch, var(--muted-foreground, GrayText) 10%, transparent); }
 		.verdict.verdict-unknown .dot { background: var(--muted-foreground, GrayText); }
 		.verdict.verdict-unknown b { color: var(--muted-foreground, GrayText); }
@@ -1457,7 +1459,7 @@ export class PrWalkthroughPanel extends LitElement {
 
 	private renderOrientationConcerns(concerns: PrWalkthroughOrientationConcern[]): TemplateResult {
 		const blocking = concerns.filter(concern => concern.severity === "blocking").length;
-		const nonBlocking = concerns.length - blocking;
+		const nonBlocking = concerns.filter(concern => concern.severity === "non_blocking").length;
 		const severityClass: Record<PrWalkthroughOrientationConcern["severity"], string> = {
 			blocking: "blocking",
 			non_blocking: "non-blocking",

--- a/src/ui/components/pr-walkthrough/fixtures.ts
+++ b/src/ui/components/pr-walkthrough/fixtures.ts
@@ -1,4 +1,4 @@
-import type { PrWalkthroughCard, PrWalkthroughChangesetRef } from "./types.js";
+import type { PrWalkthroughCard, PrWalkthroughCardSection, PrWalkthroughChangesetRef } from "./types.js";
 
 export const fixturePrWalkthroughChangeset: PrWalkthroughChangesetRef = {
 	baseSha: "9f4c2a1",
@@ -273,6 +273,148 @@ export function getFixturePrWalkthroughCards(): PrWalkthroughCard[] {
 					diffBlockId: "audit-remaining-lines",
 					lineId: "ar-3",
 					body: "Audit generated changeset IDs against URL and PR-number launches so review state does not collide between walkthrough tabs.",
+				},
+			],
+		},
+	];
+}
+
+const guidedOrientationSections: PrWalkthroughCardSection[] = [
+	{
+		id: "at-a-glance",
+		navLabel: "At a glance",
+		heading: "A net-deletion UI fix",
+		verdict: { recommendation: "approve", confidence: "medium", summary: "Shares the preview panel resize path." },
+		body: "The in-app walkthrough panel now resizes exactly like the HTML preview panel — one shared code path instead of two.",
+		showStats: true,
+	},
+	{
+		id: "why-it-exists",
+		navLabel: "Why it exists",
+		eyebrow: "The problem",
+		heading: "Why it exists",
+		body: "The in-app walkthrough side-panel's resize controls were dead. The previous attempt patched the standalone pop-out route, where the controls are meaningless.",
+	},
+	{
+		id: "what-it-changes",
+		navLabel: "What it changes",
+		eyebrow: "The change",
+		heading: "What it actually does",
+		body: "Deletes walkthrough-specific fullscreen special-casing so the panel shares the preview panel's rules and the standalone route reverts to chromeless.",
+	},
+	{
+		id: "should-merge",
+		navLabel: "Should we merge",
+		eyebrow: "The decision",
+		heading: "Should it be merged?",
+		body: "Yes — approve, medium confidence. Two resize code paths collapse into one, backed by a reproducing E2E that fails before and passes after.",
+	},
+	{
+		id: "what-to-watch",
+		navLabel: "What to watch",
+		heading: "What to scrutinise",
+		concerns: [
+			{ severity: "non_blocking", text: "A live walkthrough child can now be fullscreened, which hides the chat prompt. Confirm that is acceptable." },
+			{ severity: "question", text: "All coverage is E2E. Confirm CI runs the browser specs for UI-only PRs." },
+			{ severity: "nit", text: "A fullscreenState helper is duplicated across the spec files." },
+		],
+	},
+	{
+		id: "where-to-look",
+		navLabel: "Where to look",
+		heading: "Where to look",
+		body: "Start in render.ts, then pr-walkthrough.ts, then the specs.",
+		fileRoles: [
+			{ role: "core", file: "src/app/render.ts", note: "fullscreen branch + standalone panel rendering" },
+			{ role: "core", file: "src/app/pr-walkthrough.ts", note: "job upsert / patch ready handling" },
+			{ role: "support", file: "src/app/main.ts", note: "keyboard-shortcut detection" },
+			{ role: "verify", file: "tests/e2e/ui/pr-walkthrough-*.spec.ts", note: "new + inverted tests" },
+		],
+		showOriginalDescription: true,
+	},
+];
+
+/**
+ * Fixture cards where the orientation card uses the guided step-through `sections`
+ * model, plus follow-on cards with long titles and explicit short `navLabel`s.
+ * Used to exercise the orientation stepper and rail-circle navigation in tests.
+ */
+export function getGuidedOrientationFixtureCards(): PrWalkthroughCard[] {
+	return [
+		{
+			id: "orientation-scope",
+			phaseId: "orientation",
+			title: "Fix in-app PR walkthrough panel resize controls",
+			navLabel: "Orientation",
+			summary: "Shares the preview panel resize path so the walkthrough panel stops special-casing fullscreen.",
+			sections: guidedOrientationSections,
+			diffBlocks: [],
+		},
+		{
+			id: "design-resize",
+			phaseId: "design",
+			title: "render.ts: fullscreen predicate and standalone panel simplification",
+			navLabel: "Resize logic",
+			summary: "Reuses the preview panel's resize logic instead of walkthrough-specific fullscreen handling.",
+			diffBlocks: [
+				{
+					id: "design-resize-block",
+					filePath: "src/app/render.ts",
+					hunks: [
+						{
+							id: "design-resize-h1",
+							header: "@@ -100,6 +100,8 @@ function prWalkthroughPanel()",
+							lines: [
+								{ id: "dz-1", side: "context", oldLine: 100, newLine: 100, kind: "context", text: "const status = tab.state.status;" },
+								{ id: "dz-2", side: "new", newLine: 101, kind: "add", text: "const fullscreen = previewPanelFullscreen(state);" },
+							],
+						},
+					],
+				},
+			],
+		},
+		{
+			id: "significant-ready",
+			phaseId: "significant",
+			title: "pr-walkthrough.ts: job upsert and ready handling",
+			navLabel: "Ready handling",
+			summary: "Patches job upsert so the ready payload hydrates the panel without resetting fullscreen.",
+			diffBlocks: [
+				{
+					id: "significant-ready-block",
+					filePath: "src/app/pr-walkthrough.ts",
+					hunks: [
+						{
+							id: "significant-ready-h1",
+							header: "@@ -120,6 +120,9 @@ export function upsertWalkthroughJob()",
+							lines: [
+								{ id: "sr-1", side: "context", oldLine: 120, newLine: 120, kind: "context", text: "const existing = jobs.get(jobId);" },
+								{ id: "sr-2", side: "new", newLine: 121, kind: "add", text: "if (existing?.status === \"ready\") return mergeReady(existing, patch);" },
+							],
+						},
+					],
+				},
+			],
+		},
+		{
+			id: "audit-checklist",
+			phaseId: "audit",
+			title: "E2E: reproducing test and audit review checklist",
+			navLabel: "Audit checklist",
+			summary: "Remaining lines and the reproducing E2E feed the final review draft.",
+			diffBlocks: [
+				{
+					id: "audit-checklist-block",
+					filePath: "tests/e2e/ui/pr-walkthrough-real.spec.ts",
+					hunks: [
+						{
+							id: "audit-checklist-h1",
+							header: "@@ -10,0 +11,4 @@",
+							lines: [
+								{ id: "ac-1", side: "new", newLine: 11, kind: "add", text: "test(\"resize controls are user-initiated\", async ({ page }) => {" },
+							],
+						},
+					],
 				},
 			],
 		},

--- a/src/ui/components/pr-walkthrough/types.ts
+++ b/src/ui/components/pr-walkthrough/types.ts
@@ -54,6 +54,40 @@ export interface PrWalkthroughSuggestedComment {
 	body: string;
 }
 
+export type PrWalkthroughOrientationConcernSeverity = "blocking" | "non_blocking" | "question" | "nit";
+export type PrWalkthroughOrientationFileRoleKind = "core" | "support" | "verify" | "docs";
+
+export interface PrWalkthroughOrientationConcern {
+	severity: PrWalkthroughOrientationConcernSeverity;
+	text: string;
+}
+
+export interface PrWalkthroughOrientationFileRole {
+	role: PrWalkthroughOrientationFileRoleKind;
+	file: string;
+	note?: string;
+}
+
+export interface PrWalkthroughOrientationVerdict {
+	recommendation: "approve" | "comment" | "request_changes" | "unknown";
+	confidence: "low" | "medium" | "high";
+	summary?: string;
+}
+
+/** A single-idea "beat" in the orientation guided step-through. */
+export interface PrWalkthroughCardSection {
+	id: string;
+	navLabel: string;
+	eyebrow?: string;
+	heading: string;
+	body?: string;
+	verdict?: PrWalkthroughOrientationVerdict;
+	concerns?: PrWalkthroughOrientationConcern[];
+	fileRoles?: PrWalkthroughOrientationFileRole[];
+	showStats?: boolean;
+	showOriginalDescription?: boolean;
+}
+
 export interface PrWalkthroughCard {
 	id: string;
 	phaseId: PrWalkthroughPhaseId;
@@ -64,6 +98,10 @@ export interface PrWalkthroughCard {
 	suggestedComments?: PrWalkthroughSuggestedComment[];
 	cardSuggestions?: string[];
 	checklist?: string[];
+	/** Compact (≤3-word) sidebar rail label; falls back to a derived label from `title`. */
+	navLabel?: string;
+	/** Orientation guided-step "beats"; only set on the orientation card. */
+	sections?: PrWalkthroughCardSection[];
 }
 
 export interface PrWalkthroughComment {

--- a/tests/e2e/ui/pr-walkthrough-panel.spec.ts
+++ b/tests/e2e/ui/pr-walkthrough-panel.spec.ts
@@ -1,8 +1,13 @@
 import type { Locator, Page } from "@playwright/test";
 import { test, expect } from "../gateway-harness.js";
 import { apiFetch } from "../e2e-setup.js";
-import { fixturePrWalkthroughChangeset, getFixturePrWalkthroughCards } from "../../../src/ui/components/pr-walkthrough/fixtures.js";
+import { fixturePrWalkthroughChangeset, getFixturePrWalkthroughCards, getGuidedOrientationFixtureCards } from "../../../src/ui/components/pr-walkthrough/fixtures.js";
 import { openApp, createSessionViaUI, sendMessage } from "./ui-helpers.js";
+
+// Tests in the guided-orientation describe block set this to inject cards whose
+// orientation card uses the `sections` (guided step-through) model. Cleared after
+// each test so the rest of the suite keeps the default fixture cards.
+let fixtureCardsOverride: ReturnType<typeof getFixturePrWalkthroughCards> | undefined;
 
 const WALKTHROUGH_COMMAND = "/walkthrough-pr 123";
 const WALKTHROUGH_URL = "https://github.com/SuuBro/bobbit/pull/637";
@@ -46,7 +51,7 @@ function resolvedWalkthroughPayload(prNumber: string | number, title = "Resolved
 			prBody,
 			title: `PR #${prNumber}: ${title}`,
 		},
-		cards: getFixturePrWalkthroughCards(),
+		cards: fixtureCardsOverride ?? getFixturePrWalkthroughCards(),
 		warnings: [{ code: "test-warning", severity: "info", message: "Resolver warning surfaced." }],
 		export: { provider: "github", available: true },
 	};
@@ -1508,5 +1513,105 @@ This is the author's source description with **markdown**.
 		const hunkSignatureErrors = [...consoleErrors, ...pageErrors].filter((message) =>
 			/Cannot read properties of undefined \(reading 'match'\)/.test(message) || /hunkSignature/.test(message));
 		expect(hunkSignatureErrors, `panel must not throw the hunkSignature TypeError: ${hunkSignatureErrors.join("\n")}`).toEqual([]);
+	});
+});
+
+function guideCounter(page: Page): Locator {
+	return walkthroughPanel(page).getByTestId("pr-walkthrough-guide-counter");
+}
+
+function orientationStep(page: Page, beatIndex: number): Locator {
+	return walkthroughPanel(page).locator(`${tid("pr-walkthrough-orientation-step")}[data-beat-index="${beatIndex}"]`);
+}
+
+test.describe("PR walkthrough orientation guided steps", () => {
+	test.beforeEach(() => {
+		fixtureCardsOverride = getGuidedOrientationFixtureCards();
+	});
+	test.afterEach(() => {
+		fixtureCardsOverride = undefined;
+	});
+
+	test("orientation renders as guided beats with a counter, Back/Next, and synced rail circles", async ({ page }) => {
+		const { panel } = await setupWalkthrough(page, { width: 1920, height: 1080 });
+
+		const guide = panel.getByTestId("pr-walkthrough-orientation-guide");
+		await expect(guide, "guided orientation card should render the step-through instead of a wall of text").toBeVisible({ timeout: 10_000 });
+		await expect(guide.getByTestId("pr-walkthrough-guide-eyebrow")).toContainText("Phase 0 · Orientation");
+		await expect(guideCounter(page), "guide should expose a 1-based step counter").toHaveText("1 / 6");
+		await expect(guide.getByTestId("pr-walkthrough-beat-verdict"), "first beat should lead with the verdict badge").toBeVisible();
+		await expect(guide.getByTestId("pr-walkthrough-beat-stats"), "at-a-glance beat should surface diff stats").toBeVisible();
+
+		const back = guide.getByTestId("pr-walkthrough-guide-back");
+		const next = guide.getByTestId("pr-walkthrough-guide-next");
+		await expect(back, "Back should be disabled on the first beat").toBeDisabled();
+		await expect(next, "Next should read forward on non-final beats").toContainText("Next");
+
+		// Rail circles reflect the current beat.
+		const rail = panel.getByTestId("pr-walkthrough-orientation-rail");
+		await expect(rail.getByTestId("pr-walkthrough-orientation-step"), "one rail circle per orientation beat").toHaveCount(6);
+		await expect(orientationStep(page, 0), "first circle should be current").toHaveAttribute("data-state", "current");
+		await expect(orientationStep(page, 1), "later circles should start upcoming").toHaveAttribute("data-state", "upcoming");
+
+		await next.click();
+		await expect(guideCounter(page)).toHaveText("2 / 6");
+		await expect(orientationStep(page, 0), "advancing should mark the prior beat visited").toHaveAttribute("data-state", "visited");
+		await expect(orientationStep(page, 1), "the new beat should become current").toHaveAttribute("data-state", "current");
+		await expect(back, "Back should enable once past the first beat").toBeEnabled();
+
+		await back.click();
+		await expect(guideCounter(page)).toHaveText("1 / 6");
+		await expect(orientationStep(page, 0)).toHaveAttribute("data-state", "current");
+	});
+
+	test("clicking a rail circle jumps to that beat and the merge beat reframes the recommendation", async ({ page }) => {
+		const { panel } = await setupWalkthrough(page, { width: 1920, height: 1080 });
+		await expect(panel.getByTestId("pr-walkthrough-orientation-guide")).toBeVisible({ timeout: 10_000 });
+
+		await orientationStep(page, 3).click();
+		await expect(guideCounter(page)).toHaveText("4 / 6");
+		await expect(panel.getByTestId("pr-walkthrough-beat-heading"), "the reframed merge beat must lead with the question").toHaveText("Should it be merged?");
+
+		await orientationStep(page, 4).click();
+		await expect(guideCounter(page)).toHaveText("5 / 6");
+		await expect(panel.getByTestId("pr-walkthrough-beat-heading")).toHaveText("What to scrutinise");
+		await expect(panel.getByTestId("pr-walkthrough-beat-concern-count"), "concerns beat should show the blocking/non-blocking tally").toContainText(/\d+ blocking, \d+ non-blocking/);
+		await expect(panel.getByTestId("pr-walkthrough-beat-concern").first()).toBeVisible();
+
+		await orientationStep(page, 5).click();
+		await expect(guideCounter(page)).toHaveText("6 / 6");
+		await expect(panel.getByTestId("pr-walkthrough-beat-filemap"), "where-to-look beat should render the file → role map").toBeVisible();
+		await expect(panel.getByTestId("pr-walkthrough-guide-next"), "final beat advances into the review").toContainText("Start review");
+	});
+
+	test("finishing the last beat completes orientation and advances to the first review card", async ({ page }) => {
+		const { panel } = await setupWalkthrough(page, { width: 1920, height: 1080 });
+		await expect(panel.getByTestId("pr-walkthrough-orientation-guide")).toBeVisible({ timeout: 10_000 });
+
+		await orientationStep(page, 5).click();
+		await expect(guideCounter(page)).toHaveText("6 / 6");
+		await panel.getByTestId("pr-walkthrough-guide-next").click();
+
+		await expect(activeCard(page), "Start review should move to the next review card").toHaveAttribute("data-card-id", "design-resize", { timeout: 10_000 });
+		await expect(activeCard(page).getByTestId("pr-walkthrough-card-title"), "follow-on card keeps the full descriptive title in its heading").toContainText("render.ts: fullscreen predicate");
+
+		// Returning to a completed orientation shows every circle as visited.
+		await panel.getByTestId("pr-walkthrough-phase-button").filter({ hasText: "Orientation" }).click();
+		await expect(panel.getByTestId("pr-walkthrough-orientation-guide")).toBeVisible();
+		await expect(orientationStep(page, 0)).toHaveAttribute("data-state", "current");
+		await expect(orientationStep(page, 5), "beats after the cursor stay upcoming when re-entering at beat 0").toHaveAttribute("data-state", "upcoming");
+	});
+
+	test("every sidebar rail label stays short enough to avoid truncation", async ({ page }) => {
+		const { panel } = await setupWalkthrough(page, { width: 1920, height: 1080 });
+		await expect(panel.getByTestId("pr-walkthrough-labelled-rail")).toBeVisible({ timeout: 10_000 });
+
+		const overflowing = await panel.locator(".card-title").evaluateAll((nodes) =>
+			nodes
+				.map((node) => ({ text: (node.textContent || "").trim(), scroll: node.scrollWidth, client: node.clientWidth }))
+				.filter((entry) => entry.scroll > entry.client + 1)
+				.map((entry) => entry.text),
+		);
+		expect(overflowing, `rail labels should not overflow/truncate: ${overflowing.join(", ")}`).toEqual([]);
 	});
 });

--- a/tests/e2e/ui/pr-walkthrough-panel.spec.ts
+++ b/tests/e2e/ui/pr-walkthrough-panel.spec.ts
@@ -1575,7 +1575,7 @@ test.describe("PR walkthrough orientation guided steps", () => {
 		await orientationStep(page, 4).click();
 		await expect(guideCounter(page)).toHaveText("5 / 6");
 		await expect(panel.getByTestId("pr-walkthrough-beat-heading")).toHaveText("What to scrutinise");
-		await expect(panel.getByTestId("pr-walkthrough-beat-concern-count"), "concerns beat should show the blocking/non-blocking tally").toContainText(/\d+ blocking, \d+ non-blocking/);
+		await expect(panel.getByTestId("pr-walkthrough-beat-concern-count"), "tally must count only blocking + non_blocking severities, not question/nit rows").toHaveText("0 blocking, 1 non-blocking");
 		await expect(panel.getByTestId("pr-walkthrough-beat-concern").first()).toBeVisible();
 
 		await orientationStep(page, 5).click();

--- a/tests/pr-walkthrough-card-synthesis.test.ts
+++ b/tests/pr-walkthrough-card-synthesis.test.ts
@@ -115,6 +115,21 @@ describe("PR walkthrough card synthesis", () => {
 		assert.equal(cards[1].navLabel, "Check resolver behaviour");
 	});
 
+	it("replaces an overlong or empty LLM navLabel with the derived label", () => {
+		const cards = validateSynthesisedCards({
+			cards: [
+				{ phaseId: "significant", title: "Check resolver behaviour and edges", navLabel: "This label is far too long to fit", summary: "Resolver behavior changed.", diffBlockIds: ["a"] },
+				{ phaseId: "other", title: "Review smaller remaining files", navLabel: "   ", summary: "Smaller files.", diffBlockIds: ["b"] },
+			],
+		}, [file("src/a.ts", "modified", [block("a", "src/a.ts", 2)]), file("src/b.ts", "modified", [block("b", "src/b.ts", 2)])]);
+
+		assert.equal(cards.length, 2);
+		// Overlong model label is rejected and replaced by the ≤3-word derived label.
+		assert.equal(cards[0].navLabel, "Check resolver behaviour");
+		// Whitespace-only model label falls back to the derived label.
+		assert.equal(cards[1].navLabel, "Review smaller remaining");
+	});
+
 	it("validates LLM card schema and drops suggested comments with bad anchors", () => {
 		const files = [file("src/a.ts", "modified", [block("a", "src/a.ts", 2)])];
 		const cards = validateSynthesisedCards({

--- a/tests/pr-walkthrough-card-synthesis.test.ts
+++ b/tests/pr-walkthrough-card-synthesis.test.ts
@@ -24,6 +24,8 @@ describe("PR walkthrough card synthesis", () => {
 		]);
 
 		assert.deepEqual(cards.map(card => card.phaseId), ["orientation", "design", "significant", "other", "audit"]);
+		for (const card of cards) assert.ok(card.navLabel && card.navLabel.trim().length > 0, `expected navLabel on ${card.id}`);
+		assert.equal(cards[0].navLabel, "Orientation");
 		const design = cards.find(card => card.phaseId === "design");
 		assert.ok(design);
 		assert.deepEqual(design.diffBlocks.map(block => block.id), ["server-a", "server-b"]);
@@ -74,6 +76,9 @@ describe("PR walkthrough card synthesis", () => {
 		assert.match(orientation.rationale ?? "", /Context to understand the PR: GitHub remains the source of truth/);
 		assert.ok(orientation.checklist?.some(item => /Testing strategy: Run typecheck plus targeted walkthrough browser coverage/.test(item)));
 		assert.doesNotMatch(`${orientation.summary} ${orientation.rationale}`, /confirming scope|review generated cards|walkthrough process/i);
+		assert.deepEqual(orientation.sections?.map(section => section.id), ["at-a-glance", "why-it-exists", "what-it-changes", "where-to-look"]);
+		assert.equal(orientation.sections?.find(section => section.id === "at-a-glance")?.showStats, true);
+		assert.equal(orientation.sections?.find(section => section.id === "where-to-look")?.showOriginalDescription, true);
 	});
 
 	it("keeps deterministic PR-context phase 0 even when LLM synthesis returns walkthrough instructions", async () => {
@@ -97,14 +102,17 @@ describe("PR walkthrough card synthesis", () => {
 	it("validates LLM orientation cards without requiring diff blocks", () => {
 		const cards = validateSynthesisedCards({
 			cards: [
-				{ phaseId: "orientation", title: "PR context", summary: "Why: fixes review context", diffBlockIds: [], checklist: ["Testing strategy: npm test"] },
-				{ phaseId: "significant", title: "Check resolver", summary: "Resolver behavior changed.", diffBlockIds: ["a"] },
+				{ phaseId: "orientation", title: "PR context", navLabel: "Orientation", summary: "Why: fixes review context", diffBlockIds: [], checklist: ["Testing strategy: npm test"] },
+				{ phaseId: "significant", title: "Check resolver behaviour and edges", summary: "Resolver behavior changed.", diffBlockIds: ["a"] },
 			],
 		}, [file("src/a.ts", "modified", [block("a", "src/a.ts", 2)])]);
 
 		assert.equal(cards.length, 2);
 		assert.equal(cards[0].phaseId, "orientation");
+		assert.equal(cards[0].navLabel, "Orientation");
 		assert.deepEqual(cards[0].diffBlocks, []);
+		// navLabel is derived from the title when the candidate omits it.
+		assert.equal(cards[1].navLabel, "Check resolver behaviour");
 	});
 
 	it("validates LLM card schema and drops suggested comments with bad anchors", () => {

--- a/tests/pr-walkthrough-nav-label.test.ts
+++ b/tests/pr-walkthrough-nav-label.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { NAV_LABEL_MAX_CHARS, NAV_LABEL_MAX_WORDS, deriveNavLabel, navLabelError } from "../src/shared/pr-walkthrough/nav-label.ts";
+
+describe("PR walkthrough nav label", () => {
+	it("exposes the documented limits", () => {
+		assert.equal(NAV_LABEL_MAX_WORDS, 3);
+		assert.equal(NAV_LABEL_MAX_CHARS, 24);
+	});
+
+	it("accepts labels within the word and character limits", () => {
+		assert.equal(navLabelError("At a glance"), null);
+		assert.equal(navLabelError("Orientation"), null);
+		assert.equal(navLabelError(""), null);
+		assert.equal(navLabelError("  Where to look  "), null);
+	});
+
+	it("rejects labels with more than three words", () => {
+		assert.match(navLabelError("one two three four") ?? "", /3 words/);
+	});
+
+	it("rejects labels longer than the character cap", () => {
+		assert.match(navLabelError("abcdefghijklmnopqrstuvwxyz") ?? "", /24 characters/);
+	});
+
+	it("derives a compact label from the prefix before a separator", () => {
+		assert.equal(deriveNavLabel("render.ts: fullscreen predicate"), "render.ts");
+		assert.equal(deriveNavLabel("Schema — validation rules"), "Schema");
+		assert.equal(deriveNavLabel("Panel - rail simplification"), "Panel");
+	});
+
+	it("uses the whole title when no usable separator prefix exists", () => {
+		assert.equal(deriveNavLabel("Agent submits YAML"), "Agent submits YAML");
+		assert.equal(deriveNavLabel("Just three words"), "Just three words");
+	});
+
+	it("keeps only the first three words", () => {
+		assert.equal(deriveNavLabel("one two three four five"), "one two three");
+	});
+
+	it("hard-truncates long single-prefix labels to 23 chars plus an ellipsis", () => {
+		const derived = deriveNavLabel("supercalifragilisticexpialidocious");
+		assert.equal(derived.length, NAV_LABEL_MAX_CHARS);
+		assert.ok(derived.endsWith("…"));
+	});
+
+	it("returns an empty string for blank titles", () => {
+		assert.equal(deriveNavLabel("   "), "");
+	});
+});

--- a/tests/pr-walkthrough-nav-label.test.ts
+++ b/tests/pr-walkthrough-nav-label.test.ts
@@ -12,8 +12,12 @@ describe("PR walkthrough nav label", () => {
 	it("accepts labels within the word and character limits", () => {
 		assert.equal(navLabelError("At a glance"), null);
 		assert.equal(navLabelError("Orientation"), null);
-		assert.equal(navLabelError(""), null);
 		assert.equal(navLabelError("  Where to look  "), null);
+	});
+
+	it("rejects empty or whitespace-only labels so callers fall back to the derived label", () => {
+		assert.match(navLabelError("") ?? "", /empty/);
+		assert.match(navLabelError("   ") ?? "", /empty/);
 	});
 
 	it("rejects labels with more than three words", () => {

--- a/tests/pr-walkthrough-yaml-schema.test.ts
+++ b/tests/pr-walkthrough-yaml-schema.test.ts
@@ -98,11 +98,13 @@ describe("PR walkthrough YAML schema", () => {
 		assert.equal(payload.changeset.prBody, "## Why\nFixes review scope.");
 		assert.deepEqual(payload.cards.map(card => card.phaseId), ["orientation", "design", "significant", "other", "audit", "audit"]);
 		assert.equal(payload.cards[0]?.title, "PR context");
-		assert.match(payload.cards[0]?.summary ?? "", /Why created/);
+		assert.equal(payload.cards[0]?.navLabel, "Orientation");
+		assert.equal(payload.cards[0]?.summary, "Good direction with follow-up checks.");
 		assert.match(payload.cards[0]?.rationale ?? "", /Author intent/);
 
 		const design = payload.cards.find(card => card.phaseId === "design");
 		assert.ok(design);
+		assert.equal(design.navLabel, "Agent submits YAML");
 		assert.deepEqual(design.diffBlocks.map(block => block.id), ["block-src-a"]);
 
 		const review = payload.cards.find(card => card.id === "significant-chunk-api");
@@ -115,6 +117,73 @@ describe("PR walkthrough YAML schema", () => {
 		assert.ok(payload.cards.some(card => card.title === "Omissions and follow-ups"));
 		assert.ok(payload.cards.some(card => card.title === "Audit and review checklist"));
 		assert.ok(payload.warnings.some(warning => warning.code === "existing"));
+	});
+
+	it("renders the orientation card as six guided beats with the reframed merge heading", () => {
+		const validation = validatePrWalkthroughYaml(validYaml());
+		assert.equal(validation.ok, true);
+		if (!validation.ok) return;
+
+		const payload = mapYamlToWalkthroughPayload(validation.document, { files: diffBlocks() });
+		const sections = payload.cards[0]?.sections;
+		assert.ok(sections);
+		assert.deepEqual(sections.map(section => section.id), [
+			"at-a-glance",
+			"why-it-exists",
+			"what-it-changes",
+			"should-merge",
+			"what-to-watch",
+			"where-to-look",
+		]);
+		assert.deepEqual(sections.map(section => section.navLabel), [
+			"At a glance",
+			"Why it exists",
+			"What it changes",
+			"Should we merge",
+			"What to watch",
+			"Where to look",
+		]);
+
+		const atAGlance = sections.find(section => section.id === "at-a-glance");
+		assert.equal(atAGlance?.showStats, true);
+		assert.equal(atAGlance?.verdict?.recommendation, "comment");
+		assert.equal(atAGlance?.verdict?.confidence, "medium");
+
+		const merge = sections.find(section => section.id === "should-merge");
+		assert.equal(merge?.heading, "Should it be merged?");
+		assert.match(merge?.body ?? "", /^Maybe — comment, medium confidence\./);
+		assert.match(merge?.body ?? "", /It makes review safer\./);
+
+		const watch = sections.find(section => section.id === "what-to-watch");
+		assert.ok(watch?.concerns?.some(concern => concern.severity === "non_blocking" && /reload persistence/i.test(concern.text)));
+		assert.ok(watch?.concerns?.some(concern => concern.severity === "question"));
+
+		const whereToLook = sections.find(section => section.id === "where-to-look");
+		assert.equal(whereToLook?.showOriginalDescription, true);
+		assert.match(whereToLook?.body ?? "", /Start with API chunk/);
+	});
+
+	it("derives a nav_label fallback from the title and carries an explicit nav_label through", () => {
+		const validation = validatePrWalkthroughYaml(validYaml().replace("title: API submission flow", "title: API submission flow\n      nav_label: API flow"));
+		assert.equal(validation.ok, true);
+		if (!validation.ok) return;
+
+		const payload = mapYamlToWalkthroughPayload(validation.document, { files: diffBlocks() });
+		const review = payload.cards.find(card => card.id === "significant-chunk-api");
+		assert.equal(review?.navLabel, "API flow");
+
+		const design = payload.cards.find(card => card.phaseId === "design");
+		assert.equal(design?.navLabel, "Agent submits YAML");
+	});
+
+	it("rejects nav_label values that exceed the word or character cap", () => {
+		const tooManyWords = validatePrWalkthroughYaml(validYaml().replace("title: Agent submits YAML", "title: Agent submits YAML\n      nav_label: one two three four"));
+		assert.equal(tooManyWords.ok, false);
+		if (!tooManyWords.ok) assertError(tooManyWords.summary.errors, "$.walkthrough.design_decisions[0].nav_label", /3 words/);
+
+		const tooLong = validatePrWalkthroughYaml(validYaml().replace("title: API submission flow", "title: API submission flow\n      nav_label: abcdefghijklmnopqrstuvwxyz"));
+		assert.equal(tooLong.ok, false);
+		if (!tooLong.ok) assertError(tooLong.summary.errors, "$.walkthrough.review_chunks[0].nav_label", /24 characters/);
 	});
 
 	it("preserves authoritative resolved changeset SHAs over YAML SHAs", () => {

--- a/tests/pr-walkthrough-yaml-schema.test.ts
+++ b/tests/pr-walkthrough-yaml-schema.test.ts
@@ -186,6 +186,16 @@ describe("PR walkthrough YAML schema", () => {
 		if (!tooLong.ok) assertError(tooLong.summary.errors, "$.walkthrough.review_chunks[0].nav_label", /24 characters/);
 	});
 
+	it("treats an empty nav_label as omitted and falls back to the derived label", () => {
+		const validation = validatePrWalkthroughYaml(validYaml().replace("title: Agent submits YAML", "title: Agent submits YAML\n      nav_label: \"\""));
+		assert.equal(validation.ok, true);
+		if (!validation.ok) return;
+
+		const payload = mapYamlToWalkthroughPayload(validation.document, { files: diffBlocks() });
+		const design = payload.cards.find(card => card.phaseId === "design");
+		assert.equal(design?.navLabel, "Agent submits YAML");
+	});
+
 	it("preserves authoritative resolved changeset SHAs over YAML SHAs", () => {
 		const validation = validatePrWalkthroughYaml(validYaml());
 		assert.equal(validation.ok, true);


### PR DESCRIPTION
## Summary

Redesigns the **Phase 0 / Orientation** screen of the in-app PR walkthrough panel so it *walks the reviewer through* the PR in bite-size steps instead of two run-on wall-of-text paragraphs, and enforces short, non-truncating navigation labels across every sidebar entry.

### What changed
- **Guided orientation stepper** — the orientation card now renders as 6 single-idea beats (At a glance · Why it exists · What it changes · **Should it be merged?** · What to scrutinise · Where to look) with Back/Next + a step counter. Beats are server-derived from the existing YAML `walkthrough.context` + `merge_assessment` (no new agent content).
- **Per-section rail circles** — under the Phase 0 rail entry, one circle per beat (visited ✓ / current ringed dot / upcoming hollow); click jumps to a beat, Back/Next keep the rail in sync.
- **Reframed merge beat** — "Should it be merged?" with answer-first copy (recommendation before rationale).
- **Short nav labels everywhere** — every rail entry uses a compact `navLabel` (≤3 words / ≤24 chars); full title retained in the card `<h2>` and tooltip.
- **LLM agent contract** — optional `nav_label` field added to `design_decisions[]` / `review_chunks[]`, documented in the schema + synthesis prompts and validated server-side, with a graceful title-derived fallback so existing/partial YAML still renders.

### Data model
- New `src/shared/pr-walkthrough/nav-label.ts` (`deriveNavLabel`, `navLabelError`, caps 3 words / 24 chars).
- `PrWalkthroughCard` gains optional `navLabel` + structured orientation `sections` (`PrWalkthroughCardSection`). All additions optional — `submit_pr_walkthrough_yaml` contract and legacy payloads intact.

### Testing
- Unit: `nav_label` validation (rejects >3 words / >24 chars / empty), title-derived fallback, LLM-path invalid-label fallback, and the 6-beat orientation structure.
- Browser E2E: orientation renders as steps, Back/Next + rail-circle navigation move through beats and sync the sidebar, the merge beat reads "Should it be merged?", and rail labels do not overflow.
- `npm run check` clean; full unit + E2E suites green via gate verification.

### Docs
Updated `docs/pr-walkthrough-panel.md`, `docs/design/pr-walkthrough-agent-ux.md`, `docs/design/pr-walkthrough-panel.md`.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)