### PR TITLE
Delegate restart survival (team_delegate children survive a gateway reboot)

### DIFF
--- a/docs/design/orchestration-core.md
+++ b/docs/design/orchestration-core.md
@@ -37,7 +37,7 @@ All in `src/server/agent/session-manager.ts`:
 - `waitForIdle(sessionId, timeoutMs=600_000)` (`:4063`) — resolves on `agent_end`, rejects on `process_exit`/timeout, instant if already `idle`. `waitForStreaming` (`:4098`) is the symmetric helper.
 - `getSessionOutput(sessionId)` (`:4128`) — concatenated assistant text.
 - `terminateSession(id)` (`:5297`) — terminate + archive; **already cascades** to live children where `delegateOf===id` OR (`childKind==="pr-walkthrough" && parentSessionId===id`) (`:5305`), and archives persisted-but-dormant such children (`:5314-5322`).
-- `restoreSessions()` (`:3150`) — restores `regular` sessions; **`delegateOf` children are deferred as dormant** (`:3179-3203`, revived on-demand via `addClient`); **no boot-reap for delegates**. `pr-walkthrough` children are boot-reaped in `restoreOneSession` via `shouldReapWalkthroughChildOnBoot` (`:3293-3318`).
+- `restoreSessions()` (`:3150`) — restores `regular` sessions live; **`delegateOf` children are now also restored LIVE** through the same `restoreOneSession`/`restoreSession` path (§4 — durable-task / re-run model), after an orphan-reap pass (`shouldReapChildOnBoot`) archives delegates whose owner is gone/archived. (Originally delegates were deferred as dormant via `addDormantSession` and revived on-demand; that was superseded — see §4.) `pr-walkthrough` children are boot-reaped in `restoreOneSession` via `shouldReapWalkthroughChildOnBoot` (`:3293-3318`).
 - `updateSessionMeta(id, {delegateOf?, parentSessionId?, childKind?, readOnly?, ...})` (`:4854`).
 
 Model-inheritance resolver already exists at the call sites: `resolveSessionModel(sessionId)` (`server.ts:1536`, `:2398`) returns `"${provider}/${id}"` from the persisted session — this is what `OrchestrationCore` uses to inherit the parent's **current** model.
@@ -169,20 +169,33 @@ The core keeps `Map<ownerSessionId, ChildHandle[]>` **in memory only**. It is **
 
 ---
 
-## 4. Restart survival (outcome #3) — children survive, parent reminded, one shared wait
+## 4. Restart survival (outcome #3) — delegates ride the worker restart path
 
-**Locked principle: no transparent tool-call resumption.** A blocking `team_delegate` is *spawn tracked child → shared `wait(policy:"all")` → auto-dismiss*, all inside the agent's tool loop. On restart the agent subprocess dies; the long-poll promise is gone; the parent is rebuilt from transcript with a `tool_use` and no matching `tool_result`. We **do not** splice a synthetic `tool_result`.
+> **REVISION (shipped).** This section originally specified that surviving delegates were kept as **dormant** session entries on restore and that the locked principle was *"no transparent tool-call resumption."* That decision proved insufficient **for delegates** and was **deliberately superseded** by the **durable-task / re-run-on-restart model** described below — the same machinery goal-team **workers** already use. This is a conscious design revision, not silent drift. The historical decision and the one nuance still kept from it are recorded at the end of this section.
 
-Mechanism:
+**Why the dormant model failed.** Workers survive a restart because (a) they are restored **live** (their subprocess comes back) and (b) their task — the **goal spec** — is durable and rebuilt into the system prompt on restore (`restoreSession` → `resolveGoal` → `goal.spec` → `buildRestoreRolePrompt`), then re-nudged. Delegates had **neither**: `restoreSessions()` split sessions into `regular` (restored live via `restoreOneSession`/`restoreSession`) and `delegates` (handed to `addDormantSession`, which created a `terminated` placeholder with an un-started bridge — revived only when a human opened the session in the UI). And a delegate's task lived only in its **spawn-time** prompt (`session-setup.ts` `mode === "delegate"`), never persisted on the session record. The two failure symptoms followed directly:
 
