### PR TITLE
Durable HTML Preview

### DIFF
--- a/docs/preview-architecture.md
+++ b/docs/preview-architecture.md
@@ -8,11 +8,11 @@ per-session side-panel workspace shared by regular and assistant sessions.
 
 ## Mental model
 
-Four pieces, one mount, one URL shape:
+Five pieces, one mount, one URL shape:
 
 1. **Per-session mount on disk** — `<bobbitStateDir>/preview/<sid>/` holds the
    entry HTML and any sibling assets (images, CSS, video, …). Single source of
-   truth for what the panel shows.
+   truth for rendered bytes.
 2. **Content origin** — the gateway serves the mount at `/preview/<sid>/<path>`.
    Same shape for the iframe `src`, the "Open in new tab" button, and any link
    the user clicks inside the preview.
@@ -22,6 +22,10 @@ Four pieces, one mount, one URL shape:
 4. **SSE hot reload** — `GET /api/sessions/:sid/preview-events` streams a
    `preview-changed` event whenever the gateway repopulates the mount. The panel
    bumps `#mtime=<n>` on the iframe `src` to force a reload.
+5. **Server-backed workspace tab** — successful mount/open events persist the
+   active preview tab identity and small render metadata. This is what restores
+   the side-panel tab after a gateway restart; the mount/artifact files still
+   serve the bytes.
 
 Every populated mount also has a `contentHash`: a lowercase SHA-256 identity for
 that mounted preview tree. The hash represents rendered content identity, not a
@@ -50,7 +54,9 @@ preview mount, immutable artifact, bootstrap response, or SSE event may update
 content caches, but it must not resurrect a closed tab. Explicit preview tool
 mount/open events and historical preview-card Open buttons create or focus tabs;
 bootstrap and SSE updates patch only already-open tabs when they are not an
-explicit open. Full workspace rules live in
+explicit open. After a gateway restart, the client renders the active preview
+iframe from the hydrated server workspace tab, not from transient preview mirrors
+or mount discovery. Full workspace rules live in
 [`side-panel-workspace.md`](./side-panel-workspace.md).
 
 Preview tab identity:
@@ -159,6 +165,34 @@ When the user clicks **Open** on a historical `preview_open` tool card
 | v3 without `artifactId`, with `html` / `file` original params | `POST /api/preview/mount {html\|file}` | Remount the original; the POST response's `artifactId` and `contentHash` are attached to the tab. Same collapse rule. |
 | v3 without `artifactId` and no remount body | None (recorded entry / mtime / url) | Select the recorded entry; iframe points at the existing mount path. Best-effort. |
 | Legacy v1 / v2 | `POST /api/preview/mount {html\|file}` | Stays historical even when the response includes `contentHash`. |
+
+### Restart restore
+
+A successful `POST /api/preview/mount` opens or updates the current preview
+workspace tab unless the caller opts out with `workspaceTab: false`,
+`openWorkspaceTab: false`, or an internal restore flag. The tab persists enough
+small metadata to render after restart:
+
+- source identity: `entry`, `contentHash`, `path`, `url`, and `artifactId` when a
+  matching artifact exists;
+- tab state: `entry`, `mtime`, `path`, `url`, `contentHash`, `artifactId`, and
+  `origin: "preview-mount"`;
+- workspace state: tab id/order and `activeTabId`.
+
+On gateway restart, `sidePanelWorkspace` is loaded with the session. When the
+browser reloads or returns to the session, the side-panel shell renders the
+active preview tab and the iframe derives `entry`, `mtime`, and `artifactId` from
+that tab before transient preview mirrors are repopulated. Live tabs point at
+`/preview/<sid>/<entry>?mtime=<n>`; artifact-backed historical tabs point at
+`/preview/<sid>/_artifact/<artifactId>/<entry>?mtime=<n>`.
+
+Bootstrap (`GET /api/preview/mount`) and `preview-changed` SSE metadata may later
+refresh already-open tabs, but they are not tab-creation sources. If the user
+closed the preview tab before restart, the persisted workspace has no preview
+tab, so reload/reconnect/bootstrap must leave the side panel closed until a new
+explicit `preview_open` / mount event or historical-card **Open** action occurs.
+
+Pinned by `tests/e2e/ui/preview-durable-restart.spec.ts`.
 
 ## Per-session mount
 

