### PR TITLE
Portable test recipes (--reporter=line)

### DIFF
--- a/defaults/roles/team-lead.yaml
+++ b/defaults/roles/team-lead.yaml
@@ -139,7 +139,7 @@ promptTemplate: |
   Gates with `format: command` (e.g. reproducing-test, test-results) have special semantics:
   - Content must be a raw shell command — no markdown, no backticks, no prose
   - It will be substituted into `{{command}}` in verification scripts
-  - Example: `npx playwright test tests/e2e/my-test.spec.ts --reporter=json 2>/dev/null | node scripts/test-filter.mjs`
+  - Example: `npx playwright test tests/e2e/my-test.spec.ts --reporter=line`
 
   ### Verification execution context
   The verification harness runs the command in the **goal's worktree** (`goal.cwd`), using Git Bash on Windows — specifically, from the goal branch's current HEAD. The command does NOT run on agent sub-branches.

--- a/defaults/tools/shell/bash.yaml
+++ b/defaults/tools/shell/bash.yaml
@@ -156,11 +156,10 @@ detail_docs: >-
   bash(command="npm run check")
 
 
-  # Run E2E tests with filtered output
+  # Run E2E tests (line reporter — readable, gate_inspect-friendly)
 
   bash(command="npm run build:server && npx playwright test --config
-  playwright-e2e.config.ts --reporter=json 2>/dev/null | node
-  scripts/test-filter.mjs")
+  playwright-e2e.config.ts --reporter=line")
 
 
   # Search for all usages of a function across the codebase
@@ -186,8 +185,7 @@ detail_docs: >-
 
   # Run a specific test file with timeout
 
-  bash(command="npx playwright test tests/e2e/tools-api.spec.ts --reporter=json
-  2>/dev/null | node scripts/test-filter.mjs", timeout=120)
+  bash(command="npx playwright test tests/e2e/tools-api.spec.ts --reporter=line", timeout=120)
 
   ```
 

--- a/defaults/workflow-authoring-guide.md
+++ b/defaults/workflow-authoring-guide.md
@@ -395,8 +395,8 @@ components:
     commands:
       build: npm run build
       check: npm run check
-      unit:  npx playwright test --config tests/playwright.config.ts --reporter=json 2>/dev/null | node scripts/test-filter.mjs
-      e2e:   npx playwright test --grep-invert 'mcp-integration|session-lifecycle-ui' --config playwright-e2e.config.ts --reporter=json 2>/dev/null | node scripts/test-filter.mjs
+      unit:  npx playwright test --config tests/playwright.config.ts --reporter=line
+      e2e:   npx playwright test --grep-invert 'mcp-integration|session-lifecycle-ui' --config playwright-e2e.config.ts --reporter=line
     config:
       # QA testbed config — read by the /qa-test skill via the agent-qa step's component field.
       # Env vars are inlined into qa_start_command itself; there is no separate qa_env field.

--- a/playwright-fullstack.config.ts
+++ b/playwright-fullstack.config.ts
@@ -8,7 +8,7 @@
  * Prerequisites: `npm run build` (both server and UI).
  *
  * Run:
- *   npm run build && npx playwright test --config playwright-fullstack.config.ts --reporter=json 2>/dev/null | node scripts/test-filter.mjs
+ *   npm run build && npx playwright test --config playwright-fullstack.config.ts --reporter=line
  */
 import { defineConfig } from "@playwright/test";
 import path from "node:path";

--- a/scripts/test-filter.mjs
+++ b/scripts/test-filter.mjs
@@ -3,6 +3,14 @@
  * Filters Playwright JSON reporter output to a compact summary.
  * Pipe test output in, get only what matters out.
  *
+ * REPO-LOCAL DEV HELPER — NOT SHIPPED. This script is a convenience for
+ * running tests locally inside the bobbit source repo. It is excluded from
+ * the published package (`package.json` `files` ships only `dist/`, `data/`,
+ * `README.md`), so it does NOT exist in bobbit installs. Do not reference it
+ * from shipped defaults or reproduce this pipe recipe in other projects —
+ * use a plain `--reporter=line` invocation, which `gate_inspect` can
+ * tail/grep/slice cleanly.
+ *
  * Usage:
  *   npx playwright test --reporter=json 2>/dev/null | node scripts/test-filter.mjs [OPTIONS]
  *


### PR DESCRIPTION
## Summary

Bobbit's shipped defaults taught a test-command recipe that only worked inside the bobbit source repo:

```
npx playwright test … --reporter=json 2>/dev/null | node scripts/test-filter.mjs
```

`scripts/test-filter.mjs` is **not shipped** to installs (`package.json` `files` = `["dist/","data/","README.md"]`), but `defaults/` **is** shipped — so an installed bobbit managing a non-bobbit project surfaced guidance referencing a script that doesn't exist there. The recipe was broken for every install except the bobbit repo itself.

Separately, `--reporter=json` emits one giant line that `gate_inspect`'s line modes (`slice|grep|head|tail`) can't navigate; the JSON+filter pipe was a context-compaction workaround predating `gate_inspect` slicing. `--reporter=line` produces one line per test that `gate_inspect` can tail/grep/slice cleanly, and Playwright's native exit code already treats flaky-recovered tests as success — so dropping the filter doesn't regress gate pass/fail.

## Changes

Replaced the repo-specific piped recipe with a plain `--reporter=line` invocation in all **shipped** defaults:

- `defaults/workflow-authoring-guide.md` — example `unit`/`e2e` command lines.
- `defaults/tools/shell/bash.yaml` — two bash-tool examples; comment reworded to "line reporter — readable, gate_inspect-friendly".
- `defaults/roles/team-lead.yaml` — command-format-gate example.
- `playwright-fullstack.config.ts` — header Run example.

Kept `scripts/test-filter.mjs` as a repo-local dev helper (in-repo consumers untouched), with a header note clarifying it is **not shipped** and should not be reproduced in other projects.

## Verification

- `rg "test-filter|reporter=json" defaults/ playwright-fullstack.config.ts` → no matches.
- Build, type-check, unit, and E2E all green (implementation gate passed).
- No `docs/`/`README.md`/`AGENTS.md` referenced the old recipe (stale-reference scan clean).
- Seeded workflows reference commands structurally (`command: "unit"`), so no seeded-workflow strings changed.

## Out of scope

- `.bobbit/config/project.yaml` `unit`/`e2e` commands are updated separately via the project-edit flow.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)