### PR TITLE
Fix inherited MCP policy labels

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1301,7 +1301,7 @@ Resolution order is unchanged (first non-null wins):
 
 MCP server groups behave identically to built-in tool groups: with no override anywhere, they fall through to the system `allow` fallback. `defaults/tool-group-policies.yaml` deliberately ships **no** `mcp__*` entries.
 
-Why no MCP-specific builtin denials: the Tools page renders the cascaded effective policy but cannot show its origin, so a builtin `mcp__<server>: never` would display as "Allow (default)" while silently blocking every agent call — the UI must be honest. A user who wants to block a server does so explicitly via the Tools page (or `.bobbit/config/tool-group-policies.yaml`), and the dropdown then reflects reality.
+Why no MCP-specific builtin denials: MCP servers should have the same baseline as other tool groups, and any restriction should come from an explicit user/project or role decision. The Tools page now mirrors the MCP cascade for display: a sub-namespace row with no stored `mcp__<server>__<sub>` key shows an explicit parent `mcp__<server>` policy as inherited while keeping the sub-key unset.
 
 Disruptive servers (e.g. headed Chromium from `@playwright/mcp`) are opted out at the **role** layer instead — see `defaults/roles/qa-tester.yaml`, which sets `toolPolicies: { mcp__playwright: never }`. Roles that need the tool inherit the `allow` default; roles that shouldn't have it block it locally.
 

--- a/docs/mcp-meta-tools.md
+++ b/docs/mcp-meta-tools.md
@@ -230,6 +230,11 @@ clearing the select sends `policy: null`, removes that key, and returns the row
 to the inherited parent display. Flat servers keep using only `mcp__<server>`
 and do not show a synthetic inherited sub-policy.
 
+Access-tab effective policy and source hints use the same MCP keys for MCP
+operation and meta-tool rows before falling back to generic display group
+labels: `mcp__<server>__<sub>` first, then `mcp__<server>` (and role-level
+`mcp__` wildcard), then labels such as `MCP: <server>`.
+
 The page reads the structured `/api/mcp-servers` payload directly: each
 operation entry carries `subNamespace?` + `op`, so the UI groups by
 sub-namespace without re-parsing names. A small client-side fallback

--- a/docs/mcp-meta-tools.md
+++ b/docs/mcp-meta-tools.md
@@ -221,6 +221,15 @@ Both the server and tool selects route through `updateGroupPolicy(key, value)`
 top-level tool count visible to the user matches the model's view, with the
 option to drill into any server when needed.
 
+Sub-namespace rows mirror the runtime MCP policy cascade for display: when
+`mcp__<server>` is explicitly set and `mcp__<server>__<sub>` is unset, the row
+shows the inherited parent policy (for example, `Never (inherited from mcp__gr)`)
+while the select value remains empty. Empty still means "no stored
+sub-key". Selecting Allow, Ask, or Never writes an explicit sub-namespace key;
+clearing the select sends `policy: null`, removes that key, and returns the row
+to the inherited parent display. Flat servers keep using only `mcp__<server>`
+and do not show a synthetic inherited sub-policy.
+
 The page reads the structured `/api/mcp-servers` payload directly: each
 operation entry carries `subNamespace?` + `op`, so the UI groups by
 sub-namespace without re-parsing names. A small client-side fallback

