### PR TITLE
Add OpenRouter API key setting

### DIFF
--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -2172,7 +2172,7 @@ export function renderModelsTab() {
 // Providers offered in the Models-tab "Provider API Keys" fallback section. Plain
 // `google` is the Google AI Studio / Gemini Developer API-key provider (distinct
 // from the `google-gemini-cli` account OAuth flow in Settings → Account).
-const PROVIDER_KEY_PROVIDERS = ["google", "anthropic", "openai"] as const;
+const PROVIDER_KEY_PROVIDERS = ["google", "anthropic", "openai", "openrouter"] as const;
 
 /** Human-readable labels for known project config keys. */
 const PROJECT_KEY_LABELS: Record<string, string> = {

--- a/src/server/agent/model-registry.ts
+++ b/src/server/agent/model-registry.ts
@@ -258,6 +258,7 @@ const ENV_MAP: Record<string, string> = {
 	"amazon-bedrock": "AWS_ACCESS_KEY_ID",
 	"groq": "GROQ_API_KEY",
 	"mistral": "MISTRAL_API_KEY",
+	"openrouter": "OPENROUTER_API_KEY",
 };
 
 /**

--- a/tests/settings-models-tab-redesign.spec.ts
+++ b/tests/settings-models-tab-redesign.spec.ts
@@ -270,6 +270,12 @@ test.describe("Settings Models tab redesign", () => {
 		// The component renders its (capitalized) provider name in the label.
 		await expect(googleKey).toContainText(/google/i);
 
+		// OpenRouter key input wrapper + its provider-key-input element render too.
+		const openrouterKey = page.locator('[data-testid="provider-key-input-openrouter"]');
+		await expect(openrouterKey).toBeVisible();
+		await expect(openrouterKey.locator("provider-key-input")).toHaveCount(1);
+		await expect(openrouterKey).toContainText(/openrouter/i);
+
 		// Provider API Keys appears after Default Models in document order.
 		const order = await page.evaluate(() => {
 			const d = document.querySelector('[data-testid="defaults-section"]')!;


### PR DESCRIPTION
## Summary

- Add OpenRouter to Settings → Models → Provider API Keys
- Detect `OPENROUTER_API_KEY` env-var auth in the model registry
- Extend the Models tab browser fixture to assert the OpenRouter key input renders

## Testing

- `npm run check`
- `npm run test:unit`
- `npx playwright test --config tests/playwright.config.ts settings-models-tab-redesign.spec.ts -g "Provider API Keys"`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)