### PR TITLE
Fix typed PR walkthrough slash launch

### DIFF
--- a/docs/pr-walkthrough-panel.md
+++ b/docs/pr-walkthrough-panel.md
@@ -37,14 +37,18 @@ The current end-to-end flow:
   SPA route and no standalone `/walkthrough?...` pathname route.
 - **Launch (spawn-on-click).** A pack **entrypoint** — a git-widget button, a
   composer-slash launcher, a command-palette launcher, and a `kind:"route"`
-  deep-link — drives the feature. The three **launchers** all do the **same**
-  thing on click: they spawn a fresh read-only reviewer sub-agent and
-  auto-switch the user's view to it. **No panel or tab is ever mounted in the
-  current (owner) session** — there is no owner-session walkthrough surface at
-  all. The launchers carry **no** hard-coded `jobId`. A no-PR / spawn failure
-  surfaces as an inline error in the git-status-widget dropdown and spawns
-  nothing (no session, no view switch). Every click is a **fresh** reviewer
-  (there is no target dedup), so multiple reviewers per PR are allowed. See
+  deep-link — drives the feature. The launchers spawn a fresh read-only reviewer
+  sub-agent and auto-switch the user's view to it. **No panel or tab is ever
+  mounted in the current (owner) session** — there is no owner-session
+  walkthrough surface at all. The launchers carry **no** hard-coded `jobId`.
+  Selecting `/pr-walkthrough` from composer autocomplete/menu, using the
+  git-widget button, or using the command-palette launcher calls `run` with an
+  empty body and resolves the current branch's open PR. Typed composer forms can
+  pass an explicit PR target: `/pr-walkthrough <github-pr-url>` or
+  `/pr-walkthrough <pr-number>`. A no-PR / spawn failure surfaces as an inline
+  error in the git-status-widget dropdown and spawns nothing (no session, no view
+  switch). Every click is a **fresh** reviewer (there is no target dedup), so
+  multiple reviewers per PR are allowed. See
   [Launch model: the isolated reviewer child](#launch-model-the-isolated-reviewer-child).
 - **Run.** The launcher click calls the pack's **`run`** route, which mints a
   **real, isolated, read-only reviewer child** (`host.agents.spawn`) — it does
@@ -138,14 +142,27 @@ walkthrough pane.
 All three launchers — the **git-widget button**, the **composer-slash** launcher,
 and the **command-palette** launcher — carry the same declarative target
 `{ action: "spawn", route: "run", panelId: "pr-walkthrough.panel" }`
-(`entrypoints/pr-walkthrough-*.yaml`). On click the platform launcher dispatch
-(`src/app/pack-entrypoints.ts`) calls the pack's **`run`** route (POST, empty
-body) through the versioned Host API, and on `{ ok: true, childSessionId }` opens
-`panelId` **in that child session** via `host.ui.openPanel({ panelId, sessionId })`
+(`entrypoints/pr-walkthrough-*.yaml`). The platform launcher dispatch
+(`src/app/pack-entrypoints.ts`) calls the pack's **`run`** route (POST) through
+the versioned Host API, and on `{ ok: true, childSessionId }` opens `panelId`
+**in that child session** via `host.ui.openPanel({ panelId, sessionId })`
 (contract-v2 `PanelTarget.sessionId`), which performs a real session switch so the
 sidebar and main view follow. See
 [docs/extension-host-authoring.md](extension-host-authoring.md#entrypoints--non-chat-launchers--deep-link-routes-hostuinavigate)
 for the `SpawnLaunchTarget` entrypoint shape.
+
+Composer slash supports two full-line typed forms that use the same spawn path but
+provide an explicit target to `run`:
+
+- `/pr-walkthrough <github-pr-url>` sends `{ prUrl: "<github-pr-url>" }`.
+- `/pr-walkthrough <pr-number>` sends `{ prNumber: <pr-number> }`.
+
+These forms only change target resolution; they still spawn a fresh isolated
+reviewer child and switch the view to that child on success. Selecting
+`/pr-walkthrough` from the composer autocomplete/menu, typing `/pr-walkthrough`
+without an argument, clicking the git-widget launcher, and using the
+command-palette launcher all keep the empty-body behavior (`{}`), so `run`
+resolves the current branch's open GitHub PR.
 
 **Why spawn-on-click and not navigate-then-autorun?** The previous model navigated
 the *owner* session to the deep-link, transiently mounted the panel there, autoran
@@ -342,10 +359,11 @@ retired.
 
 ### Target resolution — GitHub PRs only
 
-When a launcher invokes `run` with an empty body (the normal path — the launcher
-surface, not any panel, calls the route on click), the `run` route resolves **the
-current branch's open GitHub PR** from the server-derived session worktree via
-`gh`/`git`. An explicit target in the body (a deep-link or test) always wins.
+When a launcher invokes `run` with an empty body (composer autocomplete/menu,
+git-widget, command palette, or typed `/pr-walkthrough` without an argument), the
+`run` route resolves **the current branch's open GitHub PR** from the
+server-derived session worktree via `gh`/`git`. An explicit target in the body
+(typed composer URL/number, a deep-link, or test) always wins.
 
 The walkthrough is **GitHub-PR-only**. The route rejects two cases before any
 spawn:

--- a/src/app/pack-entrypoints.ts
+++ b/src/app/pack-entrypoints.ts
@@ -265,8 +265,13 @@ export function listLauncherEntrypoints(kind?: LauncherKind): RegisteredLauncher
  * success (backward-compatible).
  */
 export interface LauncherDispatchResult { ok: boolean; error?: string; code?: string; }
+export interface LauncherDispatchOptions { body?: Record<string, unknown>; }
 
-export function runLauncherEntrypoint(keyOrId: string, onResult?: (r: LauncherDispatchResult) => void): void {
+export function runLauncherEntrypoint(
+	keyOrId: string,
+	onResult?: (r: LauncherDispatchResult) => void,
+	options?: LauncherDispatchOptions,
+): void {
 	let l = launchers.get(keyOrId);
 	if (!l) {
 		// Narrow fallback: a bare id that matches exactly ONE launcher resolves it.
@@ -283,7 +288,7 @@ export function runLauncherEntrypoint(keyOrId: string, onResult?: (r: LauncherDi
 	}
 	// Spawn launcher FIRST (it also carries a `panelId`, so an `action`-first check
 	// keeps it from being mis-routed to `openPackPanel`; design §3.1 / R3).
-	if (isSpawnLaunchTarget(l.target)) { void runSpawnLauncher(l, l.target, onResult); return; }
+	if (isSpawnLaunchTarget(l.target)) { void runSpawnLauncher(l, l.target, onResult, options?.body); return; }
 	if (isPanelTarget(l.target)) { openPackPanel(l.target, l.packId); onResult?.({ ok: true }); return; }
 	navigateToTarget(l.target as RouteTarget);
 	onResult?.({ ok: true });
@@ -295,15 +300,16 @@ export function runLauncherEntrypoint(keyOrId: string, onResult?: (r: LauncherDi
  *  reviewer (always-fresh, Q4). */
 const inFlightSpawnLaunch = new Set<string>();
 
-/** Dispatch a SpawnLaunchTarget: call the pack `route` (POST, empty body) on the
- *  active (owner) session via the launcher-bound Host API; on `ok:true` open the
- *  returned child's panel (which selects + switches). `ok:false` / errors flow back
- *  through `onResult` so the surface renders them inline — nothing is spawned on the
- *  owner session and the view never switches on failure. */
+/** Dispatch a SpawnLaunchTarget: call the pack `route` (POST) on the active
+ *  (owner) session via the launcher-bound Host API; on `ok:true` open the returned
+ *  child's panel (which selects + switches). `ok:false` / errors flow back through
+ *  `onResult` so the surface renders them inline — nothing is spawned on the owner
+ *  session and the view never switches on failure. */
 async function runSpawnLauncher(
 	l: RegisteredLauncher,
 	target: SpawnLaunchTarget,
 	onResult?: (r: LauncherDispatchResult) => void,
+	body?: Record<string, unknown>,
 ): Promise<void> {
 	if (inFlightSpawnLaunch.has(l.key)) return;      // ignore re-entrant click
 	inFlightSpawnLaunch.add(l.key);
@@ -312,7 +318,7 @@ async function runSpawnLauncher(
 		if (!host?.capabilities?.callRoute) { onResult?.({ ok: false, error: "PR Walkthrough is unavailable." }); return; }
 		let res: { ok?: boolean; childSessionId?: string; error?: string; code?: string } | undefined;
 		try {
-			res = await host.callRoute(target.route, { method: "POST", body: {} });
+			res = await host.callRoute(target.route, { method: "POST", body: body ?? {} });
 		} catch (e) {
 			const message = e instanceof Error ? e.message : String(e);
 			onResult?.({ ok: false, error: message });

--- a/src/ui/components/MessageEditor.ts
+++ b/src/ui/components/MessageEditor.ts
@@ -319,6 +319,27 @@ export class MessageEditor extends LitElement {
 		}
 	}
 
+	private _packSlashLaunchFromText(text: string): { entrypointId: string; body: Record<string, unknown> } | undefined {
+		const trimmed = text.trim();
+		const match = trimmed.match(/^\/([A-Za-z0-9_.-]+)(?:\s+([\s\S]+))?$/);
+		if (!match) return undefined;
+
+		const name = match[1];
+		const launcher = listLauncherEntrypoints("composer-slash").find((l) => l.id === name);
+		if (!launcher) return undefined;
+
+		const arg = (match[2] ?? "").trim();
+		if (!arg) return { entrypointId: launcher.key, body: {} };
+
+		// PR walkthrough's run route already accepts these argument fields.
+		if (launcher.packId === "pr-walkthrough" || launcher.id === "pr-walkthrough") {
+			if (/^\d+$/.test(arg)) return { entrypointId: launcher.key, body: { prNumber: Number(arg) } };
+			return { entrypointId: launcher.key, body: { prUrl: arg } };
+		}
+
+		return { entrypointId: launcher.key, body: { input: arg } };
+	}
+
 	/** Fetch the file list for the current `@` query from the server (debounced).
 	 *  Mirrors `_loadSlashSkills` but is query-scoped because the file tree can be
 	 *  large/remote, so the server does the filtering + ranking. */
@@ -696,6 +717,26 @@ export class MessageEditor extends LitElement {
 			}
 		}
 		this._sendSizeError = "";
+		const packSlashLaunch = this.attachments.length === 0 ? this._packSlashLaunchFromText(text) : undefined;
+		if (packSlashLaunch) {
+			this._slashMenuOpen = false;
+			this.dispatchEvent(new CustomEvent("message-send", { bubbles: true, composed: true }));
+			this.value = "";
+			this.onInput?.(this.value);
+			const textarea = this.textareaRef.value;
+			if (textarea) {
+				textarea.value = this.value;
+				textarea.focus();
+			}
+			this._historyIndex = -1;
+			this._savedDraft = "";
+			void this.addToHistory(text);
+
+			runLauncherEntrypoint(packSlashLaunch.entrypointId, (r) => {
+				if (!r.ok) this._showLauncherError(r.error || "Could not start the PR walkthrough.");
+			}, { body: packSlashLaunch.body });
+			return;
+		}
 		// Dispatch a composed event that escapes shadow DOM — used by
 		// session-manager for draft cleanup without monkey-patching.
 		this.dispatchEvent(new CustomEvent("message-send", { bubbles: true, composed: true }));

--- a/tests/fixtures/message-editor-pack-slash-entry.ts
+++ b/tests/fixtures/message-editor-pack-slash-entry.ts
@@ -1,0 +1,108 @@
+// Test entry — bundles the REAL <message-editor> with the client pack launcher
+// registry to pin typed pack composer-slash dispatch behavior.
+import "../../src/ui/components/MessageEditor.js";
+import { MessageEditor } from "../../src/ui/components/MessageEditor.js";
+import { registerPackEntrypoints, launcherKey } from "../../src/app/pack-entrypoints.js";
+import { setLauncherHostFactory } from "../../src/app/pack-panels.js";
+
+(window as any).MessageEditorClass = MessageEditor;
+
+type CallRouteCall = {
+	route: string;
+	sessionId: string | undefined;
+	packId: string;
+	contributionId: string;
+	body?: unknown;
+};
+
+const sendCalls: Array<{ text: string; attachmentCount: number }> = [];
+const inputCalls: string[] = [];
+const callRouteCalls: CallRouteCall[] = [];
+const messageSendEvents: string[] = [];
+
+function installPrWalkthroughLauncher(): void {
+	callRouteCalls.length = 0;
+	registerPackEntrypoints([
+		{
+			id: "pr-walkthrough",
+			packId: "pr-walkthrough",
+			kind: "composer-slash",
+			label: "PR Walkthrough",
+			target: { action: "spawn", route: "run", panelId: "pr-walkthrough.panel" },
+		},
+	] as any, "project-a");
+	setLauncherHostFactory((sessionId, packId, contributionId) => ({
+		capabilities: { callRoute: true } as any,
+		callRoute: async (route: string, init?: { body?: unknown }) => {
+			callRouteCalls.push({ route, sessionId, packId, contributionId, body: init?.body });
+			return { ok: true, childSessionId: "child-pr", jobId: "job-pr" };
+		},
+		ui: { openPanel: () => { /* not needed for these assertions */ } },
+	}) as any);
+}
+
+function textarea(el: HTMLElement): HTMLTextAreaElement {
+	const ta = el.querySelector("textarea") as HTMLTextAreaElement | null;
+	if (!ta) throw new Error("textarea not found in message-editor");
+	return ta;
+}
+
+function mount(container: HTMLElement): any {
+	container.innerHTML = "";
+	sendCalls.length = 0;
+	inputCalls.length = 0;
+	messageSendEvents.length = 0;
+	installPrWalkthroughLauncher();
+	const el = document.createElement("message-editor") as any;
+	el.sessionId = "pack-slash-session";
+	el.showAttachmentButton = false;
+	el.showModelSelector = false;
+	el.showThinkingSelector = false;
+	el.onInput = (value: string) => inputCalls.push(value);
+	el.onSend = (text: string, attachments: unknown[]) => sendCalls.push({ text, attachmentCount: attachments.length });
+	el.addEventListener("message-send", () => { messageSendEvents.push(el.value); });
+	container.appendChild(el);
+	return el;
+}
+
+(window as any).__mountEditor = mount;
+(window as any).__setValue = async (el: any, value: string): Promise<void> => {
+	await el.updateComplete;
+	const ta = textarea(el);
+	ta.value = value;
+	ta.setSelectionRange(value.length, value.length);
+	ta.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+	await el.updateComplete;
+};
+(window as any).__pressEnter = async (el: any): Promise<void> => {
+	await el.updateComplete;
+	const ta = textarea(el);
+	ta.focus();
+	ta.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+	await new Promise((r) => setTimeout(r, 30));
+	await el.updateComplete;
+};
+(window as any).__typeText = async (el: any, text: string): Promise<void> => {
+	await el.updateComplete;
+	const ta = textarea(el);
+	ta.focus();
+	for (const ch of text) {
+		ta.value += ch;
+		ta.setSelectionRange(ta.value.length, ta.value.length);
+		ta.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+		await el.updateComplete;
+	}
+};
+(window as any).__isSlashMenuOpen = (el: any): boolean => !!el.querySelector(".slash-menu");
+(window as any).__slashEntryKey = (): string => launcherKey("pr-walkthrough", "pr-walkthrough");
+(window as any).__getSendCalls = () => sendCalls.slice();
+(window as any).__getInputCalls = () => inputCalls.slice();
+(window as any).__getCallRouteCalls = () => callRouteCalls.slice();
+(window as any).__getMessageSendEvents = () => messageSendEvents.slice();
+(window as any).__resetCalls = () => {
+	sendCalls.length = 0;
+	inputCalls.length = 0;
+	callRouteCalls.length = 0;
+	messageSendEvents.length = 0;
+};
+(window as any).__ready = true;

--- a/tests/fixtures/message-editor-pack-slash.html
+++ b/tests/fixtures/message-editor-pack-slash.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8" /><title>MessageEditor pack slash fixture</title></head>
+<body>
+<div id="container"></div>
+<script src="./message-editor-pack-slash-bundle.js"></script>
+</body>
+</html>

--- a/tests/fixtures/pack-entrypoints-reconcile-entry.ts
+++ b/tests/fixtures/pack-entrypoints-reconcile-entry.ts
@@ -127,15 +127,15 @@ const PANEL_MODULE = "export default function(){ return { render(){ return ''; }
 // back through onResult; a never-resolving `callRoute` proves the within-gesture guard
 // suppresses a second concurrent click.
 type SpawnBehavior = "ok" | "nopr" | "throw" | "hang";
-const callRouteCalls: Array<{ route: string; sessionId: string | undefined; packId: string; contributionId: string }> = [];
+const callRouteCalls: Array<{ route: string; sessionId: string | undefined; packId: string; contributionId: string; body?: unknown }> = [];
 const openPanelCalls: Array<{ panelId?: string; sessionId?: string }> = [];
 (window as any).__installLauncherHost = (behavior: SpawnBehavior): void => {
 	callRouteCalls.length = 0;
 	openPanelCalls.length = 0;
 	setLauncherHostFactory((sessionId, packId, contributionId) => ({
 		capabilities: { callRoute: true } as any,
-		callRoute: async (route: string) => {
-			callRouteCalls.push({ route, sessionId, packId, contributionId });
+		callRoute: async (route: string, init?: { body?: unknown }) => {
+			callRouteCalls.push({ route, sessionId, packId, contributionId, body: init?.body });
 			if (behavior === "nopr") return { ok: false, code: "NO_PR", error: "No open GitHub PR for the current branch." };
 			if (behavior === "throw") throw new Error("spawn boom");
 			if (behavior === "hang") return await new Promise(() => { /* never resolves */ });
@@ -149,6 +149,11 @@ const openPanelCalls: Array<{ panelId?: string; sessionId?: string }> = [];
 (window as any).__runSpawn = (keyOrId: string): Promise<any> => new Promise((resolve) => {
 	let settled = false;
 	runLauncherEntrypoint(keyOrId, (r) => { settled = true; resolve(r); });
+	setTimeout(() => { if (!settled) resolve(null); }, 250);
+});
+(window as any).__runSpawnWithBody = (keyOrId: string, body: Record<string, unknown>): Promise<any> => new Promise((resolve) => {
+	let settled = false;
+	(runLauncherEntrypoint as any)(keyOrId, (r: any) => { settled = true; resolve(r); }, { body });
 	setTimeout(() => { if (!settled) resolve(null); }, 250);
 });
 // Fire the SAME launcher twice synchronously (a re-entrant double-click) — the

--- a/tests/message-editor-pack-slash.spec.ts
+++ b/tests/message-editor-pack-slash.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * PR walkthrough pack slash launch regression coverage (real <message-editor>).
+ *
+ * Typed full-line `/pr-walkthrough <arg>` sends must dispatch the registered
+ * composer-slash spawn launcher instead of falling through to normal chat.
+ */
+import { test, expect } from "@playwright/test";
+import path from "node:path";
+import { buildBundle } from "./fixtures/build-bundle.js";
+
+const FIXTURE = path.resolve("tests/fixtures/message-editor-pack-slash.html");
+const BUNDLE = path.resolve("tests/fixtures/message-editor-pack-slash-bundle.js");
+const ENTRY = path.resolve("tests/fixtures/message-editor-pack-slash-entry.ts");
+const EDITOR_SRC = path.resolve("src/ui/components/MessageEditor.ts");
+const PACK_ENTRYPOINTS_SRC = path.resolve("src/app/pack-entrypoints.ts");
+const PACK_PANELS_SRC = path.resolve("src/app/pack-panels.ts");
+
+test.beforeAll(() => {
+	buildBundle({ entry: ENTRY, outfile: BUNDLE, deps: [ENTRY, EDITOR_SRC, PACK_ENTRYPOINTS_SRC, PACK_PANELS_SRC] });
+});
+
+const PAGE = `file://${FIXTURE}`;
+
+async function ready(page: any) {
+	await page.goto(PAGE);
+	await page.waitForFunction(() => (window as any).__ready === true, null, { timeout: 10_000 });
+}
+
+async function sendTypedComposerValue(page: any, text: string) {
+	return await page.evaluate(async (value) => {
+		const w = window as any;
+		const el = w.__mountEditor(document.getElementById("container"));
+		await el.updateComplete;
+		await w.__setValue(el, value);
+		await w.__pressEnter(el);
+		return {
+			sendCalls: w.__getSendCalls(),
+			callRoute: w.__getCallRouteCalls(),
+			messageSendEvents: w.__getMessageSendEvents(),
+		};
+	}, text);
+}
+
+test.describe("MessageEditor pack composer slash dispatch", () => {
+	test("typed /pr-walkthrough <github-pr-url> launches the PR walkthrough route and does not call onSend", async ({ page }) => {
+		await ready(page);
+		const prUrl = "https://github.com/SuuBro/bobbit/pull/764";
+		const out = await sendTypedComposerValue(page, `/pr-walkthrough ${prUrl}`);
+
+		expect(out.sendCalls).toHaveLength(0);
+		expect(out.callRoute).toHaveLength(1);
+		expect(out.callRoute[0]).toMatchObject({
+			route: "run",
+			packId: "pr-walkthrough",
+			contributionId: "pr-walkthrough",
+			body: { prUrl },
+		});
+		expect(out.messageSendEvents).toHaveLength(1);
+	});
+
+	test("typed /pr-walkthrough <pr-number> launches the PR walkthrough route and does not call onSend", async ({ page }) => {
+		await ready(page);
+		const out = await sendTypedComposerValue(page, "/pr-walkthrough 764");
+
+		expect(out.sendCalls).toHaveLength(0);
+		expect(out.callRoute).toHaveLength(1);
+		expect(out.callRoute[0]).toMatchObject({
+			route: "run",
+			packId: "pr-walkthrough",
+			contributionId: "pr-walkthrough",
+			body: { prNumber: 764 },
+		});
+		expect(out.messageSendEvents).toHaveLength(1);
+	});
+
+	test("selecting /pr-walkthrough from autocomplete still launches with an empty body", async ({ page }) => {
+		await ready(page);
+		const out = await page.evaluate(async () => {
+			const w = window as any;
+			const el = w.__mountEditor(document.getElementById("container"));
+			await el.updateComplete;
+			await w.__typeText(el, "/pr-walkthrough");
+			if (!w.__isSlashMenuOpen(el)) throw new Error("slash menu did not open for /pr-walkthrough");
+			await w.__pressEnter(el);
+			return {
+				sendCalls: w.__getSendCalls(),
+				callRoute: w.__getCallRouteCalls(),
+				messageSendEvents: w.__getMessageSendEvents(),
+			};
+		});
+
+		expect(out.sendCalls).toHaveLength(0);
+		expect(out.callRoute).toHaveLength(1);
+		expect(out.callRoute[0]).toMatchObject({ route: "run", body: {} });
+		expect(out.messageSendEvents).toHaveLength(0);
+	});
+});

--- a/tests/pack-entrypoints-reconcile.spec.ts
+++ b/tests/pack-entrypoints-reconcile.spec.ts
@@ -284,6 +284,25 @@ test.describe("pack-entrypoints registry (pack schema V1 §8.2)", () => {
 		expect(out.fetches.some((u: string) => u.includes("/panels/"))).toBe(false);
 	});
 
+	test("T-1 — spawn launcher passes an explicit route body to callRoute", async ({ page }) => {
+		await gotoAndWait(page);
+		const prUrl = "https://github.com/SuuBro/bobbit/pull/764";
+		const out = await page.evaluate(async (body) => {
+			await (window as any).__reconcile("A");
+			(window as any).__installLauncherHost("ok");
+			const result = await (window as any).__runSpawnWithBody("tp.spawn", body);
+			await (window as any).__flush();
+			return {
+				result,
+				callRoute: (window as any).__callRouteCalls(),
+			};
+		}, { prUrl });
+
+		expect(out.result).toEqual({ ok: true });
+		expect(out.callRoute).toHaveLength(1);
+		expect(out.callRoute[0]).toMatchObject({ route: "run", body: { prUrl } });
+	});
+
 	test("T-1 — a NO_PR (ok:false) result flows back through onResult; no panel opens", async ({ page }) => {
 		await gotoAndWait(page);
 		const out = await page.evaluate(async () => {


### PR DESCRIPTION
## Summary
- Route typed `/pr-walkthrough <github-pr-url>` and `/pr-walkthrough <pr-number>` through the registered composer-slash spawn launcher instead of chat send
- Add additive spawn launcher body dispatch while preserving empty-body behavior for existing launch surfaces
- Add focused Playwright coverage and document typed composer usage

## Verification
- `npx playwright test --config tests/playwright.config.ts tests/pack-entrypoints-reconcile.spec.ts tests/message-editor-pack-slash.spec.ts`
- `npm run check`
- Workflow implementation gate passed build, type check, focused repro, unit, E2E, and reviews

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)