--- a/docs/qa-testing.md
+++ b/docs/qa-testing.md
@@ -189,7 +189,7 @@ QA agents drive browsers **only** through the native `browser_*` tools (`browser
 
 ### What's blocked
 
-The `mcp__playwright__*` tool group (from `@playwright/mcp`) is **denied by default for every role** via `defaults/tool-group-policies.yaml` (`mcp__playwright: never`). The `qa-tester` role additionally sets the same policy in its own `toolPolicies` as a belt-and-braces block. Attempting to call `mcp__playwright__browser_navigate` (or any sibling) returns a policy-denied error without launching the MCP server.
+QA agents should use the native `browser_*` tools, not the `mcp__playwright__*` tool group from `@playwright/mcp`. Defaults ship no `mcp__*` denials in `defaults/tool-group-policies.yaml`; instead, the `qa-tester` role blocks MCP Playwright at the role layer with `toolPolicies: { mcp__playwright: never }`. In a `qa-tester` session, attempting to call `mcp__playwright__browser_navigate` (or any sibling) returns a policy-denied error without launching the MCP server.
 
 ### Why
 
@@ -200,15 +200,19 @@ The `mcp__playwright__*` tool group (from `@playwright/mcp`) is **denied by defa
 
 ### Overriding (if you actually want MCP Playwright)
 
-If a project legitimately needs `mcp__playwright__*` (e.g. driving a real headed browser for manual inspection), allow it at the project layer:
+If a project legitimately needs `mcp__playwright__*` (e.g. driving a real headed browser for manual inspection), allow it for the role that will use it:
 
-1. Create `.bobbit/config/tool-group-policies.yaml` with:
+1. Override that role's `toolPolicies` with:
    ```yaml
    mcp__playwright: allow
    ```
-2. Optionally override `.mcp.json` in the project to drop `--headless` (e.g. `.bobbit/config/mcp.json` or `.claude/.mcp.json` — see [internals.md — MCP servers](internals.md#mcp-servers) for precedence).
+2. Optionally add a project-layer default in `.bobbit/config/tool-group-policies.yaml` for roles that do not already set their own MCP Playwright policy:
+   ```yaml
+   mcp__playwright: allow
+   ```
+3. Optionally override `.mcp.json` in the project to drop `--headless` (e.g. `.bobbit/config/mcp.json` or `.claude/.mcp.json` — see [internals.md — MCP servers](internals.md#mcp-servers) for precedence).
 
-Per-role overrides in a role YAML's `toolPolicies` also work for scoping the allowance to a single role.
+Role-level `toolPolicies` win over project group defaults, so a project-layer `allow` alone does not override the `qa-tester` role's `never` policy.
 
 ## Budget enforcement
 

--- a/src/app/tool-manager-page.ts
+++ b/src/app/tool-manager-page.ts
@@ -240,17 +240,67 @@ const POLICY_LABELS: Record<string, string> = {
 	"never": "Never",
 };
 
+interface McpPolicyKeys {
+	group: string;
+	tool: string;
+}
+
+function mcpPolicyKeysLocal(toolName: string): McpPolicyKeys | undefined {
+	if (!toolName) return undefined;
+	if (toolName.startsWith("mcp__")) {
+		const remainder = toolName.slice(5);
+		const serverSep = remainder.indexOf("__");
+		if (serverSep <= 0) return undefined;
+		const server = remainder.slice(0, serverSep);
+		const afterServer = remainder.slice(serverSep + 2);
+		if (!server || !afterServer) return undefined;
+		const subSep = afterServer.indexOf("__");
+		const group = `mcp__${server}`;
+		const sub = subSep === -1 ? "" : afterServer.slice(0, subSep);
+		return sub ? { group, tool: `mcp__${server}__${sub}` } : { group, tool: group };
+	}
+	if (toolName.startsWith("mcp_") && !toolName.startsWith("mcp__")) {
+		const rest = toolName.slice(4);
+		if (!rest) return undefined;
+		const subSep = rest.indexOf("__");
+		if (subSep === -1) {
+			const group = `mcp__${rest}`;
+			return { group, tool: group };
+		}
+		const server = rest.slice(0, subSep);
+		const sub = rest.slice(subSep + 2);
+		if (!server || !sub) {
+			const group = `mcp__${rest}`;
+			return { group, tool: group };
+		}
+		return { group: `mcp__${server}`, tool: `mcp__${server}__${sub}` };
+	}
+	return undefined;
+}
+
+function mcpGroupPolicyDefault(toolName: string, toolGroup: string): { policy: string; source: string } {
+	const mcpKeys = mcpPolicyKeysLocal(toolName);
+	if (mcpKeys) {
+		if (mcpKeys.tool !== mcpKeys.group && groupPolicies[mcpKeys.tool]) {
+			return { policy: groupPolicies[mcpKeys.tool], source: mcpKeys.tool };
+		}
+		if (groupPolicies[mcpKeys.group]) return { policy: groupPolicies[mcpKeys.group], source: mcpKeys.group };
+	}
+	if (groupPolicies[toolGroup]) return { policy: groupPolicies[toolGroup], source: toolGroup };
+	return { policy: "allow", source: "system default" };
+}
+
 /** Resolve effective policy for a tool using the layered resolution order */
 function resolveEffectivePolicy(toolName: string, toolGroup: string, roleToolPolicies?: Record<string, string>): string {
 	// 1. Role + tool override
 	if (roleToolPolicies?.[toolName]) return roleToolPolicies[toolName];
-	// 2. Role + group override (check MCP server prefix and display group name)
+	// 2. Role + group override (MCP tool > MCP server > MCP wildcard > display group)
+	const mcpKeys = mcpPolicyKeysLocal(toolName);
 	if (roleToolPolicies) {
-		// Check MCP-style prefix (e.g. "mcp__playwright" for "mcp__playwright__click")
-		const parts = toolName.split("__");
-		if (parts.length >= 3) {
-			const serverPrefix = parts.slice(0, 2).join("__");
-			if (roleToolPolicies[serverPrefix]) return roleToolPolicies[serverPrefix];
+		if (mcpKeys) {
+			if (mcpKeys.tool !== mcpKeys.group && roleToolPolicies[mcpKeys.tool]) return roleToolPolicies[mcpKeys.tool];
+			if (roleToolPolicies[mcpKeys.group]) return roleToolPolicies[mcpKeys.group];
+			if (roleToolPolicies["mcp__"]) return roleToolPolicies["mcp__"];
 		}
 		// Check display group name (e.g. "Browser")
 		if (roleToolPolicies[toolGroup]) return roleToolPolicies[toolGroup];
@@ -259,7 +309,8 @@ function resolveEffectivePolicy(toolName: string, toolGroup: string, roleToolPol
 	const tool = tools.find(t => t.name === toolName);
 	if (tool?.grantPolicy) return tool.grantPolicy;
 	// 4. Group default
-	if (groupPolicies[toolGroup]) return groupPolicies[toolGroup];
+	const groupDefault = mcpGroupPolicyDefault(toolName, toolGroup);
+	if (groupDefault.source !== "system default") return groupDefault.policy;
 	// 5. System fallback
 	return "allow";
 }
@@ -267,17 +318,19 @@ function resolveEffectivePolicy(toolName: string, toolGroup: string, roleToolPol
 /** Describe where a resolved policy came from */
 function policySource(toolName: string, toolGroup: string, roleToolPolicies?: Record<string, string>): string {
 	if (roleToolPolicies?.[toolName]) return "tool override";
+	const mcpKeys = mcpPolicyKeysLocal(toolName);
 	if (roleToolPolicies) {
-		const parts = toolName.split("__");
-		if (parts.length >= 3) {
-			const serverPrefix = parts.slice(0, 2).join("__");
-			if (roleToolPolicies[serverPrefix]) return `from ${serverPrefix}`;
+		if (mcpKeys) {
+			if (mcpKeys.tool !== mcpKeys.group && roleToolPolicies[mcpKeys.tool]) return `from ${mcpKeys.tool} role override`;
+			if (roleToolPolicies[mcpKeys.group]) return `from ${mcpKeys.group} role override`;
+			if (roleToolPolicies["mcp__"]) return "from mcp__ role override";
 		}
 		if (roleToolPolicies[toolGroup]) return `from ${toolGroup} role override`;
 	}
 	const tool = tools.find(t => t.name === toolName);
 	if (tool?.grantPolicy) return "tool default";
-	if (groupPolicies[toolGroup]) return "group default";
+	const groupDefault = mcpGroupPolicyDefault(toolName, toolGroup);
+	if (groupDefault.source !== "system default") return `from ${groupDefault.source} group default`;
 	return "system default";
 }
 
@@ -541,7 +594,7 @@ async function handleMcpPolicyChange(key: string, value: string): Promise<void> 
 	renderApp();
 }
 
-function renderMcpPolicySelect(key: string, current: string, testid: string): TemplateResult {
+function renderMcpPolicySelect(key: string, current: string, testid: string, emptyLabel = "Allow (default)"): TemplateResult {
 	return html`
 		<select class="tool-group-select"
 			data-testid=${testid}
@@ -553,7 +606,7 @@ function renderMcpPolicySelect(key: string, current: string, testid: string): Te
 				const val = (e.target as HTMLSelectElement).value;
 				await handleMcpPolicyChange(key, val);
 			}}>
