### PR TITLE
fix(ui): stop sidebar blanking to Loading… on idle poll ticks

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -373,6 +373,13 @@ The existing guard remains as a last-line safety net for genuinely unbindable pr
 - `renderApp()` debounced via `requestAnimationFrame` — multiple calls collapse
 - For synchronous DOM updates, use `renderAppSync()`
 
+## Sidebar / landing list blanks to "Loading…" every ~5s (or flashes on first load)
+
+- **Symptom**: the left sidebar (and the mobile landing list) periodically replaces the whole projects/goals/sessions list with a centered "Loading…" placeholder and then repopulates. Most visible on first load; for some users it recurs every ~5s while idle.
+- **Root cause**: `refreshSessions()` (`src/app/api.ts`) decided "this is an initial load — show the spinner" via `state.gatewaySessions.length === 0`. List length is the wrong proxy for "never fetched": any user whose live-session list is legitimately empty (projects/goals present but no live sessions, or no projects at all) keeps `length === 0` true forever, so every 5s poll tick re-entered initial-load and re-blanked the list.
+- **Fix**: the decision lives in the pure helper `isInitialSessionsLoad` (`src/app/session-load-state.ts`), keyed off whether a fetch has ever *completed* rather than list emptiness — `state.sessionsGeneration` is `-1` until the first successful fetch and `>= 0` thereafter, so `isInitialSessionsLoad` returns `sessionsGeneration < 0 && !sessionsError`. After the first fetch the spinner never re-appears on background polls. The error term keeps the spinner suppressed while an error is on screen; `retryLoadSessions()` (`src/app/api.ts`) clears `sessionsError` before re-fetching so the Retry button shows the one-time spinner again after an initial-load failure. The helper is dependency-free (no `renderApp`/DOM import) so it can be unit-tested in node.
+- **Pinning test**: `tests/sidebar-loading-flash.test.ts` — proves a second poll tick with an empty `gatewaySessions` list does not re-enter initial-load once `sessionsGeneration >= 0`, while genuine first load and post-error retry still show the spinner.
+
 ## Toolbar / sidebar buttons missing shortcut hints in `title`
 
 - **Symptom**: hovering a toolbar or sidebar button on a freshly-booted app shows a bare label (e.g. `New goal`, `Terminate session`, `Collapse preview`) instead of the labelled-with-shortcut form (`New goal (Alt+G)`, etc.). A second render — any WS event, sessions poll, hash change, or user input — fixes it. Under heavy parallel e2e load this race accounted for the largest single category of toolbar-locator flakes.

--- a/docs/session-refresh.md
+++ b/docs/session-refresh.md
@@ -24,6 +24,14 @@ Client poll after server mutation:
   → renderApp() once
 ```
 
+## Initial-load spinner gating
+
+On the *first* fetch the sidebar shows a one-time "Loading…" placeholder; afterwards the list is updated in place and never blanks. `refreshSessions()` decides whether a given call is that initial load via the pure helper `isInitialSessionsLoad` (`src/app/session-load-state.ts`).
+
+The signal is **`sessionsGeneration`, not list length**. `sessionsGeneration` is `-1` until the first successful fetch and `>= 0` thereafter, so the helper returns `sessionsGeneration < 0 && !sessionsError`. List emptiness is the wrong proxy for "never fetched": a user whose live-session list is legitimately empty (projects/goals but no live sessions, or no projects at all) would keep `gatewaySessions.length === 0` forever, which previously re-flagged every 5s poll as an initial load and re-blanked the sidebar.
+
+The `!sessionsError` term keeps the spinner suppressed while an error is on screen, so background poll retries stay silent under the error/Retry UI. `retryLoadSessions()` (`src/app/api.ts`) exists for the explicit Retry button: it clears `sessionsError` before calling `refreshSessions()`, restoring the one-time spinner after an initial-load failure. Pinned by `tests/sidebar-loading-flash.test.ts`.
+
 ## Client refresh patterns
 
 ### Pattern 1 — Optimistic local mutations (no fetch needed)
@@ -52,5 +60,6 @@ After server-side mutations (session deletion, role assignment, team teardown), 
 | `src/server/agent/goal-store.ts` | Server-side generation counter for goals |
 | `src/server/server.ts` | API endpoints with `?since=` support |
 | `src/app/state.ts` | Client-side `sessionsGeneration` and `goalsGeneration` |
-| `src/app/api.ts` | `refreshSessions()` with generation-gated logic |
+| `src/app/api.ts` | `refreshSessions()` with generation-gated logic; `retryLoadSessions()` |
+| `src/app/session-load-state.ts` | `isInitialSessionsLoad` — pure initial-load/spinner decision |
 | `src/app/session-manager.ts` | Session lifecycle (optimistic local updates) |

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -286,6 +286,16 @@ export function stopSessionPolling(): void {
 	}
 }
 
+/**
+ * Clear any sessions-fetch error and re-fetch. Used by the sidebar/landing
+ * "Retry" buttons: clearing the error lets `isInitialSessionsLoad` show the
+ * one-time spinner again on a genuine retry after an initial-load failure.
+ */
+export function retryLoadSessions(): void {
+	state.sessionsError = "";
+	refreshSessions();
+}
+
 export async function refreshSessions(): Promise<void> {
 	const isInitial = isInitialSessionsLoad({
 		gatewaySessionsLength: state.gatewaySessions.length,

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -36,6 +36,7 @@ import {
 	showStopTeamDialog,
 } from "./dialogs-lazy.js";
 import { countDescendants } from "./goal-descendants-count.js";
+import { isInitialSessionsLoad } from "./session-load-state.js";
 
 /** Track previous session statuses to detect streaming→idle transitions. */
 const _prevSessionStatus = new Map<string, string>();
@@ -286,7 +287,11 @@ export function stopSessionPolling(): void {
 }
 
 export async function refreshSessions(): Promise<void> {
-	const isInitial = state.gatewaySessions.length === 0 && !state.sessionsError;
+	const isInitial = isInitialSessionsLoad({
+		gatewaySessionsLength: state.gatewaySessions.length,
+		sessionsGeneration: state.sessionsGeneration,
+		sessionsError: state.sessionsError,
+	});
 	if (isInitial) {
 		state.sessionsLoading = true;
 		state.sessionsError = "";

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -21,7 +21,7 @@ import {
 	getSidebarData,
 	setRenderSuppressed,
 } from "./state.js";
-import { gatewayFetch, refreshSessions } from "./api.js";
+import { gatewayFetch, retryLoadSessions } from "./api.js";
 import { clearAllAnnotations, clearAnnotations, getDocumentAnnotationCount, markReviewSubmitted, flushPendingWrites } from "../ui/components/review/AnnotationStore.js";
 import {
 	clearPersistedReviewDocuments,
@@ -544,7 +544,7 @@ function renderMobileLanding() {
 					: state.sessionsError
 						? html`<div class="text-center py-12">
 								<p class="text-red-500 mb-3">${state.sessionsError}</p>
