### PR TITLE
Quiet 204 Probes

### DIFF
--- a/docs/design/reduce-server-cpu-api-polling-research.md
+++ b/docs/design/reduce-server-cpu-api-polling-research.md
@@ -25,7 +25,7 @@ Each tick calls `refreshSessions()`, which issues these in parallel:
 Additional sidebar badge work:
 
 - On initial load or goal-list changes, `refreshGateStatusCache()` sends one `GET /api/goals/:id/gates` per live goal with a workflow.
-- PR badge polling is throttled client-side to 60s and only considers active, non-archived, non-complete goals with branches; it sends one `GET /api/goals/:id/pr-status` per eligible goal.
+- PR badge polling is throttled client-side to 60s and only considers active, non-archived, non-complete goals with branches; it sends one quiet optional `GET /api/goals/:id/pr-status?optional=1` per eligible goal.
 - On `visibilitychange -> visible`, `main.ts` resets the PR throttle and calls `refreshSessions()` immediately.
 - Initial load hydrates PR data from `GET /api/pr-status-cache` once.
 
@@ -43,7 +43,7 @@ Initial dashboard fetches:
 - `GET /api/goals/:id/gates`
 - `GET /api/goals/:id/git-status`
 - `GET /api/goals/:id/cost`
-- `GET /api/goals/:id/pr-status`
+- `GET /api/goals/:id/pr-status?optional=1`
 - then `GET /api/goals/:id/team`
 - plus `GET /api/goals/:id/team/agents` from `startAgentPolling()`
 - plus `GET /api/goals/:id/verifications/active` after data load
@@ -56,7 +56,7 @@ Steady dashboard pollers:
 | Tasks | `/tasks` | every 10s | No |
 | Gates | `/gates`, `/verifications/active` | every 8s | No |
 | Cost | `/cost` | every 15s | No |
-| Goal git/PR | `/git-status`, `/pr-status` | every 60s | Yes |
+| Goal git/PR | `/git-status`, `/pr-status?optional=1` | every 60s | Yes |
 | Setup banner | `/api/goals/:id` | every 3s while `setupStatus === "preparing"` | No |
 
 A single open goal dashboard adds roughly **51 REST requests/minute** in steady state, excluding the global sidebar poll and excluding retries. Most of these dashboard pollers keep running in hidden tabs; browsers may throttle timers, but the code itself does not pause them.
@@ -66,7 +66,7 @@ A single open goal dashboard adds roughly **51 REST requests/minute** in steady 
 The active session widget has its own safety poll in `session-manager.ts`:
 
 - `GET /api/sessions/:id/git-status` every 30s for the active session, visible tabs only, with a 10s coalesce window after event-driven refreshes.
-- Every session git-status refresh is followed by a PR status refresh: `GET /api/goals/:goalId/pr-status` when the session has a goal, otherwise `GET /api/sessions/:id/pr-status`.
+- Every session git-status refresh is followed by a quiet optional PR status refresh: `GET /api/goals/:goalId/pr-status?optional=1` when the session has a goal, otherwise `GET /api/sessions/:id/pr-status?optional=1`.
 - Visibility changes to visible trigger an immediate git refresh.
 - Event-driven refreshes happen on active session connect, reconnect, idle status, and user git actions.
 - `runGitStatusRefresh()` retries transient failures up to 4 attempts at delays `[0, 500, 2000, 5000]`; `not-a-repo` is terminal.

