### PR TITLE
Fix team lead never going idle after team_spawn

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -9441,9 +9441,18 @@ async function handleApiRoute(
 			// POST /orchestrate/wait — policy:"first"; chunked heartbeat like /wait.
 			if (verb === "wait") {
 				const timeoutMs = body?.timeout_ms ?? 600_000;
+				// Default (no explicit ids) excludes `childKind:"team"` workers: a team
+				// lead's goal members are NOT waited on via team_wait — they are
+				// notify-managed by the team-manager (worker-idle nudge), and the lead is
+				// meant to spawn-then-go-idle, not block. Mirrors the restart reminder's
+				// `childKind!=="team"` filter (orchestration-core remindOwnersWithLiveChildren).
+				// An EXPLICIT childSessionIds list is still honored verbatim (own-child
+				// scoping is enforced by orchestrationCore.wait → requireOwnChild). Without
+				// this, a lead that called team_wait after team_spawn blocked for the whole
+				// worker lifetime and never went idle.
 				const childIds: string[] = Array.isArray(body?.childSessionIds) && body.childSessionIds.length > 0
 					? body.childSessionIds.map((s: any) => String(s))
-					: orchestrationCore.list(ownerId).map(h => h.sessionId);
+					: orchestrationCore.list(ownerId).filter(h => h.childKind !== "team").map(h => h.sessionId);
 				if (childIds.length === 0) { json({ error: "No children to await" }, 400); return; }
 				res.writeHead(200, { "Content-Type": "application/json", "Transfer-Encoding": "chunked", "Cache-Control": "no-cache" });
 				const heartbeat = setInterval(() => { try { res.write("\n"); } catch { /* ignore */ } }, 60_000);

--- a/tests/e2e/team-delegate.spec.ts
+++ b/tests/e2e/team-delegate.spec.ts
@@ -268,6 +268,47 @@ test.describe("team_delegate — team-lead parity", () => {
 		}
 	});
 
+	test("team_wait (no ids) EXCLUDES team-spawned workers so the lead goes idle, not block", async () => {
+		// Regression: a team-spawned worker is registered as an OrchestrationCore
+		// child (childKind:"team") of the lead, but it is notify-managed by the
+		// team-manager — the lead is meant to spawn-then-go-idle. Before the fix,
+		// `team_wait` with no ids defaulted to ALL children (incl. the team worker)
+		// and BLOCKED for the worker's whole lifetime, so the lead never went idle.
+		const goal = await createGoal({ title: "team_wait excludes team workers", team: true });
+		let leadId: string | undefined;
+		let workerId: string | undefined;
+		try {
+			leadId = await startTeam(goal.id as string);
+			expect(leadId).toBeTruthy();
+
+			// Spawn a LIVE team worker (kept busy) — a tracked childKind:"team" child.
+			const spawnResp = await apiFetch(`/api/goals/${goal.id}/team/spawn`, {
+				method: "POST",
+				body: JSON.stringify({ role: "coder", task: "STAY_BUSY:3000 Run this exact bash command: sleep 120. Do not do anything else." }),
+			});
+			expect(spawnResp.status).toBe(201);
+			workerId = (await spawnResp.json()).sessionId as string;
+			expect(workerId).toBeTruthy();
+
+			// It IS a tracked child of the lead, with childKind "team".
+			await pollUntil(async () => {
+				const kids = await listChildren(leadId!);
+				const w = kids.find((c) => c.sessionId === workerId);
+				return w && w.childKind === "team" ? true : null;
+			}, { timeoutMs: 5_000, intervalMs: 50, label: "worker registered as team child" });
+
+			// team_wait with NO ids must NOT block on the team worker — it is excluded
+			// from the default set, leaving nothing to await → 400 immediately.
+			const wait = await orchestrate(leadId!, "wait", { timeout_ms: 600_000 });
+			expect(wait.status).toBe(400);
+			expect(wait.json?.error).toBe("No children to await");
+		} finally {
+			if (workerId) await apiFetch(`/api/goals/${goal.id}/team/dismiss`, { method: "POST", body: JSON.stringify({ sessionId: workerId }) }).catch(() => {});
+			await teardownTeam(goal.id as string).catch(() => {});
+			await deleteGoal(goal.id as string).catch(() => {});
+		}
+	});
+
 	test("a team-lead can prompt + dismiss its own non-blocking team_delegate child via /team/* (finding #6)", async ({ gateway }) => {
 		// A team-lead holds the GOAL-scoped team_prompt/dismiss (from team/extension.ts),
 		// not the own-child variants. Its own team_delegate(non_blocking) child is NOT a


### PR DESCRIPTION
## Problem

Team leads stopped going idle after spawning a team member — a regression from #745 (Orchestration Core). After `team_spawn`, a lead would call `team_wait` and block for the worker's **entire lifetime** (observed: 7 minutes), never going idle, defeating the event-driven notification model the team-lead role is built around.

## Root cause

`#745` did two things that combined badly:
1. Team-spawned workers are now registered as the lead's `OrchestrationCore` children (`childKind:"team"`).
2. `team_wait` is exposed to team-lead sessions.

`POST /api/sessions/:id/orchestrate/wait` with no explicit `childSessionIds` defaulted to **all** the owner's children — including those `childKind:"team"` workers. But team workers are **notify-managed** by the team-manager (worker-idle nudge); the lead is meant to spawn-then-go-idle and be woken by a notification. So `team_wait` blocked on work it should never have waited on.

This same invariant already exists elsewhere: the restart reminder path (`remindOwnersWithLiveChildren`) deliberately filters `childKind!=="team"` for exactly this reason.

## Fix

Exclude `childKind:"team"` from `team_wait`'s **default** child set, mirroring the existing reminder filter:

- An explicit `childSessionIds` list is still honored verbatim (own-child scoping stays enforced by `orchestrationCore.wait → requireOwnChild`).
- The lead keeps `team_wait` for its own `team_delegate` children (`childKind:"delegate"`) — no capability lost, coherent tool surface preserved.

One `.filter` in the wait route + an explanatory comment.

## Tests

- New regression test in `tests/e2e/team-delegate.spec.ts`: a lead with a live `childKind:"team"` worker calling `team_wait` (no ids) now gets `No children to await` instead of blocking.
- `npm run check` clean.
- Green: `team-delegate` (11/11), `orchestrate-restart` + `team-wait-semantics` (12/12).

> Note: server-side change — requires a gateway restart to take effect.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