-								<button class="text-muted-foreground underline" title="Retry" @click=${refreshSessions}>Retry</button>
+								<button class="text-muted-foreground underline" title="Retry" @click=${retryLoadSessions}>Retry</button>
 							</div>`
 						: state.goals.length === 0 && state.gatewaySessions.length === 0
 							? html`<div class="text-center py-12">

--- a/src/app/session-load-state.ts
+++ b/src/app/session-load-state.ts
@@ -12,13 +12,15 @@
  * extracted here as a tiny dependency-free function that can be unit-tested
  * directly in node — fast and DOM-free.
  *
- * NOTE (TDD red step): this currently encodes the OLD, BUGGY logic that keys
- * off list emptiness. List length is the wrong proxy for "never fetched": a
- * user whose `gatewaySessions` is legitimately empty (projects/goals but no
- * live sessions, or no projects at all) keeps `length === 0` true forever, so
- * every 5s poll tick re-enters "initial load" and re-blanks the sidebar. The
- * correct contract (pinned by tests/sidebar-loading-flash.test.ts) keys off
- * `sessionsGeneration` instead; the green step flips the implementation below.
+ * Contract: initial-load is keyed off whether a fetch has ever COMPLETED —
+ * `state.sessionsGeneration` is -1 until the first successful fetch and >= 0
+ * thereafter — not off list emptiness. List length is the wrong proxy for
+ * "never fetched": a user whose `gatewaySessions` is legitimately empty
+ * (projects/goals but no live sessions, or no projects at all) keeps
+ * `length === 0` true forever, which previously re-entered "initial load" on
+ * every 5s poll tick and re-blanked the sidebar. We still suppress the spinner
+ * while an error is on screen so background poll retries stay silent under the
+ * error/Retry UI. Pinned by tests/sidebar-loading-flash.test.ts.
  */
 export interface SessionLoadStateArgs {
 	/** Current length of `state.gatewaySessions`. */
@@ -34,5 +36,5 @@ export interface SessionLoadStateArgs {
  * spinner for this invocation.
  */
 export function isInitialSessionsLoad(args: SessionLoadStateArgs): boolean {
-	return args.gatewaySessionsLength === 0 && !args.sessionsError;
+	return args.sessionsGeneration < 0 && !args.sessionsError;
 }

--- a/src/app/session-load-state.ts
+++ b/src/app/session-load-state.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure helper: decide whether a `refreshSessions()` invocation should be
+ * treated as an *initial* load — i.e. whether it should flip
+ * `state.sessionsLoading = true` and blank the sidebar to a "Loading…"
+ * placeholder while it fetches.
+ *
+ * This decision was previously inlined in `refreshSessions()` (src/app/api.ts)
+ * as `state.gatewaySessions.length === 0 && !state.sessionsError`. That module
+ * pulls the DOM-bound app-shell graph (via `renderApp`) and so is not
+ * runtime-importable in node:test. Following the established pattern
+ * (`safe-storage.ts`/`error-helpers.ts` + their tests), the decision is
+ * extracted here as a tiny dependency-free function that can be unit-tested
+ * directly in node — fast and DOM-free.
+ *
+ * NOTE (TDD red step): this currently encodes the OLD, BUGGY logic that keys
+ * off list emptiness. List length is the wrong proxy for "never fetched": a
+ * user whose `gatewaySessions` is legitimately empty (projects/goals but no
+ * live sessions, or no projects at all) keeps `length === 0` true forever, so
+ * every 5s poll tick re-enters "initial load" and re-blanks the sidebar. The
+ * correct contract (pinned by tests/sidebar-loading-flash.test.ts) keys off
+ * `sessionsGeneration` instead; the green step flips the implementation below.
+ */
+export interface SessionLoadStateArgs {
+	/** Current length of `state.gatewaySessions`. */
+	gatewaySessionsLength: number;
+	/** `state.sessionsGeneration`: -1 until the first successful fetch, then >= 0. */
+	sessionsGeneration: number;
+	/** `state.sessionsError`: empty string when there is no error. */
+	sessionsError: string;
+}
+
+/**
+ * Returns true when `refreshSessions()` should show the one-time "Loading…"
+ * spinner for this invocation.
+ */
+export function isInitialSessionsLoad(args: SessionLoadStateArgs): boolean {
+	return args.gatewaySessionsLength === 0 && !args.sessionsError;
+}

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -32,7 +32,7 @@ import { createAndConnectSession, connectToSession } from "./session-manager.js"
 import { cwdCombobox } from "./cwd-combobox.js";
 import { showGoalDialog, showProjectDialog, showConnectionError } from "./dialogs-lazy.js";
 import { startNewGoalFlow, showProjectPickerPopover } from "./goal-entry.js";
-import { refreshSessions, fetchRoles, fetchStaff, fetchOrphanedStaff, reassignStaffProject, enqueueInboxManual, fetchArchivedSessions, archivedSessionsLoaded, archivedGoalsLoaded, fetchSandboxStatus, fetchArchivedGoalsPaginated, fetchArchivedSessionsPaginated, gatewayFetch, clearArchivedSessionsState, fetchProjects, saveProjectOrder } from "./api.js";
+import { refreshSessions, retryLoadSessions, fetchRoles, fetchStaff, fetchOrphanedStaff, reassignStaffProject, enqueueInboxManual, fetchArchivedSessions, archivedSessionsLoaded, archivedGoalsLoaded, fetchSandboxStatus, fetchArchivedGoalsPaginated, fetchArchivedSessionsPaginated, gatewayFetch, clearArchivedSessionsState, fetchProjects, saveProjectOrder } from "./api.js";
 import { errorFromResponse, errorDetails } from "./error-helpers.js";
 import { statusBobbit, sessionAcronym } from "./session-colors.js";
 import { renderGoalGroup, renderSessionRow, SESSION_ROW_PY, INDENT, CHEVRON_W, HEADER_CHEVRON_W, terseRelativeTime, hasUnseenActivity, formatSessionAge, renderSessionTitle, getProjectAccentColor, filterArchivedGoalsByQuery, filterArchivedSessionsByQuery, renderProjectArchivedSection as renderSharedProjectArchivedSection, archivedDivider, bucketActiveArchived, passesSidebarFilters, isChildSession } from "./render-helpers.js";
@@ -1554,7 +1554,7 @@ export function renderSidebar() {
 					: state.sessionsError
 						? html`<div class="text-center py-6">
 								<p class="text-red-500 mb-2">${state.sessionsError}</p>
-								<button class="text-muted-foreground hover:text-foreground underline" title="Retry loading sessions" @click=${refreshSessions}>Retry</button>
+								<button class="text-muted-foreground hover:text-foreground underline" title="Retry loading sessions" @click=${retryLoadSessions}>Retry</button>
 							</div>`
 						: (() => {
 							// Apply search filtering. Staff render as rows inside each project's

--- a/tests/sidebar-loading-flash.test.ts
+++ b/tests/sidebar-loading-flash.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Regression test for the sidebar "Loading…" flash.
+ *
+ * Symptom: the left sidebar (projects, goals, sessions) momentarily blanks to a
+ * centered "Loading…" placeholder and repopulates — most visible on first load,
+ * but for some users it recurs every ~5s while idle.
+ *
+ * Root cause: `refreshSessions()` (src/app/api.ts) decided "this is an initial
+ * load → show the spinner" using `state.gatewaySessions.length === 0 &&
+ * !state.sessionsError`. List length is the wrong proxy for "never fetched":
+ * any user whose `gatewaySessions` is legitimately empty (projects/goals but no
+ * *live* sessions, or no projects at all) keeps `length === 0` true forever, so
+ * every 5s poll tick re-enters "initial load" and re-blanks the sidebar.
+ *
+ * Correct contract: initial-load must be keyed off whether a fetch has ever
+ * COMPLETED — `state.sessionsGeneration` is -1 until the first successful fetch
+ * and >= 0 thereafter — while still suppressing the spinner when an error is on
+ * screen (so background poll retries stay silent under the error/Retry UI).
+ *
+ * The decision lives in the dependency-free helper `isInitialSessionsLoad`
+ * (src/app/session-load-state.ts) so it can be pinned here directly in node,
+ * without the DOM-bound app-shell graph. This test asserts the CORRECT post-fix
+ * contract; it FAILS against the old list-length logic on the second-poll-tick
+ * row (`generation:0` → expected `false`, old logic returns `true`).
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isInitialSessionsLoad } from "../src/app/session-load-state.ts";
+
+describe("isInitialSessionsLoad — sidebar loading-flash contract", () => {
+	it("shows the spinner once on a genuine first load (never fetched, no error)", () => {
+		assert.equal(
+			isInitialSessionsLoad({ gatewaySessionsLength: 0, sessionsGeneration: -1, sessionsError: "" }),
+			true,
+		);
+	});
+
+	it("does NOT re-show the spinner on a later poll tick once a fetch completed, even with an empty list", () => {
+		// This is the reproduction: empty list + already-fetched (generation 0)
+		// must NOT be treated as an initial load. The old list-length logic
+		// returns true here, which is the 5s flash bug.
+		assert.equal(
+			isInitialSessionsLoad({ gatewaySessionsLength: 0, sessionsGeneration: 0, sessionsError: "" }),
+			false,
+		);
+	});
+
+	it("does NOT re-show the spinner on any later poll tick with an empty list", () => {
+		assert.equal(
+			isInitialSessionsLoad({ gatewaySessionsLength: 0, sessionsGeneration: 5, sessionsError: "" }),
+			false,
+		);
+	});
+
+	it("does NOT show the spinner while an initial fetch error is on screen (polls retry silently)", () => {
+		assert.equal(
+			isInitialSessionsLoad({ gatewaySessionsLength: 0, sessionsGeneration: -1, sessionsError: "boom" }),
+			false,
+		);
+	});
+
+	it("shows the spinner again on Retry after an initial error is cleared (never loaded, error cleared)", () => {
+		assert.equal(
+			isInitialSessionsLoad({ gatewaySessionsLength: 0, sessionsGeneration: -1, sessionsError: "" }),
+			true,
+		);
+	});
+});


### PR DESCRIPTION
## Problem
The left sidebar (and mobile landing list) periodically replaced the whole projects/goals/sessions list with a centered \"Loading…\" placeholder and repopulated — most visible on first load, but recurring every ~5s while idle for any user whose live-session list is legitimately empty (projects/goals present but no live sessions, or no projects at all).

## Root cause
`refreshSessions()` (`src/app/api.ts`) decided "initial load → show spinner" via `state.gatewaySessions.length === 0`. List length is the wrong proxy for "never fetched": an empty live-session list keeps `length === 0` true forever, so every 5s poll tick re-entered initial-load and re-blanked the list.

## Fix
The initial-load decision is extracted into a dependency-free pure helper `isInitialSessionsLoad` (`src/app/session-load-state.ts`), keyed off whether a fetch has ever *completed*:

```ts
return sessionsGeneration < 0 && !sessionsError;
```

`sessionsGeneration` is `-1` until the first successful fetch and `>= 0` thereafter, so the spinner shows exactly once on genuine first load and never re-appears on background polls. The `!sessionsError` term keeps the spinner suppressed while an error is on screen (polls retry silently); a new `retryLoadSessions()` wrapper clears `sessionsError` before re-fetching so the **Retry** button restores the one-time spinner after an initial-load failure (both Retry buttons in `sidebar.ts` / `render.ts` repointed to it).

No loading-placeholder markup or polling-interval changes.

## Tests
- New regression test `tests/sidebar-loading-flash.test.ts` (TDD red→green): proves a second poll tick with an empty list does **not** re-enter initial-load once `sessionsGeneration >= 0`, while genuine first load and post-error retry still show the spinner.
- `npm run check`, `npm run test:unit`, and the full implementation gate (build, type-check, repro, unit, E2E, code/security/coverage reviews, QA) all pass.

## Docs
- `docs/debugging.md`: new symptom→fix entry.
- `docs/session-refresh.md`: "Initial-load spinner gating" section + file-map updates.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)