### PR TITLE
Fix Search Titles

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1583,11 +1583,12 @@ The search flush-on-close path is **fully awaitable** end to end. This matters b
 - **`ProjectContextManager.closeAll()`** (`project-context-manager.ts`) is `async` and `await`s `Promise.allSettled(...)` over every context's `close()` before clearing the map. `remove(projectId)` stays fire-and-forget (`void ctx.close().catch(...)`) on purpose — it runs during normal operation, not teardown, so it must not block but must not throw.
 - **`server.ts` shutdown** `await`s `projectContextManager.closeAll()`.
 
-`SearchService.close()` (`search-service.ts`) coordinates with two async paths: a possibly in-flight `open()` and an already-fired startup/background rebuild. Without the open guard, `_doOpen()` could resume *after* `close()` returned and re-establish the store, indexer, and rebuild timer — leaking live search resources past shutdown. Without rebuild tracking, a timer callback that already passed its closed-state guard could keep using the FlexSearch store while close closes it, surfacing `FlexSearchStore: already closed`. The shutdown guards are:
+`SearchService.close()` (`search-service.ts`) coordinates with three async paths: a possibly in-flight `open()`, an already-fired startup/background rebuild, and fire-and-forget mutation tasks. Without the open guard, `_doOpen()` could resume *after* `close()` returned and re-establish the store, indexer, and rebuild timer — leaking live search resources past shutdown. Without rebuild or mutation tracking, background work could keep using the FlexSearch store while close closes it, surfacing `FlexSearchStore: already closed` or allowing stale title metadata writes to finish after shutdown. The shutdown guards are:
 
 1. `close()` first `await`s any in-flight `_openPromise`, then sets `_state = "closed"` and clears the startup `_rebuildTimer`.
 2. `_doOpen()` re-checks `_state` after the `FlexSearchStore.open()` await *and* after the meta-read awaits. If state went `"closed"` mid-open it `await store.close()` and returns **without** assigning `_store`/`_indexer`, scheduling the rebuild timer, or flipping to `"ready"`.
 3. The startup rebuild timer is `unref()`'d and cancelled on close; its callback also re-checks `_state === "closed" || !_indexer` before rebuilding. Once a rebuild starts, the callback stores `_backgroundRebuildPromise`, and `close()` awaits it before re-reading `_store`, closing it, and nulling `_indexer`.
+4. All mutation helpers go through `_scheduleMutation()`. `close()` waits for the tracked mutation set to settle before closing the store, and compound message reindexes are serialized per parent session so an older delete-and-reinsert cannot overwrite newer `sessionTitle` metadata.
 
 `FlexSearchStore` (`flex-store.ts`) is the belt-and-braces layer for any flush that still loses the race (a debounced timer or concurrent project-delete):
 
@@ -1606,6 +1607,17 @@ The surface in `src/server/search/types.ts` that downstream code sees is unchang
 
 `SearchService` (`search-service.ts`) is the per-project facade that bundles `FlexSearchStore`, `Indexer`, and the source array. `ProjectContext` constructs and owns one per project. No embedder component exists.
 
+### Search result titles
+
+Full search title rendering is driven by resolved search metadata, not client-side guesses. This matters because message hits are indexed as standalone rows; when a message-only result is restored after a rebuild or arrives without a direct session hit beside it, the UI still needs authoritative parent-session context.
+
+- `SessionIndexSource`, `MessageIndexSource`, and live `SearchService.indexMessage()` calls all use the same session-title formatter before writing rows.
+- Message rows carry the resolved parent session title in `metadata.sessionTitle`; `indexableToDoc()` stores it as `session_title`, and `toSearchResult()` returns it as `SearchResult.sessionTitle`.
+- The full search page groups message hits under their parent session and uses that resolved `sessionTitle` for both message-only session cards and nested message rows. It should not fall back to the raw message row title for message context.
+- Goal-owned sessions render as `<Goal title>: <Session title>`. The formatter avoids duplicating the goal when the session title already contains the goal title as a standalone phrase, after trimming, whitespace normalization, and case-folding.
+- Goal title, session title, and session goal-ownership changes must refresh dependent message rows as well as the session row. Project context update hooks reindex the session row and call `reindexMessagesForSession()` for affected sessions; the message content hash includes the resolved display title so metadata-only title changes are not skipped as unchanged content.
+- Full rebuilds get the same behavior because sources rebuild from the goal and session stores, including archived sessions, instead of trying to reconstruct titles in the UI.
+
 ### Content policy (role-aware weighting)
 
 What gets indexed per message matters more than the store choice. `content-policy.ts` (replaces the old `message-extractor.ts`) extracts role-tagged entries with weights applied as post-rank multipliers:
@@ -1620,7 +1632,7 @@ What gets indexed per message matters more than the store choice. `content-polic
 | `tool_call` | 0.8 | `<tool_name> + first line of input` |
 | `tool_result` | 0.5 | first 500 chars; **hard-skipped if raw >32KB** (aligns with `truncate-large-content.ts`) |
 
-Bump `CONTENT_POLICY_VERSION` when the policy changes - the meta-mismatch check auto-rebuilds. Weights are tunable server-side without re-indexing the content itself.
+Bump `CONTENT_POLICY_VERSION` when the policy changes - the meta-mismatch check auto-rebuilds. Treat derived display metadata as part of the content policy: if existing rows would keep stale titles, goal prefixes, snippets, roles, weights, or other rendered metadata after a code change, bump the version so the index is safely rebuilt from authoritative stores. Weights are tunable server-side without changing user data, but any persisted ranking/display semantics that old rows cannot self-correct must force a rebuild.
 
 ### Chunking
 

--- a/src/app/search-page.ts
+++ b/src/app/search-page.ts
@@ -265,14 +265,17 @@ export function buildGroups(filtered: SearchResultItem[]): ResultGroup[] {
 				if (!hit.sessionId) continue;
 				const key = `session:${hit.sessionId}`;
 				const g = ensureGroup(key, "session");
+				const sessionTitle = hit.sessionTitle?.trim();
 				if (!g.parent && !g.parentFallback) {
 					g.parentFallback = {
 						id: hit.sessionId,
-						title: hit.sessionTitle ?? "Untitled session",
+						title: sessionTitle || "Untitled session",
 						archived: hit.archived ?? false,
 						timestamp: hit.timestamp ?? 0,
 						projectId: hit.projectId,
 					};
+				} else if (!g.parent && g.parentFallback && sessionTitle && /^Untitled(?: session)?$/i.test(g.parentFallback.title)) {
+					g.parentFallback.title = sessionTitle;
 				}
 				g.children.push(hit);
 				g.matchCount.messages++;
@@ -385,9 +388,9 @@ export function resetSearchPage(): void {
 // RENDER — child (nested) rows
 // ============================================================================
 
-function _renderChildRow(result: SearchResultItem) {
+function _renderChildRow(result: SearchResultItem, sessionTitleContext?: string) {
 	const title = result.type === "message"
-		? (result.sessionTitle || result.title)
+		? (sessionTitleContext || result.sessionTitle || result.title)
 		: result.title;
 	const isStale = _staleIds.has(result.id) || (result.sessionId ? _staleIds.has(result.sessionId) : false);
 
@@ -498,6 +501,9 @@ function _renderGroupCard(group: ResultGroup) {
 		renderApp();
 	};
 
+	const childSessionTitleContext = group.kind === "session"
+		? (parent?.title || fallback?.title || undefined)
+		: undefined;
 	const fragments = expanded ? [] : _collapsedSnippetFragments(group);
 	// Only render the muted "matched on title/metadata" note in the header
 	// when the card is *collapsed* — the expanded body renders its own copy,
@@ -566,7 +572,7 @@ function _renderGroupCard(group: ResultGroup) {
 					` : ""}
 					${group.children.length > 0 ? html`
 						<div class="flex flex-col gap-0.5 border-l-2 border-border/50 ml-2 pl-1">
-							${group.children.map(c => _renderChildRow(c))}
+							${group.children.map(c => _renderChildRow(c, childSessionTitleContext))}
 						</div>
 					` : ""}
 				</div>

