### PR TITLE
Human gate bypass (human-only override)

### DIFF
--- a/docs/design/production-subgoals-port.md
+++ b/docs/design/production-subgoals-port.md
@@ -118,7 +118,7 @@ client + WS state**. The detailed UX requirements these must satisfy:
   child's plan recursively (depth cap 3); overflow collapses to a
   "Show N more…" affordance. `plan-live-only-toggle` (`data-testid`) defaults
   to inclusive (shows archived, dimmed/dashed with `plan-node-archived-pill`).
-  Per-node gate status pending/running/passed/failed; merge/conflict state per
+  Per-node gate status pending/running/passed/failed/bypassed; merge/conflict state per
   child. Source DAG from `GET /descendants` (live + archived), not the
   archived-filtered sidebar list.
 - **Sidebar:** children nest under their spawning team-lead

--- a/docs/goals-workflows-tasks.md
+++ b/docs/goals-workflows-tasks.md
@@ -208,14 +208,15 @@ Each gate has a status: `pending`, `passed`, `failed`, or `bypassed`.
 
 When a previously-passed gate is re-signaled, all transitive downstream gates are cascade-reset to `pending`.
 
-### Viewing and resetting passed gates
+### Per-gate actions in the goal status widget
 
-The chat-header `<goal-status-widget>` is the compact workflow surface for the current goal. Its popover lists every gate, but only `passed` rows show gate actions:
+The chat-header `<goal-status-widget>` is the compact workflow surface for the current goal. Its popover lists every gate. The actions shown on a row depend on its status:
 
