### PR TITLE
Add per-goal worktree setup hook

### DIFF
--- a/defaults/tools/proposals/extension.ts
+++ b/defaults/tools/proposals/extension.ts
@@ -142,8 +142,8 @@ export default function (pi: ExtensionAPI) {
 				description: Type.Optional(Type.String()),
 				gates: Type.Array(Type.Any()),
 			}, { description: "Inline workflow snapshot frozen on the goal; may reference inlineRoles." })),
-			worktreeSetupCommand: Type.Optional(Type.String({ description: "Host command run once during this goal's worktree provisioning, after component setup. Runs on the host (same trust model as project worktree_setup_command); cwd is the goal worktree, env includes SOURCE_REPO + BOBBIT_GOAL_ID/BRANCH/WORKTREE_PATH." })),
-			worktreeSetupTimeoutMs: Type.Optional(Type.Integer({ minimum: 1, description: "Per-goal worktree-setup timeout override in ms (>0). Omit for the project default, else 120000." })),
+			worktreeSetupCommand: Type.Optional(Type.String({ description: "Host setup command run once after component setup." })),
+			worktreeSetupTimeoutMs: Type.Optional(Type.Integer({ minimum: 1, description: "Per-goal setup timeout override in ms." })),
 		}),
 		async execute(_id, args) {
 			// `workflow` (string id) and `inlineWorkflow` (full Workflow object)

--- a/defaults/tools/proposals/extension.ts
+++ b/defaults/tools/proposals/extension.ts
@@ -142,6 +142,8 @@ export default function (pi: ExtensionAPI) {
 				description: Type.Optional(Type.String()),
 				gates: Type.Array(Type.Any()),
 			}, { description: "Inline workflow snapshot frozen on the goal; may reference inlineRoles." })),
