### PR TITLE
Extension Platform G1.2: Lifecycle Hub core + worker dispatch + budgets + trace

### DIFF
--- a/docs/extension-host-authoring.md
+++ b/docs/extension-host-authoring.md
@@ -42,7 +42,7 @@ The renderer+action working example lives at `tests/fixtures/market-sources/retr
 | **Pack routes** | `pack.yaml` `routes:` | Gateway (confined worker) | called via `host.callRoute` |
 | **Entrypoints** | `entrypoints/<ep>.yaml` (listed in `contents`) | Browser (launchers + deep-link routes) | `host.ui.navigate` / `openPanel` |
 | **Pack store** | *implicit* — no declaration | Gateway | `host.store.{get,put,list}` (pack-namespaced) |
-| **Providers** *(schema 2; inert)* | `providers/<id>.yaml` (listed in `contents.providers`) | — not dispatched yet — | none yet (loaded + toggleable only) |
+| **Providers** *(schema 2; core landed, not yet wired)* | `providers/<id>.yaml` (listed in `contents.providers`) | Server (Lifecycle Hub, worker tier) | default-export hook object — see [docs/lifecycle-hub.md](lifecycle-hub.md) |
 
 Plus the cross-cutting `host.session.*` (transcript reads, agent-driving posts, live events)
 and the server-side `host.agents.*` (launch + orchestrate child agents), available to surfaces
@@ -784,20 +784,29 @@ a fresh read-only reviewer sub-agent and the panel lives only in that child sess
   packs declaring the same `routeId` is a hard rejection at registry build). Panel ids referenced
   by `target.panelId` are pack-local.
 
-### Providers (`providers/<id>.yaml`) — schema 2, loaded but inert
+### Providers (`providers/<id>.yaml`) — schema 2; core landed, not yet wired into sessions
 
-**Status:** a `schema: 2` pack may ship **provider** contributions — a new pack-scoped
-contribution loaded into the same `PackContributionRegistry` as panels/entrypoints/routes. Schema-1
-packs ignore `contents.providers` and keep the old activation-catalogue shape. In
-this PR they are **loaded, validated, catalogued, and per-entity toggleable, but never
-dispatched**: nothing imports a provider `module`, runs a `hook`, or applies its `budget`.
-Provider *dispatch* (the lifecycle hub) is a later Extension-Platform goal. Author them now to
-get validation + activation; expect no runtime effect yet.
+**Status:** a `schema: 2` pack may ship **provider** contributions — a pack-scoped
+contribution loaded into the same `PackContributionRegistry` as panels/entrypoints/routes.
+Schema-1 packs ignore `contents.providers` and keep the old activation-catalogue shape.
 
-Unlike every other contribution in this guide, a provider has **no Host-API surface** — it is
-not reached through `ctx.host`. It is a forward-declared entity whose only observable behaviour
-today is that it appears in the activation catalogue and in
-`PackContributionRegistry.listProviders(projectId)` (installed + active + enabled).
+Provider **dispatch infrastructure now exists**: a server-core `LifecycleHub` can resolve
+enabled providers via `PackContributionRegistry.listProviders(projectId)`, run a named hook on
+the Extension Host worker tier with a per-provider timeout, collect the returned
+`ContextBlock`s, apply token budgets, fence the content, and record a trace. See
+[docs/lifecycle-hub.md](lifecycle-hub.md) for the full Hub contract.
+
+**But nothing calls the Hub from any session path yet, so authoring a provider still has no
+runtime effect in production today.** The `sessionSetup` wiring lands in a later goal (G1.3) and
+the per-turn `beforePrompt` wiring after that (G1.4). Author providers now to get validation,
+catalogue listing, and activation toggles — and to be ready for when the wiring lands — but
+expect no observable behaviour until then beyond appearing in `listProviders(projectId)`
+(installed + active + enabled).
+
+Unlike every other contribution in this guide, a provider has **no `ctx.host` Host-API
+surface** — it is not reached through the panel/entrypoint/route Host API. Instead, when the Hub
+eventually dispatches it, the provider runs as a module on the worker tier and returns context
+blocks (see the [provider module contract](#provider-module-contract) below).
 
 Key author-facing rules (full reference, field table, defaults, and clamps live in
 [docs/marketplace.md → Provider contributions](marketplace.md#provider-contributions-providersidyaml)):
@@ -813,6 +822,46 @@ Key author-facing rules (full reference, field table, defaults, and clamps live 
 - `hooks` must be a subset of `sessionSetup` / `beforePrompt` / `afterTurn` / `beforeCompact` /
   `sessionShutdown`; an unknown hook drops *that* provider (warn) and the rest of the pack
   still loads.
+- `budget` (`{ maxTokens, timeoutMs }`) bounds dispatch: `maxTokens` is clamped to `[64, 8192]`
+  (default 1600) and `timeoutMs` to `[100, 10000]` (default 1500). When the Hub dispatches, the
+  per-provider token max feeds the budget algorithm and the timeout bounds the worker call.
+- `config` is an opaque mapping handed to the hook verbatim as `ctx.config`.
+
+#### Provider module contract
+
+A provider `module` is authored as a **default-export object** whose members are the hook
+handlers — **not** a named `providers` export (this is what distinguishes the provider worker
+path from routes/actions). Each handler is `async (ctx) => ({ blocks: [...] })` and returns
+`ContextBlock`s (a bare `ContextBlock[]` is also accepted):
+
+```js
+// providers/memory.mjs
+export default {
+  async sessionSetup(ctx) {
+    // ctx carries: sessionId, projectId, scope, cwd, goalId?, roleName?, prompt?, turn?,
+    //   budget.maxTokens (this provider's clamped allowance), config (the YAML `config`),
+    //   and gateway { baseUrl, token } for calling back into the gateway.
+    return {
+      blocks: [{
+        id: "recent-decisions",
+        title: "Project memory",        // → fence source="…"
+        authority: "memory",             // memory|skill|tool|workflow|role|generic
+        content: "…",                    // the text injected into the prompt
+        reason: "continuity across sessions",  // → fence reason="…"
+        priority: 10,                    // higher = kept first under budget pressure
+      }],
+    };
+  },
+  async beforePrompt(ctx) { /* … */ },
+};
+```
+
+The Hub **forces `providerId`** to your provider id and **recomputes `tokenEstimate`** from
+`content` host-side, so you cannot mis-attribute a block or under-report its size. Malformed
+blocks are dropped (not fatal); a throw or timeout becomes a diagnostic and never breaks other
+providers. Accepted blocks are wrapped in a `<context-block id=… source=… authority=…
+reason=…>` envelope (attribute values are newline-stripped and `"`-escaped). Full algorithm and
+trace details: [docs/lifecycle-hub.md](lifecycle-hub.md).
 
 ### `host.session.*` — transcript reads, posts, and live events
 

