### PR TITLE
perf: attribute get_messages snapshot cost (rpc/pipeline/serialize)

### DIFF
--- a/docs/design/boot-timing-instrumentation.md
+++ b/docs/design/boot-timing-instrumentation.md
@@ -39,6 +39,11 @@ across a reload and writes them somewhere agents can inspect.
   `snapshot-applied`, `post-snapshot-paint` (`remote-agent.ts`). The raw
   snapshot frame size is captured as `snapshotChars` to distinguish payload
   transfer cost from server-side assembly.
+- **Server-side snapshot breakdown** (dev harness only): the `get_messages`
+  handler attaches a `SnapshotServerTiming` (`rpcMs` agent assembly /
+  `pipelineMs` server transform / `stampMs` / `stringifyMs` / `bytes` /
+  `msgCount`) to the `messages` frame, captured into the sample's `serverTiming`
+  field — so the ws-open→snapshot gap is fully attributed end to end.
 - One terminal report per load (idempotent): logs a `console.table` and POSTs
   the sample to the sink. Triggered immediately after the session snapshot
   paints, with a 3s idle-debounce fallback for no-session views.

--- a/src/app/boot-timing.ts
+++ b/src/app/boot-timing.ts
@@ -29,6 +29,8 @@ interface BootMeta {
 	transcriptMessages?: number;
 	/** Size (chars ≈ bytes for ASCII JSON) of the raw get_state snapshot frame. */
 	snapshotChars?: number;
+	/** Per-phase server-side snapshot build timing (dev harness only). */
+	serverTiming?: Record<string, number>;
 }
 
 const marks: Mark[] = [];
