### PR TITLE
Expand Edit Goal modal

### DIFF
--- a/src/app/dialogs.ts
+++ b/src/app/dialogs.ts
@@ -1359,6 +1359,7 @@ function showGoalEditDialog(existingGoal: Goal): void {
 	let specValue = existingGoal.spec;
 	let stateValue: GoalState = existingGoal.state;
 	let saving = false;
+	let titleFocused = false;
 
 	let cwdDropdownOpenEdit = false;
 	let cwdHighlightIndexEdit = -1;
@@ -1394,29 +1395,33 @@ function showGoalEditDialog(existingGoal: Goal): void {
 			Dialog({
 				isOpen: true,
 				onClose: cleanup,
-				width: "min(540px, 92vw)",
-				height: "auto",
-				className: "max-h-[90vh]",
+				width: "min(1100px, 96vw)",
+				height: "min(900px, 92vh)",
+				className: "max-h-[92vh]",
 				backdropClassName: "bg-black/50 backdrop-blur-sm",
 				children: html`
-					${DialogContent({
-						className: "overflow-y-auto",
-						children: html`
+					<div class="flex flex-col h-full min-h-0" data-testid="goal-edit-dialog">
+						<div class="shrink-0 px-6 pt-6 pb-2">
 							${DialogHeader({ title: "Edit Goal" })}
-							<div class="mt-4 flex flex-col gap-4">
-								<div>
-									<label class="text-xs text-muted-foreground mb-1 block">Title</label>
-									${Input({
-										type: "text",
-										value: titleValue,
-										onInput: (e: Event) => { titleValue = (e.target as HTMLInputElement).value; renderDialog(); },
-										onKeyDown: (e: KeyboardEvent) => {
+						</div>
+						<div class="flex-1 min-h-0 px-6 pb-4 overflow-y-auto">
+							<div class="flex min-h-full flex-col gap-4">
+								<div class="shrink-0">
+									<label class="text-xs text-muted-foreground mb-1 block" for="goal-edit-title-input">Title</label>
+									<input
+										id="goal-edit-title-input"
+										data-testid="goal-edit-title-input"
+										type="text"
+										class="w-full h-10 px-3 py-2 text-sm rounded-md border border-border bg-background text-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+										.value=${titleValue}
+										@input=${(e: Event) => { titleValue = (e.target as HTMLInputElement).value; renderDialog(); }}
+										@keydown=${(e: KeyboardEvent) => {
 											if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); doSave(); }
 											if (e.key === "Escape") cleanup();
-										},
-									})}
+										}}
+									/>
 								</div>
-								<div>
+								<div class="shrink-0">
 									<label class="text-xs text-muted-foreground mb-1 block">Working Directory</label>
 									${cwdCombobox({
 										value: cwdValue,
@@ -1429,9 +1434,9 @@ function showGoalEditDialog(existingGoal: Goal): void {
 										onHighlight: (i) => { cwdHighlightIndexEdit = i; },
 									})}
 								</div>
-								<div>
+								<div class="shrink-0">
 									<label class="text-xs text-muted-foreground mb-1 block">State</label>
-									<div class="flex gap-1.5">
+									<div class="flex flex-wrap gap-1.5">
 										${stateOptions.map((opt) => html`
 											<button
 												class="px-3 py-1.5 text-xs rounded-md border transition-colors
@@ -1444,43 +1449,48 @@ function showGoalEditDialog(existingGoal: Goal): void {
 										`)}
 									</div>
 								</div>
-								<div>
-									<label class="text-xs text-muted-foreground mb-1 block">Goal Spec (Markdown)</label>
+								<div class="flex flex-1 min-h-[320px] flex-col">
+									<label class="text-xs text-muted-foreground mb-1 block" for="goal-edit-spec-textarea">Goal Spec (Markdown)</label>
 									<textarea
-										class="w-full min-h-[120px] max-h-[300px] p-3 text-sm font-mono rounded-md border border-border bg-background text-foreground resize-y focus:outline-none focus:ring-1 focus:ring-ring"
+										id="goal-edit-spec-textarea"
+										data-testid="goal-edit-spec-textarea"
+										class="w-full flex-1 min-h-[320px] p-3 text-sm font-mono rounded-md border border-border bg-background text-foreground resize-y focus:outline-none focus:ring-1 focus:ring-ring"
 										placeholder="Describe the goal, acceptance criteria, constraints..."
 										.value=${specValue}
 										@input=${(e: Event) => { specValue = (e.target as HTMLTextAreaElement).value; }}
 									></textarea>
-									<p class="text-[10px] text-muted-foreground mt-1">Injected into the context window of all sessions under this goal.</p>
+									<p class="shrink-0 text-[10px] text-muted-foreground mt-1">Injected into the context window of all sessions under this goal.</p>
 								</div>
-	
 							</div>
-						`,
-					})}
-					${DialogFooter({
-						className: "px-6 pb-4",
-						children: html`
+						</div>
+						<div class="shrink-0 px-6 py-4 border-t border-border">
 							<div class="flex gap-2 justify-end">
-								${Button({ variant: "ghost", onClick: cleanup, children: "Cancel" })}
+								${Button({
+									variant: "ghost",
+									onClick: cleanup,
+									children: html`<span data-testid="goal-edit-cancel-button">Cancel</span>`,
+								})}
 								${Button({
 									variant: "default",
 									onClick: doSave,
 									disabled: !titleValue.trim() || saving,
-									children: saving ? "Saving…" : "Save",
+									children: html`<span data-testid="goal-edit-save-button">${saving ? "Saving…" : "Save"}</span>`,
 								})}
 							</div>
-						`,
-					})}
+						</div>
+					</div>
 				`,
 			}),
 			container,
 		);
 
