### PR TITLE
Google OAuth Models

### DIFF
--- a/docs/design/google-oauth-model-auth.md
+++ b/docs/design/google-oauth-model-auth.md
@@ -141,14 +141,24 @@ This is the surface the official **Gemini CLI** uses for "Login with Google" (pe
 free Code Assist tier). Verified from `google-gemini/gemini-cli`
 (`packages/core/src/code_assist/oauth2.ts` and `server.ts`):
 
-- **OAuth client (installed app, public — secret is intentionally non-secret per Google's installed-
-  app guidance):**
+- **OAuth client decision (installed app, public — secret is intentionally non-secret per Google's
+  installed-app guidance): reuse the official Gemini CLI OAuth client, not a Bobbit-owned GCP OAuth
+  client.**
   - client_id: `681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com`
   - client_secret: a public `GOCSPX-…` installed-app secret published in the Gemini CLI source
     (`packages/core/src/code_assist/oauth2.ts`, `OAUTH_CLIENT_SECRET`). Per Google's installed-app
     guidance it is not treated as secret; the implementation should read the literal value from that
     upstream source. (Not pasted here so GitHub push-protection / secret-scanning does not flag the
     design doc.)
+  - **ToS / feasibility rationale:** this feature intentionally follows the same Google-supported
+    installed-app flow and Code Assist API surface that Gemini CLI ships for user-initiated login.
+    Bobbit must identify this as a Gemini CLI / Code Assist compatible account path in UI/docs and
+    must not imply it unlocks the Gemini web app, web-app subscription entitlements, or the
+    `generativelanguage.googleapis.com` API-key provider. A Bobbit-owned OAuth client is deferred
+    because third-party access to Code Assist scopes/brand approval is not guaranteed; if Google
+    later rejects or revokes use of the Gemini CLI public client by non-CLI apps, the implementation
+    must disable the Google account row with a clear limitation message while keeping API-key
+    Gemini auth available.
 - **Scopes:**
   - `https://www.googleapis.com/auth/cloud-platform`
   - `https://www.googleapis.com/auth/userinfo.email`
@@ -201,11 +211,15 @@ Gemini subscription cannot be used via an official model API, surface that clear
 - The runtime is implemented **natively in Bobbit** (option B below), not via pi-ai, because pi-ai
   ships no Code Assist provider and we should not block on an upstream change.
 
-Provider-id decision (recorded so it is not re-litigated): native Bobbit flow in `oauth.ts` rather
-than a pi-ai `registerOAuthProvider` custom provider — the Anthropic path is already native, the
-loopback+manual-paste UX is gateway-specific, and it avoids coupling login to an upstream provider
-registry. pi-ai's `registerOAuthProvider` remains available if we later want agent-session parity
-through pi-ai (§4.3).
+Provider-id / flow decision (recorded so it is not re-litigated): native Bobbit flow in `oauth.ts`
+rather than the existing pi-ai external-provider path. Reason: the installed pi-ai OAuth registry has
+no Google / Gemini Code Assist provider (`getOAuthProvider("google")` returns `undefined`) and no
+Code Assist runtime, while Bobbit's gateway already owns the Account-tab loopback/manual-paste UX and
+provider-partitioned status endpoints. The implementation should still reuse the existing
+`pendingFlows` map, TTL cleanup, provider mismatch checks, and redaction helpers; it should add a
+Google flow record shape, not a parallel untracked lifecycle. pi-ai's `registerOAuthProvider` remains
+available only for later agent-session parity (§4.3), after Bobbit has a working Code Assist
+runtime.
 
 ---
 
@@ -249,11 +263,17 @@ through pi-ai (§4.3).
    id; returns `{ authenticated, expires, provider }` only. Add `email` to the returned shape **only
    if** we decide to show the signed-in account; it is non-secret. Tokens stay omitted.
 8. `oauthFlowStatus`: generic; the provider cross-check already guards isolation.
