### PR TITLE
Refresh MCP permissions on agent restart

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1035,6 +1035,12 @@ If you still see this on an old build, upgrade — or check `.bobbit/config/tool
 
 `GET /api/mcp-servers` returns the structured list (`{name,status,toolCount,tools[]}`). `src/app/tool-manager-page.ts::renderMcpSection()` filters them out of normal group rendering and shows one row per server in a dedicated MCP section. Empty section means `getMcpManager()` returned no configs — check the `discoverServers()` cascade in `src/server/mcp/mcp-manager.ts`.
 
+## MCP group changed from `never`, but refreshed agent still cannot use it
+
+`Refresh agent` should recompute normal role-derived allowed tools from the current role/group/MCP policy cascade. If the `mcp_<server>` meta-tool is still absent after changing `mcp__<server>` from `never` to `ask` or `allow`, check `SessionManager.recomputeAllowedToolsForRestart()` and `restoreSession()` in `src/server/agent/session-manager.ts`: normal sessions must not carry the stale live `session.allowedTools` cache as `_overrideAllowedTools`. Persisted session allow-lists, `session-only` grants, and unconsumed `one-time` grants are the exceptions. Regression coverage: `tests/e2e/mcp-tool-permission.spec.ts`.
+
+If the meta-tool remains blocked only for one role, inspect that role's `toolPolicies`. Role-level `mcp__<server>: never` intentionally wins over group defaults.
+
 ## Auto-nudge flooding
 
 Symptom: team-lead receives many `team_agent_finished` steers in quick succession. Cause: missing dedup. The `nudgePending` guard in `TeamManager` coalesces concurrent nudges into one delivery; if a regression removes it, a flood returns. Reviewer / QA sub-sessions are additionally filtered by `kind: "reviewer"` in `resubscribeTeamEvents()` and `notifyTeamLead()` — they must never nudge the team lead.

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1324,6 +1324,24 @@ Why no MCP-specific builtin denials: MCP servers should have the same baseline a
 
 Disruptive servers (e.g. headed Chromium from `@playwright/mcp`) are opted out at the **role** layer instead — see `defaults/roles/qa-tester.yaml`, which sets `toolPolicies: { mcp__playwright: never }`. Roles that need the tool inherit the `allow` default; roles that shouldn't have it block it locally.
 
+### Refresh agent and MCP policy changes
+
+`Refresh agent` respawns the agent through the same restore path used for session recovery, but normal role-derived sessions do **not** reuse the previous live `session.allowedTools` as the authority. That array is a runtime cache of whatever was active when the agent was first spawned. On refresh, Bobbit recomputes the role-derived tool surface from the current role, tool default, group policy, and MCP server policy cascade.
+
+This matters for MCP policy edits made in the Tools page:
+
+- Changing an MCP group from `never` to `ask` makes the refreshed session register the relevant `mcp_<server>` meta-tool. Calls then hit the guard extension and broadcast the normal `tool_permission_needed` card.
+- Changing an MCP group from `never` to `allow` makes the refreshed session register the meta-tool and execute it without a permission card.
+- An explicit role-level `never` still wins over group defaults. For example, a role with `toolPolicies: { mcp__mock: never }` still blocks `mcp_mock` after the group default changes to `ask` or `allow`.
+
+Only genuinely session-scoped tool state is carried across the respawn:
+
+- persisted session allow-lists, such as delegate/read-only constraints or explicit creation-time overrides, remain authoritative and are preserved exactly;
+- `session-only` grants are re-applied in memory so they survive refresh without becoming durable role policy;
+- `one-time` grants are re-applied only for the interrupted turn and are still revoked on `agent_end`.
+
+Regression coverage lives in `tests/e2e/mcp-tool-permission.spec.ts`: the refresh scenario pins `never` → `ask` registration plus the permission-card broadcast, and the role-deny scenario pins role-level `mcp__mock: never` precedence over group `allow`.
+
 ### REST API
 
 - `PUT /api/roles/:name` - accepts `toolPolicies` (Record of tool/group name → `allow` | `ask` | `never`)

--- a/docs/mcp-meta-tools.md
+++ b/docs/mcp-meta-tools.md
@@ -196,6 +196,24 @@ carry sub-namespaces. Per-op policies on `mcp__<server>__<op>` /
 `mcp__<server>__<sub>__<op>` continue to be matched at Layer B (per-call)
 before meta-aggregation.
 
+### Applying policy changes to existing agents
+
+Changing an MCP group policy updates the stored cascade immediately, but an
+already-running agent must be refreshed before its model-facing tool surface
+changes. `Refresh agent` recomputes role-derived allowed tools from the current
+cascade, so a server that moved from `never` to `ask` or `allow` registers its
+`mcp_<server>` meta-tool after the refresh.
+
+`ask` and `allow` differ only at execution time: `ask` registers the meta-tool
+and routes calls through the permission guard, while `allow` registers it for
+direct execution. A role-level `never` on the MCP key still wins over group
+policy and keeps the meta-tool unavailable.
+
+Session-scoped grants are not lost during this respawn. `session-only` grants
+and any unconsumed `one-time` grants are re-applied in memory; persisted
+session allow-list constraints, such as delegate/read-only restrictions, remain
+authoritative.
+
 ## Tools page UI
 
 The Tools page surfaces one row per MCP **server** under a dedicated "MCP"

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -111,6 +111,8 @@ Success returns `200`:
 
 Restart is in-place. It preserves the session id, transcript/history, persisted session metadata, and any connected WebSocket clients. The manager stops the existing process, restores the persisted session, reattaches clients, and switches the new process back to the existing transcript file. The restore path rebuilds the session prompt, tool definitions, tool activation, MCP proxy/guard extensions, MCP-backed tool surface, MCP server configuration/auth state, and per-session environment from the current server-side managers and config.
 
+For normal role-derived sessions, restart recomputes allowed tools from the current role/tool/group/MCP policy cascade instead of reusing the previous live allow-list. This is why an MCP group changed from `never` to `ask` or `allow` takes effect after `Refresh agent`. Persisted session allow-list constraints and live `session-only` / `one-time` grants are still carried across where appropriate, and explicit role-level `never` policies still take precedence over group defaults.
+
 Stable error codes:
 
 | Status | Code | Meaning |

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -320,7 +320,9 @@ export interface SessionInfo {
 		seq: number;
 		ts: number;
 	};
-	/** Tools granted via "one-time" mode — revoked on agent_end */
+	/** Tools granted via "session-only" mode — re-applied across Refresh agent, not persisted to disk. */
+	sessionOnlyGrantedTools?: string[];
+	/** Tools granted via "one-time" mode — re-applied across Refresh agent and revoked on agent_end. */
 	oneTimeGrantedTools?: string[];
 	/** Whether post-start setup (model, thinking, metadata) has completed */
 	setupComplete?: boolean;
@@ -1730,6 +1732,18 @@ export class SessionManager {
 		return [];
 	}
 
+	private mergeToolNames(existing: string[] | undefined, additions: string[] | undefined): string[] | undefined {
+		const merged: string[] = [];
+		const seen = new Set<string>();
+		for (const name of [...(existing ?? []), ...(additions ?? [])]) {
+			const key = name.toLowerCase();
+			if (seen.has(key)) continue;
+			seen.add(key);
+			merged.push(name);
+		}
+		return merged.length > 0 ? merged : undefined;
+	}
+
 	private buildToolActivationArgs(
 		sessionId: string,
 		allowedTools: EffectiveTool[] | undefined,
@@ -3054,7 +3068,7 @@ export class SessionManager {
 	 *
 	 * @param mode - Grant persistence mode:
 	 *   - "persistent" (default): updates role YAML permanently
-	 *   - "session-only": adds to session.allowedTools in memory only (survives until session ends/restarts)
+	 *   - "session-only": adds to session.allowedTools in memory only (survives Refresh agent, not gateway restart)
 	 *   - "one-time": adds to session.allowedTools + tracks for revocation on agent_end
 	 */
 	async grantToolPermission(sessionId: string, toolName: string, scope: "tool" | "group", group?: string, mode?: "persistent" | "session-only" | "one-time"): Promise<string[]> {
@@ -3112,13 +3126,14 @@ export class SessionManager {
 		if (mode === "one-time") {
 			// Temporary grant: add to session.allowedTools, track for revocation on agent_end
 			session.allowedTools = [...(session.allowedTools || []), ...newTools];
-			session.oneTimeGrantedTools = [...(session.oneTimeGrantedTools || []), ...newTools];
+			session.oneTimeGrantedTools = this.mergeToolNames(session.oneTimeGrantedTools, newTools);
 			await this._restartSessionWithUpdatedRole(session);
 			resultTools = session.allowedTools;
 
 		} else if (mode === "session-only") {
 			// Session-scoped grant: add to session.allowedTools only, don't write role YAML
 			session.allowedTools = [...(session.allowedTools || []), ...newTools];
+			session.sessionOnlyGrantedTools = this.mergeToolNames(session.sessionOnlyGrantedTools, newTools);
 			await this._restartSessionWithUpdatedRole(session);
 			resultTools = session.allowedTools;
 
@@ -3215,6 +3230,28 @@ export class SessionManager {
 		pending.resolve({ granted: false });
 	}
 
+	private recomputeAllowedToolsForRestart(session: SessionInfo, ps: PersistedSession): string[] | undefined {
+		const persistedAllowedTools = Array.isArray(ps.allowedTools) && ps.allowedTools.length > 0
+			? ps.allowedTools
+			: undefined;
+		const sessionGrants = this.mergeToolNames(session.sessionOnlyGrantedTools, session.oneTimeGrantedTools);
+
+		// Persisted allow-lists are true session-scoped constraints (delegate/read-only
+		// children, explicit createSession overrides). Preserve them exactly, with any
+		// live grants layered on top.
+		if (persistedAllowedTools) {
+			return this.mergeToolNames(persistedAllowedTools, sessionGrants);
+		}
+
+		// Normal sessions derive their tool surface from the current role/group/MCP
+		// policy cascade. Only one-time/session-only grants are carried across the
+		// respawn; the old live session.allowedTools is just a stale cache.
+		if (!sessionGrants) return undefined;
+		const restoredRole = this.resolveSessionRole(ps.role, ps.assistantType, ps.projectId);
+		const recomputedAllowed = this.resolveEffectiveAllowedTools(restoredRole).map(t => t.name);
+		return this.mergeToolNames(recomputedAllowed, sessionGrants);
+	}
+
 	/**
 	 * Restart a session's agent process so it picks up updated role/tools.
 	 * Stops the current agent, then restores from the persisted session file
@@ -3225,19 +3262,18 @@ export class SessionManager {
 		if (!ps) return;
 
 		// Save in-memory grant state that restoreSession doesn't persist.
-		const savedAllowedTools = session.allowedTools ? [...session.allowedTools] : undefined;
+		const savedSessionOnlyGrantedTools = session.sessionOnlyGrantedTools ? [...session.sessionOnlyGrantedTools] : undefined;
 		const savedOneTimeGrantedTools = session.oneTimeGrantedTools ? [...session.oneTimeGrantedTools] : undefined;
+		const overrideAllowedTools = this.recomputeAllowedToolsForRestart(session, ps);
 
 		const restored = await this._respawnAgentInPlace(session, ps, {
 			mutatePs: p => {
-				// restoreSession normally derives allowedTools from role YAML; session-only
-				// and one-time grants need the augmented list to round-trip.
-				(p as any)._overrideAllowedTools = savedAllowedTools;
+				if (overrideAllowedTools) (p as any)._overrideAllowedTools = overrideAllowedTools;
 			},
 		});
 
 		if (restored) {
-			if (savedAllowedTools) restored.allowedTools = savedAllowedTools;
+			if (savedSessionOnlyGrantedTools) restored.sessionOnlyGrantedTools = savedSessionOnlyGrantedTools;
 			if (savedOneTimeGrantedTools) restored.oneTimeGrantedTools = savedOneTimeGrantedTools;
 		}
 	}
@@ -3346,15 +3382,18 @@ export class SessionManager {
 			throw zombieErr;
 		}
 
-		const savedAllowedTools = session.allowedTools ? [...session.allowedTools] : undefined;
+		const savedSessionOnlyGrantedTools = session.sessionOnlyGrantedTools ? [...session.sessionOnlyGrantedTools] : undefined;
 		const savedOneTimeGrantedTools = session.oneTimeGrantedTools ? [...session.oneTimeGrantedTools] : undefined;
+		const overrideAllowedTools = this.recomputeAllowedToolsForRestart(session, ps);
 
 		const restored = await this._respawnAgentInPlace(session, ps, {
-			mutatePs: p => { (p as any)._overrideAllowedTools = savedAllowedTools; },
+			mutatePs: p => {
+				if (overrideAllowedTools) (p as any)._overrideAllowedTools = overrideAllowedTools;
+			},
 		});
 
 		if (restored) {
-			if (savedAllowedTools) restored.allowedTools = savedAllowedTools;
+			if (savedSessionOnlyGrantedTools) restored.sessionOnlyGrantedTools = savedSessionOnlyGrantedTools;
 			if (savedOneTimeGrantedTools) restored.oneTimeGrantedTools = savedOneTimeGrantedTools;
 		} else {
 			throw new Error("Failed to restore session after restart");

--- a/tests/e2e/mcp-tool-permission.spec.ts
+++ b/tests/e2e/mcp-tool-permission.spec.ts
@@ -40,6 +40,37 @@ test.setTimeout(60_000);
 
 const ROLE_NAME = "mcp-perm-test-role";
 const DENIED_TOOL = "mcp__mock__echo";
+const MCP_GROUP_POLICY_KEY = "mcp__mock";
+const MCP_META_TOOL = "mcp_mock";
+const REFRESH_ROLE_NAME = "mcp-refresh-policy-role";
+const GROUP_DENY_ROLE_NAME = "mcp-group-deny-precedence-role";
+
+async function setMockMcpGroupPolicy(policy: "allow" | "ask" | "never" | null): Promise<void> {
+	const resp = await apiFetch(`/api/tool-group-policies/${encodeURIComponent(MCP_GROUP_POLICY_KEY)}`, {
+		method: "PUT",
+		body: JSON.stringify({ policy }),
+	});
+	expect(resp.status).toBe(200);
+}
+
+function sessionAllowedTools(
+	gateway: { sessionManager?: { getSession(id: string): { allowedTools?: string[] } | undefined } },
+	sessionId: string,
+): string[] {
+	const session = gateway.sessionManager?.getSession(sessionId);
+	expect(session, `Expected live session ${sessionId} to exist`).toBeTruthy();
+	return session?.allowedTools ?? [];
+}
+
+async function waitForSessionIdle(
+	gateway: { sessionManager?: { getSession(id: string): { status?: string } | undefined } },
+	sessionId: string,
+): Promise<void> {
+	await expect.poll(
+		() => gateway.sessionManager?.getSession(sessionId)?.status,
+		{ timeout: 15_000, message: `session ${sessionId} should become idle` },
+	).toBe("idle");
+}
 
 test.beforeAll(async () => {
 	// 1. Write MCP config to point at the mock MCP server
@@ -78,8 +109,11 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
-	// Clean up role
-	await apiFetch(`/api/roles/${ROLE_NAME}`, { method: "DELETE" }).catch(() => {});
+	// Clean up roles
+	for (const roleName of [ROLE_NAME, REFRESH_ROLE_NAME, GROUP_DENY_ROLE_NAME]) {
+		await apiFetch(`/api/roles/${roleName}`, { method: "DELETE" }).catch(() => {});
+	}
+	await setMockMcpGroupPolicy(null).catch(() => {});
 	// Clean up MCP config
 	const mcpConfigPath = join(bobbitDir(), "config", "mcp.json");
 	if (existsSync(mcpConfigPath)) {
@@ -95,6 +129,117 @@ test.describe("MCP Tool Permission — WebSocket protocol", () => {
 	let sessionId: string;
 	test.afterEach(async () => {
 		if (sessionId) { await deleteSession(sessionId); sessionId = ""; }
+	});
+
+	test("refresh recomputes MCP group policy from never to ask and broadcasts permission request", async ({ gateway }) => {
+		await apiFetch(`/api/roles/${REFRESH_ROLE_NAME}`, { method: "DELETE" }).catch(() => {});
+		await setMockMcpGroupPolicy("never");
+
+		const roleResp = await apiFetch("/api/roles", {
+			method: "POST",
+			body: JSON.stringify({
+				name: REFRESH_ROLE_NAME,
+				label: "MCP Refresh Policy Role",
+				promptTemplate: "Test role with no role-level MCP denial.",
+				toolPolicies: { Read: "allow" },
+			}),
+		});
+		expect(roleResp.status).toBe(201);
+
+		try {
+			const resp = await apiFetch("/api/sessions", {
+				method: "POST",
+				body: JSON.stringify({ cwd: nonGitCwd(), roleId: REFRESH_ROLE_NAME }),
+			});
+			expect(resp.status).toBe(201);
+			sessionId = (await resp.json()).id;
+			await waitForSessionIdle(gateway, sessionId);
+
+			const initialAllowed = sessionAllowedTools(gateway, sessionId);
+			expect(initialAllowed.length).toBeGreaterThan(0);
+			expect(initialAllowed).not.toContain(MCP_META_TOOL);
+
+			await setMockMcpGroupPolicy("ask");
+			const restartResp = await apiFetch(`/api/sessions/${sessionId}/restart`, { method: "POST" });
+			expect(restartResp.status).toBe(200);
+			await waitForSessionIdle(gateway, sessionId);
+
+			const refreshedAllowed = sessionAllowedTools(gateway, sessionId);
+			expect(
+				refreshedAllowed,
+				"MCP_REFRESH_ALLOWED_TOOLS_STALE: Refresh agent must recompute allowed tools after mcp__mock policy changes from never to ask",
+			).toContain(MCP_META_TOOL);
+
+			const conn = await connectWs(sessionId);
+			try {
+				const permissionReceived = conn.waitFor(
+					(m) => m.type === "tool_permission_needed" && m.toolName === DENIED_TOOL,
+					10_000,
+				);
+				const grantPromise = apiFetch(`/api/sessions/${sessionId}/tool-grant-request`, {
+					method: "POST",
+					body: JSON.stringify({ toolName: DENIED_TOOL, toolGroup: "MCP: mock" }),
+				});
+
+				const permMsg = await permissionReceived;
+				expect(permMsg.group).toBe("MCP: mock");
+				expect(permMsg.roleName).toBe(REFRESH_ROLE_NAME);
+
+				conn.send({ type: "deny_tool_permission", toolName: DENIED_TOOL });
+				const grantResult = await grantPromise.then(r => r.json());
+				expect(grantResult.granted).toBe(false);
+			} finally {
+				conn.close();
+			}
+		} finally {
+			await apiFetch(`/api/roles/${REFRESH_ROLE_NAME}`, { method: "DELETE" }).catch(() => {});
+			await setMockMcpGroupPolicy(null).catch(() => {});
+		}
+	});
+
+	test("role-level mcp__mock never overrides group allow for MCP calls", async ({ gateway }) => {
+		await apiFetch(`/api/roles/${GROUP_DENY_ROLE_NAME}`, { method: "DELETE" }).catch(() => {});
+		await setMockMcpGroupPolicy("allow");
+
+		const roleResp = await apiFetch("/api/roles", {
+			method: "POST",
+			body: JSON.stringify({
+				name: GROUP_DENY_ROLE_NAME,
+				label: "MCP Group Deny Precedence Role",
+				promptTemplate: "Test role with explicit MCP group denial.",
+				toolPolicies: { Read: "allow", [MCP_GROUP_POLICY_KEY]: "never" },
+			}),
+		});
+		expect(roleResp.status).toBe(201);
+
+		try {
+			const resp = await apiFetch("/api/sessions", {
+				method: "POST",
+				body: JSON.stringify({ cwd: nonGitCwd(), roleId: GROUP_DENY_ROLE_NAME }),
+			});
+			expect(resp.status).toBe(201);
+			sessionId = (await resp.json()).id;
+			await waitForSessionIdle(gateway, sessionId);
+
+			expect(sessionAllowedTools(gateway, sessionId)).not.toContain(MCP_META_TOOL);
+
+			const callResp = await fetch(`${base()}/api/internal/mcp-call`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${readE2EToken()}`,
+					"X-Bobbit-Session-Id": sessionId,
+				},
+				body: JSON.stringify({ tool: DENIED_TOOL, args: { message: "should be blocked" } }),
+			});
+			expect(callResp.status).toBe(403);
+			const callBody = await callResp.json();
+			expect(callBody.error).toMatch(/denied by policy/);
+			expect(callBody.reason).toBe("policy=never");
+		} finally {
+			await apiFetch(`/api/roles/${GROUP_DENY_ROLE_NAME}`, { method: "DELETE" }).catch(() => {});
+			await setMockMcpGroupPolicy(null).catch(() => {});
+		}
 	});
 
 	test("server broadcasts tool_permission_needed when denied MCP tool is used", async () => {


### PR DESCRIPTION
## Summary
- Recompute role-derived allowed tools during Refresh agent so current MCP group policies apply.
- Preserve explicit session allow-list constraints plus session-only/one-time grants across refresh.
- Add MCP refresh regression coverage and document behavior.

## Validation
- npm run check
- npx playwright test tests/e2e/mcp-tool-permission.spec.ts --project=browser --config=playwright-e2e.config.ts -g "refresh recomputes MCP group policy from never to ask" --retries=0
- npx playwright test tests/e2e/mcp-tool-permission.spec.ts --project=browser --config=playwright-e2e.config.ts -g "role-level mcp__mock never overrides group allow" --retries=0
- Implementation gate verification passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)