### PR TITLE
Fix Windows bash_bg not surviving dev-harness restart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,7 @@ npm run restart-server # Rebuild & restart after server changes
 npm run check          # Type-check server + web (no emit)
 npm run test:unit      # Unit phase — node:test logic + file:// browser fixtures, run concurrently (~90s)
 npm run test:e2e       # E2E phase — API (in-process) + browser (spawned gateway)
-npm run test:manual    # Manual integration — real agents/LLM + Docker (~5 min); ONLY gate-exempt path
-SCREENSHOTS=1 npm run test:manual  # + browser screenshots + HTML report
+npm run test:manual    # Manual integration — real agents/LLM + Docker (~5 min); ONLY gate-exempt path (SCREENSHOTS=1 adds screenshots + HTML report)
 ```
 
 UI changes (`src/ui/`, `src/app/`) hot-reload under `npm run dev:harness`. Server changes (`src/server/`) require `npm run restart-server`. Always `npm run check` before restarting. Sessions survive restarts via `.bobbit/state/sessions.json`.
@@ -23,7 +22,7 @@ Where things live. Use this to orient, then `rg` for the symbol.
 - **Agent runtime**: `src/server/agent/` — sessions, manager, status, steer, respawn, store, project context. `bash_bg` processes persist + re-attach across restart via `bg-process-{manager,store,runner}.ts`; state under `<stateDir>/bg-processes/`. See [docs/bg-process-persistence.md](docs/bg-process-persistence.md).
 - **MCP / tools**: `src/server/mcp/`, `defaults/tools/<group>/` (project overrides under `.bobbit/config/tools/<group>/`). Tool descriptions are budget-pinned by `tests/tool-description-budget.test.ts`.
 - **Skills**: `.claude/skills/<name>/SKILL.md`.
-- **Roles/tools/skills resolution**: unified `PackResolver` over one ordered pack list in `src/server/agent/pack-*.ts`; `config-cascade.ts` + `slash-skills.ts` are adapters. Built-in first-party packs live in `market-packs/`, shipped via `scripts/copy-builtin-packs.mjs` and resolved in place by `builtin-packs.ts`. See [docs/marketplace.md](docs/marketplace.md).
+- **Roles/tools/skills resolution**: unified `PackResolver` over one ordered pack list in `src/server/agent/pack-*.ts`; built-in packs in `market-packs/`. See [docs/marketplace.md](docs/marketplace.md).
 - **UI shell**: `src/app/` — state, render, message-reducer, dialogs, follow-tail.
 - **UI components**: `src/ui/` — components, `tools/renderers/`, `lazy/`.
 - **Tests**: `tests/` (unit), `tests/e2e/` (API), `tests/e2e/ui/` (browser), `tests/manual-integration/` (real agents + Docker).

--- a/docs/bg-process-persistence.md
+++ b/docs/bg-process-persistence.md
@@ -100,10 +100,22 @@ re-attachable — there is no non-persistent host path:
 
 - **POSIX shell wrapper (primary)** — Git Bash on Windows, `/bin/sh` on
   Linux/macOS, and `/bin/sh` inside docker. A single `sh -c` string that writes
-  the pidfile (`$$` + nonce), launches a wrapper-owned background trimmer that
-  bounds both spools, runs the isolated subshell appending (`>>`) to the spools,
-  then writes the real exit code to the status file. Built by `buildHostWrapper`
-  / `buildDockerWrapper`.
+  the pidfile (a **Windows-usable pid** + nonce — see below), launches a
+  wrapper-owned background trimmer that bounds both spools, runs the isolated
+  subshell appending (`>>`) to the spools, then writes the real exit code to the
+  status file. Built by `buildHostWrapper` / `buildDockerWrapper`.
+
+  **Windows-usable pid in the pidfile.** The pidfile's pid line is
+  `$(cat /proc/$$/winpid 2>/dev/null || echo $$)`, not bare `$$`. On MSYS / Git
+  Bash `$$` is the **MSYS-internal** pid, which is *not* a Windows pid the
+  gateway can signal (empirically `$$`=1105 while `/proc/$$/winpid`=17172 for the
+  same shell); `/proc/$$/winpid` yields the real Windows pid. Off Windows
+  (Linux/macOS) `/proc/$$/winpid` does not exist, so `cat` fails and the line
+  falls back to `$$` — which already *is* the real pid there, making the pidfile
+  content byte-for-byte identical off-Windows (no behaviour change). This matters
+  because the host restore path reconciles `processPid` from this pidfile (see
+  [`processPid` vs `hostPid`](#processpid-vs-hostpid)) so liveness checks and
+  kills target the signalable pid.
 - **Node `bg-runner` helper (Windows without Git Bash)** — `bg-runner.ts`, spawned
   detached via `process.execPath`. On a Windows host with no Git for Windows,
   `cmd.exe` can't run the POSIX wrapper, so rather than degrade to a
@@ -131,12 +143,28 @@ Two pids are persisted because they differ for docker:
 - **`hostPid`** — the host-side `child.pid`. For docker this is the `docker exec`
   handle, valid only while the original gateway lives; **never** used for
   liveness or kill after a restart.
-- **`processPid`** — the signalable wrapper pid in its own namespace. On host it
-  equals `child.pid`; for docker it is the in-container wrapper pid, read back
-  from the pidfile after spawn (via `docker exec cat <containerPid>`). Liveness
-  checks and kills always target `processPid`. It is `0` until resolved (docker
-  resolves it synchronously at create time with a bounded retry, and again on
-  restore if needed).
+- **`processPid`** — the signalable wrapper pid in its own namespace. For docker
+  it is the in-container wrapper pid, read back from the pidfile after spawn (via
+  `docker exec cat <containerPid>`). On host the spawn-time value is `child.pid`
+  (the top-level wrapper pid), but **on restore the host path re-reads the
+  pidfile and adopts the pid the wrapper published** — see below. Liveness checks
+  and kills always target `processPid`. It is `0` until resolved (docker resolves
+  it synchronously at create time with a bounded retry, and again on restore if
+  needed).
+
+**Host `processPid` reconciliation (Windows + Git Bash).** On Windows the
+spawn-time `child.pid` is the OS pid of the top-level `bash.exe`, which can
+*differ* from the Windows pid the wrapper publishes via `/proc/$$/winpid` (the
+wrapper resolves its own winpid from inside MSYS). So `restoreSession` reconciles
+the host `processPid` the same way the docker path does: for a non-container
+record it re-reads the nonce-checked pidfile **before** the liveness check, and
+if the pidfile pid is valid, its nonce matches the record, and it differs from
+the persisted `processPid`, it adopts the pidfile pid (and persists it). This
+runs before `isHostPidAlive` / `taskkill` so both target the correct signalable
+pid. On Linux/macOS the pidfile pid equals `child.pid`, so the reconciliation is
+a no-op. The nonce pid-reuse guard is unchanged — a *mismatched* nonce is never
+adopted (it still resolves to unrecoverable/killed) and no pid is ever
+fabricated.
 
 ## Restore reconciliation — the three cases
 
@@ -173,6 +201,29 @@ file and the persisted `processPid` is alive, the gateway re-reads the pidfile
 and compares its per-spawn `nonce` against the record. Match → genuinely our
 process → re-attach. Missing/mismatched nonce → the live pid is foreign
 (reused) → unrecoverable. This is why every spawn mechanism writes a nonce.
+
+### Dev restart harness must not tree-kill (Windows)
+
+Re-attach only works if the detached bg children **outlive the gateway** across
+a restart. The dev restart harness (`src/server/harness.ts`) used to force-kill
+the gateway on Windows with `taskkill /pid <pid> /T /F`. The `/T` walks the
+gateway's child-process tree by parent→child pid linkage and kills *every*
+descendant — including the detached `bash.exe` wrappers running `bash_bg`
+commands. On Windows `detached: true` only creates a new process *group*; it does
+**not** sever the parent-pid linkage, so `/T` still found and euthanized those
+wrappers, and `/F` denied them the chance to flush their `.status`. The next
+boot then found a dead `processPid` and no status snapshot, so restore correctly
+classified the record `unrecoverable` — the persistence layer reporting the
+truth while the harness quietly killed the children it was meant to let survive.
+
+The fix lives in `src/server/harness-kill.ts`: `windowsGatewayKillArgs(pid)`
+returns `taskkill /pid <pid> /F` — **no `/T`**. Force-killing only the gateway
+process still reliably frees the port, while the detached + unref'd wrappers
+survive, keep writing their spools while the gateway is down, and write
+`.status` on natural exit — so restore re-attaches a still-running process or
+reads the real exit code of one that finished during downtime. This was a
+harness-local defect: a normal (non-harness) gateway shutdown already let bg
+children survive, because it does not tree-kill.
 
 ## Kill vs dismiss
 

--- a/docs/design/persistent-bg-processes.md
+++ b/docs/design/persistent-bg-processes.md
@@ -265,8 +265,12 @@ Immediately after `spawnFn` returns, and **before the process is reported as cre
 resolves the signalable wrapper pid (`processPid`) and sync-flushes it to disk — this is
 recovery-critical because restore, liveness, and post-restart kill all target `processPid`:
 
-- **Host:** read the `<pid>` pidfile written by the wrapper (`$$`/pid-write), or fall back to
-  `child.pid`; for host these coincide. `hostPid = child.pid`.
+- **Host:** `hostPid = child.pid` (the top-level wrapper pid). The wrapper also writes a pidfile
+  carrying a **Windows-usable pid** (`/proc/$$/winpid` on MSYS, `$$` elsewhere — §4.1) plus the
+  nonce. On Linux/macOS the pidfile pid equals `child.pid`; on Windows + Git Bash it can differ
+  (`child.pid` is the OS pid of `bash.exe`, the pidfile carries the MSYS-resolved winpid). The host
+  `processPid` is reconciled **from this pidfile on restore** (§7.1), analogous to the docker path,
+  so liveness/kill target the signalable pid.
 - **Docker:** the in-container wrapper pid is **not** `child.pid` (that is the host-side `docker
   exec` handle, valid only while the original gateway lives). Read it via
   `docker exec <cid> cat <containerPid>`, **retrying briefly** (the wrapper writes the pidfile
@@ -295,7 +299,7 @@ only exits the subshell and the wrapper still captures the real `code=$?`; (4) a
 to the spools; (5) stops the trimmer and writes the real exit code to the status file:
 
 ```sh
