### PR TITLE
feat: harness-gated perf instrumentation toggle + reload-timing sink

### DIFF
--- a/docs/design/boot-timing-instrumentation.md
+++ b/docs/design/boot-timing-instrumentation.md
@@ -1,0 +1,73 @@
+# Boot/reload performance instrumentation
+
+Opt-in instrumentation that measures the cost of a full page reload with hard
+numbers, so we can reason about reload disruption (e.g. while an agent is
+editing UI code under Vite) with data instead of estimates.
+
+## Why
+
+A full reload under Vite dev re-does two expensive things: re-evaluating the
+unbundled module graph (the dev module waterfall) and rehydrating session state
+(WebSocket reconnect + `get_state` snapshot replay + full `MessageList`
+re-render). Both resist a small time budget, and the snapshot replay scales with
+transcript length. Rather than guess, this feature records named milestones
+across a reload and writes them somewhere agents can inspect.
+
+## Surface
+
+- **Toggle**: Settings header, next to **Restart Server**
+  (`renderPerfInstrumentationToggle` in `src/app/settings-page.ts`). Gated to
+  **dev-harness mode only** — same gate as Restart Server
+  (`/api/harness-status` → `BOBBIT_DEV_HARNESS === "1"`).
+- **Persistence**: server preference `devPerfInstrumentation`, mirrored to the
+  `bobbit-perf-instrumentation` localStorage key. The localStorage mirror is the
+  synchronous source of truth that **arms the next reload** (it must be readable
+  before the module graph finishes evaluating); the server preference is the
+  durable record and seeds a fresh browser's mirror via `loadHarnessStatus`.
+
+## Client (`src/app/boot-timing.ts`)
+
+- Gated at runtime by the localStorage mirror — **no `__BOBBIT_DEV__`
+  compile-time gate**, so it ships in production but is a cheap boolean
+  early-return when disarmed.
+- `bootMark(name)` records `performance.now()` (ms since navigation start) at:
+  `modules-evaluated` (main.ts, after the eager graph evaluates),
+  `initApp-start`, `first-render-call` (main.ts), `first-paint`
+  (`pwa-lifecycle.ts::finalizeBoot`, when `#app` actually paints), `ws-open`,
+  `snapshot-received(N msgs)`, `snapshot-applied`, `post-snapshot-paint`
+  (`remote-agent.ts`).
+- One terminal report per load (idempotent): logs a `console.table` and POSTs
+  the sample to the sink. Triggered immediately after the session snapshot
+  paints, with a 3s idle-debounce fallback for no-session views.
+- `window.__bobbitBootTimings` always holds the latest sample for ad-hoc
+  devtools inspection (`copy(window.__bobbitBootTimings)`).
+
+## Server sink
+
+- `src/server/dev-boot-timing.ts`: `recordBootTiming` / `readBootTimings`. The
+  log is capped append-only JSONL — trimmed to the most recent 300 entries once
+  it passes 1 MB; oversized (>64 KB) or non-object samples are rejected.
+- Routes in `server.ts`, both **harness-gated** (403 otherwise):
+  - `POST /api/dev/boot-timing` → appends one sample, returns the file path.
+  - `GET  /api/dev/boot-timing?limit=N` → recent samples (newest last).
+- **Known location for agents**: `<stateDir>/boot-timing.jsonl`
+  (i.e. `.bobbit/state/boot-timing.jsonl` in the server cwd). Inspect with
+  `tail -f .bobbit/state/boot-timing.jsonl` or `GET /api/dev/boot-timing`.
+
+## Reading a sample
+
+Each JSONL line carries `reason`, `isReload`, `total_ms`, `route`, `sessionId`,
+`transcriptMessages`, `marks[]`, and a `rows[]` table with per-phase
+`Δ prev (ms)` deltas — the delta column shows where the time actually goes
+(module waterfall vs. first paint vs. snapshot replay).
+
+## Tests
+
+- `tests/dev-boot-timing.test.ts` — sink: append/parse, dir creation, limit,
+  rejection of non-object/oversized samples, byte-cap trimming, malformed-line
+  skipping.
+- `tests/e2e/dev-boot-timing-api.spec.ts` — endpoint gating (403 off-harness),
+  write+read-back under the harness, 422 on a non-object body.
+- `tests/e2e/ui/perf-instrumentation-toggle.spec.ts` — toggle hidden without the
+  harness; visible/toggles/persists-across-reload and arms reload
+  instrumentation under the harness.

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -2110,6 +2110,21 @@ export async function requestHarnessRestart(): Promise<{ ok: boolean; error?: st
 	}
 }
 
+/**
+ * POST one boot/reload-timing sample to the harness-gated sink
+ * (`/api/dev/boot-timing` → `<stateDir>/boot-timing.jsonl`). Fire-and-forget;
+ * swallows all errors so diagnostics can never disrupt the app. No-op-safe to
+ * call when the server is not under the harness (returns a 403 we ignore).
+ */
+export async function postBootTiming(sample: unknown): Promise<void> {
+	try {
+		await gatewayFetch("/api/dev/boot-timing", {
+			method: "POST",
+			body: JSON.stringify(sample),
+		});
+	} catch { /* ignore */ }
+}
+
 // ============================================================================
 // SANDBOX STATUS API
 // ============================================================================

--- a/src/app/boot-timing.ts
+++ b/src/app/boot-timing.ts
@@ -1,29 +1,75 @@
 // src/app/boot-timing.ts
 //
-// Dev-only boot/reload timing instrumentation. Records `performance.now()`
+// Opt-in boot/reload performance instrumentation. Records `performance.now()`
 // (ms since navigation start / `performance.timeOrigin`) at named boot
-// milestones so we can see, with hard numbers, where a full page reload spends
-// its time: the Vite dev module waterfall, first paint, the WebSocket
-// reconnect, and the `get_state` snapshot replay + re-render.
+// milestones so a full page reload's cost can be measured with hard numbers:
+// the module waterfall, first paint, the WebSocket reconnect, and the
+// `get_state` snapshot replay + re-render.
 //
-// Zero cost in production: every entry point short-circuits unless
-// `globalThis.__BOBBIT_DEV__` is true (stamped by vite.config.ts `define`).
-// Marks are cheap (`performance.now()` + array push); the only console output
-// happens in dev via `bootTimingFlush()`.
+// Gated at runtime by a localStorage flag (`bobbit-perf-instrumentation`),
+// flipped from Settings → "Perf instrumentation" (shown only under the dev
+// harness, next to Restart Server). When armed, the terminal report is logged
+// to the console AND POSTed to `/api/dev/boot-timing`, which appends it to
+// `<stateDir>/boot-timing.jsonl` for agents/tooling to inspect.
 //
