### PR TITLE
Migrate workflow {{master}} references to {{baseBranch}}

### DIFF
--- a/.bobbit/config/project.yaml
+++ b/.bobbit/config/project.yaml
@@ -121,7 +121,7 @@ workflows:
               {{goal_spec}}
 
 
-              Run `git diff origin/{{master}}...{{branch}} -- .
+              Run `git diff origin/{{baseBranch}}...{{branch}} -- .
               ':!package-lock.json'` to see the implementation diff.
 
               Read the design document content from upstream gates.
@@ -148,14 +148,14 @@ workflows:
             role: code-reviewer
             phase: 2
             prompt: >-
-              Review the code changes on branch {{branch}} vs origin/{{master}}
+              Review the code changes on branch {{branch}} vs origin/{{baseBranch}}
               for quality.
 
 
-              Start with `git diff --stat origin/{{master}}...{{branch}} -- .
+              Start with `git diff --stat origin/{{baseBranch}}...{{branch}} -- .
               ':!package-lock.json'` to see which files changed.
 
-              Then use `git diff origin/{{master}}...{{branch}} -M -- .
+              Then use `git diff origin/{{baseBranch}}...{{branch}} -M -- .
               ':!package-lock.json'` (with rename detection) to see actual
               content changes — this collapses pure renames into one-line
               summaries.
@@ -189,7 +189,7 @@ workflows:
               {{goal_spec}}
 
 
-              Run `git diff origin/{{master}}...{{branch}} -- .
+              Run `git diff origin/{{baseBranch}}...{{branch}} -- .
               ':!package-lock.json'` to see all changes.
 
 
@@ -251,10 +251,10 @@ workflows:
             phase: 2
             prompt: >-
               Security review of changes on branch {{branch}} vs
-              origin/{{master}}.
+              origin/{{baseBranch}}.
 
 
-              Run `git diff origin/{{master}}...{{branch}} -- .
+              Run `git diff origin/{{baseBranch}}...{{branch}} -- .
               ':!package-lock.json'` to see changes.
 
 
@@ -280,10 +280,10 @@ workflows:
             type: llm-review
             prompt: >-
               Review documentation for the changes on branch {{branch}} vs
-              origin/{{master}}.
+              origin/{{baseBranch}}.
 
 
-              Run `git diff origin/{{master}}...{{branch}} -- .
+              Run `git diff origin/{{baseBranch}}...{{branch}} -- .
               ':!package-lock.json'` to see all changes.
 
               Read the key documentation files: AGENTS.md, README.md, and files
@@ -401,11 +401,11 @@ workflows:
               origin {{branch}} | grep -q .
           - name: Master merged into branch
             type: command
-            run: git fetch origin {{master}} && git merge-base --is-ancestor
-              origin/{{master}} {{branch}}
+            run: git fetch origin {{baseBranch}} && git merge-base --is-ancestor
+              origin/{{baseBranch}} {{branch}}
           - name: PR raised
             type: command
-            run: gh pr list --head {{branch}} --base {{master}} --state open --json url -q
+            run: gh pr list --head {{branch}} --base {{baseBranch}} --state open --json url -q
               ".[0].url" | grep -q .
   pr-review:
     id: pr-review
@@ -778,7 +778,7 @@ workflows:
               {{goal_spec}}
 
 
-              Run `git diff origin/{{master}}...{{branch}} -- .
+              Run `git diff origin/{{baseBranch}}...{{branch}} -- .
               ':!package-lock.json'` to see the implementation diff.
 
               Read the design document content from upstream gates.
@@ -805,14 +805,14 @@ workflows:
             role: code-reviewer
             phase: 2
             prompt: >-
-              Review the code changes on branch {{branch}} vs origin/{{master}}
+              Review the code changes on branch {{branch}} vs origin/{{baseBranch}}
               for quality.
 
 
-              Start with `git diff --stat origin/{{master}}...{{branch}} -- .
+              Start with `git diff --stat origin/{{baseBranch}}...{{branch}} -- .
               ':!package-lock.json'` to see which files changed.
 
