### PR TITLE
Replace bobbit sprite with text (chat blob toggle)

### DIFF
--- a/docs/bobbit-sprites.md
+++ b/docs/bobbit-sprites.md
@@ -396,6 +396,9 @@ Compaction has a minimum duration of 3.5s and a safety timeout of 10 minutes.
 - `transform-origin: 5px 8px` — pivot at bottom center
 - Three simultaneous animations during busy: `blob-busy-move` (body), `blob-busy-eyes` (eyes), `blob-shimmer` (skin)
 
+> **Note**: A General-settings toggle can replace this sprite with an animated
+> status-text label for the chat blob only. See [section 10, Text-Replacement Mode](#10-text-replacement-mode-settings-toggle).
+
 ### Role page — `idleBlob()`
 
 **File**: `src/app/role-manager-page.ts`
@@ -579,3 +582,95 @@ This prevents the bobbit from looking off-center in the narrower chat area.
 On screens ≤ 639px:
 - Chat blob gets `margin-left: 16px` to avoid hugging the screen edge (where container padding is tighter)
 - This is applied via margin rather than changing `translateX` to avoid breaking the entry/exit animation transitions
+
+---
+
+## 10. Text-Replacement Mode (Settings Toggle)
+
+### What it does
+
+Some people find the large animated chat blob distracting, or simply prefer a
+quieter, more literal status indicator. The **"Replace bobbit sprite with text"**
+toggle (Settings → General, directly below "Show message timestamps") swaps the
+chat blob's animated sprite for a compact animated **status-text label** that
+spells out the agent's current state.
+
+**Scope is the chat blob only.** The sidebar (`statusBobbit()`) and goal-dashboard
+status sprites are deliberately **not** affected — they stay as sprites. The chat
+blob is the one place where the sprite is large enough to be distracting, and it
+already exposes a rich state machine (see section 5) that maps cleanly to words,
+so it is the only context worth replacing.
+
+### Preference
+
+| | |
+|---|---|
+| Key | `replaceBobbitWithText` |
+| Type | boolean |
+| Default | **OFF** — only an explicit `true` enables it |
+| Transport | `PUT /api/preferences` (auto-included in `getSafePreferences`, no special-casing) |
+
+The default is off so the sprite — the app's mascot and the default experience —
+is preserved unless the user opts in.
+
+### State → text mapping
+
+The label reflects the chat blob's current `_blobState` (and the `archived`
+property). The mapping lives in `StreamingMessageContainer._blobTextInfo()`:
+
+| Blob state | Text | Colour | Animation |
+|------------|------|--------|-----------|
+| `active` / `entering` (streaming/busy) | **Busy** | sprite colour | Mexican wave — each letter rises and falls in sequence, looping |
+| `compacting` / `compact-shake` / `compact-pop` | **Compacting** | muted | Reverse (right→left) pulse sweep across the letters, looping |
+| `idle` / `exiting` | **Idle** | muted | Static (no/minimal motion) |
+| `archived` | **Ended** | muted, desaturated | Static |
+
+"Busy" uses the sprite's own canonical colour rather than a generic accent so the
+text still reads as "the bobbit". It applies the same per-session
+`--bobbit-hue-rotate` the sprite uses, so the word shifts hue with the session
+identity exactly as the sprite body would (see section 3). The single source for
+the sprite colour is `--bobbit-sprite-main` defined on `.bobbit-blob-text` in
+`src/ui/app.css` (mirroring `CANONICAL_PALETTE.main` in `src/ui/bobbit-render.ts`) —
+the hex is not scattered elsewhere.
+
+### Rendering
+
+`StreamingMessageContainer.render()` branches on the preference: when enabled it
+renders the text label **instead of** the entire sprite block. Because the
+`<canvas>` is never created, the eye-animation loop never starts — the sprite is
+fully suppressed, not merely hidden. When disabled, the sprite renders exactly as
+before. All blob-state transition logic is unchanged; only the render output
+differs.
+
+The label spells the word with one `<span>` per letter so the wave / pulse can
+stagger per-letter via `animation-delay` (`:nth-child`). For accessibility the
+container carries `role="status"` and `aria-label` with the full word, while the
+per-letter spans are `aria-hidden="true"` so a screen reader announces "Busy"
+rather than "B u s y". Keyframes (`blob-text-wave`, `blob-text-pulse`) live in
+`src/ui/app.css` alongside the blob keyframes and collapse to static text under
+`@media (prefers-reduced-motion: reduce)`.
+
+The label is sized (`min-height` + matching margins) to occupy roughly the same
+vertical footprint as the sprite block, so toggling the setting — or changing
+state — does not shift the surrounding chat layout.
+
+### Preference plumbing (dataset mirror)
+
+The text label is a Lit component, but the preference is a plain dataset string —
+this follows the same default-off boolean pattern as `subgoalsEnabled` and
+`playAgentFinishSound`. The value is mirrored to
+`document.documentElement.dataset.replaceBobbitWithText` (`"true"` / `"false"`) at
+three sites so it survives load and updates live:
+
+1. **`src/app/main.ts`** — initial-load and reconnect preference blocks.
+2. **`src/app/remote-agent.ts`** — the `preferences_changed` WebSocket handler.
+3. **`src/app/settings-page.ts`** — synchronously in the toggle handler (before the
+   `PUT`), so the blob flips immediately without waiting on the broadcast.
+
+`StreamingMessageContainer` reads the dataset value on each render and stays
+reactive via a `MutationObserver` on `document.documentElement` (filtered to
+`data-replace-bobbit-with-text`), so the label appears/disappears the instant the
+preference changes — no reload required.
+
+For the full design rationale, file-by-file plan, and CSS specifics, see
+[docs/design/sprite-to-text.md](design/sprite-to-text.md).

