### PR TITLE
Omit skipped verification steps from failure notices

### DIFF
--- a/src/server/agent/notify-team-lead-failure.ts
+++ b/src/server/agent/notify-team-lead-failure.ts
@@ -15,6 +15,7 @@ export interface FailureStepLike {
 	name: string;
 	type: string;
 	passed: boolean;
+	skipped?: boolean;
 	output?: string;
 }
 
@@ -45,6 +46,8 @@ function describeFailedStep(step: FailureStepLike): string {
  *
  * @param gateId The gate that failed (for the leading line).
  * @param steps All step results from this verification (failed + passed).
+ *              Skipped steps are intentionally not listed as failures: later
+ *              phases skipped after an earlier failure have no logs to inspect.
  *              Pass an empty array if step detail is unavailable — the
  *              builder degrades to a generic inspect/status prompt.
  */
@@ -52,7 +55,7 @@ export function buildVerificationFailureMessage(
 	gateId: string,
 	steps: ReadonlyArray<FailureStepLike>,
 ): string {
-	const failed = steps.filter((s) => !s.passed);
+	const failed = steps.filter((s) => !s.passed && !s.skipped);
 
 	const lines: string[] = [];
 	lines.push("**Gate verification FAILED**");

--- a/tests/notify-team-lead-failure.test.ts
+++ b/tests/notify-team-lead-failure.test.ts
@@ -56,6 +56,21 @@ describe("buildVerificationFailureMessage", () => {
 		assert.match(message, /step="Signoff"/);
 	});
 
+	it("omits skipped later-phase steps from failed-step inspect commands", () => {
+		const message = buildVerificationFailureMessage("ready-to-merge", [
+			{ name: "Unit tests", type: "command", passed: false, output: "unit output" },
+			{ name: "Code review", type: "llm-review", passed: false, skipped: true, output: "Skipped — earlier phase failed" },
+			{ name: "QA", type: "agent-qa", passed: false, skipped: true, output: "Skipped — earlier phase failed" },
+		]);
+
+		assert.match(message, /\*\*Failed gate:\*\* `ready-to-merge` — `Unit tests`/);
+		assert.match(message, /step="Unit tests"/);
+		assert.doesNotMatch(message, /\*\*Failed step:\*\* `Code review`/);
+		assert.doesNotMatch(message, /\*\*Failed step:\*\* `QA`/);
+		assert.doesNotMatch(message, /step="Code review"/);
+		assert.doesNotMatch(message, /step="QA"/);
+	});
+
 	it("omits long failed-step output entirely instead of truncating it", () => {
 		const output = `START\n${"x".repeat(610)}\nTAIL`;
 		const message = buildVerificationFailureMessage("execution", [


### PR DESCRIPTION
## Summary
- Exclude skipped verification steps from team-lead failure notifications
- Keep inspect commands focused on steps that actually ran and failed
- Add regression coverage for later-phase steps skipped after an earlier failure

## Testing
- npx tsx --test tests/notify-team-lead-failure.test.ts
- npm run check

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)