-              Then use `git diff origin/{{master}}...{{branch}} -M -- .
+              Then use `git diff origin/{{baseBranch}}...{{branch}} -M -- .
               ':!package-lock.json'` (with rename detection) to see actual
               content changes — this collapses pure renames into one-line
               summaries.
@@ -839,10 +839,10 @@ workflows:
             phase: 2
             prompt: >-
               Security review of changes on branch {{branch}} vs
-              origin/{{master}}.
+              origin/{{baseBranch}}.
 
 
-              Run `git diff origin/{{master}}...{{branch}} -- .
+              Run `git diff origin/{{baseBranch}}...{{branch}} -- .
               ':!package-lock.json'` to see changes.
 
 
@@ -998,10 +998,10 @@ workflows:
             type: llm-review
             prompt: >-
               Review documentation for the changes on branch {{branch}} vs
-              origin/{{master}}.
+              origin/{{baseBranch}}.
 
 
-              Run `git diff origin/{{master}}...{{branch}} -- .
+              Run `git diff origin/{{baseBranch}}...{{branch}} -- .
               ':!package-lock.json'` to see all changes.
 
               Read the key documentation files: AGENTS.md, README.md, and files
@@ -1119,11 +1119,11 @@ workflows:
               origin {{branch}} | grep -q .
           - name: Master merged into branch
             type: command
-            run: git fetch origin {{master}} && git merge-base --is-ancestor
-              origin/{{master}} {{branch}}
+            run: git fetch origin {{baseBranch}} && git merge-base --is-ancestor
+              origin/{{baseBranch}} {{branch}}
           - name: PR raised
             type: command
-            run: gh pr list --head {{branch}} --base {{master}} --state open --json url -q
+            run: gh pr list --head {{branch}} --base {{baseBranch}} --state open --json url -q
               ".[0].url" | grep -q .
   bug-fix:
     id: bug-fix
@@ -1222,7 +1222,7 @@ workflows:
               {{goal_spec}}
 
 
-              Run `git diff {{master}}...{{branch}} -- . ':!package-lock.json'`
+              Run `git diff {{baseBranch}}...{{branch}} -- . ':!package-lock.json'`
               to see the implementation diff.
 
 
@@ -1248,14 +1248,14 @@ workflows:
             role: code-reviewer
             phase: 2
             prompt: >-
-              Review the code changes on branch {{branch}} vs {{master}} for
+              Review the code changes on branch {{branch}} vs {{baseBranch}} for
               quality.
 
 
-              Start with `git diff --stat {{master}}...{{branch}} -- .
+              Start with `git diff --stat {{baseBranch}}...{{branch}} -- .
               ':!package-lock.json'` to see which files changed.
 
-              Then use `git diff {{master}}...{{branch}} -M -- .
+              Then use `git diff {{baseBranch}}...{{branch}} -M -- .
               ':!package-lock.json'` (with rename detection) to see actual
               content changes — this collapses pure renames into one-line
               summaries.
@@ -1289,7 +1289,7 @@ workflows:
               {{goal_spec}}
 
 
-              Run `git diff {{master}}...{{branch}} -- . ':!package-lock.json'`
+              Run `git diff {{baseBranch}}...{{branch}} -- . ':!package-lock.json'`
               to see all changes.
 
 
@@ -1319,10 +1319,10 @@ workflows:
             role: security-reviewer
             phase: 2
             prompt: >-
-              Security review of changes on branch {{branch}} vs {{master}}.
+              Security review of changes on branch {{branch}} vs {{baseBranch}}.
 
 
-              Run `git diff {{master}}...{{branch}} -- . ':!package-lock.json'`
+              Run `git diff {{baseBranch}}...{{branch}} -- . ':!package-lock.json'`
               to see changes.
 
 
@@ -1478,10 +1478,10 @@ workflows:
             type: llm-review
             prompt: >-
               Review documentation for the changes on branch {{branch}} vs
-              {{master}}.
+              {{baseBranch}}.
 
 
-              Run `git diff {{master}}...{{branch}} -- . ':!package-lock.json'`
+              Run `git diff {{baseBranch}}...{{branch}} -- . ':!package-lock.json'`
               to see all changes.
 
               Read the key documentation files: AGENTS.md, README.md, and files
@@ -1599,11 +1599,11 @@ workflows:
               origin {{branch}} | grep -q .
           - name: Master merged into branch
             type: command
-            run: git fetch origin {{master}} && git merge-base --is-ancestor
-              origin/{{master}} {{branch}}
+            run: git fetch origin {{baseBranch}} && git merge-base --is-ancestor
+              origin/{{baseBranch}} {{branch}}
           - name: PR raised
             type: command
-            run: gh pr list --head {{branch}} --base {{master}} --state open --json url -q
+            run: gh pr list --head {{branch}} --base {{baseBranch}} --state open --json url -q
               ".[0].url" | grep -q .
   quick-fix:
     id: quick-fix
@@ -1649,7 +1649,7 @@ workflows:
               {{goal_spec}}
 
 
-              Run `git diff {{master}}...{{branch}} -- . ':!package-lock.json'`
+              Run `git diff {{baseBranch}}...{{branch}} -- . ':!package-lock.json'`
               to see the implementation diff.
 
 
@@ -1676,14 +1676,14 @@ workflows:
             role: code-reviewer
             phase: 2
             prompt: >-
-              Review the code changes on branch {{branch}} vs {{master}} for
+              Review the code changes on branch {{branch}} vs {{baseBranch}} for
               quality.
 
 
-              Start with `git diff --stat {{master}}...{{branch}} -- .
+              Start with `git diff --stat {{baseBranch}}...{{branch}} -- .
               ':!package-lock.json'` to see which files changed.
 
