### PR TITLE
Add nurse-cap accessory for bobbit sprites

### DIFF
--- a/src/app/role-manager.css
+++ b/src/app/role-manager.css
@@ -511,7 +511,8 @@
 .bobbit-blob--inline .bobbit-blob__set-square,
 .bobbit-blob--inline .bobbit-blob__flask,
 .bobbit-blob--inline .bobbit-blob__wand,
-.bobbit-blob--inline .bobbit-blob__wizard-hat {
+.bobbit-blob--inline .bobbit-blob__wizard-hat,
+.bobbit-blob--inline .bobbit-blob__nurse-cap {
 	display: none !important;
 }
 /* Show the accessory when the class is on the blob div itself */
@@ -525,6 +526,7 @@
 .bobbit-blob--inline.bobbit-flask .bobbit-blob__flask { display: block !important; }
 .bobbit-blob--inline.bobbit-wand .bobbit-blob__wand { display: block !important; }
 .bobbit-blob--inline.bobbit-wizard-hat .bobbit-blob__wizard-hat { display: block !important; }
+.bobbit-blob--inline.bobbit-nurse-cap .bobbit-blob__nurse-cap { display: block !important; }
 
 /* Sync accessory idle animations with the same phase stagger as the eyes.
    --bobbit-idle-phase is the canonical var; --bobbit-eye-delay is a fallback. */

--- a/src/server/agent/staff-store.ts
+++ b/src/server/agent/staff-store.ts
@@ -36,6 +36,7 @@ const STAFF_ACCESSORY_IDS = new Set([
 	"wand",
 	"stamp",
 	"clipboard",
+	"nurse-cap",
 ]);
 
 export function normalizeStaffAccessory(value: unknown): string {

--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -1335,6 +1335,7 @@ html {
 .bobbit-blob--archived .bobbit-blob__flask,
 .bobbit-blob--archived .bobbit-blob__wand,
 .bobbit-blob--archived .bobbit-blob__wizard-hat,
+.bobbit-blob--archived .bobbit-blob__nurse-cap,
 .bobbit-blob--archived .bobbit-blob__stamp,
 .bobbit-blob--archived .bobbit-blob__clipboard,
 .bobbit-blob--archived .bobbit-blob__zzz,
@@ -2369,6 +2370,73 @@ html {
 }
 .bobbit-blob--compact-pop .bobbit-blob__clipboard {
 	animation: blob-compact-pop-rigid 0.6s cubic-bezier(0.34, 1.56, 0.64, 1) forwards !important;
+}
+
+/* ===== Nurse cap overlay (white folded cap with red cross, addsHeight hat) ===== */
+/* Mirrors the crown's rule set exactly (same scale/origin/margin, same state
+   follow-animations), with two deliberate differences:
+     1. a half-sprite-pixel downward `translate` so the brim hugs the head, and
+     2. its own white+red box-shadow art.
+   Counter-hue-rotated like the crown so it never shifts color. */
+.bobbit-blob__nurse-cap {
+	display: none;
+}
+/* Push the whole bobbit down when capped to prevent dome-tip clipping */
+.bobbit-nurse-cap .bobbit-blob {
+	padding-top: 6px;
+}
+.bobbit-nurse-cap .bobbit-blob__nurse-cap {
+	display: block;
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	overflow: visible;
+	transform-origin: 5px 8px; /* same as sprite */
+	transform: scale(4);
+	/* Seat half a sprite pixel (0.5 × 4 = 2 CSS px) lower than the crown so the
+	   brim hugs the head. Independent `translate` composes with the bob / idle
+	   `transform` animations instead of being overwritten (same trick the
+	   bandana uses). */
+	translate: 0 2px;
+	margin: 8px 18px 28px 17px;
+	image-rendering: pixelated;
+	/* Counter hue-rotate so the cap stays white + red across session hues */
+	filter: hue-rotate(calc(-1 * var(--bobbit-hue-rotate, 0deg)));
+	box-shadow:
+		3px -2px 0 #000, 4px -2px 0 #000, 5px -2px 0 #000, 6px -2px 0 #000, 7px -2px 0 #000,
+		2px -1px 0 #000, 3px -1px 0 #ffffff, 4px -1px 0 #ffffff, 5px -1px 0 #ef4444, 6px -1px 0 #ffffff, 7px -1px 0 #f3f4f6, 8px -1px 0 #000,
+		2px 0px 0 #000, 3px 0px 0 #ffffff, 4px 0px 0 #ef4444, 5px 0px 0 #ef4444, 6px 0px 0 #ef4444, 7px 0px 0 #f3f4f6, 8px 0px 0 #000,
+		1px 1px 0 #000, 2px 1px 0 #ffffff, 3px 1px 0 #ffffff, 4px 1px 0 #ffffff, 5px 1px 0 #ef4444, 6px 1px 0 #f3f4f6, 7px 1px 0 #f3f4f6, 8px 1px 0 #e5e7eb, 9px 1px 0 #000,
+		1px 2px 0 #000, 2px 2px 0 #000, 3px 2px 0 #000, 4px 2px 0 #000, 5px 2px 0 #000, 6px 2px 0 #000, 7px 2px 0 #000, 8px 2px 0 #000, 9px 2px 0 #000;
+	/* Match sprite's busy animation so the cap moves in sync */
+	animation: blob-busy-move 10s cubic-bezier(0.34, 1, 0.64, 1) infinite;
+}
+/* Cap follows all sprite state animations (reuses the crown keyframes) */
+.bobbit-blob--idle .bobbit-blob__nurse-cap {
+	animation: blob-crown-idle-sleep-breathe 3.6s ease-in-out infinite;
+	animation-delay: var(--bobbit-idle-phase, 0s);
+	transform: scale(4) translateX(-7px) translateY(0.75px);
+}
+.bobbit-blob--exit .bobbit-blob__nurse-cap {
+	animation: blob-exit 0.7s cubic-bezier(0.34, 1.56, 0.64, 1) forwards !important;
+}
+.bobbit-blob--exit-roll .bobbit-blob__nurse-cap {
+	animation: blob-exit-roll 0.9s cubic-bezier(0.22, 1, 0.36, 1) forwards !important;
+}
+.bobbit-blob--enter .bobbit-blob__nurse-cap {
+	animation: blob-enter 0.7s cubic-bezier(0.34, 1.56, 0.64, 1) forwards !important;
+}
+.bobbit-blob--enter-roll .bobbit-blob__nurse-cap {
+	animation: blob-enter-roll 0.9s cubic-bezier(0.22, 1, 0.36, 1) forwards !important;
+}
+.bobbit-blob--compact-shake .bobbit-blob__nurse-cap {
+	animation: blob-compact-shake 0.8s ease-in-out forwards !important;
+}
+.bobbit-blob--compacting .bobbit-blob__nurse-cap {
+	animation: blob-compact-squash 3s ease-in-out infinite !important;
+}
+.bobbit-blob--compact-pop .bobbit-blob__nurse-cap {
+	animation: blob-compact-pop 0.6s cubic-bezier(0.34, 1.56, 0.64, 1) forwards !important;
 }
 
 /* Disney 12-principles bounce:

--- a/src/ui/bobbit-render.ts
+++ b/src/ui/bobbit-render.ts
@@ -528,6 +528,7 @@ export function renderChatBlobCanvas(opts: ChatBlobOptions): TemplateResult {
 			<div class="bobbit-blob__flask"></div>
 			<div class="bobbit-blob__wand"></div>
 			<div class="bobbit-blob__wizard-hat"></div>
+			<div class="bobbit-blob__nurse-cap"></div>
 			<div class="bobbit-blob__stamp"></div>
 			<div class="bobbit-blob__clipboard"></div>
 			<div class="bobbit-blob__shadow"></div>
@@ -581,6 +582,7 @@ export function renderIdleBlobCanvas(opts: IdleBlobOptions): TemplateResult {
 					<div class="bobbit-blob__flask"></div>
 					<div class="bobbit-blob__wand"></div>
 					<div class="bobbit-blob__wizard-hat"></div>
+					<div class="bobbit-blob__nurse-cap"></div>
 					<div class="bobbit-blob__stamp"></div>
 					<div class="bobbit-blob__clipboard"></div>
 				</div>

--- a/src/ui/bobbit-sprite-data.ts
+++ b/src/ui/bobbit-sprite-data.ts
@@ -481,6 +481,38 @@ export const ACCESSORY_CLIPBOARD: AccessorySpriteData = {
   ],
 };
 
+/**
+ * Nurse cap accessory — white folded cap with a red cross. addsHeight hat.
+ * Sidebar coordinates (yOffset=2, addsHeight=true). Stepped dome (rows -2..0)
+ * flaring to a folded brim (row 1) with the brim outline at row 2 — the same
+ * row the crown / wizard-hat brim sits on, so it seats identically on the head
+ * one row above the eyes. The centred red cross (vertical x5 rows -1..1,
+ * horizontal arms x4-6 row 0) is the medical signifier; the right side is
+ * lightly shaded (#f3f4f6 / #e5e7eb) for a light-from-upper-left read.
+ *
+ * Like the crown, this is counter-hue-rotated at render time so it stays white
+ * and red across every session palette (it is NOT in the flask exception set).
+ */
+export const ACCESSORY_NURSE_CAP: AccessorySpriteData = {
+  id: 'nurse-cap',
+  label: 'Nurse Cap',
+  yOffset: 2,
+  addsHeight: true,
+  blobYAdjust: 0,
+  pixels: [
+    // Row -2: dome top outline
+    [3, -2, '#000'], [4, -2, '#000'], [5, -2, '#000'], [6, -2, '#000'], [7, -2, '#000'],
+    // Row -1: upper cap (white) + cross top
+    [2, -1, '#000'], [3, -1, '#ffffff'], [4, -1, '#ffffff'], [5, -1, '#ef4444'], [6, -1, '#ffffff'], [7, -1, '#f3f4f6'], [8, -1, '#000'],
+    // Row 0: cap (white) + cross arms
+    [2, 0, '#000'], [3, 0, '#ffffff'], [4, 0, '#ef4444'], [5, 0, '#ef4444'], [6, 0, '#ef4444'], [7, 0, '#f3f4f6'], [8, 0, '#000'],
+    // Row 1: folded brim (widest) + cross bottom + right-side shade
+    [1, 1, '#000'], [2, 1, '#ffffff'], [3, 1, '#ffffff'], [4, 1, '#ffffff'], [5, 1, '#ef4444'], [6, 1, '#f3f4f6'], [7, 1, '#f3f4f6'], [8, 1, '#e5e7eb'], [9, 1, '#000'],
+    // Row 2: brim bottom outline (same row as crown / wizard-hat brim)
+    [1, 2, '#000'], [2, 2, '#000'], [3, 2, '#000'], [4, 2, '#000'], [5, 2, '#000'], [6, 2, '#000'], [7, 2, '#000'], [8, 2, '#000'], [9, 2, '#000'],
+  ],
+};
+
 /** Registry of all accessories by ID */
 export const ACCESSORIES: Record<string, AccessorySpriteData> = {
   'crown':       ACCESSORY_CROWN,
@@ -495,6 +527,7 @@ export const ACCESSORIES: Record<string, AccessorySpriteData> = {
   'wand':        ACCESSORY_WAND,
   'stamp':       ACCESSORY_STAMP,
   'clipboard':   ACCESSORY_CLIPBOARD,
+  'nurse-cap':   ACCESSORY_NURSE_CAP,
 };
 
 /** All accessory IDs (excluding "none") */

--- a/src/ui/components/StreamingMessageContainer.ts
+++ b/src/ui/components/StreamingMessageContainer.ts
@@ -357,6 +357,7 @@ export class StreamingMessageContainer extends LitElement {
 					<div class="bobbit-blob__flask"></div>
 					<div class="bobbit-blob__wand"></div>
 					<div class="bobbit-blob__wizard-hat"></div>
+					<div class="bobbit-blob__nurse-cap"></div>
 					<div class="bobbit-blob__stamp"></div>
 					<div class="bobbit-blob__clipboard"></div>
 					<div class="bobbit-blob__shadow"></div>

--- a/tests/nurse-cap-accessory.test.ts
+++ b/tests/nurse-cap-accessory.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Pins the "nurse-cap" accessory end-to-end wiring.
+ *
+ * Adding an accessory touches several decoupled places (canonical sprite data,
+ * the box-shadow CSS overlay, the blob DOM templates, the role-manager inline
+ * display rules, and the staff allowlist). This test guards each of those so a
+ * future refactor can't silently drop one and leave the cap invisible in one
+ * context but not another.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { ACCESSORIES, ACCESSORY_IDS, ACCESSORY_NURSE_CAP } from "../src/ui/bobbit-sprite-data.ts";
+import { normalizeStaffAccessory } from "../src/server/agent/staff-store.ts";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const read = (rel: string) => fs.readFileSync(path.join(root, rel), "utf8");
+
+describe("nurse-cap accessory", () => {
+	it("is registered in the canonical sprite registry", () => {
+		assert.equal(ACCESSORIES["nurse-cap"], ACCESSORY_NURSE_CAP);
+		assert.ok(ACCESSORY_IDS.includes("nurse-cap"));
+		assert.equal(ACCESSORY_NURSE_CAP.id, "nurse-cap");
+		assert.equal(ACCESSORY_NURSE_CAP.label, "Nurse Cap");
+	});
+
+	it("is an addsHeight hat seated like the crown (yOffset 2, brim outline at row 2)", () => {
+		assert.equal(ACCESSORY_NURSE_CAP.addsHeight, true, "must add height like crown/wizard-hat");
+		assert.equal(ACCESSORY_NURSE_CAP.yOffset, 2, "must share the crown's yOffset so it seats above the eyes");
+		// Brim outline: a contiguous black span across x1..9 at row 2 — the exact
+		// row the crown / wizard-hat brim sits on.
+		const brim = ACCESSORY_NURSE_CAP.pixels
+			.filter(([, y, c]) => y === 2 && c === "#000")
+			.map(([x]) => x)
+			.sort((a, b) => a - b);
+		assert.deepEqual(brim, [1, 2, 3, 4, 5, 6, 7, 8, 9], "brim outline must span x1..9 at row 2");
+	});
+
+	it("renders a centred red cross on white", () => {
+		const has = (x: number, y: number, c: string) =>
+			ACCESSORY_NURSE_CAP.pixels.some(([px, py, pc]) => px === x && py === y && pc === c);
+		// Vertical bar of the cross at x5, rows -1..1
+		assert.ok(has(5, -1, "#ef4444") && has(5, 0, "#ef4444") && has(5, 1, "#ef4444"), "cross vertical at x5");
+		// Horizontal arms at row 0, x4..6
+		assert.ok(has(4, 0, "#ef4444") && has(6, 0, "#ef4444"), "cross arms at row 0");
+		// White cap body present
+		assert.ok(ACCESSORY_NURSE_CAP.pixels.some(([, , c]) => c === "#ffffff"), "white cap body");
+	});
+
+	it("is allowed as a staff accessory", () => {
+		assert.equal(normalizeStaffAccessory("nurse-cap"), "nurse-cap");
+	});
+
+	it("is wired into every blob render context", () => {
+		// Box-shadow overlay + counter hue-rotate (stays white+red across hues).
+		const css = read("src/ui/app.css");
+		assert.match(css, /\.bobbit-nurse-cap \.bobbit-blob__nurse-cap \{/, "app.css overlay rule");
+		assert.match(css, /\.bobbit-blob--archived \.bobbit-blob__nurse-cap/, "archived animation-kill list");
+		// DOM templates (chat blob, idle blob, streaming container).
+		const render = read("src/ui/bobbit-render.ts");
+		const chatDivs = render.match(/bobbit-blob__nurse-cap/g) ?? [];
+		assert.ok(chatDivs.length >= 2, "nurse-cap div in both bobbit-render templates");
+		assert.match(read("src/ui/components/StreamingMessageContainer.ts"), /bobbit-blob__nurse-cap/);
+		// Role-manager inline display rules (per-blob gating, no html-class leak).
+		const rm = read("src/app/role-manager.css");
+		assert.match(rm, /\.bobbit-blob--inline\.bobbit-nurse-cap \.bobbit-blob__nurse-cap \{ display: block/, "inline enable rule");
+		assert.match(rm, /\.bobbit-blob--inline \.bobbit-blob__nurse-cap/, "inline reset rule");
+	});
+});


### PR DESCRIPTION
## Nurse Cap accessory

Adds a new pixel-art accessory for bobbit sprites: a **white folded nurse cap with a red cross**, for medical/nurse roles and staff.


### Design
Built to the **crown's hat grammar** so it behaves like a first-class hat:
- Same `transform-origin`, `scale(4)`, and `margin` as the crown; pixels span rows −2…2 with the brim outline at **row 2** — the exact row the crown/wizard-hat brim sits on, so it seats on the head one row above the eyes.
- Seated **half a sprite pixel (2 CSS px) lower** via an independent `translate` (the bandana's trick) so the brim hugs the head; it composes with the bob/idle/compact `transform` animations instead of being overwritten.
- **Counter-hue-rotated** like the crown (not in the `flask` exception set), so it stays white + red across every session palette.
- Tracks every state by reusing the real crown keyframes (busy hop, idle sleep-breathe, compact squash/shake/pop, enter/exit ±roll).

### Wiring (one accessory, several decoupled touch-points)
- `bobbit-sprite-data.ts` — `ACCESSORY_NURSE_CAP` + registry entry (the role-manager picker and sidebar pick it up automatically from `ACCESSORY_IDS`).
- `app.css` — box-shadow overlay rule set + archived animation-kill list.
- `bobbit-render.ts` + `StreamingMessageContainer.ts` — the cap `<div>` in the chat, idle, and streaming blob templates.
- `role-manager.css` — inline per-blob display rules (reset + enable) so the cap gates per-blob without the html-class leaking across the role grid.
- `staff-store.ts` — added to the staff accessory allowlist.

### Testing
- `npm run check` — clean.
- New `tests/nurse-cap-accessory.test.ts` pins the full wiring (registry, hat geometry/seating, red-cross art, staff allowlist, and presence in every render context).
- Verified visually across all contexts/states (chat busy & idle, role-manager grid across all 14 palettes confirming no hue-shift, sidebar at true 16px) via an interactive design mockup.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
