### PR TITLE
Default subgoals off

### DIFF
--- a/docs/design/production-subgoals-port.md
+++ b/docs/design/production-subgoals-port.md
@@ -176,8 +176,9 @@ Port all `tests/**` named in #497 except `*lsp*`/`tests/lsp/**`/
   flags. Team-lead at `depth == maxDepth` cannot spawn any child.
 - Server-side enforcement on both spawn paths: `403 SUBGOALS_DISABLED` /
   `403 NESTING_DEPTH_EXCEEDED`.
-- System `subgoalsEnabled` is the master gate; **default flipped ON** in
-  production (the one deliberate deviation from #497, which defaults OFF).
+- System `subgoalsEnabled` is the master gate; **defaults OFF**, aligned with
+  #497 (an earlier production deviation that flipped it ON has been reverted —
+  unset/missing reads as disabled, only an explicit `true` enables it).
 - Children merge locally into parent branch (`git merge --no-ff`); only root
   raises a PR; conflicts `git merge --abort` + preserve child.
 - Per-root concurrency semaphore (default 3, floor 1, max 8) is the scheduler.
@@ -200,12 +201,18 @@ Port all `tests/**` named in #497 except `*lsp*`/`tests/lsp/**`/
   spawn path returns `409 GOAL_PAUSED`; boot respawn supervisor skips paused
   goals.
 
-## Production deviation from #497
+## Production deviation from #497 (reverted)
 
-In `readSubgoalNestingPrefs` / the system prefs default, flip
-`subgoalsEnabled` default from `false` to `true`. Update the corresponding
-unit/E2E expectation accordingly. This is the only intentional behavioural
-change; everything else is verbatim.
+An earlier production build deviated from #497 by flipping the
+`subgoalsEnabled` default from `false` to `true` in `readSubgoalNestingPrefs` /
+the system prefs default. **That deviation has been reverted**: the default is
+now `false` (OFF), matching #497. Every `subgoalsEnabled !== false` (unset →
+enabled) read was inverted to `subgoalsEnabled === true` (unset → disabled), and
+the UI dataset mirror (`document.documentElement.dataset.subgoalsEnabled`)
+defaults to `"false"` when the preference is unset. Sub-goals are now an
+experimental, opt-in feature; the user enables them via
+Settings → System → General → Subgoals. There are no remaining intentional
+behavioural deviations from #497.
 
 ## Architecture / API contracts (self-contained)
 

--- a/docs/nested-goals.md
+++ b/docs/nested-goals.md
@@ -25,22 +25,30 @@ drift away from the approved acceptance criteria.
 
 Sub-goals are gated at two levels. Both must be on for a goal to spawn children.
 
-### 1. System preference (master gate, default ON)
+### 1. System preference (master gate, default OFF)
 
 **Settings → System → General → Subgoals** (`data-testid="general-subgoals-enabled"`).
 This is the master switch. When it is OFF, the per-goal controls are hidden and
 no goal can spawn children regardless of its own flags — a per-goal flag can
 never override a system-level OFF.
 
-The toggle is **defaulted ON in production**. (This is the one intentional
-deviation from the reference PR #497, which shipped it OFF behind an
-experimental flag.)
+The toggle **defaults OFF**. Sub-goals are an experimental, opt-in capability:
+on a fresh install with no stored preference, subgoals read as disabled
+everywhere and the user must explicitly enable them here. Only an explicit
+stored `true` enables subgoals — an unset/missing preference reads as disabled.
+This aligns with the reference PR #497's original OFF default; an earlier
+production build deviated by shipping this ON, and that deviation has since been
+reverted.
+
+The server is the single source of truth for this gate. The toggle state is
+mirrored to `document.documentElement.dataset.subgoalsEnabled` (a UX-only flag,
+defaulting to `"false"` when the preference is unset) synchronously on change so
+the proposal form and other client-side gate sites flip immediately, without
+waiting on the `preferences_changed` broadcast.
 
 Beneath it, **Max subgoal depth** (`data-testid="general-max-nesting-depth"`) is
