### PR TITLE
Remove Boot Respawn

### DIFF
--- a/docs/cold-restart-reprompt.md
+++ b/docs/cold-restart-reprompt.md
@@ -87,10 +87,11 @@ leak across restarts.
 ## Boot-resume nudge path
 
 `TeamManager._bootResumeIdleTeamLeads` runs on boot, after teams are
-re-subscribed. For each team whose lead is idle and has concrete outstanding work
-(and which is not paused / complete / shelved / archived / already nudge-pending),
-it dispatches a `[BOOT-RESUME]` nudge so progress resumes without waiting for the
-stuck-sweep tick.
+re-subscribed. It only iterates restored active teams from the team store; it does
+not start a new lead for a sessionless goal. For each restored team whose lead is
+idle and has concrete outstanding work (and which is not paused / complete /
+shelved / archived / already nudge-pending), it dispatches a `[BOOT-RESUME]`
+nudge so progress resumes without waiting for the stuck-sweep tick.
 
 The nudge is dispatched via `SessionManager.enqueuePrompt(sessionId, msg,
 { isSteered: true, coldStart: true })`. The `coldStart: true` option threads down

--- a/docs/design/production-subgoals-port.md
+++ b/docs/design/production-subgoals-port.md
@@ -198,8 +198,8 @@ Port all `tests/**` named in #497 except `*lsp*`/`tests/lsp/**`/
   `criteria-drop`); criteria-drop always rejected; divergence policy matrix
   (`strict`/`balanced`/`autonomous`); `replanCount > 5` auto-pauses.
 - Pause/resume cascade requires `{cascade}` (`422 CASCADE_REQUIRED`); every
-  spawn path returns `409 GOAL_PAUSED`; boot respawn supervisor skips paused
-  goals.
+  spawn path returns `409 GOAL_PAUSED`; restart boot-resume nudges skip paused
+  restored teams.
 
 ## Production deviation from #497 (reverted)
 
@@ -389,7 +389,7 @@ children.
 | "An agent can attach a custom workflow … and a child may override its parent's workflow." | spawn-child-workflow, workflow-store, nested-goal-routes | proposal-panels (Workflow/Roles tabs) | spawn-child-workflow-resolution, runSubgoalStep-inline-roles-inheritance |
 | "Completed child work merges locally into the parent branch with no per-child PR; only the root goal raises a PR; merge conflicts preserve the child." | skills/git (`mergeChildBranchLocal`, `shouldSkipRemotePush`), verification-harness (`runSubgoalStep`), child-ready-to-merge | GoalMergeChildRenderer | child-ready-to-merge-helper, runSubgoalStep-merge-then-archive |
 | "Plan changes after freeze are classified and gated by the divergence policy; criteria-drops are always rejected; excessive replans auto-pause the goal." | plan-mutation, plan-mutation-store, parent-workflow-freeze | GoalPlanProposeRenderer, GoalDecideMutationRenderer, children-mutation-approval | plan-mutation, plan-mutation-store, api-goals-plan-mutation |
-| "An operator can pause/resume a goal's entire subtree, and pause actually stops the work and survives supervisor respawn." | goal-paused-guard, goal-manager (`_bootRespawnSessionlessGoals` skip) | GoalPauseResumeRenderer | any-in-flight-child-excludes-paused, runSubgoalStep-paused-child-keeps-waiting |
+| "An operator can pause/resume a goal's entire subtree, and pause actually stops the work and survives supervisor respawn." | goal-paused-guard, TeamManager boot-resume skip predicates | GoalPauseResumeRenderer | any-in-flight-child-excludes-paused, runSubgoalStep-paused-child-keeps-waiting |
 
 ## Edge cases and recovery
 

