### PR TITLE
docs: add 'Maintaining a fork' section to dev-workflow guide

### DIFF
--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -284,6 +284,61 @@ This is not a Bobbit bug — it's a git behaviour. There is no per-worktree stas
 
 ---
 
+## Maintaining a fork
+
+Bobbit can be run as a downstream **fork** that carries local customisations while tracking this repository for upstream changes. The conventions below keep that sustainable in both directions. Set up two remotes in your fork's clone:
+
+| Remote | Points at | Role |
+|---|---|---|
+| `origin` | your fork (e.g. `<you>/bobbit`) | Your fork. Day-to-day PRs target its `master`. |
+| `upstream` | the repository you forked from | The source you track for new commits. |
+
+Add it once with `git remote add upstream <url>`; confirm with `git remote -v`. Targeting the wrong base sends review traffic to a repo you may not control — always verify the PR base before creating it.
+
+### Syncing changes *from* upstream
+
+Pull new `upstream/master` commits into your fork through a single review-ready PR (some forks automate this with a scheduled job, titled e.g. `[upstream-sync] …`):
+
+1. `git fetch upstream && git fetch origin`.
+2. Stop if `git rev-list --count origin/master..upstream/master` is `0` — nothing new.
+3. `git switch -c sync/upstream-<date> origin/master`.
+4. `git merge --no-ff upstream/master`, resolve conflicts so your fork-specific behaviour is preserved, validate (`npm run check` + tests), push, open the PR.
+
+**⚠️ Merge-commit rule.** **Merge upstream-sync PRs with a real merge commit — never squash, never rebase.**
+
+- Squash/rebase **discards the merge's second parent**, so git loses all record that upstream's commits already live in your `master`. After that, `git merge-base master upstream/master` stays pinned at an ancient commit, `origin/master..upstream/master` re-counts every already-merged commit as "ahead", and the next sync re-litigates conflicts you already resolved.
+- A merge commit keeps `upstream/master` as a true parent, so future syncs surface **only** genuinely-new commits.
+- Enable merge commits on your fork (`allow_merge_commit = true`) and don't require linear history; then use "Create a merge commit" / `gh pr merge <n> --merge`. (If the GitHub UI hides the option right after you change the setting, hard-refresh the PR page — the merge dropdown is cached at load time.)
+
+**If a sync PR was squashed by mistake.** You can't rewrite a protected `master`, so heal the ancestry *forward*: branch off the current `master`, build a commit that records `upstream/master` as a second parent while keeping `master`'s tree, then merge that PR with a merge commit:
+
+```bash
+git switch -c sync/heal origin/master
+git cherry-pick <new-upstream-commits>          # land any new upstream content cleanly
+TREE=$(git write-tree)
+HEAL=$(git commit-tree "$TREE" -p origin/master -p upstream/master -m "Merge upstream/master (heal ancestry)")
+git reset --hard "$HEAL"                         # branch tip = merge commit, tree = master + new content
+# push, open PR, then: gh pr merge <n> --merge   (NEVER squash)
+```
+
+### Contributing changes back upstream
+
+To get a fork change accepted into the upstream project:
+
+1. **Develop upstreamable work on a branch cut from `upstream/master`, not your fork's `master`.** A branch based on upstream produces a PR containing *only* your change — no fork-specific commits (CI tweaks, local config, …) leak in.
+   ```bash
+   git fetch upstream
+   git switch -c feature/<name> upstream/master
+   # build the change in focused, self-contained commits
+   git push origin feature/<name>
+   gh pr create --repo <upstream-owner>/bobbit --base master --head <you>:feature/<name>
+   ```
+2. **Land it in both places.** Merge the branch into your fork (fork PR) and submit it upstream. Once upstream accepts it, the next sync brings it back as a normal ancestor — no duplication, no conflict.
+3. **Extracting a change that currently lives only in your fork.** Cherry-pick just its commits onto a fresh `upstream/master`-based branch, dropping fork-only adaptations, and open the upstream PR from there.
+4. **Keep fork divergence minimal.** Every file your fork edits that upstream also maintains becomes a recurring merge conflict. Prefer additive, isolated changes (new files, local config) over editing files upstream actively changes. The smaller and more separable the divergence, the cheaper both syncing-down and contributing-up become.
+
+---
+
 ## Related docs
 
 - **[README.md](../README.md)** — Architecture overview, quick start, CLI flags


### PR DESCRIPTION
## Add a "Maintaining a fork" section to the dev-workflow guide

Bobbit is forkable, but there's currently no written guidance for running a downstream fork that tracks this repo. This adds a generic **Maintaining a fork** section to `docs/dev-workflow.md` covering both directions:

- **Remote setup** — `origin` (your fork) vs `upstream` (this repo).
- **Syncing *from* upstream** — the `[upstream-sync]` PR procedure, and prominently the **merge-commit rule**: merge upstream-sync PRs with a real merge commit, never squash/rebase. Squashing discards the merge's second parent, so git loses upstream ancestry — `git merge-base` stays pinned at an ancient commit, `origin/master..upstream/master` re-counts already-merged commits as "ahead", and every later sync re-litigates resolved conflicts. Also includes a recovery recipe (a `git commit-tree` "ancestry heal") for when a sync PR was squashed by mistake.
- **Contributing *back* upstream** — the sustainable pattern: develop upstreamable work on a branch cut from `upstream/master` (so the PR carries only the change, not fork-specific config), land it in both places, extract fork-only features cleanly, and keep divergence minimal.

The content is generic (placeholders like `<you>/bobbit`, `<upstream-owner>/bobbit`) so it applies to any fork. Docs-only; no code touched.

This was written and battle-tested while maintaining a downstream fork of this project — offering it back in case it's useful upstream. Happy to adjust tone/placement or trim if you'd prefer something shorter.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
