### PR TITLE
Refresh agent

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -47,6 +47,7 @@ These endpoints expose restart support only for gateways launched through `npm r
 | `GET` | `/api/sessions` | List all sessions. Supports `?since=N` generation counter for conditional fetch. Response includes `archivedDelegates` array (see below) |
 | `POST` | `/api/sessions` | Create a session (normal, delegate, or with role/traits/assistant type/reattemptGoalId) |
 | `POST` | `/api/sessions/:id/fork` | Fork a live session: clone its transcript (+ tool-content / proposal drafts) into a new session and preserve its context. Body `{ newWorktree?: boolean }` (default `true`). See [Fork session endpoint](#fork-session-endpoint) |
+| `POST` | `/api/sessions/:id/restart` | Restart a live session's agent process in place. Body `{ force?: boolean }`. See [Restart session agent endpoint](#restart-session-agent-endpoint) |
 | `GET` | `/api/sessions/:id` | Get session details |
 | `DELETE` | `/api/sessions/:id` | Terminate a session |
 | `PATCH` | `/api/sessions/:id` | Update session properties (title, colorIndex, preview, roleId, traits, assistantType, goalId) |
@@ -86,6 +87,42 @@ The side-panel workspace endpoints persist the right-side panel tab set for a se
 | `POST` | `/api/sessions/:id/side-panel-workspace/migrate` | One-time import from legacy localStorage keys. Ignored once the workspace has tabs or `metadata.migratedFromLocalStorageAt`. |
 
 Each committed mutation increments `revision`, persists on the session record, and emits `side_panel_workspace` on the session WebSocket.
+
+### Restart session agent endpoint
+
+`POST /api/sessions/:id/restart` restarts the live agent process for an existing session. It is the REST contract behind the sidebar hamburger action labeled exactly `Refresh agent`.
+
+This endpoint exists alongside the active-session WebSocket `restart_agent` command. The WebSocket command is scoped to the session socket that sends it; the REST endpoint accepts an explicit `:id`, so sidebar actions can refresh an inactive row without switching the open chat. Both paths call `SessionManager.restartAgent(sessionId)`.
+
+Request body (optional):
+
+```json
+{ "force": false }
+```
+
+- Omit the body, omit `force`, or send `force: false` for an idle session.
+- Send `force: true` only after user confirmation when the session is `busy`, `streaming`, or compacting. Without force, those states return `409 SESSION_BUSY`.
+
+Success returns `200`:
+
+```json
+{ "ok": true, "sessionId": "session-id" }
+```
+
+Restart is in-place. It preserves the session id, transcript/history, persisted session metadata, and any connected WebSocket clients. The manager stops the existing process, restores the persisted session, reattaches clients, and switches the new process back to the existing transcript file. The restore path rebuilds the session prompt, tool definitions, tool activation, MCP proxy/guard extensions, MCP-backed tool surface, MCP server configuration/auth state, and per-session environment from the current server-side managers and config.
+
+Stable error codes:
+
+| Status | Code | Meaning |
+|---|---|---|
+| `404` | `SESSION_NOT_FOUND` | No live restartable session exists for `:id`, including missing, archived, or terminated sessions. |
+| `403` | `SESSION_NOT_RESTARTABLE` | The session is read-only or non-interactive. |
+| `409` | `SESSION_BUSY` | The session is `busy`, `streaming`, or compacting and the request did not include `{ "force": true }`. |
+| `500` | `RESTART_ERROR` or a manager-provided code | Restart was accepted but the session manager could not respawn the process. The response still uses the standard `{ error, code }` shape. |
+
+Clients should surface 5xx restart failures visibly rather than silently retrying. A manager-provided restart code, such as an unrecoverable archived-zombie condition, should be displayed or logged with the human-readable `error`.
+
+See [Sidebar Actions Menu — Refresh agent](sidebar-actions-menu.md#refresh-agent) for the user-facing behavior.
 
 ### Fork session endpoint
 

--- a/docs/sidebar-actions-menu.md
+++ b/docs/sidebar-actions-menu.md
@@ -44,6 +44,7 @@ Menu-only actions are intentionally desktop-only in v1:
 
 - Session `Copy link`
 - Session `Open in new window`
+- Session `Refresh agent`
 - Session `Fork`
 - Goal `Copy link`
 - Goal `Open on GitHub`
@@ -62,9 +63,34 @@ This avoids adding a redundant dense tap target on mobile, where the quick actio
 | `End team` | Quick + menu | Team-lead session | Opens the existing team-end confirmation with goal context. |
 | `Copy link` | Menu only | Live session / team-lead row | Copies an absolute hash route for the session. |
 | `Open in new window` | Menu only | Live session / team-lead row | Opens the session's deep link in a new browser window/tab (see [Open in new window](#open-in-new-window-and-middle-click)). |
+| `Refresh agent` | Menu only | Live, interactive session / team-lead row (see [Refresh agent](#refresh-agent)) | Restarts that session's agent process without clearing its transcript. |
 | `Fork` | Menu only | Forkable live session (see [Forkability policy](#forkability-policy)) | Clones the session's conversation history into a new session and connects to it. Carries an inline **New worktree** checkbox (see below). |
 
-Archived sessions and unsupported live session kinds do not expose `Fork`. The server also enforces this with `422` responses so clients cannot bypass UI availability checks.
+Archived sessions and unsupported live session kinds do not expose `Refresh agent` or `Fork`. The server also enforces this for both actions so clients cannot bypass UI availability checks.
+
+#### Refresh agent
+
+`Refresh agent` is a hamburger-only action. It is intentionally not a quick hover button because it restarts the agent process and can interrupt work in progress.
+
+The label is exactly `Refresh agent` when idle. While the request is in flight, the row is rebuilt with `Refreshing agent…`, and the client shows toast feedback for pending, success, and failure states.
+
+Availability is intentionally conservative:
+
+| State | UI behavior | Server behavior |
+|---|---|---|
+| Live, interactive session | Shows `Refresh agent`. | `POST /api/sessions/:id/restart` may restart it. |
+| Inactive but live session | Shows `Refresh agent` on that row. | The explicit REST `:id` targets that exact session, not the currently open chat. |
+| `busy`, `streaming`, or `isCompacting` | Shows `Refresh agent`, then asks for confirmation before interrupting. | Requires `{ "force": true }`; otherwise returns `409 SESSION_BUSY`. |
+| Archived or terminated | Hidden. | Returns `404 SESSION_NOT_FOUND`. |
+| Read-only or non-interactive | Hidden. | Returns `403 SESSION_NOT_RESTARTABLE`. |
+
+On a busy, streaming, or compacting session, selecting the menu item opens a confirmation dialog. Cancel does not call the server. Confirm posts `{ "force": true }`, which lets the server interrupt and respawn the process. Idle refreshes post without force.
+
+The sidebar action uses the REST endpoint because it can target any visible row, including sessions that are not currently open. The older active-chat path still exists: `RemoteAgent.restartAgent()` sends the WebSocket `restart_agent` command on the active session socket. Both paths call the same `SessionManager.restartAgent(sessionId)` implementation, so respawn semantics stay aligned.
+
+A refresh preserves the session identity, transcript/history, persisted session metadata, and attached clients. The manager stops the old process, restores the persisted session through the normal restore path, reattaches existing WebSocket clients, and switches the new process back to the existing transcript file. During restore it rebuilds the session prompt, tool definitions, tool activation, MCP proxy/guard extensions, MCP-backed tool surface, MCP server configuration/auth state, and per-session environment from the current server-side managers and config.
+
+See [REST API — Restart session agent endpoint](rest-api.md#restart-session-agent-endpoint) for the request and error contract.
 
 #### Forkability policy
 
@@ -224,7 +250,7 @@ For changes to this feature, run the focused coverage first:
 
 ```bash
 npx tsx --import ./tests/helpers/css-stub-loader.mjs --test --test-force-exit tests/sidebar-actions-flip.test.ts