--- a/docs/design/production-subgoals-port.md
+++ b/docs/design/production-subgoals-port.md
@@ -389,7 +389,7 @@ children.
 | "An agent can attach a custom workflow … and a child may override its parent's workflow." | spawn-child-workflow, workflow-store, nested-goal-routes | proposal-panels (Workflow/Roles tabs) | spawn-child-workflow-resolution, runSubgoalStep-inline-roles-inheritance |
 | "Completed child work merges locally into the parent branch with no per-child PR; only the root goal raises a PR; merge conflicts preserve the child." | skills/git (`mergeChildBranchLocal`, `shouldSkipRemotePush`), verification-harness (`runSubgoalStep`), child-ready-to-merge | GoalMergeChildRenderer | child-ready-to-merge-helper, runSubgoalStep-merge-then-archive |
 | "Plan changes after freeze are classified and gated by the divergence policy; criteria-drops are always rejected; excessive replans auto-pause the goal." | plan-mutation, plan-mutation-store, parent-workflow-freeze | GoalPlanProposeRenderer, GoalDecideMutationRenderer, children-mutation-approval | plan-mutation, plan-mutation-store, api-goals-plan-mutation |
-| "An operator can pause/resume a goal's entire subtree, and pause actually stops the work and survives supervisor respawn." | goal-paused-guard, TeamManager boot-resume skip predicates | GoalPauseResumeRenderer | any-in-flight-child-excludes-paused, runSubgoalStep-paused-child-keeps-waiting |
+| "An operator can pause/resume a goal's entire subtree, and pause remains durable across gateway restart." | goal-paused-guard, TeamManager restored-lead boot-resume skip predicates | GoalPauseResumeRenderer | any-in-flight-child-excludes-paused, runSubgoalStep-paused-child-keeps-waiting |
 
 ## Edge cases and recovery
 
@@ -404,7 +404,7 @@ children.
 | `replanCount > 5` | plan PATCH | auto-pause the goal | plan-mutation, api-goals-plan-mutation |
 | Pending mutation TTL / restart | `plan-mutation-store` | 24h TTL, restart-safe persistence | plan-mutation-store |
 | Archived descendants in DAG vs live-only sidebar | `GET /descendants` (inclusive) vs `plan-live-only-toggle` | DAG includes archived (dimmed); sidebar filters | plan-archived-children |
-| Boot respawn over paused goal | `goal-manager` supervisor | skips paused goals (whack-a-mole fix); `backfillCompleteState` | any-in-flight-child-excludes-paused, cost-backfill-on-boot |
+| Restart with paused restored team | `TeamManager` restore/resubscribe | restores persisted active teams; boot-resume nudges skip paused restored leads; teamless existing goals are not started; `backfillCompleteState` | any-in-flight-child-excludes-paused, cost-backfill-on-boot |
 
 ## Execution plan (parallel, file-disjoint)
 

--- a/docs/goals-workflows-tasks.md
+++ b/docs/goals-workflows-tasks.md
@@ -10,7 +10,9 @@ A **goal** is a unit of work with a title, spec (markdown), working directory, a
 
 `POST /api/goals` requires the caller to identify the project: either an explicit `projectId` in the request body, or a `cwd` inside a registered project's `rootPath`. There is no default-project fallback — a request with neither resolvable returns **400**. See the [Project resolution contract](rest-api.md#project-resolution-contract) in the REST API docs for the exact error shape.
 
