### PR TITLE
Deny team_delegate + team_wait on the team-lead role

### DIFF
--- a/defaults/roles/team-lead.yaml
+++ b/defaults/roles/team-lead.yaml
@@ -14,6 +14,27 @@ toolPolicies:
   gate_inspect: always-allow
   # Re-enable the Team tool group (default policy is `never` for non-leads).
   Team: allow
+  # Deny the own-children delegation pair team_delegate + team_wait (both live in
+  # the allow-by-default `Agent` group, so without these denies a lead inherits
+  # them). A team lead's ONE delegation primitive is team_spawn: it puts each
+  # worker in an ISOLATED sub-branch worktree and the team-manager NOTIFIES the
+  # lead on worker-idle — the role prompt's "spawn, then end your turn and go
+  # idle" model. The Agent-group pair is for a NON-goal agent orchestrating its
+  # own children, and for a lead it actively harms:
+  #   • team_delegate runs a child in the LEAD'S OWN goal-branch worktree (shared,
+  #     last-write-wins) — the opposite of the lead's isolated-worktree, merge-
+  #     member-branches model.
+  #   • team_wait tempts the lead to BLOCK on team-spawned workers (notify-managed
+  #     core children), so it never goes idle — the exact regression here. The
+  #     server already excludes team workers from team_wait's default set, but the
+  #     tool's result text instructs an explicit-id re-call that bypasses that, so
+  #     the only robust fix is to remove the tool from the lead's surface.
+  # Stripping both removes them from the lead's tool docs entirely so the model
+  # can't reach for them. The /orchestrate/* routes stay reachable (authz'd by
+  # session ownership, not tool policy) — this only governs the lead's EXPOSURE.
+  # Pinned by tests/role-team-tools-policy.test.ts.
+  team_delegate: never
+  team_wait: never
   goal_spawn_child: always-allow
   goal_plan_propose: always-allow
   goal_plan_status: always-allow

--- a/tests/e2e/team-delegate.spec.ts
+++ b/tests/e2e/team-delegate.spec.ts
@@ -13,8 +13,11 @@
  *   • a spawned child inherits the parent's CURRENT model (regression vs the
  *     old system-default drop) + per-call `model` override,
  *   • the non-blocking interactive flow spawn → prompt → wait → read → dismiss,
- *   • a team-lead can ALSO `team_delegate` (the Agent-group reclassification
- *     does not regress its goal `team_*` tools).
+ *   • the /orchestrate/delegate ROUTE stays functional for a team-lead caller
+ *     even though the lead's MODEL no longer sees `team_delegate`/`team_wait`
+ *     (denied at the role layer so the lead orchestrates via team_spawn +
+ *     notifications and goes idle; route authz is ownership-based, not tool-
+ *     policy-based — see role-team-tools-policy.test.ts).
  */
 import { test, expect } from "./in-process-harness.js";
 import { apiFetch, createSession, createGoal, startTeam, deleteSession, deleteGoal, teardownTeam, connectWs } from "./e2e-setup.js";
