### PR TITLE
perf: request transcript snapshot immediately on WS auth (~700ms faster reload)

### DIFF
--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -1040,6 +1040,7 @@ export class RemoteAgent {
 	}
 
 	requestMessages(): void {
+		bootMark("get-messages-sent");
 		this.send({ type: "get_messages" });
 	}
 

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -1172,6 +1172,23 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 		await remote.connect(url, token, sessionId);
 		if (isStale()) { remote.disconnect(); return; }
 
+		// ── Fire the transcript snapshot request the INSTANT the WS is
+		// authenticated — before the refreshSessions()/setAgent() awaits below.
+		// Profiling (boot-timing) showed those awaits stall the snapshot request
+		// by ~700ms on a cold reload, even though the server builds the snapshot
+		// in ~200ms. The reducer applies the snapshot to remote.state
+		// independently of the ChatPanel binding, so the request can fly in
+		// parallel with all the connect setup; the panel renders the messages
+		// when setAgent() binds. Proposal checking is deferred here and released
+		// by runDeferredProposalCheck() after draft restores complete — so an
+		// early snapshot can't fill form state before drafts restore.
+		// (Previously this lived ~250 lines below, AFTER those awaits, which
+		// defeated the "fire early" intent.)
+		if (isExisting) {
+			remote.deferProposalCheck();
+			remote.requestMessages();
+		}
+
 		// Auto-prompt for new assistant sessions — fire IMMEDIATELY after connect
 		// before any draft-restore awaits that could yield and race
 		const AUTO_PROMPTS: Record<string, string> = {
@@ -1967,14 +1984,10 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			setHashRoute("session", sessionId, true);
 		}
 
-		// ── Fire requestMessages() early so the network roundtrip overlaps
-		// with draft restores and refreshSessions below. Proposal checking
-		// is deferred so incoming messages won't fill form state before
-		// draft restores have a chance to run.
-		if (isExisting) {
-			remote.deferProposalCheck();
-			remote.requestMessages();
-		}
+		// (Snapshot request + proposal-check deferral were hoisted to fire
+		// immediately after connect() resolves — see the block right after
+		// `await remote.connect(...)` above. Firing here, after the
+		// refreshSessions()/setAgent() awaits, added ~700ms to every reload.)
 
 		// Initial git status and bg process fetch (fire-and-forget)
 		refreshGitStatusForSession(sessionId);


### PR DESCRIPTION
## What

Fire the transcript snapshot request (`get_messages`) the instant the WebSocket authenticates, instead of after `connectToSession` awaits `refreshSessions()` and `chatPanel.setAgent()`.

## Why (measured)

Boot-timing profiling of a reload on a 369-message session:

| Phase | ms |
|---|---:|
| `auth-ok → snapshot-received` (client waited) | **1171** |
| …of which server-side build (`serverTiming`) | **~200** (194 rpc + 1 pipeline + 0.2 stamp + 4.5 stringify) |
| **unaccounted client-side stall** | **~770** |

The server builds the whole snapshot in ~200 ms, but the client didn't *ask* for it until ~700 ms after auth — because `requestMessages()` was placed **after** `await refreshSessions()` (a full session-list REST fetch, which always runs on a cold reload since the sidebar cache is empty) and `await chatPanel.setAgent()` (lazy imports). The "fire early to overlap" comment was wrong: it sat after those awaits.

## The change

Hoist the `deferProposalCheck() + requestMessages()` pair to fire immediately after `connect()` resolves, before those awaits. The reducer applies the snapshot to `remote.state` independently of the ChatPanel binding (the panel renders the messages when `setAgent()` binds), so the network round-trip now overlaps the rest of connect setup.

**Invariants preserved exactly:**
- Same `deferProposalCheck()` → `requestMessages()` → (draft restores) → `runDeferredProposalCheck()` ordering, so an early snapshot still can't fill form state before drafts restore.
- Same `isExisting` gate (new/empty sessions don't request).
- `connect()` is always an initial connect; reconnects keep their existing `!initial` request path untouched.

Also adds a `get-messages-sent` boot mark so the collapsed stall is visible in `boot-timing.jsonl`.

Expected saving: most of the ~700 ms on every session reload/reconnect, dev and prod. (Module waterfall and client render are separate, already-known costs.)

## Tests

`npm run check` + targeted E2E over the sensitive paths — snapshot dedup (`new-tab-no-duplicate-messages`), draft-vs-snapshot ordering (`draft-loss`), proposal deferral (`proposal-spec-survives-navigate`), recovery (`session-recovery`). All assertions pass on every real run. Observed flakes were all the pre-existing Windows cold-import harness race (`gateway-harness.ts:260`, random module each time) tracked separately — not assertion failures and not introduced here.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