-Goals can run in **team mode**, where a Team Lead agent orchestrates multiple role agents (coders, reviewers, testers) working concurrently in their own worktrees. Goals carry an `autoStartTeam` flag (defaults to `true`). When enabled, the server automatically calls `teamManager.startTeam()` after worktree setup completes — no manual "Start Team" click needed. If auto-start fails but the worktree succeeded, the error is logged and the worktree remains usable; the user can start the team manually. The retry-setup handler also respects this flag.
+Goals can run in **team mode**, where a Team Lead agent orchestrates multiple role agents (coders, reviewers, testers) working concurrently in their own worktrees. Goals carry an `autoStartTeam` flag (defaults to `true`). That flag is evaluated only during the goal creation / setup flow: after worktree setup completes, the server may call `teamManager.startTeam()` so no manual "Start Team" click is needed. The retry-setup handler also respects the same flag.
+
+`autoStartTeam` is **not** a standing restart policy. On gateway/server restart, Bobbit restores persisted active teams and re-subscribes their existing sessions, but it does not create a new Team Lead for an existing goal that has no active team. A goal created with `autoStartTeam: false`, or a goal whose team was later stopped with `teardownTeam`, remains teamless across restart; once setup is ready the UI should continue to offer manual "Start Team". If creation-time auto-start fails but the worktree succeeded, the error is logged and the worktree remains usable for that same manual start path.
 
 ### Workflows
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -164,6 +164,18 @@ The migration is idempotent and handles missing files gracefully (fresh installs
 
 **Known limitations**: `active-verifications.json` stays in the central state dir (transient operational state).
 
+### Team restart restoration
+
+Team state is restored from each project's `team-state.json` so live teams survive gateway restarts without losing their lead/worker wiring. The restart path is restorative only:
+
+- `TeamManager.restoreTeams()` loads persisted team entries, repairs recoverable dangling records, and drops unrecoverable team-store entries so a future manual "Start Team" is not blocked by stale state.
+- After `SessionManager.restoreSessions()`, `TeamManager.resubscribeTeamEvents()` re-attaches lead/worker event listeners for those restored entries and may nudge an already-restored idle lead that has concrete outstanding work.
+- Restart does **not** scan team-mode goals and call `startTeam()` for goals that lack a restored team entry. A teamless existing goal stays teamless even if its persisted `autoStartTeam` flag is `true`.
+
+This distinction matters because `autoStartTeam` is a creation/setup affordance, not a supervisor. Goals created with `autoStartTeam: false` and goals explicitly stopped through `teardownTeam()` have no active team-store entry after setup/teardown, so they remain manual-start goals across restart. The UI should show "Start Team" rather than a silently recreated lead.
+
+Regression coverage: `tests/team-manager-boot-respawn.test.ts` pins that boot resubscribe does not call `startTeam()` for a sessionless ready team goal, and `tests/e2e/remove-boot-respawn-restart.spec.ts` covers start → teardown → restart → still teamless → manual start.
+
 ### Verification architecture
 
 The verification system is split into two modules:

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -174,7 +174,7 @@ Team state is restored from each project's `team-state.json` so live teams survi
 
 This distinction matters because `autoStartTeam` is a creation/setup affordance, not a supervisor. Goals created with `autoStartTeam: false` and goals explicitly stopped through `teardownTeam()` have no active team-store entry after setup/teardown, so they remain manual-start goals across restart. The UI should show "Start Team" rather than a silently recreated lead.
 
-Regression coverage: `tests/team-manager-boot-respawn.test.ts` pins that boot resubscribe does not call `startTeam()` for a sessionless ready team goal, and `tests/e2e/remove-boot-respawn-restart.spec.ts` covers start → teardown → restart → still teamless → manual start.
+Regression coverage pins that boot resubscribe does not call `startTeam()` for a sessionless ready team goal, and that start → teardown → restart leaves the goal teamless until manual start.
 
 ### Verification architecture
 

--- a/docs/nested-goals.md
+++ b/docs/nested-goals.md
@@ -309,9 +309,12 @@ place.
 
 - soft-aborts the subtree's sessions and cancels in-flight verifications,
 - makes every spawn path return `409 GOAL_PAUSED`,
-- and — critically — the **boot-respawn supervisor skips paused goals**, so a
-  paused goal stays paused across a gateway restart instead of being
-  resurrected (the "whack-a-mole" fix).
+- and keeps the pause durable across gateway restart.
+
+Restart restores persisted active teams and re-subscribes their existing leads.
+Boot-resume/nudge skip predicates apply only to those restored leads, so a
+paused restored lead is not nudged. Restart does not create a new Team Lead for
+an existing goal that is teamless.
 
 Resume re-enables spawns but does not auto-restart sessions. Pause/resume is an
 **operator** action and is distinct from the scheduler's dependency `blocked`

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -337,6 +337,8 @@ Routes accept both `/team/` and legacy `/swarm/` paths.
 | `POST` | `/api/goals/:id/team/complete` | Complete a team (dismiss agents, keep team lead). Body `{ confirmBypassedGates?: boolean }` — the agent/MCP path is refused while any gate is `bypassed`; a human confirms with `confirmBypassedGates: true` (403 for sandbox tokens). See [Gate bypass endpoint](#gate-bypass-endpoint). |
 | `POST` | `/api/goals/:id/team/teardown` | Fully tear down a team (dismiss all + terminate team lead) |
 
+Restart semantics: boot restores persisted active team entries and re-subscribes their sessions; it does not call `/team/start` implicitly for existing teamless goals. After `/team/teardown`, or after creating a goal with `autoStartTeam: false`, the goal remains teamless across restart and this explicit start route remains the manual recovery path.
+
 ### Orchestration routes (child agents)
 
 These back the `team_delegate` / `team_wait` / own-children `team_*` agent tools. `:id` is the

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -950,9 +950,6 @@ export class TeamManager {
 				);
 			}
 		}