-              Then use `git diff {{master}}...{{branch}} -M -- .
+              Then use `git diff {{baseBranch}}...{{branch}} -M -- .
               ':!package-lock.json'` (with rename detection) to see actual
               content changes — this collapses pure renames into one-line
               summaries.
@@ -1715,11 +1715,11 @@ workflows:
               origin {{branch}} | grep -q .
           - name: Master merged into branch
             type: command
-            run: git fetch origin {{master}} && git merge-base --is-ancestor
-              origin/{{master}} {{branch}}
+            run: git fetch origin {{baseBranch}} && git merge-base --is-ancestor
+              origin/{{baseBranch}} {{branch}}
           - name: PR raised
             type: command
-            run: gh pr list --head {{branch}} --base {{master}} --state open --json url -q
+            run: gh pr list --head {{branch}} --base {{baseBranch}} --state open --json url -q
               ".[0].url" | grep -q .
     createdAt: 1774734770196
     updatedAt: 1774734770196

--- a/defaults/workflow-authoring-guide.md
+++ b/defaults/workflow-authoring-guide.md
@@ -256,7 +256,7 @@ Reviewer agent. Runs against the diff between the goal's branch and master, with
   role: code-reviewer       # any registered role; default if omitted
   phase: 2
   prompt: |
-    Review the code changes on branch {{branch}} vs origin/{{master}} for quality.
+    Review the code changes on branch {{branch}} vs origin/{{baseBranch}} for quality.
 ```
 
 ### 4.3 `type: agent-qa`
