### PR TITLE
Staff proposal panel: role picker + create-in-flight guard

### DIFF
--- a/docs/design/staff-role-selection.md
+++ b/docs/design/staff-role-selection.md
@@ -190,3 +190,26 @@ Run: `npm run check`, `npm run test:unit`, `npm run test:e2e`.
 - **Unit C — Proposal/tool** (after B for api.ts roleId): `defaults/tools/proposals/extension.ts`, `propose_staff.yaml`, `src/server/agent/staff-assistant.ts`, `src/app/proposal-panels.ts` (apply path role→roleId).
 
 A and B run in parallel (no file overlap). C runs after B (depends on `api.ts` `roleId`; touches `staff-assistant.ts` which A leaves untouched).
+
+## Follow-ups (fix-up on top of the merged feature)
+
+The original feature (above) shipped and is mostly working. Two gaps in the staff **proposal panel** (`src/app/proposal-panels.ts`, `staffPreviewPanel()` / `handleCreateStaff`) were closed afterwards. Both are UI-only — no server, tool, or shared-helper changes — and reuse the idioms the regular surfaces already established rather than inventing new ones.
+
+### 1. Proposal-panel role picker parity
+
+The edit page (`staff-page.ts`) already had a working role picker, but the proposal panel only read the proposed role from `state.activeProposals.staff?.fields?.role` and forwarded it to `createStaffAgent` with no visible control. So a proposed role could not be seen, changed, or added when absent.
+
+Fix: add a role `<select>` to the panel mirroring `staff-page.ts` — an explicit **"No role"** option plus one option per role, populated lazily via `ensureStaffProposalRolesLoaded()` (panel-local mirror of `staff-page.ts::ensureRolesLoaded()`; roles are kept panel-local so the two surfaces never share mutable state, and fetch errors are swallowed since roles are optional). Panel-local module state: `_staffProposalRoles`, `_staffProposalRoleId` (`null` ⇒ "No role"), `_staffProposalRolesLoaded`, and `_staffProposalRoleSeeded`.
+
+The selector is **seeded once** from the proposal's `role` field, guarded by `_staffProposalRoleSeeded` so re-renders never clobber a user choice. The seed guard (and the role selection) is reset in `resetProposalAnnCount("staff")` when a fresh proposal arrives. `handleCreateStaff` now reads `_staffProposalRoleId` instead of the raw proposal field; empty/`null` ⇒ no role. Server-side 404 still rejects unknown roles, so no extra client validation is added. The panel has no accessory control, so the role→accessory default stays server-side (the create path already fills accessory from the role when the request supplies none) — no accessory picker was added.
+
+### 2. Create-in-flight guard
+
+`handleCreateStaff` previously `await`ed `createStaffAgent` with no in-flight UI, so the slow round trip invited double-clicks. Fix mirrors the goal panel's `config.saving ? "Creating…"` idiom and the session `state.creatingSession` re-entrancy guard:
+
+- Module-local `_creatingStaff` flag, set before the request and cleared in a `finally` (so it always re-enables on error).
+- `handleCreateStaff` early-returns if `_creatingStaff` is already set (belt-and-braces alongside the disabled button).
+- While in flight: the "Create Staff" button is disabled and shows **"Creating…"**; the Dismiss button is disabled too.
+- Error path preserved: the pre-existing `if (!result) return` still fires **before** any teardown, so the proposal panel and staff-assistant session stay open; the only addition is clearing `_creatingStaff` in `finally` so the user can retry. Success path unchanged.
+
+Tests: `tests/e2e/ui/staff-proposal-role.spec.ts` (role select appears, reflects the proposed role, is changeable, persists on the created staff after reload, plus a "No role" case and the disabled/"Creating…" in-flight assertions), with a mock-agent hook in `tests/e2e/mock-agent-core.mjs`.

--- a/docs/staff-agents.md
+++ b/docs/staff-agents.md
@@ -50,8 +50,13 @@ Both staff and regular-session paths funnel through these helpers, so prompt ord
 ### Setting a role
 
 - **Edit page** (`#/staff/<id>`): a role `<select>` with an explicit **"No role"** option, initialised from the staff's current `roleId`. Picking a role pre-fills the accessory picker as a default; clearing it sends `roleId: null`.
