### PR TITLE
fix(tests): full unit suite flaky — harden load-sensitive waits

### DIFF
--- a/tests/goal-push-safety-regression.test.ts
+++ b/tests/goal-push-safety-regression.test.ts
@@ -83,7 +83,10 @@ async function waitForPublishedUpstream(
 	branch: string,
 ): Promise<{ upstreamName: string; remoteSha: string }> {
 	const expectedUpstream = `origin/${branch}`;
-	const deadline = Date.now() + 10_000;
+	// Full unit runs exercise many git-heavy fixtures concurrently on Windows;
+	// keep this eventual-background-publish wait long enough to test the
+	// contract instead of scheduler contention.
+	const deadline = Date.now() + 60_000;
 	let lastUpstream: string | null = null;
 	let lastRemoteSha: string | null = null;
 

--- a/tests/verification-harness-timeout.test.ts
+++ b/tests/verification-harness-timeout.test.ts
@@ -74,28 +74,24 @@ function makeHarness() {
 
 /**
  * Inline JS payload (passed via `node -e`) that:
- *   - prints `PARENT_PID=<pid>`
- *   - spawns an inner `node -e` child that prints `CHILD_PID=<pid>` and idles
- *   - pipes the inner stdout through so the parent's stdout carries both
+ *   - spawns an inner `node -e` child that idles
+ *   - prints both `PARENT_PID=<pid>` and `CHILD_PID=<pid>` from the parent
+ *     immediately after spawn
  *   - idles forever (the test kills the parent via tree-kill)
  *
  * Works identically on POSIX and Windows.
  */
-// Inner script: print CHILD_PID then idle. The child writes through its own
-// piped stdout, which the parent forwards onto its own stdout. We wait for
-// the first chunk before printing PARENT_PID so the test always sees both
-// pids together (no timing window where only PARENT_PID is visible).
-// Three-level escaping (this TS source → outer node -e → inner node -e).
-// To get a real newline written by the innermost script, the inner-
-// inner JS source string must contain the literal sequence `\n` (two
-// chars). The outer payload is itself a JS string, so we double again
-// to `\\n`. That requires four backslashes in this TS source.
+// Inner script: idle forever. The parent reports both PIDs synchronously
+// immediately after spawn (`child.pid` is available as soon as the OS child
+// exists). Do not wait for the child to schedule and write stdout here: under
+// full-suite load on slow Windows workers the 2s timeout can fire before that
+// asynchronous round-trip, making the test fail before it has the PIDs needed
+// to verify tree-kill.
 const TREE_PAYLOAD = [
 	'var cp=require("child_process");',
-	'var inner=\'process.stdout.write("CHILD_PID="+process.pid+"\\\\n");setInterval(function(){},1000);\';',
-	'var c=cp.spawn(process.execPath,["-e",inner],{stdio:["ignore","pipe","inherit"]});',
-	'c.stdout.on("data",function(d){process.stdout.write(d);});',
-	'c.stdout.once("data",function(){process.stdout.write("PARENT_PID="+process.pid+"\\n");});',
+	'var inner=\'setInterval(function(){},1000);\';',
+	'var c=cp.spawn(process.execPath,["-e",inner],{stdio:["ignore","ignore","inherit"]});',
+	'process.stdout.write("PARENT_PID="+process.pid+"\\nCHILD_PID="+c.pid+"\\n");',
 	'setInterval(function(){},1000);',
 ].join("");
 
@@ -144,7 +140,7 @@ describe("spawn-tree helper", () => {
 		t.killTree("SIGKILL", 0);
 		await new Promise<void>((resolve) => t.child.once("close", () => resolve()));
 
-		const cleaned = await poll(() => !isAlive(parentPid) && !isAlive(childPid), 3000);
+		const cleaned = await poll(() => !isAlive(parentPid) && !isAlive(childPid), 10_000);
 		assert.ok(cleaned, `both pids should be reaped; parent=${isAlive(parentPid)} child=${isAlive(childPid)}`);
 	});
 
@@ -185,7 +181,7 @@ describe("runCommandStep tree-kill", () => {
 		const parentPid = Number(parentMatch![1]);
 		const childPid = Number(childMatch![1]);
 
-		const dead = await poll(() => !isAlive(parentPid) && !isAlive(childPid), 5000);
+		const dead = await poll(() => !isAlive(parentPid) && !isAlive(childPid), 10_000);
 		assert.ok(dead, `descendants should be reaped after timeout; parent=${isAlive(parentPid)} child=${isAlive(childPid)}`);
 	});
 
@@ -226,7 +222,7 @@ describe("runCommandStep tree-kill", () => {
 
 		await harness.cancelStaleVerifications(goalId, gateId);
 
-		const dead = await poll(() => !isAlive(parentPid) && !isAlive(childPid), 3000);
+		const dead = await poll(() => !isAlive(parentPid) && !isAlive(childPid), 10_000);
 		assert.ok(dead, `tree should be reaped within budget; parent=${isAlive(parentPid)} child=${isAlive(childPid)}`);
 
 		const result = await stepPromise;

--- a/tests/worktree-pool.test.ts
+++ b/tests/worktree-pool.test.ts
@@ -74,16 +74,22 @@ describe("WorktreePool — Phase 3 claim sequence", () => {
 				await new Promise(r => setTimeout(r, 100));
 			}
 			assert.equal(pool.size, 1, "pool should have one entry after fill");
+			const { stdout: beforeBranchList } = await execFile("git", ["branch", "--list", "pool/_pool-*", "--format=%(refname:short)"], { cwd: repo });
+			const originalPoolBranch = beforeBranchList.trim();
+			assert.ok(originalPoolBranch.startsWith("pool/_pool-"), `fixture should have one pool branch, got: ${beforeBranchList}`);
 
 			const claim = await pool.claim("session/abcd1234");
 			assert.ok(claim, "claim should succeed");
 			assert.equal(claim!.branchName, "session/abcd1234");
 			assert.equal(claim!.degraded, false);
 
-			// Verify the branch was renamed (no `pool/_pool-*` branch left).
-			const { stdout: branchList } = await execFile("git", ["branch", "--list"], { cwd: repo });
-			assert.ok(branchList.includes("session/abcd1234"), "target branch should exist");
-			assert.ok(!branchList.includes("pool/_pool-"), "pool branch should be gone");
+			// Verify the claimed branch was renamed. claim() replenishes the pool in
+			// the background, so a different pool/_pool-* branch may already exist;
+			// only the original claimed pool branch must be gone.
+			const { stdout: branchList } = await execFile("git", ["branch", "--list", "--format=%(refname:short)"], { cwd: repo });
+			const branches = branchList.split(/\r?\n/).map(b => b.trim()).filter(Boolean);
+			assert.ok(branches.includes("session/abcd1234"), "target branch should exist");
+			assert.ok(!branches.includes(originalPoolBranch), "claimed pool branch should be gone");
 
 			// Verify the directory was moved (path basename is the flattened slug).
 			assert.equal(path.basename(claim!.worktreePath), "session-abcd1234");


### PR DESCRIPTION
## Failing/flaky tests

- `tests/verification-harness-timeout.test.ts` — command-step tree-kill timeout/cancellation tests
- `tests/goal-push-safety-regression.test.ts` — claimed pool branch publish/upstream repair
- `tests/worktree-pool.test.ts` — happy-path pool claim branch rename assertion

## Observed vs expected

During guardian runs for `1272afc5`, the full unit suite intermittently failed while targeted reruns passed. Failures were caused by full-suite Windows scheduler/git contention, not product behavior:

- tree-kill fixture timed out before child stdout round-tripped, or before Windows process-tree reap was observable
- background pool publish/upstream repair exceeded the short eventual-consistency wait
- pool claim assertion rejected any replenished `pool/_pool-*` branch, even though `claim()` intentionally starts background replenishment immediately

## Root cause

The tests had timing/order assumptions that are false under full-suite load: async child stdout, short process-reap/publish polling budgets, and assuming no replacement pool branch appears after claim.

## Changed

- Report tree-kill parent/child PIDs synchronously from the parent process and use a larger observation budget for OS process reap.
- Extend the background publish/upstream wait to test the eventual contract instead of scheduler contention.
- Assert that the original claimed pool branch is gone, while allowing a new replenishment pool branch.

## Verification

- `npx tsx --import ./tests/helpers/css-stub-loader.mjs --test --test-force-exit tests/verification-harness-timeout.test.ts tests/goal-push-safety-regression.test.ts` — pass (`11/11`)
- `npx tsx --import ./tests/helpers/css-stub-loader.mjs --test --test-force-exit tests/worktree-pool.test.ts` — pass (`11/11`)
- `npm run check` — pass
- `node .bobbit/state/guardian/run.mjs` — pass (`nodeFail: 0`, Playwright `1379` passed, `2` skipped)
- Focused slow-sample rerun: `npx playwright test --config tests/playwright.config.ts --workers=1 ...` — pass (`293` passed); slow samples were not confirmed under focused rerun

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