-			<option value="" ?selected=${!current}>Allow (default)</option>
+			<option value="" ?selected=${!current}>${emptyLabel}</option>
 			<option value="allow" ?selected=${current === "allow"}>Allow</option>
 			<option value="ask" ?selected=${current === "ask"}>Ask</option>
 			<option value="never" ?selected=${current === "never"}>Never</option>
@@ -624,6 +677,10 @@ function renderMcpSection(): TemplateResult {
 													const hasSub = sub.length > 0;
 													const toolPolicyKey = hasSub ? `mcp__${server.name}__${sub}` : `mcp__${server.name}`;
 													const toolPolicy = groupPolicies[toolPolicyKey] || "";
+													const inheritedPolicy = hasSub && !toolPolicy ? groupPolicies[serverPolicyKey] : "";
+													const emptyPolicyLabel = inheritedPolicy
+														? `${POLICY_LABELS[inheritedPolicy] || inheritedPolicy} (inherited from ${serverPolicyKey})`
+														: "Allow (default)";
 													const toolKey = `${server.name}::${sub}`;
 													const toolExpanded = expandedMcpTools.has(toolKey);
 													const toolLabel = hasSub ? sub : server.name;
@@ -639,7 +696,7 @@ function renderMcpSection(): TemplateResult {
 																<span class="tool-group-name">${toolLabel}</span>
 																<span class="tool-group-count">${ops.length} operation${ops.length !== 1 ? "s" : ""}</span>
 																<span class="tool-group-policy-label">Tool Policy:</span>
-																${renderMcpPolicySelect(toolPolicyKey, toolPolicy, "mcp-tool-policy")}
+																${renderMcpPolicySelect(toolPolicyKey, toolPolicy, "mcp-tool-policy", emptyPolicyLabel)}
 															</div>
 															${toolExpanded
 																? html`<div class="mcp-server-ops" data-testid="mcp-server-ops" style="padding-left: 1.5rem;">
@@ -868,8 +925,11 @@ function renderAccessTab(): TemplateResult {
 
 	const toolName = selectedTool.name;
 	const toolGroup = selectedTool.group || "Other";
-	const groupDefault = groupPolicies[toolGroup] || "allow";
-	const groupDefaultLabel = POLICY_LABELS[groupDefault] || groupDefault;
+	const groupDefault = mcpGroupPolicyDefault(toolName, toolGroup);
+	const groupDefaultLabel = POLICY_LABELS[groupDefault.policy] || groupDefault.policy;
+	const groupDefaultHint = groupDefault.source === "system default"
+		? `${groupDefaultLabel} [system default]`
+		: `${groupDefaultLabel} [from ${groupDefault.source}]`;
 
 	return html`
 		<!-- Default Grant Policy -->
@@ -882,7 +942,7 @@ function renderAccessTab(): TemplateResult {
 					editGrantPolicy,
 					(val) => { editGrantPolicy = val; renderApp(); },
 					POLICY_OPTIONS,
-					!editGrantPolicy ? `${groupDefaultLabel} [from group]` : undefined,
+					!editGrantPolicy ? groupDefaultHint : undefined,
 				)}
 			</div>
 		</div>

--- a/tests/ui-fixtures/tool-manager-mcp-section.spec.ts
+++ b/tests/ui-fixtures/tool-manager-mcp-section.spec.ts
@@ -167,6 +167,50 @@ test.describe("Tools page → MCP section fixture", () => {
 		});
 	});
 
