### PR TITLE
Reduce XML-style prompt placeholders

### DIFF
--- a/defaults/system-prompt.md
+++ b/defaults/system-prompt.md
@@ -32,13 +32,20 @@ Always pass `rg` / `grep` / `find` an explicit, tight path. Procedure:
 
 `ls` on any directory is cheap. Recursive *content* searches from high up are the problem — `node_modules`, caches, system files, and other projects dominate the output and blow the token budget.
 
-<example>
-<bad>rg "useState" /</bad>
-<bad>find ~ -name '*.ts'</bad>
-<good>rg "useState" src/</good>
-<good>ls packages/ && rg "useState" packages/web/src/</good>
-<good>find /etc/nginx -name '*.conf'</good>
-</example>
+Examples:
+
+Bad:
+```bash
+rg "useState" /
+find ~ -name '*.ts'
+```
+
+Good:
+```bash
+rg "useState" src/
+ls packages/ && rg "useState" packages/web/src/
+find /etc/nginx -name '*.conf'
+```
 
 # Inline rendering
 
@@ -129,18 +136,18 @@ git commit -m "your message" --trailer "Co-authored-by: bobbit-ai <bobbit@bobbit
 
 Never override the repo's `user.name` or `user.email`. Commits must be authored by the human developer; Bobbit is always the co-author.
 
-**Dirty working copy**: when asked to commit, other unstaged/staged changes may exist from another agent or the user. **Never discard, stash, or reset those changes.** Stage only the files you modified (`git add <your-files>`) and commit. If your changes overlap and can't be cleanly separated, ask the user.
+**Dirty working copy**: when asked to commit, other unstaged/staged changes may exist from another agent or the user. **Never discard, stash, or reset those changes.** Stage only the files you modified (`git add YOUR_FILES`) and commit. If your changes overlap and can't be cleanly separated, ask the user.
 
 ## Pull requests
 
 **Never push to a merged PR.** Before pushing commits or opening/updating a PR, check whether your branch's PR has already been merged:
 
-1. **Detect (primary — `gh`):** `gh pr list --head <branch> --state all` — if it lists a `MERGED` (or `CLOSED`) PR, the branch is done. This catches squash/rebase merges where the branch is not a literal ancestor of the primary branch. Bobbit is GitHub-centric, so `gh` is normally present.
-2. **Fallback (only if `gh` is unavailable):** determine the primary branch (`git symbolic-ref refs/remotes/origin/HEAD`), then `git fetch origin <primary> && git merge-base --is-ancestor <branch> origin/<primary>` — exit 0 means the branch is already merged. (This misses squash/rebase-merges, hence it is only the fallback.)
+1. **Detect (primary — `gh`):** `gh pr list --head BRANCH --state all` — if it lists a `MERGED` (or `CLOSED`) PR, the branch is done. This catches squash/rebase merges where the branch is not a literal ancestor of the primary branch. Bobbit is GitHub-centric, so `gh` is normally present.
+2. **Fallback (only if `gh` is unavailable):** determine the primary branch (`git symbolic-ref refs/remotes/origin/HEAD`), then `git fetch origin PRIMARY && git merge-base --is-ancestor BRANCH origin/PRIMARY` — exit 0 means the branch is already merged. (This misses squash/rebase-merges, hence it is only the fallback.)
 
 If the branch is merged, do NOT push more commits to it — they become orphaned commits that never reach the primary branch. Instead:
 
-- Create a fresh branch off `origin/<primary>` (detect the primary name as above — never assume `master`/`main`).
+- Create a fresh branch off `origin/PRIMARY` (detect the primary name as above — never assume `master`/`main`).
 - Move the new work onto that fresh branch, push it, and open a **new** PR.
 
 **PR description footer**: Every PR description you generate must end with the following line (after a blank line):

--- a/defaults/tools/ask/ask_user_choices.yaml
+++ b/defaults/tools/ask/ask_user_choices.yaml
@@ -10,7 +10,7 @@ docs: |
   Post 1–5 multiple-choice questions to the user as an inline interactive widget.
 
   **This tool is non-blocking.** It returns immediately with `{ status: "posted",
-  tool_use_id: "<id>" }` and your current turn ends. The user's answers arrive
+  tool_use_id: "TOOL_USE_ID" }` and your current turn ends. The user's answers arrive
   later as a separate user message (see the "Non-blocking contract" section in
   detail_docs for the envelope format).
 detail_docs: |
@@ -41,7 +41,7 @@ detail_docs: |
 
   When you post **more than one question**, every question MUST include a
   `tab_label` field. The widget renders the tab strip as
-  `A. <tab_label>`, `B. <tab_label>`, … so the user can jump between
+  `A. {tab_label}`, `B. {tab_label}`, … so the user can jump between
   questions without re-reading the full prompt.
 
   Keep it to **2–4 words, ≤24 characters**, topical and question-scoped
@@ -63,7 +63,7 @@ detail_docs: |
   Calling `ask_user_choices` returns immediately with:
 
   ```json
-  { "status": "posted", "tool_use_id": "<id>" }
+  { "status": "posted", "tool_use_id": "TOOL_USE_ID" }
   ```
 
   This ends your turn. **Do not emit further reasoning or tool calls in the
@@ -73,7 +73,7 @@ detail_docs: |
   exactly:
 
   ```
-  [ask_user_choices_response tool_use_id=<same id as above>]
+  [ask_user_choices_response tool_use_id=SAME_TOOL_USE_ID_AS_ABOVE]
   {"answers":[{"question":"...","selected":"...","other_text":null}, ...]}
   ```
 

--- a/defaults/tools/ask/extension.ts
+++ b/defaults/tools/ask/extension.ts
@@ -8,7 +8,7 @@
  * The user's answers arrive later as a separate user message whose text is the
  * envelope:
  *
- *     [ask_user_choices_response tool_use_id=<id>]
+ *     [ask_user_choices_response tool_use_id=TOOL_USE_ID]
  *     {"answers":[{"question":"...","selected":"...","other_text":null}, ...]}
  *
  * See src/shared/ask-envelope.ts for the canonical format. The envelope is
@@ -40,7 +40,7 @@ export default function (pi: ExtensionAPI) {
 		description: "Post 1–5 multiple-choice questions to the user. Non-blocking; ends your turn.",
 		promptSnippet: [
 			"Post multiple-choice questions to the user. The tool returns immediately and ends your turn.",
-			"Answers arrive later as a user message prefixed with `[ask_user_choices_response tool_use_id=<id>]`",
+			"Answers arrive later as a user message prefixed with `[ask_user_choices_response tool_use_id=TOOL_USE_ID]`",
 			"followed by a JSON body `{\"answers\":[...]}`. Match tool_use_id to your tool call.",
 		].join(" "),
 		parameters: Type.Object({


### PR DESCRIPTION
## Summary
- Replace XML-style placeholders in `ask_user_choices` docs and prompt snippet with plain uppercase placeholders.
- Convert system prompt XML-style examples to Markdown and remove angle-bracket placeholders where unnecessary.

## Testing
- `git diff --check` for edited ask docs/files.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
