### PR TITLE
Fix sandbox clone fallback for remote-less projects

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1922,7 +1922,7 @@ Bobbit server                           /workspace        (repo clone, native Li
 ```
 
 - **One container per project**, created when sandbox is enabled, lives until disabled/removed
-- **Container clones its own repo** from the real remote - no host-side clone, no cross-OS bind mounts for workspace
+- **Container clones its own repo** — from the real remote when one exists, otherwise from a read-only bind-mount of the host repo root (see [Sandbox clone source](#sandbox-clone-source)). No host-side clone; the `/workspace` clone itself is always a native Linux clone, never a bind-mounted host directory
 - **`npm ci`, Playwright install, and build happen inside the container** on native Linux filesystem
 - **Agents use git worktrees** inside the container - identical to non-sandbox mode
 - **One scoped token per project container** (not per-agent/session)
@@ -1971,7 +1971,7 @@ A sandbox is never created for a project that has not asked for one. The image b
    - **Found running** → reconnect (reuse container ID)
    - **Found stopped** → restart via `docker start`
    - **Not found** → create new container with named Docker volumes (`bobbit-workspace-<projectId>` for `/workspace`, `bobbit-worktrees-<projectId>` for `/workspace-wt`)
-3. On first create, the container runs an init sequence: `git clone <repoUrl>`, `npm ci`, optional Playwright install, `npm run build`
+3. On first create, the container runs an init sequence: `git clone <repoUrl>`, `npm ci`, optional Playwright install, `npm run build`. `<repoUrl>` is chosen by the clone-source resolver — see [Sandbox clone source](#sandbox-clone-source) for how a remote, remote-less, or local-only project each resolve.
 4. Container runs with `--restart=unless-stopped` so it survives Docker daemon restarts
 
 **Agent spawn:**
@@ -1985,6 +1985,23 @@ A sandbox is never created for a project that has not asked for one. The image b
 **Session termination:**
 
 1. `ProjectSandbox.removeWorktree(name)` removes the worktree inside the container via `docker exec git worktree remove`
+
+### Sandbox clone source
+
+The sandbox container is a native Linux box with its own filesystem and its own git ref visibility — it does **not** share the host's working tree. So before the init sequence can `git clone`, the host has to answer one question: *what source can git reach from inside the container?* That decision lives in `resolveSandboxCloneSource` (`src/server/agent/sandbox-clone-source.ts`), called from the `sandboxBootstrap` closure in `server.ts`. The resolver is pure (no filesystem access) and returns one of three outcomes.
+
+**1. Network `origin` remote → clone it directly.** If `origin` is an `https`/`ssh`/`git`/`git+ssh` URL or scp-style `[user@]host:path`, the container clones that URL. The token is stripped from the URL before it lands in `.git/config` (so credentials never persist in the clone); the container's git credential helper supplies auth from `GITHUB_TOKEN` at runtime instead. This is the common case and is unchanged from the project's normal behaviour.
+
+**2. No `origin` → bind-mount the main repo root and clone via `file://`.** When the project has no `origin` remote, there is no URL to clone, so the host's canonical **main repo root** is bind-mounted **read-only** into the container at a fixed path (`/workspace-src`) and cloned via `file:///workspace-src`. Two subtleties:
+
+- The mount source is the *main* repo root, not the session's worktree. A session runs in a **linked git worktree** whose `.git` is a gitdir-*file* pointing at the main repo's object store; bind-mounting just the worktree would clone successfully but find no objects. `resolveSandboxMountRoot` (`src/server/skills/git.ts`) resolves the canonical main working tree via `git rev-parse --git-common-dir` (and always returns a realpath), so the clone works regardless of which worktree triggered the sandbox.
+- **Multi-repo** projects mount each component's main root at a per-repo path (`/workspace-src/<repo>`) and clone each from its own `file://` URL. `_createContainer` de-dupes mounts by container path so two components can't collide.
+
+  *Tradeoff:* the read-only mount exposes the project's **entire working tree — including untracked files** — to the sandbox. That is intentional for remote-less projects (it is the only reachable source), but it means the sandbox sees more than a clean clone of committed history would. Projects that want strict isolation should configure a network remote.
+
+**3. Local-only `origin` (a `file://` URL or any absolute/relative/UNC/drive-letter path) → fail fast.** The resolver throws a clear, actionable error instead of attempting the clone. This is the bug fix that motivated this design: the old code silently fell back to the **raw host path** as the clone URL. On Windows, a drive-letter path (`C:/Users/...`) was misparsed by git as scp/SSH syntax (`host:path`) and failed with `cannot run ssh` / `unable to fork`; on any OS the host path was simply unreachable from inside the container. Failing fast with "configure a clonable network remote, or remove the origin to use the mounted project repo" is far more useful than an opaque clone failure. Note the resolver never derives a mount path from the `origin` value — only from the caller-canonicalized repo root — which also closes the door on an in-repo symlink being used to bind-mount an arbitrary host path.
+
+**Failure isolation.** A sandbox that can't initialise must never take down the gateway for *other* projects' sessions. `ProjectSandbox.init()` exposes its readiness through an internal `_readyPromise` that only `getContainerId()` awaits; when init fails with no concurrent awaiter, that promise would reject with no handler and surface as a global `unhandledRejection` — which under load was observed to wedge the gateway for unrelated sessions. The fix attaches a no-op `.catch` to `_readyPromise` so the rejection is always "handled", while the real error is still re-thrown on the **awaited** `init()` boundary. Session setup observes it there, records a setup failure, and ends the session cleanly. The same guarantee holds at the manager level: `SandboxManager.ensureForProject` rejects on the awaited boundary, clears its in-flight entry (so the project can be retried), and a different project's sandbox keeps working. Pinned by `tests/sandbox-init-rejection.test.ts` and `tests/sandbox-manager-init-failure.test.ts`.
 
 ### Network
 

--- a/src/server/agent/docker-args.ts
+++ b/src/server/agent/docker-args.ts
@@ -92,6 +92,16 @@ export interface DockerRunConfig {
 	sandboxAgentAuthPrefs?: PreferencesStore | null;
 	/** Scope for the generated auth.json file; defaults to projectId when present. */
 	sandboxAgentAuthScope?: string;
+
+	/**
+	 * Extra read-only bind mounts as `{ hostPath, mountPath }` pairs. Used for
+	 * the remote-less sandbox clone source: the host repo is mounted read-only
+	 * at a container-internal path so `git clone file://<mountPath>` works
+	 * without ever passing a raw host path (or Windows drive letter) to git.
+	 * Host paths are rewritten via `toDockerPath` for Docker Desktop on
+	 * Windows/macOS.
+	 */
+	extraReadonlyMounts?: Array<{ hostPath: string; mountPath: string }>;
 }
 
 // ── Builder ────────────────────────────────────────────────────────────────
@@ -103,6 +113,7 @@ export function buildDockerRunArgs(config: DockerRunConfig): string[] {
 		projectId, stateDir, sessionId,
 		sandboxMounts, sandboxCredentials,
 		sandboxNetwork,
+		extraReadonlyMounts,
 	} = config;
 
 	const toolsDir = TOOLS_DIR;
@@ -219,6 +230,14 @@ export function buildDockerRunArgs(config: DockerRunConfig): string[] {
 	const sessionPromptsDir = path.join(bobbitDir(), "state", "session-prompts");
 	fs.mkdirSync(sessionPromptsDir, { recursive: true });
 	args.push("-v", `${toDockerPath(sessionPromptsDir)}:/tmp/session-prompts`);
+
+	// Extra read-only bind mounts (e.g. remote-less sandbox clone source).
+	if (extraReadonlyMounts) {
+		for (const { hostPath, mountPath } of extraReadonlyMounts) {
+			if (!hostPath || !mountPath) continue;
+			args.push("-v", `${toDockerPath(hostPath)}:${mountPath}:ro`);
+		}
+	}
 
 	// User-configured mounts
 	if (sandboxMounts) {

--- a/src/server/agent/project-sandbox.ts
+++ b/src/server/agent/project-sandbox.ts
@@ -25,6 +25,7 @@ import type { PreferencesStore } from "./preferences-store.js";
 import type { ToolManager } from "./tool-manager.js";
 import { stripTokenFromGitUrl, shouldSkipRemotePush, resolveBaseRefWithExec } from "../skills/git.js";
 import type { Component } from "./project-config-store.js";
+import type { SandboxCloneSource } from "./sandbox-clone-source.js";
 
 const execFileAsync = promisify(execFileCb);
 const DOCKER_BIN = "docker";
@@ -151,6 +152,13 @@ export interface ProjectSandboxOptions {
 	projectId: string;
 	projectDir: string;        // host project root
 	repoUrl: string;           // git remote URL to clone inside container (single-repo)
+	/**
+	 * Resolved clone source for the single-repo clone. When `kind === "mounted"`
+	 * the host repo is bind-mounted read-only into the container and cloned via
+	 * `file://`, never a raw host path. Falls back to `repoUrl` when absent.
+	 * See `resolveSandboxCloneSource` and `docs/design/...`.
+	 */
+	cloneSource?: SandboxCloneSource;
 	image: string;             // Docker image name
 	sandboxNetwork?: string;
 	sandboxMounts?: string[];
@@ -174,6 +182,13 @@ export interface ProjectSandboxOptions {
 	 * remote prefix and the host can resolve them via `git remote get-url`).
 	 */
 	repoUrlByName?: Record<string, string>;
+	/**
+	 * Multi-repo: optional per-repo resolved clone sources. When a repo has no
+	 * `origin`, the resolver yields a `mounted` source so the container clones
+	 * via `file://` instead of an unreachable host path. Each `mounted` source's
+	 * host path is bind-mounted read-only at its `mountPath`.
+	 */
+	cloneSourceByName?: Record<string, SandboxCloneSource>;
 	/**
 	 * Live resolver for the project's `base_ref` setting. Called fresh on every
 	 * `createWorktree` / `createWorktreeSet` so the container path adopts the
@@ -221,6 +236,13 @@ export class ProjectSandbox {
 			this._readyResolve = resolve;
 			this._readyReject = reject;
 		});
+		// Always "handle" the ready promise so a failed init with no concurrent
+		// awaiter (only `getContainerId()` awaits it) never surfaces as a global
+		// `unhandledRejection` — which under load can wedge the gateway for other
+		// sessions. The real rejection is still observed by `getContainerId()`
+		// (which awaits the same promise) and re-thrown on the awaited `init()`
+		// boundary below. See tests/sandbox-init-rejection.test.ts.
+		this._readyPromise.catch(() => {});
 
 		try {
 			await this._initContainer();
@@ -718,6 +740,21 @@ export class ProjectSandbox {
 			dockerLimits?.memBytes,
 		);
 
+		// Collect read-only bind mounts for any `mounted` clone sources (remote-less
+		// repos). The host repo is mounted at a fixed container path so the init
+		// sequence clones it via `file://<mountPath>` instead of an unreachable
+		// host path. De-dupe by mountPath so multi-repo sources can't collide.
+		const extraReadonlyMounts: Array<{ hostPath: string; mountPath: string }> = [];
+		const seenMountPaths = new Set<string>();
+		const addMount = (src?: SandboxCloneSource): void => {
+			if (src?.kind === "mounted" && !seenMountPaths.has(src.mountPath)) {
+				seenMountPaths.add(src.mountPath);
+				extraReadonlyMounts.push({ hostPath: src.hostPath, mountPath: src.mountPath });
+			}
+		};
+		addMount(this.options.cloneSource);
+		for (const src of Object.values(this.options.cloneSourceByName ?? {})) addMount(src);
+
 		const dockerArgs = buildDockerRunArgs({
 			image,
 			workspaceDir: "", // unused — named volume instead
@@ -734,6 +771,7 @@ export class ProjectSandbox {
 			sandboxAgentAuthPrefs,
 			sandboxNetwork,
 			toolManager: this.options.toolManager,
+			extraReadonlyMounts: extraReadonlyMounts.length ? extraReadonlyMounts : undefined,
 		});
 
 		// Inject GITHUB_TOKEN for git push/PR inside container
@@ -805,9 +843,12 @@ export class ProjectSandbox {
 			// .git doesn't exist — need to clone
 		}
 
-		// Strip any embedded token from the URL (defense-in-depth).
-		// Auth is handled by the credential helper reading GITHUB_TOKEN from env.
-		const repoUrl = stripTokenFromGitUrl(this.options.repoUrl);
+		// Resolve the clone source. Prefer the pre-resolved `cloneSource`
+		// (which is guaranteed to never be a raw host path — remote-less repos
+		// become a `file://` bind-mount source). Fall back to the legacy
+		// `repoUrl` for backward compatibility, stripping any embedded token
+		// (defense-in-depth — auth is via the GITHUB_TOKEN credential helper).
+		const repoUrl = this.options.cloneSource?.cloneUrl ?? stripTokenFromGitUrl(this.options.repoUrl);
 
 		// Clone the repo
 		console.log(`[project-sandbox] Cloning ${repoUrl} into /workspace...`);
@@ -874,7 +915,8 @@ export class ProjectSandbox {
 	private async _runInitSequenceMultiRepo(repoNames: string[]): Promise<void> {
 		if (!this.containerId) return;
 		const urlMap = this.options.repoUrlByName ?? {};
-		const defaultUrl = stripTokenFromGitUrl(this.options.repoUrl);
+		const cloneSourceMap = this.options.cloneSourceByName ?? {};
+		const defaultUrl = this.options.cloneSource?.cloneUrl ?? stripTokenFromGitUrl(this.options.repoUrl);
 
 		// Mark all of /workspace as a safe directory for git
 		await this._dockerExec(this.containerId, ["git", "config", "--global", "--add", "safe.directory", "*"]);
@@ -888,7 +930,9 @@ export class ProjectSandbox {
 				continue;
 			} catch { /* not cloned yet */ }
 
-			const url = stripTokenFromGitUrl(urlMap[repo] ?? defaultUrl);
+			// Prefer the pre-resolved per-repo clone source (never a raw host
+			// path); fall back to the legacy per-repo URL map, then the default.
+			const url = cloneSourceMap[repo]?.cloneUrl ?? stripTokenFromGitUrl(urlMap[repo] ?? defaultUrl);
 			try {
 				await this._dockerExec(this.containerId, ["sh", "-c", `mkdir -p ${dest}`]);
 			} catch { /* will be created by clone */ }

--- a/src/server/agent/sandbox-clone-source.ts
+++ b/src/server/agent/sandbox-clone-source.ts
@@ -10,11 +10,16 @@
  * is unreachable from inside the container.
  *
  * The fix: this resolver NEVER emits a raw host path as the clone URL.
- * - With an `origin` remote → clone the remote URL directly.
- * - Without one → declare a read-only bind-mount of the host repo at a fixed
- *   container path (`/workspace-src`) and clone from `file:///workspace-src`.
+ * - With a network `origin` remote → clone the remote URL directly.
+ * - With no origin → bind-mount the declared project repo (the sandbox's own
+ *   source — always safe) at a fixed container path and clone from `file://`.
+ * - With a LOCAL origin (file://, absolute/relative/UNC/drive-letter path):
+ *   only mount it when it resolves to a path inside the project root. Any
+ *   local origin pointing OUTSIDE the project root throws — bind-mounting an
+ *   arbitrary host path into the sandbox is a data-exposure risk (security).
  */
 
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { stripTokenFromGitUrl } from "../skills/git.js";
 
@@ -28,35 +33,86 @@ export type SandboxCloneSource =
 	| { kind: "mounted"; hostPath: string; mountPath: string; cloneUrl: string };
 
 /**
- * True network/transport remote schemes git can reach from inside the container.
- * Anything else (file://, absolute/relative paths, drive-letter paths) is a
- * LOCAL source that must be bind-mounted — never handed to git as-is.
+ * URL-scheme network remote git can reach from inside the container.
+ * Case-insensitive. Anything matching this is treated as a network remote.
  */
-const REMOTE_SCHEME_RE = /^(https?|git|ssh|git\+ssh):\/\//i;
-/** scp-style remote: `user@host:path` (no scheme). */
-const SCP_REMOTE_RE = /^[^/@\s]+@[^/:\s]+:/;
-/** Windows drive-letter path: `C:\...` or `C:/...`. Checked BEFORE scp so it is never misparsed. */
-const WINDOWS_DRIVE_RE = /^[A-Za-z]:[\\/]/;
+const URL_SCHEME_RE = /^(https?|git|ssh|git\+ssh|ftp|ftps):\/\//i;
+
+/**
+ * Decide whether `origin` is a network remote, mirroring git's own heuristic.
+ *
+ * A remote is either:
+ * - a URL with a recognised network scheme (`https://`, `ssh://`, …), OR
+ * - scp-style `[user@]host:path`: a colon appears BEFORE the first `/`, and the
+ *   host part (text before that colon, with any leading `user@` stripped) is
+ *   NOT a single drive letter.
+ *
+ * The single-letter-host exclusion is what keeps a Windows drive path
+ * (`C:/Users/...`) from being misparsed as an scp remote — git itself treats a
+ * single-letter "host" before a colon as a local drive path, not a remote.
+ */
+function isNetworkRemote(origin: string): boolean {
+	if (URL_SCHEME_RE.test(origin)) return true;
+	// Any other explicit URL scheme (`file://`, …) is a URL form, not scp-style —
+	// and not a network scheme we clone directly. Treat it as local.
+	if (/^[a-z][a-z0-9+.-]*:\/\//i.test(origin)) return false;
+
+	const slashIdx = origin.indexOf("/");
+	const colonIdx = origin.indexOf(":");
+	// scp-style requires a colon before the first slash (`host:path`).
+	if (colonIdx < 0) return false;
+	if (slashIdx >= 0 && slashIdx < colonIdx) return false;
+
+	// Host part is everything before the colon, minus an optional `user@`.
+	let host = origin.slice(0, colonIdx);
+	const at = host.lastIndexOf("@");
+	if (at >= 0) host = host.slice(at + 1);
+	// A single-character host (e.g. `C` in `C:/...`) is a Windows drive letter,
+	// not an scp host → local path, not a remote.
+	if (host.length <= 1) return false;
+	return host.length > 0;
+}
+
+/**
+ * True if `p` is an absolute path on any OS: POSIX-absolute (`/foo`), a Windows
+ * drive path (`C:\` / `C:/`), or a UNC path (`\\host` / `//host`). We detect
+ * Windows-style forms explicitly so a drive-letter origin is never (mis)treated
+ * as relative-to-repoPath when this code runs on a POSIX host.
+ */
+function isAbsoluteLike(p: string): boolean {
+	return path.isAbsolute(p) || /^[A-Za-z]:[\\/]/.test(p) || /^[\\/]{2}[^\\/]/.test(p);
+}
+
+/** True if `candidate` is `root` or a descendant of `root` (cross-platform). */
+function isWithinRoot(root: string, candidate: string): boolean {
+	const rel = path.relative(path.resolve(root), path.resolve(candidate));
+	// Empty rel → same path. Otherwise it must not escape (`..`) and must not be
+	// absolute (which path.relative returns when the two are on different roots,
+	// e.g. different Windows drives).
+	return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+}
 
 /**
  * Resolve the clone source for a sandbox container.
  *
  * @param opts.originUrl   The project's `origin` remote URL (or null/empty/undefined when absent).
- * @param opts.repoPath    The host repo root — used as the bind-mount host path when origin is absent.
+ * @param opts.repoPath    The host repo root. Bind-mounted when origin is absent;
+ *                         also the security root for local-origin validation.
  * @param opts.mountPath   Container-internal mount point (default `/workspace-src`). Multi-repo
  *                         callers pass a per-repo path like `/workspace-src/web`.
  *
  * Classification:
- * - A TRUE remote (http(s)/git/ssh/git+ssh scheme, or scp-style `user@host:path`)
- *   → `{ kind: "remote", cloneUrl }` cloned directly.
- * - Everything else — empty origin, `file://` URL, absolute POSIX path, Windows
- *   drive-letter path, UNC path, or relative path — is a LOCAL source. The host
- *   directory is bind-mounted read-only and cloned via `file://<mountPath>`.
+ * - A network remote (URL scheme or scp-style `[user@]host:path`) →
+ *   `{ kind: "remote", cloneUrl: stripTokenFromGitUrl(origin) }`, cloned directly.
+ * - Absent/empty origin → bind-mount the declared `repoPath` (always safe — it's
+ *   the sandbox's own source) and clone via `file://<mountPath>`.
+ * - A LOCAL origin (file://, absolute/relative/UNC/drive-letter) is resolved to a
+ *   canonical filesystem path. If it is inside `repoPath` it is bind-mounted;
+ *   otherwise this THROWS — bind-mounting an arbitrary host path is a data-exposure
+ *   risk.
  *
  * Invariant: the returned `cloneUrl` is NEVER a raw host path or a Windows
- * drive-letter string (git misparses `C:/...` as scp/SSH syntax → `cannot run
- * ssh` / `unable to fork`). It is always either a true remote URL or
- * `file://<mountPath>`.
+ * drive-letter string. It is always a network remote URL or `file://<mountPath>`.
  */
 export function resolveSandboxCloneSource(opts: {
 	originUrl?: string | null;
@@ -67,22 +123,37 @@ export function resolveSandboxCloneSource(opts: {
 	const mountPath = opts.mountPath ?? MOUNTED_SRC_PATH;
 	const cloneUrl = `file://${mountPath}`;
 
-	// True remote → clone directly (Windows-drive check first so `C:/...` is never
-	// classified as an scp `host:path` remote — that misparse was the original bug).
-	if (origin && !WINDOWS_DRIVE_RE.test(origin) && (REMOTE_SCHEME_RE.test(origin) || SCP_REMOTE_RE.test(origin))) {
+	// Network remote → clone directly.
+	if (origin && isNetworkRemote(origin)) {
 		return { kind: "remote", cloneUrl: stripTokenFromGitUrl(origin) };
 	}
 
-	// Local source → bind-mount. Decode `file://` origins to a filesystem path;
-	// use the origin path string directly when it's a local path; fall back to
-	// the repo root when origin is absent.
-	let hostPath: string;
+	// Absent origin → mount the declared repo (the sandbox's own source).
 	if (!origin) {
-		hostPath = opts.repoPath;
-	} else if (/^file:\/\//i.test(origin)) {
+		return { kind: "mounted", hostPath: opts.repoPath, mountPath, cloneUrl };
+	}
+
+	// Local origin → resolve to a canonical absolute filesystem path.
+	let hostPath: string;
+	if (/^file:\/\//i.test(origin)) {
 		hostPath = fileURLToPath(origin);
+	} else if (isAbsoluteLike(origin)) {
+		// Already absolute (POSIX / drive-letter / UNC) — keep it; never join with repoPath.
+		hostPath = path.resolve(origin);
 	} else {
-		hostPath = origin;
+		// Relative origin resolves against the repo root.
+		hostPath = path.resolve(opts.repoPath, origin);
+	}
+
+	// Security: only mount local origins that live inside the project root.
+	// Bind-mounting an arbitrary host path (e.g. `file:///some/other/private/repo`)
+	// would expose it inside the sandbox.
+	if (!isWithinRoot(opts.repoPath, hostPath)) {
+		throw new Error(
+			`[sandbox] origin "${origin}" is a local path outside the project root ` +
+				`(${opts.repoPath}) and cannot be safely cloned into the sandbox. ` +
+				`Configure a clonable network remote (https/ssh) or remove the local origin.`,
+		);
 	}
 
 	return { kind: "mounted", hostPath, mountPath, cloneUrl };

--- a/src/server/agent/sandbox-clone-source.ts
+++ b/src/server/agent/sandbox-clone-source.ts
@@ -1,0 +1,50 @@
+/**
+ * Sandbox clone-source resolution.
+ *
+ * Picks the source `git clone` uses *inside* the Linux sandbox container.
+ *
+ * The historical bug: when a project had no `origin` remote, the bootstrap
+ * fell back to the raw HOST directory path as the clone URL. On Windows the
+ * drive-letter path (`C:/Users/...`) is misparsed by git as scp/SSH syntax
+ * (`host:path`) → `cannot run ssh` / `unable to fork`; on any OS the host path
+ * is unreachable from inside the container.
+ *
+ * The fix: this resolver NEVER emits a raw host path as the clone URL.
+ * - With an `origin` remote → clone the remote URL directly.
+ * - Without one → declare a read-only bind-mount of the host repo at a fixed
+ *   container path (`/workspace-src`) and clone from `file:///workspace-src`.
+ */
+
+import { stripTokenFromGitUrl } from "../skills/git.js";
+
+/** Fixed container-internal mount point for the remote-less bind-mount source. */
+export const MOUNTED_SRC_PATH = "/workspace-src";
+/** Clone URL git uses inside the container for the bind-mounted source. */
+export const MOUNTED_SRC_CLONE_URL = "file:///workspace-src";
+
+export type SandboxCloneSource =
+	| { kind: "remote"; cloneUrl: string }
+	| { kind: "mounted"; hostPath: string; mountPath: string; cloneUrl: string };
+
+/**
+ * Resolve the clone source for a sandbox container.
+ *
+ * @param opts.originUrl  The project's `origin` remote URL (or null/empty/undefined when absent).
+ * @param opts.repoPath   The host repo root — used only as the bind-mount host path when origin is absent.
+ *
+ * Invariant: the returned `cloneUrl` is NEVER a raw host path or a Windows
+ * drive-letter string. A remote-less project always becomes a `mounted` source
+ * cloned via `file:///workspace-src`.
+ */
+export function resolveSandboxCloneSource(opts: { originUrl?: string | null; repoPath: string }): SandboxCloneSource {
+	const origin = (opts.originUrl ?? "").trim();
+	if (origin) {
+		return { kind: "remote", cloneUrl: stripTokenFromGitUrl(origin) };
+	}
+	return {
+		kind: "mounted",
+		hostPath: opts.repoPath,
+		mountPath: MOUNTED_SRC_PATH,
+		cloneUrl: MOUNTED_SRC_CLONE_URL,
+	};
+}

--- a/src/server/agent/sandbox-clone-source.ts
+++ b/src/server/agent/sandbox-clone-source.ts
@@ -9,18 +9,22 @@
  * (`host:path`) → `cannot run ssh` / `unable to fork`; on any OS the host path
  * is unreachable from inside the container.
  *
- * The fix: this resolver NEVER emits a raw host path as the clone URL.
+ * The fix: this resolver NEVER emits a raw host path as the clone URL, and
+ * NEVER derives a bind-mount source from the `origin` value.
  * - With a network `origin` remote → clone the remote URL directly.
- * - With no origin → bind-mount the declared project repo (the sandbox's own
- *   source — always safe) at a fixed container path and clone from `file://`.
+ * - With no origin → bind-mount the CALLER-supplied canonical main-repo root
+ *   (`mountSourcePath`) at a fixed container path and clone from `file://`.
+ *   The resolver never touches the filesystem and never derives any path from
+ *   `origin` — this removes the entire local-origin→mount attack surface (an
+ *   in-root symlink pointing outside can no longer escape, because no path is
+ *   ever derived from `origin`).
  * - With a LOCAL origin (file://, absolute/relative/UNC/drive-letter path):
- *   only mount it when it resolves to a path inside the project root. Any
- *   local origin pointing OUTSIDE the project root throws — bind-mounting an
- *   arbitrary host path into the sandbox is a data-exposure risk (security).
+ *   THROW a clear, actionable error. A local origin cannot be cloned into the
+ *   container (the host path is unreachable / a drive-letter is misparsed as
+ *   scp), so the caller must configure a clonable network remote or remove the
+ *   origin to fall back to the mounted project repo.
  */
 
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { stripTokenFromGitUrl } from "../skills/git.js";
 
 /** Fixed container-internal mount point for the remote-less bind-mount source. */
@@ -74,49 +78,30 @@ function isNetworkRemote(origin: string): boolean {
 }
 
 /**
- * True if `p` is an absolute path on any OS: POSIX-absolute (`/foo`), a Windows
- * drive path (`C:\` / `C:/`), or a UNC path (`\\host` / `//host`). We detect
- * Windows-style forms explicitly so a drive-letter origin is never (mis)treated
- * as relative-to-repoPath when this code runs on a POSIX host.
- */
-function isAbsoluteLike(p: string): boolean {
-	return path.isAbsolute(p) || /^[A-Za-z]:[\\/]/.test(p) || /^[\\/]{2}[^\\/]/.test(p);
-}
-
-/** True if `candidate` is `root` or a descendant of `root` (cross-platform). */
-function isWithinRoot(root: string, candidate: string): boolean {
-	const rel = path.relative(path.resolve(root), path.resolve(candidate));
-	// Empty rel → same path. Otherwise it must not escape (`..`) and must not be
-	// absolute (which path.relative returns when the two are on different roots,
-	// e.g. different Windows drives).
-	return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
-}
-
-/**
  * Resolve the clone source for a sandbox container.
  *
- * @param opts.originUrl   The project's `origin` remote URL (or null/empty/undefined when absent).
- * @param opts.repoPath    The host repo root. Bind-mounted when origin is absent;
- *                         also the security root for local-origin validation.
- * @param opts.mountPath   Container-internal mount point (default `/workspace-src`). Multi-repo
- *                         callers pass a per-repo path like `/workspace-src/web`.
+ * @param opts.originUrl       The project's `origin` remote URL (or null/empty/undefined when absent).
+ * @param opts.mountSourcePath The CANONICAL main-repo working directory to bind-mount when origin
+ *                             is absent. Required. The caller resolves this (see
+ *                             `resolveSandboxMountRoot`) — the resolver NEVER derives a path from
+ *                             `origin` and NEVER touches the filesystem.
+ * @param opts.mountPath       Container-internal mount point (default `/workspace-src`). Multi-repo
+ *                             callers pass a per-repo path like `/workspace-src/web`.
  *
  * Classification:
  * - A network remote (URL scheme or scp-style `[user@]host:path`) →
  *   `{ kind: "remote", cloneUrl: stripTokenFromGitUrl(origin) }`, cloned directly.
- * - Absent/empty origin → bind-mount the declared `repoPath` (always safe — it's
- *   the sandbox's own source) and clone via `file://<mountPath>`.
- * - A LOCAL origin (file://, absolute/relative/UNC/drive-letter) is resolved to a
- *   canonical filesystem path. If it is inside `repoPath` it is bind-mounted;
- *   otherwise this THROWS — bind-mounting an arbitrary host path is a data-exposure
- *   risk.
+ * - Absent/empty origin → bind-mount `mountSourcePath` (the caller-canonicalized
+ *   main repo root — always safe) and clone via `file://<mountPath>`.
+ * - A LOCAL origin (file://, absolute/relative/UNC/drive-letter) → THROW. A local
+ *   origin can never be cloned into the container.
  *
  * Invariant: the returned `cloneUrl` is NEVER a raw host path or a Windows
  * drive-letter string. It is always a network remote URL or `file://<mountPath>`.
  */
 export function resolveSandboxCloneSource(opts: {
 	originUrl?: string | null;
-	repoPath: string;
+	mountSourcePath: string;
 	mountPath?: string;
 }): SandboxCloneSource {
 	const origin = (opts.originUrl ?? "").trim();
@@ -128,33 +113,21 @@ export function resolveSandboxCloneSource(opts: {
 		return { kind: "remote", cloneUrl: stripTokenFromGitUrl(origin) };
 	}
 
-	// Absent origin → mount the declared repo (the sandbox's own source).
+	// Absent origin → mount the caller-supplied canonical main repo root (the
+	// sandbox's own source). No path is derived from `origin`, so an in-root
+	// symlink can never be used to escape and bind-mount an arbitrary host path.
 	if (!origin) {
-		return { kind: "mounted", hostPath: opts.repoPath, mountPath, cloneUrl };
+		return { kind: "mounted", hostPath: opts.mountSourcePath, mountPath, cloneUrl };
 	}
 
-	// Local origin → resolve to a canonical absolute filesystem path.
-	let hostPath: string;
-	if (/^file:\/\//i.test(origin)) {
-		hostPath = fileURLToPath(origin);
-	} else if (isAbsoluteLike(origin)) {
-		// Already absolute (POSIX / drive-letter / UNC) — keep it; never join with repoPath.
-		hostPath = path.resolve(origin);
-	} else {
-		// Relative origin resolves against the repo root.
-		hostPath = path.resolve(opts.repoPath, origin);
-	}
-
-	// Security: only mount local origins that live inside the project root.
-	// Bind-mounting an arbitrary host path (e.g. `file:///some/other/private/repo`)
-	// would expose it inside the sandbox.
-	if (!isWithinRoot(opts.repoPath, hostPath)) {
-		throw new Error(
-			`[sandbox] origin "${origin}" is a local path outside the project root ` +
-				`(${opts.repoPath}) and cannot be safely cloned into the sandbox. ` +
-				`Configure a clonable network remote (https/ssh) or remove the local origin.`,
-		);
-	}
-
-	return { kind: "mounted", hostPath, mountPath, cloneUrl };
+	// Non-empty LOCAL origin (file://, absolute/relative/UNC/drive-letter). We do
+	// NOT mount anything derived from `origin` — bind-mounting an origin-derived
+	// path is the attack surface this fix removes. A local origin cannot be
+	// cloned into the container (host path unreachable; a drive-letter is
+	// misparsed as scp), so fail fast with an actionable message.
+	throw new Error(
+		`[sandbox] origin "${origin}" is a local path, which cannot be cloned into the sandbox. ` +
+			`Configure a clonable network remote (https/ssh), or remove the origin to use the ` +
+			`project's own repository as the mounted clone source.`,
+	);
 }

--- a/src/server/agent/sandbox-clone-source.ts
+++ b/src/server/agent/sandbox-clone-source.ts
@@ -15,6 +15,7 @@
  *   container path (`/workspace-src`) and clone from `file:///workspace-src`.
  */
 
+import { fileURLToPath } from "node:url";
 import { stripTokenFromGitUrl } from "../skills/git.js";
 
 /** Fixed container-internal mount point for the remote-less bind-mount source. */
@@ -27,24 +28,62 @@ export type SandboxCloneSource =
 	| { kind: "mounted"; hostPath: string; mountPath: string; cloneUrl: string };
 
 /**
+ * True network/transport remote schemes git can reach from inside the container.
+ * Anything else (file://, absolute/relative paths, drive-letter paths) is a
+ * LOCAL source that must be bind-mounted — never handed to git as-is.
+ */
+const REMOTE_SCHEME_RE = /^(https?|git|ssh|git\+ssh):\/\//i;
+/** scp-style remote: `user@host:path` (no scheme). */
+const SCP_REMOTE_RE = /^[^/@\s]+@[^/:\s]+:/;
+/** Windows drive-letter path: `C:\...` or `C:/...`. Checked BEFORE scp so it is never misparsed. */
+const WINDOWS_DRIVE_RE = /^[A-Za-z]:[\\/]/;
+
+/**
  * Resolve the clone source for a sandbox container.
  *
- * @param opts.originUrl  The project's `origin` remote URL (or null/empty/undefined when absent).
- * @param opts.repoPath   The host repo root — used only as the bind-mount host path when origin is absent.
+ * @param opts.originUrl   The project's `origin` remote URL (or null/empty/undefined when absent).
+ * @param opts.repoPath    The host repo root — used as the bind-mount host path when origin is absent.
+ * @param opts.mountPath   Container-internal mount point (default `/workspace-src`). Multi-repo
+ *                         callers pass a per-repo path like `/workspace-src/web`.
+ *
+ * Classification:
+ * - A TRUE remote (http(s)/git/ssh/git+ssh scheme, or scp-style `user@host:path`)
+ *   → `{ kind: "remote", cloneUrl }` cloned directly.
+ * - Everything else — empty origin, `file://` URL, absolute POSIX path, Windows
+ *   drive-letter path, UNC path, or relative path — is a LOCAL source. The host
+ *   directory is bind-mounted read-only and cloned via `file://<mountPath>`.
  *
  * Invariant: the returned `cloneUrl` is NEVER a raw host path or a Windows
- * drive-letter string. A remote-less project always becomes a `mounted` source
- * cloned via `file:///workspace-src`.
+ * drive-letter string (git misparses `C:/...` as scp/SSH syntax → `cannot run
+ * ssh` / `unable to fork`). It is always either a true remote URL or
+ * `file://<mountPath>`.
  */
-export function resolveSandboxCloneSource(opts: { originUrl?: string | null; repoPath: string }): SandboxCloneSource {
+export function resolveSandboxCloneSource(opts: {
+	originUrl?: string | null;
+	repoPath: string;
+	mountPath?: string;
+}): SandboxCloneSource {
 	const origin = (opts.originUrl ?? "").trim();
-	if (origin) {
+	const mountPath = opts.mountPath ?? MOUNTED_SRC_PATH;
+	const cloneUrl = `file://${mountPath}`;
+
+	// True remote → clone directly (Windows-drive check first so `C:/...` is never
+	// classified as an scp `host:path` remote — that misparse was the original bug).
+	if (origin && !WINDOWS_DRIVE_RE.test(origin) && (REMOTE_SCHEME_RE.test(origin) || SCP_REMOTE_RE.test(origin))) {
 		return { kind: "remote", cloneUrl: stripTokenFromGitUrl(origin) };
 	}
-	return {
-		kind: "mounted",
-		hostPath: opts.repoPath,
-		mountPath: MOUNTED_SRC_PATH,
-		cloneUrl: MOUNTED_SRC_CLONE_URL,
-	};
+
+	// Local source → bind-mount. Decode `file://` origins to a filesystem path;
+	// use the origin path string directly when it's a local path; fall back to
+	// the repo root when origin is absent.
+	let hostPath: string;
+	if (!origin) {
+		hostPath = opts.repoPath;
+	} else if (/^file:\/\//i.test(origin)) {
+		hostPath = fileURLToPath(origin);
+	} else {
+		hostPath = origin;
+	}
+
+	return { kind: "mounted", hostPath, mountPath, cloneUrl };
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -56,7 +56,7 @@ import { BgProcessManager } from "./agent/bg-process-manager.js";
 import { sessionFileRead, type SessionFsContext } from "./agent/session-fs.js";
 import { readTranscript, TranscriptReaderError } from "./agent/transcript-reader.js";
 
-import { isGitRepo, getRepoRoot, shouldSkipRemotePush, stripTokenFromGitUrl, detectPrimaryBranch, parseBaseRef, detectBaseRefFromRemote, resolveBaseRef, refExistsInRepo } from "./skills/git.js";
+import { isGitRepo, getRepoRoot, resolveSandboxMountRoot, shouldSkipRemotePush, stripTokenFromGitUrl, detectPrimaryBranch, parseBaseRef, detectBaseRefFromRemote, resolveBaseRef, refExistsInRepo } from "./skills/git.js";
 // Helper used by PUT /api/projects/:id/config to validate `base_ref` branch grammar.
 // Mirrors git's `check-ref-format` predicate in pure JS so the API can respond
 // without an exec round-trip. See docs/design/base-ref.md.
@@ -1548,8 +1548,11 @@ export function createGateway(config: GatewayConfig) {
 				// syntax → `cannot run ssh`) or an otherwise-unreachable host path.
 				// With an `origin` remote we clone the remote URL (tokens stripped so
 				// they don't leak into .git/config — the container's credential helper
-				// reads GITHUB_TOKEN from env instead). Without one, the host repo is
-				// bind-mounted read-only and cloned via `file://`.
+				// reads GITHUB_TOKEN from env instead). Without one, the canonical main
+				// repo root (resolved via `resolveSandboxMountRoot`, which handles linked
+				// worktrees) is bind-mounted read-only and cloned via `file://`. A LOCAL
+				// origin throws here — propagating through the awaited bootstrap so
+				// `ensureForProject` rejects on the awaited boundary (no fire-and-forget).
 				const resolveOrigin = async (cwd: string): Promise<string | null> => {
 					try {
 						const { stdout } = await execFileAsync("git", ["remote", "get-url", "origin"], { cwd, timeout: 5000 });
@@ -1558,7 +1561,8 @@ export function createGateway(config: GatewayConfig) {
 						return null;
 					}
 				};
-				const cloneSource = resolveSandboxCloneSource({ originUrl: await resolveOrigin(repoPath), repoPath });
+				const mountSourcePath = await resolveSandboxMountRoot(repoPath);
+				const cloneSource = resolveSandboxCloneSource({ originUrl: await resolveOrigin(repoPath), mountSourcePath });
 				const repoUrl = cloneSource.cloneUrl;
 
 				let poolMounts: string[] = [];
@@ -1594,13 +1598,14 @@ export function createGateway(config: GatewayConfig) {
 						seen.add(c.repo);
 						const rp = path.join(projectDir, c.repo);
 						// Same resolution as the single-repo path: never fall back to a
-						// raw host path. Local-origin/remote-less repos get a `file://`
-						// bind-mount source at a per-repo container mount path; the
-						// resolver derives the correct per-repo cloneUrl and decodes the
-						// real on-host source dir (from a file:// origin or the repo path).
+						// raw host path. Remote-less repos bind-mount their canonical main
+						// repo root (resolved via `resolveSandboxMountRoot`, which handles
+						// linked worktrees) at a per-repo container mount path and clone
+						// via `file://`. A local origin throws (caller's awaited boundary).
+						const perRepoMountSource = await resolveSandboxMountRoot(rp);
 						const perRepoSrc = resolveSandboxCloneSource({
 							originUrl: await resolveOrigin(rp),
-							repoPath: rp,
+							mountSourcePath: perRepoMountSource,
 							mountPath: `/workspace-src/${c.repo}`,
 						});
 						cloneSourceByName[c.repo] = perRepoSrc;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1594,12 +1594,15 @@ export function createGateway(config: GatewayConfig) {
 						seen.add(c.repo);
 						const rp = path.join(projectDir, c.repo);
 						// Same resolution as the single-repo path: never fall back to a
-						// raw host path. Remote-less repos get a `file://` bind-mount
-						// source at a per-repo container mount path.
-						const src = resolveSandboxCloneSource({ originUrl: await resolveOrigin(rp), repoPath: rp });
-						const perRepoSrc: SandboxCloneSource = src.kind === "mounted"
-							? { ...src, mountPath: `/workspace-src/${c.repo}`, cloneUrl: `file:///workspace-src/${c.repo}` }
-							: src;
+						// raw host path. Local-origin/remote-less repos get a `file://`
+						// bind-mount source at a per-repo container mount path; the
+						// resolver derives the correct per-repo cloneUrl and decodes the
+						// real on-host source dir (from a file:// origin or the repo path).
+						const perRepoSrc = resolveSandboxCloneSource({
+							originUrl: await resolveOrigin(rp),
+							repoPath: rp,
+							mountPath: `/workspace-src/${c.repo}`,
+						});
 						cloneSourceByName[c.repo] = perRepoSrc;
 						repoUrlByName[c.repo] = perRepoSrc.cloneUrl;
 					}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -169,6 +169,7 @@ import { ToolGroupPolicyStore } from "./agent/tool-group-policy-store.js";
 import { getAllConfigDirectories, removeBuiltinDirectory, resetConfigDirectories } from "./agent/config-directories.js";
 import { checkDockerAvailability, buildSandboxImage, isBuildingImage, ensureImageAgentVersion } from "./agent/sandbox-status.js";
 import { SandboxManager, type SandboxBootstrap } from "./agent/sandbox-manager.js";
+import { resolveSandboxCloneSource, type SandboxCloneSource } from "./agent/sandbox-clone-source.js";
 import { validateSandboxMounts } from "./agent/sandbox-mounts.js";
 import { SandboxTokenStore, type SandboxScope } from "./auth/sandbox-token.js";
 import { CookieStore, issueIfMissing as issueCookieIfMissing, tryAuth as cookieTryAuth } from "./auth/cookie.js";
@@ -1541,16 +1542,24 @@ export function createGateway(config: GatewayConfig) {
 				}
 				const repoPath = await getRepoRoot(projectDir);
 
-				// Repo URL for cloning inside the container. Strip embedded tokens so
-				// they don't leak into .git/config; the container's credential helper
-				// reads GITHUB_TOKEN from env instead.
-				let repoUrl: string;
-				try {
-					const { stdout } = await execFileAsync("git", ["remote", "get-url", "origin"], { cwd: repoPath, timeout: 5000 });
-					repoUrl = stripTokenFromGitUrl(stdout.trim());
-				} catch {
-					repoUrl = repoPath;
-				}
+				// Resolve the clone source for the container. Resolving via
+				// `resolveSandboxCloneSource` guarantees we NEVER hand git a raw host
+				// path (e.g. a Windows drive-letter path, which git misparses as scp
+				// syntax → `cannot run ssh`) or an otherwise-unreachable host path.
+				// With an `origin` remote we clone the remote URL (tokens stripped so
+				// they don't leak into .git/config — the container's credential helper
+				// reads GITHUB_TOKEN from env instead). Without one, the host repo is
+				// bind-mounted read-only and cloned via `file://`.
+				const resolveOrigin = async (cwd: string): Promise<string | null> => {
+					try {
+						const { stdout } = await execFileAsync("git", ["remote", "get-url", "origin"], { cwd, timeout: 5000 });
+						return stdout.trim() || null;
+					} catch {
+						return null;
+					}
+				};
+				const cloneSource = resolveSandboxCloneSource({ originUrl: await resolveOrigin(repoPath), repoPath });
+				const repoUrl = cloneSource.cloneUrl;
 
 				let poolMounts: string[] = [];
 				try {
@@ -1575,19 +1584,24 @@ export function createGateway(config: GatewayConfig) {
 				// a remote configured (the bootstrap will then clone the same repo
 				// into multiple paths — only useful as a defensive default).
 				let repoUrlByName: Record<string, string> | undefined;
+				let cloneSourceByName: Record<string, SandboxCloneSource> | undefined;
 				if (components.some(c => c.repo !== ".")) {
 					repoUrlByName = {};
+					cloneSourceByName = {};
 					const seen = new Set<string>();
 					for (const c of components) {
 						if (c.repo === "." || seen.has(c.repo)) continue;
 						seen.add(c.repo);
 						const rp = path.join(projectDir, c.repo);
-						try {
-							const { stdout } = await execFileAsync("git", ["remote", "get-url", "origin"], { cwd: rp, timeout: 5000 });
-							repoUrlByName[c.repo] = stripTokenFromGitUrl(stdout.trim());
-						} catch {
-							repoUrlByName[c.repo] = repoUrl;
-						}
+						// Same resolution as the single-repo path: never fall back to a
+						// raw host path. Remote-less repos get a `file://` bind-mount
+						// source at a per-repo container mount path.
+						const src = resolveSandboxCloneSource({ originUrl: await resolveOrigin(rp), repoPath: rp });
+						const perRepoSrc: SandboxCloneSource = src.kind === "mounted"
+							? { ...src, mountPath: `/workspace-src/${c.repo}`, cloneUrl: `file:///workspace-src/${c.repo}` }
+							: src;
+						cloneSourceByName[c.repo] = perRepoSrc;
+						repoUrlByName[c.repo] = perRepoSrc.cloneUrl;
 					}
 				}
 
@@ -1596,6 +1610,7 @@ export function createGateway(config: GatewayConfig) {
 					projectId,
 					projectDir,
 					repoUrl,
+					cloneSource,
 					image: imageName,
 					sandboxNetwork,
 					sandboxMounts: poolMounts,
@@ -1606,6 +1621,7 @@ export function createGateway(config: GatewayConfig) {
 					toolManager: ctx.toolManager,
 					components,
 					repoUrlByName,
+					cloneSourceByName,
 					// Resolver is invoked at worktree-creation time inside the container, so it always
 					// reads the current project-config-store value rather than a snapshot taken at
 					// sandbox bootstrap. Same shape as the worktree-pool baseRefResolver.

--- a/src/server/skills/git.ts
+++ b/src/server/skills/git.ts
@@ -316,6 +316,58 @@ export async function isGitRepoRoot(dir: string): Promise<boolean> {
 	}
 }
 
+/**
+ * Resolve the canonical main-repo working directory to bind-mount as the sandbox
+ * clone source.
+ *
+ * A linked git worktree's `.git` is a gitdir-FILE pointing at the main repo's
+ * object store, not a real `.git` directory. Bind-mounting and `git clone`ing
+ * just the worktree dir fails because the objects live in the main repo, which
+ * isn't mounted. So we resolve the canonical MAIN repo root via
+ * `git rev-parse --git-common-dir` and mount that instead.
+ *
+ * Returns the realpath of the main working tree (parent of the resolved
+ * `.git`), or the realpath of the common dir itself for a bare repo. On any
+ * failure, falls back to `canonicalizePath(repoPath)`. Always resolves symlinks
+ * (defense in depth: the mount source is never an un-canonicalized path).
+ */
+export async function resolveSandboxMountRoot(repoPath: string): Promise<string> {
+	const realpath = async (p: string): Promise<string> => {
+		try {
+			return await fs.promises.realpath(p);
+		} catch {
+			return path.resolve(p);
+		}
+	};
+	try {
+		let commonDir: string;
+		try {
+			const { stdout } = await execGit(
+				["-C", repoPath, "rev-parse", "--path-format=absolute", "--git-common-dir"],
+				{ timeout: 5_000 },
+			);
+			commonDir = stdout.toString().trim();
+		} catch {
+			// Older git without --path-format: result may be relative to repoPath.
+			const { stdout } = await execGit(["-C", repoPath, "rev-parse", "--git-common-dir"], {
+				timeout: 5_000,
+			});
+			commonDir = stdout.toString().trim();
+		}
+		if (!commonDir) return canonicalizePath(repoPath);
+		if (!path.isAbsolute(commonDir)) commonDir = path.resolve(repoPath, commonDir);
+		const realCommon = await realpath(commonDir);
+		// A non-bare repo's common dir ends in `.git` — the main working tree is its parent.
+		if (path.basename(realCommon) === ".git") {
+			return await realpath(path.dirname(realCommon));
+		}
+		// Bare repo — the common dir itself is the canonical source.
+		return realCommon;
+	} catch {
+		return canonicalizePath(repoPath);
+	}
+}
+
 export interface WorktreeResult {
 	worktreePath: string;
 	branchName: string;

--- a/tests/manual-integration/agent-tool-use.spec.ts
+++ b/tests/manual-integration/agent-tool-use.spec.ts
@@ -40,7 +40,6 @@ import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import { createServer } from "node:net";
 import { mkdirSync, rmSync, readFileSync, writeFileSync, existsSync, readdirSync, cpSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
 import { buildDefaultWorkflows } from "../../src/server/state-migration/seed-default-workflows.ts";
 import { seedManualTestModelPreferences } from "./manual-test-model-seeding.ts";
 
@@ -299,15 +298,9 @@ function initRepo(dir: string) {
 	}, null, 2));
 	execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore" });
 	execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "ignore" });
-	// Real, reachable `origin`: a local bare repo cloned via a `file://` URL.
-	// The old code copied PROJECT_ROOT's GitHub origin, which is unreachable
-	// from inside the sandbox container (and a Windows host path misparses as
-	// scp/ssh syntax). A local bare repo works on every OS.
-	const bareRepo = `${dir}.origin.git`;
-	rmSync(bareRepo, { recursive: true, force: true });
-	execFileSync("git", ["init", "--bare", bareRepo], { stdio: "ignore" });
-	execFileSync("git", ["remote", "add", "origin", pathToFileURL(bareRepo).href], { cwd: dir, stdio: "ignore" });
-	execFileSync("git", ["push", "-u", "origin", "master"], { cwd: dir, stdio: "ignore" });
+	// Deliberately leave this repo WITHOUT an `origin` remote. With no origin the
+	// sandbox bind-mounts the project repo read-only at `/workspace-src` and
+	// clones it via `file://` — the working mounted-clone path on every OS.
 	const srcConfig = join(PROJECT_ROOT, ".bobbit", "config");
 	const dstConfig = join(dir, ".bobbit", "config");
 	if (existsSync(srcConfig)) {

--- a/tests/manual-integration/agent-tool-use.spec.ts
+++ b/tests/manual-integration/agent-tool-use.spec.ts
@@ -40,6 +40,7 @@ import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import { createServer } from "node:net";
 import { mkdirSync, rmSync, readFileSync, writeFileSync, existsSync, readdirSync, cpSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import { buildDefaultWorkflows } from "../../src/server/state-migration/seed-default-workflows.ts";
 import { seedManualTestModelPreferences } from "./manual-test-model-seeding.ts";
 
@@ -298,10 +299,15 @@ function initRepo(dir: string) {
 	}, null, 2));
 	execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore" });
 	execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "ignore" });
-	try {
-		const origin = execFileSync("git", ["remote", "get-url", "origin"], { cwd: PROJECT_ROOT, encoding: "utf-8", timeout: 5_000 }).trim();
-		execFileSync("git", ["remote", "add", "origin", origin], { cwd: dir, stdio: "ignore" });
-	} catch {}
+	// Real, reachable `origin`: a local bare repo cloned via a `file://` URL.
+	// The old code copied PROJECT_ROOT's GitHub origin, which is unreachable
+	// from inside the sandbox container (and a Windows host path misparses as
+	// scp/ssh syntax). A local bare repo works on every OS.
+	const bareRepo = `${dir}.origin.git`;
+	rmSync(bareRepo, { recursive: true, force: true });
+	execFileSync("git", ["init", "--bare", bareRepo], { stdio: "ignore" });
+	execFileSync("git", ["remote", "add", "origin", pathToFileURL(bareRepo).href], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["push", "-u", "origin", "master"], { cwd: dir, stdio: "ignore" });
 	const srcConfig = join(PROJECT_ROOT, ".bobbit", "config");
 	const dstConfig = join(dir, ".bobbit", "config");
 	if (existsSync(srcConfig)) {

--- a/tests/manual-integration/sandbox-recovery-frame-continuity.spec.ts
+++ b/tests/manual-integration/sandbox-recovery-frame-continuity.spec.ts
@@ -40,6 +40,7 @@ import {
 	cpSync,
 } from "node:fs";
 import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import WebSocket from "ws";
 import { seedManualTestModelPreferences } from "./manual-test-model-seeding.ts";
 
@@ -147,15 +148,17 @@ function initRepo(dir: string) {
 	writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "p", version: "1.0.0" }, null, 2));
 	execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore" });
 	execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "ignore" });
-	// Add a real origin so project-sandbox can clone the repo via https inside
-	// the Linux container. Without this, server.ts falls back to repoUrl =
-	// repoPath (a Windows host path like "C:/Users/..."), which git inside
-	// the container interprets as an ssh-style URL because of the colon and
-	// fails with "cannot run ssh: No such file or directory".
-	try {
-		const origin = execFileSync("git", ["remote", "get-url", "origin"], { cwd: PROJECT_ROOT, encoding: "utf-8", timeout: 5_000 }).trim();
-		execFileSync("git", ["remote", "add", "origin", origin], { cwd: dir, stdio: "ignore" });
-	} catch {}
+	// Add a real, reachable `origin` so project-sandbox can clone the repo
+	// inside the Linux container. We use a local bare repo cloned via a
+	// `file://` URL rather than copying PROJECT_ROOT's GitHub origin: the
+	// GitHub origin is unreachable from inside the container, and on Windows
+	// the host path (`C:/Users/...`) misparses as ssh-style syntax and fails
+	// with "cannot run ssh: No such file or directory".
+	const bareRepo = `${dir}.origin.git`;
+	rmSync(bareRepo, { recursive: true, force: true });
+	execFileSync("git", ["init", "--bare", bareRepo], { stdio: "ignore" });
+	execFileSync("git", ["remote", "add", "origin", pathToFileURL(bareRepo).href], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["push", "-u", "origin", "master"], { cwd: dir, stdio: "ignore" });
 	const srcConfig = join(PROJECT_ROOT, ".bobbit", "config");
 	const dstConfig = join(dir, ".bobbit", "config");
 	if (existsSync(srcConfig)) {

--- a/tests/manual-integration/sandbox-recovery-frame-continuity.spec.ts
+++ b/tests/manual-integration/sandbox-recovery-frame-continuity.spec.ts
@@ -40,7 +40,6 @@ import {
 	cpSync,
 } from "node:fs";
 import { join, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
 import WebSocket from "ws";
 import { seedManualTestModelPreferences } from "./manual-test-model-seeding.ts";
 
@@ -148,17 +147,10 @@ function initRepo(dir: string) {
 	writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "p", version: "1.0.0" }, null, 2));
 	execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore" });
 	execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "ignore" });
-	// Add a real, reachable `origin` so project-sandbox can clone the repo
-	// inside the Linux container. We use a local bare repo cloned via a
-	// `file://` URL rather than copying PROJECT_ROOT's GitHub origin: the
-	// GitHub origin is unreachable from inside the container, and on Windows
-	// the host path (`C:/Users/...`) misparses as ssh-style syntax and fails
-	// with "cannot run ssh: No such file or directory".
-	const bareRepo = `${dir}.origin.git`;
-	rmSync(bareRepo, { recursive: true, force: true });
-	execFileSync("git", ["init", "--bare", bareRepo], { stdio: "ignore" });
-	execFileSync("git", ["remote", "add", "origin", pathToFileURL(bareRepo).href], { cwd: dir, stdio: "ignore" });
-	execFileSync("git", ["push", "-u", "origin", "master"], { cwd: dir, stdio: "ignore" });
+	// Deliberately leave this repo WITHOUT an `origin` remote. With no origin the
+	// sandbox bind-mounts the project repo read-only at `/workspace-src` and
+	// clones it via `file://` — exercising the working mounted-clone path on
+	// every OS (no scp/ssh misparse of a host path, no unreachable host path).
 	const srcConfig = join(PROJECT_ROOT, ".bobbit", "config");
 	const dstConfig = join(dir, ".bobbit", "config");
 	if (existsSync(srcConfig)) {

--- a/tests/manual-integration/session-resilience.spec.ts
+++ b/tests/manual-integration/session-resilience.spec.ts
@@ -26,7 +26,6 @@ import {
 	cpSync,
 } from "node:fs";
 import { join, resolve, normalize } from "node:path";
-import { pathToFileURL } from "node:url";
 import { buildDefaultWorkflows } from "../../src/server/state-migration/seed-default-workflows.ts";
 import { seedManualTestModelPreferences } from "./manual-test-model-seeding.ts";
 
@@ -443,16 +442,12 @@ function initRepo(dir: string) {
 	}, null, 2));
 	execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore" });
 	execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "ignore" });
-	// Give the fixture a real, reachable `origin`: a local bare repo cloned via
-	// a `file://` URL. The old code copied PROJECT_ROOT's GitHub origin, which
-	// is unreachable from inside the sandbox container; on Windows the host path
-	// also misparses as scp/ssh syntax (`cannot run ssh`). A local bare repo
-	// works on every OS and exercises the real clone path.
-	const bareRepo = `${dir}.origin.git`;
-	rmSync(bareRepo, { recursive: true, force: true });
-	execFileSync("git", ["init", "--bare", bareRepo], { stdio: "ignore" });
-	execFileSync("git", ["remote", "add", "origin", pathToFileURL(bareRepo).href], { cwd: dir, stdio: "ignore" });
-	execFileSync("git", ["push", "-u", "origin", "master"], { cwd: dir, stdio: "ignore" });
+	// Deliberately leave this repo WITHOUT an `origin` remote. With no origin the
+	// sandbox bind-mounts the project repo read-only at `/workspace-src` and
+	// clones it via `file://` — exercising the working mounted-clone path. This
+	// is the safe default: a remote-less project is always its own clone source.
+	// (Adding an external `file://` bare-repo origin would now be rejected by the
+	// resolver as a local path outside the project root — a data-exposure guard.)
 
 	// Copy config files (workflows, roles, tools, etc.) so the gateway has them.
 	// Exclude project.yaml since we write our own.

--- a/tests/manual-integration/session-resilience.spec.ts
+++ b/tests/manual-integration/session-resilience.spec.ts
@@ -26,6 +26,7 @@ import {
 	cpSync,
 } from "node:fs";
 import { join, resolve, normalize } from "node:path";
+import { pathToFileURL } from "node:url";
 import { buildDefaultWorkflows } from "../../src/server/state-migration/seed-default-workflows.ts";
 import { seedManualTestModelPreferences } from "./manual-test-model-seeding.ts";
 
@@ -442,10 +443,16 @@ function initRepo(dir: string) {
 	}, null, 2));
 	execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore" });
 	execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "ignore" });
-	try {
-		const origin = execFileSync("git", ["remote", "get-url", "origin"], { cwd: PROJECT_ROOT, encoding: "utf-8", timeout: 5_000 }).trim();
-		execFileSync("git", ["remote", "add", "origin", origin], { cwd: dir, stdio: "ignore" });
-	} catch {}
+	// Give the fixture a real, reachable `origin`: a local bare repo cloned via
+	// a `file://` URL. The old code copied PROJECT_ROOT's GitHub origin, which
+	// is unreachable from inside the sandbox container; on Windows the host path
+	// also misparses as scp/ssh syntax (`cannot run ssh`). A local bare repo
+	// works on every OS and exercises the real clone path.
+	const bareRepo = `${dir}.origin.git`;
+	rmSync(bareRepo, { recursive: true, force: true });
+	execFileSync("git", ["init", "--bare", bareRepo], { stdio: "ignore" });
+	execFileSync("git", ["remote", "add", "origin", pathToFileURL(bareRepo).href], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["push", "-u", "origin", "master"], { cwd: dir, stdio: "ignore" });
 
 	// Copy config files (workflows, roles, tools, etc.) so the gateway has them.
 	// Exclude project.yaml since we write our own.

--- a/tests/sandbox-clone-source.test.ts
+++ b/tests/sandbox-clone-source.test.ts
@@ -16,6 +16,7 @@
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { resolveSandboxCloneSource } from "../src/server/agent/sandbox-clone-source.js";
 
 describe("resolveSandboxCloneSource", () => {
@@ -67,5 +68,74 @@ describe("resolveSandboxCloneSource", () => {
 		const result = resolveSandboxCloneSource({ originUrl: "", repoPath: "/x" });
 		assert.equal(result.kind, "mounted");
 		assert.equal(result.cloneUrl, "file:///workspace-src");
+	});
+
+	it("treats an scp-style origin as a true remote", () => {
+		const result = resolveSandboxCloneSource({
+			originUrl: "git@github.com:foo/bar.git",
+			repoPath: "/some/path",
+		});
+		assert.deepEqual(result, { kind: "remote", cloneUrl: "git@github.com:foo/bar.git" });
+	});
+
+	it("treats an ssh:// origin as a true remote", () => {
+		const result = resolveSandboxCloneSource({
+			originUrl: "ssh://git@host/foo.git",
+			repoPath: "/some/path",
+		});
+		assert.equal(result.kind, "remote");
+		// stripTokenFromGitUrl removes the `git@` userinfo; the scheme stays ssh://.
+		assert.ok(/^ssh:\/\//.test(result.cloneUrl));
+	});
+
+	it("classifies a file:// origin as a mounted source with a decoded host path", () => {
+		// Build the file:// origin from an OS-appropriate absolute path so the test
+		// is cross-platform (a drive-less `file:///tmp/...` throws on Windows).
+		const hostDir = process.platform === "win32" ? "C:/tmp/foo.git" : "/tmp/foo.git";
+		const origin = pathToFileURL(hostDir).href;
+		const result = resolveSandboxCloneSource({ originUrl: origin, repoPath: "/unused" });
+		assert.equal(result.kind, "mounted");
+		assert.equal(result.cloneUrl, "file:///workspace-src");
+		// Cross-platform: compare against fileURLToPath rather than a hardcoded path.
+		assert.equal((result as { hostPath: string }).hostPath, fileURLToPath(origin));
+		// Must never be a file:// URL — it has to be a real filesystem path to bind-mount.
+		assert.ok(!/^file:\/\//i.test((result as { hostPath: string }).hostPath));
+	});
+
+	it("classifies a local absolute POSIX path origin as mounted", () => {
+		const result = resolveSandboxCloneSource({
+			originUrl: "/srv/repos/foo.git",
+			repoPath: "/unused",
+		});
+		assert.equal(result.kind, "mounted");
+		assert.equal((result as { hostPath: string }).hostPath, "/srv/repos/foo.git");
+		assert.equal(result.cloneUrl, "file:///workspace-src");
+	});
+
+	it("classifies a Windows drive-letter origin as mounted, NOT a remote", () => {
+		const result = resolveSandboxCloneSource({
+			originUrl: "C:/Users/jsubr/foo.git",
+			repoPath: "/unused",
+		});
+		assert.equal(result.kind, "mounted");
+		assert.equal((result as { hostPath: string }).hostPath, "C:/Users/jsubr/foo.git");
+		// cloneUrl must never be a drive-letter path (the scp misparse bug).
+		assert.ok(
+			!/^[A-Za-z]:/.test(result.cloneUrl),
+			`cloneUrl must not be a Windows drive-letter path, got: ${result.cloneUrl}`,
+		);
+		assert.equal(result.cloneUrl, "file:///workspace-src");
+	});
+
+	it("honours a per-repo mountPath for multi-repo callers", () => {
+		const result = resolveSandboxCloneSource({
+			originUrl: undefined,
+			repoPath: "/host/web",
+			mountPath: "/workspace-src/web",
+		});
+		assert.equal(result.kind, "mounted");
+		assert.equal((result as { mountPath: string }).mountPath, "/workspace-src/web");
+		assert.equal(result.cloneUrl, "file:///workspace-src/web");
+		assert.equal((result as { hostPath: string }).hostPath, "/host/web");
 	});
 });

--- a/tests/sandbox-clone-source.test.ts
+++ b/tests/sandbox-clone-source.test.ts
@@ -1,141 +1,156 @@
 /**
- * Regression test for the Docker sandbox clone-fallback bug.
+ * Contract test for the Docker sandbox clone-source resolver.
  *
- * When a project has no `origin` remote, the old code fell back to using the
- * raw HOST directory path as the `git clone` source inside the Linux
- * container. On Windows the drive-letter path (`C:/Users/...`) is misparsed by
- * git as scp/SSH syntax; on any OS the host path is unreachable from inside the
- * container.
+ * `resolveSandboxCloneSource()` decides what `git clone` uses *inside* the
+ * Linux sandbox container. It must NEVER emit a raw host path as the clone URL
+ * (a Windows drive-letter path like `C:/Users/...` is misparsed by git as
+ * scp/SSH syntax → `cannot run ssh` / `unable to fork`; any host path is
+ * unreachable from inside the container).
  *
- * The fix introduces a pure `resolveSandboxCloneSource()` that NEVER emits a
- * raw host path as the clone URL — the remote-less case becomes a read-only
- * bind-mount cloned via `file:///workspace-src`.
+ * Two security/quality invariants this test pins:
  *
- * This test pins that contract. It fails (red) on the current branch because
- * the module/function does not exist yet.
+ *  - Classification mirrors git's heuristic: a URL scheme OR scp-style
+ *    `[user@]host:path` (host not a single drive letter) is a network remote;
+ *    everything else is local.
+ *  - A LOCAL origin is only bind-mounted when it resolves INSIDE the project
+ *    root. A local origin pointing outside the root throws — bind-mounting an
+ *    arbitrary host path into the sandbox is a data-exposure risk.
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { resolveSandboxCloneSource } from "../src/server/agent/sandbox-clone-source.js";
 
-describe("resolveSandboxCloneSource", () => {
-	it("returns a remote source when origin is present", () => {
+// An absolute repo root for the running platform (drive-rooted on Windows).
+const REPO_ROOT = path.resolve(process.platform === "win32" ? "C:/proj/app" : "/proj/app");
+
+describe("resolveSandboxCloneSource — network remotes", () => {
+	it("classifies an https:// origin as a remote (token stripped)", () => {
 		const result = resolveSandboxCloneSource({
 			originUrl: "https://github.com/foo/bar.git",
-			repoPath: "/some/path",
+			repoPath: REPO_ROOT,
 		});
-		assert.deepEqual(result, {
-			kind: "remote",
-			cloneUrl: "https://github.com/foo/bar.git",
-		});
+		assert.deepEqual(result, { kind: "remote", cloneUrl: "https://github.com/foo/bar.git" });
 	});
 
-	it("returns a mounted source when origin is absent (Windows host path)", () => {
+	it("classifies an scp-style origin with user (git@host:path) as a remote", () => {
 		const result = resolveSandboxCloneSource({
-			originUrl: undefined,
-			repoPath: "C:/Users/jsubr/proj",
+			originUrl: "git@github.com:foo/bar.git",
+			repoPath: REPO_ROOT,
 		});
-		assert.equal(result.kind, "mounted");
-		assert.equal(result.cloneUrl, "file:///workspace-src");
-		assert.equal((result as { mountPath: string }).mountPath, "/workspace-src");
-		assert.equal((result as { hostPath: string }).hostPath, "C:/Users/jsubr/proj");
+		assert.equal(result.kind, "remote");
+		// stripTokenFromGitUrl leaves scp-style host:path remotes intact here.
+		assert.equal(result.cloneUrl, "git@github.com:foo/bar.git");
 	});
 
-	it("NEVER emits the raw host path as the clone URL (the heart of the bug)", () => {
-		const repoPath = "C:/Users/jsubr/proj";
-		const result = resolveSandboxCloneSource({ originUrl: undefined, repoPath });
+	it("classifies an scp-style origin WITHOUT user (host:path) as a remote", () => {
+		// This is the Finding-1 regression: a host-without-user scp remote was
+		// previously misclassified as a local/mounted source.
+		const result = resolveSandboxCloneSource({
+			originUrl: "github.example.com:team/repo.git",
+			repoPath: REPO_ROOT,
+		});
+		assert.equal(result.kind, "remote");
+		assert.equal(result.cloneUrl, "github.example.com:team/repo.git");
+	});
 
-		// Must not be the raw host path.
+	it("classifies an ssh:// origin as a remote", () => {
+		const result = resolveSandboxCloneSource({
+			originUrl: "ssh://git@host/foo.git",
+			repoPath: REPO_ROOT,
+		});
+		assert.equal(result.kind, "remote");
+		assert.ok(/^ssh:\/\//.test(result.cloneUrl));
+	});
+});
+
+describe("resolveSandboxCloneSource — absent origin (mount the declared repo)", () => {
+	for (const [label, originUrl] of [
+		["undefined", undefined],
+		["null", null],
+		["empty string", ""],
+	] as const) {
+		it(`mounts the project repo when origin is ${label}`, () => {
+			const result = resolveSandboxCloneSource({ originUrl, repoPath: REPO_ROOT });
+			assert.equal(result.kind, "mounted");
+			assert.equal((result as { hostPath: string }).hostPath, REPO_ROOT);
+			assert.equal((result as { mountPath: string }).mountPath, "/workspace-src");
+			assert.equal(result.cloneUrl, "file:///workspace-src");
+		});
+	}
+
+	it("NEVER emits a raw host path or drive-letter as the clone URL", () => {
+		const repoPath = process.platform === "win32" ? "C:/Users/jsubr/proj" : "/home/dev/proj";
+		const result = resolveSandboxCloneSource({ originUrl: undefined, repoPath });
 		assert.notEqual(result.cloneUrl, repoPath);
-		// Must not look like a Windows drive-letter path (which git misparses as
-		// scp/SSH syntax → `cannot run ssh` / `unable to fork`).
 		assert.ok(
 			!/^[A-Za-z]:/.test(result.cloneUrl),
 			`cloneUrl must not be a Windows drive-letter path, got: ${result.cloneUrl}`,
 		);
-	});
-
-	it("never emits an scp-style remote for a POSIX host path either", () => {
-		const repoPath = "/home/dev/project-without-origin";
-		const result = resolveSandboxCloneSource({ originUrl: null, repoPath });
-		assert.equal(result.kind, "mounted");
-		assert.equal(result.cloneUrl, "file:///workspace-src");
-		assert.notEqual(result.cloneUrl, repoPath);
-	});
-
-	it("treats an empty-string origin as absent", () => {
-		const result = resolveSandboxCloneSource({ originUrl: "", repoPath: "/x" });
-		assert.equal(result.kind, "mounted");
 		assert.equal(result.cloneUrl, "file:///workspace-src");
 	});
+});
 
-	it("treats an scp-style origin as a true remote", () => {
-		const result = resolveSandboxCloneSource({
-			originUrl: "git@github.com:foo/bar.git",
-			repoPath: "/some/path",
-		});
-		assert.deepEqual(result, { kind: "remote", cloneUrl: "git@github.com:foo/bar.git" });
-	});
-
-	it("treats an ssh:// origin as a true remote", () => {
-		const result = resolveSandboxCloneSource({
-			originUrl: "ssh://git@host/foo.git",
-			repoPath: "/some/path",
-		});
-		assert.equal(result.kind, "remote");
-		// stripTokenFromGitUrl removes the `git@` userinfo; the scheme stays ssh://.
-		assert.ok(/^ssh:\/\//.test(result.cloneUrl));
-	});
-
-	it("classifies a file:// origin as a mounted source with a decoded host path", () => {
-		// Build the file:// origin from an OS-appropriate absolute path so the test
-		// is cross-platform (a drive-less `file:///tmp/...` throws on Windows).
-		const hostDir = process.platform === "win32" ? "C:/tmp/foo.git" : "/tmp/foo.git";
-		const origin = pathToFileURL(hostDir).href;
-		const result = resolveSandboxCloneSource({ originUrl: origin, repoPath: "/unused" });
+describe("resolveSandboxCloneSource — local origins inside the project root", () => {
+	it("mounts a file:// origin that points inside repoPath", () => {
+		const inside = path.join(REPO_ROOT, "sub");
+		const origin = pathToFileURL(inside).href;
+		const result = resolveSandboxCloneSource({ originUrl: origin, repoPath: REPO_ROOT });
 		assert.equal(result.kind, "mounted");
-		assert.equal(result.cloneUrl, "file:///workspace-src");
-		// Cross-platform: compare against fileURLToPath rather than a hardcoded path.
 		assert.equal((result as { hostPath: string }).hostPath, fileURLToPath(origin));
-		// Must never be a file:// URL — it has to be a real filesystem path to bind-mount.
+		assert.equal(result.cloneUrl, "file:///workspace-src");
+		// hostPath must be a real filesystem path, never a file:// URL.
 		assert.ok(!/^file:\/\//i.test((result as { hostPath: string }).hostPath));
 	});
 
-	it("classifies a local absolute POSIX path origin as mounted", () => {
-		const result = resolveSandboxCloneSource({
-			originUrl: "/srv/repos/foo.git",
-			repoPath: "/unused",
-		});
+	it("mounts a relative origin resolved against repoPath", () => {
+		const result = resolveSandboxCloneSource({ originUrl: "./vendored", repoPath: REPO_ROOT });
 		assert.equal(result.kind, "mounted");
-		assert.equal((result as { hostPath: string }).hostPath, "/srv/repos/foo.git");
+		assert.equal((result as { hostPath: string }).hostPath, path.resolve(REPO_ROOT, "./vendored"));
 		assert.equal(result.cloneUrl, "file:///workspace-src");
 	});
+});
 
-	it("classifies a Windows drive-letter origin as mounted, NOT a remote", () => {
-		const result = resolveSandboxCloneSource({
-			originUrl: "C:/Users/jsubr/foo.git",
-			repoPath: "/unused",
-		});
-		assert.equal(result.kind, "mounted");
-		assert.equal((result as { hostPath: string }).hostPath, "C:/Users/jsubr/foo.git");
-		// cloneUrl must never be a drive-letter path (the scp misparse bug).
-		assert.ok(
-			!/^[A-Za-z]:/.test(result.cloneUrl),
-			`cloneUrl must not be a Windows drive-letter path, got: ${result.cloneUrl}`,
+describe("resolveSandboxCloneSource — local origins OUTSIDE the project root throw", () => {
+	it("throws for a file:// origin outside repoPath (security)", () => {
+		const outside = process.platform === "win32" ? "C:/some/other/private/repo" : "/some/other/private/repo";
+		const origin = pathToFileURL(outside).href;
+		assert.throws(
+			() => resolveSandboxCloneSource({ originUrl: origin, repoPath: REPO_ROOT }),
+			/outside the project root/,
 		);
-		assert.equal(result.cloneUrl, "file:///workspace-src");
 	});
 
-	it("honours a per-repo mountPath for multi-repo callers", () => {
+	it("throws for an absolute path origin outside repoPath", () => {
+		const outside = process.platform === "win32" ? "C:/srv/repos/foo.git" : "/srv/repos/foo.git";
+		assert.throws(
+			() => resolveSandboxCloneSource({ originUrl: outside, repoPath: REPO_ROOT }),
+			/outside the project root/,
+		);
+	});
+
+	it("throws (NOT classified as remote) for a Windows drive path not under repoPath", () => {
+		// A bare drive-letter path must be treated as a local path, never as an
+		// scp `host:path` remote (single-letter host). Outside the root → throw.
+		const repoPath = process.platform === "win32" ? "C:/totally/unrelated/root" : "/totally/unrelated/root";
+		assert.throws(
+			() => resolveSandboxCloneSource({ originUrl: "C:/Users/jsubr/foo.git", repoPath }),
+			/outside the project root/,
+		);
+	});
+});
+
+describe("resolveSandboxCloneSource — per-repo mountPath", () => {
+	it("honours a custom mountPath for multi-repo callers", () => {
 		const result = resolveSandboxCloneSource({
 			originUrl: undefined,
-			repoPath: "/host/web",
+			repoPath: REPO_ROOT,
 			mountPath: "/workspace-src/web",
 		});
 		assert.equal(result.kind, "mounted");
 		assert.equal((result as { mountPath: string }).mountPath, "/workspace-src/web");
 		assert.equal(result.cloneUrl, "file:///workspace-src/web");
-		assert.equal((result as { hostPath: string }).hostPath, "/host/web");
+		assert.equal((result as { hostPath: string }).hostPath, REPO_ROOT);
 	});
 });

--- a/tests/sandbox-clone-source.test.ts
+++ b/tests/sandbox-clone-source.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Regression test for the Docker sandbox clone-fallback bug.
+ *
+ * When a project has no `origin` remote, the old code fell back to using the
+ * raw HOST directory path as the `git clone` source inside the Linux
+ * container. On Windows the drive-letter path (`C:/Users/...`) is misparsed by
+ * git as scp/SSH syntax; on any OS the host path is unreachable from inside the
+ * container.
+ *
+ * The fix introduces a pure `resolveSandboxCloneSource()` that NEVER emits a
+ * raw host path as the clone URL — the remote-less case becomes a read-only
+ * bind-mount cloned via `file:///workspace-src`.
+ *
+ * This test pins that contract. It fails (red) on the current branch because
+ * the module/function does not exist yet.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolveSandboxCloneSource } from "../src/server/agent/sandbox-clone-source.js";
+
+describe("resolveSandboxCloneSource", () => {
+	it("returns a remote source when origin is present", () => {
+		const result = resolveSandboxCloneSource({
+			originUrl: "https://github.com/foo/bar.git",
+			repoPath: "/some/path",
+		});
+		assert.deepEqual(result, {
+			kind: "remote",
+			cloneUrl: "https://github.com/foo/bar.git",
+		});
+	});
+
+	it("returns a mounted source when origin is absent (Windows host path)", () => {
+		const result = resolveSandboxCloneSource({
+			originUrl: undefined,
+			repoPath: "C:/Users/jsubr/proj",
+		});
+		assert.equal(result.kind, "mounted");
+		assert.equal(result.cloneUrl, "file:///workspace-src");
+		assert.equal((result as { mountPath: string }).mountPath, "/workspace-src");
+		assert.equal((result as { hostPath: string }).hostPath, "C:/Users/jsubr/proj");
+	});
+
+	it("NEVER emits the raw host path as the clone URL (the heart of the bug)", () => {
+		const repoPath = "C:/Users/jsubr/proj";
+		const result = resolveSandboxCloneSource({ originUrl: undefined, repoPath });
+
+		// Must not be the raw host path.
+		assert.notEqual(result.cloneUrl, repoPath);
+		// Must not look like a Windows drive-letter path (which git misparses as
+		// scp/SSH syntax → `cannot run ssh` / `unable to fork`).
+		assert.ok(
+			!/^[A-Za-z]:/.test(result.cloneUrl),
+			`cloneUrl must not be a Windows drive-letter path, got: ${result.cloneUrl}`,
+		);
+	});
+
+	it("never emits an scp-style remote for a POSIX host path either", () => {
+		const repoPath = "/home/dev/project-without-origin";
+		const result = resolveSandboxCloneSource({ originUrl: null, repoPath });
+		assert.equal(result.kind, "mounted");
+		assert.equal(result.cloneUrl, "file:///workspace-src");
+		assert.notEqual(result.cloneUrl, repoPath);
+	});
+
+	it("treats an empty-string origin as absent", () => {
+		const result = resolveSandboxCloneSource({ originUrl: "", repoPath: "/x" });
+		assert.equal(result.kind, "mounted");
+		assert.equal(result.cloneUrl, "file:///workspace-src");
+	});
+});

--- a/tests/sandbox-clone-source.test.ts
+++ b/tests/sandbox-clone-source.test.ts
@@ -7,29 +7,31 @@
  * scp/SSH syntax → `cannot run ssh` / `unable to fork`; any host path is
  * unreachable from inside the container).
  *
- * Two security/quality invariants this test pins:
+ * Invariants this test pins:
  *
  *  - Classification mirrors git's heuristic: a URL scheme OR scp-style
  *    `[user@]host:path` (host not a single drive letter) is a network remote;
  *    everything else is local.
- *  - A LOCAL origin is only bind-mounted when it resolves INSIDE the project
- *    root. A local origin pointing outside the root throws — bind-mounting an
- *    arbitrary host path into the sandbox is a data-exposure risk.
+ *  - The bind-mount source is ALWAYS the caller-supplied `mountSourcePath`, never
+ *    a path derived from `origin`. This removes the local-origin→mount attack
+ *    surface (no in-root symlink can escape, because no `origin`-derived path is
+ *    ever mounted).
+ *  - A non-empty LOCAL origin THROWS with an actionable `/local path/` message —
+ *    a drive-letter origin must be treated as local, never as an scp remote.
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
 import { resolveSandboxCloneSource } from "../src/server/agent/sandbox-clone-source.js";
 
-// An absolute repo root for the running platform (drive-rooted on Windows).
-const REPO_ROOT = path.resolve(process.platform === "win32" ? "C:/proj/app" : "/proj/app");
+// A POSIX-style canonical mount source (what the caller's resolveSandboxMountRoot
+// returns). Pure resolver — never touches the filesystem, so this need not exist.
+const MOUNT_SRC = "/main/repo";
 
 describe("resolveSandboxCloneSource — network remotes", () => {
 	it("classifies an https:// origin as a remote (token stripped)", () => {
 		const result = resolveSandboxCloneSource({
 			originUrl: "https://github.com/foo/bar.git",
-			repoPath: REPO_ROOT,
+			mountSourcePath: MOUNT_SRC,
 		});
 		assert.deepEqual(result, { kind: "remote", cloneUrl: "https://github.com/foo/bar.git" });
 	});
@@ -37,7 +39,7 @@ describe("resolveSandboxCloneSource — network remotes", () => {
 	it("classifies an scp-style origin with user (git@host:path) as a remote", () => {
 		const result = resolveSandboxCloneSource({
 			originUrl: "git@github.com:foo/bar.git",
-			repoPath: REPO_ROOT,
+			mountSourcePath: MOUNT_SRC,
 		});
 		assert.equal(result.kind, "remote");
 		// stripTokenFromGitUrl leaves scp-style host:path remotes intact here.
@@ -45,11 +47,10 @@ describe("resolveSandboxCloneSource — network remotes", () => {
 	});
 
 	it("classifies an scp-style origin WITHOUT user (host:path) as a remote", () => {
-		// This is the Finding-1 regression: a host-without-user scp remote was
-		// previously misclassified as a local/mounted source.
+		// A host-without-user scp remote must not be misclassified as local.
 		const result = resolveSandboxCloneSource({
 			originUrl: "github.example.com:team/repo.git",
-			repoPath: REPO_ROOT,
+			mountSourcePath: MOUNT_SRC,
 		});
 		assert.equal(result.kind, "remote");
 		assert.equal(result.cloneUrl, "github.example.com:team/repo.git");
@@ -58,99 +59,80 @@ describe("resolveSandboxCloneSource — network remotes", () => {
 	it("classifies an ssh:// origin as a remote", () => {
 		const result = resolveSandboxCloneSource({
 			originUrl: "ssh://git@host/foo.git",
-			repoPath: REPO_ROOT,
+			mountSourcePath: MOUNT_SRC,
 		});
 		assert.equal(result.kind, "remote");
 		assert.ok(/^ssh:\/\//.test(result.cloneUrl));
 	});
 });
 
-describe("resolveSandboxCloneSource — absent origin (mount the declared repo)", () => {
+describe("resolveSandboxCloneSource — absent origin (mount the supplied source)", () => {
 	for (const [label, originUrl] of [
 		["undefined", undefined],
 		["null", null],
 		["empty string", ""],
 	] as const) {
-		it(`mounts the project repo when origin is ${label}`, () => {
-			const result = resolveSandboxCloneSource({ originUrl, repoPath: REPO_ROOT });
+		it(`mounts mountSourcePath when origin is ${label}`, () => {
+			const result = resolveSandboxCloneSource({ originUrl, mountSourcePath: MOUNT_SRC });
 			assert.equal(result.kind, "mounted");
-			assert.equal((result as { hostPath: string }).hostPath, REPO_ROOT);
+			assert.equal((result as { hostPath: string }).hostPath, MOUNT_SRC);
 			assert.equal((result as { mountPath: string }).mountPath, "/workspace-src");
 			assert.equal(result.cloneUrl, "file:///workspace-src");
 		});
 	}
 
 	it("NEVER emits a raw host path or drive-letter as the clone URL", () => {
-		const repoPath = process.platform === "win32" ? "C:/Users/jsubr/proj" : "/home/dev/proj";
-		const result = resolveSandboxCloneSource({ originUrl: undefined, repoPath });
-		assert.notEqual(result.cloneUrl, repoPath);
+		const mountSourcePath = process.platform === "win32" ? "C:/Users/jsubr/proj" : "/home/dev/proj";
+		const result = resolveSandboxCloneSource({ originUrl: undefined, mountSourcePath });
+		assert.notEqual(result.cloneUrl, mountSourcePath);
 		assert.ok(
 			!/^[A-Za-z]:/.test(result.cloneUrl),
 			`cloneUrl must not be a Windows drive-letter path, got: ${result.cloneUrl}`,
 		);
 		assert.equal(result.cloneUrl, "file:///workspace-src");
 	});
-});
 
-describe("resolveSandboxCloneSource — local origins inside the project root", () => {
-	it("mounts a file:// origin that points inside repoPath", () => {
-		const inside = path.join(REPO_ROOT, "sub");
-		const origin = pathToFileURL(inside).href;
-		const result = resolveSandboxCloneSource({ originUrl: origin, repoPath: REPO_ROOT });
-		assert.equal(result.kind, "mounted");
-		assert.equal((result as { hostPath: string }).hostPath, fileURLToPath(origin));
-		assert.equal(result.cloneUrl, "file:///workspace-src");
-		// hostPath must be a real filesystem path, never a file:// URL.
-		assert.ok(!/^file:\/\//i.test((result as { hostPath: string }).hostPath));
-	});
-
-	it("mounts a relative origin resolved against repoPath", () => {
-		const result = resolveSandboxCloneSource({ originUrl: "./vendored", repoPath: REPO_ROOT });
-		assert.equal(result.kind, "mounted");
-		assert.equal((result as { hostPath: string }).hostPath, path.resolve(REPO_ROOT, "./vendored"));
-		assert.equal(result.cloneUrl, "file:///workspace-src");
-	});
-});
-
-describe("resolveSandboxCloneSource — local origins OUTSIDE the project root throw", () => {
-	it("throws for a file:// origin outside repoPath (security)", () => {
-		const outside = process.platform === "win32" ? "C:/some/other/private/repo" : "/some/other/private/repo";
-		const origin = pathToFileURL(outside).href;
-		assert.throws(
-			() => resolveSandboxCloneSource({ originUrl: origin, repoPath: REPO_ROOT }),
-			/outside the project root/,
-		);
-	});
-
-	it("throws for an absolute path origin outside repoPath", () => {
-		const outside = process.platform === "win32" ? "C:/srv/repos/foo.git" : "/srv/repos/foo.git";
-		assert.throws(
-			() => resolveSandboxCloneSource({ originUrl: outside, repoPath: REPO_ROOT }),
-			/outside the project root/,
-		);
-	});
-
-	it("throws (NOT classified as remote) for a Windows drive path not under repoPath", () => {
-		// A bare drive-letter path must be treated as a local path, never as an
-		// scp `host:path` remote (single-letter host). Outside the root → throw.
-		const repoPath = process.platform === "win32" ? "C:/totally/unrelated/root" : "/totally/unrelated/root";
-		assert.throws(
-			() => resolveSandboxCloneSource({ originUrl: "C:/Users/jsubr/foo.git", repoPath }),
-			/outside the project root/,
-		);
-	});
-});
-
-describe("resolveSandboxCloneSource — per-repo mountPath", () => {
 	it("honours a custom mountPath for multi-repo callers", () => {
 		const result = resolveSandboxCloneSource({
 			originUrl: undefined,
-			repoPath: REPO_ROOT,
+			mountSourcePath: MOUNT_SRC,
 			mountPath: "/workspace-src/web",
 		});
 		assert.equal(result.kind, "mounted");
 		assert.equal((result as { mountPath: string }).mountPath, "/workspace-src/web");
 		assert.equal(result.cloneUrl, "file:///workspace-src/web");
-		assert.equal((result as { hostPath: string }).hostPath, REPO_ROOT);
+		assert.equal((result as { hostPath: string }).hostPath, MOUNT_SRC);
+	});
+});
+
+describe("resolveSandboxCloneSource — local origins throw (never mounted, never remote)", () => {
+	for (const [label, origin] of [
+		["file:// URL", "file:///tmp/x.git"],
+		["POSIX absolute path", "/abs/x.git"],
+		["relative path", "./rel"],
+		["Windows drive-letter path", "C:/Users/x.git"],
+	] as const) {
+		it(`throws with a /local path/ message for a ${label}`, () => {
+			assert.throws(
+				() => resolveSandboxCloneSource({ originUrl: origin, mountSourcePath: MOUNT_SRC }),
+				/local path/,
+			);
+		});
+	}
+
+	it("does NOT classify a drive-letter origin as an scp remote", () => {
+		// A bare drive-letter path must be treated as a local path (→ throw),
+		// never as an scp `host:path` remote (single-letter host).
+		let result: unknown;
+		assert.throws(
+			() => {
+				result = resolveSandboxCloneSource({
+					originUrl: "C:/Users/jsubr/foo.git",
+					mountSourcePath: MOUNT_SRC,
+				});
+			},
+			/local path/,
+		);
+		assert.equal(result, undefined);
 	});
 });

--- a/tests/sandbox-init-rejection.test.ts
+++ b/tests/sandbox-init-rejection.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Regression test for the dangling-rejection bug in ProjectSandbox.init().
+ *
+ * `init()` creates a dedicated `_readyPromise` whose only consumer is
+ * `getContainerId()`. When init fails and nobody is concurrently awaiting
+ * `getContainerId()`, the internal `_readyReject!(err)` rejects a promise that
+ * NO ONE is awaiting — even though the awaited `init()` boundary already
+ * observes the same error via `throw err`. That dangling rejection surfaces as
+ * a global `unhandledRejection`, which under load can wedge the gateway for
+ * unrelated sessions.
+ *
+ * This test drives `init()` down its failure path WITHOUT a real Docker daemon
+ * by stubbing the private `_initContainer()` to throw. It awaits `init()`
+ * inside a try/catch (so the awaited boundary observes the error), flushes
+ * timers/microtasks, and asserts that ZERO `unhandledRejection` events fired.
+ *
+ * On the current branch this FAILS because `_readyPromise` is rejected with no
+ * awaiter. After the fix (a no-op `.catch` attached to `_readyPromise`, or
+ * equivalent), it passes.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { ProjectSandbox } from "../src/server/agent/project-sandbox.js";
+
+describe("ProjectSandbox.init() failure does not leak an unhandled rejection", () => {
+	it("does not emit a global unhandledRejection when init fails", async () => {
+		const sandbox = new ProjectSandbox({
+			projectId: "test-rejection-project",
+			projectDir: "/tmp/nonexistent-project",
+			repoUrl: "file:///workspace-src",
+			image: "bobbit-sandbox:nonexistent-test-image",
+		});
+
+		const FORCED = "forced init failure for dangling-rejection test";
+
+		// Stub the private container-init step so we exercise the real init()
+		// failure path deterministically without touching Docker. Assigning to
+		// the instance shadows the prototype method; init() calls
+		// `this._initContainer()` which resolves to this stub.
+		(sandbox as unknown as { _initContainer: () => Promise<void> })._initContainer =
+			async () => {
+				throw new Error(FORCED);
+			};
+
+		const rejections: unknown[] = [];
+		const listener = (reason: unknown) => {
+			rejections.push(reason);
+		};
+		process.on("unhandledRejection", listener);
+
+		try {
+			// The awaited boundary MUST observe the thrown error.
+			let observed: Error | null = null;
+			try {
+				await sandbox.init();
+			} catch (err) {
+				observed = err as Error;
+			}
+			assert.ok(observed, "init() should reject on the awaited path");
+			assert.match(String(observed?.message), new RegExp(FORCED));
+
+			// Flush microtasks + timers so any dangling rejection has a chance to
+			// surface to the global handler.
+			await new Promise((r) => setTimeout(r, 100));
+
+			assert.equal(
+				rejections.length,
+				0,
+				`init() failure leaked ${rejections.length} unhandled rejection(s): ` +
+					rejections.map((r) => (r instanceof Error ? r.message : String(r))).join(", "),
+			);
+		} finally {
+			process.off("unhandledRejection", listener);
+		}
+	});
+});

--- a/tests/sandbox-manager-init-failure.test.ts
+++ b/tests/sandbox-manager-init-failure.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Regression test: a failing sandbox bootstrap/init must not wedge the gateway.
+ *
+ * `SandboxManager.ensureForProject(projectId)` runs the bootstrap closure and,
+ * on success, initialises a ProjectSandbox. The original bug surfaced sandbox
+ * setup failures BOTH on the awaited boundary AND as a dangling global
+ * `unhandledRejection`, which under load could make the gateway unreachable for
+ * unrelated sessions.
+ *
+ * This pins three invariants using a stub bootstrap we control (no Docker):
+ *   (a) the awaited `ensureForProject` call rejects with the bootstrap error;
+ *   (b) NO global `unhandledRejection` fires while/after that failure;
+ *   (c) the manager stays usable — a subsequent `ensureForProject` for a
+ *       different project whose bootstrap returns `null` (sandbox not
+ *       applicable) resolves without throwing.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { SandboxManager, type SandboxBootstrap } from "../src/server/agent/sandbox-manager.js";
+
+describe("SandboxManager.ensureForProject failure isolation", () => {
+	it("rejects on the awaited boundary, leaks no unhandledRejection, and stays usable", async () => {
+		const BOOT_FAIL = "forced bootstrap failure local origin outside project root";
+
+		// Stub bootstrap: throw for the broken project, return null (sandbox not
+		// applicable) for any other project. Never returns real options, so we
+		// never touch Docker.
+		const bootstrap: SandboxBootstrap = async (projectId) => {
+			if (projectId === "broken-project") {
+				throw new Error(BOOT_FAIL);
+			}
+			return null;
+		};
+
+		const manager = new SandboxManager({ bootstrap });
+
+		const rejections: unknown[] = [];
+		const listener = (reason: unknown) => rejections.push(reason);
+		process.on("unhandledRejection", listener);
+
+		try {
+			// (a) The awaited call must reject with the bootstrap error.
+			await assert.rejects(
+				() => manager.ensureForProject("broken-project"),
+				new RegExp(BOOT_FAIL),
+			);
+
+			// Flush microtasks + timers so any dangling rejection can surface.
+			await new Promise((r) => setTimeout(r, 100));
+
+			// (b) No global unhandled rejection from the failed init.
+			assert.equal(
+				rejections.length,
+				0,
+				`failed sandbox init leaked ${rejections.length} unhandled rejection(s): ` +
+					rejections.map((r) => (r instanceof Error ? r.message : String(r))).join(", "),
+			);
+
+			// (c) The manager is still usable for other projects.
+			await assert.doesNotReject(() => manager.ensureForProject("healthy-other-project"));
+			assert.equal(manager.has("healthy-other-project"), false, "null bootstrap registers nothing");
+
+			// And the broken project can be retried (in-flight entry was cleared).
+			await assert.rejects(
+				() => manager.ensureForProject("broken-project"),
+				new RegExp(BOOT_FAIL),
+			);
+			await new Promise((r) => setTimeout(r, 50));
+			assert.equal(rejections.length, 0, "retry must not leak a rejection either");
+		} finally {
+			process.off("unhandledRejection", listener);
+		}
+	});
+});

--- a/tests/sandbox-mount-root.test.ts
+++ b/tests/sandbox-mount-root.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for `resolveSandboxMountRoot` — the helper that picks the canonical
+ * MAIN-repo working directory to bind-mount as the sandbox clone source.
+ *
+ * The regression it guards (Finding B): when the project root is a linked git
+ * worktree, its `.git` is a gitdir-FILE pointing at the MAIN repo's object
+ * store. Bind-mounting + `git clone`ing just the worktree dir fails (objects
+ * aren't present). The helper must resolve the canonical MAIN repo root via
+ * `git rev-parse --git-common-dir` so the mount source is always cloneable.
+ *
+ * Uses real temp git repos (follows tests/base-ref-parse.test.ts patterns).
+ * Run via `node --test --test-force-exit` (npm run test:unit).
+ */
+import { describe, it, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resolveSandboxMountRoot } from "../src/server/skills/git.ts";
+
+const tmpDirs: string[] = [];
+
+function rmDir(p: string): void {
+	try { fs.rmSync(p, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+function git(cwd: string, ...args: string[]): string {
+	return execFileSync("git", args, { cwd, encoding: "utf-8", windowsHide: true }).trim();
+}
+
+function makeTempRepo(): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-mount-root-"));
+	tmpDirs.push(root);
+	git(root, "init", "-q");
+	git(root, "config", "user.email", "test@example.com");
+	git(root, "config", "user.name", "Test");
+	git(root, "config", "commit.gpgsign", "false");
+	git(root, "checkout", "-q", "-b", "master");
+	fs.writeFileSync(path.join(root, "README.md"), "init\n");
+	git(root, "add", "README.md");
+	git(root, "commit", "-q", "-m", "init");
+	return root;
+}
+
+/** realpath, falling back to resolve when the path doesn't exist. */
+function realpath(p: string): string {
+	try {
+		return fs.realpathSync(p);
+	} catch {
+		return path.resolve(p);
+	}
+}
+
+after(() => {
+	for (const d of tmpDirs) rmDir(d);
+});
+
+describe("resolveSandboxMountRoot", () => {
+	it("returns realpath(repoRoot) for a normal (main) repo", async () => {
+		const root = makeTempRepo();
+		const result = await resolveSandboxMountRoot(root);
+		assert.equal(result, realpath(root));
+	});
+
+	it("returns the MAIN repo root for a linked worktree (origin-less regression)", async () => {
+		const main = makeTempRepo();
+		// Place the linked worktree OUTSIDE the main repo so a naive realpath of
+		// the worktree dir would NOT equal the main root.
+		const wtPath = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-mount-wt-"));
+		tmpDirs.push(wtPath);
+		rmDir(wtPath); // `git worktree add` wants to create the dir itself
+		git(main, "worktree", "add", "-q", "-b", "feature/x", wtPath);
+
+		const result = await resolveSandboxMountRoot(wtPath);
+		// Must resolve to the MAIN working tree, NOT the worktree path.
+		assert.equal(result, realpath(main));
+		assert.notEqual(result, realpath(wtPath));
+	});
+
+	it("falls back to a canonicalized path for a non-git directory", async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-mount-nongit-"));
+		tmpDirs.push(dir);
+		const result = await resolveSandboxMountRoot(dir);
+		// Non-git → fallback canonicalizePath(repoPath). On win32 canonicalizePath
+		// lowercases; compare case-insensitively to stay cross-platform.
+		assert.equal(result.toLowerCase(), realpath(dir).toLowerCase());
+	});
+});


### PR DESCRIPTION
## Problem

Docker-sandboxed sessions failed to start for any project without a usable `origin` remote. The repo-URL resolution fell back to the **raw host directory path** as the clone source, which was then handed to `git clone` *inside the Linux container*. On Windows the drive-letter path (`C:/Users/...`) was misparsed by git as scp/SSH syntax (`cannot run ssh` / `unable to fork`); on any OS the host path was unreachable from inside the container. A secondary defect left sandbox-init failures as **dangling promise rejections** caught only by the global `unhandledRejection` handler, which under load could wedge the gateway for unrelated sessions.

## Fix

- **`resolveSandboxCloneSource`** (`src/server/agent/sandbox-clone-source.ts`) — classifies the origin:
  - **Network remote** (https/http/git/ssh/git+ssh/ftp, or scp-style `[user@]host:path`) → cloned directly (tokens stripped; container credential helper uses `GITHUB_TOKEN`).
  - **No origin** → the project's canonical **main repo root** is bind-mounted read-only at `/workspace-src` and cloned via `file:///workspace-src`. Multi-repo uses per-repo `/workspace-src/<repo>`.
  - **Local/`file://`/path origin** → **fails fast** with a clear, actionable error (never bind-mounts an arbitrary host path; never passes a raw/drive-letter path to `git clone`).
- **`resolveSandboxMountRoot`** (`src/server/skills/git.ts`) — resolves the canonical main repo working dir via `git --git-common-dir` + `realpath`, so the mounted clone works even when the project root is a **linked worktree** (whose `.git` is a gitdir-file).
- **Dangling-rejection fix** (`project-sandbox.ts` `init()`) — a no-op `.catch` on `_readyPromise` keeps the rejection "handled" while `getContainerId()`/`init()` still observe and rethrow on the awaited boundary. A failed sandbox init is recorded on the awaited path and never reaches the global handler, so one project's broken sandbox can't wedge the gateway for other sessions.
- **Manual-integration fixtures** are now remote-less, exercising the working absent-origin mounted-clone path.

## Tests

- `tests/sandbox-clone-source.test.ts` — clone-source classification (network incl. scp host-without-user → remote; absent → mounted; local origins throw; drive-letter never treated as scp).
- `tests/sandbox-mount-root.test.ts` — real temp repos: normal repo → realpath(root); linked worktree → main repo root; non-git → canonicalized fallback.
- `tests/sandbox-init-rejection.test.ts` + `tests/sandbox-manager-init-failure.test.ts` — failed init rejects on the awaited boundary, emits zero global `unhandledRejection`, and the manager stays usable for other projects.

Full build, type-check, unit (1261), and E2E suites pass.

## Docs

`docs/internals.md` — new "Sandbox clone source" subsection (resolution outcomes, linked-worktree rationale, init failure isolation).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
