### PR TITLE
Extension Platform G1.3: sessionSetup Dynamic Context

### DIFF
--- a/docs/extension-host-authoring.md
+++ b/docs/extension-host-authoring.md
@@ -42,7 +42,7 @@ The renderer+action working example lives at `tests/fixtures/market-sources/retr
 | **Pack routes** | `pack.yaml` `routes:` | Gateway (confined worker) | called via `host.callRoute` |
 | **Entrypoints** | `entrypoints/<ep>.yaml` (listed in `contents`) | Browser (launchers + deep-link routes) | `host.ui.navigate` / `openPanel` |
 | **Pack store** | *implicit* — no declaration | Gateway | `host.store.{get,put,list}` (pack-namespaced) |
-| **Providers** *(schema 2; core landed, not yet wired)* | `providers/<id>.yaml` (listed in `contents.providers`) | Server (Lifecycle Hub, worker tier) | default-export hook object — see [docs/lifecycle-hub.md](lifecycle-hub.md) |
+| **Providers** *(schema 2; `sessionSetup` wired, per-turn pending)* | `providers/<id>.yaml` (listed in `contents.providers`) | Server (Lifecycle Hub, worker tier) | default-export hook object — see [docs/lifecycle-hub.md](lifecycle-hub.md) |
 
 Plus the cross-cutting `host.session.*` (transcript reads, agent-driving posts, live events)
 and the server-side `host.agents.*` (launch + orchestrate child agents), available to surfaces
@@ -784,24 +784,27 @@ a fresh read-only reviewer sub-agent and the panel lives only in that child sess
   packs declaring the same `routeId` is a hard rejection at registry build). Panel ids referenced
   by `target.panelId` are pack-local.
 
-### Providers (`providers/<id>.yaml`) — schema 2; core landed, not yet wired into sessions
+### Providers (`providers/<id>.yaml`) — schema 2; `sessionSetup` wired into sessions
 
 **Status:** a `schema: 2` pack may ship **provider** contributions — a pack-scoped
 contribution loaded into the same `PackContributionRegistry` as panels/entrypoints/routes.
 Schema-1 packs ignore `contents.providers` and keep the old activation-catalogue shape.
 
-Provider **dispatch infrastructure now exists**: a server-core `LifecycleHub` can resolve
-enabled providers via `PackContributionRegistry.listProviders(projectId)`, run a named hook on
-the Extension Host worker tier with a per-provider timeout, collect the returned
-`ContextBlock`s, apply token budgets, fence the content, and record a trace. See
-[docs/lifecycle-hub.md](lifecycle-hub.md) for the full Hub contract.
+The `LifecycleHub` resolves enabled providers via
+`PackContributionRegistry.listProviders(projectId)`, runs a named hook on the Extension Host
+worker tier with a per-provider timeout, collects the returned `ContextBlock`s, applies token
+budgets, fences the content, and records a trace. See [docs/lifecycle-hub.md](lifecycle-hub.md)
+for the full Hub contract.
 
-**But nothing calls the Hub from any session path yet, so authoring a provider still has no
-runtime effect in production today.** The `sessionSetup` wiring lands in a later goal (G1.3) and
-the per-turn `beforePrompt` wiring after that (G1.4). Author providers now to get validation,
-catalogue listing, and activation toggles — and to be ready for when the wiring lands — but
-expect no observable behaviour until then beyond appearing in `listProviders(projectId)`
-(installed + active + enabled).
+**The `sessionSetup` hook is now wired into the session runtime.** When a new session is
+created, the Hub dispatches `sessionSetup` and the returned blocks render as a final
+**Dynamic Context** prompt section (visible in the prompt-sections inspector with
+`source: "providers"` provenance) — so a provider that declares `sessionSetup` and is installed +
+active + enabled for the session's scope contributes context today. A provider fault never blocks
+the spawn. The per-turn `beforePrompt` hook and the rest of the hook set are **not wired yet**
+(G1.4 and later), and **no built-in production provider ships yet** (G1.6), so an out-of-the-box
+install produces no Dynamic Context section. See
+[docs/lifecycle-hub.md → Session-setup wiring](lifecycle-hub.md#session-setup-wiring-g13).
 
 Unlike every other contribution in this guide, a provider has **no `ctx.host` Host-API
 surface** — it is not reached through the panel/entrypoint/route Host API. Instead, when the Hub

--- a/docs/features.md
+++ b/docs/features.md
@@ -125,7 +125,7 @@ Context compaction reduces token usage by summarising the conversation.
 
 ## System Prompt Assembly
 
-Each session's system prompt is assembled from eight sections. Sections are separated by `\n\n---\n\n` and written to `.bobbit/state/session-prompts/{sessionId}.md` at spawn time.
+Each session's system prompt is assembled from a fixed set of ordered sections (numbered below) plus an optional provider-supplied tail. Sections are separated by `\n\n---\n\n` and written to `.bobbit/state/session-prompts/{sessionId}.md` at spawn time.
 
 The sections are ordered so that the **stable prefix** (sections 1–5, which are deterministic functions of the project and allowed tools) comes before the **volatile suffix** (sections 6–8, which vary per goal/task/session). This ordering lets provider prompt caches (Anthropic ephemeral, OpenAI prompt cache) reuse the tool docs and skills catalog across team spawns and between turns, because the cache key only invalidates at the first changed byte.
 
@@ -139,8 +139,9 @@ The sections are ordered so that the **stable prefix** (sections 1–5, which ar
 | 6 | **Goal + Role** | Yes | Goal spec and/or role prompt; combined under a single `# Goal` heading. |
 | 7 | **Current Task** | Yes | Task title, type, spec, and dependency list. Omitted when no task is assigned. |
 | 8 | **Workflow upstream-gate context** | Yes | Passed gate content injected for context. Omitted when not in a workflow. |
