### PR TITLE
Memoize sprite canvas rendering (toDataURL + getAnimations)

### DIFF
--- a/src/ui/bobbit-render.ts
+++ b/src/ui/bobbit-render.ts
@@ -307,15 +307,33 @@ export function startCanvasEyeAnimation(
 	// This bypasses every clock-arithmetic edge case (mount time, document
 	// timeline epoch, negative-delay semantics): we don't compute the phase,
 	// we observe the same one CSS observes.
+	//
+	// Perf: getAnimations() enumerates + allocates an array of every Animation on
+	// the element on each call. Calling it once per rAF frame per sprite was a
+	// measurable renderer hotspot (~8.5% CPU under sidebar churn). The target
+	// Animation is a persistent object that lives as long as the CSS animation
+	// runs, so we resolve it once and cache the reference, reusing it across
+	// frames — .currentTime is read live off the cached object each frame, giving
+	// a value identical to re-querying. We only re-enumerate when the cache is
+	// empty or the cached animation has gone stale (no longer running, so its
+	// currentTime reads null — e.g. it was cancelled or replaced).
+	let phaseAnim: Animation | null = null;
+	function resolvePhaseAnimation(): Animation | null {
+		// Fast path: the cached animation is still live (running/paused, with a
+		// readable clock). A finished/cancelled animation reports currentTime
+		// null here, forcing a single re-enumeration below.
+		if (phaseAnim && phaseAnim.currentTime != null) return phaseAnim;
+		phaseAnim = null;
+		for (const a of canvas.getAnimations()) {
+			const dur = (a.effect as KeyframeEffect | null)?.getTiming?.()?.duration;
+			if (dur === cycleDurationMs) { phaseAnim = a; break; }
+		}
+		return phaseAnim;
+	}
 	function readPhasePct(): number {
-		const anims = canvas.getAnimations();
 		// Pick the 10s-cycle animation; its currentTime already accounts for
 		// animation-delay (negative delays make it start positive).
-		let anim: Animation | undefined;
-		for (const a of anims) {
-			const dur = (a.effect as KeyframeEffect | null)?.getTiming?.()?.duration;
-			if (dur === cycleDurationMs) { anim = a; break; }
-		}
+		const anim = resolvePhaseAnimation();
 		if (!anim || anim.currentTime == null) return 0;
 		const raw = typeof anim.currentTime === "number"
 			? anim.currentTime
@@ -596,6 +614,42 @@ export function renderIdleBlobCanvas(opts: IdleBlobOptions): TemplateResult {
 // ============================================================================
 
 /**
+ * Data-URL caches for the sidebar sprite layers.
+ *
+ * `canvas.toDataURL()` is a synchronous, main-thread PNG encode (~5–9ms per
+ * call for these small canvases). The sidebar re-renders on every WS status
+ * tick, and each sprite issues up to 4 encodes (body + blink + eye + accessory),
+ * so an un-memoized sidebar with ~20 sessions burns ~200ms of blocking work per
+ * render event. Every data-URL here is a PURE FUNCTION of a small discrete input
+ * set (see each key below), so caching by that key collapses all repeat encodes
+ * to a single Map lookup — the canvas build + fillRect loop + encode only ever
+ * runs once per unique sprite layer.
+ *
+ * Bounded by construction: keys are tuples of a handful of enum/boolean
+ * dimensions (status bucket × a few booleans) plus the fixed accessory id set,
+ * so the total number of distinct entries is at most a few dozen across the
+ * whole app lifetime. No eviction needed — a plain Map is the right structure.
+ *
+ * NOTE: `hueRotate` and the saturate()/filter styles are NOT keyed here — they
+ * are applied as CSS on the <img> element (see filterStyle / accFilter below),
+ * never baked into the bitmap, so two sessions that differ only by hue share
+ * the same cached data-URL. Bitmaps are device-pixel-ratio-independent (fixed
+ * HI=8), so DPR is not a key dimension either.
+ */
+const sidebarBodyUrlCache = new Map<string, string>();
+const sidebarBlinkUrlCache = new Map<string, string>();
+const sidebarEyeUrlCache = new Map<string, string>();
+const sidebarAccessoryUrlCache = new Map<string, string>();
+
+/** Discrete status bucket — the only aspect of `status` that affects pixels
+ *  (it selects the palette). Everything else (idle/streaming) drives CSS only. */
+function sidebarStatusBucket(status: string): "starting" | "terminated" | "canonical" {
+	if (status === "starting") return "starting";
+	if (status === "terminated") return "terminated";
+	return "canonical";
+}
+
+/**
  * Render a sidebar bobbit to a canvas-based <img> element.
  * Draws body, eyes, and accessories to off-screen canvases displayed via <img>.
  * Animations (bob, shimmer, eye blink) still use CSS on the container.
@@ -629,17 +683,33 @@ export function renderSidebarBobbitCanvas(opts: SidebarBobbitOptions): TemplateR
 	// Draw body to canvas at HI× scale
 	const eyeColor = isSelected ? p.main : p.eye;
 	const bodyGaze = unread ? "right" : "center";
-	const bodyPixels = resolveBodyPixels(p, bodyGaze, isSleeping, eyeColor);
-	const bodyCanvas = document.createElement("canvas");
-	bodyCanvas.width = BODY_WIDTH * HI;
-	bodyCanvas.height = BODY_HEIGHT * HI;
-	const bodyCtx = bodyCanvas.getContext("2d")!;
-	bodyCtx.imageSmoothingEnabled = false;
-	for (const [x, y, color] of bodyPixels) {
-		bodyCtx.fillStyle = color;
-		bodyCtx.fillRect(x * HI, y * HI, HI, HI);
+	const statusBucket = sidebarStatusBucket(status);
+	// Body pixels are a pure function of EXACTLY four things: the palette
+	// (status bucket), the eye color (isSelected → p.main vs p.eye), the gaze
+	// (bodyGaze, derived from unread), and whether the eyes are closed
+	// (isSleeping). isSleeping MUST be in the key directly — NOT folded into the
+	// status bucket — because the bucket collapses "idle"/"streaming"/"busy"/…
+	// all to "canonical", yet only "idle" sleeps; keying on the bucket alone
+	// would let an idle (eyes-closed) sprite and a streaming (eyes-open) sprite
+	// collide on one cache entry. Keying on the resolved isSleeping value is both
+	// exact and minimal: any two opts yielding the same (bucket, eyeColor, gaze,
+	// sleeping) tuple resolve to pixel-identical body bitmaps.
+	const bodyKey = `${statusBucket}|${isSelected ? 1 : 0}|${bodyGaze}|${isSleeping ? 1 : 0}`;
+	let bodyUrl = sidebarBodyUrlCache.get(bodyKey);
+	if (bodyUrl === undefined) {
+		const bodyPixels = resolveBodyPixels(p, bodyGaze, isSleeping, eyeColor);
+		const bodyCanvas = document.createElement("canvas");
+		bodyCanvas.width = BODY_WIDTH * HI;
+		bodyCanvas.height = BODY_HEIGHT * HI;
+		const bodyCtx = bodyCanvas.getContext("2d")!;
+		bodyCtx.imageSmoothingEnabled = false;
+		for (const [x, y, color] of bodyPixels) {
+			bodyCtx.fillStyle = color;
+			bodyCtx.fillRect(x * HI, y * HI, HI, HI);
+		}
+		bodyUrl = bodyCanvas.toDataURL();
+		sidebarBodyUrlCache.set(bodyKey, bodyUrl);
 	}
-	const bodyUrl = bodyCanvas.toDataURL();
 
 	// Unread state: pre-render a second body image with the eyes blinked
 	// (right gaze, blink=true). The CSS class `bobbit-sidebar-unread-blink`
@@ -647,37 +717,53 @@ export function renderSidebarBobbitCanvas(opts: SidebarBobbitOptions): TemplateR
 	// to produce a periodic blink.
 	let blinkUrl = "";
 	if (unread) {
-		const blinkPixels = resolveBodyPixels(p, "right", true, eyeColor);
-		const blinkCanvas = document.createElement("canvas");
-		blinkCanvas.width = BODY_WIDTH * HI;
-		blinkCanvas.height = BODY_HEIGHT * HI;
-		const blinkCtx = blinkCanvas.getContext("2d")!;
-		blinkCtx.imageSmoothingEnabled = false;
-		for (const [x, y, color] of blinkPixels) {
-			blinkCtx.fillStyle = color;
-			blinkCtx.fillRect(x * HI, y * HI, HI, HI);
+		// Blink pixels depend only on the palette (status bucket) and eye color
+		// (isSelected) — gaze is fixed "right" and blink is fixed true here.
+		const blinkKey = `${statusBucket}|${isSelected ? 1 : 0}`;
+		let cached = sidebarBlinkUrlCache.get(blinkKey);
+		if (cached === undefined) {
+			const blinkPixels = resolveBodyPixels(p, "right", true, eyeColor);
+			const blinkCanvas = document.createElement("canvas");
+			blinkCanvas.width = BODY_WIDTH * HI;
+			blinkCanvas.height = BODY_HEIGHT * HI;
+			const blinkCtx = blinkCanvas.getContext("2d")!;
+			blinkCtx.imageSmoothingEnabled = false;
+			for (const [x, y, color] of blinkPixels) {
+				blinkCtx.fillStyle = color;
+				blinkCtx.fillRect(x * HI, y * HI, HI, HI);
+			}
+			cached = blinkCanvas.toDataURL();
+			sidebarBlinkUrlCache.set(blinkKey, cached);
 		}
-		blinkUrl = blinkCanvas.toDataURL();
+		blinkUrl = cached;
 	}
 
 	// Eye overlay at HI× (only when selected)
 	let eyeUrl = "";
 	if (isSelected) {
-		const eyePos = EYE_POSITIONS["center"];
-		const eyePixels: SpritePixel[] = [
-			[eyePos.lx, eyePos.ly, p.eye], [eyePos.rx, eyePos.ry, p.eye],
-			[eyePos.lx, eyePos.ly + 1, p.eye], [eyePos.rx, eyePos.ry + 1, p.eye],
-		];
-		const eyeCanvas = document.createElement("canvas");
-		eyeCanvas.width = BODY_WIDTH * HI;
-		eyeCanvas.height = BODY_HEIGHT * HI;
-		const eyeCtx = eyeCanvas.getContext("2d")!;
-		eyeCtx.imageSmoothingEnabled = false;
-		for (const [x, y, color] of eyePixels) {
-			eyeCtx.fillStyle = color;
-			eyeCtx.fillRect(x * HI, y * HI, HI, HI);
+		// The overlay eye pixels use only the palette eye color (p.eye) at the
+		// fixed center gaze, so they depend solely on the status bucket.
+		const eyeKey = statusBucket;
+		let cached = sidebarEyeUrlCache.get(eyeKey);
+		if (cached === undefined) {
+			const eyePos = EYE_POSITIONS["center"];
+			const eyePixels: SpritePixel[] = [
+				[eyePos.lx, eyePos.ly, p.eye], [eyePos.rx, eyePos.ry, p.eye],
+				[eyePos.lx, eyePos.ly + 1, p.eye], [eyePos.rx, eyePos.ry + 1, p.eye],
+			];
+			const eyeCanvas = document.createElement("canvas");
+			eyeCanvas.width = BODY_WIDTH * HI;
+			eyeCanvas.height = BODY_HEIGHT * HI;
+			const eyeCtx = eyeCanvas.getContext("2d")!;
+			eyeCtx.imageSmoothingEnabled = false;
+			for (const [x, y, color] of eyePixels) {
+				eyeCtx.fillStyle = color;
+				eyeCtx.fillRect(x * HI, y * HI, HI, HI);
+			}
+			cached = eyeCanvas.toDataURL();
+			sidebarEyeUrlCache.set(eyeKey, cached);
 		}
-		eyeUrl = eyeCanvas.toDataURL();
+		eyeUrl = cached;
 	}
 
 	// Accessory at HI× scale
@@ -696,18 +782,26 @@ export function renderSidebarBobbitCanvas(opts: SidebarBobbitOptions): TemplateR
 			const yShift = Math.min(0, minY);
 			const srcW = maxX + 1;
 			const srcH = maxY - yShift + 1;
+			// CSS geometry is derived from the (static) pixel bounds — cheap to
+			// recompute. Only the data-URL encode is cached, keyed by accessory
+			// id alone since each accessory's pixels are immutable.
 			accCssW = srcW * S;
 			accCssH = srcH * S;
-			const accCanvas = document.createElement("canvas");
-			accCanvas.width = srcW * HI;
-			accCanvas.height = srcH * HI;
-			const accCtx = accCanvas.getContext("2d")!;
-			accCtx.imageSmoothingEnabled = false;
-			for (const [x, y, color] of spriteData.pixels) {
-				accCtx.fillStyle = color;
-				accCtx.fillRect(x * HI, (y - yShift) * HI, HI, HI);
+			let cached = sidebarAccessoryUrlCache.get(acc.id);
+			if (cached === undefined) {
+				const accCanvas = document.createElement("canvas");
+				accCanvas.width = srcW * HI;
+				accCanvas.height = srcH * HI;
+				const accCtx = accCanvas.getContext("2d")!;
+				accCtx.imageSmoothingEnabled = false;
+				for (const [x, y, color] of spriteData.pixels) {
+					accCtx.fillStyle = color;
+					accCtx.fillRect(x * HI, (y - yShift) * HI, HI, HI);
+				}
+				cached = accCanvas.toDataURL();
+				sidebarAccessoryUrlCache.set(acc.id, cached);
 			}
-			accUrl = accCanvas.toDataURL();
+			accUrl = cached;
 		}
 	}
 

--- a/tests/canvas-eye-getanimations.spec.ts
+++ b/tests/canvas-eye-getanimations.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression: the rAF eye-animation loop must NOT call getAnimations() every
+ * frame.
+ *
+ * readPhasePct() observes the CSS animation clock by finding the cycle-duration
+ * Animation on the canvas. getAnimations() enumerates + allocates an array of
+ * every Animation on the element, and was being called once per requestAnimation
+ * Frame per sprite — a measurable renderer hotspot (~8.5% CPU under sidebar
+ * churn). The target Animation is a persistent object, so it must be resolved
+ * once and cached, then reused across frames (reading .currentTime live each
+ * frame). This spec lets the loop run many frames and asserts getAnimations()
+ * is called only a small constant number of times, NOT once per frame.
+ */
+import { test, expect } from "@playwright/test";
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const FIXTURE = path.resolve("tests/fixtures/canvas-eye-getanimations.html");
+const BUNDLE = path.resolve("tests/fixtures/canvas-eye-getanimations-bundle.js");
+const ENTRY = path.resolve("tests/fixtures/canvas-eye-getanimations-entry.ts");
+const SOURCES = [
+	ENTRY,
+	path.resolve("src/ui/bobbit-render.ts"),
+	path.resolve("src/ui/bobbit-sprite-data.ts"),
+];
+
+function fileUrl(file: string): string {
+	return `file://${file.replace(/\\/g, "/")}`;
+}
+
+test.beforeAll(() => {
+	const sourceMtime = Math.max(...SOURCES.map(source => fs.statSync(source).mtimeMs));
+	const bundleExists = fs.existsSync(BUNDLE);
+	const bundleStale = bundleExists && fs.statSync(BUNDLE).mtimeMs < sourceMtime;
+	if (!bundleExists || bundleStale) {
+		execSync(
+			[
+				`npx esbuild ${ENTRY}`,
+				"--bundle --format=iife --target=es2022",
+				`--outfile=${BUNDLE}`,
+				"--tsconfig=tsconfig.web.json",
+			].join(" "),
+			{ stdio: "pipe" },
+		);
+	}
+});
+
+test.describe("Canvas eye animation getAnimations() caching", () => {
+	test("resolves the phase animation once, not once per rAF frame", async ({ page }) => {
+		await page.addInitScript(() => {
+			(window as any).__getAnimationsCalls = 0;
+			const original = Element.prototype.getAnimations;
+			Element.prototype.getAnimations = function (...args: any[]) {
+				(window as any).__getAnimationsCalls = ((window as any).__getAnimationsCalls ?? 0) + 1;
+				return Reflect.apply(original, this, args);
+			} as any;
+		});
+
+		await page.goto(fileUrl(FIXTURE));
+		await page.waitForFunction(() => (window as any).__ready === true);
+
+		const result = await page.evaluate(async () => {
+			const canvas = document.getElementById("sprite") as HTMLCanvasElement;
+			const cycleMs = 10000;
+			// Give the canvas a live, infinitely-looping animation with the cycle
+			// duration the loop looks for, so resolvePhaseAnimation() finds and
+			// caches a real (never-finishing) Animation object on frame 1.
+			canvas.animate(
+				[{ transform: "translateY(0)" }, { transform: "translateY(0)" }],
+				{ duration: cycleMs, iterations: Infinity },
+			);
+
+			const stop = (window as any).__canvasEyeAnim.start(canvas, cycleMs);
+
+			// Run the rAF loop for a fixed number of frames.
+			const FRAMES = 30;
+			(window as any).__getAnimationsCalls = 0; // count only steady-state frames
+			await new Promise<void>((resolve) => {
+				let n = 0;
+				const step = () => {
+					if (++n >= FRAMES) { resolve(); return; }
+					requestAnimationFrame(step);
+				};
+				requestAnimationFrame(step);
+			});
+
+			stop();
+			return {
+				calls: (window as any).__getAnimationsCalls as number,
+				frames: FRAMES,
+			};
+		});
+
+		// The cached reference is reused every frame: getAnimations() should fire
+		// at most a small constant number of times (ideally 0–1 in steady state),
+		// NEVER proportional to the ~30 frames that elapsed. Pre-fix this was ~30.
+		expect(result.calls).toBeLessThanOrEqual(2);
+		expect(result.calls).toBeLessThan(result.frames);
+	});
+});

--- a/tests/fixtures/canvas-eye-getanimations-entry.ts
+++ b/tests/fixtures/canvas-eye-getanimations-entry.ts
@@ -1,0 +1,13 @@
+// Test entry point — bundles startCanvasEyeAnimation for file:// use so a spec
+// can drive the real rAF eye-animation loop and observe how often
+// Element.prototype.getAnimations() is called per frame. Pins the per-frame
+// getAnimations() caching in readPhasePct (src/ui/bobbit-render.ts).
+import { startCanvasEyeAnimation } from "../../src/ui/bobbit-render.js";
+import { BUSY_EYE_SEQUENCE } from "../../src/ui/bobbit-sprite-data.js";
+
+(window as any).__canvasEyeAnim = {
+	start(canvas: HTMLCanvasElement, cycleMs: number): () => void {
+		return startCanvasEyeAnimation(canvas, BUSY_EYE_SEQUENCE, cycleMs);
+	},
+};
+(window as any).__ready = true;

--- a/tests/fixtures/canvas-eye-getanimations.html
+++ b/tests/fixtures/canvas-eye-getanimations.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  canvas { width: 40px; height: 36px; }
+</style>
+</head>
+<body>
+<canvas id="sprite"></canvas>
+<script src="canvas-eye-getanimations-bundle.js"></script>
+</body>
+</html>

--- a/tests/fixtures/sidebar-bobbit-datauri-cache-entry.ts
+++ b/tests/fixtures/sidebar-bobbit-datauri-cache-entry.ts
@@ -1,0 +1,22 @@
+// Test entry point — bundles the real renderSidebarBobbitCanvas (and Lit's
+// render) for file:// use, so the spec can render the same sprite opts N times
+// and observe how many times the canvas data-URL encode (toDataURL) actually
+// runs. Pins the data-URL memoization in src/ui/bobbit-render.ts.
+import { render } from "lit";
+import {
+	renderSidebarBobbitCanvas,
+	ACCESSORY_DEFS,
+	NO_ACCESSORY,
+	type SidebarBobbitOptions,
+} from "../../src/ui/bobbit-render.js";
+
+function renderInto(host: HTMLElement, opts: SidebarBobbitOptions): void {
+	render(renderSidebarBobbitCanvas(opts), host);
+}
+
+(window as any).__sidebarBobbit = {
+	renderInto,
+	ACCESSORY_DEFS,
+	NO_ACCESSORY,
+};
+(window as any).__ready = true;

--- a/tests/fixtures/sidebar-bobbit-datauri-cache.html
+++ b/tests/fixtures/sidebar-bobbit-datauri-cache.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+</style>
+</head>
+<body>
+<div id="host"></div>
+<script src="sidebar-bobbit-datauri-cache-bundle.js"></script>
+</body>
+</html>

--- a/tests/sidebar-bobbit-datauri-cache.spec.ts
+++ b/tests/sidebar-bobbit-datauri-cache.spec.ts
@@ -1,0 +1,229 @@
+/**
+ * Regression: renderSidebarBobbitCanvas must memoize its per-layer
+ * canvas.toDataURL() encodes.
+ *
+ * toDataURL() is a synchronous, main-thread PNG encode (~5-9ms per call for
+ * these small canvases). The sidebar re-renders on every WS status tick, and
+ * each sprite issues up to 4 encodes (body + blink + eye + accessory). Without
+ * memoization a ~20-session sidebar burned ~200ms of blocking work per render
+ * event. Every data-URL is a pure function of a small discrete input set, so
+ * repeat renders of identical opts must reuse the cached URL and call
+ * toDataURL() ONLY on the first render.
+ *
+ * This spec FAILS on the pre-memoization behaviour (4 encodes × N renders) and
+ * also guards key correctness (different pixel-affecting opts ⇒ different URL;
+ * hue-rotate, applied as CSS, ⇒ same URL).
+ */
+import { test, expect } from "@playwright/test";
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const FIXTURE = path.resolve("tests/fixtures/sidebar-bobbit-datauri-cache.html");
+const BUNDLE = path.resolve("tests/fixtures/sidebar-bobbit-datauri-cache-bundle.js");
+const ENTRY = path.resolve("tests/fixtures/sidebar-bobbit-datauri-cache-entry.ts");
+const SOURCES = [
+	ENTRY,
+	path.resolve("src/ui/bobbit-render.ts"),
+	path.resolve("src/ui/bobbit-sprite-data.ts"),
+];
+
+function fileUrl(file: string): string {
+	return `file://${file.replace(/\\/g, "/")}`;
+}
+
+test.beforeAll(() => {
+	const sourceMtime = Math.max(...SOURCES.map(source => fs.statSync(source).mtimeMs));
+	const bundleExists = fs.existsSync(BUNDLE);
+	const bundleStale = bundleExists && fs.statSync(BUNDLE).mtimeMs < sourceMtime;
+	if (!bundleExists || bundleStale) {
+		execSync(
+			[
+				`npx esbuild ${ENTRY}`,
+				"--bundle --format=iife --target=es2022",
+				`--outfile=${BUNDLE}`,
+				"--tsconfig=tsconfig.web.json",
+			].join(" "),
+			{ stdio: "pipe" },
+		);
+	}
+});
+
+/** Install a toDataURL spy BEFORE any module loads so module-level caches are
+ *  fresh per page and every encode is counted. Records each produced URL. */
+async function installSpyAndLoad(page: import("@playwright/test").Page): Promise<void> {
+	await page.addInitScript(() => {
+		(window as any).__dataUrlCalls = 0;
+		(window as any).__dataUrls = [] as string[];
+		const original = HTMLCanvasElement.prototype.toDataURL;
+		HTMLCanvasElement.prototype.toDataURL = function (...args: any[]) {
+			(window as any).__dataUrlCalls = ((window as any).__dataUrlCalls ?? 0) + 1;
+			const url = Reflect.apply(original, this, args);
+			(window as any).__dataUrls.push(url);
+			return url;
+		} as any;
+	});
+	await page.goto(fileUrl(FIXTURE));
+	await page.waitForFunction(() => (window as any).__ready === true);
+}
+
+test.describe("Sidebar bobbit data-URL memoization", () => {
+	test("identical opts: toDataURL runs once on first render, never again", async ({ page }) => {
+		await installSpyAndLoad(page);
+
+		const N = 8;
+		const result = await page.evaluate((n) => {
+			const api = (window as any).__sidebarBobbit;
+			const host = document.getElementById("host")!;
+			// Selected + unread + accessory: exercises all four layers
+			// (body, blink, eye, accessory) so the first render encodes 4 times.
+			const opts = {
+				status: "idle",
+				isSelected: true,
+				unread: true,
+				accessory: api.ACCESSORY_DEFS["crown"],
+			};
+			(window as any).__dataUrlCalls = 0;
+			for (let i = 0; i < n; i++) api.renderInto(host, opts);
+			return { calls: (window as any).__dataUrlCalls };
+		}, N);
+
+		// First render encodes the 4 distinct layers; every subsequent identical
+		// render is a pure cache hit. Pre-memoization this would be 4 * N = 32.
+		expect(result.calls).toBe(4);
+		expect(result.calls).toBeLessThan(4 * N);
+	});
+
+	test("single-layer sprite: only one encode across many renders", async ({ page }) => {
+		await installSpyAndLoad(page);
+
+		const N = 10;
+		const calls = await page.evaluate((n) => {
+			const api = (window as any).__sidebarBobbit;
+			const host = document.getElementById("host")!;
+			// Plain streaming sprite: body layer only (no blink, no eye overlay,
+			// no accessory) ⇒ exactly one encode total.
+			const opts = { status: "streaming", accessory: api.NO_ACCESSORY };
+			(window as any).__dataUrlCalls = 0;
+			for (let i = 0; i < n; i++) api.renderInto(host, opts);
+			return (window as any).__dataUrlCalls;
+		}, N);
+
+		expect(calls).toBe(1);
+	});
+
+	test("hue-rotate is CSS-only: does not produce a distinct cached bitmap", async ({ page }) => {
+		await installSpyAndLoad(page);
+
+		const calls = await page.evaluate(() => {
+			const api = (window as any).__sidebarBobbit;
+			const host = document.getElementById("host")!;
+			(window as any).__dataUrlCalls = 0;
+			// Same pixel inputs, different hue. Hue is applied as a CSS filter on
+			// the <img>, never baked into the bitmap, so both share one encode.
+			api.renderInto(host, { status: "streaming", hueRotate: 0, accessory: api.NO_ACCESSORY });
+			api.renderInto(host, { status: "streaming", hueRotate: 90, accessory: api.NO_ACCESSORY });
+			api.renderInto(host, { status: "streaming", hueRotate: -60, accessory: api.NO_ACCESSORY });
+			return (window as any).__dataUrlCalls;
+		});
+
+		expect(calls).toBe(1);
+	});
+
+	test("key correctness: pixel-affecting opts produce DIFFERENT cached URLs", async ({ page }) => {
+		await installSpyAndLoad(page);
+
+		const urls = await page.evaluate(() => {
+			const api = (window as any).__sidebarBobbit;
+			const host = document.getElementById("host")!;
+			const grab = () => {
+				(window as any).__dataUrls = [];
+				return (window as any).__dataUrls as string[];
+			};
+
+			// 1. Body palette differs by status bucket (canonical vs starting vs terminated).
+			grab();
+			api.renderInto(host, { status: "idle", accessory: api.NO_ACCESSORY });
+			const canonicalBody = (window as any).__dataUrls.slice();
+			grab();
+			api.renderInto(host, { status: "starting", accessory: api.NO_ACCESSORY });
+			const startingBody = (window as any).__dataUrls.slice();
+			grab();
+			api.renderInto(host, { status: "terminated", accessory: api.NO_ACCESSORY });
+			const terminatedBody = (window as any).__dataUrls.slice();
+
+			// 2. isSelected changes the body eye color AND adds an eye overlay.
+			grab();
+			api.renderInto(host, { status: "idle", isSelected: true, accessory: api.NO_ACCESSORY });
+			const selected = (window as any).__dataUrls.slice();
+
+			// 3. unread changes gaze (right) and pose vs sleeping idle.
+			grab();
+			api.renderInto(host, { status: "idle", unread: true, accessory: api.NO_ACCESSORY });
+			const unread = (window as any).__dataUrls.slice();
+
+			// 4. Different accessories ⇒ different accessory bitmaps.
+			grab();
+			api.renderInto(host, { status: "idle", accessory: api.ACCESSORY_DEFS["crown"] });
+			const crown = (window as any).__dataUrls.slice();
+			grab();
+			api.renderInto(host, { status: "idle", accessory: api.ACCESSORY_DEFS["bandana"] });
+			const bandana = (window as any).__dataUrls.slice();
+
+			return {
+				canonicalBody: canonicalBody[0],
+				startingBody: startingBody[0],
+				terminatedBody: terminatedBody[0],
+				selectedFirst: selected[0],
+				unreadFirst: unread[0],
+				crownAcc: crown[crown.length - 1],
+				bandanaAcc: bandana[bandana.length - 1],
+			};
+		});
+
+		// Status buckets ⇒ distinct body bitmaps (palette).
+		expect(urls.canonicalBody).not.toEqual(urls.startingBody);
+		expect(urls.canonicalBody).not.toEqual(urls.terminatedBody);
+		expect(urls.startingBody).not.toEqual(urls.terminatedBody);
+		// isSelected and unread change the body bitmap vs plain idle.
+		expect(urls.selectedFirst).not.toEqual(urls.canonicalBody);
+		expect(urls.unreadFirst).not.toEqual(urls.canonicalBody);
+		// Distinct accessories ⇒ distinct accessory bitmaps.
+		expect(urls.crownAcc).not.toEqual(urls.bandanaAcc);
+		// Sanity: encodes are non-empty PNG data URLs.
+		expect(urls.canonicalBody.startsWith("data:image/png")).toBe(true);
+	});
+
+	test("idle vs streaming must NOT collide: idle sleeps (eyes closed), streaming is awake", async ({ page }) => {
+		await installSpyAndLoad(page);
+
+		// Reads the rendered body <img src> directly (not the spy) so a cache HIT
+		// vs MISS both report the final bitmap. Both "idle" and "streaming" share
+		// the same palette bucket ("canonical") and identical option booleans, so
+		// a key built only from the status BUCKET would alias them onto one cache
+		// entry — and the second render would silently reuse the first's bitmap.
+		// They differ in pixels: idle resolves to the sleeping (eyes-closed) pose,
+		// streaming to the awake (eyes-open) pose. This pins that distinction.
+		const r = await page.evaluate(() => {
+			const api = (window as any).__sidebarBobbit;
+			const bodySrc = (opts: any) => {
+				const h = document.createElement("div");
+				document.body.appendChild(h);
+				api.renderInto(h, { accessory: api.NO_ACCESSORY, ...opts });
+				return h.querySelector("img")!.getAttribute("src");
+			};
+			return {
+				idle: bodySrc({ status: "idle" }),
+				streaming: bodySrc({ status: "streaming" }),
+				busy: bodySrc({ status: "busy" }),
+			};
+		});
+
+		// idle (sleeping) must differ from the awake non-idle statuses, even though
+		// all three map to the "canonical" palette bucket.
+		expect(r.idle).not.toEqual(r.streaming);
+		expect(r.idle).not.toEqual(r.busy);
+		// streaming and busy are both awake canonical bodies ⇒ legitimately equal.
+		expect(r.streaming).toEqual(r.busy);
+	});
+});


### PR DESCRIPTION
## Problem

The sidebar Bobbit sprite (`renderSidebarBobbitCanvas` in `src/ui/bobbit-render.ts`) re-encoded its canvas bitmaps to PNG data-URLs on **every Lit render** — `canvas.toDataURL()` is **~5–9ms per call** (measured), up to 4 layers per sprite. Separately, `readPhasePct()` called `canvas.getAnimations()` on **every `requestAnimationFrame` frame, per sprite**.

Profiled live via the Chrome DevTools Protocol: under sidebar activity (e.g. session-switch re-renders with ~20 sessions) this was **~17–29% of renderer CPU in `toDataURL` + ~8.5% in `getAnimations`**, bursting to **~60% of a core**. A settled UI is idle, so the cost is entirely per-render-event and scales with sprite count.

## Fix

- **`toDataURL` memoization** — four module-level `Map<string,string>` caches keyed on the discrete pixel-affecting inputs. The body layer is keyed on the resolved `isSleeping` value, not the raw status bucket (the bucket collapses `idle`/`streaming` to `canonical`, but only `idle` is the eyes-closed pose — keying on the bucket alone would collide the two and render the wrong sprite). `hueRotate`/`saturate` remain CSS filters (not keyed); DPR is not keyed (fixed `HI=8`). Caches are unbounded-but-tiny by construction (a few dozen entries) — documented inline.
- **`getAnimations` caching** — cache the `Animation` reference in `readPhasePct()`, re-enumerating only when it goes stale. `.currentTime` is still read live each frame, so the observed CSS-clock value is identical frame-to-frame and the "single source of truth" semantics are preserved. The eye-frame drawing path (`tick` / `drawImage`) is untouched.

## Impact

- `toDataURL` calls: 8 identical renders **32 → 4** (one per unique sprite); a single-layer streaming sprite over 10 renders **10 → 1**.
- `getAnimations` calls: over 30 frames **30 → 1**.
- **Pixel-identical** across a 16-opt × 27-layer matrix (byte-level data-URL diff vs the un-memoized build).

## Tests (both fail on the old behavior — verified)

- `tests/sidebar-bobbit-datauri-cache.spec.ts` — spies on `HTMLCanvasElement.prototype.toDataURL`; asserts one encode per unique sprite, hue is CSS-only, distinct pixel-affecting opts produce distinct URLs, and an explicit idle-vs-streaming non-collision case.
- `tests/canvas-eye-getanimations.spec.ts` — spies on `Element.prototype.getAnimations`; runs the real rAF loop for 30 frames and asserts ≤2 calls.

`npm run check` is green; the full `test:unit` phase passes (1453 passed, 2 skipped), including the existing `streaming-bobbit-canvas-ref` and `nurse-cap` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