-// Read the latest numbers from devtools at any time:
-//   copy(window.__bobbitBootTimings)        // structured
+// When disarmed every entry point is a cheap boolean check + early return, so
+// shipping this in production carries negligible overhead.
+//
+// Inspect the latest sample from devtools at any time:
+//   copy(window.__bobbitBootTimings)
 //   console.table(window.__bobbitBootTimings.rows)
 
-const DEV = (globalThis as { __BOBBIT_DEV__?: boolean }).__BOBBIT_DEV__ === true;
+/** localStorage key mirroring the `devPerfInstrumentation` server preference. */
+export const PERF_INSTRUMENTATION_KEY = "bobbit-perf-instrumentation";
 
 interface Mark { name: string; t: number; }
 
+interface BootMeta {
+	sessionId?: string;
+	transcriptMessages?: number;
+}
+
 const marks: Mark[] = [];
-// Once the initial load/reload sequence is captured we stop recording, so
-// later mid-session reconnects / compaction snapshots don't append to (and
-// distort) the boot table. `window.__bobbitBootTimings` keeps the first run.
-let sealed = false;
+let meta: BootMeta = {};
+// Captured synchronously at module load so the very first reload milestones are
+// recorded when the user enabled the toggle on a prior page (the reload case).
+let armed = readArmed();
+// One terminal report per page load. Guards against the dual triggers
+// (post-snapshot terminal + idle-debounce fallback) double-posting.
+let reported = false;
+let reportTimer: ReturnType<typeof setTimeout> | null = null;
+
+// Idle window after the last mark before we assume boot has settled and report
+// (covers no-session views, where no snapshot milestone ever fires).
+const IDLE_REPORT_MS = 3000;
+
+function readArmed(): boolean {
+	try { return localStorage.getItem(PERF_INSTRUMENTATION_KEY) === "1"; } catch { return false; }
+}
+
+/** True when boot instrumentation is currently armed (localStorage mirror). */
+export function isPerfInstrumentationEnabled(): boolean {
+	return readArmed();
+}
+
+/**
+ * Set the localStorage mirror that arms instrumentation on the NEXT reload.
+ * Called by the Settings toggle (alongside the `devPerfInstrumentation` PUT)
+ * and by preference hydration so a fresh browser reflects the server value.
+ */
+export function setPerfInstrumentationEnabled(on: boolean): void {
+	try {
+		if (on) localStorage.setItem(PERF_INSTRUMENTATION_KEY, "1");
+		else localStorage.removeItem(PERF_INSTRUMENTATION_KEY);
+	} catch { /* private mode — ignore */ }
+	armed = on;
+}
+
+/** Attach metadata to the eventual report (session id, transcript size, …). */
+export function bootTimingMeta(partial: BootMeta): void {
+	if (!armed) return;
+	meta = { ...meta, ...partial };
+}
 
 function buildRows(): Array<Record<string, unknown>> {
 	return marks.map((m, i) => ({
@@ -33,48 +79,66 @@ function buildRows(): Array<Record<string, unknown>> {
 	}));
 }
 
-function publish(reason: string): void {
-	const isReload = (() => {
-		try { return sessionStorage.getItem("bobbit-hot-reload") === "1"; } catch { return false; }
-	})();
-	(window as unknown as { __bobbitBootTimings?: unknown }).__bobbitBootTimings = {
+function buildSample(reason: string): Record<string, unknown> {
+	let isReload = false;
+	try { isReload = sessionStorage.getItem("bobbit-hot-reload") === "1"; } catch { /* ignore */ }
+	const total = marks.length ? Math.round(marks[marks.length - 1].t * 10) / 10 : 0;
+	return {
 		reason,
 		isReload,
-		total_ms: marks.length ? Math.round(marks[marks.length - 1].t * 10) / 10 : 0,
+		total_ms: total,
+		route: typeof location !== "undefined" ? location.hash || location.pathname : undefined,
+		sessionId: meta.sessionId,
+		transcriptMessages: meta.transcriptMessages,
+		buildId: (globalThis as { __BOBBIT_BUILD_ID__?: string }).__BOBBIT_BUILD_ID__,
+		userAgent: typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+		viewport: typeof window !== "undefined" ? { w: window.innerWidth, h: window.innerHeight } : undefined,
+		clientTs: Date.now(),
 		marks: marks.map((m) => ({ ...m })),
 		rows: buildRows(),
 	};
 }
 
-/** Record a named boot milestone. No-op outside dev or after the run is sealed. */
+function publish(reason: string): Record<string, unknown> {
+	const sample = buildSample(reason);
+	(window as unknown as { __bobbitBootTimings?: unknown }).__bobbitBootTimings = sample;
+	return sample;
+}
+
+function scheduleIdleReport(): void {
+	if (reportTimer) clearTimeout(reportTimer);
+	reportTimer = setTimeout(() => bootTimingReport("idle"), IDLE_REPORT_MS);
+}
+
+/** Record a named boot milestone. No-op when disarmed or already reported. */
 export function bootMark(name: string): void {
-	if (!DEV || sealed || typeof performance === "undefined") return;
+	if (!armed || reported || typeof performance === "undefined") return;
 	marks.push({ name, t: performance.now() });
-	// Keep the window snapshot live so devtools always sees the latest, even
-	// before an explicit flush (the session snapshot lands after first paint).
-	try { publish("live"); } catch { /* window may be unavailable in some contexts */ }
+	publish("live");
+	scheduleIdleReport();
 }
 
 /**
- * Log the current timing table to the console. Safe to call multiple times
- * (e.g. once at first paint for the structural floor, once after the session
- * snapshot replay). No-op outside dev.
+ * Emit the terminal report exactly once: log the table and POST the sample to
+ * the server sink. Idempotent and no-op when disarmed. Called both immediately
+ * after the session snapshot paints (fast path) and via the idle-debounce
+ * fallback (no-session views).
  */
-export function bootTimingFlush(reason: string): void {
-	if (!DEV || typeof performance === "undefined" || marks.length === 0) return;
-	publish(reason);
-	const isReload = (window as unknown as { __bobbitBootTimings?: { isReload?: boolean } }).__bobbitBootTimings?.isReload;
-	const total = Math.round(marks[marks.length - 1].t * 10) / 10;
-	console.log(`[boot-timing] ${reason} — reload=${isReload} total=${total}ms (navigation→last mark)`);
+export function bootTimingReport(reason: string): void {
+	if (!armed || reported || marks.length === 0) return;
+	reported = true;
+	if (reportTimer) { clearTimeout(reportTimer); reportTimer = null; }
+
+	const sample = publish(reason);
+	const isReload = (sample as { isReload?: boolean }).isReload;
+	const total = (sample as { total_ms?: number }).total_ms;
+	console.log(`[boot-timing] ${reason} — reload=${isReload} total=${total}ms (navigation→last mark). Sample: window.__bobbitBootTimings`);
 	(console as { table?: (data: unknown) => void }).table?.(buildRows());
-}
 
-/**
- * Seal the run: stop recording further marks. Called once the initial
- * load/reload sequence is fully captured (after the first session snapshot
- * paints) so mid-session reconnects don't distort the table. No-op outside dev.
- */
-export function bootTimingSeal(): void {
-	if (!DEV) return;
-	sealed = true;
+	// Fire-and-forget POST to the harness-gated sink. Dynamic import avoids a
+	// static dependency cycle (api.ts → state.ts → …) and keeps boot-timing
+	// importable from very early modules.
+	import("./api.js")
+		.then((m) => m.postBootTiming(sample))
+		.catch(() => { /* diagnostics must never break the app */ });
 }

--- a/src/app/boot-timing.ts
+++ b/src/app/boot-timing.ts
@@ -1,0 +1,80 @@
+// src/app/boot-timing.ts
+//
+// Dev-only boot/reload timing instrumentation. Records `performance.now()`
+// (ms since navigation start / `performance.timeOrigin`) at named boot
+// milestones so we can see, with hard numbers, where a full page reload spends
+// its time: the Vite dev module waterfall, first paint, the WebSocket
+// reconnect, and the `get_state` snapshot replay + re-render.
+//
+// Zero cost in production: every entry point short-circuits unless
+// `globalThis.__BOBBIT_DEV__` is true (stamped by vite.config.ts `define`).
+// Marks are cheap (`performance.now()` + array push); the only console output
+// happens in dev via `bootTimingFlush()`.
+//
+// Read the latest numbers from devtools at any time:
+//   copy(window.__bobbitBootTimings)        // structured
+//   console.table(window.__bobbitBootTimings.rows)
+
+const DEV = (globalThis as { __BOBBIT_DEV__?: boolean }).__BOBBIT_DEV__ === true;
+
+interface Mark { name: string; t: number; }
+
+const marks: Mark[] = [];
+// Once the initial load/reload sequence is captured we stop recording, so
+// later mid-session reconnects / compaction snapshots don't append to (and
+// distort) the boot table. `window.__bobbitBootTimings` keeps the first run.
+let sealed = false;
+
+function buildRows(): Array<Record<string, unknown>> {
+	return marks.map((m, i) => ({
+		phase: m.name,
+		"t (ms)": Math.round(m.t * 10) / 10,
+		"Δ prev (ms)": i === 0 ? Math.round(m.t * 10) / 10 : Math.round((m.t - marks[i - 1].t) * 10) / 10,
+	}));
+}
+
+function publish(reason: string): void {
+	const isReload = (() => {
+		try { return sessionStorage.getItem("bobbit-hot-reload") === "1"; } catch { return false; }
+	})();
+	(window as unknown as { __bobbitBootTimings?: unknown }).__bobbitBootTimings = {
+		reason,
+		isReload,
+		total_ms: marks.length ? Math.round(marks[marks.length - 1].t * 10) / 10 : 0,
+		marks: marks.map((m) => ({ ...m })),
+		rows: buildRows(),
+	};
+}
+
+/** Record a named boot milestone. No-op outside dev or after the run is sealed. */
+export function bootMark(name: string): void {
+	if (!DEV || sealed || typeof performance === "undefined") return;
+	marks.push({ name, t: performance.now() });
+	// Keep the window snapshot live so devtools always sees the latest, even
+	// before an explicit flush (the session snapshot lands after first paint).
+	try { publish("live"); } catch { /* window may be unavailable in some contexts */ }
+}
+
+/**
+ * Log the current timing table to the console. Safe to call multiple times
+ * (e.g. once at first paint for the structural floor, once after the session
+ * snapshot replay). No-op outside dev.
+ */
+export function bootTimingFlush(reason: string): void {
+	if (!DEV || typeof performance === "undefined" || marks.length === 0) return;
+	publish(reason);
+	const isReload = (window as unknown as { __bobbitBootTimings?: { isReload?: boolean } }).__bobbitBootTimings?.isReload;
+	const total = Math.round(marks[marks.length - 1].t * 10) / 10;
+	console.log(`[boot-timing] ${reason} — reload=${isReload} total=${total}ms (navigation→last mark)`);
+	(console as { table?: (data: unknown) => void }).table?.(buildRows());
+}
+
+/**
+ * Seal the run: stop recording further marks. Called once the initial
+ * load/reload sequence is fully captured (after the first session snapshot
+ * paints) so mid-session reconnects don't distort the table. No-op outside dev.
+ */
+export function bootTimingSeal(): void {
+	if (!DEV) return;
+	sealed = true;
+}

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -49,6 +49,12 @@ function clearDashboardState(): void {
 }
 import { registerShortcut, startListening, loadSavedBindings } from "./shortcut-registry.js";
 import { activeSidePanelTabIdForSession, loadPersistedPanelWorkspace } from "./panel-workspace.js";
+import { bootMark } from "./boot-timing.js";
+
+// Boot-timing: this fires only after the entire eager module graph has been
+// fetched + evaluated (the Vite dev module waterfall), so `t` here ≈ cost of
+// navigation → all modules ready. Dev-only; no-op in production.
+bootMark("modules-evaluated");
 
 // ============================================================================
 // WIRE UP RENDER
@@ -394,6 +400,7 @@ async function handleHashChange(): Promise<void> {
 // ============================================================================
 
 async function initApp() {
+	bootMark("initApp-start");
 	const app = document.getElementById("app");
 	if (!app) throw new Error("App container not found");
 
@@ -438,6 +445,7 @@ async function initApp() {
 	if (savedUrl && savedToken) {
 		state.appView = "gateway-starting";
 	}
+	bootMark("first-render-call");
 	renderApp();
 	// Signal boot intent. renderApp() defers the real Lit render to a rAF, so
 	// #app may still be empty right now — markAppBooted() does NOT clear the

--- a/src/app/pwa-lifecycle.ts
+++ b/src/app/pwa-lifecycle.ts
@@ -36,6 +36,8 @@
  * unit-testable `shouldReloadOnResume()` — no DOM, no globals.
  */
 
+import { bootMark, bootTimingFlush } from "./boot-timing.js";
+
 declare global {
 	interface Window {
 		__bobbitBootStart?: number;
@@ -322,6 +324,11 @@ export function installPwaLifecycleRecovery(): void {
 function finalizeBoot(): void {
 	if (booted) return;
 	booted = true;
+	// First real paint: #app has child content. Records the structural-floor
+	// timing (navigation → module waterfall → first paint) before any session
+	// snapshot lands. Dev-only; no-op in production. See boot-timing.ts.
+	bootMark("first-paint");
+	bootTimingFlush("first-paint");
 	if (bootObserver) {
 		try {
 			bootObserver.disconnect();

--- a/src/app/pwa-lifecycle.ts
+++ b/src/app/pwa-lifecycle.ts
@@ -36,7 +36,7 @@
  * unit-testable `shouldReloadOnResume()` — no DOM, no globals.
  */
 
-import { bootMark, bootTimingFlush } from "./boot-timing.js";
+import { bootMark } from "./boot-timing.js";
 
 declare global {
 	interface Window {
@@ -326,9 +326,10 @@ function finalizeBoot(): void {
 	booted = true;
 	// First real paint: #app has child content. Records the structural-floor
 	// timing (navigation → module waterfall → first paint) before any session
-	// snapshot lands. Dev-only; no-op in production. See boot-timing.ts.
+	// snapshot lands. Opt-in; no-op when disarmed. The terminal report fires
+	// later (after the snapshot paints, or via the idle fallback for
+	// no-session views). See boot-timing.ts.
 	bootMark("first-paint");
-	bootTimingFlush("first-paint");
 	if (bootObserver) {
 		try {
 			bootObserver.disconnect();

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -1,6 +1,6 @@
 import type { Model } from "@earendil-works/pi-ai";
 import { PROPOSAL_PARSERS } from "./proposal-parsers.js";
-import { bootMark, bootTimingFlush, bootTimingSeal } from "./boot-timing.js";
+import { bootMark, bootTimingMeta, bootTimingReport } from "./boot-timing.js";
 
 /**
  * Placeholder model used as the initial value of `_state.model` before the
@@ -1374,7 +1374,8 @@ export class RemoteAgent {
 				const msgs = Array.isArray(msg.data) ? msg.data : msg.data?.messages;
 				if (Array.isArray(msgs)) {
 					// Boot-timing: bracket the get_state snapshot replay — the cost
-					// that scales with transcript length. Dev-only; no-op in prod.
+					// that scales with transcript length. Opt-in; no-op when disarmed.
+					bootTimingMeta({ sessionId: this._sessionId, transcriptMessages: msgs.length });
 					bootMark(`snapshot-received(${msgs.length} msgs)`);
 					// Server snapshot is authoritative for any id it contains. The
 					// reducer merges in survivors (optimistic, synthetic, permission)
@@ -1385,8 +1386,7 @@ export class RemoteAgent {
 					// paints so the table captures the full reload incl. MessageList.
 					requestAnimationFrame(() => requestAnimationFrame(() => {
 						bootMark("post-snapshot-paint");
-						bootTimingFlush("post-snapshot-paint");
-						bootTimingSeal();
+						bootTimingReport("post-snapshot-paint");
 					}));
 					// Post-compaction refreshAfterCompaction lands here. Amend the
 					// in-flight compaction card with authoritative tokensAfter if

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -1,5 +1,6 @@
 import type { Model } from "@earendil-works/pi-ai";
 import { PROPOSAL_PARSERS } from "./proposal-parsers.js";
+import { bootMark, bootTimingFlush, bootTimingSeal } from "./boot-timing.js";
 
 /**
  * Placeholder model used as the initial value of `_state.model` before the
@@ -664,6 +665,7 @@ export class RemoteAgent {
 			let settled = false;
 
 			this.ws.onopen = () => {
+				bootMark("ws-open");
 				this.ws!.send(JSON.stringify({ type: "auth", token: this._authToken }));
 			};
 
@@ -1371,10 +1373,21 @@ export class RemoteAgent {
 			case "messages": {
 				const msgs = Array.isArray(msg.data) ? msg.data : msg.data?.messages;
 				if (Array.isArray(msgs)) {
+					// Boot-timing: bracket the get_state snapshot replay — the cost
+					// that scales with transcript length. Dev-only; no-op in prod.
+					bootMark(`snapshot-received(${msgs.length} msgs)`);
 					// Server snapshot is authoritative for any id it contains. The
 					// reducer merges in survivors (optimistic, synthetic, permission)
 					// and sorts the result by (_order, _insertionTick).
 					this.apply({ type: "snapshot", messages: msgs });
+					bootMark("snapshot-applied");
+					// The reducer triggers a re-render via rAF; mark + flush after it
+					// paints so the table captures the full reload incl. MessageList.
+					requestAnimationFrame(() => requestAnimationFrame(() => {
+						bootMark("post-snapshot-paint");
+						bootTimingFlush("post-snapshot-paint");
+						bootTimingSeal();
+					}));
 					// Post-compaction refreshAfterCompaction lands here. Amend the
 					// in-flight compaction card with authoritative tokensAfter if
 					// the new transcript carries usable usage.

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -7,7 +7,7 @@ import { Button } from "@mariozechner/mini-lit/dist/Button.js";
 import { Select, type SelectOption } from "@mariozechner/mini-lit/dist/Select.js";
 import { html } from "lit";
 import { live } from "lit/directives/live.js";
-import { ArrowLeft, Brain, Check, FlaskConical, Image as ImageIcon, Loader2, Plus, RotateCcw, Sparkles, Trash2, X } from "lucide";
+import { ArrowLeft, Brain, Check, FlaskConical, Gauge, Image as ImageIcon, Loader2, Plus, RotateCcw, Sparkles, Trash2, X } from "lucide";
 import {
 	getShortcuts,
 	formatBinding,
@@ -39,6 +39,7 @@ import { renderWorkflowPage, loadWorkflowPageData } from "./workflow-page.js";
 import { setConfigScope, getConfigScope } from "./config-scope.js";
 import { gatewayFetch, fetchSandboxStatus, fetchHarnessStatus, requestHarnessRestart, removeProject, fetchProjects, searchStats, searchRebuild, orphanedIndexRows, cleanupOrphanedIndexRows, type SearchStats, type OrphanedIndexRows } from "./api.js";
 import { applyProjectPalette } from "./session-manager.js";
+import { setPerfInstrumentationEnabled, isPerfInstrumentationEnabled } from "./boot-timing.js";
 import { dispatchIndexEvent } from "./components/search-status-dot.js";
 import "./components/search-status-dot.js";
 import { openOAuthDialog } from "./dialogs.js";
@@ -110,6 +111,10 @@ let harnessStatusLoaded = false;
 let harnessRestartAvailable = false;
 let harnessRestartState: "idle" | "requesting" | "requested" | "error" = "idle";
 let harnessRestartError = "";
+// Dev perf-instrumentation toggle (harness-only, next to Restart Server).
+// Mirrors the `devPerfInstrumentation` server preference; the localStorage
+// mirror (see boot-timing.ts) is what actually arms the next reload.
+let settingsPerfInstrumentation = false;
 // Skills-catalog byte budget override. `null` means "use server default" (no preference set).
 let settingsSkillsCatalogBudget: number | null = null;
 
@@ -920,10 +925,40 @@ export function toggleSettings(): void {
 function loadHarnessStatus(): void {
 	if (harnessStatusLoaded) return;
 	harnessStatusLoaded = true;
-	fetchHarnessStatus().then(status => {
+	fetchHarnessStatus().then(async status => {
 		harnessRestartAvailable = status.restartAvailable;
+		// Load the perf-instrumentation toggle state from the server preference
+		// and mirror it into localStorage so a fresh browser arms correctly on
+		// the next reload. Only meaningful under the harness.
+		if (status.restartAvailable) {
+			try {
+				const res = await gatewayFetch("/api/preferences");
+				if (res.ok) {
+					const prefs = await res.json();
+					settingsPerfInstrumentation = prefs.devPerfInstrumentation === true;
+					setPerfInstrumentationEnabled(settingsPerfInstrumentation);
+				}
+			} catch { /* fall back to localStorage mirror */ }
+			// If the server pref was unreadable, reflect the local mirror so the
+			// button still shows the truth that governs the next reload.
+			if (!settingsPerfInstrumentation) settingsPerfInstrumentation = isPerfInstrumentationEnabled();
+		}
 		renderApp();
 	});
+}
+
+async function togglePerfInstrumentation(): Promise<void> {
+	settingsPerfInstrumentation = !settingsPerfInstrumentation;
+	// Arm/disarm the NEXT reload immediately via the localStorage mirror; the
+	// current page is already past its boot marks.
+	setPerfInstrumentationEnabled(settingsPerfInstrumentation);
+	renderApp();
+	try {
+		await gatewayFetch("/api/preferences", {
+			method: "PUT",
+			body: JSON.stringify({ devPerfInstrumentation: settingsPerfInstrumentation }),
+		});
+	} catch { /* the localStorage mirror still governs the next reload */ }
 }
 
 async function requestSettingsRestart(): Promise<void> {
@@ -944,6 +979,25 @@ async function requestSettingsRestart(): Promise<void> {
 	renderApp();
 }
 
+function renderPerfInstrumentationToggle() {
+	const on = settingsPerfInstrumentation;
+	return html`
+		<button
+			class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border transition-colors ${on
+				? "border-primary bg-primary/10 text-primary"
+				: "border-border bg-background text-foreground hover:bg-secondary"}"
+			role="switch"
+			aria-checked=${on ? "true" : "false"}
+			data-testid="perf-instrumentation-toggle"
+			@click=${togglePerfInstrumentation}
+			title="Record reload performance stats to .bobbit/state/boot-timing.jsonl on each full reload. Applies on the next reload."
+		>
+			${icon(Gauge, "xs")}
+			<span>Perf ${on ? "On" : "Off"}</span>
+		</button>
+	`;
+}
+
 function renderHarnessRestartControl() {
 	if (!harnessRestartAvailable) return "";
 	const requesting = harnessRestartState === "requesting";
@@ -954,6 +1008,7 @@ function renderHarnessRestartControl() {
 			${harnessRestartState === "error" && harnessRestartError ? html`
 				<span class="text-xs text-destructive max-w-[40vw] sm:max-w-[18rem] truncate" title=${harnessRestartError}>${harnessRestartError}</span>
 			` : ""}
+			${renderPerfInstrumentationToggle()}
 			<button
 				class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border bg-background text-foreground hover:bg-secondary transition-colors disabled:opacity-60 disabled:pointer-events-none"
 				?disabled=${requesting || requested}

--- a/src/server/dev-boot-timing.ts
+++ b/src/server/dev-boot-timing.ts
@@ -1,0 +1,129 @@
+// src/server/dev-boot-timing.ts
+//
+// Sink for client-side boot/reload performance samples. When the dev "perf
+// instrumentation" toggle is enabled (Settings → next to Restart Server,
+// harness-mode only), the client POSTs one timing sample per full reload to
+// `POST /api/dev/boot-timing`, and the route appends it here as a JSON line at
+// `<stateDir>/boot-timing.jsonl` — a known, easily-inspectable location in the
+// server cwd that agents can `cat`/`tail` to read real reload numbers.
+//
+// The file is a capped append-only JSONL log: once it grows past
+// `MAX_FILE_BYTES` we keep only the most recent `KEEP_LINES` entries so it can
+// never grow without bound during a long instrumented session.
+
+import fs from "node:fs";
+import path from "node:path";
+import { bobbitStateDir } from "./bobbit-dir.js";
+
+/** File name under the state dir. */
+export const BOOT_TIMING_FILE = "boot-timing.jsonl";
+
+/** Trim the log once it exceeds this many bytes. */
+const MAX_FILE_BYTES = 1_000_000; // 1 MB
+/** Number of most-recent lines retained when trimming. */
+const KEEP_LINES = 300;
+/** Reject samples whose serialized form exceeds this (defends the disk). */
+const MAX_SAMPLE_BYTES = 64 * 1024; // 64 KB
+
+export interface BootTimingMark { name: string; t: number; }
+
+/** One client-reported reload sample. Shape is advisory — extra keys are kept. */
+export interface BootTimingSample {
+	reason?: string;
+	isReload?: boolean;
+	total_ms?: number;
+	route?: string;
+	sessionId?: string;
+	transcriptMessages?: number;
+	buildId?: string;
+	userAgent?: string;
+	viewport?: { w: number; h: number };
+	clientTs?: number;
+	marks?: BootTimingMark[];
+	rows?: Array<Record<string, unknown>>;
+	[key: string]: unknown;
+}
+
+/** Stored line = the client sample plus a server receive timestamp. */
+export interface StoredBootTimingSample extends BootTimingSample {
+	receivedAt: string;
+}
+
+function filePath(stateDir: string): string {
+	return path.join(stateDir, BOOT_TIMING_FILE);
+}
+
+/**
+ * Append one boot-timing sample as a JSON line. Returns the absolute path
+ * written (so the route can echo it back for discoverability) or null if the
+ * sample was rejected (too large / not an object).
+ *
+ * Best-effort: filesystem errors are swallowed — diagnostics must never break
+ * a reload. Throws only on a programmer error (missing stateDir).
+ */
+export function recordBootTiming(sample: unknown, stateDir: string = bobbitStateDir()): string | null {
+	if (!stateDir) throw new Error("recordBootTiming: stateDir is required");
+	if (!sample || typeof sample !== "object" || Array.isArray(sample)) return null;
+
+	const stored: StoredBootTimingSample = { ...(sample as BootTimingSample), receivedAt: new Date().toISOString() };
+	let line: string;
+	try {
+		line = JSON.stringify(stored);
+	} catch {
+		return null;
+	}
+	if (line.length > MAX_SAMPLE_BYTES) return null;
+
+	const target = filePath(stateDir);
+	try {
+		fs.mkdirSync(stateDir, { recursive: true });
+		fs.appendFileSync(target, line + "\n", "utf-8");
+		trimIfNeeded(target);
+		return target;
+	} catch {
+		return null;
+	}
+}
+
+/** Keep only the last KEEP_LINES entries once the file passes MAX_FILE_BYTES. */
+function trimIfNeeded(target: string): void {
+	let size: number;
+	try {
+		size = fs.statSync(target).size;
+	} catch {
+		return;
+	}
+	if (size <= MAX_FILE_BYTES) return;
+	try {
+		const lines = fs.readFileSync(target, "utf-8").split("\n").filter((l) => l.trim().length > 0);
+		const kept = lines.slice(-KEEP_LINES);
+		fs.writeFileSync(target, kept.join("\n") + "\n", "utf-8");
+	} catch {
+		/* best-effort */
+	}
+}
+
+/**
+ * Read the most-recent `limit` samples (newest last), parsed from JSONL.
+ * Malformed lines are skipped. Returns [] when the file does not exist.
+ */
+export function readBootTimings(limit = 50, stateDir: string = bobbitStateDir()): StoredBootTimingSample[] {
+	const target = filePath(stateDir);
+	let raw: string;
+	try {
+		raw = fs.readFileSync(target, "utf-8");
+	} catch {
+		return [];
+	}
+	const out: StoredBootTimingSample[] = [];
+	for (const l of raw.split("\n")) {
+		const trimmed = l.trim();
+		if (!trimmed) continue;
+		try {
+			out.push(JSON.parse(trimmed) as StoredBootTimingSample);
+		} catch {
+			/* skip malformed */
+		}
+	}
+	return limit > 0 ? out.slice(-limit) : out;
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import os from "node:os";
 import { fileURLToPath } from "node:url";
 import { bobbitStateDir, bobbitConfigDir, getProjectRoot } from "./bobbit-dir.js";
+import { recordBootTiming, readBootTimings, BOOT_TIMING_FILE } from "./dev-boot-timing.js";
 import { touchGatewayRestartSentinel } from "./harness-signal.js";
 import { isSetupComplete } from "./setup-status.js";
 export { isSetupComplete };
@@ -2293,6 +2294,36 @@ async function handleApiRoute(
 		}
 		touchGatewayRestartSentinel();
 		json({ ok: true, restartRequested: true }, 202);
+		return;
+	}
+
+	// POST /api/dev/boot-timing — append one client reload-timing sample to
+	// <stateDir>/boot-timing.jsonl. Harness-only (same gate as restart): the
+	// perf-instrumentation toggle that drives these POSTs is only shown under
+	// the dev harness, and we reject here too as defense-in-depth.
+	if (url.pathname === "/api/dev/boot-timing" && req.method === "POST") {
+		if (process.env.BOBBIT_DEV_HARNESS !== "1") {
+			json({ error: "Perf instrumentation is only available under the dev harness" }, 403);
+			return;
+		}
+		const body = await readBody(req);
+		if (!body || typeof body !== "object") { json({ error: "Missing body" }, 400); return; }
+		const written = recordBootTiming(body);
+		if (!written) { json({ error: "Sample rejected" }, 422); return; }
+		json({ ok: true, path: path.join(bobbitStateDir(), BOOT_TIMING_FILE) }, 201);
+		return;
+	}
+
+	// GET /api/dev/boot-timing — read recent reload-timing samples (newest last)
+	// for inspection from the UI or tooling. Harness-only. `?limit=N` caps rows.
+	if (url.pathname === "/api/dev/boot-timing" && req.method === "GET") {
+		if (process.env.BOBBIT_DEV_HARNESS !== "1") {
+			json({ error: "Perf instrumentation is only available under the dev harness" }, 403);
+			return;
+		}
+		const limitParamRaw = url.searchParams.get("limit");
+		const limit = limitParamRaw ? Math.max(1, Math.min(500, parseInt(limitParamRaw, 10) || 50)) : 50;
+		json({ path: path.join(bobbitStateDir(), BOOT_TIMING_FILE), samples: readBootTimings(limit) });
 		return;
 	}
 

--- a/tests/dev-boot-timing.test.ts
+++ b/tests/dev-boot-timing.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+	recordBootTiming,
+	readBootTimings,
+	BOOT_TIMING_FILE,
+	type BootTimingSample,
+} from "../src/server/dev-boot-timing.ts";
+
+let stateDir: string;
+
+function sample(extra: Partial<BootTimingSample> = {}): BootTimingSample {
+	return {
+		reason: "post-snapshot-paint",
+		isReload: true,
+		total_ms: 412.5,
+		route: "#/session/abc",
+		sessionId: "abc",
+		transcriptMessages: 42,
+		marks: [{ name: "modules-evaluated", t: 180 }, { name: "first-paint", t: 240 }],
+		...extra,
+	};
+}
+
+beforeEach(() => {
+	stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-boot-timing-"));
+});
+
+afterEach(() => {
+	try { fs.rmSync(stateDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe("dev-boot-timing sink", () => {
+	it("appends a sample as one JSON line and stamps receivedAt", () => {
+		const written = recordBootTiming(sample(), stateDir);
+		assert.equal(written, path.join(stateDir, BOOT_TIMING_FILE));
+
+		const raw = fs.readFileSync(written!, "utf-8");
+		const lines = raw.split("\n").filter((l) => l.trim());
+		assert.equal(lines.length, 1);
+		const parsed = JSON.parse(lines[0]);
+		assert.equal(parsed.sessionId, "abc");
+		assert.equal(parsed.transcriptMessages, 42);
+		assert.equal(typeof parsed.receivedAt, "string");
+		assert.ok(!Number.isNaN(Date.parse(parsed.receivedAt)));
+	});
+
+	it("creates the state dir if missing", () => {
+		const nested = path.join(stateDir, "deep", "state");
+		const written = recordBootTiming(sample(), nested);
+		assert.ok(written && fs.existsSync(written));
+	});
+
+	it("readBootTimings returns samples oldest→newest and respects limit", () => {
+		for (let i = 0; i < 5; i++) recordBootTiming(sample({ sessionId: `s${i}` }), stateDir);
+		const all = readBootTimings(50, stateDir);
+		assert.equal(all.length, 5);
+		assert.deepEqual(all.map((s) => s.sessionId), ["s0", "s1", "s2", "s3", "s4"]);
+
+		const last2 = readBootTimings(2, stateDir);
+		assert.deepEqual(last2.map((s) => s.sessionId), ["s3", "s4"]);
+	});
+
+	it("returns [] when the file does not exist", () => {
+		assert.deepEqual(readBootTimings(50, stateDir), []);
+	});
+
+	it("rejects non-object and array samples", () => {
+		assert.equal(recordBootTiming(null, stateDir), null);
+		assert.equal(recordBootTiming("nope", stateDir), null);
+		assert.equal(recordBootTiming([1, 2, 3], stateDir), null);
+		assert.equal(readBootTimings(50, stateDir).length, 0);
+	});
+
+	it("rejects oversized samples without writing", () => {
+		const huge = sample({ note: "x".repeat(70 * 1024) } as Partial<BootTimingSample>);
+		assert.equal(recordBootTiming(huge, stateDir), null);
+		assert.equal(readBootTimings(50, stateDir).length, 0);
+	});
+
+	it("trims the log to the most-recent entries once it passes the byte cap", () => {
+		// ~4 KB per line × 400 lines ≈ 1.6 MB > 1 MB cap → trims to last 300.
+		const pad = "y".repeat(4 * 1024);
+		for (let i = 0; i < 400; i++) recordBootTiming(sample({ sessionId: `n${i}`, pad } as Partial<BootTimingSample>), stateDir);
+		const kept = readBootTimings(1000, stateDir);
+		assert.ok(kept.length <= 300, `expected ≤300 retained lines, got ${kept.length}`);
+		// The newest sample must survive the trim.
+		assert.equal(kept[kept.length - 1].sessionId, "n399");
+	});
+
+	it("skips malformed lines when reading", () => {
+		recordBootTiming(sample({ sessionId: "good" }), stateDir);
+		fs.appendFileSync(path.join(stateDir, BOOT_TIMING_FILE), "{not json}\n", "utf-8");
+		recordBootTiming(sample({ sessionId: "good2" }), stateDir);
+		const parsed = readBootTimings(50, stateDir);
+		assert.deepEqual(parsed.map((s) => s.sessionId), ["good", "good2"]);
+	});
+});

--- a/tests/e2e/dev-boot-timing-api.spec.ts
+++ b/tests/e2e/dev-boot-timing-api.spec.ts
@@ -1,0 +1,91 @@
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { test, expect } from "./in-process-harness.js";
+import { rawApiFetch } from "./e2e-setup.js";
+
+function bootTimingPath(bobbitDir: string): string {
+	return join(bobbitDir, "state", "boot-timing.jsonl");
+}
+
+const SAMPLE = {
+	reason: "post-snapshot-paint",
+	isReload: true,
+	total_ms: 512.3,
+	route: "#/session/xyz",
+	sessionId: "xyz",
+	transcriptMessages: 17,
+	marks: [
+		{ name: "modules-evaluated", t: 210 },
+		{ name: "first-paint", t: 260 },
+		{ name: "post-snapshot-paint", t: 512.3 },
+	],
+};
+
+test.describe("dev boot-timing API", () => {
+	test.describe.configure({ mode: "serial" });
+
+	test("rejects POST and GET outside the dev harness", async ({ gateway }) => {
+		const previous = process.env.BOBBIT_DEV_HARNESS;
+		const file = bootTimingPath(gateway.bobbitDir);
+		try {
+			rmSync(file, { force: true });
+			delete process.env.BOBBIT_DEV_HARNESS;
+
+			const post = await rawApiFetch("/api/dev/boot-timing", { method: "POST", body: JSON.stringify(SAMPLE) });
+			expect(post.status).toBe(403);
+			expect(await post.json()).toMatchObject({ error: expect.stringMatching(/dev harness/i) });
+
+			const get = await rawApiFetch("/api/dev/boot-timing");
+			expect(get.status).toBe(403);
+
+			expect(existsSync(file)).toBe(false);
+		} finally {
+			if (previous === undefined) delete process.env.BOBBIT_DEV_HARNESS;
+			else process.env.BOBBIT_DEV_HARNESS = previous;
+		}
+	});
+
+	test("under the harness, appends a sample and reads it back", async ({ gateway }) => {
+		const previous = process.env.BOBBIT_DEV_HARNESS;
+		const file = bootTimingPath(gateway.bobbitDir);
+		try {
+			rmSync(file, { force: true });
+			process.env.BOBBIT_DEV_HARNESS = "1";
+
+			const post = await rawApiFetch("/api/dev/boot-timing", { method: "POST", body: JSON.stringify(SAMPLE) });
+			expect(post.status).toBe(201);
+			expect(await post.json()).toMatchObject({ ok: true, path: expect.stringContaining("boot-timing.jsonl") });
+
+			// File on disk has exactly one JSONL row carrying the sample.
+			expect(existsSync(file)).toBe(true);
+			const lines = readFileSync(file, "utf-8").split("\n").filter((l) => l.trim());
+			expect(lines.length).toBe(1);
+			const stored = JSON.parse(lines[0]);
+			expect(stored).toMatchObject({ sessionId: "xyz", transcriptMessages: 17 });
+			expect(typeof stored.receivedAt).toBe("string");
+
+			// GET returns the parsed sample (newest last).
+			const get = await rawApiFetch("/api/dev/boot-timing?limit=10");
+			expect(get.status).toBe(200);
+			const body = await get.json();
+			expect(Array.isArray(body.samples)).toBe(true);
+			expect(body.samples.at(-1)).toMatchObject({ sessionId: "xyz" });
+		} finally {
+			if (previous === undefined) delete process.env.BOBBIT_DEV_HARNESS;
+			else process.env.BOBBIT_DEV_HARNESS = previous;
+		}
+	});
+
+	test("rejects a non-object sample with 422", async () => {
+		const previous = process.env.BOBBIT_DEV_HARNESS;
+		try {
+			process.env.BOBBIT_DEV_HARNESS = "1";
+			const post = await rawApiFetch("/api/dev/boot-timing", { method: "POST", body: JSON.stringify([1, 2, 3]) });
+			expect(post.status).toBe(422);
+			expect(await post.json()).toMatchObject({ error: expect.stringMatching(/rejected/i) });
+		} finally {
+			if (previous === undefined) delete process.env.BOBBIT_DEV_HARNESS;
+			else process.env.BOBBIT_DEV_HARNESS = previous;
+		}
+	});
+});

--- a/tests/e2e/ui/perf-instrumentation-toggle.spec.ts
+++ b/tests/e2e/ui/perf-instrumentation-toggle.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect, type Page } from "../gateway-harness.js";
+import { openApp, navigateToHash } from "./ui-helpers.js";
+
+// The Perf-instrumentation toggle lives next to Restart Server and is gated to
+// dev-harness mode, so opt the worker into harness mode like the restart spec.
+const devHarnessTest = test.extend<{}, { enableDevHarnessRestart: boolean }>({
+	enableDevHarnessRestart: [true, { scope: "worker", option: true }],
+});
+
+async function openSettings(page: Page): Promise<void> {
+	await openApp(page);
+	await navigateToHash(page, "#/settings/system/general");
+	await expect(page.locator("h1").filter({ hasText: "Settings" })).toBeVisible({ timeout: 10_000 });
+}
+
+const toggle = (page: Page) => page.getByTestId("perf-instrumentation-toggle");
+
+test.describe("Perf instrumentation toggle without dev harness", () => {
+	test("is hidden when the dev harness is not active", async ({ page }) => {
+		await openSettings(page);
+		await expect(toggle(page)).toHaveCount(0);
+	});
+});
+
+devHarnessTest.describe("Perf instrumentation toggle with dev harness", () => {
+	devHarnessTest("appears, toggles on, persists across reload, and arms reload instrumentation", async ({ page }) => {
+		// Spy on the sink POST without blocking it — passthrough to the real
+		// harness-gated endpoint so the file actually gets written.
+		let bootTimingPosts = 0;
+		await page.route("**/api/dev/boot-timing", async (route) => {
+			if (route.request().method() === "POST") bootTimingPosts += 1;
+			await route.continue();
+		});
+
+		await openSettings(page);
+
+		// Default off.
+		await expect(toggle(page)).toBeVisible({ timeout: 10_000 });
+		await expect(toggle(page)).toHaveAttribute("aria-checked", "false");
+		await expect(toggle(page)).toContainText("Perf Off");
+
+		// Turn on → button reflects state and the localStorage mirror is armed.
+		await toggle(page).click();
+		await expect(toggle(page)).toHaveAttribute("aria-checked", "true");
+		await expect(toggle(page)).toContainText("Perf On");
+		await expect
+			.poll(() => page.evaluate(() => localStorage.getItem("bobbit-perf-instrumentation")))
+			.toBe("1");
+
+		// Persists across reload (server preference + mirror) …
+		await page.reload();
+		await expect(page.locator("button").filter({ hasText: "Settings" }).first()).toBeVisible({ timeout: 15_000 });
+		await navigateToHash(page, "#/settings/system/general");
+		await expect(toggle(page)).toHaveAttribute("aria-checked", "true", { timeout: 10_000 });
+
+		// … and the armed reload actually recorded + reported a timing sample.
+		await expect
+			.poll(() => page.evaluate(() => (window as unknown as { __bobbitBootTimings?: { marks?: unknown[] } }).__bobbitBootTimings?.marks?.length ?? 0), { timeout: 10_000 })
+			.toBeGreaterThan(0);
+		await expect.poll(() => bootTimingPosts, { timeout: 10_000 }).toBeGreaterThan(0);
+
+		// Turn back off → mirror cleared so the next reload is not instrumented.
+		await toggle(page).click();
+		await expect(toggle(page)).toHaveAttribute("aria-checked", "false");
+		await expect
+			.poll(() => page.evaluate(() => localStorage.getItem("bobbit-perf-instrumentation")))
+			.toBeNull();
+	});
+});


### PR DESCRIPTION
## What

Adds an opt-in **Perf instrumentation** toggle in the Settings header, right next to **Restart Server**, gated to **dev-harness mode only** (same `BOBBIT_DEV_HARNESS` gate). When enabled, every full page reload records phase-by-phase timing and writes one JSONL sample to a known location agents can inspect: **`.bobbit/state/boot-timing.jsonl`**.

This replaces guesswork about reload cost (e.g. the "UI fully reloads every time an agent edits UI code under Vite" disruption) with hard, per-phase numbers.

## Why

A full reload re-does two expensive things — re-evaluating the unbundled Vite module graph (the module waterfall) and rehydrating session state (WS reconnect + `get_state` snapshot replay + full `MessageList` re-render). The snapshot replay scales with transcript length. This instrumentation measures each phase so we can decide whether sub-100ms reload, non-disruptive reload, or HMR is the right lever.

## How

- **Toggle**: `renderPerfInstrumentationToggle` in `settings-page.ts`, shown only when `/api/harness-status` reports the harness is active.
- **Persistence**: server preference `devPerfInstrumentation`, mirrored to the `bobbit-perf-instrumentation` localStorage key. The mirror is the synchronous source of truth that arms the *next* reload (it must be readable before the module graph finishes evaluating); the preference is the durable record.
- **Client** (`boot-timing.ts`): runtime-gated (no compile-time gate; cheap early-return when disarmed). Marks `modules-evaluated → initApp-start → first-render-call → first-paint → ws-open → snapshot-received(N) → snapshot-applied → post-snapshot-paint`. One idempotent terminal report per load: `console.table` + POST to the sink. `window.__bobbitBootTimings` always holds the latest sample.
- **Server**: `dev-boot-timing.ts` (capped append-only JSONL — trimmed to last 300 entries past 1 MB, rejects >64 KB / non-object samples) + harness-gated `POST`/`GET /api/dev/boot-timing` routes in `server.ts`.

## Inspecting

```bash
tail -f .bobbit/state/boot-timing.jsonl     # raw samples
# or: GET /api/dev/boot-timing?limit=N
# or, in devtools: copy(window.__bobbitBootTimings)
```

## Tests

- `tests/dev-boot-timing.test.ts` — sink: append/parse, dir creation, limit, non-object/oversized rejection, byte-cap trimming, malformed-line skipping.
- `tests/e2e/dev-boot-timing-api.spec.ts` — endpoint gating (403 off-harness), write + read-back under the harness, 422 on bad body.
- `tests/e2e/ui/perf-instrumentation-toggle.spec.ts` — toggle hidden without the harness; visible/toggles/persists across reload and arms reload instrumentation under the harness.

All green: `npm run check`, full `test:unit` (1281 + 8 sink), the new API E2E (3/3), and the UI toggle spec. Design notes: `docs/design/boot-timing-instrumentation.md`.

> Note: the harness-mode UI spec retried once on the pre-existing Windows/Node cold-import harness flake (`'does not provide an export named getAssistantDef'`, documented in `in-process-harness.ts`) — unrelated to this change; assertions pass.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
