### PR TITLE
Shared Worktree Guard

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -646,6 +646,18 @@ Multi-repo pool entries are sets: each pool slot pre-builds N worktrees (one per
 
 **Session flow.** Pool entries pre-build on `pool/_pool-<id>`. On claim, `pool.claim(targetBranch)` runs the single branch-rename + worktree-move to the final `session/<id8>` name and the session is persisted with that name immediately. There is no first-prompt rename. The display title is independent of the git ref - `PUT /api/sessions/:id/title` updates metadata only. Archive cleanup operates on the final branch. See [Remove session worktree & branch renaming](design/remove-session-worktree-rename.md) for the full rationale and the test plan.
 
+**Shared worktree deletion guard.** Cleanup must never remove a worktree just because the session or goal currently being archived, purged, or repaired owns a stale record for it. Delegates, continued sessions, read-only children, shared session flows, and multi-repo goal/session sets can leave more than one persisted session pointing at the same host path. Deleting that path while any non-archived session still references it loses the other session's working tree and branch context.
+
+Before deleting a host worktree, cleanup checks persisted sessions across visible project contexts and skips deletion if any other non-archived session references the same normalized path. The guard considers:
+
+- `worktreePath` - the single-repo worktree root.
+- `cwd` - protects the candidate when the live session cwd is the same path or a child of it, which covers subdirectory projects.
+- `repoWorktrees` - every per-repo worktree path in a multi-repo session.
+
+Normalization is intentionally host-path focused: paths are trimmed, backslashes are treated as forward slashes, trailing separators are ignored, and comparison is case-insensitive. This lets Windows and Linux-style separators, casing differences, and stored `cwd` offsets compare consistently. It is not a broad ownership lock: if no live session references the normalized path, true orphan cleanup is still allowed.
+
+Protected cleanup paths include archived-session purge, manual maintenance orphan listing and cleanup, boot worktree sweeper classification/cleanup, multi-repo goal archive cleanup, and setup-failure cleanup. The existing delegate skip remains, but shared-path detection is the authoritative protection.
+
 **Boot sweeper.** `worktree-sweeper.ts` runs at server boot and reconciles `.git/worktrees/*` against persisted session/goal/staff records. It detects:
 
 - `pool/_pool-<id>` worktrees not in the in-memory pool - reclaimed.
@@ -661,8 +673,8 @@ This means crash recovery doesn't require the user to manually clean up pool det
 
 1. **Creation**: When `POST /api/sessions` creates a non-goal, non-assistant session in a git repo, the server auto-generates worktree options. For host sessions, the pool claim (or fallback `git worktree add`) creates the branch. For sandbox sessions, `ProjectSandbox.createWorktree()` creates it inside the container. In multi-repo projects, this provisions a worktree set (one per configured repo) at the `pool/_pool-<id>` branch; all repos share the same branch name; on first claim the pool entry's `pool/_pool-<id>` is renamed once to `session/<id8>` (or the goal branch as appropriate). Staff worktrees are provisioned by `StaffManager` directly and use the same project worktree-root/base-ref/component setup helpers when auto mode chooses a worktree. **Subdirectory projects**: When a project's `rootPath` is a subdirectory of a git repo (e.g. `/repo/packages/my-app`), worktrees are still created at the git repo root level (full checkout), but the session `cwd` is offset to the corresponding subdirectory within the worktree. The `worktreePath` remains the worktree root (for cleanup). This offset is computed via `path.relative(repoRoot, project.rootPath)` and applied consistently in goal creation, `executeWorktreeAsync`, pool claims, staff provisioning, and team member spawning.
 2. **Working**: The agent works in the worktree directory (or subdirectory for offset projects). The git status widget shows ahead/behind master, and push/pull controls work the same as for goal branches.
-3. **Cleanup**: On session terminate or archive, the worktree and branch are removed via `cleanupWorktree()` (host) or `ProjectSandbox.removeWorktree()` (sandbox).
-4. **Orphan detection**: Orphaned `session/*` worktrees (from ungraceful shutdowns where cleanup didn't run) are **not** removed automatically on startup. Use Settings → Maintenance tab to preview orphaned worktrees and clean them up manually. The REST API (`GET /api/maintenance/orphaned-worktrees`) lists orphans; `POST /api/maintenance/cleanup-worktrees` removes them after validation.
+3. **Cleanup**: On session terminate or archive, the worktree and branch are removed via `cleanupWorktree()` (host) or `ProjectSandbox.removeWorktree()` (sandbox) only after the shared worktree deletion guard confirms no other non-archived session still references the same host path.
+4. **Orphan detection**: Orphaned `session/*` worktrees (from ungraceful shutdowns where cleanup didn't run) are exposed in Settings → Maintenance and through the REST API (`GET /api/maintenance/orphaned-worktrees`, `POST /api/maintenance/cleanup-worktrees`). The same shared-path guard keeps live referenced paths out of the orphan list; unreferenced worktrees remain eligible for cleanup.
 5. **Restore**: After a restart, existing session worktrees are reused - the server reconnects to the worktree on disk without recreating it.
 
 **Session creation modes:** The session-setup pipeline (`src/server/agent/session-setup.ts`) handles four modes, all routed through the same plan/execute structure:

--- a/src/server/agent/goal-manager.ts
+++ b/src/server/agent/goal-manager.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { execFile as execFileCb } from "node:child_process";
+import fs from "node:fs";
 import { promisify } from "node:util";
 import path from "node:path";
 import { GoalStore, type GoalState, type PersistedGoal } from "./goal-store.js";
@@ -11,6 +12,7 @@ import type { Component } from "./project-config-store.js";
 import type { GateStore } from "./gate-store.js";
 import type { TeamStore } from "./team-store.js";
 import type { SessionStore } from "./session-store.js";
+import { isWorktreePathReferencedByLiveSession, type WorktreeReferenceRecord } from "./worktree-reference-guard.js";
 
 const pExecFile = promisify(execFileCb);
 
@@ -108,12 +110,34 @@ export class GoalManager {
 	 * setupWorktreeAndStartTeam to create the worktree from the right base
 	 * branch. Set by server.ts on startup. */
 	private baseRefResolver?: (projectId: string) => string | undefined;
+	private liveSessionResolver?: () => WorktreeReferenceRecord[];
 	setBaseRefResolver(resolver: (projectId: string) => string | undefined): void {
 		this.baseRefResolver = resolver;
 	}
 	/** Returns the configured base ref for a project, if set. */
 	getBaseRef(projectId: string): string | undefined {
 		return this.baseRefResolver?.(projectId);
+	}
+
+	setLiveSessionResolver(resolver: () => WorktreeReferenceRecord[]): void {
+		this.liveSessionResolver = resolver;
+	}
+
+	private getSessionsForWorktreeGuard(): WorktreeReferenceRecord[] {
+		if (this.liveSessionResolver) return this.liveSessionResolver();
+		try {
+			const storeDir = (this.store as unknown as { storeDir?: string }).storeDir;
+			if (!storeDir) return [];
+			const sessionFile = path.join(storeDir, "sessions.json");
+			if (!fs.existsSync(sessionFile)) return [];
+			const raw = JSON.parse(fs.readFileSync(sessionFile, "utf8"));
+			if (Array.isArray(raw)) return raw as WorktreeReferenceRecord[];
+			if (Array.isArray(raw?.sessions)) return raw.sessions as WorktreeReferenceRecord[];
+			if (raw && typeof raw === "object") return Object.values(raw).filter(Array.isArray).flat() as WorktreeReferenceRecord[];
+		} catch {
+			// Best-effort guard; missing/corrupt session store should not block archive.
+		}
+		return [];
 	}
 
 	constructor(goalStore: GoalStore, workflowStore?: WorkflowStore) {
@@ -765,7 +789,12 @@ export class GoalManager {
 		if (archived && goal.repoWorktrees && goal.repoPath && goal.branch && Object.keys(goal.repoWorktrees).length > 0) {
 			const { cleanupWorktree } = await import("../skills/git.js");
 			const entries = Object.entries(goal.repoWorktrees);
+			const sessions = this.getSessionsForWorktreeGuard();
 			Promise.allSettled(entries.map(([repo, wt]) => {
+				if (isWorktreePathReferencedByLiveSession(wt, sessions)) {
+					console.log(`[goal-manager] Skipping shared goal worktree cleanup for archived goal ${goal.id}: ${wt}`);
+					return Promise.resolve();
+				}
 				const repoPath = repo === "." ? goal.repoPath! : path.join(goal.repoPath!, repo);
 				return cleanupWorktree(repoPath, wt, goal.branch, true);
 			})).catch(() => { /* swallow — best-effort */ });

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -31,6 +31,7 @@ import {
 	mergeCompactionSidecarIntoMessages,
 } from "./compaction-sidecar.js";
 import { SessionStore, type PersistedSession } from "./session-store.js";
+import { isWorktreePathReferencedByLiveSession, type WorktreeReferenceRecord } from "./worktree-reference-guard.js";
 import { BgProcessStore } from "./bg-process-store.js";
 import { SessionSecretStore } from "../auth/session-secret.js";
 import { shouldKeepDespiteOrphan, scanOrphanedTranscripts } from "./orphan-cleanup.js";
@@ -1185,6 +1186,12 @@ export class SessionManager {
 		return null;
 	}
 
+	private getAllPersistedSessionsForWorktreeGuard(): PersistedSession[] {
+		return this.projectContextManager
+			? this.projectContextManager.getAllSessions()
+			: (this._testStore?.getAll() ?? []);
+	}
+
 	/** Resolve the correct CostTracker for a session based on its project. */
 	private resolveCostTracker(session: { projectId?: string }): CostTracker {
 		if (session.projectId && this.projectContextManager) {
@@ -1269,6 +1276,7 @@ export class SessionManager {
 		} else {
 			throw new Error("Cannot build pipeline context: no project context manager or test stores");
 		}
+		resolvedGoalManager.setLiveSessionResolver(() => this.getAllPersistedSessionsForWorktreeGuard());
 		return {
 			agentCliPath: this.agentCliPath,
 			systemPromptPath: this.systemPromptPath,
@@ -1287,6 +1295,7 @@ export class SessionManager {
 			store: resolvedStore,
 			searchIndex: resolvedSearchIndex,
 			sessions: this.sessions,
+			listPersistedSessionsForWorktreeGuard: () => this.getAllPersistedSessionsForWorktreeGuard(),
 			assemblePrompt: (id, parts) => this.assemblePrompt(id, parts),
 
 			applySandboxWiring: (opts, id, sandboxOpts) => this.applySandboxWiring(opts, id, sandboxOpts),
@@ -6209,15 +6218,22 @@ export class SessionManager {
 		if (ps.worktreePath && ps.repoPath && !ps.worktreePath.startsWith("/workspace") && !ps.delegateOf) {
 			try {
 				const { cleanupWorktree } = await import("../skills/git.js");
+				const allPersisted = this.getAllPersistedSessionsForWorktreeGuard();
 				// Multi-repo: clean each repo's worktree in parallel + delete the
 				// shared branch from each repo's remote (Phase 4a).
 				if (ps.repoWorktrees && Object.keys(ps.repoWorktrees).length > 0) {
 					await Promise.allSettled(Object.entries(ps.repoWorktrees).map(([repo, wt]) => {
+						if (isWorktreePathReferencedByLiveSession(wt, allPersisted, { ignoreSessionId: ps.id })) {
+							console.log(`[session-manager] Skipping shared worktree cleanup for purged session ${ps.id}: ${wt}`);
+							return Promise.resolve();
+						}
 						const repoPath = repo === "." ? ps.repoPath! : path.join(ps.repoPath!, repo);
 						return cleanupWorktree(repoPath, wt, ps.branch, true);
 					}));
-				} else {
+				} else if (!isWorktreePathReferencedByLiveSession(ps.worktreePath, allPersisted, { ignoreSessionId: ps.id })) {
 					await cleanupWorktree(ps.repoPath, ps.worktreePath, ps.branch, true);
+				} else {
+					console.log(`[session-manager] Skipping shared worktree cleanup for purged session ${ps.id}: ${ps.worktreePath}`);
 				}
 			} catch (err) {
 				console.error(`[session-manager] Failed to cleanup worktree for ${ps.id}:`, err);
@@ -6342,18 +6358,25 @@ export class SessionManager {
 			const { stdout } = await execFileAsync("git", ["worktree", "list", "--porcelain"], { cwd: repoPath });
 			const blocks = stdout.split("\n\n");
 
-			// Build a set of branches owned by live (non-archived) persisted sessions.
+			// Build a set of branches/paths owned by live (non-archived) persisted sessions.
 			// Prior to the fix, pool worktree directories were renamed on claim but
 			// `git worktree repair` could fail — git tracked the OLD path while
 			// the session stored the NEW path. Matching by branch prevents the
 			// cleanup from deleting worktrees that are actually in use.
 			const persistedBranches = new Set<string>();
-			const allPersisted = this.projectContextManager
-				? [...this.projectContextManager.getAllLiveSessions()]
-				: (this._testStore?.getLive() ?? []);
+			const allPersisted = this.getAllPersistedSessionsForWorktreeGuard();
 			for (const ps of allPersisted) {
-				if (ps.branch) persistedBranches.add(ps.branch);
+				if (!ps.archived && ps.branch) persistedBranches.add(ps.branch);
 			}
+			const runtimeRecords: WorktreeReferenceRecord[] = [...this.sessions.values()].map(s => ({
+				id: s.id,
+				worktreePath: s.worktreePath,
+				cwd: s.cwd,
+				repoWorktrees: s.repoWorktrees
+					? Object.fromEntries(s.repoWorktrees.map(w => [w.repo, w.worktreePath]))
+					: undefined,
+			}));
+			const allPathRecords: WorktreeReferenceRecord[] = [...allPersisted, ...runtimeRecords];
 
 			for (const block of blocks) {
 				const branchMatch = block.match(/^branch refs\/heads\/(session\/.+)$/m);
@@ -6365,15 +6388,8 @@ export class SessionManager {
 				const pathMatch = block.match(/^worktree (.+)$/m);
 				if (!pathMatch) continue;
 				const wtPath = pathMatch[1];
-				// Normalize paths for comparison — git uses forward slashes on Windows,
-				// but session store uses OS-native backslashes. Without normalization,
-				// every session worktree is considered "orphaned" and deleted on restart.
-				const normalize = (p: string | undefined) => p?.replace(/\\/g, "/").toLowerCase();
-				const normalizedWtPath = normalize(wtPath);
 				// Check if any active session uses this worktree (by path or branch)
-				const isActive = [...this.sessions.values()].some(
-					s => normalize(s.worktreePath) === normalizedWtPath || normalize(s.cwd) === normalizedWtPath
-				) || persistedBranches.has(branch);
+				const isActive = isWorktreePathReferencedByLiveSession(wtPath, allPathRecords) || persistedBranches.has(branch);
 				if (!isActive) {
 					console.log(`[session-manager] Cleaning up orphaned session worktree: ${wtPath} (branch: ${branch})`);
 					const { cleanupWorktree } = await import("../skills/git.js");
@@ -6395,12 +6411,19 @@ export class SessionManager {
 			const blocks = stdout.split("\n\n");
 
 			const persistedBranches = new Set<string>();
-			const allPersisted = this.projectContextManager
-				? [...this.projectContextManager.getAllLiveSessions()]
-				: (this._testStore?.getLive() ?? []);
+			const allPersisted = this.getAllPersistedSessionsForWorktreeGuard();
 			for (const ps of allPersisted) {
-				if (ps.branch) persistedBranches.add(ps.branch);
+				if (!ps.archived && ps.branch) persistedBranches.add(ps.branch);
 			}
+			const runtimeRecords: WorktreeReferenceRecord[] = [...this.sessions.values()].map(s => ({
+				id: s.id,
+				worktreePath: s.worktreePath,
+				cwd: s.cwd,
+				repoWorktrees: s.repoWorktrees
+					? Object.fromEntries(s.repoWorktrees.map(w => [w.repo, w.worktreePath]))
+					: undefined,
+			}));
+			const allPathRecords: WorktreeReferenceRecord[] = [...allPersisted, ...runtimeRecords];
 
 			const orphans: Array<{ path: string; branch: string }> = [];
 			for (const block of blocks) {
@@ -6411,11 +6434,7 @@ export class SessionManager {
 				const pathMatch = block.match(/^worktree (.+)$/m);
 				if (!pathMatch) continue;
 				const wtPath = pathMatch[1];
-				const normalize = (p: string | undefined) => p?.replace(/\\/g, "/").toLowerCase();
-				const normalizedWtPath = normalize(wtPath);
-				const isActive = [...this.sessions.values()].some(
-					s => normalize(s.worktreePath) === normalizedWtPath || normalize(s.cwd) === normalizedWtPath
-				) || persistedBranches.has(branch);
+				const isActive = isWorktreePathReferencedByLiveSession(wtPath, allPathRecords) || persistedBranches.has(branch);
 				if (!isActive) {
 					orphans.push({ path: wtPath, branch });
 				}

--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -39,6 +39,7 @@ import { getAssistantDef } from "./assistant-registry.js";
 import { buildReattemptContext } from "./goal-assistant.js";
 import { computeToolActivationArgs, writeMcpProxyExtensions, writeToolGuardExtension, computeEffectiveAllowedTools, type EffectiveTool } from "./tool-activation.js";
 import { createWorktree, cleanupWorktree } from "../skills/git.js";
+import { isWorktreePathReferencedByLiveSession, type WorktreeReferenceRecord } from "./worktree-reference-guard.js";
 
 import { TOOLS_DIR } from "./tool-manager.js";
 import { profile, profileAsync, recordElapsed } from "./profiling.js";
@@ -230,6 +231,7 @@ export interface PipelineContext {
 	store: SessionStore;
 	searchIndex: SearchService;
 	sessions: Map<string, SessionInfo>;
+	listPersistedSessionsForWorktreeGuard?: () => WorktreeReferenceRecord[];
 	assemblePrompt: (id: string, parts: PromptParts) => string | undefined;
 
 	applySandboxWiring: (opts: RpcBridgeOptions, id: string, sandboxOpts?: SandboxWiringOptions) => Promise<boolean>;
@@ -1293,7 +1295,12 @@ export function handleSetupFailure(
 
 	// 4. Background worktree cleanup (slow, non-blocking)
 	if (plan.worktreePath && plan.repoPath && plan.branch) {
-		cleanupWorktree(plan.repoPath, plan.worktreePath, plan.branch, true).catch(() => {});
+		const persistedSessions = ctx.listPersistedSessionsForWorktreeGuard?.() ?? ctx.store.getAll();
+		if (!isWorktreePathReferencedByLiveSession(plan.worktreePath, persistedSessions, { ignoreSessionId: session.id })) {
+			cleanupWorktree(plan.repoPath, plan.worktreePath, plan.branch, true).catch(() => {});
+		} else {
+			console.log(`[session-setup] Skipping setup-failure cleanup for shared worktree ${plan.worktreePath} (session ${session.id})`);
+		}
 	}
 
 	// 5. Clean up sandbox token for this session

--- a/src/server/agent/worktree-reference-guard.ts
+++ b/src/server/agent/worktree-reference-guard.ts
@@ -1,0 +1,86 @@
+import type { PersistedSession } from "./session-store.js";
+
+export interface WorktreeReferenceRecord {
+	id?: string;
+	archived?: boolean;
+	worktreePath?: string;
+	cwd?: string;
+	repoWorktrees?: Record<string, string>;
+}
+
+export interface WorktreeReferenceOptions {
+	ignoreSessionId?: string;
+}
+
+/** Normalize host worktree paths for cross-platform ownership checks. */
+export function normalizeWorktreeHostPath(p?: string): string | undefined {
+	if (!p) return undefined;
+	let normalized = p.trim().replace(/\\/g, "/");
+	while (normalized.length > 1 && normalized.endsWith("/")) {
+		normalized = normalized.slice(0, -1);
+	}
+	return normalized ? normalized.toLowerCase() : undefined;
+}
+
+function isSameOrChildPath(candidate: string, reference: string): boolean {
+	return reference === candidate || reference.startsWith(`${candidate}/`);
+}
+
+function liveRecords(
+	sessions: Iterable<WorktreeReferenceRecord | PersistedSession>,
+	options?: WorktreeReferenceOptions,
+): WorktreeReferenceRecord[] {
+	const records: WorktreeReferenceRecord[] = [];
+	for (const session of sessions) {
+		if (!session || session.archived) continue;
+		if (options?.ignoreSessionId && session.id === options.ignoreSessionId) continue;
+		records.push(session);
+	}
+	return records;
+}
+
+/** Collect exact worktree roots referenced by live sessions. */
+export function collectLiveSessionWorktreePaths(
+	sessions: Iterable<WorktreeReferenceRecord | PersistedSession>,
+	options?: WorktreeReferenceOptions,
+): Set<string> {
+	const paths = new Set<string>();
+	for (const session of liveRecords(sessions, options)) {
+		const worktreePath = normalizeWorktreeHostPath(session.worktreePath);
+		if (worktreePath) paths.add(worktreePath);
+		const cwd = normalizeWorktreeHostPath(session.cwd);
+		if (cwd) paths.add(cwd);
+		if (session.repoWorktrees) {
+			for (const wt of Object.values(session.repoWorktrees)) {
+				const normalized = normalizeWorktreeHostPath(wt);
+				if (normalized) paths.add(normalized);
+			}
+		}
+	}
+	return paths;
+}
+
+/**
+ * Return true when another non-archived persisted session still references the
+ * candidate worktree path. `cwd` protects the candidate when it is equal to or
+ * inside the candidate worktree; worktreePath/repoWorktrees require exact roots.
+ */
+export function isWorktreePathReferencedByLiveSession(
+	candidatePath: string | undefined,
+	sessions: Iterable<WorktreeReferenceRecord | PersistedSession>,
+	options?: WorktreeReferenceOptions,
+): boolean {
+	const candidate = normalizeWorktreeHostPath(candidatePath);
+	if (!candidate) return false;
+	for (const session of liveRecords(sessions, options)) {
+		if (normalizeWorktreeHostPath(session.worktreePath) === candidate) return true;
+		const cwd = normalizeWorktreeHostPath(session.cwd);
+		if (cwd && isSameOrChildPath(candidate, cwd)) return true;
+		if (session.repoWorktrees) {
+			for (const wt of Object.values(session.repoWorktrees)) {
+				if (normalizeWorktreeHostPath(wt) === candidate) return true;
+			}
+		}
+	}
+	return false;
+}

--- a/src/server/agent/worktree-sweeper.ts
+++ b/src/server/agent/worktree-sweeper.ts
@@ -29,6 +29,7 @@ import path from "node:path";
 import { isPoolBranch } from "./worktree-pool.js";
 import { cleanupWorktree } from "../skills/git.js";
 import { cpuDiagnosticsEnabled, getCpuDiagnostics } from "./cpu-diagnostics.js";
+import { isWorktreePathReferencedByLiveSession, normalizeWorktreeHostPath } from "./worktree-reference-guard.js";
 
 const execFile = promisify(execFileCb);
 
@@ -77,6 +78,7 @@ export interface SweepRecord {
 	id: string;
 	branch?: string;
 	worktreePath?: string;
+	cwd?: string;
 	archived?: boolean;
 	/** Per-repo worktree paths (multi-repo). Each is treated as separately owned. */
 	repoWorktrees?: Record<string, string>;
@@ -110,8 +112,7 @@ function parseWorktreeList(stdout: string): ParsedWorktree[] {
 	return out;
 }
 
-const normalize = (p: string | undefined): string | undefined =>
-	p ? p.replace(/\\/g, "/").toLowerCase() : undefined;
+const normalize = normalizeWorktreeHostPath;
 
 /**
  * Sweep orphaned worktrees across all projects.
@@ -145,11 +146,14 @@ export async function sweepOrphanedWorktrees(opts: {
 		const ownedBranches = new Set<string>();
 		const ownedPaths = new Set<string>();
 		const branchToExpectedPath = new Map<string, string>();
-		for (const rec of [...opts.goals, ...opts.sessions, ...opts.staff]) {
+		const allRecords = [...opts.goals, ...opts.sessions, ...opts.staff];
+		for (const rec of allRecords) {
 			if (rec.archived) continue;
 			if (rec.branch) ownedBranches.add(rec.branch);
 			const np = normalize(rec.worktreePath);
 			if (np) ownedPaths.add(np);
+			const cwd = normalize(rec.cwd);
+			if (cwd) ownedPaths.add(cwd);
 			if (rec.branch && rec.worktreePath) branchToExpectedPath.set(rec.branch, rec.worktreePath);
 			// Multi-repo: each per-repo worktree is separately owned. The branch is
 			// shared across repos so we only add to ownedPaths.
@@ -214,7 +218,7 @@ export async function sweepOrphanedWorktrees(opts: {
 
 				// Active record owns this worktree (by branch or path).
 				const ownedByBranch = !!(branch && ownedBranches.has(branch));
-				const ownedByPath = ownedPaths.has(wtPathNorm);
+				const ownedByPath = ownedPaths.has(wtPathNorm) || isWorktreePathReferencedByLiveSession(wt.path, allRecords);
 
 				if (ownedByBranch || ownedByPath) {
 					// Multi-repo: a per-repo path explicitly listed in any record's
@@ -284,11 +288,14 @@ export function classifyWorktrees(opts: {
 	const ownedBranches = new Set<string>();
 	const ownedPaths = new Set<string>();
 	const branchToExpectedPath = new Map<string, string>();
-	for (const rec of [...opts.goals, ...opts.sessions, ...opts.staff]) {
+	const allRecords = [...opts.goals, ...opts.sessions, ...opts.staff];
+	for (const rec of allRecords) {
 		if (rec.archived) continue;
 		if (rec.branch) ownedBranches.add(rec.branch);
 		const np = normalize(rec.worktreePath);
 		if (np) ownedPaths.add(np);
+		const cwd = normalize(rec.cwd);
+		if (cwd) ownedPaths.add(cwd);
 		if (rec.branch && rec.worktreePath) branchToExpectedPath.set(rec.branch, rec.worktreePath);
 		if (rec.repoWorktrees) {
 			for (const wp of Object.values(rec.repoWorktrees)) {
@@ -309,7 +316,7 @@ export function classifyWorktrees(opts: {
 			continue;
 		}
 		const ownedByBranch = !!(wt.branch && ownedBranches.has(wt.branch));
-		const ownedByPath = !!wtPathNorm && ownedPaths.has(wtPathNorm);
+		const ownedByPath = !!wtPathNorm && (ownedPaths.has(wtPathNorm) || isWorktreePathReferencedByLiveSession(wt.path, allRecords));
 		if (ownedByBranch || ownedByPath) {
 			// Multi-repo: a per-repo path explicitly listed in any record's
 			// `repoWorktrees` map is active even if it differs from the record's

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -133,6 +133,40 @@ function isValidBaseRefBranchGrammar(name: string): boolean {
 	return /^[A-Za-z0-9_./-]+$/.test(name);
 }
 
+function collectVisibleSessionWorktreeReferences(projectContextManager: ProjectContextManager): WorktreeReferenceRecord[] {
+	const sessions: WorktreeReferenceRecord[] = [];
+	for (const ctx of projectContextManager.visible()) {
+		sessions.push(...ctx.sessionStore.getAll());
+	}
+	return sessions;
+}
+
+function wireGoalManagerResolvers(
+	ctx: ProjectContext,
+	deps: {
+		sessionManager: SessionManager;
+		projectContextManager: ProjectContextManager;
+		projectRegistry: ProjectRegistry;
+	},
+): void {
+	const projectId = ctx.project.id;
+	ctx.goalManager.setPoolResolver(() => deps.sessionManager.getWorktreePool(projectId));
+	ctx.goalManager.setComponentsResolver((pid: string) => {
+		const c = deps.projectContextManager.getOrCreate(pid);
+		return c ? c.projectConfigStore.getComponents() : [];
+	});
+	ctx.goalManager.setProjectRootResolver((pid: string) => deps.projectRegistry.get(pid)?.rootPath);
+	ctx.goalManager.setWorktreeRootResolver((pid: string) => {
+		const c = deps.projectContextManager.getOrCreate(pid);
+		return c?.projectConfigStore.get("worktree_root") || undefined;
+	});
+	ctx.goalManager.setBaseRefResolver((pid: string) => {
+		const c = deps.projectContextManager.getOrCreate(pid);
+		return c?.projectConfigStore.get("base_ref") || undefined;
+	});
+	ctx.goalManager.setLiveSessionResolver(() => collectVisibleSessionWorktreeReferences(deps.projectContextManager));
+}
+
 // Best-effort guard for add-time `base_ref` pinning: a detected `origin/<branch>`
 // must exist in EVERY configured component repo before it is persisted — mirroring
 // the save-time validator (which rejects a ref missing in any component). Without
@@ -267,8 +301,10 @@ import { ProjectRegistry, SymlinkProjectRootError, PreflightFailedError, SYSTEM_
 import { runPreflight } from "./agent/project-preflight.js";
 import { archiveProjectBobbitDir, ArchiveError } from "./agent/bobbit-archive.js";
 import { ProjectContextManager } from "./agent/project-context-manager.js";
+import type { ProjectContext } from "./agent/project-context.js";
 import { resolveProjectForRequest } from "./agent/resolve-project.js";
 import { GoalManager } from "./agent/goal-manager.js";
+import type { WorktreeReferenceRecord } from "./agent/worktree-reference-guard.js";
 import { computePlanFreezeUpdate } from "./agent/parent-workflow-freeze.js";
 import { detectHostTokens, resolveHostTokenValue, sandboxTokenPolicyAllowsCodexAuth } from "./agent/host-tokens.js";
 import type { PersistedGoal } from "./agent/goal-store.js";
@@ -1048,6 +1084,7 @@ export function createGateway(config: GatewayConfig) {
 			ctx.goalStore.bumpGeneration();
 		};
 	}
+
 	const builtinConfigProvider = new BuiltinConfigProvider();
 	// Wire builtin defaults into stores (in-memory only, no disk writes).
 	// Direct store lookups (roleStore.get()) transparently fall back to
@@ -2106,9 +2143,9 @@ export function createGateway(config: GatewayConfig) {
 					try {
 						const { sweepOrphanedWorktrees } = await import("./agent/worktree-sweeper.js");
 						const sweepProjects: Array<{ id: string; rootPath: string; repos?: string[] }> = [];
-						const sweepGoals: Array<{ id: string; branch?: string; worktreePath?: string; archived?: boolean; repoWorktrees?: Record<string, string> }> = [];
-						const sweepSessions: Array<{ id: string; branch?: string; worktreePath?: string; archived?: boolean; repoWorktrees?: Record<string, string> }> = [];
-						const sweepStaff: Array<{ id: string; branch?: string; worktreePath?: string; repoWorktrees?: Record<string, string> }> = [];
+						const sweepGoals: Array<{ id: string; branch?: string; worktreePath?: string; cwd?: string; archived?: boolean; repoWorktrees?: Record<string, string> }> = [];
+						const sweepSessions: Array<{ id: string; branch?: string; worktreePath?: string; cwd?: string; archived?: boolean; repoWorktrees?: Record<string, string> }> = [];
+						const sweepStaff: Array<{ id: string; branch?: string; worktreePath?: string; cwd?: string; repoWorktrees?: Record<string, string> }> = [];
 						// Skip hidden contexts (synthetic system project) — it has
 						// no goals/sessions/staff and must never drive worktree work.
 						for (const ctx of projectContextManager.visible()) {
@@ -2120,13 +2157,13 @@ export function createGateway(config: GatewayConfig) {
 							});
 							for (const g of ctx.goalStore.getAll()) {
 								sweepGoals.push({
-									id: g.id, branch: g.branch, worktreePath: g.worktreePath, archived: !!g.archived,
+									id: g.id, branch: g.branch, worktreePath: g.worktreePath, cwd: g.cwd, archived: !!g.archived,
 									repoWorktrees: (g as { repoWorktrees?: Record<string, string> }).repoWorktrees,
 								});
 							}
 							for (const s of ctx.sessionStore.getAll()) {
 								sweepSessions.push({
-									id: s.id, branch: s.branch, worktreePath: s.worktreePath, archived: !!s.archived,
+									id: s.id, branch: s.branch, worktreePath: s.worktreePath, cwd: s.cwd, archived: !!s.archived,
 									repoWorktrees: s.repoWorktrees,
 								});
 							}
@@ -2135,6 +2172,7 @@ export function createGateway(config: GatewayConfig) {
 									id: st.id,
 									branch: st.branch,
 									worktreePath: st.worktreePath,
+									cwd: st.cwd,
 									repoWorktrees: st.repoWorktrees,
 								});
 							}
@@ -2205,23 +2243,7 @@ export function createGateway(config: GatewayConfig) {
 			// resolve components / project root for multi-repo goal creation.
 			// Hidden contexts (synthetic system project) have no goals to wire.
 			for (const ctx of projectContextManager.visible()) {
-				const projectId = ctx.project.id;
-				ctx.goalManager.setPoolResolver(() => sessionManager.getWorktreePool(projectId));
-				ctx.goalManager.setComponentsResolver((pid: string) => {
-					const c = projectContextManager.getOrCreate(pid);
-					return c ? c.projectConfigStore.getComponents() : [];
-				});
-				ctx.goalManager.setProjectRootResolver((pid: string) => {
-					return projectRegistry.get(pid)?.rootPath;
-				});
-				ctx.goalManager.setWorktreeRootResolver((pid: string) => {
-					const c = projectContextManager.getOrCreate(pid);
-					return c?.projectConfigStore.get("worktree_root") || undefined;
-				});
-				ctx.goalManager.setBaseRefResolver((pid: string) => {
-					const c = projectContextManager.getOrCreate(pid);
-					return c?.projectConfigStore.get("base_ref") || undefined;
-				});
+				wireGoalManagerResolvers(ctx, { sessionManager, projectContextManager, projectRegistry });
 			}
 
 			// Now that sessions are live, re-subscribe to team events
@@ -3242,20 +3264,7 @@ async function handleApiRoute(
 						ctx.gateStore.onStatusChange = () => {
 							ctx.goalStore.bumpGeneration();
 						};
-						ctx.goalManager.setPoolResolver(() => sessionManager.getWorktreePool(existing.id));
-						ctx.goalManager.setComponentsResolver((pid: string) => {
-							const c = projectContextManager.getOrCreate(pid);
-							return c ? c.projectConfigStore.getComponents() : [];
-						});
-						ctx.goalManager.setProjectRootResolver((pid: string) => projectRegistry.get(pid)?.rootPath);
-						ctx.goalManager.setWorktreeRootResolver((pid: string) => {
-							const c = projectContextManager.getOrCreate(pid);
-							return c?.projectConfigStore.get("worktree_root") || undefined;
-						});
-						ctx.goalManager.setBaseRefResolver((pid: string) => {
-							const c = projectContextManager.getOrCreate(pid);
-							return c?.projectConfigStore.get("base_ref") || undefined;
-						});
+						wireGoalManagerResolvers(ctx, { sessionManager, projectContextManager, projectRegistry });
 					}
 					json(existing, 200);
 					return;
@@ -3398,20 +3407,7 @@ async function handleApiRoute(
 			}
 			// Wire the goal-manager pool resolver for the new project (Phase 3 — goals via pool).
 			if (newCtx) {
-				newCtx.goalManager.setPoolResolver(() => sessionManager.getWorktreePool(project.id));
-				newCtx.goalManager.setComponentsResolver((pid: string) => {
-					const c = projectContextManager.getOrCreate(pid);
-					return c ? c.projectConfigStore.getComponents() : [];
-				});
-				newCtx.goalManager.setProjectRootResolver((pid: string) => projectRegistry.get(pid)?.rootPath);
-				newCtx.goalManager.setWorktreeRootResolver((pid: string) => {
-					const c = projectContextManager.getOrCreate(pid);
-					return c?.projectConfigStore.get("worktree_root") || undefined;
-				});
-				newCtx.goalManager.setBaseRefResolver((pid: string) => {
-					const c = projectContextManager.getOrCreate(pid);
-					return c?.projectConfigStore.get("base_ref") || undefined;
-				});
+				wireGoalManagerResolvers(newCtx, { sessionManager, projectContextManager, projectRegistry });
 			}
 			json(project, 201);
 		} catch (err: any) {
@@ -4494,6 +4490,7 @@ async function handleApiRoute(
 				provCtx.gateStore.onStatusChange = () => {
 					provCtx.goalStore.bumpGeneration();
 				};
+				wireGoalManagerResolvers(provCtx, { sessionManager, projectContextManager, projectRegistry });
 			}
 		}
 

--- a/tests/shared-worktree-guard-repro.test.ts
+++ b/tests/shared-worktree-guard-repro.test.ts
@@ -20,6 +20,8 @@ process.env.BOBBIT_SKIP_NPM_CI = "1";
 const execFile = promisify(execFileCb);
 const { SessionManager } = await import("../src/server/agent/session-manager.ts");
 const { SessionStore } = await import("../src/server/agent/session-store.ts");
+const { GoalManager } = await import("../src/server/agent/goal-manager.ts");
+const { GoalStore } = await import("../src/server/agent/goal-store.ts");
 const { handleSetupFailure } = await import("../src/server/agent/session-setup.ts");
 const { initPromptDirs } = await import("../src/server/agent/system-prompt.ts");
 
@@ -208,6 +210,60 @@ describe("shared worktree guard reproductions", () => {
 				orphans.some((entry: { path: string }) => path.resolve(entry.path) === path.resolve(sharedWorktree)),
 				false,
 				`SHARED_WORKTREE_GUARD_ORPHAN_LIST_REGRESSION: manual orphan listing reported a path referenced by live repoWorktrees: ${JSON.stringify(orphans)}`,
+			);
+		} finally {
+			fs.rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("goal archive must not remove a multi-repo worktree referenced by a live session resolver", async () => {
+		const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "shared-wt-guard-goal-archive-"));
+		try {
+			const root = path.join(tmp, "project");
+			const api = path.join(root, "api");
+			const web = path.join(root, "web");
+			fs.mkdirSync(root, { recursive: true });
+			await makeRepoIn(api);
+			await makeRepoIn(web);
+
+			const branch = "goal/archive-shared";
+			const apiWorktree = path.join(tmp, "project-wt", "goal-archive", "api");
+			const webWorktree = path.join(tmp, "project-wt", "goal-archive", "web");
+			await makeWorktree(api, apiWorktree, branch);
+			await makeWorktree(web, webWorktree, branch);
+
+			const goalState = path.join(tmp, "goal-state");
+			const goalStore = new GoalStore(goalState);
+			const goalManager = new GoalManager(goalStore);
+			goalManager.setLiveSessionResolver(() => [makeSession("live-api-owner", {
+				cwd: apiWorktree.replace(/\\/g, "/").toUpperCase(),
+				branch: "session/live-api-owner",
+			})]);
+			goalStore.put({
+				id: "goal-archive",
+				title: "goal archive",
+				cwd: path.join(tmp, "project-wt", "goal-archive"),
+				state: "complete",
+				spec: "",
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+				repoPath: root,
+				branch,
+				worktreePath: path.join(tmp, "project-wt", "goal-archive"),
+				repoWorktrees: { api: apiWorktree, web: webWorktree },
+			});
+
+			const archived = await goalManager.archiveGoal("goal-archive");
+			assert.equal(archived, true, "goal should be archived by the test setup");
+			await waitForWorktreeRemoval(webWorktree);
+			assert.ok(
+				fs.existsSync(apiWorktree),
+				"SHARED_WORKTREE_GUARD_GOAL_ARCHIVE_REGRESSION: goal archive removed a repoWorktrees path still referenced by a live session resolver",
+			);
+			assert.equal(
+				fs.existsSync(webWorktree),
+				false,
+				"unshared goal repoWorktree should remain cleanable so archive cleanup still removes true orphans",
 			);
 		} finally {
 			fs.rmSync(tmp, { recursive: true, force: true });

--- a/tests/shared-worktree-guard-repro.test.ts
+++ b/tests/shared-worktree-guard-repro.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Reproducing tests for shared worktree cleanup guard.
+ *
+ * These tests intentionally exercise real git worktree cleanup paths in temp
+ * repos. Against the buggy implementation they fail with messages prefixed by
+ * SHARED_WORKTREE_GUARD_* because cleanup removes a worktree still referenced
+ * by a non-archived persisted session.
+ */
+import { afterEach, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFile as execFileCb } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+process.env.BOBBIT_TEST_NO_PUSH = "1";
+process.env.BOBBIT_SKIP_NPM_CI = "1";
+
+const execFile = promisify(execFileCb);
+const { SessionManager } = await import("../src/server/agent/session-manager.ts");
+const { SessionStore } = await import("../src/server/agent/session-store.ts");
+const { handleSetupFailure } = await import("../src/server/agent/session-setup.ts");
+const { initPromptDirs } = await import("../src/server/agent/system-prompt.ts");
+
+type TestRepo = { repo: string; tmp: string };
+
+const managers: any[] = [];
+let prevBobbitDir: string | undefined;
+let stateRoot = "";
+
+async function git(args: string[], cwd: string): Promise<string> {
+	const { stdout } = await execFile("git", args, { cwd });
+	return stdout.trim();
+}
+
+async function makeRepo(prefix: string): Promise<TestRepo> {
+	const tmp = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	const repo = path.join(tmp, "repo");
+	fs.mkdirSync(repo, { recursive: true });
+	await git(["-c", "init.defaultBranch=master", "init", repo], tmp);
+	await git(["config", "user.name", "Bobbit Test"], repo);
+	await git(["config", "user.email", "bobbit-test@example.invalid"], repo);
+	fs.writeFileSync(path.join(repo, "README.md"), "# repro\n", "utf8");
+	await git(["add", "README.md"], repo);
+	await git(["commit", "-m", "initial"], repo);
+	return { repo, tmp };
+}
+
+async function makeWorktree(repo: string, worktreePath: string, branch: string): Promise<void> {
+	fs.mkdirSync(path.dirname(worktreePath), { recursive: true });
+	await git(["worktree", "add", "-b", branch, worktreePath, "HEAD"], repo);
+	assert.ok(fs.existsSync(path.join(worktreePath, ".git")), `test setup failed to create worktree ${worktreePath}`);
+}
+
+function makeSession(id: string, extra: Record<string, any>): any {
+	return {
+		id,
+		title: id,
+		cwd: stateRoot,
+		agentSessionFile: "",
+		createdAt: Date.now(),
+		lastActivity: Date.now(),
+		...extra,
+	};
+}
+
+function makeManager(store: any): any {
+	const manager: any = new SessionManager();
+	manager._testStore = store;
+	managers.push(manager);
+	return manager;
+}
+
+async function waitForWorktreeRemoval(worktreePath: string, timeoutMs = 3_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline && fs.existsSync(worktreePath)) {
+		await new Promise(resolve => setTimeout(resolve, 50));
+	}
+}
+
+function cleanupManager(manager: any): void {
+	if (manager?._statusHeartbeatTimer) {
+		clearInterval(manager._statusHeartbeatTimer);
+		manager._statusHeartbeatTimer = null;
+	}
+	manager?.sessions?.clear?.();
+}
+
+describe("shared worktree guard reproductions", () => {
+	beforeEach(() => {
+		stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), "shared-wt-guard-state-"));
+		prevBobbitDir = process.env.BOBBIT_DIR;
+		process.env.BOBBIT_DIR = stateRoot;
+		initPromptDirs(stateRoot);
+	});
+
+	afterEach(() => {
+		while (managers.length > 0) cleanupManager(managers.pop());
+		if (prevBobbitDir === undefined) delete process.env.BOBBIT_DIR;
+		else process.env.BOBBIT_DIR = prevBobbitDir;
+		fs.rmSync(stateRoot, { recursive: true, force: true });
+	});
+
+	it("purging an archived session must not remove a worktree referenced by a live session cwd", async () => {
+		const { repo, tmp } = await makeRepo("shared-wt-guard-purge-single-");
+		try {
+			const sharedWorktree = path.join(tmp, "repo-wt", "session-shared");
+			const branch = "session/shared-single";
+			await makeWorktree(repo, sharedWorktree, branch);
+
+			const store = new SessionStore(stateRoot);
+			store.put(makeSession("archived-a", {
+				archived: true,
+				archivedAt: Date.now(),
+				repoPath: repo,
+				branch,
+				worktreePath: sharedWorktree,
+				cwd: sharedWorktree,
+			}));
+			store.put(makeSession("live-b", {
+				// Deliberately use cwd, separator, and case normalization rather than
+				// matching the archived row byte-for-byte.
+				cwd: sharedWorktree.replace(/\\/g, "/").toUpperCase(),
+				worktreePath: undefined,
+				branch: "session/live-different-branch",
+			}));
+
+			const manager = makeManager(store);
+			const purged = await manager.purgeArchivedSession("archived-a");
+
+			assert.equal(purged, true, "archived session should be purged by the test setup");
+			assert.ok(
+				fs.existsSync(sharedWorktree),
+				"SHARED_WORKTREE_GUARD_PURGE_SINGLE_REGRESSION: archived session purge removed a worktree path still referenced by a non-archived session cwd",
+			);
+		} finally {
+			fs.rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("purging an archived multi-repo session must keep shared repoWorktrees and may clean unshared ones", async () => {
+		const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "shared-wt-guard-purge-multi-"));
+		try {
+			const root = path.join(tmp, "project");
+			const api = path.join(root, "api");
+			const web = path.join(root, "web");
+			fs.mkdirSync(root, { recursive: true });
+			await makeRepoIn(api);
+			await makeRepoIn(web);
+
+			const branch = "session/shared-multi";
+			const apiWorktree = path.join(tmp, "project-wt", "session-shared", "api");
+			const webWorktree = path.join(tmp, "project-wt", "session-shared", "web");
+			await makeWorktree(api, apiWorktree, branch);
+			await makeWorktree(web, webWorktree, branch);
+
+			const store = new SessionStore(stateRoot);
+			store.put(makeSession("archived-multi", {
+				archived: true,
+				archivedAt: Date.now(),
+				repoPath: root,
+				branch,
+				worktreePath: path.join(tmp, "project-wt", "session-shared"),
+				repoWorktrees: { api: apiWorktree, web: webWorktree },
+			}));
+			store.put(makeSession("live-api-owner", {
+				cwd: apiWorktree,
+				branch: "session/live-api-owner",
+				repoWorktrees: { api: apiWorktree.replace(/\\/g, "/").toUpperCase() },
+			}));
+
+			const manager = makeManager(store);
+			const purged = await manager.purgeArchivedSession("archived-multi");
+
+			assert.equal(purged, true, "archived multi-repo session should be purged by the test setup");
+			assert.ok(
+				fs.existsSync(apiWorktree),
+				"SHARED_WORKTREE_GUARD_PURGE_MULTI_REGRESSION: archived multi-repo purge removed a repoWorktrees path still referenced by a non-archived session",
+			);
+			assert.equal(
+				fs.existsSync(webWorktree),
+				false,
+				"unshared multi-repo worktree should remain cleanable so the guard does not mask true cleanup",
+			);
+		} finally {
+			fs.rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("manual orphan listing must not report a worktree path referenced by live repoWorktrees", async () => {
+		const { repo, tmp } = await makeRepo("shared-wt-guard-list-");
+		try {
+			const sharedWorktree = path.join(tmp, "repo-wt", "session-shared-api");
+			await makeWorktree(repo, sharedWorktree, "session/stale-branch");
+
+			const store = new SessionStore(stateRoot);
+			store.put(makeSession("live-repo-owner", {
+				cwd: path.join(tmp, "elsewhere"),
+				branch: "session/live-different-branch",
+				repoWorktrees: { api: sharedWorktree.replace(/\\/g, "/").toUpperCase() },
+			}));
+
+			const manager = makeManager(store);
+			const orphans = await manager.listOrphanedSessionWorktrees(repo);
+
+			assert.equal(
+				orphans.some((entry: { path: string }) => path.resolve(entry.path) === path.resolve(sharedWorktree)),
+				false,
+				`SHARED_WORKTREE_GUARD_ORPHAN_LIST_REGRESSION: manual orphan listing reported a path referenced by live repoWorktrees: ${JSON.stringify(orphans)}`,
+			);
+		} finally {
+			fs.rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+
+	it("setup failure must not clean a worktree path already owned by another live persisted session", async () => {
+		const { repo, tmp } = await makeRepo("shared-wt-guard-setup-failure-");
+		try {
+			const sharedWorktree = path.join(tmp, "repo-wt", "session-shared-setup");
+			const branch = "session/setup-failed";
+			await makeWorktree(repo, sharedWorktree, branch);
+
+			const store = new SessionStore(stateRoot);
+			const failedSession = makeSession("setup-failed", {
+				cwd: sharedWorktree,
+				repoPath: repo,
+				branch,
+				worktreePath: sharedWorktree,
+			});
+			store.put(failedSession);
+			store.put(makeSession("live-owner", {
+				cwd: sharedWorktree.replace(/\\/g, "/").toUpperCase(),
+				branch: "session/live-owner",
+				worktreePath: undefined,
+			}));
+
+			const sessions = new Map<string, any>();
+			sessions.set(failedSession.id, {
+				id: failedSession.id,
+				title: failedSession.title,
+				cwd: failedSession.cwd,
+				status: "preparing",
+				statusVersion: 0,
+				createdAt: failedSession.createdAt,
+				lastActivity: failedSession.lastActivity,
+				clients: new Set(),
+			});
+
+			handleSetupFailure(
+				sessions.get(failedSession.id),
+				{ mode: "worktree", repoPath: repo, worktreePath: sharedWorktree, branch } as any,
+				new Error("intentional setup failure repro"),
+				makePipelineContext(store, sessions),
+			);
+
+			await waitForWorktreeRemoval(sharedWorktree);
+			assert.ok(
+				fs.existsSync(sharedWorktree),
+				"SHARED_WORKTREE_GUARD_SETUP_FAILURE_REGRESSION: setup-failure cleanup removed a worktree path already referenced by another non-archived persisted session",
+			);
+		} finally {
+			fs.rmSync(tmp, { recursive: true, force: true });
+		}
+	});
+});
+
+async function makeRepoIn(repo: string): Promise<void> {
+	fs.mkdirSync(repo, { recursive: true });
+	await git(["-c", "init.defaultBranch=master", "init", repo], path.dirname(repo));
+	await git(["config", "user.name", "Bobbit Test"], repo);
+	await git(["config", "user.email", "bobbit-test@example.invalid"], repo);
+	fs.writeFileSync(path.join(repo, "README.md"), "# repro\n", "utf8");
+	await git(["add", "README.md"], repo);
+	await git(["commit", "-m", "initial"], repo);
+}
+
+function makePipelineContext(store: any, sessions: Map<string, any>): any {
+	return {
+		roleManager: null,
+		toolManager: null,
+		mcpManager: null,
+		goalManager: {},
+		taskManager: {},
+		projectConfigStore: null,
+		sandboxManager: null,
+		sandboxTokenStore: null,
+		sessionSecretStore: { remove: () => {} },
+		groupPolicyStore: null,
+		configCascade: null,
+		costTracker: {},
+		store,
+		searchIndex: {},
+		sessions,
+		assemblePrompt: () => undefined,
+		applySandboxWiring: async () => true,
+		handleAgentLifecycle: () => {},
+		trackCostFromEvent: () => {},
+		broadcast: () => {},
+		tryAutoSelectModel: async () => {},
+		tryApplyDefaultThinkingLevel: async () => {},
+		buildWorkflowList: () => "",
+		resolveInitialModel: () => undefined,
+		resolveInitialThinkingLevel: () => undefined,
+		prStatusStore: {},
+	};
+}

--- a/tests/worktree-sweeper.test.ts
+++ b/tests/worktree-sweeper.test.ts
@@ -130,6 +130,22 @@ branch refs/heads/session/new-session-deadbeef
 		assert.equal(out.orphan.length, 1);
 		assert.equal(out.active.length, 0);
 	});
+
+	it("keeps a boot-sweeper candidate active when a live session only references it by cwd", () => {
+		const out = classifyWorktrees({
+			porcelainStdout: `worktree /tmp/repo-wt/session-cwd-owned\nbranch refs/heads/session/stale-cwd-branch\n`,
+			repoPath: REPO,
+			goals: [],
+			sessions: [
+				{ id: "archived", branch: "session/stale-cwd-branch", worktreePath: "/tmp/repo-wt/session-cwd-owned", archived: true },
+				{ id: "live", branch: "session/live-different", cwd: "/tmp/repo-wt/session-cwd-owned/subdir" },
+			],
+			staff: [],
+		});
+		assert.equal(out.active.length, 1);
+		assert.equal(out.active[0].path, "/tmp/repo-wt/session-cwd-owned");
+		assert.equal(out.orphan.length, 0);
+	});
 });
 
 describe("worktree-sweeper.sweepOrphanedWorktrees", () => {


### PR DESCRIPTION
## Summary

- Add a shared worktree reference guard before cleanup deletes worktrees.
- Protect session purge, setup-failure cleanup, manual orphan listing/cleanup, boot sweeper classification, and multi-repo goal archive cleanup.
- Cover worktreePath, cwd, and repoWorktrees with normalized host-path comparison.
- Add focused regression coverage and document the cleanup behavior in docs/internals.md.

## Validation

- npm run check
- npm run test:unit
- npm run test:e2e
- npx tsx --test tests/shared-worktree-guard-repro.test.ts tests/worktree-sweeper.test.ts tests/worktree-sweeper-multi.test.ts

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)