### PR TITLE
Metadata Tab

### DIFF
--- a/docs/design/goal-metadata.md
+++ b/docs/design/goal-metadata.md
@@ -454,16 +454,21 @@ if (metadata && typeof metadata === "object" && !Array.isArray(metadata)
 - Proposal draft frontmatter carries `metadata` (YAML object) — extend the goal
   proposal field set so the draft round-trips it.
 - `src/app/proposal-parsers.ts` / proposal-panels initialisation: parse the
-  `metadata` object from the proposal and seed the dialog state
-  (`_proposalGoalMetadata`).
+  `metadata` object from the proposal and seed the shared metadata row state
+  (`_proposalMetadataRows`) so agent-seeded proposals pre-fill the editor.
 
 ### 7.4 Metadata value parsing & string preservation (UI editor)
 
 The goal-creation / proposal dialog exposes a simple key/value metadata editor.
-Internally it stores ordered `[key, value]` **string** rows for direct `<input>`
-round-tripping; the conversion helpers live in `src/app/proposal-helpers.ts` and
-are shared by the editor, the submit path, and the proposal-mirror seeding so
-every surface converts identically.
+In the tabbed goal-proposal panel, the editor lives on the dedicated **Metadata**
+tab so the main **Goal** tab stays focused on title, cwd, workflow, and spec. The
+tab is ordered after **Roles** and before **Sub-goals** when sub-goals are
+available. The non-tabbed new-goal form still renders the same editor inline.
+
+Internally the editor stores ordered `[key, value]` **string** rows for direct
+`<input>` round-tripping; the conversion helpers live in
+`src/app/proposal-helpers.ts` and are shared by the editor, the submit path, and
+the proposal-mirror seeding so every surface converts identically.
 
 - **Rows → object** (`metadataRowsToObject`, at submit): blank keys are dropped;
   each value is JSON-parsed when it parses (numbers, booleans, arrays, objects,
@@ -486,18 +491,18 @@ unit tests.
 
 ### 7.5 Goal-creation UI dialog
 
-- `src/app/state.ts`: add `previewGoalMetadata?: Record<string, unknown>` (or a
-  raw key/value editor model — array of `{ key, value }` rows like the existing
-  component config editors).
-- `src/app/proposal-panels.ts` `GoalFormConfig`: add a **simple key/value editor**
-  (string key → JSON-parsed value; fall back to string when not valid JSON),
-  mirroring the `worktreeSetupCommand` control. Empty editor ⇒ no `metadata`
-  field forwarded (so empty = no override).
-- `src/app/api.ts::createGoal`: add `metadata?: Record<string, unknown>` to opts;
-  forward `body.metadata` only when non-empty (mirrors `worktreeSetupCommand`).
-- `mirrorGoalSetupFields` / proposal mirror paths (`src/app/session-manager.ts`)
-  carry `metadata` through accept so a `propose_goal`-seeded proposal pre-fills
-  the editor.
+- `src/app/state.ts`: stores preview metadata as ordered string rows
+  (`previewMetadataRows`) for the non-tabbed new-goal surface.
+- `src/app/proposal-panels.ts` `GoalFormConfig`: carries the shared
+  `metadataRows` editor model plus an updater callback. The tabbed proposal
+  panel renders these rows in `goal-proposal-panel-metadata`, controlled by
+  `goal-proposal-tab-metadata`; the non-tabbed form renders the same
+  `renderGoalMetadataEditor` inline.
+- `src/app/api.ts::createGoal`: accepts `metadata?: Record<string, unknown>` and
+  forwards `body.metadata` only when non-empty.
+- Proposal mirror paths (`src/app/session-manager.ts` and proposal panel
+  initialization) carry `metadata` through accept so a `propose_goal`-seeded
+  proposal pre-fills the Metadata tab editor.
 
 ## 8. Test matrix
 
@@ -544,9 +549,12 @@ no error).
 
 ### 8.4 Browser E2E (`tests/e2e/ui/*.spec.ts`)
 
-Goal-creation dialog: add a metadata key/value row, create the goal, reload, and
-assert the value persists (goal detail / inspector reflects it). Empty editor ⇒
-no `metadata` on the created goal (no override).
+Goal-creation dialog: open the Metadata tab in the tabbed goal-proposal panel,
+add/edit/remove metadata rows, switch tabs, create the goal, reload, and assert
+the value persists (goal detail / inspector reflects it). Empty editor ⇒ no
+`metadata` on the created goal (no override). A seeded `propose_goal(...,
+metadata)` proposal must pre-fill the Metadata tab and retain edits across tab
+switches.
 
 ### 8.5 Commands
 
@@ -569,8 +577,8 @@ worktree provisioning + the extension host, also `npm run test:manual`.
 | `src/server/server.ts` | parse `body.metadata` in goal route; wire hub `goalMetadataResolver` + pipeline `resolveGoalMetadata` closures per project |
 | `defaults/tools/.../propose_goal` schema | optional `metadata` object |
 | `src/app/api.ts` | `createGoal` opts `metadata`, forward `body.metadata` |
-| `src/app/state.ts` | `previewGoalMetadata` editor model |
-| `src/app/proposal-panels.ts` | key/value editor in `GoalFormConfig`; forward at submit |
+| `src/app/state.ts` | `previewMetadataRows` editor model |
+| `src/app/proposal-panels.ts` | key/value editor in `GoalFormConfig`; dedicated tabbed proposal Metadata panel; forward at submit |
 | `src/app/proposal-parsers.ts` / `src/app/session-manager.ts` | parse + mirror `metadata` through proposal accept |
 
 ## 10. Out of scope

--- a/src/app/proposal-panels.ts
+++ b/src/app/proposal-panels.ts
@@ -1098,7 +1098,7 @@ function renderGoalForm(config: GoalFormConfig) {
 				`;})}
 				${!tabbed ? renderSubgoalsToggle(config) : ""}
 			</div>
-			${renderGoalMetadataEditor(config)}
+			${!tabbed ? renderGoalMetadataEditor(config) : ""}
 			<div class="flex-1 flex flex-col min-h-0">
 				<div class="flex items-center justify-between mb-1.5">
 					<div class="flex items-center gap-1">
@@ -1191,7 +1191,7 @@ function renderGoalForm(config: GoalFormConfig) {
 	const subgoalsTab = showSubgoalsTab(config);
 	const onTabChange = (t: ProposalTab) => config.onTabChange?.(t);
 	const onTabKey = (e: KeyboardEvent) => {
-		const order: ProposalTab[] = subgoalsTab ? ["goal", "workflow", "roles", "subgoals"] : ["goal", "workflow", "roles"];
+		const order: ProposalTab[] = subgoalsTab ? ["goal", "workflow", "roles", "metadata", "subgoals"] : ["goal", "workflow", "roles", "metadata"];
 		const i = order.indexOf(activeTab);
 		if (e.key === "ArrowRight") { e.preventDefault(); onTabChange(order[(i + 1) % order.length]); }
 		else if (e.key === "ArrowLeft") { e.preventDefault(); onTabChange(order[(i - 1 + order.length) % order.length]); }
@@ -1238,6 +1238,17 @@ function renderGoalForm(config: GoalFormConfig) {
 				@click=${() => onTabChange("roles")}
 				@keydown=${onTabKey}
 			>Roles</button>
+			<button
+				role="tab"
+				id="goal-proposal-tab-metadata"
+				data-testid="goal-proposal-tab-metadata"
+				aria-selected=${activeTab === "metadata" ? "true" : "false"}
+				aria-controls="goal-proposal-panel-metadata"
+				tabindex=${activeTab === "metadata" ? 0 : -1}
+				class=${tabCls(activeTab === "metadata")}
+				@click=${() => onTabChange("metadata")}
+				@keydown=${onTabKey}
+			>Metadata</button>
 			${subgoalsTab ? html`<button
 				role="tab"
 				id="goal-proposal-tab-subgoals"
@@ -1256,9 +1267,11 @@ function renderGoalForm(config: GoalFormConfig) {
 		? goalBody
 		: activeTab === "workflow"
 			? renderProposalWorkflowTab(config)
-			: activeTab === "subgoals"
-				? renderProposalSubgoalsTab(config)
-				: renderProposalRolesTab(config);
+			: activeTab === "roles"
+				? renderProposalRolesTab(config)
+				: activeTab === "metadata"
+					? renderProposalMetadataTab(config)
+					: renderProposalSubgoalsTab(config);
 	return html`${tabBar}${panel}${footer}`;
 }
 
@@ -1416,6 +1429,24 @@ function renderProposalRolesTab(config: GoalFormConfig): TemplateResult {
 						}))
 					: html`<p class="text-xs text-muted-foreground">Select a role from the list to inspect or customise it.</p>`}
 			</div>