--- a/docs/quiet-204-probes.md
+++ b/docs/quiet-204-probes.md
@@ -1,0 +1,44 @@
+# Quiet optional probes
+
+Some UI reads are probes: the requested session or goal should exist, but the data being checked is optional. A fresh session usually has no prompt draft, and local/manual branches often have no GitHub PR. Treating those expected absences as `404` makes healthy UI flows look like failed network requests in browser consoles.
+
+Quiet optional probe mode keeps the legacy API contract for normal callers while giving the UI an explicit no-noise path.
+
+## Opt-in flag
+
+Append `optional=1` to a supported probe request:
+
+```http
+GET /api/sessions/:id/draft?type=prompt&optional=1
+GET /api/sessions/:id/pr-status?optional=1
+GET /api/goals/:id/pr-status?optional=1
+```
+
+Only these absence cases are quieted. Bare requests keep their existing `404` behavior.
+
+## Status contract
+
+| Endpoint | Bare absence | `optional=1` expected absence | Missing parent |
+|---|---:|---:|---:|
+| `GET /api/sessions/:id/draft?type=prompt` | `404` draft not found | `204 No Content` | `404` session not found |
+| `GET /api/sessions/:id/pr-status` | `404` no PR found | `204 No Content` | `404` session not found |
+| `GET /api/goals/:id/pr-status` | `404` no PR found | `204 No Content` | `404` goal not found |
+
+`204` responses have no JSON body. Do not call `res.json()` on them.
+
+Quiet mode does not hide real lookup failures. If the session or goal id is invalid, or the parent resource is otherwise unavailable, the endpoint still returns `404`.
+
+## Client handling
+
+Use quiet mode only for optional UI polling or badge refreshes where absence is normal. Callers that need a hard not-found signal should keep using the bare endpoint.
+
+Handle `204` before parsing JSON:
+
+```ts
+const res = await gatewayFetch(`/api/goals/${goalId}/pr-status?optional=1`);
+if (res.status === 204) return null;
+if (!res.ok) throw await errorFromResponse(res, `Failed: ${res.status}`);
+return await res.json();
+```
+
+The same pattern applies to prompt draft restore and session PR status refresh. This prevents expected absence from surfacing as browser-console errors while preserving real errors for diagnostics.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -17,6 +17,10 @@ Non-2xx JSON responses follow:
 
 Client call sites use the shared helpers `errorFromResponse(res, fallback)` and `errorDetails(err)` from `src/app/error-helpers.ts` to parse this body, attach `code`/`stack` to the thrown `Error`, and forward both to `showConnectionError(title, message, { code, stack })`, which renders via the `<error-details>` component (`src/ui/components/ErrorDetails.ts`). The set of modal call sites that must forward `{ code, stack }` is pinned by `tests/error-modal-call-sites.test.ts`; the helper contract is pinned by `tests/error-helpers.test.ts`.
 
+### Quiet optional probes
+
+A small set of UI probe endpoints accept `optional=1` to represent expected absence without producing browser-console-noisy `404` responses. In quiet mode, an existing session or goal with no optional data returns `204 No Content` and no body; genuinely missing sessions or goals still return `404`. Bare endpoints keep the legacy `404` absence contract. See [Quiet optional probes](quiet-204-probes.md).
+
 ### Health & Info
 
 | Method | Path | Description |
