### PR TITLE
Sub-goal configurability: propose_goal fields, default reconciliation, prompt gating

### DIFF
--- a/defaults/roles/assistant/goal.yaml
+++ b/defaults/roles/assistant/goal.yaml
@@ -30,6 +30,7 @@ prompt: |
 
   Pick the workflow that best fits. When in doubt, use **general**.
 
+  {if:subGoalsEnabled}
   ### When to pick `parent` (nested goals)
 
   The `parent` workflow is for goals that NATURALLY DECOMPOSE into multiple independent units of work, each of which itself benefits from a full goal lifecycle (own team, own gates, own merge). Strong signals:
@@ -42,15 +43,40 @@ prompt: |
   When `parent` is picked, the team lead will write a charter, propose a plan of subgoals (via `goal_plan_propose`), freeze it via the `goal-plan` gate, then watch children spawn in parallel. Each child runs its own workflow (default `feature`) and merges locally back into the parent's branch when its `ready-to-merge` gate passes. Only the root parent raises a PR to master.
 
   If the goal is a single chunk of work (one feature, one bug fix, one refactor), pick `feature` / `bug-fix` / `general` — NOT `parent`. Parent has overhead (charter + plan-review + goal-plan gates) that's wasted on single-shot work.
+  {endif:subGoalsEnabled}
 
   ## Proposing a goal
 
-  When ready, call the `propose_goal` tool with these parameters:
+  When ready, call the `propose_goal` tool. Everything the user can set on the
+  proposal panel is configurable from the tool — set what you already know so
+  the panel opens pre-filled rather than leaving the user to discover and flip
+  controls themselves. Parameters:
+
+  **Core**
   - **title**: Short 2-5 word title (must be under 29 characters)
   - **spec**: Markdown spec content. Include: brief description of what needs to be done, key requirements or acceptance criteria, constraints or edge cases discussed, technical approach notes if relevant
   - **workflow**: Workflow ID (e.g. "general", "feature", "bug-fix")
   - **options**: (optional) Comma-separated step names matching optional steps in the workflow to pre-enable them (e.g. "QA testing")
   - **cwd**: (optional) Working directory override path, if the user asks to change it
