### PR TITLE
PRs on forks rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,8 @@ Primary branch is **`master`** (not `main`). Never create a `main` branch.
 
 **Always edit files in your session worktree, never in the primary worktree.** For infra files: edit here → commit → push → pull from primary. Pushing to remote `master` does NOT update the dev server — `cd <primary-worktree> && git pull origin master`.
 
+**Opening PRs on fork**: when working on forks of the main repository, make sure to open PRs on fork master branch not the original repository master branch. 
+
 See [docs/dev-workflow.md](docs/dev-workflow.md) for the full worktree story — including the worktree-stash hazard (never `git stash` in a session worktree).
 
 ## Maintaining this file


### PR DESCRIPTION
Cherry-picks the changes from maciej-makowski/bobbit#8 onto upstream `master`.

Adds an "Opening PRs on fork" guidance line to `AGENTS.md`: when working on forks of the main repository, open PRs against the fork's `master` branch rather than the original repository's `master`.

### Changes
- `AGENTS.md`: one-line addition under the Git conventions / worktree section.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)