--- a/src/server/agent/project-context.ts
+++ b/src/server/agent/project-context.ts
@@ -132,6 +132,7 @@ export class ProjectContext {
     this.sessionStore.onIndexUpdate = (session) => {
       const goalTitle = session.goalId ? this.goalStore.get(session.goalId)?.title : undefined;
       this.searchIndex.indexSession(session, goalTitle, this.project.id);
+      this.searchIndex.reindexMessagesForSession(session, goalTitle, this.project.id);
     };
     // Re-apply any dispatcher wiring in case `setGoalTriggerDispatcher`
     // was called before `open()` (current call order is reverse, but the

--- a/src/server/agent/project-context.ts
+++ b/src/server/agent/project-context.ts
@@ -123,6 +123,11 @@ export class ProjectContext {
     // `onGoalCreated` / `onGoalArchived` channels wired below.
     this.goalStore.onIndexUpdate = (goal) => {
       this.searchIndex.indexGoal(goal, this.project.id);
+      for (const session of this.sessionStore.getAll()) {
+        if (session.goalId !== goal.id) continue;
+        this.searchIndex.indexSession(session, goal.title, this.project.id);
+        this.searchIndex.reindexMessagesForSession(session, goal.title, this.project.id);
+      }
     };
     this.sessionStore.onIndexUpdate = (session) => {
       const goalTitle = session.goalId ? this.goalStore.get(session.goalId)?.title : undefined;

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -2798,6 +2798,7 @@ export class SessionManager {
 		// emits one row per text / tool_use / tool_result block.
 		if (event.type === "message_end" && event.message) {
 			try {
+				const goalTitle = session.goalId ? this.resolveGoal(session.goalId)?.title : undefined;
 				this.resolveSearchIndex(session).indexMessage({
 					sessionId: session.id,
 					sessionTitle: session.title,
@@ -2805,6 +2806,7 @@ export class SessionManager {
 					timestamp: Date.now(),
 					projectId: session.projectId || undefined,
 					goalId: session.goalId,
+					goalTitle,
 				});
 			} catch {
 				// Non-critical — don't break message flow

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -3426,7 +3426,14 @@ export class SessionManager {
 				testSearchIndex.open({ goalStore, sessionStore: this._testStore });
 				// Wire index update callbacks
 				goalStore.onIndexUpdate = (goal) => {
-					try { testSearchIndex.indexGoal(goal, goal.projectId || ""); } catch (err) { console.error("[search] Failed to index goal:", err); }
+					try {
+						testSearchIndex.indexGoal(goal, goal.projectId || "");
+						for (const session of this._testStore?.getAll() ?? []) {
+							if (session.goalId !== goal.id) continue;
+							testSearchIndex.indexSession(session, goal.title, session.projectId || "");
+							testSearchIndex.reindexMessagesForSession(session, goal.title, session.projectId || "");
+						}
+					} catch (err) { console.error("[search] Failed to index goal:", err); }
 				};
 				this._testStore.onIndexUpdate = (session) => {
 					try {

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -3439,6 +3439,7 @@ export class SessionManager {
 					try {
 						const goalTitle = session.goalId ? this.resolveGoal(session.goalId)?.title : undefined;
 						testSearchIndex.indexSession(session, goalTitle, session.projectId || "");
+						testSearchIndex.reindexMessagesForSession(session, goalTitle, session.projectId || "");
 					} catch (err) { console.error("[search] Failed to index session:", err); }
 				};
 			} catch (err) {

--- a/src/server/search/content-policy.ts
+++ b/src/server/search/content-policy.ts
@@ -20,7 +20,7 @@ import type { Role } from "./types.js";
  * text gets indexed or how it is weighted. A version mismatch in
  * `search_meta` triggers a full rebuild on next open (see §10).
  */
-export const CONTENT_POLICY_VERSION = 2;
+export const CONTENT_POLICY_VERSION = 3;
 
 // ── Constants ────────────────────────────────────────────────────────
 

--- a/src/server/search/content-policy.ts
+++ b/src/server/search/content-policy.ts
@@ -20,7 +20,7 @@ import type { Role } from "./types.js";
  * text gets indexed or how it is weighted. A version mismatch in
  * `search_meta` triggers a full rebuild on next open (see §10).
  */
-export const CONTENT_POLICY_VERSION = 1;
+export const CONTENT_POLICY_VERSION = 2;
 
 // ── Constants ────────────────────────────────────────────────────────
 

--- a/src/server/search/search-service.ts
+++ b/src/server/search/search-service.ts
@@ -19,7 +19,7 @@ import * as path from "node:path";
 import type { PersistedGoal, GoalStore } from "../agent/goal-store.js";
 import type { PersistedSession, SessionStore } from "../agent/session-store.js";
 import type { PersistedStaff, StaffStore } from "../agent/staff-store.js";
-import type { IndexSource, IndexSourceContext, SearchResults } from "./types.js";
+import type { Indexable, IndexSource, IndexSourceContext, SearchResults } from "./types.js";
 import { FlexSearchStore, FLEX_VERSION } from "./flex-store.js";
 import { Indexer } from "./indexer.js";
 import { GoalIndexSource } from "./sources/goal-source.js";
@@ -292,6 +292,29 @@ export class SearchService {
 		this._indexer
 			.removeByFilter({ session_id: sessionId, source_id: "messages" })
 			.catch((err) => console.error("[search] removeMessagesForSession failed:", err));
+	}
+
+	reindexMessagesForSession(session: PersistedSession, goalTitle?: string, projectId?: string): void {
+		if (!this._indexer) return;
+		const indexer = this._indexer;
+		const pid = projectId ?? session.projectId ?? this.projectId;
+		const task = async () => {
+			await indexer.removeByFilter({ session_id: session.id, source_id: "messages" });
+			const goalStore = {
+				getAll: () => session.goalId ? [{ id: session.goalId, title: goalTitle ?? "" }] : [],
+			} as unknown as GoalStore;
+			const sessionStore = { getAll: () => [session] } as unknown as SessionStore;
+			const ctx: IndexSourceContext = {
+				projectId: pid,
+				goalStore,
+				sessionStore,
+				staffStore: emptyStaffStore(),
+			};
+			const entries: Indexable[] = [];
+			for await (const entry of this._messageSource.iterate(ctx)) entries.push(entry);
+			await indexer.upsertEntries(entries);
+		};
+		task().catch((err) => console.error("[search] reindexMessagesForSession failed:", err));
 	}
 
 	indexMessage(arg: {

--- a/src/server/search/search-service.ts
+++ b/src/server/search/search-service.ts
@@ -100,6 +100,13 @@ export class SearchService {
 	 */
 	private readonly _mutationTasks = new Set<Promise<void>>();
 
+	/**
+	 * Compound message mutations (`deleteWhere` + reinsert) must be serialized per
+	 * parent session. Otherwise rapid title/goal updates can complete out of order
+	 * and let an older reindex overwrite newer message `sessionTitle` metadata.
+	 */
+	private readonly _sessionMessageMutationChains = new Map<string, Promise<void>>();
+
 	private readonly _goalSource = new GoalIndexSource();
 	private readonly _sessionSource = new SessionIndexSource();
 	private readonly _messageSource = new MessageIndexSource();
@@ -293,21 +300,24 @@ export class SearchService {
 		const indexer = this._indexer;
 		this._scheduleMutation("removeMessagesForSession", indexer, () =>
 			indexer.removeByFilter({ session_id: sessionId, source_id: "messages" }),
+			this._messageMutationKey(sessionId),
 		);
 	}
 
 	reindexMessagesForSession(session: PersistedSession, goalTitle?: string, projectId?: string): void {
 		if (!this._indexer) return;
 		const indexer = this._indexer;
-		const pid = projectId ?? session.projectId ?? this.projectId;
+		const sessionSnapshot = { ...session };
+		const pid = projectId ?? sessionSnapshot.projectId ?? this.projectId;
+		const goalTitleSnapshot = goalTitle;
 		this._scheduleMutation("reindexMessagesForSession", indexer, async () => {
 			if ((this._state as SearchServiceState) === "closed" || this._indexer !== indexer) return;
-			await indexer.removeByFilter({ session_id: session.id, source_id: "messages" });
+			await indexer.removeByFilter({ session_id: sessionSnapshot.id, source_id: "messages" });
 			if ((this._state as SearchServiceState) === "closed" || this._indexer !== indexer) return;
 			const goalStore = {
-				getAll: () => session.goalId ? [{ id: session.goalId, title: goalTitle ?? "" }] : [],
+				getAll: () => sessionSnapshot.goalId ? [{ id: sessionSnapshot.goalId, title: goalTitleSnapshot ?? "" }] : [],
 			} as unknown as GoalStore;
-			const sessionStore = { getAll: () => [session] } as unknown as SessionStore;
+			const sessionStore = { getAll: () => [sessionSnapshot] } as unknown as SessionStore;
 			const ctx: IndexSourceContext = {
 				projectId: pid,
 				goalStore,
@@ -318,7 +328,7 @@ export class SearchService {
 			for await (const entry of this._messageSource.iterate(ctx)) entries.push(entry);
 			if ((this._state as SearchServiceState) === "closed" || this._indexer !== indexer) return;
 			await indexer.upsertEntries(entries);
-		});
+		}, this._messageMutationKey(sessionSnapshot.id));
 	}
 
 	indexMessage(arg: {
@@ -545,21 +555,39 @@ export class SearchService {
 		});
 	}
 
-	private _scheduleMutation(label: string, indexer: Indexer, task: () => Promise<void>): void {
+	private _scheduleMutation(
+		label: string,
+		indexer: Indexer,
+		task: () => Promise<void>,
+		serializeKey?: string,
+	): void {
 		if (this._state === "closed" || this._indexer !== indexer) return;
-		let tracked: Promise<void>;
-		tracked = (async () => {
+		const previous = serializeKey
+			? this._sessionMessageMutationChains.get(serializeKey) ?? Promise.resolve()
+			: Promise.resolve();
+		const run = async () => {
+			await previous.catch(() => undefined);
 			if (this._state === "closed" || this._indexer !== indexer) return;
 			await task();
-		})()
+		};
+		let tracked: Promise<void>;
+		tracked = run()
 			.catch((err) => {
 				if (this._state === "closed" && isStoreAlreadyClosedError(err)) return;
 				console.error(`[search] ${label} failed:`, err);
 			})
 			.finally(() => {
 				this._mutationTasks.delete(tracked);
+				if (serializeKey && this._sessionMessageMutationChains.get(serializeKey) === tracked) {
+					this._sessionMessageMutationChains.delete(serializeKey);
+				}
 			});
+		if (serializeKey) this._sessionMessageMutationChains.set(serializeKey, tracked);
 		this._mutationTasks.add(tracked);
+	}
+
+	private _messageMutationKey(sessionId: string): string {
+		return `messages:${sessionId}`;
 	}
 
 	private async _waitForMutationTasks(): Promise<void> {

--- a/src/server/search/search-service.ts
+++ b/src/server/search/search-service.ts
@@ -27,6 +27,7 @@ import { SessionIndexSource } from "./sources/session-source.js";
 import { MessageIndexSource } from "./sources/message-source.js";
 import { StaffIndexSource } from "./sources/staff-source.js";
 import { contentHashOf } from "./sources/hash.js";
+import { formatSessionSearchTitle } from "./sources/session-title.js";
 import { progressBus as sharedProgressBus, type ProgressBus } from "./progress-bus.js";
 import { needsRebuild as metaNeedsRebuild, buildCurrentMeta } from "./meta.js";
 import { CONTENT_POLICY_VERSION, extractForIndexing } from "./content-policy.js";
@@ -253,6 +254,7 @@ export class SearchService {
 		const weight = 3.0;
 		const role = "title" as const;
 		const timestamp = session.createdAt ?? session.lastActivity ?? 0;
+		const displayTitle = formatSessionSearchTitle(title, goalTitle);
 		const metadata: Record<string, string | number | boolean> = { sessionId: session.id };
 		if (session.goalId) metadata.goalId = session.goalId;
 		if (goalTitle) metadata.goalTitle = goalTitle;
@@ -264,13 +266,13 @@ export class SearchService {
 					sourceId: "sessions",
 					text: title,
 					metadata,
-					contentHash: contentHashOf(title, weight, role, timestamp),
+					contentHash: contentHashOf(`${title}\n${displayTitle}`, weight, role, timestamp),
 					timestamp,
 					projectId: pid,
 					archived: session.archived === true,
 					weight,
 					role,
-					display: { title, snippet: title },
+					display: { title: displayTitle, snippet: displayTitle },
 				},
 			])
 			.catch((err) => console.error("[search] indexSession failed:", err));
@@ -300,6 +302,7 @@ export class SearchService {
 		projectId?: string;
 		msgIdx?: number;
 		goalId?: string;
+		goalTitle?: string;
 	}): void;
 	indexMessage(
 		sessionId: string,
@@ -320,6 +323,7 @@ export class SearchService {
 					projectId?: string;
 					msgIdx?: number;
 					goalId?: string;
+					goalTitle?: string;
 			  },
 		sessionTitle?: string,
 		text?: string,
@@ -332,7 +336,7 @@ export class SearchService {
 
 		if (typeof arg1 === "string") {
 			const sessionId = arg1;
-			const title = sessionTitle ?? "";
+			const title = (sessionTitle ?? "").trim();
 			const ts = timestamp ?? 0;
 			const pid = projectId ?? this.projectId;
 			const body = (text ?? "").trim();
@@ -345,8 +349,12 @@ export class SearchService {
 						id: `message:${sessionId}:legacy:${ts}`,
 						sourceId: "messages",
 						text: body,
-						metadata: { sessionId, blockKey: "legacy:0" },
-						contentHash: contentHashOf(body, weight, role, ts),
+						metadata: {
+							sessionId,
+							blockKey: "legacy:0",
+							...(title ? { sessionTitle: title } : {}),
+						},
+						contentHash: contentHashOf(`${body}\n${title}`, weight, role, ts),
 						timestamp: ts,
 						projectId: pid,
 						archived: false,
@@ -359,7 +367,8 @@ export class SearchService {
 			return;
 		}
 
-		const { sessionId, sessionTitle: st, message, timestamp: ts, projectId: pid, msgIdx, goalId } = arg1;
+		const { sessionId, sessionTitle: st, message, timestamp: ts, projectId: pid, msgIdx, goalId, goalTitle } = arg1;
+		const displayTitle = formatSessionSearchTitle(st, goalTitle);
 		const hit = extractForIndexing(message);
 		if (hit.entries.length === 0) return;
 		const resolvedProjectId = pid ?? this.projectId;
@@ -373,14 +382,16 @@ export class SearchService {
 				msgIdx: idx,
 				blockKey: entry.blockKey,
 				...(goalId ? { goalId } : {}),
+				...(goalTitle ? { goalTitle } : {}),
+				...(displayTitle ? { sessionTitle: displayTitle } : {}),
 			},
-			contentHash: contentHashOf(entry.text, entry.weight, entry.role, ts),
+			contentHash: contentHashOf(`${entry.text}\n${displayTitle}`, entry.weight, entry.role, ts),
 			timestamp: ts,
 			projectId: resolvedProjectId,
 			archived: false,
 			weight: entry.weight,
 			role: entry.role,
-			display: { title: st },
+			display: { title: displayTitle },
 		}));
 		indexer
 			.upsertEntries(indexables)

--- a/src/server/search/search-service.ts
+++ b/src/server/search/search-service.ts
@@ -93,6 +93,13 @@ export class SearchService {
 	 */
 	private _backgroundRebuildPromise: Promise<void> | null = null;
 
+	/**
+	 * Fire-and-forget index mutations currently using the store. `close()` marks
+	 * the service closed to block new work, then waits for this set before closing
+	 * the underlying store so teardown cannot race into `FlexSearchStore: already closed`.
+	 */
+	private readonly _mutationTasks = new Set<Promise<void>>();
+
 	private readonly _goalSource = new GoalIndexSource();
 	private readonly _sessionSource = new SessionIndexSource();
 	private readonly _messageSource = new MessageIndexSource();
@@ -197,6 +204,7 @@ export class SearchService {
 		if (this._backgroundRebuildPromise) {
 			try { await this._backgroundRebuildPromise; } catch { /* handled by owner */ }
 		}
+		await this._waitForMutationTasks();
 		// Re-read _store after the await — _doOpen() may have just assigned it.
 		if (this._store) {
 			try { await this._store.close(); }
@@ -219,30 +227,27 @@ export class SearchService {
 		const weight = 2.5;
 		const role = "spec" as const;
 		const timestamp = goal.updatedAt ?? goal.createdAt ?? 0;
-		indexer
-			.upsertEntries([
-				{
-					id: `goal:${goal.id}`,
-					sourceId: "goals",
-					text,
-					metadata: { goalId: goal.id, state: goal.state ?? "" },
-					contentHash: contentHashOf(text, weight, role, timestamp),
-					timestamp,
-					projectId: pid,
-					archived: goal.archived === true,
-					weight,
-					role,
-					display: { title, snippet: spec.slice(0, 300) },
-				},
-			])
-			.catch((err) => console.error("[search] indexGoal failed:", err));
+		this._scheduleMutation("indexGoal", indexer, () => indexer.upsertEntries([
+			{
+				id: `goal:${goal.id}`,
+				sourceId: "goals",
+				text,
+				metadata: { goalId: goal.id, state: goal.state ?? "" },
+				contentHash: contentHashOf(text, weight, role, timestamp),
+				timestamp,
+				projectId: pid,
+				archived: goal.archived === true,
+				weight,
+				role,
+				display: { title, snippet: spec.slice(0, 300) },
+			},
+		]));
 	}
 
 	removeGoal(goalId: string): void {
 		if (!this._indexer) return;
-		this._indexer
-			.removeEntries([`goal:${goalId}`])
-			.catch((err) => console.error("[search] removeGoal failed:", err));
+		const indexer = this._indexer;
+		this._scheduleMutation("removeGoal", indexer, () => indexer.removeEntries([`goal:${goalId}`]));
 	}
 
 	indexSession(session: PersistedSession, goalTitle?: string, projectId?: string): void {
@@ -259,47 +264,46 @@ export class SearchService {
 		if (session.goalId) metadata.goalId = session.goalId;
 		if (goalTitle) metadata.goalTitle = goalTitle;
 		if (session.role) metadata.agentRole = session.role;
-		indexer
-			.upsertEntries([
-				{
-					id: `session:${session.id}`,
-					sourceId: "sessions",
-					text: title,
-					metadata,
-					contentHash: contentHashOf(`${title}\n${displayTitle}`, weight, role, timestamp),
-					timestamp,
-					projectId: pid,
-					archived: session.archived === true,
-					weight,
-					role,
-					display: { title: displayTitle, snippet: displayTitle },
-				},
-			])
-			.catch((err) => console.error("[search] indexSession failed:", err));
+		this._scheduleMutation("indexSession", indexer, () => indexer.upsertEntries([
+			{
+				id: `session:${session.id}`,
+				sourceId: "sessions",
+				text: title,
+				metadata,
+				contentHash: contentHashOf(`${title}\n${displayTitle}`, weight, role, timestamp),
+				timestamp,
+				projectId: pid,
+				archived: session.archived === true,
+				weight,
+				role,
+				display: { title: displayTitle, snippet: displayTitle },
+			},
+		]));
 	}
 
 	removeSession(sessionId: string): void {
 		if (!this._indexer) return;
 		const indexer = this._indexer;
-		indexer.removeEntries([`session:${sessionId}`]).catch((err) =>
-			console.error("[search] removeSession failed:", err),
-		);
+		this._scheduleMutation("removeSession", indexer, () => indexer.removeEntries([`session:${sessionId}`]));
 		this.removeMessagesForSession(sessionId);
 	}
 
 	removeMessagesForSession(sessionId: string): void {
 		if (!this._indexer) return;
-		this._indexer
-			.removeByFilter({ session_id: sessionId, source_id: "messages" })
-			.catch((err) => console.error("[search] removeMessagesForSession failed:", err));
+		const indexer = this._indexer;
+		this._scheduleMutation("removeMessagesForSession", indexer, () =>
+			indexer.removeByFilter({ session_id: sessionId, source_id: "messages" }),
+		);
 	}
 
 	reindexMessagesForSession(session: PersistedSession, goalTitle?: string, projectId?: string): void {
 		if (!this._indexer) return;
 		const indexer = this._indexer;
 		const pid = projectId ?? session.projectId ?? this.projectId;
-		const task = async () => {
+		this._scheduleMutation("reindexMessagesForSession", indexer, async () => {
+			if ((this._state as SearchServiceState) === "closed" || this._indexer !== indexer) return;
 			await indexer.removeByFilter({ session_id: session.id, source_id: "messages" });
+			if ((this._state as SearchServiceState) === "closed" || this._indexer !== indexer) return;
 			const goalStore = {
 				getAll: () => session.goalId ? [{ id: session.goalId, title: goalTitle ?? "" }] : [],
 			} as unknown as GoalStore;
@@ -312,9 +316,9 @@ export class SearchService {
 			};
 			const entries: Indexable[] = [];
 			for await (const entry of this._messageSource.iterate(ctx)) entries.push(entry);
+			if ((this._state as SearchServiceState) === "closed" || this._indexer !== indexer) return;
 			await indexer.upsertEntries(entries);
-		};
-		task().catch((err) => console.error("[search] reindexMessagesForSession failed:", err));
+		});
 	}
 
 	indexMessage(arg: {
@@ -366,27 +370,25 @@ export class SearchService {
 			if (!body) return;
 			const weight = 1.0;
 			const role = "assistant" as const;
-			indexer
-				.upsertEntries([
-					{
-						id: `message:${sessionId}:legacy:${ts}`,
-						sourceId: "messages",
-						text: body,
-						metadata: {
-							sessionId,
-							blockKey: "legacy:0",
-							...(title ? { sessionTitle: title } : {}),
-						},
-						contentHash: contentHashOf(`${body}\n${title}`, weight, role, ts),
-						timestamp: ts,
-						projectId: pid,
-						archived: false,
-						weight,
-						role,
-						display: { title },
+			this._scheduleMutation("indexMessage", indexer, () => indexer.upsertEntries([
+				{
+					id: `message:${sessionId}:legacy:${ts}`,
+					sourceId: "messages",
+					text: body,
+					metadata: {
+						sessionId,
+						blockKey: "legacy:0",
+						...(title ? { sessionTitle: title } : {}),
 					},
-				])
-				.catch((err) => console.error("[search] indexMessage failed:", err));
+					contentHash: contentHashOf(`${body}\n${title}`, weight, role, ts),
+					timestamp: ts,
+					projectId: pid,
+					archived: false,
+					weight,
+					role,
+					display: { title },
+				},
+			]));
 			return;
 		}
 
@@ -416,9 +418,7 @@ export class SearchService {
 			role: entry.role,
 			display: { title: displayTitle },
 		}));
-		indexer
-			.upsertEntries(indexables)
-			.catch((err) => console.error("[search] indexMessage failed:", err));
+		this._scheduleMutation("indexMessage", indexer, () => indexer.upsertEntries(indexables));
 	}
 
 	indexStaff(staff: PersistedStaff, projectId?: string): void {
@@ -437,30 +437,27 @@ export class SearchService {
 			state: staff.state ?? "",
 		};
 		if (staff.roleId) metadata.roleId = staff.roleId;
-		indexer
-			.upsertEntries([
-				{
-					id: `staff:${staff.id}`,
-					sourceId: "staff",
-					text,
-					metadata,
-					contentHash: contentHashOf(text, weight, role, timestamp),
-					timestamp,
-					projectId: pid,
-					archived: false,
-					weight,
-					role,
-					display: { title: name, snippet: description.slice(0, 300) },
-				},
-			])
-			.catch((err) => console.error("[search] indexStaff failed:", err));
+		this._scheduleMutation("indexStaff", indexer, () => indexer.upsertEntries([
+			{
+				id: `staff:${staff.id}`,
+				sourceId: "staff",
+				text,
+				metadata,
+				contentHash: contentHashOf(text, weight, role, timestamp),
+				timestamp,
+				projectId: pid,
+				archived: false,
+				weight,
+				role,
+				display: { title: name, snippet: description.slice(0, 300) },
+			},
+		]));
 	}
 
 	removeStaff(staffId: string): void {
 		if (!this._indexer) return;
-		this._indexer
-			.removeEntries([`staff:${staffId}`])
-			.catch((err) => console.error("[search] removeStaff failed:", err));
+		const indexer = this._indexer;
+		this._scheduleMutation("removeStaff", indexer, () => indexer.removeEntries([`staff:${staffId}`]));
 	}
 
 	// ── Public API — search ──────────────────────────────────────────
@@ -546,6 +543,29 @@ export class SearchService {
 			if (this._state === "closed" || this._indexer !== indexer) return Promise.resolve();
 			return indexer.rebuildFromSources(srcs, ctx);
 		});
+	}
+
+	private _scheduleMutation(label: string, indexer: Indexer, task: () => Promise<void>): void {
+		if (this._state === "closed" || this._indexer !== indexer) return;
+		let tracked: Promise<void>;
+		tracked = (async () => {
+			if (this._state === "closed" || this._indexer !== indexer) return;
+			await task();
+		})()
+			.catch((err) => {
+				if (this._state === "closed" && isStoreAlreadyClosedError(err)) return;
+				console.error(`[search] ${label} failed:`, err);
+			})
+			.finally(() => {
+				this._mutationTasks.delete(tracked);
+			});
+		this._mutationTasks.add(tracked);
+	}
+
+	private async _waitForMutationTasks(): Promise<void> {
+		while (this._mutationTasks.size > 0) {
+			await Promise.allSettled([...this._mutationTasks]);
+		}
 	}
 
 	// ── Internals ────────────────────────────────────────────────────

--- a/src/server/search/sources/message-source.ts
+++ b/src/server/search/sources/message-source.ts
@@ -20,12 +20,18 @@ import * as readline from "node:readline";
 import type { IndexSource, IndexSourceContext, Indexable } from "../types.js";
 import { extractForIndexing } from "../content-policy.js";
 import { contentHashOf } from "./hash.js";
+import { formatSessionSearchTitle } from "./session-title.js";
 
 export class MessageIndexSource implements IndexSource {
 	readonly sourceId = "messages" as const;
 
 	async *iterate(ctx: IndexSourceContext): AsyncIterable<Indexable> {
 		const sessions = ctx.sessionStore.getAll();
+		const goalTitleMap = new Map<string, string>();
+		for (const g of ctx.goalStore.getAll()) {
+			goalTitleMap.set(g.id, g.title ?? "");
+		}
+
 		for (const session of sessions) {
 			const filePath = session.agentSessionFile;
 			if (!filePath) continue;
@@ -43,6 +49,12 @@ export class MessageIndexSource implements IndexSource {
 			} catch {
 				continue;
 			}
+
+			const sessionTitle = (session.title ?? "").trim();
+			const goalTitle = session.goalId
+				? goalTitleMap.get(session.goalId) ?? ""
+				: "";
+			const displayTitle = formatSessionSearchTitle(sessionTitle, goalTitle);
 
 			const rl = readline.createInterface({
 				input: stream,
@@ -80,18 +92,21 @@ export class MessageIndexSource implements IndexSource {
 					const hit = extractForIndexing(msg);
 					for (const entry of hit.entries) {
 						const id = `message:${session.id}:${msgIdx}:${entry.blockKey}`;
+						const metadata: Record<string, string | number | boolean> = {
+							sessionId: session.id,
+							msgIdx,
+							blockKey: entry.blockKey,
+							...(session.goalId ? { goalId: session.goalId } : {}),
+						};
+						if (goalTitle) metadata.goalTitle = goalTitle;
+						if (displayTitle) metadata.sessionTitle = displayTitle;
 						const indexable: Indexable = {
 							id,
 							sourceId: "messages",
 							text: entry.text,
-							metadata: {
-								sessionId: session.id,
-								msgIdx,
-								blockKey: entry.blockKey,
-								...(session.goalId ? { goalId: session.goalId } : {}),
-							},
+							metadata,
 							contentHash: contentHashOf(
-								entry.text,
+								`${entry.text}\n${displayTitle}`,
 								entry.weight,
 								entry.role,
 								timestamp,
@@ -102,7 +117,7 @@ export class MessageIndexSource implements IndexSource {
 							weight: entry.weight,
 							role: entry.role,
 							display: {
-								title: session.title ?? "",
+								title: displayTitle,
 							},
 						};
 						yield indexable;

--- a/src/server/search/sources/session-source.ts
+++ b/src/server/search/sources/session-source.ts
@@ -15,6 +15,7 @@
 
 import type { IndexSource, IndexSourceContext, Indexable } from "../types.js";
 import { contentHashOf } from "./hash.js";
+import { formatSessionSearchTitle } from "./session-title.js";
 
 export class SessionIndexSource implements IndexSource {
 	readonly sourceId = "sessions" as const;
@@ -37,6 +38,7 @@ export class SessionIndexSource implements IndexSource {
 			const goalTitle = session.goalId
 				? goalTitleMap.get(session.goalId) ?? ""
 				: "";
+			const displayTitle = formatSessionSearchTitle(title, goalTitle);
 			const metadata: Record<string, string | number | boolean> = {
 				sessionId: session.id,
 			};
@@ -50,15 +52,15 @@ export class SessionIndexSource implements IndexSource {
 				sourceId: "sessions",
 				text,
 				metadata,
-				contentHash: contentHashOf(text, weight, role, timestamp),
+				contentHash: contentHashOf(`${text}\n${displayTitle}`, weight, role, timestamp),
 				timestamp,
 				projectId: session.projectId ?? ctx.projectId,
 				archived: session.archived === true,
 				weight,
 				role,
 				display: {
-					title,
-					snippet: title,
+					title: displayTitle,
+					snippet: displayTitle,
 				},
 			};
 			yield indexable;

--- a/src/server/search/sources/session-title.ts
+++ b/src/server/search/sources/session-title.ts
@@ -1,0 +1,11 @@
+export function formatSessionSearchTitle(sessionTitle: string, goalTitle?: string): string {
+	const title = sessionTitle.trim();
+	const goal = (goalTitle ?? "").trim();
+	if (!title || !goal) return title;
+
+	const lowerTitle = title.toLocaleLowerCase();
+	const lowerGoal = goal.toLocaleLowerCase();
+	if (lowerTitle.includes(lowerGoal)) return title;
+
+	return `${goal}: ${title}`;
+}

--- a/src/server/search/sources/session-title.ts
+++ b/src/server/search/sources/session-title.ts
@@ -3,9 +3,32 @@ export function formatSessionSearchTitle(sessionTitle: string, goalTitle?: strin
 	const goal = (goalTitle ?? "").trim();
 	if (!title || !goal) return title;
 
-	const lowerTitle = title.toLocaleLowerCase();
-	const lowerGoal = goal.toLocaleLowerCase();
-	if (lowerTitle.includes(lowerGoal)) return title;
+	if (containsGoalTitleAsPhrase(title, goal)) return title;
 
 	return `${goal}: ${title}`;
+}
+
+function containsGoalTitleAsPhrase(title: string, goal: string): boolean {
+	const normalizedTitle = normalizeForTitleMatch(title);
+	const normalizedGoal = normalizeForTitleMatch(goal);
+	if (!normalizedTitle || !normalizedGoal) return false;
+
+	let start = 0;
+	while (start <= normalizedTitle.length) {
+		const idx = normalizedTitle.indexOf(normalizedGoal, start);
+		if (idx === -1) return false;
+		const before = idx === 0 ? "" : normalizedTitle[idx - 1];
+		const after = normalizedTitle[idx + normalizedGoal.length] ?? "";
+		if (!isTitleTokenChar(before) && !isTitleTokenChar(after)) return true;
+		start = idx + 1;
+	}
+	return false;
+}
+
+function normalizeForTitleMatch(value: string): string {
+	return value.trim().replace(/\s+/g, " ").toLocaleLowerCase();
+}
+
+function isTitleTokenChar(char: string): boolean {
+	return char !== "" && /[\p{L}\p{N}]/u.test(char);
 }

--- a/tests/marketplace-active-project.spec.ts
+++ b/tests/marketplace-active-project.spec.ts
@@ -13,40 +13,90 @@
  * once, a file:// fixture loads it, and we drive the helper via window globals
  * with `window.fetch` stubbed to record request URLs.
  */
-import { test, expect } from "@playwright/test";
-import { execSync } from "node:child_process";
+import { test, expect, type Page } from "@playwright/test";
+import esbuild from "esbuild";
 import fs from "node:fs";
 import path from "node:path";
+
+async function renameWithRetry(src: string, dest: string): Promise<void> {
+	const deadline = Date.now() + 5_000;
+	let lastErr: unknown;
+	while (Date.now() < deadline) {
+		try {
+			fs.renameSync(src, dest);
+			return;
+		} catch (err) {
+			lastErr = err;
+			const code = (err as NodeJS.ErrnoException).code;
+			if (code !== "EPERM" && code !== "EBUSY" && code !== "EACCES") throw err;
+			await new Promise((r) => setTimeout(r, 100));
+		}
+	}
+	throw lastErr;
+}
 
 const FIXTURE = path.resolve("tests/fixtures/marketplace-active-project.html");
 const BUNDLE = path.resolve("tests/fixtures/marketplace-active-project-bundle.js");
 const ENTRY = path.resolve("tests/fixtures/marketplace-active-project-entry.ts");
 const PAGE_SRC = path.resolve("src/app/marketplace-page.ts");
 
-test.beforeAll(() => {
+test.setTimeout(30_000);
+
+test.beforeAll(async () => {
 	const entryMtime = Math.max(fs.statSync(ENTRY).mtimeMs, fs.statSync(PAGE_SRC).mtimeMs);
 	const bundleExists = fs.existsSync(BUNDLE);
 	const bundleStale = bundleExists && fs.statSync(BUNDLE).mtimeMs < entryMtime;
 	if (!bundleExists || bundleStale) {
-		execSync(
-			[
-				`npx esbuild ${ENTRY}`,
-				"--bundle --format=iife --target=es2022",
-				`--outfile=${BUNDLE}`,
-				"--tsconfig=tsconfig.web.json",
-				"--alias:pdfjs-dist=./tests/fixtures/empty-shim",
-				"--define:import.meta.url='\"http://localhost/\"'",
-			].join(" "),
-			{ stdio: "pipe" },
-		);
+		// With fullyParallel enabled, both tests in this file may run in separate
+		// workers and rebuild the shared fixture bundle at the same time. esbuild's
+		// direct outfile write is not atomic, so a sibling page can load a partial
+		// bundle and wait forever for `window.__ready`. Build to a unique temp path,
+		// then atomically replace the shared bundle.
+		const tmpDir = fs.mkdtempSync(path.join(path.dirname(BUNDLE), ".bundle-tmp-"));
+		const tmpOut = path.join(tmpDir, path.basename(BUNDLE));
+		try {
+			await esbuild.build({
+				entryPoints: [ENTRY],
+				bundle: true,
+				format: "iife",
+				target: "es2022",
+				outfile: tmpOut,
+				tsconfig: "tsconfig.web.json",
+				alias: { "pdfjs-dist": "./tests/fixtures/empty-shim" },
+				define: { "import.meta.url": '"http://localhost/"' },
+				loader: { ".ts": "ts" },
+			});
+			await renameWithRetry(tmpOut, BUNDLE);
+		} finally {
+			try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best-effort cleanup */ }
+		}
 	}
 });
 
 const PAGE = `file://${FIXTURE}`;
 
-async function gotoAndWait(page: any) {
+async function gotoAndWait(page: Page) {
+	const consoleMessages: string[] = [];
+	const pageErrors: string[] = [];
+	page.on("console", (msg) => consoleMessages.push(`${msg.type()}: ${msg.text()}`));
+	page.on("pageerror", (err) => pageErrors.push(err.stack || err.message));
+
 	await page.goto(PAGE);
-	await page.waitForFunction(() => (window as any).__ready === true, null, { timeout: 10_000 });
+	try {
+		await page.waitForFunction(() => (window as any).__ready === true, null, { timeout: 20_000 });
+	} catch (err) {
+		const diagnostics = await page.evaluate(() => ({
+			ready: (window as any).__ready,
+			bodyText: document.body?.innerText?.slice(0, 500) ?? "",
+		})).catch((evalErr) => ({ ready: undefined, bodyText: `diagnostic evaluate failed: ${evalErr}` }));
+		throw new Error([
+			`Timed out waiting for marketplace fixture readiness: ${err}`,
+			`window.__ready: ${String(diagnostics.ready)}`,
+			`body: ${diagnostics.bodyText}`,
+			`console: ${consoleMessages.slice(-20).join("\n") || "<none>"}`,
+			`pageerror: ${pageErrors.slice(-20).join("\n") || "<none>"}`,
+		].join("\n"));
+	}
 }
 
 test.describe("marketplace refresh scopes renderers to the active session (extension-host §4c)", () => {

--- a/tests/search/content-policy.spec.ts
+++ b/tests/search/content-policy.spec.ts
@@ -17,8 +17,8 @@ import {
 } from "../../src/server/search/content-policy.ts";
 
 test.describe("CONTENT_POLICY_VERSION", () => {
-	test("is exported and equals 1", () => {
-		expect(CONTENT_POLICY_VERSION).toBe(1);
+	test("is exported and equals 3", () => {
+		expect(CONTENT_POLICY_VERSION).toBe(3);
 	});
 	test("limit constants match design", () => {
 		expect(MAX_TOOL_RESULT_INPUT_CHARS).toBe(32_768);

--- a/tests/search/index-source-contract.spec.ts
+++ b/tests/search/index-source-contract.spec.ts
@@ -24,6 +24,7 @@ import { SessionIndexSource } from "../../src/server/search/sources/session-sour
 import { StaffIndexSource } from "../../src/server/search/sources/staff-source.ts";
 import { MessageIndexSource } from "../../src/server/search/sources/message-source.ts";
 import { FilesIndexSourceStub } from "../../src/server/search/sources/files-source.stub.ts";
+import { formatSessionSearchTitle } from "../../src/server/search/sources/session-title.ts";
 import { indexableToDoc } from "../../src/server/search/indexer.ts";
 import { toSearchResult } from "../../src/server/search/flex-store.ts";
 import type { IndexSource, IndexSourceContext, Indexable } from "../../src/server/search/types.ts";
@@ -223,6 +224,14 @@ test.describe("SessionIndexSource", () => {
 			sessions: [{ ...sessions[0], title: "First goal: Working on the thing" }],
 		}));
 		expect(alreadyPrefixed[0].display?.title, "goal prefix should not be duplicated").toBe("First goal: Working on the thing");
+	});
+
+	test("does not treat goal title substrings as existing prefixes", () => {
+		expect(formatSessionSearchTitle("Prefix search", "Fix")).toBe("Fix: Prefix search");
+		expect(formatSessionSearchTitle("guide updates", "UI")).toBe("UI: guide updates");
+		expect(formatSessionSearchTitle("Fix: Prefix search", "Fix")).toBe("Fix: Prefix search");
+		expect(formatSessionSearchTitle("Prefix search for Fix", "Fix")).toBe("Prefix search for Fix");
+		expect(formatSessionSearchTitle("Build the UI guide", "UI")).toBe("Build the UI guide");
 	});
 
 	test("contentHash stable under unchanged input", async () => {

--- a/tests/search/index-source-contract.spec.ts
+++ b/tests/search/index-source-contract.spec.ts
@@ -24,6 +24,8 @@ import { SessionIndexSource } from "../../src/server/search/sources/session-sour
 import { StaffIndexSource } from "../../src/server/search/sources/staff-source.ts";
 import { MessageIndexSource } from "../../src/server/search/sources/message-source.ts";
 import { FilesIndexSourceStub } from "../../src/server/search/sources/files-source.stub.ts";
+import { indexableToDoc } from "../../src/server/search/indexer.ts";
+import { toSearchResult } from "../../src/server/search/flex-store.ts";
 import type { IndexSource, IndexSourceContext, Indexable } from "../../src/server/search/types.ts";
 import type { PersistedGoal, GoalStore } from "../../src/server/agent/goal-store.ts";
 import type { PersistedSession, SessionStore } from "../../src/server/agent/session-store.ts";
@@ -209,6 +211,20 @@ test.describe("SessionIndexSource", () => {
 		expect(s1.projectId).toBe("proj-a");
 	});
 
+	test("formats goal-owned session display titles once", async () => {
+		const ctx = makeCtx({ goals, sessions });
+		const [s1] = await collect(new SessionIndexSource(), ctx);
+		expect(s1.text).toBe("Working on the thing");
+		expect(s1.display?.title, "direct session result title should include its goal context").toBe("First goal: Working on the thing");
+		expect(s1.display?.snippet, "direct session result snippet should use the same formatted title").toBe("First goal: Working on the thing");
+
+		const alreadyPrefixed = await collect(new SessionIndexSource(), makeCtx({
+			goals,
+			sessions: [{ ...sessions[0], title: "First goal: Working on the thing" }],
+		}));
+		expect(alreadyPrefixed[0].display?.title, "goal prefix should not be duplicated").toBe("First goal: Working on the thing");
+	});
+
 	test("contentHash stable under unchanged input", async () => {
 		const ctx = makeCtx({ goals, sessions });
 		const a = await collect(new SessionIndexSource(), ctx);
@@ -302,6 +318,7 @@ test.describe("MessageIndexSource", () => {
 		expect(user.text).toBe("Hello there");
 		expect(user.weight).toBe(2.0);
 		expect(user.id).toBe("message:s1:0:text:0");
+		expect(user.metadata.sessionTitle, "message rows should carry parent session title metadata").toBe("Chat");
 
 		const assistant = out.find((o) => o.role === "assistant")!;
 		expect(assistant.weight).toBe(1.0);
@@ -312,6 +329,59 @@ test.describe("MessageIndexSource", () => {
 		expect(toolCall.text.startsWith("write ")).toBe(true);
 
 		// Cleanup
+		fs.rmSync(dir, { recursive: true, force: true });
+	});
+
+	test("denormalizes goal-prefixed session title metadata for message result round-trip", async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "msg-title-source-"));
+		const file = path.join(dir, "session.jsonl");
+		fs.writeFileSync(file, JSON.stringify({ message: { role: "user", content: "QuackerTitleRegression" } }) + "\n", "utf-8");
+
+		const ctx = makeCtx({
+			goals: [{ ...goals[0], id: "goal-title", title: "Fix Search Titles" }],
+			sessions: [{
+				id: "session-title",
+				title: "Grouped Session",
+				cwd: "/tmp",
+				agentSessionFile: file,
+				createdAt: 1_700_000_000_000,
+				lastActivity: 1_700_000_200_000,
+				goalId: "goal-title",
+				projectId: "proj-a",
+			}],
+		});
+		const [msg] = await collect(new MessageIndexSource(), ctx);
+		expect(msg.metadata.goalTitle, "message rows should carry goal title metadata").toBe("Fix Search Titles");
+		expect(msg.metadata.sessionTitle, "message rows should carry resolved parent session title metadata").toBe("Fix Search Titles: Grouped Session");
+
+		const doc = indexableToDoc(msg, msg.text, "session-title");
+		const result = toSearchResult(doc, "QuackerTitleRegression", 1);
+		expect(result.sessionTitle, "resolved message session title should round-trip through stored search docs").toBe("Fix Search Titles: Grouped Session");
+
+		fs.rmSync(dir, { recursive: true, force: true });
+	});
+
+	test("does not duplicate goal prefix in message session title metadata", async () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "msg-prefixed-title-source-"));
+		const file = path.join(dir, "session.jsonl");
+		fs.writeFileSync(file, JSON.stringify({ message: { role: "user", content: "QuackerAlreadyPrefixed" } }) + "\n", "utf-8");
+
+		const ctx = makeCtx({
+			goals: [{ ...goals[0], id: "goal-title", title: "Fix Search Titles" }],
+			sessions: [{
+				id: "session-prefixed-title",
+				title: "Fix Search Titles: Grouped Session",
+				cwd: "/tmp",
+				agentSessionFile: file,
+				createdAt: 1_700_000_000_000,
+				lastActivity: 1_700_000_200_000,
+				goalId: "goal-title",
+				projectId: "proj-a",
+			}],
+		});
+		const [msg] = await collect(new MessageIndexSource(), ctx);
+		expect(msg.metadata.sessionTitle, "goal prefix should not be duplicated for message-derived session context").toBe("Fix Search Titles: Grouped Session");
+
 		fs.rmSync(dir, { recursive: true, force: true });
 	});
 });

--- a/tests/search/search-service-extras.spec.ts
+++ b/tests/search/search-service-extras.spec.ts
@@ -8,6 +8,7 @@ import * as path from "node:path";
 import * as fs from "node:fs";
 import { SearchService } from "../../src/server/search/search-service.ts";
 import { ProgressBus } from "../../src/server/search/progress-bus.ts";
+import { ProjectContext } from "../../src/server/agent/project-context.ts";
 
 test("dataDir is scoped to stateDir (search.flex subdirectory)", () => {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "svc-path-"));
@@ -67,4 +68,70 @@ test("getEngineInfo reports flexsearch", () => {
 	expect(info.engine).toBe("flexsearch");
 	expect(typeof info.engineVersion).toBe("string");
 	expect(info.engineVersion.length).toBeGreaterThan(0);
+});
+
+test("goal title updates refresh dependent session and message titles", async () => {
+	const rootPath = fs.mkdtempSync(path.join(os.tmpdir(), "ctx-search-goal-title-"));
+	const messageFile = path.join(rootPath, "session.jsonl");
+	fs.writeFileSync(
+		messageFile,
+		JSON.stringify({ message: { role: "user", content: "RenameGoalTitleToken" } }) + "\n",
+		"utf-8",
+	);
+
+	const ctx = new ProjectContext({
+		id: "project-goal-title",
+		name: "Goal Title Project",
+		rootPath,
+		createdAt: Date.now(),
+		colorLight: "#2563eb",
+		colorDark: "#60a5fa",
+	});
+
+	try {
+		ctx.open();
+		await ctx.searchIndex.whenReady();
+		ctx.goalStore.put({
+			id: "goal-title",
+			title: "Old Goal",
+			cwd: rootPath,
+			state: "in-progress",
+			spec: "",
+			createdAt: 1,
+			updatedAt: 1,
+			projectId: "project-goal-title",
+		});
+		const session = {
+			id: "session-title",
+			title: "Grouped Session",
+			cwd: rootPath,
+			agentSessionFile: messageFile,
+			createdAt: 2,
+			lastActivity: 3,
+			goalId: "goal-title",
+			projectId: "project-goal-title",
+		};
+		ctx.sessionStore.put(session);
+		ctx.searchIndex.reindexMessagesForSession(session, "Old Goal", "project-goal-title");
+
+		await expect.poll(async () => {
+			const results = await ctx.searchIndex.search("RenameGoalTitleToken", { type: "messages", limit: 5 });
+			return results.results[0]?.sessionTitle ?? "";
+		}, { timeout: 5_000 }).toBe("Old Goal: Grouped Session");
+
+		ctx.goalStore.update("goal-title", { title: "New Goal" });
+
+		await expect.poll(async () => {
+			const results = await ctx.searchIndex.search("RenameGoalTitleToken", { type: "messages", limit: 5 });
+			return results.results[0]?.sessionTitle ?? "";
+		}, { timeout: 5_000 }).toBe("New Goal: Grouped Session");
+
+		await expect.poll(async () => {
+			const results = await ctx.searchIndex.search("Grouped Session", { type: "sessions", limit: 5 });
+			return results.results[0]?.title ?? "";
+		}, { timeout: 5_000 }).toBe("New Goal: Grouped Session");
+	} finally {
+		await ctx.searchIndex.close();
+		fs.rmSync(rootPath, { recursive: true, force: true });
+	}
 });

--- a/tests/search/search-service-extras.spec.ts
+++ b/tests/search/search-service-extras.spec.ts
@@ -242,6 +242,101 @@ test("session goal ownership updates refresh dependent message title prefixes", 
 	}
 });
 
+test("serialized message reindexes keep latest session and goal title metadata", async () => {
+	const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "svc-reindex-order-"));
+	const rootPath = fs.mkdtempSync(path.join(os.tmpdir(), "svc-reindex-order-session-"));
+	const messageFile = path.join(rootPath, "session.jsonl");
+	fs.writeFileSync(
+		messageFile,
+		JSON.stringify({ message: { role: "user", content: "ReindexOrderingToken" } }) + "\n",
+		"utf-8",
+	);
+
+	const svc = new SearchService({
+		stateDir,
+		projectId: "project-reindex-order",
+		progressBus: new ProgressBus(),
+	});
+	let releaseOldUpsert!: () => void;
+	const oldMayFinish = new Promise<void>((resolve) => { releaseOldUpsert = resolve; });
+	let markOldStarted!: () => void;
+	const oldStarted = new Promise<void>((resolve) => { markOldStarted = resolve; });
+	let markOldFinished!: () => void;
+	const oldFinished = new Promise<void>((resolve) => { markOldFinished = resolve; });
+	let markNewFinished!: () => void;
+	const newFinished = new Promise<void>((resolve) => { markNewFinished = resolve; });
+	let oldFinishedFlag = false;
+	let newStartedBeforeOldFinished = false;
+
+	try {
+		svc.open();
+		await svc.whenReady();
+
+		const internals = svc as unknown as {
+			_indexer: { upsertEntries: (entries: Array<{ metadata?: Record<string, unknown> }>) => Promise<void> };
+			_waitForMutationTasks: () => Promise<void>;
+		};
+		const originalUpsert = internals._indexer.upsertEntries.bind(internals._indexer);
+		internals._indexer.upsertEntries = async (entries) => {
+			const sessionTitle = entries
+				.map((entry) => String(entry.metadata?.sessionTitle ?? ""))
+				.find((title) => title.length > 0) ?? "";
+			if (sessionTitle === "Old Goal: Old Session") {
+				markOldStarted();
+				await oldMayFinish;
+				await originalUpsert(entries);
+				oldFinishedFlag = true;
+				markOldFinished();
+				return;
+			}
+			if (sessionTitle === "New Goal: New Session") {
+				if (!oldFinishedFlag) newStartedBeforeOldFinished = true;
+				await originalUpsert(entries);
+				markNewFinished();
+				return;
+			}
+			await originalUpsert(entries);
+		};
+
+		svc.reindexMessagesForSession({
+			id: "session-reindex-order",
+			title: "Old Session",
+			cwd: rootPath,
+			agentSessionFile: messageFile,
+			createdAt: 1,
+			lastActivity: 2,
+			goalId: "goal-reindex-order",
+			projectId: "project-reindex-order",
+		}, "Old Goal", "project-reindex-order");
+		await oldStarted;
+
+		svc.reindexMessagesForSession({
+			id: "session-reindex-order",
+			title: "New Session",
+			cwd: rootPath,
+			agentSessionFile: messageFile,
+			createdAt: 1,
+			lastActivity: 3,
+			goalId: "goal-reindex-order",
+			projectId: "project-reindex-order",
+		}, "New Goal", "project-reindex-order");
+
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		releaseOldUpsert();
+		await Promise.all([oldFinished, newFinished]);
+		await internals._waitForMutationTasks();
+
+		expect(newStartedBeforeOldFinished, "newer message reindex must wait for the older compound write").toBe(false);
+		const results = await svc.search("ReindexOrderingToken", { type: "messages", limit: 5 });
+		expect(results.results[0]?.sessionTitle).toBe("New Goal: New Session");
+	} finally {
+		releaseOldUpsert?.();
+		if (svc.getState() !== "closed") await svc.close();
+		fs.rmSync(stateDir, { recursive: true, force: true });
+		fs.rmSync(rootPath, { recursive: true, force: true });
+	}
+});
+
 test("close waits for an in-flight message reindex before closing the store", async () => {
 	const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "svc-reindex-close-"));
 	const rootPath = fs.mkdtempSync(path.join(os.tmpdir(), "svc-reindex-session-"));

--- a/tests/search/search-service-extras.spec.ts
+++ b/tests/search/search-service-extras.spec.ts
@@ -135,3 +135,109 @@ test("goal title updates refresh dependent session and message titles", async ()
 		fs.rmSync(rootPath, { recursive: true, force: true });
 	}
 });
+
+test("session title updates refresh dependent message titles", async () => {
+	const rootPath = fs.mkdtempSync(path.join(os.tmpdir(), "ctx-search-session-title-"));
+	const messageFile = path.join(rootPath, "session.jsonl");
+	fs.writeFileSync(
+		messageFile,
+		JSON.stringify({ message: { role: "user", content: "RenameSessionTitleToken" } }) + "\n",
+		"utf-8",
+	);
+
+	const ctx = new ProjectContext({
+		id: "project-session-title",
+		name: "Session Title Project",
+		rootPath,
+		createdAt: Date.now(),
+		colorLight: "#2563eb",
+		colorDark: "#60a5fa",
+	});
+
+	try {
+		ctx.open();
+		await ctx.searchIndex.whenReady();
+		ctx.sessionStore.put({
+			id: "session-title-refresh",
+			title: "",
+			cwd: rootPath,
+			agentSessionFile: messageFile,
+			createdAt: 2,
+			lastActivity: 3,
+			projectId: "project-session-title",
+		});
+
+		await expect.poll(async () => {
+			const results = await ctx.searchIndex.search("RenameSessionTitleToken", { type: "messages", limit: 5 });
+			return results.results.length;
+		}, { timeout: 5_000 }).toBe(1);
+
+		ctx.sessionStore.update("session-title-refresh", { title: "Generated Session Title" });
+
+		await expect.poll(async () => {
+			const results = await ctx.searchIndex.search("RenameSessionTitleToken", { type: "messages", limit: 5 });
+			return results.results[0]?.sessionTitle ?? "";
+		}, { timeout: 5_000 }).toBe("Generated Session Title");
+	} finally {
+		await ctx.searchIndex.close();
+		fs.rmSync(rootPath, { recursive: true, force: true });
+	}
+});
+
+test("session goal ownership updates refresh dependent message title prefixes", async () => {
+	const rootPath = fs.mkdtempSync(path.join(os.tmpdir(), "ctx-search-session-goal-"));
+	const messageFile = path.join(rootPath, "session.jsonl");
+	fs.writeFileSync(
+		messageFile,
+		JSON.stringify({ message: { role: "user", content: "SessionGoalPrefixToken" } }) + "\n",
+		"utf-8",
+	);
+
+	const ctx = new ProjectContext({
+		id: "project-session-goal",
+		name: "Session Goal Project",
+		rootPath,
+		createdAt: Date.now(),
+		colorLight: "#2563eb",
+		colorDark: "#60a5fa",
+	});
+
+	try {
+		ctx.open();
+		await ctx.searchIndex.whenReady();
+		ctx.goalStore.put({
+			id: "goal-prefix",
+			title: "Goal Prefix",
+			cwd: rootPath,
+			state: "in-progress",
+			spec: "",
+			createdAt: 1,
+			updatedAt: 1,
+			projectId: "project-session-goal",
+		});
+		ctx.sessionStore.put({
+			id: "session-goal-refresh",
+			title: "Grouped Session",
+			cwd: rootPath,
+			agentSessionFile: messageFile,
+			createdAt: 2,
+			lastActivity: 3,
+			projectId: "project-session-goal",
+		});
+
+		await expect.poll(async () => {
+			const results = await ctx.searchIndex.search("SessionGoalPrefixToken", { type: "messages", limit: 5 });
+			return results.results[0]?.sessionTitle ?? "";
+		}, { timeout: 5_000 }).toBe("Grouped Session");
+
+		ctx.sessionStore.update("session-goal-refresh", { goalId: "goal-prefix" });
+
+		await expect.poll(async () => {
+			const results = await ctx.searchIndex.search("SessionGoalPrefixToken", { type: "messages", limit: 5 });
+			return results.results[0]?.sessionTitle ?? "";
+		}, { timeout: 5_000 }).toBe("Goal Prefix: Grouped Session");
+	} finally {
+		await ctx.searchIndex.close();
+		fs.rmSync(rootPath, { recursive: true, force: true });
+	}
+});

--- a/tests/search/search-service-extras.spec.ts
+++ b/tests/search/search-service-extras.spec.ts
@@ -241,3 +241,79 @@ test("session goal ownership updates refresh dependent message title prefixes", 
 		fs.rmSync(rootPath, { recursive: true, force: true });
 	}
 });
+
+test("close waits for an in-flight message reindex before closing the store", async () => {
+	const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "svc-reindex-close-"));
+	const rootPath = fs.mkdtempSync(path.join(os.tmpdir(), "svc-reindex-session-"));
+	const messageFile = path.join(rootPath, "session.jsonl");
+	fs.writeFileSync(
+		messageFile,
+		JSON.stringify({ message: { role: "user", content: "ReindexCloseRaceToken" } }) + "\n",
+		"utf-8",
+	);
+
+	const svc = new SearchService({
+		stateDir,
+		projectId: "project-reindex-close",
+		progressBus: new ProgressBus(),
+	});
+	const errors: string[] = [];
+	const originalError = console.error;
+	let releaseUpsert!: () => void;
+	const releaseUpsertPromise = new Promise<void>((resolve) => { releaseUpsert = resolve; });
+	let markUpsertStarted!: () => void;
+	const upsertStarted = new Promise<void>((resolve) => { markUpsertStarted = resolve; });
+	let storeCloseStarted = false;
+	let storeClosedBeforeUpsertFinished = false;
+	let closeSettled = false;
+
+	console.error = (...args: unknown[]) => { errors.push(args.map(String).join(" ")); };
+	try {
+		svc.open();
+		await svc.whenReady();
+
+		const internals = svc as unknown as {
+			_indexer: { upsertEntries: (entries: unknown[]) => Promise<void> };
+			_store: { close: () => Promise<void> };
+		};
+		const originalUpsert = internals._indexer.upsertEntries.bind(internals._indexer);
+		const originalClose = internals._store.close.bind(internals._store);
+		internals._indexer.upsertEntries = async (entries: unknown[]) => {
+			markUpsertStarted();
+			await releaseUpsertPromise;
+			storeClosedBeforeUpsertFinished = storeCloseStarted;
+			return originalUpsert(entries);
+		};
+		internals._store.close = async () => {
+			storeCloseStarted = true;
+			return originalClose();
+		};
+
+		svc.reindexMessagesForSession({
+			id: "session-reindex-close",
+			title: "Race Session",
+			cwd: rootPath,
+			agentSessionFile: messageFile,
+			createdAt: 1,
+			lastActivity: 2,
+			projectId: "project-reindex-close",
+		}, undefined, "project-reindex-close");
+		await upsertStarted;
+
+		const closePromise = svc.close().then(() => { closeSettled = true; });
+		await new Promise((resolve) => setTimeout(resolve, 30));
+		const settledBeforeRelease = closeSettled;
+		releaseUpsert();
+		await closePromise;
+
+		expect(settledBeforeRelease).toBe(false);
+		expect(storeClosedBeforeUpsertFinished).toBe(false);
+		expect(errors.filter((err) => err.includes("already closed"))).toEqual([]);
+	} finally {
+		console.error = originalError;
+		releaseUpsert?.();
+		if (svc.getState() !== "closed") await svc.close();
+		fs.rmSync(stateDir, { recursive: true, force: true });
+		fs.rmSync(rootPath, { recursive: true, force: true });
+	}
+});

--- a/tests/settings-models-tab-redesign.spec.ts
+++ b/tests/settings-models-tab-redesign.spec.ts
@@ -3,6 +3,11 @@ import esbuild from "esbuild";
 import fs from "node:fs";
 import path from "node:path";
 
+const FIXTURE_TIMEOUT_MS = 60_000;
+const READY_TIMEOUT_MS = 30_000;
+
+test.setTimeout(FIXTURE_TIMEOUT_MS);
+
 async function renameWithRetry(src: string, dest: string): Promise<void> {
 	const deadline = Date.now() + 5_000;
 	let lastErr: unknown;
@@ -27,6 +32,10 @@ const SETTINGS_SRC = path.resolve("src/app/settings-page.ts");
 const DIALOG_SRC = path.resolve("src/ui/dialogs/AigwModelsDialog.ts");
 
 test.beforeAll(async () => {
+	// Full-suite browser fixture runs can be CPU/IO constrained while multiple
+	// esbuild-backed fixtures initialize concurrently. Keep the fixture-level
+	// budget above the global 15s default so a valid cold build is not flaky.
+	test.setTimeout(FIXTURE_TIMEOUT_MS);
 	const entryMtime = Math.max(
 		fs.statSync(ENTRY).mtimeMs,
 		fs.statSync(SETTINGS_SRC).mtimeMs,
@@ -76,8 +85,34 @@ test.beforeAll(async () => {
 const PAGE = `file://${FIXTURE}`;
 
 async function gotoAndWait(page: any) {
-	await page.goto(PAGE);
-	await page.waitForFunction(() => (window as any).__ready === true, null, { timeout: 15_000 });
+	const pageErrors: string[] = [];
+	page.on("pageerror", (err: Error) => pageErrors.push(err.stack || err.message));
+	const startedAt = Date.now();
+	try {
+		await page.goto(PAGE, { timeout: READY_TIMEOUT_MS });
+		await page.waitForFunction(() => (window as any).__ready === true, null, { timeout: READY_TIMEOUT_MS });
+	} catch (err) {
+		const diagnostics = await page.evaluate(() => ({
+			ready: (window as any).__ready,
+			bodyText: document.body?.innerText ?? "",
+			scripts: Array.from(document.scripts).map((script) => script.src),
+		})).catch((evalErr: Error) => ({ evalError: evalErr.message }));
+		const bundleStat = (() => {
+			try {
+				const stat = fs.statSync(BUNDLE);
+				return { exists: true, size: stat.size, mtimeMs: stat.mtimeMs };
+			} catch (statErr) {
+				return { exists: false, error: (statErr as Error).message };
+			}
+		})();
+		throw new Error([
+			`Settings models fixture did not become ready after ${Date.now() - startedAt}ms: ${(err as Error).message}`,
+			`page=${PAGE}`,
+			`bundle=${JSON.stringify(bundleStat)}`,
+			`pageErrors=${JSON.stringify(pageErrors)}`,
+			`diagnostics=${JSON.stringify(diagnostics)}`,
+		].join("\n"));
+	}
 }
 
 const AIGW_MODELS = [

--- a/tests/ui-fixtures/search-preview-search-page.spec.ts
+++ b/tests/ui-fixtures/search-preview-search-page.spec.ts
@@ -73,13 +73,13 @@ function session(id: string, title: string, score = 4): Result {
 	};
 }
 
-function message(id: string, sessionId: string, token: string, score = 3): Result {
+function message(id: string, sessionId: string, token: string, score = 3, sessionTitle = "Grouped Session"): Result {
 	return {
 		type: "message",
 		id,
 		title: `Message ${id}`,
 		sessionId,
-		sessionTitle: "Grouped Session",
+		sessionTitle,
 		snippet: `<b>${token}</b> body ${id}`,
 		timestamp: NOW - 2000,
 		archived: false,
@@ -112,6 +112,37 @@ test.describe("Search page grouped-results fixture", () => {
 		await card.locator('[data-role="group-chevron"]').click();
 		await expect(card).toHaveAttribute("data-expanded", "true");
 		await expect(card.locator('[data-role="result-child"]')).toHaveCount(5);
+	});
+
+	test("message-only groups and rows use the resolved parent session title", async ({ page }) => {
+		const rows = [message("goal-message", "goal-session", "GoalTok", 3, "Fix Search Titles: Grouped Session")];
+		await setupSearch(page, rows, "GoalTok");
+
+		const card = page.locator('[data-role="result-group"][data-key="session:goal-session"]');
+		await expect(card).toBeVisible({ timeout: 10_000 });
+		await expect(card.locator("span").filter({ hasText: "Fix Search Titles: Grouped Session" }).first()).toBeVisible();
+		await expect(card, "message-derived session card should not fall back to Untitled").not.toContainText(/Untitled(?: session)?/i);
+		await expect(card.locator('[data-role="result-child"]').first()).toContainText("Fix Search Titles: Grouped Session");
+	});
+
+	test("nested message rows inherit the direct parent session title context", async ({ page }) => {
+		const rawMessageTitle = "Raw Message Row Title";
+		const rows: Result[] = [
+			session("parent-session", "Grouped Session", 4),
+			{
+				...message("parent-message", "parent-session", "ParentTok", 3, undefined),
+				title: rawMessageTitle,
+				sessionTitle: undefined,
+			},
+		];
+		await setupSearch(page, rows, "ParentTok");
+
+		const card = page.locator('[data-role="result-group"][data-key="session:parent-session"]');
+		await expect(card).toHaveAttribute("data-expanded", "false", { timeout: 10_000 });
+		await card.locator('[data-role="group-chevron"]').click();
+		const child = card.locator('[data-role="result-child"]').first();
+		await expect(child, "expanded message rows should use parent session title context").toContainText("Grouped Session");
+		await expect(child, "expanded message rows should not render the raw message row title").not.toContainText(rawMessageTitle);
 	});
 
 	test("a group with exactly one total match auto-expands", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Fix full-search message result titles to use resolved parent session title metadata instead of Untitled fallbacks.
- Prefix goal-owned sessions as `<Goal title>: <Session title>` without duplicate prefixes.
- Refresh dependent message rows when session titles, goal ownership, or goal titles change.
- Harden search mutation lifecycle: wait for async mutation work on close and serialize compound message reindexes per session.
- Add regression tests and update search internals documentation.

## Validation
- `npm run check`
- `npm run test:unit`
- `npm run test:e2e`
- Targeted search/UI fixture Playwright tests via gate verification

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