+| 9 | **Dynamic Context** | Yes | Provider-supplied ambient context from the `sessionSetup` lifecycle hook, fenced in `<context-block>` envelopes. Appended last (freshest, lowest-authority). Omitted unless an active provider contributes blocks. See [lifecycle-hub.md](lifecycle-hub.md#session-setup-wiring-g13). |
 
-Implementation: `src/server/agent/system-prompt.ts::_assembleSystemPrompt`. The inspector UI uses `getPromptSections()` (same file) to show labeled sections in the same order.
+Implementation: `src/server/agent/system-prompt.ts::_assembleSystemPrompt`. The inspector UI uses `getPromptSections()` (same file) to show labeled sections in the same order. Section 9 is appended after section 8 by the `sessionSetup` provider wiring (Extension Platform G1.3); when no provider contributes, it is absent and the prompt is byte-identical to the 1–8 layout.
 
 ## Reconnection
 

--- a/docs/lifecycle-hub.md
+++ b/docs/lifecycle-hub.md
@@ -321,10 +321,15 @@ produces a byte-identical prompt to before this wiring — the invariant a unit 
 ### What does NOT ship yet
 
 No built-in production provider is installed (that is G1.6). The wiring is therefore exercised by a
-deterministic fixture pack, `tests/fixtures/packs/provider-demo/`, loaded by pointing
-`BOBBIT_BUILTIN_PACKS_DIR` at the fixtures dir; its `sessionSetup` returns a `DEMO_SETUP_BLOCK`
-and a throwing variant proves the failure path still spawns the session. Installing any
-schema-2 pack that ships a `sessionSetup` provider will now contribute a Dynamic Context section.
+deterministic fixture pack, `tests/fixtures/packs/provider-demo/`, whose `sessionSetup` returns a
+`DEMO_SETUP_BLOCK` and a throwing variant proves the failure path still spawns the session. The
+E2E test (`tests/e2e/provider-session-setup.spec.ts`) **copies that fixture into the per-gateway
+server-scope market-packs dir** (`.bobbit/config/market-packs/provider-demo/`) and toggles it via
+pack activation (`PUT /api/marketplace/pack-activation`), which invalidates the resolver caches.
+This layers the fixture *on top of* the real built-in band rather than replacing it — the earlier
+approach of pointing `BOBBIT_BUILTIN_PACKS_DIR` at the fixtures dir wiped the built-in band for
+the whole worker-scoped gateway and broke sibling specs. Installing any schema-2 pack that ships a
+`sessionSetup` provider will likewise contribute a Dynamic Context section.
 
 ## The trace store
 

--- a/docs/lifecycle-hub.md
+++ b/docs/lifecycle-hub.md
@@ -1,11 +1,13 @@
 # The Lifecycle Hub
 
-> **Status — server core, not yet wired (Extension Platform G1.2).** The `LifecycleHub`
-> exists and is fully tested, but **nothing in any session path calls it yet**. Authoring a
-> provider has **no runtime effect in production today**. Session-setup wiring lands in G1.3
-> and per-turn (`beforePrompt`) wiring in G1.4. See [Status / not-yet-wired](#status--not-yet-wired)
-> at the end of this doc. This page documents the core so the wiring goals (and provider
-> authors) have a stable contract to build against.
+> **Status — `sessionSetup` wired (Extension Platform G1.3); per-turn hooks still pending.**
+> New sessions now dispatch the `sessionSetup` hook through the `LifecycleHub`, and the blocks
+> it returns render as a **Dynamic Context** prompt section — see
+> [Session-setup wiring (G1.3)](#session-setup-wiring-g13). The per-turn `beforePrompt` dispatch
+> and the `afterTurn` / `beforeCompact` / `sessionShutdown` dispatches are still **not wired**
+> (G1.4 and later). **No built-in production provider ships yet** (G1.6), so an out-of-the-box
+> install produces no Dynamic Context section; the behaviour is proven by a fixture pack. This
+> page documents the Hub core and its first session wiring.
 
 ## What it is, and why
 
@@ -51,17 +53,17 @@ The three core modules live under `src/server/agent/`:
 
 A **lifecycle hook** is a named moment in a session's life. The hook set is:
 
-| Hook | Intended dispatch point | Wiring goal |
-|---|---|---|
-| `sessionSetup` | Once, when a session is created — seed durable context. | G1.3 |
-| `beforePrompt` | Before each user prompt is sent to the model. | G1.4 |
-| `afterTurn` | After a turn completes. | later |
-| `beforeCompact` | Before transcript compaction. | later |
-| `sessionShutdown` | When a session is torn down. | later |
+| Hook | Dispatch point | Wiring goal | Status |
+|---|---|---|---|
+| `sessionSetup` | Once, when a session is created — seed durable context. | G1.3 | **wired** |
+| `beforePrompt` | Before each user prompt is sent to the model. | G1.4 | pending |
+| `afterTurn` | After a turn completes. | later | pending |
+| `beforeCompact` | Before transcript compaction. | later | pending |
+| `sessionShutdown` | When a session is torn down. | later | pending |
 
 A provider declares which hooks it wants in its YAML `hooks:` list; the Hub only dispatches a
-hook to providers that declared it. **None of these dispatch points are wired into the session
-runtime yet** — the table records *intent*, not current behaviour.
+hook to providers that declared it. **Only `sessionSetup` is wired into the session runtime**
+(see below); the remaining rows record *intent*, not current behaviour.
 
 ## The `ContextBlock` contract
 
@@ -254,6 +256,76 @@ This is why the worker's member-resolution has an explicit `providers` branch: f
 group is still `mod[exportKind] ?? mod.default?.[exportKind]` — that path is unchanged, so the
 existing route/action dispatchers are unaffected.
 
+## Session-setup wiring (G1.3)
+
+This is the **first** place the Hub is actually called from a live session path. The wiring has
+three moving parts; the goal was to add session behaviour without changing the prompt for any
+session that has no active provider.
+
+### Where the Hub is constructed
+
+Exactly **one** `LifecycleHub` instance lives for the gateway's lifetime. It is built in the
+server bootstrap (`src/server/server.ts`) right after the `PackContributionRegistry`, because the
+Hub's dependencies (`registry`, `moduleHost`) only exist at that point, and assigned to the
+already-constructed `SessionManager` via a public `lifecycleHub` field (the same
+assigned-post-construction pattern as `sandboxTokenStore` / `configCascade`). Its `gatewayInfo`
+callback reads the gateway base URL and admin token the same way the tool-guard does
+(`BOBBIT_GATEWAY_URL` env or `state/gateway-url`; token from `state/token`), guarded so a missing
+file never throws.
+
+### Where the hook is dispatched
+
+The session-setup pipeline (`src/server/agent/session-setup.ts`) gains one new async step,
+`resolveDynamicContext`, dispatched immediately **before** `resolvePrompt` in both the synchronous
+(`executePlan`) and worktree-async (`executeWorktreeAsync`) paths. It:
+
+1. **Short-circuits to zero cost when no Hub is configured** (`if (!ctx.lifecycleHub) return;`).
+   A session with no providers therefore pays nothing — this is what keeps spawn latency unchanged
+   and the prompt byte-identical for the no-provider / schema-1 case.
+2. Otherwise calls `lifecycleHub.dispatch("sessionSetup", { sessionId, projectId, scope, cwd,
+   goalId, roleName, prompt })` (scope is `"project"` when the plan has a `projectId`, else
+   `"global"`; `prompt` is the delegate task prompt when present, best-effort otherwise) and
+   stashes the returned `blocks` on the plan as `dynamicContextBlocks`.
+3. **Wraps the whole step in try/catch — a provider fault is logged and the spawn proceeds.**
+   Dynamic context is ambient and optional; a throwing or slow provider must never block a session
+   from starting. (The Hub already fault-isolates *individual* providers into diagnostics; this
+   outer guard covers the dispatch call itself.)
+
+The blocks are stashed on the **plan**, not applied directly, because `resolvePrompt` is
+re-invoked on the cwd-rebind path. `_resolvePrompt` copies `plan.dynamicContextBlocks` into
+`PromptParts.dynamicContext` on **every** invocation, so the blocks survive the re-calls —
+dispatch once, re-apply many.
+
+### How the blocks reach the prompt and the inspector
+
+`system-prompt.ts` renders `PromptParts.dynamicContext` (when non-empty) as a **final** section,
+after every existing section. It is placed last deliberately: provider-supplied ambient context is
+the freshest, **lowest-authority** content, so it sits at the tail where it least disturbs the
+cache-friendly stable prefix. Each block is wrapped with `fenceBlock` (the `<context-block …>`
+envelope carrying `source` / `authority` / `reason` provenance) and the blocks are joined with
+`\n\n`.
+
+The section is added in **both** prompt builders, mirroring the skills-catalog duality:
+
+- `_assembleSystemPrompt` (the actual system prompt) prepends a `## Dynamic Context` header.
+- `getPromptSections` (the source for the prompt-sections inspector) emits
+  `{ label: "Dynamic Context", source: "providers", content, tokens }`, where `content` is exactly
+  the fenced blocks (no header) and `tokens` is the host-side estimate. Because
+  `persistPromptSections` consumes `getPromptSections`, the section appears in the inspector
+  (`GET /api/sessions/:id/prompt-sections`) **for free**, with `source: "providers"` provenance and
+  a token count; per-block `provider` / `reason` / token live inside the fence attributes.
+
+**Empty / absent `dynamicContext` adds zero sections**, so a session with no contributing provider
+produces a byte-identical prompt to before this wiring — the invariant a unit test pins.
+
+### What does NOT ship yet
+
+No built-in production provider is installed (that is G1.6). The wiring is therefore exercised by a
+deterministic fixture pack, `tests/fixtures/packs/provider-demo/`, loaded by pointing
+`BOBBIT_BUILTIN_PACKS_DIR` at the fixtures dir; its `sessionSetup` returns a `DEMO_SETUP_BLOCK`
+and a throwing variant proves the failure path still spawns the session. Installing any
+schema-2 pack that ships a `sessionSetup` provider will now contribute a Dynamic Context section.
+
 ## The trace store
 
 `ContextTraceStore` records each dispatch as one JSON line, so you can reconstruct exactly what
@@ -284,22 +356,22 @@ ambient context a session received and why blocks were dropped.
   rewritten keeping only the newest lines that fit (drop-oldest), via a temp-file rename so a
   reader never sees a half-written file.
 
-## Status / not-yet-wired
+## Status / wiring roadmap
 
-This goal (G1.2) delivers **pure server core**: the modules above plus the `"providers"`
-`exportKind` branch on the Extension Host worker seam. It is intentionally **inert in
-production** — no session lifecycle path constructs or calls the `LifecycleHub`, so installing
-or authoring a provider changes nothing at runtime today.
-
-The wiring is sequenced in later goals:
-
-- **G1.3** constructs the Hub and calls `dispatch("sessionSetup", …)` during session setup,
-  and integrates kept blocks into the system prompt (`PromptParts.dynamicContext`).
-- **G1.4** adds the per-turn `beforePrompt` dispatch and the REST/provider-bridge surface.
+- **G1.2** delivered the **server core**: the modules above plus the `"providers"` `exportKind`
+  branch on the Extension Host worker seam.
+- **G1.3 (done)** constructs the single Hub at gateway bootstrap and calls
+  `dispatch("sessionSetup", …)` during session setup, rendering kept blocks as the
+  `PromptParts.dynamicContext` → **Dynamic Context** system-prompt section — see
+  [Session-setup wiring (G1.3)](#session-setup-wiring-g13).
+- **G1.4** adds the per-turn `beforePrompt` dispatch and the REST/provider-bridge surface
+  (`/provider-hooks/*`, `/context-trace`).
+- **G1.6** ships the first built-in production provider; until then only fixture / installed
+  packs contribute blocks.
 - Selector hooks (`beforeGoalCreate` / `beforeSessionSpawn`) are a separate, later goal (G8).
 
-Until then, treat this page as the contract those goals build against, and treat provider
-authoring as "validated and catalogued, but not yet executed."
+The `afterTurn` / `beforeCompact` / `sessionShutdown` dispatches remain unwired — a provider may
+declare those hooks for forward compatibility, but the Hub is not yet called at those moments.
 
 ## See also
 

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -432,15 +432,16 @@ Field rules and defaults:
 - **`budget`** — `{ maxTokens, timeoutMs }`. Defaults `{ maxTokens: 1600, timeoutMs: 1500 }`;
   `maxTokens` is clamped to `[64, 8192]` and `timeoutMs` to `[100, 10000]`. The budget exists
   so the (future) dispatch tier can bound how much a provider may contribute and how long it
-  may run — defined now, enforced when dispatch lands.
-- **`runtime?`** / **`config?`** — optional pass-through fields for the future dispatch tier.
+  may run.
+- **`runtime?`** / **`config?`** — optional pass-through fields handed to the hook as `ctx.config`.
 
-**Authoring a provider has no runtime effect in production yet.** The loader validates them and
-the registry indexes them. The dispatch core — the `LifecycleHub` that runs a provider's `hook`
-on the worker tier and applies its `budget` — now exists ([docs/lifecycle-hub.md](lifecycle-hub.md)),
-but **no session path calls it yet** (session-setup wiring is G1.3, per-turn `beforePrompt` is
-G1.4). So today authoring a provider gets you validation, catalogue listing, and activation
-toggles, and nothing observable beyond that.
+**The `sessionSetup` hook is wired; the rest of the dispatch is not.** The loader validates
+providers and the registry indexes them, and the `LifecycleHub` that runs a provider's `hook` on
+the worker tier and applies its `budget` ([docs/lifecycle-hub.md](lifecycle-hub.md)) is now called
+during session setup: a provider that declares `sessionSetup` and is installed + active + enabled
+for the session's scope contributes a **Dynamic Context** prompt section. The per-turn
+`beforePrompt` dispatch is still pending (G1.4), and **no built-in production provider ships yet**
+(G1.6) — so an out-of-the-box install contributes nothing until you add a provider pack.
 
 #### Why providers are pack-scoped, *not* name-merged
 

--- a/src/server/agent/lifecycle-hub.ts
+++ b/src/server/agent/lifecycle-hub.ts
@@ -88,8 +88,9 @@ export class LifecycleHub {
 					epoch: 0,
 					exportKind: "providers",
 					member: hook,
-					ctx: hookCtx as unknown as InvokeRequest["ctx"],
+					ctx: { ...hookCtx, workingDir: base.cwd } as unknown as InvokeRequest["ctx"],
 					arg: undefined,
+					workingDir: base.cwd,
 				}, provider.budget.timeoutMs);
 				ms = Math.round(performance.now() - t0);
 

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -74,6 +74,7 @@ import { bobbitStateDir, bobbitConfigDir, globalAgentDir, globalAuthPath } from 
 import { shouldReapChildOnBoot, type OrchestrationCore } from "./orchestration-core.js";
 
 import type { SandboxManager } from "./sandbox-manager.js";
+import type { LifecycleHub } from "./lifecycle-hub.js";
 import { WorktreePool } from "./worktree-pool.js";
 import { backfillStaffIds as backfillStaffIdsImpl } from "./staff-backfill.js";
 import {
@@ -678,6 +679,7 @@ export class SessionManager {
 	private worktreePools: Map<string, WorktreePool> = new Map();
 	sandboxManager: SandboxManager | null = null;
 	sandboxTokenStore: import("../auth/sandbox-token.js").SandboxTokenStore | null = null;
+	lifecycleHub?: LifecycleHub;
 	/**
 	 * S1 — per-session capability secret store. Injected into the owning
 	 * session's env as `BOBBIT_SESSION_SECRET` and used by the orchestration
@@ -1295,6 +1297,7 @@ export class SessionManager {
 			sessionSecretStore: this.sessionSecretStore,
 			groupPolicyStore: this.groupPolicyStore ?? null,
 			configCascade: this.configCascade,
+			lifecycleHub: this.lifecycleHub,
 			costTracker: resolvedCostTracker,
 			store: resolvedStore,
 			searchIndex: resolvedSearchIndex,

--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -33,6 +33,8 @@ import type { McpManager } from "../mcp/mcp-manager.js";
 import type { SandboxManager } from "./sandbox-manager.js";
 import type { PromptParts, NestingContext } from "./system-prompt.js";
 import type { PrStatusStore } from "./pr-status-store.js";
+import type { LifecycleHub } from "./lifecycle-hub.js";
+import type { ContextBlock } from "./context-blocks.js";
 
 import type { ConfigCascade } from "./config-cascade.js";
 import { getAssistantDef } from "./assistant-registry.js";
@@ -169,6 +171,7 @@ export interface SessionSetupPlan {
 	bridgeOptions: RpcBridgeOptions;
 	effectiveAllowedTools?: EffectiveTool[];
 	promptPath?: string;
+	dynamicContextBlocks?: ContextBlock[];
 
 	// Options passed through from caller
 	agentArgs?: string[];
@@ -232,6 +235,7 @@ export interface PipelineContext {
 	sessionSecretStore: import("../auth/session-secret.js").SessionSecretStore;
 	groupPolicyStore: ToolGroupPolicyStore | null;
 	configCascade: ConfigCascade | null;
+	lifecycleHub?: LifecycleHub;
 	costTracker: CostTracker;
 	store: SessionStore;
 	searchIndex: SearchService;
@@ -474,6 +478,24 @@ function lookupRole(name: string, plan: SessionSetupPlan, ctx: PipelineContext):
 	return ctx.roleManager?.getRole(name);
 }
 
+export async function resolveDynamicContext(plan: SessionSetupPlan, ctx: PipelineContext): Promise<void> {
+	if (!ctx.lifecycleHub) return;
+	try {
+		const { blocks } = await ctx.lifecycleHub.dispatch("sessionSetup", {
+			sessionId: plan.id,
+			projectId: plan.projectId,
+			scope: plan.projectId ? "project" : "global",
+			cwd: plan.cwd,
+			goalId: plan.goalId,
+			roleName: plan.roleName,
+			prompt: plan.instructions,
+		});
+		plan.dynamicContextBlocks = blocks;
+	} catch (err) {
+		console.error(`[session-setup] sessionSetup dynamic context failed for ${plan.id}:`, err);
+	}
+}
+
 /** Step 4: Assemble system prompt (handles assistant, normal, delegate variants). */
 export function resolvePrompt(plan: SessionSetupPlan, ctx: PipelineContext): void {
 	return profile("resolvePrompt", () => _resolvePrompt(plan, ctx));
@@ -517,6 +539,7 @@ function _resolvePrompt(plan: SessionSetupPlan, ctx: PipelineContext): void {
 		}
 
 		const promptPath = ctx.assemblePrompt(plan.id, {
+			dynamicContext: plan.dynamicContextBlocks,
 			// Include the base system prompt so assistant sessions
 			// (goal/project/tool assistants) get it by default.
 			baseSystemPromptPath: ctx.systemPromptPath,
@@ -540,6 +563,7 @@ function _resolvePrompt(plan: SessionSetupPlan, ctx: PipelineContext): void {
 		}
 
 		const promptPath = ctx.assemblePrompt(plan.id, {
+			dynamicContext: plan.dynamicContextBlocks,
 			// Delegates still get the global base system prompt. The task spec is
 			// layered on top as goalSpec; AGENTS.md from the worktree is also included.
 			baseSystemPromptPath: ctx.systemPromptPath,
@@ -588,6 +612,7 @@ function _resolvePrompt(plan: SessionSetupPlan, ctx: PipelineContext): void {
 			: undefined;
 
 		const promptPath = ctx.assemblePrompt(plan.id, {
+			dynamicContext: plan.dynamicContextBlocks,
 			baseSystemPromptPath: ctx.systemPromptPath,
 			cwd: plan.cwd,
 			projectRoot: plan.repoPath,
@@ -729,6 +754,7 @@ export async function executePlan(plan: SessionSetupPlan, ctx: PipelineContext):
 	resolveBridgeOptions(plan, ctx);
 	resolveGoalExtensions(plan, ctx);
 	resolveTools(plan, ctx);
+	await resolveDynamicContext(plan, ctx);
 	resolvePrompt(plan, ctx);
 	resolveToolActivation(plan, ctx);
 	recordElapsed("executePlan.resolveConfig", performance.now() - __t0);
@@ -920,6 +946,7 @@ export async function executeWorktreeAsync(
 	resolveBridgeOptions(plan, ctx);
 	resolveGoalExtensions(plan, ctx);
 	resolveTools(plan, ctx);
+	await resolveDynamicContext(plan, ctx);
 	resolvePrompt(plan, ctx);
 	resolveToolActivation(plan, ctx);
 

--- a/src/server/agent/system-prompt.ts
+++ b/src/server/agent/system-prompt.ts
@@ -7,6 +7,7 @@ import { removeMount as removePreviewMount } from "../preview/mount.js";
 import { getAllConfigDirectories, type ProjectConfigReader } from "./config-directories.js";
 import type { SlashSkill } from "../skills/slash-skills.js";
 import { profile, bumpCount } from "./profiling.js";
+import { type ContextBlock, fenceBlock } from "./context-blocks.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -338,6 +339,8 @@ export interface PromptParts {
 	/** Optional override for the skills-catalog byte budget (clamped to [MIN, MAX]).
 	 *  When undefined, `SKILLS_CATALOG_BUDGET` is used. */
 	skillsCatalogBudget?: number;
+	/** Fresh provider-supplied context blocks appended as the final, lowest-authority prompt section. */
+	dynamicContext?: ContextBlock[];
 }
 
 /** Default max bytes of skills-catalog markdown to embed in the system prompt. */
@@ -520,6 +523,11 @@ function _assembleSystemPrompt(sessionId: string, parts: PromptParts): string | 
 		sections.push(parts.workflowContext.trim());
 	}
 
+	// 8. Dynamic Context (provider-supplied, freshest/lowest-authority tail)
+	if (parts.dynamicContext?.length) {
+		sections.push("## Dynamic Context\n\n" + parts.dynamicContext.map(fenceBlock).join("\n\n"));
+	}
+
 	if (sections.length === 0) return undefined;
 
 	const combined = sections.join("\n\n---\n\n") + "\n";
@@ -642,6 +650,12 @@ export function getPromptSections(parts: PromptParts): PromptSection[] {
 	// 8. Workflow context
 	if (parts.workflowContext?.trim()) {
 		sections.push({ label: "Workflow Context", source: "Upstream gates", content: parts.workflowContext.trim(), tokens: estimateTokens(parts.workflowContext.trim()) });
+	}
+
+	// 9. Dynamic Context (provider-supplied, freshest/lowest-authority tail)
+	if (parts.dynamicContext?.length) {
+		const content = parts.dynamicContext.map(fenceBlock).join("\n\n");
+		sections.push({ label: "Dynamic Context", source: "providers", content, tokens: estimateTokens(content) });
 	}
 
 	return sections;

--- a/src/server/extension-host/module-host-bootstrap.ts
+++ b/src/server/extension-host/module-host-bootstrap.ts
@@ -476,13 +476,15 @@ async function handleInvoke(msg: InvokeMessage): Promise<void> {
 			port!.postMessage({ kind: "result", ok: false, status: 404, error: `unknown ${msg.exportKind} member "${msg.member}"` });
 			return;
 		}
-		const ctx = {
-			host: buildHostProxy(msg.ctx),
-			sessionId: msg.ctx.sessionId,
-			toolUseId: msg.ctx.toolUseId,
-			tool: msg.ctx.tool,
-			workingDir: msg.ctx.workingDir,
-		};
+		const ctx = msg.exportKind === "providers"
+			? { ...msg.ctx, host: buildHostProxy(msg.ctx), workingDir: msg.ctx.workingDir }
+			: {
+				host: buildHostProxy(msg.ctx),
+				sessionId: msg.ctx.sessionId,
+				toolUseId: msg.ctx.toolUseId,
+				tool: msg.ctx.tool,
+				workingDir: msg.ctx.workingDir,
+			};
 		const result = await (fn as (c: unknown, a: unknown) => unknown)(ctx, msg.arg);
 		port!.postMessage({ kind: "result", ok: true, value: result });
 	} catch (err) {

--- a/src/server/extension-host/module-host-worker.ts
+++ b/src/server/extension-host/module-host-worker.ts
@@ -186,20 +186,27 @@ export class ModuleHost {
 		const limit = timeoutMs ?? this.defaultTimeoutMs;
 		const host = (req.ctx as { host?: unknown } | undefined)?.host;
 		const capSrc = (host as { capabilities?: Record<string, unknown> } | undefined)?.capabilities;
-		const serCtx = {
-			sessionId: req.ctx?.sessionId,
-			toolUseId: req.ctx?.toolUseId,
-			tool: req.ctx?.tool,
-			workingDir: req.ctx?.workingDir,
-			hostVersion: (host as { version?: number } | undefined)?.version,
-			hostContractVersion: (host as { contractVersion?: number } | undefined)?.contractVersion,
-			capabilities: {
-				callRoute: capSrc?.callRoute === true,
-				session: capSrc?.session === true,
-				store: capSrc?.store === true,
-				agents: capSrc?.agents === true,
-			},
-		};
+		const providerCtx = req.ctx as unknown as Record<string, unknown>;
+		const serCtx = req.exportKind === "providers"
+			? {
+				...providerCtx,
+				workingDir: providerCtx.workingDir ?? req.workingDir,
+				capabilities: { callRoute: false, session: false, store: false, agents: false },
+			}
+			: {
+				sessionId: req.ctx?.sessionId,
+				toolUseId: req.ctx?.toolUseId,
+				tool: req.ctx?.tool,
+				workingDir: req.ctx?.workingDir,
+				hostVersion: (host as { version?: number } | undefined)?.version,
+				hostContractVersion: (host as { contractVersion?: number } | undefined)?.contractVersion,
+				capabilities: {
+					callRoute: capSrc?.callRoute === true,
+					session: capSrc?.session === true,
+					store: capSrc?.store === true,
+					agents: capSrc?.agents === true,
+				},
+			};
 
 		const worker = new Worker(this.bootstrapUrl(), {
 			// No `env` option: the worker inherits a full copy of the gateway env

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -53,6 +53,8 @@ import { resolvePackIdentityForTool } from "./extension-host/pack-identity.js";
 import { mintSurfaceToken, resolveSurfaceIdentity } from "./extension-host/surface-binding.js";
 import { PackContributionRegistry } from "./extension-host/pack-contribution-registry.js";
 import { loadPackContributions } from "./agent/pack-contributions.js";
+import { LifecycleHub } from "./agent/lifecycle-hub.js";
+import { ContextTraceStore } from "./agent/context-trace-store.js";
 import { isPackPathWithinRoot } from "./extension-host/path-guard.js";
 import { buildGateStatusSummary } from "./gate-status-summary.js";
 import { buildGateVerificationSnapshot, UnknownVerificationStepError } from "./gate-verification-snapshot.js";
@@ -1235,6 +1237,20 @@ export function createGateway(config: GatewayConfig) {
 		(scope, projectId, packName) => packActivationStore(scope as PackScope, projectId)?.getPackActivation(scope as PackOrderScope, packName).entrypoints ?? [],
 		(scope, projectId, packName) => packActivationStore(scope as PackScope, projectId)?.getPackActivation(scope as PackOrderScope, packName).providers ?? [],
 	);
+	sessionManager.lifecycleHub = new LifecycleHub({
+		registry: packContributionRegistry,
+		moduleHost,
+		trace: new ContextTraceStore(bobbitStateDir()),
+		gatewayInfo: () => {
+			try {
+				const baseUrl = process.env.BOBBIT_GATEWAY_URL || fs.readFileSync(path.join(bobbitStateDir(), "gateway-url"), "utf-8").trim();
+				const token = fs.readFileSync(path.join(bobbitStateDir(), "token"), "utf-8").trim();
+				return { baseUrl, token };
+			} catch {
+				return { baseUrl: "", token: "" };
+			}
+		},
+	});
 	routeRegistry = new RouteRegistry(packContributionRegistry);
 
 	// pack-schema-v1 §7: feed pack_activation into the roles/tools cascade so a

--- a/tests/dynamic-context-section.test.ts
+++ b/tests/dynamic-context-section.test.ts
@@ -1,0 +1,67 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { getPromptSections, type PromptParts } from "../src/server/agent/system-prompt.js";
+import { fenceBlock, type ContextBlock } from "../src/server/agent/context-blocks.js";
+import { resolveDynamicContext, type SessionSetupPlan } from "../src/server/agent/session-setup.js";
+
+function block(id: string, content: string): ContextBlock {
+	return {
+		id,
+		title: `Title ${id}`,
+		providerId: "provider-demo:demo",
+		authority: "generic",
+		content,
+		reason: "fixture",
+		priority: 10,
+		tokenEstimate: Math.ceil(content.length / 4),
+	};
+}
+
+function parts(overrides: Partial<PromptParts> = {}): PromptParts {
+	return {
+		cwd: "/tmp/dynamic-context-test",
+		goalTitle: "Dynamic context goal",
+		goalState: "in-progress",
+		goalSpec: "Build dynamic context.",
+		workflowContext: "# Upstream Gates\n\nDesign approved.",
+		...overrides,
+	};
+}
+
+describe("Dynamic Context prompt section", () => {
+	it("renders fenced ContextBlocks as the final prompt-inspector section", () => {
+		const blocks = [block("one", "first context"), block("two", "second context")];
+		const sections = getPromptSections(parts({ dynamicContext: blocks }));
+		const last = sections.at(-1);
+
+		assert.ok(last, "expected at least one prompt section");
+		assert.equal(last.label, "Dynamic Context");
+		assert.equal(last.source, "providers");
+		assert.equal(last.content, blocks.map(fenceBlock).join("\n\n"));
+		assert.ok(last.tokens > 0, "expected Dynamic Context token estimate");
+	});
+
+	it("adds no section when dynamicContext is absent or empty", () => {
+		const baseline = getPromptSections(parts());
+		const absent = getPromptSections(parts({ dynamicContext: undefined }));
+		const empty = getPromptSections(parts({ dynamicContext: [] }));
+
+		assert.deepEqual(absent, baseline);
+		assert.deepEqual(empty, baseline);
+		assert.equal(baseline.some((section) => section.label === "Dynamic Context"), false);
+	});
+
+	it("short-circuits dynamic context resolution when no LifecycleHub is configured", async () => {
+		const plan = {
+			id: "session-no-hub",
+			mode: "normal",
+			title: "No hub",
+			cwd: "/tmp/no-hub",
+			bridgeOptions: { cwd: "/tmp/no-hub" },
+		} as SessionSetupPlan;
+
+		await resolveDynamicContext(plan, {} as any);
+
+		assert.equal(plan.dynamicContextBlocks, undefined);
+	});
+});

--- a/tests/e2e/provider-session-setup.spec.ts
+++ b/tests/e2e/provider-session-setup.spec.ts
@@ -5,16 +5,41 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+// The provider-demo fixture is installed as a SERVER-SCOPE market pack into the
+// per-worker gateway dir — NOT via BOBBIT_BUILTIN_PACKS_DIR. The in-process
+// gateway is worker-scoped (one gateway shared by every spec in a Playwright
+// worker) and resolves the built-in packs dir from the global process.env, so
+// mutating BOBBIT_BUILTIN_PACKS_DIR would replace the real built-in band for
+// the whole worker and break sibling specs (pr-walkthrough, marketplace, …).
+// Installing the fixture as a market pack layers it ON TOP of the real built-in
+// band — listProviders enumerates installed market packs additively — so no
+// built-in pack is removed and the fixture is still discovered.
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
-const fixturePacksDir = path.resolve(__dirname, "..", "fixtures", "packs");
-const previousBuiltinPacksDir = process.env.BOBBIT_BUILTIN_PACKS_DIR;
-process.env.BOBBIT_BUILTIN_PACKS_DIR = fixturePacksDir;
+const fixturePackDir = path.resolve(__dirname, "..", "fixtures", "packs", "provider-demo");
+const PACK_NAME = "provider-demo";
 
-test.afterAll(async ({ gateway }) => {
-	if (previousBuiltinPacksDir === undefined) delete process.env.BOBBIT_BUILTIN_PACKS_DIR;
-	else process.env.BOBBIT_BUILTIN_PACKS_DIR = previousBuiltinPacksDir;
-	try { (gateway.sessionManager.lifecycleHub as any)?.registry?.invalidate?.(); } catch { /* best-effort depollution */ }
-});
+function writeMeta(packDir: string): void {
+	fs.writeFileSync(path.join(packDir, ".pack-meta.yaml"), [
+		"sourceUrl: e2e",
+		"sourceRef: local",
+		"commit: test",
+		`packName: ${PACK_NAME}`,
+		"version: 1.0.0",
+		"installedAt: '2026-01-01T00:00:00.000Z'",
+		"updatedAt: '2026-01-01T00:00:00.000Z'",
+		"scope: server",
+	].join("\n") + "\n", "utf-8");
+}
+
+// Copy the source-of-truth fixture pack (pack.yaml + providers/ + lib/) into the
+// per-gateway server-scope market-packs dir, preserving subdir structure.
+function installPack(bobbitDir: string): string {
+	const packDir = path.join(bobbitDir, ".bobbit", "config", "market-packs", PACK_NAME);
+	fs.rmSync(packDir, { recursive: true, force: true });
+	fs.cpSync(fixturePackDir, packDir, { recursive: true });
+	writeMeta(packDir);
+	return packDir;
+}
 
 async function dynamicContextSection(sessionId: string): Promise<any | undefined> {
 	const resp = await apiFetch(`/api/sessions/${sessionId}/prompt-sections`);
@@ -28,7 +53,7 @@ async function setProviderDisabled(providers: string[]): Promise<void> {
 		method: "PUT",
 		body: JSON.stringify({
 			scope: "server",
-			packName: "provider-demo",
+			packName: PACK_NAME,
 			disabled: { providers },
 		}),
 	});
@@ -38,6 +63,22 @@ async function setProviderDisabled(providers: string[]): Promise<void> {
 test.describe("sessionSetup provider dynamic context", () => {
 	const sessions: string[] = [];
 	const cwds: string[] = [];
+	let packDir: string;
+
+	test.beforeAll(async ({ gateway }) => {
+		packDir = installPack(gateway.bobbitDir);
+		// Enable all providers + trigger a resolver-cache invalidation so the
+		// worker-scoped gateway (whose registry cache may already be built by an
+		// earlier spec) picks up the freshly-installed pack.
+		await setProviderDisabled([]);
+	});
+
+	test.afterAll(async () => {
+		// Reset activation and remove the per-gateway pack dir so the worker is
+		// left clean for any later spec sharing this gateway.
+		await setProviderDisabled([]).catch(() => {});
+		if (packDir) fs.rmSync(packDir, { recursive: true, force: true });
+	});
 
 	test.afterEach(async () => {
 		await setProviderDisabled(["demo", "boom"]).catch(() => {});

--- a/tests/e2e/provider-session-setup.spec.ts
+++ b/tests/e2e/provider-session-setup.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from "./in-process-harness.js";
+import { apiFetch, createSession, deleteSession } from "./e2e-setup.js";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const fixturePacksDir = path.resolve(__dirname, "..", "fixtures", "packs");
+const previousBuiltinPacksDir = process.env.BOBBIT_BUILTIN_PACKS_DIR;
+process.env.BOBBIT_BUILTIN_PACKS_DIR = fixturePacksDir;
+
+test.afterAll(async ({ gateway }) => {
+	if (previousBuiltinPacksDir === undefined) delete process.env.BOBBIT_BUILTIN_PACKS_DIR;
+	else process.env.BOBBIT_BUILTIN_PACKS_DIR = previousBuiltinPacksDir;
+	try { (gateway.sessionManager.lifecycleHub as any)?.registry?.invalidate?.(); } catch { /* best-effort depollution */ }
+});
+
+async function dynamicContextSection(sessionId: string): Promise<any | undefined> {
+	const resp = await apiFetch(`/api/sessions/${sessionId}/prompt-sections`);
+	expect(resp.status).toBe(200);
+	const body = await resp.json();
+	return body.sections.find((section: any) => section.label === "Dynamic Context");
+}
+
+async function setProviderDisabled(providers: string[]): Promise<void> {
+	const resp = await apiFetch("/api/marketplace/pack-activation", {
+		method: "PUT",
+		body: JSON.stringify({
+			scope: "server",
+			packName: "provider-demo",
+			disabled: { providers },
+		}),
+	});
+	expect(resp.status).toBe(200);
+}
+
+test.describe("sessionSetup provider dynamic context", () => {
+	const sessions: string[] = [];
+	const cwds: string[] = [];
+
+	test.afterEach(async () => {
+		await setProviderDisabled(["demo", "boom"]).catch(() => {});
+		for (const sessionId of sessions.splice(0)) {
+			await deleteSession(sessionId).catch(() => {});
+		}
+		for (const cwd of cwds.splice(0)) {
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("sessionSetup blocks appear in prompt sections and provider failures do not block spawn", async () => {
+		await setProviderDisabled([]);
+
+		const happyCwd = fs.mkdtempSync(path.join(os.tmpdir(), "provider-demo-happy-"));
+		cwds.push(happyCwd);
+		const happySession = await createSession({ cwd: happyCwd });
+		sessions.push(happySession);
+
+		const happySection = await dynamicContextSection(happySession);
+		expect(happySection).toBeTruthy();
+		expect(happySection.source).toBe("providers");
+		expect(happySection.content).toContain(`DEMO_SETUP_BLOCK ${happySession}`);
+
+		const logPath = path.join(happyCwd, ".provider-demo-log");
+		expect(fs.existsSync(logPath)).toBe(true);
+		const logLines = fs.readFileSync(logPath, "utf-8").trim().split(/\r?\n/).filter(Boolean);
+		expect(logLines).toEqual(["sessionSetup"]);
+
+		// Disable the block-producing provider. The throwing boom provider remains enabled:
+		// this session still spawns, and because boom returns no blocks, no Dynamic Context
+		// section is produced.
+		await setProviderDisabled(["demo"]);
+		const boomOnlyCwd = fs.mkdtempSync(path.join(os.tmpdir(), "provider-demo-boom-"));
+		cwds.push(boomOnlyCwd);
+		const boomOnlySession = await createSession({ cwd: boomOnlyCwd });
+		sessions.push(boomOnlySession);
+
+		const boomOnlySection = await dynamicContextSection(boomOnlySession);
+		expect(boomOnlySection).toBeUndefined();
+		expect(fs.existsSync(path.join(boomOnlyCwd, ".provider-demo-log"))).toBe(false);
+	});
+});

--- a/tests/e2e/ui/base-ref-settings.spec.ts
+++ b/tests/e2e/ui/base-ref-settings.spec.ts
@@ -69,7 +69,12 @@ async function saveBaseRef(page: BrowserPage, projectId: string, expectedStatus:
 			resp.request().method() === "PUT" &&
 			resp.status() === expectedStatus,
 	);
-	await page.locator("button").filter({ hasText: /^Save$/ }).first().click();
+	// Wait for the Save button to be present and enabled before clicking so the
+	// click cannot land on a disabled/re-rendering button under browser load.
+	const saveButton = page.locator("button").filter({ hasText: /^Save$/ }).first();
+	await expect(saveButton).toBeVisible({ timeout: 10_000 });
+	await expect(saveButton).toBeEnabled({ timeout: 10_000 });
+	await saveButton.click();
 	await savePromise;
 	await expect(page.locator("button").filter({ hasText: /^Saving\.\.\.$/ })).toHaveCount(0, { timeout: 10_000 });
 }
@@ -114,6 +119,11 @@ test.describe("Settings → Base Ref field", () => {
 	});
 
 	test("renders validation errors and clears stale inline errors", async ({ page }) => {
+		// This test drives four project navigations plus four git-backed
+		// validation saves in one browser context; under parallel E2E load the
+		// default 30s budget is too tight. Give it headroom rather than relying
+		// on Playwright's retry to mask a slow-but-correct run.
+		test.setTimeout(90_000);
 		const projectIds: string[] = [];
 		try {
 			const tagDir = uniqueProjectDir("tag");

--- a/tests/fixtures/packs/provider-demo/lib/provider-throws.mjs
+++ b/tests/fixtures/packs/provider-demo/lib/provider-throws.mjs
@@ -1,0 +1,5 @@
+export default {
+	sessionSetup() {
+		throw new Error("provider boom");
+	},
+};

--- a/tests/fixtures/packs/provider-demo/lib/provider.mjs
+++ b/tests/fixtures/packs/provider-demo/lib/provider.mjs
@@ -1,0 +1,37 @@
+import fs from "node:fs";
+
+function log(ctx, hook) {
+	fs.appendFileSync(ctx.cwd + "/.provider-demo-log", hook + "\n", "utf-8");
+}
+
+export default {
+	sessionSetup(ctx) {
+		log(ctx, "sessionSetup");
+		return {
+			blocks: [{
+				id: "demo:setup",
+				title: "Demo",
+				authority: "generic",
+				priority: 10,
+				reason: "fixture",
+				content: "DEMO_SETUP_BLOCK " + ctx.sessionId,
+			}],
+		};
+	},
+	beforePrompt(ctx) {
+		log(ctx, "beforePrompt");
+		return { blocks: [] };
+	},
+	afterTurn(ctx) {
+		log(ctx, "afterTurn");
+		return { blocks: [] };
+	},
+	beforeCompact(ctx) {
+		log(ctx, "beforeCompact");
+		return { blocks: [] };
+	},
+	sessionShutdown(ctx) {
+		log(ctx, "sessionShutdown");
+		return { blocks: [] };
+	},
+};

--- a/tests/fixtures/packs/provider-demo/pack.yaml
+++ b/tests/fixtures/packs/provider-demo/pack.yaml
@@ -1,0 +1,15 @@
+name: provider-demo
+description: G1.3 deterministic provider fixture.
+version: 1.0.0
+schema: 2
+contents:
+  roles: []
+  tools: []
+  skills: []
+  entrypoints: []
+  providers: [demo, boom]
+  hooks: []
+  mcp: []
+  pi-extensions: []
+  runtimes: []
+  workflows: []

--- a/tests/fixtures/packs/provider-demo/providers/boom.yaml
+++ b/tests/fixtures/packs/provider-demo/providers/boom.yaml
@@ -1,0 +1,6 @@
+id: boom
+kind: generic
+module: ../lib/provider-throws.mjs
+hooks: [sessionSetup]
+budget: { maxTokens: 512, timeoutMs: 1000 }
+defaultEnabled: true

--- a/tests/fixtures/packs/provider-demo/providers/demo.yaml
+++ b/tests/fixtures/packs/provider-demo/providers/demo.yaml
@@ -1,0 +1,6 @@
+id: demo
+kind: generic
+module: ../lib/provider.mjs
+hooks: [sessionSetup, beforePrompt, afterTurn, beforeCompact, sessionShutdown]
+budget: { maxTokens: 512, timeoutMs: 1000 }
+defaultEnabled: true


### PR DESCRIPTION
## Summary
- Wire provider `sessionSetup` through `LifecycleHub` during session creation.
- Render returned `ContextBlock[]` as the final "Dynamic Context" system-prompt section and prompt-sections inspector entry.
- Add deterministic provider fixture coverage, E2E isolation fixes, and docs for the new behavior.

## Verification
- `npm run check`
- `npm run test:unit`
- `npm run test:e2e` → full suite green locally after stabilization fixes
- Implementation and documentation gates passed

## Notes
This PR is stacked on G1.2 (`goal/lifecycle-hub-2ef9e8c8`) and targets `master` per the Extension Platform merge sequence.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)