### PR TITLE
Mobile Action Menus

### DIFF
--- a/docs/design/mobile-action-menus-ux.md
+++ b/docs/design/mobile-action-menus-ux.md
@@ -1,0 +1,76 @@
+# Mobile action menus UX note
+
+**Status:** Decision note for the Mobile Action Menus goal.  
+**Scope:** Mobile sidebar/landing rows and the mobile chat header. This is an implementation-oriented UX spec, not a prototype.
+
+## Decisions
+
+### Mobile sidebar and landing rows
+
+- Keep the row as the primary navigation target, but reserve a right-aligned action cluster inside each relevant row.
+- Session rows show quick icon buttons first, then the hamburger trigger:
+  1. Edit / modify session, when available.
+  2. Terminate / end team, when available.
+  3. Hamburger for the full session menu.
+- Quick buttons and the hamburger must be always visible on touch/mobile; do not rely on hover discovery.
+- Use the same visual density as current mobile rows: compact icons, no text labels in the row action cluster, and alignment centered to the row height.
+- Minimum effective tap target: 44px high and about 36-44px wide per control. If the visual icon remains smaller, increase the button hit area with padding.
+- Action controls must call `preventDefault()` and `stopPropagation()` for pointer/click/keyboard activation so tapping them never selects, opens, or navigates the underlying row.
+- Keep focus order predictable: row content first, then quick actions left-to-right, then hamburger.
+
+### Mobile goal rows
+
+- Goal rows expose a right-aligned hamburger trigger on mobile, even when they have no inline quick actions.
+- The hamburger opens the existing `SidebarActionsPopover` for goal actions.
+- Menu contents should match the desktop goal menu model and include applicable actions such as:
+  - Dashboard / open goal.
+  - Re-attempt.
+  - Copy link.
+  - Open on GitHub, when a GitHub branch URL is available or still loading.
+  - Archive / destructive actions when already supported by the desktop menu.
+- Popover-only goal actions remain popover-only; do not promote actions such as Re-attempt into permanent mobile inline buttons unless a separate decision changes the desktop action taxonomy.
+
+### Mobile chat header
+
+- In the mobile chat screen header, place icon-only quick actions immediately before the hamburger in the top-right action group.
+- Show quick actions for:
+  - Edit / modify session or goal-team details, when available.
+  - Terminate session / end team, when available.
+- Do not render text labels in the header action group. Use accessible names and optional tooltips/title text instead.
+- The hamburger opens the full session action menu using the same `SidebarActionsPopover` component and action descriptors as the desktop/sidebar model.
+- The full menu should include quick actions as menu rows as well, so the open menu remains complete and keyboard-accessible.
+- On narrow widths, preserve the back button and title first. If space is constrained, keep the hamburger visible and allow lower-priority quick icons to collapse before the hamburger.
+
+## Shared-element / FLIP motion
+
+- Reuse the existing `SidebarActionsPopover` shared-element pattern rather than inventing a mobile-only animation.
+- When opening from the sidebar row or mobile header hamburger, capture source rects for the visible quick action buttons and pass them into the popover so matching menu rows animate from the icon locations.
+- The animation should communicate continuity: visible quick icons become their corresponding rows in the opened menu.
+- If a quick action is not currently rendered, it should not produce a source rect; the menu row simply appears with the normal popover entrance.
+- Respect reduced-motion settings by disabling or shortening transform animation while keeping the menu behavior identical.
+
+## Accessibility and interaction requirements
+
+- Render quick actions and hamburgers as real buttons.
+- Every icon-only button needs a specific `aria-label`, for example:
+  - `Edit session <title>`
+  - `Terminate session <title>`
+  - `Session actions for <title>`
+  - `Goal actions for <title>`
+- Hamburger buttons set `aria-haspopup="menu"` and keep `aria-expanded` synchronized with popover state.
+- The popover keeps existing menu semantics: `role="menu"`, menu items with clear labels, roving keyboard focus, and disabled states where applicable.
+- Keyboard behavior:
+  - Enter/Space activates focused quick buttons and hamburger.
+  - Escape closes an open popover and returns focus to the trigger.
+  - Arrow-key behavior inside the popover follows the existing `SidebarActionsPopover` implementation.
+- Pointer behavior:
+  - Outside click/tap closes the popover.
+  - Tapping a menu item runs the action and closes or refreshes the menu according to existing desktop behavior.
+  - Tapping quick buttons or hamburger must never bubble to row navigation.
+
+## Implementation anchors
+
+- Sidebar rows: `src/app/render-helpers.ts` — `renderSessionRow`, `renderGoalGroup`, `renderSidebarQuickActions`, `renderSidebarActionsTrigger`, `openSidebarActionsPopover`.
+- Mobile chat header: `src/app/render.ts` — `renderHeaderSessionActions` and header popover source-rect capture.
+- Popover and motion: `src/ui/components/SidebarActionsPopover.ts` and `src/ui/components/sidebar-actions-flip.ts`.
+- Tests should update the previous mobile invariant that hid sidebar hamburgers and add coverage for mobile row triggers, header quick icons, no header labels, and source rect capture for visible quick actions.

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -544,10 +544,12 @@ function renderSidebarActionsTrigger(input: {
 	btnPad: string;
 	refresh: () => SidebarActionItem[];
 	onBeforeOpen?: () => void;
-}): TemplateResult | typeof nothing {
-	if (input.mobile) return nothing;
+}): TemplateResult {
 	const expanded = isSidebarActionsPopoverOpen(input.kind, input.entityId);
 	const label = input.kind === "session" ? "Session actions" : "Goal actions";
+	const className = input.mobile
+		? `${input.btnPad} rounded text-muted-foreground active:bg-secondary/80`
+		: `${input.btnPad} rounded hover:bg-secondary/80 text-muted-foreground hover:text-foreground`;
 	const openFromTrigger = (event: Event) => {
 		event.preventDefault();
 		event.stopPropagation();
@@ -566,7 +568,7 @@ function renderSidebarActionsTrigger(input: {
 	};
 	return html`
 		<button
-			class="${input.btnPad} rounded hover:bg-secondary/80 text-muted-foreground hover:text-foreground"
+			class=${className}
 			data-testid="sidebar-actions-trigger"
 			data-sidebar-actions-kind=${input.kind}
 			data-sidebar-actions-id=${input.entityId}

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -34,6 +34,7 @@ import {
 import { backToSessions, createAndConnectSession } from "./session-manager.js";
 import { buildSessionActions, resetSessionForkNewWorktree, type SessionActionDescriptor } from "./session-actions.js";
 import type { SidebarActionsPopover, SidebarActionsPopoverItem } from "../ui/components/SidebarActionsPopover.js";
+import { captureSidebarActionSourceRects, type SidebarActionsFlipRect } from "../ui/components/sidebar-actions-flip.js";
 // Lazy wrapper for the proposal-panels chunk. Static import here keeps
 // the wrapper itself in the entry bundle while the ~80 kB body of
 // goal/role/tool/staff/project preview panels lands on first view.
@@ -681,7 +682,13 @@ function partitionHeaderSessionActions(actions: SessionActionDescriptor[], mobil
 	const directLimit = firstTrailingActionIndex >= 0
 		? Math.min(headerDirectSessionActionLimit(), firstTrailingActionIndex)
 		: headerDirectSessionActionLimit();
-	const directCount = mobile ? 0 : Math.min(actions.length, directLimit);
+	if (mobile) {
+		return {
+			directActions: actions.filter((action) => action.quick),
+			overflowActions: actions,
+		};
+	}
+	const directCount = Math.min(actions.length, directLimit);
 	return {
 		directActions: actions.slice(0, directCount),
 		overflowActions: actions.slice(directCount),
@@ -731,6 +738,7 @@ async function openHeaderSessionActionsPopover(input: {
 	trigger: HTMLElement;
 	actions: SessionActionDescriptor[];
 	refresh: () => SessionActionDescriptor[];
+	sourceRects: SidebarActionsFlipRect[];
 }): Promise<void> {
 	if (isHeaderSessionActionsPopoverOpen(input.sessionId)) {
 		closeHeaderSessionActionsPopover();
@@ -743,7 +751,7 @@ async function openHeaderSessionActionsPopover(input: {
 	const element = document.createElement("sidebar-actions-popover") as SidebarActionsPopover;
 	element.anchorEl = input.trigger;
 	element.items = toHeaderPopoverItems(input.actions);
-	element.sourceRects = [];
+	element.sourceRects = input.sourceRects;
 	element.open = true;
 	const handleResize = () => refreshOpenHeaderSessionActionsPopover();
 	window.addEventListener("resize", handleResize);
@@ -775,19 +783,26 @@ async function openHeaderSessionActionsPopover(input: {
 	renderApp();
 }
 
-function renderHeaderSessionActionButton(action: SessionActionDescriptor) {
+function renderHeaderSessionActionButton(action: SessionActionDescriptor, mobile = false) {
 	const danger = action.tone === "danger";
 	return html`
 		<button
 			type="button"
-			class="h-7 px-2 rounded-md transition-colors inline-flex items-center justify-center text-muted-foreground hover:bg-secondary/80 hover:text-foreground ${danger ? "hover:text-destructive" : ""}"
+			class="${mobile ? "h-10 w-10 p-0" : "h-7 px-2"} rounded-md transition-colors inline-flex items-center justify-center text-muted-foreground hover:bg-secondary/80 hover:text-foreground ${danger ? "hover:text-destructive" : ""}"
 			data-session-action-surface="header"
 			data-session-action-id=${String(action.id)}
-			@click=${(event: Event) => { closeHeaderSessionActionsPopover(false); void action.run(event); }}
+			data-sidebar-action-id=${String(action.id)}
+			data-sidebar-action-quick=${action.quick ? "true" : "false"}
+			@click=${(event: Event) => {
+				event.preventDefault();
+				event.stopPropagation();
+				closeHeaderSessionActionsPopover(false);
+				void action.run(event);
+			}}
 			title=${action.title || action.label}
 			aria-label=${action.label}
 		>
-			<span class="inline-flex items-center gap-1">${action.icon}<span class="text-xs hidden md:inline">${action.label}</span></span>
+			<span class="inline-flex items-center gap-1">${action.icon}${mobile ? html`` : html`<span class="text-xs hidden md:inline">${action.label}</span>`}</span>
 		</button>
 	`;
 }
@@ -815,6 +830,7 @@ function renderHeaderSessionActions(input: {
 		event.preventDefault();
 		event.stopPropagation();
 		const trigger = event.currentTarget as HTMLElement;
+		const row = trigger.closest<HTMLElement>("[data-sidebar-actions-row-root]");
 		resetSessionForkNewWorktree();
 		const currentOverflowActions = () => partitionHeaderSessionActions(buildActions(), input.mobile).overflowActions;
 		void openHeaderSessionActionsPopover({
@@ -822,23 +838,26 @@ function renderHeaderSessionActions(input: {
 			trigger,
 			actions: currentOverflowActions(),
 			refresh: currentOverflowActions,
+			sourceRects: row ? captureSidebarActionSourceRects(row) : [],
 		});
 	};
 	return html`
-		<div class="flex items-center gap-1 shrink-0 relative" data-session-action-surface="header">
-			${input.mobile ? html`` : directActions.map(renderHeaderSessionActionButton)}
-			${showOverflow ? html`
-				<button
-					type="button"
-					class="${input.mobile ? "h-10 w-10 p-0" : "h-7 px-2"} rounded-md transition-colors inline-flex items-center justify-center text-muted-foreground hover:bg-secondary/80 hover:text-foreground"
-					data-testid="session-actions-trigger"
-					aria-label="Session actions"
-					aria-haspopup="menu"
-					aria-expanded=${isHeaderSessionActionsPopoverOpen(input.session.id) ? "true" : "false"}
-					title="Session actions"
-					@click=${openFromTrigger}
-				>${icon(Menu, "xs")}</button>
-			` : html``}
+		<div class="flex items-center gap-1 shrink-0 relative" data-session-action-surface="header" data-sidebar-actions-row-root>
+			<div class="sidebar-actions flex items-center gap-1">
+				${directActions.map((action) => renderHeaderSessionActionButton(action, input.mobile))}
+				${showOverflow ? html`
+					<button
+						type="button"
+						class="${input.mobile ? "h-10 w-10 p-0" : "h-7 px-2"} rounded-md transition-colors inline-flex items-center justify-center text-muted-foreground hover:bg-secondary/80 hover:text-foreground"
+						data-testid="session-actions-trigger"
+						aria-label="Session actions"
+						aria-haspopup="menu"
+						aria-expanded=${isHeaderSessionActionsPopoverOpen(input.session.id) ? "true" : "false"}
+						title="Session actions"
+						@click=${openFromTrigger}
+					>${icon(Menu, "xs")}</button>
+				` : html``}
+			</div>
 		</div>
 	`;
 }

--- a/tests/e2e/ui/session-actions.spec.ts
+++ b/tests/e2e/ui/session-actions.spec.ts
@@ -279,7 +279,7 @@ test.describe("unified session actions", () => {
 		);
 	});
 
-	test("mobile session header keeps back/title usable and exposes full actions through hamburger", async ({ page }) => {
+	test("mobile session header shows icon-only quick actions and opens the remaining menu with FLIP sources", async ({ page }) => {
 		const sessionId = await createSession();
 		sessionsToDelete.add(sessionId);
 		await waitForSessionStatus(sessionId, "idle");
@@ -289,10 +289,60 @@ test.describe("unified session actions", () => {
 		await expect(page.getByTitle("Back to session list")).toBeVisible({ timeout: 5_000 });
 		await expect(page.locator(".mobile-header-title").first()).toBeVisible({ timeout: 5_000 });
 		await expect(headerTrigger(page), "mobile session view must expose the unified session actions menu").toBeVisible({ timeout: 5_000 });
-		await expect(page.locator(HEADER_ACTION_SELECTOR), "mobile should suppress individual header action buttons").toHaveCount(0);
+
+		const directIds = await page.locator(HEADER_ACTION_SELECTOR).evaluateAll((els) =>
+			els.map((el) => (el as HTMLElement).dataset.sessionActionId || "").filter(Boolean),
+		);
+		expect(directIds, "mobile header should render exactly the icon-only quick actions next to the hamburger").toEqual(["modify", "terminate"]);
+		for (const actionId of ["modify", "terminate"] as const) {
+			const button = headerDirectAction(page, actionId);
+			await expect(button, `${actionId} quick action should be visible in the mobile header`).toBeVisible({ timeout: 5_000 });
+			await expect(button).toHaveAttribute("aria-label", actionId === "modify" ? /Edit|Modify/ : /Terminate|End team/);
+			const visibleLabelText = await button.evaluate((el) => {
+				const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+				const visible: string[] = [];
+				while (walker.nextNode()) {
+					const node = walker.currentNode as Text;
+					const text = node.textContent?.trim();
+					if (!text) continue;
+					const parent = node.parentElement;
+					if (!parent) continue;
+					const style = getComputedStyle(parent);
+					if (style.display === "none" || style.visibility === "hidden" || Number(style.opacity) === 0) continue;
+					const range = document.createRange();
+					range.selectNodeContents(node);
+					const rect = range.getBoundingClientRect();
+					range.detach();
+					if (rect.width > 2 && rect.height > 2) visible.push(text);
+				}
+				return visible.join(" ");
+			});
+			expect(visibleLabelText, `${actionId} quick action should not expose a visible text label on mobile`).toBe("");
+		}
+
+		await page.evaluate(() => {
+			const original = Element.prototype.animate;
+			(window as any).__mobileHeaderActionAnimations = [];
+			Element.prototype.animate = function(keyframes: Keyframe[] | PropertyIndexedKeyframes | null, options?: number | KeyframeAnimationOptions) {
+				const el = this as HTMLElement;
+				(window as any).__mobileHeaderActionAnimations.push({
+					actionId: el.dataset.sidebarActionId || el.dataset.sessionActionId || "",
+					quick: el.dataset.sidebarActionQuick || "",
+					keyframes,
+					options,
+				});
+				return original.call(this, keyframes, options);
+			};
+		});
 
 		await openHeaderActions(page);
-		expect(await popoverActionIds(page)).toEqual(CANONICAL_SESSION_ACTION_IDS);
+		const overflowIds = await popoverActionIds(page);
+		expect(overflowIds).toEqual(CANONICAL_SESSION_ACTION_IDS);
+		const sourceIds = await page.locator("sidebar-actions-popover").first().evaluate((el) => ((el as any).sourceRects || []).map((rect: { actionId: string }) => rect.actionId));
+		expect(sourceIds, "mobile header hamburger should capture quick-action source rects for FLIP").toEqual(expect.arrayContaining(["modify", "terminate"]));
+		await expect.poll(() => page.evaluate(() => (window as any).__mobileHeaderActionAnimations
+			.filter((call: any) => ["modify", "terminate"].includes(call.actionId) && call.quick === "true" && JSON.stringify(call.keyframes).includes("translate"))
+			.map((call: any) => call.actionId)), { timeout: 5_000 }).toEqual(expect.arrayContaining(["modify", "terminate"]));
 		const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
 		expect(overflow, "mobile header must not create horizontal document overflow").toBeLessThanOrEqual(1);
 	});

--- a/tests/e2e/ui/sidebar-actions-menu.spec.ts
+++ b/tests/e2e/ui/sidebar-actions-menu.spec.ts
@@ -642,7 +642,7 @@ test.describe("Sidebar actions menu", () => {
 		).toHaveCount(0, { timeout: 5_000 });
 	});
 
-	test.skip("fixture-covered: mobile v1 hides hamburger while keeping existing inline quick actions visible", async ({ page }) => {
+	test("mobile sidebar rows keep quick actions and open full hamburger menus without row navigation", async ({ page }) => {
 		await page.setViewportSize({ width: 390, height: 820 });
 		const sessionId = await createSession();
 		sessionIds.push(sessionId);
@@ -653,16 +653,29 @@ test.describe("Sidebar actions menu", () => {
 		await openApp(page);
 		const sRow = sessionRow(page, sessionId);
 		await expect(sRow).toBeVisible({ timeout: 10_000 });
-		await expect(triggerFor(sRow, "session", sessionId)).toHaveCount(0);
 		await expect(sRow.locator('[data-sidebar-action-id="modify"][data-sidebar-action-quick="true"]')).toBeVisible();
 		await expect(sRow.locator('[data-sidebar-action-id="terminate"][data-sidebar-action-quick="true"]')).toBeVisible();
 		await expect(sRow.locator('[data-sidebar-action-id="copy-link"]')).toHaveCount(0);
+		const startingHash = await page.evaluate(() => window.location.hash);
+		await expect(triggerFor(sRow, "session", sessionId), "mobile session rows must expose a hamburger actions trigger").toBeVisible();
+		await triggerFor(sRow, "session", sessionId).click();
+		await expect(page.locator("sidebar-actions-popover [role='menu']")).toBeVisible({ timeout: 5_000 });
+		expect(await menuLabels(page)).toEqual(expect.arrayContaining(["Refresh agent", "Fork", "Copy link", "View System Prompt", "Open in new window"]));
+		await expect.poll(() => page.evaluate(() => window.location.hash), { message: "session hamburger should not select/navigate its row" }).toBe(startingHash);
+		await page.keyboard.press("Escape");
+		await expectNoPopover(page);
 
 		const gRow = await ensureGoalExpanded(page, goal.id as string);
-		await expect(triggerFor(gRow, "goal", goal.id as string)).toHaveCount(0);
-		await expect(gRow.locator('[data-sidebar-action-id="reattempt"]'), "re-attempt is popover-only and not an inline quick action").toHaveCount(0);
 		await expect(gRow.locator('[data-sidebar-action-id="archive"][data-sidebar-action-quick="true"]')).toBeVisible();
 		await expect(gRow.locator('[data-sidebar-action-id="dashboard"][data-sidebar-action-quick="true"]')).toBeVisible();
+		await expect(gRow.locator('[data-sidebar-action-id="reattempt"]'), "re-attempt remains popover-only, not an inline quick action").toHaveCount(0);
 		await expect(gRow.locator('[data-sidebar-action-id="copy-link"]')).toHaveCount(0);
+		await expect(triggerFor(gRow, "goal", goal.id as string), "mobile goal rows must expose a hamburger actions trigger").toBeVisible();
+		const expandedBefore = await page.evaluate((id) => (window as any).__bobbitExpandedGoals?.has?.(id), goal.id);
+		await triggerFor(gRow, "goal", goal.id as string).click();
+		await expect(page.locator("sidebar-actions-popover [role='menu']")).toBeVisible({ timeout: 5_000 });
+		expect(await menuLabels(page)).toEqual(expect.arrayContaining(["Re-attempt", "Copy link"]));
+		await expect.poll(() => page.evaluate(() => window.location.hash), { message: "goal hamburger should not navigate its row" }).toBe(startingHash);
+		await expect.poll(() => page.evaluate((id) => (window as any).__bobbitExpandedGoals?.has?.(id), goal.id), { message: "goal hamburger should not toggle expansion" }).toBe(expandedBefore);
 	});
 });

--- a/tests/ui-fixtures/sidebar-actions-menu-fixture.spec.ts
+++ b/tests/ui-fixtures/sidebar-actions-menu-fixture.spec.ts
@@ -271,18 +271,45 @@ test("reduced-motion opens and closes without component animations", async ({ pa
 	await expect.poll(() => page.evaluate(() => (window as any).__sidebarActionsAnimateCalls)).toBe(0);
 });
 
-test("mobile v1 hides the hamburger and keeps existing inline quick actions visible", async ({ page }) => {
+test("mobile rows expose quick actions plus hamburger menus without row navigation", async ({ page }) => {
 	const ids = await loadFixture(page, { width: 390, height: 820 });
 	const sRow = row(page, "session", ids.session);
-	await expect(trigger(page, "session", ids.session)).toHaveCount(0);
 	await expect(sRow.locator('[data-sidebar-action-id="modify"][data-sidebar-action-quick="true"]')).toBeVisible();
 	await expect(sRow.locator('[data-sidebar-action-id="terminate"][data-sidebar-action-quick="true"]')).toBeVisible();
 	await expect(sRow.locator('[data-sidebar-action-id="copy-link"]')).toHaveCount(0);
 
+	const startingHash = await page.evaluate(() => window.location.hash);
+	const startingActive = await sRow.getAttribute("data-nav-active");
+	await expect(trigger(page, "session", ids.session), "mobile session rows must expose a hamburger actions trigger").toBeVisible();
+	await openMenu(page, "session", ids.session);
+	await expect.poll(() => menuLabels(page)).toEqual(["Modify", "Terminate", "Refresh agent", "Fork", "Copy link", "View System Prompt", "Open in new window"]);
+	await expect(item(page, "refresh-agent")).toBeVisible();
+	await expect(item(page, "fork")).toBeVisible();
+	await expect(item(page, "copy-link")).toBeVisible();
+	await expect(item(page, "view-system-prompt")).toBeVisible();
+	await expect(item(page, "open-new-window")).toBeVisible();
+	await expect.poll(() => page.evaluate(() => window.location.hash), { message: `${MARK}: session hamburger must not select/navigate the row` }).toBe(startingHash);
+	await expect(sRow).toHaveAttribute("data-nav-active", startingActive ?? "false");
+	await page.keyboard.press("Escape");
+	await expectNoPopover(page);
+
+	await sRow.locator('[data-sidebar-action-id="modify"][data-sidebar-action-quick="true"]').click();
+	await expect.poll(() => page.evaluate(() => window.location.hash), { message: `${MARK}: quick modify must not select/navigate the row` }).toBe(startingHash);
+	await expect(sRow).toHaveAttribute("data-nav-active", startingActive ?? "false");
+	await page.keyboard.press("Escape").catch(() => {});
+
 	const gRow = row(page, "goal", ids.goal);
-	await expect(trigger(page, "goal", ids.goal)).toHaveCount(0);
-	await expect(gRow.locator('[data-sidebar-action-id="reattempt"]'), "re-attempt is popover-only and not an inline quick action").toHaveCount(0);
 	await expect(gRow.locator('[data-sidebar-action-id="archive"][data-sidebar-action-quick="true"]')).toBeVisible();
 	await expect(gRow.locator('[data-sidebar-action-id="dashboard"][data-sidebar-action-quick="true"]')).toBeVisible();
+	await expect(gRow.locator('[data-sidebar-action-id="reattempt"]'), "re-attempt remains popover-only, not an inline quick action").toHaveCount(0);
 	await expect(gRow.locator('[data-sidebar-action-id="copy-link"]')).toHaveCount(0);
+	const emptyState = page.getByText("No sessions").first();
+	const emptyStateWasVisible = await emptyState.isVisible();
+	await expect(trigger(page, "goal", ids.goal), "mobile goal rows must expose a hamburger actions trigger").toBeVisible();
+	await openMenu(page, "goal", ids.goal);
+	await expect.poll(() => menuLabels(page)).toEqual(["Goal dashboard", "Archive", "Re-attempt", "Copy link"]);
+	await expect(item(page, "reattempt")).toBeVisible();
+	await expect(item(page, "copy-link")).toBeVisible();
+	await expect.poll(() => page.evaluate(() => window.location.hash), { message: `${MARK}: goal hamburger must not navigate the row` }).toBe(startingHash);
+	if (emptyStateWasVisible) await expect(emptyState, `${MARK}: goal hamburger must not toggle expansion`).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- Add mobile sidebar/landing row hamburger action menus for sessions, team leads, and goals while preserving quick actions.
- Add mobile chat-header icon-only quick actions next to the full session actions hamburger with FLIP source rects.
- Update strict mobile fixture/E2E coverage and add UX notes.

## Verification
- npm run check
- npm run test:unit
- npx playwright test --config playwright-e2e.config.ts --project=browser tests/e2e/ui/session-actions.spec.ts tests/e2e/ui/sidebar-actions-menu.spec.ts --workers=1

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)