-printf '%s\n%s\n' "$$" "<nonce>" > "<pid>"
+printf '%s\n%s\n' "$(cat /proc/$$/winpid 2>/dev/null || echo $$)" "<nonce>" > "<pid>"
 # wrapper-owned trimmer: bounds each spool to <KEEP> bytes, restart-independent
 ( while kill -0 "$$" 2>/dev/null; do
     for f in "<outSpool>" "<errSpool>"; do
@@ -312,6 +316,16 @@ kill "$trimmer" 2>/dev/null
 printf '%s\n' "$code" > "<status>"
 exit "$code"
 ```
+
+**Why the pidfile publishes `/proc/$$/winpid`, not bare `$$`.** On MSYS / Git Bash `$$` is the
+**MSYS-internal** pid, which is *not* a Windows pid the gateway can signal (empirically `$$`=1105 vs
+`/proc/$$/winpid`=17172 for the same shell). `/proc/$$/winpid` yields the real Windows pid. Off
+Windows `/proc/$$/winpid` does not exist, so `cat` fails and the expression falls back to `$$` —
+which already *is* the real pid there, so the pidfile content is **byte-for-byte identical**
+off-Windows (no behaviour change). The host restore path reconciles `processPid` from this pidfile
+(§4.0/§7.1) so `isHostPidAlive` / `taskkill` target the signalable pid. The trimmer loop keeps
+using `$$` for `kill -0 "$$"` — that is a same-shell self-liveness check inside MSYS, where the
+MSYS pid is correct. (The kill-trigger `$?`/subshell semantics are unchanged.)
 
 (The manager builds this single-string form by joining the lines with `;`/`&` as needed; it is
 shown multi-line for readability. `<KEEP>` = `MAX_LOG_BYTES` = 512KB is the retained tail; the
@@ -391,7 +405,7 @@ append to both spools, and the real `code=$?` written to the status file — and
 
 ```sh
 mkdir -p "<dir>"
-printf '%s\n%s\n' "$$" "<nonce>" > "<pid>"
+printf '%s\n%s\n' "$(cat /proc/$$/winpid 2>/dev/null || echo $$)" "<nonce>" > "<pid>"
 ( while kill -0 "$$" 2>/dev/null; do
     for f in "<outSpool>" "<errSpool>"; do
       if [ -f "$f" ] && [ "$(wc -c < "$f" 2>/dev/null || echo 0)" -gt <MAX_LOG_BYTES> ]; then
@@ -408,7 +422,11 @@ printf '%s\n' "$code" > "<status>"
 exit "$code"
 ```
 
-(joined into the single `-c` string by the builder; shown multi-line for readability. `<KEEP>` =
+(joined into the single `-c` string by the builder; shown multi-line for readability. Both the host
+and docker wrappers share one builder (`buildPosixWrapper`), so the pidfile line is identical —
+`$(cat /proc/$$/winpid 2>/dev/null || echo $$)`. Inside a Linux container `/proc/$$/winpid` does not
+exist, so it falls back to the in-container `$$` (the correct in-container wrapper pid), exactly as
+before the winpid change; the winpid path only ever fires on a Windows host. `<KEEP>` =
 `MAX_LOG_BYTES` = 512KB. For docker `<outSpool>`/`<errSpool>` = `containerOutSpool`/
 `containerErrSpool`, `<status>` = `containerStatus`, `<pid>` = `containerPid` — all container-internal
 under `/tmp/bobbit-bg/...`. The gateway tails these via `docker exec` and **mirrors** observed bytes
@@ -472,8 +490,11 @@ export interface PersistedBgProcess {
   /** host-side child.pid; for docker this is the `docker exec` handle pid — valid ONLY while the
    *  original gateway lives, NOT usable after restart. Liveness/kill must NOT use this. */
   hostPid: number;
-  /** the signalable wrapper pid in its OWN namespace — host: equals child.pid; docker: the
-   *  in-container wrapper pid read from the pidfile post-spawn. Liveness/kill use THIS. 0 = pending. */
+  /** the signalable wrapper pid in its OWN namespace. host: spawn-time child.pid, but RECONCILED
+   *  from the (nonce-checked) pidfile on restore — on Windows+Git Bash the wrapper publishes a
+   *  Windows-usable winpid (/proc/$$/winpid) that can differ from child.pid; on Linux/macOS they
+   *  coincide. docker: the in-container wrapper pid read from the pidfile post-spawn. Liveness/kill
+   *  use THIS. 0 = pending. */
   processPid: number;
   cwd: string;
   containerId?: string;       // present for sandboxed/docker spawns
@@ -753,8 +774,15 @@ if status == "running":
 
 ### 7.1 Liveness checks
 
-- **Host:** `process.kill(processPid, 0)` — throws ESRCH if gone, returns if alive (host
-  `processPid` equals `child.pid`). **Pid-reuse guard (nonce):** if the status file exists, the
+- **Host:** **first reconcile `processPid` from the pidfile** (analogous to the docker path): for a
+  non-container record, re-read the nonce-checked pidfile **before** the liveness check; if the
+  pidfile pid is valid, its nonce matches the record, and it differs from the persisted
+  `processPid`, adopt the pidfile pid and persist it. This matters on Windows + Git Bash where the
+  spawn-time `child.pid` (the OS pid of `bash.exe`) can differ from the Windows-usable pid the
+  wrapper published via `/proc/$$/winpid` (§4.1); on Linux/macOS the two coincide so it is a no-op.
+  A **mismatched** nonce is never adopted here — that is true pid reuse, handled by the post-liveness
+  guard below — and no pid is ever fabricated. Then `process.kill(processPid, 0)` — throws ESRCH if
+  gone, returns if alive. **Pid-reuse guard (nonce):** if the status file exists, the
   process already finished → treat as COMPLETED regardless of pid liveness (a reused pid can't
   retroactively un-write the status file). If the status file is absent and `kill(processPid,0)`
   succeeds, **re-read the pidfile and compare its nonce** against the persisted `nonce`:
@@ -992,6 +1020,7 @@ tailers poll detect delta -> read spool bytes -> appendLog() [combined interleav
 boot: restoreSessions() loops sessions; per session containerId re-resolved
   -> bgMgr.restoreSession(sessionId):            # store = storeProvider(sessionId) (this session's store)
   for each PersistedBgProcess of that session:                       # liveness/kill target processPid (NOT hostPid)
+    HOST records: reconcile processPid from the (nonce-checked) pidfile BEFORE liveness  # Windows winpid != child.pid
     running + alive(processPid + nonce match) -> rehydrate; read bounded tail of BOTH spools -> combined projection;
                                       copytruncate spools; tailers.start(newOffsets); statusWatcher.start()  (terminalReason stays null)
     running + completed            -> read <status> exitCode; bounded spool tails -> combined projection;
@@ -1092,6 +1121,35 @@ Dismiss: delete HOST <bgId>.log + <bgId>.status; best-effort docker exec rm -f t
   **`terminalReason="killed"`** — we *know* it was killed, which is not fabrication. This is
   distinct from the restart-loss case (`terminalReason="unrecoverable"`). If the wrapper *did* get
   to write the status file, `terminalReason="normal"` with the real code instead.
+- **Dev restart harness tree-kill (Windows) — the primary restart-survival bug.** The dev restart
+  harness (`src/server/harness.ts`) force-kills the gateway on Windows. It used to use
+  `taskkill /pid <pid> /T /F`; the `/T` walks the gateway's child-process tree by parent→child pid
+  linkage and kills **every** descendant — including the detached `bash.exe` wrappers running
+  `bash_bg` commands. On Windows `detached: true` only creates a new process *group*; it does **not**
+  sever the parent-pid linkage, so `/T` still found and euthanized those wrappers, and `/F` denied
+  them the chance to flush their `.status`. The next boot then found a dead `processPid` and no
+  status snapshot, so restore **correctly** classified the record `unrecoverable` — the persistence
+  layer reporting the truth while the harness silently killed the very children it was meant to let
+  survive. **Fix:** `src/server/harness-kill.ts` exports `windowsGatewayKillArgs(pid)` →
+  `taskkill /pid <pid> /F` (**no `/T`**); `harness.ts::killServer()` uses it. Force-killing only the
+  gateway pid still reliably frees the port, while the detached + unref'd wrappers survive, keep
+  writing their spools while the gateway is down, and write `.status` on natural exit — so restore
+  re-attaches a still-running process or reads the real exit code of one that finished during
+  downtime. This was a **harness-local** defect: a normal (non-harness) gateway shutdown does not
+  tree-kill, so bg children already survived it. `harness-kill.ts` is a pure, side-effect-free module
+  (importing it launches nothing) so the argv construction is unit-testable in isolation.
+- **Host `processPid` is the wrapper's Windows pid, not `child.pid` (Windows + Git Bash).** On MSYS /
+  Git Bash `$$` is the MSYS-internal pid, which is **not** a Windows pid the gateway can signal
+  (empirically `$$`=1105 vs `/proc/$$/winpid`=17172 for the same shell). So the wrapper pidfile line
+  publishes `$(cat /proc/$$/winpid 2>/dev/null || echo $$)` — the real Windows pid — with a `$$`
+  fallback off Windows (where `$$` already *is* the real pid, making the pidfile byte-for-byte
+  identical off-Windows). The spawn-time `child.pid` persisted as `processPid` is the OS pid of the
+  top-level `bash.exe`, which can differ from this winpid. So on restore the host path **reconciles
+  `processPid` from the nonce-checked pidfile before the liveness check** (§7.1), the same way the
+  docker path reconciles the in-container pid — so `isHostPidAlive` / `taskkill` target the
+  signalable pid. On Linux/macOS the pidfile pid equals `child.pid`, so the reconciliation is a
+  no-op. A mismatched nonce is never adopted (it stays true pid-reuse) and no pid is ever
+  fabricated.
 - **Docker container gone.** The container-internal `/tmp` source files vanish with the container,
   **but the HOST projection + HOST status snapshot survive**. The retained host output is always
   shown; if a real exit code was already mirrored to the host snapshot → exited with that code; else
@@ -1160,6 +1218,14 @@ field, no standalone `unrecoverable?`); add `bg_process_dismissed`.
 
 `src/ui/components/BgProcessPill.ts` — render by `terminalReason` (`normal`→`exit N`,
 `killed`→"killed", `unrecoverable`→"exit status unknown"); dismiss for all terminal states.
+
+`src/server/harness-kill.ts` (NEW) — pure, side-effect-free helper `windowsGatewayKillArgs(pid):
+string[]` returning the Windows gateway-kill argv `taskkill /pid <pid> /F` (**no `/T`**), so the dev
+restart harness force-kills only the gateway pid and the detached `bash_bg` wrappers survive the
+restart (§11). Importing the module launches nothing, so it is unit-testable in isolation.
+
+`src/server/harness.ts` — `killServer()` builds its Windows kill command from
+`windowsGatewayKillArgs(child.pid)` instead of the inline `taskkill /pid <pid> /T /F`.
 
 ## 13. Test plan
 
@@ -1262,6 +1328,17 @@ Extend/replace `tests/bg-process-manager.test.ts` and add **`tests/bg-process-pe
   stdout/stderr and assert each spool is trimmed to the last `<KEEP>` (bounded ring, in-place,
   restart-independent); emit an `exit` with code 7 and assert the helper writes `7` to the status
   file and `processPid`+`nonce` to the pidfile. No real processes.
+- **Windows dev-harness restart survival (reproducing) — `tests/bg-process-windows-restart.test.ts`:**
+  pins the three fixable seams of the Windows restart bug, all with injected deps (fake `SpawnFn`,
+  noop tailers, isolated temp `BgProcessStore`, faked `BgEnv`) so **no real OS process** is touched.
+  (A) `src/server/harness-kill.ts` exports `windowsGatewayKillArgs(pid)` returning a `taskkill`
+  argv that targets the gateway pid with `/F` **and omits `/T`** (no tree-kill). (B) `buildHostWrapper`
+  emits a pidfile line publishing a Windows-usable winpid via `/proc/$$/winpid`, not bare `$$`.
+  (C) `restoreSession` reconciles the host `processPid` from the nonce-checked pidfile: persist a
+  running HOST record with a stale `processPid`, write a pidfile with a different (Windows-usable)
+  pid + matching nonce, make liveness pass **only** for the pidfile pid, and assert restore adopts
+  and persists the pidfile pid and re-attaches (`running`, not `unrecoverable`). Every assertion
+  message carries the `WIN_BG_RESTART_BUG` marker for the reproducing-test gate.
 
 ### Browser E2E (required) — `tests/e2e/ui/bg-process-persistence.spec.ts`
 
@@ -1289,6 +1366,24 @@ unchanged). Docker re-attach — including the **copytruncate offset rebase afte
 in-container process whose spool the in-container trimmer copytruncated, then a gateway restart still
 resumes streaming via probe + `tail -c +1 -F` from the normalized offset) — is covered by
 `test:manual` (extend `sandbox-recovery-docker.spec.ts`).
