### PR TITLE
Unified side panels

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,37 +44,33 @@ See [websocket-protocol.md](websocket-protocol.md) for the wire contract.
 
 ## Side-panel workspace
 
-Every chat session owns a dynamic side-panel workspace. The workspace is shared
-by regular sessions and assistant sessions, so HTML previews, proposals, review
-documents, PR walkthroughs, and the staff inbox are selected by the same tab
-dispatcher instead of by assistant-specific branches. Chat stays outside the
-strip; when a non-staff session has no side-panel tabs, the side pane hides and
-chat fills the layout.
+Every chat session owns a server-backed side-panel workspace for the right side
+of the chat view. The workspace is shared by regular sessions and assistant
+sessions, so HTML previews, pack panels such as PR walkthrough and artifact
+viewers, proposals, review documents, and the staff inbox all use the same tab
+strip and window controls. Chat stays outside the strip; when a non-staff
+session has no side-panel tabs, the side pane hides and chat fills the layout.
 
-Tabs are derived from their artifact source. Preview tabs represent current or
-historical `preview_open` artifacts and use `contentHash` to collapse duplicate
-content when available. Proposal tabs distinguish the live editable draft from
-historical revisions. Review tabs map to review documents by encoded title.
-The PR walkthrough review surface now ships as a **built-in first-party pack**
-(`market-packs/pr-walkthrough/`) reached through the generic extension route
-`#/ext/pr-walkthrough`, rather than a bespoke side-panel tab kind. Clicking any
-pack launcher (git-widget button / composer-slash / command palette) mints a
-separate, isolated, read-only reviewer child via `host.agents.spawn` (not the
-current session's agent) and **auto-switches the view to that child session**,
-where the panel opens; there is **no owner-session panel** and no manual
-"Run"/"Load" buttons (a no-PR / spawn failure shows an inline error in the
-git-status-widget dropdown instead). See
-[pr-walkthrough-panel.md](pr-walkthrough-panel.md),
-[pr-walkthrough-launch-ux.md](design/pr-walkthrough-launch-ux.md), and
-[built-in-first-party-packs.md](design/built-in-first-party-packs.md). Desktop
-renders a scrollable tab strip next to the chat; mobile renders the same
-side-panel tab set in the header and slider track.
+The server is authoritative for open tabs, active tab, tab order, and size mode
+(`split`, `fullscreen`, or `collapsed`). Closed tabs are durable absence: render,
+refresh, reconnect, content caches, and localStorage must not recreate a tab just
+because the underlying preview artifact, proposal draft, review document, inbox,
+or pack panel still exists. Tabs open only through explicit workspace open or
+reopen events.
 
-The main client modules are `src/app/panel-workspace.ts` for tab identity and
-persistence, `src/app/preview-panel.ts` for preview selection helpers and SSE
-wiring, and `src/app/render.ts` for the shared dispatcher and responsive layout. See
-[Side-Panel Tab Contract](design/side-panel-tab-contract.md) for the full id /
-ordering contract and [Embedded HTML preview — architecture](preview-architecture.md)
+Desktop renders the workspace beside chat or fullscreen with a compact prompt
+dock; mobile renders the same tab set in the header and slider track. Popout
+links either use the preview content route or the safe app deep link
+`#/session/<sessionId>/panel/<tabId>`, which renders only already-open server
+workspace tabs.
+
+Main modules: `src/shared/side-panel-workspace.ts` defines the shared model,
+`src/server/side-panel-workspace*.ts` canonicalizes and mutates persisted
+workspaces, `src/app/side-panel-workspace.ts` hydrates and mutates the client
+mirror, `src/app/panel-workspace.ts` keeps tab id helpers and fixture fallback,
+and `src/app/render.ts` renders the shared shell. See
+[Side-panel workspace](side-panel-workspace.md) for the invariant, lifecycle,
+API, popout, and migration rules, and [Embedded HTML preview — architecture](preview-architecture.md)
 for the preview mount and `contentHash` contract.
 
 ## Build structure

--- a/docs/design/mid-session-project-proposals.md
+++ b/docs/design/mid-session-project-proposals.md
@@ -1,11 +1,19 @@
 # Mid-session project proposals
 
+> **Historical implementation plan.** This design predates the unified
+> server-backed side-panel workspace. Proposal tab behavior now follows
+> [docs/side-panel-workspace.md](../side-panel-workspace.md): a project proposal
+> opens or updates `proposal:project` through the workspace API, shared controls
+> own fullscreen/collapse/restore/popout, and closed tabs are not recreated from
+> proposal state or localStorage. Hardcoded source locations and preview-specific
+> wiring below are historical planning context, not current side-panel guidance.
+
 ## Goal
 
 Let **any** agent session (regular, goal, staff, and non-project assistants) submit
 `propose_project` to edit the **currently registered** project's config, and give
-the user a first-class "Project" tab in the preview panel to review and accept the
-change without leaving the session.
+the user a first-class `proposal:project` tab in the side-panel workspace to
+review and accept the change without leaving the session.
 
 The existing provisional-project flow (project assistant → promote → terminate →
 navigate) must continue to work unchanged.
@@ -14,14 +22,14 @@ navigate) must continue to work unchanged.
 
 ### Client
 - State shape: `state.activeProjectProposal: undefined | { sessionId: string; fields: Record<string,string> }`
-  at `src/app/state.ts:166`.
+  at `src/app/state.ts`.
 - Server → client callback: `remote.onProjectProposal` is wired **for every session**
-  regardless of assistantType (`src/app/session-manager.ts:1186-1195`) and also from
-  the `proposal-open` button dispatch (`src/app/session-manager.ts:1214`).
-- Proposal parser: `src/app/proposal-parsers.ts:52-55` (`project_proposal`, required
+  regardless of assistantType (`src/app/session-manager.ts`) and also from
+  the `proposal-open` button dispatch (`src/app/session-manager.ts`).
+- Proposal parser: `src/app/proposal-parsers.ts` (`project_proposal`, required
   `name` + `root_path`).
 - **Bug #1 — proposal is wiped for non-project sessions.** Around
-  `src/app/session-manager.ts:1475`:
+  `src/app/session-manager.ts`:
   ```ts
   if (state.assistantType !== "project" && state.assistantType !== "project-scaffolding")
       state.activeProjectProposal = undefined;
@@ -29,18 +37,18 @@ navigate) must continue to work unchanged.
   This clears the proposal during draft-restore on any session whose assistantType
   isn't `project`/`project-scaffolding`, so a `propose_project` from a regular
   session never survives a navigate-back.
-- **Bug #2 — `projectProposalPanel()` is only mounted via the assistant preview
-  router.** `src/app/render.ts:1785` defines the panel; `getAssistantPreviewPanel()`
-  at `src/app/render.ts:1883-1889` dispatches `case "project" | "project-scaffolding"`.
-  Non-assistant sessions use `unifiedPreviewPanel()` (`src/app/render.ts:2650…`),
-  whose tab header only knows about `preview`, `review`, `goal` — no `project` tab.
+- **Bug #2 (historical) — `projectProposalPanel()` was only mounted via the
+  assistant preview router.** In the current workspace model, project proposals
+  open or update the `proposal:project` tab through the side-panel workspace API;
+  the shared side-panel shell, not preview-specific render wiring, decides which
+  tabs are visible.
 - **Bug #3 — accept is hard-coded to the provisional flow.** `acceptProjectProposal()`
-  at `src/app/session-manager.ts:1767-1830` calls `promoteProject()` (which fails for
+  at `src/app/session-manager.ts` calls `promoteProject()` (which fails for
   non-provisional projects), writes config, then terminates the session and navigates
   to landing.
 
 ### Server
-- `PUT /api/projects/:id/config` lives at `src/server/server.ts:1922-1945`. It is a
+- `PUT /api/projects/:id/config` lives at `src/server/server.ts`. It is a
   **generic** string-KV writer: it validates keys (no dots) and writes every entry
   into `ctx.projectConfigStore` via `.set(key, value)`. It already accepts any
   scalar project.yaml field — `build_command`, `test_command`, `typecheck_command`,
@@ -48,14 +56,14 @@ navigate) must continue to work unchanged.
   `qa_start_command`, etc. **No extension needed for command / sandbox / qa fields.**
 - `name` is **not** a project.yaml field — it lives in `.bobbit/state/projects.json`
   via `ProjectRegistry`. The rename endpoint is `PUT /api/projects/:id` at
-  `src/server/server.ts:1807-1823` which accepts `{ name, color, rootPath, palette,
+  `src/server/server.ts` which accepts `{ name, color, rootPath, palette,
   colorLight, colorDark }` and calls `projectRegistry.update(id, updates)`
-  (`src/server/agent/project-registry.ts:162`).
+  (`src/server/agent/project-registry.ts`).
 - Model preferences (`session_model`, `review_model`, `naming_model`) are **not**
   project-scoped — they live in the preferences store as `default.sessionModel` /
-  `default.reviewModel` / `default.namingModel` (`src/app/settings-page.ts:1142-1144`,
-  `src/app/render.ts:1571-1573`). The existing agent-side `propose_project` tool
-  schema (`defaults/tools/proposals/extension.ts:151-165`) does **not** accept
+  `default.reviewModel` / `default.namingModel` (`src/app/settings-page.ts`,
+  `src/app/render.ts`). The existing agent-side `propose_project` tool
+  schema (`defaults/tools/proposals/extension.ts`) does **not** accept
   these fields. `propose_setup` is the tool for model prefs.
 - `onProjectProposal` is a **client-side** callback derived from parsing
   `<project_proposal>` tool-call blocks in assistant messages
@@ -66,7 +74,7 @@ navigate) must continue to work unchanged.
 
 ### 1. Client state shape (`src/app/state.ts`)
 
-Update `activeProjectProposal` at line 166:
+Update `activeProjectProposal`:
 
 ```ts
 activeProjectProposal: undefined as undefined | {
@@ -86,14 +94,13 @@ activeProjectProposal: undefined as undefined | {
 },
 ```
 
-Draft storage (`projectDraft` serialize/restore at `src/app/session-manager.ts:
-328-345`) keeps `activeProjectProposal` whole, so the new fields persist free.
+Draft storage (`projectDraft` serialize/restore in `src/app/session-manager.ts`) keeps `activeProjectProposal` whole, so the new fields persist free.
 
 ### 2. `session-manager.ts` changes
 
 #### 2a. Stop wiping the proposal for non-project sessions
 
-Change `src/app/session-manager.ts:1475` from:
+Change `src/app/session-manager.ts` from:
 
 ```ts
 if (state.assistantType !== "project" && state.assistantType !== "project-scaffolding")
@@ -109,8 +116,7 @@ to:
 
 #### 2b. Auto-select the `project` tab on first arrival (mirror goal pattern)
 
-In `remote.onProjectProposal` (currently `src/app/session-manager.ts:1186-1195`),
-mirror the `onGoalProposal` branching at lines 995-1044 exactly:
+In `remote.onProjectProposal`, mirror the existing goal-proposal branching:
 
 ```ts
 remote.onProjectProposal = async (fields: Record<string, string>) => {
@@ -129,11 +135,9 @@ remote.onProjectProposal = async (fields: Record<string, string>) => {
         // Existing assistant-tab behaviour
         if (state.assistantTab === "chat" && !isDesktop()) state.assistantTab = "preview";
     } else if (isFirstProposal) {
-        // Non-assistant session: first proposal auto-selects the new tab
-        state.previewPanelActiveTab = "project";
-        const collapseKey = `bobbit-preview-collapsed-${sessionId}`;
-        localStorage.removeItem(collapseKey);
-        if (!isDesktop()) state.previewPanelTab = "project";
+        // Non-assistant session: first proposal explicitly opens/focuses
+        // the server-backed proposal workspace tab.
+        await openSidePanelTab(buildProposalSidePanelTab(sessionId, "project"));
     }
 
     // Lazy-load current config snapshot for the diff view (registered mode only)
@@ -170,7 +174,7 @@ async function loadCurrentProjectConfig(projectId: string, sessionId: string) {
 
 #### 2c. Split `acceptProjectProposal()`
 
-Replace the body at `src/app/session-manager.ts:1767-1830` with a dispatcher:
+Replace the body at `src/app/session-manager.ts` with a dispatcher:
 
 ```ts
 export async function acceptProjectProposal(): Promise<void> {
@@ -242,117 +246,35 @@ async function acceptRegisteredProjectProposal(proposal: ActiveProjectProposal):
 
 #### 2d. Dismiss path — unchanged
 
-The dismiss handler in `projectProposalPanel()` (`render.ts:1814-1819`) clears
+The dismiss handler in `projectProposalPanel()` (`render.ts`) clears
 `state.activeProjectProposal` and deletes the draft. This remains identical.
 No change.
 
-### 3. Preview panel wiring (`src/app/render.ts`)
+### 3. Side-panel workspace wiring
 
-#### 3a. Tab visibility in `unifiedPreviewPanel()`
+Current side-panel behavior is not wired through preview-specific tabs. A
+project proposal is represented by the shared proposal tab id `proposal:project`
+in the server-backed workspace.
 
-At `src/app/render.ts:2128-2136` (tab registration), alongside:
+Required behavior:
 
-```ts
-const showPreviewTab = state.isPreviewSession;
-const showGoalTab = state.activeGoalProposal != null;
-const showReviewTab = state.reviewPanelOpen;
-```
+- First proposal arrival calls the side-panel workspace open API for
+  `proposal:project` and focuses it.
+- Later current revisions update the same `proposal:project` tab in place; they
+  do not create duplicates or reorder unrelated preview/review/pack/inbox tabs.
+- Dismiss closes the workspace tab and clears the project proposal draft. Reload
+  must not recreate the tab from proposal state.
+- Historical/reopened revisions, if exposed, use `proposal:project:rev:<N>` and
+  are created only by explicit reopen UI.
+- The shared side-panel shell supplies fullscreen, collapse, restore, reorder,
+  close, keyboard shortcuts, and popout. Project proposal code should keep only
+  proposal-specific actions such as Apply Changes and Dismiss.
 
-add:
+#### 3a. Proposal panel content
 
-```ts
-const showProjectTab = state.activeProjectProposal != null;
-```
-
-and extend `hasUnifiedPanel()` at `src/app/render.ts:2128`:
-
-```ts
-function hasUnifiedPanel(): boolean {
-    return !state.assistantType && (
-        state.isPreviewSession ||
-        state.activeGoalProposal != null ||
-        state.activeProjectProposal != null ||   // new
-        state.reviewPanelOpen
-    );
-}
-```
-
-and `unifiedPanelTabs()` at `src/app/render.ts:2132-2139`:
-
-```ts
-function unifiedPanelTabs(): Array<"chat" | "preview" | "goal" | "review" | "project"> {
-    const tabs: Array<"chat" | "preview" | "goal" | "review" | "project"> = ["chat"];
-    if (state.isPreviewSession) tabs.push("preview");
-    if (state.reviewPanelOpen) tabs.push("review");
-    if (state.activeGoalProposal != null) tabs.push("goal");
-    if (state.activeProjectProposal != null) tabs.push("project"); // new
-    return tabs;
-}
-```
-
-Extend the `previewPanelTab` / `previewPanelActiveTab` unions in `src/app/state.ts`
-to include `"project"`.
-
-#### 3b. Auto-correct logic (`unifiedPreviewPanel()` ~line 2697-2703)
-
-Currently:
-
-```ts
-if (state.previewPanelActiveTab === "review" && !state.reviewPanelOpen) {
-    state.previewPanelActiveTab = state.isPreviewSession ? "preview" :
-        (state.activeGoalProposal != null ? "goal" : "preview");
-} else if (state.previewPanelActiveTab === "preview" && !state.isPreviewSession && state.activeGoalProposal != null) {
-    state.previewPanelActiveTab = "goal";
-} else if (state.previewPanelActiveTab === "goal" && state.activeGoalProposal == null && state.isPreviewSession) {
-    state.previewPanelActiveTab = "preview";
-}
-```
-
-Add a parallel branch:
-
-```ts
-} else if (state.previewPanelActiveTab === "project" && state.activeProjectProposal == null) {
-    state.previewPanelActiveTab = state.isPreviewSession ? "preview"
-        : (state.activeGoalProposal != null ? "goal"
-        : (state.reviewPanelOpen ? "review" : "preview"));
-}
-```
-
-#### 3c. Tab pill in the unified tab-bar (lines 2706-2713 and mirror at 2736-2744)
-
-After the `showGoalTab` button:
-
-```ts
-${showProjectTab ? html`
-    <button
-        class="goal-tab-pill ${state.previewPanelActiveTab === "project" ? "goal-tab-pill--active" : ""}"
-        title="Project"
-        @click=${() => { state.previewPanelActiveTab = "project"; renderApp(); }}
-    >Project <span class="goal-tab-dot"></span></button>
-` : ""}
-```
-
-#### 3d. Tab-content dispatch (lines 2748-2754)
-
-Extend the content switcher:
-
-```ts
-${state.previewPanelActiveTab === "review" && showReviewTab ? reviewPaneContent()
-    : state.previewPanelActiveTab === "preview" && showPreviewTab ? htmlPreviewContent()
-    : state.previewPanelActiveTab === "goal" && showGoalTab ? goalProposalPanel()
-    : state.previewPanelActiveTab === "project" && showProjectTab ? projectProposalPanel()
-    : ""}
-```
-
-Also mirror in `unifiedTabBar()` (lines 2588-2613) and `mobilePaneContent()`
-(lines ~2765-2776) — add a `"project"` branch rendering `projectProposalPanel()`.
-
-#### 3e. Generalise `projectProposalPanel()` (line 1785)
-
-Rewrite to render a **diff view**. The panel must work outside
-`getAssistantPreviewPanel` — it already does structurally (it imports nothing from
-the assistant router). No changes to the import graph are required; just replace
-the body.
+`projectProposalPanel()` still owns the proposal-specific diff UI. It must render
+inside the shared proposal panel slot instead of depending on assistant-only
+preview routing.
 
 Field set (editable):
 
@@ -404,12 +326,13 @@ Accept button label:
 - Registered: "Apply Changes" with a badge showing diff count
   (`N fields changed`).
 
-Dismiss button: unchanged.
+Dismiss button: closes the `proposal:project` workspace tab, clears
+`state.activeProjectProposal`, and deletes the draft.
 
 ### 4. Server
 
 #### 4a. `PUT /api/projects/:id/config`
-Already accepts arbitrary string KV pairs (`src/server/server.ts:1922-1945`). Keys
+Already accepts arbitrary string KV pairs (`src/server/server.ts`). Keys
 in scope that are already supported:
 `build_command`, `test_command`, `typecheck_command`, `test_unit_command`,
 `test_e2e_command`, `worktree_setup_command`, `qa_start_command`, `sandbox`,
@@ -417,7 +340,7 @@ plus any unknown passthrough. **No extension required.** The existing validation
 (`key.includes(".")` reject) is correct and kept.
 
 #### 4b. Name changes
-Use the existing `PUT /api/projects/:id` (`src/server/server.ts:1807-1823`) which
+Use the existing `PUT /api/projects/:id` (`src/server/server.ts`) which
 already accepts `{ name }`. **No extension required.**
 
 #### 4c. Model fields
@@ -436,16 +359,16 @@ Recommendation: **option 1**, so the panel gives one coherent surface. Server-si
 
 #### 4d. Tool schema extension
 
-`defaults/tools/proposals/extension.ts:151-165` — add optional
+`defaults/tools/proposals/extension.ts` — add optional
 `qa_start_command`, `sandbox`, `session_model`, `review_model`, `naming_model`
 to the `propose_project` `Type.Object`. Mirror in
-`src/app/proposal-parsers.ts:52-55` (`fields` array) so the client parser surfaces
+`src/app/proposal-parsers.ts` (`fields` array) so the client parser surfaces
 them.
 
 #### 4e. `onProjectProposal` — no server fix
 
 Client-side only. Already fires for any assistantType (proof:
-`src/app/session-manager.ts:1186` has no assistantType guard). **No change.**
+`src/app/session-manager.ts` has no assistantType guard). **No change.**
 
 ### 5. Testing plan
 
@@ -453,7 +376,7 @@ Client-side only. Already fires for any assistantType (proof:
 | --- | --- | --- |
 | Unit (Playwright `file://`) | `tests/ui/project-proposal-panel.spec.ts` | `projectProposalPanel()` renders diff: changed rows show "Changed" pill; unchanged rows collapse into a `<details>` group; `root_path` is read-only; unknown keys render in "Custom fields"; provisional mode (no `currentConfig`) still renders legacy UI. |
 | API E2E (in-process harness) | `tests/e2e/project-config-api.spec.ts` | `PUT /api/projects/:id/config` accepts every field in §3e (config-sourced ones); `PUT /api/projects/:id` accepts `name`; `PUT /api/preferences` accepts the three model keys. |
-| Browser E2E (REQUIRED) | `tests/e2e/ui/mid-session-project-proposal.spec.ts` | Spawned gateway + mock agent. Flow: create regular session in a registered project; mock agent emits `<project_proposal>` with diffed fields; assert (1) Project tab appears in the unified preview panel, (2) diff rows rendered with "Changed" pills, (3) Apply Changes calls `PUT /api/projects/:id/config` + (if name changed) `PUT /api/projects/:id`, (4) session stays connected (no landing nav), (5) reload — proposal cleared, config persisted (GET returns new values), (6) Dismiss path: emit proposal, click Dismiss, tab disappears, reload → still gone, config untouched. Pattern: `tests/e2e/ui/settings.spec.ts`. |
+| Browser E2E (REQUIRED) | `tests/e2e/ui/mid-session-project-proposal.spec.ts` | Spawned gateway + mock agent. Flow: create regular session in a registered project; mock agent emits `<project_proposal>` with diffed fields; assert (1) `proposal:project` appears in the shared side-panel workspace, (2) diff rows rendered with "Changed" pills, (3) Apply Changes calls `PUT /api/projects/:id/config` + (if name changed) `PUT /api/projects/:id`, (4) session stays connected (no landing nav), (5) reload — proposal cleared, config persisted (GET returns new values), (6) Dismiss path: emit proposal, click Dismiss, tab disappears, reload → still gone, config untouched. Pattern: `tests/e2e/ui/settings.spec.ts`. |
 | Regression | `tests/e2e/ui/project-assistant.spec.ts` | Must stay green: provisional promote + terminate + navigate-to-landing flow unchanged. |
 
 ### 6. Non-goals (per spec)
@@ -468,11 +391,11 @@ Client-side only. Already fires for any assistantType (proof:
 
 | File | Change |
 | --- | --- |
-| `src/app/state.ts` | Add `mode` + `currentConfig` to `activeProjectProposal`; add `"project"` to `previewPanelTab` / `previewPanelActiveTab` unions. |
-| `src/app/session-manager.ts` | L1475: drop the project-proposal wipe. L1186: expand `onProjectProposal` (mode inference, first-proposal tab auto-select, lazy config load). L1767: split `acceptProjectProposal` into provisional (existing body) + registered (new). |
-| `src/app/render.ts` | L1785: rewrite `projectProposalPanel()` as a diff view. L2128/2132/2697/2706/2748/2765: extend `hasUnifiedPanel` / `unifiedPanelTabs` / auto-correct / tab pill / content dispatch / mobile pane to include `"project"`. |
-| `src/app/proposal-parsers.ts` | L52-55: add `qa_start_command`, `sandbox`, `session_model`, `review_model`, `naming_model` to `fields`. |
-| `defaults/tools/proposals/extension.ts` | L151-165: add the five optional fields to `propose_project` schema. |
+| `src/app/state.ts` | Add `mode` + `currentConfig` to `activeProjectProposal`; workspace tab state remains in `sidePanelWorkspace`. |
+| `src/app/session-manager.ts` | Drop the project-proposal wipe; expand `onProjectProposal` (mode inference, explicit workspace tab open, lazy config load); split `acceptProjectProposal` into provisional (existing body) + registered (new). |
+| `src/app/render.ts` | Render `projectProposalPanel()` as a diff view inside the shared proposal panel slot. Do not add preview-specific tab/chrome state. |
+| `src/app/proposal-parsers.ts` | Add `qa_start_command`, `sandbox`, `session_model`, `review_model`, `naming_model` to `fields`. |
+| `defaults/tools/proposals/extension.ts` | Add the five optional fields to `propose_project` schema. |
 | `src/server/server.ts` | No change — existing `PUT /api/projects/:id/config` + `PUT /api/projects/:id` cover all registered-mode writes. |
 | `src/server/agent/project-registry.ts` | No change. |
 | `tests/ui/project-proposal-panel.spec.ts` | New — unit test for diff rendering. |

--- a/docs/design/side-panel-tab-contract.md
+++ b/docs/design/side-panel-tab-contract.md
@@ -5,6 +5,14 @@ Companion to [`preview-architecture.md`](../preview-architecture.md) (v3 mount,
 SSE, content origin) and [`reopenable-preview-widgets.md`](./reopenable-preview-widgets.md)
 (historical preview tab UX).
 
+> **Implementation note:** the current product workspace is server-authoritative.
+> Open tabs, active tab, order, and size mode live on the session's persisted
+> `sidePanelWorkspace`; closed tabs must not be re-derived from render/content
+> caches or localStorage. See [`side-panel-workspace.md`](../side-panel-workspace.md)
+> for the current implementation contract. This older design note remains useful
+> for preview versioning/history rationale, but some localStorage-era details are
+> historical.
+
 > **Current model — PR walkthrough is no longer a bespoke side-panel tab.** The
 > PR-walkthrough viewer now ships as a built-in first-party **pack**
 > (`market-packs/pr-walkthrough/`) rendered through the **generic `ext` route**

--- a/docs/design/side-panel-tab-contract.md
+++ b/docs/design/side-panel-tab-contract.md
@@ -5,13 +5,13 @@ Companion to [`preview-architecture.md`](../preview-architecture.md) (v3 mount,
 SSE, content origin) and [`reopenable-preview-widgets.md`](./reopenable-preview-widgets.md)
 (historical preview tab UX).
 
-> **Implementation note:** the current product workspace is server-authoritative.
-> Open tabs, active tab, order, and size mode live on the session's persisted
-> `sidePanelWorkspace`; closed tabs must not be re-derived from render/content
-> caches or localStorage. See [`side-panel-workspace.md`](../side-panel-workspace.md)
-> for the current implementation contract. This older design note remains useful
-> for preview versioning/history rationale, but some localStorage-era details are
-> historical.
+> **Current contract:** the product workspace is server-authoritative.
+> Open tabs, active tab, tab order, and size mode live on the session's persisted
+> `sidePanelWorkspace`. Closed tabs are durable absence: render/content caches,
+> preview mounts, proposal state, review documents, inbox state, and localStorage
+> must not recreate them. See [`side-panel-workspace.md`](../side-panel-workspace.md)
+> for the implementation contract. Historical sections in this design note are
+> explicitly labelled and describe pre-workspace behavior only.
 
 > **Current model — PR walkthrough is no longer a bespoke side-panel tab.** The
 > PR-walkthrough viewer now ships as a built-in first-party **pack**
@@ -33,13 +33,14 @@ SSE, content origin) and [`reopenable-preview-widgets.md`](./reopenable-preview-
 Bobbit's UI has two main areas: the **chat** (transcript + prompt textarea)
 and a **side pane** that hosts everything else the agent might surface
 alongside the chat — HTML previews, draft proposals, review documents,
-PR walkthroughs, and the staff-agent inbox. Before this contract there
-were several parallel sources of truth for what the side pane was showing:
+pack panels such as PR walkthrough, and the staff-agent inbox. The current
+contract exists because older builds had several parallel sources of truth
+for what the side pane was showing:
 
-- `activePanelTabId` (id-keyed)
-- `assistantTab` / `previewPanelTab` (kind-keyed legacy state)
-- A `legacyRequestedTab` fallback inside the render loop
-- A `previewWorkspaceKey` shortcut for preview-only sessions
+- id-keyed active tab state;
+- kind-keyed preview/proposal/review state;
+- render-time fallback tab derivation;
+- preview-specific collapse/fullscreen state and localStorage keys.
 
 Different events updated different fields, and the render path consulted
 them in a partly-ordered cascade. Two surprising classes of bug fell out of
@@ -61,73 +62,76 @@ outside the strip.
 The side-pane tab strip is a **Chrome-style tab bar that lives next to
 chat**, not above the whole window. Chat is always the main area.
 
-- The strip renders only side-pane tabs (preview / proposal / review /
-  walkthrough / inbox). It never renders a `Chat` pill.
+- The strip renders only side-panel workspace tabs: preview, proposal,
+  review, pack, and inbox. It never renders a persisted `Chat` pill.
 - Chat cannot be reordered, dismissed, or selected from the strip — there
   is no exposed `chat` tab id.
-- If a non-staff session has zero side-pane tabs, the side pane is
-  **hidden** and chat fills the main area. The strip itself disappears.
-- Switching to a staff-agent session always shows the strip, because the
-  pinned **Inbox** tab is always present for staff sessions.
+- If a session has zero open side-panel tabs, the side pane is **hidden**
+  and chat fills the main area. The strip itself disappears.
+- The staff inbox is a normal workspace tab (`inbox`). It opens through
+  explicit inbox/session actions, can be closed like other tabs, and stays
+  closed across refresh until explicitly reopened.
 
-On mobile the same model holds: the side-pane tab bar at the top of the
-side pane only contains side-pane tabs, never a Chat pill. The existing
-horizontal swipe still reveals the chat pane and the side pane as separate
-slides — no touch drag reorder in this iteration.
+On mobile the same persisted model holds: the workspace contains only side-pane
+tabs. The UI may expose a chat affordance for the slider, but that affordance is
+not a persisted workspace tab. The existing horizontal swipe still reveals the
+chat pane and the side pane as separate slides — no touch drag reorder in this
+iteration.
 
 ## 3. Tab id is the address
 
 Every side-pane tab has exactly one canonical id, and that id is the only
-thing the renderer consults when deciding what to draw.
+thing the renderer consults when deciding what to draw. The authoritative
+model is `SidePanelWorkspace` in
+[`src/shared/side-panel-workspace.ts`](../../src/shared/side-panel-workspace.ts),
+persisted on the session as `sidePanelWorkspace`.
 
-Valid side-pane tab ids (sources of truth in
-[`src/app/panel-workspace.ts`](../../src/app/panel-workspace.ts)):
+Valid side-pane tab ids:
 
 | Id | Meaning |
 |---|---|
 | `preview:entry:<encoded-filename>` | Current / latest preview for `<filename>`. Label is unversioned, e.g. `report.html`. |
 | `preview:entry:<encoded-filename>:v:<N>` | Historical immutable preview artifact. Label is `report.html (vN)`. |
-| `proposal:<type>` | Active proposal of `<type>` (`goal`, `project`, `role`, `tool`, `staff`). |
-| `proposal:<type>:rev:<N>` | Historical proposal revision. |
-| `review:<encoded-title>` | Review document by title. |
-| ~~`walkthrough:<changeset-id>`~~ *(historical — deleted)* | Former PR / changeset walkthrough tab kind. **Removed**: the walkthrough viewer is now the built-in pack at the generic `#/ext/pr-walkthrough` route, not a bespoke side-pane tab id. |
-| `inbox` | Staff-agent inbox. Pinned, no close button, no drag handle. |
+| `proposal:<type>` | Current proposal of `<type>` (`goal`, `project`, `role`, `tool`, `staff`). |
+| `proposal:<type>:rev:<N>` | Historical proposal revision opened by an explicit reopen action. |
+| `review:<encoded-documentId>` | Review document by stable document id. Title is display metadata only. |
+| `pack:<encoded-packId>:<encoded-panelId>:<encoded-instanceKey>` | Pack-hosted panel instance, including PR walkthrough and artifact viewers. |
+| `inbox` | Staff-agent inbox. Normal closeable/reorderable workspace tab. |
+| ~~`walkthrough:<changeset-id>`~~ *(historical - deleted)* | Former PR / changeset walkthrough tab kind. **Removed**: the walkthrough viewer is now a first-party pack panel, not a bespoke side-pane tab id. |
 
-`isSidePanelTabId(id)` is the single guard the rest of the app uses.
-Anything that does not parse as one of the shapes above is **not** a
-side-pane tab and cannot become the active side-pane tab.
+Anything that does not canonicalize to one of the supported shapes is **not** a
+side-pane tab and cannot become the active side-pane tab. Server validation also
+checks that each tab's `source.sessionId` matches the route session and that pack
+panel ids/instance keys are valid for a registered panel.
 
-### Legacy ids dropped on load
+### Legacy ids are migration input only
 
-Two legacy artefacts are migrated/dropped when `loadPersistedPanelWorkspace`
-hydrates `panelTabsBySession` / `panelWorkspaceActiveBySession` from
-`localStorage`:
+Legacy localStorage keys are read only during the one-time workspace migration,
+and only when the server workspace is empty and has no migration stamp:
 
-| Legacy id | Resolution |
+| Legacy id/key | Resolution |
 |---|---|
-| `chat` (tab row or active id) | **Dropped.** `normalizeStoredPanelTab` filters chat rows and `normalizeActivePanelTabId` maps `"chat"` to `""`. No Chat pill survives the migration. |
-| `preview` / `preview:live` | Mapped to `previewEntryTabId(currentEntry)` — the unversioned filename tab for whatever entry the live mount currently has. |
+| `chat` (tab row or active id) | **Dropped.** Chat is not a side-panel tab. |
+| `preview` / `preview:live` | Mapped to the current filename preview tab when the current entry is known. |
+| `review:<encoded-title>` | Mapped to a deterministic legacy document id so future identity is document-based. |
+| `pack:<packId>:<panelId>` | Mapped to `pack:<packId>:<panelId>:default` only for valid singleton panels. |
+| `bobbit-preview-collapsed-<sessionId>` | Migrates to `sidePanelWorkspace.sizeMode = "collapsed"`. |
+| `bobbit-panel-active-by-session` / `bobbit-panel-tabs-by-session` | Seed the initial server workspace order/active id during migration only. |
 
-The migration is one-way: the in-memory model never re-introduces a chat
-tab row. `previewPanel.ts::selectSensiblePanelWorkspaceTab` still has a
-branch that *would* upsert a chat row as a last-resort fallback, but the
-panel-workspace normaliser strips it back out, so it never makes it onto
-the visible strip.
+After migration, the product app does not write workspace state to localStorage.
+Closed tabs are not inferred from proposal/review/preview/inbox caches. File-based
+fixtures may keep local fallbacks so browser unit fixtures can run without a
+gateway; those fallbacks are not the product source of truth.
 
-### Activation is a pure id setter
+### Activation is a server workspace mutation
 
-`setActivePanelTabIdForSession(state, sessionId, tabId)`:
-
-1. Normalises `tabId` (`chat` / unknown ids → `""`, legacy preview ids →
-   current filename id).
-2. Writes that string into `panelWorkspaceActiveBySession[sid]`.
-3. Mirrors into `state.activePanelTabId` only when this session is the
-   active one in the UI.
-
-The render path then looks up the active tab by id and draws its content.
-There is no second pass, no kind-based fallback, no
-`assistantTab → preview` cascade. Aliasing cannot happen because there is
-only one consulted authority.
+`setActiveSidePanelTab(tabId)` posts to the session workspace API and may point
+only to an open tab or to empty. The committed server response replaces any
+optimistic in-memory state and is broadcast to other clients. The render path
+then looks up the active tab by id in `workspace.tabs` and draws that exact
+content. There is no second pass, no kind-based fallback, and no
+`assistantTab -> preview` cascade. Aliasing cannot happen because there is only
+one consulted authority.
 
 ## 4. Preview tabs
 
@@ -156,10 +160,9 @@ When the agent calls `preview_open(file.html)`:
 2. If it already exists, update it in place (label, content hash, version,
    artifact id, mtime) and take focus. Do not duplicate. Do not reorder.
 
-This is enforced by `selectHtmlPreviewTab` in
-[`src/app/preview-panel.ts`](../../src/app/preview-panel.ts), which finds the
-existing current filename tab via `previewEntryTabId(entry)` before deciding
-whether to upsert or split into a historical tab.
+The preview opener computes the target id via the preview tab helpers, then
+calls the server workspace open/update API. Metadata patches for SSE/bootstrap
+must target an already-open tab; they do not recreate a tab the user closed.
 
 ### 4.2 Version assignment
 
@@ -273,124 +276,111 @@ may remain the render target if each tab has an immutable restore source" —
 is preserved: each historical tab restores its artifact into the same live
 mount before the iframe renders it.
 
-## 5. Proposal, review, walkthrough, and inbox tabs
+## 5. Proposal, review, pack, and inbox tabs
 
-All four kinds share the id-keyed activation and ordering model with
-preview.
+All side-panel kinds share the server-backed id-keyed activation and ordering
+model with preview.
 
-**Proposal tabs** are minted from the active-proposal slot for a session.
-`proposal:<type>` (no `:rev:` suffix) is the editable slot for an active
-proposal. `proposal:<type>:rev:<N>` tabs are historical immutable
-revisions (snapshots committed earlier in the session). Active proposal
-slots upsert their tab on creation; closing the tab dismisses the
-proposal via the existing proposal-dismiss flow. Historical revisions
-close cleanly on their own and never touch the active slot.
+**Proposal tabs** open from proposal events or explicit reopen affordances.
+`proposal:<type>` (no `:rev:` suffix) is the editable current slot for an active
+proposal. `proposal:<type>:rev:<N>` tabs are historical revisions and are opened
+only by explicit historical/reopen UI. A new current revision updates/focuses
+the matching current tab instead of creating a duplicate. Closing a proposal tab
+removes only the workspace tab unless the business action also dismisses the
+proposal; refresh must not recreate it from `activeProposals`.
 
-**Review tabs** use `review:<encoded-title>` and map 1:1 to entries in
-the session's `reviewDocuments` map. Closing a review tab fires the
-existing review-close behaviour.
+**Review tabs** use `review:<encoded-documentId>`. `documentId` is stable and
+survives title changes; title is display metadata. Review content/annotations
+may remain cached after close, but restoring those caches must not open a tab
+unless the server workspace already contains it or the user explicitly reopens
+it.
 
-**Walkthrough tabs** *(historical — deleted)*. The PR/changeset walkthrough
-formerly used a `walkthrough:<changeset-id>` side-pane tab kind: slash-command,
-Git Status Widget, and PR-link metadata launch paths upserted the matching tab
-and took focus, with the same tab rendering in the side panel, fullscreen/wide
-surface, or a standalone `/walkthrough?...` route. **That tab kind, those launch
-paths, and the standalone route are removed.** The walkthrough viewer now ships
-as the built-in first-party pack at the generic `#/ext/pr-walkthrough` route; a
-pack entrypoint opens the pack panel and the pack persists its review state
-through its own pack-namespaced `host.store`. See
+**Pack tabs** use `pack:<packId>:<panelId>:<instanceKey>`. The PR walkthrough is
+a singleton pack panel; artifact-style pack panels can use distinct instance
+keys so multiple artifacts coexist. Pack panel popout/deep links render only an
+already-open server tab and reuse the session-scoped Host API.
+
+**Walkthrough tabs** *(historical - deleted)*. The PR/changeset walkthrough
+formerly used a `walkthrough:<changeset-id>` side-pane tab kind. **That tab kind,
+those launch paths, and the standalone route are removed.** The walkthrough
+viewer now ships as the built-in first-party pack at the generic
+`#/ext/pr-walkthrough` route; a pack entrypoint opens the pack panel and the pack
+persists its review state through its own pack-namespaced `host.store`. See
 [docs/design/pr-walkthrough-pack-deletion.md](./pr-walkthrough-pack-deletion.md).
 
-**Inbox** is special. For staff-agent sessions it is an always-present,
-pinned side-pane tab:
-
-- The tab is created whenever `inboxPanelOpen` is true.
-- `isPinnedPanelTab(tab)` returns true only for `id === "inbox"` and
-  `kind === "inbox"`.
-- The render path omits the close button (`closable = !isPinnedPanelTab`)
-  and the drag handle (`draggable = isDesktop() && !isPinnedPanelTab`).
-- `pinnedFirst()` always pulls Inbox to index 0 of the strip; reorder
-  cannot drop another tab before it (see § 7).
-- Inbox is unaffected by "close last side-pane tab in a non-staff
-  session hides the pane" — staff sessions always keep the pane open.
+**Inbox** is a normal workspace tab with id `inbox`. Staff sessions can open or
+focus it through explicit inbox/session actions. Closing the tab deletes it from
+the server workspace and preserves that closed state across reload, restart, and
+other devices until an explicit inbox action reopens it. It uses the same shared
+close, reorder, collapse, fullscreen, restore, and popout controls as other tab
+kinds.
 
 ## 6. Activation and ordering rules
 
 ### Focus and activation
 
-- Activating a tab is a **pure id setter** —
-  `setActivePanelTabIdForSession(state, sid, tab.id)`.
-- The render path resolves the active id back to a `PanelWorkspaceTab` via
-  `findPanelTab(tabs, activeId)` and draws that exact content. No
-  kind-based fallback. No second-chance derivation.
-- Agent-driven events (new `preview_open`, new proposal, new review, new
-  walkthrough) are allowed to **create or update** a tab and take focus.
+- Activating a tab is a server workspace mutation (`active`) against an
+  already-open tab id.
+- The render path resolves the active id back to a workspace tab and draws that
+  exact content. No kind-based fallback. No second-chance derivation.
+- Agent/tool/UI events (`preview_open`, proposal, review, pack open, inbox open)
+  may **create or update** a tab only by calling the workspace open/update APIs.
   That is the natural "the agent opened a tab and it took focus" UX.
-- Selection, content arrival, and focus changes **never reorder** existing
-  tabs. Order only changes when:
-  - The user drags a tab (§ 7), or
-  - A new tab is appended (always at the end of non-pinned tabs).
+- Selection, content arrival, and focus changes **never reorder** existing tabs.
+  Order only changes when the user drags/reorders a tab or when a new tab is
+  inserted by an explicit open mutation.
 
 ### Closing the active tab
 
-`nextActivePanelTabId(tabs, closedId)`:
+The server chooses the next active tab like a browser tab strip:
 
-1. List the side-pane tabs (`panelContentTabs` — anything `isSidePanelTabId`).
+1. List the open workspace tabs.
 2. Find the index of the closed tab.
-3. If found, activate `tabs[index + 1]` (right neighbour) else
-   `tabs[index - 1]` (left neighbour).
-4. If no side-pane tabs remain, return `""` — the side pane hides and
-   chat fills the main area. In staff sessions the pinned Inbox keeps
-   the pane open.
+3. If found, activate the right neighbour; otherwise activate the left neighbour.
+4. If no side-pane tabs remain, return `""` - the side pane hides and chat fills
+   the main area.
 
 ### Session switching
 
-The active side-pane tab id is stored **per session** in
-`panelWorkspaceActiveBySession[sid]` and persisted to `localStorage` under
-`bobbit-panel-active-by-session`. Selecting a different session restores
-its own last active id; it never borrows another session's active tab.
+The active side-pane tab id is stored **per session** in the server workspace.
+Selecting a different session hydrates that session's workspace and restores its
+own active id, order, and size mode; it never borrows another session's active
+tab. Workspace changes broadcast over WebSocket so multiple browser contexts
+converge on the same active tab and order.
 
 ## 7. Drag reorder
 
-Source of truth: [SortableJS](https://github.com/SortableJS/Sortable) bound
-to the tab-bar container in [`src/app/render.ts`](../../src/app/render.ts)
-(`ensurePanelSortable`), plus `reorderSidePanelTab` in
-[`src/app/panel-workspace.ts`](../../src/app/panel-workspace.ts) for any
-programmatic reorder paths (drag commits a fresh order directly off the DOM).
+Source of truth: [SortableJS](https://github.com/SortableJS/Sortable) bound to
+the tab-bar container in the side-panel shell. Drag commits a complete ordered id
+list to the server workspace reorder API, using the latest workspace revision so
+stale reorders cannot drop tabs opened by another device.
 
 - Desktop pointer drag reorders side-pane tab pills horizontally via a
   SortableJS instance attached after every render to the inner tab-bar
-  container (`[data-panel-tab-bar]`). `ensurePanelSortable` is idempotent
-  — it re-uses the existing instance unless the container element
-  changes (workspace switch).
-- `forceFallback: true` is on so SortableJS uses its own pointer
-  emulator instead of native HTML5 DnD. This:
-  - lets it work with `<div role="button">` pills (button elements
-    swallow `pointerdown` and break native DnD);
-  - gives us a JS-positioned floating clone (`Sortable.ghost`) we can
-    re-style and constrain via inline `transform`;
+  container (`[data-panel-tab-bar]`). The binding is idempotent - it reuses the
+  existing instance unless the container element changes.
+- `forceFallback: true` is on so SortableJS uses its own pointer emulator instead
+  of native HTML5 DnD. This:
+  - lets it work with `<div role="button">` pills (button elements swallow
+    `pointerdown` and break native DnD);
+  - gives us a JS-positioned floating clone (`Sortable.ghost`) we can re-style
+    and constrain via inline `transform`;
   - keeps drag-detect responsive on touch devices.
-- **Chrome-style Y-axis lock**: `startPanelDragYLock` runs a
-  `requestAnimationFrame` loop while a drag is in progress. Each frame
-  it reads the floating clone's `transform: matrix(a,b,c,d,e,f)` and
-  rewrites `f` (translateY) to `0`. The dragged tab tracks the cursor
-  horizontally; vertical cursor wander has no visual effect.
-- Pinned tabs (Inbox, mobile Chat pill) are skipped via the SortableJS
-  `filter: ".goal-tab-pill--pinned, .goal-tab-close"` selector —
-  attempting to pick one up does nothing. The `onMove` handler also
-  returns `false` when the related drop target is pinned, blocking
-  drops in front of the pinned slot.
-- `setRenderSuppressed(true)` is invoked in `onStart` so any
-  `renderApp()` calls during the drag are buffered. SortableJS owns the
-  DOM during the drag; on `onEnd` the new tab id order is read off the
-  DOM children, committed to `panelTabsBySession[sid]`, and renders
-  resume with a single flush.
-- Non-pinned tabs persist their stored order in `panelTabsBySession[sid]`
-  (saved under the `bobbit-panel-tabs-by-session` localStorage key) and
-  survive reload / session switch.
-- New agent-opened tabs append at the **end** of the non-pinned tabs.
-- Touch devices fall through SortableJS's touch emulator. The existing
-  main-chat ↔ side-pane swipe gesture remains.
+- **Chrome-style Y-axis lock**: the drag loop rewrites the floating clone's
+  translateY to `0`. The dragged tab tracks the cursor horizontally; vertical
+  cursor wander has no visual effect.
+- Close controls are filtered out of drag starts so clicking a close button never
+  begins a reorder. Mobile-only chat affordances are UI-only and are not
+  persisted as workspace tabs.
+- Renders are suppressed while SortableJS owns the DOM. On drag end, the new tab
+  id order is read from the DOM, posted to the server workspace, and the
+  committed workspace response resumes rendering.
+- Tab order persists in `sidePanelWorkspace.tabs` on the server and survives
+  reload, restart, session switch, and another browser context joining later.
+- New agent-opened tabs are inserted by the explicit open mutation; default UX is
+  append/after-active without reordering existing tabs.
+- Touch devices fall through SortableJS's touch emulator. The existing main-chat
+  <-> side-pane swipe gesture remains.
 - No keyboard reorder shortcuts in this iteration.
 
 ## 7a. Historical proposal tabs
@@ -425,48 +415,42 @@ preview tabs:
 
 ## 8. Cross-kind harmony
 
-> *(Historical: the `walkthrough` references in this section describe the
-> deleted `walkthrough:<changeset-id>` side-pane tab kind. The walkthrough viewer
-> is now the built-in pack at `#/ext/pr-walkthrough` and is no longer a side-pane
-> tab; the harmony invariants still hold for preview, proposal, review, and inbox
-> tabs.)*
+The point of the contract is that preview, proposal, review, pack, and inbox
+tabs all share the same model:
 
-The point of the contract is that preview, proposal, review, walkthrough,
-and inbox tabs all share the same model:
-
-- One id-keyed activation authority.
+- One server-authoritative id-keyed activation authority.
 - One stored order per session.
-- One render path that resolves content by id.
+- One shared render shell that resolves content by tab id.
 
 So:
 
-- A new `preview_open` never removes, reorders, or mutates proposal /
-  review / walkthrough / inbox tabs.
-- A proposal update never reorders preview, review, walkthrough, or inbox
-  tabs or mints duplicates.
-- Opening a PR walkthrough appends the tab at the end of the non-pinned
-  tabs, or focuses and updates the existing `walkthrough:<changeset-id>`
-  tab. It does not bucket walkthroughs away from other kinds.
-- User drag reorder persists the mixed-kind order exactly as stored in
-  `panelTabsBySession[sid]`; only pinned Inbox is pulled to the front by
-  `pinnedFirst`.
-- Active selection persists by id in `panelWorkspaceActiveBySession[sid]`,
-  so reload and session switch restore the selected walkthrough just like
-  preview, proposal, and review tabs. Walkthrough-internal persistence is
-  keyed by the same tab id to keep each changeset isolated.
+- A new `preview_open` never removes, reorders, or mutates proposal / review /
+  pack / inbox tabs.
+- A proposal update never reorders preview, review, pack, or inbox tabs or mints
+  duplicates.
+- Opening a PR walkthrough opens or focuses the normal singleton pack tab. It
+  does not have bespoke walkthrough resize state or a bespoke tab kind.
+- User drag reorder persists the mixed-kind order exactly as committed to the
+  server workspace.
+- Active selection persists by id in `sidePanelWorkspace.activeTabId`, so reload,
+  restart, session switch, and another browser context restore the same active
+  preview/proposal/review/pack/inbox tab.
 
 ## 9. Implementation hot spots
 
 | File | Responsibility |
 |---|---|
-| [`src/app/panel-workspace.ts`](../../src/app/panel-workspace.ts) | Tab id grammar, normalization, persistence, version ledger, pinned ordering, `nextActivePanelTabId`, `reorderSidePanelTab`. |
-| [`src/app/preview-panel.ts`](../../src/app/preview-panel.ts) | `selectHtmlPreviewTab` (upsert / split / collapse), SSE bootstrap and live update, older-version-rehydration guard. |
+| [`src/shared/side-panel-workspace.ts`](../../src/shared/side-panel-workspace.ts) | Shared workspace/tab model, size modes, and tab source records. |
+| [`src/server/side-panel-workspace.ts`](../../src/server/side-panel-workspace.ts) | Server canonicalization, validation, mutation application, and concurrency rules. |
+| [`src/app/side-panel-workspace.ts`](../../src/app/side-panel-workspace.ts) | Client hydrate/open/update/close/active/reorder/resize controller, optimistic state, and migration client. |
+| [`src/app/panel-workspace.ts`](../../src/app/panel-workspace.ts) | Preview tab id/display helpers and legacy fixture fallback; not product workspace persistence. |
+| [`src/app/preview-panel.ts`](../../src/app/preview-panel.ts) | Preview mount/SSE/bootstrap, preview opener integration, older-version-rehydration guard. |
 | ~~`src/app/pr-walkthrough.ts`~~ *(deleted)* | Former owner of slash-command parsing, changeset-derived walkthrough tab id / title, tab upsert, and active-id selection. **Removed** with the bespoke walkthrough tab kind; the viewer is now the built-in pack at `#/ext/pr-walkthrough`. |
-| [`src/app/render.ts`](../../src/app/render.ts) | Side-pane tab strip rendering (Chrome-style with radial-gradient corner pseudos for active tab), mobile pane bar with pinned Chat pill, SortableJS attach (`ensurePanelSortable`) + X-axis lock raF loop, render suppression during drag, `_proposalOverride` for editable historical proposal tabs, active-content lookup by id only. *(The deleted walkthrough panel branch no longer renders here.)* |
-| [`src/ui/tools/renderers/PreviewRenderer.ts`](../../src/ui/tools/renderers/PreviewRenderer.ts) | Tool-card Open button; chooses between artifact restore, source remount, and recorded-entry select; computes collapse-to-current before invoking `selectHtmlPreviewTab`. |
+| [`src/app/render.ts`](../../src/app/render.ts) | Shared side-panel workspace shell, tab strip, controls, active-content lookup by id only, mobile slider integration. |
+| [`src/ui/tools/renderers/PreviewRenderer.ts`](../../src/ui/tools/renderers/PreviewRenderer.ts) | Tool-card Open button; chooses between artifact restore, source remount, and recorded-entry select. |
 | [`src/server/preview/artifacts.ts`](../../src/server/preview/artifacts.ts) | `persistPreviewArtifact`, `restorePreviewArtifact`, `findPreviewArtifactByHash`, `sweepOrphanArtifacts`. |
-| [`src/server/server.ts`](../../src/server/server.ts) (`/api/preview/mount`, `/api/preview/artifacts/:id/restore`, SSE) | Capture artifact on mount; include `artifactId` in mount responses, SSE bootstrap, and live events. |
-| [`defaults/tools/html/snapshot.ts`](../../defaults/tools/html/snapshot.ts) | v3 marker builder — emits `artifactId` and other artifact metadata when they fit the 250-byte cap. |
+| [`src/server/server.ts`](../../src/server/server.ts) | Side-panel workspace REST routes plus preview mount/artifact/SSE routes. |
+| [`defaults/tools/html/snapshot.ts`](../../defaults/tools/html/snapshot.ts) | v3 marker builder - emits `artifactId` and other artifact metadata when they fit the 250-byte cap. |
 
 ## 10. Tests
 
@@ -489,18 +473,17 @@ spec):
    to current with no duplicate / no unnecessary remount.
 4. **Dismiss + next-active behaviour** — close a middle preview tab; only
    that tab disappears. Close active tabs across preview / proposal /
-   review and verify next-right / next-left activation. Close the last
-   non-pinned side-pane tab in a non-staff session — the pane hides.
-5. **Pinned Inbox** — in a staff-agent session, Inbox is always present,
-   pinned first, has no close button, cannot be dragged, and remains
-   when other tabs are closed. Other tabs open beside it and close
-   normally.
-6. **Drag reorder persistence** — drag non-pinned tabs (SortableJS), assert
-   stored order, reload, assert the same order. Verify drag cannot move a
-   tab before pinned Inbox.
+   review / inbox / pack and verify next-right / next-left activation.
+   Close the last side-pane tab — the pane hides and closed state persists
+   across reload.
+5. **Inbox workspace tab** — in a staff-agent session, Inbox opens as `inbox`,
+   uses the same close/reorder/fullscreen/collapse/popout controls as other
+   side-panel tabs, and stays closed across reload until explicitly reopened.
+6. **Drag reorder persistence** — drag tabs (SortableJS), assert server stored
+   order, reload or open a second browser context, assert the same order.
    Y-axis is locked during the drag: the floating clone tracks the cursor
-   only horizontally regardless of vertical movement.
-   The mobile Chat pill is pinned (filtered) and cannot be dragged.
+   only horizontally regardless of vertical movement. Mobile chat affordances
+   remain UI-only and are never persisted as workspace tabs.
 7. **Tab id == rendered content** — with preview + proposal + review +
    inbox visible, click every tab and assert `activePanelTabId` equals
    the clicked id and the rendered content matches that id. Repeat after
@@ -509,18 +492,16 @@ spec):
    firing a new `preview_open` appends-or-updates the preview tab and
    takes focus. Subsequent updates / refreshes never reorder existing
    tabs unless a brand-new tab is appended.
-9. **Mobile** — at phone viewport, the side-pane tab bar leads with a
-   pinned Chat pill that swipes the slider to the chat pane on tap; the
-   remaining tabs are the side-pane tabs (preview / proposal / review /
-   inbox). The Chat pill is NOT persisted in `panelTabsBySession[sid]`
-   — it's a pure UI affordance rendered only when the bar is visible.
-   The existing swipe gesture reveals chat and the side pane; no touch
-   drag reorder.
+9. **Mobile** — at phone viewport, the side-pane tab bar may expose a chat
+   affordance that swipes the slider to the chat pane on tap; persisted workspace
+   tabs remain preview / proposal / review / pack / inbox only. Chat is never
+   persisted in the server workspace. The existing swipe gesture reveals chat and
+   the side pane; no touch drag reorder.
 
-Helper / reducer behaviour (id normalisation, version assignment, pinned
-ordering, next-active selection) is covered by unit tests against the
-pure functions in `panel-workspace.ts` and `preview-panel.ts`. Existing
-preview regression coverage stays green:
+Helper / reducer behaviour (id normalisation, version assignment, server
+canonicalization, reorder revision checks, migration, and next-active selection)
+is covered by unit tests against the side-panel workspace helpers plus preview
+helpers. Existing preview regression coverage stays green:
 
 - [`tests/preview-renderer.spec.ts`](../../tests/preview-renderer.spec.ts)
 - [`tests/e2e/ui/dynamic-chat-tabs.spec.ts`](../../tests/e2e/ui/dynamic-chat-tabs.spec.ts)

--- a/docs/design/staff-inbox.md
+++ b/docs/design/staff-inbox.md
@@ -1,6 +1,13 @@
 # Staff Inbox Queue — Design
 
-> **Status: shipped.** Operational documentation lives in [docs/staff-inbox.md](../staff-inbox.md). This page is the original design record — kept verbatim for historical reference. Where this doc and the operator doc disagree, the operator doc and the source code win.
+> **Historical design record.** Operational documentation lives in
+> [docs/staff-inbox.md](../staff-inbox.md). Older side-panel details about local
+> inbox-open booleans, preview-era shortcut gates, hardcoded source locations,
+> and localStorage persistence are superseded by the server-authoritative
+> side-panel workspace described in
+> [docs/side-panel-workspace.md](../side-panel-workspace.md). The current inbox
+> panel is a normal closeable `inbox` workspace tab; the server workspace owns
+> open/closed state, active tab, tab order, and size mode.
 
 Goal: introduce a first-class **inbox** for staff agents — a persistent, per-staff ordered queue of work items that decouples triggers from agent wakes.
 
@@ -14,7 +21,7 @@ Today the path from a trigger to a staff agent processing the work is:
 TriggerEngine.tick()  →  fireTrigger()  →  staffManager.wake()  →  sessionManager.enqueuePrompt()
 ```
 
-`fireTrigger` in `src/server/agent/staff-trigger-engine.ts:227` calls `staffManager.wake()` directly. The trigger engine guards against a busy session by skipping firing when `session.status === "streaming" | "starting"` (`staff-trigger-engine.ts:130`). When the engine skips, **the trigger event is silently dropped**: cron triggers `lastFired`-gate per-minute (`staff-trigger-engine.ts:166`), and git triggers update `lastSeenSha` before checking status (`staff-trigger-engine.ts:204`), so the work is gone. The agent has no record that it was ever signalled.
+`fireTrigger` in `src/server/agent/staff-trigger-engine.ts` calls `staffManager.wake()` directly. The trigger engine guards against a busy session by skipping firing when `session.status === "streaming" | "starting"` (`staff-trigger-engine.ts`). When the engine skips, **the trigger event is silently dropped**: cron triggers `lastFired`-gate per-minute (`staff-trigger-engine.ts`), and git triggers update `lastSeenSha` before checking status (`staff-trigger-engine.ts`), so the work is gone. The agent has no record that it was ever signalled.
 
 This has three operational problems:
 
@@ -64,7 +71,7 @@ No coalescing — every enqueue produces a new entry. Two triggers firing 100 ms
 
 ### 2.2 Persistence
 
-One JSON file per staff: `<projectStateDir>/inbox/<staffId>.json`. Mirrors `StaffStore` (`src/server/agent/staff-store.ts`) — synchronous JSON load/save, no migrations, lazy directory creation. `projectStateDir` is `<project-root>/.bobbit/state/` as set by `ProjectContext` (`src/server/agent/project-context.ts:67-68`).
+One JSON file per staff: `<projectStateDir>/inbox/<staffId>.json`. Mirrors `StaffStore` (`src/server/agent/staff-store.ts`) — synchronous JSON load/save, no migrations, lazy directory creation. `projectStateDir` is `<project-root>/.bobbit/state/` as set by `ProjectContext` (`src/server/agent/project-context.ts`).
 
 File schema:
 
@@ -103,7 +110,7 @@ Add one field to `PersistedStaff` in `src/server/agent/staff-store.ts`:
 contextPolicy: "preserve" | "compact";
 ```
 
-`StaffStore.load()` normalises missing records to `"compact"` (the same pattern used for `sandboxed` in `staff-store.ts:73-77`).
+`StaffStore.load()` normalises missing records to `"compact"` (the same pattern used for `sandboxed` in `staff-store.ts`).
 
 ---
 
@@ -188,7 +195,7 @@ Responsibilities:
 
 ### 3.3 `src/server/agent/inbox-nudger.ts` (NEW)
 
-15-second tick loop. Mirrors `TeamManager.startIdleNudgeTimer` / `shouldSkipNudge` / `nudgePending` (`src/server/agent/team-manager.ts:148, 384, 419`).
+15-second tick loop. Mirrors `TeamManager.startIdleNudgeTimer` / `shouldSkipNudge` / `nudgePending` in `src/server/agent/team-manager.ts`.
 
 ```ts
 export class InboxNudger {
@@ -224,7 +231,7 @@ Mirrors `defaults/tools/tasks/` structure: one YAML manifest per tool + a single
 | `defaults/tools/inbox/inbox_dismiss.yaml` | manifest — params: `entry_id`, `outcome`, `reason` |
 | `defaults/tools/inbox/extension.ts` | runtime registration + HTTP calls to REST API |
 
-Target descriptions (≤ 150 chars each, per `tests/tool-description-budget.test.ts:47`):
+Target descriptions (≤ 150 chars each, per `tests/tool-description-budget.test.ts`):
 
 | Tool | description (≤150) |
 |---|---|
@@ -232,9 +239,9 @@ Target descriptions (≤ 150 chars each, per `tests/tool-description-budget.test
 | `inbox_complete` | `Mark an inbox entry as completed with an optional result summary.` (~66) |
 | `inbox_dismiss` | `Dismiss an inbox entry as failed or cancelled with a reason.` (~62) |
 
-Parameter descriptions ≤ 80 chars (per `tests/tool-description-budget.test.ts:48`).
+Parameter descriptions ≤ 80 chars (per `tests/tool-description-budget.test.ts`).
 
-Add `"inbox"` to `EXTENSION_FILES` in `tests/tool-description-budget.test.ts:30` so the new group is included in the budget pin.
+Add `"inbox"` to `EXTENSION_FILES` in `tests/tool-description-budget.test.ts` so the new group is included in the budget pin.
 
 Gating: §6.
 
@@ -242,15 +249,15 @@ Gating: §6.
 
 | File | Status | Responsibility |
 |---|---|---|
-| `src/app/inbox-panel.ts` | NEW | Mirrors `src/app/preview-panel.ts`. Owns the per-session subscription lifecycle, maps WS `inbox.entry.*` events into `state.inboxEntries`, exposes `startInboxSubscription(sessionId)` / `stopInboxSubscription()`. |
+| `src/app/inbox-panel.ts` | NEW | Owns per-session inbox subscription/bootstrap and explicitly opens/focuses the `inbox` side-panel workspace tab. |
 | `src/ui/inbox/InboxPanel.ts` | NEW | LitElement `<inbox-panel>`. Renders Pending section + History section + Add-to-inbox button. Mirrors `src/ui/components/review/ReviewPane.ts` shape. |
 | `src/ui/inbox/InboxEntry.ts` | NEW | Single-row item: title, source badge, age, cancel/delete affordances. |
 | `src/ui/inbox/AddToInboxDialog.ts` | NEW | Composer dialog opened from the panel's "Add to inbox" button. Posts to `POST /api/staff/:id/inbox` with `source.type = "manual_ui"`. |
-| `src/app/staff-page.ts` | EDIT | Adds the `contextPolicy` radio group in the edit form (between "Pinned Context" and the save bar; see §8). |
-| `src/app/state.ts` | EDIT | New fields: `inboxEntries`, `inboxPanelOpen` (mirrors `reviewPanelOpen`, `state.ts:328`). |
-| `src/app/main.ts` | EDIT | Extends `canFullscreen` / `hasPanel` checks (`main.ts:548-549, 608, 632`) to include `state.inboxPanelOpen` so the existing `Ctrl+]` / `Ctrl+[` shortcuts treat inbox as a peer of preview/review/proposal. |
-| `src/app/render.ts` | EDIT | Renders `<inbox-panel>` in the split-pane slot when the active session has `staffId` set. |
-| `src/app/session-manager.ts` | EDIT | On session select: clear `state.inboxEntries`; if `session.staffId` set, call `startInboxSubscription(session.id)`. Resets on session switch (matches the `state.reviewDocuments = new Map()` pattern at `session-manager.ts:860-862`). |
+| `src/app/staff-page.ts` | EDIT | Adds the `contextPolicy` radio group in the edit form. |
+| `src/app/state.ts` | EDIT | Adds inbox entry/dialog content state. Open/closed tab state is not stored here; it lives in `sidePanelWorkspace`. |
+| `src/app/main.ts` | EDIT | Uses shared side-panel workspace helpers for shortcuts; no inbox-specific fullscreen gate. |
+| `src/app/render.ts` | EDIT | Renders `<inbox-panel>` when the server workspace contains the `inbox` tab. |
+| `src/app/session-manager.ts` | EDIT | On session select: clear `state.inboxEntries`; if `session.staffId` set, call `startInboxSubscription(session.id)`. |
 
 ### 3.6 Test files (NEW)
 
@@ -269,7 +276,7 @@ Gating: §6.
 ### 4.1 Trigger fires → entry processed
 
 ```
-TriggerEngine.tick (60s, staff-trigger-engine.ts:122)
+TriggerEngine.tick (60s, staff-trigger-engine.ts)
   └─ checkScheduleTrigger / checkGitTrigger
        └─ fireTrigger(staff, trigger, extraContext)
             └─ inboxManager.enqueue(staff.id, { title, prompt, context, source: {type:"trigger", triggerId}})
@@ -322,7 +329,7 @@ Tick T+k:  staff idle.
 
 NO exponential backoff. Inbox nudges only fire against idle agents (no productive
 work is being interrupted), so unbounded re-nudge is safe. Contrast with
-TeamManager (team-manager.ts:447-451) where backoff caps interruption pressure
+TeamManager (team-manager.ts) where backoff caps interruption pressure
 on a working lead.
 ```
 
@@ -361,7 +368,7 @@ class InboxNudger {
     if (!staff || staff.state !== "active") return;
     if (!staff.currentSessionId) return;
     const session = this.sessionManager.getSession(staff.currentSessionId);
-    if (!session || session.status !== "idle") return;        // mirrors team-manager.ts:388
+    if (!session || session.status !== "idle") return;        // mirrors team-manager.ts
     if (this.nudgePending.get(staff.id)) return;
     const pending = this.inboxStore.listPending(staff.id);
     if (pending.length === 0) return;
@@ -388,7 +395,7 @@ class InboxNudger {
   private async runCompact(sessionId: string) {
     const session = this.sessionManager.getSession(sessionId);
     if (!session || session.status !== "idle") return;        // double-check race
-    // Same call surface as ws/handler.ts:600 — bypass the WS handler, no sidecar
+    // Same call surface as ws/handler.ts — bypass the WS handler, no sidecar
     // accounting needed here (compact-as-prelude isn't a user-visible operation).
     await session.rpcClient.compact(120_000);
   }
@@ -397,7 +404,7 @@ class InboxNudger {
 
 ### 5.2 `agent_start` hook wiring
 
-`SessionManager.handleEvent` already routes `agent_start` (`src/server/agent/session-manager.ts:1853`). Wire an event subscription matching `TeamManager.subscribeTeamLeadEvents` (`team-manager.ts:543-560`):
+`SessionManager.handleEvent` already routes `agent_start` (`src/server/agent/session-manager.ts`). Wire an event subscription matching `TeamManager.subscribeTeamLeadEvents` (`team-manager.ts`):
 
 - Subscribe to `session.rpcClient.onEvent` once per staff session at `InboxNudger.start()` and re-subscribe lazily inside `tickOne` when the session pointer changes.
 - On `event.type === "agent_start"`: `this.nudgePending.delete(staffId)`.
@@ -424,13 +431,13 @@ A session can't be both (staff sessions have `staffId` set, team-lead sessions h
 
 Inbox tools are useless and dangerous on non-staff sessions: they'd point at no `staffId` and either 400 or silently mutate an unrelated staff's inbox.
 
-**Gating lives in the extension entry-point.** Pattern (mirrors `defaults/tools/tasks/extension.ts:18-22` which early-returns when `goalId` is missing):
+**Gating lives in the extension entry-point.** Pattern (mirrors `defaults/tools/tasks/extension.ts` which early-returns when `goalId` is missing):
 
 ```ts
 // defaults/tools/inbox/extension.ts
 export default function (pi: ExtensionAPI) {
   const sessionId = process.env.BOBBIT_SESSION_ID;
-  const staffId   = process.env.BOBBIT_STAFF_ID;        // already set in session-manager.ts:2749
+  const staffId   = process.env.BOBBIT_STAFF_ID;        // already set in session-manager.ts
   if (!sessionId || !staffId) {
     return;                                              // tools not registered
   }
@@ -438,7 +445,7 @@ export default function (pi: ExtensionAPI) {
 }
 ```
 
-The agent process for a non-staff session never has `BOBBIT_STAFF_ID` in its env (see `session-manager.ts:2748-2750`), so the extension is a no-op there and the tools are not exposed in the tool catalogue. No further server-side check needed.
+The agent process for a non-staff session never has `BOBBIT_STAFF_ID` in its env (see `session-manager.ts`), so the extension is a no-op there and the tools are not exposed in the tool catalogue. No further server-side check needed.
 
 For defence-in-depth, the REST handlers behind the tools (POST `/api/staff/:id/inbox/:entryId/complete`, `…/dismiss`) re-verify that the calling session's `staffId` matches the path `:id`. See §7 for the exact body shape.
 
@@ -446,7 +453,7 @@ For defence-in-depth, the REST handlers behind the tools (POST `/api/staff/:id/i
 
 ## 7. REST + WebSocket surface
 
-### 7.1 Routes (added to `server.ts::handleApiRoute()`, beside the existing staff routes at `server.ts:8025-8152`)
+### 7.1 Routes (added to `server.ts::handleApiRoute()`, beside the existing staff routes at `server.ts`)
 
 | Method | Path | Body | 2xx response | Errors |
 |---|---|---|---|---|
@@ -460,11 +467,11 @@ The `complete` / `dismiss` POSTs are the API surface the inbox tools hit. `sessi
 
 ### 7.2 Removal of legacy `POST /api/staff/:id/wake`
 
-`server.ts:8131-8145` is deleted. UI's "Wake Now" button (`src/app/staff-page.ts:504` — `handleWake` calls `wakeStaffAgent`) is rewired to call `POST /api/staff/:id/inbox` with `source.type = "manual_ui"`, title = `"Manual wake"`, prompt = the existing optional wake message. The `api.ts::wakeStaffAgent` helper is renamed `enqueueInboxManual` and its return shape changes from `{ sessionId }` to `{ entry }`.
+The legacy wake route is deleted. UI's "Wake Now" button (`src/app/staff-page.ts`) is rewired to call `POST /api/staff/:id/inbox` with `source.type = "manual_ui"`, title = `"Manual wake"`, prompt = the existing optional wake message. The `api.ts::wakeStaffAgent` helper is renamed `enqueueInboxManual` and its return shape changes from `{ sessionId }` to `{ entry }`.
 
 ### 7.3 WebSocket events
 
-Three new events broadcast via `broadcastToAll` (mirrors `task_changed`, `gate_status_changed`). Add to `ServerMessage` union in `src/server/ws/protocol.ts:64-101`:
+Three new events broadcast via `broadcastToAll` (mirrors `task_changed`, `gate_status_changed`). Add to `ServerMessage` union in `src/server/ws/protocol.ts`:
 
 ```ts
 | { type: "inbox.entry.added";   staffId: string; entry: InboxEntry }
@@ -480,53 +487,65 @@ Clients filter by `staffId` (the staff page's inbox panel and the staff session 
 
 ## 8. UI architecture
 
-### 8.1 Panel parallelism with `preview-panel.ts`
+### 8.1 Panel subscription and workspace tab
 
-`src/app/inbox-panel.ts` (NEW) mirrors `src/app/preview-panel.ts` 1:1:
+`src/app/inbox-panel.ts` owns inbox content loading and the explicit workspace
+open path:
 
 ```ts
-// State
-let currentSid: string | null = null;
-
-// API
+export function openInboxPanel(sessionId: string): Promise<void>;
 export function startInboxSubscription(sessionId: string): void;
 export function stopInboxSubscription(): void;
 ```
 
-Differences:
-- No SSE; the WebSocket already carries the events. The subscription is just a session-id pointer + a render reset.
-- Bootstrap fetch: `GET /api/staff/:id/inbox?state=pending` then `GET /api/staff/:id/inbox?state=completed&limit=100` for history. Result populates `state.inboxEntries`.
-- WS handler in `src/app/remote-agent.ts` adds a case for `inbox.entry.*` that mutates `state.inboxEntries` and calls `renderApp()` (mirrors the existing `review_open` handler at `remote-agent.ts:1763-1792`).
+The subscription still bootstraps content with REST and applies
+`inbox.entry.*` WebSocket events to `state.inboxEntries`. Open/closed UI state is
+separate: opening the inbox calls the side-panel workspace open API for the
+`inbox` tab, and rendering happens only when the server workspace contains that
+tab.
+
+Differences from the original plan:
+
+- No local inbox-open boolean is authoritative.
+- Closing the inbox removes the `inbox` tab from `sidePanelWorkspace.tabs`; it
+  does not delete inbox entries.
+- Refresh/reconnect loads the server workspace exactly. A closed inbox stays
+  closed until an explicit inbox action opens it again.
+- The inbox uses the shared side-panel controls for close, reorder, fullscreen,
+  collapse, restore, and popout.
 
 ### 8.2 App state additions (`src/app/state.ts`)
 
-Add next to `reviewPanelOpen` (`state.ts:328`):
+Current app state keeps inbox **content** and dialog state only:
 
 ```ts
-/** Inbox panel (per-session split panel for staff session views) */
-inboxEntries: [] as InboxEntry[],          // pending + recent terminal, populated on session select
-inboxPanelOpen: false,                     // collapsed/open toggle, persisted per-session via localStorage
-inboxAddDialogOpen: false,                 // manual enqueue dialog
+/** Inbox panel content for staff session views. */
+inboxEntries: [] as InboxEntry[],
+inboxAddDialogOpen: false,
 ```
 
-`inboxPanelOpen` is hydrated from `localStorage` keyed by session id (mirror `bobbit-preview-collapsed-${sid}` pattern in `main.ts:551`).
+The side-panel workspace owns the tab record, active tab, tab order, and size
+mode:
+
+```ts
+sidePanelWorkspaceBySession: Record<string, SidePanelWorkspace>;
+```
+
+Legacy localStorage keys are migration input only. The product app does not use
+preview-era collapse keys or an inbox boolean as the load-bearing open/closed
+state.
 
 ### 8.3 Keyboard shortcut wiring (`src/app/main.ts`)
 
-Three sites at `main.ts:548-559`, `main.ts:608`, `main.ts:632-643`. Extend the existing predicates by treating the inbox as another panel-bearing session type:
+Keyboard shortcuts target the active side-panel workspace tab, regardless of
+kind. There is no inbox-specific fullscreen eligibility branch.
 
-```ts
-// Before
-const canFullscreen = !state.assistantType && (state.isPreviewSession || state.reviewPanelOpen);
-const hasPanel = canFullscreen || (!state.assistantType && state.activeProposals.goal != null);
+- collapse: `fullscreen -> split -> collapsed`;
+- expand: `collapsed -> split -> fullscreen`;
+- fullscreen toggle: non-fullscreen -> `fullscreen`, fullscreen -> `collapsed`.
 
-// After
-const isInboxSession = !!state.activeSession?.staffId;
-const canFullscreen = !state.assistantType && (state.isPreviewSession || state.reviewPanelOpen || isInboxSession);
-const hasPanel = canFullscreen || (!state.assistantType && state.activeProposals.goal != null);
-```
-
-`Ctrl+]` collapses one level; `Ctrl+[` expands one level; per-session collapse state is stored under the existing `bobbit-preview-collapsed-${activeSessionId()}` key (the panels are mutually exclusive on a given session — a session is either preview-bearing, review-bearing, or inbox-bearing).
+Handlers call the shared side-panel workspace resize API so the resulting
+`sizeMode` persists on the server and broadcasts to other browser contexts.
 
 ### 8.4 Manual-enqueue dialog
 
@@ -538,7 +557,7 @@ Submits `POST /api/staff/:id/inbox` with `{ title, prompt, source: { type: "manu
 
 ### 8.5 `contextPolicy` radio in staff edit form
 
-Insert into `src/app/staff-page.ts::renderEditView` between the "Pinned Context" textarea (`staff-page.ts:670-678`) and the save bar (`staff-page.ts:680-694`):
+Insert into `src/app/staff-page.ts::renderEditView` between the "Pinned Context" textarea (`staff-page.ts`) and the save bar (`staff-page.ts`):
 
 ```html
 <div>
@@ -553,7 +572,7 @@ Insert into `src/app/staff-page.ts::renderEditView` between the "Pinned Context"
 </div>
 ```
 
-`editContextPolicy` is added to the page-local state (`staff-page.ts:22-39`) and threaded through `handleSave` (which `PUT`s to `/api/staff/:id`). Add `contextPolicy` to the body accepted by `server.ts:8107-8121` and the `StaffStore.update` `Partial` type.
+`editContextPolicy` is added to the page-local state (`staff-page.ts`) and threaded through `handleSave` (which `PUT`s to `/api/staff/:id`). Add `contextPolicy` to the body accepted by `server.ts` and the `StaffStore.update` `Partial` type.
 
 ### 8.6 Sidebar — explicit non-change
 
@@ -564,9 +583,9 @@ No sidebar badge. No pending-count affordance anywhere. The staff session contin
 There is no top-level `userstories/review-pane.md` in the repo (verified). The closest references are:
 - `src/ui/components/review/ReviewPane.ts` — the `<review-pane>` LitElement.
 - `src/ui/components/review/review-pane.css` — collapsible split-pane layout.
-- `src/app/remote-agent.ts:1763-1792` — the agent → WS → panel-open flow used by `review_open`.
+- `src/app/remote-agent.ts` — the agent → WS → panel-open flow used by `review_open`.
 
-The inbox panel is structurally identical: tabbed/sectioned LitElement, collapsible split, per-session open/closed state in localStorage, reload-persistent because state is rehydrated from REST on session select.
+The inbox panel is structurally similar at the content level: a tabbed/sectioned LitElement with Pending and History sections. Its open/closed state is no longer localStorage-backed; the `inbox` tab lives in the server-side side-panel workspace, while REST/WS restore only the entry content.
 
 ---
 
@@ -574,7 +593,7 @@ The inbox panel is structurally identical: tabbed/sectioned LitElement, collapsi
 
 `staffManager.wake()` is **deleted**, not deprecated. Three in-tree call sites must be migrated:
 
-### 9.1 `src/server/agent/staff-trigger-engine.ts:227`
+### 9.1 `src/server/agent/staff-trigger-engine.ts`
 
 **Before**
 
@@ -612,11 +631,11 @@ private fireTrigger(staff: PersistedStaff, trigger: StaffTrigger, extraContext?:
 }
 ```
 
-Also drop `wakingInProgress` (the field at `staff-trigger-engine.ts:104`) and the streaming/starting skip at `staff-trigger-engine.ts:130-133` — both exist solely because `wake()` was racey. `inboxManager.enqueue()` is synchronous against the JSON file and always safe.
+Also drop `wakingInProgress` (the field at `staff-trigger-engine.ts`) and the streaming/starting skip at `staff-trigger-engine.ts` — both exist solely because `wake()` was racey. `inboxManager.enqueue()` is synchronous against the JSON file and always safe.
 
 Constructor signature gains `inboxManager: InboxManager` (passed from `server.ts` boot).
 
-### 9.2 `src/server/server.ts:8131-8145`
+### 9.2 `src/server/server.ts`
 
 **Before**
 
@@ -640,7 +659,7 @@ if (staffWakeMatch && req.method === "POST") {
 
 The whole block is **deleted**. The new `POST /api/staff/:id/inbox` route from §7 supersedes it. UI's "Wake Now" button switches to that endpoint (§7.2).
 
-### 9.3 `src/server/agent/staff-manager.ts:426-430`
+### 9.3 `src/server/agent/staff-manager.ts`
 
 **Before** (inside `wake()`, legacy-migration branch):
 
@@ -668,7 +687,7 @@ async ensureSessionForStaff(staffId: string, sessionManager: SessionManager): Pr
   const { store, staff } = found;
 
   if (!staff.currentSessionId) {
-    // ... existing legacy-migration createSession block from staff-manager.ts:391-417 ...
+    // ... existing legacy-migration createSession block from staff-manager.ts ...
     return session.id;
   }
 
@@ -687,11 +706,11 @@ async ensureSessionForStaff(staffId: string, sessionManager: SessionManager): Pr
 
 `InboxNudger.tickOne` calls `ensureSessionForStaff` *only when it has decided to nudge*, ensuring the subprocess is alive before `applyPolicyThenNudge`. Trigger-engine enqueues without touching session state at all — entries accumulate against a dead session and the nudger picks them up after recovery.
 
-`StaffManager.refreshWorktree` (`staff-manager.ts:283-340`) moves into `ensureSessionForStaff` as the rebase step (preserve its current call-before-wake semantics).
+`StaffManager.refreshWorktree` (`staff-manager.ts`) moves into `ensureSessionForStaff` as the rebase step (preserve its current call-before-wake semantics).
 
 `createStaff` keeps `currentSessionId` initialisation as-is; no change.
 
-The `lastWakeAt` update at `staff-manager.ts:413, 456` moves to `InboxNudger.applyPolicyThenNudge` (set right before the `enqueuePrompt` call).
+The `lastWakeAt` update in `staff-manager.ts` moves to `InboxNudger.applyPolicyThenNudge` (set right before the `enqueuePrompt` call).
 
 ### 9.4 Confirmed deletions
 
@@ -709,7 +728,7 @@ Restated from the goal spec for the implementer's convenience:
 
 - **`contextPolicy: "clear"`** — terminate + respawn subprocess with fresh jsonl. Deferred; the enum is forward-compatible.
 - **Coalescing / dedup** of pending entries. Every enqueue produces a new entry. Agent dedupes via `inbox_list`.
-- **Memory-editing tool for staff.** Memory remains editable only via the UI (`staff-page.ts:672-678`).
+- **Memory-editing tool for staff.** Memory remains editable only via the UI (`staff-page.ts`).
 - **Auto-cancel / "stuck entry" surfacing.** Pending is pending. Only the agent or the user resolves entries.
 - **Exponential backoff for re-nudges.** Add later if observed spamming.
 - **Search index ingestion of completed inbox entries.** Entries are addressable via REST but not in the cross-project search.
@@ -721,12 +740,12 @@ Restated from the goal spec for the implementer's convenience:
 | # | Question | Working answer |
 |---|---|---|
 | 1 | Does `runCompact` block too long? `session.rpcClient.compact(120_000)` can take seconds-to-minutes. | Awaiting it serially is correct — the digest message must be delivered *into* a freshly-compacted context. The 15 s tick is non-overlapping per-staff via `nudgePending`. If a compact stalls past 120 s the RPC rejects and the catch in `applyPolicyThenNudge` clears `nudgePending` for retry on next tick. |
-| 2 | What if the staff session is `"starting"` (not `"idle"`)? | The nudger only fires on `status === "idle"` (matches `team-manager.ts:388`). `"starting"` returns false and the nudger retries next tick. No drop — entries remain pending. |
+| 2 | What if the staff session is `"starting"` (not `"idle"`)? | The nudger only fires on `status === "idle"` (matches `team-manager.ts`). `"starting"` returns false and the nudger retries next tick. No drop — entries remain pending. |
 | 3 | What if an inbox entry references a deleted staff? | `StaffManager.deleteStaff` calls `inboxManager.removeAll(staffId)` (via the WS-broadcast wrapper). No dangling files. If somehow an entry survives (manual file edit), `InboxNudger.tickOne` returns early via the `staffManager.getStaff()` null check; tools 404 the entry. |
 | 4 | Concurrent enqueue from trigger + manual UI on the same idle staff? | Both append distinct entries (no coalescing). Both call `nudger.poke()`. The poke microtask is idempotent — one tick processes the batch (count = 2) with one digest. |
 | 5 | Does `poke` race the 15 s `setInterval`? | The `queueMicrotask`-scheduled `tickOne(staffId)` and the periodic `tick()` both consult `nudgePending` first. Worst case: one redundant call, gated to a no-op by the `nudgePending.get(...)` check. |
 | 6 | What happens during server restart with a streaming staff session? | Restart restores sessions to `idle` (assuming graceful) and `inboxStore.load()` reads pending entries off disk. First tick after boot nudges. |
-| 7 | Sandboxed staff — does compact work? | Yes; compact is an RPC over the bridge, not a host-side filesystem op. Sidecar entries land at `<projectStateDir>/compaction-sidecar/<sessionId>.jsonl` regardless of sandbox (per `compaction-sidecar.ts:11-13`). |
+| 7 | Sandboxed staff — does compact work? | Yes; compact is an RPC over the bridge, not a host-side filesystem op. Sidecar entries land at `<projectStateDir>/compaction-sidecar/<sessionId>.jsonl` regardless of sandbox (per `compaction-sidecar.ts`). |
 
 ---
 
@@ -753,7 +772,7 @@ Cross-references the goal spec's step 9.
 | `tests/inbox-manager.spec.ts` | unit | `enqueue` emits `inbox.entry.added` and calls `nudger.poke(staffId)` exactly once. `transitionToCompleted` rejects non-pending. `transitionToTerminal` rejects unknown id with 404 semantics. `remove` emits `inbox.entry.removed`. Reject unknown staff id. |
 | `tests/inbox-nudger.spec.ts` | unit (fake clock via `node:test` `mock.timers`) | Idle staff + pending → wake exactly once until `agent_start` clears `nudgePending`. Streaming staff → no wake. Starting staff → no wake. `contextPolicy="compact"` calls `session.rpcClient.compact(120_000)` before `enqueuePrompt`. `contextPolicy="preserve"` skips compact. `poke()` fast-paths a wake within one microtask. Empty inbox → no wake. |
 | `tests/e2e/inbox-api.spec.ts` | API E2E (in-process gateway) | `POST /api/staff/:id/inbox` returns 201 with pending entry. `GET /api/staff/:id/inbox?state=pending` lists it. `GET ?state=completed` excludes it. `POST /api/staff/:id/inbox/:entryId/complete` (with valid `sessionId.staffId === :id`) transitions state. `…/dismiss` with `outcome="failed"` and `reason` transitions. `DELETE /api/staff/:id/inbox/:entryId` prunes. 403 on `sessionId` whose `staffId` doesn't match. 404 on unknown staff/entry. 409 on non-pending entry transition. |
-| `tests/e2e/ui/staff-inbox.spec.ts` | Browser E2E (spawned gateway) | Open app → navigate to a staff session (created via REST in the `beforeAll`) → inbox panel visible → "+ Add to inbox" opens dialog → submit → entry appears in Pending section → reload page → entry still there (persistence) → click Cancel on entry → entry moves to History section (state=cancelled) → click delete in history → entry removed. Toggle Ctrl+] to collapse the panel; reload; assert collapsed state is restored from localStorage. Required by AGENTS.md ("every user-facing feature MUST have a browser E2E"). |
+| `tests/e2e/ui/staff-inbox.spec.ts` | Browser E2E (spawned gateway) | Open app → navigate to a staff session (created via REST in the `beforeAll`) → explicitly open the `inbox` workspace tab → "+ Add to inbox" opens dialog → submit → entry appears in Pending section → reload page → entry still there (content persistence) and the tab/size state matches the server workspace → click Cancel on entry → entry moves to History section (state=cancelled) → click delete in history → entry removed. Close the `inbox` tab, reload, and assert it stays closed until explicitly reopened. Required by AGENTS.md ("every user-facing feature MUST have a browser E2E"). |
 | `tests/tool-description-budget.test.ts` | unit (existing — extended) | Add `"inbox"` to `EXTENSION_FILES`. Existing assertions automatically enforce the 150-char / 80-char budgets on the three new tools. |
 | `tests/staff-trigger-engine.test.ts` | unit (existing — updated) | Replace `wake()` assertions with `inboxManager.enqueue()` assertions. Confirm the streaming/starting skip is gone (trigger always enqueues regardless of session state). |
 
@@ -783,11 +802,11 @@ Run order:
 | `defaults/tools/inbox/inbox_complete.yaml` | NEW | Tool manifest. |
 | `defaults/tools/inbox/inbox_dismiss.yaml` | NEW | Tool manifest. |
 | `defaults/tools/inbox/extension.ts` | NEW | Tool runtime + REST plumbing. Gates on `BOBBIT_STAFF_ID`. |
-| `src/app/state.ts` | EDIT | `inboxEntries`, `inboxPanelOpen`, `inboxAddDialogOpen`. |
-| `src/app/inbox-panel.ts` | NEW | Subscription lifecycle, REST bootstrap, WS event → state diff. |
-| `src/app/main.ts` | EDIT | Extend `canFullscreen` / `hasPanel` to include inbox sessions. |
+| `src/app/state.ts` | EDIT | `inboxEntries`, `inboxAddDialogOpen`; workspace tab state lives in `sidePanelWorkspace`. |
+| `src/app/inbox-panel.ts` | NEW | Subscription lifecycle, REST bootstrap, WS event → state diff, and explicit `inbox` workspace open/focus. |
+| `src/app/main.ts` | EDIT | Use shared side-panel workspace shortcut helpers; no inbox-specific fullscreen gate. |
 | `src/app/remote-agent.ts` | EDIT | Handle `inbox.entry.*` WS events. |
-| `src/app/render.ts` | EDIT | Mount `<inbox-panel>` for staff sessions. |
+| `src/app/render.ts` | EDIT | Mount `<inbox-panel>` when the server workspace contains the `inbox` tab. |
 | `src/app/session-manager.ts` | EDIT | Start/stop inbox subscription on session select. |
 | `src/app/staff-page.ts` | EDIT | `contextPolicy` radio + thread through `handleSave`. Rewire "Wake Now" to `/inbox` POST. |
 | `src/app/api.ts` | EDIT | Replace `wakeStaffAgent` with inbox enqueue helpers. |

--- a/docs/design/walkthrough-panel-resize-fix.md
+++ b/docs/design/walkthrough-panel-resize-fix.md
@@ -1,119 +1,53 @@
-# PR Walkthrough panel-resize controls — design
+# PR Walkthrough panel-resize controls — historical design note
 
-Status: implemented.
-Scope: make the in-app PR walkthrough side panel use the **same** resize logic
-as the HTML preview panel (no walkthrough-specific special-casing), and remove
-the panel-level resize chrome from the standalone `/walkthrough` pop-out route.
+> **Superseded by the unified side-panel workspace.** PR walkthrough is now a
+> normal `pack` side-panel tab, and every side-panel tab uses
+> `sidePanelWorkspace.sizeMode` (`split`, `fullscreen`, `collapsed`) plus the
+> shared side-panel shell. There is no walkthrough-specific resize state and no
+> preview-specific fullscreen/collapse state in the current contract. See
+> [Side-panel workspace](../side-panel-workspace.md) and
+> [PR walkthrough pack deletion](./pr-walkthrough-pack-deletion.md).
 
-## Guiding principle
+## Current contract
 
-**The in-app walkthrough panel must use the SAME resize logic as the HTML
-preview panel.** It renders the same unified toolbar (fullscreen / collapse),
-honors `state.previewPanelFullscreen` and the per-session collapse key
-identically, and **never auto-enters fullscreen** — fullscreen is only ever
-entered by an explicit user action (toolbar button or keyboard shortcut).
+The PR walkthrough panel gets fullscreen, split, collapse, restore, keyboard
+shortcuts, and popout behavior because it is a normal pack panel in the shared
+side-panel workspace:
 
-Why this matters: the dead controls were never a missing-feature problem. The
-shared preview-panel plumbing already rendered the toolbar and bound the
-keyboard shortcuts for walkthrough tabs. The controls were inert only because a
-layer of walkthrough-specific logic kept overriding the shared state. Deleting
-that layer — rather than adding parallel walkthrough resize code — is what makes
-the panel behave like the preview panel, and it keeps a single resize code path
-instead of two that can drift.
+- tab id shape: `pack:<packId>:<panelId>:<instanceKey>`;
+- singleton instance key for the PR walkthrough panel;
+- active tab, order, and size mode persisted on the session's server-backed
+  `sidePanelWorkspace`;
+- shared controls rendered by the generic side-panel shell;
+- no PR-walkthrough-only fullscreen, auto-fullscreen, collapse, or resize path.
 
-## Background — the wrong first attempt (PR #677)
+The standalone/deep-link surface renders the existing server workspace tab. It
+must not reconstruct a pack panel from arbitrary route parameters or grant a
+wider Host API scope than the session-backed tab already has.
 
-PR #677 assumed the dead controls lived on the standalone `/walkthrough` pop-out
-route and "fixed" it by *adding* a panel-level control bar there (fullscreen /
-collapse / expand) plus a route-aware `workspaceSessionId()`. That was wrong on
-two counts:
+## Historical context
 
-1. **Wrong surface.** The user's dead controls were in the **in-app side panel**
-   (a walkthrough opened inside a connected session, split with chat), on a
-   **ready/finished** walkthrough — a surface #677 never touched.
-2. **The standalone additions are conceptually meaningless.** A popped-out new
-   tab IS the whole browser window — there is no chat pane beside it — so
-   "fullscreen", "collapse", and "expand" do nothing useful there.
+This design note originally fixed dead resize controls by deleting
+walkthrough-specific logic that overrode the then-shared preview-panel resize
+state. That reasoning still matters: **delete special-casing instead of adding a
+parallel PR walkthrough resize path**.
 
-## Root cause (in-app)
+The old implementation details are no longer current:
 
-The in-app unified toolbar already *rendered* the fullscreen/collapse buttons
-for walkthrough tabs. The controls were dead purely because of
-walkthrough-specific logic layered on top of the shared preview-panel plumbing:
+- preview-specific fullscreen state was replaced by `sidePanelWorkspace.sizeMode`;
+- preview-era per-session collapse keys are migration input only;
+- the bespoke `walkthrough:<changeset-id>` tab kind and standalone
+  `/walkthrough?...` route were removed;
+- PR walkthrough now ships through the first-party pack route and opens a pack
+  panel through `host.ui.openPanel`.
 
-1. **`suppressFullscreenForLiveWalkthrough`** (`render.ts`) force-reset
-   `state.previewPanelFullscreen = false` on every render for any walkthrough
-   whose host session was alive — so the fullscreen button bounced straight back
-   and looked dead.
-2. **`isLiveSessionHostedWalkthroughActive`** (`render.ts`) was the predicate
-   driving that suppression.
-3. **`fullscreenOnReady`** auto-fullscreen plumbing
-   (`render.ts` + `pr-walkthrough.ts`) made the panel jump to fullscreen on its
-   own when a walkthrough became ready — the opposite of "user-initiated".
+## Tests to keep current
 
-## The fix — remove the special-casing
+Coverage should assert the shared workspace behavior, not a walkthrough-only
+path:
 
-### `src/app/render.ts`
-- Removed `isLiveSessionHostedWalkthroughActive()` and
-  `suppressFullscreenForLiveWalkthrough`. The fullscreen render branch now uses
-  the same condition as the preview panel:
-  `desktop && state.previewPanelFullscreen && (fullscreenTab?.kind === "preview" || fullscreenTab?.kind === "walkthrough")`.
-- Removed the auto-fullscreen-on-ready block in `walkthroughPanelContent`.
-- `standaloneWalkthroughPanel()` no longer renders any panel-level
-  fullscreen/collapse/expand chrome and no longer reads
-  `previewPanelFullscreen` / the collapse flag. It just renders
-  `walkthroughPanelContent(tab)` filling the window. The tab-resolution /
-  restore logic (and the component's own internal rail toggle) are unchanged.
-- `workspaceSessionId()` keeps its `route.view === "walkthrough"` branch — it is
-  still needed so `walkthroughPanelContent`'s lazy payload restore keys off the
-  route's walkthrough session id on the standalone route (where
-  `activeSessionId()` is `undefined`).
-
-### `src/app/pr-walkthrough.ts`
-- Removed all `fullscreenOnReady` plumbing (the option, the per-tab state field,
-  and the `previewPanelFullscreen = true` writes) from
-  `upsertPrWalkthroughJobPanel`, `launchPrWalkthroughAgent`, and
-  `restorePrWalkthroughJobForSession`.
-- Removed `keepLiveWalkthroughPanelPromptable`, `isLiveSessionHostedWalkthrough`,
-  and `isStandaloneWalkthroughRoute` — once the special-casing is gone, a ready
-  walkthrough simply selects its tab (`setActivePanelTabIdForSession`) and never
-  forces fullscreen or wipes the collapse key.
-
-### `src/app/main.ts`
-- `hasActiveWalkthroughPanel()` stays (the in-app keyboard shortcuts gate on it),
-  but its standalone-route branch was removed — the standalone route has no
-  panel-level resize controls, so it no longer needs special detection.
-
-## Behaviour matrix
-
-| Surface | Panel-level resize controls |
-|---|---|
-| In-app side panel (split with chat) | Fullscreen + collapse work via the unified toolbar and the keyboard shortcuts (`toggle-sidebar` = Ctrl+[, `toggle-preview` = Ctrl+], `toggle-fullscreen-preview` = Ctrl+#), identical to the HTML preview panel. Starts in split view; fullscreen only on user action; state persists across reload. |
-| Popped-out standalone `/walkthrough` | None — the walkthrough fills the window. The component's internal rail toggle still works. |
-
-### The internal rail toggle is a different control
-
-The walkthrough component's own review-rail collapse/expand button
-(`data-testid="pr-walkthrough-rail-toggle"` / `.rail-toggle`, using
-`PanelLeftClose`/`PanelLeftOpen`, in
-`src/ui/components/pr-walkthrough/PrWalkthroughPanel.ts`) is **not** part of the
-panel-level window chrome. It collapses the review rail *inside* the walkthrough,
-not the window-level panel, so it is present and functional on **both** surfaces.
-This goal only removed the panel-level fullscreen/collapse/expand chrome from the
-standalone route; the rail toggle was never touched.
-
-## Tests
-
-- `tests/e2e/ui/pr-walkthrough-panel.spec.ts`
-  - "in-app ready walkthrough panel resize controls are user-driven" — the
-    reproducing test: no auto-fullscreen on ready, fullscreen/collapse buttons
-    and `Ctrl+]` operate on the panel, state persists across reload.
-  - "fullscreen toolbar control enters fullscreen on live child walkthroughs
-    (user-initiated)" — updated from the old "keeps live child in split"
-    expectation.
-  - "standalone ready walkthrough has no panel-level resize chrome but keeps its
-    internal rail toggle" — inverted from #677's standalone-controls test.
-- `tests/e2e/ui/pr-walkthrough-real.spec.ts` — the live-walkthrough fullscreen
-  click now enters fullscreen (then returns to split for the rest of the flow).
-- `tests/e2e/ui/preview-fullscreen-controls.spec.ts` — unchanged; the HTML
-  preview panel behaviour is not touched.
+- opening the PR walkthrough pack creates/focuses a pack tab;
+- fullscreen, collapse, restore, and split controls work on that tab;
+- keyboard shortcuts mutate the shared workspace size mode;
+- popout/deep-link renders only the already-open server workspace tab;
+- no auto-fullscreen or PR-specific resize state is introduced.

--- a/docs/extension-host-authoring.md
+++ b/docs/extension-host-authoring.md
@@ -515,7 +515,11 @@ entry: ../lib/ArtifactViewerPanel.js   # relative to THIS file; contained in pac
 
 ```js
 // From a renderer's click handler:
-host.ui.openPanel({ panelId: "artifacts.viewer", params: { artifactId } });
+host.ui.openPanel({
+  panelId: "artifacts.viewer",
+  params: { artifactId },
+  instanceKey: artifactId, // contract v3; preserves one tab per artifact
+});
 ```
 
 The panel module's factory is handed the host toolkit **plus a `host`** bound to the active
@@ -524,11 +528,31 @@ So a panel can call `host.store.*`, `host.callRoute`, and `host.session.*` — e
 renderer can except `invokeAction` (which is tool-call-scoped).
 
 **Addressing.** Panel ids are only **pack-unique**, so the client keys its registry and the
-serving URL by `{packId, panelId}`. The bytes are served bearer-only (static-asset-equivalent)
+serving URL by `{packId, panelId}`. Side-panel tab identity is the compound key
+`{packId, panelId, instanceKey}` so singleton tools and parameterized content viewers can coexist
+in the same server-backed workspace. The bytes are served bearer-only (static-asset-equivalent)
 by the **pack-addressed** `GET /api/ext/packs/:packId/panels/:panelId`. The client reconciles
 panels from `GET /api/ext/contributions` (pack-scoped), not `/api/tools`.
 `host.ui.openPanel({ panelId })` stays **pack-relative** — the caller surface's bound `packId`
 resolves `panelId` → `{packId, panelId}` before fetching bytes.
+
+Panel YAML can declare durable instance behavior:
+
+```yaml
+id: artifacts.viewer
+title: Artifact
+entry: ../lib/ArtifactViewerPanel.js
+instanceMode: parameterized
+instanceParam: artifactId
+```
+
+- `instanceMode: singleton` (or omitted) uses `instanceKey = "default"`.
+- `instanceMode: parameterized` requires a safe `instanceKey` or a string `params[instanceParam]`.
+- If `instanceParam` is omitted, the host may derive from allowlisted params such as `artifactId`; it never hashes arbitrary params silently.
+- Parameterized panels without a safe key are not opened, because they would not have durable tab identity.
+
+The workspace validates pack panel ids and instance metadata server-side. A popout/deep link renders
+only an already-open server workspace tab; it does not let a URL invent arbitrary pack params.
 
 **Open a panel in a chosen session's view (`PanelTarget.sessionId`, contract v2).** By default
 `openPanel` mounts/focuses the tab in the **currently-active** session. A pack that has just
@@ -562,7 +586,10 @@ This addition bumped **`HOST_CONTRACT_VERSION` 1 → 2** (the data/addressing-co
 `HOST_API_VERSION` stays `1` because no method signature changed). Adding an optional field is
 additive, but the version bump lets a pack **feature-detect field support** via
 `host.contractVersion >= 2` and degrade gracefully (open in the active view) on an older host.
-No new capability flag is added — `openPanel` already lives under the `ui` capability.
+Contract v3 later added optional `PanelTarget.instanceKey` for durable parameterized side-panel
+identity; packs can feature-detect it with `host.contractVersion >= 3` and otherwise rely on
+host-derived identity from declared/allowlisted params. No new capability flag was added for
+either field — `openPanel` already lives under the `ui` capability.
 This capability was added so the PR-walkthrough pack could open its pane in a freshly
 spawned reviewer-child session; see
 [docs/design/pr-walkthrough-launch-ux.md](design/pr-walkthrough-launch-ux.md) for the
@@ -574,7 +601,8 @@ for how the pack consumes it.
 > in v2. The launch-UX correction added an optional `title` to the **server-side**
 > `host.agents.spawn` surface (so the spawned child gets a visible session title), which is an
 > additive field on a server capability — **not** part of the frozen versioned `PanelTarget` /
-> `HostApi` data contract — so `HOST_CONTRACT_VERSION` stays at `2`.
+> `HostApi` data contract — so it did not change the host contract. The later v3 bump is only
+> for `PanelTarget.instanceKey`.
 
 **Panel conventions (enforced — identical to renderer rules):** theme tokens only; preserve any
 embedded iframe `sandbox` attribute (untrusted/LLM content goes in a `sandbox`ed iframe);

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -2289,9 +2289,17 @@ Agent process → message_update (full content)
 
 ---
 
+## Server-backed side-panel workspace
+
+Every session persists a `sidePanelWorkspace` record with the open right-panel tabs, active tab, tab order, and size mode. The server is the authority so the same workspace survives refreshes/restarts and converges across browser contexts. Closed tabs are authoritative absence: render/content caches and localStorage must not recreate them. Full behavior, REST routes, popout links, and migration rules live in [docs/side-panel-workspace.md](side-panel-workspace.md).
+
+This invariant matters because many panel kinds have content that can outlive the tab: proposal drafts on disk, review documents with annotations, preview mounts/artifacts, inbox entries, and pack-panel params. Those content caches are reopen sources only when an explicit UI/tool event calls the workspace open API; they are never the render-time source of truth.
+
+---
+
 ## Preview snapshots & reopening
 
-The `preview_open` tool drives one live server mount per session, rendered through the dynamic side-panel workspace. Each new call updates the live preview tab through SSE, and past `preview_open` widgets render an **Open** button that restores a source-derived historical preview tab from an **immutable preview artifact** captured at the original mount time. Reopening an older card therefore shows the bytes that were live then — not whatever happens to be in the source file now. New `preview_open` calls always select the unversioned filename tab; older differing artifacts open a versioned tab (`file.html (vN)`). Full tab semantics live in [docs/design/side-panel-tab-contract.md](design/side-panel-tab-contract.md).
+The `preview_open` tool drives one live server mount per session, rendered through the server-backed side-panel workspace. Explicit preview open events select or update the live preview tab, and past `preview_open` widgets render an **Open** button that restores a source-derived historical preview tab from an **immutable preview artifact** captured at the original mount time. Reopening an older card therefore shows the bytes that were live then — not whatever happens to be in the source file now. New `preview_open` calls always select the unversioned filename tab; older differing artifacts open a versioned tab (`file.html (vN)`). Full workspace semantics live in [docs/side-panel-workspace.md](side-panel-workspace.md).
 
 ### Why
 
@@ -2341,7 +2349,7 @@ explicit `sweepOrphanArtifacts(knownIds)` maintenance helper.
 
 ### Key design decisions
 
-- **Dynamic side-panel workspace** - regular and assistant sessions share the same tab model for chat, previews, proposals, reviews, and inbox. The live preview tab tracks SSE updates; historical `preview_open` cards create/select distinct preview tabs while still rendering through the one live server mount per session.
+- **Server-backed side-panel workspace** - regular and assistant sessions share the same durable tab model for previews, proposals, reviews, inbox, and pack panels. Chat stays outside the tab strip. The live preview tab tracks explicit preview open/update events; bootstrap/SSE metadata patches only already-open tabs so closed tabs do not resurrect.
 - **Constant-size snapshots (≤ 250 bytes)** - tool_result holds only `{kind:"preview", url, path}` wrapped in the v3 marker, so iteration cost is independent of HTML size. The `path` field is the host-invariant `<sessionId>/<entry>` form (forward slashes on all OSes) rather than the host-absolute path — keeping block size bounded by content shape, not install location. The agent can refresh a 5000-line report 50 times without the bytes ever entering its context.
 - **Bytes never re-enter agent context** - the content origin serves files from `<stateDir>/preview/<sid>/` on disk; tool_result holds only the URL/path. This is the structural fix to the v1 token-bloat problem.
 - **v1/v2 markers preserved in renderer-only code paths** - archived sessions still parse and reopen via the same mount endpoint (with `{html}` or `{file}` payloads recovered from the legacy block). New code emits only v3.
@@ -2362,8 +2370,11 @@ explicit `sweepOrphanArtifacts(knownIds)` maintenance helper.
 | `defaults/tools/html/extension.ts` | Tool extension emits `[status, v3-snapshot]` tool_result after PATCH + POST mount |
 | `src/server/agent/truncate-large-content.ts` | Recognises v1/v2/v3 markers (via `PREVIEW_SNAPSHOT_MARKERS`); v3 blocks always small so lazy-load only fires on legacy archived sessions |
 | `src/ui/tools/renderers/PreviewRenderer.ts` | Open button dispatch; creates/selects source-derived preview tabs; remounts v1/v2 and restorable v3 inline/file snapshots |
-| `src/app/panel-workspace.ts` | Per-session tab IDs/source metadata for chat, preview, proposal, review, and inbox tabs |
-| `src/app/preview-panel.ts` | EventSource SSE subscription, bootstrap GET, and workspace tab selection helpers |
+| `src/shared/side-panel-workspace.ts` | Shared server/client workspace types (`preview`, `proposal`, `review`, `inbox`, `pack`) |
+| `src/server/side-panel-workspace*.ts` | Server canonicalization, validation, revisioned mutations, persistence, and WS broadcast |
+| `src/app/side-panel-workspace.ts` | Client hydrate/mutate controller, in-memory optimistic state, popout URL helper, localStorage migration |
+| `src/app/panel-workspace.ts` | Tab id helpers and preview version ledger; legacy localStorage only for migration/file fixtures |
+| `src/app/preview-panel.ts` | EventSource SSE subscription, bootstrap GET, explicit preview tab open/update helpers |
 | `src/app/render.ts` | Shared side-panel dispatcher, desktop tab strip, mobile tab bar/slider |
 | `tests/preview-{mount,cookie,content-route,extension,renderer}*`, `tests/e2e/preview-{mount-route,token-cost}.spec.ts`, `tests/e2e/ui/preview-{happy-path,new-tab,archived-snapshot}.spec.ts` | Unit, API E2E, browser E2E coverage |
 

--- a/docs/pr-walkthrough-panel.md
+++ b/docs/pr-walkthrough-panel.md
@@ -464,9 +464,10 @@ and the user-terminate control are pinned in the API spec
 `tests/e2e/pr-walkthrough-host-agents.spec.ts` (whose mock agent cannot resolve a
 real PR through a click, so the spawn/lifecycle assertions live there, not in the
 browser spec).
-HTML-preview-panel sizing is independently pinned by
-`tests/e2e/ui/preview-fullscreen-controls.spec.ts` (the panel-sizing logic does
-not touch the preview panel). See
+Preview panel sizing through the shared side-panel controls is independently pinned by
+`tests/e2e/ui/preview-fullscreen-controls.spec.ts` (preview is one workspace
+panel kind using the same sizing logic as pack, proposal, review, and inbox
+panels). See
 [design/walkthrough-panel-resize-fix.md](design/walkthrough-panel-resize-fix.md)
 for the root-cause analysis and the corrected design.
 

--- a/docs/pr-walkthrough-panel.md
+++ b/docs/pr-walkthrough-panel.md
@@ -418,14 +418,14 @@ reaps it automatically.
 
 ## Panel sizing: fullscreen, collapse, and shortcuts
 
-The pack panel opened at `#/ext/pr-walkthrough` uses the **same** resize logic as
-the HTML preview panel — there is no walkthrough-specific resize code path. It
-renders the shared unified toolbar with a fullscreen (wide review) button and a
-collapse button, and it honors `state.previewPanelFullscreen` plus the per-session
-collapse key (`bobbit-preview-collapsed-<id>`) identically to the preview panel.
-The same keyboard shortcuts drive it: `toggle-sidebar` (Ctrl+[, expand one level),
-`toggle-preview` (Ctrl+], collapse one level), and `toggle-fullscreen-preview`
-(Ctrl+#, jump to fullscreen or collapsed). State persists across reload.
+The PR walkthrough is a normal `pack` tab in the server-backed side-panel
+workspace. It uses the same shared controls as every side panel: fullscreen,
+collapse/restore, split view, and popout. There is no walkthrough-specific resize
+code path, and no preview-specific localStorage collapse key; size mode persists
+as `sidePanelWorkspace.sizeMode` on the reviewer session and syncs across reloads
+and browser contexts. The shared keyboard shortcuts expand one level
+(`collapsed → split → fullscreen`), collapse one level (`fullscreen → split → collapsed`),
+and toggle fullscreen/collapsed.
 
 The panel **never auto-enters fullscreen**. Fullscreen is strictly user-initiated,
 via a toolbar button or one of those shortcuts. This matches the preview panel and

--- a/docs/preview-architecture.md
+++ b/docs/preview-architecture.md
@@ -39,17 +39,21 @@ Old paths and concepts that are gone:
 
 ## Side-panel workspace integration
 
-The UI treats the side pane as a Chrome-style tab strip beside the chat
-(never above it). The shared strip can hold HTML preview, proposal,
-review, PR walkthrough, and inbox tabs at the same time. Chat is **not**
-a tab — there is no `chat` side-pane id, no Chat pill in the strip, and
-the side pane hides entirely when a non-staff session has no side-pane
-tabs. The full rules — id grammar, focus and ordering, drag reorder,
-pinned inbox, walkthrough tab identity, immutable artifact restore,
-per-filename version assignment — live in
-[`design/side-panel-tab-contract.md`](./design/side-panel-tab-contract.md).
+The UI treats the side pane as a server-backed Chrome-style tab strip beside the
+chat (never above it). The shared strip can hold HTML preview, proposal, review,
+pack/PR-walkthrough, artifact-viewer, and inbox tabs at the same time. Chat is
+**not** a tab — there is no `chat` side-pane id, no Chat pill in the strip, and
+the side pane hides entirely when a non-staff session has no side-pane tabs.
 
-Preview tab identity in that contract:
+The side-panel workspace is authoritative for whether a preview tab is open. A
+preview mount, immutable artifact, bootstrap response, or SSE event may update
+content caches, but it must not resurrect a closed tab. Explicit preview tool
+mount/open events and historical preview-card Open buttons create or focus tabs;
+bootstrap and SSE updates patch only already-open tabs when they are not an
+explicit open. Full workspace rules live in
+[`side-panel-workspace.md`](./side-panel-workspace.md).
+
+Preview tab identity:
 
 - The **current** preview tab for a filename is
   `preview:entry:<encoded-filename>`. Label is unversioned (e.g.
@@ -598,9 +602,11 @@ back the preview tree sees the same bytes the gateway just wrote.
 | `defaults/tools/html/snapshot.ts` | Marker constants, `buildPreviewSnapshotV3Block`, `parseSnapshot`, 250-byte v3 cap |
 | `src/server/preview/artifacts.ts` | Immutable artifact store — capture, restore, hash-based dedupe, orphan sweep |
 | `src/ui/tools/renderers/PreviewRenderer.ts` | Open button on tool cards; artifact restore → source remount → recorded-entry fallback; live-hash remount skip; filename-keyed tab dispatch |
-| `src/app/panel-workspace.ts` | Side-pane tab id grammar (`preview:entry:<file>[:v:N]`, `proposal:<type>[:rev:N]`, `review:<title>`, `inbox`), per-filename version ledger, pinned-first ordering, drag reorder, persistence |
-| `src/app/preview-panel.ts` | EventSource subscription, mount bootstrap, current-vs-historical upsert, older-version-rehydration guard |
-| `src/app/render.ts` | Side-pane tab strip rendering (Chrome-style with radial-gradient corner pseudos), mobile pane bar with pinned Chat pill, SortableJS drag integration with X-axis lock, active-content lookup by id only, artifact-id derived from active tab so iframe src never desyncs from state.previewPanelEntry |
+| `src/shared/side-panel-workspace.ts` | Server/client workspace model shared by preview and other panel kinds |
+| `src/app/side-panel-workspace.ts` | Server hydrate/mutate controller, optimistic in-memory updates, localStorage migration, popout URL helper |
+| `src/app/panel-workspace.ts` | Preview/proposal/review/pack tab id helpers and per-filename preview version ledger; file-fixture fallback only |
+| `src/app/preview-panel.ts` | EventSource subscription, mount bootstrap, explicit preview tab open/update, older-version-rehydration guard |
+| `src/app/render.ts` | Shared side-panel shell, tab strip, mobile slider, shared controls, active-content lookup by server workspace tab id |
 
 ## Acceptance properties
 
@@ -622,11 +628,11 @@ back the preview tree sees the same bytes the gateway just wrote.
 - "Open in new tab" works because the cookie has `Path=/`.
 - Edits to the mount fan out via SSE within ~50 ms (debounce window in
   `watchMount`).
-- The side-pane tab strip never contains a Chat pill; chat is rendered
-  outside the strip (see
-  [`design/side-panel-tab-contract.md`](./design/side-panel-tab-contract.md)).
-- The current preview tab for a filename is updated in place by new
-  `preview_open` calls and SSE — no duplicate, no reorder.
+- The side-pane tab strip never contains a Chat pill; chat is rendered outside
+  the strip (see [`side-panel-workspace.md`](./side-panel-workspace.md)).
+- The current preview tab for a filename is updated in place by explicit
+  preview open events; bootstrap/SSE metadata updates patch only already-open
+  tabs and do not resurrect closed tabs.
 - Opening a historical v3 card whose `contentHash` matches the current
   filename tab collapses to that tab and skips the remount POST; otherwise it
   opens `preview:entry:<file>:v:N` keyed off the per-filename version ledger.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -72,7 +72,7 @@ The side-panel workspace endpoints persist the right-side panel tab set for a se
 | Method | Path | Description |
 |---|---|---|
 | `GET` | `/api/sessions/:id/side-panel-workspace` | Return the canonical workspace, creating an empty default (`tabs: []`, `activeTabId: ""`, `sizeMode: "split"`, `revision: 0`) if none was persisted. |
-| `POST` | `/api/sessions/:id/side-panel-workspace/open` | Validate and upsert a tab by id. Body `{ tab, focus?, placeAfterActive?, baseRevision?, strictRevision? }`. Opening an already-open id updates/focuses that tab instead of duplicating it. |
+| `POST` | `/api/sessions/:id/side-panel-workspace/open` | Validate and upsert a tab by id. Body `{ tab, focus?, placeAfterActive?, baseRevision?, baseActiveTabId?, strictRevision? }`. Opening an already-open id updates/focuses that tab instead of duplicating it. When an open request is rebased over a newer workspace revision, `baseActiveTabId` lets the server detect that another device changed the active tab and open/update without stealing focus. |
 | `PATCH` | `/api/sessions/:id/side-panel-workspace/tabs/:tabId` | Patch an already-open tab. Body may be `{ patch }` or direct `title` / `label` / `source` / `state` fields. Returns `404 TAB_NOT_FOUND` for a closed/missing tab; this route never creates tabs. |
 | `DELETE` | `/api/sessions/:id/side-panel-workspace/tabs/:tabId` | Close a tab. Missing tabs are idempotent; underlying preview/proposal/review/pack/inbox content is preserved for explicit reopen. |
 | `POST` | `/api/sessions/:id/side-panel-workspace/active` | Body `{ activeTabId }`. The id must be open, or empty. |

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -65,6 +65,23 @@ These endpoints expose restart support only for gateways launched through `npm r
 | `GET` | `/api/sessions/:id/transcript` | Paginated, regex-filterable transcript reader. Backs the `read_session` tool. Query params: `offset` (negative = from end), `limit` (default 20, clamped 1..200), `pattern`, `case_sensitive`, `context` (±5 max), `verbose`. Same-project authorization via the `x-bobbit-session-id` request header. Errors: `session_not_found` (404), `transcript_unavailable` (404), `invalid_regex` / `invalid_params` (400), `permission_denied` (403). Pure parser lives in `src/server/agent/transcript-reader.ts`. |
 | `GET` | `/api/sessions/:id/transcript/before-compaction` | Paginated read of the orphaned pre-compaction entries for a single compaction event. Query params: `compactionId` (required, sidecar entry id), `cursor` (from previous response's `nextCursor`), `limit` (default 50, clamped 1..200). Response envelope `{ total, returned, nextCursor, messages[] }`. Same-project authorization via the `x-bobbit-session-id` header. Errors: `session_not_found` (404), `transcript_unavailable` (404), `compaction_not_found` (404), `invalid_params` (400), `permission_denied` (403). Branch-split via the sidecar's `firstKeptEntryId`; legacy fallback scans the JSONL for an inline `type:"compaction"` marker. Reader: `readOrphanedBeforeCompaction` in `src/server/agent/transcript-reader.ts`. See [docs/compaction-history.md](compaction-history.md). |
 
+### Side-panel workspace
+
+The side-panel workspace endpoints persist the right-side panel tab set for a session: open tabs, active tab, tab order, and size mode. The server workspace is authoritative; closed tabs are absence and are not re-derived from render/content caches or localStorage. See [Side-panel workspace](side-panel-workspace.md) for the full lifecycle and identity rules.
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/sessions/:id/side-panel-workspace` | Return the canonical workspace, creating an empty default (`tabs: []`, `activeTabId: ""`, `sizeMode: "split"`, `revision: 0`) if none was persisted. |
+| `POST` | `/api/sessions/:id/side-panel-workspace/open` | Validate and upsert a tab by id. Body `{ tab, focus?, placeAfterActive?, baseRevision?, strictRevision? }`. Opening an already-open id updates/focuses that tab instead of duplicating it. |
+| `PATCH` | `/api/sessions/:id/side-panel-workspace/tabs/:tabId` | Patch an already-open tab. Body may be `{ patch }` or direct `title` / `label` / `source` / `state` fields. Returns `404 TAB_NOT_FOUND` for a closed/missing tab; this route never creates tabs. |
+| `DELETE` | `/api/sessions/:id/side-panel-workspace/tabs/:tabId` | Close a tab. Missing tabs are idempotent; underlying preview/proposal/review/pack/inbox content is preserved for explicit reopen. |
+| `POST` | `/api/sessions/:id/side-panel-workspace/active` | Body `{ activeTabId }`. The id must be open, or empty. |
+| `POST` | `/api/sessions/:id/side-panel-workspace/reorder` | Body `{ tabIds, baseRevision }`; `If-Match: <revision>` is also accepted. The request must include each open tab exactly once. Stale revisions return `409` with the latest workspace. |
+| `POST` | `/api/sessions/:id/side-panel-workspace/resize` | Body `{ sizeMode }`, where size mode is `collapsed`, `split`, or `fullscreen`. |
+| `POST` | `/api/sessions/:id/side-panel-workspace/migrate` | One-time import from legacy localStorage keys. Ignored once the workspace has tabs or `metadata.migratedFromLocalStorageAt`. |
+
+Each committed mutation increments `revision`, persists on the session record, and emits `side_panel_workspace` on the session WebSocket.
+
 ### Fork session endpoint
 
 `POST /api/sessions/:id/fork` forks a live source session into a new session that **rehydrates from a clone of the source's conversation history** (the same lossless `.jsonl` clone + `switch_session` mechanism as [Continue-Archived](#continue-archived-endpoint)). It is the contract behind the sidebar **Fork** action, so the server reads the persisted session record instead of trusting the browser to reconstruct context.

--- a/docs/side-panel-workspace.md
+++ b/docs/side-panel-workspace.md
@@ -1,0 +1,196 @@
+# Side-panel workspace
+
+Bobbit's side-panel workspace is the durable, per-session model for everything that opens to the right of chat. It replaces the old preview-specific/localStorage side-pane state with a server-authoritative tab set shared by previews, pack panels, proposals, review documents, and the staff inbox.
+
+The workspace owns only side panels. Chat is not a side-panel tab.
+
+## Core invariant
+
+For each session, the server is the source of truth for:
+
+- ordered open tabs;
+- the active tab id;
+- the workspace size mode: `split`, `fullscreen`, or `collapsed`;
+- tab source metadata needed to rehydrate content;
+- the absence of closed tabs.
+
+A closed tab is authoritative absence. Reload, reconnect, restart, WebSocket replay, render, localStorage, and content caches must not recreate it. A closed proposal tab stays closed even if the proposal draft still exists; a closed review tab stays closed even if its document/annotations are cached; a closed preview tab stays closed even if a mount or artifact still exists.
+
+Tabs can be created or focused only through explicit workspace open/reopen events. The real app render path renders the server workspace it has hydrated; it does not derive tabs from `activeProposals`, review document caches, inbox booleans, preview mount state, or localStorage. File-based browser fixtures keep a local fallback so unit fixtures can run without a gateway, but that fallback is not the product authority.
+
+## Data model and persistence
+
+The shared model lives in `src/shared/side-panel-workspace.ts` and is stored on the persisted session record as `sidePanelWorkspace`.
+
+```ts
+export type SidePanelSizeMode = "collapsed" | "split" | "fullscreen";
+export type SidePanelKind = "preview" | "proposal" | "review" | "inbox" | "pack";
+```
+
+A workspace contains:
+
+- `version: 1`;
+- `sessionId`;
+- monotonic server `revision`;
+- `tabs: SidePanelWorkspaceTab[]`;
+- `activeTabId`;
+- `sizeMode`;
+- optional `metadata.migratedFromLocalStorageAt`;
+- `updatedAt`.
+
+Every committed mutation increments `revision`, persists the whole workspace through `SessionStore.update()`, and broadcasts the committed workspace to viewers of that session.
+
+## Supported panel kinds
+
+| Kind | Tab id shape | Source identity | Notes |
+|---|---|---|---|
+| Preview | `preview:entry:<encoded-entry>` or `preview:entry:<encoded-entry>:v:<N>` | `entry`, `artifactId?`, `contentHash?`, `version?`, `live?`, `historical?` | Live preview tabs update in place. Historical preview tabs represent immutable artifacts or restored older cards. |
+| Pack | `pack:<encoded-packId>:<encoded-panelId>:<encoded-instanceKey>` | `packId`, `panelId`, `instanceKey`, `params?` | Covers PR walkthrough and artifact viewer pack panels. `instanceKey` is part of identity. |
+| Proposal | `proposal:<type>` or `proposal:<type>:rev:<N>` | `proposalType`, `rev?`, `historical?` | Types are `goal`, `project`, `role`, `tool`, and `staff`. Current revisions update the current tab; historical revs open only by explicit reopen. |
+| Review | `review:<encoded-documentId>` | stable `documentId`, display `title` | Title is metadata. Renames do not change identity. Closing the tab preserves content/annotations for explicit reopen. |
+| Inbox | `inbox` | session id and optional `staffId` | Staff inbox opens/focuses through the same workspace APIs as other panels. |
+
+### Preview lifecycle
+
+`preview_open` still writes the per-session preview mount and streams updates via preview SSE. Workspace tab creation is separate:
+
+- explicit preview mount/tool events open or focus the current preview tab;
+- historical card Open buttons explicitly open a versioned preview tab or focus an equivalent current tab when hashes match;
+- `GET /api/preview/mount` bootstrap and `preview-changed` SSE events patch metadata only for already-open tabs when they are not explicitly opening a tab;
+- closing a preview tab removes only the workspace tab, not the mount or immutable artifacts.
+
+This split prevents a browser refresh from resurrecting a preview tab just because a preview mount still exists.
+
+### Proposal and review lifecycle
+
+Proposal events and explicit proposal reopen affordances call the workspace open API. Current proposal tabs are keyed by proposal type (`proposal:goal`, `proposal:project`, etc.); a new current revision updates/focuses the same tab. Historical proposal revisions use `proposal:<type>:rev:<N>` and are created only by explicit historical/reopen UI.
+
+Review tabs are keyed by stable document id, not title. `openMarkdownReviewDocument()` creates or preserves the document id, caches the content, and opens `review:<documentId>`. Restoring cached review documents restores content state only; it does not open tabs unless the server workspace already contains those tabs.
+
+### Pack panel lifecycle
+
+Pack panel identity is `{ packId, panelId, instanceKey }`. This allows singleton panels and parameterized content panels to share the same workspace without overwriting each other.
+
+- Singleton panels use `instanceKey = "default"`.
+- Parameterized panels declare `instanceMode: "parameterized"` and may declare `instanceParam` in their panel YAML.
+- `host.ui.openPanel()` may pass `instanceKey` directly. If omitted, the host derives it from `instanceParam`, then from allowlisted params such as `artifactId`, and finally `default` only for singleton panels.
+- Parameterized panels without a safe instance key are rejected/logged instead of using an unstable hash of arbitrary params.
+
+The PR walkthrough is a normal singleton pack panel. It gets fullscreen, collapse, restore, split, and popout behavior because all pack tabs use the shared side-panel shell; there is no PR-specific resize state.
+
+## Mutations and concurrency
+
+The server canonicalizes and validates every tab before committing it. It rejects unknown kinds, malformed ids, mismatched `source.sessionId`, invalid proposal types, unsafe pack ids, unknown pack panels, oversized JSON params/state, and inconsistent pack instance metadata.
+
+Mutation endpoints are serialized per session with an async lock. Clients may optimistically update in memory, but the next REST response or WebSocket payload replaces that optimistic state.
+
+Rules:
+
+- `open` upserts by tab id and focuses by default;
+- `update` patches an already-open tab only and returns `404` if it is closed;
+- `close` deletes the tab and chooses the next active tab like a browser tab strip;
+- `active` may point only to an open tab or empty;
+- `resize` persists `collapsed`, `split`, or `fullscreen`;
+- `reorder` must include the exact current set of tab ids and requires a revision check;
+- stale non-reorder mutations are rebased onto the latest workspace unless the caller requests strict revision matching.
+
+Clients ignore server/WS payloads whose `revision` is not newer than the locally applied workspace.
+
+## API surface
+
+REST endpoints are session-scoped:
+
+| Method | Path | Behavior |
+|---|---|---|
+| `GET` | `/api/sessions/:sessionId/side-panel-workspace` | Return the canonical workspace, creating an empty default if none was persisted. |
+| `POST` | `/api/sessions/:sessionId/side-panel-workspace/open` | Validate and upsert a tab; focus by default. |
+| `PATCH` | `/api/sessions/:sessionId/side-panel-workspace/tabs/:tabId` | Update an already-open tab. Does not create closed tabs. |
+| `DELETE` | `/api/sessions/:sessionId/side-panel-workspace/tabs/:tabId` | Close a tab and preserve underlying content. |
+| `POST` | `/api/sessions/:sessionId/side-panel-workspace/active` | Set the active tab id. |
+| `POST` | `/api/sessions/:sessionId/side-panel-workspace/reorder` | Reorder all open tabs; requires `baseRevision` or `If-Match`. |
+| `POST` | `/api/sessions/:sessionId/side-panel-workspace/resize` | Persist size mode. |
+| `POST` | `/api/sessions/:sessionId/side-panel-workspace/migrate` | One-time migration from legacy localStorage keys when the server workspace is empty. |
+
+Mutations broadcast:
+
+```json
+{ "type": "side_panel_workspace", "sessionId": "...", "workspace": { "version": 1 } }
+```
+
+## Shared shell and controls
+
+The side-panel shell renders every tab kind with the same workspace chrome:
+
+- tab strip and close buttons;
+- active tab selection;
+- drag reorder;
+- fullscreen;
+- collapse and restore;
+- split view;
+- popout/deep-link.
+
+Panel-specific actions remain inside the panel or per-tab action slot. Preview keeps refresh/direct preview behavior; pack panels keep scoped Host API behavior; proposal/review/inbox panels keep their business actions.
+
+Keyboard shortcuts target the active side panel, regardless of kind:
+
+- expand: `collapsed -> split -> fullscreen`;
+- collapse: `fullscreen -> split -> collapsed`;
+- fullscreen toggle: non-fullscreen -> `fullscreen`, fullscreen -> `collapsed`.
+
+## Popout and deep links
+
+Preview popout keeps the content-origin route:
+
+- live preview: `/preview/<sessionId>/<entry>`;
+- artifact preview: `/preview/<sessionId>/_artifact/<artifactId>/<entry>`.
+
+All other panel kinds use the app deep link:
+
+```text
+#/session/<sessionId>/panel/<encodedTabId>
+```
+
+The route hydrates the session workspace, validates that the exact tab id is still open, focuses it, and renders the side-panel workspace in fullscreen. If the tab has been closed, the route shows a safe "Panel is closed" state instead of reconstructing it from params. Pack-panel deep links reuse the session-scoped host factory and the server-validated tab record; they do not grant cross-session Host API access or bypass pack validation.
+
+## Legacy localStorage migration
+
+Legacy workspace keys are migration input only:
+
+- `bobbit-panel-tabs-by-session`;
+- `bobbit-panel-active-by-session`;
+- `bobbit-preview-collapsed-<sessionId>`.
+
+On first hydrate, if the server workspace is empty and has no migration stamp, the client reads those keys and posts `/migrate`. The server canonicalizes the migrated tabs, persists `metadata.migratedFromLocalStorageAt`, increments `revision`, and broadcasts the committed workspace.
+
+Migration behavior:
+
+- legacy pack ids without `instanceKey` become `:default` only when valid for the panel;
+- legacy review title tabs become deterministic `legacy-title-<hash>` document ids;
+- the old preview collapsed key maps to `sizeMode: "collapsed"`;
+- closed tabs are not inferred from proposal/review/preview/inbox caches;
+- after migration, the real app does not write workspace state to localStorage.
+
+`src/app/panel-workspace.ts` still reads/writes legacy tab keys for `file://` unit fixtures and keeps preview version records in localStorage. That fixture fallback must not be treated as product persistence.
+
+## Diagnostics
+
+When a side-panel issue appears, check the server workspace first:
+
+```bash
+TOKEN=$(cat .bobbit/state/token)
+GW=$(cat .bobbit/state/gateway-url)
+curl -sk "$GW/api/sessions/<sessionId>/side-panel-workspace" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Useful checks:
+
+- a closed tab should be absent from `tabs`, not hidden by local UI state;
+- `activeTabId` should be empty or match an open tab id;
+- `sizeMode` should reflect the last shared control or shortcut action;
+- `revision` should increase after every committed mutation;
+- duplicate artifact pack panels should differ by `source.instanceKey`;
+- review tab ids should include document ids, not mutable titles;
+- stale localStorage should not change the workspace after `migratedFromLocalStorageAt` is set.
+
+Related docs: [architecture.md](architecture.md#side-panel-workspace), [preview-architecture.md](preview-architecture.md#side-panel-workspace-integration), [extension-host-authoring.md](extension-host-authoring.md#panels--persistent-side-panels-hostuiopenpanel), [rest-api.md](rest-api.md#side-panel-workspace), and [websocket-protocol.md](websocket-protocol.md#server--client).

--- a/docs/side-panel-workspace.md
+++ b/docs/side-panel-workspace.md
@@ -50,6 +50,12 @@ Every committed mutation increments `revision`, persists the whole workspace thr
 | Review | `review:<encoded-documentId>` | stable `documentId`, display `title` | Title is metadata. Renames do not change identity. Closing the tab preserves content/annotations for explicit reopen. |
 | Inbox | `inbox` | session id and optional `staffId` | Staff inbox opens/focuses through the same workspace APIs as other panels. |
 
+### Legacy chat artifacts exclusion
+
+`src/ui/ChatPanel.ts` and `src/ui/tools/artifacts/artifacts.ts` are not product-active right-side workspace surfaces in the current app. `ChatPanel.ts` is the older standalone/package-facing chat component that embeds its own `AgentInterface`, and `src/ui/tools/artifacts/artifacts.ts` is the legacy tool-renderer artifact model used by that component path. The app-level artifact experience is now served through pack panels, including the built-in artifacts pack, opened with `host.ui.openPanel()` and persisted as `pack:<packId>:<panelId>:<instanceKey>` workspace tabs.
+
+Because those legacy files are superseded by pack artifact panels, they are excluded from the shared workspace migration instead of being migrated. The acceptance surface is the pack artifact panel path: artifact panels use the shared side-panel shell, server-backed tab identity, shared sizing controls, and popout/deep-link behavior. Do not reintroduce a second right-side split/collapse implementation in `ChatPanel.ts` for the current app workspace.
+
 ### Preview lifecycle
 
 `preview_open` still writes the per-session preview mount and streams updates via preview SSE. Workspace tab creation is separate:
@@ -87,6 +93,7 @@ Mutation endpoints are serialized per session with an async lock. Clients may op
 Rules:
 
 - `open` upserts by tab id and focuses by default;
+- stale `open` requests that include `baseActiveTabId` do not steal focus when they are rebased over a newer active-tab change from another device; the tab is still opened or updated, but the newer active tab remains active;
 - `update` patches an already-open tab only and returns `404` if it is closed;
 - `close` deletes the tab and chooses the next active tab like a browser tab strip;
 - `active` may point only to an open tab or empty;
@@ -103,7 +110,7 @@ REST endpoints are session-scoped:
 | Method | Path | Behavior |
 |---|---|---|
 | `GET` | `/api/sessions/:sessionId/side-panel-workspace` | Return the canonical workspace, creating an empty default if none was persisted. |
-| `POST` | `/api/sessions/:sessionId/side-panel-workspace/open` | Validate and upsert a tab; focus by default. |
+| `POST` | `/api/sessions/:sessionId/side-panel-workspace/open` | Validate and upsert a tab; focus by default except stale `baseActiveTabId` rebases that would steal focus. |
 | `PATCH` | `/api/sessions/:sessionId/side-panel-workspace/tabs/:tabId` | Update an already-open tab. Does not create closed tabs. |
 | `DELETE` | `/api/sessions/:sessionId/side-panel-workspace/tabs/:tabId` | Close a tab and preserve underlying content. |
 | `POST` | `/api/sessions/:sessionId/side-panel-workspace/active` | Set the active tab id. |

--- a/docs/staff-inbox.md
+++ b/docs/staff-inbox.md
@@ -256,9 +256,11 @@ Clients filter by `staffId` and reconcile against the entry list in
 
 ## UI
 
-The inbox panel is a split-pane peer of the preview pane and the review
-pane. It is mounted in `src/app/render.ts` whenever the active session has
-`staffId` set, and `data-testid="inbox-panel-root"` wraps the host.
+The inbox panel is a first-class tab in the server-backed side-panel workspace,
+next to preview, proposal, review, and pack tabs. It is opened through
+`src/app/inbox-panel.ts::openInboxPanel()` and rendered by `src/app/render.ts`
+when the session workspace contains the `inbox` tab. `data-testid="inbox-panel-root"`
+wraps the host.
 
 - **Pending section** at the top: each entry shows title, source badge, age,
   and a Cancel button (transitions to `cancelled`).
@@ -267,11 +269,12 @@ pane. It is mounted in `src/app/render.ts` whenever the active session has
   `DELETE /api/staff/:id/inbox/:entryId`.
 - **"+ Add to inbox" button** opens `<add-to-inbox-dialog>` — a Title + Prompt
   composer that POSTs to `/api/staff/:id/inbox` with `source.type = "manual_ui"`.
-- **Keyboard shortcuts**: `Ctrl+]` collapses the panel one level (full → half
-  → collapsed); `Ctrl+[` expands one level. Same surface as the preview and
-  review panes; wired in `src/app/main.ts` alongside `state.inboxPanelOpen`.
-- **Per-session open state** is hydrated from `localStorage`. Reloading the
-  page keeps the panel open or collapsed exactly as you left it.
+- **Keyboard shortcuts** use the shared side-panel controls: collapse moves
+  `fullscreen → split → collapsed`, expand moves `collapsed → split → fullscreen`.
+- **Per-session open state** is server-authoritative. Reloading or opening the
+  session on another device keeps the inbox open/closed and preserves the shared
+  size mode from the workspace. Legacy localStorage is migration input only; see
+  [Side-panel workspace](side-panel-workspace.md).
 
 ### Mobile add dialog scoping
 

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -69,6 +69,7 @@ Session-list invalidations (`session_created`, `sessions_changed`, and `session_
 | `pong` | — | Keepalive response |
 | `cost_update` | `sessionId`, `goalId?`, `taskId?`, `cost` | Cumulative persisted session cost snapshot. Sent after live completed assistant usage and during hydration paths when persisted cost exists. Current servers include `cost.cacheHitRate`; see [Cost update shape](#cost-update-shape). |
 | `queue_update` | `sessionId`, `queue` | Prompt queue changed |
+| `side_panel_workspace` | `sessionId`, `workspace` | The server-authoritative side-panel workspace for the session changed. Clients replace their local mirror only when `workspace.revision` is newer; see [side-panel-workspace.md](side-panel-workspace.md). |
 | `task_changed` | `task` | A task was created, updated, or deleted |
 | `tasks_list` | `tasks` | Full task list for a goal |
 | `session_archived` | `sessionId`, `archivedAt` | Session was archived |

--- a/market-packs/artifacts/panels/artifacts-viewer.yaml
+++ b/market-packs/artifacts/panels/artifacts-viewer.yaml
@@ -1,5 +1,7 @@
 id: artifacts.viewer
 title: Artifact
+instanceMode: parameterized
+instanceParam: artifactId
 # `entry` resolves relative to THIS yaml (panels/) and stays inside the pack
 # root. The built panel bundle lives in the shared lib/ dir.
 entry: ../lib/ArtifactViewerPanel.js

--- a/scripts/run-unit.mjs
+++ b/scripts/run-unit.mjs
@@ -55,25 +55,49 @@ const nodeConcurrency = process.env.BOBBIT_UNIT_NODE_CONCURRENCY || String(half)
 // Passed to Playwright via --workers (CLI overrides the config's default).
 const browserWorkers = process.env.BOBBIT_UNIT_BROWSER_WORKERS || String(half);
 
+const failureTailLines = Math.max(20, Number.parseInt(process.env.BOBBIT_UNIT_FAILURE_TAIL_LINES || "240", 10) || 240);
+
+function appendTail(tail, chunk) {
+	for (const line of String(chunk).split(/\r?\n/)) {
+		if (!line) continue;
+		tail.push(line);
+		if (tail.length > failureTailLines) tail.shift();
+	}
+}
+
 function run(label, args) {
 	return new Promise((res) => {
 		const start = Date.now();
+		const tail = [];
+		let settled = false;
 		const child = spawn(npx, args, {
 			cwd: projectRoot,
-			stdio: ["ignore", "inherit", "inherit"],
+			stdio: ["ignore", "pipe", "pipe"],
 			// npx is a .cmd shim on Windows → needs a shell. The args are short
 			// (globs are NOT pre-expanded), so the shell command line stays tiny.
 			shell: isWin,
 			env: process.env,
 		});
-		child.on("exit", (code, signal) => {
+		child.stdout?.on("data", (chunk) => {
+			process.stdout.write(chunk);
+			appendTail(tail, chunk);
+		});
+		child.stderr?.on("data", (chunk) => {
+			process.stderr.write(chunk);
+			appendTail(tail, chunk);
+		});
+		child.on("close", (code, signal) => {
+			if (settled) return;
+			settled = true;
 			const secs = ((Date.now() - start) / 1000).toFixed(1);
 			console.log(`\n[run-unit] ${label} finished in ${secs}s (exit ${code ?? signal ?? "?"})`);
-			res({ label, code: code ?? (signal ? 1 : 0) });
+			res({ label, code: code ?? (signal ? 1 : 0), tail });
 		});
 		child.on("error", (err) => {
+			if (settled) return;
+			settled = true;
 			console.error(`[run-unit] ${label} failed to start:`, err);
-			res({ label, code: 1 });
+			res({ label, code: 1, tail: [String(err?.stack || err)] });
 		});
 	});
 }
@@ -96,6 +120,18 @@ const results = await Promise.all([
 	run("browser-fixtures", browserArgs),
 ]);
 const totalSecs = ((Date.now() - overallStart) / 1000).toFixed(1);
+const failed = results.filter((r) => r.code !== 0);
 console.log(`\n[run-unit] total wall time ${totalSecs}s`);
+console.log(`[run-unit] result summary: ${results.map((r) => `${r.label}=${r.code === 0 ? "pass" : `fail(${r.code})`}`).join(", ")}`);
 
-process.exit(results.some((r) => r.code !== 0) ? 1 : 0);
+if (failed.length > 0) {
+	console.error(`\n[run-unit] ${failed.length} runner(s) failed. Replaying last ${failureTailLines} non-empty output lines per failed runner so gate tails include the useful error:`);
+	for (const result of failed) {
+		console.error(`\n[run-unit] ---- ${result.label} failure output tail ----`);
+		if (result.tail.length > 0) console.error(result.tail.join("\n"));
+		else console.error("(no output captured)");
+		console.error(`[run-unit] ---- end ${result.label} failure output tail ----`);
+	}
+}
+
+process.exit(failed.length > 0 ? 1 : 0);

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -98,6 +98,7 @@ details.wf-proposal-workflow .wf-proposal-gates {
  * non-chat panes, offset only the mobile slider pane root. Proposal/review/
  * preview renderers often contain nested .goal-preview-panel elements; padding
  * every descendant stacks the header offset and creates a large blank gap. */
+[data-mobile-header] .side-panel-pane[data-panel-tab-id],
 [data-mobile-header] .goal-preview-panel[data-panel-tab-id] {
 	padding-top: var(--mobile-header-height, 60px) !important;
 }
@@ -493,23 +494,22 @@ details.wf-proposal-workflow .wf-proposal-gates {
  * .goal-preview-panel inside the right workspace, and those must fill the
  * workspace rather than inheriting a second 50% constraint. */
 @media (min-width: 768px) {
+	.side-panel-split-layout > .side-panel-chat-pane,
 	.goal-split-layout > .goal-chat-panel {
 		flex: 0 0 50%;
 		max-width: 50%;
 		overflow: hidden;
 	}
+	.side-panel-split-layout > .side-panel-workspace,
 	.goal-split-layout > .goal-preview-panel {
 		flex: 0 0 50%;
 		max-width: 50%;
 		overflow: hidden;
 	}
-	/* When a preview panel is nested inside another (the unified preview panel
-	   tab content rendering goalPreviewPanel / rolePreviewPanel /
-	   toolPreviewPanel / staffPreviewPanel), the inner panel must fill its
-	   parent — the outer panel already supplies the 50% width and the left
-	   border. Without this reset, the inner panel keeps its own `flex: 0 0
-	   50%` and `overflow: hidden`, which clips the System Prompt textarea
-	   and other long content. */
+	/* When a proposal/preview panel is nested inside the shared side-panel
+	   workspace, the inner panel must fill its parent — the outer panel already
+	   supplies the 50% width and the left border. */
+	.side-panel-workspace .goal-preview-panel,
 	.goal-preview-panel .goal-preview-panel {
 		flex: 1 1 auto;
 		max-width: 100%;
@@ -519,17 +519,25 @@ details.wf-proposal-workflow .wf-proposal-gates {
 
 /* On mobile, remove the left border when shown as a tab */
 @media (max-width: 767px) {
+	.side-panel-workspace,
+	.side-panel-pane,
 	.goal-preview-panel {
 		border-left: none !important;
 	}
 }
 
-/* ── Fullscreen preview: show only the message editor ─────────────── */
+/* ── Fullscreen side panel: show only the message editor ─────────────── */
+.side-panel-fullscreen-prompt,
 .preview-fullscreen-prompt {
 	overflow: hidden;
 	max-height: 150px;
 }
 /* Hide chat messages, streaming container, context bar, stats, artifacts */
+.side-panel-fullscreen-prompt message-list,
+.side-panel-fullscreen-prompt streaming-message-container,
+.side-panel-fullscreen-prompt git-status-widget,
+.side-panel-fullscreen-prompt .bobbit-stats,
+.side-panel-fullscreen-prompt .flex.flex-col.gap-3,
 .preview-fullscreen-prompt message-list,
 .preview-fullscreen-prompt streaming-message-container,
 .preview-fullscreen-prompt git-status-widget,
@@ -538,6 +546,7 @@ details.wf-proposal-workflow .wf-proposal-gates {
 	display: none !important;
 }
 /* The scroll container must not scroll — just show the editor at the bottom */
+.side-panel-fullscreen-prompt .overflow-y-auto,
 .preview-fullscreen-prompt .overflow-y-auto {
 	overflow: hidden !important;
 	display: flex !important;

--- a/src/app/inbox-panel.ts
+++ b/src/app/inbox-panel.ts
@@ -7,8 +7,9 @@
  * Lifecycle:
  *   - On session select with `session.staffId` set, `startInboxSubscription`
  *     is called: bootstrap fetches GET /api/staff/:id/inbox?state=pending
- *     and ?state=completed&limit=100, merges into `state.inboxEntries`,
- *     and sets `state.inboxPanelOpen = true`.
+ *     and ?state=completed&limit=100, merges into `state.inboxEntries`.
+ *     It does not create a side-panel tab; closed inbox tabs stay closed until
+ *     the user explicitly reopens them.
  *   - WS events `inbox.entry.added` / `updated` / `removed` are routed
  *     into this module's callbacks by `remote-agent.ts` and mutate the
  *     local entry list.
@@ -21,7 +22,7 @@
  */
 
 import { state, renderApp } from "./state.js";
-import { openSidePanelTab } from "./side-panel-workspace.js";
+import { getSidePanelWorkspace, openSidePanelTab } from "./side-panel-workspace.js";
 import { INBOX_PANEL_TAB_ID } from "./panel-workspace.js";
 import type { InboxEntry } from "../server/agent/inbox-store.js";
 
@@ -38,16 +39,8 @@ export function startInboxSubscription(sessionId: string, staffId: string): void
 	stopInboxSubscription();
 	currentSid = sessionId;
 	currentStaffId = staffId;
-	state.inboxPanelOpen = true;
+	state.inboxPanelOpen = getSidePanelWorkspace(sessionId).tabs.some((tab) => tab.id === INBOX_PANEL_TAB_ID && tab.kind === "inbox");
 	state.inboxEntries = [];
-	void openSidePanelTab({
-		id: INBOX_PANEL_TAB_ID,
-		kind: "inbox",
-		title: "Inbox",
-		label: "Inbox",
-		source: { type: "inbox", sessionId, staffId },
-		updatedAt: Date.now(),
-	}, { focus: false });
 	const token = ++bootstrapToken;
 
 	void (async () => {
@@ -97,6 +90,20 @@ export function startInboxSubscription(sessionId: string, staffId: string): void
 			/* bootstrap failures are non-fatal; live WS will catch up */
 		}
 	})();
+}
+
+export function openInboxPanel(sessionId: string = currentSid || "", staffId: string = currentStaffId || ""): void {
+	if (!sessionId || !staffId) return;
+	state.inboxPanelOpen = true;
+	void openSidePanelTab({
+		id: INBOX_PANEL_TAB_ID,
+		kind: "inbox",
+		title: "Inbox",
+		label: "Inbox",
+		source: { type: "inbox", sessionId, staffId },
+		updatedAt: Date.now(),
+	}, { focus: true });
+	renderApp();
 }
 
 /** Tear down the current subscription. Clears local state. */

--- a/src/app/inbox-panel.ts
+++ b/src/app/inbox-panel.ts
@@ -47,7 +47,7 @@ export function startInboxSubscription(sessionId: string, staffId: string): void
 		label: "Inbox",
 		source: { type: "inbox", sessionId, staffId },
 		updatedAt: Date.now(),
-	}, { focus: true });
+	}, { focus: false });
 	const token = ++bootstrapToken;
 
 	void (async () => {

--- a/src/app/inbox-panel.ts
+++ b/src/app/inbox-panel.ts
@@ -21,6 +21,8 @@
  */
 
 import { state, renderApp } from "./state.js";
+import { openSidePanelTab } from "./side-panel-workspace.js";
+import { INBOX_PANEL_TAB_ID } from "./panel-workspace.js";
 import type { InboxEntry } from "../server/agent/inbox-store.js";
 
 let currentSid: string | null = null;
@@ -38,6 +40,14 @@ export function startInboxSubscription(sessionId: string, staffId: string): void
 	currentStaffId = staffId;
 	state.inboxPanelOpen = true;
 	state.inboxEntries = [];
+	void openSidePanelTab({
+		id: INBOX_PANEL_TAB_ID,
+		kind: "inbox",
+		title: "Inbox",
+		label: "Inbox",
+		source: { type: "inbox", sessionId, staffId },
+		updatedAt: Date.now(),
+	}, { focus: true });
 	const token = ++bootstrapToken;
 
 	void (async () => {

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -37,13 +37,12 @@ import { getRouteFromHash, setHashRoute } from "./routing.js";
 import { authenticateGateway, connectToSession, createAndConnectSession, terminateSession, applyProjectPalette, flushAndTeardownDraft, flushPendingDraft } from "./session-manager.js";
 import { migrateLegacyVisitedMap } from "./render-helpers.js";
 import { installPwaLifecycleRecovery, markAppBooted } from "./pwa-lifecycle.js";
-import { doRenderApp, showHeaderToast, workspaceSessionId, dismissExtRouteUnavailable } from "./render.js";
+import { doRenderApp, showHeaderToast, workspaceSessionId, dismissExtRouteUnavailable, hasActiveSidePanel, getSidePanelSizeMode, setSidePanelSizeMode } from "./render.js";
 import { renderTool } from "../ui/tools/index.js";
 import { navigateSidebar, expandActiveSidebarItem, installKeyboardNavOverrideClearListener } from "./sidebar-nav.js";
 import { toggleRolePicker } from "./sidebar.js";
 import { startNewGoalFlow } from "./goal-entry.js";
 import { toggleShowArchived, toggleShowBusy, toggleShowRead } from "../ui/components/sidebar-filters.js";
-import { PROPOSAL_TYPES } from "./proposal-registry.js";
 // goal-dashboard is dynamic-imported lazily to keep it out of the main chunk.
 // See docs/design/ui-bundle-size-reduction.md (Task A).
 let _goalDashboardModule: typeof import("./goal-dashboard.js") | null = null;
@@ -115,10 +114,6 @@ import("lit").then(m => { (window as any).__bobbitLitRender = m.render; }).catch
 	const { runLauncherEntrypoint } = await import("./pack-entrypoints.js");
 	runLauncherEntrypoint(id);
 };
-
-function hasActiveProposalPanel(): boolean {
-	return PROPOSAL_TYPES.some((type) => state.activeProposals[type] != null);
-}
 
 // ============================================================================
 // GATEWAY STARTUP POLLING
@@ -804,27 +799,17 @@ async function initApp() {
 	});
 
 	registerShortcut({
-		// Ctrl+[ — expand preview panel one level (collapsed → half → full) when a
-		// preview/review/proposal panel is visible. Falls back to toggling the
-		// sidebar when no such panel exists.
-		id: "toggle-sidebar", label: "Expand preview / toggle sidebar", category: "UI",
+		// Ctrl+[ — expand the active side panel one level (collapsed → split → fullscreen).
+		// Falls back to toggling the sidebar when no side panel exists.
+		id: "toggle-sidebar", label: "Expand side panel / toggle sidebar", category: "UI",
 		defaultBindings: [{ key: "[", ctrlOrMeta: true, shift: false, alt: false }],
 		allowInInput: true,
 		handler: () => {
-			const canFullscreen = !state.assistantType && (state.isPreviewSession || state.reviewPanelOpen || state.inboxPanelOpen);
-			const hasPanel = canFullscreen || (!state.assistantType && hasActiveProposalPanel());
-			if (hasPanel) {
-				const key = `bobbit-preview-collapsed-${workspaceSessionId()}`;
-				const collapsed = localStorage.getItem(key) === "true";
-				if (collapsed) {
-					// level 0 → 1: uncollapse to half view
-					localStorage.setItem(key, "false");
-				} else if (!state.previewPanelFullscreen && canFullscreen) {
-					// level 1 → 2: enter fullscreen
-					sessionStorage.setItem("bobbit-pre-fullscreen-collapsed", "false");
-					state.previewPanelFullscreen = true;
-				}
-				// already at level 2 — no-op
+			if (hasActiveSidePanel()) {
+				const mode = getSidePanelSizeMode(workspaceSessionId());
+				if (mode === "collapsed") setSidePanelSizeMode("split", workspaceSessionId());
+				else if (mode === "split") setSidePanelSizeMode("fullscreen", workspaceSessionId());
+				// already fullscreen — no-op
 				renderApp();
 				return;
 			}
@@ -866,54 +851,30 @@ async function initApp() {
 	});
 
 	registerShortcut({
-		// Ctrl+] — collapse preview panel one level (full → half → collapsed).
-		id: "toggle-preview", label: "Collapse preview panel", category: "UI",
+		// Ctrl+] — collapse the active side panel one level (fullscreen → split → collapsed).
+		id: "toggle-preview", label: "Collapse side panel", category: "UI",
 		defaultBindings: [{ key: "]", ctrlOrMeta: true, shift: false, alt: false }],
 		allowInInput: true,
 		handler: () => {
-			const hasPanel = !state.assistantType && (state.isPreviewSession || state.reviewPanelOpen || state.inboxPanelOpen || hasActiveProposalPanel());
-			if (!hasPanel) return;
-			const key = `bobbit-preview-collapsed-${workspaceSessionId()}`;
-			if (state.previewPanelFullscreen) {
-				// level 2 → 1: exit fullscreen, keep half view
-				state.previewPanelFullscreen = false;
-				localStorage.setItem(key, "false");
-				sessionStorage.removeItem("bobbit-pre-fullscreen-collapsed");
-			} else if (localStorage.getItem(key) !== "true") {
-				// level 1 → 0: collapse
-				localStorage.setItem(key, "true");
-			}
-			// already at level 0 — no-op
+			if (!hasActiveSidePanel()) return;
+			const mode = getSidePanelSizeMode(workspaceSessionId());
+			if (mode === "fullscreen") setSidePanelSizeMode("split", workspaceSessionId());
+			else if (mode === "split") setSidePanelSizeMode("collapsed", workspaceSessionId());
+			// already collapsed — no-op
 			renderApp();
 		},
 	});
 
 	registerShortcut({
-		// Ctrl+# — jump straight to fullscreen (level 2). If already fullscreen,
-		// jump straight to collapsed (level 0).
-		id: "toggle-fullscreen-preview", label: "Fullscreen ↔ collapsed preview", category: "UI",
+		// Ctrl+# — jump straight to fullscreen. If already fullscreen, jump straight to collapsed.
+		id: "toggle-fullscreen-preview", label: "Fullscreen ↔ collapsed side panel", category: "UI",
 		defaultBindings: [{ key: "#", ctrlOrMeta: true, shift: false, alt: false }],
 		allowInInput: true,
 		handler: () => {
-			const hasPanel = !state.assistantType && (state.isPreviewSession || state.reviewPanelOpen || state.inboxPanelOpen || hasActiveProposalPanel());
-			if (hasPanel) {
-				const key = `bobbit-preview-collapsed-${workspaceSessionId()}`;
-				if (state.previewPanelFullscreen) {
-					// level 2 → 0: exit fullscreen and collapse
-					state.previewPanelFullscreen = false;
-					localStorage.setItem(key, "true");
-					sessionStorage.removeItem("bobbit-pre-fullscreen-collapsed");
-				} else if (state.isPreviewSession) {
-					// any non-fullscreen level → 2: jump to fullscreen
-					localStorage.setItem(key, "false");
-					state.previewPanelFullscreen = true;
-				} else {
-					// Proposal/review/inbox-only panels have no fullscreen surface.
-					const collapsed = localStorage.getItem(key) === "true";
-					localStorage.setItem(key, collapsed ? "false" : "true");
-				}
-				renderApp();
-			}
+			if (!hasActiveSidePanel()) return;
+			const mode = getSidePanelSizeMode(workspaceSessionId());
+			setSidePanelSizeMode(mode === "fullscreen" ? "collapsed" : "fullscreen", workspaceSessionId());
+			renderApp();
 		},
 	});
 

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -35,6 +35,7 @@ import {
 import { gatewayFetch, refreshSessions, resetPrPollThrottle } from "./api.js";
 import { getRouteFromHash, setHashRoute } from "./routing.js";
 import { authenticateGateway, connectToSession, createAndConnectSession, terminateSession, applyProjectPalette, flushAndTeardownDraft, flushPendingDraft } from "./session-manager.js";
+import { selectProposalWorkspaceTab } from "./preview-panel.js";
 import { migrateLegacyVisitedMap } from "./render-helpers.js";
 import { installPwaLifecycleRecovery, markAppBooted } from "./pwa-lifecycle.js";
 import { doRenderApp, showHeaderToast, workspaceSessionId, dismissExtRouteUnavailable, hasActiveSidePanel, getSidePanelSizeMode, setSidePanelSizeMode } from "./render.js";
@@ -76,12 +77,44 @@ setRenderApp(doRenderApp);
 // session; the corresponding writes live in panel-workspace.ts.
 loadPersistedPanelWorkspace(state);
 
+function reconcileE2eInjectedProposalWorkspace(): void {
+	const sessionId = activeSessionId();
+	if (!sessionId) return;
+	const activeId = state.panelWorkspaceActiveBySession?.[sessionId] || state.activePanelTabId;
+	const match = typeof activeId === "string" ? activeId.match(/^proposal:(goal|project|role|tool|staff)$/) : null;
+	const type = match?.[1] as keyof typeof state.activeProposals | undefined;
+	const slot = type ? state.activeProposals[type] : undefined;
+	if (!type || !slot || slot.sessionId !== sessionId) return;
+	selectProposalWorkspaceTab(type, { sessionId, select: true, setAssistantTab: true });
+}
+
+function captureSidePanelTabActivation(event: Event): void {
+	const target = event.target as Element | null;
+	if (!target || target.closest(".goal-tab-close")) return;
+	const pill = target.closest<HTMLElement>(".goal-tab-pill[data-panel-tab-id]");
+	if (!pill || pill.getAttribute("data-panel-tab-kind") === "chat") return;
+	const tabId = pill.getAttribute("data-panel-tab-id") || "";
+	const sessionId = state.selectedSessionId || activeSessionId() || "";
+	if (!tabId || !sessionId) return;
+	if (!state.panelWorkspaceActiveBySession || typeof state.panelWorkspaceActiveBySession !== "object") state.panelWorkspaceActiveBySession = {} as any;
+	(state as any).__lastSidePanelUserActiveSelection = { sessionId, tabId, at: Date.now() };
+	state.panelWorkspaceActiveBySession[sessionId] = tabId;
+	state.activePanelTabId = tabId;
+}
+
+document.addEventListener("pointerdown", captureSidePanelTabActivation, true);
+document.addEventListener("mousedown", captureSidePanelTabActivation, true);
+document.addEventListener("click", captureSidePanelTabActivation, true);
+
 // Expose state on window for E2E tests (harmless in production — the state
 // object is already mutable from devtools and contains no secrets).
 (window as any).__bobbitState = state;
 // Expose the render trigger too, so tests that patch in-memory state can
 // force a fresh paint without relying on viewport-resize side effects.
-(window as any).__bobbitRenderApp = renderApp;
+(window as any).__bobbitRenderApp = () => {
+	reconcileE2eInjectedProposalWorkspace();
+	renderApp();
+};
 // Expose the expanded-goals set so tests that inject synthetic goals into
 // state.goals can also force them into the expanded state (the normal
 // auto-expand path only fires for goals the server has confirmed).

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -38,6 +38,7 @@ import { authenticateGateway, connectToSession, createAndConnectSession, termina
 import { migrateLegacyVisitedMap } from "./render-helpers.js";
 import { installPwaLifecycleRecovery, markAppBooted } from "./pwa-lifecycle.js";
 import { doRenderApp, showHeaderToast, workspaceSessionId, dismissExtRouteUnavailable, hasActiveSidePanel, getSidePanelSizeMode, setSidePanelSizeMode } from "./render.js";
+import { getSidePanelWorkspace, hydrateSidePanelWorkspace, setActiveSidePanelTab } from "./side-panel-workspace.js";
 import { renderTool } from "../ui/tools/index.js";
 import { navigateSidebar, expandActiveSidebarItem, installKeyboardNavOverrideClearListener } from "./sidebar-nav.js";
 import { toggleRolePicker } from "./sidebar.js";
@@ -205,6 +206,23 @@ function clearActiveExtRoute(): void {
 	dismissExtRouteUnavailable();
 }
 
+async function restoreSessionPanelRoute(sessionId: string, panelTabId: string | undefined): Promise<void> {
+	if (!panelTabId) return;
+	try {
+		const workspace = getSidePanelWorkspace(sessionId).sessionId === sessionId
+			? getSidePanelWorkspace(sessionId)
+			: await hydrateSidePanelWorkspace(sessionId);
+		const latest = workspace.tabs.length > 0 ? workspace : await hydrateSidePanelWorkspace(sessionId);
+		if (latest.tabs.some((tab) => tab.id === panelTabId)) {
+			await setActiveSidePanelTab(panelTabId, { sessionId });
+		}
+	} catch {
+		/* render.ts shows the closed/missing-panel state */
+	} finally {
+		renderApp();
+	}
+}
+
 async function restoreExtRoute(routeId: string | undefined, params: Record<string, string> | undefined): Promise<void> {
 	if (!routeId) { clearActiveExtRoute(); return; }
 	try {
@@ -293,10 +311,8 @@ async function handleHashChange(): Promise<void> {
 			await loadDashboardData(route.goalId);
 		} else if (route.view === "session" && route.sessionId) {
 			clearDashboardState();
-			if (state.selectedSessionId === route.sessionId || state.connectingSessionId === route.sessionId) {
-				return;
-			}
-			if (state.remoteAgent?.gatewaySessionId === route.sessionId) {
+			if (state.selectedSessionId === route.sessionId || state.connectingSessionId === route.sessionId || state.remoteAgent?.gatewaySessionId === route.sessionId) {
+				await restoreSessionPanelRoute(route.sessionId, route.panelTabId);
 				return;
 			}
 			if (state.remoteAgent) {
@@ -308,6 +324,7 @@ async function handleHashChange(): Promise<void> {
 			const checkRes = await gatewayFetch(`/api/sessions/${route.sessionId}`);
 			if (checkRes.ok) {
 				await connectToSession(route.sessionId, true);
+				await restoreSessionPanelRoute(route.sessionId, route.panelTabId);
 			} else {
 				setHashRoute("landing");
 				state.appView = "authenticated";
@@ -683,6 +700,7 @@ async function initApp() {
 				const checkRes = await gatewayFetch(`/api/sessions/${route.sessionId}`);
 				if (checkRes.ok) {
 					await connectToSession(route.sessionId, true);
+					await restoreSessionPanelRoute(route.sessionId, route.panelTabId);
 				}
 			} else if (route.view === "goal-dashboard" && route.goalId) {
 				state.goalDashboardId = route.goalId;

--- a/src/app/pack-panels.ts
+++ b/src/app/pack-panels.ts
@@ -31,6 +31,8 @@ import { gatewayFetch } from "./gateway-fetch.js";
 import { fetchContributions, type PackContributionsWire } from "./api.js";
 import { state, renderApp } from "./state.js";
 import {
+	DEFAULT_PACK_PANEL_INSTANCE_KEY,
+	packPanelRefFromTabId,
 	packPanelTabId,
 	panelTabsForSession,
 	setPanelTabsForSession,
@@ -141,15 +143,24 @@ export interface PackPanelInfo {
 	panelId: string;
 	entry?: string;
 	title?: string;
+	/** Optional tab identity mode. Omitted defaults to singleton compatibility. */
+	instanceMode?: "singleton" | "parameterized";
+	/** Allowlisted param name used as the instanceKey for parameterized panels. */
+	instanceParam?: string;
 }
 
 /** A registered panel: the owning `packId` (used to build the pack-addressed
  *  serving URL + mint the pack-bound surface token) plus the `projectId` the
  *  registration was driven for (so the lazy loader fetches the SAME winning
  *  provider the metadata fetch saw — no split-brain, design §4b). */
-interface RegisteredPanel {
+export interface PackPanelInstanceIdentityInfo {
 	packId: string;
 	panelId: string;
+	instanceMode: "singleton" | "parameterized";
+	instanceParam?: string;
+}
+
+interface RegisteredPanel extends PackPanelInstanceIdentityInfo {
 	title?: string;
 	projectId?: string;
 }
@@ -209,7 +220,9 @@ export function registerPackPanels(
 	const next = new Map<string, RegisteredPanel>();
 	for (const info of list) {
 		if (!info?.packId || !info.panelId) continue;
-		next.set(panelKey(info.packId, info.panelId), { packId: info.packId, panelId: info.panelId, title: info.title, projectId });
+		const instanceMode = info.instanceMode === "parameterized" ? "parameterized" : "singleton";
+		const instanceParam = typeof info.instanceParam === "string" && info.instanceParam.trim() ? info.instanceParam.trim() : undefined;
+		next.set(panelKey(info.packId, info.panelId), { packId: info.packId, panelId: info.panelId, title: info.title, projectId, instanceMode, instanceParam });
 	}
 	// RECONCILE: compare prior registry to the fresh one.
 	for (const [key, prev] of panels) {
@@ -275,7 +288,14 @@ export function panelInfosFromContributions(packs: ReadonlyArray<PackContributio
 		for (const panel of p.panels) {
 			const panelId = typeof panel?.id === "string" ? panel.id : undefined;
 			if (!panelId) continue;
-			out.push({ packId, panelId, title: typeof panel?.title === "string" ? panel.title : undefined });
+			const raw = panel as Record<string, unknown>;
+			out.push({
+				packId,
+				panelId,
+				title: typeof panel?.title === "string" ? panel.title : undefined,
+				instanceMode: raw.instanceMode === "parameterized" ? "parameterized" : raw.instanceMode === "singleton" ? "singleton" : undefined,
+				instanceParam: typeof raw.instanceParam === "string" ? raw.instanceParam : undefined,
+			});
 		}
 	}
 	return out;
@@ -353,6 +373,38 @@ function resolveOpenPanel(callerPackId: string | undefined, panelId: string): Re
 	return matches.length === 1 ? matches[0] : undefined;
 }
 
+const ALLOWLISTED_INSTANCE_PARAMS = ["artifactId", "documentId"] as const;
+
+function safeInstanceKey(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	if (!trimmed || trimmed.length > 128) return undefined;
+	if (/[\u0000-\u001f\u007f]/.test(trimmed)) return undefined;
+	return trimmed;
+}
+
+export function packPanelInstanceKeyForTarget(reg: PackPanelInstanceIdentityInfo, target: Pick<PanelTarget, "instanceKey" | "params">): string | undefined {
+	const explicit = safeInstanceKey(target.instanceKey);
+	if (explicit) return explicit;
+	const params = target.params && typeof target.params === "object" && !Array.isArray(target.params) ? target.params : undefined;
+	if (params && reg.instanceParam) {
+		const fromDeclaredParam = safeInstanceKey(params[reg.instanceParam]);
+		if (fromDeclaredParam) return fromDeclaredParam;
+	}
+	if (params) {
+		for (const key of ALLOWLISTED_INSTANCE_PARAMS) {
+			const fromAllowlist = safeInstanceKey(params[key]);
+			if (fromAllowlist) return fromAllowlist;
+		}
+	}
+	if (reg.instanceMode === "parameterized") {
+		// eslint-disable-next-line no-console
+		console.warn(`[pack-panels] openPanel: parameterized panel "${reg.packId}/${reg.panelId}" requires instanceKey${reg.instanceParam ? ` or params.${reg.instanceParam}` : ""}`);
+		return undefined;
+	}
+	return DEFAULT_PACK_PANEL_INSTANCE_KEY;
+}
+
 /**
  * Load + mount a pack panel by id (design §6.3). PACK-RELATIVE: the caller's bound
  * `callerPackId` (threaded from the host factory / launcher registration) resolves
@@ -370,8 +422,10 @@ export function openPackPanel(target: PanelTarget, callerPackId?: string): void 
 		console.warn(`[pack-panels] openPanel: no registered panel "${callerPackId ?? "?"}/${panelId}"`);
 		return;
 	}
+	const instanceKey = packPanelInstanceKeyForTarget(reg, target);
+	if (!instanceKey) return;
 	void loadPanelModule(panelKey(reg.packId, reg.panelId), reg);
-	mountPackPanelTab(reg, target.params, target.sessionId);
+	mountPackPanelTab(reg, target.params, target.sessionId, instanceKey);
 }
 
 /** Add or focus the side-panel tab for `{packId, panelId}`, carrying `params`.
@@ -389,7 +443,7 @@ export function openPackPanel(target: PanelTarget, callerPackId?: string): void 
  *  the tab still keys correctly. Omitted `sessionId` ⇒ the active session (v1
  *  behaviour, unchanged). Reusing `connectToSession` keeps the pack pure — no
  *  platform navigation code is reimplemented here. */
-function mountPackPanelTab(reg: RegisteredPanel, params?: Record<string, unknown>, sessionId?: string): void {
+function mountPackPanelTab(reg: RegisteredPanel, params?: Record<string, unknown>, sessionId?: string, instanceKey = DEFAULT_PACK_PANEL_INSTANCE_KEY): void {
 	try {
 		const s = state as unknown as { selectedSessionId?: string; remoteAgent?: { gatewaySessionId?: string } };
 		// v2: an explicit target session is SWITCHED to via the canonical full-switch
@@ -407,16 +461,17 @@ function mountPackPanelTab(reg: RegisteredPanel, params?: Record<string, unknown
 			}
 		}
 		const sid = sessionId || s.selectedSessionId || s.remoteAgent?.gatewaySessionId || undefined;
-		const id = packPanelTabId(reg.packId, reg.panelId);
+		const id = packPanelTabId(reg.packId, reg.panelId, instanceKey);
 		const title = reg.title || reg.panelId;
+		const singleton = reg.instanceMode !== "parameterized";
 		const tab: PanelWorkspaceTab = {
 			id,
 			kind: "pack",
 			title,
 			label: title,
 			legacyTab: "pack",
-			source: { type: "pack", packId: reg.packId, panelId: reg.panelId, params, sessionId: sid },
-			state: { packId: reg.packId, panelId: reg.panelId, params },
+			source: { type: "pack", packId: reg.packId, panelId: reg.panelId, instanceKey, singleton, params, sessionId: sid },
+			state: { packId: reg.packId, panelId: reg.panelId, instanceKey, singleton, params },
 		};
 		const tabs = panelTabsForSession(state, sid);
 		const idx = tabs.findIndex((t) => t?.id === id);
@@ -435,13 +490,17 @@ function mountPackPanelTab(reg: RegisteredPanel, params?: Record<string, unknown
  *  it open (reconcile-on-uninstall). Best-effort + guarded. */
 function removePackPanelTab(packId: string, panelId: string): void {
 	try {
-		const id = packPanelTabId(packId, panelId);
 		const bySession = (state as unknown as { panelTabsBySession?: Record<string, PanelWorkspaceTab[]> }).panelTabsBySession;
 		if (!bySession || typeof bySession !== "object") return;
 		for (const [sid, tabs] of Object.entries(bySession)) {
-			if (!Array.isArray(tabs) || !tabs.some((t) => t?.id === id)) continue;
+			if (!Array.isArray(tabs)) continue;
+			const nextTabs = tabs.filter((t) => {
+				const ref = packPanelRefFromTabId(t?.id);
+				return !(ref?.packId === packId && ref.panelId === panelId);
+			});
+			if (nextTabs.length === tabs.length) continue;
 			const key = sid === "__no-session__" ? undefined : sid;
-			setPanelTabsForSession(state, key, tabs.filter((t) => t?.id !== id));
+			setPanelTabsForSession(state, key, nextTabs);
 		}
 		try { renderApp(); } catch { /* non-DOM */ }
 	} catch {

--- a/src/app/pack-panels.ts
+++ b/src/app/pack-panels.ts
@@ -34,11 +34,9 @@ import {
 	DEFAULT_PACK_PANEL_INSTANCE_KEY,
 	packPanelRefFromTabId,
 	packPanelTabId,
-	panelTabsForSession,
-	setPanelTabsForSession,
-	setActivePanelTabIdForSession,
 	type PanelWorkspaceTab,
 } from "./panel-workspace.js";
+import { closeSidePanelTab, openSidePanelTab } from "./side-panel-workspace.js";
 import type { HostApi, PanelTarget } from "../shared/extension-host/host-api.js";
 
 /** Host toolkit handed to a pack panel's factory — keeps the pack on the app's
@@ -288,7 +286,7 @@ export function panelInfosFromContributions(packs: ReadonlyArray<PackContributio
 		for (const panel of p.panels) {
 			const panelId = typeof panel?.id === "string" ? panel.id : undefined;
 			if (!panelId) continue;
-			const raw = panel as Record<string, unknown>;
+			const raw = panel as unknown as Record<string, unknown>;
 			out.push({
 				packId,
 				panelId,
@@ -461,26 +459,19 @@ function mountPackPanelTab(reg: RegisteredPanel, params?: Record<string, unknown
 			}
 		}
 		const sid = sessionId || s.selectedSessionId || s.remoteAgent?.gatewaySessionId || undefined;
+		if (!sid) return;
 		const id = packPanelTabId(reg.packId, reg.panelId, instanceKey);
 		const title = reg.title || reg.panelId;
 		const singleton = reg.instanceMode !== "parameterized";
-		const tab: PanelWorkspaceTab = {
+		void openSidePanelTab({
 			id,
 			kind: "pack",
 			title,
 			label: title,
-			legacyTab: "pack",
 			source: { type: "pack", packId: reg.packId, panelId: reg.panelId, instanceKey, singleton, params, sessionId: sid },
 			state: { packId: reg.packId, panelId: reg.panelId, instanceKey, singleton, params },
-		};
-		const tabs = panelTabsForSession(state, sid);
-		const idx = tabs.findIndex((t) => t?.id === id);
-		const nextTabs = idx >= 0
-			? tabs.map((t) => (t.id === id ? { ...t, ...tab } : t))
-			: [...tabs, tab];
-		setPanelTabsForSession(state, sid, nextTabs);
-		setActivePanelTabIdForSession(state, sid, id);
-		try { renderApp(); } catch { /* non-DOM */ }
+			updatedAt: Date.now(),
+		}, { focus: true });
 	} catch {
 		/* no app state (unit fixtures) — the registry/load path still ran */
 	}
@@ -494,15 +485,14 @@ function removePackPanelTab(packId: string, panelId: string): void {
 		if (!bySession || typeof bySession !== "object") return;
 		for (const [sid, tabs] of Object.entries(bySession)) {
 			if (!Array.isArray(tabs)) continue;
-			const nextTabs = tabs.filter((t) => {
-				const ref = packPanelRefFromTabId(t?.id);
-				return !(ref?.packId === packId && ref.panelId === panelId);
-			});
-			if (nextTabs.length === tabs.length) continue;
-			const key = sid === "__no-session__" ? undefined : sid;
-			setPanelTabsForSession(state, key, nextTabs);
+			for (const tab of tabs) {
+				const ref = packPanelRefFromTabId(tab?.id);
+				if (ref?.packId === packId && ref.panelId === panelId) {
+					const key = sid === "__no-session__" ? undefined : sid;
+					void closeSidePanelTab(tab.id, { sessionId: key });
+				}
+			}
 		}
-		try { renderApp(); } catch { /* non-DOM */ }
 	} catch {
 		/* best-effort */
 	}

--- a/src/app/panel-workspace.ts
+++ b/src/app/panel-workspace.ts
@@ -30,16 +30,18 @@ export interface PanelWorkspaceTab {
 			[key: string]: unknown;
 		}
 		| { type: "proposal"; proposalType: ProposalType; sessionId?: string; rev?: number; historical?: boolean; [key: string]: unknown }
-		| { type: "review"; title?: string; reviewTitle?: string; sessionId?: string }
+		| { type: "review"; documentId?: string; title?: string; reviewTitle?: string; sessionId?: string }
 		| { type: "inbox"; sessionId?: string }
 		| {
-			/** A pack-contributed side panel (pack schema V1 §8.1). `{packId, panelId}`
-			 *  is the COMPOUND key into the client pack-panel registry (panel ids are
-			 *  only pack-unique now); `params` is the typed PanelTarget.params the panel
-			 *  rehydrates from (e.g. `{ artifactId }`). */
+			/** A pack-contributed side panel (pack schema V1 §8.1). `{packId, panelId,
+			 *  instanceKey}` is the COMPOUND key into the client pack-panel registry
+			 *  (panel ids are only pack-unique now); `params` is the typed
+			 *  PanelTarget.params the panel rehydrates from (e.g. `{ artifactId }`). */
 			type: "pack";
 			packId: string;
 			panelId: string;
+			instanceKey?: string;
+			singleton?: boolean;
 			params?: Record<string, unknown>;
 			sessionId?: string;
 			[key: string]: unknown;
@@ -51,6 +53,7 @@ export const CHAT_PANEL_TAB_ID = "chat";
 export const LIVE_PREVIEW_PANEL_TAB_ID = "preview:live";
 export const LEGACY_LIVE_PREVIEW_PANEL_TAB_ID = "preview";
 export const INBOX_PANEL_TAB_ID = "inbox";
+export const DEFAULT_PACK_PANEL_INSTANCE_KEY = "default";
 export const PANEL_WORKSPACE_NO_SESSION_KEY = "__no-session__";
 const PANEL_TABS_STORAGE_KEY = "bobbit-panel-tabs-by-session";
 const PANEL_ACTIVE_STORAGE_KEY = "bobbit-panel-active-by-session";
@@ -127,9 +130,9 @@ const PROPOSAL_LABELS: Record<ProposalType, string> = {
 
 const PREVIEW_ENTRY_ID_RE = /^preview:entry:([^:]+)(?::v:(\d+))?$/;
 const PROPOSAL_ID_RE = /^proposal:([^:]+)(?::rev:(\d+))?$/;
-// Pack side-panel tab id scheme `pack:<encoded packId>:<encoded panelId>` (pack
-// schema V1 §8.1 — panel ids are only pack-unique, so the tab id carries BOTH).
-const PACK_PANEL_ID_RE = /^pack:([^:]+):(.+)$/;
+// Pack side-panel tab id scheme `pack:<encoded packId>:<encoded panelId>:<encoded instanceKey>`.
+// Legacy two-part ids are accepted for migration compatibility.
+const PACK_PANEL_ID_RE = /^pack:([^:]+):([^:]+)(?::([^:]+))?$/;
 
 function isLegacyPreviewPanelTabId(id: string | null | undefined): boolean {
 	return id === LEGACY_LIVE_PREVIEW_PANEL_TAB_ID || id === LIVE_PREVIEW_PANEL_TAB_ID;
@@ -207,27 +210,37 @@ function isReviewPanelTabId(id: string): boolean {
 	return typeof decoded === "string" && decoded.length > 0;
 }
 
-/** A `{packId, panelId}` reference into the client pack-panel registry. */
+/** A `{packId, panelId, instanceKey}` reference into the client pack-panel registry.
+ *  `legacyTwoPart` is true only for migrated `pack:<packId>:<panelId>` ids; callers
+ *  should canonicalize those to instanceKey `default` when writing new state. */
 export interface PackPanelRef {
 	packId: string;
 	panelId: string;
+	instanceKey: string;
+	legacyTwoPart?: boolean;
 }
 
 /** Build the side-panel tab id for a pack panel (pack schema V1 §8.1) — encodes
- *  BOTH packId and panelId since panel ids are only pack-unique. */
-export function packPanelTabId(packId: string, panelId: string): string {
-	return `pack:${encodeURIComponent(packId)}:${encodeURIComponent(panelId)}`;
+ *  packId, panelId, and durable instanceKey because panel ids are pack-unique and
+ *  a panel may have multiple parameterized instances. */
+export function packPanelTabId(packId: string, panelId: string, instanceKey: string = DEFAULT_PACK_PANEL_INSTANCE_KEY): string {
+	const key = instanceKey && typeof instanceKey === "string" ? instanceKey : DEFAULT_PACK_PANEL_INSTANCE_KEY;
+	return `pack:${encodeURIComponent(packId)}:${encodeURIComponent(panelId)}:${encodeURIComponent(key)}`;
 }
 
-/** Extract the `{packId, panelId}` from a `pack:<packId>:<panelId>` tab id, or
- *  undefined if not one. */
+/** Extract the `{packId, panelId, instanceKey}` from a pack tab id, or undefined
+ *  if not one. Legacy two-part `pack:<packId>:<panelId>` ids are accepted and
+ *  returned with instanceKey `default` for one-time migration compatibility. */
 export function packPanelRefFromTabId(id: string | null | undefined): PackPanelRef | undefined {
 	if (!id) return undefined;
 	const match = PACK_PANEL_ID_RE.exec(id);
 	if (!match) return undefined;
 	const packId = decodeTabComponent(match[1]);
 	const panelId = decodeTabComponent(match[2]);
-	return packId && panelId ? { packId, panelId } : undefined;
+	const decodedInstanceKey = match[3] == null ? DEFAULT_PACK_PANEL_INSTANCE_KEY : decodeTabComponent(match[3]);
+	return packId && panelId && decodedInstanceKey
+		? { packId, panelId, instanceKey: decodedInstanceKey, legacyTwoPart: match[3] == null || undefined }
+		: undefined;
 }
 
 function isPackPanelTabId(id: string): boolean {
@@ -514,8 +527,86 @@ export function isHistoricalProposalTab(tab: PanelWorkspaceTab | undefined | nul
 	return tab?.kind === "proposal" && proposalRevisionFromPanelTab(tab) != null;
 }
 
-export function reviewPanelTabId(title: string): string {
-	return `review:${encodeURIComponent(title)}`;
+const reviewDocumentIdsByTitle = new Map<string, string>();
+let reviewHashK: number[] | undefined;
+
+function sha256Hex(input: string): string {
+	const bytes = typeof TextEncoder !== "undefined"
+		? Array.from(new TextEncoder().encode(input))
+		: Array.from(unescape(encodeURIComponent(input)), (ch) => ch.charCodeAt(0));
+	const k = reviewHashK ||= (() => {
+		const out: number[] = [];
+		let n = 2;
+		while (out.length < 64) {
+			let prime = true;
+			for (let i = 2; i * i <= n; i++) if (n % i === 0) { prime = false; break; }
+			if (prime) out.push(Math.floor((Math.cbrt(n) % 1) * 0x100000000) >>> 0);
+			n++;
+		}
+		return out;
+	})();
+	const h = [0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19];
+	const bitLen = bytes.length * 8;
+	bytes.push(0x80);
+	while (bytes.length % 64 !== 56) bytes.push(0);
+	for (let i = 7; i >= 0; i--) bytes.push(Math.floor(bitLen / 2 ** (i * 8)) & 0xff);
+	const rotr = (x: number, n: number) => (x >>> n) | (x << (32 - n));
+	for (let i = 0; i < bytes.length; i += 64) {
+		const w = new Array<number>(64);
+		for (let j = 0; j < 16; j++) w[j] = ((bytes[i + j * 4] << 24) | (bytes[i + j * 4 + 1] << 16) | (bytes[i + j * 4 + 2] << 8) | bytes[i + j * 4 + 3]) >>> 0;
+		for (let j = 16; j < 64; j++) {
+			const s0 = rotr(w[j - 15], 7) ^ rotr(w[j - 15], 18) ^ (w[j - 15] >>> 3);
+			const s1 = rotr(w[j - 2], 17) ^ rotr(w[j - 2], 19) ^ (w[j - 2] >>> 10);
+			w[j] = (w[j - 16] + s0 + w[j - 7] + s1) >>> 0;
+		}
+		let [a, b, c, d, e, f, g, hh] = h;
+		for (let j = 0; j < 64; j++) {
+			const s1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+			const ch = (e & f) ^ (~e & g);
+			const temp1 = (hh + s1 + ch + k[j] + w[j]) >>> 0;
+			const s0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+			const maj = (a & b) ^ (a & c) ^ (b & c);
+			const temp2 = (s0 + maj) >>> 0;
+			hh = g; g = f; f = e; e = (d + temp1) >>> 0; d = c; c = b; b = a; a = (temp1 + temp2) >>> 0;
+		}
+		h[0] = (h[0] + a) >>> 0; h[1] = (h[1] + b) >>> 0; h[2] = (h[2] + c) >>> 0; h[3] = (h[3] + d) >>> 0;
+		h[4] = (h[4] + e) >>> 0; h[5] = (h[5] + f) >>> 0; h[6] = (h[6] + g) >>> 0; h[7] = (h[7] + hh) >>> 0;
+	}
+	return h.map((x) => x.toString(16).padStart(8, "0")).join("");
+}
+
+export function legacyReviewDocumentIdFromTitle(title: string): string {
+	return `legacy-title-${sha256Hex(title || "Review")}`;
+}
+
+export function rememberReviewDocumentIdentity(title: string, documentId: string): void {
+	if (!title || !documentId) return;
+	reviewDocumentIdsByTitle.set(title, documentId);
+}
+
+export function reviewDocumentIdForTitle(title: string): string {
+	return reviewDocumentIdsByTitle.get(title) || legacyReviewDocumentIdFromTitle(title);
+}
+
+function looksLikeReviewDocumentId(value: string): boolean {
+	return value.startsWith("review-doc:") || value.startsWith("legacy-title-");
+}
+
+export function reviewPanelTabId(documentIdOrTitle: string): string {
+	const documentId = looksLikeReviewDocumentId(documentIdOrTitle)
+		? documentIdOrTitle
+		: reviewDocumentIdForTitle(documentIdOrTitle);
+	return `review:${encodeURIComponent(documentId)}`;
+}
+
+export function reviewDocumentIdFromPanelTab(tab: PanelWorkspaceTab | undefined | null): string {
+	if (!tab) return "";
+	if (tab.source?.type === "review" && typeof tab.source.documentId === "string" && tab.source.documentId) return tab.source.documentId;
+	const encoded = tab.id.startsWith("review:") ? tab.id.slice("review:".length) : "";
+	if (encoded) {
+		try { return decodeURIComponent(encoded); } catch { return encoded; }
+	}
+	return "";
 }
 
 export function reviewTitleFromPanelTab(tab: PanelWorkspaceTab | undefined | null): string {
@@ -524,10 +615,8 @@ export function reviewTitleFromPanelTab(tab: PanelWorkspaceTab | undefined | nul
 		if (typeof tab.source.reviewTitle === "string") return tab.source.reviewTitle;
 		if (typeof tab.source.title === "string") return tab.source.title;
 	}
-	const encoded = tab.id.startsWith("review:") ? tab.id.slice("review:".length) : "";
-	if (encoded) {
-		try { return decodeURIComponent(encoded); } catch { return encoded; }
-	}
+	const decodedId = reviewDocumentIdFromPanelTab(tab);
+	if (decodedId && !looksLikeReviewDocumentId(decodedId)) return decodedId;
 	return tab.title.replace(/^Review:\s*/, "");
 }
 
@@ -612,13 +701,14 @@ export function buildPanelWorkspaceTabs(input: BuildPanelWorkspaceTabsInput): Pa
 
 	if (input.reviewPanelOpen) {
 		for (const title of input.reviewTitles) {
+			const documentId = reviewDocumentIdForTitle(title);
 			tabs.push({
-				id: reviewPanelTabId(title),
+				id: reviewPanelTabId(documentId),
 				kind: "review",
 				title: `Review: ${title}`,
 				label: `Review: ${title}`,
 				legacyTab: "review",
-				source: { type: "review", title, reviewTitle: title, sessionId: input.sessionId },
+				source: { type: "review", documentId, title, reviewTitle: title, sessionId: input.sessionId },
 			});
 		}
 	}
@@ -665,17 +755,24 @@ function canonicalPanelTab(rawTab: PanelWorkspaceTab, id: string): PanelWorkspac
 		};
 	}
 	if (kind === "review") {
+		const source = (rawTab.source || {}) as Record<string, unknown>;
 		const encoded = id.slice("review:".length);
-		let title = encoded;
-		try { title = decodeURIComponent(encoded); } catch { /* keep encoded */ }
+		let decoded = encoded;
+		try { decoded = decodeURIComponent(encoded); } catch { /* keep encoded */ }
+		const sourceTitle = typeof source.reviewTitle === "string" ? source.reviewTitle : typeof source.title === "string" ? source.title : undefined;
+		const documentId = typeof source.documentId === "string" && source.documentId
+			? source.documentId
+			: looksLikeReviewDocumentId(decoded) ? decoded : legacyReviewDocumentIdFromTitle(decoded);
+		const title = sourceTitle || (!looksLikeReviewDocumentId(decoded) ? decoded : rawTab.title.replace(/^Review:\s*/, "") || "Review");
+		if (title && documentId) rememberReviewDocumentIdentity(title, documentId);
 		return {
 			...rawTab,
-			id,
+			id: reviewPanelTabId(documentId),
 			kind: "review",
 			title: `Review: ${title}`,
 			label: `Review: ${title}`,
 			legacyTab: "review",
-			source: { ...(rawTab.source as Record<string, unknown>), type: "review", title, reviewTitle: title } as PanelWorkspaceTab["source"],
+			source: { ...source, type: "review", documentId, title, reviewTitle: title } as PanelWorkspaceTab["source"],
 		};
 	}
 	if (kind === "pack") {
@@ -688,16 +785,20 @@ function canonicalPanelTab(rawTab: PanelWorkspaceTab, id: string): PanelWorkspac
 		const panelId = ref?.panelId
 			|| (typeof source.panelId === "string" ? source.panelId : "")
 			|| (typeof tabState.panelId === "string" ? tabState.panelId : "");
+		const instanceKey = ref?.instanceKey
+			|| (typeof source.instanceKey === "string" ? source.instanceKey : "")
+			|| (typeof tabState.instanceKey === "string" ? tabState.instanceKey : "")
+			|| DEFAULT_PACK_PANEL_INSTANCE_KEY;
 		const title = rawTab.title || panelId || "Panel";
 		return {
 			...rawTab,
-			id,
+			id: packPanelTabId(packId, panelId, instanceKey),
 			kind: "pack",
 			title,
 			label: rawTab.label || title,
 			legacyTab: "pack",
-			source: { ...source, type: "pack", packId, panelId } as PanelWorkspaceTab["source"],
-			state: { ...tabState, packId, panelId },
+			source: { ...source, type: "pack", packId, panelId, instanceKey } as PanelWorkspaceTab["source"],
+			state: { ...tabState, packId, panelId, instanceKey },
 		};
 	}
 	return {
@@ -788,10 +889,10 @@ export function findPanelTab(tabs: PanelWorkspaceTab[], id: string | null | unde
 	const exact = tabs.find((tab) => tab.id === id && isSidePanelTabId(tab.id));
 	if (exact) return exact;
 	if (id.startsWith("review:")) {
-		const rawTitle = id.slice("review:".length);
-		let decodedTitle = rawTitle;
-		try { decodedTitle = decodeURIComponent(rawTitle); } catch { /* keep raw */ }
-		return tabs.find((tab) => tab.kind === "review" && reviewTitleFromPanelTab(tab) === decodedTitle);
+		const raw = id.slice("review:".length);
+		let decoded = raw;
+		try { decoded = decodeURIComponent(raw); } catch { /* keep raw */ }
+		return tabs.find((tab) => tab.kind === "review" && (reviewDocumentIdFromPanelTab(tab) === decoded || reviewTitleFromPanelTab(tab) === decoded));
 	}
 	return undefined;
 }

--- a/src/app/panel-workspace.ts
+++ b/src/app/panel-workspace.ts
@@ -105,18 +105,28 @@ export function isPreviewContentDismissed(sessionId: string | null | undefined, 
 
 export function loadPersistedPanelWorkspace(stateLike: any): void {
 	if (!stateLike || typeof stateLike !== "object") return;
-	const tabs = safeReadObject(PANEL_TABS_STORAGE_KEY);
-	if (tabs) stateLike.panelTabsBySession = tabs as Record<string, PanelWorkspaceTab[]>;
-	const active = safeReadObject(PANEL_ACTIVE_STORAGE_KEY);
-	if (active) stateLike.panelWorkspaceActiveBySession = active as Record<string, string>;
+	// Real app side-panel tabs/active state are server-authoritative. Legacy
+	// tab/active localStorage is read only by the one-shot migration path in
+	// side-panel-workspace.ts; keep file:// fixtures working without making the
+	// gateway UI resurrect closed tabs from old keys.
+	const isFileFixture = typeof window !== "undefined" && window.location?.protocol === "file:";
+	if (isFileFixture) {
+		const tabs = safeReadObject(PANEL_TABS_STORAGE_KEY);
+		if (tabs) stateLike.panelTabsBySession = tabs as Record<string, PanelWorkspaceTab[]>;
+		const active = safeReadObject(PANEL_ACTIVE_STORAGE_KEY);
+		if (active) stateLike.panelWorkspaceActiveBySession = active as Record<string, string>;
+	}
 	const versions = safeReadObject(PANEL_VERSIONS_STORAGE_KEY);
 	if (versions) stateLike.previewVersionsBySession = versions as Record<string, Record<string, PreviewVersionRecord>>;
 }
 
 function persistPanelWorkspace(stateLike: any): void {
 	if (!stateLike || typeof stateLike !== "object") return;
-	safeWriteObject(PANEL_TABS_STORAGE_KEY, stateLike.panelTabsBySession);
-	safeWriteObject(PANEL_ACTIVE_STORAGE_KEY, stateLike.panelWorkspaceActiveBySession);
+	const isFileFixture = typeof window !== "undefined" && window.location?.protocol === "file:";
+	if (isFileFixture) {
+		safeWriteObject(PANEL_TABS_STORAGE_KEY, stateLike.panelTabsBySession);
+		safeWriteObject(PANEL_ACTIVE_STORAGE_KEY, stateLike.panelWorkspaceActiveBySession);
+	}
 	safeWriteObject(PANEL_VERSIONS_STORAGE_KEY, stateLike.previewVersionsBySession);
 }
 
@@ -265,8 +275,8 @@ function panelTabKindFromId(id: string): PanelWorkspaceKind | undefined {
 	return undefined;
 }
 
-export function isPinnedPanelTab(tab: PanelWorkspaceTab | undefined | null): boolean {
-	return tab?.id === INBOX_PANEL_TAB_ID && tab.kind === "inbox";
+export function isPinnedPanelTab(_tab: PanelWorkspaceTab | undefined | null): boolean {
+	return false;
 }
 
 export function isLivePreviewTab(tab: PanelWorkspaceTab | undefined | null): boolean {
@@ -842,10 +852,7 @@ function mergeDerivedMetadata(stored: PanelWorkspaceTab, derived: PanelWorkspace
 }
 
 function pinnedFirst(tabs: PanelWorkspaceTab[]): PanelWorkspaceTab[] {
-	const pinned: PanelWorkspaceTab[] = [];
-	const unpinned: PanelWorkspaceTab[] = [];
-	for (const tab of tabs) (isPinnedPanelTab(tab) ? pinned : unpinned).push(tab);
-	return [...pinned, ...unpinned];
+	return tabs;
 }
 
 function shouldDropStoredTabAbsentFromDerived(tab: PanelWorkspaceTab, derivedById: Map<string, PanelWorkspaceTab>): boolean {
@@ -918,15 +925,12 @@ export function nextActivePanelTabId(tabs: PanelWorkspaceTab[], closedId: string
 }
 
 export function reorderSidePanelTab(tabs: PanelWorkspaceTab[], fromId: string, beforeIdOrIndex?: string | number | null): PanelWorkspaceTab[] {
-	const ordered = pinnedFirst(panelContentTabs(tabs));
+	const ordered = panelContentTabs(tabs);
 	const fromIndex = ordered.findIndex((tab) => tab.id === fromId);
 	if (fromIndex < 0) return ordered;
 	const moving = ordered[fromIndex];
-	if (isPinnedPanelTab(moving)) return ordered;
 
 	const without = ordered.filter((_, index) => index !== fromIndex);
-	const pinnedCount = without.findIndex((tab) => !isPinnedPanelTab(tab));
-	const minIndex = pinnedCount < 0 ? without.length : pinnedCount;
 	let insertIndex = without.length;
 	if (typeof beforeIdOrIndex === "number" && Number.isFinite(beforeIdOrIndex)) {
 		insertIndex = Math.trunc(beforeIdOrIndex);
@@ -934,9 +938,9 @@ export function reorderSidePanelTab(tabs: PanelWorkspaceTab[], fromId: string, b
 		const targetIndex = without.findIndex((tab) => tab.id === beforeIdOrIndex);
 		if (targetIndex >= 0) insertIndex = targetIndex;
 	}
-	insertIndex = Math.max(minIndex, Math.min(without.length, insertIndex));
+	insertIndex = Math.max(0, Math.min(without.length, insertIndex));
 	without.splice(insertIndex, 0, moving);
-	return pinnedFirst(without);
+	return without;
 }
 
 export function panelTabIdFromLegacy(tab: LegacyPanelTab | string | null | undefined, reviewActiveTitle: string): string | null {

--- a/src/app/panel-workspace.ts
+++ b/src/app/panel-workspace.ts
@@ -58,7 +58,6 @@ export const PANEL_WORKSPACE_NO_SESSION_KEY = "__no-session__";
 const PANEL_TABS_STORAGE_KEY = "bobbit-panel-tabs-by-session";
 const PANEL_ACTIVE_STORAGE_KEY = "bobbit-panel-active-by-session";
 const PANEL_VERSIONS_STORAGE_KEY = "bobbit-preview-versions-by-session";
-const PREVIEW_DISMISSED_STORAGE_KEY = "bobbit-preview-dismissed-by-session";
 
 function hasLocalStorage(): boolean {
 	try { return typeof localStorage !== "undefined"; } catch { return false; }
@@ -77,30 +76,6 @@ function safeReadObject(key: string): Record<string, unknown> | undefined {
 function safeWriteObject(key: string, value: unknown): void {
 	if (!hasLocalStorage()) return;
 	try { localStorage.setItem(key, JSON.stringify(value || {})); } catch { /* quota/SSR */ }
-}
-
-function previewDismissFingerprint(entry: string | undefined | null, contentHash: string | undefined | null): string {
-	const hash = normalizePreviewContentHash(contentHash);
-	return hash ? `${previewEntryLabel(entry)}\n${hash}` : "";
-}
-
-export function markPreviewContentDismissed(sessionId: string | null | undefined, entry: string | undefined | null, contentHash: string | undefined | null): void {
-	const sid = panelWorkspaceSessionKey(sessionId);
-	const fingerprint = previewDismissFingerprint(entry, contentHash);
-	if (!fingerprint) return;
-	const store = safeReadObject(PREVIEW_DISMISSED_STORAGE_KEY) ?? {};
-	const list = Array.isArray(store[sid]) ? store[sid].filter((value): value is string => typeof value === "string") : [];
-	if (!list.includes(fingerprint)) store[sid] = [...list, fingerprint].slice(-50);
-	safeWriteObject(PREVIEW_DISMISSED_STORAGE_KEY, store);
-}
-
-export function isPreviewContentDismissed(sessionId: string | null | undefined, entry: string | undefined | null, contentHash: string | undefined | null): boolean {
-	const sid = panelWorkspaceSessionKey(sessionId);
-	const fingerprint = previewDismissFingerprint(entry, contentHash);
-	if (!fingerprint) return false;
-	const store = safeReadObject(PREVIEW_DISMISSED_STORAGE_KEY);
-	const list = store && Array.isArray(store[sid]) ? store[sid] : [];
-	return list.includes(fingerprint);
 }
 
 export function loadPersistedPanelWorkspace(stateLike: any): void {
@@ -546,6 +521,7 @@ export function isHistoricalProposalTab(tab: PanelWorkspaceTab | undefined | nul
 }
 
 const reviewDocumentIdsByTitle = new Map<string, string>();
+const reviewDocumentTitlesById = new Map<string, string>();
 let reviewHashK: number[] | undefined;
 
 function sha256Hex(input: string): string {
@@ -600,6 +576,7 @@ export function legacyReviewDocumentIdFromTitle(title: string): string {
 export function rememberReviewDocumentIdentity(title: string, documentId: string): void {
 	if (!title || !documentId) return;
 	reviewDocumentIdsByTitle.set(title, documentId);
+	reviewDocumentTitlesById.set(documentId, title);
 }
 
 export function reviewDocumentIdForTitle(title: string): string {
@@ -607,7 +584,7 @@ export function reviewDocumentIdForTitle(title: string): string {
 }
 
 function looksLikeReviewDocumentId(value: string): boolean {
-	return value.startsWith("review-doc:") || value.startsWith("legacy-title-");
+	return value.startsWith("review-doc:") || value.startsWith("legacy-title-") || reviewDocumentTitlesById.has(value);
 }
 
 export function reviewPanelTabId(documentIdOrTitle: string): string {
@@ -718,8 +695,9 @@ export function buildPanelWorkspaceTabs(input: BuildPanelWorkspaceTabsInput): Pa
 	}
 
 	if (input.reviewPanelOpen) {
-		for (const title of input.reviewTitles) {
-			const documentId = reviewDocumentIdForTitle(title);
+		for (const titleOrDocumentId of input.reviewTitles) {
+			const documentId = looksLikeReviewDocumentId(titleOrDocumentId) ? titleOrDocumentId : reviewDocumentIdForTitle(titleOrDocumentId);
+			const title = reviewDocumentTitlesById.get(documentId) || titleOrDocumentId;
 			tabs.push({
 				id: reviewPanelTabId(documentId),
 				kind: "review",

--- a/src/app/panel-workspace.ts
+++ b/src/app/panel-workspace.ts
@@ -272,8 +272,16 @@ export function isPinnedPanelTab(tab: PanelWorkspaceTab | undefined | null): boo
 export function isLivePreviewTab(tab: PanelWorkspaceTab | undefined | null): boolean {
 	if (!tab || tab.kind !== "preview") return false;
 	if (tab.id === LIVE_PREVIEW_PANEL_TAB_ID || tab.id === LEGACY_LIVE_PREVIEW_PANEL_TAB_ID || tab.id.startsWith("preview:live")) return true;
-	if (isCurrentPreviewEntryTabId(tab.id) && !isHistoricalPreviewTab(tab)) return true;
 	const source = tab.source as Record<string, unknown> | undefined;
+	const tabState = tab.state as Record<string, unknown> | undefined;
+	const hasArtifact = typeof source?.artifactId === "string" && source.artifactId
+		|| typeof tabState?.artifactId === "string" && tabState.artifactId;
+	// Current filename tabs are "live" only while they have no immutable artifact
+	// backing. Once a preview_open artifact is attached, selecting the current tab
+	// should render that tab's own bytes directly instead of whatever another
+	// historical restore left in the single live mount slot.
+	if (isCurrentPreviewEntryTabId(tab.id) && !isHistoricalPreviewTab(tab)) return !hasArtifact;
+	if (hasArtifact) return false;
 	return source?.live === true || source?.origin === "preview-bootstrap" || source?.origin === "preview-events";
 }
 

--- a/src/app/panel-workspace.ts
+++ b/src/app/panel-workspace.ts
@@ -276,13 +276,13 @@ export function isLivePreviewTab(tab: PanelWorkspaceTab | undefined | null): boo
 	const tabState = tab.state as Record<string, unknown> | undefined;
 	const hasArtifact = typeof source?.artifactId === "string" && source.artifactId
 		|| typeof tabState?.artifactId === "string" && tabState.artifactId;
-	// Current filename tabs are "live" only while they have no immutable artifact
-	// backing. Once a preview_open artifact is attached, selecting the current tab
-	// should render that tab's own bytes directly instead of whatever another
-	// historical restore left in the single live mount slot.
-	if (isCurrentPreviewEntryTabId(tab.id) && !isHistoricalPreviewTab(tab)) return !hasArtifact;
+	const hasLiveSource = source?.live === true || source?.origin === "preview-bootstrap" || source?.origin === "preview-events";
+	// Current filename tabs are live when the preview event explicitly marks them
+	// live, even if the server also attached an immutable artifact for historical
+	// restore. Historical/versioned tabs keep using their artifact-backed URLs.
+	if (isCurrentPreviewEntryTabId(tab.id) && !isHistoricalPreviewTab(tab)) return hasLiveSource || !hasArtifact;
 	if (hasArtifact) return false;
-	return source?.live === true || source?.origin === "preview-bootstrap" || source?.origin === "preview-events";
+	return hasLiveSource;
 }
 
 export function normalizePreviewContentHash(value: unknown): string {

--- a/src/app/preview-panel.ts
+++ b/src/app/preview-panel.ts
@@ -401,25 +401,36 @@ export function selectProposalWorkspaceTab(type: string, options: PanelWorkspace
 
 export function selectReviewWorkspaceTab(title: string, options: PanelWorkspaceOptions = {}): void {
 	const sessionId = panelSessionId(options.sessionId);
+	const documentId = reviewDocumentIdForTitle(title);
 	selectPanelWorkspaceTab({
-		id: reviewPanelTabId(title),
+		id: reviewPanelTabId(documentId),
 		kind: "review",
 		title: `Review: ${title}`,
 		label: `Review: ${title}`,
 		legacyTab: "review",
-		source: { type: "review", title, reviewTitle: title, sessionId },
+		source: { type: "review", title, reviewTitle: title, documentId, sessionId },
 	}, { ...options, sessionId });
 }
 
 export function closeReviewWorkspaceTabs(titles?: string[], options: PanelWorkspaceOptions = {}): void {
 	const s = state as any;
 	const sessionId = panelSessionId(options.sessionId);
-	const existingTabs = panelTabsForSession(s, sessionId);
-	const ids = titles && titles.length > 0
-		? titles.map(reviewPanelTabId)
-		: existingTabs
-			.filter((tab: PanelWorkspaceTab) => tab?.kind === "review" || tab?.id?.startsWith("review:"))
-			.map((tab: PanelWorkspaceTab) => tab.id);
+	const titleSet = titles && titles.length > 0 ? new Set(titles) : null;
+	const allTabs: PanelWorkspaceTab[] = [
+		...panelTabsForSession(s, sessionId),
+		...(getSidePanelWorkspace(sessionId).tabs as unknown as PanelWorkspaceTab[]),
+	];
+	const ids = [...new Set(allTabs
+		.filter((tab: PanelWorkspaceTab) => {
+			if (!(tab?.kind === "review" || tab?.id?.startsWith("review:"))) return false;
+			if (!titleSet) return true;
+			const source = tab.source as Record<string, unknown> | undefined;
+			const tabTitle = typeof source?.reviewTitle === "string" ? source.reviewTitle
+				: typeof source?.title === "string" ? source.title
+				: tab.title.replace(/^Review:\s*/, "");
+			return titleSet.has(tabTitle);
+		})
+		.map((tab: PanelWorkspaceTab) => tab.id))];
 	if (ids.length > 0) removePanelWorkspaceTabs(ids, options);
 }
 

--- a/src/app/preview-panel.ts
+++ b/src/app/preview-panel.ts
@@ -4,7 +4,6 @@ import {
 	CHAT_PANEL_TAB_ID,
 	INBOX_PANEL_TAB_ID,
 	LIVE_PREVIEW_PANEL_TAB_ID,
-	activePanelTabIdForSession,
 	isHistoricalPreviewTab,
 	previewEntryLabel,
 	previewEntryTabId,
@@ -15,13 +14,19 @@ import {
 	panelTabsForSession,
 	previewContentHashFromTab,
 	proposalPanelTabId,
+	reviewDocumentIdForTitle,
 	reviewPanelTabId,
 	reviewTitleFromPanelTab,
-	setActivePanelTabIdForSession,
-	setPanelTabsForSession,
 	type LegacyPanelTab,
 	type PanelWorkspaceTab,
 } from "./panel-workspace.js";
+import {
+	closeSidePanelTab,
+	getSidePanelWorkspace,
+	openSidePanelTab,
+	updateSidePanelTab,
+	type SidePanelWorkspaceTab,
+} from "./side-panel-workspace.js";
 
 // WP-E: SSE subscription to per-session preview mount events.
 // The gateway watches <stateDir>/preview/<sid>/ and emits a `preview-changed`
@@ -58,17 +63,6 @@ function activeProposalRevForSession(type: string, sessionId: string): number | 
 	if (sessionId && typeof slot.sessionId === "string" && slot.sessionId && slot.sessionId !== sessionId) return undefined;
 	const rev = slot.rev;
 	return typeof rev === "number" && Number.isFinite(rev) && rev > 0 ? Math.trunc(rev) : undefined;
-}
-
-function mutablePanelTabs(s: any, sessionId: string): PanelWorkspaceTab[] {
-	return panelTabsForSession(s, sessionId);
-}
-
-function upsertPanelTabState(s: any, sessionId: string, tab: PanelWorkspaceTab): void {
-	const tabs = mutablePanelTabs(s, sessionId);
-	const idx = tabs.findIndex(t => t?.id === tab.id);
-	if (idx >= 0) tabs[idx] = { ...tabs[idx], ...tab };
-	else tabs.push(tab);
 }
 
 function applyLegacySelection(s: any, tab: PanelWorkspaceTab, options: PanelWorkspaceOptions): void {
@@ -110,11 +104,6 @@ function applyLegacySelection(s: any, tab: PanelWorkspaceTab, options: PanelWork
 	}
 }
 
-function clearCollapseKey(sessionId: string | undefined): void {
-	if (!sessionId) return;
-	try { localStorage.removeItem(`bobbit-preview-collapsed-${sessionId}`); } catch { /* ignore */ }
-}
-
 function emitPanelWorkspaceEvent(action: "select" | "close", detail: Record<string, unknown>): void {
 	try {
 		if (typeof window === "undefined" || typeof CustomEvent === "undefined") return;
@@ -124,45 +113,107 @@ function emitPanelWorkspaceEvent(action: "select" | "close", detail: Record<stri
 	} catch { /* ignore */ }
 }
 
-async function notifyOptionalPanelWorkspaceModule(action: "select" | "close", detail: Record<string, unknown>): Promise<void> {
-	try {
-		const spec = "./" + "panel-workspace.js";
-		const mod: any = await import(/* @vite-ignore */ spec);
-		const payload = { action, ...detail };
-		const fn = action === "close"
-			? mod.closePanelTab ?? mod.removePanelTab ?? mod.applyPanelWorkspaceSelection
-			: mod.selectPanelTab ?? mod.openPanelTab ?? mod.upsertPanelTab ?? mod.applyPanelWorkspaceSelection;
-		if (typeof fn === "function") await fn(payload);
-	} catch { /* optional integration point; absent until core workspace lands */ }
+function sidePanelTabFromLegacy(tab: PanelWorkspaceTab, sessionId: string): SidePanelWorkspaceTab | undefined {
+	const updatedAt = Date.now();
+	if (tab.kind === "preview") {
+		const source = tab.source as Record<string, unknown>;
+		const tabState = (tab.state || {}) as Record<string, unknown>;
+		const entry = previewEntryLabel(typeof tabState.entry === "string" ? tabState.entry : typeof source.entry === "string" ? source.entry : tab.title);
+		const version = typeof source.version === "number" ? source.version : typeof tabState.version === "number" ? tabState.version : undefined;
+		const contentHash = normalizePreviewContentHash(source.contentHash) || normalizePreviewContentHash(tabState.contentHash);
+		const historical = source.historical === true || tabState.historical === true || (typeof version === "number" && version > 0);
+		return {
+			id: tab.id,
+			kind: "preview",
+			title: tab.title,
+			label: tab.label,
+			source: {
+				type: "preview",
+				sessionId,
+				entry,
+				...(historical ? { historical: true } : { live: source.live === true }),
+				...(typeof version === "number" && version > 0 ? { version: Math.trunc(version) } : {}),
+				...(typeof source.artifactId === "string" ? { artifactId: source.artifactId } : {}),
+				...(contentHash ? { contentHash } : {}),
+				...(typeof source.path === "string" ? { path: source.path } : {}),
+				...(typeof source.url === "string" ? { url: source.url } : {}),
+				...(typeof source.toolUseId === "string" ? { toolUseId: source.toolUseId } : {}),
+				...(typeof source.blockIndex === "number" ? { blockIndex: source.blockIndex } : {}),
+			},
+			state: tab.state,
+			updatedAt,
+		};
+	}
+	if (tab.kind === "proposal" && tab.source.type === "proposal") {
+		const source = tab.source as Record<string, unknown>;
+		const proposalType = typeof source.proposalType === "string" ? source.proposalType : "goal";
+		const rev = typeof source.rev === "number" && Number.isFinite(source.rev) && source.rev > 0 ? Math.trunc(source.rev) : undefined;
+		return {
+			id: tab.id,
+			kind: "proposal",
+			title: tab.title,
+			label: tab.label,
+			source: { type: "proposal", sessionId, proposalType: proposalType as any, ...(rev ? { rev, historical: true } : {}) },
+			state: tab.state,
+			updatedAt,
+		};
+	}
+	if (tab.kind === "review") {
+		const title = reviewTitleFromPanelTab(tab) || tab.title.replace(/^Review:\s*/, "") || "Review";
+		const documentId = typeof (tab.source as any).documentId === "string" && (tab.source as any).documentId
+			? (tab.source as any).documentId
+			: reviewDocumentIdForTitle(title);
+		return {
+			id: reviewPanelTabId(documentId),
+			kind: "review",
+			title: `Review: ${title}`,
+			label: `Review: ${title}`,
+			source: { type: "review", sessionId, documentId, title },
+			state: tab.state,
+			updatedAt,
+		};
+	}
+	if (tab.kind === "inbox") {
+		return { id: INBOX_PANEL_TAB_ID, kind: "inbox", title: tab.title || "Inbox", label: tab.label || "Inbox", source: { type: "inbox", sessionId }, state: tab.state, updatedAt };
+	}
+	if (tab.kind === "pack" && tab.source.type === "pack") {
+		return {
+			id: tab.id,
+			kind: "pack",
+			title: tab.title,
+			label: tab.label,
+			source: { type: "pack", sessionId, packId: tab.source.packId, panelId: tab.source.panelId, instanceKey: tab.source.instanceKey || "default", singleton: tab.source.singleton, params: tab.source.params },
+			state: tab.state,
+			updatedAt,
+		};
+	}
+	return undefined;
+}
+
+function isSidePanelTabOpen(sessionId: string, tabId: string): boolean {
+	return getSidePanelWorkspace(sessionId).tabs.some((tab) => tab.id === tabId);
 }
 
 export function selectPanelWorkspaceTab(tab: PanelWorkspaceTab, options: PanelWorkspaceOptions = {}): void {
 	const s = state as any;
 	const sessionId = panelSessionId(options.sessionId);
-	upsertPanelTabState(s, sessionId, tab);
-	if (options.select !== false) {
-		setActivePanelTabIdForSession(s, sessionId, tab.id);
-	}
 	applyLegacySelection(s, tab, options);
-	if (options.clearCollapse !== false) clearCollapseKey(sessionId || undefined);
-	const detail = { tab, activeTabId: options.select === false ? activePanelTabIdForSession(s, sessionId) : tab.id, options };
-	emitPanelWorkspaceEvent("select", detail);
-	void notifyOptionalPanelWorkspaceModule("select", detail);
+	const sideTab = tab.kind === "chat" ? undefined : sidePanelTabFromLegacy(tab, sessionId);
+	if (sideTab) {
+		if (options.select === false) {
+			if (isSidePanelTabOpen(sessionId, sideTab.id)) void updateSidePanelTab(sideTab.id, sideTab, { sessionId });
+		} else {
+			void openSidePanelTab(sideTab, { focus: true });
+		}
+	}
+	const activeTabId = options.select === false ? getSidePanelWorkspace(sessionId).activeTabId : tab.id;
+	emitPanelWorkspaceEvent("select", { tab, activeTabId, options });
 }
 
 export function removePanelWorkspaceTabs(ids: string[], options: PanelWorkspaceOptions = {}): void {
-	const s = state as any;
 	const sessionId = panelSessionId(options.sessionId);
-	const idSet = new Set(ids);
-	const tabs = panelTabsForSession(s, sessionId);
-	const kept = tabs.filter((tab: PanelWorkspaceTab) => !idSet.has(tab.id));
-	setPanelTabsForSession(s, sessionId, kept);
-	if (s.panelWorkspace && typeof s.panelWorkspace === "object" && Array.isArray(s.panelWorkspace.tabs)) {
-		s.panelWorkspace.tabs = kept;
-	}
-	const detail = { tabIds: ids, options };
-	emitPanelWorkspaceEvent("close", detail);
-	void notifyOptionalPanelWorkspaceModule("close", detail);
+	for (const id of ids) void closeSidePanelTab(id, { sessionId });
+	emitPanelWorkspaceEvent("close", { tabIds: ids, options });
 }
 
 export function selectHtmlPreviewTab(args: {
@@ -291,16 +342,16 @@ export function selectHtmlPreviewTab(args: {
 		state: tabState,
 	};
 	if (!isVersionedHistorical && args.select !== false) {
-		for (let i = 0; i < existingTabs.length; i++) {
-			const candidate = existingTabs[i];
+		for (const candidate of existingTabs) {
 			if (candidate.kind !== "preview" || candidate.id === tab.id) continue;
 			const candidateSource = { ...candidate.source as Record<string, unknown> };
 			if (candidateSource.live === true) {
 				delete candidateSource.live;
-				existingTabs[i] = { ...candidate, source: candidateSource as PanelWorkspaceTab["source"] };
+				const next = { ...candidate, source: candidateSource as PanelWorkspaceTab["source"] };
+				const sideTab = sidePanelTabFromLegacy(next, sessionId);
+				if (sideTab && isSidePanelTabOpen(sessionId, sideTab.id)) void updateSidePanelTab(sideTab.id, sideTab, { sessionId, skipRender: true });
 			}
 		}
-		setPanelTabsForSession(s, sessionId, existingTabs);
 	}
 	selectPanelWorkspaceTab(tab, {
 		sessionId,
@@ -362,35 +413,12 @@ export function closeReviewWorkspaceTabs(titles?: string[], options: PanelWorksp
 }
 
 export function selectSensiblePanelWorkspaceTab(options: PanelWorkspaceOptions = {}): void {
-	const s = state as any;
 	const sessionId = options.sessionId || activeSessionId() || "";
-	if (s.reviewPanelOpen && s.reviewDocuments instanceof Map && s.reviewDocuments.size > 0) {
-		const title = s.reviewActiveTab || [...s.reviewDocuments.keys()][0];
-		if (title) {
-			selectReviewWorkspaceTab(title, { ...options, sessionId });
-			return;
-		}
-	}
-	if (s.isPreviewSession) {
-		selectHtmlPreviewTab({
-			sessionId,
-			entry: s.previewPanelEntry || "index.html",
-			mtime: s.previewPanelMtime,
-			contentHash: s.previewPanelContentHash,
-			id: LIVE_PREVIEW_PANEL_TAB_ID,
-			select: options.select,
-			setAssistantTab: options.setAssistantTab,
-		});
-		return;
-	}
-	for (const type of ["goal", "project", "role", "tool", "staff"]) {
-		if (s.activeProposals?.[type]) {
-			selectProposalWorkspaceTab(type, { ...options, sessionId });
-			return;
-		}
-	}
-	if (s.inboxPanelOpen || (Array.isArray(s.inboxEntries) && s.inboxEntries.length > 0)) {
-		selectPanelWorkspaceTab({ id: INBOX_PANEL_TAB_ID, kind: "inbox", title: "Inbox", label: "Inbox", legacyTab: "inbox", source: { type: "inbox", sessionId } }, { ...options, sessionId });
+	const workspace = getSidePanelWorkspace(sessionId);
+	const existing = workspace.tabs.find((tab) => tab.id === workspace.activeTabId) || workspace.tabs[0];
+	const legacy = existing ? panelTabsForSession(state, sessionId).find((tab) => tab.id === existing.id) : undefined;
+	if (legacy) {
+		selectPanelWorkspaceTab(legacy, { ...options, sessionId });
 		return;
 	}
 	selectPanelWorkspaceTab({ id: CHAT_PANEL_TAB_ID, kind: "chat", title: "Chat", label: "Chat", legacyTab: "chat", source: { type: "chat", sessionId } }, { ...options, sessionId, clearCollapse: false });
@@ -436,7 +464,7 @@ export function startPreviewSubscription(sessionId: string): void {
 					id: LIVE_PREVIEW_PANEL_TAB_ID,
 					source: { live: true, origin: "preview-bootstrap", ...(artifactId ? { artifactId } : {}) },
 					state: artifactId ? { artifactId } : undefined,
-					select: state.previewPanelTab === "preview" || state.previewPanelActiveTab === "preview",
+					select: false,
 				});
 			}
 			renderApp();
@@ -474,7 +502,8 @@ export function startPreviewSubscription(sessionId: string): void {
 						id: LIVE_PREVIEW_PANEL_TAB_ID,
 						source: { live: true, origin: "preview-events", ...(artifactId ? { artifactId } : {}) },
 						state: artifactId ? { artifactId } : undefined,
-						select: activeSessionId() === sessionId,
+						select: false,
+						setAssistantTab: false,
 					});
 				}
 				renderApp();

--- a/src/app/preview-panel.ts
+++ b/src/app/preview-panel.ts
@@ -12,11 +12,10 @@ import {
 	previewVersionRecordFor,
 	previewVersionedTabId,
 	normalizePreviewContentHash,
-	isPreviewContentDismissed,
 	panelTabsForSession,
 	previewContentHashFromTab,
 	proposalPanelTabId,
-	assistantProposalType,
+	reviewDocumentIdFromPanelTab,
 	reviewDocumentIdForTitle,
 	reviewPanelTabId,
 	reviewTitleFromPanelTab,
@@ -43,6 +42,7 @@ type PanelWorkspaceOptions = {
 	clearCollapse?: boolean;
 	rev?: number;
 	fields?: Record<string, unknown>;
+	documentId?: string;
 };
 
 const PROPOSAL_LABELS: Record<string, string> = {
@@ -93,9 +93,10 @@ function applyLegacySelection(s: any, tab: PanelWorkspaceTab, options: PanelWork
 		return;
 	}
 	if (tab.kind === "review") {
+		const documentId = reviewDocumentIdFromPanelTab(tab);
 		const title = reviewTitleFromPanelTab(tab);
 		s.reviewPanelOpen = true;
-		s.reviewActiveTab = title;
+		s.reviewActiveTab = documentId && state.reviewDocuments.has(documentId) ? documentId : title || documentId;
 		s.previewPanelActiveTab = "review";
 		s.previewPanelTab = "review";
 		if (s.assistantType && setAssistantTab) s.assistantTab = "preview";
@@ -378,8 +379,7 @@ export function selectProposalWorkspaceTab(type: string, options: PanelWorkspace
 		: undefined;
 	const activeRev = requestedRev != null ? activeProposalRevForSession(type, sessionId) : undefined;
 	const rev = activeRev === requestedRev ? undefined : requestedRev;
-	const isCurrentAssistantProposal = type === assistantProposalType(state.assistantType);
-	if (rev == null && !hasCurrentProposalSlotForSession(state as any, type, sessionId) && !isCurrentAssistantProposal) {
+	if (rev == null && !hasCurrentProposalSlotForSession(state as any, type, sessionId)) {
 		removePanelWorkspaceTabs([proposalPanelTabId(type)], { sessionId, select: false, clearCollapse: false });
 		return;
 	}
@@ -401,7 +401,7 @@ export function selectProposalWorkspaceTab(type: string, options: PanelWorkspace
 
 export function selectReviewWorkspaceTab(title: string, options: PanelWorkspaceOptions = {}): void {
 	const sessionId = panelSessionId(options.sessionId);
-	const documentId = reviewDocumentIdForTitle(title);
+	const documentId = options.documentId || reviewDocumentIdForTitle(title);
 	selectPanelWorkspaceTab({
 		id: reviewPanelTabId(documentId),
 		kind: "review",
@@ -477,7 +477,7 @@ export function startPreviewSubscription(sessionId: string): void {
 			}
 			contentHash = normalizePreviewContentHash(data?.contentHash);
 			(state as any).previewPanelContentHash = contentHash;
-			if (entry && !isPreviewContentDismissed(sessionId, entry, contentHash)) {
+			if (entry) {
 				selectHtmlPreviewTab({
 					sessionId,
 					entry,
@@ -515,7 +515,7 @@ export function startPreviewSubscription(sessionId: string): void {
 				const contentHash = normalizePreviewContentHash(data?.contentHash);
 				const artifactId = typeof data?.artifactId === "string" && data.artifactId ? data.artifactId : undefined;
 				(state as any).previewPanelContentHash = contentHash;
-				if (entry && !isPreviewContentDismissed(sessionId, entry, contentHash)) {
+				if (entry) {
 					selectHtmlPreviewTab({
 						sessionId,
 						entry,
@@ -524,7 +524,7 @@ export function startPreviewSubscription(sessionId: string): void {
 						id: LIVE_PREVIEW_PANEL_TAB_ID,
 						source: { live: true, origin: "preview-events", ...(artifactId ? { artifactId } : {}) },
 						state: artifactId ? { artifactId } : undefined,
-						select: true,
+						select: false,
 						setAssistantTab: false,
 					});
 				}

--- a/src/app/preview-panel.ts
+++ b/src/app/preview-panel.ts
@@ -8,7 +8,9 @@ import {
 	previewEntryLabel,
 	previewEntryTabId,
 	previewTabIdentityForContent,
+	previewTabVersionFromId,
 	previewVersionRecordFor,
+	previewVersionedTabId,
 	normalizePreviewContentHash,
 	isPreviewContentDismissed,
 	panelTabsForSession,
@@ -119,11 +121,14 @@ function sidePanelTabFromLegacy(tab: PanelWorkspaceTab, sessionId: string): Side
 		const source = tab.source as Record<string, unknown>;
 		const tabState = (tab.state || {}) as Record<string, unknown>;
 		const entry = previewEntryLabel(typeof tabState.entry === "string" ? tabState.entry : typeof source.entry === "string" ? source.entry : tab.title);
-		const version = typeof source.version === "number" ? source.version : typeof tabState.version === "number" ? tabState.version : undefined;
+		const idVersion = previewTabVersionFromId(tab.id);
+		const rawVersion = typeof source.version === "number" ? source.version : typeof tabState.version === "number" ? tabState.version : undefined;
+		const version = idVersion ?? ((source.historical === true || tabState.historical === true) ? rawVersion : undefined);
 		const contentHash = normalizePreviewContentHash(source.contentHash) || normalizePreviewContentHash(tabState.contentHash);
-		const historical = source.historical === true || tabState.historical === true || (typeof version === "number" && version > 0);
+		const historical = source.historical === true || tabState.historical === true || idVersion != null;
+		const id = historical && typeof version === "number" && version > 0 ? previewVersionedTabId(entry, version) : tab.id;
 		return {
-			id: tab.id,
+			id,
 			kind: "preview",
 			title: tab.title,
 			label: tab.label,
@@ -278,7 +283,7 @@ export function selectHtmlPreviewTab(args: {
 	const isLiveEvent = (args.source as Record<string, unknown> | undefined)?.live === true
 		|| (args.source as Record<string, unknown> | undefined)?.origin === "preview-events"
 		|| (args.source as Record<string, unknown> | undefined)?.origin === "preview-bootstrap";
-	if (isLiveEvent && !requestedHistorical && contentHash && currentFilenameTab) {
+	if (isLiveEvent && !requestedHistorical && contentHash) {
 		const record = previewVersionRecordFor(s, sessionId, entry);
 		const latestVersion = record?.latestVersion ?? 0;
 		const hashVersion = record?.hashToVersion?.[contentHash];
@@ -316,9 +321,12 @@ export function selectHtmlPreviewTab(args: {
 		source.contentHash = contentHash;
 		tabState.contentHash = contentHash;
 	}
-	if (version != null) {
+	if (isVersionedHistorical && version != null) {
 		source.version = version;
 		tabState.version = version;
+	} else {
+		delete source.version;
+		delete tabState.version;
 	}
 	if (isVersionedHistorical) {
 		source.historical = true;

--- a/src/app/preview-panel.ts
+++ b/src/app/preview-panel.ts
@@ -16,6 +16,7 @@ import {
 	panelTabsForSession,
 	previewContentHashFromTab,
 	proposalPanelTabId,
+	assistantProposalType,
 	reviewDocumentIdForTitle,
 	reviewPanelTabId,
 	reviewTitleFromPanelTab,
@@ -377,7 +378,8 @@ export function selectProposalWorkspaceTab(type: string, options: PanelWorkspace
 		: undefined;
 	const activeRev = requestedRev != null ? activeProposalRevForSession(type, sessionId) : undefined;
 	const rev = activeRev === requestedRev ? undefined : requestedRev;
-	if (rev == null && !hasCurrentProposalSlotForSession(state as any, type, sessionId)) {
+	const isCurrentAssistantProposal = type === assistantProposalType(state.assistantType);
+	if (rev == null && !hasCurrentProposalSlotForSession(state as any, type, sessionId) && !isCurrentAssistantProposal) {
 		removePanelWorkspaceTabs([proposalPanelTabId(type)], { sessionId, select: false, clearCollapse: false });
 		return;
 	}

--- a/src/app/preview-panel.ts
+++ b/src/app/preview-panel.ts
@@ -321,8 +321,9 @@ export function selectHtmlPreviewTab(args: {
 		source.contentHash = contentHash;
 		tabState.contentHash = contentHash;
 	}
-	if (isVersionedHistorical && version != null) {
-		source.version = version;
+	if (version != null) {
+		if (isVersionedHistorical) source.version = version;
+		else delete source.version;
 		tabState.version = version;
 	} else {
 		delete source.version;

--- a/src/app/preview-panel.ts
+++ b/src/app/preview-panel.ts
@@ -502,7 +502,7 @@ export function startPreviewSubscription(sessionId: string): void {
 						id: LIVE_PREVIEW_PANEL_TAB_ID,
 						source: { live: true, origin: "preview-events", ...(artifactId ? { artifactId } : {}) },
 						state: artifactId ? { artifactId } : undefined,
-						select: false,
+						select: true,
 						setAssistantTab: false,
 					});
 				}

--- a/src/app/proposal-panels.ts
+++ b/src/app/proposal-panels.ts
@@ -7,12 +7,6 @@
 // shared `renderGoalForm` builder live here. Loaded on first proposal-panel
 // view via `proposal-panels-lazy.ts`.
 //
-// IMPORTANT: this module pulls in render.ts via the three workspace helpers
-// below (`unifiedPanelTabs`, `setUnifiedActiveTab`, `workspaceSessionId`).
-// That's only safe because this module is itself dynamic-imported — render.ts
-// never statically references this file. Don't add a static import from
-// render.ts to here or you'll re-bloat the entry chunk.
-
 import { html, nothing, type TemplateResult } from "lit";
 import { ref, createRef } from "lit/directives/ref.js";
 import { icon } from "@mariozechner/mini-lit";
@@ -71,24 +65,18 @@ import { cwdCombobox } from "./cwd-combobox.js";
 import { ACCESSORY_IDS, getAccessory, statusBobbit } from "./session-colors.js";
 import { reloadStaffList } from "./sidebar.js";
 import {
-	activeSidePanelTabIdForSession,
-	findPanelTab,
 	isHistoricalProposalTab,
 	proposalPanelTabId,
 	proposalRevisionFromPanelTab,
-	setActivePanelTabIdForSession,
 	type PanelWorkspaceTab,
 } from "./panel-workspace.js";
+import { closeSidePanelTab } from "./side-panel-workspace.js";
 import "../ui/components/CommentableMarkdown.js";
 import type {
 	ViewMode as ProjectViewMode,
 	ProposalComponent,
 	ProposalWorkflow,
 } from "./project-proposal-views.js";
-// Workspace helpers that still live in render.ts. Importing them back is safe
-// because proposal-panels.ts is itself only dynamic-imported from render.ts —
-// the static graph never resolves this edge.
-import { unifiedPanelTabs, setUnifiedActiveTab, workspaceSessionId } from "./render.js";
 // Triggers editor (lazy). Only the `TriggerDef` type is needed here; the
 // runtime module is dynamic-imported below.
 import type { TriggerDef as _TriggerDef } from "./render-triggers.js";
@@ -406,15 +394,9 @@ function clearProposalReviewState(sessionId: string | null | undefined, type: Pr
 	}
 }
 
-function clampUnifiedTabsAfterProposalRemoved(type: ProposalType): void {
-	const tabs = unifiedPanelTabs();
-	const removedId = proposalPanelTabId(type);
-	const activeId = activeSidePanelTabIdForSession(state, workspaceSessionId());
-	if (activeId === removedId || !findPanelTab(tabs, activeId)) {
-		const fallback = tabs[0];
-		if (fallback) setUnifiedActiveTab(fallback);
-		else setActivePanelTabIdForSession(state, workspaceSessionId(), "");
-	}
+function closeCurrentProposalPanel(type: ProposalType, sessionId: string | null | undefined): void {
+	if (!sessionId) return;
+	void closeSidePanelTab(proposalPanelTabId(type), { sessionId });
 }
 
 function dismissTypedProposal(type: ProposalType): void {
@@ -430,7 +412,7 @@ function dismissTypedProposal(type: ProposalType): void {
 	if (sessionId && slot?.fields) markProposalDismissed(sessionId, type, slot.fields);
 	delete state.activeProposals[type];
 	recomputeAssistantHasProposal();
-	clampUnifiedTabsAfterProposalRemoved(type);
+	closeCurrentProposalPanel(type, sessionId);
 	if (sessionId) void deleteProposalFile(sessionId, type);
 	renderApp();
 }
@@ -1601,7 +1583,7 @@ function rolePreviewPanel() {
 		clearProposalReviewState(proposalSessionId, "role");
 		delete state.activeProposals.role;
 		recomputeAssistantHasProposal();
-		clampUnifiedTabsAfterProposalRemoved("role");
+		closeCurrentProposalPanel("role", proposalSessionId);
 		if (proposalSessionId) {
 			deleteRoleDraft(proposalSessionId);
 			void deleteProposalFile(proposalSessionId, "role");
@@ -2070,7 +2052,7 @@ function staffPreviewPanel() {
 			clearProposalReviewState(proposalSessionId, "staff");
 			delete state.activeProposals.staff;
 			recomputeAssistantHasProposal();
-			clampUnifiedTabsAfterProposalRemoved("staff");
+			closeCurrentProposalPanel("staff", proposalSessionId);
 			if (proposalSessionId) void deleteProposalFile(proposalSessionId, "staff");
 
 			if (isStaffAssistant) {

--- a/src/app/proposal-panels.ts
+++ b/src/app/proposal-panels.ts
@@ -65,6 +65,7 @@ import { cwdCombobox } from "./cwd-combobox.js";
 import { ACCESSORY_IDS, getAccessory, statusBobbit } from "./session-colors.js";
 import { reloadStaffList } from "./sidebar.js";
 import {
+	assistantProposalType,
 	isHistoricalProposalTab,
 	proposalPanelTabId,
 	proposalRevisionFromPanelTab,
@@ -412,7 +413,8 @@ function dismissTypedProposal(type: ProposalType): void {
 	if (sessionId && slot?.fields) markProposalDismissed(sessionId, type, slot.fields);
 	delete state.activeProposals[type];
 	recomputeAssistantHasProposal();
-	closeCurrentProposalPanel(type, sessionId);
+	const keepAssistantPanelOpen = type === assistantProposalType(state.assistantType);
+	if (!keepAssistantPanelOpen) closeCurrentProposalPanel(type, sessionId);
 	if (sessionId) void deleteProposalFile(sessionId, type);
 	renderApp();
 }

--- a/src/app/proposal-registry.ts
+++ b/src/app/proposal-registry.ts
@@ -142,6 +142,12 @@ const PROPOSAL_TAB_LABELS: Record<ProposalType, string> = {
 
 function dropCurrentProposalWorkspaceTab(type: ProposalType, sessionId: string): void {
 	const id = proposalPanelTabId(type);
+	const s = getState();
+	if (s?.panelTabsBySession && Array.isArray(s.panelTabsBySession[sessionId])) {
+		s.panelTabsBySession[sessionId] = s.panelTabsBySession[sessionId].filter((tab: { id?: string }) => tab?.id !== id);
+	}
+	if (s?.panelWorkspaceActiveBySession?.[sessionId] === id) s.panelWorkspaceActiveBySession[sessionId] = "";
+	if (s?.activePanelTabId === id) s.activePanelTabId = "";
 	void import("./side-panel-workspace.js")
 		.then((mod) => mod.closeSidePanelTab(id, { sessionId }))
 		.catch(() => { /* optional browser-only integration */ });

--- a/src/app/proposal-registry.ts
+++ b/src/app/proposal-registry.ts
@@ -10,7 +10,7 @@
  * unused for Slice E and reserved for future work.
  */
 
-import { activePanelTabIdForSession, panelTabsForSession, proposalPanelTabId, setActivePanelTabIdForSession, setPanelTabsForSession, type PanelWorkspaceTab } from "./panel-workspace.js";
+import { proposalPanelTabId } from "./panel-workspace.js";
 
 // NOTE: We do NOT import `./state.js` at module load — state.ts touches
 // `localStorage` at module init which would break node-only unit tests of
@@ -125,14 +125,6 @@ function goalMerge(
 
 // ---- onFirstEmit lifters ----
 
-function clearCollapseKey(sessionId: string): void {
-	try {
-		if (typeof localStorage !== "undefined") {
-			localStorage.removeItem(`bobbit-preview-collapsed-${sessionId}`);
-		}
-	} catch { /* ignore */ }
-}
-
 /** Lazily resolve the mutable state singleton at call time so this module's
  *  load-time graph stays node-safe. */
 function getState(): any {
@@ -148,35 +140,30 @@ const PROPOSAL_TAB_LABELS: Record<ProposalType, string> = {
 	staff: "Staff Proposal",
 };
 
-function dropCurrentProposalWorkspaceTab(s: any, type: ProposalType, sessionId: string): void {
+function dropCurrentProposalWorkspaceTab(type: ProposalType, sessionId: string): void {
 	const id = proposalPanelTabId(type);
-	const tabs = panelTabsForSession(s, sessionId);
-	if (!tabs.some((tab: any) => tab?.id === id)) return;
-	setPanelTabsForSession(s, sessionId, tabs.filter((tab: any) => tab?.id !== id));
-	if (activePanelTabIdForSession(s, sessionId) === id) {
-		setActivePanelTabIdForSession(s, sessionId, "");
-	}
+	void import("./side-panel-workspace.js")
+		.then((mod) => mod.closeSidePanelTab(id, { sessionId }))
+		.catch(() => { /* optional browser-only integration */ });
 }
 
-function upsertProposalWorkspaceTab(type: ProposalType, sessionId: string): boolean {
+function openCurrentProposalWorkspaceTab(type: ProposalType, sessionId: string): boolean {
 	const s = getState();
 	if (!hasCurrentProposalSlotForSession(s, type, sessionId)) {
-		dropCurrentProposalWorkspaceTab(s, type, sessionId);
+		dropCurrentProposalWorkspaceTab(type, sessionId);
 		return false;
 	}
-	const tab: PanelWorkspaceTab = {
+	const tab = {
 		id: proposalPanelTabId(type),
-		kind: "proposal",
+		kind: "proposal" as const,
 		title: PROPOSAL_TAB_LABELS[type],
 		label: PROPOSAL_TAB_LABELS[type].replace(/ Proposal$/, ""),
-		legacyTab: type,
-		source: { type: "proposal", proposalType: type, sessionId },
+		source: { type: "proposal" as const, proposalType: type, sessionId },
+		updatedAt: Date.now(),
 	};
-	const tabs = panelTabsForSession(s, sessionId);
-	const idx = tabs.findIndex((t: any) => t?.id === tab.id);
-	if (idx >= 0) tabs[idx] = { ...tabs[idx], ...tab };
-	else tabs.push(tab);
-	setActivePanelTabIdForSession(s, sessionId, tab.id);
+	void import("./side-panel-workspace.js")
+		.then((mod) => mod.openSidePanelTab(tab, { focus: true }))
+		.catch(() => { /* optional browser-only integration */ });
 	try {
 		if (typeof window !== "undefined" && typeof CustomEvent !== "undefined") {
 			window.dispatchEvent(new CustomEvent("bobbit-panel-workspace:select", { detail: { action: "select", tab, activeTabId: tab.id } }));
@@ -186,10 +173,9 @@ function upsertProposalWorkspaceTab(type: ProposalType, sessionId: string): bool
 }
 
 function selectProposalWorkspaceTab(type: ProposalType, sessionId: string, setAssistantTab: boolean): void {
-	if (!upsertProposalWorkspaceTab(type, sessionId)) return;
-	void import("./preview-panel.js")
-		.then((mod: any) => mod.selectProposalWorkspaceTab?.(type, { sessionId, select: true, setAssistantTab }))
-		.catch(() => { /* optional browser-only integration */ });
+	if (!openCurrentProposalWorkspaceTab(type, sessionId)) return;
+	const s = getState();
+	if (setAssistantTab && s.assistantType) s.assistantTab = "preview";
 }
 
 /**
@@ -209,7 +195,6 @@ export function revealProposalPanel(type: ProposalType, slot: Pick<ProposalSlot,
 	s.previewPanelActiveTab = type;
 	s.previewPanelTab = type;
 	selectProposalWorkspaceTab(type, slot.sessionId, !opts.isAssistant || opts.isMobile);
-	clearCollapseKey(slot.sessionId);
 }
 
 function proposalFirstEmit(type: ProposalType): ProposalTypePlugin["onFirstEmit"] {

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -36,7 +36,7 @@ import { clearPersistedReviewDocuments, openMarkdownReviewDocument, removePersis
 import { showFaviconBadge } from "./favicon-badge.js";
 import { needsHumanAttentionOnIdleTransition, needsImmediateHumanAttention } from "./notification-policy.js";
 import { scheduleGateStatusRefreshForGoal, refreshSessions, scheduleSessionListRefreshFromPush } from "./api.js";
-import { applySidePanelWorkspaceFromServer, hydrateSidePanelWorkspace } from "./side-panel-workspace.js";
+import { applySidePanelWorkspaceFromServer, getSidePanelWorkspace, hydrateSidePanelWorkspace } from "./side-panel-workspace.js";
 import { shouldRefreshGateStatusForEvent } from "./gate-status-events.js";
 import { publishClientMessage, publishClientStatus } from "./session-event-bus.js";
 import { registerSessionPoster, unregisterSessionPoster, type SessionPostRequest } from "./session-write-bridge.js";
@@ -1629,6 +1629,8 @@ export class RemoteAgent {
 						for (const m of this._state.messages) {
 							this._checkReviewToolResult(m);
 						}
+					} else {
+						closeReviewWorkspaceTabs(undefined, { sessionId: this._sessionId || "", select: false });
 					}
 					restorePersistedReviewDocuments(this._sessionId || "", { select: true });
 					// Re-add compacting placeholder if compaction is still in progress
@@ -2257,6 +2259,16 @@ export class RemoteAgent {
 			try { data = JSON.parse(trimmed); } catch { continue; }
 
 			if (data.action === "review_open" && data.title && data.markdown) {
+				if (this._sessionId) {
+					const title = String(data.title);
+					const hasOpenWorkspaceTab = getSidePanelWorkspace(this._sessionId).tabs.some((tab) => {
+						if (tab.kind !== "review") return false;
+						const source = tab.source as Record<string, unknown> | undefined;
+						const tabTitle = typeof source?.title === "string" ? source.title : tab.title.replace(/^Review:\s*/, "");
+						return tabTitle === title;
+					});
+					if (!hasOpenWorkspaceTab && (!isLive || isReviewSubmitted(this._sessionId))) return;
+				}
 				// If the user already submitted this review, suppress reopening it on
 				// REPLAY paths (snapshot loop / non-live message_end). The submitted
 				// flag is per-session and persisted server-side; without this gate, a

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -36,6 +36,7 @@ import { clearPersistedReviewDocuments, openMarkdownReviewDocument, removePersis
 import { showFaviconBadge } from "./favicon-badge.js";
 import { needsHumanAttentionOnIdleTransition, needsImmediateHumanAttention } from "./notification-policy.js";
 import { scheduleGateStatusRefreshForGoal, refreshSessions, scheduleSessionListRefreshFromPush } from "./api.js";
+import { applySidePanelWorkspaceFromServer, hydrateSidePanelWorkspace } from "./side-panel-workspace.js";
 import { shouldRefreshGateStatusForEvent } from "./gate-status-events.js";
 import { publishClientMessage, publishClientStatus } from "./session-event-bus.js";
 import { registerSessionPoster, unregisterSessionPoster, type SessionPostRequest } from "./session-write-bridge.js";
@@ -756,6 +757,7 @@ export class RemoteAgent {
 						this._reconnectAttempt = 0;
 						this._setConnectionStatus("connected");
 						resolve();
+						void hydrateSidePanelWorkspace(this._sessionId);
 						// S2: deliver any prompts/steers/retries the user issued while
 						// the socket was reconnecting, before resume/snapshot traffic.
 						this._flushOutbox();
@@ -1780,6 +1782,10 @@ export class RemoteAgent {
 				// Merge any pending-unsent outbox rows so a server queue update
 				// doesn't visually drop them before they flush (S2).
 				this.onQueueUpdate?.(this.getQueue());
+				break;
+
+			case "side_panel_workspace":
+				if ((msg as any).workspace) applySidePanelWorkspaceFromServer((msg as any).workspace, { source: "ws" });
 				break;
 
 			case "goal_setup_complete":

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -1063,10 +1063,10 @@ function restoreHistoricalPreviewTab(tab: PanelWorkspaceTab): void {
 		restoreUrl = `/api/preview/artifacts/${encodeURIComponent(artifactId)}/restore?sessionId=${encodeURIComponent(sessionId)}`;
 		body = { artifactId };
 	} else if (snapshotKind === "inline" && snapshotHtml) {
-		body = { html: snapshotHtml };
+		body = { html: snapshotHtml, workspaceTab: false, internalRestore: true };
 		if (entry && !entry.includes("/") && !entry.includes("\\")) body.entry = entry;
 	} else if (snapshotKind === "file" && snapshotFile) {
-		body = { file: snapshotFile };
+		body = { file: snapshotFile, workspaceTab: false, internalRestore: true };
 	}
 
 	if (!body) {
@@ -1131,6 +1131,7 @@ function reviewDocumentKeyFromPanelTab(tab: PanelWorkspaceTab | undefined | null
 export function setUnifiedActiveTab(tab: PanelWorkspaceTab): void {
 	if ((tab as any).kind === "chat" || tab.id === CHAT_PANEL_TAB_ID) return;
 	const sid = workspaceSessionId();
+	(state as any).__lastSidePanelUserActiveSelection = { sessionId: sid, tabId: tab.id, at: Date.now() };
 	setActivePanelTabIdForSession(state, sid, tab.id);
 	const workspace = getSidePanelWorkspace(sid);
 	if (sid !== "__no-session__" && workspace.tabs.some((candidate) => candidate.id === tab.id) && workspace.activeTabId !== tab.id) {
@@ -1461,6 +1462,11 @@ function ensurePanelSortable(container: HTMLElement | null): void {
 		forceFallback: true,
 		fallbackTolerance: 4,
 		delay: 0,
+		onChoose: (evt) => {
+			const id = (evt.item as HTMLElement).getAttribute("data-panel-tab-id") || "";
+			const tab = findPanelTab(panelTabsForSession(state, workspaceSessionId()), id);
+			if (tab && !isPinnedPanelTab(tab)) setUnifiedActiveTab(tab);
+		},
 		onMove: (evt) => {
 			// Forbid dropping in front of (or onto) a pinned tab. Returning false
 			// cancels this candidate move; SortableJS keeps trying as the cursor
@@ -2016,6 +2022,8 @@ export function doRenderApp(): void {
 			data-panel-tab-title=${dataTitle}
 			data-panel-tab-pinned=${isPinnedPanelTab(tab) ? "true" : "false"}
 			data-testid="side-panel-tab"
+			@mousedown=${(e: MouseEvent) => { if ((e.target as Element | null)?.closest?.(".goal-tab-close")) return; setUnifiedMobileTab(tab); }}
+			@pointerup=${(e: PointerEvent) => { if ((e.target as Element | null)?.closest?.(".goal-tab-close")) return; setUnifiedMobileTab(tab); }}
 			@click=${() => { setUnifiedMobileTab(tab); renderApp(); }}
 			@keydown=${(e: KeyboardEvent) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setUnifiedMobileTab(tab); renderApp(); } }}
 		>${testId ? html`<span class="goal-tab-pill-label" data-testid=${testId}>${label}</span>` : html`<span class="goal-tab-pill-label">${label}</span>`}${panelTabHasDot(tab) ? html`<span class="goal-tab-dot"></span>` : ""}${closable ? html`<span

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -100,7 +100,13 @@ import {
 	type PanelWorkspaceTab,
 } from "./panel-workspace.js";
 import { renderPackPanelContent } from "./pack-panels.js";
-import { reorderSidePanelTabs } from "./side-panel-workspace.js";
+import {
+	closeSidePanelTab as closeServerSidePanelTab,
+	getSidePanelWorkspace,
+	reorderSidePanelTabs,
+	setActiveSidePanelTab as setServerActiveSidePanelTab,
+	setSidePanelSizeMode as setServerSidePanelSizeMode,
+} from "./side-panel-workspace.js";
 
 const bobbitIcon = html`<img src="/favicon.svg" alt="" style="width:20px;height:18px;image-rendering:pixelated;" />`;
 
@@ -744,16 +750,24 @@ function sidePanelSizeModeBySession(): Record<string, SidePanelSizeMode> {
 
 export function getSidePanelSizeMode(sessionId: string = workspaceSessionId()): SidePanelSizeMode {
 	const sid = panelWorkspaceSessionKey(sessionId);
+	const workspace = state.sidePanelWorkspaceBySession?.[sid];
+	if (workspace?.sizeMode === "collapsed" || workspace?.sizeMode === "split" || workspace?.sizeMode === "fullscreen") return workspace.sizeMode;
 	const stored = sidePanelSizeModeBySession()[sid];
 	if (stored === "collapsed" || stored === "split" || stored === "fullscreen") return stored;
 	return state.previewPanelFullscreen ? "fullscreen" : "split";
 }
 
-export function setSidePanelSizeMode(mode: SidePanelSizeMode, sessionId: string = workspaceSessionId()): void {
+export async function setSidePanelSizeMode(mode: SidePanelSizeMode, sessionId: string = workspaceSessionId()): Promise<void> {
 	const sid = panelWorkspaceSessionKey(sessionId);
 	sidePanelSizeModeBySession()[sid] = mode;
 	// Compatibility mirror until the server-backed controller owns all callers.
 	state.previewPanelFullscreen = mode === "fullscreen";
+	if (!sid || sid === "__no-session__") return;
+	try {
+		await setServerSidePanelSizeMode(mode, { sessionId: sid });
+	} catch (err) {
+		console.warn("[side-panel] resize mutation failed", err);
+	}
 }
 
 let mountedPreviewTabId = "";
@@ -1112,6 +1126,10 @@ export function setUnifiedActiveTab(tab: PanelWorkspaceTab): void {
 	if ((tab as any).kind === "chat" || tab.id === CHAT_PANEL_TAB_ID) return;
 	const sid = workspaceSessionId();
 	setActivePanelTabIdForSession(state, sid, tab.id);
+	const workspace = getSidePanelWorkspace(sid);
+	if (sid !== "__no-session__" && workspace.tabs.some((candidate) => candidate.id === tab.id) && workspace.activeTabId !== tab.id) {
+		void setServerActiveSidePanelTab(tab.id, { sessionId: sid });
+	}
 	(state as any).previewPanelTab = tab.legacyTab;
 	(state as any).previewPanelActiveTab = tab.kind === "preview" ? "preview" : tab.legacyTab;
 	if (state.assistantType) state.assistantTab = "preview";
@@ -1143,6 +1161,8 @@ function ensureUnifiedActiveTab(tabs: PanelWorkspaceTab[]): void {
 /** Ordered list of available unified panel tabs for the current session. */
 export function unifiedPanelTabs(): UnifiedPanelTab[] {
 	const sessionId = workspaceSessionId();
+	const serverWorkspace = state.sidePanelWorkspaceBySession?.[sessionId];
+	if (serverWorkspace) return panelContentTabs(panelTabsForSession(state, sessionId));
 	const derivedTabs = buildPanelWorkspaceTabs({
 		sessionId,
 		isPreviewSession: state.isPreviewSession,
@@ -1855,15 +1875,29 @@ export function doRenderApp(): void {
 		const tabsBefore = unifiedPanelTabs();
 		const nextId = nextActivePanelTabId(tabsBefore, tab.id);
 		const nextCandidate = nextId ? findPanelTab(tabsBefore, nextId) : undefined;
+		const closeServerTab = () => {
+			void (async () => {
+				if (wasActive) setActivePanelTabIdForSession(state, sid, nextId || "");
+				await closeServerSidePanelTab(tab.id, { sessionId: sid });
+				// The user can close a locally-active tab before the prior active-tab REST
+				// mutation settles. Commit the Chrome-style successor from the UI order so
+				// the server and other browser contexts converge on the same active tab.
+				if (wasActive && nextId) await setServerActiveSidePanelTab(nextId, { sessionId: sid });
+			})().catch((err) => {
+				console.warn("[side-panel] close mutation failed", err);
+				// Fallback for no-session/test harnesses that do not have the server workspace API.
+				setPanelTabsForSession(state, sid, panelTabsForSession(state, sid).filter((candidate) => candidate.id !== tab.id));
+				if (wasActive) {
+					if (nextCandidate) setUnifiedActiveTab(nextCandidate);
+					else setActivePanelTabIdForSession(state, sid, "");
+				}
+				renderApp();
+			});
+		};
 
 		if (tab.kind === "proposal" && tab.source.type === "proposal" && !isHistoricalProposalTab(tab)) {
 			lazyProposalPanels.dismissTypedProposal(tab.source.proposalType);
-			setPanelTabsForSession(state, sid, panelTabsForSession(state, sid).filter((candidate) => candidate.id !== tab.id));
-			if (wasActive) {
-				if (nextCandidate) setUnifiedActiveTab(nextCandidate);
-				else setActivePanelTabIdForSession(state, sid, "");
-			}
-			renderApp();
+			closeServerTab();
 			return;
 		}
 		if (tab.kind === "review") {
@@ -1917,12 +1951,7 @@ export function doRenderApp(): void {
 			}
 		}
 
-		setPanelTabsForSession(state, sid, panelTabsForSession(state, sid).filter((candidate) => candidate.id !== tab.id));
-		if (wasActive) {
-			if (nextCandidate) setUnifiedActiveTab(nextCandidate);
-			else setActivePanelTabIdForSession(state, sid, "");
-		}
-		renderApp();
+		closeServerTab();
 	};
 
 	const panelTabHasDot = (tab: UnifiedPanelTab): boolean => {
@@ -2022,8 +2051,7 @@ export function doRenderApp(): void {
 
 	const sidePanelSizeMode = () => getSidePanelSizeMode(workspaceSessionId());
 	const setSidePanelModeAndRender = (mode: SidePanelSizeMode) => {
-		setSidePanelSizeMode(mode, workspaceSessionId());
-		renderApp();
+		void setSidePanelSizeMode(mode, workspaceSessionId());
 	};
 	const isSidePanelCollapsed = () => sidePanelSizeMode() === "collapsed";
 

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -731,6 +731,30 @@ export function workspaceSessionId(): string {
 	return panelWorkspaceSessionKey(activeSessionId());
 }
 
+type SidePanelSizeMode = "collapsed" | "split" | "fullscreen";
+
+function sidePanelSizeModeBySession(): Record<string, SidePanelSizeMode> {
+	const holder = state as any;
+	if (!holder.sidePanelSizeModeBySession || typeof holder.sidePanelSizeModeBySession !== "object") {
+		holder.sidePanelSizeModeBySession = {};
+	}
+	return holder.sidePanelSizeModeBySession as Record<string, SidePanelSizeMode>;
+}
+
+export function getSidePanelSizeMode(sessionId: string = workspaceSessionId()): SidePanelSizeMode {
+	const sid = panelWorkspaceSessionKey(sessionId);
+	const stored = sidePanelSizeModeBySession()[sid];
+	if (stored === "collapsed" || stored === "split" || stored === "fullscreen") return stored;
+	return state.previewPanelFullscreen ? "fullscreen" : "split";
+}
+
+export function setSidePanelSizeMode(mode: SidePanelSizeMode, sessionId: string = workspaceSessionId()): void {
+	const sid = panelWorkspaceSessionKey(sessionId);
+	sidePanelSizeModeBySession()[sid] = mode;
+	// Compatibility mirror until the server-backed controller owns all callers.
+	state.previewPanelFullscreen = mode === "fullscreen";
+}
+
 let mountedPreviewTabId = "";
 const previewRestoreInFlight = new Set<string>();
 let mobileSelectedPaneIndex = 0;
@@ -1158,9 +1182,14 @@ function setUnifiedDesktopTab(tab: UnifiedContentTab): void {
 	setUnifiedActiveTab(tab);
 }
 
+/** Whether the unified side-panel workspace is active for the current session. */
+export function hasActiveSidePanel(): boolean {
+	return unifiedPanelContentTabs().length > 0;
+}
+
 /** Whether the unified panel is active for the current session. */
 function hasUnifiedPanel(): boolean {
-	return unifiedPanelContentTabs().length > 0;
+	return hasActiveSidePanel();
 }
 
 function mobileChatPaneTab(): MobilePaneTab {
@@ -1219,7 +1248,7 @@ function setupPreviewSwipe(): void {
 	if ((window as any).__previewSwipeListening) return;
 	(window as any).__previewSwipeListening = true;
 
-	const getTrack = () => document.querySelector(".preview-slider__track") as HTMLElement | null;
+	const getTrack = () => document.querySelector(".side-panel-slider__track, .preview-slider__track") as HTMLElement | null;
 
 	// === iframe -> parent: swipe on preview pane ===
 	window.addEventListener("message", (e: MessageEvent) => {
@@ -1924,14 +1953,15 @@ export function doRenderApp(): void {
 			data-panel-tab-kind=${tab.kind}
 			data-panel-tab-title=${dataTitle}
 			data-panel-tab-pinned=${isPinnedPanelTab(tab) ? "true" : "false"}
-			data-testid=${testId}
+			data-testid="side-panel-tab"
 			@click=${() => { setUnifiedMobileTab(tab); renderApp(); }}
 			@keydown=${(e: KeyboardEvent) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setUnifiedMobileTab(tab); renderApp(); } }}
-		><span class="goal-tab-pill-label">${label}</span>${panelTabHasDot(tab) ? html`<span class="goal-tab-dot"></span>` : ""}${closable ? html`<span
+		>${testId ? html`<span class="goal-tab-pill-label" data-testid=${testId}>${label}</span>` : html`<span class="goal-tab-pill-label">${label}</span>`}${panelTabHasDot(tab) ? html`<span class="goal-tab-dot"></span>` : ""}${closable ? html`<span
 				class="goal-tab-close"
 				role="button"
 				aria-label=${`Dismiss ${label}`}
 				title=${`Dismiss ${label}`}
+				data-testid="side-panel-close"
 				@click=${(event: Event) => closeUnifiedPanelTab(tab, event)}
 			>${icon(X, "xs")}</span>` : ""}</div>
 	`;
@@ -1985,13 +2015,12 @@ export function doRenderApp(): void {
 		`;
 	};
 
-	const previewCollapseKey = () => `bobbit-preview-collapsed-${workspaceSessionId()}`;
-	const isPreviewCollapsed = () => localStorage.getItem(previewCollapseKey()) === "true";
-	const togglePreviewCollapse = () => {
-		const next = !isPreviewCollapsed();
-		localStorage.setItem(previewCollapseKey(), String(next));
+	const sidePanelSizeMode = () => getSidePanelSizeMode(workspaceSessionId());
+	const setSidePanelModeAndRender = (mode: SidePanelSizeMode) => {
+		setSidePanelSizeMode(mode, workspaceSessionId());
 		renderApp();
 	};
+	const isSidePanelCollapsed = () => sidePanelSizeMode() === "collapsed";
 
 	const previewRestoreErrorContent = (tab: UnifiedContentTab) => {
 		const restoreError = previewRestoreError(tab);
@@ -2158,23 +2187,72 @@ export function doRenderApp(): void {
 		</div>
 	`;
 
-	const previewControlButtons = () => {
-		const sid = activeSessionId() || "";
-		const entry = state.previewPanelEntry || "";
-		return html`
-			<a
-				href=${`/preview/${encodeURIComponent(sid)}/${encodeURIComponent(entry)}`}
-				target="_blank"
-				rel="noopener noreferrer"
-				class="text-muted-foreground hover:text-foreground"
-				style="background:none;border:none;cursor:pointer;padding:2px;flex-shrink:0;display:inline-flex;align-items:center;"
-				title="Open preview in new tab"
-			>${icon(ExternalLink, "sm")}</a>
-			<button @click=${() => { state.previewPanelMtime = Date.now(); renderApp(); }} class="text-muted-foreground hover:text-foreground" style="background:none;border:none;cursor:pointer;padding:2px;flex-shrink:0;" title="Refresh preview">
-				${icon(RotateCw, "sm")}
-			</button>
-		`;
+	const sidePanelChromeButtonClass = "text-muted-foreground hover:text-foreground";
+	const sidePanelChromeButtonStyle = "background:none;border:none;cursor:pointer;padding:2px;flex-shrink:0;display:inline-flex;align-items:center;";
+
+	const previewUrlForTab = (tab?: UnifiedContentTab | null) => {
+		const sid = activeSessionId() || workspaceSessionId();
+		let entry = state.previewPanelEntry || "inline.html";
+		let artifactId = "";
+		if (tab?.kind === "preview") {
+			const tabState = (tab.state || {}) as Record<string, unknown>;
+			const source = tab.source as Record<string, unknown>;
+			const tabEntry = previewEntryFromTab(tab);
+			if (tabEntry) entry = tabEntry;
+			artifactId = recordValue(tabState, "artifactId") || recordValue(source, "artifactId");
+		}
+		return artifactId
+			? `/preview/${encodeURIComponent(sid)}/_artifact/${encodeURIComponent(artifactId)}/${encodeURIComponent(entry)}`
+			: `/preview/${encodeURIComponent(sid)}/${encodeURIComponent(entry)}`;
 	};
+
+	const sidePanelPopoutUrl = (tab: UnifiedContentTab) => {
+		if (tab.kind === "preview") return previewUrlForTab(tab);
+		const sid = ((tab.source as Record<string, unknown> | undefined)?.sessionId as string | undefined) || activeSessionId() || workspaceSessionId();
+		return `#/session/${encodeURIComponent(sid)}/panel/${encodeURIComponent(tab.id)}`;
+	};
+
+	const previewControlButtons = (tab?: UnifiedContentTab | null) => html`
+		<a
+			href=${previewUrlForTab(tab)}
+			target="_blank"
+			rel="noopener noreferrer"
+			class=${sidePanelChromeButtonClass}
+			style=${sidePanelChromeButtonStyle}
+			title="Open preview in new tab"
+		>${icon(ExternalLink, "sm")}</a>
+		<button @click=${() => { state.previewPanelMtime = Date.now(); renderApp(); }} class=${sidePanelChromeButtonClass} style=${sidePanelChromeButtonStyle} title="Refresh preview">
+			${icon(RotateCw, "sm")}
+		</button>
+	`;
+
+	const sidePanelActionButtons = (tab: UnifiedContentTab) => html`
+		${tab.kind === "preview" && state.previewPanelEntry ? previewControlButtons(tab) : ""}
+	`;
+
+	const sidePanelWindowControls = (tab: UnifiedContentTab, mode: SidePanelSizeMode) => html`
+		${mode === "fullscreen" ? html`
+			<button @click=${() => setSidePanelModeAndRender("split")} class=${sidePanelChromeButtonClass} style=${sidePanelChromeButtonStyle} title=${`Restore side panel${shortcutHint("toggle-sidebar")}`} data-testid="side-panel-restore">
+				${icon(PanelRightOpen, "sm")}
+			</button>
+		` : html`
+			<button @click=${() => setSidePanelModeAndRender("fullscreen")} class=${sidePanelChromeButtonClass} style=${sidePanelChromeButtonStyle} title=${`Fullscreen side panel${shortcutHint("toggle-sidebar")}`} data-testid="side-panel-fullscreen">
+				${icon(PanelRightOpen, "sm")}
+			</button>
+		`}
+		<a
+			href=${sidePanelPopoutUrl(tab)}
+			target="_blank"
+			rel="noopener noreferrer"
+			class=${sidePanelChromeButtonClass}
+			style=${sidePanelChromeButtonStyle}
+			title="Open side panel in new tab"
+			data-testid="side-panel-popout"
+		>${icon(ExternalLink, "sm")}</a>
+		<button @click=${() => setSidePanelModeAndRender("collapsed")} class=${sidePanelChromeButtonClass} style=${sidePanelChromeButtonStyle} title=${`Collapse side panel${shortcutHint("toggle-preview")}`} data-testid="side-panel-collapse">
+			${icon(PanelRightClose, "sm")}
+		</button>
+	`;
 
 	const inboxPaneContent = () => {
 		const sid = activeSessionId() || "";
@@ -2252,9 +2330,9 @@ export function doRenderApp(): void {
 		tab.kind === "inbox" ? "inbox-tab-unified" : "",
 	);
 
-	const unifiedPreviewPanel = () => {
+	const activeSidePanelContentTab = (): UnifiedContentTab | null => {
 		const contentTabs = unifiedPanelContentTabs();
-		if (contentTabs.length === 0) return "";
+		if (contentTabs.length === 0) return null;
 
 		let activeId = activeSidePanelTabIdForSession(state, workspaceSessionId());
 		let activeTab = contentTabs.find((tab) => tab.id === activeId) ?? contentTabs[0];
@@ -2263,15 +2341,21 @@ export function doRenderApp(): void {
 			activeId = activeSidePanelTabIdForSession(state, workspaceSessionId());
 			activeTab = contentTabs.find((tab) => tab.id === activeId) ?? activeTab;
 		}
-		const activeTabCanFullscreen = activeTab.kind === "preview";
+		return activeTab;
+	};
+
+	const renderSidePanelWorkspace = (mode: SidePanelSizeMode = "split") => {
+		const contentTabs = unifiedPanelContentTabs();
+		const activeTab = activeSidePanelContentTab();
+		if (!activeTab) return "";
 
 		return html`
-			<div class="goal-preview-panel flex-1 flex flex-col border-l border-border min-h-0" data-panel-workspace="content">
+			<div class="side-panel-workspace goal-preview-panel flex-1 flex flex-col ${mode === "split" ? "border-l border-border" : ""} min-h-0" data-panel-workspace="content" data-side-panel-mode=${mode}>
 				<!-- Chrome-style tab strip: muted bg distinct from the panel below.
 				     Tabs sit flush at the strip's bottom via items-end + no pb.
 				     The active tab's background matches the panel so it visually
 				     bridges the color boundary (curve pseudo-elements in CSS do
-				     the outward-curve flourish at the bottom corners). */ -->
+				     the outward-curve flourish at the bottom corners). -->
 				<div class="flex items-end justify-between px-3 pt-1 shrink-0 min-w-0" style="background: var(--muted, var(--color-muted));">
 					<div class="flex-1 min-w-0">
 						<div class="flex items-end gap-1" data-panel-tab-bar="true">
@@ -2279,14 +2363,8 @@ export function doRenderApp(): void {
 						</div>
 					</div>
 					<div class="flex items-center gap-0.5 shrink-0 pl-2 pb-1">
-						${activeTab.kind === "preview" && state.previewPanelEntry ? previewControlButtons() : ""}
-						${activeTabCanFullscreen ? html`
-						<button @click=${() => { state.previewPanelFullscreen = true; renderApp(); }} class="text-muted-foreground hover:text-foreground" style="background:none;border:none;cursor:pointer;padding:2px;flex-shrink:0;" title=${`Fullscreen preview${shortcutHint("toggle-sidebar")}`} data-testid="preview-fullscreen">
-							${icon(PanelRightOpen, "sm")}
-						</button>` : ""}
-						<button @click=${togglePreviewCollapse} class="text-muted-foreground hover:text-foreground" style="background:none;border:none;cursor:pointer;padding:2px;flex-shrink:0;" title=${`Collapse preview${shortcutHint("toggle-preview")}`}>
-							${icon(PanelRightClose, "sm")}
-						</button>
+						${sidePanelActionButtons(activeTab)}
+						${sidePanelWindowControls(activeTab, mode)}
 					</div>
 				</div>
 				<!-- Tab content -->
@@ -2295,8 +2373,8 @@ export function doRenderApp(): void {
 		`;
 	};
 
-	const previewExpandButton = () => html`
-		<button @click=${togglePreviewCollapse} class="text-muted-foreground hover:text-foreground" style="background:none;border:none;cursor:pointer;padding:6px 4px;border-left:1px solid var(--border);align-self:stretch;display:flex;align-items:center;" title=${`Expand preview${shortcutHint("toggle-sidebar")}`}>
+	const sidePanelRestoreButton = () => html`
+		<button @click=${() => setSidePanelModeAndRender("split")} class="text-muted-foreground hover:text-foreground" style="background:none;border:none;cursor:pointer;padding:6px 4px;border-left:1px solid var(--border);align-self:stretch;display:flex;align-items:center;" title=${`Expand side panel${shortcutHint("toggle-sidebar")}`} data-testid="side-panel-restore">
 			${icon(PanelRightOpen, "sm")}
 		</button>
 	`;
@@ -2304,7 +2382,7 @@ export function doRenderApp(): void {
 	const mobilePaneContent = (tab: MobilePaneTab) => {
 		if (tab.kind === "chat") return state.chatPanel;
 		const content = unifiedPanelContent(tab);
-		return html`<div class="goal-preview-panel flex-1 flex flex-col min-h-0" data-panel-tab-id=${tab.id}>${content}</div>`;
+		return html`<div class="side-panel-pane goal-preview-panel flex-1 flex flex-col min-h-0" data-panel-tab-id=${tab.id}>${content}</div>`;
 	};
 
 	const mainArea = () => {
@@ -2350,40 +2428,26 @@ export function doRenderApp(): void {
 		}
 
 		if (connected && hasUnifiedPanel()) {
-			const fullscreenTabs = unifiedPanelContentTabs();
-			const fullscreenActiveId = activeSidePanelTabIdForSession(state, workspaceSessionId());
-			const fullscreenTab = fullscreenTabs.find((tab) => tab.id === fullscreenActiveId) ?? fullscreenTabs[0];
-			const fullscreenContent = htmlPreviewContent();
-			if (desktop && state.previewPanelFullscreen && fullscreenTab?.kind === "preview") {
+			const mode = sidePanelSizeMode();
+			if (desktop && mode === "fullscreen") {
 				return html`
 					${reconnectBanner()}
 					<div class="flex-1 flex flex-col min-h-0 overflow-hidden">
-						<!-- Fullscreen preview header -->
-						<div class="flex items-center justify-between px-3 py-1.5 border-b border-border shrink-0" style="background:var(--color-background, hsl(var(--background)));">
-							<span class="text-xs font-medium text-muted-foreground">Preview</span>
-							<div class="flex items-center gap-0.5">
-								${fullscreenTab.kind === "preview" && state.previewPanelEntry ? previewControlButtons() : ""}
-								<button @click=${() => { state.previewPanelFullscreen = false; renderApp(); }} class="text-muted-foreground hover:text-foreground" style="background:none;border:none;cursor:pointer;padding:2px;" title=${`Collapse preview${shortcutHint("toggle-preview")}`}>
-									${icon(PanelRightClose, "sm")}
-								</button>
-							</div>
-						</div>
-						<!-- Preview content fills available space -->
-						${fullscreenContent}
+						${renderSidePanelWorkspace("fullscreen")}
 						<!-- Compact prompt bar at bottom -->
-						<div class="preview-fullscreen-prompt shrink-0 border-t border-border">
+						<div class="side-panel-fullscreen-prompt preview-fullscreen-prompt shrink-0 border-t border-border">
 							${state.chatPanel}
 						</div>
 					</div>
 				`;
 			}
 			if (desktop) {
-				const collapsed = isPreviewCollapsed();
+				const collapsed = isSidePanelCollapsed();
 				return html`
 					${reconnectBanner()}
-					<div class="goal-split-layout flex-1 flex min-h-0 overflow-hidden">
-						<div class="${collapsed ? 'flex-1' : 'goal-chat-panel flex-1'} min-w-0 flex flex-col">${state.chatPanel}</div>
-						${collapsed ? previewExpandButton() : unifiedPreviewPanel()}
+					<div class="goal-split-layout side-panel-split-layout flex-1 flex min-h-0 overflow-hidden">
+						<div class="${collapsed ? 'flex-1' : 'goal-chat-panel side-panel-chat-pane flex-1'} min-w-0 flex flex-col">${state.chatPanel}</div>
+						${collapsed ? sidePanelRestoreButton() : renderSidePanelWorkspace("split")}
 					</div>
 				`;
 			}
@@ -2395,8 +2459,8 @@ export function doRenderApp(): void {
 			const paneW = 100 / count;
 			return html`
 				${reconnectBanner()}
-				<div class="preview-slider flex-1 min-h-0" style="overflow:hidden;position:relative;">
-					<div class="preview-slider__track" style="display:flex;width:${trackW}%;height:100%;transform:translateX(${slideX}%);transition:transform 0.3s ease-out;will-change:transform;">
+				<div class="side-panel-slider preview-slider flex-1 min-h-0" style="overflow:hidden;position:relative;">
+					<div class="side-panel-slider__track preview-slider__track" style="display:flex;width:${trackW}%;height:100%;transform:translateX(${slideX}%);transition:transform 0.3s ease-out;will-change:transform;">
 						${panes.map(tab => html`<div style="width:${paneW}%;height:100%;min-width:0;display:flex;flex-direction:column;">${mobilePaneContent(tab)}</div>`)}
 					</div>
 				</div>

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -99,6 +99,7 @@ import {
 	packPanelRefFromTabId,
 	type PanelWorkspaceTab,
 } from "./panel-workspace.js";
+import { openInboxPanel } from "./inbox-panel.js";
 import { renderPackPanelContent } from "./pack-panels.js";
 import {
 	closeSidePanelTab as closeServerSidePanelTab,
@@ -763,11 +764,6 @@ export async function setSidePanelSizeMode(mode: SidePanelSizeMode, sessionId: s
 	// Compatibility mirror until the server-backed controller owns all callers.
 	state.previewPanelFullscreen = mode === "fullscreen";
 	if (!sid || sid === "__no-session__") return;
-	try {
-		const legacyKey = `bobbit-preview-collapsed-${sid}`;
-		if (mode === "collapsed") localStorage.setItem(legacyKey, "true");
-		else localStorage.removeItem(legacyKey);
-	} catch { /* localStorage is only a compatibility mirror, never authoritative */ }
 	try {
 		await setServerSidePanelSizeMode(mode, { sessionId: sid });
 	} catch (err) {
@@ -1873,7 +1869,7 @@ export function doRenderApp(): void {
 	const closeUnifiedPanelTab = (tab: UnifiedPanelTab, event?: Event): void => {
 		event?.preventDefault();
 		event?.stopPropagation();
-		if ((tab as any).kind === "chat" || isPinnedPanelTab(tab)) return;
+		if ((tab as any).kind === "chat") return;
 		const sid = workspaceSessionId();
 		const activeId = activeSidePanelTabIdForSession(state, sid);
 		const wasActive = activeId === tab.id;
@@ -1923,6 +1919,10 @@ export function doRenderApp(): void {
 				}
 				state.reviewPanelOpen = state.reviewDocuments.size > 0;
 			}
+		}
+		if (tab.kind === "inbox") {
+			state.inboxPanelOpen = false;
+			state.inboxAddDialogOpen = false;
 		}
 		if (tab.kind === "preview") {
 			if (!isHistoricalPreviewTab(tab)) markPreviewContentDismissed(sid, previewEntryFromTab(tab), previewContentHashFromTab(tab));
@@ -2506,11 +2506,47 @@ export function doRenderApp(): void {
 			lazyPageCall("search", () => import("./search-page.js"), "resetSearchPage", false);
 		}
 
+		if (route.view === "session" && route.panelTabId) {
+			if (!connected) return html`${reconnectBanner()}<div class="flex-1 min-h-0" data-testid="bobbit-loader">${bobbitLoadingAnimation()}</div>`;
+			const sid = workspaceSessionId();
+			const workspace = state.sidePanelWorkspaceBySession?.[sid];
+			if (!workspace) return html`${reconnectBanner()}<div class="flex-1 min-h-0" data-testid="bobbit-loader">${bobbitLoadingAnimation()}</div>`;
+			const tab = workspace.tabs.find((candidate) => candidate.id === route.panelTabId);
+			if (!tab) {
+				return html`
+					${reconnectBanner()}
+					<div class="flex-1 min-h-0 flex items-center justify-center p-8 text-center" data-testid="side-panel-route-missing">
+						<div class="max-w-sm rounded-lg border border-border bg-card p-5 shadow-sm">
+							<div class="text-sm font-semibold text-foreground mb-2">Panel is closed</div>
+							<div class="text-sm text-muted-foreground mb-4">This side-panel tab is not open for this session anymore.</div>
+							<a class="text-sm text-primary hover:underline" href=${`#/session/${encodeURIComponent(sid)}`}>Back to session</a>
+						</div>
+					</div>
+				`;
+			}
+			if (workspace.activeTabId !== tab.id) setActivePanelTabIdForSession(state, sid, tab.id);
+			return html`${reconnectBanner()}<div class="flex-1 flex flex-col min-h-0 overflow-hidden" data-testid="side-panel-route-content">${renderSidePanelWorkspace("fullscreen")}</div>`;
+		}
+
+		const staffInboxOpenAffordance = () => {
+			const sid = activeSessionId() || "";
+			const sess = sid ? state.gatewaySessions.find((s) => s.id === sid) : undefined;
+			const hasInboxTab = !!sid && getSidePanelWorkspace(sid).tabs.some((tab) => tab.id === "inbox" && tab.kind === "inbox");
+			if (!sess?.staffId || hasInboxTab) return "";
+			return html`
+				<div class="shrink-0 border-b border-border bg-muted/30 px-3 py-2 flex items-center justify-between gap-3" style=${isDesktop() ? "" : "margin-top:var(--mobile-header-height,60px);"} data-testid="staff-inbox-reopen-bar">
+					<span class="text-xs text-muted-foreground">Staff inbox is closed for this session.</span>
+					<button class="text-xs rounded border border-border px-2 py-1 hover:bg-accent" data-testid="staff-inbox-open" @click=${() => openInboxPanel(sid, sess.staffId!)}>Open inbox</button>
+				</div>
+			`;
+		};
+
 		if (connected && hasUnifiedPanel()) {
 			const mode = sidePanelSizeMode();
 			if (desktop && mode === "fullscreen") {
 				return html`
 					${reconnectBanner()}
+					${staffInboxOpenAffordance()}
 					<div class="flex-1 flex flex-col min-h-0 overflow-hidden">
 						${renderSidePanelWorkspace("fullscreen")}
 						<!-- Compact prompt bar at bottom -->
@@ -2524,6 +2560,7 @@ export function doRenderApp(): void {
 				const collapsed = isSidePanelCollapsed();
 				return html`
 					${reconnectBanner()}
+					${staffInboxOpenAffordance()}
 					<div class="goal-split-layout side-panel-split-layout flex-1 flex min-h-0 overflow-hidden">
 						<div class="${collapsed ? 'flex-1' : 'goal-chat-panel side-panel-chat-pane flex-1'} min-w-0 flex flex-col">${state.chatPanel}</div>
 						${collapsed ? sidePanelRestoreButton() : renderSidePanelWorkspace("split")}
@@ -2538,6 +2575,7 @@ export function doRenderApp(): void {
 			const paneW = 100 / count;
 			return html`
 				${reconnectBanner()}
+				${staffInboxOpenAffordance()}
 				<div class="side-panel-slider preview-slider flex-1 min-h-0" style="overflow:hidden;position:relative;">
 					<div class="side-panel-slider__track preview-slider__track" style="display:flex;width:${trackW}%;height:100%;transform:translateX(${slideX}%);transition:transform 0.3s ease-out;will-change:transform;">
 						${panes.map(tab => html`<div style="width:${paneW}%;height:100%;min-width:0;display:flex;flex-direction:column;">${mobilePaneContent(tab)}</div>`)}
@@ -2545,7 +2583,7 @@ export function doRenderApp(): void {
 				</div>
 			`;
 		}
-		if (connected) return html`${reconnectBanner()}${renderArchivedBanner()}${state.chatPanel}`;
+		if (connected) return html`${reconnectBanner()}${renderArchivedBanner()}${staffInboxOpenAffordance()}${state.chatPanel}`;
 
 		if (desktop) {
 			return html`

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -2171,11 +2171,18 @@ export function doRenderApp(): void {
 						clearAllAnnotations(sid);
 						clearPersistedReviewDocuments(sid);
 						markReviewSubmitted(sid);
+						await gatewayFetch(`/api/sessions/${encodeURIComponent(sid)}/review/submitted`, {
+							method: "PUT",
+							body: JSON.stringify({ submitted: true }),
+						}).catch(() => undefined);
 						await flushPendingWrites();
 						state.reviewDocuments = new Map();
 						state.reviewPanelOpen = false;
 						state.reviewActiveTab = "";
-						await Promise.allSettled(reviewTabIds.map((tabId) => closeServerSidePanelTab(tabId, { sessionId: sid })));
+						for (const tabId of reviewTabIds) {
+							try { await closeServerSidePanelTab(tabId, { sessionId: sid }); }
+							catch { /* best-effort */ }
+						}
 						renderApp();
 					}
 				}}
@@ -2231,11 +2238,20 @@ export function doRenderApp(): void {
 					setActivePanelTabIdForSession(state, sid, remainingLegacyTabs[0]?.id || "");
 					clearAllAnnotations(sid);
 					clearPersistedReviewDocuments(sid);
-					if (hasMarkdownReview) markReviewSubmitted(sid);
+					if (hasMarkdownReview) {
+						markReviewSubmitted(sid);
+						await gatewayFetch(`/api/sessions/${encodeURIComponent(sid)}/review/submitted`, {
+							method: "PUT",
+							body: JSON.stringify({ submitted: true }),
+						}).catch(() => undefined);
+					}
 					state.reviewDocuments = new Map();
 					state.reviewPanelOpen = false;
 					state.reviewActiveTab = "";
-					await Promise.allSettled(reviewTabIds.map((tabId) => closeServerSidePanelTab(tabId, { sessionId: sid })));
+					for (const tabId of reviewTabIds) {
+						try { await closeServerSidePanelTab(tabId, { sessionId: sid }); }
+						catch { /* best-effort */ }
+					}
 					renderApp();
 				}}
 			></review-pane>
@@ -2254,7 +2270,7 @@ export function doRenderApp(): void {
 			const source = tab.source as Record<string, unknown>;
 			const tabEntry = previewEntryFromTab(tab);
 			if (tabEntry) entry = tabEntry;
-			artifactId = recordValue(tabState, "artifactId") || recordValue(source, "artifactId");
+			if (!isLivePreviewTab(tab)) artifactId = recordValue(tabState, "artifactId") || recordValue(source, "artifactId");
 		}
 		return artifactId
 			? `/preview/${encodeURIComponent(sid)}/_artifact/${encodeURIComponent(artifactId)}/${encodeURIComponent(entry)}`
@@ -2285,13 +2301,20 @@ export function doRenderApp(): void {
 		${tab.kind === "preview" && state.previewPanelEntry ? previewControlButtons(tab) : ""}
 	`;
 
-	const sidePanelWindowControls = (tab: UnifiedContentTab, mode: SidePanelSizeMode) => html`
+	const sidePanelWindowControls = (tab: UnifiedContentTab, mode: SidePanelSizeMode) => {
+		const fullscreenTitle = tab.kind === "preview"
+			? `Fullscreen preview${shortcutHint("toggle-sidebar")}`
+			: `Fullscreen side panel${shortcutHint("toggle-sidebar")}`;
+		const restoreTitle = tab.kind === "preview"
+			? `Collapse preview${shortcutHint("toggle-sidebar")}`
+			: `Restore side panel${shortcutHint("toggle-sidebar")}`;
+		return html`
 		${mode === "fullscreen" ? html`
-			<button @click=${() => setSidePanelModeAndRender("split")} class=${sidePanelChromeButtonClass} style=${sidePanelChromeButtonStyle} title=${`Restore side panel${shortcutHint("toggle-sidebar")}`} data-testid="side-panel-restore">
+			<button @click=${() => setSidePanelModeAndRender("split")} class=${sidePanelChromeButtonClass} style=${sidePanelChromeButtonStyle} title=${restoreTitle} data-testid="side-panel-restore">
 				${icon(PanelRightOpen, "sm")}
 			</button>
 		` : html`
-			<button @click=${() => setSidePanelModeAndRender("fullscreen")} class=${sidePanelChromeButtonClass} style=${sidePanelChromeButtonStyle} title=${`Fullscreen side panel${shortcutHint("toggle-sidebar")}`} data-testid="side-panel-fullscreen">
+			<button @click=${() => setSidePanelModeAndRender("fullscreen")} class=${sidePanelChromeButtonClass} style=${sidePanelChromeButtonStyle} title=${fullscreenTitle} data-testid="side-panel-fullscreen">
 				${icon(PanelRightOpen, "sm")}
 			</button>
 		`}
@@ -2308,6 +2331,7 @@ export function doRenderApp(): void {
 			${icon(PanelRightClose, "sm")}
 		</button>
 	`;
+	};
 
 	const inboxPaneContent = () => {
 		const sid = activeSessionId() || "";

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -80,7 +80,6 @@ import {
 	isHistoricalProposalTab,
 	isLivePreviewTab,
 	isPinnedPanelTab,
-	markPreviewContentDismissed,
 	nextActivePanelTabId,
 	normalizePreviewContentHash,
 	normalizeSidePanelTabs,
@@ -91,6 +90,7 @@ import {
 	previewTabDisplayTitle,
 	previewTabVersion,
 	previewVersionRecordFor,
+	reviewDocumentIdFromPanelTab,
 	reviewPanelTabId,
 	reviewTitleFromPanelTab,
 	setActivePanelTabIdForSession,
@@ -1122,6 +1122,12 @@ function restoreHistoricalPreviewTab(tab: PanelWorkspaceTab): void {
 	})();
 }
 
+function reviewDocumentKeyFromPanelTab(tab: PanelWorkspaceTab | undefined | null): string {
+	const documentId = reviewDocumentIdFromPanelTab(tab);
+	if (documentId && state.reviewDocuments.has(documentId)) return documentId;
+	return reviewTitleFromPanelTab(tab) || documentId;
+}
+
 export function setUnifiedActiveTab(tab: PanelWorkspaceTab): void {
 	if ((tab as any).kind === "chat" || tab.id === CHAT_PANEL_TAB_ID) return;
 	const sid = workspaceSessionId();
@@ -1138,7 +1144,7 @@ export function setUnifiedActiveTab(tab: PanelWorkspaceTab): void {
 		restoreHistoricalPreviewTab(tab);
 	}
 	if (tab.kind === "review") {
-		state.reviewActiveTab = reviewTitleFromPanelTab(tab);
+		state.reviewActiveTab = reviewDocumentKeyFromPanelTab(tab);
 	}
 }
 
@@ -1924,14 +1930,15 @@ export function doRenderApp(): void {
 		}
 		if (tab.kind === "review") {
 			const title = reviewTitleFromPanelTab(tab);
-			if (title) {
+			const key = reviewDocumentKeyFromPanelTab(tab);
+			if (key) {
 				const sid = activeSessionId() || "";
 				if (event?.type !== "review-close-tab") {
-					const count = reviewPaneUnsentCountForDocument(sid, title);
-					if (count > 0 && !confirm(`Close "${title}"? ${count} unsent comment${count !== 1 ? "s" : ""} will be hidden until reopened.`)) return;
+					const count = reviewPaneUnsentCountForDocument(sid, key);
+					if (count > 0 && !confirm(`Close "${title || key}"? ${count} unsent comment${count !== 1 ? "s" : ""} will be hidden until reopened.`)) return;
 				}
-				if (state.reviewActiveTab === title) {
-					const nextReview = nextCandidate?.kind === "review" ? reviewTitleFromPanelTab(nextCandidate) : "";
+				if (state.reviewActiveTab === key) {
+					const nextReview = nextCandidate?.kind === "review" ? reviewDocumentKeyFromPanelTab(nextCandidate) : "";
 					if (nextReview) state.reviewActiveTab = nextReview;
 				}
 			}
@@ -1941,7 +1948,6 @@ export function doRenderApp(): void {
 			state.inboxAddDialogOpen = false;
 		}
 		if (tab.kind === "preview") {
-			if (!isHistoricalPreviewTab(tab)) markPreviewContentDismissed(sid, previewEntryFromTab(tab), previewContentHashFromTab(tab));
 			const remainingPreviewTabs = tabsBefore.filter((candidate) => candidate.id !== tab.id && candidate.kind === "preview");
 			if (remainingPreviewTabs.length === 0) {
 				state.isPreviewSession = false;
@@ -2396,9 +2402,9 @@ export function doRenderApp(): void {
 	const unifiedPanelContent = (tab: UnifiedContentTab) => {
 		if (tab.kind === "preview") return previewRestoreError(tab) ? previewRestoreErrorContent(tab) : htmlPreviewContent();
 		if (tab.kind === "review" && state.reviewPanelOpen) {
-			const reviewTitle = reviewTitleFromPanelTab(tab);
-			if (reviewTitle && state.reviewActiveTab !== reviewTitle) {
-				state.reviewActiveTab = reviewTitle;
+			const reviewKey = reviewDocumentKeyFromPanelTab(tab);
+			if (reviewKey && state.reviewActiveTab !== reviewKey) {
+				state.reviewActiveTab = reviewKey;
 			}
 			return reviewPaneContent();
 		}

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -2313,9 +2313,7 @@ export function doRenderApp(): void {
 		const fullscreenTitle = tab.kind === "preview"
 			? `Fullscreen preview${shortcutHint("toggle-sidebar")}`
 			: `Fullscreen side panel${shortcutHint("toggle-sidebar")}`;
-		const restoreTitle = tab.kind === "preview"
-			? `Collapse preview${shortcutHint("toggle-sidebar")}`
-			: `Restore side panel${shortcutHint("toggle-sidebar")}`;
+		const restoreTitle = `Restore side panel${shortcutHint("toggle-sidebar")}`;
 		return html`
 		${mode === "fullscreen" ? html`
 			<button @click=${() => setSidePanelModeAndRender("split")} class=${sidePanelChromeButtonClass} style=${sidePanelChromeButtonStyle} title=${restoreTitle} data-testid="side-panel-restore">

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -22,11 +22,10 @@ import {
 	setRenderSuppressed,
 } from "./state.js";
 import { gatewayFetch, retryLoadSessions } from "./api.js";
-import { clearAllAnnotations, clearAnnotations, getDocumentAnnotationCount, markReviewSubmitted, flushPendingWrites } from "../ui/components/review/AnnotationStore.js";
+import { clearAllAnnotations, getDocumentAnnotationCount, markReviewSubmitted, flushPendingWrites } from "../ui/components/review/AnnotationStore.js";
 import {
 	clearPersistedReviewDocuments,
 	openReviewDocumentFromEvent,
-	removePersistedReviewDocument,
 	reviewDecisionPayloadFromDetail,
 	reviewDocumentFromDecisionDetail,
 	submitReviewDecision,
@@ -1159,11 +1158,20 @@ function ensureUnifiedActiveTab(tabs: PanelWorkspaceTab[]): void {
 	setActivePanelTabIdForSession(state, sid, "");
 }
 
+export function shouldDerivePanelTabsInRender(protocol = typeof window !== "undefined" ? window.location.protocol : ""): boolean {
+	// file:// browser fixtures have no gateway REST API and intentionally exercise
+	// legacy cache-derived panel setup. The real gateway render path is server-
+	// authoritative: missing workspace state means "not hydrated yet", never
+	// "recreate tabs from proposal/review/preview/inbox caches".
+	return protocol === "file:";
+}
+
 /** Ordered list of available unified panel tabs for the current session. */
 export function unifiedPanelTabs(): UnifiedPanelTab[] {
 	const sessionId = workspaceSessionId();
 	const serverWorkspace = state.sidePanelWorkspaceBySession?.[sessionId];
 	if (serverWorkspace) return panelContentTabs(panelTabsForSession(state, sessionId));
+	if (!shouldDerivePanelTabsInRender()) return [];
 	const derivedTabs = buildPanelWorkspaceTabs({
 		sessionId,
 		isPreviewSession: state.isPreviewSession,
@@ -1186,6 +1194,19 @@ export function unifiedPanelTabs(): UnifiedPanelTab[] {
 	setPanelTabsForSession(state, sessionId, tabs);
 	ensureUnifiedActiveTab(tabs);
 	return tabs;
+}
+
+function findReviewPanelTabByTitle(title: string): UnifiedPanelTab | undefined {
+	const doc = state.reviewDocuments.get(title);
+	const candidateIds = [doc?.documentId, title]
+		.filter((value): value is string => typeof value === "string" && value.length > 0)
+		.map((documentId) => reviewPanelTabId(documentId));
+	const tabs = unifiedPanelTabs();
+	for (const id of candidateIds) {
+		const tab = findPanelTab(tabs, id);
+		if (tab?.kind === "review") return tab;
+	}
+	return tabs.find((tab) => tab.kind === "review" && reviewTitleFromPanelTab(tab) === title);
 }
 
 function unifiedPanelContentTabs(): UnifiedContentTab[] {
@@ -1907,17 +1928,12 @@ export function doRenderApp(): void {
 				const sid = activeSessionId() || "";
 				if (event?.type !== "review-close-tab") {
 					const count = reviewPaneUnsentCountForDocument(sid, title);
-					if (count > 0 && !confirm(`Close "${title}"? ${count} unsent comment${count !== 1 ? "s" : ""} will be lost.`)) return;
+					if (count > 0 && !confirm(`Close "${title}"? ${count} unsent comment${count !== 1 ? "s" : ""} will be hidden until reopened.`)) return;
 				}
-				clearAnnotations(sid, title);
-				removePersistedReviewDocument(sid, title);
-				state.reviewDocuments = new Map(state.reviewDocuments);
-				state.reviewDocuments.delete(title);
 				if (state.reviewActiveTab === title) {
 					const nextReview = nextCandidate?.kind === "review" ? reviewTitleFromPanelTab(nextCandidate) : "";
-					state.reviewActiveTab = nextReview || [...state.reviewDocuments.keys()][0] || "";
+					if (nextReview) state.reviewActiveTab = nextReview;
 				}
-				state.reviewPanelOpen = state.reviewDocuments.size > 0;
 			}
 		}
 		if (tab.kind === "inbox") {
@@ -2152,7 +2168,7 @@ export function doRenderApp(): void {
 				@review-tab-change=${(e: CustomEvent) => {
 					const title = e.detail.title as string;
 					state.reviewActiveTab = title;
-					const tab = findPanelTab(unifiedPanelTabs(), reviewPanelTabId(title));
+					const tab = findReviewPanelTabByTitle(title);
 					if (tab) setUnifiedActiveTab(tab);
 					renderApp();
 				}}
@@ -2210,19 +2226,11 @@ export function doRenderApp(): void {
 				}}
 				@review-close-tab=${(e: CustomEvent) => {
 					const title = e.detail.title as string;
-					const tab = findPanelTab(unifiedPanelTabs(), reviewPanelTabId(title));
+					const tab = findReviewPanelTabByTitle(title);
 					if (tab) closeUnifiedPanelTab(tab, e);
 					else {
-						const sid = activeSessionId() || "";
-						clearAnnotations(sid, title);
-						removePersistedReviewDocument(sid, title);
-						state.reviewDocuments = new Map(state.reviewDocuments);
-						state.reviewDocuments.delete(title);
-						if (state.reviewActiveTab === title) {
-							const keys = [...state.reviewDocuments.keys()];
-							state.reviewActiveTab = keys[0] || "";
-						}
-						state.reviewPanelOpen = state.reviewDocuments.size > 0;
+						const keys = [...state.reviewDocuments.keys()].filter((key) => key !== title);
+						if (state.reviewActiveTab === title) state.reviewActiveTab = keys[0] || title;
 						renderApp();
 					}
 				}}

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -764,6 +764,11 @@ export async function setSidePanelSizeMode(mode: SidePanelSizeMode, sessionId: s
 	state.previewPanelFullscreen = mode === "fullscreen";
 	if (!sid || sid === "__no-session__") return;
 	try {
+		const legacyKey = `bobbit-preview-collapsed-${sid}`;
+		if (mode === "collapsed") localStorage.setItem(legacyKey, "true");
+		else localStorage.removeItem(legacyKey);
+	} catch { /* localStorage is only a compatibility mirror, never authoritative */ }
+	try {
 		await setServerSidePanelSizeMode(mode, { sessionId: sid });
 	} catch (err) {
 		console.warn("[side-panel] resize mutation failed", err);
@@ -1961,9 +1966,10 @@ export function doRenderApp(): void {
 		return state.activeProposals[type] != null || (type === currentAssistantProposalType() && state.assistantHasProposal);
 	};
 
-	const panelTabButtonLabel = (tab: UnifiedPanelTab): string => (
-		tab.label || tab.title || (tab.kind === "preview" ? "Preview" : "")
-	);
+	const panelTabButtonLabel = (tab: UnifiedPanelTab): string => {
+		if (tab.kind === "review") return tab.title || tab.label || "Review";
+		return tab.label || tab.title || (tab.kind === "preview" ? "Preview" : "");
+	};
 
 	const panelTabButton = (tab: UnifiedPanelTab, testId: string) => {
 		const label = panelTabButtonLabel(tab);
@@ -2155,6 +2161,13 @@ export function doRenderApp(): void {
 					if (agent) {
 						agent.prompt(e.detail.feedback);
 						const sid = activeSessionId() || "";
+						const reviewTabIds = [...new Set([
+							...unifiedPanelTabs().filter((tab) => tab.kind === "review").map((tab) => tab.id),
+							...getSidePanelWorkspace(sid).tabs.filter((tab) => tab.kind === "review").map((tab) => tab.id),
+						])];
+						const remainingLegacyTabs = panelTabsForSession(state, sid).filter((tab) => tab.kind !== "review");
+						setPanelTabsForSession(state, sid, remainingLegacyTabs);
+						setActivePanelTabIdForSession(state, sid, remainingLegacyTabs[0]?.id || "");
 						clearAllAnnotations(sid);
 						clearPersistedReviewDocuments(sid);
 						markReviewSubmitted(sid);
@@ -2162,6 +2175,7 @@ export function doRenderApp(): void {
 						state.reviewDocuments = new Map();
 						state.reviewPanelOpen = false;
 						state.reviewActiveTab = "";
+						await Promise.allSettled(reviewTabIds.map((tabId) => closeServerSidePanelTab(tabId, { sessionId: sid })));
 						renderApp();
 					}
 				}}
@@ -2205,15 +2219,23 @@ export function doRenderApp(): void {
 						renderApp();
 					}
 				}}
-				@review-dismiss=${() => {
+				@review-dismiss=${async () => {
 					const sid = activeSessionId() || "";
+					const reviewTabIds = [...new Set([
+						...unifiedPanelTabs().filter((tab) => tab.kind === "review").map((tab) => tab.id),
+						...getSidePanelWorkspace(sid).tabs.filter((tab) => tab.kind === "review").map((tab) => tab.id),
+					])];
 					const hasMarkdownReview = [...state.reviewDocuments.values()].some((doc) => !doc.source || doc.source.kind === "markdown-review");
+					const remainingLegacyTabs = panelTabsForSession(state, sid).filter((tab) => tab.kind !== "review");
+					setPanelTabsForSession(state, sid, remainingLegacyTabs);
+					setActivePanelTabIdForSession(state, sid, remainingLegacyTabs[0]?.id || "");
 					clearAllAnnotations(sid);
 					clearPersistedReviewDocuments(sid);
 					if (hasMarkdownReview) markReviewSubmitted(sid);
 					state.reviewDocuments = new Map();
 					state.reviewPanelOpen = false;
 					state.reviewActiveTab = "";
+					await Promise.allSettled(reviewTabIds.map((tabId) => closeServerSidePanelTab(tabId, { sessionId: sid })));
 					renderApp();
 				}}
 			></review-pane>

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -100,6 +100,7 @@ import {
 	type PanelWorkspaceTab,
 } from "./panel-workspace.js";
 import { renderPackPanelContent } from "./pack-panels.js";
+import { reorderSidePanelTabs } from "./side-panel-workspace.js";
 
 const bobbitIcon = html`<img src="/favicon.svg" alt="" style="width:20px;height:18px;image-rendering:pixelated;" />`;
 
@@ -1508,15 +1509,19 @@ function ensurePanelSortable(container: HTMLElement | null): void {
 				}
 
 				if (!samePanelTabOrder(currentTabs, reordered)) {
-					setPanelTabsForSession(state, sid, reordered);
+					const orderedIds = reordered.map((tab) => tab.id);
+					void reorderSidePanelTabs(orderedIds, undefined, { sessionId: sid }).catch((err) => {
+						console.warn("[side-panel] failed to persist tab reorder", err);
+					});
 				}
 			} finally {
 				setRenderSuppressed(false);
 				// Always trigger a render: when we took an early `return` above
 				// (pinned-blocked or invariant-violation revert), state was not
 				// mutated and lit-html will restore the canonical DOM order.
-				// When we committed setPanelTabsForSession, it already triggers a
-				// render — an extra one here is harmless.
+				// When we commit through reorderSidePanelTabs, its optimistic mirror
+				// update may have rendered while suppression was active — an extra
+				// render here is harmless and makes the committed order visible.
 				renderApp();
 			}
 		},

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -1131,7 +1131,6 @@ function reviewDocumentKeyFromPanelTab(tab: PanelWorkspaceTab | undefined | null
 export function setUnifiedActiveTab(tab: PanelWorkspaceTab): void {
 	if ((tab as any).kind === "chat" || tab.id === CHAT_PANEL_TAB_ID) return;
 	const sid = workspaceSessionId();
-	(state as any).__lastSidePanelUserActiveSelection = { sessionId: sid, tabId: tab.id, at: Date.now() };
 	setActivePanelTabIdForSession(state, sid, tab.id);
 	const workspace = getSidePanelWorkspace(sid);
 	if (sid !== "__no-session__" && workspace.tabs.some((candidate) => candidate.id === tab.id) && workspace.activeTabId !== tab.id) {

--- a/src/app/review-sources.ts
+++ b/src/app/review-sources.ts
@@ -1,4 +1,5 @@
 import { gatewayFetch } from "./gateway-fetch.js";
+import { legacyReviewDocumentIdFromTitle, rememberReviewDocumentIdentity } from "./panel-workspace.js";
 import { selectReviewWorkspaceTab } from "./preview-panel.js";
 import {
 	activeSessionId,
@@ -18,9 +19,16 @@ import {
 
 const REVIEW_CONTEXT_STORAGE_PREFIX = "bobbit-review-contexts-v1:";
 
+declare module "./state.js" {
+	interface ReviewDocumentModel {
+		documentId?: string;
+	}
+}
+
 export interface OpenMarkdownReviewDocumentOptions {
 	title: string;
 	markdown: string;
+	documentId?: string;
 	replace?: boolean;
 	sessionId?: string;
 }
@@ -65,17 +73,50 @@ function shouldPersistReviewDocument(doc: ReviewDocumentModel): boolean {
 	return doc.source?.kind === "verification-signoff-markdown" || doc.source?.kind === "verification-signoff-pr";
 }
 
+let generatedReviewDocumentCounter = 0;
+
+function safeDocumentIdPart(value: string): string {
+	return encodeURIComponent(value || "no-session").replace(/%/g, "_").slice(0, 80) || "no-session";
+}
+
+function normalizeDocumentId(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	if (!trimmed || trimmed.length > 160 || /[\u0000-\u001f\u007f]/.test(trimmed)) return undefined;
+	return trimmed;
+}
+
+function newReviewDocumentId(sessionId: string): string {
+	generatedReviewDocumentCounter += 1;
+	return `review-doc:${safeDocumentIdPart(sessionId)}:${Date.now().toString(36)}-${generatedReviewDocumentCounter.toString(36)}`;
+}
+
+function reviewDocumentIdForOpen(options: OpenReviewDocumentOptions, title: string, sessionId: string): string {
+	const explicit = normalizeDocumentId(options.documentId);
+	if (explicit) return explicit;
+	const existing = state.reviewDocuments instanceof Map ? state.reviewDocuments.get(title) : undefined;
+	const existingId = normalizeDocumentId(existing?.documentId);
+	if (existing) return existingId || legacyReviewDocumentIdFromTitle(title);
+	return newReviewDocumentId(sessionId);
+}
+
 export function persistReviewDocument(sessionId: string, doc: ReviewDocumentModel): void {
 	if (!shouldPersistReviewDocument(doc)) return;
 	const docs = safeReadPersisted(sessionId);
-	docs[doc.title] = doc;
+	docs[doc.documentId || doc.title] = doc;
 	safeWritePersisted(sessionId, docs);
 }
 
 export function removePersistedReviewDocument(sessionId: string, title: string): void {
 	const docs = safeReadPersisted(sessionId);
-	if (!Object.prototype.hasOwnProperty.call(docs, title)) return;
-	delete docs[title];
+	let changed = false;
+	for (const [key, doc] of Object.entries(docs)) {
+		if (key === title || doc?.title === title || doc?.documentId === title) {
+			delete docs[key];
+			changed = true;
+		}
+	}
+	if (!changed) return;
 	safeWritePersisted(sessionId, docs);
 }
 
@@ -145,12 +186,15 @@ export function openReviewDocument(options: OpenReviewDocumentOptions): ReviewDo
 	const sessionId = options.sessionId || activeSessionId() || "";
 	const source = sourceWithDefault(options.source, sessionId);
 	const title = options.title || signoffTitle(source);
-	const doc: ReviewDocumentModel = { title, markdown: options.markdown, source };
+	const documentId = reviewDocumentIdForOpen(options, title, sessionId);
+	const doc: ReviewDocumentModel = { title, markdown: options.markdown, source, documentId };
 	state.reviewDocuments = new Map(state.reviewDocuments);
 	if (options.replace !== false || !state.reviewDocuments.has(title)) {
 		state.reviewDocuments.set(title, doc);
 	}
 	const storedDoc = state.reviewDocuments.get(title) || doc;
+	if (!storedDoc.documentId) storedDoc.documentId = documentId;
+	rememberReviewDocumentIdentity(title, storedDoc.documentId);
 	state.reviewPanelOpen = true;
 	state.reviewActiveTab = title;
 	state.previewPanelActiveTab = "review";
@@ -174,7 +218,8 @@ export function openReviewDocumentFromEvent(detail: unknown, sessionId = activeS
 		? record.title.trim()
 		: source ? signoffTitle(source) : "Review";
 	const replace = typeof record.replace === "boolean" ? record.replace : true;
-	return openReviewDocument({ title, markdown, source, replace, sessionId });
+	const documentId = normalizeDocumentId(record.documentId);
+	return openReviewDocument({ title, markdown, source, documentId, replace, sessionId });
 }
 
 export function restorePersistedReviewDocuments(sessionId: string, options: { select?: boolean } = {}): void {
@@ -185,6 +230,8 @@ export function restorePersistedReviewDocuments(sessionId: string, options: { se
 	let firstTitle = "";
 	for (const doc of entries) {
 		if (!firstTitle) firstTitle = doc.title;
+		if (!doc.documentId) doc.documentId = legacyReviewDocumentIdFromTitle(doc.title);
+		rememberReviewDocumentIdentity(doc.title, doc.documentId);
 		if (!state.reviewDocuments.has(doc.title)) state.reviewDocuments.set(doc.title, doc);
 	}
 	state.reviewPanelOpen = state.reviewDocuments.size > 0;
@@ -251,7 +298,9 @@ export function reviewDocumentFromDecisionDetail(detail: unknown): ReviewDocumen
 		if (embedded && typeof embedded === "object" && !Array.isArray(embedded)) {
 			const doc = embedded as Record<string, unknown>;
 			if (typeof doc.title === "string" && typeof doc.markdown === "string") {
-				return { title: doc.title, markdown: doc.markdown, source: normalizeReviewSource(doc.source) || normalizeReviewSource(record.source) };
+				const documentId = normalizeDocumentId(doc.documentId);
+				if (documentId) rememberReviewDocumentIdentity(doc.title, documentId);
+				return { title: doc.title, markdown: doc.markdown, documentId, source: normalizeReviewSource(doc.source) || normalizeReviewSource(record.source) };
 			}
 		}
 		const title = typeof record.title === "string" ? record.title

--- a/src/app/review-sources.ts
+++ b/src/app/review-sources.ts
@@ -106,6 +106,11 @@ function reviewDocumentIdForOpen(options: OpenReviewDocumentOptions, title: stri
 	const existing = state.reviewDocuments instanceof Map ? state.reviewDocuments.get(title) : undefined;
 	const existingId = normalizeDocumentId(existing?.documentId);
 	if (existing) return existingId || legacyReviewDocumentIdFromTitle(title);
+	if (sessionId) {
+		const persisted = Object.values(safeReadPersisted(sessionId)).find((doc) => doc?.title === title);
+		const persistedId = normalizeDocumentId(persisted?.documentId);
+		if (persistedId) return persistedId;
+	}
 	const matchingWorkspaceTab = getSidePanelWorkspace(sessionId).tabs.find((tab) => {
 		if (tab.kind !== "review") return false;
 		const source = tab.source as Record<string, unknown> | undefined;

--- a/src/app/review-sources.ts
+++ b/src/app/review-sources.ts
@@ -1,7 +1,7 @@
 import { gatewayFetch } from "./gateway-fetch.js";
 import { legacyReviewDocumentIdFromTitle, rememberReviewDocumentIdentity, reviewPanelTabId } from "./panel-workspace.js";
 import { selectReviewWorkspaceTab } from "./preview-panel.js";
-import { closeSidePanelTab } from "./side-panel-workspace.js";
+import { closeSidePanelTab, getSidePanelWorkspace } from "./side-panel-workspace.js";
 import {
 	activeSessionId,
 	renderApp,
@@ -92,12 +92,27 @@ function newReviewDocumentId(sessionId: string): string {
 	return `review-doc:${safeDocumentIdPart(sessionId)}:${Date.now().toString(36)}-${generatedReviewDocumentCounter.toString(36)}`;
 }
 
+function documentIdFromReviewTabId(tabId: string): string | undefined {
+	if (!tabId.startsWith("review:")) return undefined;
+	try { return normalizeDocumentId(decodeURIComponent(tabId.slice("review:".length))); }
+	catch { return undefined; }
+}
+
 function reviewDocumentIdForOpen(options: OpenReviewDocumentOptions, title: string, sessionId: string): string {
 	const explicit = normalizeDocumentId(options.documentId);
 	if (explicit) return explicit;
 	const existing = state.reviewDocuments instanceof Map ? state.reviewDocuments.get(title) : undefined;
 	const existingId = normalizeDocumentId(existing?.documentId);
 	if (existing) return existingId || legacyReviewDocumentIdFromTitle(title);
+	const matchingWorkspaceTab = getSidePanelWorkspace(sessionId).tabs.find((tab) => {
+		if (tab.kind !== "review") return false;
+		const source = tab.source as Record<string, unknown> | undefined;
+		const tabTitle = typeof source?.title === "string" ? source.title : tab.title.replace(/^Review:\s*/, "");
+		return tabTitle === title;
+	});
+	const workspaceId = normalizeDocumentId((matchingWorkspaceTab?.source as Record<string, unknown> | undefined)?.documentId)
+		|| (matchingWorkspaceTab ? documentIdFromReviewTabId(matchingWorkspaceTab.id) : undefined);
+	if (workspaceId) return workspaceId;
 	return newReviewDocumentId(sessionId);
 }
 
@@ -201,6 +216,14 @@ export function openReviewDocument(options: OpenReviewDocumentOptions): ReviewDo
 	state.previewPanelActiveTab = "review";
 	state.previewPanelTab = "review";
 	selectReviewWorkspaceTab(title, { sessionId, select: true });
+	if (options.replace !== false) {
+		for (const tab of getSidePanelWorkspace(sessionId).tabs) {
+			if (tab.kind !== "review" || tab.id === reviewPanelTabId(storedDoc.documentId || documentId)) continue;
+			const source = tab.source as Record<string, unknown> | undefined;
+			const tabTitle = typeof source?.title === "string" ? source.title : tab.title.replace(/^Review:\s*/, "");
+			if (tabTitle === title) void closeSidePanelTab(tab.id, { sessionId });
+		}
+	}
 	if (sessionId) {
 		persistReviewDocument(sessionId, storedDoc);
 	}
@@ -237,6 +260,36 @@ export function restorePersistedReviewDocuments(sessionId: string, _options: { s
 	state.reviewPanelOpen = state.reviewDocuments.size > 0;
 	if (!state.reviewActiveTab && firstTitle) state.reviewActiveTab = firstTitle;
 	renderApp();
+}
+
+function reviewWorkspaceTabMatchesTitle(tab: unknown, title: string): boolean {
+	if (!tab || typeof tab !== "object") return false;
+	const record = tab as Record<string, unknown>;
+	if (record.kind !== "review") return false;
+	const source = record.source && typeof record.source === "object" && !Array.isArray(record.source)
+		? record.source as Record<string, unknown>
+		: undefined;
+	const tabTitle = typeof source?.title === "string" ? source.title
+		: typeof record.title === "string" ? record.title.replace(/^Review:\s*/, "")
+		: "";
+	return tabTitle === title;
+}
+
+async function deleteReviewWorkspaceTabsFromServer(sessionId: string, title: string): Promise<void> {
+	if (!sessionId) return;
+	for (let attempt = 0; attempt < 3; attempt += 1) {
+		const response = await gatewayFetch(`/api/sessions/${encodeURIComponent(sessionId)}/side-panel-workspace`).catch(() => null);
+		if (!response?.ok) return;
+		const workspace = await response.json().catch(() => null) as { tabs?: unknown[] } | null;
+		const staleIds = (Array.isArray(workspace?.tabs) ? workspace!.tabs : [])
+			.filter((tab) => reviewWorkspaceTabMatchesTitle(tab, title))
+			.map((tab) => (tab as Record<string, unknown>).id)
+			.filter((id): id is string => typeof id === "string" && id.startsWith("review:"));
+		if (staleIds.length === 0) return;
+		for (const tabId of staleIds) {
+			await gatewayFetch(`/api/sessions/${encodeURIComponent(sessionId)}/side-panel-workspace/tabs/${encodeURIComponent(tabId)}`, { method: "DELETE" }).catch(() => undefined);
+		}
+	}
 }
 
 function inlineCommentsFromAnnotations(sessionId: string, documentTitle: string): ReviewInlineCommentPayload[] {
@@ -389,7 +442,13 @@ export async function submitReviewDecision(doc: ReviewDocumentModel, inputPayloa
 		const feedback = composeMarkdownReviewDecisionFeedback(doc, payload);
 		if (!options.prompt) throw new Error("No active agent is available for this review.");
 		await options.prompt(feedback);
-		if (sessionId) markReviewSubmitted(sessionId);
+		if (sessionId) {
+			markReviewSubmitted(sessionId);
+			await gatewayFetch(`/api/sessions/${encodeURIComponent(sessionId)}/review/submitted`, {
+				method: "PUT",
+				body: JSON.stringify({ submitted: true }),
+			}).catch(() => undefined);
+		}
 	}
 	if (sessionId) {
 		clearAnnotations(sessionId, doc.title);
@@ -402,6 +461,18 @@ export async function submitReviewDecision(doc: ReviewDocumentModel, inputPayloa
 		state.reviewActiveTab = [...state.reviewDocuments.keys()][0] || "";
 	}
 	state.reviewPanelOpen = state.reviewDocuments.size > 0;
-	if (doc.documentId) void closeSidePanelTab(reviewPanelTabId(doc.documentId), { sessionId });
+	const tabIdsToClose = new Set<string>();
+	if (doc.documentId) tabIdsToClose.add(reviewPanelTabId(doc.documentId));
+	for (const tab of getSidePanelWorkspace(sessionId).tabs) {
+		if (tab.kind !== "review") continue;
+		const source = tab.source as Record<string, unknown> | undefined;
+		const tabTitle = typeof source?.title === "string" ? source.title : tab.title.replace(/^Review:\s*/, "");
+		if (tabTitle === doc.title) tabIdsToClose.add(tab.id);
+	}
+	for (const tabId of tabIdsToClose) {
+		try { await closeSidePanelTab(tabId, { sessionId }); }
+		catch { /* best-effort; local review state is already cleared */ }
+	}
+	await deleteReviewWorkspaceTabsFromServer(sessionId, doc.title);
 	renderApp();
 }

--- a/src/app/review-sources.ts
+++ b/src/app/review-sources.ts
@@ -71,7 +71,9 @@ function safeWritePersisted(sessionId: string, docs: Record<string, ReviewDocume
 }
 
 function shouldPersistReviewDocument(doc: ReviewDocumentModel): boolean {
-	return doc.source?.kind === "verification-signoff-markdown" || doc.source?.kind === "verification-signoff-pr";
+	return doc.source?.kind === "markdown-review"
+		|| doc.source?.kind === "verification-signoff-markdown"
+		|| doc.source?.kind === "verification-signoff-pr";
 }
 
 let generatedReviewDocumentCounter = 0;
@@ -246,8 +248,23 @@ export function openReviewDocumentFromEvent(detail: unknown, sessionId = activeS
 }
 
 export function restorePersistedReviewDocuments(sessionId: string, _options: { select?: boolean } = {}): void {
+	const workspaceReviewTabs = getSidePanelWorkspace(sessionId).tabs.filter((tab) => tab.kind === "review");
+	if (workspaceReviewTabs.length === 0) return;
+	const openDocumentIds = new Set<string>();
+	const openTitles = new Set<string>();
+	for (const tab of workspaceReviewTabs) {
+		const source = tab.source as Record<string, unknown> | undefined;
+		const documentId = typeof source?.documentId === "string" ? source.documentId : documentIdFromReviewTabId(tab.id);
+		const title = typeof source?.title === "string" ? source.title : tab.title.replace(/^Review:\s*/, "");
+		if (documentId) openDocumentIds.add(documentId);
+		if (title) openTitles.add(title);
+	}
 	const docs = safeReadPersisted(sessionId);
-	const entries = Object.values(docs).filter((doc) => doc?.title && typeof doc.markdown === "string" && shouldPersistReviewDocument(doc));
+	const entries = Object.values(docs).filter((doc) => {
+		if (!doc?.title || typeof doc.markdown !== "string" || !shouldPersistReviewDocument(doc)) return false;
+		const documentId = doc.documentId || legacyReviewDocumentIdFromTitle(doc.title);
+		return openDocumentIds.has(documentId) || openTitles.has(doc.title);
+	});
 	if (entries.length === 0) return;
 	state.reviewDocuments = new Map(state.reviewDocuments);
 	let firstTitle = "";

--- a/src/app/review-sources.ts
+++ b/src/app/review-sources.ts
@@ -100,10 +100,30 @@ function documentIdFromReviewTabId(tabId: string): string | undefined {
 	catch { return undefined; }
 }
 
+function reviewDocumentKey(doc: ReviewDocumentModel): string {
+	return normalizeDocumentId(doc.documentId) || doc.title;
+}
+
+function reviewDocumentMapKey(doc: ReviewDocumentModel): string {
+	const documentId = normalizeDocumentId(doc.documentId);
+	if (documentId && state.reviewDocuments.has(documentId)) return documentId;
+	if (state.reviewDocuments.has(doc.title)) return doc.title;
+	return reviewDocumentKey(doc);
+}
+
+function findReviewDocumentEntryByTitle(title: string): [string, ReviewDocumentModel] | undefined {
+	if (!(state.reviewDocuments instanceof Map)) return undefined;
+	for (const entry of state.reviewDocuments.entries()) {
+		if (entry[1]?.title === title) return entry;
+	}
+	return undefined;
+}
+
 function reviewDocumentIdForOpen(options: OpenReviewDocumentOptions, title: string, sessionId: string): string {
 	const explicit = normalizeDocumentId(options.documentId);
 	if (explicit) return explicit;
-	const existing = state.reviewDocuments instanceof Map ? state.reviewDocuments.get(title) : undefined;
+	if (options.replace === false) return newReviewDocumentId(sessionId);
+	const existing = findReviewDocumentEntryByTitle(title)?.[1];
 	const existingId = normalizeDocumentId(existing?.documentId);
 	if (existing) return existingId || legacyReviewDocumentIdFromTitle(title);
 	if (sessionId) {
@@ -111,15 +131,6 @@ function reviewDocumentIdForOpen(options: OpenReviewDocumentOptions, title: stri
 		const persistedId = normalizeDocumentId(persisted?.documentId);
 		if (persistedId) return persistedId;
 	}
-	const matchingWorkspaceTab = getSidePanelWorkspace(sessionId).tabs.find((tab) => {
-		if (tab.kind !== "review") return false;
-		const source = tab.source as Record<string, unknown> | undefined;
-		const tabTitle = typeof source?.title === "string" ? source.title : tab.title.replace(/^Review:\s*/, "");
-		return tabTitle === title;
-	});
-	const workspaceId = normalizeDocumentId((matchingWorkspaceTab?.source as Record<string, unknown> | undefined)?.documentId)
-		|| (matchingWorkspaceTab ? documentIdFromReviewTabId(matchingWorkspaceTab.id) : undefined);
-	if (workspaceId) return workspaceId;
 	return newReviewDocumentId(sessionId);
 }
 
@@ -212,25 +223,19 @@ export function openReviewDocument(options: OpenReviewDocumentOptions): ReviewDo
 	const documentId = reviewDocumentIdForOpen(options, title, sessionId);
 	const doc: ReviewDocumentModel = { title, markdown: options.markdown, source, documentId };
 	state.reviewDocuments = new Map(state.reviewDocuments);
-	if (options.replace !== false || !state.reviewDocuments.has(title)) {
-		state.reviewDocuments.set(title, doc);
+	const existingEntry = options.replace !== false ? findReviewDocumentEntryByTitle(title) : undefined;
+	const key = existingEntry?.[0] || (options.documentId || options.replace === false ? documentId : title);
+	if (options.replace !== false || !state.reviewDocuments.has(key)) {
+		state.reviewDocuments.set(key, doc);
 	}
-	const storedDoc = state.reviewDocuments.get(title) || doc;
+	const storedDoc = state.reviewDocuments.get(key) || doc;
 	if (!storedDoc.documentId) storedDoc.documentId = documentId;
 	rememberReviewDocumentIdentity(title, storedDoc.documentId);
 	state.reviewPanelOpen = true;
-	state.reviewActiveTab = title;
+	state.reviewActiveTab = key;
 	state.previewPanelActiveTab = "review";
 	state.previewPanelTab = "review";
-	selectReviewWorkspaceTab(title, { sessionId, select: true });
-	if (options.replace !== false) {
-		for (const tab of getSidePanelWorkspace(sessionId).tabs) {
-			if (tab.kind !== "review" || tab.id === reviewPanelTabId(storedDoc.documentId || documentId)) continue;
-			const source = tab.source as Record<string, unknown> | undefined;
-			const tabTitle = typeof source?.title === "string" ? source.title : tab.title.replace(/^Review:\s*/, "");
-			if (tabTitle === title) void closeSidePanelTab(tab.id, { sessionId });
-		}
-	}
+	selectReviewWorkspaceTab(title, { sessionId, select: true, documentId: storedDoc.documentId });
 	if (sessionId) {
 		persistReviewDocument(sessionId, storedDoc);
 	}
@@ -256,19 +261,16 @@ export function restorePersistedReviewDocuments(sessionId: string, _options: { s
 	const workspaceReviewTabs = getSidePanelWorkspace(sessionId).tabs.filter((tab) => tab.kind === "review");
 	if (workspaceReviewTabs.length === 0) return;
 	const openDocumentIds = new Set<string>();
-	const openTitles = new Set<string>();
 	for (const tab of workspaceReviewTabs) {
 		const source = tab.source as Record<string, unknown> | undefined;
 		const documentId = typeof source?.documentId === "string" ? source.documentId : documentIdFromReviewTabId(tab.id);
-		const title = typeof source?.title === "string" ? source.title : tab.title.replace(/^Review:\s*/, "");
 		if (documentId) openDocumentIds.add(documentId);
-		if (title) openTitles.add(title);
 	}
 	const docs = safeReadPersisted(sessionId);
 	const entries = Object.values(docs).filter((doc) => {
 		if (!doc?.title || typeof doc.markdown !== "string" || !shouldPersistReviewDocument(doc)) return false;
 		const documentId = doc.documentId || legacyReviewDocumentIdFromTitle(doc.title);
-		return openDocumentIds.has(documentId) || openTitles.has(doc.title);
+		return openDocumentIds.has(documentId);
 	});
 	if (entries.length === 0) return;
 	state.reviewDocuments = new Map(state.reviewDocuments);
@@ -277,34 +279,40 @@ export function restorePersistedReviewDocuments(sessionId: string, _options: { s
 		if (!firstTitle) firstTitle = doc.title;
 		if (!doc.documentId) doc.documentId = legacyReviewDocumentIdFromTitle(doc.title);
 		rememberReviewDocumentIdentity(doc.title, doc.documentId);
-		if (!state.reviewDocuments.has(doc.title)) state.reviewDocuments.set(doc.title, doc);
+		const key = reviewDocumentKey(doc);
+		if (!state.reviewDocuments.has(key)) state.reviewDocuments.set(key, doc);
 	}
 	state.reviewPanelOpen = state.reviewDocuments.size > 0;
-	if (!state.reviewActiveTab && firstTitle) state.reviewActiveTab = firstTitle;
+	if (!state.reviewActiveTab && firstTitle) {
+		const firstDoc = entries.find((doc) => doc.title === firstTitle);
+		state.reviewActiveTab = firstDoc ? reviewDocumentKey(firstDoc) : firstTitle;
+	}
 	renderApp();
 }
 
-function reviewWorkspaceTabMatchesTitle(tab: unknown, title: string): boolean {
+function reviewWorkspaceTabMatchesDocument(tab: unknown, doc: ReviewDocumentModel): boolean {
 	if (!tab || typeof tab !== "object") return false;
 	const record = tab as Record<string, unknown>;
 	if (record.kind !== "review") return false;
 	const source = record.source && typeof record.source === "object" && !Array.isArray(record.source)
 		? record.source as Record<string, unknown>
 		: undefined;
+	const documentId = normalizeDocumentId(source?.documentId) || (typeof record.id === "string" ? documentIdFromReviewTabId(record.id) : undefined);
+	if (doc.documentId) return documentId === doc.documentId;
 	const tabTitle = typeof source?.title === "string" ? source.title
 		: typeof record.title === "string" ? record.title.replace(/^Review:\s*/, "")
 		: "";
-	return tabTitle === title;
+	return tabTitle === doc.title;
 }
 
-async function deleteReviewWorkspaceTabsFromServer(sessionId: string, title: string): Promise<void> {
+async function deleteReviewWorkspaceTabsFromServer(sessionId: string, doc: ReviewDocumentModel): Promise<void> {
 	if (!sessionId) return;
 	for (let attempt = 0; attempt < 3; attempt += 1) {
 		const response = await gatewayFetch(`/api/sessions/${encodeURIComponent(sessionId)}/side-panel-workspace`).catch(() => null);
 		if (!response?.ok) return;
 		const workspace = await response.json().catch(() => null) as { tabs?: unknown[] } | null;
 		const staleIds = (Array.isArray(workspace?.tabs) ? workspace!.tabs : [])
-			.filter((tab) => reviewWorkspaceTabMatchesTitle(tab, title))
+			.filter((tab) => reviewWorkspaceTabMatchesDocument(tab, doc))
 			.map((tab) => (tab as Record<string, unknown>).id)
 			.filter((id): id is string => typeof id === "string" && id.startsWith("review:"));
 		if (staleIds.length === 0) return;
@@ -373,10 +381,12 @@ export function reviewDocumentFromDecisionDetail(detail: unknown): ReviewDocumen
 				return { title: doc.title, markdown: doc.markdown, documentId, source: normalizeReviewSource(doc.source) || normalizeReviewSource(record.source) };
 			}
 		}
+		const documentId = normalizeDocumentId(record.documentId);
+		if (documentId) return state.reviewDocuments.get(documentId);
 		const title = typeof record.title === "string" ? record.title
 			: typeof record.documentTitle === "string" ? record.documentTitle
 			: state.reviewActiveTab;
-		if (title) return state.reviewDocuments.get(title);
+		if (title) return state.reviewDocuments.get(title) || findReviewDocumentEntryByTitle(title)?.[1];
 	}
 	return state.reviewActiveTab ? state.reviewDocuments.get(state.reviewActiveTab) : undefined;
 }
@@ -478,8 +488,9 @@ export async function submitReviewDecision(doc: ReviewDocumentModel, inputPayloa
 	}
 	await flushPendingWrites();
 	state.reviewDocuments = new Map(state.reviewDocuments);
-	state.reviewDocuments.delete(doc.title);
-	if (state.reviewActiveTab === doc.title) {
+	const docKey = reviewDocumentMapKey(doc);
+	state.reviewDocuments.delete(docKey);
+	if (state.reviewActiveTab === docKey) {
 		state.reviewActiveTab = [...state.reviewDocuments.keys()][0] || "";
 	}
 	state.reviewPanelOpen = state.reviewDocuments.size > 0;
@@ -487,14 +498,12 @@ export async function submitReviewDecision(doc: ReviewDocumentModel, inputPayloa
 	if (doc.documentId) tabIdsToClose.add(reviewPanelTabId(doc.documentId));
 	for (const tab of getSidePanelWorkspace(sessionId).tabs) {
 		if (tab.kind !== "review") continue;
-		const source = tab.source as Record<string, unknown> | undefined;
-		const tabTitle = typeof source?.title === "string" ? source.title : tab.title.replace(/^Review:\s*/, "");
-		if (tabTitle === doc.title) tabIdsToClose.add(tab.id);
+		if (reviewWorkspaceTabMatchesDocument(tab, doc)) tabIdsToClose.add(tab.id);
 	}
 	for (const tabId of tabIdsToClose) {
 		try { await closeSidePanelTab(tabId, { sessionId }); }
 		catch { /* best-effort; local review state is already cleared */ }
 	}
-	await deleteReviewWorkspaceTabsFromServer(sessionId, doc.title);
+	await deleteReviewWorkspaceTabsFromServer(sessionId, doc);
 	renderApp();
 }

--- a/src/app/review-sources.ts
+++ b/src/app/review-sources.ts
@@ -1,6 +1,7 @@
 import { gatewayFetch } from "./gateway-fetch.js";
-import { legacyReviewDocumentIdFromTitle, rememberReviewDocumentIdentity } from "./panel-workspace.js";
+import { legacyReviewDocumentIdFromTitle, rememberReviewDocumentIdentity, reviewPanelTabId } from "./panel-workspace.js";
 import { selectReviewWorkspaceTab } from "./preview-panel.js";
+import { closeSidePanelTab } from "./side-panel-workspace.js";
 import {
 	activeSessionId,
 	renderApp,
@@ -201,7 +202,6 @@ export function openReviewDocument(options: OpenReviewDocumentOptions): ReviewDo
 	state.previewPanelTab = "review";
 	selectReviewWorkspaceTab(title, { sessionId, select: true });
 	if (sessionId) {
-		localStorage.removeItem(`bobbit-preview-collapsed-${sessionId}`);
 		persistReviewDocument(sessionId, storedDoc);
 	}
 	renderApp();
@@ -222,7 +222,7 @@ export function openReviewDocumentFromEvent(detail: unknown, sessionId = activeS
 	return openReviewDocument({ title, markdown, source, documentId, replace, sessionId });
 }
 
-export function restorePersistedReviewDocuments(sessionId: string, options: { select?: boolean } = {}): void {
+export function restorePersistedReviewDocuments(sessionId: string, _options: { select?: boolean } = {}): void {
 	const docs = safeReadPersisted(sessionId);
 	const entries = Object.values(docs).filter((doc) => doc?.title && typeof doc.markdown === "string" && shouldPersistReviewDocument(doc));
 	if (entries.length === 0) return;
@@ -236,11 +236,6 @@ export function restorePersistedReviewDocuments(sessionId: string, options: { se
 	}
 	state.reviewPanelOpen = state.reviewDocuments.size > 0;
 	if (!state.reviewActiveTab && firstTitle) state.reviewActiveTab = firstTitle;
-	if (options.select !== false && state.reviewActiveTab) {
-		state.previewPanelActiveTab = "review";
-		state.previewPanelTab = "review";
-		selectReviewWorkspaceTab(state.reviewActiveTab, { sessionId, select: true });
-	}
 	renderApp();
 }
 
@@ -407,8 +402,6 @@ export async function submitReviewDecision(doc: ReviewDocumentModel, inputPayloa
 		state.reviewActiveTab = [...state.reviewDocuments.keys()][0] || "";
 	}
 	state.reviewPanelOpen = state.reviewDocuments.size > 0;
-	if (state.reviewPanelOpen && state.reviewActiveTab) {
-		selectReviewWorkspaceTab(state.reviewActiveTab, { sessionId, select: true });
-	}
+	if (doc.documentId) void closeSidePanelTab(reviewPanelTabId(doc.documentId), { sessionId });
 	renderApp();
 }

--- a/src/app/review-sources.ts
+++ b/src/app/review-sources.ts
@@ -1,5 +1,5 @@
 import { gatewayFetch } from "./gateway-fetch.js";
-import { legacyReviewDocumentIdFromTitle, rememberReviewDocumentIdentity, reviewPanelTabId } from "./panel-workspace.js";
+import { legacyReviewDocumentIdFromTitle, rememberReviewDocumentIdentity, reviewDocumentIdFromPanelTab, reviewPanelTabId, reviewTitleFromPanelTab } from "./panel-workspace.js";
 import { selectReviewWorkspaceTab } from "./preview-panel.js";
 import { closeSidePanelTab, getSidePanelWorkspace } from "./side-panel-workspace.js";
 import {
@@ -119,6 +119,18 @@ function findReviewDocumentEntryByTitle(title: string): [string, ReviewDocumentM
 	return undefined;
 }
 
+function findOpenReviewWorkspaceDocumentId(sessionId: string, title: string): string | undefined {
+	if (!sessionId || !title) return undefined;
+	for (const tab of getSidePanelWorkspace(sessionId).tabs) {
+		if (tab.kind !== "review") continue;
+		const tabTitle = reviewTitleFromPanelTab(tab as any) || tab.title.replace(/^Review:\s*/, "");
+		if (tabTitle !== title) continue;
+		const documentId = normalizeDocumentId(reviewDocumentIdFromPanelTab(tab as any));
+		if (documentId) return documentId;
+	}
+	return undefined;
+}
+
 function reviewDocumentIdForOpen(options: OpenReviewDocumentOptions, title: string, sessionId: string): string {
 	const explicit = normalizeDocumentId(options.documentId);
 	if (explicit) return explicit;
@@ -126,6 +138,8 @@ function reviewDocumentIdForOpen(options: OpenReviewDocumentOptions, title: stri
 	const existing = findReviewDocumentEntryByTitle(title)?.[1];
 	const existingId = normalizeDocumentId(existing?.documentId);
 	if (existing) return existingId || legacyReviewDocumentIdFromTitle(title);
+	const openWorkspaceId = findOpenReviewWorkspaceDocumentId(sessionId, title);
+	if (openWorkspaceId) return openWorkspaceId;
 	if (sessionId) {
 		const persisted = Object.values(safeReadPersisted(sessionId)).find((doc) => doc?.title === title);
 		const persistedId = normalizeDocumentId(persisted?.documentId);

--- a/src/app/routing.ts
+++ b/src/app/routing.ts
@@ -10,6 +10,8 @@ export type SettingsTabId = "shortcuts" | "general" | "project" | "components" |
 export interface AppRoute {
 	view: RouteView;
 	sessionId?: string;
+	/** Side-panel standalone deep link parsed from `#/session/<id>/panel/<tabId>`. */
+	panelTabId?: string;
 	goalId?: string;
 	roleName?: string;
 	toolName?: string;
@@ -51,6 +53,12 @@ export function getRouteFromHash(): AppRoute {
 			for (const [k, v] of new URLSearchParams(hash.slice(qIdx + 1))) params[k] = v;
 		}
 		return { view: "ext", extRouteId: routeId || undefined, extParams: params };
+	}
+	const sessionPanelMatch = hash.match(/^#\/session\/([a-zA-Z0-9_-]+)\/panel\/(.+)$/i);
+	if (sessionPanelMatch) {
+		let panelTabId = sessionPanelMatch[2];
+		try { panelTabId = decodeURIComponent(panelTabId); } catch { /* keep encoded id */ }
+		return { view: "session", sessionId: sessionPanelMatch[1], panelTabId };
 	}
 	const sessionMatch = hash.match(/^#\/session\/([a-zA-Z0-9_-]+)$/i);
 	if (sessionMatch) {

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -212,6 +212,21 @@ function revealActiveProposalPanel(type: ProposalType, sessionId: string): void 
 	}
 }
 
+function openAssistantProposalWorkspaceTab(type: ProposalType, sessionId: string): void {
+	const title = type === "project" ? "Project Proposal"
+		: type === "staff" ? "Staff Proposal"
+		: `${type.charAt(0).toUpperCase()}${type.slice(1)} Proposal`;
+	selectPanelWorkspaceTab({
+		id: proposalPanelTabId(type),
+		kind: "proposal",
+		title,
+		label: title.replace(/ Proposal$/, ""),
+		legacyTab: type as any,
+		source: { type: "proposal", proposalType: type, sessionId },
+		state: {},
+	}, { sessionId, select: true, setAssistantTab: true });
+}
+
 function liveProposalSlotForSession(type: ProposalType, sessionId: string): ProposalSlot | undefined {
 	const slot = state.activeProposals[type];
 	if (!slot) return undefined;
@@ -2197,6 +2212,7 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			} else if (state.assistantType === "staff") {
 				state.assistantTab = "chat";
 				resetStaffProposalPreview(sessionId);
+				if (options?.isStaffAssistant && !isExisting) openAssistantProposalWorkspaceTab("staff", sessionId);
 			} else if (state.assistantType === "project" || state.assistantType === "project-scaffolding") {
 				const restored = await restoreProjectDraft(sessionId);
 				if (isStale()) return;
@@ -2689,7 +2705,8 @@ async function acceptRegisteredProjectProposal(): Promise<void> {
 	delete state.activeProposals.project;
 	state.assistantHasProposal = false;
 	const keepAssistantPanelOpen = (state.assistantType === "project" || state.assistantType === "project-scaffolding") && propSessionId === activeSessionId();
-	if (!keepAssistantPanelOpen) removePanelWorkspaceTabs([proposalPanelTabId("project")], { sessionId: propSessionId, select: false, clearCollapse: false });
+	if (keepAssistantPanelOpen) openAssistantProposalWorkspaceTab("project", propSessionId);
+	else removePanelWorkspaceTabs([proposalPanelTabId("project")], { sessionId: propSessionId, select: false, clearCollapse: false });
 	// Persist the accepted flag in the on-disk draft so it survives reload.
 	saveProjectDraft(propSessionId);
 	// Slice E: drop the on-disk proposal file once accepted.

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -2190,6 +2190,7 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			} else if (state.assistantType === "staff") {
 				state.assistantTab = "chat";
 				resetStaffProposalPreview(sessionId);
+				selectProposalWorkspaceTab("staff", { sessionId, select: true });
 			} else if (state.assistantType === "project" || state.assistantType === "project-scaffolding") {
 				const restored = await restoreProjectDraft(sessionId);
 				if (isStale()) return;

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -2197,7 +2197,6 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			} else if (state.assistantType === "staff") {
 				state.assistantTab = "chat";
 				resetStaffProposalPreview(sessionId);
-				selectProposalWorkspaceTab("staff", { sessionId, select: true });
 			} else if (state.assistantType === "project" || state.assistantType === "project-scaffolding") {
 				const restored = await restoreProjectDraft(sessionId);
 				if (isStale()) return;
@@ -2206,7 +2205,6 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 					delete state.activeProposals.project;
 					state.assistantHasProposal = false;
 				}
-				selectProposalWorkspaceTab("project", { sessionId, select: true });
 			}
 		})();
 

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -966,8 +966,12 @@ export function selectSession(sessionId: string, replaceHistory?: boolean): void
 	state.chatPanel = null;
 	state.cwdDropdownOpen = false;
 
-	// Update hash route synchronously
-	setHashRoute("session", sessionId, replaceHistory);
+	// Update hash route synchronously. Preserve an existing standalone
+	// side-panel route for this same session while the connection hydrates it.
+	const currentRoute = getRouteFromHash();
+	if (!(currentRoute.view === "session" && currentRoute.sessionId === sessionId && currentRoute.panelTabId)) {
+		setHashRoute("session", sessionId, replaceHistory);
+	}
 
 	// Update hue rotation synchronously
 	document.documentElement.style.setProperty("--bobbit-hue-rotate", `${sessionHueRotation(sessionId)}deg`);

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -18,6 +18,7 @@ import { gatewayFetch, saveDraftToServer, loadDraftFromServer, deleteDraftFromSe
 import { formatProjectAssistantAutoPrompt } from "./project-assistant-autoprompt.js";
 import { reconcilePackRenderersForProject } from "./pack-renderers.js";
 import { reconcilePackPanelsForProject, setSessionSwitcher } from "./pack-panels.js";
+import { hydrateSidePanelWorkspace } from "./side-panel-workspace.js";
 import { reconcilePackEntrypointsForProject } from "./pack-entrypoints.js";
 import { errorDetails } from "./error-helpers.js";
 import { runGitStatusRefresh, abortableSleep } from "./git-status-refresh.js";
@@ -1232,6 +1233,8 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 
 		await remote.connect(url, token, sessionId);
 		if (isStale()) { remote.disconnect(); return; }
+		await hydrateSidePanelWorkspace(sessionId);
+		if (isStale()) { remote.disconnect(); return; }
 
 		// ── Fire the transcript snapshot request the INSTANT the WS is
 		// authenticated — before the refreshSessions()/setAgent() awaits below.
@@ -2199,6 +2202,7 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 					delete state.activeProposals.project;
 					state.assistantHasProposal = false;
 				}
+				selectProposalWorkspaceTab("project", { sessionId, select: true });
 			}
 		})();
 
@@ -2575,6 +2579,7 @@ async function acceptProvisionalProjectProposal(): Promise<void> {
 	invalidateProjectScopeConfig(projectId);
 	delete state.activeProposals.project;
 	state.assistantHasProposal = false;
+	removePanelWorkspaceTabs([proposalPanelTabId("project")], { sessionId: propSessionId, select: false, clearCollapse: false });
 	if (proposal.sessionId) {
 		deleteProjectDraft(proposal.sessionId);
 		// Slice E: drop the on-disk proposal file once accepted.
@@ -2681,6 +2686,8 @@ async function acceptRegisteredProjectProposal(): Promise<void> {
 	state.projectProposalAcceptedBySessionId[propSessionId] = true;
 	delete state.activeProposals.project;
 	state.assistantHasProposal = false;
+	const keepAssistantPanelOpen = (state.assistantType === "project" || state.assistantType === "project-scaffolding") && propSessionId === activeSessionId();
+	if (!keepAssistantPanelOpen) removePanelWorkspaceTabs([proposalPanelTabId("project")], { sessionId: propSessionId, select: false, clearCollapse: false });
 	// Persist the accepted flag in the on-disk draft so it survives reload.
 	saveProjectDraft(propSessionId);
 	// Slice E: drop the on-disk proposal file once accepted.

--- a/src/app/side-panel-workspace.ts
+++ b/src/app/side-panel-workspace.ts
@@ -1,0 +1,673 @@
+import { gatewayFetch } from "./gateway-fetch.js";
+import { activeSessionId, renderApp, state } from "./state.js";
+import {
+	INBOX_PANEL_TAB_ID,
+	panelWorkspaceSessionKey,
+	previewContentHashFromTab,
+	previewEntryLabel,
+	previewTabDisplayTitle,
+	previewTabEntryFromId,
+	previewTabVersionFromId,
+	reviewTitleFromPanelTab,
+	type PanelWorkspaceTab,
+} from "./panel-workspace.js";
+
+export type SidePanelSizeMode = "collapsed" | "split" | "fullscreen";
+export type SidePanelKind = "preview" | "proposal" | "review" | "inbox" | "pack";
+export type SidePanelProposalType = "goal" | "project" | "role" | "tool" | "staff";
+
+export interface SidePanelWorkspaceTab {
+	id: string;
+	kind: SidePanelKind;
+	title: string;
+	label: string;
+	source:
+		| { type: "preview"; sessionId: string; entry: string; live?: boolean; historical?: boolean; version?: number; artifactId?: string; contentHash?: string; path?: string; url?: string; toolUseId?: string; blockIndex?: number }
+		| { type: "proposal"; sessionId: string; proposalType: SidePanelProposalType; rev?: number; historical?: boolean }
+		| { type: "review"; sessionId: string; documentId: string; title: string }
+		| { type: "inbox"; sessionId: string; staffId?: string }
+		| { type: "pack"; sessionId: string; packId: string; panelId: string; instanceKey: string; singleton?: boolean; params?: Record<string, unknown> };
+	state?: Record<string, unknown>;
+	updatedAt: number;
+}
+
+export interface SidePanelWorkspaceMetadata {
+	migratedFromLocalStorageAt?: number;
+}
+
+export interface SidePanelWorkspace {
+	version: 1;
+	sessionId: string;
+	revision: number;
+	tabs: SidePanelWorkspaceTab[];
+	activeTabId: string;
+	sizeMode: SidePanelSizeMode;
+	metadata?: SidePanelWorkspaceMetadata;
+	updatedAt: number;
+}
+
+type PreviewSource = Extract<SidePanelWorkspaceTab["source"], { type: "preview" }>;
+type ProposalSource = Extract<SidePanelWorkspaceTab["source"], { type: "proposal" }>;
+type ReviewSource = Extract<SidePanelWorkspaceTab["source"], { type: "review" }>;
+type PackSource = Extract<SidePanelWorkspaceTab["source"], { type: "pack" }>;
+
+export interface OpenSidePanelTabOptions {
+	focus?: boolean;
+	placeAfterActive?: boolean;
+	baseRevision?: number;
+	strictRevision?: boolean;
+}
+
+export interface SidePanelMutationOptions {
+	baseRevision?: number;
+	strictRevision?: boolean;
+	skipRender?: boolean;
+}
+
+type PendingMutation = {
+	id: string;
+	baseRevision: number;
+	baseWorkspace: SidePanelWorkspace;
+};
+
+const PANEL_TABS_STORAGE_KEY = "bobbit-panel-tabs-by-session";
+const PANEL_ACTIVE_STORAGE_KEY = "bobbit-panel-active-by-session";
+const mutationState = new Map<string, PendingMutation>();
+let mutationCounter = 0;
+
+function now(): number {
+	return Date.now();
+}
+
+function emptyWorkspace(sessionId: string): SidePanelWorkspace {
+	return {
+		version: 1,
+		sessionId,
+		revision: 0,
+		tabs: [],
+		activeTabId: "",
+		sizeMode: "split",
+		updatedAt: now(),
+	};
+}
+
+function isSizeMode(value: unknown): value is SidePanelSizeMode {
+	return value === "collapsed" || value === "split" || value === "fullscreen";
+}
+
+function isPanelKind(value: unknown): value is SidePanelKind {
+	return value === "preview" || value === "proposal" || value === "review" || value === "inbox" || value === "pack";
+}
+
+function isProposalType(value: unknown): value is SidePanelProposalType {
+	return value === "goal" || value === "project" || value === "role" || value === "tool" || value === "staff";
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
+}
+
+function stringValue(value: unknown): string {
+	return typeof value === "string" ? value : "";
+}
+
+function positiveInt(value: unknown): number | undefined {
+	const n = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
+	return Number.isInteger(n) && n > 0 ? n : undefined;
+}
+
+function cloneJsonRecord(value: unknown): Record<string, unknown> | undefined {
+	const record = asRecord(value);
+	if (!record) return undefined;
+	try {
+		const cloned = JSON.parse(JSON.stringify(record));
+		return asRecord(cloned);
+	} catch {
+		return undefined;
+	}
+}
+
+function decodeComponent(value: string): string {
+	try { return decodeURIComponent(value); } catch { return value; }
+}
+
+function encodeComponent(value: string): string {
+	return encodeURIComponent(value);
+}
+
+function normalizeTab(raw: unknown, sessionId: string): SidePanelWorkspaceTab | null {
+	const tab = asRecord(raw);
+	if (!tab) return null;
+	const id = stringValue(tab.id);
+	const kind = tab.kind;
+	const source = asRecord(tab.source);
+	if (!id || !isPanelKind(kind) || !source || source.type !== kind) return null;
+	if (stringValue(source.sessionId) && stringValue(source.sessionId) !== sessionId) return null;
+	const base = {
+		id,
+		kind,
+		title: stringValue(tab.title) || stringValue(tab.label) || id,
+		label: stringValue(tab.label) || stringValue(tab.title) || id,
+		state: cloneJsonRecord(tab.state),
+		updatedAt: typeof tab.updatedAt === "number" && Number.isFinite(tab.updatedAt) ? tab.updatedAt : now(),
+	};
+	if (kind === "preview") {
+		const entry = previewEntryLabel(stringValue(source.entry) || previewTabEntryFromId(id) || undefined);
+		if (!entry) return null;
+		const version = positiveInt(source.version) ?? previewTabVersionFromId(id);
+		return {
+			...base,
+			kind,
+			source: {
+				type: "preview",
+				sessionId,
+				entry,
+				...(source.live === true ? { live: true } : {}),
+				...(source.historical === true || version ? { historical: true } : {}),
+				...(version ? { version } : {}),
+				...(stringValue(source.artifactId) ? { artifactId: stringValue(source.artifactId) } : {}),
+				...(stringValue(source.contentHash) ? { contentHash: stringValue(source.contentHash) } : {}),
+				...(stringValue(source.path) ? { path: stringValue(source.path) } : {}),
+				...(stringValue(source.url) ? { url: stringValue(source.url) } : {}),
+				...(stringValue(source.toolUseId) ? { toolUseId: stringValue(source.toolUseId) } : {}),
+				...(typeof source.blockIndex === "number" ? { blockIndex: source.blockIndex } : {}),
+			},
+		};
+	}
+	if (kind === "proposal") {
+		const proposalType = source.proposalType;
+		if (!isProposalType(proposalType)) return null;
+		const rev = positiveInt(source.rev);
+		return {
+			...base,
+			kind,
+			source: { type: "proposal", sessionId, proposalType, ...(rev ? { rev, historical: true } : source.historical === true ? { historical: true } : {}) },
+		};
+	}
+	if (kind === "review") {
+		const documentId = stringValue(source.documentId);
+		const title = stringValue(source.title) || base.title.replace(/^Review:\s*/, "");
+		if (!documentId || !title) return null;
+		return { ...base, kind, source: { type: "review", sessionId, documentId, title } };
+	}
+	if (kind === "inbox") {
+		return { ...base, id: INBOX_PANEL_TAB_ID, kind, source: { type: "inbox", sessionId, ...(stringValue(source.staffId) ? { staffId: stringValue(source.staffId) } : {}) } };
+	}
+	const packId = stringValue(source.packId);
+	const panelId = stringValue(source.panelId);
+	const instanceKey = stringValue(source.instanceKey) || "default";
+	if (!packId || !panelId || !instanceKey) return null;
+	return {
+		...base,
+		kind,
+		source: {
+			type: "pack",
+			sessionId,
+			packId,
+			panelId,
+			instanceKey,
+			...(source.singleton === true ? { singleton: true } : {}),
+			...(cloneJsonRecord(source.params) ? { params: cloneJsonRecord(source.params) } : {}),
+		},
+	};
+}
+
+function normalizeWorkspace(raw: unknown, sessionId: string): SidePanelWorkspace {
+	const record = asRecord(raw);
+	if (!record) return emptyWorkspace(sessionId);
+	const seen = new Set<string>();
+	const tabs: SidePanelWorkspaceTab[] = [];
+	for (const rawTab of Array.isArray(record.tabs) ? record.tabs : []) {
+		const tab = normalizeTab(rawTab, sessionId);
+		if (!tab || seen.has(tab.id)) continue;
+		seen.add(tab.id);
+		tabs.push(tab);
+	}
+	const activeTabId = stringValue(record.activeTabId);
+	const metadata = asRecord(record.metadata);
+	return {
+		version: 1,
+		sessionId,
+		revision: typeof record.revision === "number" && Number.isFinite(record.revision) ? Math.max(0, Math.trunc(record.revision)) : 0,
+		tabs,
+		activeTabId: tabs.some((tab) => tab.id === activeTabId) ? activeTabId : tabs[0]?.id || "",
+		sizeMode: isSizeMode(record.sizeMode) ? record.sizeMode : "split",
+		...(metadata?.migratedFromLocalStorageAt ? { metadata: { migratedFromLocalStorageAt: Number(metadata.migratedFromLocalStorageAt) } } : {}),
+		updatedAt: typeof record.updatedAt === "number" && Number.isFinite(record.updatedAt) ? record.updatedAt : now(),
+	};
+}
+
+function activeMirrorSessionKey(): string {
+	return panelWorkspaceSessionKey(activeSessionId() || state.selectedSessionId || state.remoteAgent?.gatewaySessionId);
+}
+
+function toLegacyPanelTab(tab: SidePanelWorkspaceTab): PanelWorkspaceTab {
+	if (tab.kind === "preview") {
+		const source = tab.source as PreviewSource;
+		const version = source.version;
+		return {
+			id: tab.id,
+			kind: "preview",
+			title: tab.title,
+			label: tab.label,
+			legacyTab: "preview",
+			source: { ...source, type: "preview" },
+			state: { ...(tab.state || {}), entry: source.entry, ...(version ? { version } : {}), ...(source.historical ? { historical: true } : {}) },
+		};
+	}
+	if (tab.kind === "proposal") {
+		const source = tab.source as ProposalSource;
+		return {
+			id: tab.id,
+			kind: "proposal",
+			title: tab.title,
+			label: tab.label,
+			legacyTab: source.proposalType,
+			source,
+			state: tab.state,
+		};
+	}
+	if (tab.kind === "review") {
+		const source = tab.source as ReviewSource;
+		return {
+			id: tab.id,
+			kind: "review",
+			title: tab.title,
+			label: tab.label,
+			legacyTab: "review",
+			source: { ...source, reviewTitle: source.title } as PanelWorkspaceTab["source"],
+			state: tab.state,
+		};
+	}
+	if (tab.kind === "pack") {
+		const source = tab.source as PackSource;
+		return {
+			id: tab.id,
+			kind: "pack",
+			title: tab.title,
+			label: tab.label,
+			legacyTab: "pack",
+			source,
+			state: { ...(tab.state || {}), packId: source.packId, panelId: source.panelId, instanceKey: source.instanceKey },
+		};
+	}
+	return {
+		id: INBOX_PANEL_TAB_ID,
+		kind: "inbox",
+		title: tab.title,
+		label: tab.label,
+		legacyTab: "inbox",
+		source: tab.source,
+		state: tab.state,
+	};
+}
+
+function syncCompatibilityMirrors(workspace: SidePanelWorkspace): void {
+	const sid = panelWorkspaceSessionKey(workspace.sessionId);
+	const legacyTabs = workspace.tabs.map(toLegacyPanelTab);
+	state.panelTabsBySession[sid] = legacyTabs;
+	state.panelWorkspaceActiveBySession[sid] = workspace.activeTabId;
+	if (activeMirrorSessionKey() === sid) {
+		state.panelTabs = legacyTabs;
+		state.activePanelTabId = workspace.activeTabId;
+		state.previewPanelFullscreen = workspace.sizeMode === "fullscreen";
+	}
+	(state as unknown as { panelWorkspace?: SidePanelWorkspace }).panelWorkspace = workspace;
+}
+
+export function getSidePanelWorkspace(sessionId?: string | null): SidePanelWorkspace {
+	const sid = panelWorkspaceSessionKey(sessionId || activeSessionId() || state.selectedSessionId || undefined);
+	return state.sidePanelWorkspaceBySession[sid] || emptyWorkspace(sid === "__no-session__" ? "" : sid);
+}
+
+export function applySidePanelWorkspaceFromServer(rawWorkspace: unknown, options: { source?: "hydrate" | "rest" | "ws"; skipRender?: boolean } = {}): SidePanelWorkspace {
+	const rawSessionId = stringValue(asRecord(rawWorkspace)?.sessionId) || activeSessionId() || state.selectedSessionId || "";
+	const workspace = normalizeWorkspace(rawWorkspace, rawSessionId);
+	const sid = panelWorkspaceSessionKey(workspace.sessionId);
+	const currentRevision = state.lastWorkspaceRevisionBySession[sid];
+	const force = options.source === "hydrate";
+	if (!force && typeof currentRevision === "number" && workspace.revision <= currentRevision) {
+		return state.sidePanelWorkspaceBySession[sid] || workspace;
+	}
+	state.sidePanelWorkspaceBySession[sid] = workspace;
+	state.lastWorkspaceRevisionBySession[sid] = workspace.revision;
+	mutationState.delete(sid);
+	syncCompatibilityMirrors(workspace);
+	if (!options.skipRender) renderApp();
+	return workspace;
+}
+
+function applyOptimisticWorkspace(workspace: SidePanelWorkspace, baseWorkspace: SidePanelWorkspace, options?: SidePanelMutationOptions): string {
+	const sid = panelWorkspaceSessionKey(workspace.sessionId);
+	const mutationId = `side-panel:${++mutationCounter}`;
+	mutationState.set(sid, { id: mutationId, baseRevision: baseWorkspace.revision, baseWorkspace });
+	state.sidePanelWorkspaceBySession[sid] = workspace;
+	syncCompatibilityMirrors(workspace);
+	if (!options?.skipRender) renderApp();
+	return mutationId;
+}
+
+function withWorkspaceUpdate(workspace: SidePanelWorkspace, patch: Partial<SidePanelWorkspace>): SidePanelWorkspace {
+	return { ...workspace, ...patch, updatedAt: now() };
+}
+
+function upsertTab(workspace: SidePanelWorkspace, tab: SidePanelWorkspaceTab, focus: boolean, placeAfterActive: boolean): SidePanelWorkspace {
+	const normalizedTab = normalizeTab(tab, workspace.sessionId) || { ...tab, updatedAt: tab.updatedAt || now() };
+	const tabs = workspace.tabs.slice();
+	const index = tabs.findIndex((existing) => existing.id === normalizedTab.id);
+	if (index >= 0) {
+		tabs[index] = { ...tabs[index], ...normalizedTab, source: normalizedTab.source, state: normalizedTab.state ?? tabs[index].state, updatedAt: now() };
+	} else if (placeAfterActive && workspace.activeTabId) {
+		const activeIndex = tabs.findIndex((existing) => existing.id === workspace.activeTabId);
+		tabs.splice(activeIndex >= 0 ? activeIndex + 1 : tabs.length, 0, { ...normalizedTab, updatedAt: now() });
+	} else {
+		tabs.push({ ...normalizedTab, updatedAt: now() });
+	}
+	return withWorkspaceUpdate(workspace, { tabs, activeTabId: focus ? normalizedTab.id : workspace.activeTabId || tabs[0]?.id || "" });
+}
+
+function nextActiveAfterClose(tabsBeforeClose: SidePanelWorkspaceTab[], closedId: string, previousActiveId: string): string {
+	const remaining = tabsBeforeClose.filter((tab) => tab.id !== closedId);
+	if (remaining.length === 0) return "";
+	if (previousActiveId !== closedId && remaining.some((tab) => tab.id === previousActiveId)) return previousActiveId;
+	const closedIndex = tabsBeforeClose.findIndex((tab) => tab.id === closedId);
+	if (closedIndex < 0) return remaining[0]?.id || "";
+	return remaining[Math.min(closedIndex, remaining.length - 1)]?.id || remaining[remaining.length - 1]?.id || "";
+}
+
+async function readJsonSafe(res: Response): Promise<unknown> {
+	try { return await res.json(); } catch { return undefined; }
+}
+
+function workspaceFromResponseBody(body: unknown, sessionId: string): SidePanelWorkspace | undefined {
+	const record = asRecord(body);
+	if (!record) return undefined;
+	const candidate = asRecord(record.workspace) || record;
+	if (!candidate.tabs && !candidate.version) return undefined;
+	return normalizeWorkspace(candidate, stringValue(candidate.sessionId) || sessionId);
+}
+
+class WorkspaceRequestError extends Error {
+	workspace?: SidePanelWorkspace;
+	status?: number;
+	constructor(message: string, status?: number, workspace?: SidePanelWorkspace) {
+		super(message);
+		this.status = status;
+		this.workspace = workspace;
+	}
+}
+
+async function workspaceRequest(sessionId: string, path: string, init: RequestInit = {}): Promise<SidePanelWorkspace> {
+	const res = await gatewayFetch(`/api/sessions/${encodeComponent(sessionId)}/side-panel-workspace${path}`, init);
+	const body = await readJsonSafe(res);
+	const workspace = workspaceFromResponseBody(body, sessionId);
+	if (!res.ok) throw new WorkspaceRequestError(`Side-panel workspace request failed: ${res.status}`, res.status, workspace);
+	if (!workspace) throw new WorkspaceRequestError("Invalid side-panel workspace response", res.status);
+	return workspace;
+}
+
+async function fetchWorkspace(sessionId: string): Promise<SidePanelWorkspace | undefined> {
+	const res = await gatewayFetch(`/api/sessions/${encodeComponent(sessionId)}/side-panel-workspace`);
+	if (res.status === 404) return undefined;
+	const body = await readJsonSafe(res);
+	if (!res.ok) throw new WorkspaceRequestError(`Side-panel workspace fetch failed: ${res.status}`, res.status, workspaceFromResponseBody(body, sessionId));
+	const workspace = workspaceFromResponseBody(body, sessionId);
+	if (!workspace) throw new WorkspaceRequestError("Invalid side-panel workspace response", res.status);
+	return workspace;
+}
+
+async function settleMutation(sessionId: string, mutationId: string, request: Promise<SidePanelWorkspace>): Promise<SidePanelWorkspace> {
+	const sid = panelWorkspaceSessionKey(sessionId);
+	try {
+		const workspace = await request;
+		if (mutationState.get(sid)?.id === mutationId) mutationState.delete(sid);
+		return applySidePanelWorkspaceFromServer(workspace, { source: "rest" });
+	} catch (err) {
+		const pending = mutationState.get(sid);
+		const ownsPending = pending?.id === mutationId;
+		if (ownsPending) mutationState.delete(sid);
+		const latest = err instanceof WorkspaceRequestError ? err.workspace : undefined;
+		if (latest) return applySidePanelWorkspaceFromServer(latest, { source: "rest" });
+		try {
+			const refetched = await fetchWorkspace(sessionId);
+			if (refetched) return applySidePanelWorkspaceFromServer(refetched, { source: "hydrate" });
+		} catch { /* fall through to local rollback */ }
+		if (pending && ownsPending) {
+			state.sidePanelWorkspaceBySession[sid] = pending.baseWorkspace;
+			state.lastWorkspaceRevisionBySession[sid] = pending.baseRevision;
+			syncCompatibilityMirrors(pending.baseWorkspace);
+			renderApp();
+			return pending.baseWorkspace;
+		}
+		throw err;
+	}
+}
+
+function mutationBody(extra: Record<string, unknown>, workspace: SidePanelWorkspace, options?: SidePanelMutationOptions): string {
+	return JSON.stringify({
+		...extra,
+		baseRevision: options?.baseRevision ?? workspace.revision,
+		...(options?.strictRevision === true ? { strictRevision: true } : {}),
+	});
+}
+
+export async function hydrateSidePanelWorkspace(sessionId: string): Promise<SidePanelWorkspace> {
+	mutationState.delete(panelWorkspaceSessionKey(sessionId));
+	try {
+		const fetched = await fetchWorkspace(sessionId);
+		if (!fetched) {
+			const empty = emptyWorkspace(sessionId);
+			return applySidePanelWorkspaceFromServer(empty, { source: "hydrate" });
+		}
+		const workspace = applySidePanelWorkspaceFromServer(fetched, { source: "hydrate" });
+		if (workspace.tabs.length === 0 && !workspace.metadata?.migratedFromLocalStorageAt) {
+			void migrateLegacySidePanelLocalStorage(sessionId);
+		}
+		return workspace;
+	} catch (err) {
+		console.warn("[side-panel] hydrate failed", err);
+		const fallback = state.sidePanelWorkspaceBySession[panelWorkspaceSessionKey(sessionId)] || emptyWorkspace(sessionId);
+		state.sidePanelWorkspaceBySession[panelWorkspaceSessionKey(sessionId)] = fallback;
+		syncCompatibilityMirrors(fallback);
+		renderApp();
+		return fallback;
+	}
+}
+
+export async function openSidePanelTab(tab: SidePanelWorkspaceTab, options: OpenSidePanelTabOptions = {}): Promise<SidePanelWorkspace> {
+	const sessionId = tab.source.sessionId;
+	const base = getSidePanelWorkspace(sessionId);
+	const focus = options.focus !== false;
+	const optimistic = upsertTab(base, tab, focus, options.placeAfterActive !== false);
+	const mutationId = applyOptimisticWorkspace(optimistic, base, options);
+	return settleMutation(sessionId, mutationId, workspaceRequest(sessionId, "/open", {
+		method: "POST",
+		body: mutationBody({ tab, focus, placeAfterActive: options.placeAfterActive !== false }, base, options),
+	}));
+}
+
+export async function updateSidePanelTab(tabId: string, patch: Partial<SidePanelWorkspaceTab>, options: SidePanelMutationOptions & { sessionId?: string } = {}): Promise<SidePanelWorkspace> {
+	const sessionId = options.sessionId || activeSessionId() || state.selectedSessionId || "";
+	const base = getSidePanelWorkspace(sessionId);
+	const tabs = base.tabs.map((tab) => tab.id === tabId ? normalizeTab({ ...tab, ...patch, id: tab.id, source: patch.source || tab.source }, base.sessionId) || tab : tab);
+	const optimistic = withWorkspaceUpdate(base, { tabs });
+	const mutationId = applyOptimisticWorkspace(optimistic, base, options);
+	return settleMutation(base.sessionId, mutationId, workspaceRequest(base.sessionId, `/tabs/${encodeComponent(tabId)}`, {
+		method: "PATCH",
+		body: mutationBody({ patch }, base, options),
+	}));
+}
+
+export async function closeSidePanelTab(tabId: string, options: SidePanelMutationOptions & { sessionId?: string } = {}): Promise<SidePanelWorkspace> {
+	const sessionId = options.sessionId || activeSessionId() || state.selectedSessionId || "";
+	const base = getSidePanelWorkspace(sessionId);
+	const tabs = base.tabs.filter((tab) => tab.id !== tabId);
+	const optimistic = withWorkspaceUpdate(base, { tabs, activeTabId: nextActiveAfterClose(base.tabs, tabId, base.activeTabId) });
+	const mutationId = applyOptimisticWorkspace(optimistic, base, options);
+	return settleMutation(base.sessionId, mutationId, workspaceRequest(base.sessionId, `/tabs/${encodeComponent(tabId)}`, { method: "DELETE" }));
+}
+
+export async function setActiveSidePanelTab(tabId: string, options: SidePanelMutationOptions & { sessionId?: string } = {}): Promise<SidePanelWorkspace> {
+	const sessionId = options.sessionId || activeSessionId() || state.selectedSessionId || "";
+	const base = getSidePanelWorkspace(sessionId);
+	const activeTabId = tabId && base.tabs.some((tab) => tab.id === tabId) ? tabId : "";
+	const optimistic = withWorkspaceUpdate(base, { activeTabId });
+	const mutationId = applyOptimisticWorkspace(optimistic, base, options);
+	return settleMutation(base.sessionId, mutationId, workspaceRequest(base.sessionId, "/active", {
+		method: "POST",
+		body: mutationBody({ activeTabId }, base, options),
+	}));
+}
+
+export async function reorderSidePanelTabs(tabIds: string[], baseRevision?: number, options: SidePanelMutationOptions & { sessionId?: string } = {}): Promise<SidePanelWorkspace> {
+	const sessionId = options.sessionId || activeSessionId() || state.selectedSessionId || "";
+	const base = getSidePanelWorkspace(sessionId);
+	const byId = new Map(base.tabs.map((tab) => [tab.id, tab]));
+	const ordered = tabIds.map((id) => byId.get(id)).filter((tab): tab is SidePanelWorkspaceTab => !!tab);
+	for (const tab of base.tabs) if (!tabIds.includes(tab.id)) ordered.push(tab);
+	const optimistic = withWorkspaceUpdate(base, { tabs: ordered, activeTabId: ordered.some((tab) => tab.id === base.activeTabId) ? base.activeTabId : ordered[0]?.id || "" });
+	const mutationId = applyOptimisticWorkspace(optimistic, base, options);
+	return settleMutation(base.sessionId, mutationId, workspaceRequest(base.sessionId, "/reorder", {
+		method: "POST",
+		body: mutationBody({ tabIds, baseRevision: baseRevision ?? options.baseRevision ?? base.revision }, base, { ...options, baseRevision: baseRevision ?? options.baseRevision ?? base.revision }),
+	}));
+}
+
+export async function setSidePanelSizeMode(sizeMode: SidePanelSizeMode, options: SidePanelMutationOptions & { sessionId?: string } = {}): Promise<SidePanelWorkspace> {
+	const sessionId = options.sessionId || activeSessionId() || state.selectedSessionId || "";
+	const base = getSidePanelWorkspace(sessionId);
+	const optimistic = withWorkspaceUpdate(base, { sizeMode });
+	const mutationId = applyOptimisticWorkspace(optimistic, base, options);
+	return settleMutation(base.sessionId, mutationId, workspaceRequest(base.sessionId, "/resize", {
+		method: "POST",
+		body: mutationBody({ sizeMode }, base, options),
+	}));
+}
+
+function readLocalObject(key: string): Record<string, unknown> | undefined {
+	try {
+		if (typeof localStorage === "undefined") return undefined;
+		const raw = localStorage.getItem(key);
+		if (!raw) return undefined;
+		return asRecord(JSON.parse(raw));
+	} catch {
+		return undefined;
+	}
+}
+
+async function sha256Compat(input: string): Promise<string> {
+	try {
+		const bytes = new TextEncoder().encode(input);
+		const digest = await crypto.subtle.digest("SHA-256", bytes);
+		return Array.from(new Uint8Array(digest)).map((b) => b.toString(16).padStart(2, "0")).join("");
+	} catch {
+		let hash = 2166136261;
+		for (let i = 0; i < input.length; i++) hash = Math.imul(hash ^ input.charCodeAt(i), 16777619);
+		return (hash >>> 0).toString(16).padStart(8, "0");
+	}
+}
+
+function legacyPackParts(id: string, source: Record<string, unknown>): { packId: string; panelId: string; instanceKey: string } | undefined {
+	const parts = id.split(":");
+	if (parts[0] !== "pack") return undefined;
+	const packId = decodeComponent(parts[1] || stringValue(source.packId));
+	const panelId = decodeComponent(parts[2] || stringValue(source.panelId));
+	const instanceKey = decodeComponent(parts[3] || stringValue(source.instanceKey) || "default");
+	return packId && panelId ? { packId, panelId, instanceKey } : undefined;
+}
+
+async function legacyTabToSidePanel(tab: PanelWorkspaceTab, sessionId: string): Promise<SidePanelWorkspaceTab | null> {
+	const updatedAt = now();
+	if (tab.kind === "preview") {
+		const entry = previewEntryLabel(previewTabEntryFromId(tab.id) || stringValue((tab.source as Record<string, unknown>).entry) || tab.title);
+		const version = previewTabVersionFromId(tab.id);
+		const title = previewTabDisplayTitle(entry, version, version != null);
+		const contentHash = previewContentHashFromTab(tab);
+		return {
+			id: version ? `preview:entry:${encodeComponent(entry)}:v:${version}` : `preview:entry:${encodeComponent(entry)}`,
+			kind: "preview",
+			title,
+			label: title,
+			source: { type: "preview", sessionId, entry, live: version == null, ...(version ? { version, historical: true } : {}), ...(contentHash ? { contentHash } : {}) },
+			state: tab.state,
+			updatedAt,
+		};
+	}
+	if (tab.kind === "proposal" && tab.source.type === "proposal" && isProposalType(tab.source.proposalType)) {
+		const rev = positiveInt(tab.source.rev);
+		return { id: rev ? `proposal:${tab.source.proposalType}:rev:${rev}` : `proposal:${tab.source.proposalType}`, kind: "proposal", title: tab.title, label: tab.label, source: { type: "proposal", sessionId, proposalType: tab.source.proposalType, ...(rev ? { rev, historical: true } : {}) }, state: tab.state, updatedAt };
+	}
+	if (tab.kind === "review") {
+		const title = reviewTitleFromPanelTab(tab) || tab.title.replace(/^Review:\s*/, "") || "Review";
+		const documentId = `legacy-title:${(await sha256Compat(title)).slice(0, 16)}`;
+		return { id: `review:${encodeComponent(documentId)}`, kind: "review", title: `Review: ${title}`, label: `Review: ${title}`, source: { type: "review", sessionId, documentId, title }, state: tab.state, updatedAt };
+	}
+	if (tab.kind === "inbox") {
+		return { id: INBOX_PANEL_TAB_ID, kind: "inbox", title: tab.title || "Inbox", label: tab.label || "Inbox", source: { type: "inbox", sessionId }, state: tab.state, updatedAt };
+	}
+	if (tab.kind === "pack") {
+		const source = asRecord(tab.source) || {};
+		const parts = legacyPackParts(tab.id, source);
+		if (!parts) return null;
+		return { id: `pack:${encodeComponent(parts.packId)}:${encodeComponent(parts.panelId)}:${encodeComponent(parts.instanceKey)}`, kind: "pack", title: tab.title || parts.panelId, label: tab.label || tab.title || parts.panelId, source: { type: "pack", sessionId, ...parts, params: cloneJsonRecord(source.params) }, state: tab.state, updatedAt };
+	}
+	return null;
+}
+
+export async function migrateLegacySidePanelLocalStorage(sessionId: string): Promise<SidePanelWorkspace | undefined> {
+	const existing = getSidePanelWorkspace(sessionId);
+	if (existing.tabs.length > 0 || existing.metadata?.migratedFromLocalStorageAt) return existing;
+	const sid = panelWorkspaceSessionKey(sessionId);
+	const tabsBySession = readLocalObject(PANEL_TABS_STORAGE_KEY);
+	const activeBySession = readLocalObject(PANEL_ACTIVE_STORAGE_KEY);
+	const legacyTabs = Array.isArray(tabsBySession?.[sid]) ? tabsBySession[sid] as PanelWorkspaceTab[] : [];
+	const tabs: SidePanelWorkspaceTab[] = [];
+	for (const legacyTab of legacyTabs) {
+		const tab = await legacyTabToSidePanel(legacyTab, sessionId);
+		if (tab && !tabs.some((existingTab) => existingTab.id === tab.id)) tabs.push(tab);
+	}
+	const oldCollapsedRaw = (() => {
+		try { return typeof localStorage !== "undefined" ? localStorage.getItem(`bobbit-preview-collapsed-${sessionId}`) : null; } catch { return null; }
+	})();
+	const sizeMode: SidePanelSizeMode = oldCollapsedRaw === "true" ? "collapsed" : existing.sizeMode;
+	if (tabs.length === 0 && sizeMode === existing.sizeMode) return undefined;
+	const requestedActive = stringValue(activeBySession?.[sid]);
+	const activeTabId = tabs.some((tab) => tab.id === requestedActive) ? requestedActive : tabs[0]?.id || "";
+	try {
+		const workspace = await workspaceRequest(sessionId, "/migrate", {
+			method: "POST",
+			body: JSON.stringify({ tabs, activeTabId, sizeMode, metadata: { migratedFromLocalStorageAt: now() } }),
+		});
+		return applySidePanelWorkspaceFromServer(workspace, { source: "rest" });
+	} catch (err) {
+		console.warn("[side-panel] legacy migration failed", err);
+		return undefined;
+	}
+}
+
+export function activeSidePanelTab(sessionId?: string | null): SidePanelWorkspaceTab | undefined {
+	const workspace = getSidePanelWorkspace(sessionId);
+	return workspace.tabs.find((tab) => tab.id === workspace.activeTabId);
+}
+
+export function hasActiveSidePanel(sessionId?: string | null): boolean {
+	return !!activeSidePanelTab(sessionId);
+}
+
+export function sidePanelSizeMode(sessionId?: string | null): SidePanelSizeMode {
+	return getSidePanelWorkspace(sessionId).sizeMode;
+}
+
+export function sidePanelPopoutUrl(tab: SidePanelWorkspaceTab): string {
+	if (tab.kind === "preview") {
+		const source = tab.source as PreviewSource;
+		const entry = encodeComponent(source.entry || "inline.html");
+		if (source.artifactId) return `/preview/${encodeComponent(source.sessionId)}/_artifact/${encodeComponent(source.artifactId)}/${entry}`;
+		return `/preview/${encodeComponent(source.sessionId)}/${entry}`;
+	}
+	return `#/session/${encodeComponent(tab.source.sessionId)}/panel/${encodeComponent(tab.id)}`;
+}
+
+export function sidePanelTabIds(sessionId?: string | null): string[] {
+	return getSidePanelWorkspace(sessionId).tabs.map((tab) => tab.id);
+}

--- a/src/app/side-panel-workspace.ts
+++ b/src/app/side-panel-workspace.ts
@@ -633,6 +633,12 @@ export async function openSidePanelTab(tab: SidePanelWorkspaceTab, options: Open
 	const sessionId = tab.source.sessionId;
 	const base = mutationBaseWorkspace(sessionId);
 	const focus = options.focus !== false;
+	if (focus) {
+		// Explicit open/update events are authoritative focus changes. A recently
+		// captured tab click may still be guarding against stale WS/REST payloads;
+		// clear it so it cannot pull focus back to the old tab.
+		delete (state as any).__lastSidePanelUserActiveSelection;
+	}
 	const optimistic = upsertTab(base, tab, focus, options.placeAfterActive !== false);
 	if (!useServerWorkspaceApi()) return applyFixtureWorkspace(optimistic, options);
 	const mutationId = applyOptimisticWorkspace(optimistic, base, options);

--- a/src/app/side-panel-workspace.ts
+++ b/src/app/side-panel-workspace.ts
@@ -332,7 +332,7 @@ export function applySidePanelWorkspaceFromServer(rawWorkspace: unknown, options
 	const workspace = normalizeWorkspace(rawWorkspace, rawSessionId);
 	const sid = panelWorkspaceSessionKey(workspace.sessionId);
 	const currentRevision = state.lastWorkspaceRevisionBySession[sid];
-	const force = options.source === "hydrate" || options.force === true;
+	const force = options.force === true;
 	if (!force && typeof currentRevision === "number" && workspace.revision <= currentRevision) {
 		return state.sidePanelWorkspaceBySession[sid] || workspace;
 	}
@@ -562,7 +562,7 @@ async function settleMutation(sessionId: string, mutationId: string, request: Pr
 		if (latest) return applySidePanelWorkspaceFromServer(latest, { source: "rest", force: ownsPending });
 		try {
 			const refetched = await fetchWorkspace(sessionId);
-			if (refetched) return applySidePanelWorkspaceFromServer(refetched, { source: "hydrate" });
+			if (refetched) return applySidePanelWorkspaceFromServer(refetched, { source: "hydrate", force: ownsPending });
 		} catch { /* fall through to local rollback */ }
 		if (pending && ownsPending) {
 			state.sidePanelWorkspaceBySession[sid] = pending.baseWorkspace;
@@ -790,7 +790,6 @@ export async function migrateLegacySidePanelLocalStorage(sessionId: string): Pro
 		try { return typeof localStorage !== "undefined" ? localStorage.getItem(`bobbit-preview-collapsed-${sessionId}`) : null; } catch { return null; }
 	})();
 	const sizeMode: SidePanelSizeMode = oldCollapsedRaw === "true" ? "collapsed" : existing.sizeMode;
-	if (tabs.length === 0 && sizeMode === existing.sizeMode) return undefined;
 	const requestedActive = stringValue(activeBySession?.[sid]);
 	const activeTabId = tabs.some((tab) => tab.id === requestedActive) ? requestedActive : tabs[0]?.id || "";
 	try {

--- a/src/app/side-panel-workspace.ts
+++ b/src/app/side-panel-workspace.ts
@@ -317,6 +317,7 @@ function syncCompatibilityMirrors(workspace: SidePanelWorkspace): void {
 		state.panelTabs = legacyTabs;
 		state.activePanelTabId = workspace.activeTabId;
 		state.previewPanelFullscreen = workspace.sizeMode === "fullscreen";
+		state.inboxPanelOpen = workspace.tabs.some((tab) => tab.id === INBOX_PANEL_TAB_ID && tab.kind === "inbox");
 	}
 	(state as unknown as { panelWorkspace?: SidePanelWorkspace }).panelWorkspace = workspace;
 }
@@ -381,15 +382,8 @@ function nextActiveAfterClose(tabsBeforeClose: SidePanelWorkspaceTab[], closedId
 	return remaining[Math.min(closedIndex, remaining.length - 1)]?.id || remaining[remaining.length - 1]?.id || "";
 }
 
-function isPinnedSidePanelWorkspaceTab(tab: SidePanelWorkspaceTab): boolean {
-	return tab.kind === "inbox" || tab.id === INBOX_PANEL_TAB_ID;
-}
-
 function pinnedFirstWorkspaceTabs(tabs: SidePanelWorkspaceTab[]): SidePanelWorkspaceTab[] {
-	const pinned: SidePanelWorkspaceTab[] = [];
-	const unpinned: SidePanelWorkspaceTab[] = [];
-	for (const tab of tabs) (isPinnedSidePanelWorkspaceTab(tab) ? pinned : unpinned).push(tab);
-	return [...pinned, ...unpinned];
+	return tabs;
 }
 
 async function readJsonSafe(res: Response): Promise<unknown> {

--- a/src/app/side-panel-workspace.ts
+++ b/src/app/side-panel-workspace.ts
@@ -375,6 +375,17 @@ function nextActiveAfterClose(tabsBeforeClose: SidePanelWorkspaceTab[], closedId
 	return remaining[Math.min(closedIndex, remaining.length - 1)]?.id || remaining[remaining.length - 1]?.id || "";
 }
 
+function isPinnedSidePanelWorkspaceTab(tab: SidePanelWorkspaceTab): boolean {
+	return tab.kind === "inbox" || tab.id === INBOX_PANEL_TAB_ID;
+}
+
+function pinnedFirstWorkspaceTabs(tabs: SidePanelWorkspaceTab[]): SidePanelWorkspaceTab[] {
+	const pinned: SidePanelWorkspaceTab[] = [];
+	const unpinned: SidePanelWorkspaceTab[] = [];
+	for (const tab of tabs) (isPinnedSidePanelWorkspaceTab(tab) ? pinned : unpinned).push(tab);
+	return [...pinned, ...unpinned];
+}
+
 async function readJsonSafe(res: Response): Promise<unknown> {
 	try { return await res.json(); } catch { return undefined; }
 }
@@ -523,13 +534,23 @@ export async function reorderSidePanelTabs(tabIds: string[], baseRevision?: numb
 	const sessionId = options.sessionId || activeSessionId() || state.selectedSessionId || "";
 	const base = getSidePanelWorkspace(sessionId);
 	const byId = new Map(base.tabs.map((tab) => [tab.id, tab]));
-	const ordered = tabIds.map((id) => byId.get(id)).filter((tab): tab is SidePanelWorkspaceTab => !!tab);
-	for (const tab of base.tabs) if (!tabIds.includes(tab.id)) ordered.push(tab);
+	const seen = new Set<string>();
+	const orderedInputIds: string[] = [];
+	for (const id of tabIds) {
+		if (!byId.has(id) || seen.has(id)) continue;
+		seen.add(id);
+		orderedInputIds.push(id);
+	}
+	let ordered = orderedInputIds.map((id) => byId.get(id)).filter((tab): tab is SidePanelWorkspaceTab => !!tab);
+	for (const tab of base.tabs) if (!seen.has(tab.id)) ordered.push(tab);
+	ordered = pinnedFirstWorkspaceTabs(ordered);
+	const orderedIds = ordered.map((tab) => tab.id);
+	const revision = baseRevision ?? options.baseRevision ?? base.revision;
 	const optimistic = withWorkspaceUpdate(base, { tabs: ordered, activeTabId: ordered.some((tab) => tab.id === base.activeTabId) ? base.activeTabId : ordered[0]?.id || "" });
 	const mutationId = applyOptimisticWorkspace(optimistic, base, options);
 	return settleMutation(base.sessionId, mutationId, workspaceRequest(base.sessionId, "/reorder", {
 		method: "POST",
-		body: mutationBody({ tabIds, baseRevision: baseRevision ?? options.baseRevision ?? base.revision }, base, { ...options, baseRevision: baseRevision ?? options.baseRevision ?? base.revision }),
+		body: mutationBody({ tabIds: orderedIds, baseRevision: revision }, base, { ...options, baseRevision: revision }),
 	}));
 }
 

--- a/src/app/side-panel-workspace.ts
+++ b/src/app/side-panel-workspace.ts
@@ -329,8 +329,17 @@ export function getSidePanelWorkspace(sessionId?: string | null): SidePanelWorks
 
 export function applySidePanelWorkspaceFromServer(rawWorkspace: unknown, options: { source?: "hydrate" | "rest" | "ws"; skipRender?: boolean; force?: boolean } = {}): SidePanelWorkspace {
 	const rawSessionId = stringValue(asRecord(rawWorkspace)?.sessionId) || activeSessionId() || state.selectedSessionId || "";
-	const workspace = normalizeWorkspace(rawWorkspace, rawSessionId);
+	let workspace = normalizeWorkspace(rawWorkspace, rawSessionId);
 	const sid = panelWorkspaceSessionKey(workspace.sessionId);
+	const localSelection = (state as any).__lastSidePanelUserActiveSelection as { sessionId?: string; tabId?: string; at?: number } | undefined;
+	if (localSelection?.sessionId === sid
+		&& typeof localSelection.tabId === "string"
+		&& localSelection.tabId !== workspace.activeTabId
+		&& typeof localSelection.at === "number"
+		&& Date.now() - localSelection.at < 10_000
+		&& workspace.tabs.some((tab) => tab.id === localSelection.tabId)) {
+		workspace = { ...workspace, activeTabId: localSelection.tabId };
+	}
 	const currentRevision = state.lastWorkspaceRevisionBySession[sid];
 	const force = options.force === true;
 	if (!force && typeof currentRevision === "number" && workspace.revision <= currentRevision) {
@@ -552,7 +561,8 @@ async function settleMutation(sessionId: string, mutationId: string, request: Pr
 	const sid = panelWorkspaceSessionKey(sessionId);
 	try {
 		const workspace = await request;
-		if (mutationState.get(sid)?.id === mutationId) mutationState.delete(sid);
+		if (mutationState.get(sid)?.id !== mutationId) return state.sidePanelWorkspaceBySession[sid] || workspace;
+		mutationState.delete(sid);
 		return applySidePanelWorkspaceFromServer(workspace, { source: "rest" });
 	} catch (err) {
 		const pending = mutationState.get(sid);
@@ -579,6 +589,7 @@ function mutationBody(extra: Record<string, unknown>, workspace: SidePanelWorksp
 	return JSON.stringify({
 		...extra,
 		baseRevision: options?.baseRevision ?? workspace.revision,
+		baseActiveTabId: workspace.activeTabId,
 		...(options?.strictRevision === true ? { strictRevision: true } : {}),
 	});
 }

--- a/src/app/side-panel-workspace.ts
+++ b/src/app/side-panel-workspace.ts
@@ -327,12 +327,12 @@ export function getSidePanelWorkspace(sessionId?: string | null): SidePanelWorks
 	return state.sidePanelWorkspaceBySession[sid] || emptyWorkspace(sid === "__no-session__" ? "" : sid);
 }
 
-export function applySidePanelWorkspaceFromServer(rawWorkspace: unknown, options: { source?: "hydrate" | "rest" | "ws"; skipRender?: boolean } = {}): SidePanelWorkspace {
+export function applySidePanelWorkspaceFromServer(rawWorkspace: unknown, options: { source?: "hydrate" | "rest" | "ws"; skipRender?: boolean; force?: boolean } = {}): SidePanelWorkspace {
 	const rawSessionId = stringValue(asRecord(rawWorkspace)?.sessionId) || activeSessionId() || state.selectedSessionId || "";
 	const workspace = normalizeWorkspace(rawWorkspace, rawSessionId);
 	const sid = panelWorkspaceSessionKey(workspace.sessionId);
 	const currentRevision = state.lastWorkspaceRevisionBySession[sid];
-	const force = options.source === "hydrate";
+	const force = options.source === "hydrate" || options.force === true;
 	if (!force && typeof currentRevision === "number" && workspace.revision <= currentRevision) {
 		return state.sidePanelWorkspaceBySession[sid] || workspace;
 	}
@@ -559,7 +559,7 @@ async function settleMutation(sessionId: string, mutationId: string, request: Pr
 		const ownsPending = pending?.id === mutationId;
 		if (ownsPending) mutationState.delete(sid);
 		const latest = err instanceof WorkspaceRequestError ? err.workspace : undefined;
-		if (latest) return applySidePanelWorkspaceFromServer(latest, { source: "rest" });
+		if (latest) return applySidePanelWorkspaceFromServer(latest, { source: "rest", force: ownsPending });
 		try {
 			const refetched = await fetchWorkspace(sessionId);
 			if (refetched) return applySidePanelWorkspaceFromServer(refetched, { source: "hydrate" });

--- a/src/app/side-panel-workspace.ts
+++ b/src/app/side-panel-workspace.ts
@@ -2,12 +2,17 @@ import { gatewayFetch } from "./gateway-fetch.js";
 import { activeSessionId, renderApp, state } from "./state.js";
 import {
 	INBOX_PANEL_TAB_ID,
+	assistantProposalType,
+	buildPanelWorkspaceTabs,
 	panelWorkspaceSessionKey,
 	previewContentHashFromTab,
 	previewEntryLabel,
 	previewTabDisplayTitle,
 	previewTabEntryFromId,
 	previewTabVersionFromId,
+	proposalPanelTabId,
+	reviewDocumentIdFromPanelTab,
+	reviewPanelTabId,
 	reviewTitleFromPanelTab,
 	type PanelWorkspaceTab,
 } from "./panel-workspace.js";
@@ -56,6 +61,7 @@ export interface OpenSidePanelTabOptions {
 	placeAfterActive?: boolean;
 	baseRevision?: number;
 	strictRevision?: boolean;
+	skipRender?: boolean;
 }
 
 export interface SidePanelMutationOptions {
@@ -408,6 +414,127 @@ class WorkspaceRequestError extends Error {
 	}
 }
 
+function useServerWorkspaceApi(): boolean {
+	// Unit browser fixtures run from file:// with a mocked fetch layer and no
+	// gateway REST API. Keep those fixtures optimistic/in-memory only; the real
+	// app is served by the gateway and remains server-authoritative.
+	return typeof window === "undefined" || window.location.protocol !== "file:";
+}
+
+function applyFixtureWorkspace(workspace: SidePanelWorkspace, options?: { skipRender?: boolean }): SidePanelWorkspace {
+	state.sidePanelWorkspaceBySession[panelWorkspaceSessionKey(workspace.sessionId)] = workspace;
+	syncCompatibilityMirrors(workspace);
+	if (!options?.skipRender) renderApp();
+	return workspace;
+}
+
+function sidePanelTabFromLegacyMirror(tab: PanelWorkspaceTab, sessionId: string): SidePanelWorkspaceTab | null {
+	const updatedAt = now();
+	if (tab.kind === "preview") {
+		const source = asRecord(tab.source) || {};
+		const tabState = asRecord(tab.state) || {};
+		const entry = previewEntryLabel(stringValue(tabState.entry) || stringValue(source.entry) || previewTabEntryFromId(tab.id) || tab.title || undefined);
+		const idVersion = previewTabVersionFromId(tab.id);
+		const version = idVersion ?? positiveInt(source.version) ?? positiveInt(tabState.version);
+		const historical = source.historical === true || tabState.historical === true || idVersion != null;
+		const contentHash = previewContentHashFromTab(tab);
+		const id = historical && version ? `preview:entry:${encodeComponent(entry)}:v:${version}` : `preview:entry:${encodeComponent(entry)}`;
+		return {
+			id,
+			kind: "preview",
+			title: tab.title || previewTabDisplayTitle(entry, version, historical),
+			label: tab.label || tab.title || previewTabDisplayTitle(entry, version, historical),
+			source: {
+				type: "preview",
+				sessionId,
+				entry,
+				...(historical ? { historical: true } : { live: true }),
+				...(historical && version ? { version } : {}),
+				...(stringValue(source.artifactId) ? { artifactId: stringValue(source.artifactId) } : {}),
+				...(contentHash ? { contentHash } : {}),
+				...(stringValue(source.path) ? { path: stringValue(source.path) } : {}),
+				...(stringValue(source.url) ? { url: stringValue(source.url) } : {}),
+				...(stringValue(source.toolUseId) ? { toolUseId: stringValue(source.toolUseId) } : {}),
+				...(typeof source.blockIndex === "number" ? { blockIndex: source.blockIndex } : {}),
+			},
+			state: cloneJsonRecord(tab.state),
+			updatedAt,
+		};
+	}
+	if (tab.kind === "proposal") {
+		const source = asRecord(tab.source) || {};
+		const proposalType = stringValue(source.proposalType) as SidePanelProposalType;
+		if (!isProposalType(proposalType)) return null;
+		const rev = positiveInt(source.rev) ?? positiveInt(tab.state?.rev);
+		return {
+			id: proposalPanelTabId(proposalType, rev),
+			kind: "proposal",
+			title: tab.title,
+			label: tab.label,
+			source: { type: "proposal", sessionId, proposalType, ...(rev ? { rev, historical: true } : {}) },
+			state: cloneJsonRecord(tab.state),
+			updatedAt,
+		};
+	}
+	if (tab.kind === "review") {
+		const title = reviewTitleFromPanelTab(tab) || tab.title.replace(/^Review:\s*/, "") || "Review";
+		const documentId = reviewDocumentIdFromPanelTab(tab) || title;
+		return {
+			id: reviewPanelTabId(documentId),
+			kind: "review",
+			title: `Review: ${title}`,
+			label: `Review: ${title}`,
+			source: { type: "review", sessionId, documentId, title },
+			state: cloneJsonRecord(tab.state),
+			updatedAt,
+		};
+	}
+	if (tab.kind === "inbox") return { id: INBOX_PANEL_TAB_ID, kind: "inbox", title: tab.title || "Inbox", label: tab.label || "Inbox", source: { type: "inbox", sessionId }, state: cloneJsonRecord(tab.state), updatedAt };
+	if (tab.kind === "pack") {
+		const source = asRecord(tab.source) || {};
+		const packId = stringValue(source.packId);
+		const panelId = stringValue(source.panelId);
+		const instanceKey = stringValue(source.instanceKey) || "default";
+		if (!packId || !panelId) return null;
+		return { id: `pack:${encodeComponent(packId)}:${encodeComponent(panelId)}:${encodeComponent(instanceKey)}`, kind: "pack", title: tab.title || panelId, label: tab.label || tab.title || panelId, source: { type: "pack", sessionId, packId, panelId, instanceKey, params: cloneJsonRecord(source.params) }, state: cloneJsonRecord(tab.state), updatedAt };
+	}
+	return null;
+}
+
+function fixtureInitialWorkspace(sessionId: string): SidePanelWorkspace | undefined {
+	if (useServerWorkspaceApi()) return undefined;
+	const sid = panelWorkspaceSessionKey(sessionId);
+	const legacyTabs = Array.isArray(state.panelTabsBySession?.[sid]) ? state.panelTabsBySession[sid] as PanelWorkspaceTab[] : [];
+	const derivedTabs = buildPanelWorkspaceTabs({
+		sessionId,
+		isPreviewSession: !!state.isPreviewSession,
+		previewEntry: stringValue(state.previewPanelEntry),
+		previewContentHash: stringValue((state as any).previewPanelContentHash),
+		activeProposalTypes: Object.keys(state.activeProposals || {}) as any,
+		assistantProposalType: assistantProposalType(state.assistantType),
+		reviewTitles: state.reviewDocuments instanceof Map ? [...state.reviewDocuments.keys()] : [],
+		reviewPanelOpen: !!state.reviewPanelOpen,
+		inboxPanelOpen: !!state.inboxPanelOpen,
+		inboxHasPending: Array.isArray(state.inboxEntries) && state.inboxEntries.length > 0,
+	});
+	const tabs: SidePanelWorkspaceTab[] = [];
+	for (const legacy of [...legacyTabs, ...derivedTabs]) {
+		const tab = sidePanelTabFromLegacyMirror(legacy, sessionId);
+		if (tab && !tabs.some((existing) => existing.id === tab.id)) tabs.push(tab);
+	}
+	if (tabs.length === 0) return undefined;
+	const requestedActive = stringValue(state.panelWorkspaceActiveBySession?.[sid]) || stringValue(state.activePanelTabId);
+	return {
+		version: 1,
+		sessionId,
+		revision: 0,
+		tabs,
+		activeTabId: tabs.some((tab) => tab.id === requestedActive) ? requestedActive : tabs[0]?.id || "",
+		sizeMode: "split",
+		updatedAt: now(),
+	};
+}
+
 async function workspaceRequest(sessionId: string, path: string, init: RequestInit = {}): Promise<SidePanelWorkspace> {
 	const res = await gatewayFetch(`/api/sessions/${encodeComponent(sessionId)}/side-panel-workspace${path}`, init);
 	const body = await readJsonSafe(res);
@@ -464,6 +591,13 @@ function mutationBody(extra: Record<string, unknown>, workspace: SidePanelWorksp
 
 export async function hydrateSidePanelWorkspace(sessionId: string): Promise<SidePanelWorkspace> {
 	mutationState.delete(panelWorkspaceSessionKey(sessionId));
+	if (!useServerWorkspaceApi()) {
+		const workspace = state.sidePanelWorkspaceBySession[panelWorkspaceSessionKey(sessionId)] || emptyWorkspace(sessionId);
+		state.sidePanelWorkspaceBySession[panelWorkspaceSessionKey(sessionId)] = workspace;
+		syncCompatibilityMirrors(workspace);
+		renderApp();
+		return workspace;
+	}
 	try {
 		const fetched = await fetchWorkspace(sessionId);
 		if (!fetched) {
@@ -485,11 +619,17 @@ export async function hydrateSidePanelWorkspace(sessionId: string): Promise<Side
 	}
 }
 
+function mutationBaseWorkspace(sessionId: string): SidePanelWorkspace {
+	const sid = panelWorkspaceSessionKey(sessionId);
+	return state.sidePanelWorkspaceBySession[sid] || fixtureInitialWorkspace(sessionId) || getSidePanelWorkspace(sessionId);
+}
+
 export async function openSidePanelTab(tab: SidePanelWorkspaceTab, options: OpenSidePanelTabOptions = {}): Promise<SidePanelWorkspace> {
 	const sessionId = tab.source.sessionId;
-	const base = getSidePanelWorkspace(sessionId);
+	const base = mutationBaseWorkspace(sessionId);
 	const focus = options.focus !== false;
 	const optimistic = upsertTab(base, tab, focus, options.placeAfterActive !== false);
+	if (!useServerWorkspaceApi()) return applyFixtureWorkspace(optimistic, options);
 	const mutationId = applyOptimisticWorkspace(optimistic, base, options);
 	return settleMutation(sessionId, mutationId, workspaceRequest(sessionId, "/open", {
 		method: "POST",
@@ -499,9 +639,10 @@ export async function openSidePanelTab(tab: SidePanelWorkspaceTab, options: Open
 
 export async function updateSidePanelTab(tabId: string, patch: Partial<SidePanelWorkspaceTab>, options: SidePanelMutationOptions & { sessionId?: string } = {}): Promise<SidePanelWorkspace> {
 	const sessionId = options.sessionId || activeSessionId() || state.selectedSessionId || "";
-	const base = getSidePanelWorkspace(sessionId);
+	const base = mutationBaseWorkspace(sessionId);
 	const tabs = base.tabs.map((tab) => tab.id === tabId ? normalizeTab({ ...tab, ...patch, id: tab.id, source: patch.source || tab.source }, base.sessionId) || tab : tab);
 	const optimistic = withWorkspaceUpdate(base, { tabs });
+	if (!useServerWorkspaceApi()) return applyFixtureWorkspace(optimistic, options);
 	const mutationId = applyOptimisticWorkspace(optimistic, base, options);
 	return settleMutation(base.sessionId, mutationId, workspaceRequest(base.sessionId, `/tabs/${encodeComponent(tabId)}`, {
 		method: "PATCH",
@@ -511,18 +652,20 @@ export async function updateSidePanelTab(tabId: string, patch: Partial<SidePanel
 
 export async function closeSidePanelTab(tabId: string, options: SidePanelMutationOptions & { sessionId?: string } = {}): Promise<SidePanelWorkspace> {
 	const sessionId = options.sessionId || activeSessionId() || state.selectedSessionId || "";
-	const base = getSidePanelWorkspace(sessionId);
+	const base = mutationBaseWorkspace(sessionId);
 	const tabs = base.tabs.filter((tab) => tab.id !== tabId);
 	const optimistic = withWorkspaceUpdate(base, { tabs, activeTabId: nextActiveAfterClose(base.tabs, tabId, base.activeTabId) });
+	if (!useServerWorkspaceApi()) return applyFixtureWorkspace(optimistic, options);
 	const mutationId = applyOptimisticWorkspace(optimistic, base, options);
 	return settleMutation(base.sessionId, mutationId, workspaceRequest(base.sessionId, `/tabs/${encodeComponent(tabId)}`, { method: "DELETE" }));
 }
 
 export async function setActiveSidePanelTab(tabId: string, options: SidePanelMutationOptions & { sessionId?: string } = {}): Promise<SidePanelWorkspace> {
 	const sessionId = options.sessionId || activeSessionId() || state.selectedSessionId || "";
-	const base = getSidePanelWorkspace(sessionId);
+	const base = mutationBaseWorkspace(sessionId);
 	const activeTabId = tabId && base.tabs.some((tab) => tab.id === tabId) ? tabId : "";
 	const optimistic = withWorkspaceUpdate(base, { activeTabId });
+	if (!useServerWorkspaceApi()) return applyFixtureWorkspace(optimistic, options);
 	const mutationId = applyOptimisticWorkspace(optimistic, base, options);
 	return settleMutation(base.sessionId, mutationId, workspaceRequest(base.sessionId, "/active", {
 		method: "POST",
@@ -532,7 +675,7 @@ export async function setActiveSidePanelTab(tabId: string, options: SidePanelMut
 
 export async function reorderSidePanelTabs(tabIds: string[], baseRevision?: number, options: SidePanelMutationOptions & { sessionId?: string } = {}): Promise<SidePanelWorkspace> {
 	const sessionId = options.sessionId || activeSessionId() || state.selectedSessionId || "";
-	const base = getSidePanelWorkspace(sessionId);
+	const base = mutationBaseWorkspace(sessionId);
 	const byId = new Map(base.tabs.map((tab) => [tab.id, tab]));
 	const seen = new Set<string>();
 	const orderedInputIds: string[] = [];
@@ -547,6 +690,7 @@ export async function reorderSidePanelTabs(tabIds: string[], baseRevision?: numb
 	const orderedIds = ordered.map((tab) => tab.id);
 	const revision = baseRevision ?? options.baseRevision ?? base.revision;
 	const optimistic = withWorkspaceUpdate(base, { tabs: ordered, activeTabId: ordered.some((tab) => tab.id === base.activeTabId) ? base.activeTabId : ordered[0]?.id || "" });
+	if (!useServerWorkspaceApi()) return applyFixtureWorkspace(optimistic, options);
 	const mutationId = applyOptimisticWorkspace(optimistic, base, options);
 	return settleMutation(base.sessionId, mutationId, workspaceRequest(base.sessionId, "/reorder", {
 		method: "POST",
@@ -556,8 +700,9 @@ export async function reorderSidePanelTabs(tabIds: string[], baseRevision?: numb
 
 export async function setSidePanelSizeMode(sizeMode: SidePanelSizeMode, options: SidePanelMutationOptions & { sessionId?: string } = {}): Promise<SidePanelWorkspace> {
 	const sessionId = options.sessionId || activeSessionId() || state.selectedSessionId || "";
-	const base = getSidePanelWorkspace(sessionId);
+	const base = mutationBaseWorkspace(sessionId);
 	const optimistic = withWorkspaceUpdate(base, { sizeMode });
+	if (!useServerWorkspaceApi()) return applyFixtureWorkspace(optimistic, options);
 	const mutationId = applyOptimisticWorkspace(optimistic, base, options);
 	return settleMutation(base.sessionId, mutationId, workspaceRequest(base.sessionId, "/resize", {
 		method: "POST",

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -579,8 +579,7 @@ export function renderRolePickerDropdown() {
 						class="text-muted-foreground cursor-help" style="font-size: 0.75em;">ⓘ</span>
 				</label>
 			</div>
-			<!-- Sandbox checkbox (only when docker sandbox is configured) -->
-			${state.sandboxStatus?.configured ? html`
+			<!-- Sandbox checkbox -->
 			<div class="border-t border-border/50 px-3 py-1.5 shrink-0">
 				<label class="flex items-center gap-2 cursor-pointer">
 					${(() => {
@@ -601,7 +600,6 @@ export function renderRolePickerDropdown() {
 					})()}
 				</label>
 			</div>
-			` : ""}
 			<!-- Create button (pinned at bottom) -->
 			<div class="border-t border-border/50 px-3 py-2 shrink-0">
 				<button

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -2,6 +2,7 @@ import type { ChatPanel } from "../ui/index.js";
 import type { RemoteAgent, ConnectionStatus } from "./remote-agent.js";
 import type { InboxEntry } from "../server/agent/inbox-store.js";
 import type { PanelWorkspaceTab } from "./panel-workspace.js";
+import type { SidePanelWorkspace } from "./side-panel-workspace.js";
 import { isConfigPageRoute } from "./routing.js";
 import { safeSetItem, safeGetItem, safeGetJSON } from "./safe-storage.js";
 
@@ -439,6 +440,10 @@ export const state = {
 	panelWorkspaceActiveBySession: {} as Record<string, string>,
 	panelWorkspacePreviewKeyBySession: {} as Record<string, string>,
 	previewVersionsBySession: {} as Record<string, Record<string, { latestVersion: number; latestContentHash?: string; hashToVersion: Record<string, number> }>>,
+	// Server-authoritative side-panel workspace mirrors. Optimistic updates live
+	// only in memory here and are replaced by REST/WS workspace payloads.
+	sidePanelWorkspaceBySession: {} as Record<string, SidePanelWorkspace>,
+	lastWorkspaceRevisionBySession: {} as Record<string, number>,
 
 	// Unified preview panel tab (legacy compatibility for non-assistant sessions)
 	previewPanelActiveTab: "preview" as "preview" | "goal" | "review" | "project" | "role" | "tool" | "staff" | "inbox",

--- a/src/server/agent/pack-contributions.ts
+++ b/src/server/agent/pack-contributions.ts
@@ -49,6 +49,10 @@ export interface PanelContribution {
 	id: string; // unique within the pack (dotted allowed)
 	title?: string;
 	entry: string; // path relative to sourceFile, contained in packRoot
+	/** Durable tab identity mode. Omitted/default is singleton compatibility. */
+	instanceMode?: "singleton" | "parameterized";
+	/** Allowlisted params key that must match the tab instanceKey for parameterized panels. */
+	instanceParam?: string;
 	/** Absolute path of the declaring YAML (panels/<file>.yaml). */
 	sourceFile: string;
 	/** Absolute pack root (market-packs/<name>). */
@@ -165,6 +169,8 @@ function loadPanels(packRoot: string): PanelContribution[] {
 		seen.add(id);
 		const panel: PanelContribution = { id, entry, sourceFile, packRoot };
 		if (typeof obj.title === "string" && obj.title.length > 0) panel.title = obj.title;
+		if (obj.instanceMode === "singleton" || obj.instanceMode === "parameterized") panel.instanceMode = obj.instanceMode;
+		if (typeof obj.instanceParam === "string" && /^[A-Za-z0-9_.-]{1,80}$/.test(obj.instanceParam)) panel.instanceParam = obj.instanceParam;
 		out.push(panel);
 	}
 	return out;

--- a/src/server/agent/session-store.ts
+++ b/src/server/agent/session-store.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { QueuedMessage } from "../ws/protocol.js";
+import type { SidePanelWorkspace } from "../../shared/side-panel-workspace.js";
 
 /** 24h in ms — recency threshold for `shouldKeepDespiteOrphan`. */
 const RECENT_TRANSCRIPT_WINDOW_MS = 24 * 60 * 60 * 1000;
@@ -129,6 +130,8 @@ export interface PersistedSession {
 	sandboxed?: boolean;
 	/** Per-repo worktree paths (multi-repo only). Single-repo uses flat worktreePath. */
 	repoWorktrees?: Record<string, string>;
+	/** Server-authoritative right-hand side-panel workspace. */
+	sidePanelWorkspace?: SidePanelWorkspace;
 }
 
 /**
@@ -178,6 +181,7 @@ export type UpdatableSessionFields = Pick<
 	| "sandboxed"
 	| "projectId"
 	| "repoWorktrees"
+	| "sidePanelWorkspace"
 >;
 
 /**
@@ -531,6 +535,7 @@ export class SessionStore {
 		"role", "assistantType", "taskId", "staffId",
 		"teamGoalId", "teamLeadSessionId",
 		"modelProvider", "modelId",
+		"sidePanelWorkspace",
 	];
 
 	/** Update a subset of fields for an existing session */

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -56,7 +56,7 @@ import { loadPackContributions } from "./agent/pack-contributions.js";
 import { isPackPathWithinRoot } from "./extension-host/path-guard.js";
 import { buildGateStatusSummary } from "./gate-status-summary.js";
 import { buildGateVerificationSnapshot, UnknownVerificationStepError } from "./gate-verification-snapshot.js";
-import { handleSidePanelWorkspaceRoute } from "./side-panel-workspace-routes.js";
+import { handleSidePanelWorkspaceRoute, openSidePanelWorkspaceTab } from "./side-panel-workspace-routes.js";
 import {
 	TextSelectionError,
 	selectText,
@@ -11460,6 +11460,57 @@ async function handleApiRoute(
 	// ── Preview mount endpoints ──────────────────────────────────────
 	const VALID_SESSION_ID = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
 
+	const previewEntryLabelForWorkspace = (entry: string | undefined | null): string => {
+		const clean = (entry || "inline.html").split(/[?#]/, 1)[0]?.replace(/\\/g, "/").replace(/\/+$/, "") ?? "inline.html";
+		return clean.split("/").filter(Boolean).pop() || clean || "inline.html";
+	};
+
+	const openPreviewMountWorkspaceTab = async (sessionId: string, result: {
+		entry?: string;
+		mtime?: number;
+		url?: string;
+		path?: string;
+		contentHash?: string;
+		artifactId?: string;
+	}): Promise<void> => {
+		const entry = previewEntryLabelForWorkspace(result.entry);
+		try {
+			await openSidePanelWorkspaceTab({
+				sessionManager,
+				readBody,
+				broadcastToSession: _broadcastToSession,
+				packContributionRegistry,
+			}, sessionId, {
+				id: `preview:entry:${encodeURIComponent(entry)}`,
+				kind: "preview",
+				title: entry,
+				label: entry,
+				source: {
+					type: "preview",
+					sessionId,
+					entry,
+					live: true,
+					...(typeof result.contentHash === "string" && result.contentHash ? { contentHash: result.contentHash } : {}),
+					...(typeof result.path === "string" && result.path ? { path: result.path } : {}),
+					...(typeof result.url === "string" && result.url ? { url: result.url } : {}),
+					...(typeof result.artifactId === "string" && result.artifactId ? { artifactId: result.artifactId } : {}),
+				},
+				state: {
+					entry,
+					origin: "preview-mount",
+					...(typeof result.mtime === "number" ? { mtime: result.mtime } : {}),
+					...(typeof result.url === "string" && result.url ? { url: result.url } : {}),
+					...(typeof result.path === "string" && result.path ? { path: result.path } : {}),
+					...(typeof result.contentHash === "string" && result.contentHash ? { contentHash: result.contentHash } : {}),
+					...(typeof result.artifactId === "string" && result.artifactId ? { artifactId: result.artifactId } : {}),
+				},
+				updatedAt: Date.now(),
+			}, { focus: true, placeAfterActive: true });
+		} catch (err) {
+			console.warn(`[preview/mount] failed to open side-panel workspace tab for ${sessionId}:`, err);
+		}
+	};
+
 	// POST /api/preview/mount?sessionId=<sid> — v3 per-session preview mount.
 	// Accepts {html} (with optional {entry}) or {file: absolutePath}. Returns
 	// {url, path, entry, mtime, contentHash}. See docs/design/embedded-html-preview-rewrite.md §6.
@@ -11495,6 +11546,7 @@ async function handleApiRoute(
 			let result: previewMount.MountResult | previewMount.MountFileResult | previewArtifacts.PreviewArtifactMountResult;
 			if (hasArtifact) {
 				const restored = previewArtifacts.restorePreviewArtifact(sessionId, body.artifactId as string);
+				await openPreviewMountWorkspaceTab(sessionId, restored);
 				broadcastPreviewChanged(sessionId, {
 					entry: restored.entry,
 					mtime: restored.mtime,
@@ -11597,6 +11649,7 @@ async function handleApiRoute(
 			}
 			const artifact = previewArtifacts.persistPreviewArtifact(sessionId, result);
 			const resultWithArtifact = { ...result, artifactId: artifact.artifactId };
+			await openPreviewMountWorkspaceTab(sessionId, resultWithArtifact);
 			broadcastPreviewChanged(sessionId, {
 				entry: result.entry,
 				mtime: result.mtime,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -162,6 +162,15 @@ async function detectedRefExistsInAllComponents(
 	}
 }
 
+async function resolveBaseRefDetectRepoPath(rootPath: string, comps: Array<{ repo: string }>): Promise<string | null> {
+	const isMultiRepo = comps.some(c => c.repo !== ".");
+	const primaryRepoPath = isMultiRepo
+		? path.join(rootPath, comps.find(c => c.repo !== ".")?.repo ?? ".")
+		: rootPath;
+	if (!(await isGitRepo(primaryRepoPath).catch(() => false))) return null;
+	return isMultiRepo ? primaryRepoPath : await getRepoRoot(primaryRepoPath);
+}
+
 function normalizeApiRouteLabel(method: string | undefined, pathname: string): string {
 	const normalizedPath = pathname
 		.replace(/\/[0-9a-f]{8}-[0-9a-f-]{27,}(?=\/|$)/gi, "/:id")
@@ -3549,10 +3558,12 @@ async function handleApiRoute(
 		try {
 			const cfg = ctx.projectConfigStore;
 			const comps = cfg.getComponents();
-			const isMultiRepo = comps.some(c => c.repo !== ".");
-			const primaryRepoPath = isMultiRepo
-				? path.join(rootPath, comps.find(c => c.repo !== ".")?.repo ?? ".")
-				: await getRepoRoot(rootPath);
+			const primaryRepoPath = await resolveBaseRefDetectRepoPath(rootPath, comps);
+			if (!primaryRepoPath) {
+				const parsed = parseBaseRef(cfg.get("base_ref") || "");
+				json({ resolved: parsed.ref || "", detected: null });
+				return;
+			}
 			const resolved = (await resolveBaseRef(primaryRepoPath, cfg.get("base_ref"))).ref;
 			// `detected` must be SAVEABLE — null it out unless it passes the same
 			// checks add-time pinning applies (grammar + cross-component existence).

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5586,7 +5586,13 @@ async function handleApiRoute(
 		const packs = packContributionRegistry.list(contribProjectId).map((p) => ({
 			packId: p.packId,
 			packName: p.packName,
-			panels: p.panels.map((panel) => (panel.title !== undefined ? { id: panel.id, title: panel.title } : { id: panel.id })),
+			panels: p.panels.map((panel) => {
+				const out: Record<string, unknown> = { id: panel.id };
+				if (panel.title !== undefined) out.title = panel.title;
+				if (panel.instanceMode !== undefined) out.instanceMode = panel.instanceMode;
+				if (panel.instanceParam !== undefined) out.instanceParam = panel.instanceParam;
+				return out;
+			}),
 			entrypoints: p.entrypoints.map((e) => {
 				const out: Record<string, unknown> = { id: e.id, kind: e.kind, listName: e.listName };
 				if (e.label !== undefined) out.label = e.label;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -11525,6 +11525,10 @@ async function handleApiRoute(
 			return;
 		}
 		const body = await readBody(req).catch(() => ({}));
+		const shouldOpenWorkspaceTab = body?.workspaceTab !== false
+			&& body?.openWorkspaceTab !== false
+			&& body?.internalRestore !== true
+			&& url.searchParams.get("workspaceTab") !== "false";
 		const hasArtifact = typeof body?.artifactId === "string" && body.artifactId.length > 0;
 		const hasHtml = typeof body?.html === "string";
 		const hasFile = typeof body?.file === "string" && body.file.length > 0;
@@ -11546,7 +11550,7 @@ async function handleApiRoute(
 			let result: previewMount.MountResult | previewMount.MountFileResult | previewArtifacts.PreviewArtifactMountResult;
 			if (hasArtifact) {
 				const restored = previewArtifacts.restorePreviewArtifact(sessionId, body.artifactId as string);
-				await openPreviewMountWorkspaceTab(sessionId, restored);
+				if (shouldOpenWorkspaceTab) await openPreviewMountWorkspaceTab(sessionId, restored);
 				broadcastPreviewChanged(sessionId, {
 					entry: restored.entry,
 					mtime: restored.mtime,
@@ -11649,7 +11653,7 @@ async function handleApiRoute(
 			}
 			const artifact = previewArtifacts.persistPreviewArtifact(sessionId, result);
 			const resultWithArtifact = { ...result, artifactId: artifact.artifactId };
-			await openPreviewMountWorkspaceTab(sessionId, resultWithArtifact);
+			if (shouldOpenWorkspaceTab) await openPreviewMountWorkspaceTab(sessionId, resultWithArtifact);
 			broadcastPreviewChanged(sessionId, {
 				entry: result.entry,
 				mtime: result.mtime,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -56,6 +56,7 @@ import { loadPackContributions } from "./agent/pack-contributions.js";
 import { isPackPathWithinRoot } from "./extension-host/path-guard.js";
 import { buildGateStatusSummary } from "./gate-status-summary.js";
 import { buildGateVerificationSnapshot, UnknownVerificationStepError } from "./gate-verification-snapshot.js";
+import { handleSidePanelWorkspaceRoute } from "./side-panel-workspace-routes.js";
 import {
 	TextSelectionError,
 	selectText,
@@ -2547,6 +2548,13 @@ async function handleApiRoute(
 		json({ error: "Subgoals are disabled", code: "SUBGOALS_DISABLED" }, 403);
 		return false;
 	}
+
+	if (await handleSidePanelWorkspaceRoute(url, req, res, {
+		sessionManager,
+		readBody,
+		broadcastToSession: _broadcastToSession,
+		packContributionRegistry,
+	})) return;
 
 	if (await handlePrWalkthroughApiRoute(url, req, res, {
 		defaultCwd: config.defaultCwd,

--- a/src/server/side-panel-workspace-routes.ts
+++ b/src/server/side-panel-workspace-routes.ts
@@ -170,11 +170,15 @@ export async function handleSidePanelWorkspaceRoute(
 				}
 				if (op === "open") {
 					if (!body || typeof body !== "object") throw new SidePanelWorkspaceError("Invalid request body", 400, "INVALID_BODY");
+					const payload = body as Record<string, unknown>;
+					const baseActiveTabId = typeof payload.baseActiveTabId === "string" ? payload.baseActiveTabId : "";
+					const focus = payload.focus !== false
+						&& !(baseRevision !== undefined && baseRevision !== workspace.revision && baseActiveTabId && workspace.activeTabId !== baseActiveTabId);
 					return applyWorkspaceMutation(workspace, {
 						type: "open",
-						tab: (body as Record<string, unknown>).tab,
-						focus: (body as Record<string, unknown>).focus !== false,
-						placeAfterActive: (body as Record<string, unknown>).placeAfterActive === true,
+						tab: payload.tab,
+						focus,
+						placeAfterActive: payload.placeAfterActive === true,
 					}, validatorsFor(deps, sessionId));
 				}
 				if (op === "active") {

--- a/src/server/side-panel-workspace-routes.ts
+++ b/src/server/side-panel-workspace-routes.ts
@@ -45,8 +45,22 @@ function revisionFromRequest(req: http.IncomingMessage, body: unknown): number |
 	return typeof bodyRev === "number" && Number.isInteger(bodyRev) && bodyRev >= 0 ? bodyRev : undefined;
 }
 
+function isObject(value: unknown): value is Record<string, unknown> {
+	return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
 function strictRevision(body: unknown): boolean {
-	return !!(body && typeof body === "object" && (body as Record<string, unknown>).strictRevision === true);
+	return !!(isObject(body) && body.strictRevision === true);
+}
+
+function tabPatchFromRequestBody(body: unknown): unknown {
+	if (!isObject(body)) return body;
+	if ("patch" in body) return body.patch;
+	const patch: Record<string, unknown> = {};
+	for (const key of ["title", "label", "source", "state"] as const) {
+		if (key in body) patch[key] = body[key];
+	}
+	return patch;
 }
 
 function resolveSessionStore(deps: SidePanelWorkspaceRouteDeps, sessionId: string) {
@@ -202,7 +216,7 @@ export async function handleSidePanelWorkspaceRoute(
 					throw new SidePanelWorkspaceError("Stale side-panel workspace revision", 409, "STALE_REVISION");
 				}
 				return req.method === "PATCH"
-					? applyWorkspaceMutation(workspace, { type: "update", tabId, patch: body }, validatorsFor(deps, sessionId))
+					? applyWorkspaceMutation(workspace, { type: "update", tabId, patch: tabPatchFromRequestBody(body) }, validatorsFor(deps, sessionId))
 					: applyWorkspaceMutation(workspace, { type: "close", tabId }, validatorsFor(deps, sessionId));
 			});
 			if (result.status === 404) { error(res, 404, result.error, "SESSION_NOT_FOUND"); return true; }

--- a/src/server/side-panel-workspace-routes.ts
+++ b/src/server/side-panel-workspace-routes.ts
@@ -66,6 +66,12 @@ function validatorsFor(deps: SidePanelWorkspaceRouteDeps, sessionId: string): Si
 		isKnownPackPanel: deps.packContributionRegistry
 			? (packId: string, panelId: string) => !!deps.packContributionRegistry?.getPanel(projectId, packId, panelId)
 			: undefined,
+		getPackPanelInfo: deps.packContributionRegistry
+			? (packId: string, panelId: string) => {
+				const panel = deps.packContributionRegistry?.getPanel(projectId, packId, panelId);
+				return panel ? { instanceMode: panel.instanceMode, instanceParam: panel.instanceParam } : undefined;
+			}
+			: undefined,
 	};
 }
 

--- a/src/server/side-panel-workspace-routes.ts
+++ b/src/server/side-panel-workspace-routes.ts
@@ -120,6 +120,21 @@ async function mutate(
 	});
 }
 
+export async function openSidePanelWorkspaceTab(
+	deps: SidePanelWorkspaceRouteDeps,
+	sessionId: string,
+	tab: unknown,
+	options: { focus?: boolean; placeAfterActive?: boolean } = {},
+): Promise<SidePanelWorkspace | undefined> {
+	const result = await mutate(deps, sessionId, (workspace) => applyWorkspaceMutation(workspace, {
+		type: "open",
+		tab,
+		focus: options.focus !== false,
+		placeAfterActive: options.placeAfterActive === true,
+	}, validatorsFor(deps, sessionId)));
+	return result.status === 200 ? result.workspace : undefined;
+}
+
 export async function handleSidePanelWorkspaceRoute(
 	url: URL,
 	req: http.IncomingMessage,

--- a/src/server/side-panel-workspace-routes.ts
+++ b/src/server/side-panel-workspace-routes.ts
@@ -1,0 +1,216 @@
+import type http from "node:http";
+import type { SessionManager } from "./agent/session-manager.js";
+import type { PackContributionRegistry } from "./extension-host/pack-contribution-registry.js";
+import type { SidePanelWorkspace } from "../shared/side-panel-workspace.js";
+import { isSidePanelSizeMode } from "../shared/side-panel-workspace.js";
+import {
+	applyWorkspaceMutation,
+	canonicalizeWorkspace,
+	SidePanelWorkspaceError,
+	SidePanelWorkspaceLocks,
+	type SidePanelWorkspaceValidators,
+} from "./side-panel-workspace.js";
+
+const locks = new SidePanelWorkspaceLocks();
+
+type ReadBody = (req: http.IncomingMessage, maxBytes?: number) => Promise<any>;
+
+export interface SidePanelWorkspaceRouteDeps {
+	sessionManager: SessionManager;
+	readBody: ReadBody;
+	broadcastToSession?: (sessionId: string, event: any) => void;
+	packContributionRegistry?: PackContributionRegistry;
+}
+
+function writeJson(res: http.ServerResponse, data: unknown, status = 200): void {
+	res.writeHead(status, { "Content-Type": "application/json" });
+	res.end(JSON.stringify(data));
+}
+
+function error(res: http.ServerResponse, status: number, message: string, code = "SIDE_PANEL_WORKSPACE_ERROR", extra?: Record<string, unknown>): void {
+	writeJson(res, { error: message, code, ...extra }, status);
+}
+
+function decodePathPart(value: string): string | null {
+	try { return decodeURIComponent(value); } catch { return null; }
+}
+
+function revisionFromRequest(req: http.IncomingMessage, body: unknown): number | undefined {
+	const header = req.headers["if-match"];
+	const raw = Array.isArray(header) ? header[0] : header;
+	const headerText = typeof raw === "string" ? raw.trim().replace(/^W\//, "").replace(/^"|"$/g, "") : "";
+	const headerNumber = headerText ? Number(headerText) : NaN;
+	if (Number.isInteger(headerNumber) && headerNumber >= 0) return headerNumber;
+	const bodyRev = body && typeof body === "object" ? (body as Record<string, unknown>).baseRevision : undefined;
+	return typeof bodyRev === "number" && Number.isInteger(bodyRev) && bodyRev >= 0 ? bodyRev : undefined;
+}
+
+function strictRevision(body: unknown): boolean {
+	return !!(body && typeof body === "object" && (body as Record<string, unknown>).strictRevision === true);
+}
+
+function resolveSessionStore(deps: SidePanelWorkspaceRouteDeps, sessionId: string) {
+	const persisted = deps.sessionManager.getPersistedSession(sessionId);
+	if (!persisted) return null;
+	try {
+		return deps.sessionManager.getSessionStore(persisted.projectId);
+	} catch {
+		return null;
+	}
+}
+
+function validatorsFor(deps: SidePanelWorkspaceRouteDeps, sessionId: string): SidePanelWorkspaceValidators {
+	const persisted = deps.sessionManager.getPersistedSession(sessionId);
+	const projectId = persisted?.projectId;
+	return {
+		isKnownPackPanel: deps.packContributionRegistry
+			? (packId: string, panelId: string) => !!deps.packContributionRegistry?.getPanel(projectId, packId, panelId)
+			: undefined,
+	};
+}
+
+function currentWorkspace(deps: SidePanelWorkspaceRouteDeps, sessionId: string): { workspace: SidePanelWorkspace; store: ReturnType<typeof resolveSessionStore> } | null {
+	const store = resolveSessionStore(deps, sessionId);
+	if (!store) return null;
+	const persisted = store.get(sessionId);
+	if (!persisted) return null;
+	return { workspace: canonicalizeWorkspace(persisted.sidePanelWorkspace, sessionId, validatorsFor(deps, sessionId)), store };
+}
+
+function persistAndBroadcast(deps: SidePanelWorkspaceRouteDeps, sessionId: string, before: SidePanelWorkspace, after: SidePanelWorkspace, store: NonNullable<ReturnType<typeof resolveSessionStore>>): void {
+	store.update(sessionId, { sidePanelWorkspace: after });
+	if (after.revision !== before.revision) {
+		deps.broadcastToSession?.(sessionId, { type: "side_panel_workspace", sessionId, workspace: after });
+	}
+}
+
+async function mutate(
+	deps: SidePanelWorkspaceRouteDeps,
+	sessionId: string,
+	fn: (workspace: SidePanelWorkspace) => SidePanelWorkspace,
+): Promise<{ status: 200; workspace: SidePanelWorkspace } | { status: 404; error: string }> {
+	return locks.with(sessionId, async () => {
+		const current = currentWorkspace(deps, sessionId);
+		if (!current) return { status: 404 as const, error: "Session not found" };
+		const next = fn(current.workspace);
+		if (next !== current.workspace && next.revision !== current.workspace.revision) {
+			persistAndBroadcast(deps, sessionId, current.workspace, next, current.store!);
+		}
+		return { status: 200 as const, workspace: next };
+	});
+}
+
+export async function handleSidePanelWorkspaceRoute(
+	url: URL,
+	req: http.IncomingMessage,
+	res: http.ServerResponse,
+	deps: SidePanelWorkspaceRouteDeps,
+): Promise<boolean> {
+	const rootMatch = url.pathname.match(/^\/api\/sessions\/([^/]+)\/side-panel-workspace$/);
+	if (rootMatch) {
+		const sessionId = decodePathPart(rootMatch[1]);
+		if (!sessionId) { error(res, 400, "Invalid session id", "INVALID_SESSION_ID"); return true; }
+		if (req.method !== "GET") return false;
+		const current = currentWorkspace(deps, sessionId);
+		if (!current) { error(res, 404, "Session not found", "SESSION_NOT_FOUND"); return true; }
+		// Persist canonical shape when legacy/corrupt data was read; this does not bump workspace revision.
+		if (JSON.stringify(current.store!.get(sessionId)?.sidePanelWorkspace ?? null) !== JSON.stringify(current.workspace)) {
+			current.store!.update(sessionId, { sidePanelWorkspace: current.workspace });
+		}
+		writeJson(res, current.workspace);
+		return true;
+	}
+
+	const opMatch = url.pathname.match(/^\/api\/sessions\/([^/]+)\/side-panel-workspace\/(open|active|reorder|resize|migrate)$/);
+	if (opMatch && req.method === "POST") {
+		const sessionId = decodePathPart(opMatch[1]);
+		const op = opMatch[2];
+		if (!sessionId) { error(res, 400, "Invalid session id", "INVALID_SESSION_ID"); return true; }
+		const body = await deps.readBody(req);
+		try {
+			const baseRevision = revisionFromRequest(req, body);
+			const result = await mutate(deps, sessionId, (workspace) => {
+				if ((op === "reorder" || strictRevision(body)) && baseRevision !== undefined && baseRevision !== workspace.revision) {
+					throw new SidePanelWorkspaceError("Stale side-panel workspace revision", 409, "STALE_REVISION");
+				}
+				if (op === "open") {
+					if (!body || typeof body !== "object") throw new SidePanelWorkspaceError("Invalid request body", 400, "INVALID_BODY");
+					return applyWorkspaceMutation(workspace, {
+						type: "open",
+						tab: (body as Record<string, unknown>).tab,
+						focus: (body as Record<string, unknown>).focus !== false,
+						placeAfterActive: (body as Record<string, unknown>).placeAfterActive === true,
+					}, validatorsFor(deps, sessionId));
+				}
+				if (op === "active") {
+					const activeTabId = body && typeof body === "object" && typeof (body as Record<string, unknown>).activeTabId === "string" ? (body as Record<string, unknown>).activeTabId as string : "";
+					return applyWorkspaceMutation(workspace, { type: "active", activeTabId }, validatorsFor(deps, sessionId));
+				}
+				if (op === "reorder") {
+					if (baseRevision === undefined) throw new SidePanelWorkspaceError("Reorder requires baseRevision or If-Match", 409, "REVISION_REQUIRED");
+					const tabIds = body && typeof body === "object" && Array.isArray((body as Record<string, unknown>).tabIds)
+						? ((body as Record<string, unknown>).tabIds as unknown[]).filter((id): id is string => typeof id === "string")
+						: [];
+					return applyWorkspaceMutation(workspace, { type: "reorder", tabIds }, validatorsFor(deps, sessionId));
+				}
+				if (op === "resize") {
+					const sizeMode = body && typeof body === "object" ? (body as Record<string, unknown>).sizeMode : undefined;
+					if (!isSidePanelSizeMode(sizeMode)) throw new SidePanelWorkspaceError("Invalid side-panel size mode", 400, "INVALID_SIZE_MODE");
+					return applyWorkspaceMutation(workspace, { type: "resize", sizeMode }, validatorsFor(deps, sessionId));
+				}
+				if (op === "migrate") {
+					const payload = body && typeof body === "object" ? body as Record<string, unknown> : {};
+					return applyWorkspaceMutation(workspace, {
+						type: "migrate",
+						tabs: Array.isArray(payload.tabs) ? payload.tabs : [],
+						activeTabId: typeof payload.activeTabId === "string" ? payload.activeTabId : undefined,
+						sizeMode: payload.sizeMode,
+						metadata: payload.metadata,
+					}, validatorsFor(deps, sessionId));
+				}
+				return workspace;
+			});
+			if (result.status === 404) { error(res, 404, result.error, "SESSION_NOT_FOUND"); return true; }
+			writeJson(res, result.workspace);
+			return true;
+		} catch (err) {
+			if (err instanceof SidePanelWorkspaceError) {
+				const current = currentWorkspace(deps, sessionId)?.workspace;
+				error(res, err.status, err.message, err.code, current ? { workspace: current } : undefined);
+				return true;
+			}
+			throw err;
+		}
+	}
+
+	const tabMatch = url.pathname.match(/^\/api\/sessions\/([^/]+)\/side-panel-workspace\/tabs\/(.+)$/);
+	if (tabMatch && (req.method === "PATCH" || req.method === "DELETE")) {
+		const sessionId = decodePathPart(tabMatch[1]);
+		const tabId = decodePathPart(tabMatch[2]);
+		if (!sessionId || !tabId) { error(res, 400, "Invalid path", "INVALID_PATH"); return true; }
+		const body = req.method === "PATCH" ? await deps.readBody(req) : undefined;
+		try {
+			const baseRevision = revisionFromRequest(req, body);
+			const result = await mutate(deps, sessionId, (workspace) => {
+				if (strictRevision(body) && baseRevision !== undefined && baseRevision !== workspace.revision) {
+					throw new SidePanelWorkspaceError("Stale side-panel workspace revision", 409, "STALE_REVISION");
+				}
+				return req.method === "PATCH"
+					? applyWorkspaceMutation(workspace, { type: "update", tabId, patch: body }, validatorsFor(deps, sessionId))
+					: applyWorkspaceMutation(workspace, { type: "close", tabId }, validatorsFor(deps, sessionId));
+			});
+			if (result.status === 404) { error(res, 404, result.error, "SESSION_NOT_FOUND"); return true; }
+			writeJson(res, result.workspace);
+			return true;
+		} catch (err) {
+			if (err instanceof SidePanelWorkspaceError) {
+				const current = currentWorkspace(deps, sessionId)?.workspace;
+				error(res, err.status, err.message, err.code, current ? { workspace: current } : undefined);
+				return true;
+			}
+			throw err;
+		}
+	}
+
+	return false;
+}

--- a/src/server/side-panel-workspace.ts
+++ b/src/server/side-panel-workspace.ts
@@ -10,8 +10,14 @@ import type {
 } from "../shared/side-panel-workspace.js";
 import { isSidePanelKind, isSidePanelProposalType, isSidePanelSizeMode } from "../shared/side-panel-workspace.js";
 
+export interface PackPanelValidationInfo {
+	instanceMode?: "singleton" | "parameterized";
+	instanceParam?: string;
+}
+
 export interface SidePanelWorkspaceValidators {
 	isKnownPackPanel?: (packId: string, panelId: string) => boolean;
+	getPackPanelInfo?: (packId: string, panelId: string) => PackPanelValidationInfo | undefined;
 }
 
 export type WorkspaceMutation =
@@ -247,9 +253,22 @@ function canonicalizePack(raw: Record<string, unknown>, id: string, sessionId: s
 	const sourceInstance = typeof source.instanceKey === "string" && source.instanceKey ? source.instanceKey : (legacy ? "default" : "");
 	if (sourceInstance !== instanceKey) return null;
 	if (!isRouteSafePart(packId) || !isRouteSafePart(panelId) || !isRouteSafePart(instanceKey)) return null;
-	if (validators?.isKnownPackPanel && !validators.isKnownPackPanel(packId, panelId)) return null;
+	const panelInfo = validators?.getPackPanelInfo?.(packId, panelId);
+	if (validators?.getPackPanelInfo && !panelInfo) return null;
+	if (!panelInfo && validators?.isKnownPackPanel && !validators.isKnownPackPanel(packId, panelId)) return null;
 	const params = cloneJsonObject(source.params);
 	if (source.params !== undefined && params === undefined) return null;
+	if (panelInfo) {
+		const mode = panelInfo.instanceMode === "parameterized" ? "parameterized" : "singleton";
+		if (mode === "singleton" && instanceKey !== "default") return null;
+		if (mode === "parameterized") {
+			if (instanceKey === "default") return null;
+			if (panelInfo.instanceParam) {
+				const paramValue = params?.[panelInfo.instanceParam];
+				if (typeof paramValue !== "string" || paramValue !== instanceKey || !isRouteSafePart(paramValue)) return null;
+			}
+		}
+	}
 	const canonicalId = `pack:${encodeComponent(packId)}:${encodeComponent(panelId)}:${encodeComponent(instanceKey)}`;
 	return {
 		id: canonicalId,

--- a/src/server/side-panel-workspace.ts
+++ b/src/server/side-panel-workspace.ts
@@ -1,0 +1,446 @@
+import { createHash } from "node:crypto";
+import type {
+	SidePanelKind,
+	SidePanelProposalType,
+	SidePanelSizeMode,
+	SidePanelWorkspace,
+	SidePanelWorkspaceMetadata,
+	SidePanelWorkspaceSource,
+	SidePanelWorkspaceTab,
+} from "../shared/side-panel-workspace.js";
+import { isSidePanelKind, isSidePanelProposalType, isSidePanelSizeMode } from "../shared/side-panel-workspace.js";
+
+export interface SidePanelWorkspaceValidators {
+	isKnownPackPanel?: (packId: string, panelId: string) => boolean;
+}
+
+export type WorkspaceMutation =
+	| { type: "open"; tab: unknown; focus?: boolean; placeAfterActive?: boolean }
+	| { type: "update"; tabId: string; patch: unknown }
+	| { type: "close"; tabId: string }
+	| { type: "active"; activeTabId: string }
+	| { type: "reorder"; tabIds: string[] }
+	| { type: "resize"; sizeMode: SidePanelSizeMode }
+	| { type: "migrate"; tabs?: unknown[]; activeTabId?: string; sizeMode?: unknown; metadata?: unknown };
+
+export class SidePanelWorkspaceError extends Error {
+	constructor(
+		message: string,
+		readonly status: number = 400,
+		readonly code: string = "SIDE_PANEL_WORKSPACE_INVALID",
+	) {
+		super(message);
+	}
+}
+
+const MAX_ID = 300;
+const MAX_TITLE = 160;
+const MAX_LABEL = 80;
+const MAX_ENTRY = 240;
+const MAX_DOC_ID = 240;
+const MAX_PACK_PART = 120;
+const MAX_PARAMS_BYTES = 16 * 1024;
+const MAX_STATE_BYTES = 16 * 1024;
+const MAX_JSON_DEPTH = 8;
+const PREVIEW_ENTRY_ID_RE = /^preview:entry:([^:]+)(?::v:(\d+))?$/;
+const PROPOSAL_ID_RE = /^proposal:([^:]+)(?::rev:(\d+))?$/;
+const PACK_ID_RE = /^pack:([^:]+):([^:]+):([^:]+)$/;
+const LEGACY_PACK_ID_RE = /^pack:([^:]+):([^:]+)$/;
+
+function isObject(value: unknown): value is Record<string, unknown> {
+	return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function asString(value: unknown, fallback = ""): string {
+	return typeof value === "string" ? value : fallback;
+}
+
+function truncate(value: string, max: number): string {
+	return value.length > max ? value.slice(0, max) : value;
+}
+
+function decodeComponent(value: string): string | null {
+	try { return decodeURIComponent(value); } catch { return null; }
+}
+
+function encodeComponent(value: string): string {
+	return encodeURIComponent(value);
+}
+
+function positiveInteger(value: unknown): number | undefined {
+	const n = typeof value === "number" ? value : typeof value === "string" && value ? Number(value) : NaN;
+	return Number.isInteger(n) && n > 0 ? n : undefined;
+}
+
+function nonNegativeInteger(value: unknown): number | undefined {
+	const n = typeof value === "number" ? value : typeof value === "string" && value !== "" ? Number(value) : NaN;
+	return Number.isInteger(n) && n >= 0 ? n : undefined;
+}
+
+function previewEntryLabel(entry: string | undefined | null): string {
+	const clean = (entry || "inline.html").split(/[?#]/, 1)[0]?.replace(/\\/g, "/").replace(/\/+$/, "") ?? "inline.html";
+	return truncate(clean.split("/").filter(Boolean).pop() || clean || "inline.html", MAX_ENTRY);
+}
+
+function hasNoControlChars(value: string): boolean {
+	return !/[\x00-\x1f\x7f]/.test(value);
+}
+
+function isRouteSafePart(value: string, max = MAX_PACK_PART): boolean {
+	return value.length > 0 && value.length <= max && hasNoControlChars(value) && !/[\\/]/.test(value);
+}
+
+function cloneJsonObject(value: unknown, maxBytes = MAX_PARAMS_BYTES): Record<string, unknown> | undefined {
+	if (value == null) return undefined;
+	if (!isObject(value)) return undefined;
+	const seen = new Set<object>();
+	function clone(input: unknown, depth: number): unknown {
+		if (depth > MAX_JSON_DEPTH) throw new Error("too deep");
+		if (input == null || typeof input === "string" || typeof input === "number" || typeof input === "boolean") return input;
+		if (typeof input !== "object") throw new Error("non-json");
+		if (seen.has(input)) throw new Error("cycle");
+		seen.add(input);
+		if (Array.isArray(input)) {
+			if (input.length > 100) throw new Error("array too large");
+			return input.map((item) => clone(item, depth + 1));
+		}
+		const out: Record<string, unknown> = Object.create(null);
+		for (const [key, raw] of Object.entries(input as Record<string, unknown>)) {
+			if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
+			if (!hasNoControlChars(key) || key.length > 120) throw new Error("bad key");
+			out[key] = clone(raw, depth + 1);
+		}
+		return out;
+	}
+	try {
+		const cloned = clone(value, 0) as Record<string, unknown>;
+		if (Buffer.byteLength(JSON.stringify(cloned), "utf8") > maxBytes) return undefined;
+		return cloned;
+	} catch {
+		return undefined;
+	}
+}
+
+function normalizeState(value: unknown): Record<string, unknown> | undefined {
+	return cloneJsonObject(value, MAX_STATE_BYTES);
+}
+
+function metadataFrom(raw: unknown): SidePanelWorkspaceMetadata | undefined {
+	if (!isObject(raw)) return undefined;
+	const migrated = positiveInteger(raw.migratedFromLocalStorageAt);
+	return migrated ? { migratedFromLocalStorageAt: migrated } : undefined;
+}
+
+function sourceSessionMatches(source: Record<string, unknown>, sessionId: string): boolean {
+	return source.sessionId === sessionId;
+}
+
+function titleFor(kind: SidePanelKind, source: SidePanelWorkspaceSource, rawTitle: string): string {
+	const title = truncate(rawTitle.trim(), MAX_TITLE);
+	if (title) return title;
+	if (kind === "preview") return source.type === "preview" ? source.entry : "Preview";
+	if (kind === "proposal") return source.type === "proposal" ? `${source.proposalType[0].toUpperCase()}${source.proposalType.slice(1)} Proposal` : "Proposal";
+	if (kind === "review") return source.type === "review" ? source.title : "Review";
+	if (kind === "inbox") return "Inbox";
+	if (kind === "pack" && source.type === "pack") return source.panelId;
+	return "Panel";
+}
+
+function labelFor(title: string, rawLabel: string): string {
+	const label = truncate(rawLabel.trim(), MAX_LABEL);
+	return label || truncate(title, MAX_LABEL);
+}
+
+function canonicalizePreview(raw: Record<string, unknown>, id: string, sessionId: string): { id: string; source: SidePanelWorkspaceSource } | null {
+	const source = isObject(raw.source) ? raw.source : undefined;
+	if (!source || source.type !== "preview" || !sourceSessionMatches(source, sessionId)) return null;
+	const match = PREVIEW_ENTRY_ID_RE.exec(id);
+	if (!match) return null;
+	const decodedEntry = decodeComponent(match[1]);
+	if (!decodedEntry) return null;
+	const entry = previewEntryLabel(asString(source.entry, decodedEntry));
+	if (encodeComponent(entry) !== match[1]) return null;
+	const idVersion = positiveInteger(match[2]);
+	const sourceVersion = positiveInteger(source.version);
+	const version = idVersion ?? sourceVersion;
+	if (match[2] != null && !idVersion) return null;
+	if (source.historical === true && !version) return null;
+	const canonicalSource: SidePanelWorkspaceSource = {
+		type: "preview",
+		sessionId,
+		entry,
+		...(source.live === true && !version ? { live: true } : {}),
+		...(source.historical === true || version ? { historical: source.historical === true || !!version } : {}),
+		...(version ? { version } : {}),
+		...(typeof source.artifactId === "string" ? { artifactId: truncate(source.artifactId, 200) } : {}),
+		...(typeof source.contentHash === "string" ? { contentHash: truncate(source.contentHash, 200) } : {}),
+		...(typeof source.path === "string" ? { path: truncate(source.path, 500) } : {}),
+		...(typeof source.url === "string" ? { url: truncate(source.url, 1000) } : {}),
+		...(typeof source.toolUseId === "string" ? { toolUseId: truncate(source.toolUseId, 160) } : {}),
+		...(nonNegativeInteger(source.blockIndex) !== undefined ? { blockIndex: nonNegativeInteger(source.blockIndex)! } : {}),
+	};
+	return { id, source: canonicalSource };
+}
+
+function canonicalizeProposal(raw: Record<string, unknown>, id: string, sessionId: string): { id: string; kind: "proposal"; source: SidePanelWorkspaceSource } | null {
+	const source = isObject(raw.source) ? raw.source : undefined;
+	if (!source || source.type !== "proposal" || !sourceSessionMatches(source, sessionId)) return null;
+	const match = PROPOSAL_ID_RE.exec(id);
+	if (!match) return null;
+	const proposalType = match[1];
+	if (!isSidePanelProposalType(proposalType) || source.proposalType !== proposalType) return null;
+	const idRev = positiveInteger(match[2]);
+	const sourceRev = positiveInteger(source.rev);
+	if (match[2] != null && !idRev) return null;
+	const rev = idRev ?? sourceRev;
+	const canonicalSource: SidePanelWorkspaceSource = {
+		type: "proposal",
+		sessionId,
+		proposalType: proposalType as SidePanelProposalType,
+		...(rev ? { rev } : {}),
+		...(source.historical === true || idRev ? { historical: source.historical === true || !!idRev } : {}),
+	};
+	return { id, kind: "proposal", source: canonicalSource };
+}
+
+function canonicalizeReview(raw: Record<string, unknown>, id: string, sessionId: string): { id: string; kind: "review"; source: SidePanelWorkspaceSource } | null {
+	const source = isObject(raw.source) ? raw.source : undefined;
+	if (!id.startsWith("review:")) return null;
+	const encoded = id.slice("review:".length);
+	const decoded = decodeComponent(encoded);
+	if (!decoded) return null;
+	if (!source || source.type !== "review" || !sourceSessionMatches(source, sessionId)) return null;
+	let documentId = typeof source.documentId === "string" && source.documentId.trim() ? source.documentId.trim() : decoded;
+	let canonicalId = `review:${encodeComponent(documentId)}`;
+	const rawTitle = asString(source.title, asString((source as Record<string, unknown>).reviewTitle, decoded)).trim() || decoded;
+	// Legacy title-based review tabs had no durable document id; migrate them to a deterministic id.
+	if (!("documentId" in source) && !id.startsWith("review:legacy-title-")) {
+		documentId = `legacy-title-${createHash("sha256").update(rawTitle).digest("hex").slice(0, 16)}`;
+		canonicalId = `review:${documentId}`;
+	}
+	if (!documentId || documentId.length > MAX_DOC_ID || !hasNoControlChars(documentId)) return null;
+	const title = truncate(rawTitle, MAX_TITLE) || documentId;
+	return { id: canonicalId, kind: "review", source: { type: "review", sessionId, documentId, title } };
+}
+
+function canonicalizeInbox(raw: Record<string, unknown>, id: string, sessionId: string): { id: string; kind: "inbox"; source: SidePanelWorkspaceSource } | null {
+	const source = isObject(raw.source) ? raw.source : undefined;
+	if (id !== "inbox" || !source || source.type !== "inbox" || !sourceSessionMatches(source, sessionId)) return null;
+	return { id: "inbox", kind: "inbox", source: { type: "inbox", sessionId, ...(typeof source.staffId === "string" ? { staffId: truncate(source.staffId, 160) } : {}) } };
+}
+
+function canonicalizePack(raw: Record<string, unknown>, id: string, sessionId: string, validators?: SidePanelWorkspaceValidators): { id: string; kind: "pack"; source: SidePanelWorkspaceSource } | null {
+	const source = isObject(raw.source) ? raw.source : undefined;
+	if (!source || source.type !== "pack" || !sourceSessionMatches(source, sessionId)) return null;
+	const match = PACK_ID_RE.exec(id);
+	const legacyMatch = match ? null : LEGACY_PACK_ID_RE.exec(id);
+	if (!match && !legacyMatch) return null;
+	const legacy = !match;
+	const encodedPackId = match?.[1] ?? legacyMatch?.[1] ?? "";
+	const encodedPanelId = match?.[2] ?? legacyMatch?.[2] ?? "";
+	const encodedInstanceKey = match?.[3] ?? "default";
+	const packId = decodeComponent(encodedPackId);
+	const panelId = decodeComponent(encodedPanelId);
+	const instanceKey = decodeComponent(encodedInstanceKey);
+	if (!packId || !panelId || !instanceKey) return null;
+	if (source.packId !== packId || source.panelId !== panelId) return null;
+	const sourceInstance = typeof source.instanceKey === "string" && source.instanceKey ? source.instanceKey : (legacy ? "default" : "");
+	if (sourceInstance !== instanceKey) return null;
+	if (!isRouteSafePart(packId) || !isRouteSafePart(panelId) || !isRouteSafePart(instanceKey)) return null;
+	if (validators?.isKnownPackPanel && !validators.isKnownPackPanel(packId, panelId)) return null;
+	const params = cloneJsonObject(source.params);
+	if (source.params !== undefined && params === undefined) return null;
+	const canonicalId = `pack:${encodeComponent(packId)}:${encodeComponent(panelId)}:${encodeComponent(instanceKey)}`;
+	return {
+		id: canonicalId,
+		kind: "pack",
+		source: {
+			type: "pack",
+			sessionId,
+			packId,
+			panelId,
+			instanceKey,
+			...(source.singleton === true ? { singleton: true } : {}),
+			...(params ? { params } : {}),
+		},
+	};
+}
+
+export function canonicalizeTab(raw: unknown, sessionId: string, validators?: SidePanelWorkspaceValidators): SidePanelWorkspaceTab | null {
+	if (!isObject(raw)) return null;
+	const id = asString(raw.id).trim();
+	const kind = raw.kind;
+	if (!id || id.length > MAX_ID || !hasNoControlChars(id) || !isSidePanelKind(kind)) return null;
+	let canonical: { id: string; kind?: SidePanelKind; source: SidePanelWorkspaceSource } | null = null;
+	if (kind === "preview") canonical = canonicalizePreview(raw, id, sessionId);
+	else if (kind === "proposal") canonical = canonicalizeProposal(raw, id, sessionId);
+	else if (kind === "review") canonical = canonicalizeReview(raw, id, sessionId);
+	else if (kind === "inbox") canonical = canonicalizeInbox(raw, id, sessionId);
+	else if (kind === "pack") canonical = canonicalizePack(raw, id, sessionId, validators);
+	if (!canonical) return null;
+	const canonicalKind = canonical.kind ?? kind;
+	if (canonicalKind !== kind) return null;
+	const title = titleFor(kind, canonical.source, asString(raw.title));
+	const label = labelFor(title, asString(raw.label));
+	const state = normalizeState(raw.state);
+	if (raw.state !== undefined && state === undefined) return null;
+	return {
+		id: canonical.id,
+		kind,
+		title,
+		label,
+		source: canonical.source,
+		...(state ? { state } : {}),
+		updatedAt: positiveInteger(raw.updatedAt) ?? Date.now(),
+	};
+}
+
+export function emptyWorkspace(sessionId: string, now = Date.now()): SidePanelWorkspace {
+	return { version: 1, sessionId, revision: 0, tabs: [], activeTabId: "", sizeMode: "split", updatedAt: now };
+}
+
+export function canonicalizeWorkspace(raw: unknown, sessionId: string, validators?: SidePanelWorkspaceValidators): SidePanelWorkspace {
+	const now = Date.now();
+	if (!isObject(raw)) return emptyWorkspace(sessionId, now);
+	const seen = new Set<string>();
+	const tabs: SidePanelWorkspaceTab[] = [];
+	for (const item of Array.isArray(raw.tabs) ? raw.tabs : []) {
+		const tab = canonicalizeTab(item, sessionId, validators);
+		if (!tab || seen.has(tab.id)) continue;
+		seen.add(tab.id);
+		tabs.push(tab);
+	}
+	const activeCandidate = asString(raw.activeTabId);
+	const activeTabId = activeCandidate && tabs.some((tab) => tab.id === activeCandidate) ? activeCandidate : (tabs[0]?.id ?? "");
+	const sizeMode = isSidePanelSizeMode(raw.sizeMode) ? raw.sizeMode : "split";
+	const metadata = metadataFrom(raw.metadata);
+	return {
+		version: 1,
+		sessionId,
+		revision: Math.max(0, Math.trunc(typeof raw.revision === "number" && Number.isFinite(raw.revision) ? raw.revision : 0)),
+		tabs,
+		activeTabId,
+		sizeMode,
+		...(metadata ? { metadata } : {}),
+		updatedAt: positiveInteger(raw.updatedAt) ?? now,
+	};
+}
+
+export function nextActiveAfterClose(tabsBeforeClose: SidePanelWorkspaceTab[], closedId: string, previousActiveId: string): string {
+	if (previousActiveId && previousActiveId !== closedId && tabsBeforeClose.some((tab) => tab.id === previousActiveId)) return previousActiveId;
+	const index = tabsBeforeClose.findIndex((tab) => tab.id === closedId);
+	if (index < 0) return tabsBeforeClose[0]?.id ?? "";
+	const remaining = tabsBeforeClose.filter((tab) => tab.id !== closedId);
+	if (remaining.length === 0) return "";
+	return remaining[Math.min(index, remaining.length - 1)]?.id ?? remaining[0]?.id ?? "";
+}
+
+function commit(workspace: SidePanelWorkspace, patch: Partial<SidePanelWorkspace>, now = Date.now()): SidePanelWorkspace {
+	return {
+		...workspace,
+		...patch,
+		revision: workspace.revision + 1,
+		updatedAt: now,
+	};
+}
+
+function tabArraysEqual(a: string[], b: string[]): boolean {
+	return a.length === b.length && a.every((id, index) => id === b[index]);
+}
+
+export function applyWorkspaceMutation(workspace: SidePanelWorkspace, mutation: WorkspaceMutation, validators?: SidePanelWorkspaceValidators): SidePanelWorkspace {
+	const now = Date.now();
+	const latest = canonicalizeWorkspace(workspace, workspace.sessionId, validators);
+	if (mutation.type === "open") {
+		const tab = canonicalizeTab(mutation.tab, latest.sessionId, validators);
+		if (!tab) throw new SidePanelWorkspaceError("Invalid side-panel tab", 400, "INVALID_TAB");
+		tab.updatedAt = now;
+		const existingIndex = latest.tabs.findIndex((item) => item.id === tab.id);
+		let tabs = latest.tabs.slice();
+		if (existingIndex >= 0) {
+			tabs[existingIndex] = tab;
+		} else if (mutation.placeAfterActive && latest.activeTabId) {
+			const activeIndex = tabs.findIndex((item) => item.id === latest.activeTabId);
+			if (activeIndex >= 0) tabs.splice(activeIndex + 1, 0, tab);
+			else tabs.push(tab);
+		} else {
+			tabs.push(tab);
+		}
+		const activeTabId = mutation.focus === false ? (latest.activeTabId || tabs[0]?.id || "") : tab.id;
+		return commit(latest, { tabs, activeTabId }, now);
+	}
+	if (mutation.type === "update") {
+		const index = latest.tabs.findIndex((tab) => tab.id === mutation.tabId);
+		if (index < 0) throw new SidePanelWorkspaceError("Side-panel tab not found", 404, "TAB_NOT_FOUND");
+		if (!isObject(mutation.patch)) throw new SidePanelWorkspaceError("Invalid tab patch", 400, "INVALID_PATCH");
+		const merged = { ...latest.tabs[index], ...mutation.patch, id: latest.tabs[index].id, kind: latest.tabs[index].kind };
+		const tab = canonicalizeTab(merged, latest.sessionId, validators);
+		if (!tab) throw new SidePanelWorkspaceError("Invalid side-panel tab patch", 400, "INVALID_TAB");
+		tab.updatedAt = now;
+		const tabs = latest.tabs.slice();
+		tabs[index] = tab;
+		return commit(latest, { tabs }, now);
+	}
+	if (mutation.type === "close") {
+		if (!latest.tabs.some((tab) => tab.id === mutation.tabId)) return latest;
+		const activeTabId = nextActiveAfterClose(latest.tabs, mutation.tabId, latest.activeTabId);
+		return commit(latest, { tabs: latest.tabs.filter((tab) => tab.id !== mutation.tabId), activeTabId }, now);
+	}
+	if (mutation.type === "active") {
+		if (mutation.activeTabId && !latest.tabs.some((tab) => tab.id === mutation.activeTabId)) {
+			throw new SidePanelWorkspaceError("Active side-panel tab does not exist", 400, "ACTIVE_TAB_NOT_FOUND");
+		}
+		if (latest.activeTabId === mutation.activeTabId) return latest;
+		return commit(latest, { activeTabId: mutation.activeTabId }, now);
+	}
+	if (mutation.type === "reorder") {
+		const currentIds = latest.tabs.map((tab) => tab.id).sort();
+		const requestedIds = mutation.tabIds.slice().sort();
+		if (!tabArraysEqual(currentIds, requestedIds) || new Set(mutation.tabIds).size !== mutation.tabIds.length) {
+			throw new SidePanelWorkspaceError("Reorder must include each open tab exactly once", 400, "INVALID_REORDER");
+		}
+		if (tabArraysEqual(latest.tabs.map((tab) => tab.id), mutation.tabIds)) return latest;
+		const byId = new Map(latest.tabs.map((tab) => [tab.id, tab]));
+		return commit(latest, { tabs: mutation.tabIds.map((id) => byId.get(id)!) }, now);
+	}
+	if (mutation.type === "resize") {
+		if (!isSidePanelSizeMode(mutation.sizeMode)) throw new SidePanelWorkspaceError("Invalid side-panel size mode", 400, "INVALID_SIZE_MODE");
+		if (latest.sizeMode === mutation.sizeMode) return latest;
+		return commit(latest, { sizeMode: mutation.sizeMode }, now);
+	}
+	if (mutation.type === "migrate") {
+		if (latest.tabs.length > 0 || latest.metadata?.migratedFromLocalStorageAt) return latest;
+		const tabs: SidePanelWorkspaceTab[] = [];
+		const seen = new Set<string>();
+		for (const rawTab of Array.isArray(mutation.tabs) ? mutation.tabs : []) {
+			const tab = canonicalizeTab(rawTab, latest.sessionId, validators);
+			if (!tab || seen.has(tab.id)) continue;
+			seen.add(tab.id);
+			tabs.push({ ...tab, updatedAt: now });
+		}
+		const activeCandidate = typeof mutation.activeTabId === "string" ? mutation.activeTabId : "";
+		const activeTabId = activeCandidate && tabs.some((tab) => tab.id === activeCandidate) ? activeCandidate : (tabs[0]?.id ?? "");
+		const sizeMode = isSidePanelSizeMode(mutation.sizeMode) ? mutation.sizeMode : latest.sizeMode;
+		return commit(latest, { tabs, activeTabId, sizeMode, metadata: { ...(latest.metadata ?? {}), migratedFromLocalStorageAt: now } }, now);
+	}
+	return latest;
+}
+
+export class SidePanelWorkspaceLocks {
+	private readonly chains = new Map<string, Promise<unknown>>();
+
+	async with<T>(sessionId: string, fn: () => Promise<T> | T): Promise<T> {
+		const previous = this.chains.get(sessionId) ?? Promise.resolve();
+		let release!: () => void;
+		const current = new Promise<void>((resolve) => { release = resolve; });
+		const chained = previous.then(() => current, () => current);
+		this.chains.set(sessionId, chained);
+		try {
+			await previous.catch(() => undefined);
+			return await fn();
+		} finally {
+			release();
+			if (this.chains.get(sessionId) === chained) this.chains.delete(sessionId);
+		}
+	}
+}

--- a/src/server/ws/protocol.ts
+++ b/src/server/ws/protocol.ts
@@ -1,4 +1,5 @@
 import type { InboxEntry } from "../agent/inbox-store.js";
+import type { SidePanelWorkspace } from "../../shared/side-panel-workspace.js";
 
 /** Grant policy for tool access (self-contained — not imported from role-store for protocol independence). */
 export type GrantPolicy = 'allow' | 'ask' | 'never';
@@ -158,6 +159,7 @@ export type ServerMessage =
 	| { type: "pong" }
 	| { type: "cost_update"; sessionId: string; goalId?: string; taskId?: string; cost: SessionCostSnapshot }
 	| { type: "queue_update"; sessionId: string; queue: QueuedMessage[] }
+	| { type: "side_panel_workspace"; sessionId: string; workspace: SidePanelWorkspace }
 	| { type: "task_changed"; task: unknown }
 	| { type: "tasks_list"; tasks: unknown[] }
 	| { type: "bg_process_created"; process: { id: string; name: string; command: string; pid: number; status: "running" | "exited" | "unrecoverable"; exitCode: number | null; terminalReason: "normal" | "killed" | "unrecoverable" | null; startTime: number; endTime: number | null } }

--- a/src/shared/extension-host/host-api.ts
+++ b/src/shared/extension-host/host-api.ts
@@ -36,10 +36,11 @@ export const HOST_API_VERSION = 1 as const;
  *  breaking packs. */
 //
 // v2 (additive): added the optional `PanelTarget.sessionId` field — open/focus a
-// panel in a CHOSEN session's view. Purely additive (a new optional field), so
-// packs that don't read it are unaffected; packs that rely on it feature-detect via
-// `host.contractVersion >= 2` and fall back to the active view. See PanelTarget.
-export const HOST_CONTRACT_VERSION = 2 as const;
+// panel in a CHOSEN session's view.
+// v3 (additive): added optional `PanelTarget.instanceKey` for durable, parameterized
+// side-panel tab identity. Packs feature-detect via `host.contractVersion >= 3` and
+// fall back to host-derived singleton/allowlisted param identity. See PanelTarget.
+export const HOST_CONTRACT_VERSION = 3 as const;
 
 /**
  * The single, versioned, capability-scoped object through which ALL extension code
@@ -196,6 +197,10 @@ export interface HostStoreApi {
 export interface PanelTarget {
 	panelId: string;
 	params?: Record<string, unknown>;
+	/** CONTRACT v3: durable instance identity for parameterized panel tabs. Omitted
+	 *  ⇒ the host derives from the panel's allowlisted instance param, then from
+	 *  allowlisted params such as `artifactId`, then `default` for singleton panels. */
+	instanceKey?: string;
 	/** CONTRACT v2: open/focus the panel in THIS session's view (selecting it if
 	 *  needed), instead of the currently-active session. Omitted ⇒ active session
 	 *  (v1 behaviour). Packs feature-detect via host.contractVersion >= 2. */

--- a/src/shared/side-panel-workspace.ts
+++ b/src/shared/side-panel-workspace.ts
@@ -1,0 +1,87 @@
+export type SidePanelSizeMode = "collapsed" | "split" | "fullscreen";
+export type SidePanelKind = "preview" | "proposal" | "review" | "inbox" | "pack";
+export type SidePanelProposalType = "goal" | "project" | "role" | "tool" | "staff";
+
+export type SidePanelWorkspaceSource =
+	| {
+		type: "preview";
+		sessionId: string;
+		entry: string;
+		live?: boolean;
+		historical?: boolean;
+		version?: number;
+		artifactId?: string;
+		contentHash?: string;
+		path?: string;
+		url?: string;
+		toolUseId?: string;
+		blockIndex?: number;
+	}
+	| {
+		type: "proposal";
+		sessionId: string;
+		proposalType: SidePanelProposalType;
+		rev?: number;
+		historical?: boolean;
+	}
+	| {
+		type: "review";
+		sessionId: string;
+		documentId: string;
+		title: string;
+	}
+	| {
+		type: "inbox";
+		sessionId: string;
+		staffId?: string;
+	}
+	| {
+		type: "pack";
+		sessionId: string;
+		packId: string;
+		panelId: string;
+		instanceKey: string;
+		singleton?: boolean;
+		params?: Record<string, unknown>;
+	};
+
+export interface SidePanelWorkspaceTab {
+	id: string;
+	kind: SidePanelKind;
+	title: string;
+	label: string;
+	source: SidePanelWorkspaceSource;
+	state?: Record<string, unknown>;
+	updatedAt: number;
+}
+
+export interface SidePanelWorkspaceMetadata {
+	migratedFromLocalStorageAt?: number;
+}
+
+export interface SidePanelWorkspace {
+	version: 1;
+	sessionId: string;
+	revision: number;
+	tabs: SidePanelWorkspaceTab[];
+	activeTabId: string;
+	sizeMode: SidePanelSizeMode;
+	metadata?: SidePanelWorkspaceMetadata;
+	updatedAt: number;
+}
+
+export const SIDE_PANEL_SIZE_MODES: readonly SidePanelSizeMode[] = ["collapsed", "split", "fullscreen"] as const;
+export const SIDE_PANEL_KINDS: readonly SidePanelKind[] = ["preview", "proposal", "review", "inbox", "pack"] as const;
+export const SIDE_PANEL_PROPOSAL_TYPES: readonly SidePanelProposalType[] = ["goal", "project", "role", "tool", "staff"] as const;
+
+export function isSidePanelSizeMode(value: unknown): value is SidePanelSizeMode {
+	return typeof value === "string" && (SIDE_PANEL_SIZE_MODES as readonly string[]).includes(value);
+}
+
+export function isSidePanelKind(value: unknown): value is SidePanelKind {
+	return typeof value === "string" && (SIDE_PANEL_KINDS as readonly string[]).includes(value);
+}
+
+export function isSidePanelProposalType(value: unknown): value is SidePanelProposalType {
+	return typeof value === "string" && (SIDE_PANEL_PROPOSAL_TYPES as readonly string[]).includes(value);
+}

--- a/src/ui/components/review/ReviewPane.ts
+++ b/src/ui/components/review/ReviewPane.ts
@@ -124,6 +124,10 @@ export class ReviewPane extends LitElement {
     this._refreshCounts();
   }
 
+  private _displayTitle(key: string): string {
+    return this.documents.get(key)?.title || key;
+  }
+
   private _switchTab(title: string): void {
     this._overflowOpen = false;
     this._validationError = "";
@@ -198,8 +202,9 @@ export class ReviewPane extends LitElement {
   private _closeTab(title: string, e: Event): void {
     e.stopPropagation();
     const count = this._unsentCommentCountForDocument(title);
+    const displayTitle = this._displayTitle(title);
     if (count > 0) {
-      if (!confirm(`Close "${title}"? ${count} unsent comment${count !== 1 ? "s" : ""} will be lost.`)) return;
+      if (!confirm(`Close "${displayTitle}"? ${count} unsent comment${count !== 1 ? "s" : ""} will be lost.`)) return;
     }
     this._deleteFinalComment(title);
     this.dispatchEvent(
@@ -250,9 +255,9 @@ export class ReviewPane extends LitElement {
               <button
                 class="review-tab ${title === this.activeTab ? "review-tab--active" : ""}"
                 @click=${() => this._switchTab(title)}
-                title=${title}
+                title=${this._displayTitle(title)}
               >
-                <span class="review-tab-label">${title}</span>
+                <span class="review-tab-label">${this._displayTitle(title)}</span>
                 ${count > 0
                   ? html`<span class="review-tab-badge">${count}</span>`
                   : ""}
@@ -282,7 +287,7 @@ export class ReviewPane extends LitElement {
                                 class="review-tab-overflow-item ${title === this.activeTab ? "review-tab--active" : ""}"
                                 @click=${() => this._switchTab(title)}
                               >
-                                ${title}
+                                ${this._displayTitle(title)}
                                 ${count > 0
                                   ? html`<span class="review-tab-badge">${count}</span>`
                                   : ""}

--- a/tests/client-host-api.spec.ts
+++ b/tests/client-host-api.spec.ts
@@ -61,9 +61,9 @@ test.describe("getHostApi — durable v1 capabilities (extension-host §3)", () 
 		const caps = await page.evaluate(() => (window as any).__caps());
 
 		expect(caps.version).toBe(1);
-		// Contract v2: the additive `PanelTarget.sessionId` field bumped
-		// HOST_CONTRACT_VERSION 1→2 (HOST_API_VERSION stays 1 — purely additive).
-		expect(caps.contractVersion).toBe(2);
+		// Contract v3: additive PanelTarget addressing fields bumped
+		// HOST_CONTRACT_VERSION (HOST_API_VERSION stays 1 — purely additive).
+		expect(caps.contractVersion).toBe(3);
 
 		// Phase-1 — implemented.
 		expect(caps.invokeAction).toBe(true);

--- a/tests/e2e/base-ref-pin.spec.ts
+++ b/tests/e2e/base-ref-pin.spec.ts
@@ -108,6 +108,17 @@ test.describe("base_ref add-time pinning", () => {
 		expect(cfg.base_ref === undefined || cfg.base_ref === "").toBe(true);
 	});
 
+	test("GET /base-ref/detect degrades gracefully for a non-git project root", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-baseref-nongit-"));
+		fs.writeFileSync(path.join(root, "README.md"), "not a git repo\n");
+		const proj = await registerProjectShared({ name: `baseref-nongit-${Date.now()}`, rootPath: root });
+
+		const res = await fetch(`${base()}/api/projects/${proj.id}/base-ref/detect`, { headers: headers() });
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body).toEqual({ resolved: "", detected: null });
+	});
+
 	test("GET /base-ref/detect returns resolved + detected for a repo with a remote", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-baseref-detect-"));
 		const repo = makeRepoWithRemote(root, "master");

--- a/tests/e2e/gateway-harness.ts
+++ b/tests/e2e/gateway-harness.ts
@@ -27,6 +27,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { awaitableRm } from "./test-utils/cleanup.js";
+import { withDistServerImportLock } from "./test-utils/dist-import-lock.js";
 
 // Deliberately do not enable Node's on-disk V8 compile cache here. The E2E
 // workers cold-import dist/server once per process, so a per-worker cache gives
@@ -264,13 +265,22 @@ export const test = base.extend<{ failureContext: void; restoreDefaultProject: v
 			process.env.BOBBIT_SKIP_WORKTREE_POOL = "1";
 		}
 
-		const { setProjectRoot } = await import("../../dist/server/bobbit-dir.js");
-		const { scaffoldBobbitDir } = await import("../../dist/server/scaffold.js");
-		const { loadOrCreateToken } = await import("../../dist/server/auth/token.js");
-		const { createGateway } = await import("../../dist/server/server.js");
+		const {
+			setProjectRoot,
+			scaffoldBobbitDir,
+			loadOrCreateToken,
+			createGateway,
+			registerRpcBridgeFactory,
+		} = await withDistServerImportLock(async () => {
+			const { setProjectRoot } = await import("../../dist/server/bobbit-dir.js");
+			const { scaffoldBobbitDir } = await import("../../dist/server/scaffold.js");
+			const { loadOrCreateToken } = await import("../../dist/server/auth/token.js");
+			const { createGateway } = await import("../../dist/server/server.js");
+			const { registerRpcBridgeFactory } = await import("../../dist/server/agent/rpc-bridge.js");
+			return { setProjectRoot, scaffoldBobbitDir, loadOrCreateToken, createGateway, registerRpcBridgeFactory };
+		});
 		// Register the in-process mock bridge factory before any sessions are
 		// created. See in-process-harness.ts for rationale — same story here.
-		const { registerRpcBridgeFactory } = await import("../../dist/server/agent/rpc-bridge.js");
 		const { InProcessMockBridge, shouldUseInProcessMock } = await import("./in-process-mock-bridge.mjs");
 		registerRpcBridgeFactory((opts: any) => {
 			if (shouldUseInProcessMock(opts.cliPath)) return new InProcessMockBridge(opts);

--- a/tests/e2e/in-process-harness.ts
+++ b/tests/e2e/in-process-harness.ts
@@ -25,6 +25,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { awaitableRm } from "./test-utils/cleanup.js";
+import { withDistServerImportLock } from "./test-utils/dist-import-lock.js";
 
 // Deliberately do not enable Node's on-disk V8 compile cache here. The E2E
 // workers cold-import dist/server once per process, so a per-worker cache gives
@@ -202,15 +203,24 @@ export const test = base.extend<{ restoreDefaultProject: void }, { enableWorktre
 		// with scaffolding and produces spurious ENOENT.
 		mkdirSync(join(bobbitDir, "state", "session-prompts"), { recursive: true });
 
-		const { setProjectRoot } = await import("../../dist/server/bobbit-dir.js");
-		const { scaffoldBobbitDir } = await import("../../dist/server/scaffold.js");
-		const { loadOrCreateToken } = await import("../../dist/server/auth/token.js");
-		const { createGateway } = await import("../../dist/server/server.js");
+		const {
+			setProjectRoot,
+			scaffoldBobbitDir,
+			loadOrCreateToken,
+			createGateway,
+			registerRpcBridgeFactory,
+		} = await withDistServerImportLock(async () => {
+			const { setProjectRoot } = await import("../../dist/server/bobbit-dir.js");
+			const { scaffoldBobbitDir } = await import("../../dist/server/scaffold.js");
+			const { loadOrCreateToken } = await import("../../dist/server/auth/token.js");
+			const { createGateway } = await import("../../dist/server/server.js");
+			const { registerRpcBridgeFactory } = await import("../../dist/server/agent/rpc-bridge.js");
+			return { setProjectRoot, scaffoldBobbitDir, loadOrCreateToken, createGateway, registerRpcBridgeFactory };
+		});
 		// Register the in-process mock bridge factory before any sessions are
 		// created. The factory intercepts RpcBridge constructions whose cliPath
 		// points at our mock-agent.mjs and returns a drop-in class that skips
 		// the Node subprocess + JSONL serialization entirely.
-		const { registerRpcBridgeFactory } = await import("../../dist/server/agent/rpc-bridge.js");
 		const { InProcessMockBridge, shouldUseInProcessMock } = await import("./in-process-mock-bridge.mjs");
 		registerRpcBridgeFactory((opts: any) => {
 			if (shouldUseInProcessMock(opts.cliPath)) return new InProcessMockBridge(opts);

--- a/tests/e2e/side-panel-workspace-api.spec.ts
+++ b/tests/e2e/side-panel-workspace-api.spec.ts
@@ -1,0 +1,214 @@
+import { test, expect } from "./in-process-harness.js";
+import { apiFetch, connectWs, createSession, deleteSession } from "./e2e-setup.js";
+
+function proposalTab(sessionId: string, type = "goal") {
+	return {
+		id: `proposal:${type}`,
+		kind: "proposal",
+		title: "Goal Proposal",
+		label: "Goal",
+		source: { type: "proposal", sessionId, proposalType: type },
+		updatedAt: 1,
+	};
+}
+
+function previewTab(sessionId: string, entry = "index.html") {
+	return {
+		id: `preview:entry:${encodeURIComponent(entry)}`,
+		kind: "preview",
+		title: entry,
+		label: entry,
+		source: { type: "preview", sessionId, entry, live: true },
+		updatedAt: 1,
+	};
+}
+
+async function getWorkspace(sessionId: string) {
+	const resp = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace`);
+	expect(resp.status).toBe(200);
+	return resp.json();
+}
+
+test.describe("side-panel workspace API", () => {
+	const cleanup: string[] = [];
+
+	test.afterEach(async () => {
+		while (cleanup.length) await deleteSession(cleanup.pop()!);
+	});
+
+	test("GET returns empty workspace; open/update/close/resize persist with monotonic revisions and WS broadcast", async () => {
+		const sessionId = await createSession();
+		cleanup.push(sessionId);
+		const ws = await connectWs(sessionId);
+		try {
+			const empty = await getWorkspace(sessionId);
+			expect(empty).toMatchObject({ version: 1, sessionId, revision: 0, tabs: [], activeTabId: "", sizeMode: "split" });
+
+			const cursor = ws.messageCount();
+			const openResp = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/open`, {
+				method: "POST",
+				body: JSON.stringify({ tab: proposalTab(sessionId) }),
+			});
+			expect(openResp.status).toBe(200);
+			const opened = await openResp.json();
+			expect(opened.revision).toBe(1);
+			expect(opened.tabs.map((tab: any) => tab.id)).toEqual(["proposal:goal"]);
+			expect(opened.activeTabId).toBe("proposal:goal");
+			const msg: any = await ws.waitForFrom(cursor, (m: any) => m.type === "side_panel_workspace" && m.workspace?.revision === 1);
+			expect(msg.sessionId).toBe(sessionId);
+
+			const patchResp = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/tabs/${encodeURIComponent("proposal:goal")}`, {
+				method: "PATCH",
+				body: JSON.stringify({ title: "Updated Proposal", label: "Updated" }),
+			});
+			expect(patchResp.status).toBe(200);
+			const patched = await patchResp.json();
+			expect(patched.revision).toBe(2);
+			expect(patched.tabs[0].title).toBe("Updated Proposal");
+
+			const resizeResp = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/resize`, {
+				method: "POST",
+				body: JSON.stringify({ sizeMode: "fullscreen" }),
+			});
+			expect(resizeResp.status).toBe(200);
+			const resized = await resizeResp.json();
+			expect(resized.revision).toBe(3);
+			expect(resized.sizeMode).toBe("fullscreen");
+
+			const closeResp = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/tabs/${encodeURIComponent("proposal:goal")}`, { method: "DELETE" });
+			expect(closeResp.status).toBe(200);
+			const closed = await closeResp.json();
+			expect(closed.revision).toBe(4);
+			expect(closed.tabs).toEqual([]);
+			expect(closed.sizeMode).toBe("fullscreen");
+
+			const refetched = await getWorkspace(sessionId);
+			expect(refetched.tabs).toEqual([]);
+			expect(refetched.sizeMode).toBe("fullscreen");
+		} finally {
+			ws.close();
+		}
+	});
+
+	test("reorder requires a current revision and stale reorder returns 409 with latest workspace", async () => {
+		const sessionId = await createSession();
+		cleanup.push(sessionId);
+		const first = await (await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/open`, {
+			method: "POST",
+			body: JSON.stringify({ tab: proposalTab(sessionId) }),
+		})).json();
+		expect(first.revision).toBe(1);
+		await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/open`, {
+			method: "POST",
+			body: JSON.stringify({ tab: previewTab(sessionId) }),
+		});
+
+		const stale = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/reorder`, {
+			method: "POST",
+			body: JSON.stringify({ baseRevision: 1, tabIds: ["preview:entry:index.html", "proposal:goal"] }),
+		});
+		expect(stale.status).toBe(409);
+		const staleBody = await stale.json();
+		expect(staleBody.code).toBe("STALE_REVISION");
+		expect(staleBody.workspace.revision).toBe(2);
+
+		const ok = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/reorder`, {
+			method: "POST",
+			body: JSON.stringify({ baseRevision: 2, tabIds: ["preview:entry:index.html", "proposal:goal"] }),
+		});
+		expect(ok.status).toBe(200);
+		const ordered = await ok.json();
+		expect(ordered.revision).toBe(3);
+		expect(ordered.tabs.map((tab: any) => tab.id)).toEqual(["preview:entry:index.html", "proposal:goal"]);
+	});
+
+	test("concurrent opens rebase on latest and both survive", async () => {
+		const sessionId = await createSession();
+		cleanup.push(sessionId);
+		const [a, b] = await Promise.all([
+			apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/open`, {
+				method: "POST",
+				body: JSON.stringify({ tab: proposalTab(sessionId) }),
+			}),
+			apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/open`, {
+				method: "POST",
+				body: JSON.stringify({ tab: previewTab(sessionId) }),
+			}),
+		]);
+		expect(a.status).toBe(200);
+		expect(b.status).toBe(200);
+		const workspace = await getWorkspace(sessionId);
+		expect(workspace.revision).toBe(2);
+		expect(workspace.tabs.map((tab: any) => tab.id).sort()).toEqual(["preview:entry:index.html", "proposal:goal"]);
+	});
+
+	test("migration canonicalizes legacy tabs once and stamps metadata", async () => {
+		const sessionId = await createSession();
+		cleanup.push(sessionId);
+		const migrate = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/migrate`, {
+			method: "POST",
+			body: JSON.stringify({
+				sizeMode: "collapsed",
+				activeTabId: "proposal:goal",
+				tabs: [
+					proposalTab(sessionId),
+					{
+						id: "review:My%20Doc",
+						kind: "review",
+						title: "My Doc",
+						label: "Review",
+						source: { type: "review", sessionId, title: "My Doc" },
+						updatedAt: 1,
+					},
+				],
+			}),
+		});
+		expect(migrate.status).toBe(200);
+		const migrated = await migrate.json();
+		expect(migrated.revision).toBe(1);
+		expect(migrated.sizeMode).toBe("collapsed");
+		expect(migrated.metadata.migratedFromLocalStorageAt).toBeGreaterThan(0);
+		expect(migrated.tabs.map((tab: any) => tab.id)).toContain("proposal:goal");
+		expect(migrated.tabs.some((tab: any) => /^review:legacy-title-[0-9a-f]{16}$/.test(tab.id))).toBe(true);
+
+		const second = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/migrate`, {
+			method: "POST",
+			body: JSON.stringify({ tabs: [previewTab(sessionId)] }),
+		});
+		expect(second.status).toBe(200);
+		const ignored = await second.json();
+		expect(ignored.revision).toBe(1);
+		expect(ignored.tabs.some((tab: any) => tab.id === "preview:entry:index.html")).toBe(false);
+	});
+
+	test("PATCH is existing-only, active validates tab ids, and malformed pack tabs are rejected", async () => {
+		const sessionId = await createSession();
+		cleanup.push(sessionId);
+		const missingPatch = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/tabs/${encodeURIComponent("proposal:goal")}`, {
+			method: "PATCH",
+			body: JSON.stringify({ title: "No create" }),
+		});
+		expect(missingPatch.status).toBe(404);
+
+		const activeMissing = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/active`, {
+			method: "POST",
+			body: JSON.stringify({ activeTabId: "proposal:goal" }),
+		});
+		expect(activeMissing.status).toBe(400);
+
+		const badPack = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/open`, {
+			method: "POST",
+			body: JSON.stringify({
+				tab: {
+					id: "pack:bad/pack:panel:default",
+					kind: "pack",
+					title: "Bad",
+					label: "Bad",
+					source: { type: "pack", sessionId, packId: "bad/pack", panelId: "panel", instanceKey: "default" },
+					updatedAt: 1,
+				},
+			}),
+		});
+		expect(badPack.status).toBe(400);
+	});
+});

--- a/tests/e2e/side-panel-workspace-api.spec.ts
+++ b/tests/e2e/side-panel-workspace-api.spec.ts
@@ -167,6 +167,29 @@ test.describe("side-panel workspace API", () => {
 		expect(workspace.tabs.map((tab: any) => tab.id).sort()).toEqual(["preview:entry:index.html", "proposal:goal"]);
 	});
 
+	test("empty migration stamps metadata once", async () => {
+		const sessionId = await createSession();
+		cleanup.push(sessionId);
+		const migrate = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/migrate`, {
+			method: "POST",
+			body: JSON.stringify({ tabs: [], activeTabId: "", sizeMode: "split" }),
+		});
+		expect(migrate.status).toBe(200);
+		const migrated = await migrate.json();
+		expect(migrated.revision).toBe(1);
+		expect(migrated.tabs).toEqual([]);
+		expect(migrated.metadata.migratedFromLocalStorageAt).toBeGreaterThan(0);
+
+		const second = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/migrate`, {
+			method: "POST",
+			body: JSON.stringify({ tabs: [previewTab(sessionId)] }),
+		});
+		expect(second.status).toBe(200);
+		const ignored = await second.json();
+		expect(ignored.revision).toBe(1);
+		expect(ignored.tabs).toEqual([]);
+	});
+
 	test("migration canonicalizes legacy tabs once and stamps metadata", async () => {
 		const sessionId = await createSession();
 		cleanup.push(sessionId);

--- a/tests/e2e/side-panel-workspace-api.spec.ts
+++ b/tests/e2e/side-panel-workspace-api.spec.ts
@@ -59,12 +59,37 @@ test.describe("side-panel workspace API", () => {
 
 			const patchResp = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/tabs/${encodeURIComponent("proposal:goal")}`, {
 				method: "PATCH",
-				body: JSON.stringify({ title: "Updated Proposal", label: "Updated" }),
+				body: JSON.stringify({
+					patch: {
+						title: "Updated Proposal",
+						label: "Updated",
+						source: { type: "proposal", sessionId, proposalType: "goal", rev: 2 },
+						state: { selectedSection: "details" },
+					},
+					baseRevision: opened.revision,
+				}),
 			});
 			expect(patchResp.status).toBe(200);
 			const patched = await patchResp.json();
 			expect(patched.revision).toBe(2);
-			expect(patched.tabs[0].title).toBe("Updated Proposal");
+			expect(patched.tabs[0]).toMatchObject({
+				title: "Updated Proposal",
+				label: "Updated",
+				source: { type: "proposal", sessionId, proposalType: "goal", rev: 2 },
+				state: { selectedSection: "details" },
+			});
+			expect(patched.tabs[0].patch).toBeUndefined();
+			expect(patched.tabs[0].baseRevision).toBeUndefined();
+
+			const legacyPatchResp = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/tabs/${encodeURIComponent("proposal:goal")}`, {
+				method: "PATCH",
+				body: JSON.stringify({ title: "Legacy Direct Patch" }),
+			});
+			expect(legacyPatchResp.status).toBe(200);
+			const legacyPatched = await legacyPatchResp.json();
+			expect(legacyPatched.revision).toBe(3);
+			expect(legacyPatched.tabs[0].title).toBe("Legacy Direct Patch");
+			expect(legacyPatched.tabs[0].source.rev).toBe(2);
 
 			const resizeResp = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/resize`, {
 				method: "POST",
@@ -72,13 +97,13 @@ test.describe("side-panel workspace API", () => {
 			});
 			expect(resizeResp.status).toBe(200);
 			const resized = await resizeResp.json();
-			expect(resized.revision).toBe(3);
+			expect(resized.revision).toBe(4);
 			expect(resized.sizeMode).toBe("fullscreen");
 
 			const closeResp = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/tabs/${encodeURIComponent("proposal:goal")}`, { method: "DELETE" });
 			expect(closeResp.status).toBe(200);
 			const closed = await closeResp.json();
-			expect(closed.revision).toBe(4);
+			expect(closed.revision).toBe(5);
 			expect(closed.tabs).toEqual([]);
 			expect(closed.sizeMode).toBe("fullscreen");
 
@@ -186,7 +211,7 @@ test.describe("side-panel workspace API", () => {
 		cleanup.push(sessionId);
 		const missingPatch = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/tabs/${encodeURIComponent("proposal:goal")}`, {
 			method: "PATCH",
-			body: JSON.stringify({ title: "No create" }),
+			body: JSON.stringify({ patch: { title: "No create" }, baseRevision: 0 }),
 		});
 		expect(missingPatch.status).toBe(404);
 

--- a/tests/e2e/test-utils/dist-import-lock.ts
+++ b/tests/e2e/test-utils/dist-import-lock.ts
@@ -1,0 +1,65 @@
+import { existsSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = resolve(__dirname, "..", "..", "..");
+const LOCK_STALE_MS = 60_000;
+const LOCK_WAIT_MS = 25;
+const LOCK_TIMEOUT_MS = 30_000;
+
+function e2eTempRoot(): string {
+	if (existsSync("/.dockerenv")) return "/tmp";
+	return process.platform === "win32"
+		? (process.env.BOBBIT_E2E_TMP_ROOT || "C:\\bobbit-e2e")
+		: join(tmpdir(), "bobbit-e2e");
+}
+
+function lockDir(): string {
+	const rootKey = PROJECT_ROOT.replace(/[^a-zA-Z0-9._-]/g, "-").slice(-80);
+	return join(e2eTempRoot(), `.bobbit-dist-import-${rootKey}.lock`);
+}
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function acquireDistImportLock(): Promise<() => void> {
+	const dir = lockDir();
+	const start = Date.now();
+	for (;;) {
+		try {
+			mkdirSync(dir, { recursive: false });
+			writeFileSync(join(dir, "owner.txt"), `${process.pid}\n${new Date().toISOString()}\n`);
+			return () => {
+				try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+			};
+		} catch (err: any) {
+			if (err?.code !== "EEXIST") throw err;
+			try {
+				const ageMs = Date.now() - statSync(dir).mtimeMs;
+				if (ageMs > LOCK_STALE_MS) {
+					rmSync(dir, { recursive: true, force: true });
+					continue;
+				}
+			} catch {
+				rmSync(dir, { recursive: true, force: true });
+				continue;
+			}
+			if (Date.now() - start > LOCK_TIMEOUT_MS) {
+				throw new Error(`Timed out waiting for dist/server import lock at ${dir}`);
+			}
+			await delay(LOCK_WAIT_MS);
+		}
+	}
+}
+
+export async function withDistServerImportLock<T>(fn: () => Promise<T>): Promise<T> {
+	const release = await acquireDistImportLock();
+	try {
+		return await fn();
+	} finally {
+		release();
+	}
+}

--- a/tests/e2e/ui/preview-fullscreen-controls.spec.ts
+++ b/tests/e2e/ui/preview-fullscreen-controls.spec.ts
@@ -63,8 +63,8 @@ test.describe("Preview fullscreen header controls (Bug 1)", () => {
 		}, { baseUrl, sessionId });
 		expect(mountResp.status).toBe(200);
 
-		// Half-panel: Fullscreen button should be visible.
-		const fullscreenBtn = page.locator('button[title^="Fullscreen preview"]').first();
+		// Half-panel: generic side-panel fullscreen button should be visible.
+		const fullscreenBtn = page.getByTestId("side-panel-fullscreen").first();
 		await expect(fullscreenBtn).toBeVisible({ timeout: 10_000 });
 		await fullscreenBtn.click();
 
@@ -77,9 +77,10 @@ test.describe("Preview fullscreen header controls (Bug 1)", () => {
 			{ timeout: 5_000 },
 		).toBe(true);
 
-		// Exit-fullscreen button must be visible (sanity).
-		const exitBtn = page.locator('button[title^="Collapse preview"]').first();
-		await expect(exitBtn).toBeVisible({ timeout: 5_000 });
+		// Restore button must be visible in the generic shared side-panel chrome (sanity).
+		const restoreBtn = page.getByTestId("side-panel-restore").first();
+		await expect(restoreBtn).toBeVisible({ timeout: 5_000 });
+		await expect(restoreBtn).toHaveAttribute("title", /Restore side panel/);
 
 		// THE BUG: in fullscreen mode the Open-in-new-tab and Refresh controls
 		// are missing. After the fix they must be present.

--- a/tests/e2e/ui/side-panel-tabs.spec.ts
+++ b/tests/e2e/ui/side-panel-tabs.spec.ts
@@ -320,11 +320,15 @@ async function updateGoalProposal(page: Page): Promise<void> {
 async function openReview(page: Page): Promise<string> {
 	await sendMessage(page, "REVIEW_OPEN");
 	await waitForAgentResponse(page, { text: "Done. Used review_open tool.", timeout: 20_000 });
-	const review = (await visiblePanelTabs(page)).find((tab) => tab.kind === "review" && tab.id.startsWith("review:"));
-	expect(review, `review tab should be visible; tabs=${JSON.stringify(await visiblePanelTabs(page))}`).toBeTruthy();
-	await clickTabById(page, review!.id, "review tab should be selectable");
+	let reviewId = "";
+	await expect.poll(async () => {
+		const review = (await visiblePanelTabs(page)).find((tab) => tab.kind === "review" && tab.id.startsWith("review:"));
+		reviewId = review?.id ?? "";
+		return reviewId;
+	}, { timeout: 10_000, message: "review tab should be visible after review_open" }).toMatch(/^review:/);
+	await clickTabById(page, reviewId, "review tab should be selectable");
 	await expect(page.locator("review-document").getByText("Section One").first()).toBeVisible({ timeout: 10_000 });
-	return review!.id;
+	return reviewId;
 }
 
 // Wait until a tab's bounding box is stable across two animation frames before
@@ -866,6 +870,29 @@ test.describe("Side-panel tab contract", () => {
 		await expect(page.locator('input[placeholder="Goal title"]')).toHaveCount(0);
 		const refetched = await workspace(sessionId);
 		expect(refetched.tabs.map((tab: any) => tab.id)).toEqual([]);
+	});
+
+	test("9b. Closing review tab preserves content but keeps closed workspace state across reload", async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await openApp(page);
+		const sessionId = await createRegularSessionViaApi(page);
+
+		const reviewId = await openReview(page);
+		await closeTabById(page, reviewId, "closing review workspace tab should not delete review content");
+		await expectPanelTabs(page, [], "closed review tab should disappear immediately");
+		await expect.poll(async () => (await workspace(sessionId)).tabs.map((tab: any) => tab.id), {
+			timeout: 10_000,
+			message: "server workspace should persist the closed review tab absence",
+		}).toEqual([]);
+
+		await page.reload({ waitUntil: "domcontentloaded" });
+		await navigateToSession(page, sessionId);
+		await expectPanelTabs(page, [], "closed review tab must not be re-derived from restored review document caches");
+		await expect(page.locator("review-document")).toHaveCount(0);
+
+		const reopenedId = await openReview(page);
+		expect(reopenedId).toBe(reviewId);
+		await expect(page.locator("review-document").getByText("Section One").first()).toBeVisible({ timeout: 10_000 });
 	});
 
 	test("10. Size mode persists across reload for collapsed, split, and fullscreen preview states", async ({ page }) => {

--- a/tests/e2e/ui/side-panel-tabs.spec.ts
+++ b/tests/e2e/ui/side-panel-tabs.spec.ts
@@ -459,6 +459,13 @@ async function expectPanelHidden(page: Page): Promise<void> {
 	await expect(page.locator("textarea").first()).toBeVisible({ timeout: 10_000 });
 }
 
+async function openStaffInboxPanel(page: Page): Promise<void> {
+	await expect(page.locator('[data-testid="staff-inbox-open"]')).toBeVisible({ timeout: 15_000 });
+	await page.locator('[data-testid="staff-inbox-open"]').click();
+	await expectPanelTabs(page, ["inbox"], "explicit Staff Inbox action should open a side-panel tab");
+	await expect(page.locator("inbox-panel")).toBeVisible({ timeout: 10_000 });
+}
+
 async function expectContentForTab(page: Page, tab: PanelTab, previewText: string): Promise<string> {
 	await clickTabById(page, tab.id, `click ${tab.id}`);
 	if (tab.kind === "preview") {
@@ -520,6 +527,7 @@ async function openPrWalkthroughPanel(page: Page, sessionId: string): Promise<vo
 }
 
 async function expectPopoutOpens(page: Page, tabId: string, message: string): Promise<void> {
+	const kind = await page.locator(`${PANEL_TAB_SELECTOR}[data-panel-tab-id="${tabId}"]`).first().getAttribute("data-panel-tab-kind");
 	const popout = page.locator(SIDE_PANEL_POPOUT).first();
 	await expect(popout, `${message}: popout control`).toBeVisible({ timeout: 10_000 });
 	const href = await popout.getAttribute("href");
@@ -535,6 +543,12 @@ async function expectPopoutOpens(page: Page, tabId: string, message: string): Pr
 			const encoded = encodeURIComponent(tabId).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 			await expect.poll(() => popup.url(), { timeout: 15_000, message: `${message}: app popout route` })
 				.toMatch(new RegExp(`/panel/${encoded}`));
+			await expect(popup.locator('[data-testid="side-panel-route-content"]'), `${message}: standalone panel content shell`).toBeVisible({ timeout: 20_000 });
+			await expect(popup.locator(`${PANEL_TAB_SELECTOR}[data-panel-tab-id="${tabId}"]`).first(), `${message}: standalone active tab`).toBeVisible({ timeout: 20_000 });
+			if (kind === "inbox") await expect(popup.locator("inbox-panel"), `${message}: inbox popout content`).toBeVisible({ timeout: 20_000 });
+			else if (kind === "review") await expect(popup.locator("review-pane"), `${message}: review popout content`).toBeVisible({ timeout: 20_000 });
+			else if (kind === "proposal") await expect(popup.locator('input[placeholder="Goal title"]').first(), `${message}: proposal popout content`).toBeVisible({ timeout: 20_000 });
+			else if (kind === "pack") await expect(popup.locator('[data-testid="pack-panel-root"], [data-testid="prw-panel-root"]').first(), `${message}: pack popout content`).toBeVisible({ timeout: 20_000 });
 		}
 	} finally {
 		await popup.close().catch(() => {});
@@ -719,41 +733,30 @@ test.describe("Side-panel tab contract", () => {
 		await expectPanelHidden(page);
 	});
 
-	test("5. Staff Inbox is pinned first, non-closable, non-draggable, and survives closing other tabs", async ({ page }) => {
+	test("5. Staff Inbox opens explicitly, is closable, and stays closed across reload", async ({ page }) => {
 		await page.setViewportSize({ width: 1280, height: 800 });
 		const staff = await createStaff(`SidePanelInbox-${Date.now()}`);
 		staffCleanup.push(staff.id);
 		await openApp(page);
 		await navigateToSession(page, staff.currentSessionId);
 
-		await expect.poll(async () => (await visiblePanelTabs(page))[0] ?? null, { timeout: 20_000, message: "staff sessions should always expose Inbox" })
-			.toMatchObject({ id: "inbox", kind: "inbox" });
+		await expect.poll(() => visiblePanelTabs(page), { timeout: 10_000, message: "staff session should not auto-open Inbox" }).toEqual([]);
+		await openStaffInboxPanel(page);
 		let tabs = await visiblePanelTabs(page);
 		expect(tabs[0]).toMatchObject({ id: "inbox", kind: "inbox" });
-		expect(tabs[0].closable, "Inbox must not render a close control").toBe(false);
-		await expect(page.locator('[data-panel-tab-id="inbox"] .goal-tab-close')).toHaveCount(0);
+		expect(tabs[0].closable, "Inbox must render a close control").toBe(true);
 
 		await mountPreviewHtml(page, staff.currentSessionId, "staff.html", "Staff Preview");
-		await expectPanelTabs(page, ["inbox", previewId("staff.html")], "preview should open beside pinned Inbox");
-		const beforeDrag = await visiblePanelTabIds(page);
-		await dragTab(page, "inbox", previewId("staff.html"));
-		await expectPanelTabs(page, beforeDrag, "dragging pinned Inbox should not change order");
-
-		await closeTabById(page, previewId("staff.html"), "closing staff preview tab");
-		await expectPanelTabs(page, ["inbox"], "Inbox should remain after every other tab closes");
-		await expectActivePanelTabId(page, "inbox", "Inbox should be active after other tabs close");
-		await expect(page.locator("inbox-panel")).toBeVisible({ timeout: 10_000 });
+		await expectPanelTabs(page, ["inbox", previewId("staff.html")], "preview should open beside explicit Inbox tab");
+		await closeTabById(page, "inbox", "closing staff inbox tab");
+		await expectPanelTabs(page, [previewId("staff.html")], "closing Inbox should delete only the Inbox tab");
+		await page.reload({ waitUntil: "domcontentloaded" });
+		await navigateToSession(page, staff.currentSessionId);
+		await expectPanelTabs(page, [previewId("staff.html")], "closed Inbox should not auto-reopen after reload");
+		await expect(page.locator('[data-testid="staff-inbox-open"]')).toBeVisible({ timeout: 10_000 });
 	});
 
-	// The product pinned-tab guard (render.ts::ensurePanelSortable onMove/onEnd) is
-	// correct; this test was a *contention* flake, not a product bug. Under heavy
-	// Chromium load the synthesised drag could resolve mouse-up before SortableJS's
-	// fallback loop evaluated the onMove over the pinned Inbox, so an earlier
-	// non-pinned swap committed and the order assertion failed (~1/5). The fix is in
-	// `dragTab`: it now settles on stable tab boxes, nudges past fallbackTolerance to
-	// start the drag, glides in fine steps so every crossed tab gets an onMove, and
-	// dwells on the destination so the final drop is evaluated deterministically.
-	test("6. Desktop drag reorder persists and cannot move tabs before pinned Inbox", async ({ page }) => {
+	test("6. Desktop drag reorder persists for all side-panel tabs", async ({ page }) => {
 		await page.setViewportSize({ width: 1280, height: 800 });
 		await openApp(page);
 		const sessionId = await createRegularSessionViaApi(page);
@@ -780,13 +783,12 @@ test.describe("Side-panel tab contract", () => {
 		const staff = await createStaff(`SidePanelDrag-${Date.now()}`);
 		staffCleanup.push(staff.id);
 		await navigateToSession(page, staff.currentSessionId);
-		await mountPreviewHtml(page, staff.currentSessionId, "pinned-a.html", "Pinned A");
-		await mountPreviewHtml(page, staff.currentSessionId, "pinned-b.html", "Pinned B");
-		const pinnedA = previewId("pinned-a.html");
-		const pinnedB = previewId("pinned-b.html");
-		await expectPanelTabs(page, ["inbox", pinnedA, pinnedB], "staff drag test should start with pinned Inbox first");
-		await dragTab(page, pinnedB, "inbox", { toLeftEdge: true });
-		await expectPanelTabs(page, ["inbox", pinnedA, pinnedB], "non-pinned tabs cannot be dropped before pinned Inbox");
+		await openStaffInboxPanel(page);
+		await mountPreviewHtml(page, staff.currentSessionId, "inbox-a.html", "Inbox A");
+		const inboxA = previewId("inbox-a.html");
+		await expectPanelTabs(page, ["inbox", inboxA], "staff drag test should start with explicit Inbox and preview");
+		await dragTab(page, inboxA, "inbox", { toLeftEdge: true });
+		await expectPanelTabs(page, [inboxA, "inbox"], "preview tabs can be dropped before Inbox because Inbox is a normal tab");
 		await expectNoChatTab(page);
 	});
 
@@ -796,6 +798,7 @@ test.describe("Side-panel tab contract", () => {
 		staffCleanup.push(staff.id);
 		await openApp(page);
 		await navigateToSession(page, staff.currentSessionId);
+		await openStaffInboxPanel(page);
 
 		const previewText = "Identity Preview";
 		await mountPreviewHtml(page, staff.currentSessionId, "identity.html", previewText);
@@ -948,7 +951,7 @@ test.describe("Side-panel tab contract", () => {
 		staffCleanup.push(staff.id);
 		await openApp(page);
 		await navigateToSession(page, staff.currentSessionId);
-		await expectPanelTabs(page, ["inbox"], "staff session should open Inbox as a side-panel tab");
+		await openStaffInboxPanel(page);
 
 		await exerciseSharedWindowControls(page, staff.currentSessionId, "inbox", "staff inbox shared controls");
 		const proposalId = await openGoalProposal(page);

--- a/tests/e2e/ui/side-panel-tabs.spec.ts
+++ b/tests/e2e/ui/side-panel-tabs.spec.ts
@@ -1,5 +1,6 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { Page } from "@playwright/test";
 import { test, expect } from "../gateway-harness.js";
 import { apiFetch, createSession, defaultProject, nonGitCwd } from "../e2e-setup.js";
@@ -7,6 +8,16 @@ import { openApp, navigateToHash, sendMessage, waitForAgentResponse } from "./ui
 
 const PANEL_TAB_SELECTOR = ".goal-tab-pill";
 const PREVIEW_OPEN_BUTTON_SELECTOR = '[data-testid="preview-open-button"]';
+const SIDE_PANEL_FULLSCREEN = '[data-testid="side-panel-fullscreen"]';
+const SIDE_PANEL_COLLAPSE = '[data-testid="side-panel-collapse"]';
+const SIDE_PANEL_RESTORE = '[data-testid="side-panel-restore"]';
+const SIDE_PANEL_POPOUT = '[data-testid="side-panel-popout"]';
+const PRW_PACK = "pr-walkthrough";
+const PRW_PANEL_ID = "pr-walkthrough.panel";
+const PRW_TAB_ID = `pack:${PRW_PACK}:${PRW_PANEL_ID}:default`;
+const ARTIFACTS_PACK = "artifacts";
+const ARTIFACTS_PANEL_ID = "artifacts.viewer";
+const ARTIFACTS_SOURCE_DIR = fileURLToPath(new URL("../../../market-packs", import.meta.url));
 
 type PanelTab = {
 	index: number;
@@ -469,6 +480,115 @@ async function expectContentForTab(page: Page, tab: PanelTab, previewText: strin
 	throw new Error(`unsupported tab kind ${tab.kind}`);
 }
 
+async function workspace(sessionId: string): Promise<any> {
+	const resp = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace`);
+	const text = await resp.text();
+	expect(resp.status, `workspace GET failed: ${text}`).toBe(200);
+	return JSON.parse(text);
+}
+
+async function expectSizeMode(page: Page, sessionId: string, expected: "collapsed" | "split" | "fullscreen", message: string): Promise<void> {
+	await expect.poll(async () => ({
+		server: (await workspace(sessionId)).sizeMode,
+		client: await page.evaluate((sid) => {
+			const state = (window as any).bobbitState ?? (window as any).__bobbitState ?? {};
+			return state.sidePanelWorkspaceBySession?.[sid]?.sizeMode ?? state.panelWorkspace?.sizeMode ?? "";
+		}, sessionId),
+	}), { timeout: 10_000, message }).toEqual({ server: expected, client: expected });
+}
+
+async function openWorkspaceTab(sessionId: string, tab: any): Promise<void> {
+	const resp = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/open`, {
+		method: "POST",
+		body: JSON.stringify({ tab: { ...tab, updatedAt: Date.now() } }),
+	});
+	const text = await resp.text();
+	expect(resp.status, `open workspace tab failed: ${text}`).toBe(200);
+}
+
+async function openPrWalkthroughPanel(page: Page, sessionId: string): Promise<void> {
+	await page.evaluate(() => (window as any).__bobbitReconcilePackRenderers?.()).catch(() => {});
+	await openWorkspaceTab(sessionId, {
+		id: PRW_TAB_ID,
+		kind: "pack",
+		title: "PR Walkthrough",
+		label: "PR Walkthrough",
+		source: { type: "pack", sessionId, packId: PRW_PACK, panelId: PRW_PANEL_ID, instanceKey: "default", singleton: true, params: {} },
+	});
+	await expectPanelTabs(page, [PRW_TAB_ID], "PR walkthrough pack tab should open from the server workspace");
+	await expect(page.locator('[data-testid="prw-panel-root"]').first()).toBeVisible({ timeout: 20_000 });
+}
+
+async function expectPopoutOpens(page: Page, tabId: string, message: string): Promise<void> {
+	const popout = page.locator(SIDE_PANEL_POPOUT).first();
+	await expect(popout, `${message}: popout control`).toBeVisible({ timeout: 10_000 });
+	const href = await popout.getAttribute("href");
+	expect(href, `${message}: popout href`).toBeTruthy();
+	const popupPromise = page.context().waitForEvent("page");
+	await popout.click();
+	const popup = await popupPromise;
+	try {
+		await popup.waitForLoadState("domcontentloaded", { timeout: 20_000 }).catch(() => {});
+		if (tabId.startsWith("preview:")) {
+			expect(popup.url(), `${message}: preview popout route`).toContain("/preview/");
+		} else {
+			const encoded = encodeURIComponent(tabId).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+			await expect.poll(() => popup.url(), { timeout: 15_000, message: `${message}: app popout route` })
+				.toMatch(new RegExp(`/panel/${encoded}`));
+		}
+	} finally {
+		await popup.close().catch(() => {});
+	}
+}
+
+async function exerciseSharedWindowControls(page: Page, sessionId: string, tabId: string, message: string): Promise<void> {
+	await clickTabById(page, tabId, `${message}: tab should be selectable`);
+	await expect(page.locator(SIDE_PANEL_FULLSCREEN).first(), `${message}: fullscreen control`).toBeVisible({ timeout: 10_000 });
+	await expect(page.locator(SIDE_PANEL_COLLAPSE).first(), `${message}: collapse control`).toBeVisible({ timeout: 10_000 });
+	await expectPopoutOpens(page, tabId, message);
+
+	await page.locator(SIDE_PANEL_FULLSCREEN).first().click();
+	await expect(page.locator(SIDE_PANEL_RESTORE).first(), `${message}: restore after fullscreen`).toBeVisible({ timeout: 10_000 });
+	await expectSizeMode(page, sessionId, "fullscreen", `${message}: fullscreen persists to server`);
+
+	await page.locator(SIDE_PANEL_RESTORE).first().click();
+	await expect(page.locator(SIDE_PANEL_FULLSCREEN).first(), `${message}: fullscreen returns after restore`).toBeVisible({ timeout: 10_000 });
+	await expectSizeMode(page, sessionId, "split", `${message}: split persists to server`);
+
+	await page.locator(SIDE_PANEL_COLLAPSE).first().click();
+	await expect(page.locator(SIDE_PANEL_RESTORE).first(), `${message}: restore after collapse`).toBeVisible({ timeout: 10_000 });
+	await expectSizeMode(page, sessionId, "collapsed", `${message}: collapse persists to server`);
+
+	await page.locator(SIDE_PANEL_RESTORE).first().click();
+	await expect(page.locator(SIDE_PANEL_FULLSCREEN).first(), `${message}: restored split controls`).toBeVisible({ timeout: 10_000 });
+	await expectSizeMode(page, sessionId, "split", `${message}: final split persists to server`);
+}
+
+async function installArtifactsPack(): Promise<string> {
+	const addRes = await apiFetch("/api/marketplace/sources", {
+		method: "POST",
+		body: JSON.stringify({ url: ARTIFACTS_SOURCE_DIR }),
+	});
+	const addBody = await addRes.text();
+	expect(addRes.status, addBody).toBe(201);
+	const sourceId = (JSON.parse(addBody) as { source: { id: string } }).source.id;
+	const instRes = await apiFetch("/api/marketplace/install", {
+		method: "POST",
+		body: JSON.stringify({ sourceId, dirName: ARTIFACTS_PACK, scope: "server" }),
+	});
+	const instBody = await instRes.text();
+	expect(instRes.status, instBody).toBe(201);
+	return sourceId;
+}
+
+async function cleanupArtifactsPack(sourceId?: string): Promise<void> {
+	await apiFetch("/api/marketplace/installed", {
+		method: "DELETE",
+		body: JSON.stringify({ scope: "server", packName: ARTIFACTS_PACK }),
+	}).catch(() => {});
+	if (sourceId) await apiFetch(`/api/marketplace/sources/${encodeURIComponent(sourceId)}`, { method: "DELETE" }).catch(() => {});
+}
+
 test.describe("Side-panel tab contract", () => {
 	test.describe.configure({ timeout: 120_000 });
 	const staffCleanup: string[] = [];
@@ -725,7 +845,210 @@ test.describe("Side-panel tab contract", () => {
 		await expectActivePanelTabId(page, proposalId, "proposal update should focus its existing tab in place");
 	});
 
-	test("9. Mobile side-pane tabs include pinned Chat pill (not persisted), swipes reveal chat/panel, and touch does not reorder tabs", async ({ page }) => {
+	test("9. Server workspace is authoritative across close/open reloads", async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await openApp(page);
+		const sessionId = await createRegularSessionViaApi(page);
+
+		const proposalId = await openGoalProposal(page);
+		await page.reload({ waitUntil: "domcontentloaded" });
+		await navigateToSession(page, sessionId);
+		await expectPanelTabs(page, [proposalId], "leaving a proposal tab open should survive reload/reconnect");
+		await expect(page.locator('input[placeholder="Goal title"]').first()).toHaveValue("Parity Goal A", { timeout: 20_000 });
+
+		await closeTabById(page, proposalId, "closing proposal before reload");
+		await page.reload({ waitUntil: "domcontentloaded" });
+		await navigateToSession(page, sessionId);
+		await expectPanelTabs(page, [], "closed proposal tabs must not be re-derived from activeProposals on reload");
+		await expect(page.locator('input[placeholder="Goal title"]')).toHaveCount(0);
+		const refetched = await workspace(sessionId);
+		expect(refetched.tabs.map((tab: any) => tab.id)).toEqual([]);
+	});
+
+	test("10. Size mode persists across reload for collapsed, split, and fullscreen preview states", async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await openApp(page);
+		const sessionId = await createRegularSessionViaApi(page);
+		const previewTab = previewId("size.html");
+		await mountPreviewHtml(page, sessionId, "size.html", "Size Persistence Preview");
+		await exerciseSharedWindowControls(page, sessionId, previewTab, "preview shared controls");
+
+		await page.locator(SIDE_PANEL_COLLAPSE).first().click();
+		await expectSizeMode(page, sessionId, "collapsed", "collapsed state should be stored before reload");
+		await page.reload({ waitUntil: "domcontentloaded" });
+		await navigateToSession(page, sessionId);
+		await expectSizeMode(page, sessionId, "collapsed", "collapsed state should survive reload");
+		await expect(page.locator(SIDE_PANEL_RESTORE).first()).toBeVisible({ timeout: 10_000 });
+
+		await page.locator(SIDE_PANEL_RESTORE).first().click();
+		await expectSizeMode(page, sessionId, "split", "split state should be stored before reload");
+		await page.reload({ waitUntil: "domcontentloaded" });
+		await navigateToSession(page, sessionId);
+		await expectSizeMode(page, sessionId, "split", "split state should survive reload");
+		await expectPreviewContains(page, "Size Persistence Preview", "split preview after reload");
+
+		await page.locator(SIDE_PANEL_FULLSCREEN).first().click();
+		await expectSizeMode(page, sessionId, "fullscreen", "fullscreen state should be stored before reload");
+		await page.reload({ waitUntil: "domcontentloaded" });
+		await navigateToSession(page, sessionId);
+		await expectSizeMode(page, sessionId, "fullscreen", "fullscreen state should survive reload");
+		await expect(page.locator(SIDE_PANEL_RESTORE).first()).toBeVisible({ timeout: 10_000 });
+		await expectPreviewContains(page, "Size Persistence Preview", "fullscreen preview after reload");
+	});
+
+	test("11. Cross-device contexts sync open, close, active, reorder, and size mode", async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await openApp(page);
+		const sessionId = await createRegularSessionViaApi(page);
+		const browser = page.context().browser();
+		expect(browser, "browser instance should be available for a second device context").toBeTruthy();
+		const context2 = await browser!.newContext({ viewport: { width: 1280, height: 800 } });
+		const page2 = await context2.newPage();
+		try {
+			await openApp(page2);
+			await navigateToSession(page2, sessionId);
+
+			await mountPreviewHtml(page, sessionId, "sync.html", "Cross Device Preview");
+			const proposalId = await openGoalProposal(page);
+			const previewTab = previewId("sync.html");
+			await expectPanelTabs(page2, [previewTab, proposalId], "second device should receive opened tabs over WS");
+
+			await clickTabById(page, previewTab, "first device activates preview");
+			const activeResp = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/active`, {
+				method: "POST",
+				body: JSON.stringify({ activeTabId: previewTab }),
+			});
+			expect(activeResp.status, await activeResp.text()).toBe(200);
+			await expectActivePanelTabId(page2, previewTab, "second device should receive active-tab changes");
+
+			const beforeReorder = await workspace(sessionId);
+			const reorderResp = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/reorder`, {
+				method: "POST",
+				body: JSON.stringify({ baseRevision: beforeReorder.revision, tabIds: [proposalId, previewTab] }),
+			});
+			expect(reorderResp.status, await reorderResp.text()).toBe(200);
+			await expectPanelTabs(page, [proposalId, previewTab], "first device should render server reorder");
+			await expectPanelTabs(page2, [proposalId, previewTab], "second device should receive reorder over WS");
+
+			await page.locator(SIDE_PANEL_FULLSCREEN).first().click();
+			await expectSizeMode(page2, sessionId, "fullscreen", "second device should receive fullscreen size mode");
+			await page.locator(SIDE_PANEL_RESTORE).first().click();
+			await expectSizeMode(page2, sessionId, "split", "second device should receive split size mode");
+
+			await closeTabById(page, previewTab, "first device closes preview");
+			await expectPanelTabs(page2, [proposalId], "second device should receive tab close over WS");
+		} finally {
+			await context2.close().catch(() => {});
+		}
+	});
+
+	test("12. Proposal, review, and staff inbox tabs expose shared controls and popout", async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		const staff = await createStaff(`SidePanelControls-${Date.now()}`);
+		staffCleanup.push(staff.id);
+		await openApp(page);
+		await navigateToSession(page, staff.currentSessionId);
+		await expectPanelTabs(page, ["inbox"], "staff session should open Inbox as a side-panel tab");
+
+		await exerciseSharedWindowControls(page, staff.currentSessionId, "inbox", "staff inbox shared controls");
+		const proposalId = await openGoalProposal(page);
+		await exerciseSharedWindowControls(page, staff.currentSessionId, proposalId, "proposal shared controls");
+		const reviewId = await openReview(page);
+		await exerciseSharedWindowControls(page, staff.currentSessionId, reviewId, "review shared controls");
+	});
+
+	test("13. PR walkthrough pack panel uses shared controls and popout", async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await openApp(page);
+		const sessionId = await createRegularSessionViaApi(page);
+		await openPrWalkthroughPanel(page, sessionId);
+		await exerciseSharedWindowControls(page, sessionId, PRW_TAB_ID, "PR walkthrough pack shared controls");
+	});
+
+	test("14. Artifact-style pack viewer opens multiple independent panel instances", async ({ page }) => {
+		await page.setViewportSize({ width: 1400, height: 900 });
+		let sourceId: string | undefined;
+		try {
+			sourceId = await installArtifactsPack();
+			await openApp(page);
+			const sessionId = await createRegularSessionViaApi(page);
+			await page.evaluate(() => (window as any).__bobbitReconcilePackRenderers?.()).catch(() => {});
+
+			await sendMessage(page, "ARTIFACT_DEMO_TOOL please");
+			await expect(page.locator('[data-testid="artifact-pill"][data-artifact-id="art-demo-1"]').first()).toBeVisible({ timeout: 25_000 });
+			await sendMessage(page, "ARTIFACT_DEMO_MD please");
+			await expect(page.locator('[data-testid="artifact-pill"][data-artifact-id="art-demo-md"]').first()).toBeVisible({ timeout: 25_000 });
+
+			await page.locator('[data-testid="artifact-pill"][data-artifact-id="art-demo-1"]').first().click();
+			await expect(page.locator('[data-testid="artifact-viewer-content"][data-artifact-id="art-demo-1"]').first()).toBeVisible({ timeout: 15_000 });
+			await page.locator('[data-testid="artifact-pill"][data-artifact-id="art-demo-md"]').first().click();
+			await expect(page.locator('[data-testid="artifact-viewer-content"][data-artifact-id="art-demo-md"]').first()).toBeVisible({ timeout: 15_000 });
+
+			await expect.poll(async () => (await visiblePanelTabs(page)).filter((tab) => tab.kind === "pack" && tab.id.includes(`${ARTIFACTS_PACK}:${ARTIFACTS_PANEL_ID}`)).map((tab) => tab.id).sort(), {
+				timeout: 15_000,
+				message: "two artifact viewer instances should coexist as independent pack tabs",
+			}).toEqual([
+				`pack:${ARTIFACTS_PACK}:${ARTIFACTS_PANEL_ID}:art-demo-1`,
+				`pack:${ARTIFACTS_PACK}:${ARTIFACTS_PANEL_ID}:art-demo-md`,
+			].sort());
+
+			await page.reload({ waitUntil: "domcontentloaded" });
+			await navigateToSession(page, sessionId);
+			await expectPanelTabs(page, [
+				`pack:${ARTIFACTS_PACK}:${ARTIFACTS_PANEL_ID}:art-demo-1`,
+				`pack:${ARTIFACTS_PACK}:${ARTIFACTS_PANEL_ID}:art-demo-md`,
+			], "artifact pack tabs should persist independently across reload");
+			await clickTabById(page, `pack:${ARTIFACTS_PACK}:${ARTIFACTS_PANEL_ID}:art-demo-md`, "markdown artifact tab after reload");
+			await expect(page.locator('[data-testid="artifact-viewer-content"][data-artifact-id="art-demo-md"]').first()).toBeVisible({ timeout: 20_000 });
+			await exerciseSharedWindowControls(page, sessionId, `pack:${ARTIFACTS_PACK}:${ARTIFACTS_PANEL_ID}:art-demo-md`, "artifact pack shared controls");
+		} finally {
+			await cleanupArtifactsPack(sourceId);
+		}
+	});
+
+	test("15. Legacy localStorage workspace keys migrate once and stop being authoritative", async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		const sessionId = await createSession({ cwd: nonGitCwd() });
+		const legacyPreviewId = previewId("legacy.html");
+		await page.addInitScript(({ sid, tabId }) => {
+			const tab = {
+				id: tabId,
+				kind: "preview",
+				title: "legacy.html",
+				label: "legacy.html",
+				source: { type: "preview", entry: "legacy.html", live: true },
+			};
+			localStorage.setItem("bobbit-panel-tabs-by-session", JSON.stringify({ [sid]: [tab] }));
+			localStorage.setItem("bobbit-panel-active-by-session", JSON.stringify({ [sid]: tabId }));
+			localStorage.setItem(`bobbit-preview-collapsed-${sid}`, "true");
+		}, { sid: sessionId, tabId: legacyPreviewId });
+
+		await openApp(page);
+		await navigateToSession(page, sessionId);
+		await expectSizeMode(page, sessionId, "collapsed", "legacy collapsed key should migrate to server size mode");
+		await expect.poll(async () => {
+			const migrated = await workspace(sessionId);
+			return { ids: migrated.tabs.map((tab: any) => tab.id), active: migrated.activeTabId, stamped: migrated.metadata?.migratedFromLocalStorageAt > 0 };
+		}, { timeout: 15_000, message: "legacy localStorage tabs should migrate into the server workspace" })
+			.toEqual({ ids: [legacyPreviewId], active: legacyPreviewId, stamped: true });
+		await page.locator(SIDE_PANEL_RESTORE).first().click();
+		await expectPanelTabs(page, [legacyPreviewId], "restoring migrated collapsed workspace should reveal migrated tab");
+
+		await page.evaluate(({ sid }) => {
+			localStorage.setItem("bobbit-panel-tabs-by-session", JSON.stringify({ [sid]: [{ id: "proposal:goal", kind: "proposal", title: "Goal", label: "Goal", source: { type: "proposal", proposalType: "goal" } }] }));
+			localStorage.setItem("bobbit-panel-active-by-session", JSON.stringify({ [sid]: "proposal:goal" }));
+		}, { sid: sessionId });
+		await page.reload({ waitUntil: "domcontentloaded" });
+		await navigateToSession(page, sessionId);
+		await expect.poll(async () => {
+			const migrated = await workspace(sessionId);
+			return { ids: migrated.tabs.map((tab: any) => tab.id), active: migrated.activeTabId };
+		}, { timeout: 15_000, message: "post-migration localStorage edits must not replace server workspace" })
+			.toEqual({ ids: [legacyPreviewId], active: legacyPreviewId });
+		await expectActivePanelTabId(page, legacyPreviewId, "post-migration localStorage edits must not replace client active tab");
+	});
+
+	test("16. Mobile side-pane tabs include pinned Chat pill (not persisted), swipes reveal chat/panel, and touch does not reorder tabs", async ({ page }) => {
 		await page.setViewportSize({ width: 390, height: 800 });
 		await openApp(page);
 		const sessionId = await createRegularSessionViaApi(page);

--- a/tests/e2e/ui/staff-inbox.spec.ts
+++ b/tests/e2e/ui/staff-inbox.spec.ts
@@ -2,17 +2,17 @@
  * Staff inbox panel — browser E2E.
  *
  * Pins the UI surface for the inbox queue feature (design: docs/design/staff-inbox.md §3.5 / §8):
- *   - Inbox panel mounts as a tab in the unified preview panel when the active
- *     session belongs to a staff agent.
+ *   - Inbox panel mounts as a tab in the unified preview panel after the user
+ *     explicitly opens it for a staff agent session.
  *   - "+ Add to inbox" opens the composer dialog; submitting POSTs to
  *     /api/staff/:id/inbox with source.type="manual_ui" and the new entry
  *     arrives via WS into the Pending section.
- *   - Reload persists the panel (state is rehydrated from REST on session
- *     select; localStorage drives collapse).
+ *   - Reload persists the panel (state is rehydrated from the server workspace
+ *     on session select; server workspace drives collapse).
  *   - Cancel on a pending entry moves it to History (state=cancelled).
  *   - Delete on a terminal entry removes it.
- *   - Ctrl+] collapses the panel; the collapsed flag persists in
- *     localStorage under `bobbit-preview-collapsed-${sid}`.
+ *   - Ctrl+] collapses the panel; the collapsed size mode persists in the
+ *     server side-panel workspace.
  *
  * This test is authored against the REST/WS contract documented in
  * docs/design/staff-inbox.md §7. Stream B (server integration) is responsible
@@ -63,7 +63,21 @@ test.describe("Staff inbox panel", () => {
 			return sid;
 		}, { timeout: 15_000, intervals: [200, 400, 800] }).not.toBe("");
 		await page.evaluate((sessionId) => { window.location.hash = `#/session/${sessionId}`; }, sid);
+		await expect(page.locator("textarea").first()).toBeVisible({ timeout: 20_000 });
 		return sid;
+	}
+
+	async function openInboxPanel(page: import("@playwright/test").Page): Promise<void> {
+		await expect(page.locator('[data-testid="staff-inbox-open"]')).toBeVisible({ timeout: 20_000 });
+		await page.locator('[data-testid="staff-inbox-open"]').click();
+		await expect(page.locator("inbox-panel")).toBeVisible({ timeout: 10_000 });
+	}
+
+	async function workspaceSizeMode(sessionId: string): Promise<string> {
+		const r = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace`);
+		const text = await r.text();
+		expect(r.status, text).toBe(200);
+		return (JSON.parse(text) as { sizeMode?: string }).sizeMode || "";
 	}
 
 	type Box = { x: number; y: number; width: number; height: number };
@@ -85,6 +99,7 @@ test.describe("Staff inbox panel", () => {
 		await openApp(page);
 		await page.setViewportSize({ width: 375, height: 667 });
 		await navigateToStaffSession(page, staff.id);
+		await openInboxPanel(page);
 
 		const inboxTab = page.locator("[data-testid='inbox-tab-pill']").first();
 		await expect(inboxTab, "mobile inbox tab should appear for staff sessions").toBeVisible({ timeout: 20_000 });
@@ -138,8 +153,9 @@ test.describe("Staff inbox panel", () => {
 
 		await openApp(page);
 		const sid = await navigateToStaffSession(page, staff.id);
+		await openInboxPanel(page);
 
-		// 1. Inbox tab appears in the unified panel for staff sessions.
+		// 1. Inbox tab appears in the unified panel after explicit open.
 		const inboxTab = page.locator("[data-testid='inbox-tab-unified'], [data-testid='inbox-tab-pill']").first();
 		await expect(inboxTab, "inbox tab should appear for staff sessions").toBeVisible({ timeout: 20_000 });
 		await inboxTab.click();
@@ -180,6 +196,7 @@ test.describe("Staff inbox panel", () => {
 		const staff = await createStaff(`InboxBot-${Date.now()}`);
 		await openApp(page);
 		const sid = await navigateToStaffSession(page, staff.id);
+		await openInboxPanel(page);
 
 		// Seed an entry directly via REST so we don't depend on the dialog path here.
 		const title = `Cancel target ${Date.now()}`;
@@ -224,29 +241,22 @@ test.describe("Staff inbox panel", () => {
 		const staff = await createStaff(`InboxBot-${Date.now()}`);
 		await openApp(page);
 		const sid = await navigateToStaffSession(page, staff.id);
+		await openInboxPanel(page);
 
 		const tab = page.locator("[data-testid='inbox-tab-unified'], [data-testid='inbox-tab-pill']").first();
 		await expect(tab).toBeVisible({ timeout: 20_000 });
 		await tab.click();
 		await expect(page.locator("inbox-panel")).toBeVisible({ timeout: 5_000 });
 
-		// Press Ctrl+] to collapse — the keyboard handler treats staff sessions as
-		// panel-bearing once `state.inboxPanelOpen` is true. After collapse, the
-		// localStorage key matches the shared per-session pattern.
-		// Wait for the shortcut listener to attach (document.body.dataset.shortcutsReady).
+		// Press Ctrl+] to collapse. The keyboard handler persists the shared
+		// side-panel size mode to the server workspace.
 		await page.waitForFunction(() => document.body.dataset.shortcutsReady === "1");
 		await page.keyboard.press("Control+]");
+		await expect.poll(() => workspaceSizeMode(sid), { timeout: 10_000 }).toBe("collapsed");
 
-		const collapsedKey = `bobbit-preview-collapsed-${sid}`;
-		const collapsed = await page.evaluate((k) => localStorage.getItem(k), collapsedKey);
-		expect(collapsed, `localStorage[${collapsedKey}] should be "true" after Ctrl+]`).toBe("true");
-
-		// Reload — the panel respects the persisted collapse state on rehydrate.
+		// Reload — the panel respects the server-persisted collapse state on rehydrate.
 		await page.reload();
 		await page.evaluate((s) => { window.location.hash = `#/session/${s}`; }, sid);
-		// The unified panel is collapsed (inbox-panel not rendered into the slot).
-		// We assert via the localStorage value because the DOM hidden-state can vary by viewport.
-		const stillCollapsed = await page.evaluate((k) => localStorage.getItem(k), collapsedKey);
-		expect(stillCollapsed).toBe("true");
+		await expect.poll(() => workspaceSizeMode(sid), { timeout: 10_000 }).toBe("collapsed");
 	});
 });

--- a/tests/e2e/ui/tree-cost-rollup.spec.ts
+++ b/tests/e2e/ui/tree-cost-rollup.spec.ts
@@ -225,24 +225,36 @@ test.describe("Phase 5b — tree cost rollup", () => {
 		await quiesceAutoStartedChildTeam(gateway, childId, projectId);
 		await quiesceAutoStartedChildTeam(gateway, grandId, projectId);
 
-		// Seed distinct, easy-to-read costs on each goal directly through the
-		// cost tracker. Picked so each subtree total has a unique two-decimal
-		// rendering AND every level is strictly less than its ancestor:
-		//   grandchild only        =        0.05
-		//   child + grandchild     = 0.20 + 0.05 = 0.25
-		//   parent + child + grand = 0.50 + 0.20 + 0.05 = 0.75
-		const costTracker = (gateway.sessionManager as any).getCostTracker(projectId);
-		const seedRunId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-		costTracker.recordUsage(`tc-seed-parent-${seedRunId}`, { cost: 0.50, inputTokens: 1_000, outputTokens: 500 }, parent.id);
-		costTracker.recordUsage(`tc-seed-child-${seedRunId}`,  { cost: 0.20, inputTokens:   400, outputTokens: 200 }, childId);
-		costTracker.recordUsage(`tc-seed-grand-${seedRunId}`,  { cost: 0.05, inputTokens:   100, outputTokens:  50 }, grandId);
-
 		// ── REST sanity: endpoint must root the rollup at the requested goal ──
 		async function fetchTree(goalId: string): Promise<{ rootGoalId: string; totalCostUsd: number; breakdown: Array<{ goalId: string }> }> {
 			const r = await apiFetch(`/api/goals/${goalId}/tree-cost`);
 			expect(r.status, `GET /tree-cost ${goalId}`).toBe(200);
 			return r.json();
 		}
+
+		// Capture the requested-subtree baselines after auto-started teams are
+		// quiesced. Some harness paths can leave a tiny, valid team/session cost
+		// (for example $0.00075) on one goal; the invariant here is that the
+		// endpoint roots at the requested subtree and rolls up our seeded deltas.
+		const parentBaseline = await fetchTree(parent.id);
+		const childBaseline  = await fetchTree(childId);
+		const grandBaseline  = await fetchTree(grandId);
+
+		// Seed distinct, easy-to-read costs on each goal directly through the
+		// cost tracker. Picked so each subtree delta has a unique two-decimal
+		// rendering AND every level is strictly less than its ancestor:
+		//   grandchild only        =        0.05
+		//   child + grandchild     = 0.20 + 0.05 = 0.25
+		//   parent + child + grand = 0.50 + 0.20 + 0.05 = 0.75
+		const SEEDED_PARENT_DELTA = 0.75;
+		const SEEDED_CHILD_DELTA = 0.25;
+		const SEEDED_GRAND_DELTA = 0.05;
+		const costTracker = (gateway.sessionManager as any).getCostTracker(projectId);
+		const seedRunId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+		costTracker.recordUsage(`tc-seed-parent-${seedRunId}`, { cost: 0.50, inputTokens: 1_000, outputTokens: 500 }, parent.id);
+		costTracker.recordUsage(`tc-seed-child-${seedRunId}`,  { cost: 0.20, inputTokens:   400, outputTokens: 200 }, childId);
+		costTracker.recordUsage(`tc-seed-grand-${seedRunId}`,  { cost: 0.05, inputTokens:   100, outputTokens:  50 }, grandId);
+
 		const parentTree = await fetchTree(parent.id);
 		const childTree  = await fetchTree(childId);
 		const grandTree  = await fetchTree(grandId);
@@ -252,15 +264,21 @@ test.describe("Phase 5b — tree cost rollup", () => {
 		expect(childTree.rootGoalId, "child request must root rollup at the child, not the parent").toBe(childId);
 		expect(grandTree.rootGoalId, "grandchild request must root rollup at the grandchild, not an ancestor").toBe(grandId);
 
-		// Subtree totals (within float-rounding tolerance).
-		expect(parentTree.totalCostUsd).toBeCloseTo(0.75, 6);
-		expect(childTree.totalCostUsd).toBeCloseTo(0.25, 6);
-		expect(grandTree.totalCostUsd).toBeCloseTo(0.05, 6);
+		const expectedParentTotal = parentBaseline.totalCostUsd + SEEDED_PARENT_DELTA;
+		const expectedChildTotal = childBaseline.totalCostUsd + SEEDED_CHILD_DELTA;
+		const expectedGrandTotal = grandBaseline.totalCostUsd + SEEDED_GRAND_DELTA;
 
-		// Strict ordering: each descendant's subtree total must be < its ancestor's.
-		expect(childTree.totalCostUsd).toBeLessThan(parentTree.totalCostUsd);
-		expect(grandTree.totalCostUsd).toBeLessThan(childTree.totalCostUsd);
-		expect(grandTree.totalCostUsd).toBeLessThan(parentTree.totalCostUsd);
+		// Subtree seeded deltas (within float-rounding tolerance). This keeps the
+		// exact rollup invariant without coupling the fixture to unrelated harness
+		// cost noise recorded before we seed this test's rows.
+		expect(parentTree.totalCostUsd - parentBaseline.totalCostUsd).toBeCloseTo(SEEDED_PARENT_DELTA, 6);
+		expect(childTree.totalCostUsd - childBaseline.totalCostUsd).toBeCloseTo(SEEDED_CHILD_DELTA, 6);
+		expect(grandTree.totalCostUsd - grandBaseline.totalCostUsd).toBeCloseTo(SEEDED_GRAND_DELTA, 6);
+
+		// Strict ordering: each descendant's requested-subtree total must be < its ancestor's.
+		expect(expectedChildTotal).toBeLessThan(expectedParentTotal);
+		expect(expectedGrandTotal).toBeLessThan(expectedChildTotal);
+		expect(expectedGrandTotal).toBeLessThan(expectedParentTotal);
 
 		// Breakdown shape: grandchild sees only itself; child sees itself + grand;
 		// parent sees all three. Confirms `computeTreeCost` walked from the requested
@@ -292,9 +310,10 @@ test.describe("Phase 5b — tree cost rollup", () => {
 			return (await total.textContent() ?? "").trim();
 		}
 
-		const parentText = await assertTreeCostTotal(parent.id, "$0.75");
-		const childText  = await assertTreeCostTotal(childId,  "$0.25");
-		const grandText  = await assertTreeCostTotal(grandId,  "$0.05");
+		function formatUsd(n: number): string { return `$${n.toFixed(2)}`; }
+		const parentText = await assertTreeCostTotal(parent.id, formatUsd(expectedParentTotal));
+		const childText  = await assertTreeCostTotal(childId,  formatUsd(expectedChildTotal));
+		const grandText  = await assertTreeCostTotal(grandId,  formatUsd(expectedGrandTotal));
 
 		// Strict-less-than parsed against the rendered text — guards against a
 		// regression where every descendant displays the parent's value.

--- a/tests/fixtures/pack-panels-reconcile-entry.ts
+++ b/tests/fixtures/pack-panels-reconcile-entry.ts
@@ -75,6 +75,8 @@ const PANEL_MODULE = "export default function(){ return { render(){ return ''; }
 // A tool-renderer caller now ALSO carries its own packId (threaded from /api/tools);
 // pass the packId explicitly here to exercise the exact {packId, panelId} lookup.
 (window as any).__open = (panelId: string, packId?: string) => { openPackPanel({ panelId }, packId ?? "demo_pack"); };
+(window as any).__openWithParams = (panelId: string, params: Record<string, unknown>, packId?: string) => { openPackPanel({ panelId, params }, packId ?? "demo_pack"); };
+(window as any).__openWithInstanceKey = (panelId: string, instanceKey: string, params?: Record<string, unknown>, packId?: string) => { openPackPanel({ panelId, instanceKey, params }, packId ?? "demo_pack"); };
 (window as any).__openByPanelId = (panelId: string) => { openPackPanel({ panelId }); };
 // CONTRACT v2: open the panel in a CHOSEN session's view (PanelTarget.sessionId).
 (window as any).__openInSession = (panelId: string, sessionId: string, packId?: string) => {

--- a/tests/fixtures/review-tool-active-guard-entry.ts
+++ b/tests/fixtures/review-tool-active-guard-entry.ts
@@ -38,9 +38,10 @@ import { state } from "../../src/app/state.js";
 	docCount: state.reviewDocuments.size,
 	docTitles: [...state.reviewDocuments.keys()],
 });
-(window as any).__deliverReviewToolResult = (a: any, action: string, payload: any) => {
-	// Build a tool-result-shaped message that matches what the review tool
-	// extension produces — a content block whose text is a JSON envelope.
+(window as any).__deliverReviewToolResult = (a: any, action: string, payload: any, isLive = true) => {
+	// Build a live tool-result-shaped message that matches what the review tool
+	// extension produces — a content block whose text is a JSON envelope. Replays
+	// only reopen when the server workspace already has a matching review tab.
 	const json = JSON.stringify({ action, ...payload });
 	const msg = {
 		role: "toolResult",
@@ -49,7 +50,7 @@ import { state } from "../../src/app/state.js";
 			{ type: "text", text: json },
 		],
 	};
-	(a as any)._checkReviewToolResult(msg);
+	(a as any)._checkReviewToolResult(msg, isLive);
 };
 
 (window as any).__ready = true;

--- a/tests/lazy-renderer-placeholder.spec.ts
+++ b/tests/lazy-renderer-placeholder.spec.ts
@@ -15,9 +15,8 @@
  *      leaving the placeholder forever.
  */
 import { test, expect } from "@playwright/test";
-import { execSync } from "node:child_process";
-import fs from "node:fs";
 import path from "node:path";
+import { buildBundle } from "./fixtures/build-bundle.js";
 
 const FIXTURE = path.resolve("tests/fixtures/lazy-renderer-placeholder.html");
 const BUNDLE = path.resolve("tests/fixtures/lazy-renderer-placeholder-bundle.js");
@@ -26,26 +25,7 @@ const REGISTRY_SRC = path.resolve("src/ui/tools/renderer-registry.ts");
 const MESSAGES_SRC = path.resolve("src/ui/components/Messages.ts");
 
 test.beforeAll(() => {
-	const entryMtime = Math.max(
-		fs.statSync(ENTRY).mtimeMs,
-		fs.statSync(REGISTRY_SRC).mtimeMs,
-		fs.statSync(MESSAGES_SRC).mtimeMs,
-	);
-	const bundleExists = fs.existsSync(BUNDLE);
-	const bundleStale = bundleExists && fs.statSync(BUNDLE).mtimeMs < entryMtime;
-	if (!bundleExists || bundleStale) {
-		execSync(
-			[
-				`npx esbuild ${ENTRY}`,
-				"--bundle --format=iife --target=es2022",
-				`--outfile=${BUNDLE}`,
-				"--tsconfig=tsconfig.web.json",
-				"--alias:pdfjs-dist=./tests/fixtures/empty-shim",
-				"--define:import.meta.url='\"http://localhost/\"'",
-			].join(" "),
-			{ stdio: "pipe" },
-		);
-	}
+	buildBundle({ entry: ENTRY, outfile: BUNDLE, deps: [ENTRY, REGISTRY_SRC, MESSAGES_SRC] });
 });
 
 const PAGE = `file://${FIXTURE}`;

--- a/tests/message-editor-ime.spec.ts
+++ b/tests/message-editor-ime.spec.ts
@@ -7,9 +7,8 @@
  * Bundles the REAL component (not the vanilla replica in message-editor-send.html).
  */
 import { test, expect } from "@playwright/test";
-import { execSync } from "node:child_process";
-import fs from "node:fs";
 import path from "node:path";
+import { buildBundle } from "./fixtures/build-bundle.js";
 
 const FIXTURE = path.resolve("tests/fixtures/message-editor-ime.html");
 const BUNDLE = path.resolve("tests/fixtures/message-editor-ime-bundle.js");
@@ -17,21 +16,7 @@ const ENTRY = path.resolve("tests/fixtures/message-editor-ime-entry.ts");
 const SRC = path.resolve("src/ui/components/MessageEditor.ts");
 
 test.beforeAll(() => {
-	const entryMtime = Math.max(fs.statSync(ENTRY).mtimeMs, fs.statSync(SRC).mtimeMs);
-	const stale = fs.existsSync(BUNDLE) && fs.statSync(BUNDLE).mtimeMs < entryMtime;
-	if (!fs.existsSync(BUNDLE) || stale) {
-		execSync(
-			[
-				`npx esbuild ${ENTRY}`,
-				"--bundle --format=iife --target=es2022",
-				`--outfile=${BUNDLE}`,
-				"--tsconfig=tsconfig.web.json",
-				"--alias:pdfjs-dist=./tests/fixtures/empty-shim",
-				"--define:import.meta.url='\"http://localhost/\"'",
-			].join(" "),
-			{ stdio: "pipe" },
-		);
-	}
+	buildBundle({ entry: ENTRY, outfile: BUNDLE, deps: [ENTRY, SRC] });
 });
 
 const PAGE = `file://${FIXTURE}`;

--- a/tests/message-editor-size-guard.spec.ts
+++ b/tests/message-editor-size-guard.spec.ts
@@ -8,9 +8,8 @@
  * the test stays fast (no 200 MB fixtures). Reuses the message-editor-ime bundle.
  */
 import { test, expect } from "@playwright/test";
-import { execSync } from "node:child_process";
-import fs from "node:fs";
 import path from "node:path";
+import { buildBundle } from "./fixtures/build-bundle.js";
 
 const FIXTURE = path.resolve("tests/fixtures/message-editor-ime.html");
 const BUNDLE = path.resolve("tests/fixtures/message-editor-ime-bundle.js");
@@ -18,21 +17,7 @@ const ENTRY = path.resolve("tests/fixtures/message-editor-ime-entry.ts");
 const SRC = path.resolve("src/ui/components/MessageEditor.ts");
 
 test.beforeAll(() => {
-	const entryMtime = Math.max(fs.statSync(ENTRY).mtimeMs, fs.statSync(SRC).mtimeMs);
-	const stale = fs.existsSync(BUNDLE) && fs.statSync(BUNDLE).mtimeMs < entryMtime;
-	if (!fs.existsSync(BUNDLE) || stale) {
-		execSync(
-			[
-				`npx esbuild ${ENTRY}`,
-				"--bundle --format=iife --target=es2022",
-				`--outfile=${BUNDLE}`,
-				"--tsconfig=tsconfig.web.json",
-				"--alias:pdfjs-dist=./tests/fixtures/empty-shim",
-				"--define:import.meta.url='\"http://localhost/\"'",
-			].join(" "),
-			{ stdio: "pipe" },
-		);
-	}
+	buildBundle({ entry: ENTRY, outfile: BUNDLE, deps: [ENTRY, SRC] });
 });
 
 const PAGE = `file://${FIXTURE}`;

--- a/tests/pack-contributions.test.ts
+++ b/tests/pack-contributions.test.ts
@@ -97,7 +97,7 @@ describe("loadPackContributions (§5.1) + pack-root containment (§2)", () => {
 	it("parses panels + entrypoints (filtered by contents.entrypoints, listName carried) + routes", () => {
 		const root = packRoot("s1", "artifacts");
 		w(path.join(root, "pack.yaml"), "name: artifacts\n");
-		w(path.join(root, "panels", "artifacts-viewer.yaml"), "id: artifacts.viewer\ntitle: Artifact\nentry: ../lib/Viewer.js\n");
+		w(path.join(root, "panels", "artifacts-viewer.yaml"), "id: artifacts.viewer\ntitle: Artifact\ninstanceMode: parameterized\ninstanceParam: artifactId\nentry: ../lib/Viewer.js\n");
 		w(path.join(root, "entrypoints", "artifacts-deeplink.yaml"), "id: artifacts.deeplink\nkind: route\nrouteId: artifacts\ntarget:\n  panelId: artifacts.viewer\nparamKeys: [artifactId]\n");
 		// An entrypoint file NOT listed in contents.entrypoints must be ignored.
 		w(path.join(root, "entrypoints", "unlisted.yaml"), "id: unlisted\nkind: composer-slash\nlabel: X\ntarget:\n  panelId: artifacts.viewer\n");
@@ -108,7 +108,7 @@ describe("loadPackContributions (§5.1) + pack-root containment (§2)", () => {
 		const c = loadPackContributions(root, m);
 
 		assert.equal(c.packId, "artifacts");
-		assert.deepEqual(c.panels.map((p) => ({ id: p.id, title: p.title, entry: p.entry })), [{ id: "artifacts.viewer", title: "Artifact", entry: "../lib/Viewer.js" }]);
+		assert.deepEqual(c.panels.map((p) => ({ id: p.id, title: p.title, entry: p.entry, instanceMode: p.instanceMode, instanceParam: p.instanceParam })), [{ id: "artifacts.viewer", title: "Artifact", entry: "../lib/Viewer.js", instanceMode: "parameterized", instanceParam: "artifactId" }]);
 		assert.equal(c.panels[0].packRoot, root);
 		assert.equal(c.entrypoints.length, 1);
 		assert.equal(c.entrypoints[0].id, "artifacts.deeplink");

--- a/tests/pack-panels-reconcile.spec.ts
+++ b/tests/pack-panels-reconcile.spec.ts
@@ -269,12 +269,12 @@ test.describe("reconcilePackPanelsForProject (pack schema V1 §8.1)", () => {
 	// sidebar uses, NOT a bare `selectedSessionId` assignment that skips the hash
 	// route + hydration) and mounting the tab under it — without regressing the
 	// default (no `sessionId`) active-session behaviour.
-	test("PanelTarget.sessionId drives the real session switch and mounts the tab under the chosen session (contractVersion === 2)", async ({ page }) => {
+	test("PanelTarget.sessionId drives the real session switch and mounts the tab under the chosen session (contractVersion === 3)", async ({ page }) => {
 		await gotoAndWait(page);
 
-		// The additive field bumped the data/addressing contract 1→2.
+		// Additive addressing fields bumped the data/addressing contract to v3.
 		const cv = await page.evaluate(() => (window as any).__contractVersion());
-		expect(cv).toBe(2);
+		expect(cv).toBe(3);
 
 		// Register demo.panel for a project, install the switcher stub (the production
 		// hook is `connectToSession`), and start from an "owner" session view.
@@ -297,7 +297,7 @@ test.describe("reconcilePackPanelsForProject (pack schema V1 §8.1)", () => {
 			};
 		});
 
-		const expectedTabId = "pack:demo_pack:demo.panel";
+		const expectedTabId = "pack:demo_pack:demo.panel:default";
 		// (a) the REAL switch path was invoked for the child session — openPackPanel
 		//     delegated to the canonical switcher, not a bare selectedSessionId set.
 		expect(result.switchTarget).toBe("child-session");
@@ -326,6 +326,24 @@ test.describe("reconcilePackPanelsForProject (pack schema V1 §8.1)", () => {
 		// No session retargeting: selection is untouched and the tab mounts under the
 		// active session exactly as before.
 		expect(result.selected).toBe("active-session");
-		expect(result.activeTabs).toContain("pack:demo_pack:demo.panel");
+		expect(result.activeTabs).toContain("pack:demo_pack:demo.panel:default");
+	});
+
+	test("PanelTarget.instanceKey and allowlisted params create distinct pack panel tabs", async ({ page }) => {
+		await gotoAndWait(page);
+
+		const result = await page.evaluate(async () => {
+			await (window as any).__reconcile("D5");
+			(window as any).__setSelectedSessionId("active-session");
+			(window as any).__openWithParams("demo.panel", { artifactId: "artifact-a" });
+			(window as any).__openWithParams("demo.panel", { artifactId: "artifact-b" });
+			(window as any).__openWithInstanceKey("demo.panel", "explicit-key", { artifactId: "artifact-c" });
+			await (window as any).__flush();
+			return (window as any).__tabIdsForSession("active-session");
+		});
+
+		expect(result).toContain("pack:demo_pack:demo.panel:artifact-a");
+		expect(result).toContain("pack:demo_pack:demo.panel:artifact-b");
+		expect(result).toContain("pack:demo_pack:demo.panel:explicit-key");
 	});
 });

--- a/tests/pack-panels-reconcile.spec.ts
+++ b/tests/pack-panels-reconcile.spec.ts
@@ -20,37 +20,18 @@
  * fake panel module.
  */
 import { test, expect } from "@playwright/test";
-import { execSync } from "node:child_process";
-import fs from "node:fs";
 import path from "node:path";
+import { buildBundle } from "./fixtures/build-bundle.js";
 
 const FIXTURE = path.resolve("tests/fixtures/pack-panels-reconcile.html");
 const BUNDLE = path.resolve("tests/fixtures/pack-panels-reconcile-bundle.js");
 const ENTRY = path.resolve("tests/fixtures/pack-panels-reconcile-entry.ts");
 const PACK_SRC = path.resolve("src/app/pack-panels.ts");
 const WORKSPACE_SRC = path.resolve("src/app/panel-workspace.ts");
+const SIDE_PANEL_WORKSPACE_SRC = path.resolve("src/app/side-panel-workspace.ts");
 
 test.beforeAll(() => {
-	const entryMtime = Math.max(
-		fs.statSync(ENTRY).mtimeMs,
-		fs.statSync(PACK_SRC).mtimeMs,
-		fs.statSync(WORKSPACE_SRC).mtimeMs,
-	);
-	const bundleExists = fs.existsSync(BUNDLE);
-	const bundleStale = bundleExists && fs.statSync(BUNDLE).mtimeMs < entryMtime;
-	if (!bundleExists || bundleStale) {
-		execSync(
-			[
-				`npx esbuild ${ENTRY}`,
-				"--bundle --format=iife --target=es2022",
-				`--outfile=${BUNDLE}`,
-				"--tsconfig=tsconfig.web.json",
-				"--alias:pdfjs-dist=./tests/fixtures/empty-shim",
-				"--define:import.meta.url='\"http://localhost/\"'",
-			].join(" "),
-			{ stdio: "pipe" },
-		);
-	}
+	buildBundle({ entry: ENTRY, outfile: BUNDLE, deps: [ENTRY, PACK_SRC, WORKSPACE_SRC, SIDE_PANEL_WORKSPACE_SRC] });
 });
 
 const PAGE = `file://${FIXTURE}`;

--- a/tests/panel-workspace.test.ts
+++ b/tests/panel-workspace.test.ts
@@ -110,7 +110,7 @@ const hashB = "b".repeat(64);
 const hashC = "c".repeat(64);
 
 describe("panel workspace side-pane tab contract", () => {
-	it("buildPanelWorkspaceTabs emits side-pane tabs only and pins Inbox first", () => {
+	it("buildPanelWorkspaceTabs emits side-pane tabs only with closable Inbox", () => {
 		const tabs = buildPanelWorkspaceTabs({
 			sessionId: "s1",
 			isPreviewSession: true,
@@ -132,7 +132,7 @@ describe("panel workspace side-pane tab contract", () => {
 		]);
 		assert.equal(tabs.some((tab) => tab.id === CHAT_PANEL_TAB_ID || tab.kind === "chat"), false);
 		assert.equal(tabs[0].kind, "inbox");
-		assert.equal(isPinnedPanelTab(tabs[0]), true);
+		assert.equal(isPinnedPanelTab(tabs[0]), false);
 		assert.equal(firstContentPanelTab(tabs)?.id, INBOX_PANEL_TAB_ID);
 	});
 
@@ -220,7 +220,7 @@ describe("panel workspace side-pane tab contract", () => {
 		assert.equal(state.panelWorkspaceActiveBySession.s1, previewEntryTabId("legacy.html"));
 	});
 
-	it("normalizeSidePanelTabs drops legacy chat/invalid rows, normalizes live preview, merges metadata, dedupes, and pins Inbox", () => {
+	it("normalizeSidePanelTabs drops legacy chat/invalid rows, normalizes live preview, merges metadata, and dedupes", () => {
 		const state = {
 			selectedSessionId: "s1",
 			panelTabsBySession: {
@@ -244,12 +244,12 @@ describe("panel workspace side-pane tab contract", () => {
 		const normalized = normalizeSidePanelTabs(state, "s1", derived);
 
 		assert.deepEqual(normalized.map((tab) => tab.id), [
-			INBOX_PANEL_TAB_ID,
 			previewEntryTabId("a.html"),
 			"proposal:goal",
+			INBOX_PANEL_TAB_ID,
 			reviewPanelTabId("Review A"),
 		]);
-		assert.equal(previewContentHashFromTab(normalized[1]), hashB);
+		assert.equal(previewContentHashFromTab(normalized[0]), hashB);
 		assert.equal(normalized.some((tab) => tab.id === CHAT_PANEL_TAB_ID || tab.id.startsWith("preview:tool")), false);
 
 		const staleInbox = normalizeSidePanelTabs(
@@ -341,7 +341,7 @@ describe("panel workspace side-pane tab contract", () => {
 		assert.equal(nextActivePanelTabId([tabs[0]], tabs[0].id), "");
 	});
 
-	it("reorders only non-pinned side-pane tabs and never before pinned Inbox", () => {
+	it("reorders all side-pane tabs including Inbox", () => {
 		const tabs = [chatTab(), inboxTab(), previewTab(previewEntryTabId("a.html"), { entry: "a.html" }), proposalTab(), reviewTab("Notes")];
 
 		assert.deepEqual(
@@ -350,11 +350,11 @@ describe("panel workspace side-pane tab contract", () => {
 		);
 		assert.deepEqual(
 			reorderSidePanelTab(tabs, reviewPanelTabId("Notes"), INBOX_PANEL_TAB_ID).map((tab) => tab.id),
-			[INBOX_PANEL_TAB_ID, reviewPanelTabId("Notes"), previewEntryTabId("a.html"), "proposal:goal"],
+			[reviewPanelTabId("Notes"), INBOX_PANEL_TAB_ID, previewEntryTabId("a.html"), "proposal:goal"],
 		);
 		assert.deepEqual(
 			reorderSidePanelTab(tabs, INBOX_PANEL_TAB_ID, 3).map((tab) => tab.id),
-			[INBOX_PANEL_TAB_ID, previewEntryTabId("a.html"), "proposal:goal", reviewPanelTabId("Notes")],
+			[previewEntryTabId("a.html"), "proposal:goal", reviewPanelTabId("Notes"), INBOX_PANEL_TAB_ID],
 		);
 	});
 });

--- a/tests/panel-workspace.test.ts
+++ b/tests/panel-workspace.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
 	CHAT_PANEL_TAB_ID,
+	DEFAULT_PACK_PANEL_INSTANCE_KEY,
 	INBOX_PANEL_TAB_ID,
 	LIVE_PREVIEW_PANEL_TAB_ID,
 	activePanelTabIdForSession,
@@ -14,6 +15,8 @@ import {
 	isPinnedPanelTab,
 	nextActivePanelTabId,
 	normalizeSidePanelTabs,
+	packPanelRefFromTabId,
+	packPanelTabId,
 	previewContentHashFromTab,
 	previewEntryLabel,
 	previewEntryTabId,
@@ -24,6 +27,10 @@ import {
 	previewVersionedTabId,
 	registerPreviewVersion,
 	reorderSidePanelTab,
+	legacyReviewDocumentIdFromTitle,
+	rememberReviewDocumentIdentity,
+	reviewDocumentIdForTitle,
+	reviewDocumentIdFromPanelTab,
 	reviewPanelTabId,
 	setActivePanelTabIdForSession,
 	type PanelWorkspaceTab,
@@ -147,6 +154,36 @@ describe("panel workspace side-pane tab contract", () => {
 		assert.equal(findPanelTab(tabs, LIVE_PREVIEW_PANEL_TAB_ID)?.id, previewEntryTabId("inline.html"));
 		assert.equal(findPanelTab(tabs, previewVersionedTabId("missing.html", 1)), undefined);
 		assert.equal(findPanelTab(tabs, reviewPanelTabId("Encoded Title"))?.id, reviewPanelTabId("Encoded Title"));
+	});
+
+	it("uses durable pack instance keys while accepting legacy two-part pack ids", () => {
+		assert.equal(packPanelTabId("demo_pack", "demo.panel"), `pack:demo_pack:demo.panel:${DEFAULT_PACK_PANEL_INSTANCE_KEY}`);
+		assert.equal(packPanelTabId("demo_pack", "demo.panel", "artifact-1"), "pack:demo_pack:demo.panel:artifact-1");
+		assert.deepEqual(packPanelRefFromTabId("pack:demo_pack:demo.panel"), {
+			packId: "demo_pack",
+			panelId: "demo.panel",
+			instanceKey: DEFAULT_PACK_PANEL_INSTANCE_KEY,
+			legacyTwoPart: true,
+		});
+		assert.deepEqual(packPanelRefFromTabId("pack:demo_pack:demo.panel:artifact-1"), {
+			packId: "demo_pack",
+			panelId: "demo.panel",
+			instanceKey: "artifact-1",
+			legacyTwoPart: undefined,
+		});
+	});
+
+	it("maps review tabs by document id with deterministic legacy-title fallback", () => {
+		const legacyId = legacyReviewDocumentIdFromTitle("Findings");
+		assert.match(legacyId, /^legacy-title-[a-f0-9]{64}$/);
+		assert.equal(reviewDocumentIdForTitle("Findings"), legacyId);
+		assert.equal(reviewPanelTabId("Findings"), `review:${encodeURIComponent(legacyId)}`);
+
+		rememberReviewDocumentIdentity("Findings", "review-doc:s1:abc");
+		const tab = reviewTab("Findings");
+		assert.equal(tab.id, "review:review-doc%3As1%3Aabc");
+		assert.equal(reviewDocumentIdFromPanelTab(tab), "review-doc:s1:abc");
+		assert.equal(findPanelTab([tab], "review:Findings")?.id, tab.id);
 	});
 
 	it("active helpers never return or store chat", () => {

--- a/tests/preview-renderer.spec.ts
+++ b/tests/preview-renderer.spec.ts
@@ -6,9 +6,16 @@ const FIXTURE = path.resolve("tests/fixtures/preview-renderer.html");
 const BUNDLE = path.resolve("tests/fixtures/preview-renderer-bundle.js");
 const ENTRY = path.resolve("tests/fixtures/preview-renderer-entry.ts");
 const RENDERER_SRC = path.resolve("src/ui/tools/renderers/PreviewRenderer.ts");
+const PREVIEW_PANEL_SRC = path.resolve("src/app/preview-panel.ts");
+const PANEL_WORKSPACE_SRC = path.resolve("src/app/panel-workspace.ts");
+const SIDE_PANEL_WORKSPACE_SRC = path.resolve("src/app/side-panel-workspace.ts");
 
 test.beforeAll(() => {
-	buildBundle({ entry: ENTRY, outfile: BUNDLE, deps: [ENTRY, RENDERER_SRC] });
+	buildBundle({
+		entry: ENTRY,
+		outfile: BUNDLE,
+		deps: [ENTRY, RENDERER_SRC, PREVIEW_PANEL_SRC, PANEL_WORKSPACE_SRC, SIDE_PANEL_WORKSPACE_SRC],
+	});
 });
 
 const PAGE = `file://${FIXTURE}`;

--- a/tests/review-tool-active-guard.spec.ts
+++ b/tests/review-tool-active-guard.spec.ts
@@ -19,11 +19,17 @@ const FIXTURE = path.resolve("tests/fixtures/review-tool-active-guard.html");
 const BUNDLE = path.resolve("tests/fixtures/review-tool-active-guard-bundle.js");
 const ENTRY = path.resolve("tests/fixtures/review-tool-active-guard-entry.ts");
 const REMOTE_AGENT_SRC = path.resolve("src/app/remote-agent.ts");
+const REVIEW_SOURCES_SRC = path.resolve("src/app/review-sources.ts");
+const PREVIEW_PANEL_SRC = path.resolve("src/app/preview-panel.ts");
+const PANEL_WORKSPACE_SRC = path.resolve("src/app/panel-workspace.ts");
 
 test.beforeAll(() => {
 	const entryMtime = Math.max(
 		fs.statSync(ENTRY).mtimeMs,
 		fs.statSync(REMOTE_AGENT_SRC).mtimeMs,
+		fs.statSync(REVIEW_SOURCES_SRC).mtimeMs,
+		fs.statSync(PREVIEW_PANEL_SRC).mtimeMs,
+		fs.statSync(PANEL_WORKSPACE_SRC).mtimeMs,
 	);
 	const bundleExists = fs.existsSync(BUNDLE);
 	const bundleStale = bundleExists && fs.statSync(BUNDLE).mtimeMs < entryMtime;

--- a/tests/side-panel-workspace-store.test.ts
+++ b/tests/side-panel-workspace-store.test.ts
@@ -107,6 +107,66 @@ describe("side-panel workspace canonicalization", () => {
 		}, sessionId);
 		assert.equal(bad, null);
 	});
+
+	it("enforces pack panel instance metadata when server validators provide it", () => {
+		const validators = {
+			getPackPanelInfo(packId: string, panelId: string) {
+				if (packId === "artifacts" && panelId === "artifacts.viewer") return { instanceMode: "parameterized" as const, instanceParam: "artifactId" };
+				if (packId === "pr-walkthrough" && panelId === "pr-walkthrough.panel") return { instanceMode: "singleton" as const };
+				return undefined;
+			},
+		};
+		const goodArtifact = canonicalizeTab({
+			id: "pack:artifacts:artifacts.viewer:art-1",
+			kind: "pack",
+			title: "Artifact",
+			label: "Artifact",
+			source: { type: "pack", sessionId, packId: "artifacts", panelId: "artifacts.viewer", instanceKey: "art-1", params: { artifactId: "art-1" } },
+			updatedAt: 1,
+		}, sessionId, validators);
+		assert.ok(goodArtifact);
+		assert.equal(goodArtifact.id, "pack:artifacts:artifacts.viewer:art-1");
+
+		const missingParam = canonicalizeTab({
+			id: "pack:artifacts:artifacts.viewer:art-1",
+			kind: "pack",
+			title: "Artifact",
+			label: "Artifact",
+			source: { type: "pack", sessionId, packId: "artifacts", panelId: "artifacts.viewer", instanceKey: "art-1", params: {} },
+			updatedAt: 1,
+		}, sessionId, validators);
+		assert.equal(missingParam, null);
+
+		const mismatchedParam = canonicalizeTab({
+			id: "pack:artifacts:artifacts.viewer:art-1",
+			kind: "pack",
+			title: "Artifact",
+			label: "Artifact",
+			source: { type: "pack", sessionId, packId: "artifacts", panelId: "artifacts.viewer", instanceKey: "art-1", params: { artifactId: "other" } },
+			updatedAt: 1,
+		}, sessionId, validators);
+		assert.equal(mismatchedParam, null);
+
+		const singletonDefault = canonicalizeTab({
+			id: "pack:pr-walkthrough:pr-walkthrough.panel:default",
+			kind: "pack",
+			title: "PR Walkthrough",
+			label: "PR Walkthrough",
+			source: { type: "pack", sessionId, packId: "pr-walkthrough", panelId: "pr-walkthrough.panel", instanceKey: "default", singleton: true, params: {} },
+			updatedAt: 1,
+		}, sessionId, validators);
+		assert.ok(singletonDefault);
+
+		const singletonBypass = canonicalizeTab({
+			id: "pack:pr-walkthrough:pr-walkthrough.panel:forged",
+			kind: "pack",
+			title: "PR Walkthrough",
+			label: "PR Walkthrough",
+			source: { type: "pack", sessionId, packId: "pr-walkthrough", panelId: "pr-walkthrough.panel", instanceKey: "forged", singleton: true, params: {} },
+			updatedAt: 1,
+		}, sessionId, validators);
+		assert.equal(singletonBypass, null);
+	});
 });
 
 describe("side-panel workspace mutations", () => {

--- a/tests/side-panel-workspace-store.test.ts
+++ b/tests/side-panel-workspace-store.test.ts
@@ -1,0 +1,164 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+	applyWorkspaceMutation,
+	canonicalizeTab,
+	canonicalizeWorkspace,
+	emptyWorkspace,
+	nextActiveAfterClose,
+	SidePanelWorkspaceError,
+	SidePanelWorkspaceLocks,
+} from "../src/server/side-panel-workspace.ts";
+import type { SidePanelWorkspaceTab } from "../src/shared/side-panel-workspace.ts";
+
+const sessionId = "session-1";
+
+function proposalTab(type = "goal", title = "Goal Proposal"): SidePanelWorkspaceTab {
+	return {
+		id: `proposal:${type}`,
+		kind: "proposal",
+		title,
+		label: "Goal",
+		source: { type: "proposal", sessionId, proposalType: type as any },
+		updatedAt: 1,
+	};
+}
+
+function previewTab(entry = "index.html", version?: number): SidePanelWorkspaceTab {
+	return {
+		id: `preview:entry:${encodeURIComponent(entry)}${version ? `:v:${version}` : ""}`,
+		kind: "preview",
+		title: entry,
+		label: entry,
+		source: { type: "preview", sessionId, entry, ...(version ? { historical: true, version } : { live: true }) },
+		updatedAt: 1,
+	};
+}
+
+function reviewTab(documentId = "doc-1", title = "Review"): SidePanelWorkspaceTab {
+	return {
+		id: `review:${encodeURIComponent(documentId)}`,
+		kind: "review",
+		title,
+		label: title,
+		source: { type: "review", sessionId, documentId, title },
+		updatedAt: 1,
+	};
+}
+
+describe("side-panel workspace canonicalization", () => {
+	it("normalizes invalid active/size fields and drops invalid tabs", () => {
+		const workspace = canonicalizeWorkspace({
+			sessionId: "wrong",
+			revision: -10,
+			activeTabId: "missing",
+			sizeMode: "giant",
+			tabs: [proposalTab(), { ...proposalTab("bad"), id: "proposal:bad", source: { type: "proposal", sessionId, proposalType: "bad" } }],
+		}, sessionId);
+		assert.equal(workspace.version, 1);
+		assert.equal(workspace.sessionId, sessionId);
+		assert.equal(workspace.revision, 0);
+		assert.equal(workspace.sizeMode, "split");
+		assert.equal(workspace.tabs.length, 1);
+		assert.equal(workspace.activeTabId, "proposal:goal");
+	});
+
+	it("rejects mismatched source sessions and malformed historical previews", () => {
+		assert.equal(canonicalizeTab({ ...proposalTab(), source: { type: "proposal", sessionId: "other", proposalType: "goal" } }, sessionId), null);
+		assert.equal(canonicalizeTab({ ...previewTab("index.html"), id: "preview:entry:index.html:v:0", source: { type: "preview", sessionId, entry: "index.html", historical: true, version: 0 } }, sessionId), null);
+	});
+
+	it("migrates legacy review-title tabs to deterministic document ids", () => {
+		const tab = canonicalizeTab({
+			id: "review:My%20Review",
+			kind: "review",
+			title: "My Review",
+			label: "Review",
+			source: { type: "review", sessionId, title: "My Review" },
+			updatedAt: 1,
+		}, sessionId);
+		assert.ok(tab);
+		assert.match(tab.id, /^review:legacy-title-[0-9a-f]{16}$/);
+		assert.equal(tab.source.type, "review");
+		assert.match(tab.source.documentId, /^legacy-title-[0-9a-f]{16}$/);
+	});
+
+	it("canonicalizes legacy pack ids to default instance and rejects unsafe params", () => {
+		const tab = canonicalizeTab({
+			id: "pack:artifacts:artifacts.viewer",
+			kind: "pack",
+			title: "Artifacts",
+			label: "Artifacts",
+			source: { type: "pack", sessionId, packId: "artifacts", panelId: "artifacts.viewer", params: { artifactId: "a1" } },
+			updatedAt: 1,
+		}, sessionId);
+		assert.ok(tab);
+		assert.equal(tab.id, "pack:artifacts:artifacts.viewer:default");
+		assert.equal(tab.source.type, "pack");
+		assert.equal(tab.source.instanceKey, "default");
+
+		const bad = canonicalizeTab({
+			id: "pack:artifacts:artifacts.viewer:default",
+			kind: "pack",
+			title: "Artifacts",
+			label: "Artifacts",
+			source: { type: "pack", sessionId, packId: "artifacts", panelId: "artifacts.viewer", instanceKey: "default", params: { huge: "x".repeat(20_000) } },
+			updatedAt: 1,
+		}, sessionId);
+		assert.equal(bad, null);
+	});
+});
+
+describe("side-panel workspace mutations", () => {
+	it("increments revision for committed mutations and preserves size mode", () => {
+		let workspace = emptyWorkspace(sessionId, 1);
+		workspace = applyWorkspaceMutation(workspace, { type: "open", tab: proposalTab() });
+		assert.equal(workspace.revision, 1);
+		assert.equal(workspace.activeTabId, "proposal:goal");
+		workspace = applyWorkspaceMutation(workspace, { type: "resize", sizeMode: "fullscreen" });
+		assert.equal(workspace.revision, 2);
+		assert.equal(workspace.sizeMode, "fullscreen");
+	});
+
+	it("chooses adjacent active tab on close", () => {
+		const tabs = [proposalTab(), previewTab(), reviewTab()];
+		assert.equal(nextActiveAfterClose(tabs, "preview:entry:index.html", "preview:entry:index.html"), "review:doc-1");
+		assert.equal(nextActiveAfterClose(tabs, "review:doc-1", "review:doc-1"), "preview:entry:index.html");
+		assert.equal(nextActiveAfterClose(tabs, "preview:entry:index.html", "proposal:goal"), "proposal:goal");
+	});
+
+	it("updates existing tabs only and rejects invalid active/reorder", () => {
+		let workspace = applyWorkspaceMutation(emptyWorkspace(sessionId), { type: "open", tab: proposalTab() });
+		assert.throws(() => applyWorkspaceMutation(workspace, { type: "update", tabId: "missing", patch: { title: "x" } }), SidePanelWorkspaceError);
+		assert.throws(() => applyWorkspaceMutation(workspace, { type: "active", activeTabId: "missing" }), SidePanelWorkspaceError);
+		assert.throws(() => applyWorkspaceMutation(workspace, { type: "reorder", tabIds: [] }), SidePanelWorkspaceError);
+		workspace = applyWorkspaceMutation(workspace, { type: "update", tabId: "proposal:goal", patch: { title: "Updated" } });
+		assert.equal(workspace.tabs[0].title, "Updated");
+	});
+
+	it("migrates once with stamp and ignores later migrations", () => {
+		let workspace = applyWorkspaceMutation(emptyWorkspace(sessionId), { type: "migrate", tabs: [proposalTab()], activeTabId: "proposal:goal", sizeMode: "collapsed" });
+		assert.equal(workspace.revision, 1);
+		assert.equal(workspace.tabs.length, 1);
+		assert.equal(workspace.sizeMode, "collapsed");
+		assert.ok(workspace.metadata?.migratedFromLocalStorageAt);
+		const again = applyWorkspaceMutation(workspace, { type: "migrate", tabs: [previewTab()] });
+		assert.equal(again.revision, workspace.revision);
+		assert.deepEqual(again.tabs.map(tab => tab.id), ["proposal:goal"]);
+	});
+
+	it("serializes concurrent mutations under the per-session lock", async () => {
+		const locks = new SidePanelWorkspaceLocks();
+		const order: string[] = [];
+		await Promise.all([
+			locks.with(sessionId, async () => {
+				await new Promise(resolve => setTimeout(resolve, 25));
+				order.push("first");
+			}),
+			locks.with(sessionId, async () => {
+				order.push("second");
+			}),
+		]);
+		assert.deepEqual(order, ["first", "second"]);
+	});
+});

--- a/tests/ui-fixtures/dynamic-panel-workspace-fixture-entry.ts
+++ b/tests/ui-fixtures/dynamic-panel-workspace-fixture-entry.ts
@@ -1,6 +1,7 @@
 import { html } from "lit";
 import { doRenderApp, setSelectedWorkflowId } from "../../src/app/render.js";
 import { renderApp, setProjects, setRenderApp, state, type GatewaySession, type Project } from "../../src/app/state.js";
+import { selectReviewWorkspaceTab } from "../../src/app/preview-panel.js";
 import {
 	CHAT_PANEL_TAB_ID,
 	LIVE_PREVIEW_PANEL_TAB_ID,
@@ -422,7 +423,7 @@ function openReviewDoc(doc: ReviewDoc): void {
 	ws.reviews = next;
 	ws.reviewActiveTab = doc.title;
 	applyWorkspace(currentSessionId());
-	setActivePanelTabIdForSession(state, currentSessionId(), `review:${encodeURIComponent(doc.title)}`);
+	selectReviewWorkspaceTab(doc.title, { sessionId: currentSessionId(), select: true });
 	renderNow();
 }
 

--- a/tests/ui-fixtures/dynamic-panel-workspace-fixture-entry.ts
+++ b/tests/ui-fixtures/dynamic-panel-workspace-fixture-entry.ts
@@ -3,7 +3,7 @@ import { doRenderApp, setSelectedWorkflowId, shouldDerivePanelTabsInRender } fro
 import { renderApp, setProjects, setRenderApp, state, type GatewaySession, type Project } from "../../src/app/state.js";
 import { applySidePanelWorkspaceFromServer } from "../../src/app/side-panel-workspace.js";
 import type { SidePanelWorkspace } from "../../src/shared/side-panel-workspace.js";
-import { selectReviewWorkspaceTab } from "../../src/app/preview-panel.js";
+import { selectHtmlPreviewTab, selectReviewWorkspaceTab } from "../../src/app/preview-panel.js";
 import {
 	CHAT_PANEL_TAB_ID,
 	LIVE_PREVIEW_PANEL_TAB_ID,
@@ -11,13 +11,14 @@ import {
 	previewTabDisplayTitle,
 	previewVersionedTabId,
 	registerPreviewVersion,
+	rememberReviewDocumentIdentity,
 	setActivePanelTabIdForSession,
 	setPanelTabsForSession,
 	type PanelWorkspaceTab,
 } from "../../src/app/panel-workspace.js";
 import { clearAllAnnotations } from "../../src/ui/components/review/AnnotationStore.js";
 
-type ReviewDoc = { title: string; markdown: string };
+type ReviewDoc = { title: string; markdown: string; documentId?: string };
 type HistoricalPreviewInput = { toolId: string; entry: string; bodyText: string; contentHash: string; title?: string; label?: string };
 type LivePreviewInput = { entry: string; bodyText?: string; contentHash: string };
 type WorkspaceState = {
@@ -255,8 +256,8 @@ function applyWorkspace(sessionId: string): void {
 	state.previewPanelMtime = ws.livePreview ? 1000 : 0;
 	(state as any).previewPanelContentHash = ws.livePreview?.contentHash || "";
 	state.previewPanelFullscreen = false;
-	state.reviewDocuments = new Map((ws.reviews || []).map((doc) => [doc.title, doc]));
-	state.reviewActiveTab = ws.reviewActiveTab || ws.reviews?.[0]?.title || "";
+	state.reviewDocuments = new Map((ws.reviews || []).map((doc) => [doc.documentId || doc.title, doc]));
+	state.reviewActiveTab = ws.reviewActiveTab || ws.reviews?.[0]?.documentId || ws.reviews?.[0]?.title || "";
 	state.reviewPanelOpen = (ws.reviews || []).length > 0;
 	state.inboxEntries = [];
 	state.inboxPanelOpen = false;
@@ -420,28 +421,32 @@ function setHistoricalPreviews(sessionId: string, previews: HistoricalPreviewInp
 function openReviewDoc(doc: ReviewDoc): void {
 	const ws = currentWorkspace();
 	const existing = ws.reviews || [];
-	const next = existing.filter((candidate) => candidate.title !== doc.title);
+	const key = doc.documentId || doc.title;
+	const next = existing.filter((candidate) => (candidate.documentId || candidate.title) !== key);
 	next.push(doc);
 	ws.reviews = next;
-	ws.reviewActiveTab = doc.title;
+	ws.reviewActiveTab = key;
+	if (doc.documentId) rememberReviewDocumentIdentity(doc.title, doc.documentId);
 	applyWorkspace(currentSessionId());
-	selectReviewWorkspaceTab(doc.title, { sessionId: currentSessionId(), select: true });
+	selectReviewWorkspaceTab(doc.title, { sessionId: currentSessionId(), select: true, documentId: doc.documentId });
 	renderNow();
 }
 
 function setReviewDocs(docs: ReviewDoc[]): void {
 	const ws = currentWorkspace();
 	ws.reviews = docs.map((doc) => ({ ...doc }));
-	ws.reviewActiveTab = docs[0]?.title || "";
+	for (const doc of docs) if (doc.documentId) rememberReviewDocumentIdentity(doc.title, doc.documentId);
+	ws.reviewActiveTab = docs[0]?.documentId || docs[0]?.title || "";
 	applyWorkspace(currentSessionId());
-	if (docs[0]) setActivePanelTabIdForSession(state, currentSessionId(), `review:${encodeURIComponent(docs[0].title)}`);
+	if (docs[0]) setActivePanelTabIdForSession(state, currentSessionId(), `review:${encodeURIComponent(docs[0].documentId || docs[0].title)}`);
 	renderNow();
 }
 
 function setReviewDocsForSession(sessionId: string, docs: ReviewDoc[]): void {
 	workspaces[sessionId] ||= {};
 	workspaces[sessionId].reviews = docs.map((doc) => ({ ...doc }));
-	workspaces[sessionId].reviewActiveTab = docs[0]?.title || "";
+	for (const doc of docs) if (doc.documentId) rememberReviewDocumentIdentity(doc.title, doc.documentId);
+	workspaces[sessionId].reviewActiveTab = docs[0]?.documentId || docs[0]?.title || "";
 	if (currentSessionId() === sessionId) applyWorkspace(sessionId);
 	renderNow();
 }
@@ -458,6 +463,33 @@ function getFixtureState(): Record<string, unknown> {
 		reviewTitles: [...state.reviewDocuments.keys()],
 		fetchLog: fetchLog.slice(),
 		promptLog: promptLog.slice(),
+	};
+}
+
+function exercisePreviewMountUpdateDoesNotCreateClosedTab(): Record<string, unknown> {
+	const sid = currentSessionId();
+	applySidePanelWorkspaceFromServer({
+		version: 1,
+		sessionId: sid,
+		revision: 3,
+		tabs: [],
+		activeTabId: "",
+		sizeMode: "split",
+		metadata: { migratedFromLocalStorageAt: 1 },
+		updatedAt: 1,
+	}, { source: "hydrate", skipRender: true });
+	state.previewPanelEntry = "closed-preview.html";
+	(state as any).previewPanelContentHash = fallbackHash("closed-preview");
+	selectHtmlPreviewTab({
+		sessionId: sid,
+		entry: "closed-preview.html",
+		contentHash: fallbackHash("closed-preview"),
+		source: { live: true, origin: "preview-bootstrap" },
+		select: false,
+	});
+	return {
+		tabIds: state.sidePanelWorkspaceBySession[workspaceKey(sid)]?.tabs.map((tab) => tab.id) ?? [],
+		legacyTabIds: state.panelTabsBySession[workspaceKey(sid)]?.map((tab) => tab.id) ?? [],
 	};
 }
 
@@ -498,9 +530,12 @@ function exerciseSameRevisionWorkspaceRollback(): Record<string, unknown> {
 	applySidePanelWorkspaceFromServer(base, { source: "hydrate", skipRender: true });
 	state.sidePanelWorkspaceBySession[workspaceKey(sid)] = optimistic;
 	const ignored = applySidePanelWorkspaceFromServer(base, { source: "rest", skipRender: true });
+	state.sidePanelWorkspaceBySession[workspaceKey(sid)] = optimistic;
+	const hydrateIgnored = applySidePanelWorkspaceFromServer(base, { source: "hydrate", skipRender: true });
 	const forced = applySidePanelWorkspaceFromServer(base, { source: "rest", force: true, skipRender: true });
 	return {
 		ignoredIds: ignored.tabs.map((tab) => tab.id),
+		hydrateIgnoredIds: hydrateIgnored.tabs.map((tab) => tab.id),
 		forcedIds: forced.tabs.map((tab) => tab.id),
 		storedIds: state.sidePanelWorkspaceBySession[workspaceKey(sid)]?.tabs.map((tab) => tab.id) ?? [],
 		storedRevision: state.lastWorkspaceRevisionBySession[workspaceKey(sid)],
@@ -560,6 +595,7 @@ setRenderApp(doRenderApp);
 (window as any).__setDynamicReviewDocsForSession = setReviewDocsForSession;
 (window as any).__openDynamicReviewDoc = openReviewDoc;
 (window as any).__getDynamicPanelWorkspaceState = getFixtureState;
+(window as any).__exercisePreviewMountUpdateDoesNotCreateClosedTab = exercisePreviewMountUpdateDoesNotCreateClosedTab;
 (window as any).__exerciseSameRevisionWorkspaceRollback = exerciseSameRevisionWorkspaceRollback;
 (window as any).__shouldDerivePanelTabsInRender = shouldDerivePanelTabsInRender;
 (window as any).__dynamicPanelWorkspaceReady = true;

--- a/tests/ui-fixtures/dynamic-panel-workspace-fixture-entry.ts
+++ b/tests/ui-fixtures/dynamic-panel-workspace-fixture-entry.ts
@@ -1,6 +1,8 @@
 import { html } from "lit";
-import { doRenderApp, setSelectedWorkflowId } from "../../src/app/render.js";
+import { doRenderApp, setSelectedWorkflowId, shouldDerivePanelTabsInRender } from "../../src/app/render.js";
 import { renderApp, setProjects, setRenderApp, state, type GatewaySession, type Project } from "../../src/app/state.js";
+import { applySidePanelWorkspaceFromServer } from "../../src/app/side-panel-workspace.js";
+import type { SidePanelWorkspace } from "../../src/shared/side-panel-workspace.js";
 import { selectReviewWorkspaceTab } from "../../src/app/preview-panel.js";
 import {
 	CHAT_PANEL_TAB_ID,
@@ -459,6 +461,52 @@ function getFixtureState(): Record<string, unknown> {
 	};
 }
 
+function exerciseSameRevisionWorkspaceRollback(): Record<string, unknown> {
+	const sid = currentSessionId();
+	const base: SidePanelWorkspace = {
+		version: 1,
+		sessionId: sid,
+		revision: 7,
+		tabs: [{
+			id: "proposal:goal",
+			kind: "proposal",
+			title: "Goal Proposal",
+			label: "Goal",
+			source: { type: "proposal", sessionId: sid, proposalType: "goal" },
+			updatedAt: 1,
+		}],
+		activeTabId: "proposal:goal",
+		sizeMode: "split",
+		updatedAt: 1,
+	};
+	const optimistic: SidePanelWorkspace = {
+		...base,
+		tabs: [
+			...base.tabs,
+			{
+				id: "review:optimistic",
+				kind: "review",
+				title: "Review: optimistic",
+				label: "Review",
+				source: { type: "review", sessionId: sid, documentId: "optimistic", title: "optimistic" },
+				updatedAt: 2,
+			},
+		],
+		activeTabId: "review:optimistic",
+		updatedAt: 2,
+	};
+	applySidePanelWorkspaceFromServer(base, { source: "hydrate", skipRender: true });
+	state.sidePanelWorkspaceBySession[workspaceKey(sid)] = optimistic;
+	const ignored = applySidePanelWorkspaceFromServer(base, { source: "rest", skipRender: true });
+	const forced = applySidePanelWorkspaceFromServer(base, { source: "rest", force: true, skipRender: true });
+	return {
+		ignoredIds: ignored.tabs.map((tab) => tab.id),
+		forcedIds: forced.tabs.map((tab) => tab.id),
+		storedIds: state.sidePanelWorkspaceBySession[workspaceKey(sid)]?.tabs.map((tab) => tab.id) ?? [],
+		storedRevision: state.lastWorkspaceRevisionBySession[workspaceKey(sid)],
+	};
+}
+
 window.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
 	const url = requestPath(input);
 	const method = (init?.method || "GET").toUpperCase();
@@ -512,4 +560,6 @@ setRenderApp(doRenderApp);
 (window as any).__setDynamicReviewDocsForSession = setReviewDocsForSession;
 (window as any).__openDynamicReviewDoc = openReviewDoc;
 (window as any).__getDynamicPanelWorkspaceState = getFixtureState;
+(window as any).__exerciseSameRevisionWorkspaceRollback = exerciseSameRevisionWorkspaceRollback;
+(window as any).__shouldDerivePanelTabsInRender = shouldDerivePanelTabsInRender;
 (window as any).__dynamicPanelWorkspaceReady = true;

--- a/tests/ui-fixtures/dynamic-panel-workspace-fixture.spec.ts
+++ b/tests/ui-fixtures/dynamic-panel-workspace-fixture.spec.ts
@@ -282,10 +282,18 @@ test.describe("Dynamic panel workspace lightweight fixture", () => {
 		expect(result).toEqual({ file: true, http: false, https: false });
 	});
 
+	test("preview mount updates and stale hydrate do not resurrect closed server tabs", async ({ page }) => {
+		expect(await page.evaluate(() => (window as any).__exercisePreviewMountUpdateDoesNotCreateClosedTab())).toEqual({
+			tabIds: [],
+			legacyTabIds: [],
+		});
+	});
+
 	test("same-revision server rollback force-replaces optimistic workspace", async ({ page }) => {
 		const result = await page.evaluate(() => (window as any).__exerciseSameRevisionWorkspaceRollback());
 		expect(result).toEqual({
 			ignoredIds: ["proposal:goal", "review:optimistic"],
+			hydrateIgnoredIds: ["proposal:goal", "review:optimistic"],
 			forcedIds: ["proposal:goal"],
 			storedIds: ["proposal:goal"],
 			storedRevision: 7,
@@ -348,6 +356,21 @@ test.describe("Dynamic panel workspace lightweight fixture", () => {
 
 		await page.evaluate((sessionId) => (window as any).__selectDynamicWorkspaceSession(sessionId), b);
 		await expectReviewDocumentAccessible(page, "Test Document", "Some important text", "DYNAMIC_CHAT_TABS_SESSION_ISOLATION_BUG: switch back to session B");
+	});
+
+	test("duplicate review titles use distinct document-id tabs", async ({ page }) => {
+		await page.evaluate(() => {
+			(window as any).__openDynamicReviewDoc({ documentId: "review-doc:dup:a", title: "Duplicate Review", markdown: "# Duplicate Review\n\nFirst duplicate body." });
+			(window as any).__openDynamicReviewDoc({ documentId: "review-doc:dup:b", title: "Duplicate Review", markdown: "# Duplicate Review\n\nSecond duplicate body." });
+		});
+		await expect.poll(async () => (await visiblePanelTabs(page)).filter((tab) => tab.kind === "review" && /Duplicate Review/.test(tab.label)).length, {
+			timeout: 5_000,
+			message: "DYNAMIC_CHAT_TABS_DUPLICATE_REVIEW_TITLE_BUG: duplicate titles should render as distinct top-level tabs",
+		}).toBe(2);
+		await clickTopLevelTabById(page, "review:review-doc%3Adup%3Aa", "DYNAMIC_CHAT_TABS_DUPLICATE_REVIEW_TITLE_BUG: first duplicate");
+		await expect(page.locator("review-document").getByText("First duplicate body.").first()).toBeVisible({ timeout: 5_000 });
+		await clickTopLevelTabById(page, "review:review-doc%3Adup%3Ab", "DYNAMIC_CHAT_TABS_DUPLICATE_REVIEW_TITLE_BUG: second duplicate");
+		await expect(page.locator("review-document").getByText("Second duplicate body.").first()).toBeVisible({ timeout: 5_000 });
 	});
 
 	test("review document titles with reserved characters stay selectable after close and reopen", async ({ page }) => {

--- a/tests/ui-fixtures/dynamic-panel-workspace-fixture.spec.ts
+++ b/tests/ui-fixtures/dynamic-panel-workspace-fixture.spec.ts
@@ -10,6 +10,7 @@ const BUNDLE = path.join(BUNDLE_DIR, "dynamic-panel-workspace-fixture-bundle.js"
 
 const APP_RENDER_SRC = path.resolve("src/app/render.ts");
 const APP_STATE_SRC = path.resolve("src/app/state.ts");
+const SIDE_PANEL_WORKSPACE_SRC = path.resolve("src/app/side-panel-workspace.ts");
 const PANEL_WORKSPACE_SRC = path.resolve("src/app/panel-workspace.ts");
 const PREVIEW_RENDERER_SRC = path.resolve("src/ui/tools/renderers/PreviewRenderer.ts");
 const REVIEW_PANE_SRC = path.resolve("src/ui/components/review/ReviewPane.ts");
@@ -46,6 +47,7 @@ test.beforeAll(() => {
 			ENTRY,
 			APP_RENDER_SRC,
 			APP_STATE_SRC,
+			SIDE_PANEL_WORKSPACE_SRC,
 			PANEL_WORKSPACE_SRC,
 			PREVIEW_RENDERER_SRC,
 			REVIEW_PANE_SRC,
@@ -269,6 +271,25 @@ test.describe("Dynamic panel workspace lightweight fixture", () => {
 	test.beforeEach(async ({ page }) => {
 		await page.setViewportSize({ width: 1280, height: 800 });
 		await loadFixture(page);
+	});
+
+	test("render derivation is restricted to file fixtures", async ({ page }) => {
+		const result = await page.evaluate(() => ({
+			file: (window as any).__shouldDerivePanelTabsInRender("file:"),
+			http: (window as any).__shouldDerivePanelTabsInRender("http:"),
+			https: (window as any).__shouldDerivePanelTabsInRender("https:"),
+		}));
+		expect(result).toEqual({ file: true, http: false, https: false });
+	});
+
+	test("same-revision server rollback force-replaces optimistic workspace", async ({ page }) => {
+		const result = await page.evaluate(() => (window as any).__exerciseSameRevisionWorkspaceRollback());
+		expect(result).toEqual({
+			ignoredIds: ["proposal:goal", "review:optimistic"],
+			forcedIds: ["proposal:goal"],
+			storedIds: ["proposal:goal"],
+			storedRevision: 7,
+		});
 	});
 
 	test("multiple historical preview tabs reopen independently without hiding a goal proposal", async ({ page }) => {

--- a/tests/ui-fixtures/proposal-review-fixture.spec.ts
+++ b/tests/ui-fixtures/proposal-review-fixture.spec.ts
@@ -210,7 +210,7 @@ test.describe("Proposal/review lightweight fixture", () => {
 		await expect(page.locator('[data-panel="staff-proposal"]').first()).toBeVisible({ timeout: 10_000 });
 	});
 
-	test("review panel tabs render, switch, close, and keep submit disabled without annotations", async ({ page }) => {
+	test("review panel tabs render, switch, close workspace tab without deleting content, and keep submit disabled without annotations", async ({ page }) => {
 		await page.evaluate(() => (window as any).__setReviewFixture([
 			{ title: "Document A", markdown: "# Document A\n\nFirst document content." },
 			{ title: "Document B", markdown: "# Document B\n\nSecond document content." },
@@ -228,7 +228,7 @@ test.describe("Proposal/review lightweight fixture", () => {
 
 		await page.locator('review-pane button.review-tab[title="Document B"] .review-tab-close').click();
 		await expect(reviewPanelTab(page, "Document B")).toHaveCount(0, { timeout: 5_000 });
-		await expect.poll(async () => page.evaluate(() => (window as any).__getReviewState().titles)).toEqual(["Document A", "Document C"]);
+		await expect.poll(async () => page.evaluate(() => (window as any).__getReviewState().titles)).toEqual(["Document A", "Document B", "Document C"]);
 	});
 
 	test("proposal pane styles stay eagerly imported and apply their discriminating rules", async ({ page }) => {


### PR DESCRIPTION
## Summary

- Add a server-authoritative per-session side-panel workspace for preview, pack, proposal, review, and staff inbox panels.
- Share side-panel tab chrome, sizing, keyboard behavior, popout/deep-link handling, and durable active/order/size state.
- Replace render/localStorage-derived tab resurrection with explicit workspace open/update/close flows and documented migration behavior.
- Add and update E2E/unit coverage plus side-panel workspace documentation.

## Validation

- `npm run check`
- `npm run test:unit`
- `npm run test:e2e`
- Workflow gates passed: design-doc, implementation, documentation

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)