### PR TITLE
Fix PR walkthrough slash launcher

### DIFF
--- a/docs/design/pack-schema-v1-rationalisation.md
+++ b/docs/design/pack-schema-v1-rationalisation.md
@@ -203,7 +203,7 @@ paramKeys: [artifactId]
 
 ```yaml
 # entrypoints/pr-walkthrough-open.yaml
-id: pr-walkthrough.open
+id: pr-walkthrough
 kind: composer-slash
 label: PR Walkthrough                  # required for launcher kinds
 target:

--- a/market-packs/pr-walkthrough/entrypoints/pr-walkthrough-open.yaml
+++ b/market-packs/pr-walkthrough/entrypoints/pr-walkthrough-open.yaml
@@ -1,4 +1,4 @@
-id: pr-walkthrough.open
+id: pr-walkthrough
 kind: composer-slash
 label: PR Walkthrough
 # A composer-slash LAUNCHER (the slash menu). Its selection IS the user gesture.

--- a/src/ui/components/MessageEditor.ts
+++ b/src/ui/components/MessageEditor.ts
@@ -234,9 +234,13 @@ export class MessageEditor extends LitElement {
 			}
 			this._slashTokenStart = cursorPos - match[2].length - 1; // position of "/"
 			const query = match[2].toLowerCase();
+			// Pack entrypoints reconcile asynchronously after session/project changes.
+			// Re-merge them at filter time so the slash menu never shows stale launcher ids
+			// (or misses newly-registered launchers) because the base skill list loaded early.
+			const slashSkills = this._withPackEntrypoints(this._slashSkills.filter((s) => s.source !== "pack"));
 			this._slashFilteredSkills = query
-				? this._slashSkills.filter((s) => s.name.toLowerCase().includes(query))
-				: this._slashSkills;
+				? slashSkills.filter((s) => s.name.toLowerCase().includes(query))
+				: slashSkills;
 			this._slashMenuOpen = this._slashFilteredSkills.length > 0;
 			this._slashSelectedIndex = 0;
 		} else {
@@ -266,12 +270,37 @@ export class MessageEditor extends LitElement {
 		}
 	}
 
+	private _clearSlashToken(): void {
+		const textarea = this.textareaRef.value;
+		if (!textarea) return;
+		const cursorPos = textarea.selectionStart;
+		const before = this.value.substring(0, this._slashTokenStart);
+		const after = this.value.substring(cursorPos);
+		this.value = before + after;
+		this.onInput?.(this.value);
+		textarea.value = this.value;
+		const newPos = before.length;
+		textarea.focus();
+		textarea.setSelectionRange(newPos, newPos);
+	}
+
+	private _showLauncherError(message: string): void {
+		void import("../../app/render.js")
+			.then((m) => m.showHeaderToast(message))
+			.catch(() => { /* best-effort */ });
+	}
+
 	private _selectSlashSkill(skill: SlashSkillInfo) {
 		// Slice C1 — a pack composer-slash ENTRYPOINT runs its launcher (open panel /
 		// navigate) on selection (the user gesture) instead of inserting text.
 		if (skill.entrypointId) {
 			this._slashMenuOpen = false;
-			try { runLauncherEntrypoint(skill.entrypointId); } catch { /* non-fatal */ }
+			this._clearSlashToken();
+			try {
+				runLauncherEntrypoint(skill.entrypointId, (r) => {
+					if (!r.ok) this._showLauncherError(r.error || "Could not start the PR walkthrough.");
+				});
+			} catch { /* non-fatal */ }
 			return;
 		}
 		const textarea = this.textareaRef.value;

--- a/tests/e2e/ui/pr-walkthrough-pack.spec.ts
+++ b/tests/e2e/ui/pr-walkthrough-pack.spec.ts
@@ -513,6 +513,30 @@ test.describe("PR walkthrough — launch UX (NO_PR error + child-session pane)",
 		return sid!;
 	}
 
+	// ── T-1: the composer slash command is `/pr-walkthrough` (not the internal
+	//    launcher filename/id suffix) and selecting it invokes the same run route. ──
+	test("T-1 — slash launcher is /pr-walkthrough and invokes run", async ({ page }) => {
+		await openApp(page);
+		await createSessionViaUI(page);
+		await page.evaluate(() => (window as any).__bobbitReconcilePackRenderers());
+
+		const textarea = page.locator("textarea").first();
+		await textarea.fill("/pr-walkthrough");
+		const command = page.getByTestId("slash-command-pr-walkthrough");
+		await expect(command, "slash autocomplete must expose /pr-walkthrough").toBeVisible({ timeout: 10_000 });
+		await expect(page.getByTestId("slash-command-pr-walkthrough.open"), "the old .open-suffixed command must not render").toHaveCount(0);
+
+		const runResp = page.waitForResponse(
+			(r) => /\/api\/ext\/route\/run\b/.test(r.url()) && r.request().method() === "POST",
+			{ timeout: 20_000 },
+		);
+		await textarea.press("Enter");
+		const resp = await runResp;
+		expect(resp.status(), `run route failed: ${await resp.text().catch(() => "")}`).toBe(200);
+		await expect(textarea, "selecting the launcher should consume the typed slash token").toHaveValue("");
+		await expect(page.getByTestId("header-toast")).toContainText(/No open GitHub PR/i, { timeout: 10_000 });
+	});
+
 	// ── T-2: a NO_PR launch surfaces an INLINE error in the GitStatusWidget dropdown,
 	//    spawns NO reviewer child, and does NOT switch the view. ──
 	test("T-2 — NO_PR launch shows an inline git-widget error, spawns no reviewer, no view switch", async ({ page, gateway }) => {


### PR DESCRIPTION
## Summary
- Rename the PR walkthrough composer slash entrypoint so autocomplete shows `/pr-walkthrough` instead of `/pr-walkthrough.open`.
- Clear the slash token and surface launcher failures as a toast when invoked from the composer.
- Add browser E2E coverage for the slash launcher path.

## Tests
- `npm run check`
- `npm run build --silent && npm run test:e2e:run -- tests/e2e/ui/pr-walkthrough-pack.spec.ts --grep "T-1"`
- `npm run test:unit` (passed on rerun; first run had one transient fixture readiness timeout that passed in isolation)

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)