### PR TITLE
Block pushes to merged PRs

### DIFF
--- a/defaults/roles/team-lead.yaml
+++ b/defaults/roles/team-lead.yaml
@@ -335,6 +335,7 @@ promptTemplate: |
      ```
      If there are conflicts, resolve them (or spawn a coder to resolve them), then run the project's type-check and unit tests to confirm the merge is clean.
   2. **Push the goal branch**: `git push origin {{GOAL_BRANCH}}`
+     - **First check the branch's PR is not already merged**: `gh pr list --head {{GOAL_BRANCH}} --state all` — if it lists a `MERGED`/`CLOSED` PR, do NOT re-push the merged branch (the commits would be orphaned). Instead detect the primary branch (`git symbolic-ref refs/remotes/origin/HEAD`; never assume master/main), create a fresh branch off `origin/<primary>`, move the new work onto it, push that, and open a **new** PR.
   3. **Create a pull request** — this is **mandatory**, not optional:
      - Check for `gh` CLI: `which gh`
      - If `gh` is available: `gh pr create --title "<goal title>" --body "<work summary>" --head {{GOAL_BRANCH}}`

--- a/defaults/system-prompt.md
+++ b/defaults/system-prompt.md
@@ -121,7 +121,15 @@ Never override the repo's `user.name` or `user.email`. Commits must be authored 
 
 ## Pull requests
 
-**Never push to a merged PR.** Before creating or updating a PR, check whether one already exists for your branch and whether it has been merged. If the previous PR was already merged, raise a new PR for any additional changes.
+**Never push to a merged PR.** Before pushing commits or opening/updating a PR, check whether your branch's PR has already been merged:
+
+1. **Detect (primary — `gh`):** `gh pr list --head <branch> --state all` — if it lists a `MERGED` (or `CLOSED`) PR, the branch is done. This catches squash/rebase merges where the branch is not a literal ancestor of the primary branch. Bobbit is GitHub-centric, so `gh` is normally present.
+2. **Fallback (only if `gh` is unavailable):** determine the primary branch (`git symbolic-ref refs/remotes/origin/HEAD`), then `git fetch origin <primary> && git merge-base --is-ancestor <branch> origin/<primary>` — exit 0 means the branch is already merged. (This misses squash/rebase-merges, hence it is only the fallback.)
+
+If the branch is merged, do NOT push more commits to it — they become orphaned commits that never reach the primary branch. Instead:
+
+- Create a fresh branch off `origin/<primary>` (detect the primary name as above — never assume `master`/`main`).
+- Move the new work onto that fresh branch, push it, and open a **new** PR.
 
 **PR description footer**: Every PR description you generate must end with the following line (after a blank line):
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -33,6 +33,17 @@ Scannable checklists for common issues. Each entry: symptom → where to look �
 - **Where to look**: custom workflow command steps in `project.yaml::workflows.*.gates.*.verify[].run`; runtime guard in `verification-harness.ts::validateVerificationPushSafety`; authoring guidance in [goals-workflows-tasks.md](goals-workflows-tasks.md#gate-verification-baselines).
 - **Pinning tests**: `tests/verification-push-guard.test.ts` and `tests/goal-push-safety-regression.test.ts`.
 
+## Agent pushed commits to a branch whose PR was already merged
+
+- **Symptom**: an agent (regular session or team-lead) keeps pushing new commits to a branch whose PR is already closed/merged. The commits never appear on the primary branch — they are **orphaned**, because a merged PR is closed and re-pushing its head ref does nothing useful.
+- **Why it bites**: squash- and rebase-merges are the common case here, and a plain ancestor check (`git merge-base --is-ancestor`) does **not** catch them — the squashed commit on the primary branch has a different SHA, so the original branch is never a literal ancestor. You must ask GitHub about the PR's state, not just inspect local history.
+- **Detection (run before pushing or opening/updating a PR)**:
+  - **Primary — `gh`**: `gh pr list --head <branch> --state all` — a `MERGED` (or `CLOSED`) entry means the branch is done. Catches squash/rebase merges. Bobbit is GitHub-centric, so `gh` is normally present.
+  - **Fallback (only if `gh` is unavailable)**: detect the primary branch (`git symbolic-ref refs/remotes/origin/HEAD` — never assume `master`/`main`), then `git fetch origin <primary> && git merge-base --is-ancestor <branch> origin/<primary>` (exit 0 ⇒ already merged). Misses squash/rebase-merges, hence fallback only.
+- **Recovery**: do NOT push more commits to the merged branch. Create a fresh branch off `origin/<primary>`, move the new work onto it, push that, and open a **new** PR.
+- **Where the guidance lives** (keep these consistent if you touch one): the `## Pull requests` procedure in `defaults/system-prompt.md` (every session); the Ready-to-Merge step in `defaults/roles/team-lead.yaml` (goal-branch push); the re-attempt context in `src/server/agent/goal-assistant.ts` (new work goes on the fresh branch the re-attempt goal creates, never the old merged branch).
+- **Pinning test**: `tests/system-prompt-merged-branch.test.ts` asserts the system-prompt `## Pull requests` section keeps the concrete detection commands and fresh-branch recovery wording, so it can't rot back into a vague one-liner.
+
 ## Streaming performance (UI sluggishness)
 
 - **Architecture**: `StreamingMessageContainer` owns rendering during streaming via `setMessage()` with `requestAnimationFrame` batching. `AgentInterface` must NOT call `this.requestUpdate()` in the `message_update` event handler — only the streaming container updates on each token.

