### PR TITLE
Marketplace: source-level trust warning

### DIFF
--- a/docs/design/pack-based-marketplace.md
+++ b/docs/design/pack-based-marketplace.md
@@ -111,10 +111,11 @@ version: 1.2.0                   # REQUIRED. Semver string. Informational + show
 author: jane@example.com         # OPTIONAL.
 homepage: https://...            # OPTIONAL.
 # Declared contents — what the pack ships. REQUIRED. Drives the browse UI
-# (declared-entity chips) and the "installs executable code" warning
-# (tools[] non-empty). All three keys MUST be present; each is an array that
-# MAY be empty. The resolver loads whatever is physically present, but
+# (declared-entity chips). All three keys MUST be present; each is an array
+# that MAY be empty. The resolver loads whatever is physically present, but
 # `contents` is the authoritative advertised manifest the UI renders.
+# (No per-pack "executable code" gate keys off tools[]: trust is handled
+#  once at the source-add boundary — see §10.2.)
 contents:
   roles:  [researcher]
   tools:  [research]             # tool GROUP names (dir names under tools/)
@@ -599,7 +600,7 @@ New endpoints (added in `server.ts::handleApiRoute`). Responses reuse existing c
 | `POST /api/marketplace/sources` | Add a source `{ url, ref? }` → syncs + returns the created source. |
 | `DELETE /api/marketplace/sources/:id` | Remove a source (and its cache dir). |
 | `POST /api/marketplace/sources/:id/sync` | Re-sync (re-clone/fetch); returns updated `lastCommit`. |
-| `GET /api/marketplace/sources/:id/packs` | Browse: `{ packs: Array<PackManifest & { dirName, hasTools }> }`. `hasTools` drives the executable-code warning. |
+| `GET /api/marketplace/sources/:id/packs` | Browse: `{ packs: Array<PackManifest & { dirName, hasTools }> }`. `hasTools` is informational (declared-entity rendering); it no longer drives a per-pack install gate. |
 | `POST /api/marketplace/install` | Body `{ sourceId, packName, scope, projectId? }` → installs; returns `.pack-meta.yaml`. |
 | `POST /api/marketplace/update` | Body `{ scope, packName, projectId? }` → updates; returns new meta. |
 | `DELETE /api/marketplace/installed` | Body `{ scope, packName, projectId? }` → uninstall. |