-npm run test:e2e -- tests/e2e/sidebar-actions-server.spec.ts tests/e2e/ui/sidebar-actions-menu.spec.ts
+npm run test:e2e -- tests/e2e/sidebar-actions-server.spec.ts tests/e2e/session-restart-api.spec.ts tests/e2e/ui/sidebar-actions-menu.spec.ts tests/e2e/ui/sidebar-refresh-agent.spec.ts
 ```
 
 Then run the broader validation expected for UI + server changes:
@@ -235,4 +261,4 @@ npm run test:unit
 npm run test:e2e
 ```
 
-The focused browser suite covers desktop hover/focus hamburger visibility, direct quick-action regressions, menu contents, copy success and the insecure-context `execCommand` fallback (both flashing the toast with no modal), fork navigation with the New worktree checkbox toggle (toggling without firing/closing, and posting the chosen `newWorktree` value), `Open in new window` and the middle-click row shortcut both opening the session deep link via a stubbed `window.open` without swapping the active session, `Open on GitHub` mirroring the PR badge (shown with the coloured icon when the badge is visible, hidden for gated/no-PR goals), flip-above near the bottom viewport edge, dismissal cleanup, reduced motion, and mobile v1 hamburger suppression. The server-coupled fork behavior is covered by `tests/e2e/sidebar-actions-server.spec.ts`.
+The focused browser suite covers desktop hover/focus hamburger visibility, direct quick-action regressions, menu contents, copy success and the insecure-context `execCommand` fallback (both flashing the toast with no modal), `Refresh agent` visibility/targeting/feedback/busy confirmation, fork navigation with the New worktree checkbox toggle (toggling without firing/closing, and posting the chosen `newWorktree` value), `Open in new window` and the middle-click row shortcut both opening the session deep link via a stubbed `window.open` without swapping the active session, `Open on GitHub` mirroring the PR badge (shown with the coloured icon when the badge is visible, hidden for gated/no-PR goals), flip-above near the bottom viewport edge, dismissal cleanup, reduced motion, and mobile v1 hamburger suppression. The server-coupled fork behavior is covered by `tests/e2e/sidebar-actions-server.spec.ts`; the restart REST contract is covered by `tests/e2e/session-restart-api.spec.ts`.

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -34,6 +34,7 @@ Session-list invalidations (`session_created`, `sessions_changed`, and `session_
 | `reorder_queue` | `messageIds` | Reorder the prompt queue to match the given ID order |
 | `abort` | — | Abort the current agent turn |
 | `retry` | — | Retry the last failed turn |
+| `restart_agent` | — | Restart the agent process for this socket's session. This is the active-session path; the sidebar `Refresh agent` action uses `POST /api/sessions/:id/restart` to target any live row by id. Both paths call the same session-manager restart implementation. |
 | `set_model` | `provider`, `modelId` | Switch the AI model |
 | `set_image_model` | `provider`, `modelId` | Switch the per-session image generation model. Server validates `(provider, modelId)` against `getAvailableImageModels()`; on unknown the server replies with `{ type: "error", message: "unknown image model", code: "UNKNOWN_IMAGE_MODEL" }` and does **not** mutate session state. On valid, persists `imageModelProvider`/`imageModelId` to the session row and broadcasts the updated state to all attached clients. |
 | `compact` | — | Trigger context compaction |

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -1595,6 +1595,34 @@ export function patchSession(sessionId: string, updates: Record<string, unknown>
 	}).catch(() => { /* best-effort */ });
 }
 
+export async function refreshAgentSession(sessionId: string, opts?: { force?: boolean }): Promise<boolean> {
+	await flashSidebarToast("Refreshing agent…");
+	let ok = false;
+	try {
+		const res = await gatewayFetch(`/api/sessions/${encodeURIComponent(sessionId)}/restart`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ force: opts?.force === true }),
+		});
+		if (!res.ok) throw await errorFromResponse(res, `Failed to refresh agent: ${res.status}`);
+		ok = true;
+		await flashSidebarToast("Agent refreshed");
+		return true;
+	} catch (err) {
+		const { message } = errorDetails(err);
+		console.error("[refresh-agent] Failed:", err);
+		await flashSidebarToast(`Refresh agent failed: ${message}`);
+		return false;
+	} finally {
+		try {
+			await refreshSessions();
+		} catch (err) {
+			console.warn("[refresh-agent] Session refresh failed after restart", err);
+		}
+		if (!ok) renderApp();
+	}
+}
+
 // ============================================================================
 // TEAM API
 // ============================================================================

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -26,9 +26,9 @@ import {
 import { statusBobbit } from "./session-colors.js";
 import { shortcutHint } from "./shortcut-registry.js";
 import { connectToSession, terminateSession, createAndConnectSession, startReattempt, forkSession } from "./session-manager.js";
-import { showRenameDialog } from "./dialogs-lazy.js";
+import { confirmAction, showRenameDialog } from "./dialogs-lazy.js";
 import { setHashRoute } from "./routing.js";
-import { startTeam, deleteGoal, gatewayFetch, copySidebarLink, fetchGoalGithubLink, getCachedGoalGithubLink, goalDeepLink, sessionDeepLink, type GoalGithubLinkResponse } from "./api.js";
+import { startTeam, deleteGoal, gatewayFetch, copySidebarLink, fetchGoalGithubLink, getCachedGoalGithubLink, goalDeepLink, refreshAgentSession, sessionDeepLink, type GoalGithubLinkResponse } from "./api.js";
 import { getActiveNavId } from "./sidebar-nav.js";
 import { needsHumanAttention, needsImmediateHumanAttention } from "./notification-policy.js";
 import type { SidebarActionsPopover, SidebarActionsPopoverItem } from "../ui/components/SidebarActionsPopover.js";
@@ -437,6 +437,9 @@ export interface SidebarActionItem {
 // each time a session actions menu opens.
 let _forkNewWorktree = true;
 
+/** Session ids with an in-flight sidebar Refresh agent request. */
+const _refreshingAgentSessionIds = new Set<string>();
+
 interface OpenSidebarActionsPopover {
 	kind: SidebarActionEntityKind;
 	entityId: string;
@@ -631,6 +634,7 @@ function buildSessionSidebarActions(session: GatewaySession, displayTitle: strin
 			run: (e: Event) => { e.stopPropagation(); openSessionInNewWindow(session.id); },
 		},
 	];
+	if (canRefreshAgentSession(session)) actions.push(buildRefreshAgentSidebarAction(session));
 	if (canForkSidebarSession(session)) {
 		actions.push({
 			id: "fork",
@@ -651,7 +655,7 @@ function buildSessionSidebarActions(session: GatewaySession, displayTitle: strin
 }
 
 function buildTeamLeadSidebarActions(session: GatewaySession, displayTitle: string, goalId?: string): SidebarActionItem[] {
-	return [
+	const actions: SidebarActionItem[] = [
 		{
 			id: "modify",
 			label: "Modify",
@@ -684,6 +688,8 @@ function buildTeamLeadSidebarActions(session: GatewaySession, displayTitle: stri
 			run: (e: Event) => { e.stopPropagation(); openSessionInNewWindow(session.id); },
 		},
 	];
+	if (canRefreshAgentSession(session)) actions.push(buildRefreshAgentSidebarAction(session));
+	return actions;
 }
 
 function buildGoalSidebarActions(goal: Goal, input: { hasActiveSession: boolean; showArchive: boolean }): SidebarActionItem[] {
@@ -742,6 +748,54 @@ function buildGoalSidebarActions(goal: Goal, input: { hasActiveSession: boolean;
 		});
 	}
 	return actions;
+}
+
+function buildRefreshAgentSidebarAction(session: GatewaySession): SidebarActionItem {
+	const refreshing = _refreshingAgentSessionIds.has(session.id);
+	return {
+		id: "refresh-agent",
+		label: refreshing ? "Refreshing agent…" : "Refresh agent",
+		title: refreshing ? "Refreshing agent…" : "Refresh agent",
+		icon: icon(RotateCcw, "xs"),
+		quick: false,
+		run: (e: Event) => { e.stopPropagation(); void runRefreshAgentSession(session); },
+	};
+}
+
+function canRefreshAgentSession(session: GatewaySession): boolean {
+	return !session.archived
+		&& !session.readOnly
+		&& !session.nonInteractive
+		&& session.status !== "terminated"
+		&& session.status !== "archived";
+}
+
+function refreshAgentNeedsConfirmation(session: GatewaySession): boolean {
+	return session.status === "streaming" || session.status === "busy" || session.isCompacting === true;
+}
+
+async function runRefreshAgentSession(session: GatewaySession): Promise<void> {
+	if (_refreshingAgentSessionIds.has(session.id)) return;
+	const force = refreshAgentNeedsConfirmation(session);
+	if (force) {
+		const confirmed = await confirmAction(
+			"Refresh agent",
+			"This will interrupt the current agent process and restart it with the latest prompt, tools, MCP configuration, and auth state. Transcript and history remain intact.",
+			"Refresh agent",
+			false,
+		);
+		if (!confirmed) return;
+	}
+	_refreshingAgentSessionIds.add(session.id);
+	refreshOpenSidebarActionsPopover();
+	renderApp();
+	try {
+		await refreshAgentSession(session.id, { force });
+	} finally {
+		_refreshingAgentSessionIds.delete(session.id);
+		refreshOpenSidebarActionsPopover();
+		renderApp();
+	}
 }
 
 function canForkSidebarSession(session: GatewaySession): boolean {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4215,6 +4215,45 @@ async function handleApiRoute(
 		return;
 	}
 
+	// POST /api/sessions/:id/restart — restart a live session's agent process by id.
+	const restartMatch = url.pathname.match(/^\/api\/sessions\/([^/]+)\/restart$/);
+	if (restartMatch && req.method === "POST") {
+		let id: string;
+		try {
+			id = decodeURIComponent(restartMatch[1]);
+		} catch {
+			json({ error: "Session not found", code: "SESSION_NOT_FOUND" }, 404);
+			return;
+		}
+
+		const session = sessionManager.getSession(id);
+		const persisted = session ? sessionManager.getSessionStore(session.projectId).get(session.id) : undefined;
+		if (!session || session.status === "terminated" || persisted?.archived) {
+			json({ error: "Session not found", code: "SESSION_NOT_FOUND" }, 404);
+			return;
+		}
+		if (session.readOnly || session.nonInteractive || persisted?.readOnly || persisted?.nonInteractive) {
+			json({ error: "Session cannot be restarted", code: "SESSION_NOT_RESTARTABLE" }, 403);
+			return;
+		}
+
+		const body = await readBody(req).catch(() => null);
+		const status = String(session.status);
+		if ((status === "busy" || status === "streaming" || session.isCompacting) && body?.force !== true) {
+			json({ error: "Session is busy; retry with force to restart", code: "SESSION_BUSY" }, 409);
+			return;
+		}
+
+		try {
+			await sessionManager.restartAgent(id);
+			json({ ok: true, sessionId: id });
+		} catch (err: any) {
+			const code = typeof err?.code === "string" && err.code ? err.code : "RESTART_ERROR";
+			json({ error: err instanceof Error ? err.message : String(err), code }, 500);
+		}
+		return;
+	}
+
 	// GET /api/sessions/:id (exact match — not /api/sessions/:id/output etc.)
 	const singleSessionMatch = url.pathname.match(/^\/api\/sessions\/([^/]+)$/);
 	if (singleSessionMatch && req.method === "GET") {

--- a/tests/e2e/session-restart-api.spec.ts
+++ b/tests/e2e/session-restart-api.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from "./in-process-harness.js";
+import {
+	createSession,
+	defaultProjectId,
+	deleteSession,
+	rawApiFetch,
+	waitForSessionStatus,
+} from "./e2e-setup.js";
+
+async function readJson(resp: Response): Promise<any> {
+	return resp.json().catch(() => ({}));
+}
+
+async function postRestart(sessionId: string, body: Record<string, unknown> = {}): Promise<Response> {
+	return rawApiFetch(`/api/sessions/${encodeURIComponent(sessionId)}/restart`, {
+		method: "POST",
+		body: JSON.stringify(body),
+	});
+}
+
+async function projectIdFor(gateway: any, sessionId: string): Promise<string> {
+	return gateway.sessionManager.getPersistedSession(sessionId)?.projectId ?? await defaultProjectId();
+}
+
+test.describe("POST /api/sessions/:id/restart", () => {
+	test("restarts a valid idle session and returns ok with the matching session id", async () => {
+		const sessionId = await createSession();
+		try {
+			await waitForSessionStatus(sessionId, "idle");
+
+			const resp = await postRestart(sessionId);
+			expect(resp.status).toBe(200);
+			expect(resp.ok).toBe(true);
+			expect(await readJson(resp)).toMatchObject({ ok: true, sessionId });
+		} finally {
+			await deleteSession(sessionId);
+		}
+	});
+
+	test("returns SESSION_NOT_FOUND for a missing session id", async () => {
+		const resp = await postRestart("missing-restart-session-id");
+
+		expect(resp.status).toBe(404);
+		expect(await readJson(resp)).toMatchObject({ code: "SESSION_NOT_FOUND" });
+	});
+
+	test("rejects a busy session without force", async ({ gateway }) => {
+		const sessionId = await createSession();
+		let previousStatus: string | undefined;
+		try {
+			await waitForSessionStatus(sessionId, "idle");
+			const live = gateway.sessionManager.getSession(sessionId);
+			expect(live).toBeTruthy();
+			previousStatus = live.status;
+			live.status = "streaming";
+			gateway.sessionManager.getSessionStore(await projectIdFor(gateway, sessionId)).update(sessionId, { status: "streaming" });
+
+			const resp = await postRestart(sessionId, { force: false });
+			expect(resp.status).toBe(409);
+			expect(await readJson(resp)).toMatchObject({ code: "SESSION_BUSY" });
+		} finally {
+			const live = gateway.sessionManager.getSession(sessionId);
+			if (live && previousStatus) live.status = previousStatus;
+			gateway.sessionManager.getSessionStore(await projectIdFor(gateway, sessionId)).update(sessionId, { status: previousStatus ?? "idle" });
+			await deleteSession(sessionId);
+		}
+	});
+
+	test("rejects a non-interactive session as not restartable", async ({ gateway }) => {
+		const sessionId = await createSession();
+		try {
+			await waitForSessionStatus(sessionId, "idle");
+			const live = gateway.sessionManager.getSession(sessionId);
+			expect(live).toBeTruthy();
+			live.nonInteractive = true;
+			gateway.sessionManager.getSessionStore(await projectIdFor(gateway, sessionId)).update(sessionId, { nonInteractive: true });
+
+			const resp = await postRestart(sessionId);
+			expect([403, 409]).toContain(resp.status);
+			expect(await readJson(resp)).toMatchObject({ code: "SESSION_NOT_RESTARTABLE" });
+		} finally {
+			const live = gateway.sessionManager.getSession(sessionId);
+			if (live) live.nonInteractive = false;
+			gateway.sessionManager.getSessionStore(await projectIdFor(gateway, sessionId)).update(sessionId, { nonInteractive: false });
+			await deleteSession(sessionId);
+		}
+	});
+});

--- a/tests/e2e/ui/sidebar-actions-menu.spec.ts
+++ b/tests/e2e/ui/sidebar-actions-menu.spec.ts
@@ -135,12 +135,12 @@ test.describe("Sidebar actions menu", () => {
 		// then the menu-only actions in their declared order. The Fork row carries
 		// a trailing "New worktree" checkbox, but only its `[role=menuitem]` label
 		// counts here (the checkbox is a sibling `[role=menuitemcheckbox]`).
-		await expect.poll(() => menuLabels(page)).toEqual(["Terminate", "Modify", "Copy link", "Open in new window", "Fork"]);
+		await expect.poll(() => menuLabels(page)).toEqual(["Terminate", "Modify", "Copy link", "Open in new window", "Refresh agent", "Fork"]);
 		await page.keyboard.press("Escape");
 		await expectNoPopover(page);
 
 		await openMenu(row, "session", sessionId);
-		await expect.poll(() => menuLabels(page)).toEqual(["Terminate", "Modify", "Copy link", "Open in new window", "Fork"]);
+		await expect.poll(() => menuLabels(page)).toEqual(["Terminate", "Modify", "Copy link", "Open in new window", "Refresh agent", "Fork"]);
 		await expect(triggerFor(row, "session", sessionId), "hamburger trigger stays visible while the menu is open").toBeVisible();
 
 		await page.keyboard.press("Escape");
@@ -409,7 +409,8 @@ test.describe("Sidebar actions menu", () => {
 		const menu = page.locator("sidebar-actions-popover [role='menu']");
 		await expect(checkbox).toHaveAttribute("aria-checked", "true");
 
-		// Walk down to the Fork row: Terminate(0) > Modify(1) > Copy link(2) > Open in new window(3) > Fork(4).
+		// Walk down to the Fork row: Terminate(0) > Modify(1) > Copy link(2) > Open in new window(3) > Refresh agent(4) > Fork(5).
+		await page.keyboard.press("ArrowDown");
 		await page.keyboard.press("ArrowDown");
 		await page.keyboard.press("ArrowDown");
 		await page.keyboard.press("ArrowDown");

--- a/tests/e2e/ui/sidebar-refresh-agent.spec.ts
+++ b/tests/e2e/ui/sidebar-refresh-agent.spec.ts
@@ -1,0 +1,219 @@
+import type { Locator, Page } from "@playwright/test";
+import { test, expect } from "../gateway-harness.js";
+import {
+	apiFetch,
+	createSession,
+	deleteSession,
+	waitForSessionStatus,
+} from "../e2e-setup.js";
+import { openApp, navigateToHash } from "./ui-helpers.js";
+
+test.describe("Sidebar Refresh agent action", () => {
+	const sessionIds: string[] = [];
+
+	test.beforeEach(async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 900 });
+	});
+
+	test.afterAll(async () => {
+		for (const id of sessionIds.splice(0)) await deleteSession(id).catch(() => {});
+	});
+
+	function sessionRow(page: Page, sessionId: string): Locator {
+		return page.locator(`[data-session-id="${sessionId}"]`).first();
+	}
+
+	function triggerFor(row: Locator, sessionId: string): Locator {
+		return row.locator(`[data-testid="sidebar-actions-trigger"][data-sidebar-actions-kind="session"][data-sidebar-actions-id="${sessionId}"]`).first();
+	}
+
+	function refreshMenuItem(page: Page): Locator {
+		return page.locator('sidebar-actions-popover [role="menuitem"][data-sidebar-action-id="refresh-agent"]').first();
+	}
+
+	async function renameSession(sessionId: string, title: string): Promise<void> {
+		const resp = await apiFetch(`/api/sessions/${sessionId}`, {
+			method: "PATCH",
+			body: JSON.stringify({ title }),
+		});
+		expect(resp.ok, `renaming ${sessionId} should succeed`).toBeTruthy();
+	}
+
+	async function createIdleSession(title: string): Promise<string> {
+		const sessionId = await createSession();
+		sessionIds.push(sessionId);
+		await renameSession(sessionId, title);
+		await waitForSessionStatus(sessionId, "idle");
+		return sessionId;
+	}
+
+	async function openSession(page: Page, sessionId: string): Promise<Locator> {
+		await openApp(page);
+		await navigateToHash(page, `#/session/${sessionId}`);
+		await expect(page.locator("textarea").first()).toBeVisible({ timeout: 15_000 });
+		const row = sessionRow(page, sessionId);
+		await expect(row).toBeVisible({ timeout: 10_000 });
+		return row;
+	}
+
+	async function openMenu(row: Locator, sessionId: string): Promise<void> {
+		await expect(row).toBeVisible({ timeout: 10_000 });
+		const trigger = triggerFor(row, sessionId);
+		await row.hover();
+		await expect(trigger, "session hamburger should appear on hover").toBeVisible({ timeout: 5_000 });
+		await trigger.click();
+		await expect(row.page().locator("sidebar-actions-popover [role='menu']")).toBeVisible({ timeout: 5_000 });
+	}
+
+	async function closeMenu(page: Page): Promise<void> {
+		await page.keyboard.press("Escape");
+		await expect(page.locator("sidebar-actions-popover")).toHaveCount(0, { timeout: 5_000 });
+	}
+
+	async function patchClientSession(page: Page, sessionId: string, patch: Record<string, unknown>): Promise<void> {
+		await page.evaluate(({ id, patch }) => {
+			const state = (window as any).bobbitState ?? (window as any).__bobbitState;
+			if (!state?.gatewaySessions) throw new Error("missing bobbit gatewaySessions state");
+			const idx = state.gatewaySessions.findIndex((s: any) => s.id === id);
+			if (idx < 0) throw new Error(`missing session ${id}`);
+			state.gatewaySessions[idx] = { ...state.gatewaySessions[idx], ...patch };
+			(window as any).__bobbitRenderApp?.();
+		}, { id: sessionId, patch });
+	}
+
+	async function expectRefreshHiddenForPatchedSession(page: Page, row: Locator, sessionId: string): Promise<void> {
+		const trigger = triggerFor(row, sessionId);
+		await row.hover();
+		if (await trigger.isVisible().catch(() => false)) {
+			await trigger.click();
+			await expect(page.locator("sidebar-actions-popover [role='menu']")).toBeVisible({ timeout: 5_000 });
+			await expect(refreshMenuItem(page), "Refresh agent must not appear for ineligible sessions").toHaveCount(0);
+			await closeMenu(page);
+		} else {
+			await expect(trigger, "ineligible sessions may hide the whole action trigger").not.toBeVisible();
+		}
+	}
+
+	test("eligible live session menu shows exact non-quick Refresh agent item", async ({ page }) => {
+		const sessionId = await createIdleSession(`Refresh eligible ${Date.now()}`);
+		const row = await openSession(page, sessionId);
+
+		await row.hover();
+		await expect(
+			row.locator('[data-sidebar-action-id="refresh-agent"][data-sidebar-action-quick="true"]'),
+			"Refresh agent must be hamburger-only, not a quick action",
+		).toHaveCount(0);
+
+		await openMenu(row, sessionId);
+		const item = refreshMenuItem(page);
+		await expect(item).toBeVisible({ timeout: 5_000 });
+		await expect.poll(async () => (await item.textContent() || "").replace(/\s+/g, " ").trim()).toBe("Refresh agent");
+	});
+
+	test("inactive session row refresh posts to that exact session id and shows feedback", async ({ page }) => {
+		const activeId = await createIdleSession(`Refresh active ${Date.now()}`);
+		const inactiveId = await createIdleSession(`Refresh inactive ${Date.now()}`);
+		await openSession(page, activeId);
+
+		let releaseRestart!: () => void;
+		const restartCanFinish = new Promise<void>((resolve) => { releaseRestart = resolve; });
+		const restartPaths: string[] = [];
+		await page.route("**/api/sessions/*/restart", async (route) => {
+			const req = route.request();
+			restartPaths.push(new URL(req.url()).pathname);
+			await restartCanFinish;
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				body: JSON.stringify({ ok: true, sessionId: inactiveId }),
+			});
+		});
+
+		const inactiveRow = sessionRow(page, inactiveId);
+		await openMenu(inactiveRow, inactiveId);
+		const requestPromise = page.waitForRequest((req) => {
+			const url = new URL(req.url());
+			return req.method() === "POST" && url.pathname === `/api/sessions/${inactiveId}/restart`;
+		});
+		await refreshMenuItem(page).click();
+
+		const toast = page.locator('[data-testid="header-toast"]').first();
+		await expect(toast, "refresh should show visible pending feedback").toContainText(/Refreshing agent/i, { timeout: 5_000 });
+		const req = await requestPromise;
+		expect(req.method()).toBe("POST");
+		expect(new URL(req.url()).pathname).toBe(`/api/sessions/${inactiveId}/restart`);
+		expect(restartPaths).not.toContain(`/api/sessions/${activeId}/restart`);
+
+		releaseRestart();
+		await expect(toast, "refresh should leave visible refresh feedback after completion").toContainText(/refresh/i, { timeout: 5_000 });
+	});
+
+	test("refresh failure shows visible error feedback", async ({ page }) => {
+		const sessionId = await createIdleSession(`Refresh error ${Date.now()}`);
+		const row = await openSession(page, sessionId);
+		let releaseFailure!: () => void;
+		const failureCanFinish = new Promise<void>((resolve) => { releaseFailure = resolve; });
+		await page.route(`**/api/sessions/${sessionId}/restart`, async (route) => {
+			await failureCanFinish;
+			await route.fulfill({
+				status: 500,
+				contentType: "application/json",
+				body: JSON.stringify({ error: "forced restart failure", code: "FORCED_REFRESH_FAILURE" }),
+			});
+		});
+
+		await openMenu(row, sessionId);
+		await refreshMenuItem(page).click();
+		const toast = page.locator('[data-testid="header-toast"]').first();
+		await expect(toast).toContainText(/Refreshing agent/i, { timeout: 5_000 });
+		releaseFailure();
+		await expect(toast, "restart failures must not be silent").toContainText(/fail|error|unable|could not/i, { timeout: 10_000 });
+	});
+
+	test("ineligible sessions hide Refresh agent and busy sessions are confirmation-guarded or disabled", async ({ page }) => {
+		const ineligibleId = await createIdleSession(`Refresh ineligible ${Date.now()}`);
+		const busyId = await createIdleSession(`Refresh busy ${Date.now()}`);
+		const ineligibleRow = await openSession(page, ineligibleId);
+
+		await patchClientSession(page, ineligibleId, { readOnly: true });
+		await expectRefreshHiddenForPatchedSession(page, ineligibleRow, ineligibleId);
+
+		await patchClientSession(page, ineligibleId, { readOnly: false, nonInteractive: true });
+		await expectRefreshHiddenForPatchedSession(page, ineligibleRow, ineligibleId);
+
+		await navigateToHash(page, `#/session/${busyId}`);
+		await expect(page.locator("textarea").first()).toBeVisible({ timeout: 15_000 });
+		const busyRow = sessionRow(page, busyId);
+		await patchClientSession(page, busyId, { status: "streaming" });
+		let restartCalls = 0;
+		await page.route(`**/api/sessions/${busyId}/restart`, async (route) => {
+			restartCalls += 1;
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				body: JSON.stringify({ ok: true, sessionId: busyId }),
+			});
+		});
+
+		await openMenu(busyRow, busyId);
+		const item = refreshMenuItem(page);
+		await expect(item, "busy sessions should keep Refresh agent visible but safe").toBeVisible({ timeout: 5_000 });
+		const disabled = await item.evaluate((el) =>
+			el.getAttribute("aria-disabled") === "true"
+			|| el.hasAttribute("disabled")
+			|| (el as HTMLButtonElement).disabled === true,
+		);
+		if (disabled) {
+			const affordance = `${await item.textContent() || ""} ${await item.getAttribute("title") || ""}`;
+			expect(affordance).toMatch(/busy|streaming|running|finish|wait|interrupt/i);
+			expect(restartCalls).toBe(0);
+		} else {
+			await item.click();
+			const dialog = page.locator(".fixed.inset-0, [role='dialog']").filter({ hasText: /Refresh agent|interrupt|restart/i }).last();
+			await expect(dialog, "busy refresh must ask for confirmation before interrupting").toBeVisible({ timeout: 5_000 });
+			expect(restartCalls, "opening the confirmation must not call restart yet").toBe(0);
+			await dialog.getByRole("button", { name: "Cancel", exact: true }).click();
+			expect(restartCalls, "cancel must not call restart").toBe(0);
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- Add POST /api/sessions/:id/restart to restart a live session's agent process by explicit session id.
- Add a sidebar hamburger action labeled exactly Refresh agent with eligibility guards, busy-session confirmation, and visible feedback.
- Add API/browser E2E coverage and documentation for the REST and WebSocket restart paths.

## Validation
- npm run check
- npm run test:unit
- npm run build --silent
- npx playwright test --config playwright-e2e.config.ts --project=api tests/e2e/session-restart-api.spec.ts
- npm run test:e2e:run -- tests/e2e/ui/sidebar-refresh-agent.spec.ts
- npm run test:e2e:run -- tests/e2e/ui/sidebar-actions-menu.spec.ts
- npm run test:e2e:run -- (diagnostic full run: passed with unrelated flakes retried)

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)