-- **View** — opens the goal dashboard Gates tab for that gate and expands the gate detail section.
-- **Reset** — asks for confirmation, then clears the selected gate and downstream dependent gates back to `pending`.
+- **View** (`passed` rows only) — opens the goal dashboard Gates tab for that gate and expands the gate detail section.
+- **Reset** (`passed` rows only) — asks for confirmation, then clears the selected gate and downstream dependent gates back to `pending`.
+- **Bypass** (`pending` and `failed` rows only) — the human-only override that forces the gate to the `bypassed` state. It is never shown on `passed`, `running`, or already-`bypassed` rows. See [Human gate bypass](#human-gate-bypass).
 
-Pending, running, and failed rows do not show these actions. This keeps the popover focused on completed approvals that can be inspected or invalidated.
+So `passed` rows show View/Reset, `pending`/`failed` rows show Bypass, and `running` rows show no actions. This keeps View/Reset focused on completed approvals that can be inspected or invalidated, while exposing the bypass override only where it is meaningful.
 
 #### Dashboard focus route
 
@@ -723,7 +724,9 @@ Here's the typical flow for a team goal with a workflow:
    gate_signal(gate_id="implementation")
    → Verification runs (npm run check + LLM review) → gate status: passed
 
-8. Process continues through the DAG until all gates pass
+8. Process continues through the DAG until every gate is passed (or human-bypassed —
+   a bypassed gate satisfies downstream dependency ordering like a passed one, but
+   completion still requires explicit human confirmation; see step 9)
 
 9. team_complete() — server verifies all workflow gates have passed.
    (If any gate was human-bypassed, team_complete is refused; a human must

--- a/docs/goals-workflows-tasks.md
+++ b/docs/goals-workflows-tasks.md
@@ -199,11 +199,12 @@ This serves two purposes:
 
 ### Gate states
 
-Each gate has a status: `pending`, `passed`, or `failed`.
+Each gate has a status: `pending`, `passed`, `failed`, or `bypassed`.
 
 - **`pending`** — initial state; the gate has not been signaled, or was reset after an upstream re-signal or explicit reset.
 - **`passed`** — the gate was signaled and all verification steps succeeded (or no verification was defined).
 - **`failed`** — the gate was signaled but verification failed.
+- **`bypassed`** — a human overseer forced the gate past verification without the work passing. It is deliberately a distinct state from `passed` so the override is auditable and visually obvious. See [Human gate bypass](#human-gate-bypass).
 
 When a previously-passed gate is re-signaled, all transitive downstream gates are cascade-reset to `pending`.
 
@@ -273,6 +274,61 @@ Coverage lives in:
 - [`tests/gate-store-logic.test.ts`](../tests/gate-store-logic.test.ts) — gate-store reset and dependency behavior.
 - [`tests/e2e/gate-reset-api.spec.ts`](../tests/e2e/gate-reset-api.spec.ts) — DAG invalidation, idempotency, preserved history/content, active verification cancellation, sandbox denial, team lead notification.
 - [`tests/e2e/ui/goal-status-widget.spec.ts`](../tests/e2e/ui/goal-status-widget.spec.ts) — passed-gate View/Reset controls, dashboard focus route reload/back behavior, confirmation guard, widget/sidebar/dashboard refresh, and team lead message visibility.
+
+### Human gate bypass
+
+A gate can be **bypassed**: a human overseer forces it past verification when an agent reports that a verification step is genuinely impossible to satisfy (for example, a check that cannot pass in the current environment, or a requirement that has been overtaken by a deliberate scope decision). Bypass exists so a goal is not permanently stuck behind a gate that no amount of agent work can clear — while keeping the escape hatch firmly in human hands.
+
+#### Why this is human-only, and how that is enforced
+
+The whole point of a gate is to stop low-quality or unverified work from flowing downstream. If an agent could clear its own gate, the gate would be worthless. Bypass is therefore an **honesty-system override reserved for the human overseer** — consistent with the rest of the gate UI, which trusts the gateway token rather than modeling per-user identity.
+
+This is defended in two layers, in order of importance:
+
+1. **Non-advertisement (primary).** The bypass capability is *never* exposed to agents. There is no MCP/agent tool for it, and it is never mentioned in any agent-facing prompt, tool description, or injected context. An agent has no way to learn the capability exists from inside its own context.
+2. **Runtime guard (backstop).** The bypass endpoint requires `isInitiatedByHuman: true` in the request body and refuses anything else with a 400 explaining that bypass is for human use only. Sandbox-scoped agent tokens are rejected with 403 before the guard is even reached.
+
+Because there is no identity model yet, the endpoint does not (and cannot) cryptographically prove a human sent the request. The trust model is honesty plus non-discoverability, not authentication. This is intentional and matches the existing reset / sign-off endpoints.
+
+#### What a bypass records
+
+Bypass is auditable like any other gate event. `POST /api/goals/:id/gates/:gateId/bypass` appends a **synthetic audit signal** to the gate's signal history (`sessionId: "human-bypass"`, `metadata.bypass: "true"`) capturing:
+
+- **`whyBypassed`** — required free-text justification, persisted verbatim;
+- **`whoAmI`** — required free-text label naming who performed the bypass (not verified — honesty system);
+- **`bypassedAt`** — server timestamp.
+
+The gate status is then set to `bypassed`, persisted, and a `gate_status_changed` event is broadcast on the goal WebSocket. The team lead session, if live, is notified with a system-origin message naming the gate, the `whoAmI` label, the reason, and a reminder that the goal still needs explicit human confirmation before it can complete. See [rest-api.md — Gate bypass endpoint](rest-api.md#gate-bypass-endpoint) for the full request/response contract and error matrix.
+
+#### Dependency vs. completion semantics
+
+A bypassed gate is treated differently depending on what is being decided:
+
+- **Downstream dependency ordering — satisfied.** A bypassed upstream gate unblocks its dependents exactly as a passed gate would, so the rest of the workflow can proceed. Without this, bypassing one stuck gate would still leave everything behind it blocked, defeating the purpose.
+- **Downstream context injection — NOT injected.** Only `passed` gates with `injectDownstream` inject their content into downstream agents' prompts. A bypassed gate has no verified content to stand behind, so nothing is injected. Dependents proceed, but they do not receive bypassed-gate content as trusted upstream context.
+- **Goal completion — still blocked until a human confirms.** `team_complete` (the agent/MCP path) refuses to finish a goal that has any bypassed gate, with a distinct error (`Cannot complete: N gate(s) were bypassed and require human confirmation`). An agent therefore cannot auto-finish a goal that was only resolved via a human override.
+
+#### Confirming completion despite bypassed gates
+
+The explicit human path to finish such a goal is `POST /api/goals/:id/team/complete` with `{ confirmBypassedGates: true }`. This reuses the completion route's options (`completeTeam({ allowBypassedGates: true })`) rather than adding a separate endpoint. Like bypass itself, this confirmation is human-only: sandbox-scoped tokens are rejected with 403, so an agent cannot confirm its way past a bypass. In the UI a **Confirm completion** button appears only when bypassed gates exist.
+
+#### Resetting a bypassed gate
+
+Bypass is reversible. Resetting a bypassed gate (via the reset endpoint or the widget's Reset action) returns it to `pending` and clears it from the downstream/completion calculus, just like resetting a passed gate. The bypass audit signal remains in history for the record.
+
+#### UI differentiation
+
+The override is made visually unmistakable so a bypass is never mistaken for a clean pass:
+
+- **Bypass button** — the `<goal-status-widget>` popover shows a destructive-styled **Bypass** action only on gates that have *not* yet passed (pending/failed rows). It is never offered on a passed or already-bypassed gate. Clicking it opens an inline form collecting `whyBypassed` (multi-line) and `whoAmI` (text), then calls the endpoint with `isInitiatedByHuman: true`; endpoint errors surface inline like the reset error row.
+- **Per-gate icon** — a bypassed gate renders a red warning/exclamation triangle (distinct from the green check used for passed), with the `whoAmI` and `whyBypassed` available on the row.
+- **Differentiated progress badge** — `renderGateProgressBadge` (the chat-header pill and the sidebar goal badge both call it) counts bypassed gates *toward the numerator* so a fully-resolved-via-bypass goal still reads `(4/4)`, **but turns the whole badge red and appends a trailing `!`** (e.g. red `(4/4)!`) to signal this is not a clean pass. The dropdown's header badge inherits the same treatment. The badge reads `bypassed` / `bypassedCount` from the cached `GateStatusSummary`.
+
+#### Coverage
+
+- [`tests/gate-dependency-enforcement.test.ts`](../tests/gate-dependency-enforcement.test.ts) — a bypassed upstream gate unblocks dependents like a passed one.
+- [`tests/e2e/gate-bypass-api.spec.ts`](../tests/e2e/gate-bypass-api.spec.ts) — endpoint happy path, audit-signal persistence, broadcast, guard/validation errors, sandbox denial, reset-to-pending, and completion gating.
+- [`tests/e2e/ui/gate-bypass.spec.ts`](../tests/e2e/ui/gate-bypass.spec.ts) — Bypass button visibility, why/who form submission, bypassed row state, red `(N/N)!` badge, and persistence across reload.
 
 ### Signaling a gate
 
@@ -669,7 +725,10 @@ Here's the typical flow for a team goal with a workflow:
 
 8. Process continues through the DAG until all gates pass
 
-9. team_complete() — server verifies all workflow gates have passed
+9. team_complete() — server verifies all workflow gates have passed.
+   (If any gate was human-bypassed, team_complete is refused; a human must
+   confirm via POST /api/goals/:id/team/complete { confirmBypassedGates: true }.
+   See "Human gate bypass" above.)
 ```
 
 ## REST API reference

--- a/docs/nested-goals.md
+++ b/docs/nested-goals.md
@@ -133,7 +133,8 @@ archived)**, layered by their `dependsOnPlanIds` dependency edges. It is sourced
 from `GET /api/goals/:id/descendants` — deliberately **independent of the
 sidebar's archived filter**, so archived nodes still appear in the graph.
 
-- **Per-node gate status**: pending / running / passed / failed.
+- **Per-node gate status**: pending / running / passed / failed / bypassed (a
+  human-overseer override; see [Human gate bypass](goals-workflows-tasks.md#human-gate-bypass)).
 - **Archived distinction**: archived nodes are dimmed/dashed and carry a
   `data-testid="plan-node-archived-pill"` badge.
 - **Merge / conflict state** per child.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -245,6 +245,7 @@ Branch names are never interpolated into a shell command; PR lookup and remote r
 | `GET` | `/api/goals/:id/gates/:gateId/inspect` | Scoped gate data retrieval (content, verification, or signal history) |
 | `POST` | `/api/goals/:id/gates/:gateId/signal` | Signal a gate (`{ status, content?, verifiedBy? }`) |
 | `POST` | `/api/goals/:id/gates/:gateId/reset` | Reset the gate plus transitive downstream dependents to `pending`; preserves signal history. See [Gate reset endpoint](#gate-reset-endpoint). |
+| `POST` | `/api/goals/:id/gates/:gateId/bypass` | **Human-only.** Force a not-yet-passed gate to `bypassed` (`{ whyBypassed, whoAmI, isInitiatedByHuman: true }`); persists a synthetic audit signal. Never advertised to agents. See [Gate bypass endpoint](#gate-bypass-endpoint). |
 | `POST` | `/api/goals/:id/gates/:gateId/cancel-verification` | Cancel a stuck running verification (idempotent) |
 | `POST` | `/api/goals/:id/gates/:gateId/signoff` | Resolve a parked `human-signoff` step (`{ signalId, stepName, decision: "pass"\|"fail", feedback? }`); idempotent 409 on already-resolved steps. See [Sign-off endpoint](#sign-off-endpoint). |
 
@@ -262,7 +263,7 @@ Routes accept both `/team/` and legacy `/swarm/` paths.
 | `POST` | `/api/goals/:id/team/abort` | Force-abort a stuck team agent (`{ sessionId }`) |
 | `POST` | `/api/goals/:id/team/prompt` | Send prompt to a team agent, queued if busy (`{ sessionId, message }`) |
 | `GET` | `/api/goals/:id/team/agents` | List agents for a team goal. `?include=archived` also returns archived agents with `teamLeadSessionId`, `teamGoalId`, and `delegateOf` fields |
-| `POST` | `/api/goals/:id/team/complete` | Complete a team (dismiss agents, keep team lead) |
+| `POST` | `/api/goals/:id/team/complete` | Complete a team (dismiss agents, keep team lead). Body `{ confirmBypassedGates?: boolean }` — the agent/MCP path is refused while any gate is `bypassed`; a human confirms with `confirmBypassedGates: true` (403 for sandbox tokens). See [Gate bypass endpoint](#gate-bypass-endpoint). |
 | `POST` | `/api/goals/:id/team/teardown` | Fully tear down a team (dismiss all + terminate team lead) |
 
 ### Tasks
@@ -815,6 +816,8 @@ Returns the server-authoritative gate progress summary for counters and status c
 ```json
 {
   "passed": 0,
+  "bypassed": 0,
+  "bypassedCount": 0,
   "total": 1,
   "verifying": true,
   "verifyingCount": 1,
@@ -836,7 +839,7 @@ Returns the server-authoritative gate progress summary for counters and status c
 }
 ```
 
-Goal-wide fields: `passed`, `total`, `verifying`, `verifyingCount`, `awaitingSignoffCount`, `awaitingHumanSignoff`, `runningGateIds`, and `gates`. Per-gate fields: `gateId`, `name`, stored `status`, `effectiveStatus` (`running` while an active verification overlays stored state), `running`, `awaitingSignoffCount`, `dependsOn`, and `signalCount`. Conditional fields: `updatedAt` (if signaled) and `failedSteps` (if failed — names of non-passed, non-skipped verification steps). The top-level fields preserve existing consumers; `summary` is the canonical grouped shape used by newer clients.
+Goal-wide fields: `passed`, `bypassed` (count of gates a human forced past verification; `bypassedCount` is an emitted alias for the same value), `total`, `verifying`, `verifyingCount`, `awaitingSignoffCount`, `awaitingHumanSignoff`, `runningGateIds`, and `gates`. `bypassed` is reported separately from `passed` so the badge can count bypassed gates toward the numerator while still flagging the goal as not-clean (red `(N/N)!`) — see [Human gate bypass](goals-workflows-tasks.md#human-gate-bypass). Per-gate fields: `gateId`, `name`, stored `status` (now includes `bypassed`), `effectiveStatus` (`running` while an active verification overlays stored state), `running`, `awaitingSignoffCount`, `dependsOn`, and `signalCount`. Conditional fields: `updatedAt` (if signaled) and `failedSteps` (if failed — names of non-passed, non-skipped verification steps). The top-level fields preserve existing consumers; `summary` is the canonical grouped shape used by newer clients.
 
 **`GET /api/goals/:id/gates/:gateId?view=summary`**
 
@@ -970,6 +973,52 @@ Notes:
 - Sandboxed agent tokens are forbidden from this route.
 
 Errors: 400 when the goal has no workflow; 403 for sandbox-scoped tokens; 404 for unknown goal/gate; 409 when the goal is archived.
+
+### Gate bypass endpoint
+
+**`POST /api/goals/:id/gates/:gateId/bypass`** — a **human-only** override that forces a not-yet-passed gate to the distinct `bypassed` status when a verification step is genuinely impossible to satisfy. Modeled on the reset endpoint. This capability is **never advertised to agents**: there is no MCP/agent tool for it and it is absent from all agent-facing prompts and docs. The `isInitiatedByHuman` flag is the runtime backstop; non-discoverability is the primary defense. Full design and UI behavior: [goals-workflows-tasks.md — Human gate bypass](goals-workflows-tasks.md#human-gate-bypass).
+
+Request body:
+
+```json
+{
+  "whyBypassed": "The integration suite needs a vendor sandbox we can't provision here; verified manually instead.",
+  "whoAmI": "Jane (release owner)",
+  "isInitiatedByHuman": true
+}
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `whyBypassed` | yes | Non-empty justification, persisted verbatim in the audit signal. |
+| `whoAmI` | yes | Non-empty free-text label naming who bypassed. Not verified — honesty system. |
+| `isInitiatedByHuman` | yes | Must be exactly `true`. Anything else is refused (see below). |
+
+On success the gate status becomes `bypassed`, a synthetic audit signal (`sessionId: "human-bypass"`, `metadata.bypass: "true"`, plus `whyBypassed` / `whoAmI` / `bypassedAt`) is appended to the gate's signal history, any stale running verification for the gate is cancelled, a `gate_status_changed` event is broadcast on the goal WebSocket, and the live team lead (if any) is notified.
+
+Response:
+
+```json
+{
+  "ok": true,
+  "gateId": "agent-qa",
+  "status": "bypassed",
+  "whyBypassed": "...",
+  "whoAmI": "Jane (release owner)",
+  "bypassedAt": "1739812345678",
+  "teamLeadNotified": true
+}
+```
+
+Errors:
+
+- **400** when `isInitiatedByHuman !== true`, with the guard message: *"This method is currently intended for human use only. Bypassing a gate as an agent is not acting in the best interest of the outcome."* This is the default response an agent gets if it ever stumbles onto the route.
+- **400** when `whyBypassed` or `whoAmI` is missing or blank; **400** when the goal has no workflow.
+- **403** for sandbox-scoped tokens (checked before the body is read).
+- **404** for unknown goal or unknown gate.
+- **409** when the goal is archived or shelved.
+
+**Downstream and completion semantics.** A bypassed gate satisfies dependency ordering for downstream gates (it unblocks dependents exactly like a passed gate), but it does **not** inject content into downstream agents — only `passed` gates with `injectDownstream` do that. The goal still cannot be completed by the agent path while a bypassed gate exists: `POST /api/goals/:id/team/complete` refuses with `Cannot complete: N gate(s) were bypassed and require human confirmation` unless called with `{ confirmBypassedGates: true }`, which is itself rejected with 403 for sandbox tokens. Resetting a bypassed gate returns it to `pending`.
 
 ### Gate inspect endpoint
 

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -956,7 +956,7 @@ export async function fetchArchivedSessionsPaginated(limit = 50, afterCursor?: n
 export interface GateStatusSummaryGate {
 	gateId: string;
 	name?: string;
-	status: "pending" | "passed" | "failed";
+	status: "pending" | "passed" | "failed" | "bypassed";
 	effectiveStatus: "pending" | "passed" | "failed" | "running";
 	running: boolean;
 	awaitingSignoffCount: number;
@@ -968,6 +968,10 @@ export interface GateStatusSummaryGate {
 
 export interface GateStatusSummary {
 	passed: number;
+	/** Count of gates a human forced past verification. Distinct from passed. */
+	bypassed: number;
+	/** Alias for `bypassed` — server emits both names. */
+	bypassedCount: number;
 	total: number;
 	verifying: boolean;
 	verifyingCount: number;
@@ -980,6 +984,8 @@ export interface GateStatusSummary {
 function emptyGateStatusSummary(): GateStatusSummary {
 	return {
 		passed: 0,
+		bypassed: 0,
+		bypassedCount: 0,
 		total: 0,
 		verifying: false,
 		verifyingCount: 0,
@@ -994,8 +1000,13 @@ function normalizeGateStatusSummary(data: any): GateStatusSummary {
 	const raw = data?.summary && typeof data.summary === "object" ? data.summary : data;
 	const awaitingSignoffCount = typeof raw?.awaitingSignoffCount === "number" ? raw.awaitingSignoffCount : 0;
 	const runningGateIds = Array.isArray(raw?.runningGateIds) ? raw.runningGateIds.filter((id: unknown): id is string => typeof id === "string") : [];
+	const bypassed = typeof raw?.bypassed === "number"
+		? raw.bypassed
+		: (typeof raw?.bypassedCount === "number" ? raw.bypassedCount : 0);
 	return {
 		passed: typeof raw?.passed === "number" ? raw.passed : 0,
+		bypassed,
+		bypassedCount: bypassed,
 		total: typeof raw?.total === "number" ? raw.total : (Array.isArray(data?.gates) ? data.gates.length : 0),
 		verifying: typeof raw?.verifying === "boolean" ? raw.verifying : runningGateIds.length > 0,
 		verifyingCount: typeof raw?.verifyingCount === "number" ? raw.verifyingCount : runningGateIds.length,
@@ -1020,6 +1031,7 @@ function applyGateStatusSummary(goalId: string, summary: GateStatusSummary): boo
 	const prev = state.gateStatusCache.get(goalId);
 	const next = {
 		passed: summary.passed,
+		bypassed: summary.bypassed,
 		total: summary.total,
 		verifying: summary.verifying,
 		verifyingCount: summary.verifyingCount,
@@ -1030,6 +1042,7 @@ function applyGateStatusSummary(goalId: string, summary: GateStatusSummary): boo
 	};
 	if (!prev
 		|| prev.passed !== next.passed
+		|| prev.bypassed !== next.bypassed
 		|| prev.total !== next.total
 		|| prev.verifying !== next.verifying
 		|| prev.verifyingCount !== next.verifyingCount
@@ -1481,10 +1494,11 @@ export async function getTeamState(goalId: string): Promise<any | null> {
 	}
 }
 
-export async function completeTeam(goalId: string): Promise<boolean> {
+export async function completeTeam(goalId: string, opts?: { confirmBypassedGates?: boolean }): Promise<boolean> {
 	try {
 		const res = await gatewayFetch(`/api/goals/${goalId}/team/complete`, {
 			method: "POST",
+			body: JSON.stringify({ confirmBypassedGates: opts?.confirmBypassedGates === true }),
 		});
 		if (!res.ok) throw await errorFromResponse(res, `Failed: ${res.status}`);
 		await refreshSessions();

--- a/src/app/goal-dashboard.ts
+++ b/src/app/goal-dashboard.ts
@@ -1390,7 +1390,7 @@ interface GatePipelineNode {
 
 type DashboardSummaryGate = {
 	gateId: string;
-	status: "pending" | "passed" | "failed";
+	status: "pending" | "passed" | "failed" | "bypassed";
 	effectiveStatus?: "pending" | "passed" | "failed" | "running";
 	running?: boolean;
 	signalCount?: number;
@@ -1409,7 +1409,11 @@ function effectiveGateStatus(
 	if (summaryGate?.running) return "running";
 	const hasRunning = gs?.signals?.some(s => s.verification.status === "running");
 	if (hasRunning) return "running";
-	return gs?.status ?? summaryGate?.status ?? "pending";
+	const resolved = gs?.status ?? summaryGate?.status ?? "pending";
+	// A human-bypassed gate counts as resolved for pipeline display (the badge
+	// surfaces the distinct red treatment); the pipeline node vocabulary has no
+	// bypassed state, so map it onto passed here.
+	return resolved === "bypassed" ? "passed" : resolved;
 }
 
 /** Compute dependency depth for each workflow gate via BFS from roots. */

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -1204,6 +1204,17 @@ const teamLoading = new Set<string>();
 export function renderGateProgressBadge(goalId: string): TemplateResult | string {
 	const gs = state.gateStatusCache.get(goalId);
 	if (!gs) return "";
+	const bypassed = gs.bypassed ?? 0;
+	if (bypassed > 0) {
+		// A human forced ≥1 gate past verification. The numerator counts the
+		// bypassed gate(s) so a fully-resolved goal reads (N/N), but the whole
+		// badge turns red with a trailing `!` to make clear this is NOT a clean
+		// pass. Static (no wave/verify animation) by design.
+		const numerator = gs.passed + bypassed;
+		const bypassStyle = `font-size:0.75em;color:#dc2626;font-weight:600;letter-spacing:-0.02em;white-space:nowrap;`;
+		const title = `${numerator} of ${gs.total} gates resolved — ${bypassed} bypassed (NOT a clean pass)`;
+		return html`<span class="shrink-0" style="${bypassStyle}" title="${title}">(${numerator}/${gs.total})!</span>`;
+	}
 	const goalAgents = state.gatewaySessions.filter(s => (s.goalId === goalId || s.teamGoalId === goalId) && !isChildSession(s));
 	const hasTeam = goalAgents.some(s => s.role === "team-lead" && s.status !== "terminated");
 	const anyAgentWorking = goalAgents.some(s => s.status === "streaming" || s.status === "busy" || s.isCompacting);
@@ -1241,10 +1252,14 @@ export function renderGateProgressBadge(goalId: string): TemplateResult | string
  * palette used by `renderGateProgressBadge` — green for passed, red for
  * failed, blue for running, muted-foreground for pending.
  */
-export function renderGateStatusIcon(status: "pending" | "passed" | "failed" | "running"): TemplateResult {
+export function renderGateStatusIcon(status: "pending" | "passed" | "failed" | "running" | "bypassed"): TemplateResult {
 	switch (status) {
 		case "passed":
 			return html`<svg class="shrink-0" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-label="passed"><polyline points="20 6 9 17 4 12"/></svg>`;
+		case "bypassed":
+			// Warning/exclamation triangle in red — a human forced this gate past
+			// verification; it is NOT a clean pass.
+			return html`<svg class="shrink-0" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-label="bypassed"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>`;
 		case "failed":
 			return html`<svg class="shrink-0" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#c47070" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-label="failed"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>`;
 		case "running":

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -305,6 +305,8 @@ export const state = {
 	 *  notification-policy hot path can do an O(1) check without recounting. */
 	gateStatusCache: new Map<string, {
 		passed: number;
+		/** Count of gates a human forced past verification (distinct from passed). */
+		bypassed: number;
 		total: number;
 		verifying: boolean;
 		verifyingCount: number;
@@ -313,7 +315,7 @@ export const state = {
 		runningGateIds?: string[];
 		gates?: Array<{
 			gateId: string;
-			status: "pending" | "passed" | "failed";
+			status: "pending" | "passed" | "failed" | "bypassed";
 			effectiveStatus?: "pending" | "passed" | "failed" | "running";
 			running?: boolean;
 			awaitingSignoffCount?: number;

--- a/src/server/agent/gate-dependency-check.ts
+++ b/src/server/agent/gate-dependency-check.ts
@@ -31,8 +31,10 @@ export function checkGateDependencies(
 	const wfGate = workflowGates.find(g => g.id === workflowGateId);
 	if (!wfGate || !wfGate.dependsOn?.length) return null;
 
+	// A bypassed gate counts as satisfied for dependency ordering (it unblocks
+	// downstream gates exactly like a passed gate). See Human Gate Bypass design.
 	const passedIds = new Set(
-		gateStates.filter(g => g.status === "passed").map(g => g.gateId),
+		gateStates.filter(g => g.status === "passed" || g.status === "bypassed").map(g => g.gateId),
 	);
 	const notPassed = wfGate.dependsOn.filter(depId => !passedIds.has(depId));
 

--- a/src/server/agent/gate-store.ts
+++ b/src/server/agent/gate-store.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
+import { randomUUID } from "node:crypto";
 import type { Workflow } from "./workflow-store.js";
 
-export type GateStatus = "pending" | "passed" | "failed";
+export type GateStatus = "pending" | "passed" | "failed" | "bypassed";
 
 export interface GateSignalStep {
 	name: string;
@@ -152,6 +153,53 @@ export class GateStore {
 		gate.updatedAt = Date.now();
 		this.save();
 		this.onStatusChange?.(signal.goalId, signal.gateId);
+	}
+
+	/**
+	 * Human-only bypass: force a gate past verification. Appends a synthetic
+	 * audit signal (so the action is auditable like any other signal), sets the
+	 * gate status to "bypassed", persists, and fires onStatusChange.
+	 *
+	 * This is an honesty-system override surfaced ONLY via the human UI — it is
+	 * never advertised to agents (no MCP tool). See docs/design Human Gate Bypass.
+	 */
+	bypassGate(goalId: string, gateId: string, opts: { whyBypassed: string; whoAmI: string }): GateSignal {
+		const key = compositeKey(goalId, gateId);
+		const gate = this.gates.get(key);
+		if (!gate) {
+			throw new Error(`Unknown gate: ${gateId}`);
+		}
+		const now = Date.now();
+		const signal: GateSignal = {
+			id: `bypass-${randomUUID()}`,
+			gateId,
+			goalId,
+			sessionId: "human-bypass",
+			timestamp: now,
+			commitSha: "",
+			content: opts.whyBypassed,
+			metadata: {
+				bypass: "true",
+				whyBypassed: opts.whyBypassed,
+				whoAmI: opts.whoAmI,
+				bypassedAt: String(now),
+			},
+			verification: { status: "passed", steps: [] },
+		};
+		gate.signals.push(signal);
+		gate.status = "bypassed";
+		gate.updatedAt = now;
+		this.save();
+		this.onStatusChange?.(goalId, gateId);
+		return signal;
+	}
+
+	/** Returns the last signal whose metadata.bypass === "true", if any. */
+	getLatestBypassSignal(gate: GateState): GateSignal | undefined {
+		for (let i = gate.signals.length - 1; i >= 0; i--) {
+			if (gate.signals[i]?.metadata?.bypass === "true") return gate.signals[i];
+		}
+		return undefined;
 	}
 
 	updateGateStatus(goalId: string, gateId: string, status: GateStatus): void {

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -2147,7 +2147,7 @@ export class TeamManager {
 	 * Complete a team: dismiss all role agents but keep the team lead alive.
 	 * The team lead remains active to await further instructions.
 	 */
-	async completeTeam(goalId: string): Promise<void> {
+	async completeTeam(goalId: string, opts?: { allowBypassedGates?: boolean }): Promise<void> {
 		const entry = this.teams.get(goalId);
 		if (!entry) {
 			throw new Error(`No active team for goal: ${goalId}`);
@@ -2165,10 +2165,18 @@ export class TeamManager {
 
 		if (goal?.workflow && completeGateStore && (!skipReqs || !skipReqs.includes("workflow"))) {
 			const gateStates = completeGateStore.getGatesForGoal(goalId);
-			const passedIds = new Set(gateStates.filter(g => g.status === "passed").map(g => g.gateId));
-			const failedGates = goal.workflow.gates.filter(g => !passedIds.has(g.id));
+			const statusById = new Map(gateStates.map(g => [g.gateId, g.status]));
+			const isResolved = (id: string) => statusById.get(id) === "passed" || statusById.get(id) === "bypassed";
+			const failedGates = goal.workflow.gates.filter(g => !isResolved(g.id));
 			if (failedGates.length > 0) {
 				throw new Error(`Cannot complete: gates not passed: ${failedGates.map(g => g.name).join(", ")}`);
+			}
+			// Bypassed gates satisfy dependency ordering but still require explicit
+			// human confirmation before the goal can be completed. An agent calling
+			// team_complete (no opts) hits this distinct error and cannot auto-finish.
+			const bypassedGates = goal.workflow.gates.filter(g => statusById.get(g.id) === "bypassed");
+			if (bypassedGates.length > 0 && !opts?.allowBypassedGates) {
+				throw new Error(`Cannot complete: ${bypassedGates.length} gate(s) were bypassed and require human confirmation`);
 			}
 		}
 

--- a/src/server/gate-status-summary.ts
+++ b/src/server/gate-status-summary.ts
@@ -19,6 +19,10 @@ export interface GateStatusSummaryGate {
 
 export interface GateStatusSummary {
 	passed: number;
+	/** Count of gates forced past verification via human bypass. */
+	bypassed: number;
+	/** Alias of `bypassed` (spec references both names). */
+	bypassedCount: number;
 	total: number;
 	verifying: boolean;
 	verifyingCount: number;
@@ -89,8 +93,11 @@ export function buildGateStatusSummary(input: GateStatusSummaryInput): GateStatu
 	const runningGateIds = summaryGates.filter(gate => gate.running).map(gate => gate.gateId);
 	const awaitingSignoffCount = summaryGates.reduce((sum, gate) => sum + gate.awaitingSignoffCount, 0);
 
+	const bypassed = summaryGates.filter(gate => gate.status === "bypassed").length;
 	return {
 		passed: summaryGates.filter(gate => gate.status === "passed").length,
+		bypassed,
+		bypassedCount: bypassed,
 		total: summaryGates.length,
 		verifying: runningGateIds.length > 0,
 		verifyingCount: runningGateIds.length,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7236,7 +7236,21 @@ async function handleApiRoute(
 		// Enrich with workflow gate definitions
 		const enriched = gates.map(g => {
 			const def = goal.workflow?.gates.find(wg => wg.id === g.gateId);
-			return { ...g, name: def?.name, dependsOn: def?.dependsOn, content: def?.content, injectDownstream: def?.injectDownstream, metadata: def?.metadata || g.currentMetadata, signalCount: g.signals.length };
+			const base = { ...g, name: def?.name, dependsOn: def?.dependsOn, content: def?.content, injectDownstream: def?.injectDownstream, metadata: def?.metadata || g.currentMetadata, signalCount: g.signals.length };
+			// Surface human-bypass audit fields as canonical top-level fields so the
+			// UI does not have to couple to internal signal shape.
+			if (g.status === "bypassed") {
+				const bypassSignal = gateStore.getLatestBypassSignal(g);
+				if (bypassSignal?.metadata) {
+					return {
+						...base,
+						whyBypassed: bypassSignal.metadata.whyBypassed,
+						whoAmI: bypassSignal.metadata.whoAmI,
+						bypassedAt: bypassSignal.metadata.bypassedAt,
+					};
+				}
+			}
+			return base;
 		});
 		if (url.searchParams.get("view") === "summary") {
 			const summary = buildGateStatusSummary({
@@ -7547,6 +7561,83 @@ async function handleApiRoute(
 		return;
 	}
 
+	// POST /api/goals/:goalId/gates/:gateId/bypass — human-only gate bypass.
+	// NOT advertised to agents: no MCP tool, no prompt/doc mention. The
+	// isInitiatedByHuman guard is the runtime backstop. Modeled on the reset
+	// endpoint above.
+	const gateBypassMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/gates\/([^/]+)\/bypass$/);
+	if (gateBypassMatch && req.method === "POST") {
+		if (sandboxScope) {
+			json({ error: "Forbidden: sandbox token cannot bypass gates" }, 403);
+			return;
+		}
+
+		const [, goalId, gateId] = gateBypassMatch;
+		const goal = getGoalAcrossProjects(goalId);
+		if (!goal) { json({ error: "Goal not found" }, 404); return; }
+		if (goal.archived) { json({ error: "Goal is archived" }, 409); return; }
+		if (goal.state === "shelved") { json({ error: "Goal is shelved" }, 409); return; }
+		if (!goal.workflow) { json({ error: "Goal has no workflow" }, 400); return; }
+
+		const gateBypassCtx = projectContextManager.getContextForGoal(goalId);
+		if (!gateBypassCtx) { json({ error: "Goal not found in any project" }, 404); return; }
+		const gateStore = gateBypassCtx.gateStore;
+		const bypassGateDef = goal.workflow.gates.find(g => g.id === gateId);
+		if (!bypassGateDef) { json({ error: `Unknown gate: ${gateId}` }, 404); return; }
+
+		const bypassBody = await readBody(req);
+		if (bypassBody?.isInitiatedByHuman !== true) {
+			json({ error: "This method is currently intended for human use only. Bypassing a gate as an agent is not acting in the best interest of the outcome." }, 400);
+			return;
+		}
+		const whyBypassed = bypassBody?.whyBypassed;
+		const whoAmI = bypassBody?.whoAmI;
+		if (typeof whyBypassed !== "string" || !whyBypassed.trim()) { json({ error: "whyBypassed is required" }, 400); return; }
+		if (typeof whoAmI !== "string" || !whoAmI.trim()) { json({ error: "whoAmI is required" }, 400); return; }
+
+		try {
+			await verificationHarness.cancelStaleVerificationsForGates(goalId, [gateId]);
+		} catch (err) {
+			console.error(`[api] Error cancelling verifications for bypassed gate ${gateId}:`, err);
+		}
+
+		const bypassSignal = gateStore.bypassGate(goalId, gateId, { whyBypassed, whoAmI });
+		const bypassedAt = bypassSignal.metadata?.bypassedAt ?? String(bypassSignal.timestamp);
+
+		broadcastToGoal(goalId, { type: "gate_status_changed", goalId, gateId, status: "bypassed" });
+
+		let teamLeadNotified = false;
+		try {
+			const notification = [
+				`Gate bypassed: ${bypassGateDef.name || gateId}`,
+				"",
+				`This gate was forced past verification by a human overseer (${whoAmI}).`,
+				"",
+				"Reason:",
+				whyBypassed,
+				"",
+				"The bypassed gate now counts as satisfied for dependency ordering, but the goal still requires explicit human confirmation before it can be completed.",
+			].join("\n");
+			const team = teamManager.getTeamState(goalId);
+			if (team?.teamLeadSessionId) {
+				const teamLeadSession = sessionManager.getSession(team.teamLeadSessionId);
+				if (teamLeadSession && teamLeadSession.status !== "terminated") {
+					if (teamLeadSession.status === "streaming") {
+						await sessionManager.deliverLiveSteer(team.teamLeadSessionId, notification, { source: "system" });
+					} else {
+						await sessionManager.enqueuePrompt(team.teamLeadSessionId, notification, { isSteered: true, source: "system" });
+					}
+					teamLeadNotified = true;
+				}
+			}
+		} catch (err) {
+			console.error(`[api] Failed to notify team lead for gate bypass ${goalId}/${gateId}:`, err);
+		}
+
+		json({ ok: true, gateId, status: "bypassed", whyBypassed, whoAmI, bypassedAt, teamLeadNotified });
+		return;
+	}
+
 	// POST /api/goals/:goalId/gates/:gateId/signal — signal a gate
 	const gateSignalMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/gates\/([^/]+)\/signal$/);
 	if (gateSignalMatch && req.method === "POST") {
@@ -7571,7 +7662,8 @@ async function handleApiRoute(
 		// Validate dependencies are met
 		for (const depId of gateDef.dependsOn) {
 			const depGate = gateStore.getGate(goalId, depId);
-			if (!depGate || depGate.status !== "passed") {
+			// A bypassed upstream gate counts as satisfied (like passed).
+			if (!depGate || (depGate.status !== "passed" && depGate.status !== "bypassed")) {
 				const depDef = goal.workflow.gates.find(g => g.id === depId);
 				json({ error: `Upstream gate "${depDef?.name || depId}" has not passed yet` }, 409);
 				return;
@@ -8616,8 +8708,10 @@ async function handleApiRoute(
 			}, 409);
 			return;
 		}
+		const completeBody = await readBody(req);
+		const confirmBypassedGates = completeBody?.confirmBypassedGates === true;
 		try {
-			await teamManager.completeTeam(goalId);
+			await teamManager.completeTeam(goalId, { allowBypassedGates: confirmBypassedGates });
 			json({ ok: true });
 		} catch (err) {
 			jsonError(400, err);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -8710,6 +8710,14 @@ async function handleApiRoute(
 		}
 		const completeBody = await readBody(req);
 		const confirmBypassedGates = completeBody?.confirmBypassedGates === true;
+		// Bypassed-gate confirmation is a HUMAN-only override. A sandbox-scoped
+		// agent token must not be able to confirm completion past bypassed gates
+		// by hitting this REST endpoint directly — that would defeat the
+		// human-in-the-loop trust boundary the bypass feature enforces.
+		if (confirmBypassedGates && sandboxScope) {
+			json({ error: "Forbidden: sandbox token cannot confirm completion of bypassed gates" }, 403);
+			return;
+		}
 		try {
 			await teamManager.completeTeam(goalId, { allowBypassedGates: confirmBypassedGates });
 			json({ ok: true });

--- a/src/ui/components/GoalStatusWidget.ts
+++ b/src/ui/components/GoalStatusWidget.ts
@@ -27,20 +27,24 @@
 import { icon } from "@mariozechner/mini-lit";
 import { html, LitElement, nothing, render, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import { Eye, FileText, Goal as GoalIcon, LayoutDashboard, Loader2, RotateCcw } from "lucide";
+import { AlertTriangle, CheckCircle2, Eye, FileText, Goal as GoalIcon, LayoutDashboard, Loader2, RotateCcw } from "lucide";
 import { ensureMarkdownBlock } from "../lazy/markdown-block.js";
 import { scheduleGateStatusRefreshForGoal } from "../../app/api.js";
 import { GATE_STATUS_CACHE_UPDATED_EVENT_TYPE, GATE_STATUS_CLIENT_EVENT, HUMAN_SIGNOFF_RESOLVED_EVENT_TYPE, shouldRefreshActiveVerificationsForEvent, shouldRefreshGateDetailsForEvent, shouldRefreshGateStatusForEvent } from "../../app/gate-status-events.js";
 import { renderGateProgressBadge, renderGateStatusIcon } from "../../app/render-helpers.js";
 import { setHashRoute } from "../../app/routing.js";
 
-type GateStatus = "pending" | "passed" | "failed" | "running";
+type GateStatus = "pending" | "passed" | "failed" | "running" | "bypassed";
 
 interface GateSummary {
 	id: string;
 	name: string;
 	status: GateStatus;
 	latestPassedSignalId?: string;
+	/** Human justification recorded when a gate was bypassed (honesty system). */
+	whyBypassed?: string;
+	/** Free-text “who am I” label of whoever bypassed the gate. */
+	whoAmI?: string;
 }
 
 interface SignoffRequest {
@@ -71,6 +75,15 @@ export class GoalStatusWidget extends LitElement {
 	@state() private _reviewLaunchErrors: Map<string, string> = new Map();
 	@state() private _resetLoading: Set<string> = new Set();
 	@state() private _resetErrors: Map<string, string> = new Map();
+	// Inline bypass form (human-only gate override). `_bypassing` holds the gate
+	// id whose form is open, or null. Mirrors the reset loading/error patterns.
+	@state() private _bypassing: string | null = null;
+	@state() private _bypassWhy = "";
+	@state() private _bypassWho = "";
+	@state() private _bypassLoading: Set<string> = new Set();
+	@state() private _bypassErrors: Map<string, string> = new Map();
+	@state() private _confirmCompletionLoading = false;
+	@state() private _confirmCompletionError = "";
 	@state() private _closing = false;
 
 	private _ws: WebSocket | null = null;
@@ -153,6 +166,13 @@ export class GoalStatusWidget extends LitElement {
 			this._reviewLaunchErrors = new Map();
 			this._resetLoading = new Set();
 			this._resetErrors = new Map();
+			this._bypassing = null;
+			this._bypassWhy = "";
+			this._bypassWho = "";
+			this._bypassLoading = new Set();
+			this._bypassErrors = new Map();
+			this._confirmCompletionLoading = false;
+			this._confirmCompletionError = "";
 			this._loading = true;
 			this._disconnectWs();
 			if (this.goalId) {
@@ -160,7 +180,7 @@ export class GoalStatusWidget extends LitElement {
 				this._connectWs();
 			}
 		}
-		if (changed.has("_expanded") || changed.has("_gates") || changed.has("_awaitingSignoffs") || changed.has("_activeGateIds") || changed.has("_reviewLaunchLoading") || changed.has("_reviewLaunchErrors") || changed.has("_resetLoading") || changed.has("_resetErrors")) {
+		if (changed.has("_expanded") || changed.has("_gates") || changed.has("_awaitingSignoffs") || changed.has("_activeGateIds") || changed.has("_reviewLaunchLoading") || changed.has("_reviewLaunchErrors") || changed.has("_resetLoading") || changed.has("_resetErrors") || changed.has("_bypassing") || changed.has("_bypassWhy") || changed.has("_bypassWho") || changed.has("_bypassLoading") || changed.has("_bypassErrors") || changed.has("_confirmCompletionLoading") || changed.has("_confirmCompletionError")) {
 			this._syncDropdown();
 		}
 	}
@@ -236,13 +256,47 @@ export class GoalStatusWidget extends LitElement {
 			const status: GateStatus = obj.status === "passed" ? "passed"
 				: obj.status === "failed" ? "failed"
 				: obj.status === "running" ? "running"
+				: obj.status === "bypassed" ? "bypassed"
 				: "pending";
 			const latestPassedSignalId = typeof obj.latestPassedSignalId === "string"
 				? obj.latestPassedSignalId
 				: this._latestPassedSignalId(obj.signals);
-			out.push({ id, name, status, latestPassedSignalId });
+			let whyBypassed: string | undefined;
+			let whoAmI: string | undefined;
+			if (status === "bypassed") {
+				// Canonical top-level read-model fields (server §5), with a fallback
+				// to the latest synthetic bypass signal for robustness.
+				whyBypassed = typeof obj.whyBypassed === "string" ? obj.whyBypassed : undefined;
+				whoAmI = typeof obj.whoAmI === "string" ? obj.whoAmI : undefined;
+				if (whyBypassed === undefined || whoAmI === undefined) {
+					const fallback = this._latestBypassSignalMeta(obj.signals);
+					if (whyBypassed === undefined) whyBypassed = fallback?.whyBypassed;
+					if (whoAmI === undefined) whoAmI = fallback?.whoAmI;
+				}
+			}
+			out.push({ id, name, status, latestPassedSignalId, whyBypassed, whoAmI });
 		}
 		return out;
+	}
+
+	/** Fallback reader: pull why/who from the latest signal whose metadata
+	 *  marks it as a bypass audit signal (metadata.bypass === "true"). Used only
+	 *  when the canonical top-level read-model fields are absent. */
+	private _latestBypassSignalMeta(rawSignals: unknown): { whyBypassed?: string; whoAmI?: string } | undefined {
+		if (!Array.isArray(rawSignals)) return undefined;
+		for (let i = rawSignals.length - 1; i >= 0; i--) {
+			const signal = rawSignals[i];
+			if (!signal || typeof signal !== "object") continue;
+			const meta = (signal as Record<string, unknown>).metadata;
+			if (!meta || typeof meta !== "object") continue;
+			const m = meta as Record<string, unknown>;
+			if (m.bypass !== "true") continue;
+			return {
+				whyBypassed: typeof m.whyBypassed === "string" ? m.whyBypassed : undefined,
+				whoAmI: typeof m.whoAmI === "string" ? m.whoAmI : undefined,
+			};
+		}
+		return undefined;
 	}
 
 	private _latestPassedSignalId(rawSignals: unknown): string | undefined {
@@ -593,10 +647,89 @@ export class GoalStatusWidget extends LitElement {
 		return `Unable to reset gate (${resp.status})`;
 	}
 
+	// ── Bypass (human-only gate override) ─────────────────────────────
+
+	private _openBypassForm(gate: GateSummary): void {
+		const next = new Map(this._bypassErrors); next.delete(gate.id); this._bypassErrors = next;
+		this._bypassWhy = "";
+		this._bypassWho = "";
+		this._bypassing = gate.id;
+	}
+
+	private _cancelBypassForm(): void {
+		this._bypassing = null;
+		this._bypassWhy = "";
+		this._bypassWho = "";
+	}
+
+	private async _confirmBypass(gate: GateSummary): Promise<void> {
+		if (this._bypassLoading.has(gate.id)) return;
+		const whyBypassed = this._bypassWhy.trim();
+		const whoAmI = this._bypassWho.trim();
+		if (!whyBypassed || !whoAmI) return;
+		const loading = new Set(this._bypassLoading); loading.add(gate.id); this._bypassLoading = loading;
+		const errors = new Map(this._bypassErrors); errors.delete(gate.id); this._bypassErrors = errors;
+		try {
+			const resp = await this._fetch(`/api/goals/${encodeURIComponent(this.goalId)}/gates/${encodeURIComponent(gate.id)}/bypass`, {
+				method: "POST",
+				body: JSON.stringify({ whyBypassed, whoAmI, isInitiatedByHuman: true }),
+			});
+			if (!resp) throw new Error("Unable to bypass gate (network)");
+			if (!resp.ok) throw new Error(await this._bypassErrorMessage(resp));
+			this._bypassing = null;
+			this._bypassWhy = "";
+			this._bypassWho = "";
+			await Promise.all([this._refreshGates(), this._refreshActive()]);
+		} catch (err) {
+			const next = new Map(this._bypassErrors);
+			next.set(gate.id, err instanceof Error ? err.message : "Unable to bypass gate");
+			this._bypassErrors = next;
+		} finally {
+			const next = new Set(this._bypassLoading); next.delete(gate.id); this._bypassLoading = next;
+		}
+	}
+
+	private async _bypassErrorMessage(resp: Response): Promise<string> {
+		const data = await resp.json().catch(() => null);
+		if (typeof data?.error === "string" && data.error.trim()) return data.error;
+		return `Unable to bypass gate (${resp.status})`;
+	}
+
+	private async _confirmCompletion(): Promise<void> {
+		if (this._confirmCompletionLoading) return;
+		const bypassedCount = this._gates.filter(g => g.status === "bypassed").length;
+		const { confirmAction } = await import("../../app/dialogs-lazy.js");
+		this._dropdownEl?.classList.add("goal-status-confirming");
+		const confirmed = await confirmAction(
+			"Complete goal despite bypassed gate(s)?",
+			`${bypassedCount} gate(s) were forced past verification. Completing now records the goal as done with un-verified gates. This cannot be undone automatically.`,
+			"Complete",
+			true,
+		);
+		this._dropdownEl?.classList.remove("goal-status-confirming");
+		if (!confirmed) return;
+		this._confirmCompletionLoading = true;
+		this._confirmCompletionError = "";
+		try {
+			const { completeTeam } = await import("../../app/api.js");
+			const ok = await completeTeam(this.goalId, { confirmBypassedGates: true });
+			if (!ok) {
+				this._confirmCompletionError = "Unable to complete goal";
+				return;
+			}
+			await Promise.all([this._refreshGates(), this._refreshActive()]);
+		} catch (err) {
+			this._confirmCompletionError = err instanceof Error ? err.message : "Unable to complete goal";
+		} finally {
+			this._confirmCompletionLoading = false;
+		}
+	}
+
 	// ── Render ───────────────────────────────────────────────────────
 
 	private _renderDropdownContent(): TemplateResult {
 		const live = this._awaitingSignoffs;
+		const anyBypassed = this._gates.some(g => g.status === "bypassed");
 		return html`
 			<div class="flex items-center justify-between gap-2 mb-2 text-foreground font-medium text-sm">
 				<div class="flex items-center gap-1.5 min-w-0">
@@ -604,13 +737,25 @@ export class GoalStatusWidget extends LitElement {
 					<span>Goal status</span>
 					${renderGateProgressBadge(this.goalId)}
 				</div>
-				<button
-					class="goal-widget-button goal-widget-button-neutral shrink-0"
-					@click=${(e: MouseEvent) => { e.stopPropagation(); this._closeDropdown(); setHashRoute("goal-dashboard", this.goalId); }}
-					data-testid="goal-widget-dashboard-link"
-					title="Goal dashboard"
-				>${icon(LayoutDashboard, "xs")}<span>Goal Dashboard</span></button>
+				<div class="flex items-center gap-1.5 shrink-0">
+					${anyBypassed ? html`
+						<button
+							class="goal-widget-button goal-widget-button-bypass"
+							?disabled=${this._confirmCompletionLoading}
+							@click=${(e: MouseEvent) => { e.stopPropagation(); void this._confirmCompletion(); }}
+							data-testid="goal-widget-confirm-completion"
+							title="Confirm completion despite bypassed gate(s)"
+						>${this._confirmCompletionLoading ? icon(Loader2, "xs", "animate-spin") : icon(CheckCircle2, "xs")}<span>${this._confirmCompletionLoading ? "Completing…" : "Confirm completion"}</span></button>
+					` : nothing}
+					<button
+						class="goal-widget-button goal-widget-button-neutral"
+						@click=${(e: MouseEvent) => { e.stopPropagation(); this._closeDropdown(); setHashRoute("goal-dashboard", this.goalId); }}
+						data-testid="goal-widget-dashboard-link"
+						title="Goal dashboard"
+					>${icon(LayoutDashboard, "xs")}<span>Goal Dashboard</span></button>
+				</div>
 			</div>
+			${anyBypassed && this._confirmCompletionError ? html`<div class="goal-widget-gate-error mb-2" data-testid="goal-widget-confirm-completion-error">${this._confirmCompletionError}</div>` : nothing}
 
 			<div class="border-t border-border mb-2"></div>
 
@@ -634,12 +779,18 @@ export class GoalStatusWidget extends LitElement {
 	private _renderGateRow(gate: GateSummary): TemplateResult {
 		const resetting = this._resetLoading.has(gate.id);
 		const resetError = this._resetErrors.get(gate.id);
+		const bypassError = this._bypassErrors.get(gate.id);
 		const effectiveStatus: GateStatus = this._activeGateIds.has(gate.id) ? "running" : gate.status;
+		const canBypass = effectiveStatus === "pending" || effectiveStatus === "failed";
+		const formOpen = this._bypassing === gate.id;
+		const rowTitle = effectiveStatus === "bypassed" && (gate.whoAmI || gate.whyBypassed)
+			? `Bypassed by ${gate.whoAmI || "unknown"}${gate.whyBypassed ? `: ${gate.whyBypassed}` : ""}`
+			: gate.name;
 		return html`
 			<div class="goal-widget-gate-row flex items-center gap-2 rounded-md" data-testid="goal-widget-gate" data-gate-id=${gate.id} data-gate-status=${effectiveStatus}>
 				<div class="goal-widget-gate-main min-w-0 flex items-center gap-2">
 					${this._renderGateStatusIndicator(gate)}
-					<span class="truncate text-foreground" title=${gate.name}>${gate.name}</span>
+					<span class="truncate text-foreground" title=${rowTitle}>${gate.name}</span>
 				</div>
 				${effectiveStatus === "passed" ? html`
 					<div class="goal-widget-gate-actions" data-testid="goal-widget-gate-actions">
@@ -658,7 +809,69 @@ export class GoalStatusWidget extends LitElement {
 						>${resetting ? icon(Loader2, "xs", "animate-spin") : icon(RotateCcw, "xs")}<span>${resetting ? "Resetting…" : "Reset"}</span></button>
 					</div>
 				` : nothing}
+				${canBypass && !formOpen ? html`
+					<div class="goal-widget-gate-actions" data-testid="goal-widget-gate-actions">
+						<button
+							type="button"
+							class="goal-widget-button goal-widget-button-bypass goal-widget-gate-action"
+							@click=${(e: MouseEvent) => { e.stopPropagation(); this._openBypassForm(gate); }}
+							data-testid="goal-widget-gate-bypass"
+							title="Force this gate past verification (human override)"
+						>${icon(AlertTriangle, "xs")}<span>Bypass</span></button>
+					</div>
+				` : nothing}
 				${resetError ? html`<div class="goal-widget-gate-error" data-testid="goal-widget-gate-reset-error">${resetError}</div>` : nothing}
+			</div>
+			${effectiveStatus === "bypassed" && (gate.whoAmI || gate.whyBypassed) ? html`
+				<div class="goal-widget-bypass-caption" data-testid="goal-widget-gate-bypass-info" title=${rowTitle}>
+					Bypassed${gate.whoAmI ? html` by <span class="goal-widget-bypass-who">${gate.whoAmI}</span>` : nothing}${gate.whyBypassed ? html`: ${gate.whyBypassed}` : nothing}
+				</div>
+			` : nothing}
+			${formOpen ? this._renderBypassForm(gate) : nothing}
+			${bypassError ? html`<div class="goal-widget-gate-error" data-testid="goal-widget-gate-bypass-error">${bypassError}</div>` : nothing}
+		`;
+	}
+
+	private _renderBypassForm(gate: GateSummary): TemplateResult {
+		const loading = this._bypassLoading.has(gate.id);
+		const canConfirm = !loading && this._bypassWhy.trim().length > 0 && this._bypassWho.trim().length > 0;
+		return html`
+			<div class="goal-widget-bypass-form" data-testid="goal-widget-bypass-form" @click=${(e: MouseEvent) => e.stopPropagation()}>
+				<div class="goal-widget-bypass-warning">${icon(AlertTriangle, "xs")}<span>Forcing this gate past verification is a human-only override. It will not be a clean pass.</span></div>
+				<label class="goal-widget-bypass-label">Why are you bypassing this gate?</label>
+				<textarea
+					class="goal-widget-bypass-input"
+					data-testid="goal-widget-bypass-why"
+					rows="3"
+					placeholder="Justification (recorded for audit)"
+					.value=${this._bypassWhy}
+					@input=${(e: Event) => { this._bypassWhy = (e.target as HTMLTextAreaElement).value; }}
+				></textarea>
+				<label class="goal-widget-bypass-label">Who are you?</label>
+				<input
+					class="goal-widget-bypass-input"
+					data-testid="goal-widget-bypass-who"
+					type="text"
+					placeholder="Your name / role"
+					.value=${this._bypassWho}
+					@input=${(e: Event) => { this._bypassWho = (e.target as HTMLInputElement).value; }}
+				/>
+				<div class="flex items-center justify-end gap-2 mt-1">
+					<button
+						type="button"
+						class="goal-widget-button goal-widget-button-neutral"
+						?disabled=${loading}
+						@click=${(e: MouseEvent) => { e.stopPropagation(); this._cancelBypassForm(); }}
+						data-testid="goal-widget-bypass-cancel"
+					>Cancel</button>
+					<button
+						type="button"
+						class="goal-widget-button goal-widget-button-bypass"
+						?disabled=${!canConfirm}
+						@click=${(e: MouseEvent) => { e.stopPropagation(); void this._confirmBypass(gate); }}
+						data-testid="goal-widget-bypass-confirm"
+					>${loading ? icon(Loader2, "xs", "animate-spin") : icon(AlertTriangle, "xs")}<span>${loading ? "Bypassing…" : "Confirm bypass"}</span></button>
+				</div>
 			</div>
 		`;
 	}
@@ -837,6 +1050,72 @@ export class GoalStatusWidget extends LitElement {
 				background: color-mix(in oklch, var(--negative, var(--destructive, #dc2626)) 10%, transparent);
 				border-color: color-mix(in oklch, var(--negative, var(--destructive, #dc2626)) 40%, var(--border));
 				color: var(--negative, var(--destructive, #dc2626));
+			}
+			.goal-widget-button-bypass {
+				color: var(--warning, var(--negative, var(--destructive, #dc2626)));
+				border-color: color-mix(in oklch, var(--warning, var(--negative, #dc2626)) 35%, var(--border));
+			}
+			.goal-widget-button-bypass:hover:not(:disabled) {
+				background: color-mix(in oklch, var(--warning, var(--negative, #dc2626)) 12%, transparent);
+				border-color: color-mix(in oklch, var(--warning, var(--negative, #dc2626)) 55%, var(--border));
+				color: var(--warning, var(--negative, var(--destructive, #dc2626)));
+			}
+			.goal-widget-bypass-caption {
+				font-size: 11px;
+				color: var(--muted-foreground);
+				padding: 0 0 2px 20px;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
+			.goal-widget-bypass-who {
+				color: var(--foreground);
+				font-weight: 600;
+			}
+			.goal-widget-bypass-form {
+				display: flex;
+				flex-direction: column;
+				gap: 4px;
+				padding: 8px;
+				margin: 2px 0 4px;
+				border: 1px solid color-mix(in oklch, var(--warning, var(--negative, #dc2626)) 35%, var(--border));
+				border-radius: 6px;
+				background: color-mix(in oklch, var(--warning, var(--negative, #dc2626)) 6%, transparent);
+			}
+			.goal-widget-bypass-warning {
+				display: flex;
+				align-items: flex-start;
+				gap: 5px;
+				font-size: 11px;
+				color: var(--warning, var(--negative, var(--destructive, #dc2626)));
+				line-height: 1.3;
+			}
+			.goal-widget-bypass-warning svg {
+				width: 12px;
+				height: 12px;
+				flex-shrink: 0;
+				margin-top: 1px;
+			}
+			.goal-widget-bypass-label {
+				font-size: 11px;
+				font-weight: 500;
+				color: var(--muted-foreground);
+			}
+			.goal-widget-bypass-input {
+				width: 100%;
+				box-sizing: border-box;
+				padding: 5px 7px;
+				border: 1px solid var(--border);
+				border-radius: 4px;
+				background: var(--background);
+				color: var(--foreground);
+				font-size: 12px;
+				font-family: inherit;
+				resize: vertical;
+			}
+			.goal-widget-bypass-input:focus {
+				outline: none;
+				border-color: color-mix(in oklch, var(--warning, var(--negative, #dc2626)) 55%, var(--border));
 			}
 			@keyframes goal-widget-running-dot-pulse {
 				0%, 100% { transform: scale(0.86); opacity: 0.55; box-shadow: 0 0 0 0 color-mix(in oklch, var(--info, #3b82f6) 36%, transparent); }

--- a/tests/e2e/gate-bypass-api.spec.ts
+++ b/tests/e2e/gate-bypass-api.spec.ts
@@ -316,6 +316,44 @@ test.describe("POST /api/goals/:goalId/gates/:gateId/bypass", () => {
 		}
 	});
 
+	test("sandbox-scoped token cannot confirm completion of bypassed gates", async ({ gateway }) => {
+		const wf = workflowId("gate-bypass-sandbox-complete");
+		await createWorkflow(wf, [
+			{ id: "root", name: "Root", dependsOn: [], verify: [{ name: "ok", type: "command", run: "echo ok" }] },
+		]);
+		const goal = await createGoal({ title: `Gate Bypass Sandbox Complete ${Date.now()}`, cwd: gitCwd(), workflowId: wf, worktree: false, team: true, autoStartTeam: false });
+		const goalId = goal.id;
+		let teamLeadId: string | undefined;
+		try {
+			await waitForGoalSetupReady(goalId);
+			teamLeadId = await startTeam(goalId);
+			expect((await bypassGate(goalId, "root", HUMAN)).status).toBe(200);
+
+			const projectId = (goal.projectId as string | undefined) || await defaultProjectId();
+			const sandboxToken = gateway.sessionManager.sandboxTokenStore.register(projectId);
+			gateway.sessionManager.sandboxTokenStore.addGoal(projectId, goalId);
+
+			// A sandbox-scoped agent must NOT be able to confirm completion past
+			// bypassed gates — the human-confirm override is rejected with 403.
+			const res = await fetch(`${base()}/api/goals/${goalId}/team/complete`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json", Authorization: `Bearer ${sandboxToken}` },
+				body: JSON.stringify({ confirmBypassedGates: true }),
+			});
+			expect(res.status).toBe(403);
+			const body = await res.json();
+			expect(String(body.error)).toContain("sandbox token cannot confirm completion");
+
+			// Gate stays bypassed (no completion happened).
+			const after = await apiFetch(`/api/goals/${goalId}/gates/root`);
+			expect((await after.json()).status).toBe("bypassed");
+		} finally {
+			if (teamLeadId) await teardownTeam(goalId).catch(() => {});
+			await deleteGoal(goalId).catch(() => {});
+			await deleteWorkflow(wf);
+		}
+	});
+
 	test("completion gating: agent team_complete blocked by bypassed gate; human confirm path succeeds", async () => {
 		const wf = workflowId("gate-bypass-complete");
 		await createWorkflow(wf, [

--- a/tests/e2e/gate-bypass-api.spec.ts
+++ b/tests/e2e/gate-bypass-api.spec.ts
@@ -1,0 +1,350 @@
+/**
+ * Route-level coverage for the human-only gate-bypass endpoint:
+ *   POST /api/goals/:goalId/gates/:gateId/bypass
+ *
+ * Verifies the endpoint matrix (design "Human Gate Bypass", acceptance
+ * criteria 1–8): happy path flips the gate to "bypassed" with a persisted
+ * audit signal + broadcast; the isInitiatedByHuman guard; required-field
+ * validation; sandbox/404/409 guards; reset of a bypassed gate; the read-model
+ * surfacing whyBypassed/whoAmI/bypassedAt; and the completion-gating contract
+ * (agent path blocked, human confirm path allowed).
+ *
+ * Mirrors tests/e2e/gate-reset-api.spec.ts harness/import patterns.
+ */
+import { test, expect } from "./in-process-harness.js";
+import {
+	apiFetch,
+	base,
+	connectWs,
+	createGoal,
+	createSession,
+	defaultProjectId,
+	deleteGoal,
+	deleteSession,
+	gitCwd,
+	startTeam,
+	teardownTeam,
+	type WsConnection,
+} from "./e2e-setup.js";
+import { pollUntil } from "./test-utils/cleanup.js";
+
+function workflowId(prefix: string): string {
+	return `${prefix}-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function createWorkflow(id: string, gates: Array<Record<string, unknown>>): Promise<void> {
+	const res = await apiFetch("/api/workflows", {
+		method: "POST",
+		body: JSON.stringify({
+			id,
+			name: `Gate Bypass ${id}`,
+			description: "Workflow fixture for gate bypass API tests",
+			gates,
+		}),
+	});
+	expect(res.status, `workflow create failed: ${res.status} ${await res.text().catch(() => "")}`).toBe(201);
+}
+
+async function deleteWorkflow(id: string): Promise<void> {
+	await apiFetch(`/api/workflows/${id}`, { method: "DELETE" }).catch(() => {});
+}
+
+async function waitForGoalSetupReady(goalId: string): Promise<any> {
+	return pollUntil(async () => {
+		const res = await apiFetch(`/api/goals/${goalId}`);
+		if (!res.ok) return null;
+		const goal = await res.json();
+		if (goal.setupStatus === "error") throw new Error(`Goal setup failed: ${JSON.stringify(goal)}`);
+		return goal.setupStatus === "ready" ? goal : null;
+	}, { timeoutMs: 60_000, intervalMs: 250, label: `goal ${goalId} setup ready` });
+}
+
+async function bypassGate(goalId: string, gateId: string, body: Record<string, unknown>): Promise<{ status: number; body: any }> {
+	const res = await apiFetch(`/api/goals/${goalId}/gates/${gateId}/bypass`, {
+		method: "POST",
+		body: JSON.stringify(body),
+	});
+	const text = await res.text();
+	let parsed: any = null;
+	try { parsed = text ? JSON.parse(text) : null; } catch { parsed = text; }
+	return { status: res.status, body: parsed };
+}
+
+async function getGate(goalId: string, gateId: string): Promise<any> {
+	const res = await apiFetch(`/api/goals/${goalId}/gates/${gateId}`);
+	expect(res.status).toBe(200);
+	return res.json();
+}
+
+async function listGates(goalId: string): Promise<any[]> {
+	const res = await apiFetch(`/api/goals/${goalId}/gates`);
+	expect(res.status).toBe(200);
+	return (await res.json()).gates || [];
+}
+
+async function resetGate(goalId: string, gateId: string): Promise<{ status: number; body: any }> {
+	const res = await apiFetch(`/api/goals/${goalId}/gates/${gateId}/reset`, { method: "POST" });
+	const text = await res.text();
+	let body: any = null;
+	try { body = text ? JSON.parse(text) : null; } catch { body = text; }
+	return { status: res.status, body };
+}
+
+const HUMAN = { whyBypassed: "Verification needs prod creds unavailable in CI", whoAmI: "overseer@example.com", isInitiatedByHuman: true };
+
+test.describe("POST /api/goals/:goalId/gates/:gateId/bypass", () => {
+	test("human bypass flips the gate to bypassed, persists audit signal, broadcasts", async () => {
+		const wf = workflowId("gate-bypass-happy");
+		await createWorkflow(wf, [
+			{ id: "root", name: "Root", dependsOn: [], verify: [{ name: "ok", type: "command", run: "echo ok" }] },
+		]);
+		const goal = await createGoal({ title: `Gate Bypass Happy ${Date.now()}`, cwd: gitCwd(), workflowId: wf, worktree: false, team: false, autoStartTeam: false });
+		const goalId = goal.id;
+		let sessionId: string | undefined;
+		let conn: WsConnection | undefined;
+		try {
+			await waitForGoalSetupReady(goalId);
+			sessionId = await createSession({ goalId });
+			conn = await connectWs(sessionId);
+
+			const cursor = conn.messageCount();
+			const res = await bypassGate(goalId, "root", HUMAN);
+			expect(res.status, JSON.stringify(res.body)).toBe(200);
+			expect(res.body.ok).toBe(true);
+			expect(res.body.status).toBe("bypassed");
+			expect(res.body.gateId).toBe("root");
+			expect(res.body.whyBypassed).toBe(HUMAN.whyBypassed);
+			expect(res.body.whoAmI).toBe(HUMAN.whoAmI);
+			expect(res.body.bypassedAt).toBeTruthy();
+
+			await conn.waitForFrom(cursor, (m) => m.type === "gate_status_changed" && m.goalId === goalId && m.gateId === "root" && m.status === "bypassed", 10_000);
+
+			const gate = await getGate(goalId, "root");
+			expect(gate.status).toBe("bypassed");
+			const auditSignal = gate.signals.find((s: any) => s?.metadata?.bypass === "true");
+			expect(auditSignal, "synthetic bypass audit signal must be persisted").toBeTruthy();
+			expect(auditSignal.metadata.whyBypassed).toBe(HUMAN.whyBypassed);
+			expect(auditSignal.metadata.whoAmI).toBe(HUMAN.whoAmI);
+			expect(auditSignal.metadata.bypassedAt).toBeTruthy();
+			expect(auditSignal.sessionId).toBe("human-bypass");
+		} finally {
+			conn?.close();
+			if (sessionId) await deleteSession(sessionId).catch(() => {});
+			await deleteGoal(goalId).catch(() => {});
+			await deleteWorkflow(wf);
+		}
+	});
+
+	test("GET /gates surfaces whyBypassed/whoAmI/bypassedAt on a bypassed gate", async () => {
+		const wf = workflowId("gate-bypass-readmodel");
+		await createWorkflow(wf, [
+			{ id: "root", name: "Root", dependsOn: [], verify: [{ name: "ok", type: "command", run: "echo ok" }] },
+		]);
+		const goal = await createGoal({ title: `Gate Bypass ReadModel ${Date.now()}`, cwd: gitCwd(), workflowId: wf, worktree: false, team: false, autoStartTeam: false });
+		const goalId = goal.id;
+		try {
+			await waitForGoalSetupReady(goalId);
+			const res = await bypassGate(goalId, "root", HUMAN);
+			expect(res.status, JSON.stringify(res.body)).toBe(200);
+
+			const gates = await listGates(goalId);
+			const root = gates.find((g) => g.gateId === "root");
+			expect(root.status).toBe("bypassed");
+			expect(root.whyBypassed).toBe(HUMAN.whyBypassed);
+			expect(root.whoAmI).toBe(HUMAN.whoAmI);
+			expect(root.bypassedAt).toBeTruthy();
+		} finally {
+			await deleteGoal(goalId).catch(() => {});
+			await deleteWorkflow(wf);
+		}
+	});
+
+	test("reset of a bypassed gate returns it to pending", async () => {
+		const wf = workflowId("gate-bypass-reset");
+		await createWorkflow(wf, [
+			{ id: "root", name: "Root", dependsOn: [], verify: [{ name: "ok", type: "command", run: "echo ok" }] },
+		]);
+		const goal = await createGoal({ title: `Gate Bypass Reset ${Date.now()}`, cwd: gitCwd(), workflowId: wf, worktree: false, team: false, autoStartTeam: false });
+		const goalId = goal.id;
+		try {
+			await waitForGoalSetupReady(goalId);
+			expect((await bypassGate(goalId, "root", HUMAN)).status).toBe(200);
+			expect((await getGate(goalId, "root")).status).toBe("bypassed");
+
+			const reset = await resetGate(goalId, "root");
+			expect(reset.status, JSON.stringify(reset.body)).toBe(200);
+			await pollUntil(async () => (await getGate(goalId, "root")).status === "pending" ? true : null, { timeoutMs: 10_000, intervalMs: 50, label: "root pending after reset" });
+		} finally {
+			await deleteGoal(goalId).catch(() => {});
+			await deleteWorkflow(wf);
+		}
+	});
+
+	test("bypassed upstream unblocks a dependent gate signal", async () => {
+		const wf = workflowId("gate-bypass-dep");
+		await createWorkflow(wf, [
+			{ id: "root", name: "Root", dependsOn: [], verify: [{ name: "ok", type: "command", run: "echo ok" }] },
+			{ id: "child", name: "Child", dependsOn: ["root"], verify: [{ name: "ok", type: "command", run: "echo ok" }] },
+		]);
+		const goal = await createGoal({ title: `Gate Bypass Dep ${Date.now()}`, cwd: gitCwd(), workflowId: wf, worktree: false, team: false, autoStartTeam: false });
+		const goalId = goal.id;
+		try {
+			await waitForGoalSetupReady(goalId);
+			expect((await bypassGate(goalId, "root", HUMAN)).status).toBe(200);
+
+			// Signalling the dependent gate must NOT be rejected with a 409
+			// "upstream not passed" because the bypassed upstream counts as satisfied.
+			const sig = await apiFetch(`/api/goals/${goalId}/gates/child/signal`, { method: "POST", body: JSON.stringify({}) });
+			expect(sig.status, await sig.text().catch(() => "")).toBe(201);
+		} finally {
+			await deleteGoal(goalId).catch(() => {});
+			await deleteWorkflow(wf);
+		}
+	});
+
+	test("validation: isInitiatedByHuman:false → 400 guard; missing why/who → 400", async () => {
+		const wf = workflowId("gate-bypass-validate");
+		await createWorkflow(wf, [
+			{ id: "root", name: "Root", dependsOn: [], verify: [{ name: "ok", type: "command", run: "echo ok" }] },
+		]);
+		const goal = await createGoal({ title: `Gate Bypass Validate ${Date.now()}`, cwd: gitCwd(), workflowId: wf, worktree: false, team: false, autoStartTeam: false });
+		const goalId = goal.id;
+		try {
+			await waitForGoalSetupReady(goalId);
+
+			const agent = await bypassGate(goalId, "root", { whyBypassed: "x", whoAmI: "y", isInitiatedByHuman: false });
+			expect(agent.status).toBe(400);
+			expect(agent.body.error).toBe("This method is currently intended for human use only. Bypassing a gate as an agent is not acting in the best interest of the outcome.");
+
+			const noFlag = await bypassGate(goalId, "root", { whyBypassed: "x", whoAmI: "y" });
+			expect(noFlag.status).toBe(400);
+
+			const missingWhy = await bypassGate(goalId, "root", { whoAmI: "y", isInitiatedByHuman: true });
+			expect(missingWhy.status).toBe(400);
+			expect(missingWhy.body.error).toBe("whyBypassed is required");
+
+			const blankWhy = await bypassGate(goalId, "root", { whyBypassed: "   ", whoAmI: "y", isInitiatedByHuman: true });
+			expect(blankWhy.status).toBe(400);
+			expect(blankWhy.body.error).toBe("whyBypassed is required");
+
+			const missingWho = await bypassGate(goalId, "root", { whyBypassed: "x", isInitiatedByHuman: true });
+			expect(missingWho.status).toBe(400);
+			expect(missingWho.body.error).toBe("whoAmI is required");
+
+			const blankWho = await bypassGate(goalId, "root", { whyBypassed: "x", whoAmI: "  ", isInitiatedByHuman: true });
+			expect(blankWho.status).toBe(400);
+			expect(blankWho.body.error).toBe("whoAmI is required");
+
+			// Gate must remain pending after all rejected attempts.
+			expect((await getGate(goalId, "root")).status).toBe("pending");
+		} finally {
+			await deleteGoal(goalId).catch(() => {});
+			await deleteWorkflow(wf);
+		}
+	});
+
+	test("unknown gate → 404; unknown goal → 404", async () => {
+		const wf = workflowId("gate-bypass-404");
+		await createWorkflow(wf, [
+			{ id: "root", name: "Root", dependsOn: [], verify: [{ name: "ok", type: "command", run: "echo ok" }] },
+		]);
+		const goal = await createGoal({ title: `Gate Bypass 404 ${Date.now()}`, cwd: gitCwd(), workflowId: wf, worktree: false, team: false, autoStartTeam: false });
+		const goalId = goal.id;
+		try {
+			await waitForGoalSetupReady(goalId);
+			const unknownGate = await bypassGate(goalId, "does-not-exist", HUMAN);
+			expect(unknownGate.status).toBe(404);
+
+			const unknownGoal = await bypassGate("goal-does-not-exist", "root", HUMAN);
+			expect(unknownGoal.status).toBe(404);
+		} finally {
+			await deleteGoal(goalId).catch(() => {});
+			await deleteWorkflow(wf);
+		}
+	});
+
+	test("denies sandbox-scoped tokens with 403", async ({ gateway }) => {
+		const wf = workflowId("gate-bypass-sandbox");
+		await createWorkflow(wf, [
+			{ id: "root", name: "Root", dependsOn: [], verify: [{ name: "ok", type: "command", run: "echo ok" }] },
+		]);
+		const goal = await createGoal({ title: `Gate Bypass Sandbox ${Date.now()}`, cwd: gitCwd(), workflowId: wf, worktree: false, team: false, autoStartTeam: false });
+		const goalId = goal.id;
+		try {
+			await waitForGoalSetupReady(goalId);
+			const projectId = (goal.projectId as string | undefined) || await defaultProjectId();
+			expect(projectId).toBeTruthy();
+			const sandboxToken = gateway.sessionManager.sandboxTokenStore.register(projectId);
+			gateway.sessionManager.sandboxTokenStore.addGoal(projectId, goalId);
+
+			const res = await fetch(`${base()}/api/goals/${goalId}/gates/root/bypass`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json", Authorization: `Bearer ${sandboxToken}` },
+				body: JSON.stringify(HUMAN),
+			});
+			expect(res.status).toBe(403);
+		} finally {
+			await deleteGoal(goalId).catch(() => {});
+			await deleteWorkflow(wf);
+		}
+	});
+
+	test("archived goal → 409", async () => {
+		const wf = workflowId("gate-bypass-archived");
+		await createWorkflow(wf, [
+			{ id: "root", name: "Root", dependsOn: [], verify: [{ name: "ok", type: "command", run: "echo ok" }] },
+		]);
+		const goal = await createGoal({ title: `Gate Bypass Archived ${Date.now()}`, cwd: gitCwd(), workflowId: wf, worktree: false, team: false, autoStartTeam: false });
+		const goalId = goal.id;
+		try {
+			await waitForGoalSetupReady(goalId);
+			// DELETE archives the goal (sets archived=true). getGoalAcrossProjects
+			// still resolves it, so bypass must reject with 409 (mirrors reset).
+			await deleteGoal(goalId);
+			await pollUntil(async () => {
+				const r = await apiFetch(`/api/goals/${goalId}`);
+				if (r.status !== 200) return null;
+				const g = await r.json();
+				return g.archived === true ? true : null;
+			}, { timeoutMs: 10_000, intervalMs: 100, label: "goal archived" });
+
+			const res = await bypassGate(goalId, "root", HUMAN);
+			expect(res.status).toBe(409);
+			expect(res.body.error).toBe("Goal is archived");
+		} finally {
+			await deleteWorkflow(wf);
+		}
+	});
+
+	test("completion gating: agent team_complete blocked by bypassed gate; human confirm path succeeds", async () => {
+		const wf = workflowId("gate-bypass-complete");
+		await createWorkflow(wf, [
+			{ id: "root", name: "Root", dependsOn: [], verify: [{ name: "ok", type: "command", run: "echo ok" }] },
+		]);
+		const goal = await createGoal({ title: `Gate Bypass Complete ${Date.now()}`, cwd: gitCwd(), workflowId: wf, worktree: false, team: true, autoStartTeam: false });
+		const goalId = goal.id;
+		let teamLeadId: string | undefined;
+		try {
+			await waitForGoalSetupReady(goalId);
+			teamLeadId = await startTeam(goalId);
+
+			expect((await bypassGate(goalId, "root", HUMAN)).status).toBe(200);
+
+			// Without confirmBypassedGates → distinct 400 error.
+			const blocked = await apiFetch(`/api/goals/${goalId}/team/complete`, { method: "POST", body: JSON.stringify({}) });
+			const blockedBody = await blocked.json();
+			expect(blocked.status).toBe(400);
+			expect(String(blockedBody.error)).toContain("bypassed and require human confirmation");
+
+			// With confirmBypassedGates:true → succeeds.
+			const confirmed = await apiFetch(`/api/goals/${goalId}/team/complete`, { method: "POST", body: JSON.stringify({ confirmBypassedGates: true }) });
+			const confirmedBody = await confirmed.json();
+			expect(confirmed.status, JSON.stringify(confirmedBody)).toBe(200);
+			expect(confirmedBody.ok).toBe(true);
+		} finally {
+			if (teamLeadId) await teardownTeam(goalId).catch(() => {});
+			await deleteGoal(goalId).catch(() => {});
+			await deleteWorkflow(wf);
+		}
+	});
+});

--- a/tests/e2e/ui/gate-bypass.spec.ts
+++ b/tests/e2e/ui/gate-bypass.spec.ts
@@ -1,0 +1,267 @@
+/**
+ * Browser E2E for the human-only "bypass gate" capability in the chat-header
+ * `<goal-status-widget>`.
+ *
+ * Covers (design §10 / E2E plan):
+ *   - Bypass button visible on a pending/failed gate, absent on a passed gate.
+ *   - Inline bypass form collects whyBypassed + whoAmI and POSTs the bypass
+ *     endpoint with isInitiatedByHuman:true.
+ *   - The bypassed gate row shows the bypassed icon/state + why/who text.
+ *   - The header pill + sidebar badge turn red and gain a trailing `!`, and the
+ *     numerator counts the bypassed gate (visual differentiation).
+ *   - The Confirm-completion button appears only once a gate is bypassed.
+ *   - Bypassed state + red badge persist across reload.
+ *
+ * The bypass + gates + summary endpoints are mocked via page.route so the test
+ * is self-contained and deterministic; the cross-slice JSON contract it asserts
+ * against is pinned by the API E2E suite (criteria 1–8).
+ */
+import { test, expect, type Page, type Route } from "../gateway-harness.js";
+import { apiFetch, createGoal, createSession, deleteGoal, deleteSession } from "../e2e-setup.js";
+import { openApp, navigateToHash } from "./ui-helpers.js";
+
+const FAILED_GATE_ID = "implementation";
+const FAILED_GATE_NAME = "Implementation";
+const WHY = "Verification step requires hardware we do not have in CI; manually verified on staging.";
+const WHO = "Jamie (overseer)";
+const RED_RGB = "rgb(220, 38, 38)"; // #dc2626
+
+interface GateRecord {
+	gateId: string;
+	name: string;
+	status: "pending" | "passed" | "failed" | "bypassed";
+	whyBypassed?: string;
+	whoAmI?: string;
+	bypassedAt?: string;
+}
+
+interface MockState {
+	gates: GateRecord[];
+}
+
+/** Mock /gates (non-summary + summary view), /verifications/active, and the
+ *  /bypass endpoint for a goal. The closure-held `state` survives reloads so
+ *  the bypassed gate persists. Returns captured bypass POST bodies. */
+async function installBypassMocks(page: Page, goalId: string): Promise<{ bypassCalls: Array<Record<string, unknown>> }> {
+	const state: MockState = {
+		gates: [
+			{ gateId: "design-doc", name: "Design Doc", status: "passed" },
+			{ gateId: FAILED_GATE_ID, name: FAILED_GATE_NAME, status: "failed" },
+			{ gateId: "ready-to-merge", name: "Ready to Merge", status: "pending" },
+		],
+	};
+	const bypassCalls: Array<Record<string, unknown>> = [];
+
+	const summaryBody = () => {
+		const passed = state.gates.filter(g => g.status === "passed").length;
+		const bypassed = state.gates.filter(g => g.status === "bypassed").length;
+		return {
+			summary: {
+				passed,
+				bypassed,
+				bypassedCount: bypassed,
+				total: state.gates.length,
+				verifying: false,
+				verifyingCount: 0,
+				awaitingSignoffCount: 0,
+				awaitingHumanSignoff: false,
+				runningGateIds: [],
+				gates: state.gates.map(g => ({
+					gateId: g.gateId,
+					name: g.name,
+					status: g.status,
+					effectiveStatus: g.status === "bypassed" ? "passed" : g.status,
+					running: false,
+					awaitingSignoffCount: 0,
+					dependsOn: [],
+					signalCount: 0,
+				})),
+			},
+		};
+	};
+
+	const gatesBody = () => ({
+		gates: state.gates.map(g => ({
+			gateId: g.gateId,
+			name: g.name,
+			status: g.status,
+			signals: [],
+			...(g.status === "bypassed" ? { whyBypassed: g.whyBypassed, whoAmI: g.whoAmI, bypassedAt: g.bypassedAt } : {}),
+		})),
+	});
+
+	const gatesRe = new RegExp(`/api/goals/${goalId}/gates(?:\\?.*)?$`);
+	const activeRe = new RegExp(`/api/goals/${goalId}/verifications/active(?:\\?.*)?$`);
+	const bypassRe = new RegExp(`/api/goals/${goalId}/gates/[^/]+/bypass$`);
+
+	await page.route(gatesRe, async (route: Route) => {
+		if (route.request().method() !== "GET") return route.fallback();
+		await route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify(route.request().url().includes("view=summary") ? summaryBody() : gatesBody()),
+		});
+	});
+
+	await page.route(activeRe, async (route: Route) => {
+		if (route.request().method() !== "GET") return route.fallback();
+		await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ verifications: [] }) });
+	});
+
+	await page.route(bypassRe, async (route: Route) => {
+		if (route.request().method() !== "POST") return route.fallback();
+		let body: Record<string, unknown> = {};
+		try { body = JSON.parse(route.request().postData() || "{}"); } catch { /* ignore */ }
+		bypassCalls.push(body);
+		const gateId = decodeURIComponent(route.request().url().replace(/\?.*$/, "").split("/").slice(-2, -1)[0]);
+		const whyBypassed = typeof body.whyBypassed === "string" ? body.whyBypassed.trim() : "";
+		const whoAmI = typeof body.whoAmI === "string" ? body.whoAmI.trim() : "";
+		if (body.isInitiatedByHuman !== true) {
+			await route.fulfill({ status: 400, contentType: "application/json", body: JSON.stringify({ error: "This method is currently intended for human use only." }) });
+			return;
+		}
+		if (!whyBypassed || !whoAmI) {
+			await route.fulfill({ status: 400, contentType: "application/json", body: JSON.stringify({ error: "whyBypassed and whoAmI are required" }) });
+			return;
+		}
+		const gate = state.gates.find(g => g.gateId === gateId);
+		if (!gate) {
+			await route.fulfill({ status: 404, contentType: "application/json", body: JSON.stringify({ error: `Unknown gate: ${gateId}` }) });
+			return;
+		}
+		const bypassedAt = String(Date.now());
+		gate.status = "bypassed";
+		gate.whyBypassed = whyBypassed;
+		gate.whoAmI = whoAmI;
+		gate.bypassedAt = bypassedAt;
+		await route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify({ ok: true, gateId, status: "bypassed", whyBypassed, whoAmI, bypassedAt }),
+		});
+	});
+
+	return { bypassCalls };
+}
+
+async function openSession(page: Page, sessionId: string): Promise<void> {
+	await navigateToHash(page, `#/session/${sessionId}`);
+	await expect(page.locator("textarea").first()).toBeVisible({ timeout: 15_000 });
+}
+
+/** Read the red bypassed badge text from a scope (pill or sidebar row). The
+ *  bypassed badge is a red span whose text ends with `!`. */
+async function bypassedBadge(scope: ReturnType<Page["locator"]>): Promise<{ text: string; color: string } | null> {
+	return scope.evaluate((root) => {
+		const norm = (v: string | null | undefined) => (v ?? "").replace(/\s+/g, " ").trim();
+		for (const el of Array.from(root.querySelectorAll("span"))) {
+			const text = norm(el.textContent);
+			if (/^\(\d+\/\d+\)!$/.test(text)) {
+				return { text, color: getComputedStyle(el).color };
+			}
+		}
+		return null;
+	});
+}
+
+test.describe("gate bypass (human-only override)", () => {
+	test("bypass a failed gate: button gating, inline form, bypassed row, red badge, confirm-completion, persistence", async ({ page }) => {
+		const goal = await createGoal({ title: `Gate-Bypass ${Date.now()}`, workflowId: "test-fast", worktree: false, team: false });
+		const goalId = goal.id;
+		let sessionId: string | undefined;
+		try {
+			const { bypassCalls } = await installBypassMocks(page, goalId);
+			sessionId = await createSession({ goalId });
+
+			await openApp(page);
+			await openSession(page, sessionId);
+
+			const pill = page.locator("[data-testid='goal-status-widget-pill']").first();
+			await expect(pill).toBeVisible({ timeout: 15_000 });
+			await pill.click();
+			await expect(page.locator("[data-testid='goal-widget-gates']")).toBeVisible({ timeout: 5_000 });
+
+			// Bypass button absent on a passed gate; present on the failed gate.
+			const passedRow = page.locator('[data-testid="goal-widget-gate"][data-gate-id="design-doc"]');
+			await expect(passedRow).toHaveAttribute("data-gate-status", "passed", { timeout: 10_000 });
+			await expect(passedRow.locator('[data-testid="goal-widget-gate-bypass"]')).toHaveCount(0);
+
+			const failedRow = page.locator(`[data-testid="goal-widget-gate"][data-gate-id="${FAILED_GATE_ID}"]`);
+			await expect(failedRow).toHaveAttribute("data-gate-status", "failed", { timeout: 10_000 });
+			const bypassBtn = failedRow.locator('[data-testid="goal-widget-gate-bypass"]');
+			await expect(bypassBtn).toBeVisible();
+
+			// Confirm-completion button absent before any gate is bypassed.
+			await expect(page.locator("[data-testid='goal-widget-confirm-completion']")).toHaveCount(0);
+
+			// Open the inline bypass form.
+			await bypassBtn.click();
+			const form = page.locator("[data-testid='goal-widget-bypass-form']");
+			await expect(form).toBeVisible({ timeout: 5_000 });
+
+			const confirm = page.locator("[data-testid='goal-widget-bypass-confirm']");
+			await expect(confirm).toBeDisabled();
+
+			await page.locator("[data-testid='goal-widget-bypass-why']").fill(WHY);
+			await expect(confirm).toBeDisabled(); // still need whoAmI
+			await page.locator("[data-testid='goal-widget-bypass-who']").fill(WHO);
+			await expect(confirm).toBeEnabled();
+
+			const bypassResp = page.waitForResponse((r) =>
+				r.request().method() === "POST"
+				&& r.url().includes(`/api/goals/${goalId}/gates/${FAILED_GATE_ID}/bypass`),
+				{ timeout: 10_000 },
+			);
+			await confirm.click();
+			const resp = await bypassResp;
+			expect(resp.status()).toBe(200);
+
+			// POST body carried the human-only guard + audit fields.
+			expect(bypassCalls.length).toBeGreaterThan(0);
+			expect(bypassCalls[0]).toMatchObject({ whyBypassed: WHY, whoAmI: WHO, isInitiatedByHuman: true });
+
+			// Gate row now reads bypassed, with the bypassed icon + why/who caption.
+			await expect(failedRow).toHaveAttribute("data-gate-status", "bypassed", { timeout: 10_000 });
+			await expect(failedRow.locator('svg[aria-label="bypassed"]')).toBeVisible();
+			const caption = page.locator("[data-testid='goal-widget-gate-bypass-info']").first();
+			await expect(caption).toBeVisible();
+			await expect(caption).toContainText(WHO);
+			await expect(caption).toContainText(WHY);
+
+			// Bypass button no longer shown on the bypassed row.
+			await expect(failedRow.locator('[data-testid="goal-widget-gate-bypass"]')).toHaveCount(0);
+
+			// Confirm-completion button now appears (gating).
+			await expect(page.locator("[data-testid='goal-widget-confirm-completion']")).toBeVisible({ timeout: 5_000 });
+
+			// Header pill badge: red, trailing `!`, numerator counts the bypassed gate.
+			// design-doc passed (1) + implementation bypassed (1) = 2 of 3.
+			await expect.poll(async () => bypassedBadge(pill), { timeout: 10_000, message: "header pill should show a red (2/3)! badge" })
+				.toMatchObject({ text: "(2/3)!", color: RED_RGB });
+
+			// Sidebar goal-row badge: same red + `!` treatment.
+			const sidebarRow = page.locator(`[data-nav-id="goal:${goalId}"]`).first();
+			await expect(sidebarRow).toBeVisible({ timeout: 10_000 });
+			await expect.poll(async () => bypassedBadge(sidebarRow), { timeout: 10_000, message: "sidebar goal row should show a red (2/3)! badge" })
+				.toMatchObject({ text: "(2/3)!", color: RED_RGB });
+
+			// Persist across reload: bypassed state + red badge survive.
+			await page.reload();
+			await openSession(page, sessionId);
+			const pillAfter = page.locator("[data-testid='goal-status-widget-pill']").first();
+			await expect(pillAfter).toBeVisible({ timeout: 15_000 });
+			await expect.poll(async () => bypassedBadge(pillAfter), { timeout: 10_000, message: "red bypassed badge should persist after reload" })
+				.toMatchObject({ text: "(2/3)!", color: RED_RGB });
+
+			await pillAfter.click();
+			await expect(page.locator("[data-testid='goal-widget-gates']")).toBeVisible({ timeout: 5_000 });
+			await expect(page.locator(`[data-testid="goal-widget-gate"][data-gate-id="${FAILED_GATE_ID}"]`))
+				.toHaveAttribute("data-gate-status", "bypassed", { timeout: 10_000 });
+			await expect(page.locator("[data-testid='goal-widget-confirm-completion']")).toBeVisible({ timeout: 5_000 });
+		} finally {
+			if (sessionId) await deleteSession(sessionId).catch(() => { /* ignore */ });
+			await deleteGoal(goalId).catch(() => { /* ignore */ });
+			await apiFetch("/api/health").catch(() => { /* keep harness happy */ });
+		}
+	});
+});

--- a/tests/gate-dependency-enforcement.test.ts
+++ b/tests/gate-dependency-enforcement.test.ts
@@ -60,6 +60,17 @@ describe("Gate Dependency Enforcement", () => {
 			assert.ok(error.includes("implementation"), `Error should name blocking gate: ${error}`);
 		});
 
+		it("treats a bypassed upstream gate as satisfied (unblocks dependents)", () => {
+			const gateStates: Array<{ gateId: string; status: string }> = [
+				{ gateId: "design-doc", status: "bypassed" },
+				{ gateId: "implementation", status: "pending" },
+				{ gateId: "ready-to-merge", status: "pending" },
+			];
+
+			const error = checkGateDependencies("implementation", testWorkflowGates, gateStates);
+			assert.equal(error, null, "A bypassed upstream gate must count as satisfied like passed");
+		});
+
 		it("allows when all upstream gates have passed", () => {
 			const gateStates: Array<{ gateId: string; status: string }> = [
 				{ gateId: "design-doc", status: "passed" },

--- a/tests/gate-status-summary.test.ts
+++ b/tests/gate-status-summary.test.ts
@@ -4,10 +4,10 @@ import { buildGateStatusSummary } from "../src/server/gate-status-summary.js";
 import type { GateState } from "../src/server/agent/gate-store.js";
 import type { ActiveVerification } from "../src/server/agent/verification-harness.js";
 
-function gate(status: GateState["status"]): GateState {
+function gate(status: GateState["status"], gateId = "implementation"): GateState {
 	return {
 		goalId: "goal-1",
-		gateId: "implementation",
+		gateId,
 		status,
 		signals: [],
 		updatedAt: Date.now(),
@@ -39,5 +39,36 @@ describe("buildGateStatusSummary", () => {
 		assert.equal(summary.gates[0]?.status, "passed");
 		assert.equal(summary.gates[0]?.effectiveStatus, "running");
 		assert.equal(summary.gates[0]?.running, true);
+	});
+
+	it("reports bypassed and bypassedCount counts", () => {
+		const summary = buildGateStatusSummary({
+			workflow: { gates: [
+				{ id: "design-doc", name: "Design Doc", dependsOn: [] },
+				{ id: "implementation", name: "Implementation", dependsOn: ["design-doc"] },
+			] },
+			gates: [gate("passed", "design-doc"), gate("bypassed", "implementation")],
+			activeVerifications: [],
+		});
+
+		assert.equal(summary.passed, 1, "bypassed must NOT be counted as passed");
+		assert.equal(summary.bypassed, 1);
+		assert.equal(summary.bypassedCount, 1);
+		assert.equal(summary.total, 2);
+		// Badge numerator = passed + bypassed = 2/2 (red ! semantics on client).
+		assert.equal(summary.passed + summary.bypassed, summary.total);
+		const impl = summary.gates.find(g => g.gateId === "implementation");
+		assert.equal(impl?.status, "bypassed");
+		assert.equal(impl?.effectiveStatus, "bypassed");
+	});
+
+	it("reports zero bypassed when no gate is bypassed", () => {
+		const summary = buildGateStatusSummary({
+			workflow: { gates: [{ id: "implementation", name: "Implementation", dependsOn: [] }] },
+			gates: [gate("passed")],
+			activeVerifications: [],
+		});
+		assert.equal(summary.bypassed, 0);
+		assert.equal(summary.bypassedCount, 0);
 	});
 });


### PR DESCRIPTION
## Summary

Adds a **human-only** capability to force a workflow gate past verification when an agent reports a verification step is genuinely impossible to satisfy. Introduces a distinct, auditable `"bypassed"` gate state that is visually differentiated from a clean pass and is **never advertised to agents**.

## What changed

**Backend**
- New `"bypassed"` `GateStatus` + `bypassGate()` (persists a synthetic audit signal with `whyBypassed`/`whoAmI`/`bypassedAt`).
- `POST /api/goals/:goalId/gates/:gateId/bypass` — guarded: 403 sandbox, 409 archived/shelved, 400 when `isInitiatedByHuman !== true` (with a human-only guard message), 400 missing `whyBypassed`/`whoAmI`, 404 unknown gate/goal. Broadcasts `gate_status_changed`, notifies the team lead.
- Bypassed gates satisfy downstream **dependency ordering** (like passed) but do **not** inject downstream content.
- `team_complete` (agent/MCP) stays **blocked** when a bypassed gate exists; a human confirms via `POST /api/goals/:id/team/complete { confirmBypassedGates: true }` — and that confirmation is **rejected with 403 for sandbox tokens** (closes an authorization-bypass found in review).
- `GET /api/goals/:id/gates` surfaces `whyBypassed`/`whoAmI`/`bypassedAt` on bypassed gates; summary reports `bypassed`/`bypassedCount`.

**Frontend**
- `<goal-status-widget>`: **Bypass** button (pending/failed rows only) + inline why/who form; bypassed-row icon + caption; **Confirm completion** button shown only when bypassed gates exist.
- Differentiated badge: bypassed gates count toward the numerator but turn the whole badge **red** with a trailing `!` (e.g. `(4/4)!`) on the chat-header pill, sidebar badge, and popover header.

**Not advertised to agents:** no new MCP/agent tool, no agent-facing prompt/doc mention. `isInitiatedByHuman` is the runtime backstop; non-advertisement is the primary defense.

## Tests
- API E2E (`tests/e2e/gate-bypass-api.spec.ts`, 10): endpoint matrix, completion gating, sandbox-confirm 403 regression, read-model, reset-to-pending.
- Unit: `buildGateStatusSummary` bypassed counts; `checkGateDependencies` bypassed satisfaction.
- Browser E2E (`tests/e2e/ui/gate-bypass.spec.ts`): button visibility, inline form, bypassed row, red `(N/N)!` badge, confirm-completion gating, persistence across reload.
- `tests/tool-description-budget.test.ts` green (no agent tool added).

## Docs
- `docs/goals-workflows-tasks.md`, `docs/rest-api.md`, `docs/nested-goals.md`, `docs/design/production-subgoals-port.md` updated for the bypassed state.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)