### PR TITLE
Marketplace UI polish

### DIFF
--- a/docs/design/pack-based-marketplace.md
+++ b/docs/design/pack-based-marketplace.md
@@ -613,11 +613,11 @@ New endpoints (added in `server.ts::handleApiRoute`). Responses reuse existing c
 | `POST /api/marketplace/sources` | Add a source `{ url, ref? }` → syncs + returns the created source. |
 | `DELETE /api/marketplace/sources/:id` | Remove a source (and its cache dir). |
 | `POST /api/marketplace/sources/:id/sync` | Re-sync (re-clone/fetch); returns updated `lastCommit`. |
-| `GET /api/marketplace/sources/:id/packs` | Browse: `{ packs: Array<PackManifest & { dirName, hasTools }> }`. `hasTools` is informational (declared-entity rendering); it no longer drives a per-pack install gate. |
+| `GET /api/marketplace/sources/:id/packs` | Browse: `{ packs: Array<PackManifest & { dirName, hasTools, descriptions? }> }`. `hasTools` is informational (declared-entity rendering); it no longer drives a per-pack install gate. `descriptions?` carries optional one-line per-entity copy (§9.1/§10.4 R3). |
 | `POST /api/marketplace/install` | Body `{ sourceId, packName, scope, projectId? }` → installs; returns `.pack-meta.yaml`. |
 | `POST /api/marketplace/update` | Body `{ scope, packName, projectId? }` → updates; returns new meta. |
 | `DELETE /api/marketplace/installed` | Body `{ scope, packName, projectId? }` → uninstall. |
-| `GET /api/marketplace/installed?projectId=` | List installed packs across all scopes with provenance (`PackMeta[]` + manifest + scope). |
+| `GET /api/marketplace/installed?projectId=` | List installed packs across all scopes with provenance (`PackMeta` + manifest + scope), plus `updateAvailable` + `sourceStatus` (sync-free update gating) per row (§9.1/§10.4 R2). |
 | `GET /api/packs/conflicts?projectId=` | List `(type, name, winner, shadowed[])` conflicts for the resolved list. |
 
 - `scope` ∈ `"global-user" | "server" | "project"`; `projectId` required when `scope === "project"`.

--- a/docs/design/pack-based-marketplace.md
+++ b/docs/design/pack-based-marketplace.md
@@ -635,13 +635,36 @@ All responses are JSON. `scope` values use the wire form `"global-user" | "serve
 // Shared wire types
 interface SourceWire { id: string; url: string; ref?: string; addedAt: string;
                        lastSyncedAt?: string; lastCommit?: string; }
-interface BrowsePackWire extends PackManifest { dirName: string; hasTools: boolean; }
+// One-line, per-entity descriptions sourced from the pack DIR (not the runtime
+// APIs), keyed by the same identity the toggles/chips use: roles/skills by name,
+// tools by GROUP name, entrypoints by `listName`. Best-effort — a kind is
+// omitted when no entity in it has a usable description, an entity is omitted
+// when its description is missing/empty. Carried on BOTH wire shapes so the
+// "Show details" disclosure works for installed AND not-yet-installed packs.
+interface PackEntityDescriptions {
+  roles?:       Record<string, string>;
+  tools?:       Record<string, string>;
+  skills?:      Record<string, string>;
+  entrypoints?: Record<string, string>;
+}
+interface BrowsePackWire extends PackManifest {
+  dirName: string;
+  hasTools: boolean;
+  descriptions?: PackEntityDescriptions;   // §10.4 R3
+}
 interface InstalledPackWire {
   scope: "global-user" | "server" | "project";
   packName: string;
   manifest: PackManifest;          // from pack.yaml
   meta: PackMeta;                  // from .pack-meta.yaml
   status: "ok" | "corrupt";        // corrupt = missing/invalid meta (§8.1 guard)
+  // §10.4 R2 — update gating, computed WITHOUT a network sync (reads the
+  // existing local cache only; see `MarketplaceInstaller.listInstalled`).
+  updateAvailable: boolean;        // true iff source's latest manifest version
+                                   //   differs from installed meta.version AND
+                                   //   the source could be checked.
+  sourceStatus: "ok" | "unknown";  // "unknown" = source removed / never-synced /
+                                   //   no version data ⇒ render "Source not found".
 }
 interface ConflictWire {
   type: "roles" | "tools" | "skills";
@@ -666,6 +689,8 @@ interface ConflictWire {
 
 - **No per-pack install gate.** Trust is handled once at the source-add boundary via a blanket warning + "Why?" disclosure (§10.2); the client POSTs `install` directly with no executable-code confirmation. The server never required a confirmation flag, and install of any pack is unrestricted. `hasTools` in the browse payload is now informational only.
 - **Reload/cache behavior:** install/update/uninstall invalidate the affected scope's resolver cache (and the `slash-skills.ts` TTL cache) synchronously before returning, so a subsequent `GET /api/roles|tools|skills` reflects the change immediately (no client reload required). `pack_order` mutations do the same.
+- **Update detection is sync-free (§10.4 R2).** `GET /api/marketplace/installed` enriches each row with `updateAvailable` + `sourceStatus`, but **never triggers a `git fetch`** — it reads only the *existing* local source cache (a git source's already-cloned cache dir, or a local-dir source read in place). The list endpoint is hit on every Market-page open, so a network sync per pack would be slow and could fail offline; the cheap local-cache read is good enough because explicit "Re-sync" / Update already refresh the cache when the user wants live data. A miss (source unregistered, never synced, cache absent, pack not found, or no source version) yields `sourceStatus: "unknown"` rather than a false "up to date", letting the UI disambiguate the two.
+- **Browse descriptions:** `GET /api/marketplace/sources/:id/packs` adds an optional `descriptions` map per pack (§10.4 R3), read from the synced source's pack dir.
 - **Idempotency / concurrency:** install is rejected (`409`) if `dest` exists; the atomic-rename (§8.1) makes concurrent installs of the same `(scope, packName)` safe — the loser sees `EEXIST`/`409`.
 
 ### 9.2 `pack-order` contract (the sole conflict-resolution wire path)
@@ -720,6 +745,39 @@ Reuse config-page conventions (`config-scope.ts`: `renderConfigScopeRow`, `rende
 ### 10.3 Config-page integration
 
 Roles (`#/roles`), Tools (`#/tools`), Skills (`#/skills`) pages need no structural change — they already render `origin`/`overrides` badges and scope rows. They will now show market-pack-originated entities with the pack as origin (badge value per §5.2). Optionally show the pack name in a tooltip on the badge.
+
+### 10.4 Marketplace UI polish
+
+A follow-up pass (`goal/marketplace-ui-b94dadf1`) tightened the Market surface for readability and to surface install/update state honestly. Theme tokens only — no hardcoded palette, no `:root` overrides (see the `marketplace.css` header). All affordances preserve the existing data-testids and add new ones for the new controls. The four requirement areas (R1–R4):
+
+**R1 — Standalone activation help removed.** The explanatory paragraph that used to render below the activation toggles (`.market-activation-help`) was deleted. *Why:* the toggles are self-explanatory once the per-entity descriptions (R3) are available; the paragraph was noise that competed with the pack provenance and action buttons for vertical space.
+
+**R2 — Update button gating + "Source not found" lozenge.** `renderInstalledPackCard()` previously always rendered an **Update** button. It is now gated on `updateAvailable`:
+- `updateAvailable: true` → render **Update** (`data-testid="market-update-pack"`).
+- else `sourceStatus: "unknown"` → render a muted/warning **"Source not found"** lozenge (`data-testid="market-source-unknown"`) in place of Update, with a tooltip explaining the source is unregistered or unsynced so updates can't be checked.
+- else (up to date, source ok) → render neither.
+- **Uninstall stays always available** regardless of source state — a user must always be able to remove an installed pack even if its source is gone.
+
+  *Why the `updateAvailable` / `sourceStatus` split:* a single boolean can't distinguish "confirmed up to date" from "we couldn't check". Showing nothing in the unknown case would imply the pack is current; showing a stale Update button would be misleading. The two-field contract (§9.1) lets the UI render the honest third state. **Change detection is version-based:** the source's latest **manifest version** is compared (string inequality) against the installed `meta.version` — not commit SHAs or file diffs — which is cheap, deterministic, and matches the semver the publisher advertises. Computed server-side in `MarketplaceInstaller.listInstalled()` via `computeSourceState()`, reading the local cache only (no `git fetch`; see §9.1).
+
+**R3 — Per-entity one-line descriptions in a collapsed disclosure.** Each declared role / tool / skill / entry point can now show a one-line description, sourced from the pack dir by `readPackEntityDescriptions()`:
+- Roles: `roles/<name>.yaml` `description` (falling back to `label` when it differs from the name).
+- Tools: a representative `tools/<group>/*.yaml` `description` (keyed by **group** name — the manifest declares tools at group granularity).
+- Skills: `skills/<name>/SKILL.md` frontmatter `description`.
+- Entry points: the entrypoint YAML `description` (falling back to its `label`), keyed by `listName`.
+
+Descriptions are carried on **both** `PackActivationCatalogue` (Installed list) and `BrowsePackWire` (Browse card) and rendered identically by a shared `renderEntityDetails()` helper inside a `<details>` disclosure labelled **"Show details"** (`data-testid="market-entity-details-<packName>"`), **collapsed by default**. *Why collapsed:* the entity-name chips and toggles stay the at-a-glance default; descriptions are progressive disclosure for users who want detail, so a pack with many entities doesn't produce a wall of text. Rows with no description are omitted; the disclosure is omitted entirely when no row would render (graceful degradation).
+
+This is read from the **same authoritative pack dir** the activation catalogue reads from — never `/api/tools` or `/api/ext/contributions` — preserving the invariant that the catalogue is the UNFILTERED source for toggles (§9, pack-schema-v1 §9). **Path-traversal safety:** `validateManifest` does not guard `contents.roles/tools/skills` names against `..` or path separators, and this helper runs on **Browse** (before any install), so every manifest-declared name is validated with `isSafeBasename` + a realpath-aware containment check (`isPackPathWithinRoot`) before any filesystem read. A rejected name simply yields no description row.
+
+**R4 — Browse install-state indicators.** `renderBrowsePackCard()` now cross-references the installed list to reflect what's already installed *at the currently-selected install scope* (including project identity — see finding #2):
+- not installed → **Install** button (`data-testid="market-install-pack"`, unchanged).
+- installed but behind the source's latest (same version comparison as R2) → **Update** button.
+- installed and current → an **"Installed"** lozenge (`data-testid="market-browse-installed"`).
+
+`installedMatchForBrowse()` resolves the match by pack name within the selected scope; for project scope it only matches when the Installed list was loaded for that same project, avoiding a wrong-project false positive. *Why:* without this, Browse always offered "Install" even for packs already present, leading to confusing `409 already installed` errors; surfacing state up front guides the user to the correct action.
+
+**Scope/project-focus discipline (finding #2, unchanged):** install/update/uninstall and the Installed-list query all address the **same project** the install targeted (`focusProjectId`), so the indicators and actions never drift to the active/first project.
 
 ---
 

--- a/docs/design/pack-schema-v1-rationalisation.md
+++ b/docs/design/pack-schema-v1-rationalisation.md
@@ -1002,7 +1002,9 @@ does not register/resolve); they never feed the activation controls.
 - container: `data-testid="market-activation-<packName>"`
 - per-entity toggle: `data-testid="market-toggle-<kind>-<name>"` (kind ∈ `role|tool|skill|entrypoint`;
   for entrypoints `<name>` = `listName`).
