### PR TITLE
Retry Mobile Menus

### DIFF
--- a/docs/design/mobile-action-menus-accessibility-check.md
+++ b/docs/design/mobile-action-menus-accessibility-check.md
@@ -1,0 +1,39 @@
+# Mobile action menus — UX/accessibility check
+
+Goal: when a mobile hamburger action menu opens, the inline quick controls must stop behaving as separate controls until the menu closes. Source-rect capture for FLIP may use them immediately before opening, but the open state must not leave duplicated visible/clickable/focusable buttons.
+
+## Current pattern risks
+
+- `src/ui/components/SidebarActionsPopover.ts` currently fades row quick buttons by setting inline `opacity`. Opacity alone is not enough: the controls can remain clickable, keyboard-focusable, and exposed to assistive tech.
+- `src/app/render.ts` mobile header direct actions are rendered independently from the hamburger open state, so they need the same explicit open-state gating as sidebar rows.
+- The trigger already carries the right pattern (`aria-haspopup="menu"`, `aria-expanded` from open state); preserve that and assert it on open and after every close path.
+
+## Implementer recommendations
+
+1. Capture FLIP source rects before flipping render state, then hide quick controls from the rendered open state.
+   - Sidebar: capture with `captureSidebarActionSourceRects(row)` in the trigger handler, then render the row with quick buttons hidden while `isSidebarActionsPopoverOpen(kind, entityId)` is true.
+   - Header: capture from the header action surface before `openHeaderSessionActionsPopover`, then render direct quick actions hidden while `isHeaderSessionActionsPopoverOpen(session.id)` is true.
+2. Do not rely on `opacity: 0` alone. Use one of these robust patterns:
+   - Prefer not rendering the quick buttons while the matching mobile menu is open; or
+   - Keep layout placeholders but set `visibility:hidden`, `pointer-events:none`, `aria-hidden="true"`, `tabindex="-1"`, and `disabled` on the actual buttons.
+3. Hide only the quick action buttons, never the hamburger trigger. The trigger must remain visible and report `aria-expanded="true"` while the menu is open.
+4. Restore controls from the single close state, not from animation callbacks alone. Escape, outside click, menu item selection, route change, and state re-render should all clear the open state and re-render quick buttons enabled/focusable.
+5. Keep action handlers stopping propagation. Hidden controls must not receive events, and visible controls must not trigger row navigation.
+
+## Tester recommendations
+
+Add mobile assertions around the existing E2E coverage:
+
+- Sidebar mobile session row:
+  - Before open: `modify` and `terminate` quick buttons are visible and enabled.
+  - After hamburger open: both are not visible and not focusable/clickable; hamburger has `aria-haspopup="menu"` and `aria-expanded="true"`; hash/row selection did not change.
+  - After Escape, outside click, and a safe menu action such as Copy link: popover is gone, `aria-expanded="false"`, quick buttons are visible/enabled again.
+- Header mobile session actions:
+  - Before open: direct quick IDs are exactly `modify`, `terminate`.
+  - After hamburger open: both direct quick buttons are hidden/non-interactive; popover still contains the full canonical action list; source rects still include `modify` and `terminate` for FLIP.
+  - After each close path: direct quick buttons are restored.
+- If the implementation keeps hidden placeholders instead of removing buttons, assert computed state too: no pointer events, disabled or `tabIndex < 0`, and `aria-hidden="true"`.
+
+## Consistency rationale
+
+This preserves the existing desktop sidebar model: hamburger remains the stable menu anchor, quick actions provide source geometry for the shared-element animation, and the popover is the only active action surface while open. The mobile change should be state-driven so all close paths restore the same accessible controls without special-case timing.

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -672,7 +672,7 @@ function buildGoalSidebarActions(goal: Goal, input: { hasActiveSession: boolean;
 		const url = prBadge.url;
 		actions.push({
 			id: "open-github",
-			label: "Open on GitHub",
+			label: prBadge.number != null ? `Open #${prBadge.number} on GitHub` : "Open on GitHub",
 			title: "Open this goal's pull request on GitHub",
 			icon: goalPrIconSvg(prBadge.color, "1.2em"),
 			quick: false,
@@ -1203,6 +1203,7 @@ interface GoalPrBadge {
 	color: string;
 	url: string | null;
 	label: string;
+	number: number | null;
 	hasConflicts: boolean;
 }
 
@@ -1217,7 +1218,7 @@ interface GoalPrBadge {
  * preserve the PR badge fallback.
  */
 function resolveGoalPrBadge(goal: Goal): GoalPrBadge {
-	const hidden: GoalPrBadge = { show: false, color: "", url: null, label: "", hasConflicts: false };
+	const hidden: GoalPrBadge = { show: false, color: "", url: null, label: "", number: null, hasConflicts: false };
 	const gs = state.gateStatusCache.get(goal.id);
 	const pr = state.prStatusCache.get(goal.id);
 	const hasWorkflowGates = !!goal.workflowId || (goal.workflow?.gates?.length ?? 0) > 0;
@@ -1236,7 +1237,7 @@ function resolveGoalPrBadge(goal: Goal): GoalPrBadge {
 		: "";
 	const hasConflicts = pr.state === "OPEN" && pr.mergeable === "CONFLICTING";
 	const label = (pr.number ? `PR #${pr.number} ${pr.state.toLowerCase()}` : `PR ${pr.state.toLowerCase()}`) + reviewLabel + (hasConflicts ? " — has conflicts" : "");
-	return { show: true, color, url: pr.url ?? null, label, hasConflicts };
+	return { show: true, color, url: pr.url ?? null, label, number: pr.number ?? null, hasConflicts };
 }
 
 /** The goal-row pull-request SVG, in the state-derived stroke color. */

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -514,7 +514,8 @@ async function openSidebarActionsPopover(input: {
 	renderApp();
 }
 
-function renderSidebarQuickActions(actions: SidebarActionItem[], opts: { kind: SidebarActionEntityKind; mobile: boolean; btnPad: string }): TemplateResult {
+function renderSidebarQuickActions(actions: SidebarActionItem[], opts: { kind: SidebarActionEntityKind; entityId: string; mobile: boolean; btnPad: string }): TemplateResult {
+	if (opts.mobile && opts.kind === "session" && isSidebarActionsPopoverOpen(opts.kind, opts.entityId)) return html``;
 	return html`${actions.filter((action) => action.quick).map((action) => {
 		const danger = action.tone === "danger";
 		const colorClass = opts.mobile
@@ -906,7 +907,7 @@ export function renderSessionRow(session: GatewaySession) {
 
 	const actions = buildSessionSidebarActions(session, displayTitle);
 	const actionRefresh = () => buildSessionSidebarActions(session, displayTitle);
-	const buttons = html`${renderSidebarQuickActions(actions, { kind: "session", mobile, btnPad })}${renderSidebarActionsTrigger({ kind: "session", entityId: session.id, actions, mobile, btnPad, refresh: actionRefresh, onBeforeOpen: resetSessionForkNewWorktree })}`;
+	const buttons = html`${renderSidebarQuickActions(actions, { kind: "session", entityId: session.id, mobile, btnPad })}${renderSidebarActionsTrigger({ kind: "session", entityId: session.id, actions, mobile, btnPad, refresh: actionRefresh, onBeforeOpen: resetSessionForkNewWorktree })}`;
 
 	const navId = `session:${session.id}`;
 	// Keyboard nav can have moved the active row away from this session even
@@ -1064,7 +1065,7 @@ function renderTeamLeadRow(session: GatewaySession, childCount: number, expanded
 
 	const actions = buildTeamLeadSidebarActions(session, displayTitle, goalId);
 	const actionRefresh = () => buildTeamLeadSidebarActions(session, displayTitle, goalId);
-	const buttons = html`${renderSidebarQuickActions(actions, { kind: "session", mobile, btnPad })}${renderSidebarActionsTrigger({ kind: "session", entityId: session.id, actions, mobile, btnPad, refresh: actionRefresh, onBeforeOpen: resetSessionForkNewWorktree })}`;
+	const buttons = html`${renderSidebarQuickActions(actions, { kind: "session", entityId: session.id, mobile, btnPad })}${renderSidebarActionsTrigger({ kind: "session", entityId: session.id, actions, mobile, btnPad, refresh: actionRefresh, onBeforeOpen: resetSessionForkNewWorktree })}`;
 
 	const chevron = html`<span
 		class="absolute left-0 top-0 bottom-0 flex items-center justify-center text-muted-foreground select-none cursor-pointer"
@@ -1351,7 +1352,7 @@ export function renderGoalGroup(goal: Goal, opts?: { descendantCount?: number; r
 	const hasActiveSession = goalSessions.some((s) => s.status !== "terminated");
 	const goalActions = buildGoalSidebarActions(goal, { hasActiveSession, showArchive });
 	const goalActionRefresh = () => buildGoalSidebarActions(goal, { hasActiveSession, showArchive });
-	const goalButtons = html`${renderSidebarQuickActions(goalActions, { kind: "goal", mobile, btnPad })}${renderSidebarActionsTrigger({ kind: "goal", entityId: goal.id, actions: goalActions, mobile, btnPad, refresh: goalActionRefresh, onBeforeOpen: () => prefetchGoalGithubLink(goal.id) })}`;
+	const goalButtons = html`${renderSidebarQuickActions(goalActions, { kind: "goal", entityId: goal.id, mobile, btnPad })}${renderSidebarActionsTrigger({ kind: "goal", entityId: goal.id, actions: goalActions, mobile, btnPad, refresh: goalActionRefresh, onBeforeOpen: () => prefetchGoalGithubLink(goal.id) })}`;
 
 	const emptyState = html`
 		<div class="pl-2 py-1 text-muted-foreground" style="${mobile ? "" : "font-size: 0.9167em;"}">

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -825,6 +825,8 @@ function renderHeaderSessionActions(input: {
 	const actions = buildActions();
 	if (!actions.length) return html``;
 	const { directActions, overflowActions } = partitionHeaderSessionActions(actions, input.mobile);
+	const hideDirectActions = input.mobile && isHeaderSessionActionsPopoverOpen(input.session.id);
+	const visibleDirectActions = hideDirectActions ? [] : directActions;
 	const showOverflow = input.mobile || overflowActions.length > 0;
 	const openFromTrigger = (event: Event) => {
 		event.preventDefault();
@@ -844,7 +846,7 @@ function renderHeaderSessionActions(input: {
 	return html`
 		<div class="flex items-center gap-1 shrink-0 relative" data-session-action-surface="header" data-sidebar-actions-row-root>
 			<div class="sidebar-actions flex items-center gap-1">
-				${directActions.map((action) => renderHeaderSessionActionButton(action, input.mobile))}
+				${visibleDirectActions.map((action) => renderHeaderSessionActionButton(action, input.mobile))}
 				${showOverflow ? html`
 					<button
 						type="button"

--- a/tests/e2e/ui/session-actions.spec.ts
+++ b/tests/e2e/ui/session-actions.spec.ts
@@ -96,6 +96,34 @@ async function closePopover(page: Page): Promise<void> {
 	}
 }
 
+async function expectQuickActionHiddenAndNonInteractive(action: Locator, description: string): Promise<void> {
+	await expect(action, `${description} should be hidden while the hamburger menu is open`).toBeHidden({ timeout: 5_000 });
+	const interactiveTargets = await action.evaluateAll((els) => els.map((el, index) => {
+		const target = el as HTMLElement;
+		let current: HTMLElement | null = target;
+		let hiddenByStyle = false;
+		while (current) {
+			const style = getComputedStyle(current);
+			if (style.display === "none" || style.visibility === "hidden") {
+				hiddenByStyle = true;
+				break;
+			}
+			current = current.parentElement;
+		}
+		const hiddenByAttribute = Boolean(target.closest("[hidden],[aria-hidden='true'],[inert]"));
+		const disabled = (target as HTMLButtonElement).disabled || target.getAttribute("aria-disabled") === "true";
+		const focusBlocked = hiddenByStyle || hiddenByAttribute || disabled || target.getAttribute("tabindex") === "-1" || target.tabIndex < 0;
+		const rect = target.getBoundingClientRect();
+		let pointerBlocked = rect.width <= 0 || rect.height <= 0 || getComputedStyle(target).pointerEvents === "none";
+		if (!pointerBlocked) {
+			const hit = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+			pointerBlocked = !hit || (hit !== target && !target.contains(hit));
+		}
+		return focusBlocked && pointerBlocked ? "" : `target ${index}: focusBlocked=${focusBlocked} pointerBlocked=${pointerBlocked}`;
+	}).filter(Boolean));
+	expect(interactiveTargets, `${description} should not leave clickable or focusable targets`).toEqual([]);
+}
+
 async function popoverActionIds(page: Page): Promise<string[]> {
 	return page.locator(POPOVER_ACTION_SELECTOR).evaluateAll((els) =>
 		els.map((el) => (el as HTMLElement).dataset.sessionActionId || "").filter(Boolean),
@@ -294,8 +322,12 @@ test.describe("unified session actions", () => {
 			els.map((el) => (el as HTMLElement).dataset.sessionActionId || "").filter(Boolean),
 		);
 		expect(directIds, "mobile header should render exactly the icon-only quick actions next to the hamburger").toEqual(["modify", "terminate"]);
+		const quickButtons = {
+			modify: headerDirectAction(page, "modify"),
+			terminate: headerDirectAction(page, "terminate"),
+		};
 		for (const actionId of ["modify", "terminate"] as const) {
-			const button = headerDirectAction(page, actionId);
+			const button = quickButtons[actionId];
 			await expect(button, `${actionId} quick action should be visible in the mobile header`).toBeVisible({ timeout: 5_000 });
 			await expect(button).toHaveAttribute("aria-label", actionId === "modify" ? /Edit|Modify/ : /Terminate|End team/);
 			const visibleLabelText = await button.evaluate((el) => {
@@ -338,6 +370,8 @@ test.describe("unified session actions", () => {
 		await openHeaderActions(page);
 		const overflowIds = await popoverActionIds(page);
 		expect(overflowIds).toEqual(CANONICAL_SESSION_ACTION_IDS);
+		await expectQuickActionHiddenAndNonInteractive(quickButtons.modify, "mobile header modify quick action");
+		await expectQuickActionHiddenAndNonInteractive(quickButtons.terminate, "mobile header terminate quick action");
 		const sourceIds = await page.locator("sidebar-actions-popover").first().evaluate((el) => ((el as any).sourceRects || []).map((rect: { actionId: string }) => rect.actionId));
 		expect(sourceIds, "mobile header hamburger should capture quick-action source rects for FLIP").toEqual(expect.arrayContaining(["modify", "terminate"]));
 		await expect.poll(() => page.evaluate(() => (window as any).__mobileHeaderActionAnimations
@@ -345,6 +379,10 @@ test.describe("unified session actions", () => {
 			.map((call: any) => call.actionId)), { timeout: 5_000 }).toEqual(expect.arrayContaining(["modify", "terminate"]));
 		const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
 		expect(overflow, "mobile header must not create horizontal document overflow").toBeLessThanOrEqual(1);
+
+		await closePopover(page);
+		await expect(quickButtons.modify, "mobile header modify quick action should return after close").toBeVisible({ timeout: 5_000 });
+		await expect(quickButtons.terminate, "mobile header terminate quick action should return after close").toBeVisible({ timeout: 5_000 });
 	});
 
 	test("fork trailing toggle is keyboard-accessible and does not fire fork until the row action runs", async ({ page }) => {

--- a/tests/e2e/ui/sidebar-actions-menu.spec.ts
+++ b/tests/e2e/ui/sidebar-actions-menu.spec.ts
@@ -57,6 +57,34 @@ test.describe("Sidebar actions menu", () => {
 		await expect(page.locator("sidebar-actions-popover")).toHaveCount(0, { timeout: 5_000 });
 	}
 
+	async function expectQuickActionHiddenAndNonInteractive(action: Locator, description: string): Promise<void> {
+		await expect(action, `${description} should be hidden while the hamburger menu is open`).toBeHidden({ timeout: 5_000 });
+		const interactiveTargets = await action.evaluateAll((els) => els.map((el, index) => {
+			const target = el as HTMLElement;
+			let current: HTMLElement | null = target;
+			let hiddenByStyle = false;
+			while (current) {
+				const style = getComputedStyle(current);
+				if (style.display === "none" || style.visibility === "hidden") {
+					hiddenByStyle = true;
+					break;
+				}
+				current = current.parentElement;
+			}
+			const hiddenByAttribute = Boolean(target.closest("[hidden],[aria-hidden='true'],[inert]"));
+			const disabled = (target as HTMLButtonElement).disabled || target.getAttribute("aria-disabled") === "true";
+			const focusBlocked = hiddenByStyle || hiddenByAttribute || disabled || target.getAttribute("tabindex") === "-1" || target.tabIndex < 0;
+			const rect = target.getBoundingClientRect();
+			let pointerBlocked = rect.width <= 0 || rect.height <= 0 || getComputedStyle(target).pointerEvents === "none";
+			if (!pointerBlocked) {
+				const hit = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+				pointerBlocked = !hit || (hit !== target && !target.contains(hit));
+			}
+			return focusBlocked && pointerBlocked ? "" : `target ${index}: focusBlocked=${focusBlocked} pointerBlocked=${pointerBlocked}`;
+		}).filter(Boolean));
+		expect(interactiveTargets, `${description} should not leave clickable or focusable targets`).toEqual([]);
+	}
+
 	async function assertHamburgerAppearsOnHover(row: Locator, kind: "session" | "goal", id: string): Promise<void> {
 		const page = row.page();
 		const trigger = triggerFor(row, kind, id);
@@ -652,18 +680,24 @@ test.describe("Sidebar actions menu", () => {
 
 		await openApp(page);
 		const sRow = sessionRow(page, sessionId);
+		const sessionModify = sRow.locator('[data-sidebar-action-id="modify"][data-sidebar-action-quick="true"]').first();
+		const sessionTerminate = sRow.locator('[data-sidebar-action-id="terminate"][data-sidebar-action-quick="true"]').first();
 		await expect(sRow).toBeVisible({ timeout: 10_000 });
-		await expect(sRow.locator('[data-sidebar-action-id="modify"][data-sidebar-action-quick="true"]')).toBeVisible();
-		await expect(sRow.locator('[data-sidebar-action-id="terminate"][data-sidebar-action-quick="true"]')).toBeVisible();
+		await expect(sessionModify, "mobile session rows should expose quick modify before the hamburger opens").toBeVisible();
+		await expect(sessionTerminate, "mobile session rows should expose quick terminate before the hamburger opens").toBeVisible();
 		await expect(sRow.locator('[data-sidebar-action-id="copy-link"]')).toHaveCount(0);
 		const startingHash = await page.evaluate(() => window.location.hash);
 		await expect(triggerFor(sRow, "session", sessionId), "mobile session rows must expose a hamburger actions trigger").toBeVisible();
 		await triggerFor(sRow, "session", sessionId).click();
 		await expect(page.locator("sidebar-actions-popover [role='menu']")).toBeVisible({ timeout: 5_000 });
+		await expectQuickActionHiddenAndNonInteractive(sessionModify, "mobile sidebar modify quick action");
+		await expectQuickActionHiddenAndNonInteractive(sessionTerminate, "mobile sidebar terminate quick action");
 		expect(await menuLabels(page)).toEqual(expect.arrayContaining(["Refresh agent", "Fork", "Copy link", "View System Prompt", "Open in new window"]));
 		await expect.poll(() => page.evaluate(() => window.location.hash), { message: "session hamburger should not select/navigate its row" }).toBe(startingHash);
 		await page.keyboard.press("Escape");
 		await expectNoPopover(page);
+		await expect(sessionModify, "mobile sidebar modify quick action should return after Escape").toBeVisible({ timeout: 5_000 });
+		await expect(sessionTerminate, "mobile sidebar terminate quick action should return after Escape").toBeVisible({ timeout: 5_000 });
 
 		const gRow = await ensureGoalExpanded(page, goal.id as string);
 		await expect(gRow.locator('[data-sidebar-action-id="archive"][data-sidebar-action-quick="true"]')).toBeVisible();

--- a/tests/ui-fixtures/sidebar-actions-menu-fixture.spec.ts
+++ b/tests/ui-fixtures/sidebar-actions-menu-fixture.spec.ts
@@ -227,6 +227,29 @@ test("copy link fallback uses legacy execCommand without surfacing a modal", asy
 	);
 });
 
+test("goal GitHub action labels PR-numbered pull requests and opens the cached URL", async ({ page }) => {
+	const ids = await loadFixture(page);
+	const prUrl = "https://github.com/acme/widget/pull/1241";
+
+	await page.evaluate(({ goalId, url }) => {
+		(window as any).__bobbitState.prStatusCache.set(goalId, { state: "OPEN", url, number: 1241 });
+	}, { goalId: ids.goal, url: prUrl });
+
+	await openMenu(page, "goal", ids.goal);
+	await expect(item(page, "open-github")).toHaveText("Open #1241 on GitHub");
+	await expect(item(page, "open-github")).toHaveAttribute("title", "Open this goal's pull request on GitHub");
+	await item(page, "open-github").click();
+	await expectNoPopover(page);
+	await expect.poll(() => page.evaluate(() => (window as any).__sidebarActionsOpenedUrls.at(-1))).toBe(prUrl);
+
+	await page.evaluate(({ goalId, url }) => {
+		(window as any).__bobbitState.prStatusCache.set(goalId, { state: "OPEN", url });
+	}, { goalId: ids.goal, url: prUrl });
+
+	await openMenu(page, "goal", ids.goal);
+	await expect(item(page, "open-github")).toHaveText("Open on GitHub");
+});
+
 test("fork checkbox toggles independently and fork reads the current New worktree state", async ({ page }) => {
 	const ids = await loadFixture(page);
 

--- a/tests/ui-fixtures/sidebar-actions-menu-fixture.spec.ts
+++ b/tests/ui-fixtures/sidebar-actions-menu-fixture.spec.ts
@@ -98,6 +98,34 @@ async function expectNoPopover(page: Page): Promise<void> {
 	await expect(page.locator("sidebar-actions-popover")).toHaveCount(0, { timeout: 5_000 });
 }
 
+async function expectQuickActionHiddenAndNonInteractive(action: Locator, description: string): Promise<void> {
+	await expect(action, `${description} should be hidden while the hamburger menu is open`).toBeHidden({ timeout: 5_000 });
+	const interactiveTargets = await action.evaluateAll((els) => els.map((el, index) => {
+		const target = el as HTMLElement;
+		let current: HTMLElement | null = target;
+		let hiddenByStyle = false;
+		while (current) {
+			const style = getComputedStyle(current);
+			if (style.display === "none" || style.visibility === "hidden") {
+				hiddenByStyle = true;
+				break;
+			}
+			current = current.parentElement;
+		}
+		const hiddenByAttribute = Boolean(target.closest("[hidden],[aria-hidden='true'],[inert]"));
+		const disabled = (target as HTMLButtonElement).disabled || target.getAttribute("aria-disabled") === "true";
+		const focusBlocked = hiddenByStyle || hiddenByAttribute || disabled || target.getAttribute("tabindex") === "-1" || target.tabIndex < 0;
+		const rect = target.getBoundingClientRect();
+		let pointerBlocked = rect.width <= 0 || rect.height <= 0 || getComputedStyle(target).pointerEvents === "none";
+		if (!pointerBlocked) {
+			const hit = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+			pointerBlocked = !hit || (hit !== target && !target.contains(hit));
+		}
+		return focusBlocked && pointerBlocked ? "" : `target ${index}: focusBlocked=${focusBlocked} pointerBlocked=${pointerBlocked}`;
+	}).filter(Boolean));
+	expect(interactiveTargets, `${description} should not leave clickable or focusable targets`).toEqual([]);
+}
+
 async function menuLabels(page: Page): Promise<string[]> {
 	return page.locator("sidebar-actions-popover [role='menuitem']").evaluateAll((els) =>
 		els.map((el) => (el.textContent || "").replace(/\s+/g, " ").trim()),
@@ -274,14 +302,18 @@ test("reduced-motion opens and closes without component animations", async ({ pa
 test("mobile rows expose quick actions plus hamburger menus without row navigation", async ({ page }) => {
 	const ids = await loadFixture(page, { width: 390, height: 820 });
 	const sRow = row(page, "session", ids.session);
-	await expect(sRow.locator('[data-sidebar-action-id="modify"][data-sidebar-action-quick="true"]')).toBeVisible();
-	await expect(sRow.locator('[data-sidebar-action-id="terminate"][data-sidebar-action-quick="true"]')).toBeVisible();
+	const sessionModify = sRow.locator('[data-sidebar-action-id="modify"][data-sidebar-action-quick="true"]').first();
+	const sessionTerminate = sRow.locator('[data-sidebar-action-id="terminate"][data-sidebar-action-quick="true"]').first();
+	await expect(sessionModify, "mobile session rows should expose quick modify before the hamburger opens").toBeVisible();
+	await expect(sessionTerminate, "mobile session rows should expose quick terminate before the hamburger opens").toBeVisible();
 	await expect(sRow.locator('[data-sidebar-action-id="copy-link"]')).toHaveCount(0);
 
 	const startingHash = await page.evaluate(() => window.location.hash);
 	const startingActive = await sRow.getAttribute("data-nav-active");
 	await expect(trigger(page, "session", ids.session), "mobile session rows must expose a hamburger actions trigger").toBeVisible();
 	await openMenu(page, "session", ids.session);
+	await expectQuickActionHiddenAndNonInteractive(sessionModify, "mobile sidebar modify quick action");
+	await expectQuickActionHiddenAndNonInteractive(sessionTerminate, "mobile sidebar terminate quick action");
 	await expect.poll(() => menuLabels(page)).toEqual(["Modify", "Terminate", "Refresh agent", "Fork", "Copy link", "View System Prompt", "Open in new window"]);
 	await expect(item(page, "refresh-agent")).toBeVisible();
 	await expect(item(page, "fork")).toBeVisible();
@@ -292,8 +324,10 @@ test("mobile rows expose quick actions plus hamburger menus without row navigati
 	await expect(sRow).toHaveAttribute("data-nav-active", startingActive ?? "false");
 	await page.keyboard.press("Escape");
 	await expectNoPopover(page);
+	await expect(sessionModify, "mobile sidebar modify quick action should return after Escape").toBeVisible({ timeout: 5_000 });
+	await expect(sessionTerminate, "mobile sidebar terminate quick action should return after Escape").toBeVisible({ timeout: 5_000 });
 
-	await sRow.locator('[data-sidebar-action-id="modify"][data-sidebar-action-quick="true"]').click();
+	await sessionModify.click();
 	await expect.poll(() => page.evaluate(() => window.location.hash), { message: `${MARK}: quick modify must not select/navigate the row` }).toBe(startingHash);
 	await expect(sRow).toHaveAttribute("data-nav-active", startingActive ?? "false");
 	await page.keyboard.press("Escape").catch(() => {});


### PR DESCRIPTION
## Summary
- Hide mobile sidebar and mobile chat-header quick actions while their hamburger action menu is open.
- Keep quick actions restored after popover close and preserve FLIP/source-rect behavior.
- Add regression coverage for mobile quick-action visibility and numbered GitHub PR menu labels.
- Label goal PR menu actions as `Open #<number> on GitHub` when the PR number is known.

## Verification
- npm run check
- npm run test:unit
- npx playwright test --config tests/playwright.config.ts tests/ui-fixtures/sidebar-actions-menu-fixture.spec.ts
- npm run build --silent && npm run test:e2e:run -- tests/e2e/ui/sidebar-actions-menu.spec.ts tests/e2e/ui/session-actions.spec.ts

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)