### PR TITLE
Unify goal proposal tabs

### DIFF
--- a/docs/goals-workflows-tasks.md
+++ b/docs/goals-workflows-tasks.md
@@ -57,6 +57,29 @@ The per-project workflow availability is cached client-side (`_workflowCacheByPr
 
 To author workflows for a project, see [defaults/workflow-authoring-guide.md](../defaults/workflow-authoring-guide.md) and run the project assistant from Settings → Components.
 
+#### Unified goal proposal tabs
+
+Every goal proposal surface uses the same tabbed form rendered by `renderGoalForm()` in `src/app/proposal-panels.ts`. This includes assistant proposal panels, the `+ New Goal` flow, historical proposal revision views, and project-scoped goal creation. The unified form keeps proposal editing predictable: fields no longer move between surfaces, and accept/dismiss/create footer actions stay available regardless of the selected tab.
+
+Guaranteed tab layout:
+
+- **Goal** is the default active tab.
+- **Goal**, **Workflow**, **Roles**, and **Metadata** are always visible for goal proposals.
+- **Sub-goals** appears only when the Settings sub-goals flag is enabled.
+- The footer is outside the tab panels, so submit/dismiss/create behavior is preserved across tabs.
+
+Tab ownership is strict:
+
+- The **Goal** tab owns title, project/directory, workflow picker shortcut, sandbox/team toggles, optional workflow-step toggles, and the spec editor/preview.
+- The **Workflow** tab owns workflow inspection and per-goal workflow customization. When no workflows are available, it renders a read-only empty state instead of disappearing.
+- The **Roles** tab owns role inspection and per-goal role customization. While roles are loading or unavailable, it renders loading/empty states instead of hiding the tab.
+- The **Metadata** tab is the only place the key/value metadata editor renders. The main Goal tab must never contain `renderGoalMetadataEditor()`.
+- The **Sub-goals** tab owns parent/child goal controls and is gated only by the system sub-goals setting.
+
+Metadata draft state is shared across tabs rather than stored in panel-local DOM. Seeded `propose_goal` metadata hydrates the Metadata tab, user edits survive tab switches, blank-key rows are dropped on submit, values are JSON-parsed where possible, and accepted/created goals persist the resulting `metadata` field. An empty metadata editor sends no override, preserving legacy goal records.
+
+Browser coverage lives in [`tests/e2e/ui/goal-metadata.spec.ts`](../tests/e2e/ui/goal-metadata.spec.ts). It pins the default Goal tab, required tab visibility, Metadata-tab-only editor placement, Sub-goals flag behavior, metadata edit persistence, and accepted-goal metadata persistence.
+
 #### `createGoal` failure preserves the assistant
 
 The goal-assistant accept flow (both the goal-preview panel handler and the `propose_goal` proposal-toast handler in `src/app/render.ts`) awaits `POST /api/goals` **before** tearing down any state. Disconnecting the remote agent, clearing the active assistant view, deleting the persisted draft, removing `gateway.sessionId`, and navigating to the goal dashboard all happen only on success.

--- a/src/app/proposal-panels.ts
+++ b/src/app/proposal-panels.ts
@@ -546,11 +546,9 @@ interface GoalFormConfig {
 	/** Invoked when the user changes the concurrency cap. */
 	onMaxConcurrentChildrenChange?: (value: number) => void;
 
-	// ---- Proposal-modal tabs (Goal / Workflow / Roles) ----
-	/** When true, wrap the form body in a tabbed surface with Workflow + Roles
-	 *  tabs alongside Goal. The footer stays outside the panels so submit/dismiss
-	 *  remain visible on every tab. */
-	tabbed?: boolean;
+	// ---- Goal proposal tabs (Goal / Workflow / Roles / Metadata) ----
+	/** Active tab for the always-tabbed goal proposal form. The footer stays
+	 *  outside the panels so submit/dismiss remain visible on every tab. */
 	activeTab?: ProposalTab;
 	onTabChange?: (tab: ProposalTab) => void;
 
@@ -663,8 +661,7 @@ function proposalSubgoalSubmission(opts: {
 }
 
 // ── Shared sub-goal UI fragments ────────────────────────────────────────────
-// Rendered inline on the non-tabbed +New Goal preview, and collated into the
-// dedicated "Sub-goals" tab of the tabbed goal-proposal panel.
+// Collated into the dedicated "Sub-goals" tab when the Subgoals setting is on.
 
 /** Parent-goal picker row. */
 function renderParentPickerRow(config: GoalFormConfig, lblCls: string): TemplateResult {
@@ -959,15 +956,15 @@ function renderGoalForm(config: GoalFormConfig) {
 	// When viewing a historical Goal (vN) tab, show that revision's number
 	// in the panel header instead of the live slot's latest rev.
 	const goalRev = (_proposalOverride?.type === "goal" ? _proposalOverride.rev : state.activeProposals.goal?.rev) ?? 0;
-	const tabbed = !!config.tabbed;
-	const activeTab: ProposalTab = config.activeTab ?? "goal";
+	const subgoalsTab = showSubgoalsTab(config);
+	const requestedActiveTab: ProposalTab = config.activeTab ?? "goal";
+	const activeTab: ProposalTab = requestedActiveTab === "subgoals" && !subgoalsTab ? "goal" : requestedActiveTab;
 	const goalBody = html`
 		<div class="flex-1 overflow-y-auto px-5 pt-3 md:pt-4 pb-3 flex flex-col gap-2.5"
-			role=${tabbed ? "tabpanel" : nothing}
-			id=${tabbed ? "goal-proposal-panel-goal" : nothing}
-			aria-labelledby=${tabbed ? "goal-proposal-tab-goal" : nothing}
-			data-testid=${tabbed ? "goal-proposal-panel-goal" : nothing}>
-			${!tabbed && goalRev > 0 ? html`<div class="text-xs text-muted-foreground -mb-1" data-testid="proposal-panel-rev">rev ${goalRev}</div>` : ""}
+			role="tabpanel"
+			id="goal-proposal-panel-goal"
+			aria-labelledby="goal-proposal-tab-goal"
+			data-testid="goal-proposal-panel-goal">
 			${noWorkflows ? html`
 				<div
 					class="rounded-md border p-3 flex flex-col gap-2"
@@ -1016,8 +1013,6 @@ function renderGoalForm(config: GoalFormConfig) {
 					</div>
 				` : ""}
 			</div>
-			${!tabbed && config.subgoalsEnabled ? renderParentPickerRow(config, lblCls) : ""}
-			${!tabbed ? renderSubgoalBreadcrumb(config) : ""}
 			${linkedProject ? html`
 				<div class="flex items-center gap-2 text-[11px] text-muted-foreground min-w-0">
 					<span class="${lblCls} w-20 md:w-16">Worktree</span>
@@ -1096,9 +1091,7 @@ function renderGoalForm(config: GoalFormConfig) {
 						` : ''}
 					</label>
 				`;})}
-				${!tabbed ? renderSubgoalsToggle(config) : ""}
 			</div>
-			${!tabbed ? renderGoalMetadataEditor(config) : ""}
 			<div class="flex-1 flex flex-col min-h-0">
 				<div class="flex items-center justify-between mb-1.5">
 					<div class="flex items-center gap-1">
@@ -1185,10 +1178,6 @@ function renderGoalForm(config: GoalFormConfig) {
 			</div>
 		</div>
 	`;
-	if (!tabbed) {
-		return html`${goalBody}${footer}`;
-	}
-	const subgoalsTab = showSubgoalsTab(config);
 	const onTabChange = (t: ProposalTab) => config.onTabChange?.(t);
 	const onTabKey = (e: KeyboardEvent) => {
 		const order: ProposalTab[] = subgoalsTab ? ["goal", "workflow", "roles", "metadata", "subgoals"] : ["goal", "workflow", "roles", "metadata"];
@@ -1276,7 +1265,7 @@ function renderGoalForm(config: GoalFormConfig) {
 }
 
 // ============================================================================
-// PROPOSAL MODAL — WORKFLOW TAB
+// GOAL PROPOSAL — WORKFLOW TAB
 //
 // A workflow <select> (synced to the Goal tab's picker via the shared
 // config.workflowId / config.onWorkflowChange) with a Customise/Revert toggle
@@ -1344,7 +1333,7 @@ function renderProposalWorkflowTab(config: GoalFormConfig): TemplateResult {
 }
 
 // ============================================================================
-// PROPOSAL MODAL — ROLES TAB
+// GOAL PROPOSAL — ROLES TAB
 //
 // Reuses renderRoleList / renderRoleInspector / renderRoleEditor exported
 // from src/app/role-manager-page.ts. Customisations are kept in a
@@ -1434,10 +1423,10 @@ function renderProposalRolesTab(config: GoalFormConfig): TemplateResult {
 }
 
 // ============================================================================
-// PROPOSAL MODAL — METADATA TAB
+// GOAL PROPOSAL — METADATA TAB
 //
-// Reuses the goal metadata editor so tabbed proposals share the same draft rows
-// and submit semantics as the non-tabbed Goal form.
+// Reuses the goal metadata editor so every goal proposal surface shares the
+// same draft rows and submit semantics.
 // ============================================================================
 function renderProposalMetadataTab(config: GoalFormConfig): TemplateResult {
 	return html`
@@ -1452,7 +1441,7 @@ function renderProposalMetadataTab(config: GoalFormConfig): TemplateResult {
 }
 
 // ============================================================================
-// PROPOSAL MODAL — SUB-GOALS TAB
+// GOAL PROPOSAL — SUB-GOALS TAB
 //
 // Collates the per-goal nesting controls: parent picker, breadcrumb, and the
 // allow-subgoals toggle + max-depth control.
@@ -1605,6 +1594,7 @@ function goalPreviewPanel() {
 		_assistantEnabledOptionalSteps = [];
 		state.previewMetadataRows = [];
 		state.previewMetadataEdited = false;
+		resetProposalTabsState();
 		if (sessionId) {
 			deleteGoalDraft(sessionId);
 		}
@@ -1719,6 +1709,8 @@ function goalPreviewPanel() {
 				onCreate: handleCreateGoal,
 				streaming: isProposalStreaming("goal_proposal"),
 				commentable: true,
+				activeTab: _proposalActiveTab,
+				onTabChange: (tab) => { _proposalActiveTab = tab; renderApp(); },
 			})}
 		</div>
 	`;
@@ -2807,7 +2799,7 @@ let _proposalDivergencePolicy: "strict" | "balanced" | "autonomous" | null = nul
 let _proposalMaxConcurrentChildren: number | null = null;
 
 // ----------------------------------------------------------------------------
-// Proposal-modal tabs state (Goal / Workflow / Roles).
+// Goal proposal tab state (Goal / Workflow / Roles / Metadata / Sub-goals).
 //
 // `_proposalInlineWorkflow` is the draft-scoped customised workflow — when
 // non-null, the submit path forwards it as `workflow` instead of
@@ -3321,8 +3313,7 @@ function goalProposalPanel() {
 		onDivergencePolicyChange: (value) => { _proposalDivergencePolicy = value; renderApp(); },
 		onMaxConcurrentChildrenChange: (value) => { _proposalMaxConcurrentChildren = value; renderApp(); },
 
-		// ---- Proposal-modal tabs wiring ----
-		tabbed: true,
+		// ---- Goal proposal tabs wiring ----
 		activeTab: _proposalActiveTab,
 		onTabChange: (tab) => { _proposalActiveTab = tab; renderApp(); },
 

--- a/src/app/proposal-panels.ts
+++ b/src/app/proposal-panels.ts
@@ -1518,6 +1518,8 @@ function goalPreviewPanel() {
 	}
 	ensureWorkflowsLoaded(state.previewProjectId || undefined);
 	ensureSandboxStatusLoaded();
+	const subgoalsEnabled = isSubgoalsEnabled();
+	const maxNestingDepth = getSystemMaxNestingDepth();
 
 	const handleCreateGoal = async () => {
 		const trimmedTitle = state.previewTitle.trim();
@@ -1547,6 +1549,22 @@ function goalPreviewPanel() {
 		const enabledOptionalSteps = _assistantEnabledOptionalSteps.length > 0 ? _assistantEnabledOptionalSteps : undefined;
 		const currentSession = state.gatewaySessions.find(s => s.id === sessionId);
 		const reattemptGoalId = currentSession?.reattemptGoalId;
+		const parentGoalIdField = subgoalsEnabled ? (_proposalParentGoalId || undefined) : undefined;
+		const subgoalSubmission = proposalSubgoalSubmission({
+			subgoalsEnabled,
+			parentGoalId: parentGoalIdField,
+			systemCap: maxNestingDepth,
+			allowedValue: _proposalSubgoalsAllowed,
+			configuredValue: _proposalMaxNestingDepth,
+		});
+		const isRootProposal = !parentGoalIdField;
+		const allowsChildren = subgoalSubmission.allowsChildren;
+		const divergencePolicyField = isRootProposal && allowsChildren && _proposalDivergencePolicy !== null
+			? _proposalDivergencePolicy
+			: undefined;
+		const maxConcurrentChildrenField = isRootProposal && allowsChildren && _proposalMaxConcurrentChildren !== null
+			? _proposalMaxConcurrentChildren
+			: undefined;
 
 		// Await the server FIRST. If it rejects, leave the assistant session,
 		// draft, gateway.sessionId, and form state intact so the user can edit
@@ -1561,6 +1579,11 @@ function goalPreviewPanel() {
 				projectId,
 				enabledOptionalSteps,
 				autoStartTeam,
+				parentGoalId: parentGoalIdField,
+				subgoalsAllowed: subgoalSubmission.subgoalsAllowed,
+				maxNestingDepth: subgoalSubmission.maxNestingDepth,
+				divergencePolicy: divergencePolicyField,
+				maxConcurrentChildren: maxConcurrentChildrenField,
 				metadata: metadataRowsToObject(state.previewMetadataRows),
 			});
 		} catch (err) {
@@ -1592,6 +1615,11 @@ function goalPreviewPanel() {
 		_goalSandboxed = false;
 		_goalAutoStartTeam = true;
 		_assistantEnabledOptionalSteps = [];
+		_proposalParentGoalId = "";
+		_proposalSubgoalsAllowed = null;
+		_proposalMaxNestingDepth = null;
+		_proposalDivergencePolicy = null;
+		_proposalMaxConcurrentChildren = null;
 		state.previewMetadataRows = [];
 		state.previewMetadataEdited = false;
 		resetProposalTabsState();
@@ -1709,6 +1737,30 @@ function goalPreviewPanel() {
 				onCreate: handleCreateGoal,
 				streaming: isProposalStreaming("goal_proposal"),
 				commentable: true,
+				createDisabled: (() => {
+					if (subgoalsEnabled && _proposalParentGoalId && maxNestingDepth !== undefined) {
+						const pDepth = nestingDepthOf(_proposalParentGoalId, state.goals);
+						if (pDepth + 1 > maxNestingDepth) return true;
+					}
+					return false;
+				})(),
+				parentGoalId: _proposalParentGoalId || undefined,
+				onParentGoalChange: (id) => {
+					_proposalParentGoalId = id || "";
+					const sid = activeSessionId();
+					if (sid) saveGoalDraft(sid);
+					renderApp();
+				},
+				subgoalsEnabled,
+				maxNestingDepth,
+				subgoalsAllowedValue: _proposalSubgoalsAllowed,
+				maxNestingDepthValue: _proposalMaxNestingDepth,
+				onSubgoalsAllowedChange: (value: boolean) => { _proposalSubgoalsAllowed = value; renderApp(); },
+				onMaxNestingDepthChange: (value: number | null) => { _proposalMaxNestingDepth = value; renderApp(); },
+				divergencePolicyValue: _proposalDivergencePolicy,
+				maxConcurrentChildrenValue: _proposalMaxConcurrentChildren,
+				onDivergencePolicyChange: (value) => { _proposalDivergencePolicy = value; renderApp(); },
+				onMaxConcurrentChildrenChange: (value) => { _proposalMaxConcurrentChildren = value; renderApp(); },
 				activeTab: _proposalActiveTab,
 				onTabChange: (tab) => { _proposalActiveTab = tab; renderApp(); },
 			})}

--- a/tests/e2e/ui/goal-metadata.spec.ts
+++ b/tests/e2e/ui/goal-metadata.spec.ts
@@ -24,6 +24,8 @@ import { openApp, sendMessage, createSessionViaUI } from "./ui-helpers.js";
 
 const GOAL_TAB_TESTID = "[data-testid='goal-proposal-tab-goal']";
 const GOAL_PANEL_TESTID = "[data-testid='goal-proposal-panel-goal']";
+const WORKFLOW_TAB_TESTID = "[data-testid='goal-proposal-tab-workflow']";
+const ROLES_TAB_TESTID = "[data-testid='goal-proposal-tab-roles']";
 const METADATA_TAB_TESTID = "[data-testid='goal-proposal-tab-metadata']";
 const METADATA_PANEL_TESTID = "[data-testid='goal-proposal-panel-metadata']";
 const METADATA_TESTID = "[data-testid='goal-form-metadata']";
@@ -160,6 +162,23 @@ async function addMetadataRow(page: import("@playwright/test").Page, key: string
 }
 
 test.describe("Goal proposal — Metadata tab", () => {
+	test("New Goal assistant proposal renders unified tabs and keeps metadata out of Goal tab", async ({ page }) => {
+		await openGoalAssistant(page, "Please create a GOAL_PROPOSAL for testing");
+
+		const goalTab = page.locator(GOAL_TAB_TESTID);
+		await expect(goalTab).toBeVisible({ timeout: 5_000 });
+		await expect(goalTab).toHaveAttribute("aria-selected", "true");
+		await expect(page.locator(WORKFLOW_TAB_TESTID)).toBeVisible();
+		await expect(page.locator(ROLES_TAB_TESTID)).toBeVisible();
+		await expect(page.locator(METADATA_TAB_TESTID)).toBeVisible();
+
+		await expect(page.locator(GOAL_PANEL_TESTID)).toBeVisible();
+		await expect(page.locator(`${GOAL_PANEL_TESTID} ${METADATA_TESTID}`)).toHaveCount(0);
+
+		await openMetadataTab(page);
+		await expect(page.locator(`${METADATA_PANEL_TESTID} ${METADATA_TESTID}`).first()).toBeVisible();
+	});
+
 	test("legacy worktree-setup controls are gone; metadata editor is present and empty by default", async ({ page }) => {
 		await openGoalAssistant(page, "Please create a GOAL_PROPOSAL for testing");
 

--- a/tests/e2e/ui/goal-metadata.spec.ts
+++ b/tests/e2e/ui/goal-metadata.spec.ts
@@ -2,8 +2,10 @@
  * Goal-creation dialog — per-goal metadata key/value editor (browser E2E).
  *
  * Supersedes the removed per-goal worktree-setup controls (PR #816). Verifies:
- *  - the tabbed goal proposal panel exposes the key/value metadata editor on
- *    the dedicated Metadata tab (data-testid goal-proposal-tab-metadata /
+ *  - every goal proposal surface uses the unified tabbed layout, with Goal as
+ *    the default tab and Workflow / Roles / Metadata always present;
+ *  - the key/value metadata editor is absent from the Goal tab and only visible
+ *    on the dedicated Metadata tab (data-testid goal-proposal-tab-metadata /
  *    goal-proposal-panel-metadata plus goal-form-metadata and
  *    goal-metadata-{add,row,key,value});
  *  - manually-entered rows are forwarded to goal creation, JSON-parsed where
@@ -12,22 +14,27 @@
  *  - the legacy per-goal worktree-setup controls are GONE;
  *  - a propose_goal-seeded proposal (mock trigger GOAL_PROPOSAL_METADATA)
  *    mirrors its `metadata` into the Metadata tab editor, retains edits across
- *    tab switches, and preserves the final rows through acceptance + reload.
+ *    tab switches, and preserves the final rows through acceptance + reload;
+ *  - the optional Sub-goals tab follows the Settings sub-goals flag.
  *
  * Mirrors tests/e2e/ui/goal-creation.spec.ts (assistant proposal flow + mock
  * agent). Persistence is asserted against the server-side goal via the API,
  * which is the durable record that survives a reload.
  */
 import { test, expect } from "../gateway-harness.js";
+import type { Page } from "@playwright/test";
 import { apiFetch } from "../e2e-setup.js";
 import { openApp, sendMessage, createSessionViaUI } from "./ui-helpers.js";
 
 const GOAL_TAB_TESTID = "[data-testid='goal-proposal-tab-goal']";
 const GOAL_PANEL_TESTID = "[data-testid='goal-proposal-panel-goal']";
 const WORKFLOW_TAB_TESTID = "[data-testid='goal-proposal-tab-workflow']";
+const WORKFLOW_PANEL_TESTID = "[data-testid='goal-proposal-panel-workflow']";
 const ROLES_TAB_TESTID = "[data-testid='goal-proposal-tab-roles']";
+const ROLES_PANEL_TESTID = "[data-testid='goal-proposal-panel-roles']";
 const METADATA_TAB_TESTID = "[data-testid='goal-proposal-tab-metadata']";
 const METADATA_PANEL_TESTID = "[data-testid='goal-proposal-panel-metadata']";
+const SUBGOALS_TAB_TESTID = "[data-testid='goal-proposal-tab-subgoals']";
 const METADATA_TESTID = "[data-testid='goal-form-metadata']";
 const ADD_TESTID = "[data-testid='goal-metadata-add']";
 const ROW_TESTID = "[data-testid='goal-metadata-row']";
@@ -40,12 +47,20 @@ const REMOVE_TESTID = "[data-testid='goal-metadata-remove']";
 const LEGACY_CMD_TESTID = "[data-testid='goal-form-worktree-setup-command']";
 const LEGACY_TIMEOUT_TESTID = "[data-testid='goal-form-worktree-setup-timeout-ms']";
 
+async function setSubgoalsEnabled(value: boolean): Promise<void> {
+	const resp = await apiFetch("/api/preferences", {
+		method: "PUT",
+		body: JSON.stringify({ subgoalsEnabled: value }),
+	});
+	expect(resp.status).toBe(200);
+}
+
 /**
  * Open the goal assistant, send `trigger`, and wait for the populated proposal
  * title input. Mirrors goal-creation.spec.ts's helper; `trigger` selects which
  * mock-agent propose_goal path fires.
  */
-async function openGoalAssistant(page: import("@playwright/test").Page, trigger: string) {
+async function openGoalAssistant(page: Page, trigger: string) {
 	test.setTimeout(90_000);
 	await openApp(page);
 	const newGoalBtn = page.locator("button[title='New goal (Alt+G)']").first();
@@ -66,7 +81,7 @@ async function openGoalAssistant(page: import("@playwright/test").Page, trigger:
 	await expect(titleInput).toHaveValue("E2E Test Goal", { timeout: 15_000 });
 }
 
-async function openRegularSessionProposal(page: import("@playwright/test").Page, trigger: string) {
+async function openRegularSessionProposal(page: Page, trigger: string) {
 	test.setTimeout(90_000);
 	await openApp(page);
 	await createSessionViaUI(page);
@@ -96,7 +111,7 @@ async function deleteGoal(goalId: string) {
  * from the create response — not matched by title — so parallel tests creating
  * goals with the same mock title never collide.
  */
-async function clickCreate(page: import("@playwright/test").Page): Promise<string> {
+async function clickCreate(page: Page): Promise<string> {
 	const createPromise = page.waitForResponse(
 		(resp) => resp.url().includes("/api/goals") && resp.request().method() === "POST" && resp.ok(),
 		{ timeout: 15_000 },
@@ -109,7 +124,45 @@ async function clickCreate(page: import("@playwright/test").Page): Promise<strin
 	return goal.id as string;
 }
 
-async function openMetadataTab(page: import("@playwright/test").Page) {
+async function assertUnifiedGoalTabs(page: Page, options: { subgoalsTab: boolean }) {
+	const goalTab = page.locator(GOAL_TAB_TESTID);
+	await expect(goalTab).toBeVisible({ timeout: 5_000 });
+	await expect(goalTab).toHaveAttribute("aria-selected", "true");
+	await expect(goalTab).toHaveAttribute("id", "goal-proposal-tab-goal");
+	await expect(goalTab).toHaveAttribute("aria-controls", "goal-proposal-panel-goal");
+	await expect(page.locator(GOAL_PANEL_TESTID)).toBeVisible({ timeout: 5_000 });
+	await expect(page.locator(`${GOAL_PANEL_TESTID} ${METADATA_TESTID}`)).toHaveCount(0);
+	await expect(page.locator(METADATA_TESTID).first()).toBeHidden();
+
+	await expect(page.locator(WORKFLOW_TAB_TESTID)).toBeVisible();
+	await expect(page.locator(ROLES_TAB_TESTID)).toBeVisible();
+	await expect(page.locator(METADATA_TAB_TESTID)).toBeVisible();
+	if (options.subgoalsTab) {
+		await expect(page.locator(SUBGOALS_TAB_TESTID)).toBeVisible();
+	} else {
+		await expect(page.locator(SUBGOALS_TAB_TESTID)).toHaveCount(0);
+	}
+
+	await page.locator(WORKFLOW_TAB_TESTID).click();
+	await expect(page.locator(WORKFLOW_TAB_TESTID)).toHaveAttribute("aria-selected", "true", { timeout: 5_000 });
+	await expect(page.locator(WORKFLOW_PANEL_TESTID)).toBeVisible({ timeout: 5_000 });
+	await expect(page.locator(METADATA_TESTID).first()).toBeHidden();
+
+	await page.locator(ROLES_TAB_TESTID).click();
+	await expect(page.locator(ROLES_TAB_TESTID)).toHaveAttribute("aria-selected", "true", { timeout: 5_000 });
+	await expect(page.locator(ROLES_PANEL_TESTID)).toBeVisible({ timeout: 5_000 });
+	await expect(page.locator(METADATA_TESTID).first()).toBeHidden();
+
+	await goalTab.click();
+	await expect(goalTab).toHaveAttribute("aria-selected", "true", { timeout: 5_000 });
+	await expect(page.locator(GOAL_PANEL_TESTID)).toBeVisible({ timeout: 5_000 });
+	await expect(page.locator(`${GOAL_PANEL_TESTID} ${METADATA_TESTID}`)).toHaveCount(0);
+	await expect(page.locator(METADATA_TESTID).first()).toBeHidden();
+}
+
+async function openMetadataTab(page: Page) {
+	await expect(page.locator(`${GOAL_PANEL_TESTID} ${METADATA_TESTID}`)).toHaveCount(0);
+	await expect(page.locator(METADATA_TESTID).first()).toBeHidden();
 	const tab = page.locator(METADATA_TAB_TESTID);
 	await expect(tab).toBeVisible({ timeout: 10_000 });
 	await expect(tab).toHaveAttribute("id", "goal-proposal-tab-metadata");
@@ -119,10 +172,10 @@ async function openMetadataTab(page: import("@playwright/test").Page) {
 	await expect(page.locator(METADATA_PANEL_TESTID)).toBeVisible({ timeout: 10_000 });
 	await expect(page.locator(METADATA_PANEL_TESTID)).toHaveAttribute("id", "goal-proposal-panel-metadata");
 	await expect(page.locator(METADATA_PANEL_TESTID)).toHaveAttribute("aria-labelledby", "goal-proposal-tab-metadata");
-	await expect(page.locator(METADATA_TESTID).first()).toBeVisible({ timeout: 5_000 });
+	await expect(page.locator(`${METADATA_PANEL_TESTID} ${METADATA_TESTID}`).first()).toBeVisible({ timeout: 5_000 });
 }
 
-async function readMetadataRows(page: import("@playwright/test").Page): Promise<Record<string, string>> {
+async function readMetadataRows(page: Page): Promise<Record<string, string>> {
 	const keyInputs = page.locator(KEY_TESTID);
 	const valueInputs = page.locator(VALUE_TESTID);
 	const rowCount = await keyInputs.count();
@@ -134,7 +187,7 @@ async function readMetadataRows(page: import("@playwright/test").Page): Promise<
 	return rows;
 }
 
-async function metadataRowIndex(page: import("@playwright/test").Page, key: string): Promise<number> {
+async function metadataRowIndex(page: Page, key: string): Promise<number> {
 	const keyInputs = page.locator(KEY_TESTID);
 	const rowCount = await keyInputs.count();
 	for (let i = 0; i < rowCount; i++) {
@@ -148,7 +201,8 @@ async function metadataRowIndex(page: import("@playwright/test").Page, key: stri
  * the just-created (last) row's key + value inputs. Re-reads the row count
  * before/after the add so we don't depend on a fixed starting position.
  */
-async function addMetadataRow(page: import("@playwright/test").Page, key: string, value: string) {
+async function addMetadataRow(page: Page, key: string, value: string) {
+	await expect(page.locator(METADATA_PANEL_TESTID)).toBeVisible({ timeout: 5_000 });
 	const before = await page.locator(ROW_TESTID).count();
 	await page.locator(ADD_TESTID).first().click();
 	await expect(page.locator(ROW_TESTID)).toHaveCount(before + 1, { timeout: 5_000 });
@@ -162,29 +216,33 @@ async function addMetadataRow(page: import("@playwright/test").Page, key: string
 }
 
 test.describe("Goal proposal — Metadata tab", () => {
+	test.afterEach(async () => { await setSubgoalsEnabled(true); });
+
 	test("New Goal assistant proposal renders unified tabs and keeps metadata out of Goal tab", async ({ page }) => {
+		await setSubgoalsEnabled(true);
 		await openGoalAssistant(page, "Please create a GOAL_PROPOSAL for testing");
 
-		const goalTab = page.locator(GOAL_TAB_TESTID);
-		await expect(goalTab).toBeVisible({ timeout: 5_000 });
-		await expect(goalTab).toHaveAttribute("aria-selected", "true");
-		await expect(page.locator(WORKFLOW_TAB_TESTID)).toBeVisible();
-		await expect(page.locator(ROLES_TAB_TESTID)).toBeVisible();
-		await expect(page.locator(METADATA_TAB_TESTID)).toBeVisible();
+		await assertUnifiedGoalTabs(page, { subgoalsTab: true });
+		await openMetadataTab(page);
+		await expect(page.locator(`${METADATA_PANEL_TESTID} ${METADATA_TESTID}`).first()).toBeVisible();
+	});
 
-		await expect(page.locator(GOAL_PANEL_TESTID)).toBeVisible();
-		await expect(page.locator(`${GOAL_PANEL_TESTID} ${METADATA_TESTID}`)).toHaveCount(0);
+	test("Sub-goals tab is hidden when the Settings sub-goals flag is off", async ({ page }) => {
+		await setSubgoalsEnabled(false);
+		await openGoalAssistant(page, "Please create a GOAL_PROPOSAL for testing");
 
+		await assertUnifiedGoalTabs(page, { subgoalsTab: false });
 		await openMetadataTab(page);
 		await expect(page.locator(`${METADATA_PANEL_TESTID} ${METADATA_TESTID}`).first()).toBeVisible();
 	});
 
 	test("legacy worktree-setup controls are gone; metadata editor is present and empty by default", async ({ page }) => {
+		await setSubgoalsEnabled(true);
 		await openGoalAssistant(page, "Please create a GOAL_PROPOSAL for testing");
+		await assertUnifiedGoalTabs(page, { subgoalsTab: true });
+		await openMetadataTab(page);
 
-		// Non-tabbed New Goal assistant behavior is preserved: the metadata editor
-		// remains in the main form and starts empty.
-		const editor = page.locator(METADATA_TESTID).first();
+		const editor = page.locator(`${METADATA_PANEL_TESTID} ${METADATA_TESTID}`).first();
 		await expect(editor).toBeVisible({ timeout: 5_000 });
 		await expect(page.locator(ROW_TESTID)).toHaveCount(0);
 		await expect(page.locator(ADD_TESTID).first()).toBeVisible();
@@ -195,10 +253,13 @@ test.describe("Goal proposal — Metadata tab", () => {
 	});
 
 	test("empty editor sends no metadata override", async ({ page }) => {
+		await setSubgoalsEnabled(true);
 		await openGoalAssistant(page, "Please create a GOAL_PROPOSAL for testing");
+		await assertUnifiedGoalTabs(page, { subgoalsTab: true });
+		await openMetadataTab(page);
 
 		// Leave the editor untouched (empty) — create a backward-compatible goal.
-		await expect(page.locator(METADATA_TESTID).first()).toBeVisible({ timeout: 5_000 });
+		await expect(page.locator(`${METADATA_PANEL_TESTID} ${METADATA_TESTID}`).first()).toBeVisible({ timeout: 5_000 });
 		await expect(page.locator(ROW_TESTID)).toHaveCount(0);
 
 		const goalId = await clickCreate(page);
@@ -214,7 +275,10 @@ test.describe("Goal proposal — Metadata tab", () => {
 	});
 
 	test("blank-key rows are dropped so they don't count as a metadata override", async ({ page }) => {
+		await setSubgoalsEnabled(true);
 		await openGoalAssistant(page, "Please create a GOAL_PROPOSAL for testing");
+		await assertUnifiedGoalTabs(page, { subgoalsTab: true });
+		await openMetadataTab(page);
 
 		// Add a row but only fill the value, leaving the key blank. The submit
 		// collapse drops blank-key rows, so the goal must carry NO metadata.
@@ -235,8 +299,10 @@ test.describe("Goal proposal — Metadata tab", () => {
 	});
 
 	test("manually-entered metadata is forwarded, JSON-parsed, and persists across reload", async ({ page }) => {
+		await setSubgoalsEnabled(true);
 		await openGoalAssistant(page, "Please create a GOAL_PROPOSAL for testing");
-		await expect(page.locator(METADATA_TESTID).first()).toBeVisible({ timeout: 5_000 });
+		await assertUnifiedGoalTabs(page, { subgoalsTab: true });
+		await openMetadataTab(page);
 
 		// A plain text value stays a string; a JSON value parses into an array.
 		await addMetadataRow(page, "experiment.flavor", "treatment");
@@ -263,8 +329,10 @@ test.describe("Goal proposal — Metadata tab", () => {
 	});
 
 	test("removing a metadata row drops that entry from the created goal", async ({ page }) => {
+		await setSubgoalsEnabled(true);
 		await openGoalAssistant(page, "Please create a GOAL_PROPOSAL for testing");
-		await expect(page.locator(METADATA_TESTID).first()).toBeVisible({ timeout: 5_000 });
+		await assertUnifiedGoalTabs(page, { subgoalsTab: true });
+		await openMetadataTab(page);
 
 		await addMetadataRow(page, "keep.me", "yes");
 		await addMetadataRow(page, "drop.me", "no");
@@ -288,11 +356,10 @@ test.describe("Goal proposal — Metadata tab", () => {
 	});
 
 	test("metadata-seeded proposal supports edit/add/remove, retains rows across tab switches, and persists", async ({ page }) => {
+		await setSubgoalsEnabled(true);
 		await openRegularSessionProposal(page, "Please GOAL_PROPOSAL_METADATA now");
 
-		// The tabbed proposal panel keeps metadata out of the Goal tab.
-		await expect(page.locator(GOAL_PANEL_TESTID)).toBeVisible({ timeout: 5_000 });
-		await expect(page.locator(`${GOAL_PANEL_TESTID} ${METADATA_TESTID}`)).toHaveCount(0);
+		await assertUnifiedGoalTabs(page, { subgoalsTab: true });
 		await openMetadataTab(page);
 
 		// The agent-seeded metadata must be mirrored into the Metadata tab rows.
@@ -318,6 +385,7 @@ test.describe("Goal proposal — Metadata tab", () => {
 		await page.locator(GOAL_TAB_TESTID).click();
 		await expect(page.locator(GOAL_PANEL_TESTID)).toBeVisible({ timeout: 5_000 });
 		await expect(page.locator(`${GOAL_PANEL_TESTID} ${METADATA_TESTID}`)).toHaveCount(0);
+		await expect(page.locator(METADATA_TESTID).first()).toBeHidden();
 		await openMetadataTab(page);
 
 		rows = await readMetadataRows(page);


### PR DESCRIPTION
## Summary
- Unified all goal proposal surfaces on the same tabbed layout.
- Removed the legacy non-tabbed goal form path so metadata renders only in the Metadata tab.
- Kept Goal as the default tab and always exposes Goal, Workflow, Roles, and Metadata tabs.
- Wired + New Goal sub-goals tab visibility to the Settings sub-goals flag.
- Updated E2E coverage and docs for the unified tab contract.

## Validation
- npm run test:unit
- npm run check && npm run build:ui && npm run test:e2e:run -- --project=browser tests/e2e/ui/goal-metadata.spec.ts
- Implementation and documentation workflow gates passed.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
