### PR TITLE
Retain gate logs

### DIFF
--- a/defaults/roles/team-lead.yaml
+++ b/defaults/roles/team-lead.yaml
@@ -110,8 +110,8 @@ promptTemplate: |
 
   - **gate_list** — List all gates with status and definitions. No parameters.
   - **gate_signal** — Signal a gate with content and/or metadata. Params: `gate_id` (required), `content` (optional markdown), `metadata` (optional key-value pairs). Re-signaling a passed gate cascade-resets downstream gates to pending.
-  - **gate_status** — Get latest signal details for a gate — verdict, truncated failed-step output, and metadata. Param: `gate_id`.
-  - **gate_inspect** — Read bounded gate content, verification output, or signal history. Params: `gate_id`, `section` ("content"/"verification"/"signals"), optional `signal_index`, `mode` ("grep"/"tail"/"head"/"slice"/"full"), `step` (verification step name — scopes `section="verification"` to one step), `pattern`, `context`, `max_results`, `lines`, `from`, `to`.
+  - **gate_status** — Get latest signal details for a gate — verdict, failed-step names, compact failed-step output tail, and metadata. Param: `gate_id`.
+  - **gate_inspect** — Read bounded gate content, verification output, or signal history. Explicit verification inspection may use retained logs/artifacts for failed command steps while status stays compact. Params: `gate_id`, `section` ("content"/"verification"/"signals"), optional `signal_index`, `mode` ("grep"/"tail"/"head"/"slice"/"full"), `step` (verification step name from `failedSteps` — scopes `section="verification"` to one step), `pattern`, `context`, `max_results`, `lines`, `from`, `to`.
 
   {if:subGoalsEnabled}
   ### Children Management (pause / resume)
@@ -185,7 +185,7 @@ promptTemplate: |
   5. **Signal gates to fulfil workflow requirements.** When signaling a gate via `gate_signal`, the server enforces dependency gating — you'll get a 409 if upstream dependencies haven't passed.
   6. **Use `suggestedRole`** from the workflow gate definition to pick which role to spawn.
   7. **Check quality criteria** — each workflow gate lists mustHave/shouldHave/mustNotHave. Ensure the produced content meets these before signaling.
-  8. **Handle failures** — if verification fails a gate, check the failure reason, fix the issue, and re-signal via `gate_signal`.
+  8. **Handle failures** — if verification fails a gate, inspect persisted gate diagnostics first (`gate_status`, then step-scoped `gate_inspect` with `grep`/`slice`/`tail`). Re-run tests only to validate new changes or when retained diagnostics are insufficient or stale, then fix and re-signal via `gate_signal`.
 
   ## Gate Content Quality
   Gate content must be substantive:
@@ -345,10 +345,10 @@ promptTemplate: |
      Returns status, counts, and failed step names. Use on every wake-up.
 
   2. **Detail** (`gate_status`) — call for a specific gate after a notification.
-     Returns latest verdict, failed step output tail, and metadata.
+     Returns latest verdict, failed step names, failed step output tail, and metadata.
      Usually enough to decide next steps.
 
-  3. **Content** (`gate_inspect`) — call only when you need to READ something. Default output is a bounded tail, not full output:
+  3. **Content** (`gate_inspect`) — call only when you need to READ something. Default output is a bounded tail, not full output. For failed command steps, explicit verification inspection may be backed by retained logs/artifacts that survive restart and worktree cleanup, while `gate_status` stays compact:
      - `gate_inspect(gate_id="design-doc", section="content")` — read a design doc, bounded if large
      - `gate_inspect(gate_id="implementation", section="verification", mode="grep", pattern="error|failed", context=2)` — targeted failure triage
      - `gate_inspect(gate_id="implementation", section="verification", step="unit", mode="grep", pattern="error|failed", context=2)` — scope triage to ONE step by name (e.g. just the failing `unit` step) instead of every step's output
@@ -363,10 +363,14 @@ promptTemplate: |
   2. Need more detail? → `gate_status(gate_id="...")` — check the verdict and output tail first.
   3. Still unclear? → `gate_inspect(gate_id="...", section="verification", mode="grep", pattern="error|failed", context=2)` — inspect matching failure lines.
   4. Multi-step gate, one culprit? → `gate_list`/`gate_status` name the failing step(s) in `failedSteps`. Pass `step="<name>"` to scope the verification snapshot to just that step, then combine with `mode="grep"`/`"slice"` to drill into its log alone — you no longer wade through every step's output. (`step` is verification-only; an unknown name returns a 400 listing the valid step names.)
-  5. Need surrounding output? → Use `mode="tail"` or `mode="slice"`; prefer `mode="full"` only as a rare escape hatch.
+  5. Need surrounding output? → Use `mode="tail"` or `mode="slice"`; prefer `mode="full"` only as a rare escape hatch because tool-result budgets can still cap it.
   6. Need to read upstream content? → `gate_inspect(gate_id="...", section="content")`.
 
   Do NOT call `gate_inspect` "just in case" — only when the decision requires it. Prefer `gate_status` first, then a `step`-scoped/`grep` read of the failing step, then `tail`/`slice`.
+
+  After verification has run, consume persisted gate data before spending time reproducing it: start with `gate_status`, use `failedSteps` from `gate_list`/`gate_status` for `step="..."`, and drill with `grep`/`slice`/`tail`. Do not re-run tests locally or spawn agents just to collect logs that gate diagnostics already retained. Re-run tests only when validating new changes or when retained diagnostics are insufficient/stale; never duplicate successful agent or gate validation just to gather context.
+
+  Retained logs/artifacts can survive restart and worktree cleanup, but every tool response is still bounded. If output is truncated, prefer narrower `grep`/`slice` calls over `mode="full"`.
 
   This is how results flow: agents write to tasks (`task_update`) and gates (`gate_signal`) → you read from tasks (`task_list`) and gates (`gate_status` / `gate_inspect`). You do NOT need to read agent session logs or parse their chat output.
 

--- a/defaults/tools/tasks/gate_inspect.yaml
+++ b/defaults/tools/tasks/gate_inspect.yaml
@@ -7,13 +7,13 @@ provider:
   extension: extension.ts
 group: Gates
 docs: >-
-  Scoped read tool for gate data. Fetches exactly one section per call:
-  content, verification, or signals. Output is bounded by default; use grep,
-  tail, head, slice, or full mode to inspect only the detail you need.
+  Scoped read tool for gate data. Fetches one section per call: content,
+  verification, or signals. Output is bounded by default; use step-scoped grep,
+  slice, or tail before rare full output.
 detail_docs: |-
   ## Purpose
 
-  Read detailed gate data by section. This is the Layer 3 content retrieval tool — use it when `gate_list` (Layer 1) and `gate_status` (Layer 2) don't have enough detail. Each call fetches exactly one piece of data and applies bounded text selection so large verification logs do not flood context.
+  Read detailed gate data by section. This is the Layer 3 content retrieval tool — use it when `gate_list` (Layer 1) and `gate_status` (Layer 2) don't have enough detail. Each call fetches exactly one piece of data and applies bounded text selection so large verification logs do not flood context. After verification has run, inspect this persisted gate data before re-running tests just to reproduce logs.
 
   ## Parameters
 
@@ -69,7 +69,7 @@ detail_docs: |-
 
   ### section="verification" — Read verification output
 
-  Returns verification steps with each step's `output` independently selected. When `step="<name>"` is given, only that one step is returned (single-element `steps[]`) and the selection mode applies to that step's output; an unknown name returns a 400 listing the available step names.
+  Returns verification steps with each step's `output` independently selected. When `step="<name>"` is given, only that one step is returned (single-element `steps[]`) and the selection mode applies to that step's output; an unknown name returns a 400 listing the available step names. For failed command steps, explicit inspection may be backed by retained stdout/stderr logs and artifact metadata (for example Playwright `test-results` or reports) that can survive restart and worktree cleanup; default/status views remain compact.
 
   - `gateId` — gate identifier
   - `section` — `"verification"`
@@ -108,10 +108,11 @@ detail_docs: |-
 
   ## When to Use
 
-  - **Start with status** — call `gate_status(gate_id="...")` first; its verdict and output tail are usually enough.
+  - **Start with status** — call `gate_status(gate_id="...")` first; its verdict, `failedSteps`, and output tail are usually enough.
   - **Target failure lines** — use `mode="grep"` with `pattern="error|failed"` and `context=2` for large verification logs.
-  - **Focus one step** — pass `step="<name>"` to scope `section="verification"` to a single step (names come from `gate_status.failedSteps`).
+  - **Focus one step** — pass `step="<name>"` to scope `section="verification"` to a single step (names come from `gate_list.failedSteps` or `gate_status.failedSteps`).
   - **Inspect nearby output** — use `mode="tail"` or `mode="slice"` when grep shows where to look.
+  - **Use retained diagnostics first** — do not re-run tests or spawn agents just to gather logs already available here; re-run only to validate new changes or when diagnostics are insufficient/stale.
   - **Read upstream content** — use `section="content"` when you need the gate's actual content.
   - **Browse attempts** — use `section="signals"` to compare signal history.
 
@@ -119,8 +120,9 @@ detail_docs: |-
 
   - **Quick status check** — use `gate_list` (Layer 1) instead.
   - **Latest verdict and failed-step tail** — use `gate_status` (Layer 2) instead.
-  - **Full output by default** — default `gate_inspect` is a bounded tail. Use `mode="full"` only as a rare escape hatch.
+  - **Full output by default** — default `gate_inspect` is a bounded tail. Use `mode="full"` only as a rare escape hatch; tool-result budgets can still truncate it.
   - **Just in case** — only call when the decision requires reading the actual content or detailed output.
+  - **Duplicating validation** — do not repeat successful agent or gate validation just to collect context.
 
   ## Examples
 
@@ -158,6 +160,8 @@ detail_docs: |-
   - `signal_index` defaults to `-1` (latest). Use `0` for the first signal, `-2` for second-to-last, etc.
   - `section="signals"` ignores `signal_index`; it reads history rather than one signal.
   - Default output is a bounded tail, not the full rendered payload.
+  - Verification inspection may read retained logs/artifacts for failed command steps; status/default responses stay compact.
+  - Retained diagnostics can survive restart and worktree cleanup, but selected output is still bounded and may be capped.
   - `mode="full"` can still be truncated by normal tool-result budgets; check `selection.truncated` and `selection.truncationReason`.
   - Invalid regexes, missing slice bounds, non-integer ranges, ranges below 1, or `from > to` return clear validation errors.
-  - For triage, prefer `gate_status`, then `gate_inspect(..., mode="grep", pattern="error|failed", context=2)`, then `tail` or `slice`.
+  - For triage, prefer `gate_status`, then step-scoped `gate_inspect(..., mode="grep", pattern="error|failed", context=2)`, then `tail` or `slice`.

--- a/defaults/tools/tasks/gate_list.yaml
+++ b/defaults/tools/tasks/gate_list.yaml
@@ -6,9 +6,9 @@ provider:
   extension: extension.ts
 group: Gates
 docs: >-
-  No parameters. Returns all workflow gates with status
-  (`pending`/`passed`/`failed`), dependencies, and content flags. Call at start
-  of work to understand workflow state.
+  No parameters. Returns all workflow gates with status, dependencies, content
+  flags, and failedSteps for failed gates. Use failedSteps to scope
+  gate_inspect(step=...).
 detail_docs: >-
   ## Purpose
 
@@ -64,6 +64,10 @@ detail_docs: >-
   - **Resuming work** — after a restart, check gate status to resume from the
   right point.
 
+  - **Scoping failure triage** — use `failedSteps` to choose
+  `gate_inspect(section="verification", step="...")` instead of reading every
+  step or re-running tests just to collect logs.
+
 
   ## When NOT to Use
 
@@ -71,8 +75,8 @@ detail_docs: >-
   - **Getting a single gate's detail** — use `gate_status` for latest verdict
   and truncated verification output.
 
-  - **Reading gate content** — use `gate_inspect` to read content, full
-  verification output, or signal history.
+  - **Reading gate content or diagnostics** — use `gate_inspect` to read
+  content, retained verification logs/artifacts, or signal history.
 
 
   ## Examples
@@ -92,6 +96,10 @@ detail_docs: >-
 
   - **Lightweight** — no parameters, fast response. Call frequently to stay
   informed.
+
+  - **Failed steps are hints** — pass a failed step name to
+  `gate_inspect(step="...")`, then use `grep`/`slice`/`tail`; use `full` only
+  as a rare escape hatch because output remains capped.
 
   - **Status values** — `pending` (not yet signaled or reset), `passed`
   (signaled and verified), `failed` (verification failed).

--- a/defaults/tools/tasks/gate_status.yaml
+++ b/defaults/tools/tasks/gate_status.yaml
@@ -7,17 +7,18 @@ provider:
   extension: extension.ts
 group: Gates
 docs: >-
-  Returns latest signal with truncated verification output (last 40 lines for
-  failed steps). Shows hasContent/contentLength instead of content body. Use
-  gate_inspect for full content, verification output, or signal history.
+  Returns latest signal with compact failed-step output, failedSteps, and
+  metadata. Use gate_inspect for targeted content, verification logs/artifacts,
+  or signal history.
 detail_docs: >-
   ## Purpose
 
 
   Get the latest signal details for a specific workflow gate — verdict,
-  truncated failed-step output, and metadata. This is the Layer 2 detail view:
-  more than `gate_list` but less than `gate_inspect`. Returns enough to decide
-  next steps without dumping full content or history.
+  failed-step names, compact failed-step output, and metadata. This is the Layer
+  2 detail view: more than `gate_list` but less than `gate_inspect`. Returns
+  enough to decide next steps without dumping full content, retained logs, or
+  history.
 
 
   ## Parameters
@@ -61,22 +62,26 @@ detail_docs: >-
     - `commitSha` — git commit (if provided)
     - `verification` — verification result:
       - `status` — `passed`, `failed`, or `running`
+      - `failedSteps` — failed verification step names, useful as `gate_inspect(step=...)`
       - `steps[]` — array of step results:
         - `name` — step name
         - `passed` — boolean
-        - `output` — last 40 lines of output (failed steps only; omitted for passed steps)
+        - `output` — compact output tail (failed steps only; omitted for passed steps)
 
 
   Does **not** return: content body (use `gate_inspect section=content`), full
-  signal history (use `gate_inspect section=signals`), full verification output
-  (use `gate_inspect section=verification`).
+  signal history (use `gate_inspect section=signals`), or retained verification
+  logs/artifacts (use `gate_inspect section=verification`, scoped by `step`).
 
 
   ## When to Use
 
 
   - **Checking verification results** — after a gate notification, see the
-  latest verdict and truncated error output.
+  latest verdict, failed steps, and compact error output.
+
+  - **Scoping inspection** — copy `failedSteps` into `gate_inspect(step="...")`
+  and drill with `grep`, `slice`, or `tail` before considering a re-run.
 
   - **Seeing latest verdict** — quick check on what failed and why.
 
@@ -90,8 +95,9 @@ detail_docs: >-
   - **Reading gate content** — use `gate_inspect(gate_id="...",
   section="content")` instead.
 
-  - **Reading full verification output** — use `gate_inspect(gate_id="...",
-  section="verification")` if the 40-line tail wasn't enough.
+  - **Reading retained verification output or artifacts** — use
+  `gate_inspect(gate_id="...", section="verification", step="...", mode="grep"|"slice"|"tail")`
+  if the compact tail wasn't enough.
 
   - **Browsing signal history** — use `gate_inspect(gate_id="...",
   section="signals")` to see all past signals.
@@ -130,8 +136,18 @@ detail_docs: >-
   - **Only the latest signal** — historical signals are not returned. Use
   `gate_inspect(section="signals")` for history.
 
-  - **Truncated output** — failed verification steps show only the last 40
-  lines of output. Use `gate_inspect(section="verification")` for full output.
+  - **Compact output** — failed verification steps show only a small tail.
+  Explicit `gate_inspect(section="verification")` may use retained logs/artifacts
+  for failed command steps while this status view stays compact.
 
-  - **Use `gate_list` first** — to discover gate IDs before querying specific
-  gates.
+  - **Bounded diagnostics** — retained logs/artifacts can survive restart and
+  worktree cleanup, but tool-result budgets still cap output. Prefer
+  step-scoped `grep`/`slice` over `full`.
+
+  - **Avoid wasteful re-runs** — after verification has run, consume persisted
+  gate diagnostics first. Re-run tests only to validate new changes or when
+  retained diagnostics are insufficient or stale; do not duplicate successful
+  agent/gate validation just to gather context.
+
+  - **Use `gate_list` first** — to discover gate IDs and `failedSteps` before
+  querying specific gates.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -11,6 +11,15 @@ Scannable checklists for common issues. Each entry: symptom → where to look �
 - **Confirm a kill**: poll `process.kill(pid, 0)` against the recorded step pid — it throws `ESRCH` once the tree is reaped (within `killGraceMs`, so ~5s on timeout, ~1s on cancel). `ps -o pid= -g <pgid>` (POSIX) or `tasklist /FI "PID eq <pid>"` (Windows) should return empty in the same window. The failed step's `output` ends with `— killed subprocess tree`.
 - **Pinning tests**: `tests/verification-harness-timeout.test.ts` (unit), `tests/e2e/verification-timeout.spec.ts` (E2E).
 
