### PR TITLE
Marketplace MVP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Where things live. Use this to orient, then `rg` for the symbol.
 - **Server REST/WS**: `src/server/` — REST in `server.ts::handleApiRoute()`, WebSocket in `src/server/ws/`.
 - **Agent runtime**: `src/server/agent/` — sessions, manager, status, steer, respawn, store, project context.
 - **MCP / tools**: `src/server/mcp/`, `defaults/tools/<group>/` (project overrides under `.bobbit/config/tools/<group>/`). Tool descriptions are budget-pinned by `tests/tool-description-budget.test.ts`.
+- **Marketplace (Extension Packs)**: `src/server/marketplace/` (source registry, sync, scanner, install engine, provenance), `/api/marketplace/*` in `server.ts`, UI in `src/app/market-page.ts`. See [docs/marketplace.md](docs/marketplace.md).
 - **Skills**: `.claude/skills/<name>/SKILL.md`.
 - **UI shell**: `src/app/` — state, render, message-reducer, dialogs, follow-tail.
 - **UI components**: `src/ui/` — components, `tools/renderers/`, `lazy/`.
@@ -68,4 +69,4 @@ AGENTS.md is loaded into **every** agent turn. Keep it small and general.
 
 ## Reference docs
 
-[docs/internals.md](docs/internals.md) · [docs/debugging.md](docs/debugging.md) · [docs/dev-workflow.md](docs/dev-workflow.md) · [docs/testing-strategy.md](docs/testing-strategy.md) · [docs/architecture.md](docs/architecture.md) · [docs/goals-workflows-tasks.md](docs/goals-workflows-tasks.md) · [docs/rest-api.md](docs/rest-api.md) · [docs/preview-architecture.md](docs/preview-architecture.md) · [docs/mcp-meta-tools.md](docs/mcp-meta-tools.md) · [docs/qa-testing.md](docs/qa-testing.md)
+[docs/internals.md](docs/internals.md) · [docs/debugging.md](docs/debugging.md) · [docs/dev-workflow.md](docs/dev-workflow.md) · [docs/testing-strategy.md](docs/testing-strategy.md) · [docs/architecture.md](docs/architecture.md) · [docs/goals-workflows-tasks.md](docs/goals-workflows-tasks.md) · [docs/marketplace.md](docs/marketplace.md) · [docs/rest-api.md](docs/rest-api.md) · [docs/preview-architecture.md](docs/preview-architecture.md) · [docs/mcp-meta-tools.md](docs/mcp-meta-tools.md) · [docs/qa-testing.md](docs/qa-testing.md)

--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ Control what agents can do (tool access, system prompts) and how they behave. Us
 ### Skills
 Reusable templates for isolated sub-agents: code review, security review, test reports. Invoke them from any session for structured, repeatable outputs.
 
+### Marketplace (Extension Packs)
+Point Bobbit at git repos or local directories that contain **Extension Packs** — themed bundles of roles, tools, and skills — then browse and install them from the **Market** button in the sidebar (between Workflows and New Goal). Installing a pack copies its entities into your config layers, so they resolve through the normal cascade exactly like hand-authored config, with the same origin badges and scope (System / project) semantics. Provenance is recorded so packs update and uninstall cleanly. No hosted registry, no sandbox — just point at repos with the right layout. See [docs/marketplace.md](docs/marketplace.md).
+
 ### Interactive Agent Prompts
 Agents can ask you structured multiple-choice questions mid-task via the builtin `ask_user_choices` tool. An inline widget renders in the chat with up to 5 questions and an always-rendered free-text "Other" escape hatch. The tool is non-blocking — the agent's turn ends immediately and the session goes idle until you submit; your answers arrive as a tagged user message that wakes the agent on the next turn. See [docs/non-blocking-ask.md](docs/non-blocking-ask.md) for the architecture.
 
@@ -130,6 +133,7 @@ A squishy pixel-art blob that lives in the UI — animated, expressive, and draw
 | [Architecture](docs/architecture.md) | System design, layers, and dependencies |
 | [Development & Testing](docs/dev-workflow.md) | Dev environment, hot reload, testing |
 | [Goals & Workflows](docs/goals-workflows-tasks.md) | Task tracking, gates, and verification |
+| [Marketplace](docs/marketplace.md) | Extension Packs: sources, install, provenance |
 | [Bobbit Sprites](docs/bobbit-sprites.md) | Pixel-art mascot, animations, and accessories |
 
 **Technical reference:** [REST API](docs/rest-api.md) · [WebSocket Protocol](docs/websocket-protocol.md) · [Security](docs/security.md) · [Networking](docs/networking.md)

--- a/docs/design/marketplace-mvp.md
+++ b/docs/design/marketplace-mvp.md
@@ -1,0 +1,678 @@
+# Marketplace MVP — Design Document
+
+Status: **Design** (implementation-ready). Author: coder-3c24. Goal: *Marketplace MVP*.
+
+This document is the single source of truth for the Marketplace MVP. It resolves every "Design-doc must resolve" item from the goal spec and gives a file-by-file implementation plan a coder can follow without further design work.
+
+---
+
+## 1. Overview & goals
+
+### What the MVP delivers
+
+A **Market** surface, reached from a new sidebar button (between **Workflows** and **New Goal**), that lets a user:
+
+1. Register **sources** — git repos or local directories that contain Extension Packs.
+2. **Sync** those sources (git clone/pull into a state cache; local dirs read in place).
+3. **Browse** the **Extension Packs** each source contains, with name, description, version, contained entities, and an installed/up-to-date status.
+4. **Install** a whole pack — copying each contained entity (roles, tools, skills) into a config layer the existing `ConfigCascade` / skill-discovery already reads, so the entities resolve exactly like hand-authored ones (same origin badges, same scope semantics).
+5. See **provenance** for installed packs (which pack + source + commit), and **update** (re-sync + re-copy) or **uninstall** (symmetric removal of exactly what install added).
+
+The headline unit of distribution is the **pack**, not the loose entity. A source contains one or more packs; a pack bundles several entity types around a theme.
+
+### In scope (entity types a pack can install)
+
+- **Roles** — `roles/<name>.yaml` → installed into a `RoleStore` config layer.
+- **Tools** — `tools/<group>/` directory bundles (YAML descriptors + `extension.ts` + `_shared/`) → installed into a `ToolManager` config layer.
+- **Skills** — `skills/<name>/SKILL.md` (+ optional `references/`, `scripts/`, `assets/`) → installed so `discoverSlashSkills` resolves them (see §6.3 for the definitive path).
+
+### Non-goals (deferred to later phases — seams designed, nothing built)
+
+These are intentionally excluded from the MVP but the architecture must leave explicit seams (see §8) so each is *additive* later, not a redesign:
+
+- **UI Panels / plugins** (PR-Walkthrough-style, generalised to an installable plugin with its own tools) — the eventual headline use case.
+- **Workflows** — currently project-scoped and bound to project-specific `(component, command)` pairs, so not portable today.
+- **Staff definitions** — runtime state, not config today.
+- **Trust / sandboxing / signing** of code-bearing bundles — MVP copies tool code as-is and surfaces a clear "installs executable code" warning, but no enforcement.
+- **Hosted / remote registry** with search/discovery — MVP sources are git repos + local dirs only.
+
+The unifying requirement: **entity-type set, bundle/source format, and install pipeline must all be extensible.**
+
+### Key architectural anchors (verified against the codebase)
+
+| Concern | Existing mechanism | File |
+|---|---|---|
+| Three-layer config resolution (builtin → server → project) | `ConfigCascade.resolveRoles/resolveTools(projectId)` | `src/server/agent/config-cascade.ts` |
+| Role persistence | `RoleStore` → `roles/<name>.yaml` (one YAML/role) | `src/server/agent/role-store.ts`, `yaml-store.ts` |
+| Tool persistence + cascade | `ToolManager`; group-level overlay; `tools/<group>/*.yaml` + `extension.ts` | `src/server/agent/tool-manager.ts` |
+| Recursive dir copy | `copyDirRecursive(src, dest)` (exported) | `src/server/agent/tool-manager.ts` |
+| Skill discovery | `discoverSlashSkills(cwd, projectConfigStore)` scans `.claude/skills`, `.bobbit/skills`, `~/.claude/skills`, `~/.bobbit/skills`, and **custom dirs** from `config_directories` | `src/server/skills/slash-skills.ts`, `agent/config-directories.ts` |
+| Server config/state dirs | `bobbitConfigDir()` = `<server-root>/.bobbit/config`; `bobbitStateDir()` = `<server-root>/.bobbit/state` | `src/server/bobbit-dir.ts` |
+| Per-project config/state dirs | `ProjectContext.configDir` / `.stateDir` = `<project-root>/.bobbit/{config,state}` | `src/server/agent/project-context.ts` |
+| Server-global JSON store pattern (atomic write) | `ProjectRegistry` → `<stateDir>/projects.json` | `src/server/agent/project-registry.ts` |
+| Config page UI conventions (origin badges, scope tabs) | `config-scope.ts` (`getConfigScope`, `renderConfigScopeRow`, `renderOriginBadge`) | `src/app/config-scope.ts` |
+| Sidebar config buttons | Workflows + New Goal row | `src/app/sidebar.ts` (~1382–1403) |
+| Hash routing | `RouteView`, `getRouteFromHash`, `setHashRoute`, `toggleConfigPage` | `src/app/routing.ts` |
+| Page mount switch | `mainArea()` route dispatch via `lazyPage(...)` | `src/app/render.ts` (~2400) |
+
+**Scope vocabulary.** The UI calls the server layer **"system"** (config-scope `"system"`, `projectId` omitted) and project layers by project id. The REST `customize`/`override` endpoints use `scope=server|project` + `projectId`. The marketplace reuses this exact vocabulary: install scope is **`system`** (server layer) or **`project`** (a specific project).
+
+---
+
+## 2. Source & pack layout
+
+### 2.1 Source layout convention
+
+A **source** is a git repo or a local directory. Its **top level is a collection of pack directories** — never a flat `defaults/` mirror. A directory is a **pack iff it contains a `pack.yaml`**; directories without one are ignored (so a source repo may carry a README, CI config, etc. at the top level without confusing the scanner). Pack scanning is **one level deep** — only immediate children of the source root are considered.
+
+```
+<source-root>/
+  research-pack/
+    pack.yaml                       # REQUIRED — makes this dir a pack
+    roles/
+      researcher.yaml
+      lit-reviewer.yaml
+    tools/
+      research/
+        web_dig.yaml
+        extension.ts
+        _shared/
+          http.ts
+    skills/
+      deep-research/
+        SKILL.md
+        references/
+          methodology.md
+  qa-pack/
+    pack.yaml
+    roles/qa-lead.yaml
+    tools/qa/ ...
+  README.md                         # ignored (no pack.yaml)
+  .github/                          # ignored
+```
+
+The entity payload layout *inside* each pack mirrors Bobbit's `defaults/` tree exactly:
+
+- `roles/<name>.yaml` — same shape as `defaults/roles/<name>.yaml` (see `RoleStore.serializeRole`).
+- `tools/<group>/` — same shape as `defaults/tools/<group>/` (YAML descriptors + `extension.ts` + `_shared/`).
+- `skills/<name>/SKILL.md` — same shape as `defaults/skills/<name>/SKILL.md` (YAML frontmatter + markdown body + optional `references/`, `scripts/`, `assets/`).
+
+### 2.2 `pack.yaml` schema (exact)
+
+`pack.yaml` is the pack's identity and a **declaration** of its contents. The declaration is the contract the scanner validates against the on-disk payload — a declared entity that is missing on disk is a pack error; an on-disk entity that is *not* declared is ignored (declaration is authoritative). This keeps install deterministic and lets a pack author intentionally ship example/unsupported files without them being installed.
+
+```yaml
+# pack.yaml
+apiVersion: 1                 # REQUIRED (int). Schema version. MVP accepts only 1.
+id: research-pack             # REQUIRED (string). Stable pack id, unique within the source.
+                              #   Pattern: ^[a-z0-9][a-z0-9-]*$ . Used in provenance + dir name.
+name: Research Pack           # REQUIRED (string). Human display name.
+description: >                # REQUIRED (string). One–three sentences shown in the browse list.
+  Research-focused roles, a web-digging tool, and a deep-research skill.
+version: 1.2.0                # REQUIRED (string). Author-declared semver-ish label. Surfaced in UI
+                              #   and provenance. NOT used for ordering logic in the MVP (commit SHA
+                              #   is the real freshness signal for git sources).
+author: jane@example.com      # OPTIONAL (string).
+homepage: https://...         # OPTIONAL (string, URL).
+license: MIT                  # OPTIONAL (string).
+minBobbit: "0.80.0"           # OPTIONAL (string). Advisory only in MVP (shown, not enforced).
+
+contents:                     # REQUIRED (object). Declares what the pack installs, per entity type.
+                              #   Every key is OPTIONAL but at least one non-empty list is REQUIRED.
+  roles:                      # list of role names (file basenames, no .yaml). Must match roles/<name>.yaml.
+    - researcher
+    - lit-reviewer
+  tools:                      # list of tool GROUP dirs (matches tools/<group>/). Group-level, like the
+                              #   ToolManager cascade (a group is replaced wholesale).
+    - research
+  skills:                     # list of skill names (matches skills/<name>/ containing SKILL.md).
+    - deep-research
+```
+
+#### Field reference
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `apiVersion` | int | yes | MVP accepts `1` only. Forward-compat gate; unknown versions → pack flagged "unsupported", not installed. |
+| `id` | string | yes | `^[a-z0-9][a-z0-9-]*$`. Unique within a source. Identity key in provenance. |
+| `name` | string | yes | Display name. |
+| `description` | string | yes | Shown in browse list + drill-down. |
+| `version` | string | yes | Display + provenance. Not used for comparison logic (commit SHA is). |
+| `author` / `homepage` / `license` / `minBobbit` | string | no | Metadata, displayed; `minBobbit` advisory only. |
+| `contents.roles` | string[] | no* | Role file basenames (no extension). |
+| `contents.tools` | string[] | no* | Tool **group** directory names. |
+| `contents.skills` | string[] | no* | Skill directory names (each must contain `SKILL.md`). |
+
+\* At least one of `contents.{roles,tools,skills}` must be a non-empty list, else the pack is invalid (it installs nothing).
+
+#### Validation rules (scanner)
+
+A pack is **valid** when: `pack.yaml` parses; `apiVersion === 1`; `id`/`name`/`description`/`version` are non-empty strings; `id` matches the pattern; `contents` has ≥1 non-empty supported list; and **every declared entity exists on disk** with the right shape:
+
+- role `r` → `roles/<r>.yaml` exists and parses via the same `parseRole` logic.
+- tool group `g` → `tools/<g>/` is a directory containing ≥1 `*.yaml` with a `name:` field.
+- skill `s` → `skills/<s>/SKILL.md` exists.
+
+Validation failures are **non-fatal at the source level**: an invalid pack is surfaced in the browse list with an `error` string and is **not installable**; sibling valid packs in the same source remain usable.
+
+#### Unknown-key forward-compat
+
+Unknown top-level keys and unknown keys under `contents` (e.g. a future `contents.panels`) are **preserved and ignored** by the MVP scanner (not an error). This is what lets a future entity type ship in a pack today and be installed once a handler exists — see §8.
+
+---
+
+## 3. Source registry
+
+### 3.1 Persistence scope — **server-global** (recommended)
+
+The list of configured sources persists **server-globally**, not per project.
+
+**Rationale.** A source answers "where do I fetch packs from?" — a machine/user-level concern, independent of any project. The same source typically serves many projects. Git credentials are the user's ambient git creds (one identity per machine). Per-project source lists would force re-registering the same repos for every project and complicate the zero-project (system-only) install flow that the cascade already supports. Install *scope* is still chosen per-install (system vs project) — only the *source list* is global.
+
+This mirrors `ProjectRegistry`, which is itself a server-global JSON store under `bobbitStateDir()`.
+
+### 3.2 On-disk shape & location
+
+```
+<server-root>/.bobbit/state/marketplace/
+  sources.json                      # the source registry
+  <source-id>/                      # per-source sync cache (git clone or symlink marker; see §4)
+```
+
+`sources.json` (atomic write: temp file + rename, like `ProjectRegistry.save()`):
+
+```jsonc
+{
+  "version": 1,
+  "sources": [
+    {
+      "id": "a1b2c3d4",              // randomUUID().slice(0,8) — stable, used as cache dir name
+      "kind": "git",                 // "git" | "local"
+      "url": "https://github.com/acme/bobbit-packs.git",  // git sources only
+      "ref": "main",                 // OPTIONAL git ref/branch/tag; default = remote HEAD
+      "path": null,                  // local sources only: absolute dir path
+      "label": "Acme Packs",         // OPTIONAL display label; defaults to repo/dir basename
+      "addedAt": 1780000000000,
+      "lastSyncedAt": 1780000050000, // null until first successful sync
+      "lastSyncCommit": "9f8e7d6…",  // git sources: HEAD SHA after last sync; null for local
+      "lastSyncError": null          // string when the last sync failed, else null
+    }
+  ]
+}
+```
+
+### 3.3 Registry API (server-global, no `projectId`)
+
+| Method | Route | Body / params | Effect |
+|---|---|---|---|
+| GET | `/api/marketplace/sources` | — | List sources with sync status. |
+| POST | `/api/marketplace/sources` | `{ kind, url?, ref?, path?, label? }` | Validate + add; assign `id`; kick a first sync (async); return the record. |
+| DELETE | `/api/marketplace/sources/:id` | — | Remove from registry + delete the sync cache dir. Does **not** uninstall packs that came from it (installed entities are independent copies). |
+| POST | `/api/marketplace/sources/:id/sync` | — | Re-sync (clone/pull) the source; return updated status. |
+
+Validation on POST: `kind` ∈ {git, local}; git requires a non-empty `url`; local requires an existing absolute `path` (reject relative paths and non-existent dirs with 400, mirroring project preflight rigor). `ref` is optional.
+
+---
+
+## 4. Sync mechanism
+
+`MarketplaceSyncService` owns clone/pull and cache layout. Cache root: `path.join(bobbitStateDir(), "marketplace")`.
+
+### 4.1 Git sources
+
+- **First sync** → **shallow clone**: `git clone --depth 1 [--branch <ref>] <url> <cacheDir>/<id>`. Shallow keeps the cache small (packs are small text trees).
+- **Re-sync** → **fetch + hard reset** to the tracked ref, not a plain `pull`, to avoid merge conflicts in a cache the user never edits:
+  `git -C <dir> fetch --depth 1 origin <ref>` then `git -C <dir> reset --hard FETCH_HEAD` then `git -C <dir> clean -fdx`.
+  If the cache dir is missing or corrupt (no `.git`), fall back to a fresh clone (reclone).
+- **Commit capture**: after sync, record `lastSyncCommit = git -C <dir> rev-parse HEAD`. This SHA is the real freshness signal used by update detection (§7).
+- **Auth**: rely entirely on the user's ambient git credentials (credential helper / SSH agent / `GIT_*` env). The MVP does **not** store or prompt for credentials. A failed auth surfaces as `lastSyncError`. Tokens embedded in URLs are accepted but stripped from any surfaced/logged URL using the existing `strip-token-git-url` helper (see `tests/strip-token-git-url.test.ts`).
+- **Timeouts / errors**: run git via a child process with a bounded timeout (e.g. 120s). On failure, set `lastSyncError`, leave any previous good cache intact, and return a structured error to the client.
+
+### 4.2 Local-dir sources
+
+Read **in place** — no copy, no clone. The "cache dir" for a local source is the source `path` itself; `lastSyncCommit` is `null`. A "sync" for a local source is a no-op that simply re-validates that `path` still exists (and refreshes `lastSyncError`). The scanner always reads the live directory, so local sources reflect on-disk edits immediately (good for pack authors iterating locally).
+
+### 4.3 Resolving a source's scan root
+
+```
+syncRoot(source):
+  git   → <bobbitStateDir>/marketplace/<id>     (the clone)
+  local → source.path                            (read in place)
+```
+
+---
+
+## 5. Browse model
+
+`MarketplacePackScanner` turns a synced source root into a list of `ScannedPack`. The browse API composes scanner output across all sources and annotates install status from provenance (§7).
+
+### 5.1 Scanner
+
+```ts
+interface ScannedEntity {
+  type: "role" | "tool" | "skill";
+  name: string;            // role/skill name, or tool GROUP name
+  // resolved absolute source path of the payload (file for role, dir for tool group/skill)
+  sourcePath: string;
+}
+
+interface ScannedPack {
+  sourceId: string;
+  packId: string;          // pack.yaml id
+  dir: string;             // absolute pack dir within syncRoot
+  manifest: PackManifest;  // parsed pack.yaml
+  entities: ScannedEntity[];
+  hasTools: boolean;       // any tool entity → drives the "executable code" warning (§9)
+  valid: boolean;
+  error?: string;          // populated when !valid
+}
+```
+
+`scanSource(source)`:
+1. `root = syncRoot(source)`; if missing → return `[]` (and surface `lastSyncError`).
+2. `readdirSync(root, { withFileTypes: true })`, one level deep, dirs only.
+3. For each dir containing `pack.yaml`: parse + validate (§2.2); build `ScannedPack` (valid or with `error`).
+4. Dirs without `pack.yaml` → ignored.
+
+### 5.2 Browse API
+
+| Method | Route | Effect |
+|---|---|---|
+| GET | `/api/marketplace/packs?scope=system\|project&projectId=…` | List packs across all sources, each annotated with install status **for the requested scope**. |
+| GET | `/api/marketplace/packs/:sourceId/:packId?scope=…&projectId=…` | Drill-down: full manifest + per-entity detail + per-entity install status. |
+
+Pack listing shape (browse list):
+
+```jsonc
+{
+  "packs": [{
+    "sourceId": "a1b2c3d4", "packId": "research-pack",
+    "name": "Research Pack", "description": "…", "version": "1.2.0",
+    "sourceLabel": "Acme Packs",
+    "entities": [
+      { "type": "role",  "name": "researcher" },
+      { "type": "tool",  "name": "research" },
+      { "type": "skill", "name": "deep-research" }
+    ],
+    "hasTools": true,
+    "valid": true,
+    "installStatus": "not-installed",   // "not-installed" | "installed" | "update-available" | "drifted"
+    "installedVersion": null,
+    "installedCommit": null
+  }]
+}
+```
+
+`installStatus` is computed by comparing provenance (§7) for the requested scope against the scanned pack:
+- `not-installed` — no provenance record for `(sourceId, packId)` at this scope.
+- `installed` — provenance exists; `lastSyncCommit` (git) or content hash matches what was installed.
+- `update-available` — provenance exists but the source's current `lastSyncCommit` differs from the installed commit (git), or content hash differs (local).
+- `drifted` — provenance exists but an installed entity file is missing/edited locally (best-effort; surfaced so the user knows uninstall/update may be partial).
+
+---
+
+## 6. Install pipeline
+
+### 6.1 Whole-pack install (primary) + individual-entity install (allowed)
+
+**Decision: installing the whole pack is the primary action; installing an individual entity from a pack IS allowed** (drill-down view exposes a per-entity install button). Rationale: the install primitive is naturally per-entity (each entity copies independently), whole-pack install is just "install every declared entity," and per-entity install costs nothing extra while giving users a clean way to take, e.g., only the role from a pack. Provenance (§7) records exactly which entities were installed, so uninstall is symmetric whether the user installed the whole pack or a subset.
+
+Both flows go through one engine: `installEntities(scope, projectId, source, pack, entities[])`.
+
+### 6.2 Install scope model & interaction with the cascade
+
+Install scope is **`system`** or **`project`**, reusing the existing config-scope vocabulary:
+
+| Scope | Roles target | Tools target | Skills target |
+|---|---|---|---|
+| `system` (server layer) | `<server-root>/.bobbit/config/roles/<name>.yaml` | `<server-root>/.bobbit/config/tools/<group>/` | `~/.bobbit/skills/<name>/` (see §6.3) |
+| `project` | `<project-root>/.bobbit/config/roles/<name>.yaml` | `<project-root>/.bobbit/config/tools/<group>/` | `<project-root>/.bobbit/config/skills/<name>/` + register custom dir (see §6.3) |
+
+These are exactly the directories the `ConfigCascade` already reads:
+- **Roles** — system writes resolve as `origin: "server"`; project writes as `origin: "project"`. They shadow lower layers per the existing cascade merge (`ConfigCascade.resolveRoles`). The origin badge and "overrides" indicator come for free.
+- **Tools** — the `ToolManager` overlay is **group-level**: a group present in a higher layer replaces the entire builtin group. Installing a tool group at project scope therefore shadows any builtin/server group of the same name. This is the same semantics as the existing `/api/tools/:name/customize` copy.
+
+**Default scope.** The Market page reuses `config-scope.ts`: the page's scope tabs default to **System** when no project is active and otherwise to the active project (matching role/tool pages). The install button label reflects the active scope ("Install to System" / "Install to <Project>").
+
+### 6.3 Skills install path — **definitively resolved**
+
+There is **no `.bobbit/config/skills/` cascade** today; `discoverSlashSkills` resolves skills from the **session cwd** (a worktree), not from the project root the server reads roles/tools from. A naive `<project-root>/.bobbit/config/skills` would *not* be scanned, because sessions run in sibling worktrees whose cwd is not the project root, and `.bobbit/config/` is committed-but-not-necessarily-present-in-a-fresh-worktree-branch.
+
+The discovery code **does** scan **custom directories** registered in project config (`config_directories`, type `"skills"`), and those are resolved as **absolute paths** (`expandPath` → `path.resolve`) regardless of session cwd (`src/server/agent/config-directories.ts`, `parseCustomDirectories`). It also always scans `~/.bobbit/skills` (user scope, global).
+
+**Therefore:**
+
+- **Project scope** → install skills to **`<project-root>/.bobbit/config/skills/<name>/`** AND ensure the project's `config_directories` contains `{ path: "<project-root>/.bobbit/config/skills", types: ["skills"] }` (idempotent add via `saveCustomDirectories`). Because the custom dir is an absolute path, every session of that project — in any worktree — resolves the skill. This co-locates skills with roles/tools under `.bobbit/config/` (committed, team-shared) and reuses the existing custom-dir plumbing with zero changes to skill discovery.
+- **System scope** → install skills to **`~/.bobbit/skills/<name>/`**, which `discoverSlashSkills` already scans unconditionally for every session on the machine. No registration needed.
+
+This is the definitive resolution. (Rejected alternative: writing into the repo's `.claude/skills/` — that requires a git commit to propagate to worktrees and pollutes the user's tracked tree; the custom-dir approach needs neither.)
+
+### 6.4 Install algorithm (per entity)
+
+```
+installEntity(scope, projectId, syncRoot, entity):
+  switch entity.type:
+    role:
+      src  = <packDir>/roles/<name>.yaml
+      dest = <roleConfigDir(scope, projectId)>/<name>.yaml
+      conflict-check(dest); copyFile(src, dest)
+      installedPaths = [dest]
+    tool:                                   # group-level
+      src  = <packDir>/tools/<group>/       # directory
+      dest = <toolConfigDir(scope, projectId)>/<group>/
+      conflict-check(dest); copyDirRecursive(src, dest)   # reuse tool-manager.copyDirRecursive
+      installedPaths = [dest]               # whole group dir
+    skill:
+      src  = <packDir>/skills/<name>/       # directory incl. SKILL.md + resources
+      dest = <skillInstallDir(scope, projectId)>/<name>/
+      conflict-check(dest); copyDirRecursive(src, dest)
+      if scope == project: ensureCustomSkillDir(projectId, skillInstallDir)
+      installedPaths = [dest]
+  return { type, name, installedPaths }
+```
+
+After install, **invalidate caches** so the new entities resolve immediately:
+- Roles: `RoleStore` reloads on read (`getAll` calls `reload()`), so no action needed; but call `ctx.roleStore.reload()` defensively.
+- Tools: the `ToolManager` scan cache is mtime-keyed and Windows mtime is coarse — call the existing `__resetToolScanCache()` (already used after tool writes) for the affected tools dir.
+- Skills: `discoverSlashSkills` has a 5s TTL cache keyed on cwd+config; registering the custom dir bumps the config value and naturally invalidates it.
+
+### 6.5 Conflict handling
+
+A **conflict** is: the destination already exists *at the target scope* (role file, tool group dir, or skill dir present).
+
+The install API accepts a `conflict` mode (query param or body field), defaulting to **`fail`**:
+
+- `fail` (default) — abort the whole install transactionally if any entity conflicts; return `409` with the conflicting entity list. Nothing is written. The UI then offers the user a choice.
+- `overwrite` — replace the existing entity at this scope. Because the install may be overwriting a *previously marketplace-installed* entity, the new provenance supersedes the old record for that entity.
+- `skip` — install only the non-conflicting entities; report which were skipped.
+
+Conflicts are evaluated against the **same scope only** — installing at project scope when a builtin/server role of the same name exists is **not** a conflict (it is the normal cascade-shadow behavior, surfaced via the origin "overrides" badge). The UI explains this.
+
+**Transactionality.** Install computes the full plan, runs all conflict checks first, then copies. If a copy fails midway, already-copied entities for that install are rolled back (delete `installedPaths`) so the system is never left half-installed; the provenance record is written only after all copies succeed.
+
+### 6.6 Install API
+
+| Method | Route | Body | Effect |
+|---|---|---|---|
+| POST | `/api/marketplace/install` | `{ sourceId, packId, scope, projectId?, entities?, conflict? }` | Install. `entities` omitted ⇒ whole pack (all declared). `entities` = array of `{type,name}` ⇒ subset. Returns provenance record + per-entity result. |
+| POST | `/api/marketplace/update` | `{ sourceId, packId, scope, projectId? }` | Re-sync source, then re-copy exactly the entities in the existing provenance record (overwrite), updating commit/version. |
+| POST | `/api/marketplace/uninstall` | `{ sourceId, packId, scope, projectId? }` | Remove exactly the `installedPaths` from provenance; deregister the custom skill dir if it becomes empty; delete provenance record. |
+
+---
+
+## 7. Provenance
+
+### 7.1 Record shape
+
+Provenance is what makes update/uninstall symmetric: it records the **exact paths** install wrote, so uninstall removes exactly those and nothing else.
+
+```jsonc
+{
+  "version": 1,
+  "installs": [
+    {
+      "scope": "project",              // "system" | "project"
+      "projectId": "f1e2…",            // null for system scope
+      "sourceId": "a1b2c3d4",
+      "packId": "research-pack",
+      "packName": "Research Pack",
+      "packVersion": "1.2.0",          // pack.yaml version at install time
+      "sourceKind": "git",
+      "sourceUrl": "https://…",        // token-stripped; null for local
+      "sourceCommit": "9f8e7d6…",      // lastSyncCommit at install time; null for local
+      "sourceContentHash": null,       // local sources: hash of installed payloads (freshness signal)
+      "installedAt": 1780000100000,
+      "entities": [
+        { "type": "role",  "name": "researcher",
+          "installedPaths": ["/abs/.bobbit/config/roles/researcher.yaml"] },
+        { "type": "tool",  "name": "research",
+          "installedPaths": ["/abs/.bobbit/config/tools/research"] },
+        { "type": "skill", "name": "deep-research",
+          "installedPaths": ["/abs/.bobbit/config/skills/deep-research"],
+          "customDirRegistered": "/abs/.bobbit/config/skills" }
+      ]
+    }
+  ]
+}
+```
+
+The record key is the tuple **`(scope, projectId, sourceId, packId)`** — unique; re-installing the same pack at the same scope supersedes its record.
+
+### 7.2 Where provenance lives
+
+Provenance is **committed alongside the entities it tracks**, per scope, so uninstall is symmetric on any machine that has the entities:
+
+- **System scope** → `<server-root>/.bobbit/config/marketplace/installed.json`
+- **Project scope** → `<project-root>/.bobbit/config/marketplace/installed.json`
+
+Rationale: installed entities live in committed `.bobbit/config/`; provenance must travel with them so a teammate who pulls the repo can cleanly uninstall/update. (The **source registry** by contrast is per-machine runtime state in `.bobbit/state/` — see §3.2 — because it is about fetch locations + credentials, not installed artifacts.)
+
+A small `ProvenanceStore` (JSON, atomic write, mirrors `ProjectRegistry`) wraps each file; the server resolves the right file from `(scope, projectId)`.
+
+### 7.3 Update & uninstall using provenance
+
+- **Update**: `sync(source)` → read provenance entities → re-run `installEntities(..., conflict=overwrite)` for exactly those entities → rewrite the record with the new `sourceCommit`/`packVersion`. Entities that the new pack version *no longer declares* are removed (so update never leaves orphans); entities newly declared are **not** auto-added (update is "refresh what I have," matching whole-pack/subset install intent) — the UI shows "N new entities available; re-install pack to add."
+- **Uninstall**: for each entity, delete its `installedPaths` (recursive for dirs). For skills at project scope, if the custom skill dir is now empty, deregister it from `config_directories` (and remove the empty dir). Delete the provenance record. Invalidate the same caches as install (§6.4).
+
+---
+
+## 8. Extensibility seams
+
+The MVP must make new entity types and new distribution backends **additive**. Three abstraction boundaries deliver that.
+
+### 8.1 Entity-type registry + install-handler-per-type
+
+Define a single registry mapping an entity type to its behavior:
+
+```ts
+interface EntityTypeHandler {
+  type: string;                                   // "role" | "tool" | "skill" | future: "panel" | "workflow" | "staff"
+  /** key under pack.yaml `contents` */
+  manifestKey: string;                            // "roles" | "tools" | "skills" | "panels" | …
+  /** verify the declared entity exists/parses in a pack dir */
+  validate(packDir: string, name: string): { ok: boolean; error?: string };
+  /** resolve the destination for a scope and copy; returns installedPaths + side-effects */
+  install(ctx: InstallCtx, packDir: string, name: string): InstalledEntity;
+  /** remove exactly what install wrote (given the provenance entity) */
+  uninstall(ctx: InstallCtx, entity: InstalledEntity): void;
+  /** does this type carry executable code? drives the §9 warning */
+  carriesCode: boolean;
+}
+
+const ENTITY_HANDLERS: Record<string, EntityTypeHandler> = {
+  role:  roleHandler,
+  tool:  toolHandler,     // carriesCode: true
+  skill: skillHandler,
+};
+```
+
+The scanner, browse annotator, install/update/uninstall engine, and the "installs executable code" check all iterate `ENTITY_HANDLERS` rather than hardcoding role/tool/skill. **Adding a new entity type is one new handler + one registry entry** — no changes to the scan/install/uninstall control flow. Unknown `contents` keys are already preserved by the scanner (§2.2), so a pack can ship a `panels:` list today and become installable the moment a `panelHandler` is registered.
+
+#### How each deferred type slots in (no redesign)
+
+- **UI Panels / plugins** — add `panelHandler` with `manifestKey: "panels"`, `carriesCode: true`. A panel bundle is a directory (`panels/<id>/` with a manifest declaring its tools + a renderer entry, à la PR-Walkthrough). `install` copies the bundle into a panel config dir and registers it the way panels are discovered (a future panel-registry, analogous to the tools overlay). The pack/source layout already supports a `panels/` payload dir; nothing about §2 changes.
+- **Portable workflows** — add `workflowHandler` with `manifestKey: "workflows"`. The hard part is **not** the marketplace — it is that workflows today bind to project-specific `(component, command)` pairs and live inline in `project.yaml` (`ConfigCascade.resolveWorkflows` is project-only, no builtin/server layer). The seam: when portable/parameterised workflows exist, `workflowHandler.install` writes into the project's workflow store and maps declared parameters to project components. The doc-level note for that future phase: a portable workflow must declare its required component *roles* abstractly and the install step must prompt the user to bind them — that binding step is the only new UI.
+- **Staff templates** — add `staffHandler` with `manifestKey: "staff"`. Staff are runtime state (`StaffStore` under `.bobbit/state`), not config, so the future phase first needs an exportable *template* shape; once that exists, `install` instantiates a staff record from the template. No marketplace-core change.
+- **Trust / permission model** — `EntityTypeHandler.carriesCode` already marks code-bearing types. The seam for enforcement: insert a `TrustPolicy.check(pack, source)` gate in the install engine *before* `handler.install` runs. MVP's implementation is a no-op that only drives the §9 warning; a future phase makes it consult a signature/allowlist and can block. The call site exists from day one.
+
+### 8.2 Source backend interface (registry-ready)
+
+Sync + scan talk to sources through one interface so a hosted registry is a new backend, not a rewrite:
+
+```ts
+interface SourceBackend {
+  kind: string;                       // "git" | "local" | future: "registry"
+  sync(source): Promise<SyncResult>;  // returns { root, commit?, contentHash?, error? }
+  // scanning always operates on the returned `root`, so it is backend-agnostic
+}
+```
+
+MVP ships `GitSourceBackend` and `LocalSourceBackend`. A future **`RegistrySourceBackend`** implements `sync` by fetching a pack index + downloading pack tarballs into the same cache layout (`<stateDir>/marketplace/<id>/`), after which the *identical* scanner/install pipeline runs. The browse API would gain optional search params, but the install path is unchanged. `sources.json` already carries a `kind` discriminator (§3.2) so adding `"registry"` is additive.
+
+### 8.3 Summary of boundaries
+
+| Future addition | Touches | Does NOT touch |
+|---|---|---|
+| New entity type (panel/workflow/staff) | one `EntityTypeHandler` + registry entry + pack `contents` key | scan/install/uninstall control flow, source backends, REST routes |
+| Trust/signing enforcement | `TrustPolicy.check` body (call site pre-exists) | handlers, scanner, UI (warning already present) |
+| Hosted registry | one `SourceBackend` + `kind: "registry"` | scanner, install engine, provenance |
+
+---
+
+## 9. "Installs executable code" warning
+
+A pack that contains **any tool entity** (and, in future, any `carriesCode` entity such as a panel) ships executable `extension.ts`. The MVP performs **no sandboxing or signing** of this code, so the UI must make the risk explicit.
+
+- **Browse list**: packs with `hasTools === true` show a small "code" badge (e.g. a warning-tinted chip "executable code") next to the pack name.
+- **Drill-down**: a prominent inline notice: *"This pack installs executable code (tools) that runs with your agent's privileges. Bobbit does not sandbox or verify pack code. Only install packs from sources you trust."*
+- **Install confirmation**: when the install target includes ≥1 code-bearing entity, the confirm dialog repeats the warning and requires explicit confirmation before the POST. (`confirmAction(...)` from `src/app/dialogs.ts`, used elsewhere for destructive confirms.)
+
+The decision of *whether* an entity is code-bearing comes from `EntityTypeHandler.carriesCode`, so the warning automatically covers future code-bearing types.
+
+---
+
+## 10. File-by-file implementation plan
+
+### 10.1 New server files
+
+```
+src/server/marketplace/
+  types.ts                  # PackManifest, ScannedPack, ScannedEntity, SourceRecord,
+                            #   ProvenanceRecord, InstalledEntity, InstallCtx, scope types.
+  source-registry.ts        # SourceRegistry: load/save sources.json (atomic write, mirrors
+                            #   ProjectRegistry). add/remove/list/get; id assignment.
+  sync-service.ts           # MarketplaceSyncService + SourceBackend interface +
+                            #   GitSourceBackend (shallow clone / fetch+reset+clean / rev-parse)
+                            #   + LocalSourceBackend (read in place). Token-strip URLs.
+  pack-scanner.ts           # parsePackManifest(), validatePack(), scanSource(root) → ScannedPack[].
+  entity-handlers.ts        # ENTITY_HANDLERS registry + roleHandler/toolHandler/skillHandler
+                            #   (validate/install/uninstall/carriesCode). Uses copyDirRecursive,
+                            #   RoleStore paths, ToolManager dirs, config-directories helpers.
+  install-service.ts        # installEntities(), update(), uninstall(); conflict detection +
+                            #   transactional copy/rollback; cache invalidation; TrustPolicy.check
+                            #   no-op seam.
+  provenance-store.ts       # ProvenanceStore per (scope, projectId): load/save installed.json
+                            #   (atomic write); upsert/remove/find by (scope,projectId,sourceId,packId).
+```
+
+Path-resolution helpers these modules need (all derivable from existing exports):
+- role config dir: `path.join(scopeConfigDir, "roles")` where `scopeConfigDir = bobbitConfigDir()` (system) or `ctx.configDir` (project).
+- tool config dir: `path.join(scopeConfigDir, "tools")`.
+- skill install dir: project → `path.join(ctx.configDir, "skills")` + `saveCustomDirectories`; system → `path.join(os.homedir(), ".bobbit", "skills")`.
+- sync cache root: `path.join(bobbitStateDir(), "marketplace")`.
+
+### 10.2 Edited server files
+
+- **`src/server/server.ts`** — add the `/api/marketplace/*` routes inside `handleApiRoute()`, modeled on the existing `/api/tools/:name/customize` block (~4443) for scope/projectId handling. Wire singletons: construct `SourceRegistry`, `MarketplaceSyncService`, `MarketplacePackScanner`, `InstallService` near where `toolManager`/`roleStore` are built (~834), and pass what the routes need (they already have `projectContextManager`, `toolManager`, `configCascade` in scope). Reuse `__resetToolScanCache` import for tool-install cache invalidation.
+- **`src/server/agent/config-directories.ts`** — no change required (reuse `parseCustomDirectories` / `saveCustomDirectories`). Note in code comments that the marketplace registers the project skills dir here.
+
+### 10.3 New UI files
+
+```
+src/app/market-page.ts        # renderMarketPage(...) + loadMarketPageData(); list view (sources +
+                              #   packs) and pack drill-down view. Reuses config-scope.ts:
+                              #   getConfigScope/renderConfigScopeRow/renderOriginBadge. Install/
+                              #   update/uninstall actions via gatewayFetch. "executable code" badge
+                              #   + confirm via dialogs.confirmAction.
+src/app/market-source-dialog.ts  # add-source modal (kind = git|local, url/ref/path/label), POST
+                              #   /api/marketplace/sources, optimistic sync status.
+src/app/market-page.css       # page styles (mirror workflow-page.css conventions / .config-* classes).
+```
+
+Add API helpers to **`src/app/api.ts`**: `fetchMarketSources`, `addMarketSource`, `removeMarketSource`, `syncMarketSource`, `fetchMarketPacks(scope, projectId)`, `fetchMarketPack(...)`, `installPack(...)`, `updatePack(...)`, `uninstallPack(...)`.
+
+### 10.4 Edited UI files
+
+- **`src/app/sidebar.ts`** (~1382–1403) — insert a **Market** button in the second config-button row, **between** the Workflows button and the New Goal button. Pattern-match the Workflows button exactly:
+  ```ts
+  // after the Workflows <button>, before the New Goal <button>
+  <button class="… ${isMarketActive ? '…active…' : '…'}"
+    @click=${() => toggleConfigPage(["market", "market-pack"], () => {
+      import("./market-page.js").then(m => m.loadMarketPageData());
+      import("./routing.js").then(m => m.setHashRoute("market"));
+    })}
+    title="Browse extension marketplace">
+    ${icon(Store, "xs", "!w-3.5 !h-3.5")}<span>Market</span>
+  </button>
+  ```
+  Add `const isMarketActive = isRouteActive("market", "market-pack");` next to the other `is*Active` flags. Import a `Store`/`ShoppingBag` icon from `lucide`.
+- **`src/app/routing.ts`** — add `"market"` and `"market-pack"` to `RouteView`; add to `CONFIG_VIEWS`; add `getRouteFromHash` cases (`#/market`, `#/market/:sourceId/:packId`); add `setHashRoute` cases.
+- **`src/app/render.ts`** (~2400 `mainArea()`) — add:
+  ```ts
+  if (route.view === "market" || route.view === "market-pack") {
+    return lazyPage("market", () => import("./market-page.js"), "renderMarketPage");
+  }
+  ```
+- **`src/app/main.ts`** — add `import "./market-page.css";` (eager CSS, mirroring `workflow-page.css`); add the route-load branches alongside the existing `route.view === "workflows"` handlers (~270, ~491) to call `loadMarketPageData()` on direct navigation/reload.
+
+### 10.5 Defaults / fixtures (not production, but shipped)
+
+- Optionally ship a tiny **example source** under `tests/fixtures/marketplace/` (a 2-pack tree) used by both unit and E2E tests (see §11). No production `defaults/` change is required for the MVP.
+
+---
+
+## 11. Test plan
+
+Follows AGENTS.md: unit via `file://` fixtures; one mandatory browser E2E for the user-facing flow, patterned after the config-page UI E2Es (`tests/e2e/ui/workflow-page-scope.spec.ts`, `tests/e2e/ui/tool-assistant-system-scope.spec.ts`).
+
+### 11.1 Unit tests (`tests/marketplace-*.test.ts`, fixture trees)
+
+Build a fixture source tree under `tests/fixtures/marketplace/source-a/` with: a valid `research-pack` (role + tool group + skill), a valid `roles-only-pack`, an **invalid** pack (declares a role that doesn't exist), and a non-pack dir (no `pack.yaml`).
+
+1. **`marketplace-pack-scanner.test.ts`**
+   - Scans only dirs with `pack.yaml`; ignores the non-pack dir.
+   - Parses `pack.yaml` fields; rejects `apiVersion !== 1` (unsupported, not crash).
+   - Validates declared-vs-on-disk: invalid pack surfaces `error`, valid siblings still returned.
+   - `hasTools` true iff a tool entity is declared.
+2. **`marketplace-install.test.ts`** (point config dirs at a temp dir)
+   - Whole-pack install copies role yaml, tool group dir (recursive, incl. `extension.ts` + `_shared/`), and skill dir to the correct scope paths.
+   - Project-scope skill install also registers the custom skills dir in project config (`config_directories`), and the path is absolute.
+   - Subset install copies only the requested entities.
+   - Installed role resolves through `ConfigCascade.resolveRoles(projectId)` with the expected `origin` (server vs project) — reuses `config-cascade.test.ts` harness style.
+3. **`marketplace-conflict.test.ts`**
+   - `fail` mode: pre-existing dest at same scope → 409-equivalent, nothing written.
+   - `overwrite` / `skip` behave as specified.
+   - Same-name builtin at a *lower* layer is **not** a conflict (cascade shadow).
+   - Mid-copy failure rolls back partial writes.
+4. **`marketplace-provenance.test.ts`**
+   - Install writes a provenance record with exact `installedPaths` at the right file (system vs project).
+   - Uninstall removes exactly those paths and the record; deregisters an emptied custom skill dir.
+   - Update re-copies recorded entities, refreshes commit/version, and drops entities the new version no longer declares.
+5. **`marketplace-source-registry.test.ts`**
+   - add/remove/list round-trips through `sources.json` (atomic write); id assignment; local-path validation rejects relative/missing paths.
+   - (Git sync covered at integration level; unit test uses a `LocalSourceBackend` source to keep it hermetic.)
+
+### 11.2 Browser E2E (`tests/e2e/ui/marketplace.spec.ts`) — mandatory
+
+Pattern after `workflow-page-scope.spec.ts`: create a temp project, point a **local** marketplace source at the fixture tree, drive the UI.
+
+1. **Market button** is visible in the sidebar **between Workflows and New Goal**, and clicking it opens the Market surface (`#/market`).
+2. **Add source** — open the add-source dialog, add a `local` source pointing at the fixture tree; the source appears with sync status.
+3. **Browse packs** — the fixture packs list with name/description/version/contained entities; a tool-bearing pack shows the "executable code" badge; the invalid pack shows its error and is not installable.
+4. **Install a pack** (project scope) — confirm the executable-code warning dialog, install; assert success.
+5. **Entities resolve** — navigate to Roles page (project scope): the installed role appears with `project` origin badge. (Tool similarly on Tools page.) This proves cascade integration end-to-end.
+6. **Persists across reload** — reload; installed status + provenance survive (records are on disk); the role still resolves.
+7. **Uninstall** — uninstall the pack; the role disappears from the Roles page; installed status returns to `not-installed`; the role file is gone from `<project>/.bobbit/config/roles/`.
+
+### 11.3 Out-of-scope for tests
+
+Real private-repo git auth, registry backend, and trust enforcement are deferred features — no tests in the MVP beyond asserting the seam interfaces compile and the warning renders.
+
+---
+
+## 12. Open-question resolutions (index)
+
+| Goal "must resolve" item | Resolution | Section |
+|---|---|---|
+| Exact `pack.yaml` schema | Defined (apiVersion/id/name/description/version + `contents.{roles,tools,skills}`) | §2.2 |
+| Individual-entity install allowed? | **Yes** — drill-down per-entity install, same engine | §6.1 |
+| Source-registry persistence scope/shape | **Server-global** JSON `<stateDir>/marketplace/sources.json` | §3 |
+| Git sync mechanism | Shallow clone; fetch+reset+clean re-sync; reclone on corruption; ambient git creds | §4 |
+| Install-scope model + cascade interaction | `system`/`project`; writes land in the exact dirs `ConfigCascade` reads; group-level tool overlay | §6.2 |
+| Conflict/override rules | `fail`(default)/`overwrite`/`skip`; same-scope only; transactional | §6.5 |
+| Provenance record shape + location | Defined; committed per-scope `.bobbit/config/marketplace/installed.json` | §7 |
+| Skills install path (key open question) | Project → `.bobbit/config/skills/` + custom-dir registration; System → `~/.bobbit/skills/` | §6.3 |
+| Seams for panels/workflows/staff/trust/registry | Entity-handler registry + source-backend interface + trust gate call site | §8 |
+| "Installs executable code" warning | Badge + drill-down notice + install-confirm gate, driven by `carriesCode` | §9 |
+```
+

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -1,0 +1,417 @@
+# Marketplace — Extension Packs
+
+The Marketplace lets a user point Bobbit at git repos or local directories that
+contain **Extension Packs**, browse the packs they hold, and install a pack's
+entities (roles, tools, skills) into the local config layers Bobbit already
+reads. There is no hosted registry, no signing, and no sandbox — the model is
+deliberately simple: *"point at repos with the right layout, install locally."*
+
+This document describes how the feature behaves and why it is shaped the way it
+is. The implementation-ready design rationale (every resolved open question,
+the file-by-file plan, the test plan) lives in
+[docs/design/marketplace-mvp.md](design/marketplace-mvp.md); this page is the
+durable behaviour reference.
+
+## Why it exists
+
+Bobbit's roles, tools, and skills are already pluggable through a three-layer
+config cascade (builtin → server → project). But there was no way to *share* a
+themed bundle of them. The Marketplace fills that gap with the smallest thing
+that works: a pack is just a directory tree laid out like Bobbit's own
+`defaults/`, and "installing" it is just copying files into the config layer the
+cascade reads. Nothing about resolution changes — an installed role is
+byte-identical to a hand-authored one and resolves with the same origin badge
+and scope semantics. That is the central design bet: **lean entirely on existing
+mechanisms instead of inventing a parallel plugin runtime.**
+
+## Where it fits
+
+```
+Source (git repo / local dir)
+  └─ pack directory (has pack.yaml)
+       ├─ roles/<name>.yaml        ─┐
+       ├─ tools/<group>/...         ├─ install → .bobbit/config/... (or ~/.bobbit/skills)
+       └─ skills/<name>/SKILL.md   ─┘            ↓
+                                          ConfigCascade / skill discovery
+                                                 ↓
+                                          resolves like hand-authored config
+```
+
+- **Source registry** — server-global list of where to fetch packs from.
+- **Sync** — clone/pull git sources into a state cache; local dirs read in place.
+- **Scanner** — turns a synced source root into a list of packs + their entities.
+- **Install engine** — copies a pack's entities into a config layer and records
+  provenance so update/uninstall are exact and reversible.
+- **Market page** — the browse/install UI, reached from a sidebar button.
+
+The headline unit of distribution is the **pack**, not the loose entity. A
+source contains one or more packs; a pack bundles several entity types around a
+theme (e.g. a "Research Pack" of research roles, a web-digging tool, and a
+deep-research skill).
+
+## The unit of distribution: packs
+
+A **source** is a git repo or a local directory. Its top level is a *collection
+of pack directories* — never a flat `defaults/` mirror. A directory is a pack
+**iff it contains a `pack.yaml`**; directories without one are ignored, so a
+source repo can carry a README, CI config, etc. at the top level without
+confusing the scanner. Scanning is **one level deep** — only immediate children
+of the source root are considered.
+
+```
+<source-root>/
+  research-pack/
+    pack.yaml          # REQUIRED — makes this dir a pack
+    roles/researcher.yaml
+    tools/research/{*.yaml, extension.ts, _shared/...}
+    skills/deep-research/SKILL.md
+  qa-pack/
+    pack.yaml
+    roles/qa-lead.yaml
+  README.md            # ignored (no pack.yaml)
+```
+
+The entity payload layout *inside* a pack mirrors Bobbit's `defaults/` tree
+exactly, so authoring a pack is the same as authoring builtin config.
+
+### `pack.yaml` manifest
+
+`pack.yaml` is the pack's identity **and** a declaration of its contents. The
+declaration is authoritative: a declared entity missing on disk makes the pack
+invalid, while an on-disk entity that is not declared is ignored. This keeps
+install deterministic and lets an author ship example/unsupported files without
+them being installed.
+
+```yaml
+apiVersion: 1                 # REQUIRED int. Schema version; MVP accepts only 1.
+id: research-pack             # REQUIRED. Stable id, unique within the source.
+                              #   Pattern: ^[a-z0-9][a-z0-9-]*$
+name: Research Pack           # REQUIRED. Display name.
+description: Research roles…  # REQUIRED. Shown in the browse list + drill-down.
+version: 1.2.0                # REQUIRED. Author-declared label. Displayed + recorded
+                              #   in provenance, but NOT used for ordering (the git
+                              #   commit SHA is the real freshness signal).
+author: jane@example.com      # OPTIONAL
+homepage: https://...         # OPTIONAL (rendered as a link only for http/https)
+license: MIT                  # OPTIONAL
+minBobbit: "0.80.0"           # OPTIONAL. Advisory only — shown, not enforced.
+
+contents:                     # REQUIRED. At least one non-empty list required.
+  roles:  [researcher]        # role file basenames (no .yaml) → roles/<name>.yaml
+  tools:  [research]          # tool GROUP dir names → tools/<group>/
+  skills: [deep-research]     # skill dir names → skills/<name>/ (must contain SKILL.md)
+```
+
+**Validation.** A pack is valid when `pack.yaml` parses, `apiVersion === 1`,
+`id`/`name`/`description`/`version` are non-empty strings, `id` matches the
+pattern, `contents` declares at least one supported entity, and every declared
+entity exists on disk with the right shape (a role file that parses and whose
+internal `name` matches the filename; a tool group dir with ≥1 `*.yaml`
+carrying a `name:`; a skill dir with a `SKILL.md`). Validation failures are
+**non-fatal at the source level**: an invalid pack is surfaced with an error and
+marked non-installable, while valid sibling packs remain usable. Two packs in
+one source claiming the same `id` are *all* marked invalid (the id is ambiguous
+for install/uninstall keying).
+
+**Forward-compat.** Unknown top-level keys and unknown `contents` keys (e.g. a
+future `contents.panels`) are preserved and ignored — never an error. This is
+what lets a future entity type ship in a pack today and become installable the
+moment a handler for it is registered (see [Extensibility](#extensibility)).
+
+## Source registry
+
+The list of configured sources is persisted **server-globally**, not
+per-project, at `<server-root>/.bobbit/state/marketplace/sources.json`.
+
+**Why server-global.** A source answers "where do I fetch packs from?" — a
+machine/user-level concern, independent of any project, typically serving many
+projects, and authenticated with the user's ambient git credentials (one
+identity per machine). Per-project source lists would force re-registering the
+same repos everywhere. Only the *source list* is global; install *scope* (system
+vs project) is still chosen per-install. This mirrors `ProjectRegistry`, itself
+a server-global JSON store with the same atomic temp-file-plus-rename write.
+
+The registry file stores the original git URL **with any embedded credentials**
+(git needs them to authenticate) and is written `0600` where the OS honours
+POSIX modes. Every record that leaves the server is passed through credential
+redaction first, so tokens in userinfo (`user:token@host`), query params
+(`?token=`, `?access_token=`, …), or a credential-bearing fragment never appear
+in an API response, a derived label, or a provenance record. See
+[docs/security.md](security.md) for the broader credential-handling posture.
+
+## Sync
+
+`MarketplaceSyncService` owns the sync cache under
+`<server-root>/.bobbit/state/marketplace/<source-id>/`. Sources are reached
+through a `SourceBackend` interface so the scanner always operates on a resolved
+`root` regardless of backend.
+
+- **Git sources.** First sync is a **shallow clone** (`--depth 1`, optional
+  `--branch <ref>`); the cache stays small because packs are small text trees.
+  Re-sync is **fetch + hard reset + clean** rather than `pull`, to avoid merge
+  conflicts in a cache the user never edits; a missing/corrupt cache falls back
+  to a fresh clone. After each sync the HEAD SHA is recorded as
+  `lastSyncCommit` — the real freshness signal for update detection. Auth relies
+  entirely on the user's ambient git credentials; a failure is surfaced as
+  `lastSyncError` (fully credential-redacted) while leaving any previous good
+  cache intact. Git runs as a child process with a bounded timeout.
+- **Local sources.** Read **in place** — no clone, no copy. The scanner always
+  reads the live directory, so on-disk edits are reflected immediately (good for
+  authors iterating locally). A "sync" just re-validates that the path still
+  exists; `lastSyncCommit` is `null`.
+
+URLs and refs are validated on add and re-validated before reaching git's argv
+(defence-in-depth against a tampered `sources.json`): a leading `-` is rejected
+so a URL/ref can never be parsed as a git option, only well-known transport
+schemes are allowed, and `--` terminates option parsing in every git
+invocation.
+
+Adding a **git** source awaits the first sync so the initial browse reflects
+real cache state and surfaces sync errors immediately; a **local** source syncs
+fire-and-forget because reading in place is cheap.
+
+## Browse
+
+`scanSource` turns a synced source root into a list of packs, and the browse API
+composes scanner output across all sources, annotating each pack with an install
+status computed from provenance for the requested scope:
+
+| Status | Meaning |
+|---|---|
+| `not-installed` | No provenance record for this pack at this scope. |
+| `installed` | Provenance exists and on-disk bytes match what was installed. |
+| `update-available` | The source's current commit (git) or content hash (local) differs from what was recorded at install. |
+| `drifted` | A recorded install path is missing, or its bytes were edited locally (per-entity content-hash mismatch). Surfaced so the user knows update/uninstall may be partial. Records predating the content-hash field fall back to existence-only drift detection. |
+
+The browse list also reports `newEntitiesAvailable` — declared entities the
+install record does not yet track (an upstream pack grew new entities since you
+installed it). Update never auto-adds these (see below); the UI prompts the user
+to re-install the pack to add them.
+
+## Install, update, uninstall
+
+### Scope and the cascade
+
+Install scope is **`system`** (server layer) or **`project`** (a specific
+project), reusing Bobbit's existing config-scope vocabulary so installed
+entities resolve through `ConfigCascade` exactly like hand-authored config:
+
+| Scope | Roles → | Tools → | Skills → |
+|---|---|---|---|
+| `system` | `<server-root>/.bobbit/config/roles/<name>.yaml` | `<server-root>/.bobbit/config/tools/<group>/` | `~/.bobbit/skills/<name>/` |
+| `project` | `<project-root>/.bobbit/config/roles/<name>.yaml` | `<project-root>/.bobbit/config/tools/<group>/` | `<project-root>/.bobbit/config/skills/<name>/` + custom-dir registration |
+
+These are exactly the directories the cascade already reads, so the origin badge
+("server" vs "project") and the "overrides" indicator come for free. Tool
+overlay is **group-level**: a group present in a higher layer replaces the
+entire builtin group of the same name — the same semantics as the existing
+tool-customize copy.
+
+### Why skills install differently
+
+Skills are the one entity type that does **not** ride the role/tool cascade.
+`discoverSlashSkills` resolves skills from the *session cwd* (a worktree), not
+the project root the server reads roles/tools from, so a naive
+`<project-root>/.bobbit/config/skills` would never be scanned. Two paths are
+guaranteed to be scanned and are used instead:
+
+- **Project scope** → skills are copied to
+  `<project-root>/.bobbit/config/skills/<name>/` **and** that directory is
+  registered (idempotently) as an absolute-path custom skills directory in the
+  project's `config_directories`. Discovery resolves custom dirs as absolute
+  paths regardless of session cwd, so every worktree session of the project sees
+  the skill, with no git commit required to propagate it.
+- **System scope** → skills are copied to `~/.bobbit/skills/<name>/`, which
+  discovery scans unconditionally for every session on the machine.
+
+The project-scope custom-dir registration is reconciled against on-disk reality
+as the **final step** of every install/uninstall/update/rollback: the "skills"
+registration exists *iff* the shared dir currently holds ≥1 skill. This single
+invariant means uninstalling one skill pack can never break a sibling pack that
+still lives under the shared dir, and the registration can never drift.
+
+### Whole-pack and per-entity install
+
+Installing the whole pack is the primary action, but installing an individual
+entity from a pack's drill-down is also allowed — the install primitive is
+naturally per-entity (each entity copies independently), so whole-pack install
+is just "install every declared entity." Provenance records exactly which
+entities were installed, so uninstall is symmetric whether the user took the
+whole pack or a subset. A subset install into an already-installed pack
+*merges* into the existing record (union by type/name) rather than replacing it.
+
+### Conflict handling
+
+A conflict is: the destination already exists *at the target scope*. The install
+API takes a `conflict` mode, defaulting to **`fail`**:
+
+- `fail` — abort the whole install transactionally; the API returns `409` with
+  the conflicting entities. Nothing is written. The UI then offers to overwrite.
+- `overwrite` — replace the existing entity. If it was previously
+  marketplace-installed by another pack, ownership transfers to the new pack so
+  uninstall stays symmetric (the prior pack must not later delete an entity it
+  no longer owns).
+- `skip` — install only the non-conflicting entities and report which were
+  skipped.
+
+Conflicts are evaluated against the **same scope only** — installing at project
+scope when a builtin/server entity of the same name exists is *not* a conflict;
+that is normal cascade-shadow behaviour, surfaced by the origin "overrides"
+badge.
+
+### Transactionality
+
+Install computes the full plan, runs all conflict checks first, then copies.
+Overwrite targets are moved aside to a temp backup before copying, so a mid-copy
+failure rolls back every write — already-copied entities are removed and backups
+restored — leaving the system byte-for-byte as it was. Provenance is written
+only after all copies succeed. Update applies the same transactional discipline
+across both removals and copies.
+
+### Update
+
+Update re-syncs the source first (and **aborts** if the sync failed, rather than
+recording a stale/null commit), then re-copies exactly the entities the existing
+provenance record tracks and the updated pack still declares. Entities the new
+pack version no longer declares are removed (so update never leaves orphans);
+newly-declared entities are **never** auto-added — update is "refresh what I
+have," and the UI surfaces new entities via `newEntitiesAvailable`. The original
+install intent (whole-pack vs subset) is preserved on the rewritten record. If
+the updated pack no longer declares any tracked entity, the provenance record is
+removed entirely rather than left as a phantom empty "installed" record.
+
+### Uninstall
+
+Uninstall deletes exactly the `installedPaths` the provenance record tracks
+(refusing any path that escapes the entity type's destination dir, in case of a
+tampered provenance file), reconciles the project skills registration, and drops
+the record.
+
+### After any change
+
+Caches are invalidated so entities resolve immediately: role stores reload, the
+tool scan cache is reset (it is mtime-keyed and Windows mtime is coarse), and
+the skills custom-dir registration bump naturally invalidates the
+discovery cache.
+
+## Provenance
+
+Provenance is what makes update/uninstall exact and reversible: it records the
+precise paths install wrote, plus the source commit/version and a per-entity
+content hash. It is **committed alongside the entities it tracks**, per scope:
+
+- **System scope** → `<server-root>/.bobbit/config/marketplace/installed.json`
+- **Project scope** → `<project-root>/.bobbit/config/marketplace/installed.json`
+
+Installed entities live in committed `.bobbit/config/`, so provenance must
+travel with them — a teammate who pulls the repo can then cleanly update or
+uninstall. (The *source registry*, by contrast, is per-machine runtime state in
+`.bobbit/state/`, because it is about fetch locations and credentials, not
+installed artifacts.) The record key is the tuple
+`(scope, projectId, sourceId, packId)`. A corrupt or hand-edited
+`installed.json` never crashes the server: records failing the shape contract
+are dropped on load.
+
+## "Installs executable code" warning
+
+A pack containing any **tool** entity ships executable `extension.ts`. The MVP
+performs **no sandboxing or signing**, so the risk is made explicit at three
+points: a warning chip on the pack card, a prominent notice on the drill-down,
+and a confirmation dialog before installing (or updating) any code-bearing
+entity. Whether an entity is code-bearing is driven by a per-entity-type
+`carriesCode` flag, so the warning automatically covers future code-bearing
+types (e.g. panels). Enforcement (a trust/permission model) is deferred — see
+the seam below.
+
+## REST API
+
+All routes are under `/api/marketplace`. Scope is validated by a shared helper:
+scope must be `system` or `project` (empty defaults to `system`), and `project`
+requires a non-empty `projectId`; anything else is a `400`. See
+[docs/rest-api.md](rest-api.md) for the full API surface.
+
+| Method | Route | Effect |
+|---|---|---|
+| `GET` | `/sources` | List sources with sync status (credential-redacted). |
+| `POST` | `/sources` | Add a source (`{kind, url?, ref?, path?, label?}`); validates, assigns an id, kicks the first sync. |
+| `DELETE` | `/sources/:id` | Remove from the registry and delete its sync cache. Does **not** uninstall packs that came from it (installed entities are independent copies). |
+| `POST` | `/sources/:id/sync` | Re-sync and return updated status. |
+| `GET` | `/packs?scope=&projectId=` | List packs across all sources, annotated with install status for the scope. |
+| `GET` | `/packs/:sourceId/:packId?scope=&projectId=` | Drill-down: manifest + per-entity install status. |
+| `POST` | `/install` | `{sourceId, packId, scope, projectId?, entities?, conflict?}`. `entities` omitted ⇒ whole pack; otherwise a subset. Returns the provenance record + per-entity result. `409` (with `conflicts`) when `conflict=fail` and a destination exists. |
+| `POST` | `/update` | Re-sync, then re-copy the tracked entities. |
+| `POST` | `/uninstall` | Remove exactly the recorded paths and drop the record. |
+
+## Market page (UI)
+
+A **Market** button sits in the sidebar between **Workflows** and **New Goal**
+(`data-testid="sidebar-market-button"`), opening the marketplace at `#/market`.
+Pack drill-down is `#/market/<sourceId>/<packId>` (route view `market-pack`).
+
+The page reuses the shared config-scope model (`config-scope.ts`): the same
+System / project scope tabs as the Roles and Tools pages, defaulting to System
+when no project is active. The install-button label reflects the active scope
+("Install to System" / "Install to <Project>"). The list view shows a Sources
+section (add / re-sync / remove) and an Extension Packs grid; invalid packs
+render their error and are not installable; tool-bearing packs show the
+executable-code chip. The drill-down lists per-entity install controls plus pack
+metadata. Install/update/uninstall route through credential-safe gateway
+fetches, with the executable-code confirmation gating code-bearing actions and
+the `409` conflict response prompting an overwrite confirmation. A pack's
+attacker-controlled `homepage` is only rendered as a clickable link for
+`http`/`https` schemes.
+
+## Extensibility
+
+The MVP is intentionally small but designed so new entity types and new
+distribution backends are *additive*, not a redesign. Three boundaries deliver
+that:
+
+1. **Entity-type handler registry.** Each entity type (role / tool / skill)
+   provides one `EntityTypeHandler` describing its manifest key, payload path,
+   validation, install/uninstall, and `carriesCode` flag. The scanner, install
+   engine, and executable-code check all iterate the registry rather than
+   hardcoding types. **Adding a type is one new handler + one registry entry** —
+   no change to the scan/install/uninstall control flow. Because unknown
+   `contents` keys are already preserved, a pack can declare a future entity
+   type today and have it install the moment its handler is registered.
+2. **Source-backend interface.** Sync talks to sources through a `SourceBackend`
+   (`git`, `local` in the MVP). A hosted **registry** backend would implement
+   `sync` to fetch into the same cache layout, after which the identical
+   scanner/install pipeline runs. `sources.json` already carries a `kind`
+   discriminator, so adding `"registry"` is additive.
+3. **Trust-policy call site.** The install engine invokes a `TrustPolicy.check`
+   gate before any handler runs. In the MVP it is a no-op that only drives the
+   executable-code warning; a future phase can make it consult a
+   signature/allowlist and block. The call site exists from day one.
+
+### Deferred to later phases
+
+These are intentionally excluded from the MVP but on the roadmap, with seams
+left so each is additive (full rationale in
+[the design doc](design/marketplace-mvp.md#8-extensibility-seams)):
+
+- **UI Panels / plugins** (the eventual headline use case) — a `panels/` payload
+  dir + a `panelHandler` with `carriesCode: true`.
+- **Portable workflows** — blocked not by the marketplace but by workflows being
+  project-scoped and bound to project-specific `(component, command)` pairs
+  today; a future phase needs parameterised workflow bundles with a binding step.
+- **Staff templates** — staff are runtime state today, not config; a future
+  phase needs an exportable template shape first.
+- **Trust / sandboxing / signing** of code-bearing packs — the call site exists;
+  enforcement does not.
+- **Hosted / remote registry** with search/discovery — a new `SourceBackend`.
+
+## Testing
+
+- **Unit** (`file://` fixtures, `tests/marketplace-*.test.ts`): manifest parsing
+  and source-layout scanning, install/uninstall/update file operations,
+  provenance records, conflict handling, and the source registry — pointed at
+  fixture source trees.
+- **Browser E2E** (`tests/e2e/ui/marketplace.spec.ts`, mandatory per
+  [AGENTS.md](../AGENTS.md)): Market button visible and opens the marketplace →
+  add a local source → browse packs → install a pack → its entities resolve on
+  the Roles/Tools pages → persists across reload → uninstall.
+
+See [docs/testing-strategy.md](testing-strategy.md) for the broader testing
+approach.

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -1579,8 +1579,6 @@ export interface MarketSource {
 export interface MarketPackEntity {
 	type: "role" | "tool" | "skill";
 	name: string;
-	/** present on drill-down responses */
-	installStatus?: MarketInstallStatus;
 }
 
 export interface MarketPack {
@@ -1599,12 +1597,39 @@ export interface MarketPack {
 	installedCommit?: string | null;
 }
 
-export interface MarketPackDetail extends MarketPack {
-	author?: string;
-	homepage?: string;
-	license?: string;
-	minBobbit?: string;
-	manifest?: Record<string, any>;
+/**
+ * A single entity row in a pack drill-down. Flat contract: per-entity install
+ * state is a plain `installed` boolean (see GET /api/marketplace/packs/:s/:p).
+ */
+export interface MarketPackDetailEntity {
+	type: "role" | "tool" | "skill";
+	name: string;
+	installed: boolean;
+}
+
+/**
+ * Pack drill-down response — a FLAT shape returned directly by
+ * GET /api/marketplace/packs/:sourceId/:packId (no nesting). Optional manifest
+ * fields are `null` (not absent) so the renderer can treat them uniformly.
+ */
+export interface MarketPackDetail {
+	sourceId: string;
+	packId: string;
+	name: string;
+	description: string;
+	version: string;
+	sourceLabel: string;
+	author: string | null;
+	homepage: string | null;
+	license: string | null;
+	minBobbit: string | null;
+	hasTools: boolean;
+	valid: boolean;
+	error: string | null;
+	installStatus: MarketInstallStatus;
+	installedVersion: string | null;
+	installedCommit: string | null;
+	entities: MarketPackDetailEntity[];
 }
 
 export interface MarketActionResult {

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -1552,6 +1552,156 @@ export async function deleteWorkflow(id: string, projectId?: string): Promise<bo
 
 
 
+// ── Marketplace API ──────────────────────────────────────────────
+//
+// Shapes mirror docs/design/marketplace-mvp.md §3.3 / §5.2 / §6.6. The
+// server side is built in parallel; helpers are defensive (optional fields,
+// graceful fallbacks) so a missing/legacy field never crashes the page.
+
+/** Install scope vocabulary, reusing the config-scope model. */
+export type MarketScope = "system" | "project";
+
+export type MarketInstallStatus = "not-installed" | "installed" | "update-available" | "drifted";
+
+export interface MarketSource {
+	id: string;
+	kind: "git" | "local";
+	url?: string | null;
+	ref?: string | null;
+	path?: string | null;
+	label?: string;
+	addedAt?: number;
+	lastSyncedAt?: number | null;
+	lastSyncCommit?: string | null;
+	lastSyncError?: string | null;
+}
+
+export interface MarketPackEntity {
+	type: "role" | "tool" | "skill";
+	name: string;
+	/** present on drill-down responses */
+	installStatus?: MarketInstallStatus;
+}
+
+export interface MarketPack {
+	sourceId: string;
+	packId: string;
+	name: string;
+	description: string;
+	version: string;
+	sourceLabel?: string;
+	entities: MarketPackEntity[];
+	hasTools: boolean;
+	valid: boolean;
+	error?: string;
+	installStatus: MarketInstallStatus;
+	installedVersion?: string | null;
+	installedCommit?: string | null;
+}
+
+export interface MarketPackDetail extends MarketPack {
+	author?: string;
+	homepage?: string;
+	license?: string;
+	minBobbit?: string;
+	manifest?: Record<string, any>;
+}
+
+export interface MarketActionResult {
+	ok: boolean;
+	status: number;
+	data?: any;
+	error?: string;
+}
+
+async function marketPost(url: string, body: any): Promise<MarketActionResult> {
+	try {
+		const res = await gatewayFetch(url, { method: "POST", body: JSON.stringify(body) });
+		const data = await res.json().catch(() => null);
+		if (!res.ok) {
+			const error = (data && (data.error || data.message)) || `Failed: ${res.status}`;
+			return { ok: false, status: res.status, data, error };
+		}
+		return { ok: true, status: res.status, data };
+	} catch (err) {
+		const { message } = errorDetails(err);
+		return { ok: false, status: 0, error: message };
+	}
+}
+
+export async function fetchMarketSources(): Promise<MarketSource[]> {
+	try {
+		const res = await gatewayFetch("/api/marketplace/sources");
+		if (!res.ok) return [];
+		const data = await res.json();
+		return data.sources || [];
+	} catch {
+		return [];
+	}
+}
+
+export function addMarketSource(input: { kind: "git" | "local"; url?: string; ref?: string; path?: string; label?: string }): Promise<MarketActionResult> {
+	return marketPost("/api/marketplace/sources", input);
+}
+
+export async function removeMarketSource(id: string): Promise<boolean> {
+	try {
+		const res = await gatewayFetch(`/api/marketplace/sources/${encodeURIComponent(id)}`, { method: "DELETE" });
+		return res.ok || res.status === 204;
+	} catch {
+		return false;
+	}
+}
+
+export function syncMarketSource(id: string): Promise<MarketActionResult> {
+	return marketPost(`/api/marketplace/sources/${encodeURIComponent(id)}/sync`, {});
+}
+
+export async function fetchMarketPacks(scope: MarketScope, projectId?: string): Promise<MarketPack[]> {
+	const params = new URLSearchParams({ scope });
+	if (projectId) params.set("projectId", projectId);
+	try {
+		const res = await gatewayFetch(`/api/marketplace/packs?${params}`);
+		if (!res.ok) return [];
+		const data = await res.json();
+		return data.packs || [];
+	} catch {
+		return [];
+	}
+}
+
+export async function fetchMarketPack(sourceId: string, packId: string, scope: MarketScope, projectId?: string): Promise<MarketPackDetail | null> {
+	const params = new URLSearchParams({ scope });
+	if (projectId) params.set("projectId", projectId);
+	try {
+		const res = await gatewayFetch(`/api/marketplace/packs/${encodeURIComponent(sourceId)}/${encodeURIComponent(packId)}?${params}`);
+		if (!res.ok) return null;
+		return await res.json();
+	} catch {
+		return null;
+	}
+}
+
+export function installPack(args: {
+	sourceId: string;
+	packId: string;
+	scope: MarketScope;
+	projectId?: string;
+	entities?: { type: string; name: string }[];
+	conflict?: "fail" | "overwrite" | "skip";
+}): Promise<MarketActionResult> {
+	return marketPost("/api/marketplace/install", args);
+}
+
+export function updatePack(args: { sourceId: string; packId: string; scope: MarketScope; projectId?: string }): Promise<MarketActionResult> {
+	return marketPost("/api/marketplace/update", args);
+}
+
+export function uninstallPack(args: { sourceId: string; packId: string; scope: MarketScope; projectId?: string }): Promise<MarketActionResult> {
+	return marketPost("/api/marketplace/uninstall", args);
+}
+
+
 // ── Gate API ─────────────────────────────────────────────────────
 
 export interface GateState {

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -1595,6 +1595,12 @@ export interface MarketPack {
 	installStatus: MarketInstallStatus;
 	installedVersion?: string | null;
 	installedCommit?: string | null;
+	/**
+	 * Count of entities declared by the upstream pack that are NOT yet installed
+	 * at the active scope. >0 means re-installing would add new entities. Absent
+	 * on older server responses — treat missing as 0.
+	 */
+	newEntitiesAvailable?: number;
 }
 
 /**
@@ -1629,6 +1635,12 @@ export interface MarketPackDetail {
 	installStatus: MarketInstallStatus;
 	installedVersion: string | null;
 	installedCommit: string | null;
+	/**
+	 * Count of entities declared by the upstream pack that are NOT yet installed
+	 * at the active scope. >0 means re-installing would add new entities. Absent
+	 * on older server responses — treat missing as 0.
+	 */
+	newEntitiesAvailable?: number;
 	entities: MarketPackDetailEntity[];
 }
 

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -10,6 +10,7 @@ import "./app.css";
 import "./workflow-page.css";
 import "./role-manager.css";
 import "./tool-manager.css";
+import "./market-page.css";
 import "./storage.js"; // must initialize before anything else
 // Eagerly register <bg-process-pill> so it's available the moment the chat
 // view mounts. Lazy-loading via `ensureBgProcessPill()` (lazy-widgets.ts) was
@@ -319,6 +320,23 @@ async function handleHashChange(): Promise<void> {
 			loadSkillsPageData();
 			renderApp();
 			await refreshSessions();
+		} else if (route.view === "market" || route.view === "market-pack") {
+			clearDashboardState();
+			if (state.remoteAgent) {
+				state.remoteAgent.disconnect();
+				state.remoteAgent = null;
+				state.connectionStatus = "disconnected";
+			}
+			state.selectedSessionId = null;
+			state.goalDashboardId = null;
+			state.appView = "authenticated";
+			const { loadMarketPageData, navigateToMarketPack } = await import("./market-page.js");
+			await loadMarketPageData();
+			if (route.view === "market-pack" && route.marketSourceId && route.marketPackId) {
+				await navigateToMarketPack(route.marketSourceId, route.marketPackId);
+			}
+			renderApp();
+			await refreshSessions();
 		} else if (route.view === "staff") {
 			clearDashboardState();
 			if (state.remoteAgent) {
@@ -504,6 +522,13 @@ async function initApp() {
 			} else if (route.view === "skills") {
 				const { loadSkillsPageData } = await import("./skills-page.js");
 				loadSkillsPageData();
+			} else if (route.view === "market") {
+				const { loadMarketPageData } = await import("./market-page.js");
+				loadMarketPageData();
+			} else if (route.view === "market-pack" && route.marketSourceId && route.marketPackId) {
+				const { loadMarketPageData, navigateToMarketPack } = await import("./market-page.js");
+				await loadMarketPageData();
+				await navigateToMarketPack(route.marketSourceId, route.marketPackId);
 			} else if (route.view === "staff") {
 				const { loadStaffPageData } = await import("./staff-page.js");
 				loadStaffPageData();

--- a/src/app/market-page.css
+++ b/src/app/market-page.css
@@ -1,0 +1,624 @@
+/* ============================================================================
+ * MARKETPLACE PAGE
+ * Aligned with workflow-page.css / role-manager.css / tool-manager.css.
+ * Uses only theme custom properties — never hardcoded colours.
+ * ============================================================================ */
+
+.market-container {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	overflow-y: auto;
+	background: var(--background);
+	color: var(--foreground);
+}
+
+/* ── NAV BAR ─────────────────────────────────────────────────────────────── */
+
+.market-nav {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 12px 20px;
+	border-bottom: 1px solid var(--border);
+	background: var(--background);
+	position: sticky;
+	top: 0;
+	z-index: 10;
+	gap: 12px;
+}
+
+.market-nav-left {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	min-width: 0;
+}
+
+.market-nav-right {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex-shrink: 0;
+}
+
+.market-back {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 6px;
+	border-radius: 6px;
+	border: none;
+	background: transparent;
+	color: var(--muted-foreground);
+	cursor: pointer;
+	transition: background 150ms, color 150ms;
+}
+.market-back:hover {
+	background: var(--secondary);
+	color: var(--foreground);
+}
+
+.market-title-group {
+	display: flex;
+	align-items: baseline;
+	gap: 8px;
+	min-width: 0;
+}
+
+.market-title {
+	font-size: 16px;
+	font-weight: 600;
+	margin: 0;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.market-breadcrumb {
+	font-size: 14px;
+	color: var(--muted-foreground);
+	cursor: pointer;
+	transition: color 150ms;
+	flex-shrink: 0;
+}
+.market-breadcrumb:hover { color: var(--foreground); }
+
+.market-breadcrumb-sep {
+	font-size: 14px;
+	color: var(--muted-foreground);
+	flex-shrink: 0;
+}
+
+/* ── BODY ────────────────────────────────────────────────────────────────── */
+
+.market-body {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+	padding: 20px;
+}
+
+.market-body-inner {
+	max-width: 920px;
+	margin: 0 auto;
+	display: flex;
+	flex-direction: column;
+	gap: 28px;
+}
+
+.market-loading {
+	flex: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	color: var(--muted-foreground);
+	font-size: 14px;
+	padding: 80px 0;
+}
+
+.market-empty {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 12px;
+	padding: 80px 24px;
+	text-align: center;
+}
+.market-empty-title { font-size: 14px; font-weight: 600; margin: 0; }
+.market-empty-desc { font-size: 12px; color: var(--muted-foreground); margin: 0; max-width: 320px; line-height: 1.5; }
+
+/* ── SECTIONS ───────────────────────────────────────────────────────────── */
+
+.market-section {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+
+.market-section-head {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+}
+
+.market-section-title {
+	font-size: 13px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: var(--muted-foreground);
+	margin: 0;
+}
+
+.market-section-empty {
+	font-size: 13px;
+	color: var(--muted-foreground);
+	margin: 0;
+	line-height: 1.5;
+}
+.market-section-empty code {
+	font-family: var(--font-mono, monospace);
+	font-size: 12px;
+	padding: 1px 4px;
+	border-radius: 4px;
+	background: var(--secondary);
+}
+
+/* ── SOURCES ────────────────────────────────────────────────────────────── */
+
+.market-source-list {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.market-source-row {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 10px 14px;
+	background: var(--secondary);
+	border: 1px solid var(--border);
+	border-radius: 8px;
+}
+
+.market-source-icon {
+	display: flex;
+	align-items: center;
+	color: var(--muted-foreground);
+	flex-shrink: 0;
+}
+
+.market-source-info {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.market-source-name {
+	font-size: 14px;
+	font-weight: 500;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.market-source-sub {
+	font-size: 12px;
+	color: var(--muted-foreground);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.market-source-error {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	font-size: 11px;
+	color: var(--negative, var(--destructive));
+	margin-top: 2px;
+}
+
+.market-source-actions {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	flex-shrink: 0;
+}
+
+.market-action-btn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	border-radius: 6px;
+	border: none;
+	background: none;
+	color: var(--muted-foreground);
+	cursor: pointer;
+	transition: background 150ms, color 150ms;
+}
+.market-action-btn:hover { background: var(--background); color: var(--foreground); }
+.market-action-btn.delete:hover { color: var(--destructive); }
+.market-action-btn:disabled { opacity: 0.5; cursor: default; }
+
+.market-spin {
+	display: inline-flex;
+	animation: market-spin 0.9s linear infinite;
+}
+@keyframes market-spin { to { transform: rotate(360deg); } }
+
+/* ── PACK GRID ──────────────────────────────────────────────────────────── */
+
+.market-pack-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+	gap: 12px;
+}
+
+.market-pack-card {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding: 14px 16px;
+	background: var(--card, var(--secondary));
+	border: 1px solid var(--border);
+	border-radius: 10px;
+	cursor: pointer;
+	transition: background 150ms, border-color 150ms;
+}
+.market-pack-card:hover {
+	border-color: color-mix(in oklch, var(--muted-foreground) 30%, transparent);
+}
+.market-pack-card:focus-visible {
+	outline: 2px solid var(--ring);
+	outline-offset: 2px;
+}
+.market-pack-invalid {
+	cursor: default;
+	opacity: 0.85;
+}
+
+.market-pack-head {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.market-pack-name {
+	font-size: 14px;
+	font-weight: 600;
+}
+
+.market-pack-version {
+	font-size: 11px;
+	color: var(--muted-foreground);
+	font-family: var(--font-mono, monospace);
+}
+
+.market-pack-desc {
+	font-size: 12px;
+	color: var(--muted-foreground);
+	margin: 0;
+	line-height: 1.5;
+}
+
+.market-pack-error {
+	font-size: 12px;
+	color: var(--negative, var(--destructive));
+	margin: 0;
+	line-height: 1.5;
+}
+
+.market-pack-foot {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	margin-top: 4px;
+}
+
+.market-pack-foot-right {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.market-pack-source {
+	font-size: 11px;
+	color: var(--muted-foreground);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+/* ── ENTITY CHIPS ───────────────────────────────────────────────────────── */
+
+.market-entity-chips {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+}
+
+.market-entity-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	font-size: 11px;
+	padding: 2px 7px;
+	border-radius: 999px;
+	background: color-mix(in oklch, var(--muted-foreground) 12%, transparent);
+	color: var(--foreground);
+}
+
+/* ── BADGES ─────────────────────────────────────────────────────────────── */
+
+.market-code-badge {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	font-size: 10px;
+	font-weight: 600;
+	padding: 2px 7px;
+	border-radius: 999px;
+	background: color-mix(in oklch, var(--warning, var(--chart-4)) 18%, transparent);
+	color: var(--warning, var(--chart-4));
+}
+.market-code-badge--sm { font-size: 9px; padding: 1px 5px; }
+
+.market-pack-invalid-badge {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	font-size: 10px;
+	font-weight: 600;
+	padding: 2px 7px;
+	border-radius: 999px;
+	background: color-mix(in oklch, var(--destructive) 16%, transparent);
+	color: var(--destructive);
+}
+
+.market-status-badge {
+	font-size: 10px;
+	font-weight: 600;
+	padding: 2px 7px;
+	border-radius: 999px;
+	white-space: nowrap;
+}
+.market-status-not-installed {
+	background: color-mix(in oklch, var(--muted-foreground) 14%, transparent);
+	color: var(--muted-foreground);
+}
+.market-status-installed {
+	background: color-mix(in oklch, var(--positive, var(--chart-2)) 18%, transparent);
+	color: var(--positive, var(--chart-2));
+}
+.market-status-update-available {
+	background: color-mix(in oklch, var(--info, var(--chart-1)) 18%, transparent);
+	color: var(--info, var(--chart-1));
+}
+.market-status-drifted {
+	background: color-mix(in oklch, var(--warning, var(--chart-4)) 18%, transparent);
+	color: var(--warning, var(--chart-4));
+}
+
+.market-installed-check {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	font-size: 12px;
+	color: var(--positive, var(--chart-2));
+	font-weight: 500;
+}
+
+/* ── PACK DETAIL ────────────────────────────────────────────────────────── */
+
+.market-detail {
+	max-width: 920px;
+	margin: 0 auto;
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+}
+
+.market-detail-head {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.market-detail-title-row {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	flex-wrap: wrap;
+}
+
+.market-detail-name {
+	font-size: 20px;
+	font-weight: 600;
+	margin: 0;
+}
+
+.market-detail-desc {
+	font-size: 13px;
+	color: var(--muted-foreground);
+	margin: 0;
+	line-height: 1.55;
+	max-width: 640px;
+}
+
+.market-detail-actions {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-top: 4px;
+}
+
+.market-code-notice {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+	padding: 12px 14px;
+	border-radius: 8px;
+	font-size: 12px;
+	line-height: 1.5;
+	background: color-mix(in oklch, var(--warning, var(--chart-4)) 12%, transparent);
+	color: var(--foreground);
+	border: 1px solid color-mix(in oklch, var(--warning, var(--chart-4)) 35%, transparent);
+}
+.market-code-notice > span:first-of-type,
+.market-code-notice svg {
+	flex-shrink: 0;
+	color: var(--warning, var(--chart-4));
+}
+
+.market-detail-grid {
+	display: grid;
+	grid-template-columns: 1.4fr 1fr;
+	gap: 24px;
+	align-items: start;
+}
+@media (max-width: 720px) {
+	.market-detail-grid { grid-template-columns: 1fr; }
+}
+
+.market-entity-rows {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.market-entity-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 12px;
+	background: var(--secondary);
+	border: 1px solid var(--border);
+	border-radius: 8px;
+}
+
+.market-entity-icon { display: flex; color: var(--muted-foreground); flex-shrink: 0; }
+.market-entity-type {
+	font-size: 10px;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: var(--muted-foreground);
+	min-width: 36px;
+}
+.market-entity-name { font-size: 13px; font-weight: 500; }
+.market-entity-spacer { flex: 1; }
+
+.market-meta {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	padding: 12px 14px;
+	background: var(--secondary);
+	border: 1px solid var(--border);
+	border-radius: 8px;
+}
+
+.market-meta-row {
+	display: flex;
+	gap: 10px;
+	font-size: 12px;
+	align-items: baseline;
+}
+.market-meta-label {
+	color: var(--muted-foreground);
+	min-width: 110px;
+	flex-shrink: 0;
+}
+.market-meta-value {
+	color: var(--foreground);
+	word-break: break-word;
+}
+.market-link { color: var(--primary); text-decoration: underline; }
+
+/* ── ADD-SOURCE DIALOG ──────────────────────────────────────────────────── */
+
+.market-dialog-body {
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+	margin-top: 12px;
+}
+
+.market-kind-toggle {
+	display: flex;
+	gap: 6px;
+}
+
+.market-kind-btn {
+	flex: 1;
+	padding: 8px 10px;
+	font-size: 13px;
+	border-radius: 8px;
+	border: 1px solid var(--border);
+	background: var(--secondary);
+	color: var(--muted-foreground);
+	cursor: pointer;
+	transition: background 150ms, color 150ms, border-color 150ms;
+}
+.market-kind-btn:hover { color: var(--foreground); }
+.market-kind-btn.is-active {
+	background: var(--background);
+	color: var(--foreground);
+	border-color: var(--primary);
+	box-shadow: 0 0 0 1px var(--primary) inset;
+}
+
+.market-field {
+	display: flex;
+	flex-direction: column;
+	gap: 5px;
+}
+
+.market-field-label {
+	font-size: 12px;
+	font-weight: 500;
+	color: var(--foreground);
+}
+.market-field-opt { color: var(--muted-foreground); font-weight: 400; }
+
+.market-field-hint {
+	font-size: 11px;
+	color: var(--muted-foreground);
+	line-height: 1.4;
+}
+
+.market-input {
+	width: 100%;
+	padding: 8px 10px;
+	font-size: 13px;
+	border-radius: 8px;
+	border: 1px solid var(--border);
+	background: var(--background);
+	color: var(--foreground);
+	box-sizing: border-box;
+}
+.market-input:focus {
+	outline: none;
+	border-color: var(--primary);
+	box-shadow: 0 0 0 1px var(--primary);
+}
+
+.market-dialog-error {
+	font-size: 12px;
+	color: var(--destructive);
+	padding: 8px 10px;
+	border-radius: 8px;
+	background: color-mix(in oklch, var(--destructive) 12%, transparent);
+	line-height: 1.45;
+}

--- a/src/app/market-page.ts
+++ b/src/app/market-page.ts
@@ -172,10 +172,12 @@ async function showPack(pack: MarketPack): Promise<void> {
 async function handleScopeChange(scope: string): Promise<void> {
 	setConfigScope(scope);
 	loading = true;
+	if (currentView === "pack") loadingPack = true;
 	renderApp();
 	await refreshPacks();
 	if (currentView === "pack") await refreshSelectedPack();
 	loading = false;
+	loadingPack = false;
 	renderApp();
 }
 
@@ -558,7 +560,7 @@ function renderPackPrimaryAction(pack: PackActionTarget, busy: boolean, compact:
 			size: size as any,
 			disabled: busy,
 			onClick: stop(() => handleInstall(pack)),
-			children: html`<span class="inline-flex items-center gap-1.5" data-testid="market-install-btn">${icon(Download, "sm")} ${busy ? "Installing\u2026" : `Install`}</span>`,
+			children: html`<span class="inline-flex items-center gap-1.5" data-testid="market-install-btn">${icon(Download, "sm")} ${busy ? "Installing\u2026" : `Install to ${scopeLabel()}`}</span>`,
 		});
 	}
 	// installed / update-available / drifted → offer update (when available) + uninstall
@@ -733,7 +735,7 @@ export function renderMarketPage(): TemplateResult {
 	return html`
 		<div class="market-container">
 			${renderNavBar()}
-			${currentView === "list" ? renderConfigScopeRow(getConfigScope(), handleScopeChange) : ""}
+			${renderConfigScopeRow(getConfigScope(), handleScopeChange)}
 			<div class="market-body">
 				${currentView === "list" ? renderListView() : renderPackDetailView()}
 			</div>

--- a/src/app/market-page.ts
+++ b/src/app/market-page.ts
@@ -239,6 +239,15 @@ function entitiesCarryCode(entities: { type: string }[]): boolean {
 	return entities.some((e) => e.type === "tool");
 }
 
+/**
+ * Number of upstream-declared entities not yet installed at the active scope.
+ * The server omits this on older responses, so treat missing/invalid as 0.
+ */
+function newEntitiesCount(pack: { newEntitiesAvailable?: number }): number {
+	const n = pack.newEntitiesAvailable;
+	return typeof n === "number" && n > 0 ? n : 0;
+}
+
 async function handleInstall(pack: PackActionTarget, entities?: PackEntityRef[]): Promise<void> {
 	const toInstall = entities ?? pack.entities;
 	if (entitiesCarryCode(toInstall)) {
@@ -288,6 +297,14 @@ async function doInstall(pack: PackActionTarget, entities?: PackEntityRef[], con
 }
 
 async function handleUpdate(pack: PackActionTarget): Promise<void> {
+	// Update re-syncs and re-copies the pack's entities. If any carry executable
+	// code (tools), gate the action behind the same exec-code confirmation as
+	// install so the user re-acknowledges running un-sandboxed pack code.
+	if (entitiesCarryCode(pack.entities)) {
+		const { confirmAction } = await import("./dialogs.js");
+		const ok = await confirmAction("Update executable code", EXEC_CODE_WARNING, "Update", false);
+		if (!ok) return;
+	}
 	busyPackKey = packKey(pack.sourceId, pack.packId);
 	renderApp();
 	const result = await updatePack({
@@ -520,6 +537,9 @@ function renderPackCard(pack: MarketPack): TemplateResult {
 			<div class="market-pack-foot">
 				<span class="market-pack-source">${pack.sourceLabel || pack.sourceId}</span>
 				<div class="market-pack-foot-right">
+					${newEntitiesCount(pack) > 0
+						? html`<span class="market-status-badge market-status-update-available market-new-entities-badge" data-testid="market-new-entities-badge" title="Re-install this pack to add the new entities" data-count="${newEntitiesCount(pack)}">+${newEntitiesCount(pack)} new</span>`
+						: nothing}
 					${renderStatusBadge(pack.installStatus)}
 					${renderPackPrimaryAction(pack, busy, true)}
 				</div>
@@ -662,6 +682,13 @@ function renderPackDetailView(): TemplateResult {
 				<div class="market-code-notice" data-testid="market-code-notice" role="note">
 					${icon(AlertTriangle, "sm")}
 					<span>${EXEC_CODE_WARNING}</span>
+				</div>
+			` : nothing}
+
+			${newEntitiesCount(pack) > 0 ? html`
+				<div class="market-code-notice market-new-entities-notice" data-testid="market-new-entities-notice" role="note" data-count="${newEntitiesCount(pack)}">
+					${icon(Plus, "sm")}
+					<span>${newEntitiesCount(pack)} new ${newEntitiesCount(pack) === 1 ? "entity" : "entities"} available — re-install pack to add.</span>
 				</div>
 			` : nothing}
 

--- a/src/app/market-page.ts
+++ b/src/app/market-page.ts
@@ -42,6 +42,7 @@ import {
 	type MarketPack,
 	type MarketPackDetail,
 	type MarketPackEntity,
+	type MarketPackDetailEntity,
 	type MarketScope,
 	type MarketInstallStatus,
 } from "./api.js";
@@ -54,6 +55,20 @@ import { getConfigScope, setConfigScope, getConfigProjectId, getCurrentProjectNa
 // ============================================================================
 
 type View = "list" | "pack";
+
+// Minimal entity ref the install engine needs (type + name). Both list-card
+// entities (MarketPackEntity) and drill-down entities (MarketPackDetailEntity)
+// satisfy it, so install/update/uninstall handlers work from either surface.
+type PackEntityRef = { type: "role" | "tool" | "skill"; name: string };
+// Structural shape the install/update/uninstall handlers operate on. Both
+// MarketPack (cards) and MarketPackDetail (drill-down) are assignable to it.
+type PackActionTarget = {
+	sourceId: string;
+	packId: string;
+	name: string;
+	installStatus: MarketInstallStatus;
+	entities: PackEntityRef[];
+};
 
 let currentView: View = "list";
 let sources: MarketSource[] = [];
@@ -224,7 +239,7 @@ function entitiesCarryCode(entities: { type: string }[]): boolean {
 	return entities.some((e) => e.type === "tool");
 }
 
-async function handleInstall(pack: MarketPack, entities?: MarketPackEntity[]): Promise<void> {
+async function handleInstall(pack: PackActionTarget, entities?: PackEntityRef[]): Promise<void> {
 	const toInstall = entities ?? pack.entities;
 	if (entitiesCarryCode(toInstall)) {
 		const { confirmAction } = await import("./dialogs.js");
@@ -234,7 +249,7 @@ async function handleInstall(pack: MarketPack, entities?: MarketPackEntity[]): P
 	await doInstall(pack, entities);
 }
 
-async function doInstall(pack: MarketPack, entities?: MarketPackEntity[], conflict?: "fail" | "overwrite" | "skip"): Promise<void> {
+async function doInstall(pack: PackActionTarget, entities?: PackEntityRef[], conflict?: "fail" | "overwrite" | "skip"): Promise<void> {
 	busyPackKey = packKey(pack.sourceId, pack.packId);
 	renderApp();
 	const result = await installPack({
@@ -272,7 +287,7 @@ async function doInstall(pack: MarketPack, entities?: MarketPackEntity[], confli
 	}
 }
 
-async function handleUpdate(pack: MarketPack): Promise<void> {
+async function handleUpdate(pack: PackActionTarget): Promise<void> {
 	busyPackKey = packKey(pack.sourceId, pack.packId);
 	renderApp();
 	const result = await updatePack({
@@ -291,7 +306,7 @@ async function handleUpdate(pack: MarketPack): Promise<void> {
 	}
 }
 
-async function handleUninstall(pack: MarketPack): Promise<void> {
+async function handleUninstall(pack: PackActionTarget): Promise<void> {
 	const { confirmAction } = await import("./dialogs.js");
 	const ok = await confirmAction(
 		"Uninstall pack",
@@ -339,6 +354,21 @@ function sourceDisplayName(source: MarketSource): string {
 		return parts[parts.length - 1] || source.path;
 	}
 	return source.id;
+}
+
+/**
+ * Return the URL only when it is a safe clickable scheme (http/https), else
+ * null. A pack manifest's `homepage` is attacker-controlled, so we never render
+ * `javascript:`, `data:`, `file:` etc. as an anchor href.
+ */
+function safeHttpUrl(raw: string | null | undefined): string | null {
+	if (!raw) return null;
+	try {
+		const scheme = new URL(raw).protocol;
+		return scheme === "http:" || scheme === "https:" ? raw : null;
+	} catch {
+		return null;
+	}
 }
 
 function entityIcon(type: string): typeof Users {
@@ -499,7 +529,7 @@ function renderPackCard(pack: MarketPack): TemplateResult {
 }
 
 /** Primary install/update/uninstall control for a pack, used on cards + detail. */
-function renderPackPrimaryAction(pack: MarketPack, busy: boolean, compact: boolean): TemplateResult {
+function renderPackPrimaryAction(pack: PackActionTarget, busy: boolean, compact: boolean): TemplateResult {
 	const stop = (fn: () => void) => (e: Event) => { e.stopPropagation(); fn(); };
 	const size = compact ? "sm" : undefined;
 	if (pack.installStatus === "not-installed") {
@@ -570,18 +600,17 @@ function renderMetaRow(label: string, value: string | TemplateResult): TemplateR
 	return html`<div class="market-meta-row"><span class="market-meta-label">${label}</span><span class="market-meta-value">${value}</span></div>`;
 }
 
-function renderEntityDetailRow(pack: MarketPackDetail, entity: MarketPackEntity): TemplateResult {
-	const status = entity.installStatus;
+function renderEntityDetailRow(pack: MarketPackDetail, entity: MarketPackDetailEntity): TemplateResult {
 	const busy = busyPackKey === packKey(pack.sourceId, pack.packId);
 	return html`
-		<div class="market-entity-row" data-testid="market-entity-row" data-entity-type="${entity.type}" data-entity-name="${entity.name}">
+		<div class="market-entity-row" data-testid="market-entity-row" data-entity-type="${entity.type}" data-entity-name="${entity.name}" data-installed="${entity.installed ? "true" : "false"}">
 			<span class="market-entity-icon">${icon(entityIcon(entity.type), "sm")}</span>
 			<span class="market-entity-type">${entity.type}</span>
 			<span class="market-entity-name">${entity.name}</span>
 			${entity.type === "tool" ? html`<span class="market-code-badge market-code-badge--sm" title=${EXEC_CODE_WARNING}>${icon(AlertTriangle, "sm")} code</span>` : nothing}
 			<span class="market-entity-spacer"></span>
-			${status && status !== "not-installed"
-				? html`<span class="market-installed-check" data-testid="market-entity-installed">${icon(Check, "sm")} ${STATUS_LABELS[status]}</span>`
+			${entity.installed
+				? html`<span class="market-installed-check" data-testid="market-entity-installed">${icon(Check, "sm")} Installed</span>`
 				: Button({
 					variant: "ghost",
 					size: "sm" as any,
@@ -650,7 +679,14 @@ function renderPackDetailView(): TemplateResult {
 						${renderMetaRow("Source", pack.sourceLabel || pack.sourceId)}
 						${renderMetaRow("Pack ID", pack.packId)}
 						${pack.author ? renderMetaRow("Author", pack.author) : nothing}
-						${pack.homepage ? renderMetaRow("Homepage", html`<a class="market-link" href=${pack.homepage} target="_blank" rel="noreferrer noopener">${pack.homepage}</a>`) : nothing}
+						${pack.homepage
+							? renderMetaRow(
+								"Homepage",
+								safeHttpUrl(pack.homepage)
+									? html`<a class="market-link" href=${safeHttpUrl(pack.homepage)!} target="_blank" rel="noreferrer noopener">${pack.homepage}</a>`
+									: pack.homepage,
+							)
+							: nothing}
 						${pack.license ? renderMetaRow("License", pack.license) : nothing}
 						${pack.minBobbit ? renderMetaRow("Min Bobbit", pack.minBobbit) : nothing}
 						${pack.installedVersion ? renderMetaRow("Installed version", pack.installedVersion) : nothing}

--- a/src/app/market-page.ts
+++ b/src/app/market-page.ts
@@ -1,0 +1,679 @@
+// ============================================================================
+// MARKET PAGE — Extension Pack marketplace (browse / install / update / uninstall)
+//
+// Implements the UI described in docs/design/marketplace-mvp.md §5 / §6 / §9 /
+// §10.3-§10.4. The page reuses the shared config-scope model (System vs a
+// project) so installed roles/tools/skills resolve through ConfigCascade /
+// skill-discovery exactly like hand-authored config — same scope tabs.
+//
+// CSS lives in market-page.css, eagerly imported from main.ts so the lazy page
+// chunk always renders styled.
+// ============================================================================
+
+import { icon } from "@mariozechner/mini-lit";
+import { Button } from "@mariozechner/mini-lit/dist/Button.js";
+import { html, nothing, type TemplateResult } from "lit";
+import {
+	AlertCircle,
+	AlertTriangle,
+	ArrowLeft,
+	Check,
+	Download,
+	FolderOpen,
+	GitBranch,
+	Package,
+	Plus,
+	RefreshCw,
+	Trash2,
+	Users,
+	Wrench,
+	Zap,
+} from "lucide";
+import {
+	fetchMarketSources,
+	fetchMarketPacks,
+	fetchMarketPack,
+	removeMarketSource,
+	syncMarketSource,
+	installPack,
+	updatePack,
+	uninstallPack,
+	type MarketSource,
+	type MarketPack,
+	type MarketPackDetail,
+	type MarketPackEntity,
+	type MarketScope,
+	type MarketInstallStatus,
+} from "./api.js";
+import { renderApp } from "./state.js";
+import { setHashRoute } from "./routing.js";
+import { getConfigScope, setConfigScope, getConfigProjectId, getCurrentProjectName, renderConfigScopeRow } from "./config-scope.js";
+
+// ============================================================================
+// STATE
+// ============================================================================
+
+type View = "list" | "pack";
+
+let currentView: View = "list";
+let sources: MarketSource[] = [];
+let packs: MarketPack[] = [];
+let selectedPack: MarketPackDetail | null = null;
+let selectedSourceId = "";
+let selectedPackId = "";
+let loading = true;
+let loadingPack = false;
+// Per-source / per-pack busy flags keyed by id so spinners stay scoped.
+let syncingSourceId: string | null = null;
+let busyPackKey: string | null = null;
+
+function packKey(sourceId: string, packId: string): string {
+	return `${sourceId}::${packId}`;
+}
+
+function currentScope(): MarketScope {
+	return getConfigScope() === "system" ? "system" : "project";
+}
+
+function scopeLabel(): string {
+	return currentScope() === "system" ? "System" : (getCurrentProjectName() || "Project");
+}
+
+// ============================================================================
+// DATA LOADING
+// ============================================================================
+
+async function refreshPacks(): Promise<void> {
+	packs = await fetchMarketPacks(currentScope(), getConfigProjectId());
+}
+
+async function refreshSelectedPack(): Promise<void> {
+	if (!selectedSourceId || !selectedPackId) return;
+	selectedPack = await fetchMarketPack(selectedSourceId, selectedPackId, currentScope(), getConfigProjectId());
+}
+
+export async function loadMarketPageData(): Promise<void> {
+	currentView = "list";
+	selectedPack = null;
+	selectedSourceId = "";
+	selectedPackId = "";
+	loading = true;
+	syncingSourceId = null;
+	busyPackKey = null;
+	renderApp();
+	sources = await fetchMarketSources();
+	await refreshPacks();
+	loading = false;
+	renderApp();
+}
+
+export function clearMarketPageState(): void {
+	currentView = "list";
+	selectedPack = null;
+	sources = [];
+	packs = [];
+	loading = true;
+}
+
+/** Deep-link entry: ensure list data is present, then open a pack drill-down. */
+export async function navigateToMarketPack(sourceId: string, packId: string): Promise<void> {
+	selectedSourceId = sourceId;
+	selectedPackId = packId;
+	currentView = "pack";
+	loadingPack = true;
+	renderApp();
+	if (sources.length === 0) sources = await fetchMarketSources();
+	if (packs.length === 0) await refreshPacks();
+	await refreshSelectedPack();
+	loadingPack = false;
+	renderApp();
+}
+
+// ============================================================================
+// NAVIGATION
+// ============================================================================
+
+function showList(): void {
+	currentView = "list";
+	selectedPack = null;
+	selectedSourceId = "";
+	selectedPackId = "";
+	setHashRoute("market");
+}
+
+async function showPack(pack: MarketPack): Promise<void> {
+	currentView = "pack";
+	selectedSourceId = pack.sourceId;
+	selectedPackId = pack.packId;
+	selectedPack = null;
+	loadingPack = true;
+	setHashRoute("market-pack", `${pack.sourceId}/${pack.packId}`);
+	renderApp();
+	await refreshSelectedPack();
+	loadingPack = false;
+	renderApp();
+}
+
+async function handleScopeChange(scope: string): Promise<void> {
+	setConfigScope(scope);
+	loading = true;
+	renderApp();
+	await refreshPacks();
+	if (currentView === "pack") await refreshSelectedPack();
+	loading = false;
+	renderApp();
+}
+
+// ============================================================================
+// SOURCE ACTIONS
+// ============================================================================
+
+async function handleAddSource(): Promise<void> {
+	const { openAddSourceDialog } = await import("./market-source-dialog.js");
+	const added = await openAddSourceDialog();
+	if (!added) return;
+	loading = true;
+	renderApp();
+	sources = await fetchMarketSources();
+	await refreshPacks();
+	loading = false;
+	renderApp();
+}
+
+async function handleSyncSource(source: MarketSource): Promise<void> {
+	syncingSourceId = source.id;
+	renderApp();
+	const result = await syncMarketSource(source.id);
+	syncingSourceId = null;
+	sources = await fetchMarketSources();
+	await refreshPacks();
+	if (currentView === "pack") await refreshSelectedPack();
+	if (!result.ok) {
+		const { showConnectionError } = await import("./dialogs.js");
+		showConnectionError("Failed to sync source", result.error || "Unknown error");
+	}
+	renderApp();
+}
+
+async function handleRemoveSource(source: MarketSource): Promise<void> {
+	const { confirmAction } = await import("./dialogs.js");
+	const ok = await confirmAction(
+		"Remove source",
+		`Remove "${sourceDisplayName(source)}" from the marketplace? Installed packs are independent copies and stay installed.`,
+		"Remove",
+		true,
+	);
+	if (!ok) return;
+	const removed = await removeMarketSource(source.id);
+	if (removed) {
+		sources = await fetchMarketSources();
+		await refreshPacks();
+		renderApp();
+	}
+}
+
+// ============================================================================
+// INSTALL / UPDATE / UNINSTALL
+// ============================================================================
+
+const EXEC_CODE_WARNING =
+	"This pack installs executable code (tools) that runs with your agent's privileges. " +
+	"Bobbit does not sandbox or verify pack code. Only install packs from sources you trust.";
+
+function entitiesCarryCode(entities: { type: string }[]): boolean {
+	return entities.some((e) => e.type === "tool");
+}
+
+async function handleInstall(pack: MarketPack, entities?: MarketPackEntity[]): Promise<void> {
+	const toInstall = entities ?? pack.entities;
+	if (entitiesCarryCode(toInstall)) {
+		const { confirmAction } = await import("./dialogs.js");
+		const ok = await confirmAction("Install executable code", EXEC_CODE_WARNING, "Install", false);
+		if (!ok) return;
+	}
+	await doInstall(pack, entities);
+}
+
+async function doInstall(pack: MarketPack, entities?: MarketPackEntity[], conflict?: "fail" | "overwrite" | "skip"): Promise<void> {
+	busyPackKey = packKey(pack.sourceId, pack.packId);
+	renderApp();
+	const result = await installPack({
+		sourceId: pack.sourceId,
+		packId: pack.packId,
+		scope: currentScope(),
+		projectId: getConfigProjectId(),
+		entities: entities ? entities.map((e) => ({ type: e.type, name: e.name })) : undefined,
+		conflict,
+	});
+	busyPackKey = null;
+
+	if (!result.ok && result.status === 409) {
+		renderApp();
+		const conflicting = Array.isArray(result.data?.conflicts)
+			? result.data.conflicts.map((c: any) => c.name).join(", ")
+			: "";
+		const { confirmAction } = await import("./dialogs.js");
+		const overwrite = await confirmAction(
+			"Already installed at this scope",
+			`Some entities already exist at ${scopeLabel()} scope${conflicting ? ` (${conflicting})` : ""}. Overwrite them?`,
+			"Overwrite",
+			true,
+		);
+		if (overwrite) await doInstall(pack, entities, "overwrite");
+		return;
+	}
+
+	if (result.ok) {
+		await reloadAfterChange();
+	} else {
+		const { showConnectionError } = await import("./dialogs.js");
+		showConnectionError("Failed to install pack", result.error || "Unknown error");
+		renderApp();
+	}
+}
+
+async function handleUpdate(pack: MarketPack): Promise<void> {
+	busyPackKey = packKey(pack.sourceId, pack.packId);
+	renderApp();
+	const result = await updatePack({
+		sourceId: pack.sourceId,
+		packId: pack.packId,
+		scope: currentScope(),
+		projectId: getConfigProjectId(),
+	});
+	busyPackKey = null;
+	if (result.ok) {
+		await reloadAfterChange();
+	} else {
+		const { showConnectionError } = await import("./dialogs.js");
+		showConnectionError("Failed to update pack", result.error || "Unknown error");
+		renderApp();
+	}
+}
+
+async function handleUninstall(pack: MarketPack): Promise<void> {
+	const { confirmAction } = await import("./dialogs.js");
+	const ok = await confirmAction(
+		"Uninstall pack",
+		`Uninstall "${pack.name}" from ${scopeLabel()} scope? This removes exactly the entities it installed.`,
+		"Uninstall",
+		true,
+	);
+	if (!ok) return;
+	busyPackKey = packKey(pack.sourceId, pack.packId);
+	renderApp();
+	const result = await uninstallPack({
+		sourceId: pack.sourceId,
+		packId: pack.packId,
+		scope: currentScope(),
+		projectId: getConfigProjectId(),
+	});
+	busyPackKey = null;
+	if (result.ok) {
+		await reloadAfterChange();
+	} else {
+		const { showConnectionError } = await import("./dialogs.js");
+		showConnectionError("Failed to uninstall pack", result.error || "Unknown error");
+		renderApp();
+	}
+}
+
+async function reloadAfterChange(): Promise<void> {
+	await refreshPacks();
+	if (currentView === "pack") await refreshSelectedPack();
+	renderApp();
+}
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+function sourceDisplayName(source: MarketSource): string {
+	if (source.label) return source.label;
+	if (source.kind === "git" && source.url) {
+		const m = source.url.replace(/\.git$/, "").split("/").filter(Boolean);
+		return m[m.length - 1] || source.url;
+	}
+	if (source.kind === "local" && source.path) {
+		const parts = source.path.replace(/[\\/]+$/, "").split(/[\\/]/);
+		return parts[parts.length - 1] || source.path;
+	}
+	return source.id;
+}
+
+function entityIcon(type: string): typeof Users {
+	switch (type) {
+		case "role": return Users;
+		case "tool": return Wrench;
+		case "skill": return Zap;
+		default: return Package;
+	}
+}
+
+const STATUS_LABELS: Record<MarketInstallStatus, string> = {
+	"not-installed": "Not installed",
+	installed: "Installed",
+	"update-available": "Update available",
+	drifted: "Modified locally",
+};
+
+function renderStatusBadge(status: MarketInstallStatus): TemplateResult {
+	return html`<span class="market-status-badge market-status-${status}" data-testid="market-install-status" data-status="${status}">${STATUS_LABELS[status]}</span>`;
+}
+
+// ============================================================================
+// RENDER: NAV BAR
+// ============================================================================
+
+function renderNavBar(): TemplateResult {
+	if (currentView === "pack") {
+		const title = selectedPack?.name || selectedPackId || "Pack";
+		return html`
+			<div class="market-nav">
+				<div class="market-nav-left">
+					<button class="market-back" @click=${showList} title="Back to marketplace">
+						${icon(ArrowLeft, "sm")}
+					</button>
+					<div class="market-title-group">
+						<span class="market-breadcrumb" @click=${showList}>Market</span>
+						<span class="market-breadcrumb-sep">/</span>
+						<h1 class="market-title">${title}</h1>
+					</div>
+				</div>
+			</div>
+		`;
+	}
+	return html`
+		<div class="market-nav">
+			<div class="market-nav-left">
+				<button class="market-back" @click=${() => setHashRoute("landing")} title="Back to sessions">
+					${icon(ArrowLeft, "sm")}
+				</button>
+				<h1 class="market-title">Market</h1>
+			</div>
+			<div class="market-nav-right">
+				${Button({
+					variant: "default",
+					size: "sm",
+					onClick: handleAddSource,
+					children: html`<span class="inline-flex items-center gap-1.5 font-semibold" data-testid="market-add-source">${icon(Plus, "sm")} Add source</span>`,
+				})}
+			</div>
+		</div>
+	`;
+}
+
+// ============================================================================
+// RENDER: SOURCES
+// ============================================================================
+
+function renderSourceRow(source: MarketSource): TemplateResult {
+	const syncing = syncingSourceId === source.id;
+	const subtitle = source.kind === "git" ? (source.url || "") : (source.path || "");
+	return html`
+		<div class="market-source-row" data-testid="market-source-row">
+			<span class="market-source-icon">${icon(source.kind === "git" ? GitBranch : FolderOpen, "sm")}</span>
+			<div class="market-source-info">
+				<span class="market-source-name">${sourceDisplayName(source)}</span>
+				<span class="market-source-sub" title=${subtitle}>${subtitle}</span>
+				${source.lastSyncError
+					? html`<span class="market-source-error" data-testid="market-source-sync-error">${icon(AlertCircle, "sm")} ${source.lastSyncError}</span>`
+					: nothing}
+			</div>
+			<div class="market-source-actions">
+				<button class="market-action-btn" title="Re-sync source" ?disabled=${syncing}
+					@click=${() => handleSyncSource(source)}>
+					<span class=${syncing ? "market-spin" : ""}>${icon(RefreshCw, "sm")}</span>
+				</button>
+				<button class="market-action-btn delete" title="Remove source"
+					@click=${() => handleRemoveSource(source)}>${icon(Trash2, "sm")}</button>
+			</div>
+		</div>
+	`;
+}
+
+function renderSourcesSection(): TemplateResult {
+	return html`
+		<div class="market-section">
+			<div class="market-section-head">
+				<h2 class="market-section-title">Sources</h2>
+			</div>
+			${sources.length === 0
+				? html`<p class="market-section-empty">No sources yet. Add a git repo or local directory that contains extension packs.</p>`
+				: html`<div class="market-source-list">${sources.map(renderSourceRow)}</div>`}
+		</div>
+	`;
+}
+
+// ============================================================================
+// RENDER: PACK LIST
+// ============================================================================
+
+function renderEntityChips(entities: MarketPackEntity[]): TemplateResult {
+	return html`
+		<div class="market-entity-chips">
+			${entities.map((e) => html`
+				<span class="market-entity-chip" title="${e.type}: ${e.name}">
+					${icon(entityIcon(e.type), "sm")}<span>${e.name}</span>
+				</span>
+			`)}
+		</div>
+	`;
+}
+
+function renderPackCard(pack: MarketPack): TemplateResult {
+	const busy = busyPackKey === packKey(pack.sourceId, pack.packId);
+	if (!pack.valid) {
+		return html`
+			<div class="market-pack-card market-pack-invalid" data-testid="market-pack-card" data-pack-id="${pack.packId}" data-valid="false">
+				<div class="market-pack-head">
+					<span class="market-pack-name">${pack.name || pack.packId}</span>
+					<span class="market-pack-invalid-badge" data-testid="market-pack-invalid">${icon(AlertTriangle, "sm")} invalid</span>
+				</div>
+				<p class="market-pack-error" data-testid="market-pack-error">${pack.error || "This pack has errors and cannot be installed."}</p>
+				<div class="market-pack-source">${pack.sourceLabel || pack.sourceId}</div>
+			</div>
+		`;
+	}
+	return html`
+		<div class="market-pack-card" data-testid="market-pack-card" data-pack-id="${pack.packId}" data-valid="true"
+			tabindex="0" role="button"
+			@click=${() => showPack(pack)}
+			@keydown=${(e: KeyboardEvent) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); showPack(pack); } }}>
+			<div class="market-pack-head">
+				<span class="market-pack-name">${pack.name}</span>
+				<span class="market-pack-version">v${pack.version}</span>
+				${pack.hasTools ? html`<span class="market-code-badge" data-testid="market-exec-code-badge" title=${EXEC_CODE_WARNING}>${icon(AlertTriangle, "sm")} executable code</span>` : nothing}
+			</div>
+			<p class="market-pack-desc">${pack.description}</p>
+			${renderEntityChips(pack.entities)}
+			<div class="market-pack-foot">
+				<span class="market-pack-source">${pack.sourceLabel || pack.sourceId}</span>
+				<div class="market-pack-foot-right">
+					${renderStatusBadge(pack.installStatus)}
+					${renderPackPrimaryAction(pack, busy, true)}
+				</div>
+			</div>
+		</div>
+	`;
+}
+
+/** Primary install/update/uninstall control for a pack, used on cards + detail. */
+function renderPackPrimaryAction(pack: MarketPack, busy: boolean, compact: boolean): TemplateResult {
+	const stop = (fn: () => void) => (e: Event) => { e.stopPropagation(); fn(); };
+	const size = compact ? "sm" : undefined;
+	if (pack.installStatus === "not-installed") {
+		return Button({
+			variant: "default",
+			size: size as any,
+			disabled: busy,
+			onClick: stop(() => handleInstall(pack)),
+			children: html`<span class="inline-flex items-center gap-1.5" data-testid="market-install-btn">${icon(Download, "sm")} ${busy ? "Installing\u2026" : `Install`}</span>`,
+		});
+	}
+	// installed / update-available / drifted → offer update (when available) + uninstall
+	return html`
+		<div class="inline-flex items-center gap-1.5" @click=${(e: Event) => e.stopPropagation()}>
+			${pack.installStatus === "update-available" || pack.installStatus === "drifted"
+				? Button({
+					variant: "secondary" as any,
+					size: size as any,
+					disabled: busy,
+					onClick: () => handleUpdate(pack),
+					children: html`<span class="inline-flex items-center gap-1.5" data-testid="market-update-btn">${icon(RefreshCw, "sm")} Update</span>`,
+				})
+				: html`<span class="market-installed-check" data-testid="market-installed-check">${icon(Check, "sm")} Installed</span>`}
+			${Button({
+				variant: "ghost",
+				size: size as any,
+				disabled: busy,
+				onClick: () => handleUninstall(pack),
+				children: html`<span class="inline-flex items-center gap-1.5" data-testid="market-uninstall-btn">${icon(Trash2, "sm")} Uninstall</span>`,
+			})}
+		</div>
+	`;
+}
+
+function renderListView(): TemplateResult {
+	if (loading) {
+		return html`
+			<div class="market-loading">
+				<svg class="animate-spin" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+					<path d="M21 12a9 9 0 1 1-6.219-8.56"></path>
+				</svg>
+				<span>Loading marketplace\u2026</span>
+			</div>
+		`;
+	}
+	return html`
+		<div class="market-body-inner">
+			${renderSourcesSection()}
+			<div class="market-section">
+				<div class="market-section-head">
+					<h2 class="market-section-title">Extension Packs</h2>
+				</div>
+				${sources.length === 0
+					? html`<p class="market-section-empty">Add a source to browse the extension packs it contains.</p>`
+					: packs.length === 0
+						? html`<p class="market-section-empty" data-testid="market-no-packs">No packs found in the configured sources. A directory is a pack only if it contains a <code>pack.yaml</code>.</p>`
+						: html`<div class="market-pack-grid">${packs.map(renderPackCard)}</div>`}
+			</div>
+		</div>
+	`;
+}
+
+// ============================================================================
+// RENDER: PACK DETAIL
+// ============================================================================
+
+function renderMetaRow(label: string, value: string | TemplateResult): TemplateResult {
+	return html`<div class="market-meta-row"><span class="market-meta-label">${label}</span><span class="market-meta-value">${value}</span></div>`;
+}
+
+function renderEntityDetailRow(pack: MarketPackDetail, entity: MarketPackEntity): TemplateResult {
+	const status = entity.installStatus;
+	const busy = busyPackKey === packKey(pack.sourceId, pack.packId);
+	return html`
+		<div class="market-entity-row" data-testid="market-entity-row" data-entity-type="${entity.type}" data-entity-name="${entity.name}">
+			<span class="market-entity-icon">${icon(entityIcon(entity.type), "sm")}</span>
+			<span class="market-entity-type">${entity.type}</span>
+			<span class="market-entity-name">${entity.name}</span>
+			${entity.type === "tool" ? html`<span class="market-code-badge market-code-badge--sm" title=${EXEC_CODE_WARNING}>${icon(AlertTriangle, "sm")} code</span>` : nothing}
+			<span class="market-entity-spacer"></span>
+			${status && status !== "not-installed"
+				? html`<span class="market-installed-check" data-testid="market-entity-installed">${icon(Check, "sm")} ${STATUS_LABELS[status]}</span>`
+				: Button({
+					variant: "ghost",
+					size: "sm" as any,
+					disabled: busy,
+					onClick: () => handleInstall(pack, [entity]),
+					children: html`<span class="inline-flex items-center gap-1" data-testid="market-entity-install">${icon(Download, "sm")} Install</span>`,
+				})}
+		</div>
+	`;
+}
+
+function renderPackDetailView(): TemplateResult {
+	if (loadingPack) {
+		return html`
+			<div class="market-loading">
+				<svg class="animate-spin" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+					<path d="M21 12a9 9 0 1 1-6.219-8.56"></path>
+				</svg>
+				<span>Loading pack\u2026</span>
+			</div>
+		`;
+	}
+	const pack = selectedPack;
+	if (!pack) {
+		return html`
+			<div class="market-empty">
+				<p class="market-empty-title">Pack not found</p>
+				<p class="market-empty-desc">This pack is no longer available. It may have been removed from its source.</p>
+				<button class="underline text-sm" @click=${showList}>Back to marketplace</button>
+			</div>
+		`;
+	}
+	const busy = busyPackKey === packKey(pack.sourceId, pack.packId);
+	return html`
+		<div class="market-detail">
+			<div class="market-detail-head">
+				<div class="market-detail-title-row">
+					<h1 class="market-detail-name">${pack.name}</h1>
+					<span class="market-pack-version">v${pack.version}</span>
+					${renderStatusBadge(pack.installStatus)}
+				</div>
+				<p class="market-detail-desc">${pack.description}</p>
+				<div class="market-detail-actions">
+					${renderPackPrimaryAction(pack, busy, false)}
+				</div>
+			</div>
+
+			${pack.hasTools ? html`
+				<div class="market-code-notice" data-testid="market-code-notice" role="note">
+					${icon(AlertTriangle, "sm")}
+					<span>${EXEC_CODE_WARNING}</span>
+				</div>
+			` : nothing}
+
+			<div class="market-detail-grid">
+				<div class="market-section">
+					<div class="market-section-head"><h2 class="market-section-title">Contents</h2></div>
+					<div class="market-entity-rows">
+						${pack.entities.map((e) => renderEntityDetailRow(pack, e))}
+					</div>
+				</div>
+
+				<div class="market-section">
+					<div class="market-section-head"><h2 class="market-section-title">Details</h2></div>
+					<div class="market-meta">
+						${renderMetaRow("Source", pack.sourceLabel || pack.sourceId)}
+						${renderMetaRow("Pack ID", pack.packId)}
+						${pack.author ? renderMetaRow("Author", pack.author) : nothing}
+						${pack.homepage ? renderMetaRow("Homepage", html`<a class="market-link" href=${pack.homepage} target="_blank" rel="noreferrer noopener">${pack.homepage}</a>`) : nothing}
+						${pack.license ? renderMetaRow("License", pack.license) : nothing}
+						${pack.minBobbit ? renderMetaRow("Min Bobbit", pack.minBobbit) : nothing}
+						${pack.installedVersion ? renderMetaRow("Installed version", pack.installedVersion) : nothing}
+						${pack.installedCommit ? renderMetaRow("Installed commit", pack.installedCommit.slice(0, 10)) : nothing}
+					</div>
+				</div>
+			</div>
+		</div>
+	`;
+}
+
+// ============================================================================
+// MAIN RENDER
+// ============================================================================
+
+export function renderMarketPage(): TemplateResult {
+	return html`
+		<div class="market-container">
+			${renderNavBar()}
+			${currentView === "list" ? renderConfigScopeRow(getConfigScope(), handleScopeChange) : ""}
+			<div class="market-body">
+				${currentView === "list" ? renderListView() : renderPackDetailView()}
+			</div>
+		</div>
+	`;
+}

--- a/src/app/market-source-dialog.ts
+++ b/src/app/market-source-dialog.ts
@@ -1,0 +1,150 @@
+// ============================================================================
+// MARKET SOURCE DIALOG — add a marketplace source (git repo or local dir)
+//
+// Models the add-source modal described in docs/design/marketplace-mvp.md
+// §3.3 / §10.3. The dialog POSTs to /api/marketplace/sources itself so it can
+// surface server-side validation errors (400) inline and stay open; it
+// resolves `true` only after a source was successfully added.
+// ============================================================================
+
+import { Button } from "@mariozechner/mini-lit/dist/Button.js";
+import { Dialog, DialogContent, DialogFooter, DialogHeader } from "@mariozechner/mini-lit/dist/Dialog.js";
+import { html, render } from "lit";
+import { addMarketSource } from "./api.js";
+
+type SourceKind = "git" | "local";
+
+/**
+ * Open the add-source modal. Resolves `true` when a source was added (the
+ * caller should reload), `false` if the user cancelled.
+ */
+export function openAddSourceDialog(): Promise<boolean> {
+	return new Promise((resolve) => {
+		const container = document.createElement("div");
+		document.body.appendChild(container);
+
+		let kind: SourceKind = "git";
+		let url = "";
+		let ref = "";
+		let path = "";
+		let label = "";
+		let submitting = false;
+		let errorMsg: string | null = null;
+
+		const cleanup = (result: boolean) => {
+			render(html``, container);
+			container.remove();
+			resolve(result);
+		};
+
+		const canSubmit = (): boolean => {
+			if (submitting) return false;
+			if (kind === "git") return url.trim().length > 0;
+			return path.trim().length > 0;
+		};
+
+		const submit = async () => {
+			if (!canSubmit()) return;
+			submitting = true;
+			errorMsg = null;
+			rerender();
+			const input = kind === "git"
+				? { kind, url: url.trim(), ref: ref.trim() || undefined, label: label.trim() || undefined }
+				: { kind, path: path.trim(), label: label.trim() || undefined };
+			const result = await addMarketSource(input);
+			submitting = false;
+			if (result.ok) {
+				cleanup(true);
+				return;
+			}
+			errorMsg = result.error || "Failed to add source.";
+			rerender();
+		};
+
+		const rerender = () => {
+			render(
+				Dialog({
+					isOpen: true,
+					onClose: () => cleanup(false),
+					width: "min(480px, 92vw)",
+					height: "auto",
+					backdropClassName: "bg-black/50 backdrop-blur-sm",
+					children: html`
+						${DialogContent({
+							children: html`
+								${DialogHeader({ title: "Add marketplace source" })}
+								<div class="market-dialog-body" data-testid="market-source-dialog">
+									<div class="market-kind-toggle">
+										<button
+											class="market-kind-btn ${kind === "git" ? "is-active" : ""}"
+											data-testid="market-kind-git"
+											@click=${() => { kind = "git"; errorMsg = null; rerender(); }}
+										>Git repo</button>
+										<button
+											class="market-kind-btn ${kind === "local" ? "is-active" : ""}"
+											data-testid="market-kind-local"
+											@click=${() => { kind = "local"; errorMsg = null; rerender(); }}
+										>Local directory</button>
+									</div>
+
+									${kind === "git" ? html`
+										<label class="market-field">
+											<span class="market-field-label">Repository URL</span>
+											<input class="market-input" data-testid="market-source-url"
+												.value=${url}
+												placeholder="https://github.com/acme/bobbit-packs.git"
+												@input=${(e: Event) => { url = (e.target as HTMLInputElement).value; rerender(); }} />
+										</label>
+										<label class="market-field">
+											<span class="market-field-label">Branch / ref <span class="market-field-opt">(optional)</span></span>
+											<input class="market-input" data-testid="market-source-ref"
+												.value=${ref}
+												placeholder="main"
+												@input=${(e: Event) => { ref = (e.target as HTMLInputElement).value; }} />
+										</label>
+									` : html`
+										<label class="market-field">
+											<span class="market-field-label">Absolute directory path</span>
+											<input class="market-input" data-testid="market-source-path"
+												.value=${path}
+												placeholder="/Users/you/bobbit-packs"
+												@input=${(e: Event) => { path = (e.target as HTMLInputElement).value; rerender(); }} />
+											<span class="market-field-hint">Must be an existing absolute path. Local sources are read in place.</span>
+										</label>
+									`}
+
+									<label class="market-field">
+										<span class="market-field-label">Label <span class="market-field-opt">(optional)</span></span>
+										<input class="market-input" data-testid="market-source-label"
+											.value=${label}
+											placeholder="Acme Packs"
+											@input=${(e: Event) => { label = (e.target as HTMLInputElement).value; }} />
+									</label>
+
+									${errorMsg ? html`<div class="market-dialog-error" data-testid="market-source-error" role="alert">${errorMsg}</div>` : ""}
+								</div>
+							`,
+						})}
+						${DialogFooter({
+							className: "px-6 pb-4",
+							children: html`
+								<div class="flex gap-2 justify-end">
+									${Button({ variant: "ghost", onClick: () => cleanup(false), children: "Cancel" })}
+									${Button({
+										variant: "default",
+										onClick: submit,
+										disabled: !canSubmit(),
+										children: submitting ? "Adding\u2026" : "Add source",
+									})}
+								</div>
+							`,
+						})}
+					`,
+				}),
+				container,
+			);
+		};
+
+		rerender();
+	});
+}

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -2413,6 +2413,9 @@ export function doRenderApp(): void {
 		if (route.view === "skills") {
 			return lazyPage("skills", () => import("./skills-page.js"), "renderSkillsPage");
 		}
+		if (route.view === "market" || route.view === "market-pack") {
+			return lazyPage("market", () => import("./market-page.js"), "renderMarketPage");
+		}
 		if (route.view === "settings") {
 			return lazyPage("settings", () => import("./settings-page.js"), "renderSettingsPage");
 		}

--- a/src/app/routing.ts
+++ b/src/app/routing.ts
@@ -2,7 +2,7 @@
 // URL ROUTING (hash-based: #/ = landing, #/session/{id} = connected, #/goal/{id} = dashboard)
 // ============================================================================
 
-export type RouteView = "landing" | "session" | "goal" | "goal-dashboard" | "roles" | "role-edit" | "tools" | "tool-edit" | "workflows" | "workflow-edit" | "staff" | "staff-edit" | "skills" | "settings" | "search" | "walkthrough";
+export type RouteView = "landing" | "session" | "goal" | "goal-dashboard" | "roles" | "role-edit" | "tools" | "tool-edit" | "workflows" | "workflow-edit" | "staff" | "staff-edit" | "skills" | "market" | "market-pack" | "settings" | "search" | "walkthrough";
 
 export type DashboardTabId = "spec" | "tasks" | "agents" | "commits" | "gates";
 export type SettingsTabId = "shortcuts" | "general" | "project" | "components" | "workflows" | "models" | "palette" | "directories" | "account" | "appearance" | "maintenance";
@@ -15,6 +15,8 @@ export interface AppRoute {
 	toolName?: string;
 	workflowId?: string;
 	staffId?: string;
+	marketSourceId?: string;
+	marketPackId?: string;
 	settingsScope?: string;
 	settingsTab?: SettingsTabId;
 	searchQuery?: string;
@@ -100,6 +102,13 @@ export function getRouteFromHash(): AppRoute {
 	if (hash === "#/skills") {
 		return { view: "skills" };
 	}
+	const marketPackMatch = hash.match(/^#\/market\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)$/);
+	if (marketPackMatch) {
+		return { view: "market-pack", marketSourceId: marketPackMatch[1], marketPackId: marketPackMatch[2] };
+	}
+	if (hash === "#/market") {
+		return { view: "market" };
+	}
 	const settingsMatch = hash.match(/^#\/settings(?:\/([a-z0-9-]+))?(?:\/([a-z]+))?$/);
 	if (settingsMatch) {
 		const first = settingsMatch[1] as string | undefined;
@@ -180,6 +189,11 @@ export function setHashRoute(view: RouteView, id?: string, replace?: boolean): v
 		newHash = "#/staff";
 	} else if (view === "skills") {
 		newHash = "#/skills";
+	} else if (view === "market-pack" && id) {
+		// id is the compound "<sourceId>/<packId>".
+		newHash = `#/market/${id}`;
+	} else if (view === "market") {
+		newHash = "#/market";
 	} else if (view === "search") {
 		newHash = id ? `#/search?q=${encodeURIComponent(id)}` : "#/search";
 	} else if (view === "walkthrough") {
@@ -213,7 +227,7 @@ export function setHashRoute(view: RouteView, id?: string, replace?: boolean): v
 /** Config page route views (not landing, session, or goal-dashboard). */
 const CONFIG_VIEWS: Set<RouteView> = new Set([
 	"roles", "role-edit", "tools", "tool-edit", "workflows", "workflow-edit",
-	"skills", "settings", "staff", "staff-edit",
+	"skills", "market", "market-pack", "settings", "staff", "staff-edit",
 	"search",
 ]);
 

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -1,6 +1,6 @@
 import { icon } from "@mariozechner/mini-lit";
 import { html } from "lit";
-import { Bot, ChevronDown, FolderOpen, Goal as GoalIcon, GripVertical, List, MessagesSquare, PanelLeftClose, PanelLeftOpen, Pencil, Plus, Settings, Users, Workflow, Wrench, Zap } from "lucide";
+import { Bot, ChevronDown, FolderOpen, Goal as GoalIcon, GripVertical, List, MessagesSquare, PanelLeftClose, PanelLeftOpen, Pencil, Plus, Settings, Store, Users, Workflow, Wrench, Zap } from "lucide";
 // Register search web components (self-registering via @customElement)
 // Lazy-load via the shared widgets registrar; see render.ts for
 // rationale. Both modules ship in one shared chunk fetched in parallel
@@ -1347,6 +1347,7 @@ export function renderSidebar() {
 	const isToolsActive = isRouteActive("tools", "tool-edit");
 	const isWorkflowsActive = isRouteActive("workflows", "workflow-edit");
 	const isSkillsActive = isRouteActive("skills");
+	const isMarketActive = isRouteActive("market", "market-pack");
 
 	return html`
 		<div class="shrink-0 h-full flex flex-col sidebar-edge sidebar-root relative" data-testid="sidebar-expanded" data-project-reordering=${isProjectReordering() ? "true" : "false"} style="background: var(--sidebar); width: var(--sidebar-w, 240px);">
@@ -1387,6 +1388,15 @@ export function renderSidebar() {
 					>
 						${icon(Workflow, "xs", "!w-3.5 !h-3.5")}
 						<span>Workflows</span>
+					</button>
+					<button
+						data-testid="sidebar-market-button"
+						class="flex-1 flex items-center justify-center gap-1 px-1 py-1 whitespace-nowrap ${isMarketActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'} rounded-md transition-colors"
+						@click=${() => toggleConfigPage(["market", "market-pack"], () => { import("./market-page.js").then((m) => m.loadMarketPageData()); import("./routing.js").then((m) => m.setHashRoute("market")); })}
+						title="Browse extension marketplace"
+					>
+						${icon(Store, "xs", "!w-3.5 !h-3.5")}
+						<span>Market</span>
 					</button>
 					<button
 						data-new-goal-trigger

--- a/src/server/marketplace/entity-handlers.ts
+++ b/src/server/marketplace/entity-handlers.ts
@@ -11,7 +11,6 @@
 import fs from "node:fs";
 import path from "node:path";
 import YAML from "yaml";
-import { copyDirRecursive } from "../agent/tool-manager.js";
 import {
 	parseCustomDirectories,
 	saveCustomDirectories,
@@ -42,10 +41,75 @@ export function isSafeEntityName(name: unknown): name is string {
  * code path that bypasses the scanner can never write/delete outside scope.
  */
 export function assertWithin(root: string, target: string): void {
+	if (!isWithin(root, target)) {
+		throw new Error(`marketplace: path escapes ${root}: ${target}`);
+	}
+}
+
+/** Non-throwing containment check used by uninstall before any delete. */
+export function isWithin(root: string, target: string): boolean {
 	const r = path.resolve(root);
 	const t = path.resolve(target);
-	if (t !== r && !t.startsWith(r + path.sep)) {
-		throw new Error(`marketplace: path escapes ${root}: ${target}`);
+	return t === r || t.startsWith(r + path.sep);
+}
+
+/**
+ * Delete each path only if it is contained within `root` (the entity type's
+ * destination dir for the resolved scope). A path that escapes `root` — e.g.
+ * from a hand-edited / tampered provenance file — is refused and surfaced, so
+ * uninstall can never delete arbitrary host files.
+ */
+export function removeContainedPaths(root: string, paths: string[], recursive: boolean): void {
+	for (const p of paths) {
+		if (!isWithin(root, p)) {
+			console.error(`marketplace: refusing to delete path outside ${root}: ${p}`);
+			continue;
+		}
+		try { fs.rmSync(p, { recursive, force: true }); } catch { /* best-effort */ }
+	}
+}
+
+/**
+ * Recursively detect a symlink anywhere in a pack payload (the path itself or
+ * any descendant), using lstat so symlinks are not followed. A marketplace
+ * pack containing a symlink under roles/tools/skills is invalid: copying or
+ * hashing it could read/exfiltrate host files the symlink points at. Returns
+ * the offending path, or null if the subtree is symlink-free.
+ */
+export function findSymlink(p: string): string | null {
+	let st: fs.Stats;
+	try { st = fs.lstatSync(p); } catch { return null; }
+	if (st.isSymbolicLink()) return p;
+	if (st.isDirectory()) {
+		for (const name of fs.readdirSync(p)) {
+			const hit = findSymlink(path.join(p, name));
+			if (hit) return hit;
+		}
+	}
+	return null;
+}
+
+/**
+ * Marketplace-local recursive copy that refuses to follow symlinks. Unlike the
+ * shared tool-manager copyDirRecursive (which copyFileSync-follows links), this
+ * lstat-checks every node and throws on a symlink or any non-regular file, so a
+ * malicious pack cannot exfiltrate host files into a config layer.
+ */
+export function copyNoSymlinks(src: string, dest: string): void {
+	const st = fs.lstatSync(src);
+	if (st.isSymbolicLink()) {
+		throw new Error(`marketplace: refusing to copy symlink: ${src}`);
+	}
+	if (st.isDirectory()) {
+		fs.mkdirSync(dest, { recursive: true });
+		for (const name of fs.readdirSync(src)) {
+			copyNoSymlinks(path.join(src, name), path.join(dest, name));
+		}
+	} else if (st.isFile()) {
+		fs.mkdirSync(path.dirname(dest), { recursive: true });
+		fs.copyFileSync(src, dest);
+	} else {
+		throw new Error(`marketplace: refusing to copy non-regular file: ${src}`);
 	}
 }
 
@@ -124,6 +188,8 @@ const roleHandler: EntityTypeHandler = {
 	validate(packDir, name) {
 		const p = this.payloadPath(packDir, name);
 		if (!fs.existsSync(p)) return { ok: false, error: `role file missing: roles/${name}.yaml` };
+		const link = findSymlink(p);
+		if (link) return { ok: false, error: `role roles/${name}.yaml is a symlink (not allowed in packs)` };
 		try {
 			const parsed = YAML.parse(fs.readFileSync(p, "utf-8"));
 			if (!parsed || typeof parsed !== "object" || typeof parsed.name !== "string" || !parsed.name.trim()) {
@@ -141,15 +207,12 @@ const roleHandler: EntityTypeHandler = {
 		const dest = this.destPath(ctx, name);
 		assertWithin(path.join(packDir, "roles"), src);
 		assertWithin(roleConfigDir(ctx), dest);
-		fs.mkdirSync(path.dirname(dest), { recursive: true });
-		fs.copyFileSync(src, dest);
+		copyNoSymlinks(src, dest);
 		ctx.invalidateRoles?.();
 		return { type: "role", name, installedPaths: [dest] };
 	},
 	uninstall(ctx, entity) {
-		for (const p of entity.installedPaths) {
-			try { fs.rmSync(p, { force: true }); } catch { /* best-effort */ }
-		}
+		removeContainedPaths(roleConfigDir(ctx), entity.installedPaths, false);
 		ctx.invalidateRoles?.();
 	},
 };
@@ -164,6 +227,8 @@ const toolHandler: EntityTypeHandler = {
 		let stat: fs.Stats;
 		try { stat = fs.statSync(dir); } catch { return { ok: false, error: `tool group missing: tools/${name}/` }; }
 		if (!stat.isDirectory()) return { ok: false, error: `tools/${name} is not a directory` };
+		const link = findSymlink(dir);
+		if (link) return { ok: false, error: `tool group tools/${name}/ contains a symlink (not allowed in packs)` };
 		let yamlWithName = 0;
 		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
 			if (!entry.isFile() || !entry.name.endsWith(".yaml")) continue;
@@ -184,14 +249,12 @@ const toolHandler: EntityTypeHandler = {
 		const dest = this.destPath(ctx, name);
 		assertWithin(path.join(packDir, "tools"), src);
 		assertWithin(toolConfigDir(ctx), dest);
-		copyDirRecursive(src, dest);
+		copyNoSymlinks(src, dest);
 		ctx.invalidateTools?.();
 		return { type: "tool", name, installedPaths: [dest] };
 	},
 	uninstall(ctx, entity) {
-		for (const p of entity.installedPaths) {
-			try { fs.rmSync(p, { recursive: true, force: true }); } catch { /* best-effort */ }
-		}
+		removeContainedPaths(toolConfigDir(ctx), entity.installedPaths, true);
 		ctx.invalidateTools?.();
 	},
 };
@@ -202,8 +265,11 @@ const skillHandler: EntityTypeHandler = {
 	carriesCode: false,
 	payloadPath: (packDir, name) => path.join(packDir, "skills", name),
 	validate(packDir, name) {
-		const skillFile = path.join(this.payloadPath(packDir, name), "SKILL.md");
+		const dir = this.payloadPath(packDir, name);
+		const skillFile = path.join(dir, "SKILL.md");
 		if (!fs.existsSync(skillFile)) return { ok: false, error: `skill missing: skills/${name}/SKILL.md` };
+		const link = findSymlink(dir);
+		if (link) return { ok: false, error: `skill skills/${name}/ contains a symlink (not allowed in packs)` };
 		return { ok: true };
 	},
 	destPath: (ctx, name) => path.join(ctx.skillInstallDir, name),
@@ -213,7 +279,7 @@ const skillHandler: EntityTypeHandler = {
 		const dest = this.destPath(ctx, name);
 		assertWithin(path.join(packDir, "skills"), src);
 		assertWithin(ctx.skillInstallDir, dest);
-		copyDirRecursive(src, dest);
+		copyNoSymlinks(src, dest);
 		const entity: InstalledEntity = { type: "skill", name, installedPaths: [dest] };
 		// Project scope: register the (absolute) skills dir so discoverSlashSkills
 		// resolves it cross-worktree. System scope (~/.bobbit/skills) is always scanned.
@@ -224,9 +290,7 @@ const skillHandler: EntityTypeHandler = {
 		return entity;
 	},
 	uninstall(ctx, entity) {
-		for (const p of entity.installedPaths) {
-			try { fs.rmSync(p, { recursive: true, force: true }); } catch { /* best-effort */ }
-		}
+		removeContainedPaths(ctx.skillInstallDir, entity.installedPaths, true);
 		// Drop only the "skills" registration for this dir, preserving any other
 		// config types registered on the same path. Delete the dir only if it is
 		// now empty AND no longer referenced by config_directories.

--- a/src/server/marketplace/entity-handlers.ts
+++ b/src/server/marketplace/entity-handlers.ts
@@ -232,6 +232,13 @@ const roleHandler: EntityTypeHandler = {
 			if (!parsed || typeof parsed !== "object" || typeof parsed.name !== "string" || !parsed.name.trim()) {
 				return { ok: false, error: `role roles/${name}.yaml has no valid name field` };
 			}
+			// The role's YAML `name` is the key ConfigCascade resolves it under, so it
+			// must equal the declared entity name (= the filename). A mismatch would
+			// install roles/<name>.yaml yet resolve under a different role name,
+			// breaking provenance/uninstall symmetry and origin badges.
+			if (parsed.name.trim() !== name) {
+				return { ok: false, error: `role roles/${name}.yaml declares name "${parsed.name.trim()}" but must match entity name "${name}"` };
+			}
 		} catch (err) {
 			return { ok: false, error: `role roles/${name}.yaml failed to parse: ${(err as Error).message}` };
 		}

--- a/src/server/marketplace/entity-handlers.ts
+++ b/src/server/marketplace/entity-handlers.ts
@@ -1,0 +1,202 @@
+/**
+ * Marketplace MVP — entity-type handler registry (§8.1).
+ *
+ * Each entity type (role / tool / skill, and future panel/workflow/staff)
+ * provides one handler. The scanner, install engine, and the "executable
+ * code" check all iterate `ENTITY_HANDLERS` rather than hardcoding types, so
+ * adding a new entity type is one new handler + one registry entry — no
+ * changes to the scan/install/uninstall control flow.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import YAML from "yaml";
+import { copyDirRecursive } from "../agent/tool-manager.js";
+import {
+	parseCustomDirectories,
+	saveCustomDirectories,
+	type ProjectConfigWriter,
+} from "../agent/config-directories.js";
+import type { EntityType, InstallCtx, InstalledEntity } from "./types.js";
+
+export interface ValidationResult {
+	ok: boolean;
+	error?: string;
+}
+
+export interface EntityTypeHandler {
+	type: EntityType;
+	/** key under pack.yaml `contents`. */
+	manifestKey: string;
+	/** does this type carry executable code? drives the §9 warning. */
+	carriesCode: boolean;
+	/** absolute payload path within a pack dir (file for role, dir for tool/skill). */
+	payloadPath(packDir: string, name: string): string;
+	/** verify the declared entity exists / parses in a pack dir. */
+	validate(packDir: string, name: string): ValidationResult;
+	/** primary destination path used for conflict detection. */
+	destPath(ctx: InstallCtx, name: string): string;
+	/** resolve the destination for a scope and copy; returns installedPaths + side-effects. */
+	install(ctx: InstallCtx, packDir: string, name: string): InstalledEntity;
+	/** remove exactly what install wrote (given the provenance entity). */
+	uninstall(ctx: InstallCtx, entity: InstalledEntity): void;
+}
+
+function roleConfigDir(ctx: InstallCtx): string {
+	return path.join(ctx.configDir, "roles");
+}
+
+function toolConfigDir(ctx: InstallCtx): string {
+	return path.join(ctx.configDir, "tools");
+}
+
+/** Idempotently add `dir` to the project's config_directories (type "skills"). */
+function ensureCustomSkillDir(store: ProjectConfigWriter, dir: string): void {
+	const resolved = path.resolve(dir);
+	const dirs = parseCustomDirectories(store);
+	const existing = dirs.find((d) => path.resolve(d.path) === resolved);
+	if (existing) {
+		if (!existing.types.includes("skills")) {
+			existing.types = [...existing.types, "skills"];
+			saveCustomDirectories(store, dirs);
+		}
+		return;
+	}
+	dirs.push({ path: resolved, types: ["skills"] });
+	saveCustomDirectories(store, dirs);
+}
+
+/** Remove `dir` from config_directories if it carries only the "skills" type. */
+function removeCustomSkillDir(store: ProjectConfigWriter, dir: string): void {
+	const resolved = path.resolve(dir);
+	const dirs = parseCustomDirectories(store);
+	const next = dirs.filter((d) => path.resolve(d.path) !== resolved);
+	if (next.length !== dirs.length) saveCustomDirectories(store, next);
+}
+
+const roleHandler: EntityTypeHandler = {
+	type: "role",
+	manifestKey: "roles",
+	carriesCode: false,
+	payloadPath: (packDir, name) => path.join(packDir, "roles", `${name}.yaml`),
+	validate(packDir, name) {
+		const p = this.payloadPath(packDir, name);
+		if (!fs.existsSync(p)) return { ok: false, error: `role file missing: roles/${name}.yaml` };
+		try {
+			const parsed = YAML.parse(fs.readFileSync(p, "utf-8"));
+			if (!parsed || typeof parsed !== "object" || typeof parsed.name !== "string" || !parsed.name.trim()) {
+				return { ok: false, error: `role roles/${name}.yaml has no valid name field` };
+			}
+		} catch (err) {
+			return { ok: false, error: `role roles/${name}.yaml failed to parse: ${(err as Error).message}` };
+		}
+		return { ok: true };
+	},
+	destPath: (ctx, name) => path.join(roleConfigDir(ctx), `${name}.yaml`),
+	install(ctx, packDir, name) {
+		const src = this.payloadPath(packDir, name);
+		const dest = this.destPath(ctx, name);
+		fs.mkdirSync(path.dirname(dest), { recursive: true });
+		fs.copyFileSync(src, dest);
+		ctx.invalidateRoles?.();
+		return { type: "role", name, installedPaths: [dest] };
+	},
+	uninstall(ctx, entity) {
+		for (const p of entity.installedPaths) {
+			try { fs.rmSync(p, { force: true }); } catch { /* best-effort */ }
+		}
+		ctx.invalidateRoles?.();
+	},
+};
+
+const toolHandler: EntityTypeHandler = {
+	type: "tool",
+	manifestKey: "tools",
+	carriesCode: true,
+	payloadPath: (packDir, name) => path.join(packDir, "tools", name),
+	validate(packDir, name) {
+		const dir = this.payloadPath(packDir, name);
+		let stat: fs.Stats;
+		try { stat = fs.statSync(dir); } catch { return { ok: false, error: `tool group missing: tools/${name}/` }; }
+		if (!stat.isDirectory()) return { ok: false, error: `tools/${name} is not a directory` };
+		let yamlWithName = 0;
+		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+			if (!entry.isFile() || !entry.name.endsWith(".yaml")) continue;
+			try {
+				const parsed = YAML.parse(fs.readFileSync(path.join(dir, entry.name), "utf-8"));
+				if (parsed && typeof parsed === "object" && typeof parsed.name === "string" && parsed.name.trim()) {
+					yamlWithName++;
+				}
+			} catch { /* skip unparseable */ }
+		}
+		if (yamlWithName === 0) return { ok: false, error: `tool group tools/${name}/ has no *.yaml with a name field` };
+		return { ok: true };
+	},
+	destPath: (ctx, name) => path.join(toolConfigDir(ctx), name),
+	install(ctx, packDir, name) {
+		const src = this.payloadPath(packDir, name);
+		const dest = this.destPath(ctx, name);
+		copyDirRecursive(src, dest);
+		ctx.invalidateTools?.();
+		return { type: "tool", name, installedPaths: [dest] };
+	},
+	uninstall(ctx, entity) {
+		for (const p of entity.installedPaths) {
+			try { fs.rmSync(p, { recursive: true, force: true }); } catch { /* best-effort */ }
+		}
+		ctx.invalidateTools?.();
+	},
+};
+
+const skillHandler: EntityTypeHandler = {
+	type: "skill",
+	manifestKey: "skills",
+	carriesCode: false,
+	payloadPath: (packDir, name) => path.join(packDir, "skills", name),
+	validate(packDir, name) {
+		const skillFile = path.join(this.payloadPath(packDir, name), "SKILL.md");
+		if (!fs.existsSync(skillFile)) return { ok: false, error: `skill missing: skills/${name}/SKILL.md` };
+		return { ok: true };
+	},
+	destPath: (ctx, name) => path.join(ctx.skillInstallDir, name),
+	install(ctx, packDir, name) {
+		const src = this.payloadPath(packDir, name);
+		const dest = this.destPath(ctx, name);
+		copyDirRecursive(src, dest);
+		const entity: InstalledEntity = { type: "skill", name, installedPaths: [dest] };
+		// Project scope: register the (absolute) skills dir so discoverSlashSkills
+		// resolves it cross-worktree. System scope (~/.bobbit/skills) is always scanned.
+		if (ctx.scope === "project" && ctx.projectConfigStore) {
+			ensureCustomSkillDir(ctx.projectConfigStore, ctx.skillInstallDir);
+			entity.customDirRegistered = path.resolve(ctx.skillInstallDir);
+		}
+		return entity;
+	},
+	uninstall(ctx, entity) {
+		for (const p of entity.installedPaths) {
+			try { fs.rmSync(p, { recursive: true, force: true }); } catch { /* best-effort */ }
+		}
+		// Deregister the custom skill dir if it is now empty.
+		if (ctx.scope === "project" && ctx.projectConfigStore && entity.customDirRegistered) {
+			const dir = entity.customDirRegistered;
+			let empty = true;
+			try { empty = fs.readdirSync(dir).length === 0; } catch { empty = true; }
+			if (empty) {
+				removeCustomSkillDir(ctx.projectConfigStore, dir);
+				try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+			}
+		}
+	},
+};
+
+/** The entity-type registry. Adding a type = one handler + one entry here. */
+export const ENTITY_HANDLERS: Record<EntityType, EntityTypeHandler> = {
+	role: roleHandler,
+	tool: toolHandler,
+	skill: skillHandler,
+};
+
+/** Look up a handler by manifest key (e.g. "roles" → roleHandler). */
+export function handlerForManifestKey(key: string): EntityTypeHandler | undefined {
+	return Object.values(ENTITY_HANDLERS).find((h) => h.manifestKey === key);
+}

--- a/src/server/marketplace/entity-handlers.ts
+++ b/src/server/marketplace/entity-handlers.ts
@@ -24,6 +24,31 @@ export interface ValidationResult {
 	error?: string;
 }
 
+/**
+ * Safe entity-name grammar. Entity names from a pack manifest are joined into
+ * filesystem paths, so they must never contain path separators, `..`, drive
+ * letters, or leading dots. Anything outside this grammar makes the declaring
+ * pack invalid and is rejected during scan — it must never reach `path.join`.
+ */
+export const ENTITY_NAME_PATTERN = /^[a-z0-9][a-z0-9_-]*$/;
+
+export function isSafeEntityName(name: unknown): name is string {
+	return typeof name === "string" && ENTITY_NAME_PATTERN.test(name);
+}
+
+/**
+ * Defence-in-depth: assert that a resolved path stays under `root`. The scanner
+ * already rejects unsafe names, but install/uninstall re-check so a future
+ * code path that bypasses the scanner can never write/delete outside scope.
+ */
+export function assertWithin(root: string, target: string): void {
+	const r = path.resolve(root);
+	const t = path.resolve(target);
+	if (t !== r && !t.startsWith(r + path.sep)) {
+		throw new Error(`marketplace: path escapes ${root}: ${target}`);
+	}
+}
+
 export interface EntityTypeHandler {
 	type: EntityType;
 	/** key under pack.yaml `contents`. */
@@ -66,12 +91,29 @@ function ensureCustomSkillDir(store: ProjectConfigWriter, dir: string): void {
 	saveCustomDirectories(store, dirs);
 }
 
-/** Remove `dir` from config_directories if it carries only the "skills" type. */
-function removeCustomSkillDir(store: ProjectConfigWriter, dir: string): void {
+/**
+ * Drop only the "skills" type registration for `dir` from config_directories,
+ * preserving any other types (mcp/tools/agents) configured on the same path.
+ * The dir entry is removed entirely only when "skills" was its sole type.
+ * Returns whether `dir` is still referenced by config_directories afterwards.
+ */
+function removeCustomSkillType(store: ProjectConfigWriter, dir: string): boolean {
 	const resolved = path.resolve(dir);
 	const dirs = parseCustomDirectories(store);
-	const next = dirs.filter((d) => path.resolve(d.path) !== resolved);
-	if (next.length !== dirs.length) saveCustomDirectories(store, next);
+	let changed = false;
+	const next = [];
+	for (const d of dirs) {
+		if (path.resolve(d.path) !== resolved) {
+			next.push(d);
+			continue;
+		}
+		const types = d.types.filter((t) => t !== "skills");
+		changed = changed || types.length !== d.types.length;
+		if (types.length > 0) next.push({ ...d, types });
+		// else: drop the entry — "skills" was its only type.
+	}
+	if (changed) saveCustomDirectories(store, next);
+	return next.some((d) => path.resolve(d.path) === resolved);
 }
 
 const roleHandler: EntityTypeHandler = {
@@ -94,8 +136,11 @@ const roleHandler: EntityTypeHandler = {
 	},
 	destPath: (ctx, name) => path.join(roleConfigDir(ctx), `${name}.yaml`),
 	install(ctx, packDir, name) {
+		if (!isSafeEntityName(name)) throw new Error(`marketplace: unsafe role name: ${name}`);
 		const src = this.payloadPath(packDir, name);
 		const dest = this.destPath(ctx, name);
+		assertWithin(path.join(packDir, "roles"), src);
+		assertWithin(roleConfigDir(ctx), dest);
 		fs.mkdirSync(path.dirname(dest), { recursive: true });
 		fs.copyFileSync(src, dest);
 		ctx.invalidateRoles?.();
@@ -134,8 +179,11 @@ const toolHandler: EntityTypeHandler = {
 	},
 	destPath: (ctx, name) => path.join(toolConfigDir(ctx), name),
 	install(ctx, packDir, name) {
+		if (!isSafeEntityName(name)) throw new Error(`marketplace: unsafe tool group name: ${name}`);
 		const src = this.payloadPath(packDir, name);
 		const dest = this.destPath(ctx, name);
+		assertWithin(path.join(packDir, "tools"), src);
+		assertWithin(toolConfigDir(ctx), dest);
 		copyDirRecursive(src, dest);
 		ctx.invalidateTools?.();
 		return { type: "tool", name, installedPaths: [dest] };
@@ -160,8 +208,11 @@ const skillHandler: EntityTypeHandler = {
 	},
 	destPath: (ctx, name) => path.join(ctx.skillInstallDir, name),
 	install(ctx, packDir, name) {
+		if (!isSafeEntityName(name)) throw new Error(`marketplace: unsafe skill name: ${name}`);
 		const src = this.payloadPath(packDir, name);
 		const dest = this.destPath(ctx, name);
+		assertWithin(path.join(packDir, "skills"), src);
+		assertWithin(ctx.skillInstallDir, dest);
 		copyDirRecursive(src, dest);
 		const entity: InstalledEntity = { type: "skill", name, installedPaths: [dest] };
 		// Project scope: register the (absolute) skills dir so discoverSlashSkills
@@ -176,13 +227,15 @@ const skillHandler: EntityTypeHandler = {
 		for (const p of entity.installedPaths) {
 			try { fs.rmSync(p, { recursive: true, force: true }); } catch { /* best-effort */ }
 		}
-		// Deregister the custom skill dir if it is now empty.
+		// Drop only the "skills" registration for this dir, preserving any other
+		// config types registered on the same path. Delete the dir only if it is
+		// now empty AND no longer referenced by config_directories.
 		if (ctx.scope === "project" && ctx.projectConfigStore && entity.customDirRegistered) {
 			const dir = entity.customDirRegistered;
+			const stillReferenced = removeCustomSkillType(ctx.projectConfigStore, dir);
 			let empty = true;
 			try { empty = fs.readdirSync(dir).length === 0; } catch { empty = true; }
-			if (empty) {
-				removeCustomSkillDir(ctx.projectConfigStore, dir);
+			if (empty && !stillReferenced) {
 				try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
 			}
 		}

--- a/src/server/marketplace/entity-handlers.ts
+++ b/src/server/marketplace/entity-handlers.ts
@@ -159,9 +159,8 @@ function ensureCustomSkillDir(store: ProjectConfigWriter, dir: string): void {
  * Drop only the "skills" type registration for `dir` from config_directories,
  * preserving any other types (mcp/tools/agents) configured on the same path.
  * The dir entry is removed entirely only when "skills" was its sole type.
- * Returns whether `dir` is still referenced by config_directories afterwards.
  */
-function removeCustomSkillType(store: ProjectConfigWriter, dir: string): boolean {
+function removeCustomSkillType(store: ProjectConfigWriter, dir: string): void {
 	const resolved = path.resolve(dir);
 	const dirs = parseCustomDirectories(store);
 	let changed = false;
@@ -177,7 +176,45 @@ function removeCustomSkillType(store: ProjectConfigWriter, dir: string): boolean
 		// else: drop the entry — "skills" was its only type.
 	}
 	if (changed) saveCustomDirectories(store, next);
-	return next.some((d) => path.resolve(d.path) === resolved);
+}
+
+/** True iff `dir` directly contains ≥1 skill subdir (a subdir with a SKILL.md). */
+function skillDirHasSkills(dir: string): boolean {
+	let entries: fs.Dirent[];
+	try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return false; }
+	for (const e of entries) {
+		if (e.isDirectory() && fs.existsSync(path.join(dir, e.name, "SKILL.md"))) return true;
+	}
+	return false;
+}
+
+/**
+ * Authoritative, idempotent reconciliation of the project-scope skills custom
+ * dir registration against on-disk reality. The `config_directories` "skills"
+ * registration for `ctx.skillInstallDir` must exist **iff** that dir currently
+ * holds ≥1 skill subdir. This is the single invariant every install / uninstall
+ * / update / rollback settles on as its final step, so the registration can
+ * never drift (e.g. uninstalling one skill pack must not break sibling packs
+ * that still live under the shared dir).
+ *
+ * System scope is always scanned by discoverSlashSkills, so this is a no-op
+ * there. When the dir is empty AND no longer registered, it is removed.
+ */
+export function reconcileSkillDirRegistration(ctx: InstallCtx): void {
+	if (ctx.scope !== "project" || !ctx.projectConfigStore) return;
+	const dir = ctx.skillInstallDir;
+	if (skillDirHasSkills(dir)) {
+		ensureCustomSkillDir(ctx.projectConfigStore, dir);
+		return;
+	}
+	// No skills remain → drop only the "skills" registration (preserve other
+	// types on the same path) and delete the now-empty dir if nothing else uses it.
+	removeCustomSkillType(ctx.projectConfigStore, dir);
+	try {
+		if (fs.existsSync(dir) && fs.readdirSync(dir).length === 0) {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	} catch { /* best-effort */ }
 }
 
 const roleHandler: EntityTypeHandler = {
@@ -279,30 +316,25 @@ const skillHandler: EntityTypeHandler = {
 		const dest = this.destPath(ctx, name);
 		assertWithin(path.join(packDir, "skills"), src);
 		assertWithin(ctx.skillInstallDir, dest);
+		// Ensure the shared skills dir exists, copy this skill's files, then let
+		// reconcile (the authoritative step) own the config_directories registration.
+		fs.mkdirSync(ctx.skillInstallDir, { recursive: true });
 		copyNoSymlinks(src, dest);
 		const entity: InstalledEntity = { type: "skill", name, installedPaths: [dest] };
-		// Project scope: register the (absolute) skills dir so discoverSlashSkills
-		// resolves it cross-worktree. System scope (~/.bobbit/skills) is always scanned.
+		// Project scope: discoverSlashSkills resolves the (absolute) skills dir via
+		// config_directories. Record the dir for provenance; reconcile keeps the
+		// registration in sync with on-disk reality. System scope is always scanned.
 		if (ctx.scope === "project" && ctx.projectConfigStore) {
-			ensureCustomSkillDir(ctx.projectConfigStore, ctx.skillInstallDir);
 			entity.customDirRegistered = path.resolve(ctx.skillInstallDir);
 		}
+		reconcileSkillDirRegistration(ctx);
 		return entity;
 	},
 	uninstall(ctx, entity) {
+		// Remove only THIS skill's files, then reconcile: the registration survives
+		// iff a sibling skill pack still lives under the shared dir.
 		removeContainedPaths(ctx.skillInstallDir, entity.installedPaths, true);
-		// Drop only the "skills" registration for this dir, preserving any other
-		// config types registered on the same path. Delete the dir only if it is
-		// now empty AND no longer referenced by config_directories.
-		if (ctx.scope === "project" && ctx.projectConfigStore && entity.customDirRegistered) {
-			const dir = entity.customDirRegistered;
-			const stillReferenced = removeCustomSkillType(ctx.projectConfigStore, dir);
-			let empty = true;
-			try { empty = fs.readdirSync(dir).length === 0; } catch { empty = true; }
-			if (empty && !stillReferenced) {
-				try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
-			}
-		}
+		reconcileSkillDirRegistration(ctx);
 	},
 };
 

--- a/src/server/marketplace/git-url-redact.ts
+++ b/src/server/marketplace/git-url-redact.ts
@@ -53,10 +53,13 @@ export function redactGitUrl(url: string): string {
 }
 
 /**
- * Secret substrings embedded in a git url: the userinfo password/token, and the
- * values of sensitive query-string params / a sensitive fragment assignment.
- * Both the raw and percent-decoded forms are returned so a value can be matched
- * however it happens to appear in a tool's output.
+ * Secret substrings embedded in a git url: the userinfo username AND password/
+ * token, and the values of sensitive query-string params / a sensitive fragment
+ * assignment. The username is included because the token-as-username form
+ * (`https://ghp_xxx@host/repo.git`) is common and would otherwise survive in
+ * `lastSyncError`/logs when git reformats the url in its stderr. Both the raw
+ * and percent-decoded forms are returned so a value can be matched however it
+ * happens to appear in a tool's output.
  */
 export function gitUrlSecrets(url: string): string[] {
 	const secrets = new Set<string>();
@@ -71,6 +74,7 @@ export function gitUrlSecrets(url: string): string[] {
 	} catch {
 		return [];
 	}
+	add(parsed.username);
 	add(parsed.password);
 	for (const [key, value] of parsed.searchParams.entries()) {
 		if (SENSITIVE_URL_KEYS.test(key)) add(value);

--- a/src/server/marketplace/git-url-redact.ts
+++ b/src/server/marketplace/git-url-redact.ts
@@ -1,0 +1,101 @@
+/**
+ * Marketplace MVP — shared git-URL credential redaction.
+ *
+ * Extracted into its own module so every code path that surfaces or logs a git
+ * URL (the source registry's DTOs/labels, provenance records, AND sync-error
+ * messages) redacts identically. Sync errors previously used only
+ * `stripTokenFromGitUrl` (userinfo only), so a `?token=`/`#token=` credential
+ * could leak into `lastSyncError`; routing every path through `redactGitUrl`
+ * closes that gap.
+ */
+
+import { stripTokenFromGitUrl } from "../skills/git.js";
+
+/**
+ * Query-param / fragment keys that may carry a credential and must be redacted
+ * from any surfaced/logged git URL (case-insensitive).
+ */
+export const SENSITIVE_URL_KEYS = /^(?:token|access_token|private_token|personal_access_token|oauth_token|api[_-]?key|key|auth|authorization|password|passwd|secret)$/i;
+
+/**
+ * Fully redact credentials from a git URL for display/logging:
+ *  - userinfo (`user:token@host`) via the shared `stripTokenFromGitUrl` helper;
+ *  - sensitive query-string params (`?token=…`, `?access_token=…`, …);
+ *  - a fragment that carries a token assignment (`#access_token=…`).
+ * Non-URL forms (scp-like `git@host:path`, local paths) are returned unchanged.
+ */
+export function redactGitUrl(url: string): string {
+	const stripped = stripTokenFromGitUrl(url);
+	let parsed: URL;
+	try {
+		parsed = new URL(stripped);
+	} catch {
+		return stripped; // not a parseable URL (ssh shorthand / local path)
+	}
+	let changed = false;
+	for (const key of [...parsed.searchParams.keys()]) {
+		if (SENSITIVE_URL_KEYS.test(key)) {
+			parsed.searchParams.delete(key);
+			changed = true;
+		}
+	}
+	// Fragments are meaningless to git remotes; drop one that looks like it
+	// smuggles a credential (`#token=…`, `#access_token=…`, …).
+	if (parsed.hash) {
+		const frag = parsed.hash.replace(/^#/, "");
+		const fragKey = frag.split("=")[0];
+		if (SENSITIVE_URL_KEYS.test(fragKey)) {
+			parsed.hash = "";
+			changed = true;
+		}
+	}
+	return changed ? parsed.toString() : stripped;
+}
+
+/**
+ * Secret substrings embedded in a git url: the userinfo password/token, and the
+ * values of sensitive query-string params / a sensitive fragment assignment.
+ * Both the raw and percent-decoded forms are returned so a value can be matched
+ * however it happens to appear in a tool's output.
+ */
+export function gitUrlSecrets(url: string): string[] {
+	const secrets = new Set<string>();
+	const add = (v: string | undefined): void => {
+		if (!v) return;
+		secrets.add(v);
+		try { secrets.add(decodeURIComponent(v)); } catch { /* malformed escape — keep raw only */ }
+	};
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return [];
+	}
+	add(parsed.password);
+	for (const [key, value] of parsed.searchParams.entries()) {
+		if (SENSITIVE_URL_KEYS.test(key)) add(value);
+	}
+	if (parsed.hash) {
+		const frag = parsed.hash.replace(/^#/, "");
+		const eq = frag.indexOf("=");
+		if (eq > 0 && SENSITIVE_URL_KEYS.test(frag.slice(0, eq))) add(frag.slice(eq + 1));
+	}
+	return [...secrets].filter((s) => s.length > 0);
+}
+
+/**
+ * Redact a git url AND any secret substrings it carries from a free-text
+ * message (e.g. a git stderr). git rewrites the url form in its error output
+ * (drops the scheme, moves the query into the path, etc.), so replacing only
+ * the exact url string is not enough — the raw token value must also be scrubbed
+ * wherever it surfaces. Used to sanitise sync errors before they reach
+ * `lastSyncError`.
+ */
+export function redactGitUrlInText(text: string, url: string): string {
+	if (!url) return text;
+	let out = text.split(url).join(redactGitUrl(url));
+	for (const secret of gitUrlSecrets(url)) {
+		out = out.split(secret).join("***");
+	}
+	return out;
+}

--- a/src/server/marketplace/install-service.ts
+++ b/src/server/marketplace/install-service.ts
@@ -8,6 +8,7 @@
  * call site exists from day one.
  */
 
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import { stripTokenFromGitUrl } from "../skills/git.js";
 import { ENTITY_HANDLERS } from "./entity-handlers.js";
@@ -184,23 +185,38 @@ export class InstallService {
 		const skipped = conflict === "skip" ? conflicting : [];
 
 		const installed: InstalledEntity[] = [];
+		// Overwrite mode: MOVE each existing destination to a temp backup before
+		// copying so a mid-install failure can restore it. Deleting up-front (the
+		// old behaviour) made rollback unable to recover a clobbered entity.
+		const backups: { dest: string; backup: string }[] = [];
 		try {
 			for (const t of toInstall) {
 				const handler = ENTITY_HANDLERS[t.type];
-				// Overwrite: remove the existing destination first so a dir copy
-				// can't leave stale files behind from a previous version.
 				if (conflict === "overwrite" && conflictKeys.has(`${t.type}/${t.name}`)) {
 					const dest = handler.destPath(ctx, t.name);
-					try { fs.rmSync(dest, { recursive: true, force: true }); } catch { /* best-effort */ }
+					const backup = `${dest}.mp-bak-${randomUUID().slice(0, 8)}`;
+					fs.renameSync(dest, backup);
+					backups.push({ dest, backup });
 				}
 				installed.push(handler.install(ctx, packDir, t.name));
 			}
 		} catch (err) {
-			// Roll back this install's writes (best-effort).
+			// Roll back this install's writes (best-effort), then restore backups so
+			// the system is left exactly as it was before the install began.
 			for (const e of installed) {
 				try { ENTITY_HANDLERS[e.type].uninstall(ctx, e); } catch { /* best-effort */ }
 			}
+			for (const b of backups) {
+				try {
+					if (fs.existsSync(b.dest)) fs.rmSync(b.dest, { recursive: true, force: true });
+					fs.renameSync(b.backup, b.dest);
+				} catch { /* best-effort */ }
+			}
 			throw err;
+		}
+		// Success: discard the backups of overwritten entities.
+		for (const b of backups) {
+			try { fs.rmSync(b.backup, { recursive: true, force: true }); } catch { /* best-effort */ }
 		}
 		return { installed, skipped };
 	}

--- a/src/server/marketplace/install-service.ts
+++ b/src/server/marketplace/install-service.ts
@@ -1,0 +1,230 @@
+/**
+ * Marketplace MVP — install pipeline (§6).
+ *
+ * One engine drives whole-pack and individual-entity install, plus update and
+ * uninstall. Conflict detection runs before any copy; copies are transactional
+ * with rollback of this install's writes on mid-copy failure. A TrustPolicy
+ * gate is invoked before any handler runs — a no-op in the MVP (§8.1) — so the
+ * call site exists from day one.
+ */
+
+import fs from "node:fs";
+import { stripTokenFromGitUrl } from "../skills/git.js";
+import { ENTITY_HANDLERS } from "./entity-handlers.js";
+import { hashPackPayload } from "./pack-scanner.js";
+import { ProvenanceStore } from "./provenance-store.js";
+import type {
+	ConflictMode,
+	EntityRef,
+	InstallCtx,
+	InstallEntityResult,
+	InstallOutcome,
+	InstallScope,
+	InstalledEntity,
+	ProvenanceRecord,
+	ScannedPack,
+	SourceRecord,
+} from "./types.js";
+
+/** Thrown when conflict mode is `fail` and ≥1 destination already exists. */
+export class ConflictError extends Error {
+	constructor(public readonly conflicts: EntityRef[]) {
+		super(`install conflict: ${conflicts.map((c) => `${c.type}/${c.name}`).join(", ")}`);
+		this.name = "ConflictError";
+	}
+}
+
+/** MVP no-op trust gate (§8.1). A future phase consults signatures/allowlists. */
+export interface TrustPolicy {
+	check(source: SourceRecord, pack: ScannedPack): void;
+}
+const NOOP_TRUST: TrustPolicy = { check: () => { /* no-op in MVP */ } };
+
+export interface InstallServiceDeps {
+	resolveCtx: (scope: InstallScope, projectId: string | null) => InstallCtx | null;
+	resolveProvenance: (scope: InstallScope, projectId: string | null) => ProvenanceStore | null;
+	trustPolicy?: TrustPolicy;
+}
+
+export interface InstallArgs {
+	scope: InstallScope;
+	projectId: string | null;
+	source: SourceRecord;
+	pack: ScannedPack;
+	/** null ⇒ whole pack (all declared); else a subset. */
+	entities: EntityRef[] | null;
+	conflict: ConflictMode;
+}
+
+export interface UpdateArgs {
+	scope: InstallScope;
+	projectId: string | null;
+	source: SourceRecord;
+	pack: ScannedPack;
+}
+
+export class InstallService {
+	private readonly deps: InstallServiceDeps;
+	private readonly trust: TrustPolicy;
+
+	constructor(deps: InstallServiceDeps) {
+		this.deps = deps;
+		this.trust = deps.trustPolicy ?? NOOP_TRUST;
+	}
+
+	/** Install a whole pack or a declared subset. */
+	install(args: InstallArgs): InstallOutcome {
+		const { scope, projectId, source, pack, entities, conflict } = args;
+		if (!pack.valid) throw new Error(`pack ${pack.packId} is invalid and cannot be installed: ${pack.error ?? ""}`);
+
+		const ctx = this.deps.resolveCtx(scope, projectId);
+		if (!ctx) throw new Error(`could not resolve install context for scope=${scope} projectId=${projectId ?? ""}`);
+		const provenance = this.deps.resolveProvenance(scope, projectId);
+		if (!provenance) throw new Error(`could not resolve provenance store for scope=${scope}`);
+
+		this.trust.check(source, pack);
+
+		const targets = this.resolveTargets(pack, entities);
+		if (targets.length === 0) throw new Error("no installable entities matched the request");
+
+		const { installed, skipped } = this.doCopy(ctx, targets, pack.dir, conflict);
+
+		const record = this.buildRecord(scope, projectId, source, pack, installed);
+		provenance.upsert(record);
+
+		const results: InstallEntityResult[] = [
+			...installed.map((e): InstallEntityResult => ({ type: e.type, name: e.name, status: "installed", installedPaths: e.installedPaths })),
+			...skipped.map((e): InstallEntityResult => ({ type: e.type, name: e.name, status: "skipped" })),
+		];
+		return { record, results, skipped };
+	}
+
+	/** Re-sync-then-refresh: re-copy recorded entities still declared; drop orphans. */
+	update(args: UpdateArgs): InstallOutcome {
+		const { scope, projectId, source, pack } = args;
+		const provenance = this.deps.resolveProvenance(scope, projectId);
+		if (!provenance) throw new Error(`could not resolve provenance store for scope=${scope}`);
+		const existing = provenance.find(source.id, pack.packId);
+		if (!existing) throw new Error(`pack ${pack.packId} is not installed at scope=${scope}`);
+		if (!pack.valid) throw new Error(`pack ${pack.packId} is invalid and cannot be updated: ${pack.error ?? ""}`);
+
+		const ctx = this.deps.resolveCtx(scope, projectId);
+		if (!ctx) throw new Error(`could not resolve install context for scope=${scope}`);
+		this.trust.check(source, pack);
+
+		const declaredNow = new Set(pack.entities.map((e) => `${e.type}/${e.name}`));
+		const toRefresh = existing.entities.filter((e) => declaredNow.has(`${e.type}/${e.name}`));
+		const toRemove = existing.entities.filter((e) => !declaredNow.has(`${e.type}/${e.name}`));
+
+		// Drop entities the new version no longer declares (no orphans).
+		for (const entity of toRemove) {
+			ENTITY_HANDLERS[entity.type].uninstall(ctx, entity);
+		}
+
+		// Re-copy the still-declared entities (overwrite).
+		const targets: EntityRef[] = toRefresh.map((e) => ({ type: e.type, name: e.name }));
+		const { installed, skipped } = this.doCopy(ctx, targets, pack.dir, "overwrite");
+
+		const record = this.buildRecord(scope, projectId, source, pack, installed);
+		provenance.upsert(record);
+
+		const results: InstallEntityResult[] = installed.map((e): InstallEntityResult => ({
+			type: e.type, name: e.name, status: "installed", installedPaths: e.installedPaths,
+		}));
+		return { record, results, skipped };
+	}
+
+	/** Remove exactly the paths the provenance record tracks, then drop the record. */
+	uninstall(args: { scope: InstallScope; projectId: string | null; sourceId: string; packId: string }): { removed: InstalledEntity[] } {
+		const { scope, projectId, sourceId, packId } = args;
+		const provenance = this.deps.resolveProvenance(scope, projectId);
+		if (!provenance) throw new Error(`could not resolve provenance store for scope=${scope}`);
+		const record = provenance.find(sourceId, packId);
+		if (!record) return { removed: [] };
+
+		const ctx = this.deps.resolveCtx(scope, projectId);
+		if (!ctx) throw new Error(`could not resolve install context for scope=${scope}`);
+
+		for (const entity of record.entities) {
+			ENTITY_HANDLERS[entity.type].uninstall(ctx, entity);
+		}
+		provenance.remove(sourceId, packId);
+		return { removed: record.entities };
+	}
+
+	// ── internals ──────────────────────────────────────────────
+
+	private resolveTargets(pack: ScannedPack, entities: EntityRef[] | null): EntityRef[] {
+		if (!entities) return pack.entities.map((e) => ({ type: e.type, name: e.name }));
+		const declared = new Set(pack.entities.map((e) => `${e.type}/${e.name}`));
+		return entities.filter((e) => declared.has(`${e.type}/${e.name}`));
+	}
+
+	private doCopy(
+		ctx: InstallCtx,
+		targets: EntityRef[],
+		packDir: string,
+		conflict: ConflictMode,
+	): { installed: InstalledEntity[]; skipped: EntityRef[] } {
+		// Conflict detection up front (against the same scope only).
+		const conflicting: EntityRef[] = [];
+		for (const t of targets) {
+			const dest = ENTITY_HANDLERS[t.type].destPath(ctx, t.name);
+			if (fs.existsSync(dest)) conflicting.push(t);
+		}
+		const conflictKeys = new Set(conflicting.map((c) => `${c.type}/${c.name}`));
+
+		if (conflict === "fail" && conflicting.length > 0) {
+			throw new ConflictError(conflicting);
+		}
+
+		const toInstall = conflict === "skip"
+			? targets.filter((t) => !conflictKeys.has(`${t.type}/${t.name}`))
+			: targets;
+		const skipped = conflict === "skip" ? conflicting : [];
+
+		const installed: InstalledEntity[] = [];
+		try {
+			for (const t of toInstall) {
+				const handler = ENTITY_HANDLERS[t.type];
+				// Overwrite: remove the existing destination first so a dir copy
+				// can't leave stale files behind from a previous version.
+				if (conflict === "overwrite" && conflictKeys.has(`${t.type}/${t.name}`)) {
+					const dest = handler.destPath(ctx, t.name);
+					try { fs.rmSync(dest, { recursive: true, force: true }); } catch { /* best-effort */ }
+				}
+				installed.push(handler.install(ctx, packDir, t.name));
+			}
+		} catch (err) {
+			// Roll back this install's writes (best-effort).
+			for (const e of installed) {
+				try { ENTITY_HANDLERS[e.type].uninstall(ctx, e); } catch { /* best-effort */ }
+			}
+			throw err;
+		}
+		return { installed, skipped };
+	}
+
+	private buildRecord(
+		scope: InstallScope,
+		projectId: string | null,
+		source: SourceRecord,
+		pack: ScannedPack,
+		installed: InstalledEntity[],
+	): ProvenanceRecord {
+		return {
+			scope,
+			projectId: scope === "project" ? projectId : null,
+			sourceId: source.id,
+			packId: pack.packId,
+			packName: pack.manifest?.name ?? pack.packId,
+			packVersion: pack.manifest?.version ?? "",
+			sourceKind: source.kind,
+			sourceUrl: source.url ? stripTokenFromGitUrl(source.url) : null,
+			sourceCommit: source.lastSyncCommit ?? null,
+			sourceContentHash: source.kind === "local" ? hashPackPayload(pack) : null,
+			installedAt: Date.now(),
+			entities: installed,
+		};
+	}
+}

--- a/src/server/marketplace/install-service.ts
+++ b/src/server/marketplace/install-service.ts
@@ -112,7 +112,7 @@ export class InstallService {
 			for (const e of installed) byKey.set(`${e.type}/${e.name}`, e);
 			recordEntities = [...byKey.values()];
 		}
-		const installMode = this.resolveInstallMode(isWholePack, pack, recordEntities);
+		const installMode = this.resolveInstallMode(pack, recordEntities);
 		const record = this.buildRecord(scope, projectId, source, pack, recordEntities, installMode);
 		provenance.upsert(record);
 
@@ -123,9 +123,15 @@ export class InstallService {
 		return { record, results, skipped };
 	}
 
-	/** subset install becomes "pack" once its record covers every declared entity. */
-	private resolveInstallMode(isWholePack: boolean, pack: ScannedPack, recordEntities: InstalledEntity[]): InstallMode {
-		if (isWholePack) return "pack";
+	/**
+	 * installMode is "pack" iff the FINAL recorded entity set covers every
+	 * declared entity — derived from on-disk reality, never from whether the
+	 * caller requested a whole-pack install. This matters for a whole-pack
+	 * install that skipped a conflict (conflict="skip"): the record then omits
+	 * the skipped entity, so it is correctly "subset" and a later whole-pack
+	 * update won't clobber the entity the user deliberately kept.
+	 */
+	private resolveInstallMode(pack: ScannedPack, recordEntities: InstalledEntity[]): InstallMode {
 		const declared = pack.entities.map((e) => `${e.type}/${e.name}`);
 		const have = new Set(recordEntities.map((e) => `${e.type}/${e.name}`));
 		const coversAll = declared.length > 0 && declared.every((k) => have.has(k));
@@ -176,7 +182,7 @@ export class InstallService {
 			reconcileSkillDirRegistration(ctx);
 		}
 
-		const installMode = this.resolveInstallMode(mode === "pack", pack, installed);
+		const installMode = this.resolveInstallMode(pack, installed);
 		const record = this.buildRecord(scope, projectId, source, pack, installed, installMode);
 		provenance.upsert(record);
 

--- a/src/server/marketplace/install-service.ts
+++ b/src/server/marketplace/install-service.ts
@@ -12,7 +12,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { stripTokenFromGitUrl } from "../skills/git.js";
-import { ENTITY_HANDLERS, isWithin } from "./entity-handlers.js";
+import { ENTITY_HANDLERS, isWithin, reconcileSkillDirRegistration } from "./entity-handlers.js";
 import { hashPackPayload } from "./pack-scanner.js";
 import { ProvenanceStore } from "./provenance-store.js";
 import type {
@@ -90,7 +90,16 @@ export class InstallService {
 		const targets = this.resolveTargets(pack, entities);
 		if (targets.length === 0) throw new Error("no installable entities matched the request");
 
-		const { installed, skipped } = this.doCopy(ctx, targets, pack.dir, conflict);
+		// reconcile is the authoritative final step: whatever doCopy leaves on
+		// disk (full success, conflict abort, or rolled-back failure), the skills
+		// registration is settled against on-disk reality afterwards.
+		let installed: InstalledEntity[];
+		let skipped: EntityRef[];
+		try {
+			({ installed, skipped } = this.doCopy(ctx, targets, pack.dir, conflict));
+		} finally {
+			reconcileSkillDirRegistration(ctx);
+		}
 
 		const isWholePack = entities === null;
 		// Subset install into an already-installed pack MERGES (union by type/name,
@@ -158,7 +167,14 @@ export class InstallService {
 		const finalKeys = new Set(finalTargets.map((t) => `${t.type}/${t.name}`));
 		const toRemove = existing.entities.filter((e) => !finalKeys.has(`${e.type}/${e.name}`));
 
-		const installed = this.applyUpdateTransactional(ctx, pack.dir, finalTargets, toRemove);
+		let installed: InstalledEntity[];
+		try {
+			installed = this.applyUpdateTransactional(ctx, pack.dir, finalTargets, toRemove);
+		} finally {
+			// Authoritative final step: settle the skills registration against
+			// on-disk reality regardless of success or rolled-back failure.
+			reconcileSkillDirRegistration(ctx);
+		}
 
 		const installMode = this.resolveInstallMode(mode === "pack", pack, installed);
 		const record = this.buildRecord(scope, projectId, source, pack, installed, installMode);
@@ -226,14 +242,10 @@ export class InstallService {
 		for (const b of backups) {
 			try { fs.rmSync(b.backup, { recursive: true, force: true }); } catch { /* best-effort */ }
 		}
-		// Removed skills: paths are already gone; drop the config_directories "skills"
-		// registration only when no skill remains installed (else a surviving skill
-		// would lose its dir registration).
-		if (toRemove.some((e) => e.type === "skill") && !installed.some((e) => e.type === "skill")) {
-			for (const e of toRemove.filter((e) => e.type === "skill")) {
-				try { ENTITY_HANDLERS.skill.uninstall(ctx, { ...e, installedPaths: [] }); } catch { /* best-effort */ }
-			}
-		}
+		// Removed skills: their files are already gone (backups discarded above);
+		// the shared config_directories "skills" registration is settled by the
+		// authoritative reconcile in update()'s finally — never dropped here, so a
+		// surviving sibling skill can't lose its dir registration.
 		if (toRemove.some((e) => e.type === "role")) ctx.invalidateRoles?.();
 		if (toRemove.some((e) => e.type === "tool")) ctx.invalidateTools?.();
 		return installed;
@@ -250,8 +262,14 @@ export class InstallService {
 		const ctx = this.deps.resolveCtx(scope, projectId);
 		if (!ctx) throw new Error(`could not resolve install context for scope=${scope}`);
 
-		for (const entity of record.entities) {
-			ENTITY_HANDLERS[entity.type].uninstall(ctx, entity);
+		try {
+			for (const entity of record.entities) {
+				ENTITY_HANDLERS[entity.type].uninstall(ctx, entity);
+			}
+		} finally {
+			// Authoritative final step — keep the skills registration iff any skill
+			// (e.g. from a sibling pack) still lives under the shared dir.
+			reconcileSkillDirRegistration(ctx);
 		}
 		provenance.remove(sourceId, packId);
 		return { removed: record.entities };

--- a/src/server/marketplace/install-service.ts
+++ b/src/server/marketplace/install-service.ts
@@ -10,8 +10,9 @@
 
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
+import path from "node:path";
 import { stripTokenFromGitUrl } from "../skills/git.js";
-import { ENTITY_HANDLERS } from "./entity-handlers.js";
+import { ENTITY_HANDLERS, isWithin } from "./entity-handlers.js";
 import { hashPackPayload } from "./pack-scanner.js";
 import { ProvenanceStore } from "./provenance-store.js";
 import type {
@@ -19,6 +20,7 @@ import type {
 	EntityRef,
 	InstallCtx,
 	InstallEntityResult,
+	InstallMode,
 	InstallOutcome,
 	InstallScope,
 	InstalledEntity,
@@ -90,7 +92,19 @@ export class InstallService {
 
 		const { installed, skipped } = this.doCopy(ctx, targets, pack.dir, conflict);
 
-		const record = this.buildRecord(scope, projectId, source, pack, installed);
+		const isWholePack = entities === null;
+		// Subset install into an already-installed pack MERGES (union by type/name,
+		// new install wins) so installing A then B never loses A from provenance.
+		// Whole-pack install writes the full record.
+		const existing = provenance.find(source.id, pack.packId);
+		let recordEntities = installed;
+		if (!isWholePack && existing) {
+			const byKey = new Map(existing.entities.map((e) => [`${e.type}/${e.name}`, e]));
+			for (const e of installed) byKey.set(`${e.type}/${e.name}`, e);
+			recordEntities = [...byKey.values()];
+		}
+		const installMode = this.resolveInstallMode(isWholePack, pack, recordEntities);
+		const record = this.buildRecord(scope, projectId, source, pack, recordEntities, installMode);
 		provenance.upsert(record);
 
 		const results: InstallEntityResult[] = [
@@ -100,7 +114,29 @@ export class InstallService {
 		return { record, results, skipped };
 	}
 
-	/** Re-sync-then-refresh: re-copy recorded entities still declared; drop orphans. */
+	/** subset install becomes "pack" once its record covers every declared entity. */
+	private resolveInstallMode(isWholePack: boolean, pack: ScannedPack, recordEntities: InstalledEntity[]): InstallMode {
+		if (isWholePack) return "pack";
+		const declared = pack.entities.map((e) => `${e.type}/${e.name}`);
+		const have = new Set(recordEntities.map((e) => `${e.type}/${e.name}`));
+		const coversAll = declared.length > 0 && declared.every((k) => have.has(k));
+		return coversAll ? "pack" : "subset";
+	}
+
+	/**
+	 * Re-sync-then-refresh, fully transactional across removals AND copies.
+	 *
+	 * - installMode "pack"   → install everything the updated pack now declares
+	 *   (add newly-declared, refresh existing, remove no-longer-declared), so a
+	 *   whole-pack update truly reflects upstream.
+	 * - installMode "subset" → refresh only tracked entities still declared and
+	 *   remove tracked entities no longer declared; never auto-add new ones.
+	 *
+	 * A mid-update failure restores the system exactly as it was: every removed
+	 * and every overwritten entity is backed up first, and on failure newly
+	 * copied entities are removed and all backups restored. Provenance is
+	 * rewritten only on full success.
+	 */
 	update(args: UpdateArgs): InstallOutcome {
 		const { scope, projectId, source, pack } = args;
 		const provenance = this.deps.resolveProvenance(scope, projectId);
@@ -113,26 +149,94 @@ export class InstallService {
 		if (!ctx) throw new Error(`could not resolve install context for scope=${scope}`);
 		this.trust.check(source, pack);
 
+		const mode: InstallMode = existing.installMode === "subset" ? "subset" : "pack";
 		const declaredNow = new Set(pack.entities.map((e) => `${e.type}/${e.name}`));
-		const toRefresh = existing.entities.filter((e) => declaredNow.has(`${e.type}/${e.name}`));
-		const toRemove = existing.entities.filter((e) => !declaredNow.has(`${e.type}/${e.name}`));
 
-		// Drop entities the new version no longer declares (no orphans).
-		for (const entity of toRemove) {
-			ENTITY_HANDLERS[entity.type].uninstall(ctx, entity);
-		}
+		const finalTargets: EntityRef[] = mode === "pack"
+			? pack.entities.map((e) => ({ type: e.type, name: e.name }))
+			: existing.entities.filter((e) => declaredNow.has(`${e.type}/${e.name}`)).map((e) => ({ type: e.type, name: e.name }));
+		const finalKeys = new Set(finalTargets.map((t) => `${t.type}/${t.name}`));
+		const toRemove = existing.entities.filter((e) => !finalKeys.has(`${e.type}/${e.name}`));
 
-		// Re-copy the still-declared entities (overwrite).
-		const targets: EntityRef[] = toRefresh.map((e) => ({ type: e.type, name: e.name }));
-		const { installed, skipped } = this.doCopy(ctx, targets, pack.dir, "overwrite");
+		const installed = this.applyUpdateTransactional(ctx, pack.dir, finalTargets, toRemove);
 
-		const record = this.buildRecord(scope, projectId, source, pack, installed);
+		const installMode = this.resolveInstallMode(mode === "pack", pack, installed);
+		const record = this.buildRecord(scope, projectId, source, pack, installed, installMode);
 		provenance.upsert(record);
 
 		const results: InstallEntityResult[] = installed.map((e): InstallEntityResult => ({
 			type: e.type, name: e.name, status: "installed", installedPaths: e.installedPaths,
 		}));
-		return { record, results, skipped };
+		return { record, results, skipped: [] };
+	}
+
+	/** Entity-type destination root for the resolved scope (for containment + backup). */
+	private entityRoot(ctx: InstallCtx, ref: EntityRef): string {
+		return path.dirname(ENTITY_HANDLERS[ref.type].destPath(ctx, ref.name));
+	}
+
+	/**
+	 * Apply an update's removals + copies as one transaction. Every path that
+	 * will be removed or overwritten is renamed to a temp backup first; on any
+	 * failure newly-copied entities are removed and all backups restored, leaving
+	 * the system byte-for-byte as before. On success backups are discarded and
+	 * skill custom-dir registrations are dropped only when no skill remains.
+	 */
+	private applyUpdateTransactional(
+		ctx: InstallCtx,
+		packDir: string,
+		targets: EntityRef[],
+		toRemove: InstalledEntity[],
+	): InstalledEntity[] {
+		const backups: { dest: string; backup: string }[] = [];
+		const installed: InstalledEntity[] = [];
+		const backup = (dest: string): void => {
+			if (!fs.existsSync(dest)) return;
+			const bak = `${dest}.mp-bak-${randomUUID().slice(0, 8)}`;
+			fs.renameSync(dest, bak);
+			backups.push({ dest, backup: bak });
+		};
+		try {
+			// 1. Back up (move aside) every entity that is being removed.
+			for (const e of toRemove) {
+				const root = this.entityRoot(ctx, e);
+				for (const p of e.installedPaths) {
+					if (!isWithin(root, p)) continue; // never touch tampered out-of-scope paths
+					backup(p);
+				}
+			}
+			// 2. Back up overwrite targets, then copy every target fresh.
+			for (const t of targets) {
+				backup(ENTITY_HANDLERS[t.type].destPath(ctx, t.name));
+				installed.push(ENTITY_HANDLERS[t.type].install(ctx, packDir, t.name));
+			}
+		} catch (err) {
+			for (const e of installed) {
+				try { ENTITY_HANDLERS[e.type].uninstall(ctx, e); } catch { /* best-effort */ }
+			}
+			for (const b of [...backups].reverse()) {
+				try {
+					if (fs.existsSync(b.dest)) fs.rmSync(b.dest, { recursive: true, force: true });
+					fs.renameSync(b.backup, b.dest);
+				} catch { /* best-effort */ }
+			}
+			throw err;
+		}
+		// Success: discard backups.
+		for (const b of backups) {
+			try { fs.rmSync(b.backup, { recursive: true, force: true }); } catch { /* best-effort */ }
+		}
+		// Removed skills: paths are already gone; drop the config_directories "skills"
+		// registration only when no skill remains installed (else a surviving skill
+		// would lose its dir registration).
+		if (toRemove.some((e) => e.type === "skill") && !installed.some((e) => e.type === "skill")) {
+			for (const e of toRemove.filter((e) => e.type === "skill")) {
+				try { ENTITY_HANDLERS.skill.uninstall(ctx, { ...e, installedPaths: [] }); } catch { /* best-effort */ }
+			}
+		}
+		if (toRemove.some((e) => e.type === "role")) ctx.invalidateRoles?.();
+		if (toRemove.some((e) => e.type === "tool")) ctx.invalidateTools?.();
+		return installed;
 	}
 
 	/** Remove exactly the paths the provenance record tracks, then drop the record. */
@@ -227,6 +331,7 @@ export class InstallService {
 		source: SourceRecord,
 		pack: ScannedPack,
 		installed: InstalledEntity[],
+		installMode: InstallMode,
 	): ProvenanceRecord {
 		return {
 			scope,
@@ -240,6 +345,7 @@ export class InstallService {
 			sourceCommit: source.lastSyncCommit ?? null,
 			sourceContentHash: source.kind === "local" ? hashPackPayload(pack) : null,
 			installedAt: Date.now(),
+			installMode,
 			entities: installed,
 		};
 	}

--- a/src/server/marketplace/install-service.ts
+++ b/src/server/marketplace/install-service.ts
@@ -190,6 +190,14 @@ export class InstallService {
 			reconcileSkillDirRegistration(ctx);
 		}
 
+		// When the updated pack no longer declares any TRACKED entity, nothing
+		// remains installed for this pack: REMOVE the provenance record rather than
+		// upserting an empty one (an empty record is a phantom "installed" pack).
+		if (installed.length === 0) {
+			provenance.remove(source.id, pack.packId);
+			return { record: null, results: [], skipped: [] };
+		}
+
 		// Preserve the original install intent — update never flips pack↔subset.
 		const record = this.buildRecord(scope, projectId, source, pack, installed, existing.installMode);
 		provenance.upsert(record);
@@ -325,6 +333,11 @@ export class InstallService {
 		// copying so a mid-install failure can restore it. Deleting up-front (the
 		// old behaviour) made rollback unable to recover a clobbered entity.
 		const backups: { dest: string; backup: string }[] = [];
+		// Destination of the entity currently being written — cleared once its
+		// install returns. If install() throws mid-write it leaves a partial dest
+		// that is NOT yet in `installed`, so the rollback loop below can't reach it;
+		// we remove it explicitly first.
+		let failingDest: string | null = null;
 		try {
 			for (const t of toInstall) {
 				const handler = ENTITY_HANDLERS[t.type];
@@ -334,9 +347,17 @@ export class InstallService {
 					fs.renameSync(dest, backup);
 					backups.push({ dest, backup });
 				}
+				failingDest = handler.destPath(ctx, t.name);
 				installed.push(withContentHash(handler.install(ctx, packDir, t.name)));
+				failingDest = null;
 			}
 		} catch (err) {
+			// Clean up the partially-written dest of the entity that failed mid-copy
+			// (it never made it into `installed`), so rollback can restore a backup
+			// to that path and no half-written entity is left behind.
+			if (failingDest) {
+				try { fs.rmSync(failingDest, { recursive: true, force: true }); } catch { /* best-effort */ }
+			}
 			// Roll back this install's writes (best-effort), then restore backups so
 			// the system is left exactly as it was before the install began.
 			for (const e of installed) {

--- a/src/server/marketplace/install-service.ts
+++ b/src/server/marketplace/install-service.ts
@@ -11,10 +11,10 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { stripTokenFromGitUrl } from "../skills/git.js";
 import { ENTITY_HANDLERS, isWithin, reconcileSkillDirRegistration } from "./entity-handlers.js";
-import { hashPackPayload } from "./pack-scanner.js";
+import { hashInstalledEntity, hashPackPayload } from "./pack-scanner.js";
 import { ProvenanceStore } from "./provenance-store.js";
+import { redactGitUrl } from "./source-registry.js";
 import type {
 	ConflictMode,
 	EntityRef,
@@ -42,6 +42,12 @@ export interface TrustPolicy {
 	check(source: SourceRecord, pack: ScannedPack): void;
 }
 const NOOP_TRUST: TrustPolicy = { check: () => { /* no-op in MVP */ } };
+
+/** Stamp the content hash of what was just written onto a freshly-installed entity. */
+function withContentHash(entity: InstalledEntity): InstalledEntity {
+	entity.contentHash = hashInstalledEntity(entity.installedPaths);
+	return entity;
+}
 
 export interface InstallServiceDeps {
 	resolveCtx: (scope: InstallScope, projectId: string | null) => InstallCtx | null;
@@ -141,11 +147,13 @@ export class InstallService {
 	/**
 	 * Re-sync-then-refresh, fully transactional across removals AND copies.
 	 *
-	 * - installMode "pack"   → install everything the updated pack now declares
-	 *   (add newly-declared, refresh existing, remove no-longer-declared), so a
-	 *   whole-pack update truly reflects upstream.
-	 * - installMode "subset" → refresh only tracked entities still declared and
-	 *   remove tracked entities no longer declared; never auto-add new ones.
+	 * Update is "refresh what I have" for BOTH pack and subset installs (design
+	 * §7.3): re-copy every TRACKED entity the updated pack still declares, and
+	 * remove tracked entities the pack no longer declares (so update never
+	 * leaves orphans). Newly-declared entities are **never** auto-added — the UI
+	 * surfaces them via `newEntitiesAvailable` so the user can re-install the
+	 * pack to add them. The original install intent (pack vs subset) is
+	 * preserved on the rewritten record.
 	 *
 	 * A mid-update failure restores the system exactly as it was: every removed
 	 * and every overwritten entity is backed up first, and on failure newly
@@ -164,12 +172,12 @@ export class InstallService {
 		if (!ctx) throw new Error(`could not resolve install context for scope=${scope}`);
 		this.trust.check(source, pack);
 
-		const mode: InstallMode = existing.installMode === "subset" ? "subset" : "pack";
+		// Refresh only tracked entities still declared; drop tracked entities the
+		// pack no longer declares. No auto-add of newly-declared entities.
 		const declaredNow = new Set(pack.entities.map((e) => `${e.type}/${e.name}`));
-
-		const finalTargets: EntityRef[] = mode === "pack"
-			? pack.entities.map((e) => ({ type: e.type, name: e.name }))
-			: existing.entities.filter((e) => declaredNow.has(`${e.type}/${e.name}`)).map((e) => ({ type: e.type, name: e.name }));
+		const finalTargets: EntityRef[] = existing.entities
+			.filter((e) => declaredNow.has(`${e.type}/${e.name}`))
+			.map((e) => ({ type: e.type, name: e.name }));
 		const finalKeys = new Set(finalTargets.map((t) => `${t.type}/${t.name}`));
 		const toRemove = existing.entities.filter((e) => !finalKeys.has(`${e.type}/${e.name}`));
 
@@ -182,8 +190,8 @@ export class InstallService {
 			reconcileSkillDirRegistration(ctx);
 		}
 
-		const installMode = this.resolveInstallMode(pack, installed);
-		const record = this.buildRecord(scope, projectId, source, pack, installed, installMode);
+		// Preserve the original install intent — update never flips pack↔subset.
+		const record = this.buildRecord(scope, projectId, source, pack, installed, existing.installMode);
 		provenance.upsert(record);
 
 		const results: InstallEntityResult[] = installed.map((e): InstallEntityResult => ({
@@ -230,7 +238,7 @@ export class InstallService {
 			// 2. Back up overwrite targets, then copy every target fresh.
 			for (const t of targets) {
 				backup(ENTITY_HANDLERS[t.type].destPath(ctx, t.name));
-				installed.push(ENTITY_HANDLERS[t.type].install(ctx, packDir, t.name));
+				installed.push(withContentHash(ENTITY_HANDLERS[t.type].install(ctx, packDir, t.name)));
 			}
 		} catch (err) {
 			for (const e of installed) {
@@ -326,7 +334,7 @@ export class InstallService {
 					fs.renameSync(dest, backup);
 					backups.push({ dest, backup });
 				}
-				installed.push(handler.install(ctx, packDir, t.name));
+				installed.push(withContentHash(handler.install(ctx, packDir, t.name)));
 			}
 		} catch (err) {
 			// Roll back this install's writes (best-effort), then restore backups so
@@ -365,7 +373,7 @@ export class InstallService {
 			packName: pack.manifest?.name ?? pack.packId,
 			packVersion: pack.manifest?.version ?? "",
 			sourceKind: source.kind,
-			sourceUrl: source.url ? stripTokenFromGitUrl(source.url) : null,
+			sourceUrl: source.url ? redactGitUrl(source.url) : null,
 			sourceCommit: source.lastSyncCommit ?? null,
 			sourceContentHash: source.kind === "local" ? hashPackPayload(pack) : null,
 			installedAt: Date.now(),

--- a/src/server/marketplace/install-service.ts
+++ b/src/server/marketplace/install-service.ts
@@ -118,6 +118,16 @@ export class InstallService {
 			for (const e of installed) byKey.set(`${e.type}/${e.name}`, e);
 			recordEntities = [...byKey.values()];
 		}
+		// Overwrite install may have rewritten the bytes of an entity another pack
+		// previously installed at this scope. Transfer ownership of everything we
+		// actually wrote away from those other records so uninstall stays symmetric
+		// (the prior pack must not delete an entity it no longer owns).
+		provenance.supersedeEntities(
+			installed.map((e) => ({ type: e.type, name: e.name })),
+			source.id,
+			pack.packId,
+		);
+
 		const installMode = this.resolveInstallMode(pack, recordEntities);
 		const record = this.buildRecord(scope, projectId, source, pack, recordEntities, installMode);
 		provenance.upsert(record);
@@ -197,6 +207,14 @@ export class InstallService {
 			provenance.remove(source.id, pack.packId);
 			return { record: null, results: [], skipped: [] };
 		}
+
+		// Re-copying the tracked entities rewrites their bytes, reclaiming ownership
+		// from any other pack that had superseded them in the interim.
+		provenance.supersedeEntities(
+			installed.map((e) => ({ type: e.type, name: e.name })),
+			source.id,
+			pack.packId,
+		);
 
 		// Preserve the original install intent — update never flips pack↔subset.
 		const record = this.buildRecord(scope, projectId, source, pack, installed, existing.installMode);

--- a/src/server/marketplace/pack-scanner.ts
+++ b/src/server/marketplace/pack-scanner.ts
@@ -1,0 +1,159 @@
+/**
+ * Marketplace MVP — pack manifest parsing + source scanning (§2, §5).
+ *
+ * A directory is a pack iff it contains `pack.yaml`. Scanning is one level
+ * deep: only immediate children of the source root are considered. Declared
+ * contents are validated against on-disk payloads via the entity-handler
+ * registry, so adding an entity type does not touch this file.
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import YAML from "yaml";
+import { ENTITY_HANDLERS, handlerForManifestKey } from "./entity-handlers.js";
+import type { PackManifest, ScannedEntity, ScannedPack } from "./types.js";
+
+const ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+export interface ManifestParseResult {
+	manifest?: PackManifest;
+	error?: string;
+}
+
+/** Parse + shallow-validate the identity fields of a pack.yaml document. */
+export function parsePackManifest(yamlText: string): ManifestParseResult {
+	let raw: unknown;
+	try {
+		raw = YAML.parse(yamlText);
+	} catch (err) {
+		return { error: `pack.yaml failed to parse: ${(err as Error).message}` };
+	}
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+		return { error: "pack.yaml must be a YAML object" };
+	}
+	const obj = raw as Record<string, unknown>;
+
+	if (obj.apiVersion !== 1) {
+		return { error: `unsupported apiVersion ${JSON.stringify(obj.apiVersion)} (MVP accepts 1)` };
+	}
+	for (const field of ["id", "name", "description", "version"] as const) {
+		if (typeof obj[field] !== "string" || !(obj[field] as string).trim()) {
+			return { error: `pack.yaml missing required string field: ${field}` };
+		}
+	}
+	if (!ID_PATTERN.test(obj.id as string)) {
+		return { error: `pack.yaml id "${obj.id as string}" must match ${ID_PATTERN}` };
+	}
+	if (!obj.contents || typeof obj.contents !== "object" || Array.isArray(obj.contents)) {
+		return { error: "pack.yaml missing required object: contents" };
+	}
+
+	const contents = obj.contents as Record<string, unknown>;
+	const hasAnySupported = Object.values(ENTITY_HANDLERS).some((h) => {
+		const list = contents[h.manifestKey];
+		return Array.isArray(list) && list.length > 0;
+	});
+	if (!hasAnySupported) {
+		return { error: "pack.yaml contents must declare at least one of: roles, tools, skills" };
+	}
+
+	// Preserve the whole object (unknown keys + unknown contents keys) for
+	// forward-compat; the typed view is a superset.
+	return { manifest: obj as unknown as PackManifest };
+}
+
+/**
+ * Build a ScannedPack from a pack directory. Returns a pack with `valid:false`
+ * + `error` on any manifest/validation failure (non-fatal at source level).
+ */
+export function scanPackDir(sourceId: string, packDir: string): ScannedPack {
+	const manifestPath = path.join(packDir, "pack.yaml");
+	let packId = path.basename(packDir);
+
+	const parsed = parsePackManifest(safeRead(manifestPath));
+	if (!parsed.manifest) {
+		return { sourceId, packId, dir: packDir, manifest: null, entities: [], hasTools: false, valid: false, error: parsed.error };
+	}
+	const manifest = parsed.manifest;
+	packId = manifest.id;
+
+	const entities: ScannedEntity[] = [];
+	const errors: string[] = [];
+
+	// Iterate declared contents through the handler registry. Unknown contents
+	// keys (no handler) are ignored — forward-compat (§2.2).
+	for (const [key, listRaw] of Object.entries(manifest.contents)) {
+		const handler = handlerForManifestKey(key);
+		if (!handler) continue; // unknown contents key — preserved, ignored
+		const list = Array.isArray(listRaw) ? listRaw : [];
+		for (const name of list) {
+			if (typeof name !== "string" || !name.trim()) {
+				errors.push(`${key}: entry must be a non-empty string`);
+				continue;
+			}
+			const res = handler.validate(packDir, name);
+			if (!res.ok) {
+				errors.push(res.error ?? `${key}/${name} is invalid`);
+				continue;
+			}
+			entities.push({ type: handler.type, name, sourcePath: handler.payloadPath(packDir, name) });
+		}
+	}
+
+	const hasTools = entities.some((e) => e.type === "tool");
+	if (errors.length > 0) {
+		return { sourceId, packId, dir: packDir, manifest, entities, hasTools, valid: false, error: errors.join("; ") };
+	}
+	return { sourceId, packId, dir: packDir, manifest, entities, hasTools, valid: true };
+}
+
+/** Scan a synced source root → list of ScannedPack (one level deep). */
+export function scanSource(sourceId: string, root: string): ScannedPack[] {
+	let entries: fs.Dirent[];
+	try {
+		entries = fs.readdirSync(root, { withFileTypes: true });
+	} catch {
+		return [];
+	}
+	const packs: ScannedPack[] = [];
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+		const dir = path.join(root, entry.name);
+		if (!fs.existsSync(path.join(dir, "pack.yaml"))) continue; // not a pack
+		packs.push(scanPackDir(sourceId, dir));
+	}
+	return packs;
+}
+
+/**
+ * Stable content hash over a pack's declared entity payloads. Used as the
+ * freshness signal for local sources (no commit SHA). Hashes relative path +
+ * bytes of every file under each entity's payload path.
+ */
+export function hashPackPayload(pack: ScannedPack): string {
+	const hash = crypto.createHash("sha256");
+	const sorted = [...pack.entities].sort((a, b) => (a.type + a.name).localeCompare(b.type + b.name));
+	for (const entity of sorted) {
+		hash.update(`\u0000${entity.type}:${entity.name}\u0000`);
+		hashPath(hash, entity.sourcePath, entity.sourcePath);
+	}
+	return hash.digest("hex");
+}
+
+function hashPath(hash: crypto.Hash, root: string, p: string): void {
+	let stat: fs.Stats;
+	try { stat = fs.statSync(p); } catch { return; }
+	if (stat.isDirectory()) {
+		for (const name of fs.readdirSync(p).sort()) {
+			hashPath(hash, root, path.join(p, name));
+		}
+	} else if (stat.isFile()) {
+		hash.update(path.relative(root, p).replace(/\\/g, "/"));
+		hash.update(fs.readFileSync(p));
+	}
+}
+
+function safeRead(p: string): string {
+	try { return fs.readFileSync(p, "utf-8"); } catch { return ""; }
+}

--- a/src/server/marketplace/pack-scanner.ts
+++ b/src/server/marketplace/pack-scanner.ts
@@ -147,6 +147,22 @@ export function hashPackPayload(pack: ScannedPack): string {
 	return hash.digest("hex");
 }
 
+/**
+ * Stable content hash over the bytes an install actually wrote (its
+ * `installedPaths`). Recorded per entity at install/update time and recomputed
+ * by computeInstallStatus to detect local edits as drift. Each path is hashed
+ * relative to itself, so the digest is machine-independent (absolute install
+ * dirs differ per machine but the payload bytes + intra-entity layout don't).
+ */
+export function hashInstalledEntity(installedPaths: string[]): string {
+	const hash = crypto.createHash("sha256");
+	for (const p of [...installedPaths].sort()) {
+		hash.update(`\u0000${p.replace(/\\/g, "/").split("/").pop() ?? ""}\u0000`);
+		hashPath(hash, p, p);
+	}
+	return hash.digest("hex");
+}
+
 function hashPath(hash: crypto.Hash, root: string, p: string): void {
 	let stat: fs.Stats;
 	// lstat (not stat) so a symlink is never followed/read while hashing — a

--- a/src/server/marketplace/pack-scanner.ts
+++ b/src/server/marketplace/pack-scanner.ts
@@ -86,7 +86,14 @@ export function scanPackDir(sourceId: string, packDir: string): ScannedPack {
 	for (const [key, listRaw] of Object.entries(manifest.contents)) {
 		const handler = handlerForManifestKey(key);
 		if (!handler) continue; // unknown contents key — preserved, ignored
-		const list = Array.isArray(listRaw) ? listRaw : [];
+		// A SUPPORTED contents key whose value is not an array is malformed: reject
+		// the pack rather than silently coercing to [] (which would hide declared
+		// entities the author intended to ship).
+		if (!Array.isArray(listRaw)) {
+			errors.push(`${key}: contents value must be an array of entity names`);
+			continue;
+		}
+		const list = listRaw;
 		for (const name of list) {
 			if (typeof name !== "string" || !name.trim()) {
 				errors.push(`${key}: entry must be a non-empty string`);

--- a/src/server/marketplace/pack-scanner.ts
+++ b/src/server/marketplace/pack-scanner.ts
@@ -149,7 +149,10 @@ export function hashPackPayload(pack: ScannedPack): string {
 
 function hashPath(hash: crypto.Hash, root: string, p: string): void {
 	let stat: fs.Stats;
-	try { stat = fs.statSync(p); } catch { return; }
+	// lstat (not stat) so a symlink is never followed/read while hashing — a
+	// pack containing a symlink is rejected at scan time, but defence-in-depth.
+	try { stat = fs.lstatSync(p); } catch { return; }
+	if (stat.isSymbolicLink()) return; // never follow links into host files
 	if (stat.isDirectory()) {
 		for (const name of fs.readdirSync(p).sort()) {
 			hashPath(hash, root, path.join(p, name));

--- a/src/server/marketplace/pack-scanner.ts
+++ b/src/server/marketplace/pack-scanner.ts
@@ -129,6 +129,19 @@ export function scanSource(sourceId: string, root: string): ScannedPack[] {
 		if (!fs.existsSync(path.join(dir, "pack.yaml"))) continue; // not a pack
 		packs.push(scanPackDir(sourceId, dir));
 	}
+
+	// Reject duplicate pack ids within one source. install/uninstall key on
+	// (sourceId, packId), so two packs claiming the same id are ambiguous — mark
+	// every pack in a colliding id group invalid rather than silently picking one.
+	const idCounts = new Map<string, number>();
+	for (const p of packs) idCounts.set(p.packId, (idCounts.get(p.packId) ?? 0) + 1);
+	for (const p of packs) {
+		if ((idCounts.get(p.packId) ?? 0) > 1) {
+			const dupMsg = `duplicate pack id "${p.packId}" declared by multiple pack directories in this source`;
+			p.valid = false;
+			p.error = p.error ? `${p.error}; ${dupMsg}` : dupMsg;
+		}
+	}
 	return packs;
 }
 

--- a/src/server/marketplace/pack-scanner.ts
+++ b/src/server/marketplace/pack-scanner.ts
@@ -11,7 +11,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import YAML from "yaml";
-import { ENTITY_HANDLERS, handlerForManifestKey } from "./entity-handlers.js";
+import { ENTITY_HANDLERS, ENTITY_NAME_PATTERN, handlerForManifestKey, isSafeEntityName } from "./entity-handlers.js";
 import type { PackManifest, ScannedEntity, ScannedPack } from "./types.js";
 
 const ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
@@ -90,6 +90,12 @@ export function scanPackDir(sourceId: string, packDir: string): ScannedPack {
 		for (const name of list) {
 			if (typeof name !== "string" || !name.trim()) {
 				errors.push(`${key}: entry must be a non-empty string`);
+				continue;
+			}
+			// Reject path-traversal / unsafe names BEFORE any path.join. An unsafe
+			// name makes the whole pack invalid; it never becomes a ScannedEntity.
+			if (!isSafeEntityName(name)) {
+				errors.push(`${key}/${name}: invalid entity name (must match ${ENTITY_NAME_PATTERN})`);
 				continue;
 			}
 			const res = handler.validate(packDir, name);

--- a/src/server/marketplace/provenance-store.ts
+++ b/src/server/marketplace/provenance-store.ts
@@ -12,6 +12,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { hashInstalledEntity } from "./pack-scanner.js";
 import type { EntityType, InstallStatus, ProvenanceRecord, ScannedPack, SourceRecord } from "./types.js";
 
 const ENTITY_TYPES: EntityType[] = ["role", "tool", "skill"];
@@ -93,7 +94,9 @@ export class ProvenanceStore {
 /**
  * Compute install status for a scanned pack against its provenance record (§5).
  * - not-installed: no record.
- * - drifted: a recorded installed path is missing on disk (best-effort).
+ * - drifted: a recorded installed path is missing OR its bytes were edited
+ *   locally (per-entity contentHash mismatch). Records that predate the
+ *   contentHash field fall back to existence-only drift detection.
  * - update-available: source commit (git) / content hash (local) differs from recorded.
  * - installed: otherwise.
  */
@@ -107,6 +110,12 @@ export function computeInstallStatus(
 	for (const entity of record.entities) {
 		for (const p of entity.installedPaths) {
 			if (!fs.existsSync(p)) return "drifted";
+		}
+		// Edit drift: recompute the on-disk hash and compare to what install
+		// recorded. Skipped for legacy records lacking a contentHash (existence
+		// check above is the only signal then).
+		if (entity.contentHash && hashInstalledEntity(entity.installedPaths) !== entity.contentHash) {
+			return "drifted";
 		}
 	}
 

--- a/src/server/marketplace/provenance-store.ts
+++ b/src/server/marketplace/provenance-store.ts
@@ -1,0 +1,101 @@
+/**
+ * Marketplace MVP — provenance store (§7).
+ *
+ * Provenance is committed alongside the entities it tracks, per scope, so
+ * update/uninstall is symmetric on any machine that has the entities:
+ *   - system scope  → <server-root>/.bobbit/config/marketplace/installed.json
+ *   - project scope → <project-root>/.bobbit/config/marketplace/installed.json
+ *
+ * Record key is (scope, projectId, sourceId, packId). Atomic write mirrors
+ * ProjectRegistry.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import type { InstallStatus, ProvenanceRecord, ScannedPack, SourceRecord } from "./types.js";
+
+export class ProvenanceStore {
+	private records: ProvenanceRecord[] = [];
+	private readonly storePath: string;
+
+	/** @param configDir scope config root (provenance lives at <configDir>/marketplace/installed.json). */
+	constructor(configDir: string) {
+		this.storePath = path.join(configDir, "marketplace", "installed.json");
+		this.load();
+	}
+
+	load(): void {
+		try {
+			const parsed = JSON.parse(fs.readFileSync(this.storePath, "utf-8"));
+			this.records = Array.isArray(parsed?.installs) ? parsed.installs : [];
+		} catch {
+			this.records = [];
+		}
+	}
+
+	private save(): void {
+		const dir = path.dirname(this.storePath);
+		fs.mkdirSync(dir, { recursive: true });
+		const tmp = this.storePath + ".tmp";
+		fs.writeFileSync(tmp, JSON.stringify({ version: 1, installs: this.records }, null, 2), "utf-8");
+		fs.renameSync(tmp, this.storePath);
+	}
+
+	list(): ProvenanceRecord[] {
+		return [...this.records];
+	}
+
+	find(sourceId: string, packId: string): ProvenanceRecord | undefined {
+		return this.records.find((r) => r.sourceId === sourceId && r.packId === packId);
+	}
+
+	/** Insert or replace the record for (sourceId, packId). */
+	upsert(record: ProvenanceRecord): void {
+		const idx = this.records.findIndex((r) => r.sourceId === record.sourceId && r.packId === record.packId);
+		if (idx >= 0) this.records[idx] = record;
+		else this.records.push(record);
+		this.save();
+	}
+
+	remove(sourceId: string, packId: string): void {
+		const before = this.records.length;
+		this.records = this.records.filter((r) => !(r.sourceId === sourceId && r.packId === packId));
+		if (this.records.length !== before) this.save();
+	}
+}
+
+/**
+ * Compute install status for a scanned pack against its provenance record (§5).
+ * - not-installed: no record.
+ * - drifted: a recorded installed path is missing on disk (best-effort).
+ * - update-available: source commit (git) / content hash (local) differs from recorded.
+ * - installed: otherwise.
+ */
+export function computeInstallStatus(
+	source: SourceRecord,
+	record: ProvenanceRecord | undefined,
+	currentContentHash: string | null,
+): InstallStatus {
+	if (!record) return "not-installed";
+
+	for (const entity of record.entities) {
+		for (const p of entity.installedPaths) {
+			if (!fs.existsSync(p)) return "drifted";
+		}
+	}
+
+	if (source.kind === "git") {
+		if (record.sourceCommit && source.lastSyncCommit && record.sourceCommit !== source.lastSyncCommit) {
+			return "update-available";
+		}
+	} else if (currentContentHash && record.sourceContentHash && currentContentHash !== record.sourceContentHash) {
+		return "update-available";
+	}
+
+	return "installed";
+}
+
+/** Convenience for tests/diagnostics: presence check ignoring drift/freshness. */
+export function isInstalled(record: ProvenanceRecord | undefined, pack: ScannedPack): boolean {
+	return !!record && record.packId === pack.packId;
+}

--- a/src/server/marketplace/provenance-store.ts
+++ b/src/server/marketplace/provenance-store.ts
@@ -105,7 +105,9 @@ export function computeInstallStatus(
 	record: ProvenanceRecord | undefined,
 	currentContentHash: string | null,
 ): InstallStatus {
-	if (!record) return "not-installed";
+	// No record — or a record that tracks zero entities (e.g. a stale empty
+	// record) — means nothing is installed for this pack.
+	if (!record || record.entities.length === 0) return "not-installed";
 
 	for (const entity of record.entities) {
 		for (const p of entity.installedPaths) {

--- a/src/server/marketplace/provenance-store.ts
+++ b/src/server/marketplace/provenance-store.ts
@@ -12,7 +12,32 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import type { InstallStatus, ProvenanceRecord, ScannedPack, SourceRecord } from "./types.js";
+import type { EntityType, InstallStatus, ProvenanceRecord, ScannedPack, SourceRecord } from "./types.js";
+
+const ENTITY_TYPES: EntityType[] = ["role", "tool", "skill"];
+
+/**
+ * Validate + normalise a record loaded from installed.json. A hand-edited or
+ * corrupt file must never crash the server or feed malformed records into the
+ * install engine, so records failing the shape/type contract are dropped.
+ * Missing `installMode` defaults to "pack" (legacy records predate the field).
+ */
+function coerceRecord(raw: unknown): ProvenanceRecord | null {
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+	const r = raw as Record<string, unknown>;
+	if (typeof r.sourceId !== "string" || typeof r.packId !== "string") return null;
+	if (r.scope !== "system" && r.scope !== "project") return null;
+	if (!Array.isArray(r.entities)) return null;
+	for (const e of r.entities) {
+		if (!e || typeof e !== "object" || Array.isArray(e)) return null;
+		const ent = e as Record<string, unknown>;
+		if (!ENTITY_TYPES.includes(ent.type as EntityType)) return null;
+		if (typeof ent.name !== "string") return null;
+		if (!Array.isArray(ent.installedPaths) || !ent.installedPaths.every((p) => typeof p === "string")) return null;
+	}
+	if (r.installMode !== "pack" && r.installMode !== "subset") r.installMode = "pack";
+	return r as unknown as ProvenanceRecord;
+}
 
 export class ProvenanceStore {
 	private records: ProvenanceRecord[] = [];
@@ -27,7 +52,8 @@ export class ProvenanceStore {
 	load(): void {
 		try {
 			const parsed = JSON.parse(fs.readFileSync(this.storePath, "utf-8"));
-			this.records = Array.isArray(parsed?.installs) ? parsed.installs : [];
+			const arr: unknown[] = Array.isArray(parsed?.installs) ? parsed.installs : [];
+			this.records = arr.map(coerceRecord).filter((r): r is ProvenanceRecord => r !== null);
 		} catch {
 			this.records = [];
 		}

--- a/src/server/marketplace/provenance-store.ts
+++ b/src/server/marketplace/provenance-store.ts
@@ -13,7 +13,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { hashInstalledEntity } from "./pack-scanner.js";
-import type { EntityType, InstallStatus, ProvenanceRecord, ScannedPack, SourceRecord } from "./types.js";
+import type { EntityRef, EntityType, InstallStatus, ProvenanceRecord, ScannedPack, SourceRecord } from "./types.js";
 
 const ENTITY_TYPES: EntityType[] = ["role", "tool", "skill"];
 
@@ -88,6 +88,43 @@ export class ProvenanceStore {
 		const before = this.records.length;
 		this.records = this.records.filter((r) => !(r.sourceId === sourceId && r.packId === packId));
 		if (this.records.length !== before) this.save();
+	}
+
+	/**
+	 * Transfer ownership of the given (type, name) entities to the installing pack
+	 * by dropping them from every OTHER pack record in this (same-scope) store.
+	 *
+	 * Called after an `overwrite` install/update rewrites the bytes of an entity
+	 * another pack previously installed: the destination path is now the new
+	 * pack's, so the prior pack must no longer claim it — otherwise uninstalling
+	 * the prior pack would delete an entity it no longer owns (asymmetry). A record
+	 * emptied by the removal is dropped entirely so it never lingers as a phantom
+	 * "installed" pack. The (keepSourceId, keepPackId) record is never touched
+	 * (the caller upserts it separately).
+	 */
+	supersedeEntities(entities: EntityRef[], keepSourceId: string, keepPackId: string): void {
+		if (entities.length === 0) return;
+		const keys = new Set(entities.map((e) => `${e.type}/${e.name}`));
+		let changed = false;
+		const next: ProvenanceRecord[] = [];
+		for (const r of this.records) {
+			if (r.sourceId === keepSourceId && r.packId === keepPackId) {
+				next.push(r);
+				continue;
+			}
+			const filtered = r.entities.filter((e) => !keys.has(`${e.type}/${e.name}`));
+			if (filtered.length === r.entities.length) {
+				next.push(r);
+				continue;
+			}
+			changed = true;
+			if (filtered.length > 0) next.push({ ...r, entities: filtered });
+			// else: drop the now-empty record entirely.
+		}
+		if (changed) {
+			this.records = next;
+			this.save();
+		}
 	}
 }
 

--- a/src/server/marketplace/service.ts
+++ b/src/server/marketplace/service.ts
@@ -12,7 +12,7 @@ import path from "node:path";
 import { ConflictError, InstallService, type InstallArgs } from "./install-service.js";
 import { hashPackPayload, scanSource } from "./pack-scanner.js";
 import { ProvenanceStore, computeInstallStatus } from "./provenance-store.js";
-import { SourceRegistry, type AddSourceInput } from "./source-registry.js";
+import { SourceRegistry, redactSourceUrl, type AddSourceInput } from "./source-registry.js";
 import { MarketplaceSyncService } from "./sync-service.js";
 import type { ProjectConfigWriter } from "../agent/config-directories.js";
 import type {
@@ -63,6 +63,27 @@ export interface PackSummary {
 	installedCommit: string | null;
 }
 
+/** Flat drill-down DTO the Market UI consumes (one pack, annotated for a scope). */
+export interface PackDetail {
+	sourceId: string;
+	packId: string;
+	name: string;
+	description: string;
+	version: string;
+	sourceLabel: string | null;
+	author: string | null;
+	homepage: string | null;
+	license: string | null;
+	minBobbit: string | null;
+	hasTools: boolean;
+	valid: boolean;
+	error: string | null;
+	installStatus: InstallStatus;
+	installedVersion: string | null;
+	installedCommit: string | null;
+	entities: Array<{ type: EntityRef["type"]; name: string; installed: boolean }>;
+}
+
 export class MarketplaceService {
 	readonly registry: SourceRegistry;
 	readonly sync: MarketplaceSyncService;
@@ -84,11 +105,12 @@ export class MarketplaceService {
 	// ── Sources ────────────────────────────────────────────────
 
 	listSources(): SourceRecord[] {
-		return this.registry.list();
+		// Redact credentials from every DTO leaving the service (§3, security).
+		return this.registry.list().map(redactSourceUrl);
 	}
 
 	addSource(input: AddSourceInput): SourceRecord {
-		return this.registry.add(input);
+		return redactSourceUrl(this.registry.add(input));
 	}
 
 	/** Sync a source (clone/pull git; validate local) and persist sync status. */
@@ -96,11 +118,12 @@ export class MarketplaceService {
 		const source = this.registry.get(id);
 		if (!source) throw new Error(`source not found: ${id}`);
 		const result = await this.sync.sync(source);
-		return this.registry.update(id, {
+		const updated = this.registry.update(id, {
 			lastSyncedAt: Date.now(),
 			lastSyncCommit: result.commit,
 			lastSyncError: result.error,
 		});
+		return redactSourceUrl(updated);
 	}
 
 	removeSource(id: string): void {
@@ -138,6 +161,42 @@ export class MarketplaceService {
 		return { summary: this.summarize(source, pack, provenance), pack, installedEntities };
 	}
 
+	/** Drill-down (flat): the Market UI's per-pack DTO, annotated for the scope. */
+	getPackDetail(sourceId: string, packId: string, scope: InstallScope, projectId: string | null): PackDetail | null {
+		const found = this.findPack(sourceId, packId);
+		if (!found) return null;
+		const { source, pack } = found;
+		const provenance = this.resolveProvenance(scope, projectId);
+		const record = provenance?.find(sourceId, packId);
+		const installedSet = new Set((record?.entities ?? []).map((e) => `${e.type}/${e.name}`));
+		const summary = this.summarize(source, pack, provenance);
+		const m = pack.manifest;
+		const str = (v: unknown): string | null => (typeof v === "string" && v.trim() ? v : null);
+		return {
+			sourceId: source.id,
+			packId: pack.packId,
+			name: summary.name,
+			description: summary.description,
+			version: summary.version,
+			sourceLabel: source.label,
+			author: str(m?.author),
+			homepage: str(m?.homepage),
+			license: str(m?.license),
+			minBobbit: str(m?.minBobbit),
+			hasTools: pack.hasTools,
+			valid: pack.valid,
+			error: pack.error ?? null,
+			installStatus: summary.installStatus,
+			installedVersion: summary.installedVersion,
+			installedCommit: summary.installedCommit,
+			entities: pack.entities.map((e) => ({
+				type: e.type,
+				name: e.name,
+				installed: installedSet.has(`${e.type}/${e.name}`),
+			})),
+		};
+	}
+
 	// ── Install / update / uninstall ───────────────────────────
 
 	installPack(opts: {
@@ -161,8 +220,13 @@ export class MarketplaceService {
 	}
 
 	async updatePack(opts: { sourceId: string; packId: string; scope: InstallScope; projectId: string | null }): Promise<InstallOutcome> {
-		// Re-sync first so the re-copy reflects upstream changes.
-		await this.syncSource(opts.sourceId);
+		// Re-sync first so the re-copy reflects upstream changes. If the sync
+		// failed, ABORT: the cache is stale and re-copying / rewriting provenance
+		// would record a null/stale commit and possibly clobber a good install.
+		const synced = await this.syncSource(opts.sourceId);
+		if (synced.lastSyncError) {
+			throw new Error(`cannot update pack ${opts.packId}: source ${opts.sourceId} failed to sync: ${synced.lastSyncError}`);
+		}
 		const found = this.requirePack(opts.sourceId, opts.packId);
 		return this.install.update({ scope: opts.scope, projectId: opts.projectId, source: found.source, pack: found.pack });
 	}

--- a/src/server/marketplace/service.ts
+++ b/src/server/marketplace/service.ts
@@ -1,0 +1,247 @@
+/**
+ * Marketplace MVP — service facade.
+ *
+ * Wires the source registry, sync service, scanner, provenance, and install
+ * engine behind high-level methods the REST routes call. Resolution of a
+ * (scope, projectId) pair into concrete config dirs + invalidation callbacks
+ * lives here so routes stay thin and the engine stays testable.
+ */
+
+import os from "node:os";
+import path from "node:path";
+import { ConflictError, InstallService, type InstallArgs } from "./install-service.js";
+import { hashPackPayload, scanSource } from "./pack-scanner.js";
+import { ProvenanceStore, computeInstallStatus } from "./provenance-store.js";
+import { SourceRegistry, type AddSourceInput } from "./source-registry.js";
+import { MarketplaceSyncService } from "./sync-service.js";
+import type { ProjectConfigWriter } from "../agent/config-directories.js";
+import type {
+	ConflictMode,
+	EntityRef,
+	InstallCtx,
+	InstallOutcome,
+	InstallScope,
+	InstallStatus,
+	ScannedPack,
+	SourceRecord,
+} from "./types.js";
+
+/** Per-project resolution result the host supplies. */
+export interface ResolvedProject {
+	configDir: string;
+	projectConfigStore: ProjectConfigWriter;
+	invalidateTools?: () => void;
+	invalidateRoles?: () => void;
+}
+
+export interface MarketplaceServiceDeps {
+	/** Server-global state dir (sources.json + sync cache live under here). */
+	stateDir: string;
+	/** System-scope config dir (= bobbitConfigDir()). */
+	systemConfigDir: string;
+	/** System-scope skills dir (always scanned by discoverSlashSkills). Default ~/.bobbit/skills. */
+	systemSkillsDir?: string;
+	/** Resolve a projectId to its config dir + writer + invalidators, or null. */
+	resolveProject: (projectId: string) => ResolvedProject | null;
+	invalidateSystemTools?: () => void;
+	invalidateSystemRoles?: () => void;
+}
+
+export interface PackSummary {
+	sourceId: string;
+	packId: string;
+	name: string;
+	description: string;
+	version: string;
+	sourceLabel: string | null;
+	entities: EntityRef[];
+	hasTools: boolean;
+	valid: boolean;
+	error?: string;
+	installStatus: InstallStatus;
+	installedVersion: string | null;
+	installedCommit: string | null;
+}
+
+export class MarketplaceService {
+	readonly registry: SourceRegistry;
+	readonly sync: MarketplaceSyncService;
+	private readonly install: InstallService;
+	private readonly deps: MarketplaceServiceDeps;
+	private readonly systemSkillsDir: string;
+
+	constructor(deps: MarketplaceServiceDeps) {
+		this.deps = deps;
+		this.systemSkillsDir = deps.systemSkillsDir ?? path.join(os.homedir(), ".bobbit", "skills");
+		this.registry = new SourceRegistry(deps.stateDir);
+		this.sync = new MarketplaceSyncService(path.join(deps.stateDir, "marketplace"));
+		this.install = new InstallService({
+			resolveCtx: (scope, projectId) => this.resolveCtx(scope, projectId),
+			resolveProvenance: (scope, projectId) => this.resolveProvenance(scope, projectId),
+		});
+	}
+
+	// ── Sources ────────────────────────────────────────────────
+
+	listSources(): SourceRecord[] {
+		return this.registry.list();
+	}
+
+	addSource(input: AddSourceInput): SourceRecord {
+		return this.registry.add(input);
+	}
+
+	/** Sync a source (clone/pull git; validate local) and persist sync status. */
+	async syncSource(id: string): Promise<SourceRecord> {
+		const source = this.registry.get(id);
+		if (!source) throw new Error(`source not found: ${id}`);
+		const result = await this.sync.sync(source);
+		return this.registry.update(id, {
+			lastSyncedAt: Date.now(),
+			lastSyncCommit: result.commit,
+			lastSyncError: result.error,
+		});
+	}
+
+	removeSource(id: string): void {
+		this.registry.remove(id);
+		this.sync.removeCache(id);
+	}
+
+	// ── Browse ─────────────────────────────────────────────────
+
+	/** List all packs across all sources, annotated with install status for the scope. */
+	listPacks(scope: InstallScope, projectId: string | null): PackSummary[] {
+		const provenance = this.resolveProvenance(scope, projectId);
+		const out: PackSummary[] = [];
+		for (const source of this.registry.list()) {
+			const root = this.sync.syncRoot(source);
+			for (const pack of scanSource(source.id, root)) {
+				out.push(this.summarize(source, pack, provenance));
+			}
+		}
+		return out;
+	}
+
+	/** Drill-down: the scanned pack + install status for the scope. */
+	getPack(sourceId: string, packId: string, scope: InstallScope, projectId: string | null): {
+		summary: PackSummary;
+		pack: ScannedPack;
+		installedEntities: EntityRef[];
+	} | null {
+		const found = this.findPack(sourceId, packId);
+		if (!found) return null;
+		const { source, pack } = found;
+		const provenance = this.resolveProvenance(scope, projectId);
+		const record = provenance?.find(sourceId, packId);
+		const installedEntities = record ? record.entities.map((e) => ({ type: e.type, name: e.name })) : [];
+		return { summary: this.summarize(source, pack, provenance), pack, installedEntities };
+	}
+
+	// ── Install / update / uninstall ───────────────────────────
+
+	installPack(opts: {
+		sourceId: string;
+		packId: string;
+		scope: InstallScope;
+		projectId: string | null;
+		entities: EntityRef[] | null;
+		conflict: ConflictMode;
+	}): InstallOutcome {
+		const found = this.requirePack(opts.sourceId, opts.packId);
+		const args: InstallArgs = {
+			scope: opts.scope,
+			projectId: opts.projectId,
+			source: found.source,
+			pack: found.pack,
+			entities: opts.entities,
+			conflict: opts.conflict,
+		};
+		return this.install.install(args);
+	}
+
+	async updatePack(opts: { sourceId: string; packId: string; scope: InstallScope; projectId: string | null }): Promise<InstallOutcome> {
+		// Re-sync first so the re-copy reflects upstream changes.
+		await this.syncSource(opts.sourceId);
+		const found = this.requirePack(opts.sourceId, opts.packId);
+		return this.install.update({ scope: opts.scope, projectId: opts.projectId, source: found.source, pack: found.pack });
+	}
+
+	uninstallPack(opts: { sourceId: string; packId: string; scope: InstallScope; projectId: string | null }): { removed: EntityRef[] } {
+		const res = this.install.uninstall({ scope: opts.scope, projectId: opts.projectId, sourceId: opts.sourceId, packId: opts.packId });
+		return { removed: res.removed.map((e) => ({ type: e.type, name: e.name })) };
+	}
+
+	// ── internals ──────────────────────────────────────────────
+
+	private findPack(sourceId: string, packId: string): { source: SourceRecord; pack: ScannedPack } | null {
+		const source = this.registry.get(sourceId);
+		if (!source) return null;
+		const root = this.sync.syncRoot(source);
+		const pack = scanSource(sourceId, root).find((p) => p.packId === packId);
+		if (!pack) return null;
+		return { source, pack };
+	}
+
+	private requirePack(sourceId: string, packId: string): { source: SourceRecord; pack: ScannedPack } {
+		const found = this.findPack(sourceId, packId);
+		if (!found) throw new Error(`pack not found: ${sourceId}/${packId}`);
+		return found;
+	}
+
+	private summarize(source: SourceRecord, pack: ScannedPack, provenance: ProvenanceStore | null): PackSummary {
+		const record = provenance?.find(source.id, pack.packId);
+		const contentHash = source.kind === "local" && pack.valid ? hashPackPayload(pack) : null;
+		const installStatus = computeInstallStatus(source, record, contentHash);
+		return {
+			sourceId: source.id,
+			packId: pack.packId,
+			name: pack.manifest?.name ?? pack.packId,
+			description: pack.manifest?.description ?? "",
+			version: pack.manifest?.version ?? "",
+			sourceLabel: source.label,
+			entities: pack.entities.map((e) => ({ type: e.type, name: e.name })),
+			hasTools: pack.hasTools,
+			valid: pack.valid,
+			error: pack.error,
+			installStatus,
+			installedVersion: record?.packVersion ?? null,
+			installedCommit: record?.sourceCommit ?? null,
+		};
+	}
+
+	private resolveCtx(scope: InstallScope, projectId: string | null): InstallCtx | null {
+		if (scope === "system") {
+			return {
+				scope,
+				projectId: null,
+				configDir: this.deps.systemConfigDir,
+				skillInstallDir: this.systemSkillsDir,
+				invalidateTools: this.deps.invalidateSystemTools,
+				invalidateRoles: this.deps.invalidateSystemRoles,
+			};
+		}
+		if (!projectId) return null;
+		const proj = this.deps.resolveProject(projectId);
+		if (!proj) return null;
+		return {
+			scope,
+			projectId,
+			configDir: proj.configDir,
+			skillInstallDir: path.join(proj.configDir, "skills"),
+			projectConfigStore: proj.projectConfigStore,
+			invalidateTools: proj.invalidateTools,
+			invalidateRoles: proj.invalidateRoles,
+		};
+	}
+
+	private resolveProvenance(scope: InstallScope, projectId: string | null): ProvenanceStore | null {
+		if (scope === "system") return new ProvenanceStore(this.deps.systemConfigDir);
+		if (!projectId) return null;
+		const proj = this.deps.resolveProject(projectId);
+		if (!proj) return null;
+		return new ProvenanceStore(proj.configDir);
+	}
+}
+
+export { ConflictError };

--- a/src/server/marketplace/service.ts
+++ b/src/server/marketplace/service.ts
@@ -61,6 +61,8 @@ export interface PackSummary {
 	installStatus: InstallStatus;
 	installedVersion: string | null;
 	installedCommit: string | null;
+	/** declared entities not present in the install record (0 when not installed). */
+	newEntitiesAvailable: number;
 }
 
 /** Flat drill-down DTO the Market UI consumes (one pack, annotated for a scope). */
@@ -81,6 +83,8 @@ export interface PackDetail {
 	installStatus: InstallStatus;
 	installedVersion: string | null;
 	installedCommit: string | null;
+	/** declared entities not present in the install record (0 when not installed). */
+	newEntitiesAvailable: number;
 	entities: Array<{ type: EntityRef["type"]; name: string; installed: boolean }>;
 }
 
@@ -189,6 +193,7 @@ export class MarketplaceService {
 			installStatus: summary.installStatus,
 			installedVersion: summary.installedVersion,
 			installedCommit: summary.installedCommit,
+			newEntitiesAvailable: summary.newEntitiesAvailable,
 			entities: pack.entities.map((e) => ({
 				type: e.type,
 				name: e.name,
@@ -257,6 +262,12 @@ export class MarketplaceService {
 		const record = provenance?.find(source.id, pack.packId);
 		const contentHash = source.kind === "local" && pack.valid ? hashPackPayload(pack) : null;
 		const installStatus = computeInstallStatus(source, record, contentHash);
+		// Declared entities the install record does not yet track. Only meaningful
+		// once installed (update never auto-adds these — see InstallService.update).
+		const installedKeys = new Set((record?.entities ?? []).map((e) => `${e.type}/${e.name}`));
+		const newEntitiesAvailable = record
+			? pack.entities.filter((e) => !installedKeys.has(`${e.type}/${e.name}`)).length
+			: 0;
 		return {
 			sourceId: source.id,
 			packId: pack.packId,
@@ -271,6 +282,7 @@ export class MarketplaceService {
 			installStatus,
 			installedVersion: record?.packVersion ?? null,
 			installedCommit: record?.sourceCommit ?? null,
+			newEntitiesAvailable,
 		};
 	}
 

--- a/src/server/marketplace/service.ts
+++ b/src/server/marketplace/service.ts
@@ -26,6 +26,29 @@ import type {
 	SourceRecord,
 } from "./types.js";
 
+/**
+ * Validate an install scope + projectId from a request (REST routes). Only
+ * "system" and "project" are accepted — a missing/empty scope defaults to
+ * "system", a misspelled scope is rejected, and "project" requires a non-empty
+ * projectId. Returns the normalised pair or an `error` string for a 400.
+ */
+export function parseInstallScope(
+	rawScope: unknown,
+	rawProjectId: unknown,
+): { scope: InstallScope; projectId: string | null } | { error: string } {
+	const scopeVal = rawScope == null || rawScope === "" ? "system" : rawScope;
+	if (scopeVal !== "system" && scopeVal !== "project") {
+		return { error: `scope must be "system" or "project", got: ${JSON.stringify(rawScope)}` };
+	}
+	const projectId = scopeVal === "project"
+		? (typeof rawProjectId === "string" && rawProjectId.trim() ? rawProjectId : null)
+		: null;
+	if (scopeVal === "project" && !projectId) {
+		return { error: "project scope requires projectId" };
+	}
+	return { scope: scopeVal, projectId };
+}
+
 /** Per-project resolution result the host supplies. */
 export interface ResolvedProject {
 	configDir: string;

--- a/src/server/marketplace/source-registry.ts
+++ b/src/server/marketplace/source-registry.ts
@@ -184,7 +184,10 @@ export class SourceRegistry {
 			url = (input.url ?? "").trim();
 			if (!url) throw new SourceRegistryError("git source requires a non-empty url");
 			validateGitUrl(url);
-			defaultLabel = basenameFromGitUrl(url);
+			// Derive the default label from the REDACTED url so a credential
+			// embedded in the url (userinfo / ?token= / #token=) never leaks into
+			// the surfaced label.
+			defaultLabel = basenameFromGitUrl(redactGitUrl(url));
 		} else {
 			srcPath = (input.path ?? "").trim();
 			if (!srcPath) throw new SourceRegistryError("local source requires a path");

--- a/src/server/marketplace/source-registry.ts
+++ b/src/server/marketplace/source-registry.ts
@@ -10,7 +10,19 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { stripTokenFromGitUrl } from "../skills/git.js";
 import type { SourceKind, SourceRecord } from "./types.js";
+
+/**
+ * Return a copy of a source record with any embedded git credentials stripped
+ * from `url`. Storage keeps the credential-bearing URL (the git backend needs
+ * it to authenticate); every API DTO must pass through here so tokens never
+ * leave the server.
+ */
+export function redactSourceUrl(record: SourceRecord): SourceRecord {
+	if (!record.url) return record;
+	return { ...record, url: stripTokenFromGitUrl(record.url) };
+}
 
 export interface AddSourceInput {
 	kind: SourceKind;

--- a/src/server/marketplace/source-registry.ts
+++ b/src/server/marketplace/source-registry.ts
@@ -10,49 +10,12 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { stripTokenFromGitUrl } from "../skills/git.js";
+import { redactGitUrl } from "./git-url-redact.js";
 import type { SourceKind, SourceRecord } from "./types.js";
 
-/**
- * Query-param / fragment keys that may carry a credential and must be redacted
- * from any surfaced/logged git URL (case-insensitive).
- */
-const SENSITIVE_URL_KEYS = /^(?:token|access_token|private_token|personal_access_token|oauth_token|api[_-]?key|key|auth|authorization|password|passwd|secret)$/i;
-
-/**
- * Fully redact credentials from a git URL for display/logging:
- *  - userinfo (`user:token@host`) via the shared `stripTokenFromGitUrl` helper;
- *  - sensitive query-string params (`?token=…`, `?access_token=…`, …);
- *  - a fragment that carries a token assignment (`#access_token=…`).
- * Non-URL forms (scp-like `git@host:path`, local paths) are returned unchanged.
- */
-export function redactGitUrl(url: string): string {
-	const stripped = stripTokenFromGitUrl(url);
-	let parsed: URL;
-	try {
-		parsed = new URL(stripped);
-	} catch {
-		return stripped; // not a parseable URL (ssh shorthand / local path)
-	}
-	let changed = false;
-	for (const key of [...parsed.searchParams.keys()]) {
-		if (SENSITIVE_URL_KEYS.test(key)) {
-			parsed.searchParams.delete(key);
-			changed = true;
-		}
-	}
-	// Fragments are meaningless to git remotes; drop one that looks like it
-	// smuggles a credential (`#token=…`, `#access_token=…`, …).
-	if (parsed.hash) {
-		const frag = parsed.hash.replace(/^#/, "");
-		const fragKey = frag.split("=")[0];
-		if (SENSITIVE_URL_KEYS.test(fragKey)) {
-			parsed.hash = "";
-			changed = true;
-		}
-	}
-	return changed ? parsed.toString() : stripped;
-}
+// redactGitUrl lives in its own module so the sync service can redact identically
+// without importing the whole registry. Re-exported here for existing callers.
+export { redactGitUrl } from "./git-url-redact.js";
 
 /**
  * Return a copy of a source record with any embedded git credentials stripped

--- a/src/server/marketplace/source-registry.ts
+++ b/src/server/marketplace/source-registry.ts
@@ -117,8 +117,15 @@ export class SourceRegistry {
 		const dir = path.dirname(this.storePath);
 		fs.mkdirSync(dir, { recursive: true });
 		const tmp = this.storePath + ".tmp";
-		fs.writeFileSync(tmp, JSON.stringify({ version: 1, sources: this.list() }, null, 2), "utf-8");
+		// sources.json stores original git URLs WITH embedded credentials (git
+		// needs them to authenticate), so restrict it to owner-only. mode on the
+		// open + an explicit chmod (belt-and-suspenders against a pre-existing
+		// file / lenient umask); guarded because Windows/some filesystems ignore
+		// POSIX modes and chmod can throw there.
+		fs.writeFileSync(tmp, JSON.stringify({ version: 1, sources: this.list() }, null, 2), { encoding: "utf-8", mode: 0o600 });
+		try { fs.chmodSync(tmp, 0o600); } catch { /* platform/filesystem ignores POSIX modes */ }
 		fs.renameSync(tmp, this.storePath);
+		try { fs.chmodSync(this.storePath, 0o600); } catch { /* platform/filesystem ignores POSIX modes */ }
 	}
 
 	list(): SourceRecord[] {

--- a/src/server/marketplace/source-registry.ts
+++ b/src/server/marketplace/source-registry.ts
@@ -1,0 +1,137 @@
+/**
+ * Marketplace MVP — source registry (§3).
+ *
+ * Server-global JSON store at <stateDir>/marketplace/sources.json. Mirrors
+ * ProjectRegistry's atomic write (temp file + rename). The source list is a
+ * machine/user-level concern (fetch locations + credentials), independent of
+ * any project — install *scope* is chosen per-install, not here.
+ */
+
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type { SourceKind, SourceRecord } from "./types.js";
+
+export interface AddSourceInput {
+	kind: SourceKind;
+	url?: string | null;
+	ref?: string | null;
+	path?: string | null;
+	label?: string | null;
+}
+
+export class SourceRegistryError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "SourceRegistryError";
+	}
+}
+
+export class SourceRegistry {
+	private sources = new Map<string, SourceRecord>();
+	private readonly storePath: string;
+
+	constructor(stateDir: string) {
+		this.storePath = path.join(stateDir, "marketplace", "sources.json");
+		this.load();
+	}
+
+	load(): void {
+		try {
+			const raw = fs.readFileSync(this.storePath, "utf-8");
+			const parsed = JSON.parse(raw);
+			const arr: unknown[] = Array.isArray(parsed) ? parsed : parsed?.sources;
+			this.sources.clear();
+			if (Array.isArray(arr)) {
+				for (const s of arr) {
+					if (s && typeof s === "object" && typeof (s as SourceRecord).id === "string") {
+						this.sources.set((s as SourceRecord).id, s as SourceRecord);
+					}
+				}
+			}
+		} catch {
+			this.sources.clear();
+		}
+	}
+
+	private save(): void {
+		const dir = path.dirname(this.storePath);
+		fs.mkdirSync(dir, { recursive: true });
+		const tmp = this.storePath + ".tmp";
+		fs.writeFileSync(tmp, JSON.stringify({ version: 1, sources: this.list() }, null, 2), "utf-8");
+		fs.renameSync(tmp, this.storePath);
+	}
+
+	list(): SourceRecord[] {
+		return [...this.sources.values()].sort((a, b) => a.addedAt - b.addedAt);
+	}
+
+	get(id: string): SourceRecord | undefined {
+		return this.sources.get(id);
+	}
+
+	/** Validate + add a source; assign an id. Does NOT sync (caller kicks sync). */
+	add(input: AddSourceInput): SourceRecord {
+		const kind = input.kind;
+		if (kind !== "git" && kind !== "local") {
+			throw new SourceRegistryError(`kind must be "git" or "local", got: ${String(kind)}`);
+		}
+
+		let url: string | null = null;
+		let srcPath: string | null = null;
+		let defaultLabel: string;
+
+		if (kind === "git") {
+			url = (input.url ?? "").trim();
+			if (!url) throw new SourceRegistryError("git source requires a non-empty url");
+			defaultLabel = basenameFromGitUrl(url);
+		} else {
+			srcPath = (input.path ?? "").trim();
+			if (!srcPath) throw new SourceRegistryError("local source requires a path");
+			if (!path.isAbsolute(srcPath)) throw new SourceRegistryError(`local source path must be absolute, got: ${srcPath}`);
+			let stat: fs.Stats;
+			try { stat = fs.statSync(srcPath); } catch { throw new SourceRegistryError(`local source path does not exist: ${srcPath}`); }
+			if (!stat.isDirectory()) throw new SourceRegistryError(`local source path is not a directory: ${srcPath}`);
+			defaultLabel = path.basename(srcPath);
+		}
+
+		const record: SourceRecord = {
+			id: randomUUID().slice(0, 8),
+			kind,
+			url,
+			ref: input.ref?.trim() || null,
+			path: srcPath,
+			label: input.label?.trim() || defaultLabel,
+			addedAt: Date.now(),
+			lastSyncedAt: null,
+			lastSyncCommit: null,
+			lastSyncError: null,
+		};
+		this.sources.set(record.id, record);
+		this.save();
+		return record;
+	}
+
+	/** Apply a partial update (typically sync status) and persist. */
+	update(id: string, patch: Partial<SourceRecord>): SourceRecord {
+		const record = this.sources.get(id);
+		if (!record) throw new SourceRegistryError(`source not found: ${id}`);
+		const next = { ...record, ...patch, id: record.id };
+		this.sources.set(id, next);
+		this.save();
+		return next;
+	}
+
+	remove(id: string): void {
+		if (!this.sources.has(id)) throw new SourceRegistryError(`source not found: ${id}`);
+		this.sources.delete(id);
+		this.save();
+	}
+}
+
+function basenameFromGitUrl(url: string): string {
+	const cleaned = url.replace(/\.git$/, "").replace(/\/+$/, "");
+	const idx = Math.max(cleaned.lastIndexOf("/"), cleaned.lastIndexOf(":"));
+	const base = idx >= 0 ? cleaned.slice(idx + 1) : cleaned;
+	return base || url;
+}

--- a/src/server/marketplace/source-registry.ts
+++ b/src/server/marketplace/source-registry.ts
@@ -14,6 +14,47 @@ import { stripTokenFromGitUrl } from "../skills/git.js";
 import type { SourceKind, SourceRecord } from "./types.js";
 
 /**
+ * Query-param / fragment keys that may carry a credential and must be redacted
+ * from any surfaced/logged git URL (case-insensitive).
+ */
+const SENSITIVE_URL_KEYS = /^(?:token|access_token|private_token|personal_access_token|oauth_token|api[_-]?key|key|auth|authorization|password|passwd|secret)$/i;
+
+/**
+ * Fully redact credentials from a git URL for display/logging:
+ *  - userinfo (`user:token@host`) via the shared `stripTokenFromGitUrl` helper;
+ *  - sensitive query-string params (`?token=…`, `?access_token=…`, …);
+ *  - a fragment that carries a token assignment (`#access_token=…`).
+ * Non-URL forms (scp-like `git@host:path`, local paths) are returned unchanged.
+ */
+export function redactGitUrl(url: string): string {
+	const stripped = stripTokenFromGitUrl(url);
+	let parsed: URL;
+	try {
+		parsed = new URL(stripped);
+	} catch {
+		return stripped; // not a parseable URL (ssh shorthand / local path)
+	}
+	let changed = false;
+	for (const key of [...parsed.searchParams.keys()]) {
+		if (SENSITIVE_URL_KEYS.test(key)) {
+			parsed.searchParams.delete(key);
+			changed = true;
+		}
+	}
+	// Fragments are meaningless to git remotes; drop one that looks like it
+	// smuggles a credential (`#token=…`, `#access_token=…`, …).
+	if (parsed.hash) {
+		const frag = parsed.hash.replace(/^#/, "");
+		const fragKey = frag.split("=")[0];
+		if (SENSITIVE_URL_KEYS.test(fragKey)) {
+			parsed.hash = "";
+			changed = true;
+		}
+	}
+	return changed ? parsed.toString() : stripped;
+}
+
+/**
  * Return a copy of a source record with any embedded git credentials stripped
  * from `url`. Storage keeps the credential-bearing URL (the git backend needs
  * it to authenticate); every API DTO must pass through here so tokens never
@@ -21,7 +62,7 @@ import type { SourceKind, SourceRecord } from "./types.js";
  */
 export function redactSourceUrl(record: SourceRecord): SourceRecord {
 	if (!record.url) return record;
-	return { ...record, url: stripTokenFromGitUrl(record.url) };
+	return { ...record, url: redactGitUrl(record.url) };
 }
 
 export interface AddSourceInput {

--- a/src/server/marketplace/source-registry.ts
+++ b/src/server/marketplace/source-registry.ts
@@ -39,6 +39,49 @@ export class SourceRegistryError extends Error {
 	}
 }
 
+/** git refs/branches/tags joined into argv must match a conservative grammar. */
+export const GIT_REF_PATTERN = /^[A-Za-z0-9._/-]+$/;
+const ALLOWED_GIT_SCHEMES = ["https", "ssh", "git", "file"];
+
+/**
+ * Reject a git URL that could be mis-parsed by `git clone`/`git fetch` as an
+ * option (a leading `-`) or that uses a dangerous protocol helper (e.g.
+ * `ext::`). Only the well-known transport schemes are allowed; the scp-like
+ * shorthand `user@host:path` (no URL scheme) is permitted because it cannot
+ * begin with `-` and carries no protocol-helper risk.
+ */
+export function validateGitUrl(url: string): void {
+	if (url.startsWith("-")) {
+		throw new SourceRegistryError(`git url must not start with "-" (would be parsed as a git option): ${url}`);
+	}
+	const schemeMatch = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(url);
+	if (schemeMatch) {
+		const scheme = schemeMatch[1].toLowerCase();
+		if (!ALLOWED_GIT_SCHEMES.includes(scheme)) {
+			throw new SourceRegistryError(
+				`git url scheme must be one of ${ALLOWED_GIT_SCHEMES.join("/")}, got: ${scheme}:`,
+			);
+		}
+		return;
+	}
+	// No URL scheme — only the scp-like shorthand (user@host:path) is acceptable.
+	if (!/^[^/:]+@[^/:]+:/.test(url)) {
+		throw new SourceRegistryError(
+			`git url must use an ${ALLOWED_GIT_SCHEMES.join("/")} scheme or scp-like syntax, got: ${url}`,
+		);
+	}
+}
+
+/** Reject a git ref that could be mis-parsed as an option or contains unsafe chars. */
+export function validateGitRef(ref: string): void {
+	if (ref.startsWith("-")) {
+		throw new SourceRegistryError(`git ref must not start with "-": ${ref}`);
+	}
+	if (!GIT_REF_PATTERN.test(ref)) {
+		throw new SourceRegistryError(`git ref must match ${GIT_REF_PATTERN}, got: ${ref}`);
+	}
+}
+
 export class SourceRegistry {
 	private sources = new Map<string, SourceRecord>();
 	private readonly storePath: string;
@@ -93,9 +136,13 @@ export class SourceRegistry {
 		let srcPath: string | null = null;
 		let defaultLabel: string;
 
+		const ref = input.ref?.trim() || null;
+		if (ref) validateGitRef(ref);
+
 		if (kind === "git") {
 			url = (input.url ?? "").trim();
 			if (!url) throw new SourceRegistryError("git source requires a non-empty url");
+			validateGitUrl(url);
 			defaultLabel = basenameFromGitUrl(url);
 		} else {
 			srcPath = (input.path ?? "").trim();
@@ -111,7 +158,7 @@ export class SourceRegistry {
 			id: randomUUID().slice(0, 8),
 			kind,
 			url,
-			ref: input.ref?.trim() || null,
+			ref,
 			path: srcPath,
 			label: input.label?.trim() || defaultLabel,
 			addedAt: Date.now(),

--- a/src/server/marketplace/sync-service.ts
+++ b/src/server/marketplace/sync-service.ts
@@ -1,0 +1,125 @@
+/**
+ * Marketplace MVP — sync mechanism (§4).
+ *
+ * Sources are reached through a SourceBackend so a hosted registry is a new
+ * backend, not a rewrite (§8.2). MVP ships GitSourceBackend (shallow clone /
+ * fetch+reset+clean) and LocalSourceBackend (read in place). The scanner
+ * always operates on the returned `root`, so it is backend-agnostic.
+ */
+
+import { execFile as execFileCb } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+import { stripTokenFromGitUrl } from "../skills/git.js";
+import type { SourceRecord } from "./types.js";
+
+const execFile = promisify(execFileCb);
+const GIT_TIMEOUT_MS = 120_000;
+
+export interface SyncResult {
+	root: string;
+	commit: string | null;
+	contentHash: string | null;
+	error: string | null;
+}
+
+export interface SourceBackend {
+	kind: string;
+	/** Sync the source into `cacheDir` (git) or validate it in place (local). */
+	sync(source: SourceRecord, cacheDir: string): Promise<SyncResult>;
+}
+
+async function git(args: string[], cwd?: string): Promise<string> {
+	const { stdout } = await execFile("git", args, { cwd, timeout: GIT_TIMEOUT_MS, maxBuffer: 32 * 1024 * 1024 });
+	return stdout.toString();
+}
+
+export class GitSourceBackend implements SourceBackend {
+	kind = "git";
+
+	async sync(source: SourceRecord, cacheDir: string): Promise<SyncResult> {
+		const url = source.url ?? "";
+		if (!url) return { root: cacheDir, commit: null, contentHash: null, error: "git source has no url" };
+		const ref = source.ref || null;
+		try {
+			const hasClone = fs.existsSync(path.join(cacheDir, ".git"));
+			if (!hasClone) {
+				// Fresh / corrupt cache → shallow clone.
+				if (fs.existsSync(cacheDir)) fs.rmSync(cacheDir, { recursive: true, force: true });
+				fs.mkdirSync(path.dirname(cacheDir), { recursive: true });
+				const cloneArgs = ["clone", "--depth", "1"];
+				if (ref) cloneArgs.push("--branch", ref);
+				cloneArgs.push(url, cacheDir);
+				await git(cloneArgs);
+			} else {
+				// Re-sync → fetch + hard reset + clean (never a merge in a cache the user never edits).
+				const fetchRef = ref || "HEAD";
+				await git(["fetch", "--depth", "1", "origin", fetchRef], cacheDir);
+				await git(["reset", "--hard", "FETCH_HEAD"], cacheDir);
+				await git(["clean", "-fdx"], cacheDir);
+			}
+			const commit = (await git(["rev-parse", "HEAD"], cacheDir)).trim();
+			return { root: cacheDir, commit: commit || null, contentHash: null, error: null };
+		} catch (err) {
+			// Surface a token-stripped message; leave any previous good cache intact.
+			const msg = (err as Error).message.split(url).join(stripTokenFromGitUrl(url));
+			return { root: cacheDir, commit: null, contentHash: null, error: msg };
+		}
+	}
+}
+
+export class LocalSourceBackend implements SourceBackend {
+	kind = "local";
+
+	async sync(source: SourceRecord): Promise<SyncResult> {
+		const root = source.path ?? "";
+		if (!root) return { root, commit: null, contentHash: null, error: "local source has no path" };
+		try {
+			if (!fs.statSync(root).isDirectory()) {
+				return { root, commit: null, contentHash: null, error: `local source path is not a directory: ${root}` };
+			}
+		} catch {
+			return { root, commit: null, contentHash: null, error: `local source path does not exist: ${root}` };
+		}
+		return { root, commit: null, contentHash: null, error: null };
+	}
+}
+
+export class MarketplaceSyncService {
+	private readonly cacheRoot: string;
+	private readonly backends: Record<string, SourceBackend>;
+
+	constructor(cacheRoot: string, backends?: Record<string, SourceBackend>) {
+		this.cacheRoot = cacheRoot;
+		this.backends = backends ?? {
+			git: new GitSourceBackend(),
+			local: new LocalSourceBackend(),
+		};
+	}
+
+	/** The per-source git clone cache dir. */
+	cacheDir(id: string): string {
+		return path.join(this.cacheRoot, id);
+	}
+
+	/** The directory the scanner reads: git → clone cache; local → path in place. */
+	syncRoot(source: SourceRecord): string {
+		if (source.kind === "local") return source.path ?? "";
+		return this.cacheDir(source.id);
+	}
+
+	async sync(source: SourceRecord): Promise<SyncResult> {
+		const backend = this.backends[source.kind];
+		if (!backend) {
+			return { root: this.syncRoot(source), commit: null, contentHash: null, error: `unknown source kind: ${source.kind}` };
+		}
+		return backend.sync(source, this.cacheDir(source.id));
+	}
+
+	/** Delete a source's git clone cache (no-op for local). */
+	removeCache(id: string): void {
+		const dir = this.cacheDir(id);
+		try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+	}
+}

--- a/src/server/marketplace/sync-service.ts
+++ b/src/server/marketplace/sync-service.ts
@@ -12,6 +12,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
 import { stripTokenFromGitUrl } from "../skills/git.js";
+import { validateGitRef, validateGitUrl } from "./source-registry.js";
 import type { SourceRecord } from "./types.js";
 
 const execFile = promisify(execFileCb);
@@ -42,6 +43,14 @@ export class GitSourceBackend implements SourceBackend {
 		const url = source.url ?? "";
 		if (!url) return { root: cacheDir, commit: null, contentHash: null, error: "git source has no url" };
 		const ref = source.ref || null;
+		// Defence-in-depth: the registry validates url/ref on add, but a tampered
+		// sources.json must never let a `-`-leading url/ref reach git's argv.
+		try {
+			validateGitUrl(url);
+			if (ref) validateGitRef(ref);
+		} catch (err) {
+			return { root: cacheDir, commit: null, contentHash: null, error: (err as Error).message };
+		}
 		try {
 			const hasClone = fs.existsSync(path.join(cacheDir, ".git"));
 			if (!hasClone) {
@@ -50,12 +59,14 @@ export class GitSourceBackend implements SourceBackend {
 				fs.mkdirSync(path.dirname(cacheDir), { recursive: true });
 				const cloneArgs = ["clone", "--depth", "1"];
 				if (ref) cloneArgs.push("--branch", ref);
-				cloneArgs.push(url, cacheDir);
+				// `--` terminates option parsing so a `-`-leading url/dir can never be
+				// interpreted as a git option (protocol-helper injection).
+				cloneArgs.push("--", url, cacheDir);
 				await git(cloneArgs);
 			} else {
 				// Re-sync → fetch + hard reset + clean (never a merge in a cache the user never edits).
 				const fetchRef = ref || "HEAD";
-				await git(["fetch", "--depth", "1", "origin", fetchRef], cacheDir);
+				await git(["fetch", "--depth", "1", "origin", "--", fetchRef], cacheDir);
 				await git(["reset", "--hard", "FETCH_HEAD"], cacheDir);
 				await git(["clean", "-fdx"], cacheDir);
 			}

--- a/src/server/marketplace/sync-service.ts
+++ b/src/server/marketplace/sync-service.ts
@@ -11,7 +11,7 @@ import { execFile as execFileCb } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
-import { stripTokenFromGitUrl } from "../skills/git.js";
+import { redactGitUrlInText } from "./git-url-redact.js";
 import { validateGitRef, validateGitUrl } from "./source-registry.js";
 import type { SourceRecord } from "./types.js";
 
@@ -73,8 +73,10 @@ export class GitSourceBackend implements SourceBackend {
 			const commit = (await git(["rev-parse", "HEAD"], cacheDir)).trim();
 			return { root: cacheDir, commit: commit || null, contentHash: null, error: null };
 		} catch (err) {
-			// Surface a token-stripped message; leave any previous good cache intact.
-			const msg = (err as Error).message.split(url).join(stripTokenFromGitUrl(url));
+			// Surface a fully-redacted message: the url is redacted AND its secret
+			// substrings (userinfo + ?token=/#token= values) are scrubbed wherever git
+			// reformatted them, so no credential can leak into lastSyncError.
+			const msg = redactGitUrlInText((err as Error).message, url);
 			return { root: cacheDir, commit: null, contentHash: null, error: msg };
 		}
 	}

--- a/src/server/marketplace/types.ts
+++ b/src/server/marketplace/types.ts
@@ -12,6 +12,13 @@ export type SourceKind = "git" | "local";
 export type InstallScope = "system" | "project";
 export type EntityType = "role" | "tool" | "skill";
 export type ConflictMode = "fail" | "overwrite" | "skip";
+/**
+ * How a pack was installed, recorded in provenance so update() can apply the
+ * right semantics: `pack` = whole pack (update adds newly-declared entities,
+ * refreshes existing, removes dropped); `subset` = explicit entity subset
+ * (update refreshes only tracked entities, never auto-adds new ones).
+ */
+export type InstallMode = "pack" | "subset";
 
 /** A configured marketplace source (git repo or local dir). Persisted in sources.json (§3.2). */
 export interface SourceRecord {
@@ -105,6 +112,8 @@ export interface ProvenanceRecord {
 	sourceCommit: string | null;
 	sourceContentHash: string | null;
 	installedAt: number;
+	/** whole-pack vs subset install — drives update() semantics (§6). */
+	installMode: InstallMode;
 	entities: InstalledEntity[];
 }
 

--- a/src/server/marketplace/types.ts
+++ b/src/server/marketplace/types.ts
@@ -95,6 +95,12 @@ export interface InstalledEntity {
 	name: string;
 	/** exact paths install wrote — uninstall removes exactly these. */
 	installedPaths: string[];
+	/**
+	 * Content hash of the bytes install wrote (recorded at install/update). Lets
+	 * computeInstallStatus detect local *edits* as drift, not just missing files.
+	 * Absent on legacy records → drift detection falls back to existence-only.
+	 */
+	contentHash?: string;
 	/** project-scope skills only: the custom dir registered in config_directories. */
 	customDirRegistered?: string;
 }

--- a/src/server/marketplace/types.ts
+++ b/src/server/marketplace/types.ts
@@ -1,0 +1,151 @@
+/**
+ * Marketplace MVP — shared types.
+ *
+ * See docs/design/marketplace-mvp.md for the authoritative design. These
+ * types model the source registry (§3), pack manifests/scan output (§2, §5),
+ * the install pipeline (§6), and provenance (§7).
+ */
+
+import type { ProjectConfigWriter } from "../agent/config-directories.js";
+
+export type SourceKind = "git" | "local";
+export type InstallScope = "system" | "project";
+export type EntityType = "role" | "tool" | "skill";
+export type ConflictMode = "fail" | "overwrite" | "skip";
+
+/** A configured marketplace source (git repo or local dir). Persisted in sources.json (§3.2). */
+export interface SourceRecord {
+	id: string;
+	kind: SourceKind;
+	/** git sources only — token-stripped on read/surface. */
+	url: string | null;
+	/** OPTIONAL git ref/branch/tag; null = remote HEAD. */
+	ref: string | null;
+	/** local sources only — absolute dir path. */
+	path: string | null;
+	/** OPTIONAL display label; defaults to repo/dir basename. */
+	label: string | null;
+	addedAt: number;
+	/** null until first successful sync. */
+	lastSyncedAt: number | null;
+	/** git sources: HEAD SHA after last sync; null for local. */
+	lastSyncCommit: string | null;
+	/** string when the last sync failed, else null. */
+	lastSyncError: string | null;
+}
+
+/** Parsed pack.yaml manifest (§2.2). Unknown keys preserved for forward-compat. */
+export interface PackManifest {
+	apiVersion: number;
+	id: string;
+	name: string;
+	description: string;
+	version: string;
+	author?: string;
+	homepage?: string;
+	license?: string;
+	minBobbit?: string;
+	contents: PackContents;
+	/** Unknown top-level keys preserved verbatim. */
+	[key: string]: unknown;
+}
+
+export interface PackContents {
+	roles?: string[];
+	tools?: string[];
+	skills?: string[];
+	/** Unknown contents keys (e.g. a future `panels`) preserved verbatim. */
+	[key: string]: string[] | undefined;
+}
+
+/** A single entity declared by a pack and resolved on disk. */
+export interface ScannedEntity {
+	type: EntityType;
+	/** role/skill name, or tool GROUP name. */
+	name: string;
+	/** absolute source path of the payload (file for role, dir for tool group / skill). */
+	sourcePath: string;
+}
+
+/** A pack discovered in a synced source root (§5.1). */
+export interface ScannedPack {
+	sourceId: string;
+	packId: string;
+	/** absolute pack dir within the sync root. */
+	dir: string;
+	/** parsed pack.yaml; null when parsing failed. */
+	manifest: PackManifest | null;
+	entities: ScannedEntity[];
+	/** any tool entity → drives the "executable code" warning (§9). */
+	hasTools: boolean;
+	valid: boolean;
+	error?: string;
+}
+
+/** A single entity that install actually wrote (provenance leaf). */
+export interface InstalledEntity {
+	type: EntityType;
+	name: string;
+	/** exact paths install wrote — uninstall removes exactly these. */
+	installedPaths: string[];
+	/** project-scope skills only: the custom dir registered in config_directories. */
+	customDirRegistered?: string;
+}
+
+/** Provenance record — one per (scope, projectId, sourceId, packId) (§7.1). */
+export interface ProvenanceRecord {
+	scope: InstallScope;
+	projectId: string | null;
+	sourceId: string;
+	packId: string;
+	packName: string;
+	packVersion: string;
+	sourceKind: SourceKind;
+	sourceUrl: string | null;
+	sourceCommit: string | null;
+	sourceContentHash: string | null;
+	installedAt: number;
+	entities: InstalledEntity[];
+}
+
+/**
+ * Resolved install context for a (scope, projectId) pair. The install engine
+ * and entity handlers derive every destination path from this — no module
+ * reaches for server singletons directly, which keeps the pipeline testable
+ * against temp dirs.
+ */
+export interface InstallCtx {
+	scope: InstallScope;
+	projectId: string | null;
+	/** scope config root — roles/, tools/, marketplace/ live here. */
+	configDir: string;
+	/** where skill dirs are copied (project: <configDir>/skills; system: ~/.bobbit/skills). */
+	skillInstallDir: string;
+	/** project scope only — used to (de)register the custom skills dir in config_directories. */
+	projectConfigStore?: ProjectConfigWriter;
+	/** invalidate tool scan caches after a tool write/remove. */
+	invalidateTools?: () => void;
+	/** reload role stores after a role write/remove. */
+	invalidateRoles?: () => void;
+}
+
+export interface EntityRef {
+	type: EntityType;
+	name: string;
+}
+
+export interface InstallEntityResult {
+	type: EntityType;
+	name: string;
+	status: "installed" | "skipped" | "conflict";
+	installedPaths?: string[];
+}
+
+export interface InstallOutcome {
+	record: ProvenanceRecord | null;
+	results: InstallEntityResult[];
+	/** entities skipped due to conflict (skip mode). */
+	skipped: EntityRef[];
+}
+
+export type InstallStatus = "not-installed" | "installed" | "update-available" | "drifted";

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4536,7 +4536,7 @@ async function handleApiRoute(
 		const packId = decodeURIComponent(marketPackMatch[2]);
 		const scope = parseMarketScope(url.searchParams.get("scope"));
 		const projectId = url.searchParams.get("projectId") || null;
-		const result = marketplace.getPack(sourceId, packId, scope, scope === "project" ? projectId : null);
+		const result = marketplace.getPackDetail(sourceId, packId, scope, scope === "project" ? projectId : null);
 		if (!result) { json({ error: "Pack not found" }, 404); return; }
 		json(result);
 		return;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -27,7 +27,9 @@ import { shouldCreateWorktree } from "./agent/worktree-decision.js";
 import { resolveWorktreeSupport } from "./agent/worktree-support.js";
 import { RoleStore } from "./agent/role-store.js";
 import { RoleManager } from "./agent/role-manager.js";
-import { ToolManager, copyDirRecursive } from "./agent/tool-manager.js";
+import { ToolManager, copyDirRecursive, __resetToolScanCache } from "./agent/tool-manager.js";
+import { MarketplaceService, ConflictError as MarketplaceConflictError } from "./marketplace/service.js";
+import type { ConflictMode, EntityRef, InstallScope } from "./marketplace/types.js";
 import { buildGateStatusSummary } from "./gate-status-summary.js";
 import { buildGateVerificationSnapshot } from "./gate-verification-snapshot.js";
 import {
@@ -876,6 +878,27 @@ export function createGateway(config: GatewayConfig) {
 	}, projectContextManager);
 	sessionManager.configCascade = configCascade;
 
+	// Marketplace MVP — source registry + sync + install engine. Server-global
+	// sources live under <stateDir>/marketplace; installs land in the exact
+	// dirs ConfigCascade / skill discovery already read. See
+	// docs/design/marketplace-mvp.md.
+	const marketplaceService = new MarketplaceService({
+		stateDir,
+		systemConfigDir: configDir,
+		resolveProject: (projectId: string) => {
+			const ctx = projectContextManager.getOrCreate(projectId);
+			if (!ctx) return null;
+			return {
+				configDir: ctx.configDir,
+				projectConfigStore: ctx.projectConfigStore,
+				invalidateTools: () => __resetToolScanCache(),
+				invalidateRoles: () => ctx.roleStore.reload(),
+			};
+		},
+		invalidateSystemTools: () => __resetToolScanCache(),
+		invalidateSystemRoles: () => roleStore.reload(),
+	});
+
 	const staffManager = new StaffManager(projectContextManager);
 
 	// Inbox plumbing: trigger fires now enqueue entries on `inboxManager`,
@@ -1065,7 +1088,7 @@ export function createGateway(config: GatewayConfig) {
 			// Enable via BOBBIT_TIMING_LOG=1 to print "[timing] METHOD path ms" for each API call.
 			const _timingEnabled = process.env.BOBBIT_TIMING_LOG === "1";
 			const _timingStart = _timingEnabled ? performance.now() : 0;
-			await handleApiRoute(url, req, res, sessionManager, config, colorStore, prStatusStore, teamManager, roleManager, toolManager, projectContextManager, bgProcessManager, staffManager, verificationHarness, preferencesStore, projectConfigStore, groupPolicyStore, broadcastToGoal, broadcastToAll, sandboxManager, projectRegistry, configCascade, sandboxScope, sandboxTokenStore, reviewAnnotationStore, broadcastToSession, roleStore, inboxManager, prWalkthroughAgentManager);
+			await handleApiRoute(url, req, res, sessionManager, config, colorStore, prStatusStore, teamManager, roleManager, toolManager, projectContextManager, bgProcessManager, staffManager, verificationHarness, preferencesStore, projectConfigStore, groupPolicyStore, broadcastToGoal, broadcastToAll, sandboxManager, projectRegistry, configCascade, sandboxScope, sandboxTokenStore, reviewAnnotationStore, broadcastToSession, roleStore, inboxManager, prWalkthroughAgentManager, marketplaceService);
 			if (_timingEnabled) {
 				const dur = performance.now() - _timingStart;
 				if (dur >= 100) console.log(`[timing] ${req.method} ${url.pathname}${url.search} ${dur.toFixed(1)}ms`);
@@ -2056,10 +2079,12 @@ async function handleApiRoute(
 	roleStore?: RoleStore,
 	inboxManager?: InboxManager,
 	prWalkthroughAgentManager?: WalkthroughAgentManager,
+	marketplaceService?: MarketplaceService,
 ) {
 	// These are always wired by the sole caller; the optional markers are only to avoid
 	// touching every existing signature site.
 	const serverRoleStore = roleStore!;
+	const marketplace = marketplaceService!;
 	const json = (data: unknown, status = 200) => {
 		res.writeHead(status, { "Content-Type": "application/json" });
 		res.end(JSON.stringify(data));
@@ -4437,6 +4462,138 @@ async function handleApiRoute(
 			}
 		} catch { /* dir doesn't exist */ }
 		return null;
+	}
+
+	// ── Marketplace (Extension Packs) ──
+	// See docs/design/marketplace-mvp.md. Source registry is server-global;
+	// install scope is system|project, landing in the exact dirs the cascade
+	// and skill discovery already read.
+
+	const parseMarketScope = (raw: unknown): InstallScope => (raw === "project" ? "project" : "system");
+
+	// GET /api/marketplace/sources
+	if (url.pathname === "/api/marketplace/sources" && req.method === "GET") {
+		json({ sources: marketplace.listSources() });
+		return;
+	}
+
+	// POST /api/marketplace/sources
+	if (url.pathname === "/api/marketplace/sources" && req.method === "POST") {
+		const body = await readBody(req);
+		if (!body) { json({ error: "Missing body" }, 400); return; }
+		let record;
+		try {
+			record = marketplace.addSource({ kind: body.kind, url: body.url, ref: body.ref, path: body.path, label: body.label });
+		} catch (err) {
+			json({ error: (err as Error).message }, 400);
+			return;
+		}
+		// Kick a first sync asynchronously; the record is already persisted.
+		marketplace.syncSource(record.id).catch((err) => console.warn(`[marketplace] initial sync failed for ${record.id}: ${err}`));
+		json({ source: record }, 201);
+		return;
+	}
+
+	// DELETE /api/marketplace/sources/:id
+	const marketSourceMatch = url.pathname.match(/^\/api\/marketplace\/sources\/([^/]+)$/);
+	if (marketSourceMatch && req.method === "DELETE") {
+		const id = decodeURIComponent(marketSourceMatch[1]);
+		try {
+			marketplace.removeSource(id);
+		} catch (err) {
+			json({ error: (err as Error).message }, 404);
+			return;
+		}
+		json({ ok: true });
+		return;
+	}
+
+	// POST /api/marketplace/sources/:id/sync
+	const marketSyncMatch = url.pathname.match(/^\/api\/marketplace\/sources\/([^/]+)\/sync$/);
+	if (marketSyncMatch && req.method === "POST") {
+		const id = decodeURIComponent(marketSyncMatch[1]);
+		try {
+			const source = await marketplace.syncSource(id);
+			json({ source });
+		} catch (err) {
+			json({ error: (err as Error).message }, 404);
+		}
+		return;
+	}
+
+	// GET /api/marketplace/packs?scope=&projectId=
+	if (url.pathname === "/api/marketplace/packs" && req.method === "GET") {
+		const scope = parseMarketScope(url.searchParams.get("scope"));
+		const projectId = url.searchParams.get("projectId") || null;
+		json({ packs: marketplace.listPacks(scope, scope === "project" ? projectId : null) });
+		return;
+	}
+
+	// GET /api/marketplace/packs/:sourceId/:packId?scope=&projectId=
+	const marketPackMatch = url.pathname.match(/^\/api\/marketplace\/packs\/([^/]+)\/([^/]+)$/);
+	if (marketPackMatch && req.method === "GET") {
+		const sourceId = decodeURIComponent(marketPackMatch[1]);
+		const packId = decodeURIComponent(marketPackMatch[2]);
+		const scope = parseMarketScope(url.searchParams.get("scope"));
+		const projectId = url.searchParams.get("projectId") || null;
+		const result = marketplace.getPack(sourceId, packId, scope, scope === "project" ? projectId : null);
+		if (!result) { json({ error: "Pack not found" }, 404); return; }
+		json(result);
+		return;
+	}
+
+	// POST /api/marketplace/install
+	if (url.pathname === "/api/marketplace/install" && req.method === "POST") {
+		const body = await readBody(req);
+		if (!body || !body.sourceId || !body.packId) { json({ error: "Missing sourceId/packId" }, 400); return; }
+		const scope = parseMarketScope(body.scope);
+		const projectId = scope === "project" ? (body.projectId || null) : null;
+		if (scope === "project" && !projectId) { json({ error: "project scope requires projectId" }, 400); return; }
+		const entities: EntityRef[] | null = Array.isArray(body.entities) ? body.entities : null;
+		const conflict: ConflictMode = ["fail", "overwrite", "skip"].includes(body.conflict) ? body.conflict : "fail";
+		try {
+			const outcome = marketplace.installPack({ sourceId: body.sourceId, packId: body.packId, scope, projectId, entities, conflict });
+			json(outcome, 201);
+		} catch (err) {
+			if (err instanceof MarketplaceConflictError) {
+				json({ error: err.message, conflicts: err.conflicts }, 409);
+				return;
+			}
+			json({ error: (err as Error).message }, 400);
+		}
+		return;
+	}
+
+	// POST /api/marketplace/update
+	if (url.pathname === "/api/marketplace/update" && req.method === "POST") {
+		const body = await readBody(req);
+		if (!body || !body.sourceId || !body.packId) { json({ error: "Missing sourceId/packId" }, 400); return; }
+		const scope = parseMarketScope(body.scope);
+		const projectId = scope === "project" ? (body.projectId || null) : null;
+		if (scope === "project" && !projectId) { json({ error: "project scope requires projectId" }, 400); return; }
+		try {
+			const outcome = await marketplace.updatePack({ sourceId: body.sourceId, packId: body.packId, scope, projectId });
+			json(outcome);
+		} catch (err) {
+			json({ error: (err as Error).message }, 400);
+		}
+		return;
+	}
+
+	// POST /api/marketplace/uninstall
+	if (url.pathname === "/api/marketplace/uninstall" && req.method === "POST") {
+		const body = await readBody(req);
+		if (!body || !body.sourceId || !body.packId) { json({ error: "Missing sourceId/packId" }, 400); return; }
+		const scope = parseMarketScope(body.scope);
+		const projectId = scope === "project" ? (body.projectId || null) : null;
+		if (scope === "project" && !projectId) { json({ error: "project scope requires projectId" }, 400); return; }
+		try {
+			const result = marketplace.uninstallPack({ sourceId: body.sourceId, packId: body.packId, scope, projectId });
+			json(result);
+		} catch (err) {
+			json({ error: (err as Error).message }, 400);
+		}
+		return;
 	}
 
 	// POST /api/tools/:name/customize — copy tool group to a target scope

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -28,8 +28,8 @@ import { resolveWorktreeSupport } from "./agent/worktree-support.js";
 import { RoleStore } from "./agent/role-store.js";
 import { RoleManager } from "./agent/role-manager.js";
 import { ToolManager, copyDirRecursive, __resetToolScanCache } from "./agent/tool-manager.js";
-import { MarketplaceService, ConflictError as MarketplaceConflictError } from "./marketplace/service.js";
-import type { ConflictMode, EntityRef, InstallScope, SourceRecord } from "./marketplace/types.js";
+import { MarketplaceService, ConflictError as MarketplaceConflictError, parseInstallScope } from "./marketplace/service.js";
+import type { ConflictMode, EntityRef, SourceRecord } from "./marketplace/types.js";
 import { buildGateStatusSummary } from "./gate-status-summary.js";
 import { buildGateVerificationSnapshot } from "./gate-verification-snapshot.js";
 import {
@@ -4469,7 +4469,10 @@ async function handleApiRoute(
 	// install scope is system|project, landing in the exact dirs the cascade
 	// and skill discovery already read.
 
-	const parseMarketScope = (raw: unknown): InstallScope => (raw === "project" ? "project" : "system");
+	// Validate the install scope + projectId from a request via the shared
+	// `parseInstallScope` helper (unit-tested): only system|project, project
+	// requires projectId, a misspelled scope is a 400.
+	const resolveMarketScope = parseInstallScope;
 
 	// GET /api/marketplace/sources
 	if (url.pathname === "/api/marketplace/sources" && req.method === "GET") {
@@ -4534,9 +4537,9 @@ async function handleApiRoute(
 
 	// GET /api/marketplace/packs?scope=&projectId=
 	if (url.pathname === "/api/marketplace/packs" && req.method === "GET") {
-		const scope = parseMarketScope(url.searchParams.get("scope"));
-		const projectId = url.searchParams.get("projectId") || null;
-		json({ packs: marketplace.listPacks(scope, scope === "project" ? projectId : null) });
+		const parsed = resolveMarketScope(url.searchParams.get("scope"), url.searchParams.get("projectId"));
+		if ("error" in parsed) { json({ error: parsed.error }, 400); return; }
+		json({ packs: marketplace.listPacks(parsed.scope, parsed.projectId) });
 		return;
 	}
 
@@ -4545,9 +4548,9 @@ async function handleApiRoute(
 	if (marketPackMatch && req.method === "GET") {
 		const sourceId = decodeURIComponent(marketPackMatch[1]);
 		const packId = decodeURIComponent(marketPackMatch[2]);
-		const scope = parseMarketScope(url.searchParams.get("scope"));
-		const projectId = url.searchParams.get("projectId") || null;
-		const result = marketplace.getPackDetail(sourceId, packId, scope, scope === "project" ? projectId : null);
+		const parsed = resolveMarketScope(url.searchParams.get("scope"), url.searchParams.get("projectId"));
+		if ("error" in parsed) { json({ error: parsed.error }, 400); return; }
+		const result = marketplace.getPackDetail(sourceId, packId, parsed.scope, parsed.projectId);
 		if (!result) { json({ error: "Pack not found" }, 404); return; }
 		json(result);
 		return;
@@ -4557,9 +4560,9 @@ async function handleApiRoute(
 	if (url.pathname === "/api/marketplace/install" && req.method === "POST") {
 		const body = await readBody(req);
 		if (!body || !body.sourceId || !body.packId) { json({ error: "Missing sourceId/packId" }, 400); return; }
-		const scope = parseMarketScope(body.scope);
-		const projectId = scope === "project" ? (body.projectId || null) : null;
-		if (scope === "project" && !projectId) { json({ error: "project scope requires projectId" }, 400); return; }
+		const parsed = resolveMarketScope(body.scope, body.projectId);
+		if ("error" in parsed) { json({ error: parsed.error }, 400); return; }
+		const { scope, projectId } = parsed;
 		const entities: EntityRef[] | null = Array.isArray(body.entities) ? body.entities : null;
 		const conflict: ConflictMode = ["fail", "overwrite", "skip"].includes(body.conflict) ? body.conflict : "fail";
 		try {
@@ -4579,9 +4582,9 @@ async function handleApiRoute(
 	if (url.pathname === "/api/marketplace/update" && req.method === "POST") {
 		const body = await readBody(req);
 		if (!body || !body.sourceId || !body.packId) { json({ error: "Missing sourceId/packId" }, 400); return; }
-		const scope = parseMarketScope(body.scope);
-		const projectId = scope === "project" ? (body.projectId || null) : null;
-		if (scope === "project" && !projectId) { json({ error: "project scope requires projectId" }, 400); return; }
+		const parsed = resolveMarketScope(body.scope, body.projectId);
+		if ("error" in parsed) { json({ error: parsed.error }, 400); return; }
+		const { scope, projectId } = parsed;
 		try {
 			const outcome = await marketplace.updatePack({ sourceId: body.sourceId, packId: body.packId, scope, projectId });
 			json(outcome);
@@ -4595,9 +4598,9 @@ async function handleApiRoute(
 	if (url.pathname === "/api/marketplace/uninstall" && req.method === "POST") {
 		const body = await readBody(req);
 		if (!body || !body.sourceId || !body.packId) { json({ error: "Missing sourceId/packId" }, 400); return; }
-		const scope = parseMarketScope(body.scope);
-		const projectId = scope === "project" ? (body.projectId || null) : null;
-		if (scope === "project" && !projectId) { json({ error: "project scope requires projectId" }, 400); return; }
+		const parsed = resolveMarketScope(body.scope, body.projectId);
+		if ("error" in parsed) { json({ error: parsed.error }, 400); return; }
+		const { scope, projectId } = parsed;
 		try {
 			const result = marketplace.uninstallPack({ sourceId: body.sourceId, packId: body.packId, scope, projectId });
 			json(result);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -29,7 +29,7 @@ import { RoleStore } from "./agent/role-store.js";
 import { RoleManager } from "./agent/role-manager.js";
 import { ToolManager, copyDirRecursive, __resetToolScanCache } from "./agent/tool-manager.js";
 import { MarketplaceService, ConflictError as MarketplaceConflictError } from "./marketplace/service.js";
-import type { ConflictMode, EntityRef, InstallScope } from "./marketplace/types.js";
+import type { ConflictMode, EntityRef, InstallScope, SourceRecord } from "./marketplace/types.js";
 import { buildGateStatusSummary } from "./gate-status-summary.js";
 import { buildGateVerificationSnapshot } from "./gate-verification-snapshot.js";
 import {
@@ -4481,15 +4481,26 @@ async function handleApiRoute(
 	if (url.pathname === "/api/marketplace/sources" && req.method === "POST") {
 		const body = await readBody(req);
 		if (!body) { json({ error: "Missing body" }, 400); return; }
-		let record;
+		let record: SourceRecord;
 		try {
 			record = marketplace.addSource({ kind: body.kind, url: body.url, ref: body.ref, path: body.path, label: body.label });
 		} catch (err) {
 			json({ error: (err as Error).message }, 400);
 			return;
 		}
-		// Kick a first sync asynchronously; the record is already persisted.
-		marketplace.syncSource(record.id).catch((err) => console.warn(`[marketplace] initial sync failed for ${record.id}: ${err}`));
+		// Initial sync. For git sources AWAIT it so the first packs reload reflects
+		// real cache state (populated lastSyncedAt/lastSyncCommit/lastSyncError) and
+		// sync errors surface immediately rather than later. Local sources are read
+		// in place, so their (cheap, validating) sync can stay fire-and-forget.
+		if (record.kind === "git") {
+			try {
+				record = await marketplace.syncSource(record.id);
+			} catch (err) {
+				console.warn(`[marketplace] initial sync failed for ${record.id}: ${err}`);
+			}
+		} else {
+			marketplace.syncSource(record.id).catch((err) => console.warn(`[marketplace] initial sync failed for ${record.id}: ${err}`));
+		}
 		json({ source: record }, 201);
 		return;
 	}

--- a/tests/e2e/ui/marketplace.spec.ts
+++ b/tests/e2e/ui/marketplace.spec.ts
@@ -1,0 +1,215 @@
+/**
+ * Marketplace MVP — mandatory browser E2E.
+ *
+ * Drives the full user-facing flow described in docs/design/marketplace-mvp.md
+ * §11 and the goal's acceptance criteria, end to end through the real UI:
+ *
+ *   1. The "Market" sidebar button is present BETWEEN "Workflows" and
+ *      "New Goal" and opens the marketplace surface.
+ *   2. Add a local source pointing at the committed fixture source tree
+ *      tests/fixtures/marketplace/source-a/.
+ *   3. Browse the packs it contains — the tool-bearing pack shows the
+ *      "executable code" badge, and the broken pack surfaces its error.
+ *   4. Install the tool-bearing pack at PROJECT scope; the "installs
+ *      executable code" confirmation gate must appear before the install runs.
+ *   5. The pack's role then resolves on the Roles page with a "project"
+ *      origin badge — i.e. it flows through ConfigCascade exactly like a
+ *      hand-authored role.
+ *   6. The install persists across a full page reload.
+ *   7. Uninstalling the pack removes exactly what it installed — the role
+ *      disappears from the Roles page again.
+ *
+ * Canonical pattern: tests/e2e/ui/workflow-page-scope.spec.ts
+ *                    tests/e2e/ui/settings.spec.ts
+ *
+ * The server-side pack scanner / install engine are covered by unit tests
+ * against the same fixture tree (tests/marketplace-*.test.ts); this spec
+ * proves the wired-up UI path the user actually walks.
+ */
+import { test, expect } from "../gateway-harness.js";
+import { apiFetch, defaultProject } from "../e2e-setup.js";
+import { openApp, navigateToHash } from "./ui-helpers.js";
+import type { Page, Locator } from "@playwright/test";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Committed fixture source tree (also exercised by the marketplace unit tests).
+// Absolute path is required: local sources must be absolute + existing dirs.
+const SOURCE_A = join(__dirname, "..", "..", "fixtures", "marketplace", "source-a");
+
+// The mini-lit Dialog modal — both confirmAction() and the add-source dialog
+// render into this container. Scoping button clicks to it disambiguates the
+// dialog's own action button from same-labelled buttons on the page behind it.
+const DIALOG = '[class*="shadow-xl"]';
+
+const RESEARCH_CARD = '[data-testid="market-pack-card"][data-pack-id="research-pack"]';
+const INVALID_CARD = '[data-testid="market-pack-card"][data-pack-id="invalid-pack"]';
+
+/** Click a config-scope tab (System / a project name) inside a config page. */
+async function selectScopeTab(page: Page, containerSelector: string, tabName: string): Promise<void> {
+	await page
+		.locator(containerSelector)
+		.getByRole("button", { name: tabName, exact: true })
+		.first()
+		.click();
+}
+
+/** The install-status badge for a pack card (data-status drives the assertion). */
+function statusBadge(card: Locator): Locator {
+	return card.locator('[data-testid="market-install-status"]');
+}
+
+test.describe("Marketplace MVP", () => {
+	let projectName: string;
+	let projectId: string;
+
+	// The gateway is worker-scoped, so the source registry + any installed
+	// provenance persist across test runs (and across Playwright retries).
+	// Reset to a clean slate before each run so the test is idempotent: drop
+	// every configured source and uninstall research-pack at project scope.
+	async function resetMarketplace(): Promise<void> {
+		try {
+			const res = await apiFetch("/api/marketplace/sources");
+			if (!res.ok) return;
+			const { sources } = await res.json();
+			for (const s of sources ?? []) {
+				await apiFetch("/api/marketplace/uninstall", {
+					method: "POST",
+					body: JSON.stringify({ sourceId: s.id, packId: "research-pack", scope: "project", projectId }),
+				}).catch(() => {});
+				await apiFetch(`/api/marketplace/sources/${encodeURIComponent(s.id)}`, { method: "DELETE" }).catch(() => {});
+			}
+		} catch { /* best-effort */ }
+	}
+
+	test.beforeAll(async () => {
+		const proj = await defaultProject();
+		projectName = proj.name || "default";
+		projectId = proj.id;
+	});
+
+	test.beforeEach(async () => {
+		await resetMarketplace();
+	});
+
+	test.afterAll(async () => {
+		await resetMarketplace();
+	});
+
+	test("Market button → add source → browse → install at project scope → role resolves → persists → uninstall @smoke", async ({ page }) => {
+		await openApp(page);
+
+		// ── 1. Sidebar Market button: present and ordered between Workflows and New Goal ──
+		const marketBtn = page.locator('[data-testid="sidebar-market-button"]');
+		await expect(marketBtn).toBeVisible({ timeout: 15_000 });
+
+		const order = await page.evaluate(() => {
+			const buttons = Array.from(document.querySelectorAll("button"));
+			const workflows = buttons.find((b) => b.title === "Manage workflows") || null;
+			const market = document.querySelector('[data-testid="sidebar-market-button"]');
+			const newGoal = document.querySelector("[data-new-goal-trigger]");
+			if (!workflows || !market || !newGoal) return null;
+			const FOLLOWING = Node.DOCUMENT_POSITION_FOLLOWING;
+			return {
+				workflowsBeforeMarket: !!(workflows.compareDocumentPosition(market) & FOLLOWING),
+				marketBeforeNewGoal: !!(market.compareDocumentPosition(newGoal) & FOLLOWING),
+			};
+		});
+		expect(order).toEqual({ workflowsBeforeMarket: true, marketBeforeNewGoal: true });
+
+		// Opening the marketplace surface.
+		await marketBtn.click();
+		await expect(page.locator(".market-container")).toBeVisible({ timeout: 10_000 });
+		await expect(page.locator(".market-title").first()).toHaveText("Market");
+
+		// ── 2. Add a local source pointing at the fixture tree ──
+		await page.locator('[data-testid="market-add-source"]').click();
+		await expect(page.locator('[data-testid="market-source-dialog"]')).toBeVisible({ timeout: 10_000 });
+		await page.locator('[data-testid="market-kind-local"]').click();
+		const pathInput = page.locator('[data-testid="market-source-path"]');
+		await expect(pathInput).toBeVisible();
+		await pathInput.fill(SOURCE_A);
+		await page.locator(DIALOG).getByRole("button", { name: "Add source", exact: true }).click();
+		await expect(page.locator('[data-testid="market-source-dialog"]')).toHaveCount(0, { timeout: 10_000 });
+
+		// Source row appears.
+		await expect(page.locator('[data-testid="market-source-row"]')).toHaveCount(1, { timeout: 10_000 });
+
+		// ── 3. Browse packs: exec-code badge + invalid-pack error ──
+		const researchCard = page.locator(RESEARCH_CARD);
+		await expect(researchCard).toBeVisible({ timeout: 10_000 });
+		// research-pack ships a tool → executable-code badge present.
+		await expect(researchCard.locator('[data-testid="market-exec-code-badge"]')).toBeVisible();
+
+		// invalid-pack declares a role that does not exist on disk → flagged, not installable.
+		const invalidCard = page.locator(INVALID_CARD);
+		await expect(invalidCard).toBeVisible();
+		await expect(invalidCard).toHaveAttribute("data-valid", "false");
+		await expect(invalidCard.locator('[data-testid="market-pack-invalid"]')).toBeVisible();
+		await expect(invalidCard.locator('[data-testid="market-pack-error"]')).toContainText("missing-role");
+
+		// ── 4. Install research-pack at PROJECT scope (confirm the exec-code warning) ──
+		await selectScopeTab(page, ".market-container", projectName);
+		// Wait for the project-scope re-render to settle (card re-rendered, not installed yet).
+		await expect(researchCard).toBeVisible({ timeout: 10_000 });
+		await expect(statusBadge(researchCard)).toHaveAttribute("data-status", "not-installed", { timeout: 10_000 });
+
+		await researchCard.locator('[data-testid="market-install-btn"]').click();
+
+		// The "installs executable code" confirmation gate must appear first.
+		const confirmDialog = page.locator(DIALOG).filter({ hasText: "Install executable code" });
+		await expect(confirmDialog).toBeVisible({ timeout: 10_000 });
+		await expect(confirmDialog).toContainText("installs executable code");
+		await confirmDialog.getByRole("button", { name: "Install", exact: true }).click();
+
+		// Pack reports installed.
+		await expect(statusBadge(researchCard)).toHaveAttribute("data-status", "installed", { timeout: 15_000 });
+
+		// ── 5. The pack's role resolves on the Roles page with a project origin ──
+		await navigateToHash(page, "#/roles");
+		await expect(page.locator(".roles-container")).toBeVisible({ timeout: 10_000 });
+		await selectScopeTab(page, ".roles-container", projectName);
+
+		const researcherRow = page.locator(".role-row").filter({ hasText: "researcher" });
+		await expect(researcherRow).toHaveCount(1, { timeout: 10_000 });
+		await expect(researcherRow.locator(".config-origin-badge")).toHaveText("project");
+
+		// ── 6. Persists across a full page reload ──
+		await page.reload();
+		await expect(page.locator("button").filter({ hasText: "Settings" }).first()).toBeVisible({ timeout: 20_000 });
+
+		// Install + provenance survived: pack still shows installed at project scope.
+		await navigateToHash(page, "#/market");
+		await expect(page.locator(".market-container")).toBeVisible({ timeout: 10_000 });
+		await selectScopeTab(page, ".market-container", projectName);
+		const researchCardAfter = page.locator(RESEARCH_CARD);
+		await expect(statusBadge(researchCardAfter)).toHaveAttribute("data-status", "installed", { timeout: 15_000 });
+
+		// Role still resolves at project scope after reload.
+		await navigateToHash(page, "#/roles");
+		await expect(page.locator(".roles-container")).toBeVisible({ timeout: 10_000 });
+		await selectScopeTab(page, ".roles-container", projectName);
+		await expect(page.locator(".role-row").filter({ hasText: "researcher" })).toHaveCount(1, { timeout: 10_000 });
+
+		// ── 7. Uninstall removes exactly what it installed ──
+		await navigateToHash(page, "#/market");
+		await expect(page.locator(".market-container")).toBeVisible({ timeout: 10_000 });
+		await selectScopeTab(page, ".market-container", projectName);
+		await expect(statusBadge(researchCardAfter)).toHaveAttribute("data-status", "installed", { timeout: 10_000 });
+
+		await researchCardAfter.locator('[data-testid="market-uninstall-btn"]').click();
+		const uninstallDialog = page.locator(DIALOG).filter({ hasText: "Uninstall pack" });
+		await expect(uninstallDialog).toBeVisible({ timeout: 10_000 });
+		await uninstallDialog.getByRole("button", { name: "Uninstall", exact: true }).click();
+
+		// Pack returns to not-installed.
+		await expect(statusBadge(researchCardAfter)).toHaveAttribute("data-status", "not-installed", { timeout: 15_000 });
+
+		// Role is gone from the Roles page at project scope.
+		await navigateToHash(page, "#/roles");
+		await expect(page.locator(".roles-container")).toBeVisible({ timeout: 10_000 });
+		await selectScopeTab(page, ".roles-container", projectName);
+		await expect(page.locator(".role-row").filter({ hasText: "researcher" })).toHaveCount(0, { timeout: 10_000 });
+	});
+});

--- a/tests/e2e/ui/marketplace.spec.ts
+++ b/tests/e2e/ui/marketplace.spec.ts
@@ -192,6 +192,42 @@ test.describe("Marketplace MVP", () => {
 		await selectScopeTab(page, ".roles-container", projectName);
 		await expect(page.locator(".role-row").filter({ hasText: "researcher" })).toHaveCount(1, { timeout: 10_000 });
 
+		// ── 6b. Pack drill-down: open the pack card → detail route renders the
+		//        flat manifest meta + per-entity rows with install controls ──
+		await navigateToHash(page, "#/market");
+		await expect(page.locator(".market-container")).toBeVisible({ timeout: 10_000 });
+		await selectScopeTab(page, ".market-container", projectName);
+		const researchCardDrill = page.locator(RESEARCH_CARD);
+		await expect(researchCardDrill).toBeVisible({ timeout: 10_000 });
+
+		// Clicking the card body (not an action button) opens the drill-down.
+		await researchCardDrill.locator(".market-pack-name").click();
+		await expect(page).toHaveURL(/#\/market\/[^/]+\/research-pack$/, { timeout: 10_000 });
+
+		// Manifest meta renders from the flat fields (name / version / description).
+		await expect(page.locator(".market-detail-name")).toHaveText("Research Pack", { timeout: 10_000 });
+		await expect(page.locator(".market-detail .market-pack-version")).toContainText("1.2.0");
+		await expect(page.locator(".market-detail-desc")).toContainText("Research-focused");
+		// research-pack ships a tool → the executable-code notice is shown.
+		await expect(page.locator('[data-testid="market-code-notice"]')).toBeVisible();
+
+		// Per-entity rows render with the declared contents (role / tool / skill).
+		const entityRows = page.locator('[data-testid="market-entity-row"]');
+		await expect(entityRows).toHaveCount(3, { timeout: 10_000 });
+		// The tool entity carries the per-row "code" badge (drives the warning).
+		const toolRow = page.locator('[data-testid="market-entity-row"][data-entity-type="tool"]');
+		await expect(toolRow.locator(".market-code-badge")).toBeVisible();
+		// The pack is installed at project scope, so each entity reports installed
+		// (per-entity `installed` boolean) and exposes no per-entity install button.
+		const researcherRowDetail = page.locator('[data-testid="market-entity-row"][data-entity-name="researcher"]');
+		await expect(researcherRowDetail).toHaveAttribute("data-installed", "true", { timeout: 10_000 });
+		await expect(researcherRowDetail.locator('[data-testid="market-entity-installed"]')).toBeVisible();
+		await expect(researcherRowDetail.locator('[data-testid="market-entity-install"]')).toHaveCount(0);
+
+		// Back to the marketplace list to finish the lifecycle from the cards.
+		await page.locator(".market-breadcrumb").first().click();
+		await expect(page.locator(".market-pack-grid")).toBeVisible({ timeout: 10_000 });
+
 		// ── 7. Uninstall removes exactly what it installed ──
 		await navigateToHash(page, "#/market");
 		await expect(page.locator(".market-container")).toBeVisible({ timeout: 10_000 });

--- a/tests/fixtures/marketplace/source-a/README.md
+++ b/tests/fixtures/marketplace/source-a/README.md
@@ -1,0 +1,8 @@
+# Marketplace fixture source-a
+
+A test marketplace source containing several Extension Packs:
+
+- `research-pack/` — valid; role + tool group + skill (tool ⇒ executable code).
+- `roles-only-pack/` — valid; a single role.
+- `invalid-pack/` — declares a role missing on disk (must surface an error).
+- `not-a-pack/` — no `pack.yaml` (must be ignored by the scanner).

--- a/tests/fixtures/marketplace/source-a/invalid-pack/pack.yaml
+++ b/tests/fixtures/marketplace/source-a/invalid-pack/pack.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+id: invalid-pack
+name: Invalid Pack
+description: Declares a role that does not exist on disk — must surface an error.
+version: 0.0.1
+contents:
+  roles:
+    - missing-role

--- a/tests/fixtures/marketplace/source-a/not-a-pack/README.md
+++ b/tests/fixtures/marketplace/source-a/not-a-pack/README.md
@@ -1,0 +1,3 @@
+# Not a pack
+
+This directory has no `pack.yaml`, so the scanner must ignore it.

--- a/tests/fixtures/marketplace/source-a/notes-pack/pack.yaml
+++ b/tests/fixtures/marketplace/source-a/notes-pack/pack.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+id: notes-pack
+name: Notes Pack
+description: A standalone note-taking skill, used to prove sibling skill packs coexist under one shared skills dir.
+version: 1.0.0
+contents:
+  skills:
+    - note-taker

--- a/tests/fixtures/marketplace/source-a/notes-pack/skills/note-taker/SKILL.md
+++ b/tests/fixtures/marketplace/source-a/notes-pack/skills/note-taker/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: note-taker
+description: Capture and organise notes from a working session.
+argument-hint: <topic>
+---
+
+# Note Taker
+
+Capture structured notes during a working session.
+
+1. Record key decisions.
+2. Tag follow-ups.
+3. Summarise at the end.

--- a/tests/fixtures/marketplace/source-a/research-pack/pack.yaml
+++ b/tests/fixtures/marketplace/source-a/research-pack/pack.yaml
@@ -1,0 +1,16 @@
+apiVersion: 1
+id: research-pack
+name: Research Pack
+description: Research-focused roles, a web-digging tool, and a deep-research skill.
+version: 1.2.0
+author: jane@example.com
+homepage: https://example.com/research-pack
+license: MIT
+minBobbit: "0.80.0"
+contents:
+  roles:
+    - researcher
+  tools:
+    - research
+  skills:
+    - deep-research

--- a/tests/fixtures/marketplace/source-a/research-pack/roles/researcher.yaml
+++ b/tests/fixtures/marketplace/source-a/research-pack/roles/researcher.yaml
@@ -1,0 +1,8 @@
+name: researcher
+label: Researcher
+accessory: none
+createdAt: 0
+updatedAt: 0
+promptTemplate: |-
+  You are a meticulous research agent. Gather sources, synthesize findings,
+  and cite everything.

--- a/tests/fixtures/marketplace/source-a/research-pack/skills/deep-research/SKILL.md
+++ b/tests/fixtures/marketplace/source-a/research-pack/skills/deep-research/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: deep-research
+description: Run a structured deep-research pass on a topic.
+argument-hint: <topic>
+---
+
+# Deep Research
+
+Perform a methodical, multi-source research pass on the supplied topic.
+
+1. Decompose the topic into sub-questions.
+2. Gather sources for each.
+3. Synthesize findings with citations.
+
+See `references/methodology.md` for the full methodology.

--- a/tests/fixtures/marketplace/source-a/research-pack/skills/deep-research/references/methodology.md
+++ b/tests/fixtures/marketplace/source-a/research-pack/skills/deep-research/references/methodology.md
@@ -1,0 +1,8 @@
+# Deep Research Methodology
+
+A reference document bundled inside the skill payload. Verifies that nested
+skill resources are copied on install.
+
+- Triangulate every claim across at least two independent sources.
+- Prefer primary sources.
+- Record provenance for each finding.

--- a/tests/fixtures/marketplace/source-a/research-pack/tools/research/_shared/http.ts
+++ b/tests/fixtures/marketplace/source-a/research-pack/tools/research/_shared/http.ts
@@ -1,0 +1,4 @@
+// Shared helper for the Research Pack fixture tool. Verifies _shared/ is copied.
+export function normalizeUrl(url: string): string {
+	return url.trim().replace(/\/+$/, "");
+}

--- a/tests/fixtures/marketplace/source-a/research-pack/tools/research/extension.ts
+++ b/tests/fixtures/marketplace/source-a/research-pack/tools/research/extension.ts
@@ -1,0 +1,4 @@
+// Research Pack fixture tool — executable code payload (drives the §9 warning).
+export async function web_dig(args: { url: string }): Promise<{ result: string }> {
+	return { result: `dug into ${args.url}` };
+}

--- a/tests/fixtures/marketplace/source-a/research-pack/tools/research/web_dig.yaml
+++ b/tests/fixtures/marketplace/source-a/research-pack/tools/research/web_dig.yaml
@@ -1,0 +1,11 @@
+name: web_dig
+description: "Deep web research helper — fetch + summarize a URL"
+summary: "Dig into a web page"
+params: [url]
+provider:
+  type: bobbit-extension
+  extension: extension.ts
+group: Research
+docs: |-
+  Fetches a URL and extracts the salient research content. Example tool shipped
+  by the Research Pack fixture.

--- a/tests/fixtures/marketplace/source-a/roles-only-pack/pack.yaml
+++ b/tests/fixtures/marketplace/source-a/roles-only-pack/pack.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+id: roles-only-pack
+name: Roles Only Pack
+description: A pack that ships a single role and nothing else.
+version: 0.1.0
+contents:
+  roles:
+    - analyst

--- a/tests/fixtures/marketplace/source-a/roles-only-pack/roles/analyst.yaml
+++ b/tests/fixtures/marketplace/source-a/roles-only-pack/roles/analyst.yaml
@@ -1,0 +1,7 @@
+name: analyst
+label: Analyst
+accessory: none
+createdAt: 0
+updatedAt: 0
+promptTemplate: |-
+  You are a data analyst. Turn raw data into clear, defensible conclusions.

--- a/tests/fixtures/marketplace/source-b/bad-contents-pack/pack.yaml
+++ b/tests/fixtures/marketplace/source-b/bad-contents-pack/pack.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+id: bad-contents-pack
+name: Bad Contents Pack
+description: A supported contents key (tools) is a string, not an array.
+version: 1.0.0
+contents:
+  roles:
+    - good-role
+  tools: oops-not-an-array

--- a/tests/fixtures/marketplace/source-b/bad-contents-pack/roles/good-role.yaml
+++ b/tests/fixtures/marketplace/source-b/bad-contents-pack/roles/good-role.yaml
@@ -1,0 +1,8 @@
+name: good-role
+label: Good Role
+accessory: none
+createdAt: 0
+updatedAt: 0
+promptTemplate: |-
+  A role whose declaration is fine; the pack is invalid only because the
+  sibling `tools` contents key is a string instead of an array.

--- a/tests/fixtures/marketplace/source-b/good-pack/pack.yaml
+++ b/tests/fixtures/marketplace/source-b/good-pack/pack.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+id: good-pack
+name: Good Pack
+description: A fully valid pack so sibling validity is observable in the scan.
+version: 1.0.0
+contents:
+  roles:
+    - helper

--- a/tests/fixtures/marketplace/source-b/good-pack/roles/helper.yaml
+++ b/tests/fixtures/marketplace/source-b/good-pack/roles/helper.yaml
@@ -1,0 +1,7 @@
+name: helper
+label: Helper
+accessory: none
+createdAt: 0
+updatedAt: 0
+promptTemplate: |-
+  A valid role whose YAML name matches the declared entity name.

--- a/tests/fixtures/marketplace/source-b/role-name-mismatch-pack/pack.yaml
+++ b/tests/fixtures/marketplace/source-b/role-name-mismatch-pack/pack.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+id: role-name-mismatch-pack
+name: Role Name Mismatch Pack
+description: Declares role "mismatch" but the YAML name field disagrees.
+version: 1.0.0
+contents:
+  roles:
+    - mismatch

--- a/tests/fixtures/marketplace/source-b/role-name-mismatch-pack/roles/mismatch.yaml
+++ b/tests/fixtures/marketplace/source-b/role-name-mismatch-pack/roles/mismatch.yaml
@@ -1,0 +1,8 @@
+name: something-else
+label: Something Else
+accessory: none
+createdAt: 0
+updatedAt: 0
+promptTemplate: |-
+  Declared as entity "mismatch" but the YAML name is "something-else" — this
+  must make the pack invalid (the name is the cascade resolution key).

--- a/tests/helpers/marketplace-harness.ts
+++ b/tests/helpers/marketplace-harness.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared helpers for marketplace install/conflict/provenance unit tests.
+ * Builds an InstallService against temp config dirs and an in-memory
+ * project-config writer so file operations are exercised hermetically.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { InstallService } from "../../src/server/marketplace/install-service.ts";
+import { ProvenanceStore } from "../../src/server/marketplace/provenance-store.ts";
+import { scanPackDir } from "../../src/server/marketplace/pack-scanner.ts";
+import type { ProjectConfigWriter } from "../../src/server/agent/config-directories.ts";
+import type { InstallScope, ScannedPack, SourceRecord } from "../../src/server/marketplace/types.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const SOURCE_A = path.join(__dirname, "..", "fixtures", "marketplace", "source-a");
+
+export function tmpDir(label = "bobbit-market-"): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), label));
+}
+
+/** Minimal in-memory ProjectConfigWriter (key→string), no typed accessors. */
+export class MemConfigStore implements ProjectConfigWriter {
+	private map = new Map<string, string>();
+	get(key: string): string | undefined { return this.map.get(key); }
+	set(key: string, value: string): void { this.map.set(key, value); }
+	remove(key: string): void { this.map.delete(key); }
+}
+
+export interface Harness {
+	service: InstallService;
+	systemConfigDir: string;
+	systemSkillsDir: string;
+	projectConfigDir: string;
+	projectConfigStore: MemConfigStore;
+	systemProvenance: () => ProvenanceStore;
+	projectProvenance: () => ProvenanceStore;
+}
+
+export function makeHarness(): Harness {
+	const systemConfigDir = tmpDir("bobbit-market-sys-");
+	const systemSkillsDir = tmpDir("bobbit-market-sysskills-");
+	const projectConfigDir = tmpDir("bobbit-market-proj-");
+	const projectConfigStore = new MemConfigStore();
+
+	const service = new InstallService({
+		resolveCtx: (scope: InstallScope, projectId) => {
+			if (scope === "system") {
+				return { scope, projectId: null, configDir: systemConfigDir, skillInstallDir: systemSkillsDir };
+			}
+			return {
+				scope: "project",
+				projectId,
+				configDir: projectConfigDir,
+				skillInstallDir: path.join(projectConfigDir, "skills"),
+				projectConfigStore,
+			};
+		},
+		resolveProvenance: (scope: InstallScope) =>
+			new ProvenanceStore(scope === "system" ? systemConfigDir : projectConfigDir),
+	});
+
+	return {
+		service,
+		systemConfigDir,
+		systemSkillsDir,
+		projectConfigDir,
+		projectConfigStore,
+		systemProvenance: () => new ProvenanceStore(systemConfigDir),
+		projectProvenance: () => new ProvenanceStore(projectConfigDir),
+	};
+}
+
+export function localSource(): SourceRecord {
+	return {
+		id: "src-a",
+		kind: "local",
+		url: null,
+		ref: null,
+		path: SOURCE_A,
+		label: "Source A",
+		addedAt: 0,
+		lastSyncedAt: 0,
+		lastSyncCommit: null,
+		lastSyncError: null,
+	};
+}
+
+export function pack(packId: string): ScannedPack {
+	return scanPackDir("src-a", path.join(SOURCE_A, packId));
+}

--- a/tests/marketplace-conflict.test.ts
+++ b/tests/marketplace-conflict.test.ts
@@ -71,6 +71,54 @@ describe("marketplace conflict handling", () => {
 		assert.ok(fs.existsSync(path.join(h.projectConfigDir, "roles", "analyst.yaml")));
 	});
 
+	it("a whole-pack install that SKIPS a conflict is recorded as \"subset\", not \"pack\"", () => {
+		const h = makeHarness();
+		// A pre-existing, hand-authored role at the same scope.
+		fs.mkdirSync(path.join(h.projectConfigDir, "roles"), { recursive: true });
+		const roleDest = path.join(h.projectConfigDir, "roles", "researcher.yaml");
+		fs.writeFileSync(roleDest, "name: researcher\n# hand-authored\n");
+
+		installResearch(h, "skip");
+
+		const rec = h.projectProvenance().find("src-a", "research-pack")!;
+		// installMode derives from COVERAGE, not the whole-pack request shape:
+		// the skipped role is absent, so the record does not cover all declared.
+		assert.equal(rec.installMode, "subset");
+		assert.ok(!rec.entities.some((e) => `${e.type}/${e.name}` === "role/researcher"), "skipped entity is not in the record");
+		assert.deepEqual(rec.entities.map((e) => `${e.type}/${e.name}`).sort(), ["skill/deep-research", "tool/research"]);
+	});
+
+	it("update() after a skip-install does NOT clobber the user's skipped entity", () => {
+		const h = makeHarness();
+		fs.mkdirSync(path.join(h.projectConfigDir, "roles"), { recursive: true });
+		const roleDest = path.join(h.projectConfigDir, "roles", "researcher.yaml");
+		fs.writeFileSync(roleDest, "name: researcher\n# SENTINEL-USER\n");
+
+		installResearch(h, "skip");
+		// Because the record is "subset", a whole-pack update must touch only the
+		// tracked (installed) entities — never the user's deliberately-kept role.
+		h.service.update({ scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack") });
+
+		assert.match(fs.readFileSync(roleDest, "utf-8"), /SENTINEL-USER/, "user's role untouched by update");
+		const rec = h.projectProvenance().find("src-a", "research-pack")!;
+		assert.equal(rec.installMode, "subset");
+		assert.ok(!rec.entities.some((e) => `${e.type}/${e.name}` === "role/researcher"), "skipped entity still not tracked after update");
+	});
+
+	it("a whole-pack install with no conflicts (and overwrite) records \"pack\" (regression guard)", () => {
+		// No conflicts → covers all declared → "pack".
+		const clean = makeHarness();
+		installResearch(clean, "fail");
+		assert.equal(clean.projectProvenance().find("src-a", "research-pack")!.installMode, "pack");
+
+		// Overwrite of a conflicting entity still covers all declared → "pack".
+		const h = makeHarness();
+		fs.mkdirSync(path.join(h.projectConfigDir, "roles"), { recursive: true });
+		fs.writeFileSync(path.join(h.projectConfigDir, "roles", "researcher.yaml"), "name: researcher\n# stale\n");
+		installResearch(h, "overwrite");
+		assert.equal(h.projectProvenance().find("src-a", "research-pack")!.installMode, "pack");
+	});
+
 	it("rolls back partial writes when a copy fails mid-transaction", () => {
 		const h = makeHarness();
 		// Plant a FILE at <configDir>/tools so creating the tools/research group

--- a/tests/marketplace-conflict.test.ts
+++ b/tests/marketplace-conflict.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for marketplace conflict handling (§6.5):
+ * fail / overwrite / skip modes, same-scope-only semantics, and rollback.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { makeHarness, pack, localSource } from "./helpers/marketplace-harness.ts";
+import { ConflictError } from "../src/server/marketplace/install-service.ts";
+
+function installResearch(h: ReturnType<typeof makeHarness>, conflict: "fail" | "overwrite" | "skip") {
+	return h.service.install({
+		scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"), entities: null, conflict,
+	});
+}
+
+describe("marketplace conflict handling", () => {
+	it("fail mode aborts transactionally when a destination already exists", () => {
+		const h = makeHarness();
+		// Pre-create the role destination at the same scope.
+		fs.mkdirSync(path.join(h.projectConfigDir, "roles"), { recursive: true });
+		fs.writeFileSync(path.join(h.projectConfigDir, "roles", "researcher.yaml"), "name: researcher\n");
+
+		assert.throws(() => installResearch(h, "fail"), (err: unknown) => {
+			assert.ok(err instanceof ConflictError);
+			assert.deepEqual(err.conflicts.map((c) => `${c.type}/${c.name}`), ["role/researcher"]);
+			return true;
+		});
+		// Nothing else was written (transactional abort).
+		assert.ok(!fs.existsSync(path.join(h.projectConfigDir, "tools", "research")));
+		assert.ok(!fs.existsSync(path.join(h.projectConfigDir, "skills", "deep-research")));
+		// No provenance record persisted.
+		assert.equal(h.projectProvenance().find("src-a", "research-pack"), undefined);
+	});
+
+	it("overwrite mode replaces the existing entity", () => {
+		const h = makeHarness();
+		fs.mkdirSync(path.join(h.projectConfigDir, "roles"), { recursive: true });
+		const dest = path.join(h.projectConfigDir, "roles", "researcher.yaml");
+		fs.writeFileSync(dest, "name: researcher\n# stale\n");
+
+		const outcome = installResearch(h, "overwrite");
+		assert.equal(outcome.results.filter((r) => r.status === "installed").length, 3);
+		assert.ok(!fs.readFileSync(dest, "utf-8").includes("# stale"));
+	});
+
+	it("skip mode installs only the non-conflicting entities", () => {
+		const h = makeHarness();
+		fs.mkdirSync(path.join(h.projectConfigDir, "roles"), { recursive: true });
+		fs.writeFileSync(path.join(h.projectConfigDir, "roles", "researcher.yaml"), "name: researcher\n");
+
+		const outcome = installResearch(h, "skip");
+		assert.deepEqual(outcome.skipped.map((s) => `${s.type}/${s.name}`), ["role/researcher"]);
+		// Non-conflicting entities still installed.
+		assert.ok(fs.existsSync(path.join(h.projectConfigDir, "tools", "research")));
+		assert.ok(fs.existsSync(path.join(h.projectConfigDir, "skills", "deep-research")));
+	});
+
+	it("a same-name entity at a different (system) scope is not a conflict", () => {
+		const h = makeHarness();
+		// Install at system scope first.
+		h.service.install({
+			scope: "system", projectId: null, source: localSource(), pack: pack("roles-only-pack"), entities: null, conflict: "fail",
+		});
+		// Installing at project scope must NOT be a conflict (cascade shadow).
+		assert.doesNotThrow(() => h.service.install({
+			scope: "project", projectId: "p1", source: localSource(), pack: pack("roles-only-pack"), entities: null, conflict: "fail",
+		}));
+		assert.ok(fs.existsSync(path.join(h.projectConfigDir, "roles", "analyst.yaml")));
+	});
+
+	it("rolls back partial writes when a copy fails mid-transaction", () => {
+		const h = makeHarness();
+		// Plant a FILE at <configDir>/tools so creating the tools/research group
+		// dir throws (ENOTDIR) — the tool entity copies second, after the role.
+		fs.writeFileSync(path.join(h.projectConfigDir, "tools"), "not a dir");
+
+		assert.throws(() => h.service.install({
+			scope: "project", projectId: "p1", source: localSource(),
+			// Order role before tool so the role copies first, then the tool fails.
+			pack: pack("research-pack"),
+			entities: [{ type: "role", name: "researcher" }, { type: "tool", name: "research" }],
+			conflict: "fail",
+		}));
+		// The role that copied first must have been rolled back.
+		assert.ok(!fs.existsSync(path.join(h.projectConfigDir, "roles", "researcher.yaml")));
+	});
+});

--- a/tests/marketplace-fixes.test.ts
+++ b/tests/marketplace-fixes.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Unit tests for the server-side marketplace review fixes:
+ *  1. path-traversal validation (scanner + handlers)
+ *  2. overwrite-install backup/restore (no data loss on mid-install failure)
+ *  3. updatePack aborts on sync error (no stale re-copy / provenance rewrite)
+ *  4. skill uninstall preserves other config-dir types on the same path
+ *  5. credential redaction in source DTOs
+ *  6. flat drill-down contract from getPackDetail / the packs route
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { makeHarness, pack, localSource, tmpDir, SOURCE_A } from "./helpers/marketplace-harness.ts";
+import {
+	parseCustomDirectories,
+	saveCustomDirectories,
+} from "../src/server/agent/config-directories.ts";
+
+const { scanPackDir } = await import("../src/server/marketplace/pack-scanner.ts");
+const { MarketplaceService } = await import("../src/server/marketplace/service.ts");
+const { redactSourceUrl } = await import("../src/server/marketplace/source-registry.ts");
+const { ProvenanceStore } = await import("../src/server/marketplace/provenance-store.ts");
+
+// ── Fix 1: path traversal ──────────────────────────────────────────────────
+
+describe("marketplace fix: path-traversal validation", () => {
+	function writeEvilPack(root: string, badName: string): string {
+		const packDir = path.join(root, "evil-pack");
+		fs.mkdirSync(path.join(packDir, "roles"), { recursive: true });
+		// A legit sibling role so the pack would otherwise be valid.
+		fs.writeFileSync(path.join(packDir, "roles", "ok.yaml"), "name: ok\n");
+		fs.writeFileSync(
+			path.join(packDir, "pack.yaml"),
+			`apiVersion: 1\nid: evil-pack\nname: Evil\ndescription: d\nversion: "1"\ncontents:\n  roles:\n    - ok\n    - ${JSON.stringify(badName)}\n`,
+		);
+		return packDir;
+	}
+
+	it("marks a pack invalid when an entity name escapes its directory", () => {
+		const root = tmpDir("bobbit-market-evil-");
+		const scanned = scanPackDir("src-x", writeEvilPack(root, "../evil"));
+		assert.equal(scanned.valid, false);
+		assert.match(scanned.error ?? "", /invalid entity name/i);
+		// The escaping name never becomes a resolved entity.
+		assert.ok(!scanned.entities.some((e) => e.name.includes("..")));
+	});
+
+	it("rejects names with path separators and absolute paths", () => {
+		const root = tmpDir("bobbit-market-evil2-");
+		for (const bad of ["a/b", "/etc/passwd", "..", ".hidden", "C:evil"]) {
+			const scanned = scanPackDir("src-x", writeEvilPack(root, bad));
+			assert.equal(scanned.valid, false, `expected ${bad} to be rejected`);
+		}
+	});
+
+	it("install refuses an invalid (escaping) pack and writes nothing outside scope", () => {
+		const root = tmpDir("bobbit-market-evil3-");
+		const scanned = scanPackDir("src-x", writeEvilPack(root, "../evil"));
+		const h = makeHarness();
+		assert.throws(
+			() => h.service.install({ scope: "system", projectId: null, source: localSource(), pack: scanned, entities: null, conflict: "fail" }),
+			/invalid/i,
+		);
+		// No file escaped to the parent of the pack dir.
+		assert.ok(!fs.existsSync(path.join(root, "evil.yaml")));
+	});
+});
+
+// ── Fix 2: overwrite-install backup/restore ─────────────────────────────────
+
+describe("marketplace fix: overwrite-install is transactional (no data loss)", () => {
+	it("restores a clobbered entity when a later entity install fails", () => {
+		const h = makeHarness();
+		// Pre-existing role with sentinel content at the install scope.
+		fs.mkdirSync(path.join(h.projectConfigDir, "roles"), { recursive: true });
+		const roleDest = path.join(h.projectConfigDir, "roles", "researcher.yaml");
+		fs.writeFileSync(roleDest, "name: researcher\n# ORIGINAL-DO-NOT-LOSE\n");
+		// Plant a FILE at <configDir>/tools so the tool copy (second target) fails.
+		fs.writeFileSync(path.join(h.projectConfigDir, "tools"), "not a dir");
+
+		assert.throws(() => h.service.install({
+			scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"),
+			// role first (conflicts → overwrite path), tool second (fails mid-install).
+			entities: [{ type: "role", name: "researcher" }, { type: "tool", name: "research" }],
+			conflict: "overwrite",
+		}));
+
+		// The pre-existing role must be intact — restored from backup.
+		assert.ok(fs.existsSync(roleDest), "clobbered role must be restored");
+		assert.match(fs.readFileSync(roleDest, "utf-8"), /ORIGINAL-DO-NOT-LOSE/);
+		// No provenance persisted for the failed install.
+		assert.equal(h.projectProvenance().find("src-a", "research-pack"), undefined);
+		// No leftover backup files.
+		const leftovers = fs.readdirSync(path.join(h.projectConfigDir, "roles")).filter((f) => f.includes(".mp-bak-"));
+		assert.deepEqual(leftovers, []);
+	});
+
+	it("overwrite success replaces content and leaves no backup files", () => {
+		const h = makeHarness();
+		fs.mkdirSync(path.join(h.projectConfigDir, "roles"), { recursive: true });
+		const roleDest = path.join(h.projectConfigDir, "roles", "researcher.yaml");
+		fs.writeFileSync(roleDest, "name: researcher\n# stale\n");
+
+		h.service.install({
+			scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"),
+			entities: [{ type: "role", name: "researcher" }], conflict: "overwrite",
+		});
+		assert.ok(!fs.readFileSync(roleDest, "utf-8").includes("# stale"));
+		const leftovers = fs.readdirSync(path.join(h.projectConfigDir, "roles")).filter((f) => f.includes(".mp-bak-"));
+		assert.deepEqual(leftovers, []);
+	});
+});
+
+// ── Fix 4: skill uninstall preserves other config-dir types ─────────────────
+
+describe("marketplace fix: skill uninstall preserves other config-dir types", () => {
+	it("removes only the skills registration, keeping a co-registered type", () => {
+		const h = makeHarness();
+		h.service.install({
+			scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"),
+			entities: [{ type: "skill", name: "deep-research" }], conflict: "fail",
+		});
+		const skillsDir = path.join(h.projectConfigDir, "skills");
+
+		// Co-register another type (mcp) on the same dir path.
+		const dirs = parseCustomDirectories(h.projectConfigStore);
+		const entry = dirs.find((d) => path.resolve(d.path) === path.resolve(skillsDir))!;
+		assert.ok(entry, "skills dir should be registered after install");
+		entry.types = [...entry.types, "mcp"];
+		saveCustomDirectories(h.projectConfigStore, dirs);
+
+		h.service.uninstall({ scope: "project", projectId: "p1", sourceId: "src-a", packId: "research-pack" });
+
+		const after = parseCustomDirectories(h.projectConfigStore);
+		const e2 = after.find((d) => path.resolve(d.path) === path.resolve(skillsDir));
+		assert.ok(e2, "dir entry must survive because mcp is still registered");
+		assert.deepEqual(e2!.types, ["mcp"]);
+		assert.ok(!e2!.types.includes("skills"));
+	});
+
+	it("drops the dir entry entirely when skills was its only type", () => {
+		const h = makeHarness();
+		h.service.install({
+			scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"),
+			entities: [{ type: "skill", name: "deep-research" }], conflict: "fail",
+		});
+		const skillsDir = path.join(h.projectConfigDir, "skills");
+
+		h.service.uninstall({ scope: "project", projectId: "p1", sourceId: "src-a", packId: "research-pack" });
+
+		const after = parseCustomDirectories(h.projectConfigStore);
+		assert.ok(!after.some((d) => path.resolve(d.path) === path.resolve(skillsDir)));
+	});
+});
+
+// ── Service-level fixes (3, 5, 6) ───────────────────────────────────────────
+
+function makeService() {
+	const stateDir = tmpDir("bobbit-market-state-");
+	const systemConfigDir = tmpDir("bobbit-market-syscfg-");
+	const systemSkillsDir = tmpDir("bobbit-market-sysskills-");
+	const service = new MarketplaceService({
+		stateDir,
+		systemConfigDir,
+		systemSkillsDir,
+		resolveProject: () => null,
+	});
+	return { service, stateDir, systemConfigDir, systemSkillsDir };
+}
+
+describe("marketplace fix: credential redaction in source DTOs", () => {
+	it("redactSourceUrl strips embedded credentials and leaves storage untouched", () => {
+		const rec = redactSourceUrl({
+			id: "x", kind: "git", url: "https://user:ghp_secret@github.com/acme/packs.git",
+			ref: null, path: null, label: null, addedAt: 0,
+			lastSyncedAt: null, lastSyncCommit: null, lastSyncError: null,
+		});
+		assert.equal(rec.url, "https://github.com/acme/packs.git");
+	});
+
+	it("addSource and listSources never return a token in the url DTO", () => {
+		const { service, stateDir } = makeService();
+		const added = service.addSource({ kind: "git", url: "https://user:ghp_secret@github.com/acme/packs.git" });
+		assert.ok(!added.url!.includes("ghp_secret"));
+		assert.equal(added.url, "https://github.com/acme/packs.git");
+
+		const listed = service.listSources();
+		assert.equal(listed.length, 1);
+		assert.ok(!listed[0].url!.includes("ghp_secret"));
+
+		// Storage retains the credential-bearing URL so the git backend can auth.
+		const raw = fs.readFileSync(path.join(stateDir, "marketplace", "sources.json"), "utf-8");
+		assert.ok(raw.includes("ghp_secret"), "storage should keep credentials for auth");
+	});
+});
+
+describe("marketplace fix: updatePack aborts on sync error", () => {
+	it("does not re-copy or rewrite provenance when the sync fails", async () => {
+		const { service, systemConfigDir } = makeService();
+		const src = service.addSource({ kind: "local", path: SOURCE_A });
+
+		// Install first so a provenance record exists.
+		service.installPack({ sourceId: src.id, packId: "roles-only-pack", scope: "system", projectId: null, entities: null, conflict: "fail" });
+		const before = new ProvenanceStore(systemConfigDir).find(src.id, "roles-only-pack");
+		assert.ok(before);
+
+		// Force the next sync to fail.
+		(service.sync as any).sync = async () => ({ root: "", commit: null, contentHash: null, error: "boom: network unreachable" });
+
+		await assert.rejects(
+			() => service.updatePack({ sourceId: src.id, packId: "roles-only-pack", scope: "system", projectId: null }),
+			/failed to sync/i,
+		);
+
+		// Provenance is unchanged (not rewritten with a null/stale commit).
+		const after = new ProvenanceStore(systemConfigDir).find(src.id, "roles-only-pack");
+		assert.deepEqual(after, before);
+	});
+});
+
+describe("marketplace fix: flat drill-down contract", () => {
+	it("getPackDetail returns the flat shape with per-entity installed flags", () => {
+		const { service } = makeService();
+		const src = service.addSource({ kind: "local", path: SOURCE_A });
+
+		const detail = service.getPackDetail(src.id, "research-pack", "system", null);
+		assert.ok(detail);
+		// Flat: no nested summary/pack/installedEntities keys.
+		assert.equal((detail as any).summary, undefined);
+		assert.equal((detail as any).pack, undefined);
+		assert.equal((detail as any).installedEntities, undefined);
+
+		assert.equal(detail!.sourceId, src.id);
+		assert.equal(detail!.packId, "research-pack");
+		assert.equal(detail!.name, "Research Pack");
+		assert.equal(detail!.version, "1.2.0");
+		assert.equal(detail!.author, "jane@example.com");
+		assert.equal(detail!.license, "MIT");
+		assert.equal(detail!.hasTools, true);
+		assert.equal(detail!.valid, true);
+		assert.equal(detail!.error, null);
+		assert.equal(detail!.installStatus, "not-installed");
+		assert.ok(Array.isArray(detail!.entities));
+		assert.ok(detail!.entities.every((e) => e.installed === false));
+
+		// After installing one entity, only that one flips to installed.
+		service.installPack({ sourceId: src.id, packId: "research-pack", scope: "system", projectId: null, entities: [{ type: "role", name: "researcher" }], conflict: "fail" });
+		const after = service.getPackDetail(src.id, "research-pack", "system", null)!;
+		const role = after.entities.find((e) => e.type === "role" && e.name === "researcher")!;
+		assert.equal(role.installed, true);
+		const tool = after.entities.find((e) => e.type === "tool")!;
+		assert.equal(tool.installed, false);
+	});
+
+	it("nulls optional manifest fields a pack omits", () => {
+		const { service } = makeService();
+		const src = service.addSource({ kind: "local", path: SOURCE_A });
+		const detail = service.getPackDetail(src.id, "roles-only-pack", "system", null)!;
+		assert.equal(detail.author, null);
+		assert.equal(detail.homepage, null);
+		assert.equal(detail.license, null);
+		assert.equal(detail.minBobbit, null);
+	});
+});

--- a/tests/marketplace-install.test.ts
+++ b/tests/marketplace-install.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for the marketplace install pipeline (§6): file operations,
+ * skill custom-dir registration, subset install, and cascade resolution of
+ * an installed role.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { makeHarness, pack, localSource } from "./helpers/marketplace-harness.ts";
+import { parseCustomDirectories } from "../src/server/agent/config-directories.ts";
+
+const { RoleStore } = await import("../src/server/agent/role-store.ts");
+const { ConfigCascade } = await import("../src/server/agent/config-cascade.ts");
+const { BuiltinConfigProvider } = await import("../src/server/agent/builtin-config.ts");
+
+describe("marketplace install — file operations", () => {
+	it("whole-pack install copies role yaml, tool group dir (recursive), and skill dir to project scope", () => {
+		const h = makeHarness();
+		const outcome = h.service.install({
+			scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"), entities: null, conflict: "fail",
+		});
+		assert.equal(outcome.results.filter((r) => r.status === "installed").length, 3);
+
+		// Role file
+		assert.ok(fs.existsSync(path.join(h.projectConfigDir, "roles", "researcher.yaml")));
+		// Tool group dir incl. extension.ts + _shared/
+		assert.ok(fs.existsSync(path.join(h.projectConfigDir, "tools", "research", "web_dig.yaml")));
+		assert.ok(fs.existsSync(path.join(h.projectConfigDir, "tools", "research", "extension.ts")));
+		assert.ok(fs.existsSync(path.join(h.projectConfigDir, "tools", "research", "_shared", "http.ts")));
+		// Skill dir incl. nested references/
+		assert.ok(fs.existsSync(path.join(h.projectConfigDir, "skills", "deep-research", "SKILL.md")));
+		assert.ok(fs.existsSync(path.join(h.projectConfigDir, "skills", "deep-research", "references", "methodology.md")));
+	});
+
+	it("project-scope skill install registers an absolute custom skills dir in project config", () => {
+		const h = makeHarness();
+		h.service.install({
+			scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"), entities: null, conflict: "fail",
+		});
+		const dirs = parseCustomDirectories(h.projectConfigStore);
+		const skillsDir = path.join(h.projectConfigDir, "skills");
+		const entry = dirs.find((d) => path.resolve(d.path) === path.resolve(skillsDir));
+		assert.ok(entry, "custom skills dir should be registered");
+		assert.ok(path.isAbsolute(entry!.path), "registered path must be absolute");
+		assert.ok(entry!.types.includes("skills"));
+	});
+
+	it("system-scope skill install lands in the system skills dir without custom-dir registration", () => {
+		const h = makeHarness();
+		h.service.install({
+			scope: "system", projectId: null, source: localSource(), pack: pack("research-pack"), entities: null, conflict: "fail",
+		});
+		assert.ok(fs.existsSync(path.join(h.systemSkillsDir, "deep-research", "SKILL.md")));
+	});
+
+	it("subset install copies only the requested entities", () => {
+		const h = makeHarness();
+		const outcome = h.service.install({
+			scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"),
+			entities: [{ type: "role", name: "researcher" }], conflict: "fail",
+		});
+		assert.equal(outcome.results.length, 1);
+		assert.ok(fs.existsSync(path.join(h.projectConfigDir, "roles", "researcher.yaml")));
+		assert.ok(!fs.existsSync(path.join(h.projectConfigDir, "tools", "research")));
+		assert.ok(!fs.existsSync(path.join(h.projectConfigDir, "skills", "deep-research")));
+	});
+
+	it("installed role at system scope resolves through ConfigCascade with origin 'server'", () => {
+		const h = makeHarness();
+		h.service.install({
+			scope: "system", projectId: null, source: localSource(), pack: pack("roles-only-pack"), entities: null, conflict: "fail",
+		});
+		const serverRoleStore = new RoleStore(h.systemConfigDir);
+		const cascade = new ConfigCascade(
+			new BuiltinConfigProvider(),
+			{
+				getRoles: () => serverRoleStore.getAllLocal(),
+				getTools: () => [],
+				getToolGroupPolicies: () => ({}),
+			},
+			{ getOrCreate: () => null } as any,
+		);
+		const resolved = cascade.resolveRoles(undefined);
+		const analyst = resolved.find((r) => r.item.name === "analyst");
+		assert.ok(analyst, "installed role should resolve through the cascade");
+		assert.equal(analyst!.origin, "server");
+	});
+});

--- a/tests/marketplace-pack-scanner.test.ts
+++ b/tests/marketplace-pack-scanner.test.ts
@@ -19,7 +19,7 @@ describe("marketplace pack scanner", () => {
 	it("scans only dirs with pack.yaml and ignores non-pack dirs", () => {
 		const packs = scanSource("src-a", SOURCE_A);
 		const ids = packs.map((p) => p.packId).sort();
-		assert.deepEqual(ids, ["invalid-pack", "research-pack", "roles-only-pack"]);
+		assert.deepEqual(ids, ["invalid-pack", "notes-pack", "research-pack", "roles-only-pack"]);
 		// not-a-pack/ has no pack.yaml → ignored
 		assert.ok(!ids.includes("not-a-pack"));
 	});

--- a/tests/marketplace-pack-scanner.test.ts
+++ b/tests/marketplace-pack-scanner.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for the marketplace pack scanner (§2, §5).
+ * Points at the file:// fixture source tree tests/fixtures/marketplace/source-a.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const { scanSource, scanPackDir, parsePackManifest, hashPackPayload } =
+	await import("../src/server/marketplace/pack-scanner.ts");
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SOURCE_A = path.join(__dirname, "fixtures", "marketplace", "source-a");
+
+describe("marketplace pack scanner", () => {
+	it("scans only dirs with pack.yaml and ignores non-pack dirs", () => {
+		const packs = scanSource("src-a", SOURCE_A);
+		const ids = packs.map((p) => p.packId).sort();
+		assert.deepEqual(ids, ["invalid-pack", "research-pack", "roles-only-pack"]);
+		// not-a-pack/ has no pack.yaml → ignored
+		assert.ok(!ids.includes("not-a-pack"));
+	});
+
+	it("parses manifest identity fields and declared entities", () => {
+		const packs = scanSource("src-a", SOURCE_A);
+		const research = packs.find((p) => p.packId === "research-pack")!;
+		assert.equal(research.valid, true);
+		assert.equal(research.manifest?.name, "Research Pack");
+		assert.equal(research.manifest?.version, "1.2.0");
+		const entityKeys = research.entities.map((e) => `${e.type}/${e.name}`).sort();
+		assert.deepEqual(entityKeys, ["role/researcher", "skill/deep-research", "tool/research"]);
+	});
+
+	it("sets hasTools true iff a tool entity is declared", () => {
+		const packs = scanSource("src-a", SOURCE_A);
+		assert.equal(packs.find((p) => p.packId === "research-pack")!.hasTools, true);
+		assert.equal(packs.find((p) => p.packId === "roles-only-pack")!.hasTools, false);
+	});
+
+	it("surfaces an error for a pack declaring a missing entity, keeping siblings valid", () => {
+		const packs = scanSource("src-a", SOURCE_A);
+		const invalid = packs.find((p) => p.packId === "invalid-pack")!;
+		assert.equal(invalid.valid, false);
+		assert.match(invalid.error ?? "", /missing-role/);
+		// Sibling valid packs are still returned.
+		assert.equal(packs.find((p) => p.packId === "roles-only-pack")!.valid, true);
+	});
+
+	it("rejects apiVersion !== 1 without crashing", () => {
+		const res = parsePackManifest("apiVersion: 2\nid: x\nname: X\ndescription: d\nversion: 1\ncontents:\n  roles: [a]\n");
+		assert.equal(res.manifest, undefined);
+		assert.match(res.error ?? "", /apiVersion/);
+	});
+
+	it("rejects a pack id that violates the pattern", () => {
+		const res = parsePackManifest('apiVersion: 1\nid: Bad_Id\nname: X\ndescription: d\nversion: "1"\ncontents:\n  roles: [a]\n');
+		assert.match(res.error ?? "", /must match/);
+	});
+
+	it("rejects contents with no supported non-empty list", () => {
+		const res = parsePackManifest('apiVersion: 1\nid: x\nname: X\ndescription: d\nversion: "1"\ncontents:\n  panels: [a]\n');
+		assert.match(res.error ?? "", /at least one/);
+	});
+
+	it("preserves unknown contents keys (forward-compat) while still parsing", () => {
+		const res = parsePackManifest(
+			'apiVersion: 1\nid: x\nname: X\ndescription: d\nversion: "1"\ncontents:\n  roles: [a]\n  panels: [p]\n',
+		);
+		assert.ok(res.manifest);
+		assert.deepEqual((res.manifest!.contents as Record<string, unknown>).panels, ["p"]);
+	});
+
+	it("hashPackPayload is stable and changes when payload changes", () => {
+		const research = scanPackDir("src-a", path.join(SOURCE_A, "research-pack"));
+		const h1 = hashPackPayload(research);
+		const h2 = hashPackPayload(scanPackDir("src-a", path.join(SOURCE_A, "research-pack")));
+		assert.equal(h1, h2);
+
+		// Copy to a temp dir, mutate a file, expect a different hash.
+		const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-pack-hash-"));
+		fs.cpSync(path.join(SOURCE_A, "research-pack"), path.join(tmp, "research-pack"), { recursive: true });
+		const copyPack = scanPackDir("src-a", path.join(tmp, "research-pack"));
+		assert.equal(hashPackPayload(copyPack), h1);
+		fs.appendFileSync(path.join(tmp, "research-pack", "roles", "researcher.yaml"), "\n# mutated\n");
+		assert.notEqual(hashPackPayload(scanPackDir("src-a", path.join(tmp, "research-pack"))), h1);
+	});
+});

--- a/tests/marketplace-provenance.test.ts
+++ b/tests/marketplace-provenance.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for marketplace provenance (§7): record shape + location,
+ * symmetric uninstall, custom-skill-dir deregistration, and update refresh.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { makeHarness, pack, localSource, MemConfigStore } from "./helpers/marketplace-harness.ts";
+import { parseCustomDirectories } from "../src/server/agent/config-directories.ts";
+import type { ScannedPack } from "../src/server/marketplace/types.ts";
+
+describe("marketplace provenance", () => {
+	it("install writes a record with exact installedPaths at the project provenance file", () => {
+		const h = makeHarness();
+		h.service.install({
+			scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"), entities: null, conflict: "fail",
+		});
+		const file = path.join(h.projectConfigDir, "marketplace", "installed.json");
+		assert.ok(fs.existsSync(file));
+		const record = h.projectProvenance().find("src-a", "research-pack")!;
+		assert.equal(record.scope, "project");
+		assert.equal(record.projectId, "p1");
+		assert.equal(record.packVersion, "1.2.0");
+		assert.equal(record.sourceKind, "local");
+		assert.ok(record.sourceContentHash, "local source records a content hash");
+		const role = record.entities.find((e) => e.type === "role")!;
+		assert.deepEqual(role.installedPaths, [path.join(h.projectConfigDir, "roles", "researcher.yaml")]);
+		const skill = record.entities.find((e) => e.type === "skill")!;
+		assert.equal(skill.customDirRegistered, path.resolve(path.join(h.projectConfigDir, "skills")));
+	});
+
+	it("system-scope install writes provenance under the system config dir", () => {
+		const h = makeHarness();
+		h.service.install({
+			scope: "system", projectId: null, source: localSource(), pack: pack("roles-only-pack"), entities: null, conflict: "fail",
+		});
+		assert.ok(fs.existsSync(path.join(h.systemConfigDir, "marketplace", "installed.json")));
+		assert.ok(h.systemProvenance().find("src-a", "roles-only-pack"));
+	});
+
+	it("uninstall removes exactly the installed paths, the record, and an emptied custom skill dir", () => {
+		const h = makeHarness();
+		h.service.install({
+			scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"), entities: null, conflict: "fail",
+		});
+		const skillsDir = path.join(h.projectConfigDir, "skills");
+		assert.ok(parseCustomDirectories(h.projectConfigStore).some((d) => path.resolve(d.path) === path.resolve(skillsDir)));
+
+		h.service.uninstall({ scope: "project", projectId: "p1", sourceId: "src-a", packId: "research-pack" });
+
+		assert.ok(!fs.existsSync(path.join(h.projectConfigDir, "roles", "researcher.yaml")));
+		assert.ok(!fs.existsSync(path.join(h.projectConfigDir, "tools", "research")));
+		assert.ok(!fs.existsSync(path.join(h.projectConfigDir, "skills", "deep-research")));
+		assert.equal(h.projectProvenance().find("src-a", "research-pack"), undefined);
+		// Custom skill dir deregistered now that it is empty.
+		assert.ok(!parseCustomDirectories(h.projectConfigStore).some((d) => path.resolve(d.path) === path.resolve(skillsDir)));
+	});
+
+	it("update re-copies recorded entities, refreshes version, and drops entities no longer declared", () => {
+		const h = makeHarness();
+		h.service.install({
+			scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"), entities: null, conflict: "fail",
+		});
+
+		// Simulate an upstream change: the pack now declares only the role
+		// (tool + skill dropped) and bumps its version.
+		const updated: ScannedPack = pack("research-pack");
+		updated.manifest!.version = "2.0.0";
+		updated.entities = updated.entities.filter((e) => e.type === "role");
+
+		// InstallService.update() refreshes recorded entities against the new
+		// pack (no real sync needed — MarketplaceService layers the sync on top).
+		h.service.update({ scope: "project", projectId: "p1", source: localSource(), pack: updated });
+
+		const record = h.projectProvenance().find("src-a", "research-pack")!;
+		assert.equal(record.packVersion, "2.0.0");
+		assert.deepEqual(record.entities.map((e) => e.type), ["role"]);
+		// Orphaned entities removed from disk.
+		assert.ok(fs.existsSync(path.join(h.projectConfigDir, "roles", "researcher.yaml")));
+		assert.ok(!fs.existsSync(path.join(h.projectConfigDir, "tools", "research")));
+		assert.ok(!fs.existsSync(path.join(h.projectConfigDir, "skills", "deep-research")));
+	});
+
+	it("MemConfigStore round-trips config_directories JSON", () => {
+		const store = new MemConfigStore();
+		store.set("config_directories", JSON.stringify([{ path: "/abs/skills", types: ["skills"] }]));
+		assert.deepEqual(parseCustomDirectories(store).map((d) => d.path), [path.resolve("/abs/skills")]);
+	});
+});

--- a/tests/marketplace-round2-fixes.test.ts
+++ b/tests/marketplace-round2-fixes.test.ts
@@ -218,7 +218,7 @@ describe("marketplace fix: uninstall path containment", () => {
 // ── Fix 4: update transactionality + pack/subset semantics ───────────────────
 
 describe("marketplace fix: update semantics + transactionality", () => {
-	it("whole-pack update installs an upstream-added entity", () => {
+	it("whole-pack update refreshes tracked entities only and does NOT auto-add upstream-added entities", () => {
 		const h = makeHarness();
 		// Initial whole-pack install of a pack that (at the time) declares only the role.
 		const initial = pack("research-pack");
@@ -228,12 +228,14 @@ describe("marketplace fix: update semantics + transactionality", () => {
 		assert.equal(rec.installMode, "pack");
 		assert.deepEqual(rec.entities.map((e) => e.type), ["role"]);
 
-		// Upstream now declares all three entities. A whole-pack update adds them.
+		// Upstream now declares all three entities. Update refreshes the tracked
+		// role only — the newly-declared tool + skill are NOT auto-added (design §7.3).
 		h.service.update({ scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack") });
 		rec = h.projectProvenance().find("src-a", "research-pack")!;
-		assert.deepEqual(rec.entities.map((e) => e.type).sort(), ["role", "skill", "tool"]);
-		assert.ok(fs.existsSync(path.join(h.projectConfigDir, "tools", "research", "web_dig.yaml")));
-		assert.ok(fs.existsSync(path.join(h.projectConfigDir, "skills", "deep-research", "SKILL.md")));
+		assert.deepEqual(rec.entities.map((e) => e.type), ["role"]);
+		assert.equal(rec.installMode, "pack", "install intent preserved across update");
+		assert.ok(!fs.existsSync(path.join(h.projectConfigDir, "tools", "research")));
+		assert.ok(!fs.existsSync(path.join(h.projectConfigDir, "skills", "deep-research")));
 	});
 
 	it("subset update does NOT auto-add a newly-declared entity", () => {
@@ -253,30 +255,30 @@ describe("marketplace fix: update semantics + transactionality", () => {
 
 	it("a mid-update failure restores the prior state intact (no orphaned deletes, no leftover backups)", () => {
 		const h = makeHarness();
-		// Install role + skill (whole-pack of a pack that, at the time, omits the tool).
+		// Install role + tool (whole-pack of a pack that, at the time, omits the skill).
 		const initial = pack("research-pack");
-		initial.entities = initial.entities.filter((e) => e.type !== "tool");
+		initial.entities = initial.entities.filter((e) => e.type !== "skill");
 		h.service.install({ scope: "project", projectId: "p1", source: localSource(), pack: initial, entities: null, conflict: "fail" });
 
 		// Mark the on-disk role so we can prove it was RESTORED (not freshly re-copied).
 		const roleDest = path.join(h.projectConfigDir, "roles", "researcher.yaml");
 		fs.appendFileSync(roleDest, "\n# SENTINEL-KEEP\n");
 
-		// Force the tool copy to fail: plant a FILE where the tools group dir must be created.
+		// Sabotage the TRACKED tool's refresh: drop its installed dir and plant a
+		// FILE where the tools group dir must be re-created so the copy throws.
+		fs.rmSync(path.join(h.projectConfigDir, "tools"), { recursive: true, force: true });
 		fs.writeFileSync(path.join(h.projectConfigDir, "tools"), "not a dir");
 
-		// Whole-pack update now declares the tool too → role refresh succeeds, tool copy fails.
+		// Update refreshes tracked entities (role then tool) → role refresh succeeds, tool copy fails.
 		assert.throws(() => h.service.update({
 			scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"),
 		}));
 
 		// Role restored to the exact pre-update bytes (sentinel survives).
 		assert.match(fs.readFileSync(roleDest, "utf-8"), /SENTINEL-KEEP/);
-		// Skill untouched.
-		assert.ok(fs.existsSync(path.join(h.projectConfigDir, "skills", "deep-research", "SKILL.md")));
-		// Provenance unchanged: still role + skill, mode pack.
+		// Provenance unchanged: still role + tool, mode pack.
 		const rec = h.projectProvenance().find("src-a", "research-pack")!;
-		assert.deepEqual(rec.entities.map((e) => e.type).sort(), ["role", "skill"]);
+		assert.deepEqual(rec.entities.map((e) => e.type).sort(), ["role", "tool"]);
 		assert.equal(rec.installMode, "pack");
 		// No leftover backup files.
 		const leftovers = fs.readdirSync(path.join(h.projectConfigDir, "roles")).filter((f) => f.includes(".mp-bak-"));

--- a/tests/marketplace-round2-fixes.test.ts
+++ b/tests/marketplace-round2-fixes.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Unit tests for the round-2 server-side marketplace review fixes:
+ *  1. git clone option injection — reject `-`-leading URLs, validate scheme + ref, `--` terminators
+ *  2. symlink escape — packs containing symlinks under roles/tools/skills are invalid + never copied/hashed
+ *  3. uninstall path containment — a tampered installed.json cannot delete files outside the scope root
+ *  4. update transactionality + installMode pack/subset semantics
+ *  5. subset-install provenance MERGE (union, not replace)
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { makeHarness, pack, localSource, tmpDir, SOURCE_A } from "./helpers/marketplace-harness.ts";
+
+const { MarketplaceService } = await import("../src/server/marketplace/service.ts");
+const { ProvenanceStore } = await import("../src/server/marketplace/provenance-store.ts");
+const { scanPackDir } = await import("../src/server/marketplace/pack-scanner.ts");
+const { GitSourceBackend } = await import("../src/server/marketplace/sync-service.ts");
+const { validateGitUrl, validateGitRef } = await import("../src/server/marketplace/source-registry.ts");
+const { ENTITY_HANDLERS, findSymlink } = await import("../src/server/marketplace/entity-handlers.ts");
+
+function makeService() {
+	const stateDir = tmpDir("bobbit-market-state-");
+	const systemConfigDir = tmpDir("bobbit-market-syscfg-");
+	const systemSkillsDir = tmpDir("bobbit-market-sysskills-");
+	const service = new MarketplaceService({
+		stateDir,
+		systemConfigDir,
+		systemSkillsDir,
+		resolveProject: () => null,
+	});
+	return { service, stateDir, systemConfigDir, systemSkillsDir };
+}
+
+/** Create a symlink, returning false (so the caller can skip) if the platform forbids it. */
+function trySymlink(target: string, linkPath: string): boolean {
+	try {
+		fs.symlinkSync(target, linkPath);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+// ── Fix 1: git clone option injection ───────────────────────────────────────
+
+describe("marketplace fix: git url/ref validation rejects option injection", () => {
+	it("validateGitUrl rejects a `-`-leading url and disallowed schemes", () => {
+		assert.throws(() => validateGitUrl("-oProxyCommand=touch /tmp/pwn"), /must not start with/i);
+		assert.throws(() => validateGitUrl("ext::sh -c whoami"), /scheme must be one of/i);
+	});
+
+	it("validateGitUrl accepts well-known schemes and scp-like syntax", () => {
+		for (const ok of [
+			"https://github.com/acme/packs.git",
+			"ssh://git@github.com/acme/packs.git",
+			"git://github.com/acme/packs.git",
+			"file:///srv/packs",
+			"git@github.com:acme/packs.git",
+		]) {
+			assert.doesNotThrow(() => validateGitUrl(ok), `expected ${ok} to be accepted`);
+		}
+	});
+
+	it("validateGitRef rejects a `-`-leading ref and unsafe characters", () => {
+		assert.throws(() => validateGitRef("-x"), /must not start with/i);
+		assert.throws(() => validateGitRef("a b"), /must match/i);
+		assert.throws(() => validateGitRef("a;b"), /must match/i);
+		assert.doesNotThrow(() => validateGitRef("release/1.2.x"));
+	});
+
+	it("addSource rejects a `-`-leading git url, a bad scheme, and a `-`-leading ref", () => {
+		const { service } = makeService();
+		assert.throws(() => service.addSource({ kind: "git", url: "-oProxyCommand=evil" }), /must not start with/i);
+		assert.throws(() => service.addSource({ kind: "git", url: "ext::sh -c whoami" }), /scheme must be one of/i);
+		assert.throws(() => service.addSource({ kind: "git", url: "https://h/r.git", ref: "-x" }), /ref must not start/i);
+		const ok = service.addSource({ kind: "git", url: "https://github.com/acme/packs.git", ref: "main" });
+		assert.ok(ok.id);
+	});
+
+	it("GitSourceBackend.sync refuses a `-`-leading url/ref without invoking git", async () => {
+		const backend = new GitSourceBackend();
+		const base = {
+			id: "g1", kind: "git" as const, url: "-oProxyCommand=evil", ref: null,
+			path: null, label: null, addedAt: 0, lastSyncedAt: null, lastSyncCommit: null, lastSyncError: null,
+		};
+		const res = await backend.sync(base, tmpDir("bobbit-market-clone-"));
+		assert.match(res.error ?? "", /must not start with/i);
+		assert.equal(res.commit, null);
+
+		const badRef = { ...base, url: "https://github.com/acme/packs.git", ref: "-x" };
+		const res2 = await backend.sync(badRef, tmpDir("bobbit-market-clone2-"));
+		assert.match(res2.error ?? "", /ref must not start/i);
+	});
+});
+
+// ── Fix 2: symlink escape in pack payloads ──────────────────────────────────
+
+describe("marketplace fix: symlink payloads are rejected, never copied or hashed", () => {
+	function writeSecret(root: string): string {
+		const secret = path.join(root, "secret.txt");
+		fs.writeFileSync(secret, "TOPSECRET-HOST-FILE");
+		return secret;
+	}
+
+	it("a role that is a symlink makes the pack invalid (top-level symlink)", () => {
+		const root = tmpDir("bobbit-market-symrole-");
+		const secret = writeSecret(root);
+		const packDir = path.join(root, "evil-pack");
+		fs.mkdirSync(path.join(packDir, "roles"), { recursive: true });
+		if (!trySymlink(secret, path.join(packDir, "roles", "leak.yaml"))) return; // platform forbids symlinks
+		fs.writeFileSync(
+			path.join(packDir, "pack.yaml"),
+			`apiVersion: 1\nid: evil-pack\nname: Evil\ndescription: d\nversion: "1"\ncontents:\n  roles:\n    - leak\n`,
+		);
+
+		const scanned = scanPackDir("src-x", packDir);
+		assert.equal(scanned.valid, false);
+		assert.match(scanned.error ?? "", /symlink/i);
+
+		// Install refuses an invalid pack — nothing is copied.
+		const h = makeHarness();
+		assert.throws(
+			() => h.service.install({ scope: "system", projectId: null, source: localSource(), pack: scanned, entities: null, conflict: "fail" }),
+			/invalid/i,
+		);
+		assert.ok(!fs.existsSync(path.join(h.systemConfigDir, "roles", "leak.yaml")));
+	});
+
+	it("a symlink nested inside a tool group dir makes the pack invalid (recursive detection)", () => {
+		const root = tmpDir("bobbit-market-symtool-");
+		const secret = writeSecret(root);
+		const packDir = path.join(root, "evil-pack");
+		const toolDir = path.join(packDir, "tools", "research");
+		fs.mkdirSync(toolDir, { recursive: true });
+		fs.writeFileSync(path.join(toolDir, "web_dig.yaml"), "name: web_dig\n");
+		if (!trySymlink(secret, path.join(toolDir, "leak.ts"))) return; // platform forbids symlinks
+		fs.writeFileSync(
+			path.join(packDir, "pack.yaml"),
+			`apiVersion: 1\nid: evil-pack\nname: Evil\ndescription: d\nversion: "1"\ncontents:\n  tools:\n    - research\n`,
+		);
+
+		const scanned = scanPackDir("src-x", packDir);
+		assert.equal(scanned.valid, false);
+		assert.match(scanned.error ?? "", /symlink/i);
+
+		// findSymlink surfaces the offending node.
+		assert.ok(findSymlink(toolDir));
+	});
+});
+
+// ── Fix 3: uninstall path containment ───────────────────────────────────────
+
+describe("marketplace fix: uninstall path containment", () => {
+	it("a tampered installed.json cannot delete files outside the scope root", () => {
+		const { service, systemConfigDir } = makeService();
+		const src = service.addSource({ kind: "local", path: SOURCE_A });
+		service.installPack({ sourceId: src.id, packId: "roles-only-pack", scope: "system", projectId: null, entities: null, conflict: "fail" });
+
+		// Plant a sentinel OUTSIDE the scope and inject it into the provenance file.
+		const outside = tmpDir("bobbit-market-outside-");
+		const sentinel = path.join(outside, "keep.txt");
+		fs.writeFileSync(sentinel, "DO-NOT-DELETE");
+		const file = path.join(systemConfigDir, "marketplace", "installed.json");
+		const data = JSON.parse(fs.readFileSync(file, "utf-8"));
+		data.installs[0].entities[0].installedPaths.push(sentinel);
+		fs.writeFileSync(file, JSON.stringify(data, null, 2));
+
+		service.uninstallPack({ sourceId: src.id, packId: "roles-only-pack", scope: "system", projectId: null });
+
+		assert.ok(fs.existsSync(sentinel), "an out-of-scope path must never be deleted");
+		assert.ok(!fs.existsSync(path.join(systemConfigDir, "roles", "analyst.yaml")), "the in-scope role is still removed");
+	});
+
+	it("ProvenanceStore drops malformed records on load", () => {
+		const dir = tmpDir("bobbit-market-prov-");
+		const file = path.join(dir, "marketplace", "installed.json");
+		fs.mkdirSync(path.dirname(file), { recursive: true });
+		const valid = {
+			scope: "system", projectId: null, sourceId: "s", packId: "p", packName: "P", packVersion: "1",
+			sourceKind: "local", sourceUrl: null, sourceCommit: null, sourceContentHash: null,
+			installedAt: 0, installMode: "pack", entities: [{ type: "role", name: "r", installedPaths: ["/x/r.yaml"] }],
+		};
+		fs.writeFileSync(file, JSON.stringify({
+			version: 1,
+			installs: [
+				{ sourceId: 123 },                                   // bad: sourceId not a string
+				{ sourceId: "a", packId: "b", scope: "weird", entities: [] }, // bad: scope
+				{ sourceId: "a", packId: "b", scope: "system", entities: [{ type: "nope", name: "x", installedPaths: [] }] }, // bad: entity type
+				valid,
+			],
+		}, null, 2));
+
+		const store = new ProvenanceStore(dir);
+		const all = store.list();
+		assert.equal(all.length, 1);
+		assert.equal(all[0].packId, "p");
+	});
+
+	it("a legacy record without installMode defaults to \"pack\" on load", () => {
+		const dir = tmpDir("bobbit-market-prov2-");
+		const file = path.join(dir, "marketplace", "installed.json");
+		fs.mkdirSync(path.dirname(file), { recursive: true });
+		fs.writeFileSync(file, JSON.stringify({
+			version: 1,
+			installs: [{
+				scope: "system", projectId: null, sourceId: "s", packId: "p", packName: "P", packVersion: "1",
+				sourceKind: "local", sourceUrl: null, sourceCommit: null, sourceContentHash: null,
+				installedAt: 0, entities: [{ type: "role", name: "r", installedPaths: ["/x/r.yaml"] }],
+			}],
+		}, null, 2));
+		const store = new ProvenanceStore(dir);
+		assert.equal(store.list()[0].installMode, "pack");
+	});
+});
+
+// ── Fix 4: update transactionality + pack/subset semantics ───────────────────
+
+describe("marketplace fix: update semantics + transactionality", () => {
+	it("whole-pack update installs an upstream-added entity", () => {
+		const h = makeHarness();
+		// Initial whole-pack install of a pack that (at the time) declares only the role.
+		const initial = pack("research-pack");
+		initial.entities = initial.entities.filter((e) => e.type === "role");
+		h.service.install({ scope: "project", projectId: "p1", source: localSource(), pack: initial, entities: null, conflict: "fail" });
+		let rec = h.projectProvenance().find("src-a", "research-pack")!;
+		assert.equal(rec.installMode, "pack");
+		assert.deepEqual(rec.entities.map((e) => e.type), ["role"]);
+
+		// Upstream now declares all three entities. A whole-pack update adds them.
+		h.service.update({ scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack") });
+		rec = h.projectProvenance().find("src-a", "research-pack")!;
+		assert.deepEqual(rec.entities.map((e) => e.type).sort(), ["role", "skill", "tool"]);
+		assert.ok(fs.existsSync(path.join(h.projectConfigDir, "tools", "research", "web_dig.yaml")));
+		assert.ok(fs.existsSync(path.join(h.projectConfigDir, "skills", "deep-research", "SKILL.md")));
+	});
+
+	it("subset update does NOT auto-add a newly-declared entity", () => {
+		const h = makeHarness();
+		h.service.install({
+			scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"),
+			entities: [{ type: "role", name: "researcher" }], conflict: "fail",
+		});
+		assert.equal(h.projectProvenance().find("src-a", "research-pack")!.installMode, "subset");
+
+		h.service.update({ scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack") });
+		const rec = h.projectProvenance().find("src-a", "research-pack")!;
+		assert.deepEqual(rec.entities.map((e) => e.type), ["role"]);
+		assert.ok(!fs.existsSync(path.join(h.projectConfigDir, "tools", "research")));
+		assert.ok(!fs.existsSync(path.join(h.projectConfigDir, "skills", "deep-research")));
+	});
+
+	it("a mid-update failure restores the prior state intact (no orphaned deletes, no leftover backups)", () => {
+		const h = makeHarness();
+		// Install role + skill (whole-pack of a pack that, at the time, omits the tool).
+		const initial = pack("research-pack");
+		initial.entities = initial.entities.filter((e) => e.type !== "tool");
+		h.service.install({ scope: "project", projectId: "p1", source: localSource(), pack: initial, entities: null, conflict: "fail" });
+
+		// Mark the on-disk role so we can prove it was RESTORED (not freshly re-copied).
+		const roleDest = path.join(h.projectConfigDir, "roles", "researcher.yaml");
+		fs.appendFileSync(roleDest, "\n# SENTINEL-KEEP\n");
+
+		// Force the tool copy to fail: plant a FILE where the tools group dir must be created.
+		fs.writeFileSync(path.join(h.projectConfigDir, "tools"), "not a dir");
+
+		// Whole-pack update now declares the tool too → role refresh succeeds, tool copy fails.
+		assert.throws(() => h.service.update({
+			scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"),
+		}));
+
+		// Role restored to the exact pre-update bytes (sentinel survives).
+		assert.match(fs.readFileSync(roleDest, "utf-8"), /SENTINEL-KEEP/);
+		// Skill untouched.
+		assert.ok(fs.existsSync(path.join(h.projectConfigDir, "skills", "deep-research", "SKILL.md")));
+		// Provenance unchanged: still role + skill, mode pack.
+		const rec = h.projectProvenance().find("src-a", "research-pack")!;
+		assert.deepEqual(rec.entities.map((e) => e.type).sort(), ["role", "skill"]);
+		assert.equal(rec.installMode, "pack");
+		// No leftover backup files.
+		const leftovers = fs.readdirSync(path.join(h.projectConfigDir, "roles")).filter((f) => f.includes(".mp-bak-"));
+		assert.deepEqual(leftovers, []);
+	});
+});
+
+// ── Fix 5: subset-install provenance merge ──────────────────────────────────
+
+describe("marketplace fix: subset-install provenance merge", () => {
+	it("installing entity A then entity B keeps BOTH; pack uninstall removes BOTH", () => {
+		const h = makeHarness();
+		h.service.install({
+			scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"),
+			entities: [{ type: "role", name: "researcher" }], conflict: "fail",
+		});
+		h.service.install({
+			scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"),
+			entities: [{ type: "tool", name: "research" }], conflict: "fail",
+		});
+
+		const rec = h.projectProvenance().find("src-a", "research-pack")!;
+		assert.deepEqual(
+			rec.entities.map((e) => `${e.type}/${e.name}`).sort(),
+			["role/researcher", "tool/research"],
+		);
+		assert.equal(rec.installMode, "subset"); // skill still missing → not whole-pack
+
+		h.service.uninstall({ scope: "project", projectId: "p1", sourceId: "src-a", packId: "research-pack" });
+		assert.ok(!fs.existsSync(path.join(h.projectConfigDir, "roles", "researcher.yaml")));
+		assert.ok(!fs.existsSync(path.join(h.projectConfigDir, "tools", "research")));
+	});
+
+	it("subset installs that together cover all declared entities flip installMode to \"pack\"", () => {
+		const h = makeHarness();
+		for (const ref of [
+			{ type: "role" as const, name: "researcher" },
+			{ type: "tool" as const, name: "research" },
+			{ type: "skill" as const, name: "deep-research" },
+		]) {
+			h.service.install({
+				scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"),
+				entities: [ref], conflict: "fail",
+			});
+		}
+		const rec = h.projectProvenance().find("src-a", "research-pack")!;
+		assert.equal(rec.entities.length, 3);
+		assert.equal(rec.installMode, "pack");
+	});
+});

--- a/tests/marketplace-round3-fixes.test.ts
+++ b/tests/marketplace-round3-fixes.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit tests for the round-3 server-side marketplace review fixes:
+ *  1. Shared project-scope skills registration is reconciled against on-disk
+ *     reality — uninstalling one skill pack must not break sibling skill packs.
+ *  2. reconcile is the authoritative final step of every install/update/
+ *     uninstall/rollback, so a rolled-back skill-bearing update keeps the
+ *     skills registration.
+ *  3. Git add-source awaits the initial sync so packs are immediately visible.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { makeHarness, pack, localSource, tmpDir, SOURCE_A } from "./helpers/marketplace-harness.ts";
+import { parseCustomDirectories } from "../src/server/agent/config-directories.ts";
+
+const { MarketplaceService } = await import("../src/server/marketplace/service.ts");
+const { reconcileSkillDirRegistration } = await import("../src/server/marketplace/entity-handlers.ts");
+
+function makeService() {
+	const stateDir = tmpDir("bobbit-market-state-");
+	const systemConfigDir = tmpDir("bobbit-market-syscfg-");
+	const systemSkillsDir = tmpDir("bobbit-market-sysskills-");
+	const service = new MarketplaceService({
+		stateDir,
+		systemConfigDir,
+		systemSkillsDir,
+		resolveProject: () => null,
+	});
+	return { service, stateDir, systemConfigDir, systemSkillsDir };
+}
+
+/** The "skills"-typed config_directories entry for `dir`, or undefined. */
+function skillReg(store: Parameters<typeof parseCustomDirectories>[0], dir: string) {
+	return parseCustomDirectories(store).find((d) => path.resolve(d.path) === path.resolve(dir));
+}
+
+// ── Fix 1: shared skills registration survives single-pack uninstall ─────────
+
+describe("marketplace fix: shared project skills registration is reconciled", () => {
+	it("uninstalling one skill pack keeps a sibling skill pack resolvable AND registered", () => {
+		const h = makeHarness();
+		const skillsDir = path.join(h.projectConfigDir, "skills");
+
+		// Two packs each contribute a skill under the SAME shared skills dir.
+		h.service.install({ scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"), entities: null, conflict: "fail" });
+		h.service.install({ scope: "project", projectId: "p1", source: localSource(), pack: pack("notes-pack"), entities: null, conflict: "fail" });
+
+		assert.ok(fs.existsSync(path.join(skillsDir, "deep-research", "SKILL.md")));
+		assert.ok(fs.existsSync(path.join(skillsDir, "note-taker", "SKILL.md")));
+		assert.ok(skillReg(h.projectConfigStore, skillsDir)?.types.includes("skills"));
+
+		// Uninstall ONE pack — the sibling skill must still resolve AND stay registered.
+		h.service.uninstall({ scope: "project", projectId: "p1", sourceId: "src-a", packId: "notes-pack" });
+		assert.ok(!fs.existsSync(path.join(skillsDir, "note-taker")), "uninstalled skill removed");
+		assert.ok(fs.existsSync(path.join(skillsDir, "deep-research", "SKILL.md")), "sibling skill survives");
+		assert.ok(skillReg(h.projectConfigStore, skillsDir)?.types.includes("skills"), "registration remains while a skill survives");
+
+		// Uninstall the last skill pack → registration dropped + empty dir removed.
+		h.service.uninstall({ scope: "project", projectId: "p1", sourceId: "src-a", packId: "research-pack" });
+		assert.equal(skillReg(h.projectConfigStore, skillsDir), undefined, "registration dropped when no skills remain");
+		assert.ok(!fs.existsSync(skillsDir), "empty shared skills dir removed");
+	});
+
+	it("reconcileSkillDirRegistration is idempotent and matches on-disk reality", () => {
+		const h = makeHarness();
+		const skillsDir = path.join(h.projectConfigDir, "skills");
+		const ctx = {
+			scope: "project" as const,
+			projectId: "p1",
+			configDir: h.projectConfigDir,
+			skillInstallDir: skillsDir,
+			projectConfigStore: h.projectConfigStore,
+		};
+
+		// No skills on disk → reconcile is a no-op (no registration).
+		reconcileSkillDirRegistration(ctx);
+		assert.equal(skillReg(h.projectConfigStore, skillsDir), undefined);
+
+		// Add a skill on disk, then reconcile (twice) → registration present, stable.
+		fs.mkdirSync(path.join(skillsDir, "manual-skill"), { recursive: true });
+		fs.writeFileSync(path.join(skillsDir, "manual-skill", "SKILL.md"), "---\nname: manual-skill\n---\n");
+		reconcileSkillDirRegistration(ctx);
+		reconcileSkillDirRegistration(ctx);
+		const after = parseCustomDirectories(h.projectConfigStore).filter((d) => path.resolve(d.path) === path.resolve(skillsDir));
+		assert.equal(after.length, 1, "registration is added once, not duplicated");
+		assert.ok(after[0].types.includes("skills"));
+
+		// Remove the skill on disk, reconcile → registration dropped + dir removed.
+		fs.rmSync(path.join(skillsDir, "manual-skill"), { recursive: true, force: true });
+		reconcileSkillDirRegistration(ctx);
+		assert.equal(skillReg(h.projectConfigStore, skillsDir), undefined);
+		assert.ok(!fs.existsSync(skillsDir));
+	});
+
+	it("reconcile preserves a non-skills type registered on the same path", () => {
+		const h = makeHarness();
+		const skillsDir = path.join(h.projectConfigDir, "skills");
+		// Pre-register the same path with both skills + tools.
+		h.projectConfigStore.set("config_directories", JSON.stringify([{ path: path.resolve(skillsDir), types: ["skills", "tools"] }]));
+
+		const ctx = {
+			scope: "project" as const, projectId: "p1", configDir: h.projectConfigDir,
+			skillInstallDir: skillsDir, projectConfigStore: h.projectConfigStore,
+		};
+		// No skills on disk → only the "skills" type is dropped; "tools" survives.
+		reconcileSkillDirRegistration(ctx);
+		const entry = skillReg(h.projectConfigStore, skillsDir);
+		assert.ok(entry, "entry retained because another type remains");
+		assert.deepEqual(entry!.types, ["tools"]);
+	});
+});
+
+// ── Fix 2: rolled-back skill-bearing update keeps the registration ───────────
+
+describe("marketplace fix: rollback keeps the skills registration", () => {
+	it("a rolled-back whole-pack update restores the skill AND keeps it registered", () => {
+		const h = makeHarness();
+		const skillsDir = path.join(h.projectConfigDir, "skills");
+
+		// Install role + skill (whole-pack of a pack that, at the time, omits the tool).
+		const initial = pack("research-pack");
+		initial.entities = initial.entities.filter((e) => e.type !== "tool");
+		h.service.install({ scope: "project", projectId: "p1", source: localSource(), pack: initial, entities: null, conflict: "fail" });
+		assert.ok(skillReg(h.projectConfigStore, skillsDir)?.types.includes("skills"));
+
+		// Force the tool copy to fail mid-update: plant a FILE where the tools group dir must go.
+		fs.writeFileSync(path.join(h.projectConfigDir, "tools"), "not a dir");
+
+		// Whole-pack update now declares the tool too → skill refresh + tool copy fails.
+		assert.throws(() => h.service.update({
+			scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"),
+		}));
+
+		// Skill restored AND still registered — the rollback's intermediate uninstall
+		// must not leave the shared registration dropped.
+		assert.ok(fs.existsSync(path.join(skillsDir, "deep-research", "SKILL.md")), "skill restored after rollback");
+		assert.ok(skillReg(h.projectConfigStore, skillsDir)?.types.includes("skills"), "registration survives a rolled-back update");
+
+		// Provenance unchanged: still role + skill.
+		const rec = h.projectProvenance().find("src-a", "research-pack")!;
+		assert.deepEqual(rec.entities.map((e) => e.type).sort(), ["role", "skill"]);
+	});
+});
+
+// ── Fix 3: git add-source awaits the initial sync ───────────────────────────
+
+describe("marketplace fix: git source sync populates the cache before packs are read", () => {
+	it("an awaited sync of a file://-backed git source makes its packs immediately visible", async () => {
+		// Build a real git repo containing a pack.
+		const repo = tmpDir("bobbit-market-gitrepo-");
+		fs.cpSync(path.join(SOURCE_A, "research-pack"), path.join(repo, "research-pack"), { recursive: true });
+		const gitEnv = { ...process.env, GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@t", GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@t" };
+		const run = (...args: string[]) => execFileSync("git", args, { cwd: repo, env: gitEnv, stdio: "ignore" });
+		run("init", "-q");
+		run("add", "-A");
+		run("commit", "-q", "-m", "packs");
+
+		const { service } = makeService();
+		const src = service.addSource({ kind: "git", url: pathToFileURL(repo).href });
+
+		// Mirrors what the add-source route AWAITs: after sync, packs are visible.
+		const synced = await service.syncSource(src.id);
+		assert.equal(synced.lastSyncError, null, "sync should succeed");
+		assert.ok(synced.lastSyncedAt, "lastSyncedAt populated");
+		assert.ok(synced.lastSyncCommit, "lastSyncCommit populated");
+
+		const packs = service.listPacks("system", null);
+		assert.ok(packs.some((p) => p.packId === "research-pack"), "pack visible immediately after awaited sync");
+	});
+});

--- a/tests/marketplace-round3-fixes.test.ts
+++ b/tests/marketplace-round3-fixes.test.ts
@@ -117,20 +117,22 @@ describe("marketplace fix: shared project skills registration is reconciled", ()
 // ── Fix 2: rolled-back skill-bearing update keeps the registration ───────────
 
 describe("marketplace fix: rollback keeps the skills registration", () => {
-	it("a rolled-back whole-pack update restores the skill AND keeps it registered", () => {
+	it("a rolled-back update restores the skill AND keeps it registered", () => {
 		const h = makeHarness();
 		const skillsDir = path.join(h.projectConfigDir, "skills");
 
-		// Install role + skill (whole-pack of a pack that, at the time, omits the tool).
-		const initial = pack("research-pack");
-		initial.entities = initial.entities.filter((e) => e.type !== "tool");
-		h.service.install({ scope: "project", projectId: "p1", source: localSource(), pack: initial, entities: null, conflict: "fail" });
+		// Install skill + tool (as a subset) so the skill is refreshed — and
+		// intermediately uninstalled during rollback — BEFORE the failing tool.
+		h.service.install({ scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"), entities: [{ type: "skill", name: "deep-research" }], conflict: "fail" });
+		h.service.install({ scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"), entities: [{ type: "tool", name: "research" }], conflict: "fail" });
 		assert.ok(skillReg(h.projectConfigStore, skillsDir)?.types.includes("skills"));
 
-		// Force the tool copy to fail mid-update: plant a FILE where the tools group dir must go.
+		// Sabotage the tool refresh: drop its installed dir and plant a FILE where
+		// the tools group dir must be re-created so the copy throws mid-update.
+		fs.rmSync(path.join(h.projectConfigDir, "tools"), { recursive: true, force: true });
 		fs.writeFileSync(path.join(h.projectConfigDir, "tools"), "not a dir");
 
-		// Whole-pack update now declares the tool too → skill refresh + tool copy fails.
+		// Update refreshes tracked entities (skill then tool) → skill refresh succeeds, tool fails.
 		assert.throws(() => h.service.update({
 			scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"),
 		}));
@@ -140,9 +142,9 @@ describe("marketplace fix: rollback keeps the skills registration", () => {
 		assert.ok(fs.existsSync(path.join(skillsDir, "deep-research", "SKILL.md")), "skill restored after rollback");
 		assert.ok(skillReg(h.projectConfigStore, skillsDir)?.types.includes("skills"), "registration survives a rolled-back update");
 
-		// Provenance unchanged: still role + skill.
+		// Provenance unchanged: still skill + tool.
 		const rec = h.projectProvenance().find("src-a", "research-pack")!;
-		assert.deepEqual(rec.entities.map((e) => e.type).sort(), ["role", "skill"]);
+		assert.deepEqual(rec.entities.map((e) => e.type).sort(), ["skill", "tool"]);
 	});
 });
 

--- a/tests/marketplace-round5-fixes.test.ts
+++ b/tests/marketplace-round5-fixes.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit tests for the round-5 server-side marketplace fixes:
+ *  1. update() refreshes ONLY tracked entities for BOTH pack and subset installs
+ *     (no auto-add of newly-declared entities; install intent preserved).
+ *  2. PackSummary / PackDetail expose `newEntitiesAvailable` (declared entities
+ *     not in the install record).
+ *  3. Drift detection via per-entity contentHash — edited files report
+ *     `drifted`; legacy records without a hash fall back to existence-only.
+ *  4. URL credential redaction also strips query-string / fragment tokens.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { makeHarness, pack, localSource, tmpDir, SOURCE_A } from "./helpers/marketplace-harness.ts";
+
+const { MarketplaceService } = await import("../src/server/marketplace/service.ts");
+const { redactGitUrl } = await import("../src/server/marketplace/source-registry.ts");
+
+function makeService() {
+	const stateDir = tmpDir("bobbit-market-state-");
+	const systemConfigDir = tmpDir("bobbit-market-syscfg-");
+	const systemSkillsDir = tmpDir("bobbit-market-sysskills-");
+	const service = new MarketplaceService({
+		stateDir,
+		systemConfigDir,
+		systemSkillsDir,
+		resolveProject: () => null,
+	});
+	return { service, stateDir, systemConfigDir, systemSkillsDir };
+}
+
+const findPack = (service: InstanceType<typeof MarketplaceService>, packId: string) =>
+	service.listPacks("system", null).find((p) => p.packId === packId)!;
+
+// ── Fix 1: update refreshes only tracked entities (pack AND subset) ──────────
+
+describe("marketplace fix: update refreshes only tracked entities", () => {
+	it("a whole-pack install whose tracked set is partial does NOT auto-add the rest on update", () => {
+		const h = makeHarness();
+		// Whole-pack install of a pack that, at the time, declared only the role.
+		const initial = pack("research-pack");
+		initial.entities = initial.entities.filter((e) => e.type === "role");
+		h.service.install({ scope: "project", projectId: "p1", source: localSource(), pack: initial, entities: null, conflict: "fail" });
+
+		// Upstream now declares role + tool + skill. Update refreshes the role only.
+		h.service.update({ scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack") });
+		const rec = h.projectProvenance().find("src-a", "research-pack")!;
+		assert.deepEqual(rec.entities.map((e) => e.type), ["role"]);
+		assert.equal(rec.installMode, "pack", "install intent preserved");
+		assert.ok(!fs.existsSync(path.join(h.projectConfigDir, "tools", "research")));
+		assert.ok(!fs.existsSync(path.join(h.projectConfigDir, "skills", "deep-research")));
+	});
+
+	it("update drops a tracked entity the pack no longer declares (no orphans)", () => {
+		const h = makeHarness();
+		h.service.install({ scope: "project", projectId: "p1", source: localSource(), pack: pack("research-pack"), entities: null, conflict: "fail" });
+
+		// Upstream drops the tool + skill.
+		const trimmed = pack("research-pack");
+		trimmed.entities = trimmed.entities.filter((e) => e.type === "role");
+		h.service.update({ scope: "project", projectId: "p1", source: localSource(), pack: trimmed });
+
+		const rec = h.projectProvenance().find("src-a", "research-pack")!;
+		assert.deepEqual(rec.entities.map((e) => e.type), ["role"]);
+		assert.ok(fs.existsSync(path.join(h.projectConfigDir, "roles", "researcher.yaml")));
+		assert.ok(!fs.existsSync(path.join(h.projectConfigDir, "tools", "research")));
+		assert.ok(!fs.existsSync(path.join(h.projectConfigDir, "skills", "deep-research")));
+	});
+});
+
+// ── Fix 2: newEntitiesAvailable ─────────────────────────────────────────────
+
+describe("marketplace fix: newEntitiesAvailable", () => {
+	it("is 0 when the pack is not installed", () => {
+		const { service } = makeService();
+		const src = service.addSource({ kind: "local", path: SOURCE_A });
+		assert.equal(findPack(service, "research-pack").newEntitiesAvailable, 0);
+		assert.equal(service.getPackDetail(src.id, "research-pack", "system", null)!.newEntitiesAvailable, 0);
+	});
+
+	it("counts declared entities missing from a subset install (summary + detail)", () => {
+		const { service } = makeService();
+		const src = service.addSource({ kind: "local", path: SOURCE_A });
+		service.installPack({
+			sourceId: src.id, packId: "research-pack", scope: "system", projectId: null,
+			entities: [{ type: "role", name: "researcher" }], conflict: "fail",
+		});
+		assert.equal(findPack(service, "research-pack").newEntitiesAvailable, 2); // tool + skill
+		assert.equal(service.getPackDetail(src.id, "research-pack", "system", null)!.newEntitiesAvailable, 2);
+	});
+
+	it("is 0 after a whole-pack install (everything tracked)", () => {
+		const { service } = makeService();
+		const src = service.addSource({ kind: "local", path: SOURCE_A });
+		service.installPack({ sourceId: src.id, packId: "research-pack", scope: "system", projectId: null, entities: null, conflict: "fail" });
+		assert.equal(findPack(service, "research-pack").newEntitiesAvailable, 0);
+	});
+});
+
+// ── Fix 3: drift detection via per-entity contentHash ───────────────────────
+
+describe("marketplace fix: drift detection via contentHash", () => {
+	it("reports drifted when an installed file is edited locally", () => {
+		const { service, systemConfigDir } = makeService();
+		const src = service.addSource({ kind: "local", path: SOURCE_A });
+		service.installPack({ sourceId: src.id, packId: "roles-only-pack", scope: "system", projectId: null, entities: null, conflict: "fail" });
+		assert.equal(findPack(service, "roles-only-pack").installStatus, "installed");
+
+		fs.appendFileSync(path.join(systemConfigDir, "roles", "analyst.yaml"), "\n# locally edited\n");
+		assert.equal(findPack(service, "roles-only-pack").installStatus, "drifted");
+		assert.equal(service.getPackDetail(src.id, "roles-only-pack", "system", null)!.installStatus, "drifted");
+	});
+
+	it("reports drifted when an installed file is missing", () => {
+		const { service, systemConfigDir } = makeService();
+		const src = service.addSource({ kind: "local", path: SOURCE_A });
+		service.installPack({ sourceId: src.id, packId: "roles-only-pack", scope: "system", projectId: null, entities: null, conflict: "fail" });
+
+		fs.rmSync(path.join(systemConfigDir, "roles", "analyst.yaml"), { force: true });
+		assert.equal(findPack(service, "roles-only-pack").installStatus, "drifted");
+	});
+
+	it("legacy records without contentHash fall back to existence-only (edits not flagged)", () => {
+		const { service, systemConfigDir } = makeService();
+		const src = service.addSource({ kind: "local", path: SOURCE_A });
+		service.installPack({ sourceId: src.id, packId: "roles-only-pack", scope: "system", projectId: null, entities: null, conflict: "fail" });
+
+		// Simulate a record written before the contentHash field existed.
+		const file = path.join(systemConfigDir, "marketplace", "installed.json");
+		const data = JSON.parse(fs.readFileSync(file, "utf-8"));
+		for (const inst of data.installs) for (const e of inst.entities) delete e.contentHash;
+		fs.writeFileSync(file, JSON.stringify(data, null, 2));
+
+		fs.appendFileSync(path.join(systemConfigDir, "roles", "analyst.yaml"), "\n# edited\n");
+		assert.equal(findPack(service, "roles-only-pack").installStatus, "installed");
+	});
+
+	it("records a per-entity contentHash at install time", () => {
+		const { service, systemConfigDir } = makeService();
+		service.addSource({ kind: "local", path: SOURCE_A });
+		service.installPack({ sourceId: service.listSources()[0].id, packId: "research-pack", scope: "system", projectId: null, entities: null, conflict: "fail" });
+		const data = JSON.parse(fs.readFileSync(path.join(systemConfigDir, "marketplace", "installed.json"), "utf-8"));
+		assert.ok(data.installs[0].entities.every((e: { contentHash?: string }) => typeof e.contentHash === "string" && e.contentHash.length > 0));
+	});
+});
+
+// ── Fix 4: query-string / fragment credential redaction ─────────────────────
+
+describe("marketplace fix: redactGitUrl strips query-string + fragment tokens", () => {
+	it("strips userinfo, sensitive query params, and a token-bearing fragment", () => {
+		assert.equal(redactGitUrl("https://user:ghp_x@github.com/acme/packs.git"), "https://github.com/acme/packs.git");
+		assert.equal(redactGitUrl("https://github.com/acme/packs.git?token=ghp_secret"), "https://github.com/acme/packs.git");
+		assert.equal(redactGitUrl("https://github.com/acme/packs.git?access_token=abc&ref=main"), "https://github.com/acme/packs.git?ref=main");
+		assert.equal(redactGitUrl("https://github.com/acme/packs.git#access_token=abc"), "https://github.com/acme/packs.git");
+	});
+
+	it("leaves credential-free URLs and non-URL forms unchanged", () => {
+		assert.equal(redactGitUrl("https://github.com/acme/packs.git"), "https://github.com/acme/packs.git");
+		assert.equal(redactGitUrl("https://github.com/acme/packs.git?ref=v1#readme"), "https://github.com/acme/packs.git?ref=v1#readme");
+		assert.equal(redactGitUrl("git@github.com:acme/packs.git"), "git@github.com:acme/packs.git");
+	});
+
+	it("addSource / listSources never surface a query-string token (storage keeps it for auth)", () => {
+		const { service, stateDir } = makeService();
+		const added = service.addSource({ kind: "git", url: "https://github.com/acme/packs.git?token=ghp_secret", label: "packs" });
+		assert.ok(!added.url!.includes("ghp_secret"));
+		assert.equal(service.listSources()[0].url, "https://github.com/acme/packs.git");
+
+		const raw = fs.readFileSync(path.join(stateDir, "marketplace", "sources.json"), "utf-8");
+		assert.ok(raw.includes("ghp_secret"), "storage retains the credential for auth");
+	});
+});

--- a/tests/marketplace-round6-fixes.test.ts
+++ b/tests/marketplace-round6-fixes.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Unit tests for the round-6 server-side marketplace review fixes:
+ *  1. update() REMOVES the provenance record (not an empty upsert) when no
+ *     tracked entity remains declared; computeInstallStatus treats an
+ *     empty-entities record as not-installed.
+ *  2. doCopy cleans up the partially-written failing entity's dest on a
+ *     mid-copy error (no half-written entity left behind).
+ *  3. parseInstallScope rejects an invalid/misspelled scope and a project
+ *     scope without a projectId.
+ *  4. scanSource rejects duplicate pack ids within one source (every colliding
+ *     pack is marked invalid).
+ *  5. the default git source label is derived from the REDACTED url (a token in
+ *     the url never leaks into the surfaced label).
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { makeHarness, localSource, tmpDir } from "./helpers/marketplace-harness.ts";
+
+const { computeInstallStatus } = await import("../src/server/marketplace/provenance-store.ts");
+const { scanPackDir, scanSource } = await import("../src/server/marketplace/pack-scanner.ts");
+const { parseInstallScope } = await import("../src/server/marketplace/service.ts");
+const { SourceRegistry } = await import("../src/server/marketplace/source-registry.ts");
+import type { ProvenanceRecord, SourceRecord } from "../src/server/marketplace/types.ts";
+
+/** Write a minimal single-role pack into a fresh temp dir; returns the pack dir. */
+function writeRolePack(packId: string, roleName: string): string {
+	const dir = path.join(tmpDir("bobbit-market-pack-"), packId);
+	fs.mkdirSync(path.join(dir, "roles"), { recursive: true });
+	fs.writeFileSync(
+		path.join(dir, "pack.yaml"),
+		`apiVersion: 1\nid: ${packId}\nname: ${packId}\ndescription: test\nversion: 1.0.0\ncontents:\n  roles:\n    - ${roleName}\n`,
+	);
+	fs.writeFileSync(path.join(dir, "roles", `${roleName}.yaml`), `name: ${roleName}\nprompt: hi\n`);
+	return dir;
+}
+
+/** Rewrite a role pack in place to declare a different role. */
+function rewriteRolePack(dir: string, packId: string, roleName: string): void {
+	fs.writeFileSync(
+		path.join(dir, "pack.yaml"),
+		`apiVersion: 1\nid: ${packId}\nname: ${packId}\ndescription: test\nversion: 2.0.0\ncontents:\n  roles:\n    - ${roleName}\n`,
+	);
+	fs.writeFileSync(path.join(dir, "roles", `${roleName}.yaml`), `name: ${roleName}\nprompt: hi\n`);
+}
+
+function trySymlink(target: string, linkPath: string): boolean {
+	try { fs.symlinkSync(target, linkPath); return true; } catch { return false; }
+}
+
+// ── Fix 1: update removes the record when nothing tracked remains ────────────
+
+describe("marketplace fix: update removes record with no tracked entities", () => {
+	it("removes the provenance record (not an empty upsert) when the pack replaces its only entity", () => {
+		const h = makeHarness();
+		const src = localSource();
+		const dir = writeRolePack("mp", "r1");
+
+		h.service.install({ scope: "system", projectId: null, source: src, pack: scanPackDir(src.id, dir), entities: null, conflict: "fail" });
+		assert.ok(h.systemProvenance().find(src.id, "mp"), "installed record present");
+		assert.ok(fs.existsSync(path.join(h.systemConfigDir, "roles", "r1.yaml")));
+
+		// Upstream replaces r1 with r2 — none of the TRACKED entities (r1) remain.
+		rewriteRolePack(dir, "mp", "r2");
+		const outcome = h.service.update({ scope: "system", projectId: null, source: src, pack: scanPackDir(src.id, dir) });
+
+		assert.equal(outcome.record, null, "outcome reports no record");
+		assert.equal(h.systemProvenance().find(src.id, "mp"), undefined, "record removed, not empty-upserted");
+		assert.ok(!fs.existsSync(path.join(h.systemConfigDir, "roles", "r1.yaml")), "orphaned r1 removed");
+		// r2 is newly-declared — update never auto-adds it.
+		assert.ok(!fs.existsSync(path.join(h.systemConfigDir, "roles", "r2.yaml")));
+	});
+
+	it("computeInstallStatus treats an empty-entities record as not-installed", () => {
+		const src: SourceRecord = localSource();
+		const emptyRecord = { sourceId: src.id, packId: "mp", entities: [] } as unknown as ProvenanceRecord;
+		assert.equal(computeInstallStatus(src, emptyRecord, null), "not-installed");
+		assert.equal(computeInstallStatus(src, undefined, null), "not-installed");
+	});
+});
+
+// ── Fix 2: doCopy cleans up the partial dest of a mid-copy failure ───────────
+
+describe("marketplace fix: doCopy cleans up partially-written failing entity", () => {
+	it("removes the failing tool group's dest dir when copy throws mid-write", (t) => {
+		const h = makeHarness();
+		const src = localSource();
+		// A valid tool pack scanned BEFORE we inject a symlink, so install proceeds
+		// then fails inside copyNoSymlinks, leaving a partial dest to clean up.
+		const dir = path.join(tmpDir("bobbit-market-pack-"), "tp");
+		const toolDir = path.join(dir, "tools", "mytool");
+		fs.mkdirSync(toolDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(dir, "pack.yaml"),
+			"apiVersion: 1\nid: tp\nname: tp\ndescription: test\nversion: 1.0.0\ncontents:\n  tools:\n    - mytool\n",
+		);
+		fs.writeFileSync(path.join(toolDir, "a.yaml"), "name: mytool\ndescription: x\n");
+
+		const scanned = scanPackDir(src.id, dir);
+		assert.ok(scanned.valid, "pack scans valid before symlink injection");
+
+		// Inject a symlink AFTER scan so install's copyNoSymlinks throws mid-copy.
+		if (!trySymlink(path.join(dir, "pack.yaml"), path.join(toolDir, "z-link.yaml"))) {
+			t.skip("platform forbids symlink creation");
+			return;
+		}
+
+		const dest = path.join(h.systemConfigDir, "tools", "mytool");
+		assert.throws(
+			() => h.service.install({ scope: "system", projectId: null, source: src, pack: scanned, entities: null, conflict: "fail" }),
+			/symlink/i,
+		);
+		assert.ok(!fs.existsSync(dest), "partially-written tool dest cleaned up after failure");
+		assert.equal(h.systemProvenance().find(src.id, "tp"), undefined, "no provenance recorded for failed install");
+	});
+});
+
+// ── Fix 3: scope validation ─────────────────────────────────────────────────
+
+describe("marketplace fix: parseInstallScope rejects invalid scope", () => {
+	it("defaults a missing/empty scope to system", () => {
+		assert.deepEqual(parseInstallScope(undefined, undefined), { scope: "system", projectId: null });
+		assert.deepEqual(parseInstallScope("", null), { scope: "system", projectId: null });
+	});
+
+	it("rejects a misspelled scope", () => {
+		const r = parseInstallScope("systom", null);
+		assert.ok("error" in r && /scope must be/i.test(r.error));
+	});
+
+	it("rejects project scope without a projectId", () => {
+		const r = parseInstallScope("project", null);
+		assert.ok("error" in r && /requires projectId/i.test(r.error));
+		const r2 = parseInstallScope("project", "  ");
+		assert.ok("error" in r2 && /requires projectId/i.test(r2.error));
+	});
+
+	it("accepts a well-formed project scope and ignores projectId for system", () => {
+		assert.deepEqual(parseInstallScope("project", "p1"), { scope: "project", projectId: "p1" });
+		assert.deepEqual(parseInstallScope("system", "p1"), { scope: "system", projectId: null });
+	});
+});
+
+// ── Fix 4: duplicate pack ids within one source ──────────────────────────────
+
+describe("marketplace fix: scanSource rejects duplicate pack ids", () => {
+	it("marks every pack in a colliding id group invalid", () => {
+		const root = tmpDir("bobbit-market-src-");
+		for (const subdir of ["alpha", "beta"]) {
+			const dir = path.join(root, subdir);
+			fs.mkdirSync(path.join(dir, "roles"), { recursive: true });
+			fs.writeFileSync(
+				path.join(dir, "pack.yaml"),
+				`apiVersion: 1\nid: dup\nname: ${subdir}\ndescription: test\nversion: 1.0.0\ncontents:\n  roles:\n    - r\n`,
+			);
+			fs.writeFileSync(path.join(dir, "roles", "r.yaml"), "name: r\nprompt: hi\n");
+		}
+		// A non-colliding pack stays valid.
+		const okDir = path.join(root, "gamma");
+		fs.mkdirSync(path.join(okDir, "roles"), { recursive: true });
+		fs.writeFileSync(
+			path.join(okDir, "pack.yaml"),
+			"apiVersion: 1\nid: solo\nname: gamma\ndescription: test\nversion: 1.0.0\ncontents:\n  roles:\n    - r\n",
+		);
+		fs.writeFileSync(path.join(okDir, "roles", "r.yaml"), "name: r\nprompt: hi\n");
+
+		const packs = scanSource("src-x", root);
+		const dups = packs.filter((p) => p.packId === "dup");
+		assert.equal(dups.length, 2);
+		for (const p of dups) {
+			assert.equal(p.valid, false);
+			assert.match(p.error ?? "", /duplicate pack id/i);
+		}
+		assert.equal(packs.find((p) => p.packId === "solo")!.valid, true);
+	});
+});
+
+// ── Fix 5: default git label derived from the redacted url ───────────────────
+
+describe("marketplace fix: default git label is derived from the redacted url", () => {
+	it("does not leak a userinfo token into the default label", () => {
+		const reg = new SourceRegistry(tmpDir("bobbit-market-state-"));
+		const rec = reg.add({ kind: "git", url: "https://user:ghp_secret@github.com/acme/my-packs.git" });
+		assert.equal(rec.label, "my-packs");
+		assert.ok(!rec.label!.includes("ghp_secret"));
+	});
+
+	it("does not leak a query-string token into the default label", () => {
+		const reg = new SourceRegistry(tmpDir("bobbit-market-state-"));
+		const rec = reg.add({ kind: "git", url: "https://github.com/acme/my-packs.git?token=ghp_secret" });
+		assert.equal(rec.label, "my-packs");
+		assert.ok(!rec.label!.includes("ghp_secret"));
+	});
+});

--- a/tests/marketplace-round7-fixes.test.ts
+++ b/tests/marketplace-round7-fixes.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for the round-7 server-side marketplace review fixes:
+ *  1. HIGH — an `overwrite` install supersedes another pack's provenance for the
+ *     same entity: ownership transfers to the installing pack, the prior pack's
+ *     record drops that entity (and is removed entirely if emptied), so
+ *     uninstall stays symmetric (uninstalling the prior pack never deletes an
+ *     entity it no longer owns).
+ *  2. HIGH — sync-error redaction routes through the shared `redactGitUrl`, so a
+ *     `?token=`/`#token=` credential in a git url can't leak into lastSyncError
+ *     (previously only userinfo was stripped).
+ *  3. MED — a SUPPORTED contents key whose value is not an array makes the pack
+ *     invalid, rather than being silently coerced to [].
+ *  4. MED — role validation requires the YAML `name` to equal the declared
+ *     entity name (the cascade resolution key).
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { makeHarness, localSource, tmpDir } from "./helpers/marketplace-harness.ts";
+
+const { scanPackDir, scanSource } = await import("../src/server/marketplace/pack-scanner.ts");
+const { GitSourceBackend } = await import("../src/server/marketplace/sync-service.ts");
+const { redactGitUrl } = await import("../src/server/marketplace/git-url-redact.ts");
+import type { SourceRecord } from "../src/server/marketplace/types.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SOURCE_B = path.join(__dirname, "fixtures", "marketplace", "source-b");
+
+/** Write a pack declaring one role per supplied name; returns the pack dir. */
+function writeRolePack(packId: string, roleNames: string[]): string {
+	const dir = path.join(tmpDir("bobbit-market-pack-"), packId);
+	fs.mkdirSync(path.join(dir, "roles"), { recursive: true });
+	const roleList = roleNames.map((n) => `    - ${n}`).join("\n");
+	fs.writeFileSync(
+		path.join(dir, "pack.yaml"),
+		`apiVersion: 1\nid: ${packId}\nname: ${packId}\ndescription: test\nversion: 1.0.0\ncontents:\n  roles:\n${roleList}\n`,
+	);
+	for (const n of roleNames) {
+		fs.writeFileSync(path.join(dir, "roles", `${n}.yaml`), `name: ${n}\nprompt: from ${packId}\n`);
+	}
+	return dir;
+}
+
+function gitSource(url: string): SourceRecord {
+	return {
+		id: "git-1", kind: "git", url, ref: null, path: null, label: "git",
+		addedAt: 0, lastSyncedAt: null, lastSyncCommit: null, lastSyncError: null,
+	};
+}
+
+// ── Fix 1: overwrite install supersedes another pack's provenance ────────────
+
+describe("marketplace fix: overwrite install supersedes another pack's entity", () => {
+	it("transfers ownership and removes an emptied prior record (uninstall stays symmetric)", () => {
+		const h = makeHarness();
+		const src = localSource();
+		const roleDest = path.join(h.systemConfigDir, "roles", "shared.yaml");
+
+		// Pack A installs the single role "shared".
+		const dirA = writeRolePack("pack-a", ["shared"]);
+		h.service.install({ scope: "system", projectId: null, source: src, pack: scanPackDir(src.id, dirA), entities: null, conflict: "fail" });
+		assert.ok(h.systemProvenance().find(src.id, "pack-a"));
+		assert.match(fs.readFileSync(roleDest, "utf-8"), /from pack-a/);
+
+		// Pack B overwrites "shared".
+		const dirB = writeRolePack("pack-b", ["shared"]);
+		h.service.install({ scope: "system", projectId: null, source: src, pack: scanPackDir(src.id, dirB), entities: null, conflict: "overwrite" });
+		assert.match(fs.readFileSync(roleDest, "utf-8"), /from pack-b/, "B's bytes won the overwrite");
+
+		// A's record is emptied by the supersede → dropped entirely; B owns the entity.
+		assert.equal(h.systemProvenance().find(src.id, "pack-a"), undefined, "emptied prior record removed");
+		const recB = h.systemProvenance().find(src.id, "pack-b")!;
+		assert.deepEqual(recB.entities.map((e) => e.name), ["shared"]);
+
+		// Uninstalling A must NOT delete the entity it no longer owns.
+		h.service.uninstall({ scope: "system", projectId: null, sourceId: src.id, packId: "pack-a" });
+		assert.ok(fs.existsSync(roleDest), "B's file survives A's uninstall");
+
+		// Uninstalling B (the real owner) removes it.
+		h.service.uninstall({ scope: "system", projectId: null, sourceId: src.id, packId: "pack-b" });
+		assert.ok(!fs.existsSync(roleDest), "owner uninstall removes the file");
+	});
+
+	it("keeps the prior record's other entities while dropping only the superseded one", () => {
+		const h = makeHarness();
+		const src = localSource();
+		const uniqueDest = path.join(h.systemConfigDir, "roles", "only-a.yaml");
+		const sharedDest = path.join(h.systemConfigDir, "roles", "shared.yaml");
+
+		const dirA = writeRolePack("pack-a", ["only-a", "shared"]);
+		h.service.install({ scope: "system", projectId: null, source: src, pack: scanPackDir(src.id, dirA), entities: null, conflict: "fail" });
+
+		const dirB = writeRolePack("pack-b", ["shared"]);
+		h.service.install({ scope: "system", projectId: null, source: src, pack: scanPackDir(src.id, dirB), entities: null, conflict: "overwrite" });
+
+		const recA = h.systemProvenance().find(src.id, "pack-a")!;
+		assert.deepEqual(recA.entities.map((e) => e.name).sort(), ["only-a"], "shared superseded, only-a retained");
+
+		// Uninstall A removes only its own remaining entity; B's shared survives.
+		h.service.uninstall({ scope: "system", projectId: null, sourceId: src.id, packId: "pack-a" });
+		assert.ok(!fs.existsSync(uniqueDest), "A's unique entity removed");
+		assert.ok(fs.existsSync(sharedDest), "B's shared entity survives");
+	});
+});
+
+// ── Fix 2: sync-error redaction uses redactGitUrl ────────────────────────────
+
+describe("marketplace fix: sync-error redaction strips query/fragment tokens", () => {
+	it("redactGitUrl drops a ?token= query param", () => {
+		assert.equal(redactGitUrl("https://github.com/acme/p.git?token=ghp_secret"), "https://github.com/acme/p.git");
+	});
+
+	it("does not leak a query-string token into lastSyncError on a failed clone", async () => {
+		const backend = new GitSourceBackend();
+		const cache = path.join(tmpDir("bobbit-market-cache-"), "clone");
+		// A file:// url to a nonexistent repo fails fast (offline, no network),
+		// and the failing argv carries the token verbatim into the error message.
+		const url = `file:///no/such/marketplace-repo-xyz?token=ghp_secret`;
+		const res = await backend.sync(gitSource(url), cache);
+		assert.notEqual(res.error, null, "clone of a nonexistent repo fails");
+		assert.ok(!res.error!.includes("ghp_secret"), `token leaked: ${res.error}`);
+	});
+});
+
+// ── Fix 3: malformed supported contents key (non-array) → invalid ────────────
+
+describe("marketplace fix: non-array supported contents key invalidates the pack", () => {
+	it("rejects a pack whose `tools` contents value is a string", () => {
+		const p = scanPackDir("src-b", path.join(SOURCE_B, "bad-contents-pack"));
+		assert.equal(p.valid, false);
+		assert.match(p.error ?? "", /tools: contents value must be an array/i);
+	});
+
+	it("keeps a valid sibling pack valid while invalidating the malformed one", () => {
+		const packs = scanSource("src-b", SOURCE_B);
+		assert.equal(packs.find((p) => p.packId === "bad-contents-pack")!.valid, false);
+		assert.equal(packs.find((p) => p.packId === "good-pack")!.valid, true);
+	});
+});
+
+// ── Fix 4: role YAML name must equal the declared entity name ─────────────────
+
+describe("marketplace fix: role YAML name must match declared entity name", () => {
+	it("rejects a role whose YAML name disagrees with the declared name", () => {
+		const p = scanPackDir("src-b", path.join(SOURCE_B, "role-name-mismatch-pack"));
+		assert.equal(p.valid, false);
+		assert.match(p.error ?? "", /declares name "something-else" but must match entity name "mismatch"/i);
+	});
+
+	it("accepts a role whose YAML name matches the declared name", () => {
+		const p = scanPackDir("src-b", path.join(SOURCE_B, "good-pack"));
+		assert.equal(p.valid, true);
+		assert.deepEqual(p.entities.map((e) => `${e.type}/${e.name}`), ["role/helper"]);
+	});
+});

--- a/tests/marketplace-round8-fixes.test.ts
+++ b/tests/marketplace-round8-fixes.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Round-8 security fixes:
+ *  1. HIGH — token-as-username URLs (`https://ghp_xxx@host/repo.git`) are now
+ *     scrubbed: `gitUrlSecrets()` returns `parsed.username`, so
+ *     `redactGitUrlInText` removes the token even when git reformats the url in
+ *     its stderr (trailing slash, decoded, scheme-less).
+ *  2. MED — `sources.json` is written with mode 0o600 (it stores original git
+ *     URLs WITH embedded credentials), with a guarded chmod that does not throw
+ *     on platforms/filesystems that ignore POSIX modes.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const { gitUrlSecrets, redactGitUrl, redactGitUrlInText } =
+	await import("../src/server/marketplace/git-url-redact.ts");
+const { SourceRegistry, redactSourceUrl } = await import("../src/server/marketplace/source-registry.ts");
+
+function tmp(): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-market-r8-"));
+}
+
+// ── Fix 1: token-as-username redaction ───────────────────────────────────────
+
+describe("marketplace fix: token-as-username is redacted", () => {
+	const url = "https://ghp_SECRET@github.com/acme/packs.git";
+
+	it("gitUrlSecrets() includes the username token", () => {
+		assert.ok(gitUrlSecrets(url).includes("ghp_SECRET"));
+	});
+
+	it("redactGitUrl() strips the userinfo (no token in the displayed url)", () => {
+		const out = redactGitUrl(url);
+		assert.equal(out, "https://github.com/acme/packs.git");
+		assert.ok(!out.includes("ghp_SECRET"));
+	});
+
+	it("redactGitUrlInText() scrubs the token even when git reformats the url", () => {
+		// git rewrites the url in stderr: decoded, trailing slash, no scheme, etc.
+		const stderr =
+			"fatal: unable to access 'https://ghp_SECRET@github.com/acme/packs.git/': " +
+			"The requested URL returned error: 403 for ghp_SECRET@github.com";
+		const out = redactGitUrlInText(stderr, url);
+		assert.ok(!out.includes("ghp_SECRET"), `token leaked: ${out}`);
+	});
+
+	it("redactSourceUrl() returns a DTO without the token", () => {
+		const reg = new SourceRegistry(tmp());
+		const rec = reg.add({ kind: "git", url });
+		assert.ok(!String(redactSourceUrl(rec).url).includes("ghp_SECRET"));
+	});
+});
+
+// ── Fix 2: sources.json written 0o600 ────────────────────────────────────────
+
+describe("marketplace fix: sources.json is owner-only (0o600)", () => {
+	it("applies 0o600 where supported and does not throw on platforms that ignore it", () => {
+		const stateDir = tmp();
+		const reg = new SourceRegistry(stateDir);
+		// add() persists — must not throw on any platform.
+		reg.add({ kind: "git", url: "https://ghp_SECRET@github.com/acme/packs.git" });
+
+		const file = path.join(stateDir, "marketplace", "sources.json");
+		assert.ok(fs.existsSync(file));
+
+		// On POSIX filesystems the mode must be exactly owner read/write. Windows
+		// and some filesystems ignore POSIX modes, so only assert there.
+		if (process.platform !== "win32") {
+			const mode = fs.statSync(file).mode & 0o777;
+			assert.equal(mode, 0o600, `expected 0o600, got 0o${mode.toString(8)}`);
+		}
+	});
+
+	it("preserves the credential-bearing url on disk (git needs it to auth)", () => {
+		const stateDir = tmp();
+		const reg = new SourceRegistry(stateDir);
+		reg.add({ kind: "git", url: "https://ghp_SECRET@github.com/acme/packs.git" });
+		const file = path.join(stateDir, "marketplace", "sources.json");
+		const onDisk = fs.readFileSync(file, "utf-8");
+		assert.ok(onDisk.includes("ghp_SECRET"), "stored url must keep its credentials for git auth");
+	});
+});

--- a/tests/marketplace-source-registry.test.ts
+++ b/tests/marketplace-source-registry.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for the marketplace source registry (§3): add/remove/list
+ * round-trips through sources.json, id assignment, and local-path validation.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const { SourceRegistry, SourceRegistryError } =
+	await import("../src/server/marketplace/source-registry.ts");
+
+function tmp(): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-market-reg-"));
+}
+
+describe("marketplace source registry", () => {
+	it("adds a local source, assigns an id, and persists to sources.json", () => {
+		const stateDir = tmp();
+		const localPath = tmp();
+		const reg = new SourceRegistry(stateDir);
+		const rec = reg.add({ kind: "local", path: localPath });
+		assert.match(rec.id, /^[a-f0-9]{8}$/);
+		assert.equal(rec.kind, "local");
+		assert.equal(rec.path, localPath);
+		assert.equal(rec.label, path.basename(localPath));
+
+		// Round-trip: a fresh registry on the same stateDir sees it.
+		const reg2 = new SourceRegistry(stateDir);
+		assert.equal(reg2.list().length, 1);
+		assert.equal(reg2.get(rec.id)?.path, localPath);
+
+		const file = path.join(stateDir, "marketplace", "sources.json");
+		assert.ok(fs.existsSync(file));
+		const parsed = JSON.parse(fs.readFileSync(file, "utf-8"));
+		assert.equal(parsed.version, 1);
+		assert.equal(parsed.sources.length, 1);
+	});
+
+	it("adds a git source and derives a label from the url", () => {
+		const reg = new SourceRegistry(tmp());
+		const rec = reg.add({ kind: "git", url: "https://github.com/acme/bobbit-packs.git", ref: "main" });
+		assert.equal(rec.kind, "git");
+		assert.equal(rec.url, "https://github.com/acme/bobbit-packs.git");
+		assert.equal(rec.ref, "main");
+		assert.equal(rec.label, "bobbit-packs");
+		assert.equal(rec.path, null);
+	});
+
+	it("rejects a git source without a url", () => {
+		const reg = new SourceRegistry(tmp());
+		assert.throws(() => reg.add({ kind: "git" }), SourceRegistryError);
+	});
+
+	it("rejects a local source with a relative or missing path", () => {
+		const reg = new SourceRegistry(tmp());
+		assert.throws(() => reg.add({ kind: "local", path: "relative/dir" }), SourceRegistryError);
+		assert.throws(() => reg.add({ kind: "local", path: path.join(os.tmpdir(), "does-not-exist-" + Date.now()) }), SourceRegistryError);
+	});
+
+	it("rejects an unknown kind", () => {
+		const reg = new SourceRegistry(tmp());
+		assert.throws(() => reg.add({ kind: "ftp" as any, url: "x" }), SourceRegistryError);
+	});
+
+	it("update() persists sync status and remove() deletes the record", () => {
+		const stateDir = tmp();
+		const reg = new SourceRegistry(stateDir);
+		const rec = reg.add({ kind: "git", url: "https://example.com/p.git" });
+		reg.update(rec.id, { lastSyncedAt: 123, lastSyncCommit: "abc123", lastSyncError: null });
+
+		const reg2 = new SourceRegistry(stateDir);
+		assert.equal(reg2.get(rec.id)?.lastSyncCommit, "abc123");
+		assert.equal(reg2.get(rec.id)?.lastSyncedAt, 123);
+
+		reg2.remove(rec.id);
+		assert.equal(new SourceRegistry(stateDir).list().length, 0);
+		assert.throws(() => reg2.remove(rec.id), SourceRegistryError);
+	});
+});


### PR DESCRIPTION
## Marketplace MVP

Adds a lightweight **Marketplace** for Bobbit: a new **Market** sidebar button (between Workflows and New Goal) where you register **sources** (git repos or local directories) containing **Extension Packs** — themed bundles of roles, tools, and skills — then browse and install them. Installed entities are copied into the existing config layers, so they resolve through the normal `ConfigCascade` / skill discovery exactly like hand-authored config (same origin badges, same System/project scope semantics). No hosted registry, no signing, no sandbox.

### Highlights
- **Sources**: git (shallow clone / fetch+reset) + local dirs read in place; server-global registry at `.bobbit/state/marketplace/sources.json` (`0o600`); ambient git creds; credentials redacted from all API responses/labels/errors.
- **Packs**: a source's top level is pack directories; a dir is a pack iff it has a `pack.yaml` manifest (`apiVersion`/`id`/`name`/`description`/`version` + optional metadata + `contents.{roles,tools,skills}`); payload mirrors `defaults/`.
- **Install/update/uninstall**: whole-pack or individual-entity; System vs project scope; conflict modes (fail/overwrite/skip) with transactional copy + rollback; provenance for symmetric uninstall; update refreshes tracked entities (new entities surfaced, not auto-added); drift detection; explicit "installs executable code" warning for tool-bearing packs.
- **Extensibility seams**: entity-handler registry, source-backend interface, and a trust-policy call site so future panels/workflows/staff and a hosted registry are additive.

### Implementation
- Server: `src/server/marketplace/*` (types, source-registry, sync-service, pack-scanner, entity-handlers, install-service, provenance-store, service, git-url-redact) + `/api/marketplace/*` routes in `server.ts`.
- UI: `src/app/market-page.ts`, `market-source-dialog.ts`, `market-page.css`, `api.ts` helpers; sidebar/routing/render/main wiring.
- Docs: `docs/marketplace.md` (+ `docs/design/marketplace-mvp.md`), README + AGENTS pointers.

### Testing
- Unit (`file://` fixtures): scanner, install/conflict/provenance, source registry, and 8 rounds of regression fixes — 100 marketplace assertions, 0 failures.
- Browser E2E (`tests/e2e/ui/marketplace.spec.ts`): Market button → add source → browse (exec-code badge, invalid-pack error) → install at project scope (with warning) → role resolves with project origin → persists across reload → uninstall, plus pack drill-down.
- Full suite green (typecheck, unit, E2E); all workflow gates passed (design-doc, implementation incl. gap/quality/security review, documentation).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