--- a/docs/design/sprite-to-text.md
+++ b/docs/design/sprite-to-text.md
@@ -1,0 +1,182 @@
+# Design: Replace bobbit sprite with text (chat blob)
+
+## Goal
+
+Add a General-settings toggle **"Replace bobbit sprite with text"** (default OFF). When ON,
+the large animated bobbit sprite in the **chat view** (the "chat blob") is hidden and replaced
+by an animated status-text label that reflects the blob's current `_blobState`. Out of scope:
+sidebar / team-list / goal-dashboard sprites (`renderSidebarBobbitCanvas` / `statusBobbit`) —
+those stay as sprites and must not change.
+
+## Preference plumbing
+
+New boolean preference key: **`replaceBobbitWithText`**, default **OFF** (only explicit `true`
+enables). This follows the existing `subgoalsEnabled` pattern exactly (default-off boolean).
+
+### Server (no code change required)
+`getSafePreferences()` in `src/server/server.ts` already passes through every key that is not
+prefixed `providerKey.`, and `PUT /api/preferences` already accepts arbitrary keys. So the new
+key is persisted and broadcast automatically. **Do not** add server-side special-casing.
+(Confirm via the existing preferences E2E coverage; no new server logic.)
+
+### Client dataset mirroring (3 sites — mirror `subgoalsEnabled`/`playAgentFinishSound`)
+The preference is mirrored to `document.documentElement.dataset.replaceBobbitWithText` as the
+string `"true"` / `"false"` so it survives load and updates live. Three sites:
+
+1. **`src/app/main.ts`** — initial load block (~line 657, alongside `showTimestamps` /
+   `playAgentFinishSound` / `subgoalsEnabled`) **and** the reconnect block (~line 1007). Add:
+   ```ts
+   // Apply replaceBobbitWithText — default OFF (only explicit true opts in).
+   document.documentElement.dataset.replaceBobbitWithText =
+       prefs.replaceBobbitWithText === true ? "true" : "false";
+   ```
+   Add the same line in both the initial-load and reconnect locations.
+
+2. **`src/app/remote-agent.ts`** — `preferences_changed` WS handler (~line 2300, after the
+   `playAgentFinishSound` block):
+   ```ts
+   // Apply replaceBobbitWithText — default OFF.
+   if ("replaceBobbitWithText" in prefs) {
+       document.documentElement.dataset.replaceBobbitWithText =
+           prefs.replaceBobbitWithText === true ? "true" : "false";
+   }
+   ```
+
+3. **`src/app/settings-page.ts`** — synchronously in the toggle handler (mirrors
+   `togglePlayFinishSound` / `toggleSubgoalsEnabled` which set the dataset before the PUT).
+
+## Settings UI (`src/app/settings-page.ts`, `renderGeneralTab`)
+
+- New module-level state var: `let settingsReplaceBobbitWithText = false;` (near line 108,
+  alongside `settingsShowTimestamps` / `settingsPlayFinishSound` / `settingsSubgoalsEnabled`).
+- In `loadGeneralSettings()` (~line 2178): `settingsReplaceBobbitWithText = prefs.replaceBobbitWithText === true;`
+- New async toggle handler `toggleReplaceBobbitWithText()` mirroring `togglePlayFinishSound`
+  exactly: flip the var, set `document.documentElement.dataset.replaceBobbitWithText`
+  synchronously, `renderApp()`, then `PUT /api/preferences` with
+  `{ replaceBobbitWithText: settingsReplaceBobbitWithText }`.
+- New checkbox row in `renderGeneralTab`, inserted **immediately below** the
+  "Show message timestamps" row (which is at ~line 2404-2417) and **above** the
+  "Play agent finish sound" row. Match the existing markup exactly: a `<label>` with the
+  checkbox + `<span class="text-sm font-medium text-foreground">Replace bobbit sprite with text</span>`
+  and a helper `<p class="text-xs text-muted-foreground ml-6">` explaining it replaces the
+  animated chat avatar with a status-text label. Checkbox classes:
+  `w-4 h-4 rounded border-input accent-primary cursor-pointer`. Add
+  `data-testid="general-replace-bobbit-with-text"`, `.checked=${settingsReplaceBobbitWithText}`,
+  `@change=${toggleReplaceBobbitWithText}`.
+
+## Chat blob: text vs sprite (`src/ui/components/StreamingMessageContainer.ts`)
+
+The component already tracks `_blobState` ('hidden' | 'active' | 'entering' | 'exiting' | 'idle'
+| 'compact-shake' | 'compacting' | 'compact-pop') plus an `archived` property. All blob-state
+transition logic stays unchanged — only the **render output** branches on the preference.
+
+### Reading the preference reactively
+The dataset value is not a Lit property, so the component must re-read it on each render and
+re-render when it changes. Implement with a small reactive mirror:
+- Add `@state() private _replaceWithText = false;`
+- A module-private helper `readReplacePref()` returns
+  `document.documentElement.dataset.replaceBobbitWithText === "true"`.
+- In `connectedCallback`, set `this._replaceWithText = readReplacePref()` and register a
+  `MutationObserver` on `document.documentElement` (attributeFilter:
+  `["data-replace-bobbit-with-text"]`) that updates `this._replaceWithText` (triggering a Lit
+  re-render). Disconnect the observer in `disconnectedCallback`.
+  This makes the text update both when the state changes (existing `_blobState` `@state`
+  re-renders) and when the preference is toggled live.
+
+### Render branch
+In `render()`, where the blob `<div class="${this._blobClass}">…sprite…</div>` is produced:
+- When `this._replaceWithText` is **true**: render the status-text element **instead of** the
+  entire sprite block (no `<canvas>`, no accessory divs, no shadow). Because the canvas is never
+  created, `ensureCanvasEyeAnimation` never runs — sprite fully suppressed, no hidden eye loop.
+- When **false**: unchanged — render exactly today's sprite block via `renderBlobSpriteImg(...)`.
+
+`_blobVisible` gating stays the same (text shows whenever the sprite would have shown,
+including `archived`).
+
+### State → text + animation-class mapping
+A pure helper maps `_blobState` + `archived` → `{ text, motionClass }`:
+
+| condition | text | style/animation |
+|---|---|---|
+| `archived` | `Ended` | muted, desaturated, static |
+| `_blobState === 'idle'` (and `exiting`) | `Idle` | muted grey, no/minimal animation |
+| `_blobState === 'compacting'` / `compact-shake` / `compact-pop` | `Compacting` | muted, reverse (right-to-left) pulse sweep |
+| `active` / `entering` (default streaming) | `Busy` | sprite-colour, Mexican-wave letter rise/fall |
+
+The text element renders each letter in its own `<span>` so the wave / pulse can target letters
+sequentially via `animation-delay` (nth-child). Use `aria-label` on the container with the full
+word and `aria-hidden` on the per-letter spans for accessibility. Markup shape:
+```html
+<div class="bobbit-blob-text bobbit-blob-text--busy" aria-label="Busy">
+  <span aria-hidden="true">B</span><span aria-hidden="true">u</span>…
+</div>
+```
+The modifier class (`--idle` / `--busy` / `--compacting` / `--ended`) drives colour + animation.
+
+## CSS (`src/ui/app.css`, alongside the blob keyframes ~line 3199+)
+
+Add a `.bobbit-blob-text` block and keyframes. Requirements:
+- **Layout parity**: the text container occupies roughly the same vertical footprint as the
+  sprite block so toggling / state changes don't shift the chat layout. The sprite block renders
+  in a fixed-ish box (canvas ~40×36 CSS px inside padded blob). Give `.bobbit-blob-text` a
+  `min-height` / padding matching the blob's effective height (inspect the rendered blob box;
+  the blob wrapper uses `padding:8px 20px 40px 20px` in the preview renderer — match the chat
+  blob's actual box). Center the text vertically.
+- **Colours (design-system tokens / sprite value only)**:
+  - muted states (`--idle`, `--compacting`, `--ended`): `color: var(--muted-foreground);`
+  - `--busy`: the sprite's own main colour. The sprite body colour is the canonical green
+    `#8ec63f` (`CANONICAL_PALETTE.main` in `src/ui/bobbit-render.ts`). To honour the per-session
+    hue **and** keep a single source of truth, define **one** CSS custom property for the sprite
+    main colour and reuse it — e.g. in `app.css` add `--bobbit-sprite-main: #8ec63f;` on the blob
+    text scope (this is the *sprite's own* value, not a new palette colour), then
+    `.bobbit-blob-text--busy { color: var(--bobbit-sprite-main); filter: hue-rotate(var(--bobbit-hue-rotate, 0deg)); }`
+    so the per-session `--bobbit-hue-rotate` (already set on `document.documentElement`) rotates
+    the text colour exactly as it rotates the sprite. Do **not** scatter the hex; define it once.
+  - `--ended`: muted + `filter: saturate(0)` (or `opacity`) to read as desaturated/static.
+- **Animations** (keyframes named consistently with existing `blob-*`):
+  - **Busy — Mexican wave**: `@keyframes blob-text-wave { 0%,60%,100% { transform: translateY(0);} 30% { transform: translateY(-0.25em);} }`
+    applied per-letter with staggered `animation-delay` (nth-child) so letters rise/fall in
+    sequence, looping.
+  - **Compacting — reverse pulse**: a highlight/opacity (or scale) sweep across letters from
+    **right to left**. Either a per-letter `@keyframes blob-text-pulse` with `animation-delay`
+    assigned in **reverse** order (last letter starts first), or a background-position sweep.
+    Must loop and visibly move right→left.
+  - Idle: no animation (or a very subtle one). Ended: static.
+- **`prefers-reduced-motion: reduce`**: degrade all `.bobbit-blob-text` letter animations to
+  `animation: none` (static text), consistent with the existing reduced-motion block (~line 3388).
+
+## Testing
+
+### Browser E2E (new) — pattern: `tests/e2e/ui/settings.spec.ts`
+New spec (e.g. `tests/e2e/ui/replace-bobbit-text.spec.ts`) covering:
+1. Toggle appears in General settings **immediately below** "Show message timestamps"
+   (assert DOM order / position relative to the timestamps row).
+2. Enabling it: the chat blob `<canvas class="bobbit-blob__sprite">` disappears and a
+   `.bobbit-blob-text` status label is present.
+3. **Persists across reload** — reload, the toggle is still checked and the text label still
+   shows (sprite still gone).
+4. Disabling restores the sprite canvas (text label gone).
+5. If practical, assert the text content differs between idle (`Idle`) and busy (`Busy`) — e.g.
+   by exercising a streaming state or by directly driving the container's `_blobState` in a test
+   harness. Keep this assertion best-effort/robust; do not make the whole spec flaky on timing.
+
+### Pinning / existing tests
+- Run `npm run check`, `npm run test:unit`, `npm run test:e2e`.
+- Tool-description budget and test-phase-invariant pinning tests must still pass. The new spec
+  must be placed so `tests/test-phase-invariant.test.ts` classifies it correctly (browser E2E →
+  `tests/e2e/ui/*.spec.ts`). Add the missing test rather than weakening any existing one.
+
+## Files touched
+- `src/app/settings-page.ts` — state var, load, toggle handler, checkbox row.
+- `src/app/main.ts` — dataset mirror (initial load + reconnect).
+- `src/app/remote-agent.ts` — dataset mirror (preferences_changed handler).
+- `src/ui/components/StreamingMessageContainer.ts` — reactive pref read + render branch + text mapping.
+- `src/ui/app.css` — `.bobbit-blob-text` styles, keyframes, reduced-motion, single sprite-colour var.
+- `tests/e2e/ui/replace-bobbit-text.spec.ts` — new browser E2E.
+- Docs: feature documentation (handled by documentation gate).
+
+## Constraints honoured
+- LF endings; branch `master`. No sidebar/team/dashboard sprite changes; `statusBobbit`
+  untouched. Reuses existing preference transport (PUT + WS broadcast + dataset mirror). Colour
+  via design-system tokens (`--muted-foreground`) and the single sprite-colour value + existing
+  `--bobbit-hue-rotate`; no new `:root` palette, no `prefers-color-scheme`.

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -660,6 +660,9 @@ async function initApp() {
 					// Apply playAgentFinishSound — default ON when unset.
 					document.documentElement.dataset.playAgentFinishSound =
 						prefs.playAgentFinishSound === false ? "false" : "true";
+					// Apply replaceBobbitWithText — default OFF (only explicit true opts in).
+					document.documentElement.dataset.replaceBobbitWithText =
+						prefs.replaceBobbitWithText === true ? "true" : "false";
 					// Apply subgoalsEnabled — default OFF (only explicit true opts in).
 					document.documentElement.dataset.subgoalsEnabled =
 						prefs.subgoalsEnabled === true ? "true" : "false";
@@ -1008,6 +1011,9 @@ async function initApp() {
 			// Apply playAgentFinishSound — default ON when unset.
 			document.documentElement.dataset.playAgentFinishSound =
 				prefs.playAgentFinishSound === false ? "false" : "true";
+			// Apply replaceBobbitWithText — default OFF (only explicit true opts in).
+			document.documentElement.dataset.replaceBobbitWithText =
+				prefs.replaceBobbitWithText === true ? "true" : "false";
 			// Apply subgoalsEnabled — default OFF (only explicit true opts in).
 			document.documentElement.dataset.subgoalsEnabled =
 				prefs.subgoalsEnabled === true ? "true" : "false";

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -2309,6 +2309,12 @@ export class RemoteAgent {
 				prefs.playAgentFinishSound === false ? "false" : "true";
 		}
 
+		// Apply replaceBobbitWithText — default OFF (only explicit true opts in).
+		if ("replaceBobbitWithText" in prefs) {
+			document.documentElement.dataset.replaceBobbitWithText =
+				prefs.replaceBobbitWithText === true ? "true" : "false";
+		}
+
 		// Apply subgoalsEnabled — default OFF. See subgoals-flag.ts. Mirror
 		// unconditionally: the broadcast sends the full prefs object, so an
 		// unset pref is absent and must normalize to "false" (not retain stale).

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -108,6 +108,7 @@ let _listening = false;
 let settingsShowTimestamps = false;
 let settingsShowTimestampsLoaded = false;
 let settingsPlayFinishSound = true;
+let settingsReplaceBobbitWithText = false;
 let settingsSubgoalsEnabled = true;
 let settingsMaxNestingDepth: number | null = null;
 const MAX_NESTING_DEPTH_DEFAULT = 3;
@@ -2178,6 +2179,8 @@ function loadGeneralSettings() {
 					settingsShowTimestamps = !!prefs.showTimestamps;
 					// Default ON when unset — only an explicit `false` opts out.
 					settingsPlayFinishSound = prefs.playAgentFinishSound !== false;
+					// Replace bobbit sprite with text (chat blob) — default OFF; only an explicit `true` enables.
+					settingsReplaceBobbitWithText = prefs.replaceBobbitWithText === true;
 					// Subgoals (Experimental) — default OFF; only an explicit `true` enables. See docs/nested-goals.md.
 					settingsSubgoalsEnabled = prefs.subgoalsEnabled === true;
 					const rawDepth = prefs.maxNestingDepth;
@@ -2304,6 +2307,20 @@ async function togglePlayFinishSound(): Promise<void> {
 	} catch {}
 }
 
+async function toggleReplaceBobbitWithText(): Promise<void> {
+	settingsReplaceBobbitWithText = !settingsReplaceBobbitWithText;
+	// Apply synchronously to the dataset so the chat blob flips without waiting
+	// on the preferences_changed broadcast — mirrors togglePlayFinishSound.
+	document.documentElement.dataset.replaceBobbitWithText = settingsReplaceBobbitWithText ? "true" : "false";
+	renderApp();
+	try {
+		await gatewayFetch("/api/preferences", {
+			method: "PUT",
+			body: JSON.stringify({ replaceBobbitWithText: settingsReplaceBobbitWithText }),
+		});
+	} catch {}
+}
+
 async function setMaxNestingDepth(raw: number): Promise<void> {
 	if (!Number.isFinite(raw)) return;
 	let n = Math.floor(raw);
@@ -2413,6 +2430,21 @@ function renderGeneralTab() {
 				</label>
 				<p class="text-xs text-muted-foreground ml-6">
 					Display timestamps next to user and assistant messages.
+				</p>
+			</div>
+			<div class="flex flex-col gap-1.5">
+				<label class="flex items-center gap-2 cursor-pointer">
+					<input
+						type="checkbox"
+						class="w-4 h-4 rounded border-input accent-primary cursor-pointer"
+						data-testid="general-replace-bobbit-with-text"
+						.checked=${settingsReplaceBobbitWithText}
+						@change=${toggleReplaceBobbitWithText}
+					/>
+					<span class="text-sm font-medium text-foreground">Replace bobbit sprite with text</span>
+				</label>
+				<p class="text-xs text-muted-foreground ml-6">
+					Replace the animated chat avatar with a status-text label that reflects the agent's current state.
 				</p>
 			</div>
 			<div class="flex flex-col gap-1.5">

--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -3391,6 +3391,101 @@ html {
 	.bobbit-blob__zzz-letter--3 { transform: translate(18px, -42px); }
 }
 
+/* ============================================================================
+   Sprite-to-text chat blob (Settings → General → "Replace bobbit sprite with text")
+   Replaces the animated chat-blob sprite with an animated status-text label.
+   Layout parity: occupies roughly the same vertical footprint as the sprite
+   block (canvas 40×36 with margin -15 -6 16 3 inside a .bobbit-blob whose
+   margin-bottom is -28px) so toggling the setting — or changing state — does
+   not shift the surrounding chat layout.
+   ============================================================================ */
+.bobbit-blob-text {
+	/* Single source for the canonical sprite main colour (CANONICAL_PALETTE.main
+	   in src/ui/bobbit-render.ts). Do not scatter this hex elsewhere. */
+	--bobbit-sprite-main: #8ec63f;
+	display: flex;
+	align-items: center;
+	justify-content: flex-start;
+	min-height: 37px;
+	margin: 0 0 -28px 3px;
+	padding-left: 4px;
+	font-weight: 700;
+	font-size: 15px;
+	letter-spacing: 0.01em;
+	line-height: 1;
+	user-select: none;
+	/* Muted by default; the --busy modifier overrides colour + filter below. */
+	color: var(--muted-foreground);
+}
+.goal-chat-panel .bobbit-blob-text {
+	margin-left: 18px;
+}
+.bobbit-blob-text > span {
+	display: inline-block;
+	white-space: pre;
+	will-change: transform, opacity;
+}
+
+/* Idle / Ended — muted, static. */
+.bobbit-blob-text--idle,
+.bobbit-blob-text--compacting {
+	color: var(--muted-foreground);
+}
+.bobbit-blob-text--ended {
+	color: var(--muted-foreground);
+	filter: saturate(0);
+	opacity: 0.7;
+}
+
+/* Busy — sprite's own colour, honouring the per-session hue exactly like the
+   sprite (which applies the same hue-rotate on .bobbit-blob). */
+.bobbit-blob-text--busy {
+	color: var(--bobbit-sprite-main);
+	filter: hue-rotate(var(--bobbit-hue-rotate, 0deg));
+}
+/* Busy — Mexican wave: each letter rises and falls in sequence, looping. */
+.bobbit-blob-text--busy > span {
+	animation: blob-text-wave 1.1s ease-in-out infinite;
+}
+.bobbit-blob-text--busy > span:nth-child(1) { animation-delay: 0s; }
+.bobbit-blob-text--busy > span:nth-child(2) { animation-delay: 0.08s; }
+.bobbit-blob-text--busy > span:nth-child(3) { animation-delay: 0.16s; }
+.bobbit-blob-text--busy > span:nth-child(4) { animation-delay: 0.24s; }
+.bobbit-blob-text--busy > span:nth-child(5) { animation-delay: 0.32s; }
+.bobbit-blob-text--busy > span:nth-child(6) { animation-delay: 0.40s; }
+.bobbit-blob-text--busy > span:nth-child(7) { animation-delay: 0.48s; }
+.bobbit-blob-text--busy > span:nth-child(8) { animation-delay: 0.56s; }
+
+/* Compacting — reverse (right→left) pulse: the highlight sweeps across the
+   letters from the last to the first (reverse per-letter delays). "Compacting"
+   has 10 letters. */
+.bobbit-blob-text--compacting > span {
+	animation: blob-text-pulse 1.4s ease-in-out infinite;
+}
+.bobbit-blob-text--compacting > span:nth-child(10) { animation-delay: 0s; }
+.bobbit-blob-text--compacting > span:nth-child(9)  { animation-delay: 0.08s; }
+.bobbit-blob-text--compacting > span:nth-child(8)  { animation-delay: 0.16s; }
+.bobbit-blob-text--compacting > span:nth-child(7)  { animation-delay: 0.24s; }
+.bobbit-blob-text--compacting > span:nth-child(6)  { animation-delay: 0.32s; }
+.bobbit-blob-text--compacting > span:nth-child(5)  { animation-delay: 0.40s; }
+.bobbit-blob-text--compacting > span:nth-child(4)  { animation-delay: 0.48s; }
+.bobbit-blob-text--compacting > span:nth-child(3)  { animation-delay: 0.56s; }
+.bobbit-blob-text--compacting > span:nth-child(2)  { animation-delay: 0.64s; }
+.bobbit-blob-text--compacting > span:nth-child(1)  { animation-delay: 0.72s; }
+
+@keyframes blob-text-wave {
+	0%, 60%, 100% { transform: translateY(0); }
+	30% { transform: translateY(-6px); }
+}
+@keyframes blob-text-pulse {
+	0%, 100% { opacity: 0.45; transform: translateY(0); }
+	50% { opacity: 1; transform: translateY(-2px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.bobbit-blob-text > span { animation: none !important; opacity: 1; transform: none; }
+}
+
 /* Idle state — sitting still, offset left, eyes looking around */
 .bobbit-blob--idle .bobbit-blob__sprite {
 	transform: scale(4) translateX(-7px);

--- a/src/ui/components/StreamingMessageContainer.ts
+++ b/src/ui/components/StreamingMessageContainer.ts
@@ -18,6 +18,11 @@ export class StreamingMessageContainer extends LitElement {
 
 	@state() private _message: AgentMessage | null = null;
 	@state() private _blobState: 'hidden' | 'active' | 'entering' | 'exiting' | 'idle' | 'compact-shake' | 'compacting' | 'compact-pop' = 'idle';
+	/** When true, the chat blob sprite is replaced by an animated status-text
+	 * label. Mirrors `document.documentElement.dataset.replaceBobbitWithText`,
+	 * kept reactive via a MutationObserver registered in connectedCallback. */
+	@state() private _replaceWithText = false;
+	private _replaceWithTextObserver: MutationObserver | null = null;
 	private _exitVariant: 'exit' | 'exit-roll' = 'exit';
 	private _entryVariant: 'enter' | 'enter-roll' = 'enter';
 	private _entryTimer: ReturnType<typeof setTimeout> | null = null;
@@ -38,6 +43,51 @@ export class StreamingMessageContainer extends LitElement {
 	override connectedCallback(): void {
 		super.connectedCallback();
 		this.style.display = "block";
+		this._replaceWithText = StreamingMessageContainer._readReplaceWithText();
+		// Stay reactive to live preference changes (settings toggle / WS
+		// preferences_changed broadcast both mirror to the documentElement
+		// dataset). A MutationObserver re-reads the flag and Lit re-renders on
+		// the @state change.
+		this._replaceWithTextObserver = new MutationObserver(() => {
+			this._replaceWithText = StreamingMessageContainer._readReplaceWithText();
+		});
+		this._replaceWithTextObserver.observe(document.documentElement, {
+			attributes: true,
+			attributeFilter: ["data-replace-bobbit-with-text"],
+		});
+	}
+
+	override disconnectedCallback(): void {
+		super.disconnectedCallback();
+		if (this._replaceWithTextObserver) {
+			this._replaceWithTextObserver.disconnect();
+			this._replaceWithTextObserver = null;
+		}
+	}
+
+	private static _readReplaceWithText(): boolean {
+		return document.documentElement.dataset.replaceBobbitWithText === "true";
+	}
+
+	/** Pure map from the current blob state to the status word + CSS modifier. */
+	private _blobTextInfo(): { word: string; modifier: string } {
+		if (this.archived) return { word: "Ended", modifier: "ended" };
+		if (this._blobState === 'idle' || this._blobState === 'exiting') return { word: "Idle", modifier: "idle" };
+		if (this._blobState === 'compacting' || this._blobState === 'compact-shake' || this._blobState === 'compact-pop') {
+			return { word: "Compacting", modifier: "compacting" };
+		}
+		// 'active' / 'entering' (and any future busy-like state) → Busy.
+		return { word: "Busy", modifier: "busy" };
+	}
+
+	private _renderBlobText() {
+		const { word, modifier } = this._blobTextInfo();
+		const letters = word.split("");
+		return html`<div
+			class="bobbit-blob-text bobbit-blob-text--${modifier}"
+			role="status"
+			aria-label=${word}
+		>${letters.map((ch) => html`<span aria-hidden="true">${ch}</span>`)}</div>`;
 	}
 
 	override updated(changed: Map<string, unknown>) {
@@ -345,7 +395,10 @@ export class StreamingMessageContainer extends LitElement {
 		return html`
 			<div class="flex flex-col gap-3 mb-3">
 				${content}
-				${this._blobVisible ? html`<div class="${this._blobClass}">
+				${this._blobVisible
+					? (this._replaceWithText
+						? this._renderBlobText()
+						: html`<div class="${this._blobClass}">
 					${renderBlobSpriteImg(this._blobClass.includes("idle"), this.archived)}
 					<div class="bobbit-blob__crown"></div>
 					<div class="bobbit-blob__bandana"></div>
@@ -366,7 +419,8 @@ export class StreamingMessageContainer extends LitElement {
 						<span class="bobbit-blob__zzz-letter bobbit-blob__zzz-letter--2">z</span>
 						<span class="bobbit-blob__zzz-letter bobbit-blob__zzz-letter--3">z</span>
 					</div>
-				</div>` : nothing}
+				</div>`)
+					: nothing}
 				${showTimer
 					? html`<div class="px-2 sm:px-4 text-xs text-muted-foreground text-right tabular-nums" style="margin-top:-32px;">
 						<live-timer .startTime=${this.turnStartTime} .running=${true}></live-timer>

--- a/tests/e2e/ui/replace-bobbit-text.spec.ts
+++ b/tests/e2e/ui/replace-bobbit-text.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * "Replace bobbit sprite with text" chat-blob E2E tests.
+ *
+ * Covers the General-settings toggle that swaps the animated chat-blob sprite
+ * for an animated status-text label (Idle / Busy / Compacting / Ended):
+ *   • the toggle renders immediately BELOW the "Show message timestamps" row;
+ *   • enabling it replaces the sprite canvas with a `.bobbit-blob-text` label;
+ *   • the preference persists across a full page reload;
+ *   • disabling it restores the sprite canvas.
+ */
+import { test, expect } from "../gateway-harness.js";
+import { createSession, deleteSession, waitForSessionStatus } from "../e2e-setup.js";
+import { openApp, sendMessage, waitForAgentResponse, navigateToHash } from "./ui-helpers.js";
+
+const EXPECTED_WORDS = ["Idle", "Busy", "Compacting", "Ended"];
+
+test.describe("Replace bobbit sprite with text", () => {
+	test("toggle sits below timestamps, swaps sprite for text, persists, and reverts", async ({ page }) => {
+		// Create a session with content so the chat blob renders.
+		const sessionId = await createSession();
+		await waitForSessionStatus(sessionId, "idle");
+
+		await openApp(page);
+		await page.evaluate((id) => { window.location.hash = `#/session/${id}`; }, sessionId);
+		await expect(page.locator("textarea").first()).toBeVisible({ timeout: 10_000 });
+		await sendMessage(page, "hello");
+		await waitForAgentResponse(page);
+		await waitForSessionStatus(sessionId, "idle");
+
+		// Sprite canvas is present while the setting is OFF (default).
+		const spriteCanvas = page.locator("canvas.bobbit-blob__sprite").first();
+		const textLabel = page.locator(".bobbit-blob-text").first();
+		await expect(spriteCanvas).toBeVisible({ timeout: 10_000 });
+		await expect(textLabel).toHaveCount(0);
+
+		// --- Settings: toggle appears immediately below "Show message timestamps" ---
+		await navigateToHash(page, "#/settings/system/general");
+		const toggle = page.getByTestId("general-replace-bobbit-with-text");
+		await expect(toggle).toBeVisible({ timeout: 10_000 });
+
+		const timestampsLabel = page.getByText("Show message timestamps", { exact: true });
+		const playSoundToggle = page.getByTestId("general-play-finish-sound");
+		await expect(timestampsLabel).toBeVisible();
+		await expect(playSoundToggle).toBeVisible();
+
+		const orderY = async () => {
+			const ts = await timestampsLabel.boundingBox();
+			const rep = await toggle.boundingBox();
+			const snd = await playSoundToggle.boundingBox();
+			return { ts: ts!.y, rep: rep!.y, snd: snd!.y };
+		};
+		const { ts, rep, snd } = await orderY();
+		// Replace-with-text row is below the timestamps row and above play-sound.
+		expect(rep).toBeGreaterThan(ts);
+		expect(snd).toBeGreaterThan(rep);
+
+		// --- Enable: sprite canvas gone, status-text label present ---
+		await expect(toggle).not.toBeChecked();
+		await toggle.click();
+		await expect(toggle).toBeChecked();
+
+		await page.evaluate((id) => { window.location.hash = `#/session/${id}`; }, sessionId);
+		await expect(page.locator("textarea").first()).toBeVisible({ timeout: 10_000 });
+
+		await expect(textLabel).toBeVisible({ timeout: 10_000 });
+		await expect(page.locator("canvas.bobbit-blob__sprite")).toHaveCount(0);
+		// Label content is one of the known status words.
+		const labelText = (await textLabel.getAttribute("aria-label")) ?? "";
+		expect(EXPECTED_WORDS).toContain(labelText);
+
+		// --- Persistence across a full reload ---
+		await page.reload();
+		await expect(
+			page.locator("button").filter({ hasText: "Settings" }).first(),
+		).toBeVisible({ timeout: 20_000 });
+		await page.evaluate((id) => { window.location.hash = `#/session/${id}`; }, sessionId);
+		await expect(page.locator("textarea").first()).toBeVisible({ timeout: 10_000 });
+
+		await expect(textLabel).toBeVisible({ timeout: 10_000 });
+		await expect(page.locator("canvas.bobbit-blob__sprite")).toHaveCount(0);
+
+		// Toggle still reflects the persisted ON state in settings.
+		await navigateToHash(page, "#/settings/system/general");
+		const toggleAfterReload = page.getByTestId("general-replace-bobbit-with-text");
+		await expect(toggleAfterReload).toBeChecked({ timeout: 10_000 });
+
+		// --- Disable: sprite canvas restored, text label gone ---
+		await toggleAfterReload.click();
+		await expect(toggleAfterReload).not.toBeChecked();
+
+		await page.evaluate((id) => { window.location.hash = `#/session/${id}`; }, sessionId);
+		await expect(page.locator("textarea").first()).toBeVisible({ timeout: 10_000 });
+
+		await expect(page.locator("canvas.bobbit-blob__sprite").first()).toBeVisible({ timeout: 10_000 });
+		await expect(page.locator(".bobbit-blob-text")).toHaveCount(0);
+
+		await deleteSession(sessionId);
+	});
+});


### PR DESCRIPTION
## Summary
Adds a General-settings toggle **"Replace bobbit sprite with text"** (preference `replaceBobbitWithText`, default **OFF**). When enabled, the large animated bobbit sprite in the **chat view** is hidden and replaced by an animated status-text label reflecting the chat blob's state. Sidebar / team-list / goal-dashboard sprites are unchanged.

## State → text mapping
- **idle / exiting** → "Idle" (muted, static)
- **active / entering** → "Busy" (sprite colour, honouring per-session `--bobbit-hue-rotate`; Mexican-wave letter animation)
- **compacting / compact-shake / compact-pop** → "Compacting" (muted, right→left reverse pulse)
- **archived** → "Ended" (muted, desaturated, static)

## Changes
- `src/app/settings-page.ts` — new checkbox row below "Show message timestamps" (`data-testid="general-replace-bobbit-with-text"`), state var, load + async toggle handler (mirrors `togglePlayFinishSound`).
- `src/app/main.ts`, `src/app/remote-agent.ts` — mirror the preference to `document.documentElement.dataset.replaceBobbitWithText` (initial load, reconnect, and `preferences_changed` WS handler).
- `src/ui/components/StreamingMessageContainer.ts` — reactive pref read (`MutationObserver`); when enabled renders an animated per-letter status-text label (`role="status"` + `aria-label`) instead of the sprite block (canvas never created → eye-animation suppressed).
- `src/ui/app.css` — `.bobbit-blob-text` styles + `blob-text-wave` / `blob-text-pulse` keyframes; single sprite-colour custom property; design-system tokens; `prefers-reduced-motion` degrade; layout parity to avoid chat reflow.
- `tests/e2e/ui/replace-bobbit-text.spec.ts` — new browser E2E (toggle placement, sprite→text swap, persistence across reload, restore on disable).
- Docs: `docs/bobbit-sprites.md` (feature section) + `docs/design/sprite-to-text.md` (design).

## Server
No server change required — `getSafePreferences` already passes through all non-`providerKey.` keys and `PUT /api/preferences` accepts arbitrary keys.

## Testing
`npm run check`, `npm run test:unit`, `npm run test:e2e` (incl. the new spec) pass. Pinning tests (tool-description-budget, test-phase-invariant) pass.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)