### PR TITLE
Add view link to read_session renderer; warn against same-target parallel tool calls

### DIFF
--- a/defaults/system-prompt.md
+++ b/defaults/system-prompt.md
@@ -10,6 +10,16 @@ Delegating to **read + analyse/transform** is fine — the delegate does real wo
 
 **When to delegate:** Use `delegate` (including `parallel` delegates) for sub-tasks that involve multi-step reasoning the delegate completes autonomously — code changes across many files, independent investigations, analysing or reviewing modules, researching separate topics, writing documentation. The key test: does the delegate do substantial work and return a result that is smaller or more useful than the raw inputs? If yes, delegate. If the delegate is just a proxy for a tool call you could make directly, don't.
 
+# Parallel tool calls that mutate the same target
+
+Parallelism is only safe for *independent* operations. **Never schedule multiple tool calls in the same message that mutate the same target** — they race against shared state and fail or corrupt it. This includes:
+
+- Multiple `Edit` calls to the same file (or `Edit` + `Write` on it).
+- Multiple `edit_proposal` calls editing the same proposal draft (use one call, or sequence them across turns).
+- Any pair of writes to the same file, gate, task, or proposal.
+
+Either batch all the changes into a single tool call (e.g. one `Edit` with multiple `edits`, one `Write` with the full content), or issue them sequentially — wait for each to complete before the next. Parallelism is fine when the targets are distinct (reading many files, editing different files).
+
 # Scoping searches
 
 Always pass `rg` / `grep` / `find` an explicit, tight path. Procedure:

--- a/src/ui/tools/renderers/ReadSessionRenderer.ts
+++ b/src/ui/tools/renderers/ReadSessionRenderer.ts
@@ -12,6 +12,7 @@ import { createRef, ref } from "lit/directives/ref.js";
 import { History, ExternalLink } from "lucide";
 import { renderCollapsibleHeader, getToolState } from "../renderer-registry.js";
 import type { ToolRenderer, ToolRenderResult } from "../types.js";
+import { renderSessionLink } from "./delegate-cards.js";
 
 interface ReadSessionParams {
 	session_id: string;
@@ -237,7 +238,7 @@ export class ReadSessionRenderer implements ToolRenderer<ReadSessionParams, Read
 				content: html`
 					<div>
 						${renderCollapsibleHeader(state, History,
-							html`read_session <span class="font-mono text-xs">${sidShort}</span> — <span class="text-destructive text-xs">error</span>`,
+							html`read_session <span class="font-mono text-xs">${sidShort}</span> — <span class="text-destructive text-xs">error</span> ${sid ? renderSessionLink(sid) : ""}`,
 							contentRef, chevronRef, true)}
 						<div ${ref(contentRef)} class="max-h-[2000px] mt-3 overflow-hidden transition-all duration-300">
 							<div class="text-xs font-mono text-destructive whitespace-pre-wrap">${txt}</div>
@@ -266,7 +267,7 @@ export class ReadSessionRenderer implements ToolRenderer<ReadSessionParams, Read
 			content: html`
 				<div>
 					${renderCollapsibleHeader(state, History,
-						html`read_session <span class="font-mono text-xs">${sidShort}</span> — ${summaryFragment}`,
+						html`read_session <span class="font-mono text-xs">${sidShort}</span> — ${summaryFragment} ${sid ? renderSessionLink(sid) : ""}`,
 						contentRef, chevronRef, true)}
 					<div ${ref(contentRef)} class="max-h-[2000px] mt-3 overflow-hidden transition-all duration-300">
 						<div class="space-y-1">


### PR DESCRIPTION
## Summary

Two small fixes bundled on this branch:

1. **`read_session` renderer — view session link**
   Adds an inline `view` session link to the `read_session` tool renderer header (both success and error states), matching the pattern used by the `team_spawn` / `team_prompt` renderers. Uses the shared `renderSessionLink` helper, navigating in-place to `#/session/<id>`.

2. **System prompt — parallel tool-call guidance**
   Warns agents against issuing parallel tool calls that mutate the same target, to avoid overlapping/conflicting edits.

## Testing

- `npm run check` passes (server + web type-check, no emit).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
