### PR TITLE
Shrink main UI bundle under 600 KB raw budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ npm run build     # compile server + bundle UI
 npm start         # start gateway on :3001
 ```
 
-The UI build enforces a **600 kB gzipped budget** on the main `index-*.js` chunk (and 500 kB per non-worker chunk) via `tests/bundle-size.test.ts`. Run `npm run test:bundle` to build and assert in one shot. See [docs/design/ui-bundle-size-reduction.md](docs/design/ui-bundle-size-reduction.md) for the route-splitting and lazy-loading patterns that keep the bundle small.
+The UI build enforces bundle budgets via `tests/bundle-size.test.ts`: the main `index-*.js` chunk ≤ **250 kB gzipped**, every non-worker chunk ≤ **200 kB gzipped**, and no non-worker chunk over **600 kB raw** (which pins Vite's `chunkSizeWarningLimit`). Run `npm run test:bundle` to build and assert in one shot. See [docs/design/ui-bundle-size-reduction.md](docs/design/ui-bundle-size-reduction.md) for the route-splitting and lazy-loading patterns that keep the bundle small.
 
 ### From global install
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1058,8 +1058,7 @@ If the popup window closes without the UI advancing, poll `GET /api/oauth/flow-s
 
 ## Bundle-size assertion fails
 