-- the explanatory copy: `data-testid="market-activation-help"`.
+- collapsed entity-description disclosure (Marketplace UI polish §10.4 R3): `data-testid="market-entity-details-<packName>"`,
+  with per-row `data-testid="market-entity-desc-<kind>-<name>"`. (The former standalone explanatory copy
+  `data-testid="market-activation-help"` was REMOVED — the toggles + per-entity descriptions stand on their own.)
 
 After a toggle PUT, re-run the same reconcile the marketplace mutation path already triggers (it
 re-fetches tool/contribution metadata and re-registers renderers/panels/entrypoints — see

--- a/docs/design/pack-schema-v1-rationalisation.md
+++ b/docs/design/pack-schema-v1-rationalisation.md
@@ -837,7 +837,13 @@ GET  /api/marketplace/pack-activation?scope=<scope>&projectId=<id>&packName=<nam
            roles:       string[],   // = installed pack manifest.contents.roles
            tools:       string[],   // = manifest.contents.tools
            skills:      string[],   // = manifest.contents.skills
-           entrypoints: Array<{ listName: string; label?: string }>  // = contents.entrypoints (+ display label from the entrypoint file)
+           entrypoints: Array<{ listName: string; label?: string }>,  // = contents.entrypoints (+ display label from the entrypoint file)
+           descriptions?: {         // OPTIONAL one-line per-entity descriptions for the
+             roles?:       Record<string, string>,   //   "Show details" disclosure (pack-based-marketplace §10.4 R3).
+             tools?:       Record<string, string>,   //   Read from the SAME installed pack dir as the
+             skills?:      Record<string, string>,   //   catalogue above — keyed by name (roles/skills),
+             entrypoints?: Record<string, string>    //   GROUP name (tools), or listName (entrypoints).
+           }
          },
          disabled: DisabledRefs   // current overrides (default {} = all enabled)
        }
@@ -861,6 +867,14 @@ follow-up `GET` after a toggle. The entrypoint `label` is a display convenience 
 
 Normalisation on PUT: drop refs for entities the pack does not declare (best-effort, validated against
 the same manifest `contents` catalogue), persist, invalidate caches.
+
+The optional **`catalogue.descriptions`** map carries one-line, per-entity descriptions read from the
+installed pack dir (role/tool YAML, skill SKILL.md frontmatter, entrypoint metadata) by
+`readPackEntityDescriptions()`. The Market UI renders them in a collapsed "Show details" disclosure next
+to the toggles. It is read from the **same** authoritative pack dir as the catalogue — never the
+runtime-filtered `/api/tools` or `/api/ext/contributions` — and every manifest-declared name is
+path-validated before any filesystem read. See [pack-based-marketplace.md §10.4 (R3)](pack-based-marketplace.md)
+for the full UI behaviour and rationale.
 
 ---
 

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -69,6 +69,16 @@ Private repos rely on your ambient git credentials (credential helper / SSH agen
 
 Select a source to list its packs. Each pack shows its name, version, description, and declared entities (the `contents` from `pack.yaml`, rendered as chips). A directory in the source is only treated as a pack if it contains a valid `pack.yaml`; anything else (a `README.md`, a `docs/` folder) is ignored.
 
+**Per-entity descriptions.** Below the entity chips, a collapsed **"Show details"** disclosure (a `<details>` element) reveals a one-line description for each declared role, tool, skill, and entry point. Descriptions are read straight from the pack dir on the source — role frontmatter, a representative tool-group YAML, skill `SKILL.md` frontmatter, and entry-point YAML respectively. The disclosure is collapsed by default so the at-a-glance chips stay the default and the descriptions are progressive disclosure — a pack with many entities never produces a wall of text. Entities without a description are simply omitted, and the disclosure disappears entirely when nothing would render.
+
+**Install state is reflected up front.** Rather than always offering an Install button, the browse card cross-references the installed list for the **currently-selected install scope** (project identity included, so it never matches a different project):
+
+- Not installed → an **Install** button (`market-install-pack`).
+- Installed but behind the source's latest version (same version comparison as [Updating and uninstalling](#updating-and-uninstalling)) → an **Update** button (`market-browse-update-pack`).
+- Installed and current → an **"Installed"** indicator (`market-browse-installed`).
+
+Why surface this on Browse? Without it, Browse always said "Install" even for packs already present, so users hit confusing `409 already installed` errors; showing the real state guides them to the correct action.
+
 ### Installing to a scope
 
 Each pack has an **Install** button with a scope picker. Installing copies the pack's directory verbatim into the chosen scope's `market-packs/<pack-name>/` and writes a generated `.pack-meta.yaml` recording provenance. Every contained role/tool/skill then resolves through the single resolver, tagged with that pack as its `origin`.
@@ -92,10 +102,23 @@ There is no signing, and the worker isolation around pack server modules is **st
 
 The **Installed** panel lists installed packs grouped by scope, each with the provenance from its `.pack-meta.yaml`: origin source URL, version, commit short SHA, and install/updated dates. A partially-copied or corrupt install (missing/invalid `.pack-meta.yaml`) is surfaced with a `corrupt` status so you can re-install or clean it up; corrupt packs are ignored by the resolver.
 
+Each installed pack also carries two install-state signals on its wire row (`InstalledPackWire`): `updateAvailable` (boolean) and `sourceStatus` (`"ok" | "unknown"`). These drive the action column honestly:
+
+- **Up to date** (`updateAvailable: false`, `sourceStatus: "ok"`) → no Update button. There is nothing to do, so nothing is shown.
+- **Update available** (`updateAvailable: true`) → an **Update** button (`market-update-pack`).
+- **Source can't be checked** (`sourceStatus: "unknown"` — the originating source was removed, never synced, or carries no version data) → a muted/warning **"Source not found"** lozenge (`market-source-unknown`) in place of the Update button.
+- **Uninstall is always available**, regardless of source state — you must always be able to remove an installed pack even if its source is gone.
+
+Why two fields instead of one boolean? A single "update available" flag can't distinguish *confirmed up to date* from *couldn't check*. Showing nothing in the unknown case would falsely imply the pack is current, and showing a stale Update button would mislead. The `updateAvailable` + `sourceStatus` split lets the UI render the honest third state — the "Source not found" lozenge.
+
 ### Updating and uninstalling
 
 - **Update** re-syncs the originating source, re-resolves the commit, and atomically replaces the installed directory (preserving the original `installedAt`, bumping `updatedAt`). Re-syncing a source then updating reflects upstream changes.
 - **Uninstall** deletes the pack directory and removes it from the scope's `pack_order`. Because the directory is the unit of truth, uninstall removes exactly what install added — no orphans.
+
+**When the Update button appears (change detection).** The Update button is shown only when the source's latest **manifest version** differs from the installed `.pack-meta.yaml` version — a plain version-string comparison, not a commit-SHA or file diff. This is cheap, deterministic, and matches the semver the publisher advertises.
+
+Crucially, this comparison is computed **server-side without a network sync**: it reads only the *existing* local source cache (a git source's already-cloned cache dir, or a local-dir source read in place). Why sync-free? The installed list (`GET /api/marketplace/installed`) is fetched on every Market-page open, and doing a per-pack `git fetch` there would be slow and would fail outright when offline. The cheap local-cache read is good enough to flag a likely update; the explicit **"Re-sync"** action (and the Update action itself) still refresh the source live, so a deliberate check is always one click away.
 
 ### Resolving same-name conflicts
 
@@ -136,6 +159,22 @@ register/resolve). The `PUT` returns the refreshed catalogue alongside the norma
 `disabled`, then invalidates resolver caches so the effect is live without a reload. Scope
 split mirrors `pack_order`: project activation lives in the project config, server +
 global-user in the server config.
+
+**No standalone help paragraph.** An earlier version rendered an explanatory paragraph below
+the toggles; it has been removed. Once each entity carries its own one-line description (below),
+the toggles are self-explanatory and the paragraph was just noise competing with the pack
+provenance and action buttons for vertical space.
+
+**Per-entity descriptions (collapsed by default).** As on the Browse card, each installed pack
+exposes a collapsed **"Show details"** disclosure listing a one-line description per declared
+role / tool / skill / entry point. The descriptions are read straight from the **installed pack's
+manifest/dir** — the same authoritative source the activation catalogue reads from, **never**
+from `/api/tools` or `/api/ext/contributions`. This preserves the unfiltered-catalogue invariant:
+if the descriptions came from the runtime-filtered endpoints, a disabled entity would vanish and
+become impossible to re-enable. Manifest-declared entity names are **path-validated** (safe
+basename + a realpath-aware pack-root containment check) before any file is read, because the
+manifest's `contents` names are publisher-authored and this helper also runs on Browse, before
+any install. A rejected name simply yields no description row.
 
 ### Config-page integration
 

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -2513,6 +2513,9 @@ export interface PackManifest {
 		roles: string[];
 		tools: string[];
 		skills: string[];
+		/** Entrypoint `listName` basenames (pack-schema-v1 §1.2). Optional on the
+		 *  client wire — present on browse/installed payloads that declare them. */
+		entrypoints?: string[];
 	};
 }
 