@@ -93,6 +95,7 @@ function buildSample(reason: string): Record<string, unknown> {
 		sessionId: meta.sessionId,
 		transcriptMessages: meta.transcriptMessages,
 		snapshotChars: meta.snapshotChars,
+		serverTiming: meta.serverTiming,
 		buildId: (globalThis as { __BOBBIT_BUILD_ID__?: string }).__BOBBIT_BUILD_ID__,
 		userAgent: typeof navigator !== "undefined" ? navigator.userAgent : undefined,
 		viewport: typeof window !== "undefined" ? { w: window.innerWidth, h: window.innerHeight } : undefined,

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -681,7 +681,7 @@ export class RemoteAgent {
 				// whether the get_state cost is payload transfer vs. server-side
 				// assembly. Cheap: a type check + a (no-copy) string length read.
 				if (msg.type === "messages" && typeof evt.data === "string") {
-					bootTimingMeta({ snapshotChars: evt.data.length });
+					bootTimingMeta({ snapshotChars: evt.data.length, serverTiming: msg.serverTiming });
 				}
 
 				if (!settled) {

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -810,12 +810,19 @@ export function handleWebSocketConnection(
 				}
 				case "get_messages": {
 					sendSessionCostUpdate(ws, sessionManager, sessionId);
+					// Perf attribution (dev harness only): split the snapshot build
+					// into agent RPC assembly vs. server transform vs. serialize, and
+					// attach it to the frame so the client's boot-timing sample
+					// captures it. See SnapshotServerTiming. Zero cost when off.
+					const perf = process.env.BOBBIT_DEV_HARNESS === "1";
+					const tStart = perf ? performance.now() : 0;
 					const diagEnabled = cpuDiagnosticsEnabled();
 					const diagStart = diagEnabled ? performance.now() : 0;
 					const msgsResp = await session.rpcClient.getMessages();
 					if (diagEnabled) {
 						getCpuDiagnostics().recordTimer("ws-handler:getMessages", performance.now() - diagStart, { success: msgsResp.success ? 1 : 0 });
 					}
+					const tRpc = perf ? performance.now() : 0;
 					if (msgsResp.success) {
 						const raw = msgsResp.data as any;
 						// msgsResp.data may be an array or { messages: [...] }
@@ -838,7 +845,32 @@ export function handleWebSocketConnection(
 							const merged = mergeSkillSidecarIntoMessages(sessionId, truncated);
 							data = merged === raw.messages ? raw : { ...raw, messages: merged };
 						}
-						send(ws, { type: "messages", data: stampSnapshotOrder(data) as unknown[] });
+						const tPipeline = perf ? performance.now() : 0;
+						const stamped = stampSnapshotOrder(data);
+						const tStamp = perf ? performance.now() : 0;
+						if (perf) {
+							const arr = Array.isArray(stamped)
+								? stamped
+								: (stamped && Array.isArray((stamped as any).messages) ? (stamped as any).messages : []);
+							const sStart = performance.now();
+							const bytes = JSON.stringify(stamped).length;
+							const stringifyMs = performance.now() - sStart;
+							const r1 = (n: number) => Math.round(n * 10) / 10;
+							send(ws, {
+								type: "messages",
+								data: stamped as unknown[],
+								serverTiming: {
+									rpcMs: r1(tRpc - tStart),
+									pipelineMs: r1(tPipeline - tRpc),
+									stampMs: r1(tStamp - tPipeline),
+									stringifyMs: r1(stringifyMs),
+									bytes,
+									msgCount: arr.length,
+								},
+							});
+						} else {
+							send(ws, { type: "messages", data: stamped as unknown[] });
+						}
 					}
 					break;
 				}

--- a/src/server/ws/protocol.ts
+++ b/src/server/ws/protocol.ts
@@ -72,12 +72,28 @@ export type ClientMessage =
 	| { type: "resume"; fromSeq: number }
 	| { type: "status_resync" };
 
+/**
+ * Optional per-phase timing for a `get_messages` snapshot, attached only under
+ * the dev harness (`BOBBIT_DEV_HARNESS=1`). Lets the client's boot-timing
+ * sample attribute the reload's snapshot cost to agent-side assembly (`rpcMs`)
+ * vs. server-side transform (`pipelineMs`/`stampMs`) vs. serialize
+ * (`stringifyMs`). `bytes` is the serialized snapshot size.
+ */
+export interface SnapshotServerTiming {
+	rpcMs: number;
+	pipelineMs: number;
+	stampMs: number;
+	stringifyMs: number;
+	bytes: number;
+	msgCount: number;
+}
+
 /** Server → Client messages over WebSocket */
 export type ServerMessage =
 	| { type: "auth_ok" }
 	| { type: "auth_failed" }
 	| { type: "state"; data: unknown }
-	| { type: "messages"; data: unknown[] }
+	| { type: "messages"; data: unknown[]; serverTiming?: SnapshotServerTiming }
 	| { type: "event"; data: unknown; seq?: number; ts?: number }
 	| { type: "resume_gap"; lastSeq: number }
 	| { type: "client_joined"; clientId: string }


### PR DESCRIPTION
## What

Splits the server-side `get_messages` snapshot build into per-phase timings, attached to the `messages` WS frame as `SnapshotServerTiming` and captured into the client's boot-timing sample (`serverTiming`). Dev-harness only (`BOBBIT_DEV_HARNESS=1`); zero cost otherwise.

## Why

Boot-timing samples showed a long-transcript reload (627 msgs, 2.09 MB snapshot) is dominated by a single ~1.2 s phase: `auth-ok → snapshot-received`. The auth handshake is 1.4 ms and 2 MB transfers over localhost in ~100 ms, so the cost is clearly server-side snapshot *production* — but we couldn't yet split **agent-side assembly** vs. **server transform** vs. **serialize**. This adds that attribution end to end.

## Phases captured (`serverTiming`)

| Field | Measures |
|---|---|
| `rpcMs` | `session.rpcClient.getMessages()` — RPC round-trip + agent subprocess assembling the transcript |
| `pipelineMs` | server transform: in-flight splice, compaction + skill sidecar merge, large-tool-content truncation |
| `stampMs` | `stampSnapshotOrder` |
| `stringifyMs` | `JSON.stringify` of the snapshot |
| `bytes` / `msgCount` | serialized size + message count |

Read it from the boot sample: `window.__bobbitBootTimings.serverTiming`, or the persisted line in `.bobbit/state/boot-timing.jsonl`.

## Notes

- Backward-compatible: `serverTiming` is an optional field on the `messages` frame, only attached under the harness.
- Builds on the boot-timing instrumentation from #705 (+ the `auth-ok`/`snapshotChars` follow-up already on `master`).

## Tests

`npm run check`, full `test:unit` (1297), and targeted E2E over the `get_messages` snapshot path (`user-message-echo`, `new-tab-no-duplicate-messages`, `transcript-api`, `dev-boot-timing-api`) — all green. (`transcript-api` retried on the known Windows cold-import harness flake, unrelated to this change.)

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