+
+### Manual-integration (real gateway + real detached wrappers) — `tests/manual-integration/bg-process-restart-survival.spec.ts`
+
+This is the natural home for the **restart-survival acceptance** because it needs a real spawn + a
+real restart (the unit test stubs both). It drives a REAL gateway with REAL detached `bash_bg`
+wrappers across a restart and asserts the documented restore contract:
+
+1. A **still-running** ticker (`while ...; echo tick $i; sleep 1`) re-attaches and **keeps streaming**
+   after the restart — the record stays `running`, its log keeps growing past the pre-restart tick
+   count, and it is **not** resolved to `unrecoverable`.
+2. A **short-lived** process that **finishes during downtime** (`sleep 4; exit 7`, with the gateway
+   down for ~6s) comes back with its **real exit code** (`terminalReason="normal"`, `exitCode=7`).
+
+Crucially, the test restarts by killing **only the gateway pid** — on Windows via the same
+`windowsGatewayKillArgs` argv the production harness now uses (no `/T`), elsewhere a single SIGTERM
+to the gateway pid (not its process group). This mirrors the harness fix; using `taskkill /T` here
+would euthanize the detached wrappers and reproduce the bug. The suite is **gate-exempt** (not run
+by the implementation gate); run it via `npm run test:manual`.
 
 ### Commands
 