--- a/src/server/agent/goal-assistant.ts
+++ b/src/server/agent/goal-assistant.ts
@@ -35,6 +35,7 @@ export function buildReattemptContext(goal: PersistedGoal, prStatusStore: PrStat
 	lines.push("   - **Revert & start fresh**: revert the merged commit(s) from master");
 	lines.push("   - **Fix up**: keep the merged work and build on top");
 	lines.push("   - **Revert & fix up**: revert from master but use old code as starting point");
+	lines.push("   (New work goes on the fresh branch the new goal creates off the primary branch — never push onto the old, already-merged branch.)");
 	lines.push("4. Compose a new goal spec that includes the original spec, what went wrong, the chosen approach, and pointers to the old branch/PR");
 	lines.push(`5. Call \`propose_goal\` with a title like "Re-attempt: ${goal.title}"`);
 	return lines.join("\n");

--- a/tests/system-prompt-merged-branch.test.ts
+++ b/tests/system-prompt-merged-branch.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Pinning test for the "Never push to a merged PR" procedure in
+ * defaults/system-prompt.md.
+ *
+ * The system prompt is loaded into every agent turn. This procedure replaced a
+ * vague one-liner with a concrete, mechanical detection + fresh-branch recovery
+ * sequence. Agents kept skipping the old wording; if the concrete commands or
+ * key phrases regress, this test fails loudly so the guidance can't silently
+ * rot back into hand-waving.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const SYSTEM_PROMPT = path.resolve(import.meta.dirname, "..", "defaults", "system-prompt.md");
+
+describe("system-prompt merged-branch procedure", () => {
+	const text = readFileSync(SYSTEM_PROMPT, "utf8");
+
+	// Isolate the Pull requests section so we assert tokens appear in the
+	// relevant area, not somewhere incidental elsewhere in the prompt.
+	const prSectionMatch = text.match(/## Pull requests[\s\S]*?(?=\n## |\n# |$)/);
+	assert.ok(prSectionMatch, "system-prompt.md must contain a `## Pull requests` section");
+	const prSection = prSectionMatch![0];
+
+	const requiredTokens: Array<[string, string]> = [
+		["gh pr list --head", "primary `gh` detector command must be present"],
+		["merge-base --is-ancestor", "git fallback detector command must be present"],
+		["MERGED", "must mention the MERGED PR state agents look for"],
+		["CLOSED", "must mention the CLOSED PR state agents look for"],
+		["fresh branch off", "must describe the fresh-branch recovery path"],
+	];
+
+	for (const [token, why] of requiredTokens) {
+		it(`Pull requests section contains "${token}"`, () => {
+			assert.ok(
+				prSection.includes(token),
+				`Missing "${token}" in the ## Pull requests section — ${why}. ` +
+					`The merged-PR procedure must stay concrete and mechanical.`,
+			);
+		});
+	}
+
+	it("still keeps the 'Never push to a merged PR' header", () => {
+		assert.ok(
+			prSection.includes("**Never push to a merged PR.**"),
+			"The merged-PR guidance header must remain in the Pull requests section.",
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Replaces the vague "Never push to a merged PR" one-liner in the shared system prompt with a concrete, mechanical procedure so all sessions detect merged branches and recover correctly.

## Changes

- **`defaults/system-prompt.md`** (`## Pull requests`): concrete pre-push/pre-PR procedure — primary detector `gh pr list --head <branch> --state all` (catches squash/rebase merges via MERGED/CLOSED), fallback `git symbolic-ref` + `git merge-base --is-ancestor` against `origin/<primary>`, and recovery by creating a fresh branch off `origin/<primary>` and opening a new PR. PR footer + co-author rules untouched.
- **`defaults/roles/team-lead.yaml`** (ready-to-merge): aligned so the lead moves to a fresh branch off `origin/<primary>` if the goal branch's PR is already merged, rather than re-pushing.
- **`src/server/agent/goal-assistant.ts`** (`buildReattemptContext`): clarifying line — new work goes on a fresh branch off primary, never the old merged branch.
- **`tests/system-prompt-merged-branch.test.ts`**: pinning test asserting the detection + recovery tokens (`gh pr list --head`, `merge-base --is-ancestor`, `MERGED`, `CLOSED`, `fresh branch off`) are present.
- **`docs/debugging.md`**: symptom→fix entry for pushes to merged PRs / orphaned commits.

## Verification

- `npm run check` clean.
- `npm run test:unit` passes including the new pinning test.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)