-1. **Children survive.** `restoreSessions()` keeps `delegateOf` children as dormant entries (unchanged, `:3179-3203`) and now also runs `rebuildIndexFromPersisted`. Boot-reap (§5) reaps a child **only** if its parent is gone or archived. A child whose parent is restoring is never reaped.
-2. **Parent reminded on resume.** Reuse the **boot-resume nudge machinery** in `team-manager.ts` (`resumeTeams` → boot-resume `enqueuePrompt(..., { isSteered:true })`, `:945-968`). Generalize it to a non-goal owner: after `restoreSessions`, for each owner with ≥1 live restored child, inject a system reminder via `sessionManager.enqueuePrompt(ownerId, msg, { source:"system", isSteered:true })`.
-   - **Injection point:** a new `OrchestrationCore.remindOwnersWithLiveChildren()` called from the server boot sequence right after `restoreSessions()` + `teamManager.restoreTeams()` (so team owners and standalone owners are both covered; team-managed children are skipped to avoid double-nudge — filter `childKind!=="team"`).
+- **Lost work / `terminated` husks.** A blocking `team_delegate` child came back as a dead placeholder; the parent's `team_wait` re-attached to a `terminated` dormant entry and resolved with no real result.
+- **"No task in my system prompt."** Even when revived, `restoreSession` ran the goal/role prompt branch, found no goal (`goalSpec` undefined), and the task evaporated.
+
+**The fix — reuse the worker machinery (one restart path, no parallel registry).** Delegates now durably persist their task and are restored **live** through the same path workers use:
+
+1. **Durable task.** `instructions` (and `context`) are persisted on the session record — the delegate's equivalent of a worker's `goal.spec`. The fields live on `PersistedSession` (`session-store.ts`: `PersistedSession.instructions` / `PersistedSession.context`) and are written at spawn by `session-setup.ts::persistOnce`. They survive restart with the rest of the session record.
+2. **Live restore.** `restoreSessions()` no longer defers `delegateOf` children to `addDormantSession`. After the orphan-reap pass (§5), surviving delegates are concatenated with the `regular` set and flow through the **same** `restoreOneSession` → `restoreSession` live-respawn path — they come back as real running processes, not dormant husks.
+3. **Prompt rebuilt from the durable task.** `restoreSession()` has a **delegate branch** (`delegateOf` set, **no** `goalId`) that rebuilds the system prompt from the persisted `instructions` + `context` + `projectRoot` (`ps.repoPath`), mirroring `session-setup.ts::_resolvePrompt` `mode === "delegate"` and assembling via `assembleSystemPrompt`. A revived delegate therefore carries its **original task**, not an empty goal/role prompt — closing the "no task" symptom.
+4. **Re-run on restart (the worker model).** The respawned delegate is re-driven by the shared **`wasStreaming` boot-resume drain** — the same mechanism workers use to resume a mid-turn task. The parent is reminded via `OrchestrationCore.remindOwnersWithLiveChildren(h => h.childKind !== "team")` (called from `restoreSessions()` after `rebuildIndexFromPersisted`), and re-collects a **real** result through the shared `team_wait`, which now re-attaches to a **LIVE** child instead of resolving a `terminated` dormant placeholder. Team-managed children (`childKind === "team"`) are skipped here to avoid a double-nudge; team-manager nudges those.
    - **Reminder text** enumerates the N live children (ids + one-line title) and points at `team_wait`:
      > `[ORCHESTRATION] The gateway restarted. You have N live child agent(s) from before the restart: <id1> "<title1>", … Their results were not collected. Call team_wait to collect them (it returns on the first child idle and tells you who remains).`
-3. **Non-blocking children** were already re-promptable; the reminder simply resurfaces them.
+5. **Boot-reap unchanged (§5).** An **orphaned** delegate — owner gone or archived — is still reaped in `restoreSessions()` via `shouldReapChildOnBoot` **before** the live-dispatch pass. It is **not** resurrected as a live orphan. Only delegates whose owner is restoring (exists, not archived) survive into the live-restore set.
 