--- a/src/server/agent/bg-process-manager.ts
+++ b/src/server/agent/bg-process-manager.ts
@@ -162,7 +162,14 @@ function buildPosixWrapper(
 	const qOut = shQuote(o.outSpool);
 	const qErr = shQuote(o.errSpool);
 	if (o.mkdir) lines.push(`mkdir -p ${shQuote(path.posix.dirname(o.outSpool))}`);
-	lines.push(`printf '%s\\n%s\\n' "$$" ${shQuote(o.nonce)} > ${shQuote(o.pid)}`);
+	// Publish a WINDOWS-USABLE pid: on MSYS/Git Bash `$$` is the MSYS-internal pid
+	// (NOT a Windows pid the gateway can signal), while `/proc/$$/winpid` yields the
+	// real Windows pid. Off Windows (Linux/macOS) `/proc/$$/winpid` does not exist,
+	// so `cat` fails and we fall back to `$$` — which already IS the real pid there,
+	// so the pidfile content is byte-for-byte equivalent off-Windows. The host
+	// restore path reconciles processPid from this pidfile so liveness/kill target
+	// the signalable pid.
+	lines.push(`printf '%s\\n%s\\n' "$(cat /proc/$$/winpid 2>/dev/null || echo $$)" ${shQuote(o.nonce)} > ${shQuote(o.pid)}`);
 	// wrapper-owned trimmer: bounds each spool to KEEP_BYTES, restart-independent.
 	lines.push(
 		`( while kill -0 "$$" 2>/dev/null; do ` +
@@ -977,6 +984,22 @@ export class BgProcessManager {
 		if (bg.paths.inContainer && bg.containerId && bg.processPid <= 0) {
 			const pf = this.readPidFile(bg);
 			if (pf && pf.pid > 0 && pf.nonce === bg.nonce) {
+				bg.processPid = pf.pid;
+				this.store(sessionId)?.update(sessionId, bg.id, { processPid: pf.pid });
+			}
+		}
+
+		// HOST processPid reconciliation, analogous to the docker Fix-1b path above.
+		// The spawn-time child.pid persisted as processPid is the top-level wrapper
+		// PID; on Windows + Git Bash the wrapper publishes a Windows-usable winpid (via
+		// /proc/$$/winpid) that can differ from it. Re-read the (nonce-checked) pidfile
+		// and adopt its pid BEFORE the liveness check so isHostPidAlive / kill target
+		// the correct signalable PID. A MISMATCHED nonce is true pid-reuse — never adopt
+		// it here (the post-liveness guard handles that); never fabricate a pid. On
+		// Linux/macOS the pidfile pid equals child.pid, so this is a no-op there.
+		if (!bg.paths.inContainer) {
+			const pf = this.readPidFile(bg);
+			if (pf && pf.pid > 0 && pf.nonce === bg.nonce && pf.pid !== bg.processPid) {
 				bg.processPid = pf.pid;
 				this.store(sessionId)?.update(sessionId, bg.id, { processPid: pf.pid });
 			}

--- a/src/server/harness-kill.ts
+++ b/src/server/harness-kill.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure, side-effect-free helpers for the dev restart harness's process-kill
+ * strategy. Importing this module must do NOTHING (no launch/watch code) so it
+ * can be unit-tested in isolation.
+ *
+ * Why this exists: the harness used to force-kill the gateway on Windows with
+ * `taskkill /pid <pid> /T /F`. The `/T` walks the gateway's child-process tree
+ * by parent→child PID linkage and kills EVERY descendant — including the
+ * detached `bash.exe` wrappers running `bash_bg` background commands. On
+ * Windows `detached: true` only creates a new process *group*; it does not sever
+ * the parent-PID linkage, so `/T` still finds and euthanizes those wrappers, and
+ * `/F` denies them the chance to flush their `.status` file. The result: on the
+ * next boot the persisted bg record has a dead `processPid` and no status
+ * snapshot, so restore correctly classifies it `unrecoverable`.
+ *
+ * Dropping `/T` force-kills ONLY the gateway process. The detached + unref'd bg
+ * wrappers then survive the restart, keep writing their spools while the gateway
+ * is down, and write `.status` on natural exit — so restore can re-attach to a
+ * still-running process (or read the real exit code of one that finished during
+ * downtime). The single-process force-kill still reliably frees the port.
+ */
+
+/**
+ * Build the Windows gateway-kill argv: force-kill ONLY the given gateway PID,
+ * WITHOUT `/T` (no tree-kill). Returns a `taskkill` argv array.
+ */
+export function windowsGatewayKillArgs(pid: number): string[] {
+	return ["taskkill", "/pid", String(pid), "/F"];
+}

--- a/src/server/harness.ts
+++ b/src/server/harness.ts
@@ -24,6 +24,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { restartSentinelPath } from "./harness-signal.js";
 import { missingDependencies } from "./harness-deps.js";
+import { windowsGatewayKillArgs } from "./harness-kill.js";
 
 // ---------------------------------------------------------------------------
 // Paths
@@ -165,10 +166,13 @@ async function killServer(): Promise<void> {
 			resolve();
 		});
 
-		// On Windows, SIGTERM doesn't work well — use tree-kill pattern
+		// On Windows, SIGTERM doesn't work well — force-kill the gateway. We kill
+		// ONLY the gateway PID (no `/T` tree-kill): `/T` would walk the child-process
+		// tree and euthanize the detached `bash_bg` wrappers we want to survive the
+		// restart. See harness-kill.ts for the full rationale.
 		if (process.platform === "win32") {
 			try {
-				execSync(`taskkill /pid ${child!.pid} /T /F`, { stdio: "ignore", shell: true as unknown as string });
+				execSync(windowsGatewayKillArgs(child!.pid!).join(" "), { stdio: "ignore", shell: true as unknown as string });
 			} catch {
 				child?.kill("SIGKILL");
 			}

--- a/tests/bg-process-persistence.test.ts
+++ b/tests/bg-process-persistence.test.ts
@@ -111,7 +111,9 @@ describe("BgProcessManager — wrapper builders (POSIX only)", () => {
 
 	it("buildHostWrapper emits subshell, trimmer, status write — no cmd / %errorlevel%", () => {
 		const w = buildHostWrapper("echo hi", paths);
-		assert.match(w, /printf '%s\\n%s\\n' "\$\$" 'NONCE123'/);
+		// Pidfile publishes a Windows-usable winpid (via /proc/$$/winpid) with a $$
+		// fallback off-Windows — see buildPosixWrapper. Off Windows this resolves to $$.
+		assert.match(w, /printf '%s\\n%s\\n' "\$\(cat \/proc\/\$\$\/winpid 2>\/dev\/null \|\| echo \$\$\)" 'NONCE123'/);
 		assert.match(w, /while kill -0 "\$\$"/);
 		assert.match(w, /tail -c 524288 "\$f" > "\$f\.trim"/);
 		assert.match(w, /cat "\$f\.trim" > "\$f"/);

--- a/tests/bg-process-windows-restart.test.ts
+++ b/tests/bg-process-windows-restart.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Reproducing test for the Windows `bash_bg` "does not survive a dev-harness
+ * restart" bug (goal: Fix Windows bg-process restart). It pins the TWO fixable
+ * seams identified in the issue-analysis gate and MUST fail on current code:
+ *
+ *   (A) Harness tree-kill (primary). The dev restart harness kills the gateway
+ *       on Windows with `taskkill /pid <pid> /T /F`; the `/T` walks the gateway's
+ *       child tree and euthanizes the detached bg-process wrappers. The fix
+ *       extracts the Windows kill-command construction into a pure, exported
+ *       helper `windowsGatewayKillArgs(pid)` in `src/server/harness-kill.ts`
+ *       that returns the taskkill argv WITHOUT `/T` (single-pid, force only).
+ *
+ *   (B) POSIX wrapper publishes a non-Windows PID (secondary). The wrapper
+ *       pidfile line writes bare `$$` — the MSYS-internal pid, NOT a Windows
+ *       pid. The fix makes it publish `$(cat /proc/$$/winpid 2>/dev/null || echo $$)`
+ *       so the pidfile carries a Windows-usable pid (with a $$ fallback off
+ *       Windows, where $$ already IS the real pid → no behaviour change).
+ *
+ *   (C) Host restore never reconciles `processPid` from the pidfile (secondary).
+ *       The docker path reconciles processPid from the (nonce-checked) pidfile on
+ *       restore; the host path does not, so liveness/kill target a possibly-wrong
+ *       pid. The fix reconciles the host processPid from the pidfile, analogous
+ *       to the docker path.
+ *
+ * Every assertion message carries the unique marker WIN_BG_RESTART_BUG so the
+ * gate's error_pattern reliably matches. The test uses the injected-dependency
+ * harness from `tests/bg-process-manager.test.ts` (fake SpawnFn, noop tailers,
+ * isolated temp BgProcessStore, faked BgEnv) so NO real OS process is touched.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ChildProcess } from "node:child_process";
+
+import {
+	BgProcessManager,
+	buildHostWrapper,
+	type SpawnFn,
+	type BgEnv,
+	type BgPaths,
+	type TailerFactory,
+	type Tailer,
+} from "../src/server/agent/bg-process-manager.ts";
+import { BgProcessStore, type PersistedBgProcess } from "../src/server/agent/bg-process-store.ts";
+
+const MARKER = "WIN_BG_RESTART_BUG";
+
+// --- (C) host-restore harness (injected deps, no real OS process) ---------
+
+function makeRestoreHarness(opts: { alivePid: number }) {
+	const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-bgwin-"));
+	const store = new BgProcessStore(stateDir);
+	// restore() never spawns; this stub exists only to satisfy the constructor.
+	const spawn: SpawnFn = () => { throw new Error("spawn must not be called during restore"); };
+	// Noop tailers so no real fs polling / DockerTailer is exercised.
+	const tailerFactory: TailerFactory = () => {
+		const mk = (): Tailer => ({ start() {}, stop() {} });
+		return { out: mk(), err: mk() };
+	};
+	const env: BgEnv = {
+		// Liveness passes ONLY for the reconciled (pidfile) pid, so the host path
+		// must reconcile processPid before re-attaching.
+		isHostPidAlive: (pid: number) => pid === opts.alivePid,
+		killHostTree: () => { /* noop */ },
+		dockerCli: () => ({ code: -1, stdout: "" }),
+	};
+	const mgr = new BgProcessManager(() => undefined, spawn, () => store, tailerFactory, env);
+	return { mgr, store, stateDir };
+}
+
+function hostRecord(stateDir: string, sessionId: string, id: string, processPid: number, nonce: string): PersistedBgProcess {
+	const dir = path.join(stateDir, "bg-processes", sessionId);
+	return {
+		sessionId, id, name: id, command: "sleep 30",
+		hostPid: processPid, processPid, nonce,
+		cwd: stateDir, containerId: undefined,
+		status: "running", exitCode: null, terminalReason: null,
+		killRequested: false, killRequestedAt: undefined,
+		startTime: Date.now(), endTime: null,
+		logFile: path.join(dir, `${id}.log`),
+		statusSnapshot: path.join(dir, `${id}.status`),
+		outSpool: path.join(dir, `${id}.out.spool`),
+		errSpool: path.join(dir, `${id}.err.spool`),
+		pidFile: path.join(dir, `${id}.pid`),
+		nonce, inContainer: false,
+		outOffset: 0, errOffset: 0,
+	};
+}
+
+// --- Tests ----------------------------------------------------------------
+
+describe("Windows bash_bg survives a dev-harness restart", () => {
+	it("(A) harness Windows gateway-kill helper kills only the gateway pid (no /T tree-kill)", async () => {
+		let mod: { windowsGatewayKillArgs?: (pid: number) => string[] } | undefined;
+		try {
+			mod = await import("../src/server/harness-kill.ts");
+		} catch {
+			// Module does not exist yet on current code.
+		}
+
+		assert.ok(
+			mod && typeof mod.windowsGatewayKillArgs === "function",
+			`${MARKER}: expected src/server/harness-kill.ts to export windowsGatewayKillArgs(pid: number): string[]`,
+		);
+
+		const argv = mod!.windowsGatewayKillArgs!(1234);
+		assert.ok(
+			Array.isArray(argv),
+			`${MARKER}: windowsGatewayKillArgs must return a string[] argv`,
+		);
+		assert.ok(
+			argv.includes("taskkill") && argv.includes("/pid") && argv.includes("1234") && argv.includes("/F"),
+			`${MARKER}: kill argv must target the gateway pid with force — got ${JSON.stringify(argv)}`,
+		);
+		assert.ok(
+			!argv.includes("/T"),
+			`${MARKER}: kill argv must NOT include /T (tree-kill euthanizes detached bg children) — got ${JSON.stringify(argv)}`,
+		);
+	});
+
+	it("(B) POSIX host wrapper publishes a Windows-usable winpid, not bare $$", () => {
+		const fakePaths: BgPaths = {
+			logFile: "/tmp/bg/bg-1.log",
+			statusSnapshot: "/tmp/bg/bg-1.status",
+			outSpool: "/tmp/bg/bg-1.out.spool",
+			errSpool: "/tmp/bg/bg-1.err.spool",
+			pidFile: "/tmp/bg/bg-1.pid",
+			nonce: "nonce-abc",
+			inContainer: false,
+		};
+		const wrapper = buildHostWrapper("echo hi", fakePaths);
+		assert.ok(
+			wrapper.includes("/proc/$$/winpid"),
+			`${MARKER}: host wrapper pidfile line must publish a Windows-usable pid via /proc/$$/winpid (with a $$ fallback), not bare $$ — wrapper was:\n${wrapper}`,
+		);
+	});
+
+	it("(C) host restore reconciles processPid from the pidfile (nonce-checked) and persists it", async () => {
+		const OLD = 11111; // stale spawn-time child.pid (persisted)
+		const NEW = 22222; // Windows-usable pid published in the pidfile
+		const h = makeRestoreHarness({ alivePid: NEW });
+		const SESSION = `s-${randomUUID()}`;
+		const ID = "bg-1";
+		const nonce = randomUUID();
+
+		// Persist a HOST running record carrying the STALE processPid.
+		h.store.put(hostRecord(h.stateDir, SESSION, ID, OLD, nonce));
+
+		// Write the pidfile with the NEW (Windows-usable) pid + MATCHING nonce.
+		const dir = path.join(h.stateDir, "bg-processes", SESSION);
+		fs.mkdirSync(dir, { recursive: true });
+		fs.writeFileSync(path.join(dir, `${ID}.pid`), `${NEW}\n${nonce}\n`);
+		// No status file → process is treated as still running.
+
+		try {
+			await h.mgr.restoreSession(SESSION);
+
+			const info = h.mgr.list(SESSION).find((p) => p.id === ID);
+			assert.ok(info, `${MARKER}: restored bg record should be present in memory`);
+			assert.equal(
+				info!.pid, NEW,
+				`${MARKER}: host restore must reconcile processPid from the pidfile (expected ${NEW}, got ${info!.pid}) so liveness/kill target the signalable pid`,
+			);
+			assert.notEqual(
+				info!.status, "unrecoverable",
+				`${MARKER}: a still-running host process must re-attach, not resolve to unrecoverable`,
+			);
+
+			const persisted = h.store.get(SESSION, ID);
+			assert.equal(
+				persisted?.processPid, NEW,
+				`${MARKER}: reconciled processPid must be persisted to the store (expected ${NEW}, got ${persisted?.processPid})`,
+			);
+		} finally {
+			h.mgr.cleanup(SESSION);
+		}
+	});
+});

--- a/tests/manual-integration/bg-process-restart-survival.spec.ts
+++ b/tests/manual-integration/bg-process-restart-survival.spec.ts
@@ -1,0 +1,314 @@
+/**
+ * Manual-integration acceptance for "Windows bash_bg survives a dev-harness
+ * restart" (goal: Fix Windows bg-process restart). Drives a REAL gateway with
+ * REAL detached `bash_bg` wrappers (POSIX wrapper on Windows+Git Bash, /bin/sh
+ * elsewhere) across a restart and asserts the documented restore contract
+ * (`docs/bg-process-persistence.md`):
+ *
+ *   (1) a STILL-RUNNING bg process re-attaches and KEEPS STREAMING after the
+ *       restart — record stays `running`, its log keeps growing, it is NOT
+ *       resolved to `unrecoverable`;
+ *   (2) a SHORT-LIVED bg process that FINISHES DURING DOWNTIME comes back with
+ *       its REAL exit code (`terminalReason="normal"`, exitCode = the real code).
+ *
+ * The restart kills ONLY the gateway PID — mirroring the production fix in
+ * `harness.ts`/`harness-kill.ts` (no `taskkill /T` tree-kill on Windows; a
+ * single SIGTERM to the gateway PID, not its group, elsewhere). The detached +
+ * unref'd bg wrappers therefore survive the gateway's death, keep writing their
+ * spools while it is down, and write `.status` on natural exit, so the next boot
+ * re-attaches (alive) or reads the real exit code (finished-during-downtime).
+ *
+ *   npm run test:manual    (or: npx playwright test --config playwright-manual.config.ts \
+ *     --grep "bg-process-restart-survival")
+ *
+ * This suite is gate-exempt — it is NOT run by the implementation gate.
+ */
+import { test, expect } from "@playwright/test";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import { createServer } from "node:net";
+import { mkdirSync, rmSync, readFileSync, writeFileSync, existsSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { windowsGatewayKillArgs } from "../../src/server/harness-kill.ts";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
+const SERVER_CLI = join(PROJECT_ROOT, "dist", "server", "cli.js");
+
+interface GW { proc: ChildProcess; port: number; dir: string; token: string; base: string; defaultProjectId?: string; }
+
+async function freePort(): Promise<number> {
+	return new Promise((res, rej) => {
+		const s = createServer();
+		s.listen(0, "127.0.0.1", () => { const p = (s.address() as any).port; s.close(() => res(p)); });
+		s.on("error", rej);
+	});
+}
+
+async function startGW(dir: string, port: number): Promise<GW> {
+	mkdirSync(join(dir, ".bobbit", "state"), { recursive: true });
+	const proc = spawn(process.execPath, [
+		SERVER_CLI, "--host", "127.0.0.1", "--port", String(port),
+		"--no-tls", "--auth", "--cwd", dir,
+	], {
+		env: { ...process.env, BOBBIT_DIR: join(dir, ".bobbit"), NODE_ENV: "test" },
+		stdio: ["pipe", "pipe", "pipe"],
+	});
+	let stderr = "";
+	proc.stderr!.on("data", (c: Buffer) => { stderr += c; });
+	const deadline = Date.now() + 60_000;
+	while (Date.now() < deadline) {
+		if (proc.exitCode !== null) throw new Error(`Gateway exited (${proc.exitCode}):\n${stderr}`);
+		try {
+			const tp = join(dir, ".bobbit", "state", "token");
+			if (existsSync(tp)) {
+				const t = readFileSync(tp, "utf-8").trim();
+				if ((await fetch(`http://127.0.0.1:${port}/api/health`, { headers: { Authorization: `Bearer ${t}` } })).ok) break;
+			}
+		} catch { /* not up yet */ }
+		await new Promise(r => setTimeout(r, 200));
+	}
+	if (Date.now() >= deadline) { proc.kill(); throw new Error(`Not healthy:\n${stderr}`); }
+	const token = readFileSync(join(dir, ".bobbit", "state", "token"), "utf-8").trim();
+	return { proc, port, dir, token, base: `http://127.0.0.1:${port}` };
+}
+
+/**
+ * Restart-harness-faithful kill: force-kill ONLY the gateway PID, never its
+ * descendant tree. On Windows this uses the SAME argv the production harness now
+ * uses ({@link windowsGatewayKillArgs} — no `/T`); elsewhere a single SIGTERM to
+ * the gateway PID (not the process group). This is the whole point of the fix:
+ * the detached bg wrappers must outlive the gateway. Using `taskkill /T` here
+ * would euthanize them and reproduce the bug.
+ */
+async function stopGatewayOnly(gw: GW): Promise<void> {
+	if (gw.proc.exitCode === null) {
+		if (process.platform === "win32") {
+			const argv = windowsGatewayKillArgs(gw.proc.pid!);
+			try { execFileSync(argv[0], argv.slice(1), { stdio: "ignore", timeout: 10_000 }); } catch { /* fall through */ }
+		} else {
+			try { gw.proc.kill("SIGTERM"); } catch { /* ignore */ }
+		}
+	}
+	await new Promise<void>(r => {
+		if (gw.proc.exitCode !== null) return r();
+		gw.proc.on("exit", () => r());
+		setTimeout(() => { try { gw.proc.kill("SIGKILL"); } catch { /* ignore */ } r(); }, 5_000);
+	});
+	await new Promise(r => setTimeout(r, 1_000));
+}
+
+function api(gw: GW, path: string, opts: RequestInit = {}) {
+	return fetch(`${gw.base}${path}`, {
+		...opts,
+		headers: { "Content-Type": "application/json", Authorization: `Bearer ${gw.token}`, ...(opts.headers as Record<string, string> || {}) },
+	});
+}
+
+async function pollIdle(gw: GW, id: string, ms = 60_000) {
+	const t0 = Date.now();
+	while (Date.now() - t0 < ms) {
+		const res = await api(gw, `/api/sessions/${id}`);
+		if (res.status === 404) { await new Promise(r => setTimeout(r, 500)); continue; }
+		const s = await res.json() as any;
+		if (s.status === "idle") return s;
+		if (s.status === "error" || s.status === "terminated" || s.status === "archived") {
+			throw new Error(`Session ${id} ${s.status}${s.restoreError ? `\n  restoreError: ${s.restoreError}` : ""}`);
+		}
+		await new Promise(r => setTimeout(r, 500));
+	}
+	throw new Error(`Session ${id} not idle in ${ms}ms`);
+}
+
+async function listBg(gw: GW, sessionId: string): Promise<any[]> {
+	const res = await api(gw, `/api/sessions/${sessionId}/bg-processes`);
+	if (!res.ok) return [];
+	return (await res.json() as any).processes ?? [];
+}
+
+async function bgLog(gw: GW, sessionId: string, pid: string, tail = 200): Promise<string[]> {
+	const res = await api(gw, `/api/sessions/${sessionId}/bg-processes/${pid}/logs?tail=${tail}`);
+	if (!res.ok) return [];
+	const j = await res.json() as any;
+	return (j.log ?? []).map((e: any) => e.text as string);
+}
+
+/** Highest `tick N` integer currently in the ticker's log (−1 if none seen). */
+function maxTick(lines: string[]): number {
+	let max = -1;
+	for (const l of lines) {
+		const m = /tick (\d+)/.exec(l);
+		if (m) max = Math.max(max, parseInt(m[1], 10));
+	}
+	return max;
+}
+
+function initRepo(dir: string) {
+	mkdirSync(dir, { recursive: true });
+	execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["symbolic-ref", "HEAD", "refs/heads/master"], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["config", "user.email", "t@t"], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["config", "user.name", "T"], { cwd: dir, stdio: "ignore" });
+	writeFileSync(join(dir, "README.md"), "# Test\n");
+	writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "p", version: "1.0.0" }, null, 2));
+	execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore" });
+	execFileSync("git", ["commit", "-m", "init"], { cwd: dir, stdio: "ignore" });
+}
+
+function cleanDirs(dir: string) {
+	const parent = resolve(dir, "..");
+	const base = dir.split(/[\\/]/).pop()!;
+	const dirs = [dir];
+	try { for (const e of readdirSync(parent)) if (e.startsWith(base)) dirs.push(join(parent, e)); } catch { /* ignore */ }
+	for (const d of dirs) {
+		for (let i = 0; i < 3; i++) { try { rmSync(d, { recursive: true, force: true }); break; } catch { /* retry */ } }
+	}
+}
+
+test.describe.configure({ mode: "serial" });
+
+test("bg-process-restart-survival: running re-attaches & keeps streaming; finished-during-downtime reports real exit code", async () => {
+	test.setTimeout(240_000);
+
+	const tmp = process.platform === "win32" ? (process.env.TEMP || "C:\\Temp") : "/tmp";
+	const port1 = await freePort();
+	const dir = join(tmp, `.bobbit-bgrestart-${port1}`);
+	cleanDirs(dir);
+	initRepo(dir);
+	mkdirSync(join(dir, ".bobbit", "state"), { recursive: true });
+	writeFileSync(join(dir, ".bobbit", "state", "projects.json"), "[]");
+
+	let gw = await startGW(dir, port1);
+	console.log(`  [boot] gateway :${port1} cwd=${dir}`);
+
+	// Register the project.
+	const regRes = await api(gw, "/api/projects", { method: "POST", body: JSON.stringify({ name: "BG Restart", rootPath: dir }) });
+	expect(regRes.status).toBe(201);
+	const reg = await regRes.json() as any;
+	gw.defaultProjectId = reg.id;
+
+	// Plain (non-worktree) session: bash_bg runs in this cwd.
+	const sessCwd = join(tmp, `.bobbit-bgrestart-cwd-${port1}`);
+	mkdirSync(sessCwd, { recursive: true });
+	const sRes = await api(gw, "/api/sessions", { method: "POST", body: JSON.stringify({ projectId: reg.id, cwd: sessCwd }) });
+	expect(sRes.status).toBe(201);
+	const sessionId = (await sRes.json() as any).id;
+	await pollIdle(gw, sessionId);
+	console.log(`  [boot] session ${sessionId} idle, cwd=${sessCwd}`);
+
+	// (1) Long-running ticker — must survive the restart and keep streaming.
+	const tickRes = await api(gw, `/api/sessions/${sessionId}/bg-processes`, {
+		method: "POST",
+		body: JSON.stringify({ name: "ticker", command: "i=0; while [ $i -lt 100000 ]; do echo tick $i; i=$((i+1)); sleep 1; done" }),
+	});
+	expect(tickRes.status).toBe(201);
+	const tickId = (await tickRes.json() as any).id;
+
+	// (2) Short-lived process — finishes DURING downtime with a distinctive exit code.
+	const SHORT_EXIT = 7;
+	const shortRes = await api(gw, `/api/sessions/${sessionId}/bg-processes`, {
+		method: "POST",
+		body: JSON.stringify({ name: "short", command: `echo short-start; sleep 4; echo short-done; exit ${SHORT_EXIT}` }),
+	});
+	expect(shortRes.status).toBe(201);
+	const shortId = (await shortRes.json() as any).id;
+	console.log(`  [boot] ticker=${tickId} short=${shortId}`);
+
+	// Confirm the ticker streams + persists before the restart.
+	let preTick = -1;
+	{
+		const t0 = Date.now();
+		while (Date.now() - t0 < 30_000) {
+			preTick = maxTick(await bgLog(gw, sessionId, tickId));
+			if (preTick >= 2) break;
+			await new Promise(r => setTimeout(r, 500));
+		}
+	}
+	expect(preTick, "ticker must stream at least a few ticks pre-restart").toBeGreaterThanOrEqual(2);
+	// Persistence sanity: the durable store + spool exist on disk.
+	const bgJson = join(dir, ".bobbit", "state", "bg-processes.json");
+	expect(existsSync(bgJson), "bg-processes.json must be written").toBe(true);
+	console.log(`  [boot] ticker streamed to tick ${preTick}; store persisted`);
+
+	// Restart: kill ONLY the gateway PID (harness-faithful — bg wrappers survive),
+	// then wait long enough that the SHORT process finishes during downtime.
+	console.log("  [restart] killing gateway (gateway-PID only, no tree-kill)");
+	await stopGatewayOnly(gw);
+	await new Promise(r => setTimeout(r, 6_000)); // > short's 4s sleep → it exits + writes .status while down
+
+	const port2 = await freePort();
+	gw = await startGW(dir, port2);
+	gw.defaultProjectId = reg.id;
+	console.log(`  [restart] gateway :${port2}`);
+
+	// Let restore-on-boot re-attach the session + its bg processes.
+	await pollIdle(gw, sessionId, 90_000);
+	await new Promise(r => setTimeout(r, 3_000));
+
+	const failures: string[] = [];
+
+	// --- Assertion (1): ticker re-attached, running, NOT unrecoverable, streaming. ---
+	let ticker: any;
+	{
+		const t0 = Date.now();
+		while (Date.now() - t0 < 30_000) {
+			ticker = (await listBg(gw, sessionId)).find(p => p.id === tickId);
+			if (ticker) break;
+			await new Promise(r => setTimeout(r, 500));
+		}
+	}
+	if (!ticker) {
+		failures.push(`ticker ${tickId} missing from bg-processes after restart`);
+	} else {
+		console.log(`  [restart] ticker status=${ticker.status} terminalReason=${ticker.terminalReason}`);
+		if (ticker.status === "unrecoverable" || ticker.terminalReason === "unrecoverable") {
+			failures.push(`ticker resolved to UNRECOVERABLE after restart — the regression. status=${ticker.status} terminalReason=${ticker.terminalReason}`);
+		} else if (ticker.status !== "running") {
+			failures.push(`ticker expected status=running after restart, got ${ticker.status} (terminalReason=${ticker.terminalReason})`);
+		} else {
+			// Keeps streaming: the surviving wrapper kept writing while down + after; the
+			// re-attached tailer must observe the tick count climb past the pre-restart max.
+			const reTick = maxTick(await bgLog(gw, sessionId, tickId));
+			let grown = reTick;
+			const t0 = Date.now();
+			while (Date.now() - t0 < 20_000 && grown <= preTick) {
+				await new Promise(r => setTimeout(r, 1_000));
+				grown = maxTick(await bgLog(gw, sessionId, tickId));
+			}
+			console.log(`  [restart] ticker re-attached: preTick=${preTick} postTick=${grown}`);
+			if (grown <= preTick) {
+				failures.push(`ticker did not keep streaming after restart: preTick=${preTick} postTick=${grown} (spool froze)`);
+			}
+		}
+	}
+
+	// --- Assertion (2): short process finished during downtime → real exit code. ---
+	let short: any;
+	{
+		const t0 = Date.now();
+		while (Date.now() - t0 < 30_000) {
+			short = (await listBg(gw, sessionId)).find(p => p.id === shortId);
+			if (short && short.status !== "running") break;
+			await new Promise(r => setTimeout(r, 500));
+		}
+	}
+	if (!short) {
+		failures.push(`short ${shortId} missing from bg-processes after restart`);
+	} else {
+		console.log(`  [restart] short status=${short.status} terminalReason=${short.terminalReason} exitCode=${short.exitCode}`);
+		if (short.terminalReason !== "normal") {
+			failures.push(`short process expected terminalReason="normal" (real exit read from .status), got "${short.terminalReason}" (status=${short.status}, exitCode=${short.exitCode})`);
+		}
+		if (short.exitCode !== SHORT_EXIT) {
+			failures.push(`short process expected real exitCode=${SHORT_EXIT}, got ${short.exitCode}`);
+		}
+	}
+
+	// Cleanup: dismiss the still-running ticker (force) so no orphan survives the test.
+	try { await api(gw, `/api/sessions/${sessionId}/bg-processes/${tickId}?action=kill`, { method: "DELETE" }); } catch { /* ignore */ }
+	await stopGatewayOnly(gw);
+	cleanDirs(dir);
+	cleanDirs(sessCwd);
+
+	if (failures.length) {
+		throw new Error(`bg-process-restart-survival failures:\n  - ${failures.join("\n  - ")}`);
+	}
+});


### PR DESCRIPTION
## Problem
On Windows, a `bash_bg` background process did **not** survive a gateway restart performed via the dev restart harness. Persistence (PR #753) worked — the pill/record/log were restored — but the record resolved to `unrecoverable` ("exit status unknown") instead of re-attaching and continuing to stream.

## Root causes
1. **Harness tree-kill (primary).** `harness.ts` killed the gateway on Windows with `taskkill /pid <pid> /T /F`. `/T` walks the child-process tree and euthanized the detached `bash.exe` bg wrappers (on Windows `detached:true` only creates a new process group; it does not sever the parent-PID link), and `/F` denied them the chance to flush their `.status`. So restore correctly found a dead `processPid` with no status snapshot → `unrecoverable`. A normal (non-harness) gateway shutdown already lets children survive — this was a harness-local defect.
2. **Host `processPid` not reconciled / non-Windows pid published (secondary, latent).** The POSIX wrapper pidfile wrote bare `$$` (the MSYS-internal pid, not a Windows pid — empirically `$$`=1105 vs `/proc/$$/winpid`=17172), and only the docker path reconciled `processPid` from the pidfile.

## Fix
- **`src/server/harness-kill.ts` (new):** `windowsGatewayKillArgs(pid)` → `taskkill /pid <pid> /F` (no `/T`). `harness.ts` `killServer()` uses it, so detached+unref'd bg wrappers survive the restart; restore re-attaches (still-running) or reads the real exit code (finished during downtime). Single-process force-kill still frees the port.
- **POSIX wrapper publishes a Windows-usable pid:** pidfile line writes `$(cat /proc/$$/winpid 2>/dev/null || echo $$)`. Off-Windows the path is absent → falls back to `$$` (already the real pid); byte-for-byte equivalent, no behavior change.
- **Host `processPid` reconciliation:** `restoreSession` re-reads the nonce-checked pidfile for host (non-container) records and adopts the pidfile pid before the liveness check (analogous to the docker path), so liveness/kill target the correct signalable pid. Nonce pid-reuse guard unchanged; never fabricates a pid. Docker path untouched.

## Tests
- **`tests/bg-process-windows-restart.test.ts`** (unit) — pins all three seams: harness kill argv has no `/T`; wrapper publishes `/proc/$$/winpid`; host restore reconciles `processPid` from the pidfile. Failed before the fix, passes after (TDD reproducing test).
- **`tests/manual-integration/bg-process-restart-survival.spec.ts`** (gate-exempt) — real spawn + harness-faithful restart: still-running process re-attaches and keeps streaming; short-lived process returns its real exit code.

## Docs
`docs/bg-process-persistence.md` and `docs/design/persistent-bg-processes.md` updated (host processPid reconciliation, winpid publication, harness no-tree-kill). Also trimmed `AGENTS.md` back under its 6144-byte budget (a pre-existing overage inherited from the branch point that was failing the unit gate).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