@@ -51,8 +55,9 @@ These endpoints expose restart support only for gateways launched through `npm r
 | `POST` | `/api/sessions/:id/mark-read` | Record that the user viewed this session. Sets `lastReadAt = Date.now()` on the persisted session row; clients compare `lastActivity > lastReadAt` to render the unseen-activity dot. Works on live, dormant, and archived sessions. See [docs/internals.md — Read/unread state](internals.md#readunread-state). 404 if the session id is unknown. |
 | `POST` | `/api/sessions/:archivedId/continue` | Create a new session whose agent CLI rehydrates from a byte-for-byte clone of the archived session's `.jsonl`. See [Continue-Archived endpoint](#continue-archived-endpoint) |
 | `GET` | `/api/sessions/:id/output` | Get final assistant output from the last turn |
+| `GET` | `/api/sessions/:id/draft?type=:type` | Read a persisted UI draft. Missing drafts return `404` by default; `optional=1` returns empty `204` for expected absence when the session exists. |
 | `GET` | `/api/sessions/:id/git-status` | Git status for session's working directory (branch, ahead/behind, dirty files) |
-| `GET` | `/api/sessions/:id/pr-status` | PR status for session's branch (via `gh pr view`) |
+| `GET` | `/api/sessions/:id/pr-status` | PR status for session's branch (via `gh pr view`). Missing PRs return `404` by default; `optional=1` returns empty `204` when the session exists. |
 | `POST` | `/api/sessions/:id/bg-processes` | Start a background process and return its `BgProcessInfo` snapshot |
 | `GET` | `/api/sessions/:id/bg-processes` | List active/exited background process snapshots for REST hydration |
 | `GET` | `/api/sessions/:id/bg-processes/:pid/wait` | Long-poll until a background process exits, times out, or is interrupted |
@@ -230,7 +235,7 @@ Per-session review annotations are stored server-side so they survive browser cl
 | `GET` | `/api/goals/:id/git-status` | Git status for goal worktree (branch, ahead/behind primary, clean) |
 | `GET` | `/api/goals/:id/cost` | Aggregate cost across all sessions linked to a goal (includes `cacheHitRate`) |
 | `GET` | `/api/goals/:id/cost/breakdown` | Goal aggregate plus per-session breakdown, used by the goal cost popover; cost objects include `cacheHitRate: number \| null`. |
-| `GET` | `/api/goals/:id/pr-status` | PR status for goal branch (cached, via `gh pr view`) |
+| `GET` | `/api/goals/:id/pr-status` | PR status for goal branch (cached, via `gh pr view`). Missing PRs return `404` by default; `optional=1` returns empty `204` when the goal exists. |
 | `GET` | `/api/goals/:id/github-link` | PR URL or sanitized GitHub branch fallback. Still available, but the sidebar `Open on GitHub` item now mirrors the goal-row PR badge instead of gating on this endpoint. See [Goal GitHub link endpoint](#goal-github-link-endpoint) |
 | `POST` | `/api/goals/:id/pr-merge` | Merge PR for goal branch (`{ method? }`) |
 

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -1259,8 +1259,8 @@ export async function refreshPrStatusCache(skipRender = false): Promise<boolean>
 	const results = await Promise.all(
 		goalsWithBranch.map(async (g) => {
 			try {
-				const res = await gatewayFetch(`/api/goals/${g.id}/pr-status`);
-				if (res.status === 404) return { goalId: g.id, pr: null, noPr: true };
+				const res = await gatewayFetch(`/api/goals/${g.id}/pr-status?optional=1`);
+				if (res.status === 204 || res.status === 404) return { goalId: g.id, pr: null, noPr: true };
 				if (!res.ok) return { goalId: g.id, pr: null, noPr: false };
 				const data = await res.json();
 				return { goalId: g.id, pr: data as { state: string; url?: string; number?: number; reviewDecision?: string; mergeable?: string }, noPr: false };
@@ -2547,8 +2547,8 @@ export async function saveDraftToServer(sessionId: string, type: string, data: u
 /** Load a draft from the server. Returns null if not found or on error. */
 export async function loadDraftFromServer(sessionId: string, type: string): Promise<unknown | null> {
 	try {
-		const res = await gatewayFetch(`/api/sessions/${sessionId}/draft?type=${encodeURIComponent(type)}`);
-		if (!res.ok) return null;
+		const res = await gatewayFetch(`/api/sessions/${sessionId}/draft?type=${encodeURIComponent(type)}&optional=1`);
+		if (res.status === 204 || !res.ok) return null;
 		const body = await res.json();
 		return body.data ?? null;
 	} catch (err) {

--- a/src/app/goal-dashboard.ts
+++ b/src/app/goal-dashboard.ts
@@ -631,7 +631,7 @@ export async function loadDashboardData(goalId: string): Promise<void> {
 			fetchGoalGates(goalId),
 			gatewayFetch(`/api/goals/${goalId}/git-status`).catch(() => null),
 			gatewayFetch(`/api/goals/${goalId}/cost`).catch(() => null),
-			gatewayFetch(`/api/goals/${goalId}/pr-status`).catch(() => null),
+			gatewayFetch(`/api/goals/${goalId}/pr-status?optional=1`).catch(() => null),
 		]);
 
 		if (!goalRes.ok) throw new Error(`Goal not found (${goalRes.status})`);
@@ -681,7 +681,9 @@ export async function loadDashboardData(goalId: string): Promise<void> {
 			goalCost = await costRes.json();
 		}
 
-		if (prStatusRes && prStatusRes.ok) {
+		if (prStatusRes && prStatusRes.status === 204) {
+			prStatus = null;
+		} else if (prStatusRes && prStatusRes.ok) {
 			prStatus = await prStatusRes.json();
 			// Sync to sidebar cache so badge persists even if polling skips this goal
 			if (prStatus && currentGoalId) state.prStatusCache.set(currentGoalId, prStatus);
@@ -1183,8 +1185,13 @@ function startGitStatusPolling(goalId: string): void {
 		}
 		let needRender = false;
 		try {
-			const prRes = await gatewayFetch(`/api/goals/${goalId}/pr-status`).catch(() => null);
-			if (prRes && prRes.ok) {
+			const prRes = await gatewayFetch(`/api/goals/${goalId}/pr-status?optional=1`).catch(() => null);
+			if (prRes && prRes.status === 204) {
+				if (prStatus !== null) {
+					prStatus = null;
+					needRender = true;
+				}
+			} else if (prRes && prRes.ok) {
 				const newPr: PrStatus = await prRes.json();
 				if (JSON.stringify(newPr) !== JSON.stringify(prStatus)) {
 					prStatus = newPr;
@@ -1589,10 +1596,12 @@ async function handlePrMerge(e: CustomEvent<{ method: string; admin?: boolean; b
 	try {
 		const [gitRes, prRes] = await Promise.all([
 			gatewayFetch(`/api/goals/${goalId}/git-status`).catch(() => null),
-			gatewayFetch(`/api/goals/${goalId}/pr-status`).catch(() => null),
+			gatewayFetch(`/api/goals/${goalId}/pr-status?optional=1`).catch(() => null),
 		]);
 		if (gitRes && gitRes.ok) gitStatus = await gitRes.json();
-		if (prRes && prRes.ok) {
+		if (prRes && prRes.status === 204) {
+			prStatus = null;
+		} else if (prRes && prRes.ok) {
 			prStatus = await prRes.json();
 			// Immediately update the goal grouping cache so it reflects the merge
 			if (prStatus) state.prStatusCache.set(goalId, prStatus);

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -1493,8 +1493,10 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			// Targeted PR status refresh — bypasses the 60s poll throttle
 			(async () => {
 				try {
-					const res = await gatewayFetch(`/api/goals/${goalId}/pr-status`);
-					if (res.ok) {
+					const res = await gatewayFetch(`/api/goals/${goalId}/pr-status?optional=1`);
+					if (res.status === 204) {
+						state.prStatusCache.delete(goalId);
+					} else if (res.ok) {
 						const data = await res.json();
 						state.prStatusCache.set(goalId, data);
 					} else if (res.status === 404) {
@@ -3015,15 +3017,15 @@ async function refreshPrStatusForSession(sessionId: string): Promise<void> {
 
 	// Build the URL: goal-scoped if available, otherwise session-scoped
 	const prStatusUrl = goalId
-		? `/api/goals/${goalId}/pr-status`
-		: `/api/sessions/${sessionId}/pr-status`;
+		? `/api/goals/${goalId}/pr-status?optional=1`
+		: `/api/sessions/${sessionId}/pr-status?optional=1`;
 
 	const ai = state.chatPanel?.agentInterface;
 	if (!ai) return;
 
 	try {
 		const res = await gatewayFetch(prStatusUrl).catch(() => null);
-		if (!res || !res.ok) {
+		if (!res || res.status === 204 || !res.ok) {
 			if (activeSessionId() === sessionId) {
 				ai.prState = undefined;
 				ai.prUrl = undefined;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2542,6 +2542,10 @@ async function handleApiRoute(
 		res.writeHead(status, { "Content-Type": "application/json" });
 		res.end(JSON.stringify(data));
 	};
+	const noContent = () => {
+		res.writeHead(204);
+		res.end();
+	};
 	const jsonError = (status: number, err: unknown, extra?: Record<string, unknown>) => {
 		const e = err instanceof Error ? err : new Error(String(err));
 		// Log stack trace server-side only; do not send it to clients to avoid
@@ -8757,8 +8761,9 @@ async function handleApiRoute(
 		if (!fs.existsSync(cwd)) { json({ error: "Working directory not found" }, 404); return; }
 		// Pass process.cwd() as fallback — if the goal's worktree has a broken git link
 		// (e.g. pruned worktree), gh can still query by branch name from the main repo.
+		const optional = url.searchParams.get("optional") === "1";
 		const pr = await getCachedPrStatus(cwd, goal.branch, process.cwd());
-		if (pr) { prStatusStore.set(goalId, pr); json(pr); } else { json({ error: "No PR found" }, 404); }
+		if (pr) { prStatusStore.set(goalId, pr); json(pr); } else if (optional) { noContent(); } else { json({ error: "No PR found" }, 404); }
 		return;
 	}
 
@@ -10882,12 +10887,13 @@ async function handleApiRoute(
 		}
 		// PR status uses `gh` CLI which needs host filesystem — use worktreePath for sandboxed sessions
 		const prCwd = cid ? (session.worktreePath || process.cwd()) : cwd;
+		const optional = url.searchParams.get("optional") === "1";
 		const pr = await getCachedPrStatus(prCwd, sessionBranch, process.cwd());
 		if (pr) {
 			const goalId = session.goalId;
 			if (goalId) prStatusStore.set(goalId, pr);
 			json(pr);
-		} else { json({ error: "No PR found" }, 404); }
+		} else if (optional) { noContent(); } else { json({ error: "No PR found" }, 404); }
 		return;
 	}
 
@@ -12038,6 +12044,7 @@ async function handleApiRoute(
 			// Check if session exists at all
 			const session = sessionManager.getSession(id);
 			if (!session) { json({ error: "Session not found" }, 404); return; }
+			if (url.searchParams.get("optional") === "1") { noContent(); return; }
 			json({ error: "Draft not found" }, 404);
 			return;
 		}

--- a/tests/e2e/draft-api.spec.ts
+++ b/tests/e2e/draft-api.spec.ts
@@ -61,9 +61,28 @@ test.describe("GET /api/sessions/:id/draft", () => {
 		expect(resp.status).toBe(404);
 	});
 
+	test("keeps bare missing prompt draft as 404 but returns empty 204 in optional mode", async () => {
+		const freshSessionId = await createSession();
+		try {
+			const bareResp = await apiFetch(`/api/sessions/${freshSessionId}/draft?type=prompt`);
+			expect(bareResp.status, "bare missing prompt draft should remain 404").toBe(404);
+
+			const optionalResp = await apiFetch(`/api/sessions/${freshSessionId}/draft?type=prompt&optional=1`);
+			expect(optionalResp.status, "quiet optional draft absence should return 204 No Content").toBe(204);
+			expect(await optionalResp.text(), "204 draft response must have no body").toBe("");
+		} finally {
+			await deleteSession(freshSessionId);
+		}
+	});
+
 	test("returns 404 for a non-existent session", async () => {
 		const resp = await apiFetch("/api/sessions/no-such-session/draft?type=prompt");
 		expect(resp.status).toBe(404);
+	});
+
+	test("returns 404 for a non-existent session even in optional draft mode", async () => {
+		const resp = await apiFetch("/api/sessions/no-such-session/draft?type=prompt&optional=1");
+		expect(resp.status, "missing session should remain 404 even for quiet draft probes").toBe(404);
 	});
 });
 

--- a/tests/e2e/quiet-pr-status-api.spec.ts
+++ b/tests/e2e/quiet-pr-status-api.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "./in-process-harness.js";
+import { apiFetch, createSession, deleteGoal, deleteSession, nonGitCwd } from "./e2e-setup.js";
+
+async function expectEmptyNoContent(resp: Response, label: string): Promise<void> {
+	expect(resp.status, `${label} should return 204 No Content`).toBe(204);
+	expect(await resp.text(), `${label} 204 response must have no body`).toBe("");
+}
+
+async function createGoalWithBranch(): Promise<{ id: string }> {
+	const resp = await apiFetch("/api/goals", {
+		method: "POST",
+		body: JSON.stringify({
+			title: `quiet pr-status no-pr ${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+			cwd: nonGitCwd(),
+			worktree: false,
+			team: false,
+			branch: `quiet-204-no-pr-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+			spec: "E2E reproducer goal for quiet optional PR status probes with no matching GitHub PR.",
+		}),
+	});
+	expect(resp.status).toBe(201);
+	return resp.json();
+}
+
+test.describe("quiet optional PR status probes", () => {
+	test("keeps bare session PR absence as 404 but returns empty 204 in optional mode", async () => {
+		const sessionId = await createSession();
+		try {
+			const bareResp = await apiFetch(`/api/sessions/${sessionId}/pr-status`);
+			expect(bareResp.status, "bare session PR-status absence should remain 404").toBe(404);
+
+			const optionalResp = await apiFetch(`/api/sessions/${sessionId}/pr-status?optional=1`);
+			await expectEmptyNoContent(optionalResp, "quiet optional session PR-status absence");
+		} finally {
+			await deleteSession(sessionId);
+		}
+	});
+
+	test("returns 404 for a missing session even in optional PR-status mode", async () => {
+		const resp = await apiFetch("/api/sessions/no-such-session/pr-status?optional=1");
+		expect(resp.status, "missing session should remain 404 even for quiet PR-status probes").toBe(404);
+	});
+
+	test("keeps bare goal PR absence as 404 but returns empty 204 in optional mode", async () => {
+		const goal = await createGoalWithBranch();
+		try {
+			const bareResp = await apiFetch(`/api/goals/${goal.id}/pr-status`);
+			expect(bareResp.status, "bare goal PR-status absence should remain 404").toBe(404);
+
+			const optionalResp = await apiFetch(`/api/goals/${goal.id}/pr-status?optional=1`);
+			await expectEmptyNoContent(optionalResp, "quiet optional goal PR-status absence");
+		} finally {
+			await deleteGoal(goal.id);
+		}
+	});
+
+	test("returns 404 for a missing goal even in optional PR-status mode", async () => {
+		const resp = await apiFetch("/api/goals/no-such-goal/pr-status?optional=1");
+		expect(resp.status, "missing goal should remain 404 even for quiet PR-status probes").toBe(404);
+	});
+});


### PR DESCRIPTION
## Summary
- Add explicit `optional=1` quiet mode for draft and PR-status probes so expected absence returns `204 No Content`.
- Preserve bare `404` behavior and missing session/goal `404` responses.
- Update UI callers, E2E coverage, and developer docs.

## Verification
- `npm run check`
- `npx playwright test --config playwright-e2e.config.ts tests/e2e/draft-api.spec.ts tests/e2e/quiet-pr-status-api.spec.ts`
- Implementation workflow gate passed, including build, type check, repro tests, unit tests, E2E tests, and reviews.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)