### PR TITLE
Pack schema v2 + provider contribution loader (EP G1.1)

### DIFF
--- a/docs/extension-host-authoring.md
+++ b/docs/extension-host-authoring.md
@@ -787,7 +787,8 @@ a fresh read-only reviewer sub-agent and the panel lives only in that child sess
 ### Providers (`providers/<id>.yaml`) — schema 2, loaded but inert
 
 **Status:** a `schema: 2` pack may ship **provider** contributions — a new pack-scoped
-contribution loaded into the same `PackContributionRegistry` as panels/entrypoints/routes. In
+contribution loaded into the same `PackContributionRegistry` as panels/entrypoints/routes. Schema-1
+packs ignore `contents.providers` and keep the old activation-catalogue shape. In
 this PR they are **loaded, validated, catalogued, and per-entity toggleable, but never
 dispatched**: nothing imports a provider `module`, runs a `hook`, or applies its `budget`.
 Provider *dispatch* (the lifecycle hub) is a later Extension-Platform goal. Author them now to
@@ -804,8 +805,8 @@ Key author-facing rules (full reference, field table, defaults, and clamps live 
 - Only files whose basename is in **`contents.providers`** load (`providers/<name>.yaml`;
   `.yml` tolerated), exactly like `contents.entrypoints` gates `entrypoints/`.
 - `id` is unique **within the pack** — two packs may each ship id `memory` and both stay
-  active, because providers are keyed `(packId, contributionId)`, **not** name-merged like an
-  `EntityType` (see the [pack-scoped rationale](marketplace.md#why-providers-are-pack-scoped-not-a-new-entitytype)).
+  active, because providers are keyed `(packId, contributionId)`, **not** name-merged
+  (see the [pack-scoped rationale](marketplace.md#why-providers-are-pack-scoped-not-name-merged)).
   A duplicate id *within one pack* is a hard `PackContributionError`.
 - `module` resolves relative to the provider YAML and is containment-checked against the pack
   root — the same guard as routes/entrypoints.

--- a/docs/extension-host-authoring.md
+++ b/docs/extension-host-authoring.md
@@ -42,6 +42,7 @@ The renderer+action working example lives at `tests/fixtures/market-sources/retr
 | **Pack routes** | `pack.yaml` `routes:` | Gateway (confined worker) | called via `host.callRoute` |
 | **Entrypoints** | `entrypoints/<ep>.yaml` (listed in `contents`) | Browser (launchers + deep-link routes) | `host.ui.navigate` / `openPanel` |
 | **Pack store** | *implicit* — no declaration | Gateway | `host.store.{get,put,list}` (pack-namespaced) |
+| **Providers** *(schema 2; inert)* | `providers/<id>.yaml` (listed in `contents.providers`) | — not dispatched yet — | none yet (loaded + toggleable only) |
 
 Plus the cross-cutting `host.session.*` (transcript reads, agent-driving posts, live events)
 and the server-side `host.agents.*` (launch + orchestrate child agents), available to surfaces
@@ -89,6 +90,7 @@ A pack is a directory with a `pack.yaml` plus an entity payload. The full V1 lay
 
   panels/<panel>.yaml             # pack-scoped panel definitions, one file each (auto-discovered)
   entrypoints/<ep>.yaml           # pack-scoped launcher/deep-link definitions, one file each
+  providers/<id>.yaml             # schema-2 provider contributions (listed in contents.providers; INERT)
 
   lib/                            # shared implementation modules, NOT entities
     SharedRenderer.js
@@ -781,6 +783,35 @@ a fresh read-only reviewer sub-agent and the panel lives only in that child sess
 - **Ids and conflicts.** Entrypoint `id` is **pack-local**; `routeId` is **host-global** (two
   packs declaring the same `routeId` is a hard rejection at registry build). Panel ids referenced
   by `target.panelId` are pack-local.
+
+### Providers (`providers/<id>.yaml`) — schema 2, loaded but inert
+
+**Status:** a `schema: 2` pack may ship **provider** contributions — a new pack-scoped
+contribution loaded into the same `PackContributionRegistry` as panels/entrypoints/routes. In
+this PR they are **loaded, validated, catalogued, and per-entity toggleable, but never
+dispatched**: nothing imports a provider `module`, runs a `hook`, or applies its `budget`.
+Provider *dispatch* (the lifecycle hub) is a later Extension-Platform goal. Author them now to
+get validation + activation; expect no runtime effect yet.
+
+Unlike every other contribution in this guide, a provider has **no Host-API surface** — it is
+not reached through `ctx.host`. It is a forward-declared entity whose only observable behaviour
+today is that it appears in the activation catalogue and in
+`PackContributionRegistry.listProviders(projectId)` (installed + active + enabled).
+
+Key author-facing rules (full reference, field table, defaults, and clamps live in
+[docs/marketplace.md → Provider contributions](marketplace.md#provider-contributions-providersidyaml)):
+
+- Only files whose basename is in **`contents.providers`** load (`providers/<name>.yaml`;
+  `.yml` tolerated), exactly like `contents.entrypoints` gates `entrypoints/`.
+- `id` is unique **within the pack** — two packs may each ship id `memory` and both stay
+  active, because providers are keyed `(packId, contributionId)`, **not** name-merged like an
+  `EntityType` (see the [pack-scoped rationale](marketplace.md#why-providers-are-pack-scoped-not-a-new-entitytype)).
+  A duplicate id *within one pack* is a hard `PackContributionError`.
+- `module` resolves relative to the provider YAML and is containment-checked against the pack
+  root — the same guard as routes/entrypoints.
+- `hooks` must be a subset of `sessionSetup` / `beforePrompt` / `afterTurn` / `beforeCompact` /
+  `sessionShutdown`; an unknown hook drops *that* provider (warn) and the rest of the pack
+  still loads.
 
 ### `host.session.*` — transcript reads, posts, and live events
 

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -49,7 +49,7 @@ Everything Bobbit resolves for these three entity types is a pack in that one li
 
 Unifying these into one resolver replaced two separate mechanisms — `ConfigCascade` (roles/tools) and `slash-skills.ts` (skills) — that each had their own precedence rules. See [Architecture](#architecture-developer) below.
 
-> **Out of scope, by design.** MCP servers (`mcp-manager.ts`, `.mcp.json`) and AGENTS/CLAUDE.md prompt assembly (`system-prompt.ts`) keep their own loaders and resolve exactly as before. A market pack may **not** ship `mcp/` or AGENTS content in the MVP. See [Limitations & deferred work](#limitations--deferred-work).
+> **Out of scope, by design.** MCP servers (`mcp-manager.ts`, `.mcp.json`) and AGENTS/CLAUDE.md prompt assembly (`system-prompt.ts`) keep their own loaders and resolve exactly as before. A market pack may **not** ship `mcp/` or AGENTS content in the MVP. See [Limitations & deferred work](#limitations--deferred-work). (The Extension-Platform `schema: 2` manifest now *accepts* a `contents.mcp` catalogue key — see [pack.yaml schema 2](#packyaml-schema-2-extension-platform) — but there is still no MCP **loader**; the key is reserved for a later goal.)
 
 ## Using the marketplace
 
@@ -135,6 +135,15 @@ surface, so you can disable individual entities without uninstalling the pack. *
 user-facing entities are toggleable:** roles, tools, skills, and entrypoints. Support surfaces
 — panels, routes, stores, renderers, actions, `lib/` — are **not** independently toggleable
 (panels may be shown read-only as "support surfaces").
+
+> **Extension Platform (`schema: 2`).** The activation system also covers the new pack-scoped
+> kinds — `providers` plus the reserved siblings `hooks` / `mcp` / `piExtensions` / `runtimes`
+> / `workflows`. They are first-class in `DisabledRefs` and `ACTIVATION_KINDS`, and the
+> `pack-activation` catalogue includes their arrays, so the toggles round-trip through the same
+> REST. Of these, only **providers** currently has a loader, so disabling a provider actually
+> removes it from `PackContributionRegistry.listProviders(...)`; the other five toggle purely as
+> catalogue metadata until their loaders land. See
+> [pack.yaml schema 2 → Per-provider activation](#per-provider-activation).
 
 What disabling does:
 
@@ -302,7 +311,173 @@ routes:                          # OPTIONAL top-level block — Extension-Host p
   names:  [bundle, publish]       #   exported route-name allowlist.
 ```
 
-Validation rules: `name`, `description`, `version` must be non-empty; `name` must match the pattern (rejects path separators, `..`, leading dots); `contents` is required with the `roles`/`tools`/`skills` array keys present (each may be empty). `contents.tools` lists tool **group** directory names, while activation catalogues expand those groups to concrete tool names. `contents.entrypoints` is optional and lists the basenames of `entrypoints/<name>.yaml` files (the Extension-Host activation catalogue — see [authoring guide](extension-host-authoring.md#entrypoints--non-chat-launchers--deep-link-routes-hostuinavigate)). The optional top-level `routes:` block declares pack-level Extension-Host routes. Panels are **auto-discovered** from `panels/*.yaml` and are not listed here. A `contents.mcp` key is **rejected** — MCP installs are out of scope in the MVP. There is **no `stores` key** (Extension-Host stores are implicit, namespaced by the server-derived `packId`) and **no `permissions` key** (trusted pack code has ambient OS access — there is no permission system). Unknown top-level keys are ignored (forward-compat). A pack whose `pack.yaml` is missing or invalid is skipped with a warning, never fatal.
+Validation rules: `name`, `description`, `version` must be non-empty; `name` must match the pattern (rejects path separators, `..`, leading dots); `contents` is required with the `roles`/`tools`/`skills` array keys present (each may be empty). `contents.tools` lists tool **group** directory names, while activation catalogues expand those groups to concrete tool names. `contents.entrypoints` is optional and lists the basenames of `entrypoints/<name>.yaml` files (the Extension-Host activation catalogue — see [authoring guide](extension-host-authoring.md#entrypoints--non-chat-launchers--deep-link-routes-hostuinavigate)). The optional top-level `routes:` block declares pack-level Extension-Host routes. Panels are **auto-discovered** from `panels/*.yaml` and are not listed here. A `contents.mcp` key is **rejected at schema 1** (the absent-or-`1` default) — MCP installs are out of scope in the MVP — but **accepted at `schema: 2`** as catalogue metadata (no MCP loader exists yet; see [pack.yaml schema 2](#packyaml-schema-2-extension-platform)). There is **no `stores` key** (Extension-Host stores are implicit, namespaced by the server-derived `packId`) and **no `permissions` key** (trusted pack code has ambient OS access — there is no permission system). Unknown top-level keys are ignored (forward-compat). A pack whose `pack.yaml` is missing or invalid is skipped with a warning, never fatal.
+
+### `pack.yaml` schema 2 (Extension Platform)
+
+Schema 2 is the first step of the **Extension Platform** workstream. It is deliberately
+**additive and inert**: schema 2 widens what a `pack.yaml` may declare and adds a loader for
+one new contribution type (**providers**), but **nothing dispatches providers yet** — there is
+zero runtime behaviour and zero behaviour change for existing schema-1 (v1) packs. A pack opts
+in with a top-level `schema:` field; absent (or `1`) keeps the exact v1 semantics.
+
+Why ship the schema ahead of the runtime? The Extension Platform lands as a sequence of
+independently-mergeable PRs. Defining the manifest surface and the per-entity activation
+plumbing first means later PRs (the lifecycle hub that actually *runs* providers, plus loaders
+for the other reserved contribution types) only add dispatch — they never have to re-open the
+manifest format or the activation REST. Authors can also start shipping provider files now and
+have them load, validate, and toggle, even though they do nothing until the dispatch PR lands.
+
+#### The `schema` field and back-compat
+
+- **`schema?: number`** — a positive integer. Absent ⇒ **1** (every existing pack). Schema 1
+  keeps verbatim v1 validation, including the `contents.mcp` rejection below.
+- **`schema: 2`** unlocks the six new `contents` keys and the `provides`/`requires` arrays.
+- **`schema: 3` or higher** is *not* fatal: the pack loads its **schema-2 subset** and one
+  forward-compat warning is recorded (`pack.yaml: schema N is newer than supported (2)`).
+  This keeps a newer pack installable on an older Bobbit rather than vanishing — the publisher
+  gets a warning, the supported keys still resolve, and unknown keys are ignored as always.
+
+#### `provides` / `requires` capability names
+
+Two optional top-level arrays of **capability names** (each entry matches `/^[a-z0-9][a-z0-9-]*$/`):
+
+- **`provides?: string[]`** — capability names this pack contributes.
+- **`requires?: string[]`** — capability names this pack depends on.
+
+They are **metadata only** in this PR (recorded on the parsed manifest, surfaced nowhere
+behaviourally yet) — the dependency/capability graph that consumes them belongs to a later
+goal. They are validated now so packs can declare them ahead of that work.
+
+#### Six new `contents` keys
+
+Schema 2 adds six optional `contents` keys. Each is a `string[]` of **safe basenames** (same
+guard as `contents.entrypoints` — no path separators, no `..`, no absolute/drive forms), and
+each defaults to `[]` when absent:
+
+| `contents` key | YAML key | Loader in this PR? | Purpose |
+|---|---|---|---|
+| `providers` | `providers` | **Yes** | `providers/<id>.yaml` provider contributions (below). |
+| `hooks` | `hooks` | No (reserved) | Hook contribution basenames. |
+| `mcp` | `mcp` | No (reserved) | MCP contribution basenames (accepted at schema 2 only). |
+| `piExtensions` | `pi-extensions` | No (reserved) | PI-extension basenames. Note the YAML key is **`pi-extensions`** (kebab-case) but the parsed field is `piExtensions` (camelCase). |
+| `runtimes` | `runtimes` | No (reserved) | Runtime contribution basenames. |
+| `workflows` | `workflows` | No (reserved) | Workflow contribution basenames. |
+
+**Only `providers` has a loader in this PR.** The other five keys are **accepted** in the
+manifest, **normalised** onto `contents`, and **surfaced in the activation catalogue** (so the
+Market UI and the `pack-activation` REST already see and toggle them), but there is no loader
+that reads their files — that is owned by the later goals that implement each contribution
+type. Declaring them today is harmless: they validate as basenames and round-trip, nothing
+more.
+
+#### Minimal schema-2 example
+
+```yaml
+# pack.yaml
+name: memory-pack
+description: Session-memory provider contributions.
+version: 1.0.0
+schema: 2                     # opt into schema 2; absent ⇒ schema 1
+provides: [session-memory]    # capability names this pack offers (metadata only)
+requires: []                  # capability names it depends on (metadata only)
+contents:
+  roles:    []
+  tools:    []
+  skills:   []
+  providers: [memory]         # loads providers/memory.yaml (see below)
+  # hooks / mcp / pi-extensions / runtimes / workflows are accepted here at
+  # schema 2 but have no loader in this PR — reserved for later goals.
+```
+
+#### Provider contributions (`providers/<id>.yaml`)
+
+A **provider** is a new **pack-scoped** Extension-Host contribution, loaded into the existing
+`PackContributionRegistry` by the same code path as panels/entrypoints/routes
+(`pack-contributions.ts`). Only files whose basename is listed in `contents.providers` are
+loaded — `providers/<name>.yaml` (a `.yml` extension is tolerated). A provider file is a
+mapping with these fields:
+
+```yaml
+# providers/memory.yaml
+id: memory                    # REQUIRED. Unique WITHIN the pack; /^[a-z0-9][a-z0-9_.-]*$/i
+kind: memory                  # memory | selector | generic. Default: generic
+module: ./memory.mjs          # REQUIRED. ESM module path, resolved RELATIVE to this file
+                              #   and containment-checked against the pack root.
+hooks: [sessionSetup, beforePrompt]   # subset of the hook allowlist (below); default []
+runtime: node                 # OPTIONAL free-form runtime hint
+budget:                       # OPTIONAL; both fields clamped
+  maxTokens: 2000             #   clamped to [64, 8192];  default 1600
+  timeoutMs: 1500             #   clamped to [100, 10000]; default 1500
+defaultEnabled: true          # default true (only an explicit `false` disables by default)
+config:                       # OPTIONAL opaque mapping handed to the provider verbatim
+  maxEntries: 50
+```
+
+Field rules and defaults:
+
+- **`id`** (required) — unique **within the pack**; a duplicate id in the same pack is a hard
+  error (`PackContributionError`) that aborts that pack's contribution load so the registry
+  surfaces it loudly rather than silently registering an ambiguous provider.
+- **`kind`** — `memory`, `selector`, or `generic`. Absent ⇒ `generic`. An unknown kind drops
+  the provider (warn) without failing the pack.
+- **`module`** (required) — an ESM module path resolved **relative to the provider YAML** and
+  re-validated (realpath-aware) to stay **inside the pack root** — the same containment guard
+  used for routes/entrypoints. A module that resolves outside the pack root drops the provider.
+- **`hooks`** — a subset of the **hook allowlist**: `sessionSetup`, `beforePrompt`,
+  `afterTurn`, `beforeCompact`, `sessionShutdown`. An **unknown hook name drops *that*
+  provider** (warn) — the rest of the pack still loads. (This is the tolerant
+  warn-and-drop contract; only the duplicate-id conflict is hard.)
+- **`budget`** — `{ maxTokens, timeoutMs }`. Defaults `{ maxTokens: 1600, timeoutMs: 1500 }`;
+  `maxTokens` is clamped to `[64, 8192]` and `timeoutMs` to `[100, 10000]`. The budget exists
+  so the (future) dispatch tier can bound how much a provider may contribute and how long it
+  may run — defined now, enforced when dispatch lands.
+- **`defaultEnabled`** — default `true`; only an explicit `false` opts out by default.
+- **`runtime?`** / **`config?`** — optional pass-through fields for the future dispatch tier.
+
+**Providers are inert in this PR.** The loader validates them and the registry indexes them,
+but nothing reads `module`, runs a `hook`, or applies the `budget` yet — provider dispatch is a
+later goal (the lifecycle hub). Authoring a provider today gets you validation, catalogue
+listing, and activation toggles, and nothing else.
+
+#### Why providers are pack-scoped, *not* a new `EntityType`
+
+Providers are keyed `(packId, contributionId)` and loaded through the pack-contribution path —
+they are deliberately **not** added to the `EntityType` union (`roles`/`tools`/`skills`) that
+the `PackResolver` name-merges. This is the binding design decision for **all** future
+pack-scoped entity types, so it is worth stating the why:
+
+`EntityType` resolution merges by **name across packs**, with higher-priority packs shadowing
+lower ones of the same name. That is exactly the wrong semantics for providers: two different
+packs may each legitimately ship a provider with id `memory`, and **both must stay active** —
+there is no "winner". Provider identity is therefore the *pair* `(packId, contributionId)`, not
+a global name, which is precisely what the `pack-contributions.ts` registry already gives
+panels/entrypoints/routes (keyed by `packId`). Reusing that path — rather than extending
+`EntityType` — keeps two same-named providers from collapsing into one. Future pack-scoped
+entity types should follow the same rule: load via the pack-contribution registry, never the
+name-merging resolver.
+
+#### Per-provider activation
+
+Providers (and the five reserved sibling kinds) are **first-class in the activation system**,
+so they round-trip through the same `GET/PUT /api/marketplace/pack-activation` REST as roles,
+tools, skills, and entrypoints — see [Activation controls](#activation-controls):
+
+- **`DisabledRefs`** gains `providers`, `hooks`, `mcp`, `piExtensions`, `runtimes`, and
+  `workflows` arrays, and all six are added to `ACTIVATION_KINDS` so normalisation, hydration,
+  and `getPackActivation` cover them automatically (one constant drives all three).
+- The **activation catalogue** in the `pack-activation` response includes the new arrays
+  (read straight from the installed pack's `contents`), so a disabled provider stays visible in
+  the unfiltered catalogue and can be re-enabled — the same
+  [catalogue/runtime split](#activation-controls) invariant that applies to every other kind.
+- A provider is toggled by its **`listName`** (its `contents.providers` basename), exactly like
+  an entrypoint. `PackContributionRegistry` filters disabled providers by `listName` (the
+  generalised analogue of the entrypoint filter), and
+  **`listProviders(projectId)`** returns only providers from packs that are **installed +
+  active + enabled** for that scope. Entrypoint filtering is byte-identical to before.
+
+These REST shapes are **purely additive** — a schema-1 pack produces a byte-identical
+catalogue, so existing clients and the existing marketplace test suite are unaffected.
 
 ### Generated `.pack-meta.yaml`
 

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -139,8 +139,8 @@ user-facing entities are toggleable:** roles, tools, skills, and entrypoints. Su
 > **Extension Platform (`schema: 2`).** The activation system also covers the new pack-scoped
 > kinds — `providers` plus the reserved siblings `hooks` / `mcp` / `piExtensions` / `runtimes`
 > / `workflows`. They are first-class in `DisabledRefs` and `ACTIVATION_KINDS`, and the
-> `pack-activation` catalogue includes their arrays, so the toggles round-trip through the same
-> REST. Of these, only **providers** currently has a loader, so disabling a provider actually
+> `pack-activation` catalogue includes their arrays only for schema-2 packs, so the toggles round-trip through the same
+> REST without changing schema-1 catalogue shapes. Of these, only **providers** currently has a loader, so disabling a provider actually
 > removes it from `PackContributionRegistry.listProviders(...)`; the other five toggle purely as
 > catalogue metadata until their loaders land. See
 > [pack.yaml schema 2 → Per-provider activation](#per-provider-activation).
@@ -331,7 +331,9 @@ have them load, validate, and toggle, even though they do nothing until the disp
 #### The `schema` field and back-compat
 
 - **`schema?: number`** — a positive integer. Absent ⇒ **1** (every existing pack). Schema 1
-  keeps verbatim v1 validation, including the `contents.mcp` rejection below.
+  keeps verbatim v1 validation, including the `contents.mcp` rejection below. Other stray
+  schema-2 `contents` keys and top-level `provides`/`requires` are ignored, so v1 packs cannot
+  load providers and their `pack-activation` catalogue remains the old shape.
 - **`schema: 2`** unlocks the six new `contents` keys and the `provides`/`requires` arrays.
 - **`schema: 3` or higher** is *not* fatal: the pack loads its **schema-2 subset** and one
   forward-compat warning is recorded (`pack.yaml: schema N is newer than supported (2)`).
@@ -409,7 +411,6 @@ runtime: node                 # OPTIONAL free-form runtime hint
 budget:                       # OPTIONAL; both fields clamped
   maxTokens: 2000             #   clamped to [64, 8192];  default 1600
   timeoutMs: 1500             #   clamped to [100, 10000]; default 1500
-defaultEnabled: true          # default true (only an explicit `false` disables by default)
 config:                       # OPTIONAL opaque mapping handed to the provider verbatim
   maxEntries: 50
 ```
@@ -432,7 +433,6 @@ Field rules and defaults:
   `maxTokens` is clamped to `[64, 8192]` and `timeoutMs` to `[100, 10000]`. The budget exists
   so the (future) dispatch tier can bound how much a provider may contribute and how long it
   may run — defined now, enforced when dispatch lands.
-- **`defaultEnabled`** — default `true`; only an explicit `false` opts out by default.
 - **`runtime?`** / **`config?`** — optional pass-through fields for the future dispatch tier.
 
 **Providers are inert in this PR.** The loader validates them and the registry indexes them,
@@ -440,22 +440,21 @@ but nothing reads `module`, runs a `hook`, or applies the `budget` yet — provi
 later goal (the lifecycle hub). Authoring a provider today gets you validation, catalogue
 listing, and activation toggles, and nothing else.
 
-#### Why providers are pack-scoped, *not* a new `EntityType`
+#### Why providers are pack-scoped, *not* name-merged
 
-Providers are keyed `(packId, contributionId)` and loaded through the pack-contribution path —
-they are deliberately **not** added to the `EntityType` union (`roles`/`tools`/`skills`) that
-the `PackResolver` name-merges. This is the binding design decision for **all** future
-pack-scoped entity types, so it is worth stating the why:
+Provider contributions are keyed `(packId, contributionId)` and loaded through the pack-contribution path —
+they are deliberately **not** added to the role/tool/skill union that the `PackResolver`
+name-merges. This is the binding design decision for **all** future pack-scoped entity types,
+so it is worth stating the why:
 
-`EntityType` resolution merges by **name across packs**, with higher-priority packs shadowing
-lower ones of the same name. That is exactly the wrong semantics for providers: two different
-packs may each legitimately ship a provider with id `memory`, and **both must stay active** —
+The role/tool/skill resolver merges by **name across packs**, with higher-priority packs
+shadowing lower ones of the same name. That is exactly the wrong semantics here: two different
+packs may each legitimately ship a contribution with id `memory`, and **both must stay active** —
 there is no "winner". Provider identity is therefore the *pair* `(packId, contributionId)`, not
 a global name, which is precisely what the `pack-contributions.ts` registry already gives
-panels/entrypoints/routes (keyed by `packId`). Reusing that path — rather than extending
-`EntityType` — keeps two same-named providers from collapsing into one. Future pack-scoped
-entity types should follow the same rule: load via the pack-contribution registry, never the
-name-merging resolver.
+panels/entrypoints/routes (keyed by `packId`). Reusing that path keeps two same-named
+contributions from collapsing into one. Future pack-scoped entity types should follow the same
+rule: load via the pack-contribution registry, never the name-merging resolver.
 
 #### Per-provider activation
 
@@ -466,8 +465,8 @@ tools, skills, and entrypoints — see [Activation controls](#activation-control
 - **`DisabledRefs`** gains `providers`, `hooks`, `mcp`, `piExtensions`, `runtimes`, and
   `workflows` arrays, and all six are added to `ACTIVATION_KINDS` so normalisation, hydration,
   and `getPackActivation` cover them automatically (one constant drives all three).
-- The **activation catalogue** in the `pack-activation` response includes the new arrays
-  (read straight from the installed pack's `contents`), so a disabled provider stays visible in
+- The **activation catalogue** in the `pack-activation` response includes the new arrays only
+  for schema-2 packs (read straight from the installed pack's `contents`), so a disabled provider stays visible in
   the unfiltered catalogue and can be re-enabled — the same
   [catalogue/runtime split](#activation-controls) invariant that applies to every other kind.
 - A provider is toggled by its **`listName`** (its `contents.providers` basename), exactly like

--- a/scripts/run-unit.mjs
+++ b/scripts/run-unit.mjs
@@ -18,8 +18,8 @@
  * expands them — never the shell (Windows command-line-length limit).
  */
 import { spawn, execSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { availableParallelism } from "node:os";
+import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { availableParallelism, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { NODE_UNIT_GLOBS } from "./test-phase-config.mjs";
@@ -53,6 +53,16 @@ function snapshotGeneratedArtifacts() {
 		}
 	};
 }
+
+// Canonicalize TMPDIR so os.tmpdir() returns the REAL path in every spawned test
+// worker. On macOS os.tmpdir() yields /var/folders/... which reaches /private/var
+// through a symlink; node-logic tests that register a project under os.tmpdir()
+// then trip the server's `symlink_root` guard (rootPath !== realpath(rootPath)).
+// The E2E phase already canonicalizes rootPaths in tests/e2e/e2e-setup.ts; this is
+// the node-logic-phase equivalent, applied once at the entry point and inherited
+// by both spawned runners. Tests that deliberately exercise the symlink guard
+// create their own explicit symlinks and are unaffected.
+try { process.env.TMPDIR = realpathSync(tmpdir()); } catch { /* leave default */ }
 
 // Some node-logic tests import compiled server modules from dist/server.
 if (!existsSync(join(projectRoot, "dist", "server"))) {

--- a/src/server/agent/pack-contributions.ts
+++ b/src/server/agent/pack-contributions.ts
@@ -96,7 +96,7 @@ export interface ProviderContribution {
 	hooks: string[];
 	runtime?: string;
 	budget: { maxTokens: number; timeoutMs: number };
-	defaultEnabled: boolean;
+	// Activation is governed solely by DisabledRefs for now; default-on/off semantics are deferred to provider dispatch/activation work.
 	config?: Record<string, unknown>;
 	listName: string;
 	sourceFile: string;
@@ -263,6 +263,7 @@ function clampNumber(value: unknown, fallback: number, min: number, max: number)
 // §0.2: providers are pack-scoped, keyed (packId, contributionId).
 // They are NOT an EntityType; two packs may each ship id "memory" and both stay active.
 export function loadProviders(packRoot: string, manifest: PackManifest): ProviderContribution[] {
+	if ((manifest.schema ?? 1) < 2) return [];
 	const listNames = manifest.contents.providers ?? [];
 	const dir = path.join(packRoot, "providers");
 	const out: ProviderContribution[] = [];
@@ -340,7 +341,6 @@ export function loadProviders(packRoot: string, manifest: PackManifest): Provide
 				maxTokens: clampNumber(budgetRaw.maxTokens, 1600, 64, 8192),
 				timeoutMs: clampNumber(budgetRaw.timeoutMs, 1500, 100, 10000),
 			},
-			defaultEnabled: data.defaultEnabled !== false,
 			listName,
 			sourceFile,
 			packRoot,

--- a/src/server/agent/pack-contributions.ts
+++ b/src/server/agent/pack-contributions.ts
@@ -7,16 +7,19 @@
 //   - `panels/<panel>.yaml`     → PanelContribution[]  (auto-discovered)
 //   - `entrypoints/<ep>.yaml`   → EntrypointContribution[] (filtered by
 //                                  manifest.contents.entrypoints[])
+//   - `providers/<id>.yaml`     → ProviderContribution[] (filtered by
+//                                  manifest.contents.providers[])
 //   - `pack.yaml.routes`        → RouteContribution
 //
 // Mirrors the tolerance of `tool-contributions.ts`: a malformed file is warned +
-// dropped and never crashes the scan — EXCEPT the four hard conflicts of §5.4,
+// dropped and never crashes the scan — EXCEPT the hard conflicts of §5.4,
 // which throw {@link PackContributionError}:
 //
 //   1. duplicate route name within a pack;
 //   2. (duplicate host-global routeId — detected at registry build, cross-pack);
 //   3. duplicate panel id within a pack;
-//   4. duplicate entrypoint id within a pack.
+//   4. duplicate entrypoint id within a pack;
+//   5. duplicate provider id within a pack.
 //
 // Each contribution carries its declaring `sourceFile` + the absolute `packRoot`
 // so the serve/import sites can resolve a path-bearing field RELATIVE to the
@@ -32,7 +35,10 @@ import { isPackPathWithinRoot } from "../extension-host/path-guard.js";
 
 // Panel ids may use dotted namespaces (e.g. `artifacts.viewer`).
 const PANEL_ID_RE = /^[a-z0-9][a-z0-9_.-]*$/i;
+const PROVIDER_ID_RE = /^[a-z0-9][a-z0-9_.-]*$/i;
 const ROUTE_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/;
+const PROVIDER_KINDS = new Set(["memory", "selector", "generic"]);
+const PROVIDER_HOOKS = new Set(["sessionSetup", "beforePrompt", "afterTurn", "beforeCompact", "sessionShutdown"]);
 
 /** A hard pack-contribution conflict (§5.4). Throwing aborts the pack's load so
  *  the registry can surface a loud error instead of silently registering an
@@ -83,6 +89,20 @@ export interface RouteContribution {
 	packRoot: string;
 }
 
+export interface ProviderContribution {
+	id: string;
+	kind: "memory" | "selector" | "generic";
+	module: string;
+	hooks: string[];
+	runtime?: string;
+	budget: { maxTokens: number; timeoutMs: number };
+	defaultEnabled: boolean;
+	config?: Record<string, unknown>;
+	listName: string;
+	sourceFile: string;
+	packRoot: string;
+}
+
 /** All pack-scoped contributions for ONE installed pack. */
 export interface PackContributions {
 	packId: string; // structural, from the pack root dir name
@@ -90,6 +110,7 @@ export interface PackContributions {
 	packRoot: string;
 	panels: PanelContribution[];
 	entrypoints: EntrypointContribution[];
+	providers: ProviderContribution[];
 	routes?: RouteContribution;
 }
 
@@ -120,6 +141,7 @@ export function loadPackContributions(packRoot: string, manifest: PackManifest):
 		packRoot,
 		panels: loadPanels(packRoot),
 		entrypoints: loadEntrypoints(packRoot, manifest),
+		providers: loadProviders(packRoot, manifest),
 	};
 	const routes = loadRoutes(packRoot, manifest);
 	if (routes) out.routes = routes;
@@ -225,6 +247,107 @@ function loadEntrypoints(packRoot: string, manifest: PackManifest): EntrypointCo
 		}
 		seenId.add(base.id);
 		out.push({ ...base, listName, sourceFile, packRoot });
+	}
+	return out;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+	return !!v && typeof v === "object" && !Array.isArray(v);
+}
+
+function clampNumber(value: unknown, fallback: number, min: number, max: number): number {
+	const n = typeof value === "number" && Number.isFinite(value) ? value : fallback;
+	return Math.min(max, Math.max(min, n));
+}
+
+// §0.2: providers are pack-scoped, keyed (packId, contributionId).
+// They are NOT an EntityType; two packs may each ship id "memory" and both stay active.
+export function loadProviders(packRoot: string, manifest: PackManifest): ProviderContribution[] {
+	const listNames = manifest.contents.providers ?? [];
+	const dir = path.join(packRoot, "providers");
+	const out: ProviderContribution[] = [];
+	const seenId = new Set<string>();
+	for (const listName of listNames) {
+		if (typeof listName !== "string" || listName.length === 0) continue;
+		if (!isSafeBasename(listName)) {
+			console.warn(`[pack-contributions] provider listName ${JSON.stringify(listName)} is not a safe basename; skipping`);
+			continue;
+		}
+		let sourceFile = path.join(dir, `${listName}.yaml`);
+		if (!fs.existsSync(sourceFile)) {
+			const alt = path.join(dir, `${listName}.yml`);
+			if (fs.existsSync(alt)) sourceFile = alt;
+		}
+		if (!isPackPathWithinRoot(dir, sourceFile)) {
+			console.warn(`[pack-contributions] provider '${listName}' resolves outside providers/ (${sourceFile}); skipping`);
+			continue;
+		}
+		let data: unknown;
+		try {
+			data = readYaml(sourceFile);
+		} catch (err) {
+			console.warn(`[pack-contributions] skipping missing/malformed provider '${listName}' (${sourceFile}): ${String(err)}`);
+			continue;
+		}
+		if (!isPlainObject(data)) {
+			console.warn(`[pack-contributions] provider '${listName}' (${sourceFile}) is not a mapping; dropping`);
+			continue;
+		}
+		const id = data.id;
+		if (typeof id !== "string" || !PROVIDER_ID_RE.test(id)) {
+			console.warn(`[pack-contributions] provider '${listName}' (${sourceFile}) has invalid id; dropping`);
+			continue;
+		}
+		const kindRaw = data.kind;
+		const kind = kindRaw === undefined ? "generic" : kindRaw;
+		if (typeof kind !== "string" || !PROVIDER_KINDS.has(kind)) {
+			console.warn(`[pack-contributions] provider '${id}' (${sourceFile}) has invalid kind; dropping`);
+			continue;
+		}
+		const mod = data.module;
+		if (typeof mod !== "string" || !isSafeRelativePath(mod)) {
+			console.warn(`[pack-contributions] provider '${id}' (${sourceFile}) has unsafe/missing module; dropping`);
+			continue;
+		}
+		const resolvedModule = path.resolve(path.dirname(sourceFile), mod);
+		if (!isPackPathWithinRoot(packRoot, resolvedModule)) {
+			console.warn(`[pack-contributions] provider '${id}' (${sourceFile}) module resolves outside pack root; dropping`);
+			continue;
+		}
+		const hooksRaw = data.hooks ?? [];
+		if (!Array.isArray(hooksRaw) || !hooksRaw.every((h): h is string => typeof h === "string")) {
+			console.warn(`[pack-contributions] provider '${id}' (${sourceFile}) has invalid hooks; dropping`);
+			continue;
+		}
+		const unknownHook = hooksRaw.find((h) => !PROVIDER_HOOKS.has(h));
+		if (unknownHook !== undefined) {
+			console.warn(`[pack-contributions] provider '${id}' (${sourceFile}) declares unknown hook ${JSON.stringify(unknownHook)}; dropping`);
+			continue;
+		}
+		if (seenId.has(id)) {
+			throw new PackContributionError(
+				`pack "${packIdFromRoot(packRoot)}" declares provider id "${id}" more than once; provider ids must be unique within a pack`,
+			);
+		}
+		seenId.add(id);
+		const budgetRaw = isPlainObject(data.budget) ? data.budget : {};
+		const provider: ProviderContribution = {
+			id,
+			kind: kind as ProviderContribution["kind"],
+			module: mod,
+			hooks: hooksRaw,
+			budget: {
+				maxTokens: clampNumber(budgetRaw.maxTokens, 1600, 64, 8192),
+				timeoutMs: clampNumber(budgetRaw.timeoutMs, 1500, 100, 10000),
+			},
+			defaultEnabled: data.defaultEnabled !== false,
+			listName,
+			sourceFile,
+			packRoot,
+		};
+		if (typeof data.runtime === "string" && data.runtime.length > 0) provider.runtime = data.runtime;
+		if (isPlainObject(data.config)) provider.config = data.config;
+		out.push(provider);
 	}
 	return out;
 }

--- a/src/server/agent/pack-manifest.ts
+++ b/src/server/agent/pack-manifest.ts
@@ -87,13 +87,40 @@ export function validateManifest(
 	if (!nonEmptyString(d.description)) return fail("pack.yaml: description is required and non-empty");
 	if (!nonEmptyString(d.version)) return fail("pack.yaml: version is required and non-empty");
 
+	let schema = 1;
+	if (d.schema !== undefined) {
+		if (typeof d.schema !== "number" || !Number.isInteger(d.schema) || d.schema <= 0) {
+			return fail("pack.yaml: schema must be a positive integer");
+		}
+		schema = d.schema;
+		if (schema > 2) problems?.push(`pack.yaml: schema ${schema} is newer than supported (2)`);
+	}
+
+	const parseCapabilities = (key: "provides" | "requires"): string[] | undefined | null => {
+		const raw = d[key];
+		if (raw === undefined) return undefined;
+		const parsed = asStringArray(raw);
+		if (parsed === null) return fail(`pack.yaml: ${key} must be an array of strings`);
+		for (const entry of parsed) {
+			if (!PACK_NAME_RE.test(entry)) {
+				return fail(`pack.yaml: ${key} entry ${JSON.stringify(entry)} must match /^[a-z0-9][a-z0-9-]*$/`);
+			}
+		}
+		return parsed;
+	};
+	const provides = parseCapabilities("provides");
+	if (provides === null) return null;
+	const requires = parseCapabilities("requires");
+	if (requires === null) return null;
+
 	const contents = d.contents;
 	if (!contents || typeof contents !== "object" || Array.isArray(contents)) {
 		return fail("pack.yaml: contents is required (object with roles/tools/skills arrays)");
 	}
 	const c = contents as Record<string, unknown>;
-	// MVP boundary: MCP installs are out of scope — reject any contents.mcp.
-	if ("mcp" in c) {
+	// MVP boundary for v1: MCP installs were out of scope. Schema 2 accepts the
+	// catalogue key only; no MCP loader is introduced in this PR.
+	if (schema < 2 && "mcp" in c) {
 		return fail("pack.yaml: contents.mcp is not allowed (MCP installs are out of scope in MVP)");
 	}
 	const roles = asStringArray(c.roles);
@@ -102,32 +129,47 @@ export function validateManifest(
 	if (roles === null) return fail("pack.yaml: contents.roles must be an array of strings");
 	if (tools === null) return fail("pack.yaml: contents.tools must be an array of strings");
 	if (skills === null) return fail("pack.yaml: contents.skills must be an array of strings");
-	// NEW (pack-schema-v1 §1.2): contents.entrypoints — basenames of entrypoints/<name>.yaml
-	// files. Optional + defaults to [] (a pack with no entrypoints stays valid); when
-	// present it MUST be a string array.
-	let entrypoints: string[] = [];
-	if (c.entrypoints !== undefined) {
-		const parsed = asStringArray(c.entrypoints);
-		if (parsed === null) return fail("pack.yaml: contents.entrypoints must be an array of strings");
-		// Path-traversal guard: each entry is a file basename joined into
-		// entrypoints/<name>.yaml — reject separators, `..`, absolute/drive forms.
+	const parseContentsBasenames = (yamlKey: string, raw: unknown): string[] | null => {
+		if (raw === undefined) return [];
+		const parsed = asStringArray(raw);
+		if (parsed === null) return fail(`pack.yaml: contents.${yamlKey} must be an array of strings`);
+		// Path-traversal guard: each entry is a file basename joined into a
+		// contribution subdir — reject separators, `..`, absolute/drive forms.
 		for (const e of parsed) {
 			if (!isSafeBasename(e)) {
 				return fail(
-					`pack.yaml: contents.entrypoints entry ${JSON.stringify(e)} is not a safe basename ` +
+					`pack.yaml: contents.${yamlKey} entry ${JSON.stringify(e)} is not a safe basename ` +
 						`(must match /^[A-Za-z0-9._-]+$/ with no path separators or ".." segments)`,
 				);
 			}
 		}
-		entrypoints = parsed;
-	}
+		return parsed;
+	};
+	// contents.entrypoints — basenames of entrypoints/<name>.yaml files.
+	const entrypoints = parseContentsBasenames("entrypoints", c.entrypoints);
+	if (entrypoints === null) return null;
+	const providers = parseContentsBasenames("providers", c.providers);
+	if (providers === null) return null;
+	const hooks = parseContentsBasenames("hooks", c.hooks);
+	if (hooks === null) return null;
+	const mcp = parseContentsBasenames("mcp", c.mcp);
+	if (mcp === null) return null;
+	const piExtensions = parseContentsBasenames("pi-extensions", c["pi-extensions"]);
+	if (piExtensions === null) return null;
+	const runtimes = parseContentsBasenames("runtimes", c.runtimes);
+	if (runtimes === null) return null;
+	const workflows = parseContentsBasenames("workflows", c.workflows);
+	if (workflows === null) return null;
 
 	const manifest: PackManifest = {
 		name: d.name as string,
 		description: (d.description as string).trim(),
 		version: (d.version as string).trim(),
-		contents: { roles, tools, skills, entrypoints },
+		contents: { roles, tools, skills, entrypoints, providers, hooks, mcp, piExtensions, runtimes, workflows },
 	};
+	if (d.schema !== undefined) manifest.schema = schema;
+	if (provides !== undefined) manifest.provides = provides;
+	if (requires !== undefined) manifest.requires = requires;
 	// NEW (pack-schema-v1 §1.2): optional top-level `routes: { module?, names? }`.
 	// Tolerant — a malformed routes block is dropped (no routes), never fatal.
 	const routes = parseRoutesRef(d.routes);

--- a/src/server/agent/pack-manifest.ts
+++ b/src/server/agent/pack-manifest.ts
@@ -108,9 +108,10 @@ export function validateManifest(
 		}
 		return parsed;
 	};
-	const provides = parseCapabilities("provides");
+	const schemaSupportsExtensionKeys = schema >= 2;
+	const provides = schemaSupportsExtensionKeys ? parseCapabilities("provides") : undefined;
 	if (provides === null) return null;
-	const requires = parseCapabilities("requires");
+	const requires = schemaSupportsExtensionKeys ? parseCapabilities("requires") : undefined;
 	if (requires === null) return null;
 
 	const contents = d.contents;
@@ -148,18 +149,32 @@ export function validateManifest(
 	// contents.entrypoints — basenames of entrypoints/<name>.yaml files.
 	const entrypoints = parseContentsBasenames("entrypoints", c.entrypoints);
 	if (entrypoints === null) return null;
-	const providers = parseContentsBasenames("providers", c.providers);
-	if (providers === null) return null;
-	const hooks = parseContentsBasenames("hooks", c.hooks);
-	if (hooks === null) return null;
-	const mcp = parseContentsBasenames("mcp", c.mcp);
-	if (mcp === null) return null;
-	const piExtensions = parseContentsBasenames("pi-extensions", c["pi-extensions"]);
-	if (piExtensions === null) return null;
-	const runtimes = parseContentsBasenames("runtimes", c.runtimes);
-	if (runtimes === null) return null;
-	const workflows = parseContentsBasenames("workflows", c.workflows);
-	if (workflows === null) return null;
+	let providers: string[] = [];
+	let hooks: string[] = [];
+	let mcp: string[] = [];
+	let piExtensions: string[] = [];
+	let runtimes: string[] = [];
+	let workflows: string[] = [];
+	if (schemaSupportsExtensionKeys) {
+		const parsedProviders = parseContentsBasenames("providers", c.providers);
+		if (parsedProviders === null) return null;
+		providers = parsedProviders;
+		const parsedHooks = parseContentsBasenames("hooks", c.hooks);
+		if (parsedHooks === null) return null;
+		hooks = parsedHooks;
+		const parsedMcp = parseContentsBasenames("mcp", c.mcp);
+		if (parsedMcp === null) return null;
+		mcp = parsedMcp;
+		const parsedPiExtensions = parseContentsBasenames("pi-extensions", c["pi-extensions"]);
+		if (parsedPiExtensions === null) return null;
+		piExtensions = parsedPiExtensions;
+		const parsedRuntimes = parseContentsBasenames("runtimes", c.runtimes);
+		if (parsedRuntimes === null) return null;
+		runtimes = parsedRuntimes;
+		const parsedWorkflows = parseContentsBasenames("workflows", c.workflows);
+		if (parsedWorkflows === null) return null;
+		workflows = parsedWorkflows;
+	}
 
 	const manifest: PackManifest = {
 		name: d.name as string,

--- a/src/server/agent/pack-types.ts
+++ b/src/server/agent/pack-types.ts
@@ -42,18 +42,24 @@ export interface PackRoutesRef {
 	names?: string[];
 }
 
-/** Parsed `pack.yaml`. `contents` is REQUIRED with all entity-list keys. */
+/** Parsed `pack.yaml`. `contents` is REQUIRED with all v1 entity-list keys. */
 export interface PackManifest {
 	name: string;
 	description: string;
 	version: string;
+	/** Manifest schema version. Absent manifests are schema 1. */
+	schema?: number;
 	author?: string;
 	homepage?: string;
+	/** Capability names this pack contributes (schema 2+ metadata). */
+	provides?: string[];
+	/** Capability names this pack depends on (schema 2+ metadata). */
+	requires?: string[];
 	/**
-	 * Authoritative advertised contents. All keys REQUIRED but each MAY be
-	 * empty. NO `mcp` key in a publishable manifest (MVP boundary — packs may
-	 * not ship/install MCP configs). `mcp` exists only as a reserved code-level
-	 * {@link EntityType} for the future loader seam.
+	 * Authoritative advertised contents. v1 keys are REQUIRED but each MAY be
+	 * empty. Schema 2 adds optional pack-scoped catalogues; only `providers` has
+	 * a loader in G1.1, the other keys are activation/catalogue metadata for later
+	 * extension-platform goals.
 	 *
 	 * `entrypoints` lists the basenames (no extension) of `entrypoints/<name>.yaml`
 	 * files — the user-facing activation catalogue the Market UI toggles and the
@@ -65,6 +71,12 @@ export interface PackManifest {
 		tools: string[]; // tool group dir names
 		skills: string[];
 		entrypoints: string[]; // entrypoints/<name>.yaml basenames; toggleable
+		providers?: string[]; // providers/<name>.yaml basenames; toggleable
+		hooks?: string[]; // hook contribution basenames (accepted, loader later)
+		mcp?: string[]; // MCP contribution basenames (schema 2+, loader later)
+		piExtensions?: string[]; // YAML key `pi-extensions`; loader later
+		runtimes?: string[]; // runtime contribution basenames (accepted, loader later)
+		workflows?: string[]; // workflow contribution basenames (accepted, loader later)
 	};
 	/** Optional top-level pack-level routes (module + allowlist). Support surface,
 	 *  not toggleable. Absent ⇒ the pack contributes no server routes. */

--- a/src/server/agent/project-config-store.ts
+++ b/src/server/agent/project-config-store.ts
@@ -221,12 +221,18 @@ export interface DisabledRefs {
 	tools?: string[];
 	skills?: string[];
 	entrypoints?: string[];
+	providers?: string[];
+	hooks?: string[];
+	mcp?: string[];
+	piExtensions?: string[];
+	runtimes?: string[];
+	workflows?: string[];
 }
 
 /** scope → packName → disabled entity refs by kind. Default (absent) = all enabled. */
 export type PackActivationMap = Partial<Record<PackOrderScope, Record<string, DisabledRefs>>>;
 
-const ACTIVATION_KINDS = ["roles", "tools", "skills", "entrypoints"] as const;
+const ACTIVATION_KINDS = ["roles", "tools", "skills", "entrypoints", "providers", "hooks", "mcp", "piExtensions", "runtimes", "workflows"] as const;
 
 function normalizePackOrder(raw: unknown): { value: PackOrderMap; ok: boolean } {
 	if (!isPlainObject(raw)) return { value: {}, ok: false };

--- a/src/server/extension-host/pack-contribution-registry.ts
+++ b/src/server/extension-host/pack-contribution-registry.ts
@@ -1,7 +1,7 @@
 // src/server/extension-host/pack-contribution-registry.ts
 //
 // Project-scoped registry of the PACK-SCOPED contributions (panels / entrypoints
-// / routes), the pack-scoped analogue of the tool cascade
+// / providers / routes), the pack-scoped analogue of the tool cascade
 // (pack-schema-v1-rationalisation §5.2).
 //
 // It enumerates installed market packs (the SAME enumeration the tool cascade
@@ -20,6 +20,7 @@ import {
 	type PackContributions,
 	type PanelContribution,
 	type EntrypointContribution,
+	type ProviderContribution,
 } from "../agent/pack-contributions.js";
 import type { PackEntry, PackScope } from "../agent/pack-types.js";
 
@@ -33,6 +34,8 @@ export interface PackContributionResolver {
 	getPanel(projectId: string | undefined, packId: string, panelId: string): PanelContribution | undefined;
 	/** Resolve an entrypoint within a pack. */
 	getEntrypoint(projectId: string | undefined, packId: string, entrypointId: string): EntrypointContribution | undefined;
+	/** List active provider contributions across all active packs. */
+	listProviders(projectId: string | undefined): ProviderContribution[];
 	/** True when the pack declares routeName in its routes.names allowlist. */
 	hasRoute(projectId: string | undefined, packId: string, routeName: string): boolean;
 }
@@ -65,6 +68,7 @@ export class PackContributionRegistry implements PackContributionResolver {
 	constructor(
 		private readonly enumerate: (projectId: string | undefined) => PackEntry[],
 		private readonly disabledEntrypoints?: DisabledEntrypointsLookup,
+		private readonly disabledProviders?: DisabledEntrypointsLookup,
 	) {}
 
 	/** Drop the per-project index cache (rebuilt lazily on next read). */
@@ -86,6 +90,10 @@ export class PackContributionRegistry implements PackContributionResolver {
 
 	getEntrypoint(projectId: string | undefined, packId: string, entrypointId: string): EntrypointContribution | undefined {
 		return this.getPack(projectId, packId)?.entrypoints.find((e) => e.id === entrypointId);
+	}
+
+	listProviders(projectId: string | undefined): ProviderContribution[] {
+		return this.index(projectId).list.flatMap((pack) => pack.providers);
 	}
 
 	hasRoute(projectId: string | undefined, packId: string, routeName: string): boolean {
@@ -134,6 +142,12 @@ export class PackContributionRegistry implements PackContributionResolver {
 				: undefined;
 			if (disabled && disabled.size > 0) {
 				contrib = { ...contrib, entrypoints: contrib.entrypoints.filter((ep) => !disabled.has(ep.listName)) };
+			}
+			const disabledProviders = this.disabledProviders
+				? new Set(this.disabledProviders(e.scope, projectId, contrib.packName))
+				: undefined;
+			if (disabledProviders && disabledProviders.size > 0) {
+				contrib = { ...contrib, providers: contrib.providers.filter((p) => !disabledProviders.has(p.listName)) };
 			}
 			loaded.push(contrib);
 		}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -6742,7 +6742,7 @@ async function handleApiRoute(
 			projectBase: string | undefined,
 			store: PackOrderStore,
 			packName: string,
-		): { roles: string[]; tools: string[]; skills: string[]; entrypoints: Array<{ listName: string; label?: string; kind?: "composer-slash" | "git-widget-button" | "command-palette" | "route"; routeId?: string }>; providers: string[]; hooks: string[]; mcp: string[]; piExtensions: string[]; runtimes: string[]; workflows: string[]; descriptions: PackEntityDescriptions } | null => {
+		): { roles: string[]; tools: string[]; skills: string[]; entrypoints: Array<{ listName: string; label?: string; kind?: "composer-slash" | "git-widget-button" | "command-palette" | "route"; routeId?: string }>; providers?: string[]; hooks?: string[]; mcp?: string[]; piExtensions?: string[]; runtimes?: string[]; workflows?: string[]; descriptions: PackEntityDescriptions } | null => {
 			const base = scope === "server" ? getProjectRoot() : scope === "global-user" ? os.homedir() : projectBase;
 			if (base === undefined) return null;
 			const entries = scopeMarketPackEntries(scope as PackScope, base, store.getPackOrder(scope));
@@ -6770,7 +6770,7 @@ async function handleApiRoute(
 					entrypointByListName.set(ep.listName, { label: ep.label, kind: ep.kind, routeId: ep.routeId });
 				}
 			} catch { /* metadata is optional; listName is the stable key */ }
-			return {
+			const baseCatalogue = {
 				roles: [...c.roles],
 				tools: concreteTools.tools,
 				skills: [...c.skills],
@@ -6778,15 +6778,23 @@ async function handleApiRoute(
 					const meta = entrypointByListName.get(listName);
 					return meta ? { listName, ...meta } : { listName };
 				}),
+				// One-line per-entity descriptions for the activation disclosure (R3).
+				// Read from the SAME installed pack dir as the catalogue above — never
+				// from the runtime-filtered /api/tools or /api/ext/contributions.
+				descriptions,
+			};
+			if ((entry.manifest.schema ?? 1) < 2) return baseCatalogue;
+			return {
+				roles: baseCatalogue.roles,
+				tools: baseCatalogue.tools,
+				skills: baseCatalogue.skills,
+				entrypoints: baseCatalogue.entrypoints,
 				providers: [...(c.providers ?? [])],
 				hooks: [...(c.hooks ?? [])],
 				mcp: [...(c.mcp ?? [])],
 				piExtensions: [...(c.piExtensions ?? [])],
 				runtimes: [...(c.runtimes ?? [])],
 				workflows: [...(c.workflows ?? [])],
-				// One-line per-entity descriptions for the activation disclosure (R3).
-				// Read from the SAME installed pack dir as the catalogue above — never
-				// from the runtime-filtered /api/tools or /api/ext/contributions.
 				descriptions,
 			};
 		};
@@ -6829,12 +6837,12 @@ async function handleApiRoute(
 				tools: normaliseKind("tools", new Set(catalogue.tools)),
 				skills: normaliseKind("skills", new Set(catalogue.skills)),
 				entrypoints: normaliseKind("entrypoints", catalogueEntrypointNames),
-				providers: normaliseKind("providers", new Set(catalogue.providers)),
-				hooks: normaliseKind("hooks", new Set(catalogue.hooks)),
-				mcp: normaliseKind("mcp", new Set(catalogue.mcp)),
-				piExtensions: normaliseKind("piExtensions", new Set(catalogue.piExtensions)),
-				runtimes: normaliseKind("runtimes", new Set(catalogue.runtimes)),
-				workflows: normaliseKind("workflows", new Set(catalogue.workflows)),
+				providers: normaliseKind("providers", new Set(catalogue.providers ?? [])),
+				hooks: normaliseKind("hooks", new Set(catalogue.hooks ?? [])),
+				mcp: normaliseKind("mcp", new Set(catalogue.mcp ?? [])),
+				piExtensions: normaliseKind("piExtensions", new Set(catalogue.piExtensions ?? [])),
+				runtimes: normaliseKind("runtimes", new Set(catalogue.runtimes ?? [])),
+				workflows: normaliseKind("workflows", new Set(catalogue.workflows ?? [])),
 			};
 			const cfgStore = st.target.store as unknown as ProjectConfigStore;
 			cfgStore.setPackActivation(scope as PackOrderScope, packName, normalized);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1233,6 +1233,7 @@ export function createGateway(config: GatewayConfig) {
 	packContributionRegistry = new PackContributionRegistry(
 		marketPackEntriesForProject,
 		(scope, projectId, packName) => packActivationStore(scope as PackScope, projectId)?.getPackActivation(scope as PackOrderScope, packName).entrypoints ?? [],
+		(scope, projectId, packName) => packActivationStore(scope as PackScope, projectId)?.getPackActivation(scope as PackOrderScope, packName).providers ?? [],
 	);
 	routeRegistry = new RouteRegistry(packContributionRegistry);
 
@@ -6741,7 +6742,7 @@ async function handleApiRoute(
 			projectBase: string | undefined,
 			store: PackOrderStore,
 			packName: string,
-		): { roles: string[]; tools: string[]; skills: string[]; entrypoints: Array<{ listName: string; label?: string; kind?: "composer-slash" | "git-widget-button" | "command-palette" | "route"; routeId?: string }>; descriptions: PackEntityDescriptions } | null => {
+		): { roles: string[]; tools: string[]; skills: string[]; entrypoints: Array<{ listName: string; label?: string; kind?: "composer-slash" | "git-widget-button" | "command-palette" | "route"; routeId?: string }>; providers: string[]; hooks: string[]; mcp: string[]; piExtensions: string[]; runtimes: string[]; workflows: string[]; descriptions: PackEntityDescriptions } | null => {
 			const base = scope === "server" ? getProjectRoot() : scope === "global-user" ? os.homedir() : projectBase;
 			if (base === undefined) return null;
 			const entries = scopeMarketPackEntries(scope as PackScope, base, store.getPackOrder(scope));
@@ -6777,6 +6778,12 @@ async function handleApiRoute(
 					const meta = entrypointByListName.get(listName);
 					return meta ? { listName, ...meta } : { listName };
 				}),
+				providers: [...(c.providers ?? [])],
+				hooks: [...(c.hooks ?? [])],
+				mcp: [...(c.mcp ?? [])],
+				piExtensions: [...(c.piExtensions ?? [])],
+				runtimes: [...(c.runtimes ?? [])],
+				workflows: [...(c.workflows ?? [])],
 				// One-line per-entity descriptions for the activation disclosure (R3).
 				// Read from the SAME installed pack dir as the catalogue above — never
 				// from the runtime-filtered /api/tools or /api/ext/contributions.
@@ -6812,7 +6819,7 @@ async function handleApiRoute(
 			// catalogue (drop refs for entities the pack does not declare).
 			const reqDisabled = (body?.disabled ?? {}) as Record<string, unknown>;
 			const catalogueEntrypointNames = new Set(catalogue.entrypoints.map((e) => e.listName));
-			const normaliseKind = (kind: "roles" | "tools" | "skills" | "entrypoints", valid: Set<string>): string[] => {
+			const normaliseKind = (kind: "roles" | "tools" | "skills" | "entrypoints" | "providers" | "hooks" | "mcp" | "piExtensions" | "runtimes" | "workflows", valid: Set<string>): string[] => {
 				const raw = reqDisabled[kind];
 				if (!Array.isArray(raw)) return [];
 				return raw.filter((x): x is string => typeof x === "string" && valid.has(x));
@@ -6822,6 +6829,12 @@ async function handleApiRoute(
 				tools: normaliseKind("tools", new Set(catalogue.tools)),
 				skills: normaliseKind("skills", new Set(catalogue.skills)),
 				entrypoints: normaliseKind("entrypoints", catalogueEntrypointNames),
+				providers: normaliseKind("providers", new Set(catalogue.providers)),
+				hooks: normaliseKind("hooks", new Set(catalogue.hooks)),
+				mcp: normaliseKind("mcp", new Set(catalogue.mcp)),
+				piExtensions: normaliseKind("piExtensions", new Set(catalogue.piExtensions)),
+				runtimes: normaliseKind("runtimes", new Set(catalogue.runtimes)),
+				workflows: normaliseKind("workflows", new Set(catalogue.workflows)),
 			};
 			const cfgStore = st.target.store as unknown as ProjectConfigStore;
 			cfgStore.setPackActivation(scope as PackOrderScope, packName, normalized);

--- a/tests/e2e/marketplace-provider-activation.spec.ts
+++ b/tests/e2e/marketplace-provider-activation.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * API E2E — schema-v2 provider activation round-trip.
+ *
+ * Pure REST coverage for the additive pack-activation shape: provider refs and
+ * the new schema-v2 catalogue arrays persist through GET/PUT without any
+ * provider runtime dispatch.
+ */
+import { test, expect } from "./in-process-harness.js";
+import { apiFetch } from "./e2e-setup.js";
+import fs from "node:fs";
+import path from "node:path";
+
+function writePack(root: string, packName: string): string {
+	const packDir = path.join(root, ".bobbit", "config", "market-packs", packName);
+	fs.mkdirSync(path.join(packDir, "providers"), { recursive: true });
+	fs.mkdirSync(path.join(packDir, "lib"), { recursive: true });
+	fs.writeFileSync(path.join(packDir, "pack.yaml"), [
+		"schema: 2",
+		`name: ${packName}`,
+		"description: Provider activation e2e",
+		"version: 1.0.0",
+		"contents:",
+		"  roles: []",
+		"  tools: []",
+		"  skills: []",
+		"  entrypoints: []",
+		"  providers: [memory]",
+		"  hooks: [turn-hook]",
+		"  mcp: [local-mcp]",
+		"  pi-extensions: [pi-card]",
+		"  runtimes: [node]",
+		"  workflows: [review-flow]",
+	].join("\n") + "\n", "utf-8");
+	fs.writeFileSync(path.join(packDir, ".pack-meta.yaml"), [
+		"sourceUrl: e2e",
+		"sourceRef: local",
+		"commit: test",
+		`packName: ${packName}`,
+		"version: 1.0.0",
+		"installedAt: '2026-01-01T00:00:00.000Z'",
+		"updatedAt: '2026-01-01T00:00:00.000Z'",
+		"scope: server",
+	].join("\n") + "\n", "utf-8");
+	fs.writeFileSync(path.join(packDir, "providers", "memory.yaml"), "id: memory\nmodule: ../lib/provider.js\nhooks: [beforePrompt]\n", "utf-8");
+	fs.writeFileSync(path.join(packDir, "lib", "provider.js"), "export default {};\n", "utf-8");
+	return packDir;
+}
+
+test.describe("marketplace pack activation — providers", () => {
+	test("PUT/GET round-trips disabled.providers and exposes schema-v2 catalogue arrays", async ({ gateway }) => {
+		const packName = `provider-activation-${Date.now()}`;
+		const packDir = writePack(gateway.bobbitDir, packName);
+		try {
+			const put = await apiFetch("/api/marketplace/pack-activation", {
+				method: "PUT",
+				body: JSON.stringify({
+					scope: "server",
+					packName,
+					disabled: {
+						providers: ["memory", "not-declared"],
+						hooks: ["turn-hook"],
+						mcp: ["local-mcp"],
+						piExtensions: ["pi-card"],
+						runtimes: ["node"],
+						workflows: ["review-flow"],
+					},
+				}),
+			});
+			expect(put.status).toBe(200);
+			const putBody = await put.json();
+			expect(putBody.catalogue.providers).toEqual(["memory"]);
+			expect(putBody.catalogue.hooks).toEqual(["turn-hook"]);
+			expect(putBody.catalogue.mcp).toEqual(["local-mcp"]);
+			expect(putBody.catalogue.piExtensions).toEqual(["pi-card"]);
+			expect(putBody.catalogue.runtimes).toEqual(["node"]);
+			expect(putBody.catalogue.workflows).toEqual(["review-flow"]);
+			expect(putBody.disabled.providers).toEqual(["memory"]);
+
+			const get = await apiFetch(`/api/marketplace/pack-activation?scope=server&packName=${encodeURIComponent(packName)}`);
+			expect(get.status).toBe(200);
+			const getBody = await get.json();
+			expect(getBody.disabled.providers).toEqual(["memory"]);
+			expect(getBody.catalogue).toMatchObject({
+				providers: ["memory"],
+				hooks: ["turn-hook"],
+				mcp: ["local-mcp"],
+				piExtensions: ["pi-card"],
+				runtimes: ["node"],
+				workflows: ["review-flow"],
+			});
+		} finally {
+			await apiFetch("/api/marketplace/pack-activation", {
+				method: "PUT",
+				body: JSON.stringify({ scope: "server", packName, disabled: {} }),
+			}).catch(() => {});
+			fs.rmSync(packDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/tests/e2e/marketplace-provider-activation.spec.ts
+++ b/tests/e2e/marketplace-provider-activation.spec.ts
@@ -10,6 +10,19 @@ import { apiFetch } from "./e2e-setup.js";
 import fs from "node:fs";
 import path from "node:path";
 
+function writeMeta(packDir: string, packName: string): void {
+	fs.writeFileSync(path.join(packDir, ".pack-meta.yaml"), [
+		"sourceUrl: e2e",
+		"sourceRef: local",
+		"commit: test",
+		`packName: ${packName}`,
+		"version: 1.0.0",
+		"installedAt: '2026-01-01T00:00:00.000Z'",
+		"updatedAt: '2026-01-01T00:00:00.000Z'",
+		"scope: server",
+	].join("\n") + "\n", "utf-8");
+}
+
 function writePack(root: string, packName: string): string {
 	const packDir = path.join(root, ".bobbit", "config", "market-packs", packName);
 	fs.mkdirSync(path.join(packDir, "providers"), { recursive: true });
@@ -31,22 +44,54 @@ function writePack(root: string, packName: string): string {
 		"  runtimes: [node]",
 		"  workflows: [review-flow]",
 	].join("\n") + "\n", "utf-8");
-	fs.writeFileSync(path.join(packDir, ".pack-meta.yaml"), [
-		"sourceUrl: e2e",
-		"sourceRef: local",
-		"commit: test",
-		`packName: ${packName}`,
+	writeMeta(packDir, packName);
+	fs.writeFileSync(path.join(packDir, "providers", "memory.yaml"), "id: memory\nmodule: ../lib/provider.js\nhooks: [beforePrompt]\n", "utf-8");
+	fs.writeFileSync(path.join(packDir, "lib", "provider.js"), "export default {};\n", "utf-8");
+	return packDir;
+}
+
+function writeSchema1Pack(root: string, packName: string): string {
+	const packDir = path.join(root, ".bobbit", "config", "market-packs", packName);
+	fs.mkdirSync(path.join(packDir, "providers"), { recursive: true });
+	fs.mkdirSync(path.join(packDir, "lib"), { recursive: true });
+	fs.writeFileSync(path.join(packDir, "pack.yaml"), [
+		`name: ${packName}`,
+		"description: Schema 1 activation e2e",
 		"version: 1.0.0",
-		"installedAt: '2026-01-01T00:00:00.000Z'",
-		"updatedAt: '2026-01-01T00:00:00.000Z'",
-		"scope: server",
+		"contents:",
+		"  roles: []",
+		"  tools: []",
+		"  skills: []",
+		"  entrypoints: []",
+		"  providers: [memory]",
+		"  hooks: [turn-hook]",
+		"  pi-extensions: [pi-card]",
+		"  runtimes: [node]",
+		"  workflows: [review-flow]",
 	].join("\n") + "\n", "utf-8");
+	writeMeta(packDir, packName);
 	fs.writeFileSync(path.join(packDir, "providers", "memory.yaml"), "id: memory\nmodule: ../lib/provider.js\nhooks: [beforePrompt]\n", "utf-8");
 	fs.writeFileSync(path.join(packDir, "lib", "provider.js"), "export default {};\n", "utf-8");
 	return packDir;
 }
 
 test.describe("marketplace pack activation — providers", () => {
+	test("schema-1 catalogue omits schema-v2 arrays", async ({ gateway }) => {
+		const packName = `provider-activation-v1-${Date.now()}`;
+		const packDir = writeSchema1Pack(gateway.bobbitDir, packName);
+		try {
+			const get = await apiFetch(`/api/marketplace/pack-activation?scope=server&packName=${encodeURIComponent(packName)}`);
+			expect(get.status).toBe(200);
+			const getBody = await get.json();
+			expect(Object.keys(getBody.catalogue).sort()).toEqual(["descriptions", "entrypoints", "roles", "skills", "tools"]);
+			for (const key of ["providers", "hooks", "mcp", "piExtensions", "runtimes", "workflows"]) {
+				expect(key in getBody.catalogue, `${key} must be absent for schema-1 packs`).toBe(false);
+			}
+		} finally {
+			fs.rmSync(packDir, { recursive: true, force: true });
+		}
+	});
+
 	test("PUT/GET round-trips disabled.providers and exposes schema-v2 catalogue arrays", async ({ gateway }) => {
 		const packName = `provider-activation-${Date.now()}`;
 		const packDir = writePack(gateway.bobbitDir, packName);

--- a/tests/extension-host-route-dispatcher.test.ts
+++ b/tests/extension-host-route-dispatcher.test.ts
@@ -136,6 +136,7 @@ function contribResolver(packs: PackContributions[]): PackContributionResolver {
 		getPack: (_pid, packId) => byId.get(packId),
 		getPanel: (_pid, packId, panelId) => byId.get(packId)?.panels.find((p) => p.id === panelId),
 		getEntrypoint: (_pid, packId, id) => byId.get(packId)?.entrypoints.find((e) => e.id === id),
+		listProviders: () => packs.flatMap((p) => p.providers),
 		hasRoute: (_pid, packId, name) => !!byId.get(packId)?.routes?.names.includes(name),
 	};
 }
@@ -143,7 +144,7 @@ function contribResolver(packs: PackContributions[]): PackContributionResolver {
 function packWithRoutes(packId: string, packRoot: string, module: string, names: string[]): PackContributions {
 	return {
 		packId, packName: packId, packRoot,
-		panels: [], entrypoints: [],
+		panels: [], entrypoints: [], providers: [],
 		routes: { module, names, sourceFile: path.join(packRoot, "pack.yaml"), packRoot },
 	};
 }
@@ -180,7 +181,7 @@ describe("RouteRegistry — pack-level resolution + allowlist + namespacing", ()
 	it("a pack with no routes ref → undefined; empty/unknown packId → undefined", () => {
 		const packRoot = path.join(tmp, "noroutes", "market-packs", "mypack");
 		const reg = new RouteRegistry(contribResolver([
-			{ packId: "mypack", packName: "mypack", packRoot, panels: [], entrypoints: [] },
+			{ packId: "mypack", packName: "mypack", packRoot, panels: [], entrypoints: [], providers: [] },
 		]));
 		assert.equal(reg.resolve("mypack", "bundle", undefined), undefined);
 		assert.equal(reg.resolve("", "bundle", undefined), undefined);

--- a/tests/pack-contributions.test.ts
+++ b/tests/pack-contributions.test.ts
@@ -84,6 +84,31 @@ describe("validateManifest (§1.2)", () => {
 		assert.equal((m.contents as Record<string, unknown>).stores, undefined);
 	});
 
+	it("schema 1 ignores schema-2 capabilities and new contents keys except mcp", () => {
+		const m = validateManifest({
+			...ok,
+			provides: ["x"],
+			requires: ["Bad_Name"],
+			contents: {
+				...ok.contents,
+				providers: ["memory"],
+				hooks: ["../unsafe"],
+				"pi-extensions": ["pi"],
+				runtimes: ["node"],
+				workflows: ["review"],
+			},
+		});
+		assert.ok(m);
+		assert.equal(m.provides, undefined);
+		assert.equal(m.requires, undefined);
+		assert.deepEqual(m.contents.providers, []);
+		assert.deepEqual(m.contents.hooks, []);
+		assert.deepEqual(m.contents.mcp, []);
+		assert.deepEqual(m.contents.piExtensions, []);
+		assert.deepEqual(m.contents.runtimes, []);
+		assert.deepEqual(m.contents.workflows, []);
+	});
+
 	it("schema 2 accepts and normalizes new contents keys plus capabilities", () => {
 		const m = validateManifest({
 			...ok,
@@ -311,7 +336,7 @@ describe("PackContributionRegistry (§5.2.1, §7)", () => {
 		w(path.join(root, "pack.yaml"), "name: memory-pack\n");
 		w(path.join(root, "providers", "memory.yaml"), "id: memory\nmodule: ../lib/provider.js\nhooks: [beforePrompt]\n");
 		w(path.join(root, "lib", "provider.js"), "export default {};\n");
-		const m = manifest("memory-pack", { providers: ["memory"] });
+		const m = { ...manifest("memory-pack", { providers: ["memory"] }), schema: 2 };
 		const enabled = new PackContributionRegistry(() => [entry(root, "server", m)]);
 		assert.deepEqual(enabled.listProviders(undefined).map((p) => p.id), ["memory"]);
 

--- a/tests/pack-contributions.test.ts
+++ b/tests/pack-contributions.test.ts
@@ -4,17 +4,17 @@
  *
  * Covers:
  *   - manifest validation: contents.entrypoints (string[]) + top-level
- *     routes:{module,names} accepted; contents.mcp still rejected; no stores schema.
+ *     routes:{module,names} accepted; contents.mcp rejected for schema 1 and accepted for schema 2; schema-v2 keys round-trip.
  *   - loadPackContributions: panels/*.yaml + entrypoints/*.yaml (filtered by
  *     contents.entrypoints[], carrying listName) + pack.yaml.routes → §5.1 shapes;
  *     malformed file warned + dropped.
  *   - path containment to PACK ROOT (renderer/entry/routes.module via
  *     isPackPathWithinRoot); escaping path rejected.
- *   - the 4 hard conflicts: dup panel id / dup entrypoint id / dup route name
+ *   - hard conflicts: dup panel id / dup entrypoint id / dup route name
  *     (loader throws PackContributionError); dup host-global routeId (registry
  *     registers NEITHER deep-link).
  *   - winning-pack collapse (§5.2.1): same packId at two scopes → ONE getPack.
- *   - activation filtering (§7): a disabled entrypoint is omitted.
+ *   - activation filtering (§7): disabled entrypoints/providers are omitted.
  *   - a no-tools pack still registers panels/entrypoints/routes.
  */
 import { describe, it, before, after } from "node:test";
@@ -76,10 +76,53 @@ describe("validateManifest (§1.2)", () => {
 		const m = validateManifest({ ...ok, routes: { module: "lib/routes.mjs", names: ["bundle", "publish"] } });
 		assert.deepEqual(m!.routes, { module: "lib/routes.mjs", names: ["bundle", "publish"] });
 	});
-	it("still rejects contents.mcp; carries no stores schema", () => {
-		assert.equal(validateManifest({ ...ok, contents: { ...ok.contents, mcp: ["x"] } }), null);
+	it("still rejects contents.mcp at schema 1; carries no stores schema", () => {
+		const problems: string[] = [];
+		assert.equal(validateManifest({ ...ok, contents: { ...ok.contents, mcp: ["x"] } }, problems), null);
+		assert.equal(problems[0], "pack.yaml: contents.mcp is not allowed (MCP installs are out of scope in MVP)");
 		const m = validateManifest(ok)! as unknown as Record<string, unknown>;
 		assert.equal((m.contents as Record<string, unknown>).stores, undefined);
+	});
+
+	it("schema 2 accepts and normalizes new contents keys plus capabilities", () => {
+		const m = validateManifest({
+			...ok,
+			schema: 2,
+			provides: ["memory-api"],
+			requires: ["host-api"],
+			contents: {
+				...ok.contents,
+				providers: ["memory"],
+				hooks: ["turn"],
+				mcp: ["local"],
+				"pi-extensions": ["pi"],
+				runtimes: ["node"],
+				workflows: ["review"],
+			},
+		});
+		assert.ok(m);
+		assert.equal(m.schema, 2);
+		assert.deepEqual(m.provides, ["memory-api"]);
+		assert.deepEqual(m.requires, ["host-api"]);
+		assert.deepEqual(m.contents.providers, ["memory"]);
+		assert.deepEqual(m.contents.hooks, ["turn"]);
+		assert.deepEqual(m.contents.mcp, ["local"]);
+		assert.deepEqual(m.contents.piExtensions, ["pi"]);
+		assert.deepEqual(m.contents.runtimes, ["node"]);
+		assert.deepEqual(m.contents.workflows, ["review"]);
+	});
+
+	it("rejects bad capability names and warns on newer schemas without failing", () => {
+		const badProblems: string[] = [];
+		assert.equal(validateManifest({ ...ok, schema: 2, provides: ["Bad_Name"] }, badProblems), null);
+		assert.equal(badProblems[0], 'pack.yaml: provides entry "Bad_Name" must match /^[a-z0-9][a-z0-9-]*$/');
+
+		const problems: string[] = [];
+		const m = validateManifest({ ...ok, schema: 3, contents: { ...ok.contents, providers: ["memory"] } }, problems);
+		assert.ok(m);
+		assert.equal(m.schema, 3);
+		assert.deepEqual(m.contents.providers, ["memory"]);
+		assert.deepEqual(problems, ["pack.yaml: schema 3 is newer than supported (2)"]);
 	});
 });
 
@@ -88,7 +131,18 @@ describe("validateManifest (§1.2)", () => {
 function manifest(name: string, opts: Partial<PackManifest["contents"]> & { routes?: PackManifest["routes"] } = {}): PackManifest {
 	return {
 		name, description: "d", version: "1",
-		contents: { roles: [], tools: [], skills: [], entrypoints: opts.entrypoints ?? [] },
+		contents: {
+			roles: [],
+			tools: [],
+			skills: [],
+			entrypoints: opts.entrypoints ?? [],
+			providers: opts.providers ?? [],
+			hooks: opts.hooks ?? [],
+			mcp: opts.mcp ?? [],
+			piExtensions: opts.piExtensions ?? [],
+			runtimes: opts.runtimes ?? [],
+			workflows: opts.workflows ?? [],
+		},
 		...(opts.routes ? { routes: opts.routes } : {}),
 	};
 }
@@ -250,6 +304,27 @@ describe("PackContributionRegistry (§5.2.1, §7)", () => {
 		const pack = filtered.getPack(undefined, "artifacts")!;
 		assert.equal(pack.entrypoints.length, 0);
 		assert.equal(pack.panels.length, 1);
+	});
+
+	it("activation filtering: a disabled provider is omitted and re-enabled by removing the ref", () => {
+		const root = packRoot("act-provider", "memory-pack");
+		w(path.join(root, "pack.yaml"), "name: memory-pack\n");
+		w(path.join(root, "providers", "memory.yaml"), "id: memory\nmodule: ../lib/provider.js\nhooks: [beforePrompt]\n");
+		w(path.join(root, "lib", "provider.js"), "export default {};\n");
+		const m = manifest("memory-pack", { providers: ["memory"] });
+		const enabled = new PackContributionRegistry(() => [entry(root, "server", m)]);
+		assert.deepEqual(enabled.listProviders(undefined).map((p) => p.id), ["memory"]);
+
+		const filtered = new PackContributionRegistry(
+			() => [entry(root, "server", m)],
+			undefined,
+			(_scope, _pid, packName) => (packName === "memory-pack" ? ["memory"] : []),
+		);
+		assert.deepEqual(filtered.listProviders(undefined).map((p) => p.id), []);
+
+		const restored = new PackContributionRegistry(() => [entry(root, "server", m)], undefined, () => []);
+		assert.deepEqual(restored.listProviders(undefined).map((p) => p.id), ["memory"]);
+		assert.equal(restored.getPack(undefined, "memory-pack")!.entrypoints.length, 0, "entrypoint filtering remains unchanged");
 	});
 
 	it("always-emit: an installed pack with no panels/entrypoints/routes still produces a list row", () => {

--- a/tests/pack-providers-loader.test.ts
+++ b/tests/pack-providers-loader.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit — schema-v2 provider contribution loader.
+ *
+ * Providers are pack-scoped contribution files listed by contents.providers[];
+ * they are loaded inertly (no dispatch), tolerate malformed individual files,
+ * and preserve hard duplicate-id failures within a pack.
+ */
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { loadPackContributions, loadProviders, PackContributionError } from "../src/server/agent/pack-contributions.ts";
+import type { PackManifest } from "../src/server/agent/pack-types.ts";
+
+let tmp: string;
+before(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pack-providers-loader-")); });
+after(() => { try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ } });
+
+function w(file: string, content: string): void {
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, content, "utf-8");
+}
+
+function packRoot(caseName: string): string {
+	return path.join(tmp, caseName, "market-packs", "provider-pack");
+}
+
+function manifest(providers: string[]): PackManifest {
+	return {
+		name: "provider-pack",
+		description: "d",
+		version: "1",
+		schema: 2,
+		contents: {
+			roles: [],
+			tools: [],
+			skills: [],
+			entrypoints: [],
+			providers,
+			hooks: [],
+			mcp: [],
+			piExtensions: [],
+			runtimes: [],
+			workflows: [],
+		},
+	};
+}
+
+function validProviderYaml(id = "memory", extras = ""): string {
+	return [
+		`id: ${id}`,
+		"kind: memory",
+		"module: ../lib/provider.js",
+		"hooks: [beforePrompt]",
+		extras.trim(),
+	].filter(Boolean).join("\n") + "\n";
+}
+
+describe("loadProviders (schema v2)", () => {
+	it("loads a valid listed provider and clamps its budget", () => {
+		const root = packRoot("valid");
+		w(path.join(root, "providers", "memory.yaml"), validProviderYaml("memory", "budget:\n  maxTokens: 99999\n  timeoutMs: 5"));
+		w(path.join(root, "lib", "provider.js"), "export default {};\n");
+
+		const providers = loadProviders(root, manifest(["memory"]));
+		assert.equal(providers.length, 1);
+		assert.deepEqual(providers[0], {
+			id: "memory",
+			kind: "memory",
+			module: "../lib/provider.js",
+			hooks: ["beforePrompt"],
+			budget: { maxTokens: 8192, timeoutMs: 100 },
+			defaultEnabled: true,
+			listName: "memory",
+			sourceFile: path.join(root, "providers", "memory.yaml"),
+			packRoot: root,
+		});
+	});
+
+	it("drops only the provider with an unknown hook name", () => {
+		const root = packRoot("bad-hook");
+		w(path.join(root, "providers", "good.yaml"), validProviderYaml("good"));
+		w(path.join(root, "providers", "bad.yaml"), "id: bad\nmodule: ../lib/provider.js\nhooks: [nope]\n");
+		w(path.join(root, "lib", "provider.js"), "export default {};\n");
+
+		const providers = loadProviders(root, manifest(["bad", "good"]));
+		assert.deepEqual(providers.map((p) => p.id), ["good"]);
+	});
+
+	it("drops a provider whose module resolves outside the pack root", () => {
+		const root = packRoot("outside-module");
+		w(path.join(root, "providers", "bad.yaml"), "id: bad\nmodule: ../../escape.js\nhooks: [beforePrompt]\n");
+		w(path.join(root, "providers", "good.yml"), validProviderYaml("good"));
+		w(path.join(root, "lib", "provider.js"), "export default {};\n");
+
+		const providers = loadProviders(root, manifest(["bad", "good"]));
+		assert.deepEqual(providers.map((p) => p.id), ["good"]);
+	});
+
+	it("duplicate provider id within a pack throws PackContributionError", () => {
+		const root = packRoot("duplicate");
+		w(path.join(root, "providers", "a.yaml"), validProviderYaml("dup"));
+		w(path.join(root, "providers", "b.yaml"), validProviderYaml("dup"));
+		w(path.join(root, "lib", "provider.js"), "export default {};\n");
+
+		assert.throws(
+			() => loadPackContributions(root, manifest(["a", "b"])),
+			(e) => e instanceof PackContributionError && /provider id "dup"/.test(e.message),
+		);
+	});
+
+	it("ignores provider files that are not listed in contents.providers", () => {
+		const root = packRoot("unlisted");
+		w(path.join(root, "providers", "listed.yaml"), validProviderYaml("listed"));
+		w(path.join(root, "providers", "unlisted.yaml"), validProviderYaml("unlisted"));
+		w(path.join(root, "lib", "provider.js"), "export default {};\n");
+
+		const providers = loadPackContributions(root, manifest(["listed"])).providers;
+		assert.deepEqual(providers.map((p) => p.id), ["listed"]);
+	});
+});

--- a/tests/pack-providers-loader.test.ts
+++ b/tests/pack-providers-loader.test.ts
@@ -10,6 +10,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { validateManifest } from "../src/server/agent/pack-manifest.ts";
 import { loadPackContributions, loadProviders, PackContributionError } from "../src/server/agent/pack-contributions.ts";
 import type { PackManifest } from "../src/server/agent/pack-types.ts";
 
@@ -71,7 +72,6 @@ describe("loadProviders (schema v2)", () => {
 			module: "../lib/provider.js",
 			hooks: ["beforePrompt"],
 			budget: { maxTokens: 8192, timeoutMs: 100 },
-			defaultEnabled: true,
 			listName: "memory",
 			sourceFile: path.join(root, "providers", "memory.yaml"),
 			packRoot: root,
@@ -108,6 +108,30 @@ describe("loadProviders (schema v2)", () => {
 			() => loadPackContributions(root, manifest(["a", "b"])),
 			(e) => e instanceof PackContributionError && /provider id "dup"/.test(e.message),
 		);
+	});
+
+	it("does not load listed providers from a schema-1 manifest", () => {
+		const root = packRoot("schema-1-gate");
+		w(path.join(root, "providers", "memory.yaml"), validProviderYaml("memory"));
+		w(path.join(root, "lib", "provider.js"), "export default {};\n");
+		const schema1 = validateManifest({
+			name: "provider-pack",
+			description: "d",
+			version: "1",
+			contents: { roles: [], tools: [], skills: [], providers: ["memory"] },
+		});
+		assert.ok(schema1);
+		assert.deepEqual(loadPackContributions(root, schema1).providers, []);
+
+		const schema2 = validateManifest({
+			name: "provider-pack",
+			description: "d",
+			version: "1",
+			schema: 2,
+			contents: { roles: [], tools: [], skills: [], providers: ["memory"] },
+		});
+		assert.ok(schema2);
+		assert.deepEqual(loadPackContributions(root, schema2).providers.map((p) => p.id), ["memory"]);
 	});
 
 	it("ignores provider files that are not listed in contents.providers", () => {


### PR DESCRIPTION
## Extension Platform — G1.1: Manifest schema 2 + provider contribution loader + activation plumbing

PR 1 of the extension-platform workstream. **Additive and inert** — nothing dispatches providers yet (later goals own that), so there is **zero behavior change for existing v1 packs**.

### What this ships
- `pack.yaml` accepts **`schema: 2`** (default 1) plus top-level **`provides`/`requires`** capability-name arrays.
- Six new optional `contents` keys: **`providers`**, `hooks`, `mcp`, `pi-extensions` (→ field `piExtensions`), `runtimes`, `workflows`. Only **`providers`** has a loader in this PR; the other five are accepted in the manifest + surfaced in the activation catalogue but not yet loaded (reserved for later goals).
- `contents.mcp` is rejected verbatim at `schema < 2` (MVP boundary) but **accepted at `schema >= 2`** as catalogue metadata. `schema > 2` loads the v2 subset with a warning.
- `providers/<id>.yaml` files load into the existing `PackContributionRegistry` via `loadProviders` (mirrors `loadEntrypoints` exactly): hook allowlist (`sessionSetup|beforePrompt|afterTurn|beforeCompact|sessionShutdown`), budget defaults `{maxTokens:1600,timeoutMs:1500}` clamped to `[64,8192]`/`[100,10000]`, `module` containment-checked against the pack root, duplicate provider id → `PackContributionError`.
- Per-provider activation round-trips through `GET/PUT /api/marketplace/pack-activation`: `DisabledRefs.providers` (+ the five sibling kinds) are first-class in `ACTIVATION_KINDS`; the catalogue response includes the new arrays; `PackContributionRegistry.listProviders(projectId)` returns installed+active+enabled providers.

### Architectural refinement (binding)
Providers are **pack-scoped**, keyed `(packId, contributionId)`, loaded via the `pack-contributions.ts` path — deliberately **not** a new `EntityType` (two packs may each ship a `memory` provider and both must stay active; EntityType name-merging would collapse them). Recorded in code + docs. `git grep "EntityType" | grep -i provider` → no hits.

### Also fixed (pre-existing, unrelated; surfaced by the gate on macOS)
- `src/app/main.ts` — staff inbox sessions now collapse via Ctrl+]/[/# (panel-bearing regardless of `assistantType`).
- `tests/e2e/ui/staff-inbox.spec.ts` — dispatch the collapse keydown with both `ctrlKey`+`metaKey` (macOS `ctrlOrMeta` = Cmd).
- `tests/worktree-pool.test.ts` — assert the claimed pool branch was renamed, tolerant of the legitimate background refill (was a load-race).
- `scripts/run-unit.mjs` — canonicalize `TMPDIR` so node-logic tests avoid the macOS `/var → /private/var` `symlink_root` failures (the node-phase equivalent of the existing E2E-setup canonicalization).

### Verification
- `npm run check` clean · `npm run test:unit` green · `npm run test:e2e` green.
- New/extended tests: `pack-contributions.test.ts` (schema-2 round-trip, mcp@schema gating, bad `provides`, `schema:3` warning, registry provider activation), `pack-providers-loader.test.ts` (clamps, unknown-hook drop, module-escape, duplicate-id, unlisted-file), `tests/e2e/marketplace-provider-activation.spec.ts` (REST round-trip).
- Existing marketplace suite green (v1 packs unaffected; schema-1 catalogue additive-only).

### Docs
`docs/marketplace.md` (canonical schema-2 + provider reference + pack-scoped rationale + per-provider activation) and `docs/extension-host-authoring.md` (providers in the contribution table + "loaded but inert" note).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)