### PR TITLE
Fix review reopen after rejection

### DIFF
--- a/docs/review-pane-signoff.md
+++ b/docs/review-pane-signoff.md
@@ -98,18 +98,30 @@ Feedback composition is deterministic:
 
 Verification sign-off approvals with no comments may omit `feedback`; the endpoint only needs `signalId`, `stepName`, and `decision: "pass"` to resolve the step.
 
-## Persistence and cleanup
+## Persistence, replay, and cleanup
 
 Sign-off review contexts persist per session in browser storage so a widget-opened sign-off review survives reloads and navigation until the user submits, dismisses, or closes it. The persisted context includes the review document, markdown, title, and source payload.
 
 Inline annotations persist through the review annotation store and are scoped by session and document title. Final comments are local drafts in the pane; submit before leaving the page if the final comment is the only rejection feedback.
+
+### Live reopen vs historical replay
+
+A `review_open` result can arrive through two paths: a fresh live event from the active agent, or historical replay/hydration while restoring chat state. The review pane intentionally treats those paths differently.
+
+- A fresh live `review_open` from the active session always opens or selects the review workspace tab, even after the previous review was approved, rejected, or otherwise submitted. The live path clears the session's submitted-review marker before opening the document so the revised review is visible immediately.
+- Historical replay and hydration still suppress submitted reviews. This prevents a page reload or reconnect from resurrecting a review the user already completed.
+- Background, cached, or non-selected sessions must not mutate active review state. Their replayed or live tool results are ignored until the session becomes active.
+
+Document opening still goes through the shared review document helpers, preserving `replace: false`, same-title replacement, persisted review documents, and side-panel workspace tab behavior.
+
+Regression coverage for this invariant lives in `tests/e2e/ui/review-pane.spec.ts`: it opens a review, rejects with feedback, verifies the tab closes, emits a revised live `review_open`, and asserts the `Review: Test Document` tab reopens with revised markdown. Fixture and unit coverage continue to own reload suppression and active-session guard behavior.
 
 Cleanup expectations:
 
 - Successful approve/reject removes the review document, clears persisted sign-off context, clears annotations for that document, and refreshes gate status for verification sign-offs.
 - Dismiss closes the current review surface and clears persisted sign-off contexts without submitting a decision.
 - Closing a tab or dismissing with unsent inline/final comments prompts before discarding them.
-- Arbitrary markdown reviews keep the existing submitted-review behavior so replayed `review_open` tool results do not reopen a review the user already submitted or dismissed.
+- Arbitrary markdown reviews keep submitted-review replay suppression so historical `review_open` tool results do not reopen a review the user already submitted or dismissed.
 
 ## Security and sanitization
 

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -2280,7 +2280,7 @@ export class RemoteAgent {
 						const tabTitle = typeof source?.title === "string" ? source.title : tab.title.replace(/^Review:\s*/, "");
 						return tabTitle === title;
 					});
-					if (!hasOpenWorkspaceTab && (!isLive || isReviewSubmitted(this._sessionId))) return;
+					if (!hasOpenWorkspaceTab && !isLive) return;
 				}
 				// If the user already submitted this review, suppress reopening it on
 				// REPLAY paths (snapshot loop / non-live message_end). The submitted

--- a/tests/e2e/mock-agent-core.mjs
+++ b/tests/e2e/mock-agent-core.mjs
@@ -477,6 +477,14 @@ export class MockAgentCore {
 				})),
 			};
 		}
+		if (lower.includes("review_open_revised")) {
+			const md = "# Test Document\n\nRevised review document after rejection.\n\n## Revised Section\n\nRevised markdown after rejected feedback should reopen the review pane.";
+			return {
+				tool: "review_open",
+				input: { title: "Test Document", markdown: md },
+				output: JSON.stringify({ action: "review_open", title: "Test Document", markdown: md, replace: true }),
+			};
+		}
 		if (lower.includes("review_open")) {
 			const md = "# Test Document\n\nThis is a test document for review.\n\n## Section One\n\nSome important text that could be commented on.\n\n## Section Two\n\nMore content here with `code examples` and details.";
 			return {

--- a/tests/e2e/ui/review-pane.spec.ts
+++ b/tests/e2e/ui/review-pane.spec.ts
@@ -53,4 +53,40 @@ test.describe("Review Pane", () => {
 			await deleteSession(sessionId);
 		}
 	});
+
+	test("reopens review pane when active agent sends revised live review_open after rejection", async ({ page }) => {
+		const sessionId = await createSession();
+		try {
+			await waitForSessionStatus(sessionId, "idle");
+			await openApp(page);
+			await goToSession(page, sessionId);
+			const pane = await openReviewDocument(page);
+
+			await pane.getByRole("textbox", { name: /final comment/i }).fill("Needs revised markdown before merge.");
+			await pane.getByRole("button", { name: "Reject" }).click();
+			await expect(
+				page.locator("user-message").filter({ hasText: /Review Rejected|Needs revised markdown before merge/i }).last(),
+				"Reject should send review feedback through the existing agent chat flow",
+			).toBeVisible({ timeout: 10_000 });
+			await waitForAgentResponse(page, { text: "OK", timeout: 15_000 });
+			await expect(reviewTab(page), "rejected review_open document should close its review tab").toHaveCount(0, { timeout: 5_000 });
+
+			await sendMessage(page, "REVIEW_OPEN_REVISED");
+			await expect(page.getByText("Done. Used review_open tool.", { exact: true })).toHaveCount(2, { timeout: 15_000 });
+
+			const reopenedTab = reviewTab(page);
+			await expect(
+				reopenedTab,
+				"fresh live review_open after rejected submission should reopen Review: Test Document tab",
+			).toHaveCount(1, { timeout: 10_000 });
+			await reopenedTab.click();
+			await expect(page.locator("review-pane"), "reopened review pane should be visible").toBeVisible({ timeout: 5_000 });
+			await expect(
+				page.locator("review-document").getByText("Revised markdown after rejected feedback should reopen the review pane.").first(),
+				"reopened review pane should display revised markdown",
+			).toBeVisible({ timeout: 5_000 });
+		} finally {
+			await deleteSession(sessionId);
+		}
+	});
 });


### PR DESCRIPTION
## Summary
- Allow fresh live active-session review_open events to reopen the review pane after a prior approve/reject submission.
- Preserve replay/hydration suppression for submitted historical review_open results and background-session isolation.
- Add browser E2E coverage for reject -> revised review_open -> reopened review tab, plus docs for the invariant.

## Validation
- npm run test:unit
- npm run test:e2e -- tests/e2e/ui/review-pane.spec.ts
- Implementation workflow gate passed build, type check, repro E2E, unit, E2E, and reviews.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)