### PR TITLE
test(manual): fix two consistently-failing manual-integration canaries

### DIFF
--- a/tests/manual-integration/agent-tool-use.spec.ts
+++ b/tests/manual-integration/agent-tool-use.spec.ts
@@ -624,8 +624,14 @@ test.describe.serial("Agent tool use", () => {
 	test("4. interrupt mid tool-use — pivot", async ({ page }) => {
 		const id = await createFreshSession(gw);
 
-		// Kick off a long-running bash command. Use a portable node one-liner
-		// to avoid POSIX/Windows shell quoting traps inside the prompt.
+		// Kick off a long-running bash command. Use a BOUNDED shell loop (not an
+		// infinite one): a never-terminating command combined with "don't reply
+		// until it finishes" is a contradiction that current models resolve by
+		// declining to call bash at all (turn ends idle, zero tool cards) — which
+		// is exactly the false-negative this canary used to suffer. A finite
+		// ~2-minute loop runs long enough for us to interrupt mid-execution while
+		// reading as a legitimate task the model will actually run. The sandbox
+		// shell is Linux bash, so a `for`/`sleep` loop needs no node/quoting gymnastics.
 		await page.goto(sessionUrl(gw, id));
 		await page.waitForSelector("textarea", { timeout: 30_000 });
 		await page.waitForTimeout(500);
@@ -633,9 +639,9 @@ test.describe.serial("Agent tool use", () => {
 		// long-running bash invocation (not any prior or later card).
 		const loopTag = `LOOPTAG_${Math.random().toString(36).slice(2, 10).toUpperCase()}`;
 		const longPrompt =
-			`Use the bash tool exactly once to run this command (do not modify it):\n` +
-			`bash -c 'node -e "let i=0;setInterval(()=>{require(\\"fs\\").writeFileSync(\\"step.txt\\",String(++i));console.log(\\"${loopTag}\\",i)},1000)"'\n` +
-			`Do not reply or summarise until the command finishes.`;
+			`Use the bash tool exactly once to run this command verbatim (do not modify it):\n` +
+			`bash -c 'for i in $(seq 1 120); do echo "${loopTag} $i"; sleep 1; done'\n` +
+			`It prints progress once a second for about two minutes. Start it now and let it run — do not summarise or reply while it is still running.`;
 		await page.fill("textarea", longPrompt);
 		await page.press("textarea", "Enter");
 

--- a/tests/manual-integration/sandbox-recovery-frame-continuity.spec.ts
+++ b/tests/manual-integration/sandbox-recovery-frame-continuity.spec.ts
@@ -121,7 +121,21 @@ function api(gw: GW, path: string, opts: RequestInit = {}) {
 	});
 }
 
-async function pollIdle(gw: GW, id: string, ms = 180_000) {
+/**
+ * Poll until the session reports `idle`.
+ *
+ * `tolerateTransientTermination` is the load-bearing knob for the
+ * post-recovery wait. After `docker rm -f` kills the project container, the
+ * agent subprocess exits (code 137) and the session legitimately transitions
+ * to `terminated`. `recoverSandboxSessions` then recreates the container
+ * (~10-15s: container create + repo clone) and respawns the agent in place,
+ * bringing the session back to `idle`. During that window `terminated` is the
+ * EXPECTED state, not a failure — so callers waiting for recovery must keep
+ * polling through it and only give up on the overall timeout (or a hard
+ * `error`/`archived`). The pre-kill calls leave this off so a session that
+ * dies before we even start is still caught immediately.
+ */
+async function pollIdle(gw: GW, id: string, ms = 180_000, opts: { tolerateTransientTermination?: boolean } = {}) {
 	const t0 = Date.now();
 	while (Date.now() - t0 < ms) {
 		const res = await api(gw, `/api/sessions/${id}`);
@@ -129,8 +143,9 @@ async function pollIdle(gw: GW, id: string, ms = 180_000) {
 		const s = await res.json();
 		if (s.status === "idle") return s;
 		if (s.status === "archived") throw new Error(`Session ${id} archived`);
-		if (s.status === "error" || s.status === "terminated") {
-			throw new Error(`Session ${id} ${s.status}${s.restoreError ? `: ${s.restoreError}` : ""}`);
+		if (s.status === "error") throw new Error(`Session ${id} error${s.restoreError ? `: ${s.restoreError}` : ""}`);
+		if (s.status === "terminated" && !opts.tolerateTransientTermination) {
+			throw new Error(`Session ${id} terminated${s.restoreError ? `: ${s.restoreError}` : ""}`);
 		}
 		await new Promise(r => setTimeout(r, 1_000));
 	}
@@ -353,25 +368,34 @@ test("sandbox-recovery preserves WS frame continuity (seq + statusVersion carry 
 		console.log(`  Killing container ${containerId.substring(0, 12)} …`);
 		execFileSync("docker", ["rm", "-f", containerId], { timeout: 15_000, stdio: "ignore" });
 
-		// 6. Wait for sandbox-status to report available again (server respawns container)
+		// 6. Confirm Docker itself is still healthy. NOTE: /api/sandbox-status
+		//    only reflects the Docker daemon + agent image — NOT whether THIS
+		//    project's container has been recreated or its sessions respawned.
+		//    Because `docker rm -f` only removes the project container (the daemon
+		//    stays up), this flips back to `available` almost immediately and is
+		//    therefore NOT a recovery signal — step 7 owns the real wait.
 		{
 			const t0 = Date.now();
-			let recovered = false;
+			let dockerHealthy = false;
 			while (Date.now() - t0 < 180_000) {
 				try {
 					const r = await (await api(gw, "/api/sandbox-status")).json();
-					if (r.available) { recovered = true; break; }
+					if (r.available) { dockerHealthy = true; break; }
 				} catch {}
 				await new Promise(r => setTimeout(r, 2_000));
 			}
-			expect(recovered).toBe(true);
-			console.log(`  Sandbox container recovered in ${Math.round((Date.now() - t0))}ms`);
+			expect(dockerHealthy).toBe(true);
+			console.log(`  Docker healthy after kill in ${Math.round((Date.now() - t0))}ms`);
 		}
 
-		// 7. Wait for the session to come back to idle. recoverSandboxSessions
-		//    respawns the agent and broadcasts a fresh "idle" status — this is
-		//    EXACTLY the frame the bug used to drop.
-		await pollIdle(gw, sessionId, 180_000);
+		// 7. Wait for the session to come back to idle. After the kill the agent
+		//    subprocess exits (code 137) and the session legitimately sits in
+		//    `terminated` for ~10-15s while recoverSandboxSessions recreates the
+		//    container (create + repo clone) and respawns the agent in place,
+		//    broadcasting a fresh "idle" status — EXACTLY the frame the bug used to
+		//    drop. Tolerate the transient `terminated` here; the overall timeout
+		//    (not the first terminated sample) is the real failure condition.
+		await pollIdle(gw, sessionId, 180_000, { tolerateTransientTermination: true });
 		console.log("  Session API status: idle (post-recovery) ✓");
 
 		// Brief settle so any post-recovery status frames have a chance to arrive.


### PR DESCRIPTION
## Summary

Fixes two manual-integration canaries that were failing consistently (not flakily) on `npm run test:manual`. Both were **test bugs** — the underlying product behaviour is correct in both cases.

## `sandbox-recovery-frame-continuity`

The post-recovery wait gated on `/api/sandbox-status.available`, which only reflects the **Docker daemon + agent image** — *not* whether the project container was recreated or its sessions respawned. Because `docker rm -f` only removes the project container (the daemon stays up), that endpoint flipped back to `available` in ~1s. `pollIdle` then threw on the session's **expected** transient `terminated` state (agent subprocess exits with code 137 when the container dies) — before `recoverSandboxSessions` respawned it ~10–15s later.

I verified the product path is healthy: after recovery the session returns to `idle` and seq/statusVersion carry forward (24→36, 7→13), so the original dropped-events fix this test guards is intact.

Fix:
- `pollIdle` gains a `tolerateTransientTermination` option; the post-recovery wait tolerates the transient `terminated` and only fails on the overall timeout (or a hard `error`/`archived`). Pre-kill calls stay strict.
- Step 6 comment corrected — `/api/sandbox-status` is a Docker-health check, not a recovery signal; step 7 owns the real wait.

## `agent-tool-use` #4 (interrupt mid tool-use — pivot)

Diagnostic showed `status=idle, cards=0` — the model never invoked bash. The prompt asked it to run an **infinite** `setInterval` loop *and* "do not reply until the command finishes" — a contradiction the current model resolves by simply not running it. Replaced with a **bounded** ~2-minute `for`/`sleep` bash loop that still carries the unique sentinel and runs long enough to interrupt mid-execution.

## Verification

- `sandbox-recovery-frame-continuity`: passes cleanly (container recovered, post-recovery turn advances frames).
- `agent-tool-use` #4: passes 3/3 consecutive runs.
- `npm run check`: clean.

## Note (follow-up, not in this PR)

Surfaced a latent environmental hazard: the global Docker network `bobbit-sandbox-net` is shared across all gateways on a machine and removed unconditionally on shutdown, so concurrent gateways (e.g. dev server + manual test) can race and hit `network bobbit-sandbox-net not found` at container startup. Worth hardening separately (per-gateway network names or ref-counted teardown).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