+	test("shows inherited parent MCP policy for unset sub-namespace rows without storing override", async ({ page }) => {
+		await setupMcp(page, GATEWAY_SERVERS, { "mcp__gr": "never" });
+
+		const section = page.locator('[data-testid="mcp-section"]');
+		const gr = section.locator('[data-server-name="gr"]');
+		await expect(gr.locator('[data-testid="mcp-server-policy"]').first()).toHaveValue("never");
+		await gr.locator('[data-testid="mcp-server-toggle"]').click();
+
+		const jiraPolicy = gr.locator('[data-testid="mcp-tool-row"][data-tool-name="jira"] [data-testid="mcp-tool-policy"]');
+		await expect(jiraPolicy).toHaveValue("");
+		await expect(jiraPolicy.locator("option:checked")).toHaveText(/Never.*inherited/i);
+
+		await jiraPolicy.selectOption("ask");
+		await expect.poll(async () => (await fetchLog(page)).filter(e => e.method === "PUT").at(-1)).toEqual({
+			url: "/api/tool-group-policies/mcp__gr__jira",
+			method: "PUT",
+			body: { policy: "ask" },
+		});
+		await expect(jiraPolicy).toHaveValue("ask");
+		await expect(jiraPolicy.locator("option:checked")).toHaveText("Ask");
+
+		await jiraPolicy.selectOption("");
+		await expect.poll(async () => (await fetchLog(page)).filter(e => e.method === "PUT").at(-1)).toEqual({
+			url: "/api/tool-group-policies/mcp__gr__jira",
+			method: "PUT",
+			body: { policy: null },
+		});
+		await expect(jiraPolicy).toHaveValue("");
+		await expect(jiraPolicy.locator("option:checked")).toHaveText(/Never.*inherited/i);
+
+		await reloadWithMcp(page, GATEWAY_SERVERS, { "mcp__gr": "never" });
+		const reloadedGr = page.locator('[data-testid="mcp-section"] [data-server-name="gr"]');
+		await reloadedGr.locator('[data-testid="mcp-server-toggle"]').click();
+		const reloadedJiraPolicy = reloadedGr.locator('[data-testid="mcp-tool-row"][data-tool-name="jira"] [data-testid="mcp-tool-policy"]');
+		await expect(reloadedJiraPolicy).toHaveValue("");
+		await expect(reloadedJiraPolicy.locator("option:checked")).toHaveText(/Never.*inherited/i);
+
+		const playwright = page.locator('[data-testid="mcp-section"] [data-server-name="playwright"]');
+		await playwright.locator('[data-testid="mcp-server-toggle"]').click();
+		const flatPolicy = playwright.locator('[data-testid="mcp-tool-row"][data-tool-name="playwright"] [data-testid="mcp-tool-policy"]');
+		await expect(flatPolicy).toHaveValue("");
+		await expect(flatPolicy.locator("option:checked")).toHaveText("Allow (default)");
+	});
+
 	test("loads default and persisted policies, and reset persists empty", async ({ page }) => {
 		await setupMcp(page, GATEWAY_SERVERS);
 		let gr = page.locator('[data-testid="mcp-section"] [data-server-name="gr"]');


### PR DESCRIPTION
## Summary
- Show inherited parent MCP server policy on unset sub-namespace rows while preserving empty/no-override storage semantics.
- Resolve MCP Access tab effective policy hints through MCP policy keys before display group labels.
- Add regression coverage and update MCP policy documentation.

## Validation
- npm run check
- npx playwright test --config tests/playwright.config.ts tests/ui-fixtures/tool-manager-mcp-section.spec.ts

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)