-`tests/bundle-size.test.ts` reads `dist/ui/.vite/manifest.json` to find the entry chunk and asserts ≤ 600 kB gzipped, plus ≤ 500 kB gzipped for any non-worker chunk. Check `dist/ui/.vite/manifest.j
- manifest.json` exists; ensure `npm run build:ui` ran first; the test reads gzipped sizes directly from `dist/ui/assets/`. The `pdf.worker.min-*.mjs` chunk is whitelisted. See [docs/design/ui-bundle-size-reduction.md](design/ui-bundle-size-reduction.md).
+`tests/bundle-size.test.ts` reads `dist/ui/.vite/manifest.json` to find the entry chunk and enforces three budgets: entry ≤ 250 kB gzipped, any non-worker chunk ≤ 200 kB gzipped, and no non-worker chunk > 600 kB raw (the raw guard pins Vite's `chunkSizeWarningLimit: 600`). Ensure `dist/ui/.vite/manifest.json` exists (`npm run build:ui` first — the test is skipped when `dist/ui` is absent); sizes are read directly from `dist/ui/assets/`. The `pdf.worker.min-*.mjs` chunk is whitelisted. Run the build-then-assert in one shot with `npm run test:bundle`. **Raw-guard regression?** The usual cause is the app-shell SCC growing back past 600 kB raw — split a stable app seam into its own chunk via `manualChunks` rather than raising the budget. Profile with [docs/perf/bundle-profile.md](perf/bundle-profile.md); see the bundle-shrink history in [docs/design/ui-bundle-size-reduction.md](design/ui-bundle-size-reduction.md) → [shrink-initial-bundle.md](design/shrink-initial-bundle.md) → [shrink-main-ui-manualchunks.md](design/shrink-main-ui-manualchunks.md).
 
 ## Markdown not rendering in chat / proposal panel
 

--- a/docs/design/shrink-initial-bundle.md
+++ b/docs/design/shrink-initial-bundle.md
@@ -2,6 +2,13 @@
 
 Status: shipped (HEAD `ed850b65`)  •  Goal branch: `goal/shrink-ini-cf48655b`  •  Author: team-lead
 
+> **Follow-up:** a later pass —
+> [`shrink-main-ui-manualchunks.md`](./shrink-main-ui-manualchunks.md)
+> (HEAD `11278c43`) — peeled the app-shell SCC (`session-manager`,
+> `remote-agent`, PR-walkthrough, review, inbox) out of the entry chunk
+> with four more app-seam `manualChunks` rules after it crept back over
+> the 600 KB raw budget. Packaging-only; no lazy deferral.
+
 ## Outcome
 
 All planned tasks shipped. `npm run build:ui` now emits **no chunk-size

--- a/docs/design/shrink-main-ui-manualchunks.md
+++ b/docs/design/shrink-main-ui-manualchunks.md
@@ -96,5 +96,4 @@ that point is the refactor, not raising the budget.
   budget-bump policy.
 - `vite.config.ts` — `build.rollupOptions.output.manualChunks`, where
   the app-seam and vendor rules live.
-</content>
-</invoke>
+

--- a/docs/design/shrink-main-ui-manualchunks.md
+++ b/docs/design/shrink-main-ui-manualchunks.md
@@ -1,0 +1,100 @@
+# Shrink main UI bundle — `manualChunks` app-seam split
+
+Status: shipped (HEAD `11278c43`)  •  Goal branch: `goal/shrink-main-ui-14713901`  •  Date: 2026-06-02
+
+Third pass in the UI bundle-shrink narrative, after
+[`ui-bundle-size-reduction.md`](./ui-bundle-size-reduction.md) (route
+splitting, lazy MarkdownBlock/renderers/pdfjs) and
+[`shrink-initial-bundle.md`](./shrink-initial-bundle.md) (lazy pi-ai
+catalog, highlight.js core, qrcode/jszip, vendor `manualChunks`).
+
+## What & why
+
+The entry chunk had crept back to **638.39 KB raw**, tripping the
+`tests/bundle-size.test.ts` raw-size guard (assertion #3, which pins
+Vite's `chunkSizeWarningLimit: 600`) and re-emitting the
+`(!) Some chunks are larger than 600 kB after minification.` warning.
+
+This was a **packaging** problem, not a code-size problem: the entry
+chunk had become the app-shell **strongly-connected component (SCC)** —
+`render.ts` ↔ `sidebar.ts` ↔ `AgentInterface.ts` ↔ `session-manager.ts`
+↔ `remote-agent.ts` and friends all import each other, so Rollup
+cannot split them by reachability and collapses the whole cycle into
+one chunk. Lazy-loading any single module does nothing while the cycle
+is intact — its earliest static importer drags it back into entry.
+
+The fix peels stable **app seams** out of that chunk with four new
+`build.rollupOptions.output.manualChunks` rules in `vite.config.ts`,
+joining the three app-seam rules (`app-message-reducer`,
+`app-panel-workspace`, `app-routing`) and the vendor rules already
+there:
+
+| New chunk | Modules pinned |
+|---|---|
+| `app-session-runtime` | `src/app/session-manager.ts`, `src/app/remote-agent.ts` |
+| `app-pr-walkthrough` | `src/app/pr-walkthrough.ts` |
+| `app-review` | `src/app/review-sources.ts`, `src/app/preview-panel.ts`, `src/ui/components/review/{ReviewPane,AnnotationStore}.ts` |
+| `app-inbox` | `src/ui/inbox/{InboxPanel,AddToInboxDialog,InboxEntry}.ts` |
+
+### Why `manualChunks`, not lazy-loading
+
+These modules are part of the eager import graph — the app needs them
+on first paint, and several sit inside the import cycle, so there is no
+clean "load on user action / route boundary" seam to defer them behind.
+`manualChunks` carves them into separate hashed files **without
+changing the import graph**: the entry chunk still statically imports
+them, `modulePreload` covers the extra requests, and the browser
+fetches them in parallel. This is a **packaging / caching change, not
+lazy deferral** — there is no behavioral change, no new `ensure*`
+upgrade seam, and no flash-of-unupgraded-element risk.
+
+## Result (as of this pass)
+
+| Chunk | Before | After |
+|---|---|---|
+| Entry `index-*.js` | 638.39 KB raw | **32.50 KB raw** |
+| `app-session-runtime-*.js` (the SCC) | (in entry) | **560.45 KB raw / 149.93 KB gz** |
+
+The entry chunk now holds little more than the bootstrap glue; the
+app-shell SCC lives in `app-session-runtime`, comfortably under both
+the 600 KB raw guard and the 200 KB-gz per-chunk guard. Don't treat
+these byte counts as eternal truth — the regression guard
+(`npm run test:bundle`) is the spec; re-run it after any UI change to
+get current numbers.
+
+## The floor: ~560 KB raw without a source refactor
+
+`app-session-runtime` is the SCC itself, so it **cannot be split
+finer** by `manualChunks` alone. Attempting to peel its members into
+separate chunks makes Rollup emit a `Circular chunk` warning and fold
+them back together, because each member statically imports the others.
+Going below ~560 KB raw therefore requires a **source-level cycle
+refactor** (break the `render`/`sidebar`/`AgentInterface`/`session`
+import cycle so the pieces become independently reachable) — out of
+scope for a packaging-only pass. Until then, ~560 KB raw is the floor,
+and the 600 KB raw budget leaves only modest headroom: a future
+regression that grows the SCC will trip the guard, and the answer at
+that point is the refactor, not raising the budget.
+
+## Verification
+
+- `npm run test:bundle` — builds the UI then runs
+  `tests/bundle-size.test.ts`; all three budget assertions pass (entry
+  ≤ 250 KB gz, per-chunk ≤ 200 KB gz, no non-worker chunk > 600 KB
+  raw).
+- `npm run build:ui` emits no chunk-size warning.
+- No functional change: `npm run check`, `npm run test:unit`,
+  `npm run test:e2e` stay green; the lazy-widget upgrade paths are
+  untouched.
+
+## See also
+
+- [`docs/perf/bundle-profile.md`](../perf/bundle-profile.md) — how to
+  profile the bundle and find the next offender; the app-seam
+  `manualChunks` rule is the lever this pass used.
+- `tests/bundle-size.test.ts` — the regression guard and its
+  budget-bump policy.
+- `vite.config.ts` — `build.rollupOptions.output.manualChunks`, where
+  the app-seam and vendor rules live.
+</content>
+</invoke>

--- a/docs/design/ui-bundle-size-reduction.md
+++ b/docs/design/ui-bundle-size-reduction.md
@@ -23,7 +23,7 @@ Follow-on bug fixes during stabilisation:
 
 A pre-existing PWA-resume cold-offline test was skipped (verified flaky on `master` at `94143ba8`) and is tracked separately.
 
-**Follow-up:** a second pass landed in [shrink-initial-bundle.md](./shrink-initial-bundle.md) (HEAD `ed850b65`) that dropped the entry chunk further to ~150 kB gz and the artifacts chunk to ~44 kB gz — lazy `pi-ai` catalog, `highlight.js` core + lazy grammars, lazy `qrcode` / `jszip`, vendor-chunk split, and a proposal-panels extraction.
+**Follow-up:** a second pass landed in [shrink-initial-bundle.md](./shrink-initial-bundle.md) (HEAD `ed850b65`) that dropped the entry chunk further to ~150 kB gz and the artifacts chunk to ~44 kB gz — lazy `pi-ai` catalog, `highlight.js` core + lazy grammars, lazy `qrcode` / `jszip`, vendor-chunk split, and a proposal-panels extraction. A third pass — [shrink-main-ui-manualchunks.md](./shrink-main-ui-manualchunks.md) (HEAD `11278c43`) — later peeled the app-shell SCC out of the entry chunk with app-seam `manualChunks` rules after it regressed past the 600 kB raw budget.
 
 ## Problem
 

--- a/docs/perf/bundle-profile.md
+++ b/docs/perf/bundle-profile.md
@@ -155,5 +155,5 @@ a literal specifier per entry.
   pass that introduced route splitting, lazy MarkdownBlock, etc.
 - `docs/design/shrink-main-ui-manualchunks.md` — the app-seam
   `manualChunks` pass that split the app-shell SCC out of the entry
-  chunk (the lever in "When lazy-loading can't help" below).
+  chunk (the lever in "When lazy-loading can't help" above).
 - `docs/dev-workflow.md` — cross-linked from the dev-workflow guide.

--- a/docs/perf/bundle-profile.md
+++ b/docs/perf/bundle-profile.md
@@ -105,6 +105,30 @@ provider SDK chunks pi-ai emits (`mistral-*.js`, `google-shared-*.js`,
 etc.) — they're already on a dynamic-import boundary inside the
 package and only load when the user selects that provider.
 
+## When lazy-loading can't help (the SCC case)
+
+Sometimes the biggest rectangle in the entry chunk is not one
+heavy module but a **cycle** of app-shell modules that import each
+other (`render` ↔ `sidebar` ↔ `AgentInterface` ↔ `session-manager`
+↔ `remote-agent`, …). Rollup cannot split a strongly-connected
+component by reachability, so it collapses the whole cycle into one
+chunk. Converting any single member to `await import()` does nothing —
+its earliest static importer drags it right back in.
+
+The lever here is **app-seam `manualChunks`**: pin stable members (or
+whole feature seams like PR-walkthrough, review, inbox) into named
+chunks in `build.rollupOptions.output.manualChunks`. This is a
+packaging change, not lazy deferral — the modules stay in the eager
+import graph and `modulePreload` covers the extra parallel requests, so
+there is no behavioral change. It shrinks the entry chunk without
+touching source.
+
+The floor is the SCC itself: you cannot split a cycle finer than its
+members (Rollup emits a `Circular chunk` warning and folds them back
+together). Going below that requires a source-level refactor to break
+the import cycle. See
+[`docs/design/shrink-main-ui-manualchunks.md`](../design/shrink-main-ui-manualchunks.md).
+
 ## Adding a per-language chunk emission
 
 `src/ui/tools/highlight-core.ts` uses a static `LAZY_GRAMMARS` map so
@@ -129,4 +153,7 @@ a literal specifier per entry.
   the current set of lazy-load boundaries.
 - `docs/design/ui-bundle-size-reduction.md` — the earlier reduction
   pass that introduced route splitting, lazy MarkdownBlock, etc.
+- `docs/design/shrink-main-ui-manualchunks.md` — the app-seam
+  `manualChunks` pass that split the app-shell SCC out of the entry
+  chunk (the lever in "When lazy-loading can't help" below).
 - `docs/dev-workflow.md` — cross-linked from the dev-workflow guide.

--- a/tests/bundle-size.test.ts
+++ b/tests/bundle-size.test.ts
@@ -2,9 +2,11 @@
  * Bundle-size regression guard for the UI build.
  *
  * Asserts that:
- *   - the main `index-*.js` chunk is ≤ 600 KB gzipped
- *   - no non-worker `.js`/`.mjs` chunk exceeds 500 KB gzipped, except
- *     the unavoidable `pdf.worker.min-*.mjs` chunk.
+ *   - the main `index-*.js` chunk is ≤ 250 KB gzipped
+ *   - no non-worker `.js`/`.mjs` chunk exceeds 200 KB gzipped, except
+ *     the unavoidable `pdf.worker.min-*.mjs` chunk
+ *   - no non-worker `.js`/`.mjs` chunk exceeds 600 KB raw (pins Vite's
+ *     `chunkSizeWarningLimit: 600`).
  *
  * Reads chunks from `dist/ui/assets/` and gzips each via `node:zlib`.
  * **Does not run a build itself** — that would double CI time. The test

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -369,6 +369,23 @@ export default defineConfig(({ mode }) => ({
 					if (normalizedId.endsWith("/src/app/message-reducer.ts")) return "app-message-reducer";
 					if (normalizedId.endsWith("/src/app/panel-workspace.ts")) return "app-panel-workspace";
 					if (normalizedId.endsWith("/src/app/routing.ts")) return "app-routing";
+					// Additional stable app seams peeled out of the entry chunk to keep
+					// its raw size under the 600 KB budget (see tests/bundle-size.test.ts).
+					// These stay in the eager import graph (entry chunk imports them);
+					// modulePreload covers the extra requests. Packaging change only.
+					if (normalizedId.endsWith("/src/app/session-manager.ts") || normalizedId.endsWith("/src/app/remote-agent.ts")) return "app-session-runtime";
+					if (normalizedId.endsWith("/src/app/pr-walkthrough.ts")) return "app-pr-walkthrough";
+					if (
+						normalizedId.endsWith("/src/app/review-sources.ts") ||
+						normalizedId.endsWith("/src/app/preview-panel.ts") ||
+						normalizedId.endsWith("/src/ui/components/review/ReviewPane.ts") ||
+						normalizedId.endsWith("/src/ui/components/review/AnnotationStore.ts")
+					) return "app-review";
+					if (
+						normalizedId.endsWith("/src/ui/inbox/InboxPanel.ts") ||
+						normalizedId.endsWith("/src/ui/inbox/AddToInboxDialog.ts") ||
+						normalizedId.endsWith("/src/ui/inbox/InboxEntry.ts")
+					) return "app-inbox";
 					if (!normalizedId.includes("node_modules")) return;
 					if (normalizedId.includes("/@sinclair/typebox/")) return "vendor-typebox";
 					if (normalizedId.includes("/marked")) return "vendor-marked";


### PR DESCRIPTION
## Summary

The main UI entry chunk had regressed to **638.39 KB raw**, tripping `tests/bundle-size.test.ts` (the 600 KB raw per-chunk budget, which pins Vite's `chunkSizeWarningLimit: 600`) and re-emitting the "chunks larger than 600 kB" build warning. This was a **packaging** problem: the entry chunk had become the app-shell strongly-connected component (`render` ↔ `sidebar` ↔ `AgentInterface` ↔ `session-manager` ↔ `remote-agent`), which Rollup cannot split by reachability.

## Change

Single production change in `vite.config.ts` — four new `build.rollupOptions.output.manualChunks` app-seam rules (same pattern as the existing `app-message-reducer`/`app-panel-workspace`/`app-routing` splits):

| New chunk | Modules |
|---|---|
| `app-session-runtime` | `session-manager.ts`, `remote-agent.ts` |
| `app-pr-walkthrough` | `pr-walkthrough.ts` |
| `app-review` | `review-sources.ts`, `preview-panel.ts`, `ReviewPane.ts`, `AnnotationStore.ts` |
| `app-inbox` | `InboxPanel.ts`, `AddToInboxDialog.ts`, `InboxEntry.ts` |

This is a packaging/caching change, **not lazy deferral** — modules stay in the eager import graph (`modulePreload` covers the extra requests), so there is no behavioral change and no flash-of-unupgraded-element risk. The eager `BgProcessPill` import and `ensure*` lazy-widget pattern are untouched.

## Results

- Entry chunk `index-*.js`: **638.39 KB raw → 32.50 KB raw**.
- The app-shell SCC now lives in `app-session-runtime` = **560.45 KB raw / 149.93 KB gz** — under both the 600 KB raw and 200 KB gz per-chunk budgets.
- No "chunks larger than 600 kB" warning; no Rollup "Circular chunk" warning.
- ~560 KB raw is the floor without a source-level cycle refactor (documented in `docs/design/shrink-main-ui-manualchunks.md`).

## Verification

- `npm run test:bundle` — all budget assertions pass.
- `npm run check` clean; `npm run test:unit` + `npm run test:e2e` green (no init-order regression).
- Console-clean smoke of the built app (no init-order/undefined-export errors; bg-process pill upgraded).
- No budget constants changed; `chunkSizeWarningLimit` stays 600; no new deps.

## Docs

New `docs/design/shrink-main-ui-manualchunks.md`; updated `README.md`, `docs/perf/bundle-profile.md`, `docs/debugging.md`, and the bundle-shrink narrative docs to reflect the current 250/200/600 budgets.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)