+			worktreeSetupCommand: Type.Optional(Type.String({ description: "Host command run once during this goal's worktree provisioning, after component setup. Runs on the host (same trust model as project worktree_setup_command); cwd is the goal worktree, env includes SOURCE_REPO + BOBBIT_GOAL_ID/BRANCH/WORKTREE_PATH." })),
+			worktreeSetupTimeoutMs: Type.Optional(Type.Integer({ minimum: 1, description: "Per-goal worktree-setup timeout override in ms (>0). Omit for the project default, else 120000." })),
 		}),
 		async execute(_id, args) {
 			// `workflow` (string id) and `inlineWorkflow` (full Workflow object)

--- a/defaults/tools/proposals/propose_goal.yaml
+++ b/defaults/tools/proposals/propose_goal.yaml
@@ -1,7 +1,7 @@
 name: propose_goal
 description: "Submit goal proposal with title, spec, workflow"
 summary: "Propose a goal for user review"
-params: [title, spec, cwd?, workflow?, options?, parentGoalId?, subgoalsAllowed?, maxNestingDepth?, divergencePolicy?, maxConcurrentChildren?, inlineRoles?, inlineWorkflow?]
+params: [title, spec, cwd?, workflow?, options?, parentGoalId?, subgoalsAllowed?, maxNestingDepth?, divergencePolicy?, maxConcurrentChildren?, inlineRoles?, inlineWorkflow?, worktreeSetupCommand?, worktreeSetupTimeoutMs?]
 provider:
   type: bobbit-extension
   extension: extension.ts
@@ -57,6 +57,20 @@ docs: >-
   on a per-spawn basis by passing their own `inlineRoles` (merged on top —
   child entries with the same name win) or `inlineWorkflow` / `workflowId`
   (replaces the inherited workflow entirely for that child).
+
+  PER-GOAL WORKTREE SETUP HOOK (`worktreeSetupCommand`, `worktreeSetupTimeoutMs`):
+  an optional host command run ONCE during this goal's worktree provisioning,
+  after any per-component worktree_setup_command hooks complete (so installed
+  dependencies are available). Use it to inject goal-specific setup — seed data,
+  enable a flag, warm a cache, build an index — without changing project config.
+  It runs on the HOST (non-sandboxed), same trust model as the project-level
+  worktree_setup_command; only set it for commands you trust. The command's cwd
+  is the goal's resolved working directory and it receives the inherited process
+  env plus SOURCE_REPO, BOBBIT_GOAL_ID, BOBBIT_GOAL_BRANCH, and
+  BOBBIT_WORKTREE_PATH. A failure marks the goal's setup as errored (the team
+  does not auto-start). `worktreeSetupTimeoutMs` is an optional integer > 0
+  overriding the per-goal setup timeout; omit it to use the project default,
+  else 120000 ms.
 
   DECISION GUIDE for the agent: ask "will any goal OTHER than this one need
   this role/workflow?". If yes → permanent (propose_role / propose_project).

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -290,6 +290,13 @@ When you list `git branch` in a Bobbit-managed repo you'll see several namespace
 
 The boot sweeper (`worktree-sweeper.ts`) reconciles these against persisted state on every server start — orphaned pool entries and renamed-but-unpersisted worktrees are cleaned up automatically. See [internals.md — Session worktrees](internals.md#session-worktrees) for the full lifecycle.
 
+**Worktree setup hooks (per-component and per-goal).** When a goal worktree is provisioned (whether freshly created or claimed from the pool), Bobbit runs setup commands on the host before the team starts:
+
+1. Each component's project-level `worktree_setup_command` (non-fatal on failure — the worktree is still used).
+2. The goal's optional **per-goal `worktreeSetupCommand`**, set at goal-creation time and run once after component setup. This one is **fatal on failure** (`setupStatus: "error"`, no auto-start) so a goal never silently starts mis-configured. The per-command timeout resolves per-goal override → project `worktree_setup_timeout_ms` → 120000 ms.
+
+Both hooks run **non-sandboxed on the host** — set them only for trusted commands. Full reference (injected env vars, timeout resolution, pool-claim behaviour, A/B-testing use case, and the global-boot-config caveat): [goals-workflows-tasks.md — Per-goal worktree setup hook](goals-workflows-tasks.md#per-goal-worktree-setup-hook).
+
 **Base ref for new worktrees.** New worktrees (session, goal, staff, pool) branch off the project's configured `base_ref` when set, otherwise off the remote primary (`origin/master`/`origin/main`) or, for local-only repos with commits, local `HEAD`. Fresh `git init` repos with unborn `HEAD` fall back to no-worktree until an initial commit is made; pool prefill skips them with the same actionable warning. A configured `base_ref` is still honored in unborn repos, while a stale configured ref fails loudly rather than silently falling back. The same value drives the `{{baseBranch}}` workflow variable and the `aheadOfPrimary`/`behindPrimary` git-status comparator. Some worktrees also use it as `@{u}` for local status, but Bobbit-owned branch publication never relies on upstream tracking: it pushes explicit destination refspecs such as `<branch>:refs/heads/<branch>` or `HEAD:refs/heads/<branch>`. `{{master}}` keeps resolving to the project primary independently. Team-member worktrees branch off the goal branch by hierarchical design and are not affected. Full semantics, validation rules, and error inventory: [design/base-ref.md](design/base-ref.md).
 
 ### Worktree-stash hazard — never `git stash` inside a session worktree

--- a/docs/goals-workflows-tasks.md
+++ b/docs/goals-workflows-tasks.md
@@ -14,6 +14,86 @@ Goals can run in **team mode**, where a Team Lead agent orchestrates multiple ro
 
 `autoStartTeam` is **not** a standing restart policy. On gateway/server restart, Bobbit restores persisted active teams and re-subscribes their existing sessions, but it does not create a new Team Lead for an existing goal that has no active team. A goal created with `autoStartTeam: false`, or a goal whose team was later stopped with `teardownTeam`, remains teamless across restart; once setup is ready the UI should continue to offer manual "Start Team". If creation-time auto-start fails but the worktree succeeded, the error is logged and the worktree remains usable for that same manual start path.
 
+### Per-goal worktree setup hook
+
+A goal can carry an **optional per-goal worktree setup command** that runs once while its worktree is being provisioned. This is distinct from the per-component `worktree_setup_command` (set in project config, identical for every goal in the project): the per-goal hook is supplied **at goal-creation time** and is unique to that one goal.
+
+**Why it exists.** The motivating use case is **A/B testing Bobbit configurations** — spin up two otherwise-identical goals for the same task where one goal's setup script configures a feature (e.g. building a knowledge-graph index) and the other does not, so you can measure the cost / token / time delta attributable to that feature. But the hook is **general-purpose**: any goal can inject any setup script — seed data, enable a flag, install an extra tool, warm a cache, build an index — without editing project config.
+
+The two fields live on `PersistedGoal` (`src/server/agent/goal-store.ts`) and persist in `goals.json`:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `worktreeSetupCommand` | `string` | Host command run once after component setup. Blank/absent ⇒ no hook. |
+| `worktreeSetupTimeoutMs` | positive integer (ms) | Per-goal timeout override. Absent ⇒ default resolution (see below). |
+
+Both are **optional and backward-compatible**: a goal without them behaves exactly as before. The goal-store load path drops a `worktreeSetupTimeoutMs` that is not a finite positive integer, so existing persisted goals load cleanly.
+
+#### When and where it runs
+
+The command runs **once during provisioning**, in `GoalManager.setupWorktree` (via `runGoalSetup` in `src/server/skills/worktree-setup.ts`):
+
+- **After** any per-component `worktree_setup_command` hooks complete, so component dependencies are already installed.
+- **Also after a pool worktree is claimed.** The pre-built worktree pool cannot run a goal-specific script, so the per-goal hook fires on the pool-claim path too — it is the one setup step the pool cannot pre-bake.
+- **Once only.** It runs at provisioning time, outside the worktree-creation retry loop, and is **never re-run** on respawn or server restart.
+
+**Working directory:** the goal's resolved `cwd` — the offset-applied worktree path where the team will actually work (worktree root plus any project subdirectory offset).
+
+**Environment:** the inherited server process env, plus:
+
+| Variable | Value |
+|---|---|
+| `SOURCE_REPO` | the project's primary checkout root (`goal.repoPath`) |
+| `BOBBIT_GOAL_ID` | the goal id |
+| `BOBBIT_GOAL_BRANCH` | the goal branch (`goal/<slug>-<id>`) |
+| `BOBBIT_WORKTREE_PATH` | the goal's worktree root (before the subdirectory offset) |
+
+**Security / trust model:** the command runs on the **host, non-sandboxed** — exactly like the per-component `worktree_setup_command`. It is supplied by the goal creator at creation time, through the same goal-creation permissions; this does not widen who can run host commands. Only set a hook for commands you trust.
+
+#### Timeout resolution
+
+The hardcoded 120s limit is gone. The per-command timeout is resolved by a single helper (`resolveSetupTimeoutMs`) used for both per-component and per-goal setup, in this order:
+
+1. **Per-goal override** — `worktreeSetupTimeoutMs` on the goal, if a finite positive integer.
+2. **Project default** — the project config key `worktree_setup_timeout_ms` (number or numeric string), if a finite positive integer.
+3. **Default** — `DEFAULT_WORKTREE_SETUP_TIMEOUT_MS` = **120000 ms** (unchanged when nothing is set).
+
+Invalid, zero, negative, non-integer, or non-finite values at any level fall through to the next.
+
+#### Failure handling — fatal, unlike component setup
+
+Per-component setup failures are **non-fatal**: they are logged as warnings and the worktree is still used (a component install that partially fails should not block the goal). This semantics is unchanged.
+
+The **per-goal** hook is deliberately stricter. A failed per-goal setup means the goal would run mis-configured — fatal for A/B integrity. So a failure (non-zero exit or timeout) is **fatal**: `GoalManager` records `setupStatus: "error"` with a descriptive `setupError` (`Per-goal worktree setup failed: …`), surfaced in the UI, and the team does **not** auto-start. The goal can be re-driven through the normal setup retry path (`retrySetup`).
+
+#### Creation surfaces
+
+The fields are accepted through every goal-creation path:
+
+- **`propose_goal` tool** — optional `worktreeSetupCommand` and `worktreeSetupTimeoutMs` params (`defaults/tools/proposals/propose_goal.yaml`). The seeded proposal carries them through assistant acceptance, not just title/spec/cwd/workflow.
+- **REST `POST /api/goals`** — accepts either camelCase (`worktreeSetupCommand` / `worktreeSetupTimeoutMs`) or snake_case (`worktree_setup_command` / `worktree_setup_timeout_ms`); the command is trimmed and passed only when non-empty, the timeout only when a finite positive integer.
+- **Goal-creation dialog UI** — a **Setup command** textarea plus an optional timeout (ms) input in the goal proposal panel. An empty command means no hook; an empty timeout means default resolution. The values persist across reload.
+
+#### A/B testing example
+
+Create two goals for the same task and spec. Goal A enables the feature under test; Goal B is the control with no hook:
+
+```text
+# Goal A — feature enabled
+worktreeSetupCommand: "./scripts/build-index.sh"   # seed/enable the feature
+
+# Goal B — control
+worktreeSetupCommand: <empty>                       # no hook, baseline config
+```
+
+Both goals run the identical task; comparing their cost / token / time totals isolates the delta attributable to the feature the hook configured.
+
+#### Caveat — what the hook can and cannot reconfigure
+
+The hook reliably affects anything Bobbit reads **from the goal worktree or project config at goal/session start** — seed data, repo-local flags, generated indexes, installed tools, warmed caches.
+
+It does **not** retroactively change **globally boot-loaded configuration** that the gateway reads once at server boot (e.g. provider/credential config loaded into the running process). A setup script that writes such global config won't take effect for an already-running server. Making that class of config goal-scoped or reloadable is future work, not part of this hook.
+
 ### Workflows
 
 A **workflow** is a reusable template that defines which gates a goal must pass, their dependency relationships (a DAG), and verification configs. Workflows live **inline in `project.yaml::workflows`** — the project assistant generates a bespoke block per project from [defaults/workflow-authoring-guide.md](../defaults/workflow-authoring-guide.md). The MD authoring guide is the single source of truth for workflow patterns; the runtime never reads it.

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -1575,8 +1575,8 @@ export async function fetchGoalGitStatus(
 // GOAL API
 // ============================================================================
 
-export async function createGoal(title: string, cwd: string, opts?: { spec?: string; workflowId?: string; reattemptOf?: string; sandboxed?: boolean; projectId?: string; enabledOptionalSteps?: string[]; autoStartTeam?: boolean; workflow?: unknown; inlineRoles?: Record<string, unknown>; subgoalsAllowed?: boolean; maxNestingDepth?: number; divergencePolicy?: "strict" | "balanced" | "autonomous"; maxConcurrentChildren?: number; parentGoalId?: string }): Promise<Goal | null> {
-	const { spec = "", workflowId, reattemptOf, sandboxed, projectId, enabledOptionalSteps, autoStartTeam, workflow, inlineRoles, subgoalsAllowed, maxNestingDepth, divergencePolicy, maxConcurrentChildren, parentGoalId } = opts ?? {};
+export async function createGoal(title: string, cwd: string, opts?: { spec?: string; workflowId?: string; reattemptOf?: string; sandboxed?: boolean; projectId?: string; enabledOptionalSteps?: string[]; autoStartTeam?: boolean; workflow?: unknown; inlineRoles?: Record<string, unknown>; subgoalsAllowed?: boolean; maxNestingDepth?: number; divergencePolicy?: "strict" | "balanced" | "autonomous"; maxConcurrentChildren?: number; parentGoalId?: string; worktreeSetupCommand?: string; worktreeSetupTimeoutMs?: number }): Promise<Goal | null> {
+	const { spec = "", workflowId, reattemptOf, sandboxed, projectId, enabledOptionalSteps, autoStartTeam, workflow, inlineRoles, subgoalsAllowed, maxNestingDepth, divergencePolicy, maxConcurrentChildren, parentGoalId, worktreeSetupCommand, worktreeSetupTimeoutMs } = opts ?? {};
 	try {
 		const body: Record<string, any> = { title, cwd, spec, team: true, worktree: true };
 		if (workflowId) body.workflowId = workflowId;
@@ -1594,6 +1594,16 @@ export async function createGoal(title: string, cwd: string, opts?: { spec?: str
 		if (divergencePolicy !== undefined) body.divergencePolicy = divergencePolicy;
 		if (maxConcurrentChildren !== undefined) body.maxConcurrentChildren = maxConcurrentChildren;
 		if (parentGoalId) body.parentGoalId = parentGoalId;
+		// Per-goal worktree setup hook: forward only when meaningful. An empty
+		// command and a non-positive/non-finite timeout are dropped so the goal
+		// resolves to default (no hook; 120s timeout) — matching the server's
+		// own parse-and-skip semantics.
+		if (typeof worktreeSetupCommand === "string" && worktreeSetupCommand.trim() !== "") {
+			body.worktreeSetupCommand = worktreeSetupCommand.trim();
+		}
+		if (typeof worktreeSetupTimeoutMs === "number" && Number.isInteger(worktreeSetupTimeoutMs) && worktreeSetupTimeoutMs > 0) {
+			body.worktreeSetupTimeoutMs = worktreeSetupTimeoutMs;
+		}
 		const res = await gatewayFetch("/api/goals", {
 			method: "POST",
 			body: JSON.stringify(body),

--- a/src/app/proposal-panels.ts
+++ b/src/app/proposal-panels.ts
@@ -469,6 +469,15 @@ interface GoalFormConfig {
 	autoStartTeam: boolean;
 	onAutoStartTeamChange: (e: Event) => void;
 
+	// ---- Per-goal worktree setup hook ----
+	/** Current value of the optional per-goal worktree setup command. */
+	worktreeSetupCommand: string;
+	/** Current value of the optional per-goal setup timeout (ms), as a raw
+	 *  string for input round-tripping. Empty = use the default. */
+	worktreeSetupTimeoutMs: string;
+	onWorktreeSetupCommandChange: (e: Event) => void;
+	onWorktreeSetupTimeoutChange: (e: Event) => void;
+
 	// CWD combobox state
 	cwdDropdownOpen: boolean;
 	cwdHighlightIndex: number;
@@ -561,6 +570,19 @@ interface GoalFormConfig {
 	roleListLoading?: boolean;
 	availableTools?: ToolInfo[];
 	groupPolicies?: Record<string, string>;
+}
+
+/**
+ * Parse the per-goal worktree-setup timeout input (a raw string) into a number
+ * suitable for createGoal. Returns undefined for blank/invalid values so the
+ * goal falls back to the project default / 120s. Only finite positive integers
+ * are forwarded.
+ */
+function parseSetupTimeoutMs(raw: string): number | undefined {
+	const t = raw.trim();
+	if (t === "") return undefined;
+	const n = Number(t);
+	return Number.isInteger(n) && n > 0 ? n : undefined;
 }
 
 /** Compute a goal's depth (1-based) by walking parentGoalId links. */
@@ -983,6 +1005,31 @@ function renderGoalForm(config: GoalFormConfig) {
 				`;})}
 				${!tabbed ? renderSubgoalsToggle(config) : ""}
 			</div>
+			<div class="flex flex-col gap-1.5" data-testid="goal-form-worktree-setup">
+				<div class="flex items-center gap-1.5">
+					<label class="text-xs text-muted-foreground font-medium">Setup command</label>
+					<span title="Runs once on the HOST during worktree provisioning, after component setup — same trust model as the project worktree setup command. cwd is the goal worktree; env includes SOURCE_REPO, BOBBIT_GOAL_ID, BOBBIT_GOAL_BRANCH, BOBBIT_WORKTREE_PATH. Optional."
+						class="text-[9px] text-muted-foreground cursor-help">ⓘ</span>
+				</div>
+				<textarea
+					data-testid="goal-form-worktree-setup-command"
+					class="min-h-[44px] p-2 text-xs font-mono rounded-md border border-border bg-background text-foreground resize-y focus:outline-none focus:ring-1 focus:ring-ring"
+					placeholder="Optional host command, e.g. ./scripts/seed.sh"
+					.value=${config.worktreeSetupCommand}
+					@input=${config.onWorktreeSetupCommandChange}
+				></textarea>
+				<p class="text-[10px] text-muted-foreground opacity-70">Runs on the host during provisioning — trusted, same as project worktree setup.</p>
+				<div class="flex items-center gap-2">
+					<label class="text-xs text-muted-foreground font-medium">Timeout (ms)</label>
+					<input type="number" min="1" step="1"
+						data-testid="goal-form-worktree-setup-timeout-ms"
+						class="w-28 text-xs px-2 py-1 rounded-md border border-border bg-background text-foreground focus:outline-none focus:ring-1 focus:ring-ring [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+						placeholder="default"
+						.value=${config.worktreeSetupTimeoutMs}
+						@input=${config.onWorktreeSetupTimeoutChange}
+					/>
+				</div>
+			</div>
 			<div class="flex-1 flex flex-col min-h-0">
 				<div class="flex items-center justify-between mb-1.5">
 					<div class="flex items-center gap-1">
@@ -1402,6 +1449,8 @@ function goalPreviewPanel() {
 				projectId,
 				enabledOptionalSteps,
 				autoStartTeam,
+				worktreeSetupCommand: state.previewWorktreeSetupCommand.trim() || undefined,
+				worktreeSetupTimeoutMs: parseSetupTimeoutMs(state.previewWorktreeSetupTimeoutMs),
 			});
 		} catch (err) {
 			const { message, code, stack } = errorDetails(err);
@@ -1432,6 +1481,8 @@ function goalPreviewPanel() {
 		_goalSandboxed = false;
 		_goalAutoStartTeam = true;
 		_assistantEnabledOptionalSteps = [];
+		state.previewWorktreeSetupCommand = "";
+		state.previewWorktreeSetupTimeoutMs = "";
 		if (sessionId) {
 			deleteGoalDraft(sessionId);
 		}
@@ -1527,6 +1578,18 @@ function goalPreviewPanel() {
 				onOptionalStepsChange: (steps) => { _assistantEnabledOptionalSteps = steps; renderApp(); },
 				autoStartTeam: _goalAutoStartTeam,
 				onAutoStartTeamChange: (e: Event) => { _goalAutoStartTeam = (e.target as HTMLInputElement).checked; renderApp(); },
+				worktreeSetupCommand: state.previewWorktreeSetupCommand,
+				worktreeSetupTimeoutMs: state.previewWorktreeSetupTimeoutMs,
+				onWorktreeSetupCommandChange: (e: Event) => {
+					state.previewWorktreeSetupCommand = (e.target as HTMLTextAreaElement).value;
+					const sid = activeSessionId();
+					if (sid) saveGoalDraft(sid);
+				},
+				onWorktreeSetupTimeoutChange: (e: Event) => {
+					state.previewWorktreeSetupTimeoutMs = (e.target as HTMLInputElement).value;
+					const sid = activeSessionId();
+					if (sid) saveGoalDraft(sid);
+				},
 				cwdDropdownOpen: state.cwdDropdownOpen,
 				cwdHighlightIndex: state.cwdHighlightIndex,
 				onCwdToggle: (open) => { state.cwdDropdownOpen = open; renderApp(); },
@@ -2608,6 +2671,10 @@ let _proposalSaving = false;
 let _proposalSandboxed = false;
 let _proposalAutoStartTeam = true;
 let _proposalEnabledOptionalSteps: string[] = [];
+// Per-goal worktree setup hook. Initialized from proposal frontmatter in
+// syncProposalFormState; stored as raw strings for input round-tripping.
+let _proposalWorktreeSetupCommand = "";
+let _proposalWorktreeSetupTimeoutMs = "";
 let _proposalInitializedFrom: string | null = null;
 // Per-goal subgoal controls. null means "inherit system preference" — only
 // forwarded to createGoal when the user actually touched the control.
@@ -2798,6 +2865,7 @@ function syncProposalFormState(): void {
 		parentGoalId?: string; inlineWorkflow?: Workflow; inlineRoles?: Record<string, RoleData>;
 		subgoalsAllowed?: boolean; maxNestingDepth?: number;
 		divergencePolicy?: "strict" | "balanced" | "autonomous"; maxConcurrentChildren?: number;
+		worktreeSetupCommand?: string; worktreeSetupTimeoutMs?: number;
 	};
 	if (!proposal) return;
 
@@ -2828,7 +2896,7 @@ function syncProposalFormState(): void {
 	}
 
 	// Use a simple identity check to avoid re-initializing on every render
-	const key = `${proposal.title}|${proposal.spec}|${proposal.cwd || ""}|${proposal.workflow || ""}|${proposal.options || ""}|${proposal.parentGoalId || ""}|${proposal.subgoalsAllowed ?? ""}|${proposal.maxNestingDepth ?? ""}|${proposal.divergencePolicy ?? ""}|${proposal.maxConcurrentChildren ?? ""}`;
+	const key = `${proposal.title}|${proposal.spec}|${proposal.cwd || ""}|${proposal.workflow || ""}|${proposal.options || ""}|${proposal.parentGoalId || ""}|${proposal.subgoalsAllowed ?? ""}|${proposal.maxNestingDepth ?? ""}|${proposal.divergencePolicy ?? ""}|${proposal.maxConcurrentChildren ?? ""}|${proposal.worktreeSetupCommand ?? ""}|${proposal.worktreeSetupTimeoutMs ?? ""}`;
 	if (_proposalInitializedFrom === key) return;
 	_proposalInitializedFrom = key;
 	_proposalTitle = proposal.title;
@@ -2859,6 +2927,10 @@ function syncProposalFormState(): void {
 		? proposal.divergencePolicy
 		: null;
 	_proposalMaxConcurrentChildren = typeof proposal.maxConcurrentChildren === "number" ? proposal.maxConcurrentChildren : null;
+	// Per-goal worktree setup hook: seed the dialog controls from frontmatter so
+	// a propose_goal-seeded proposal pre-fills the inputs. Absent => empty.
+	_proposalWorktreeSetupCommand = typeof proposal.worktreeSetupCommand === "string" ? proposal.worktreeSetupCommand : "";
+	_proposalWorktreeSetupTimeoutMs = typeof proposal.worktreeSetupTimeoutMs === "number" ? String(proposal.worktreeSetupTimeoutMs) : "";
 }
 
 function goalProposalPanel() {
@@ -2974,6 +3046,8 @@ function goalProposalPanel() {
 					maxNestingDepth: maxNestingDepthField,
 					divergencePolicy: divergencePolicyField,
 					maxConcurrentChildren: maxConcurrentChildrenField,
+					worktreeSetupCommand: _proposalWorktreeSetupCommand.trim() || undefined,
+					worktreeSetupTimeoutMs: parseSetupTimeoutMs(_proposalWorktreeSetupTimeoutMs),
 				});
 			} catch (err) {
 				const { message, code, stack } = errorDetails(err);
@@ -2998,6 +3072,8 @@ function goalProposalPanel() {
 			_proposalMaxNestingDepth = null;
 			_proposalDivergencePolicy = null;
 			_proposalMaxConcurrentChildren = null;
+			_proposalWorktreeSetupCommand = "";
+			_proposalWorktreeSetupTimeoutMs = "";
 			resetProposalTabsState();
 			await closeCurrentProposalPanel("goal", proposalSessionId);
 			if (proposalSessionId) void deleteProposalFile(proposalSessionId, "goal");
@@ -3035,6 +3111,8 @@ function goalProposalPanel() {
 		_proposalMaxNestingDepth = null;
 		_proposalDivergencePolicy = null;
 		_proposalMaxConcurrentChildren = null;
+		_proposalWorktreeSetupCommand = "";
+		_proposalWorktreeSetupTimeoutMs = "";
 		resetProposalTabsState();
 		// Persist dismiss so it survives reconnect
 		const sid = proposalSessionId;
@@ -3085,6 +3163,10 @@ function goalProposalPanel() {
 		onOptionalStepsChange: (steps) => { _proposalEnabledOptionalSteps = steps; renderApp(); },
 		autoStartTeam: _proposalAutoStartTeam,
 		onAutoStartTeamChange: (e: Event) => { _proposalAutoStartTeam = (e.target as HTMLInputElement).checked; renderApp(); },
+		worktreeSetupCommand: _proposalWorktreeSetupCommand,
+		worktreeSetupTimeoutMs: _proposalWorktreeSetupTimeoutMs,
+		onWorktreeSetupCommandChange: (e: Event) => { _proposalWorktreeSetupCommand = (e.target as HTMLTextAreaElement).value; },
+		onWorktreeSetupTimeoutChange: (e: Event) => { _proposalWorktreeSetupTimeoutMs = (e.target as HTMLInputElement).value; },
 		cwdDropdownOpen: _proposalCwdDropdownOpen,
 		cwdHighlightIndex: _proposalCwdHighlightIndex,
 		onCwdToggle: (open) => { _proposalCwdDropdownOpen = open; renderApp(); },

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -485,7 +485,7 @@ export class RemoteAgent {
 	 *  `streaming === true` means input is still arriving; consumers must keep
 	 *  their `*Edited` gating intact and must not commit destructive actions on
 	 *  streaming-mode fires. */
-	onGoalProposal?: (proposal: { title: string; spec: string; cwd?: string; workflow?: string }, streaming: boolean) => void;
+	onGoalProposal?: (proposal: { title: string; spec: string; cwd?: string; workflow?: string; worktreeSetupCommand?: string; worktreeSetupTimeoutMs?: number }, streaming: boolean) => void;
 	/** Callback fired when a role proposal is detected in an assistant message. */
 	onRoleProposal?: (proposal: { name: string; label: string; prompt: string; tools: string; accessory: string }, streaming: boolean) => void;
 	/** Callback fired when a tool proposal is detected in an assistant message. */

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -415,6 +415,8 @@ const goalDraft = createDraftManager({
 		previewCwdEdited: state.previewCwdEdited,
 		hasReceivedProposal: state.assistantHasProposal,
 		goalAssistantTab: state.assistantTab,
+		previewWorktreeSetupCommand: state.previewWorktreeSetupCommand,
+		previewWorktreeSetupTimeoutMs: state.previewWorktreeSetupTimeoutMs,
 	}),
 	restore: (_sessionId, draft: any) => {
 		let dismissed = false;
@@ -469,6 +471,8 @@ const goalDraft = createDraftManager({
 			state.previewSpecEdited = false;
 			state.previewCwdEdited = draft.previewCwdEdited ?? false;
 			state.assistantHasProposal = false;
+			state.previewWorktreeSetupCommand = draft.previewWorktreeSetupCommand ?? "";
+			state.previewWorktreeSetupTimeoutMs = draft.previewWorktreeSetupTimeoutMs ?? "";
 		} else {
 			state.previewTitle = draft.previewTitle ?? "";
 			state.previewSpec = draft.previewSpec ?? "";
@@ -478,6 +482,8 @@ const goalDraft = createDraftManager({
 			state.previewSpecEdited = draft.previewSpecEdited ?? false;
 			state.previewCwdEdited = draft.previewCwdEdited ?? false;
 			state.assistantHasProposal = draft.hasReceivedProposal ?? false;
+			state.previewWorktreeSetupCommand = draft.previewWorktreeSetupCommand ?? "";
+			state.previewWorktreeSetupTimeoutMs = draft.previewWorktreeSetupTimeoutMs ?? "";
 		}
 		state.assistantTab = draft.goalAssistantTab ?? "chat";
 	},
@@ -1109,6 +1115,8 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 		state.previewTitle = "";
 		state.previewSpec = "";
 		state.previewCwd = "";
+		state.previewWorktreeSetupCommand = "";
+		state.previewWorktreeSetupTimeoutMs = "";
 		// Restore previewProjectId from the session record on fast-path switch-back.
 		// The draft-restore on the slow path has a matching fallback at ~line 1488;
 		// without this, clicking "Create Goal" in the proposal form after switching
@@ -2188,6 +2196,8 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 					state.previewTitle = "";
 					state.previewCwd = "";
 					state.previewSpec = "";
+					state.previewWorktreeSetupCommand = "";
+					state.previewWorktreeSetupTimeoutMs = "";
 					state.previewTitleEdited = false;
 					state.previewCwdEdited = false;
 					state.previewSpecEdited = false;

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -507,14 +507,34 @@ export function deleteGoalDraft(sessionId: string): void { goalDraft.delete(sess
  * next fast-path restore is correct. Returns true if a slot for this session was
  * reconciled.
  */
+/**
+ * Mirror the optional per-goal worktree-setup fields from a proposal/slot into
+ * the legacy form-mirror state (stored as strings for direct <input>/<textarea>
+ * round-tripping). Shared by all goal-proposal mirror paths so a propose_goal-
+ * seeded assistant proposal carries `worktreeSetupCommand` /
+ * `worktreeSetupTimeoutMs` through acceptance, not just title/spec/cwd/workflow.
+ */
+function mirrorGoalSetupFields(src: { worktreeSetupCommand?: unknown; worktreeSetupTimeoutMs?: unknown }): void {
+	if (typeof src.worktreeSetupCommand === "string") {
+		state.previewWorktreeSetupCommand = src.worktreeSetupCommand;
+	}
+	const t = src.worktreeSetupTimeoutMs;
+	if (typeof t === "number" && Number.isFinite(t)) {
+		state.previewWorktreeSetupTimeoutMs = String(t);
+	} else if (typeof t === "string" && t.trim() !== "") {
+		state.previewWorktreeSetupTimeoutMs = t.trim();
+	}
+}
+
 function reconcileGoalSlotIntoFormMirror(sessionId: string): boolean {
 	const goalSlot = state.activeProposals.goal;
 	if (!goalSlot || goalSlot.sessionId !== sessionId) return false;
-	const g = goalSlot.fields as { title?: string; spec?: string; cwd?: string; workflow?: string };
+	const g = goalSlot.fields as { title?: string; spec?: string; cwd?: string; workflow?: string; worktreeSetupCommand?: unknown; worktreeSetupTimeoutMs?: unknown };
 	if (!state.previewTitleEdited && typeof g.title === "string") state.previewTitle = g.title;
 	if (!state.previewSpecEdited && typeof g.spec === "string") state.previewSpec = g.spec;
 	if (!state.previewCwdEdited && g.cwd) state.previewCwd = g.cwd;
 	if (g.workflow) setSelectedWorkflowId(g.workflow);
+	mirrorGoalSetupFields(g);
 	state.assistantHasProposal = true;
 	if (state.assistantTab === "chat" && !isDesktop()) state.assistantTab = "preview";
 	saveGoalDraft(sessionId);
@@ -1557,6 +1577,7 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 					if (!state.previewCwdEdited && proposal.cwd) state.previewCwd = proposal.cwd;
 					if (!state.previewSpecEdited) state.previewSpec = proposal.spec;
 					if (proposal.workflow) setSelectedWorkflowId(proposal.workflow);
+					mirrorGoalSetupFields(proposal);
 				}
 				state.assistantHasProposal = true;
 				if (state.assistantTab === "chat" && !isDesktop()) {
@@ -1800,11 +1821,12 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			// callback so in-progress user edits are never clobbered. Runs on every
 			// non-dismissed goal proposal (first-emit, revision, edit, rehydrate).
 			if (type === "goal" && state.assistantType === "goal") {
-				const g = merged as { title?: string; spec?: string; cwd?: string; workflow?: string };
+				const g = merged as { title?: string; spec?: string; cwd?: string; workflow?: string; worktreeSetupCommand?: unknown; worktreeSetupTimeoutMs?: unknown };
 				if (!state.previewTitleEdited && typeof g.title === "string") state.previewTitle = g.title;
 				if (!state.previewSpecEdited && typeof g.spec === "string") state.previewSpec = g.spec;
 				if (!state.previewCwdEdited && g.cwd) state.previewCwd = g.cwd;
 				if (g.workflow) setSelectedWorkflowId(g.workflow);
+				mirrorGoalSetupFields(g);
 				saveGoalDraft(sessionId);
 			}
 			renderApp();

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -101,6 +101,11 @@ export interface Goal {
 	workflowId?: string;
 	setupStatus?: "ready" | "preparing" | "error";
 	setupError?: string;
+	/** Optional host command run once after component setup during this goal's
+	 *  worktree provisioning. */
+	worktreeSetupCommand?: string;
+	/** Optional per-goal worktree-setup timeout override in milliseconds. */
+	worktreeSetupTimeoutMs?: number;
 	archived?: boolean;
 	archivedAt?: number;
 	/** If this goal is a re-attempt of another goal, the original goal's ID */
@@ -395,6 +400,10 @@ export const state = {
 	previewSpecEdited: false,
 	hasReceivedProposal: false,
 	previewProjectId: "" as string,
+	// Per-goal worktree setup hook (assistant goal-draft flow). Stored as strings
+	// for direct <input>/<textarea> round-tripping; parsed/validated at submit.
+	previewWorktreeSetupCommand: "",
+	previewWorktreeSetupTimeoutMs: "",
 	previewSpecEditMode: false,
 	cwdDropdownOpen: false,
 	cwdHighlightIndex: -1,

--- a/src/server/agent/goal-manager.ts
+++ b/src/server/agent/goal-manager.ts
@@ -14,8 +14,16 @@ import type { TeamStore } from "./team-store.js";
 import type { SessionStore } from "./session-store.js";
 import { isWorktreePathReferencedByLiveSession, type WorktreeReferenceRecord } from "./worktree-reference-guard.js";
 import { cleanupGateDiagnosticsForGoal } from "./gate-diagnostics-cleanup.js";
+import { runGoalSetup, resolveSetupTimeoutMs } from "../skills/worktree-setup.js";
 
 const pExecFile = promisify(execFileCb);
+
+/** Final worktree paths produced by provisioning, before the per-goal hook + ready flip. */
+type ProvisionedWorktree = {
+	worktreePath: string;
+	cwd: string;
+	repoWorktrees?: Record<string, string>;
+};
 
 /**
  * Sanitize a goal title into a valid git branch name.
@@ -208,6 +216,17 @@ export class GoalManager {
 	}
 
 	/**
+	 * Wire a project-level default worktree-setup timeout resolver. Returns the
+	 * project's `worktree_setup_timeout_ms` (number or numeric string, or
+	 * undefined). Used as the middle tier in `resolveSetupTimeoutMs` between a
+	 * per-goal override and the 120s default.
+	 */
+	private worktreeSetupTimeoutResolver?: (projectId: string) => number | string | undefined;
+	setWorktreeSetupTimeoutResolver(resolver: (projectId: string) => number | string | undefined): void {
+		this.worktreeSetupTimeoutResolver = resolver;
+	}
+
+	/**
 	 * On startup, scan for goals stuck in setupStatus === "preparing"
 	 * and mark them as "error" (setup was interrupted by server restart).
 	 */
@@ -231,8 +250,8 @@ export class GoalManager {
 	 * Create a goal instantly — persists to disk and returns immediately.
 	 * Does NOT create the worktree. Call setupWorktree() separately after responding.
 	 */
-	async createGoal(title: string, cwd: string, opts?: { spec?: string; workflowId?: string; workflowStore?: WorkflowStore; resolvedWorkflow?: Workflow; sandboxed?: boolean; enabledOptionalSteps?: string[]; projectId?: string; parentGoalId?: string; inlineRoles?: Record<string, import("./role-store.js").Role>; subgoalsAllowed?: boolean; maxNestingDepth?: number; divergencePolicy?: "strict" | "balanced" | "autonomous"; maxConcurrentChildren?: number }): Promise<PersistedGoal> {
-		const { spec = "", workflowId, workflowStore = this.workflowStore, resolvedWorkflow, sandboxed, enabledOptionalSteps, projectId, parentGoalId, inlineRoles, subgoalsAllowed, maxNestingDepth, divergencePolicy, maxConcurrentChildren } = opts ?? {};
+	async createGoal(title: string, cwd: string, opts?: { spec?: string; workflowId?: string; workflowStore?: WorkflowStore; resolvedWorkflow?: Workflow; sandboxed?: boolean; enabledOptionalSteps?: string[]; projectId?: string; parentGoalId?: string; inlineRoles?: Record<string, import("./role-store.js").Role>; subgoalsAllowed?: boolean; maxNestingDepth?: number; divergencePolicy?: "strict" | "balanced" | "autonomous"; maxConcurrentChildren?: number; worktreeSetupCommand?: string; worktreeSetupTimeoutMs?: number }): Promise<PersistedGoal> {
+		const { spec = "", workflowId, workflowStore = this.workflowStore, resolvedWorkflow, sandboxed, enabledOptionalSteps, projectId, parentGoalId, inlineRoles, subgoalsAllowed, maxNestingDepth, divergencePolicy, maxConcurrentChildren, worktreeSetupCommand, worktreeSetupTimeoutMs } = opts ?? {};
 		const team = true;
 		const worktree = true;
 		const now = Date.now();
@@ -309,6 +328,17 @@ export class GoalManager {
 		if (subgoalsAllowed !== undefined) goal.subgoalsAllowed = subgoalsAllowed;
 		if (maxNestingDepth !== undefined && Number.isFinite(maxNestingDepth)) {
 			goal.maxNestingDepth = maxNestingDepth;
+		}
+
+		// Per-goal worktree setup hook. Only persist a trimmed non-empty command
+		// and a finite positive integer timeout override; absent fields preserve
+		// today's behaviour (no hook, default timeout resolution).
+		if (typeof worktreeSetupCommand === "string") {
+			const trimmed = worktreeSetupCommand.trim();
+			if (trimmed) goal.worktreeSetupCommand = trimmed;
+		}
+		if (worktreeSetupTimeoutMs !== undefined && Number.isFinite(worktreeSetupTimeoutMs) && worktreeSetupTimeoutMs > 0) {
+			goal.worktreeSetupTimeoutMs = Math.floor(worktreeSetupTimeoutMs);
 		}
 
 		// Root-only orchestration policy. divergencePolicy and
@@ -434,6 +464,86 @@ export class GoalManager {
 		// worktreePath (repo root level) and goal.cwd (which may include offset).
 		const preliminaryOffset = goal.worktreePath ? path.relative(goal.worktreePath, goal.cwd) : "";
 
+		// Provision the worktree (pool claim, or create + per-component setup).
+		// _provisionGoalWorktree owns the retry loop; the per-goal hook runs ONCE
+		// afterward, outside that loop, so a hook failure never re-creates the
+		// worktree or re-runs the command.
+		const provisioned = await this._provisionGoalWorktree(goal, preliminaryOffset);
+		if (provisioned === "no-worktree") return;
+
+		// Per-goal setup runs once, after the final worktreePath/cwd are known.
+		// Fatal: on failure it sets setupStatus:"error" and rethrows so the goal
+		// never auto-starts mis-configured.
+		await this.runPerGoalSetupOrFail(goal, provisioned.worktreePath, provisioned.cwd);
+
+		this.store.update(goal.id, {
+			worktreePath: provisioned.worktreePath,
+			cwd: provisioned.cwd,
+			repoWorktrees: provisioned.repoWorktrees,
+			setupStatus: "ready",
+			setupError: undefined,
+		});
+		console.log(`[goal-manager] Worktree ready for goal "${goal.title}": ${provisioned.worktreePath} (branch: ${goal.branch})`);
+	}
+
+	/**
+	 * Resolve the worktree-setup timeout: per-goal override → project
+	 * `worktree_setup_timeout_ms` → the 120s default. Single source of truth
+	 * for both per-component and per-goal setup timeouts.
+	 */
+	private resolveGoalSetupTimeout(goal: PersistedGoal): number {
+		const projectTimeoutMs = goal.projectId && this.worktreeSetupTimeoutResolver
+			? this.worktreeSetupTimeoutResolver(goal.projectId)
+			: undefined;
+		return resolveSetupTimeoutMs({ goalTimeoutMs: goal.worktreeSetupTimeoutMs, projectTimeoutMs });
+	}
+
+	/**
+	 * Run the optional per-goal worktree setup command exactly once. A failure
+	 * is fatal: record setupStatus:"error" with a descriptive setupError and
+	 * rethrow (blocking auto-start). Runs OUTSIDE the provisioning retry loop so
+	 * the command is never re-invoked.
+	 */
+	private async runPerGoalSetupOrFail(goal: PersistedGoal, worktreePath: string, cwd: string): Promise<void> {
+		try {
+			const timeoutMs = this.resolveGoalSetupTimeout(goal);
+			const { execShellCommand } = await import("./shell-util.js");
+			await runGoalSetup({
+				goalId: goal.id,
+				branch: goal.branch!,
+				worktreePath,
+				cwd,
+				primaryWorktreeRoot: goal.repoPath!,
+				command: goal.worktreeSetupCommand,
+				timeoutMs,
+				// Same resolved timeout under the inner shell timeout — a longer
+				// override must NOT be killed early by a hardcoded inner limit.
+				exec: async (cmd, execCwd, env) => {
+					await execShellCommand(cmd, { cwd: execCwd, env, timeout: timeoutMs });
+				},
+			});
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			this.store.update(goal.id, {
+				setupStatus: "error",
+				setupError: `Per-goal worktree setup failed: ${msg}`,
+			});
+			throw err;
+		}
+	}
+
+	/**
+	 * Provision the goal's worktree: claim from the pool, or create it (single-
+	 * or multi-repo) running per-component setup, retrying only worktree
+	 * creation. Returns the final paths WITHOUT flipping setupStatus to "ready"
+	 * (the caller does that after the per-goal hook). Returns "no-worktree" when
+	 * no worktree-able repo remained (already restored to the no-worktree
+	 * state). Throws after recording setupStatus:"error" when all attempts fail.
+	 */
+	private async _provisionGoalWorktree(goal: PersistedGoal, preliminaryOffset: string): Promise<ProvisionedWorktree | "no-worktree"> {
+		// Resolved timeout shared by per-component setup here and the per-goal hook.
+		const setupTimeoutMs = this.resolveGoalSetupTimeout(goal);
+
 		// Child goals branch off the parent's HEAD so siblings see prior
 		// siblings' commits. The pool pre-builds off master, so we skip the
 		// pool for children (a pool claim would lack the parent's commits).
@@ -448,20 +558,13 @@ export class GoalManager {
 					const offsetCwd = preliminaryOffset && preliminaryOffset !== "."
 						? path.join(claim.worktreePath, preliminaryOffset)
 						: claim.worktreePath;
-					const updates: Parameters<typeof this.store.update>[1] = {
-						worktreePath: claim.worktreePath,
-						cwd: offsetCwd,
-						setupStatus: "ready",
-						setupError: undefined,
-					};
-					if (claim.worktrees && claim.worktrees.length > 0) {
-						updates.repoWorktrees = Object.fromEntries(
-							claim.worktrees.map(w => [w.repo, w.worktreePath]),
-						);
-					}
-					this.store.update(goal.id, updates);
+					const repoWorktrees = claim.worktrees && claim.worktrees.length > 0
+						? Object.fromEntries(claim.worktrees.map(w => [w.repo, w.worktreePath]))
+						: undefined;
 					console.log(`[goal-manager] Worktree claimed from pool for goal "${goal.title}": ${claim.worktreePath} (branch: ${goal.branch}${claim.degraded ? ", degraded" : ""})`);
-					return;
+					// Pool fill already ran per-component setup; the per-goal hook is
+					// goal-specific and still runs (caller) before setupStatus flips.
+					return { worktreePath: claim.worktreePath, cwd: offsetCwd, repoWorktrees };
 				}
 			} catch (err) {
 				console.warn(`[goal-manager] Pool claim failed for goal "${goal.title}" — falling back to createWorktree:`, err);
@@ -496,7 +599,7 @@ export class GoalManager {
 					if (set.worktrees.length === 0) {
 						this._restoreNoWorktree(goal, preliminaryOffset);
 						console.warn(`[goal-manager] No worktree-able repo for goal "${goal.title}" — proceeding without a worktree`);
-						return;
+						return "no-worktree";
 					}
 					// Per-component setup commands run after the worktree set lands.
 					// Non-fatal on failure (worktree is still usable). See worktree-setup.ts.
@@ -507,8 +610,9 @@ export class GoalManager {
 							components,
 							branchContainer: set.container,
 							primaryWorktreeRoot: goal.repoPath!,
+							timeoutMs: setupTimeoutMs,
 							exec: async (cmd, cwd, env) => {
-								await execShellCommand(cmd, { cwd, env, timeout: 120_000 });
+								await execShellCommand(cmd, { cwd, env, timeout: setupTimeoutMs });
 							},
 						});
 					} catch (err) {
@@ -520,15 +624,8 @@ export class GoalManager {
 					const repoWorktrees = Object.fromEntries(
 						set.worktrees.map(w => [w.repo, w.worktreePath]),
 					);
-					this.store.update(goal.id, {
-						worktreePath: set.container,
-						cwd: offsetCwd,
-						repoWorktrees,
-						setupStatus: "ready",
-						setupError: undefined,
-					});
-					console.log(`[goal-manager] Multi-repo worktree set ready for goal "${goal.title}" at ${set.container}`);
-					return;
+					console.log(`[goal-manager] Multi-repo worktree set provisioned for goal "${goal.title}" at ${set.container}`);
+					return { worktreePath: set.container, cwd: offsetCwd, repoWorktrees };
 				}
 				const result = await createWorktree(goal.repoPath!, goal.branch!, { worktreeRoot: worktreeRootOverride, startPoint: childBaseBranch, configuredBaseRef });
 				// Per-component setup — non-fatal on failure. Mirrors the multi-repo
@@ -541,8 +638,9 @@ export class GoalManager {
 							components,
 							branchContainer: result.worktreePath,
 							primaryWorktreeRoot: goal.repoPath!,
+							timeoutMs: setupTimeoutMs,
 							exec: async (cmd, cwd, env) => {
-								await execShellCommand(cmd, { cwd, env, timeout: 120_000 });
+								await execShellCommand(cmd, { cwd, env, timeout: setupTimeoutMs });
 							},
 						});
 					} catch (err) {
@@ -553,15 +651,8 @@ export class GoalManager {
 				const offsetCwd = preliminaryOffset && preliminaryOffset !== "."
 					? path.join(result.worktreePath, preliminaryOffset)
 					: result.worktreePath;
-				// Update goal with actual worktree path and mark as ready
-				this.store.update(goal.id, {
-					worktreePath: result.worktreePath,
-					cwd: offsetCwd,
-					setupStatus: "ready",
-					setupError: undefined,
-				});
-				console.log(`[goal-manager] Worktree ready for goal "${goal.title}": ${result.worktreePath} (branch: ${goal.branch})`);
-				return;
+				console.log(`[goal-manager] Worktree provisioned for goal "${goal.title}": ${result.worktreePath} (branch: ${goal.branch})`);
+				return { worktreePath: result.worktreePath, cwd: offsetCwd };
 			} catch (err) {
 				lastError = err;
 				console.error(`[goal-manager] Worktree setup attempt ${attempt + 1} failed for goal "${goal.title}":`, err);

--- a/src/server/agent/goal-store.ts
+++ b/src/server/agent/goal-store.ts
@@ -35,6 +35,10 @@ export interface PersistedGoal {
 	setupStatus?: "ready" | "preparing" | "error";
 	/** Error message when setupStatus === "error" */
 	setupError?: string;
+	/** Optional host command run once after component setup during this goal's worktree provisioning. */
+	worktreeSetupCommand?: string;
+	/** Optional per-goal setup timeout override in milliseconds. */
+	worktreeSetupTimeoutMs?: number;
 	/** If this goal is a re-attempt of another goal, the original goal's ID */
 	reattemptOf?: string;
 	/** Whether this goal has been archived (soft-deleted) */
@@ -179,6 +183,13 @@ export class GoalStore {
 							// Default setupStatus for existing goals
 							if (!g.setupStatus) {
 								g.setupStatus = "ready";
+							}
+							// Defensively drop an invalid persisted per-goal setup
+							// timeout (absent ⇒ default resolution; a finite positive
+							// integer is the only valid override).
+							if (g.worktreeSetupTimeoutMs !== undefined
+								&& !(Number.isFinite(g.worktreeSetupTimeoutMs) && g.worktreeSetupTimeoutMs > 0)) {
+								delete g.worktreeSetupTimeoutMs;
 							}
 							// Lazy-migrate workflow snapshots that were written
 							// in YAML shape (snake_case `depends_on`,

--- a/src/server/agent/project-config-store.ts
+++ b/src/server/agent/project-config-store.ts
@@ -316,6 +316,7 @@ const DEFAULTS: Record<string, string> = {
 	test_unit_command: "npm run test:unit",
 	test_e2e_command: "npm run test:e2e",
 	worktree_setup_command: "",  // Empty = no setup runs on new worktrees
+	worktree_setup_timeout_ms: "",  // Empty = default 120000ms. Project-level default for worktree setup command timeout (goal override > this > 120000).
 	base_ref: "",                      // Empty = today's behaviour (resolveRemotePrimary, typically origin/master). Else a branch ref — local ("master") or remote ("origin/develop"). See docs/design/base-ref.md.
 	sandbox: "none",                    // "none" | "docker"
 	sandbox_image: "bobbit-agent",      // Docker image name

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -1626,14 +1626,16 @@ export class SessionManager {
 	 * background so new sessions can claim one instantly (~0ms) instead of
 	 * waiting for `git worktree add` + `npm ci` + `git push` (~10-30s).
 	 */
-	initWorktreePoolForProject(projectId: string, repoPath: string, componentsResolver?: () => import("./project-config-store.js").Component[], targetSize = 2, worktreeRoot?: string, baseRefResolver?: () => string | undefined): void {
+	initWorktreePoolForProject(projectId: string, repoPath: string, componentsResolver?: () => import("./project-config-store.js").Component[], targetSize = 2, worktreeRoot?: string, baseRefResolver?: () => string | undefined, setupTimeoutResolver?: () => number | string | undefined): void {
 		if (this.worktreePools.has(projectId)) return;
 		// `baseRefResolver` reads the live project `base_ref` setting; the resolver
 		// pattern (mirrors `componentsResolver`) lets pool entries auto-adopt the
 		// current configured integration target without a server restart. When
 		// callers don't supply one, the pool falls back to today's
 		// `resolveRemotePrimary` behaviour (see `docs/design/base-ref.md` §7).
-		const pool = new WorktreePool({ repoPath, targetSize, componentsResolver, worktreeRoot, baseRefResolver });
+		// `setupTimeoutResolver` reads `worktree_setup_timeout_ms` so the project
+		// default applies to per-component setup during pool prebuild.
+		const pool = new WorktreePool({ repoPath, targetSize, componentsResolver, worktreeRoot, baseRefResolver, setupTimeoutResolver });
 		this.worktreePools.set(projectId, pool);
 
 		// Collect worktree paths owned by active sessions so the pool doesn't

--- a/src/server/agent/worktree-pool.ts
+++ b/src/server/agent/worktree-pool.ts
@@ -31,7 +31,7 @@ import { promisify } from "node:util";
 import fs from "node:fs";
 import path from "node:path";
 import { createWorktree, cleanupWorktree, shouldSkipRemotePush, shouldSkipRemoteGitForTests, createWorktreeSet, resolveBaseRef, isUnresolvedHeadWorktreeError, type WorktreeResult } from "../skills/git.js";
-import { runComponentSetups } from "../skills/worktree-setup.js";
+import { runComponentSetups, resolveSetupTimeoutMs } from "../skills/worktree-setup.js";
 import { cpuDiagnosticsEnabled, getCpuDiagnostics } from "./cpu-diagnostics.js";
 import { execShellCommand } from "./shell-util.js";
 import type { Component } from "./project-config-store.js";
@@ -273,6 +273,15 @@ export class WorktreePool {
 	 */
 	private baseRefResolver?: () => string | undefined;
 
+	/**
+	 * Live resolver for the project's `worktree_setup_timeout_ms` setting — called
+	 * fresh on every `_fill()` so the project default applies to per-component
+	 * setup during pool prebuild too (matching the per-goal setup path). Returns
+	 * a number, numeric string, or undefined; `resolveSetupTimeoutMs` validates
+	 * and falls back to the 120s default when unset/invalid.
+	 */
+	private setupTimeoutResolver?: () => number | string | undefined;
+
 	/** Project-level worktree_root override (sibling of <rootPath>-wt by default). */
 	private worktreeRoot?: string;
 
@@ -286,11 +295,12 @@ export class WorktreePool {
 	 * construction, `this.repoPath` is always the git root (or, when the
 	 * supplied path isn't a git working tree at all, the original input).
 	 */
-	constructor(opts: { repoPath: string; targetSize?: number; componentsResolver?: () => Component[]; baseRefResolver?: () => string | undefined; worktreeRoot?: string }) {
+	constructor(opts: { repoPath: string; targetSize?: number; componentsResolver?: () => Component[]; baseRefResolver?: () => string | undefined; setupTimeoutResolver?: () => number | string | undefined; worktreeRoot?: string }) {
 		this.repoPath = resolveRepoToplevel(opts.repoPath);
 		this.targetSize = opts.targetSize ?? 2;
 		this.componentsResolver = opts.componentsResolver;
 		this.baseRefResolver = opts.baseRefResolver;
+		this.setupTimeoutResolver = opts.setupTimeoutResolver;
 		this.worktreeRoot = opts.worktreeRoot;
 	}
 
@@ -776,14 +786,21 @@ export class WorktreePool {
 					const setupNames = components.filter(c => c.worktreeSetupCommand).map(c => c.name);
 					if (counters) counters.setupComponents += setupNames.length;
 					if (setupNames.length > 0) {
+						// Resolve the project default timeout fresh on every fill so a
+						// `worktree_setup_timeout_ms` config edit applies to component setup
+						// during pool prebuild too. No per-goal override exists at fill time
+						// (the pool entry isn't yet claimed by a goal), so only the project
+						// tier feeds the resolver here.
+						const setupTimeoutMs = resolveSetupTimeoutMs({ projectTimeoutMs: this.setupTimeoutResolver?.() });
 						console.log(`[worktree-pool] running setup for components: ${setupNames.join(", ")}`);
 						try {
 							await runComponentSetups({
 								components,
 								branchContainer: container,
 								primaryWorktreeRoot: this.repoPath,
+								timeoutMs: setupTimeoutMs,
 								exec: async (cmd, cwd, env) => {
-									await execShellCommand(cmd, { cwd, env, timeout: 120_000 });
+									await execShellCommand(cmd, { cwd, env, timeout: setupTimeoutMs });
 								},
 							});
 						} catch (err) {

--- a/src/server/proposals/proposal-types.ts
+++ b/src/server/proposals/proposal-types.ts
@@ -58,6 +58,8 @@ const GOAL_FRONTMATTER_KEYS = [
 	"maxNestingDepth",   // number — per-goal sub-goal nesting cap (clamped to the global ceiling)
 	"divergencePolicy",  // "strict"|"balanced"|"autonomous" — root-only plan-change autonomy
 	"maxConcurrentChildren", // number [1,8] — root-only concurrent child-team cap
+	"worktreeSetupCommand",  // string — host command run once during this goal's worktree provisioning
+	"worktreeSetupTimeoutMs", // number > 0 — per-goal worktree-setup timeout override (ms)
 ] as const;
 
 /**
@@ -138,6 +140,15 @@ function validateGoalInlineFields(fields: Record<string, unknown>): ParseError |
 	const mcc = fields.maxConcurrentChildren;
 	if (mcc !== undefined && mcc !== null && (typeof mcc !== "number" || !Number.isInteger(mcc) || mcc < 1 || mcc > 8)) {
 		return { ok: false, code: "STRUCTURAL_VALIDATION_FAILED", message: "maxConcurrentChildren must be an integer in [1, 8]" };
+	}
+	// Per-goal worktree setup hook. Both optional; validated only when present.
+	const wsc = fields.worktreeSetupCommand;
+	if (wsc !== undefined && wsc !== null && typeof wsc !== "string") {
+		return { ok: false, code: "STRUCTURAL_VALIDATION_FAILED", message: "worktreeSetupCommand must be a string" };
+	}
+	const wst = fields.worktreeSetupTimeoutMs;
+	if (wst !== undefined && wst !== null && (typeof wst !== "number" || !Number.isInteger(wst) || wst <= 0)) {
+		return { ok: false, code: "STRUCTURAL_VALIDATION_FAILED", message: "worktreeSetupTimeoutMs must be an integer > 0" };
 	}
 	return null;
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2290,7 +2290,7 @@ export function createGateway(config: GatewayConfig) {
 								// Single-repo: resolve nested rootPath to the actual git toplevel so
 								// pool entries land under <gitRoot>-wt/, not <projectDir>-wt/.
 								const poolRepoPath = isMulti ? repoPath : await getRepoRoot(repoPath);
-								sessionManager.initWorktreePoolForProject(ctx.project.id, poolRepoPath, () => pcs.getComponents(), poolSize, wtRoot, () => pcs.get("base_ref"));
+								sessionManager.initWorktreePoolForProject(ctx.project.id, poolRepoPath, () => pcs.getComponents(), poolSize, wtRoot, () => pcs.get("base_ref"), () => pcs.get("worktree_setup_timeout_ms") || undefined);
 								console.log(`[boot] pool ready: project=${ctx.project.id} in ${Date.now() - tStart}ms`);
 							} else {
 								console.log(`[boot] pool skipped (not a git repo): project=${ctx.project.id} in ${Date.now() - tStart}ms`);
@@ -3474,7 +3474,7 @@ async function handleApiRoute(
 						// Single-repo: resolve nested rootPath to the actual git toplevel so
 						// pool entries land under <gitRoot>-wt/, not <projectDir>-wt/.
 						const poolRepoPath = isMulti ? body.rootPath : await getRepoRoot(body.rootPath);
-						sessionManager.initWorktreePoolForProject(project.id, poolRepoPath, pcs ? () => pcs.getComponents() : undefined, poolSize, wtRoot, pcs ? () => pcs.get("base_ref") : undefined);
+						sessionManager.initWorktreePoolForProject(project.id, poolRepoPath, pcs ? () => pcs.getComponents() : undefined, poolSize, wtRoot, pcs ? () => pcs.get("base_ref") : undefined, pcs ? () => pcs.get("worktree_setup_timeout_ms") || undefined : undefined);
 					}
 				} catch { /* best-effort */ }
 			}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -167,6 +167,10 @@ function wireGoalManagerResolvers(
 		const c = deps.projectContextManager.getOrCreate(pid);
 		return c?.projectConfigStore.get("base_ref") || undefined;
 	});
+	ctx.goalManager.setWorktreeSetupTimeoutResolver((pid: string) => {
+		const c = deps.projectContextManager.getOrCreate(pid);
+		return c?.projectConfigStore.get("worktree_setup_timeout_ms") || undefined;
+	});
 	ctx.goalManager.setLiveSessionResolver(() => collectVisibleSessionWorktreeReferences(deps.projectContextManager));
 }
 
@@ -5091,6 +5095,20 @@ async function handleApiRoute(
 		try {
 			const sandboxed = body.sandboxed === true;
 			const autoStartTeam = body.autoStartTeam !== false; // default true
+			// Per-goal worktree setup hook (optional). Accept camelCase or snake_case.
+			// Command: trimmed, passed only when non-empty. Timeout: number or numeric
+			// string, passed only when a finite positive integer.
+			let worktreeSetupCommand: string | undefined;
+			{
+				const raw = body.worktreeSetupCommand ?? body.worktree_setup_command;
+				if (typeof raw === "string" && raw.trim()) worktreeSetupCommand = raw.trim();
+			}
+			let worktreeSetupTimeoutMs: number | undefined;
+			{
+				const raw = body.worktreeSetupTimeoutMs ?? body.worktree_setup_timeout_ms;
+				const n = typeof raw === "number" ? raw : (typeof raw === "string" && raw.trim() !== "" ? Number(raw) : NaN);
+				if (Number.isFinite(n) && n > 0) worktreeSetupTimeoutMs = Math.floor(n);
+			}
 			let enabledOptionalSteps: string[] | undefined;
 			if (Array.isArray(body.enabledOptionalSteps) && body.enabledOptionalSteps.every((s: unknown) => typeof s === "string")) {
 				enabledOptionalSteps = body.enabledOptionalSteps;
@@ -5321,6 +5339,8 @@ async function handleApiRoute(
 				maxNestingDepth: effMaxNestingDepth,
 				divergencePolicy: effDivergencePolicy,
 				maxConcurrentChildren: effMaxConcurrentChildren,
+				worktreeSetupCommand,
+				worktreeSetupTimeoutMs,
 			});
 			// Set projectId (explicit or auto-detected from cwd)
 			if (targetProjectId) {

--- a/src/server/skills/worktree-setup.ts
+++ b/src/server/skills/worktree-setup.ts
@@ -49,8 +49,11 @@ function coercePositiveIntMs(v: unknown): number | undefined {
 	if (typeof v === "number") n = v;
 	else if (typeof v === "string" && v.trim() !== "") n = Number(v);
 	else return undefined;
-	if (!Number.isFinite(n) || n <= 0) return undefined;
-	return Math.floor(n);
+	// Design says finite positive INTEGERS. Reject fractional values rather than
+	// flooring them — "0.5" must fall through to the next tier, not resolve to 0
+	// (and "1.5" must not be silently truncated to 1).
+	if (!Number.isInteger(n) || n <= 0) return undefined;
+	return n;
 }
 
 export interface RunComponentSetupsOpts {

--- a/src/server/skills/worktree-setup.ts
+++ b/src/server/skills/worktree-setup.ts
@@ -18,7 +18,40 @@ import { cpuDiagnosticsEnabled, getCpuDiagnostics } from "../agent/cpu-diagnosti
 import { componentRoot } from "./worktree-paths.js";
 import type { Component } from "../agent/project-config-store.js";
 
-const TIMEOUT_MS = 120_000;
+/**
+ * Single source of truth for the worktree-setup timeout fallback.
+ * Per-goal override → project `worktree_setup_timeout_ms` → this default.
+ */
+export const DEFAULT_WORKTREE_SETUP_TIMEOUT_MS = 120_000;
+
+/**
+ * Resolve the worktree-setup timeout (ms) from a goal override, then a
+ * project default, then {@link DEFAULT_WORKTREE_SETUP_TIMEOUT_MS}.
+ *
+ * Only finite, strictly-positive integers are accepted at each level.
+ * The project value may be a number or a numeric string (project config
+ * stores everything as strings). Invalid / zero / negative / non-finite
+ * values fall through to the next level.
+ */
+export function resolveSetupTimeoutMs(input?: {
+	goalTimeoutMs?: unknown;
+	projectTimeoutMs?: unknown;
+}): number {
+	const goal = coercePositiveIntMs(input?.goalTimeoutMs);
+	if (goal !== undefined) return goal;
+	const project = coercePositiveIntMs(input?.projectTimeoutMs);
+	if (project !== undefined) return project;
+	return DEFAULT_WORKTREE_SETUP_TIMEOUT_MS;
+}
+
+function coercePositiveIntMs(v: unknown): number | undefined {
+	let n: number;
+	if (typeof v === "number") n = v;
+	else if (typeof v === "string" && v.trim() !== "") n = Number(v);
+	else return undefined;
+	if (!Number.isFinite(n) || n <= 0) return undefined;
+	return Math.floor(n);
+}
 
 export interface RunComponentSetupsOpts {
 	components: Component[];
@@ -26,6 +59,25 @@ export interface RunComponentSetupsOpts {
 	branchContainer: string;
 	/** The project's primary checkout root — used to compute `SOURCE_REPO`. */
 	primaryWorktreeRoot: string;
+	/** Resolved per-command timeout (ms). Defaults to {@link DEFAULT_WORKTREE_SETUP_TIMEOUT_MS}. */
+	timeoutMs?: number;
+	/** Caller-supplied exec — host or in-container. */
+	exec: (cmd: string, cwd: string, env: NodeJS.ProcessEnv) => Promise<void>;
+}
+
+export interface RunGoalSetupOpts {
+	goalId: string;
+	branch: string;
+	/** The goal's worktree root (branch container). */
+	worktreePath: string;
+	/** The resolved goal cwd (worktree root + project subdirectory offset). */
+	cwd: string;
+	/** The project's primary checkout root — used to compute `SOURCE_REPO`. */
+	primaryWorktreeRoot: string;
+	/** The per-goal setup command. Blank/absent → no-op. */
+	command?: string;
+	/** Resolved timeout (ms). Defaults to {@link DEFAULT_WORKTREE_SETUP_TIMEOUT_MS}. */
+	timeoutMs?: number;
 	/** Caller-supplied exec — host or in-container. */
 	exec: (cmd: string, cwd: string, env: NodeJS.ProcessEnv) => Promise<void>;
 }
@@ -41,6 +93,7 @@ function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
 }
 
 export async function runComponentSetups(opts: RunComponentSetupsOpts): Promise<void> {
+	const timeoutMs = opts.timeoutMs ?? DEFAULT_WORKTREE_SETUP_TIMEOUT_MS;
 	const diagEnabled = cpuDiagnosticsEnabled();
 	const diagStart = diagEnabled ? performance.now() : 0;
 	const counters = diagEnabled ? { components: opts.components.length, skippedByEnv: 0, commands: 0, successes: 0, failures: 0 } : undefined;
@@ -75,7 +128,7 @@ export async function runComponentSetups(opts: RunComponentSetupsOpts): Promise<
 
 			const componentStart = diagEnabled ? performance.now() : 0;
 			try {
-				await withTimeout(opts.exec(c.worktreeSetupCommand, cwd, env), TIMEOUT_MS, `[worktree-setup] ${c.name}`);
+				await withTimeout(opts.exec(c.worktreeSetupCommand, cwd, env), timeoutMs, `[worktree-setup] ${c.name}`);
 				if (counters) counters.successes++;
 				console.log(`[worktree-setup] ${c.name}: ok`);
 				if (diagEnabled) getCpuDiagnostics().recordTimer("worktree-setup:component", performance.now() - componentStart, { commands: 1, successes: 1, failures: 0 });
@@ -88,4 +141,41 @@ export async function runComponentSetups(opts: RunComponentSetupsOpts): Promise<
 	} finally {
 		if (diagEnabled) getCpuDiagnostics().recordTimer("worktree-setup:run", performance.now() - diagStart, counters);
 	}
+}
+
+/**
+ * Run the optional per-goal worktree setup command exactly once, after any
+ * per-component setup hooks. Unlike per-component setup (best-effort,
+ * non-fatal), failures here PROPAGATE — the caller marks the goal
+ * `setupStatus: "error"` so it never auto-starts mis-configured.
+ *
+ * Blank/absent command returns without invoking `exec`. The command runs
+ * in the goal's resolved `cwd` (offset-applied), with the inherited process
+ * env plus `SOURCE_REPO` and the `BOBBIT_*` goal-context vars.
+ */
+export async function runGoalSetup(opts: RunGoalSetupOpts): Promise<void> {
+	const command = opts.command?.trim();
+	if (!command) return; // no per-goal hook
+
+	const timeoutMs = opts.timeoutMs ?? DEFAULT_WORKTREE_SETUP_TIMEOUT_MS;
+	const env: NodeJS.ProcessEnv = {
+		...process.env,
+		SOURCE_REPO: opts.primaryWorktreeRoot,
+		BOBBIT_GOAL_ID: opts.goalId,
+		BOBBIT_GOAL_BRANCH: opts.branch,
+		BOBBIT_WORKTREE_PATH: opts.worktreePath,
+	};
+
+	// Test hook: mirror runComponentSetups' BOBBIT_TEST_RECORD_SETUP audit,
+	// with a distinguishable per-goal line prefix.
+	const recordPath = process.env.BOBBIT_TEST_RECORD_SETUP;
+	if (recordPath) {
+		try {
+			fs.mkdirSync(path.dirname(recordPath), { recursive: true });
+			fs.appendFileSync(recordPath, `goal\t${opts.goalId}\t${opts.cwd}\t${opts.primaryWorktreeRoot}\t${command}\n`);
+		} catch { /* test-only — don't fail the worktree on audit IO errors */ }
+	}
+
+	await withTimeout(opts.exec(command, opts.cwd, env), timeoutMs, `[worktree-setup] goal ${opts.goalId}`);
+	console.log(`[worktree-setup] goal ${opts.goalId}: ok`);
 }

--- a/tests/e2e/goal-worktree-setup-command.spec.ts
+++ b/tests/e2e/goal-worktree-setup-command.spec.ts
@@ -1,0 +1,188 @@
+/**
+ * Per-goal worktree setup command — API E2E (freshly-created worktree path).
+ *
+ * Covers the runtime hook added by the per-goal worktree setup goal:
+ *   - direct REST creation with `worktreeSetupCommand` / `worktreeSetupTimeoutMs`
+ *     persists in the 201 response, the GET detail, and `goals.json` on disk
+ *     (i.e. survives a reload), and
+ *   - the command is actually invoked during provisioning (asserted via the
+ *     `BOBBIT_TEST_RECORD_SETUP` per-goal audit line), and
+ *   - a failing per-goal command makes setup FATAL: `setupStatus:"error"`,
+ *     a descriptive `setupError`, and the goal never reaches "ready" (so a
+ *     team can never auto-start mis-configured).
+ *
+ * The in-process harness runs the gateway in THIS process, so a
+ * `process.env.BOBBIT_TEST_RECORD_SETUP` set here is read by `runGoalSetup`
+ * at provisioning time. We filter audit lines by goalId to stay robust under
+ * worker reuse.
+ *
+ * Pool-claim coverage lives in goal-worktree-setup-pool.spec.ts (the worker
+ * pool option is file-scoped).
+ */
+import { test, expect } from "./in-process-harness.js";
+import { apiFetch, bobbitDir } from "./e2e-setup.js";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+function gitInit(dir: string): void {
+	fs.mkdirSync(dir, { recursive: true });
+	execFileSync("git", ["init", "--initial-branch=master"], { cwd: dir });
+	execFileSync("git", ["config", "user.email", "test@bobbit.local"], { cwd: dir });
+	execFileSync("git", ["config", "user.name", "test"], { cwd: dir });
+	fs.writeFileSync(path.join(dir, "README.md"), "# repo\n");
+	execFileSync("git", ["add", "."], { cwd: dir });
+	execFileSync("git", ["commit", "-m", "init", "--quiet"], { cwd: dir });
+}
+
+/**
+ * Poll the goal detail until setup settles (ready|error). Uses Playwright's
+ * `expect.poll` (event-loop-driven retry) rather than an inline sleep so the
+ * no-new-sleeps guard stays green. Returns the final goal detail.
+ */
+async function waitForSetup(goalId: string, timeoutMs = 30_000): Promise<Record<string, unknown>> {
+	let detail: Record<string, unknown> = {};
+	await expect.poll(async () => {
+		const r = await apiFetch(`/api/goals/${goalId}`);
+		if (r.status !== 200) return undefined;
+		detail = await r.json();
+		return detail.setupStatus;
+	}, { timeout: timeoutMs }).toMatch(/^(ready|error)$/);
+	return detail;
+}
+
+function goalsJsonAuditPath(repoPath: string): string {
+	return path.join(repoPath, ".bobbit", "state", "goals.json");
+}
+
+function readAuditLines(recordFile: string, goalId: string): string[] {
+	if (!fs.existsSync(recordFile)) return [];
+	return fs.readFileSync(recordFile, "utf-8")
+		.split("\n")
+		.filter((l) => l.startsWith("goal\t") && l.includes(goalId));
+}
+
+test.describe.serial("Per-goal worktree setup command (fresh-create)", () => {
+	let repoPath: string;
+	let projectId: string;
+	let recordFile: string;
+
+	test.beforeAll(async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-goal-setup-"));
+		repoPath = path.join(root, "repo");
+		gitInit(repoPath);
+
+		recordFile = path.join(root, "setup-record.tsv");
+		process.env.BOBBIT_TEST_RECORD_SETUP = recordFile;
+
+		const reg = await apiFetch("/api/projects", {
+			method: "POST",
+			body: JSON.stringify({ name: `goal-setup-${Date.now()}`, rootPath: repoPath }),
+		});
+		expect(reg.status).toBe(201);
+		projectId = (await reg.json()).id;
+	});
+
+	test.afterAll(() => {
+		delete process.env.BOBBIT_TEST_RECORD_SETUP;
+	});
+
+	test("persists fields, survives reload, and invokes the per-goal command", async () => {
+		const command = "echo per-goal-hook-ran";
+		const createRes = await apiFetch("/api/goals", {
+			method: "POST",
+			body: JSON.stringify({
+				title: "Per-goal setup happy path",
+				cwd: repoPath,
+				projectId,
+				worktree: true,
+				team: false,
+				autoStartTeam: false,
+				workflowId: "general",
+				worktreeSetupCommand: command,
+				worktreeSetupTimeoutMs: 45000,
+			}),
+		});
+		expect(createRes.status).toBe(201);
+		const created = await createRes.json();
+
+		// 1) Fields echoed in the 201 response.
+		expect(created.worktreeSetupCommand).toBe(command);
+		expect(created.worktreeSetupTimeoutMs).toBe(45000);
+
+		// 2) Survives reload — GET detail returns them.
+		const detail = await waitForSetup(created.id);
+		expect(detail.setupStatus).toBe("ready");
+		expect(detail.worktreeSetupCommand).toBe(command);
+		expect(detail.worktreeSetupTimeoutMs).toBe(45000);
+
+		// 3) Persisted in goals.json on disk (project-scoped state).
+		const goals = JSON.parse(fs.readFileSync(goalsJsonAuditPath(repoPath), "utf-8")) as Array<Record<string, unknown>>;
+		const persisted = goals.find((g) => g.id === created.id);
+		expect(persisted, "goal must be persisted to goals.json").toBeTruthy();
+		expect(persisted!.worktreeSetupCommand).toBe(command);
+		expect(persisted!.worktreeSetupTimeoutMs).toBe(45000);
+
+		// 4) Per-goal audit line written during provisioning.
+		const lines = readAuditLines(recordFile, created.id);
+		expect(lines.length).toBe(1);
+		// Format: goal\t<goalId>\t<cwd>\t<SOURCE_REPO>\t<command>
+		const cols = lines[0].split("\t");
+		expect(cols[0]).toBe("goal");
+		expect(cols[1]).toBe(created.id);
+		expect(cols[4]).toBe(command);
+	});
+
+	test("omitting the fields persists no hook (optional, backward-compatible)", async () => {
+		const createRes = await apiFetch("/api/goals", {
+			method: "POST",
+			body: JSON.stringify({
+				title: "No per-goal setup",
+				cwd: repoPath,
+				projectId,
+				worktree: true,
+				team: false,
+				autoStartTeam: false,
+				workflowId: "general",
+			}),
+		});
+		expect(createRes.status).toBe(201);
+		const created = await createRes.json();
+		expect(created.worktreeSetupCommand).toBeUndefined();
+		expect(created.worktreeSetupTimeoutMs).toBeUndefined();
+
+		const detail = await waitForSetup(created.id);
+		expect(detail.setupStatus).toBe("ready");
+
+		// No per-goal audit line for this goal.
+		expect(readAuditLines(recordFile, created.id).length).toBe(0);
+	});
+
+	test("a failing per-goal command is fatal: setupStatus=error, descriptive setupError, never ready", async () => {
+		const createRes = await apiFetch("/api/goals", {
+			method: "POST",
+			body: JSON.stringify({
+				title: "Per-goal setup failure",
+				cwd: repoPath,
+				projectId,
+				worktree: true,
+				team: false,
+				// autoStartTeam:true so we also prove the team never starts when
+				// the fatal hook throws (setup must resolve before a team starts).
+				autoStartTeam: true,
+				workflowId: "general",
+				worktreeSetupCommand: "exit 7",
+			}),
+		});
+		expect(createRes.status).toBe(201);
+		const created = await createRes.json();
+
+		const detail = await waitForSetup(created.id);
+		expect(detail.setupStatus).toBe("error");
+		expect(String(detail.setupError)).toContain("Per-goal worktree setup failed");
+
+		// Never auto-started: a failed (fatal) setup leaves no team lead session.
+		expect(detail.teamLeadSessionId).toBeFalsy();
+	});
+});

--- a/tests/e2e/goal-worktree-setup-pool.spec.ts
+++ b/tests/e2e/goal-worktree-setup-pool.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Per-goal worktree setup command — pool-claim path (API E2E).
+ *
+ * The worktree pool pre-builds branches off master; it cannot pre-run a
+ * goal-specific script. So when a goal claims a pool worktree, the per-goal
+ * setup command must still fire AFTER the claim. This spec enables the pool
+ * (file-scoped worker option) and asserts the per-goal audit line is written
+ * for a pool-claimed goal.
+ *
+ * See goal-worktree-setup-command.spec.ts for the freshly-created-worktree path.
+ */
+import { test, expect } from "./in-process-harness.js";
+
+// Pool pre-fill must actually run for this spec.
+test.use({ enableWorktreePool: true });
+
+import { apiFetch } from "./e2e-setup.js";
+import { waitForPool } from "./test-utils/pool-polling.mjs";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+function gitInit(dir: string): void {
+	fs.mkdirSync(dir, { recursive: true });
+	execFileSync("git", ["init", "--initial-branch=master"], { cwd: dir });
+	execFileSync("git", ["config", "user.email", "test@bobbit.local"], { cwd: dir });
+	execFileSync("git", ["config", "user.name", "test"], { cwd: dir });
+	execFileSync("git", ["commit", "--allow-empty", "-m", "init", "--quiet"], { cwd: dir });
+}
+
+test.describe.serial("Per-goal worktree setup command (pool claim)", () => {
+	let repoPath: string;
+	let projectId: string;
+	let recordFile: string;
+
+	test.beforeAll(async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-goal-setup-pool-"));
+		repoPath = path.join(root, "repo");
+		gitInit(repoPath);
+
+		recordFile = path.join(root, "setup-record.tsv");
+		process.env.BOBBIT_TEST_RECORD_SETUP = recordFile;
+
+		const reg = await apiFetch("/api/projects", {
+			method: "POST",
+			body: JSON.stringify({ name: `goal-setup-pool-${Date.now()}`, rootPath: repoPath }),
+		});
+		expect(reg.status).toBe(201);
+		projectId = (await reg.json()).id;
+	});
+
+	test.afterAll(() => {
+		delete process.env.BOBBIT_TEST_RECORD_SETUP;
+	});
+
+	test("pool-claimed worktree still runs the per-goal setup command", async () => {
+		// Wait for the pool to warm so the goal actually claims a pre-built entry.
+		const ready = await waitForPool(projectId, 1);
+		expect(ready).toBeGreaterThan(0);
+
+		const command = "echo pool-goal-hook-ran";
+		const createRes = await apiFetch("/api/goals", {
+			method: "POST",
+			body: JSON.stringify({
+				title: "Pool-claimed per-goal setup",
+				cwd: repoPath,
+				projectId,
+				worktree: true,
+				team: false,
+				autoStartTeam: false,
+				workflowId: "general",
+				worktreeSetupCommand: command,
+			}),
+		});
+		expect(createRes.status).toBe(201);
+		const created = await createRes.json();
+
+		// Wait for setup to settle (event-loop-driven poll, no inline sleep).
+		let detail: Record<string, unknown> = {};
+		await expect.poll(async () => {
+			const r = await apiFetch(`/api/goals/${created.id}`);
+			if (r.status !== 200) return undefined;
+			detail = await r.json();
+			return detail.setupStatus;
+		}, { timeout: 30_000 }).toMatch(/^(ready|error)$/);
+		expect(detail.setupStatus).toBe("ready");
+
+		// Per-goal audit line written even though the worktree came from the pool.
+		const lines = fs.existsSync(recordFile)
+			? fs.readFileSync(recordFile, "utf-8").split("\n").filter((l) => l.startsWith("goal\t") && l.includes(created.id))
+			: [];
+		expect(lines.length).toBe(1);
+		expect(lines[0].split("\t")[4]).toBe(command);
+	});
+});

--- a/tests/e2e/mock-agent-core.mjs
+++ b/tests/e2e/mock-agent-core.mjs
@@ -441,6 +441,25 @@ export class MockAgentCore {
 			};
 		}
 
+		// Goal proposal carrying the per-goal worktree-setup fields — used by
+		// goal-worktree-setup-command.spec.ts to assert a propose_goal-seeded
+		// proposal mirrors worktreeSetupCommand / worktreeSetupTimeoutMs into the
+		// goal form and preserves them through acceptance. Must precede the generic
+		// goal_proposal matcher (it contains the "GOAL_PROPOSAL" substring).
+		if (text.includes("GOAL_PROPOSAL_WORKTREE_SETUP")) {
+			return {
+				tool: "propose_goal",
+				input: {
+					title: "E2E Test Goal",
+					workflow: "general",
+					spec: "A goal whose worktree-setup fields are seeded by the agent.",
+					worktreeSetupCommand: "./scripts/agent-seed.sh",
+					worktreeSetupTimeoutMs: 45000,
+				},
+				output: "Proposal submitted. Waiting for user response.",
+			};
+		}
+
 		if (lower.includes("goal_proposal") || lower.includes("goal proposal")) {
 			return {
 				tool: "propose_goal",

--- a/tests/e2e/ui/goal-worktree-setup-command.spec.ts
+++ b/tests/e2e/ui/goal-worktree-setup-command.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Goal-creation dialog — per-goal worktree setup controls (browser E2E).
+ *
+ * Verifies the goal form exposes the optional "Setup command" + "Timeout (ms)"
+ * controls (data-testids goal-form-worktree-setup-command /
+ * goal-form-worktree-setup-timeout-ms), that they are optional (empty by
+ * default ⇒ no persisted hook), and that filled values are forwarded to
+ * goal creation and persist across a page reload.
+ *
+ * Mirrors tests/e2e/ui/goal-creation.spec.ts (assistant proposal flow + mock
+ * agent). Persistence is asserted against the server-side goal via the API,
+ * which is the durable record that survives a reload.
+ */
+import { test, expect } from "../gateway-harness.js";
+import { apiFetch } from "../e2e-setup.js";
+import { openApp, sendMessage } from "./ui-helpers.js";
+
+const CMD_TESTID = "[data-testid='goal-form-worktree-setup-command']";
+const TIMEOUT_TESTID = "[data-testid='goal-form-worktree-setup-timeout-ms']";
+
+/** Open the goal assistant and wait for the populated proposal title input. */
+async function openGoalAssistantProposal(page: import("@playwright/test").Page) {
+	test.setTimeout(90_000);
+	await openApp(page);
+	const newGoalBtn = page.locator("button[title='New goal (Alt+G)']").first();
+	await expect(newGoalBtn).toBeVisible({ timeout: 10_000 });
+	await expect(newGoalBtn).toBeEnabled({ timeout: 10_000 });
+	const sessionCreated = page.waitForResponse(
+		(resp) => resp.url().includes("/api/sessions") && resp.request().method() === "POST" && resp.ok(),
+		{ timeout: 60_000 },
+	);
+	await newGoalBtn.click();
+	await sessionCreated;
+	await page.waitForURL(/#\/session\//, { timeout: 10_000 });
+	const textarea = page.locator("textarea").first();
+	await expect(textarea).toBeVisible({ timeout: 10_000 });
+	await sendMessage(page, "Please create a GOAL_PROPOSAL for testing");
+	const titleInput = page.locator("input[placeholder='Goal title']").first();
+	await expect(titleInput).toBeVisible({ timeout: 10_000 });
+	await expect(titleInput).toHaveValue("E2E Test Goal", { timeout: 15_000 });
+}
+
+async function findGoalByTitle(title: string): Promise<any | undefined> {
+	const resp = await apiFetch("/api/goals");
+	const data = await resp.json();
+	const goals = data.goals || data;
+	return (goals as any[]).find((g) => g.title === title);
+}
+
+async function deleteGoal(goalId: string) {
+	await apiFetch(`/api/goals/${goalId}?cascade=true`, { method: "DELETE" }).catch(() => {});
+}
+
+async function clickCreate(page: import("@playwright/test").Page) {
+	const createPromise = page.waitForResponse(
+		(resp) => resp.url().includes("/api/goals") && resp.request().method() === "POST" && resp.ok(),
+		{ timeout: 15_000 },
+	);
+	await page.locator("button").filter({ hasText: "Create Goal" }).first().click();
+	await createPromise;
+	await expect(page).toHaveURL(/#\/goal(-dashboard)?\//, { timeout: 15_000 });
+}
+
+test.describe("Goal creation dialog — per-goal worktree setup controls", () => {
+	test("controls are visible and optional; empty fields persist no hook", async ({ page }) => {
+		await openGoalAssistantProposal(page);
+
+		// Controls are exposed and empty by default.
+		const cmd = page.locator(CMD_TESTID).first();
+		const timeout = page.locator(TIMEOUT_TESTID).first();
+		await expect(cmd).toBeVisible({ timeout: 5_000 });
+		await expect(timeout).toBeVisible({ timeout: 5_000 });
+		await expect(cmd).toHaveValue("");
+		await expect(timeout).toHaveValue("");
+
+		// Create without touching them — backward-compatible no-hook goal.
+		await clickCreate(page);
+
+		const created = await findGoalByTitle("E2E Test Goal");
+		expect(created).toBeTruthy();
+		try {
+			expect(created.worktreeSetupCommand).toBeUndefined();
+			expect(created.worktreeSetupTimeoutMs).toBeUndefined();
+		} finally {
+			if (created) await deleteGoal(created.id);
+		}
+	});
+
+	test("filled command + timeout are forwarded and persist across reload", async ({ page }) => {
+		await openGoalAssistantProposal(page);
+
+		const cmd = page.locator(CMD_TESTID).first();
+		const timeout = page.locator(TIMEOUT_TESTID).first();
+		await expect(cmd).toBeVisible({ timeout: 5_000 });
+		await cmd.fill("./scripts/seed.sh");
+		await timeout.fill("60000");
+		await expect(cmd).toHaveValue("./scripts/seed.sh");
+		await expect(timeout).toHaveValue("60000");
+
+		await clickCreate(page);
+
+		const created = await findGoalByTitle("E2E Test Goal");
+		expect(created).toBeTruthy();
+		try {
+			expect(created.worktreeSetupCommand).toBe("./scripts/seed.sh");
+			expect(created.worktreeSetupTimeoutMs).toBe(60000);
+
+			// Persisted server-side: survives a full page reload.
+			await page.reload();
+			const reloaded = await findGoalByTitle("E2E Test Goal");
+			expect(reloaded).toBeTruthy();
+			expect(reloaded.worktreeSetupCommand).toBe("./scripts/seed.sh");
+			expect(reloaded.worktreeSetupTimeoutMs).toBe(60000);
+		} finally {
+			if (created) await deleteGoal(created.id);
+		}
+	});
+});

--- a/tests/e2e/ui/goal-worktree-setup-command.spec.ts
+++ b/tests/e2e/ui/goal-worktree-setup-command.spec.ts
@@ -40,6 +40,32 @@ async function openGoalAssistantProposal(page: import("@playwright/test").Page) 
 	await expect(titleInput).toHaveValue("E2E Test Goal", { timeout: 15_000 });
 }
 
+/**
+ * Open the goal assistant and drive a propose_goal that ALREADY carries the
+ * per-goal worktree-setup fields (mock trigger GOAL_PROPOSAL_WORKTREE_SETUP),
+ * so we can assert they are mirrored into the goal form and survive acceptance.
+ */
+async function openGoalAssistantSetupSeededProposal(page: import("@playwright/test").Page) {
+	test.setTimeout(90_000);
+	await openApp(page);
+	const newGoalBtn = page.locator("button[title='New goal (Alt+G)']").first();
+	await expect(newGoalBtn).toBeVisible({ timeout: 10_000 });
+	await expect(newGoalBtn).toBeEnabled({ timeout: 10_000 });
+	const sessionCreated = page.waitForResponse(
+		(resp) => resp.url().includes("/api/sessions") && resp.request().method() === "POST" && resp.ok(),
+		{ timeout: 60_000 },
+	);
+	await newGoalBtn.click();
+	await sessionCreated;
+	await page.waitForURL(/#\/session\//, { timeout: 10_000 });
+	const textarea = page.locator("textarea").first();
+	await expect(textarea).toBeVisible({ timeout: 10_000 });
+	await sendMessage(page, "Please GOAL_PROPOSAL_WORKTREE_SETUP now");
+	const titleInput = page.locator("input[placeholder='Goal title']").first();
+	await expect(titleInput).toBeVisible({ timeout: 10_000 });
+	await expect(titleInput).toHaveValue("E2E Test Goal", { timeout: 15_000 });
+}
+
 async function findGoalByTitle(title: string): Promise<any | undefined> {
 	const resp = await apiFetch("/api/goals");
 	const data = await resp.json();
@@ -81,6 +107,35 @@ test.describe("Goal creation dialog — per-goal worktree setup controls", () =>
 		try {
 			expect(created.worktreeSetupCommand).toBeUndefined();
 			expect(created.worktreeSetupTimeoutMs).toBeUndefined();
+		} finally {
+			if (created) await deleteGoal(created.id);
+		}
+	});
+
+	test("a propose_goal-seeded proposal mirrors setup fields into the form and preserves them through acceptance", async ({ page }) => {
+		await openGoalAssistantSetupSeededProposal(page);
+
+		// Finding 1: the agent-seeded worktreeSetupCommand / worktreeSetupTimeoutMs
+		// must be mirrored into the goal form (not just title/spec/cwd/workflow).
+		const cmd = page.locator(CMD_TESTID).first();
+		const timeout = page.locator(TIMEOUT_TESTID).first();
+		await expect(cmd).toHaveValue("./scripts/agent-seed.sh", { timeout: 10_000 });
+		await expect(timeout).toHaveValue("45000", { timeout: 10_000 });
+
+		// Accept the proposal as-is — the seeded fields must reach goal creation.
+		await clickCreate(page);
+
+		const created = await findGoalByTitle("E2E Test Goal");
+		expect(created).toBeTruthy();
+		try {
+			expect(created.worktreeSetupCommand).toBe("./scripts/agent-seed.sh");
+			expect(created.worktreeSetupTimeoutMs).toBe(45000);
+
+			await page.reload();
+			const reloaded = await findGoalByTitle("E2E Test Goal");
+			expect(reloaded).toBeTruthy();
+			expect(reloaded.worktreeSetupCommand).toBe("./scripts/agent-seed.sh");
+			expect(reloaded.worktreeSetupTimeoutMs).toBe(45000);
 		} finally {
 			if (created) await deleteGoal(created.id);
 		}

--- a/tests/worktree-pool.test.ts
+++ b/tests/worktree-pool.test.ts
@@ -251,6 +251,39 @@ describe("WorktreePool — components[*].worktreeSetupCommand is the source of t
 		}
 	});
 
+	it("threads the project worktree_setup_timeout_ms into pool component setup", async () => {
+		const repo = await makeRepo();
+		try {
+			const components: Component[] = [
+				{ name: "app", repo: ".", worktreeSetupCommand: "sleep 5; touch SETUP_RAN" },
+			];
+			const pool = new WorktreePool({
+				repoPath: repo,
+				targetSize: 1,
+				componentsResolver: () => components,
+				// Tiny project default — the setup command sleeps far longer, so the
+				// resolved timeout must kill it before it can create the marker. Without
+				// threading (hardcoded 120000) the sleep would finish and the marker
+				// would appear. Mirrors the per-goal timeout-resolution path.
+				setupTimeoutResolver: () => 50,
+			});
+			pool.startFilling();
+			for (let i = 0; i < 100 && pool.size === 0; i++) {
+				await new Promise(r => setTimeout(r, 100));
+			}
+			assert.equal(pool.size, 1, "pool should still publish the entry (setup failure is non-fatal)");
+			const u = await pool.claim("session/abcd1234");
+			assert.ok(u);
+			assert.equal(
+				fs.existsSync(path.join(u!.worktreePath, "SETUP_RAN")),
+				false,
+				"component setup must be killed by the resolved project timeout before touching the marker",
+			);
+		} finally {
+			await rmRepo(repo);
+		}
+	});
+
 	it("single-repo pool fill is a no-op when no component declares worktreeSetupCommand", async () => {
 		const repo = await makeRepo();
 		try {

--- a/tests/worktree-setup-goal.test.ts
+++ b/tests/worktree-setup-goal.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Per-goal worktree setup hook + configurable timeout.
+ *
+ * Covers the pure helpers in `src/server/skills/worktree-setup.ts`:
+ *   - `resolveSetupTimeoutMs` precedence + invalid-value fallback
+ *   - `runGoalSetup` exec invocation (cwd + injected env), blank skip,
+ *     failure propagation, and the BOBBIT_TEST_RECORD_SETUP audit line.
+ *
+ * The runner takes an injected `exec`, so no real shell is needed.
+ * See the per-goal worktree setup design doc.
+ */
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+	DEFAULT_WORKTREE_SETUP_TIMEOUT_MS,
+	resolveSetupTimeoutMs,
+	runGoalSetup,
+} from "../src/server/skills/worktree-setup.ts";
+
+describe("resolveSetupTimeoutMs", () => {
+	it("exposes the documented 120s default constant", () => {
+		assert.equal(DEFAULT_WORKTREE_SETUP_TIMEOUT_MS, 120_000);
+	});
+
+	it("returns the default when nothing is supplied", () => {
+		assert.equal(resolveSetupTimeoutMs(), DEFAULT_WORKTREE_SETUP_TIMEOUT_MS);
+		assert.equal(resolveSetupTimeoutMs({}), DEFAULT_WORKTREE_SETUP_TIMEOUT_MS);
+	});
+
+	it("prefers a finite positive goal override over project + default", () => {
+		assert.equal(
+			resolveSetupTimeoutMs({ goalTimeoutMs: 5000, projectTimeoutMs: 9000 }),
+			5000,
+		);
+	});
+
+	it("falls back to the project default when the goal value is absent", () => {
+		assert.equal(resolveSetupTimeoutMs({ projectTimeoutMs: 9000 }), 9000);
+	});
+
+	it("accepts a numeric-string project default (project config stores strings)", () => {
+		assert.equal(resolveSetupTimeoutMs({ projectTimeoutMs: "30000" }), 30_000);
+	});
+
+	it("floors fractional values", () => {
+		assert.equal(resolveSetupTimeoutMs({ goalTimeoutMs: 1500.9 }), 1500);
+	});
+
+	it("falls through invalid / zero / negative / non-finite goal values to the project default", () => {
+		for (const bad of [0, -1, -1000, Number.NaN, Number.POSITIVE_INFINITY, "nope", "", "  ", null, undefined, {}, []]) {
+			assert.equal(
+				resolveSetupTimeoutMs({ goalTimeoutMs: bad as unknown, projectTimeoutMs: 7000 }),
+				7000,
+				`goal value ${String(bad)} should fall through to the project default`,
+			);
+		}
+	});
+
+	it("falls through invalid project values to the 120s default", () => {
+		for (const bad of [0, -5, Number.NaN, Number.POSITIVE_INFINITY, "abc", "", null, undefined]) {
+			assert.equal(
+				resolveSetupTimeoutMs({ projectTimeoutMs: bad as unknown }),
+				DEFAULT_WORKTREE_SETUP_TIMEOUT_MS,
+				`project value ${String(bad)} should fall through to the default`,
+			);
+		}
+	});
+});
+
+describe("runGoalSetup", () => {
+	const recordFiles: string[] = [];
+	afterEach(() => {
+		delete process.env.BOBBIT_TEST_RECORD_SETUP;
+		for (const f of recordFiles.splice(0)) {
+			try { fs.rmSync(f, { force: true }); } catch { /* best-effort */ }
+		}
+	});
+
+	const baseOpts = {
+		goalId: "goal-123",
+		branch: "goal/feature-x",
+		worktreePath: "/wt/branch-x",
+		cwd: "/wt/branch-x/app",
+		primaryWorktreeRoot: "/repo",
+	};
+
+	it("invokes exec exactly once with the resolved cwd and injected env", async () => {
+		const calls: Array<{ cmd: string; cwd: string; env: NodeJS.ProcessEnv }> = [];
+		await runGoalSetup({
+			...baseOpts,
+			command: "setup.sh",
+			exec: async (cmd, cwd, env) => { calls.push({ cmd, cwd, env }); },
+		});
+
+		assert.equal(calls.length, 1);
+		assert.equal(calls[0].cmd, "setup.sh");
+		// cwd is the offset-applied goal cwd, where the team will actually work.
+		assert.equal(calls[0].cwd, "/wt/branch-x/app");
+
+		// Injected goal-context env vars.
+		assert.equal(calls[0].env.SOURCE_REPO, "/repo");
+		assert.equal(calls[0].env.BOBBIT_GOAL_ID, "goal-123");
+		assert.equal(calls[0].env.BOBBIT_GOAL_BRANCH, "goal/feature-x");
+		assert.equal(calls[0].env.BOBBIT_WORKTREE_PATH, "/wt/branch-x");
+		// Inherited process env is preserved (spot-check PATH presence).
+		assert.equal(calls[0].env.PATH, process.env.PATH);
+	});
+
+	it("trims the command before passing it to exec", async () => {
+		const calls: string[] = [];
+		await runGoalSetup({
+			...baseOpts,
+			command: "   npm run seed   ",
+			exec: async (cmd) => { calls.push(cmd); },
+		});
+		assert.deepEqual(calls, ["npm run seed"]);
+	});
+
+	it("skips exec entirely for a blank / absent command", async () => {
+		let called = false;
+		const exec = async () => { called = true; };
+		await runGoalSetup({ ...baseOpts, command: undefined, exec });
+		await runGoalSetup({ ...baseOpts, command: "", exec });
+		await runGoalSetup({ ...baseOpts, command: "   ", exec });
+		assert.equal(called, false);
+	});
+
+	it("propagates exec failures (per-goal setup is fatal)", async () => {
+		await assert.rejects(
+			runGoalSetup({
+				...baseOpts,
+				command: "boom",
+				exec: async () => { throw new Error("setup blew up"); },
+			}),
+			/setup blew up/,
+		);
+	});
+
+	it("writes a distinguishable per-goal BOBBIT_TEST_RECORD_SETUP audit line", async () => {
+		const recordFile = path.join(
+			fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-goal-setup-")),
+			"record.tsv",
+		);
+		recordFiles.push(recordFile);
+		process.env.BOBBIT_TEST_RECORD_SETUP = recordFile;
+
+		await runGoalSetup({
+			...baseOpts,
+			command: "  setup.sh  ",
+			exec: async () => { /* no-op */ },
+		});
+
+		const contents = fs.readFileSync(recordFile, "utf-8").trim();
+		// Format: goal\t<goalId>\t<cwd>\t<SOURCE_REPO>\t<command>
+		assert.equal(contents, ["goal", "goal-123", "/wt/branch-x/app", "/repo", "setup.sh"].join("\t"));
+	});
+
+	it("does not write an audit line for a blank command", async () => {
+		const recordFile = path.join(
+			fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-goal-setup-")),
+			"record.tsv",
+		);
+		recordFiles.push(recordFile);
+		process.env.BOBBIT_TEST_RECORD_SETUP = recordFile;
+
+		await runGoalSetup({ ...baseOpts, command: "  ", exec: async () => {} });
+
+		assert.equal(fs.existsSync(recordFile), false, "blank command must not append an audit line");
+	});
+});

--- a/tests/worktree-setup-goal.test.ts
+++ b/tests/worktree-setup-goal.test.ts
@@ -46,12 +46,18 @@ describe("resolveSetupTimeoutMs", () => {
 		assert.equal(resolveSetupTimeoutMs({ projectTimeoutMs: "30000" }), 30_000);
 	});
 
-	it("floors fractional values", () => {
-		assert.equal(resolveSetupTimeoutMs({ goalTimeoutMs: 1500.9 }), 1500);
+	it("rejects fractional values rather than flooring them", () => {
+		// Design requires finite positive INTEGERS. A fractional goal override
+		// must fall through to the next tier, not be truncated.
+		assert.equal(resolveSetupTimeoutMs({ goalTimeoutMs: 1500.9 }), DEFAULT_WORKTREE_SETUP_TIMEOUT_MS);
+		assert.equal(resolveSetupTimeoutMs({ goalTimeoutMs: 1500.9, projectTimeoutMs: 7000 }), 7000);
+		// "0.5" must fall back, not resolve to 0.
+		assert.equal(resolveSetupTimeoutMs({ goalTimeoutMs: "0.5", projectTimeoutMs: 7000 }), 7000);
+		assert.equal(resolveSetupTimeoutMs({ projectTimeoutMs: "2.5" }), DEFAULT_WORKTREE_SETUP_TIMEOUT_MS);
 	});
 
-	it("falls through invalid / zero / negative / non-finite goal values to the project default", () => {
-		for (const bad of [0, -1, -1000, Number.NaN, Number.POSITIVE_INFINITY, "nope", "", "  ", null, undefined, {}, []]) {
+	it("falls through invalid / zero / negative / fractional / non-finite goal values to the project default", () => {
+		for (const bad of [0, -1, -1000, 0.5, 1.9, "0.5", "1.5", Number.NaN, Number.POSITIVE_INFINITY, "nope", "", "  ", null, undefined, {}, []]) {
 			assert.equal(
 				resolveSetupTimeoutMs({ goalTimeoutMs: bad as unknown, projectTimeoutMs: 7000 }),
 				7000,
@@ -61,7 +67,7 @@ describe("resolveSetupTimeoutMs", () => {
 	});
 
 	it("falls through invalid project values to the 120s default", () => {
-		for (const bad of [0, -5, Number.NaN, Number.POSITIVE_INFINITY, "abc", "", null, undefined]) {
+		for (const bad of [0, -5, 0.5, 2.5, "0.5", "2.5", Number.NaN, Number.POSITIVE_INFINITY, "abc", "", null, undefined]) {
 			assert.equal(
 				resolveSetupTimeoutMs({ projectTimeoutMs: bad as unknown }),
 				DEFAULT_WORKTREE_SETUP_TIMEOUT_MS,


### PR DESCRIPTION
## Summary

- Add optional per-goal `worktreeSetupCommand` and `worktreeSetupTimeoutMs` fields across goal persistence, REST creation, `propose_goal`, and the goal creation UI.
- Run the per-goal setup command once during goal worktree provisioning after component setup, including pool-claimed worktrees, with fatal setup error handling.
- Replace the hardcoded setup timeout with shared timeout resolution: goal override → project `worktree_setup_timeout_ms` → 120000 ms.
- Add unit, API E2E, pool, and browser E2E coverage plus documentation.

## Verification

- `npm run check`
- `npm run test:unit`
- `npm run test:e2e`
- Workflow implementation and documentation gates passed.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
