### PR TITLE
Per-step gate_inspect filter (by step name)

### DIFF
--- a/defaults/roles/team-lead.yaml
+++ b/defaults/roles/team-lead.yaml
@@ -77,7 +77,7 @@ promptTemplate: |
   - **gate_list** — List all gates with status and definitions. No parameters.
   - **gate_signal** — Signal a gate with content and/or metadata. Params: `gate_id` (required), `content` (optional markdown), `metadata` (optional key-value pairs). Re-signaling a passed gate cascade-resets downstream gates to pending.
   - **gate_status** — Get latest signal details for a gate — verdict, truncated failed-step output, and metadata. Param: `gate_id`.
-  - **gate_inspect** — Read bounded gate content, verification output, or signal history. Params: `gate_id`, `section` ("content"/"verification"/"signals"), optional `signal_index`, `mode` ("grep"/"tail"/"head"/"slice"/"full"), `pattern`, `context`, `max_results`, `lines`, `from`, `to`.
+  - **gate_inspect** — Read bounded gate content, verification output, or signal history. Params: `gate_id`, `section` ("content"/"verification"/"signals"), optional `signal_index`, `mode` ("grep"/"tail"/"head"/"slice"/"full"), `step` (verification step name — scopes `section="verification"` to one step), `pattern`, `context`, `max_results`, `lines`, `from`, `to`.
 
   ## Available Roles
 
@@ -269,6 +269,7 @@ promptTemplate: |
   3. **Content** (`gate_inspect`) — call only when you need to READ something. Default output is a bounded tail, not full output:
      - `gate_inspect(gate_id="design-doc", section="content")` — read a design doc, bounded if large
      - `gate_inspect(gate_id="implementation", section="verification", mode="grep", pattern="error|failed", context=2)` — targeted failure triage
+     - `gate_inspect(gate_id="implementation", section="verification", step="unit", mode="grep", pattern="error|failed", context=2)` — scope triage to ONE step by name (e.g. just the failing `unit` step) instead of every step's output
      - `gate_inspect(gate_id="implementation", section="verification", mode="tail", lines=80)` — recent verification output when grep is insufficient
      - `gate_inspect(gate_id="implementation", section="verification", mode="slice", from=120, to=180)` — a known line range
      - `gate_inspect(gate_id="implementation", section="signals")` — bounded signal history overview
@@ -279,10 +280,11 @@ promptTemplate: |
   1. Already know what failed from the notification? → Spawn fix agent directly.
   2. Need more detail? → `gate_status(gate_id="...")` — check the verdict and output tail first.
   3. Still unclear? → `gate_inspect(gate_id="...", section="verification", mode="grep", pattern="error|failed", context=2)` — inspect matching failure lines.
-  4. Need surrounding output? → Use `mode="tail"` or `mode="slice"`; prefer `mode="full"` only as a rare escape hatch.
-  5. Need to read upstream content? → `gate_inspect(gate_id="...", section="content")`.
+  4. Multi-step gate, one culprit? → `gate_list`/`gate_status` name the failing step(s) in `failedSteps`. Pass `step="<name>"` to scope the verification snapshot to just that step, then combine with `mode="grep"`/`"slice"` to drill into its log alone — you no longer wade through every step's output. (`step` is verification-only; an unknown name returns a 400 listing the valid step names.)
+  5. Need surrounding output? → Use `mode="tail"` or `mode="slice"`; prefer `mode="full"` only as a rare escape hatch.
+  6. Need to read upstream content? → `gate_inspect(gate_id="...", section="content")`.
 
-  Do NOT call `gate_inspect` "just in case" — only when the decision requires it. Prefer `gate_status` first, then targeted `grep`, then `tail`/`slice`.
+  Do NOT call `gate_inspect` "just in case" — only when the decision requires it. Prefer `gate_status` first, then a `step`-scoped/`grep` read of the failing step, then `tail`/`slice`.
 
   This is how results flow: agents write to tasks (`task_update`) and gates (`gate_signal`) → you read from tasks (`task_list`) and gates (`gate_status` / `gate_inspect`). You do NOT need to read agent session logs or parse their chat output.
 

