### PR TITLE
Square multi-select checkboxes

### DIFF
--- a/src/ui/components/AskUserChoicesWidget.ts
+++ b/src/ui/components/AskUserChoicesWidget.ts
@@ -646,7 +646,7 @@ export class AskUserChoicesWidget extends LitElement {
 				@focus=${() => { if (!readOnly) this._focusedOption = optIdx; }}>
 				${inputAttrs}
 				<span class="ask-option-index font-mono text-xs text-muted-foreground w-4 text-right select-none" aria-hidden="true">${optIdx + 1}.</span>
-				<span class="ask-option-check inline-flex items-center justify-center w-4 h-4 rounded-full border pointer-events-none ${checked ? "border-primary bg-primary text-primary-foreground" : "border-border text-transparent"}" aria-hidden="true">
+				<span class="ask-option-check inline-flex items-center justify-center w-4 h-4 ${multi ? "rounded-sm" : "rounded-full"} border pointer-events-none ${checked ? "border-primary bg-primary text-primary-foreground" : "border-border text-transparent"}" aria-hidden="true">
 					${checked ? html`<span class="ask-check-glyph text-[10px] leading-none">✓</span>` : nothing}
 				</span>
 				<span class="ask-option-text">${option}</span>
@@ -705,7 +705,7 @@ export class AskUserChoicesWidget extends LitElement {
 					@focus=${() => { if (!readOnly) this._focusedOption = optIdx; }}>
 					${inputEl}
 					<span class="ask-option-index font-mono text-xs text-muted-foreground w-4 text-right select-none" aria-hidden="true">${optIdx + 1}.</span>
-					<span class="ask-option-check inline-flex items-center justify-center w-4 h-4 rounded-full border pointer-events-none ${checked ? "border-primary bg-primary text-primary-foreground" : "border-border text-transparent"}" aria-hidden="true">
+					<span class="ask-option-check inline-flex items-center justify-center w-4 h-4 ${multi ? "rounded-sm" : "rounded-full"} border pointer-events-none ${checked ? "border-primary bg-primary text-primary-foreground" : "border-border text-transparent"}" aria-hidden="true">
 						${checked ? html`<span class="ask-check-glyph text-[10px] leading-none">✓</span>` : nothing}
 					</span>
 					<span class="ask-option-text">Other</span>

--- a/tests/e2e/ui/ask-user-choices-ui.spec.ts
+++ b/tests/e2e/ui/ask-user-choices-ui.spec.ts
@@ -125,6 +125,52 @@ test.describe("ask_user_choices widget (full-stack UI)", () => {
 		await expect(readOnly.locator('input[type="radio"]').first()).toBeDisabled();
 	});
 
+	test("indicator shape — square for multi-select, circular for single-select", async ({ page }) => {
+		await openApp(page);
+		await createSessionViaUI(page);
+
+		// ask_user_choices_multi → Q1 ("Which colors?", multi:true) + Q2 ("Team size?", single).
+		await sendMessage(page, "please use ask_user_choices_multi");
+
+		const widget = page.locator("ask-user-choices-widget").first();
+		await expect(widget).toBeVisible({ timeout: 20_000 });
+
+		// Q1 is the active tab and is multi-select → indicators must be square
+		// (rounded-sm) and NOT circular (rounded-full). Covers regular options.
+		await expect(widget.locator('[role="tab"][data-tab-index="0"]'))
+			.toHaveAttribute("aria-selected", "true");
+		const multiChecks = widget.locator(".ask-option:not(.ask-option-other) .ask-option-check");
+		await expect(multiChecks.first()).toBeVisible();
+		const multiCount = await multiChecks.count();
+		expect(multiCount).toBeGreaterThan(0);
+		for (let i = 0; i < multiCount; i++) {
+			await expect(multiChecks.nth(i)).toHaveClass(/rounded-sm/);
+			await expect(multiChecks.nth(i)).not.toHaveClass(/rounded-full/);
+		}
+		// "Other" option indicator on a multi-select question is also square.
+		const multiOther = widget.locator(".ask-option-other .ask-option-check");
+		await expect(multiOther).toHaveClass(/rounded-sm/);
+		await expect(multiOther).not.toHaveClass(/rounded-full/);
+
+		// Switch to Q2 (single-select) → indicators must be circular (rounded-full)
+		// and NOT square (rounded-sm).
+		await widget.locator('[role="tab"][data-tab-index="1"]').click();
+		await expect(widget.locator('[role="tab"][data-tab-index="1"]'))
+			.toHaveAttribute("aria-selected", "true");
+		const singleChecks = widget.locator(".ask-option:not(.ask-option-other) .ask-option-check");
+		await expect(singleChecks.first()).toBeVisible();
+		const singleCount = await singleChecks.count();
+		expect(singleCount).toBeGreaterThan(0);
+		for (let i = 0; i < singleCount; i++) {
+			await expect(singleChecks.nth(i)).toHaveClass(/rounded-full/);
+			await expect(singleChecks.nth(i)).not.toHaveClass(/rounded-sm/);
+		}
+		// "Other" option indicator on a single-select question is circular.
+		const singleOther = widget.locator(".ask-option-other .ask-option-check");
+		await expect(singleOther).toHaveClass(/rounded-full/);
+		await expect(singleOther).not.toHaveClass(/rounded-sm/);
+	});
+
 	test("cross-client finalization via keyboard-only submission", async ({ page, context, rec }) => {
 		await openApp(page);
 		await createSessionViaUI(page);


### PR DESCRIPTION
## What

In the `ask_user_choices` inline widget, multi-select questions (`multi: true`) now render a **square** selection indicator while single-select (radio) options keep a **circular** one, matching platform convention.

## Change

`src/ui/components/AskUserChoicesWidget.ts` — in both `_renderOption()` and `_renderOtherOption()`, the `.ask-option-check` span's hardcoded `rounded-full` is now `${multi ? "rounded-sm" : "rounded-full"}`. The `multi` boolean was already computed in both methods. Check glyph, checked/unchecked border + fill, and sizing unchanged. No behavior, keyboard-nav, or ARIA (`checkbox` vs `radio`) changes.

## Testing

- Extended `tests/e2e/ui/ask-user-choices-ui.spec.ts` to assert the indicator shape differs: multi-select option + Other indicators have `rounded-sm` (not `rounded-full`); single-select have `rounded-full` (not `rounded-sm`).
- `npm run check`: pass
- `npm run test:unit`: 1281 passed, 2 skipped
- E2E (`ask-user-choices-ui.spec.ts`): 5 passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)