+## Failed gate has missing or compact logs
+
+- **Symptom**: a failed command verification shows only a short tail in `gate_status`, a notification, or default `gate_inspect`, and the original `test-results` / `playwright-report` directory is gone.
+- **Expected behavior**: compact surfaces intentionally stay small. Before rerunning the suite, call `gate_inspect(section="verification", step="<failed step>", mode="grep"|"slice"|"tail"|"full")` so the snapshot can read retained stdout/stderr and Playwright-style artifacts from Bobbit state.
+- **Where to look**: `steps[].diagnostics.outputSource`, `diagnostics.logs.*.{bytes,truncated,truncationReason}`, and `diagnostics.artifacts.files` in an explicit verification inspect response. Retained files live under the state `gate-diagnostics` tree and are removed when the owning goal is archived or deleted.
+- **Limits/security**: stdout and stderr are capped independently at 20 MiB; `mode="full"` still has response/tool-result caps. Artifact copying rejects symlinked roots and descendants, so missing artifacts may mean Playwright did not write them or the path was unsafe to copy.
+- **Reference**: [Retained gate diagnostics](gate-diagnostics.md).
+- **Pinning tests**: `tests/e2e/gate-inspect-slicing.spec.ts`, `tests/gate-verification-snapshot.test.ts`, `tests/gate-diagnostics.test.ts`, `tests/gate-diagnostics-cleanup.test.ts`, `tests/e2e/gate-diagnostics-cleanup.spec.ts`.
+
 ## Gate verification stuck on a `human-signoff` step
 
 - **Symptom**: a gate's verification stays in `running` indefinitely; one of its steps is `type: human-signoff`. The chat-header `<goal-status-widget>` should be pulsing its primary-colour exclamation icon between the goal icon and gate counter, and its **View content** action should open a sign-off review document with Approve / Reject controls. Or: the review pane submits but never resolves the step.

