### PR TITLE
Fix 'Failed to execute setItem' error surfacing in sidebar on boot

### DIFF
--- a/src/app/safe-storage.ts
+++ b/src/app/safe-storage.ts
@@ -1,0 +1,76 @@
+/**
+ * Defensive localStorage wrappers.
+ *
+ * `localStorage.setItem` / `getItem` can THROW, not just no-op:
+ *   - Quota exceeded (`QuotaExceededError`) once the origin's storage is full.
+ *   - Storage disabled / partitioned (Safari private mode historically threw on
+ *     every write; some embedded webviews and locked-down enterprise profiles
+ *     deny access entirely so even reads throw `SecurityError`).
+ *   - SSR / non-window contexts where `localStorage` is undefined.
+ *
+ * Persisted UI state (sidebar expand/collapse sets, widths, etc.) is a
+ * convenience, never load-bearing. A storage failure must never abort a code
+ * path — most dangerously the boot-critical `refreshSessions()` path, where a
+ * thrown `setItem` used to bubble into `state.sessionsError` and render the raw
+ * "Failed to execute 'setItem' on 'Storage'" string in the sidebar right before
+ * the UI loaded.
+ *
+ * These helpers swallow all storage exceptions so callers can treat
+ * persistence as best-effort. This is the single source of truth — prefer it
+ * over scattered inline `try { localStorage… } catch {}` blocks.
+ */
+
+function hasLocalStorage(): boolean {
+	try {
+		return typeof localStorage !== "undefined";
+	} catch {
+		// Accessing `localStorage` itself can throw (SecurityError) in some
+		// locked-down contexts.
+		return false;
+	}
+}
+
+/** Best-effort `localStorage.setItem`. Never throws. */
+export function safeSetItem(key: string, value: string): void {
+	if (!hasLocalStorage()) return;
+	try {
+		localStorage.setItem(key, value);
+	} catch {
+		/* quota exceeded / storage disabled / SSR — persistence is best-effort */
+	}
+}
+
+/** Best-effort `localStorage.removeItem`. Never throws. */
+export function safeRemoveItem(key: string): void {
+	if (!hasLocalStorage()) return;
+	try {
+		localStorage.removeItem(key);
+	} catch {
+		/* storage disabled / SSR */
+	}
+}
+
+/** Best-effort `localStorage.getItem`. Returns `null` on any failure. */
+export function safeGetItem(key: string): string | null {
+	if (!hasLocalStorage()) return null;
+	try {
+		return localStorage.getItem(key);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Read and JSON.parse a localStorage value, returning `fallback` if the key is
+ * absent, storage is unavailable, or the stored value is corrupted (so a single
+ * bad write can never break module load via an uncaught `SyntaxError`).
+ */
+export function safeGetJSON<T>(key: string, fallback: T): T {
+	const raw = safeGetItem(key);
+	if (raw === null) return fallback;
+	try {
+		return JSON.parse(raw) as T;
+	} catch {
+		return fallback;
+	}
+}

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -40,6 +40,7 @@ import { shortcutHint } from "./shortcut-registry.js";
 import type { GatewaySession } from "./state.js";
 import { resetArchivedExpandState } from "./state.js";
 import { isRouteActive, setHashRoute, toggleConfigPage } from "./routing.js";
+import { safeSetItem, safeGetJSON } from "./safe-storage.js";
 import { getActiveNavId } from "./sidebar-nav.js";
 
 // ============================================================================
@@ -48,7 +49,7 @@ import { getActiveNavId } from "./sidebar-nav.js";
 
 const EXPANDED_PROJECTS_KEY = "bobbit-expanded-projects";
 const _expandedProjects: Set<string> = new Set(
-	JSON.parse(localStorage.getItem(EXPANDED_PROJECTS_KEY) || "[]"),
+	safeGetJSON<string[]>(EXPANDED_PROJECTS_KEY, []),
 );
 
 export function isProjectExpanded(projectId: string): boolean {
@@ -60,7 +61,7 @@ export function toggleProjectExpanded(projectId: string): void {
 	const key = `collapsed:${projectId}`;
 	if (_expandedProjects.has(key)) _expandedProjects.delete(key);
 	else _expandedProjects.add(key);
-	localStorage.setItem(EXPANDED_PROJECTS_KEY, JSON.stringify([..._expandedProjects]));
+	safeSetItem(EXPANDED_PROJECTS_KEY, JSON.stringify([..._expandedProjects]));
 }
 
 // ============================================================================
@@ -828,7 +829,7 @@ function onSidebarResizeDoubleClick(e: MouseEvent): void {
 
 export function toggleSidebar(): void {
 	state.sidebarCollapsed = !state.sidebarCollapsed;
-	localStorage.setItem("bobbit-sidebar-collapsed", String(state.sidebarCollapsed));
+	safeSetItem("bobbit-sidebar-collapsed", String(state.sidebarCollapsed));
 	renderApp();
 }
 

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -3,6 +3,7 @@ import type { RemoteAgent, ConnectionStatus } from "./remote-agent.js";
 import type { InboxEntry } from "../server/agent/inbox-store.js";
 import type { PanelWorkspaceTab } from "./panel-workspace.js";
 import { isConfigPageRoute } from "./routing.js";
+import { safeSetItem, safeGetItem, safeGetJSON } from "./safe-storage.js";
 
 // ============================================================================
 // TYPES
@@ -201,8 +202,7 @@ export function clampSidebarWidth(w: number): number {
 }
 
 function loadSidebarWidth(): number {
-	if (typeof localStorage === "undefined") return SIDEBAR_WIDTH_DEFAULT;
-	const raw = localStorage.getItem(SIDEBAR_WIDTH_KEY);
+	const raw = safeGetItem(SIDEBAR_WIDTH_KEY);
 	if (!raw) return SIDEBAR_WIDTH_DEFAULT;
 	const n = Number.parseInt(raw, 10);
 	return clampSidebarWidth(n);
@@ -320,16 +320,16 @@ export const state = {
 	defaultCwd: "",
 
 	/** Whether the sidebar is collapsed */
-	sidebarCollapsed: localStorage.getItem("bobbit-sidebar-collapsed") === "true",
+	sidebarCollapsed: safeGetItem("bobbit-sidebar-collapsed") === "true",
 	/** User-resizable sidebar width in px (expanded state). Clamped 180–480. */
 	sidebarWidth: loadSidebarWidth(),
 
 	/** Whether to show archived sessions in the sidebar */
-	showArchived: localStorage.getItem("bobbit-show-archived") === "true",
+	showArchived: safeGetItem("bobbit-show-archived") === "true",
 	/** Whether to show busy (streaming/aborting/preparing/starting/compacting) sessions. Default ON. */
-	showBusy: localStorage.getItem("bobbit-show-busy") !== "false",
+	showBusy: safeGetItem("bobbit-show-busy") !== "false",
 	/** Whether to show idle/done sessions without unread activity. Default ON. */
-	showRead: localStorage.getItem("bobbit-show-read") !== "false",
+	showRead: safeGetItem("bobbit-show-read") !== "false",
 	/** Whether the sidebar filters popover is open */
 	filtersPopoverOpen: false,
 	/** Whether the archived section is expanded */
@@ -507,7 +507,7 @@ try {
 const EXPANDED_GOALS_KEY = "bobbit-expanded-goals";
 
 export let expandedGoals: Set<string> = new Set(
-	JSON.parse(localStorage.getItem(EXPANDED_GOALS_KEY) || "[]"),
+	safeGetJSON<string[]>(EXPANDED_GOALS_KEY, []),
 );
 
 // ── Per-project collapse state (Bug 4 fix) ─────────────────────────
@@ -516,10 +516,10 @@ const COLLAPSED_UNGROUPED_KEY = "bobbit-collapsed-ungrouped";
 const COLLAPSED_STAFF_KEY = "bobbit-collapsed-staff";
 
 export let collapsedUngroupedProjects: Set<string> = new Set(
-	JSON.parse(localStorage.getItem(COLLAPSED_UNGROUPED_KEY) || "[]"),
+	safeGetJSON<string[]>(COLLAPSED_UNGROUPED_KEY, []),
 );
 export let collapsedStaffProjects: Set<string> = new Set(
-	JSON.parse(localStorage.getItem(COLLAPSED_STAFF_KEY) || "[]"),
+	safeGetJSON<string[]>(COLLAPSED_STAFF_KEY, []),
 );
 
 export function isUngroupedExpanded(projectId: string): boolean {
@@ -529,7 +529,7 @@ export function isUngroupedExpanded(projectId: string): boolean {
 export function setUngroupedExpanded(projectId: string, value: boolean): void {
 	if (value) collapsedUngroupedProjects.delete(projectId);
 	else collapsedUngroupedProjects.add(projectId);
-	localStorage.setItem(COLLAPSED_UNGROUPED_KEY, JSON.stringify([...collapsedUngroupedProjects]));
+	safeSetItem(COLLAPSED_UNGROUPED_KEY, JSON.stringify([...collapsedUngroupedProjects]));
 }
 
 export function isStaffExpanded(projectId: string): boolean {
@@ -539,7 +539,7 @@ export function isStaffExpanded(projectId: string): boolean {
 export function setStaffSectionExpanded(projectId: string, value: boolean): void {
 	if (value) collapsedStaffProjects.delete(projectId);
 	else collapsedStaffProjects.add(projectId);
-	localStorage.setItem(COLLAPSED_STAFF_KEY, JSON.stringify([...collapsedStaffProjects]));
+	safeSetItem(COLLAPSED_STAFF_KEY, JSON.stringify([...collapsedStaffProjects]));
 }
 
 // Per-project archived section expand state. Default = expanded (so toggling
@@ -548,7 +548,7 @@ export function setStaffSectionExpanded(projectId: string, value: boolean): void
 // collapsedUngroupedProjects / collapsedStaffProjects.
 const COLLAPSED_ARCHIVED_KEY = "bobbit-archived-collapsed-projects";
 export let collapsedArchivedProjects: Set<string> = new Set(
-	JSON.parse(localStorage.getItem(COLLAPSED_ARCHIVED_KEY) || "[]"),
+	safeGetJSON<string[]>(COLLAPSED_ARCHIVED_KEY, []),
 );
 
 export function isArchivedSectionExpanded(projectId: string): boolean {
@@ -558,23 +558,23 @@ export function isArchivedSectionExpanded(projectId: string): boolean {
 export function setArchivedSectionExpanded(projectId: string, value: boolean): void {
 	if (value) collapsedArchivedProjects.delete(projectId);
 	else collapsedArchivedProjects.add(projectId);
-	localStorage.setItem(COLLAPSED_ARCHIVED_KEY, JSON.stringify([...collapsedArchivedProjects]));
+	safeSetItem(COLLAPSED_ARCHIVED_KEY, JSON.stringify([...collapsedArchivedProjects]));
 }
 
 const COLLAPSED_TEAM_LEADS_KEY = "bobbit-collapsed-team-leads";
 export let collapsedTeamLeadSessions: Set<string> = new Set(
-	JSON.parse(localStorage.getItem(COLLAPSED_TEAM_LEADS_KEY) || "[]"),
+	safeGetJSON<string[]>(COLLAPSED_TEAM_LEADS_KEY, []),
 );
 
 export function saveExpandedGoals(): void {
-	localStorage.setItem(EXPANDED_GOALS_KEY, JSON.stringify([...expandedGoals]));
+	safeSetItem(EXPANDED_GOALS_KEY, JSON.stringify([...expandedGoals]));
 }
 
 
 export function setTeamLeadExpanded(sessionId: string, expanded: boolean): void {
 	if (expanded) collapsedTeamLeadSessions.delete(sessionId);
 	else collapsedTeamLeadSessions.add(sessionId);
-	localStorage.setItem(COLLAPSED_TEAM_LEADS_KEY, JSON.stringify([...collapsedTeamLeadSessions]));
+	safeSetItem(COLLAPSED_TEAM_LEADS_KEY, JSON.stringify([...collapsedTeamLeadSessions]));
 }
 
 export function toggleTeamLeadExpanded(sessionId: string): void {
@@ -587,13 +587,13 @@ export function isTeamLeadExpanded(sessionId: string): boolean {
 
 const COLLAPSED_FIRST_CLASS_PARENTS_KEY = "bobbit-collapsed-first-class-parents";
 export let collapsedFirstClassParents: Set<string> = new Set(
-	JSON.parse(localStorage.getItem(COLLAPSED_FIRST_CLASS_PARENTS_KEY) || "[]"),
+	safeGetJSON<string[]>(COLLAPSED_FIRST_CLASS_PARENTS_KEY, []),
 );
 
 export function setFirstClassParentExpanded(sessionId: string, expanded: boolean): void {
 	if (expanded) collapsedFirstClassParents.delete(sessionId);
 	else collapsedFirstClassParents.add(sessionId);
-	localStorage.setItem(COLLAPSED_FIRST_CLASS_PARENTS_KEY, JSON.stringify([...collapsedFirstClassParents]));
+	safeSetItem(COLLAPSED_FIRST_CLASS_PARENTS_KEY, JSON.stringify([...collapsedFirstClassParents]));
 }
 
 export function toggleFirstClassParentExpanded(sessionId: string): void {
@@ -606,13 +606,13 @@ export function isFirstClassParentExpanded(sessionId: string): boolean {
 
 const EXPANDED_DELEGATE_PARENTS_KEY = "bobbit-expanded-delegate-parents";
 const expandedDelegateParents: Set<string> = new Set(
-	JSON.parse(localStorage.getItem(EXPANDED_DELEGATE_PARENTS_KEY) || "[]"),
+	safeGetJSON<string[]>(EXPANDED_DELEGATE_PARENTS_KEY, []),
 );
 
 export function setArchivedParentExpanded(sessionId: string, expanded: boolean): void {
 	if (expanded) expandedDelegateParents.add(sessionId);
 	else expandedDelegateParents.delete(sessionId);
-	localStorage.setItem(EXPANDED_DELEGATE_PARENTS_KEY, JSON.stringify([...expandedDelegateParents]));
+	safeSetItem(EXPANDED_DELEGATE_PARENTS_KEY, JSON.stringify([...expandedDelegateParents]));
 }
 
 export function toggleArchivedParentExpanded(sessionId: string): void {
@@ -632,16 +632,16 @@ export function resetArchivedExpandState(): void {
 	// Remove archived session IDs from expandedDelegateParents
 	const archivedSessionIds = new Set(state.archivedSessions.map(s => s.id));
 	for (const id of archivedSessionIds) expandedDelegateParents.delete(id);
-	localStorage.setItem(EXPANDED_DELEGATE_PARENTS_KEY, JSON.stringify([...expandedDelegateParents]));
+	safeSetItem(EXPANDED_DELEGATE_PARENTS_KEY, JSON.stringify([...expandedDelegateParents]));
 
 	// Reset archived team lead sessions from collapsedTeamLeadSessions
 	// (archived team leads that were explicitly collapsed — remove them so they return to default)
 	for (const id of archivedSessionIds) collapsedTeamLeadSessions.delete(id);
-	localStorage.setItem(COLLAPSED_TEAM_LEADS_KEY, JSON.stringify([...collapsedTeamLeadSessions]));
+	safeSetItem(COLLAPSED_TEAM_LEADS_KEY, JSON.stringify([...collapsedTeamLeadSessions]));
 
 	// Reset archived first-class parent sessions from collapsedFirstClassParents
 	for (const id of archivedSessionIds) collapsedFirstClassParents.delete(id);
-	localStorage.setItem(COLLAPSED_FIRST_CLASS_PARENTS_KEY, JSON.stringify([...collapsedFirstClassParents]));
+	safeSetItem(COLLAPSED_FIRST_CLASS_PARENTS_KEY, JSON.stringify([...collapsedFirstClassParents]));
 
 	// Free memory — archived sessions will be re-fetched on next toggle-on
 	state.archivedSessions = [];
@@ -732,7 +732,7 @@ export function setSidebarWidth(w: number, persist = true): void {
 	const clamped = clampSidebarWidth(w);
 	state.sidebarWidth = clamped;
 	applySidebarWidthVar(clamped);
-	if (persist) localStorage.setItem(SIDEBAR_WIDTH_KEY, String(clamped));
+	if (persist) safeSetItem(SIDEBAR_WIDTH_KEY, String(clamped));
 }
 
 export const SIDEBAR_BREAKPOINT = 768;

--- a/src/ui/components/sidebar-filters.ts
+++ b/src/ui/components/sidebar-filters.ts
@@ -16,6 +16,7 @@ import { icon } from "@mariozechner/mini-lit";
 import { Archive, Eye, Filter, Zap } from "lucide";
 import { renderApp, resetArchivedExpandState, state } from "../../app/state.js";
 import { shortcutHint } from "../../app/shortcut-registry.js";
+import { safeSetItem } from "../../app/safe-storage.js";
 
 // ---------------------------------------------------------------------------
 // Shared toggle handlers (used by both popover clicks and keyboard shortcuts)
@@ -24,7 +25,7 @@ import { shortcutHint } from "../../app/shortcut-registry.js";
 /** Toggle Show Archived. Persists, lazy-loads/clears archived data, re-renders. */
 export function toggleShowArchived(): void {
 	state.showArchived = !state.showArchived;
-	localStorage.setItem("bobbit-show-archived", String(state.showArchived));
+	safeSetItem("bobbit-show-archived", String(state.showArchived));
 	// Manual toggle takes precedence over search-driven auto-open.
 	import("../../app/sidebar.js").then(m => m.clearArchivedBySearch()).catch(() => {});
 	if (state.showArchived) {
@@ -42,14 +43,14 @@ export function toggleShowArchived(): void {
 /** Toggle Show Busy. Persists, re-renders. */
 export function toggleShowBusy(): void {
 	state.showBusy = !state.showBusy;
-	localStorage.setItem("bobbit-show-busy", String(state.showBusy));
+	safeSetItem("bobbit-show-busy", String(state.showBusy));
 	renderApp();
 }
 
 /** Toggle Show Read. Persists, re-renders. */
 export function toggleShowRead(): void {
 	state.showRead = !state.showRead;
-	localStorage.setItem("bobbit-show-read", String(state.showRead));
+	safeSetItem("bobbit-show-read", String(state.showRead));
 	renderApp();
 }
 

--- a/tests/safe-storage.test.ts
+++ b/tests/safe-storage.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Regression test for the "Failed to execute 'setItem' on 'Storage'" error
+ * that rendered in the sidebar right before the UI loaded.
+ *
+ * Root cause: boot-critical persistence writers (notably `saveExpandedGoals()`
+ * in src/app/state.ts, invoked from the initial `refreshSessions()` path) called
+ * `localStorage.setItem` directly. When storage throws — quota exceeded, Safari
+ * private mode, or a locked-down/partitioned context — the exception bubbled
+ * into `refreshSessions()`'s catch, which on initial load assigns the raw error
+ * message to `state.sessionsError`. The sidebar then rendered that string in red.
+ *
+ * Fix: src/app/safe-storage.ts wraps every localStorage access so persistence is
+ * best-effort and NEVER throws. These tests pin that contract directly against
+ * the source helper (no DOM / browser needed) by installing a `localStorage`
+ * global whose `setItem` throws like a real quota failure.
+ */
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { safeSetItem, safeGetItem, safeRemoveItem, safeGetJSON } from "../src/app/safe-storage.ts";
+
+const realLocalStorage = (globalThis as any).localStorage;
+
+function installThrowingStorage(): void {
+	(globalThis as any).localStorage = {
+		setItem() { throw new DOMException("exceeded the quota", "QuotaExceededError"); },
+		getItem() { throw new DOMException("denied", "SecurityError"); },
+		removeItem() { throw new DOMException("denied", "SecurityError"); },
+	};
+}
+
+function installMapStorage(): Map<string, string> {
+	const map = new Map<string, string>();
+	(globalThis as any).localStorage = {
+		setItem: (k: string, v: string) => { map.set(k, String(v)); },
+		getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+		removeItem: (k: string) => { map.delete(k); },
+	};
+	return map;
+}
+
+afterEach(() => {
+	if (realLocalStorage === undefined) delete (globalThis as any).localStorage;
+	else (globalThis as any).localStorage = realLocalStorage;
+});
+
+describe("safe-storage — never throws on hostile storage", () => {
+	beforeEach(() => installThrowingStorage());
+
+	it("safeSetItem swallows a quota/security exception", () => {
+		assert.doesNotThrow(() => safeSetItem("k", "v"));
+	});
+
+	it("safeGetItem returns null instead of throwing", () => {
+		assert.strictEqual(safeGetItem("k"), null);
+	});
+
+	it("safeRemoveItem swallows a security exception", () => {
+		assert.doesNotThrow(() => safeRemoveItem("k"));
+	});
+
+	it("safeGetJSON returns the fallback instead of throwing", () => {
+		assert.deepStrictEqual(safeGetJSON<string[]>("k", ["fallback"]), ["fallback"]);
+	});
+});
+
+describe("safe-storage — round-trips when storage works", () => {
+	let map: Map<string, string>;
+	beforeEach(() => { map = installMapStorage(); });
+
+	it("safeSetItem / safeGetItem round-trip", () => {
+		safeSetItem("hello", "world");
+		assert.strictEqual(map.get("hello"), "world");
+		assert.strictEqual(safeGetItem("hello"), "world");
+	});
+
+	it("safeGetJSON parses stored JSON", () => {
+		safeSetItem("ids", JSON.stringify(["a", "b"]));
+		assert.deepStrictEqual(safeGetJSON<string[]>("ids", []), ["a", "b"]);
+	});
+
+	it("safeGetJSON falls back on corrupted JSON rather than throwing", () => {
+		safeSetItem("ids", "{not valid json");
+		assert.deepStrictEqual(safeGetJSON<string[]>("ids", []), []);
+	});
+
+	it("safeRemoveItem deletes the key", () => {
+		safeSetItem("gone", "soon");
+		safeRemoveItem("gone");
+		assert.strictEqual(safeGetItem("gone"), null);
+	});
+});


### PR DESCRIPTION
## Problem

A `Failed to execute 'setItem' on 'Storage'` error rendered in the sidebar's red error slot right before the UI loaded.

The string is the browser's raw `localStorage.setItem` exception. **Root cause:** during the initial load, `refreshSessions()` (`src/app/api.ts`) auto-expands newly discovered goals and calls `saveExpandedGoals()`, which does an **unguarded** `localStorage.setItem`. When storage throws — quota exceeded, Safari private mode, or a locked-down/partitioned context — the exception bubbled into `refreshSessions()`'s `catch`, which on the first load assigns the raw message to `state.sessionsError`. The sidebar then renders that string in red, exactly "in the sidebar just before the UI loads".

A dozen other boot/sidebar persistence writers (and a few module-level `getItem` reads that can throw `SecurityError` at import time) shared the same unguarded pattern.

## Fix

- **New `src/app/safe-storage.ts`** — single source of truth for best-effort `localStorage` access: `safeSetItem`, `safeGetItem`, `safeRemoveItem`, `safeGetJSON`. All swallow exceptions; `safeGetJSON` also falls back on corrupted JSON so one bad write can't break module load via an uncaught `SyntaxError`.
- Routed the boot-critical and sidebar persistence paths through it — `src/app/state.ts` (including the smoking-gun `saveExpandedGoals`), `src/app/sidebar.ts`, and `src/ui/components/sidebar-filters.ts`. Also hardens module-level `getItem` reads that could throw at import time.

Persistence is now best-effort: full/disabled storage degrades gracefully (expand-collapse state just isn't remembered) instead of aborting session load and dumping a cryptic error into the sidebar.

## Tests

- **`tests/safe-storage.test.ts`** — pins that the helper never throws against hostile storage (quota/security exceptions) and round-trips correctly otherwise (8 tests, passing).
- `npm run check` clean.

## Follow-up (out of scope)

Unguarded `localStorage` writes remain elsewhere (`main.ts`, `session-manager.ts`, `routing.ts`) that fire from event handlers rather than the boot path — they'd throw uncaught rather than surface in the sidebar. Can be swept into `safe-storage` separately for full consistency.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