@@ -291,7 +291,7 @@ Parks the gate on a deferred resolver until a human approves or rejects via the 
     Pay attention to the cancellation semantics in §3.
 ```
 
-Required: `label` (non-empty) and `prompt` (non-empty). The validator rejects the step on load otherwise. `{{branch}}`, `{{master}}`, `{{goal_spec}}`, and `{{<gate>.meta.<key>}}` are substituted before the prompt is shown to the user.
+Required: `label` (non-empty) and `prompt` (non-empty). The validator rejects the step on load otherwise. `{{branch}}`, `{{baseBranch}}` (and the legacy alias `{{master}}`), `{{goal_spec}}`, and `{{<gate>.meta.<key>}}` are substituted before the prompt is shown to the user.
 
 Behavior contract:
 
@@ -311,7 +311,8 @@ Free-form `run:` strings and `prompt:` bodies may reference:
 | Token | Meaning |
 |---|---|
 | `{{branch}}` | the goal/session branch name |
-| `{{master}}` | the project's primary branch (e.g. `master`, `main`) |
+| `{{baseBranch}}` | the bare integration branch from the project's `base_ref`, falling back to the detected primary branch (e.g. `master`/`main`) |
+| `{{master}}` | **deprecated/backwards-compat alias** — always resolves to the detected primary branch regardless of `base_ref`. Prefer `{{baseBranch}}`. |
 | `{{goal_spec}}` | full markdown of the goal spec |
 | `{{agent.<key>}}` | metadata supplied by the signaling agent |
 | `{{<gate_id>.meta.<key>}}` | metadata from a passed upstream gate |
@@ -425,7 +426,7 @@ workflows:
           - { name: "Check bobbit", type: command, phase: 1, component: "bobbit", command: "check" }
           - { name: "Unit bobbit",  type: command, phase: 1, component: "bobbit", command: "unit" }
           - { name: "E2E bobbit",   type: command, phase: 1, component: "bobbit", command: "e2e", timeout: 900 }
-          - { name: "Code quality review", type: llm-review, role: code-reviewer, phase: 2, prompt: "Review the code changes on branch {{branch}} vs origin/{{master}} for quality." }
+          - { name: "Code quality review", type: llm-review, role: code-reviewer, phase: 2, prompt: "Review the code changes on branch {{branch}} vs origin/{{baseBranch}} for quality." }
 
       - id: documentation
         name: Documentation
@@ -438,8 +439,8 @@ workflows:
         depends_on: [documentation]
         verify:
           - { name: "Branch pushed to remote",   type: command, run: "git push origin {{branch}}:refs/heads/{{branch}} && git ls-remote --heads origin {{branch}} | grep -q ." }
-          - { name: "Master merged into branch", type: command, run: "git fetch origin {{master}} && git merge-base --is-ancestor origin/{{master}} {{branch}}" }
-          - { name: "PR raised",                 type: command, run: "gh pr list --head {{branch}} --base {{master}} --state open --json url -q \".[0].url\" | grep -q ." }
+          - { name: "Base ref merged into branch", type: command, run: "git fetch origin {{baseBranch}} && git merge-base --is-ancestor origin/{{baseBranch}} {{branch}}" }
+          - { name: "PR raised",                 type: command, run: "gh pr list --head {{branch}} --base {{baseBranch}} --state open --json url -q \".[0].url\" | grep -q ." }
 ```
 
 ### 7.2 Multi-repo (api + web + shared data-only)

--- a/docs/design/multi-repo-components.md
+++ b/docs/design/multi-repo-components.md
@@ -228,7 +228,7 @@ Surface the warning in the project assistant chat and in Settings → project ta
    - `type: llm-review` — `role`, `prompt`, `phase`, `expect`, `optional`, `optionalLabel`, `description`, `timeout`.
    - `type: agent-qa` — same plus implicit dependency on project-level `qa_*` fields.
    - `type: human-signoff` — `label` (sign-off card title), `prompt`, `phase`, `role`, `optional`, `optionalLabel`, `description`; no timeout.
-5. **Runtime context tokens:** `{{branch}}`, `{{master}}`, `{{goal_spec}}`, `{{agent.<key>}}`, `{{<gate_id>.meta.<key>}}`. **No `{{project.<key>}}`** (replaced by structural references).
+5. **Runtime context tokens:** `{{branch}}`, `{{baseBranch}}` (`{{master}}` remains valid as a legacy alias), `{{goal_spec}}`, `{{agent.<key>}}`, `{{<gate_id>.meta.<key>}}`. **No `{{project.<key>}}`** (replaced by structural references).
 6. **Pattern library** — typical gates per workflow style: general / feature / bug-fix / quick-fix / pr-review. The bobbit appendix in the goal spec is reproduced as a worked single-repo example; multi-repo and monorepo worked examples follow the same shape.
 7. **Anti-patterns:** literal shell strings instead of structural refs; copy-paste of step bodies; over-broad `expect: failure`.
 
@@ -353,7 +353,7 @@ Rules:
   - `command` step with `command` and no `component` → reject.
   - `command` step with neither `command` nor `run` → reject.
   - `command`/`component` pair where component or command name is unknown → reject (with "did you mean" suggestion via Levenshtein on the available set).