--- a/docs/gate-diagnostics.md
+++ b/docs/gate-diagnostics.md
@@ -1,0 +1,115 @@
+# Retained gate diagnostics
+
+Retained gate diagnostics preserve the evidence from automated gate verification after a command step fails. They sit between the compact gate status surfaces and a full manual rerun: team leads can inspect persisted logs and artifacts first, then decide whether a rerun is necessary.
+
+## Where this fits
+
+Gate verification stores a compact step result in the gate history so `gate_status`, notifications, and default `gate_inspect` calls stay small enough for agent context. Command steps can also emit much larger stdout/stderr streams and Playwright artifacts. Those larger diagnostics are retained in Bobbit state, outside the goal worktree, and are only read when a caller explicitly requests an inspection mode.
+
+This split keeps routine status checks cheap while making failed E2E and browser-test gates diagnosable after worktree cleanup or a gateway restart.
+
+## What is retained
+
+For command verification steps, Bobbit writes retained diagnostics under the gateway state directory, keyed by goal, gate, signal, and step:
+
+```text
+<stateDir>/gate-diagnostics/<goalId>/<gateId>/<signalId>/<step>/
+  stdout.log
+  stderr.log
+  artifacts/
+    test-results/...
+    playwright-report/...
+```
+
+The gate store persists references to these files on the verification step. Completed gate inspection can therefore read the state copy even if:
+
+- the original goal worktree was cleaned up;
+- the gateway restarted after the command finished;
+- the compact `GateSignalStep.output` only contains a short failure tail.
+
+The compact step output is still the source for default status views. The retained files are the source for explicit diagnostic inspection.
+
+## Inspecting retained logs
+
+Use `gate_status` first to identify the failing gate and step. Then inspect that step with an explicit `gate_inspect` mode before rerunning tests:
+
+```text
+gate_inspect(gate_id="implementation", section="verification", step="E2E tests", mode="grep", pattern="error|failed|Error", context=3)
+gate_inspect(gate_id="implementation", section="verification", step="E2E tests", mode="tail", lines=200)
+gate_inspect(gate_id="implementation", section="verification", step="E2E tests", mode="slice", from=120, to=220)
+```
+
+Any explicit mode (`grep`, `tail`, `head`, `slice`, or `full`) allows verification inspection to use retained stdout/stderr when they exist. If `mode` is omitted, Bobbit keeps the implicit default compact: the last 20 lines per step, with no retained file paths or artifact file lists.
+
+Typical flow:
+
+1. `gate_status` — find the failed step name from compact status.
+2. `gate_inspect(..., mode="grep")` — search retained logs for the failure marker or stack trace.
+3. `gate_inspect(..., mode="tail"|"slice")` — read surrounding context.
+4. Rerun the suite only if the retained diagnostics are insufficient or the fix needs fresh verification.
+
+## Compact surfaces stay compact
+
+The following surfaces intentionally do not expose retained logs or artifact lists by default:
+
+- `gate_status`;
+- failure notifications sent to team leads;
+- `gate_inspect(section="verification")` when `mode` is omitted;
+- summary gate endpoints used by counters and dashboard cards.
+
+This prevents large Playwright logs, traces, screenshots, or report metadata from flooding an agent context during routine progress checks. Explicit inspection adds diagnostic metadata such as `diagnostics.outputSource`, `diagnostics.logs`, `diagnostics.artifacts`, and inspect hints.
+
+## Log caps and truncation metadata
+
+Each retained stream is capped at 20 MiB by default:
+
+- `stdout.log` has its own cap;
+- `stderr.log` has its own cap;
+- when a stream hits the cap, newer bytes beyond the cap are not appended.
+
+Explicit inspection exposes cap and truncation metadata in the verification snapshot:
+
+- `steps[].diagnostics.logs.stdout.bytes` / `stderr.bytes`;
+- `steps[].diagnostics.logs.*.truncated`;
+- `steps[].diagnostics.logs.*.truncationReason`;
+- `steps[].selection.truncated` and `steps[].selection.truncationReason` when selection or response budgets also apply.
+
+`mode="full"` still passes through normal line, byte, and tool-result budgets. If those budgets apply, use `grep`, `slice`, or a larger targeted `tail` instead of assuming the selected output contains every retained byte.
+
+## Playwright-style artifacts
+
+When available, Bobbit copies Playwright-style artifacts from the command working directory into the retained diagnostics tree:
+
+- `test-results/**/error-context.md`;
+- traces such as `trace.zip`;
+- screenshots and videos;
+- selected files under Playwright `data/` and `trace/` folders;
+- `playwright-report/**`.
+
+Small `error-context.md` files are inlined in explicit inspection metadata as markdown content, so the failure locator context can be read without opening the original artifact directory. Larger or binary files are exposed as retained artifact metadata with path, relative path, source path, size, and kind.
+
+Artifact capture is best effort. Missing reports do not change the verification result, but available reports are retained before worktree cleanup can remove them.
+
+## Symlink hardening
+
+Artifact copying treats verification output as untrusted filesystem content:
+
+- symlinked artifact roots are rejected;
+- symlinked descendants are skipped;
+- source realpaths must stay within the artifact root;
+- destination realpaths must stay within Bobbit's diagnostics directory;
+- Docker-copied artifact trees are staged and then checked with the same destination bounds.
+
+This prevents a malicious or accidental symlink in `test-results` or `playwright-report` from causing Bobbit to copy unrelated host files into retained diagnostics.
+
+## Cleanup lifecycle
+
+Retained diagnostics are goal-owned state. Bobbit removes the diagnostics directory when the owning goal is archived or hard-deleted. Cascade archiving cleans diagnostics for child/subgoals too, while unrelated goals' diagnostics are preserved.
+
+Gate reset does not delete historical diagnostics; reset changes approval state and cache eligibility, but the failed signal remains part of the gate audit history until the goal itself is archived or deleted.
+
+## Related references
+
+- [Goals, workflows, and tasks — Verification](goals-workflows-tasks.md#verification)
+- [REST API — Gate inspect endpoint](rest-api.md#gate-inspect-endpoint)
+- [Debugging — Failed gate has missing or compact logs](debugging.md#failed-gate-has-missing-or-compact-logs)

--- a/docs/goals-workflows-tasks.md
+++ b/docs/goals-workflows-tasks.md
@@ -383,6 +383,8 @@ Verification log output is bounded by default: `gate_status` and `gate_inspect s
 
 Running command steps can include live stdout/stderr tails. The server reads those log files with bounded byte limits before applying the same selection and aggregate response budgets used for persisted output.
 
+Completed command steps also retain stdout/stderr under Bobbit state. Default status surfaces and implicit inspection stay compact, but any explicit `gate_inspect(section="verification", mode=...)` request can query the retained logs and returns diagnostics metadata when available. Playwright-style `test-results` and `playwright-report` artifacts are copied into the same retained diagnostics tree, including `error-context.md`, traces, screenshots, and reports. Retained log streams are capped at 20 MiB each, artifact copying is symlink-hardened, and diagnostics are cleaned up when the owning goal is archived or deleted. Team leads should inspect these persisted diagnostics before rerunning expensive suites. See [Retained gate diagnostics](gate-diagnostics.md) for the full storage, inspection, and cleanup model.
+
 ##### Targeting a single verification step
 
 A gate often runs several verify steps (e.g. type-check + lint + unit + e2e, or multiple review steps). By default `gate_inspect section=verification` returns *every* step, so a team lead chasing one failing step still receives all the others' output and cannot scope a `grep`/`slice` to the step they care about. The optional `step` parameter fixes that: pass the step **name** and the snapshot is scoped to just that one step.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -1179,6 +1179,18 @@ Step `status` is one of `passed`, `failed`, `skipped`, `running`, `waiting`, or 
 
 Running command steps may include bounded live stdout/stderr reads via `liveLogs`. The server reads a capped portion of the live log file first, then applies the requested `tail`, `head`, `slice`, `grep`, or `full` selection and the aggregate output budget. Use those selection modes for deeper targeted logs instead of relying on the default 20-line tail.
 
+Completed command steps can include retained diagnostics. When a verification request uses an explicit `mode`, `steps[].diagnostics` may report:
+
+| Field | Meaning |
+|---|---|
+| `diagnostics.outputSource` | `"retained-logs"`, `"live-logs"`, or `"compact-tail"` |
+| `diagnostics.logs.stdout` / `stderr` | Retained log path, bytes, line count, and cap/truncation metadata |
+| `diagnostics.artifacts` | Count and retained file metadata for copied `test-results` / `playwright-report` artifacts; small `error-context.md` files may include markdown `content` |
+| `diagnostics.inspectHints` | Suggested `gate_inspect` calls for targeted follow-up |
+| `diagnostics.note` | Human-readable summary of which output source was used |
+
+Default `gate_status`, notifications, and omitted-mode inspection do not include retained log paths or artifact file lists. Retained stdout and stderr are capped at 20 MiB per stream, and explicit inspection exposes cap/truncation metadata. See [Retained gate diagnostics](gate-diagnostics.md) for artifact retention, symlink hardening, and cleanup lifecycle.
+
 **`section=signals`** — Returns bounded signal history. The `signals[]` field remains present for compatibility, and large histories include totals/truncation fields plus deterministic selected JSON-lines `text`.
 ```json
 {

--- a/src/server/agent/bobbit-archive.ts
+++ b/src/server/agent/bobbit-archive.ts
@@ -56,6 +56,7 @@ export const GATEWAY_OWNED_FILES: readonly string[] = [
 	"state/tool-guard/",          // src/server/agent/tool-activation.ts
 	"state/mcp-extensions/",      // src/server/agent/tool-activation.ts, rpc-bridge.ts
 	"state/html-snapshots/",      // server.ts
+	"state/gate-diagnostics/",    // src/server/agent/gate-diagnostics-cleanup.ts
 	"state/proposal-drafts/",     // server.ts / session-manager.ts
 	"state/pr-walkthrough/",      // src/server/pr-walkthrough/routes.ts persisted walkthrough payloads
 	"state/model-name-*",         // src/server/agent/session-manager.ts per-session model-name files

--- a/src/server/agent/gate-diagnostics-cleanup.ts
+++ b/src/server/agent/gate-diagnostics-cleanup.ts
@@ -1,0 +1,26 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { bobbitStateDir } from "../bobbit-dir.js";
+
+export const GATE_DIAGNOSTICS_DIR = "gate-diagnostics";
+
+export function safeGateDiagnosticsSegment(value: string): string {
+	const trimmed = value.trim();
+	return trimmed.replace(/[^A-Za-z0-9._-]/g, "_") || "unknown";
+}
+
+function resolveStateDir(stateDir?: string): string {
+	return stateDir ?? bobbitStateDir();
+}
+
+export function gateDiagnosticsRootDir(stateDir?: string): string {
+	return path.join(resolveStateDir(stateDir), GATE_DIAGNOSTICS_DIR);
+}
+
+export function gateDiagnosticsGoalDir(goalId: string, stateDir?: string): string {
+	return path.join(gateDiagnosticsRootDir(stateDir), safeGateDiagnosticsSegment(goalId));
+}
+
+export async function cleanupGateDiagnosticsForGoal(goalId: string, stateDir?: string): Promise<void> {
+	await fs.rm(gateDiagnosticsGoalDir(goalId, stateDir), { recursive: true, force: true });
+}

--- a/src/server/agent/gate-store.ts
+++ b/src/server/agent/gate-store.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 import type { Workflow } from "./workflow-store.js";
+import type { GateStepDiagnostics } from "../gate-diagnostics.js";
 
 export type GateStatus = "pending" | "passed" | "failed" | "bypassed";
 
@@ -18,6 +19,8 @@ export interface GateSignalStep {
 		contentType: string;
 		metadata?: Record<string, string>;
 	};
+	/** Durable diagnostics for completed command steps, stored under Bobbit state. */
+	diagnostics?: GateStepDiagnostics;
 	/**
 	 * Lifecycle status for in-flight rows. Set on initial enumeration by
 	 * `VerificationHarness.beginVerification()` so the gate-store signal

--- a/src/server/agent/goal-manager.ts
+++ b/src/server/agent/goal-manager.ts
@@ -13,6 +13,7 @@ import type { GateStore } from "./gate-store.js";
 import type { TeamStore } from "./team-store.js";
 import type { SessionStore } from "./session-store.js";
 import { isWorktreePathReferencedByLiveSession, type WorktreeReferenceRecord } from "./worktree-reference-guard.js";
+import { cleanupGateDiagnosticsForGoal } from "./gate-diagnostics-cleanup.js";
 
 const pExecFile = promisify(execFileCb);
 
@@ -111,6 +112,7 @@ export class GoalManager {
 	 * branch. Set by server.ts on startup. */
 	private baseRefResolver?: (projectId: string) => string | undefined;
 	private liveSessionResolver?: () => WorktreeReferenceRecord[];
+	private readonly diagnosticsStateDir?: string;
 	setBaseRefResolver(resolver: (projectId: string) => string | undefined): void {
 		this.baseRefResolver = resolver;
 	}
@@ -140,9 +142,10 @@ export class GoalManager {
 		return [];
 	}
 
-	constructor(goalStore: GoalStore, workflowStore?: WorkflowStore) {
+	constructor(goalStore: GoalStore, workflowStore?: WorkflowStore, stateDir?: string) {
 		this.store = goalStore;
 		this.workflowStore = workflowStore;
+		this.diagnosticsStateDir = stateDir ?? (goalStore as unknown as { storeDir?: string }).storeDir;
 		// Lazy-migrate legacy paused=true + unresolved-deps goals to state='blocked'
 		// BEFORE recovering stuck setups, so that newly-blocked goals don't get
 		// their setupStatus incorrectly marked 'error'. See docs/design/pause-cascade.md.
@@ -784,6 +787,13 @@ export class GoalManager {
 		const goal = this.store.get(id);
 		if (!goal) return false;
 		const archived = this.store.archive(id);
+		if (archived) {
+			try {
+				await cleanupGateDiagnosticsForGoal(id, this.diagnosticsStateDir);
+			} catch (err) {
+				console.warn(`[goal-manager] Failed to clean gate diagnostics for archived goal ${id}:`, err);
+			}
+		}
 		// Multi-repo cleanup: best-effort per-repo worktree + remote-branch
 		// removal. Single-repo cleanup remains owned by session purge.
 		if (archived && goal.repoWorktrees && goal.repoPath && goal.branch && Object.keys(goal.repoWorktrees).length > 0) {
@@ -905,6 +915,12 @@ export class GoalManager {
 		// Worktrees preserved for 7-day archive (cleaned by periodic purge).
 		if (goal?.team) {
 			console.log(`[goal-manager] Deleting team goal "${goal.title}" — worktrees preserved for archived session review`);
+		}
+
+		try {
+			await cleanupGateDiagnosticsForGoal(id, this.diagnosticsStateDir);
+		} catch (err) {
+			console.warn(`[goal-manager] Failed to clean gate diagnostics for deleted goal ${id}:`, err);
 		}
 
 		this.store.remove(id);

--- a/src/server/agent/verification-harness.ts
+++ b/src/server/agent/verification-harness.ts
@@ -72,6 +72,12 @@ import { buildVerificationReviewerMeta } from "./verification-reviewer-meta.js";
 import { THINKING_LEVELS, clampThinkingLevel } from "../../shared/thinking-levels.js";
 import { inferMeta } from "./aigw-manager.js";
 import { validateSpawnChildSpec } from "./spawn-child-spec-validation.js";
+import {
+	finalizeGateStepDiagnostics,
+	prepareGateStepDiagnosticsPaths,
+	type GateStepDiagnostics,
+	type GateStepDiagnosticsPaths,
+} from "../gate-diagnostics.js";
 
 /**
  * Clamp a thinking-level value against the resolved reviewer/QA model. When
@@ -704,6 +710,8 @@ export interface ActiveVerification {
 		expectFailure?: boolean;
 		/** Optional error-pattern regex for expectFailure matching. */
 		errorPattern?: string;
+		/** Host cwd used for targeted artifact retention after a command finishes. */
+		commandCwd?: string;
 	}>;
 	currentPhase?: number;
 	overallStatus: "running" | "passed" | "failed" | "cancelled";
@@ -1319,7 +1327,7 @@ export class VerificationHarness {
 	}
 
 	private async _resumeOneVerification(v: ActiveVerification): Promise<void> {
-		const resolvedSteps: Array<{ name: string; type: string; passed: boolean; output: string; duration_ms: number }> = [];
+		const resolvedSteps: Array<{ name: string; type: string; passed: boolean; output: string; duration_ms: number; diagnostics?: GateStepDiagnostics }> = [];
 
 		for (const step of v.steps) {
 			if (step.status !== "running") {
@@ -1438,13 +1446,17 @@ export class VerificationHarness {
 
 		this.resolveGateStore(v.goalId).updateSignalVerification(v.signalId, {
 			status: persistedStatus,
-			steps: resolvedSteps.map(r => ({
-				name: r.name,
-				type: r.type as "command" | "llm-review" | "agent-qa" | "human-signoff",
-				passed: r.passed,
-				output: r.output,
-				duration_ms: r.duration_ms,
-			})),
+			steps: resolvedSteps.map(r => {
+				const stepResult: GateSignalStep = {
+					name: r.name,
+					type: r.type as "command" | "llm-review" | "agent-qa" | "human-signoff",
+					passed: r.passed,
+					output: r.output,
+					duration_ms: r.duration_ms,
+				};
+				if (r.diagnostics) stepResult.diagnostics = r.diagnostics;
+				return stepResult;
+			}),
 		});
 		this.resolveGateStore(v.goalId).updateGateStatus(v.goalId, v.gateId, gateStatus);
 
@@ -2424,7 +2436,7 @@ export class VerificationHarness {
 							return { index, stepResult: cachedResult };
 						}
 
-						let result: { passed: boolean; output: string; sessionId?: string } = { passed: false, output: "No verification result." };
+						let result: { passed: boolean; output: string; sessionId?: string; diagnostics?: GateStepDiagnostics } = { passed: false, output: "No verification result." };
 						let artifact: GateSignalStep["artifact"];
 						const startTime = Date.now();
 
@@ -2747,6 +2759,7 @@ export class VerificationHarness {
 							expect: step.expect,
 						};
 						if (artifact) stepResult.artifact = artifact;
+						if (result.diagnostics) stepResult.diagnostics = result.diagnostics;
 						return { index, stepResult };
 					},
 					{ shouldSerialize: ({ step }) => shouldSerializeVerificationStepWithinPhase(step) },
@@ -3763,7 +3776,7 @@ export class VerificationHarness {
 		streamCtx?: { goalId: string; gateId: string; signalId: string; stepIndex: number },
 		errorPattern?: string,
 		containerId?: string,
-	): Promise<{ passed: boolean; output: string }> {
+	): Promise<{ passed: boolean; output: string; diagnostics?: GateStepDiagnostics }> {
 		return new Promise((resolve) => {
 			const normalizedCwd = cwd.replace(/\\/g, "/");
 			// Shell selection: default to plain bash (fast), use --login only for
@@ -3789,13 +3802,33 @@ export class VerificationHarness {
 			let exitFile: string | undefined;
 			let outFd: number | undefined;
 			let errFd: number | undefined;
+			let diagnosticsPaths: GateStepDiagnosticsPaths | undefined;
+
+			if (streamCtx) {
+				try {
+					diagnosticsPaths = prepareGateStepDiagnosticsPaths({
+						stateDir: this._stateDir,
+						goalId: streamCtx.goalId,
+						gateId: streamCtx.gateId,
+						signalId: streamCtx.signalId,
+						stepIndex: streamCtx.stepIndex,
+						stepName: this.activeVerifications.get(streamCtx.signalId)?.steps[streamCtx.stepIndex]?.name ?? `step-${streamCtx.stepIndex}`,
+					});
+					outFile = diagnosticsPaths.stdoutPath;
+					errFile = diagnosticsPaths.stderrPath;
+				} catch (err) {
+					console.warn(`[verification] Failed to set up retained command diagnostics: ${(err as Error).message}`);
+				}
+			}
 
 			if (useDetached && streamCtx) {
 				try {
 					const stepDir = path.join(this._stateDir, "verifications", streamCtx.signalId);
 					fs.mkdirSync(stepDir, { recursive: true });
-					outFile = path.join(stepDir, `${streamCtx.stepIndex}.out`);
-					errFile = path.join(stepDir, `${streamCtx.stepIndex}.err`);
+					if (!outFile || !errFile) {
+						outFile = path.join(stepDir, `${streamCtx.stepIndex}.out`);
+						errFile = path.join(stepDir, `${streamCtx.stepIndex}.err`);
+					}
 					exitFile = path.join(stepDir, `${streamCtx.stepIndex}.exit`);
 					try { fs.unlinkSync(exitFile); } catch { /* not present */ }
 					try { fs.unlinkSync(exitFile + ".tmp"); } catch { /* not present */ }
@@ -3806,7 +3839,9 @@ export class VerificationHarness {
 					if (outFd !== undefined) { try { fs.closeSync(outFd); } catch {} }
 					if (errFd !== undefined) { try { fs.closeSync(errFd); } catch {} }
 					useDetached = false;
-					outFile = errFile = exitFile = undefined;
+					outFile = diagnosticsPaths?.stdoutPath;
+					errFile = diagnosticsPaths?.stderrPath;
+					exitFile = undefined;
 				}
 			}
 
@@ -3825,16 +3860,33 @@ export class VerificationHarness {
 			// handle child.on("error", ...) — surface the error text and honour
 			// expectFailure semantics. Without this, accessing child.pid below
 			// would throw TypeError and crash the verification pipeline.
-			const handleSpawnError = (err: Error): { passed: boolean; output: string } => {
+			const finalizeDiagnostics = (): GateStepDiagnostics | undefined => {
+				if (!diagnosticsPaths) return undefined;
+				try {
+					return finalizeGateStepDiagnostics({ paths: diagnosticsPaths, commandCwd: normalizedCwd });
+				} catch (err) {
+					console.warn(`[verification] Failed to finalize retained command diagnostics: ${(err as Error).message}`);
+					return undefined;
+				}
+			};
+			const withDiagnostics = (result: { passed: boolean; output: string }): { passed: boolean; output: string; diagnostics?: GateStepDiagnostics } => {
+				const diagnostics = finalizeDiagnostics();
+				return diagnostics ? { ...result, diagnostics } : result;
+			};
+			const handleSpawnError = (err: Error): { passed: boolean; output: string; diagnostics?: GateStepDiagnostics } => {
+				try {
+					if (outFile) fs.writeFileSync(outFile, "", { flag: "a" });
+					if (errFile) fs.writeFileSync(errFile, err.message, { flag: "a" });
+				} catch { /* ignore diagnostics write failure */ }
 				if (expectFailure && errorPattern) {
 					try {
 						const regex = new RegExp(errorPattern, "i");
-						return { passed: regex.test(err.message), output: err.message };
+						return withDiagnostics({ passed: regex.test(err.message), output: err.message });
 					} catch {
-						return { passed: false, output: `Invalid error_pattern regex when handling spawn error: ${err.message}` };
+						return withDiagnostics({ passed: false, output: `Invalid error_pattern regex when handling spawn error: ${err.message}` });
 					}
 				}
-				return { passed: expectFailure, output: err.message };
+				return withDiagnostics({ passed: expectFailure, output: err.message });
 			};
 
 			// IMPORTANT: do NOT re-introduce `spawn(..., { timeout })` here.
@@ -3929,6 +3981,7 @@ export class VerificationHarness {
 					s.timeoutSec = timeoutSec;
 					s.expectFailure = expectFailure;
 					s.errorPattern = errorPattern;
+					s.commandCwd = normalizedCwd;
 					this._persistActive();
 				}
 				// unref so the child does not keep the gateway alive during a
@@ -3948,6 +4001,10 @@ export class VerificationHarness {
 				stopTail = this._startFileTailers(outFile, errFile, streamCtx);
 			} else if (!useDetached) {
 				const onData = (text: string, stream: "stdout" | "stderr") => {
+					try {
+						const target = stream === "stdout" ? outFile : errFile;
+						if (target) fs.appendFileSync(target, text, "utf8");
+					} catch { /* diagnostics retention is best-effort */ }
 					if (stream === "stdout") {
 						stdout += text;
 						if (stdout.length > 1024 * 1024) stdout = stdout.slice(-512 * 1024);
@@ -3999,23 +4056,23 @@ export class VerificationHarness {
 					const combined = tail ? `${tail}\n${marker}` : marker;
 					if (expectFailure) {
 						// Honour expectFailure + errorPattern against the accumulated output.
-						resolve(matchExpectFailure(null, combined, errorPattern));
+						resolve(withDiagnostics(matchExpectFailure(null, combined, errorPattern)));
 						return;
 					}
-					resolve({ passed: false, output: combined });
+					resolve(withDiagnostics({ passed: false, output: combined }));
 					return;
 				}
 				if (didCancel) {
 					const marker = `[step cancelled \u2014 killed subprocess tree]`;
 					const combined = tail ? `${tail}\n${marker}` : marker;
-					resolve({ passed: false, output: combined });
+					resolve(withDiagnostics({ passed: false, output: combined }));
 					return;
 				}
 				if (expectFailure) {
-					resolve(matchExpectFailure(code, tail, errorPattern));
+					resolve(withDiagnostics(matchExpectFailure(code, tail, errorPattern)));
 					return;
 				}
-				resolve({ passed: code === 0, output: tail || `exit code ${code}` });
+				resolve(withDiagnostics({ passed: code === 0, output: tail || `exit code ${code}` }));
 			});
 			child.on("error", (err: Error) => {
 				this._trackedCommandChildren.delete(trackedKey);
@@ -4113,7 +4170,7 @@ export class VerificationHarness {
 	private async _resumeCommandStep(
 		v: ActiveVerification,
 		step: ActiveVerification["steps"][number],
-	): Promise<{ name: string; type: string; passed: boolean; output: string; duration_ms: number } | null> {
+	): Promise<{ name: string; type: string; passed: boolean; output: string; duration_ms: number; diagnostics?: GateStepDiagnostics } | null> {
 		if (!step.exitFile && !step.pid) return null;
 
 		const readFiles = (): { out: string; err: string } => {
@@ -4133,6 +4190,29 @@ export class VerificationHarness {
 				return null;
 			}
 		};
+		const finalizeDiagnostics = (): GateStepDiagnostics | undefined => {
+			if (!step.outFile && !step.errFile) return undefined;
+			const baseDir = path.dirname(step.outFile ?? step.errFile!);
+			try {
+				return finalizeGateStepDiagnostics({
+					paths: {
+						baseDir,
+						stdoutPath: step.outFile ?? path.join(baseDir, "stdout.log"),
+						stderrPath: step.errFile ?? path.join(baseDir, "stderr.log"),
+						artifactsDir: path.join(baseDir, "artifacts"),
+					},
+					commandCwd: step.commandCwd ?? process.cwd(),
+				});
+			} catch (err) {
+				console.warn(`[verification] Failed to finalize retained command diagnostics during resume: ${(err as Error).message}`);
+				return undefined;
+			}
+		};
+		const withDiagnostics = (result: { name: string; type: string; passed: boolean; output: string; duration_ms: number; diagnostics?: GateStepDiagnostics }) => {
+			const diagnostics = finalizeDiagnostics();
+			if (diagnostics) result.diagnostics = diagnostics;
+			return result;
+		};
 		const finalize = (code: number | null) => {
 			const { out, err } = readFiles();
 			const output = (out + "\n" + err).trim().slice(-5000);
@@ -4146,13 +4226,13 @@ export class VerificationHarness {
 				passed = code === 0;
 				displayOutput = output || `exit code ${code}`;
 			}
-			return {
+			return withDiagnostics({
 				name: step.name,
 				type: step.type,
 				passed,
 				output: displayOutput,
 				duration_ms: Date.now() - step.startedAt,
-			};
+			});
 		};
 
 		// Case A: child already finished before we restarted.
@@ -4212,13 +4292,13 @@ export class VerificationHarness {
 				// also the pgid. killTreeByPid handles negative-pid kill (POSIX)
 				// and taskkill /T /F (Windows) so we reap descendants too.
 				if (step.pid) try { killTreeByPid(step.pid, "SIGKILL"); } catch { /* already dead */ }
-				return {
+				return withDiagnostics({
 					name: step.name,
 					type: step.type,
 					passed: false,
 					output: "Verification command did not produce an exit code (timeout or process died after restart).",
 					duration_ms: Date.now() - step.startedAt,
-				};
+				});
 			} finally {
 				if (stopTail) stopTail();
 			}
@@ -4227,13 +4307,13 @@ export class VerificationHarness {
 		// Case C: process gone, no exit file — killed by something between our
 		// last persist and now.
 		console.log(`[verification] Resume: pid/exit-file gone for "${step.name}" — marking failed`);
-		return {
+		return withDiagnostics({
 			name: step.name,
 			type: step.type,
 			passed: false,
 			output: "Verification command process died during gateway restart before producing an exit code.",
 			duration_ms: Date.now() - step.startedAt,
-		};
+		});
 	}
 	// ── Nested goals (subgoal verify-step) ───────────────────────────────
 	// `runSubgoalStep` is the single integration point. Stamp-immediately,

--- a/src/server/agent/verification-harness.ts
+++ b/src/server/agent/verification-harness.ts
@@ -73,6 +73,7 @@ import { THINKING_LEVELS, clampThinkingLevel } from "../../shared/thinking-level
 import { inferMeta } from "./aigw-manager.js";
 import { validateSpawnChildSpec } from "./spawn-child-spec-validation.js";
 import {
+	appendRetainedLogChunk,
 	finalizeGateStepDiagnostics,
 	prepareGateStepDiagnosticsPaths,
 	type GateStepDiagnostics,
@@ -3863,7 +3864,7 @@ export class VerificationHarness {
 			const finalizeDiagnostics = (): GateStepDiagnostics | undefined => {
 				if (!diagnosticsPaths) return undefined;
 				try {
-					return finalizeGateStepDiagnostics({ paths: diagnosticsPaths, commandCwd: normalizedCwd });
+					return finalizeGateStepDiagnostics({ paths: diagnosticsPaths, commandCwd: normalizedCwd, containerId });
 				} catch (err) {
 					console.warn(`[verification] Failed to finalize retained command diagnostics: ${(err as Error).message}`);
 					return undefined;
@@ -3874,10 +3875,8 @@ export class VerificationHarness {
 				return diagnostics ? { ...result, diagnostics } : result;
 			};
 			const handleSpawnError = (err: Error): { passed: boolean; output: string; diagnostics?: GateStepDiagnostics } => {
-				try {
-					if (outFile) fs.writeFileSync(outFile, "", { flag: "a" });
-					if (errFile) fs.writeFileSync(errFile, err.message, { flag: "a" });
-				} catch { /* ignore diagnostics write failure */ }
+				appendRetainedLogChunk(outFile, "");
+				appendRetainedLogChunk(errFile, err.message);
 				if (expectFailure && errorPattern) {
 					try {
 						const regex = new RegExp(errorPattern, "i");
@@ -4001,10 +4000,8 @@ export class VerificationHarness {
 				stopTail = this._startFileTailers(outFile, errFile, streamCtx);
 			} else if (!useDetached) {
 				const onData = (text: string, stream: "stdout" | "stderr") => {
-					try {
-						const target = stream === "stdout" ? outFile : errFile;
-						if (target) fs.appendFileSync(target, text, "utf8");
-					} catch { /* diagnostics retention is best-effort */ }
+					const target = stream === "stdout" ? outFile : errFile;
+					appendRetainedLogChunk(target, text);
 					if (stream === "stdout") {
 						stdout += text;
 						if (stdout.length > 1024 * 1024) stdout = stdout.slice(-512 * 1024);
@@ -4103,8 +4100,8 @@ export class VerificationHarness {
 				if (stat.size <= pos) return pos;
 				const fd = fs.openSync(filePath, "r");
 				try {
-					const len = stat.size - pos;
-					const buf = Buffer.alloc(len);
+					const len = Math.min(stat.size - pos, 64 * 1024);
+					const buf = Buffer.allocUnsafe(len);
 					fs.readSync(fd, buf, 0, len, pos);
 					const text = buf.toString("utf8");
 					this.broadcastFn(ctx.goalId, {
@@ -4123,7 +4120,7 @@ export class VerificationHarness {
 						s.output = (s.output || "") + text;
 						if (s.output.length > 512 * 1024) s.output = s.output.slice(-512 * 1024);
 					}
-					return stat.size;
+					return pos + len;
 				} finally {
 					try { fs.closeSync(fd); } catch { /* ignore */ }
 				}

--- a/src/server/gate-diagnostics.ts
+++ b/src/server/gate-diagnostics.ts
@@ -1,11 +1,17 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { gateDiagnosticsRootDir, safeGateDiagnosticsSegment } from "./agent/gate-diagnostics-cleanup.js";
+
+export const MAX_RETAINED_LOG_BYTES = 10 * 1024 * 1024;
+const LOG_COUNT_CHUNK_BYTES = 64 * 1024;
 
 export interface GateStepDiagnosticLogMetadata {
 	path: string;
 	bytes: number;
 	lines: number;
+	truncated?: boolean;
+	truncationReason?: string;
 }
 
 export interface GateStepDiagnosticArtifactMetadata {
@@ -70,17 +76,77 @@ export function prepareGateStepDiagnosticsPaths(input: {
 	};
 }
 
-function countLines(text: string): number {
-	if (!text.length) return 0;
-	return text.split(/\r?\n/).length;
+export function appendRetainedLogChunk(filePath: string | undefined, text: string): void {
+	if (!filePath || !text) return;
+	try {
+		let currentBytes = 0;
+		try {
+			const stat = fs.statSync(filePath);
+			if (stat.isFile()) currentBytes = stat.size;
+		} catch { /* file may not exist yet */ }
+		const remaining = MAX_RETAINED_LOG_BYTES - currentBytes;
+		if (remaining <= 0) return;
+		const chunk = Buffer.from(text, "utf8");
+		fs.appendFileSync(filePath, chunk.subarray(0, Math.min(chunk.length, remaining)));
+	} catch {
+		// Best-effort diagnostics must never affect verification execution.
+	}
+}
+
+function capRetainedLogFile(filePath: string): { truncated: boolean; bytes: number } {
+	try {
+		const stat = fs.statSync(filePath);
+		if (!stat.isFile()) return { truncated: false, bytes: 0 };
+		if (stat.size < MAX_RETAINED_LOG_BYTES) return { truncated: false, bytes: stat.size };
+		if (stat.size === MAX_RETAINED_LOG_BYTES) return { truncated: true, bytes: stat.size };
+		const fd = fs.openSync(filePath, "r+");
+		try {
+			fs.ftruncateSync(fd, MAX_RETAINED_LOG_BYTES);
+		} finally {
+			try { fs.closeSync(fd); } catch { /* ignore */ }
+		}
+		return { truncated: true, bytes: MAX_RETAINED_LOG_BYTES };
+	} catch {
+		return { truncated: false, bytes: 0 };
+	}
+}
+
+function countLinesInFile(filePath: string): number {
+	let fd: number | undefined;
+	try {
+		const stat = fs.statSync(filePath);
+		if (!stat.isFile() || stat.size <= 0) return 0;
+		fd = fs.openSync(filePath, "r");
+		const buffer = Buffer.allocUnsafe(LOG_COUNT_CHUNK_BYTES);
+		let position = 0;
+		let lineFeeds = 0;
+		while (position < stat.size) {
+			const bytesRead = fs.readSync(fd, buffer, 0, Math.min(LOG_COUNT_CHUNK_BYTES, stat.size - position), position);
+			if (bytesRead <= 0) break;
+			for (let i = 0; i < bytesRead; i++) if (buffer[i] === 10) lineFeeds++;
+			position += bytesRead;
+		}
+		return lineFeeds + 1;
+	} catch {
+		return 0;
+	} finally {
+		if (fd !== undefined) {
+			try { fs.closeSync(fd); } catch { /* ignore */ }
+		}
+	}
 }
 
 function logMetadata(filePath: string): GateStepDiagnosticLogMetadata | undefined {
 	try {
+		const capped = capRetainedLogFile(filePath);
 		const stat = fs.statSync(filePath);
 		if (!stat.isFile()) return undefined;
-		const text = fs.readFileSync(filePath, "utf8");
-		return { path: filePath, bytes: stat.size, lines: countLines(text) };
+		const metadata: GateStepDiagnosticLogMetadata = { path: filePath, bytes: stat.size, lines: countLinesInFile(filePath) };
+		if (capped.truncated) {
+			metadata.truncated = true;
+			metadata.truncationReason = `retained log capped at ${MAX_RETAINED_LOG_BYTES} bytes`;
+		}
+		return metadata;
 	} catch {
 		return undefined;
 	}
@@ -98,7 +164,14 @@ function isProbablyPlaywrightFile(relativePath: string): boolean {
 		|| normalized.includes("/trace/");
 }
 
-function copyArtifactTree(rootSourceDir: string, currentSourceDir: string, destRoot: string, kind: GateStepDiagnosticArtifactMetadata["kind"], state: { files: number; bytes: number; artifacts: GateStepDiagnosticArtifactMetadata[] }): void {
+function copyArtifactTree(
+	rootSourceDir: string,
+	currentSourceDir: string,
+	destRoot: string,
+	kind: GateStepDiagnosticArtifactMetadata["kind"],
+	state: { files: number; bytes: number; artifacts: GateStepDiagnosticArtifactMetadata[] },
+	sourcePathForArtifact?: (sourceRelativePath: string, sourcePath: string) => string,
+): void {
 	let entries: fs.Dirent[];
 	try {
 		entries = fs.readdirSync(currentSourceDir, { withFileTypes: true });
@@ -110,7 +183,7 @@ function copyArtifactTree(rootSourceDir: string, currentSourceDir: string, destR
 		const sourcePath = path.join(currentSourceDir, entry.name);
 		const sourceRelativePath = path.relative(rootSourceDir, sourcePath).replace(/\\/g, "/");
 		if (entry.isDirectory()) {
-			copyArtifactTree(rootSourceDir, sourcePath, destRoot, kind, state);
+			copyArtifactTree(rootSourceDir, sourcePath, destRoot, kind, state, sourcePathForArtifact);
 			continue;
 		}
 		if (!entry.isFile()) continue;
@@ -121,6 +194,7 @@ function copyArtifactTree(rootSourceDir: string, currentSourceDir: string, destR
 		if (state.bytes + stat.size > MAX_ARTIFACT_BYTES) return;
 		const retainedPath = path.join(destRoot, sourceRelativePath);
 		try {
+			if (fs.existsSync(retainedPath)) continue;
 			fs.mkdirSync(path.dirname(retainedPath), { recursive: true });
 			fs.copyFileSync(sourcePath, retainedPath);
 			state.files += 1;
@@ -128,7 +202,7 @@ function copyArtifactTree(rootSourceDir: string, currentSourceDir: string, destR
 			const artifact: GateStepDiagnosticArtifactMetadata = {
 				path: retainedPath,
 				relativePath: `${kind}/${sourceRelativePath}`.replace(/\\/g, "/"),
-				sourcePath,
+				sourcePath: sourcePathForArtifact ? sourcePathForArtifact(sourceRelativePath, sourcePath) : sourcePath,
 				bytes: stat.size,
 				kind,
 			};
@@ -143,9 +217,55 @@ function copyArtifactTree(rootSourceDir: string, currentSourceDir: string, destR
 	}
 }
 
+function shellSingleQuote(value: string): string {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function copyContainerArtifactDir(input: {
+	containerId: string;
+	containerCwd: string;
+	candidate: { name: string; kind: GateStepDiagnosticArtifactMetadata["kind"] };
+	paths: GateStepDiagnosticsPaths;
+	state: { files: number; bytes: number; artifacts: GateStepDiagnosticArtifactMetadata[] };
+}): void {
+	const containerDir = path.posix.join(input.containerCwd.replace(/\\/g, "/"), input.candidate.name);
+	const test = spawnSync("docker", ["exec", input.containerId, "sh", "-c", `test -d ${shellSingleQuote(containerDir)}`], {
+		stdio: "ignore",
+		env: { ...process.env, MSYS_NO_PATHCONV: "1", MSYS2_ARG_CONV_EXCL: "*" },
+	});
+	if (test.status !== 0) return;
+
+	const tmpParent = path.join(input.paths.baseDir, ".container-artifact-tmp", safeGateDiagnosticsSegment(input.candidate.name));
+	try {
+		fs.rmSync(tmpParent, { recursive: true, force: true });
+		fs.mkdirSync(tmpParent, { recursive: true });
+		const copied = spawnSync("docker", ["cp", `${input.containerId}:${containerDir}`, tmpParent], {
+			stdio: "ignore",
+			env: { ...process.env, MSYS_NO_PATHCONV: "1", MSYS2_ARG_CONV_EXCL: "*" },
+		});
+		if (copied.status !== 0) return;
+		const sourceDir = path.join(tmpParent, input.candidate.name);
+		if (!fs.existsSync(sourceDir)) return;
+		const destRoot = path.join(input.paths.artifactsDir, input.candidate.name);
+		copyArtifactTree(
+			sourceDir,
+			sourceDir,
+			destRoot,
+			input.candidate.kind,
+			input.state,
+			(relativePath) => `${input.containerId}:${path.posix.join(containerDir, relativePath.replace(/\\/g, "/"))}`,
+		);
+	} catch {
+		// Best-effort only.
+	} finally {
+		try { fs.rmSync(path.join(input.paths.baseDir, ".container-artifact-tmp"), { recursive: true, force: true }); } catch { /* ignore */ }
+	}
+}
+
 export function finalizeGateStepDiagnostics(input: {
 	paths: GateStepDiagnosticsPaths;
 	commandCwd: string;
+	containerId?: string;
 }): GateStepDiagnostics {
 	const artifactsState: { files: number; bytes: number; artifacts: GateStepDiagnosticArtifactMetadata[] } = {
 		files: 0,
@@ -164,6 +284,18 @@ export function finalizeGateStepDiagnostics(input: {
 		}
 	} catch {
 		// Best-effort only.
+	}
+	if (input.containerId) {
+		for (const candidate of PLAYWRIGHT_ARTIFACT_DIRS) {
+			if (artifactsState.files >= MAX_ARTIFACT_FILES || artifactsState.bytes >= MAX_ARTIFACT_BYTES) break;
+			copyContainerArtifactDir({
+				containerId: input.containerId,
+				containerCwd: input.commandCwd,
+				candidate,
+				paths: input.paths,
+				state: artifactsState,
+			});
+		}
 	}
 
 	const diagnostics: GateStepDiagnostics = {

--- a/src/server/gate-diagnostics.ts
+++ b/src/server/gate-diagnostics.ts
@@ -176,49 +176,103 @@ function isProbablyPlaywrightFile(relativePath: string): boolean {
 		|| normalized.includes("/trace/");
 }
 
+function isWithinDirectory(root: string, candidate: string): boolean {
+	const relative = path.relative(root, candidate);
+	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function safeRealpath(filePath: string): string | undefined {
+	try { return fs.realpathSync(filePath); } catch { return undefined; }
+}
+
+function prepareArtifactCopyRoot(sourceDir: string, destRoot: string): { sourceRealRoot: string; destRealRoot: string } | undefined {
+	try {
+		const sourceStat = fs.lstatSync(sourceDir);
+		if (sourceStat.isSymbolicLink() || !sourceStat.isDirectory()) return undefined;
+		const sourceRealRoot = safeRealpath(sourceDir);
+		if (!sourceRealRoot) return undefined;
+		fs.mkdirSync(destRoot, { recursive: true });
+		const destStat = fs.lstatSync(destRoot);
+		if (destStat.isSymbolicLink() || !destStat.isDirectory()) return undefined;
+		const destRealRoot = safeRealpath(destRoot);
+		if (!destRealRoot) return undefined;
+		return { sourceRealRoot, destRealRoot };
+	} catch {
+		return undefined;
+	}
+}
+
+function safeSourceRelativePath(rootSourceDir: string, sourcePath: string): string | undefined {
+	const relative = path.relative(rootSourceDir, sourcePath);
+	if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) return undefined;
+	return relative.replace(/\\/g, "/");
+}
+
 function copyArtifactTree(
 	rootSourceDir: string,
 	currentSourceDir: string,
 	destRoot: string,
 	kind: GateStepDiagnosticArtifactMetadata["kind"],
 	state: { files: number; bytes: number; artifacts: GateStepDiagnosticArtifactMetadata[] },
+	bounds: { sourceRealRoot: string; destRealRoot: string },
 	sourcePathForArtifact?: (sourceRelativePath: string, sourcePath: string) => string,
 ): void {
 	let entries: fs.Dirent[];
 	try {
+		const currentStat = fs.lstatSync(currentSourceDir);
+		if (currentStat.isSymbolicLink() || !currentStat.isDirectory()) return;
+		const currentReal = fs.realpathSync(currentSourceDir);
+		if (!isWithinDirectory(bounds.sourceRealRoot, currentReal)) return;
 		entries = fs.readdirSync(currentSourceDir, { withFileTypes: true });
 	} catch {
 		return;
 	}
 	for (const entry of entries) {
 		if (state.files >= MAX_ARTIFACT_FILES || state.bytes >= MAX_ARTIFACT_BYTES) return;
+		if (entry.isSymbolicLink()) continue;
 		const sourcePath = path.join(currentSourceDir, entry.name);
-		const sourceRelativePath = path.relative(rootSourceDir, sourcePath).replace(/\\/g, "/");
-		if (entry.isDirectory()) {
-			copyArtifactTree(rootSourceDir, sourcePath, destRoot, kind, state, sourcePathForArtifact);
+		const sourceRelativePath = safeSourceRelativePath(rootSourceDir, sourcePath);
+		if (!sourceRelativePath) continue;
+		let sourceStat: fs.Stats;
+		try { sourceStat = fs.lstatSync(sourcePath); } catch { continue; }
+		if (sourceStat.isSymbolicLink()) continue;
+		const sourceReal = safeRealpath(sourcePath);
+		if (!sourceReal || !isWithinDirectory(bounds.sourceRealRoot, sourceReal)) continue;
+		if (sourceStat.isDirectory()) {
+			copyArtifactTree(rootSourceDir, sourcePath, destRoot, kind, state, bounds, sourcePathForArtifact);
 			continue;
 		}
-		if (!entry.isFile()) continue;
+		if (!sourceStat.isFile()) continue;
 		if (kind === "test-results" && !isProbablyPlaywrightFile(sourceRelativePath)) continue;
-		let stat: fs.Stats;
-		try { stat = fs.statSync(sourcePath); } catch { continue; }
-		if (!stat.isFile()) continue;
-		if (state.bytes + stat.size > MAX_ARTIFACT_BYTES) return;
-		const retainedPath = path.join(destRoot, sourceRelativePath);
+		if (state.bytes + sourceStat.size > MAX_ARTIFACT_BYTES) return;
+		const retainedPath = path.resolve(destRoot, sourceRelativePath);
+		if (!isWithinDirectory(path.resolve(destRoot), retainedPath)) continue;
 		try {
-			if (fs.existsSync(retainedPath)) continue;
+			try {
+				fs.lstatSync(retainedPath);
+				continue;
+			} catch (err) {
+				if ((err as NodeJS.ErrnoException).code !== "ENOENT") continue;
+			}
 			fs.mkdirSync(path.dirname(retainedPath), { recursive: true });
+			const retainedParentReal = fs.realpathSync(path.dirname(retainedPath));
+			if (!isWithinDirectory(bounds.destRealRoot, retainedParentReal)) continue;
 			fs.copyFileSync(sourcePath, retainedPath);
+			const retainedReal = safeRealpath(retainedPath);
+			if (!retainedReal || !isWithinDirectory(bounds.destRealRoot, retainedReal)) {
+				try { fs.rmSync(retainedPath, { force: true }); } catch { /* ignore */ }
+				continue;
+			}
 			state.files += 1;
-			state.bytes += stat.size;
+			state.bytes += sourceStat.size;
 			const artifact: GateStepDiagnosticArtifactMetadata = {
 				path: retainedPath,
 				relativePath: `${kind}/${sourceRelativePath}`.replace(/\\/g, "/"),
 				sourcePath: sourcePathForArtifact ? sourcePathForArtifact(sourceRelativePath, sourcePath) : sourcePath,
-				bytes: stat.size,
+				bytes: sourceStat.size,
 				kind,
 			};
-			if (sourceRelativePath.toLowerCase().endsWith("error-context.md") && stat.size <= MAX_INLINE_ARTIFACT_CONTENT_BYTES) {
+			if (sourceRelativePath.toLowerCase().endsWith("error-context.md") && sourceStat.size <= MAX_INLINE_ARTIFACT_CONTENT_BYTES) {
 				artifact.content = fs.readFileSync(retainedPath, "utf8");
 				artifact.contentType = "text/markdown";
 			}
@@ -241,7 +295,7 @@ function copyContainerArtifactDir(input: {
 	state: { files: number; bytes: number; artifacts: GateStepDiagnosticArtifactMetadata[] };
 }): void {
 	const containerDir = path.posix.join(input.containerCwd.replace(/\\/g, "/"), input.candidate.name);
-	const test = spawnSync("docker", ["exec", input.containerId, "sh", "-c", `test -d ${shellSingleQuote(containerDir)}`], {
+	const test = spawnSync("docker", ["exec", input.containerId, "sh", "-c", `test -d ${shellSingleQuote(containerDir)} && ! test -L ${shellSingleQuote(containerDir)}`], {
 		stdio: "ignore",
 		env: { ...process.env, MSYS_NO_PATHCONV: "1", MSYS2_ARG_CONV_EXCL: "*" },
 	});
@@ -257,14 +311,16 @@ function copyContainerArtifactDir(input: {
 		});
 		if (copied.status !== 0) return;
 		const sourceDir = path.join(tmpParent, input.candidate.name);
-		if (!fs.existsSync(sourceDir)) return;
 		const destRoot = path.join(input.paths.artifactsDir, input.candidate.name);
+		const bounds = prepareArtifactCopyRoot(sourceDir, destRoot);
+		if (!bounds) return;
 		copyArtifactTree(
 			sourceDir,
 			sourceDir,
 			destRoot,
 			input.candidate.kind,
 			input.state,
+			bounds,
 			(relativePath) => `${input.containerId}:${path.posix.join(containerDir, relativePath.replace(/\\/g, "/"))}`,
 		);
 	} catch {
@@ -289,9 +345,10 @@ export function finalizeGateStepDiagnostics(input: {
 		if (fs.existsSync(cwd) && fs.statSync(cwd).isDirectory()) {
 			for (const candidate of PLAYWRIGHT_ARTIFACT_DIRS) {
 				const sourceDir = path.join(cwd, candidate.name);
-				if (!fs.existsSync(sourceDir)) continue;
 				const destRoot = path.join(input.paths.artifactsDir, candidate.name);
-				copyArtifactTree(sourceDir, sourceDir, destRoot, candidate.kind, artifactsState);
+				const bounds = prepareArtifactCopyRoot(sourceDir, destRoot);
+				if (!bounds) continue;
+				copyArtifactTree(sourceDir, sourceDir, destRoot, candidate.kind, artifactsState, bounds);
 			}
 		}
 	} catch {

--- a/src/server/gate-diagnostics.ts
+++ b/src/server/gate-diagnostics.ts
@@ -3,7 +3,19 @@ import fs from "node:fs";
 import path from "node:path";
 import { gateDiagnosticsRootDir, safeGateDiagnosticsSegment } from "./agent/gate-diagnostics-cleanup.js";
 
-export const MAX_RETAINED_LOG_BYTES = 10 * 1024 * 1024;
+const DEFAULT_MAX_RETAINED_LOG_BYTES = 20 * 1024 * 1024;
+const TEST_MAX_RETAINED_LOG_BYTES = 5 * 1024 * 1024;
+
+function resolveMaxRetainedLogBytes(): number {
+	const raw = process.env.BOBBIT_RETAINED_LOG_MAX_BYTES;
+	if (raw !== undefined && raw.trim() !== "") {
+		const parsed = Number(raw);
+		if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed);
+	}
+	return process.env.NODE_ENV === "test" ? TEST_MAX_RETAINED_LOG_BYTES : DEFAULT_MAX_RETAINED_LOG_BYTES;
+}
+
+export const MAX_RETAINED_LOG_BYTES = resolveMaxRetainedLogBytes();
 const LOG_COUNT_CHUNK_BYTES = 64 * 1024;
 
 export interface GateStepDiagnosticLogMetadata {

--- a/src/server/gate-diagnostics.ts
+++ b/src/server/gate-diagnostics.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { gateDiagnosticsRootDir, safeGateDiagnosticsSegment } from "./agent/gate-diagnostics-cleanup.js";
 
 export interface GateStepDiagnosticLogMetadata {
 	path: string;
@@ -43,19 +44,6 @@ const PLAYWRIGHT_ARTIFACT_DIRS: Array<{ name: string; kind: GateStepDiagnosticAr
 	{ name: "playwright-report", kind: "playwright-report" },
 ];
 
-function safeSegment(value: string): string {
-	const cleaned = value.replace(/[^a-zA-Z0-9._-]+/g, "_").replace(/^_+|_+$/g, "");
-	return cleaned.slice(0, 80) || "unnamed";
-}
-
-export function gateDiagnosticsRoot(stateDir: string): string {
-	return path.join(stateDir, "gate-diagnostics");
-}
-
-export function cleanupGateDiagnosticsForGoal(stateDir: string, goalId: string): void {
-	fs.rmSync(path.join(gateDiagnosticsRoot(stateDir), safeSegment(goalId)), { recursive: true, force: true });
-}
-
 export function prepareGateStepDiagnosticsPaths(input: {
 	stateDir: string;
 	goalId: string;
@@ -65,11 +53,11 @@ export function prepareGateStepDiagnosticsPaths(input: {
 	stepName: string;
 }): GateStepDiagnosticsPaths {
 	const baseDir = path.join(
-		gateDiagnosticsRoot(input.stateDir),
-		safeSegment(input.goalId),
-		safeSegment(input.gateId),
-		safeSegment(input.signalId),
-		`${String(input.stepIndex).padStart(2, "0")}-${safeSegment(input.stepName)}`,
+		gateDiagnosticsRootDir(input.stateDir),
+		safeGateDiagnosticsSegment(input.goalId),
+		safeGateDiagnosticsSegment(input.gateId),
+		safeGateDiagnosticsSegment(input.signalId),
+		`${String(input.stepIndex).padStart(2, "0")}-${safeGateDiagnosticsSegment(input.stepName)}`,
 	);
 	fs.rmSync(baseDir, { recursive: true, force: true });
 	fs.mkdirSync(baseDir, { recursive: true });

--- a/src/server/gate-diagnostics.ts
+++ b/src/server/gate-diagnostics.ts
@@ -1,0 +1,188 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export interface GateStepDiagnosticLogMetadata {
+	path: string;
+	bytes: number;
+	lines: number;
+}
+
+export interface GateStepDiagnosticArtifactMetadata {
+	path: string;
+	relativePath: string;
+	sourcePath: string;
+	bytes: number;
+	kind: "test-results" | "playwright-report";
+}
+
+export interface GateStepDiagnostics {
+	type: "retained-command-diagnostics";
+	baseDir: string;
+	stdout?: GateStepDiagnosticLogMetadata;
+	stderr?: GateStepDiagnosticLogMetadata;
+	artifacts?: GateStepDiagnosticArtifactMetadata[];
+	createdAt: number;
+	truncated?: boolean;
+	truncationReason?: string;
+}
+
+export interface GateStepDiagnosticsPaths {
+	baseDir: string;
+	stdoutPath: string;
+	stderrPath: string;
+	artifactsDir: string;
+}
+
+const MAX_ARTIFACT_FILES = 250;
+const MAX_ARTIFACT_BYTES = 100 * 1024 * 1024;
+const PLAYWRIGHT_ARTIFACT_DIRS: Array<{ name: string; kind: GateStepDiagnosticArtifactMetadata["kind"] }> = [
+	{ name: "test-results", kind: "test-results" },
+	{ name: "playwright-report", kind: "playwright-report" },
+];
+
+function safeSegment(value: string): string {
+	const cleaned = value.replace(/[^a-zA-Z0-9._-]+/g, "_").replace(/^_+|_+$/g, "");
+	return cleaned.slice(0, 80) || "unnamed";
+}
+
+export function gateDiagnosticsRoot(stateDir: string): string {
+	return path.join(stateDir, "gate-diagnostics");
+}
+
+export function cleanupGateDiagnosticsForGoal(stateDir: string, goalId: string): void {
+	fs.rmSync(path.join(gateDiagnosticsRoot(stateDir), safeSegment(goalId)), { recursive: true, force: true });
+}
+
+export function prepareGateStepDiagnosticsPaths(input: {
+	stateDir: string;
+	goalId: string;
+	gateId: string;
+	signalId: string;
+	stepIndex: number;
+	stepName: string;
+}): GateStepDiagnosticsPaths {
+	const baseDir = path.join(
+		gateDiagnosticsRoot(input.stateDir),
+		safeSegment(input.goalId),
+		safeSegment(input.gateId),
+		safeSegment(input.signalId),
+		`${String(input.stepIndex).padStart(2, "0")}-${safeSegment(input.stepName)}`,
+	);
+	fs.rmSync(baseDir, { recursive: true, force: true });
+	fs.mkdirSync(baseDir, { recursive: true });
+	const artifactsDir = path.join(baseDir, "artifacts");
+	return {
+		baseDir,
+		stdoutPath: path.join(baseDir, "stdout.log"),
+		stderrPath: path.join(baseDir, "stderr.log"),
+		artifactsDir,
+	};
+}
+
+function countLines(text: string): number {
+	if (!text.length) return 0;
+	return text.split(/\r?\n/).length;
+}
+
+function logMetadata(filePath: string): GateStepDiagnosticLogMetadata | undefined {
+	try {
+		const stat = fs.statSync(filePath);
+		if (!stat.isFile()) return undefined;
+		const text = fs.readFileSync(filePath, "utf8");
+		return { path: filePath, bytes: stat.size, lines: countLines(text) };
+	} catch {
+		return undefined;
+	}
+}
+
+function isProbablyPlaywrightFile(relativePath: string): boolean {
+	const normalized = relativePath.replace(/\\/g, "/").toLowerCase();
+	return normalized.endsWith("error-context.md")
+		|| normalized.endsWith("trace.zip")
+		|| normalized.endsWith(".png")
+		|| normalized.endsWith(".webm")
+		|| normalized.endsWith(".zip")
+		|| normalized.endsWith(".html")
+		|| normalized.includes("/data/")
+		|| normalized.includes("/trace/");
+}
+
+function copyArtifactTree(rootSourceDir: string, currentSourceDir: string, destRoot: string, kind: GateStepDiagnosticArtifactMetadata["kind"], state: { files: number; bytes: number; artifacts: GateStepDiagnosticArtifactMetadata[] }): void {
+	let entries: fs.Dirent[];
+	try {
+		entries = fs.readdirSync(currentSourceDir, { withFileTypes: true });
+	} catch {
+		return;
+	}
+	for (const entry of entries) {
+		if (state.files >= MAX_ARTIFACT_FILES || state.bytes >= MAX_ARTIFACT_BYTES) return;
+		const sourcePath = path.join(currentSourceDir, entry.name);
+		const sourceRelativePath = path.relative(rootSourceDir, sourcePath).replace(/\\/g, "/");
+		if (entry.isDirectory()) {
+			copyArtifactTree(rootSourceDir, sourcePath, destRoot, kind, state);
+			continue;
+		}
+		if (!entry.isFile()) continue;
+		if (kind === "test-results" && !isProbablyPlaywrightFile(sourceRelativePath)) continue;
+		let stat: fs.Stats;
+		try { stat = fs.statSync(sourcePath); } catch { continue; }
+		if (!stat.isFile()) continue;
+		if (state.bytes + stat.size > MAX_ARTIFACT_BYTES) return;
+		const retainedPath = path.join(destRoot, sourceRelativePath);
+		try {
+			fs.mkdirSync(path.dirname(retainedPath), { recursive: true });
+			fs.copyFileSync(sourcePath, retainedPath);
+			state.files += 1;
+			state.bytes += stat.size;
+			state.artifacts.push({
+				path: retainedPath,
+				relativePath: `${kind}/${sourceRelativePath}`.replace(/\\/g, "/"),
+				sourcePath,
+				bytes: stat.size,
+				kind,
+			});
+		} catch {
+			// Best-effort diagnostics must never fail verification finalization.
+		}
+	}
+}
+
+export function finalizeGateStepDiagnostics(input: {
+	paths: GateStepDiagnosticsPaths;
+	commandCwd: string;
+}): GateStepDiagnostics {
+	const artifactsState: { files: number; bytes: number; artifacts: GateStepDiagnosticArtifactMetadata[] } = {
+		files: 0,
+		bytes: 0,
+		artifacts: [],
+	};
+	try {
+		const cwd = path.resolve(input.commandCwd);
+		if (fs.existsSync(cwd) && fs.statSync(cwd).isDirectory()) {
+			for (const candidate of PLAYWRIGHT_ARTIFACT_DIRS) {
+				const sourceDir = path.join(cwd, candidate.name);
+				if (!fs.existsSync(sourceDir)) continue;
+				const destRoot = path.join(input.paths.artifactsDir, candidate.name);
+				copyArtifactTree(sourceDir, sourceDir, destRoot, candidate.kind, artifactsState);
+			}
+		}
+	} catch {
+		// Best-effort only.
+	}
+
+	const diagnostics: GateStepDiagnostics = {
+		type: "retained-command-diagnostics",
+		baseDir: input.paths.baseDir,
+		createdAt: Date.now(),
+	};
+	const stdout = logMetadata(input.paths.stdoutPath);
+	const stderr = logMetadata(input.paths.stderrPath);
+	if (stdout) diagnostics.stdout = stdout;
+	if (stderr) diagnostics.stderr = stderr;
+	if (artifactsState.artifacts.length > 0) diagnostics.artifacts = artifactsState.artifacts;
+	if (artifactsState.files >= MAX_ARTIFACT_FILES || artifactsState.bytes >= MAX_ARTIFACT_BYTES) {
+		diagnostics.truncated = true;
+		diagnostics.truncationReason = `artifact capture capped at ${MAX_ARTIFACT_FILES} files/${MAX_ARTIFACT_BYTES} bytes`;
+	}
+	return diagnostics;
+}

--- a/src/server/gate-diagnostics.ts
+++ b/src/server/gate-diagnostics.ts
@@ -13,6 +13,8 @@ export interface GateStepDiagnosticArtifactMetadata {
 	sourcePath: string;
 	bytes: number;
 	kind: "test-results" | "playwright-report";
+	content?: string;
+	contentType?: string;
 }
 
 export interface GateStepDiagnostics {
@@ -35,6 +37,7 @@ export interface GateStepDiagnosticsPaths {
 
 const MAX_ARTIFACT_FILES = 250;
 const MAX_ARTIFACT_BYTES = 100 * 1024 * 1024;
+const MAX_INLINE_ARTIFACT_CONTENT_BYTES = 64 * 1024;
 const PLAYWRIGHT_ARTIFACT_DIRS: Array<{ name: string; kind: GateStepDiagnosticArtifactMetadata["kind"] }> = [
 	{ name: "test-results", kind: "test-results" },
 	{ name: "playwright-report", kind: "playwright-report" },
@@ -134,13 +137,18 @@ function copyArtifactTree(rootSourceDir: string, currentSourceDir: string, destR
 			fs.copyFileSync(sourcePath, retainedPath);
 			state.files += 1;
 			state.bytes += stat.size;
-			state.artifacts.push({
+			const artifact: GateStepDiagnosticArtifactMetadata = {
 				path: retainedPath,
 				relativePath: `${kind}/${sourceRelativePath}`.replace(/\\/g, "/"),
 				sourcePath,
 				bytes: stat.size,
 				kind,
-			});
+			};
+			if (sourceRelativePath.toLowerCase().endsWith("error-context.md") && stat.size <= MAX_INLINE_ARTIFACT_CONTENT_BYTES) {
+				artifact.content = fs.readFileSync(retainedPath, "utf8");
+				artifact.contentType = "text/markdown";
+			}
+			state.artifacts.push(artifact);
 		} catch {
 			// Best-effort diagnostics must never fail verification finalization.
 		}

--- a/src/server/gate-verification-snapshot.ts
+++ b/src/server/gate-verification-snapshot.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 
 import type { GateSignal } from "./agent/gate-store.js";
+import type { GateStepDiagnostics } from "./gate-diagnostics.js";
 import type { ActiveVerification } from "./agent/verification-harness.js";
 import {
 	MAX_SELECTED_BYTES,
@@ -39,6 +40,21 @@ export interface GateVerificationSnapshotStep {
 	sessionId?: string;
 	session?: { id: string; href: string };
 	liveLogs?: { stdout: boolean; stderr: boolean };
+	diagnostics?: {
+		outputSource: "compact-tail" | "live-logs" | "retained-logs";
+		logs?: {
+			stdout?: { path: string; bytes: number; lines: number };
+			stderr?: { path: string; bytes: number; lines: number };
+		};
+		artifacts?: {
+			count: number;
+			truncated?: boolean;
+			truncationReason?: string;
+			files: Array<{ path: string; relativePath: string; sourcePath: string; bytes: number; kind: string }>;
+		};
+		inspectHints?: string[];
+		note?: string;
+	};
 }
 
 export interface GateVerificationSnapshot {
@@ -49,6 +65,8 @@ export interface GateVerificationSnapshot {
 	selection: TextSelectionMetadata & { truncationReason?: string };
 	active: boolean;
 }
+
+type GateVerificationOutputSource = NonNullable<GateVerificationSnapshotStep["diagnostics"]>["outputSource"];
 
 interface GateInspectOutputStep {
 	output?: string;
@@ -192,6 +210,69 @@ function composeLiveLogOutput(stdout: string, stderr: string): string {
 	return stdout || stderr;
 }
 
+function safeReadText(filePath: string | undefined): string {
+	if (!filePath) return "";
+	try {
+		const stat = fs.statSync(filePath);
+		if (!stat.isFile() || stat.size <= 0) return "";
+		return fs.readFileSync(filePath, "utf8");
+	} catch {
+		return "";
+	}
+}
+
+function buildInspectHints(gateId: string, stepName: string): string[] {
+	const encodedStep = stepName.replace(/"/g, '\\"');
+	return [
+		`gate_inspect(gate_id="${gateId}", section="verification", step="${encodedStep}", mode="grep", pattern="error|failed|Error", context=3)`,
+		`gate_inspect(gate_id="${gateId}", section="verification", step="${encodedStep}", mode="slice", from=120, to=220)`,
+		`gate_inspect(gate_id="${gateId}", section="verification", step="${encodedStep}", mode="tail", lines=200)`,
+	];
+}
+
+function diagnosticsMetadata(input: {
+	diagnostics?: GateStepDiagnostics;
+	outputSource: GateVerificationOutputSource;
+	gateId: string;
+	stepName: string;
+}): GateVerificationSnapshotStep["diagnostics"] {
+	const diagnostics = input.diagnostics;
+	const out: NonNullable<GateVerificationSnapshotStep["diagnostics"]> = {
+		outputSource: input.outputSource,
+		inspectHints: buildInspectHints(input.gateId, input.stepName),
+	};
+	if (diagnostics) {
+		out.logs = {};
+		if (diagnostics.stdout) out.logs.stdout = diagnostics.stdout;
+		if (diagnostics.stderr) out.logs.stderr = diagnostics.stderr;
+		if (!out.logs.stdout && !out.logs.stderr) delete out.logs;
+		if (diagnostics.artifacts?.length) {
+			out.artifacts = {
+				count: diagnostics.artifacts.length,
+				truncated: diagnostics.truncated,
+				truncationReason: diagnostics.truncationReason,
+				files: diagnostics.artifacts,
+			};
+		}
+		out.note = input.outputSource === "retained-logs"
+			? "Inspection output is selected from retained stdout/stderr under Bobbit state; compact status output remains bounded."
+			: "Status output is compact; use explicit gate_inspect modes to query retained logs when available.";
+	} else {
+		out.note = input.outputSource === "live-logs"
+			? "Inspection output is selected from live command log files."
+			: "Inspection output is selected from compact persisted output; no retained logs were recorded for this step.";
+	}
+	return out;
+}
+
+function readRetainedCommandOutput(diagnostics: GateStepDiagnostics | undefined): string | undefined {
+	if (!diagnostics) return undefined;
+	const stdout = trimTrailingNewlines(safeReadText(diagnostics.stdout?.path));
+	const stderr = trimTrailingNewlines(safeReadText(diagnostics.stderr?.path));
+	if (!stdout && !stderr) return undefined;
+	return composeLiveLogOutput(stdout, stderr);
+}
+
 function readLiveCommandOutput(
 	activeStep: ActiveVerification["steps"][number],
 	selectionOptions: TextSelectionOptions,
@@ -276,6 +357,7 @@ export function buildGateVerificationSnapshot(input: {
 		let durationMs = persisted.duration_ms;
 		let liveLogs: GateVerificationSnapshotStep["liveLogs"];
 		let liveLogTruncationReason: string | undefined;
+		let outputSource: GateVerificationOutputSource = "compact-tail";
 		const sessionId = activeStep?.sessionId;
 
 		if (activeStep) {
@@ -289,6 +371,7 @@ export function buildGateVerificationSnapshot(input: {
 				const live = activeStep.type === "command" ? readLiveCommandOutput(activeStep, selectionOptions) : { output: activeStep.output || rawPersistedOutput };
 				rawOutput = live.output;
 				liveLogs = live.liveLogs;
+				if (live.liveLogs) outputSource = "live-logs";
 				liveLogTruncationReason = live.truncationReason;
 			} else {
 				durationMs = activeStep.durationMs ?? persisted.duration_ms;
@@ -297,6 +380,18 @@ export function buildGateVerificationSnapshot(input: {
 			}
 		} else {
 			status = finalStatusFromPersisted(persisted, input.verification?.status);
+		}
+
+		const canUseRetainedLogs = persisted.type === "command"
+			&& !selectionOptions.implicitDefault
+			&& status !== "running"
+			&& persisted.diagnostics;
+		if (canUseRetainedLogs) {
+			const retainedOutput = readRetainedCommandOutput(persisted.diagnostics);
+			if (retainedOutput !== undefined) {
+				rawOutput = retainedOutput;
+				outputSource = "retained-logs";
+			}
 		}
 
 		const selected = selectText(rawOutput, selectionOptions);
@@ -329,6 +424,14 @@ export function buildGateVerificationSnapshot(input: {
 			out.session = { id: sessionId, href: `/sessions/${encodeURIComponent(sessionId)}` };
 		}
 		if (liveLogs) out.liveLogs = liveLogs;
+		if (persisted.type === "command") {
+			out.diagnostics = diagnosticsMetadata({
+				diagnostics: persisted.diagnostics,
+				outputSource,
+				gateId: input.gateId,
+				stepName: persisted.name,
+			});
+		}
 		return out;
 	});
 

--- a/src/server/gate-verification-snapshot.ts
+++ b/src/server/gate-verification-snapshot.ts
@@ -366,9 +366,8 @@ export function buildGateVerificationSnapshot(input: {
 }): GateVerificationSnapshot {
 	const now = input.now ?? Date.now();
 	const selectionOptions = gateVerificationDefaultSelection(input.selectionOptions ?? { implicitDefault: true });
-	const includeDiagnostics = input.selectionOptions?.includeDiagnostics === true
-		|| input.selectionOptions?.implicitDefault === false
-		|| input.selectionOptions?.mode !== undefined;
+	const explicitInspectMode = input.selectionOptions?.mode !== undefined;
+	const includeDiagnostics = explicitInspectMode && input.selectionOptions?.includeDiagnostics !== false;
 	const active = input.activeVerification
 		&& input.activeVerification.goalId === input.goalId
 		&& input.activeVerification.gateId === input.gateId

--- a/src/server/gate-verification-snapshot.ts
+++ b/src/server/gate-verification-snapshot.ts
@@ -50,7 +50,7 @@ export interface GateVerificationSnapshotStep {
 			count: number;
 			truncated?: boolean;
 			truncationReason?: string;
-			files: Array<{ path: string; relativePath: string; sourcePath: string; bytes: number; kind: string }>;
+			files: Array<{ path: string; relativePath: string; sourcePath: string; bytes: number; kind: string; content?: string; contentType?: string }>;
 		};
 		inspectHints?: string[];
 		note?: string;
@@ -235,6 +235,7 @@ function diagnosticsMetadata(input: {
 	outputSource: GateVerificationOutputSource;
 	gateId: string;
 	stepName: string;
+	includeArtifactContent: boolean;
 }): GateVerificationSnapshotStep["diagnostics"] {
 	const diagnostics = input.diagnostics;
 	const out: NonNullable<GateVerificationSnapshotStep["diagnostics"]> = {
@@ -251,7 +252,9 @@ function diagnosticsMetadata(input: {
 				count: diagnostics.artifacts.length,
 				truncated: diagnostics.truncated,
 				truncationReason: diagnostics.truncationReason,
-				files: diagnostics.artifacts,
+				files: input.includeArtifactContent
+					? diagnostics.artifacts
+					: diagnostics.artifacts.map(({ content, contentType, ...artifact }) => artifact),
 			};
 		}
 		out.note = input.outputSource === "retained-logs"
@@ -430,6 +433,7 @@ export function buildGateVerificationSnapshot(input: {
 				outputSource,
 				gateId: input.gateId,
 				stepName: persisted.name,
+				includeArtifactContent: !selectionOptions.implicitDefault,
 			});
 		}
 		return out;

--- a/src/server/gate-verification-snapshot.ts
+++ b/src/server/gate-verification-snapshot.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 
 import type { GateSignal } from "./agent/gate-store.js";
-import type { GateStepDiagnostics } from "./gate-diagnostics.js";
+import { MAX_RETAINED_LOG_BYTES, type GateStepDiagnostics } from "./gate-diagnostics.js";
 import type { ActiveVerification } from "./agent/verification-harness.js";
 import {
 	MAX_SELECTED_BYTES,
@@ -43,8 +43,8 @@ export interface GateVerificationSnapshotStep {
 	diagnostics?: {
 		outputSource: "compact-tail" | "live-logs" | "retained-logs";
 		logs?: {
-			stdout?: { path: string; bytes: number; lines: number };
-			stderr?: { path: string; bytes: number; lines: number };
+			stdout?: { path: string; bytes: number; lines: number; truncated?: boolean; truncationReason?: string };
+			stderr?: { path: string; bytes: number; lines: number; truncated?: boolean; truncationReason?: string };
 		};
 		artifacts?: {
 			count: number;
@@ -210,14 +210,28 @@ function composeLiveLogOutput(stdout: string, stderr: string): string {
 	return stdout || stderr;
 }
 
-function safeReadText(filePath: string | undefined): string {
-	if (!filePath) return "";
+function safeReadText(filePath: string | undefined, maxBytes: number): BoundedLiveLogRead {
+	if (!filePath) return { text: "", truncated: false };
+	let fd: number | undefined;
 	try {
 		const stat = fs.statSync(filePath);
-		if (!stat.isFile() || stat.size <= 0) return "";
-		return fs.readFileSync(filePath, "utf8");
+		if (!stat.isFile() || stat.size <= 0) return { text: "", truncated: false };
+		const bytesToRead = Math.min(stat.size, maxBytes);
+		const buffer = Buffer.allocUnsafe(bytesToRead);
+		fd = fs.openSync(filePath, "r");
+		const bytesRead = fs.readSync(fd, buffer, 0, bytesToRead, 0);
+		const truncated = stat.size > bytesRead;
+		return {
+			text: buffer.subarray(0, bytesRead).toString("utf8"),
+			truncated,
+			truncationReason: truncated ? `retained log read bounded to first ${bytesRead} bytes before selection` : undefined,
+		};
 	} catch {
-		return "";
+		return { text: "", truncated: false };
+	} finally {
+		if (fd !== undefined) {
+			try { fs.closeSync(fd); } catch { /* ignore close failure */ }
+		}
 	}
 }
 
@@ -268,12 +282,23 @@ function diagnosticsMetadata(input: {
 	return out;
 }
 
-function readRetainedCommandOutput(diagnostics: GateStepDiagnostics | undefined): string | undefined {
-	if (!diagnostics) return undefined;
-	const stdout = trimTrailingNewlines(safeReadText(diagnostics.stdout?.path));
-	const stderr = trimTrailingNewlines(safeReadText(diagnostics.stderr?.path));
-	if (!stdout && !stderr) return undefined;
-	return composeLiveLogOutput(stdout, stderr);
+function readRetainedCommandOutput(diagnostics: GateStepDiagnostics | undefined): { output?: string; truncationReason?: string } {
+	if (!diagnostics) return {};
+	const stdoutRead = safeReadText(diagnostics.stdout?.path, MAX_RETAINED_LOG_BYTES);
+	const stderrRead = safeReadText(diagnostics.stderr?.path, MAX_RETAINED_LOG_BYTES);
+	const stdout = trimTrailingNewlines(stdoutRead.text);
+	const stderr = trimTrailingNewlines(stderrRead.text);
+	if (!stdout && !stderr) return {};
+	return {
+		output: composeLiveLogOutput(stdout, stderr),
+		truncationReason: combineTruncationReasons([
+			stdoutRead.truncationReason,
+			stderrRead.truncationReason,
+			diagnostics.stdout?.truncationReason,
+			diagnostics.stderr?.truncationReason,
+			diagnostics.truncationReason,
+		]),
+	};
 }
 
 function readLiveCommandOutput(
@@ -341,6 +366,9 @@ export function buildGateVerificationSnapshot(input: {
 }): GateVerificationSnapshot {
 	const now = input.now ?? Date.now();
 	const selectionOptions = gateVerificationDefaultSelection(input.selectionOptions ?? { implicitDefault: true });
+	const includeDiagnostics = input.selectionOptions?.includeDiagnostics === true
+		|| input.selectionOptions?.implicitDefault === false
+		|| input.selectionOptions?.mode !== undefined;
 	const active = input.activeVerification
 		&& input.activeVerification.goalId === input.goalId
 		&& input.activeVerification.gateId === input.gateId
@@ -386,25 +414,28 @@ export function buildGateVerificationSnapshot(input: {
 		}
 
 		const canUseRetainedLogs = persisted.type === "command"
-			&& !selectionOptions.implicitDefault
+			&& includeDiagnostics
 			&& status !== "running"
 			&& persisted.diagnostics;
+		let retainedLogTruncationReason: string | undefined;
 		if (canUseRetainedLogs) {
 			const retainedOutput = readRetainedCommandOutput(persisted.diagnostics);
-			if (retainedOutput !== undefined) {
-				rawOutput = retainedOutput;
+			if (retainedOutput.output !== undefined) {
+				rawOutput = retainedOutput.output;
 				outputSource = "retained-logs";
+				retainedLogTruncationReason = retainedOutput.truncationReason;
 			}
 		}
 
 		const selected = selectText(rawOutput, selectionOptions);
-		const selection = liveLogTruncationReason
+		const outputTruncationReason = combineTruncationReasons([liveLogTruncationReason, retainedLogTruncationReason]);
+		const selection = outputTruncationReason
 			? {
 				...selected.selection,
 				truncated: true,
 				truncationReason: selected.selection.truncationReason
-					? `${liveLogTruncationReason}; ${selected.selection.truncationReason}`
-					: liveLogTruncationReason,
+					? `${outputTruncationReason}; ${selected.selection.truncationReason}`
+					: outputTruncationReason,
 			}
 			: selected.selection;
 		aggregateTotalLines += selection.totalLines;
@@ -427,13 +458,13 @@ export function buildGateVerificationSnapshot(input: {
 			out.session = { id: sessionId, href: `/sessions/${encodeURIComponent(sessionId)}` };
 		}
 		if (liveLogs) out.liveLogs = liveLogs;
-		if (persisted.type === "command") {
+		if (persisted.type === "command" && includeDiagnostics) {
 			out.diagnostics = diagnosticsMetadata({
 				diagnostics: persisted.diagnostics,
 				outputSource,
 				gateId: input.gateId,
 				stepName: persisted.name,
-				includeArtifactContent: !selectionOptions.implicitDefault,
+				includeArtifactContent: true,
 			});
 		}
 		return out;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7648,7 +7648,7 @@ async function handleApiRoute(
 
 		let selectionOptions: TextSelectionOptions;
 		try {
-			selectionOptions = parseGateInspectSelectionOptions(url.searchParams);
+			selectionOptions = { ...parseGateInspectSelectionOptions(url.searchParams), includeDiagnostics: true };
 			selectText("", selectionOptions);
 		} catch (err) {
 			if (err instanceof TextSelectionError) { json({ error: err.message }, 400); return; }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -304,6 +304,7 @@ import { ProjectContextManager } from "./agent/project-context-manager.js";
 import type { ProjectContext } from "./agent/project-context.js";
 import { resolveProjectForRequest } from "./agent/resolve-project.js";
 import { GoalManager } from "./agent/goal-manager.js";
+import { cleanupGateDiagnosticsForGoal } from "./agent/gate-diagnostics-cleanup.js";
 import type { WorktreeReferenceRecord } from "./agent/worktree-reference-guard.js";
 import { computePlanFreezeUpdate } from "./agent/parent-workflow-freeze.js";
 import { detectHostTokens, resolveHostTokenValue, sandboxTokenPolicyAllowsCodexAuth } from "./agent/host-tokens.js";
@@ -5179,7 +5180,14 @@ async function handleApiRoute(
 		const mergedManually = url.searchParams.get("mergedManually") === "true";
 
 		const archiveOne = async (g: import("./agent/goal-store.js").PersistedGoal): Promise<boolean> => {
-			if (g.archived) return false;
+			if (g.archived) {
+				try {
+					await cleanupGateDiagnosticsForGoal(g.id, projectContextManager.getContextForGoal(g.id)?.stateDir);
+				} catch (err) {
+					console.warn(`[api] archive: gate diagnostics cleanup failed for already-archived goal ${g.id}:`, err);
+				}
+				return false;
+			}
 			if (mergedManually && g.id === id && g.state !== "complete") {
 				await getGoalManagerForGoal(g.id).updateGoal(g.id, { state: "complete" });
 			}

--- a/src/server/utils/text-selection.ts
+++ b/src/server/utils/text-selection.ts
@@ -9,6 +9,8 @@ export const MAX_SELECTED_BYTES = 50 * 1024;
 export interface TextSelectionOptions {
 	mode?: TextSelectionMode;
 	implicitDefault?: boolean;
+	/** Include retained diagnostic metadata. Set by explicit gate_inspect calls, not compact status snapshots. */
+	includeDiagnostics?: boolean;
 	pattern?: string;
 	context?: number;
 	maxResults?: number;

--- a/tests/e2e/gate-diagnostics-cleanup.spec.ts
+++ b/tests/e2e/gate-diagnostics-cleanup.spec.ts
@@ -1,0 +1,70 @@
+import fs from "node:fs";
+import path from "node:path";
+import { test, expect } from "./in-process-harness.js";
+import { apiFetch, createGoal, defaultProject, defaultProjectId, deleteGoal, nonGitCwd } from "./e2e-setup.js";
+import { gateDiagnosticsGoalDir } from "../../src/server/agent/gate-diagnostics-cleanup.js";
+
+const SPEC = "Gate diagnostics cleanup E2E goal spec padded enough to satisfy goal creation validation.";
+
+async function setSubgoalsEnabled(enabled: boolean): Promise<void> {
+	const resp = await apiFetch("/api/preferences", {
+		method: "PUT",
+		body: JSON.stringify({ subgoalsEnabled: enabled }),
+	});
+	expect(resp.status).toBe(200);
+}
+
+function seedDiagnostics(stateDir: string, goalId: string): string {
+	const dir = gateDiagnosticsGoalDir(goalId, stateDir);
+	fs.mkdirSync(path.join(dir, "gate", "signal", "step"), { recursive: true });
+	fs.writeFileSync(path.join(dir, "gate", "signal", "step", "stdout.log"), `diagnostics for ${goalId}`, "utf-8");
+	return dir;
+}
+
+async function createChild(parentId: string): Promise<string> {
+	const resp = await apiFetch("/api/goals", {
+		method: "POST",
+		body: JSON.stringify({
+			title: `diagnostic cleanup child ${Date.now()}`,
+			cwd: nonGitCwd(),
+			worktree: false,
+			autoStartTeam: false,
+			workflowId: "feature",
+			spec: SPEC,
+			projectId: await defaultProjectId(),
+			parentGoalId: parentId,
+		}),
+	});
+	expect(resp.status).toBe(201);
+	return ((await resp.json()) as { id: string }).id;
+}
+
+test("cascade archiving a goal tree removes retained diagnostics for parent and child goals", async () => {
+	await setSubgoalsEnabled(true);
+	const project = await defaultProject();
+	const stateDir = path.join(project.rootPath, ".bobbit", "state");
+	const parent = await createGoal({
+		title: `diagnostic cleanup parent ${Date.now()}`,
+		spec: SPEC,
+		autoStartTeam: false,
+		subgoalsAllowed: true,
+	});
+	let childId: string | undefined;
+	try {
+		childId = await createChild(parent.id as string);
+		const parentDir = seedDiagnostics(stateDir, parent.id as string);
+		const childDir = seedDiagnostics(stateDir, childId);
+		const unrelatedDir = seedDiagnostics(stateDir, "unrelated-goal");
+
+		const resp = await apiFetch(`/api/goals/${parent.id}?cascade=true`, { method: "DELETE" });
+		expect(resp.status).toBe(200);
+		expect((await resp.json()).archived).toBe(2);
+
+		expect(fs.existsSync(parentDir), "parent diagnostics should be removed").toBe(false);
+		expect(fs.existsSync(childDir), "child diagnostics should be removed").toBe(false);
+		expect(fs.existsSync(unrelatedDir), "unrelated diagnostics should be preserved").toBe(true);
+	} finally {
+		if (childId) await deleteGoal(childId).catch(() => {});
+		await deleteGoal(parent.id as string).catch(() => {});
+	}
+});

--- a/tests/e2e/gate-inspect-slicing.spec.ts
+++ b/tests/e2e/gate-inspect-slicing.spec.ts
@@ -1,3 +1,7 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { test, expect } from "./in-process-harness.js";
 import { apiFetch, createGoal, deleteGoal } from "./e2e-setup.js";
 import { pollUntil } from "./test-utils/cleanup.js";
@@ -5,6 +9,8 @@ import { pollUntil } from "./test-utils/cleanup.js";
 const VERIFY_LOG_CMD = `node -e "for (let i=1;i<=160;i++) console.log((i===125?'ERROR failed sentinel line '+i:'noise line '+i))"`;
 const RETAINED_DIAGNOSTICS_MARKER = "RETAINED_GATE_DIAGNOSTICS_EARLY_MARKER stack frame";
 const FAILED_RETAINED_DIAGNOSTICS_CMD = `node -e "for (let i=1;i<=80;i++) console.log('prelude line '+i+' '+ 'x'.repeat(100)); console.log('${RETAINED_DIAGNOSTICS_MARKER}'); for (let i=81;i<=260;i++) console.log('tail line '+i+' '+ 'y'.repeat(100)); process.exit(1)"`;
+const PLAYWRIGHT_ERROR_CONTEXT_MARKER = "PLAYWRIGHT_ERROR_CONTEXT_FILE_RETAINED_MARKER";
+const PLAYWRIGHT_STYLE_ARTIFACT_CMD = `node -e "const fs=require('fs'),path=require('path'); const dir=path.join('test-results','retain-artifact-fixture'); fs.mkdirSync(dir,{recursive:true}); fs.writeFileSync(path.join(dir,'error-context.md'),'# Error Context\\n${PLAYWRIGHT_ERROR_CONTEXT_MARKER}\\nlocator(\\\"text=Missing\\\") failed after retry\\n'); fs.writeFileSync(path.join(dir,'trace.zip'),'trace placeholder'); fs.writeFileSync(path.join(dir,'screenshot.png'),'png placeholder'); console.error('PLAYWRIGHT_STYLE_FAILURE_SUMMARY: expect(locator).toBeVisible failed; see test-results/retain-artifact-fixture/error-context.md'); process.exit(1)"`;
 
 function makeWorkflowId(): string {
 	return `gate-inspect-slicing-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -41,6 +47,11 @@ async function createInspectWorkflow(workflowId: string): Promise<void> {
 					id: "failed-retained-diagnostics-gate",
 					name: "Failed Retained Diagnostics Gate",
 					verify: [{ name: "failing verbose command", type: "command", run: FAILED_RETAINED_DIAGNOSTICS_CMD }],
+				},
+				{
+					id: "playwright-artifacts-gate",
+					name: "Playwright Artifacts Gate",
+					verify: [{ name: "playwright-style failure", type: "command", run: PLAYWRIGHT_STYLE_ARTIFACT_CMD }],
 				},
 				{ id: "signals-gate", name: "Signals Gate", content: true },
 			],
@@ -117,6 +128,51 @@ async function withGoal<T>(run: (goalId: string) => Promise<T>): Promise<T> {
 		await deleteGoal(goal.id);
 		await deleteInspectWorkflow(workflowId);
 	}
+}
+
+function findFiles(root: string, predicate: (file: string) => boolean): string[] {
+	const matches: string[] = [];
+	const visit = (dir: string) => {
+		let entries: fs.Dirent[];
+		try {
+			entries = fs.readdirSync(dir, { withFileTypes: true });
+		} catch {
+			return;
+		}
+		for (const entry of entries) {
+			const fullPath = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				visit(fullPath);
+			} else if (entry.isFile() && predicate(fullPath)) {
+				matches.push(fullPath);
+			}
+		}
+	};
+	visit(root);
+	return matches;
+}
+
+function findFilesContaining(root: string, marker: string): string[] {
+	return findFiles(root, (file) => {
+		try {
+			return fs.readFileSync(file, "utf8").includes(marker);
+		} catch {
+			// Binary or transient files are irrelevant for this marker search.
+			return false;
+		}
+	});
+}
+
+function findPersistedGateStoreDir(root: string, goalId: string): string | undefined {
+	return findFiles(root, file => path.basename(file) === "gates.json")
+		.find(file => {
+			try {
+				return fs.readFileSync(file, "utf8").includes(goalId);
+			} catch {
+				return false;
+			}
+		})
+		?.replace(/[\\/]gates\.json$/, "");
 }
 
 test.describe("gate inspect slicing", () => {
@@ -252,6 +308,71 @@ test.describe("gate inspect slicing", () => {
 			expect(sliceStep.output).toMatch(/^82\b.*tail line 81/m);
 			expect(sliceStep.selection).toMatchObject({ mode: "slice", totalLines: 261, range: { from: 78, to: 83 } });
 		});
+	});
+
+	test("retains completed failed command diagnostics after reloading persisted gate stores", async ({ gateway }) => {
+		await withGoal(async (goalId) => {
+			const post = await signalAndWaitFailed(goalId, "failed-retained-diagnostics-gate", {});
+			const { GateStore } = await import("../../dist/server/agent/gate-store.js");
+			const { buildGateVerificationSnapshot } = await import("../../dist/server/gate-verification-snapshot.js");
+			const gateStoreDir = findPersistedGateStoreDir(gateway.bobbitDir, goalId);
+			expect(gateStoreDir, "RETAINED_GATE_DIAGNOSTICS_GATE_STORE_FILE_MISSING: persisted gates.json for the failed signal must be reconstructable after restart").toBeTruthy();
+			const reloadedGateStore = new GateStore(gateStoreDir!);
+			const reloadedGate = reloadedGateStore.getGate(goalId, "failed-retained-diagnostics-gate");
+			const reloadedSignal = reloadedGate?.signals.find((signal: any) => signal.id === post.signal.id);
+			expect(reloadedSignal, "RETAINED_GATE_DIAGNOSTICS_RELOAD_MISSING: failed signal must survive gate-store reconstruction").toBeTruthy();
+
+			const snapshot = buildGateVerificationSnapshot({
+				goalId,
+				gateId: "failed-retained-diagnostics-gate",
+				signalId: post.signal.id,
+				verification: reloadedSignal.verification,
+				selectionOptions: { mode: "grep", pattern: "RETAINED_GATE_DIAGNOSTICS_EARLY_MARKER", context: 1 },
+			});
+			expect(snapshot.steps).toHaveLength(1);
+			expect(
+				snapshot.steps[0].output,
+				"RETAINED_GATE_DIAGNOSTICS_RELOAD_GREP_MISSING: reconstructed gate inspection must read retained full diagnostics after restart/store reload, not only gates.json's compact tail",
+			).toContain(RETAINED_DIAGNOSTICS_MARKER);
+			expect(snapshot.steps[0].output).toContain("prelude line 80");
+			expect(snapshot.steps[0].output).toContain("tail line 81");
+			expect(snapshot.steps[0].selection).toMatchObject({ mode: "grep", matchCount: 1, shownMatches: 1 });
+		});
+	});
+
+	test("copies and exposes Playwright-style error-context artifacts for failed command inspection", async ({ gateway }) => {
+		const workflowId = makeWorkflowId();
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), `bobbit-playwright-artifacts-${Date.now()}-`));
+		await createInspectWorkflow(workflowId);
+		const goal = await createGoal({ title: `Gate Inspect Playwright Artifacts ${Date.now()}`, workflowId, cwd });
+		try {
+			await signalAndWaitFailed(goal.id, "playwright-artifacts-gate", {});
+			fs.rmSync(path.join(cwd, "test-results"), { recursive: true, force: true });
+
+			const inspectRes = await inspectGate(goal.id, "playwright-artifacts-gate", "verification", { mode: "full" });
+			expect(inspectRes.status).toBe(200);
+			const body = await inspectRes.json();
+			const serialized = JSON.stringify(body);
+			expect(
+				serialized,
+				"PLAYWRIGHT_ARTIFACT_REFERENCE_MISSING: failed gate inspection must expose copied Playwright artifact metadata/path for test-results/**/error-context.md after the original worktree artifact is gone",
+			).toContain("error-context.md");
+			expect(
+				serialized,
+				"PLAYWRIGHT_ERROR_CONTEXT_CONTENT_MISSING: failed gate inspection must expose or link retained error-context.md content, not only the compact command tail",
+			).toContain(PLAYWRIGHT_ERROR_CONTEXT_MARKER);
+
+			const stateMarkerFiles = findFilesContaining(path.join(gateway.bobbitDir, "state"), PLAYWRIGHT_ERROR_CONTEXT_MARKER)
+				.filter(file => !file.endsWith("gates.json"));
+			expect(
+				stateMarkerFiles,
+				"PLAYWRIGHT_ARTIFACT_COPY_MISSING: error-context.md content must be copied under Bobbit state outside gates.json so worktree cleanup/restart does not destroy diagnostics",
+			).not.toEqual([]);
+		} finally {
+			await deleteGoal(goal.id);
+			await deleteInspectWorkflow(workflowId);
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
 	});
 
 	test("scopes verification to a single named step and rejects unknown/misplaced step params", async () => {

--- a/tests/e2e/gate-inspect-slicing.spec.ts
+++ b/tests/e2e/gate-inspect-slicing.spec.ts
@@ -3,6 +3,8 @@ import { apiFetch, createGoal, deleteGoal } from "./e2e-setup.js";
 import { pollUntil } from "./test-utils/cleanup.js";
 
 const VERIFY_LOG_CMD = `node -e "for (let i=1;i<=160;i++) console.log((i===125?'ERROR failed sentinel line '+i:'noise line '+i))"`;
+const RETAINED_DIAGNOSTICS_MARKER = "RETAINED_GATE_DIAGNOSTICS_EARLY_MARKER stack frame";
+const FAILED_RETAINED_DIAGNOSTICS_CMD = `node -e "for (let i=1;i<=80;i++) console.log('prelude line '+i+' '+ 'x'.repeat(100)); console.log('${RETAINED_DIAGNOSTICS_MARKER}'); for (let i=81;i<=260;i++) console.log('tail line '+i+' '+ 'y'.repeat(100)); process.exit(1)"`;
 
 function makeWorkflowId(): string {
 	return `gate-inspect-slicing-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -34,6 +36,11 @@ async function createInspectWorkflow(workflowId: string): Promise<void> {
 						{ name: "unit", type: "command", run: VERIFY_LOG_CMD },
 						{ name: "lint", type: "command", run: `node -e "console.log('lint ok line')"` },
 					],
+				},
+				{
+					id: "failed-retained-diagnostics-gate",
+					name: "Failed Retained Diagnostics Gate",
+					verify: [{ name: "failing verbose command", type: "command", run: FAILED_RETAINED_DIAGNOSTICS_CMD }],
 				},
 				{ id: "signals-gate", name: "Signals Gate", content: true },
 			],
@@ -85,6 +92,12 @@ async function waitForSignalVerificationStatus(
 async function signalAndWait(goalId: string, gateId: string, body: Record<string, unknown>): Promise<any> {
 	const signal = await signalGate(goalId, gateId, body);
 	await waitForSignalVerificationStatus(goalId, gateId, signal.signal.id, "passed");
+	return signal;
+}
+
+async function signalAndWaitFailed(goalId: string, gateId: string, body: Record<string, unknown>): Promise<any> {
+	const signal = await signalGate(goalId, gateId, body);
+	await waitForSignalVerificationStatus(goalId, gateId, signal.signal.id, "failed");
 	return signal;
 }
 
@@ -197,6 +210,47 @@ test.describe("gate inspect slicing", () => {
 			expect(sliceStep.output).not.toContain("noise line 127");
 			expect(sliceStep.selection).toMatchObject({ mode: "slice", totalLines: 160, range: { from: 120, to: 126 } });
 			expect(sliceStep.selection.omittedHint).toBeUndefined();
+		});
+	});
+
+	test("retains completed failed command diagnostics for explicit grep and slice inspection", async () => {
+		await withGoal(async (goalId) => {
+			const post = await signalAndWaitFailed(goalId, "failed-retained-diagnostics-gate", {});
+
+			const grepRes = await inspectGate(goalId, "failed-retained-diagnostics-gate", "verification", {
+				mode: "grep",
+				pattern: "RETAINED_GATE_DIAGNOSTICS_EARLY_MARKER",
+				context: 1,
+			});
+			expect(grepRes.status).toBe(200);
+			const grepBody = await grepRes.json();
+			expect(grepBody.signalId).toBe(post.signal.id);
+			expect(grepBody.steps).toHaveLength(1);
+			const grepStep = grepBody.steps[0];
+			expect(
+				grepStep.output,
+				"RETAINED_GATE_DIAGNOSTICS_GREP_MISSING: completed failed command inspection must search retained full diagnostics, not only the compact persisted tail",
+			).toContain(RETAINED_DIAGNOSTICS_MARKER);
+			expect(grepStep.output).toContain("prelude line 80");
+			expect(grepStep.output).toContain("tail line 81");
+			expect(grepStep.selection).toMatchObject({ mode: "grep", matchCount: 1, shownMatches: 1 });
+
+			const sliceRes = await inspectGate(goalId, "failed-retained-diagnostics-gate", "verification", {
+				mode: "slice",
+				from: 78,
+				to: 83,
+			});
+			expect(sliceRes.status).toBe(200);
+			const sliceBody = await sliceRes.json();
+			const sliceStep = sliceBody.steps[0];
+			expect(
+				sliceStep.output,
+				"RETAINED_GATE_DIAGNOSTICS_SLICE_MISSING: completed failed command inspection must slice retained full diagnostics, not only the compact persisted tail",
+			).toContain(RETAINED_DIAGNOSTICS_MARKER);
+			expect(sliceStep.output).toMatch(/^80\b.*prelude line 80/m);
+			expect(sliceStep.output).toMatch(/^81\b.*RETAINED_GATE_DIAGNOSTICS_EARLY_MARKER/m);
+			expect(sliceStep.output).toMatch(/^82\b.*tail line 81/m);
+			expect(sliceStep.selection).toMatchObject({ mode: "slice", totalLines: 261, range: { from: 78, to: 83 } });
 		});
 	});
 

--- a/tests/e2e/gate-inspect-slicing.spec.ts
+++ b/tests/e2e/gate-inspect-slicing.spec.ts
@@ -11,6 +11,11 @@ const RETAINED_DIAGNOSTICS_MARKER = "RETAINED_GATE_DIAGNOSTICS_EARLY_MARKER stac
 const FAILED_RETAINED_DIAGNOSTICS_CMD = `node -e "for (let i=1;i<=80;i++) console.log('prelude line '+i+' '+ 'x'.repeat(100)); console.log('${RETAINED_DIAGNOSTICS_MARKER}'); for (let i=81;i<=260;i++) console.log('tail line '+i+' '+ 'y'.repeat(100)); process.exit(1)"`;
 const PLAYWRIGHT_ERROR_CONTEXT_MARKER = "PLAYWRIGHT_ERROR_CONTEXT_FILE_RETAINED_MARKER";
 const PLAYWRIGHT_STYLE_ARTIFACT_CMD = `node -e "const fs=require('fs'),path=require('path'); const dir=path.join('test-results','retain-artifact-fixture'); fs.mkdirSync(dir,{recursive:true}); fs.writeFileSync(path.join(dir,'error-context.md'),'# Error Context\\n${PLAYWRIGHT_ERROR_CONTEXT_MARKER}\\nlocator(\\\"text=Missing\\\") failed after retry\\n'); fs.writeFileSync(path.join(dir,'trace.zip'),'trace placeholder'); fs.writeFileSync(path.join(dir,'screenshot.png'),'png placeholder'); console.error('PLAYWRIGHT_STYLE_FAILURE_SUMMARY: expect(locator).toBeVisible failed; see test-results/retain-artifact-fixture/error-context.md'); process.exit(1)"`;
+const RETAINED_LOG_CAP_MARKER = "RETAINED_GATE_DIAGNOSTICS_CAP_MARKER";
+const HUGE_RETAINED_LOG_CHUNKS = 3072;
+const HUGE_RETAINED_LOG_CHUNK_BYTES = 2048;
+const HUGE_RETAINED_LOG_EMITTED_BYTES = HUGE_RETAINED_LOG_CHUNKS * ("CAP-FILL ".length + HUGE_RETAINED_LOG_CHUNK_BYTES + 1);
+const HUGE_RETAINED_LOG_CMD = `node -e "const chunk='CAP-FILL '+ 'x'.repeat(${HUGE_RETAINED_LOG_CHUNK_BYTES})+'\\n'; for (let i=0;i<${HUGE_RETAINED_LOG_CHUNKS};i++) process.stdout.write(chunk); console.error('${RETAINED_LOG_CAP_MARKER}'); process.exit(1)"`;
 
 function makeWorkflowId(): string {
 	return `gate-inspect-slicing-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -52,6 +57,11 @@ async function createInspectWorkflow(workflowId: string): Promise<void> {
 					id: "playwright-artifacts-gate",
 					name: "Playwright Artifacts Gate",
 					verify: [{ name: "playwright-style failure", type: "command", run: PLAYWRIGHT_STYLE_ARTIFACT_CMD }],
+				},
+				{
+					id: "huge-retained-log-gate",
+					name: "Huge Retained Log Gate",
+					verify: [{ name: "huge retained log failure", type: "command", run: HUGE_RETAINED_LOG_CMD }],
 				},
 				{ id: "signals-gate", name: "Signals Gate", content: true },
 			],
@@ -116,6 +126,12 @@ async function inspectGate(goalId: string, gateId: string, section: string, para
 	const qs = new URLSearchParams({ section });
 	for (const [key, value] of Object.entries(params)) qs.set(key, String(value));
 	return apiFetch(`/api/goals/${goalId}/gates/${gateId}/inspect?${qs.toString()}`);
+}
+
+async function gateSummary(goalId: string, gateId: string): Promise<any> {
+	const res = await apiFetch(`/api/goals/${goalId}/gates/${gateId}?view=summary`);
+	if (res.status !== 200) throw new Error(`gate summary ${gateId} failed: ${res.status} ${await res.text().catch(() => "")}`);
+	return res.json();
 }
 
 async function withGoal<T>(run: (goalId: string) => Promise<T>): Promise<T> {
@@ -340,7 +356,7 @@ test.describe("gate inspect slicing", () => {
 		});
 	});
 
-	test("copies and exposes Playwright-style error-context artifacts for failed command inspection", async ({ gateway }) => {
+	test("copies and exposes Playwright-style error-context artifacts from the verification command cwd", async ({ gateway }) => {
 		const workflowId = makeWorkflowId();
 		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), `bobbit-playwright-artifacts-${Date.now()}-`));
 		await createInspectWorkflow(workflowId);
@@ -366,13 +382,88 @@ test.describe("gate inspect slicing", () => {
 				.filter(file => !file.endsWith("gates.json"));
 			expect(
 				stateMarkerFiles,
-				"PLAYWRIGHT_ARTIFACT_COPY_MISSING: error-context.md content must be copied under Bobbit state outside gates.json so worktree cleanup/restart does not destroy diagnostics",
+				"PLAYWRIGHT_ARTIFACT_COPY_MISSING: error-context.md content must be copied under Bobbit state outside gates.json so worktree cleanup/restart does not destroy diagnostics. This focused E2E covers the host-visible command cwd path; Docker sandbox transfer needs manual/docker coverage.",
 			).not.toEqual([]);
 		} finally {
 			await deleteGoal(goal.id);
 			await deleteInspectWorkflow(workflowId);
 			fs.rmSync(cwd, { recursive: true, force: true });
 		}
+	});
+
+	test("keeps gate status compact while explicit inspection exposes retained diagnostics", async ({ gateway }) => {
+		const workflowId = makeWorkflowId();
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), `bobbit-compact-artifacts-${Date.now()}-`));
+		await createInspectWorkflow(workflowId);
+		const goal = await createGoal({ title: `Gate Status Compact Diagnostics ${Date.now()}`, workflowId, cwd });
+		try {
+			await signalAndWaitFailed(goal.id, "playwright-artifacts-gate", {});
+			fs.rmSync(path.join(cwd, "test-results"), { recursive: true, force: true });
+
+			const summary = await gateSummary(goal.id, "playwright-artifacts-gate");
+			const summaryJson = JSON.stringify(summary.latestSignal?.verification ?? summary);
+			expect(summary.latestSignal?.verification?.status).toBe("failed");
+			expect(
+				summaryJson,
+				"GATE_STATUS_RETAINED_DIAGNOSTICS_TOO_VERBOSE: compact gate status/default verification snapshots must not expose retained log paths or bulky Playwright artifact file lists",
+			).not.toMatch(/stdout\.log|stderr\.log|trace\.zip|screenshot\.png|gate-diagnostics|PLAYWRIGHT_ERROR_CONTEXT_FILE_RETAINED_MARKER/i);
+
+			const defaultInspectRes = await inspectGate(goal.id, "playwright-artifacts-gate", "verification");
+			expect(defaultInspectRes.status).toBe(200);
+			const defaultInspect = await defaultInspectRes.json();
+			expect(
+				JSON.stringify(defaultInspect.steps),
+				"GATE_INSPECT_DEFAULT_RETAINED_DIAGNOSTICS_TOO_VERBOSE: implicit/default gate_inspect should stay compact unless a mode is explicit",
+			).not.toMatch(/stdout\.log|stderr\.log|trace\.zip|screenshot\.png|gate-diagnostics|PLAYWRIGHT_ERROR_CONTEXT_FILE_RETAINED_MARKER/i);
+
+			const explicitRes = await inspectGate(goal.id, "playwright-artifacts-gate", "verification", { mode: "full" });
+			expect(explicitRes.status).toBe(200);
+			const explicit = await explicitRes.json();
+			const explicitJson = JSON.stringify(explicit.steps);
+			expect(
+				explicitJson,
+				"GATE_INSPECT_EXPLICIT_DIAGNOSTICS_MISSING: explicit gate_inspect must expose retained diagnostic log/artifact metadata",
+			).toMatch(/stdout\.log|stderr\.log|gate-diagnostics/i);
+			expect(explicitJson).toContain("error-context.md");
+			expect(explicitJson).toContain(PLAYWRIGHT_ERROR_CONTEXT_MARKER);
+
+			const stateMarkerFiles = findFilesContaining(path.join(gateway.bobbitDir, "state"), PLAYWRIGHT_ERROR_CONTEXT_MARKER)
+				.filter(file => !file.endsWith("gates.json"));
+			expect(stateMarkerFiles).not.toEqual([]);
+		} finally {
+			await deleteGoal(goal.id);
+			await deleteInspectWorkflow(workflowId);
+			fs.rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	test("caps retained command logs and exposes cap metadata in explicit inspection", async () => {
+		await withGoal(async (goalId) => {
+			await signalAndWaitFailed(goalId, "huge-retained-log-gate", {});
+
+			const inspectRes = await inspectGate(goalId, "huge-retained-log-gate", "verification", { mode: "full" });
+			expect(inspectRes.status).toBe(200);
+			const body = await inspectRes.json();
+			const step = body.steps[0];
+			const diagnosticsJson = JSON.stringify(step.diagnostics ?? {});
+			expect(
+				step.diagnostics?.logs?.stdout?.bytes,
+				"RETAINED_LOG_CAP_MISSING: retained stdout bytes should be smaller than the emitted output instead of growing without bound",
+			).toBeLessThan(HUGE_RETAINED_LOG_EMITTED_BYTES);
+			expect(
+				diagnosticsJson,
+				"RETAINED_LOG_TRUNCATION_METADATA_MISSING: explicit inspection must expose retained-log cap/truncation metadata, not only selected-output truncation",
+			).toMatch(/truncat|cap|bounded/i);
+			expect(step.selection?.truncated || body.selection?.truncated).toBe(true);
+
+			const grepRes = await inspectGate(goalId, "huge-retained-log-gate", "verification", {
+				mode: "grep",
+				pattern: RETAINED_LOG_CAP_MARKER,
+			});
+			expect(grepRes.status).toBe(200);
+			const grepBody = await grepRes.json();
+			expect(JSON.stringify(grepBody)).toContain(RETAINED_LOG_CAP_MARKER);
+		});
 	});
 
 	test("scopes verification to a single named step and rejects unknown/misplaced step params", async () => {

--- a/tests/e2e/gate-verification-resume.spec.ts
+++ b/tests/e2e/gate-verification-resume.spec.ts
@@ -7,8 +7,7 @@
  *   Bug 1 — TeamManager.resubscribeTeamEvents() must NOT attach the
  *           agent_end → notifyTeamLead listener to reviewer sessions.
  *           After restart, firing agent_end on a reviewer must NOT
- *           steer/enqueue a "Agent ... has finished" message to the
- *           team lead.
+ *           steer/enqueue a worker-completion nudge to the team lead.
  *
  *   Bug 2 — VerificationHarness._tryResumeFromSession must give a resumed
  *           reviewer the full reminder window before declaring failure
@@ -121,7 +120,13 @@ test.describe("gate verification resume after restart", () => {
 			let nudgeCount = 0;
 			let reviewerNudgeCount = 0;
 			let workerNudgeCount = 0;
-			const matchNudge = (msg: string) => /has finished/i.test(msg);
+			// Match the worker-completion nudge sent by TeamManager.notifyTeamLead
+			// without depending on one exact prose variant. The message currently
+			// uses markdown headings like `Agent finished` or `Task complete`, and
+			// includes the standard `task_list` next step.
+			const matchNudge = (msg: string) =>
+				/(?:^|\n)\s*(?:#{1,6}\s*)?(?:\*\*)?(?:Agent finished|Task complete)(?:\*\*)?\s*(?:\n|$)/i.test(msg)
+				&& /\btask_list\b/.test(msg);
 			sm.deliverLiveSteer = async (sid: string, msg: string) => {
 				if (sid === teamLeadId && matchNudge(msg)) {
 					nudgeCount++;

--- a/tests/gate-diagnostics-cleanup.test.ts
+++ b/tests/gate-diagnostics-cleanup.test.ts
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { GoalStore, type PersistedGoal } from "../src/server/agent/goal-store.js";
+import { GoalManager } from "../src/server/agent/goal-manager.js";
+import { gateDiagnosticsGoalDir } from "../src/server/agent/gate-diagnostics-cleanup.js";
+
+function makeGoal(id: string): PersistedGoal {
+	return {
+		id,
+		title: id,
+		cwd: process.cwd(),
+		state: "in-progress",
+		spec: "diagnostic cleanup test goal",
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		setupStatus: "ready",
+	};
+}
+
+function seedDiagnostics(stateDir: string, goalId: string): string {
+	const dir = gateDiagnosticsGoalDir(goalId, stateDir);
+	fs.mkdirSync(path.join(dir, "gate-a", "signal-b", "step-c"), { recursive: true });
+	fs.writeFileSync(path.join(dir, "gate-a", "signal-b", "step-c", "stdout.log"), "retained output", "utf-8");
+	return dir;
+}
+
+test("goal archive and hard delete remove retained gate diagnostics", async () => {
+	const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-gate-diagnostics-cleanup-"));
+	try {
+		const stateDir = path.join(tmp, "state");
+		const store = new GoalStore(stateDir);
+		const manager = new GoalManager(store, undefined, stateDir);
+
+		store.put(makeGoal("archive-goal"));
+		const archiveDir = seedDiagnostics(stateDir, "archive-goal");
+		assert.equal(fs.existsSync(archiveDir), true);
+		assert.equal(await manager.archiveGoal("archive-goal"), true);
+		assert.equal(fs.existsSync(archiveDir), false, "archive should remove goal diagnostics");
+
+		store.put(makeGoal("delete-goal"));
+		const deleteDir = seedDiagnostics(stateDir, "delete-goal");
+		assert.equal(fs.existsSync(deleteDir), true);
+		assert.equal(await manager.deleteGoal("delete-goal"), true);
+		assert.equal(fs.existsSync(deleteDir), false, "hard delete should remove goal diagnostics");
+	} finally {
+		fs.rmSync(tmp, { recursive: true, force: true });
+	}
+});

--- a/tests/gate-diagnostics.test.ts
+++ b/tests/gate-diagnostics.test.ts
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { finalizeGateStepDiagnostics, prepareGateStepDiagnosticsPaths } from "../src/server/gate-diagnostics.ts";
+
+function makeTempDir(prefix: string): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function tryCreateDirectorySymlink(target: string, linkPath: string): boolean {
+	try {
+		fs.symlinkSync(target, linkPath, process.platform === "win32" ? "junction" : "dir");
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function makeDiagnosticsPaths(stateDir: string) {
+	return prepareGateStepDiagnosticsPaths({
+		stateDir,
+		goalId: "goal-symlink-test",
+		gateId: "gate-a",
+		signalId: `signal-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+		stepIndex: 0,
+		stepName: "playwright artifacts",
+	});
+}
+
+test("retained artifact copy rejects a symlinked artifact root", (t) => {
+	const tmp = makeTempDir("bobbit-gate-diagnostics-symlink-root-");
+	try {
+		const cwd = path.join(tmp, "cwd");
+		const outsideResults = path.join(tmp, "outside", "test-results", "case");
+		fs.mkdirSync(cwd, { recursive: true });
+		fs.mkdirSync(outsideResults, { recursive: true });
+		fs.writeFileSync(path.join(outsideResults, "error-context.md"), "LEAKED_SYMLINK_ROOT_MARKER", "utf8");
+		if (!tryCreateDirectorySymlink(path.join(tmp, "outside", "test-results"), path.join(cwd, "test-results"))) {
+			t.skip("directory symlinks are unavailable on this platform");
+			return;
+		}
+
+		const paths = makeDiagnosticsPaths(path.join(tmp, "state"));
+		const diagnostics = finalizeGateStepDiagnostics({ paths, commandCwd: cwd });
+
+		assert.equal(diagnostics.artifacts, undefined, "symlinked artifact roots must not be retained");
+		assert.equal(fs.existsSync(path.join(paths.artifactsDir, "test-results", "case", "error-context.md")), false);
+	} finally {
+		fs.rmSync(tmp, { recursive: true, force: true });
+	}
+});
+
+test("retained artifact copy skips symlinked descendants without losing normal Playwright artifacts", (t) => {
+	const tmp = makeTempDir("bobbit-gate-diagnostics-symlink-descendant-");
+	try {
+		const cwd = path.join(tmp, "cwd");
+		const legitCase = path.join(cwd, "test-results", "legit-case");
+		const outsideCase = path.join(tmp, "outside-case");
+		fs.mkdirSync(legitCase, { recursive: true });
+		fs.mkdirSync(outsideCase, { recursive: true });
+		fs.writeFileSync(path.join(legitCase, "error-context.md"), "LEGIT_ERROR_CONTEXT_MARKER", "utf8");
+		fs.writeFileSync(path.join(outsideCase, "error-context.md"), "LEAKED_SYMLINK_DESCENDANT_MARKER", "utf8");
+		if (!tryCreateDirectorySymlink(outsideCase, path.join(cwd, "test-results", "linked-case"))) {
+			t.skip("directory symlinks are unavailable on this platform");
+			return;
+		}
+
+		const paths = makeDiagnosticsPaths(path.join(tmp, "state"));
+		const diagnostics = finalizeGateStepDiagnostics({ paths, commandCwd: cwd });
+		const artifacts = diagnostics.artifacts ?? [];
+		const artifactJson = JSON.stringify(artifacts);
+
+		assert.match(artifactJson, /LEGIT_ERROR_CONTEXT_MARKER/, "normal Playwright artifacts should still be retained");
+		assert.doesNotMatch(artifactJson, /LEAKED_SYMLINK_DESCENDANT_MARKER/, "symlink descendants must not be traversed");
+		assert.equal(fs.existsSync(path.join(paths.artifactsDir, "test-results", "linked-case", "error-context.md")), false);
+		assert.equal(fs.existsSync(path.join(paths.artifactsDir, "test-results", "legit-case", "error-context.md")), true);
+	} finally {
+		fs.rmSync(tmp, { recursive: true, force: true });
+	}
+});

--- a/tests/gate-verification-snapshot.test.ts
+++ b/tests/gate-verification-snapshot.test.ts
@@ -85,6 +85,52 @@ function makeMultiStepSnapshot(stepName?: string, selectionOptions?: Parameters<
 	});
 }
 
+function makeDiagnosticsSnapshot(selectionOptions?: Parameters<typeof buildGateVerificationSnapshot>[0]["selectionOptions"]) {
+	const dir = makeTempDir();
+	const stdoutPath = path.join(dir, "stdout.log");
+	const stderrPath = path.join(dir, "stderr.log");
+	const artifactPath = path.join(dir, "artifacts", "test-results", "case", "error-context.md");
+	fs.mkdirSync(path.dirname(artifactPath), { recursive: true });
+	fs.writeFileSync(stdoutPath, "retained stdout marker\n", "utf8");
+	fs.writeFileSync(stderrPath, "retained stderr marker\n", "utf8");
+	fs.writeFileSync(artifactPath, "# Error Context\nretained artifact marker\n", "utf8");
+
+	return buildGateVerificationSnapshot({
+		goalId: "goal-1",
+		gateId: "gate-1",
+		signalId: "signal-1",
+		verification: {
+			status: "failed",
+			steps: [{
+				name: "playwright command",
+				type: "command",
+				status: "failed",
+				passed: false,
+				output: "compact failure tail only",
+				duration_ms: 7,
+				diagnostics: {
+					type: "retained-command-diagnostics",
+					baseDir: dir,
+					stdout: { path: stdoutPath, bytes: fs.statSync(stdoutPath).size, lines: 1 },
+					stderr: { path: stderrPath, bytes: fs.statSync(stderrPath).size, lines: 1 },
+					artifacts: [{
+						path: artifactPath,
+						relativePath: "test-results/case/error-context.md",
+						sourcePath: path.join(dir, "source", "test-results", "case", "error-context.md"),
+						bytes: fs.statSync(artifactPath).size,
+						kind: "test-results",
+						content: "# Error Context\nretained artifact marker\n",
+						contentType: "text/markdown",
+					}],
+					createdAt: 1,
+				},
+			}],
+		},
+		selectionOptions,
+		now: 100,
+	});
+}
+
 describe("gate verification per-step (stepName) filter", () => {
 	it("returns the full step array when stepName is omitted", () => {
 		const snapshot = makeMultiStepSnapshot();
@@ -136,6 +182,29 @@ describe("gate verification per-step (stepName) filter", () => {
 		assert.doesNotMatch(step.output ?? "", /build-out-5\b/);
 		assert.equal(step.selection?.mode, "slice");
 		assert.deepEqual(step.selection?.range, { from: 2, to: 4 });
+	});
+});
+
+describe("gate verification retained diagnostics compactness", () => {
+	it("keeps implicit/default snapshots compact while preserving explicit diagnostics access", () => {
+		const compact = makeDiagnosticsSnapshot({ implicitDefault: true });
+		const compactStep = compact.steps[0];
+		const compactJson = JSON.stringify(compactStep);
+
+		assert.equal(compactStep.output, "compact failure tail only");
+		assert.doesNotMatch(compactJson, /stdout\.log|stderr\.log|error-context\.md|retained artifact marker/);
+		assert.equal(compactStep.diagnostics?.logs, undefined, "default status snapshots must not expose retained log paths");
+		assert.equal(compactStep.diagnostics?.artifacts?.files, undefined, "default status snapshots must not expose retained artifact file lists");
+
+		const explicit = makeDiagnosticsSnapshot({ mode: "full" });
+		const explicitStep = explicit.steps[0];
+		const explicitJson = JSON.stringify(explicitStep);
+
+		assert.match(explicitStep.output ?? "", /retained stdout marker/);
+		assert.match(explicitStep.output ?? "", /retained stderr marker/);
+		assert.match(explicitJson, /stdout\.log/);
+		assert.match(explicitJson, /error-context\.md/);
+		assert.match(explicitJson, /retained artifact marker/);
 	});
 });
 


### PR DESCRIPTION
## Summary

- Retain failed gate command stdout/stderr under Bobbit state for explicit gate inspection across restarts and worktree cleanup.
- Preserve Playwright-style artifacts, including error contexts, traces, screenshots, and reports, with symlink-hardened copying and archive/delete cleanup.
- Keep gate status/default inspection compact while adding explicit retained-log metadata, caps, and team-lead/tool documentation.

## Validation

- npm run check
- npx tsx --test tests/gate-verification-snapshot.test.ts
- npx tsx --test tests/gate-diagnostics.test.ts tests/gate-verification-snapshot.test.ts tests/gate-diagnostics-cleanup.test.ts
- npm run test:e2e -- tests/e2e/gate-inspect-slicing.spec.ts
- npm run test:e2e -- tests/e2e/gate-diagnostics-cleanup.spec.ts
- npx tsx --test tests/tool-description-budget.test.ts
- npx tsx --test tests/agents-md-budget.test.ts

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)