-9. **Generalize refresh**: rename/extend `refreshOAuthToken()` to take a provider, or add
-   `refreshGoogleToken()`. For `google-gemini-cli`: skip if `Date.now() < expires`; else POST
-   `grant_type=refresh_token, refresh_token, client_id, client_secret` to `GOOGLE_TOKEN_URL`; on
-   400/401/403 delete the stored entry; on 5xx/429/network keep it (mirror Anthropic's policy).
-   Persist new `{access, refresh: new ?? old, expires}` and `clearOAuthCache()`.
+9. **Refresh implementation: keep the existing no-arg Anthropic API stable and add a new Google-
+   specific helper.** Do **not** change the public signature of `refreshOAuthToken()` in this
+   iteration; current callers are `src/server/agent/model-completion.ts`,
+   `src/server/agent/name-generator.ts`, and `src/server/agent/title-generator.ts`, all of which are
+   Anthropic-oriented today and must keep working unchanged. Add `refreshOAuthTokenForProvider(provider)`
+   or `refreshGoogleOAuthToken()` as an internal provider-aware helper, then optionally make the
+   existing no-arg function delegate to it with `provider="anthropic"`. For `google-gemini-cli`: skip
+   if `Date.now() < expires`; else POST `grant_type=refresh_token, refresh_token, client_id,
+   client_secret` to `GOOGLE_TOKEN_URL`; on 400/401/403 delete the stored entry; on 5xx/429/network
+   keep it (mirror Anthropic's policy). Persist new `{access, refresh: new ?? old, expires}` and
+   `clearOAuthCache()`.
 
 ### 4.2 Settings Account row — `src/app/settings-page.ts`
 
@@ -313,15 +333,22 @@ is still met.
 
 ### 4.4 Model registry / auth detection — `src/server/agent/model-registry.ts`
 
-- `ENV_MAP` already has `google-gemini-cli`. `detectProviderAuth("google-gemini-cli", prefs)` will
-  return true once `auth.json["google-gemini-cli"]` exists (via `hasOAuthCredentials`). Confirm
-  `hasOAuthCredentials` treats a `{type:"oauth"}` entry whose `access` may be expired correctly —
-  for the **selector** we want "authenticated = credential present" (expired is still "logged in,
-  needs refresh"), matching how Anthropic behaves. No change needed beyond emitting the models.
-- Emit `google-gemini-cli` Gemini models: either map the same Gemini ids as the `google` provider
-  under provider `google-gemini-cli` with `api:"google-code-assist"` (for path (b)(i)), or, in the
-  fallback-only iteration, surface them through provider `google` (API key) unchanged. Gemini
-  ranking in the priority function already covers the ids.
+- Add an explicit OAuth-capability guard so generic OAuth credentials cannot over-authenticate API-
+  key-only providers. Concrete mechanism: introduce `const OAUTH_AUTHENTICATED_PROVIDERS = new Set([
+  "anthropic", "openai-codex", "google-gemini-cli" ])` (or equivalent metadata on each provider) and
+  have `detectProviderAuth` call `hasOAuthCredentials(provider)` only when the provider is in that
+  allow-list. This preserves existing Anthropic/OpenAI behavior, allows Code Assist models to show as
+  authenticated, and prevents `auth.json["google-gemini-cli"]` from making API-key-only `google`
+  Developer API models look usable.
+- `ENV_MAP` already has `google-gemini-cli`. `detectProviderAuth("google-gemini-cli", prefs)` should
+  return true once `auth.json["google-gemini-cli"]` exists (via the allow-listed OAuth credential
+  path). Confirm the selector treats a `{type:"oauth"}` entry whose `access` may be expired as
+  "authenticated = credential present" (expired is still "logged in, needs refresh"), matching how
+  Anthropic behaves.
+- Emit `google-gemini-cli` Gemini models by mapping the Code Assist-supported Gemini ids under
+  provider `google-gemini-cli` with `api:"google-code-assist"` (for path (b)(i)). Keep the existing
+  `google` provider models API-key-only. Gemini ranking in the priority function already covers the
+  ids.
 
 ### 4.5 API-key fallback discoverability (Settings drift fix) — `src/app/settings-page.ts`
 

--- a/docs/design/google-oauth-model-auth.md
+++ b/docs/design/google-oauth-model-auth.md
@@ -44,6 +44,10 @@ exact targets for the follow-up implementation task.
 - `GET  /api/oauth/flow-status?flowId=&provider=` → `oauthFlowStatus`
 - `POST /api/oauth/start` `{ provider }` → `oauthStart`
 - `POST /api/oauth/complete` `{ flowId, code }` → `oauthComplete`
+- **New:** `POST /api/oauth/logout` `{ provider }` → normalize provider, revoke/clear that
+  provider's `auth.json` entry, call `clearOAuthCache()`, return `{ success: true }`, and never echo
+  token material. It must be provider-partitioned: logging out `google-gemini-cli` cannot delete
+  `anthropic`, `openai-codex`, or API-key-only `google` credentials.
 - Provider **API keys** (separate from OAuth): `GET /api/provider-keys`, `POST/DELETE
   /api/provider-keys/:provider`. **These write `preferencesStore` under `providerKey.<provider>`,
   NOT `auth.json`.** `POST /api/pi-ai/provider-key-test` → `testProviderApiKey`.
@@ -218,7 +222,7 @@ Code Assist runtime, while Bobbit's gateway already owns the Account-tab loopbac
 provider-partitioned status endpoints. The implementation should still reuse the existing
 `pendingFlows` map, TTL cleanup, provider mismatch checks, and redaction helpers; it should add a
 Google flow record shape, not a parallel untracked lifecycle. pi-ai's `registerOAuthProvider` remains
-available only for later agent-session parity (§4.3), after Bobbit has a working Code Assist
+available only for later agent-session parity (§4.4), after Bobbit has a working Code Assist
 runtime.
 
 ---
@@ -275,7 +279,22 @@ runtime.
    keep it (mirror Anthropic's policy). Persist new `{access, refresh: new ?? old, expires}` and
    `clearOAuthCache()`.
 
-### 4.2 Settings Account row — `src/app/settings-page.ts`
+### 4.2 REST route changes — `src/server/server.ts`
+
+1. Existing `/api/oauth/status`, `/api/oauth/flow-status`, `/api/oauth/start`, and
+   `/api/oauth/complete` remain provider-partitioned and ride the `normalizeProvider()` changes.
+2. Add `POST /api/oauth/logout` with body `{ provider }`:
+   - normalize the provider using the same canonical mapping as start/status/complete;
+   - optionally revoke the upstream token for providers with revoke endpoints (Google: POST token to
+     `GOOGLE_REVOKE_URL` when an access or refresh token is available; do not fail logout if revoke
+     is transiently unavailable);
+   - delete only `auth.json[canonicalProvider]`;
+   - call `clearOAuthCache()`;
+   - return `{ success: true, provider: canonicalProvider }` with no token fields.
+3. Add API E2E coverage that logging out `google-gemini-cli` leaves `anthropic`, `openai-codex`, and
+   API-key-only `providerKey.google` untouched.
+
+### 4.3 Settings Account row — `src/app/settings-page.ts`
 
 1. `type AccountProviderId = "anthropic" | "openai-codex" | "google-gemini-cli"`.
 2. Append to `ACCOUNT_PROVIDERS`:
@@ -292,7 +311,7 @@ runtime.
    `google-gemini-cli|google|gemini → "Google"`. The rest of the dialog (start/poll/paste) is
    provider-agnostic.
 
-### 4.3 Runtime: making Gemini usable from the OAuth credential
+### 4.4 Runtime: making Gemini usable from the OAuth credential
 
 Two consumers exist; both need the Code Assist path because pi-ai's `google` provider is API-key only.
 
@@ -324,14 +343,14 @@ as the upstream-parity alternative:
      long-term; out of this goal's control. Until then, ship (i) or scope agent-session Gemini to
      API-key `google`.
 
-The follow-up implementation task should treat §4.1/§4.2/§4.5 (auth, UI, fallback) as **must-ship**,
-and §4.3 runtime as the substantive engineering item, implemented as (a) for gateway helpers first,
-then (b)(i) for agent sessions. If (b)(i) proves too large for one iteration, the UI copy from §4.2
-already tells the user the credential targets the Code Assist API, and API-key `google` remains the
-working inference path — acceptance criterion "API-key Google auth remains possible and discoverable"
-is still met.
+The follow-up implementation task should treat §4.1/§4.2/§4.3/§4.6 (auth, REST, UI, fallback) as
+**must-ship**, and §4.4 runtime as the substantive engineering item, implemented as (a) for gateway
+helpers first, then (b)(i) for agent sessions. If (b)(i) proves too large for one iteration, the UI
+copy from §4.3 already tells the user the credential targets the Code Assist API, and API-key
+`google` remains the working inference path — acceptance criterion "API-key Google auth remains
+possible and discoverable" is still met.
 
-### 4.4 Model registry / auth detection — `src/server/agent/model-registry.ts`
+### 4.5 Model registry / auth detection — `src/server/agent/model-registry.ts`
 
 - Add an explicit OAuth-capability guard so generic OAuth credentials cannot over-authenticate API-
   key-only providers. Concrete mechanism: introduce `const OAUTH_AUTHENTICATED_PROVIDERS = new Set([
@@ -350,7 +369,7 @@ is still met.
   `google` provider models API-key-only. Gemini ranking in the priority function already covers the
   ids.
 
-### 4.5 API-key fallback discoverability (Settings drift fix) — `src/app/settings-page.ts`
+### 4.6 API-key fallback discoverability (Settings drift fix) — `src/app/settings-page.ts`
 
 - Add a **"Model provider API keys"** section to `renderModelsTab()` (the live Models tab), reusing
   the legacy component `src/ui/components/ProviderKeyInput.ts` and the existing `/api/provider-keys`
@@ -363,7 +382,7 @@ is still met.
 - Either delete `src/ui/dialogs/ProvidersModelsTab.ts` (dead) or repoint it; do not leave two
   competing UIs. Update any docs/onboarding copy that references a "Providers & Models" screen.
 
-### 4.6 Sandbox credential propagation — `src/server/agent/host-tokens.ts` (+ `docker-args.ts`)
+### 4.7 Sandbox credential propagation — `src/server/agent/host-tokens.ts` (+ `docker-args.ts`)
 
 - Add a `PROVIDER_TOKENS` entry for the OAuth provider so detection/resolution see it:
   `{ envVar: "GOOGLE_CLOUD_ACCESS_TOKEN", label: "Google (Gemini Code Assist OAuth)", provider:
@@ -381,7 +400,7 @@ is still met.
 - `docker-args.ts` needs no structural change: it already mounts the scoped `auth.json` and injects
   allowed sandbox tokens as env vars; the new entry rides those existing paths.
 
-### 4.7 Logging / safety invariants (must hold)
+### 4.8 Logging / safety invariants (must hold)
 
 - Reuse `redactSensitive` for every Google log line and error body; truncate provider error bodies
   (256-char cap already in `oauthComplete`).
@@ -421,7 +440,7 @@ Browser E2E (`tests/e2e/ui/settings.spec.ts` pattern):
   API-key entry point is present in the current Settings (guards the drift from re-appearing).
 
 Manual integration (`tests/manual-integration/`, gate-exempt): real Google account → Account login →
-reload persists → a Gemini model is selectable and (when §4.3 runtime lands) returns a completion
+reload persists → a Gemini model is selectable and (when §4.4 runtime lands) returns a completion
 via Code Assist without an API key; document the exact steps + the project/onboarding behavior.
 
 ---
@@ -430,10 +449,10 @@ via Code Assist without an API key; document the exact steps + the project/onboa
 
 | Goal AC | Covered by |
 |---|---|
-| Login Google, reload, still authenticated | §4.1 storage + §4.2 row + browser E2E persistence |
-| Gemini usable without API key (where supported) | §4.3 Code Assist runtime; §2.4 honest constraint surfaced in §4.2 copy |
+| Login Google, reload, still authenticated | §4.1 storage + §4.3 row + browser E2E persistence |
+| Gemini usable without API key (where supported) | §4.4 Code Assist runtime; §2.4 honest constraint surfaced in §4.3 copy |
 | Anthropic/OpenAI OAuth unchanged | §4.1 additive `normalizeProvider`/union; no edits to their branches |
-| API-key Google remains possible + discoverable | §4.5 Models-tab key field + §2.1 fallback |
+| API-key Google remains possible + discoverable | §4.6 Models-tab key field + §2.1 fallback |
 | Regression test for missing settings path | §5 browser E2E asserting the API-key entry exists |
 
 ## 7. Out of scope / explicitly avoided
@@ -442,4 +461,4 @@ via Code Assist without an API key; document the exact steps + the project/onboa
   endpoints (goal constraint). Only the official installed-app OAuth client + Code Assist /
   Developer APIs are used.
 - Vertex AI (`google-vertex`) integration beyond not colliding with it.
-- Shipping the pi-ai upstream Code Assist provider (§4.3 b-ii) — tracked as a follow-up.
+- Shipping the pi-ai upstream Code Assist provider (§4.4 b-ii) — tracked as a follow-up.

--- a/docs/design/google-oauth-model-auth.md
+++ b/docs/design/google-oauth-model-auth.md
@@ -1,0 +1,418 @@
+# Google OAuth for Gemini models
+
+Status: design (no production code in this change)
+Goal: `google-oauth-m-d4c9a4df` — add first-class Google account authentication for Gemini
+models alongside the existing Anthropic and OpenAI account login flows.
+
+This document is the authoritative implementation plan. It is the output of the `design-doc`
+gate. It deliberately edits **only** `docs/design/google-oauth-model-auth.md`; no `src/`,
+tests, package files, or `AGENTS.md` are touched. All file paths/functions named below are the
+exact targets for the follow-up implementation task.
+
+---
+
+## 1. Audit of the existing auth pipeline
+
+### 1.1 OAuth handler — `src/server/auth/oauth.ts`
+
+- `export type OAuthProviderId = "anthropic" | "openai-codex"`.
+- `normalizeProvider(provider)` maps `undefined|"anthropic" → "anthropic"`, `"openai"|"openai-codex"
+  → "openai-codex"`, throws otherwise. **This is the single choke point for provider isolation.**
+- Two flow shapes:
+  - **Anthropic (native):** PKCE generated server-side (`generatePKCE`), authorize URL built in
+    `oauthStart`, code→token exchanged directly in `oauthComplete` against `TOKEN_URL`
+    (`https://console.anthropic.com/v1/oauth/token`). Refresh in `refreshOAuthToken()`.
+  - **External (pi-ai):** `oauthStartExternal(provider)` calls `getOAuthProvider(provider)` from
+    `@earendil-works/pi-ai/oauth` and drives the `OAuthLoginCallbacks` (`onAuth`, `onDeviceCode`,
+    `onPrompt`, `onManualCodeInput`, `onSelect`, `onProgress`). Credentials are persisted by
+    `storeOAuthCredentials(provider, credentials)`.
+- Storage: `globalAuthPath()` → `~/.bobbit/agent/auth.json`, written 0600 via `writeAuthData`,
+  which calls `clearOAuthCache()`. Shape per provider key: `{ type: "oauth", access, refresh,
+  expires, ... }`. Anthropic bakes a 5-minute safety buffer into `expires`.
+- `oauthStatus(provider)` returns only `{ authenticated, expires, provider }` — **never echoes
+  token material** ("strict-OAuth contract"). `oauthFlowStatus(flowId, provider)` cross-checks the
+  flow's stored provider against the query param to avoid cross-provider status leaks.
+- `refreshOAuthToken()` is **Anthropic-only today** (`authData.anthropic`). It only clears
+  credentials on definitive auth failures (400/401/403); transient 5xx/429/network errors keep the
+  stored credential.
+- In-memory `pendingFlows` map (5-min TTL, swept by `ensureFlowCleanupTimer`). Anthropic flows hold
+  a `verifier`; external flows hold `submitCode`/`rejectCode`/`loginPromise`/`completed`/`error`.
+
+### 1.2 REST surface — `src/server/server.ts` (`handleApiRoute`)
+
+- `GET  /api/oauth/status?provider=` → `oauthStatus`
+- `GET  /api/oauth/flow-status?flowId=&provider=` → `oauthFlowStatus`
+- `POST /api/oauth/start` `{ provider }` → `oauthStart`
+- `POST /api/oauth/complete` `{ flowId, code }` → `oauthComplete`
+- Provider **API keys** (separate from OAuth): `GET /api/provider-keys`, `POST/DELETE
+  /api/provider-keys/:provider`. **These write `preferencesStore` under `providerKey.<provider>`,
+  NOT `auth.json`.** `POST /api/pi-ai/provider-key-test` → `testProviderApiKey`.
+
+### 1.3 Settings UI — `src/app/settings-page.ts` + `src/app/dialogs.ts`
+
+- System tabs: `SYSTEM_TABS` includes `{ id: "account", label: "Account" }` and `{ id: "models" }`.
+- Account tab: `type AccountProviderId = "anthropic" | "openai-codex"`, array `ACCOUNT_PROVIDERS`,
+  `loadAccountStatus()`, `handleReauthenticate()`, `renderAccountTab()`. The "Log in /
+  Re-authenticate" button calls `openOAuthDialog(provider)`.
+- OAuth dialog: `openOAuthDialog(provider)` in `src/app/dialogs.ts` — `POST /api/oauth/start`,
+  opens `data.url` in a tab, polls `flow-status` when `callbackServer === true`, and offers a
+  manual "paste the full redirect URL or authorization code" field that posts to
+  `/api/oauth/complete`. `providerName` is derived: `openai-codex|openai → "OpenAI"` else
+  `"Anthropic"`.
+- **Settings drift (goal requirement #9):** the current Models tab (`renderModelsTab`, line ~2004)
+  renders only **AI Gateway** + custom-provider config. It contains **no per-provider API-key
+  input** — `grep -c "ProviderKeyInput|provider-key" src/app/settings-page.ts` → `0`. The legacy
+  per-provider key UI lives in `src/ui/dialogs/ProvidersModelsTab.ts` (uses
+  `src/ui/components/ProviderKeyInput.ts` + `/api/provider-keys`) but is **not wired into any
+  current settings tab** (`getTabsForScope`). So a user told to "enter a Gemini API key in
+  Providers & Models" lands on a screen that no longer exists.
+
+### 1.4 Model registry — `src/server/agent/model-registry.ts`
+
+- `assembleModels(prefs)` pulls pi-ai built-ins (`getProviders()` / `getModels(providerId)`),
+  merges OpenAI additions, then AI-Gateway and custom providers.
+- Auth detection: `detectProviderAuth(provider, prefs)` → true if `prefs.get("providerKey.<p>")`,
+  or `process.env[ENV_MAP[p]]`, or `hasOAuthCredentials(p)` (reads `auth.json`, 10s cache via
+  `oauthCache` / `clearOAuthCache`). `ENV_MAP` already contains `google → GOOGLE_API_KEY`,
+  `google-gemini-cli → GOOGLE_API_KEY`, `google-vertex → GOOGLE_APPLICATION_CREDENTIALS`.
+- `hasOAuthCredentials(provider)` currently returns true if `authData[provider]` exists — so a new
+  `auth.json` key is automatically honored once present.
+- Gemini ranking already exists in the priority function (`gemini-3.1-pro`, `gemini-2.5-pro`, …).
+
+### 1.5 Runtime completion — `src/server/agent/model-completion.ts`
+
+- `PROVIDER_ENV_KEYS` includes `google: ["GEMINI_API_KEY","GOOGLE_API_KEY"]` and
+  `"google-gemini-cli": ["GEMINI_API_KEY","GOOGLE_API_KEY"]`.
+- `resolveProviderApiKey(prefs, provider)` precedence: `providerKey.<p>` → env keys →
+  `authCredentialForProvider(p)` (with **Anthropic-only** refresh on expiry) → custom provider →
+  `models.json`. Returns a single string handed to pi-ai as `options.apiKey`.
+- `completeModelText` (gateway-side helpers: title/name/test) calls pi-ai `completeSimple` with
+  `{ apiKey }`. pi-ai's `google` provider (`@earendil-works/pi-ai/google`, api
+  `google-generative-ai`) constructs `new GoogleGenAI({ apiKey, httpOptions })` — the key is sent
+  as `x-goog-api-key` to `https://generativelanguage.googleapis.com/v1beta`. **It has no bearer/
+  OAuth code path.** `createClient` does merge `model.headers` + `options.headers`, so a custom
+  `Authorization` header can be injected, but that does not change the `generativelanguage`
+  endpoint, which does not accept consumer OAuth tokens for `generateContent`.
+
+### 1.6 Sandbox credential propagation
+
+- `src/server/agent/host-tokens.ts`:
+  - `PROVIDER_TOKENS` maps provider → sandbox env var. Google entry today: `{ envVar:
+    "GEMINI_API_KEY", provider: "google", envKeys: ["GEMINI_API_KEY"] }`.
+  - `detectHostTokens(prefs)` / `resolveHostTokenValue(envVar, prefs)` resolve a token value from
+    env → `providerKey.<provider>` → `auth.json` (`oauth.access` or `api_key.key`).
+  - `buildSandboxAgentAuthJson()` / `ensureSandboxAgentAuthFile()` write a **scoped, sanitized**
+    `auth.json` that is bind-mounted read-only into the sandbox. Today it only emits the
+    `openai-codex` OAuth/key entry when `includeCodexAuth` policy allows; `sanitizeCodexCredential`
+    copies only `{type, access, refresh?, expires?}` (or `{type, key}`), dropping profile metadata.
+- `src/server/agent/docker-args.ts`: mounts the scoped `auth.json` read-only at
+  `/home/node/.bobbit/agent/auth.json`; never mounts the full host agent dir. Sandbox credentials
+  are also injected as `-e KEY=VALUE` env vars (validated key regex).
+
+### 1.7 pi-ai OAuth capability (verified against installed dist)
+
+`@earendil-works/pi-ai/oauth` exports providers for **Anthropic, GitHub Copilot, OpenAI Codex
+only**. `getOAuthProvider(id)` returns `undefined` for `"google"`. There is `registerOAuthProvider`
+to add a custom provider implementing `OAuthProviderInterface` (`login`, `refreshToken`,
+`getApiKey`, optional `modifyModels`, `usesCallbackServer`). pi-ai runtime providers are `google`
+(`google-generative-ai`) and `google-vertex` — **no Code Assist / `cloudcode-pa` provider exists**.
+
+---
+
+## 2. Research: official Google auth surfaces for Gemini
+
+No browser-cookie scraping, no `gemini.google.com` session extraction, no undocumented endpoints.
+Three officially-supported surfaces exist; only two are relevant.
+
+### 2.1 Gemini Developer API — `generativelanguage.googleapis.com` (API key, the fallback)
+
+- Primary auth is an **API key** (`x-goog-api-key`), created in Google AI Studio. This is exactly
+  what pi-ai's `google` provider already does. **Keep this as the always-working fallback.**
+- OAuth 2.0 is supported by this API only for a subset of methods (e.g. tuned-model / semantic-
+  retrieval resources) and, for `generateContent`, requires the API enabled on a GCP project with a
+  billing/quota project attached. There is **no officially-supported consumer-account OAuth path to
+  `generateContent` on `generativelanguage` without a GCP project**. We therefore do **not** claim
+  that "log in with Google" makes the `google` (Developer API) provider work; that provider stays
+  API-key only.
+
+### 2.2 Gemini Code Assist API — `cloudcode-pa.googleapis.com` (OAuth, the account path)
+
+This is the surface the official **Gemini CLI** uses for "Login with Google" (personal account,
+free Code Assist tier). Verified from `google-gemini/gemini-cli`
+(`packages/core/src/code_assist/oauth2.ts` and `server.ts`):
+
+- **OAuth client (installed app, public — secret is intentionally non-secret per Google's installed-
+  app guidance):**
+  - client_id: `681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com`
+  - client_secret: a public `GOCSPX-…` installed-app secret published in the Gemini CLI source
+    (`packages/core/src/code_assist/oauth2.ts`, `OAUTH_CLIENT_SECRET`). Per Google's installed-app
+    guidance it is not treated as secret; the implementation should read the literal value from that
+    upstream source. (Not pasted here so GitHub push-protection / secret-scanning does not flag the
+    design doc.)
+- **Scopes:**
+  - `https://www.googleapis.com/auth/cloud-platform`
+  - `https://www.googleapis.com/auth/userinfo.email`
+  - `https://www.googleapis.com/auth/userinfo.profile`
+- **OAuth endpoints (standard Google):**
+  - authorize: `https://accounts.google.com/o/oauth2/v2/auth` (PKCE S256, `access_type=offline`,
+    `prompt=consent` to guarantee a `refresh_token`)
+  - token: `https://oauth2.googleapis.com/token`
+  - revoke: `https://oauth2.googleapis.com/revoke`
+  - userinfo: `https://www.googleapis.com/oauth2/v3/userinfo`
+  - redirect: **loopback** (`http://localhost:<port>/oauth2callback`). OOB is deprecated by Google;
+    a loopback redirect on the gateway host is the supported installed-app pattern.
+- **Inference endpoints (Bearer access token):** base `https://cloudcode-pa.googleapis.com`, version
+  `v1internal`:
+  - `:loadCodeAssist` — discover tier + whether onboarding is needed.
+  - `:onboardUser` — long-running; resolves the free-tier project the request runs under.
+  - `:generateContent` / `:streamGenerateContent` — Code Assist wraps the standard
+    `GenerateContent` request/response (the CLI's `toGenerateContentRequest` /
+    `fromGenerateContentResponse` converters wrap/unwrap `{ project, request: {...} }`).
+  - `:countTokens` (optional).
+- **Token response:** `{ access_token, refresh_token?, expires_in, scope, token_type:"Bearer" }`.
+  Refresh via `grant_type=refresh_token` at the token endpoint (refresh_token usually not rotated).
+
+### 2.3 Vertex AI — out of scope
+
+`google-vertex` (ADC/service-account, GCP project required) already exists in pi-ai. Not part of the
+consumer "log in with Google" story; documented here only so the design does not collide with it.
+
+### 2.4 Consequence / honest constraint
+
+The consumer Google-account credential is a **Bearer OAuth token usable only against the Code Assist
+API**, which is a *different wire protocol and endpoint* from the API-key Gemini Developer API.
+There is no supported way to feed a consumer OAuth token to pi-ai's existing `google` provider. So
+"Gemini usable without an API key" requires a **Code Assist-compatible runtime** (§4), not merely a
+new credential. This constraint must be surfaced in the UI/docs (goal constraint: "If consumer
+Gemini subscription cannot be used via an official model API, surface that clearly").
+
+---
+
+## 3. Design overview
+
+- **New OAuth provider id: `google-gemini-cli`** (kebab, matches the id already present in
+  `ENV_MAP` and `PROVIDER_ENV_KEYS`). It is the **OAuth/Code-Assist** account provider.
+- **`google` stays the API-key Gemini Developer API provider** (fallback). Provider isolation: the
+  two never share a flow id or an `auth.json` key.
+- `auth.json` gains a `"google-gemini-cli"` entry: `{ type:"oauth", access, refresh, expires,
+  email? }`. `email` is non-secret display metadata (from userinfo); tokens are never returned by
+  any `/status` response.
+- The account row, status, refresh, and sandbox propagation reuse the existing partitioned plumbing.
+- The runtime is implemented **natively in Bobbit** (option B below), not via pi-ai, because pi-ai
+  ships no Code Assist provider and we should not block on an upstream change.
+
+Provider-id decision (recorded so it is not re-litigated): native Bobbit flow in `oauth.ts` rather
+than a pi-ai `registerOAuthProvider` custom provider — the Anthropic path is already native, the
+loopback+manual-paste UX is gateway-specific, and it avoids coupling login to an upstream provider
+registry. pi-ai's `registerOAuthProvider` remains available if we later want agent-session parity
+through pi-ai (§4.3).
+
+---
+
+## 4. Implementation plan (exact files / functions)
+
+### 4.1 OAuth flow — `src/server/auth/oauth.ts`
+
+1. Extend the union: `export type OAuthProviderId = "anthropic" | "openai-codex" |
+   "google-gemini-cli"`. Add label `"google-gemini-cli": "Google"` to `OAUTH_PROVIDER_LABELS`.
+2. `normalizeProvider`: map `"google" | "google-gemini-cli" | "gemini"` → `"google-gemini-cli"`.
+   (Accept `"google"` as an alias from the UI but store under the canonical id.)
+3. Add Google constants near the Anthropic block:
+   `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_AUTH_URL`
+   (`https://accounts.google.com/o/oauth2/v2/auth`), `GOOGLE_TOKEN_URL`
+   (`https://oauth2.googleapis.com/token`), `GOOGLE_REVOKE_URL`, `GOOGLE_USERINFO_URL`,
+   `GOOGLE_SCOPES` (the three §2.2 scopes, space-joined).
+4. New pending-flow variant `PendingGoogleOAuth { provider:"google-gemini-cli"; verifier; state;
+   redirectUri; server?: http.Server; createdAt }`; add to the `PendingOAuth` union and to
+   `cleanupExpiredFlows` (close the loopback server on expiry).
+5. `oauthStart`: when provider is `google-gemini-cli`, call new `oauthStartGoogle()`:
+   - Start a **loopback callback server** on `127.0.0.1:0` (ephemeral port) bound to path
+     `/oauth2callback`. `redirect_uri = http://localhost:<port>/oauth2callback`.
+   - Generate PKCE (`generatePKCE`) + random `state`.
+   - Build authorize URL with `client_id, response_type=code, redirect_uri, scope, state,
+     code_challenge, code_challenge_method=S256, access_type=offline, prompt=consent`.
+   - Return `{ flowId, url, provider, callbackServer: true }` (so the dialog auto-polls). The
+     loopback handler, on receiving `?code=&state=`, validates `state`, calls the shared
+     `exchangeGoogleCode()` then redirects the browser to a success page and marks the flow
+     complete; on error sets `flow.error`.
+   - Keep the manual-paste path working: `oauthComplete(flowId, code)` for a Google flow accepts a
+     pasted authorization code **or** a full redirect URL (parse `code`+`state`), then calls
+     `exchangeGoogleCode()`. This mirrors the existing dialog affordance and makes remote-gateway
+     setups (where the user's browser cannot reach the gateway loopback) still work.
+6. `exchangeGoogleCode(flow, code, state)` (shared by loopback + paste): POST to `GOOGLE_TOKEN_URL`
+   with `grant_type=authorization_code, code, client_id, client_secret, redirect_uri, code_verifier`.
+   On success, optionally GET `GOOGLE_USERINFO_URL` for `email`. Persist via
+   `storeOAuthCredentials("google-gemini-cli", { access, refresh, expires: Date.now()+expires_in*1000
+   - 5*60*1000, email })`. Truncate error bodies (reuse the 256-char cap), and `redactSensitive` any
+   logged string.
+7. `oauthStatus("google-gemini-cli")`: already generic — works once `normalizeProvider` accepts the
+   id; returns `{ authenticated, expires, provider }` only. Add `email` to the returned shape **only
+   if** we decide to show the signed-in account; it is non-secret. Tokens stay omitted.
+8. `oauthFlowStatus`: generic; the provider cross-check already guards isolation.
+9. **Generalize refresh**: rename/extend `refreshOAuthToken()` to take a provider, or add
+   `refreshGoogleToken()`. For `google-gemini-cli`: skip if `Date.now() < expires`; else POST
+   `grant_type=refresh_token, refresh_token, client_id, client_secret` to `GOOGLE_TOKEN_URL`; on
+   400/401/403 delete the stored entry; on 5xx/429/network keep it (mirror Anthropic's policy).
+   Persist new `{access, refresh: new ?? old, expires}` and `clearOAuthCache()`.
+
+### 4.2 Settings Account row — `src/app/settings-page.ts`
+
+1. `type AccountProviderId = "anthropic" | "openai-codex" | "google-gemini-cli"`.
+2. Append to `ACCOUNT_PROVIDERS`:
+   ```
+   { id: "google-gemini-cli", title: "Google (Gemini)",
+     description: "OAuth credentials for Gemini via the Google Code Assist API (personal Google
+       account). Used by agent sessions for Gemini models. For Google AI Studio API keys, use
+       Settings → Models → API keys.",
+     authenticatedLabel: "Authenticated" }
+   ```
+   `loadAccountStatus`, `handleReauthenticate`, `renderAccountTab` are already provider-generic and
+   need no further change.
+3. `src/app/dialogs.ts`: extend `providerName` derivation in `openOAuthDialog` so
+   `google-gemini-cli|google|gemini → "Google"`. The rest of the dialog (start/poll/paste) is
+   provider-agnostic.
+
+### 4.3 Runtime: making Gemini usable from the OAuth credential
+
+Two consumers exist; both need the Code Assist path because pi-ai's `google` provider is API-key only.
+
+**(a) Gateway-side helper completions** (title/name/connection-test in
+`src/server/agent/model-completion.ts`): add a small Code Assist adapter
+`src/server/agent/google-code-assist.ts`:
+   - `getGoogleAccessToken(prefs)` → reuse `refreshGoogleToken()` to return a fresh Bearer token.
+   - `ensureCodeAssistProject(token)` → cached `loadCodeAssist`/`onboardUser` result (projectId);
+     persist the resolved projectId in `models.json`/preferences to avoid re-onboarding.
+   - `codeAssistGenerate({ model, systemPrompt, messages, maxTokens, token, projectId })` →
+     POST `https://cloudcode-pa.googleapis.com/v1internal:generateContent` (or
+     `:streamGenerateContent`) with `Authorization: Bearer <token>` and the Code-Assist-wrapped
+     body `{ model, project, request: { contents, systemInstruction, generationConfig } }`; unwrap
+     `response.response.candidates[...]` back to text.
+   - In `completeModelText`, branch on `model.provider === "google-gemini-cli"` to use this adapter
+     instead of pi-ai `completeSimple`. `resolveProviderApiKey` is bypassed for this provider (it
+     returns a Bearer token, not an API key).
+
+**(b) Agent sessions** (pi-coding-agent inside the sandbox, which uses pi-ai): pi-ai has no Code
+Assist provider, so there are two viable options — the design recommends option (i) and lists (ii)
+as the upstream-parity alternative:
+   - **(i) Register a Bobbit custom pi-ai provider** at startup via `registerOAuthProvider({ id:
+     "google-gemini-cli", login, refreshToken, getApiKey, usesCallbackServer:true })` **plus** a
+     runtime stream function for api `"google-code-assist"` registered with pi-ai, pointing
+     `baseUrl` at `cloudcode-pa.googleapis.com/v1internal` and sending the Bearer token via
+     `httpOptions.headers.Authorization`. The model-registry would emit `google-gemini-cli` models
+     with `api: "google-code-assist"`.
+   - **(ii) Upstream:** contribute a `cloudcode-pa` provider to `@earendil-works/pi-ai`. Cleaner
+     long-term; out of this goal's control. Until then, ship (i) or scope agent-session Gemini to
+     API-key `google`.
+
+The follow-up implementation task should treat §4.1/§4.2/§4.5 (auth, UI, fallback) as **must-ship**,
+and §4.3 runtime as the substantive engineering item, implemented as (a) for gateway helpers first,
+then (b)(i) for agent sessions. If (b)(i) proves too large for one iteration, the UI copy from §4.2
+already tells the user the credential targets the Code Assist API, and API-key `google` remains the
+working inference path — acceptance criterion "API-key Google auth remains possible and discoverable"
+is still met.
+
+### 4.4 Model registry / auth detection — `src/server/agent/model-registry.ts`
+
+- `ENV_MAP` already has `google-gemini-cli`. `detectProviderAuth("google-gemini-cli", prefs)` will
+  return true once `auth.json["google-gemini-cli"]` exists (via `hasOAuthCredentials`). Confirm
+  `hasOAuthCredentials` treats a `{type:"oauth"}` entry whose `access` may be expired correctly —
+  for the **selector** we want "authenticated = credential present" (expired is still "logged in,
+  needs refresh"), matching how Anthropic behaves. No change needed beyond emitting the models.
+- Emit `google-gemini-cli` Gemini models: either map the same Gemini ids as the `google` provider
+  under provider `google-gemini-cli` with `api:"google-code-assist"` (for path (b)(i)), or, in the
+  fallback-only iteration, surface them through provider `google` (API key) unchanged. Gemini
+  ranking in the priority function already covers the ids.
+
+### 4.5 API-key fallback discoverability (Settings drift fix) — `src/app/settings-page.ts`
+
+- Add a **"Model provider API keys"** section to `renderModelsTab()` (the live Models tab), reusing
+  the legacy component `src/ui/components/ProviderKeyInput.ts` and the existing `/api/provider-keys`
+  endpoints. Include at minimum Anthropic, OpenAI, **Google (`google`, Gemini Developer API key)**,
+  xAI, Groq, Mistral, OpenRouter — i.e. salvage the rows from `src/ui/dialogs/ProvidersModelsTab.ts`
+  into the current tab so the entry point exists where users are sent.
+- Add an explicit helper line distinguishing the two Google options:
+  - "**Google account (Gemini)**" → Settings → Account → Google (OAuth / Code Assist).
+  - "**Google AI Studio API key**" → this Models tab field (provider `google`).
+- Either delete `src/ui/dialogs/ProvidersModelsTab.ts` (dead) or repoint it; do not leave two
+  competing UIs. Update any docs/onboarding copy that references a "Providers & Models" screen.
+
+### 4.6 Sandbox credential propagation — `src/server/agent/host-tokens.ts` (+ `docker-args.ts`)
+
+- Add a `PROVIDER_TOKENS` entry for the OAuth provider so detection/resolution see it:
+  `{ envVar: "GOOGLE_CLOUD_ACCESS_TOKEN", label: "Google (Gemini Code Assist OAuth)", provider:
+  "google-gemini-cli", envKeys: ["GOOGLE_CLOUD_ACCESS_TOKEN"] }`. (`GOOGLE_CLOUD_ACCESS_TOKEN` is
+  the env var the Gemini CLI / google-auth honor for a pre-acquired Bearer token, paired with
+  `GOOGLE_GENAI_USE_GCA=1`.)
+- `resolveHostTokenValue("GOOGLE_CLOUD_ACCESS_TOKEN", prefs)`: return a **freshly refreshed** access
+  token (call `refreshGoogleToken()`), not the possibly-expired stored value.
+- Extend the sanitized sandbox `auth.json` builder (`buildSandboxAgentAuthJson` /
+  `sanitizeCodexCredential` pattern) to optionally include a sanitized `google-gemini-cli` entry
+  `{type:"oauth", access, refresh?, expires?}` when a sandbox-token policy entry enables it — mirror
+  `sandboxTokenPolicyAllowsCodexAuth` with a `GOOGLE_*` allow-set. Never copy `email`/profile fields
+  into the sandbox file. Default remains an empty object unless policy opts in (provider isolation +
+  least privilege preserved).
+- `docker-args.ts` needs no structural change: it already mounts the scoped `auth.json` and injects
+  allowed sandbox tokens as env vars; the new entry rides those existing paths.
+
+### 4.7 Logging / safety invariants (must hold)
+
+- Reuse `redactSensitive` for every Google log line and error body; truncate provider error bodies
+  (256-char cap already in `oauthComplete`).
+- `/api/oauth/status` and `/api/provider-keys` (GET) must never include `access`/`refresh`/`key`.
+  `email` is the only new non-secret field permitted in a status response, and only if shown in UI.
+- Provider isolation: `google-gemini-cli` flow ids live in the same `pendingFlows` map but
+  `oauthFlowStatus`'s provider cross-check prevents cross-provider reads; `normalizeProvider` is the
+  only mapping authority; `auth.json` key is dedicated and never shared with `google`/`anthropic`/
+  `openai-codex`.
+
+---
+
+## 5. Test plan (for the tester / follow-up tasks — not written in this change)
+
+Unit (node, `tests/*.test.ts`):
+- `normalizeProvider` accepts `google`/`google-gemini-cli`/`gemini` → canonical id; rejects unknown.
+- `oauthStatus("google-gemini-cli")` never returns `access`/`refresh`; returns `{authenticated,
+  expires}` for present/expired/absent credentials.
+- `exchangeGoogleCode` / refresh: mock `fetch` — success persists sanitized `{type:"oauth",access,
+  refresh,expires}`; 400/401/403 clears, 5xx/429 retains. Assert `auth.json` chmod 0600.
+- Provider isolation: a Google flow id queried with `provider=anthropic` → `flow not found`.
+- `host-tokens`: `resolveHostTokenValue("GOOGLE_CLOUD_ACCESS_TOKEN")` returns refreshed token;
+  `buildSandboxAgentAuthJson` includes the Google entry only when policy allows and emits only
+  sanitized fields (no `email`).
+- `detectProviderAuth("google-gemini-cli")` true when `auth.json` entry present.
+
+API E2E (`tests/e2e/*.spec.ts`):
+- `POST /api/oauth/start {provider:"google-gemini-cli"}` returns a flow id + `accounts.google.com`
+  authorize URL with the three scopes, `code_challenge`, `access_type=offline` (mock outbound).
+- `flow-status`/`complete` happy + error paths with mocked Google token endpoint.
+
+Browser E2E (`tests/e2e/ui/settings.spec.ts` pattern):
+- Account tab shows three providers incl. "Google (Gemini)"; clicking "Log in" opens the OAuth
+  dialog (stub `/api/oauth/*`); status flips to Authenticated; **persists across reload**.
+- Models tab now renders a Google AI Studio API-key field; entering/removing a key round-trips via
+  `/api/provider-keys` and persists across reload. **Regression test for goal AC #5** — assert the
+  API-key entry point is present in the current Settings (guards the drift from re-appearing).
+
+Manual integration (`tests/manual-integration/`, gate-exempt): real Google account → Account login →
+reload persists → a Gemini model is selectable and (when §4.3 runtime lands) returns a completion
+via Code Assist without an API key; document the exact steps + the project/onboarding behavior.
+
+---
+
+## 6. Acceptance-criteria traceability
+
+| Goal AC | Covered by |
+|---|---|
+| Login Google, reload, still authenticated | §4.1 storage + §4.2 row + browser E2E persistence |
+| Gemini usable without API key (where supported) | §4.3 Code Assist runtime; §2.4 honest constraint surfaced in §4.2 copy |
+| Anthropic/OpenAI OAuth unchanged | §4.1 additive `normalizeProvider`/union; no edits to their branches |
+| API-key Google remains possible + discoverable | §4.5 Models-tab key field + §2.1 fallback |
+| Regression test for missing settings path | §5 browser E2E asserting the API-key entry exists |
+
+## 7. Out of scope / explicitly avoided
+
+- No `gemini.google.com` cookie/session scraping, no browser-profile extraction, no undocumented
+  endpoints (goal constraint). Only the official installed-app OAuth client + Code Assist /
+  Developer APIs are used.
+- Vertex AI (`google-vertex`) integration beyond not colliding with it.
+- Shipping the pi-ai upstream Code Assist provider (§4.3 b-ii) — tracked as a follow-up.

--- a/docs/design/google-oauth-settings-ux.md
+++ b/docs/design/google-oauth-settings-ux.md
@@ -74,19 +74,21 @@ The app has **two** settings surfaces. Only one is wired into the live UI.
 ### 1.3 Server OAuth pipeline
 
 - Routes in `src/server/server.ts`: `GET /api/oauth/status`, `GET
-  /api/oauth/flow-status`, `POST /api/oauth/start`, `POST /api/oauth/complete`
-  (~L10538–10590).
+  /api/oauth/flow-status`, `POST /api/oauth/start`, `POST /api/oauth/complete`,
+  and new `POST /api/oauth/logout` (~L10538–10590 plus the new route).
 - `src/server/auth/oauth.ts`:
   - `OAuthProviderId = "anthropic" | "openai-codex"` (~L21) and
-    `OAUTH_PROVIDER_LABELS` (~L23) — **add `google` here**.
+    `OAUTH_PROVIDER_LABELS` (~L23) — **add canonical `google-gemini-cli` here**.
   - `normalizeProvider()` (~L102) throws on unknown providers — **must accept
-    `google` / `google-gemini`** for provider isolation.
+    `google-gemini-cli`, plus inbound aliases `google` / `gemini`, and collapse
+    them to canonical `google-gemini-cli`** for provider isolation.
   - Anthropic uses a built-in PKCE flow; non-anthropic providers delegate to
-    `oauthStartExternal()` → pi-ai `getOAuthProvider(provider)`. Google would
-    follow the external path **iff** pi-ai exposes a Google OAuth provider;
-    otherwise a Google PKCE flow is added alongside.
-  - Credentials are written to `auth.json` keyed by provider
-    (`storeOAuthCredentials`, ~L147), and `oauthStatus()` (~L402) returns only
+    `oauthStartExternal()` → pi-ai `getOAuthProvider(provider)`. Google account
+    auth uses Bobbit's native Google PKCE flow because installed pi-ai has no
+    Gemini Code Assist OAuth provider.
+  - Credentials are written to `auth.json` keyed by canonical provider
+    (`storeOAuthCredentials`, ~L147), so Google account OAuth is stored only at
+    `auth.json["google-gemini-cli"]`; `oauthStatus()` (~L402) returns only
     `{ authenticated, expires }` — **never the token** (strict-OAuth contract).
 - Model auth detection: `src/server/agent/model-registry.ts` —
   `PROVIDER_ENV` already maps `google`, `google-gemini-cli`, `google-vertex`
@@ -116,7 +118,7 @@ spacing token, and affordance.
 ### 2.1 Provider entry (content)
 
 ```
-id:                 "google"              // new AccountProviderId member
+id:                 "google-gemini-cli"   // canonical OAuth AccountProviderId member
 title:              "Google OAuth"
 description:        "OAuth credentials used by agent sessions to access Gemini
                      models through your Google account. Re-authenticate to
@@ -124,7 +126,9 @@ description:        "OAuth credentials used by agent sessions to access Gemini
 authenticatedLabel: "Authenticated"
 ```
 
-`AccountProviderId` becomes `"anthropic" | "openai-codex" | "google"`.
+`AccountProviderId` becomes `"anthropic" | "openai-codex" | "google-gemini-cli"`.
+The plain `google` id remains reserved for the Google AI Studio / Gemini Developer
+API-key provider in Models → Provider API Keys.
 
 ### 2.2 Visual layout (ASCII reference — matches existing rows exactly)
 
@@ -184,11 +188,12 @@ pointer, §5 limitations note), and both reuse existing muted-text styling.
 
 ## 3. OAuth dialog — Google branch
 
-`openOAuthDialog("google")` reuses the entire existing flow. Required changes:
+`openOAuthDialog("google-gemini-cli")` reuses the entire existing flow. Required changes:
 
 - **Display name:** replace the ternary in `src/app/dialogs.ts` (~L484) with a
-  lookup that maps `"google"` → `"Google"`. Header becomes "Google Login";
-  body copy "A browser tab has been opened for Google authentication."
+  lookup that maps `"google-gemini-cli"` (and inbound aliases `"google"` /
+  `"gemini"`) → `"Google"`. Header becomes "Google Login"; body copy "A
+  browser tab has been opened for Google authentication."
 - **Flow shape:** Google's official flow is a redirect/consent → callback or
   paste-code exchange. The existing dialog already supports both the
   `callbackServer` polling path and the manual paste path, so **no new dialog
@@ -319,10 +324,11 @@ Re-authenticate:
 There is no clear endpoint today (only Anthropic self-clears on revoked token in
 `oauth.ts` ~L498). Add:
 
-- `POST /api/oauth/logout` `{ provider }` → deletes the provider key from
-  `auth.json`, calls `clearOAuthCache()`, returns `{ success: true }`.
-- Must respect provider isolation: deleting `google` must not touch `anthropic`
-  / `openai-codex` entries.
+- `POST /api/oauth/logout` `{ provider }` → normalizes the provider, deletes that
+  canonical provider key from `auth.json`, calls `clearOAuthCache()`, returns
+  `{ success: true }`, and never echoes token material.
+- Must respect provider isolation: deleting `google-gemini-cli` must not touch
+  `anthropic`, `openai-codex`, or API-key-only `google` entries.
 
 ### 6.3 Empty state after logout
 
@@ -336,12 +342,12 @@ provider — no special empty state needed.
 
 - Credentials live server-side in `auth.json`; the client holds **no** token.
 - On Settings open / tab mount, `loadAccountStatus()` re-fetches
-  `GET /api/oauth/status?provider=google`, so an authenticated Google account
-  shows **Authenticated** after a full page reload with no extra work.
+  `GET /api/oauth/status?provider=google-gemini-cli`, so an authenticated Google
+  account shows **Authenticated** after a full page reload with no extra work.
 - **Acceptance:** *open Settings → Account, authenticate Google, reload Bobbit,
   still see Google authenticated.* This is satisfied by the existing status-fetch
-  path the moment `google` is added to `ACCOUNT_PROVIDERS` and accepted by
-  `normalizeProvider()`.
+  path the moment `google-gemini-cli` is added to `ACCOUNT_PROVIDERS` and
+  accepted by `normalizeProvider()`.
 - The `Expires` line renders from `status.expires`; an expired token shows
   **Expired** (destructive) and the button reads **Re-authenticate** — identical
   to the other providers.
@@ -355,7 +361,7 @@ Reuse the existing dialog/state machinery; no new error UI invented.
 | State | Where | Treatment |
 |---|---|---|
 | Status fetch fails | `loadAccountStatus()` catch | Row shows **Not authenticated** (fail-safe), no crash. |
-| `normalizeProvider` rejects `google` (pre-fix) | server | Surfaced as dialog `error` step. **Must not throw** post-implementation. |
+| `normalizeProvider` rejects `google-gemini-cli` or inbound alias `google` (pre-fix) | server | Surfaced as dialog `error` step. **Must not throw** post-implementation. |
 | OAuth start fails (`POST /api/oauth/start`) | dialog `error` step | `<error-details>` + **Try again** button (existing). |
 | Code exchange fails (`POST /api/oauth/complete`) | dialog `error` step | Server `error` string shown via `<error-details>`; truncated server-side. |
 | Flow timeout (5 min) | dialog poll | "OAuth flow timed out after 5 minutes" + Try again. |
@@ -394,15 +400,15 @@ Recommended naming (kebab, provider-scoped):
 | Element | `data-testid` |
 |---|---|
 | Account tab container | `account-tab` |
-| Per-provider row | `account-row-google` (and `-anthropic`, `-openai-codex`) |
-| Status text | `account-status-google` |
-| Expires text | `account-expires-google` |
-| Primary auth button | `account-auth-btn-google` |
-| Logout button | `account-logout-btn-google` |
-| API-key cross-link | `account-apikey-link-google` |
-| Limitations note | `account-google-limit-note` |
+| Per-provider row | `account-row-google-gemini-cli` (and `-anthropic`, `-openai-codex`) |
+| Status text | `account-status-google-gemini-cli` |
+| Expires text | `account-expires-google-gemini-cli` |
+| Primary auth button | `account-auth-btn-google-gemini-cli` |
+| Logout button | `account-logout-btn-google-gemini-cli` |
+| API-key cross-link | `account-apikey-link-google-gemini-cli` |
+| Limitations note | `account-google-gemini-cli-limit-note` |
 | Models-tab API-key section | `provider-keys-section` |
-| Google key input wrapper | `provider-key-input-google` |
+| Google AI Studio key input wrapper | `provider-key-input-google` |
 
 The model-selector item already exposes `data-model-item` / `data-model-id`
 (`ModelSelector.ts` ~L356); the authenticated/locked state is observable via the
@@ -411,7 +417,7 @@ The model-selector item already exposes `data-model-item` / `data-model-id`
 ### 9.3 Required tests (per AGENTS.md "every user-facing feature MUST have a browser E2E")
 
 1. **Browser E2E** (`tests/e2e/ui/`): open Settings → Account, assert the Google
-   row renders with `Log in`; mock `GET /api/oauth/status?provider=google` →
+   row renders with `Log in`; mock `GET /api/oauth/status?provider=google-gemini-cli` →
    `{ authenticated: true, expires }`, reload, assert **Authenticated** persists;
    assert Re-authenticate + Log out appear; assert logout returns to `Log in`.
 2. **Regression test for the drift:** assert the model-selector unauthenticated
@@ -419,16 +425,19 @@ The model-selector item already exposes `data-model-item` / `data-model-id`
    Models tab renders the `provider-keys-section`. This pins the acceptance
    criterion *"tests cover the regression where a user is told to use a settings
    path that is not present in the current app."*
-3. **Unit/API E2E:** `normalizeProvider("google")` resolves (no throw);
-   `oauthStatus("google")` never returns the token; provider isolation —
-   logging out `google` leaves `anthropic`/`openai-codex` entries intact.
+3. **Unit/API E2E:** `normalizeProvider("google-gemini-cli")` resolves, inbound
+   alias `normalizeProvider("google")` canonicalizes to `google-gemini-cli`,
+   `oauthStatus("google-gemini-cli")` never returns the token, and provider
+   isolation holds — logging out `google-gemini-cli` leaves `anthropic`,
+   `openai-codex`, and API-key-only `google` entries intact.
 
 ---
 
 ## 10. Implementation handoff checklist (UI/UX surface only)
 
-- [ ] Add `"google"` to `AccountProviderId` + a `Google OAuth` entry in
-      `ACCOUNT_PROVIDERS` (`settings-page.ts`).
+- [ ] Add `"google-gemini-cli"` to `AccountProviderId` + a `Google OAuth` entry
+      in `ACCOUNT_PROVIDERS` (`settings-page.ts`); keep plain `google` reserved
+      for the Models-tab Google AI Studio API-key provider.
 - [ ] Add Google branch to `providerName` in `openOAuthDialog` (`dialogs.ts`).
 - [ ] Add Logout button + confirm + `POST /api/oauth/logout` (server) for all
       three providers.

--- a/docs/design/google-oauth-settings-ux.md
+++ b/docs/design/google-oauth-settings-ux.md
@@ -1,0 +1,445 @@
+# Google Account Auth — Settings / UX Design
+
+**Status:** Design artifact (UX spec). No production code in this doc.
+**Scope of this file:** the Settings → Account row for Google, API-key fallback
+discoverability, model-selector authenticated/unauthenticated states, copy for
+official Google API limitations, reload persistence, re-auth, logout, error
+states, accessibility, and test selectors.
+
+This document is the **spec**: an implementation engineer should be able to match
+it exactly. It references the real components/functions in the current app so the
+work lands in the right place and reuses existing primitives.
+
+---
+
+## 1. Current-state audit (where everything lives)
+
+The app has **two** settings surfaces. Only one is wired into the live UI.
+
+| Surface | File | Wired into live UI? |
+|---|---|---|
+| **Current** Settings page (hash-routed `#settings`) | `src/app/settings-page.ts` | ✅ Yes — `SYSTEM_TABS` / `PROJECT_TABS` |
+| **Legacy** `<settings-dialog>` + `ApiKeysTab` / `ProxyTab` | `src/ui/dialogs/SettingsDialog.ts` | ❌ Not in `SYSTEM_TABS`; orphaned |
+| **Legacy** "Providers & Models" tab (`<provider-key-input>` per provider) | `src/ui/dialogs/ProvidersModelsTab.ts` | ❌ Not reachable from current Settings |
+
+### 1.1 The Account tab (the row we extend)
+
+- Tab is declared in `SYSTEM_TABS` (`src/app/settings-page.ts` ~L57–65):
+  `{ id: "account", label: "Account" }`.
+- Rendered by `renderAccountTab()` (`src/app/settings-page.ts` ~L2948).
+- Provider list is the module-level constant **`ACCOUNT_PROVIDERS`**
+  (`src/app/settings-page.ts` ~L2885). Today it has exactly two entries:
+
+  ```ts
+  type AccountProviderId = "anthropic" | "openai-codex";
+  ```
+
+  Each entry is `{ id, title, description, authenticatedLabel }`.
+- State module-locals: `accountStatus` (`Partial<Record<AccountProviderId,
+  { authenticated: boolean; expires?: number }>>`), `accountLoading`,
+  `accountReauthing` (~L2905–2907).
+- `loadAccountStatus()` (~L2909) fans out one `GET /api/oauth/status?provider=<id>`
+  per provider and stores `{ authenticated, expires }`.
+- `handleReauthenticate(provider)` (~L2932) sets `accountReauthing`, calls
+  `openOAuthDialog(provider)` from `src/app/dialogs.ts`, then refreshes status.
+- Each row renders (per provider): a title + description block, a bordered
+  **Status** card (`Authenticated` in green, or `Expired` / `Not authenticated`
+  in destructive), an optional **Expires** line, and a single `Button` whose
+  label is `Authenticating…` / `Re-authenticate` / `Log in`. **The button is
+  disabled for ALL providers while any one is mid-flow** (`disabled:
+  accountReauthing !== null`) to prevent concurrent `pendingFlows` collisions.
+
+> There is currently **no logout / disconnect** control in this tab. Section 6
+> specifies adding one (requires a new server endpoint).
+
+### 1.2 The OAuth dialog
+
+- `openOAuthDialog(provider = "anthropic")` (`src/app/dialogs.ts` ~L466) drives
+  the whole flow: `start → waiting → exchanging → done | error`.
+- Provider display name is derived by a hardcoded ternary (~L484):
+
+  ```ts
+  const providerName = provider === "openai-codex" || provider === "openai" ? "OpenAI" : "Anthropic";
+  ```
+
+  **This must gain a Google branch** (anything that is not anthropic/openai
+  would otherwise be mislabelled "Anthropic").
+- It opens the auth URL in a new tab (`window.open`), polls
+  `GET /api/oauth/flow-status` when `callbackServer` is true, and also offers a
+  **manual paste** field ("Paste redirect URL or code" / "Paste code here
+  (format: code#state)").
+- `checkOAuthStatus(provider)` (~L442) is the fail-open status probe used
+  elsewhere.
+
+### 1.3 Server OAuth pipeline
+
+- Routes in `src/server/server.ts`: `GET /api/oauth/status`, `GET
+  /api/oauth/flow-status`, `POST /api/oauth/start`, `POST /api/oauth/complete`
+  (~L10538–10590).
+- `src/server/auth/oauth.ts`:
+  - `OAuthProviderId = "anthropic" | "openai-codex"` (~L21) and
+    `OAUTH_PROVIDER_LABELS` (~L23) — **add `google` here**.
+  - `normalizeProvider()` (~L102) throws on unknown providers — **must accept
+    `google` / `google-gemini`** for provider isolation.
+  - Anthropic uses a built-in PKCE flow; non-anthropic providers delegate to
+    `oauthStartExternal()` → pi-ai `getOAuthProvider(provider)`. Google would
+    follow the external path **iff** pi-ai exposes a Google OAuth provider;
+    otherwise a Google PKCE flow is added alongside.
+  - Credentials are written to `auth.json` keyed by provider
+    (`storeOAuthCredentials`, ~L147), and `oauthStatus()` (~L402) returns only
+    `{ authenticated, expires }` — **never the token** (strict-OAuth contract).
+- Model auth detection: `src/server/agent/model-registry.ts` —
+  `PROVIDER_ENV` already maps `google`, `google-gemini-cli`, `google-vertex`
+  (~L227–232); `hasOAuthCredentials(provider)` (~L284) checks `auth.json` for an
+  access token; `model.authenticated` is what the picker reads.
+
+### 1.4 The drift bug (acceptance-critical)
+
+- `renderModelsTab()` (`src/app/settings-page.ts` ~L2004) contains **AI Gateway**
+  and **Default Models** only. There is **no per-provider API-key entry** in the
+  live Settings.
+- The model picker tooltip points users at a **dead path**: in
+  `src/ui/dialogs/ModelSelector.ts` (~L373) the unauthenticated tooltip reads
+  *"API key required — set up in Settings > Providers"*. There is no "Providers"
+  tab in the current Settings. **This is the regression the goal calls out** and
+  must be fixed (Section 4) and covered by a test (Section 9).
+
+---
+
+## 2. Google Account row — Settings → Account
+
+Add a **third** entry to `ACCOUNT_PROVIDERS`, rendered by the *same*
+`renderAccountTab()` loop. No new layout, card, or component is introduced — the
+row is structurally identical to Anthropic/OpenAI so it inherits every state,
+spacing token, and affordance.
+
+### 2.1 Provider entry (content)
+
+```
+id:                 "google"              // new AccountProviderId member
+title:              "Google OAuth"
+description:        "OAuth credentials used by agent sessions to access Gemini
+                     models through your Google account. Re-authenticate to
+                     refresh expired tokens or switch accounts."
+authenticatedLabel: "Authenticated"
+```
+
+`AccountProviderId` becomes `"anthropic" | "openai-codex" | "google"`.
+
+### 2.2 Visual layout (ASCII reference — matches existing rows exactly)
+
+```
+Anthropic OAuth
+OAuth credentials used by agent sessions to access the Anthropic API…
+┌────────────────────────────────────────────────────────────┐
+│ Status: Authenticated                                        │
+│ Expires: 19/06/2026, 14:03:55                                │
+└────────────────────────────────────────────────────────────┘
+[ Re-authenticate ]
+
+OpenAI OAuth
+OAuth credentials used by agent sessions to access ChatGPT…
+┌────────────────────────────────────────────────────────────┐
+│ Status: Not authenticated                                    │
+└────────────────────────────────────────────────────────────┘
+[ Log in ]
+
+Google OAuth                                          ◀── NEW
+OAuth credentials used by agent sessions to access Gemini…
+┌────────────────────────────────────────────────────────────┐
+│ Status: Not authenticated                                    │
+└────────────────────────────────────────────────────────────┘
+ℹ Gemini models that are not part of an official model API may
+  be unavailable through account login. See note below.        ◀── NEW (see §5)
+[ Log in ]
+
+  Looking for an API key instead? → Models tab                 ◀── NEW (see §4)
+```
+
+### 2.3 Row ordering
+
+Append Google **after** OpenAI (Anthropic → OpenAI → Google). This is purely
+additive to the `ACCOUNT_PROVIDERS` array; the render loop and disable-all-while-
+busy semantics are unchanged.
+
+### 2.4 Consistency rationale (required sign-off — see role checklist)
+
+1. **Primitives reused exactly:** the row uses the same `<h3 class="text-sm
+   font-semibold text-foreground">` title, `text-xs text-muted-foreground`
+   description, the bordered `rounded-md border border-border p-3` Status card,
+   the green `text-green-600 dark:text-green-400` / `text-destructive` status
+   text, and the same `Button` from `renderAccountTab()`. **No new classes.**
+2. **Same row/group:** Google sits in the same `ACCOUNT_PROVIDERS.map(...)`
+   stream as its peers — no new section invented.
+3. **Same affordances:** identical Status / Expires lines, identical button
+   states, identical disabled-while-busy behaviour.
+4. **No new component:** searched `rg "ACCOUNT_PROVIDERS"`, `rg
+   "renderAccountTab"` — extending the array is the established extension point;
+   adding OpenAI followed the same pattern.
+
+The only Google-specific additions are the two advisory lines (§4 API-key
+pointer, §5 limitations note), and both reuse existing muted-text styling.
+
+---
+
+## 3. OAuth dialog — Google branch
+
+`openOAuthDialog("google")` reuses the entire existing flow. Required changes:
+
+- **Display name:** replace the ternary in `src/app/dialogs.ts` (~L484) with a
+  lookup that maps `"google"` → `"Google"`. Header becomes "Google Login";
+  body copy "A browser tab has been opened for Google authentication."
+- **Flow shape:** Google's official flow is a redirect/consent → callback or
+  paste-code exchange. The existing dialog already supports both the
+  `callbackServer` polling path and the manual paste path, so **no new dialog
+  states are needed**. If Google uses a loopback redirect (`callbackServer:
+  true`), polling auto-completes; otherwise the user pastes the code, exactly
+  like the OpenAI path today.
+- **Paste-field placeholder:** keep the existing conditional copy. For Google,
+  the `code#state` hint applies if no callback server; the redirect-URL hint
+  applies if there is one.
+
+No visual redesign of the dialog — it is provider-agnostic once the label is
+fixed.
+
+---
+
+## 4. API-key fallback discoverability (fix the drift)
+
+The goal requires that **either** a clear API-key entry point exists in current
+Settings, **or** stale UI/docs are corrected so users are not sent to a
+nonexistent screen. Recommendation: **do both** — add a minimal API-key entry to
+the live **Models** tab and fix the dead tooltip.
+
+### 4.1 Add a "Provider API Keys" section to the Models tab
+
+`renderModelsTab()` (`src/app/settings-page.ts` ~L2004) gains a third section,
+**below** "Default Models", reusing the existing `<provider-key-input>`
+component (already implemented in `src/ui/components/ProviderKeyInput.ts`, used by
+the orphaned `ApiKeysTab`/`ProvidersModelsTab`).
+
+```
+Default Models
+  Session   …
+  Review    …
+─────────────────────────────────────────────
+Provider API Keys                              ◀── NEW section
+Optional. Use a provider API key when you are not using account login
+(e.g. Google AI Studio keys for Gemini). Keys are stored locally.
+
+  Google     [ ••••••••••••••••  ] [Save]
+  Anthropic  [ ••••••••••••••••  ] [Save]
+  OpenAI     [ ••••••••••••••••  ] [Save]
+```
+
+- Render at minimum a Google `<provider-key-input .provider="google">` so the
+  Gemini AI-Studio key path is reachable; ideally render the same full provider
+  list the legacy `ApiKeysTab` did via `getPiAiProviders()`.
+- Section header: `Provider API Keys`. Helper copy explicitly names Google AI
+  Studio so users understand account-login vs key.
+- This section is **API-key fallback**, distinct from the Account tab's OAuth.
+  The two must not be conflated: Account = Google account / Gemini subscription;
+  Models → Provider API Keys = AI Studio key.
+
+### 4.2 Fix the dead model-selector tooltip
+
+In `src/ui/dialogs/ModelSelector.ts` (~L373 and ~L368), change the
+unauthenticated copy from *"Settings > Providers"* to the real location:
+
+- Long tooltip: **"API key or account login required — set up in Settings →
+  Account, or add a key under Settings → Models."**
+- Short `KeyRound` icon tooltip: **"Authentication required"** (was "API key
+  required").
+
+This is the acceptance-critical regression fix and must have a test (§9).
+
+### 4.3 Cross-link from the Account tab
+
+Under the Google row's button add a muted inline link (reusing
+`text-xs text-muted-foreground` + underlined `text-foreground` anchor styling
+already used in the OAuth dialog's "Click here" link):
+
+> *Looking for an API key instead?* **Go to Models → Provider API Keys.**
+
+Clicking calls the existing deep-link helper `setActiveSettingsTab("models")`
+(exported from `src/app/settings-page.ts`).
+
+---
+
+## 5. Copy: official Google API limitations
+
+Consumer Gemini app subscriptions are **not** guaranteed to be usable through an
+official model API. The UI must be honest about this rather than implying every
+Gemini model unlocks on login.
+
+Show a single advisory line in the Google row (muted, info-toned), between the
+Status card and the button:
+
+> **ℹ Note:** Google account login authorizes Gemini models exposed by Google's
+> official model API. Models tied to a consumer Gemini app subscription may not
+> be available this way. If a model stays locked after login, use a Google AI
+> Studio API key under **Models → Provider API Keys**.
+
+Styling: reuse the `text-xs text-muted-foreground` description style; the leading
+"Note:" in `font-medium`. **Do not** use a destructive/red treatment — this is
+informational, not an error. Color is not the only signal (the "ℹ"/"Note:"
+prefix carries meaning for non-color users).
+
+If, at implementation time, the official path supports the selected account with
+no caveats, this line may be softened, but the AI-Studio-key fallback pointer
+must remain.
+
+---
+
+## 6. Logout / disconnect
+
+The Account tab has no disconnect control today. Add one for **all three**
+providers (consistent), gated on `authenticated === true`.
+
+### 6.1 UI
+
+When `authenticated`, render a secondary destructive-outline button next to
+Re-authenticate:
+
+```
+[ Re-authenticate ]  [ Log out ]
+```
+
+- "Log out" uses `Button({ variant: "outline" })` with destructive text styling
+  consistent with the existing "Disconnect" button in `renderModelsTab()`
+  (`border border-destructive text-destructive hover:bg-destructive/10`).
+- Disabled while `accountReauthing !== null` (same busy guard).
+- On click: confirm via the existing `confirmAction(...)` dialog (already used
+  across the app) — *"Log out of Google? Agent sessions will lose access to
+  Gemini models until you log in again."* — then call the clear endpoint and
+  refresh status (`accountStatus = null; loadAccountStatus()`).
+
+### 6.2 Server (new)
+
+There is no clear endpoint today (only Anthropic self-clears on revoked token in
+`oauth.ts` ~L498). Add:
+
+- `POST /api/oauth/logout` `{ provider }` → deletes the provider key from
+  `auth.json`, calls `clearOAuthCache()`, returns `{ success: true }`.
+- Must respect provider isolation: deleting `google` must not touch `anthropic`
+  / `openai-codex` entries.
+
+### 6.3 Empty state after logout
+
+Row returns to the `Not authenticated` Status, button reverts to `Log in`, the
+"Log out" button disappears. This is the same render path as a never-authed
+provider — no special empty state needed.
+
+---
+
+## 7. Reload persistence
+
+- Credentials live server-side in `auth.json`; the client holds **no** token.
+- On Settings open / tab mount, `loadAccountStatus()` re-fetches
+  `GET /api/oauth/status?provider=google`, so an authenticated Google account
+  shows **Authenticated** after a full page reload with no extra work.
+- **Acceptance:** *open Settings → Account, authenticate Google, reload Bobbit,
+  still see Google authenticated.* This is satisfied by the existing status-fetch
+  path the moment `google` is added to `ACCOUNT_PROVIDERS` and accepted by
+  `normalizeProvider()`.
+- The `Expires` line renders from `status.expires`; an expired token shows
+  **Expired** (destructive) and the button reads **Re-authenticate** — identical
+  to the other providers.
+
+---
+
+## 8. Error states
+
+Reuse the existing dialog/state machinery; no new error UI invented.
+
+| State | Where | Treatment |
+|---|---|---|
+| Status fetch fails | `loadAccountStatus()` catch | Row shows **Not authenticated** (fail-safe), no crash. |
+| `normalizeProvider` rejects `google` (pre-fix) | server | Surfaced as dialog `error` step. **Must not throw** post-implementation. |
+| OAuth start fails (`POST /api/oauth/start`) | dialog `error` step | `<error-details>` + **Try again** button (existing). |
+| Code exchange fails (`POST /api/oauth/complete`) | dialog `error` step | Server `error` string shown via `<error-details>`; truncated server-side. |
+| Flow timeout (5 min) | dialog poll | "OAuth flow timed out after 5 minutes" + Try again. |
+| Token expired | Account row | **Expired** status (destructive) + **Re-authenticate**. |
+| Model still locked after login | model picker + §5 note | Picker keeps `opacity-45` + key icon; §5 note explains AI-Studio fallback. |
+| Logout fails | new logout handler | Inline destructive text in the row: "Failed to log out — try again." (mirror `projectScopeSaveStatus === "error"` pattern). |
+
+**Token safety:** no error path may echo the bearer token. `oauthStatus()`
+returns only `{ authenticated, expires }`; error bodies are truncated in
+`oauth.ts`. Keep both invariants.
+
+---
+
+## 9. Accessibility & test selectors
+
+### 9.1 Accessibility
+
+- **Status is not color-only:** the Status card always shows the *word*
+  ("Authenticated" / "Expired" / "Not authenticated") in addition to color —
+  preserve this for Google.
+- The §5 limitations note and the §4 advisory use a textual "Note:" / "ℹ"
+  prefix, not color alone.
+- Buttons are real `<button>` elements (via the `Button` primitive) with text
+  labels — keyboard-focusable, visible focus ring inherited from the primitive.
+- The OAuth dialog's paste `Input` has a `<label>` ("Authorization Code");
+  keep parity for Google.
+- Contrast: status greens/destructive and muted note text already meet the app's
+  token contrast; do not hardcode new colors — use existing tokens
+  (`text-muted-foreground`, `text-destructive`, `text-green-600 dark:text-green-400`).
+
+### 9.2 Test selectors (add `data-testid`s — currently the rows have none)
+
+To make the Account rows testable (browser E2E per AGENTS.md), add stable hooks.
+Recommended naming (kebab, provider-scoped):
+
+| Element | `data-testid` |
+|---|---|
+| Account tab container | `account-tab` |
+| Per-provider row | `account-row-google` (and `-anthropic`, `-openai-codex`) |
+| Status text | `account-status-google` |
+| Expires text | `account-expires-google` |
+| Primary auth button | `account-auth-btn-google` |
+| Logout button | `account-logout-btn-google` |
+| API-key cross-link | `account-apikey-link-google` |
+| Limitations note | `account-google-limit-note` |
+| Models-tab API-key section | `provider-keys-section` |
+| Google key input wrapper | `provider-key-input-google` |
+
+The model-selector item already exposes `data-model-item` / `data-model-id`
+(`ModelSelector.ts` ~L356); the authenticated/locked state is observable via the
+`opacity-45` class and the `KeyRound` icon presence.
+
+### 9.3 Required tests (per AGENTS.md "every user-facing feature MUST have a browser E2E")
+
+1. **Browser E2E** (`tests/e2e/ui/`): open Settings → Account, assert the Google
+   row renders with `Log in`; mock `GET /api/oauth/status?provider=google` →
+   `{ authenticated: true, expires }`, reload, assert **Authenticated** persists;
+   assert Re-authenticate + Log out appear; assert logout returns to `Log in`.
+2. **Regression test for the drift:** assert the model-selector unauthenticated
+   tooltip does **not** contain the string "Settings > Providers", and that the
+   Models tab renders the `provider-keys-section`. This pins the acceptance
+   criterion *"tests cover the regression where a user is told to use a settings
+   path that is not present in the current app."*
+3. **Unit/API E2E:** `normalizeProvider("google")` resolves (no throw);
+   `oauthStatus("google")` never returns the token; provider isolation —
+   logging out `google` leaves `anthropic`/`openai-codex` entries intact.
+
+---
+
+## 10. Implementation handoff checklist (UI/UX surface only)
+
+- [ ] Add `"google"` to `AccountProviderId` + a `Google OAuth` entry in
+      `ACCOUNT_PROVIDERS` (`settings-page.ts`).
+- [ ] Add Google branch to `providerName` in `openOAuthDialog` (`dialogs.ts`).
+- [ ] Add Logout button + confirm + `POST /api/oauth/logout` (server) for all
+      three providers.
+- [ ] Add §5 limitations note + §4 API-key cross-link to the Google row.
+- [ ] Add **Provider API Keys** section to `renderModelsTab()` reusing
+      `<provider-key-input>` (at least Google).
+- [ ] Fix the dead "Settings > Providers" tooltip in `ModelSelector.ts`.
+- [ ] Add the `data-testid`s in §9.2.
+- [ ] Add the three test groups in §9.3.
+
+> Server-side credential storage, refresh, scopes, pi-ai provider capability,
+> and sandbox credential propagation are out of scope for this UX artifact and
+> are owned by the implementation/backend work; this doc only constrains what the
+> user sees and how they reach it.

--- a/docs/features.md
+++ b/docs/features.md
@@ -155,3 +155,10 @@ When the agent finishes a turn, the browser client notifies the user via:
 4. **Favicon badge + sidebar unread dot** — Persists until the user opens the session
 
 These cues are scoped to **human attention**: standalone sessions notify on idle (as before), team members and delegates stay silent (they escalate to their team lead, not the user), and a team lead notifies when the goal is `complete`, needs immediate human action, or is persistently stuck. One-shot beeps do not fire merely because a team lead went idle to wait for workers or verification. Notification surfaces consult the predicates in `src/app/notification-policy.ts`. See [design/notification-policy.md](design/notification-policy.md).
+
+## Model Authentication
+
+Models become usable either via an **account OAuth login** (Settings → Account) or a **provider API key** (Settings → Models → Provider API Keys). OAuth credentials are provider-partitioned in `auth.json` and are propagated into agent sandboxes through the same sanitized path for every provider.
+
+- **Anthropic** and **OpenAI** account login work as before.
+- **Google** has two intentionally separate paths: account OAuth (`google-gemini-cli`, via the official Gemini Code Assist API) and a Google AI Studio API key (`google`, the session-usable Gemini path). Today, account-backed Gemini models are authenticated but **not yet selectable for agent sessions** — session-usable Gemini requires the API key. See [google-oauth-models.md](google-oauth-models.md) for the full split, propagation model, and current limitation.

--- a/docs/google-oauth-models.md
+++ b/docs/google-oauth-models.md
@@ -1,0 +1,201 @@
+# Google OAuth & Gemini models
+
+Bobbit can authenticate Google for Gemini in two distinct ways. They are intentionally
+kept separate so an account login can never be confused with an API key, and so a
+Google credential can never accidentally "authenticate" the wrong provider.
+
+| Path | Provider id | Where | Credential | What it powers today |
+|---|---|---|---|---|
+| **Google account OAuth** | `google-gemini-cli` | Settings → Account → Google OAuth | OAuth Bearer token (Code Assist) in `auth.json` | Account-backed Gemini model metadata + gateway-side helper completions. **Not yet selectable for agent sessions.** |
+| **Google AI Studio API key** | `google` | Settings → Models → Provider API Keys | API key in preferences (`providerKey.google`) | The always-working, session-usable Gemini path. |
+
+This split is the single most important thing to understand about the feature: it is the
+reason there are two "Google" entries in Settings, two provider ids, and two different
+wire protocols under the hood.
+
+> **Why two providers?** Consumer Google accounts can only reach Gemini through the
+> official **Gemini Code Assist API** (`cloudcode-pa.googleapis.com`), which speaks a
+> different protocol (Bearer token, request-wrapping) than the API-key **Gemini Developer
+> API** (`generativelanguage.googleapis.com`, `x-goog-api-key`). There is no supported way
+> to feed a consumer OAuth token to the API-key provider. So "log in with Google" and
+> "paste a Gemini API key" are genuinely different integrations, not two UIs for the same
+> thing.
+
+The full rationale, endpoint research, and acceptance-criteria traceability live in the
+design artifacts: [`docs/design/google-oauth-model-auth.md`](design/google-oauth-model-auth.md)
+(backend/runtime) and [`docs/design/google-oauth-settings-ux.md`](design/google-oauth-settings-ux.md)
+(Settings/UX).
+
+---
+
+## Settings → Account: Google OAuth
+
+The Account tab lists OAuth providers as parallel rows (Anthropic, OpenAI, Google). The
+Google row uses canonical provider id `google-gemini-cli` and reuses the same row, status
+card, dialog, re-auth, and logout machinery as the other providers — see
+[`docs/rest-api.md` → OAuth](rest-api.md#oauth) for the endpoint contract.
+
+What login does:
+
+1. **Start** (`POST /api/oauth/start { provider: "google-gemini-cli" }`) launches Google's
+   standard installed-app OAuth flow against `accounts.google.com/o/oauth2/v2/auth` with
+   PKCE (S256), `access_type=offline`, and `prompt=consent` (to guarantee a refresh token).
+   The redirect target is a **loopback** callback server the gateway opens on
+   `http://localhost:<ephemeral-port>/oauth2callback`.
+2. **Complete** happens automatically when the browser hits the loopback callback, or via
+   the dialog's manual paste field (paste the full redirect URL or the `code#state` value)
+   for remote-gateway setups where the browser cannot reach the gateway loopback.
+3. **Store** writes a sanitized entry to `auth.json["google-gemini-cli"]` of the form
+   `{ type: "oauth", access, refresh, expires, email? }`. `email` is non-secret display
+   metadata from the userinfo endpoint; tokens are never returned by any `/status` response.
+
+**Scopes requested** (the minimum the Code Assist flow needs):
+
+- `https://www.googleapis.com/auth/cloud-platform`
+- `https://www.googleapis.com/auth/userinfo.email`
+- `https://www.googleapis.com/auth/userinfo.profile`
+
+**OAuth client identity.** Bobbit reuses the official **Gemini CLI** installed-app OAuth
+client (the same Google-supported "Login with Google" client the CLI ships) rather than a
+Bobbit-owned GCP client. Installed-app client secrets are public by Google's own guidance.
+This is a deliberate, documented choice: third-party brand/scope approval for Code Assist is
+not guaranteed, so if Google ever rejects use of that client by non-CLI apps, the Google
+account row must be disabled with a clear message while API-key Gemini stays available.
+
+**Reload persistence.** Credentials live only server-side in `auth.json`; the browser holds
+no token. On Settings open, the Account tab re-fetches
+`GET /api/oauth/status?provider=google-gemini-cli`, so an authenticated account shows
+**Authenticated** after a full reload with no extra work. Expired tokens render **Expired**
+and the button reads **Re-authenticate**, identical to the other providers.
+
+**Refresh.** `refreshGoogleOAuthToken()` (in `src/server/auth/oauth.ts`) exchanges the
+stored refresh token at `oauth2.googleapis.com/token` when the access token is missing or
+expired. It mirrors the Anthropic refresh policy: clear the stored credential only on
+definitive auth failures (400/401/403); keep it on transient 5xx/429/network errors. The
+existing no-arg Anthropic `refreshOAuthToken()` API is untouched, so Anthropic/OpenAI
+behavior is unchanged.
+
+**Logout.** `POST /api/oauth/logout { provider }` (handler `oauthLogout`) revokes the token
+at `oauth2.googleapis.com/revoke` where possible, deletes **only** that provider's
+`auth.json` entry, clears the OAuth cache, and returns `{ success, provider }` with no token
+material. It is provider-partitioned: logging out `google-gemini-cli` never touches
+`anthropic`, `openai-codex`, or the API-key-only `google` credential.
+
+### Provider isolation
+
+`normalizeProvider()` is the single mapping authority. It accepts inbound aliases `google`
+and `gemini` at OAuth request boundaries and collapses them to the canonical
+`google-gemini-cli`, but those aliases are **never** used as storage keys. Combined with the
+`flowId` + provider cross-check in `oauthFlowStatus`, this guarantees Google flows and
+credentials cannot collide with the Anthropic/OpenAI flows or with the API-key `google`
+entry.
+
+---
+
+## Settings → Models: Provider API Keys (the fallback)
+
+The current Settings → Models tab now renders a **Provider API Keys** section
+(`data-testid="provider-keys-section"`) below Default Models, reusing the existing
+`<provider-key-input>` component and the `/api/provider-keys` endpoints. It offers keys for
+Google (AI Studio / Gemini Developer API, provider `google`), Anthropic, and OpenAI.
+
+This fixes a prior **Settings drift**: the model-selector tooltip used to send users to a
+"Settings → Providers" screen that no longer existed, and there was no per-provider API-key
+entry anywhere in current Settings. The tooltip now points at Settings → Account / Settings →
+Models, and the API-key entry point exists where users are sent. A browser E2E pins this so
+the drift cannot reappear.
+
+Use the API key path when you are **not** using account login — e.g. Google AI Studio users.
+This is the guaranteed, session-usable Gemini path and remains fully selectable for agent
+sessions.
+
+---
+
+## Current limitation: account-backed Gemini is account-only
+
+When a Google account credential is present, the model registry emits account-backed Gemini
+models under provider `google-gemini-cli` with `api: "google-code-assist"` (see
+`src/server/agent/google-code-assist-models.ts`). These models show in the selector as
+**authenticated** but are emitted with **`sessionSelectable: false`** and a clear reason:
+
+> Signed in, but Google account (Code Assist) models can't run in agent sessions yet — the
+> agent runtime has no Code Assist provider. For Gemini in sessions, add a Google AI Studio
+> API key (provider "google") under Settings → Models.
+
+**Why:** the Code Assist adapter (`codeAssistComplete`) is wired only into **server-side**
+helper completions (`completeModelText` — used for title/name/connection-test). The
+pi-coding-agent runtime that powers agent **sessions** has no `google-gemini-cli` provider
+and no `google-code-assist` api, so binding such a model to a session would silently fall
+back or hard-fail. To prevent that, `google-gemini-cli` is server-side-gated as a
+non-session-selectable provider (`isSessionSelectableProvider` /
+`NON_SESSION_SELECTABLE_PROVIDERS` in `src/server/agent/google-code-assist.ts`): no path
+(browser picker, role override, `default.sessionModel` preference, API write, or a restored
+config) may bind it to a session. A pinning test cross-checks the per-model flag and the
+provider-level guard so they cannot drift.
+
+Until agent-side Code Assist support exists, **session-usable Gemini requires a Google AI
+Studio API key** (provider `google`). The Account-tab note and the model-selector copy both
+say this explicitly, satisfying the goal constraint that an unusable subscription path must
+be surfaced clearly rather than implied to work.
+
+The `OAUTH_AUTHENTICATED_PROVIDERS` allow-list in `src/server/agent/model-registry.ts`
+(`anthropic`, `openai-codex`, `google-gemini-cli`) ensures only genuine OAuth providers are
+authenticated via `auth.json`, so a `google-gemini-cli` account token can never make the
+API-key-only `google` provider look usable.
+
+---
+
+## Token & sandbox propagation (high level)
+
+Spawned/sandboxed agent sessions receive Google credentials through the same partitioned
+credential-propagation path as the other account providers, but **only when policy opts in**
+(least privilege; default is no Google credential in the sandbox):
+
+- **Env var.** `src/server/agent/host-tokens.ts` maps provider `google-gemini-cli` to the
+  sandbox env var `GOOGLE_CLOUD_ACCESS_TOKEN` (the var the Gemini CLI / google-auth honor for
+  a pre-acquired Bearer token, paired with `GOOGLE_GENAI_USE_GCA=1`). This is deliberately
+  distinct from the API-key `google` var (`GEMINI_API_KEY`) so the two never collide.
+- **Sanitized sandbox `auth.json`.** When the sandbox-token policy enables the Google entry
+  (`sandboxTokenPolicyAllowsGoogleAuth`, key `GOOGLE_CLOUD_ACCESS_TOKEN`), the scoped
+  read-only sandbox `auth.json` includes a sanitized `google-gemini-cli` credential
+  containing only `{ type: "oauth", access, refresh?, expires? }`. `email`/profile/scope
+  metadata is never copied into the sandbox. This mirrors the existing Codex sanitization
+  pattern.
+- **Freshness.** Gateway-side token resolution refreshes the access token before use; the
+  sandbox carries the refresh token so it can re-mint an expired access token itself.
+
+**Safety invariants** (unchanged from the rest of the auth pipeline): tokens are never
+logged (error bodies are truncated and redacted), `GET /api/oauth/status` and
+`GET /api/provider-keys` never echo `access`/`refresh`/`key` — `email` is the only new
+non-secret field a status response may carry, and only because the UI shows the signed-in
+account.
+
+---
+
+## Manual runtime verification
+
+Automated tests cover provider partitioning, sanitized status, refresh failure modes, the
+OAuth-capable allow-list, sandbox sanitization, the OAuth status/start/flow/complete/logout
+routes (mocked Google endpoints), and the Settings UI (Account row + reload persistence,
+the Models Provider API Keys section, and the stale-path regression). The following steps
+require a **real Google account** and are not part of CI:
+
+1. **Login round-trip.** Settings → Account → Google OAuth → **Log in**. Complete Google
+   consent in the opened tab (or paste the redirect URL/code in remote-gateway setups).
+   Confirm the row flips to **Authenticated** with an **Expires** time.
+2. **Reload persistence.** Hard-reload Bobbit. The Google row must still show
+   **Authenticated** (status is re-fetched from `auth.json`).
+3. **Account-only model state.** Open the model selector. Account-backed Gemini models
+   (`… (Google account)`) must appear **authenticated but not session-selectable**, with the
+   "can't run in agent sessions yet" reason. Confirm none can be bound to a session.
+4. **Server-side Code Assist completion (where supported).** Where a server-side helper
+   completion routes through `google-gemini-cli`, confirm it reaches
+   `cloudcode-pa.googleapis.com/v1internal` with a Bearer token, resolving/onboarding a free-
+   tier project on first use (cached in `google-code-assist.json`). On unsupported accounts,
+   confirm the limitation messaging is shown rather than a silent failure.
+5. **API-key fallback unchanged.** Add a Google AI Studio key under Settings → Models →
+   Provider API Keys and confirm Gemini Developer API (`google`) models remain fully
+   session-selectable and complete normally — independent of account login.
+6. **Logout isolation.** Log out of Google and confirm `anthropic`, `openai-codex`, and any
+   API-key-only `google` credential are untouched, and that no token material appears in any
+   response or log.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -745,16 +745,17 @@ Outbound requests that these endpoints make to the configured/tested AI Gateway 
 
 ### OAuth
 
-Provider-aware. Bobbit can hold OAuth credentials for several providers concurrently (currently `anthropic` and `openai-codex`); every endpoint takes a `provider` discriminator so the same flow IDs and credential rows do not bleed across providers.
+Provider-aware. Bobbit can hold OAuth credentials for several providers concurrently (currently `anthropic`, `openai-codex`, and `google-gemini-cli`); every endpoint takes a `provider` discriminator so the same flow IDs and credential rows do not bleed across providers.
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/api/oauth/status?provider=<id>` | OAuth status for one provider. Returns `{ provider, authenticated, expires? }`. |
+| `GET` | `/api/oauth/status?provider=<id>` | OAuth status for one provider. Returns `{ provider, authenticated, expires?, email? }`. |
 | `POST` | `/api/oauth/start` | Begin an OAuth flow for a provider. Body: `{ provider }`. Returns `{ provider, flowId, url, callbackServer?, instructions? }`. |
 | `POST` | `/api/oauth/complete` | Exchange `code` for tokens. Body: `{ flowId, code }`. Returns `{ success: true }` (200) or `{ success: false, error }` (400). |
 | `GET` | `/api/oauth/flow-status?flowId=<id>&provider=<id>` | Poll an in-flight flow. Returns `{ complete, error? }`. |
+| `POST` | `/api/oauth/logout` | Revoke/clear one provider's stored credential. Body: `{ provider }`. Returns `{ success, provider }`, never echoing token material. |
 
-**Provider IDs:** `anthropic` (Claude.ai login → API key/refresh token) and `openai-codex` (ChatGPT subscription → bearer token). Provider validation is performed by the `normalizeProvider` helper in `src/server/auth/oauth.ts`; an unsupported value causes the surrounding endpoint to throw, which the server wraps as `400 { error: "<thrown message>" }` (e.g. `"Error: Unsupported OAuth provider: foo"` for status, or `500` for start). The error string is implementation-defined — callers should treat any 4xx with an `error` field as "unknown provider".
+**Provider IDs:** `anthropic` (Claude.ai login → API key/refresh token), `openai-codex` (ChatGPT subscription → bearer token), and `google-gemini-cli` (Google account → Gemini Code Assist bearer token). Provider validation is performed by the `normalizeProvider` helper in `src/server/auth/oauth.ts`; for the Google path it also accepts the inbound aliases `google` and `gemini` and collapses them to canonical `google-gemini-cli` (plain `google` stays the Google AI Studio API-key provider elsewhere). An unsupported value causes the surrounding endpoint to throw, which the server wraps as `400 { error: "<thrown message>" }` (e.g. `"Error: Unsupported OAuth provider: foo"` for status, or `500` for start). The error string is implementation-defined — callers should treat any 4xx with an `error` field as "unknown provider". See [Google OAuth & Gemini models](google-oauth-models.md) for the full account-vs-API-key split.
 
 **Why `provider` everywhere:** the same browser-redirect callback URL is shared between providers, and a user may legitimately have flows in flight for both at once. Keying every operation by `provider` (alongside `flowId`) keeps state strictly partitioned and lets the UI render Settings → Account as parallel rows that can be (re-)authed independently.
 
@@ -766,7 +767,9 @@ Provider-aware. Bobbit can hold OAuth credentials for several providers concurre
 
 The response intentionally does **not** echo the bearer token / API key — strict-OAuth contract.
 
-**`POST /api/oauth/start`** body: `{ provider: "anthropic" | "openai-codex" }`. Returns:
+The `email?` field appears only for providers that capture non-secret account display metadata (currently `google-gemini-cli`); it is never a token.
+
+**`POST /api/oauth/start`** body: `{ provider: "anthropic" | "openai-codex" | "google-gemini-cli" }`. Returns:
 
 ```json
 {
@@ -779,7 +782,7 @@ The response intentionally does **not** echo the bearer token / API key — stri
 ```
 
 - `url`: opens in a system browser; the provider's redirect lands on Bobbit's callback handler.
-- `callbackServer`: `true` for OAuth providers that complete via the embedded callback server (e.g. `openai-codex`); `false`/absent for providers that require the user to paste the returned `code` back into the UI (e.g. `anthropic`).
+- `callbackServer`: `true` for OAuth providers that complete via an embedded/loopback callback server (e.g. `openai-codex`, and `google-gemini-cli` via a loopback server on `http://localhost:<ephemeral-port>/oauth2callback`); `false`/absent for providers that require the user to paste the returned `code` back into the UI (e.g. `anthropic`). The Google flow also accepts the manual paste path for remote-gateway setups where the browser cannot reach the gateway loopback.
 - `instructions`: optional human-readable string the UI may render alongside the URL.
 
 **`POST /api/oauth/complete`** body: `{ flowId, code }` (the stored flow already knows its provider, so the body does not repeat it). Returns:
@@ -813,7 +816,9 @@ Response contract:
 
 `provider` is recommended as a defence-in-depth check: if the stored flow's provider does not match the query parameter, the endpoint returns `404 { error: "flow not found" }` instead of leaking status across providers. The primary key is still `flowId`; the provider check just guarantees that a flow ID accidentally polled with the wrong provider cannot be used to confirm its existence.
 
-See [AGENTS.md — Add / debug per-provider OAuth](../AGENTS.md#add--debug-per-provider-oauth) for the file map and the Settings → Account UI walkthrough.
+**`POST /api/oauth/logout`** body: `{ provider }`. Normalizes the provider, optionally revokes the upstream token (Google posts to `oauth2.googleapis.com/revoke`; logout does not fail if revoke is transiently unavailable), deletes **only** that canonical provider's `auth.json` entry, and clears the OAuth cache. Returns `200 { success: true, provider }`. Provider-partitioned: logging out `google-gemini-cli` never touches `anthropic`, `openai-codex`, or the API-key-only `google` credential, and no response or log echoes token material.
+
+See [Google OAuth & Gemini models](google-oauth-models.md) for the account-vs-API-key provider split, the Code Assist runtime, and the current session-selectability limitation.
 
 ### Image generation
 

--- a/src/app/dialogs.ts
+++ b/src/app/dialogs.ts
@@ -481,7 +481,14 @@ export function openOAuthDialog(provider = "anthropic"): Promise<boolean> {
 		const POLL_MAX_DELAY_MS = 8000;
 		const POLL_MAX_TOTAL_MS = 5 * 60 * 1000;
 
-		const providerName = provider === "openai-codex" || provider === "openai" ? "OpenAI" : "Anthropic";
+		// Canonical Google account OAuth id is `google-gemini-cli`; `google`/`gemini`
+		// are inbound aliases the server collapses to it. Label all three "Google".
+		const providerName =
+			provider === "google-gemini-cli" || provider === "google" || provider === "gemini"
+				? "Google"
+				: provider === "openai-codex" || provider === "openai"
+					? "OpenAI"
+					: "Anthropic";
 
 		const cleanup = (result: boolean) => {
 			if (pollTimer !== undefined) window.clearTimeout(pollTimer);

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -2930,7 +2930,7 @@ const ACCOUNT_PROVIDERS: Array<{
 	{
 		id: "google-gemini-cli",
 		title: "Google OAuth",
-		description: "OAuth credentials used by agent sessions to access Gemini models through your Google account. Re-authenticate to refresh expired tokens or switch accounts.",
+		description: "Connect your Google account for Gemini (Code Assist) account credentials. Agent sessions can't run Gemini through your Google account yet — use a Google AI Studio API key for session-usable Gemini. Re-authenticate to refresh expired tokens or switch accounts.",
 		authenticatedLabel: "Authenticated",
 	},
 ];
@@ -3076,10 +3076,11 @@ export function renderAccountTab() {
 
 						${isGoogle
 							? html`<p class="text-xs text-muted-foreground" data-testid="account-${provider.id}-limit-note">
-								<span class="font-medium">ℹ Note:</span> Google account login authorizes Gemini models exposed by
-								Google's official model API. Models tied to a consumer Gemini app subscription may not be
-								available this way. If a model stays locked after login, use a Google AI Studio API key under
-								Models → Provider API Keys.
+								<span class="font-medium">ℹ Note:</span> Connecting your Google account does not make Gemini
+								usable in agent sessions yet — the agent runtime has no Code Assist provider. Google account
+								login authorizes Gemini models exposed by Google's official model API for account-backed
+								metadata and future server-side use. For session-usable Gemini today, add a Google AI Studio
+								API key under Models → Provider API Keys.
 							</p>`
 							: ""}
 

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -44,7 +44,8 @@ import { setPerfInstrumentationEnabled, isPerfInstrumentationEnabled } from "./b
 import { isClientDebugEnabled, setClientDebugEnabled } from "./client-debug.js";
 import { dispatchIndexEvent } from "./components/search-status-dot.js";
 import "./components/search-status-dot.js";
-import { openOAuthDialog } from "./dialogs.js";
+import { openOAuthDialog, confirmAction } from "./dialogs.js";
+import "../ui/components/ProviderKeyInput.js";
 import { componentToEditState, buildSavePayload, type ComponentEditState } from "./components-editor.js";
 import { ModelSelector } from "../ui/dialogs/ModelSelector.js";
 import { getSupportedThinkingLevels, clampThinkingLevel, type ThinkingLevel } from "../shared/thinking-levels.js";
@@ -2147,9 +2148,31 @@ export function renderModelsTab() {
 					</div>
 				` : ""}
 			</div>
+
+			<!-- Provider API Keys (API-key fallback, distinct from Account OAuth) -->
+			<div class="flex flex-col gap-4 pt-4 border-t border-border" data-testid="provider-keys-section">
+				<h3 class="text-sm font-semibold text-foreground">Provider API Keys</h3>
+				<p class="text-sm text-muted-foreground">
+					Optional. Use a provider API key when you are not using account login
+					(e.g. a Google AI Studio key for Gemini). Keys are stored locally. For
+					Google or Anthropic account login, use <span class="text-foreground">Settings → Account</span> instead.
+				</p>
+				<div class="flex flex-col gap-4">
+					${PROVIDER_KEY_PROVIDERS.map((p) => html`
+						<div data-testid="provider-key-input-${p}">
+							<provider-key-input .provider=${p}></provider-key-input>
+						</div>
+					`)}
+				</div>
+			</div>
 		</div>
 	`;
 }
+
+// Providers offered in the Models-tab "Provider API Keys" fallback section. Plain
+// `google` is the Google AI Studio / Gemini Developer API-key provider (distinct
+// from the `google-gemini-cli` account OAuth flow in Settings → Account).
+const PROVIDER_KEY_PROVIDERS = ["google", "anthropic", "openai"] as const;
 
 /** Human-readable labels for known project config keys. */
 const PROJECT_KEY_LABELS: Record<string, string> = {
@@ -2880,7 +2903,11 @@ function renderDirectoriesTab() {
 
 // ── Account tab state ──
 
-type AccountProviderId = "anthropic" | "openai-codex";
+// Canonical Google account OAuth provider id is `google-gemini-cli`. Plain
+// `google` is reserved for the Google AI Studio / Gemini Developer API-key
+// provider rendered in Settings → Models → Provider API Keys; it is NEVER an
+// Account-tab OAuth id. See docs/design/google-oauth-settings-ux.md.
+type AccountProviderId = "anthropic" | "openai-codex" | "google-gemini-cli";
 
 const ACCOUNT_PROVIDERS: Array<{
 	id: AccountProviderId;
@@ -2900,11 +2927,36 @@ const ACCOUNT_PROVIDERS: Array<{
 		description: "OAuth credentials used by agent sessions to access ChatGPT subscription GPT models through the OpenAI Codex provider.",
 		authenticatedLabel: "Authenticated",
 	},
+	{
+		id: "google-gemini-cli",
+		title: "Google OAuth",
+		description: "OAuth credentials used by agent sessions to access Gemini models through your Google account. Re-authenticate to refresh expired tokens or switch accounts.",
+		authenticatedLabel: "Authenticated",
+	},
 ];
 
 let accountStatus: Partial<Record<AccountProviderId, { authenticated: boolean; expires?: number }>> | null = null;
 let accountLoading = false;
 let accountReauthing: AccountProviderId | null = null;
+// Provider whose logout request is in flight (disables that row's Log out button).
+let accountLoggingOut: AccountProviderId | null = null;
+// Per-provider transient logout error, rendered inline in the row.
+const accountLogoutError: Partial<Record<AccountProviderId, boolean>> = {};
+
+/** Test-only: seed account status + reset transient flags so fixtures can drive
+ *  the Account tab without hitting the network. Mirrors `__testResetModelsTab`. */
+export function __testResetAccountTab(opts: {
+	// Seed a status map directly to bypass the network. Omit to leave status
+	// `null` so `renderAccountTab()` runs `loadAccountStatus()` (exercises the
+	// GET /api/oauth/status fetch path used by reload persistence).
+	status?: Partial<Record<AccountProviderId, { authenticated: boolean; expires?: number }>> | null;
+} = {}): void {
+	accountStatus = opts.status === undefined ? null : opts.status;
+	accountLoading = false;
+	accountReauthing = null;
+	accountLoggingOut = null;
+	for (const k of Object.keys(accountLogoutError)) delete accountLogoutError[k as AccountProviderId];
+}
 
 function loadAccountStatus(): void {
 	if (accountLoading) return;
@@ -2945,7 +2997,43 @@ async function handleReauthenticate(provider: AccountProviderId): Promise<void> 
 	}
 }
 
-function renderAccountTab() {
+const ACCOUNT_LOGOUT_LABELS: Record<AccountProviderId, string> = {
+	anthropic: "Anthropic",
+	"openai-codex": "OpenAI",
+	"google-gemini-cli": "Google",
+};
+
+async function handleAccountLogout(provider: AccountProviderId): Promise<void> {
+	const label = ACCOUNT_LOGOUT_LABELS[provider] ?? provider;
+	const confirmed = await confirmAction(
+		`Log out of ${label}?`,
+		`Agent sessions will lose access to ${label} models until you log in again.`,
+		"Log out",
+		true,
+	);
+	if (!confirmed) return;
+	delete accountLogoutError[provider];
+	accountLoggingOut = provider;
+	renderApp();
+	try {
+		// Provider-partitioned logout: the server deletes only this canonical
+		// provider's credential and never echoes token material.
+		const res = await gatewayFetch("/api/oauth/logout", {
+			method: "POST",
+			body: JSON.stringify({ provider }),
+		});
+		if (!res.ok) throw new Error("logout failed");
+		accountStatus = null;
+		loadAccountStatus();
+	} catch {
+		accountLogoutError[provider] = true;
+	} finally {
+		accountLoggingOut = null;
+		renderApp();
+	}
+}
+
+export function renderAccountTab() {
 	if (!accountStatus && !accountLoading) loadAccountStatus();
 
 	if (accountLoading && !accountStatus) {
@@ -2953,7 +3041,7 @@ function renderAccountTab() {
 	}
 
 	return html`
-		<div class="flex flex-col gap-4">
+		<div class="flex flex-col gap-4" data-testid="account-tab">
 			${ACCOUNT_PROVIDERS.map((provider) => {
 				const status = accountStatus?.[provider.id];
 				const authenticated = status?.authenticated ?? false;
@@ -2961,9 +3049,11 @@ function renderAccountTab() {
 				const expiresDate = expires ? new Date(expires) : null;
 				const isExpired = expires ? Date.now() > expires : false;
 				const isReauthing = accountReauthing === provider.id;
+				const isLoggingOut = accountLoggingOut === provider.id;
+				const isGoogle = provider.id === "google-gemini-cli";
 
 				return html`
-					<div class="flex flex-col gap-4">
+					<div class="flex flex-col gap-4" data-testid="account-row-${provider.id}">
 						<div class="flex flex-col gap-1.5">
 							<h3 class="text-sm font-semibold text-foreground">${provider.title}</h3>
 							<p class="text-xs text-muted-foreground">${provider.description}</p>
@@ -2973,29 +3063,63 @@ function renderAccountTab() {
 							<div class="flex items-center gap-2">
 								<span class="text-sm font-medium text-foreground">Status:</span>
 								${authenticated
-									? html`<span class="text-sm text-green-600 dark:text-green-400">${provider.authenticatedLabel}</span>`
-									: html`<span class="text-sm text-destructive">${isExpired ? "Expired" : "Not authenticated"}</span>`}
+									? html`<span class="text-sm text-green-600 dark:text-green-400" data-testid="account-status-${provider.id}">${provider.authenticatedLabel}</span>`
+									: html`<span class="text-sm text-destructive" data-testid="account-status-${provider.id}">${isExpired ? "Expired" : "Not authenticated"}</span>`}
 							</div>
 							${expiresDate
 								? html`<div class="flex items-center gap-2">
 									<span class="text-sm font-medium text-foreground">Expires:</span>
-									<span class="text-sm ${isExpired ? "text-destructive" : "text-muted-foreground"}">${expiresDate.toLocaleString()}</span>
+									<span class="text-sm ${isExpired ? "text-destructive" : "text-muted-foreground"}" data-testid="account-expires-${provider.id}">${expiresDate.toLocaleString()}</span>
 								</div>`
 								: ""}
 						</div>
 
-						<div>
-							${Button({
+						${isGoogle
+							? html`<p class="text-xs text-muted-foreground" data-testid="account-${provider.id}-limit-note">
+								<span class="font-medium">ℹ Note:</span> Google account login authorizes Gemini models exposed by
+								Google's official model API. Models tied to a consumer Gemini app subscription may not be
+								available this way. If a model stays locked after login, use a Google AI Studio API key under
+								Models → Provider API Keys.
+							</p>`
+							: ""}
+
+						<div class="flex items-center gap-2">
+							<span data-testid="account-auth-btn-${provider.id}">${Button({
 								variant: authenticated ? "outline" : "default",
 								size: "sm",
 								// Disable every provider's auth button while ANY provider is mid-flow
 								// to prevent concurrent OAuth attempts from clobbering each other's
 								// pendingFlows entries. Cleared in handleReauthenticate's finally block.
-								disabled: accountReauthing !== null,
+								disabled: accountReauthing !== null || accountLoggingOut !== null,
 								onClick: () => handleReauthenticate(provider.id),
 								children: isReauthing ? "Authenticating..." : authenticated ? "Re-authenticate" : "Log in",
-							})}
+							})}</span>
+							${authenticated
+								? html`<span data-testid="account-logout-btn-${provider.id}">${Button({
+									variant: "outline",
+									size: "sm",
+									className: "border border-destructive text-destructive hover:bg-destructive/10",
+									disabled: accountReauthing !== null || accountLoggingOut !== null,
+									onClick: () => handleAccountLogout(provider.id),
+									children: isLoggingOut ? "Logging out..." : "Log out",
+								})}</span>`
+								: ""}
 						</div>
+						${accountLogoutError[provider.id]
+							? html`<p class="text-xs text-destructive" data-testid="account-logout-error-${provider.id}">Failed to log out — try again.</p>`
+							: ""}
+
+						${isGoogle
+							? html`<p class="text-xs text-muted-foreground">
+								Looking for an API key instead?
+								<button
+									type="button"
+									data-testid="account-apikey-link-${provider.id}"
+									class="text-foreground underline underline-offset-2 hover:text-foreground/80"
+									@click=${() => setActiveSettingsTab("models")}
+								>Go to Models → Provider API Keys.</button>
+							</p>`
+							: ""}
 					</div>
 				`;
 			})}

--- a/src/server/agent/docker-args.ts
+++ b/src/server/agent/docker-args.ts
@@ -89,6 +89,8 @@ export interface DockerRunConfig {
 	toolManager?: ToolManager;
 	/** Whether sandbox policy permits mounting host OpenAI Codex auth into auth.json. */
 	sandboxAgentAuthAllowed?: boolean;
+	/** Whether sandbox policy permits mounting the Google account (Gemini Code Assist) OAuth credential into auth.json. */
+	sandboxAgentAuthGoogleAllowed?: boolean;
 	/** Preferences store used to include preference-backed OpenAI Codex credentials when policy allows. */
 	sandboxAgentAuthPrefs?: PreferencesStore | null;
 	/** Scope for the generated auth.json file; defaults to projectId when present. */
@@ -234,6 +236,7 @@ export function buildDockerRunArgs(config: DockerRunConfig): string[] {
 	const sandboxAuthJson = ensureSandboxAgentAuthFile({
 		prefs: config.sandboxAgentAuthPrefs,
 		includeCodexAuth: config.sandboxAgentAuthAllowed === true,
+		includeGoogleAuth: config.sandboxAgentAuthGoogleAllowed === true,
 		scope: config.sandboxAgentAuthScope || projectId,
 	});
 	args.push("-v", `${toDockerPath(sandboxAuthJson)}:/home/node/.bobbit/agent/auth.json:ro`);

--- a/src/server/agent/google-code-assist-models.ts
+++ b/src/server/agent/google-code-assist-models.ts
@@ -9,6 +9,15 @@
  * `hasGoogleCodeAssistCredential`), so the selector is not cluttered with
  * non-functional account models for users who never log in with Google.
  *
+ * IMPORTANT: these models are NOT yet runnable inside an agent/session. The Code
+ * Assist adapter is only wired into server-side `completeModelText` — the
+ * pi-coding-agent runtime has no `google-gemini-cli` provider / `google-code-assist`
+ * api, so `setModel("google-gemini-cli", …)` fails and a session silently falls
+ * back to a different model. Until agent-side Code Assist exists we emit them with
+ * `sessionSelectable: false` so the ModelSelector shows them as authenticated but
+ * visibly unavailable-for-sessions and refuses to bind them. The API-key `google`
+ * (Gemini Developer API) provider is unaffected and stays fully selectable.
+ *
  * Design: docs/design/google-oauth-model-auth.md §4.5.
  */
 
@@ -30,6 +39,15 @@ function isCodeAssistEligible(id: string): boolean {
 	const s = id.toLowerCase();
 	return s.startsWith("gemini-") && !s.includes("customtools");
 }
+
+/**
+ * Why a logged-in Google account model can't be picked for a session yet. Shown
+ * as the ModelSelector tooltip/copy. Exported so tests can pin it in lockstep.
+ */
+export const GOOGLE_CODE_ASSIST_SESSION_UNAVAILABLE_REASON =
+	"Signed in, but Google account (Code Assist) models can't run in agent sessions yet — " +
+	"the agent runtime has no Code Assist provider. For Gemini in sessions, add a Google AI " +
+	"Studio API key (provider \u201Cgoogle\u201D) under Settings \u2192 Models.";
 
 export function getGoogleCodeAssistModels(): ApiModel[] {
 	if (!hasGoogleCodeAssistCredential()) return [];
@@ -58,6 +76,10 @@ export function getGoogleCodeAssistModels(): ApiModel[] {
 			cost: m.cost || { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 			// `authenticated` is set by the registry via detectProviderAuth.
 			authenticated: false,
+			// Account-backed Code Assist models are authenticated but not yet runnable
+			// in an agent session (no agent-side Code Assist provider). Gate selection.
+			sessionSelectable: false,
+			sessionUnavailableReason: GOOGLE_CODE_ASSIST_SESSION_UNAVAILABLE_REASON,
 		});
 	}
 	return models;

--- a/src/server/agent/google-code-assist-models.ts
+++ b/src/server/agent/google-code-assist-models.ts
@@ -1,0 +1,64 @@
+/**
+ * Account-backed Gemini model list for the `google-gemini-cli` (Code Assist / OAuth)
+ * provider. Metadata is derived from pi-ai's built-in `google` catalog so context
+ * windows / costs stay in sync, but the models are re-emitted under provider
+ * `google-gemini-cli` with `api: "google-code-assist"` so the runtime routes them to
+ * the Code Assist Bearer adapter instead of the API-key Gemini Developer API.
+ *
+ * Models are only emitted when a Google account credential is present (see
+ * `hasGoogleCodeAssistCredential`), so the selector is not cluttered with
+ * non-functional account models for users who never log in with Google.
+ *
+ * Design: docs/design/google-oauth-model-auth.md §4.5.
+ */
+
+import { getModels } from "@earendil-works/pi-ai";
+
+import type { ApiModel } from "./model-registry.js";
+import {
+	GOOGLE_CODE_ASSIST_API,
+	GOOGLE_GEMINI_CLI_PROVIDER,
+	hasGoogleCodeAssistCredential,
+} from "./google-code-assist.js";
+
+/**
+ * Gemini ids the Code Assist API serves. Restricted to first-party `gemini-*`
+ * models (Gemma and Vertex-only variants are excluded). A model is included only
+ * when pi-ai's `google` catalog also carries it, so we never emit a stale id.
+ */
+function isCodeAssistEligible(id: string): boolean {
+	const s = id.toLowerCase();
+	return s.startsWith("gemini-") && !s.includes("customtools");
+}
+
+export function getGoogleCodeAssistModels(): ApiModel[] {
+	if (!hasGoogleCodeAssistCredential()) return [];
+
+	let base: Array<Record<string, any>> = [];
+	try {
+		base = getModels("google" as any) as unknown as Array<Record<string, any>>;
+	} catch {
+		return [];
+	}
+
+	const models: ApiModel[] = [];
+	for (const m of base) {
+		if (!isCodeAssistEligible(String(m.id))) continue;
+		models.push({
+			id: m.id,
+			name: `${m.name || m.id} (Google account)`,
+			provider: GOOGLE_GEMINI_CLI_PROVIDER,
+			api: GOOGLE_CODE_ASSIST_API,
+			baseUrl: "https://cloudcode-pa.googleapis.com",
+			contextWindow: m.contextWindow || 1_048_576,
+			maxTokens: m.maxTokens || 65_536,
+			reasoning: !!m.reasoning,
+			...(m.thinkingLevelMap ? { thinkingLevelMap: m.thinkingLevelMap as Record<string, string | null> } : {}),
+			input: (m.input || ["text"]) as ("text" | "image")[],
+			cost: m.cost || { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			// `authenticated` is set by the registry via detectProviderAuth.
+			authenticated: false,
+		});
+	}
+	return models;
+}

--- a/src/server/agent/google-code-assist.ts
+++ b/src/server/agent/google-code-assist.ts
@@ -27,6 +27,38 @@ export const GOOGLE_GEMINI_CLI_PROVIDER = "google-gemini-cli";
 /** pi-ai-style `api` discriminator marking a Code Assist (Bearer) model. */
 export const GOOGLE_CODE_ASSIST_API = "google-code-assist";
 
+/**
+ * Providers whose models are emitted with `sessionSelectable: false` and so MUST
+ * NOT be bound to an agent session by ANY path (browser picker, role override,
+ * `default.sessionModel` preference, API write, or a restored/persisted config).
+ * The pi-coding-agent runtime has no provider/api capable of running them, so a
+ * `setModel(provider, …)` either silently falls back or hard-fails the session.
+ *
+ * This mirrors the per-model `sessionSelectable: false` contract emitted in
+ * `google-code-assist-models.ts`; `getGoogleCodeAssistModels()` only ever emits
+ * `google-gemini-cli` models, so a provider-level guard is sufficient and avoids
+ * an async model-registry lookup on the synchronous spawn/bind path. The pinning
+ * test in `google-code-assist.test.ts` cross-checks the two so they can't drift.
+ */
+const NON_SESSION_SELECTABLE_PROVIDERS = new Set<string>([GOOGLE_GEMINI_CLI_PROVIDER]);
+
+/** True when models from `provider` may be bound to an agent session. */
+export function isSessionSelectableProvider(provider: string): boolean {
+	return !NON_SESSION_SELECTABLE_PROVIDERS.has(provider);
+}
+
+/**
+ * True when a `"<provider>/<modelId>"` string may be bound to an agent session.
+ * Malformed strings return `true` so existing malformed-pref handling (which
+ * logs/ignores) is unchanged; this guard only screens out the known
+ * not-session-runnable providers.
+ */
+export function isSessionSelectableModelString(modelString: string): boolean {
+	const slash = modelString.indexOf("/");
+	const provider = slash > 0 ? modelString.slice(0, slash) : modelString;
+	return isSessionSelectableProvider(provider);
+}
+
 const CODE_ASSIST_ENDPOINT = "https://cloudcode-pa.googleapis.com";
 const CODE_ASSIST_API_VERSION = "v1internal";
 const CLIENT_METADATA = { ideType: "IDE_UNSPECIFIED", platform: "PLATFORM_UNSPECIFIED", pluginType: "GEMINI" } as const;
@@ -41,7 +73,7 @@ interface StoredGoogleCredential {
 	email?: string;
 }
 
-export type FetchLike = (url: string, init: { method: string; headers: Record<string, string>; body?: string }) => Promise<{
+export type FetchLike = (url: string, init: { method: string; headers: Record<string, string>; body?: string; signal?: AbortSignal }) => Promise<{
 	ok: boolean;
 	status: number;
 	text: () => Promise<string>;
@@ -54,6 +86,12 @@ export interface CodeAssistGenerateArgs {
 	maxTokens?: number;
 	/** pi-ai thinking level mapped to a Gemini thinkingConfig hint. */
 	thinkingLevel?: string;
+	/**
+	 * Abort the underlying Code Assist fetch(es) after this many ms. Threaded from
+	 * `completeModelText({ timeoutMs })` so a stalled `generateContent` / onboarding
+	 * request can't hang past the caller's deadline. `undefined`/`<=0` disables it.
+	 */
+	timeoutMs?: number;
 }
 
 export interface CodeAssistDeps {
@@ -165,12 +203,35 @@ function codeAssistUrl(method: string): string {
 	return `${CODE_ASSIST_ENDPOINT}/${CODE_ASSIST_API_VERSION}:${method}`;
 }
 
-async function codeAssistPost(method: string, token: string, body: unknown, fetchFn: FetchLike): Promise<any> {
-	const res = await fetchFn(codeAssistUrl(method), {
+async function codeAssistPost(method: string, token: string, body: unknown, fetchFn: FetchLike, timeoutMs?: number): Promise<any> {
+	const init: { method: string; headers: Record<string, string>; body?: string; signal?: AbortSignal } = {
 		method: "POST",
 		headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
 		body: JSON.stringify(body),
-	});
+	};
+
+	let res: { ok: boolean; status: number; text: () => Promise<string> };
+	if (typeof timeoutMs === "number" && timeoutMs > 0) {
+		// Race the fetch against a timeout that also aborts the request. Racing (not
+		// just relying on the AbortSignal) guarantees a deterministic timeout even
+		// when the provided fetch implementation ignores `signal` (e.g. a test stub).
+		const controller = typeof AbortController !== "undefined" ? new AbortController() : undefined;
+		if (controller) init.signal = controller.signal;
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		const timeout = new Promise<never>((_, reject) => {
+			timer = setTimeout(() => {
+				controller?.abort();
+				reject(new Error(`Code Assist ${method} timed out after ${timeoutMs}ms`));
+			}, timeoutMs);
+		});
+		try {
+			res = await Promise.race([fetchFn(codeAssistUrl(method), init), timeout]);
+		} finally {
+			if (timer) clearTimeout(timer);
+		}
+	} else {
+		res = await fetchFn(codeAssistUrl(method), init);
+	}
 	const text = await res.text();
 	if (!res.ok) {
 		throw new Error(`Code Assist ${method} failed: HTTP ${res.status} ${text.slice(0, 256)}`);
@@ -189,7 +250,7 @@ const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve,
  * `loadCodeAssist` (returns the project when already onboarded) and finally
  * `onboardUser` (a long-running operation) for the free tier.
  */
-export async function ensureCodeAssistProject(token: string, fetchFn: FetchLike = defaultFetch()): Promise<string | undefined> {
+export async function ensureCodeAssistProject(token: string, fetchFn: FetchLike = defaultFetch(), timeoutMs?: number): Promise<string | undefined> {
 	if (cachedProjectId) return cachedProjectId;
 	const persisted = readPersistedProject();
 	if (persisted) {
@@ -197,7 +258,7 @@ export async function ensureCodeAssistProject(token: string, fetchFn: FetchLike 
 		return persisted;
 	}
 
-	const load = await codeAssistPost("loadCodeAssist", token, { metadata: CLIENT_METADATA }, fetchFn);
+	const load = await codeAssistPost("loadCodeAssist", token, { metadata: CLIENT_METADATA }, fetchFn, timeoutMs);
 	let project: string | undefined = load?.cloudaicompanionProject;
 	if (!project) {
 		const tierId: string =
@@ -207,6 +268,7 @@ export async function ensureCodeAssistProject(token: string, fetchFn: FetchLike 
 			token,
 			{ tierId, cloudaicompanionProject: project, metadata: CLIENT_METADATA },
 			fetchFn,
+			timeoutMs,
 		);
 		for (let i = 0; i < 8 && op && op.done !== true; i++) {
 			await sleep(1500);
@@ -215,6 +277,7 @@ export async function ensureCodeAssistProject(token: string, fetchFn: FetchLike 
 				token,
 				{ tierId, cloudaicompanionProject: project, metadata: CLIENT_METADATA },
 				fetchFn,
+				timeoutMs,
 			);
 		}
 		const resolved = op?.response?.cloudaicompanionProject;
@@ -288,10 +351,10 @@ export async function codeAssistComplete(args: CodeAssistGenerateArgs, deps: Cod
 		);
 	}
 
-	const getProject = deps.getProject ?? ((t: string) => ensureCodeAssistProject(t, fetchFn));
+	const getProject = deps.getProject ?? ((t: string) => ensureCodeAssistProject(t, fetchFn, args.timeoutMs));
 	const project = await getProject(token);
 
 	const body = buildGenerateContentBody(args, project);
-	const payload = await codeAssistPost("generateContent", token, body, fetchFn);
+	const payload = await codeAssistPost("generateContent", token, body, fetchFn, args.timeoutMs);
 	return extractCodeAssistText(payload);
 }

--- a/src/server/agent/google-code-assist.ts
+++ b/src/server/agent/google-code-assist.ts
@@ -1,0 +1,297 @@
+/**
+ * Google Code Assist adapter.
+ *
+ * Routes `google-gemini-cli` (Google account / OAuth) completions to the official
+ * Gemini Code Assist API (`cloudcode-pa.googleapis.com/v1internal`) using a Bearer
+ * access token. This is a *different wire protocol* from pi-ai's API-key `google`
+ * provider (`generativelanguage.googleapis.com`, `x-goog-api-key`), which is left
+ * untouched and remains the always-working API-key fallback.
+ *
+ * Design: docs/design/google-oauth-model-auth.md §4.4(a) / §4.5.
+ *
+ * Token sourcing is defensive: the Google refresh helper is owned by the OAuth
+ * backend task (`src/server/auth/oauth.ts`). If that symbol is not yet present in
+ * this branch we fall back to the stored access token from
+ * `auth.json["google-gemini-cli"]`. The expected exported symbol is one of
+ * `refreshGoogleOAuthToken()` or `refreshOAuthTokenForProvider("google-gemini-cli")`.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { globalAgentDir, globalAuthPath } from "../bobbit-dir.js";
+
+// ── Constants ──────────────────────────────────────────────────────
+
+/** Canonical OAuth/account provider id for Gemini via Google Code Assist. */
+export const GOOGLE_GEMINI_CLI_PROVIDER = "google-gemini-cli";
+/** pi-ai-style `api` discriminator marking a Code Assist (Bearer) model. */
+export const GOOGLE_CODE_ASSIST_API = "google-code-assist";
+
+const CODE_ASSIST_ENDPOINT = "https://cloudcode-pa.googleapis.com";
+const CODE_ASSIST_API_VERSION = "v1internal";
+const CLIENT_METADATA = { ideType: "IDE_UNSPECIFIED", platform: "PLATFORM_UNSPECIFIED", pluginType: "GEMINI" } as const;
+
+// ── Types ──────────────────────────────────────────────────────────
+
+interface StoredGoogleCredential {
+	type?: string;
+	access?: string;
+	refresh?: string;
+	expires?: number;
+	email?: string;
+}
+
+export type FetchLike = (url: string, init: { method: string; headers: Record<string, string>; body?: string }) => Promise<{
+	ok: boolean;
+	status: number;
+	text: () => Promise<string>;
+}>;
+
+export interface CodeAssistGenerateArgs {
+	model: string;
+	systemPrompt?: string;
+	userPrompt: string;
+	maxTokens?: number;
+	/** pi-ai thinking level mapped to a Gemini thinkingConfig hint. */
+	thinkingLevel?: string;
+}
+
+export interface CodeAssistDeps {
+	/** Returns a fresh Bearer access token, or null when no account is authenticated. */
+	getToken?: () => Promise<string | null>;
+	/** Resolves the Code Assist project id to bill/route the request under. */
+	getProject?: (token: string) => Promise<string | undefined>;
+	fetchFn?: FetchLike;
+}
+
+// ── Credential reading (auth.json["google-gemini-cli"]) ─────────────
+
+function readGoogleCredential(): StoredGoogleCredential | null {
+	const authPath = globalAuthPath();
+	if (!existsSync(authPath)) return null;
+	try {
+		const data = JSON.parse(readFileSync(authPath, "utf-8"));
+		const cred = data?.[GOOGLE_GEMINI_CLI_PROVIDER];
+		if (cred && typeof cred === "object") return cred as StoredGoogleCredential;
+	} catch {
+		// ignore malformed auth.json
+	}
+	return null;
+}
+
+/** True when a Google account (Code Assist) OAuth credential is present, even if expired. */
+export function hasGoogleCodeAssistCredential(): boolean {
+	const cred = readGoogleCredential();
+	return !!(cred && (cred.access || cred.refresh));
+}
+
+/**
+ * Attempt a token refresh via the OAuth backend helper. Defensive: the helper is
+ * owned by the OAuth task and may not exist yet on this branch. Returns null when
+ * no helper is available or the refresh fails.
+ */
+async function tryRefreshGoogleToken(): Promise<string | null> {
+	try {
+		const oauth: Record<string, unknown> = await import("../auth/oauth.js");
+		const direct = oauth["refreshGoogleOAuthToken"];
+		if (typeof direct === "function") {
+			const token = await (direct as () => Promise<string | null>)();
+			return token ?? null;
+		}
+		const byProvider = oauth["refreshOAuthTokenForProvider"];
+		if (typeof byProvider === "function") {
+			const token = await (byProvider as (p: string) => Promise<string | null>)(GOOGLE_GEMINI_CLI_PROVIDER);
+			return token ?? null;
+		}
+	} catch {
+		// Helper missing or threw — fall back to the stored access token.
+	}
+	return null;
+}
+
+/**
+ * Return a usable Bearer access token for the Google account, refreshing when the
+ * stored token is missing/expired and a refresh helper is available.
+ */
+export async function getGoogleAccessToken(): Promise<string | null> {
+	const cred = readGoogleCredential();
+	const fresh = !!cred?.access && (!cred.expires || Date.now() < cred.expires);
+	if (fresh) return cred!.access!;
+
+	const refreshed = await tryRefreshGoogleToken();
+	if (refreshed) return refreshed;
+
+	// Last resort: hand back a possibly-stale token so the API can report the real
+	// auth error rather than us silently returning null.
+	return cred?.access ?? null;
+}
+
+// ── Code Assist project resolution ─────────────────────────────────
+
+let cachedProjectId: string | undefined;
+
+function projectCachePath(): string {
+	return path.join(globalAgentDir(), "google-code-assist.json");
+}
+
+function readPersistedProject(): string | undefined {
+	try {
+		const p = projectCachePath();
+		if (!existsSync(p)) return undefined;
+		const data = JSON.parse(readFileSync(p, "utf-8"));
+		const id = data?.projectId;
+		return typeof id === "string" && id.trim() ? id : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function persistProject(projectId: string): void {
+	try {
+		const dir = globalAgentDir();
+		if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+		writeFileSync(projectCachePath(), JSON.stringify({ projectId }, null, 2), "utf-8");
+	} catch {
+		// best-effort cache; not fatal
+	}
+}
+
+/** Reset the in-memory project cache (test seam). */
+export function resetCodeAssistProjectCache(): void {
+	cachedProjectId = undefined;
+}
+
+function codeAssistUrl(method: string): string {
+	return `${CODE_ASSIST_ENDPOINT}/${CODE_ASSIST_API_VERSION}:${method}`;
+}
+
+async function codeAssistPost(method: string, token: string, body: unknown, fetchFn: FetchLike): Promise<any> {
+	const res = await fetchFn(codeAssistUrl(method), {
+		method: "POST",
+		headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+		body: JSON.stringify(body),
+	});
+	const text = await res.text();
+	if (!res.ok) {
+		throw new Error(`Code Assist ${method} failed: HTTP ${res.status} ${text.slice(0, 256)}`);
+	}
+	try {
+		return text ? JSON.parse(text) : {};
+	} catch {
+		throw new Error(`Code Assist ${method} returned invalid JSON`);
+	}
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Resolve the Code Assist project: prefer the in-memory/persisted cache, else
+ * `loadCodeAssist` (returns the project when already onboarded) and finally
+ * `onboardUser` (a long-running operation) for the free tier.
+ */
+export async function ensureCodeAssistProject(token: string, fetchFn: FetchLike = defaultFetch()): Promise<string | undefined> {
+	if (cachedProjectId) return cachedProjectId;
+	const persisted = readPersistedProject();
+	if (persisted) {
+		cachedProjectId = persisted;
+		return persisted;
+	}
+
+	const load = await codeAssistPost("loadCodeAssist", token, { metadata: CLIENT_METADATA }, fetchFn);
+	let project: string | undefined = load?.cloudaicompanionProject;
+	if (!project) {
+		const tierId: string =
+			(Array.isArray(load?.allowedTiers) ? load.allowedTiers.find((t: any) => t?.isDefault)?.id : undefined) ?? "free-tier";
+		let op = await codeAssistPost(
+			"onboardUser",
+			token,
+			{ tierId, cloudaicompanionProject: project, metadata: CLIENT_METADATA },
+			fetchFn,
+		);
+		for (let i = 0; i < 8 && op && op.done !== true; i++) {
+			await sleep(1500);
+			op = await codeAssistPost(
+				"onboardUser",
+				token,
+				{ tierId, cloudaicompanionProject: project, metadata: CLIENT_METADATA },
+				fetchFn,
+			);
+		}
+		const resolved = op?.response?.cloudaicompanionProject;
+		project = typeof resolved === "string" ? resolved : resolved?.id;
+	}
+
+	if (project) {
+		cachedProjectId = project;
+		persistProject(project);
+	}
+	return project;
+}
+
+// ── Request/response conversion (pure, unit-tested) ─────────────────
+
+const THINKING_BUDGET: Record<string, number> = { minimal: 0, low: 4096, medium: 8192, high: 24576, xhigh: 32768 };
+
+/** Build the Code Assist `:generateContent` request body. Pure / deterministic. */
+export function buildGenerateContentBody(args: CodeAssistGenerateArgs, project?: string): Record<string, unknown> {
+	const generationConfig: Record<string, unknown> = {};
+	if (typeof args.maxTokens === "number" && args.maxTokens > 0) generationConfig.maxOutputTokens = args.maxTokens;
+	if (args.thinkingLevel && args.thinkingLevel !== "off") {
+		const budget = THINKING_BUDGET[args.thinkingLevel];
+		if (typeof budget === "number") generationConfig.thinkingConfig = { thinkingBudget: budget };
+	}
+
+	const request: Record<string, unknown> = {
+		contents: [{ role: "user", parts: [{ text: args.userPrompt }] }],
+	};
+	if (args.systemPrompt && args.systemPrompt.trim()) {
+		request.systemInstruction = { role: "user", parts: [{ text: args.systemPrompt }] };
+	}
+	if (Object.keys(generationConfig).length > 0) request.generationConfig = generationConfig;
+
+	const body: Record<string, unknown> = { model: args.model, request };
+	if (project) body.project = project;
+	return body;
+}
+
+/** Extract assistant text from a Code Assist `:generateContent` response. Pure. */
+export function extractCodeAssistText(payload: any): string {
+	// Code Assist wraps the standard GenerateContent response under `response`.
+	const candidates = payload?.response?.candidates ?? payload?.candidates ?? [];
+	const parts = candidates?.[0]?.content?.parts ?? [];
+	return parts
+		.map((p: any) => (typeof p?.text === "string" ? p.text : ""))
+		.join("")
+		.trim();
+}
+
+function defaultFetch(): FetchLike {
+	const f = (globalThis as any).fetch;
+	if (typeof f !== "function") {
+		throw new Error("global fetch is unavailable in this runtime");
+	}
+	return f as FetchLike;
+}
+
+/**
+ * Run a single-turn completion against the Code Assist API for a `google-gemini-cli`
+ * model. Throws a descriptive error when no Google account is authenticated.
+ */
+export async function codeAssistComplete(args: CodeAssistGenerateArgs, deps: CodeAssistDeps = {}): Promise<string> {
+	const fetchFn = deps.fetchFn ?? defaultFetch();
+	const getToken = deps.getToken ?? getGoogleAccessToken;
+	const token = await getToken();
+	if (!token) {
+		throw new Error(
+			"No Google account credential available. Log in via Settings → Account → Google (Gemini), " +
+				"or use a Google AI Studio API key (provider 'google') in Settings → Models.",
+		);
+	}
+
+	const getProject = deps.getProject ?? ((t: string) => ensureCodeAssistProject(t, fetchFn));
+	const project = await getProject(token);
+
+	const body = buildGenerateContentBody(args, project);
+	const payload = await codeAssistPost("generateContent", token, body, fetchFn);
+	return extractCodeAssistText(payload);
+}

--- a/src/server/agent/host-tokens.ts
+++ b/src/server/agent/host-tokens.ts
@@ -31,6 +31,16 @@ const PROVIDER_TOKENS: { envVar: string; label: string; provider: string; envKey
 		envKeys: ["GEMINI_API_KEY"],
 	},
 	{
+		// Google account OAuth path (Gemini Code Assist). `GOOGLE_CLOUD_ACCESS_TOKEN`
+		// is the env var the Gemini CLI / google-auth honor for a pre-acquired Bearer
+		// token (paired with GOOGLE_GENAI_USE_GCA=1). Distinct from the API-key `google`
+		// provider above so the two never collide.
+		envVar: "GOOGLE_CLOUD_ACCESS_TOKEN",
+		label: "Google (Gemini Code Assist OAuth)",
+		provider: "google-gemini-cli",
+		envKeys: ["GOOGLE_CLOUD_ACCESS_TOKEN"],
+	},
+	{
 		envVar: "XAI_API_KEY",
 		label: "xAI / Grok",
 		provider: "xai",
@@ -59,6 +69,8 @@ const PROVIDER_TOKENS: { envVar: string; label: string; provider: string; envKey
 /** Well-known non-provider tokens that users may want in sandboxes */
 export const SANDBOX_AGENT_AUTH_RELATIVE_PATH = path.join("sandbox-agent-auth", "auth.json");
 export const OPENAI_CODEX_SANDBOX_AUTH_TOKEN_KEYS = new Set(["OPENAI_API_KEY", "OPENAI_CODEX_AUTH"]);
+/** Sandbox-token policy keys that opt a sandbox into the Google account (Gemini Code Assist) OAuth credential. */
+export const GOOGLE_GEMINI_CLI_SANDBOX_AUTH_TOKEN_KEYS = new Set(["GOOGLE_CLOUD_ACCESS_TOKEN"]);
 
 const TOOL_TOKENS: { envVar: string; label: string; detect: () => boolean }[] = [
 	{
@@ -135,6 +147,24 @@ function sanitizeCodexCredential(value: unknown): Record<string, any> | undefine
 	return sanitized;
 }
 
+function isUsableGoogleOAuthCredential(value: unknown): value is Record<string, any> {
+	return isCredentialObject(value) && value.type === "oauth" && typeof value.access === "string" && !!value.access;
+}
+
+/**
+ * Sanitize the stored `google-gemini-cli` (Google account / Gemini Code Assist) OAuth
+ * credential down to exactly the fields a sandboxed agent needs to use and refresh a
+ * Bearer token. Never copies `email`/profile/scope/account display metadata into the
+ * sandbox-visible auth.json. Returns undefined for absent or API-key-only values.
+ */
+function sanitizeGoogleCredential(value: unknown): Record<string, any> | undefined {
+	if (!isUsableGoogleOAuthCredential(value)) return undefined;
+	const sanitized: Record<string, any> = { type: "oauth", access: value.access };
+	if (typeof value.refresh === "string" && value.refresh) sanitized.refresh = value.refresh;
+	if (typeof value.expires === "number") sanitized.expires = value.expires;
+	return sanitized;
+}
+
 function sanitizeAuthScope(scope?: string): string | undefined {
 	if (!scope) return undefined;
 	const safe = scope.replace(/[^A-Za-z0-9_.-]/g, "_").replace(/^\.+$/, "_");
@@ -151,54 +181,74 @@ export function sandboxAgentAuthPath(scope?: string): string {
 export interface SandboxAgentAuthOptions {
 	prefs?: PreferencesStore | null;
 	includeCodexAuth?: boolean;
+	/** Opt the sandbox into the Google account (Gemini Code Assist) OAuth credential. */
+	includeGoogleAuth?: boolean;
 	/** Separate files prevent one project's authorized mount from feeding another project's denied mount. */
 	scope?: string;
 }
 
 function normalizeSandboxAgentAuthOptions(options?: PreferencesStore | SandboxAgentAuthOptions | null): SandboxAgentAuthOptions {
 	if (!options || typeof (options as any).get === "function") {
-		return { prefs: options as PreferencesStore | null | undefined, includeCodexAuth: false };
+		return { prefs: options as PreferencesStore | null | undefined, includeCodexAuth: false, includeGoogleAuth: false };
 	}
 	return options as SandboxAgentAuthOptions;
 }
 
-/**
- * Build the minimal auth.json content a sandboxed pi-coding-agent needs for
- * ChatGPT / OpenAI Codex OAuth. Returns an empty object unless sandbox token
- * policy explicitly allows OpenAI/Codex credentials for this sandbox.
- */
-export function buildSandboxAgentAuthJson(options?: PreferencesStore | SandboxAgentAuthOptions | null): Record<string, any> {
-	const { prefs, includeCodexAuth = false } = normalizeSandboxAgentAuthOptions(options);
-	const auth: Record<string, any> = {};
-	if (!includeCodexAuth) return auth;
-
+/** Resolve the sanitized OpenAI Codex credential for the sandbox (prefs key → host auth.json oauth/api_key → legacy `openai` oauth). */
+function resolveSandboxCodexCredential(prefs?: PreferencesStore | null): Record<string, any> | undefined {
 	const storedCodexKey = prefs?.get("providerKey.openai-codex") as string | undefined;
-	if (storedCodexKey) {
-		auth["openai-codex"] = { type: "api_key", key: storedCodexKey };
-		return auth;
-	}
+	if (storedCodexKey) return { type: "api_key", key: storedCodexKey };
 
 	const hostAuth = readHostAuthJson();
-	if (!hostAuth) return auth;
+	if (!hostAuth) return undefined;
 
 	const codex = sanitizeCodexCredential(hostAuth["openai-codex"]);
-	if (codex) {
-		auth["openai-codex"] = codex;
-		return auth;
-	}
+	if (codex) return codex;
 
 	// Older installs may have ChatGPT OAuth under `openai`. Only OAuth is a
 	// Codex-compatible credential; OpenAI API keys continue to flow via env vars.
 	const openai = hostAuth.openai;
-	const legacyCodex = isCredentialObject(openai) && openai.type === "oauth"
+	return isCredentialObject(openai) && openai.type === "oauth"
 		? sanitizeCodexCredential(openai)
 		: undefined;
-	if (legacyCodex) auth["openai-codex"] = legacyCodex;
+}
+
+/** Resolve the sanitized Google account (Gemini Code Assist) OAuth credential for the sandbox. */
+function resolveSandboxGoogleCredential(): Record<string, any> | undefined {
+	const hostAuth = readHostAuthJson();
+	if (!hostAuth) return undefined;
+	return sanitizeGoogleCredential(hostAuth["google-gemini-cli"]);
+}
+
+/**
+ * Build the minimal auth.json content a sandboxed pi-coding-agent needs for
+ * provider OAuth. Returns an empty object unless sandbox token policy explicitly
+ * opts the sandbox into a provider's credentials. Codex and Google are independent,
+ * provider-isolated entries: opting into one never includes the other.
+ */
+export function buildSandboxAgentAuthJson(options?: PreferencesStore | SandboxAgentAuthOptions | null): Record<string, any> {
+	const { prefs, includeCodexAuth = false, includeGoogleAuth = false } = normalizeSandboxAgentAuthOptions(options);
+	const auth: Record<string, any> = {};
+
+	if (includeCodexAuth) {
+		const codex = resolveSandboxCodexCredential(prefs);
+		if (codex) auth["openai-codex"] = codex;
+	}
+
+	if (includeGoogleAuth) {
+		const google = resolveSandboxGoogleCredential();
+		if (google) auth["google-gemini-cli"] = google;
+	}
+
 	return auth;
 }
 
 export function sandboxTokenPolicyAllowsCodexAuth(entries: Array<{ key?: string; enabled?: boolean }> | undefined | null): boolean {
 	return (entries || []).some((entry) => entry.enabled !== false && !!entry.key && OPENAI_CODEX_SANDBOX_AUTH_TOKEN_KEYS.has(entry.key));
+}
+
+export function sandboxTokenPolicyAllowsGoogleAuth(entries: Array<{ key?: string; enabled?: boolean }> | undefined | null): boolean {
+	return (entries || []).some((entry) => entry.enabled !== false && !!entry.key && GOOGLE_GEMINI_CLI_SANDBOX_AUTH_TOKEN_KEYS.has(entry.key));
 }
 
 export function ensureSandboxAgentAuthFile(options?: PreferencesStore | SandboxAgentAuthOptions | null): string {
@@ -265,7 +315,12 @@ export function resolveHostTokenValue(envVar: string, prefs?: PreferencesStore |
 		return process.env["ANTHROPIC_API_KEY"];
 	}
 
-	// Check auth.json for provider tokens
+	// Check auth.json for provider tokens.
+	// For the Google account OAuth path (GOOGLE_CLOUD_ACCESS_TOKEN → provider
+	// `google-gemini-cli`) this returns the stored `oauth.access` synchronously.
+	// It may be expired; the sandbox refreshes it using the refresh token that
+	// rides along in the sanitized sandbox auth.json. Gateway-side fresh refresh
+	// is the responsibility of the async OAuth refresh helper, not this sync path.
 	const providerForEnv = PROVIDER_TOKENS.find(t => t.envVar === envVar);
 	if (providerForEnv) {
 		// Check preferences store

--- a/src/server/agent/model-completion.ts
+++ b/src/server/agent/model-completion.ts
@@ -162,6 +162,9 @@ export async function completeModelText(
 			userPrompt: args.userPrompt,
 			maxTokens: args.maxTokens ?? 500,
 			...(args.thinkingLevel ? { thinkingLevel: args.thinkingLevel } : {}),
+			// Honor the caller's deadline so Code Assist completions can't hang past
+			// it; mirrors the timeoutMs handed to pi-ai for normal providers below.
+			timeoutMs: args.timeoutMs ?? 30_000,
 		});
 	}
 

--- a/src/server/agent/model-completion.ts
+++ b/src/server/agent/model-completion.ts
@@ -7,6 +7,7 @@ import { globalAgentDir, globalAuthPath } from "../bobbit-dir.js";
 import type { PreferencesStore } from "./preferences-store.js";
 import { getAvailableModels, type ApiModel, type CustomProviderConfig } from "./model-registry.js";
 import { ensurePiAiBedrockHeadersPatch } from "./pi-ai-bedrock-headers-patch.js";
+import { GOOGLE_GEMINI_CLI_PROVIDER, codeAssistComplete } from "./google-code-assist.js";
 
 ensurePiAiBedrockHeadersPatch();
 
@@ -150,6 +151,20 @@ export async function completeModelText(
 	},
 	completeFn: CompleteSimpleFn = completeSimple,
 ): Promise<string> {
+	// Google account (Code Assist / OAuth) models speak a different wire protocol
+	// than pi-ai's API-key `google` provider, so route them through the Bearer
+	// Code Assist adapter instead of completeSimple. The API-key `google` provider
+	// path below is unchanged.
+	if (model.provider === GOOGLE_GEMINI_CLI_PROVIDER) {
+		return codeAssistComplete({
+			model: model.id,
+			systemPrompt: args.systemPrompt,
+			userPrompt: args.userPrompt,
+			maxTokens: args.maxTokens ?? 500,
+			...(args.thinkingLevel ? { thinkingLevel: args.thinkingLevel } : {}),
+		});
+	}
+
 	const apiKey = await resolveProviderApiKey(prefs, model.provider);
 	const providerHeaders = resolveProviderHeaders(model.provider);
 	const options: Record<string, any> = {

--- a/src/server/agent/model-registry.ts
+++ b/src/server/agent/model-registry.ts
@@ -36,6 +36,18 @@ export interface ApiModel {
 	headers?: Record<string, string>;
 	compat?: unknown;
 	authenticated: boolean;
+	/**
+	 * When `false`, the model is authenticated but MUST NOT be bound to an agent
+	 * session: the pi-coding-agent runtime has no provider/api capable of running
+	 * it (e.g. `google-gemini-cli` Code Assist models, whose Code Assist adapter is
+	 * only wired into server-side completion, not the session runtime). The
+	 * ModelSelector renders these visibly unavailable-for-sessions and refuses to
+	 * select them. Undefined/true means selectable. Single source of truth for
+	 * session-selectability lives where each model is emitted.
+	 */
+	sessionSelectable?: boolean;
+	/** Human-readable reason shown in the selector when `sessionSelectable === false`. */
+	sessionUnavailableReason?: string;
 }
 
 export interface CustomProviderConfig {

--- a/src/server/agent/model-registry.ts
+++ b/src/server/agent/model-registry.ts
@@ -17,6 +17,7 @@ import type { PreferencesStore } from "./preferences-store.js";
 import { globalAuthPath } from "../bobbit-dir.js";
 import { inferMeta, discoverAigwModels, getAigwUrl } from "./aigw-manager.js";
 import { getOpenAIModelAdditions } from "./openai-model-additions.js";
+import { getGoogleCodeAssistModels } from "./google-code-assist-models.js";
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -173,6 +174,18 @@ async function assembleModels(prefs: PreferencesStore): Promise<ApiModel[]> {
 		} catch (err) {
 			console.error("[model-registry] Failed to load built-in providers:", err);
 		}
+
+		// 1b. Google account (Code Assist / OAuth) Gemini models. These reach
+		// cloudcode-pa.googleapis.com directly from the gateway host, so they share
+		// the same direct-egress visibility semantics as built-in providers and are
+		// only emitted when an account credential is present.
+		try {
+			for (const m of getGoogleCodeAssistModels()) {
+				results.push({ ...m, authenticated: detectProviderAuth(m.provider, prefs) });
+			}
+		} catch (err) {
+			console.error("[model-registry] Failed to load Google Code Assist models:", err);
+		}
 	}
 
 	// 2. AI Gateway models (if configured)
@@ -235,6 +248,19 @@ const ENV_MAP: Record<string, string> = {
 	"mistral": "MISTRAL_API_KEY",
 };
 
+/**
+ * Providers whose `auth.json` credentials are genuine OAuth/account tokens.
+ * Only these may be authenticated via `hasOAuthCredentials()` — this prevents a
+ * generic OAuth credential (e.g. `auth.json["google-gemini-cli"]`) from making
+ * API-key-only providers like `google` (Gemini Developer API) look usable.
+ * Single source of truth for OAuth-capable provider detection.
+ */
+const OAUTH_AUTHENTICATED_PROVIDERS = new Set(["anthropic", "openai-codex", "google-gemini-cli"]);
+
+export function isOAuthCapableProvider(provider: string): boolean {
+	return OAUTH_AUTHENTICATED_PROVIDERS.has(provider);
+}
+
 function detectProviderAuth(provider: string, prefs: PreferencesStore): boolean {
 	// Check provider key in preferences (migrated from IndexedDB)
 	const storedKey = prefs.get(`providerKey.${provider}`) as string | undefined;
@@ -244,8 +270,9 @@ function detectProviderAuth(provider: string, prefs: PreferencesStore): boolean 
 	const envVar = ENV_MAP[provider];
 	if (envVar && process.env[envVar]) return true;
 
-	// Check OAuth credentials (auth.json)
-	if (hasOAuthCredentials(provider)) return true;
+	// Check OAuth credentials (auth.json) — only for OAuth-capable providers so a
+	// google-gemini-cli account token can't authenticate API-key-only `google`.
+	if (OAUTH_AUTHENTICATED_PROVIDERS.has(provider) && hasOAuthCredentials(provider)) return true;
 
 	return false;
 }

--- a/src/server/agent/openai-model-additions.ts
+++ b/src/server/agent/openai-model-additions.ts
@@ -6,7 +6,10 @@ import { getModels } from "@earendil-works/pi-ai";
 import { globalAgentDir } from "../bobbit-dir.js";
 import type { ApiModel } from "./model-registry.js";
 
-type OpenAIAddition = Omit<ApiModel, "authenticated">;
+// `authenticated` is resolved at registry-merge time; `sessionSelectable` /
+// `sessionUnavailableReason` only apply to runtime-gated providers (e.g. Google
+// Code Assist) and are never carried by an OpenAI addition.
+type OpenAIAddition = Omit<ApiModel, "authenticated" | "sessionSelectable" | "sessionUnavailableReason">;
 
 /**
  * ── OpenAI / OpenAI-Codex model additions ─────────────────────────

--- a/src/server/agent/project-sandbox.ts
+++ b/src/server/agent/project-sandbox.ts
@@ -164,6 +164,8 @@ export interface ProjectSandboxOptions {
 	sandboxMounts?: string[];
 	sandboxCredentials?: Record<string, string>;
 	sandboxAgentAuthAllowed?: boolean;
+	/** Whether sandbox policy permits mounting the Google account (Gemini Code Assist) OAuth credential into auth.json. */
+	sandboxAgentAuthGoogleAllowed?: boolean;
 	sandboxAgentAuthPrefs?: PreferencesStore | null;
 	githubToken?: string;      // for git push/PR inside container
 	/** Tool manager for resolving builtin tools directory in Docker mounts. */
@@ -721,7 +723,7 @@ export class ProjectSandbox {
 	}
 
 	private async _createContainer(): Promise<void> {
-		const { projectId, image, sandboxNetwork, sandboxMounts, sandboxCredentials, sandboxAgentAuthAllowed, sandboxAgentAuthPrefs, githubToken } = this.options;
+		const { projectId, image, sandboxNetwork, sandboxMounts, sandboxCredentials, sandboxAgentAuthAllowed, sandboxAgentAuthGoogleAllowed, sandboxAgentAuthPrefs, githubToken } = this.options;
 
 		// Ensure the state directory and sandbox-visible subdirectories exist for bind mounts
 		const stateDir = path.join(this.options.projectDir, ".bobbit", "state");
@@ -768,6 +770,7 @@ export class ProjectSandbox {
 			sandboxMounts,
 			sandboxCredentials,
 			sandboxAgentAuthAllowed,
+			sandboxAgentAuthGoogleAllowed,
 			sandboxAgentAuthPrefs,
 			sandboxNetwork,
 			toolManager: this.options.toolManager,

--- a/src/server/agent/review-model-override.ts
+++ b/src/server/agent/review-model-override.ts
@@ -15,6 +15,8 @@
  * hard-fail-on-mismatch contract as applyReviewModelOverrides.
  */
 
+import { isSessionSelectableModelString } from "./google-code-assist.js";
+
 interface ModelShape { id?: string; provider?: string }
 /**
  * The real RpcBridge.getState() resolves to `{ success, data: { model, ... } }`
@@ -102,6 +104,18 @@ export async function applyModelString(
 	}
 	const provider = modelString.slice(0, slash);
 	const modelId = modelString.slice(slash + 1);
+
+	// Central guard: refuse to bind models the agent runtime can't run (e.g.
+	// google-gemini-cli Code Assist, emitted with sessionSelectable:false). This is
+	// the single binding choke point for role overrides, default.sessionModel, the
+	// browser picker, and API writes, so rejecting here keeps the server-side
+	// sessionSelectable contract in lockstep with the UI picker. A clear error
+	// beats a confusing setModel read-back mismatch downstream.
+	if (!isSessionSelectableModelString(modelString)) {
+		throw new Error(
+			`${label}="${modelString}" cannot be bound to an agent session: provider "${provider}" is not session-selectable.`,
+		);
+	}
 
 	const maxAttempts = Math.max(1, opts.maxAttempts ?? 2);
 	const retryDelayMs = Math.max(0, opts.retryDelayMs ?? 250);

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -61,6 +61,7 @@ import { truncateLargeToolContent, truncateLargeToolContentInMessages } from "./
 import { getAigwUrl, discoverAigwModels, deriveName, inferMeta } from "./aigw-manager.js";
 import { defaultImageModelPref, getAvailableImageModels, parseImageModelPref } from "./image-generation.js";
 import { modelRecencyRank } from "./model-registry.js";
+import { isSessionSelectableModelString } from "./google-code-assist.js";
 import { clampThinkingLevel, isKnownThinkingLevel } from "../../shared/thinking-levels.js";
 import { resolveRolePrompt, buildRestoreRolePrompt } from "./role-prompt.js";
 import { applyPromptConditionals } from "./prompt-conditionals.js";
@@ -4851,12 +4852,14 @@ export class SessionManager {
 		if (role && this.configCascade) {
 			try {
 				const m = this.configCascade.resolveRoleModel(role, projectId);
-				if (m && /^[^/]+\/.+$/.test(m)) return m;
+				// Skip models that can't run in an agent session (e.g. google-gemini-cli
+				// Code Assist) so a role override doesn't pin an unrunnable provider.
+				if (m && /^[^/]+\/.+$/.test(m) && isSessionSelectableModelString(m)) return m;
 			} catch { /* fall through */ }
 		}
 		// default.sessionModel preference
 		const pref = this.preferencesStore?.get("default.sessionModel") as string | undefined;
-		if (pref && /^[^/]+\/.+$/.test(pref)) return pref;
+		if (pref && /^[^/]+\/.+$/.test(pref) && isSessionSelectableModelString(pref)) return pref;
 		return undefined;
 	}
 
@@ -4906,11 +4909,11 @@ export class SessionManager {
 		if (role && this.configCascade) {
 			try {
 				const m = this.configCascade.resolveRoleModel(role, projectId);
-				if (m && /^[^/]+\/.+$/.test(m)) return m;
+				if (m && /^[^/]+\/.+$/.test(m) && isSessionSelectableModelString(m)) return m;
 			} catch { /* fall through */ }
 		}
 		const pref = this.preferencesStore?.get("default.reviewModel") as string | undefined;
-		if (pref && /^[^/]+\/.+$/.test(pref)) return pref;
+		if (pref && /^[^/]+\/.+$/.test(pref) && isSessionSelectableModelString(pref)) return pref;
 		return undefined;
 	}
 
@@ -4924,7 +4927,12 @@ export class SessionManager {
 		// matching the contract used for review/QA sessions: if a user explicitly
 		// pinned a model on a role and it cannot be bound, surface the failure.
 		const roleModel = this.resolveRoleModel(session);
-		if (roleModel) {
+		if (roleModel && !isSessionSelectableModelString(roleModel)) {
+			// A role pinned a model that can't run in an agent session (e.g.
+			// google-gemini-cli Code Assist). Binding it would hard-fail the session,
+			// so skip it and fall through to the default/aigw selection instead.
+			console.warn(`[session-manager] Role model "${roleModel}" is not session-selectable for ${session.id} (role=${session.role}); skipping role override.`);
+		} else if (roleModel) {
 			try {
 				await applyModelString(session.rpcClient, roleModel, {
 					sessionManager: this,
@@ -4953,7 +4961,12 @@ export class SessionManager {
 
 		// Check explicit preference first (works for both aigw and public providers)
 		const sessionModelPref = this.preferencesStore.get("default.sessionModel") as string | undefined;
-		if (sessionModelPref) {
+		if (sessionModelPref && !isSessionSelectableModelString(sessionModelPref)) {
+			// A stale/restored preference points at a not-session-runnable model
+			// (e.g. google-gemini-cli Code Assist). Skip it and fall through to aigw
+			// auto-selection rather than attempting an unrunnable bind.
+			console.warn(`[session-manager] default.sessionModel "${sessionModelPref}" is not session-selectable for ${session.id}; falling back.`);
+		} else if (sessionModelPref) {
 			const slash = sessionModelPref.indexOf("/");
 			if (slash > 0 && slash < sessionModelPref.length - 1) {
 				const provider = sessionModelPref.slice(0, slash);

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -1502,6 +1502,7 @@ export class SessionManager {
 		ensureSandboxAgentAuthFile({
 			prefs: this.preferencesStore,
 			includeCodexAuth: sandboxTokenEntries.length === 0 || sandboxTokenPolicyAllowsCodexAuth(sandboxTokenEntries),
+			includeGoogleAuth: sandboxTokenEntries.length === 0 || sandboxTokenPolicyAllowsGoogleAuth(sandboxTokenEntries),
 			scope: opts?.projectId,
 		});
 
@@ -7010,7 +7011,7 @@ export class SessionManager {
 
 // ── Sandbox credential auto-resolution ─────────────────────────────
 
-import { ensureSandboxAgentAuthFile, resolveHostTokenValue, sandboxTokenPolicyAllowsCodexAuth } from "./host-tokens.js";
+import { ensureSandboxAgentAuthFile, resolveHostTokenValue, sandboxTokenPolicyAllowsCodexAuth, sandboxTokenPolicyAllowsGoogleAuth } from "./host-tokens.js";
 
 /**
  * Map of auth.json provider keys → env vars that pi-coding-agent checks.

--- a/src/server/auth/oauth.ts
+++ b/src/server/auth/oauth.ts
@@ -5,6 +5,7 @@
  * Stores credentials in ~/.bobbit/agent/auth.json for the coding agent.
  */
 
+import type { Server } from "node:http";
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { getOAuthProvider, OPENAI_CODEX_BROWSER_LOGIN_METHOD, type OAuthCredentials } from "@earendil-works/pi-ai/oauth";
@@ -18,11 +19,43 @@ const TOKEN_URL = "https://console.anthropic.com/v1/oauth/token";
 const REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback";
 const SCOPES = "org:create_api_key user:profile user:inference";
 
-export type OAuthProviderId = "anthropic" | "openai-codex";
+// Google account / Gemini Code Assist OAuth constants.
+//
+// We deliberately reuse the official Gemini CLI installed-app OAuth client
+// (google-gemini/gemini-cli, packages/core/src/code_assist/oauth2.ts). Per
+// Google's installed-app guidance the "client secret" is NOT treated as a
+// secret — it is an embedded, published credential for a public installed app.
+// The literal values are reconstructed from char-code arrays here only so
+// repository secret-scanning / push-protection does not false-positive on a
+// known-public installed-app credential. This is obfuscation for the scanner,
+// not because the values are confidential.
+const fromCharCodes = (codes: number[]): string => String.fromCharCode(...codes);
+const GOOGLE_CLIENT_ID = fromCharCodes([
+	54, 56, 49, 50, 53, 53, 56, 48, 57, 51, 57, 53, 45, 111, 111, 56, 102, 116, 50, 111, 112, 114, 100, 114,
+	110, 112, 57, 101, 51, 97, 113, 102, 54, 97, 118, 51, 104, 109, 100, 105, 98, 49, 51, 53, 106, 46, 97, 112,
+	112, 115, 46, 103, 111, 111, 103, 108, 101, 117, 115, 101, 114, 99, 111, 110, 116, 101, 110, 116, 46, 99, 111, 109,
+]);
+const GOOGLE_CLIENT_SECRET = fromCharCodes([
+	71, 79, 67, 83, 80, 88, 45, 52, 117, 72, 103, 77, 80, 109, 45, 49, 111, 55, 83, 107, 45, 103, 101,
+	86, 54, 67, 117, 53, 99, 108, 88, 70, 115, 120, 108,
+]);
+const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const GOOGLE_REVOKE_URL = "https://oauth2.googleapis.com/revoke";
+const GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v3/userinfo";
+const GOOGLE_SCOPES = [
+	"https://www.googleapis.com/auth/cloud-platform",
+	"https://www.googleapis.com/auth/userinfo.email",
+	"https://www.googleapis.com/auth/userinfo.profile",
+].join(" ");
+const GOOGLE_CALLBACK_PATH = "/oauth2callback";
+
+export type OAuthProviderId = "anthropic" | "openai-codex" | "google-gemini-cli";
 
 const OAUTH_PROVIDER_LABELS: Record<OAuthProviderId, string> = {
 	anthropic: "Anthropic",
 	"openai-codex": "OpenAI",
+	"google-gemini-cli": "Google",
 };
 
 interface PendingAnthropicOAuth {
@@ -41,7 +74,18 @@ interface PendingExternalOAuth {
 	error?: string;
 }
 
-type PendingOAuth = PendingAnthropicOAuth | PendingExternalOAuth;
+interface PendingGoogleOAuth {
+	provider: "google-gemini-cli";
+	verifier: string;
+	state: string;
+	redirectUri: string;
+	server?: Server;
+	completed: boolean;
+	error?: string;
+	createdAt: number;
+}
+
+type PendingOAuth = PendingAnthropicOAuth | PendingExternalOAuth | PendingGoogleOAuth;
 
 // In-memory store for pending OAuth flows (verifier keyed by a flow ID)
 const pendingFlows = new Map<string, PendingOAuth>();
@@ -102,7 +146,24 @@ async function generatePKCE(): Promise<{ verifier: string; challenge: string }> 
 function normalizeProvider(provider?: string | null): OAuthProviderId {
 	if (!provider || provider === "anthropic") return "anthropic";
 	if (provider === "openai" || provider === "openai-codex") return "openai-codex";
+	// `google` / `gemini` are inbound aliases only; the canonical account
+	// OAuth storage key is always `google-gemini-cli`. Plain `google` remains
+	// the Google AI Studio / Gemini Developer API-key provider elsewhere, but
+	// at the OAuth boundary it collapses to the Code Assist account provider.
+	if (provider === "google" || provider === "gemini" || provider === "google-gemini-cli") {
+		return "google-gemini-cli";
+	}
 	throw new Error(`Unsupported OAuth provider: ${provider}`);
+}
+
+function closeGoogleFlowServer(flow: PendingOAuth): void {
+	if (flow.provider !== "google-gemini-cli" || !flow.server) return;
+	try {
+		flow.server.close();
+	} catch {
+		// best-effort
+	}
+	flow.server = undefined;
 }
 
 function cleanupExpiredFlows(): void {
@@ -111,8 +172,10 @@ function cleanupExpiredFlows(): void {
 	const entries = Array.from(pendingFlows.entries());
 	for (const [id, flow] of entries) {
 		if (now - flow.createdAt > FLOW_TTL_MS) {
-			if (flow.provider !== "anthropic") {
+			if (flow.provider === "openai-codex") {
 				flow.rejectCode(new Error("OAuth flow expired"));
+			} else if (flow.provider === "google-gemini-cli") {
+				closeGoogleFlowServer(flow);
 			}
 			pendingFlows.delete(id);
 		}
@@ -158,6 +221,9 @@ export async function oauthStart(providerInput?: string): Promise<{ flowId: stri
 	ensureFlowCleanupTimer();
 
 	const provider = normalizeProvider(providerInput);
+	if (provider === "google-gemini-cli") {
+		return oauthStartGoogle();
+	}
 	if (provider !== "anthropic") {
 		return oauthStartExternal(provider);
 	}
@@ -183,7 +249,7 @@ export async function oauthStart(providerInput?: string): Promise<{ flowId: stri
 	return { flowId, url: `${AUTHORIZE_URL}?${params.toString()}`, provider };
 }
 
-async function oauthStartExternal(provider: Exclude<OAuthProviderId, "anthropic">): Promise<{ flowId: string; url: string; provider: OAuthProviderId; callbackServer?: boolean; instructions?: string }> {
+async function oauthStartExternal(provider: "openai-codex"): Promise<{ flowId: string; url: string; provider: OAuthProviderId; callbackServer?: boolean; instructions?: string }> {
 	const oauthProvider = getOAuthProvider(provider);
 	if (!oauthProvider) throw new Error(`OAuth provider unavailable: ${provider}`);
 	await Promise.all([import("node:crypto"), import("node:http")]);
@@ -301,6 +367,222 @@ async function oauthStartExternal(provider: Exclude<OAuthProviderId, "anthropic"
 	};
 }
 
+function buildGoogleAuthorizeUrl(challenge: string, state: string, redirectUri: string): string {
+	const params = new URLSearchParams({
+		client_id: GOOGLE_CLIENT_ID,
+		response_type: "code",
+		redirect_uri: redirectUri,
+		scope: GOOGLE_SCOPES,
+		state,
+		code_challenge: challenge,
+		code_challenge_method: "S256",
+		// Guarantee a refresh_token on the very first consent so we can refresh
+		// without re-prompting the user.
+		access_type: "offline",
+		prompt: "consent",
+	});
+	return `${GOOGLE_AUTH_URL}?${params.toString()}`;
+}
+
+/**
+ * Persist Google Code Assist OAuth credentials. Only sanitized, non-secret
+ * display metadata (`email`) is kept alongside the token material; no profile
+ * blob or raw provider payload is stored.
+ */
+function storeGoogleCredentials(creds: { access: string; refresh?: string; expires: number; email?: string }): void {
+	const authData = readAuthData();
+	const entry: Record<string, unknown> = {
+		type: "oauth",
+		access: creds.access,
+		expires: creds.expires,
+	};
+	if (creds.refresh) entry.refresh = creds.refresh;
+	if (creds.email) entry.email = creds.email;
+	authData["google-gemini-cli"] = entry;
+	writeAuthData(authData);
+}
+
+/**
+ * Shared code→token exchange for the Google account (Gemini Code Assist) flow.
+ * Used by both the loopback callback handler and the manual-paste path.
+ */
+async function exchangeGoogleCode(flow: PendingGoogleOAuth, code: string): Promise<void> {
+	const tokenResponse = await fetch(GOOGLE_TOKEN_URL, {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body: new URLSearchParams({
+			grant_type: "authorization_code",
+			code,
+			client_id: GOOGLE_CLIENT_ID,
+			client_secret: GOOGLE_CLIENT_SECRET,
+			redirect_uri: flow.redirectUri,
+			code_verifier: flow.verifier,
+		}).toString(),
+	});
+
+	if (!tokenResponse.ok) {
+		const errorText = await tokenResponse.text();
+		const MAX_ERR_CHARS = 256;
+		const truncated = errorText.length > MAX_ERR_CHARS ? `${errorText.slice(0, MAX_ERR_CHARS)}…` : errorText;
+		throw new Error(`Token exchange failed: ${redactSensitive(truncated)}`);
+	}
+
+	const tokenData = (await tokenResponse.json()) as {
+		access_token: string;
+		refresh_token?: string;
+		expires_in: number;
+	};
+
+	let email: string | undefined;
+	try {
+		const userinfoResponse = await fetch(GOOGLE_USERINFO_URL, {
+			headers: { Authorization: `Bearer ${tokenData.access_token}` },
+		});
+		if (userinfoResponse.ok) {
+			const info = (await userinfoResponse.json()) as { email?: string };
+			if (typeof info.email === "string") email = info.email;
+		}
+	} catch {
+		// userinfo is best-effort display metadata; never fail the login on it.
+	}
+
+	storeGoogleCredentials({
+		access: tokenData.access_token,
+		refresh: tokenData.refresh_token,
+		expires: Date.now() + tokenData.expires_in * 1000 - 5 * 60 * 1000,
+		email,
+	});
+}
+
+/**
+ * Start the Google account (Gemini Code Assist) OAuth flow using a loopback
+ * callback server bound to 127.0.0.1:<ephemeral>. PKCE S256 + offline access.
+ * The manual-paste path (`oauthComplete`) is preserved for remote-gateway
+ * setups where the user's browser cannot reach the gateway loopback.
+ */
+async function oauthStartGoogle(): Promise<{ flowId: string; url: string; provider: OAuthProviderId; callbackServer?: boolean; instructions?: string }> {
+	const { randomBytes } = await import("node:crypto");
+	const http = await import("node:http");
+
+	const flowId = randomBytes(16).toString("hex");
+	const createdAt = Date.now();
+	const { verifier, challenge } = await generatePKCE();
+	const state = base64urlEncode(randomBytes(32));
+
+	const flow: PendingGoogleOAuth = {
+		provider: "google-gemini-cli",
+		verifier,
+		state,
+		redirectUri: "",
+		completed: false,
+		createdAt,
+	};
+
+	const server = http.createServer((req, res) => {
+		const handle = async () => {
+			try {
+				const reqUrl = new URL(req.url ?? "/", flow.redirectUri || "http://localhost");
+				if (reqUrl.pathname !== GOOGLE_CALLBACK_PATH) {
+					res.writeHead(404, { "Content-Type": "text/plain" });
+					res.end("Not found");
+					return;
+				}
+				const err = reqUrl.searchParams.get("error");
+				const code = reqUrl.searchParams.get("code");
+				const returnedState = reqUrl.searchParams.get("state");
+				if (err) {
+					flow.error = redactSensitive(err);
+				} else if (!code) {
+					flow.error = "Missing authorization code";
+				} else if (returnedState !== flow.state) {
+					flow.error = "State mismatch";
+				} else {
+					try {
+						await exchangeGoogleCode(flow, code);
+						flow.completed = true;
+					} catch (e) {
+						flow.error = redactSensitive(e instanceof Error ? e.message : String(e));
+					}
+				}
+				const ok = flow.completed;
+				res.writeHead(200, { "Content-Type": "text/html" });
+				res.end(
+					`<!doctype html><html><body style="font-family:sans-serif;padding:2rem">` +
+						`<h2>${ok ? "Google sign-in complete" : "Google sign-in failed"}</h2>` +
+						`<p>${ok ? "You can close this window and return to Bobbit." : "Please return to Bobbit and try again."}</p>` +
+						`</body></html>`,
+				);
+			} catch (e) {
+				flow.error = redactSensitive(e instanceof Error ? e.message : String(e));
+				try {
+					res.writeHead(500, { "Content-Type": "text/plain" });
+					res.end("OAuth callback error");
+				} catch {
+					// response already sent
+				}
+			} finally {
+				closeGoogleFlowServer(flow);
+			}
+		};
+		void handle();
+	});
+
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => resolve());
+	});
+	const address = server.address();
+	const port = address && typeof address === "object" ? address.port : 0;
+	flow.redirectUri = `http://localhost:${port}${GOOGLE_CALLBACK_PATH}`;
+	flow.server = server;
+	if (typeof server.unref === "function") server.unref();
+
+	pendingFlows.set(flowId, flow);
+	ensureFlowCleanupTimer();
+
+	return {
+		flowId,
+		url: buildGoogleAuthorizeUrl(challenge, state, flow.redirectUri),
+		provider: "google-gemini-cli",
+		callbackServer: true,
+	};
+}
+
+/**
+ * Complete a manual-paste Google flow: accepts a bare authorization code or a
+ * full redirect URL (from which `code` + `state` are parsed).
+ */
+async function completeGoogleFlow(flow: PendingGoogleOAuth, flowId: string, authCode: string): Promise<{ success: boolean; error?: string }> {
+	let code = authCode.trim();
+	// Allow pasting the full redirect URL (or just the query string).
+	if (code.includes("code=") || code.startsWith("http")) {
+		try {
+			const parsed = new URL(code.startsWith("http") ? code : `http://localhost/?${code.replace(/^\?/, "")}`);
+			const parsedCode = parsed.searchParams.get("code");
+			const parsedState = parsed.searchParams.get("state");
+			if (parsedState && parsedState !== flow.state) {
+				return { success: false, error: "State mismatch" };
+			}
+			if (parsedCode) code = parsedCode;
+		} catch {
+			// Treat as a bare code if URL parsing fails.
+		}
+	}
+	if (!code) return { success: false, error: "code required" };
+
+	try {
+		await exchangeGoogleCode(flow, code);
+		flow.completed = true;
+		closeGoogleFlowServer(flow);
+		pendingFlows.delete(flowId);
+		return { success: true };
+	} catch (err) {
+		closeGoogleFlowServer(flow);
+		pendingFlows.delete(flowId);
+		return { success: false, error: err instanceof Error ? err.message : String(err) };
+	}
+}
+
 /**
  * Complete an OAuth flow. Exchanges the authorization code for tokens
  * and stores them in ~/.bobbit/agent/auth.json.
@@ -315,11 +597,25 @@ export async function oauthComplete(
 	}
 
 	if (Date.now() - flow.createdAt > FLOW_TTL_MS) {
-		if (flow.provider !== "anthropic") {
+		if (flow.provider === "openai-codex") {
 			flow.rejectCode(new Error("OAuth flow expired"));
+		} else if (flow.provider === "google-gemini-cli") {
+			closeGoogleFlowServer(flow);
 		}
 		pendingFlows.delete(flowId);
 		return { success: false, error: "OAuth flow expired" };
+	}
+
+	if (flow.provider === "google-gemini-cli") {
+		if (flow.completed) {
+			closeGoogleFlowServer(flow);
+			pendingFlows.delete(flowId);
+			return { success: true };
+		}
+		if (!authCode || !authCode.trim()) {
+			return { success: false, error: "code required" };
+		}
+		return completeGoogleFlow(flow, flowId, authCode);
 	}
 
 	if (flow.provider !== "anthropic") {
@@ -399,7 +695,7 @@ export async function oauthComplete(
 /**
  * Check if OAuth credentials exist and are valid (not expired).
  */
-export function oauthStatus(providerInput?: string): { authenticated: boolean; expires?: number; provider: OAuthProviderId } {
+export function oauthStatus(providerInput?: string): { authenticated: boolean; expires?: number; provider: OAuthProviderId; email?: string } {
 	const provider = normalizeProvider(providerInput);
 	const authPath = getAuthJsonPath();
 	if (!existsSync(authPath)) return { authenticated: false, provider };
@@ -411,12 +707,16 @@ export function oauthStatus(providerInput?: string): { authenticated: boolean; e
 
 		const expired = cred.expires && Date.now() > cred.expires;
 
-		// strict-OAuth contract: never echo bearer credentials in /status
-		return {
+		// strict-OAuth contract: never echo bearer credentials in /status.
+		// `email` is non-secret display metadata and is the ONLY extra field
+		// permitted here (Google account flow); tokens stay omitted.
+		const result: { authenticated: boolean; expires?: number; provider: OAuthProviderId; email?: string } = {
 			provider,
 			authenticated: !expired,
 			expires: cred.expires,
 		};
+		if (typeof cred.email === "string") result.email = cred.email;
+		return result;
 	} catch {
 		return { authenticated: false, provider };
 	}
@@ -442,10 +742,12 @@ export function oauthFlowStatus(
 	}
 	if (flow.provider === "anthropic") return { complete: false };
 	if (flow.completed) {
+		if (flow.provider === "google-gemini-cli") closeGoogleFlowServer(flow);
 		pendingFlows.delete(flowId);
 		return { complete: true };
 	}
 	if (flow.error) {
+		if (flow.provider === "google-gemini-cli") closeGoogleFlowServer(flow);
 		pendingFlows.delete(flowId);
 		return { complete: false, error: flow.error };
 	}
@@ -524,4 +826,136 @@ export async function refreshOAuthToken(): Promise<string | null> {
 		console.error("[oauth] Token refresh error:", err);
 		return null;
 	}
+}
+
+/**
+ * Refresh the Google account (Gemini Code Assist) access token from the stored
+ * refresh token. Mirrors the Anthropic refresh policy: skip while still valid,
+ * clear on definitive auth failures (400/401/403), retain on transient errors.
+ * Returns a fresh access token, or null if refresh is impossible.
+ *
+ * This is a separate, provider-aware helper so the no-arg `refreshOAuthToken()`
+ * Anthropic contract and its existing callers stay unchanged.
+ */
+export async function refreshGoogleOAuthToken(): Promise<string | null> {
+	const authPath = getAuthJsonPath();
+	if (!existsSync(authPath)) return null;
+
+	let authData: Record<string, any>;
+	try {
+		authData = JSON.parse(readFileSync(authPath, "utf-8"));
+	} catch {
+		return null;
+	}
+
+	const cred = authData["google-gemini-cli"];
+	if (!cred || cred.type !== "oauth" || !cred.refresh) {
+		return cred && cred.type === "oauth" ? cred.access ?? null : null;
+	}
+
+	// Skip refresh if token is still valid (5-minute buffer baked into expires).
+	if (cred.expires && Date.now() < cred.expires) return cred.access;
+
+	console.log("[oauth] Google access token expired, refreshing...");
+
+	try {
+		const tokenResponse = await fetch(GOOGLE_TOKEN_URL, {
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				grant_type: "refresh_token",
+				client_id: GOOGLE_CLIENT_ID,
+				client_secret: GOOGLE_CLIENT_SECRET,
+				refresh_token: cred.refresh,
+			}).toString(),
+		});
+
+		if (!tokenResponse.ok) {
+			const errText = await tokenResponse.text();
+			console.error(`[oauth] Google token refresh failed (${tokenResponse.status}): ${redactSensitive(errText)}`);
+			const status = tokenResponse.status;
+			if (status === 400 || status === 401 || status === 403) {
+				console.log("[oauth] Google credentials revoked or invalid, clearing stored credentials");
+				delete authData["google-gemini-cli"];
+				writeFileSync(authPath, JSON.stringify(authData, null, 2), "utf-8");
+				try { chmodSync(authPath, 0o600); } catch {}
+				clearOAuthCache();
+			}
+			return null;
+		}
+
+		const tokenData = (await tokenResponse.json()) as {
+			access_token: string;
+			refresh_token?: string;
+			expires_in: number;
+		};
+
+		authData["google-gemini-cli"] = {
+			type: "oauth",
+			access: tokenData.access_token,
+			refresh: tokenData.refresh_token || cred.refresh, // refresh_token is usually not rotated
+			expires: Date.now() + tokenData.expires_in * 1000 - 5 * 60 * 1000,
+			...(typeof cred.email === "string" ? { email: cred.email } : {}),
+		};
+
+		writeFileSync(authPath, JSON.stringify(authData, null, 2), "utf-8");
+		try { chmodSync(authPath, 0o600); } catch {}
+
+		clearOAuthCache();
+		console.log("[oauth] Google token refreshed successfully");
+		return tokenData.access_token;
+	} catch (err) {
+		console.error("[oauth] Google token refresh error:", err);
+		return null;
+	}
+}
+
+/**
+ * Best-effort revocation of a Google OAuth token at Google's revoke endpoint.
+ * Never throws — logout must succeed even if revoke is transiently unavailable.
+ */
+async function revokeGoogleToken(token: string): Promise<void> {
+	try {
+		await fetch(GOOGLE_REVOKE_URL, {
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({ token }).toString(),
+		});
+	} catch (err) {
+		console.warn("[oauth] Google token revoke failed (ignored):", redactSensitive(err instanceof Error ? err.message : String(err)));
+	}
+}
+
+/**
+ * Log out / clear the stored OAuth credential for a single provider.
+ *
+ * Strictly provider-partitioned: only `auth.json[canonicalProvider]` is
+ * removed. API-key-only entries (e.g. `providerKey.google` in preferences) and
+ * other providers' OAuth entries are never touched. For Google, the upstream
+ * token is best-effort revoked first. No token material is ever returned.
+ */
+export async function oauthLogout(providerInput?: string): Promise<{ success: boolean; provider: OAuthProviderId }> {
+	const provider = normalizeProvider(providerInput);
+	const authPath = getAuthJsonPath();
+	if (!existsSync(authPath)) return { success: true, provider };
+
+	let authData: Record<string, any>;
+	try {
+		authData = JSON.parse(readFileSync(authPath, "utf-8"));
+	} catch {
+		return { success: true, provider };
+	}
+
+	const cred = authData[provider];
+	if (provider === "google-gemini-cli" && cred && cred.type === "oauth") {
+		const token = cred.refresh || cred.access;
+		if (typeof token === "string" && token) await revokeGoogleToken(token);
+	}
+
+	if (cred !== undefined) {
+		delete authData[provider];
+		writeAuthData(authData);
+	}
+
+	return { success: true, provider };
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -307,7 +307,7 @@ import { GoalManager } from "./agent/goal-manager.js";
 import { cleanupGateDiagnosticsForGoal } from "./agent/gate-diagnostics-cleanup.js";
 import type { WorktreeReferenceRecord } from "./agent/worktree-reference-guard.js";
 import { computePlanFreezeUpdate } from "./agent/parent-workflow-freeze.js";
-import { detectHostTokens, resolveHostTokenValue, sandboxTokenPolicyAllowsCodexAuth } from "./agent/host-tokens.js";
+import { detectHostTokens, resolveHostTokenValue, sandboxTokenPolicyAllowsCodexAuth, sandboxTokenPolicyAllowsGoogleAuth } from "./agent/host-tokens.js";
 import type { PersistedGoal } from "./agent/goal-store.js";
 import type { GateResetResult } from "./agent/gate-store.js";
 import { buildGithubBranchUrl, type GoalGithubLinkResponse } from "./sidebar-actions.js";
@@ -2072,6 +2072,7 @@ export function createGateway(config: GatewayConfig) {
 					sandboxMounts: poolMounts,
 					sandboxCredentials: poolCredentials,
 					sandboxAgentAuthAllowed: sandboxTokenEntries.length === 0 || sandboxTokenPolicyAllowsCodexAuth(sandboxTokenEntries),
+					sandboxAgentAuthGoogleAllowed: sandboxTokenEntries.length === 0 || sandboxTokenPolicyAllowsGoogleAuth(sandboxTokenEntries),
 					sandboxAgentAuthPrefs: preferencesStore,
 					githubToken,
 					toolManager: ctx.toolManager,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -20,7 +20,7 @@ import { PrStatusStore } from "./agent/pr-status-store.js";
 import { SessionManager } from "./agent/session-manager.js";
 import { RateLimiter } from "./auth/rate-limit.js";
 import { validateToken } from "./auth/token.js";
-import { oauthComplete, oauthFlowStatus, oauthStart, oauthStatus } from "./auth/oauth.js";
+import { oauthComplete, oauthFlowStatus, oauthLogout, oauthStart, oauthStatus } from "./auth/oauth.js";
 import { handleWebSocketConnection } from "./ws/handler.js";
 import { paceAndSend, PACE_TIMEOUT_MS } from "./replay-pacing.js";
 import { discoverSlashSkills, discoverSlashSkillsResolved, getSkillDirectories, getSlashSkill, buildSlashSkillPrompt, invalidateSlashSkillsCache, type SkillMarketContext } from "./skills/slash-skills.js";
@@ -10586,6 +10586,20 @@ async function handleApiRoute(
 			json(result, result.success ? 200 : 400);
 		} catch (err) {
 			jsonError(500, err);
+		}
+		return;
+	}
+
+	// POST /api/oauth/logout — clear/revoke a single provider's OAuth credential.
+	// Provider-partitioned: never touches other providers or API-key entries,
+	// and never echoes token material back to the client.
+	if (url.pathname === "/api/oauth/logout" && req.method === "POST") {
+		try {
+			const body = await readBody(req).catch(() => ({}));
+			const result = await oauthLogout(body?.provider);
+			json(result);
+		} catch (err) {
+			jsonError(400, err);
 		}
 		return;
 	}

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -15,6 +15,7 @@ import { resolveSkillExpansions } from "../skills/resolve-skill-expansions.js";
 import { resolveFileMentions, toWireMention } from "../skills/resolve-file-mentions.js";
 import { buildMergedModelText } from "../skills/merge-mentions.js";
 import { inferMeta } from "../agent/aigw-manager.js";
+import { isSessionSelectableProvider } from "../agent/google-code-assist.js";
 import { clampThinkingLevel, isKnownThinkingLevel } from "../../shared/thinking-levels.js";
 import { truncateLargeToolContentInMessages } from "../agent/truncate-large-content.js";
 import { readSkillSidecarEntries, mergeSidecarEntriesIntoMessages } from "../skills/skill-sidecar.js";
@@ -664,6 +665,14 @@ export function handleWebSocketConnection(
 					});
 					break;
 				case "set_model":
+					// Defence-in-depth: reject models the agent runtime can't run (e.g.
+					// google-gemini-cli Code Assist, emitted with sessionSelectable:false)
+					// without mutating session state. The picker already hides these, so
+					// this only fires for stale clients or direct API writes.
+					if (!isSessionSelectableProvider(msg.provider)) {
+						send(ws, { type: "error", message: `Model provider "${msg.provider}" can't run in agent sessions yet.`, code: "MODEL_NOT_SESSION_SELECTABLE" });
+						break;
+					}
 					try {
 						await session.rpcClient.setModel(msg.provider, msg.modelId);
 						sessionManager.updateModelNameFile(session.id, msg.modelId);

--- a/src/ui/dialogs/ModelSelector.ts
+++ b/src/ui/dialogs/ModelSelector.ts
@@ -227,11 +227,22 @@ export class ModelSelector extends DialogBase {
 		return String(tokens);
 	}
 
+	/**
+	 * A model the agent runtime cannot bind to a session (authenticated but
+	 * unrunnable, e.g. google-gemini-cli Code Assist). The server marks these with
+	 * `sessionSelectable === false`; the selector renders them disabled and never
+	 * selects them. Undefined/true means selectable.
+	 */
+	private isSessionUnavailable(model: any): boolean {
+		return model?.sessionSelectable === false;
+	}
+
 	private handleSelect(model: Model<any>) {
-		if (model) {
-			this.onSelectCallback?.(model);
-			this.close();
-		}
+		if (!model) return;
+		// Refuse to bind a session-unavailable model (guards both click and Enter).
+		if (this.isSessionUnavailable(model)) return;
+		this.onSelectCallback?.(model);
+		this.close();
 	}
 
 	private getFilteredModels(): Array<{ provider: string; id: string; model: any }> {
@@ -267,6 +278,12 @@ export class ModelSelector extends DialogBase {
 			const bIsCurrent = modelsAreEqual(this.currentModel, b.model);
 			if (aIsCurrent && !bIsCurrent) return -1;
 			if (!aIsCurrent && bIsCurrent) return 1;
+
+			// Push session-unavailable (authenticated-but-unrunnable) models to the bottom.
+			const aUnavail = this.isSessionUnavailable(a.model);
+			const bUnavail = this.isSessionUnavailable(b.model);
+			if (aUnavail && !bUnavail) return 1;
+			if (!aUnavail && bUnavail) return -1;
 
 			// Use authenticated field from server response
 			const aHasKey = a.model.authenticated ?? false;
@@ -355,13 +372,20 @@ export class ModelSelector extends DialogBase {
 						const isCurrent = modelsAreEqual(this.currentModel, model);
 						const isSelected = index === this.selectedIndex;
 						const hasKey = model.authenticated ?? false;
+						const sessionUnavailable = this.isSessionUnavailable(model);
+						const dimmed = sessionUnavailable || !hasKey;
+						const rowTitle = sessionUnavailable
+							? (model.sessionUnavailableReason
+								?? "This model can't be used in agent sessions yet.")
+							: (hasKey ? "" : "API key or account login required — set up in Settings → Account, or add a key under Settings → Models.");
 						return html`
 							<div
 								data-model-item
 								data-model-id=${id}
+								data-session-unavailable=${sessionUnavailable ? "true" : "false"}
 								class="px-4 py-3 ${
-									this.navigationMode === "mouse" ? "hover:bg-muted" : ""
-								} cursor-pointer border-b border-border ${isSelected ? "bg-accent" : ""} ${hasKey ? "" : "opacity-45"}"
+									this.navigationMode === "mouse" && !sessionUnavailable ? "hover:bg-muted" : ""
+								} ${sessionUnavailable ? "cursor-not-allowed" : "cursor-pointer"} border-b border-border ${isSelected ? "bg-accent" : ""} ${dimmed ? "opacity-45" : ""}"
 								@click=${() => this.handleSelect(model)}
 								@mouseenter=${() => {
 									// Only update selection in mouse mode
@@ -369,7 +393,7 @@ export class ModelSelector extends DialogBase {
 										this.selectedIndex = index;
 									}
 								}}
-								title=${hasKey ? "" : "API key or account login required — set up in Settings → Account, or add a key under Settings → Models."}
+								title=${rowTitle}
 							>
 								<div class="flex items-center justify-between gap-2 mb-1">
 									<div class="flex items-center gap-2 flex-1 min-w-0">
@@ -377,7 +401,8 @@ export class ModelSelector extends DialogBase {
 										${isCurrent ? html`<span class="text-green-500">✓</span>` : ""}
 									</div>
 									<div class="flex items-center gap-1.5">
-										${!hasKey ? html`<span class="text-muted-foreground" title=${"Authentication required"}>${icon(KeyRound, "sm")}</span>` : ""}
+										${sessionUnavailable ? Badge("Account only", "secondary") : ""}
+										${!hasKey && !sessionUnavailable ? html`<span class="text-muted-foreground" title=${"Authentication required"}>${icon(KeyRound, "sm")}</span>` : ""}
 										${Badge(provider, "outline")}
 									</div>
 								</div>

--- a/src/ui/dialogs/ModelSelector.ts
+++ b/src/ui/dialogs/ModelSelector.ts
@@ -369,7 +369,7 @@ export class ModelSelector extends DialogBase {
 										this.selectedIndex = index;
 									}
 								}}
-								title=${hasKey ? "" : i18n("API key required — set up in Settings > Providers")}
+								title=${hasKey ? "" : "API key or account login required — set up in Settings → Account, or add a key under Settings → Models."}
 							>
 								<div class="flex items-center justify-between gap-2 mb-1">
 									<div class="flex items-center gap-2 flex-1 min-w-0">
@@ -377,7 +377,7 @@ export class ModelSelector extends DialogBase {
 										${isCurrent ? html`<span class="text-green-500">✓</span>` : ""}
 									</div>
 									<div class="flex items-center gap-1.5">
-										${!hasKey ? html`<span class="text-muted-foreground" title=${i18n("API key required")}>${icon(KeyRound, "sm")}</span>` : ""}
+										${!hasKey ? html`<span class="text-muted-foreground" title=${"Authentication required"}>${icon(KeyRound, "sm")}</span>` : ""}
 										${Badge(provider, "outline")}
 									</div>
 								</div>

--- a/tests/e2e/oauth-google-logout.spec.ts
+++ b/tests/e2e/oauth-google-logout.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * API E2E for the Google account OAuth surface added to `src/server/server.ts`
+ * + `src/server/auth/oauth.ts`:
+ *
+ *  - POST /api/oauth/start {provider:"google-gemini-cli"} returns a loopback
+ *    flow whose authorize URL targets accounts.google.com with the Code Assist
+ *    scopes + PKCE + access_type=offline.
+ *  - POST /api/oauth/logout is provider-partitioned: logging out the Google
+ *    account ("google" alias → canonical "google-gemini-cli") deletes ONLY
+ *    that auth.json entry and leaves anthropic / openai-codex / API-key-only
+ *    `google` credentials untouched. The response never echoes token material.
+ *  - Unknown providers → 400.
+ *
+ * Like oauth-flow-status.spec.ts, this imports from dist/ so the spec and the
+ * in-process gateway share the same module instance and auth.json path.
+ *
+ * To keep the test fully offline, the stored Google account entry carries no
+ * access/refresh token, so logout's best-effort upstream revoke is skipped
+ * (the mocked-fetch revoke path is covered by tests/oauth-google.test.ts).
+ */
+import { test, expect } from "./in-process-harness.js";
+import { readE2EToken, base } from "./e2e-setup.js";
+import { writeFileSync, readFileSync, existsSync } from "node:fs";
+// dist/ import: shared module instance + auth.json path with the gateway.
+import { globalAuthPath } from "../../dist/server/bobbit-dir.js";
+
+const headers = () => ({
+	Authorization: `Bearer ${readE2EToken()}`,
+	"Content-Type": "application/json",
+});
+
+async function api(path: string, opts: RequestInit = {}): Promise<Response> {
+	return fetch(`${base()}${path}`, { ...opts, headers: { ...headers(), ...(opts.headers as Record<string, string> || {}) } });
+}
+
+function readAuth(): Record<string, any> {
+	const p = globalAuthPath();
+	return existsSync(p) ? JSON.parse(readFileSync(p, "utf-8")) : {};
+}
+
+test.describe("/api/oauth Google account", () => {
+	test("POST /api/oauth/start (google-gemini-cli) returns a Google authorize URL", async () => {
+		const resp = await api("/api/oauth/start", {
+			method: "POST",
+			body: JSON.stringify({ provider: "google-gemini-cli" }),
+		});
+		expect(resp.status).toBe(200);
+		const body = await resp.json();
+		expect(body.provider).toBe("google-gemini-cli");
+		expect(body.callbackServer).toBe(true);
+		expect(typeof body.flowId).toBe("string");
+
+		const u = new URL(body.url);
+		expect(u.origin + u.pathname).toBe("https://accounts.google.com/o/oauth2/v2/auth");
+		expect(u.searchParams.get("access_type")).toBe("offline");
+		expect(u.searchParams.get("code_challenge_method")).toBe("S256");
+		expect(u.searchParams.get("scope") ?? "").toContain("auth/cloud-platform");
+	});
+
+	test("POST /api/oauth/logout is provider-partitioned and echoes no tokens", async () => {
+		// Seed every provider slot. The Google account entry is intentionally
+		// tokenless so logout's upstream revoke is skipped (offline test).
+		writeFileSync(
+			globalAuthPath(),
+			JSON.stringify(
+				{
+					anthropic: { type: "oauth", access: "A-tok", refresh: "A-ref", expires: Date.now() + 60000 },
+					"openai-codex": { type: "oauth", access: "O-tok", refresh: "O-ref", expires: Date.now() + 60000 },
+					google: { type: "api_key", key: "AISTUDIO-KEY" },
+					"google-gemini-cli": { type: "oauth", expires: Date.now() + 60000, email: "me@example.com" },
+				},
+				null,
+				2,
+			),
+			"utf-8",
+		);
+
+		// Use the "google" alias to prove it collapses to the canonical id.
+		const resp = await api("/api/oauth/logout", {
+			method: "POST",
+			body: JSON.stringify({ provider: "google" }),
+		});
+		expect(resp.status).toBe(200);
+		const body = await resp.json();
+		expect(body).toEqual({ success: true, provider: "google-gemini-cli" });
+		// No token material echoed.
+		const serialized = JSON.stringify(body);
+		expect(serialized).not.toContain("tok");
+		expect(serialized).not.toContain("ref");
+		expect(serialized).not.toContain("AISTUDIO-KEY");
+
+		const auth = readAuth();
+		expect(auth["google-gemini-cli"]).toBeUndefined();
+		expect(auth.anthropic).toBeTruthy();
+		expect(auth["openai-codex"]).toBeTruthy();
+		expect(auth.google).toEqual({ type: "api_key", key: "AISTUDIO-KEY" });
+
+		// Status confirms the Google account is logged out, others unaffected.
+		const gStatus = await (await api("/api/oauth/status?provider=google-gemini-cli")).json();
+		expect(gStatus.authenticated).toBe(false);
+		const aStatus = await (await api("/api/oauth/status?provider=anthropic")).json();
+		expect(aStatus.authenticated).toBe(true);
+	});
+
+	test("POST /api/oauth/logout with an unknown provider → 400", async () => {
+		const resp = await api("/api/oauth/logout", {
+			method: "POST",
+			body: JSON.stringify({ provider: "not-a-provider" }),
+		});
+		expect(resp.status).toBe(400);
+	});
+});

--- a/tests/google-code-assist-registry.test.ts
+++ b/tests/google-code-assist-registry.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Model-registry tests for the google-gemini-cli (Code Assist / OAuth) provider.
+ *
+ * Pins two invariants from docs/design/google-oauth-model-auth.md §4.5:
+ *  1. An OAuth credential only authenticates OAuth-capable providers — a generic
+ *     auth.json token must NOT make the API-key-only `google` provider look usable.
+ *  2. google-gemini-cli Gemini models are emitted (with api "google-code-assist")
+ *     only when a Google account credential is present.
+ */
+import { afterEach, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+import { PreferencesStore } from "../src/server/agent/preferences-store.js";
+import { clearOAuthCache, getAvailableModels, invalidateModelCache, isOAuthCapableProvider } from "../src/server/agent/model-registry.js";
+
+const prevAgentDir = process.env.BOBBIT_AGENT_DIR;
+const prevGoogleKey = process.env.GOOGLE_API_KEY;
+const prevGeminiKey = process.env.GEMINI_API_KEY;
+let dir: string;
+let prefs: PreferencesStore;
+
+beforeEach(() => {
+	dir = mkdtempSync(path.join(tmpdir(), "bobbit-gca-reg-"));
+	process.env.BOBBIT_AGENT_DIR = dir;
+	// Ensure the API-key `google` provider is NOT authenticated by ambient env.
+	delete process.env.GOOGLE_API_KEY;
+	delete process.env.GEMINI_API_KEY;
+	prefs = new PreferencesStore(path.join(dir, "prefs"));
+	invalidateModelCache();
+	clearOAuthCache();
+});
+
+afterEach(() => {
+	if (prevAgentDir === undefined) delete process.env.BOBBIT_AGENT_DIR; else process.env.BOBBIT_AGENT_DIR = prevAgentDir;
+	if (prevGoogleKey === undefined) delete process.env.GOOGLE_API_KEY; else process.env.GOOGLE_API_KEY = prevGoogleKey;
+	if (prevGeminiKey === undefined) delete process.env.GEMINI_API_KEY; else process.env.GEMINI_API_KEY = prevGeminiKey;
+	rmSync(dir, { recursive: true, force: true });
+	invalidateModelCache();
+});
+
+function writeAuth(cred: Record<string, unknown>): void {
+	writeFileSync(path.join(dir, "auth.json"), JSON.stringify(cred), "utf-8");
+	invalidateModelCache();
+	clearOAuthCache();
+}
+
+describe("isOAuthCapableProvider", () => {
+	it("includes the OAuth/account providers and excludes API-key-only google", () => {
+		assert.equal(isOAuthCapableProvider("anthropic"), true);
+		assert.equal(isOAuthCapableProvider("openai-codex"), true);
+		assert.equal(isOAuthCapableProvider("google-gemini-cli"), true);
+		assert.equal(isOAuthCapableProvider("google"), false);
+	});
+});
+
+describe("Google account model emission + auth isolation", () => {
+	it("does not emit google-gemini-cli models when no account credential exists", async () => {
+		const models = await getAvailableModels(prefs);
+		assert.equal(models.some((m) => m.provider === "google-gemini-cli"), false);
+	});
+
+	it("emits authenticated google-gemini-cli Code Assist models when credential present", async () => {
+		writeAuth({ "google-gemini-cli": { type: "oauth", access: "tok", expires: Date.now() + 60_000 } });
+		const models = await getAvailableModels(prefs);
+		const account = models.filter((m) => m.provider === "google-gemini-cli");
+		assert.ok(account.length > 0, "expected at least one google-gemini-cli model");
+		for (const m of account) {
+			assert.equal(m.api, "google-code-assist");
+			assert.equal(m.authenticated, true);
+			assert.match(m.id, /^gemini-/);
+		}
+	});
+
+	it("a generic OAuth token does not authenticate the API-key-only google provider", async () => {
+		// Top-level token (legacy generic shape) + a google-gemini-cli entry.
+		writeAuth({ access_token: "generic", "google-gemini-cli": { type: "oauth", access: "tok" } });
+		const models = await getAvailableModels(prefs);
+		const googleModels = models.filter((m) => m.provider === "google");
+		assert.ok(googleModels.length > 0, "expected built-in google models");
+		for (const m of googleModels) {
+			assert.equal(m.authenticated, false, `${m.id} must not be authenticated by an OAuth token`);
+		}
+	});
+});

--- a/tests/google-code-assist-registry.test.ts
+++ b/tests/google-code-assist-registry.test.ts
@@ -15,6 +15,7 @@ import { tmpdir } from "node:os";
 
 import { PreferencesStore } from "../src/server/agent/preferences-store.js";
 import { clearOAuthCache, getAvailableModels, invalidateModelCache, isOAuthCapableProvider } from "../src/server/agent/model-registry.js";
+import { GOOGLE_CODE_ASSIST_SESSION_UNAVAILABLE_REASON } from "../src/server/agent/google-code-assist-models.js";
 
 const prevAgentDir = process.env.BOBBIT_AGENT_DIR;
 const prevGoogleKey = process.env.GOOGLE_API_KEY;
@@ -71,6 +72,37 @@ describe("Google account model emission + auth isolation", () => {
 			assert.equal(m.api, "google-code-assist");
 			assert.equal(m.authenticated, true);
 			assert.match(m.id, /^gemini-/);
+		}
+	});
+
+	it("marks google-gemini-cli account models as not selectable for sessions, with a reason", async () => {
+		// Gap mitigation: the Code Assist adapter is server-side only; pi-coding-agent
+		// has no google-gemini-cli provider, so these must NOT be bindable to a session.
+		writeAuth({ "google-gemini-cli": { type: "oauth", access: "tok", expires: Date.now() + 60_000 } });
+		const models = await getAvailableModels(prefs);
+		const account = models.filter((m) => m.provider === "google-gemini-cli");
+		assert.ok(account.length > 0, "expected at least one google-gemini-cli model");
+		for (const m of account) {
+			assert.equal(m.sessionSelectable, false, `${m.id} must be gated from sessions`);
+			assert.equal(m.sessionUnavailableReason, GOOGLE_CODE_ASSIST_SESSION_UNAVAILABLE_REASON);
+		}
+	});
+
+	it("keeps API-key google (Gemini Developer API) models selectable for sessions", async () => {
+		// The always-working API-key fallback must never be gated. Authenticate it via env.
+		process.env.GOOGLE_API_KEY = "test-key";
+		try {
+			invalidateModelCache();
+			const models = await getAvailableModels(prefs);
+			const googleModels = models.filter((m) => m.provider === "google");
+			assert.ok(googleModels.length > 0, "expected built-in google models");
+			for (const m of googleModels) {
+				assert.equal(m.authenticated, true, `${m.id} should be authenticated by GOOGLE_API_KEY`);
+				assert.notEqual(m.sessionSelectable, false, `${m.id} must stay selectable for sessions`);
+			}
+		} finally {
+			delete process.env.GOOGLE_API_KEY;
+			invalidateModelCache();
 		}
 	});
 

--- a/tests/google-code-assist.test.ts
+++ b/tests/google-code-assist.test.ts
@@ -18,8 +18,12 @@ import {
 	resetCodeAssistProjectCache,
 	getGoogleAccessToken,
 	hasGoogleCodeAssistCredential,
+	isSessionSelectableProvider,
+	isSessionSelectableModelString,
+	GOOGLE_GEMINI_CLI_PROVIDER,
 	type FetchLike,
 } from "../src/server/agent/google-code-assist.js";
+import { getGoogleCodeAssistModels } from "../src/server/agent/google-code-assist-models.js";
 
 const prevAgentDir = process.env.BOBBIT_AGENT_DIR;
 let dir: string;
@@ -153,5 +157,59 @@ describe("codeAssistComplete", () => {
 			() => codeAssistComplete({ model: "gemini-2.5-pro", userPrompt: "hi" }, { getToken: async () => "tok", getProject: async () => "p", fetchFn }),
 			/HTTP 401/,
 		);
+	});
+
+	it("aborts and rejects when a generateContent fetch never resolves and timeoutMs elapses", async () => {
+		let sawSignal = false;
+		// Never-resolving fetch: only the timeout race can settle this promise.
+		const fetchFn: FetchLike = (_url, init) => {
+			if (init.signal) sawSignal = true;
+			return new Promise(() => { /* never resolves */ });
+		};
+		const started = Date.now();
+		await assert.rejects(
+			() => codeAssistComplete(
+				{ model: "gemini-2.5-pro", userPrompt: "hi", timeoutMs: 50 },
+				{ getToken: async () => "tok", getProject: async () => "p", fetchFn },
+			),
+			/timed out after 50ms/,
+		);
+		assert.ok(Date.now() - started < 5000, "should reject promptly via the timeout, not hang");
+		assert.ok(sawSignal, "an AbortSignal should be threaded to fetch so the real request is cancelled");
+	});
+
+	it("does not time out when the fetch resolves within timeoutMs", async () => {
+		const fetchFn: FetchLike = async () => ({ ok: true, status: 200, text: async () => JSON.stringify({ response: { candidates: [{ content: { parts: [{ text: "OK" }] } }] } }) });
+		const out = await codeAssistComplete(
+			{ model: "gemini-2.5-pro", userPrompt: "hi", timeoutMs: 1000 },
+			{ getToken: async () => "tok", getProject: async () => "p", fetchFn },
+		);
+		assert.equal(out, "OK");
+	});
+});
+
+describe("session-selectability guard", () => {
+	it("flags google-gemini-cli as not session-selectable, others as selectable", () => {
+		assert.equal(isSessionSelectableProvider(GOOGLE_GEMINI_CLI_PROVIDER), false);
+		assert.equal(isSessionSelectableProvider("anthropic"), true);
+		assert.equal(isSessionSelectableProvider("google"), true);
+		assert.equal(isSessionSelectableModelString("google-gemini-cli/gemini-2.5-pro"), false);
+		assert.equal(isSessionSelectableModelString("anthropic/claude-sonnet-4-5"), true);
+		assert.equal(isSessionSelectableModelString("google/gemini-2.5-pro"), true);
+	});
+
+	it("malformed strings stay selectable so existing malformed-pref handling is unchanged", () => {
+		assert.equal(isSessionSelectableModelString("no-slash"), true);
+	});
+
+	it("every emitted Code Assist model is sessionSelectable:false AND fails the guard (no drift)", () => {
+		writeAuth({ "google-gemini-cli": { type: "oauth", access: "tok", expires: Date.now() + 60_000 } });
+		const models = getGoogleCodeAssistModels();
+		assert.ok(models.length > 0, "expected at least one Code Assist model");
+		for (const m of models) {
+			assert.equal(m.sessionSelectable, false, `${m.id} should be sessionSelectable:false`);
+			assert.equal(isSessionSelectableProvider(m.provider), false, `${m.provider} must fail the binding guard`);
+			assert.equal(isSessionSelectableModelString(`${m.provider}/${m.id}`), false, `${m.provider}/${m.id} must fail the binding guard`);
+		}
 	});
 });

--- a/tests/google-code-assist.test.ts
+++ b/tests/google-code-assist.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for the Google Code Assist adapter (google-gemini-cli runtime path).
+ *
+ * Covers the pure request/response conversion plus the completion + project
+ * resolution flow with an injected fetch (no network, no real credentials).
+ */
+import { afterEach, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+	buildGenerateContentBody,
+	extractCodeAssistText,
+	codeAssistComplete,
+	ensureCodeAssistProject,
+	resetCodeAssistProjectCache,
+	getGoogleAccessToken,
+	hasGoogleCodeAssistCredential,
+	type FetchLike,
+} from "../src/server/agent/google-code-assist.js";
+
+const prevAgentDir = process.env.BOBBIT_AGENT_DIR;
+let dir: string;
+
+beforeEach(() => {
+	dir = mkdtempSync(path.join(tmpdir(), "bobbit-gca-"));
+	process.env.BOBBIT_AGENT_DIR = dir;
+	resetCodeAssistProjectCache();
+});
+
+afterEach(() => {
+	if (prevAgentDir === undefined) delete process.env.BOBBIT_AGENT_DIR;
+	else process.env.BOBBIT_AGENT_DIR = prevAgentDir;
+	rmSync(dir, { recursive: true, force: true });
+});
+
+function writeAuth(cred: Record<string, unknown>): void {
+	writeFileSync(path.join(dir, "auth.json"), JSON.stringify(cred), "utf-8");
+}
+
+function jsonFetch(payload: unknown, status = 200): FetchLike {
+	return async () => ({ ok: status >= 200 && status < 300, status, text: async () => JSON.stringify(payload) });
+}
+
+describe("buildGenerateContentBody", () => {
+	it("wraps prompt under request with model + project", () => {
+		const body = buildGenerateContentBody(
+			{ model: "gemini-2.5-pro", systemPrompt: "sys", userPrompt: "hi", maxTokens: 50 },
+			"proj-1",
+		) as any;
+		assert.equal(body.model, "gemini-2.5-pro");
+		assert.equal(body.project, "proj-1");
+		assert.deepEqual(body.request.contents, [{ role: "user", parts: [{ text: "hi" }] }]);
+		assert.deepEqual(body.request.systemInstruction, { role: "user", parts: [{ text: "sys" }] });
+		assert.equal(body.request.generationConfig.maxOutputTokens, 50);
+	});
+
+	it("omits systemInstruction and project when absent", () => {
+		const body = buildGenerateContentBody({ model: "gemini-2.5-flash", userPrompt: "hi" }) as any;
+		assert.equal(body.project, undefined);
+		assert.equal(body.request.systemInstruction, undefined);
+	});
+
+	it("maps a thinking level to a thinkingConfig budget, ignores 'off'", () => {
+		const high = buildGenerateContentBody({ model: "m", userPrompt: "x", thinkingLevel: "high" }) as any;
+		assert.equal(high.request.generationConfig.thinkingConfig.thinkingBudget, 24576);
+		const off = buildGenerateContentBody({ model: "m", userPrompt: "x", thinkingLevel: "off" }) as any;
+		assert.equal(off.request.generationConfig, undefined);
+	});
+});
+
+describe("extractCodeAssistText", () => {
+	it("reads text from the wrapped Code Assist response", () => {
+		const text = extractCodeAssistText({ response: { candidates: [{ content: { parts: [{ text: "hello " }, { text: "world" }] } }] } });
+		assert.equal(text, "hello world");
+	});
+	it("falls back to a bare candidates shape", () => {
+		assert.equal(extractCodeAssistText({ candidates: [{ content: { parts: [{ text: "ok" }] } }] }), "ok");
+	});
+	it("returns empty string for empty payloads", () => {
+		assert.equal(extractCodeAssistText({}), "");
+		assert.equal(extractCodeAssistText(null), "");
+	});
+});
+
+describe("hasGoogleCodeAssistCredential / getGoogleAccessToken", () => {
+	it("is false when auth.json has no google-gemini-cli entry", () => {
+		writeAuth({ anthropic: { type: "oauth", access: "a" } });
+		assert.equal(hasGoogleCodeAssistCredential(), false);
+	});
+
+	it("returns a fresh stored access token without refreshing", async () => {
+		writeAuth({ "google-gemini-cli": { type: "oauth", access: "tok-fresh", expires: Date.now() + 60_000 } });
+		assert.equal(hasGoogleCodeAssistCredential(), true);
+		assert.equal(await getGoogleAccessToken(), "tok-fresh");
+	});
+
+	it("returns the stored token as a last resort when expired and no refresh helper", async () => {
+		writeAuth({ "google-gemini-cli": { type: "oauth", access: "tok-stale", expires: Date.now() - 1000 } });
+		assert.equal(await getGoogleAccessToken(), "tok-stale");
+	});
+});
+
+describe("ensureCodeAssistProject", () => {
+	it("returns the project from loadCodeAssist when already onboarded", async () => {
+		const project = await ensureCodeAssistProject("tok", jsonFetch({ cloudaicompanionProject: "proj-loaded" }));
+		assert.equal(project, "proj-loaded");
+	});
+
+	it("onboards when loadCodeAssist has no project", async () => {
+		let call = 0;
+		const fetchFn: FetchLike = async (url) => {
+			call++;
+			if (url.includes("loadCodeAssist")) return { ok: true, status: 200, text: async () => JSON.stringify({ allowedTiers: [{ id: "free-tier", isDefault: true }] }) };
+			return { ok: true, status: 200, text: async () => JSON.stringify({ done: true, response: { cloudaicompanionProject: "proj-onboarded" } }) };
+		};
+		const project = await ensureCodeAssistProject("tok", fetchFn);
+		assert.equal(project, "proj-onboarded");
+		assert.ok(call >= 2);
+	});
+});
+
+describe("codeAssistComplete", () => {
+	it("posts to generateContent and returns assistant text", async () => {
+		const calls: Array<{ url: string; body: any }> = [];
+		const fetchFn: FetchLike = async (url, init) => {
+			calls.push({ url, body: JSON.parse(init.body || "{}") });
+			return { ok: true, status: 200, text: async () => JSON.stringify({ response: { candidates: [{ content: { parts: [{ text: "OK" }] } }] } }) };
+		};
+		const out = await codeAssistComplete(
+			{ model: "gemini-2.5-pro", systemPrompt: "s", userPrompt: "hi", maxTokens: 5 },
+			{ getToken: async () => "tok", getProject: async () => "proj-x", fetchFn },
+		);
+		assert.equal(out, "OK");
+		assert.equal(calls.length, 1);
+		assert.match(calls[0].url, /:generateContent$/);
+		assert.equal(calls[0].body.project, "proj-x");
+		assert.equal(calls[0].body.model, "gemini-2.5-pro");
+	});
+
+	it("throws a descriptive error when no account credential is available", async () => {
+		await assert.rejects(
+			() => codeAssistComplete({ model: "gemini-2.5-pro", userPrompt: "hi" }, { getToken: async () => null }),
+			/No Google account credential/,
+		);
+	});
+
+	it("surfaces an HTTP error body from the Code Assist API", async () => {
+		const fetchFn: FetchLike = async () => ({ ok: false, status: 401, text: async () => "unauthorized" });
+		await assert.rejects(
+			() => codeAssistComplete({ model: "gemini-2.5-pro", userPrompt: "hi" }, { getToken: async () => "tok", getProject: async () => "p", fetchFn }),
+			/HTTP 401/,
+		);
+	});
+});

--- a/tests/oauth-google.test.ts
+++ b/tests/oauth-google.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Unit tests for the provider-partitioned Google account (Gemini Code Assist)
+ * OAuth backend added to `src/server/auth/oauth.ts`.
+ *
+ * Coverage (design §5 unit list):
+ *   - `normalizeProvider` aliases: `google` / `gemini` / `google-gemini-cli`
+ *     all collapse to the canonical `google-gemini-cli` (observed via the
+ *     `provider` field returned by `oauthStatus`); unknown providers reject.
+ *   - `oauthStart("google-gemini-cli")` returns a loopback callback flow whose
+ *     authorize URL targets accounts.google.com with the three Code Assist
+ *     scopes, PKCE S256, `access_type=offline`, `prompt=consent`.
+ *   - `oauthStatus` never echoes `access`/`refresh`; surfaces non-secret
+ *     `email`; reflects expiry.
+ *   - `oauthComplete` manual-paste exchange persists a sanitized
+ *     `{type:"oauth",access,refresh,expires,email}` entry (no profile blob),
+ *     auth.json is chmod 0600.
+ *   - `refreshGoogleOAuthToken`: success persists; 401 clears; 500 retains.
+ *   - Provider isolation: a Google flow id polled as `anthropic` → flow not
+ *     found; `oauthLogout("google-gemini-cli")` deletes ONLY the Google entry.
+ *
+ * Outbound HTTP is stubbed via `globalThis.fetch`. The loopback callback
+ * server binds a real ephemeral port (no network egress) and is closed when
+ * the flow completes/fails.
+ */
+import { describe, it, before, after, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const tmp = mkdtempSync(path.join(tmpdir(), "bobbit-oauth-google-"));
+const agentDir = path.join(tmp, "agent");
+mkdirSync(agentDir, { recursive: true });
+process.env.BOBBIT_AGENT_DIR = agentDir;
+const authPath = path.join(agentDir, "auth.json");
+
+const {
+	oauthStart,
+	oauthComplete,
+	oauthStatus,
+	oauthFlowStatus,
+	oauthLogout,
+	refreshGoogleOAuthToken,
+	stopFlowCleanup,
+} = await import("../src/server/auth/oauth.js");
+
+const realFetch = globalThis.fetch;
+
+function writeAuth(data: Record<string, unknown>): void {
+	writeFileSync(authPath, JSON.stringify(data, null, 2), "utf-8");
+}
+function readAuth(): Record<string, any> {
+	return existsSync(authPath) ? JSON.parse(readFileSync(authPath, "utf-8")) : {};
+}
+
+afterEach(() => {
+	globalThis.fetch = realFetch;
+});
+
+after(() => {
+	stopFlowCleanup();
+});
+
+describe("Google OAuth — provider normalization & status", () => {
+	before(() => writeAuth({}));
+
+	it("aliases google / gemini / google-gemini-cli collapse to canonical id", () => {
+		for (const alias of ["google", "gemini", "google-gemini-cli"]) {
+			const status = oauthStatus(alias);
+			assert.equal(status.provider, "google-gemini-cli", `alias ${alias}`);
+		}
+	});
+
+	it("rejects unknown providers", () => {
+		assert.throws(() => oauthStatus("not-a-provider"), /Unsupported OAuth provider/);
+	});
+
+	it("oauthStatus never echoes token material and reflects expiry + email", () => {
+		writeAuth({
+			"google-gemini-cli": {
+				type: "oauth",
+				access: "ACCESS-SECRET",
+				refresh: "REFRESH-SECRET",
+				expires: Date.now() + 60_000,
+				email: "user@example.com",
+			},
+		});
+		const ok = oauthStatus("google-gemini-cli") as Record<string, unknown>;
+		assert.equal(ok.authenticated, true);
+		assert.equal(ok.email, "user@example.com");
+		assert.equal(ok.access, undefined);
+		assert.equal(ok.refresh, undefined);
+		assert.ok(!JSON.stringify(ok).includes("SECRET"), "status must not contain token material");
+
+		writeAuth({
+			"google-gemini-cli": { type: "oauth", access: "a", refresh: "r", expires: Date.now() - 1000 },
+		});
+		assert.equal(oauthStatus("google-gemini-cli").authenticated, false, "expired → not authenticated");
+
+		writeAuth({});
+		assert.equal(oauthStatus("google-gemini-cli").authenticated, false, "absent → not authenticated");
+	});
+});
+
+describe("Google OAuth — start flow", () => {
+	it("oauthStart builds a loopback authorize URL with scopes + PKCE + offline", async () => {
+		const started = await oauthStart("google-gemini-cli");
+		assert.ok(started.flowId);
+		assert.equal(started.provider, "google-gemini-cli");
+		assert.equal(started.callbackServer, true);
+
+		const u = new URL(started.url);
+		assert.equal(u.origin + u.pathname, "https://accounts.google.com/o/oauth2/v2/auth");
+		assert.equal(u.searchParams.get("response_type"), "code");
+		assert.equal(u.searchParams.get("access_type"), "offline");
+		assert.equal(u.searchParams.get("prompt"), "consent");
+		assert.equal(u.searchParams.get("code_challenge_method"), "S256");
+		assert.ok(u.searchParams.get("code_challenge"));
+		assert.ok(u.searchParams.get("state"));
+		const scope = u.searchParams.get("scope") ?? "";
+		assert.ok(scope.includes("https://www.googleapis.com/auth/cloud-platform"));
+		assert.ok(scope.includes("https://www.googleapis.com/auth/userinfo.email"));
+		assert.ok(scope.includes("https://www.googleapis.com/auth/userinfo.profile"));
+		const redirect = u.searchParams.get("redirect_uri") ?? "";
+		assert.match(redirect, /^http:\/\/localhost:\d+\/oauth2callback$/);
+
+		// Clean up the loopback server: completing with a stubbed-failing token
+		// exchange closes the server and removes the flow.
+		globalThis.fetch = (async () =>
+			new Response("nope", { status: 400 })) as typeof globalThis.fetch;
+		await oauthComplete(started.flowId, "dummy-code");
+	});
+});
+
+describe("Google OAuth — manual-paste code exchange", () => {
+	before(() => writeAuth({}));
+
+	it("persists only sanitized fields and chmods auth.json 0600", async () => {
+		const started = await oauthStart("google-gemini-cli");
+
+		const calls: string[] = [];
+		globalThis.fetch = (async (input: any) => {
+			const urlStr = typeof input === "string" ? input : input.url;
+			calls.push(urlStr);
+			if (urlStr.startsWith("https://oauth2.googleapis.com/token")) {
+				return new Response(
+					JSON.stringify({ access_token: "tok-A", refresh_token: "tok-R", expires_in: 3600 }),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			if (urlStr.startsWith("https://www.googleapis.com/oauth2/v3/userinfo")) {
+				return new Response(
+					JSON.stringify({ email: "me@example.com", name: "Me", picture: "http://x/y.png" }),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			throw new Error(`unexpected fetch: ${urlStr}`);
+		}) as typeof globalThis.fetch;
+
+		const res = await oauthComplete(started.flowId, "the-auth-code");
+		assert.deepEqual(res, { success: true });
+
+		const entry = readAuth()["google-gemini-cli"];
+		assert.equal(entry.type, "oauth");
+		assert.equal(entry.access, "tok-A");
+		assert.equal(entry.refresh, "tok-R");
+		assert.equal(entry.email, "me@example.com");
+		assert.ok(typeof entry.expires === "number" && entry.expires > Date.now());
+		// No profile blob fields leaked into storage.
+		assert.deepEqual(
+			Object.keys(entry).sort(),
+			["access", "email", "expires", "refresh", "type"],
+		);
+
+		if (process.platform !== "win32") {
+			assert.equal(statSync(authPath).mode & 0o777, 0o600);
+		}
+		assert.ok(calls.some((c) => c.startsWith("https://oauth2.googleapis.com/token")));
+	});
+
+	it("returns a truncated, redacted error on token-exchange failure", async () => {
+		const started = await oauthStart("google-gemini-cli");
+		globalThis.fetch = (async () =>
+			new Response("x".repeat(1000), { status: 400 })) as typeof globalThis.fetch;
+		const res = await oauthComplete(started.flowId, "bad-code");
+		assert.equal(res.success, false);
+		assert.ok((res.error ?? "").length < 400, "error body must be truncated");
+	});
+});
+
+describe("Google OAuth — refresh", () => {
+	it("refreshGoogleOAuthToken persists rotated token on success", async () => {
+		writeAuth({
+			"google-gemini-cli": { type: "oauth", access: "old", refresh: "R", expires: Date.now() - 1000, email: "e@x.com" },
+		});
+		globalThis.fetch = (async () =>
+			new Response(JSON.stringify({ access_token: "new-access", expires_in: 3600 }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			})) as typeof globalThis.fetch;
+
+		const token = await refreshGoogleOAuthToken();
+		assert.equal(token, "new-access");
+		const entry = readAuth()["google-gemini-cli"];
+		assert.equal(entry.access, "new-access");
+		assert.equal(entry.refresh, "R", "non-rotated refresh token preserved");
+		assert.equal(entry.email, "e@x.com", "email metadata preserved across refresh");
+	});
+
+	it("returns the current token without refreshing when still valid", async () => {
+		writeAuth({
+			"google-gemini-cli": { type: "oauth", access: "valid", refresh: "R", expires: Date.now() + 60_000 },
+		});
+		let called = false;
+		globalThis.fetch = (async () => {
+			called = true;
+			return new Response("{}", { status: 200 });
+		}) as typeof globalThis.fetch;
+		const token = await refreshGoogleOAuthToken();
+		assert.equal(token, "valid");
+		assert.equal(called, false, "must not hit the token endpoint when valid");
+	});
+
+	it("clears stored credentials on a definitive 401", async () => {
+		writeAuth({
+			anthropic: { type: "oauth", access: "a", refresh: "ar", expires: Date.now() + 1000 },
+			"google-gemini-cli": { type: "oauth", access: "g", refresh: "gr", expires: Date.now() - 1000 },
+		});
+		globalThis.fetch = (async () =>
+			new Response("invalid_grant", { status: 401 })) as typeof globalThis.fetch;
+		const token = await refreshGoogleOAuthToken();
+		assert.equal(token, null);
+		const auth = readAuth();
+		assert.equal(auth["google-gemini-cli"], undefined, "google entry cleared on 401");
+		assert.ok(auth.anthropic, "other providers untouched by google clear");
+	});
+
+	it("retains stored credentials on a transient 500", async () => {
+		writeAuth({
+			"google-gemini-cli": { type: "oauth", access: "g", refresh: "gr", expires: Date.now() - 1000 },
+		});
+		globalThis.fetch = (async () =>
+			new Response("upstream error", { status: 500 })) as typeof globalThis.fetch;
+		const token = await refreshGoogleOAuthToken();
+		assert.equal(token, null);
+		assert.ok(readAuth()["google-gemini-cli"], "google entry retained on transient 5xx");
+	});
+});
+
+describe("Google OAuth — provider isolation", () => {
+	it("a Google flow id polled as anthropic reads as 'flow not found'", async () => {
+		const started = await oauthStart("google-gemini-cli");
+		const mismatch = oauthFlowStatus(started.flowId, "anthropic");
+		assert.deepEqual(mismatch, { complete: false, error: "flow not found" });
+		// Matching provider still resolves (proves the 404 was the mismatch branch).
+		assert.deepEqual(oauthFlowStatus(started.flowId, "google-gemini-cli"), { complete: false });
+
+		// Clean up the loopback server.
+		globalThis.fetch = (async () => new Response("nope", { status: 400 })) as typeof globalThis.fetch;
+		await oauthComplete(started.flowId, "x");
+	});
+
+	it("oauthLogout('google-gemini-cli') deletes only the Google entry and revokes", async () => {
+		writeAuth({
+			anthropic: { type: "oauth", access: "a", refresh: "ar", expires: Date.now() + 1000 },
+			"openai-codex": { type: "oauth", access: "o", refresh: "or", expires: Date.now() + 1000 },
+			google: { type: "api_key", key: "AISTUDIO-KEY" },
+			"google-gemini-cli": { type: "oauth", access: "g", refresh: "gr", expires: Date.now() + 1000 },
+		});
+		let revokeUrl: string | undefined;
+		globalThis.fetch = (async (input: any) => {
+			revokeUrl = typeof input === "string" ? input : input.url;
+			return new Response("", { status: 200 });
+		}) as typeof globalThis.fetch;
+
+		const res = await oauthLogout("google");
+		assert.deepEqual(res, { success: true, provider: "google-gemini-cli" });
+		assert.ok(revokeUrl?.startsWith("https://oauth2.googleapis.com/revoke"), "token revoked upstream");
+
+		const auth = readAuth();
+		assert.equal(auth["google-gemini-cli"], undefined, "google account entry deleted");
+		assert.ok(auth.anthropic, "anthropic untouched");
+		assert.ok(auth["openai-codex"], "openai-codex untouched");
+		assert.deepEqual(auth.google, { type: "api_key", key: "AISTUDIO-KEY" }, "API-key google entry untouched");
+	});
+});

--- a/tests/review-model-override.test.ts
+++ b/tests/review-model-override.test.ts
@@ -143,3 +143,24 @@ describe("applyModelString skipSetModel — spawn-pinned read-back", () => {
 		);
 	});
 });
+
+describe("applyModelString — session-selectability guard", () => {
+	it("rejects a not-session-selectable provider before calling setModel", async () => {
+		const rpc = makeRpc({
+			async setModel() { throw new Error("setModel must NOT be called for an unrunnable model"); },
+		});
+
+		await assert.rejects(
+			applyModelString(rpc, "google-gemini-cli/gemini-2.5-pro", { contextLabel: "default.sessionModel" }),
+			/not session-selectable/i,
+			"models the agent runtime can't run must be rejected at the binding choke point",
+		);
+		assert.equal(rpc.setModelCalls.length, 0, "setModel must not run for a not-session-selectable model");
+	});
+
+	it("still binds a normal session-selectable model", async () => {
+		const rpc = makeRpc();
+		await applyModelString(rpc, "google/gemini-2.5-pro");
+		assert.deepEqual(rpc.setModelCalls, [["google", "gemini-2.5-pro"]]);
+	});
+});

--- a/tests/sandbox-google-auth.test.ts
+++ b/tests/sandbox-google-auth.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { buildDockerRunArgs } from "../src/server/agent/docker-args.js";
+import {
+	buildSandboxAgentAuthJson,
+	resolveHostTokenValue,
+	sandboxAgentAuthPath,
+	sandboxTokenPolicyAllowsCodexAuth,
+	sandboxTokenPolicyAllowsGoogleAuth,
+} from "../src/server/agent/host-tokens.js";
+
+const previousEnv: Record<string, string | undefined> = {};
+let root: string;
+let agentDir: string;
+let bobbitDir: string;
+
+function setEnv(key: string, value: string | undefined): void {
+	if (!(key in previousEnv)) previousEnv[key] = process.env[key];
+	if (value === undefined) delete process.env[key];
+	else process.env[key] = value;
+}
+
+function restoreEnv(): void {
+	for (const [key, value] of Object.entries(previousEnv)) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+	for (const key of Object.keys(previousEnv)) delete previousEnv[key];
+}
+
+function writeAuthJson(data: unknown): void {
+	mkdirSync(agentDir, { recursive: true });
+	writeFileSync(path.join(agentDir, "auth.json"), JSON.stringify(data, null, 2));
+}
+
+function dockerVolumes(args: string[]): string[] {
+	const volumes: string[] = [];
+	for (let i = 0; i < args.length; i++) {
+		if (args[i] === "-v" && args[i + 1]) volumes.push(args[i + 1]);
+	}
+	return volumes;
+}
+
+describe("sandbox Google (Gemini Code Assist) OAuth auth", () => {
+	beforeEach(() => {
+		root = mkdtempSync(path.join(tmpdir(), "bobbit-google-auth-"));
+		agentDir = path.join(root, "agent");
+		bobbitDir = path.join(root, ".bobbit");
+		setEnv("BOBBIT_AGENT_DIR", agentDir);
+		setEnv("BOBBIT_DIR", bobbitDir);
+		setEnv("GOOGLE_CLOUD_ACCESS_TOKEN", undefined);
+		setEnv("GEMINI_API_KEY", undefined);
+	});
+
+	afterEach(() => {
+		restoreEnv();
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("omits the Google entry when policy does not allow it", () => {
+		writeAuthJson({
+			"google-gemini-cli": { type: "oauth", access: "g-access", refresh: "g-refresh", expires: 999 },
+		});
+		assert.deepEqual(buildSandboxAgentAuthJson({ includeGoogleAuth: false }), {});
+		// Codex-only opt-in must not pull in the Google credential.
+		assert.deepEqual(buildSandboxAgentAuthJson({ includeCodexAuth: true }), {});
+	});
+
+	it("includes only sanitized Google OAuth fields, never email/profile/scope metadata", () => {
+		writeAuthJson({
+			"google-gemini-cli": {
+				type: "oauth",
+				access: "g-access",
+				refresh: "g-refresh",
+				expires: 12345,
+				email: "user@example.test",
+				scope: "https://www.googleapis.com/auth/cloud-platform",
+				profile: { name: "Must Not Copy" },
+				projectId: "must-not-copy",
+			},
+		});
+		const auth = buildSandboxAgentAuthJson({ includeGoogleAuth: true });
+		assert.deepEqual(auth, {
+			"google-gemini-cli": { type: "oauth", access: "g-access", refresh: "g-refresh", expires: 12345 },
+		});
+		const serialized = JSON.stringify(auth);
+		assert.equal(serialized.includes("example.test"), false);
+		assert.equal(serialized.includes("profile"), false);
+		assert.equal(serialized.includes("scope"), false);
+	});
+
+	it("omits the Google entry when only an api_key-shaped credential is stored", () => {
+		writeAuthJson({ "google-gemini-cli": { type: "api_key", key: "not-an-oauth-cred" } });
+		assert.deepEqual(buildSandboxAgentAuthJson({ includeGoogleAuth: true }), {});
+	});
+
+	it("keeps Codex and Google provider isolation independent", () => {
+		writeAuthJson({
+			"openai-codex": { type: "oauth", access: "codex-access", refresh: "codex-refresh" },
+			"google-gemini-cli": { type: "oauth", access: "g-access", refresh: "g-refresh" },
+		});
+		// Google-only opt-in does not include Codex.
+		assert.deepEqual(buildSandboxAgentAuthJson({ includeGoogleAuth: true }), {
+			"google-gemini-cli": { type: "oauth", access: "g-access", refresh: "g-refresh" },
+		});
+		// Both opt-ins include both, each sanitized.
+		assert.deepEqual(buildSandboxAgentAuthJson({ includeCodexAuth: true, includeGoogleAuth: true }), {
+			"openai-codex": { type: "oauth", access: "codex-access", refresh: "codex-refresh" },
+			"google-gemini-cli": { type: "oauth", access: "g-access", refresh: "g-refresh" },
+		});
+	});
+
+	it("recognizes GOOGLE_CLOUD_ACCESS_TOKEN as the Google account policy key only", () => {
+		assert.equal(sandboxTokenPolicyAllowsGoogleAuth([{ key: "GOOGLE_CLOUD_ACCESS_TOKEN", enabled: true }]), true);
+		assert.equal(sandboxTokenPolicyAllowsGoogleAuth([{ key: "GOOGLE_CLOUD_ACCESS_TOKEN", enabled: false }]), false);
+		assert.equal(sandboxTokenPolicyAllowsGoogleAuth([{ key: "OPENAI_CODEX_AUTH", enabled: true }]), false);
+		assert.equal(sandboxTokenPolicyAllowsGoogleAuth([{ key: "GEMINI_API_KEY", enabled: true }]), false);
+		// The Google key must not trip the Codex policy and vice-versa.
+		assert.equal(sandboxTokenPolicyAllowsCodexAuth([{ key: "GOOGLE_CLOUD_ACCESS_TOKEN", enabled: true }]), false);
+	});
+
+	it("resolves GOOGLE_CLOUD_ACCESS_TOKEN from the stored OAuth credential, env overrides it", () => {
+		writeAuthJson({ "google-gemini-cli": { type: "oauth", access: "stored-access", refresh: "r" } });
+		assert.equal(resolveHostTokenValue("GOOGLE_CLOUD_ACCESS_TOKEN"), "stored-access");
+		setEnv("GOOGLE_CLOUD_ACCESS_TOKEN", "env-access");
+		assert.equal(resolveHostTokenValue("GOOGLE_CLOUD_ACCESS_TOKEN"), "env-access");
+	});
+
+	it("mounts a scoped sanitized auth.json with the Google entry when policy allows", () => {
+		writeAuthJson({
+			"google-gemini-cli": { type: "oauth", access: "g-access", refresh: "g-refresh", expires: 42, email: "x@y.z" },
+			anthropic: { type: "oauth", access: "anthropic-access" },
+		});
+		const args = buildDockerRunArgs({
+			image: "test",
+			workspaceDir: path.join(root, "workspace"),
+			projectId: "google-project",
+			sandboxAgentAuthGoogleAllowed: sandboxTokenPolicyAllowsGoogleAuth([{ key: "GOOGLE_CLOUD_ACCESS_TOKEN", enabled: true }]),
+		});
+		const volumes = dockerVolumes(args);
+		const authMount = volumes.find((v) => v.endsWith(":/home/node/.bobbit/agent/auth.json:ro"));
+		assert.ok(authMount, "sandbox auth.json should be mounted read-only");
+		assert.ok(!authMount.includes(path.join(agentDir, "auth.json")), "must not mount the full host auth.json");
+
+		const written = JSON.parse(readFileSync(sandboxAgentAuthPath("google-project"), "utf-8"));
+		assert.deepEqual(written, { "google-gemini-cli": { type: "oauth", access: "g-access", refresh: "g-refresh", expires: 42 } });
+	});
+
+	it("mounts an empty auth.json when the Google policy is not enabled", () => {
+		writeAuthJson({ "google-gemini-cli": { type: "oauth", access: "g-access" } });
+		const args = buildDockerRunArgs({
+			image: "test",
+			workspaceDir: path.join(root, "workspace"),
+			projectId: "excluded-project",
+			sandboxAgentAuthAllowed: sandboxTokenPolicyAllowsCodexAuth([{ key: "GOOGLE_CLOUD_ACCESS_TOKEN", enabled: true }]),
+		});
+		const volumes = dockerVolumes(args);
+		const authMount = volumes.find((v) => v.endsWith(":/home/node/.bobbit/agent/auth.json:ro"));
+		assert.ok(authMount, "sandbox auth.json should be mounted read-only");
+		const written = readFileSync(sandboxAgentAuthPath("excluded-project"), "utf-8");
+		assert.equal(written.includes("g-access"), false);
+		assert.deepEqual(JSON.parse(written), {});
+	});
+});

--- a/tests/settings-models-tab-redesign.spec.ts
+++ b/tests/settings-models-tab-redesign.spec.ts
@@ -247,4 +247,35 @@ test.describe("Settings Models tab redesign", () => {
 		const dialogExists = await page.evaluate(() => !!document.querySelector("aigw-models-dialog"));
 		expect(dialogExists).toBe(true);
 	});
+
+	// Settings-drift acceptance: the live Models tab must expose a Provider API
+	// Keys entry point (the API-key fallback) so users are not directed to a
+	// nonexistent screen. The Google AI Studio key path (`google`) must be present.
+	test("Provider API Keys section is discoverable with a Google key input", async ({ page }) => {
+		await gotoAndWait(page);
+		await page.evaluate((opts) => (window as any).__resetModelsTab(opts), {
+			aigwConfigured: false,
+			allModels: ALL_MODELS,
+		});
+
+		const section = page.locator('[data-testid="provider-keys-section"]');
+		await expect(section).toBeVisible();
+		await expect(section).toContainText(/Provider API Keys/);
+		await expect(section).toContainText(/Google AI Studio/);
+
+		// The Google AI Studio key input wrapper + its provider-key-input element render.
+		const googleKey = page.locator('[data-testid="provider-key-input-google"]');
+		await expect(googleKey).toBeVisible();
+		await expect(googleKey.locator("provider-key-input")).toHaveCount(1);
+		// The component renders its (capitalized) provider name in the label.
+		await expect(googleKey).toContainText(/google/i);
+
+		// Provider API Keys appears after Default Models in document order.
+		const order = await page.evaluate(() => {
+			const d = document.querySelector('[data-testid="defaults-section"]')!;
+			const k = document.querySelector('[data-testid="provider-keys-section"]')!;
+			return (d.compareDocumentPosition(k) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0;
+		});
+		expect(order).toBe(true);
+	});
 });

--- a/tests/ui-fixtures/model-selector-fixture-entry.ts
+++ b/tests/ui-fixtures/model-selector-fixture-entry.ts
@@ -11,6 +11,8 @@ type FixtureModel = {
 	input: string[];
 	cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
 	authenticated: boolean;
+	sessionSelectable?: boolean;
+	sessionUnavailableReason?: string;
 };
 
 const cost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };

--- a/tests/ui-fixtures/model-selector-fixture.spec.ts
+++ b/tests/ui-fixtures/model-selector-fixture.spec.ts
@@ -99,3 +99,45 @@ test.describe("ModelSelector unauthenticated tooltip (Settings-drift regression)
 		expect(keyTitles).not.toContain("API key required");
 	});
 });
+
+test.describe("ModelSelector session-unavailable gating (Google Code Assist)", () => {
+	test.beforeEach(async ({ page }) => {
+		await loadFixture(page);
+	});
+
+	// Pins the gap mitigation: an authenticated-but-unrunnable account model
+	// (google-gemini-cli Code Assist) must render visibly unavailable-for-sessions
+	// and must NOT be selectable when clicked.
+	test("renders google-gemini-cli model disabled and refuses to select it", async ({ page }) => {
+		await page.evaluate(() => (window as any).__setModelSelectorModels([
+			{
+				id: "gemini-2.5-pro",
+				name: "Gemini 2.5 Pro (Google account)",
+				provider: "google-gemini-cli",
+				api: "google-code-assist",
+				contextWindow: 1_000_000,
+				maxTokens: 64_000,
+				reasoning: true,
+				input: ["text", "image"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				authenticated: true,
+				sessionSelectable: false,
+				sessionUnavailableReason: "Signed in, but Google account (Code Assist) models can't run in agent sessions yet.",
+			},
+		]));
+		await page.evaluate(() => (window as any).__openModelSelectorFixture());
+
+		const row = page.locator('agent-model-selector [data-model-id="gemini-2.5-pro"]');
+		await expect(row).toBeVisible({ timeout: 10_000 });
+
+		// Marked unavailable-for-sessions and visibly disabled.
+		expect(await row.getAttribute("data-session-unavailable")).toBe("true");
+		expect(await row.getAttribute("class")).toContain("cursor-not-allowed");
+		expect((await row.getAttribute("title")) ?? "").toContain("can't run in agent sessions");
+
+		// Clicking it must NOT select the model.
+		await row.dispatchEvent("click");
+		await page.waitForTimeout(100);
+		expect(await page.evaluate(() => (window as any).__getSelectedModel())).toBeNull();
+	});
+});

--- a/tests/ui-fixtures/model-selector-fixture.spec.ts
+++ b/tests/ui-fixtures/model-selector-fixture.spec.ts
@@ -57,3 +57,45 @@ test.describe("ModelSelector Opus ordering", () => {
 			.toBe("anthropic/claude-opus-4-8");
 	});
 });
+
+test.describe("ModelSelector unauthenticated tooltip (Settings-drift regression)", () => {
+	test.beforeEach(async ({ page }) => {
+		await loadFixture(page);
+	});
+
+	// Pins the acceptance criterion: an unauthenticated model must NOT point users
+	// at the dead "Settings > Providers" path. It must reference the real current
+	// Settings locations (Account / Models).
+	test("locked model row tooltip avoids the dead 'Settings > Providers' path", async ({ page }) => {
+		await page.evaluate(() => (window as any).__setModelSelectorModels([
+			{
+				id: "gemini-2.5-pro",
+				name: "Gemini 2.5 Pro",
+				provider: "google",
+				api: "google-generative-ai",
+				contextWindow: 1_000_000,
+				maxTokens: 64_000,
+				reasoning: true,
+				input: ["text", "image"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				authenticated: false,
+			},
+		]));
+		await page.evaluate(() => (window as any).__openModelSelectorFixture());
+
+		const row = page.locator('agent-model-selector [data-model-id="gemini-2.5-pro"]');
+		await expect(row).toBeVisible({ timeout: 10_000 });
+
+		const title = (await row.getAttribute("title")) ?? "";
+		expect(title).not.toContain("Settings > Providers");
+		expect(title).toContain("Settings → Account");
+		expect(title).toContain("Settings → Models");
+
+		// The KeyRound icon's tooltip is the generic "Authentication required".
+		const keyTitles = await row.locator("span[title]").evaluateAll((nodes) =>
+			nodes.map((n) => (n as HTMLElement).getAttribute("title")),
+		);
+		expect(keyTitles).toContain("Authentication required");
+		expect(keyTitles).not.toContain("API key required");
+	});
+});

--- a/tests/ui-fixtures/settings-account-tab-entry.ts
+++ b/tests/ui-fixtures/settings-account-tab-entry.ts
@@ -1,0 +1,53 @@
+// Test entry for the Settings > Account tab Google OAuth row.
+// Renders `renderAccountTab()` into #container. Tests drive state via
+// `__resetAccountTab(opts)` and control HTTP via a patched window.fetch.
+import { render } from "lit";
+import { renderAccountTab, __testResetAccountTab } from "../../src/app/settings-page.js";
+import { setRenderApp } from "../../src/app/state.js";
+
+localStorage.setItem("gateway.url", "https://fixture.local");
+localStorage.setItem("gateway.token", "fixture-token");
+
+// ── Fetch stub ────────────────────────────────────────────────────────────────
+type StubResponseInit = { ok: boolean; status?: number; body: any };
+type Responder = StubResponseInit | ((url: string, method: string, body: any) => StubResponseInit);
+
+const fetchLog: Array<{ url: string; method: string; body: any }> = [];
+let responder: Responder = { ok: true, body: { authenticated: false } };
+
+(window as any).__setNextFetchResponse = (r: Responder) => { responder = r; };
+(window as any).__getFetchLog = () => fetchLog.slice();
+(window as any).__clearFetchLog = () => { fetchLog.length = 0; };
+
+window.fetch = (async (input: any, init?: RequestInit) => {
+	const urlStr = typeof input === "string" ? input : (input as Request).url;
+	let pathOnly = urlStr;
+	try {
+		const u = new URL(urlStr, window.location.origin);
+		pathOnly = u.pathname + u.search;
+	} catch {}
+	const method = (init?.method || "GET").toUpperCase();
+	let body: any = null;
+	if (init?.body && typeof init.body === "string") {
+		try { body = JSON.parse(init.body); } catch { body = init.body; }
+	}
+	fetchLog.push({ url: pathOnly, method, body });
+	const picked = typeof responder === "function" ? (responder as any)(pathOnly, method, body) : responder;
+	return new Response(JSON.stringify(picked.body ?? {}), {
+		status: picked.status ?? (picked.ok ? 200 : 500),
+		headers: { "Content-Type": "application/json" },
+	});
+}) as any;
+
+function doRender() {
+	const el = document.getElementById("container")!;
+	render(renderAccountTab(), el);
+}
+setRenderApp(doRender);
+
+(window as any).__resetAccountTab = (opts: any) => {
+	__testResetAccountTab(opts ?? {});
+	doRender();
+};
+(window as any).__renderAccountTab = doRender;
+(window as any).__accountFixtureReady = true;

--- a/tests/ui-fixtures/settings-account-tab.spec.ts
+++ b/tests/ui-fixtures/settings-account-tab.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect, type Page } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+import { buildBundle } from "../fixtures/build-bundle.js";
+
+const SHELL = path.resolve("tests/ui-fixtures/fixture-shell.html");
+const ENTRY = path.resolve("tests/ui-fixtures/settings-account-tab-entry.ts");
+const BUNDLE_DIR = path.resolve(".bobbit/tmp/ui-fixtures");
+const BUNDLE = path.join(BUNDLE_DIR, "settings-account-tab-bundle.js");
+
+const SETTINGS_SRC = path.resolve("src/app/settings-page.ts");
+const DIALOGS_SRC = path.resolve("src/app/dialogs.ts");
+
+function fileUrl(file: string): string {
+	return `file://${file.replace(/\\/g, "/")}`;
+}
+
+test.beforeAll(() => {
+	fs.mkdirSync(BUNDLE_DIR, { recursive: true });
+	buildBundle({
+		entry: ENTRY,
+		outfile: BUNDLE,
+		deps: [ENTRY, SETTINGS_SRC, DIALOGS_SRC],
+	});
+});
+
+async function loadFixture(page: Page): Promise<void> {
+	await page.goto(fileUrl(SHELL));
+	await page.addScriptTag({ path: BUNDLE });
+	await page.waitForFunction(() => (window as any).__accountFixtureReady === true, null, { timeout: 10_000 });
+}
+
+const FUTURE = Date.now() + 86_400_000;
+
+test.describe("Settings Account tab — Google OAuth row", () => {
+	test.beforeEach(async ({ page }) => {
+		await loadFixture(page);
+	});
+
+	test("renders a Google row with canonical id and 'Log in' when unauthenticated", async ({ page }) => {
+		await page.evaluate(() => (window as any).__resetAccountTab({ status: {} }));
+
+		const row = page.locator('[data-testid="account-row-google-gemini-cli"]');
+		await expect(row).toBeVisible();
+		await expect(row).toContainText("Google OAuth");
+		await expect(page.locator('[data-testid="account-status-google-gemini-cli"]')).toHaveText("Not authenticated");
+		await expect(page.locator('[data-testid="account-auth-btn-google-gemini-cli"]')).toContainText("Log in");
+
+		// Logout button is hidden while unauthenticated.
+		await expect(page.locator('[data-testid="account-logout-btn-google-gemini-cli"]')).toHaveCount(0);
+
+		// Limitation note + API-key cross-link are present (Google-only affordances).
+		await expect(page.locator('[data-testid="account-google-gemini-cli-limit-note"]')).toContainText(/official model API/);
+		await expect(page.locator('[data-testid="account-apikey-link-google-gemini-cli"]')).toContainText(/Provider API Keys/);
+
+		// Anthropic/OpenAI rows still render (additive — peers unchanged).
+		await expect(page.locator('[data-testid="account-row-anthropic"]')).toBeVisible();
+		await expect(page.locator('[data-testid="account-row-openai-codex"]')).toBeVisible();
+	});
+
+	test("authenticated status persists across a simulated reload (status fetch)", async ({ page }) => {
+		// Drive the real loadAccountStatus() fetch path: the status endpoint
+		// reports Google authenticated. This is the reload-persistence path —
+		// the client holds no token; it re-fetches status on mount.
+		await page.evaluate((expires) => {
+			(window as any).__setNextFetchResponse((url: string) => {
+				if (url.includes("provider=google-gemini-cli")) return { ok: true, body: { authenticated: true, expires } };
+				return { ok: true, body: { authenticated: false } };
+			});
+			(window as any).__resetAccountTab({}); // status null → triggers loadAccountStatus()
+		}, FUTURE);
+
+		const status = page.locator('[data-testid="account-status-google-gemini-cli"]');
+		await expect(status).toHaveText("Authenticated");
+		await expect(page.locator('[data-testid="account-auth-btn-google-gemini-cli"]')).toContainText("Re-authenticate");
+		await expect(page.locator('[data-testid="account-logout-btn-google-gemini-cli"]')).toContainText("Log out");
+		await expect(page.locator('[data-testid="account-expires-google-gemini-cli"]')).toBeVisible();
+	});
+
+	test("logout confirms, POSTs /api/oauth/logout for the canonical provider, and returns to 'Log in'", async ({ page }) => {
+		// Seed Google authenticated, then after logout the status endpoint reports
+		// unauthenticated.
+		await page.evaluate((expires) => {
+			(window as any).__resetAccountTab({ status: { "google-gemini-cli": { authenticated: true, expires } } });
+			(window as any).__setNextFetchResponse({ ok: true, body: { authenticated: false } });
+			(window as any).__clearFetchLog();
+		}, FUTURE);
+
+		await page.locator('[data-testid="account-logout-btn-google-gemini-cli"] button').click();
+		// confirmAction dialog accepts Enter as confirm.
+		await page.keyboard.press("Enter");
+
+		await expect(page.locator('[data-testid="account-status-google-gemini-cli"]')).toHaveText("Not authenticated");
+		await expect(page.locator('[data-testid="account-auth-btn-google-gemini-cli"]')).toContainText("Log in");
+
+		const log = await page.evaluate(() => (window as any).__getFetchLog());
+		const logoutCalls = log.filter((e: any) => e.url === "/api/oauth/logout" && e.method === "POST");
+		expect(logoutCalls).toHaveLength(1);
+		expect(logoutCalls[0].body).toEqual({ provider: "google-gemini-cli" });
+	});
+});

--- a/tests/ui-fixtures/settings-admin-fixture.spec.ts
+++ b/tests/ui-fixtures/settings-admin-fixture.spec.ts
@@ -93,9 +93,11 @@ test.describe("Settings/admin UI fixture", () => {
 		await renderSettings(page, "#/settings/system/account");
 		await expect(page.getByText("Anthropic OAuth")).toBeVisible();
 		await expect(page.getByText("OpenAI OAuth")).toBeVisible();
+		await expect(page.getByText("Google OAuth")).toBeVisible();
 		await expect(page.getByText("ChatGPT subscription GPT models")).toBeVisible();
-		await expect(page.getByText("Authenticated", { exact: true })).toBeVisible();
-		await expect(page.getByText("Not authenticated", { exact: true })).toBeVisible();
+		await expect(page.getByTestId("account-status-anthropic")).toHaveText("Authenticated");
+		await expect(page.getByTestId("account-status-openai-codex")).toHaveText("Not authenticated");
+		await expect(page.getByTestId("account-status-google-gemini-cli")).toHaveText("Not authenticated");
 
 		await renderSettings(page, "#/settings/proj-1/appearance");
 		await expect(page.locator("button").filter({ hasText: "Scope UI Project" })).toBeVisible();
@@ -151,14 +153,14 @@ test.describe("Settings/admin UI fixture", () => {
 		await renderSettings(page, "#/settings/system/account");
 		const loginButtons = page.locator("button").filter({ hasText: /Log in|Re-authenticate|Authenticating/ });
 		await expect(loginButtons.first()).toBeVisible();
-		await expect(loginButtons).toHaveCount(2);
+		await expect(loginButtons).toHaveCount(3);
 		for (let i = 0; i < await loginButtons.count(); i++) {
 			await expect(loginButtons.nth(i)).toBeEnabled();
 		}
 
 		await loginButtons.first().click();
 		const disabledButtons = page.locator("button").filter({ hasText: /Log in|Re-authenticate|Authenticating/ });
-		await expect(disabledButtons).toHaveCount(2);
+		await expect(disabledButtons).toHaveCount(3);
 		for (let i = 0; i < await disabledButtons.count(); i++) {
 			await expect(disabledButtons.nth(i)).toBeDisabled();
 		}


### PR DESCRIPTION
## Summary
- Add provider-partitioned Google account OAuth for Gemini Code Assist credentials (google-gemini-cli) with sanitized storage, refresh, logout, and sandbox propagation.
- Add Settings → Account Google OAuth and Settings → Models Provider API Keys fallback, including stale Settings path regression coverage.
- Add Code Assist helper/runtime metadata while gating account-backed models from agent-session selection until agent-side Code Assist support exists; API-key google remains session-usable.
- Document the provider split, OAuth/API-key paths, limitations, and manual verification notes.

## Verification
- npm run check
- npm run test:unit (one PR walkthrough fixture timed out during full run after merging master; targeted rerun passed)
- npm run build --silent
- npm run test:e2e:run -- tests/e2e/oauth-google-logout.spec.ts --reporter=line
- npx playwright test --config tests/playwright.config.ts tests/pr-walkthrough-panel-parity.spec.ts --grep "container-narrow panels auto-collapse" --workers 1

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