+
+  {if:subGoalsEnabled}
+  **Sub-goals & nesting** (the proposal panel's "Sub-goals" tab)
+  - **parentGoalId**: (optional) Make this a subgoal of an existing goal in the same project. Inside a team-lead session the server auto-fills this from the current goal; omit for a top-level goal.
+  - **subgoalsAllowed**: (optional, boolean) Allow the team lead to spawn sub-goals for this goal. Defaults OFF — only set `true` when the work naturally decomposes (the same signals as the `parent` workflow above).
+  - **maxNestingDepth**: (optional, integer ≥1) Per-goal cap on how deep sub-goals may nest. Clamped to the global ceiling at accept time.
+
+  **Tree orchestration** (root-only — only meaningful on a top-level goal; children inherit the root's values)
+  - **divergencePolicy**: (optional) How much the team lead may replan on its own: `strict` (approve every change), `balanced` (auto-apply minor fix-ups; default), `autonomous` (most self-directed). Hard floors always apply regardless — dropping acceptance criteria and unpaused restructures are always blocked.
+  - **maxConcurrentChildren**: (optional, integer 1–8) How many child teams may run in parallel across the tree. Defaults to 5; raise it (up to 8) for more throughput, lower it when token/compute cost is the constraint.
+
+  The last two (`divergencePolicy`, `maxConcurrentChildren`) only apply to a top-level goal; children inherit the root's values, so don't set them on a subgoal.
+  {endif:subGoalsEnabled}
+
+  **Ephemeral roles / workflow** (rarely needed — prefer reusing existing ones)
+  - **inlineRoles**: (optional) A `Record<roleName, Role>` of one-off roles that matter only for THIS goal. For roles other goals will need, use `propose_role` instead.
+  - **inlineWorkflow**: (optional) A full Workflow object snapshotted onto the goal when the project's existing workflows don't fit. For workflows other goals will need, add it to the project instead.
+
+  Only set the optional fields you have a real reason to set — don't fill them in speculatively.
 
   Keep the spec focused and actionable — it will be injected into every coding agent session's context window for this goal. Don't pad it with generic advice. Every line should be specific to THIS goal.
 

--- a/defaults/roles/team-lead.yaml
+++ b/defaults/roles/team-lead.yaml
@@ -28,7 +28,9 @@ updatedAt: 1775088361805
 promptTemplate: |
   You are the **Team Lead** (id: {{AGENT_ID}}) orchestrating a team of coding agents.
 
+  {if:subGoalsEnabled}
   **Goal nesting awareness:** If you are a child goal's team-lead, you DO NOT raise PRs — your branch merges locally into your parent. Only the root goal opens a PR to master. Read the "Goal nesting context" stanza below for your specific role; it tells you whether you're root or child.
+  {endif:subGoalsEnabled}
 
   ## Your Role
   You plan, delegate, and coordinate — you do NOT write production code or tests yourself.
@@ -90,6 +92,7 @@ promptTemplate: |
   - **gate_status** — Get latest signal details for a gate — verdict, truncated failed-step output, and metadata. Param: `gate_id`.
   - **gate_inspect** — Read bounded gate content, verification output, or signal history. Params: `gate_id`, `section` ("content"/"verification"/"signals"), optional `signal_index`, `mode` ("grep"/"tail"/"head"/"slice"/"full"), `step` (verification step name — scopes `section="verification"` to one step), `pattern`, `context`, `max_results`, `lines`, `from`, `to`.
 
+  {if:subGoalsEnabled}
   ### Children Management (pause / resume)
 
   Pause semantics: `goal.paused` is operator-only. Set ONLY by `goal_pause`, cleared ONLY by `goal_resume`. The scheduler never touches it. (Children blocked by `dependsOn` use `state: 'blocked'` instead — don't conflate the two.)
@@ -100,6 +103,24 @@ promptTemplate: |
   - Resume mirrors pause with the same `childGoalId` / `cascade` semantics.
 
   Cascade-pause uses a soft abort: workers' current LLM turns are interrupted but their sessions stay registered for resume. Your own session is excluded from the abort sweep so calling `goal_pause` never kills your own turn.
+
+  ### Sub-goal controls & orchestration knobs
+
+  Whether and how you may nest sub-goals is governed by per-goal settings — the user sets them on the goal proposal panel, and you can adjust the tree-wide ones at runtime via `goal_set_policy`. Know them before you plan:
+
+  - **Can you nest at all?** `goal_spawn_child` / `goal_plan_propose` return **403 `SUBGOALS_DISABLED`** when this goal does not allow sub-goals, and **403 `NESTING_DEPTH_EXCEEDED`** (with `currentDepth` / `maxDepth`) when you are already at the nesting ceiling. Sub-goal spawning defaults OFF unless the user enabled it for this goal. If you hit either error, do NOT retry — complete the work with a flat team of role agents (`team_spawn`) instead.
+
+  - **How many children run at once — `maxConcurrentChildren` (root-only, clamped to 1–8, default 5).** This is the tree-wide cap on *child goals* running in parallel. It is SEPARATE from the "up to 12 role agents" limit — that limit is role agents inside a single goal; this one is child goals (each with its own team-lead). When your plan has more ready children than the cap, the surplus queue and start as running ones finish — this is normal, and additive to `dependsOn` blocking. Only the root goal's value is consulted; children inherit it. Change it for this tree with `goal_set_policy({ maxConcurrentChildren: N })` as throughput-vs-cost trade-offs shift.
+
+  - **How much you may replan on your own — `divergencePolicy` (root-only: `strict` | `balanced` | `autonomous`, default `balanced`).** Once your plan is frozen, `goal_plan_propose` runs each change through a classifier:
+    - *No-op / fix-up* (tweaks at the same or an earlier phase) — applied directly under `balanced`/`autonomous`; held for approval under `strict`.
+    - *Expansion* (new work at a later phase) — always held for approval.
+    - *Restructure* (removing a step, pulling a phase earlier, rewiring `dependsOn`) — rejected unless the goal is paused first, then held for approval.
+    - *Criteria-drop* (a root acceptance criterion would become uncovered) — **always rejected**; no policy overrides this.
+    When a change is held, `goal_plan_propose` returns a `requestId`; resolve it with `goal_decide_mutation(requestId, "approve" | "reject")` (the user can also approve/reject from the dashboard). Runaway replanning is back-stopped: once `replanCount` exceeds 5 the goal auto-pauses. Adjust autonomy for this tree with `goal_set_policy({ divergencePolicy: "..." })`.
+
+  These knobs only matter once you are orchestrating sub-goals. For a single-team goal you can ignore them entirely.
+  {endif:subGoalsEnabled}
 
   ## Available Roles
 
@@ -265,7 +286,9 @@ promptTemplate: |
 
   ## Startup Sequence
   1. **The goal spec is in your first user message** — read it carefully before doing anything else. Do NOT call `view_goal_spec` on startup; it's only for re-reading after a `goal_spec_changed` notification.
+  {if:subGoalsEnabled}
   2. **If the goal has more than one subgoal**: call `goal_plan_propose` with the **full DAG** (all steps, all `dependsOn` wired) before spawning anything — even the first wave. Never call `goal_spawn_child` directly for a multi-step plan; direct spawns bypass plan tracking and the classifier/freeze flow. If `goal_plan_propose` returns `warning: "degraded-execution"`, the workflow has no `execution` gate; `dependsOn` is enforced via auto-pause but classifier/freeze is unavailable. `blockedCount`/`blockedPlanIds` in the response identify which children are waiting.
+  {endif:subGoalsEnabled}
   3. `git checkout {{GOAL_BRANCH}}` (create if needed).
   4. Identify the workflow and its gate DAG from the spec and `gate_list`.
   5. Check existing gates via `gate_list` — resume from where things left off.

--- a/defaults/tools/children/goal_set_policy.yaml
+++ b/defaults/tools/children/goal_set_policy.yaml
@@ -6,7 +6,7 @@ provider:
   extension: extension.ts
 group: Children
 docs: |-
-  Optional: `divergencePolicy` (`"strict" | "balanced" | "autonomous"`), `maxConcurrentChildren` (1..8). Both default unset (server defaults: `"balanced"`, 3). `maxConcurrentChildren` is only consulted on root goals; children store the value but the harness reads the root's. Returns 200 `{ ok: true }`.
+  Optional: `divergencePolicy` (`"strict" | "balanced" | "autonomous"`), `maxConcurrentChildren` (1..8). Both default unset (server defaults: `"balanced"`, 5). `maxConcurrentChildren` is only consulted on root goals; children store the value but the harness reads the root's. Returns 200 `{ ok: true }`.
 detail_docs: >-
   ## Purpose
 
@@ -19,4 +19,4 @@ detail_docs: >-
 
 
   `maxConcurrentChildren` is clamped to 1..8 by the harness (Section
-  3.5) regardless of what's stored. Defaults: 3 if unset.
+  3.5) regardless of what's stored. Defaults: 5 if unset.

--- a/defaults/tools/proposals/extension.ts
+++ b/defaults/tools/proposals/extension.ts
@@ -123,6 +123,10 @@ export default function (pi: ExtensionAPI) {
 			workflow: Type.Optional(Type.String({ description: "Workflow ID, e.g. general, feature, bug-fix." })),
 			options: Type.Optional(Type.String({ description: "Comma-separated optional step names." })),
 			parentGoalId: Type.Optional(Type.String({ description: "Parent goal ID for a subgoal; omit for top-level (team-lead auto-fills)." })),
+			subgoalsAllowed: Type.Optional(Type.Boolean({ description: "Allow the team-lead to spawn sub-goals. Default off." })),
+			maxNestingDepth: Type.Optional(Type.Integer({ minimum: 1, description: "Per-goal sub-goal nesting cap; clamped to the global ceiling." })),
+			divergencePolicy: Type.Optional(Type.Union([Type.Literal("strict"), Type.Literal("balanced"), Type.Literal("autonomous")], { description: "Root-only plan-change autonomy (default balanced)." })),
+			maxConcurrentChildren: Type.Optional(Type.Integer({ minimum: 1, maximum: 8, description: "Root-only: max child teams running in parallel, 1-8 (default 5)." })),
 			inlineRoles: Type.Optional(Type.Record(Type.String(), Type.Object({
 				name: Type.String({ description: "Role id (kebab-case); must equal the map key." }),
 				label: Type.String({ description: "Display name." }),

--- a/defaults/tools/proposals/propose_goal.yaml
+++ b/defaults/tools/proposals/propose_goal.yaml
@@ -1,7 +1,7 @@
 name: propose_goal
 description: "Submit goal proposal with title, spec, workflow"
 summary: "Propose a goal for user review"
-params: [title, spec, cwd?, workflow?, options?]
+params: [title, spec, cwd?, workflow?, options?, parentGoalId?, subgoalsAllowed?, maxNestingDepth?, divergencePolicy?, maxConcurrentChildren?, inlineRoles?, inlineWorkflow?]
 provider:
   type: bobbit-extension
   extension: extension.ts
@@ -19,6 +19,16 @@ docs: >-
   in the same project; when called from inside a team-lead session the server
   auto-fills from the current goal so this param is usually omitted; pass the
   id explicitly to override or omit to create a top-level goal).
+
+  SUB-GOAL + ORCHESTRATION SETTINGS (everything a human can set on the
+  proposal panel's Sub-goals tab — set these to pre-fill the panel instead of
+  leaving them to the user at accept time): subgoalsAllowed (boolean — let the
+  team-lead spawn sub-goals; default off), maxNestingDepth (integer ≥1 —
+  per-goal nesting cap, clamped to the global ceiling), divergencePolicy
+  (root-only plan-change autonomy: strict | balanced | autonomous, default
+  balanced), maxConcurrentChildren (root-only integer 1–8 — child teams run in
+  parallel, default 5). The last two are tree-wide and only apply to top-level
+  goals; children inherit the root's values.
 
   EPHEMERAL ROLES (`inlineRoles`): when an existing role doesn't fit and the
   custom role would only matter for THIS goal (e.g. a one-off

--- a/docs/design/production-subgoals-port.md
+++ b/docs/design/production-subgoals-port.md
@@ -181,7 +181,7 @@ Port all `tests/**` named in #497 except `*lsp*`/`tests/lsp/**`/
   unset/missing reads as disabled, only an explicit `true` enables it).
 - Children merge locally into parent branch (`git merge --no-ff`); only root
   raises a PR; conflicts `git merge --abort` + preserve child.
-- Per-root concurrency semaphore (default 3, floor 1, max 8) is the scheduler.
+- Per-root concurrency semaphore (default 5, floor 1, max 8) is the scheduler.
   The shared `ChildTeamScheduler` (`child-team-scheduler.ts`, owned by the
   harness, reached by the REST routes via `verificationHarness.requestChildStart`
   / `notifyChildTerminal`) is the SINGLE authority for ALL child-team starts —

--- a/src/app/proposal-panels.ts
+++ b/src/app/proposal-panels.ts
@@ -754,7 +754,7 @@ function renderSubgoalOrchestration(config: GoalFormConfig): TemplateResult | st
 	if (config.parentGoalId) {
 		const root = findRootGoal(config.parentGoalId);
 		const pol = (root?.divergencePolicy as string) || "balanced";
-		const cc = root?.maxConcurrentChildren ?? 3;
+		const cc = root?.maxConcurrentChildren ?? 5;
 		return html`
 			<div class="rounded-md border border-border bg-muted/40 px-3 py-2 text-[11px] leading-snug text-muted-foreground" data-testid="goal-form-orchestration-inherited">
 				Concurrency and plan-change autonomy are owned by the top-level goal${root ? html` <span class="text-foreground/70 font-medium">${root.title}</span>` : ""} and inherited across the tree: <span class="text-foreground/80 font-medium">${cc} parallel</span> · <span class="text-foreground/80 font-medium">${pol}</span>.
@@ -762,9 +762,10 @@ function renderSubgoalOrchestration(config: GoalFormConfig): TemplateResult | st
 		`;
 	}
 
-	// Root goal: editable controls. Default to the max (8) — favour throughput;
-	// the human dials it down when cost/compute is the constraint.
-	const concurrency = Math.max(1, Math.min(8, config.maxConcurrentChildrenValue ?? 8));
+	// Root goal: editable controls. Display the server's default (5) when the
+	// user hasn't overridden it; submission keeps the field unset in that case
+	// so the server stays the single source of truth for the default.
+	const concurrency = Math.max(1, Math.min(8, config.maxConcurrentChildrenValue ?? 5));
 	const policy = config.divergencePolicyValue ?? "balanced";
 	const activeDesc = DIVERGENCE_OPTS.find(o => o.id === policy)?.desc ?? "";
 	return html`
@@ -2798,6 +2799,8 @@ function syncProposalFormState(): void {
 	const proposal = raw as undefined | {
 		title: string; spec: string; cwd?: string; workflow?: string; options?: string;
 		parentGoalId?: string; inlineWorkflow?: Workflow; inlineRoles?: Record<string, RoleData>;
+		subgoalsAllowed?: boolean; maxNestingDepth?: number;
+		divergencePolicy?: "strict" | "balanced" | "autonomous"; maxConcurrentChildren?: number;
 	};
 	if (!proposal) return;
 
@@ -2828,7 +2831,7 @@ function syncProposalFormState(): void {
 	}
 
 	// Use a simple identity check to avoid re-initializing on every render
-	const key = `${proposal.title}|${proposal.spec}|${proposal.cwd || ""}|${proposal.workflow || ""}|${proposal.options || ""}|${proposal.parentGoalId || ""}`;
+	const key = `${proposal.title}|${proposal.spec}|${proposal.cwd || ""}|${proposal.workflow || ""}|${proposal.options || ""}|${proposal.parentGoalId || ""}|${proposal.subgoalsAllowed ?? ""}|${proposal.maxNestingDepth ?? ""}|${proposal.divergencePolicy ?? ""}|${proposal.maxConcurrentChildren ?? ""}`;
 	if (_proposalInitializedFrom === key) return;
 	_proposalInitializedFrom = key;
 	_proposalTitle = proposal.title;
@@ -2849,10 +2852,16 @@ function syncProposalFormState(): void {
 		? proposal.options.split(",").map(s => s.trim()).filter(Boolean)
 		: [];
 	_proposalSaving = false;
-	_proposalSubgoalsAllowed = null;
-	_proposalMaxNestingDepth = null;
-	_proposalDivergencePolicy = null;
-	_proposalMaxConcurrentChildren = null;
+	// Seed the per-goal nesting + orchestration controls from the proposal so an
+	// agent can pre-set everything a human sets on the Sub-goals tab. Absent
+	// fields fall back to null = "inherit default" (submission still defaults
+	// subgoalsAllowed to off and maxConcurrentChildren to its max).
+	_proposalSubgoalsAllowed = typeof proposal.subgoalsAllowed === "boolean" ? proposal.subgoalsAllowed : null;
+	_proposalMaxNestingDepth = typeof proposal.maxNestingDepth === "number" ? proposal.maxNestingDepth : null;
+	_proposalDivergencePolicy = (proposal.divergencePolicy === "strict" || proposal.divergencePolicy === "balanced" || proposal.divergencePolicy === "autonomous")
+		? proposal.divergencePolicy
+		: null;
+	_proposalMaxConcurrentChildren = typeof proposal.maxConcurrentChildren === "number" ? proposal.maxConcurrentChildren : null;
 }
 
 function goalProposalPanel() {
@@ -2935,10 +2944,13 @@ function goalProposalPanel() {
 				const divergencePolicyField = isRootProposal && allowsChildren && _proposalDivergencePolicy !== null
 					? _proposalDivergencePolicy
 					: undefined;
-				// Default to the max (8) so the created goal matches the value
-				// shown on the tab even when the user never touches the stepper.
-				const maxConcurrentChildrenField = isRootProposal && allowsChildren
-					? (_proposalMaxConcurrentChildren ?? 8)
+				// Only forward an explicit value when the user actually changed the
+				// stepper; an untouched control stays unset so the goal resolves to
+				// the server default (resolveRootMaxConcurrentChildren). This avoids
+				// baking a literal default into stored data and keeps the default a
+				// single source of truth on the server.
+				const maxConcurrentChildrenField = isRootProposal && allowsChildren && _proposalMaxConcurrentChildren !== null
+					? _proposalMaxConcurrentChildren
 					: undefined;
 				// Customised inline workflow takes precedence over the library
 				// workflowId. inlineRoles is only forwarded when non-empty.

--- a/src/server/agent/goal-manager.ts
+++ b/src/server/agent/goal-manager.ts
@@ -801,7 +801,9 @@ export class GoalManager {
 
 	/**
 	 * Per-tree concurrency cap for `runSubgoalStep`. Reads root's
-	 * `maxConcurrentChildren`. Defaults: 3.
+	 * `maxConcurrentChildren`. Defaults: 5 (single source of truth for the
+	 * unset default — the proposal panel only stores a value when the user
+	 * overrides it, so an absent field must resolve to the same default here).
 	 *
 	 * C4: the result is ALWAYS an integer in [1, 8]. A fractional stored
 	 * value (e.g. `1.5`) is floored before clamping so it can never let an
@@ -811,8 +813,8 @@ export class GoalManager {
 	 */
 	resolveRootMaxConcurrentChildren(rootGoalId: string): number {
 		const root = this.store.get(rootGoalId);
-		if (!root) return 3;
-		const raw = Math.floor(Number(root.maxConcurrentChildren ?? 3));
+		if (!root) return 5;
+		const raw = Math.floor(Number(root.maxConcurrentChildren ?? 5));
 		if (!Number.isFinite(raw)) return 1;
 		return Math.max(1, Math.min(8, raw));
 	}

--- a/src/server/agent/prompt-conditionals.ts
+++ b/src/server/agent/prompt-conditionals.ts
@@ -1,0 +1,54 @@
+/**
+ * Conditional-block processor for prompt templates.
+ *
+ * Syntax: `{if:NAME} … {endif:NAME}` — the open and close tags BOTH carry the
+ * flag name so mismatches/nesting are validatable. A block's body is kept iff
+ * `flags[NAME]` is truthy AND every enclosing block is also kept. Blocks may
+ * nest. An unknown flag is treated as false (body removed) — gating fails
+ * closed, never leaking content that was meant to be conditional.
+ *
+ * Tag names match `[A-Za-z0-9_]+`. Surrounding whitespace/newlines are left
+ * as-authored; templates should put tags on their own lines so removal leaves
+ * clean spacing.
+ *
+ * Throws on a malformed template (an `{endif:X}` with no open, a close whose
+ * name doesn't match the innermost open, or an unclosed `{if:X}`). These are
+ * authoring bugs — pinned by tests/prompt-conditionals.test.ts and the
+ * template-validity scan — so failing loud at assembly time is correct.
+ *
+ * Lives in its own module (no imports) so both role-prompt.ts and
+ * team-manager.ts can use it without a circular dependency.
+ */
+export function applyPromptConditionals(text: string, flags: Record<string, boolean>): string {
+	if (!text.includes("{if:") && !text.includes("{endif:")) return text;
+	const re = /\{if:([A-Za-z0-9_]+)\}|\{endif:([A-Za-z0-9_]+)\}/g;
+	let out = "";
+	let lastIndex = 0;
+	let emitting = true;
+	const stack: Array<{ name: string; parentEmitting: boolean }> = [];
+	let m: RegExpExecArray | null;
+	while ((m = re.exec(text)) !== null) {
+		if (emitting) out += text.slice(lastIndex, m.index);
+		lastIndex = re.lastIndex;
+		if (m[1] !== undefined) {
+			// {if:NAME}
+			const name = m[1];
+			stack.push({ name, parentEmitting: emitting });
+			emitting = emitting && !!flags[name];
+		} else {
+			// {endif:NAME}
+			const name = m[2]!;
+			const top = stack.pop();
+			if (!top) throw new Error(`applyPromptConditionals: unmatched {endif:${name}}`);
+			if (top.name !== name) {
+				throw new Error(`applyPromptConditionals: {if:${top.name}} closed by {endif:${name}}`);
+			}
+			emitting = top.parentEmitting;
+		}
+	}
+	if (stack.length > 0) {
+		throw new Error(`applyPromptConditionals: unclosed {if:${stack[stack.length - 1].name}}`);
+	}
+	out += text.slice(lastIndex);
+	return out;
+}

--- a/src/server/agent/role-prompt.ts
+++ b/src/server/agent/role-prompt.ts
@@ -1,4 +1,5 @@
 import { buildAvailableRolesList } from "./team-manager.js";
+import { applyPromptConditionals } from "./prompt-conditionals.js";
 import type { RoleManager } from "./role-manager.js";
 import type { PersistedStaff } from "./staff-store.js";
 
@@ -28,13 +29,17 @@ interface RoleSource {
  */
 export function resolveRolePrompt(
 	role: RoleLike | undefined,
-	ctx: { branch?: string; agentId: string; roleManager?: RoleSource },
+	ctx: { branch?: string; agentId: string; roleManager?: RoleSource; subGoalsEnabled?: boolean },
 ): string | undefined {
 	if (!role?.promptTemplate) return undefined;
 	let p = role.promptTemplate;
 	if (ctx.branch) p = p.replace(/\{\{GOAL_BRANCH\}\}/g, ctx.branch);
 	p = p.replace(/\{\{AGENT_ID\}\}/g, ctx.agentId);
 	p = p.replace(/\{\{AVAILABLE_ROLES\}\}/g, buildAvailableRolesList(ctx.roleManager as any));
+	// Conditional blocks ({if:subGoalsEnabled} … {endif:subGoalsEnabled}) are
+	// resolved LAST so they can wrap any substituted content. No-op for
+	// templates without conditional tags.
+	p = applyPromptConditionals(p, { subGoalsEnabled: ctx.subGoalsEnabled ?? false });
 	return p;
 }
 
@@ -96,6 +101,8 @@ export function buildRestoreRolePrompt(
 		 * view so project-scoped `promptTemplate` overrides survive a restart.
 		 */
 		resolveTemplate?: (roleName: string, projectId?: string) => string | undefined;
+		/** System-scope subgoals feature flag — gates `{if:subGoalsEnabled}` blocks. */
+		subGoalsEnabled?: boolean;
 	},
 ): { rolePrompt?: string; roleName?: string } {
 	if (ps.staffId && ctx.getStaff) {
@@ -112,6 +119,7 @@ export function buildRestoreRolePrompt(
 		branch: ctx.goalBranch,
 		agentId: `${ps.role}-${(ps.goalId || ps.id).slice(0, 8)}`,
 		roleManager: ctx.roleManager,
+		subGoalsEnabled: ctx.subGoalsEnabled,
 	});
 	return { rolePrompt, roleName: rolePrompt ? ps.role : undefined };
 }

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -61,6 +61,7 @@ import { defaultImageModelPref, getAvailableImageModels, parseImageModelPref } f
 import { modelRecencyRank } from "./model-registry.js";
 import { clampThinkingLevel, isKnownThinkingLevel } from "../../shared/thinking-levels.js";
 import { resolveRolePrompt, buildRestoreRolePrompt } from "./role-prompt.js";
+import { applyPromptConditionals } from "./prompt-conditionals.js";
 // createWorktree is used in session-setup.ts pipeline
 import { ProjectContextManager } from "./project-context-manager.js";
 import { GoalStore, type PersistedGoal } from "./goal-store.js";
@@ -1073,6 +1074,16 @@ export class SessionManager {
 		return (this.projectConfigStore?.get("sandbox") || "none") === "docker";
 	}
 
+	/**
+	 * System-scope Subgoals feature flag (experimental; default OFF). Drives
+	 * `{if:subGoalsEnabled}` conditional blocks in role/assistant prompt
+	 * templates so the team-lead/goal-assistant are not told about sub-goal
+	 * tooling that resolves to `never` when the feature is disabled.
+	 */
+	get isSubgoalsEnabled(): boolean {
+		return this.preferencesStore?.get("subgoalsEnabled") === true;
+	}
+
 	/** Get the role manager (used by the staff path to resolve role prompts). */
 	getRoleManager(): RoleManager | undefined {
 		return this.roleManager;
@@ -1697,6 +1708,7 @@ export class SessionManager {
 					}
 				}
 			}
+			assistantGoalSpec = applyPromptConditionals(assistantGoalSpec, { subGoalsEnabled: this.isSubgoalsEnabled });
 			parts = {
 				// Assistant prompt reconstruction must include the base system prompt
 				// so it survives respawn / rebuild paths (not just initial session-setup).
@@ -1720,6 +1732,7 @@ export class SessionManager {
 				branch: goal?.branch,
 				agentId: `${session.role}-${(session.goalId || session.id).slice(0, 8)}`,
 				roleManager: this.roleManager,
+				subGoalsEnabled: this.isSubgoalsEnabled,
 			});
 			const roleName = rolePrompt ? session.role : undefined;
 
@@ -3515,6 +3528,7 @@ export class SessionManager {
 					}
 				}
 			}
+			assistantGoalSpec = applyPromptConditionals(assistantGoalSpec, { subGoalsEnabled: this.isSubgoalsEnabled });
 
 			const promptPath = this.assemblePrompt(ps.id, {
 				// Restore/respawn path: keep the global base prompt so it reaches
@@ -3541,6 +3555,7 @@ export class SessionManager {
 				roleManager: this.roleManager,
 				getStaff: this.staffRecordSource ? (id) => this.staffRecordSource!.getStaff(id) : undefined,
 				resolveTemplate: (rn, pid) => this.resolveRolePromptTemplate(rn, pid),
+				subGoalsEnabled: this.isSubgoalsEnabled,
 			});
 
 			const promptPath = this.assemblePrompt(ps.id, {

--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -20,6 +20,7 @@ import { RpcBridge } from "./rpc-bridge.js";
 import { sanitizeAgentTranscriptFile } from "./transcript-sanitizer.js";
 import { EventBuffer } from "./event-buffer.js";
 import { PromptQueue } from "./prompt-queue.js";
+import { applyPromptConditionals } from "./prompt-conditionals.js";
 import type { SessionStore } from "./session-store.js";
 import type { GoalManager } from "./goal-manager.js";
 import type { TaskManager } from "./task-manager.js";
@@ -72,8 +73,9 @@ function resolveProposalToolsExtPath(ctx: PipelineContext): string {
 function buildNestingContext(
 	goal: import("./goal-store.js").PersistedGoal,
 	goalManager: GoalManager,
+	subGoalsEnabled: boolean,
 ): NestingContext {
-	const ctx: NestingContext = { team: !!goal.team, goalBranch: goal.branch };
+	const ctx: NestingContext = { team: !!goal.team, goalBranch: goal.branch, subGoalsEnabled };
 	if (!goal.team) return ctx;
 	if (goal.parentGoalId) {
 		const parent = goalManager.getGoal(goal.parentGoalId);
@@ -474,6 +476,11 @@ function _resolvePrompt(plan: SessionSetupPlan, ctx: PipelineContext): void {
 				}
 			}
 		}
+		// Resolve {if:subGoalsEnabled} blocks (e.g. the goal assistant's sub-goal
+		// guidance) against the system feature flag, mirroring the team-lead path.
+		assistantGoalSpec = applyPromptConditionals(assistantGoalSpec, {
+			subGoalsEnabled: ctx.groupPolicyStore?.getSubgoalsEnabled?.() ?? false,
+		});
 
 		// Use assistant role's tool restrictions
 		if (assistantRole && ctx.toolManager) {
@@ -550,7 +557,7 @@ function _resolvePrompt(plan: SessionSetupPlan, ctx: PipelineContext): void {
 		// team-leads — before this was populated, the child agent had no
 		// structural awareness that its spec might be parent-flavoured.
 		const nestingContext = plan.roleName === "team-lead" && goal
-			? buildNestingContext(goal, ctx.goalManager)
+			? buildNestingContext(goal, ctx.goalManager, ctx.groupPolicyStore?.getSubgoalsEnabled?.() ?? false)
 			: undefined;
 
 		const promptPath = ctx.assemblePrompt(plan.id, {

--- a/src/server/agent/system-prompt.ts
+++ b/src/server/agent/system-prompt.ts
@@ -196,6 +196,15 @@ export interface NestingContext {
 	parent?: { id: string; title: string; branch?: string };
 	/** Set when this goal has a non-self root (i.e. it is a child or grandchild). */
 	root?: { id: string; title: string; branch?: string };
+	/**
+	 * System-scope Subgoals feature flag. When false, the Children tools resolve
+	 * to `never`, so the tool-dependent stanzas (root orchestration, the
+	 * subgoal/team_spawn/task_create decision rule, and the "spawn deeper
+	 * children" bullet) are omitted. A child goal's POSITION guardrails (don't
+	 * raise a PR, branch merges into parent) are always emitted — a child can
+	 * outlive the flag being turned off.
+	 */
+	subGoalsEnabled?: boolean;
 }
 
 /**
@@ -213,16 +222,20 @@ export function buildNestingContextSection(ctx: NestingContext): string | undefi
 	const parts: string[] = [];
 
 	if (!ctx.parent) {
-		// Stanza A — top-level root
-		parts.push(
-			"## Goal nesting context (TOP-LEVEL ROOT)\n\n" +
-			"You are the team lead of a TOP-LEVEL (root) goal. This is the only goal in the tree that opens a pull request to `master`.\n\n" +
-			"**Your special responsibilities:**\n" +
-			"- After ready-to-merge passes, raise the PR via `gh pr create` (or, if `gh` is not installed in this environment, tell the user to create the PR manually). Child goals MUST NOT raise PRs.\n" +
-			"- Decide whether to decompose this work into nested sub-goals: see \"When to use subgoal vs team_spawn vs task_create\" below.\n" +
-			"- The root's `maxConcurrentChildren` (default 3, max 8) caps parallelism for the WHOLE tree — your tool `goal_set_policy` adjusts it.\n" +
-			"- The root's `divergencePolicy` (strict / balanced / autonomous) controls how mid-flight plan mutations are classified — see plan-mutation classifier docs."
-		);
+		// Stanza A — top-level root. Tool-dependent (decompose / concurrency /
+		// divergence), so omitted entirely when the Subgoals feature is off —
+		// a root with no Children tools has nothing to act on here.
+		if (ctx.subGoalsEnabled) {
+			parts.push(
+				"## Goal nesting context (TOP-LEVEL ROOT)\n\n" +
+				"You are the team lead of a TOP-LEVEL (root) goal. This is the only goal in the tree that opens a pull request to `master`.\n\n" +
+				"**Your special responsibilities:**\n" +
+				"- After ready-to-merge passes, raise the PR via `gh pr create` (or, if `gh` is not installed in this environment, tell the user to create the PR manually). Child goals MUST NOT raise PRs.\n" +
+				"- Decide whether to decompose this work into nested sub-goals: see \"When to use subgoal vs team_spawn vs task_create\" below.\n" +
+				"- The root's `maxConcurrentChildren` (default 5, max 8) caps parallelism for the WHOLE tree — your tool `goal_set_policy` adjusts it.\n" +
+				"- The root's `divergencePolicy` (strict / balanced / autonomous) controls how mid-flight plan mutations are classified — see plan-mutation classifier docs."
+			);
+		}
 	} else {
 		// Stanza B — child team-lead
 		const parentTitle = ctx.parent.title || ctx.parent.id;
@@ -241,12 +254,17 @@ export function buildNestingContextSection(ctx: NestingContext): string | undefi
 			"- **DO NOT raise a PR.** Only the root team-lead raises a PR (to `master`). If you call `gh pr create`, you create work the root must clean up.\n" +
 			"- **DO NOT spawn sibling goals.** Your siblings already exist (or will be spawned by your parent). If you need work that sounds like a sibling, surface it to your parent via `ready-to-merge` feedback rather than spawning it yourself.\n" +
 			`- Your worktree was created off \`${parentBranch}\` HEAD at spawn time. Sibling goals spawned later see your committed work after the parent's merge.\n` +
-			"- If a sibling completed before you started, you should already see their commits via the parent's branch tip.\n" +
-			"- You MAY decompose YOUR own work into deeper nested sub-goals (not siblings) via `goal_spawn_child` if the work is large enough to warrant its own team-lead. Rule of thumb: sub-goals are for decomposition WITHIN your spec, not expansion BEYOND your spec."
+			"- If a sibling completed before you started, you should already see their commits via the parent's branch tip." +
+			// Deeper-nesting bullet is tool-dependent — only when subgoals are on.
+			(ctx.subGoalsEnabled
+				? "\n- You MAY decompose YOUR own work into deeper nested sub-goals (not siblings) via `goal_spawn_child` if the work is large enough to warrant its own team-lead. Rule of thumb: sub-goals are for decomposition WITHIN your spec, not expansion BEYOND your spec."
+				: "")
 		);
 	}
 
-	// Stanza C — always present for team goals
+	// Stanza C — the subgoal/team_spawn/task_create decision rule. Tool-dependent
+	// (references goal_spawn_child / goal_plan_propose), so only when subgoals are on.
+	if (ctx.subGoalsEnabled) {
 	parts.push(
 		"## When to use `subgoal` vs `team_spawn` vs `task_create`\n\n" +
 		"You have THREE delegation primitives. Pick the right one:\n\n" +
@@ -266,7 +284,10 @@ export function buildNestingContextSection(ctx: NestingContext): string | undefi
 		"**Dependency scheduling works on every workflow type**, but the full classifier + freeze + approve flow requires the `parent` workflow (or any workflow with an `execution` gate). Without an `execution` gate, `goal_plan_propose` falls back to direct spawning with `dependsOn` enforced by the scheduler — a child with unmet deps is created in the scheduler-managed `blocked` state (its team/worktree is not started) and auto-resumes (`blocked`→`todo`) when its last dependency merges. This is NOT operator pause: `blocked` is a distinct scheduler axis, and `goal_pause`/`goal_resume` neither set nor clear dependency-blocking. Plan-mutation classification is unavailable in this mode.\n\n" +
 		"**Note: repeated plan changes (>5) on a parent-workflow goal trigger auto-pause for human review.** The freeze classifier (see plan-mutation docs) tracks `replanCount` per goal — if you keep restructuring the frozen plan, the system will pause the goal and surface a mutation-approval card to the user. Plan once, plan well; don't churn."
 	);
+	}
 
+	// With subgoals off, a root goal contributes no stanzas at all.
+	if (parts.length === 0) return undefined;
 	return parts.join("\n\n");
 }
 

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -8,6 +8,7 @@ import type { SessionManager, SessionInfo } from "./session-manager.js";
 import { GoalManager } from "./goal-manager.js";
 import { GoalStore, type PersistedGoal } from "./goal-store.js";
 import { createWorktree, cleanupWorktree } from "../skills/git.js";
+import { applyPromptConditionals } from "./prompt-conditionals.js";
 import type { RoleStore, Role } from "./role-store.js";
 import { resolveRole, listAvailableRoles } from "./resolve-role.js";
 import { GoalPausedError } from "./goal-paused-guard.js";
@@ -1408,10 +1409,13 @@ export class TeamManager {
 			throw new Error('Role "team-lead" not found. Ensure roles/team-lead.yaml exists.');
 		}
 		const teamLeadPromptTemplate = storedRole.promptTemplate;
-		const teamLeadPrompt = teamLeadPromptTemplate
-			.replace(/\{\{GOAL_BRANCH\}\}/g, goal.branch || "main")
-			.replace(/\{\{AGENT_ID\}\}/g, `team-lead-${goalId.slice(0, 8)}`)
-			.replace(/\{\{AVAILABLE_ROLES\}\}/g, buildAvailableRolesList(roleStore));
+		const teamLeadPrompt = applyPromptConditionals(
+			teamLeadPromptTemplate
+				.replace(/\{\{GOAL_BRANCH\}\}/g, goal.branch || "main")
+				.replace(/\{\{AGENT_ID\}\}/g, `team-lead-${goalId.slice(0, 8)}`)
+				.replace(/\{\{AVAILABLE_ROLES\}\}/g, buildAvailableRolesList(roleStore)),
+			{ subGoalsEnabled: this.sessionManager.isSubgoalsEnabled },
+		);
 
 		// Create the team lead session with the team tools extension.
 		// The extension registers first-class tools (team_spawn, task_create, etc.) in the agent.

--- a/src/server/proposals/proposal-types.ts
+++ b/src/server/proposals/proposal-types.ts
@@ -54,6 +54,10 @@ const GOAL_FRONTMATTER_KEYS = [
 	"inlineWorkflow",    // full Workflow object (snapshotted onto goal.workflow, bypasses store)
 	"inlineRoles",       // Record<roleName, Role> (snapshotted onto goal.inlineRoles)
 	"parentGoalId",      // optional parent goal id — when set, the created goal becomes a subgoal
+	"subgoalsAllowed",   // boolean — allow the team-lead to spawn sub-goals (Sub-goals tab toggle)
+	"maxNestingDepth",   // number — per-goal sub-goal nesting cap (clamped to the global ceiling)
+	"divergencePolicy",  // "strict"|"balanced"|"autonomous" — root-only plan-change autonomy
+	"maxConcurrentChildren", // number [1,8] — root-only concurrent child-team cap
 ] as const;
 
 /**
@@ -114,6 +118,26 @@ function validateGoalInlineFields(fields: Record<string, unknown>): ParseError |
 				}
 			}
 		}
+	}
+
+	// Per-goal nesting + orchestration scalars. All optional; validated only
+	// when present so an agent can pre-set what a human sets on the Sub-goals
+	// tab. Acceptance (POST /api/goals) re-clamps and applies root-only gating.
+	const sa = fields.subgoalsAllowed;
+	if (sa !== undefined && sa !== null && typeof sa !== "boolean") {
+		return { ok: false, code: "STRUCTURAL_VALIDATION_FAILED", message: "subgoalsAllowed must be a boolean" };
+	}
+	const mnd = fields.maxNestingDepth;
+	if (mnd !== undefined && mnd !== null && (typeof mnd !== "number" || !Number.isInteger(mnd) || mnd < 1)) {
+		return { ok: false, code: "STRUCTURAL_VALIDATION_FAILED", message: "maxNestingDepth must be an integer >= 1" };
+	}
+	const dp = fields.divergencePolicy;
+	if (dp !== undefined && dp !== null && dp !== "strict" && dp !== "balanced" && dp !== "autonomous") {
+		return { ok: false, code: "STRUCTURAL_VALIDATION_FAILED", message: "divergencePolicy must be one of: strict, balanced, autonomous" };
+	}
+	const mcc = fields.maxConcurrentChildren;
+	if (mcc !== undefined && mcc !== null && (typeof mcc !== "number" || !Number.isInteger(mcc) || mcc < 1 || mcc > 8)) {
+		return { ok: false, code: "STRUCTURAL_VALIDATION_FAILED", message: "maxConcurrentChildren must be an integer in [1, 8]" };
 	}
 	return null;
 }

--- a/tests/e2e/mock-agent-core.mjs
+++ b/tests/e2e/mock-agent-core.mjs
@@ -399,6 +399,26 @@ export class MockAgentCore {
 			};
 		}
 
+		// Goal proposal pre-filled with the Sub-goals tab fields — used by
+		// goal-proposal-subgoal-prefill.spec.ts to assert the agent can set
+		// everything a human sets on that tab. Must precede the generic
+		// goal_proposal matcher (it contains the "GOAL_PROPOSAL" substring).
+		if (text.includes("GOAL_PROPOSAL_SUBGOAL_PREFILL")) {
+			return {
+				tool: "propose_goal",
+				input: {
+					title: "Prefilled Goal",
+					workflow: "general",
+					spec: "A goal whose Sub-goals tab is pre-filled by the agent.",
+					subgoalsAllowed: true,
+					maxNestingDepth: 2,
+					divergencePolicy: "autonomous",
+					maxConcurrentChildren: 4,
+				},
+				output: "Proposal submitted. Waiting for user response.",
+			};
+		}
+
 		if (lower.includes("goal_proposal") || lower.includes("goal proposal")) {
 			return {
 				tool: "propose_goal",

--- a/tests/e2e/ui/goal-proposal-subgoal-prefill.spec.ts
+++ b/tests/e2e/ui/goal-proposal-subgoal-prefill.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * Browser E2E: an agent can pre-fill everything a human sets on the goal
+ * proposal's Sub-goals tab.
+ *
+ * The propose_goal tool now accepts subgoalsAllowed, maxNestingDepth,
+ * divergencePolicy and maxConcurrentChildren (proposal-types.ts frontmatter +
+ * extension.ts schema). syncProposalFormState() seeds the form controls from
+ * those fields, so the panel opens with the agent's choices already selected
+ * instead of leaving the toggle off / defaults at accept time.
+ *
+ * The mock agent emits these fields when the prompt contains
+ * "GOAL_PROPOSAL_SUBGOAL_PREFILL":
+ *   subgoalsAllowed: true, maxNestingDepth: 2,
+ *   divergencePolicy: "autonomous", maxConcurrentChildren: 4
+ */
+import { test, expect } from "../gateway-harness.js";
+import { apiFetch } from "../e2e-setup.js";
+import { openApp, sendMessage, createSessionViaUI } from "./ui-helpers.js";
+
+async function setSubgoals(value: boolean): Promise<void> {
+	const resp = await apiFetch("/api/preferences", {
+		method: "PUT",
+		body: JSON.stringify({ subgoalsEnabled: value }),
+	});
+	expect(resp.status).toBe(200);
+}
+
+test.describe("Goal proposal — agent-prefilled Sub-goals tab", () => {
+	test.afterEach(async () => { await setSubgoals(true); });
+
+	test("the Sub-goals tab reflects the agent's subgoalsAllowed/depth/policy/concurrency @smoke", async ({ page }) => {
+		await setSubgoals(true);
+		await openApp(page);
+		await createSessionViaUI(page);
+
+		await sendMessage(page, "Please GOAL_PROPOSAL_SUBGOAL_PREFILL now");
+
+		const titleInput = page.locator("input[placeholder='Goal title']").first();
+		await expect(titleInput).toBeVisible({ timeout: 20_000 });
+		await expect(titleInput).toHaveValue("Prefilled Goal", { timeout: 15_000 });
+
+		// Open the Sub-goals tab.
+		const subgoalsTab = page.locator("[data-testid='goal-proposal-tab-subgoals']");
+		await expect(subgoalsTab).toBeVisible({ timeout: 10_000 });
+		await subgoalsTab.click();
+
+		// Allow-subgoals is pre-checked (agent set subgoalsAllowed: true).
+		const toggle = page.locator("[data-testid='goal-form-subgoals-toggle']");
+		await expect(toggle).toBeVisible({ timeout: 10_000 });
+		await expect(toggle).toBeChecked();
+
+		// Max-depth reflects the agent's value (2).
+		await expect(page.locator("[data-testid='goal-form-max-depth']"))
+			.toHaveValue("2", { timeout: 10_000 });
+
+		// Concurrency reflects the agent's value (4).
+		await expect(page.locator("[data-testid='goal-form-max-concurrent-children']"))
+			.toHaveValue("4", { timeout: 10_000 });
+
+		// Divergence policy 'autonomous' is the pressed segment.
+		await expect(page.locator("[data-testid='goal-form-divergence-autonomous']"))
+			.toHaveAttribute("aria-pressed", "true", { timeout: 10_000 });
+		await expect(page.locator("[data-testid='goal-form-divergence-balanced']"))
+			.toHaveAttribute("aria-pressed", "false", { timeout: 5_000 });
+	});
+});

--- a/tests/nesting-context-subgoals-gate.test.ts
+++ b/tests/nesting-context-subgoals-gate.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Pins the subgoals-flag gating of the dynamically-injected team-lead nesting
+ * context (`buildNestingContextSection` in src/server/agent/system-prompt.ts).
+ *
+ * When the Subgoals feature is OFF the Children tools resolve to `never`, so the
+ * tool-dependent guidance must NOT be injected — otherwise the team-lead is told
+ * to use tools it doesn't have. But a CHILD goal's position guardrails ("DO NOT
+ * raise a PR", branch merges into parent) must ALWAYS show, since a child can
+ * outlive the flag being turned off.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildNestingContextSection } from "../src/server/agent/system-prompt.ts";
+
+describe("buildNestingContextSection — subgoals flag gating", () => {
+	it("root + subgoals OFF → no nesting section at all", () => {
+		const out = buildNestingContextSection({ team: true, subGoalsEnabled: false });
+		assert.equal(out, undefined);
+	});
+
+	it("root + subgoals ON → emits root orchestration guidance", () => {
+		const out = buildNestingContextSection({ team: true, subGoalsEnabled: true });
+		assert.ok(out && out.includes("TOP-LEVEL ROOT"));
+		assert.ok(out!.includes("maxConcurrentChildren"));
+		assert.ok(out!.includes("When to use `subgoal`"), "Stanza C should be present when enabled");
+	});
+
+	it("child + subgoals OFF → keeps position guardrails, drops tool-dependent parts", () => {
+		const out = buildNestingContextSection({
+			team: true,
+			subGoalsEnabled: false,
+			parent: { id: "p1", title: "Parent", branch: "goal-parent" },
+			goalBranch: "goal-child",
+		});
+		assert.ok(out, "child always gets its position guardrails");
+		assert.ok(out!.includes("CHILD GOAL"));
+		assert.ok(out!.includes("DO NOT raise a PR"));
+		assert.ok(out!.includes("merges INTO the parent's branch"));
+		// Tool-dependent parts must be gone.
+		assert.ok(!out!.includes("deeper nested sub-goals"), "deeper-nesting bullet must be dropped");
+		assert.ok(!out!.includes("When to use `subgoal`"), "Stanza C must be dropped");
+		assert.ok(!out!.includes("goal_spawn_child"), "no Children-tool references when disabled");
+	});
+
+	it("child + subgoals ON → includes the deeper-nesting bullet and Stanza C", () => {
+		const out = buildNestingContextSection({
+			team: true,
+			subGoalsEnabled: true,
+			parent: { id: "p1", title: "Parent", branch: "goal-parent" },
+			goalBranch: "goal-child",
+		});
+		assert.ok(out!.includes("DO NOT raise a PR"), "position guardrails still present");
+		assert.ok(out!.includes("deeper nested sub-goals"));
+		assert.ok(out!.includes("When to use `subgoal`"));
+	});
+
+	it("non-team goal → no section regardless of flag", () => {
+		assert.equal(buildNestingContextSection({ team: false, subGoalsEnabled: true }), undefined);
+	});
+});

--- a/tests/prompt-conditionals.test.ts
+++ b/tests/prompt-conditionals.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for the prompt-template conditional processor
+ * (`applyPromptConditionals` in src/server/agent/prompt-conditionals.ts) plus a
+ * validity scan over the shipped role/assistant templates.
+ *
+ * Syntax: `{if:NAME} … {endif:NAME}` — symmetric named tags so mismatches and
+ * nesting are validatable. A block is kept iff `flags[NAME]` is truthy and all
+ * enclosing blocks are kept; unknown flags fail closed (body removed); a
+ * malformed template throws.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as yamlParse } from "yaml";
+import { applyPromptConditionals } from "../src/server/agent/prompt-conditionals.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+
+describe("applyPromptConditionals", () => {
+	it("returns text unchanged when there are no conditional tags", () => {
+		const t = "plain prompt with {{AGENT_ID}} but no conditionals";
+		assert.equal(applyPromptConditionals(t, { subGoalsEnabled: false }), t);
+	});
+
+	it("keeps a block when its flag is true", () => {
+		const t = "A {if:subGoalsEnabled}B{endif:subGoalsEnabled} C";
+		assert.equal(applyPromptConditionals(t, { subGoalsEnabled: true }), "A B C");
+	});
+
+	it("drops a block (and its tags) when its flag is false", () => {
+		const t = "A {if:subGoalsEnabled}B{endif:subGoalsEnabled} C";
+		assert.equal(applyPromptConditionals(t, { subGoalsEnabled: false }), "A  C");
+	});
+
+	it("treats an unknown flag as false (fails closed)", () => {
+		const t = "A {if:unknownFlag}secret{endif:unknownFlag} C";
+		assert.equal(applyPromptConditionals(t, {}), "A  C");
+	});
+
+	it("handles nested blocks — inner kept only when outer is kept", () => {
+		const t = "[{if:outer}o1 {if:inner}i{endif:inner} o2{endif:outer}]";
+		assert.equal(applyPromptConditionals(t, { outer: true, inner: true }), "[o1 i o2]");
+		assert.equal(applyPromptConditionals(t, { outer: true, inner: false }), "[o1  o2]");
+		// Outer false → whole block (incl. inner) dropped regardless of inner.
+		assert.equal(applyPromptConditionals(t, { outer: false, inner: true }), "[]");
+	});
+
+	it("throws on an unmatched endif", () => {
+		assert.throws(() => applyPromptConditionals("x {endif:foo} y", {}), /unmatched \{endif:foo\}/);
+	});
+
+	it("throws on a name mismatch between if and endif", () => {
+		assert.throws(
+			() => applyPromptConditionals("{if:foo}x{endif:bar}", { foo: true, bar: true }),
+			/\{if:foo\} closed by \{endif:bar\}/,
+		);
+	});
+
+	it("throws on an unclosed if", () => {
+		assert.throws(() => applyPromptConditionals("{if:foo}x", { foo: true }), /unclosed \{if:foo\}/);
+	});
+});
+
+/** All conditional flag names the runtime knows how to resolve. */
+const KNOWN_FLAGS = new Set(["subGoalsEnabled"]);
+
+/** Gather the prompt text from a role/assistant YAML (promptTemplate or prompt). */
+function promptOf(file: string): string {
+	const doc = yamlParse(fs.readFileSync(file, "utf-8")) as Record<string, unknown>;
+	return (typeof doc.promptTemplate === "string" ? doc.promptTemplate : "")
+		+ "\n" + (typeof doc.prompt === "string" ? doc.prompt : "");
+}
+
+function listYaml(dir: string): string[] {
+	if (!fs.existsSync(dir)) return [];
+	const out: string[] = [];
+	for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+		const p = path.join(dir, e.name);
+		if (e.isDirectory()) out.push(...listYaml(p));
+		else if (e.name.endsWith(".yaml")) out.push(p);
+	}
+	return out;
+}
+
+describe("shipped prompt templates — conditional validity", () => {
+	const files = [
+		...listYaml(path.join(REPO, "defaults", "roles")),
+	];
+
+	it("found role/assistant templates to scan", () => {
+		assert.ok(files.length > 0, "expected at least one role YAML under defaults/roles");
+	});
+
+	for (const file of files) {
+		const rel = path.relative(REPO, file);
+		it(`${rel}: conditionals are balanced and use known flags only`, () => {
+			const text = promptOf(file);
+			// Balanced/well-formed under both flag states (throws on malformed).
+			assert.doesNotThrow(() => applyPromptConditionals(text, { subGoalsEnabled: true }));
+			assert.doesNotThrow(() => applyPromptConditionals(text, { subGoalsEnabled: false }));
+			// No leftover markers after processing with the real flag set.
+			for (const v of [true, false]) {
+				const out = applyPromptConditionals(text, { subGoalsEnabled: v });
+				assert.ok(!out.includes("{if:"), `${rel}: leftover {if:} marker (flag=${v})`);
+				assert.ok(!out.includes("{endif:"), `${rel}: leftover {endif:} marker (flag=${v})`);
+			}
+			// Every referenced flag name must be one the runtime resolves.
+			const names = new Set<string>();
+			for (const m of text.matchAll(/\{(?:if|endif):([A-Za-z0-9_]+)\}/g)) names.add(m[1]);
+			for (const n of names) {
+				assert.ok(KNOWN_FLAGS.has(n), `${rel}: unknown conditional flag {if:${n}} — add it to KNOWN_FLAGS and wire a value`);
+			}
+		});
+	}
+});

--- a/tests/proposal-files.test.ts
+++ b/tests/proposal-files.test.ts
@@ -84,6 +84,45 @@ describe("goal proposal round-trip", () => {
 		}
 	});
 
