### PR TITLE
@-mention file references in the prompt composer

### DIFF
--- a/docs/at-mention-file-references.md
+++ b/docs/at-mention-file-references.md
@@ -1,0 +1,214 @@
+# `@`-Mention File References
+
+Type `@` in the prompt composer to reference a file by path. On send, Bobbit
+resolves each `@path` token into the referenced file's content: **text files are
+inlined into the model-facing prompt**, while **images and other binaries are
+attached** via the existing attachment pipeline. Each reference renders as a
+clickable chip in the sent message that expands to show the exact content the
+model saw.
+
+## Why it works this way
+
+The feature is built as a deliberate parallel to the [`/` slash-skill
+feature](design/skill-ux-and-autonomous-activation.md) — same autocomplete UX,
+same send-time resolution shape, same chip + sidecar persistence model. Reusing
+those patterns keeps the two features consistent for users and lets the merge,
+chip, and replay machinery be shared rather than duplicated.
+
+Two design choices drive the rest of the behaviour:
+
+- **Snapshot at send time.** When you send, the file content (or image/binary
+  bytes) is captured into the message. Replaying the `.jsonl` transcript later
+  renders exactly what the model originally saw, even if the file has since
+  changed or been deleted on disk. This is the same stability guarantee skill
+  expansions provide.
+- **Never tear down a send.** Any reference that cannot be resolved — missing,
+  unreadable, too large, outside the working directory, or over a count/size cap
+  — degrades to the literal `@path` text plus a non-fatal warning. A bad
+  reference never fails the whole message.
+
+## Autocomplete UX
+
+Typing `@` at a word boundary (start of input, or after whitespace/newline)
+opens a file-picker menu, mirroring the slash-skill menu:
+
+- The query is the path fragment after `@` (no whitespace, no further `@`).
+- The menu lists files under the session's worktree, ranked so basename matches
+  (exact > prefix > substring) sort ahead of path-only matches, then by shorter
+  path, then lexicographically.
+- Keyboard: ↑/↓ move the selection, Enter/Tab select, Escape dismisses; mouse
+  hover/click also select.
+- Selecting a file inserts `@<relative-path>` followed by a space.
+
+The menu is query-scoped against the server (debounced ~120 ms) because the file
+tree can be large or remote, so the server does the filtering and ranking. A
+local cache provides an instant filter between fetches.
+
+### What's listed
+
+The menu enumerates **all files** under the session's host worktree —
+**including gitignored and untracked files** — because those branch-local files
+are exactly what you often want to reference. Bobbit does *not* consult
+`.gitignore`. A short, fixed exclusion list keeps obvious noise out:
+
+```
+.git  node_modules  dist  .bobbit  .next  coverage  build
+```
+
+Symlinks are skipped during the walk to avoid loops and escapes.
+
+Two hard caps keep large trees from blocking the event loop:
+
+- **Walk cap** — max directory entries visited (~20k) before the walk stops.
+- **Result cap** — max files returned (`limit`, default 500, clamped to 1000;
+  the autocomplete requests 50).
+
+Source: `src/server/skills/file-enumeration.ts` (`enumerateFiles`).
+
+## REST endpoint
+
+```
+GET /api/file-mentions?cwd=&projectId=&q=&sessionId=&limit=
+```
+
+Returns `{ files: [{ path }] }` — relative forward-slash paths scoped to the
+resolved working directory. Modeled on `GET /api/slash-skills`.
+
+The endpoint enumerates the **session's host worktree**, not the project root.
+This matters: the project-root redirect used for *skill discovery* is wrong here
+because a goal/session worktree has its own branch-local, untracked, and
+gitignored files that the project root does not see. When `sessionId` is
+provided, the server resolves the session's `worktreePath` (the host path —
+required for sandboxed sessions, whose `cwd` is a container path) and falls back
+to the session `cwd`, then to the raw `cwd` query param. It never falls back to
+the project root.
+
+## Resolution on send (hybrid)
+
+At send time the server runs the pure resolver
+`resolveFileMentions(text, cwd)` (`src/server/skills/resolve-file-mentions.ts`)
+against the verbatim text. It scans `@path` tokens with an inline,
+word-boundary-anchored regex (`(^|\s)@([^\s@]+)`), trims trailing punctuation
+(`. , ) : ;`) off each token, and classifies each reference into one of four
+kinds:
+
+| Kind | Detection | Model delivery | `modelText` |
+|---|---|---|---|
+| `text` | content sniffs as UTF-8 text | inlined as a `<file-reference>` block | rewritten |
+| `image` | image extension (`.png`, `.jpg`, `.gif`, `.webp`, `.svg`, …) | base64 via the `images[]` frame | unchanged (literal `@path` kept) |
+| `binary` | non-text, non-image | base64 document via the attachment pipeline | unchanged (literal `@path` kept) |
+| `unresolved` | failed any check below | not delivered | unchanged (literal `@path` kept) |
+
+Text content is spliced into the model-facing prompt inside a delimiter that
+names the path:
+
+```
+<file-reference path="src/foo.ts">
+…file content…
+</file-reference>
+```
+
+The path is XML-attribute-escaped so a quote or angle bracket in a filename
+cannot break out of the `path="…"` delimiter. Text mentions are spliced
+**right-to-left** by range so earlier indices stay valid.
+
+For `image` and `binary` mentions, `modelText` is left untouched — the literal
+`@path` stays so the model still sees the filename — and the bytes are routed
+through the existing prompt frames: images into `images[]`, binaries as
+`document` attachments. Binaries are attached primarily for UI chip + snapshot
+parity with user-uploaded documents.
+
+### Overlap with a prefix slash-skill
+
+A *prefix-only* slash skill (e.g. `/mockup …`) claims the whole-message range,
+which overlaps any `@file` token in the same message. On overlap, the skill
+expansion wins: the file content is **appended** after the spliced skill body as
+a `<file-reference>` block rather than spliced inline (which would corrupt the
+skill body). The chip still renders at the original `@path` range either way.
+The merge is handled by `buildMergedModelText`
+(`src/server/skills/merge-mentions.ts`), which combines skill expansions and
+text mentions into a single right-to-left splice over the original text.
+
+## Caps and degradation
+
+Caps are enforced in the resolver. Mention-count and per-file caps are checked
+**before** any file read so an oversized or over-the-limit reference never loads
+bytes into memory:
+
+| Cap | Value | Over-cap kind |
+|---|---|---|
+| Inline text per file | 256 KiB | `too-large` |
+| Image/binary per file | 10 MiB | `too-large` |
+| Aggregate across one send | 20 MiB | `aggregate-cap` |
+| Mentions per send | 50 | `too-many-mentions` |
+
+The aggregate budget is pre-checked against each file's stat size before
+reading, then re-validated against the actual bytes after reading to handle the
+file growing between stat and read (TOCTOU). Every degraded reference is
+recorded as kind `unresolved` with a human-readable `reason`
+(`missing`, `unreadable`, `too-large`, `outside-cwd`, `aggregate-cap`,
+`too-many-mentions`) and surfaces a non-fatal `console.warn` on the server; the
+literal `@path` text is preserved in the prompt.
+
+## Path safety
+
+References are confined to the working directory:
+
+1. **Lexical reject** — `path.resolve(cwd, rel)` followed by a containment check
+   cheaply rejects obvious `..`/absolute escapes (and non-existent traversal
+   paths).
+2. **Canonical reject** — the target is canonicalized with `fs.realpathSync` and
+   the containment check is re-run on the **canonical** paths **before any
+   stat/read**. This defeats a symlink that lives inside `cwd` but points
+   outside it — it cannot leak host files. A `realpath` failure is treated as
+   `missing`.
+
+The canonical absolute path is kept internally for the read but stripped
+(`toWireMention`) before the mention crosses the wire or is persisted, so the
+host filesystem layout is never exposed to the client.
+
+## Chips, persistence, and replay
+
+Each `@file` reference renders an inline `<file-mention-chip>` in the sent user
+message (`src/ui/components/FileMentionChip.ts`), mirroring `SkillChip`.
+Clicking the chip toggles a disclosure showing the snapshotted content:
+
+- `text` → a `<pre>` of the captured content,
+- `image` → an `<img>` of the snapshotted bytes,
+- `binary` / `unresolved` → a note (size / reason).
+
+Chips are spliced into the user bubble at the recorded `@path` range by the
+shared chip-item builder in `src/ui/components/Messages.ts`, which handles both
+`<skill-chip>` and `<file-mention-chip>`.
+
+Persistence reuses the **skill sidecar**
+(`src/server/skills/skill-sidecar.ts`). The pi-coding-agent CLI owns the
+`.jsonl` transcript schema, so mentions are stored out-of-band in a sidecar
+file (one JSON line per user message) under a `fileMentions` field alongside
+`skillExpansions`. On replay, the sidecar entry is matched to the message by
+`modelText` (with a small timestamp tolerance) and both `skillExpansions` and
+`fileMentions` are re-attached so chips and the original `@path` text restore
+correctly. A missing or unreadable sidecar degrades to plain text — old sessions
+render with the literal `@path`, fully backward compatible.
+
+## Key source files
+
+| Concern | File |
+|---|---|
+| Pure send-time resolver | `src/server/skills/resolve-file-mentions.ts` |
+| Skill + mention merge into model text | `src/server/skills/merge-mentions.ts` |
+| Bounded file enumeration (autocomplete backend) | `src/server/skills/file-enumeration.ts` |
+| REST endpoint | `GET /api/file-mentions` in `src/server/server.ts` |
+| Send-time wiring (resolve, merge, route, persist) | `src/server/ws/handler.ts` |
+| Sidecar persistence / replay | `src/server/skills/skill-sidecar.ts` |
+| Composer autocomplete (`@` menu, keyboard nav, insertion) | `src/ui/components/MessageEditor.ts` |
+| Chip component | `src/ui/components/FileMentionChip.ts` |
+| Chip splicing into the user bubble | `src/ui/components/Messages.ts` |
+
+## Related
+
+- [Skills (slash commands)](features.md#skills) — the sibling `/` feature this
+  one parallels.
+- [Skill chip rendering & sidecar persistence](internals.md#skill-chip-rendering--autonomous-activation)
+  — the shared chip + sidecar machinery.
+- [Slash-skill UX design](design/skill-ux-and-autonomous-activation.md).

--- a/docs/features.md
+++ b/docs/features.md
@@ -56,6 +56,10 @@ Slash-command skills discovered from Claude Code-compatible `SKILL.md` files.
 - **Catalog budget**: The catalog is capped in bytes to keep the system prompt small. Default is **16 KB**; configurable per-user via Settings → General → "Skills catalog budget" within **1–128 KB**. The preference is stored as `skillsCatalogBudget` (bytes) via `PUT /api/preferences`; absent or `null` falls back to the default. When skills exceed the budget, the list is sorted alphabetically by name and the tail is dropped with a `_… (N more skills omitted, alphabetically truncated)_` footer so the agent knows more exist (it can still invoke them by name). A `[system-prompt] Skills catalog exceeded <budget>B budget — truncated N skill(s).` warning is logged. Tuning bounds are enforced server-side in `resolveSkillsCatalogBudget` (`src/server/agent/system-prompt.ts`) and mirrored by the Settings input.
 - **API**: `GET /api/slash-skills` for autocomplete data, `GET /api/slash-skills/details` for full content, file paths, and scanned directories.
 
+## File References (`@`-mentions)
+
+Type `@` in the prompt composer to reference a file by path, mirroring the `/` slash-skill menu. On send the server resolves each `@path` token: text files are inlined into the model-facing prompt as `<file-reference>` blocks, images route through the `images[]` frame, and other binaries become document attachments. Unresolvable / oversized / out-of-cwd references degrade gracefully to the literal `@path`. Content is snapshotted at send time, so chips and original text replay stably via the shared skill sidecar. Backed by `GET /api/file-mentions`. See [at-mention-file-references.md](at-mention-file-references.md) for the full behaviour, caps, path-safety, and source map.
+
 ## Cost Tracking
 
 Per-session token usage and cost tracking, aggregated to goal and task level.

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -20,6 +20,7 @@ import { RpcBridge, synthesizeAttachmentText, ATTACHMENT_ONLY_TEXT, type RpcBrid
 import { sessionFileExists, sessionFileRead, sessionFileDelete, type SessionFsContext } from "./session-fs.js";
 import { sanitizeAgentTranscriptFile } from "./transcript-sanitizer.js";
 import type { SkillExpansion } from "../skills/resolve-skill-expansions.js";
+import type { FileMention } from "../skills/resolve-file-mentions.js";
 import { appendSkillSidecarEntry } from "../skills/skill-sidecar.js";
 import {
 	appendCompactionSidecarEntry,
@@ -309,6 +310,8 @@ export interface SessionInfo {
 		modelText: string;
 		originalText: string;
 		skillExpansions: SkillExpansion[];
+		/** `@path` file-mention chips re-attached alongside skill expansions. */
+		fileMentions?: FileMention[];
 	}>;
 	/** Repo path (cached from worktree provisioning). */
 	repoPath?: string;
@@ -519,7 +522,7 @@ import { broadcastStatus } from "./session-status.js";
  *  used to do `eventBuffer.push(ev); broadcast(clients, {type:"event", data:ev})`
  *  must route through here so envelope fields stay consistent.
  *  See docs/design/streaming-dedup-reorder.md §4.2. */
-export function emitSessionEvent(session: { clients: Set<WebSocket>; eventBuffer: EventBuffer; pendingSkillExpansions?: Array<{ modelText: string; originalText: string; skillExpansions: SkillExpansion[] }> }, truncated: unknown): void {
+export function emitSessionEvent(session: { clients: Set<WebSocket>; eventBuffer: EventBuffer; pendingSkillExpansions?: Array<{ modelText: string; originalText: string; skillExpansions: SkillExpansion[]; fileMentions?: FileMention[] }> }, truncated: unknown): void {
 	const spliced = spliceSkillExpansionsIntoEvent(session, truncated);
 	const entry = session.eventBuffer.push(spliced);
 	const frame = { type: "event" as const, data: spliced, seq: entry.seq, ts: entry.ts };
@@ -548,7 +551,7 @@ export function emitSessionEvent(session: { clients: Set<WebSocket>; eventBuffer
  * the un-spliced (modelText) message — that is what the model has seen.
  */
 function spliceSkillExpansionsIntoEvent(
-	session: { pendingSkillExpansions?: Array<{ modelText: string; originalText: string; skillExpansions: SkillExpansion[] }> },
+	session: { pendingSkillExpansions?: Array<{ modelText: string; originalText: string; skillExpansions: SkillExpansion[]; fileMentions?: FileMention[] }> },
 	event: unknown,
 ): unknown {
 	const ev = event as any;
@@ -564,6 +567,9 @@ function spliceSkillExpansionsIntoEvent(
 	const envelope = pending.splice(idx, 1)[0];
 	const rewrittenMsg = rewriteUserMessageText(msg, envelope.originalText);
 	rewrittenMsg.skillExpansions = envelope.skillExpansions;
+	if (envelope.fileMentions && envelope.fileMentions.length > 0) {
+		rewrittenMsg.fileMentions = envelope.fileMentions;
+	}
 	return { ...ev, message: rewrittenMsg };
 }
 
@@ -1727,6 +1733,8 @@ export class SessionManager {
 		modelText?: string;
 		/** Resolved slash-skill expansions, in original-text order. UI-only metadata. */
 		skillExpansions?: SkillExpansion[];
+		/** Resolved `@path` file mentions (all kinds), in original-text order. UI-only metadata. */
+		fileMentions?: FileMention[];
 		/** Provenance of this prompt. Defaults to "user". Read by TeamManager
 		 *  on agent_start to decide whether to reset idle-nudge backoff counters. */
 		source?: PromptSource;
@@ -1746,13 +1754,15 @@ export class SessionManager {
 		// no-attachment prompts pass through unchanged. See
 		// synthesizeAttachmentText for the exact rule.
 		const dispatchText = synthesizeAttachmentText(opts?.modelText ?? text, opts?.images, opts?.attachments);
-		const hasExpansions = !!(opts?.skillExpansions && opts.skillExpansions.length > 0);
-		if (hasExpansions) {
+		const hasSkillExpansions = !!(opts?.skillExpansions && opts.skillExpansions.length > 0);
+		const hasFileMentions = !!(opts?.fileMentions && opts.fileMentions.length > 0);
+		if (hasSkillExpansions || hasFileMentions) {
 			appendSkillSidecarEntry(session.id, {
 				ts: Date.now(),
 				modelText: dispatchText,
 				originalText: text,
-				skillExpansions: opts!.skillExpansions!,
+				skillExpansions: opts?.skillExpansions ?? [],
+				...(hasFileMentions ? { fileMentions: opts!.fileMentions! } : {}),
 			});
 			// Stash the envelope so when the agent echoes the user message
 			// back via `message_end`, we can splice the original text +
@@ -1761,7 +1771,8 @@ export class SessionManager {
 			session.pendingSkillExpansions.push({
 				modelText: dispatchText,
 				originalText: text,
-				skillExpansions: opts!.skillExpansions!,
+				skillExpansions: opts?.skillExpansions ?? [],
+				...(hasFileMentions ? { fileMentions: opts!.fileMentions! } : {}),
 			});
 		}
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -8475,7 +8475,7 @@ async function handleApiRoute(
 		const limit = limitParsed !== undefined && Number.isFinite(limitParsed) ? limitParsed : undefined;
 		// Sandbox sessions have container-internal cwds; resolve the host path.
 		const cwd = resolveSkillDiscoveryCwd(rawCwd, projectId);
-		const files = enumerateFiles(cwd, { query: q, limit });
+		const files = await enumerateFiles(cwd, { query: q, limit });
 		json({ files: files.map((p) => ({ path: p })) });
 		return;
 	}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -8468,13 +8468,26 @@ async function handleApiRoute(
 	// Includes gitignored/untracked files; excludes .git/node_modules/etc. (no .gitignore consulted).
 	if (url.pathname === "/api/file-mentions" && req.method === "GET") {
 		const rawCwd = url.searchParams.get("cwd") || process.cwd();
-		const projectId = url.searchParams.get("projectId");
+		const sessionId = url.searchParams.get("sessionId");
 		const q = url.searchParams.get("q") || undefined;
 		const limitRaw = url.searchParams.get("limit");
 		const limitParsed = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
 		const limit = limitParsed !== undefined && Number.isFinite(limitParsed) ? limitParsed : undefined;
-		// Sandbox sessions have container-internal cwds; resolve the host path.
-		const cwd = resolveSkillDiscoveryCwd(rawCwd, projectId);
+		// Enumerate the session's HOST worktree, NOT the project root. The
+		// project-root redirect (resolveSkillDiscoveryCwd) is correct for SKILL
+		// discovery but wrong here: file mentions must see the goal/session
+		// worktree's branch-local, untracked and gitignored files. worktreePath
+		// is the host path; for sandboxed sessions cwd is a container path so
+		// worktreePath is required. Fall back to the raw `cwd` param (never the
+		// project root) when no session is bound.
+		let cwd = rawCwd;
+		if (sessionId) {
+			const session = sessionManager.getSession(sessionId);
+			const persisted = sessionManager.getPersistedSession(sessionId);
+			const worktree = session?.worktreePath || persisted?.worktreePath;
+			const sessionCwd = session?.cwd || persisted?.cwd;
+			cwd = worktree || sessionCwd || rawCwd;
+		}
 		const files = await enumerateFiles(cwd, { query: q, limit });
 		json({ files: files.map((p) => ({ path: p })) });
 		return;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -21,6 +21,7 @@ import { oauthComplete, oauthFlowStatus, oauthStart, oauthStatus } from "./auth/
 import { handleWebSocketConnection } from "./ws/handler.js";
 import { paceAndSend, PACE_TIMEOUT_MS } from "./replay-pacing.js";
 import { discoverSlashSkills, getSkillDirectories, getSlashSkill, buildSlashSkillPrompt } from "./skills/slash-skills.js";
+import { enumerateFiles } from "./skills/file-enumeration.js";
 import { TeamManager, GateDependencyError } from "./agent/team-manager.js";
 import { checkGateDependencies } from "./agent/gate-dependency-check.js";
 import { shouldCreateWorktree } from "./agent/worktree-decision.js";
@@ -8460,6 +8461,22 @@ async function handleApiRoute(
 		const cwd = resolveSkillDiscoveryCwd(rawCwd, projectId);
 		const skills = discoverSlashSkills(cwd, resolvedStore);
 		json({ skills: skills.map((s) => ({ name: s.name, description: s.description, argumentHint: s.argumentHint, source: s.source })) });
+		return;
+	}
+
+	// GET /api/file-mentions — bounded file enumeration for @-mention autocomplete.
+	// Includes gitignored/untracked files; excludes .git/node_modules/etc. (no .gitignore consulted).
+	if (url.pathname === "/api/file-mentions" && req.method === "GET") {
+		const rawCwd = url.searchParams.get("cwd") || process.cwd();
+		const projectId = url.searchParams.get("projectId");
+		const q = url.searchParams.get("q") || undefined;
+		const limitRaw = url.searchParams.get("limit");
+		const limitParsed = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
+		const limit = limitParsed !== undefined && Number.isFinite(limitParsed) ? limitParsed : undefined;
+		// Sandbox sessions have container-internal cwds; resolve the host path.
+		const cwd = resolveSkillDiscoveryCwd(rawCwd, projectId);
+		const files = enumerateFiles(cwd, { query: q, limit });
+		json({ files: files.map((p) => ({ path: p })) });
 		return;
 	}
 

--- a/src/server/skills/file-enumeration.ts
+++ b/src/server/skills/file-enumeration.ts
@@ -48,9 +48,10 @@ export interface EnumerateFilesOptions {
 
 /**
  * Enumerate files under `cwd`. Returns relative forward-slash paths, ranked
- * and bounded. Never throws — unreadable directories are skipped.
+ * and bounded. Never throws — unreadable directories are skipped. Async so the
+ * directory walk never blocks the HTTP event loop on large/slow trees.
  */
-export function enumerateFiles(cwd: string, opts?: EnumerateFilesOptions): string[] {
+export async function enumerateFiles(cwd: string, opts?: EnumerateFilesOptions): Promise<string[]> {
 	const query = (opts?.query ?? "").trim().toLowerCase();
 	const resultCap = Math.max(1, Math.min(opts?.limit ?? DEFAULT_RESULT_CAP, MAX_RESULT_CAP));
 	const walkCap = opts?.walkCap ?? DEFAULT_WALK_CAP;
@@ -64,7 +65,7 @@ export function enumerateFiles(cwd: string, opts?: EnumerateFilesOptions): strin
 		const dir = queue.shift()!;
 		let entries: fs.Dirent[];
 		try {
-			entries = fs.readdirSync(dir, { withFileTypes: true });
+			entries = await fs.promises.readdir(dir, { withFileTypes: true });
 		} catch {
 			continue; // unreadable dir — skip
 		}

--- a/src/server/skills/file-enumeration.ts
+++ b/src/server/skills/file-enumeration.ts
@@ -1,0 +1,113 @@
+/**
+ * Bounded directory enumeration backing `GET /api/file-mentions` (design §3).
+ *
+ * Walks the tree under `cwd` and returns relative (forward-slash) paths for
+ * autocomplete. **Includes gitignored/untracked files** — we intentionally do
+ * NOT consult `.gitignore`. A short, documented exclusion list keeps obvious
+ * noise (`.git`, `node_modules`, build output) out of the results.
+ *
+ * Hard caps keep large trees from blocking the event loop:
+ *   - `walkCap`   — max directory entries visited (default ~20k).
+ *   - `resultCap` — max files returned after filtering (`limit`, default 500,
+ *                   clamped to 1000). The walk stops early once this is hit.
+ *
+ * Filtering: case-insensitive substring match on the relative path. Ranking
+ * promotes basename matches (exact > prefix > substring) ahead of path-only
+ * matches, then shorter paths, then lexicographic — no fuzzy library.
+ *
+ * Pure aside from reading the directory tree; unit-testable with a `file://`
+ * fixture tree.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+/** Directory names excluded from the walk. Kept short and documented. */
+const EXCLUDED_DIRS = new Set([
+	".git",
+	"node_modules",
+	"dist",
+	".bobbit",
+	".next",
+	"coverage",
+	"build",
+]);
+
+export const DEFAULT_RESULT_CAP = 500;
+export const MAX_RESULT_CAP = 1000;
+export const DEFAULT_WALK_CAP = 20_000;
+
+export interface EnumerateFilesOptions {
+	/** Case-insensitive substring query on the relative path. */
+	query?: string;
+	/** Max files returned after filtering (clamped to {@link MAX_RESULT_CAP}). */
+	limit?: number;
+	/** Max directory entries visited before the walk stops. */
+	walkCap?: number;
+}
+
+/**
+ * Enumerate files under `cwd`. Returns relative forward-slash paths, ranked
+ * and bounded. Never throws — unreadable directories are skipped.
+ */
+export function enumerateFiles(cwd: string, opts?: EnumerateFilesOptions): string[] {
+	const query = (opts?.query ?? "").trim().toLowerCase();
+	const resultCap = Math.max(1, Math.min(opts?.limit ?? DEFAULT_RESULT_CAP, MAX_RESULT_CAP));
+	const walkCap = opts?.walkCap ?? DEFAULT_WALK_CAP;
+
+	const matches: string[] = [];
+	let visited = 0;
+
+	// Iterative BFS to avoid deep recursion on large trees.
+	const queue: string[] = [cwd];
+	walk: while (queue.length > 0) {
+		const dir = queue.shift()!;
+		let entries: fs.Dirent[];
+		try {
+			entries = fs.readdirSync(dir, { withFileTypes: true });
+		} catch {
+			continue; // unreadable dir — skip
+		}
+		for (const entry of entries) {
+			if (++visited > walkCap) break walk;
+			if (entry.isSymbolicLink()) continue; // avoid symlink loops / escapes
+			const abs = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				if (EXCLUDED_DIRS.has(entry.name)) continue;
+				queue.push(abs);
+				continue;
+			}
+			if (!entry.isFile()) continue;
+			const rel = path.relative(cwd, abs).replace(/\\/g, "/");
+			if (query && !rel.toLowerCase().includes(query)) continue;
+			matches.push(rel);
+			// Collect more than the cap when filtering so ranking can pick the
+			// best; bound the buffer to avoid unbounded growth on huge trees.
+			if (!query && matches.length >= resultCap) break walk;
+			if (matches.length >= resultCap * 4) break walk;
+		}
+	}
+
+	if (query) rankMatches(matches, query);
+	else matches.sort((a, b) => (a.length - b.length) || (a < b ? -1 : a > b ? 1 : 0));
+
+	return matches.slice(0, resultCap);
+}
+
+/** Rank matches: basename exact > basename prefix > basename substring > path-only. */
+function rankMatches(matches: string[], query: string): void {
+	const score = (rel: string): number => {
+		const base = rel.slice(rel.lastIndexOf("/") + 1).toLowerCase();
+		if (base === query) return 0;
+		if (base.startsWith(query)) return 1;
+		if (base.includes(query)) return 2;
+		return 3; // matched only elsewhere in the path
+	};
+	matches.sort((a, b) => {
+		const sa = score(a);
+		const sb = score(b);
+		if (sa !== sb) return sa - sb;
+		if (a.length !== b.length) return a.length - b.length;
+		return a < b ? -1 : a > b ? 1 : 0;
+	});
+}

--- a/src/server/skills/merge-mentions.ts
+++ b/src/server/skills/merge-mentions.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure merge of slash-skill expansions and `@file` text mentions into a single
+ * model-facing string. Extracted from the WS prompt handler so it is unit
+ * testable in isolation (handler.ts has a heavy import surface).
+ *
+ * The `/` and `@` *inline* token sets are disjoint, BUT a PREFIX-only slash
+ * skill claims the whole-message range `[0, originalText.length]`
+ * (see resolve-skill-expansions.ts), which overlaps any `@file` token in the
+ * same message (e.g. `/mockup @notes.txt`). On overlap the SKILL expansion
+ * wins for `modelText` and the file mention is NOT inlined — inlining it too
+ * would corrupt the spliced text. The file mention is still recorded by the
+ * resolver so its chip renders in the user bubble.
+ *
+ * All replacements are spliced right-to-left to preserve earlier indices.
+ */
+
+import { buildFileReferenceBlock, type FileMention } from "./resolve-file-mentions.js";
+
+export interface RangedExpansion {
+	range: readonly [number, number];
+	expanded: string;
+}
+
+function overlaps(a: readonly [number, number], b: readonly [number, number]): boolean {
+	return a[0] < b[1] && b[0] < a[1];
+}
+
+/**
+ * Build the merged model-facing text. `skillExpansions` and `fileMentions`
+ * are both expressed as ranges over the SAME `originalText`.
+ */
+export function buildMergedModelText(
+	originalText: string,
+	skillExpansions: readonly RangedExpansion[],
+	fileMentions: readonly FileMention[],
+): string {
+	const skillRanges = skillExpansions.map((e) => e.range);
+	const replacements: Array<{ start: number; end: number; expanded: string }> = [];
+
+	for (const e of skillExpansions) {
+		replacements.push({ start: e.range[0], end: e.range[1], expanded: e.expanded });
+	}
+	for (const m of fileMentions) {
+		if (m.kind !== "text" || m.content === undefined) continue;
+		// Skill expansion wins on overlap — skip inlining this file mention.
+		if (skillRanges.some((sr) => overlaps(sr, m.range))) continue;
+		replacements.push({
+			start: m.range[0],
+			end: m.range[1],
+			expanded: buildFileReferenceBlock(m.path, m.content),
+		});
+	}
+
+	if (replacements.length === 0) return originalText;
+	replacements.sort((a, b) => a.start - b.start);
+	let out = originalText;
+	for (let i = replacements.length - 1; i >= 0; i--) {
+		const r = replacements[i];
+		out = out.slice(0, r.start) + r.expanded + out.slice(r.end);
+	}
+	return out;
+}

--- a/src/server/skills/merge-mentions.ts
+++ b/src/server/skills/merge-mentions.ts
@@ -6,12 +6,16 @@
  * The `/` and `@` *inline* token sets are disjoint, BUT a PREFIX-only slash
  * skill claims the whole-message range `[0, originalText.length]`
  * (see resolve-skill-expansions.ts), which overlaps any `@file` token in the
- * same message (e.g. `/mockup @notes.txt`). On overlap the SKILL expansion
- * wins for `modelText` and the file mention is NOT inlined — inlining it too
- * would corrupt the spliced text. The file mention is still recorded by the
- * resolver so its chip renders in the user bubble.
+ * same message (e.g. `/mockup @notes.txt`). We must NOT splice the overlapping
+ * file mention inline (that would corrupt the skill-expanded body), but we also
+ * must NOT drop its content — the spec requires every text `@path` to reach the
+ * model. So overlapping TEXT mentions are APPENDED (in original-text order) as
+ * `<file-reference>` blocks AFTER the spliced body. The skill expansion stays
+ * intact and the file content is still delivered. image/binary mentions never
+ * touch `modelText` (routed as attachments). The chip still renders at the
+ * original `@path` range in the user bubble regardless.
  *
- * All replacements are spliced right-to-left to preserve earlier indices.
+ * Inline replacements are spliced right-to-left to preserve earlier indices.
  */
 
 import { buildFileReferenceBlock, type FileMention } from "./resolve-file-mentions.js";
@@ -36,27 +40,33 @@ export function buildMergedModelText(
 ): string {
 	const skillRanges = skillExpansions.map((e) => e.range);
 	const replacements: Array<{ start: number; end: number; expanded: string }> = [];
+	const appended: string[] = []; // overlapping text mentions, original-text order
 
 	for (const e of skillExpansions) {
 		replacements.push({ start: e.range[0], end: e.range[1], expanded: e.expanded });
 	}
 	for (const m of fileMentions) {
 		if (m.kind !== "text" || m.content === undefined) continue;
-		// Skill expansion wins on overlap — skip inlining this file mention.
-		if (skillRanges.some((sr) => overlaps(sr, m.range))) continue;
-		replacements.push({
-			start: m.range[0],
-			end: m.range[1],
-			expanded: buildFileReferenceBlock(m.path, m.content),
-		});
+		const block = buildFileReferenceBlock(m.path, m.content);
+		if (skillRanges.some((sr) => overlaps(sr, m.range))) {
+			// Overlaps a skill range: cannot splice inline without corrupting the
+			// skill body — append the file content after the spliced body instead.
+			appended.push(block);
+		} else {
+			replacements.push({ start: m.range[0], end: m.range[1], expanded: block });
+		}
 	}
 
-	if (replacements.length === 0) return originalText;
-	replacements.sort((a, b) => a.start - b.start);
 	let out = originalText;
-	for (let i = replacements.length - 1; i >= 0; i--) {
-		const r = replacements[i];
-		out = out.slice(0, r.start) + r.expanded + out.slice(r.end);
+	if (replacements.length > 0) {
+		replacements.sort((a, b) => a.start - b.start);
+		for (let i = replacements.length - 1; i >= 0; i--) {
+			const r = replacements[i];
+			out = out.slice(0, r.start) + r.expanded + out.slice(r.end);
+		}
+	}
+	if (appended.length > 0) {
+		out += "\n\n" + appended.join("\n\n");
 	}
 	return out;
 }

--- a/src/server/skills/resolve-file-mentions.ts
+++ b/src/server/skills/resolve-file-mentions.ts
@@ -1,0 +1,299 @@
+/**
+ * Pure resolver for `@path` file-mention references in user prompt text.
+ *
+ * Parallels `resolve-skill-expansions.ts` layer-for-layer (see design §2):
+ *
+ *   - **Inline scan only** — regex `(^|\s)@([^\s@]+)`. There is no
+ *     prefix-only special case (a bare `@path` whole-message still works
+ *     through the inline scan). Trailing punctuation (`.`, `,`, `)`, `:`,
+ *     `;`) is trimmed off the token end and excluded from the chip range.
+ *
+ *   - **Hybrid resolution** — each `@path` is classified:
+ *       • `text`  → file content is inlined into `modelText` inside a
+ *                   `<file-reference path="…">…</file-reference>` block.
+ *       • `image` → base64 snapshot in `data`; `modelText` left untouched
+ *                   (the literal `@path` stays so the model has the
+ *                   filename, and the handler routes the bytes through the
+ *                   image attachment frame).
+ *       • `binary`→ base64 snapshot in `data`; routed as a document
+ *                   attachment by the handler; `modelText` untouched.
+ *       • `unresolved` → missing / unreadable / too-large / outside-cwd /
+ *                   aggregate-cap. Literal `@path` left in `modelText`,
+ *                   `reason` set. **Never throws** — every failure path
+ *                   degrades gracefully.
+ *
+ *   - **Snapshot at resolve time** — file content (text) and base64 bytes
+ *     (image/binary) are captured now so replaying a `.jsonl` later renders
+ *     the same content the model originally saw, even if the file changed
+ *     on disk. (Same guarantee as skill expansions.)
+ *
+ * Text inlining splices **right-to-left** by range to preserve indices.
+ *
+ * Pure function: the only side effect is reading the referenced files.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+/** Char range, in UTF-16 code units (matches `String.prototype.slice`). */
+export type MentionRange = [number, number];
+
+export type MentionKind = "text" | "image" | "binary" | "unresolved";
+
+export interface FileMention {
+	/** Relative path exactly as typed (after the `@`), trailing punctuation trimmed. */
+	path: string;
+	/** Resolved absolute host path (omitted if unresolved). */
+	absPath?: string;
+	/** UTF-16 char range in `originalText` that the chip replaces (`@path` span). */
+	range: MentionRange;
+	kind: MentionKind;
+	/** text kind: snapshotted file content (verbatim). */
+	content?: string;
+	/** image/binary kind: base64 (no data-URL prefix) snapshot. */
+	data?: string;
+	/** image/binary kind: detected MIME type. */
+	mimeType?: string;
+	/** Resolved file size in bytes. */
+	bytes?: number;
+	/** unresolved kind: human-readable reason. */
+	reason?: string;
+}
+
+export interface ResolvedMentions {
+	/** The user's original verbatim text. */
+	originalText: string;
+	/** Text after inlining text-file content — what the model sees. Equals `originalText` when no text mentions. */
+	modelText: string;
+	/** Recorded mentions of ALL kinds, in original-text order. Drives chips. */
+	mentions: FileMention[];
+	/** Non-fatal warnings, surfaced via `console.warn` by the handler. */
+	warnings: string[];
+}
+
+/** Per-file cap for **text** inlining. Oversized text → unresolved (too-large). */
+export const MAX_INLINE_TEXT_BYTES = 256 * 1024; // 256 KiB
+/** Per-file cap for image/binary snapshots. Over → unresolved (too-large). */
+export const MAX_MENTION_FILE_BYTES = 10 * 1024 * 1024; // 10 MiB
+/** Aggregate cap across all resolved mentions in one send. */
+export const MAX_MENTION_AGGREGATE_BYTES = 20 * 1024 * 1024; // 20 MiB
+
+/** Image extensions → MIME type. */
+const IMAGE_MIME: Record<string, string> = {
+	".png": "image/png",
+	".jpg": "image/jpeg",
+	".jpeg": "image/jpeg",
+	".gif": "image/gif",
+	".webp": "image/webp",
+	".bmp": "image/bmp",
+	".svg": "image/svg+xml",
+	".ico": "image/x-icon",
+	".avif": "image/avif",
+};
+
+/** Trailing punctuation trimmed off a token end (unlikely to be part of a path). */
+const TRAILING_PUNCT = new Set([".", ",", ")", ":", ";"]);
+
+/**
+ * Build the model-facing inline block for a text mention. Exported so the
+ * handler can re-splice text mentions and skill expansions onto the same
+ * original string in one merged right-to-left pass (disjoint ranges).
+ */
+export function buildFileReferenceBlock(relPath: string, content: string): string {
+	return `<file-reference path="${relPath.replace(/\\/g, "/")}">\n${content}\n</file-reference>`;
+}
+
+export interface ResolveFileMentionsOptions {
+	/** Text inlining cap (default {@link MAX_INLINE_TEXT_BYTES}). */
+	maxFileBytes?: number;
+	/** Image/binary per-file cap (default {@link MAX_MENTION_FILE_BYTES}). */
+	maxMentionFileBytes?: number;
+	/** Aggregate cap across one send (default {@link MAX_MENTION_AGGREGATE_BYTES}). */
+	maxAggregateBytes?: number;
+}
+
+interface ScannedToken {
+	/** Trimmed path exactly as typed (forward or back slashes preserved). */
+	rawPath: string;
+	/** UTF-16 range covering `@path` in the original text. */
+	range: MentionRange;
+}
+
+/** Scan the text for `@path` tokens (inline, word-boundary anchored). */
+function scanTokens(text: string): ScannedToken[] {
+	const re = /(^|\s)@([^\s@]+)/g;
+	const out: ScannedToken[] = [];
+	let m: RegExpExecArray | null;
+	while ((m = re.exec(text)) !== null) {
+		let token = m[2];
+		// Trim trailing punctuation that is unlikely to be part of a path.
+		while (token.length > 0 && TRAILING_PUNCT.has(token[token.length - 1])) {
+			token = token.slice(0, -1);
+		}
+		if (token.length === 0) continue;
+		const prefixLen = m[1].length; // 0 at string start, 1 after whitespace
+		const tokenStart = m.index + prefixLen; // position of "@"
+		const tokenEnd = tokenStart + 1 + token.length; // covers "@" + path
+		out.push({ rawPath: token, range: [tokenStart, tokenEnd] });
+	}
+	return out;
+}
+
+/** Heuristic: is this buffer likely UTF-8 text (not binary)? */
+function isLikelyText(buf: Buffer): boolean {
+	if (buf.length === 0) return true;
+	if (buf.includes(0)) return false; // NUL byte ⇒ binary
+	const sample = buf.subarray(0, Math.min(buf.length, 8192));
+	let control = 0;
+	for (const b of sample) {
+		if (b === 9 || b === 10 || b === 13) continue; // tab / LF / CR
+		if (b < 32 || b === 127) control++;
+	}
+	return control / sample.length < 0.3;
+}
+
+/**
+ * Resolve all `@path` file mentions in `text`, relative to `cwd`.
+ * See module doc for semantics. Pure — only reads the referenced files.
+ */
+export function resolveFileMentions(
+	text: string,
+	cwd: string,
+	opts?: ResolveFileMentionsOptions,
+): ResolvedMentions {
+	const originalText = text;
+	const maxTextBytes = opts?.maxFileBytes ?? MAX_INLINE_TEXT_BYTES;
+	const maxFileBytes = opts?.maxMentionFileBytes ?? MAX_MENTION_FILE_BYTES;
+	const maxAggregate = opts?.maxAggregateBytes ?? MAX_MENTION_AGGREGATE_BYTES;
+
+	const tokens = scanTokens(text);
+	const mentions: FileMention[] = [];
+	const warnings: string[] = [];
+	const replacements: Array<{ start: number; end: number; expanded: string }> = [];
+
+	let aggregateUsed = 0;
+
+	for (const tok of tokens) {
+		const rawPath = tok.rawPath;
+		const normRel = rawPath.replace(/\\/g, "/");
+		const base: FileMention = { path: rawPath, range: tok.range, kind: "unresolved" };
+
+		const markUnresolved = (reason: string) => {
+			base.kind = "unresolved";
+			base.reason = reason;
+			mentions.push(base);
+			warnings.push(`@${rawPath}: ${reason}`);
+		};
+
+		// Path safety: resolve relative to cwd and reject escapes.
+		const absPath = path.resolve(cwd, normRel);
+		const relCheck = path.relative(cwd, absPath);
+		if (relCheck === ".." || relCheck.startsWith(".." + path.sep) || path.isAbsolute(relCheck)) {
+			markUnresolved("outside-cwd");
+			continue;
+		}
+
+		// Stat the file.
+		let size: number;
+		try {
+			const st = fs.statSync(absPath);
+			if (!st.isFile()) {
+				markUnresolved("missing");
+				continue;
+			}
+			size = st.size;
+		} catch {
+			markUnresolved("missing");
+			continue;
+		}
+
+		base.absPath = absPath;
+		base.bytes = size;
+		const ext = path.extname(normRel).toLowerCase();
+
+		// ── Image (by extension) ──────────────────────────────────────
+		if (IMAGE_MIME[ext]) {
+			if (size > maxFileBytes) {
+				markUnresolved("too-large");
+				continue;
+			}
+			let data: string;
+			try {
+				data = fs.readFileSync(absPath).toString("base64");
+			} catch {
+				markUnresolved("unreadable");
+				continue;
+			}
+			if (aggregateUsed + data.length > maxAggregate) {
+				markUnresolved("aggregate-cap");
+				continue;
+			}
+			aggregateUsed += data.length;
+			base.kind = "image";
+			base.data = data;
+			base.mimeType = IMAGE_MIME[ext];
+			mentions.push(base);
+			continue;
+		}
+
+		// ── Non-image: read and sniff text vs binary ─────────────────
+		if (size > maxFileBytes) {
+			markUnresolved("too-large");
+			continue;
+		}
+		let buf: Buffer;
+		try {
+			buf = fs.readFileSync(absPath);
+		} catch {
+			markUnresolved("unreadable");
+			continue;
+		}
+
+		if (isLikelyText(buf)) {
+			if (size > maxTextBytes) {
+				markUnresolved("too-large");
+				continue;
+			}
+			const content = buf.toString("utf-8");
+			const contentBytes = Buffer.byteLength(content, "utf-8");
+			if (aggregateUsed + contentBytes > maxAggregate) {
+				markUnresolved("aggregate-cap");
+				continue;
+			}
+			aggregateUsed += contentBytes;
+			base.kind = "text";
+			base.content = content;
+			mentions.push(base);
+			replacements.push({
+				start: tok.range[0],
+				end: tok.range[1],
+				expanded: buildFileReferenceBlock(normRel, content),
+			});
+			continue;
+		}
+
+		// Binary (non-image).
+		const data = buf.toString("base64");
+		if (aggregateUsed + data.length > maxAggregate) {
+			markUnresolved("aggregate-cap");
+			continue;
+		}
+		aggregateUsed += data.length;
+		base.kind = "binary";
+		base.data = data;
+		base.mimeType = "application/octet-stream";
+		mentions.push(base);
+	}
+
+	// Build modelText by splicing text mentions right-to-left.
+	let modelText = text;
+	if (replacements.length > 0) {
+		replacements.sort((a, b) => a.start - b.start);
+		for (let i = replacements.length - 1; i >= 0; i--) {
+			const r = replacements[i];
+			modelText = modelText.slice(0, r.start) + r.expanded + modelText.slice(r.end);
+		}
+	}
+
+	return { originalText, modelText, mentions, warnings };
+}

--- a/src/server/skills/resolve-file-mentions.ts
+++ b/src/server/skills/resolve-file-mentions.ts
@@ -15,22 +15,23 @@
  *                   (the literal `@path` stays so the model has the
  *                   filename, and the handler routes the bytes through the
  *                   image attachment frame).
+ *       • `binary`→ non-image, non-text files (e.g. `.zip`, `.bin`): base64
+ *                   snapshot in `data`, ext-derived (or octet-stream) mimeType;
+ *                   `modelText` left untouched (literal `@path` kept). The
+ *                   handler routes these to the attachment pipeline as a
+ *                   document — for UI chip + snapshot parity with
+ *                   user-uploaded documents. (See handler note: model-side
+ *                   delivery of document bytes is an existing platform concern,
+ *                   not a regression of this feature.)
  *       • `unresolved` → missing / unreadable / too-large / outside-cwd /
- *                   aggregate-cap / too-many-mentions / unsupported-binary.
- *                   Literal `@path` left in `modelText`, `reason` set.
- *                   **Never throws** — every failure path degrades gracefully.
+ *                   aggregate-cap / too-many-mentions. Literal `@path` left in
+ *                   `modelText`, `reason` set. **Never throws** — every failure
+ *                   path degrades gracefully.
  *
- *     Non-image, non-text files (e.g. `.zip`, `.bin`) are classified
- *     `unresolved` with reason `unsupported-binary`: the prompt RPC only
- *     carries text + images (`rpcClient.prompt(text, images)`), so there is
- *     no honest way to deliver raw binary bytes to the model. The literal
- *     `@path` stays in `modelText` so the model at least sees the filename,
- *     and the chip surfaces the reason.
- *
- *   - **Snapshot at resolve time** — text content and image base64 bytes are
- *     captured now so replaying a `.jsonl` later renders the same content the
- *     model originally saw, even if the file changed on disk. (Same guarantee
- *     as skill expansions.)
+ *   - **Snapshot at resolve time** — text content and image/binary base64
+ *     bytes are captured now so replaying a `.jsonl` later renders the same
+ *     content the model originally saw, even if the file changed on disk.
+ *     (Same guarantee as skill expansions.)
  *
  *   - **Path safety** — the target is canonicalized with `fs.realpathSync`
  *     and a `path.relative` containment check is applied to the CANONICAL
@@ -48,21 +49,22 @@ import path from "node:path";
 /** Char range, in UTF-16 code units (matches `String.prototype.slice`). */
 export type MentionRange = [number, number];
 
-export type MentionKind = "text" | "image" | "unresolved";
+export type MentionKind = "text" | "image" | "binary" | "unresolved";
 
 export interface FileMention {
 	/** Relative path exactly as typed (after the `@`), trailing punctuation trimmed. */
 	path: string;
-	/** Resolved (canonical) absolute host path (omitted if unresolved). */
+	/** Resolved (canonical) absolute host path. Internal to the resolver — the
+	 *  handler strips this before the mention crosses the wire / is persisted. */
 	absPath?: string;
 	/** UTF-16 char range in `originalText` that the chip replaces (`@path` span). */
 	range: MentionRange;
 	kind: MentionKind;
 	/** text kind: snapshotted file content (verbatim). */
 	content?: string;
-	/** image kind: base64 (no data-URL prefix) snapshot. */
+	/** image/binary kind: base64 (no data-URL prefix) snapshot. */
 	data?: string;
-	/** image kind: detected MIME type. */
+	/** image/binary kind: detected MIME type. */
 	mimeType?: string;
 	/** Resolved file size in bytes. */
 	bytes?: number;
@@ -83,7 +85,7 @@ export interface ResolvedMentions {
 
 /** Per-file cap for **text** inlining. Oversized text → unresolved (too-large). */
 export const MAX_INLINE_TEXT_BYTES = 256 * 1024; // 256 KiB
-/** Per-file cap for image snapshots. Over → unresolved (too-large). */
+/** Per-file cap for image/binary snapshots. Over → unresolved (too-large). */
 export const MAX_MENTION_FILE_BYTES = 10 * 1024 * 1024; // 10 MiB
 /** Aggregate cap across all resolved mentions in one send. */
 export const MAX_MENTION_AGGREGATE_BYTES = 20 * 1024 * 1024; // 20 MiB
@@ -103,6 +105,25 @@ const IMAGE_MIME: Record<string, string> = {
 	".avif": "image/avif",
 };
 
+/** A few common binary extensions → MIME type. Falls back to octet-stream. */
+const BINARY_MIME: Record<string, string> = {
+	".pdf": "application/pdf",
+	".zip": "application/zip",
+	".gz": "application/gzip",
+	".tar": "application/x-tar",
+	".wasm": "application/wasm",
+	".doc": "application/msword",
+	".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+	".xls": "application/vnd.ms-excel",
+	".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+	".ppt": "application/vnd.ms-powerpoint",
+	".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+};
+
+function binaryMimeForExt(ext: string): string {
+	return BINARY_MIME[ext] ?? "application/octet-stream";
+}
+
 /** Trailing punctuation trimmed off a token end (unlikely to be part of a path). */
 const TRAILING_PUNCT = new Set([".", ",", ")", ":", ";"]);
 
@@ -113,6 +134,16 @@ const TRAILING_PUNCT = new Set([".", ",", ")", ":", ";"]);
  */
 export function buildFileReferenceBlock(relPath: string, content: string): string {
 	return `<file-reference path="${relPath.replace(/\\/g, "/")}">\n${content}\n</file-reference>`;
+}
+
+/**
+ * Strip resolver-internal fields (`absPath`) from a mention before it crosses
+ * the wire / is persisted to the sidecar. The UI never needs `absPath` and
+ * exposing it would leak the host filesystem layout (FOLLOW-UP-D).
+ */
+export function toWireMention(m: FileMention): FileMention {
+	const { absPath: _absPath, ...rest } = m;
+	return rest;
 }
 
 export interface ResolveFileMentionsOptions {
@@ -161,6 +192,13 @@ function escapesDir(baseDir: string, target: string): boolean {
 function isLikelyText(buf: Buffer): boolean {
 	if (buf.length === 0) return true;
 	if (buf.includes(0)) return false; // NUL byte ⇒ binary
+	// Reject content that is not valid UTF-8 (e.g. stray high bytes from a
+	// binary blob without NULs). A fatal TextDecoder throws on malformed input.
+	try {
+		new TextDecoder("utf-8", { fatal: true }).decode(buf);
+	} catch {
+		return false;
+	}
 	const sample = buf.subarray(0, Math.min(buf.length, 8192));
 	let control = 0;
 	for (const b of sample) {
@@ -324,11 +362,20 @@ export function resolveFileMentions(
 			continue;
 		}
 
-		// Non-image binary: the prompt RPC only carries text + images, so raw
-		// binary bytes cannot be honestly delivered to the model. Leave the
-		// literal `@path` in modelText (model still sees the filename) and
-		// surface the reason in the chip.
-		markUnresolved("unsupported-binary");
+		// Non-image binary (per frozen design §2): snapshot base64 in `data`,
+		// ext-derived mimeType. The handler routes this to attachments[] as a
+		// document for UI chip + snapshot parity. `modelText` is left untouched
+		// (literal `@path` kept). Subject to the per-file + aggregate caps.
+		const data = buf.toString("base64");
+		if (aggregateUsed + data.length > maxAggregate) {
+			markUnresolved("aggregate-cap");
+			continue;
+		}
+		aggregateUsed += data.length;
+		base.kind = "binary";
+		base.data = data;
+		base.mimeType = binaryMimeForExt(ext);
+		mentions.push(base);
 	}
 
 	// Build modelText by splicing text mentions right-to-left.

--- a/src/server/skills/resolve-file-mentions.ts
+++ b/src/server/skills/resolve-file-mentions.ts
@@ -127,13 +127,24 @@ function binaryMimeForExt(ext: string): string {
 /** Trailing punctuation trimmed off a token end (unlikely to be part of a path). */
 const TRAILING_PUNCT = new Set([".", ",", ")", ":", ";"]);
 
+/** Escape the five XML attribute-significant chars so a quote / angle bracket
+ *  in a filename cannot break out of the `path="…"` delimiter. */
+function escapeXmlAttr(s: string): string {
+	return s
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;");
+}
+
 /**
  * Build the model-facing inline block for a text mention. Exported so the
  * handler can re-splice text mentions and skill expansions onto the same
- * original string in one merged right-to-left pass (disjoint ranges).
+ * original string in one merged right-to-left pass (disjoint ranges). The path
+ * is XML-attribute-escaped so a hostile filename cannot break the delimiter.
  */
 export function buildFileReferenceBlock(relPath: string, content: string): string {
-	return `<file-reference path="${relPath.replace(/\\/g, "/")}">\n${content}\n</file-reference>`;
+	return `<file-reference path="${escapeXmlAttr(relPath.replace(/\\/g, "/"))}">\n${content}\n</file-reference>`;
 }
 
 /**
@@ -301,36 +312,22 @@ export function resolveFileMentions(
 		base.bytes = size;
 		const ext = path.extname(normRel).toLowerCase();
 
-		// ── Image (by extension) ──────────────────────────────────────
-		if (IMAGE_MIME[ext]) {
-			if (size > maxFileBytes) {
-				markUnresolved("too-large");
-				continue;
-			}
-			let data: string;
-			try {
-				data = fs.readFileSync(absPath).toString("base64");
-			} catch {
-				markUnresolved("unreadable");
-				continue;
-			}
-			if (aggregateUsed + data.length > maxAggregate) {
-				markUnresolved("aggregate-cap");
-				continue;
-			}
-			aggregateUsed += data.length;
-			base.kind = "image";
-			base.data = data;
-			base.mimeType = IMAGE_MIME[ext];
-			mentions.push(base);
-			continue;
-		}
-
-		// ── Non-image: read and sniff text vs binary ─────────────────
+		// Per-file cap, checked against the STAT size before any read so a giant
+		// file is never loaded. (Text has a smaller cap, applied post-read on
+		// the decoded content below.)
 		if (size > maxFileBytes) {
 			markUnresolved("too-large");
 			continue;
 		}
+		// Aggregate gate BEFORE reading/encoding: with up to 50 mentions × 10 MiB
+		// each, unconditional reads would block the WS handler with hundreds of
+		// MiB despite the 20 MiB cap. Pre-check using the known stat size; only
+		// read when it fits, then account the actual bytes.
+		if (aggregateUsed + size > maxAggregate) {
+			markUnresolved("aggregate-cap");
+			continue;
+		}
+
 		let buf: Buffer;
 		try {
 			buf = fs.readFileSync(absPath);
@@ -338,14 +335,39 @@ export function resolveFileMentions(
 			markUnresolved("unreadable");
 			continue;
 		}
+		// TOCTOU: the file may have grown between stat and read. Re-validate the
+		// per-file cap and remaining aggregate budget against the bytes we
+		// actually got; never emit oversized content.
+		if (buf.length > maxFileBytes) {
+			markUnresolved("too-large");
+			continue;
+		}
+		if (aggregateUsed + buf.length > maxAggregate) {
+			markUnresolved("aggregate-cap");
+			continue;
+		}
 
+		// ── Image (by extension) ──────────────────────────────────────
+		if (IMAGE_MIME[ext]) {
+			aggregateUsed += buf.length;
+			base.kind = "image";
+			base.data = buf.toString("base64");
+			base.mimeType = IMAGE_MIME[ext];
+			base.bytes = buf.length;
+			mentions.push(base);
+			continue;
+		}
+
+		// ── Non-image: sniff text vs binary ──────────────────────────
 		if (isLikelyText(buf)) {
-			if (size > maxTextBytes) {
+			const content = buf.toString("utf-8");
+			const contentBytes = Buffer.byteLength(content, "utf-8");
+			// Text has a smaller per-file cap, applied to the decoded content.
+			if (contentBytes > maxTextBytes) {
 				markUnresolved("too-large");
 				continue;
 			}
-			const content = buf.toString("utf-8");
-			const contentBytes = Buffer.byteLength(content, "utf-8");
+			// Re-check aggregate against the actual content bytes (TOCTOU).
 			if (aggregateUsed + contentBytes > maxAggregate) {
 				markUnresolved("aggregate-cap");
 				continue;
@@ -353,6 +375,7 @@ export function resolveFileMentions(
 			aggregateUsed += contentBytes;
 			base.kind = "text";
 			base.content = content;
+			base.bytes = buf.length;
 			mentions.push(base);
 			replacements.push({
 				start: tok.range[0],
@@ -365,16 +388,12 @@ export function resolveFileMentions(
 		// Non-image binary (per frozen design §2): snapshot base64 in `data`,
 		// ext-derived mimeType. The handler routes this to attachments[] as a
 		// document for UI chip + snapshot parity. `modelText` is left untouched
-		// (literal `@path` kept). Subject to the per-file + aggregate caps.
-		const data = buf.toString("base64");
-		if (aggregateUsed + data.length > maxAggregate) {
-			markUnresolved("aggregate-cap");
-			continue;
-		}
-		aggregateUsed += data.length;
+		// (literal `@path` kept). Caps already enforced above.
+		aggregateUsed += buf.length;
 		base.kind = "binary";
-		base.data = data;
+		base.data = buf.toString("base64");
 		base.mimeType = binaryMimeForExt(ext);
+		base.bytes = buf.length;
 		mentions.push(base);
 	}
 

--- a/src/server/skills/resolve-file-mentions.ts
+++ b/src/server/skills/resolve-file-mentions.ts
@@ -15,17 +15,27 @@
  *                   (the literal `@path` stays so the model has the
  *                   filename, and the handler routes the bytes through the
  *                   image attachment frame).
- *       • `binary`→ base64 snapshot in `data`; routed as a document
- *                   attachment by the handler; `modelText` untouched.
  *       • `unresolved` → missing / unreadable / too-large / outside-cwd /
- *                   aggregate-cap. Literal `@path` left in `modelText`,
- *                   `reason` set. **Never throws** — every failure path
- *                   degrades gracefully.
+ *                   aggregate-cap / too-many-mentions / unsupported-binary.
+ *                   Literal `@path` left in `modelText`, `reason` set.
+ *                   **Never throws** — every failure path degrades gracefully.
  *
- *   - **Snapshot at resolve time** — file content (text) and base64 bytes
- *     (image/binary) are captured now so replaying a `.jsonl` later renders
- *     the same content the model originally saw, even if the file changed
- *     on disk. (Same guarantee as skill expansions.)
+ *     Non-image, non-text files (e.g. `.zip`, `.bin`) are classified
+ *     `unresolved` with reason `unsupported-binary`: the prompt RPC only
+ *     carries text + images (`rpcClient.prompt(text, images)`), so there is
+ *     no honest way to deliver raw binary bytes to the model. The literal
+ *     `@path` stays in `modelText` so the model at least sees the filename,
+ *     and the chip surfaces the reason.
+ *
+ *   - **Snapshot at resolve time** — text content and image base64 bytes are
+ *     captured now so replaying a `.jsonl` later renders the same content the
+ *     model originally saw, even if the file changed on disk. (Same guarantee
+ *     as skill expansions.)
+ *
+ *   - **Path safety** — the target is canonicalized with `fs.realpathSync`
+ *     and a `path.relative` containment check is applied to the CANONICAL
+ *     paths BEFORE any stat/read, so a symlink inside `cwd` that points
+ *     outside `cwd` cannot leak host files.
  *
  * Text inlining splices **right-to-left** by range to preserve indices.
  *
@@ -38,21 +48,21 @@ import path from "node:path";
 /** Char range, in UTF-16 code units (matches `String.prototype.slice`). */
 export type MentionRange = [number, number];
 
-export type MentionKind = "text" | "image" | "binary" | "unresolved";
+export type MentionKind = "text" | "image" | "unresolved";
 
 export interface FileMention {
 	/** Relative path exactly as typed (after the `@`), trailing punctuation trimmed. */
 	path: string;
-	/** Resolved absolute host path (omitted if unresolved). */
+	/** Resolved (canonical) absolute host path (omitted if unresolved). */
 	absPath?: string;
 	/** UTF-16 char range in `originalText` that the chip replaces (`@path` span). */
 	range: MentionRange;
 	kind: MentionKind;
 	/** text kind: snapshotted file content (verbatim). */
 	content?: string;
-	/** image/binary kind: base64 (no data-URL prefix) snapshot. */
+	/** image kind: base64 (no data-URL prefix) snapshot. */
 	data?: string;
-	/** image/binary kind: detected MIME type. */
+	/** image kind: detected MIME type. */
 	mimeType?: string;
 	/** Resolved file size in bytes. */
 	bytes?: number;
@@ -73,10 +83,12 @@ export interface ResolvedMentions {
 
 /** Per-file cap for **text** inlining. Oversized text → unresolved (too-large). */
 export const MAX_INLINE_TEXT_BYTES = 256 * 1024; // 256 KiB
-/** Per-file cap for image/binary snapshots. Over → unresolved (too-large). */
+/** Per-file cap for image snapshots. Over → unresolved (too-large). */
 export const MAX_MENTION_FILE_BYTES = 10 * 1024 * 1024; // 10 MiB
 /** Aggregate cap across all resolved mentions in one send. */
 export const MAX_MENTION_AGGREGATE_BYTES = 20 * 1024 * 1024; // 20 MiB
+/** Max `@path` tokens resolved per send. Extra tokens → unresolved (too-many-mentions), no fs work. */
+export const MAX_MENTIONS_PER_SEND = 50;
 
 /** Image extensions → MIME type. */
 const IMAGE_MIME: Record<string, string> = {
@@ -139,6 +151,12 @@ function scanTokens(text: string): ScannedToken[] {
 	return out;
 }
 
+/** True when `target` is not contained within `baseDir` (escape via `..` / absolute). */
+function escapesDir(baseDir: string, target: string): boolean {
+	const rel = path.relative(baseDir, target);
+	return rel === ".." || rel.startsWith(".." + path.sep) || path.isAbsolute(rel);
+}
+
 /** Heuristic: is this buffer likely UTF-8 text (not binary)? */
 function isLikelyText(buf: Buffer): boolean {
 	if (buf.length === 0) return true;
@@ -171,7 +189,18 @@ export function resolveFileMentions(
 	const warnings: string[] = [];
 	const replacements: Array<{ start: number; end: number; expanded: string }> = [];
 
+	// Canonicalize cwd once for symlink-safe containment checks. Fall back to
+	// the lexically-resolved cwd if it cannot be realpath'd (e.g. missing).
+	const resolvedCwd = path.resolve(cwd);
+	let canonicalCwd: string;
+	try {
+		canonicalCwd = fs.realpathSync.native(resolvedCwd);
+	} catch {
+		canonicalCwd = resolvedCwd;
+	}
+
 	let aggregateUsed = 0;
+	let resolvedCount = 0;
 
 	for (const tok of tokens) {
 		const rawPath = tok.rawPath;
@@ -185,15 +214,38 @@ export function resolveFileMentions(
 			warnings.push(`@${rawPath}: ${reason}`);
 		};
 
-		// Path safety: resolve relative to cwd and reject escapes.
-		const absPath = path.resolve(cwd, normRel);
-		const relCheck = path.relative(cwd, absPath);
-		if (relCheck === ".." || relCheck.startsWith(".." + path.sep) || path.isAbsolute(relCheck)) {
+		// Mention-count cap: beyond the cap, degrade without any filesystem work.
+		if (resolvedCount >= MAX_MENTIONS_PER_SEND) {
+			markUnresolved("too-many-mentions");
+			continue;
+		}
+		resolvedCount++;
+
+		// Path safety, step 1: cheap lexical reject of obvious `..` / absolute
+		// escapes (also handles non-existent traversal paths).
+		const lexicalAbs = path.resolve(resolvedCwd, normRel);
+		if (escapesDir(resolvedCwd, lexicalAbs)) {
 			markUnresolved("outside-cwd");
 			continue;
 		}
 
-		// Stat the file.
+		// Path safety, step 2: canonicalize to defeat symlink escapes. realpath
+		// throws when the target does not exist → treat as missing. The
+		// containment check runs on the CANONICAL paths BEFORE any stat/read,
+		// so a symlink inside cwd pointing outside cwd is rejected.
+		let absPath: string;
+		try {
+			absPath = fs.realpathSync.native(lexicalAbs);
+		} catch {
+			markUnresolved("missing");
+			continue;
+		}
+		if (escapesDir(canonicalCwd, absPath)) {
+			markUnresolved("outside-cwd");
+			continue;
+		}
+
+		// Stat the (canonical) file.
 		let size: number;
 		try {
 			const st = fs.statSync(absPath);
@@ -272,17 +324,11 @@ export function resolveFileMentions(
 			continue;
 		}
 
-		// Binary (non-image).
-		const data = buf.toString("base64");
-		if (aggregateUsed + data.length > maxAggregate) {
-			markUnresolved("aggregate-cap");
-			continue;
-		}
-		aggregateUsed += data.length;
-		base.kind = "binary";
-		base.data = data;
-		base.mimeType = "application/octet-stream";
-		mentions.push(base);
+		// Non-image binary: the prompt RPC only carries text + images, so raw
+		// binary bytes cannot be honestly delivered to the model. Leave the
+		// literal `@path` in modelText (model still sees the filename) and
+		// surface the reason in the chip.
+		markUnresolved("unsupported-binary");
 	}
 
 	// Build modelText by splicing text mentions right-to-left.

--- a/src/server/skills/skill-sidecar.ts
+++ b/src/server/skills/skill-sidecar.ts
@@ -131,6 +131,65 @@ export function findSkillSidecarEntry(
 	return entries.find((e) => e.modelText === modelText);
 }
 
+/**
+ * Pure merge of sidecar entries into a list of agent messages. For each user
+ * message whose text body equals an entry's `modelText`, rewrite the body to
+ * `originalText` and re-attach BOTH `skillExpansions` and `fileMentions`
+ * (when present). This is the restore / authoritative-snapshot counterpart to
+ * the live broadcast splice (`spliceSkillExpansionsIntoEvent`); the two MUST
+ * stay in sync or chips vanish on reload. Pinned by tests/skill-sidecar.test.ts.
+ *
+ * Duplicate identical messages are matched in FIFO order. Idempotent for
+ * messages without a matching entry. The input array/objects are not mutated.
+ */
+export function mergeSidecarEntriesIntoMessages(
+	entries: SkillSidecarEntry[],
+	messages: any[],
+): any[] {
+	if (!Array.isArray(messages) || messages.length === 0) return messages;
+	if (!Array.isArray(entries) || entries.length === 0) return messages;
+	const queues = new Map<string, SkillSidecarEntry[]>();
+	for (const e of entries) {
+		const arr = queues.get(e.modelText) ?? [];
+		arr.push(e);
+		queues.set(e.modelText, arr);
+	}
+	let changed = false;
+	const out = messages.map((msg: any) => {
+		if (!msg || (msg.role !== "user" && msg.role !== "user-with-attachments")) return msg;
+		let body: string;
+		if (typeof msg.content === "string") body = msg.content;
+		else if (Array.isArray(msg.content)) {
+			const block = msg.content.find((c: any) => c?.type === "text");
+			body = block?.text ?? "";
+		} else body = "";
+		const q = queues.get(body);
+		if (!q || q.length === 0) return msg;
+		const envelope = q.shift()!;
+		changed = true;
+		let newContent: any;
+		if (typeof msg.content === "string") {
+			newContent = envelope.originalText;
+		} else if (Array.isArray(msg.content)) {
+			newContent = msg.content.map((c: any) =>
+				c?.type === "text" ? { ...c, text: envelope.originalText } : c,
+			);
+			if (!newContent.some((c: any) => c?.type === "text")) {
+				newContent.unshift({ type: "text", text: envelope.originalText });
+			}
+		} else {
+			newContent = envelope.originalText;
+		}
+		return {
+			...msg,
+			content: newContent,
+			skillExpansions: envelope.skillExpansions,
+			...(envelope.fileMentions?.length ? { fileMentions: envelope.fileMentions } : {}),
+		};
+	});
+	return changed ? out : messages;
+}
+
 /** Delete the sidecar for a session (archive purge / terminate). */
 export function purgeSkillSidecar(sessionId: string): void {
 	const file = sidecarPath(sessionId);

--- a/src/server/skills/skill-sidecar.ts
+++ b/src/server/skills/skill-sidecar.ts
@@ -22,6 +22,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { SkillExpansion } from "./resolve-skill-expansions.js";
+import type { FileMention } from "./resolve-file-mentions.js";
 
 export interface SkillSidecarEntry {
 	/** Unix epoch (ms) at the moment the user message was persisted. */
@@ -30,8 +31,14 @@ export interface SkillSidecarEntry {
 	modelText: string;
 	/** What the user actually typed. */
 	originalText: string;
-	/** Chips, snapshotted at invocation time. */
+	/** Slash-skill chips, snapshotted at invocation time. */
 	skillExpansions: SkillExpansion[];
+	/**
+	 * `@path` file-mention chips, snapshotted at send time. Optional so old
+	 * entries (written before this field existed) still parse, and entries
+	 * carrying only file mentions (no skill expansions) round-trip correctly.
+	 */
+	fileMentions?: FileMention[];
 }
 
 let _sidecarDir: string | undefined;
@@ -89,7 +96,13 @@ export function readSkillSidecarEntries(sessionId: string): SkillSidecarEntry[] 
 			if (!trimmed) continue;
 			try {
 				const parsed = JSON.parse(trimmed) as SkillSidecarEntry;
-				if (parsed && typeof parsed.modelText === "string" && Array.isArray(parsed.skillExpansions)) {
+				// Accept entries with skillExpansions OR fileMentions (either may be
+				// absent now that file mentions can be persisted without skills).
+				if (
+					parsed &&
+					typeof parsed.modelText === "string" &&
+					(Array.isArray(parsed.skillExpansions) || Array.isArray(parsed.fileMentions))
+				) {
 					out.push(parsed);
 				}
 			} catch { /* skip malformed line */ }

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -12,7 +12,7 @@ import type { ClientMessage, ServerMessage } from "./protocol.js";
 import type { TaskState } from "../agent/task-store.js";
 import { TaskManager } from "../agent/task-manager.js";
 import { resolveSkillExpansions } from "../skills/resolve-skill-expansions.js";
-import { resolveFileMentions } from "../skills/resolve-file-mentions.js";
+import { resolveFileMentions, toWireMention } from "../skills/resolve-file-mentions.js";
 import { buildMergedModelText } from "../skills/merge-mentions.js";
 import { inferMeta } from "../agent/aigw-manager.js";
 import { clampThinkingLevel, isKnownThinkingLevel } from "../../shared/thinking-levels.js";
@@ -551,9 +551,18 @@ export function handleWebSocketConnection(
 					// two resolvers never produce overlapping ranges. A bad
 					// reference never tears down the send — it degrades to a
 					// literal `@path` plus a warning.
-					const fileMentionResult = resolveFileMentions(msg.text, skillCwd);
+					//
+					// IMPORTANT: file mentions resolve against the session's HOST
+					// worktree, NOT skillCwd. skillCwd redirects to the project
+					// rootPath for SKILL discovery (correct there), but that tree
+					// misses the goal/session worktree's branch-local, untracked
+					// and gitignored files. worktreePath is the host path; for
+					// sandboxed sessions session.cwd is a container path, so
+					// worktreePath is required to reach the real files.
+					const fileMentionCwd = session.worktreePath || session.cwd;
+					const fileMentionResult = resolveFileMentions(msg.text, fileMentionCwd);
 					for (const w of fileMentionResult.warnings) {
-						console.warn(`[ws-handler] File mention ${w} (session ${sessionId}, cwd=${session.cwd})`);
+						console.warn(`[ws-handler] File mention ${w} (session ${sessionId}, cwd=${fileMentionCwd})`);
 					}
 					if (fileMentionResult.mentions.length > 0) {
 						console.log(`[ws-handler] Resolved ${fileMentionResult.mentions.length} file mention(s) for session ${sessionId}`);
@@ -566,25 +575,46 @@ export function handleWebSocketConnection(
 					// renders). See buildMergedModelText for the full rationale.
 					const mergedModelText = buildMergedModelText(originalText, expansions, fileMentionResult.mentions);
 
-					// Route image mentions through the existing image frame. Text
-					// mentions are inlined into modelText above; non-image/binary
-					// mentions resolve to `unresolved` (the prompt RPC carries
-					// only text + images, so raw binary cannot reach the model).
+					// Route image mentions through the image frame and binary
+					// mentions through the document-attachment pipeline (text
+					// mentions are inlined into modelText above). Binary mentions
+					// are attached for UI chip + snapshot parity with
+					// user-uploaded documents; model-side delivery of document
+					// bytes is an existing platform concern (the prompt RPC
+					// carries text + images), NOT a regression of this feature.
 					const sendImages = msg.images ? [...msg.images] : [];
+					const sendAttachments = msg.attachments ? [...msg.attachments] : [];
 					for (const mention of fileMentionResult.mentions) {
 						if (mention.kind === "image" && mention.data && mention.mimeType) {
 							sendImages.push({ type: "image", data: mention.data, mimeType: mention.mimeType });
+						} else if (mention.kind === "binary" && mention.data) {
+							const norm = mention.path.replace(/\\/g, "/");
+							sendAttachments.push({
+								id: `mention-${Date.now()}-${mention.range[0]}`,
+								type: "document",
+								fileName: norm.slice(norm.lastIndexOf("/") + 1) || norm,
+								mimeType: mention.mimeType ?? "application/octet-stream",
+								size: mention.bytes ?? 0,
+								content: mention.data,
+							});
 						}
 					}
 
 					const hasFileMentions = fileMentionResult.mentions.length > 0;
 					const modelChanged = mergedModelText !== originalText;
 
+					// Strip the internal canonical `absPath` before the mention
+					// crosses the wire / is persisted to the sidecar — the UI
+					// never needs it and it would leak host filesystem layout.
+					const wireFileMentions = hasFileMentions
+						? fileMentionResult.mentions.map(toWireMention)
+						: undefined;
+
 					await sessionManager.enqueuePrompt(sessionId, originalText, {
 						images: sendImages.length ? sendImages : undefined,
-						attachments: msg.attachments,
+						attachments: sendAttachments.length ? sendAttachments : undefined,
 						skillExpansions: expansions.length ? expansions : undefined,
-						fileMentions: hasFileMentions ? fileMentionResult.mentions : undefined,
+						fileMentions: wireFileMentions,
 						modelText: modelChanged ? mergedModelText : undefined,
 					});
 					break;

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -12,7 +12,8 @@ import type { ClientMessage, ServerMessage } from "./protocol.js";
 import type { TaskState } from "../agent/task-store.js";
 import { TaskManager } from "../agent/task-manager.js";
 import { resolveSkillExpansions } from "../skills/resolve-skill-expansions.js";
-import { resolveFileMentions, buildFileReferenceBlock } from "../skills/resolve-file-mentions.js";
+import { resolveFileMentions } from "../skills/resolve-file-mentions.js";
+import { buildMergedModelText } from "../skills/merge-mentions.js";
 import { inferMeta } from "../agent/aigw-manager.js";
 import { clampThinkingLevel, isKnownThinkingLevel } from "../../shared/thinking-levels.js";
 import { truncateLargeToolContentInMessages } from "../agent/truncate-large-content.js";
@@ -559,48 +560,20 @@ export function handleWebSocketConnection(
 					}
 
 					// Merge skill expansions + text file mentions into one
-					// right-to-left splice over the original text (disjoint
-					// ranges). `modelText` from resolveSkillExpansions is
-					// recomputed here so both edits land on the same string.
-					const mergedReplacements: Array<{ start: number; end: number; expanded: string }> = [];
-					for (const e of expansions) {
-						mergedReplacements.push({ start: e.range[0], end: e.range[1], expanded: e.expanded });
-					}
-					for (const mention of fileMentionResult.mentions) {
-						if (mention.kind === "text" && mention.content !== undefined) {
-							mergedReplacements.push({
-								start: mention.range[0],
-								end: mention.range[1],
-								expanded: buildFileReferenceBlock(mention.path, mention.content),
-							});
-						}
-					}
-					let mergedModelText = originalText;
-					if (mergedReplacements.length > 0) {
-						mergedReplacements.sort((a, b) => a.start - b.start);
-						for (let i = mergedReplacements.length - 1; i >= 0; i--) {
-							const r = mergedReplacements[i];
-							mergedModelText = mergedModelText.slice(0, r.start) + r.expanded + mergedModelText.slice(r.end);
-						}
-					}
+					// right-to-left splice over the original text. Prefix-only
+					// slash skills overlap any @file token; on overlap the skill
+					// wins and the file mention is not inlined (chip still
+					// renders). See buildMergedModelText for the full rationale.
+					const mergedModelText = buildMergedModelText(originalText, expansions, fileMentionResult.mentions);
 
-					// Route image/binary mentions through the existing attachment
-					// pipeline; text mentions are already inlined into modelText.
+					// Route image mentions through the existing image frame. Text
+					// mentions are inlined into modelText above; non-image/binary
+					// mentions resolve to `unresolved` (the prompt RPC carries
+					// only text + images, so raw binary cannot reach the model).
 					const sendImages = msg.images ? [...msg.images] : [];
-					const sendAttachments = msg.attachments ? [...msg.attachments] : [];
 					for (const mention of fileMentionResult.mentions) {
 						if (mention.kind === "image" && mention.data && mention.mimeType) {
 							sendImages.push({ type: "image", data: mention.data, mimeType: mention.mimeType });
-						} else if (mention.kind === "binary" && mention.data) {
-							const norm = mention.path.replace(/\\/g, "/");
-							sendAttachments.push({
-								id: `mention-${Date.now()}-${mention.range[0]}`,
-								type: "document",
-								fileName: norm.slice(norm.lastIndexOf("/") + 1) || norm,
-								mimeType: mention.mimeType ?? "application/octet-stream",
-								size: mention.bytes ?? 0,
-								content: mention.data,
-							});
 						}
 					}
 
@@ -609,7 +582,7 @@ export function handleWebSocketConnection(
 
 					await sessionManager.enqueuePrompt(sessionId, originalText, {
 						images: sendImages.length ? sendImages : undefined,
-						attachments: sendAttachments.length ? sendAttachments : undefined,
+						attachments: msg.attachments,
 						skillExpansions: expansions.length ? expansions : undefined,
 						fileMentions: hasFileMentions ? fileMentionResult.mentions : undefined,
 						modelText: modelChanged ? mergedModelText : undefined,

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -16,7 +16,7 @@ import { resolveFileMentions, buildFileReferenceBlock } from "../skills/resolve-
 import { inferMeta } from "../agent/aigw-manager.js";
 import { clampThinkingLevel, isKnownThinkingLevel } from "../../shared/thinking-levels.js";
 import { truncateLargeToolContentInMessages } from "../agent/truncate-large-content.js";
-import { readSkillSidecarEntries } from "../skills/skill-sidecar.js";
+import { readSkillSidecarEntries, mergeSidecarEntriesIntoMessages } from "../skills/skill-sidecar.js";
 import {
 	appendCompactionSidecarEntry,
 	makeCompactionId,
@@ -58,50 +58,16 @@ function stampSnapshotOrder(data: unknown): unknown {
  * Merge persisted skill-expansion sidecar entries into a list of agent
  * messages. For each user message whose text body equals a sidecar
  * `modelText`, rewrite the body to `originalText` and attach
- * `skillExpansions`. Idempotent: messages without matching sidecar entries
- * pass through unchanged.
+ * `skillExpansions` AND `fileMentions` (mirroring the live broadcast splice
+ * in `spliceSkillExpansionsIntoEvent`, so @-mention chips survive reload /
+ * the authoritative post-turn snapshot). Idempotent: messages without
+ * matching sidecar entries pass through unchanged.
  */
 function mergeSkillSidecarIntoMessages(sessionId: string, messages: any[]): any[] {
 	if (!Array.isArray(messages) || messages.length === 0) return messages;
 	const entries = readSkillSidecarEntries(sessionId);
 	if (entries.length === 0) return messages;
-	// Build a queue of envelopes per modelText so duplicate identical
-	// messages each get matched in FIFO order.
-	const queues = new Map<string, typeof entries>();
-	for (const e of entries) {
-		const arr = queues.get(e.modelText) ?? [];
-		arr.push(e);
-		queues.set(e.modelText, arr);
-	}
-	let changed = false;
-	const out = messages.map((msg: any) => {
-		if (!msg || (msg.role !== "user" && msg.role !== "user-with-attachments")) return msg;
-		let body: string;
-		if (typeof msg.content === "string") body = msg.content;
-		else if (Array.isArray(msg.content)) {
-			const block = msg.content.find((c: any) => c?.type === "text");
-			body = block?.text ?? "";
-		} else body = "";
-		const q = queues.get(body);
-		if (!q || q.length === 0) return msg;
-		const envelope = q.shift()!;
-		changed = true;
-		let newContent: any;
-		if (typeof msg.content === "string") {
-			newContent = envelope.originalText;
-		} else if (Array.isArray(msg.content)) {
-			newContent = msg.content.map((c: any) =>
-				c?.type === "text" ? { ...c, text: envelope.originalText } : c,
-			);
-			if (!newContent.some((c: any) => c?.type === "text")) {
-				newContent.unshift({ type: "text", text: envelope.originalText });
-			}
-		} else {
-			newContent = envelope.originalText;
-		}
-		return { ...msg, content: newContent, skillExpansions: envelope.skillExpansions };
-	});
-	return changed ? out : messages;
+	return mergeSidecarEntriesIntoMessages(entries, messages);
 }
 
 /** Send persisted model info as fallback when getState() is unavailable. */

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -12,6 +12,7 @@ import type { ClientMessage, ServerMessage } from "./protocol.js";
 import type { TaskState } from "../agent/task-store.js";
 import { TaskManager } from "../agent/task-manager.js";
 import { resolveSkillExpansions } from "../skills/resolve-skill-expansions.js";
+import { resolveFileMentions, buildFileReferenceBlock } from "../skills/resolve-file-mentions.js";
 import { inferMeta } from "../agent/aigw-manager.js";
 import { clampThinkingLevel, isKnownThinkingLevel } from "../../shared/thinking-levels.js";
 import { truncateLargeToolContentInMessages } from "../agent/truncate-large-content.js";
@@ -565,7 +566,7 @@ export function handleWebSocketConnection(
 							return null;
 						}
 						: undefined;
-					const { originalText, modelText, expansions, unknown } = resolveSkillExpansions(
+					const { originalText, expansions, unknown } = resolveSkillExpansions(
 						msg.text,
 						skillCwd,
 						resolvedConfigStore,
@@ -578,11 +579,74 @@ export function handleWebSocketConnection(
 						console.log(`[ws-handler] Resolved ${expansions.length} slash-skill expansion(s) for session ${sessionId}`);
 					}
 
+					// Resolve `@path` file mentions on the SAME verbatim text. The
+					// `/` and `@` token sets are disjoint by construction, so the
+					// two resolvers never produce overlapping ranges. A bad
+					// reference never tears down the send — it degrades to a
+					// literal `@path` plus a warning.
+					const fileMentionResult = resolveFileMentions(msg.text, skillCwd);
+					for (const w of fileMentionResult.warnings) {
+						console.warn(`[ws-handler] File mention ${w} (session ${sessionId}, cwd=${session.cwd})`);
+					}
+					if (fileMentionResult.mentions.length > 0) {
+						console.log(`[ws-handler] Resolved ${fileMentionResult.mentions.length} file mention(s) for session ${sessionId}`);
+					}
+
+					// Merge skill expansions + text file mentions into one
+					// right-to-left splice over the original text (disjoint
+					// ranges). `modelText` from resolveSkillExpansions is
+					// recomputed here so both edits land on the same string.
+					const mergedReplacements: Array<{ start: number; end: number; expanded: string }> = [];
+					for (const e of expansions) {
+						mergedReplacements.push({ start: e.range[0], end: e.range[1], expanded: e.expanded });
+					}
+					for (const mention of fileMentionResult.mentions) {
+						if (mention.kind === "text" && mention.content !== undefined) {
+							mergedReplacements.push({
+								start: mention.range[0],
+								end: mention.range[1],
+								expanded: buildFileReferenceBlock(mention.path, mention.content),
+							});
+						}
+					}
+					let mergedModelText = originalText;
+					if (mergedReplacements.length > 0) {
+						mergedReplacements.sort((a, b) => a.start - b.start);
+						for (let i = mergedReplacements.length - 1; i >= 0; i--) {
+							const r = mergedReplacements[i];
+							mergedModelText = mergedModelText.slice(0, r.start) + r.expanded + mergedModelText.slice(r.end);
+						}
+					}
+
+					// Route image/binary mentions through the existing attachment
+					// pipeline; text mentions are already inlined into modelText.
+					const sendImages = msg.images ? [...msg.images] : [];
+					const sendAttachments = msg.attachments ? [...msg.attachments] : [];
+					for (const mention of fileMentionResult.mentions) {
+						if (mention.kind === "image" && mention.data && mention.mimeType) {
+							sendImages.push({ type: "image", data: mention.data, mimeType: mention.mimeType });
+						} else if (mention.kind === "binary" && mention.data) {
+							const norm = mention.path.replace(/\\/g, "/");
+							sendAttachments.push({
+								id: `mention-${Date.now()}-${mention.range[0]}`,
+								type: "document",
+								fileName: norm.slice(norm.lastIndexOf("/") + 1) || norm,
+								mimeType: mention.mimeType ?? "application/octet-stream",
+								size: mention.bytes ?? 0,
+								content: mention.data,
+							});
+						}
+					}
+
+					const hasFileMentions = fileMentionResult.mentions.length > 0;
+					const modelChanged = mergedModelText !== originalText;
+
 					await sessionManager.enqueuePrompt(sessionId, originalText, {
-						images: msg.images,
-						attachments: msg.attachments,
+						images: sendImages.length ? sendImages : undefined,
+						attachments: sendAttachments.length ? sendAttachments : undefined,
 						skillExpansions: expansions.length ? expansions : undefined,
-						modelText: expansions.length ? modelText : undefined,
+						fileMentions: hasFileMentions ? fileMentionResult.mentions : undefined,
+						modelText: modelChanged ? mergedModelText : undefined,
 					});
 					break;
 				}

--- a/src/ui/components/FileMentionChip.ts
+++ b/src/ui/components/FileMentionChip.ts
@@ -1,0 +1,163 @@
+import { icon } from "@mariozechner/mini-lit";
+import { html, LitElement, type TemplateResult } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { ChevronDown, ChevronRight, File, FileText, Image as ImageIcon } from "lucide";
+
+/**
+ * Kind of a resolved `@path` file reference. Mirrors the server-side
+ * `MentionKind` (see `src/server/skills/resolve-file-mentions.ts`).
+ */
+export type FileMentionKind = "text" | "image" | "binary" | "unresolved";
+
+/**
+ * The data the chip needs to render. Mirrors the server-side `FileMention`
+ * shape (minus `range`, which is consumed by the splice logic in Messages.ts
+ * before reaching here, and minus `absPath`, which is host-only). The UI
+ * re-declares this structurally-identical interface so the JSON crosses the
+ * wire unchanged — it deliberately does NOT import the server module.
+ */
+export interface FileMentionChipData {
+	/** Relative path exactly as typed (after the `@`). */
+	path: string;
+	kind: FileMentionKind;
+	/** text kind: snapshotted file content (verbatim). */
+	content?: string;
+	/** image/binary kind: base64 (no data-URL prefix) snapshot. */
+	data?: string;
+	mimeType?: string;
+	/** resolved file size in bytes. */
+	bytes?: number;
+	/** unresolved kind: human-readable reason. */
+	reason?: string;
+}
+
+/** Human-readable byte size, e.g. "1.2 KB". */
+function formatBytes(bytes: number | undefined): string {
+	if (bytes == null || !Number.isFinite(bytes)) return "";
+	if (bytes < 1024) return `${bytes} B`;
+	const kb = bytes / 1024;
+	if (kb < 1024) return `${kb.toFixed(kb < 10 ? 1 : 0)} KB`;
+	const mb = kb / 1024;
+	return `${mb.toFixed(mb < 10 ? 1 : 0)} MB`;
+}
+
+/**
+ * Inline pill that represents a resolved `@path` file reference.
+ *
+ * Rendered inside `<user-message>`, spliced at the recorded `range` of an
+ * `@<path>` token in the original user text. Mirrors `SkillChip` layer-for-layer.
+ *
+ * Click toggles a disclosure that renders the snapshotted content. The body is
+ * captured at send time so replay is stable even if the file changes on disk
+ * (same guarantee as skill expansions).
+ */
+@customElement("file-mention-chip")
+export class FileMentionChip extends LitElement {
+	@property({ type: Object }) data!: FileMentionChipData;
+	/** When true, render in a block context (with footer stacked). */
+	@property({ type: Boolean }) block = false;
+	@state() private expanded = false;
+
+	protected override createRenderRoot(): HTMLElement | DocumentFragment {
+		return this; // light DOM — share global tailwind classes
+	}
+
+	override connectedCallback(): void {
+		super.connectedCallback();
+		// `display: contents` so the pill + expansion participate directly in the
+		// parent's flex-wrap layout (matches SkillChip inline behaviour).
+		this.style.display = this.block ? "block" : "contents";
+	}
+
+	private toggle = (e: Event) => {
+		e.preventDefault();
+		e.stopPropagation();
+		this.expanded = !this.expanded;
+	};
+
+	private get iconForKind() {
+		switch (this.data.kind) {
+			case "image":
+				return ImageIcon;
+			case "text":
+				return FileText;
+			default:
+				return File;
+		}
+	}
+
+	private renderPill(): TemplateResult {
+		const unresolved = this.data.kind === "unresolved";
+		const pillClass = unresolved
+			? "bg-destructive/10 hover:bg-destructive/20 text-destructive border-destructive/20"
+			: "bg-primary/10 hover:bg-primary/20 text-primary border-primary/20";
+		return html`
+			<button
+				type="button"
+				class="file-mention-chip-pill inline-flex items-center gap-1 align-baseline px-2 py-0.5 rounded-md
+					${pillClass} text-xs font-medium border transition-colors cursor-pointer max-w-full"
+				title=${`File: @${this.data.path}${this.data.reason ? ` (${this.data.reason})` : ""}`}
+				@click=${this.toggle}
+			>
+				${icon(this.iconForKind, "sm")}
+				<span class="truncate">@${this.data.path}</span>
+				${icon(this.expanded ? ChevronDown : ChevronRight, "sm")}
+			</button>
+		`;
+	}
+
+	private renderDisclosureBody(): TemplateResult {
+		const { kind, content, data, mimeType, reason } = this.data;
+		if (kind === "text") {
+			return html`<pre
+				class="px-3 py-2 max-h-[420px] overflow-auto text-xs font-mono whitespace-pre-wrap break-words"
+			>${content ?? ""}</pre>`;
+		}
+		if (kind === "image" && data) {
+			const src = `data:${mimeType || "image/png"};base64,${data}`;
+			return html`<div class="px-3 py-2 max-h-[420px] overflow-auto">
+				<img src=${src} alt=${this.data.path} class="max-w-full h-auto rounded" />
+			</div>`;
+		}
+		if (kind === "unresolved") {
+			return html`<div class="px-3 py-2 text-xs text-muted-foreground">
+				Could not resolve <span class="font-mono">@${this.data.path}</span>${reason ? html` — ${reason}` : ""}
+			</div>`;
+		}
+		// binary
+		return html`<div class="px-3 py-2 text-xs text-muted-foreground">
+			Binary file <span class="font-mono">${this.data.path}</span>${this.data.bytes != null
+				? html` (${formatBytes(this.data.bytes)})`
+				: ""} — attached, not inlined.
+		</div>`;
+	}
+
+	private renderExpansion(): TemplateResult {
+		const size = formatBytes(this.data.bytes);
+		return html`
+			<div class="file-mention-chip-expansion mt-2 mb-1 border border-border/60 rounded-md bg-muted/40 overflow-hidden">
+				${this.renderDisclosureBody()}
+				<div class="px-3 py-1.5 border-t border-border/60 text-[11px] text-muted-foreground font-mono truncate">
+					${this.data.path}${size ? html` · ${size}` : ""}
+				</div>
+			</div>
+		`;
+	}
+
+	override render(): TemplateResult {
+		if (!this.block) {
+			return html`
+				${this.renderPill()}
+				${this.expanded
+					? html`<div class="basis-full w-full">${this.renderExpansion()}</div>`
+					: ""}
+			`;
+		}
+		return html`
+			<div class="flex flex-col gap-0">
+				<div>${this.renderPill()}</div>
+				${this.expanded ? this.renderExpansion() : ""}
+			</div>
+		`;
+	}
+}

--- a/src/ui/components/MessageEditor.ts
+++ b/src/ui/components/MessageEditor.ts
@@ -276,6 +276,9 @@ export class MessageEditor extends LitElement {
 		try {
 			let url = `/api/file-mentions?cwd=${encodeURIComponent(this.cwd)}`;
 			if (this.projectId) url += `&projectId=${encodeURIComponent(this.projectId)}`;
+			// Let the server resolve the session's real host worktree (autocomplete
+			// must be scoped to the session cwd, not the project root).
+			if (this.sessionId) url += `&sessionId=${encodeURIComponent(this.sessionId)}`;
 			if (query) url += `&q=${encodeURIComponent(query)}`;
 			url += `&limit=50`;
 			const res = await gatewayFetch(url);

--- a/src/ui/components/MessageEditor.ts
+++ b/src/ui/components/MessageEditor.ts
@@ -139,6 +139,19 @@ export class MessageEditor extends LitElement {
 	private _slashSkillsCwd?: string;
 	private _slashSkillsProjectId?: string;
 
+	// @-mention file autocomplete state (parallel to the _slash* fields above).
+	@state() private _atFiles: string[] = [];
+	@state() private _atFilteredFiles: string[] = [];
+	@state() private _atMenuOpen = false;
+	@state() private _atSelectedIndex = 0;
+	@state() private _atTokenStart = 0;
+	/** The query (path fragment) typed after the most recent `@`. */
+	private _atQuery = "";
+	/** Cache invalidation keys — refetch when cwd/project changes. */
+	private _atFilesCwd?: string;
+	private _atFilesProjectId?: string;
+	private _atLoadTimer: ReturnType<typeof setTimeout> | null = null;
+
 	// Drag-to-reorder state
 	private _draggedPillId: string | null = null;
 
@@ -248,6 +261,91 @@ export class MessageEditor extends LitElement {
 		}
 	}
 
+	/** Fetch the file list for the current `@` query from the server (debounced).
+	 *  Mirrors `_loadSlashSkills` but is query-scoped because the file tree can be
+	 *  large/remote, so the server does the filtering + ranking. */
+	private async _loadFileMentions(query: string) {
+		if (!this.cwd) {
+			this._atFiles = [];
+			this._atFilteredFiles = [];
+			return;
+		}
+		// Invalidate the local cache key so a later cwd/project change refetches.
+		this._atFilesCwd = this.cwd;
+		this._atFilesProjectId = this.projectId;
+		try {
+			let url = `/api/file-mentions?cwd=${encodeURIComponent(this.cwd)}`;
+			if (this.projectId) url += `&projectId=${encodeURIComponent(this.projectId)}`;
+			if (query) url += `&q=${encodeURIComponent(query)}`;
+			url += `&limit=50`;
+			const res = await gatewayFetch(url);
+			if (res.ok) {
+				const data = await res.json();
+				this._atFiles = Array.isArray(data.files)
+					? (data.files as Array<{ path: string }>).map((f) => f.path).filter((p) => typeof p === "string")
+					: [];
+				// Re-apply the current (possibly newer) token filter so the menu
+				// reflects what the user has typed since this fetch was scheduled.
+				this._applyAtFilter();
+			}
+		} catch {
+			// Best effort — leave the last results in place.
+		}
+	}
+
+	private _scheduleLoadFileMentions(query: string) {
+		if (this._atLoadTimer) clearTimeout(this._atLoadTimer);
+		this._atLoadTimer = setTimeout(() => {
+			this._atLoadTimer = null;
+			this._loadFileMentions(query);
+		}, 120);
+	}
+
+	/** Filter the cached file list by the current `@` query for an instant menu. */
+	private _applyAtFilter() {
+		const q = this._atQuery.toLowerCase();
+		const files = q ? this._atFiles.filter((p) => p.toLowerCase().includes(q)) : this._atFiles;
+		this._atFilteredFiles = files;
+		this._atMenuOpen = files.length > 0;
+		if (this._atSelectedIndex >= files.length) this._atSelectedIndex = 0;
+	}
+
+	private _updateAtAutocomplete() {
+		const textarea = this.textareaRef.value;
+		if (!textarea) { this._atMenuOpen = false; return; }
+		const cursorPos = textarea.selectionStart;
+		const textBeforeCursor = this.value.substring(0, cursorPos);
+		// Trigger on an `@` at a word boundary (start, whitespace, or newline)
+		// followed by a path fragment with no whitespace or further `@`.
+		const match = textBeforeCursor.match(/(^|[\s])@([^\s@]*)$/);
+		if (match) {
+			this._atTokenStart = cursorPos - match[2].length - 1; // position of "@"
+			this._atQuery = match[2];
+			// Instant filter from cache, then refresh from the server (debounced).
+			this._applyAtFilter();
+			this._scheduleLoadFileMentions(this._atQuery);
+		} else {
+			this._atMenuOpen = false;
+		}
+	}
+
+	private _selectFileMention(filePath: string) {
+		const textarea = this.textareaRef.value;
+		if (!textarea) return;
+		const before = this.value.substring(0, this._atTokenStart);
+		const after = this.value.substring(textarea.selectionStart);
+		this.value = before + `@${filePath} ` + after;
+		this._atMenuOpen = false;
+		this.onInput?.(this.value);
+		// Update textarea and move cursor after the inserted path + trailing space.
+		if (textarea) {
+			textarea.value = this.value;
+			const newPos = before.length + filePath.length + 2; // "@" + path + " "
+			textarea.focus();
+			textarea.setSelectionRange(newPos, newPos);
+		}
+	}
+
 	private _isCursorOnVisualTopRow(): boolean {
 		const textarea = this.textareaRef.value;
 		if (!textarea) return true;
@@ -288,20 +386,27 @@ export class MessageEditor extends LitElement {
 		return (fullHeight - cursorHeight) <= singleRowHeight;
 	}
 
-	private _getSlashMenuLeft(): number {
+	/** Horizontal pixel offset of the autocomplete menu for a token starting at
+	 *  `tokenStart` — measures the rendered width of the text from the start of
+	 *  the visual line up to the token. Shared by the slash and `@` menus. */
+	private _getMenuLeft(tokenStart: number): number {
 		const textarea = this.textareaRef.value;
 		if (!textarea) return 0;
 		const style = getComputedStyle(textarea);
 		const mirror = document.createElement("span");
 		mirror.style.cssText = `position:absolute;visibility:hidden;white-space:pre-wrap;font:${style.font};letter-spacing:${style.letterSpacing};`;
 		mirror.textContent = this.value.substring(
-			this.value.lastIndexOf("\n", this._slashTokenStart - 1) + 1,
-			this._slashTokenStart,
+			this.value.lastIndexOf("\n", tokenStart - 1) + 1,
+			tokenStart,
 		);
 		document.body.appendChild(mirror);
 		const leftOffset = mirror.offsetWidth;
 		document.body.removeChild(mirror);
 		return leftOffset;
+	}
+
+	private _getSlashMenuLeft(): number {
+		return this._getMenuLeft(this._slashTokenStart);
 	}
 
 	/** Live preview order of pill IDs while dragging. Null when not dragging. */
@@ -361,6 +466,7 @@ export class MessageEditor extends LitElement {
 		if (this._sendSizeError) this._sendSizeError = ""; // clear the S31 error once the user edits
 		this.onInput?.(this.value);
 		this._updateSlashAutocomplete();
+		this._updateAtAutocomplete();
 	};
 
 	private handleKeyDown = (e: KeyboardEvent) => {
@@ -390,6 +496,30 @@ export class MessageEditor extends LitElement {
 			} else if (e.key === "Escape") {
 				e.preventDefault();
 				this._slashMenuOpen = false;
+				return;
+			}
+		}
+
+		// @-mention file autocomplete keyboard handling. Mutually exclusive with
+		// the slash menu — a trailing token can only be `/...` or `@...`, never both.
+		if (this._atMenuOpen) {
+			if (e.key === "ArrowDown") {
+				e.preventDefault();
+				this._atSelectedIndex = Math.min(this._atSelectedIndex + 1, this._atFilteredFiles.length - 1);
+				return;
+			} else if (e.key === "ArrowUp") {
+				e.preventDefault();
+				this._atSelectedIndex = Math.max(this._atSelectedIndex - 1, 0);
+				return;
+			} else if (e.key === "Enter" || e.key === "Tab") {
+				e.preventDefault();
+				if (this._atFilteredFiles[this._atSelectedIndex]) {
+					this._selectFileMention(this._atFilteredFiles[this._atSelectedIndex]);
+				}
+				return;
+			} else if (e.key === "Escape") {
+				e.preventDefault();
+				this._atMenuOpen = false;
 				return;
 			}
 		}
@@ -766,6 +896,7 @@ export class MessageEditor extends LitElement {
 		super.disconnectedCallback();
 		document.removeEventListener("keydown", this.handleGlobalKeyDown);
 		document.removeEventListener("keyup", this.handleGlobalKeyUp);
+		if (this._atLoadTimer) { clearTimeout(this._atLoadTimer); this._atLoadTimer = null; }
 		this.stopSpeechRecognition();
 	}
 
@@ -787,6 +918,15 @@ export class MessageEditor extends LitElement {
 		if ((changed.has("cwd") || changed.has("projectId")) && this.cwd) {
 			this._slashSkillsLoaded = false;
 			this._loadSlashSkills();
+		}
+
+		if (changed.has("cwd") || changed.has("projectId")) {
+			// Invalidate the @-mention file cache so the next `@` refetches.
+			if (this._atFilesCwd !== this.cwd || this._atFilesProjectId !== this.projectId) {
+				this._atFiles = [];
+				this._atFilteredFiles = [];
+				this._atMenuOpen = false;
+			}
 		}
 	}
 
@@ -933,6 +1073,27 @@ export class MessageEditor extends LitElement {
 								<span class="text-xs text-muted-foreground truncate">${skill.description}</span>
 							</button>
 						`)}
+					</div>
+				` : nothing}
+
+				<!-- @-mention file autocomplete (reuses slash-menu styling) -->
+				${this._atMenuOpen ? html`
+					<div class="slash-menu at-menu border-b border-border max-h-48 overflow-y-auto" style="margin-left: ${this._getMenuLeft(this._atTokenStart)}px">
+						${this._atFilteredFiles.map((filePath, i) => {
+							const slash = filePath.lastIndexOf("/");
+							const dir = slash >= 0 ? filePath.slice(0, slash + 1) : "";
+							const base = slash >= 0 ? filePath.slice(slash + 1) : filePath;
+							return html`
+							<button
+								class="w-full text-left px-3 py-2 flex items-center gap-2 cursor-pointer transition-colors ${i === this._atSelectedIndex ? "bg-accent text-accent-foreground" : "hover:bg-muted/50"}"
+								data-testid=${`file-mention-${filePath}`}
+								@mousedown=${(e: Event) => { e.preventDefault(); this._selectFileMention(filePath); }}
+								@mouseenter=${() => { this._atSelectedIndex = i; }}
+							>
+								<span class="font-mono text-sm truncate"><span class="text-muted-foreground">@${dir}</span><span class="text-primary">${base}</span></span>
+							</button>
+						`;
+						})}
 					</div>
 				` : nothing}
 

--- a/src/ui/components/MessageEditor.ts
+++ b/src/ui/components/MessageEditor.ts
@@ -310,7 +310,10 @@ export class MessageEditor extends LitElement {
 		const files = q ? this._atFiles.filter((p) => p.toLowerCase().includes(q)) : this._atFiles;
 		this._atFilteredFiles = files;
 		this._atMenuOpen = files.length > 0;
-		if (this._atSelectedIndex >= files.length) this._atSelectedIndex = 0;
+		// Reset to the top-ranked match on every recompute (mirrors the slash
+		// menu) so a changed query never leaves a stale highlight that Enter/Tab
+		// would select.
+		this._atSelectedIndex = 0;
 	}
 
 	private _updateAtAutocomplete() {

--- a/src/ui/components/Messages.ts
+++ b/src/ui/components/Messages.ts
@@ -22,6 +22,8 @@ import "./LiveTimer.js";
 import "./ToolGroup.js";
 import "./SkillChip.js";
 import type { SkillChipData } from "./SkillChip.js";
+import "./FileMentionChip.js";
+import type { FileMentionChipData, FileMentionKind } from "./FileMentionChip.js";
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 
 /** Format a message timestamp for display (locale-appropriate time). */
@@ -52,12 +54,32 @@ export interface SkillExpansion {
 	expanded: string;
 }
 
+/**
+ * Persisted record of a user-typed `@path` file reference. Mirrors the
+ * server-side `FileMention` shape — `range` uses UTF-16 code-unit offsets
+ * into the original `text`, matching `String.prototype.slice`. The UI
+ * re-declares this structurally-identical interface (it does NOT import the
+ * server module) so the JSON crosses the wire unchanged.
+ */
+export interface FileMention {
+	path: string;
+	absPath?: string;
+	range: [number, number];
+	kind: FileMentionKind;
+	content?: string;
+	data?: string;
+	mimeType?: string;
+	bytes?: number;
+	reason?: string;
+}
+
 export type UserMessageWithAttachments = {
 	role: "user-with-attachments";
 	content: string | (TextContent | ImageContent)[];
 	timestamp: number;
 	attachments?: Attachment[];
 	skillExpansions?: SkillExpansion[];
+	fileMentions?: FileMention[];
 };
 
 // Artifact message type for session persistence
@@ -78,26 +100,38 @@ declare module "@earendil-works/pi-agent-core" {
 }
 
 /**
- * Render `text` with `<skill-chip>` elements spliced in at each expansion's
- * recorded UTF-16 character range. Plain-text gaps are rendered through
- * `<markdown-block>` so user formatting is preserved exactly as today; line
- * breaks become `<br>` via the trailing-spaces trick used in render().
- *
- * Robustness: any expansion whose range is invalid (out of bounds, inverted,
- * or overlapping) is dropped with a warning — the surrounding plain text
- * still renders. This guarantees we never crash a user bubble because of a
- * malformed sidecar entry.
+ * A single chip to splice into the user text at a recorded UTF-16 range.
+ * Generalised so both `<skill-chip>` (slash skills) and `<file-mention-chip>`
+ * (`@path` references) flow through one robust splice path.
  */
-function renderTextWithSkillChips(
+interface ChipItem {
+	range: [number, number];
+	render: () => TemplateResult;
+}
+
+/**
+ * Render `text` with chip elements spliced in at each item's recorded UTF-16
+ * character range. Plain-text gaps are rendered as inline HTML so user
+ * formatting is preserved exactly as today; line breaks become `<br>` via the
+ * trailing-spaces trick used in render().
+ *
+ * Robustness: any item whose range is invalid (out of bounds, inverted, or
+ * overlapping a previously-accepted item) is dropped with a warning — the
+ * surrounding plain text still renders. This guarantees we never crash a user
+ * bubble because of a malformed sidecar entry.
+ */
+function renderTextWithChips(
 	text: string,
-	expansions: SkillExpansion[],
+	items: ChipItem[],
 ): TemplateResult {
-	const valid: SkillExpansion[] = [];
+	const valid: ChipItem[] = [];
 	let lastEnd = 0;
 	// Sort by range start so we can splice left-to-right and detect overlap.
-	const sorted = [...expansions].sort((a, b) => a.range[0] - b.range[0]);
-	for (const e of sorted) {
-		const [start, end] = e.range;
+	// Skill and file-mention items cannot overlap by construction (`/` vs `@`
+	// triggers), but the guard below drops any that do regardless of source.
+	const sorted = [...items].sort((a, b) => a.range[0] - b.range[0]);
+	for (const item of sorted) {
+		const [start, end] = item.range;
 		if (
 			typeof start !== "number" ||
 			typeof end !== "number" ||
@@ -106,10 +140,10 @@ function renderTextWithSkillChips(
 			start >= end ||
 			start < lastEnd
 		) {
-			console.warn("[SkillChip] dropping invalid expansion", e);
+			console.warn("[Messages] dropping invalid chip range", item.range);
 			continue;
 		}
-		valid.push(e);
+		valid.push(item);
 		lastEnd = end;
 	}
 
@@ -130,9 +164,25 @@ function renderTextWithSkillChips(
 		const inlineHtml = marked.parseInline(withBreaks, { async: false }) as string;
 		return html`<span class="skill-chip-gap">${unsafeHTML(inlineHtml)}</span>`;
 	};
-	for (const e of valid) {
-		const [s, eIdx] = e.range;
+	for (const item of valid) {
+		const [s, eIdx] = item.range;
 		if (s > cursor) parts.push(renderGap(text.slice(cursor, s)));
+		parts.push(item.render());
+		cursor = eIdx;
+	}
+	if (cursor < text.length) parts.push(renderGap(text.slice(cursor)));
+	return html`<div class="skill-chip-flow flex flex-wrap items-baseline gap-x-1 gap-y-1 markdown-content">${parts}</div>`;
+}
+
+/** Build the merged chip list from a user message's skill expansions and file
+ *  mentions. Each entry carries its splice `range` plus a renderer for the chip
+ *  element. Kept pure so the splice path stays the single source of truth. */
+function buildChipItems(
+	expansions: SkillExpansion[] | undefined,
+	mentions: FileMention[] | undefined,
+): ChipItem[] {
+	const items: ChipItem[] = [];
+	for (const e of expansions ?? []) {
 		const data: SkillChipData = {
 			name: e.name,
 			args: e.args,
@@ -140,11 +190,21 @@ function renderTextWithSkillChips(
 			filePath: e.filePath,
 			expanded: e.expanded,
 		};
-		parts.push(html`<skill-chip .data=${data}></skill-chip>`);
-		cursor = eIdx;
+		items.push({ range: e.range, render: () => html`<skill-chip .data=${data}></skill-chip>` });
 	}
-	if (cursor < text.length) parts.push(renderGap(text.slice(cursor)));
-	return html`<div class="skill-chip-flow flex flex-wrap items-baseline gap-x-1 gap-y-1 markdown-content">${parts}</div>`;
+	for (const m of mentions ?? []) {
+		const data: FileMentionChipData = {
+			path: m.path,
+			kind: m.kind,
+			content: m.content,
+			data: m.data,
+			mimeType: m.mimeType,
+			bytes: m.bytes,
+			reason: m.reason,
+		};
+		items.push({ range: m.range, render: () => html`<file-mention-chip .data=${data}></file-mention-chip>` });
+	}
+	return items;
 }
 
 @customElement("user-message")
@@ -170,10 +230,11 @@ export class UserMessage extends LitElement {
 		// so markdown renders them as <br> instead of collapsing to a single space.
 		const content = rawContent.replace(/\n/g, "  \n");
 
-		const expansions = (this.message as UserMessageWithAttachments).skillExpansions;
+		const withAttachments = this.message as UserMessageWithAttachments;
+		const chipItems = buildChipItems(withAttachments.skillExpansions, withAttachments.fileMentions);
 		const body =
-			expansions && expansions.length
-				? renderTextWithSkillChips(rawContent, expansions)
+			chipItems.length
+				? renderTextWithChips(rawContent, chipItems)
 				: html`<markdown-block .content=${content}></markdown-block>`;
 
 		return html`

--- a/tests/e2e/file-mentions-api.spec.ts
+++ b/tests/e2e/file-mentions-api.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * API E2E for GET /api/file-mentions (BLOCKER-B): a session-bound enumeration
+ * must target the session's HOST worktree (here, the session cwd), NOT the
+ * project root. A file that exists only under the session tree must be found
+ * when `sessionId` is supplied, and must NOT be found when enumerating an
+ * unrelated cwd without a session.
+ */
+import { test, expect } from "./in-process-harness.js";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createSession, deleteSession, apiFetch } from "./e2e-setup.js";
+
+function freshDir(label: string): string {
+	const dir = path.join(
+		os.tmpdir(),
+		`bobbit-file-mentions-${label}-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+	);
+	fs.mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+test.setTimeout(30_000);
+
+test.describe.serial("GET /api/file-mentions", () => {
+	let sessionId = "";
+	let sessionCwd: string;
+	let otherCwd: string;
+
+	test.beforeAll(() => {
+		sessionCwd = freshDir("session");
+		// A file that exists ONLY under the session tree (not the project root).
+		fs.writeFileSync(path.join(sessionCwd, "only-in-worktree.txt"), "hello", "utf-8");
+		// Also write a gitignored-style file to prove untracked files are listed.
+		fs.writeFileSync(path.join(sessionCwd, "untracked.secret.env"), "X=1", "utf-8");
+		otherCwd = freshDir("other"); // empty — used to prove the contrast
+	});
+
+	test.beforeEach(async () => {
+		sessionId = await createSession({ cwd: sessionCwd });
+	});
+	test.afterEach(async () => {
+		if (sessionId) { await deleteSession(sessionId); sessionId = ""; }
+	});
+
+	test("sessionId binds enumeration to the session tree (finds worktree-only file)", async () => {
+		const resp = await apiFetch(`/api/file-mentions?sessionId=${sessionId}&q=only-in-worktree`);
+		expect(resp.ok).toBe(true);
+		const data = await resp.json() as { files: Array<{ path: string }> };
+		const paths = data.files.map((f) => f.path);
+		expect(paths).toContain("only-in-worktree.txt");
+	});
+
+	test("untracked/gitignored files are included", async () => {
+		const resp = await apiFetch(`/api/file-mentions?sessionId=${sessionId}&q=untracked`);
+		const data = await resp.json() as { files: Array<{ path: string }> };
+		expect(data.files.map((f) => f.path)).toContain("untracked.secret.env");
+	});
+
+	test("without sessionId, an unrelated cwd does NOT see the session file", async () => {
+		const resp = await apiFetch(`/api/file-mentions?cwd=${encodeURIComponent(otherCwd)}&q=only-in-worktree`);
+		expect(resp.ok).toBe(true);
+		const data = await resp.json() as { files: Array<{ path: string }> };
+		expect(data.files.map((f) => f.path)).not.toContain("only-in-worktree.txt");
+	});
+});

--- a/tests/e2e/ui/at-mention.spec.ts
+++ b/tests/e2e/ui/at-mention.spec.ts
@@ -2,22 +2,28 @@
  * Browser E2E tests for the `@`-mention file reference UI.
  *
  * Covers (per AGENTS.md E2E coverage requirement + design §8.4):
- *   1. autocomplete  — typing `@` shows a file menu; filter narrows; ↑/↓ + Enter
- *                      selects and inserts `@<path> `.
+ *   1. autocomplete  — typing `@` shows a file menu; filter narrows; ↑/↓ keys
+ *                      navigate; Enter selects and inserts `@<path> `.
  *   2. happy path    — sending a message with an `@text-file` renders a
- *                      `<file-mention-chip>`; clicking it expands the snapshot.
- *   3. image routing — an `@image` reference renders an attachment tile (image
- *                      frame), not inlined text.
- *   4. persistence   — chip + literal `@path` survive a page reload (sidecar).
- *   5. degradation   — an unresolvable `@nope.txt` is sent as literal text with
- *                      no chip and no crash.
+ *                      `<file-mention-chip>`; clicking it expands the snapshot;
+ *                      the chip + literal `@path` survive a reload (sidecar).
+ *   3. image routing — an `@image` reference renders an image chip whose
+ *                      disclosure shows an <img> (kind "image", base64 data) —
+ *                      i.e. routed as an attachment, not inlined as text.
+ *   4. degradation   — an unresolvable `@nope.txt` is captured as a kind
+ *                      "unresolved" mention: it renders a chip labelled with the
+ *                      literal `@path` (design §2: ALL kinds drive chips) and
+ *                      never crashes the send.
  *
- * NOTE: This test depends on the server-side producer (`/api/file-mentions`
+ * Setup: each test registers a project rooted at the fixture dir and binds the
+ * session to it (the `skill-expansion.spec.ts` pattern). The file-mentions
+ * endpoint resolves discovery cwd via the project rootPath, and the session's
+ * cwd is the fixture dir (worktree:false), so both autocomplete enumeration and
+ * send-time resolution target the files we write below.
+ *
+ * NOTE: depends on the merged server-side producer (`/api/file-mentions`
  * endpoint + `resolveFileMentions` in the WS handler) that snapshots
- * `fileMentions` into the broadcast user message. It is intended to run only
- * after the server-side branch for this goal has merged into the goal branch.
- * Against an older server it will fail at the menu/chip steps — that is the
- * intended signal that the server change has not landed yet.
+ * `fileMentions` into the broadcast user message.
  */
 import { test, expect } from "../gateway-harness.js";
 import { mkdirSync, writeFileSync } from "node:fs";
@@ -31,6 +37,15 @@ const IMAGE_FILE = "pic.png";
 // 1x1 transparent PNG.
 const PNG_BASE64 =
 	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+/** A unique fixture dir under the worker's non-git tmp root. `nonGitCwd()` is
+ *  memoized per worker, so each test must use its own subdir — otherwise the
+ *  second project registered at the same rootPath fails with a duplicate 400. */
+function uniqueCwd(): string {
+	const cwd = join(nonGitCwd(), `at-mention-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	mkdirSync(cwd, { recursive: true });
+	return cwd;
+}
 
 /** Create the file fixtures the server enumerates / resolves under `cwd`. */
 function writeFixtures(cwd: string) {
@@ -50,14 +65,26 @@ function fileChip(page: import("@playwright/test").Page) {
 	return page.locator(".file-mention-chip-pill").first();
 }
 
-/** Create a session bound to `cwd` and navigate the app to it. */
+/**
+ * Register a project rooted at `cwd`, create a session bound to it (worktree
+ * disabled so the session cwd is exactly the fixture dir), and navigate to it.
+ */
 async function openSession(page: import("@playwright/test").Page, cwd: string): Promise<string> {
+	const projResp = await apiFetch("/api/projects", {
+		method: "POST",
+		body: JSON.stringify({ name: `at-mention-${Date.now()}-${Math.random().toString(36).slice(2)}`, rootPath: cwd }),
+	});
+	expect(projResp.status).toBe(201);
+	const proj = await projResp.json();
+
 	const created = await apiFetch("/api/sessions", {
 		method: "POST",
-		body: JSON.stringify({ cwd }),
+		body: JSON.stringify({ cwd, projectId: proj.id, worktree: false }),
 	});
+	expect(created.status).toBe(201);
 	const { id: sessionId } = await created.json();
 	expect(sessionId).toBeTruthy();
+
 	await openApp(page);
 	await page.evaluate((id) => { window.location.hash = `#/session/${id}`; }, sessionId);
 	await expect(page.locator("textarea").first()).toBeVisible({ timeout: 20_000 });
@@ -65,84 +92,116 @@ async function openSession(page: import("@playwright/test").Page, cwd: string): 
 }
 
 test.describe("@-mention file references UI", () => {
-	test("typing @ shows menu, filters, ↑/↓ + Enter inserts @<path>", async ({ page }) => {
-		const cwd = nonGitCwd();
+	test("typing @ shows menu, filters, ↑/↓ navigate, Enter inserts @<path>", async ({ page }) => {
+		const cwd = uniqueCwd();
 		writeFixtures(cwd);
 		await openSession(page, cwd);
 
 		const textarea = page.locator("textarea").first();
 		await textarea.click();
 
-		// Type "@" — a file menu should appear (populated by the server fetch).
+		// Type "@" — a file menu appears (populated by the server fetch) listing
+		// the fixture files.
 		await textarea.pressSequentially("@");
 		await expect(page.locator(".at-menu")).toBeVisible({ timeout: 15_000 });
+		await expect(page.locator(`[data-testid="file-mention-${TEXT_FILE}"]`)).toBeVisible({ timeout: 10_000 });
+		await expect(page.locator(`[data-testid="file-mention-${IMAGE_FILE}"]`)).toBeVisible();
 
-		// Filter to the text fixture.
+		// Exercise keyboard navigation while the menu is open, then narrow to the
+		// text fixture so selection is deterministic regardless of ranking.
+		await page.keyboard.press("ArrowDown");
+		await page.keyboard.press("ArrowUp");
 		await textarea.pressSequentially("notes");
 		const item = page.locator(`[data-testid="file-mention-${TEXT_FILE}"]`);
 		await expect(item).toBeVisible({ timeout: 10_000 });
 
-		// ↓ then Enter selects the highlighted item and inserts "@notes.txt ".
-		await page.keyboard.press("ArrowDown");
-		await page.keyboard.press("ArrowUp"); // back to first
+		// Enter selects the (only) highlighted item and inserts "@notes.txt ".
 		await page.keyboard.press("Enter");
-
 		await expect(textarea).toHaveValue(`@${TEXT_FILE} `, { timeout: 10_000 });
 		await expect(page.locator(".at-menu")).toHaveCount(0);
 	});
 
-	test("sending @text-file renders a chip; click expands the snapshot", async ({ page }) => {
-		const cwd = nonGitCwd();
+	// KNOWN SERVER GAP — text-mention chip persistence (design §5/§8.4).
+	//
+	// The UI is correct: a text `@`-mention DOES render a chip live (verified
+	// manually — `fileMentions` arrives on the broadcast user message and
+	// `FileMentionChip` renders, same code path the image/unresolved tests
+	// exercise green here). But the chip is lost on the authoritative
+	// snapshot/reload path because the SERVER-side merge drops `fileMentions`:
+	//
+	//   src/server/ws/handler.ts  `mergeSkillSidecarIntoMessages` returns
+	//     `{ ...msg, content, skillExpansions: envelope.skillExpansions }`
+	//   — it never re-attaches `envelope.fileMentions`. So on reload (and the
+	//   post-turn snapshot that replaces the live row) text mentions lose their
+	//   chip. Image/unresolved survive only because their `modelText` equals the
+	//   original text, so they don't depend on this rewrite carrying metadata.
+	//
+	// One-line server fix (team-lead owns the server bundle; UI must not touch
+	// src/server): in `mergeSkillSidecarIntoMessages`, mirror the live splice in
+	// `spliceSkillExpansionsIntoEvent` —
+	//   return { ...msg, content: newContent,
+	//            skillExpansions: envelope.skillExpansions,
+	//            ...(envelope.fileMentions?.length ? { fileMentions: envelope.fileMentions } : {}) };
+	//
+	// Once that lands, drop `.fixme` and this test verifies chip + literal text
+	// persist across reload.
+	test.fixme("@text-file persists as a chip across reload; click expands the snapshot", async ({ page }) => {
+		const cwd = uniqueCwd();
 		writeFixtures(cwd);
 		await openSession(page, cwd);
 
 		await sendMessage(page, `please read @${TEXT_FILE} carefully`);
 
-		// (1) bubble shows the literal user text.
 		await expect(userBubble(page)).toBeVisible({ timeout: 15_000 });
 		await expect(userBubble(page)).toContainText(`@${TEXT_FILE}`, { timeout: 15_000 });
 
-		// (2) chip rendered; snapshot collapsed by default.
+		await page.reload();
+		await expect(userBubble(page)).toBeVisible({ timeout: 20_000 });
+		await expect(userBubble(page)).toContainText(`@${TEXT_FILE}`);
+
 		const chip = fileChip(page);
 		await expect(chip).toBeVisible({ timeout: 15_000 });
 		await expect(page.getByText(TEXT_MARKER).first()).toHaveCount(0);
 
-		// (3) click expands the snapshot body.
 		await chip.click();
 		await expect(page.getByText(TEXT_MARKER).first()).toBeVisible({ timeout: 5_000 });
-
-		// (4) reload — chip + literal text persist (replay from sidecar).
-		await page.reload();
-		await expect(userBubble(page)).toBeVisible({ timeout: 20_000 });
-		await expect(userBubble(page)).toContainText(`@${TEXT_FILE}`);
-		await expect(fileChip(page)).toBeVisible({ timeout: 10_000 });
 	});
 
-	test("sending @image renders an attachment tile, not inlined text", async ({ page }) => {
-		const cwd = nonGitCwd();
+	test("sending @image renders an image chip (routed as attachment, not inlined)", async ({ page }) => {
+		const cwd = uniqueCwd();
 		writeFixtures(cwd);
 		await openSession(page, cwd);
 
 		await sendMessage(page, `look at @${IMAGE_FILE}`);
 
+		// The image reference renders a chip; its body is an <img> from the
+		// base64 snapshot rather than inlined text (kind "image" never alters the
+		// model text — it routes through the attachment/image frame).
 		await expect(userBubble(page)).toBeVisible({ timeout: 15_000 });
-		// Image references route through the attachment/image frame — an image tile
-		// (or rendered <img>) appears in the bubble rather than inlined bytes.
-		await expect(
-			page.locator("attachment-tile img, user-message img").first(),
-		).toBeVisible({ timeout: 15_000 });
+		const chip = fileChip(page);
+		await expect(chip).toBeVisible({ timeout: 15_000 });
+		await chip.click();
+		await expect(page.locator("file-mention-chip img").first()).toBeVisible({ timeout: 5_000 });
+		// Literal @path remains in the text — the image bytes are not inlined.
+		await expect(userBubble(page)).toContainText(`@${IMAGE_FILE}`);
 	});
 
-	test("unresolvable @nope.txt sends as literal text with no chip or crash", async ({ page }) => {
-		const cwd = nonGitCwd();
+	test("unresolvable @nope.txt is captured as an unresolved chip without crashing", async ({ page }) => {
+		const cwd = uniqueCwd();
 		writeFixtures(cwd);
 		await openSession(page, cwd);
 
 		await sendMessage(page, "this references @nope.txt which does not exist");
 
+		// The send never tears down; the message renders with the literal @path.
 		await expect(userBubble(page)).toBeVisible({ timeout: 15_000 });
 		await expect(userBubble(page)).toContainText("@nope.txt");
-		// No chip for an unresolved reference rendered as plain text.
-		await expect(page.locator(".file-mention-chip-pill")).toHaveCount(0);
+		// Per design §2 ALL kinds drive chips: an unresolved reference renders a
+		// chip labelled with the literal path (the disclosure shows the reason).
+		const chip = fileChip(page);
+		await expect(chip).toBeVisible({ timeout: 15_000 });
+		await expect(chip).toContainText("@nope.txt");
+		// No crash — the composer is still usable.
+		await expect(page.locator("textarea").first()).toBeVisible();
 	});
 });

--- a/tests/e2e/ui/at-mention.spec.ts
+++ b/tests/e2e/ui/at-mention.spec.ts
@@ -121,31 +121,13 @@ test.describe("@-mention file references UI", () => {
 		await expect(page.locator(".at-menu")).toHaveCount(0);
 	});
 
-	// KNOWN SERVER GAP — text-mention chip persistence (design §5/§8.4).
-	//
-	// The UI is correct: a text `@`-mention DOES render a chip live (verified
-	// manually — `fileMentions` arrives on the broadcast user message and
-	// `FileMentionChip` renders, same code path the image/unresolved tests
-	// exercise green here). But the chip is lost on the authoritative
-	// snapshot/reload path because the SERVER-side merge drops `fileMentions`:
-	//
-	//   src/server/ws/handler.ts  `mergeSkillSidecarIntoMessages` returns
-	//     `{ ...msg, content, skillExpansions: envelope.skillExpansions }`
-	//   — it never re-attaches `envelope.fileMentions`. So on reload (and the
-	//   post-turn snapshot that replaces the live row) text mentions lose their
-	//   chip. Image/unresolved survive only because their `modelText` equals the
-	//   original text, so they don't depend on this rewrite carrying metadata.
-	//
-	// One-line server fix (team-lead owns the server bundle; UI must not touch
-	// src/server): in `mergeSkillSidecarIntoMessages`, mirror the live splice in
-	// `spliceSkillExpansionsIntoEvent` —
-	//   return { ...msg, content: newContent,
-	//            skillExpansions: envelope.skillExpansions,
-	//            ...(envelope.fileMentions?.length ? { fileMentions: envelope.fileMentions } : {}) };
-	//
-	// Once that lands, drop `.fixme` and this test verifies chip + literal text
-	// persist across reload.
-	test.fixme("@text-file persists as a chip across reload; click expands the snapshot", async ({ page }) => {
+	// Exercises the text-mention round trip: the chip renders live and survives
+	// the authoritative snapshot/reload path (the sidecar carries `fileMentions`
+	// alongside `skillExpansions`, so the rewritten user message restores both).
+	// Text mentions are the case where `modelText !== originalText` (content is
+	// inlined for the model), so this guards the rewrite-carries-metadata path
+	// that image/unresolved mentions don't depend on.
+	test("@text-file persists as a chip across reload; click expands the snapshot", async ({ page }) => {
 		const cwd = uniqueCwd();
 		writeFixtures(cwd);
 		await openSession(page, cwd);

--- a/tests/e2e/ui/at-mention.spec.ts
+++ b/tests/e2e/ui/at-mention.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * Browser E2E tests for the `@`-mention file reference UI.
+ *
+ * Covers (per AGENTS.md E2E coverage requirement + design §8.4):
+ *   1. autocomplete  — typing `@` shows a file menu; filter narrows; ↑/↓ + Enter
+ *                      selects and inserts `@<path> `.
+ *   2. happy path    — sending a message with an `@text-file` renders a
+ *                      `<file-mention-chip>`; clicking it expands the snapshot.
+ *   3. image routing — an `@image` reference renders an attachment tile (image
+ *                      frame), not inlined text.
+ *   4. persistence   — chip + literal `@path` survive a page reload (sidecar).
+ *   5. degradation   — an unresolvable `@nope.txt` is sent as literal text with
+ *                      no chip and no crash.
+ *
+ * NOTE: This test depends on the server-side producer (`/api/file-mentions`
+ * endpoint + `resolveFileMentions` in the WS handler) that snapshots
+ * `fileMentions` into the broadcast user message. It is intended to run only
+ * after the server-side branch for this goal has merged into the goal branch.
+ * Against an older server it will fail at the menu/chip steps — that is the
+ * intended signal that the server change has not landed yet.
+ */
+import { test, expect } from "../gateway-harness.js";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { apiFetch, nonGitCwd } from "../e2e-setup.js";
+import { openApp, sendMessage } from "./ui-helpers.js";
+
+const TEXT_FILE = "notes.txt";
+const TEXT_MARKER = "AT_MENTION_E2E_TEXT_MARKER_BODY";
+const IMAGE_FILE = "pic.png";
+// 1x1 transparent PNG.
+const PNG_BASE64 =
+	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+/** Create the file fixtures the server enumerates / resolves under `cwd`. */
+function writeFixtures(cwd: string) {
+	mkdirSync(cwd, { recursive: true });
+	writeFileSync(join(cwd, TEXT_FILE), `${TEXT_MARKER}\nsecond line\n`);
+	writeFileSync(join(cwd, IMAGE_FILE), Buffer.from(PNG_BASE64, "base64"));
+}
+
+/** Locator: the user-message bubble in the chat. */
+function userBubble(page: import("@playwright/test").Page) {
+	return page.locator("user-message").first();
+}
+
+/** Locator: a FileMentionChip pill. The `<file-mention-chip>` host uses
+ *  `display: contents` inline, so target the inner `.file-mention-chip-pill`. */
+function fileChip(page: import("@playwright/test").Page) {
+	return page.locator(".file-mention-chip-pill").first();
+}
+
+/** Create a session bound to `cwd` and navigate the app to it. */
+async function openSession(page: import("@playwright/test").Page, cwd: string): Promise<string> {
+	const created = await apiFetch("/api/sessions", {
+		method: "POST",
+		body: JSON.stringify({ cwd }),
+	});
+	const { id: sessionId } = await created.json();
+	expect(sessionId).toBeTruthy();
+	await openApp(page);
+	await page.evaluate((id) => { window.location.hash = `#/session/${id}`; }, sessionId);
+	await expect(page.locator("textarea").first()).toBeVisible({ timeout: 20_000 });
+	return sessionId;
+}
+
+test.describe("@-mention file references UI", () => {
+	test("typing @ shows menu, filters, ↑/↓ + Enter inserts @<path>", async ({ page }) => {
+		const cwd = nonGitCwd();
+		writeFixtures(cwd);
+		await openSession(page, cwd);
+
+		const textarea = page.locator("textarea").first();
+		await textarea.click();
+
+		// Type "@" — a file menu should appear (populated by the server fetch).
+		await textarea.pressSequentially("@");
+		await expect(page.locator(".at-menu")).toBeVisible({ timeout: 15_000 });
+
+		// Filter to the text fixture.
+		await textarea.pressSequentially("notes");
+		const item = page.locator(`[data-testid="file-mention-${TEXT_FILE}"]`);
+		await expect(item).toBeVisible({ timeout: 10_000 });
+
+		// ↓ then Enter selects the highlighted item and inserts "@notes.txt ".
+		await page.keyboard.press("ArrowDown");
+		await page.keyboard.press("ArrowUp"); // back to first
+		await page.keyboard.press("Enter");
+
+		await expect(textarea).toHaveValue(`@${TEXT_FILE} `, { timeout: 10_000 });
+		await expect(page.locator(".at-menu")).toHaveCount(0);
+	});
+
+	test("sending @text-file renders a chip; click expands the snapshot", async ({ page }) => {
+		const cwd = nonGitCwd();
+		writeFixtures(cwd);
+		await openSession(page, cwd);
+
+		await sendMessage(page, `please read @${TEXT_FILE} carefully`);
+
+		// (1) bubble shows the literal user text.
+		await expect(userBubble(page)).toBeVisible({ timeout: 15_000 });
+		await expect(userBubble(page)).toContainText(`@${TEXT_FILE}`, { timeout: 15_000 });
+
+		// (2) chip rendered; snapshot collapsed by default.
+		const chip = fileChip(page);
+		await expect(chip).toBeVisible({ timeout: 15_000 });
+		await expect(page.getByText(TEXT_MARKER).first()).toHaveCount(0);
+
+		// (3) click expands the snapshot body.
+		await chip.click();
+		await expect(page.getByText(TEXT_MARKER).first()).toBeVisible({ timeout: 5_000 });
+
+		// (4) reload — chip + literal text persist (replay from sidecar).
+		await page.reload();
+		await expect(userBubble(page)).toBeVisible({ timeout: 20_000 });
+		await expect(userBubble(page)).toContainText(`@${TEXT_FILE}`);
+		await expect(fileChip(page)).toBeVisible({ timeout: 10_000 });
+	});
+
+	test("sending @image renders an attachment tile, not inlined text", async ({ page }) => {
+		const cwd = nonGitCwd();
+		writeFixtures(cwd);
+		await openSession(page, cwd);
+
+		await sendMessage(page, `look at @${IMAGE_FILE}`);
+
+		await expect(userBubble(page)).toBeVisible({ timeout: 15_000 });
+		// Image references route through the attachment/image frame — an image tile
+		// (or rendered <img>) appears in the bubble rather than inlined bytes.
+		await expect(
+			page.locator("attachment-tile img, user-message img").first(),
+		).toBeVisible({ timeout: 15_000 });
+	});
+
+	test("unresolvable @nope.txt sends as literal text with no chip or crash", async ({ page }) => {
+		const cwd = nonGitCwd();
+		writeFixtures(cwd);
+		await openSession(page, cwd);
+
+		await sendMessage(page, "this references @nope.txt which does not exist");
+
+		await expect(userBubble(page)).toBeVisible({ timeout: 15_000 });
+		await expect(userBubble(page)).toContainText("@nope.txt");
+		// No chip for an unresolved reference rendered as plain text.
+		await expect(page.locator(".file-mention-chip-pill")).toHaveCount(0);
+	});
+});

--- a/tests/file-mentions-enumerate.test.ts
+++ b/tests/file-mentions-enumerate.test.ts
@@ -43,8 +43,8 @@ const { enumerateFiles, DEFAULT_RESULT_CAP, MAX_RESULT_CAP } =
 	await import("../src/server/skills/file-enumeration.ts");
 
 describe("enumerateFiles", () => {
-	it("includes gitignored/untracked files, excludes noise dirs", () => {
-		const files = enumerateFiles(cwdDir);
+	it("includes gitignored/untracked files, excludes noise dirs", async () => {
+		const files = await enumerateFiles(cwdDir);
 		assert.ok(files.includes("secret.env"), "gitignored file should be included");
 		assert.ok(files.includes(".gitignore"));
 		assert.ok(files.includes("src/index.ts"));
@@ -54,40 +54,40 @@ describe("enumerateFiles", () => {
 		assert.ok(!files.some((f) => f.startsWith(".bobbit/")), ".bobbit excluded");
 	});
 
-	it("returns forward-slash relative paths", () => {
-		const files = enumerateFiles(cwdDir);
+	it("returns forward-slash relative paths", async () => {
+		const files = await enumerateFiles(cwdDir);
 		assert.ok(files.every((f) => !f.includes("\\")));
 		assert.ok(files.includes("src/util/helpers.ts"));
 	});
 
-	it("query substring filter is case-insensitive", () => {
-		const files = enumerateFiles(cwdDir, { query: "BUTTON" });
+	it("query substring filter is case-insensitive", async () => {
+		const files = await enumerateFiles(cwdDir, { query: "BUTTON" });
 		assert.ok(files.includes("src/components/Button.tsx"));
 		assert.ok(!files.includes("README.md"));
 	});
 
-	it("basename matches rank ahead of path-only matches", () => {
+	it("basename matches rank ahead of path-only matches", async () => {
 		touch("util.ts");
-		const files = enumerateFiles(cwdDir, { query: "util" });
+		const files = await enumerateFiles(cwdDir, { query: "util" });
 		// "util.ts" (basename match) should outrank "src/util/helpers.ts" (path-only).
 		assert.equal(files[0], "util.ts");
 	});
 
-	it("respects the result cap (limit), clamped to MAX_RESULT_CAP", () => {
-		const limited = enumerateFiles(cwdDir, { limit: 2 });
+	it("respects the result cap (limit), clamped to MAX_RESULT_CAP", async () => {
+		const limited = await enumerateFiles(cwdDir, { limit: 2 });
 		assert.equal(limited.length, 2);
 		// Over-max limit clamps rather than returning more than MAX_RESULT_CAP.
-		const clamped = enumerateFiles(cwdDir, { limit: MAX_RESULT_CAP + 5000 });
+		const clamped = await enumerateFiles(cwdDir, { limit: MAX_RESULT_CAP + 5000 });
 		assert.ok(clamped.length <= MAX_RESULT_CAP);
 	});
 
-	it("walk cap stops enumeration early", () => {
-		const capped = enumerateFiles(cwdDir, { walkCap: 1 });
+	it("walk cap stops enumeration early", async () => {
+		const capped = await enumerateFiles(cwdDir, { walkCap: 1 });
 		assert.ok(capped.length <= DEFAULT_RESULT_CAP);
 	});
 
-	it("never throws on an unreadable / missing root", () => {
-		const files = enumerateFiles(path.join(cwdDir, "does-not-exist"));
+	it("never throws on an unreadable / missing root", async () => {
+		const files = await enumerateFiles(path.join(cwdDir, "does-not-exist"));
 		assert.deepEqual(files, []);
 	});
 });

--- a/tests/file-mentions-enumerate.test.ts
+++ b/tests/file-mentions-enumerate.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for enumerateFiles — see design §3 / §8.2.
+ *
+ * Builds a tmp fixture tree (including gitignored/excluded dirs) and asserts
+ * inclusion/exclusion, caps, and query ranking.
+ */
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+let cwdDir: string;
+
+function touch(rel: string, body = "x") {
+	const abs = path.join(cwdDir, rel);
+	fs.mkdirSync(path.dirname(abs), { recursive: true });
+	fs.writeFileSync(abs, body, "utf-8");
+}
+
+before(() => {
+	cwdDir = fs.mkdtempSync(path.join(os.tmpdir(), "file-enum-test-"));
+	touch("README.md");
+	touch("src/index.ts");
+	touch("src/util/helpers.ts");
+	touch("src/components/Button.tsx");
+	touch(".gitignore", "dist/\nsecret.env");
+	// Gitignored / untracked files MUST still be enumerated.
+	touch("secret.env", "TOKEN=abc");
+	touch("build-artifact.log");
+	// Excluded directories must be skipped.
+	touch(".git/config");
+	touch("node_modules/dep/index.js");
+	touch("dist/bundle.js");
+	touch(".bobbit/state/x.json");
+});
+
+after(() => {
+	try { fs.rmSync(cwdDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+const { enumerateFiles, DEFAULT_RESULT_CAP, MAX_RESULT_CAP } =
+	await import("../src/server/skills/file-enumeration.ts");
+
+describe("enumerateFiles", () => {
+	it("includes gitignored/untracked files, excludes noise dirs", () => {
+		const files = enumerateFiles(cwdDir);
+		assert.ok(files.includes("secret.env"), "gitignored file should be included");
+		assert.ok(files.includes(".gitignore"));
+		assert.ok(files.includes("src/index.ts"));
+		assert.ok(!files.some((f) => f.startsWith(".git/")), ".git excluded");
+		assert.ok(!files.some((f) => f.startsWith("node_modules/")), "node_modules excluded");
+		assert.ok(!files.some((f) => f.startsWith("dist/")), "dist excluded");
+		assert.ok(!files.some((f) => f.startsWith(".bobbit/")), ".bobbit excluded");
+	});
+
+	it("returns forward-slash relative paths", () => {
+		const files = enumerateFiles(cwdDir);
+		assert.ok(files.every((f) => !f.includes("\\")));
+		assert.ok(files.includes("src/util/helpers.ts"));
+	});
+
+	it("query substring filter is case-insensitive", () => {
+		const files = enumerateFiles(cwdDir, { query: "BUTTON" });
+		assert.ok(files.includes("src/components/Button.tsx"));
+		assert.ok(!files.includes("README.md"));
+	});
+
+	it("basename matches rank ahead of path-only matches", () => {
+		touch("util.ts");
+		const files = enumerateFiles(cwdDir, { query: "util" });
+		// "util.ts" (basename match) should outrank "src/util/helpers.ts" (path-only).
+		assert.equal(files[0], "util.ts");
+	});
+
+	it("respects the result cap (limit), clamped to MAX_RESULT_CAP", () => {
+		const limited = enumerateFiles(cwdDir, { limit: 2 });
+		assert.equal(limited.length, 2);
+		// Over-max limit clamps rather than returning more than MAX_RESULT_CAP.
+		const clamped = enumerateFiles(cwdDir, { limit: MAX_RESULT_CAP + 5000 });
+		assert.ok(clamped.length <= MAX_RESULT_CAP);
+	});
+
+	it("walk cap stops enumeration early", () => {
+		const capped = enumerateFiles(cwdDir, { walkCap: 1 });
+		assert.ok(capped.length <= DEFAULT_RESULT_CAP);
+	});
+
+	it("never throws on an unreadable / missing root", () => {
+		const files = enumerateFiles(path.join(cwdDir, "does-not-exist"));
+		assert.deepEqual(files, []);
+	});
+});

--- a/tests/file-mentions-resolve.test.ts
+++ b/tests/file-mentions-resolve.test.ts
@@ -37,6 +37,7 @@ const {
 	MAX_INLINE_TEXT_BYTES,
 	MAX_MENTION_FILE_BYTES,
 	MAX_MENTION_AGGREGATE_BYTES,
+	MAX_MENTIONS_PER_SEND,
 } = await import("../src/server/skills/resolve-file-mentions.ts");
 
 describe("resolveFileMentions", () => {
@@ -44,6 +45,7 @@ describe("resolveFileMentions", () => {
 		assert.equal(MAX_INLINE_TEXT_BYTES, 256 * 1024);
 		assert.equal(MAX_MENTION_FILE_BYTES, 10 * 1024 * 1024);
 		assert.equal(MAX_MENTION_AGGREGATE_BYTES, 20 * 1024 * 1024);
+		assert.equal(MAX_MENTIONS_PER_SEND, 50);
 	});
 
 	it("no mentions → text unchanged, empty mentions", () => {
@@ -105,12 +107,13 @@ describe("resolveFileMentions", () => {
 		assert.equal(r.modelText, text); // literal @path left in place
 	});
 
-	it("non-image binary (NUL bytes) → kind binary, modelText unchanged", () => {
+	it("non-image binary (NUL bytes) → unresolved (unsupported-binary), literal preserved", () => {
 		const text = "@data.bin";
 		const r = resolveFileMentions(text, cwdDir);
-		assert.equal(r.mentions[0].kind, "binary");
-		assert.ok(r.mentions[0].data);
-		assert.equal(r.modelText, text);
+		assert.equal(r.mentions[0].kind, "unresolved");
+		assert.equal(r.mentions[0].reason, "unsupported-binary");
+		assert.equal(r.mentions[0].data, undefined); // bytes are NOT snapshotted
+		assert.equal(r.modelText, text); // literal @path left so model sees the filename
 	});
 
 	it("missing file → unresolved, literal token preserved, reason set", () => {
@@ -168,5 +171,39 @@ describe("resolveFileMentions", () => {
 			r.mentions.map((m) => m.kind),
 			["text", "unresolved", "unresolved", "image"],
 		);
+	});
+
+	it("HIGH-1: symlink inside cwd pointing outside cwd is rejected (outside-cwd), no leak", (t) => {
+		const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "file-mentions-outside-"));
+		const secret = path.join(outsideDir, "secret.txt");
+		fs.writeFileSync(secret, "TOPSECRET", "utf-8");
+		const link = path.join(cwdDir, "link-to-secret.txt");
+		try {
+			fs.symlinkSync(secret, link);
+		} catch {
+			// Creating symlinks can throw EPERM on unprivileged Windows — skip
+			// so the suite stays green there.
+			t.skip("symlink creation not permitted on this platform");
+			fs.rmSync(outsideDir, { recursive: true, force: true });
+			return;
+		}
+		const r = resolveFileMentions("@link-to-secret.txt", cwdDir);
+		assert.equal(r.mentions[0].kind, "unresolved");
+		assert.equal(r.mentions[0].reason, "outside-cwd");
+		assert.ok(!(r.mentions[0].content ?? "").includes("TOPSECRET"), "secret must not be snapshotted");
+		fs.rmSync(link, { force: true });
+		fs.rmSync(outsideDir, { recursive: true, force: true });
+	});
+
+	it("HIGH-5: more than MAX_MENTIONS_PER_SEND tokens → extras unresolved (too-many-mentions)", () => {
+		const n = MAX_MENTIONS_PER_SEND + 3;
+		const text = Array.from({ length: n }, () => "@notes.txt").join(" ");
+		const r = resolveFileMentions(text, cwdDir);
+		assert.equal(r.mentions.length, n);
+		// First MAX are resolved (text); extras degrade without fs work.
+		assert.equal(r.mentions[MAX_MENTIONS_PER_SEND - 1].kind, "text");
+		assert.equal(r.mentions[MAX_MENTIONS_PER_SEND].kind, "unresolved");
+		assert.equal(r.mentions[MAX_MENTIONS_PER_SEND].reason, "too-many-mentions");
+		assert.equal(r.mentions[n - 1].reason, "too-many-mentions");
 	});
 });

--- a/tests/file-mentions-resolve.test.ts
+++ b/tests/file-mentions-resolve.test.ts
@@ -175,12 +175,39 @@ describe("resolveFileMentions", () => {
 		assert.equal(r.mentions[1].reason, "aggregate-cap");
 	});
 
+	it("BLOCKER-B: once aggregate is exhausted, a subsequent large mention is aggregate-cap with NO data (not read)", () => {
+		fs.writeFileSync(path.join(cwdDir, "first.txt"), "aaaa", "utf-8"); // 4 bytes
+		// A large file that would be expensive to read; must NOT be read once the
+		// budget is gone. Image extension so it would otherwise base64-encode.
+		fs.writeFileSync(path.join(cwdDir, "huge.png"), Buffer.alloc(1024, 1));
+		const r = resolveFileMentions("@first.txt @huge.png", cwdDir, { maxAggregateBytes: 5 });
+		assert.equal(r.mentions[0].kind, "text");
+		const big = r.mentions[1];
+		assert.equal(big.kind, "unresolved");
+		assert.equal(big.reason, "aggregate-cap");
+		assert.equal(big.data, undefined, "oversized mention must not be read/encoded");
+		assert.equal(big.content, undefined);
+	});
+
 	it("trailing punctuation is trimmed from the token (see @notes.txt.)", () => {
 		const r = resolveFileMentions("see @notes.txt.", cwdDir);
 		assert.equal(r.mentions.length, 1);
 		assert.equal(r.mentions[0].path, "notes.txt");
 		// Range must cover exactly "@notes.txt" (not the trailing dot).
 		assert.deepEqual(r.mentions[0].range, [4, 4 + "@notes.txt".length]);
+	});
+
+	it("LOW-SEC: buildFileReferenceBlock escapes XML attribute chars in the path", () => {
+		const block = buildFileReferenceBlock('a"><x>&.txt', "BODY");
+		// The raw quote/angle/amp must not appear unescaped inside the attribute.
+		assert.ok(block.startsWith('<file-reference path="'));
+		assert.ok(block.includes("&quot;"));
+		assert.ok(block.includes("&gt;"));
+		assert.ok(block.includes("&lt;"));
+		assert.ok(block.includes("&amp;"));
+		// No stray closing-bracket from the path can terminate the opening tag early.
+		const openTag = block.slice(0, block.indexOf("\n"));
+		assert.equal((openTag.match(/>/g) || []).length, 1, "opening tag has exactly one '>'");
 	});
 
 	it("backslash path normalised for lookup (header uses forward slashes)", () => {

--- a/tests/file-mentions-resolve.test.ts
+++ b/tests/file-mentions-resolve.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Unit tests for resolveFileMentions — see design §2 / §8.1.
+ *
+ * Strategy: build a tmp tree with real files of various kinds and point the
+ * pure resolver at it. Mirrors tests/skill-resolve.test.ts.
+ */
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+let cwdDir: string;
+
+before(() => {
+	cwdDir = fs.mkdtempSync(path.join(os.tmpdir(), "file-mentions-test-"));
+	fs.mkdirSync(path.join(cwdDir, "src"), { recursive: true });
+	fs.writeFileSync(path.join(cwdDir, "notes.txt"), "hello world\nline two", "utf-8");
+	fs.writeFileSync(path.join(cwdDir, "src", "a.ts"), "export const x = 1;", "utf-8");
+	// A tiny 1x1 PNG (binary, image extension).
+	const png = Buffer.from(
+		"89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a49444154789c6360000002000100ffff03000006000557bfabd40000000049454e44ae426082",
+		"hex",
+	);
+	fs.writeFileSync(path.join(cwdDir, "pixel.png"), png);
+	// A non-image binary (NUL bytes, .bin extension).
+	fs.writeFileSync(path.join(cwdDir, "data.bin"), Buffer.from([0, 1, 2, 3, 0, 255, 254]));
+});
+
+after(() => {
+	try { fs.rmSync(cwdDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+const {
+	resolveFileMentions,
+	buildFileReferenceBlock,
+	MAX_INLINE_TEXT_BYTES,
+	MAX_MENTION_FILE_BYTES,
+	MAX_MENTION_AGGREGATE_BYTES,
+} = await import("../src/server/skills/resolve-file-mentions.ts");
+
+describe("resolveFileMentions", () => {
+	it("exports the documented cap constants", () => {
+		assert.equal(MAX_INLINE_TEXT_BYTES, 256 * 1024);
+		assert.equal(MAX_MENTION_FILE_BYTES, 10 * 1024 * 1024);
+		assert.equal(MAX_MENTION_AGGREGATE_BYTES, 20 * 1024 * 1024);
+	});
+
+	it("no mentions → text unchanged, empty mentions", () => {
+		const r = resolveFileMentions("just a normal message", cwdDir);
+		assert.equal(r.modelText, "just a normal message");
+		assert.equal(r.mentions.length, 0);
+		assert.equal(r.warnings.length, 0);
+	});
+
+	it("inline text file → inlined with <file-reference> header; range covers @path", () => {
+		const text = "see @notes.txt please";
+		const r = resolveFileMentions(text, cwdDir);
+		assert.equal(r.mentions.length, 1);
+		const m = r.mentions[0];
+		assert.equal(m.kind, "text");
+		assert.equal(m.path, "notes.txt");
+		assert.equal(m.content, "hello world\nline two");
+		assert.deepEqual(m.range, [4, 4 + "@notes.txt".length]);
+		const block = buildFileReferenceBlock("notes.txt", "hello world\nline two");
+		assert.equal(r.modelText, "see " + block + " please");
+	});
+
+	it("bare @path whole-message works through inline scan", () => {
+		const r = resolveFileMentions("@src/a.ts", cwdDir);
+		assert.equal(r.mentions.length, 1);
+		assert.equal(r.mentions[0].kind, "text");
+		assert.equal(r.mentions[0].path, "src/a.ts");
+		assert.equal(r.mentions[0].content, "export const x = 1;");
+	});
+
+	it("multiple mentions → right-to-left splice preserves earlier indices", () => {
+		const text = "x @notes.txt y @src/a.ts z";
+		const r = resolveFileMentions(text, cwdDir);
+		assert.equal(r.mentions.length, 2);
+		assert.equal(r.mentions[0].path, "notes.txt");
+		assert.equal(r.mentions[1].path, "src/a.ts");
+		const b1 = buildFileReferenceBlock("notes.txt", "hello world\nline two");
+		const b2 = buildFileReferenceBlock("src/a.ts", "export const x = 1;");
+		assert.equal(r.modelText, "x " + b1 + " y " + b2 + " z");
+	});
+
+	it("content snapshot is captured at resolve time (later mutation ignored)", () => {
+		const tmp = path.join(cwdDir, "mutating.txt");
+		fs.writeFileSync(tmp, "ORIGINAL", "utf-8");
+		const r = resolveFileMentions("@mutating.txt", cwdDir);
+		fs.writeFileSync(tmp, "CHANGED", "utf-8");
+		assert.equal(r.mentions[0].content, "ORIGINAL");
+	});
+
+	it("image by extension → kind image, base64 data, modelText unchanged", () => {
+		const text = "look @pixel.png ok";
+		const r = resolveFileMentions(text, cwdDir);
+		assert.equal(r.mentions.length, 1);
+		const m = r.mentions[0];
+		assert.equal(m.kind, "image");
+		assert.equal(m.mimeType, "image/png");
+		assert.ok(m.data && m.data.length > 0);
+		assert.equal(m.content, undefined);
+		assert.equal(r.modelText, text); // literal @path left in place
+	});
+
+	it("non-image binary (NUL bytes) → kind binary, modelText unchanged", () => {
+		const text = "@data.bin";
+		const r = resolveFileMentions(text, cwdDir);
+		assert.equal(r.mentions[0].kind, "binary");
+		assert.ok(r.mentions[0].data);
+		assert.equal(r.modelText, text);
+	});
+
+	it("missing file → unresolved, literal token preserved, reason set", () => {
+		const text = "see @nope.txt here";
+		const r = resolveFileMentions(text, cwdDir);
+		assert.equal(r.mentions[0].kind, "unresolved");
+		assert.equal(r.mentions[0].reason, "missing");
+		assert.equal(r.modelText, text);
+		assert.ok(r.warnings.length >= 1);
+	});
+
+	it("outside-cwd traversal → unresolved (outside-cwd), no throw", () => {
+		const r = resolveFileMentions("@../secret.txt", cwdDir);
+		assert.equal(r.mentions[0].kind, "unresolved");
+		assert.equal(r.mentions[0].reason, "outside-cwd");
+	});
+
+	it("oversized text (per-file text cap) → unresolved too-large, literal preserved", () => {
+		const big = path.join(cwdDir, "big.txt");
+		fs.writeFileSync(big, "x".repeat(2048), "utf-8");
+		const r = resolveFileMentions("@big.txt", cwdDir, { maxFileBytes: 1024 });
+		assert.equal(r.mentions[0].kind, "unresolved");
+		assert.equal(r.mentions[0].reason, "too-large");
+		assert.equal(r.modelText, "@big.txt");
+	});
+
+	it("aggregate cap → later mentions become unresolved (aggregate-cap)", () => {
+		fs.writeFileSync(path.join(cwdDir, "p.txt"), "aaaa", "utf-8");
+		fs.writeFileSync(path.join(cwdDir, "q.txt"), "bbbb", "utf-8");
+		const r = resolveFileMentions("@p.txt @q.txt", cwdDir, { maxAggregateBytes: 5 });
+		assert.equal(r.mentions[0].kind, "text");
+		assert.equal(r.mentions[1].kind, "unresolved");
+		assert.equal(r.mentions[1].reason, "aggregate-cap");
+	});
+
+	it("trailing punctuation is trimmed from the token (see @notes.txt.)", () => {
+		const r = resolveFileMentions("see @notes.txt.", cwdDir);
+		assert.equal(r.mentions.length, 1);
+		assert.equal(r.mentions[0].path, "notes.txt");
+		// Range must cover exactly "@notes.txt" (not the trailing dot).
+		assert.deepEqual(r.mentions[0].range, [4, 4 + "@notes.txt".length]);
+	});
+
+	it("backslash path normalised for lookup (header uses forward slashes)", () => {
+		const r = resolveFileMentions("@src\\a.ts", cwdDir);
+		assert.equal(r.mentions[0].kind, "text");
+		assert.ok(r.modelText.includes('path="src/a.ts"'));
+	});
+
+	it("never throws on a mix of good and bad references", () => {
+		const text = "@notes.txt @nope.txt @../x @pixel.png";
+		const r = resolveFileMentions(text, cwdDir);
+		assert.equal(r.mentions.length, 4);
+		assert.deepEqual(
+			r.mentions.map((m) => m.kind),
+			["text", "unresolved", "unresolved", "image"],
+		);
+	});
+});

--- a/tests/file-mentions-resolve.test.ts
+++ b/tests/file-mentions-resolve.test.ts
@@ -34,6 +34,7 @@ after(() => {
 const {
 	resolveFileMentions,
 	buildFileReferenceBlock,
+	toWireMention,
 	MAX_INLINE_TEXT_BYTES,
 	MAX_MENTION_FILE_BYTES,
 	MAX_MENTION_AGGREGATE_BYTES,
@@ -53,6 +54,15 @@ describe("resolveFileMentions", () => {
 		assert.equal(r.modelText, "just a normal message");
 		assert.equal(r.mentions.length, 0);
 		assert.equal(r.warnings.length, 0);
+	});
+
+	it("FOLLOW-UP-D: resolver sets internal absPath; toWireMention strips it", () => {
+		const r = resolveFileMentions("@notes.txt", cwdDir);
+		assert.ok(r.mentions[0].absPath, "resolver keeps canonical absPath internally");
+		const wire = toWireMention(r.mentions[0]);
+		assert.equal(wire.absPath, undefined, "wire mention must not carry absPath");
+		assert.equal(wire.path, "notes.txt"); // other fields preserved
+		assert.equal(wire.kind, "text");
 	});
 
 	it("inline text file → inlined with <file-reference> header; range covers @path", () => {
@@ -107,13 +117,29 @@ describe("resolveFileMentions", () => {
 		assert.equal(r.modelText, text); // literal @path left in place
 	});
 
-	it("non-image binary (NUL bytes) → unresolved (unsupported-binary), literal preserved", () => {
+	it("non-image binary (NUL bytes) → kind binary, base64 data, modelText unchanged", () => {
 		const text = "@data.bin";
 		const r = resolveFileMentions(text, cwdDir);
-		assert.equal(r.mentions[0].kind, "unresolved");
-		assert.equal(r.mentions[0].reason, "unsupported-binary");
-		assert.equal(r.mentions[0].data, undefined); // bytes are NOT snapshotted
-		assert.equal(r.modelText, text); // literal @path left so model sees the filename
+		assert.equal(r.mentions[0].kind, "binary");
+		assert.ok(r.mentions[0].data && r.mentions[0].data.length > 0);
+		assert.equal(r.mentions[0].mimeType, "application/octet-stream");
+		assert.equal(r.modelText, text); // literal @path left (not inlined)
+	});
+
+	it("binary mimeType is ext-derived when known (.pdf)", () => {
+		fs.writeFileSync(path.join(cwdDir, "doc.pdf"), Buffer.from([0x25, 0x50, 0x44, 0x46, 0x00, 0x01]));
+		const r = resolveFileMentions("@doc.pdf", cwdDir);
+		assert.equal(r.mentions[0].kind, "binary");
+		assert.equal(r.mentions[0].mimeType, "application/pdf");
+	});
+
+	it("FOLLOW-UP-C: invalid UTF-8 without NUL bytes → kind binary, not inlined as text", () => {
+		// Lone 0xFF / 0xFE continuation bytes are not valid UTF-8 and contain no NUL.
+		fs.writeFileSync(path.join(cwdDir, "invalid-utf8.dat"), Buffer.from([0xff, 0xfe, 0x41, 0xc0, 0x80]));
+		const r = resolveFileMentions("@invalid-utf8.dat", cwdDir);
+		assert.equal(r.mentions[0].kind, "binary");
+		assert.equal(r.mentions[0].content, undefined);
+		assert.equal(r.modelText, "@invalid-utf8.dat");
 	});
 
 	it("missing file → unresolved, literal token preserved, reason set", () => {

--- a/tests/merge-mentions.test.ts
+++ b/tests/merge-mentions.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for buildMergedModelText — the pure merge of slash-skill
+ * expansions and @file text mentions (HIGH-2 regression: prefix-only slash
+ * skills overlap @file tokens and must not double-splice / corrupt modelText).
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { buildMergedModelText } = await import("../src/server/skills/merge-mentions.ts");
+const { buildFileReferenceBlock } = await import("../src/server/skills/resolve-file-mentions.ts");
+
+/** Minimal text FileMention factory. */
+function textMention(p: string, content: string, range: [number, number]) {
+	return { path: p, range, kind: "text" as const, content, bytes: content.length };
+}
+
+describe("buildMergedModelText", () => {
+	it("no expansions/mentions → original text unchanged", () => {
+		assert.equal(buildMergedModelText("hello world", [], []), "hello world");
+	});
+
+	it("inline /skill AND @file (disjoint) → both applied", () => {
+		// "see /skill and @a.txt"
+		const text = "see /skill and @a.txt";
+		const skillStart = text.indexOf("/skill");
+		const skill = { range: [skillStart, skillStart + "/skill".length] as [number, number], expanded: "SKILL-BODY" };
+		const fileStart = text.indexOf("@a.txt");
+		const file = textMention("a.txt", "FILE", [fileStart, fileStart + "@a.txt".length]);
+		const out = buildMergedModelText(text, [skill], [file]);
+		assert.equal(out, "see SKILL-BODY and " + buildFileReferenceBlock("a.txt", "FILE"));
+	});
+
+	it("HIGH-2: prefix-only /skill claiming whole range overlaps @file → skill wins, no corruption", () => {
+		// "/mockup @notes.txt" — prefix-only skill range covers the whole text.
+		const text = "/mockup @notes.txt";
+		const skill = { range: [0, text.length] as [number, number], expanded: "EXPANDED" };
+		const fileStart = text.indexOf("@notes.txt");
+		const file = textMention("notes.txt", "HELLO", [fileStart, fileStart + "@notes.txt".length]);
+		const out = buildMergedModelText(text, [skill], [file]);
+		// Skill expansion wins for the whole message; file content is NOT inlined.
+		assert.equal(out, "EXPANDED");
+		assert.ok(!out.includes("file-reference"), "overlapping file mention must not be inlined");
+	});
+
+	it("multiple @file mentions splice right-to-left preserving indices", () => {
+		const text = "x @a y @b z";
+		const aStart = text.indexOf("@a");
+		const bStart = text.indexOf("@b");
+		const a = textMention("a", "A", [aStart, aStart + 2]);
+		const b = textMention("b", "B", [bStart, bStart + 2]);
+		const out = buildMergedModelText(text, [], [a, b]);
+		assert.equal(out, "x " + buildFileReferenceBlock("a", "A") + " y " + buildFileReferenceBlock("b", "B") + " z");
+	});
+
+	it("non-text mentions (image/unresolved) never alter modelText", () => {
+		const text = "look @img.png and @bad.bin";
+		const img = { path: "img.png", range: [5, 12] as [number, number], kind: "image" as const, data: "x", mimeType: "image/png" };
+		const bad = { path: "bad.bin", range: [18, 26] as [number, number], kind: "unresolved" as const, reason: "unsupported-binary" };
+		const out = buildMergedModelText(text, [], [img, bad]);
+		assert.equal(out, text);
+	});
+});

--- a/tests/merge-mentions.test.ts
+++ b/tests/merge-mentions.test.ts
@@ -30,16 +30,31 @@ describe("buildMergedModelText", () => {
 		assert.equal(out, "see SKILL-BODY and " + buildFileReferenceBlock("a.txt", "FILE"));
 	});
 
-	it("HIGH-2: prefix-only /skill claiming whole range overlaps @file → skill wins, no corruption", () => {
+	it("BLOCKER-A: prefix-only /skill overlaps @file → skill body, then APPENDED file-reference (content not dropped)", () => {
 		// "/mockup @notes.txt" — prefix-only skill range covers the whole text.
 		const text = "/mockup @notes.txt";
 		const skill = { range: [0, text.length] as [number, number], expanded: "EXPANDED" };
 		const fileStart = text.indexOf("@notes.txt");
 		const file = textMention("notes.txt", "HELLO", [fileStart, fileStart + "@notes.txt".length]);
 		const out = buildMergedModelText(text, [skill], [file]);
-		// Skill expansion wins for the whole message; file content is NOT inlined.
-		assert.equal(out, "EXPANDED");
-		assert.ok(!out.includes("file-reference"), "overlapping file mention must not be inlined");
+		// Skill body stays intact AND the file content is delivered (appended).
+		assert.equal(out, "EXPANDED" + "\n\n" + buildFileReferenceBlock("notes.txt", "HELLO"));
+		assert.ok(out.startsWith("EXPANDED"), "skill expansion must remain intact at the front");
+		assert.ok(out.includes("file-reference"), "overlapping text mention content must still be delivered");
+	});
+
+	it("BLOCKER-A: multiple overlapping @file mentions appended in original-text order", () => {
+		const text = "/mockup @a.txt @b.txt";
+		const skill = { range: [0, text.length] as [number, number], expanded: "EXP" };
+		const aStart = text.indexOf("@a.txt");
+		const bStart = text.indexOf("@b.txt");
+		const a = textMention("a.txt", "AA", [aStart, aStart + 6]);
+		const b = textMention("b.txt", "BB", [bStart, bStart + 6]);
+		const out = buildMergedModelText(text, [skill], [a, b]);
+		assert.equal(
+			out,
+			"EXP\n\n" + buildFileReferenceBlock("a.txt", "AA") + "\n\n" + buildFileReferenceBlock("b.txt", "BB"),
+		);
 	});
 
 	it("multiple @file mentions splice right-to-left preserving indices", () => {

--- a/tests/skill-sidecar.test.ts
+++ b/tests/skill-sidecar.test.ts
@@ -18,6 +18,7 @@ const {
 	readSkillSidecarEntries,
 	findSkillSidecarEntry,
 	purgeSkillSidecar,
+	mergeSidecarEntriesIntoMessages,
 } = await import("../src/server/skills/skill-sidecar.ts");
 
 initSkillSidecarDir(stateDir);
@@ -38,6 +39,23 @@ const sample = {
 			filePath: "/path/to/SKILL.md",
 			range: [0, "/mockup hero".length] as [number, number],
 			expanded: "EXPANDED-BODY",
+		},
+	],
+};
+
+const fileMentionSample = {
+	ts: 1714000001000,
+	modelText: "see <file-reference path=\"a.txt\">hi</file-reference>",
+	originalText: "see @a.txt",
+	skillExpansions: [],
+	fileMentions: [
+		{
+			path: "a.txt",
+			absPath: "/abs/a.txt",
+			range: [4, 10] as [number, number],
+			kind: "text" as const,
+			content: "hi",
+			bytes: 2,
 		},
 	],
 };
@@ -99,23 +117,6 @@ describe("skill-sidecar", () => {
 		assert.equal(got?.originalText, "SECOND");
 	});
 
-	const fileMentionSample = {
-		ts: 1714000001000,
-		modelText: "see <file-reference path=\"a.txt\">hi</file-reference>",
-		originalText: "see @a.txt",
-		skillExpansions: [],
-		fileMentions: [
-			{
-				path: "a.txt",
-				absPath: "/abs/a.txt",
-				range: [4, 10] as [number, number],
-				kind: "text" as const,
-				content: "hi",
-				bytes: 2,
-			},
-		],
-	};
-
 	it("round-trips an entry carrying fileMentions (no skill expansions)", () => {
 		const sid = "session-file-mentions";
 		appendSkillSidecarEntry(sid, fileMentionSample);
@@ -149,5 +150,61 @@ describe("skill-sidecar", () => {
 		assert.equal(entries.length, 1);
 		assert.equal(entries[0].fileMentions, undefined);
 		assert.equal(entries[0].skillExpansions.length, 1);
+	});
+});
+
+describe("mergeSidecarEntriesIntoMessages (restore / snapshot path)", () => {
+	// Regression: the restore path must re-attach fileMentions, not just
+	// skillExpansions — otherwise @-mention chips vanish on reload.
+	it("re-attaches fileMentions onto a restored pure @-mention message", () => {
+		const messages = [
+			{ role: "user", content: fileMentionSample.modelText },
+		];
+		const out = mergeSidecarEntriesIntoMessages([fileMentionSample], messages);
+		assert.equal(out[0].content, "see @a.txt"); // body rewritten to originalText
+		assert.deepEqual(out[0].fileMentions, fileMentionSample.fileMentions);
+		assert.deepEqual(out[0].skillExpansions, []);
+	});
+
+	it("re-attaches BOTH skillExpansions and fileMentions when present", () => {
+		const entry = {
+			ts: 1,
+			modelText: "EXPANDED-BODY",
+			originalText: "/mockup @a.txt",
+			skillExpansions: sample.skillExpansions,
+			fileMentions: fileMentionSample.fileMentions,
+		};
+		const out = mergeSidecarEntriesIntoMessages([entry], [{ role: "user", content: "EXPANDED-BODY" }]);
+		assert.equal(out[0].content, "/mockup @a.txt");
+		assert.equal(out[0].skillExpansions.length, 1);
+		assert.deepEqual(out[0].fileMentions, fileMentionSample.fileMentions);
+	});
+
+	it("does NOT add a fileMentions key when the entry has none", () => {
+		const out = mergeSidecarEntriesIntoMessages([sample], [{ role: "user", content: "EXPANDED-BODY" }]);
+		assert.equal(out[0].content, "/mockup hero");
+		assert.ok(!("fileMentions" in out[0]), "no empty fileMentions key on skill-only restore");
+	});
+
+	it("rewrites the text block of an array-content (user-with-attachments) message", () => {
+		const messages = [
+			{
+				role: "user-with-attachments",
+				content: [
+					{ type: "text", text: fileMentionSample.modelText },
+					{ type: "image", data: "..." },
+				],
+			},
+		];
+		const out = mergeSidecarEntriesIntoMessages([fileMentionSample], messages);
+		const textBlock = out[0].content.find((c: any) => c.type === "text");
+		assert.equal(textBlock.text, "see @a.txt");
+		assert.deepEqual(out[0].fileMentions, fileMentionSample.fileMentions);
+	});
+
+	it("passes through messages with no matching entry (idempotent)", () => {
+		const messages = [{ role: "user", content: "no match here" }];
+		const out = mergeSidecarEntriesIntoMessages([fileMentionSample], messages);
+		assert.equal(out, messages); // same reference — unchanged
 	});
 });

--- a/tests/skill-sidecar.test.ts
+++ b/tests/skill-sidecar.test.ts
@@ -98,4 +98,56 @@ describe("skill-sidecar", () => {
 		// Within 500ms tolerance: only the second matches.
 		assert.equal(got?.originalText, "SECOND");
 	});
+
+	const fileMentionSample = {
+		ts: 1714000001000,
+		modelText: "see <file-reference path=\"a.txt\">hi</file-reference>",
+		originalText: "see @a.txt",
+		skillExpansions: [],
+		fileMentions: [
+			{
+				path: "a.txt",
+				absPath: "/abs/a.txt",
+				range: [4, 10] as [number, number],
+				kind: "text" as const,
+				content: "hi",
+				bytes: 2,
+			},
+		],
+	};
+
+	it("round-trips an entry carrying fileMentions (no skill expansions)", () => {
+		const sid = "session-file-mentions";
+		appendSkillSidecarEntry(sid, fileMentionSample);
+		const entries = readSkillSidecarEntries(sid);
+		assert.equal(entries.length, 1);
+		assert.deepEqual(entries[0], fileMentionSample);
+		assert.equal(entries[0].fileMentions?.[0].kind, "text");
+	});
+
+	it("entry with only fileMentions (no skillExpansions array) still reads", () => {
+		const sid = "session-file-only";
+		const file = path.join(stateDir, "skill-sidecar", `${sid}.jsonl`);
+		fs.mkdirSync(path.dirname(file), { recursive: true });
+		// Hand-write an entry missing skillExpansions entirely.
+		const raw = {
+			ts: 123,
+			modelText: "m",
+			originalText: "o",
+			fileMentions: [{ path: "x.txt", range: [0, 6], kind: "text", content: "c" }],
+		};
+		fs.appendFileSync(file, JSON.stringify(raw) + "\n", "utf-8");
+		const entries = readSkillSidecarEntries(sid);
+		assert.equal(entries.length, 1);
+		assert.equal(entries[0].fileMentions?.[0].path, "x.txt");
+	});
+
+	it("old entry without fileMentions field still parses (backward compat)", () => {
+		const sid = "session-old-entry";
+		appendSkillSidecarEntry(sid, sample); // no fileMentions field
+		const entries = readSkillSidecarEntries(sid);
+		assert.equal(entries.length, 1);
+		assert.equal(entries[0].fileMentions, undefined);
+		assert.equal(entries[0].skillExpansions.length, 1);
+	});
 });


### PR DESCRIPTION
## Summary

Adds `@`-triggered file-path autocomplete to the prompt composer, mirroring the existing `/` slash-skill feature. On send, each `@path` token resolves into the referenced file's content: **text files are inlined** into the model-facing prompt, **images** route through the image frame, and **other binaries** route as document attachments. Sent messages render a clickable, expandable chip per reference, persisted via the skill sidecar so chips + original text survive reload/replay.

## What's included

**Server**
- `src/server/skills/resolve-file-mentions.ts` — pure resolver: inline-only `@path` scan, realpath-canonicalized cwd containment (rejects symlink escapes), ext-first image classification + strict-UTF-8 text sniff, right-to-left `<file-reference>` inlining, snapshot at send time, size/count caps (256 KiB inline · 10 MiB/file · 20 MiB aggregate · 50 mentions, all checked before reads), graceful unresolved degradation.
- `src/server/skills/file-enumeration.ts` — bounded async walk (incl. gitignored/untracked; excludes `.git`/`node_modules`/`dist`/`.bobbit`/`.next`/`coverage`/`build`).
- `src/server/skills/merge-mentions.ts` — overlap-safe merge of slash-skill + `@file` ranges; overlapping text mentions appended after a prefix-skill expansion.
- `GET /api/file-mentions` endpoint scoped to the session host worktree via `sessionId`.
- Sidecar persistence (`fileMentions`) re-attached on restore/snapshot so chips replay.

**UI**
- `MessageEditor` `@`-autocomplete (debounced fetch, instant filter, keyboard nav mutually exclusive with the slash menu).
- `FileMentionChip` (text→`<pre>`, image→`<img>`, binary/unresolved→note).
- Generalised chip splice in `Messages.ts` (skill + file-mention chips, no duplication).

**Tests**: unit suites (resolve/enumerate/merge/sidecar), `tests/e2e/file-mentions-api.spec.ts`, and browser E2E `tests/e2e/ui/at-mention.spec.ts` (autocomplete, text-chip render+expand+reload persistence, image-as-chip, unresolved degradation).

**Docs**: `docs/at-mention-file-references.md` + index link in `docs/features.md`.

## Verification
`npm run check`, `npm run test:unit`, `npm run test:e2e` all green. Implementation gate passed (build/typecheck/unit/E2E + gap/code-quality/security review); documentation gate passed.

## Non-blocking follow-ups (security gate passed)
- Sidecar lacks a cumulative per-session quota (replay needs the snapshot — a hardening tradeoff).
- `/api/file-mentions` keeps a raw-`cwd` fallback when no `sessionId` is bound (parity with `/api/slash-skills`).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)