+- **Proposal panel** (the staff-creation assistant's preview): a role `<select>` mirroring the edit-page picker — an explicit **"No role"** option plus one option per role, populated lazily from the roles API. It is **seeded once** from the proposal's own `role` field so the user can see which role the assistant chose, override it, or add a role when none was proposed; the selected value is what gets persisted as `roleId` on create. Before this feature the panel silently forwarded the proposed `role` with no visible control, so a proposed role could be neither seen nor changed. The panel has no accessory picker, so the role→accessory default is applied server-side on create (see item 2 above), not in the panel.
 - **REST**: `POST /api/staff` and `PUT /api/staff/:id` accept `roleId` (a string to set, `null` to clear). Unknown role → `404`; a non-string, non-null value → `400`. See [rest-api.md — Staff Agents](rest-api.md#staff-agents).
 - **`propose_staff` tool**: accepts an optional `role` parameter. The staff-creation assistant can suggest a role; the accepted proposal maps `role` → `roleId` when the staff is created. The assistant should only propose roles that exist.
+
+### Create-in-flight guard
+
+"Create Staff" in the proposal panel guards against double-submission: the create round trip is slow, so the button is disabled and shows **"Creating…"** (and the Dismiss button is disabled too) while the request is in flight, and a re-entrancy check drops repeated clicks so at most one create request is issued. The in-flight flag is cleared in a `finally`, so on failure the button re-enables for a retry. Failure handling is otherwise unchanged: when `createStaffAgent` returns `null` the handler returns early **before** any teardown, so the proposal panel and the staff-assistant session stay open and editable. On success the behaviour is unchanged — proposal state clears, the assistant redirects, and the client connects to the new staff session.
 
 ## Project and cwd anchoring
 

--- a/src/app/proposal-panels.ts
+++ b/src/app/proposal-panels.ts
@@ -32,6 +32,8 @@ import {
 	fetchTools,
 	type ToolInfo,
 	createStaffAgent,
+	fetchRoles,
+	type RoleData,
 } from "./api.js";
 import { clearSessionModel, setHashRoute } from "./routing.js";
 import { reconcileFollowTail } from "./follow-tail.js";
@@ -128,6 +130,20 @@ let _goalSandboxed = false;
 let _goalAutoStartTeam = true;
 let _staffSandboxed = false;
 let _assistantEnabledOptionalSteps: string[] = [];
+
+// ---- Staff proposal panel: role picker + create-in-flight state ----
+// Roles fetched lazily for the proposal panel's role <select>. Mirrors
+// staff-page.ts's `roles`/`ensureRolesLoaded()` but kept panel-local so the two
+// surfaces never share mutable state.
+let _staffProposalRoles: RoleData[] = [];
+/** Current role selection in the staff proposal panel (null ⇒ "No role"). */
+let _staffProposalRoleId: string | null = null;
+/** Guards one-time seeding from the proposal field so re-renders don't clobber a user choice. */
+let _staffProposalRoleSeeded = false;
+/** Guards the lazy roles fetch. */
+let _staffProposalRolesLoaded = false;
+/** In-flight flag for the "Create Staff" submit — disables the button + shows "Creating…". */
+let _creatingStaff = false;
 
 /** Set the selected workflow ID from outside the render module (e.g. from a goal proposal).
  *  Normalizes against the loaded workflow cache: a proposed id that isn't a configured
@@ -260,6 +276,20 @@ function ensureSandboxStatusLoaded(): void {
 	fetchSandboxStatus().then(s => { _sandboxStatusFetching = false; if (s) { state.sandboxStatus = s; renderApp(); } });
 }
 
+/** Lazily fetch roles for the staff proposal panel's role <select>.
+ *  Idempotent; mirrors staff-page.ts::ensureRolesLoaded(). Roles are optional, so
+ *  fetch errors are swallowed and leave the list empty. */
+async function ensureStaffProposalRolesLoaded(): Promise<void> {
+	if (_staffProposalRolesLoaded) return;
+	_staffProposalRolesLoaded = true;
+	try {
+		_staffProposalRoles = await fetchRoles();
+		renderApp();
+	} catch {
+		/* roles are optional; leave list empty */
+	}
+}
+
 // ============================================================================
 // PROPOSAL STREAMING UX (shared helpers)
 // ============================================================================
@@ -340,7 +370,14 @@ export function showProposalToast(text: string): void {
 export function resetProposalAnnCount(type: "goal" | "role" | "staff"): void {
 	if (type === "goal") _goalAnnCount = 0;
 	else if (type === "role") _roleAnnCount = 0;
-	else if (type === "staff") _staffAnnCount = 0;
+	else if (type === "staff") {
+		_staffAnnCount = 0;
+		// Re-seed the role selector from the next staff proposal's own field, and
+		// drop any in-flight create state, when a fresh proposal arrives.
+		_staffProposalRoleSeeded = false;
+		_staffProposalRoleId = null;
+		_creatingStaff = false;
+	}
 }
 
 function recomputeAssistantHasProposal(): void {
@@ -1359,6 +1396,17 @@ function seedStaffPreviewCwdFromProject(project = activeProjectForStaffPreview()
 function staffPreviewPanel() {
 	ensureMarkdownBlock();
 	ensureSandboxStatusLoaded();
+	void ensureStaffProposalRolesLoaded();
+	// Seed the role selector once from the proposal's own `role` field. Guarded so
+	// re-renders never clobber a user choice; reset on a fresh proposal (see
+	// resetProposalAnnCount).
+	if (!_staffProposalRoleSeeded) {
+		const seededRole = state.activeProposals.staff?.fields?.role;
+		_staffProposalRoleId = typeof seededRole === "string" && seededRole.trim()
+			? seededRole.trim()
+			: null;
+		_staffProposalRoleSeeded = true;
+	}
 	const staffProject = activeProjectForStaffPreview();
 	seedStaffPreviewCwdFromProject(staffProject);
 	const streaming = isProposalStreaming("staff_proposal");
@@ -1368,6 +1416,8 @@ function staffPreviewPanel() {
 		reconcileFollowTail(staffPromptTextareaRef.value);
 	});
 	const handleCreateStaff = async () => {
+		// Re-entrancy guard — belt-and-braces alongside the disabled button.
+		if (_creatingStaff) return;
 		const trimmedName = state.staffPreviewName.trim();
 		if (!trimmedName) return;
 		// Block create if any goal-* trigger lacks a prompt. The submit button is
@@ -1387,56 +1437,65 @@ function staffPreviewPanel() {
 			? state.projects.find(p => p.id === submitProjectId)
 			: undefined;
 		const cwd = effectiveStaffPreviewCwd(submitProject);
-		// Optional role carried by the proposal seed. Unknown roles are rejected
-		// server-side (404) — no extra client validation needed.
-		const proposalRole = state.activeProposals.staff?.fields?.role;
-		const roleId = typeof proposalRole === "string" && proposalRole.trim()
-			? proposalRole.trim()
+		// Optional role from the panel's role <select> (null/empty ⇒ no role).
+		// Unknown roles are rejected server-side (404) — no extra client validation.
+		const roleId = _staffProposalRoleId && _staffProposalRoleId.trim()
+			? _staffProposalRoleId.trim()
 			: undefined;
-		const result = await createStaffAgent({
-			name: trimmedName,
-			description: state.staffPreviewDescription,
-			systemPrompt: state.staffPreviewPrompt,
-			cwd,
-			worktree: state.staffPreviewWorktree,
-			triggers,
-			projectId: submitProjectId,
-			sandboxed,
-			roleId,
-		});
-		if (!result) return;
 
-		_staffSandboxed = false;
-		state.staffPreviewWorktree = true;
-		clearProposalReviewState(proposalSessionId, "staff");
-		delete state.activeProposals.staff;
-		recomputeAssistantHasProposal();
-		clampUnifiedTabsAfterProposalRemoved("staff");
-		if (proposalSessionId) void deleteProposalFile(proposalSessionId, "staff");
-
-		if (isStaffAssistant) {
-			if (state.remoteAgent) {
-				state.remoteAgent.disconnect();
-				state.remoteAgent = null;
-				state.connectionStatus = "disconnected";
-			}
-			state.assistantType = null;
-			localStorage.removeItem("gateway.sessionId");
-			setHashRoute("landing");
-			state.appView = "authenticated";
-			if (proposalSessionId && !isSessionArchived(proposalSessionId)) {
-				await gatewayFetch(`/api/sessions/${proposalSessionId}`, { method: "DELETE" });
-				clearSessionModel(proposalSessionId);
-			}
-		}
-
-		reloadStaffList();
-		await refreshSessions();
-		if (result?.currentSessionId) {
-			const { connectToSession } = await import("./session-manager.js");
-			await connectToSession(result.currentSessionId, false);
-		}
+		// In-flight: disable the submit/dismiss buttons + show "Creating…". Cleared
+		// in `finally` so the button re-enables for retry on error (the early
+		// `if (!result) return` keeps the panel + assistant session open).
+		_creatingStaff = true;
 		renderApp();
+		try {
+			const result = await createStaffAgent({
+				name: trimmedName,
+				description: state.staffPreviewDescription,
+				systemPrompt: state.staffPreviewPrompt,
+				cwd,
+				worktree: state.staffPreviewWorktree,
+				triggers,
+				projectId: submitProjectId,
+				sandboxed,
+				roleId,
+			});
+			if (!result) return;
+
+			_staffSandboxed = false;
+			state.staffPreviewWorktree = true;
+			clearProposalReviewState(proposalSessionId, "staff");
+			delete state.activeProposals.staff;
+			recomputeAssistantHasProposal();
+			clampUnifiedTabsAfterProposalRemoved("staff");
+			if (proposalSessionId) void deleteProposalFile(proposalSessionId, "staff");
+
+			if (isStaffAssistant) {
+				if (state.remoteAgent) {
+					state.remoteAgent.disconnect();
+					state.remoteAgent = null;
+					state.connectionStatus = "disconnected";
+				}
+				state.assistantType = null;
+				localStorage.removeItem("gateway.sessionId");
+				setHashRoute("landing");
+				state.appView = "authenticated";
+				if (proposalSessionId && !isSessionArchived(proposalSessionId)) {
+					await gatewayFetch(`/api/sessions/${proposalSessionId}`, { method: "DELETE" });
+					clearSessionModel(proposalSessionId);
+				}
+			}
+
+			reloadStaffList();
+			await refreshSessions();
+			if (result?.currentSessionId) {
+				const { connectToSession } = await import("./session-manager.js");
+				await connectToSession(result.currentSessionId, false);
+			}
+		} finally {
+			_creatingStaff = false;
+			renderApp();
+		}
 	};
 
 	return html`
@@ -1522,6 +1581,19 @@ function staffPreviewPanel() {
 							class="text-[9px] text-muted-foreground cursor-help">ⓘ</span>
 					</label>
 				</div>
+				<div data-testid="staff-proposal-role-picker">
+					<label class="text-xs text-muted-foreground mb-1.5 block font-medium">Role</label>
+					<p class="text-[10px] text-muted-foreground mb-1">Optional. Prepends the role's prompt context and pre-fills the accessory.</p>
+					<select
+						data-testid="staff-proposal-role-select"
+						class="w-full h-9 px-2 text-sm rounded-md border border-border bg-background text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+						.value=${_staffProposalRoleId ?? ""}
+						@change=${(e: Event) => { _staffProposalRoleId = (e.target as HTMLSelectElement).value || null; renderApp(); }}
+					>
+						<option value="" ?selected=${!_staffProposalRoleId}>No role</option>
+						${_staffProposalRoles.map((r) => html`<option value=${r.name} ?selected=${_staffProposalRoleId === r.name}>${r.label || r.name}</option>`)}
+					</select>
+				</div>
 				<div>
 					<div class="flex items-center justify-between mb-1.5">
 						<label class="text-xs text-muted-foreground font-medium">Triggers</label>
@@ -1597,12 +1669,14 @@ function staffPreviewPanel() {
 					},
 					children: html`<span data-testid="proposal-send-feedback">Send feedback (${_staffAnnCount})</span>`,
 				}) : ""}
-				${!state.assistantType ? Button({ variant: "ghost", onClick: () => dismissTypedProposal("staff"), children: "Dismiss" }) : ""}
+				${!state.assistantType ? Button({ variant: "ghost", onClick: () => dismissTypedProposal("staff"), disabled: _creatingStaff, children: "Dismiss" }) : ""}
 				<span data-testid="proposal-primary-submit">${Button({
 					variant: "default",
 					onClick: handleCreateStaff,
-					disabled: !state.staffPreviewName.trim() || streaming || hasInvalidGoalTriggersForPreview(),
-					children: html`<span class="inline-flex items-center gap-1.5">${icon(UserCheck, "sm")} Create Staff</span>`,
+					disabled: _creatingStaff || !state.staffPreviewName.trim() || streaming || hasInvalidGoalTriggersForPreview(),
+					children: _creatingStaff
+						? html`<span class="inline-flex items-center gap-1.5" data-testid="staff-creating-label">Creating…</span>`
+						: html`<span class="inline-flex items-center gap-1.5">${icon(UserCheck, "sm")} Create Staff</span>`,
 				})}</span>
 			</div>
 		</div>

--- a/tests/e2e/mock-agent-core.mjs
+++ b/tests/e2e/mock-agent-core.mjs
@@ -345,6 +345,13 @@ export class MockAgentCore {
 				output: "Staff proposal partial submitted.",
 			};
 		}
+		if (text.includes("STAFF_PROPOSAL_ROLE")) {
+			return {
+				tool: "propose_staff",
+				input: { name: "parity-staff", description: "Parity staff description.", prompt: "Parity staff prompt.", triggers: "[]", cwd: "", role: "coder" },
+				output: "Staff proposal (with role) submitted.",
+			};
+		}
 		if (text.includes("STAFF_PROPOSAL_PARITY")) {
 			return {
 				tool: "propose_staff",

--- a/tests/e2e/ui/staff-proposal-role.spec.ts
+++ b/tests/e2e/ui/staff-proposal-role.spec.ts
@@ -1,0 +1,236 @@
+/**
+ * Browser E2E coverage for the staff *proposal* panel's role selector and the
+ * Create-Staff in-flight / double-submit guard (proposal-panels.ts).
+ *
+ * Issue 1 — the staff proposal panel must expose a role <select> that reflects
+ *   the proposed role, is user-editable, and persists the chosen role as
+ *   `roleId` on the created staff. A "No role" selection creates with no role.
+ * Issue 2 — clicking "Create Staff" must immediately disable the button and
+ *   show a "Creating…" label; on failure the panel + assistant session stay
+ *   open, the error modal is shown, and the button re-enables for retry.
+ *
+ * The staff proposal is driven by the mock agent via the `STAFF_PROPOSAL_ROLE`
+ * trigger (mock-agent-core.mjs), which proposes a staff with `role: "coder"`.
+ */
+import { test, expect } from "../gateway-harness.js";
+import { apiFetch } from "../e2e-setup.js";
+import type { Page } from "@playwright/test";
+import { openApp, createSessionViaUI, sendMessage } from "./ui-helpers.js";
+
+// Built-in roles (defaults/roles/*.yaml) — same ones used by staff-role.spec.ts.
+const PROPOSED_ROLE = "coder";
+const CHANGED_ROLE = "architect";
+
+interface UiProject {
+	id: string;
+	name: string;
+	rootPath: string;
+}
+
+interface StaffRecord {
+	id: string;
+	name: string;
+	currentSessionId?: string | null;
+	roleId?: string | null;
+}
+
+async function waitForActiveProject(page: Page): Promise<UiProject> {
+	await page.waitForFunction(() => {
+		const state = (window as any).bobbitState ?? (window as any).__bobbitState;
+		const project = state?.projects?.find((p: any) => p.id === state?.activeProjectId);
+		return !!project?.id && !!project?.rootPath;
+	}, null, { timeout: 15_000 });
+	return await page.evaluate(() => {
+		const state = (window as any).bobbitState ?? (window as any).__bobbitState;
+		return state.projects.find((p: any) => p.id === state.activeProjectId);
+	}) as UiProject;
+}
+
+async function waitForStaffProposal(page: Page): Promise<void> {
+	await page.waitForFunction(() => {
+		const state = (window as any).bobbitState ?? (window as any).__bobbitState;
+		const fields = state?.activeProposals?.staff?.fields;
+		return fields && typeof fields === "object" && fields.name === "parity-staff";
+	}, null, { timeout: 15_000 });
+}
+
+async function openStaffProposalPanel(page: Page) {
+	const panel = page.locator('[data-panel="staff-proposal"]').first();
+	if (!(await panel.isVisible().catch(() => false))) {
+		const tab = page.locator('.goal-tab-pill[title="Staff"]').first();
+		if (await tab.isVisible().catch(() => false)) {
+			await tab.click();
+		} else {
+			const openButton = page.locator('[data-testid="proposal-open-button"]').last();
+			await expect(openButton).toBeVisible({ timeout: 15_000 });
+			await openButton.click();
+		}
+	}
+	await expect(panel).toBeVisible({ timeout: 10_000 });
+	return panel;
+}
+
+/** Force a unique name into the proposal panel so created staff don't collide. */
+async function setStaffName(page: Page, name: string): Promise<void> {
+	await page.evaluate((n) => {
+		const state = (window as any).bobbitState ?? (window as any).__bobbitState;
+		state.staffPreviewName = n;
+		state.staffPreviewNameEdited = true;
+		(window as any).__bobbitRenderApp?.();
+	}, name);
+}
+
+async function findStaffByName(name: string): Promise<StaffRecord | undefined> {
+	const res = await apiFetch("/api/staff");
+	expect(res.ok).toBe(true);
+	const body = await res.json();
+	const list: StaffRecord[] = Array.isArray(body) ? body : (body.staff ?? body.agents ?? []);
+	return list.find((s) => s.name === name);
+}
+
+async function cleanupStaff(name: string): Promise<void> {
+	const staff = await findStaffByName(name);
+	if (!staff?.id) return;
+	if (staff.currentSessionId) {
+		await apiFetch(`/api/sessions/${staff.currentSessionId}`, { method: "DELETE" }).catch(() => {});
+	}
+	await apiFetch(`/api/staff/${staff.id}`, { method: "DELETE" }).catch(() => {});
+}
+
+test.describe("Staff proposal panel — role selector + create guard", () => {
+	test.describe.configure({ timeout: 90_000 });
+
+	test("role selector reflects the proposed role, is changeable, and persists as roleId", async ({ page }) => {
+		const staffName = `proposal-role-${Date.now().toString(36)}`;
+		try {
+			await openApp(page);
+			await createSessionViaUI(page);
+			await waitForActiveProject(page);
+
+			await sendMessage(page, "STAFF_PROPOSAL_ROLE");
+			await waitForStaffProposal(page);
+			const panel = await openStaffProposalPanel(page);
+
+			// Role <select> appears and reflects the proposed role.
+			const select = panel.locator('[data-testid="staff-proposal-role-select"]');
+			await expect(select).toBeVisible({ timeout: 10_000 });
+			await expect(select).toHaveValue(PROPOSED_ROLE);
+
+			// User can change the selection.
+			await select.selectOption(CHANGED_ROLE);
+			await expect(select).toHaveValue(CHANGED_ROLE);
+
+			await setStaffName(page, staffName);
+
+			const createButton = panel.locator('[data-testid="proposal-primary-submit"] button');
+			await expect(createButton).toBeEnabled({ timeout: 5_000 });
+			await createButton.click();
+
+			// On success the proposal is cleared.
+			await page.waitForFunction(() => {
+				const state = (window as any).bobbitState ?? (window as any).__bobbitState;
+				return state?.activeProposals?.staff == null;
+			}, null, { timeout: 20_000 });
+
+			// The chosen role persisted as roleId on the created staff.
+			await expect.poll(async () => (await findStaffByName(staffName))?.roleId, { timeout: 10_000 })
+				.toBe(CHANGED_ROLE);
+		} finally {
+			await cleanupStaff(staffName);
+		}
+	});
+
+	test("selecting \"No role\" creates a staff with no role", async ({ page }) => {
+		const staffName = `proposal-norole-${Date.now().toString(36)}`;
+		try {
+			await openApp(page);
+			await createSessionViaUI(page);
+			await waitForActiveProject(page);
+
+			await sendMessage(page, "STAFF_PROPOSAL_ROLE");
+			await waitForStaffProposal(page);
+			const panel = await openStaffProposalPanel(page);
+
+			const select = panel.locator('[data-testid="staff-proposal-role-select"]');
+			await expect(select).toHaveValue(PROPOSED_ROLE, { timeout: 10_000 });
+
+			// Clear the role.
+			await select.selectOption("");
+			await expect(select).toHaveValue("");
+
+			await setStaffName(page, staffName);
+
+			const createButton = panel.locator('[data-testid="proposal-primary-submit"] button');
+			await expect(createButton).toBeEnabled({ timeout: 5_000 });
+			await createButton.click();
+
+			await page.waitForFunction(() => {
+				const state = (window as any).bobbitState ?? (window as any).__bobbitState;
+				return state?.activeProposals?.staff == null;
+			}, null, { timeout: 20_000 });
+
+			const saved = await findStaffByName(staffName);
+			expect(saved, "staff should have been created").toBeTruthy();
+			expect(saved?.roleId ?? null, "no role should persist as null").toBeNull();
+		} finally {
+			await cleanupStaff(staffName);
+		}
+	});
+
+	test("Create Staff shows Creating…/disabled in flight, and on failure keeps the panel open + re-enables", async ({ page }) => {
+		const staffName = `proposal-fail-${Date.now().toString(36)}`;
+		// Intercept the create call: hold it open until the test has observed the
+		// in-flight state (event-driven gate, no wall-clock sleep), then fail with
+		// 404 to simulate a rejected create.
+		let releaseCreate: () => void = () => {};
+		const createGate = new Promise<void>((resolve) => { releaseCreate = resolve; });
+		await page.route("**/api/staff", async (route) => {
+			if (route.request().method() !== "POST") {
+				await route.continue();
+				return;
+			}
+			await createGate;
+			await route.fulfill({
+				status: 404,
+				contentType: "application/json",
+				body: JSON.stringify({ error: "role not found" }),
+			});
+		});
+
+		try {
+			await openApp(page);
+			await createSessionViaUI(page);
+			await waitForActiveProject(page);
+
+			await sendMessage(page, "STAFF_PROPOSAL_ROLE");
+			await waitForStaffProposal(page);
+			const panel = await openStaffProposalPanel(page);
+
+			await setStaffName(page, staffName);
+
+			const createButton = panel.locator('[data-testid="proposal-primary-submit"] button');
+			await expect(createButton).toBeEnabled({ timeout: 5_000 });
+			await createButton.click();
+
+			// In-flight: button disabled + "Creating…" label.
+			await expect(panel.locator('[data-testid="staff-creating-label"]')).toBeVisible({ timeout: 5_000 });
+			await expect(createButton).toBeDisabled();
+
+			// Let the create call complete (with the simulated 404).
+			releaseCreate();
+
+			// On failure: error modal shown, panel stays open, button re-enables.
+			await expect(page.getByText("Failed to create staff agent")).toBeVisible({ timeout: 10_000 });
+			await expect(panel).toBeVisible();
+			await page.waitForFunction(() => {
+				const state = (window as any).bobbitState ?? (window as any).__bobbitState;
+				return state?.activeProposals?.staff != null;
+			}, null, { timeout: 5_000 });
+			await expect(createButton).toBeEnabled({ timeout: 5_000 });
+			await expect(panel.locator('[data-testid="staff-creating-label"]')).toHaveCount(0);
+		} finally {
+			await page.unroute("**/api/staff").catch(() => {});
+			await cleanupStaff(staffName);
+		}
+	});
+});


### PR DESCRIPTION
Fix-up on top of the merged staff role-selection feature (PR #702). No revert — two follow-ups in the staff **proposal panel** (`src/app/proposal-panels.ts`).

## Issue 1 — Role selector in the staff proposal panel
Previously the panel silently read the proposed role from `state.activeProposals.staff?.fields?.role` and forwarded it as `roleId`, with no UI. Now it has a role `<select>` (with "No role"), mirroring the regular `staff-page.ts` picker:
- Lazily populated from the roles API via `ensureStaffProposalRolesLoaded()`.
- Seeded once from the proposed `role` field (guarded so re-renders don't clobber a user choice); fully user-editable.
- `handleCreateStaff` persists the selected value as `roleId` (empty ⇒ no role). Unknown role still rejected server-side (404).
- No accessory picker added; accessory default stays server-side.

## Issue 2 — Create-Staff in-flight feedback + double-submit guard
- Module-local `_creatingStaff` flag; re-entrancy guard drops repeated clicks (at most one create request).
- "Create Staff" shows "Creating…" and is disabled while in flight; Dismiss also disabled.
- Flag cleared in `finally`; on failure the proposal panel + staff-assistant session stay open and the button re-enables for retry (pre-existing early-return preserved). Success path unchanged.

## Tests
- New `tests/e2e/ui/staff-proposal-role.spec.ts` (role reflected/changeable/persisted as `roleId` after reload, "No role" case, create-feedback failure keeps panel open + re-enables), plus a `STAFF_PROPOSAL_ROLE` mock-agent trigger.
- `npm run check`, `npm run test:unit` (1281 passed), and the new spec all pass.

## Docs
- `docs/design/staff-role-selection.md` — follow-ups section.
- `docs/staff-agents.md` — proposal-panel role picker + create-in-flight guard.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)