+	it("round-trips the Sub-goals tab fields (subgoalsAllowed, maxNestingDepth, divergencePolicy, maxConcurrentChildren)", async () => {
+		const sgSid = "sess-subgoal-fields";
+		await writeProposalFile(stateDir, sgSid, "goal", {
+			title: "Nested Goal",
+			spec: "Body.\n",
+			subgoalsAllowed: true,
+			maxNestingDepth: 3,
+			divergencePolicy: "autonomous",
+			maxConcurrentChildren: 5,
+		});
+		const raw = await readProposalFile(stateDir, sgSid, "goal");
+		assert.match(raw!, /subgoalsAllowed: true/);
+		assert.match(raw!, /divergencePolicy: autonomous/);
+		const parsed = await parseProposalFile(stateDir, sgSid, "goal");
+		assert.equal(parsed.ok, true, JSON.stringify(parsed));
+		if (parsed.ok) {
+			assert.equal(parsed.value.fields.subgoalsAllowed, true);
+			assert.equal(parsed.value.fields.maxNestingDepth, 3);
+			assert.equal(parsed.value.fields.divergencePolicy, "autonomous");
+			assert.equal(parsed.value.fields.maxConcurrentChildren, 5);
+		}
+	});
+
+	it("rejects malformed Sub-goals tab fields with STRUCTURAL_VALIDATION_FAILED", async () => {
+		const fp = proposalFilePath(stateDir, sid, "goal");
+		const cases = [
+			"divergencePolicy: yolo",
+			"maxConcurrentChildren: 99",
+			"maxNestingDepth: 0",
+			"subgoalsAllowed: maybe",
+		];
+		for (const bad of cases) {
+			fs.writeFileSync(fp, `---\ntitle: G\n${bad}\n---\nbody\n`);
+			const parsed = await parseProposalFile(stateDir, sid, "goal");
+			assert.equal(parsed.ok, false, `expected rejection for: ${bad}`);
+			if (!parsed.ok) assert.equal(parsed.code, "STRUCTURAL_VALIDATION_FAILED", bad);
+		}
+	});
+
 	it("missing title yields MISSING_REQUIRED_FIELD on parse", async () => {
 		// Hand-craft a goal file with empty title
 		const fp = proposalFilePath(stateDir, sid, "goal");

--- a/tests/resolve-root-max-concurrent-children.test.ts
+++ b/tests/resolve-root-max-concurrent-children.test.ts
@@ -43,11 +43,11 @@ function makeManager(): { gm: GoalManager; store: GoalStore } {
 }
 
 describe("GoalManager.resolveRootMaxConcurrentChildren", () => {
-	it("returns 3 when maxConcurrentChildren is unset", async () => {
+	it("returns 5 when maxConcurrentChildren is unset", async () => {
 		const { gm, store } = makeManager();
 		const root = await gm.createGoal("Root", tmpRoot, { workflowId: "general" });
 		assert.equal(store.get(root.id)?.maxConcurrentChildren, undefined);
-		assert.equal(gm.resolveRootMaxConcurrentChildren(root.id), 3);
+		assert.equal(gm.resolveRootMaxConcurrentChildren(root.id), 5);
 	});
 
 	it("returns the configured value when in [1, 8]", async () => {
@@ -78,9 +78,9 @@ describe("GoalManager.resolveRootMaxConcurrentChildren", () => {
 		assert.equal(gm.resolveRootMaxConcurrentChildren(root.id), 1);
 	});
 
-	it("returns 3 when rootGoalId is unknown (defensive — orphaned semaphore)", () => {
+	it("returns 5 when rootGoalId is unknown (defensive — orphaned semaphore)", () => {
 		const { gm } = makeManager();
-		assert.equal(gm.resolveRootMaxConcurrentChildren("nonexistent"), 3);
+		assert.equal(gm.resolveRootMaxConcurrentChildren("nonexistent"), 5);
 	});
 
 	it("returns 8 when value is exactly 8 (boundary check)", async () => {

--- a/tests/runSubgoalStep-concurrency-semaphore.test.ts
+++ b/tests/runSubgoalStep-concurrency-semaphore.test.ts
@@ -49,11 +49,11 @@ describe("runSubgoalStep — concurrency semaphore (§3.5)", () => {
 			`semaphore must cap concurrency at 2, observed peak ${maxObserved}`);
 	});
 
-	it("uses default cap=3 when maxConcurrentChildren is unset on root", async () => {
+	it("uses default cap=5 when maxConcurrentChildren is unset on root", async () => {
 		const fx = await buildFixture();
 		after(() => fx.cleanup());
 		// No maxConcurrentChildren set on parent.
-		assert.equal(fx.goalManager.resolveRootMaxConcurrentChildren(fx.parent.id), 3);
+		assert.equal(fx.goalManager.resolveRootMaxConcurrentChildren(fx.parent.id), 5);
 
 		let inFlight = 0;
 		let maxObserved = 0;
@@ -65,13 +65,13 @@ describe("runSubgoalStep — concurrency semaphore (§3.5)", () => {
 			return "passed";
 		});
 
-		const steps = [0, 1, 2, 3, 4, 5].map(i => buildSubgoalStep({ planId: `d-${i}`, title: `Leaf ${i}` }));
+		const steps = [0, 1, 2, 3, 4, 5, 6].map(i => buildSubgoalStep({ planId: `d-${i}`, title: `Leaf ${i}` }));
 		const actives = steps.map(() => buildActive(fx.parent.id));
 		await Promise.all(steps.map((s, i) =>
 			fx.harness.runSubgoalStep(s, actives[i].signal, actives[i].active, 0),
 		));
 
-		assert.equal(maxObserved, 3, `default cap=3, observed peak ${maxObserved}`);
+		assert.equal(maxObserved, 5, `default cap=5, observed peak ${maxObserved}`);
 	});
 
 	it("clamps user-supplied cap above 8 to the hard max of 8", async () => {


### PR DESCRIPTION
## Summary

Makes everything a human can set on the goal proposal panel's **Sub-goals tab** settable by an agent, reconciles the concurrency default to a single source of truth, and gates sub-goal prompt content on the `subgoalsEnabled` system flag so the team-lead / goal-assistant are never told about tooling that's disabled.

## propose_goal fields
- Added `subgoalsAllowed`, `maxNestingDepth`, `divergencePolicy`, `maxConcurrentChildren` to the `propose_goal` tool schema **and** the goal-proposal frontmatter (`proposal-types.ts`), with structural validation (boolean / integer≥1 / enum / `[1,8]`).
- `syncProposalFormState` seeds the Sub-goals tab from those fields, so an agent-authored proposal opens **pre-filled** instead of leaving the user to flip controls at accept time.

## Default reconciliation
- `maxConcurrentChildren` default unified to **5**, with the server (`resolveRootMaxConcurrentChildren`) as the single source of truth.
- The panel now submits `undefined` when the stepper is untouched, so the default is no longer baked into stored data and can change without re-pinning existing goals.

## Prompt conditionals (`{if:NAME} … {endif:NAME}`)
- New `applyPromptConditionals()` — symmetric named tags, nesting-aware, validating (fails closed on unknown flags, throws on malformed). Lives in its own module to avoid an import cycle.
- Wired at every team-lead / goal-assistant substitution site (initial spawn, restore, prompt-parts rebuild).
- Static sub-goal sections in `team-lead.yaml` / `assistant/goal.yaml` are wrapped in `{if:subGoalsEnabled}`.
- The **dynamic** nesting context gates its tool-dependent stanzas on the same flag, while **always** keeping a child goal's position guardrails ("DO NOT raise a PR", branch merges into parent) — a child can outlive the flag being turned off.
- Prompts also now document the sub-goal / orchestration knobs for both the goal assistant and the team lead.

## Tests
- `prompt-conditionals.test.ts` — processor unit tests **+ a validity scan** over every `defaults/roles/**.yaml` (balanced tags, no leftover markers, known flags only).
- `nesting-context-subgoals-gate.test.ts` — root-off→nothing, child-off→guardrails-only, on→full.
- `proposal-files.test.ts` — round-trip + malformed-rejection for the new frontmatter fields.
- default-5 pins updated; new `goal-proposal-subgoal-prefill` browser E2E.

**Unit:** 1338 passed / 2 skipped. **E2E:** 1271 passed / 7 skipped (3 pre-existing flakies passed on retry).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