-a stepper clamped to `1..10` that sets the **system ceiling** for nesting depth.
-The toggle state is mirrored to `document.documentElement.dataset.subgoalsEnabled`
-synchronously on change so the proposal form and other client-side gate sites
-flip immediately, without waiting on the `preferences_changed` broadcast.
+a stepper clamped to `1..10` that sets the **system ceiling** for nesting depth
+(default 3).
 
 ### 2. Per-goal proposal controls
 

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -538,9 +538,9 @@ async function initApp() {
 					// Apply playAgentFinishSound — default ON when unset.
 					document.documentElement.dataset.playAgentFinishSound =
 						prefs.playAgentFinishSound === false ? "false" : "true";
-					// Apply subgoalsEnabled — default ON (only explicit false opts out).
+					// Apply subgoalsEnabled — default OFF (only explicit true opts in).
 					document.documentElement.dataset.subgoalsEnabled =
-						prefs.subgoalsEnabled === false ? "false" : "true";
+						prefs.subgoalsEnabled === true ? "true" : "false";
 					// Apply maxNestingDepth — default 3 when unset/invalid.
 					document.documentElement.dataset.maxNestingDepth =
 						(typeof prefs.maxNestingDepth === "number" && Number.isFinite(prefs.maxNestingDepth))
@@ -885,9 +885,9 @@ async function initApp() {
 			// Apply playAgentFinishSound — default ON when unset.
 			document.documentElement.dataset.playAgentFinishSound =
 				prefs.playAgentFinishSound === false ? "false" : "true";
-			// Apply subgoalsEnabled — default ON (only explicit false opts out).
+			// Apply subgoalsEnabled — default OFF (only explicit true opts in).
 			document.documentElement.dataset.subgoalsEnabled =
-				prefs.subgoalsEnabled === false ? "false" : "true";
+				prefs.subgoalsEnabled === true ? "true" : "false";
 			// Apply maxNestingDepth — default 3 when unset/invalid.
 			document.documentElement.dataset.maxNestingDepth =
 				(typeof prefs.maxNestingDepth === "number" && Number.isFinite(prefs.maxNestingDepth))

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -2146,11 +2146,11 @@ export class RemoteAgent {
 				prefs.playAgentFinishSound === false ? "false" : "true";
 		}
 
-		// Apply subgoalsEnabled — default OFF. See subgoals-flag.ts.
-		if ("subgoalsEnabled" in prefs) {
-			document.documentElement.dataset.subgoalsEnabled =
-				prefs.subgoalsEnabled === true ? "true" : "false";
-		}
+		// Apply subgoalsEnabled — default OFF. See subgoals-flag.ts. Mirror
+		// unconditionally: the broadcast sends the full prefs object, so an
+		// unset pref is absent and must normalize to "false" (not retain stale).
+		document.documentElement.dataset.subgoalsEnabled =
+			prefs.subgoalsEnabled === true ? "true" : "false";
 		// Apply maxNestingDepth — default 3 when unset/invalid.
 		if ("maxNestingDepth" in prefs) {
 			document.documentElement.dataset.maxNestingDepth =

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -2170,8 +2170,8 @@ function loadGeneralSettings() {
 					settingsShowTimestamps = !!prefs.showTimestamps;
 					// Default ON when unset — only an explicit `false` opts out.
 					settingsPlayFinishSound = prefs.playAgentFinishSound !== false;
-					// Subgoals (Experimental) — default ON; only explicit false opts out. See docs/nested-goals.md.
-					settingsSubgoalsEnabled = prefs.subgoalsEnabled !== false;
+					// Subgoals (Experimental) — default OFF; only an explicit `true` enables. See docs/nested-goals.md.
+					settingsSubgoalsEnabled = prefs.subgoalsEnabled === true;
 					const rawDepth = prefs.maxNestingDepth;
 					settingsMaxNestingDepth = (typeof rawDepth === "number" && Number.isFinite(rawDepth)) ? rawDepth : null;
 					const raw = prefs.skillsCatalogBudget;

--- a/src/app/subgoals-flag.ts
+++ b/src/app/subgoals-flag.ts
@@ -7,18 +7,18 @@
  * `settings-page.ts`. Callers consult this helper from UI gate sites without
  * having to await preferences.
  *
- * Default ON — only an explicit stored `false` (mirrored as the string
- * `"false"`) reads as disabled. A missing/undefined dataset value reads as
- * enabled, matching the server's unset → enabled default.
- * See docs/design/subgoals-experimental-toggle.md.
+ * Default OFF — only an explicit stored `true` (mirrored as the string
+ * `"true"`) reads as enabled. A missing/undefined dataset value reads as
+ * disabled, matching the server's unset → disabled default.
+ * See docs/nested-goals.md.
  */
 
 let testOverride: boolean | undefined;
 
 export function isSubgoalsEnabled(): boolean {
 	if (testOverride !== undefined) return testOverride;
-	if (typeof document === "undefined") return true;
-	return document.documentElement.dataset.subgoalsEnabled !== "false";
+	if (typeof document === "undefined") return false;
+	return document.documentElement.dataset.subgoalsEnabled === "true";
 }
 
 /**

--- a/src/server/agent/subgoal-nesting-limit.ts
+++ b/src/server/agent/subgoal-nesting-limit.ts
@@ -9,7 +9,7 @@
  *     effective value — system is the ceiling, descendants can only tighten).
  *
  * Plus the gate:
- *   - system pref `subgoalsEnabled` (default true in production; unset reads as enabled).
+ *   - system pref `subgoalsEnabled` (default false; unset reads as disabled).
  *   - per-goal optional override `subgoalsAllowed` (can disable but not
  *     enable when system is OFF — system is the ceiling).
  *
@@ -32,9 +32,9 @@ export interface SubgoalNestingPrefs {
 export function readSubgoalNestingPrefs(
 	prefsGet: (key: string) => unknown,
 ): SubgoalNestingPrefs {
-	// Production deviation from PR #497: subgoals default ON. An unset pref reads
-	// as enabled; only an explicit `false` disables the system-wide gate.
-	const subgoalsEnabled = prefsGet("subgoalsEnabled") !== false;
+	// Subgoals default OFF (aligned with PR #497). An unset pref reads as
+	// disabled; only an explicit `true` enables the system-wide gate.
+	const subgoalsEnabled = prefsGet("subgoalsEnabled") === true;
 	const rawDepth = prefsGet("maxNestingDepth");
 	const depth = (typeof rawDepth === "number" && Number.isFinite(rawDepth))
 		? rawDepth

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -896,7 +896,7 @@ export function createGateway(config: GatewayConfig) {
 	// `never` at policy time — silently dropped from every team-lead's tool
 	// surface. See docs/design/subgoals-experimental-toggle.md.
 	// Production deviation from PR #497: subgoals default ON — unset reads as enabled.
-	groupPolicyStore.setSubgoalsEnabledGetter(() => preferencesStore.get("subgoalsEnabled") !== false);
+	groupPolicyStore.setSubgoalsEnabledGetter(() => preferencesStore.get("subgoalsEnabled") === true);
 
 	const configCascade = new ConfigCascade(builtinConfigProvider, {
 		getRoles: () => roleStore.getAllLocal(),
@@ -2250,8 +2250,8 @@ async function handleApiRoute(
 
 	/** Subgoals feature gate. Writes 403 SUBGOALS_DISABLED + returns false when off. */
 	function requireSubgoalsEnabled(): boolean {
-		// Production deviation from PR #497: subgoals default ON — unset reads as enabled.
-		if (preferencesStore.get("subgoalsEnabled") !== false) return true;
+		// Subgoals default OFF (aligned with PR #497) — only an explicit `true` enables.
+		if (preferencesStore.get("subgoalsEnabled") === true) return true;
 		json({ error: "Subgoals are disabled", code: "SUBGOALS_DISABLED" }, 403);
 		return false;
 	}

--- a/tests/e2e/api-subgoals-disabled.spec.ts
+++ b/tests/e2e/api-subgoals-disabled.spec.ts
@@ -5,7 +5,7 @@
  * processing. With the flag ON, the gate is transparent (the request
  * proceeds and may fail for unrelated reasons — we just assert non-403).
  *
- * See docs/design/subgoals-experimental-toggle.md.
+ * See docs/nested-goals.md.
  */
 import { test, expect } from "./in-process-harness.js";
 import { apiFetch, gitCwd } from "./e2e-setup.js";
@@ -16,6 +16,15 @@ async function setSubgoalsEnabled(enabled: boolean): Promise<void> {
 	const resp = await apiFetch("/api/preferences", {
 		method: "PUT",
 		body: JSON.stringify({ subgoalsEnabled: enabled }),
+	});
+	expect(resp.status).toBe(200);
+}
+
+/** Remove the stored pref entirely (PUT null) so the server sees an unset value. */
+async function unsetSubgoalsEnabled(): Promise<void> {
+	const resp = await apiFetch("/api/preferences", {
+		method: "PUT",
+		body: JSON.stringify({ subgoalsEnabled: null }),
 	});
 	expect(resp.status).toBe(200);
 }
@@ -72,6 +81,21 @@ test.describe("Subgoals (Experimental) feature gate — REST routes", () => {
 
 	test("all nine routes return 403 SUBGOALS_DISABLED when flag is off @smoke", async () => {
 		await setSubgoalsEnabled(false);
+		const goal = await createGoalReady();
+		for (const route of ROUTES) {
+			const opts: RequestInit = { method: route.method };
+			if (route.body) opts.body = JSON.stringify(route.body);
+			const resp = await apiFetch(route.path(goal.id), opts);
+			expect(resp.status, `${route.name} status`).toBe(403);
+			const json = await resp.json().catch(() => ({}));
+			expect(json.code, `${route.name} code`).toBe("SUBGOALS_DISABLED");
+		}
+	});
+
+	test("all nine routes return 403 SUBGOALS_DISABLED on a fresh install (pref unset)", async () => {
+		// Unset the pref entirely (no stored value) — the new default reads OFF,
+		// so the REST layer must enforce SUBGOALS_DISABLED end-to-end.
+		await unsetSubgoalsEnabled();
 		const goal = await createGoalReady();
 		for (const route of ROUTES) {
 			const opts: RequestInit = { method: route.method };

--- a/tests/e2e/ui/subgoals-experimental-toggle.spec.ts
+++ b/tests/e2e/ui/subgoals-experimental-toggle.spec.ts
@@ -15,7 +15,7 @@
  */
 import { test, expect } from "../gateway-harness.js";
 import { apiFetch } from "../e2e-setup.js";
-import { openApp, navigateToHash } from "./ui-helpers.js";
+import { openApp, navigateToHash, sendMessage, createSessionViaUI } from "./ui-helpers.js";
 
 /** Reset the flag at the API layer so each test starts deterministically. */
 async function resetFlag(value: boolean): Promise<void> {
@@ -157,5 +157,97 @@ test.describe("Subgoals (Experimental) toggle", () => {
 		await navigateToHash(page, "#/settings/system/general");
 		const final = page.locator("[data-testid='general-subgoals-enabled']");
 		await expect(final).toBeChecked();
+	});
+
+	test("ON→OFF cleanup: flip OFF from ON and the dataset / checkbox agree across reload", async ({ page }) => {
+		await resetFlag(true);
+		await openApp(page);
+		await navigateToHash(page, "#/settings/system/general");
+
+		const checkbox = page.locator("[data-testid='general-subgoals-enabled']");
+		await expect(checkbox).toBeVisible({ timeout: 10_000 });
+		await expect(checkbox).toBeChecked();
+		await expect.poll(
+			() => page.evaluate(() => document.documentElement.dataset.subgoalsEnabled),
+		).toBe("true");
+
+		const offResp = page.waitForResponse(
+			r => r.url().includes("/api/preferences") && r.request().method() === "PUT" && r.status() === 200,
+		);
+		await checkbox.click();
+		await expect(checkbox).not.toBeChecked();
+		await offResp;
+		await expect.poll(
+			() => page.evaluate(() => document.documentElement.dataset.subgoalsEnabled),
+		).toBe("false");
+
+		// Reload — still OFF.
+		await page.reload();
+		await expect(
+			page.locator("button").filter({ hasText: "Settings" }).first(),
+		).toBeVisible({ timeout: 15_000 });
+		await navigateToHash(page, "#/settings/system/general");
+		const final = page.locator("[data-testid='general-subgoals-enabled']");
+		await expect(final).toBeVisible({ timeout: 5_000 });
+		await expect(final).not.toBeChecked();
+		await expect.poll(
+			() => page.evaluate(() => document.documentElement.dataset.subgoalsEnabled),
+		).toBe("false");
+
+		// Restore the harness default for subsequent specs/tests.
+		await resetFlag(true);
+	});
+
+	test("proposal panel renders the per-goal subgoal controls when subgoals are ON", async ({ page }) => {
+		// The per-goal Allow-subgoals / Max-depth controls live on the
+		// regular-session goal-proposal panel (renderGoalForm wired with
+		// onSubgoalsAllowedChange + subgoalsEnabled), gated by isSubgoalsEnabled().
+		// Set the pref BEFORE opening the app so the dataset flag is correct on
+		// first paint (isSubgoalsEnabled() reads the dataset at render time).
+		await resetFlag(true);
+		await openApp(page);
+		await createSessionViaUI(page);
+
+		// Mock agent emits a propose_goal titled "E2E Test Goal" when the prompt
+		// contains "GOAL_PROPOSAL".
+		await sendMessage(page, "Please create a GOAL_PROPOSAL for testing");
+
+		const titleInput = page.locator("input[placeholder='Goal title']").first();
+		await expect(titleInput).toBeVisible({ timeout: 20_000 });
+		await expect(titleInput).toHaveValue("E2E Test Goal", { timeout: 15_000 });
+
+		// With subgoals ON, the Allow-subgoals control is present.
+		const subgoalsToggle = page.locator("[data-testid='goal-form-subgoals-toggle']");
+		await expect(subgoalsToggle).toBeVisible({ timeout: 10_000 });
+		// Enabling Allow-subgoals reveals the Max-depth input.
+		await subgoalsToggle.click();
+		await expect(
+			page.locator("[data-testid='goal-form-max-depth']"),
+		).toBeVisible({ timeout: 10_000 });
+	});
+
+	test("proposal panel hides the per-goal subgoal controls when subgoals are OFF/unset", async ({ page }) => {
+		// Unset the pref (fresh-install default) BEFORE opening the app so the
+		// dataset reads "false" on first paint.
+		await unsetFlag();
+		await openApp(page);
+		await createSessionViaUI(page);
+
+		await sendMessage(page, "Please create a GOAL_PROPOSAL for testing");
+
+		const titleInput = page.locator("input[placeholder='Goal title']").first();
+		await expect(titleInput).toBeVisible({ timeout: 20_000 });
+		await expect(titleInput).toHaveValue("E2E Test Goal", { timeout: 15_000 });
+
+		// With subgoals OFF, neither per-goal control is rendered.
+		await expect(
+			page.locator("[data-testid='goal-form-subgoals-toggle']"),
+		).toHaveCount(0);
+		await expect(
+			page.locator("[data-testid='goal-form-max-depth']"),
+		).toHaveCount(0);
+
+		// Restore the harness default for subsequent specs/tests.
+		await resetFlag(true);
 	});
 });

--- a/tests/e2e/ui/subgoals-experimental-toggle.spec.ts
+++ b/tests/e2e/ui/subgoals-experimental-toggle.spec.ts
@@ -10,7 +10,8 @@
  *   4. Cleanup/undo — flip back ON, dataset and checkbox state agree.
  *
  * The harness defaults `subgoalsEnabled: true`. Each test resets via the
- * REST PUT it exercises, so cross-test interference is avoided.
+ * REST PUT it exercises, so cross-test interference is avoided. A fresh
+ * install (no stored pref) now reads as disabled — the default is OFF.
  */
 import { test, expect } from "../gateway-harness.js";
 import { apiFetch } from "../e2e-setup.js";
@@ -38,21 +39,21 @@ async function unsetFlag(): Promise<void> {
 }
 
 test.describe("Subgoals (Experimental) toggle", () => {
-	test("defaults ON when the pref is unset, and persists across reload", async ({ page }) => {
-		// Production default: unset/missing reads as enabled (mirrors the server's
-		// `subgoalsEnabled !== false` gate). G1 fix — UI must not default OFF.
+	test("defaults OFF when the pref is unset, and persists across reload", async ({ page }) => {
+		// Fresh-install default: unset/missing reads as disabled (mirrors the
+		// server's `subgoalsEnabled === true` gate). The user opts in via Settings.
 		await unsetFlag();
 		await openApp(page);
 		await navigateToHash(page, "#/settings/system/general");
 
 		const checkbox = page.locator("[data-testid='general-subgoals-enabled']");
 		await expect(checkbox).toBeVisible({ timeout: 10_000 });
-		await expect(checkbox).toBeChecked();
+		await expect(checkbox).not.toBeChecked();
 		await expect.poll(
 			() => page.evaluate(() => document.documentElement.dataset.subgoalsEnabled),
-		).toBe("true");
+		).toBe("false");
 
-		// Reload — still ON (pref still unset, default holds).
+		// Reload — still OFF (pref still unset, default holds).
 		await page.reload();
 		await expect(
 			page.locator("button").filter({ hasText: "Settings" }).first(),
@@ -60,10 +61,10 @@ test.describe("Subgoals (Experimental) toggle", () => {
 		await navigateToHash(page, "#/settings/system/general");
 		const afterReload = page.locator("[data-testid='general-subgoals-enabled']");
 		await expect(afterReload).toBeVisible({ timeout: 5_000 });
-		await expect(afterReload).toBeChecked();
+		await expect(afterReload).not.toBeChecked();
 		await expect.poll(
 			() => page.evaluate(() => document.documentElement.dataset.subgoalsEnabled),
-		).toBe("true");
+		).toBe("false");
 
 		// Restore the harness default for subsequent specs/tests.
 		await resetFlag(true);

--- a/tests/subgoal-nesting-limit.test.ts
+++ b/tests/subgoal-nesting-limit.test.ts
@@ -91,18 +91,18 @@ describe("readSubgoalNestingPrefs", () => {
 	it("returns defaults when prefs are empty", () => {
 		const prefs = new PreferencesStore(stateDir);
 		const r = readSubgoalNestingPrefs((k) => prefs.get(k));
-		// Production default: subgoals are ON unless the pref is explicitly
-		// set to false (an unset pref reads as enabled — see
-		// readSubgoalNestingPrefs `!== false`).
-		assert.equal(r.subgoalsEnabled, true);
+		// Default OFF: subgoals are disabled unless the pref is explicitly
+		// set to true (an unset pref reads as disabled — see
+		// readSubgoalNestingPrefs `=== true`).
+		assert.equal(r.subgoalsEnabled, false);
 		assert.equal(r.maxNestingDepth, SYSTEM_MAX_NESTING_DEPTH_DEFAULT);
 	});
 
-	it("returns subgoalsEnabled=false only when the pref is explicitly false", () => {
+	it("returns subgoalsEnabled=true only when the pref is explicitly true", () => {
 		const prefs = new PreferencesStore(stateDir);
-		prefs.set("subgoalsEnabled", false);
+		prefs.set("subgoalsEnabled", true);
 		const r = readSubgoalNestingPrefs((k) => prefs.get(k));
-		assert.equal(r.subgoalsEnabled, false);
+		assert.equal(r.subgoalsEnabled, true);
 	});
 
 	it("round-trips maxNestingDepth via preferencesStore", () => {

--- a/tests/subgoals-flag.test.ts
+++ b/tests/subgoals-flag.test.ts
@@ -1,6 +1,6 @@
 /**
  * Unit tests for the client-side Subgoals (Experimental) flag helper.
- * See docs/design/subgoals-experimental-toggle.md.
+ * See docs/nested-goals.md.
  */
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
@@ -26,29 +26,29 @@ describe("isSubgoalsEnabled", () => {
 		delete (globalThis as { document?: unknown }).document;
 	});
 
-	it("defaults to true when dataset is unset (default-on)", () => {
-		// This is the path the goal-proposal modal relies on: with no stored
-		// preference the Allow-subgoals toggle + Max-depth control must render.
-		// See src/app/proposal-panels.ts goalProposalPanel() and the G1 fix.
-		assert.equal(isSubgoalsEnabled(), true);
+	it("defaults to false when dataset is unset (default-off)", () => {
+		// With no stored preference the goal-proposal modal must hide the
+		// Allow-subgoals toggle + Max-depth control. The user opts in via
+		// Settings → System → General → Subgoals.
+		assert.equal(isSubgoalsEnabled(), false);
 	});
 
-	it("returns true when dataset value is anything other than 'false'", () => {
-		const root = (globalThis as { document?: { documentElement: { dataset: Record<string, string> } } })
-			.document!.documentElement;
-		root.dataset.subgoalsEnabled = "true";
-		assert.equal(isSubgoalsEnabled(), true);
-		root.dataset.subgoalsEnabled = "1";
-		assert.equal(isSubgoalsEnabled(), true);
-		root.dataset.subgoalsEnabled = "";
-		assert.equal(isSubgoalsEnabled(), true);
-	});
-
-	it("returns false only when dataset value is the explicit string 'false'", () => {
+	it("returns false when dataset value is anything other than 'true'", () => {
 		const root = (globalThis as { document?: { documentElement: { dataset: Record<string, string> } } })
 			.document!.documentElement;
 		root.dataset.subgoalsEnabled = "false";
 		assert.equal(isSubgoalsEnabled(), false);
+		root.dataset.subgoalsEnabled = "1";
+		assert.equal(isSubgoalsEnabled(), false);
+		root.dataset.subgoalsEnabled = "";
+		assert.equal(isSubgoalsEnabled(), false);
+	});
+
+	it("returns true only when dataset value is the explicit string 'true'", () => {
+		const root = (globalThis as { document?: { documentElement: { dataset: Record<string, string> } } })
+			.document!.documentElement;
+		root.dataset.subgoalsEnabled = "true";
+		assert.equal(isSubgoalsEnabled(), true);
 	});
 
 	it("test override wins over dataset", () => {
@@ -62,8 +62,8 @@ describe("isSubgoalsEnabled", () => {
 		assert.equal(isSubgoalsEnabled(), false);
 	});
 
-	it("returns true in non-DOM environments when no test override is set", () => {
+	it("returns false in non-DOM environments when no test override is set", () => {
 		delete (globalThis as { document?: unknown }).document;
-		assert.equal(isSubgoalsEnabled(), true);
+		assert.equal(isSubgoalsEnabled(), false);
 	});
 });


### PR DESCRIPTION
## Summary

Flips the system-scope **Subgoals** feature preference default from **ON → OFF**. On a fresh install (no stored `subgoalsEnabled` preference), subgoals now read as **disabled** everywhere — per-goal proposal controls hidden, Children tools dropped from team-leads, and the nine nested-goal REST routes returning `403 SUBGOALS_DISABLED`. Users opt in via **Settings → System → General → Subgoals**.

This reverts the documented "production deviation from PR #497" (which intentionally shipped the master gate ON); the default now aligns with #497's original OFF default. The semantics invert: only an explicit stored `true` reads as enabled; missing/undefined now reads as disabled. This is a **default-flip only** — no change to per-goal tightening, depth-cap enforcement, or any nesting/governance logic. The server remains the single source of truth; UI gates are UX only.

## Changes — default flip

**Production code** (inverted `subgoalsEnabled !== false` → `=== true`; dataset default `"true"` → `"false"`)
- `src/server/server.ts`: `setSubgoalsEnabledGetter` + `requireSubgoalsEnabled` now use `=== true`; `POST /api/goals` nesting ceiling inherits via `readSubgoalNestingPrefs`.
- `src/server/agent/subgoal-nesting-limit.ts`: `readSubgoalNestingPrefs` uses `=== true`; comments updated.
- `src/app/subgoals-flag.ts`: dataset read `=== "true"`; SSR branch returns `false`.
- `src/app/settings-page.ts`: `settingsSubgoalsEnabled === true`.
- `src/app/main.ts` (both load sites): dataset mirrors `prefs.subgoalsEnabled === true ? "true" : "false"`.
- `src/app/remote-agent.ts`: `preferences_changed` mirror now always runs, normalizing missing/undefined → `"false"` (prevents a stale dataset when the pref is cleared).

**Tests**: unit defaults inverted (`subgoals-flag`, `subgoal-nesting-limit`); fresh-install API E2E (all nine routes → `403 SUBGOALS_DISABLED` with no stored pref); browser E2E for proposal-modal control visibility + ON→OFF cleanup.

**Docs**: `docs/nested-goals.md` + `docs/design/production-subgoals-port.md` updated to default-OFF; #497 deviation note rewritten as reverted.

## Changes — bundled pre-existing test fixes (child goal)

This branch also merges a child goal that fixes two **pre-existing** unit-test failures introduced by the `#714` "Production sub-goals system" merge (unrelated to the default flip, but they failed `npm run test:unit` on master):
- **`tests/agents-md-budget.test.ts`**: `AGENTS.md` was 6319 bytes (over the 6144 cap) → trimmed to 5870 bytes without losing essential guidance.
- **`tests/nested-goal-routes-findings.test.ts`** (3 tests): `spawn-child` returned 400 vs expected 201 — fixed at the correct layer.

Both suites now pass (19/19).

## Verification
- `npm run check` clean; affected unit + E2E suites green; the two formerly-failing suites now pass.
- design-doc, implementation, documentation, and ready-to-merge workflow gates all passed (for both the parent and child goals).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)