-- Free-form `run:` strings and `prompt:` strings → **not** validated for tokens. Runtime context tokens (`{{branch}}`, `{{master}}`, `{{goal_spec}}`, `{{agent.x}}`, `{{<gate>.meta.x}}`) pass through to `verification-logic.ts::substituteVars`. Anything else fails at shell-time as a typo. (Acceptance criterion 6.)
+- Free-form `run:` strings and `prompt:` strings → **not** validated for tokens. Runtime context tokens (`{{branch}}`, `{{baseBranch}}`, `{{goal_spec}}`, `{{agent.x}}`, `{{<gate>.meta.x}}`; `{{master}}` is still accepted as a legacy alias) pass through to `verification-logic.ts::substituteVars`. Anything else fails at shell-time as a typo. (Acceptance criterion 6.)
 - `optional` step requires `optionalLabel` (legacy non-human `label` is migrated on load and saved canonically).
 - `agent-qa` step requires the project to have `qa_start_command` configured (warn, don't reject — runtime already returns "QA not configured").
 
@@ -395,7 +395,7 @@ Audit performed by reading every `defaults/workflows/*.yaml`, `workflow-store.ts
 | 14 | Step `timeout:` (seconds) | build/E2E steps | Unchanged | `step-timeout.spec.ts` |
 | 15 | Step `phase:` (parallel grouping) | many | Unchanged | `phased-verification.spec.ts` (existing) |
 | 16 | Step `optional: true` + `optionalLabel` + `description` | feature/bug-fix QA testing | `optionalLabel` is canonical for goal-creation toggles; legacy non-human `label` is migrated on load/save. `label` is reserved for human-signoff card titles. | `optional-step-toggle.spec.ts` (existing) |
-| 17 | `{{branch}}` / `{{master}}` runtime tokens | many | Unchanged in `run:` and `prompt:` | `template-vars.spec.ts` (existing) |
+| 17 | `{{branch}}` / `{{baseBranch}}` runtime tokens (`{{master}}` still valid as legacy alias) | many | Unchanged in `run:` and `prompt:` | `template-vars.spec.ts` (existing) |
 | 18 | `{{goal_spec}}` injection | many | Unchanged | existing |
 | 19 | `{{agent.X}}` from signal metadata | bug-fix `{{agent.test_command}}` | Unchanged | existing |
 | 20 | `{{gate_id.meta.key}}` from upstream gates | bug-fix `{{reproducing-test.meta.test_command}}` | Unchanged | existing |

--- a/docs/goals-workflows-tasks.md
+++ b/docs/goals-workflows-tasks.md
@@ -161,7 +161,7 @@ workflows:
           - { name: "Build myapp", type: command, component: "myapp", command: "build" }
           # Component-linked, free-form shell (cwd derived from component):
           - { name: "Custom thing", type: command, component: "myapp", run: "./scripts/special.sh" }
-          - { name: "Code review", type: llm-review, phase: 1, prompt: "Review the changes on {{branch}} vs origin/{{master}}." }
+          - { name: "Code review", type: llm-review, phase: 1, prompt: "Review the changes on {{branch}} vs origin/{{baseBranch}}." }
 
       - id: ready-to-merge
         name: Ready to Merge
@@ -180,7 +180,7 @@ workflows:
 - `component:` referencing an unknown component name
 - a `(component, command)` pair where the component has no such command name
 
-The validator does **not** reject template tokens in free-form `run:` or `prompt:` strings. Runtime context tokens (`{{branch}}`, `{{master}}`, `{{goal_spec}}`, `{{goal_title}}`, etc.) are necessary for workflows to function and are substituted by the gate runner before each step executes. Any other tokens (e.g. a stale `{{project.foo}}` left from a hand edit) just pass through to the shell as literal strings and fail at runtime the same way any other typo would.
+The validator does **not** reject template tokens in free-form `run:` or `prompt:` strings. Runtime context tokens (`{{branch}}`, `{{baseBranch}}`, `{{goal_spec}}`, `{{goal_title}}`, etc. — `{{master}}` is still accepted as a legacy alias) are necessary for workflows to function and are substituted by the gate runner before each step executes. Any other tokens (e.g. a stale `{{project.foo}}` left from a hand edit) just pass through to the shell as literal strings and fail at runtime the same way any other typo would.
 
 #### Workflow editor authoring
 
@@ -557,7 +557,7 @@ verify:
       Review the design doc for {{branch}} and approve or reject.
 ```
 
-Both `label` and `prompt` are required (the validator rejects the step on load otherwise). `{{branch}}`, `{{master}}`, `{{goal_spec}}`, and `{{<gate>.meta.<key>}}` tokens are substituted before the prompt is shown to the user — same machinery as the other step types.
+Both `label` and `prompt` are required (the validator rejects the step on load otherwise). `{{branch}}`, `{{baseBranch}}`, `{{goal_spec}}`, and `{{<gate>.meta.<key>}}` tokens (`{{master}}` remains valid as a legacy alias) are substituted before the prompt is shown to the user — same machinery as the other step types.
 
 **Lifecycle.** When the harness reaches the step it broadcasts `gate_verification_awaiting_human` (see [websocket-protocol.md](websocket-protocol.md)), sets `awaitingHuman: true` on the active step, persists, and `await`s a deferred resolver. The chat-header `<goal-status-widget>` (mounted on any session with a goal id) surfaces the pending request and its **View content** action opens the submitted gate content in the review pane. The review pane owns inline comments, final comment, Approve / Reject validation, and decision submission. The browser POSTs to `/api/goals/:id/gates/:gateId/signoff` with `{ signalId, stepName, decision, feedback? }`; the harness builds a step result (passed = `decision === "pass"`; `output` and a `text/markdown` artifact carry the composed final/inline feedback when present) and the gate completes through the standard phase machinery. See [Review Pane Sign-Off](review-pane-signoff.md) for the review-source model, validation rules, persistence, and sanitization constraints.
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -549,7 +549,7 @@ The **multi-repo invariant** - every configured repo is checked out as a sibling
 
 Free-form `{ run }` steps that need a different working directory use `cd ... && ...` inside the `run` string. This keeps the schema small and the working-dir rule unambiguous: it is structurally derived from the component, or it is the per-branch container root.
 
-`llm-review` and `agent-qa` step shapes are unchanged - they keep their `prompt:` body and runtime context tokens (`{{branch}}`, `{{master}}`, `{{goal_spec}}`) which are substituted by the gate runner before execution. `agent-qa` additionally carries an optional `component:` field that selects which component's `config:` map the `/qa-test` skill reads (and which workspace to start). When omitted, the verification harness falls back to the first component whose `config.qa_start_command` is set, then to a name-match against the project, then to `components[0]`.
+`llm-review` and `agent-qa` step shapes are unchanged - they keep their `prompt:` body and runtime context tokens (`{{branch}}`, `{{baseBranch}}`, `{{goal_spec}}`; `{{master}}` is still accepted as a legacy alias) which are substituted by the gate runner before execution. `agent-qa` additionally carries an optional `component:` field that selects which component's `config:` map the `/qa-test` skill reads (and which workspace to start). When omitted, the verification harness falls back to the first component whose `config.qa_start_command` is set, then to a name-match against the project, then to `components[0]`.
 
 The workflow validator (`workflow-validator.ts`) rejects, at load time:
 

--- a/scripts/qa-seed/seed.mjs
+++ b/scripts/qa-seed/seed.mjs
@@ -149,7 +149,7 @@ const frozenWorkflow = {
 				{
 					name: "Master merged into branch",
 					type: "command",
-					run: "git fetch origin {{master}}",
+					run: "git fetch origin {{baseBranch}}",
 				},
 				{
 					name: "PR raised",

--- a/src/app/workflow-page.ts
+++ b/src/app/workflow-page.ts
@@ -1042,7 +1042,7 @@ function renderVerifyStepEditor(inst: EditorInstance, gate: WorkflowGate, gateId
 								?disabled=${readOnly}
 								@click=${(e: Event) => e.stopPropagation()}
 								@input=${(e: Event) => updateStep({ run: (e.target as HTMLInputElement).value })} />
-							${readOnly ? nothing : html`<div class="wf-field-hint">Variables: {{branch}}, {{master}}, {{cwd}}, {{project.key}}, {{agent.key}}, {{gate_id.meta.key}}</div>`}
+							${readOnly ? nothing : html`<div class="wf-field-hint" data-testid="wf-step-run-hint">Variables: {{branch}}, {{baseBranch}}, {{cwd}}, {{project.key}}, {{agent.key}}, {{gate_id.meta.key}}</div>`}
 							${errs.run ? html`<div class="wf-field-error" data-testid="wf-step-run-error">${errs.run}</div>` : nothing}
 						` : html`
 							<input class="wf-input ${errs.command ? "wf-input-error" : ""}" data-testid="wf-step-command" .value=${step.command || ""} placeholder="Named command (e.g. build, unit)"

--- a/src/server/skills/git.ts
+++ b/src/server/skills/git.ts
@@ -91,7 +91,8 @@ export function stripTokenFromGitUrl(url: string): string {
  *
  * Unlike `resolveRemotePrimary` (which returns the ref with `origin/` prefix),
  * this returns the bare branch name suitable for substituting into prompt
- * templates as `{{master}}`.
+ * templates as `{{baseBranch}}` (the legacy alias `{{master}}` resolves through
+ * here too).
  */
 export async function detectPrimaryBranch(cwd: string): Promise<string> {
 	try {

--- a/src/server/state-migration/seed-default-workflows.ts
+++ b/src/server/state-migration/seed-default-workflows.ts
@@ -214,7 +214,7 @@ Pass if every criterion is verbatim-covered. Fail with the list of uncovered cri
 /** Integration LLM-review prompt — once children have merged, does the integrated whole make sense? */
 export const INTEGRATION_PROMPT = `Review the cross-component integration after all subgoals have merged.
 
-Run \`git diff origin/{{master}}...HEAD\` to see the cumulative result on the parent branch.
+Run \`git diff origin/{{baseBranch}}...HEAD\` to see the cumulative result on the parent branch.
 
 Verify:
 1. Subgoal merges play together — no accidental regressions where one subgoal silently broke another.

--- a/tests/e2e/ui/workflow-editor.spec.ts
+++ b/tests/e2e/ui/workflow-editor.spec.ts
@@ -331,6 +331,41 @@ test.describe("Workflow editor UI/YAML parity @smoke", () => {
 		await apiFetch(`/api/workflows/${wfId}?projectId=${encodeURIComponent(projectId)}`, { method: "DELETE" }).catch(() => {});
 	});
 
+	test("free-form command run hint advertises {{baseBranch}} and not {{master}}, persists, and clears on type switch", async ({ page }) => {
+		const wfId = "run-hint-" + Date.now();
+		await gotoNewEditor(page, wfId, [{
+			id: "g1", name: "Gate", depends_on: [],
+			verify: [{ name: "Step", type: "command", run: "echo x" }],
+		}]);
+		await expandFirstGate(page);
+		await expandFirstStep(page);
+
+		// Hint advertises {{baseBranch}}, not the legacy {{master}} alias.
+		const hint = page.locator("[data-testid='wf-step-run-hint']").first();
+		await expect(hint).toBeVisible({ timeout: 5_000 });
+		await expect(hint).toContainText("{{baseBranch}}");
+		expect(await hint.textContent()).not.toContain("{{master}}");
+
+		// Persistence across reload — re-open the editor and re-expand the step.
+		await openWorkflowEditor(page, wfId);
+		await expandFirstGate(page);
+		// Gate body re-renders after reload; wait for the step card before expanding.
+		await expect(page.locator("[data-testid='wf-vstep-card']").first()).toBeVisible({ timeout: 10_000 });
+		await expandFirstStep(page);
+		const hintAfterReload = page.locator("[data-testid='wf-step-run-hint']").first();
+		await expect(hintAfterReload).toBeVisible({ timeout: 5_000 });
+		await expect(hintAfterReload).toContainText("{{baseBranch}}");
+		expect(await hintAfterReload.textContent()).not.toContain("{{master}}");
+
+		// Cleanup: switching away from `command` removes the run field and its hint.
+		await page.locator("[data-testid='wf-step-type']").first().selectOption("human-signoff");
+		await expect(page.locator("[data-testid='wf-step-type']").first()).toHaveValue("human-signoff");
+		await expect(page.locator("[data-testid='wf-step-run']")).toHaveCount(0);
+		await expect(page.locator("[data-testid='wf-step-run-hint']")).toHaveCount(0);
+
+		await apiFetch(`/api/workflows/${wfId}?projectId=${encodeURIComponent(projectId)}`, { method: "DELETE" }).catch(() => {});
+	});
+
 	test("gate-level fields round-trip: optional, manual, metadata", async ({ page }) => {
 		const wfId = "gate-fields-" + Date.now();
 		await gotoNewEditor(page, wfId, [{

--- a/tests/ui-fixtures/goal-workflow-editor.spec.ts
+++ b/tests/ui-fixtures/goal-workflow-editor.spec.ts
@@ -93,6 +93,19 @@ test.describe("Goal/workflow editor fixture", () => {
 		await expect(stepBody.locator("select.wf-select")).toHaveCount(1);
 	});
 
+	test("free-form command run hint advertises {{baseBranch}} and not {{master}}", async ({ page }) => {
+		await loadWorkflow(page, workflowWithSteps([
+			{ name: "Run step", type: "command", run: "echo test", phase: 0 },
+		]));
+		await expandFirstGate(page);
+		await expandStep(page, "Run step");
+
+		const hint = page.locator("[data-testid='wf-step-run-hint']").first();
+		await expect(hint).toBeVisible({ timeout: 5_000 });
+		await expect(hint).toContainText("{{baseBranch}}");
+		expect(await hint.textContent()).not.toContain("{{master}}");
+	});
+
 	test("phase grouping renders headers and defaults missing phase to phase 0", async ({ page }) => {
 		await loadWorkflow(page, workflowWithSteps([
 			{ name: "No phase step", type: "command", run: "echo default" },


### PR DESCRIPTION
## Summary

Migrates every *generative* `{{master}}` workflow-template reference to `{{baseBranch}}` (the correct integration target derived from the project's `base_ref`, falling back to the detected primary branch), while keeping `{{master}}` a fully-resolvable backwards-compat alias forever.

Previously, role prompts, default/reference workflows, the live project workflows, and the workflow UI all advertised `{{master}}` — which always resolves via `detectPrimaryBranch()` and ignores `base_ref`. This caused project assistants to keep generating workflows that silently ignore `base_ref`.

## Changes

**Generative sources migrated to `{{baseBranch}}`:**
- `defaults/workflow-authoring-guide.md` — `llm-review` + ready-to-merge `run:` examples, token table (now leads with `{{baseBranch}}`; `{{master}}` documented as a deprecated alias), prose substitution lists.
- `src/server/state-migration/seed-default-workflows.ts` — `INTEGRATION_PROMPT` diff command.
- `scripts/qa-seed/seed.mjs` — fetch step.
- `.bobbit/config/project.yaml` — all 42 occurrences in workflow `run:`/`prompt:` strings (preserving `origin/` prefixes).
- `src/app/workflow-page.ts` — `wf-field-hint` now advertises `{{baseBranch}}`; added `data-testid="wf-step-run-hint"`.
- `src/server/skills/git.ts` — `detectPrimaryBranch` doc comment reworded (comment-only).
- `docs/` — `goals-workflows-tasks.md`, `internals.md`, `design/multi-repo-components.md` now lead with `{{baseBranch}}`, keeping `{{master}}` as a documented legacy alias.

**Backwards compatibility preserved:**
- The `{{master}}` resolver in `verification-logic.ts` / `verification-harness.ts` is untouched — `{{master}}` still resolves to the detected primary branch.
- All `{{master}}` pinning tests pass unchanged.

## Tests
- `tests/ui-fixtures/goal-workflow-editor.spec.ts` — unit pin: the run-field hint advertises `{{baseBranch}}`, not `{{master}}`.
- `tests/e2e/ui/workflow-editor.spec.ts` — browser E2E: hint visibility, persistence across reload, cleanup on step type-switch.

## Verification
- `rg "{{master}}"` over `defaults/`, `src/`, `scripts/qa-seed/`, `.bobbit/config/project.yaml` returns only intentional backwards-compat mentions (the resolver doc comments + legacy-alias framing).
- `npm run check` and `npm run test:unit` pass; E2E passes.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)