--- a/docs/lifecycle-hub.md
+++ b/docs/lifecycle-hub.md
@@ -1,0 +1,310 @@
+# The Lifecycle Hub
+
+> **Status — server core, not yet wired (Extension Platform G1.2).** The `LifecycleHub`
+> exists and is fully tested, but **nothing in any session path calls it yet**. Authoring a
+> provider has **no runtime effect in production today**. Session-setup wiring lands in G1.3
+> and per-turn (`beforePrompt`) wiring in G1.4. See [Status / not-yet-wired](#status--not-yet-wired)
+> at the end of this doc. This page documents the core so the wiring goals (and provider
+> authors) have a stable contract to build against.
+
+## What it is, and why
+
+The Lifecycle Hub is the server-side seam that lets **pack-contributed providers** inject
+*ambient context* into an agent session at well-defined moments — when a session starts, before
+each prompt, after a turn, before a compaction, and at shutdown. A provider is trusted,
+pack-shipped code (see [provider contributions](marketplace.md#provider-contributions-providersidyaml)
+and the [authoring guide](extension-host-authoring.md)); the Hub is what eventually *runs* that
+code and folds its output into the prompt.
+
+The design problem the Hub solves: ambient context is powerful but dangerous. Untrusted *output*
+and slow/looping *code* can both wreck a session. So the Hub is built around a single principle —
+
+> **The provider code is trusted; its output is not, and its runtime is bounded.**
+
+Concretely that means every dispatch is:
+
+- **Isolated** — each provider runs on the Extension Host worker tier (`ModuleHost.invoke`),
+  the same confined-worker seam that backs pack routes/actions. The worker is terminated on
+  settle or timeout, so a runaway provider cannot block the gateway.
+- **Budgeted** — each provider has a token budget and a wall-clock timeout; a global token cap
+  bounds the whole dispatch. Over-budget content is truncated/dropped, never silently inflated.
+- **Fenced** — accepted content is wrapped in a `<context-block …>` envelope with provenance
+  attributes, so the model can tell ambient provider text apart from the user's own words.
+- **Validated + provenance-forced** — the Hub re-checks the shape of every returned block,
+  forces the `providerId`, and recomputes the token estimate host-side. A provider cannot
+  claim to be another provider or under-report its size.
+- **Traced** — one trace row per dispatch records which providers ran, how long they took, how
+  many blocks they contributed, and any error — for debugging and budget tuning.
+- **Fault-isolated** — a provider that throws, times out, or returns malformed blocks becomes a
+  *diagnostic* and the dispatch **continues**; one bad provider never fails the others or the
+  session.
+
+The three core modules live under `src/server/agent/`:
+
+| Module | Responsibility |
+|---|---|
+| `context-blocks.ts` | The `ContextBlock` shape, token estimation, fencing, and the budget algorithm. |
+| `lifecycle-hub.ts` | The `LifecycleHub` class: resolve providers, dispatch a hook, collect/validate/budget, write a trace row. |
+| `context-trace-store.ts` | Append-only JSONL trace per session, size-capped. |
+
+## Hooks
+
+A **lifecycle hook** is a named moment in a session's life. The hook set is:
+
+| Hook | Intended dispatch point | Wiring goal |
+|---|---|---|
+| `sessionSetup` | Once, when a session is created — seed durable context. | G1.3 |
+| `beforePrompt` | Before each user prompt is sent to the model. | G1.4 |
+| `afterTurn` | After a turn completes. | later |
+| `beforeCompact` | Before transcript compaction. | later |
+| `sessionShutdown` | When a session is torn down. | later |
+
+A provider declares which hooks it wants in its YAML `hooks:` list; the Hub only dispatches a
+hook to providers that declared it. **None of these dispatch points are wired into the session
+runtime yet** — the table records *intent*, not current behaviour.
+
+## The `ContextBlock` contract
+
+A provider hook returns blocks the Hub will consider injecting. The shape
+(`context-blocks.ts`):
+
+```ts
+type ContextBlockAuthority = "memory" | "skill" | "tool" | "workflow" | "role" | "generic";
+
+interface ContextBlock {
+  id: string;            // provider-local block id (used in the fence envelope)
+  title: string;         // human/source label → fence `source="…"`
+  providerId: string;    // FORCED host-side to the dispatching provider's id
+  authority: ContextBlockAuthority;
+  content: string;       // the actual text injected into the prompt
+  reason: string;        // why this block is here → fence `reason="…"`
+  priority: number;      // higher = kept first under budget pressure
+  tokenEstimate: number; // RECOMPUTED host-side from content
+}
+```
+
+### Host-forced provenance — what a provider cannot fake
+
+When a hook returns, the Hub validates each candidate block and **rewrites two fields**:
+
+- **`providerId` is forced** to the id of the provider that actually ran. A block cannot
+  attribute itself to another provider.
+- **`tokenEstimate` is recomputed** host-side via `estimateTokens(content)` — a provider cannot
+  under-report its size to dodge the budget.
+
+`estimateTokens` is `Math.ceil(content.length / 4)`. This deliberately matches
+`PromptSection.tokens` in `system-prompt.ts` so the Hub's accounting lines up with how the rest
+of the prompt is measured.
+
+### Validation — malformed blocks are dropped
+
+A returned value is accepted as a block list if it is either an array of blocks or an object
+with a `blocks` array. Each candidate must be a plain object with string `id`, `title`,
+`content`, and `reason`; an `authority` in the allowed set; and a finite numeric `priority`.
+Anything else is **dropped** and counted as malformed (one diagnostic per provider that
+produced malformed blocks). The provider is not failed for it — valid blocks from the same
+return still flow through.
+
+## Fencing
+
+Accepted blocks are wrapped so the model can distinguish ambient provider text from the
+conversation. `fenceBlock(block)` produces:
+
+```
+<context-block id="…" source="…" authority="…" reason="…">
+{content}
+</context-block>
+```
+
+- `source` is the block's `title`; `id`, `authority`, and `reason` map straight across.
+- **Attribute values are sanitised**: newlines are collapsed to spaces and `"` becomes
+  `&quot;`, so a crafted `title`/`reason` cannot break out of the attribute or inject a fake
+  tag. The `content` itself is placed between the tags verbatim (on its own lines).
+
+## The budget algorithm
+
+`applyBudgets(blocks, perProviderMax, globalMax)` decides which blocks survive. It returns
+`{ kept, omitted }`, where each omitted entry carries a `why`. The rules, in order:
+
+1. **Sort by `priority` descending**, ties broken by original collection order (which follows
+   provider order). High-priority context wins scarce budget.
+2. **Walk the sorted list, accumulating usage.** For each block the available *headroom* is the
+   smaller of the remaining global budget and the remaining per-provider budget —
+   `headroom = min(globalMax − globalUsed, providerMax − providerUsed)`. **The global cap binds
+   before any per-provider headroom**: a provider can never spend budget the global cap has
+   already exhausted, even if its own allowance remains.
+3. **A block that fits is kept** and its tokens are charged to both the global and per-provider
+   tallies.
+4. **The first block that does *not* fit triggers single-shot truncation.** If the remaining
+   headroom is at least 32 tokens, that one block's `content` is truncated to fit (with a
+   trailing `…[truncated]` marker) and kept; its `tokenEstimate` is recomputed. If the headroom
+   is below 32 tokens — or truncation would leave a remainder under 32 tokens — the block is
+   **dropped instead of truncated** (never emit a uselessly tiny fragment).
+5. **Every block after the truncation point is omitted** (`why: "after-truncation"`). The
+   algorithm truncates at most one block, then stops keeping.
+
+The `why` reasons you'll see in `omitted`: `after-truncation`, `truncated-below-min`,
+`below-min`.
+
+A `perProviderMax` entry comes from each provider's clamped `budget.maxTokens`; a provider with
+no entry falls back to the global cap. `globalMax` defaults to **4000 tokens** (the Hub's
+`globalMaxTokens` constructor option).
+
+## The `LifecycleHub` class
+
+```ts
+class LifecycleHub {
+  constructor(deps: {
+    registry: PackContributionRegistry;
+    moduleHost: ModuleHost;
+    trace: ContextTraceStore;
+    gatewayInfo: () => { baseUrl: string; token: string };
+    globalMaxTokens?: number; // default 4000
+  });
+
+  dispatch(
+    hook: LifecycleHook,
+    base: Omit<HookCtx, "budget" | "config" | "gateway">,
+  ): Promise<{ blocks: ContextBlock[]; diagnostics: HubDiagnostic[] }>;
+}
+```
+
+### What `dispatch` does
+
+1. **Resolve providers.** It asks `registry.listProviders(base.projectId)` (G1.1's resolver —
+   installed, active, enabled providers for the project scope) and keeps only those whose
+   `hooks` include the requested hook.
+2. **Build a `HookCtx` per provider** by merging the caller's `base` context with the
+   provider's YAML `config`, the provider's clamped `budget.maxTokens`, and the gateway
+   coordinates from `gatewayInfo()`. The full `HookCtx` shape:
+
+   ```ts
+   interface HookCtx {
+     sessionId: string; projectId?: string; scope: "project" | "global"; cwd: string;
+     goalId?: string; roleName?: string; prompt?: string; turn?: { index: number };
+     budget: { maxTokens: number };
+     config: Record<string, unknown>;
+     runtime?: { baseUrl: string; headers: Record<string, string>; status: string };
+     gateway: { baseUrl: string; token: string };
+   }
+   ```
+3. **Invoke each provider on the worker tier.** It calls `moduleHost.invoke({ exportKind:
+   "providers", member: hook, url, packRoot, epoch, ctx, arg })` with the provider's
+   `budget.timeoutMs` as the per-provider timeout. The worker resolves the module's hook from
+   the **default-export object** (see [provider module contract](#provider-module-contract)).
+4. **Collect + validate + force provenance** on the returned blocks (per the rules above).
+5. **Apply budgets** across all collected blocks — per-provider maxima from each provider's
+   budget, global from `globalMaxTokens`.
+6. **Write one trace row** for the dispatch.
+7. **Return** the kept blocks plus a list of diagnostics. `dispatch` **never throws** because
+   of a provider — provider faults become diagnostics.
+
+### Diagnostics — one bad provider never breaks the rest
+
+`dispatch` returns a `HubDiagnostic[]` alongside the kept blocks:
+
+```ts
+interface HubDiagnostic {
+  providerId: string;
+  hook: LifecycleHook;
+  error?: string;    // thrown-error message, or "malformed block(s) dropped"
+  timeout?: boolean; // true when the per-provider timeout fired
+  ms: number;        // how long the provider's invocation took
+}
+```
+
+- **Timeout** — a provider that exceeds its `budget.timeoutMs` is terminated by the worker host;
+  the Hub records `{ timeout: true }` and moves on. The other providers are unaffected, and the
+  whole dispatch stays fast (the timeout bounds it).
+- **Throw** — an exception in provider code becomes `{ error: message }`; no crash.
+- **Malformed** — invalid blocks are dropped and the provider gets `{ error: "malformed
+  block(s) dropped" }` while its valid blocks still flow through.
+
+### Provider module contract
+
+A provider module is authored as a **default-export object** whose members are the hook
+handlers — *not* a named `providers` export. Each handler is `async (ctx) => { blocks: [...] }`
+(it may also return a bare `ContextBlock[]`):
+
+```js
+// providers/memory.mjs
+export default {
+  async sessionSetup(ctx) {
+    return {
+      blocks: [
+        {
+          id: "recent-decisions",
+          title: "Project memory",
+          authority: "memory",
+          content: "…",
+          reason: "surfacing recent decisions for continuity",
+          priority: 10,
+          // tokenEstimate is recomputed host-side; providerId is forced.
+        },
+      ],
+    };
+  },
+  async beforePrompt(ctx) { /* … */ },
+};
+```
+
+This is why the worker's member-resolution has an explicit `providers` branch: for
+`exportKind: "providers"` the hook *group* is the **default export object itself**
+(`mod.default ?? mod`), and the hook name is one of its members. For `actions`/`routes` the
+group is still `mod[exportKind] ?? mod.default?.[exportKind]` — that path is unchanged, so the
+existing route/action dispatchers are unaffected.
+
+## The trace store
+
+`ContextTraceStore` records each dispatch as one JSON line, so you can reconstruct exactly what
+ambient context a session received and why blocks were dropped.
+
+- **Location:** `<stateDir>/session-context-trace/<sessionId>.jsonl` (the directory is created
+  lazily; the session id is sanitised to a safe basename). This mirrors the `bg-process` state
+  layout under the state dir.
+- **Entry shape** (`appendTrace(sessionId, entry)`):
+
+  ```ts
+  interface TraceEntry {
+    ts: number;          // epoch ms
+    hook: string;        // the dispatched hook
+    sessionId: string;
+    providers: {
+      id: string;        // provider id
+      ms: number;        // invocation duration
+      blocks: number;    // blocks KEPT after budgeting
+      omitted: number;   // budget-omitted + malformed-dropped count
+      error?: string;    // error / "timeout" / "malformed block(s) dropped"
+    }[];
+  }
+  ```
+- **Reads:** `readTrace(sessionId, limit?)` returns entries oldest→newest; `limit` keeps the
+  most recent N. Corrupt/partial lines are skipped rather than failing the read.
+- **Size cap:** the file is capped at **2 MB**. On append, if the file exceeds the cap it is
+  rewritten keeping only the newest lines that fit (drop-oldest), via a temp-file rename so a
+  reader never sees a half-written file.
+
+## Status / not-yet-wired
+
+This goal (G1.2) delivers **pure server core**: the modules above plus the `"providers"`
+`exportKind` branch on the Extension Host worker seam. It is intentionally **inert in
+production** — no session lifecycle path constructs or calls the `LifecycleHub`, so installing
+or authoring a provider changes nothing at runtime today.
+
+The wiring is sequenced in later goals:
+
+- **G1.3** constructs the Hub and calls `dispatch("sessionSetup", …)` during session setup,
+  and integrates kept blocks into the system prompt (`PromptParts.dynamicContext`).
+- **G1.4** adds the per-turn `beforePrompt` dispatch and the REST/provider-bridge surface.
+- Selector hooks (`beforeGoalCreate` / `beforeSessionSpawn`) are a separate, later goal (G8).
+
+Until then, treat this page as the contract those goals build against, and treat provider
+authoring as "validated and catalogued, but not yet executed."
+
+## See also
+
+- [Extension Host authoring guide](extension-host-authoring.md) — how to write a provider pack.
+- [Marketplace → Provider contributions](marketplace.md#provider-contributions-providersidyaml) —
+  the provider YAML schema, defaults, and clamps.
+- [Extension Host internals](extension-host-authoring.md) and `module-host-worker.ts` —
+  the confined-worker `ModuleHost.invoke` seam the Hub dispatches through.

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -435,10 +435,12 @@ Field rules and defaults:
   may run — defined now, enforced when dispatch lands.
 - **`runtime?`** / **`config?`** — optional pass-through fields for the future dispatch tier.
 
-**Providers are inert in this PR.** The loader validates them and the registry indexes them,
-but nothing reads `module`, runs a `hook`, or applies the `budget` yet — provider dispatch is a
-later goal (the lifecycle hub). Authoring a provider today gets you validation, catalogue
-listing, and activation toggles, and nothing else.
+**Authoring a provider has no runtime effect in production yet.** The loader validates them and
+the registry indexes them. The dispatch core — the `LifecycleHub` that runs a provider's `hook`
+on the worker tier and applies its `budget` — now exists ([docs/lifecycle-hub.md](lifecycle-hub.md)),
+but **no session path calls it yet** (session-setup wiring is G1.3, per-turn `beforePrompt` is
+G1.4). So today authoring a provider gets you validation, catalogue listing, and activation
+toggles, and nothing observable beyond that.
 
 #### Why providers are pack-scoped, *not* name-merged
 

--- a/src/server/agent/context-blocks.ts
+++ b/src/server/agent/context-blocks.ts
@@ -1,0 +1,89 @@
+export type ContextBlockAuthority = "memory" | "skill" | "tool" | "workflow" | "role" | "generic";
+
+export interface ContextBlock {
+	id: string;
+	title: string;
+	providerId: string;
+	authority: ContextBlockAuthority;
+	content: string;
+	reason: string;
+	priority: number;
+	tokenEstimate: number;
+}
+
+export function estimateTokens(s: string): number {
+	return Math.ceil(s.length / 4);
+}
+
+function attr(value: string): string {
+	return value.replace(/\r?\n/g, " ").replace(/"/g, "&quot;");
+}
+
+export function fenceBlock(b: ContextBlock): string {
+	return `<context-block id="${attr(b.id)}" source="${attr(b.title)}" authority="${attr(b.authority)}" reason="${attr(b.reason)}">\n${b.content}\n</context-block>`;
+}
+
+export function applyBudgets(
+	blocks: ContextBlock[],
+	perProviderMax: Map<string, number>,
+	globalMax: number,
+): { kept: ContextBlock[]; omitted: { block: ContextBlock; why: string }[] } {
+	const kept: ContextBlock[] = [];
+	const omitted: { block: ContextBlock; why: string }[] = [];
+	const usedByProvider = new Map<string, number>();
+	let globalUsed = 0;
+	let truncationConsumed = false;
+
+	const ordered = blocks
+		.map((block, index) => ({ block, index }))
+		.sort((a, b) => (b.block.priority - a.block.priority) || (a.index - b.index));
+
+	for (const { block } of ordered) {
+		if (truncationConsumed) {
+			omitted.push({ block, why: "after-truncation" });
+			continue;
+		}
+
+		const providerUsed = usedByProvider.get(block.providerId) ?? 0;
+		const providerMax = perProviderMax.get(block.providerId) ?? globalMax;
+		const globalHeadroom = Math.max(0, globalMax - globalUsed);
+		const providerHeadroom = Math.max(0, providerMax - providerUsed);
+		const headroom = Math.min(globalHeadroom, providerHeadroom);
+
+		if (block.tokenEstimate <= headroom) {
+			kept.push(block);
+			globalUsed += block.tokenEstimate;
+			usedByProvider.set(block.providerId, providerUsed + block.tokenEstimate);
+			continue;
+		}
+
+		truncationConsumed = true;
+		if (headroom < 32) {
+			omitted.push({ block, why: "truncated-below-min" });
+			continue;
+		}
+
+		const suffix = "…[truncated]";
+		const keepChars = headroom * 4 - suffix.length;
+		if (keepChars <= 0) {
+			omitted.push({ block, why: "below-min" });
+			continue;
+		}
+
+		const truncated: ContextBlock = {
+			...block,
+			content: block.content.slice(0, keepChars) + suffix,
+		};
+		truncated.tokenEstimate = estimateTokens(truncated.content);
+		if (truncated.tokenEstimate < 32) {
+			omitted.push({ block, why: "truncated-below-min" });
+			continue;
+		}
+
+		kept.push(truncated);
+		globalUsed += truncated.tokenEstimate;
+		usedByProvider.set(block.providerId, providerUsed + truncated.tokenEstimate);
+	}
+
+	return { kept, omitted };
+}

--- a/src/server/agent/context-trace-store.ts
+++ b/src/server/agent/context-trace-store.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export interface TraceProviderRow {
+	id: string;
+	ms: number;
+	blocks: number;
+	omitted: number;
+	error?: string;
+}
+
+export interface TraceEntry {
+	ts: number;
+	hook: string;
+	sessionId: string;
+	providers: TraceProviderRow[];
+}
+
+const MAX_TRACE_BYTES = 2 * 1024 * 1024;
+
+export class ContextTraceStore {
+	private readonly traceDir: string;
+
+	constructor(stateDir: string) {
+		this.traceDir = path.join(stateDir, "session-context-trace");
+	}
+
+	appendTrace(sessionId: string, entry: TraceEntry): void {
+		fs.mkdirSync(this.traceDir, { recursive: true });
+		const file = this.traceFile(sessionId);
+		fs.appendFileSync(file, JSON.stringify(entry) + "\n");
+		this.enforceCap(file);
+	}
+
+	readTrace(sessionId: string, limit?: number): TraceEntry[] {
+		const file = this.traceFile(sessionId);
+		if (!fs.existsSync(file)) return [];
+		const entries: TraceEntry[] = [];
+		for (const line of fs.readFileSync(file, "utf-8").split("\n")) {
+			if (!line.trim()) continue;
+			try {
+				entries.push(JSON.parse(line) as TraceEntry);
+			} catch {
+				// Skip corrupt partial lines rather than failing trace reads.
+			}
+		}
+		return typeof limit === "number" ? entries.slice(-Math.max(0, limit)) : entries;
+	}
+
+	private traceFile(sessionId: string): string {
+		return path.join(this.traceDir, safeBasename(sessionId) + ".jsonl");
+	}
+
+	private enforceCap(file: string): void {
+		let stat: fs.Stats;
+		try {
+			stat = fs.statSync(file);
+		} catch {
+			return;
+		}
+		if (stat.size <= MAX_TRACE_BYTES) return;
+
+		const lines = fs.readFileSync(file, "utf-8").split("\n").filter((line) => line.length > 0);
+		const kept: string[] = [];
+		let bytes = 0;
+		for (let i = lines.length - 1; i >= 0; i--) {
+			const line = lines[i] + "\n";
+			const lineBytes = Buffer.byteLength(line);
+			if (bytes + lineBytes > MAX_TRACE_BYTES) break;
+			kept.push(line);
+			bytes += lineBytes;
+		}
+		kept.reverse();
+
+		const tmp = `${file}.tmp-${process.pid}-${Date.now()}`;
+		fs.writeFileSync(tmp, kept.join(""));
+		fs.renameSync(tmp, file);
+	}
+}
+
+function safeBasename(sessionId: string): string {
+	const stripped = sessionId.replace(/\.\./g, "_").replace(/[\\/]/g, "_").replace(/[^a-zA-Z0-9._-]/g, "_");
+	return stripped || "session";
+}

--- a/src/server/agent/lifecycle-hub.ts
+++ b/src/server/agent/lifecycle-hub.ts
@@ -1,0 +1,171 @@
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { pathToFileURL } from "node:url";
+import { ActionError } from "../extension-host/action-dispatcher.js";
+import type { PackContributionRegistry } from "../extension-host/pack-contribution-registry.js";
+import { ModuleHost, type InvokeRequest } from "../extension-host/module-host-worker.js";
+import { applyBudgets, estimateTokens, type ContextBlock, type ContextBlockAuthority } from "./context-blocks.js";
+import { ContextTraceStore, type TraceProviderRow } from "./context-trace-store.js";
+
+export type LifecycleHook = "sessionSetup" | "beforePrompt" | "afterTurn" | "beforeCompact" | "sessionShutdown";
+
+export interface HookCtx {
+	sessionId: string;
+	projectId?: string;
+	scope: "project" | "global";
+	cwd: string;
+	goalId?: string;
+	roleName?: string;
+	prompt?: string;
+	turn?: { index: number };
+	budget: { maxTokens: number };
+	config: Record<string, unknown>;
+	runtime?: { baseUrl: string; headers: Record<string, string>; status: string };
+	gateway: { baseUrl: string; token: string };
+}
+
+export interface HubDiagnostic {
+	providerId: string;
+	hook: LifecycleHook;
+	error?: string;
+	timeout?: boolean;
+	ms: number;
+}
+
+interface ProviderTraceState {
+	id: string;
+	ms: number;
+	error?: string;
+	malformed: number;
+}
+
+const AUTHORITIES: ReadonlySet<ContextBlockAuthority> = new Set(["memory", "skill", "tool", "workflow", "role", "generic"]);
+
+export class LifecycleHub {
+	private readonly registry: PackContributionRegistry;
+	private readonly moduleHost: ModuleHost;
+	private readonly trace: ContextTraceStore;
+	private readonly gatewayInfo: () => { baseUrl: string; token: string };
+	private readonly globalMaxTokens: number;
+
+	constructor(deps: {
+		registry: PackContributionRegistry;
+		moduleHost: ModuleHost;
+		trace: ContextTraceStore;
+		gatewayInfo: () => { baseUrl: string; token: string };
+		globalMaxTokens?: number;
+	}) {
+		this.registry = deps.registry;
+		this.moduleHost = deps.moduleHost;
+		this.trace = deps.trace;
+		this.gatewayInfo = deps.gatewayInfo;
+		this.globalMaxTokens = deps.globalMaxTokens ?? 4_000;
+	}
+
+	async dispatch(
+		hook: LifecycleHook,
+		base: Omit<HookCtx, "budget" | "config" | "gateway">,
+	): Promise<{ blocks: ContextBlock[]; diagnostics: HubDiagnostic[] }> {
+		const providers = this.registry.listProviders(base.projectId).filter((p) => p.hooks.includes(hook));
+		const diagnostics: HubDiagnostic[] = [];
+		const collected: ContextBlock[] = [];
+		const traceStates = new Map<string, ProviderTraceState>();
+
+		for (const provider of providers) {
+			const hookCtx: HookCtx = {
+				...base,
+				config: provider.config ?? {},
+				budget: { maxTokens: provider.budget.maxTokens },
+				gateway: this.gatewayInfo(),
+			};
+			const url = pathToFileURL(path.resolve(path.dirname(provider.sourceFile), provider.module)).href;
+			const t0 = performance.now();
+			let ms = 0;
+			try {
+				const result = await this.moduleHost.invoke({
+					url,
+					packRoot: provider.packRoot,
+					epoch: 0,
+					exportKind: "providers",
+					member: hook,
+					ctx: hookCtx as unknown as InvokeRequest["ctx"],
+					arg: undefined,
+				}, provider.budget.timeoutMs);
+				ms = Math.round(performance.now() - t0);
+
+				const candidates = extractBlocks(result);
+				let malformed = 0;
+				for (const candidate of candidates) {
+					const block = validateBlock(candidate, provider.id);
+					if (!block) {
+						malformed++;
+						continue;
+					}
+					collected.push(block);
+				}
+				if (malformed > 0) {
+					diagnostics.push({ providerId: provider.id, hook, error: "malformed block(s) dropped", ms });
+				}
+				traceStates.set(provider.id, { id: provider.id, ms, malformed, error: malformed > 0 ? "malformed block(s) dropped" : undefined });
+			} catch (err) {
+				ms = Math.round(performance.now() - t0);
+				const message = err instanceof Error ? err.message : String(err);
+				if ((err instanceof ActionError && err.status === 504) || message.includes("timed out")) {
+					diagnostics.push({ providerId: provider.id, hook, timeout: true, ms });
+					traceStates.set(provider.id, { id: provider.id, ms, malformed: 0, error: "timeout" });
+				} else {
+					diagnostics.push({ providerId: provider.id, hook, error: message, ms });
+					traceStates.set(provider.id, { id: provider.id, ms, malformed: 0, error: message });
+				}
+			}
+		}
+
+		const perProviderMax = new Map(providers.map((p) => [p.id, p.budget.maxTokens]));
+		const budgeted = applyBudgets(collected, perProviderMax, this.globalMaxTokens);
+		const traceRows = providers.map((provider): TraceProviderRow => {
+			const state = traceStates.get(provider.id) ?? { id: provider.id, ms: 0, malformed: 0 };
+			return {
+				id: provider.id,
+				ms: state.ms,
+				blocks: budgeted.kept.filter((block) => block.providerId === provider.id).length,
+				omitted: budgeted.omitted.filter(({ block }) => block.providerId === provider.id).length + state.malformed,
+				...(state.error ? { error: state.error } : {}),
+			};
+		});
+		this.trace.appendTrace(base.sessionId, { ts: Date.now(), hook, sessionId: base.sessionId, providers: traceRows });
+
+		return { blocks: budgeted.kept, diagnostics };
+	}
+}
+
+function extractBlocks(result: unknown): unknown[] {
+	if (Array.isArray(result)) return result;
+	if (isPlainObject(result) && Array.isArray(result.blocks)) return result.blocks;
+	return [];
+}
+
+function validateBlock(candidate: unknown, providerId: string): ContextBlock | undefined {
+	if (!isPlainObject(candidate)) return undefined;
+	if (typeof candidate.id !== "string") return undefined;
+	if (typeof candidate.title !== "string") return undefined;
+	if (typeof candidate.content !== "string") return undefined;
+	if (typeof candidate.reason !== "string") return undefined;
+	if (typeof candidate.authority !== "string" || !AUTHORITIES.has(candidate.authority as ContextBlockAuthority)) return undefined;
+	if (typeof candidate.priority !== "number" || !Number.isFinite(candidate.priority)) return undefined;
+	return {
+		id: candidate.id,
+		title: candidate.title,
+		providerId,
+		authority: candidate.authority as ContextBlockAuthority,
+		content: candidate.content,
+		reason: candidate.reason,
+		priority: candidate.priority,
+		tokenEstimate: estimateTokens(candidate.content),
+	};
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	if (!value || typeof value !== "object") return false;
+	const proto = Object.getPrototypeOf(value);
+	return proto === Object.prototype || proto === null;
+}

--- a/src/server/extension-host/module-host-bootstrap.ts
+++ b/src/server/extension-host/module-host-bootstrap.ts
@@ -101,7 +101,7 @@ interface InvokeMessage {
 	kind: "invoke";
 	/** The epoch-cache-busted file URL the dispatcher resolved + validated. */
 	url: string;
-	exportKind: "actions" | "routes";
+	exportKind: "actions" | "routes" | "providers";
 	member: string;
 	/** Serializable handler context (identity + capability flags; NO live host). */
 	ctx: SerializableCtx;
@@ -458,7 +458,9 @@ async function handleInvoke(msg: InvokeMessage): Promise<void> {
 	try {
 		// ── (4) Dynamic-import the pack module through the module-import containment hook. ──
 		const mod = (await import(msg.url)) as Record<string, Record<string, unknown>>;
-		const group = mod[msg.exportKind] ?? (mod.default as Record<string, Record<string, unknown>> | undefined)?.[msg.exportKind];
+		const group = msg.exportKind === "providers"
+			? ((mod.default as Record<string, unknown> | undefined) ?? mod)
+			: (mod[msg.exportKind] ?? (mod.default as Record<string, Record<string, unknown>> | undefined)?.[msg.exportKind]);
 		// Export-map validation now lives HERE (moved off the parent so the parent never
 		// imports pack code): a module with no `actions`/`routes` export object is a 500,
 		// matching the status the dispatcher used to throw parent-side.

--- a/src/server/extension-host/module-host-worker.ts
+++ b/src/server/extension-host/module-host-worker.ts
@@ -62,7 +62,7 @@ export interface InvokeRequest {
 	/** Snapshot of the dispatcher epoch at resolution (carried for audit/debug). */
 	epoch: number;
 	/** Which export group on the pack module holds the member. */
-	exportKind: "actions" | "routes";
+	exportKind: "actions" | "routes" | "providers";
 	/** The member (action/route name) to invoke — pre-validated by the dispatcher. */
 	member: string;
 	/** The FULL handler context. Its `host` (a live ServerHostApi) stays in the

--- a/tests/context-blocks.test.ts
+++ b/tests/context-blocks.test.ts
@@ -1,0 +1,81 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { applyBudgets, estimateTokens, fenceBlock, type ContextBlock } from "../src/server/agent/context-blocks.ts";
+
+function block(id: string, providerId: string, priority: number, tokens: number): ContextBlock {
+	const content = "x".repeat(tokens * 4);
+	return {
+		id,
+		title: `Title ${id}`,
+		providerId,
+		authority: "memory",
+		content,
+		reason: "because",
+		priority,
+		tokenEstimate: estimateTokens(content),
+	};
+}
+
+describe("context blocks", () => {
+	it("fences content and escapes/strips attributes", () => {
+		const fenced = fenceBlock({
+			id: "id\"\n1",
+			title: "title\"\r\nsource",
+			providerId: "p1",
+			authority: "memory",
+			content: "line 1\nline 2",
+			reason: "why\"\nnow",
+			priority: 1,
+			tokenEstimate: 4,
+		});
+
+		assert.equal(
+			fenced,
+			`<context-block id="id&quot; 1" source="title&quot; source" authority="memory" reason="why&quot; now">\nline 1\nline 2\n</context-block>`,
+		);
+	});
+
+	it("keeps two fitting blocks and omits the third with a reason", () => {
+		const result = applyBudgets([
+			block("a", "p", 10, 5),
+			block("b", "p", 9, 5),
+			block("c", "p", 8, 5),
+		], new Map([["p", 100]]), 10);
+
+		assert.deepEqual(result.kept.map((b) => b.id), ["a", "b"]);
+		assert.equal(result.omitted.length, 1);
+		assert.equal(result.omitted[0].block.id, "c");
+		assert.ok(result.omitted[0].why.length > 0);
+	});
+
+	it("truncates the first over-budget block when enough headroom remains", () => {
+		const result = applyBudgets([block("large", "p", 10, 200)], new Map([["p", 80]]), 80);
+
+		assert.equal(result.omitted.length, 0);
+		assert.equal(result.kept.length, 1);
+		assert.equal(result.kept[0].id, "large");
+		assert.ok(result.kept[0].content.endsWith("…[truncated]"));
+		assert.ok(result.kept[0].tokenEstimate <= 80);
+	});
+
+	it("drops instead of truncating when the truncated remainder would be below 32 tokens", () => {
+		const result = applyBudgets([block("large", "p", 10, 200)], new Map([["p", 31]]), 31);
+
+		assert.equal(result.kept.length, 0);
+		assert.equal(result.omitted.length, 1);
+		assert.equal(result.omitted[0].block.id, "large");
+		assert.equal(result.omitted[0].why, "truncated-below-min");
+	});
+
+	it("global cap binds before remaining per-provider headroom", () => {
+		const result = applyBudgets([
+			block("first", "p1", 10, 30),
+			block("second", "p2", 9, 80),
+		], new Map([["p1", 100], ["p2", 200]]), 50);
+
+		assert.deepEqual(result.kept.map((b) => b.id), ["first"]);
+		assert.equal(result.omitted.length, 1);
+		assert.equal(result.omitted[0].block.id, "second");
+		assert.equal(result.omitted[0].why, "truncated-below-min");
+	});
+});

--- a/tests/context-trace-store.test.ts
+++ b/tests/context-trace-store.test.ts
@@ -1,0 +1,53 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { ContextTraceStore, type TraceEntry } from "../src/server/agent/context-trace-store.ts";
+
+function tmpDir(): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), "context-trace-store-"));
+}
+
+function entry(n: number, extra = ""): TraceEntry {
+	return {
+		ts: n,
+		hook: "sessionSetup",
+		sessionId: "sess-1",
+		providers: [{ id: `p${n}`, ms: n, blocks: 1, omitted: 0, error: extra || undefined }],
+	};
+}
+
+describe("ContextTraceStore", () => {
+	it("appends and reads traces in order with optional limits", () => {
+		const dir = tmpDir();
+		try {
+			const store = new ContextTraceStore(dir);
+			store.appendTrace("sess-1", entry(1));
+			store.appendTrace("sess-1", entry(2));
+
+			assert.deepEqual(store.readTrace("sess-1").map((e) => e.ts), [1, 2]);
+			assert.deepEqual(store.readTrace("sess-1", 1).map((e) => e.ts), [2]);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("caps trace files at 2 MB by dropping oldest lines", () => {
+		const dir = tmpDir();
+		try {
+			const store = new ContextTraceStore(dir);
+			const large = "x".repeat(12 * 1024);
+			for (let i = 0; i < 260; i++) store.appendTrace("sess-cap", entry(i, large));
+
+			const traceFile = path.join(dir, "session-context-trace", "sess-cap.jsonl");
+			assert.ok(fs.statSync(traceFile).size <= 2 * 1024 * 1024);
+			const rows = store.readTrace("sess-cap");
+			assert.ok(rows.length > 0);
+			assert.ok(rows[0].ts > 0, "oldest entries should be dropped");
+			assert.equal(rows.at(-1)?.ts, 259, "newest entry should be retained");
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/tests/lifecycle-hub.test.ts
+++ b/tests/lifecycle-hub.test.ts
@@ -1,0 +1,158 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { ContextTraceStore } from "../src/server/agent/context-trace-store.ts";
+import { LifecycleHub, type HookCtx } from "../src/server/agent/lifecycle-hub.ts";
+import type { ProviderContribution } from "../src/server/agent/pack-contributions.ts";
+import type { PackContributionRegistry } from "../src/server/extension-host/pack-contribution-registry.ts";
+import { ModuleHost } from "../src/server/extension-host/module-host-worker.ts";
+
+function tmpDir(): string {
+	return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "lifecycle-hub-")));
+}
+
+let seq = 0;
+function fixtureProvider(tmp: string, id: string, body: string, budget: { maxTokens?: number; timeoutMs?: number } = {}): ProviderContribution {
+	const file = path.join(tmp, `${id}-${seq++}.mjs`);
+	fs.writeFileSync(file, body);
+	return {
+		id,
+		kind: "memory",
+		module: path.basename(file),
+		hooks: ["sessionSetup"],
+		budget: { maxTokens: budget.maxTokens ?? 400, timeoutMs: budget.timeoutMs ?? 1_000 },
+		config: { enabled: true },
+		listName: id,
+		sourceFile: path.join(tmp, "pack.yaml"),
+		packRoot: tmp,
+	};
+}
+
+function registry(providers: ProviderContribution[]): PackContributionRegistry {
+	return { listProviders: () => providers } as unknown as PackContributionRegistry;
+}
+
+function base(tmp: string, sessionId = "sess-1"): Omit<HookCtx, "budget" | "config" | "gateway"> {
+	return { sessionId, projectId: "project-1", scope: "project", cwd: tmp };
+}
+
+function hub(tmp: string, providers: ProviderContribution[], moduleHost: ModuleHost, globalMaxTokens = 4_000): LifecycleHub {
+	return new LifecycleHub({
+		registry: registry(providers),
+		moduleHost,
+		trace: new ContextTraceStore(path.join(tmp, "state")),
+		gatewayInfo: () => ({ baseUrl: "https://gateway.test", token: "token-1" }),
+		globalMaxTokens,
+	});
+}
+
+describe("LifecycleHub", () => {
+	it("merges provider blocks, applies budgets, and forces provenance", async () => {
+		const tmp = tmpDir();
+		const moduleHost = new ModuleHost({ timeoutMs: 5_000 });
+		try {
+			const p1 = fixtureProvider(tmp, "p1", `export default { async sessionSetup(ctx) { return { blocks: [{ id: "a", title: "A", providerId: "spoof", authority: "memory", content: "alpha " + ctx.sessionId, reason: "r1", priority: 10, tokenEstimate: 999 }] }; } };`);
+			const p2 = fixtureProvider(tmp, "p2", `export default { async sessionSetup() { return { blocks: [{ id: "b", title: "B", authority: "skill", content: "beta", reason: "r2", priority: 9 }] }; } };`);
+
+			const result = await hub(tmp, [p1, p2], moduleHost).dispatch("sessionSetup", base(tmp));
+
+			assert.deepEqual(result.diagnostics, []);
+			assert.deepEqual(result.blocks.map((b) => b.id), ["a", "b"]);
+			assert.deepEqual(result.blocks.map((b) => b.providerId), ["p1", "p2"]);
+			assert.equal(result.blocks[0].tokenEstimate, Math.ceil(result.blocks[0].content.length / 4));
+		} finally {
+			moduleHost.dispose();
+			fs.rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("times out one provider without preventing later providers", async () => {
+		const tmp = tmpDir();
+		const moduleHost = new ModuleHost({ timeoutMs: 5_000 });
+		try {
+			const slow = fixtureProvider(tmp, "slow", `export default { async sessionSetup() { await new Promise((r) => setTimeout(r, 5000)); return { blocks: [{ id: "slow", title: "slow", authority: "memory", content: "late", reason: "r", priority: 10 }] }; } };`, { timeoutMs: 200 });
+			const fast = fixtureProvider(tmp, "fast", `export default { async sessionSetup() { return { blocks: [{ id: "fast", title: "fast", authority: "memory", content: "ok", reason: "r", priority: 9 }] }; } };`);
+
+			const t0 = performance.now();
+			const result = await hub(tmp, [slow, fast], moduleHost).dispatch("sessionSetup", base(tmp));
+			const elapsed = performance.now() - t0;
+
+			assert.ok(elapsed < 1_000, `dispatch should return promptly, got ${elapsed}ms`);
+			assert.equal(result.blocks.length, 1);
+			assert.equal(result.blocks[0].providerId, "fast");
+			assert.equal(result.diagnostics.length, 1);
+			assert.equal(result.diagnostics[0].providerId, "slow");
+			assert.equal(result.diagnostics[0].timeout, true);
+		} finally {
+			moduleHost.dispose();
+			fs.rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("reports thrown provider errors and continues", async () => {
+		const tmp = tmpDir();
+		const moduleHost = new ModuleHost({ timeoutMs: 5_000 });
+		try {
+			const bad = fixtureProvider(tmp, "bad", `export default { async sessionSetup() { throw new Error("boom"); } };`);
+			const good = fixtureProvider(tmp, "good", `export default { async sessionSetup() { return { blocks: [{ id: "good", title: "good", authority: "memory", content: "ok", reason: "r", priority: 1 }] }; } };`);
+
+			const result = await hub(tmp, [bad, good], moduleHost).dispatch("sessionSetup", base(tmp));
+
+			assert.equal(result.blocks.length, 1);
+			assert.equal(result.blocks[0].providerId, "good");
+			assert.equal(result.diagnostics.length, 1);
+			assert.equal(result.diagnostics[0].providerId, "bad");
+			assert.match(result.diagnostics[0].error ?? "", /boom/);
+		} finally {
+			moduleHost.dispose();
+			fs.rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("drops malformed blocks with a diagnostic while keeping valid blocks", async () => {
+		const tmp = tmpDir();
+		const moduleHost = new ModuleHost({ timeoutMs: 5_000 });
+		try {
+			const provider = fixtureProvider(tmp, "mixed", `export default { async sessionSetup() { return { blocks: [null, { id: 1, title: "bad", authority: "memory", content: "x", reason: "r", priority: 1 }, { id: "ok", title: "ok", authority: "generic", content: "kept", reason: "r", priority: 2 }] }; } };`);
+
+			const result = await hub(tmp, [provider], moduleHost).dispatch("sessionSetup", base(tmp));
+
+			assert.deepEqual(result.blocks.map((b) => b.id), ["ok"]);
+			assert.equal(result.diagnostics.length, 1);
+			assert.equal(result.diagnostics[0].providerId, "mixed");
+			assert.equal(result.diagnostics[0].error, "malformed block(s) dropped");
+		} finally {
+			moduleHost.dispose();
+			fs.rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("records one trace entry per dispatch", async () => {
+		const tmp = tmpDir();
+		const moduleHost = new ModuleHost({ timeoutMs: 5_000 });
+		try {
+			const trace = new ContextTraceStore(path.join(tmp, "state"));
+			const provider = fixtureProvider(tmp, "p1", `export default { async sessionSetup() { return { blocks: [{ id: "ok", title: "ok", authority: "memory", content: "kept", reason: "r", priority: 1 }] }; } };`);
+			const lifecycleHub = new LifecycleHub({
+				registry: registry([provider]),
+				moduleHost,
+				trace,
+				gatewayInfo: () => ({ baseUrl: "https://gateway.test", token: "token-1" }),
+			});
+
+			await lifecycleHub.dispatch("sessionSetup", base(tmp, "trace-sess"));
+			const rows = trace.readTrace("trace-sess");
+
+			assert.equal(rows.length, 1);
+			assert.equal(rows[0].hook, "sessionSetup");
+			assert.equal(rows[0].sessionId, "trace-sess");
+			assert.deepEqual(rows[0].providers.map((p) => ({ id: p.id, blocks: p.blocks, omitted: p.omitted })), [{ id: "p1", blocks: 1, omitted: 0 }]);
+		} finally {
+			moduleHost.dispose();
+			fs.rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+});

--- a/tests/remote-agent-outbox.spec.ts
+++ b/tests/remote-agent-outbox.spec.ts
@@ -35,8 +35,13 @@ test.beforeAll(() => {
 
 const PAGE = `file://${FIXTURE}`;
 async function ready(page: any) {
-	await page.goto(PAGE);
-	await page.waitForFunction(() => (window as any).__ready === true, null, { timeout: 10_000 });
+	// `waitUntil: "load"` guarantees the synchronous bundle <script> has executed
+	// (so `__ready` is already set) before we poll. The generous timeout absorbs
+	// CPU-saturation spikes during the concurrent full unit run, where a fixed 10s
+	// budget was occasionally exceeded on loaded machines (macOS/CI) even though the
+	// flag is set effectively immediately — see the flake fixed alongside G1.2.
+	await page.goto(PAGE, { waitUntil: "load" });
+	await page.waitForFunction(() => (window as any).__ready === true, null, { timeout: 30_000 });
 }
 
 test.describe("RemoteAgent send outbox (S2)", () => {


### PR DESCRIPTION
## Extension Platform — G1.2: Lifecycle Hub core + worker dispatch + budgets + trace

Adds a server-core `LifecycleHub` that resolves enabled providers (via G1.1's `PackContributionRegistry.listProviders`) and dispatches a named lifecycle hook to each on the Extension Host worker tier with a per-provider timeout, collects `ContextBlock[]`, applies budgets, fences content, and records a trace.

**Pure server core, inert in production** — nothing in any session path calls it yet (G1.3 wires `sessionSetup`, G1.4 wires per-turn `beforePrompt`).

### Stacked on G1.1 — merge order
This PR is **stacked on the G1.1 branch `goal/pack-schema-v2-d0a26761`** (it depends on G1.1's `ProviderContribution` loader + `listProviders`). Merge **G1.1 first**; this PR then rebases cleanly onto `master`. The G1.2-only commits are:
- `de81069` Add lifecycle hub core (3 new modules + minimal worker `exportKind` extension)
- `7f66f28` Document Lifecycle Hub core
- `6c9f610` Harden `remote-agent-outbox` ready() against a load-induced flake (drive-by)

### What's added
- `src/server/agent/context-blocks.ts` — `ContextBlock`, `estimateTokens` (ceil(len/4)), `fenceBlock`, `applyBudgets` (priority-desc, single-truncation-then-drop, 32-token floor, global cap binds before per-provider).
- `src/server/agent/lifecycle-hub.ts` — `LifecycleHub.dispatch(hook, base)`: per-provider worker invoke with timeout, validation + provenance-forcing + host-side token recompute, budgeting, one trace row/dispatch; per-provider timeout/throw/malformed → diagnostic, dispatch continues.
- `src/server/agent/context-trace-store.ts` — JSONL trace at `<stateDir>/session-context-trace/<sessionId>.jsonl`, 2 MB drop-oldest cap.
- Worker seam: `module-host-worker.ts` + `module-host-bootstrap.ts` `exportKind` union += `"providers"`; provider hook group resolves to the default-export object. Actions/routes resolution byte-identical.
- Docs: new `docs/lifecycle-hub.md`; updated `docs/extension-host-authoring.md` + `docs/marketplace.md`.

### Tests
- `npm run check` clean; `npm run test:unit` green.
- New: `tests/context-blocks.test.ts`, `tests/lifecycle-hub.test.ts` (real `ModuleHost` + fixture providers: merge/budget/provenance, timeout, throw, malformed-drop, trace), `tests/context-trace-store.test.ts`.
- Existing `ModuleHost` route/action dispatcher + isolation suites untouched and green (providers branch does not regress actions/routes).
- Full e2e suite green (retries on; pre-existing unrelated flakes recovered).
- Inert: `rg "LifecycleHub|lifecycle-hub" src/server/agent/session-*.ts` → no hits.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