-		// boot-respawn for sessionless in-progress goals — Boot-respawn for sessionless in-progress goals.
-		this._bootRespawnSessionlessGoals();
-
 		// boot-resume idle team-leads with outstanding work. The stuck-sweep
 		// would catch these after STUCK_QUIET_THRESHOLD_MS (5 min) but that
 		// leaves a gap where the operator sees a freshly-restored team-lead
@@ -1055,60 +1052,6 @@ export class TeamManager {
 		if (failedGates > 0) parts.push(`${failedGates} failed gate(s)`);
 		if (openTasks > 0) parts.push(`${openTasks} open task(s)`);
 		return parts.join(", ");
-	}
-
-	/**
-	 * boot-respawn for sessionless in-progress goals — Walk every non-archived goal that is in-progress, has
-	 * setupStatus=ready, and is a team goal but has no live team entry. Spin
-	 * up a fresh team-lead for each so the goal is not stranded.
-	 *
-	 * Symptom on PR #409: after several gateway restarts, three Phase-2 leaves
-	 * all sat in `state: in-progress, setupStatus: ready, archived: null`
-	 * with ZERO team agents and ZERO team-lead session. The harness's
-	 * existing recovery only fired when there was an active verification with
-	 * the child's planId — but the parent's verification record was itself
-	 * lost in the restart, so nothing rescued the orphan.
-	 *
-	 * Wraps each respawn in try/catch — one bad goal must not block the rest.
-	 */
-	private _bootRespawnSessionlessGoals(): void {
-		if (!this.config.projectContextManager) return;
-
-		for (const ctx of this.config.projectContextManager.all()) {
-			for (const goal of ctx.goalStore.getAll()) {
-				if (goal.archived) continue;
-				// Pause-cascade: a paused goal must never trigger a fresh
-				// team-lead spawn on boot/respawn. Without this guard, an
-				// operator who pauses a goal then aborts its team-lead would
-				// see a new team-lead reappear within seconds (whack-a-mole).
-				// See docs/design/pause-cascade.md §Call-site 7 (CRITICAL).
-				if (goal.paused) continue;
-				if (goal.state !== "in-progress") continue;
-				if (goal.setupStatus !== "ready") continue;
-				if (!goal.team) continue;
-				if (this.teams.has(goal.id)) continue;
-
-				try {
-					console.log(
-						`[team-manager] Boot recovery: respawning team-lead for sessionless in-progress goal "${goal.title}" (id=${goal.id})`,
-					);
-					// Fire and forget — startTeam returns a promise but boot can't
-					// block on it. Errors are logged inside the catch so they
-					// don't propagate as unhandled rejections.
-					this.startTeam(goal.id).catch((err) => {
-						console.error(
-							`[team-manager] Boot recovery startTeam failed for goal=${goal.id} ("${goal.title}"):`,
-							err,
-						);
-					});
-				} catch (err) {
-					console.error(
-						`[team-manager] Boot recovery failed synchronously for goal=${goal.id} ("${goal.title}"):`,
-						err,
-					);
-				}
-			}
-		}
 	}
 
 	/** Clear and remove all idle-nudge timers for a goal. */

