### PR TITLE
fix(tests): extension-host docs residual sandbox term failing — stale framing survived

### DIFF
--- a/docs/extension-host-authoring.md
+++ b/docs/extension-host-authoring.md
@@ -366,7 +366,7 @@ terminated on timeout (the CPU control), bounded by memory caps, and any child p
 spawns is SIGKILLed on terminate. Separately, the module graph's `import`/`require` resolution
 is **confined to the pack root** — so a handler may `import("../lib/helper.mjs")` (a sibling
 of `tools/`), but an import that resolves outside the pack root is rejected. That containment
-is import hygiene / loader stability, **not** a capability sandbox (it is near-cosmetic now
+is import hygiene / loader stability, **not** an OS-level security boundary (it is near-cosmetic now
 that `fs` is ambient).
 
 > **Confinement root = pack root.** Earlier the import-containment root was the tool's group


### PR DESCRIPTION
## Failing test

`tests/extension-host-no-capability-sandbox-residual.test.ts` — `the extension-host docs contain no sandbox-framing terms or the manifest key token`

## Observed vs expected

- Observed: `npm run test:unit` failed because `docs/extension-host-authoring.md` still contained the forbidden doc phrase `capability sandbox`.
- Expected: extension-host authoring docs avoid all deleted capability-sandbox framing after the sandbox removal.

## Root cause

A V1 schema doc update retained one stale comparison phrase while explaining import containment. The guard test intentionally rejects this wording so the old sandbox model is not reintroduced in public docs.

## Changed

Reworded the import-containment note to say it is not an OS-level security boundary, avoiding the removed sandbox framing while preserving the intended warning.

## Verification

- `npx tsx --import ./tests/helpers/css-stub-loader.mjs --test --test-force-exit tests/extension-host-no-capability-sandbox-residual.test.ts` — pass (`4/4`)
- `npm run check` — pass
- `node .bobbit/state/guardian/run.mjs` — pass (`nodeFail: 0`, Playwright `1379` passed, `2` skipped)
- Focused slow-sample rerun: `npx playwright test --config tests/playwright.config.ts --workers=1 ...` — pass (`154` passed); slow samples were not confirmed under focused rerun

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
