### PR TITLE
Auto-select Other on type in ask_user_choices

### DIFF
--- a/src/ui/components/AskUserChoicesWidget.ts
+++ b/src/ui/components/AskUserChoicesWidget.ts
@@ -225,6 +225,32 @@ export class AskUserChoicesWidget extends LitElement {
 		this._draft = this._draft.map((d, i) => i === qIdx ? { ...d, other_text: text } : d);
 	}
 
+	/**
+	 * Handler for typing in the "Other" free-text input. Updates the draft text
+	 * and auto-selects "Other" if it isn't already selected — so the typed
+	 * answer counts without a separate click on the option.
+	 *
+	 * - Single-select: selecting Other replaces the previous selection.
+	 * - Multi-select: Other is ADDED (only call `_selectOption` when not already
+	 *   selected, since it toggles for multi — re-calling would deselect it).
+	 * - Never auto-deselects when text is cleared (deselection stays manual).
+	 * - No-op on selection changes when read-only (mirrors `_setOtherText`).
+	 */
+	private _onOtherInput(qIdx: number, text: string): void {
+		this._setOtherText(qIdx, text);
+		if (this._isReadOnly()) return;
+		const d = this._draft[qIdx];
+		if (!d) return;
+		const alreadySelected = Array.isArray(d.selected)
+			? d.selected.includes(OTHER_SENTINEL)
+			: d.selected === OTHER_SENTINEL;
+		if (!alreadySelected) {
+			// Reuse `_selectOption`, which handles single-vs-multi and never
+			// auto-advances/auto-submits for OTHER_SENTINEL.
+			this._selectOption(qIdx, OTHER_SENTINEL);
+		}
+	}
+
 	private _canSubmit(): boolean {
 		if (this._draft.length !== this.questions.length) return false;
 		return this._draft.every((_d, i) => this._isQuestionValid(i));
@@ -716,7 +742,7 @@ export class AskUserChoicesWidget extends LitElement {
 					placeholder="Type your answer…"
 					.value=${otherText}
 					?disabled=${readOnly}
-					@input=${(e: Event) => this._setOtherText(qIdx, (e.target as HTMLInputElement).value)}>
+					@input=${(e: Event) => this._onOtherInput(qIdx, (e.target as HTMLInputElement).value)}>
 			</div>`;
 	}
 }

--- a/tests/ask-user-choices-widget.html
+++ b/tests/ask-user-choices-widget.html
@@ -200,6 +200,18 @@ class AskWidget {
     this.render();
   }
 
+  // Mirrors AskUserChoicesWidget._onOtherInput: typing in Other auto-selects it.
+  onOtherInput(qIdx, text) {
+    this.setOtherText(qIdx, text);
+    if (this.isReadOnly()) return;
+    const d = this.draft[qIdx];
+    if (!d) return;
+    const alreadySelected = Array.isArray(d.selected)
+      ? d.selected.includes(OTHER_SENTINEL)
+      : d.selected === OTHER_SENTINEL;
+    if (!alreadySelected) this.selectOption(qIdx, OTHER_SENTINEL);
+  }
+
   async submit() {
     if (!this.canSubmit() || this.submitting) return;
     this.submitting = true;
@@ -462,7 +474,7 @@ class AskWidget {
       txt.className = "ask-other-input";
       txt.value = otherText;
       if (readOnly) txt.disabled = true;
-      txt.addEventListener("input", (e) => this.setOtherText(this.activeTab, e.target.value));
+      txt.addEventListener("input", (e) => this.onOtherInput(this.activeTab, e.target.value));
       row.appendChild(txt);
       return row;
     };

--- a/tests/ask-user-choices-widget.spec.ts
+++ b/tests/ask-user-choices-widget.spec.ts
@@ -129,21 +129,62 @@ test.describe("ask_user_choices widget", () => {
 		await expect(page.locator('input[type=radio][value="__OTHER__"]')).not.toBeChecked();
 	});
 
-	test("Typing in Other input before selecting Other does not auto-select", async ({ page }) => {
+	test("Typing in Other input auto-selects Other (single-select)", async ({ page }) => {
+		// Single-question single-select: Other is the only path that doesn't
+		// auto-submit/advance, so typing into it must auto-select it.
 		await page.evaluate(() => (window as any).mountWidget({
-			questions: [
-				{ question: "Q1", options: ["a", "b"], tab_label: "First" },
-				{ question: "Q2", options: ["c", "d"], tab_label: "Second" },
-			],
+			questions: [{ question: "Q1", options: ["a", "b"] }],
 		}));
 		const input = page.locator('.ask-other-input').first();
-		await input.fill("speculative");
-		// Other radio still NOT checked.
 		await expect(page.locator('input[type=radio][value="__OTHER__"]').first()).not.toBeChecked();
-		// Now click Other — typed text is preserved.
-		await page.locator('input[type=radio][value="__OTHER__"]').first().click({ force: true });
+		await input.fill("speculative");
 		await expect(page.locator('input[type=radio][value="__OTHER__"]').first()).toBeChecked();
-		await expect(page.locator('.ask-other-input').first()).toHaveValue("speculative");
+		await expect(input).toHaveValue("speculative");
+		// Single-select draft is scalar, so selecting Other replaces any prior
+		// selection — no other radio remains checked.
+		await expect(page.locator('input[type=radio]:checked')).toHaveCount(1);
+	});
+
+	test("Typing in Other input adds Other to selection (multi-select) without removing others", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [{ question: "Pick", options: ["a", "b", "c"], multi: true }],
+		}));
+		// Check two real options first.
+		await page.locator('label:has(input[value="a"])').click();
+		await page.locator('label:has(input[value="c"])').click();
+		await expect(page.locator('input[type=checkbox][value="a"]')).toBeChecked();
+		await expect(page.locator('input[type=checkbox][value="c"]')).toBeChecked();
+		// Type into Other → Other is ADDED; existing selections remain.
+		await page.locator('.ask-other-input').fill("custom");
+		await expect(page.locator('input[type=checkbox][value="__OTHER__"]')).toBeChecked();
+		await expect(page.locator('input[type=checkbox][value="a"]')).toBeChecked();
+		await expect(page.locator('input[type=checkbox][value="c"]')).toBeChecked();
+		await expect(page.locator('input[type=checkbox][value="b"]')).not.toBeChecked();
+	});
+
+	test("Clearing Other text does NOT deselect Other (single-select)", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [{ question: "Q1", options: ["a", "b"] }],
+		}));
+		const input = page.locator('.ask-other-input').first();
+		await input.fill("x");
+		await expect(page.locator('input[type=radio][value="__OTHER__"]').first()).toBeChecked();
+		// Clear the text → Other stays selected (deselection is a manual action).
+		await input.fill("");
+		await expect(input).toHaveValue("");
+		await expect(page.locator('input[type=radio][value="__OTHER__"]').first()).toBeChecked();
+	});
+
+	test("Clearing Other text does NOT deselect Other (multi-select)", async ({ page }) => {
+		await page.evaluate(() => (window as any).mountWidget({
+			questions: [{ question: "Pick", options: ["a", "b"], multi: true }],
+		}));
+		const input = page.locator('.ask-other-input').first();
+		await input.fill("x");
+		await expect(page.locator('input[type=checkbox][value="__OTHER__"]')).toBeChecked();
+		await input.fill("");
+		await expect(input).toHaveValue("");
+		await expect(page.locator('input[type=checkbox][value="__OTHER__"]')).toBeChecked();
 	});
 
 	test("successful submit() → widget becomes read-only (no Submit button)", async ({ page }) => {

--- a/tests/e2e/ui/ask-user-choices-ui.spec.ts
+++ b/tests/e2e/ui/ask-user-choices-ui.spec.ts
@@ -47,16 +47,14 @@ test.describe("ask_user_choices widget (full-stack UI)", () => {
 		const input = widget.locator(".ask-other-input");
 		await expect(input).toBeVisible();
 
-		// Type into Other speculatively, select it, then Escape clears both the
-		// selection and text without removing the always-visible input.
+		// Typing into Other auto-selects it (no separate click needed); Escape
+		// then clears both the selection and text without removing the input.
 		await input.fill("abc");
 		await expect(input).toHaveValue("abc");
 		await expect(widget.locator('input[type="radio"][value="__OTHER__"]').first())
-			.not.toBeChecked();
-		await widget.locator('label:has(input[value="__OTHER__"])').first().click();
+			.toBeChecked();
 		await expect(widget.locator('[role="tab"][data-tab-index="0"]'))
 			.toHaveAttribute("aria-selected", "true");
-		await expect(widget.locator('input[type="radio"][value="__OTHER__"]').first()).toBeChecked();
 		await widget.locator('[role="tab"][data-tab-index="0"]').focus();
 		await page.keyboard.press("Escape");
 		await expect(input).toHaveValue("");
@@ -273,6 +271,45 @@ test.describe("ask_user_choices widget (full-stack UI)", () => {
 		// only ONE shows interactive chrome — the failed one is collapsed.
 		await expect(page.locator("[role=\"tab\"]")).toHaveCount(2); // two tabs on the live widget
 		await expect(page.locator(".ask-submit")).toHaveCount(1); // exactly one Submit button
+	});
+
+	test("typing in Other auto-selects it and submit carries the typed other_text", async ({ page }) => {
+		await openApp(page);
+		await createSessionViaUI(page);
+
+		await sendMessage(page, "please use ask_user_choices");
+
+		const widget = page.locator("ask-user-choices-widget").first();
+		await expect(widget).toBeVisible({ timeout: 20_000 });
+
+		// Wait for streaming to settle so auto-advance timers aren't dropped by
+		// mid-stream re-renders (see keyboard-only test for the full rationale).
+		await page.waitForFunction(
+			() => (window as any).__bobbitState?.remoteAgent?.state?.isStreaming === false,
+			{ timeout: 15_000 },
+		);
+
+		// Pick "red" on Q1 → auto-advance to Q2.
+		await widget.locator('label:has(input[value="red"])').click();
+		await expect(widget.locator('[role="tab"][data-tab-index="1"]'))
+			.toHaveAttribute("aria-selected", "true", { timeout: 5_000 });
+
+		// Type directly into the Other input on Q2 — Other auto-selects, no click.
+		const input = widget.locator(".ask-other-input");
+		await expect(input).toBeVisible();
+		await input.fill("eleven");
+		await expect(widget.locator('input[type="radio"][value="__OTHER__"]')).toBeChecked();
+
+		// Submit is enabled once Other is selected with non-empty text.
+		const submit = widget.locator(".ask-submit");
+		await expect(submit).toBeEnabled({ timeout: 5_000 });
+		await submit.click();
+
+		// Widget goes read-only and the agent echoes the answers, including the
+		// typed other_text, back into the chat.
+		await expect(widget.locator(".ask-submit")).toHaveCount(0, { timeout: 10_000 });
+		await expect(page.locator("assistant-message").filter({ hasText: "eleven" }).first())
+			.toBeVisible({ timeout: 10_000 });
 	});
 
 	test("keyboard-only multi-question submission", async ({ page }) => {


### PR DESCRIPTION
## Summary
Typing into the "Other" free-text box of the `ask_user_choices` widget now auto-selects the "Other" option, so the typed answer counts without a separate click.

- **Single-select**: selecting Other replaces the prior selection.
- **Multi-select**: Other is added without removing other checked options.
- **No auto-deselect** when text is cleared — deselection stays manual.
- Respects read-only mode; reuses `_selectOption(OTHER_SENTINEL)` so no auto-advance/auto-submit.

## Changes
- `src/ui/components/AskUserChoicesWidget.ts` — new `_onOtherInput` handler wired to `.ask-other-input` `@input`.
- `tests/ask-user-choices-widget.spec.ts` (+ `.html` fixture) — unit coverage for single/multi auto-select and clear-does-not-deselect.
- `tests/e2e/ui/ask-user-choices-ui.spec.ts` — happy-path browser E2E.

## Verification
`npm run check`, unit (40 passed), and E2E (6 passed) all green.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)