@@ -650,7 +651,7 @@ interface ConflictWire {
 | `GET /api/marketplace/installed?projectId=` | — | `200 { installed: InstalledPackWire[] }` (all scopes; `corrupt` entries included) | `400` project scope requested without projectId |
 | `GET /api/packs/conflicts?projectId=` | — | `200 { conflicts: ConflictWire[] }` | `400` as above |
 
-- **Tool-bearing confirmation** is a UI-side gate (§10): the client only POSTs `install` after the user accepts the executable-code warning, which it derives from `hasTools`/`contents.tools` in the browse payload. The server does not require a confirmation flag, but install of a tool-bearing pack is otherwise unrestricted.
+- **No per-pack install gate.** Trust is handled once at the source-add boundary via a blanket warning + "Why?" disclosure (§10.2); the client POSTs `install` directly with no executable-code confirmation. The server never required a confirmation flag, and install of any pack is unrestricted. `hasTools` in the browse payload is now informational only.
 - **Reload/cache behavior:** install/update/uninstall invalidate the affected scope's resolver cache (and the `slash-skills.ts` TTL cache) synchronously before returning, so a subsequent `GET /api/roles|tools|skills` reflects the change immediately (no client reload required). `pack_order` mutations do the same.
 - **Idempotency / concurrency:** install is rejected (`409`) if `dest` exists; the atomic-rename (§8.1) makes concurrent installs of the same `(scope, packName)` safe — the loser sees `EEXIST`/`409`.
 
@@ -697,9 +698,8 @@ import { ShoppingBag /* or Store */ } from "lucide";
 
 Reuse config-page conventions (`config-scope.ts`: `renderConfigScopeRow`, `renderOriginBadge`, scope state):
 
-- **Sources panel:** list registered sources; "Add source" (URL + optional ref); per-source "Re-sync" and "Remove".
+- **Sources panel:** list registered sources; "Add source" (URL + optional ref); per-source "Re-sync" and "Remove". The Add-source controls carry a persistent **blanket trust warning** (only add sources you trust — installing any pack can run code or instruct agents on your machine) plus an expandable, keyboard-accessible **"Why?"** disclosure (collapsed by default) explaining the per-entity-type risk spectrum: **Tools** ship `extension.ts` / `_shared/` code that runs directly in the Bobbit server process on the host with no LLM/sandbox in the loop (highest risk); **Skills** are free-form instructions an agent follows literally (agent has shell access); **Roles** steer persona/behavior (more diffuse, but still drive an LLM with tool access). Trust is decided here, once, at the source boundary.
 - **Browse panel:** select a source → list its packs (name, version, description, declared entities as chips). Each pack has an **Install** button with a **scope picker** (System/server, Global-user, or a project — reuse `renderConfigScopeRow` semantics).
-- **Executable-code warning:** if a pack ships tools (`hasTools` / `contents.tools` non-empty), show an explicit confirm dialog **"This pack installs executable code that runs on your machine"** before install.
 - **Installed panel:** list installed packs grouped by scope with provenance (source URL, version, commit short SHA, install/updated dates from `.pack-meta.yaml`); per-pack **Update** and **Uninstall**.
 - **Conflict warnings:** packs participating in a same-name conflict show a warning icon (from `GET /api/packs/conflicts`); expand to see entity/type/winner/shadowed; the only resolution affordance is **reorder** (adjust `pack_order` via drag) — no per-conflict pin in MVP.
 - After install/uninstall/update, refresh the Roles/Tools/Skills page data so installed entities appear with the pack as `origin` and the existing badge styling.
@@ -780,7 +780,7 @@ Point at fixture pack trees under a tmp dir.
 5. **Persists across reload.**
 6. **Provenance** shown (source + version/commit + date).
 7. **Update** (re-sync after upstream change reflected) and **Uninstall** (entities disappear; exactly what install added is removed).
-8. **Executable-code warning** shown for a tool-bearing pack before install.
+8. **Source-level trust warning** is shown in the Add-source panel, with a "Why?" disclosure (collapsed by default) that expands to the per-entity-type threat model; no per-pack confirmation appears before install.
 9. **Conflict warning icon** appears when two installed packs define the same entity name; **drag-reorder** (which calls `PUT /api/marketplace/pack-order`) flips the winner and the warning/`origin` updates after re-resolve. Persists across reload.
 
 ### 12.4 Acceptance-criterion → test map
@@ -795,7 +795,7 @@ Point at fixture pack trees under a tmp dir.
 | Same-name conflicts → warning + configured precedence (`pack_order` reorder) | E2E #9 + unit #2,#4 (pack_order reordering) |
 | Entities tagged with the specific pack as origin | E2E #4 (originPackName) |
 | `disabled_config_directories` now enforced for skills | unit #6 |
-| Tool-bearing packs show executable-code warning | E2E #8 |
+| Source-level trust warning + "Why?" disclosure in Add-source panel | E2E #8 |
 | Re-sync + re-install reflects upstream | E2E #7 + unit #8 |
 
 ---

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -64,7 +64,15 @@ Select a source to list its packs. Each pack shows its name, version, descriptio
 
 Each pack has an **Install** button with a scope picker. Installing copies the pack's directory verbatim into the chosen scope's `market-packs/<pack-name>/` and writes a generated `.pack-meta.yaml` recording provenance. Every contained role/tool/skill then resolves through the single resolver, tagged with that pack as its `origin`.
 
-**Executable-code warning.** If a pack ships tools (`contents.tools` is non-empty), the UI shows an explicit confirmation — *"This pack installs executable code that runs on your machine"* — before install. Tool packs carry `extension.ts` / `_shared/` code that runs in Bobbit; this is the only trust gate in the MVP (there is no signing or sandboxing yet).
+**Trust lives at the source boundary, not per pack.** There is no per-pack confirmation dialog and no "executable code" chip. The trust decision is made once, when you **add a source**: the Add-source panel carries a persistent warning that you should only add sources you trust, because installing *any* pack from a source can run code or instruct agents on your machine. Install then proceeds without a further gate.
+
+Why a blanket warning rather than a tool-pack-only one? The old model implied a false binary — tool packs dangerous, role/skill packs safe. In reality every pack is risky once installed, because roles and skills become instructions to an LLM that has shell access. The Add-source panel includes an expandable **"Why?"** disclosure (collapsed by default) explaining the risk spectrum across the three entity types, highest to lowest:
+
+- **Tools** — ship `extension.ts` / `_shared/` code that runs **directly in the Bobbit server process on the host**, deterministically, with no LLM and no sandbox in the loop. This is the highest, most immediate risk.
+- **Skills** — free-form instructions an agent tends to follow literally. An agent with shell access can be directed to do damage.
+- **Roles** — persona/behavior steering; influential but more diffuse. Still drives an LLM with tool access.
+
+There is no signing or sandboxing yet, so the source-level trust decision is the only safeguard.
 
 ### Viewing provenance
 
@@ -155,9 +163,10 @@ version: 1.2.0                   # REQUIRED. Semver-ish string; shown in provena
 author: jane@example.com         # OPTIONAL.
 homepage: https://...            # OPTIONAL.
 contents:                        # REQUIRED. All three keys required; each MAY be empty.
-  roles:  [researcher]           #   Drives the browse-UI chips and the
-  tools:  [research]             #   executable-code warning (tools non-empty).
-  skills: [lit-review]           #   tools[] are tool GROUP dir names under tools/.
+  roles:  [researcher]           #   Drives the browse-UI declared-entity chips.
+  tools:  [research]             #   tools[] are tool GROUP dir names under tools/.
+  skills: [lit-review]           #   (No per-pack gate keys off tools[]; trust is
+                                 #    decided once when adding a source.)
 ```
 
 Validation rules: `name`, `description`, `version` must be non-empty; `name` must match the pattern (rejects path separators, `..`, leading dots); `contents` is required with all three array keys present (each may be empty). A `contents.mcp` key is **rejected** — MCP installs are out of scope in the MVP. Unknown top-level keys are ignored (forward-compat). A pack whose `pack.yaml` is missing or invalid is skipped with a warning, never fatal.
@@ -189,7 +198,7 @@ All marketplace routes live in `server.ts::handleApiRoute()`. Full request/respo
 | `POST /api/marketplace/sources` | Add a source `{ url, ref? }` (syncs immediately). |
 | `DELETE /api/marketplace/sources/:id` | Remove a source and its cache dir. |
 | `POST /api/marketplace/sources/:id/sync` | Re-sync (re-clone/fetch). |
-| `GET /api/marketplace/sources/:id/packs` | Browse a source's packs (`hasTools` drives the warning). |
+| `GET /api/marketplace/sources/:id/packs` | Browse a source's packs (`hasTools` reflects whether the pack ships tools; informational only — it no longer drives a per-pack gate). |
 | `POST /api/marketplace/install` | `{ sourceId, dirName, scope, projectId? }` — install a pack. |
 | `POST /api/marketplace/update` | `{ scope, packName, projectId? }` — re-pull + replace. |
 | `DELETE /api/marketplace/installed` | `{ scope, packName, projectId? }` — uninstall. |
@@ -253,7 +262,7 @@ See [docs/design/pack-based-marketplace.md](design/pack-based-marketplace.md) fo
 
 - **MCP and AGENTS are not installable.** `.mcp.json` and AGENTS/CLAUDE.md keep their own loaders and resolve as before; a pack may not ship `mcp/` or AGENTS content. MCP configs reference local binaries, absolute paths, and secrets that mostly won't run on the installer's machine; AGENTS.md describes one specific project. The resolver leaves an `mcp/` loader seam for when a parameterization/secrets model exists.
 - **Per-conflict pinning is deferred.** The only conflict-resolution mechanism is `pack_order` (plus user-pack customization). A future `pack_conflicts` schema is sketched in the design doc but not implemented, surfaced, or tested.
-- **No trust, signing, or sandboxing.** Installing a tool-bearing pack copies executable code as-is; the only safeguard is the "installs executable code" warning. A permission/trust gate would slot into the install pipeline later.
+- **No trust, signing, or sandboxing.** Installing any pack copies its contents as-is — tool packs copy executable code that runs in the Bobbit server process, and role/skill packs copy instructions for an LLM with shell access. The only safeguard is the blanket trust warning shown when adding a source (see the "Why?" disclosure for the per-entity-type threat model). A per-pack permission/signing gate would slot into the install pipeline later.
 - **Git sync is synchronous.** Add-source, re-sync, and install run git inline and block until done.
 - **No hosted registry yet.** Sources are git repos or local dirs; the `MarketplaceSource` abstraction is kept open to a future hosted/searchable registry backend.
 - **Portable workflows and staff templates are not packable.** Workflows stay project-scoped inline in `project.yaml`; staff templates are noted as a gap. UI panels/plugins are the intended future headline entity type — the pack/loader format is designed to accommodate a `panels/` type additively.

--- a/src/app/marketplace-page.ts
+++ b/src/app/marketplace-page.ts
@@ -263,18 +263,6 @@ async function handleInstall(pack: BrowsePackWire): Promise<void> {
 	// same project we installed into (finding #2).
 	if (scope === "project" && projectId) focusProjectId = projectId;
 
-	const shipsTools = pack.hasTools || (pack.contents?.tools?.length ?? 0) > 0;
-	if (shipsTools) {
-		const { confirmAction } = await import("./dialogs.js");
-		const ok = await confirmAction(
-			"Install executable code?",
-			`This pack installs executable code that runs on your machine. Only install "${pack.name}" from sources you trust.`,
-			"Install anyway",
-			true,
-		);
-		if (!ok) return;
-	}
-
 	const key = `install:${pack.dirName}`;
 	busy.add(key);
 	renderApp();
@@ -478,6 +466,20 @@ function renderSourcesPanel(): TemplateResult {
 
 			<div class="flex flex-col gap-2 mt-2 pt-3 border-t border-border">
 				<div class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Add source</div>
+				<div class="market-trust-warning" data-testid="market-trust-warning">
+					${icon(AlertTriangle, "xs")}
+					<div class="flex flex-col gap-1.5">
+						<span>Only add sources you trust. Installing any pack from a source can run code or instruct agents on your machine.</span>
+						<details class="market-trust-why" data-testid="market-trust-why">
+							<summary>Why?</summary>
+							<div class="market-trust-why-body">
+								<p data-kind="tool"><strong>Tools</strong> ship <code>extension.ts</code> / <code>_shared/</code> code that runs directly in the Bobbit server process on the host, deterministically, with no LLM and no sandbox in the loop. Highest, most immediate risk.</p>
+								<p data-kind="skill"><strong>Skills</strong> are free-form instructions an agent tends to follow literally; an agent with shell access can be directed to do damage.</p>
+								<p data-kind="role"><strong>Roles</strong> steer persona/behavior; influential but more diffuse. Still drives an LLM with tool access.</p>
+							</div>
+						</details>
+					</div>
+				</div>
 				<input
 					type="text"
 					data-testid="market-source-url"
@@ -586,7 +588,6 @@ function renderBrowsePanel(): TemplateResult {
 }
 
 function renderBrowsePackCard(pack: BrowsePackWire): TemplateResult {
-	const shipsTools = pack.hasTools || (pack.contents?.tools?.length ?? 0) > 0;
 	const installing = busy.has(`install:${pack.dirName}`);
 	return html`
 		<div class="market-pack-card" data-testid="market-browse-pack" data-pack-name=${pack.name}>
@@ -595,7 +596,6 @@ function renderBrowsePackCard(pack: BrowsePackWire): TemplateResult {
 					<div class="flex items-center gap-2 flex-wrap">
 						<span class="text-sm font-semibold">${pack.name}</span>
 						<span class="text-[11px] text-muted-foreground">v${pack.version}</span>
-						${shipsTools ? html`<span class="market-exec-warning" title="Installs executable code">${icon(AlertTriangle, "xs")} executable code</span>` : ""}
 					</div>
 					<div class="text-xs text-muted-foreground mt-0.5">${pack.description}</div>
 					<div class="mt-1.5">${entityChips(pack)}</div>

--- a/src/app/marketplace.css
+++ b/src/app/marketplace.css
@@ -175,7 +175,6 @@
 	color: var(--chart-3);
 }
 
-.market-exec-warning,
 .market-corrupt,
 .market-conflict-icon {
 	display: inline-flex;
@@ -186,11 +185,6 @@
 	font-weight: 500;
 	border-radius: 4px;
 	white-space: nowrap;
-}
-
-.market-exec-warning {
-	background: color-mix(in oklch, var(--warning, var(--chart-4)) 16%, transparent);
-	color: var(--warning, var(--chart-4));
 }
 
 .market-corrupt,
@@ -215,6 +209,83 @@
 
 .market-conflict-winner {
 	font-weight: 600;
+	color: var(--foreground);
+}
+
+/* Source-level trust warning (Add-source block) + collapsible "Why?" disclosure. */
+.market-trust-warning {
+	display: flex;
+	align-items: flex-start;
+	gap: 0.5rem;
+	font-size: 0.75rem;
+	line-height: 1.45;
+	padding: 0.5rem 0.625rem;
+	border-radius: 0.375rem;
+	border: 1px solid color-mix(in oklch, var(--warning, var(--chart-4)) 35%, transparent);
+	background: color-mix(in oklch, var(--warning, var(--chart-4)) 10%, transparent);
+	color: var(--foreground);
+}
+
+.market-trust-warning > :first-child {
+	color: var(--warning, var(--chart-4));
+	flex-shrink: 0;
+	margin-top: 0.0625rem;
+}
+
+.market-trust-why {
+	font-size: 0.6875rem;
+	color: var(--muted-foreground);
+}
+
+.market-trust-why > summary {
+	cursor: pointer;
+	font-weight: 500;
+	color: var(--muted-foreground);
+	user-select: none;
+	width: fit-content;
+}
+
+.market-trust-why > summary:hover,
+.market-trust-why > summary:focus-visible {
+	color: var(--foreground);
+}
+
+.market-trust-why-body {
+	display: flex;
+	flex-direction: column;
+	gap: 0.375rem;
+	margin-top: 0.375rem;
+}
+
+.market-trust-why-body p {
+	margin: 0;
+	padding-left: 0.5rem;
+	border-left: 2px solid var(--border);
+	color: var(--muted-foreground);
+}
+
+.market-trust-why-body p[data-kind="tool"] {
+	border-left-color: color-mix(in oklch, var(--chart-2) 60%, transparent);
+}
+
+.market-trust-why-body p[data-kind="skill"] {
+	border-left-color: color-mix(in oklch, var(--chart-3) 60%, transparent);
+}
+
+.market-trust-why-body p[data-kind="role"] {
+	border-left-color: color-mix(in oklch, var(--chart-1) 60%, transparent);
+}
+
+.market-trust-why-body strong {
+	color: var(--foreground);
+	font-weight: 600;
+}
+
+.market-trust-why-body code {
+	font-size: 0.625rem;
+	padding: 0 0.1875rem;
+	border-radius: 0.1875rem;
+	background: var(--muted);
 	color: var(--foreground);
 }
 

--- a/tests/e2e/ui/marketplace.spec.ts
+++ b/tests/e2e/ui/marketplace.spec.ts
@@ -242,12 +242,6 @@ async function selectConfigProjectScope(page: Page, container: string, projectNa
 	await tab.click();
 }
 
-/** Confirm the "installs executable code" dialog. */
-async function confirmExecWarning(page: Page): Promise<void> {
-	await expect(page.getByText(/installs executable code that runs on your machine/i)).toBeVisible({ timeout: 10_000 });
-	await page.getByRole("button", { name: "Install anyway" }).click();
-}
-
 /** Ordinal of the named config-nav button within the expanded sidebar's nav row. */
 async function navButtonOrder(page: Page): Promise<string[]> {
 	return page.evaluate(() => {
@@ -359,9 +353,8 @@ test.describe("Marketplace UI", () => {
 		await registerSource(page, repo);
 		await selectInstallScopeProject(page, proj.id);
 
-		// The pack ships a tool → executable-code warning dialog appears; confirm.
+		// Install proceeds directly — no per-pack confirm gate.
 		await page.locator('[data-testid="market-browse-pack"][data-pack-name="kit-pack"]').locator('[data-testid="market-install-pack"]').click();
-		await confirmExecWarning(page);
 
 		// Installed card + provenance (the active project is the dedicated one).
 		await goToTab(page, "installed");
@@ -557,23 +550,39 @@ test.describe("Marketplace UI", () => {
 		await expect(page.locator(".role-row").filter({ hasText: "upd-role" })).toHaveCount(0, { timeout: 15_000 });
 	});
 
-	// §12.3 #8 — tool-bearing packs show the executable-code warning before
-	// install. Cancels — nothing is installed — so no scope is needed.
-	test("tool-bearing pack shows executable-code warning before install", async ({ page }) => {
-		const repo = makeRepo();
-		writePack(repo, { name: "warn-pack", tools: [{ group: "warngroup", name: "warn-tool" }] });
-
+	// Source-level trust warning lives in the Add-source panel: it is always
+	// visible, the "Why?" disclosure is collapsed by default, expands on click to
+	// reveal the per-entity-type risk explanations, and survives a reload. There
+	// is no longer a per-pack executable-code gate — install proceeds directly.
+	test("source panel shows blanket trust warning with collapsible Why disclosure", async ({ page }) => {
 		await openMarket(page);
-		await registerSource(page, repo);
 
-		const card = page.locator('[data-testid="market-browse-pack"][data-pack-name="warn-pack"]');
-		await expect(card.locator(".market-exec-warning")).toBeVisible({ timeout: 15_000 });
+		const warning = page.locator('[data-testid="market-trust-warning"]');
+		await expect(warning).toBeVisible({ timeout: 15_000 });
+		await expect(warning).toContainText(/only add sources you trust/i);
 
-		await card.locator('[data-testid="market-install-pack"]').click();
-		await expect(page.getByText(/installs executable code that runs on your machine/i)).toBeVisible({ timeout: 10_000 });
-		// Cancel — nothing installed.
-		await page.getByRole("button", { name: "Cancel" }).click();
-		await expect(page.locator('[data-testid="market-installed-pack"][data-pack-name="warn-pack"]')).toHaveCount(0);
+		// "Why?" disclosure is collapsed by default — body not visible.
+		const why = page.locator('[data-testid="market-trust-why"]');
+		await expect(why).toBeVisible();
+		await expect(why).not.toHaveAttribute("open", /.*/);
+		const body = why.locator(".market-trust-why-body");
+		await expect(body).toBeHidden();
+
+		// Expand → per-entity explanations become visible.
+		await why.locator("summary").click();
+		await expect(why).toHaveAttribute("open", /.*/);
+		await expect(body).toBeVisible();
+		await expect(body).toContainText(/Tools/);
+		await expect(body).toContainText(/Skills/);
+		await expect(body).toContainText(/Roles/);
+		await expect(body).toContainText(/runs directly in the Bobbit server process/i);
+
+		// Warning persists across reload.
+		await page.reload();
+		await expect(page.locator("button").filter({ hasText: "Settings" }).first()).toBeVisible({ timeout: 20_000 });
+		await navigateToHash(page, "#/market");
+		await goToTab(page, "sources");
+		await expect(page.locator('[data-testid="market-trust-warning"]')).toBeVisible({ timeout: 15_000 });
 	});
 
 	// §12.3 #9 — same-name conflict warning + reorder flips the winner.


### PR DESCRIPTION
## Summary
Replaces the per-pack "executable code" warnings in the marketplace with a single blanket trust warning shown when **adding a source**, plus an expandable "Why?" disclosure explaining the per-entity-type risk spectrum. The old model implied a false binary (tool packs = dangerous, role/skill packs = safe); in reality every pack is risky once installed because roles/skills become instructions to an LLM with shell access. The warning now lives at the source-trust boundary.

## Changes
- **src/app/marketplace-page.ts**: blanket trust warning + collapsed native `<details>` "Why?" disclosure (tools > skills > roles threat model) in the Add-source panel; removed the install-time `confirmAction` gate and the per-pack `market-exec-warning` chip.
- **src/app/marketplace.css**: dropped `.market-exec-warning`; added theme-token-only styling for the new warning + disclosure.
- **tests/e2e/ui/marketplace.spec.ts**: removed the two exec-code-confirm assertions/helper; added E2E for warning visibility, collapsed-by-default "Why?", expand-on-click, and persistence across reload.
- **docs/marketplace.md**, **docs/design/pack-based-marketplace.md**: updated to describe the source-level trust model.

## Testing
- `npm run check`, `npm run test:unit` pass.
- Marketplace browser E2E: 9 passed.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)