### PR TITLE
Fix PR walkthrough base SHA resolution

### DIFF
--- a/market-packs/pr-walkthrough/lib/routes.mjs
+++ b/market-packs/pr-walkthrough/lib/routes.mjs
@@ -824,7 +824,7 @@ function hasExplicitTarget(body) {
 // Returns { ok:false, code:"NO_PR" } when the branch has no open GitHub PR so the
 // panel can surface a clear "open a PR first" message. The walkthrough is
 // GitHub-PR-only; local base/head targets are not resolved here.
-async function resolveCurrentBranchTarget(cwd) {
+async function resolveCurrentBranchTarget(cwd, io = { gh, git }) {
 	const noPr = {
 		ok: false,
 		retryable: false,
@@ -834,7 +834,7 @@ async function resolveCurrentBranchTarget(cwd) {
 
 	let pr;
 	try {
-		const out = await gh(cwd, ["pr", "view", "--json", "number,url,headRefOid,baseRefName,headRefName"]);
+		const out = await io.gh(cwd, ["pr", "view", "--json", "number,url,headRefOid,baseRefOid,baseRefName,headRefName"]);
 		pr = JSON.parse(String(out).trim());
 	} catch {
 		return noPr; // gh non-zero / no PR for branch / gh unavailable
@@ -845,7 +845,7 @@ async function resolveCurrentBranchTarget(cwd) {
 	let owner;
 	let repo;
 	try {
-		const repoOut = await gh(cwd, ["repo", "view", "--json", "owner,name"]);
+		const repoOut = await io.gh(cwd, ["repo", "view", "--json", "owner,name"]);
 		const repoJson = JSON.parse(String(repoOut).trim());
 		owner = repoJson && repoJson.owner ? strOf(repoJson.owner.login) : undefined;
 		repo = repoJson ? strOf(repoJson.name) : undefined;
@@ -861,17 +861,19 @@ async function resolveCurrentBranchTarget(cwd) {
 	// headSha: the PR head commit (headRefOid), else the worktree HEAD.
 	let headSha = strOf(pr.headRefOid);
 	if (!headSha) {
-		headSha = await git(cwd, ["rev-parse", "HEAD"]).then((s) => s.trim()).catch(() => undefined);
+		headSha = await io.git(cwd, ["rev-parse", "HEAD"]).then((s) => s.trim()).catch(() => undefined);
 	}
-	// baseSha: the PR base branch tip — prefer origin/<base>, else the local ref,
-	// else the merge-base with HEAD.
-	let baseSha;
+	// baseSha: the PR comparison base GitHub reports for the PR. This is the
+	// pre-merge base OID for merged PRs, so the launch-time bundle matches the
+	// Files changed diff GitHub shows instead of diffing against the current
+	// origin/<base> tip (which may already contain the PR and produce an empty diff).
+	let baseSha = strOf(pr.baseRefOid);
 	const baseRef = strOf(pr.baseRefName);
-	if (baseRef) {
-		baseSha = await git(cwd, ["rev-parse", `origin/${baseRef}`]).then((s) => s.trim()).catch(() => undefined);
-		if (!baseSha) baseSha = await git(cwd, ["rev-parse", baseRef]).then((s) => s.trim()).catch(() => undefined);
+	if (!baseSha && baseRef) {
+		baseSha = await io.git(cwd, ["rev-parse", `origin/${baseRef}`]).then((s) => s.trim()).catch(() => undefined);
+		if (!baseSha) baseSha = await io.git(cwd, ["rev-parse", baseRef]).then((s) => s.trim()).catch(() => undefined);
 		if (!baseSha && headSha) {
-			baseSha = await git(cwd, ["merge-base", `origin/${baseRef}`, "HEAD"]).then((s) => s.trim()).catch(() => undefined);
+			baseSha = await io.git(cwd, ["merge-base", `origin/${baseRef}`, "HEAD"]).then((s) => s.trim()).catch(() => undefined);
 		}
 	}
 
@@ -975,6 +977,8 @@ async function inferGithubRepository(cwd) {
 		return undefined;
 	}
 }
+
+export const __test = { resolveCurrentBranchTarget };
 
 function parseGithubRemoteUrl(url) {
 	if (!url) return undefined;

--- a/tests/pr-walkthrough-current-branch-target.test.ts
+++ b/tests/pr-walkthrough-current-branch-target.test.ts
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const routesModule = await import("../market-packs/pr-walkthrough/lib/routes.mjs");
+const { resolveCurrentBranchTarget } = routesModule.__test;
+
+test("PR walkthrough launch uses GitHub's PR baseRefOid instead of the current base branch tip", async () => {
+	const gitCalls: string[][] = [];
+	const result = await resolveCurrentBranchTarget("/repo", {
+		gh: async (_cwd: string, args: string[]) => {
+			if (args[0] === "pr" && args[1] === "view") {
+				assert.ok(args.includes("number,url,headRefOid,baseRefOid,baseRefName,headRefName"));
+				return JSON.stringify({
+					number: 766,
+					url: "https://github.com/SuuBro/bobbit/pull/766",
+					headRefOid: "head-pr-branch",
+					baseRefOid: "base-at-pr-comparison",
+					baseRefName: "master",
+					headRefName: "session/aab88279",
+				});
+			}
+			if (args[0] === "repo" && args[1] === "view") {
+				return JSON.stringify({ owner: { login: "SuuBro" }, name: "bobbit" });
+			}
+			throw new Error(`unexpected gh args: ${args.join(" ")}`);
+		},
+		git: async (_cwd: string, args: string[]) => {
+			gitCalls.push(args);
+			return "current-origin-master-tip";
+		},
+	});
+
+	assert.equal(result.ok, true);
+	assert.equal(result.target.baseSha, "base-at-pr-comparison");
+	assert.equal(result.target.headSha, "head-pr-branch");
+	assert.equal(result.target.prNumber, 766);
+	assert.equal(result.target.owner, "SuuBro");
+	assert.equal(result.target.repo, "bobbit");
+	assert.deepEqual(gitCalls, [], "current origin/master must not replace GitHub's PR comparison base");
+});


### PR DESCRIPTION
## Summary
- Use GitHub's `baseRefOid` as the PR walkthrough comparison base so bundles match the PR Files changed diff.
- Keep the existing local base-branch fallback only when GitHub does not provide a base OID.
- Add a unit test pinning that `baseRefOid` wins over the current `origin/<base>` tip.

## Tests
- `npx tsx --test --test-force-exit tests/pr-walkthrough-current-branch-target.test.ts`
- `npm run check`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)