--- a/defaults/tools/tasks/extension.ts
+++ b/defaults/tools/tasks/extension.ts
@@ -205,6 +205,7 @@ export default function (pi: ExtensionAPI) {
 				Type.Literal("signals"),
 			]),
 			signal_index: Type.Optional(Type.Number({ description: "0-based, negative from end. Default -1 (latest)." })),
+			step: Type.Optional(Type.String({ description: "Verification step name to scope to (section=verification only)." })),
 			mode: Type.Optional(Type.Union([
 				Type.Literal("full"),
 				Type.Literal("grep"),
@@ -223,6 +224,7 @@ export default function (pi: ExtensionAPI) {
 			try {
 				const qs = new URLSearchParams({ section: params.section });
 				if (params.signal_index !== undefined) qs.set("signal_index", String(params.signal_index));
+				if (params.step !== undefined) qs.set("step", String(params.step));
 				if (params.mode !== undefined) qs.set("mode", String(params.mode));
 				if (params.pattern !== undefined) qs.set("pattern", String(params.pattern));
 				if (params.context !== undefined) qs.set("context", String(params.context));

--- a/defaults/tools/tasks/gate_inspect.yaml
+++ b/defaults/tools/tasks/gate_inspect.yaml
@@ -1,7 +1,7 @@
 name: gate_inspect
 description: "Fetch one bounded gate section: content, verification, or signals"
 summary: "Read bounded gate content, verification, or signals"
-params: ["gate_id", "section", "signal_index?", "mode?", "pattern?", "context?", "max_results?", "lines?", "from?", "to?"]
+params: ["gate_id", "section", "signal_index?", "step?", "mode?", "pattern?", "context?", "max_results?", "lines?", "from?", "to?"]
 provider:
   type: bobbit-extension
   extension: extension.ts
@@ -22,6 +22,7 @@ detail_docs: |-
   | `gate_id` | string | **Yes** | — | Gate ID (e.g. `"design-doc"`, `"implementation"`) |
   | `section` | `"content"` / `"verification"` / `"signals"` | **Yes** | — | What to read |
   | `signal_index` | number | No | `-1` (latest) | Which signal. 0-based, negative from end. Ignored for `section="signals"`. |
+  | `step` | string | No | — | `section="verification"` only: scope to one step by name. Other sections → 400. |
   | `mode` | `"full"` / `"grep"` / `"head"` / `"tail"` / `"slice"` | No | `"tail"` | Retrieval mode. Default output is a bounded tail, not full content. |
   | `pattern` | string | For `grep` | — | Regex to match. Invalid regexes return a validation error. |
   | `context` | number | No | `0` | Surrounding lines to include around each grep match. |
@@ -68,7 +69,7 @@ detail_docs: |-
 
   ### section="verification" — Read verification output
 
-  Returns verification steps with each step's `output` independently selected.
+  Returns verification steps with each step's `output` independently selected. When `step="<name>"` is given, only that one step is returned (single-element `steps[]`) and the selection mode applies to that step's output; an unknown name returns a 400 listing the available step names.
 
   - `gateId` — gate identifier
   - `section` — `"verification"`
@@ -109,6 +110,7 @@ detail_docs: |-
 
   - **Start with status** — call `gate_status(gate_id="...")` first; its verdict and output tail are usually enough.
   - **Target failure lines** — use `mode="grep"` with `pattern="error|failed"` and `context=2` for large verification logs.
+  - **Focus one step** — pass `step="<name>"` to scope `section="verification"` to a single step (names come from `gate_status.failedSteps`).
   - **Inspect nearby output** — use `mode="tail"` or `mode="slice"` when grep shows where to look.
   - **Read upstream content** — use `section="content"` when you need the gate's actual content.
   - **Browse attempts** — use `section="signals"` to compare signal history.
@@ -128,6 +130,9 @@ detail_docs: |-
 
   # Grep large implementation verification output for failure lines
   gate_inspect(gate_id="implementation", section="verification", mode="grep", pattern="error|failed", context=2)
+
+  # Scope to a single verification step by name, then grep it for failures
+  gate_inspect(gate_id="implementation", section="verification", step="unit", mode="grep", pattern="error|failed", context=2)
 
   # Inspect the latest tail with an explicit line count
   gate_inspect(gate_id="implementation", section="verification", mode="tail", lines=80)

--- a/docs/goals-workflows-tasks.md
+++ b/docs/goals-workflows-tasks.md
@@ -326,6 +326,16 @@ Verification log output is bounded by default: `gate_status` and `gate_inspect s
 
 Running command steps can include live stdout/stderr tails. The server reads those log files with bounded byte limits before applying the same selection and aggregate response budgets used for persisted output.
 
+##### Targeting a single verification step
+
+A gate often runs several verify steps (e.g. type-check + lint + unit + e2e, or multiple review steps). By default `gate_inspect section=verification` returns *every* step, so a team lead chasing one failing step still receives all the others' output and cannot scope a `grep`/`slice` to the step they care about. The optional `step` parameter fixes that: pass the step **name** and the snapshot is scoped to just that one step.
+
+- **Why by name:** step names are already surfaced to callers — `gate_status` returns the names of failed steps in `failedSteps`, and each step's `name` appears in an unfiltered verification snapshot. So the names needed to target a step are always in hand. Targeting is by name only; there is no index-based selector.
+- **What changes:** `steps[]` contains only the matching step (still a single-element array, so the response shape is unchanged), and the selection mode (`grep`/`tail`/`slice`/`head`/`full`) applies to that one step's output. Per-step `selection` metadata and the default bounded-tail behavior are preserved.
+- **Validation:** an unknown step name returns 400 listing the available step names for that signal. `step` is only meaningful for `section=verification`; combining it with `section=content` or `section=signals` returns 400 (`step is only valid with section='verification'`).
+
+Typical triage flow: `gate_status` reports a failure and names the culprit in `failedSteps`, then `gate_inspect(section="verification", step="<name>", mode="grep", pattern="error|failed", context=2)` focuses the search on that step's log alone. See the [`gate_inspect` tool docs](../defaults/tools/tasks/gate_inspect.yaml) for the full parameter table.
+
 The UI uses the same explicit-status model. Gate status cards, the `gate_inspect` renderer, and signaled gate live cards reconcile WebSocket events, active-verification fetches, and persisted signal rows without flickering back to placeholder failed or `0ms` states while verification is still running.
 
 #### Gate verification baselines

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -981,6 +981,7 @@ A scoped read endpoint for targeted gate data retrieval. Used by the `gate_inspe
 |-----------|------|----------|---------|-------------|
 | `section` | `"content"` \| `"verification"` \| `"signals"` | yes | — | What data to retrieve |
 | `signal_index` | integer | no | `-1` (latest) | Which signal. 0-based, negative indexes from end. Ignored for `section=signals`. |
+| `step` | string | no | — | `section=verification` only: scope the response to a single verification step by name. Other sections return 400. |
 | `mode` | `"full"` \| `"grep"` \| `"head"` \| `"tail"` \| `"slice"` | no | `"tail"` | Retrieval mode. Omitted mode returns the last 20 lines per selected field/verification step, not full output. |
 | `pattern` | string | for `grep` | — | Regex used by `mode=grep`. Invalid regexes return 400. |
 | `context` | integer | no | `0` | Surrounding lines to include around each grep match. |
@@ -1033,6 +1034,8 @@ Selection metadata is returned with filtered output:
 ```
 
 **`section=verification`** — Returns a verification snapshot with each step's `output` independently selected. For the latest running signal, this is the same active snapshot used by `gate_status`: persisted signal rows are overlaid with active harness state before output selection. A top-level `selection` may also appear when the combined response is capped.
+
+Pass `step=<name>` to scope the snapshot to a single verification step. When set, `steps[]` contains only the matching step (still a single-element array, so the same response shape applies) and the selection mode applies to that one step's output. Step names come from `gate_status.failedSteps` and from each step's `name` in an unfiltered snapshot. An unknown step name returns 400 with the list of available step names for that signal; using `step` with `section=content` or `section=signals` returns 400 (`step is only valid with section='verification'`).
 ```json
 {
   "gateId": "implementation",
@@ -1102,10 +1105,11 @@ Examples:
 GET /api/goals/goal-1/gates/implementation/inspect?section=verification&mode=grep&pattern=error%7Cfailed&context=2
 GET /api/goals/goal-1/gates/implementation/inspect?section=verification&mode=tail&lines=80
 GET /api/goals/goal-1/gates/implementation/inspect?section=verification&mode=slice&from=120&to=180
+GET /api/goals/goal-1/gates/implementation/inspect?section=verification&step=unit&mode=grep&pattern=error%7Cfailed&context=2
 GET /api/goals/goal-1/gates/implementation/inspect?section=verification&mode=full
 ```
 
-Returns 400 if `section` is missing or invalid, regex compilation fails, line counts are invalid, or a slice range is missing/non-integer/below 1/`from > to`. Returns 404 if the resolved signal index is out of range.
+Returns 400 if `section` is missing or invalid, regex compilation fails, line counts are invalid, a slice range is missing/non-integer/below 1/`from > to`, `step` names an unknown step (the error lists the available step names), or `step` is combined with `section=content`/`section=signals`. Returns 404 if the resolved signal index is out of range.
 
 ### Session error-state fields
 

--- a/src/server/gate-verification-snapshot.ts
+++ b/src/server/gate-verification-snapshot.ts
@@ -16,6 +16,16 @@ const LIVE_LOG_TAIL_CHUNK_BYTES = 16 * 1024;
 
 export type GateVerificationSnapshotStatus = "passed" | "failed" | "skipped" | "running" | "waiting" | "blocked";
 
+/** Thrown when a `stepName` filter does not match any verification step. Maps to a 400. */
+export class UnknownVerificationStepError extends Error {
+	availableSteps: string[];
+	constructor(stepName: string, availableSteps: string[]) {
+		super(`Unknown verification step "${stepName}". Available steps: ${availableSteps.join(", ")}`);
+		this.name = "UnknownVerificationStepError";
+		this.availableSteps = availableSteps;
+	}
+}
+
 export interface GateVerificationSnapshotStep {
 	name: string;
 	type: string;
@@ -242,6 +252,7 @@ export function buildGateVerificationSnapshot(input: {
 	verification?: GateSignal["verification"];
 	activeVerification?: ActiveVerification;
 	selectionOptions?: TextSelectionOptions;
+	stepName?: string;
 	now?: number;
 }): GateVerificationSnapshot {
 	const now = input.now ?? Date.now();
@@ -321,7 +332,19 @@ export function buildGateVerificationSnapshot(input: {
 		return out;
 	});
 
-	const aggregate = enforceGateVerificationAggregateOutputBudget(steps);
+	// Narrow to a single named step when requested. Blocked/prior-failure state is
+	// already computed during the full map above; we only filter what is returned and
+	// re-run the aggregate budget over the single step so per-step selection is preserved.
+	let finalSteps = steps;
+	let totalLines = aggregateTotalLines;
+	if (input.stepName !== undefined) {
+		const matched = steps.find(step => step.name === input.stepName);
+		if (!matched) throw new UnknownVerificationStepError(input.stepName, steps.map(step => step.name));
+		finalSteps = [matched];
+		totalLines = matched.selection?.totalLines ?? 0;
+	}
+
+	const aggregate = enforceGateVerificationAggregateOutputBudget(finalSteps);
 	const counts: Record<GateVerificationSnapshotStatus, number> = {
 		passed: 0,
 		failed: 0,
@@ -330,16 +353,16 @@ export function buildGateVerificationSnapshot(input: {
 		waiting: 0,
 		blocked: 0,
 	};
-	for (const step of steps) counts[step.status]++;
+	for (const step of finalSteps) counts[step.status]++;
 
 	return {
 		status: active?.overallStatus ?? input.verification?.status,
-		steps,
+		steps: finalSteps,
 		counts,
 		summary: buildSummary(counts),
 		selection: {
 			mode: selectionOptions.mode ?? "tail",
-			totalLines: aggregateTotalLines,
+			totalLines,
 			truncated: aggregate.truncated,
 			truncationReason: aggregate.truncationReason,
 		},

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -32,7 +32,7 @@ import { RoleStore } from "./agent/role-store.js";
 import { RoleManager } from "./agent/role-manager.js";
 import { ToolManager, copyDirRecursive, __resetToolScanCache } from "./agent/tool-manager.js";
 import { buildGateStatusSummary } from "./gate-status-summary.js";
-import { buildGateVerificationSnapshot } from "./gate-verification-snapshot.js";
+import { buildGateVerificationSnapshot, UnknownVerificationStepError } from "./gate-verification-snapshot.js";
 import {
 	TextSelectionError,
 	selectText,
@@ -5918,6 +5918,12 @@ async function handleApiRoute(
 			return;
 		}
 
+		const stepName = url.searchParams.get("step") ?? undefined;
+		if (stepName !== undefined && section !== "verification") {
+			json({ error: "step is only valid with section='verification'" }, 400);
+			return;
+		}
+
 		let selectionOptions: TextSelectionOptions;
 		try {
 			selectionOptions = parseGateInspectSelectionOptions(url.searchParams);
@@ -5967,6 +5973,7 @@ async function handleApiRoute(
 					verification: resolved.signal.verification,
 					activeVerification: verificationHarness.getActiveVerification(resolved.signal.id),
 					selectionOptions,
+					stepName,
 				});
 				json({
 					gateId, section: "verification",
@@ -5981,6 +5988,7 @@ async function handleApiRoute(
 				});
 			} catch (err) {
 				if (err instanceof TextSelectionError) { json({ error: err.message }, 400); return; }
+				if (err instanceof UnknownVerificationStepError) { json({ error: err.message }, 400); return; }
 				throw err;
 			}
 			return;

--- a/tests/e2e/gate-inspect-slicing.spec.ts
+++ b/tests/e2e/gate-inspect-slicing.spec.ts
@@ -26,6 +26,15 @@ async function createInspectWorkflow(workflowId: string): Promise<void> {
 					name: "Verification Gate",
 					verify: [{ name: "Large command output", type: "command", run: VERIFY_LOG_CMD }],
 				},
+				{
+					id: "multi-verify-gate",
+					name: "Multi Verification Gate",
+					verify: [
+						{ name: "build", type: "command", run: `node -e "console.log('build ok line')"` },
+						{ name: "unit", type: "command", run: VERIFY_LOG_CMD },
+						{ name: "lint", type: "command", run: `node -e "console.log('lint ok line')"` },
+					],
+				},
 				{ id: "signals-gate", name: "Signals Gate", content: true },
 			],
 		}),
@@ -171,6 +180,52 @@ test.describe("gate inspect slicing", () => {
 			expect(sliceStep.output).not.toContain("noise line 127");
 			expect(sliceStep.selection).toMatchObject({ mode: "slice", totalLines: 160, range: { from: 120, to: 126 } });
 			expect(sliceStep.selection.omittedHint).toBeUndefined();
+		});
+	});
+
+	test("scopes verification to a single named step and rejects unknown/misplaced step params", async () => {
+		await withGoal(async (goalId) => {
+			await signalAndWait(goalId, "multi-verify-gate", {});
+
+			// step=<name> returns exactly one step.
+			const oneRes = await inspectGate(goalId, "multi-verify-gate", "verification", { step: "lint", mode: "full" });
+			expect(oneRes.status).toBe(200);
+			const oneBody = await oneRes.json();
+			expect(oneBody.steps).toHaveLength(1);
+			expect(oneBody.steps[0].name).toBe("lint");
+			expect(oneBody.steps[0].output).toContain("lint ok line");
+			expect(oneBody.summary).toBe("1 passed");
+			expect(oneBody.counts).toMatchObject({ passed: 1, failed: 0 });
+
+			// step + mode=grep scopes grep to that one step.
+			const grepRes = await inspectGate(goalId, "multi-verify-gate", "verification", {
+				step: "unit",
+				mode: "grep",
+				pattern: "ERROR|failed",
+				context: 1,
+			});
+			expect(grepRes.status).toBe(200);
+			const grepBody = await grepRes.json();
+			expect(grepBody.steps).toHaveLength(1);
+			expect(grepBody.steps[0].name).toBe("unit");
+			expect(grepBody.steps[0].output).toContain("ERROR failed sentinel line 125");
+			expect(grepBody.steps[0].output).not.toMatch(/\bnoise line 1\b/);
+			expect(grepBody.steps[0].selection).toMatchObject({ mode: "grep" });
+
+			// Unknown step name → 400 listing available names.
+			const unknownRes = await inspectGate(goalId, "multi-verify-gate", "verification", { step: "nope" });
+			expect(unknownRes.status).toBe(400);
+			const unknownBody = await unknownRes.json();
+			expect(unknownBody.error).toMatch(/Unknown verification step "nope"/);
+			expect(unknownBody.error).toContain("build");
+			expect(unknownBody.error).toContain("unit");
+			expect(unknownBody.error).toContain("lint");
+
+			// step + section=content → 400.
+			const wrongSectionRes = await inspectGate(goalId, "multi-verify-gate", "content", { step: "unit" });
+			expect(wrongSectionRes.status).toBe(400);
+			const wrongSectionBody = await wrongSectionRes.json();
+			expect(wrongSectionBody.error).toMatch(/step is only valid with section='verification'/);
 		});
 	});
 

--- a/tests/gate-verification-snapshot.test.ts
+++ b/tests/gate-verification-snapshot.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { buildGateVerificationSnapshot } from "../src/server/gate-verification-snapshot.ts";
+import { buildGateVerificationSnapshot, UnknownVerificationStepError } from "../src/server/gate-verification-snapshot.ts";
 
 const tempDirs: string[] = [];
 
@@ -61,6 +61,83 @@ function makeSnapshot(outFile: string, selectionOptions?: Parameters<typeof buil
 		now: 100,
 	});
 }
+
+function lines(prefix: string, count: number): string {
+	return Array.from({ length: count }, (_, i) => `${prefix}-${i + 1}`).join("\n");
+}
+
+function makeMultiStepSnapshot(stepName?: string, selectionOptions?: Parameters<typeof buildGateVerificationSnapshot>[0]["selectionOptions"]) {
+	return buildGateVerificationSnapshot({
+		goalId: "goal-1",
+		gateId: "gate-1",
+		signalId: "signal-1",
+		verification: {
+			status: "failed",
+			steps: [
+				{ name: "build", type: "command", status: "passed", passed: true, output: lines("build-out", 30), duration_ms: 10 },
+				{ name: "unit", type: "command", status: "failed", passed: false, output: `noise A\nERROR failed sentinel\nnoise B\n${lines("unit-tail", 50)}`, duration_ms: 20 },
+				{ name: "lint", type: "command", status: "passed", passed: true, output: lines("lint-out", 15), duration_ms: 5 },
+			],
+		},
+		selectionOptions,
+		stepName,
+		now: 100,
+	});
+}
+
+describe("gate verification per-step (stepName) filter", () => {
+	it("returns the full step array when stepName is omitted", () => {
+		const snapshot = makeMultiStepSnapshot();
+		assert.equal(snapshot.steps.length, 3);
+		assert.deepEqual(snapshot.steps.map(s => s.name), ["build", "unit", "lint"]);
+		assert.equal(snapshot.counts.passed, 2);
+		assert.equal(snapshot.counts.failed, 1);
+	});
+
+	it("narrows to a single named step and recomputes counts/summary", () => {
+		const snapshot = makeMultiStepSnapshot("unit");
+		assert.equal(snapshot.steps.length, 1);
+		assert.equal(snapshot.steps[0].name, "unit");
+		assert.equal(snapshot.counts.failed, 1);
+		assert.equal(snapshot.counts.passed, 0);
+		assert.equal(snapshot.summary, "1 failed");
+		assert.equal(snapshot.selection.totalLines, snapshot.steps[0].selection?.totalLines);
+	});
+
+	it("throws UnknownVerificationStepError listing available names for an unknown step", () => {
+		assert.throws(
+			() => makeMultiStepSnapshot("nope"),
+			(err: unknown) => {
+				assert.ok(err instanceof UnknownVerificationStepError);
+				assert.deepEqual(err.availableSteps, ["build", "unit", "lint"]);
+				assert.match(err.message, /Unknown verification step "nope"\. Available steps: build, unit, lint/);
+				return true;
+			},
+		);
+	});
+
+	it("applies grep selection to the targeted step only", () => {
+		const snapshot = makeMultiStepSnapshot("unit", { mode: "grep", pattern: "ERROR|failed", context: 1 });
+		assert.equal(snapshot.steps.length, 1);
+		const step = snapshot.steps[0];
+		assert.equal(step.name, "unit");
+		assert.match(step.output ?? "", /ERROR failed sentinel/);
+		assert.doesNotMatch(step.output ?? "", /unit-tail-50/);
+		assert.equal(step.selection?.mode, "grep");
+	});
+
+	it("applies slice selection to the targeted step only", () => {
+		const snapshot = makeMultiStepSnapshot("build", { mode: "slice", from: 2, to: 4 });
+		assert.equal(snapshot.steps.length, 1);
+		const step = snapshot.steps[0];
+		assert.equal(step.name, "build");
+		assert.match(step.output ?? "", /^2\b.*build-out-2/m);
+		assert.match(step.output ?? "", /^4\b.*build-out-4/m);
+		assert.doesNotMatch(step.output ?? "", /build-out-5\b/);
+		assert.equal(step.selection?.mode, "slice");
+		assert.deepEqual(step.selection?.range, { from: 2, to: 4 });
+	});
+});
 
 describe("gate verification active live command log reads", () => {
 	it("default tail selection reads a bounded suffix and exposes the last 20 live log lines", () => {


### PR DESCRIPTION
## What

Adds an optional `step` parameter (verification step **name**) to the `gate_inspect` tool, letting callers scope `section="verification"` to a single step instead of always receiving every step's output.

## Behavior

- `step` omitted → all steps returned (unchanged).
- `step` set + `section="verification"` → only that one step (single-element `steps[]`); the selection mode (grep/tail/slice/head) applies to that step's output.
- Unknown step name → HTTP 400 listing the available step names.
- `step` with `section="content"` / `"signals"` → HTTP 400 (`step is only valid with section='verification'`).

Targeting is by name only (no index selector). Step names are surfaced via `gate_status.failedSteps` and each step's `name`.

## Changes

- `src/server/gate-verification-snapshot.ts` — optional `stepName` input; exported `UnknownVerificationStepError` (carries `availableSteps`). Full step map runs unchanged; narrows to the matched step before the aggregate budget pass, recomputing counts/summary/aggregate selection.
- `src/server/server.ts` — `/inspect` reads `step` query param, validates section, maps the error to 400.
- `defaults/tools/tasks/extension.ts` + `gate_inspect.yaml` — param plumbing and docs (param desc ≤80, budget green).
- UI `GateInspectRenderer.ts` — unchanged; already maps over `data.steps`, so a single-element array renders one card.
- Docs: `docs/goals-workflows-tasks.md`, `docs/rest-api.md`.

## Tests

- Unit: `tests/gate-verification-snapshot.test.ts` (single step, unknown name error, grep/slice scoping, omitted unchanged).
- E2E: `tests/e2e/gate-inspect-slicing.spec.ts` (one step returned, unknown → 400, content+step → 400, grep scoping).
- `npm run check`, unit, and gate-inspect e2e all green; tool-description-budget test green.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)