@@ -2536,9 +2539,21 @@ export interface MarketplaceSource {
 	lastCommit?: string;
 }
 
+/** One-line per-entity descriptions sourced from the pack dir (R3). Keyed by the
+ *  same identity the toggles/chips use: roles/skills by name, tools by GROUP
+ *  name, entrypoints by `listName`. MUST stay in sync with the server type of
+ *  the same name (`src/server/agent/marketplace-install.ts`). */
+export interface PackEntityDescriptions {
+	roles?: Record<string, string>;
+	tools?: Record<string, string>;
+	skills?: Record<string, string>;
+	entrypoints?: Record<string, string>;
+}
+
 export interface BrowsePackWire extends PackManifest {
 	dirName: string;
 	hasTools: boolean;
+	descriptions?: PackEntityDescriptions;
 }
 
 export interface InstalledPackWire {
@@ -2547,6 +2562,13 @@ export interface InstalledPackWire {
 	manifest: PackManifest;
 	meta: PackMeta;
 	status: "ok" | "corrupt";
+	/** True iff the source's latest manifest version differs from the installed
+	 *  version AND the source could be checked. MUST stay in sync with the server
+	 *  `InstalledPackWire` (`src/server/agent/marketplace-install.ts`). */
+	updateAvailable: boolean;
+	/** `"unknown"` when the source can't be checked (removed / never-synced / no
+	 *  version data) — disambiguates "up to date" from "source unknown". */
+	sourceStatus: "ok" | "unknown";
 }
 
 export interface ConflictPackRef {
@@ -2678,6 +2700,8 @@ export interface PackActivationCatalogue {
 	tools: string[];
 	skills: string[];
 	entrypoints: Array<{ listName: string; label?: string }>;
+	/** One-line per-entity descriptions for the activation disclosure (R3). */
+	descriptions?: PackEntityDescriptions;
 }
 
 /** GET/PUT /api/marketplace/pack-activation response (§6.7). */

--- a/src/app/marketplace-page.ts
+++ b/src/app/marketplace-page.ts
@@ -46,6 +46,7 @@ import {
 	type MarketplaceSource,
 	type MarketScope,
 	type PackActivationResponse,
+	type PackEntityDescriptions,
 } from "./api.js";
 
 // ============================================================================
@@ -595,6 +596,56 @@ function entityChips(pack: BrowsePackWire | InstalledPackWire): TemplateResult {
 	return html`<div class="flex flex-wrap gap-1">${chips}</div>`;
 }
 
+/** Declared-entity name lists for the description disclosure, across all four
+ *  kinds. Entry points carry an optional display `label`. */
+interface EntityNameLists {
+	roles: string[];
+	tools: string[];
+	skills: string[];
+	entrypoints: Array<{ listName: string; label?: string }>;
+}
+
+/** Shared collapsed "Show details" disclosure (R3) — one row per declared
+ *  entity that HAS a one-line description, across roles/tools/skills/entry
+ *  points. Used by BOTH the Installed activation list and the Browse pack card.
+ *  Rows with no description are omitted; the disclosure is omitted entirely when
+ *  no row would render. Tools are keyed by GROUP name; entrypoints by `listName`
+ *  (kind `entrypoint`). */
+function renderEntityDetails(packName: string, descriptions: PackEntityDescriptions | undefined, entities: EntityNameLists): TemplateResult {
+	if (!descriptions) return html``;
+	const rows: TemplateResult[] = [];
+	const pushRows = (
+		kind: "role" | "tool" | "skill" | "entrypoint",
+		map: Record<string, string> | undefined,
+		names: string[],
+		labelFor?: (n: string) => string,
+	): void => {
+		if (!map) return;
+		for (const name of names) {
+			const desc = map[name];
+			if (!desc) continue;
+			rows.push(html`
+				<div class="market-entity-desc" data-testid="market-entity-desc-${kind}-${name}">
+					<span class="market-entity-desc-name">${labelFor ? labelFor(name) : name}</span>
+					<span class="market-entity-desc-text">${desc}</span>
+				</div>
+			`);
+		}
+	};
+	pushRows("role", descriptions.roles, entities.roles);
+	pushRows("tool", descriptions.tools, entities.tools);
+	pushRows("skill", descriptions.skills, entities.skills);
+	const epLabel = new Map(entities.entrypoints.map((e) => [e.listName, e.label || e.listName]));
+	pushRows("entrypoint", descriptions.entrypoints, entities.entrypoints.map((e) => e.listName), (n) => epLabel.get(n) || n);
+	if (rows.length === 0) return html``;
+	return html`
+		<details class="market-entity-details" data-testid="market-entity-details-${packName}">
+			<summary>Show details</summary>
+			<div class="market-entity-desc-list">${rows}</div>
+		</details>
+	`;
+}
+
 function renderSourcesPanel(): TemplateResult {
 	return html`
 		<section class="market-panel" data-testid="market-sources-panel">
@@ -727,8 +778,45 @@ function renderBrowsePanel(): TemplateResult {
 	`;
 }
 
+/** Find the installed copy of a browse pack AT THE CURRENTLY-SELECTED install
+ *  scope (R4). For project scope the Installed list must be loaded for the
+ *  picked project — if `installProjectId` and `currentProjectId()` diverge we
+ *  treat the pack as not-installed for that project (avoids a wrong-project
+ *  false positive; preserves finding #2). */
+function installedMatchForBrowse(pack: BrowsePackWire): InstalledPackWire | undefined {
+	if (installScope === "project") {
+		if (!installProjectId || installProjectId !== currentProjectId()) return undefined;
+		return installed.find((p) => p.scope === "project" && p.packName === pack.name);
+	}
+	return installed.find((p) => p.scope === installScope && p.packName === pack.name);
+}
+
 function renderBrowsePackCard(pack: BrowsePackWire): TemplateResult {
 	const installing = busy.has(`install:${pack.dirName}`);
+	const match = installedMatchForBrowse(pack);
+	let action: TemplateResult;
+	if (!match) {
+		action = html`
+			<button
+				class="market-btn market-btn--primary shrink-0"
+				data-testid="market-install-pack"
+				?disabled=${installing}
+				@click=${() => handleInstall(pack)}
+			>${icon(Download, "xs")} ${installing ? "Installing…" : "Install"}</button>`;
+	} else if (pack.version !== match.meta.version) {
+		// Installed but behind the source's latest version → offer an update.
+		const isBusy = busy.has(`${match.scope}:${match.packName}`);
+		action = html`
+			<button
+				class="market-btn shrink-0"
+				data-testid="market-browse-update-pack"
+				?disabled=${isBusy}
+				@click=${() => handleUpdate(match)}
+			>${icon(RotateCw, "xs", isBusy ? "animate-spin" : "")} Update</button>`;
+	} else {
+		action = html`<span class="market-lozenge shrink-0" data-testid="market-browse-installed">${icon(Package, "xs")} Installed</span>`;
+	}
+	const entrypointNames = (pack.contents?.entrypoints ?? []).map((listName) => ({ listName }));
 	return html`
 		<div class="market-pack-card" data-testid="market-browse-pack" data-pack-name=${pack.name}>
 			<div class="flex items-start justify-between gap-3">
@@ -739,13 +827,14 @@ function renderBrowsePackCard(pack: BrowsePackWire): TemplateResult {
 					</div>
 					<div class="text-xs text-muted-foreground mt-0.5">${pack.description}</div>
 					<div class="mt-1.5">${entityChips(pack)}</div>
+					${renderEntityDetails(pack.name, pack.descriptions, {
+						roles: pack.contents?.roles ?? [],
+						tools: pack.contents?.tools ?? [],
+						skills: pack.contents?.skills ?? [],
+						entrypoints: entrypointNames,
+					})}
 				</div>
-				<button
-					class="market-btn market-btn--primary shrink-0"
-					data-testid="market-install-pack"
-					?disabled=${installing}
-					@click=${() => handleInstall(pack)}
-				>${icon(Download, "xs")} ${installing ? "Installing…" : "Install"}</button>
+				${action}
 			</div>
 		</div>
 	`;
@@ -825,7 +914,11 @@ function renderInstalledPackCard(pack: InstalledPackWire, scope: MarketScope, in
 						<button class="market-icon-btn" data-testid="market-move-down" title="Move down (higher precedence)" ?disabled=${index === total - 1} @click=${() => movePack(scope, pack.packName, 1)}>${icon(ChevronDown, "xs")}</button>
 					</div>
 					<div class="flex items-center gap-1">
-						<button class="market-btn" data-testid="market-update-pack" ?disabled=${isBusy} @click=${() => handleUpdate(pack)}>${icon(RotateCw, "xs", isBusy ? "animate-spin" : "")} Update</button>
+						${pack.updateAvailable
+							? html`<button class="market-btn" data-testid="market-update-pack" ?disabled=${isBusy} @click=${() => handleUpdate(pack)}>${icon(RotateCw, "xs", isBusy ? "animate-spin" : "")} Update</button>`
+							: pack.sourceStatus === "unknown"
+								? html`<span class="market-lozenge market-lozenge--warning" data-testid="market-source-unknown" title="The originating source is not registered or has not been synced — can't check for updates">${icon(AlertTriangle, "xs")} Source not found</span>`
+								: ""}
 						<button class="market-btn market-btn--danger" data-testid="market-uninstall-pack" ?disabled=${isBusy} @click=${() => handleUninstall(pack)}>${icon(Trash2, "xs")} Uninstall</button>
 					</div>
 				</div>
@@ -901,9 +994,12 @@ function renderActivationControls(pack: InstalledPackWire): TemplateResult {
 		<div class="market-activation" data-testid="market-activation-${pack.packName}">
 			<div class="text-[11px] font-medium text-muted-foreground uppercase tracking-wide mt-2">Activation</div>
 			${groups}
-			<div class="market-activation-help text-[10px] text-muted-foreground/90" data-testid="market-activation-help">
-				Disable an entry point to hide its launcher and deep-link. A tool that opens the same panel is unaffected unless you disable the tool itself. Disabling a tool, role, or skill removes it from its resolved list (a shadowed lower-priority entity may reappear). Panels and routes are support surfaces and stay available while the pack is installed.
-			</div>
+			${renderEntityDetails(pack.packName, cat.descriptions, {
+				roles: cat.roles,
+				tools: cat.tools,
+				skills: cat.skills,
+				entrypoints: cat.entrypoints,
+			})}
 		</div>
 	`;
 }

--- a/src/app/marketplace.css
+++ b/src/app/marketplace.css
@@ -132,6 +132,11 @@
 	border-radius: 0.5rem;
 	padding: 0.625rem 0.75rem;
 	background: var(--background);
+	transition: border-color 0.15s, background 0.15s;
+}
+
+.market-pack-card:hover {
+	border-color: color-mix(in oklch, var(--border) 60%, var(--foreground));
 }
 
 .market-pack-card--drop {
@@ -349,7 +354,82 @@
 	color: var(--muted-foreground);
 }
 
-.market-activation-help {
-	line-height: 1.4;
+/* ── Status lozenges (theme tokens only) ─────────────────────────────────────
+ * Non-button status indicators: "Source not found" (R2) and the Browse
+ * "Installed" marker (R4). A muted base + a warning variant. */
+.market-lozenge {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.1875rem;
+	padding: 0.1875rem 0.4375rem;
+	font-size: 0.6875rem;
+	font-weight: 500;
+	line-height: 1.3;
+	white-space: nowrap;
+	border-radius: 0.375rem;
+	border: 1px solid var(--border);
+	background: var(--muted);
 	color: var(--muted-foreground);
+}
+
+.market-lozenge--warning {
+	border-color: color-mix(in oklch, var(--warning, var(--chart-4)) 35%, transparent);
+	background: color-mix(in oklch, var(--warning, var(--chart-4)) 12%, transparent);
+	color: var(--warning, var(--chart-4));
+}
+
+/* ── Per-entity description disclosure (R3) ──────────────────────────────────
+ * Collapsed by default; visually subordinate (small, muted summary). Shared by
+ * the Installed activation list and the Browse pack card. */
+.market-entity-details {
+	margin-top: 0.125rem;
+	font-size: 0.6875rem;
+	color: var(--muted-foreground);
+}
+
+.market-entity-details > summary {
+	cursor: pointer;
+	font-weight: 500;
+	color: var(--muted-foreground);
+	user-select: none;
+	width: fit-content;
+}
+
+.market-entity-details > summary:hover,
+.market-entity-details > summary:focus-visible {
+	color: var(--foreground);
+}
+
+.market-entity-desc-list {
+	display: flex;
+	flex-direction: column;
+	gap: 0.1875rem;
+	margin-top: 0.25rem;
+	padding-left: 0.5rem;
+	border-left: 2px solid var(--border);
+}
+
+.market-entity-desc {
+	display: flex;
+	align-items: baseline;
+	gap: 0.375rem;
+	min-width: 0;
+}
+
+.market-entity-desc-name {
+	flex-shrink: 0;
+	font-weight: 600;
+	color: var(--foreground);
+}
+
+.market-entity-desc-text {
+	min-width: 0;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	color: var(--muted-foreground);
+}
+
+.market-entity-desc-text::before {
+	content: "— ";
 }

--- a/src/server/agent/marketplace-install.ts
+++ b/src/server/agent/marketplace-install.ts
@@ -16,9 +16,12 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
 import type { PackManifest, PackMeta, PackScope } from "./pack-types.js";
 import { scopePaths } from "./pack-types.js";
 import { isValidPackName, readManifest, readMeta, writeMeta } from "./pack-manifest.js";
+import { loadPackContributions } from "./pack-contributions.js";
+import { parseFrontmatter } from "../skills/slash-skills.js";
 import type { MarketplaceSource, MarketplaceSourceStore } from "./marketplace-source-store.js";
 
 /** Install scopes — builtin is never an install target. */
@@ -33,10 +36,28 @@ export interface PackOrderStore {
 	setPackOrder(scope: PackOrderScope, order: string[]): void;
 }
 
+/**
+ * One-line, per-entity descriptions sourced from a pack dir, keyed by the same
+ * identity the activation catalogue / entity chips use (roles/skills by name,
+ * tools by GROUP name, entrypoints by `listName`). Best-effort: a kind is
+ * omitted entirely when no entity in it has a usable description, and an
+ * individual entity is omitted when its description is missing/empty. This is
+ * the SAME authoritative pack-dir source the activation catalogue reads from —
+ * never `/api/tools` or `/api/ext/contributions`.
+ */
+export interface PackEntityDescriptions {
+	roles?: Record<string, string>;
+	tools?: Record<string, string>;
+	skills?: Record<string, string>;
+	entrypoints?: Record<string, string>;
+}
+
 /** Browse-payload pack shape (manifest + dirName + executable-code flag). */
 export interface BrowsePack extends PackManifest {
 	dirName: string;
 	hasTools: boolean;
+	/** One-line per-entity descriptions for the Browse disclosure (R3). */
+	descriptions?: PackEntityDescriptions;
 }
 
 /** Installed-pack listing row for the REST layer. */
@@ -46,6 +67,12 @@ export interface InstalledPackWire {
 	manifest: PackManifest;
 	meta: PackMeta;
 	status: "ok" | "corrupt";
+	/** True iff the source's latest manifest version differs from the installed
+	 *  `meta.version` AND the source could be checked from the local cache. */
+	updateAvailable: boolean;
+	/** `"unknown"` when the source can't be checked (removed / never-synced / no
+	 *  version data) — disambiguates "up to date" from "source unknown". */
+	sourceStatus: "ok" | "unknown";
 }
 
 /** Coded error so the REST layer can map to HTTP statuses. */
@@ -133,6 +160,105 @@ export function findSourcePackByName(root: string, packName: string): { dir: str
 		if (manifest && manifest.name === packName) return { dir, manifest };
 	}
 	return null;
+}
+
+/**
+ * Pure version-based change detection (exported for unit tests). A pack is
+ * considered to have an update available iff the source's latest manifest
+ * version differs from the installed version (string inequality — the confirmed
+ * change-detection rule). Empty/absent source version ⇒ no update.
+ */
+export function packUpdateAvailable(installedVersion: string, sourceVersion: string): boolean {
+	if (!sourceVersion) return false;
+	return sourceVersion !== installedVersion;
+}
+
+/** Collapse whitespace + trim to a single line; `undefined` when empty/non-string. */
+function oneLineDescription(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const t = value.replace(/\s+/g, " ").trim();
+	return t.length > 0 ? t : undefined;
+}
+
+/** Read a YAML mapping file best-effort; `null` on any error / non-mapping. */
+function readYamlMapping(file: string): Record<string, unknown> | null {
+	try {
+		const data = parseYaml(fs.readFileSync(file, "utf-8"));
+		return data && typeof data === "object" && !Array.isArray(data) ? (data as Record<string, unknown>) : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Best-effort one-line descriptions per declared entity, sourced from the pack
+ * dir (the manifest stays the authoritative list of WHICH entities exist). Used
+ * by BOTH the Installed activation catalogue and the Browse payload (R3) so the
+ * disclosure can show descriptions for installed AND uninstalled packs.
+ *
+ *   - Roles: `roles/<name>.yaml|.yml` `description`, else `label` when it differs
+ *     from the name, else omitted.
+ *   - Tools: representative `tools/<group>/*.yaml|.yml` `description` (keyed by
+ *     GROUP name — the manifest declares tools at group granularity).
+ *   - Skills: `skills/<name>/SKILL.md` frontmatter `description`.
+ *   - Entry points: entrypoint YAML `description`, else its `label`, keyed by
+ *     `listName` (via {@link loadPackContributions}).
+ *
+ * Reads ONLY the pack dir — never the runtime-filtered tool/contribution APIs.
+ */
+export function readPackEntityDescriptions(packDir: string, manifest: PackManifest): PackEntityDescriptions {
+	const out: PackEntityDescriptions = {};
+	const c = manifest.contents;
+
+	const roles: Record<string, string> = {};
+	for (const name of c.roles ?? []) {
+		const data = readYamlMapping(path.join(packDir, "roles", `${name}.yaml`)) ?? readYamlMapping(path.join(packDir, "roles", `${name}.yml`));
+		if (!data) continue;
+		let desc = oneLineDescription(data.description);
+		if (!desc) {
+			const label = oneLineDescription(data.label);
+			if (label && label !== name) desc = label;
+		}
+		if (desc) roles[name] = desc;
+	}
+	if (Object.keys(roles).length) out.roles = roles;
+
+	const tools: Record<string, string> = {};
+	for (const group of c.tools ?? []) {
+		const dir = path.join(packDir, "tools", group);
+		let files: string[];
+		try {
+			files = fs.readdirSync(dir).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).sort();
+		} catch {
+			continue;
+		}
+		for (const f of files) {
+			const desc = oneLineDescription(readYamlMapping(path.join(dir, f))?.description);
+			if (desc) { tools[group] = desc; break; }
+		}
+	}
+	if (Object.keys(tools).length) out.tools = tools;
+
+	const skills: Record<string, string> = {};
+	for (const name of c.skills ?? []) {
+		try {
+			const { frontmatter } = parseFrontmatter(fs.readFileSync(path.join(packDir, "skills", name, "SKILL.md"), "utf-8"));
+			const desc = oneLineDescription((frontmatter as Record<string, unknown>)?.description);
+			if (desc) skills[name] = desc;
+		} catch { /* best-effort */ }
+	}
+	if (Object.keys(skills).length) out.skills = skills;
+
+	const entrypoints: Record<string, string> = {};
+	try {
+		for (const ep of loadPackContributions(packDir, manifest).entrypoints) {
+			const desc = oneLineDescription(readYamlMapping(ep.sourceFile)?.description) ?? oneLineDescription(ep.label);
+			if (desc) entrypoints[ep.listName] = desc;
+		}
+	} catch { /* best-effort — labels/descriptions are optional */ }
+	if (Object.keys(entrypoints).length) out.entrypoints = entrypoints;
+
+	return out;
 }
 
 /** Copy a directory subtree verbatim, skipping any `.git` directory. */
@@ -273,9 +399,38 @@ export class MarketplaceInstaller {
 			const dir = path.join(root, d.name);
 			const manifest = readManifest(dir);
 			if (!manifest) continue; // dir without a valid pack.yaml ⇒ not a pack
-			packs.push({ ...manifest, dirName: d.name, hasTools: manifest.contents.tools.length > 0 });
+			packs.push({
+				...manifest,
+				dirName: d.name,
+				hasTools: manifest.contents.tools.length > 0,
+				descriptions: readPackEntityDescriptions(dir, manifest),
+			});
 		}
 		return packs;
+	}
+
+	/**
+	 * Compute the source-update state for an installed pack WITHOUT any network
+	 * sync (R2). Resolves the source's readable root from the EXISTING local
+	 * cache only: a local-dir source is read at `localSourcePath(url)` if it
+	 * exists; a git source is read at `cacheDirFor(source.id)` if already cloned.
+	 * `syncSource()` is NEVER called here. Any miss (source removed, never
+	 * synced, root absent, pack not found, no version) ⇒ `sourceStatus:"unknown"`.
+	 */
+	private computeSourceState(meta: PackMeta): { updateAvailable: boolean; sourceStatus: "ok" | "unknown" } {
+		const unknown = { updateAvailable: false, sourceStatus: "unknown" as const };
+		if (!meta.sourceUrl || !meta.packName) return unknown;
+		const source = this.opts.sourceStore.getByUrl(meta.sourceUrl);
+		if (!source) return unknown;
+		const root = isLocalDirSource(source.url) ? localSourcePath(source.url) : this.cacheDirFor(source.id);
+		try {
+			if (!fs.existsSync(root) || !fs.statSync(root).isDirectory()) return unknown;
+		} catch {
+			return unknown;
+		}
+		const found = findSourcePackByName(root, meta.packName);
+		if (!found || !found.manifest.version) return unknown;
+		return { updateAvailable: packUpdateAvailable(meta.version, found.manifest.version), sourceStatus: "ok" };
 	}
 
 	// ── install / uninstall / update ─────────────────────────────
@@ -347,7 +502,7 @@ export class MarketplaceInstaller {
 		}
 
 		this.appendOrder(ctx, packName);
-		return { scope, packName, manifest, meta, status: "ok" };
+		return { scope, packName, manifest, meta, status: "ok", ...this.computeSourceState(meta) };
 	}
 
 	/** Uninstall: delete the dir, drop from pack_order. */
@@ -417,7 +572,7 @@ export class MarketplaceInstaller {
 			fs.rmSync(backup, { recursive: true, force: true });
 			throw err;
 		}
-		return { scope, packName, manifest, meta, status: "ok" };
+		return { scope, packName, manifest, meta, status: "ok", ...this.computeSourceState(meta) };
 	}
 
 	// ── listing ──────────────────────────────────────────────────
@@ -458,15 +613,18 @@ export class MarketplaceInstaller {
 				const manifest = readManifest(dir);
 				const meta = readMeta(dir);
 				if (manifest && meta) {
-					rows.set(d.name, { scope: c.scope, packName: d.name, manifest, meta, status: "ok" });
+					rows.set(d.name, { scope: c.scope, packName: d.name, manifest, meta, status: "ok", ...this.computeSourceState(meta) });
 				} else if (manifest || meta) {
 					// Partial / corrupt install — surface so the UI can offer cleanup.
+					// Corrupt rows never offer an update and report an unknown source.
 					rows.set(d.name, {
 						scope: c.scope,
 						packName: d.name,
 						manifest: manifest ?? synthManifest(d.name, meta),
 						meta: meta ?? synthMeta(d.name, c.scope, manifest),
 						status: "corrupt",
+						updateAvailable: false,
+						sourceStatus: "unknown",
 					});
 				}
 			}

--- a/src/server/agent/marketplace-install.ts
+++ b/src/server/agent/marketplace-install.ts
@@ -19,8 +19,9 @@ import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
 import type { PackManifest, PackMeta, PackScope } from "./pack-types.js";
 import { scopePaths } from "./pack-types.js";
-import { isValidPackName, readManifest, readMeta, writeMeta } from "./pack-manifest.js";
+import { isValidPackName, isSafeBasename, readManifest, readMeta, writeMeta } from "./pack-manifest.js";
 import { loadPackContributions } from "./pack-contributions.js";
+import { isPackPathWithinRoot } from "../extension-host/path-guard.js";
 import { parseFrontmatter } from "../skills/slash-skills.js";
 import type { MarketplaceSource, MarketplaceSourceStore } from "./marketplace-source-store.js";
 
@@ -205,14 +206,37 @@ function readYamlMapping(file: string): Record<string, unknown> | null {
  *     `listName` (via {@link loadPackContributions}).
  *
  * Reads ONLY the pack dir — never the runtime-filtered tool/contribution APIs.
+ *
+ * SECURITY: `validateManifest` does NOT guard `contents.roles/tools/skills`
+ * against `..` or path separators (only `contents.entrypoints` is basename-
+ * checked), so a malicious source could declare `roles: ["../../etc/passwd"]`.
+ * Since this helper runs on Browse (no install required) AND on the installed
+ * catalogue, EVERY manifest-declared name turned into a path is guarded with
+ * {@link isSafeBasename} AND a realpath-aware {@link isPackPathWithinRoot}
+ * containment check before any read/readdir. A rejected name simply yields no
+ * description row (best-effort contract preserved).
  */
 export function readPackEntityDescriptions(packDir: string, manifest: PackManifest): PackEntityDescriptions {
 	const out: PackEntityDescriptions = {};
 	const c = manifest.contents;
 
+	// Read a path ONLY if `name` is a safe basename AND the resolved path stays
+	// within `baseDir` (which itself must stay within the pack dir). Returns null
+	// for any unsafe/out-of-bounds name so the caller skips that entity.
+	const safeJoin = (baseDir: string, name: string, ...rest: string[]): string | null => {
+		if (!isSafeBasename(name)) return null;
+		if (!isPackPathWithinRoot(packDir, baseDir)) return null;
+		const resolved = path.join(baseDir, name, ...rest);
+		return isPackPathWithinRoot(baseDir, resolved) ? resolved : null;
+	};
+
 	const roles: Record<string, string> = {};
+	const rolesDir = path.join(packDir, "roles");
 	for (const name of c.roles ?? []) {
-		const data = readYamlMapping(path.join(packDir, "roles", `${name}.yaml`)) ?? readYamlMapping(path.join(packDir, "roles", `${name}.yml`));
+		const yamlPath = safeJoin(rolesDir, `${name}.yaml`);
+		const ymlPath = safeJoin(rolesDir, `${name}.yml`);
+		if (!yamlPath && !ymlPath) continue; // unsafe name — skip entirely
+		const data = (yamlPath ? readYamlMapping(yamlPath) : null) ?? (ymlPath ? readYamlMapping(ymlPath) : null);
 		if (!data) continue;
 		let desc = oneLineDescription(data.description);
 		if (!desc) {
@@ -224,8 +248,10 @@ export function readPackEntityDescriptions(packDir: string, manifest: PackManife
 	if (Object.keys(roles).length) out.roles = roles;
 
 	const tools: Record<string, string> = {};
+	const toolsDir = path.join(packDir, "tools");
 	for (const group of c.tools ?? []) {
-		const dir = path.join(packDir, "tools", group);
+		const dir = safeJoin(toolsDir, group);
+		if (!dir) continue; // unsafe group name — skip
 		let files: string[];
 		try {
 			files = fs.readdirSync(dir).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).sort();
@@ -233,6 +259,8 @@ export function readPackEntityDescriptions(packDir: string, manifest: PackManife
 			continue;
 		}
 		for (const f of files) {
+			// `f` comes from readdir of the (contained) group dir, so it is a real
+			// basename; still join + read defensively.
 			const desc = oneLineDescription(readYamlMapping(path.join(dir, f))?.description);
 			if (desc) { tools[group] = desc; break; }
 		}
@@ -240,9 +268,12 @@ export function readPackEntityDescriptions(packDir: string, manifest: PackManife
 	if (Object.keys(tools).length) out.tools = tools;
 
 	const skills: Record<string, string> = {};
+	const skillsDir = path.join(packDir, "skills");
 	for (const name of c.skills ?? []) {
+		const skillFile = safeJoin(skillsDir, name, "SKILL.md");
+		if (!skillFile) continue; // unsafe name — skip
 		try {
-			const { frontmatter } = parseFrontmatter(fs.readFileSync(path.join(packDir, "skills", name, "SKILL.md"), "utf-8"));
+			const { frontmatter } = parseFrontmatter(fs.readFileSync(skillFile, "utf-8"));
 			const desc = oneLineDescription((frontmatter as Record<string, unknown>)?.description);
 			if (desc) skills[name] = desc;
 		} catch { /* best-effort */ }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -233,7 +233,7 @@ import { resolveScalarConfig } from "./agent/config-resolver.js";
 import { BuiltinConfigProvider } from "./agent/builtin-config.js";
 import { ConfigCascade, type MarketPackProvider } from "./agent/config-cascade.js";
 import { MarketplaceSourceStore, isValidSourceId } from "./agent/marketplace-source-store.js";
-import { MarketplaceInstaller, MarketplaceError, type InstallScope, type PackOrderStore } from "./agent/marketplace-install.js";
+import { MarketplaceInstaller, MarketplaceError, readPackEntityDescriptions, type InstallScope, type PackOrderStore, type PackEntityDescriptions } from "./agent/marketplace-install.js";
 import { scopeMarketPackEntries } from "./agent/pack-list.js";
 import { buildConflictsFor, type ConflictWire, type PackScope, type PackEntry } from "./agent/pack-types.js";
 
@@ -6356,7 +6356,7 @@ async function handleApiRoute(
 			projectBase: string | undefined,
 			store: PackOrderStore,
 			packName: string,
-		): { roles: string[]; tools: string[]; skills: string[]; entrypoints: Array<{ listName: string; label?: string }> } | null => {
+		): { roles: string[]; tools: string[]; skills: string[]; entrypoints: Array<{ listName: string; label?: string }>; descriptions: PackEntityDescriptions } | null => {
 			const base = scope === "server" ? getProjectRoot() : scope === "global-user" ? os.homedir() : projectBase;
 			if (base === undefined) return null;
 			const entries = scopeMarketPackEntries(scope as PackScope, base, store.getPackOrder(scope));
@@ -6378,6 +6378,10 @@ async function handleApiRoute(
 					const label = labelByListName.get(listName);
 					return label !== undefined ? { listName, label } : { listName };
 				}),
+				// One-line per-entity descriptions for the activation disclosure (R3).
+				// Read from the SAME installed pack dir as the catalogue above — never
+				// from the runtime-filtered /api/tools or /api/ext/contributions.
+				descriptions: readPackEntityDescriptions(entry.path, entry.manifest),
 			};
 		};
 		if (url.pathname === "/api/marketplace/pack-activation" && req.method === "GET") {

--- a/tests/e2e/ui/market-activation.spec.ts
+++ b/tests/e2e/ui/market-activation.spec.ts
@@ -123,8 +123,9 @@ test.describe("Market UI activation controls — disable-entrypoint (pack schema
 		const toggle = page.locator(TOGGLE);
 		await expect(toggle, "the entrypoint toggle must render from the catalogue").toBeVisible({ timeout: 15_000 });
 		await expect(toggle).toBeChecked();
-		// The explanatory copy is present (§9 copy requirement).
-		await expect(page.locator(`[data-testid="market-activation-help"]`).first()).toBeVisible();
+		// Marketplace UI polish R1: the standalone activation-help copy was removed —
+		// the activation toggles now stand on their own — so it must NOT render.
+		await expect(page.locator(`[data-testid="market-activation-help"]`)).toHaveCount(0);
 
 		// ── (1) Disable the entrypoint → PUT + reconcile. It must disappear from the
 		// runtime /api/ext/contributions, while the PANEL stays available. ──

--- a/tests/e2e/ui/marketplace.spec.ts
+++ b/tests/e2e/ui/marketplace.spec.ts
@@ -48,9 +48,11 @@ interface PackSpec {
 	name: string;
 	version?: string;
 	description?: string;
-	roles?: Array<{ name: string; label?: string }>;
-	tools?: Array<{ group: string; name: string }>;
-	skills?: Array<{ name: string }>;
+	roles?: Array<{ name: string; label?: string; description?: string }>;
+	tools?: Array<{ group: string; name: string; description?: string }>;
+	skills?: Array<{ name: string; description?: string }>;
+	/** Pack-scoped entry points: contents.entrypoints + entrypoints/<listName>.yaml. */
+	entrypoints?: Array<{ listName: string; id?: string; label?: string; description?: string; panelId?: string }>;
 }
 
 let _repoCounter = 0;
@@ -70,6 +72,7 @@ function writePack(repo: string, spec: PackSpec): void {
 	const roles = (spec.roles ?? []).map((r) => r.name);
 	const toolGroups = [...new Set((spec.tools ?? []).map((t) => t.group))];
 	const skills = (spec.skills ?? []).map((s) => s.name);
+	const entrypoints = (spec.entrypoints ?? []).map((e) => e.listName);
 	writeFileSync(
 		join(packDir, "pack.yaml"),
 		`name: ${spec.name}\n` +
@@ -78,27 +81,41 @@ function writePack(repo: string, spec: PackSpec): void {
 			`contents:\n` +
 			`  roles: [${roles.join(", ")}]\n` +
 			`  tools: [${toolGroups.join(", ")}]\n` +
-			`  skills: [${skills.join(", ")}]\n`,
+			`  skills: [${skills.join(", ")}]\n` +
+			`  entrypoints: [${entrypoints.join(", ")}]\n`,
 	);
 	for (const r of spec.roles ?? []) {
 		mkdirSync(join(packDir, "roles"), { recursive: true });
 		writeFileSync(
 			join(packDir, "roles", `${r.name}.yaml`),
-			`name: ${r.name}\nlabel: ${r.label ?? r.name}\naccessory: none\ncreatedAt: 0\nupdatedAt: 0\npromptTemplate: hello from ${r.name}\n`,
+			`name: ${r.name}\nlabel: ${r.label ?? r.name}\naccessory: none\ncreatedAt: 0\nupdatedAt: 0\n` +
+				(r.description ? `description: ${r.description}\n` : "") +
+				`promptTemplate: hello from ${r.name}\n`,
 		);
 	}
 	for (const t of spec.tools ?? []) {
 		mkdirSync(join(packDir, "tools", t.group), { recursive: true });
 		writeFileSync(
 			join(packDir, "tools", t.group, `${t.name}.yaml`),
-			`name: ${t.name}\ndescription: tool ${t.name}\ngroup: ${t.group}\n`,
+			`name: ${t.name}\ndescription: ${t.description ?? `tool ${t.name}`}\ngroup: ${t.group}\n`,
 		);
 	}
 	for (const s of spec.skills ?? []) {
 		mkdirSync(join(packDir, "skills", s.name), { recursive: true });
 		writeFileSync(
 			join(packDir, "skills", s.name, "SKILL.md"),
-			`---\ndescription: skill ${s.name}\n---\n\n# ${s.name}\n\nbody for ${s.name}\n`,
+			`---\ndescription: ${s.description ?? `skill ${s.name}`}\n---\n\n# ${s.name}\n\nbody for ${s.name}\n`,
+		);
+	}
+	for (const e of spec.entrypoints ?? []) {
+		mkdirSync(join(packDir, "entrypoints"), { recursive: true });
+		writeFileSync(
+			join(packDir, "entrypoints", `${e.listName}.yaml`),
+			`id: ${e.id ?? `${e.listName}-id`}\n` +
+				`kind: command-palette\n` +
+				`label: ${e.label ?? e.listName}\n` +
+				(e.description ? `description: ${e.description}\n` : "") +
+				`target:\n  panelId: ${e.panelId ?? `${e.listName}-panel`}\n`,
 		);
 	}
 }
@@ -202,6 +219,11 @@ async function openMarket(page: Page, opts?: { activeProjectId?: string }): Prom
 async function reopenMarketAfterReload(page: Page, projectId: string): Promise<void> {
 	await expect(page.locator("button").filter({ hasText: "Settings" }).first()).toBeVisible({ timeout: 20_000 });
 	await setActiveProject(page, projectId);
+	// Land on a NON-market route first so the subsequent navigation to #/market
+	// is a genuine hashchange (setting window.location.hash to the value it
+	// already holds is a no-op and would NOT re-trigger loadMarketplaceData with
+	// the freshly-pinned active project — leaving the Installed list empty).
+	await navigateToHash(page, "#/roles");
 	await navigateToHash(page, "#/market");
 	await goToTab(page, "sources");
 }
@@ -524,9 +546,19 @@ test.describe("Marketplace UI", () => {
 		await expect(installed).toBeVisible({ timeout: 15_000 });
 		await expect(installed).toContainText("v1.0.0");
 
-		// Mutate the upstream pack (bump version) and update → re-sync reflected.
+		// Up to date right after install ⇒ the Update button is hidden (R2).
+		await expect(installed.locator('[data-testid="market-update-pack"]')).toHaveCount(0);
+
+		// Mutate the upstream pack (bump version); reload so the installed list
+		// recomputes update-available state, then the Update button appears and a
+		// click re-syncs upstream (R2).
 		writePack(repo, { name: "upd-pack", version: "2.0.0", roles: [{ name: "upd-role" }] });
-		await installed.locator('[data-testid="market-update-pack"]').click();
+		await page.reload();
+		await reopenMarketAfterReload(page, proj.id);
+		await goToTab(page, "installed");
+		const installedAfterBump = page.locator('[data-testid="market-installed-pack"][data-pack-name="upd-pack"]').first();
+		await expect(installedAfterBump.locator('[data-testid="market-update-pack"]')).toBeVisible({ timeout: 15_000 });
+		await installedAfterBump.locator('[data-testid="market-update-pack"]').click();
 		await expect(page.locator('[data-testid="market-installed-pack"][data-pack-name="upd-pack"]').first()).toContainText("v2.0.0", { timeout: 15_000 });
 
 		// Role currently resolves on the dedicated project scope.
@@ -654,5 +686,166 @@ test.describe("Marketplace UI", () => {
 		const orderRes = await apiFetch(`/api/marketplace/pack-order?scope=project&projectId=${pid}`);
 		const order = ((await orderRes.json()).order as string[]).filter((n) => n === "conf-a" || n === "conf-b");
 		expect(order).toEqual(["conf-b", "conf-a"]);
+	});
+
+	// ==================================================================
+	// MARKETPLACE UI POLISH (R1–R4)
+	// ==================================================================
+
+	// R1 + R2 + R3 (Installed): the Update button is HIDDEN when the installed
+	// pack is up-to-date and SHOWN after the source version is bumped; the legacy
+	// activation-help text is gone; per-entity descriptions (incl. an entry-point
+	// row) render inside the collapsed disclosure. Persists across reload.
+	test("Installed: Update button gates on source version, descriptions disclosure, no activation-help", async ({ page }) => {
+		const repo = makeRepo();
+		writePack(repo, {
+			name: "polish-pack",
+			version: "1.0.0",
+			roles: [{ name: "polish-role", description: "a polished role" }],
+			tools: [{ group: "polishgroup", name: "polish-tool", description: "a polished tool" }],
+			skills: [{ name: "polish-skill", description: "a polished skill" }],
+			entrypoints: [{ listName: "polish-ep", label: "Polish EP", description: "a polished entry point" }],
+		});
+		const proj = await makeDedicatedProject("polish");
+
+		await openMarket(page, { activeProjectId: proj.id });
+		await registerSource(page, repo);
+		await selectInstallScopeProject(page, proj.id);
+		await page.locator('[data-testid="market-browse-pack"][data-pack-name="polish-pack"]').locator('[data-testid="market-install-pack"]').click();
+
+		await goToTab(page, "installed");
+		const card = page.locator('[data-testid="market-installed-pack"][data-pack-name="polish-pack"]').first();
+		await expect(card).toBeVisible({ timeout: 15_000 });
+
+		// R2 — up-to-date ⇒ no Update button. R1 — activation-help gone everywhere.
+		await expect(card.locator('[data-testid="market-update-pack"]')).toHaveCount(0);
+		await expect(page.locator('[data-testid="market-activation-help"]')).toHaveCount(0);
+		// Uninstall stays always-available.
+		await expect(card.locator('[data-testid="market-uninstall-pack"]')).toBeVisible();
+
+		// R3 — the activation disclosure renders per-entity descriptions (incl. the
+		// entry point). The catalogue + descriptions load async, so poll for the
+		// disclosure, expand it, then assert the entry-point row.
+		const details = card.locator('[data-testid="market-entity-details-polish-pack"]');
+		await expect(details).toBeVisible({ timeout: 15_000 });
+		await details.locator("summary").click();
+		await expect(card.locator('[data-testid="market-entity-desc-entrypoint-polish-ep"]')).toBeVisible();
+		await expect(card.locator('[data-testid="market-entity-desc-entrypoint-polish-ep"]')).toContainText("a polished entry point");
+		await expect(card.locator('[data-testid="market-entity-desc-role-polish-role"]')).toContainText("a polished role");
+		await expect(card.locator('[data-testid="market-entity-desc-tool-polishgroup"]')).toContainText("a polished tool");
+		await expect(card.locator('[data-testid="market-entity-desc-skill-polish-skill"]')).toContainText("a polished skill");
+
+		// Bump the upstream version, reload, and the Update button appears (R2).
+		writePack(repo, {
+			name: "polish-pack",
+			version: "2.0.0",
+			roles: [{ name: "polish-role", description: "a polished role" }],
+			tools: [{ group: "polishgroup", name: "polish-tool", description: "a polished tool" }],
+			skills: [{ name: "polish-skill", description: "a polished skill" }],
+			entrypoints: [{ listName: "polish-ep", label: "Polish EP", description: "a polished entry point" }],
+		});
+		await page.reload();
+		await reopenMarketAfterReload(page, proj.id);
+		await goToTab(page, "installed");
+		const card2 = page.locator('[data-testid="market-installed-pack"][data-pack-name="polish-pack"]').first();
+		await expect(card2).toBeVisible({ timeout: 15_000 });
+		await expect(card2.locator('[data-testid="market-update-pack"]')).toBeVisible({ timeout: 15_000 });
+		await expect(page.locator('[data-testid="market-activation-help"]')).toHaveCount(0);
+	});
+
+	// R2 — when the originating source is removed, the installed card shows the
+	// "Source not found" lozenge in place of the Update button (no update button).
+	test("Installed: shows 'Source not found' lozenge when the source is removed", async ({ page }) => {
+		const repo = makeRepo();
+		writePack(repo, { name: "orphan-pack", version: "1.0.0", roles: [{ name: "orphan-role" }] });
+		const proj = await makeDedicatedProject("orphan");
+
+		await openMarket(page, { activeProjectId: proj.id });
+		await registerSource(page, repo);
+		await selectInstallScopeProject(page, proj.id);
+		await page.locator('[data-testid="market-browse-pack"][data-pack-name="orphan-pack"]').locator('[data-testid="market-install-pack"]').click();
+		await goToTab(page, "installed");
+		await expect(page.locator('[data-testid="market-installed-pack"][data-pack-name="orphan-pack"]').first()).toBeVisible({ timeout: 15_000 });
+
+		// Remove the originating source (so the install can no longer be checked).
+		const srcRes = await apiFetch("/api/marketplace/sources");
+		for (const s of ((await srcRes.json()).sources ?? []) as Array<{ id: string }>) {
+			await apiFetch(`/api/marketplace/sources/${encodeURIComponent(s.id)}`, { method: "DELETE" });
+		}
+
+		await page.reload();
+		await reopenMarketAfterReload(page, proj.id);
+		await goToTab(page, "installed");
+		const card = page.locator('[data-testid="market-installed-pack"][data-pack-name="orphan-pack"]').first();
+		await expect(card).toBeVisible({ timeout: 15_000 });
+		await expect(card.locator('[data-testid="market-source-unknown"]')).toBeVisible();
+		await expect(card.locator('[data-testid="market-update-pack"]')).toHaveCount(0);
+		await expect(card.locator('[data-testid="market-uninstall-pack"]')).toBeVisible();
+	});
+
+	// R3 (Browse) — descriptions render for an UNINSTALLED source pack inside the
+	// disclosure, INCLUDING an entry-point row (and role/tool/skill rows).
+	test("Browse: per-entity descriptions render for an uninstalled pack (incl. entry point)", async ({ page }) => {
+		const repo = makeRepo();
+		writePack(repo, {
+			name: "desc-pack",
+			roles: [{ name: "desc-role", description: "browse role desc" }],
+			tools: [{ group: "descgroup", name: "desc-tool", description: "browse tool desc" }],
+			skills: [{ name: "desc-skill", description: "browse skill desc" }],
+			entrypoints: [{ listName: "desc-ep", label: "Desc EP", description: "browse entry point desc" }],
+		});
+
+		await openMarket(page);
+		await registerSource(page, repo);
+		const card = page.locator('[data-testid="market-browse-pack"][data-pack-name="desc-pack"]');
+		await expect(card).toBeVisible({ timeout: 15_000 });
+		// Not installed ⇒ Install button present, no installed indicator.
+		await expect(card.locator('[data-testid="market-install-pack"]')).toBeVisible();
+
+		const details = card.locator('[data-testid="market-entity-details-desc-pack"]');
+		await expect(details).toBeVisible({ timeout: 15_000 });
+		await details.locator("summary").click();
+		await expect(card.locator('[data-testid="market-entity-desc-entrypoint-desc-ep"]')).toContainText("browse entry point desc");
+		await expect(card.locator('[data-testid="market-entity-desc-role-desc-role"]')).toContainText("browse role desc");
+		await expect(card.locator('[data-testid="market-entity-desc-tool-descgroup"]')).toContainText("browse tool desc");
+		await expect(card.locator('[data-testid="market-entity-desc-skill-desc-skill"]')).toContainText("browse skill desc");
+	});
+
+	// R4 — Browse shows "Installed" for an installed up-to-date pack and an
+	// "Update" button when the source is ahead; respects project identity (a pack
+	// installed in project A is NOT shown installed when the picker targets B).
+	test("Browse: Installed / Update indicators respect install scope + project identity", async ({ page }) => {
+		const repo = makeRepo();
+		writePack(repo, { name: "browse-state-pack", version: "1.0.0", roles: [{ name: "bs-role" }] });
+		const projA = await makeDedicatedProject("bsa");
+		const projB = await makeDedicatedProject("bsb");
+
+		await openMarket(page, { activeProjectId: projA.id });
+		await registerSource(page, repo);
+		await selectInstallScopeProject(page, projA.id);
+		const browseCard = page.locator('[data-testid="market-browse-pack"][data-pack-name="browse-state-pack"]');
+		await browseCard.locator('[data-testid="market-install-pack"]').click();
+
+		// Installed at project A's scope, up to date ⇒ "Installed" indicator (no
+		// install button) while the picker still targets project A.
+		await expect(browseCard.locator('[data-testid="market-browse-installed"]')).toBeVisible({ timeout: 15_000 });
+		await expect(browseCard.locator('[data-testid="market-install-pack"]')).toHaveCount(0);
+
+		// R4 project identity — point the picker at project B: NOT installed there,
+		// so the Install button returns and the installed indicator disappears.
+		await selectInstallScopeProject(page, projB.id);
+		await expect(browseCard.locator('[data-testid="market-install-pack"]')).toBeVisible({ timeout: 15_000 });
+		await expect(browseCard.locator('[data-testid="market-browse-installed"]')).toHaveCount(0);
+		await expect(browseCard.locator('[data-testid="market-browse-update-pack"]')).toHaveCount(0);
+
+		// Bump the source version; back on project A the Browse card offers Update.
+		writePack(repo, { name: "browse-state-pack", version: "2.0.0", roles: [{ name: "bs-role" }] });
+		await page.reload();
+		await reopenMarketAfterReload(page, projA.id);
+		await goToTab(page, "browse");
+		await selectInstallScopeProject(page, projA.id);
+		const browseCard2 = page.locator('[data-testid="market-browse-pack"][data-pack-name="browse-state-pack"]');
+		await expect(browseCard2.locator('[data-testid="market-browse-update-pack"]')).toBeVisible({ timeout: 15_000 });
+		await expect(browseCard2.locator('[data-testid="market-install-pack"]')).toHaveCount(0);
 	});
 });

--- a/tests/marketplace-install.test.ts
+++ b/tests/marketplace-install.test.ts
@@ -519,6 +519,39 @@ describe("R3 readPackEntityDescriptions (roles/tools/skills/entrypoints)", () =>
 		assert.equal(d.entrypoints!["ep"], "entry point desc");
 	});
 
+	// SECURITY — manifest-declared entity names are path-joined into the pack dir,
+	// but validateManifest does NOT guard roles/tools/skills against `..` or path
+	// separators. A traversal name must NOT cause a read/readdir OUTSIDE the pack
+	// dir (exploitable on Browse alone). Each unsafe name simply yields no row.
+	it("does NOT read outside the pack dir for traversal names (roles/tools/skills)", () => {
+		const root = fs.mkdtempSync(path.join(TMP, "descr-evil-"));
+		// A secret file OUTSIDE the pack dir whose contents must never leak.
+		w(path.join(root, "secret.yaml"), "description: TOP SECRET should never appear\nlabel: SECRET\n");
+		w(path.join(root, "secret", "SKILL.md"), "---\ndescription: TOP SECRET skill leak\n---\nbody\n");
+		const dir = path.join(root, "pack");
+		// Manifest declares traversal names for all three kinds. These bypass
+		// validateManifest (which only basename-guards entrypoints), so the helper
+		// itself must reject them. The `.yaml`/SKILL.md targets are crafted so a
+		// naive path.join would resolve onto the external secret files above.
+		w(path.join(dir, "pack.yaml"),
+			"name: evilpack\ndescription: evil\nversion: 1.0.0\ncontents:\n" +
+			"  roles: ['../secret']\n" +
+			"  tools: ['../../x', '..']\n" +
+			"  skills: ['../secret']\n");
+		const manifest = readManifest(dir)!;
+		// Sanity: the manifest parsed and kept the traversal names verbatim.
+		assert.deepEqual(manifest.contents.roles, ["../secret"]);
+
+		let d: any;
+		assert.doesNotThrow(() => { d = readPackEntityDescriptions(dir, manifest); });
+		// No description rows for any traversal name; nothing leaked from outside.
+		assert.equal(d.roles, undefined);
+		assert.equal(d.tools, undefined);
+		assert.equal(d.skills, undefined);
+		const serialized = JSON.stringify(d);
+		assert.ok(!serialized.includes("TOP SECRET"), `must not leak external file contents; got ${serialized}`);
+	});
+
 	it("collapses whitespace and omits kinds with no usable descriptions", () => {
 		const root = fs.mkdtempSync(path.join(TMP, "descr2-"));
 		const dir = path.join(root, "kit2");

--- a/tests/marketplace-install.test.ts
+++ b/tests/marketplace-install.test.ts
@@ -25,6 +25,8 @@ const {
 	localSourcePath,
 	copyDirVerbatim,
 	isInstalledPackDir,
+	packUpdateAvailable,
+	readPackEntityDescriptions,
 } = installMod;
 const { MarketplaceSourceStore, deriveSourceId, isValidSourceId } = await import(
 	"../src/server/agent/marketplace-source-store.ts"
@@ -409,6 +411,126 @@ describe("#7 corrupt-guard + listInstalled", () => {
 		// A pack_order naming an absent pack drops it; on-disk-but-unlisted appended first.
 		const partial = inst.listInstalled([{ scope: "server", packOrder: ["ghost", "alpha"] }]);
 		assert.deepEqual(partial.map((p: any) => p.packName), ["beta", "gamma", "alpha"]);
+	});
+});
+
+// ── R2 update-available signals (version-based) ──────────────────
+
+describe("R2 packUpdateAvailable (pure version comparison)", () => {
+	it("returns true only when source version differs and is non-empty", () => {
+		assert.equal(packUpdateAvailable("1.0.0", "2.0.0"), true);
+		assert.equal(packUpdateAvailable("1.0.0", "1.0.0"), false);
+		// String inequality — any difference counts (not semver-aware).
+		assert.equal(packUpdateAvailable("2.0.0", "1.0.0"), true);
+		assert.equal(packUpdateAvailable("1.0.0", "1.0.1-beta"), true);
+		// Empty/absent source version ⇒ no update (treated as unknown upstream).
+		assert.equal(packUpdateAvailable("1.0.0", ""), false);
+	});
+});
+
+describe("R2 listInstalled computes updateAvailable + sourceStatus (no network sync)", () => {
+	let root: string;
+	let repo: string;
+	let store: any;
+	let inst: any;
+	let packOrder: any;
+
+	beforeEach(() => {
+		root = fs.mkdtempSync(path.join(TMP, "srcstate-"));
+		repo = path.join(root, "repo");
+		makeSourceRepo(repo, { version: "1.0.0" });
+		store = new MarketplaceSourceStore(path.join(root, "cfg"));
+		store.add({ url: repo });
+		inst = makeInstaller({ sourceStore: store, cacheRoot: path.join(root, "cache"), serverBase: root, globalUserBase: root });
+		packOrder = new ProjectConfigStore(path.join(root, ".bobbit", "config"));
+	});
+
+	function sourceId() { return store.list()[0].id; }
+	function row() {
+		return inst.listInstalled([{ scope: "server" }]).find((p: any) => p.packName === "research-pack");
+	}
+
+	it("freshly installed pack is up-to-date (sourceStatus ok, no update)", () => {
+		inst.installPack({ sourceId: sourceId(), dirName: "research-pack", scope: "server", packOrderStore: packOrder });
+		const r = row();
+		assert.equal(r.sourceStatus, "ok");
+		assert.equal(r.updateAvailable, false);
+	});
+
+	it("flags updateAvailable when the source's manifest version is bumped", () => {
+		inst.installPack({ sourceId: sourceId(), dirName: "research-pack", scope: "server", packOrderStore: packOrder });
+		// Bump the upstream version WITHOUT updating the installed copy.
+		makeSourceRepo(repo, { version: "2.0.0" });
+		const r = row();
+		assert.equal(r.sourceStatus, "ok");
+		assert.equal(r.updateAvailable, true);
+	});
+
+	it("reports sourceStatus unknown when the source is no longer registered", () => {
+		inst.installPack({ sourceId: sourceId(), dirName: "research-pack", scope: "server", packOrderStore: packOrder });
+		store.remove(sourceId());
+		const r = row();
+		assert.equal(r.sourceStatus, "unknown");
+		assert.equal(r.updateAvailable, false);
+	});
+
+	it("reports sourceStatus unknown when the local source dir no longer exists", () => {
+		inst.installPack({ sourceId: sourceId(), dirName: "research-pack", scope: "server", packOrderStore: packOrder });
+		fs.rmSync(repo, { recursive: true, force: true });
+		const r = row();
+		assert.equal(r.sourceStatus, "unknown");
+		assert.equal(r.updateAvailable, false);
+	});
+});
+
+// ── R3 per-entity descriptions sourced from the pack dir ─────────
+
+describe("R3 readPackEntityDescriptions (roles/tools/skills/entrypoints)", () => {
+	it("sources one-line descriptions for all four kinds from the pack dir", () => {
+		const root = fs.mkdtempSync(path.join(TMP, "descr-"));
+		const dir = path.join(root, "kit");
+		w(path.join(dir, "pack.yaml"),
+			"name: kit\ndescription: kit\nversion: 1.0.0\ncontents:\n" +
+			"  roles: [r-desc, r-label, r-bare]\n" +
+			"  tools: [grp]\n" +
+			"  skills: [sk]\n" +
+			"  entrypoints: [ep]\n");
+		// role with explicit description
+		w(path.join(dir, "roles", "r-desc.yaml"), "name: r-desc\nlabel: R Desc\ndescription: explicit role description\n");
+		// role with only a (differing) label → label is used
+		w(path.join(dir, "roles", "r-label.yaml"), "name: r-label\nlabel: Friendly Label\n");
+		// role whose label equals its name → omitted (no row)
+		w(path.join(dir, "roles", "r-bare.yaml"), "name: r-bare\nlabel: r-bare\n");
+		// representative tool yaml in the group dir
+		w(path.join(dir, "tools", "grp", "thing.yaml"), "name: thing\ndescription: a grouped tool\ngroup: grp\n");
+		// skill frontmatter
+		w(path.join(dir, "skills", "sk", "SKILL.md"), "---\ndescription: skill one-liner\n---\n# sk\nbody\n");
+		// entrypoint with a description
+		w(path.join(dir, "entrypoints", "ep.yaml"),
+			"id: ep-id\nkind: command-palette\nlabel: EP Label\ndescription: entry point desc\ntarget:\n  panelId: some-panel\n");
+
+		const manifest = readManifest(dir)!;
+		const d = readPackEntityDescriptions(dir, manifest);
+		assert.equal(d.roles!["r-desc"], "explicit role description");
+		assert.equal(d.roles!["r-label"], "Friendly Label");
+		assert.equal(d.roles!["r-bare"], undefined); // label == name ⇒ omitted
+		assert.equal(d.tools!["grp"], "a grouped tool");
+		assert.equal(d.skills!["sk"], "skill one-liner");
+		assert.equal(d.entrypoints!["ep"], "entry point desc");
+	});
+
+	it("collapses whitespace and omits kinds with no usable descriptions", () => {
+		const root = fs.mkdtempSync(path.join(TMP, "descr2-"));
+		const dir = path.join(root, "kit2");
+		w(path.join(dir, "pack.yaml"),
+			"name: kit2\ndescription: kit2\nversion: 1.0.0\ncontents:\n  roles: [r]\n  tools: []\n  skills: []\n");
+		w(path.join(dir, "roles", "r.yaml"), "name: r\nlabel: r\ndescription: \"line one\\n  line two\"\n");
+		const manifest = readManifest(dir)!;
+		const d = readPackEntityDescriptions(dir, manifest);
+		assert.equal(d.roles!["r"], "line one line two");
+		assert.equal(d.tools, undefined);
+		assert.equal(d.skills, undefined);
+		assert.equal(d.entrypoints, undefined);
 	});
 });
 


### PR DESCRIPTION
## Summary

Polishes the Marketplace surface for readability and to surface update/install state honestly.

- **R1** — Removed the standalone activation-help paragraph below the entity toggles; toggles stand on their own.
- **R2** — The **Update** button now only renders when an update is available. New `InstalledPackWire` fields `updateAvailable` + `sourceStatus`, computed server-side in `listInstalled()` **without** a network sync (reads the existing local cache; version-based change detection via `computeSourceState`). When the source can't be checked (removed / never-synced / no version), a **"Source not found"** lozenge is shown instead. Uninstall stays always-available.
- **R3** — Per-entity one-line **descriptions** for roles/tools/skills/entry points, sourced from the pack dir (`readPackEntityDescriptions`) and shown in a collapsed **"Show details"** disclosure in **both** the Installed activation list and the Browse card. Reads are path-traversal-safe (`isSafeBasename` + `isPackPathWithinRoot`). The activation catalogue remains the UNFILTERED authoritative source.
- **R4** — Browse cards cross-reference the installed list (by pack name + selected scope incl. project identity) and show an **"Installed"** indicator or an **Update** button instead of Install.
- **R5** — Tightened cards/spacing/visual hierarchy. Theme tokens only — no hardcoded colours.

## Wire/API
- `InstalledPackWire`: `+ updateAvailable: boolean`, `+ sourceStatus: "ok" | "unknown"`.
- `PackActivationCatalogue` + `BrowsePackWire`: `+ descriptions?` (roles/tools/skills/entrypoints).

## Tests
- New browser E2E in `tests/e2e/ui/marketplace.spec.ts` (update gating, source-not-found lozenge, Browse Installed/Update, per-entity descriptions incl. entry points, no activation-help, persistence, project-identity scoping).
- Updated stale `market-activation-help` assertion in `tests/e2e/ui/market-activation.spec.ts` (R1).
- Unit tests in `tests/marketplace-install.test.ts` for `computeSourceState`/version comparison, `readPackEntityDescriptions` (incl. path-traversal hardening).

## Verification
- `npm run check` clean; `npm run test:unit` green; full E2E suite green (1291 passed).
- A security review caught + fixed a path-traversal vector in description sourcing (now pinned by a test).

## Docs
- `docs/marketplace.md` (user-facing) + `docs/design/pack-based-marketplace.md` (§9.1 contracts, §10.4) + `docs/design/pack-schema-v1-rationalisation.md`.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)