-Pinned by a restart E2E (§11): kill + reboot mid-orchestration → children survive, parent receives the reminder, `team_wait` collects, no orphan.
+**Idempotency caveat (explicit).** Because a survivor is re-driven from its durable task, a re-run delegate may **repeat non-idempotent side effects** (re-issue an API write, re-create a file, etc.). This is **identical to how workers already behave** on restart — the worker re-runs its goal spec the same way — and is **accepted**. We do not attempt exactly-once side-effect semantics.
+
+**What we still do NOT do (the one nuance kept from the original decision).** We still do **not** splice a **synthetic `tool_result`** into the parent's transcript. A blocking `team_delegate`'s in-flight long-poll lived in the now-dead agent subprocess; on restart the parent is rebuilt from transcript with a `tool_use` and no matching `tool_result`, and we do not fabricate one. The difference from the original model is what happens **on the child side**: instead of the child staying a dormant husk, the child survives **live** and **re-runs** its durable task, and the parent re-collects explicitly via `team_wait` (resurfaced by the reminder). So "no synthetic tool_result splicing" survives; "delegates stay dormant / no re-run" was replaced.
+
+**Pinned by:**
+- `tests/e2e/orchestrate-restart.spec.ts` — a delegate child is restored **LIVE** with its task intact across a `restoreSessions` reboot (parent gets the reminder, `team_wait` re-collects a real result, no orphan).
+- `tests/session-store.test.ts` — durable-task round-trip (`PersistedSession.instructions`/`context` persist and reload).
+- `tests/session-manager-delegate-restore.test.ts` — delegate-branch prompt re-assembly in `restoreSession` (revived delegate's prompt contains its original instructions + context).
 
 ---
 
@@ -212,7 +225,7 @@ export function shouldReapChildOnBoot(i: ReapInput): { reap: boolean; reason?: s
 - For `delegate`: `kindTerminal` is undefined (delegates have no terminal job); reap only on owner-gone/archived. **This closes the orphan-delegate gap** (today delegates are never boot-reaped).
 - Never reap a child whose owner is restoring (owner exists, not archived).
 
-`restoreOneSession` calls `shouldReapChildOnBoot` for any session with a `childKind`/`delegateOf`. Delegate children remain dormant unless reaped.
+Delegate orphan-reap runs in `restoreSessions()` (via `shouldReapChildOnBoot`) **before** the live-dispatch pass; **surviving delegates are now restored LIVE, not dormant** (§4 — they ride the worker `restoreOneSession`/`restoreSession` path). The generalized `restoreOneSession` reap still covers non-delegate kinded children (`childKind`/`parentSessionId`, e.g. `pr-walkthrough`).
 
 ---
 

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -173,25 +173,51 @@ change is purely internal.
 
 ## Restart survival
 
-Child agents **survive a gateway restart**. Before, a blocking `delegate` child became an
-orphaned dormant session and the parent lost its result. Now:
+Child agents **survive a gateway restart** — including `team_delegate` children, which now
+ride the **same restart path goal-team workers use**. Before, a blocking `delegate` child
+came back as a `terminated` dormant husk (the parent's wait collected nothing) and, even if
+revived, reported *"no task in my system prompt"* — because a delegate's task lived only in
+its spawn-time prompt and delegates were excluded from live restore. Both gaps are fixed by
+giving delegates the two things workers always had: a **durable task** and **live restore**.
 
-1. **Children survive.** On boot the in-memory index is rebuilt from the persisted link.
-   A child is reaped on boot **only** if its parent is gone or archived (a generalized
-   `shouldReapChildOnBoot`, covering delegate, PR-walkthrough, and future kinds). A child
-   whose parent is restoring is never reaped — this closes the old orphan-delegate gap.
-2. **The parent is reminded.** When a restored parent has live children, the core injects
-   a **system reminder** (reusing the boot-resume nudge machinery) enumerating the live
-   children and pointing at `team_wait`. The parent re-collects through the shared wait
-   path.
+1. **Durable task.** A delegate's `instructions` (and `context`) are persisted on the
+   session record (`PersistedSession.instructions` / `.context`, written at spawn by
+   `persistOnce`) — the delegate's equivalent of a worker's `goal.spec`. The task survives
+   the restart instead of evaporating with the dead subprocess.
+2. **Live restore.** `restoreSessions()` no longer defers `delegateOf` children to a dormant
+   placeholder. Surviving delegates flow through the **same** `restoreOneSession` →
+   `restoreSession` live-respawn path workers use, so they come back as real running
+   processes. `restoreSession` has a delegate branch that **rebuilds the system prompt from
+   the persisted `instructions` + `context`**, so a revived delegate carries its original
+   task (not an empty goal/role prompt).
+3. **Re-run + reminded.** The respawned delegate is re-driven by the shared boot-resume
+   drain (the same mechanism that resumes a mid-turn worker). When a restored parent has
+   live children, the core injects a **system reminder** (`remindOwnersWithLiveChildren`)
+   enumerating them and pointing at `team_wait`; the parent re-collects through the shared
+   wait, which now re-attaches to a **live** child and returns a **real** result instead of a
+   `terminated` placeholder.
+4. **Orphans still reaped.** A child is reaped on boot **only** if its parent is gone or
+   archived (the generalized `shouldReapChildOnBoot`, covering delegate, PR-walkthrough, and
+   future kinds). A delegate whose parent is restoring is never reaped; one whose owner is
+   gone is archived before live dispatch, never resurrected as a live orphan.
 
-> **No transparent tool-call resumption — by design.** A blocking `team_delegate` is *spawn
-> a tracked child → call the shared wait → auto-dismiss*, all inside the agent's tool loop.
-> A blocking call is an in-flight long-poll **inside the agent subprocess**; on restart
-> that subprocess dies and the promise is gone. We do **not** splice a synthetic
-> `tool_result` into a turn the new process never issued. Instead the child survives, the
-> parent is reminded, and it re-collects explicitly via `team_wait`. Non-blocking children
-> were already re-promptable; the reminder simply resurfaces them.
+> **Why reuse the worker machinery?** Delegates and workers now share **one** restart path —
+> durable task + live restore + prompt rebuild + re-nudge — with no parallel registry. The
+> earlier "delegates stay dormant" carve-out is what lost work and dropped the task; folding
+> delegates onto the worker path removes the carve-out instead of duplicating it.
+
+> **Idempotency caveat.** Because a survivor re-runs from its durable task, a re-run delegate
+> may **repeat non-idempotent side effects** (re-issue a write, re-create a file). This is
+> **identical to how workers already behave** on restart and is accepted — there is no
+> exactly-once side-effect guarantee.
+
+> **No *synthetic* tool-call resumption — still by design.** A blocking `team_delegate`'s
+> in-flight long-poll lived in the now-dead agent subprocess; on restart the parent is
+> rebuilt from transcript with a `tool_use` and no matching `tool_result`, and we do **not**
+> fabricate one. What changed is the **child side**: instead of staying a dormant husk it
+> survives **live** and **re-runs** its durable task, and the parent re-collects explicitly
+> via `team_wait` (resurfaced by the reminder). Non-blocking children were already
+> re-promptable; the reminder simply resurfaces them.
 
 ---
 

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -3198,26 +3198,26 @@ export class SessionManager {
 		const regular = persisted.filter(ps => !ps.delegateOf);
 		const delegates = persisted.filter(ps => !!ps.delegateOf);
 
-		console.log(`[session-manager] Restoring ${regular.length} session(s), deferring ${delegates.length} delegate(s)...`);
-
-		// Restore regular sessions in parallel (batched concurrency)
-		const CONCURRENCY = 5;
-		for (let i = 0; i < regular.length; i += CONCURRENCY) {
-			const batch = regular.slice(i, i + CONCURRENCY);
-			await Promise.all(batch.map(ps => this.restoreOneSession(ps)));
-		}
-
-		// Delegate sessions: dormant entries only — restored on-demand via addClient()
+		// Delegate boot-reap (orchestration-core §5): archive an orphaned delegate
+		// child (owner gone/archived) BEFORE dispatch. This reap MUST stay in
+		// restoreSessions() — the orphan-reap wiring test stubs restoreOneSession to
+		// a no-op and still expects the orphan archived, so it cannot move into the
+		// per-session path. Survivors are NOT deferred as dormant husks anymore:
+		// they ride the SAME live-restore path workers use (restoreOneSession →
+		// restoreSession), so a delegate comes back as a live process with its task
+		// rebuilt from the durable instructions/context fields, and the parent's
+		// team_wait re-attaches to a live child and collects a real result. A delegate
+		// that was mid-turn is re-driven by the shared wasStreaming boot-resume nudge
+		// in restoreSession() — no delegate-specific registry.
+		const delegateSurvivors: PersistedSession[] = [];
 		for (const ps of delegates) {
 			if (!ps.agentSessionFile) {
 				try { this.getSessionStore(ps.projectId).archive(ps.id); } catch { /* project gone */ }
 				continue;
 			}
-			// Generalized boot-reap (orchestration-core §5): reap an orphaned
-			// delegate child whose owner session is gone or archived. This closes
-			// the orphan-delegate gap — delegates were previously NEVER boot-reaped
-			// (only pr-walkthrough children were). A child whose owner is restoring
-			// (exists, not archived) is kept dormant and re-collectable via team_wait.
+			// Reap an orphaned delegate child whose owner session is gone or archived.
+			// A child whose owner is restoring (exists, not archived) survives and is
+			// restored live below.
 			const owner = ps.delegateOf ? this.getPersistedSession(ps.delegateOf) : undefined;
 			const reap = shouldReapChildOnBoot({
 				childKind: ps.childKind ?? "delegate",
@@ -3230,11 +3230,17 @@ export class SessionManager {
 				try { this.getSessionStore(ps.projectId).archive(ps.id); } catch { /* project gone */ }
 				continue;
 			}
-			// Existence check deferred to addClient() revive — add as dormant unconditionally
-			// (the file is in the agent's coordinate system; checking it here would require
-			// async docker exec for sandbox sessions, and the file may not be needed until
-			// the user opens the session)
-			this.addDormantSession(ps);
+			delegateSurvivors.push(ps);
+		}
+
+		const liveRestore = [...regular, ...delegateSurvivors];
+		console.log(`[session-manager] Restoring ${regular.length} session(s) + ${delegateSurvivors.length} delegate(s) live...`);
+
+		// Restore regular + surviving delegate sessions in parallel (batched concurrency)
+		const CONCURRENCY = 5;
+		for (let i = 0; i < liveRestore.length; i += CONCURRENCY) {
+			const batch = liveRestore.slice(i, i + CONCURRENCY);
+			await Promise.all(batch.map(ps => this.restoreOneSession(ps)));
 		}
 
 		// OrchestrationCore (§3/§4): rebuild the in-memory child index from the
@@ -3648,6 +3654,28 @@ export class SessionManager {
 				cwd: ps.cwd,
 				goalSpec: assistantGoalSpec,
 				goalTitle: assistantDef.promptTitle,
+				goalState: "active",
+				allowedTools: restoredAllowedNames,
+				projectConfigStore: this.projectConfigStore,
+			});
+			if (promptPath) bridgeOptions.systemPromptPath = promptPath;
+		} else if (ps.delegateOf && !ps.goalId) {
+			// Delegate restore: rebuild the system prompt from the durable task fields
+			// (instructions + context) — the delegate's equivalent of a worker's goal
+			// spec. Mirrors session-setup.ts::_resolvePrompt mode === "delegate" so a
+			// revived delegate carries its original task, not an empty goal/role prompt.
+			let taskSpec = ps.instructions || "";
+			if (ps.context && Object.keys(ps.context).length > 0) {
+				taskSpec += "\n\n## Context";
+				for (const [key, value] of Object.entries(ps.context)) {
+					taskSpec += `\n- **${key}**: ${value}`;
+				}
+			}
+			const promptPath = this.assemblePrompt(ps.id, {
+				baseSystemPromptPath: this.systemPromptPath,
+				cwd: ps.cwd,
+				goalSpec: taskSpec,
+				goalTitle: "Delegate Task",
 				goalState: "active",
 				allowedTools: restoredAllowedNames,
 				projectConfigStore: this.projectConfigStore,

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -3674,6 +3674,10 @@ export class SessionManager {
 			const promptPath = this.assemblePrompt(ps.id, {
 				baseSystemPromptPath: this.systemPromptPath,
 				cwd: ps.cwd,
+				// Mirror the spawn path (session-setup.ts::_resolvePrompt mode ===
+				// "delegate") so AGENTS.md / project config dirs are readable for
+				// sandbox or multi-repo delegates whose cwd is container-internal.
+				projectRoot: ps.repoPath,
 				goalSpec: taskSpec,
 				goalTitle: "Delegate Task",
 				goalState: "active",

--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -671,6 +671,10 @@ export function persistOnce(session: SessionInfo, plan: SessionSetupPlan, store:
 		nonInteractive: plan.nonInteractive,
 		sandboxed: plan.sandboxed,
 		delegateOf: plan.delegateOf,
+		// Durable delegate task — restored into the system prompt on reboot so the
+		// delegate comes back live with its task intact (mirrors a worker's goal spec).
+		instructions: plan.instructions,
+		context: plan.context,
 		parentSessionId: plan.parentSessionId,
 		childKind: plan.childKind,
 		readOnly: plan.readOnly,

--- a/src/server/agent/session-store.ts
+++ b/src/server/agent/session-store.ts
@@ -48,6 +48,14 @@ export interface PersistedSession {
 	streamingStartedAt?: number;
 	/** If this session is a delegate, the parent session ID */
 	delegateOf?: string;
+	/**
+	 * Delegate task instructions — the durable equivalent of a worker's goal
+	 * spec. Written once at spawn and rebuilt into the system prompt on restore
+	 * so a delegate survives a gateway restart with its task intact.
+	 */
+	instructions?: string;
+	/** Delegate task context key/value pairs, layered into the prompt on restore. */
+	context?: Record<string, string>;
 	/** First-class parent session ID for visible child sessions (not delegate lifecycle). */
 	parentSessionId?: string;
 	/** Kind discriminator for first-class child sessions, e.g. "pr-walkthrough". */

--- a/tests/e2e/orchestrate-restart.spec.ts
+++ b/tests/e2e/orchestrate-restart.spec.ts
@@ -14,6 +14,7 @@
  * on resume the parent is REMINDED of its live children and re-collects via the
  * shared `team_wait`.
  */
+import { readFileSync } from "node:fs";
 import { test, expect } from "./in-process-harness.js";
 import { apiFetch, createSession, deleteSession, connectWs, type WsMsg } from "./e2e-setup.js";
 import { pollUntil } from "./test-utils/cleanup.js";
@@ -135,6 +136,70 @@ test.describe("orchestration restart survival", () => {
 			expect(waitJson.statuses[0].status).toBe("idle");
 			expect(waitJson.statuses[0].status).not.toBe("timeout");
 			expect(waitJson.outputTail ?? "").toContain("OK");
+		} finally {
+			await deleteSession(child).catch(() => {});
+			await deleteSession(parent).catch(() => {});
+		}
+	});
+
+	// REPRODUCING TEST (TDD): delegate children must SURVIVE a real reboot LIVE,
+	// not as a dormant `terminated` husk, and their task must be rebuilt into the
+	// reassembled system prompt. Today restoreSessions() carves delegates out of
+	// the live-restore path (regular = !delegateOf → restoreSession; delegates =
+	// !!delegateOf → addDormantSession), and instructions/context are never
+	// persisted — so after a reboot the child comes back DORMANT (isSessionLive
+	// === false) with no task in its prompt. This test FAILS today on the
+	// isSessionLive assertion and PASSES once the fix (1) persists the task,
+	// (2) restores delegates live, (3) rebuilds the delegate prompt from the
+	// persisted task. Uses the exact steer-gateway-restart.spec.ts reboot
+	// primitive (teardown live SessionInfo + restoreSessions()).
+	test("a delegate child is restored LIVE with its task intact across a restoreSessions reboot", async ({ gateway }) => {
+		const sm = gateway.sessionManager;
+		const parent = await createSession();
+		// Distinctive marker so we can assert it lands in the rebuilt system prompt.
+		const child = await spawnChild(parent, "restart-live-survivor-MARKER helper task");
+		try {
+			// Drive the child's spawn prompt to completion (mock agent → "OK") so a
+			// persisted transcript + agentSessionFile exist before the reboot.
+			await pollUntil(async () => sm.getSession(child)?.status === "idle" ? true : null,
+				{ timeoutMs: 15_000, intervalMs: 50, label: "child idle before reboot" });
+			await pollUntil(async () => (await sm.getSessionOutput(child)).includes("OK") ? true : null,
+				{ timeoutMs: 15_000, intervalMs: 50, label: "child output persisted" });
+			expect(sm.getPersistedSession(child)?.agentSessionFile).toBeTruthy();
+
+			// ── Simulate a clean gateway reboot (steer-gateway-restart.spec.ts
+			// primitive): tear down the live child SessionInfo and drop it from the
+			// in-memory Map, then re-run the boot restore path. restoreSessions()
+			// re-reads the persisted live list — the same code the server runs at boot.
+			const liveChild = sm.sessions.get(child);
+			expect(liveChild, "child live before reboot").toBeTruthy();
+			liveChild.unsubscribe();
+			try { await liveChild.rpcClient.stop(); } catch { /* already dead */ }
+			sm.sessions.delete(child);
+
+			await sm.restoreSessions();
+
+			// CORE REPRO — the delegate must come back LIVE, not a dormant
+			// `terminated` placeholder. FAILS today (delegate → addDormantSession →
+			// dormant === true → isSessionLive false).
+			expect(sm.isSessionLive(child)).toBe(true);
+
+			// TASK INTACT — the rebuilt system prompt must carry the original
+			// instructions. Accessor: restoreSession() writes the reassembled prompt
+			// to <prompts-dir>/<id>.md and records it on bridgeOptions.systemPromptPath;
+			// the in-process mock bridge preserves `options`, so we read the actual
+			// assembled prompt file the restored agent would receive. Fallback (in case
+			// the accessor shape changes): the durable instructions/context fields the
+			// fix persists on the session record (getPersistedSession).
+			const restored = sm.sessions.get(child);
+			const promptPath = (restored?.rpcClient as any)?.options?.systemPromptPath as string | undefined;
+			let promptText = "";
+			if (promptPath) {
+				try { promptText = readFileSync(promptPath, "utf-8"); } catch { /* file gone */ }
+			}
+			const ps = sm.getPersistedSession(child) as any;
+			const durableTask = `${ps?.instructions ?? ""}\n${ps?.context ?? ""}`;
+			expect(`${promptText}\n${durableTask}`).toContain("restart-live-survivor-MARKER");
 		} finally {
 			await deleteSession(child).catch(() => {});
 			await deleteSession(parent).catch(() => {});

--- a/tests/e2e/orchestrate-restart.spec.ts
+++ b/tests/e2e/orchestrate-restart.spec.ts
@@ -184,13 +184,16 @@ test.describe("orchestration restart survival", () => {
 			// dormant === true → isSessionLive false).
 			expect(sm.isSessionLive(child)).toBe(true);
 
-			// TASK INTACT — the rebuilt system prompt must carry the original
-			// instructions. Accessor: restoreSession() writes the reassembled prompt
-			// to <prompts-dir>/<id>.md and records it on bridgeOptions.systemPromptPath;
-			// the in-process mock bridge preserves `options`, so we read the actual
-			// assembled prompt file the restored agent would receive. Fallback (in case
-			// the accessor shape changes): the durable instructions/context fields the
-			// fix persists on the session record (getPersistedSession).
+			// TASK INTACT — two STRICT, independent pins (no OR-fallback, so a broken
+			// prompt rebuild can't be masked by the durable field, and vice versa):
+			//
+			//  (a) PROMPT REBUILD — restoreSession() writes the reassembled prompt to
+			//      <prompts-dir>/<id>.md and records it on bridgeOptions.systemPromptPath;
+			//      the in-process mock bridge preserves `options`, so we read the actual
+			//      assembled prompt file the restored agent would receive. The marker must
+			//      be present here — proving the prompt was genuinely rebuilt from the task.
+			//  (b) DURABLE FIELD — the persisted `instructions` field on the session
+			//      record must carry the marker — proving the task survived to disk.
 			const restored = sm.sessions.get(child);
 			const promptPath = (restored?.rpcClient as any)?.options?.systemPromptPath as string | undefined;
 			let promptText = "";
@@ -198,8 +201,8 @@ test.describe("orchestration restart survival", () => {
 				try { promptText = readFileSync(promptPath, "utf-8"); } catch { /* file gone */ }
 			}
 			const ps = sm.getPersistedSession(child) as any;
-			const durableTask = `${ps?.instructions ?? ""}\n${ps?.context ?? ""}`;
-			expect(`${promptText}\n${durableTask}`).toContain("restart-live-survivor-MARKER");
+			expect(promptText).toContain("restart-live-survivor-MARKER");
+			expect(`${ps?.instructions ?? ""}`).toContain("restart-live-survivor-MARKER");
 		} finally {
 			await deleteSession(child).catch(() => {});
 			await deleteSession(parent).catch(() => {});

--- a/tests/session-manager-delegate-restore.test.ts
+++ b/tests/session-manager-delegate-restore.test.ts
@@ -106,9 +106,10 @@ describe("delegate restore — source guards", () => {
 		assert.ok(delegateBranchIdx > 0, "restoreSession must have an `else if (ps.delegateOf && !ps.goalId)` branch");
 
 		// The delegate branch builds the task spec from instructions + context.
-		const branchWindow = window.slice(delegateBranchIdx, delegateBranchIdx + 800);
+		const branchWindow = window.slice(delegateBranchIdx, delegateBranchIdx + 1200);
 		assert.match(branchWindow, /let taskSpec = ps\.instructions \|\| ""/);
 		assert.match(branchWindow, /for \(const \[key, value\] of Object\.entries\(ps\.context\)\)/);
+		assert.match(branchWindow, /projectRoot: ps\.repoPath/);
 		assert.match(branchWindow, /goalSpec: taskSpec/);
 
 		// It must precede the goal/role else branch (which resolves goal?.spec).

--- a/tests/session-manager-delegate-restore.test.ts
+++ b/tests/session-manager-delegate-restore.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for delegate restart survival (Delegate Restart Survival goal).
+ *
+ * Two concerns are pinned here:
+ *
+ *  1. FUNCTIONAL — restoreSession()'s delegate branch rebuilds the system prompt
+ *     from the durable `instructions` (+ `context`) fields, exactly mirroring
+ *     session-setup.ts::_resolvePrompt mode === "delegate". We exercise the real
+ *     prompt assembler (`assembleSystemPrompt`) with the same taskSpec-building
+ *     logic and assert the assembled prompt carries the original instructions +
+ *     context — NOT the empty goal/role branch a delegate (no goalId) would
+ *     otherwise hit.
+ *
+ *  2. SOURCE GUARD — restoreSession() must take a delegate branch (delegateOf set,
+ *     no goalId) BEFORE the goal/role else branch, and restoreSessions() must
+ *     restore surviving delegates LIVE (restoreOneSession), not as dormant husks
+ *     (addDormantSession). If a future refactor drops either, these fail loudly.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "delegate-restore-test-"));
+process.env.BOBBIT_DIR = tmpRoot;
+
+const { assembleSystemPrompt, initPromptDirs } = await import("../src/server/agent/system-prompt.ts");
+type PersistedSession = import("../src/server/agent/session-store.ts").PersistedSession;
+
+// assembleSystemPrompt writes to <stateDir>/session-prompts — initialize it.
+initPromptDirs(path.join(tmpRoot, "state"));
+
+/**
+ * Verbatim copy of restoreSession()'s delegate-branch taskSpec assembly
+ * (and session-setup.ts::_resolvePrompt mode === "delegate"). Kept in lock-step
+ * with the production branch by the source guard below.
+ */
+function buildDelegateTaskSpec(ps: Pick<PersistedSession, "instructions" | "context">): string {
+	let taskSpec = ps.instructions || "";
+	if (ps.context && Object.keys(ps.context).length > 0) {
+		taskSpec += "\n\n## Context";
+		for (const [key, value] of Object.entries(ps.context)) {
+			taskSpec += `\n- **${key}**: ${value}`;
+		}
+	}
+	return taskSpec;
+}
+
+describe("delegate restore — prompt re-assembly from durable task", () => {
+	it("rebuilds the system prompt from persisted instructions + context", () => {
+		const ps: PersistedSession = {
+			id: "delegate-1",
+			title: "⚡Delegate",
+			cwd: tmpRoot,
+			agentSessionFile: path.join(tmpRoot, "agent.jsonl"),
+			createdAt: Date.now(),
+			lastActivity: Date.now(),
+			delegateOf: "owner-1",
+			instructions: "restart-live-survivor-MARKER helper task",
+			context: { role: "helper", deadline: "eod" },
+		};
+
+		const taskSpec = buildDelegateTaskSpec(ps);
+		const promptPath = assembleSystemPrompt(ps.id, {
+			cwd: ps.cwd,
+			goalSpec: taskSpec,
+			goalTitle: "Delegate Task",
+			goalState: "active",
+		});
+
+		assert.ok(promptPath, "delegate restore must produce a system prompt path");
+		const prompt = fs.readFileSync(promptPath!, "utf-8");
+		// Task intact — the original instructions land in the rebuilt prompt.
+		assert.match(prompt, /restart-live-survivor-MARKER helper task/);
+		// Context is layered in too.
+		assert.match(prompt, /## Context/);
+		assert.match(prompt, /\*\*role\*\*: helper/);
+		assert.match(prompt, /\*\*deadline\*\*: eod/);
+	});
+
+	it("produces an EMPTY (no-goal) prompt when the delegate task is NOT rebuilt", () => {
+		// Demonstrates the bug the delegate branch fixes: a delegate has no goal,
+		// so the goal/role branch yields no goal spec — the task evaporates.
+		const promptPath = assembleSystemPrompt("delegate-empty", {
+			cwd: tmpRoot,
+			goalSpec: undefined, // what the goal/role branch sees for a delegate (no goal)
+		});
+		const prompt = promptPath ? fs.readFileSync(promptPath, "utf-8") : "";
+		assert.ok(!/restart-live-survivor-MARKER/.test(prompt), "without the delegate branch the task is lost");
+	});
+});
+
+describe("delegate restore — source guards", () => {
+	const src = fs.readFileSync(
+		path.join(process.cwd(), "src/server/agent/session-manager.ts"),
+		"utf-8",
+	);
+
+	it("restoreSession has a delegate branch ordered before the goal/role else branch", () => {
+		const idx = src.indexOf("private async restoreSession(ps: PersistedSession)");
+		assert.ok(idx > 0, "restoreSession declaration not found");
+		const window = src.slice(idx, idx + 20_000);
+
+		const delegateBranchIdx = window.indexOf("} else if (ps.delegateOf && !ps.goalId) {");
+		assert.ok(delegateBranchIdx > 0, "restoreSession must have an `else if (ps.delegateOf && !ps.goalId)` branch");
+
+		// The delegate branch builds the task spec from instructions + context.
+		const branchWindow = window.slice(delegateBranchIdx, delegateBranchIdx + 800);
+		assert.match(branchWindow, /let taskSpec = ps\.instructions \|\| ""/);
+		assert.match(branchWindow, /for \(const \[key, value\] of Object\.entries\(ps\.context\)\)/);
+		assert.match(branchWindow, /goalSpec: taskSpec/);
+
+		// It must precede the goal/role else branch (which resolves goal?.spec).
+		const goalElseIdx = window.indexOf("const goal = ps.goalId ? this.resolveGoal(ps.goalId) : undefined;");
+		assert.ok(goalElseIdx > delegateBranchIdx, "delegate branch must come before the goal/role else branch");
+	});
+
+	it("restoreSessions restores surviving delegates LIVE, not as dormant husks", () => {
+		const idx = src.indexOf("async restoreSessions(): Promise<void>");
+		assert.ok(idx > 0, "restoreSessions declaration not found");
+		const window = src.slice(idx, idx + 6_000);
+
+		// Survivors are collected and routed through the live restore path.
+		assert.match(window, /const delegateSurvivors: PersistedSession\[\] = \[\];/);
+		assert.match(window, /const liveRestore = \[\.\.\.regular, \.\.\.delegateSurvivors\];/);
+		assert.match(window, /liveRestore\.slice\(i, i \+ CONCURRENCY\)/);
+
+		// The orphan boot-reap MUST stay in restoreSessions() (a stubbed
+		// restoreOneSession test relies on it being here, before dispatch).
+		const reapIdx = window.indexOf("shouldReapChildOnBoot({");
+		const dispatchIdx = window.indexOf("batch.map(ps => this.restoreOneSession(ps))");
+		assert.ok(reapIdx > 0, "delegate orphan reap must remain in restoreSessions()");
+		assert.ok(dispatchIdx > reapIdx, "orphan reap must run before live restore dispatch");
+
+		// Survivors must NOT be added as dormant placeholders anymore.
+		assert.ok(
+			!/delegates[\s\S]{0,200}this\.addDormantSession\(ps\)/.test(window),
+			"surviving delegates must not be deferred via addDormantSession",
+		);
+	});
+
+	it("persistOnce persists the durable delegate task (instructions + context)", () => {
+		const setupSrc = fs.readFileSync(
+			path.join(process.cwd(), "src/server/agent/session-setup.ts"),
+			"utf-8",
+		);
+		const idx = setupSrc.indexOf("export function persistOnce(");
+		assert.ok(idx > 0, "persistOnce declaration not found");
+		const window = setupSrc.slice(idx, idx + 2_500);
+		assert.match(window, /instructions: plan\.instructions,/);
+		assert.match(window, /context: plan\.context,/);
+	});
+});

--- a/tests/session-store.test.ts
+++ b/tests/session-store.test.ts
@@ -181,6 +181,28 @@ describe("SessionStore", () => {
 			assert.equal(restored.delegateOf, undefined);
 		});
 
+		it("round-trips durable delegate task fields (instructions + context) through disk", () => {
+			// Delegate restart survival: the delegate's task (instructions + context) is
+			// its durable equivalent of a worker's goal spec. It must survive a reboot so
+			// restoreSession() can rebuild the system prompt from it.
+			const ctx = { role: "helper", deadline: "eod" };
+			const store1 = freshStore();
+			store1.put(makeSession({
+				id: "delegate-1",
+				delegateOf: "owner-1",
+				instructions: "restart-live-survivor-MARKER helper task",
+				context: ctx,
+			}));
+			store1.flush();
+
+			// New store instance reads from the same on-disk file (a real reboot).
+			const store2 = freshStore();
+			const restored = store2.get("delegate-1")!;
+			assert.equal(restored.delegateOf, "owner-1");
+			assert.equal(restored.instructions, "restart-live-survivor-MARKER helper task");
+			assert.deepEqual(restored.context, ctx);
+		});
+
 		it("updates goalId and taskId", () => {
 			const store = freshStore();
 			store.put(makeSession());


### PR DESCRIPTION
## Problem

`team_delegate` children did **not** survive a gateway restart. After a reboot, delegate children came back as `terminated` husks with no live process and no task in their system prompt ("I don't see a specific task in my system prompt"); in-flight work was lost and the outcome was non-deterministic across a `parallel` batch. Goal-team **workers** survived fine — delegates did not.

## Root cause (two deliberate carve-outs)

1. **Excluded from live restore.** `SessionManager.restoreSessions()` split sessions: `regular` (`!delegateOf`) were restored live; `delegates` (`delegateOf`) were handed to `addDormantSession` (a `terminated` placeholder with an un-started bridge), revived only when a human opened the session.
2. **No durable task.** A delegate's task (`instructions` + `context`) was assembled into its prompt only at spawn and never persisted, so even a revived delegate rebuilt an empty goal/role prompt.

## Fix — reuse the worker machinery (one restart path, no parallel registry)

1. **Durable task** — persist `instructions` + `context` on `PersistedSession` (`session-store.ts`), written by `session-setup.ts::persistOnce`.
2. **Live restore** — `restoreSessions()` no longer defers delegates to `addDormantSession`; survivors ride the same `restoreOneSession`/`restoreSession` path workers use. Orphan boot-reap (`shouldReapChildOnBoot`) stays in `restoreSessions()` before dispatch.
3. **Prompt rebuild** — `restoreSession()` delegate branch rebuilds the system prompt from persisted `instructions` + `context` + `projectRoot`, mirroring `session-setup.ts::_resolvePrompt` `mode === "delegate"`.
4. **Re-nudge** — shared `wasStreaming` boot-resume drain + `remindOwnersWithLiveChildren(childKind!=="team")`; the parent re-collects a real result via a live `team_wait`.

Idempotency caveat: a re-run delegate may repeat non-idempotent side effects — identical to workers today; accepted and documented.

## Tests

- `tests/e2e/orchestrate-restart.spec.ts` — new pin: a delegate is restored **LIVE** with its task intact across a `restoreSessions` reboot (failed before fix, passes after). Existing dormant-collect + orphan-reap wiring tests retained.
- `tests/session-store.test.ts` — durable-task round-trip.
- `tests/session-manager-delegate-restore.test.ts` — delegate-branch prompt re-assembly.

## Docs

- `docs/design/orchestration-core.md` §4/§5/§1 rewritten: the original "dormant delegates / no transparent tool-call resumption" decision is deliberately superseded for delegates by the durable-task / re-run model (the "no synthetic tool_result splicing" nuance is retained).
- `docs/orchestration.md` restart-survival section updated.

## Verification

`build`, `check`, full `orchestrate-restart.spec.ts` (6 passed), `test:unit` (node-logic 3875/0 fail) all green. Implementation gate passed (build, type-check, repro-passes, unit, e2e, gap analysis, code review, regression coverage, security review, QA).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