--- a/docs/side-panel-workspace.md
+++ b/docs/side-panel-workspace.md
@@ -44,7 +44,7 @@ Every committed mutation increments `revision`, persists the whole workspace thr
 
 | Kind | Tab id shape | Source identity | Notes |
 |---|---|---|---|
-| Preview | `preview:entry:<encoded-entry>` or `preview:entry:<encoded-entry>:v:<N>` | `entry`, `artifactId?`, `contentHash?`, `version?`, `live?`, `historical?` | Live preview tabs update in place. Historical preview tabs represent immutable artifacts or restored older cards. |
+| Preview | `preview:entry:<encoded-entry>` or `preview:entry:<encoded-entry>:v:<N>` | `entry`, `artifactId?`, `contentHash?`, `path?`, `url?`, `version?`, `live?`, `historical?`; state may include `mtime` | Live preview tabs update in place and restore from persisted tab metadata after restart. Historical preview tabs represent immutable artifacts or restored older cards. |
 | Pack | `pack:<encoded-packId>:<encoded-panelId>:<encoded-instanceKey>` | `packId`, `panelId`, `instanceKey`, `params?` | Covers PR walkthrough and artifact viewer pack panels. `instanceKey` is part of identity. |
 | Proposal | `proposal:<type>` or `proposal:<type>:rev:<N>` | `proposalType`, `rev?`, `historical?` | Types are `goal`, `project`, `role`, `tool`, and `staff`. Current revisions update the current tab; historical revs open only by explicit reopen. |
 | Review | `review:<encoded-documentId>` | stable `documentId`, display `title` | Title is metadata. Renames do not change identity. Closing the tab preserves content/annotations for explicit reopen. |
@@ -60,12 +60,13 @@ Because those legacy files are superseded by pack artifact panels, they are excl
 
 `preview_open` still writes the per-session preview mount and streams updates via preview SSE. Workspace tab creation is separate:
 
-- explicit preview open/tool actions open or focus the current preview tab;
+- explicit preview open/tool actions open or focus the current preview tab and persist render metadata such as `entry`, `mtime`, `contentHash`, `path`, `url`, and `artifactId` when available;
+- gateway restart restores the active preview iframe from that persisted workspace tab; the client does not need a fresh tool call or a mount bootstrap to recreate the tab;
 - historical card Open buttons explicitly open a versioned preview tab or focus an equivalent current tab when hashes match;
 - `GET /api/preview/mount` bootstrap, `preview-changed` SSE events, and mount metadata refreshes patch metadata only for already-open tabs;
 - closing a preview tab removes only the workspace tab, not the live mount or immutable artifacts.
 
-This split prevents navigation, reload, or reconnect from resurrecting a preview tab just because a preview mount still exists. A later explicit preview Open action can reopen it.
+This split prevents navigation, reload, restart, or reconnect from resurrecting a preview tab just because a preview mount still exists. A later explicit preview Open action can reopen it.
 
 ### Proposal lifecycle
 
@@ -213,6 +214,9 @@ Useful checks:
 - `revision` should increase after every committed mutation;
 - duplicate artifact pack panels should differ by `source.instanceKey`;
 - review tab ids should include document ids, not mutable titles;
-- stale localStorage should not change the workspace after `migratedFromLocalStorageAt` is set.
+- stale localStorage should not change the workspace after `migratedFromLocalStorageAt` is set;
+- preview restart restore should show the active preview tab in the workspace after gateway restart, and a user-closed preview tab should stay absent even while `GET /api/preview/mount` still succeeds.
 