--- a/tests/e2e/remove-boot-respawn-restart.spec.ts
+++ b/tests/e2e/remove-boot-respawn-restart.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * API E2E coverage for Remove Boot Respawn.
+ *
+ * A goal that was deliberately made teamless by /team/teardown must remain
+ * teamless across a gateway restart. Restart restoration may restore existing
+ * active teams, but it must not create a new team lead for this sessionless goal.
+ */
+import { test, expect, type GatewayInfo } from "./gateway-harness.js";
+import {
+	apiFetch,
+	createGoal,
+	deleteGoal,
+	startTeam,
+	teardownTeam,
+	waitForHealth,
+	waitForSessionStatus,
+} from "./e2e-setup.js";
+import { pollUntil } from "./test-utils/cleanup.js";
+
+interface TeamState {
+	teamLeadSessionId?: string;
+	agents?: Array<{ sessionId?: string; status?: string; role?: string }>;
+}
+
+async function readActiveTeam(goalId: string): Promise<TeamState | null> {
+	const resp = await apiFetch(`/api/goals/${goalId}/team`);
+	if (resp.status === 404) return null;
+	const text = await resp.text();
+	if (resp.status !== 200) {
+		throw new Error(`GET /team expected 200 or 404, got ${resp.status}: ${text}`);
+	}
+	return JSON.parse(text) as TeamState;
+}
+
+async function readActiveAgents(goalId: string): Promise<Array<{ sessionId?: string; status?: string; role?: string }>> {
+	const resp = await apiFetch(`/api/goals/${goalId}/team/agents`);
+	if (resp.status === 404) return [];
+	const text = await resp.text();
+	if (resp.status !== 200) {
+		throw new Error(`GET /team/agents expected 200 or 404, got ${resp.status}: ${text}`);
+	}
+	const body = JSON.parse(text) as { agents?: Array<{ sessionId?: string; status?: string; role?: string }> };
+	return body.agents ?? [];
+}
+
+async function waitForNoActiveTeam(goalId: string, label: string): Promise<void> {
+	await pollUntil(async () => {
+		const team = await readActiveTeam(goalId);
+		if (team?.teamLeadSessionId) return null;
+		const agents = await readActiveAgents(goalId);
+		return agents.length === 0 ? true : null;
+	}, { timeoutMs: 10_000, intervalMs: 100, label });
+}
+
+async function assertNoTeamRecreated(goalId: string, previousLeadId: string, durationMs = 2_000): Promise<void> {
+	const deadline = Date.now() + durationMs;
+	while (Date.now() < deadline) {
+		const team = await readActiveTeam(goalId);
+		if (team?.teamLeadSessionId) {
+			throw new Error(
+				`BOOT_RESPAWN_E2E_TEAM_RECREATED: restart created team lead ${team.teamLeadSessionId} ` +
+				`for torn-down goal ${goalId}; previous torn-down lead was ${previousLeadId}`,
+			);
+		}
+		const agents = await readActiveAgents(goalId);
+		if (agents.length > 0) {
+			throw new Error(
+				`BOOT_RESPAWN_E2E_AGENTS_RECREATED: restart created active agents for torn-down goal ${goalId}: ` +
+				JSON.stringify(agents),
+			);
+		}
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
+}
+
+async function restartCrashedGateway(gateway: GatewayInfo): Promise<void> {
+	await gateway.restart();
+	await waitForHealth(10_000);
+}
+
+test.describe.serial("Remove Boot Respawn restart coverage", () => {
+	test.setTimeout(60_000);
+
+	test("teardown keeps a goal teamless across restart and manual Start Team still succeeds", async ({ gateway }) => {
+		let goalId: string | undefined;
+		let serverOnline = true;
+
+		const goal = await createGoal({
+			title: `Remove Boot Respawn restart ${Date.now()}`,
+			worktree: false,
+			team: true,
+			autoStartTeam: false,
+			spec: "Remove Boot Respawn E2E: this goal starts manually, is torn down, survives a gateway restart as teamless, then starts manually again.",
+		});
+		goalId = goal.id;
+
+		try {
+			const firstLeadId = await startTeam(goalId);
+			await waitForSessionStatus(firstLeadId, "idle");
+			const beforeTeardown = await readActiveTeam(goalId);
+			expect(beforeTeardown?.teamLeadSessionId).toBe(firstLeadId);
+
+			await teardownTeam(goalId);
+			await waitForNoActiveTeam(goalId, "team torn down before restart");
+
+			await gateway.crash();
+			serverOnline = false;
+			await gateway.restart();
+			serverOnline = true;
+			await waitForHealth(10_000);
+
+			await assertNoTeamRecreated(goalId, firstLeadId);
+			expect(await readActiveTeam(goalId), "manual Start Team should remain available after restart").toBeNull();
+			expect(await readActiveAgents(goalId), "no active team agents should be recreated after restart").toEqual([]);
+
+			const secondLeadId = await startTeam(goalId);
+			expect(secondLeadId).toBeTruthy();
+			expect(secondLeadId).not.toBe(firstLeadId);
+			await waitForSessionStatus(secondLeadId, "idle");
+
+			const afterManualStart = await readActiveTeam(goalId);
+			expect(afterManualStart?.teamLeadSessionId).toBe(secondLeadId);
+		} finally {
+			if (!serverOnline) {
+				await restartCrashedGateway(gateway).catch(() => {});
+			}
+			if (goalId) {
+				await teardownTeam(goalId).catch(() => {});
+				await deleteGoal(goalId).catch(() => {});
+			}
+		}
+	});
+});

--- a/tests/e2e/remove-boot-respawn-restart.spec.ts
+++ b/tests/e2e/remove-boot-respawn-restart.spec.ts
@@ -54,23 +54,30 @@ async function waitForNoActiveTeam(goalId: string, label: string): Promise<void>
 
 async function assertNoTeamRecreated(goalId: string, previousLeadId: string, durationMs = 2_000): Promise<void> {
 	const deadline = Date.now() + durationMs;
-	while (Date.now() < deadline) {
+	let violation: string | undefined;
+	await expect.poll(async () => {
+		if (violation) return violation;
+
 		const team = await readActiveTeam(goalId);
 		if (team?.teamLeadSessionId) {
-			throw new Error(
+			violation =
 				`BOOT_RESPAWN_E2E_TEAM_RECREATED: restart created team lead ${team.teamLeadSessionId} ` +
-				`for torn-down goal ${goalId}; previous torn-down lead was ${previousLeadId}`,
-			);
+				`for torn-down goal ${goalId}; previous torn-down lead was ${previousLeadId}`;
+			return violation;
 		}
 		const agents = await readActiveAgents(goalId);
 		if (agents.length > 0) {
-			throw new Error(
+			violation =
 				`BOOT_RESPAWN_E2E_AGENTS_RECREATED: restart created active agents for torn-down goal ${goalId}: ` +
-				JSON.stringify(agents),
-			);
+				JSON.stringify(agents);
+			return violation;
 		}
-		await new Promise((resolve) => setTimeout(resolve, 100));
-	}
+		return Date.now() >= deadline ? "stable" : "pending";
+	}, {
+		timeout: durationMs + 1_000,
+		intervals: [100],
+		message: `no team respawn for torn-down goal ${goalId}`,
+	}).toBe("stable");
 }
 
 async function restartCrashedGateway(gateway: GatewayInfo): Promise<void> {

--- a/tests/team-manager-boot-respawn.test.ts
+++ b/tests/team-manager-boot-respawn.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Reproducing test for boot-time team respawn creating a new lead for an
+ * intentionally sessionless goal.
+ *
+ * Bug: TeamManager.resubscribeTeamEvents() runs during gateway boot and calls
+ * the private _bootRespawnSessionlessGoals() helper. That helper scans every
+ * in-progress ready team goal that has no restored team entry and calls
+ * startTeam(goalId), creating a new team lead after restart. Goals that were
+ * deliberately left teamless (autoStartTeam:false or after teardownTeam) should
+ * remain teamless until the user clicks Start Team.
+ */
+import { after, describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_BOBBIT_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-boot-respawn-test-"));
+process.env.BOBBIT_DIR = TEST_BOBBIT_DIR;
+
+const { TeamManager } = await import("../src/server/agent/team-manager.ts");
+
+const createdManagers: any[] = [];
+
+after(() => {
+	for (const tm of createdManagers) {
+		tm.dispose?.();
+		for (const [, timer] of (tm as any).idleNudgeTimers ?? []) clearTimeout(timer);
+		(tm as any).idleNudgeTimers?.clear?.();
+		for (const [, timer] of (tm as any).noWorkersNudgeTimers ?? []) clearTimeout(timer);
+		(tm as any).noWorkersNudgeTimers?.clear?.();
+		for (const [, timer] of (tm as any).pendingIdleNotify ?? []) clearTimeout(timer);
+		(tm as any).pendingIdleNotify?.clear?.();
+	}
+	try { fs.rmSync(TEST_BOBBIT_DIR, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+function makeSessionlessReadyTeamGoal() {
+	return {
+		id: "goal-sessionless-ready",
+		title: "Sessionless Ready Team Goal",
+		cwd: "/tmp/test-project",
+		state: "in-progress",
+		setupStatus: "ready",
+		spec: "# Test\nThis goal should remain teamless after restart.",
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		team: true,
+		archived: false,
+		paused: false,
+		branch: "goal/sessionless-ready",
+		repoPath: "/tmp/test-repo",
+	};
+}
+
+function makeProjectContext(goal: any) {
+	return {
+		goalStore: {
+			get: (id: string) => id === goal.id ? goal : undefined,
+			getAll: () => [goal],
+		},
+		// Empty team store is the important shape: boot restored no active team.
+		teamStore: {
+			get: () => undefined,
+			getAll: () => [],
+			remove: mock.fn(),
+			put: mock.fn(),
+		},
+		// Restore-time recovery scans these stores; keep them empty so the test
+		// isolates the sessionless-goal respawn path.
+		sessionStore: {
+			get: () => undefined,
+			getAll: () => [],
+			put: mock.fn(),
+			update: mock.fn(),
+		},
+		gateStore: { getGatesForGoal: () => [] },
+		taskStore: { getByGoalId: () => [] },
+		goalManager: { updateGoal: mock.fn(async () => true) },
+	};
+}
+
+describe("TeamManager boot respawn", () => {
+	it("does not start a team for a sessionless in-progress ready team goal during boot resubscribe", async () => {
+		const goal = makeSessionlessReadyTeamGoal();
+		const ctx = makeProjectContext(goal);
+		const projectContextManager = {
+			all: () => [ctx],
+			getContextForGoal: (goalId: string) => goalId === goal.id ? ctx : undefined,
+		};
+		const sessionManager = {
+			getSession: () => undefined,
+			goalManager: ctx.goalManager,
+		};
+		const tm = new TeamManager(sessionManager as any, {
+			projectContextManager,
+			taskManager: { getTasksByGoal: () => [], getTasksForSession: () => [] },
+			colorStore: { get: () => undefined, set: () => {}, remove: () => {}, getAll: () => ({}) },
+		} as any);
+		createdManagers.push(tm);
+
+		const startTeam = mock.fn(async (_goalId: string) => undefined as any);
+		(tm as any).startTeam = startTeam;
+
+		// This mirrors the boot sequence after sessions are restored. A goal with
+		// no restored team entry must stay teamless; boot should only re-subscribe
+		// existing teams, not create new ones.
+		tm.resubscribeTeamEvents();
+		await Promise.resolve();
+
+		assert.equal(
+			startTeam.mock.callCount(),
+			0,
+			"BOOT_RESPAWN_SESSIONLESS_GOAL_STARTED_TEAM: resubscribeTeamEvents must not call startTeam for a sessionless in-progress ready team goal on boot",
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- Remove boot-time sessionless goal team respawn from TeamManager restart resubscription.
- Preserve restored active team resubscription and goal-creation autoStartTeam behavior.
- Add unit and API E2E restart coverage for teamless goals staying teamless after teardown/restart.
- Update docs for restart/team restoration semantics and remove stale boot-respawn references.

## Validation
- npm run check
- npm run test:unit
- npm run test:e2e -- remove-boot-respawn-restart.spec.ts --project=api --workers=1

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)