+		</div>
+	`;
+}
+
+// ============================================================================
+// PROPOSAL MODAL — METADATA TAB
+//
+// Reuses the goal metadata editor so tabbed proposals share the same draft rows
+// and submit semantics as the non-tabbed Goal form.
+// ============================================================================
+function renderProposalMetadataTab(config: GoalFormConfig): TemplateResult {
+	return html`
+		<div class="flex-1 overflow-y-auto px-5 pt-3 md:pt-4 pb-3 flex flex-col gap-2.5"
+			role="tabpanel"
+			id="goal-proposal-panel-metadata"
+			aria-labelledby="goal-proposal-tab-metadata"
+			data-testid="goal-proposal-panel-metadata">
+			${renderGoalMetadataEditor(config)}
 		</div>
 	`;
 }
@@ -2789,7 +2820,7 @@ let _proposalMaxConcurrentChildren: number | null = null;
 // the main Workflows/Roles page renderers. Pinned by
 // tests/source-pin-merge-invariants.test.ts.
 // ----------------------------------------------------------------------------
-type ProposalTab = "goal" | "workflow" | "roles" | "subgoals";
+type ProposalTab = "goal" | "workflow" | "roles" | "metadata" | "subgoals";
 let _proposalActiveTab: ProposalTab = "goal";
 let _proposalInlineWorkflow: Workflow | null = null;
 let _proposalInlineRoles: Record<string, RoleData> = {};

--- a/tests/e2e/ui/goal-metadata.spec.ts
+++ b/tests/e2e/ui/goal-metadata.spec.ts
@@ -2,15 +2,17 @@
  * Goal-creation dialog — per-goal metadata key/value editor (browser E2E).
  *
  * Supersedes the removed per-goal worktree-setup controls (PR #816). Verifies:
- *  - the goal form exposes a simple key/value metadata editor
- *    (data-testid goal-form-metadata + goal-metadata-{add,row,key,value});
+ *  - the tabbed goal proposal panel exposes the key/value metadata editor on
+ *    the dedicated Metadata tab (data-testid goal-proposal-tab-metadata /
+ *    goal-proposal-panel-metadata plus goal-form-metadata and
+ *    goal-metadata-{add,row,key,value});
  *  - manually-entered rows are forwarded to goal creation, JSON-parsed where
  *    possible, persist on the server-side goal, and survive a page reload;
  *  - an empty editor sends NO `metadata` override (backward-compatible goal);
  *  - the legacy per-goal worktree-setup controls are GONE;
  *  - a propose_goal-seeded proposal (mock trigger GOAL_PROPOSAL_METADATA)
- *    mirrors its `metadata` into the editor and preserves it through
- *    acceptance + reload.
+ *    mirrors its `metadata` into the Metadata tab editor, retains edits across
+ *    tab switches, and preserves the final rows through acceptance + reload.
  *
  * Mirrors tests/e2e/ui/goal-creation.spec.ts (assistant proposal flow + mock
  * agent). Persistence is asserted against the server-side goal via the API,
@@ -18,8 +20,12 @@
  */
 import { test, expect } from "../gateway-harness.js";
 import { apiFetch } from "../e2e-setup.js";
-import { openApp, sendMessage } from "./ui-helpers.js";
+import { openApp, sendMessage, createSessionViaUI } from "./ui-helpers.js";
 
+const GOAL_TAB_TESTID = "[data-testid='goal-proposal-tab-goal']";
+const GOAL_PANEL_TESTID = "[data-testid='goal-proposal-panel-goal']";
+const METADATA_TAB_TESTID = "[data-testid='goal-proposal-tab-metadata']";
+const METADATA_PANEL_TESTID = "[data-testid='goal-proposal-panel-metadata']";
 const METADATA_TESTID = "[data-testid='goal-form-metadata']";
 const ADD_TESTID = "[data-testid='goal-metadata-add']";
 const ROW_TESTID = "[data-testid='goal-metadata-row']";
@@ -58,6 +64,16 @@ async function openGoalAssistant(page: import("@playwright/test").Page, trigger:
 	await expect(titleInput).toHaveValue("E2E Test Goal", { timeout: 15_000 });
 }
 
+async function openRegularSessionProposal(page: import("@playwright/test").Page, trigger: string) {
+	test.setTimeout(90_000);
+	await openApp(page);
+	await createSessionViaUI(page);
+	await sendMessage(page, trigger);
+	const titleInput = page.locator("input[placeholder='Goal title']").first();
+	await expect(titleInput).toBeVisible({ timeout: 20_000 });
+	await expect(titleInput).toHaveValue("E2E Test Goal", { timeout: 15_000 });
+}
+
 /** Re-fetch a goal by id (the durable server record). Returns undefined if
  *  the goal no longer exists. Using the id (not the shared "E2E Test Goal"
  *  title) keeps the assertions collision-free under parallel workers. */
@@ -91,6 +107,40 @@ async function clickCreate(page: import("@playwright/test").Page): Promise<strin
 	return goal.id as string;
 }
 
+async function openMetadataTab(page: import("@playwright/test").Page) {
+	const tab = page.locator(METADATA_TAB_TESTID);
+	await expect(tab).toBeVisible({ timeout: 10_000 });
+	await expect(tab).toHaveAttribute("id", "goal-proposal-tab-metadata");
+	await expect(tab).toHaveAttribute("aria-controls", "goal-proposal-panel-metadata");
+	await tab.click();
+	await expect(tab).toHaveAttribute("aria-selected", "true", { timeout: 5_000 });
+	await expect(page.locator(METADATA_PANEL_TESTID)).toBeVisible({ timeout: 10_000 });
+	await expect(page.locator(METADATA_PANEL_TESTID)).toHaveAttribute("id", "goal-proposal-panel-metadata");
+	await expect(page.locator(METADATA_PANEL_TESTID)).toHaveAttribute("aria-labelledby", "goal-proposal-tab-metadata");
+	await expect(page.locator(METADATA_TESTID).first()).toBeVisible({ timeout: 5_000 });
+}
+
+async function readMetadataRows(page: import("@playwright/test").Page): Promise<Record<string, string>> {
+	const keyInputs = page.locator(KEY_TESTID);
+	const valueInputs = page.locator(VALUE_TESTID);
+	const rowCount = await keyInputs.count();
+	const rows: Record<string, string> = {};
+	for (let i = 0; i < rowCount; i++) {
+		const key = await keyInputs.nth(i).inputValue();
+		rows[key] = await valueInputs.nth(i).inputValue();
+	}
+	return rows;
+}
+
+async function metadataRowIndex(page: import("@playwright/test").Page, key: string): Promise<number> {
+	const keyInputs = page.locator(KEY_TESTID);
+	const rowCount = await keyInputs.count();
+	for (let i = 0; i < rowCount; i++) {
+		if ((await keyInputs.nth(i).inputValue()) === key) return i;
+	}
+	return -1;
+}
+
 /**
  * Append a metadata key/value pair via the editor. Adds a fresh row, then fills
  * the just-created (last) row's key + value inputs. Re-reads the row count
@@ -109,11 +159,12 @@ async function addMetadataRow(page: import("@playwright/test").Page, key: string
 	await expect(valueInput).toHaveValue(value);
 }
 
-test.describe("Goal creation dialog — per-goal metadata editor", () => {
+test.describe("Goal proposal — Metadata tab", () => {
 	test("legacy worktree-setup controls are gone; metadata editor is present and empty by default", async ({ page }) => {
 		await openGoalAssistant(page, "Please create a GOAL_PROPOSAL for testing");
 
-		// The metadata editor is exposed and starts empty.
+		// Non-tabbed New Goal assistant behavior is preserved: the metadata editor
+		// remains in the main form and starts empty.
 		const editor = page.locator(METADATA_TESTID).first();
 		await expect(editor).toBeVisible({ timeout: 5_000 });
 		await expect(page.locator(ROW_TESTID)).toHaveCount(0);
@@ -217,41 +268,60 @@ test.describe("Goal creation dialog — per-goal metadata editor", () => {
 		}
 	});
 
-	test("a propose_goal-seeded proposal mirrors metadata into the editor and preserves it through acceptance", async ({ page }) => {
-		await openGoalAssistant(page, "Please GOAL_PROPOSAL_METADATA now");
+	test("metadata-seeded proposal supports edit/add/remove, retains rows across tab switches, and persists", async ({ page }) => {
+		await openRegularSessionProposal(page, "Please GOAL_PROPOSAL_METADATA now");
 
-		// The agent-seeded metadata must be mirrored into the editor rows (not
-		// just title/spec/cwd/workflow). The mock seeds two keys.
-		await expect(page.locator(METADATA_TESTID).first()).toBeVisible({ timeout: 10_000 });
+		// The tabbed proposal panel keeps metadata out of the Goal tab.
+		await expect(page.locator(GOAL_PANEL_TESTID)).toBeVisible({ timeout: 5_000 });
+		await expect(page.locator(`${GOAL_PANEL_TESTID} ${METADATA_TESTID}`)).toHaveCount(0);
+		await openMetadataTab(page);
+
+		// The agent-seeded metadata must be mirrored into the Metadata tab rows.
 		await expect(page.locator(ROW_TESTID)).toHaveCount(2, { timeout: 10_000 });
+		let rows = await readMetadataRows(page);
+		expect(rows["hindsight.memory.enabled"]).toBe("false");
+		expect(rows["bobbit.disabledTools"]).toBe('["browser_navigate"]');
 
-		// Collect the rendered key/value pairs (order is insertion order).
-		const keyInputs = page.locator(KEY_TESTID);
-		const valueInputs = page.locator(VALUE_TESTID);
-		const rowCount = await keyInputs.count();
-		const seeded: Record<string, string> = {};
-		for (let i = 0; i < rowCount; i++) {
-			const k = await keyInputs.nth(i).inputValue();
-			seeded[k] = await valueInputs.nth(i).inputValue();
-		}
-		expect(seeded["hindsight.memory.enabled"]).toBe("false");
-		expect(seeded["bobbit.disabledTools"]).toBe('["browser_navigate"]');
+		// Edit one seeded row, add one new row, and remove the other seeded row.
+		const memoryIndex = await metadataRowIndex(page, "hindsight.memory.enabled");
+		expect(memoryIndex).toBeGreaterThanOrEqual(0);
+		await page.locator(VALUE_TESTID).nth(memoryIndex).fill("true");
+		await expect(page.locator(VALUE_TESTID).nth(memoryIndex)).toHaveValue("true");
 
-		// Accept the proposal as-is — the seeded metadata must reach creation.
+		await addMetadataRow(page, "experiment.flavor", "treatment");
+
+		const disabledToolsIndex = await metadataRowIndex(page, "bobbit.disabledTools");
+		expect(disabledToolsIndex).toBeGreaterThanOrEqual(0);
+		await page.locator(REMOVE_TESTID).nth(disabledToolsIndex).click();
+		await expect(page.locator(ROW_TESTID)).toHaveCount(2, { timeout: 5_000 });
+
+		// Switch away and back: metadata rows are draft state, not panel-local DOM state.
+		await page.locator(GOAL_TAB_TESTID).click();
+		await expect(page.locator(GOAL_PANEL_TESTID)).toBeVisible({ timeout: 5_000 });
+		await expect(page.locator(`${GOAL_PANEL_TESTID} ${METADATA_TESTID}`)).toHaveCount(0);
+		await openMetadataTab(page);
+
+		rows = await readMetadataRows(page);
+		expect(rows["hindsight.memory.enabled"]).toBe("true");
+		expect(rows["experiment.flavor"]).toBe("treatment");
+		expect(rows["bobbit.disabledTools"]).toBeUndefined();
+
 		const goalId = await clickCreate(page);
 
 		const created = await findGoalById(goalId);
 		expect(created).toBeTruthy();
 		try {
 			expect(created.metadata).toBeTruthy();
-			expect(created.metadata["hindsight.memory.enabled"]).toBe(false);
-			expect(created.metadata["bobbit.disabledTools"]).toEqual(["browser_navigate"]);
+			expect(created.metadata["hindsight.memory.enabled"]).toBe(true);
+			expect(created.metadata["experiment.flavor"]).toBe("treatment");
+			expect(created.metadata["bobbit.disabledTools"]).toBeUndefined();
 
 			await page.reload();
 			const reloaded = await findGoalById(goalId);
 			expect(reloaded).toBeTruthy();
-			expect(reloaded.metadata["hindsight.memory.enabled"]).toBe(false);
-			expect(reloaded.metadata["bobbit.disabledTools"]).toEqual(["browser_navigate"]);
+			expect(reloaded.metadata["hindsight.memory.enabled"]).toBe(true);
+			expect(reloaded.metadata["experiment.flavor"]).toBe("treatment");
+			expect(reloaded.metadata["bobbit.disabledTools"]).toBeUndefined();
 		} finally {
 			await deleteGoal(goalId);
 		}

--- a/tests/source-pin-merge-invariants.test.ts
+++ b/tests/source-pin-merge-invariants.test.ts
@@ -26,6 +26,15 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.join(__dirname, "..");
 const read = (p: string) => fs.readFileSync(path.join(REPO_ROOT, p), "utf-8");
 
+function assertTextInOrder(text: string, needles: string[], message: string): void {
+	let from = 0;
+	for (const needle of needles) {
+		const idx = text.indexOf(needle, from);
+		assert.notEqual(idx, -1, `${message}\nMissing or out-of-order substring: ${needle}`);
+		from = idx + needle.length;
+	}
+}
+
 describe("Source pin — merge-loss invariants", () => {
 	it("server.ts dispatches tryHandleNestedGoalRoute (restored by ea921d7b)", () => {
 		const text = read("src/server/server.ts");
@@ -183,6 +192,59 @@ describe("Source pin — merge-loss invariants", () => {
 			"proposal-modal-tabs fix restores it as a tab alongside Goal and\n" +
 			"Workflow. DO NOT delete this pin — restore the dropped tab button\n" +
 			"instead.",
+		);
+	});
+
+	it("proposal-panels.ts renders the proposal-modal Metadata tab stable IDs (metadata-tab fix)", () => {
+		const text = read("src/app/proposal-panels.ts");
+		for (const required of [
+			'id="goal-proposal-tab-metadata"',
+			'data-testid="goal-proposal-tab-metadata"',
+			'aria-controls="goal-proposal-panel-metadata"',
+			'id="goal-proposal-panel-metadata"',
+			'data-testid="goal-proposal-panel-metadata"',
+			'aria-labelledby="goal-proposal-tab-metadata"',
+		]) {
+			assert.ok(
+				text.includes(required),
+				"src/app/proposal-panels.ts must render the proposal modal's Metadata\n" +
+				"tab and panel with stable IDs/test IDs: " + required + "\n" +
+				"The Metadata tab owns the per-goal metadata key/value editor;\n" +
+				"without these stable selectors accessibility wiring, keyboard focus,\n" +
+				"and browser E2E coverage silently regress. DO NOT delete this pin —\n" +
+				"restore the dropped Metadata tab/panel wiring instead.",
+			);
+		}
+	});
+
+	it("proposal-panels.ts orders proposal tabs Goal, Workflow, Roles, Metadata, Sub-goals (metadata-tab fix)", () => {
+		const text = read("src/app/proposal-panels.ts");
+		assertTextInOrder(
+			text,
+			[
+				'id="goal-proposal-tab-goal"',
+				'id="goal-proposal-tab-workflow"',
+				'id="goal-proposal-tab-roles"',
+				'id="goal-proposal-tab-metadata"',
+				'id="goal-proposal-tab-subgoals"',
+			],
+			"src/app/proposal-panels.ts must render proposal tabs in the order\n" +
+			"Goal → Workflow → Roles → Metadata → Sub-goals. The Metadata tab\n" +
+			"must sit immediately after Roles and before Sub-goals when the\n" +
+			"Sub-goals tab is visible.",
+		);
+
+		const keydownBlock = text.match(/const onTabKey = \(e: KeyboardEvent\) => \{[\s\S]*?\n\t\};/)?.[0] ?? "";
+		assertTextInOrder(
+			keydownBlock,
+			['"goal"', '"workflow"', '"roles"', '"metadata"'],
+			"src/app/proposal-panels.ts::onTabKey must include Metadata in\n" +
+			"ArrowLeft/ArrowRight/Home/End keyboard navigation after Roles.",
+		);
+		assert.ok(
+			keydownBlock.includes('"subgoals"'),
+			"src/app/proposal-panels.ts::onTabKey must continue to include\n" +
+			"Sub-goals after Metadata when that tab is visible.",
 		);
 	});
 


### PR DESCRIPTION
## Summary
- Move goal proposal metadata editing into a dedicated Metadata tab in the tabbed proposal panel.
- Preserve existing metadata row conversion/submission semantics and non-tabbed new-goal behavior.
- Add source pins, browser E2E coverage, and update goal metadata design docs.

## Validation
- npm run check
- npx tsx --test tests/source-pin-merge-invariants.test.ts
- npm run build
- npm run test:e2e:run -- tests/e2e/ui/goal-metadata.spec.ts

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)