-Related docs: [architecture.md](architecture.md#side-panel-workspace), [preview-architecture.md](preview-architecture.md#side-panel-workspace-integration), [extension-host-authoring.md](extension-host-authoring.md#panels--persistent-side-panels-hostuiopenpanel), [rest-api.md](rest-api.md#side-panel-workspace), and [websocket-protocol.md](websocket-protocol.md#server--client).
+Regression coverage: `tests/e2e/ui/preview-durable-restart.spec.ts`.
+
+Related docs: [architecture.md](architecture.md#side-panel-workspace), [preview-architecture.md](preview-architecture.md#restart-restore), [extension-host-authoring.md](extension-host-authoring.md#panels--persistent-side-panels-hostuiopenpanel), [rest-api.md](rest-api.md#side-panel-workspace), and [websocket-protocol.md](websocket-protocol.md#server--client).

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -2149,28 +2149,27 @@ export function doRenderApp(): void {
 	// which forces the iframe to reload via the `#mtime=<n>` hash.
 	const htmlPreviewContent = () => {
 		const sid = activeSessionId() || "";
-		const v = state.previewPanelMtime || 0;
-		// Derive artifactId and entry from the active panel tab rather than
-		// mirroring them in global state. Many code paths (SSE preview-changed,
-		// bootstrap fetch, PreviewRenderer, session-manager) update
-		// `previewPanelEntry` without knowing about artifactId; reading directly
-		// from the active tab keeps entry+artifactId always paired.
+		// Derive artifactId, entry, and mtime from the active panel tab rather than
+		// requiring global preview mirrors to be populated. After a gateway restart,
+		// the server-persisted workspace tab can be restored before the session's
+		// transient previewPanelEntry mirror is repopulated.
 		const activeId = activeSidePanelTabIdForSession(state, workspaceSessionId());
 		const panelTabs = unifiedPanelContentTabs();
 		const activeTab = panelTabs.find((t) => t.id === activeId);
 		let artifactId = "";
-		let entry = state.previewPanelEntry || "inline.html";
+		let entry = state.previewPanelEntry || "";
+		let tabMtime = 0;
 		if (activeTab && activeTab.kind === "preview") {
 			const tabState = (activeTab.state || {}) as Record<string, unknown>;
 			const source = activeTab.source as Record<string, unknown>;
+			const tabEntry = previewEntryFromTab(activeTab);
+			if (tabEntry) entry = tabEntry;
+			if (typeof tabState.mtime === "number" && Number.isFinite(tabState.mtime)) tabMtime = tabState.mtime;
 			const isLiveTab = isLivePreviewTab(activeTab);
-			if (!isLiveTab) {
-				artifactId = recordValue(tabState, "artifactId") || recordValue(source, "artifactId");
-				const tabEntry = previewEntryFromTab(activeTab);
-				if (tabEntry) entry = tabEntry;
-			}
+			if (!isLiveTab) artifactId = recordValue(tabState, "artifactId") || recordValue(source, "artifactId");
 		}
-		if (!sid || !state.previewPanelEntry) {
+		const v = state.previewPanelMtime || tabMtime || 0;
+		if (!sid || !entry) {
 			// Empty-state until the first SSE `preview-changed` event lands.
 			return html`
 				<div class="flex-1 min-h-0 flex items-center justify-center text-muted-foreground text-sm">

--- a/src/app/side-panel-workspace.ts
+++ b/src/app/side-panel-workspace.ts
@@ -4,6 +4,7 @@ import {
 	INBOX_PANEL_TAB_ID,
 	assistantProposalType,
 	buildPanelWorkspaceTabs,
+	isLivePreviewTab,
 	panelWorkspaceSessionKey,
 	previewContentHashFromTab,
 	previewEntryLabel,
@@ -308,6 +309,40 @@ function toLegacyPanelTab(tab: SidePanelWorkspaceTab): PanelWorkspaceTab {
 	};
 }
 
+function finiteNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function hydrateActivePreviewMirror(workspace: SidePanelWorkspace, legacyTabs: PanelWorkspaceTab[]): void {
+	const activeTab = legacyTabs.find((tab) => tab.id === workspace.activeTabId && tab.kind === "preview");
+	if (!activeTab) return;
+	const source = asRecord(activeTab.source) || {};
+	const tabState = asRecord(activeTab.state) || {};
+	const entry = previewEntryLabel(
+		stringValue(tabState.entry)
+		|| stringValue(source.entry)
+		|| previewTabEntryFromId(activeTab.id)
+		|| activeTab.title
+		|| activeTab.label
+		|| undefined,
+	);
+	if (!entry) return;
+	const contentHash = previewContentHashFromTab(activeTab);
+	const artifactId = stringValue(tabState.artifactId) || stringValue(source.artifactId);
+	const mtime = finiteNumber(tabState.mtime) ?? finiteNumber(source.mtime);
+	const isLiveTab = isLivePreviewTab(activeTab);
+
+	state.isPreviewSession = true;
+	state.previewPanelEntry = entry;
+	state.previewPanelActiveTab = "preview";
+	state.previewPanelTab = "preview";
+	if (mtime != null) state.previewPanelMtime = mtime;
+	else if (!state.previewPanelMtime) state.previewPanelMtime = now();
+	if (contentHash) (state as any).previewPanelContentHash = contentHash;
+	state.previewPanelArtifactId = !isLiveTab && artifactId ? artifactId : "";
+	(state as any).previewPanelMountedTabId = activeTab.id;
+}
+
 function syncCompatibilityMirrors(workspace: SidePanelWorkspace): void {
 	const sid = panelWorkspaceSessionKey(workspace.sessionId);
 	const legacyTabs = workspace.tabs.map(toLegacyPanelTab);
@@ -318,6 +353,7 @@ function syncCompatibilityMirrors(workspace: SidePanelWorkspace): void {
 		state.activePanelTabId = workspace.activeTabId;
 		state.previewPanelFullscreen = workspace.sizeMode === "fullscreen";
 		state.inboxPanelOpen = workspace.tabs.some((tab) => tab.id === INBOX_PANEL_TAB_ID && tab.kind === "inbox");
+		hydrateActivePreviewMirror(workspace, legacyTabs);
 	}
 	(state as unknown as { panelWorkspace?: SidePanelWorkspace }).panelWorkspace = workspace;
 }

--- a/tests/e2e/ui/preview-durable-restart.spec.ts
+++ b/tests/e2e/ui/preview-durable-restart.spec.ts
@@ -1,0 +1,237 @@
+/**
+ * Browser E2E reproducer for durable HTML preview restore across gateway restarts.
+ *
+ * This intentionally drives the real server-backed preview mount and
+ * side-panel workspace paths. It must not seed client preview caches directly;
+ * the persisted workspace tab and live mount/artifact files are the source of
+ * truth before and after restart.
+ */
+import type { Page } from "@playwright/test";
+import { test, expect, type GatewayInfo } from "../gateway-harness.js";
+import { apiFetch, createSession, nonGitCwd } from "../e2e-setup.js";
+import { openApp, navigateToHash } from "./ui-helpers.js";
+
+const ENTRY = "durable-preview.html";
+const BODY_TEXT = "DURABLE_PREVIEW_RESTART";
+const PREVIEW_TAB_ID = `preview:entry:${encodeURIComponent(ENTRY)}`;
+const PANEL_TAB_SELECTOR = ".goal-tab-pill";
+
+function previewHtml(): string {
+	return `<!doctype html><html><body><main><h1>${BODY_TEXT}</h1></main></body></html>`;
+}
+
+function previewTab(page: Page) {
+	return page.locator(`${PANEL_TAB_SELECTOR}[data-panel-tab-id="${PREVIEW_TAB_ID}"]`).first();
+}
+
+async function navigateToSession(page: Page, sessionId: string): Promise<void> {
+	await navigateToHash(page, `#/session/${sessionId}`);
+	await expect(page.locator("textarea").first()).toBeVisible({ timeout: 20_000 });
+	await expect.poll(
+		() => page.evaluate(() => (window as any).bobbitState?.selectedSessionId ?? ""),
+		{ timeout: 10_000, message: "session route should be active" },
+	).toBe(sessionId);
+}
+
+async function createRegularSession(page: Page): Promise<string> {
+	const sessionId = await createSession({ cwd: nonGitCwd() });
+	await navigateToSession(page, sessionId);
+	return sessionId;
+}
+
+async function enablePreviewSession(sessionId: string): Promise<void> {
+	const resp = await apiFetch(`/api/sessions/${sessionId}`, {
+		method: "PATCH",
+		body: JSON.stringify({ preview: true }),
+	});
+	const text = await resp.text();
+	expect(resp.status, `PATCH preview=true should succeed: ${text}`).toBe(200);
+}
+
+async function mountPreview(sessionId: string): Promise<{ entry: string; mtime: number; contentHash: string; url?: string }> {
+	const resp = await apiFetch(`/api/preview/mount?sessionId=${sessionId}`, {
+		method: "POST",
+		body: JSON.stringify({ entry: ENTRY, html: previewHtml() }),
+	});
+	const text = await resp.text();
+	expect(resp.status, `POST /api/preview/mount should succeed: ${text}`).toBe(200);
+	const body = JSON.parse(text) as { entry?: string; mtime?: number; contentHash?: string; url?: string };
+	expect(body.entry).toBe(ENTRY);
+	expect(body.mtime).toBeGreaterThan(0);
+	expect(body.contentHash).toMatch(/^[a-f0-9]{64}$/);
+	return body as { entry: string; mtime: number; contentHash: string; url?: string };
+}
+
+async function workspace(sessionId: string): Promise<any> {
+	const resp = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace`);
+	const text = await resp.text();
+	expect(resp.status, `workspace GET failed: ${text}`).toBe(200);
+	return JSON.parse(text);
+}
+
+async function currentMount(sessionId: string): Promise<any> {
+	const resp = await apiFetch(`/api/preview/mount?sessionId=${sessionId}`);
+	const text = await resp.text();
+	expect(resp.status, `GET /api/preview/mount should still succeed: ${text}`).toBe(200);
+	return JSON.parse(text);
+}
+
+async function waitForWorkspacePreviewTab(sessionId: string): Promise<void> {
+	await expect.poll(async () => {
+		const ws = await workspace(sessionId);
+		return {
+			activeTabId: ws.activeTabId,
+			tabs: (ws.tabs || []).map((tab: any) => ({ id: tab.id, entry: tab.source?.entry, contentHash: tab.source?.contentHash })),
+		};
+	}, {
+		timeout: 15_000,
+		message: "server-backed side-panel workspace should persist the current preview tab",
+	}).toEqual({
+		activeTabId: PREVIEW_TAB_ID,
+		tabs: [expect.objectContaining({ id: PREVIEW_TAB_ID, entry: ENTRY, contentHash: expect.stringMatching(/^[a-f0-9]{64}$/) })],
+	});
+}
+
+async function expectPreviewTabActive(page: Page, message: string): Promise<void> {
+	const tab = previewTab(page);
+	await expect(tab, `${message}: preview side-panel tab should be visible`).toBeVisible({ timeout: 15_000 });
+	await expect(tab, `${message}: preview side-panel tab should be active`).toHaveClass(/goal-tab-pill--active/, { timeout: 10_000 });
+	await expect(tab, `${message}: preview side-panel tab should show the entry label`).toContainText(ENTRY);
+}
+
+async function previewDiagnostics(page: Page): Promise<string> {
+	return page.evaluate(() => {
+		const tab = document.querySelector(`[data-panel-tab-id="${CSS.escape("preview:entry:durable-preview.html")}"]`) as HTMLElement | null;
+		const panel = document.querySelector(".goal-preview-panel") as HTMLElement | null;
+		const iframe = document.querySelector(".goal-preview-panel iframe") as HTMLIFrameElement | null;
+		let iframeBodyText = "";
+		try { iframeBodyText = iframe?.contentDocument?.body?.innerText || ""; } catch (err) { iframeBodyText = `iframe-read-error:${String(err)}`; }
+		return JSON.stringify({
+			tabVisible: !!tab && tab.getBoundingClientRect().width > 0 && tab.getBoundingClientRect().height > 0,
+			tabActive: !!tab?.classList.contains("goal-tab-pill--active"),
+			iframeSrc: iframe?.getAttribute("src") || "",
+			panelText: (panel?.innerText || "").replace(/\s+/g, " ").trim(),
+			iframeBodyText: iframeBodyText.replace(/\s+/g, " ").trim(),
+		});
+	});
+}
+
+async function expectPreviewIframeContains(page: Page, message: string): Promise<void> {
+	await expect.poll(
+		() => previewDiagnostics(page),
+		{
+			timeout: 15_000,
+			message: `${message}: expected preview iframe diagnostics to contain ${BODY_TEXT}; empty previews usually report "No preview yet."`,
+		},
+	).toContain(BODY_TEXT);
+
+	const iframe = page.locator(".goal-preview-panel iframe").first();
+	await expect(iframe, `${message}: iframe should have preview content src`).toHaveAttribute(
+		"src",
+		new RegExp(`^/preview/${sessionIdPattern()}/${ENTRY.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\?mtime=\\d+$`),
+		{ timeout: 10_000 },
+	);
+}
+
+function sessionIdPattern(): string {
+	return "[a-f0-9-]+";
+}
+
+/**
+ * Crash + restart the in-process gateway on the same port/state dir, then wait
+ * for the app to reconnect if the page is still alive.
+ */
+async function crashAndRestart(gateway: GatewayInfo, page: Page): Promise<void> {
+	await gateway.crash();
+	if (!page.isClosed()) {
+		await page.waitForFunction(() => {
+			const s = (window as any).bobbitState;
+			return !!s && s.connectionStatus !== "connected";
+		}, undefined, { timeout: 5_000 }).catch(() => { /* best-effort */ });
+	}
+
+	await gateway.restart();
+	await expect.poll(async () => {
+		try { return (await apiFetch("/api/health")).ok; } catch { return false; }
+	}, { timeout: 20_000, intervals: [250], message: "gateway should be healthy after restart" }).toBe(true);
+
+	if (!page.isClosed()) {
+		await page.waitForFunction(() => {
+			const s = (window as any).bobbitState;
+			return !!s && s.connectionStatus === "connected";
+		}, undefined, { timeout: 15_000, polling: 250 }).catch(() => { /* best-effort; reload below also reconnects */ });
+	}
+}
+
+async function reloadAndReturnToSession(page: Page, sessionId: string): Promise<void> {
+	await page.reload({ waitUntil: "domcontentloaded" });
+	await navigateToSession(page, sessionId);
+}
+
+async function closePreviewTab(page: Page): Promise<void> {
+	await previewTab(page).locator('[data-testid="side-panel-close"]').click();
+	await expect(previewTab(page), "preview tab should disappear after the user closes it").toHaveCount(0, { timeout: 10_000 });
+}
+
+async function expectWorkspaceHasNoPreviewTab(sessionId: string): Promise<void> {
+	await expect.poll(async () => {
+		const ws = await workspace(sessionId);
+		return {
+			activeTabId: ws.activeTabId,
+			hasPreviewTab: (ws.tabs || []).some((tab: any) => tab.id === PREVIEW_TAB_ID),
+		};
+	}, { timeout: 10_000, message: "closed preview tab should be removed from server workspace" }).toEqual({ activeTabId: "", hasPreviewTab: false });
+}
+
+async function expectPreviewTabStaysClosed(page: Page): Promise<void> {
+	// Bootstrap and SSE reconciliation are asynchronous; require a stable closed
+	// window so a delayed mount bootstrap cannot recreate a user-closed tab unnoticed.
+	const stayedClosed = await page.waitForFunction((tabId) => new Promise<boolean>((resolve) => {
+		const selector = `[data-panel-tab-id="${CSS.escape(tabId)}"]`;
+		const deadline = performance.now() + 3_000;
+		const tick = () => {
+			if (document.querySelector(selector)) return resolve(false);
+			if (performance.now() >= deadline) return resolve(true);
+			requestAnimationFrame(tick);
+		};
+		tick();
+	}), PREVIEW_TAB_ID, { timeout: 4_000 });
+	expect(await stayedClosed.jsonValue(), "closed preview tab must not be resurrected from mount bootstrap").toBe(true);
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Durable HTML preview restart restore", () => {
+	test("restores the mounted preview tab and iframe after restart, but keeps a user-closed tab closed", async ({ page, gateway }) => {
+		test.setTimeout(120_000);
+		await page.setViewportSize({ width: 1280, height: 800 });
+
+		await openApp(page);
+		const sessionId = await createRegularSession(page);
+
+		await enablePreviewSession(sessionId);
+		await mountPreview(sessionId);
+		await waitForWorkspacePreviewTab(sessionId);
+
+		await expectPreviewTabActive(page, "before restart");
+		await expectPreviewIframeContains(page, "before restart");
+
+		await crashAndRestart(gateway, page);
+		await reloadAndReturnToSession(page, sessionId);
+
+		await waitForWorkspacePreviewTab(sessionId);
+		await expectPreviewTabActive(page, "after restart");
+		await expectPreviewIframeContains(page, "after restart");
+
+		await closePreviewTab(page);
+		await expectWorkspaceHasNoPreviewTab(sessionId);
+		const stillMounted = await currentMount(sessionId);
+		expect(stillMounted.entry).toBe(ENTRY);
+		expect(stillMounted.contentHash).toMatch(/^[a-f0-9]{64}$/);
+
+		await crashAndRestart(gateway, page);
+		await reloadAndReturnToSession(page, sessionId);
+		await expectWorkspaceHasNoPreviewTab(sessionId);
+		await expectPreviewTabStaysClosed(page);
+	});
+});

--- a/tests/fixtures/build-bundle.ts
+++ b/tests/fixtures/build-bundle.ts
@@ -82,7 +82,8 @@ export function buildBundle(opts: BuildBundleOptions): void {
 		return;
 	}
 
-	fs.mkdirSync(path.dirname(outfile), { recursive: true });
+	const outDir = path.dirname(outfile);
+	fs.mkdirSync(outDir, { recursive: true });
 
 	const lockDir = `${outfile}.lock`;
 	const start = Date.now();
@@ -92,6 +93,13 @@ export function buildBundle(opts: BuildBundleOptions): void {
 			fs.mkdirSync(lockDir);
 			break; // acquired the lock
 		} catch (err: any) {
+			if (err.code === "ENOENT") {
+				// Playwright may delete test-results between our parent mkdir and
+				// lock acquisition. Recreate the parent and retry the same atomic
+				// mkdir lock; do not fall back to a non-atomic check-then-create.
+				fs.mkdirSync(outDir, { recursive: true });
+				continue;
+			}
 			if (err.code !== "EEXIST") throw err;
 			// Another worker holds the lock. If it's stale (process crashed),
 			// force-release.

--- a/tests/pack-entrypoints-reconcile.spec.ts
+++ b/tests/pack-entrypoints-reconcile.spec.ts
@@ -21,9 +21,8 @@
  * stubbed to record request URLs + serve fake metadata + a fake panel module.
  */
 import { test, expect } from "@playwright/test";
-import { execSync } from "node:child_process";
-import fs from "node:fs";
 import path from "node:path";
+import { buildBundle } from "./fixtures/build-bundle";
 
 const FIXTURE = path.resolve("tests/fixtures/pack-entrypoints-reconcile.html");
 const BUNDLE = path.resolve("tests/fixtures/pack-entrypoints-reconcile-bundle.js");
@@ -33,27 +32,11 @@ const ROUTING_SRC = path.resolve("src/app/routing.ts");
 const PANELS_SRC = path.resolve("src/app/pack-panels.ts");
 
 test.beforeAll(() => {
-	const entryMtime = Math.max(
-		fs.statSync(ENTRY).mtimeMs,
-		fs.statSync(PACK_SRC).mtimeMs,
-		fs.statSync(ROUTING_SRC).mtimeMs,
-		fs.statSync(PANELS_SRC).mtimeMs,
-	);
-	const bundleExists = fs.existsSync(BUNDLE);
-	const bundleStale = bundleExists && fs.statSync(BUNDLE).mtimeMs < entryMtime;
-	if (!bundleExists || bundleStale) {
-		execSync(
-			[
-				`npx esbuild ${ENTRY}`,
-				"--bundle --format=iife --target=es2022",
-				`--outfile=${BUNDLE}`,
-				"--tsconfig=tsconfig.web.json",
-				"--alias:pdfjs-dist=./tests/fixtures/empty-shim",
-				"--define:import.meta.url='\"http://localhost/\"'",
-			].join(" "),
-			{ stdio: "pipe" },
-		);
-	}
+	buildBundle({
+		entry: ENTRY,
+		outfile: BUNDLE,
+		deps: [ENTRY, PACK_SRC, ROUTING_SRC, PANELS_SRC],
+	});
 });
 
 const PAGE = `file://${FIXTURE}`;


### PR DESCRIPTION
## Summary

- Persist and hydrate HTML preview side-panel tabs across gateway restarts from the server-backed workspace.
- Restore active preview iframe metadata from persisted tab state without resurrecting user-closed tabs from mount bootstrap/SSE.
- Add restart/close regression coverage and document durable preview semantics.
- Harden shared file:// fixture bundle locking discovered by the broad unit gate.

## Validation

- npm run check
- npm run test:unit
- npm run test:e2e -- tests/e2e/ui/preview-durable-restart.spec.ts --reporter=line
- npm run test:e2e -- tests/e2e/ui/side-panel-tabs.spec.ts --reporter=line

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)