### PR TITLE
Decouple Sub-goals tab visibility from parentGoalId

### DIFF
--- a/docs/nested-goals.md
+++ b/docs/nested-goals.md
@@ -63,6 +63,17 @@ Enable QA Testing):
 
 Both render **only while the system Subgoals preference is ON**.
 
+These controls (and the parent-goal picker) live in a dedicated **Sub-goals**
+tab (`data-testid="goal-proposal-tab-subgoals"`). The tab's visibility — and the
+equivalent non-tabbed parent-picker row — is a **pure function of the system
+Subgoals preference**: present when the flag is ON (for both top-level proposals
+and child proposals that already carry a `parentGoalId`) and absent when it is
+OFF, regardless of `parentGoalId`. Earlier the visibility also keyed off
+`parentGoalId`; but a child proposal can only exist when the flag is on (child
+creation is server-gated), so `parentGoalId` always implied `subgoalsEnabled` —
+the extra clause was dead and was removed so tab visibility tracks the setting,
+not the proposal's parent/child relationship.
+
 The proposal modal also exposes **Workflow** and **Roles** tabs
 (`goal-proposal-tab-workflow` / `goal-proposal-tab-roles`) for authoring a
 goal-scoped inline workflow snapshot and per-goal role overrides (see

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -479,6 +479,19 @@ The E2E suite provides two harnesses. Choose based on what your test needs:
 - **`in-process-harness.js`** — Default for API-only tests (no browser, no MCP, no process-level behavior). Faster startup (~2s vs ~5-8s per worker). Exposes `sessionManager` on `GatewayInfo` for sandbox token testing. Import `test, expect` from `./in-process-harness.js`.
 - **`gateway-harness.js`** — Required when the test uses a `page` fixture (browser), needs MCP servers enabled, or tests process-level behavior (port allocation, auth bypass). Import `test, expect` from `./gateway-harness.js`.
 
+### Temp dirs used as project / pack / worktree roots
+
+Use `makeTmpDir(prefix)` from [`tests/helpers/tmp.ts`](../tests/helpers/tmp.ts)
+(not a raw `fs.mkdtempSync`) for any temp directory a test passes to production as
+a project, pack, or worktree root; use its `canonical(p)` to compare such paths.
+The helper `fs.realpathSync`-canonicalizes the directory. This matters because
+production canonicalizes project/pack roots, and on macOS `os.tmpdir()` resolves
+under the `/var → /private/var` symlink — a non-canonical temp root then trips
+`SymlinkProjectRootError` and produces false extension-host confinement
+"escapes". Canonicalizing in the helper keeps these tests green on macOS, Linux,
+and Windows alike. (This is distinct from the E2E scratch-space relocation under
+[Windows temp root](#windows-temp-root).)
+
 ### UI E2E page-object helpers
 
 Reusable helpers in `tests/e2e/ui/ui-helpers.ts`. Import from `./ui-helpers.js`:

--- a/src/app/proposal-panels.ts
+++ b/src/app/proposal-panels.ts
@@ -706,9 +706,9 @@ function renderSubgoalsToggle(config: GoalFormConfig): TemplateResult | string {
 	`;
 }
 
-/** Whether the dedicated Sub-goals tab should be shown for this proposal. */
+/** Whether the dedicated Sub-goals tab should be shown: it tracks only the system Subgoals (Experimental) preference. */
 function showSubgoalsTab(config: GoalFormConfig): boolean {
-	return !!(config.subgoalsEnabled || config.parentGoalId);
+	return !!config.subgoalsEnabled;
 }
 
 /** Walk parentGoalId links up to the top-level (root) goal of the tree. */
@@ -899,7 +899,7 @@ function renderGoalForm(config: GoalFormConfig) {
 					</div>
 				` : ""}
 			</div>
-			${!tabbed && (config.subgoalsEnabled || config.parentGoalId) ? renderParentPickerRow(config, lblCls) : ""}
+			${!tabbed && config.subgoalsEnabled ? renderParentPickerRow(config, lblCls) : ""}
 			${!tabbed ? renderSubgoalBreadcrumb(config) : ""}
 			${linkedProject ? html`
 				<div class="flex items-center gap-2 text-[11px] text-muted-foreground min-w-0">

--- a/tests/cold-restart-reprompt.test.ts
+++ b/tests/cold-restart-reprompt.test.ts
@@ -36,10 +36,10 @@
 import { afterEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
+import { makeTmpDir } from "./helpers/tmp.ts";
 
-const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cold-restart-reprompt-test-"));
+const tmpRoot = makeTmpDir("cold-restart-reprompt-test-");
 const stateDir = path.join(tmpRoot, "state");
 fs.mkdirSync(stateDir, { recursive: true });
 process.env.BOBBIT_DIR = tmpRoot;

--- a/tests/contract/fixtures/gateway.ts
+++ b/tests/contract/fixtures/gateway.ts
@@ -15,9 +15,9 @@
  * For tests that need HTTP/WS (most do), pass { startHttp: true }.
  */
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import WebSocket from "ws";
+import { makeTmpDir } from "../../helpers/tmp.ts";
 
 let serverModules: any = null;
 async function getServerModules() {
@@ -94,7 +94,7 @@ export async function createTestGateway(opts?: {
 	agentCliPath?: string;
 }): Promise<TestGateway> {
 	const startHttp = opts?.startHttp ?? true;
-	const dir = join(tmpdir(), `tier2-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	const dir = makeTmpDir(`tier2-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}-`);
 	mkdirSync(join(dir, "state"), { recursive: true });
 	writeFileSync(join(dir, "state", "projects.json"), "[]");
 	writeFileSync(join(dir, "state", "setup-complete"), "tier2\n");

--- a/tests/cost-tracker.test.ts
+++ b/tests/cost-tracker.test.ts
@@ -7,13 +7,13 @@
  * ESM hoists static imports, so we use dynamic import() instead.
  */
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { describe, it, beforeEach, after } from "node:test";
 import assert from "node:assert/strict";
+import { makeTmpDir } from "./helpers/tmp.ts";
 
 // Set BOBBIT_DIR before dynamically importing CostTracker
-const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cost-tracker-test-"));
+const tmpDir = makeTmpDir("cost-tracker-test-");
 process.env.BOBBIT_DIR = tmpDir;
 fs.mkdirSync(path.join(tmpDir, "state"), { recursive: true });
 

--- a/tests/e2e/mock-agent-core.mjs
+++ b/tests/e2e/mock-agent-core.mjs
@@ -419,6 +419,24 @@ export class MockAgentCore {
 			};
 		}
 
+		// Goal proposal carrying a parentGoalId (a child-goal proposal) — used by
+		// subgoals-experimental-toggle.spec.ts to assert the Sub-goals tab is a
+		// pure function of the system flag and does NOT appear merely because the
+		// proposal has a parent. Must precede the generic goal_proposal matcher
+		// (it contains the "GOAL_PROPOSAL" substring).
+		if (text.includes("GOAL_PROPOSAL_WITH_PARENT")) {
+			return {
+				tool: "propose_goal",
+				input: {
+					title: "Child Goal",
+					workflow: "general",
+					spec: "A child-goal proposal seeded with a parentGoalId.",
+					parentGoalId: "some-parent-id",
+				},
+				output: "Proposal submitted. Waiting for user response.",
+			};
+		}
+
 		if (lower.includes("goal_proposal") || lower.includes("goal proposal")) {
 			return {
 				tool: "propose_goal",

--- a/tests/e2e/ui/base-ref-settings.spec.ts
+++ b/tests/e2e/ui/base-ref-settings.spec.ts
@@ -40,7 +40,7 @@ function uniqueProjectDir(prefix: string): string {
 	return mkdtempSync(join(tmpdir(), `bobbit-baseref-ui-${prefix}-`));
 }
 
-async function createProject(name: string, rootPath: string, components?: Array<{ name: string; repo: string }>): Promise<string> {
+async function createProject(name: string, rootPath: string, components?: Array<{ name: string; repo: string }>): Promise<{ id: string; name: string }> {
 	const body: Record<string, unknown> = { name, rootPath };
 	if (components) body.components = components;
 	const resp = await apiFetch("/api/projects", {
@@ -49,11 +49,15 @@ async function createProject(name: string, rootPath: string, components?: Array<
 	});
 	expect(resp.ok, `project create failed: ${resp.status}`).toBe(true);
 	const proj = await resp.json();
-	return proj.id;
+	return { id: proj.id, name };
 }
 
-async function openBaseRefSettings(page: BrowserPage, projectId: string) {
-	await navigateToHash(page, `#/settings/${projectId}/general`);
+async function openBaseRefSettings(page: BrowserPage, project: { id: string; name: string }) {
+	await navigateToHash(page, `#/settings/${project.id}/general`);
+	// The base-ref input is shared by every project settings page. Wait for the
+	// project-specific heading so fills/saves cannot race against the previous
+	// settings render after only the hash has changed.
+	await expect(page.locator("h3").filter({ hasText: project.name }).first()).toBeVisible({ timeout: 10_000 });
 	const input = page.locator("[data-testid='base-ref-input']");
 	await expect(input).toBeVisible({ timeout: 10_000 });
 	return input;
@@ -67,6 +71,14 @@ async function saveBaseRef(page: BrowserPage, projectId: string, expectedStatus:
 	);
 	await page.locator("button").filter({ hasText: /^Save$/ }).first().click();
 	await savePromise;
+	await expect(page.locator("button").filter({ hasText: /^Saving\.\.\.$/ })).toHaveCount(0, { timeout: 10_000 });
+}
+
+async function expectBaseRefError(page: BrowserPage, expectedText: string) {
+	const errBox = page.locator("[data-testid='base-ref-error']");
+	await expect.poll(async () => (await errBox.textContent())?.trim() ?? "", { timeout: 10_000 })
+		.toContain(expectedText);
+	return errBox;
 }
 
 async function deleteProjects(projectIds: string[]): Promise<void> {
@@ -81,20 +93,20 @@ test.describe("Settings → Base Ref field", () => {
 		try {
 			const dir = uniqueProjectDir("happy");
 			gitInit(dir, { remoteRefs: ["develop"] });
-			const projectId = await createProject(`baseref-ui-happy-${Date.now()}`, dir);
-			projectIds.push(projectId);
+			const project = await createProject(`baseref-ui-happy-${Date.now()}`, dir);
+			projectIds.push(project.id);
 
 			await openApp(page);
-			const input = await openBaseRefSettings(page, projectId);
+			const input = await openBaseRefSettings(page, project);
 			await input.fill("origin/develop");
-			await saveBaseRef(page, projectId, 200);
+			await saveBaseRef(page, project.id, 200);
 
 			// Reload — value should persist.
 			await page.reload();
 			await expect(
 				page.locator("button").filter({ hasText: "Settings" }).first(),
 			).toBeVisible({ timeout: 15_000 });
-			const inputAfter = await openBaseRefSettings(page, projectId);
+			const inputAfter = await openBaseRefSettings(page, project);
 			await expect(inputAfter).toHaveValue("origin/develop");
 		} finally {
 			await deleteProjects(projectIds);
@@ -106,20 +118,20 @@ test.describe("Settings → Base Ref field", () => {
 		try {
 			const tagDir = uniqueProjectDir("tag");
 			gitInit(tagDir, { tags: ["v1.2.3"] });
-			const tagProjectId = await createProject(`baseref-ui-tag-${Date.now()}`, tagDir);
-			projectIds.push(tagProjectId);
+			const tagProject = await createProject(`baseref-ui-tag-${Date.now()}`, tagDir);
+			projectIds.push(tagProject.id);
 
 			const grammarDir = uniqueProjectDir("grammar");
 			gitInit(grammarDir);
-			const grammarProjectId = await createProject(`baseref-ui-grammar-${Date.now()}`, grammarDir);
-			projectIds.push(grammarProjectId);
+			const grammarProject = await createProject(`baseref-ui-grammar-${Date.now()}`, grammarDir);
+			projectIds.push(grammarProject.id);
 
 			const sandboxDir = uniqueProjectDir("sandbox");
 			gitInit(sandboxDir);
-			const sandboxProjectId = await createProject(`baseref-ui-sandbox-${Date.now()}`, sandboxDir);
-			projectIds.push(sandboxProjectId);
+			const sandboxProject = await createProject(`baseref-ui-sandbox-${Date.now()}`, sandboxDir);
+			projectIds.push(sandboxProject.id);
 			// Pre-set sandbox=docker via API so the UI only needs to drive base_ref.
-			const putRes = await apiFetch(`/api/projects/${sandboxProjectId}/config`, {
+			const putRes = await apiFetch(`/api/projects/${sandboxProject.id}/config`, {
 				method: "PUT",
 				body: JSON.stringify({ sandbox: "docker" }),
 			});
@@ -132,7 +144,7 @@ test.describe("Settings → Base Ref field", () => {
 			gitInit(repoA, { remoteRefs: ["develop"] });
 			gitInit(repoB); // missing origin/develop
 			gitInit(repoC); // missing origin/develop
-			const multiProjectId = await createProject(
+			const multiProject = await createProject(
 				`baseref-ui-multi-${Date.now()}`,
 				root,
 				[
@@ -141,45 +153,40 @@ test.describe("Settings → Base Ref field", () => {
 					{ name: "shared", repo: "shared" },
 				],
 			);
-			projectIds.push(multiProjectId);
+			projectIds.push(multiProject.id);
 
 			await openApp(page);
 
-			let input = await openBaseRefSettings(page, tagProjectId);
+			let input = await openBaseRefSettings(page, tagProject);
 			await input.fill("v1.2.3");
-			await saveBaseRef(page, tagProjectId, 400);
-			let errBox = page.locator("[data-testid='base-ref-error']");
-			await expect(errBox).toBeVisible({ timeout: 5_000 });
-			await expect(errBox).toContainText(
+			await saveBaseRef(page, tagProject.id, 400);
+			let errBox = await expectBaseRefError(
+				page,
 				"base_ref must be a branch ref, not a tag. Tags can't be used as git upstreams. Got: v1.2.3",
 			);
 
 			// Typing into the input clears the inline error immediately.
 			await input.fill("master");
-			await expect(errBox).toHaveCount(0);
+			await expect(input).toHaveValue("master");
+			await expect(errBox).toHaveCount(0, { timeout: 10_000 });
 
-			input = await openBaseRefSettings(page, grammarProjectId);
+			input = await openBaseRefSettings(page, grammarProject);
 			await input.fill("feature foo");
-			await saveBaseRef(page, grammarProjectId, 400);
-			errBox = page.locator("[data-testid='base-ref-error']");
-			await expect(errBox).toBeVisible({ timeout: 5_000 });
-			await expect(errBox).toContainText("base_ref must be a valid branch name. Got: feature foo");
+			await saveBaseRef(page, grammarProject.id, 400);
+			errBox = await expectBaseRefError(page, "base_ref must be a valid branch name. Got: feature foo");
 
-			input = await openBaseRefSettings(page, sandboxProjectId);
+			input = await openBaseRefSettings(page, sandboxProject);
 			await input.fill("master");
-			await saveBaseRef(page, sandboxProjectId, 400);
-			errBox = page.locator("[data-testid='base-ref-error']");
-			await expect(errBox).toBeVisible({ timeout: 5_000 });
-			await expect(errBox).toContainText(
+			await saveBaseRef(page, sandboxProject.id, 400);
+			errBox = await expectBaseRefError(
+				page,
 				"base_ref must be a remote ref (origin/...) for sandboxed projects. The container has separate ref visibility from the host. Got: master",
 			);
 
-			input = await openBaseRefSettings(page, multiProjectId);
+			input = await openBaseRefSettings(page, multiProject);
 			await input.fill("origin/develop");
-			await saveBaseRef(page, multiProjectId, 400);
-			errBox = page.locator("[data-testid='base-ref-error']");
-			await expect(errBox).toBeVisible({ timeout: 5_000 });
-			await expect(errBox).toContainText("base_ref 'origin/develop' is not present in 2 of 3 component repos");
+			await saveBaseRef(page, multiProject.id, 400);
+			errBox = await expectBaseRefError(page, "base_ref 'origin/develop' is not present in 2 of 3 component repos");
 			const bullets = errBox.locator("li");
 			await expect(bullets).toHaveCount(2);
 			await expect(bullets.filter({ hasText: "web" })).toContainText("ref not found");

--- a/tests/e2e/ui/dynamic-chat-tabs.spec.ts
+++ b/tests/e2e/ui/dynamic-chat-tabs.spec.ts
@@ -7,7 +7,7 @@
  * spawned app, live preview mount, reload, and transcript hydration.
  */
 import { mkdir, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
+import { basename, dirname } from "node:path";
 import { test, expect } from "../gateway-harness.js";
 import type { Page } from "@playwright/test";
 import { apiFetch, nonGitCwd } from "../e2e-setup.js";
@@ -437,23 +437,42 @@ async function expectOnlyLivePreviewTab(page: Page, errorPrefix: string): Promis
 	).toBe("preview:entry:inline.html");
 }
 
-async function expectLegacyPreviewTabsRemainSeparate(page: Page, expectedTexts: string[], errorPrefix: string): Promise<void> {
+async function expectLegacyPreviewTabsRemainSeparate(
+	page: Page,
+	expectedPreviews: Array<{ entry: string; text: string }>,
+	errorPrefix: string,
+): Promise<void> {
 	await expect.poll(async () => (await visiblePanelTabs(page))
 		.filter((tab) => tab.kind === "preview").length, {
 		timeout: 10_000,
 		message: `${errorPrefix}: legacy preview snapshots should remain available as one tab per filename`,
-	}).toBeGreaterThanOrEqual(expectedTexts.length);
+	}).toBeGreaterThanOrEqual(expectedPreviews.length);
 	const previewTabs = (await visiblePanelTabs(page)).filter((tab) => tab.kind === "preview");
 	expect(
 		previewTabs.map((tab) => tab.id),
 		`${errorPrefix}: legacy preview tabs collapsed incorrectly; tabs=${JSON.stringify(previewTabs)}`,
 	).not.toEqual(["preview:entry:inline.html"]);
-	const previewTabTexts = await collectAllPreviewTabTexts(page, errorPrefix);
-	for (const expectedText of expectedTexts) {
+	for (const expected of expectedPreviews) {
+		const tabId = `preview:entry:${encodeURIComponent(expected.entry)}`;
 		expect(
-			previewTabTexts.some((text) => text.includes(expectedText)),
-			`${errorPrefix}: no legacy preview tab restored ${expectedText}; texts=${JSON.stringify(previewTabTexts)}`,
+			previewTabs.some((tab) => tab.id === tabId),
+			`${errorPrefix}: expected legacy preview tab ${tabId}; tabs=${JSON.stringify(previewTabs)}`,
 		).toBe(true);
+		await clickTopLevelTabById(page, tabId, errorPrefix);
+		await expect.poll(
+			() => page.evaluate(() => (window as any).bobbitState?.activePanelTabId ?? ""),
+			{ timeout: 5_000, message: `${errorPrefix}: expected legacy preview tab ${tabId} to become active` },
+		).toBe(tabId);
+		// The previous iframe document remains readable briefly after a tab click;
+		// wait for the navigation target before asserting the frame body.
+		await expect(
+			page.locator(".goal-preview-panel iframe").first(),
+			`${errorPrefix}: iframe src should switch to ${expected.entry} before reading its body`,
+		).toHaveAttribute("src", new RegExp(escapeRegExp(encodeURIComponent(expected.entry))), { timeout: 10_000 });
+		await expect(
+			page.frameLocator(".goal-preview-panel iframe").locator("body"),
+			`${errorPrefix}: legacy preview tab ${tabId} should render ${expected.text}`,
+		).toContainText(expected.text, { timeout: 10_000 });
 	}
 }
 
@@ -475,24 +494,8 @@ async function openLegacyPreviewToolCardAndExpectMountHash(page: Page, ordinal: 
 	return contentHash;
 }
 
-async function collectAllPreviewTabTexts(page: Page, errorPrefix: string): Promise<string[]> {
-	const previewTabIds = (await visiblePanelTabs(page))
-		.filter((tab) => tab.kind === "preview" && PREVIEW_TAB_RE.test(tab.label))
-		.map((tab) => tab.id);
-	if (previewTabIds.length === 0) {
-		const labels = await visiblePanelTabLabels(page);
-		throw new Error(`${errorPrefix}: expected at least one preview tab; visible tabs were: ${labels.join(", ") || "<none>"}`);
-	}
-	const texts: string[] = [];
-	for (const id of previewTabIds) {
-		await clickTopLevelTabById(page, id, errorPrefix);
-		await expect.poll(() => rawPreviewBodyText(page), {
-			timeout: 10_000,
-			message: `${errorPrefix}: preview tab ${id} should render non-empty iframe content`,
-		}).not.toBe("");
-		texts.push(await rawPreviewBodyText(page));
-	}
-	return texts;
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 async function reloadAndNavigateToSession(page: Page, sessionId: string): Promise<void> {
@@ -588,6 +591,11 @@ test.describe("Dynamic chat tabs", () => {
 		const legacyInlineText = "Legacy V1 Inline Preview Content";
 		const legacyFileText = "Legacy V2 File Preview Content";
 		const legacyFilePath = testInfo.outputPath("legacy-v2-preview.html");
+		const legacyFileEntry = basename(legacyFilePath);
+		const expectedLegacyPreviews = [
+			{ entry: "inline.html", text: legacyInlineText },
+			{ entry: legacyFileEntry, text: legacyFileText },
+		];
 		await mkdir(dirname(legacyFilePath), { recursive: true });
 		await writeFile(legacyFilePath, previewHtmlForBodyText(legacyFileText), "utf8");
 
@@ -600,19 +608,18 @@ test.describe("Dynamic chat tabs", () => {
 		const firstHash = await openLegacyPreviewToolCardAndExpectMountHash(page, 0, legacyInlineText, "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG");
 		const secondHash = await openLegacyPreviewToolCardAndExpectMountHash(page, 1, legacyFileText, "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG");
 		expect(firstHash, "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG: fixtures should produce distinct legacy remount hashes").not.toBe(secondHash);
-		await expectLegacyPreviewTabsRemainSeparate(page, [legacyInlineText, legacyFileText], "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG");
+		await expectLegacyPreviewTabsRemainSeparate(page, expectedLegacyPreviews, "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG");
 
 		await reloadAndNavigateToSession(page, sessionId);
 		await refreshTranscriptFromGateway(page, 2, "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG: after reload");
 		await openLegacyPreviewToolCardAndExpectMountHash(page, 0, legacyInlineText, "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG: after reload");
 		await openLegacyPreviewToolCardAndExpectMountHash(page, 1, legacyFileText, "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG: after reload");
-		await expectLegacyPreviewTabsRemainSeparate(page, [legacyInlineText, legacyFileText], "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG: after reload");
-
+		await expectLegacyPreviewTabsRemainSeparate(page, expectedLegacyPreviews, "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG: after reload");
 		// Preview tabs currently have no per-tab close affordance. Switching away
 		// and back is the available cleanup/non-collapse path for legacy history.
 		await ensureChatInput(page, "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG: cleanup/no-collapse check");
 		await selectTopLevelTab(page, PREVIEW_TAB_RE, "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG: Preview should remain selectable for cleanup check");
-		await expectLegacyPreviewTabsRemainSeparate(page, [legacyInlineText, legacyFileText], "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG: cleanup/no-collapse check");
+		await expectLegacyPreviewTabsRemainSeparate(page, expectedLegacyPreviews, "DYNAMIC_CHAT_TABS_LEGACY_PREVIEW_BUG: cleanup/no-collapse check");
 	});
 
 	test("same-content historical v3 first-open collapses to the live preview tab", async ({ page, gateway }) => {

--- a/tests/e2e/ui/sidebar-keyboard-nav.spec.ts
+++ b/tests/e2e/ui/sidebar-keyboard-nav.spec.ts
@@ -124,10 +124,10 @@ async function waitForActiveNavId(page: Page, expected: string | null): Promise<
 }
 
 // Deterministic settle: gate on the concrete presence/absence of the specific
-// nav-id rows the caller cares about using Playwright's auto-retrying locator
-// matchers, then read the DOM order once. This replaces the rAF-spin stability
-// scan (waitForStableNavOrder) for the heavy archived-toggle/reload tests —
-// no per-frame polling, no 2-stable-frame requirement, no 10s spin budget.
+// nav-id rows the caller cares about, then require the full DOM order to be
+// stable before it is used as the expected keyboard cycle. This prevents the
+// archived-toggle tests from sampling an intermediate render and then walking
+// a stale order.
 async function waitForNavRows(
 	page: Page,
 	requiredIds: string[],
@@ -139,7 +139,7 @@ async function waitForNavRows(
 	for (const id of absentIds) {
 		await expect(page.locator(`[data-nav-id="${id}"]`), `${MARK}: nav row ${id} must be absent`).toHaveCount(0, { timeout: 10_000 });
 	}
-	return navIdsInDomOrder(page);
+	return waitForStableNavOrder(page, requiredIds, absentIds);
 }
 
 async function resetNavStart(page: Page): Promise<void> {

--- a/tests/e2e/ui/staff-inbox.spec.ts
+++ b/tests/e2e/ui/staff-inbox.spec.ts
@@ -80,6 +80,22 @@ test.describe("Staff inbox panel", () => {
 		return (JSON.parse(text) as { sizeMode?: string }).sizeMode || "";
 	}
 
+	async function dispatchCollapseShortcut(page: import("@playwright/test").Page): Promise<void> {
+		// The product shortcut is registered as ctrlOrMeta: Ctrl on Windows/Linux,
+		// Cmd on macOS. Dispatch both modifiers so this E2E exercises the same
+		// shortcut binding deterministically on every runner OS.
+		await page.evaluate(() => {
+			window.dispatchEvent(new KeyboardEvent("keydown", {
+				key: "]",
+				code: "BracketRight",
+				ctrlKey: true,
+				metaKey: true,
+				bubbles: true,
+				cancelable: true,
+			}));
+		});
+	}
+
 	type Box = { x: number; y: number; width: number; height: number };
 
 	function formatBox(box: Box): string {
@@ -248,10 +264,10 @@ test.describe("Staff inbox panel", () => {
 		await tab.click();
 		await expect(page.locator("inbox-panel")).toBeVisible({ timeout: 5_000 });
 
-		// Press Ctrl+] to collapse. The keyboard handler persists the shared
-		// side-panel size mode to the server workspace.
+		// Press the registered collapse shortcut. The keyboard handler persists the
+		// shared side-panel size mode to the server workspace.
 		await page.waitForFunction(() => document.body.dataset.shortcutsReady === "1");
-		await page.keyboard.press("Control+]");
+		await dispatchCollapseShortcut(page);
 		await expect.poll(() => workspaceSizeMode(sid), { timeout: 10_000 }).toBe("collapsed");
 
 		// Reload — the panel respects the server-persisted collapse state on rehydrate.

--- a/tests/e2e/ui/subgoals-experimental-toggle.spec.ts
+++ b/tests/e2e/ui/subgoals-experimental-toggle.spec.ts
@@ -269,4 +269,51 @@ test.describe("Subgoals (Experimental) toggle", () => {
 		// Restore the harness default for subsequent specs/tests.
 		await resetFlag(true);
 	});
+
+	test("Sub-goals tab is visible for a top-level proposal when subgoals are ON", async ({ page }) => {
+		// Locks the decoupling: with the system flag ON, the tab appears for a
+		// top-level proposal (no parentGoalId). Tab visibility tracks the flag —
+		// it does NOT require a parent. This passes on the unmodified tree too;
+		// the assertion exists to prevent a regression of the ON path.
+		await resetFlag(true);
+		await openApp(page);
+		await createSessionViaUI(page);
+
+		await sendMessage(page, "Please create a GOAL_PROPOSAL for testing");
+
+		const titleInput = page.locator("input[placeholder='Goal title']").first();
+		await expect(titleInput).toBeVisible({ timeout: 20_000 });
+		await expect(titleInput).toHaveValue("E2E Test Goal", { timeout: 15_000 });
+
+		await expect(
+			page.locator("[data-testid='goal-proposal-tab-subgoals']"),
+		).toBeVisible({ timeout: 10_000 });
+	});
+
+	test("Sub-goals tab is absent when subgoals are OFF with parentGoalId set", async ({ page }) => {
+		// RED repro: tab visibility must be a pure function of the system flag.
+		// With the flag OFF, a child-goal proposal (parentGoalId set) must NOT
+		// render the Sub-goals tab. On the unmodified tree showSubgoalsTab returns
+		// `!!(config.subgoalsEnabled || config.parentGoalId)`, so the truthy
+		// parentGoalId forces the tab on even though the flag is OFF — this
+		// assertion FAILS (expected 0, received 1) until the `|| parentGoalId`
+		// clause is removed.
+		await unsetFlag();
+		await openApp(page);
+		await createSessionViaUI(page);
+
+		await sendMessage(page, "Please create a GOAL_PROPOSAL_WITH_PARENT for testing");
+
+		const titleInput = page.locator("input[placeholder='Goal title']").first();
+		await expect(titleInput).toBeVisible({ timeout: 20_000 });
+		await expect(titleInput).toHaveValue("Child Goal", { timeout: 15_000 });
+
+		// Flag OFF ⇒ no Sub-goals tab, regardless of parentGoalId.
+		await expect(
+			page.locator("[data-testid='goal-proposal-tab-subgoals']"),
+		).toHaveCount(0);
+
+		// Restore the harness default for subsequent specs/tests.
+		await resetFlag(true);
+	});
 });

--- a/tests/e2e/ui/ui-helpers.ts
+++ b/tests/e2e/ui/ui-helpers.ts
@@ -23,13 +23,42 @@ export async function openApp(page: Page): Promise<void> {
 	).toBeVisible({ timeout: 20_000 });
 }
 
+export async function activeSessionId(page: Page): Promise<string | null> {
+	return page.evaluate(() => {
+		const selected = (window as any).bobbitState?.selectedSessionId;
+		if (typeof selected === "string" && selected) return selected;
+		const match = window.location.hash.match(/^#\/session\/([\w-]+)/);
+		return match?.[1] ?? null;
+	});
+}
+
 /**
- * Click "New session" button in the sidebar and wait for the chat textarea.
+ * Click "New session" button in the sidebar and wait for the newly-created
+ * session to become the active route/session, not just for the already-visible
+ * chat textarea from the previous session.
  */
-export async function createSessionViaUI(page: Page): Promise<void> {
+export async function createSessionViaUI(page: Page): Promise<string> {
+	const previousSessionId = await activeSessionId(page);
 	// In multi-project mode the button title is "New session in <project>"
 	await page.locator("button[title^='New session']").first().click();
-	await expect(page.locator("textarea").first()).toBeVisible({ timeout: 20_000 });
+	const handle = await page.waitForFunction(
+		(previous: string | null) => {
+			const selected = (window as any).bobbitState?.selectedSessionId;
+			if (typeof selected !== "string" || !selected || selected === previous) return null;
+			const routeSession = window.location.hash.match(/^#\/session\/([\w-]+)/)?.[1] ?? null;
+			if (routeSession !== selected) return null;
+			const textarea = Array.from(document.querySelectorAll("textarea"))
+				.find((el) => {
+					const rect = el.getBoundingClientRect();
+					const style = window.getComputedStyle(el);
+					return rect.width > 0 && rect.height > 0 && style.visibility !== "hidden" && style.display !== "none";
+				});
+			return textarea ? selected : null;
+		},
+		previousSessionId,
+		{ timeout: 20_000 },
+	);
+	return await handle.jsonValue() as string;
 }
 
 /**

--- a/tests/extension-host-action-dispatcher.test.ts
+++ b/tests/extension-host-action-dispatcher.test.ts
@@ -18,7 +18,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import {
 	ActionDispatcher,
@@ -27,6 +26,7 @@ import {
 	type ActionHandlerCtx,
 	type ActionToolLocationResolver,
 } from "../src/server/extension-host/action-dispatcher.ts";
+import { makeTmpDir } from "./helpers/tmp.ts";
 
 let tmp: string;
 
@@ -66,7 +66,7 @@ const ctx = (): ActionHandlerCtx => ({
 });
 
 before(() => {
-	tmp = fs.mkdtempSync(path.join(os.tmpdir(), "ext-host-dispatch-"));
+	tmp = makeTmpDir("ext-host-dispatch-");
 });
 after(() => {
 	try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ }

--- a/tests/extension-host-isolation-config-invariant.test.ts
+++ b/tests/extension-host-isolation-config-invariant.test.ts
@@ -25,7 +25,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import {
 	ActionDispatcher,
@@ -34,6 +33,7 @@ import {
 	type ActionToolLocationResolver,
 	type ActionDispatcherOptions,
 } from "../src/server/extension-host/action-dispatcher.ts";
+import { makeTmpDir } from "./helpers/tmp.ts";
 
 let tmp: string;
 
@@ -84,7 +84,7 @@ const BYPASS_ENV_KEYS = [
 ];
 
 before(() => {
-	tmp = fs.mkdtempSync(path.join(os.tmpdir(), "ext-host-iso-cfg-"));
+	tmp = makeTmpDir("ext-host-iso-cfg-");
 });
 after(() => {
 	try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ }

--- a/tests/extension-host-module-isolation.test.ts
+++ b/tests/extension-host-module-isolation.test.ts
@@ -30,11 +30,11 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { ModuleHost, type InvokeRequest } from "../src/server/extension-host/module-host-worker.ts";
 import { ActionError, type ActionHandlerCtx } from "../src/server/extension-host/action-dispatcher.ts";
+import { makeTmpDir } from "./helpers/tmp.ts";
 
 let tmp: string;
 let seq = 0;
@@ -80,7 +80,7 @@ function trySymlink(target: string, linkPath: string): boolean {
 }
 
 before(() => {
-	tmp = fs.mkdtempSync(path.join(os.tmpdir(), "ext-host-iso-"));
+	tmp = makeTmpDir("ext-host-iso-");
 });
 after(() => {
 	try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ }

--- a/tests/extension-host-route-dispatcher.test.ts
+++ b/tests/extension-host-route-dispatcher.test.ts
@@ -16,7 +16,6 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import {
 	RouteDispatcher,
@@ -26,6 +25,7 @@ import {
 import { ActionError } from "../src/server/extension-host/action-dispatcher.ts";
 import type { PackContributions } from "../src/server/agent/pack-contributions.ts";
 import type { PackContributionResolver } from "../src/server/extension-host/pack-contribution-registry.ts";
+import { makeTmpDir } from "./helpers/tmp.ts";
 
 let tmp: string;
 
@@ -45,7 +45,7 @@ function writeRoutesModule(root: string, packName: string, rel: string, src: str
 	return { modulePath: abs, packRoot };
 }
 
-before(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), "ext-host-route-")); });
+before(() => { tmp = makeTmpDir("ext-host-route-"); });
 after(() => { try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ } });
 
 describe("RouteDispatcher — resolution + happy path (pack-level module)", () => {

--- a/tests/helpers/tmp.ts
+++ b/tests/helpers/tmp.ts
@@ -1,0 +1,16 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+/**
+ * Create a temp dir and return its canonical (realpath'd) path.
+ * Portable across macOS (/var -> /private/var symlink), Linux, and Windows.
+ */
+export function makeTmpDir(prefix: string): string {
+	return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+}
+
+/** Canonicalize an existing path (no-op when already canonical). */
+export function canonical(p: string): string {
+	return fs.realpathSync(p);
+}

--- a/tests/inbox-nudger.test.ts
+++ b/tests/inbox-nudger.test.ts
@@ -9,12 +9,12 @@
  * Pinned by docs/design/staff-inbox.md §3.3, §5, §13.
  */
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { describe, it, after, mock } from "node:test";
 import assert from "node:assert/strict";
+import { makeTmpDir } from "./helpers/tmp.ts";
 
-const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "inbox-nudger-"));
+const tmpRoot = makeTmpDir("inbox-nudger-");
 
 const { InboxStore } = await import("../src/server/agent/inbox-store.ts");
 const { InboxNudger } = await import("../src/server/agent/inbox-nudger.ts");
@@ -55,6 +55,7 @@ function makeHarness(opts: {
 	const staffManager = {
 		listStaff: () => [staff],
 		getStaff: (id: string) => (id === staffId ? staff : undefined),
+		updateStaff: mock.fn((id: string, patch: Record<string, unknown>) => { if (id === staffId) Object.assign(staff, patch); return staff; }),
 	};
 
 	const session: FakeSession = {

--- a/tests/inbox-store.test.ts
+++ b/tests/inbox-store.test.ts
@@ -8,12 +8,12 @@
  * the real store against tmp directories rooted under os.tmpdir().
  */
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { describe, it, after } from "node:test";
 import assert from "node:assert/strict";
+import { makeTmpDir } from "./helpers/tmp.ts";
 
-const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "inbox-store-"));
+const tmpRoot = makeTmpDir("inbox-store-");
 
 const { InboxStore } = await import("../src/server/agent/inbox-store.ts");
 type InboxEntry = import("../src/server/agent/inbox-store.ts").InboxEntry;

--- a/tests/multi-project.test.ts
+++ b/tests/multi-project.test.ts
@@ -7,13 +7,13 @@
  * (the new LanceDB-backed stack).
  */
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { describe, it, before, after, beforeEach } from "node:test";
 import assert from "node:assert/strict";
+import { makeTmpDir } from "./helpers/tmp.ts";
 
 // Set BOBBIT_DIR before any dynamic imports
-const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "multi-proj-test-"));
+const tmpRoot = makeTmpDir("multi-proj-test-");
 process.env.BOBBIT_DIR = tmpRoot;
 fs.mkdirSync(path.join(tmpRoot, "state"), { recursive: true });
 fs.mkdirSync(path.join(tmpRoot, "config"), { recursive: true });

--- a/tests/preview-content-route.test.ts
+++ b/tests/preview-content-route.test.ts
@@ -8,11 +8,11 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import { handlePreviewRequest, pickEntry } from "../src/server/preview/content-route.ts";
 import { CookieStore, COOKIE_NAME } from "../src/server/auth/cookie.ts";
+import { makeTmpDir } from "./helpers/tmp.ts";
 
 // We need `mountDir(sid)` from preview/mount.ts to point inside our temp dir.
 // The stub uses `bobbitStateDir()` which reads BOBBIT_STATE_DIR env. Set it
@@ -21,7 +21,7 @@ let workspaceRoot: string;
 const SID = "11111111-2222-3333-4444-555555555555";
 
 before(() => {
-	workspaceRoot = mkdtempSync(path.join(tmpdir(), "bobbit-cr-"));
+	workspaceRoot = makeTmpDir("bobbit-cr-");
 	// mountDir(sid) resolves to <bobbitStateDir()>/preview/<sid>; redirect
 	// the resolver to a temp dir via BOBBIT_DIR.
 	process.env.BOBBIT_DIR = workspaceRoot;

--- a/tests/preview-path-guard.test.ts
+++ b/tests/preview-path-guard.test.ts
@@ -5,9 +5,9 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import { resolveAssetPath } from "../src/server/preview/path-guard.ts";
+import { makeTmpDir } from "./helpers/tmp.ts";
 
 let baseDir: string;
 let outsideFile: string;
@@ -15,7 +15,7 @@ let workspaceRoot: string;
 let supportsSymlink = true;
 
 before(() => {
-	workspaceRoot = mkdtempSync(path.join(tmpdir(), "bobbit-pg-"));
+	workspaceRoot = makeTmpDir("bobbit-pg-");
 	baseDir = path.join(workspaceRoot, "preview");
 	mkdirSync(baseDir, { recursive: true });
 	mkdirSync(path.join(baseDir, "gifs"), { recursive: true });

--- a/tests/project-config-store-native-yaml.test.ts
+++ b/tests/project-config-store-native-yaml.test.ts
@@ -15,9 +15,9 @@ import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
-import os from "node:os";
 import yaml from "yaml";
 import { ProjectConfigStore } from "../src/server/agent/project-config-store.js";
+import { makeTmpDir } from "./helpers/tmp.ts";
 
 let tmpDir: string;
 
@@ -31,7 +31,7 @@ function writeYaml(content: string) {
 
 describe("ProjectConfigStore — native-YAML migrated fields", () => {
 	beforeEach(() => {
-		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pcs-native-"));
+		tmpDir = makeTmpDir("pcs-native-");
 	});
 	afterEach(() => {
 		fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/tests/project-registry-order.test.ts
+++ b/tests/project-registry-order.test.ts
@@ -4,6 +4,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { makeTmpDir } from "./helpers/tmp.ts";
+
 import {
   ProjectOrderError,
   ProjectRegistry,
@@ -12,7 +14,7 @@ import {
 } from "../src/server/agent/project-registry.js";
 
 function makeStateDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-project-order-state-"));
+  return makeTmpDir("bobbit-project-order-state-");
 }
 
 function cleanup(dir: string): void {
@@ -112,7 +114,7 @@ test("ProjectRegistry register and registerProvisional append after a custom ord
   const stateDir = makeStateDir();
   const roots: string[] = [];
   const makeRoot = (name: string) => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), `bobbit-project-order-${name}-`));
+    const root = makeTmpDir(`bobbit-project-order-${name}-`);
     roots.push(root);
     return root;
   };

--- a/tests/proposal-helpers.test.ts
+++ b/tests/proposal-helpers.test.ts
@@ -49,7 +49,7 @@ const fakeDraftStore = new Map<string, unknown>();
 		if (call.method === "DELETE") {
 			const type = u.searchParams.get("type");
 			fakeDraftStore.delete(`${sid}|${type}`);
-			return new Response("", { status: 204 });
+			return new Response(null, { status: 204 });
 		}
 		const type = u.searchParams.get("type");
 		const data = fakeDraftStore.get(`${sid}|${type}`);

--- a/tests/search/flex-store.spec.ts
+++ b/tests/search/flex-store.spec.ts
@@ -13,7 +13,6 @@
  */
 import { test, expect } from "@playwright/test";
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import {
 	FlexSearchStore,
@@ -21,9 +20,10 @@ import {
 	recencyMultiplier,
 	type FlexDoc,
 } from "../../src/server/search/flex-store.ts";
+import { makeTmpDir } from "../helpers/tmp.ts";
 
 function tmp(prefix = "flex-store-"): string {
-	return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	return makeTmpDir(prefix);
 }
 
 function doc(overrides: Partial<FlexDoc> & { id: string; text: string }): FlexDoc {

--- a/tests/session-manager-force-abort-grace.test.ts
+++ b/tests/session-manager-force-abort-grace.test.ts
@@ -11,10 +11,10 @@
 import { afterEach, describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
+import { makeTmpDir } from "./helpers/tmp.ts";
 
-const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "force-abort-grace-test-"));
+const tmpRoot = makeTmpDir("force-abort-grace-test-");
 process.env.BOBBIT_DIR = tmpRoot;
 
 const { SessionManager } = await import("../src/server/agent/session-manager.ts");

--- a/tests/session-manager-no-precreate.test.ts
+++ b/tests/session-manager-no-precreate.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
+import { makeTmpDir } from "./helpers/tmp.ts";
 
-const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "session-no-precreate-"));
+const tmpRoot = makeTmpDir("session-no-precreate-");
 process.env.BOBBIT_DIR = tmpRoot;
 
 const { SessionManager } = await import("../src/server/agent/session-manager.ts");

--- a/tests/session-store.test.ts
+++ b/tests/session-store.test.ts
@@ -5,11 +5,11 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
+import { makeTmpDir } from "./helpers/tmp.ts";
 
 // Point BOBBIT_DIR to a temp directory before importing SessionStore
-const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "session-store-test-"));
+const tmpRoot = makeTmpDir("session-store-test-");
 const stateDir = path.join(tmpRoot, "state");
 fs.mkdirSync(stateDir, { recursive: true });
 process.env.BOBBIT_DIR = tmpRoot;

--- a/tests/worktree-pool.test.ts
+++ b/tests/worktree-pool.test.ts
@@ -14,12 +14,12 @@ import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
-import os from "node:os";
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 import { WorktreePool, isPoolBranch } from "../src/server/agent/worktree-pool.ts";
 import type { Component } from "../src/server/agent/project-config-store.ts";
+import { makeTmpDir } from "./helpers/tmp.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -27,7 +27,7 @@ const __dirname = path.dirname(__filename);
 const execFile = promisify(execFileCb);
 
 async function makeRepo(): Promise<string> {
-	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-pool-test-"));
+	const dir = makeTmpDir("bobbit-pool-test-");
 	const repo = path.join(dir, "repo");
 	fs.mkdirSync(repo, { recursive: true });
 	await execFile("git", ["init", "--initial-branch=master"], { cwd: repo });


### PR DESCRIPTION
## Summary

Fixes the reported bug: the goal-proposal **Sub-goals** tab visibility was coupled to `parentGoalId`. Tab visibility is now a pure function of the system **Subgoals (Experimental)** preference.

### Core fix (`src/app/proposal-panels.ts`)
- `showSubgoalsTab` now returns `!!config.subgoalsEnabled` (was `!!(config.subgoalsEnabled || config.parentGoalId)`).
- The non-tabbed parent-picker row condition (~:902) simplified the same way for consistency.
- **Decision recorded:** a child proposal can only exist when the system flag is on (server-gated), so `parentGoalId` implied `subgoalsEnabled` — the `|| parentGoalId` clause was dead. Removing it makes both surfaces track the system preference only. Behavior: flag ON ⇒ tab present for top-level *and* child proposals; flag OFF ⇒ tab absent regardless of `parentGoalId`.

### Tests (RED→GREEN)
- New mock-agent trigger `GOAL_PROPOSAL_WITH_PARENT` + two assertions in `tests/e2e/ui/subgoals-experimental-toggle.spec.ts`: tab visible for a top-level proposal with the flag ON (locks the decoupling), and tab **absent** with the flag OFF even when `parentGoalId` is set (the reproducing case — RED on the unmodified tree, GREEN after the fix).

### Pre-existing flaky/OS-specific test fixes (requested separately by the maintainer)
These were unrelated to the bug but blocked the full suite on macOS; all **test-infra only**, no further production changes:
- **OS-agnostic temp roots:** new `tests/helpers/tmp.ts` (`makeTmpDir`/`canonical` via `fs.realpathSync`) + ~20 tests refactored, so macOS `$TMPDIR` (`/var`→`/private/var` symlink) no longer trips `SymlinkProjectRootError` / false extension-host pack-root confinement escapes. No-op on Linux/Windows.
- `staff-inbox.spec.ts` Ctrl+]: test pressed literal `Control+]`; the app shortcut uses `ctrlOrMeta` (Cmd on macOS) — now dispatches both modifiers (cross-platform).
- `dynamic-chat-tabs.spec.ts`: helper sampled stale iframe content before `src` switched — now asserts exact tab ids and waits for the iframe to switch.
- Flaky stabilization with deterministic waits (no sleeps): `createSessionViaUI`/`activeSessionId` in `ui-helpers.ts` now wait for the new active session; `base-ref-settings` and `sidebar-keyboard-nav` wait on real render/order conditions.

### Verification
- `npm run check` clean · `npm run test:unit` green (3965 pass, 0 fail) · `npm run test:e2e` green (previously failing/flaky specs pass repeatedly, 15/15 each).
- Workflow gates passed: issue-analysis, reproducing-test, implementation (build + type-check + repro + unit + e2e + LLM reviews), documentation.

### Docs
- `docs/nested-goals.md` — tab/parent-picker visibility now tracks the system preference only.
- `docs/testing-strategy.md` — note to use `tests/helpers/tmp.ts::makeTmpDir` for project/pack/worktree-root temp dirs (macOS symlink rationale).

### Non-goals (untouched)
System-preference default (stays OFF), `subgoalsAllowed` submission semantics, per-goal nesting controls, server-side nesting gates.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
