### PR TITLE
Fix live message ordering after compaction

### DIFF
--- a/docs/design/fix-compaction-ordering.md
+++ b/docs/design/fix-compaction-ordering.md
@@ -1,0 +1,461 @@
+# Fix Compaction Ordering (live vs reload divergence)
+
+Status: **implemented**. Targets the goal "Fix Compaction Ordering"
+(follow-up to PR #817 "Fix compaction history recovery").
+
+§0–§6 below are the original investigation/design. §8 records the **final
+implementation** as shipped — read it for what the code actually does; the
+earlier sections explain *why*.
+
+## 0. Symptom
+
+After PR #817, the pre-compaction history is recoverable, but in the **same
+live session immediately after compaction** the compaction summary card and its
+`Show N messages before compaction` affordance render **after** the preserved
+recent messages/tool rows. Navigating away and back, or reloading, fixes the
+order. This is the classic signature of a **live reducer/order-reconciliation
+bug** rather than a persisted transcript/sidecar bug: reload produces canonical
+ordering, live does not.
+
+Maintainer feedback: the 47 compacted messages' card should be at the *start* of
+the post-compaction window (before the preserved tail), not after it; message
+display around agent events feels fragile.
+
+This doc isolates the exact ordering model, confirms the root cause, and
+proposes a fix at the **shared ordering/reconciliation layer** (the reducer's
+snapshot dedup + the `compaction-result` transition) plus failing-first
+regression coverage.
+
+## 1. The ordering model today
+
+All ordering flows through the single pure reducer in
+`src/app/message-reducer.ts` (see `docs/design/unified-message-ordering-reducer.md`).
+Every row carries `_order` (primary sort key) and `_insertionTick` (secondary).
+`sortMessages` sorts `(_order ASC, _insertionTick ASC)` after every reduce, and
+render trusts the array verbatim (`MessageList.buildRenderItems` walks it
+in-order, prepending the `<bobbit-pre-compaction-history>` widget immediately
+before any `__compaction_summary` card that carries a `compactionId`).
+
+`_order` is assigned per action type:
+
+| Row | Action | `_order` assigned |
+|---|---|---|
+| Live `message_end` (user/assistant/toolResult) | `live-event` | `seq` (server-stamped, **positive**, monotonic) |
+| Snapshot row, no explicit `_order` | `snapshot` | `SNAPSHOT_ORDER_FLOOR + i` = `-1_000_000_000 + i` (**negative**) |
+| Snapshot row carrying explicit server `_order` | `snapshot` | that value verbatim |
+| Optimistic prompt/steer | `optimistic-*` | `OPTIMISTIC_ORDER_BASE + tick` (huge positive — always tail) |
+| Live in-progress compaction card (`compact_active`) | `compaction-placeholder` | `highestSeq + 0.5` (**positive**) |
+| Terminal compaction card (`compact_active`) + paired toolResult | `compaction-result` | `highestSeq + 0.5` (card), `+0.001` (toolResult) (**positive**) |
+| `system-notification` / `error` / `mutation-pending` | resp. | `highestSeq + 0.5` (**positive**) |
+
+`highestSeq` tracks the highest **live** seq consumed (snapshots are negative
+and never raise it). So all the synthetic "+0.5" rows are anchored to *tail
+position relative to the live messages seen so far*.
+
+### 1.1 The compaction card has two lifecycles
+
+**Live emission (`remote-agent.ts`):**
+- `compaction_start`/`auto_compaction_start` → `_addCompactingPlaceholder()` →
+  `compaction-placeholder` action injects a RICH in-progress synthetic with
+  stable id `compact_active`. The in-progress payload (`buildInProgressCompactionPayload`)
+  carries **no `compactionId`**.
+- `compaction_end`/`auto_compaction_end` → after a `COMPACT_CARD_MIN_DURATION`
+  (2500 ms) floor, `transitionCard()` fires `compaction-result`. Only here does
+  the card gain `compactionId` (from `event.compactionId`). The terminal card
+  keeps id `compact_active` for single-DOM-identity continuity. The transition
+  is frequently deferred inside a `setTimeout`, so it can land **after** the
+  server's post-compaction snapshot.
+
+**Persisted/reload splice (`compaction-sidecar.ts`):**
+- `mergeCompactionSidecarIntoMessages(sessionId, messages)` reads sidecar
+  entries and, for each, builds `syntheticCompactionRowsFromSidecar` — an
+  assistant `__compaction_summary` row whose id is the sidecar **`entry.id`**
+  (NOT `compact_active`) plus a paired toolResult. Both carry `compactionId =
+  entry.id`. The block is **prepended** to the message list, on the assumption
+  the reducer's snapshot stamping (`SNAPSHOT_ORDER_FLOOR + i`) then makes the
+  card sort before the kept tail.
+- `hasLiveActive` guard: when a live `compact_active` summary toolCall is
+  already in the array, the most-recent sidecar row is dropped from the splice
+  (same compaction, two surfaces) — this guard runs in the **server-side
+  get_messages pipeline**, not in the live client reducer.
+
+### 1.2 Live↔snapshot compaction dedup in the reducer
+
+In the `snapshot` action:
+- `hasRichSyntheticCompaction` → drop the server's legacy plain-text marker.
+- `liveCompactionIds`: collect `compactionId`s from any state row with id
+  `compact_active`. If non-empty, **drop** from the incoming snapshot every row
+  whose `compactionSummaryId` is in that set, plus its paired toolResult
+  (`compaction-summary:<id>`). Rationale: the live card already hosts the
+  affordance; reuse one DOM node, avoid a duplicate. On reload there is no
+  `compact_active`, so this set is empty and the persisted sidecar synthetic
+  survives with its canonical (negative, prepended) `_order`.
+
+In the `compaction-result` action:
+- Drop `compacting_placeholder`, `compact_active`, and (when the terminal card
+  has a `compactionId`) any persisted sidecar card with the same
+  `compactionId` + its paired toolResult. Then push the new card at `highestSeq
+  + 0.5` and the toolResult at `+0.001`.
+
+### 1.3 What the post-compaction snapshot contains
+
+pi-coding-agent's `getMessages()` after compaction returns only the **active
+branch**: the summary entry + the preserved tail from `firstKeptEntryId`. Bobbit's
+server pipeline runs `mergeCompactionSidecarIntoMessages`, prepending the
+persisted sidecar card+toolResult. None of the preserved-tail rows carry an
+explicit `_order`, so in the reducer they are stamped `SNAPSHOT_ORDER_FLOOR + i`
+(negative). The preserved-tail rows that were *also* live events in this session
+get dropped from the live copy by id-match in the survivor pass, leaving the
+snapshot's **negative-ordered** copies as the survivors.
+
+## 2. Root cause (confirmed)
+
+The divergence is a missing **positional reconciliation** when the reducer keeps
+a live row in place of the snapshot row that represents the same logical entity.
+
+After compaction, the surviving state is:
+
+- live `compact_active` card: `_order = highestSeq + 0.5` → **positive**
+- live `compact_active` paired toolResult: `_order = highestSeq + 0.501`
+- preserved tail rows (from the snapshot): `_order = SNAPSHOT_ORDER_FLOOR + i`
+  → **negative**
+
+Sorting `_order ASC` puts every negative-ordered preserved-tail row **before**
+the positive-ordered card. Result: the card + affordance render *after* the
+preserved recent messages. This is the reported bug.
+
+On **reload** there is no `compact_active` in state, so the snapshot's persisted
+sidecar card survives. Because `mergeCompactionSidecarIntoMessages` **prepends**
+it, it is stamped `SNAPSHOT_ORDER_FLOOR + 0/1` — the most-negative orders — so it
+sorts **before** the preserved tail. Canonical, correct ordering.
+
+So: **reload works because the persisted card gets canonical (prepended,
+most-negative) snapshot ordering; live is wrong because the surviving
+`compact_active` card retains a stale pre-compaction positive `_order` while the
+preserved tail it should precede gets fresh negative snapshot orders.** When the
+reducer drops the snapshot's authoritative persisted card (`liveCompactionIds`
+branch) in favour of the live card, it discards the card's canonical position
+and never transfers it to the survivor. Confirms the goal's initial hypothesis.
+
+This is a shared-layer flaw, not compaction-specific cosmetics: the reducer's
+contract is "server snapshot is authoritative for any id/entity it contains."
+For toolResult and plain-text equivalence the reducer enforces this by **dropping
+the live row** (snapshot wins outright). The compaction card is the one entity
+where the reducer deliberately **keeps the live row** (DOM continuity) but
+**drops the snapshot row** — and that asymmetry is exactly where positional
+authority is lost. The same class of bug can affect any future "keep live,
+discard snapshot-equivalent" reconciliation; the fix should establish the
+invariant generally: *a live row retained in place of a snapshot-equivalent row
+inherits the snapshot row's `_order`.*
+
+### 2.1 Two timing sub-cases (both end at the bug)
+
+1. **Snapshot lands after the terminal transition** (live card has
+   `compactionId`): the `snapshot` `liveCompactionIds` branch drops the
+   persisted card; live card keeps `highestSeq + 0.5`. Bug.
+2. **Snapshot lands before the terminal transition** (in-progress card has no
+   `compactionId`): the persisted card survives the snapshot (good, negative
+   order). Then the deferred `compaction-result` fires, drops the matching
+   persisted card by `compactionId`, and pushes the new `compact_active` at
+   `highestSeq + 0.5`. The good negative-ordered card is replaced by a
+   positive-ordered one. Bug.
+
+Therefore the fix must cover **both** the `snapshot` displacement path and the
+`compaction-result` displacement path. Both are instances of the same invariant.
+
+## 3. Failing-test-first plan
+
+Land these BEFORE touching production code; confirm the listed pre-fix failure.
+
+### 3.1 Primary repro — pure reducer unit test (fast, deterministic)
+
+File: `tests/message-reducer.test.ts` (unit·node). New cases, naming follows the
+existing `(12x)` compaction family:
+
+- **`(12e) live compact_active card sorts before preserved tail after
+  post-compaction snapshot`**
+  Sequence: a few live `message_end`s → `compaction-placeholder` (`compact_active`)
+  → `compaction-result` with `compactionId: "c_x"` → `snapshot` whose rows are
+  `[persistedCard(c_x), persistedTR(c_x), keptUser, keptAsst]` (no explicit
+  `_order`; mirrors the server splice that prepends the persisted card).
+  Assert the resulting `id`/`role` order is
+  `["compact_active", <paired toolResult>, "kept-user", "kept-asst"]` — card
+  FIRST.
+  **Pre-fix failure**: order is `["kept-user", "kept-asst", "compact_active",
+  …]` — the card sits after the tail; the `deepStrictEqual` on
+  `s.messages.map(m => m.id)` fails.
+
+- **`(12f) snapshot-before-terminal-transition still anchors card before tail`**
+  Same but apply the `snapshot` (persisted card present, no live `compactionId`
+  yet) BEFORE the `compaction-result` transition. Assert card-first ordering
+  afterwards. **Pre-fix failure**: the persisted card is dropped and re-pushed
+  positive; card lands after tail.
+
+- **`(12g) live ordering equals reload ordering`**
+  Build two states from the same logical post-compaction transcript:
+  (a) *live* — placeholder → result → snapshot;
+  (b) *reload* — a single `snapshot` containing the prepended persisted card +
+  tail (no live card).
+  Assert the two `messages.map(m => ({ role, isCompactionCard }))` sequences are
+  equal (normalising the card id, since live uses `compact_active` and reload
+  uses the sidecar id). **Pre-fix failure**: live places the card last, reload
+  places it first → sequences differ.
+
+- **`(12h) exactly one compaction card after the post-compaction snapshot`**
+  Assert `messages.filter(isCompactionSummaryCard).length === 1` across both
+  timing sub-cases. Guards the PR #817 no-duplicate invariant against the fix.
+
+### 3.2 End-to-end DOM-order regression (browser)
+
+File: `tests/e2e/ui/pre-compaction-history.spec.ts`, extend the existing
+`@live-compaction-affordance` live test (which already asserts one card +
+affordance, but **not** vertical order). Add an assertion that the compaction
+card's DOM position precedes the first preserved-tail message — e.g. compare
+`boundingBox().y` of `[data-testid='compaction-summary-card']` against the first
+post-compaction `user-message`/`assistant-message`, or compare DOM index via
+`evaluate`. **Pre-fix failure**: card `y` is greater than the tail row's `y`
+(card below the preserved messages).
+
+Optionally add to `tests/e2e/ui/compaction-persistence.spec.ts` an explicit
+"live order == reload order" check: capture the ordered list of card + tail
+testids live, reload, and assert equality.
+
+## 4. Implementation plan
+
+All changes are in the shared reducer/reconciliation layer; **no render-time
+sorting in `MessageList`** (which must keep trusting `_order` verbatim).
+
+### 4.1 `src/app/message-reducer.ts` — `snapshot` action (sub-case 1)
+
+In the `liveCompactionIds` branch, instead of silently filtering the persisted
+card+toolResult out of `effectiveRows`, **capture the canonical `_order` they
+would receive** and transfer it to the surviving live rows:
+
+1. Compute the persisted card's canonical order. The simplest robust approach:
+   stamp `snapshotRows` over the **unfiltered** set so indices are canonical,
+   then partition out the rows whose `compactionSummaryId ∈ liveCompactionIds`
+   (and their paired `compaction-summary:<id>` toolResults), recording their
+   `_order`s, rather than removing them from `effectiveRows` before stamping.
+2. After building `survivors`/`merged`, locate the surviving live `compact_active`
+   card and its paired toolResult (`toolCallId === "compaction-summary:compact_active"`)
+   and override their `_order` to the recorded persisted card / toolResult
+   orders (card = persisted card order; toolResult = persisted toolResult order,
+   or card order + 0.001 when no persisted toolResult was present).
+3. Re-`sortMessages` (already done at the end of the action).
+
+Net effect: the live card inherits the prepended, most-negative snapshot order →
+sorts before the preserved tail, identical to reload. The dedup (single card)
+behaviour is unchanged.
+
+### 4.2 `src/app/message-reducer.ts` — `compaction-result` action (sub-case 2)
+
+When the terminal card carries a `resultCompactionId` and the state currently
+holds a persisted sidecar card with that `compactionId` (the snapshot landed
+first), **inherit that card's `_order`** for the new `compact_active` card
+instead of `highestSeq + 0.5` (and the toolResult at `inheritedOrder + 0.001`).
+Fall back to `highestSeq + 0.5` only when no persisted card is being displaced
+(e.g. the genuinely-live, snapshot-not-yet-arrived case — that ordering is
+corrected when the snapshot subsequently lands via 4.1).
+
+### 4.3 Factor the shared rule
+
+Extract a small helper, e.g. `compactionCardAnchorOrder(stateMessages,
+compactionId)`, returning the `_order` of the persisted/snapshot row that
+represents the compaction (or `null`). Both 4.1 and 4.2 call it. This makes the
+invariant — *the compaction card's `_order` is anchored to the snapshot position
+of the persisted sidecar row for the same compaction* — single-sourced and
+testable, rather than duplicated. Document the invariant in a code comment that
+references this doc and the pinning tests (per AGENTS.md: pin invariants in
+tests, not prose).
+
+### 4.4 Why not fix it in `compaction-sidecar.ts` or `MessageList`?
+
+- `compaction-sidecar.ts` already does the right thing (prepend → canonical
+  order); it only runs server-side in get_messages and has no visibility into
+  the live `compact_active` card's reducer `_order`. The bug is purely in the
+  live client reconciliation.
+- Sorting/repositioning in `MessageList.buildRenderItems` would re-introduce a
+  second source of ordering truth, violating the unified-reducer contract
+  (`docs/design/unified-message-ordering-reducer.md`) and would not fix the
+  underlying `_order` that other consumers (keys, defer heuristics) read. The
+  reducer is the single ordering authority; the fix belongs there.
+
+## 5. Invariants to pin in tests
+
+Encoded by §3 (extend as needed):
+
+1. **No duplicate compaction cards** — exactly one `__compaction_summary` card
+   after the full live sequence and after reload (`(12h)`; existing `(12b)–(12d)`
+   single-DOM-identity cases must stay green; E2E `cards.toHaveCount(1)`).
+2. **Card before preserved tail (live)** — the card+affordance `_order` is less
+   than every preserved-tail row's `_order` in the same live session
+   (`(12e)`,`(12f)`; E2E DOM-position assertion).
+3. **Live ordering ≡ reload ordering** — the normalised ordered role/kind
+   sequence is identical between the live-built and reload-built states
+   (`(12g)`; optional E2E live-vs-reload capture).
+4. **toolCall/toolResult adjacency + stability** — the compaction card's paired
+   `__compaction_summary` toolResult stays immediately adjacent (card order +
+   0.001 < first tail order); existing `(3)`/`(4)` toolResult ordering cases and
+   the snapshot toolCallId-equivalence dedup stay green.
+5. **PR #817 behaviour preserved** — affordance present in live session with
+   correct count, transient-404 count-probe retry intact, reload/navigate
+   persistence intact, pre-compaction rows read-only/dimmed and outside agent
+   context (existing pre-compaction-history + compaction-persistence specs stay
+   green).
+
+## 6. Risks and validation
+
+### Risks
+- **Order collision**: assigning the live card a negative order equal to a
+  snapshot row's must not tie-break wrongly. `_insertionTick` is the secondary
+  key; verify the card lands before its toolResult and before the tail. Use the
+  persisted card's exact order (and `+0.001` for the toolResult) to stay within
+  the `SNAPSHOT_ORDER_FLOOR + i` integer spacing.
+- **Multiple compactions in one session**: each card must anchor to *its own*
+  sidecar row's order; the helper keys on `compactionId`, so older cards keep
+  their earlier (more-negative) positions. Add/extend a case if needed.
+- **Snapshot churn**: repeated snapshots (visibilitychange resync) must keep the
+  card anchored, not drift it back to positive. Because the reducer re-derives
+  the anchor from the snapshot each time, this is idempotent — pin with a
+  double-snapshot case.
+- **In-progress (no compactionId) snapshots before terminal**: ensure the card
+  isn't duplicated while it lacks a `compactionId`; covered by `(12f)`/`(12h)`.
+
+### Validation commands
+```bash
+npm run check
+npm run test:unit                                   # message-reducer.test.ts (incl. new 12e–12h)
+npm run test:e2e -- pre-compaction-history          # @live-compaction-affordance DOM-order
+npm run test:e2e -- compaction-persistence          # reload/navigate persistence
+```
+
+## 7. PR
+
+PR #817 (`Fix compaction history recovery`) is already merged to `master`. This
+work opens a **new** PR off `origin/master`; the #817 branch must not be reused
+or pushed to.
+
+## 8. Final implementation (as shipped)
+
+The fix landed entirely in the shared reducer/reconciliation layer plus the
+server-side sidecar write timing. No render-time sorting was added;
+`MessageList` still trusts `_order` verbatim. All invariants are pinned by
+tests, not prose (per AGENTS.md).
+
+### 8.1 The shared anchor rule
+
+`src/app/message-reducer.ts` gained one helper that single-sources the
+invariant from §2/§4:
+
+```
+persistedCompactionAnchor(messages, compactionId)
+  → { cardOrder, toolResultOrder }
+```
+
+It returns the `_order` of the persisted/snapshot sidecar card for
+`compactionId` and its paired `compaction-summary:<id>` toolResult, **excluding
+the live `compact_active` surface itself** (`id !== "compact_active"`). `null`
+when no persisted row is present. Both displacement paths call it so the rule —
+*a live `compact_active` card retained in place of the snapshot-equivalent
+persisted card inherits that card's canonical `_order`* — exists in exactly one
+place. Pinned by `(12f)`–`(12k)`.
+
+### 8.2 Both terminal/snapshot timing paths
+
+The reducer corrects ordering regardless of which event lands first:
+
+- **Terminal-before-snapshot** (`snapshot` action, `liveCompactionIds` branch):
+  the snapshot stamps the **full** row set first so canonical
+  `SNAPSHOT_ORDER_FLOOR + i` orders reflect the server's prepended splice
+  position, then partitions out the persisted card+toolResult that the live
+  `compact_active` already represents — **recording** their orders instead of
+  dropping them blind. After the survivor merge, the surviving live card and its
+  paired toolResult inherit the recorded (negative, prepended) orders, so they
+  sort before the negative-ordered preserved tail. Pinned by `(12f)`.
+- **Snapshot-before-terminal** (`compaction-result` action): when a persisted
+  sidecar card for the terminal card's `compactionId` already sits in state, the
+  new `compact_active` card inherits that card's anchor order instead of the
+  positive `highestSeq + 0.5` tail anchor (which would re-sink it below the
+  tail). Fallback chain: persisted anchor → existing live `compact_active`
+  card's `_order` (interim case below already moved it negative) → `highestSeq +
+  0.5` only for the genuinely-live, snapshot-not-yet-arrived case (corrected
+  when that snapshot lands via the `snapshot` path). Pinned by `(12g)`.
+
+`(12h)` asserts the two paths produce **identical** ordering to a reload-built
+state (single snapshot, no live card) after normalising card identity
+(`compact_active` vs sidecar id).
+
+### 8.3 Interim duplicate-card window
+
+Between a post-compaction snapshot landing and the deferred
+`compaction-result` firing, the live `compact_active` card is still
+in-progress and carries **no `compactionId`**, so the cid-keyed dedup cannot
+match it. Without handling this, both the persisted sidecar card and the live
+card would survive (two stacked cards). The `snapshot` action detects an
+in-progress live card (`hasInProgressLiveCard`) and treats the **most recent**
+persisted sidecar card in the snapshot (greatest `_order` among sidecar cards —
+the latest row `mergeCompactionSidecarIntoMessages` prepended) as the pending
+anchor: it drops that card + its paired toolResult and transfers their
+canonical orders onto the in-progress `compact_active`. Result: exactly one
+card during the window, positioned before the tail. Pinned by `(12k)`.
+
+### 8.4 Manual `/compact` sidecar write timing
+
+The live affordance can only mount in the same session if the post-compaction
+snapshot already carries the orphan boundary, which requires the sidecar row to
+be persisted **before** `refreshAfterCompaction` broadcasts that snapshot. The
+manual path was reworked so the success row is written synchronously in
+`src/server/agent/session-manager.ts`'s manual `compaction_end` branch —
+*before* it calls `refreshAfterCompaction` — reusing the shared `compactionId`
+that `src/server/ws/handler.ts` stashes on the session (`_manualCompactionId`)
+before awaiting the compact RPC. The agent emits that manual `compaction_end`
+before the RPC promise resolves, so the row is durable by the time the snapshot
+goes out.
+
+Duplicate prevention: when session-manager's append succeeds it sets
+`session._manualSidecarWritten = compactionId`. The ws-handler success branch is
+now a **fallback** — it appends only when that marker is absent (e.g. the agent
+emitted no successful manual `compaction_end` with a result payload). The
+ws-handler still **owns the failure append** (RPC rejected) and clears the
+marker defensively. This keeps exactly one sidecar line per manual compaction.
+
+### 8.5 Stale paired-toolResult cleanup
+
+`compaction-placeholder` previously filtered the prior `compact_active`
+assistant card by id but left its paired synthetic toolResult
+(`toolCallId === "compaction-summary:compact_active"`) behind, so a *second*
+compaction in the same session orphaned a detached row. The placeholder filter
+now also drops that toolResult, mirroring the `compaction-result` filter.
+Pinned by `(12j)`.
+
+### 8.6 Regression coverage
+
+- `tests/message-reducer.test.ts` — `(12f)` terminal-before-snapshot,
+  `(12g)` snapshot-before-terminal, `(12h)` live≡reload ordering,
+  `(12i)` exactly-one-card + adjacent toolResult across both paths,
+  `(12j)` placeholder removes stale paired toolResult,
+  `(12k)` interim single-card-before-tail.
+- `tests/e2e/ui/pre-compaction-history.spec.ts` —
+  `@live-compaction-affordance` now asserts **DOM document order**: both the
+  `[data-testid='compaction-summary-card']` and the
+  `[data-testid='pre-compaction-history']` affordance appear before the first
+  preserved-tail `assistant-message` in the same live session (no reload), plus
+  the existing one-card / count-probe-404-recovery checks.
+
+### 8.7 PR #817 behaviour preserved
+
+Single card (`(12i)`, E2E `toHaveCount(1)`), transient-404 count-probe retry,
+reload/navigate persistence, and read-only/dimmed orphaned pre-compaction rows
+are all unchanged — see `docs/design/persist-compaction-history.md` for those
+durable sidecar/affordance invariants.
+
+## References
+- `docs/design/unified-message-ordering-reducer.md` — single-ordinal reducer contract.
+- `docs/design/persist-compaction-history.md` — sidecar storage + splice (§A, §3, §6.3).
+- `docs/design/compaction-e2e-rich-summary.md` — rich summary card lifecycle (§7.3, §7.4).
+- `src/app/message-reducer.ts`, `src/server/agent/compaction-sidecar.ts`,
+  `src/app/remote-agent.ts`, `src/ui/components/MessageList.ts`.
+- Tests: `tests/message-reducer.test.ts`, `tests/e2e/ui/pre-compaction-history.spec.ts`,
+  `tests/e2e/ui/compaction-persistence.spec.ts`.
+</content>
+</invoke>

--- a/docs/design/persist-compaction-history.md
+++ b/docs/design/persist-compaction-history.md
@@ -134,6 +134,19 @@ terminate).
 
 #### 3.3.1 Manual path — `src/server/ws/handler.ts`
 
+> **Implementation update (Fix Compaction Ordering).** The manual success row
+> is now written in `src/server/agent/session-manager.ts`'s manual
+> `compaction_end` branch, **synchronously before `refreshAfterCompaction`**,
+> reusing a shared `compactionId` that `ws/handler.ts` stashes on the session
+> (`_manualCompactionId`) before awaiting the compact RPC. This guarantees the
+> post-compaction snapshot already carries the orphan boundary so the live
+> `compact_active` card mounts the affordance in the same session and sorts
+> before the preserved tail. The `ws/handler.ts` block below became the
+> **fallback** success append (writes only when `_manualSidecarWritten` is
+> unset) and still owns the **failure** append. The dedup marker keeps exactly
+> one sidecar line per manual compaction. See
+> `docs/design/fix-compaction-ordering.md` §8.4.
+
 Around the existing `compaction_end` broadcast (lines 553–573). Capture
 `startedAt` at the broadcast of `compaction_start` (line 554); compute
 `durationMs` at `compaction_end` (line 566). The RPC return

--- a/src/app/message-reducer.ts
+++ b/src/app/message-reducer.ts
@@ -171,6 +171,39 @@ function isLegacyTextCompaction(m: any): boolean {
 	return typeof t === "string" && t.startsWith("Context compacted");
 }
 
+/**
+ * Shared ordering invariant (docs/design/fix-compaction-ordering.md §2, §4):
+ * a live `compact_active` card retained in place of the persisted/snapshot
+ * sidecar card for the SAME `compactionId` must inherit that persisted row's
+ * canonical `_order` (and its paired toolResult's `_order`) — otherwise the
+ * live card keeps a stale positive `highestSeq + 0.5` order and sorts AFTER
+ * the negative-ordered preserved tail, diverging from reload ordering.
+ *
+ * Returns the persisted card / paired-toolResult `_order`s for `compactionId`,
+ * EXCLUDING the live `compact_active` surface itself (id !== compact_active).
+ * `null` when no persisted row is present. Pinned by message-reducer.test.ts
+ * cases (12f)/(12g)/(12h)/(12i).
+ */
+function persistedCompactionAnchor(
+	messages: OrderedMessage[],
+	compactionId: string,
+): { cardOrder: number | null; toolResultOrder: number | null } {
+	let cardOrder: number | null = null;
+	let toolResultOrder: number | null = null;
+	const pairedToolCallId = `compaction-summary:${compactionId}`;
+	for (const m of messages) {
+		if (m.id !== COMPACTION_ACTIVE_ID && compactionSummaryId(m) === compactionId) {
+			cardOrder = m._order;
+		} else if (
+			m.role === "toolResult"
+			&& (m as any).toolCallId === pairedToolCallId
+		) {
+			toolResultOrder = m._order;
+		}
+	}
+	return { cardOrder, toolResultOrder };
+}
+
 // `parseTokensBeforeFromServerMarker` and `upgradeServerCompactionMarker`
 // removed. With the compaction sidecar (docs/design/persist-compaction-
 // history.md §A), the server splices the rich synthetic into snapshots
@@ -375,16 +408,50 @@ export function reduce(state: ReducerState, action: Action): ReducerState {
 			// in state, so this set is empty and the persisted synthetic survives
 			// untouched (reload persistence preserved).
 			const liveCompactionIds = new Set<string>();
+			// Interim duplicate-card window (docs/design/fix-compaction-ordering.md
+			// §4.1, HIGH finding): when a post-compaction snapshot arrives while the
+			// live `compact_active` card is still in-progress and carries NO
+			// `compactionId`, the cid-keyed dedup below can't see it, so BOTH the
+			// persisted sidecar card and the live card would survive until the
+			// deferred `compaction-result` fires. Track the in-progress live card so
+			// we can anchor it to the persisted sidecar card's position instead.
+			let hasInProgressLiveCard = false;
 			for (const m of state.messages) {
 				if (m._origin === "synthetic" && m.id === COMPACTION_ACTIVE_ID) {
 					const cid = compactionSummaryId(m);
 					if (cid) liveCompactionIds.add(cid);
+					else hasInProgressLiveCard = true;
 				}
 			}
+			// Stamp the FULL row set FIRST so canonical snapshot `_order`s
+			// (SNAPSHOT_ORDER_FLOOR + index) are computed over the unfiltered,
+			// server-spliced ordering — the persisted compaction card keeps the
+			// most-negative (prepended) position the server gave it. We then
+			// partition out the persisted compaction rows that a live
+			// `compact_active` card already represents, RECORDING their canonical
+			// orders, instead of dropping them before stamping. The surviving
+			// live card inherits those orders below so live ordering matches
+			// reload (docs/design/fix-compaction-ordering.md §4.1).
+			const stampedAll: OrderedMessage[] = effectiveRows.map((m, i) => {
+				const explicit = (m as any)._order;
+				const order = typeof explicit === "number" ? explicit : SNAPSHOT_ORDER_FLOOR + i;
+				return stamp(m, "server", order, tick);
+			});
+			const compactionAnchors = new Map<
+				string,
+				{ cardOrder: number | null; toolResultOrder: number | null }
+			>();
+			// Anchor transferred to an IN-PROGRESS live `compact_active` card (no
+			// compactionId yet) from the persisted sidecar card it duplicates.
+			let inProgressAnchor: { cardOrder: number; toolResultOrder: number | null } | null = null;
+			let snapshotRows: OrderedMessage[] = stampedAll;
 			if (liveCompactionIds.size > 0) {
+				for (const cid of liveCompactionIds) {
+					compactionAnchors.set(cid, persistedCompactionAnchor(stampedAll, cid));
+				}
 				const pairedToolCallIds = new Set<string>();
 				for (const id of liveCompactionIds) pairedToolCallIds.add(`compaction-summary:${id}`);
-				effectiveRows = effectiveRows.filter((m: any) => {
+				snapshotRows = stampedAll.filter((m: any) => {
 					const cid = compactionSummaryId(m);
 					if (cid && liveCompactionIds.has(cid)) return false;
 					if (
@@ -394,12 +461,38 @@ export function reduce(state: ReducerState, action: Action): ReducerState {
 					) return false;
 					return true;
 				});
+			} else if (hasInProgressLiveCard) {
+				// Interim case: the live card has no compactionId, so we can't match
+				// by cid. Treat the MOST RECENT persisted sidecar compaction card in
+				// the snapshot (greatest `_order` among sidecar cards — the latest row
+				// prepended by mergeCompactionSidecarIntoMessages) as the pending live
+				// compaction anchor. Drop that card + its paired toolResult and stash
+				// their canonical orders so the surviving in-progress live card sorts
+				// before the preserved tail — exactly one card during the window.
+				let bestCard: OrderedMessage | null = null;
+				for (const m of stampedAll) {
+					if (m.id !== COMPACTION_ACTIVE_ID && compactionSummaryId(m) !== null) {
+						if (bestCard === null || m._order > bestCard._order) bestCard = m;
+					}
+				}
+				if (bestCard) {
+					const bestCid = compactionSummaryId(bestCard) as string;
+					const pairedToolCallId = `compaction-summary:${bestCid}`;
+					let trOrder: number | null = null;
+					for (const m of stampedAll) {
+						if (m.role === "toolResult" && (m as any).toolCallId === pairedToolCallId) {
+							trOrder = m._order;
+						}
+					}
+					inProgressAnchor = { cardOrder: bestCard._order, toolResultOrder: trOrder };
+					const dropCard = bestCard;
+					snapshotRows = stampedAll.filter((m: any) => {
+						if (m === dropCard) return false;
+						if (m.role === "toolResult" && (m as any).toolCallId === pairedToolCallId) return false;
+						return true;
+					});
+				}
 			}
-			const snapshotRows: OrderedMessage[] = effectiveRows.map((m, i) => {
-				const explicit = (m as any)._order;
-				const order = typeof explicit === "number" ? explicit : SNAPSHOT_ORDER_FLOOR + i;
-				return stamp(m, "server", order, tick);
-			});
 
 			const serverIds = new Set<string>();
 			// Equivalence sets keyed on toolCallId — the snapshot is authoritative
@@ -577,7 +670,57 @@ export function reduce(state: ReducerState, action: Action): ReducerState {
 				survivors.push(m);
 			}
 
-			const merged = [...snapshotRows, ...survivors];
+			let merged = [...snapshotRows, ...survivors];
+			// Transfer the displaced persisted card's canonical `_order` to the
+			// surviving live `compact_active` card + its paired toolResult, so the
+			// card+affordance sort BEFORE the negative-ordered preserved tail —
+			// identical to reload (docs/design/fix-compaction-ordering.md §4.1;
+			// pinned by (12f)/(12h)). Pure: replace via spread, never mutate the
+			// prior-state survivor objects in place.
+			if (compactionAnchors.size > 0) {
+				const liveCard = merged.find(
+					(m) => m._origin === "synthetic" && m.id === COMPACTION_ACTIVE_ID,
+				);
+				const liveCid = liveCard ? compactionSummaryId(liveCard) : null;
+				const anchor = liveCid ? compactionAnchors.get(liveCid) : undefined;
+				if (anchor && anchor.cardOrder !== null) {
+					const cardOrder = anchor.cardOrder;
+					const trOrder = anchor.toolResultOrder ?? cardOrder + 0.001;
+					merged = merged.map((m) => {
+						if (m._origin === "synthetic" && m.id === COMPACTION_ACTIVE_ID) {
+							return { ...m, _order: cardOrder };
+						}
+						if (
+							m.role === "toolResult"
+							&& (m as any).toolCallId === `compaction-summary:${COMPACTION_ACTIVE_ID}`
+						) {
+							return { ...m, _order: trOrder };
+						}
+						return m;
+					});
+				}
+			} else if (inProgressAnchor) {
+				// Transfer the displaced persisted card's canonical (negative) order to
+				// the surviving IN-PROGRESS live `compact_active` card. Its paired
+				// toolResult usually doesn't exist yet (the in-progress placeholder is
+				// a bare toolCall), so the toolResult branch is a no-op until the
+				// terminal transition. This makes the interim window show exactly one
+				// card, positioned before the preserved tail.
+				const cardOrder = inProgressAnchor.cardOrder;
+				const trOrder = inProgressAnchor.toolResultOrder ?? cardOrder + 0.001;
+				merged = merged.map((m) => {
+					if (m._origin === "synthetic" && m.id === COMPACTION_ACTIVE_ID) {
+						return { ...m, _order: cardOrder };
+					}
+					if (
+						m.role === "toolResult"
+						&& (m as any).toolCallId === `compaction-summary:${COMPACTION_ACTIVE_ID}`
+					) {
+						return { ...m, _order: trOrder };
+					}
+					return m;
+				});
+			}
 			// highestSeq tracks live seqs only — snapshots are negative; keep prior.
 			const positiveMax = merged.reduce(
 				(acc, m) => (m._order > 0 && m._order > acc ? m._order : acc),
@@ -660,8 +803,17 @@ export function reduce(state: ReducerState, action: Action): ReducerState {
 			// `docs/design/compaction-e2e-rich-summary.md` §7.4.
 			const tick = state.nextTick;
 			const order = state.highestSeq + 0.5;
+			// Also drop the prior `compact_active` card's PAIRED synthetic
+			// toolResult (`toolCallId === "compaction-summary:compact_active"`).
+			// Filtering only the assistant card by id leaves a stale orphaned
+			// toolResult behind when a subsequent compaction starts, which then
+			// renders/anchors incorrectly. The `compaction-result` filter already
+			// removes this toolResult; keep the two filters symmetric.
 			const messages = state.messages.filter(
-				(m) => m.id !== "compacting_placeholder" && m.id !== "compact_active",
+				(m) =>
+					m.id !== "compacting_placeholder"
+					&& m.id !== "compact_active"
+					&& (m as any).toolCallId !== "compaction-summary:compact_active",
 			);
 			messages.push(stamp(action.message, "synthetic", order, tick));
 			return {
@@ -678,7 +830,6 @@ export function reduce(state: ReducerState, action: Action): ReducerState {
 			// rich row(s) under the same stable id. Single-DOM-identity
 			// invariant pinned by message-reducer.test.ts case 12d.
 			const tick = state.nextTick;
-			const order = state.highestSeq + 0.5;
 			// When the terminal live card carries a `compactionId`, also drop any
 			// persisted (reload/refresh-spliced) sidecar synthetic + paired
 			// toolResult for the SAME compaction. The server splices that card
@@ -690,6 +841,39 @@ export function reduce(state: ReducerState, action: Action): ReducerState {
 			const dupToolCallId = resultCompactionId
 				? `compaction-summary:${resultCompactionId}`
 				: null;
+			// Sub-case 2 (docs/design/fix-compaction-ordering.md §2.1, §4.2):
+			// when the post-compaction snapshot landed BEFORE this deferred
+			// terminal transition, a persisted sidecar card for `compactionId`
+			// already sits in state at its canonical (negative, prepended)
+			// snapshot order. The new `compact_active` card REPLACES it, so it
+			// must inherit that anchor order — NOT `highestSeq + 0.5` (positive),
+			// which would re-sink the card below the preserved tail. Falls back
+			// to the tail anchor only when no persisted card is being displaced
+			// (the genuinely-live case; corrected later when its snapshot lands).
+			// Pinned by (12g)/(12h).
+			const anchor = resultCompactionId
+				? persistedCompactionAnchor(state.messages, resultCompactionId)
+				: { cardOrder: null, toolResultOrder: null };
+			// Fallback chain (docs/design/fix-compaction-ordering.md §4.2): when no
+			// persisted sidecar card is being displaced — because the interim
+			// snapshot already dropped it in favour of the in-progress live card and
+			// transferred its negative order onto `compact_active` — inherit that
+			// existing live card's `_order` so the deferred transition preserves the
+			// negative anchor. Only the genuinely-live case (no snapshot yet) falls
+			// back to the positive `highestSeq + 0.5` tail anchor, corrected later
+			// when its snapshot lands.
+			const existingActiveCard = state.messages.find(
+				(m) => m._origin === "synthetic" && m.id === COMPACTION_ACTIVE_ID,
+			);
+			const existingActiveToolResult = state.messages.find(
+				(m) =>
+					m.role === "toolResult"
+					&& (m as any).toolCallId === `compaction-summary:${COMPACTION_ACTIVE_ID}`,
+			);
+			const order =
+				anchor.cardOrder ?? existingActiveCard?._order ?? state.highestSeq + 0.5;
+			const toolResultOrder =
+				anchor.toolResultOrder ?? existingActiveToolResult?._order ?? order + 0.001;
 			const messages = state.messages.filter(
 				(m) => {
 					if (
@@ -710,7 +894,7 @@ export function reduce(state: ReducerState, action: Action): ReducerState {
 			messages.push(stamp(action.message, "synthetic", order, tick));
 			if (action.toolResult) {
 				messages.push(
-					stamp(action.toolResult, "synthetic", order + 0.001, tick + 1),
+					stamp(action.toolResult, "synthetic", toolResultOrder, tick + 1),
 				);
 			}
 			return {

--- a/src/app/message-reducer.ts
+++ b/src/app/message-reducer.ts
@@ -416,11 +416,22 @@ export function reduce(state: ReducerState, action: Action): ReducerState {
 			// deferred `compaction-result` fires. Track the in-progress live card so
 			// we can anchor it to the persisted sidecar card's position instead.
 			let hasInProgressLiveCard = false;
+			// Compaction ids ALREADY established in prior state — persisted
+			// (reload-spliced) sidecar cards from EARLIER compactions in this
+			// session, plus any completed live card that gained a compactionId.
+			// The interim heuristic below must NOT consume these: they belong to
+			// older compactions, not the current pending one. Without this guard a
+			// stale older card would be dropped and its `_order` mis-transferred
+			// to an unrelated in-progress card (verifiable race; see §4.1).
+			const establishedCompactionIds = new Set<string>();
 			for (const m of state.messages) {
 				if (m._origin === "synthetic" && m.id === COMPACTION_ACTIVE_ID) {
 					const cid = compactionSummaryId(m);
 					if (cid) liveCompactionIds.add(cid);
 					else hasInProgressLiveCard = true;
+				} else {
+					const cid = compactionSummaryId(m);
+					if (cid) establishedCompactionIds.add(cid);
 				}
 			}
 			// Stamp the FULL row set FIRST so canonical snapshot `_order`s
@@ -469,11 +480,23 @@ export function reduce(state: ReducerState, action: Action): ReducerState {
 				// compaction anchor. Drop that card + its paired toolResult and stash
 				// their canonical orders so the surviving in-progress live card sorts
 				// before the preserved tail — exactly one card during the window.
+				//
+				// Verifiable race guard (review of PR #819): only consume a sidecar
+				// card that is NOT already established in prior state. An older
+				// compaction's persisted card (`establishedCompactionIds`) must not
+				// be selected as the anchor for the current pending compaction — if
+				// the new compaction's sidecar row has not been written yet, the
+				// snapshot may carry ONLY the old card, and consuming it would
+				// wrongly drop the old card and transfer its `_order` to the
+				// unrelated in-progress card. When no NEW (unestablished) sidecar
+				// card exists, leave the live card tail-anchored and keep the old
+				// card untouched.
 				let bestCard: OrderedMessage | null = null;
 				for (const m of stampedAll) {
-					if (m.id !== COMPACTION_ACTIVE_ID && compactionSummaryId(m) !== null) {
-						if (bestCard === null || m._order > bestCard._order) bestCard = m;
-					}
+					if (m.id === COMPACTION_ACTIVE_ID) continue;
+					const cid = compactionSummaryId(m);
+					if (cid === null || establishedCompactionIds.has(cid)) continue;
+					if (bestCard === null || m._order > bestCard._order) bestCard = m;
 				}
 				if (bestCard) {
 					const bestCid = compactionSummaryId(bestCard) as string;

--- a/src/server/agent/compaction-sidecar.ts
+++ b/src/server/agent/compaction-sidecar.ts
@@ -51,6 +51,18 @@ export function makeCompactionId(startedAtMs: number): string {
 	return `c_${startedAtMs}_${randomBytes(3).toString("hex")}`;
 }
 
+/** Recover the `startedAtMs` embedded in a `makeCompactionId` value, or null
+ *  if the id doesn't match the `c_<ms>_<rand>` shape. Lets the manual
+ *  `compaction_end` handler reconstruct an accurate `durationMs`/`startedAt`
+ *  without threading the start time through the session object. */
+export function parseCompactionStartMs(compactionId: string | undefined): number | null {
+	if (!compactionId) return null;
+	const m = /^c_(\d+)_/.exec(compactionId);
+	if (!m) return null;
+	const ms = Number(m[1]);
+	return Number.isFinite(ms) ? ms : null;
+}
+
 let _sidecarDir: string | undefined;
 
 /** Initialize the sidecar dir from the gateway state directory.

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -29,6 +29,7 @@ import {
 	appendCompactionSidecarEntry,
 	makeCompactionId,
 	mergeCompactionSidecarIntoMessages,
+	parseCompactionStartMs,
 } from "./compaction-sidecar.js";
 import { SessionStore, type PersistedSession } from "./session-store.js";
 import { isWorktreePathReferencedByLiveSession, type WorktreeReferenceRecord } from "./worktree-reference-guard.js";
@@ -2875,13 +2876,52 @@ export class SessionManager {
 				// a failed compaction has no orphan boundary to recover.
 				if (success) (event as any).compactionId = pending.compactionId;
 			}
-			// Manual path: ws/handler.ts owns the sidecar append but stashes the
-			// shared compactionId on the session synchronously before the RPC, so
-			// the agent-emitted manual compaction_end can carry it to the client.
+			// Manual path: ws/handler.ts stashes the shared compactionId on the
+			// session synchronously before the RPC. The agent emits this manual
+			// `compaction_end` BEFORE the RPC promise resolves in ws/handler.ts,
+			// and we call refreshAfterCompaction() below. If we waited for the
+			// ws-handler's post-RPC append, that snapshot would lack the persisted
+			// sidecar anchor and the live card would stay positive-ordered (sorts
+			// after the preserved tail). So write the SUCCESS sidecar row HERE,
+			// synchronously, before refreshAfterCompaction — using the stashed
+			// compactionId and this event's result payload. ws/handler.ts still
+			// owns the FAILURE append (when the RPC rejects without ever emitting a
+			// successful compaction_end), and skips its own success append via the
+			// `_manualSidecarWritten` marker so we don't double-write.
 			if (reason === "manual") {
 				const manualId = (session as any)._manualCompactionId as string | undefined;
 				const manualAborted = !!(event as any).aborted;
+				const manualError = (event as any).errorMessage as string | undefined;
+				const manualResult = (event as any).result as
+					| { tokensBefore?: number; firstKeptEntryId?: string }
+					| undefined;
+				const manualSuccess = !!manualId && !manualAborted && !manualError && !!manualResult;
 				if (manualId && !manualAborted) (event as any).compactionId = manualId;
+				if (manualId && manualSuccess) {
+					const endedAtMs = Date.now();
+					const startedAtMs = parseCompactionStartMs(manualId) ?? endedAtMs;
+					try {
+						const wrote = appendCompactionSidecarEntry(session.id, {
+							schemaVersion: 1,
+							id: manualId,
+							trigger: "manual",
+							tokensBefore: manualResult?.tokensBefore ?? null,
+							tokensAfter: null,
+							durationMs: Math.max(0, endedAtMs - startedAtMs),
+							startedAt: new Date(startedAtMs).toISOString(),
+							endedAt: new Date(endedAtMs).toISOString(),
+							success: true,
+							firstKeptEntryId: manualResult?.firstKeptEntryId ?? null,
+						});
+						// Tell ws/handler.ts not to append a duplicate success row — but
+						// ONLY if our append actually succeeded. On failure leave the
+						// marker unset so the ws/handler.ts fallback can append the row
+						// when the RPC resolves (otherwise the sidecar boundary is lost).
+						if (wrote) (session as any)._manualSidecarWritten = manualId;
+					} catch (err) {
+						console.warn(`[session-manager] Failed to append manual compaction sidecar for ${session.id}:`, err);
+					}
+				}
 				(session as any)._manualCompactionId = undefined;
 			}
 			(session as any)._pendingCompactionStart = undefined;

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -759,25 +759,43 @@ export function handleWebSocketConnection(
 							console.log(`[ws-handler] Compact RPC resolved for session ${sessionId}`);
 							const endedAtMs = Date.now();
 							session.isCompacting = false;
-							const tokensBefore = compactResult?.data?.tokensBefore ?? null;
-							const firstKeptEntryId = compactResult?.data?.firstKeptEntryId ?? null;
-							// Persist the sidecar row so the card survives reload.
-							appendCompactionSidecarEntry(sessionId, {
-								schemaVersion: 1,
-								id: compactionId,
-								trigger: "manual",
-								tokensBefore,
-								tokensAfter: null,
-								durationMs: endedAtMs - startedAtMs,
-								startedAt: new Date(startedAtMs).toISOString(),
-								endedAt: new Date(endedAtMs).toISOString(),
-								success: true,
-								firstKeptEntryId,
-							});
+							// session-manager's manual `compaction_end` branch writes
+							// the SUCCESS sidecar row synchronously BEFORE its
+							// refreshAfterCompaction() so the post-compaction snapshot
+							// carries the orphan-boundary anchor (otherwise the live
+							// card stays positive-ordered and sorts after the preserved
+							// tail). The agent emits that event before this RPC promise
+							// resolves, so by here the row is already persisted. Skip our
+							// own success append to avoid a duplicate sidecar line. We
+							// only write here as a fallback when session-manager did NOT
+							// (e.g. the agent emitted no successful manual compaction_end
+							// with a result payload).
+							const alreadyWritten = (session as any)._manualSidecarWritten === compactionId;
+							(session as any)._manualSidecarWritten = undefined;
+							if (!alreadyWritten) {
+								const tokensBefore = compactResult?.data?.tokensBefore ?? null;
+								const firstKeptEntryId = compactResult?.data?.firstKeptEntryId ?? null;
+								// Persist the sidecar row so the card survives reload.
+								appendCompactionSidecarEntry(sessionId, {
+									schemaVersion: 1,
+									id: compactionId,
+									trigger: "manual",
+									tokensBefore,
+									tokensAfter: null,
+									durationMs: endedAtMs - startedAtMs,
+									startedAt: new Date(startedAtMs).toISOString(),
+									endedAt: new Date(endedAtMs).toISOString(),
+									success: true,
+									firstKeptEntryId,
+								});
+							}
 						} catch (err: any) {
 							console.error(`[ws-handler] Compact failed for session ${sessionId}:`, err.message);
 							const endedAtMs = Date.now();
 							session.isCompacting = false;
+							// RPC rejected: own the failure append. session-manager only
+							// writes the success row, so clear the dedup marker defensively.
+							(session as any)._manualSidecarWritten = undefined;
 							appendCompactionSidecarEntry(sessionId, {
 								schemaVersion: 1,
 								id: compactionId,

--- a/tests/e2e/ui/pre-compaction-history.spec.ts
+++ b/tests/e2e/ui/pre-compaction-history.spec.ts
@@ -273,6 +273,46 @@ test.describe("Pre-compaction history affordance", () => {
 		// assertion is the primary repro signal.
 		await expect(cards).toHaveCount(1, { timeout: 8_000 });
 
+		// DOM-ORDER regression (docs/design/fix-compaction-ordering.md §3.2):
+		// in the SAME live session the compaction card + pre-compaction-history
+		// affordance must render BEFORE the preserved recent tail message. The
+		// mock keeps a single active-branch tail ("Resuming work after the
+		// summary."). Pre-fix the live `compact_active` card retains a positive
+		// reducer `_order` while the preserved-tail snapshot row gets a negative
+		// order, so the card sorts AFTER the tail (the reported bug); only a
+		// reload/navigate-away fixes it. We compare DOM document order (robust to
+		// scroll/layout) rather than y-coordinates.
+		const domOrder = await page.evaluate(() => {
+			const card = document.querySelector("[data-testid='compaction-summary-card']");
+			const widget = document.querySelector("[data-testid='pre-compaction-history']");
+			const tail = Array.from(document.querySelectorAll("assistant-message"))
+				.find((el) => (el.textContent || "").includes("Resuming work after the summary")) || null;
+			const before = (a: Element | null, b: Element | null): boolean | null => {
+				if (!a || !b) return null;
+				// DOCUMENT_POSITION_FOLLOWING (4) set => b follows a in document order.
+				return (a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0;
+			};
+			return {
+				hasCard: !!card,
+				hasWidget: !!widget,
+				hasTail: !!tail,
+				cardBeforeTail: before(card, tail),
+				widgetBeforeTail: before(widget, tail),
+			};
+		});
+		expect(
+			domOrder.hasCard && domOrder.hasWidget && domOrder.hasTail,
+			`card/affordance/tail must all be present in DOM: ${JSON.stringify(domOrder)}`,
+		).toBe(true);
+		expect(
+			domOrder.cardBeforeTail,
+			"compaction summary card must appear BEFORE the preserved recent message in DOM order",
+		).toBe(true);
+		expect(
+			domOrder.widgetBeforeTail,
+			"pre-compaction-history affordance must appear BEFORE the preserved recent message in DOM order",
+		).toBe(true);
+
 		// Expanding reveals the 3 orphaned pre-compaction rows.
 		await page.locator("[data-testid='pre-compaction-toggle']").click();
 		await expect(widget).toHaveAttribute("data-state", "expanded", { timeout: 15_000 });

--- a/tests/message-reducer.test.ts
+++ b/tests/message-reducer.test.ts
@@ -837,6 +837,60 @@ describe("message-reducer", () => {
 		);
 	});
 
+	it("(12l) interim with stale older sidecar: keep old card, do not consume it for the new in-progress card", () => {
+		// Verifiable race (review of PR #819): an OLDER compaction's persisted
+		// sidecar card already sits in state (e.g. from a prior reload). A NEW
+		// compaction starts — the live `compact_active` card is in-progress with
+		// NO compactionId. A refresh/snapshot arrives BEFORE the new compaction's
+		// sidecar row (`c_new`) has been written, so it carries ONLY the old card
+		// (`c_old`). The interim heuristic must NOT treat the stale `c_old` card
+		// as the current pending anchor: doing so would drop `c_old` and transfer
+		// its `_order` to the unrelated in-progress card. Expected: keep `c_old`
+		// AND show the new in-progress card separately (tail-anchored).
+		const cOld = "c_old";
+		const s = applyAll([
+			// Prior reload: persisted sidecar card for the OLD compaction is in
+			// state at its canonical (prepended) order, before a kept tail.
+			{ type: "snapshot", messages: [
+				persistedSidecarCard(cOld),
+				persistedSidecarToolResult(cOld),
+				userMsg("kept-user", "still relevant"),
+				assistantMsg("kept-asst", "carry forward"),
+			] },
+			// A NEW compaction begins; live card in-progress (no compactionId).
+			// The placeholder filter only drops `compact_active`-id rows, so the
+			// reloaded `c_old` card (id = compactionId) survives in state.
+			{ type: "compaction-placeholder", message: liveInProgressCard() },
+			// Snapshot lands BEFORE the new sidecar (`c_new`) exists — it still
+			// carries only the old card.
+			{ type: "snapshot", messages: [
+				persistedSidecarCard(cOld),
+				persistedSidecarToolResult(cOld),
+				userMsg("kept-user", "still relevant"),
+				assistantMsg("kept-asst", "carry forward"),
+			] },
+		]);
+		// The old persisted card must still be present (not consumed/dropped).
+		const oldCards = s.messages.filter(
+			(m: any) => isCompactionCard(m) && m.id === cOld,
+		);
+		assert.strictEqual(oldCards.length, 1, `old persisted card (${cOld}) must survive, got ${oldCards.length}`);
+		// The new in-progress live card must also be present, separately.
+		const liveCards = s.messages.filter((m: any) => m.id === "compact_active");
+		assert.strictEqual(liveCards.length, 1, "new in-progress live card must be present");
+		// Two distinct compaction cards exist (old + new in-progress); the old
+		// card was NOT merged/transferred into the new one.
+		const cards = s.messages.filter(isCompactionCard);
+		assert.strictEqual(cards.length, 2, `expected the old card AND the new in-progress card, got ${cards.length}`);
+		// The old card keeps its prepended (negative) anchor before the tail; the
+		// new in-progress card is tail-anchored (positive), since no matching
+		// pending sidecar exists yet.
+		const oldOrder = oldCards[0]._order;
+		const liveOrder = liveCards[0]._order;
+		assert.ok(oldOrder < 0, `old card retains its prepended anchor; got ${oldOrder}`);
+		assert.ok(liveOrder > oldOrder, `new in-progress card must not steal the old card's order; got live=${liveOrder} old=${oldOrder}`);
+	});
+
 	it("RE-07-style — preferences snapshot ordering preserved (stable by tick)", () => {
 		// Three rows with identical timestamps — must preserve insertion order.
 		const m1 = { id: "m1", role: "user", content: "1", timestamp: 100 };

--- a/tests/message-reducer.test.ts
+++ b/tests/message-reducer.test.ts
@@ -66,6 +66,92 @@ const toolResultMsg = (id: string, callId: string, text: string) => ({
 	timestamp: 0,
 });
 
+// --- Compaction ordering helpers (failing-first repro for the live-vs-reload
+// ordering divergence; see docs/design/fix-compaction-ordering.md §2–§3). ---
+const COMPACTION_TOOL = "__compaction_summary";
+const compactionArgs = (state: string, compactionId?: string) => ({
+	schemaVersion: 1,
+	trigger: "manual",
+	state,
+	success: true,
+	timestamp: "2026-05-12T00:00:01Z",
+	tokensBefore: 50_000,
+	tokensAfter: 5_000,
+	reductionPct: 90,
+	...(compactionId ? { compactionId } : {}),
+});
+// Live in-progress card (stable id `compact_active`, NO compactionId yet —
+// mirrors remote-agent's buildInProgressCompactionPayload).
+const liveInProgressCard = () => ({
+	id: "compact_active",
+	role: "assistant",
+	timestamp: 0,
+	content: [{
+		type: "toolCall",
+		id: "compaction-summary:compact_active",
+		name: COMPACTION_TOOL,
+		arguments: compactionArgs("in-progress"),
+	}],
+});
+// Live terminal card (keeps id `compact_active` for DOM continuity, gains
+// `compactionId` only on the deferred transition).
+const liveTerminalCard = (compactionId: string) => ({
+	id: "compact_active",
+	role: "assistant",
+	timestamp: 0,
+	content: [{
+		type: "toolCall",
+		id: "compaction-summary:compact_active",
+		name: COMPACTION_TOOL,
+		arguments: compactionArgs("complete", compactionId),
+	}],
+});
+const liveTerminalToolResult = () => ({
+	role: "toolResult",
+	toolCallId: "compaction-summary:compact_active",
+	toolName: COMPACTION_TOOL,
+	isError: false,
+	content: [{ type: "text", text: "ok" }],
+	timestamp: 0,
+});
+// Persisted sidecar card + paired toolResult as spliced (PREPENDED) into the
+// post-compaction snapshot by mergeCompactionSidecarIntoMessages. id = sidecar
+// compactionId (NOT `compact_active`); no explicit `_order`, so the reducer
+// stamps SNAPSHOT_ORDER_FLOOR+i (negative → before the preserved tail).
+const persistedSidecarCard = (compactionId: string) => ({
+	id: compactionId,
+	role: "assistant",
+	timestamp: 0,
+	content: [{
+		type: "toolCall",
+		id: `compaction-summary:${compactionId}`,
+		name: COMPACTION_TOOL,
+		arguments: compactionArgs("complete", compactionId),
+	}],
+});
+const persistedSidecarToolResult = (compactionId: string) => ({
+	role: "toolResult",
+	toolCallId: `compaction-summary:${compactionId}`,
+	toolName: COMPACTION_TOOL,
+	isError: false,
+	content: [{ type: "text", text: "ok" }],
+	timestamp: 0,
+});
+const isCompactionCard = (m: any): boolean =>
+	m?.role === "assistant"
+	&& Array.isArray(m.content)
+	&& m.content.some((c: any) => c?.type === "toolCall" && c?.name === COMPACTION_TOOL);
+const isCompactionToolResult = (m: any): boolean =>
+	m?.role === "toolResult" && m?.toolName === COMPACTION_TOOL;
+// Normalised position key: collapses the live (`compact_active`) vs persisted
+// (sidecar id) card identities to a single token so live and reload sequences
+// compare equal regardless of which surface survived.
+const orderKey = (m: any): string => {
+	if (isCompactionCard(m)) return "compaction-card";
+	if (isCompactionToolResult(m)) return "compaction-toolResult";
+	return String(m.id);
+};
+
 describe("message-reducer", () => {
 	it("(1) in-order live events", () => {
 		const s = applyAll([
@@ -541,6 +627,214 @@ describe("message-reducer", () => {
 		);
 		assert.ok(tr, "paired toolResult must survive snapshot");
 		assert.equal((tr as any).details?.compactionId, sidecarId);
+	});
+
+	// ---------------------------------------------------------------------
+	// Compaction ORDERING regression family (live-vs-reload divergence).
+	// See docs/design/fix-compaction-ordering.md. These are failing-first:
+	// pre-fix the live `compact_active` card retains a positive `_order`
+	// (`highestSeq + 0.5`) while the preserved tail snapshot rows get
+	// negative `SNAPSHOT_ORDER_FLOOR + i`, so the card sorts AFTER the tail.
+	// Reload works because the persisted sidecar card is prepended and gets
+	// the most-negative snapshot order. The invariant pinned here: a live row
+	// retained in place of a snapshot-equivalent row inherits the snapshot
+	// row's `_order`, so live order == reload order.
+	// (Letter suffixes continue the (12x) family; (12e) is the overflow test.)
+	// ---------------------------------------------------------------------
+
+	it("(12f) terminal-before-snapshot: compaction card sorts before preserved tail", () => {
+		// Sub-case 1 (design §2.1): the deferred terminal `compaction-result`
+		// transition fires BEFORE the post-compaction snapshot lands. The
+		// snapshot's `liveCompactionIds` branch drops the persisted card+TR
+		// (live card already hosts the affordance), leaving the live card at
+		// `highestSeq + 0.5` (positive) above the negative-ordered tail.
+		const cid = "c_terminal_first";
+		const s = applyAll([
+			liveMessageEnd(1, userMsg("kept-user", "still relevant")),
+			liveMessageEnd(2, assistantMsg("kept-asst", "carry forward")),
+			{ type: "compaction-placeholder", message: liveInProgressCard() },
+			{ type: "compaction-result", message: liveTerminalCard(cid), toolResult: liveTerminalToolResult(), success: true },
+			// Server post-compaction snapshot: persisted sidecar card + paired
+			// toolResult PREPENDED (server splice), then the preserved tail.
+			{ type: "snapshot", messages: [
+				persistedSidecarCard(cid),
+				persistedSidecarToolResult(cid),
+				userMsg("kept-user", "still relevant"),
+				assistantMsg("kept-asst", "carry forward"),
+			] },
+		]);
+		const seq = s.messages.map(orderKey);
+		assert.deepStrictEqual(
+			seq,
+			["compaction-card", "compaction-toolResult", "kept-user", "kept-asst"],
+			`compaction card+affordance must precede the preserved tail; got: ${JSON.stringify(seq)}`,
+		);
+	});
+
+	it("(12g) snapshot-before-terminal: deferred transition still anchors card before tail", () => {
+		// Sub-case 2 (design §2.1): the post-compaction snapshot lands BEFORE
+		// the deferred terminal transition (card transition runs behind the
+		// COMPACT_CARD_MIN_DURATION timer). The persisted card initially
+		// survives with canonical negative order, but `compaction-result` then
+		// drops it by compactionId and re-pushes the live card at
+		// `highestSeq + 0.5` (positive) → card lands after the tail again.
+		const cid = "c_snapshot_first";
+		const s = applyAll([
+			liveMessageEnd(1, userMsg("kept-user", "still relevant")),
+			liveMessageEnd(2, assistantMsg("kept-asst", "carry forward")),
+			{ type: "compaction-placeholder", message: liveInProgressCard() },
+			// Snapshot arrives BEFORE the terminal transition.
+			{ type: "snapshot", messages: [
+				persistedSidecarCard(cid),
+				persistedSidecarToolResult(cid),
+				userMsg("kept-user", "still relevant"),
+				assistantMsg("kept-asst", "carry forward"),
+			] },
+			// Deferred terminal transition fires last.
+			{ type: "compaction-result", message: liveTerminalCard(cid), toolResult: liveTerminalToolResult(), success: true },
+		]);
+		const seq = s.messages.map(orderKey);
+		assert.deepStrictEqual(
+			seq,
+			["compaction-card", "compaction-toolResult", "kept-user", "kept-asst"],
+			`deferred terminal transition must inherit the persisted card's position; got: ${JSON.stringify(seq)}`,
+		);
+	});
+
+	it("(12h) live ordering equals reload ordering (normalised card identity)", () => {
+		// The two states are built from the SAME logical post-compaction
+		// transcript. Live uses the `compact_active` card surface; reload uses
+		// the persisted sidecar card. After normalising that identity the
+		// ordered sequences must be identical — reload is the canonical order.
+		const cid = "c_live_reload";
+		const tail = [
+			userMsg("kept-user", "still relevant"),
+			assistantMsg("kept-asst", "carry forward"),
+		];
+		const live = applyAll([
+			liveMessageEnd(1, userMsg("kept-user", "still relevant")),
+			liveMessageEnd(2, assistantMsg("kept-asst", "carry forward")),
+			{ type: "compaction-placeholder", message: liveInProgressCard() },
+			{ type: "compaction-result", message: liveTerminalCard(cid), toolResult: liveTerminalToolResult(), success: true },
+			{ type: "snapshot", messages: [persistedSidecarCard(cid), persistedSidecarToolResult(cid), ...tail] },
+		]);
+		// RELOAD: a single snapshot with the prepended persisted card + tail,
+		// no live `compact_active` in state.
+		const reload = applyAll([
+			{ type: "snapshot", messages: [persistedSidecarCard(cid), persistedSidecarToolResult(cid), ...tail] },
+		]);
+		const liveSeq = live.messages.map(orderKey);
+		const reloadSeq = reload.messages.map(orderKey);
+		assert.deepStrictEqual(
+			reloadSeq,
+			["compaction-card", "compaction-toolResult", "kept-user", "kept-asst"],
+			`reload ordering sanity (card must lead); got: ${JSON.stringify(reloadSeq)}`,
+		);
+		assert.deepStrictEqual(
+			liveSeq,
+			reloadSeq,
+			`live order must equal reload order; live=${JSON.stringify(liveSeq)} reload=${JSON.stringify(reloadSeq)}`,
+		);
+	});
+
+	it("(12i) exactly one compaction card + adjacent toolResult after each timing path", () => {
+		// No-duplicate / adjacency invariant (preserves PR #817). Must stay
+		// green pre- AND post-fix across both timing sub-cases, guarding the
+		// ordering fix against re-introducing a stacked or detached card.
+		const cid = "c_dedupe";
+		const tail = [userMsg("kept-user", "x"), assistantMsg("kept-asst", "y")];
+		const snapshot: Action = {
+			type: "snapshot",
+			messages: [persistedSidecarCard(cid), persistedSidecarToolResult(cid), ...tail],
+		};
+		const terminalFirst = applyAll([
+			liveMessageEnd(1, userMsg("kept-user", "x")),
+			liveMessageEnd(2, assistantMsg("kept-asst", "y")),
+			{ type: "compaction-placeholder", message: liveInProgressCard() },
+			{ type: "compaction-result", message: liveTerminalCard(cid), toolResult: liveTerminalToolResult(), success: true },
+			snapshot,
+		]);
+		const snapshotFirst = applyAll([
+			liveMessageEnd(1, userMsg("kept-user", "x")),
+			liveMessageEnd(2, assistantMsg("kept-asst", "y")),
+			{ type: "compaction-placeholder", message: liveInProgressCard() },
+			snapshot,
+			{ type: "compaction-result", message: liveTerminalCard(cid), toolResult: liveTerminalToolResult(), success: true },
+		]);
+		for (const [label, st] of [["terminal-first", terminalFirst], ["snapshot-first", snapshotFirst]] as const) {
+			const cards = st.messages.filter(isCompactionCard);
+			const trs = st.messages.filter(isCompactionToolResult);
+			assert.strictEqual(cards.length, 1, `${label}: exactly one compaction summary card, got ${cards.length}`);
+			assert.strictEqual(trs.length, 1, `${label}: exactly one paired compaction toolResult, got ${trs.length}`);
+			const cardIdx = st.messages.findIndex(isCompactionCard);
+			const trIdx = st.messages.findIndex(isCompactionToolResult);
+			assert.strictEqual(trIdx, cardIdx + 1, `${label}: toolResult must be immediately adjacent to its card`);
+		}
+	});
+
+	it("(12j) new compaction placeholder removes prior compact_active card AND its paired toolResult", () => {
+		// Regression: `compaction-placeholder` filtered the prior `compact_active`
+		// assistant card by id but left its paired synthetic toolResult
+		// (`toolCallId === "compaction-summary:compact_active"`) behind. When a
+		// SECOND compaction starts in the same session, that orphaned toolResult
+		// lingers — a stale, detached row. The placeholder filter must drop it
+		// too, mirroring the `compaction-result` filter. Pinned here.
+		const cid1 = "c_first";
+		const s = applyAll([
+			liveMessageEnd(1, userMsg("u1", "hi")),
+			// First compaction completes → live card + paired toolResult.
+			{ type: "compaction-placeholder", message: liveInProgressCard() },
+			{ type: "compaction-result", message: liveTerminalCard(cid1), toolResult: liveTerminalToolResult(), success: true },
+			// A SECOND compaction begins.
+			{ type: "compaction-placeholder", message: liveInProgressCard() },
+		]);
+		const orphanToolResults = s.messages.filter(
+			(m: any) => m.toolCallId === "compaction-summary:compact_active" && m.role === "toolResult",
+		);
+		assert.strictEqual(
+			orphanToolResults.length,
+			0,
+			`stale compact_active toolResult must be removed when a new placeholder starts; got ${orphanToolResults.length}`,
+		);
+		// Exactly one in-progress card survives (the new placeholder).
+		const activeCards = s.messages.filter((m: any) => m.id === "compact_active");
+		assert.strictEqual(activeCards.length, 1, "exactly one compact_active card after new placeholder");
+	});
+
+	it("(12k) interim snapshot-before-terminal: exactly one (live) card before tail", () => {
+		// HIGH finding (docs/design/fix-compaction-ordering.md §4.1): the window
+		// AFTER the post-compaction snapshot lands but BEFORE the deferred
+		// `compaction-result` fires. The live `compact_active` card is still
+		// in-progress (NO compactionId), so the cid-keyed snapshot dedup can't
+		// match it. Pre-fix the reducer kept BOTH the persisted sidecar card and
+		// the in-progress live card. The fix drops the persisted card, transfers
+		// its canonical (negative) order to the live card, and leaves exactly one
+		// card — the live `compact_active` — positioned before the preserved tail.
+		const cid = "c_interim";
+		const s = applyAll([
+			liveMessageEnd(1, userMsg("kept-user", "still relevant")),
+			liveMessageEnd(2, assistantMsg("kept-asst", "carry forward")),
+			{ type: "compaction-placeholder", message: liveInProgressCard() },
+			// Snapshot lands while the card is still in-progress (no compactionId),
+			// BEFORE the deferred terminal transition.
+			{ type: "snapshot", messages: [
+				persistedSidecarCard(cid),
+				persistedSidecarToolResult(cid),
+				userMsg("kept-user", "still relevant"),
+				assistantMsg("kept-asst", "carry forward"),
+			] },
+		]);
+		// Exactly one compaction card, and it is the live `compact_active` surface.
+		const cards = s.messages.filter(isCompactionCard);
+		assert.strictEqual(cards.length, 1, `interim must show exactly one compaction card, got ${cards.length}`);
+		assert.strictEqual(cards[0].id, "compact_active", "the surviving interim card is the live compact_active card");
+		// Card precedes the preserved tail.
+		const seq = s.messages.map(orderKey);
+		assert.deepStrictEqual(
+			seq,
+			["compaction-card", "kept-user", "kept-asst"],
+			`interim live card must precede the preserved tail; got: ${JSON.stringify(seq)}`,
+		);
 	});
 
 	it("RE-07-style — preferences snapshot ordering preserved (stable by tick)", () => {


### PR DESCRIPTION
## Summary

- Fixes the broader live-vs-snapshot message ordering reconciliation exposed by compaction: the live compaction card is anchored to the persisted snapshot order so it appears before preserved tail messages, matching reload/navigation.
- Prevents duplicate or orphaned compaction tool results across placeholder replacement, snapshot-before-terminal, and repeated compaction timing paths.
- Moves manual compaction sidecar persistence ahead of refresh so live ordering and count recovery use the same persisted boundary.
- Adds reducer and E2E regressions that compare live ordering against reload ordering and cover adjacent timing edge cases.
- Documents the ordering invariants and failure mode.

## Verification

- `npm run check`
- `npm run build --silent && npm run test:e2e:run -- pre-compaction-history.spec.ts && npx tsx --test tests/message-reducer.test.ts`
- Subgoal ready-to-merge gate passed before replaying onto this clean branch.

## Notes

#817 was already merged, so this PR is a fresh branch off `origin/master` with the child goal's net diff replayed as a clean commit.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
