### PR TITLE
Fix restart-minimal rename selector

### DIFF
--- a/tests/manual-integration/restart-minimal.spec.ts
+++ b/tests/manual-integration/restart-minimal.spec.ts
@@ -210,10 +210,12 @@ test("restart-minimal: plain + worktree session both survive a restart", async (
 	await page.waitForSelector("textarea", { timeout: 30_000 });
 	const sidebar = page.locator('[data-testid="sidebar-expanded"]');
 	await sidebar.waitFor({ timeout: 15_000 });
-	const sessionRow = sidebar.locator(`[data-session-id="${wtId}"]`);
-	await sessionRow.waitFor({ timeout: 10_000 });
+	const sessionRow = sidebar.locator(`[data-session-id="${wtId}"]`).first();
+	await expect(sessionRow).toBeVisible({ timeout: 10_000 });
 	await sessionRow.hover();
-	await sessionRow.locator('button[title="Modify"]').click();
+	const renameBtn = sessionRow.getByRole("button", { name: "Modify", exact: true });
+	await expect(renameBtn).toBeVisible({ timeout: 5_000 });
+	await renameBtn.click();
 	const titleInput = page.locator('input[placeholder="Session title…"]').first();
 	await titleInput.waitFor({ timeout: 5_000 });
 	await titleInput.fill("Renamed Pool Worktree");


### PR DESCRIPTION
## Summary
- Update restart-minimal manual integration test to target the rename action by accessible button name instead of tooltip title.
- Add visibility assertions so selector regressions fail quickly and clearly.

## Validation
- npx playwright test --config playwright-manual.config.ts --grep "restart-minimal"
- npm run test:manual

Note: Docker-dependent manual tests were skipped because Docker Desktop/API was unavailable in this environment.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)