### PR TITLE
Fix sandbox session startup on remote-less projects

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim
+FROM node:22-slim
 
 # Install build tools, git, curl, gh CLI, ripgrep.
 #
@@ -111,7 +111,7 @@ LABEL bobbit.pi-ai-bedrock-ua-patch=1
 # Must run as root (before USER node) to write to /usr/local/lib/node_modules/.
 RUN npm install -g typescript --no-audit --no-fund 2>/dev/null
 
-# Run as non-root user. node:20-slim includes a 'node' user (uid=1000).
+# Run as non-root user. node:22-slim includes a 'node' user (uid=1000).
 # This ensures files created in /workspace via bind mount are owned by uid=1000
 # on the host, matching typical developer user IDs.
 USER node

--- a/src/server/agent/project-sandbox.ts
+++ b/src/server/agent/project-sandbox.ts
@@ -850,15 +850,21 @@ export class ProjectSandbox {
 		// (defense-in-depth — auth is via the GITHUB_TOKEN credential helper).
 		const repoUrl = this.options.cloneSource?.cloneUrl ?? stripTokenFromGitUrl(this.options.repoUrl);
 
+		// Mark all paths as safe for git BEFORE cloning. When the clone source is a
+		// `file://` bind-mount (remote-less project — see resolveSandboxCloneSource),
+		// the mounted source repo is owned by the host UID, not the container `node`
+		// user, so git's dubious-ownership guard rejects the clone
+		// ("fatal: detected dubious ownership in repository at '/workspace-src/.git'")
+		// unless safe.directory is configured first. The multi-repo init path
+		// (`_runInitSequenceMultiRepo`) already orders this before its clones.
+		await this._dockerExec(this.containerId, ["git", "config", "--global", "--add", "safe.directory", "*"]);
+
 		// Clone the repo
 		console.log(`[project-sandbox] Cloning ${repoUrl} into /workspace...`);
 		await this._dockerExec(this.containerId, ["git", "clone", repoUrl, "."], {
 			cwd: "/workspace",
 			timeout: 120_000,
 		});
-
-		// Mark /workspace-wt as safe for git
-		await this._dockerExec(this.containerId, ["git", "config", "--global", "--add", "safe.directory", "*"]);
 
 		// npm ci if package-lock.json exists
 		try {


### PR DESCRIPTION
## Summary

Fixes two follow-on blockers to the sandbox clone-source work that prevented Docker-sandboxed sessions from starting for **projects without an `origin` remote** (which clone from a `file://` bind-mount of the host repo). On this Windows host, every sandboxed manual-integration test failed; isolating the gateway/container errors surfaced three sequential blockers — the first was already fixed on `master` (clone-source resolution), and this PR fixes the remaining two.

## Changes

### 1. `safe.directory` ordering (`src/server/agent/project-sandbox.ts`)
The single-repo init sequence configured `git config --global --add safe.directory *` **after** the clone. The `file:///workspace-src` clone reads the bind-mounted source repo, which is owned by the host UID (not the container `node` user), so git rejected it:

```
fatal: detected dubious ownership in repository at '/workspace-src/.git'
fatal: Could not read from remote repository.
```

Move the `safe.directory` config **before** the clone — matching the multi-repo init path (`_runInitSequenceMultiRepo`), which already ordered it correctly.

### 2. Sandbox image Node version (`docker/Dockerfile`)
The agent image was built `FROM node:20-slim`, but `pi-coding-agent@0.77`'s bundled `undici` requires a newer-Node API (`webidl.util.markAsUncloneable`), so the agent CLI crashed on startup inside the container:

```
TypeError: webidl.util.markAsUncloneable is not a function
    at new CacheStorage (.../undici/lib/web/cache/cachestorage.js:20:17)
[rpc-bridge] Agent process exited (code 1)
```

Bump to `node:22-slim` — the base `docker/README.md` already referenced as expected. Verified the rebuilt image runs Node v22.22.3 and loads `undici` cleanly.

## Verification

- Isolated repro: a sandboxed session now **reaches idle** (`status=idle` ~11s after create).
- `npm run test:manual -- --grep "create sessions and send messages"` — the `session-resilience` test (incl. the sandboxed variation) **passes**.
- `npm run test:e2e` — green (1128 passed, 1 quarantined-flaky, 6 skipped).
- `npm run check` — clean.

## Notes / out of scope

- `npm run test:unit` has one **pre-existing** failure unrelated to this PR: `bundle-size.test.ts` (`index` chunk 623 KB > 600 KB budget), introduced by recent PR-walkthrough UI growth on `master`. This diff is server-only and does not affect the web bundle.
- Two manual tests (`agent-tool-use` bash tool, `sandbox-recovery-frame-continuity`) still fail intermittently, but that is now transient `docker run` flakiness under load + the container kill/recover path — no longer the deterministic clone/Node blockers fixed here.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