-		requestAnimationFrame(() => {
-			const input = container.querySelector("input");
-			if (input) { input.focus(); input.select(); }
-		});
+		if (!titleFocused) {
+			titleFocused = true;
+			requestAnimationFrame(() => {
+				const input = container.querySelector<HTMLInputElement>("[data-testid='goal-edit-title-input']");
+				if (input) { input.focus(); input.select(); }
+			});
+		}
 	};
 
 	renderDialog();

--- a/tests/e2e/ui/goal-edit-modal.spec.ts
+++ b/tests/e2e/ui/goal-edit-modal.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from "../gateway-harness.js";
+import { apiFetch, createGoal, deleteGoal } from "../e2e-setup.js";
+import { openApp, navigateToGoalDashboard } from "./ui-helpers.js";
+
+async function openGoalEditDialog(page: import("@playwright/test").Page) {
+	const editButton = page.locator('[data-testid="goal-dashboard"] button[title="Edit goal"]').first();
+	await expect(editButton).toBeVisible({ timeout: 15_000 });
+	await editButton.click();
+
+	const dialog = page.getByTestId("goal-edit-dialog");
+	await expect(dialog).toBeVisible({ timeout: 10_000 });
+	await expect(page.getByTestId("goal-edit-title-input")).toBeFocused({ timeout: 5_000 });
+	return dialog;
+}
+
+async function dialogBox(page: import("@playwright/test").Page) {
+	const box = await page.getByTestId("goal-edit-dialog").boundingBox();
+	expect(box, "Edit Goal dialog should have a measurable bounding box").not.toBeNull();
+	return box!;
+}
+
+async function fetchGoal(goalId: string): Promise<any> {
+	const resp = await apiFetch(`/api/goals/${goalId}`);
+	expect(resp.ok).toBe(true);
+	return resp.json();
+}
+
+test.describe("Edit Goal modal", () => {
+	test("uses near-full-screen sizing while preserving close and save behavior", async ({ page }) => {
+		const initialTitle = `Edit modal sizing ${Date.now()}`;
+		const goal = await createGoal({
+			title: initialTitle,
+			team: false,
+			worktree: false,
+			spec: [
+				"# Edit modal sizing",
+				"",
+				"This deliberately long goal spec gives the editor enough content to exercise the expanded modal layout.",
+				"",
+				...Array.from({ length: 18 }, (_, i) => `- Acceptance detail ${i + 1}: keep the footer reachable while editing.`),
+			].join("\n"),
+		});
+		const goalId = goal.id as string;
+
+		try {
+			await page.setViewportSize({ width: 1280, height: 900 });
+			await openApp(page);
+			await navigateToGoalDashboard(page, goalId);
+
+			await openGoalEditDialog(page);
+			let box = await dialogBox(page);
+			expect(box.width, "desktop dialog should occupy most of the viewport width").toBeGreaterThanOrEqual(1280 * 0.84);
+			expect(box.height, "desktop dialog should occupy most of the viewport height").toBeGreaterThanOrEqual(900 * 0.88);
+			expect(box.width).toBeLessThanOrEqual(1280);
+			expect(box.height).toBeLessThanOrEqual(900);
+			expect(await page.getByTestId("goal-edit-spec-textarea").boundingBox()).toEqual(
+				expect.objectContaining({ height: expect.any(Number) }),
+			);
+			const specBox = await page.getByTestId("goal-edit-spec-textarea").boundingBox();
+			expect(specBox?.height, "spec editor should be substantially taller than the old compact textarea").toBeGreaterThanOrEqual(300);
+
+			await page.keyboard.press("Escape");
+			await expect(page.getByTestId("goal-edit-dialog")).toBeHidden({ timeout: 5_000 });
+
+			await page.setViewportSize({ width: 390, height: 720 });
+			await openGoalEditDialog(page);
+			box = await dialogBox(page);
+			expect(box.x, "narrow dialog should not overflow left").toBeGreaterThanOrEqual(0);
+			expect(box.y, "narrow dialog should not overflow top").toBeGreaterThanOrEqual(0);
+			expect(box.x + box.width, "narrow dialog should not overflow right").toBeLessThanOrEqual(390 + 1);
+			expect(box.y + box.height, "narrow dialog should not overflow bottom").toBeLessThanOrEqual(720 + 1);
+
+			const saveButton = page.getByTestId("goal-edit-save-button");
+			const cancelButton = page.getByTestId("goal-edit-cancel-button");
+			await expect(saveButton).toBeVisible();
+			await expect(cancelButton).toBeVisible();
+			for (const control of [saveButton, cancelButton]) {
+				const controlBox = await control.boundingBox();
+				expect(controlBox, "footer action should have a measurable bounding box").not.toBeNull();
+				expect(controlBox!.y + controlBox!.height, "footer action should stay within the narrow viewport").toBeLessThanOrEqual(720 + 1);
+			}
+
+			await page.getByTestId("goal-edit-title-input").fill(`${initialTitle} canceled`);
+			await cancelButton.click();
+			await expect(page.getByTestId("goal-edit-dialog")).toBeHidden({ timeout: 5_000 });
+			expect((await fetchGoal(goalId)).title).toBe(initialTitle);
+
+			await openGoalEditDialog(page);
+			const savedTitle = `${initialTitle} saved`;
+			const titleInput = page.getByTestId("goal-edit-title-input");
+			await titleInput.fill(savedTitle);
+			await titleInput.press("Enter");
+			await expect(page.getByTestId("goal-edit-dialog")).toBeHidden({ timeout: 10_000 });
+			await expect.poll(async () => (await fetchGoal(goalId)).title, { timeout: 10_000 }).toBe(savedTitle);
+		} finally {
+			await deleteGoal(goalId);
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- Expand the Edit Goal dialog to a near-full-screen responsive modal.
- Make the goal spec editor taller/flexible with internal body scrolling and reachable footer actions.
- Add stable test selectors and browser E2E coverage for desktop/narrow sizing plus close/save behavior.

## Validation
- npm run check
- npm run test:e2e -- tests/e2e/ui/goal-edit-modal.spec.ts
- npm run test:unit

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)