### PR TITLE
Collapse read_session renderer by default

### DIFF
--- a/src/ui/tools/renderers/ReadSessionRenderer.ts
+++ b/src/ui/tools/renderers/ReadSessionRenderer.ts
@@ -268,8 +268,8 @@ export class ReadSessionRenderer implements ToolRenderer<ReadSessionParams, Read
 				<div>
 					${renderCollapsibleHeader(state, History,
 						html`read_session <span class="font-mono text-xs">${sidShort}</span> — ${summaryFragment} ${sid ? renderSessionLink(sid) : ""}`,
-						contentRef, chevronRef, true)}
-					<div ${ref(contentRef)} class="max-h-[2000px] mt-3 overflow-hidden transition-all duration-300">
+						contentRef, chevronRef, false)}
+					<div ${ref(contentRef)} class="max-h-0 overflow-hidden transition-all duration-300">
 						<div class="space-y-1">
 							${messages.length === 0
 								? html`<div class="text-xs text-muted-foreground italic">No messages in window.</div>`


### PR DESCRIPTION
## Summary

Follow-up to #735. The `read_session` tool renderer was still expanded by default after a hard refresh — only the chevron icon reflected the collapsed state, not the content's initial height class.

This collapses the success-state renderer by default: the content div now initializes with `max-h-0` and the collapsed chevron, expanding via the chevron toggle. The error state is intentionally left expanded so failures stay visible.

## Testing

- `npm run check` passes (server + web type-check, no emit).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