@@ -252,8 +255,14 @@ test.describe("team_delegate — non-blocking interactive flow", () => {
 });
 
 test.describe("team_delegate — team-lead parity", () => {
-	test("a team-lead can ALSO team_delegate (no regression to its goal team tools)", async ({ gateway }) => {
-		const goal = await createGoal({ title: "Orchestration delegate parity", team: true });
+	// The lead's MODEL no longer sees team_delegate/team_wait — they are denied at
+	// the role layer (team-lead.yaml; pinned by role-team-tools-policy.test.ts) so
+	// the lead orchestrates only via team_spawn + notifications and goes idle. The
+	// /orchestrate/delegate ROUTE, however, is authz'd by session ownership, NOT by
+	// tool policy, so it stays functional for a lead caller — this guards that the
+	// role-layer deny did not also break the route (defense-in-depth boundary).
+	test("the /orchestrate/delegate route stays functional for a lead (tool denied, route intact)", async ({ gateway }) => {
+		const goal = await createGoal({ title: "Orchestration delegate route intact", team: true });
 		let leadId: string | undefined;
 		try {
 			leadId = await startTeam(goal.id as string);

--- a/tests/role-team-tools-policy.test.ts
+++ b/tests/role-team-tools-policy.test.ts
@@ -163,3 +163,37 @@ describe("non-goal session resolved team-tool policy (the deliberate invariant c
 		});
 	}
 });
+
+describe("team-lead resolved policy denies the Agent-group delegation pair", () => {
+	// A team lead's ONE delegation primitive is team_spawn (isolated sub-branch
+	// worktree + team-manager worker-idle NOTIFICATIONS → spawn-then-go-idle).
+	// team_delegate (child in the lead's OWN worktree) and team_wait (block on
+	// notify-managed team workers) are NON-goal-agent verbs that broke the lead's
+	// go-idle behaviour, so team-lead.yaml denies both. The goal-only Team verbs
+	// stay allowed (Team: allow). read_session (also `group: Agent`) stays allowed.
+	const groupPolicyStore = defaultGroupPolicyProvider();
+	const leadRole = loadRole("team-lead");
+
+	for (const tool of ["team_delegate", "team_wait"]) {
+		it(`team-lead resolves ${tool} to never (stripped from the lead's tool surface)`, () => {
+			assert.equal(
+				leadRole.toolPolicies?.[tool],
+				"never",
+				`team-lead.yaml toolPolicies must set \`${tool}: never\``,
+			);
+			assert.equal(
+				resolveGrantPolicy(tool, "Agent", leadRole, undefined, groupPolicyStore),
+				"never",
+				`${tool} must resolve to never for the team lead so the model can't reach for it`,
+			);
+		});
+	}
+
+	it("team-lead still resolves read_session to allow (Agent group, not denied)", () => {
+		assert.equal(
+			resolveGrantPolicy("read_session", "Agent", leadRole, undefined, groupPolicyStore),
+			"allow",
+			"read_session must stay available to the lead — only the delegation pair is denied",
+		);
+	});
+});


### PR DESCRIPTION
## Problem

Follow-up to #757. Team leads were *still* reaching for `team_wait` after `team_spawn` and blocking on their workers instead of going idle.

**What changed to cause it:** #745 introduced a brand-new `team_wait` tool (and renamed `delegate`→`team_delegate`) into the **allow-by-default `Agent` group**, but never touched the `team-lead` role. So the lead's generated tool docs now advertise a wait verb (*"Wait for your child agents; returns when the first becomes idle"*). Before #745 no wait verb existed for a lead, so after `team_spawn` its only move was to go idle. Now it sees the tool and uses it — despite the role prompt's "spawn, then end your turn and go idle / rely on notifications" model.

**Why #757 wasn't enough:** #757 excluded `childKind:"team"` workers from `team_wait`'s *default* (no-ids) set, but `team_wait`'s own result text instructs the lead to *"call team_wait again… pass child_session_ids: [...]"* with explicit worker IDs — which are honored verbatim. So the lead just re-called with explicit IDs and kept blocking.

## Fix

Remove both Agent-group delegation verbs from the team-lead's tool surface (`defaults/roles/team-lead.yaml`):

```yaml
team_delegate: never
team_wait: never
```

Rationale:
- A team lead's **one** delegation primitive is `team_spawn` — isolated sub-branch worktree per worker + team-manager worker-idle **notifications** → spawn-then-go-idle.
- `team_delegate` runs a child in the lead's **own** goal-branch worktree (shared, last-write-wins), the opposite of the lead's isolated-worktree / merge-member-branches model. Keeping it while denying `team_wait` also leaves an incoherent half-pair.
- Stripping both removes them from the lead's tool docs entirely, so the model can't reach for them.

The `/api/sessions/:id/orchestrate/*` routes stay reachable (authz'd by session ownership, **not** tool policy) — this governs only the lead's tool **exposure**. `read_session` (also `group: Agent`) stays available.

## Tests

- `tests/role-team-tools-policy.test.ts`: new block asserting the team-lead resolves `team_delegate` + `team_wait` to `never`, and still resolves `read_session` to `allow` (17/17 pass).
- `reviewer-cannot-team-delegate.test.ts` unchanged (8/8 pass).
- `tests/e2e/team-delegate.spec.ts`: the former "a team-lead can ALSO team_delegate" test is reframed to assert **route integrity** (the route stays functional for a lead caller even though the tool is no longer exposed to its model) (11/11 pass).
- `npm run check` clean.

> Server-side prompt/policy change — requires a gateway restart to take effect.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
