### PR TITLE
OAuth Expiry Modal

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -808,12 +808,25 @@ Provider-aware. Bobbit can hold OAuth credentials for several providers concurre
 **`GET /api/oauth/status?provider=<id>`** responses:
 
 - `200 { provider: "anthropic", authenticated: true, expires: 1775812345000 }` — credential present and not expired.
-- `200 { provider: "anthropic", authenticated: false }` — no stored credential, or the stored credential is expired.
+- `200 { provider: "anthropic", authenticated: false, expires: 1700000000000 }` — a stored credential exists, but its expiry timestamp is in the past.
+- `200 { provider: "anthropic", authenticated: false }` — no stored credential, or no confident expiry timestamp is available.
 - `400 { error: "<message>" }` — provider value rejected by `normalizeProvider`.
 
 The response intentionally does **not** echo the bearer token / API key — strict-OAuth contract.
 
 The `email?` field appears only for providers that capture non-secret account display metadata (currently `google-gemini-cli`); it is never a token.
+
+#### Client expiry reminders
+
+After remote gateway authentication succeeds, the web client checks the Account-tab OAuth providers neutrally: `anthropic` (Anthropic), `openai-codex` (OpenAI), and `google-gemini-cli` (Google). The reminder exists to send users to the shared Account re-login surface instead of automatically launching an Anthropic-only OAuth flow.
+
+A provider is considered confidently expired only when `/api/oauth/status?provider=<id>` returns `authenticated: false` with a finite `expires` value earlier than the client clock. Missing credentials, never-authenticated rows, missing/non-finite `expires`, non-2xx responses, network errors, and invalid JSON are treated as indeterminate and do not show a reminder for that provider.
+
+When one or more providers are expired, the modal names the affected providers with their friendly labels. Its secondary left button is **Dismiss**; its primary right button is **Go to Account Settings**, which closes the modal and navigates to `#/settings/system/account` so the user can re-authenticate from Settings → Account. Dismissal never blocks normal app use.
+
+Dismissed reminders persist client-side by stable identity: `provider + expires` (stored as `${provider}:${expires}`). The same expired credential stays suppressed across rechecks and reloads, but a different provider or a later expiry timestamp resurfaces the modal. Successful Account-tab re-authentication clears dismissed reminder state for that provider so future distinct expiries can be shown.
+
+Only provider ids, friendly labels, and expiry timestamps participate in this client state. OAuth access tokens, refresh tokens, API keys, and other token material remain server-side and are never exposed by the status response or the reminder modal.
 
 **`POST /api/oauth/start`** body: `{ provider: "anthropic" | "openai-codex" | "google-gemini-cli" }`. Returns:
 

--- a/src/app/account-oauth-providers.ts
+++ b/src/app/account-oauth-providers.ts
@@ -1,0 +1,142 @@
+import { gatewayFetch } from "./gateway-fetch.js";
+
+export type AccountOAuthProviderId = "anthropic" | "openai-codex" | "google-gemini-cli";
+
+export interface AccountOAuthProvider {
+	id: AccountOAuthProviderId;
+	label: string;
+	title: string;
+	description: string;
+	authenticatedLabel: string;
+}
+
+export interface AccountOAuthStatus {
+	authenticated: boolean;
+	expires?: number;
+}
+
+export interface ExpiredAccountOAuthCredential {
+	provider: AccountOAuthProviderId;
+	label: string;
+	expires: number;
+	reminderId: string;
+}
+
+export const ACCOUNT_OAUTH_PROVIDERS: readonly AccountOAuthProvider[] = [
+	{
+		id: "anthropic",
+		label: "Anthropic",
+		title: "Anthropic OAuth",
+		description: "OAuth credentials used by agent sessions to access the Anthropic API. Re-authenticate to refresh expired tokens or switch accounts.",
+		authenticatedLabel: "Authenticated",
+	},
+	{
+		id: "openai-codex",
+		label: "OpenAI",
+		title: "OpenAI OAuth",
+		description: "OAuth credentials used by agent sessions to access ChatGPT subscription GPT models through the OpenAI Codex provider.",
+		authenticatedLabel: "Authenticated",
+	},
+	{
+		id: "google-gemini-cli",
+		label: "Google",
+		title: "Google OAuth",
+		description: "Connect your Google account to run Gemini (Code Assist) in agent sessions. This account path is unofficial and depends on your account's Code Assist quota and Google's terms — separate from a Google AI Studio API key. Re-authenticate to refresh expired tokens or switch accounts.",
+		authenticatedLabel: "Authenticated",
+	},
+];
+
+const ACCOUNT_OAUTH_PROVIDER_LABELS: Record<AccountOAuthProviderId, string> = Object.fromEntries(
+	ACCOUNT_OAUTH_PROVIDERS.map((provider) => [provider.id, provider.label]),
+) as Record<AccountOAuthProviderId, string>;
+
+const DISMISSED_OAUTH_EXPIRY_REMINDERS_KEY = "bobbit.oauthExpiry.dismissed.v1";
+
+export function accountOAuthProviderLabel(provider: string): string {
+	if (provider === "google-gemini-cli" || provider === "google" || provider === "gemini") return "Google";
+	if (provider === "openai-codex" || provider === "openai") return "OpenAI";
+	if (provider === "anthropic") return "Anthropic";
+	return provider;
+}
+
+function readDismissedOAuthExpiryReminders(): Set<string> {
+	try {
+		const raw = localStorage.getItem(DISMISSED_OAUTH_EXPIRY_REMINDERS_KEY);
+		if (!raw) return new Set();
+		const parsed = JSON.parse(raw);
+		if (!Array.isArray(parsed)) return new Set();
+		return new Set(parsed.filter((value): value is string => typeof value === "string"));
+	} catch {
+		return new Set();
+	}
+}
+
+function writeDismissedOAuthExpiryReminders(ids: Set<string>): void {
+	try {
+		if (ids.size === 0) {
+			localStorage.removeItem(DISMISSED_OAUTH_EXPIRY_REMINDERS_KEY);
+			return;
+		}
+		localStorage.setItem(DISMISSED_OAUTH_EXPIRY_REMINDERS_KEY, JSON.stringify([...ids].sort()));
+	} catch {
+		// Storage failures should not block auth or normal app use.
+	}
+}
+
+function reminderId(provider: AccountOAuthProviderId, expires: number): string {
+	return `${provider}:${expires}`;
+}
+
+function clearDismissedOAuthExpiryRemindersForProvider(provider: AccountOAuthProviderId): void {
+	const dismissed = readDismissedOAuthExpiryReminders();
+	let changed = false;
+	for (const id of [...dismissed]) {
+		if (id.startsWith(`${provider}:`)) {
+			dismissed.delete(id);
+			changed = true;
+		}
+	}
+	if (changed) writeDismissedOAuthExpiryReminders(dismissed);
+}
+
+export function dismissAccountOAuthExpiryReminders(credentials: readonly ExpiredAccountOAuthCredential[]): void {
+	const dismissed = readDismissedOAuthExpiryReminders();
+	for (const credential of credentials) dismissed.add(credential.reminderId);
+	writeDismissedOAuthExpiryReminders(dismissed);
+}
+
+function isExpiredExistingCredential(status: unknown, now: number): status is { authenticated: false; expires: number } {
+	if (!status || typeof status !== "object") return false;
+	const data = status as { authenticated?: unknown; expires?: unknown };
+	return data.authenticated === false
+		&& typeof data.expires === "number"
+		&& Number.isFinite(data.expires)
+		&& data.expires < now;
+}
+
+export async function getExpiredAccountOAuthCredentials(now = Date.now()): Promise<ExpiredAccountOAuthCredential[]> {
+	const dismissed = readDismissedOAuthExpiryReminders();
+	const results = await Promise.all(ACCOUNT_OAUTH_PROVIDERS.map(async (provider) => {
+		try {
+			const res = await gatewayFetch(`/api/oauth/status?provider=${encodeURIComponent(provider.id)}`);
+			if (!res.ok) return null;
+			const status = await res.json() as AccountOAuthStatus;
+			if (status?.authenticated === true) {
+				clearDismissedOAuthExpiryRemindersForProvider(provider.id);
+				return null;
+			}
+			if (!isExpiredExistingCredential(status, now)) return null;
+			const id = reminderId(provider.id, status.expires);
+			if (dismissed.has(id)) return null;
+			return {
+				provider: provider.id,
+				label: ACCOUNT_OAUTH_PROVIDER_LABELS[provider.id],
+				expires: status.expires,
+				reminderId: id,
+			} satisfies ExpiredAccountOAuthCredential;
+		} catch {
+			return null;
+		}
+	}));
+	return results.filter((credential): credential is ExpiredAccountOAuthCredential => credential !== null);
+}

--- a/src/app/account-oauth-providers.ts
+++ b/src/app/account-oauth-providers.ts
@@ -87,7 +87,7 @@ function reminderId(provider: AccountOAuthProviderId, expires: number): string {
 	return `${provider}:${expires}`;
 }
 
-function clearDismissedOAuthExpiryRemindersForProvider(provider: AccountOAuthProviderId): void {
+export function clearDismissedAccountOAuthExpiryRemindersForProvider(provider: AccountOAuthProviderId): void {
 	const dismissed = readDismissedOAuthExpiryReminders();
 	let changed = false;
 	for (const id of [...dismissed]) {
@@ -122,7 +122,7 @@ export async function getExpiredAccountOAuthCredentials(now = Date.now()): Promi
 			if (!res.ok) return null;
 			const status = await res.json() as AccountOAuthStatus;
 			if (status?.authenticated === true) {
-				clearDismissedOAuthExpiryRemindersForProvider(provider.id);
+				clearDismissedAccountOAuthExpiryRemindersForProvider(provider.id);
 				return null;
 			}
 			if (!isExpiredExistingCredential(status, now)) return null;

--- a/src/app/dialogs-lazy.ts
+++ b/src/app/dialogs-lazy.ts
@@ -16,6 +16,7 @@
  * fetch; subsequent calls reuse the same module promise.
  */
 import type { Goal } from "./state.js";
+import type { ExpiredAccountOAuthCredential } from "./account-oauth-providers.js";
 import type { CascadeArchiveResult, CascadePauseResult, CascadeResumeResult } from "./dialogs.js";
 
 let _loaded: Promise<typeof import("./dialogs.js")> | null = null;
@@ -77,6 +78,11 @@ export async function checkOAuthStatus(provider?: string): Promise<boolean> {
 export async function openOAuthDialog(provider?: string): Promise<boolean> {
 	const m = await load();
 	return m.openOAuthDialog(provider);
+}
+
+export async function showOAuthExpiryModal(credentials: readonly ExpiredAccountOAuthCredential[]): Promise<void> {
+	const m = await load();
+	return m.showOAuthExpiryModal(credentials);
 }
 
 export async function createProjectAssistantSession(

--- a/src/app/dialogs.ts
+++ b/src/app/dialogs.ts
@@ -50,6 +50,7 @@ import "../ui/components/ErrorDetails.js";
 // module-init time — ESM live bindings resolve at call time.
 import { authenticateGateway, connectToSession } from "./session-manager.js";
 import { BOBBIT_HUE_ROTATIONS, sessionColorMap, setSessionColor, statusBobbit, getAccessory } from "./session-colors.js";
+import { accountOAuthProviderLabel, dismissAccountOAuthExpiryReminders, type ExpiredAccountOAuthCredential } from "./account-oauth-providers.js";
 // NOTE: session-manager imports from dialogs, so we use dynamic imports to break the cycle
 
 // ============================================================================
@@ -428,7 +429,7 @@ function promptArchiveConfirm(opts: {
  *
  * IMPORTANT: a transient HTTP failure (network blip, gateway restart in
  * flight, server overload) must NOT be reported as "not authenticated" —
- * doing so causes `authenticateGateway()` to spuriously open the OAuth
+ * doing so used to cause gateway authentication to spuriously open the OAuth
  * dialog over a perfectly valid session, which is a confusing UX bug in
  * production and a long-tail E2E flake (the dialog steals focus and
  * subsequent assertions on sidebar/page elements time out).
@@ -464,6 +465,70 @@ export async function checkOAuthStatus(provider = "anthropic"): Promise<boolean>
 	return true;
 }
 
+let oauthExpiryModalOpen = false;
+
+export function showOAuthExpiryModal(credentials: readonly ExpiredAccountOAuthCredential[]): void {
+	if (credentials.length === 0 || oauthExpiryModalOpen) return;
+	oauthExpiryModalOpen = true;
+	const container = document.createElement("div");
+	document.body.appendChild(container);
+
+	const names = credentials.map((credential) => credential.label);
+	const namesText = names.length === 1
+		? names[0]
+		: `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+	const title = names.length === 1 ? `${names[0]} login expired` : "OAuth logins expired";
+	const message = names.length === 1
+		? `Your ${names[0]} OAuth login has expired and needs attention.`
+		: `Your OAuth logins for ${namesText} have expired and need attention.`;
+
+	const cleanup = () => {
+		render(html``, container);
+		container.remove();
+		oauthExpiryModalOpen = false;
+	};
+	const dismiss = () => {
+		dismissAccountOAuthExpiryReminders(credentials);
+		cleanup();
+	};
+	const goToAccountSettings = () => {
+		window.location.hash = "#/settings/system/account";
+		cleanup();
+	};
+
+	render(html`
+		<div
+			class="fixed inset-0 z-[1000] flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+			@click=${dismiss}
+		>
+			<div
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="oauth-expiry-title"
+				class="w-[min(440px,92vw)] rounded-lg border border-border bg-background text-foreground shadow-lg"
+				@click=${(event: Event) => event.stopPropagation()}
+			>
+				<div class="px-6 pt-6 pb-4">
+					<h2 id="oauth-expiry-title" class="text-lg font-semibold leading-none tracking-tight">${title}</h2>
+					<p class="text-sm text-muted-foreground mt-2">${message}</p>
+				</div>
+				<div class="flex items-center justify-between gap-2 px-6 pb-4">
+					<button
+						type="button"
+						class="inline-flex h-9 items-center justify-center rounded-md px-4 py-2 text-sm font-medium text-foreground hover:bg-secondary"
+						@click=${dismiss}
+					>Dismiss</button>
+					<button
+						type="button"
+						class="inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+						@click=${goToAccountSettings}
+					>Go to Account Settings</button>
+				</div>
+			</div>
+		</div>
+	`, container);
+}
+
 export function openOAuthDialog(provider = "anthropic"): Promise<boolean> {
 	return new Promise((resolve) => {
 		const container = document.createElement("div");
@@ -482,14 +547,7 @@ export function openOAuthDialog(provider = "anthropic"): Promise<boolean> {
 		const POLL_MAX_DELAY_MS = 8000;
 		const POLL_MAX_TOTAL_MS = 5 * 60 * 1000;
 
-		// Canonical Google account OAuth id is `google-gemini-cli`; `google`/`gemini`
-		// are inbound aliases the server collapses to it. Label all three "Google".
-		const providerName =
-			provider === "google-gemini-cli" || provider === "google" || provider === "gemini"
-				? "Google"
-				: provider === "openai-codex" || provider === "openai"
-					? "OpenAI"
-					: "Anthropic";
+		const providerName = accountOAuthProviderLabel(provider);
 
 		const cleanup = (result: boolean) => {
 			if (pollTimer !== undefined) window.clearTimeout(pollTimer);

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -26,7 +26,7 @@ import { runGitStatusRefresh, abortableSleep } from "./git-status-refresh.js";
 import { startTimeRefresh } from "./render-helpers.js";
 import { getRouteFromHash, setHashRoute, canonicalizePathSessionRoute, saveSessionModel, loadSessionModel, clearSessionModel, isConfigPageRoute } from "./routing.js";
 import { sessionHueRotation, ACCESSORY_IDS } from "./session-colors.js";
-import { showConnectionError, confirmAction, checkOAuthStatus, openOAuthDialog } from "./dialogs-lazy.js";
+import { showConnectionError, confirmAction, showOAuthExpiryModal } from "./dialogs-lazy.js";
 import { teardownMobileScrollTracking } from "./mobile-header.js";
 import { storage } from "./storage.js";
 import { markSessionVisited } from "./render-helpers.js";
@@ -35,6 +35,7 @@ import { setSelectedWorkflowId, showProposalToast, resetProposalAnnCount, resetP
 import { clearProposalAnnotations } from "../ui/components/review/proposal-annotations.js";
 import { restorePersistedReviewDocuments } from "./review-sources.js";
 import { buildProjectConfigDiff } from "./project-proposal-diff.js";
+import { getExpiredAccountOAuthCredentials } from "./account-oauth-providers.js";
 
 // settings-page is dynamic-imported lazily below to keep it out of the main chunk.
 // See docs/design/ui-bundle-size-reduction.md (Task A).
@@ -729,13 +730,7 @@ export async function authenticateGateway(url: string, token: string): Promise<v
 	if (typeof healthData.orphanedTranscripts === "number") {
 		state.orphanedTranscriptsCount = healthData.orphanedTranscripts;
 	}
-	if (!healthData.localhost && !healthData.aigw) {
-		const hasAuth = await checkOAuthStatus();
-		if (!hasAuth) {
-			const success = await openOAuthDialog();
-			if (!success) throw new Error("OAuth login required");
-		}
-	}
+	const shouldCheckOAuthExpiry = !healthData.localhost && !healthData.aigw;
 
 	state.appView = "authenticated";
 	const route = getRouteFromHash();
@@ -743,6 +738,16 @@ export async function authenticateGateway(url: string, token: string): Promise<v
 		setHashRoute("landing");
 	}
 	renderApp();
+	if (shouldCheckOAuthExpiry) {
+		void (async () => {
+			try {
+				const expiredCredentials = await getExpiredAccountOAuthCredentials();
+				if (expiredCredentials.length > 0) void showOAuthExpiryModal(expiredCredentials);
+			} catch {
+				// OAuth status failures are indeterminate; never block gateway auth.
+			}
+		})();
+	}
 	await refreshSessions();
 	try {
 		const cwdRes = await gatewayFetch("/api/config/cwd");

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -48,6 +48,7 @@ import { isClientDebugEnabled, setClientDebugEnabled } from "./client-debug.js";
 import { dispatchIndexEvent } from "./components/search-status-dot.js";
 import "./components/search-status-dot.js";
 import { openOAuthDialog, confirmAction } from "./dialogs.js";
+import { ACCOUNT_OAUTH_PROVIDERS, type AccountOAuthProviderId } from "./account-oauth-providers.js";
 import "../ui/components/ProviderKeyInput.js";
 import { componentToEditState, buildSavePayload, type ComponentEditState } from "./components-editor.js";
 import { ModelSelector } from "../ui/dialogs/ModelSelector.js";
@@ -2922,33 +2923,8 @@ function renderDirectoriesTab() {
 // `google` is reserved for the Google AI Studio / Gemini Developer API-key
 // provider rendered in Settings → Models → Provider API Keys; it is NEVER an
 // Account-tab OAuth id. See docs/design/google-oauth-settings-ux.md.
-type AccountProviderId = "anthropic" | "openai-codex" | "google-gemini-cli";
-
-const ACCOUNT_PROVIDERS: Array<{
-	id: AccountProviderId;
-	title: string;
-	description: string;
-	authenticatedLabel: string;
-}> = [
-	{
-		id: "anthropic",
-		title: "Anthropic OAuth",
-		description: "OAuth credentials used by agent sessions to access the Anthropic API. Re-authenticate to refresh expired tokens or switch accounts.",
-		authenticatedLabel: "Authenticated",
-	},
-	{
-		id: "openai-codex",
-		title: "OpenAI OAuth",
-		description: "OAuth credentials used by agent sessions to access ChatGPT subscription GPT models through the OpenAI Codex provider.",
-		authenticatedLabel: "Authenticated",
-	},
-	{
-		id: "google-gemini-cli",
-		title: "Google OAuth",
-		description: "Connect your Google account to run Gemini (Code Assist) in agent sessions. This account path is unofficial and depends on your account's Code Assist quota and Google's terms — separate from a Google AI Studio API key. Re-authenticate to refresh expired tokens or switch accounts.",
-		authenticatedLabel: "Authenticated",
-	},
-];
+type AccountProviderId = AccountOAuthProviderId;
+const ACCOUNT_PROVIDERS = ACCOUNT_OAUTH_PROVIDERS;
 
 let accountStatus: Partial<Record<AccountProviderId, { authenticated: boolean; expires?: number }>> | null = null;
 let accountLoading = false;
@@ -3012,14 +2988,8 @@ async function handleReauthenticate(provider: AccountProviderId): Promise<void> 
 	}
 }
 
-const ACCOUNT_LOGOUT_LABELS: Record<AccountProviderId, string> = {
-	anthropic: "Anthropic",
-	"openai-codex": "OpenAI",
-	"google-gemini-cli": "Google",
-};
-
 async function handleAccountLogout(provider: AccountProviderId): Promise<void> {
-	const label = ACCOUNT_LOGOUT_LABELS[provider] ?? provider;
+	const label = ACCOUNT_PROVIDERS.find((accountProvider) => accountProvider.id === provider)?.label ?? provider;
 	const confirmed = await confirmAction(
 		`Log out of ${label}?`,
 		`Agent sessions will lose access to ${label} models until you log in again.`,

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -48,7 +48,7 @@ import { isClientDebugEnabled, setClientDebugEnabled } from "./client-debug.js";
 import { dispatchIndexEvent } from "./components/search-status-dot.js";
 import "./components/search-status-dot.js";
 import { openOAuthDialog, confirmAction } from "./dialogs.js";
-import { ACCOUNT_OAUTH_PROVIDERS, type AccountOAuthProviderId } from "./account-oauth-providers.js";
+import { ACCOUNT_OAUTH_PROVIDERS, clearDismissedAccountOAuthExpiryRemindersForProvider, type AccountOAuthProviderId } from "./account-oauth-providers.js";
 import "../ui/components/ProviderKeyInput.js";
 import { componentToEditState, buildSavePayload, type ComponentEditState } from "./components-editor.js";
 import { ModelSelector } from "../ui/dialogs/ModelSelector.js";
@@ -2978,6 +2978,7 @@ async function handleReauthenticate(provider: AccountProviderId): Promise<void> 
 	try {
 		const success = await openOAuthDialog(provider);
 		if (success) {
+			clearDismissedAccountOAuthExpiryRemindersForProvider(provider);
 			// Refresh status after successful re-auth
 			accountStatus = null;
 			loadAccountStatus();

--- a/tests/ui-fixtures/oauth-expiry-modal-entry.ts
+++ b/tests/ui-fixtures/oauth-expiry-modal-entry.ts
@@ -1,11 +1,14 @@
 // Test entry for the provider-neutral OAuth expiry modal.
 // Drives gateway authentication through `authenticateGateway()` with a stubbed
 // gateway so the fixture exercises the same client path used after connecting.
+import { render } from "lit";
 import { authenticateGateway } from "../../src/app/session-manager.js";
+import { renderAccountTab, __testResetAccountTab } from "../../src/app/settings-page.js";
 import { setRenderApp } from "../../src/app/state.js";
 
 type OAuthStatus = { authenticated: boolean; expires?: number };
 type ProviderId = "anthropic" | "openai-codex" | "google-gemini-cli";
+type StatusFailureMode = "non-2xx" | "network-error" | "invalid-json";
 
 type FetchLogEntry = { url: string; method: string; body: any };
 
@@ -13,8 +16,13 @@ const GATEWAY_URL = "https://oauth-expiry.fixture";
 const GATEWAY_TOKEN = "fixture-token";
 
 let statuses: Partial<Record<ProviderId, OAuthStatus>> = {};
+let statusFailures: Partial<Record<ProviderId, StatusFailureMode>> = {};
 const fetchLog: FetchLogEntry[] = [];
 let lastAuthResult: { ok: boolean; error?: string } | null = null;
+let accountTabMounted = false;
+let allowOAuthStart = false;
+let nextFlowId = 0;
+const oauthFlowProviders = new Map<string, ProviderId>();
 
 function installGatewayStorage(): void {
 	localStorage.setItem("gateway.url", GATEWAY_URL);
@@ -39,11 +47,22 @@ function jsonResponse(body: any, init: { ok?: boolean; status?: number } = {}): 
 	});
 }
 
+function invalidJsonResponse(): Response {
+	return new Response("{", {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
 function statusFor(path: string): Response | null {
 	if (!path.startsWith("/api/oauth/status")) return null;
 	const url = new URL(path, window.location.origin);
 	const provider = url.searchParams.get("provider") as ProviderId | null;
 	if (!provider) return jsonResponse({ authenticated: false });
+	const failure = statusFailures[provider];
+	if (failure === "network-error") throw new Error(`simulated ${provider} status network error`);
+	if (failure === "invalid-json") return invalidJsonResponse();
+	if (failure === "non-2xx") return jsonResponse({ error: "simulated status failure" }, { status: 503 });
 	return jsonResponse(statuses[provider] ?? { authenticated: false });
 }
 
@@ -62,8 +81,21 @@ window.fetch = (async (input: any, init?: RequestInit) => {
 	const oauthStatus = statusFor(path);
 	if (oauthStatus) return oauthStatus;
 	if (path === "/api/oauth/start") {
-		// The expiry modal must not launch the legacy OAuth flow automatically.
-		return jsonResponse({ error: "legacy OAuth flow should not start for expiry reminders" }, { ok: false, status: 500 });
+		if (!allowOAuthStart) {
+			// The expiry modal must not launch the legacy OAuth flow automatically.
+			return jsonResponse({ error: "legacy OAuth flow should not start for expiry reminders" }, { ok: false, status: 500 });
+		}
+		const provider = body?.provider as ProviderId;
+		const flowId = `flow-${++nextFlowId}`;
+		oauthFlowProviders.set(flowId, provider);
+		return jsonResponse({ flowId, url: `https://oauth.example/${provider}/${flowId}`, callbackServer: false });
+	}
+	if (path === "/api/oauth/complete") {
+		const provider = oauthFlowProviders.get(body?.flowId);
+		if (!provider) return jsonResponse({ success: false, error: "unknown flow" });
+		statuses[provider] = { authenticated: true, expires: Date.now() + 86_400_000 };
+		delete statusFailures[provider];
+		return jsonResponse({ success: true });
 	}
 	if (path.startsWith("/api/sessions")) return jsonResponse({ sessions: [], archivedDelegates: [], generation: 0 });
 	if (path.startsWith("/api/goals")) return jsonResponse({ goals: [], generation: 0 });
@@ -77,10 +109,14 @@ window.fetch = (async (input: any, init?: RequestInit) => {
 
 (window as any).open = () => null;
 
-setRenderApp(() => {
-	// authenticateGateway() renders the shell after successful auth. The fixture
-	// only cares about independently mounted dialogs, so keep app rendering inert.
-});
+function renderAccountFixture(): void {
+	if (!accountTabMounted) return;
+	const container = document.getElementById("container");
+	if (!container) return;
+	render(renderAccountTab(), container);
+}
+
+setRenderApp(renderAccountFixture);
 
 async function runGatewayAuth(): Promise<{ ok: boolean; error?: string }> {
 	try {
@@ -96,13 +132,35 @@ async function runGatewayAuth(): Promise<{ ok: boolean; error?: string }> {
 	statuses = { ...next };
 };
 
+(window as any).__setOAuthExpiryStatusFailures = (next: Partial<Record<ProviderId, StatusFailureMode>>) => {
+	statusFailures = { ...next };
+};
+
+(window as any).__setOAuthStartAllowed = (next: boolean) => {
+	allowOAuthStart = next === true;
+};
+
+(window as any).__renderAccountTab = (opts: { status?: Partial<Record<ProviderId, OAuthStatus>> | null } = {}) => {
+	accountTabMounted = true;
+	__testResetAccountTab(opts);
+	renderAccountFixture();
+};
+
 (window as any).__resetOAuthExpiryFixture = (next: Partial<Record<ProviderId, OAuthStatus>> = {}) => {
 	localStorage.clear();
 	sessionStorage.clear();
 	installGatewayStorage();
 	statuses = { ...next };
+	statusFailures = {};
 	fetchLog.length = 0;
 	lastAuthResult = null;
+	accountTabMounted = false;
+	allowOAuthStart = false;
+	nextFlowId = 0;
+	oauthFlowProviders.clear();
+	__testResetAccountTab({ status: {} });
+	const container = document.getElementById("container");
+	if (container) render(null, container);
 	window.location.hash = "";
 };
 

--- a/tests/ui-fixtures/oauth-expiry-modal-entry.ts
+++ b/tests/ui-fixtures/oauth-expiry-modal-entry.ts
@@ -1,0 +1,118 @@
+// Test entry for the provider-neutral OAuth expiry modal.
+// Drives gateway authentication through `authenticateGateway()` with a stubbed
+// gateway so the fixture exercises the same client path used after connecting.
+import { authenticateGateway } from "../../src/app/session-manager.js";
+import { setRenderApp } from "../../src/app/state.js";
+
+type OAuthStatus = { authenticated: boolean; expires?: number };
+type ProviderId = "anthropic" | "openai-codex" | "google-gemini-cli";
+
+type FetchLogEntry = { url: string; method: string; body: any };
+
+const GATEWAY_URL = "https://oauth-expiry.fixture";
+const GATEWAY_TOKEN = "fixture-token";
+
+let statuses: Partial<Record<ProviderId, OAuthStatus>> = {};
+const fetchLog: FetchLogEntry[] = [];
+let lastAuthResult: { ok: boolean; error?: string } | null = null;
+
+function installGatewayStorage(): void {
+	localStorage.setItem("gateway.url", GATEWAY_URL);
+	localStorage.setItem("gateway.token", GATEWAY_TOKEN);
+}
+
+function normalizeUrl(input: any): string {
+	const raw = typeof input === "string" ? input : (input as Request).url;
+	try {
+		const u = new URL(raw, window.location.href);
+		return u.pathname + u.search;
+	} catch {
+		return raw;
+	}
+}
+
+function jsonResponse(body: any, init: { ok?: boolean; status?: number } = {}): Response {
+	const status = init.status ?? (init.ok === false ? 500 : 200);
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+function statusFor(path: string): Response | null {
+	if (!path.startsWith("/api/oauth/status")) return null;
+	const url = new URL(path, window.location.origin);
+	const provider = url.searchParams.get("provider") as ProviderId | null;
+	if (!provider) return jsonResponse({ authenticated: false });
+	return jsonResponse(statuses[provider] ?? { authenticated: false });
+}
+
+window.fetch = (async (input: any, init?: RequestInit) => {
+	const path = normalizeUrl(input);
+	const method = (init?.method || "GET").toUpperCase();
+	let body: any = null;
+	if (typeof init?.body === "string") {
+		try { body = JSON.parse(init.body); } catch { body = init.body; }
+	}
+	fetchLog.push({ url: path, method, body });
+
+	if (path === "/api/health") {
+		return jsonResponse({ localhost: false, aigw: false, setupComplete: true, orphanedTranscripts: 0 });
+	}
+	const oauthStatus = statusFor(path);
+	if (oauthStatus) return oauthStatus;
+	if (path === "/api/oauth/start") {
+		// The expiry modal must not launch the legacy OAuth flow automatically.
+		return jsonResponse({ error: "legacy OAuth flow should not start for expiry reminders" }, { ok: false, status: 500 });
+	}
+	if (path.startsWith("/api/sessions")) return jsonResponse({ sessions: [], archivedDelegates: [], generation: 0 });
+	if (path.startsWith("/api/goals")) return jsonResponse({ goals: [], generation: 0 });
+	if (path === "/api/projects") return jsonResponse([]);
+	if (path === "/api/config/cwd") return jsonResponse({ cwd: "" });
+	if (path === "/api/pr-status-cache") return jsonResponse({});
+	if (path.startsWith("/api/gates/status")) return jsonResponse({});
+	if (path.startsWith("/api/search/stats")) return jsonResponse({});
+	return jsonResponse({});
+}) as any;
+
+(window as any).open = () => null;
+
+setRenderApp(() => {
+	// authenticateGateway() renders the shell after successful auth. The fixture
+	// only cares about independently mounted dialogs, so keep app rendering inert.
+});
+
+async function runGatewayAuth(): Promise<{ ok: boolean; error?: string }> {
+	try {
+		await authenticateGateway(GATEWAY_URL, GATEWAY_TOKEN);
+		lastAuthResult = { ok: true };
+	} catch (err) {
+		lastAuthResult = { ok: false, error: err instanceof Error ? err.message : String(err) };
+	}
+	return lastAuthResult;
+}
+
+(window as any).__setOAuthExpiryStatuses = (next: Partial<Record<ProviderId, OAuthStatus>>) => {
+	statuses = { ...next };
+};
+
+(window as any).__resetOAuthExpiryFixture = (next: Partial<Record<ProviderId, OAuthStatus>> = {}) => {
+	localStorage.clear();
+	sessionStorage.clear();
+	installGatewayStorage();
+	statuses = { ...next };
+	fetchLog.length = 0;
+	lastAuthResult = null;
+	window.location.hash = "";
+};
+
+(window as any).__startGatewayAuth = () => {
+	void runGatewayAuth();
+};
+
+(window as any).__runGatewayAuth = runGatewayAuth;
+(window as any).__getOAuthExpiryFetchLog = () => fetchLog.slice();
+(window as any).__getLastAuthResult = () => lastAuthResult;
+
+installGatewayStorage();
+(window as any).__oauthExpiryFixtureReady = true;

--- a/tests/ui-fixtures/oauth-expiry-modal.spec.ts
+++ b/tests/ui-fixtures/oauth-expiry-modal.spec.ts
@@ -13,6 +13,8 @@ const DIALOGS_SRC = path.resolve("src/app/dialogs.ts");
 const DIALOGS_LAZY_SRC = path.resolve("src/app/dialogs-lazy.ts");
 const GATEWAY_FETCH_SRC = path.resolve("src/app/gateway-fetch.ts");
 const STATE_SRC = path.resolve("src/app/state.ts");
+const SETTINGS_SRC = path.resolve("src/app/settings-page.ts");
+const ACCOUNT_OAUTH_PROVIDERS_SRC = path.resolve("src/app/account-oauth-providers.ts");
 
 const ANTHROPIC_EXPIRES = 1_700_000_001_000;
 const OPENAI_EXPIRES = 1_700_000_002_000;
@@ -22,6 +24,13 @@ const GOOGLE_EXPIRES_CHANGED = 1_700_000_004_000;
 type OAuthStatus = { authenticated: boolean; expires?: number };
 type ProviderId = "anthropic" | "openai-codex" | "google-gemini-cli";
 type StatusMap = Partial<Record<ProviderId, OAuthStatus>>;
+type StatusFailureMode = "non-2xx" | "network-error" | "invalid-json";
+
+const TRANSIENT_STATUS_FAILURE_CASES = [
+	["non-2xx", "non-2xx"],
+	["network error", "network-error"],
+	["invalid JSON", "invalid-json"],
+] as const satisfies readonly (readonly [string, StatusFailureMode])[];
 
 function fileUrl(file: string): string {
 	return `file://${file.replace(/\\/g, "/")}`;
@@ -32,7 +41,7 @@ test.beforeAll(() => {
 	buildBundle({
 		entry: ENTRY,
 		outfile: BUNDLE,
-		deps: [ENTRY, SESSION_MANAGER_SRC, DIALOGS_SRC, DIALOGS_LAZY_SRC, GATEWAY_FETCH_SRC, STATE_SRC],
+		deps: [ENTRY, SESSION_MANAGER_SRC, DIALOGS_SRC, DIALOGS_LAZY_SRC, GATEWAY_FETCH_SRC, STATE_SRC, SETTINGS_SRC, ACCOUNT_OAUTH_PROVIDERS_SRC],
 	});
 });
 
@@ -71,6 +80,10 @@ function modalDismiss(page: Page) {
 	return page.getByRole("button", { name: "Dismiss" });
 }
 
+async function dismissedReminderIds(page: Page): Promise<string[]> {
+	return page.evaluate(() => JSON.parse(localStorage.getItem("bobbit.oauthExpiry.dismissed.v1") || "[]"));
+}
+
 async function expectExpiryModalFor(page: Page, providerNames: string[]): Promise<void> {
 	await expect(modalPrimary(page)).toBeVisible();
 	await expect(modalDismiss(page)).toBeVisible();
@@ -106,6 +119,22 @@ test.describe("OAuth expiry modal fixture", () => {
 		await expect(modalPrimary(page)).toHaveCount(0);
 		await expect(page.locator("body")).not.toContainText(/Anthropic Login|OpenAI Login|Google Login/);
 	});
+
+	for (const [name, mode] of TRANSIENT_STATUS_FAILURE_CASES) {
+		test(`transient ${name} OAuth status failures do not show the expiry modal`, async ({ page }) => {
+			await loadFixture(page, {
+				anthropic: expired(ANTHROPIC_EXPIRES),
+				"openai-codex": { authenticated: false },
+				"google-gemini-cli": { authenticated: false },
+			});
+			await page.evaluate((failureMode) => (window as any).__setOAuthExpiryStatusFailures({ anthropic: failureMode }), mode);
+
+			await runGatewayAuth(page);
+			await page.waitForTimeout(100);
+
+			await expect(modalPrimary(page)).toHaveCount(0);
+		});
+	}
 
 	test("dismiss suppresses the same provider plus expiry reminder across auth checks and reloads", async ({ page }) => {
 		const statuses = {
@@ -183,5 +212,29 @@ test.describe("OAuth expiry modal fixture", () => {
 
 		await expect.poll(() => page.evaluate(() => window.location.hash)).toBe("#/settings/system/account");
 		await expect(modalPrimary(page)).toHaveCount(0);
+	});
+
+	test("successful Account-tab re-authentication clears dismissed expiry reminders for that provider", async ({ page }) => {
+		await loadFixture(page, {
+			anthropic: authenticated(),
+			"openai-codex": { authenticated: false },
+			"google-gemini-cli": expired(GOOGLE_EXPIRES),
+		});
+		await runGatewayAuth(page);
+		await expectExpiryModalFor(page, ["Google"]);
+		await modalDismiss(page).click();
+		await expect.poll(() => dismissedReminderIds(page)).toEqual([`google-gemini-cli:${GOOGLE_EXPIRES}`]);
+
+		await page.evaluate((expires) => {
+			(window as any).__setOAuthStartAllowed(true);
+			(window as any).__renderAccountTab({ status: { "google-gemini-cli": { authenticated: false, expires } } });
+		}, GOOGLE_EXPIRES);
+		await page.locator('[data-testid="account-auth-btn-google-gemini-cli"] button').click();
+		const codeInput = page.getByPlaceholder(/Paste (redirect URL or )?code/i);
+		await codeInput.fill("code#state");
+		await codeInput.press("Enter");
+
+		await expect(page.locator('[data-testid="account-status-google-gemini-cli"]')).toHaveText("Authenticated");
+		await expect.poll(() => dismissedReminderIds(page)).toEqual([]);
 	});
 });

--- a/tests/ui-fixtures/oauth-expiry-modal.spec.ts
+++ b/tests/ui-fixtures/oauth-expiry-modal.spec.ts
@@ -1,0 +1,187 @@
+import { test, expect, type Page } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+import { buildBundle } from "../fixtures/build-bundle.js";
+
+const SHELL = path.resolve("tests/ui-fixtures/fixture-shell.html");
+const ENTRY = path.resolve("tests/ui-fixtures/oauth-expiry-modal-entry.ts");
+const BUNDLE_DIR = path.resolve(".bobbit/tmp/ui-fixtures");
+const BUNDLE = path.join(BUNDLE_DIR, "oauth-expiry-modal-bundle.js");
+
+const SESSION_MANAGER_SRC = path.resolve("src/app/session-manager.ts");
+const DIALOGS_SRC = path.resolve("src/app/dialogs.ts");
+const DIALOGS_LAZY_SRC = path.resolve("src/app/dialogs-lazy.ts");
+const GATEWAY_FETCH_SRC = path.resolve("src/app/gateway-fetch.ts");
+const STATE_SRC = path.resolve("src/app/state.ts");
+
+const ANTHROPIC_EXPIRES = 1_700_000_001_000;
+const OPENAI_EXPIRES = 1_700_000_002_000;
+const GOOGLE_EXPIRES = 1_700_000_003_000;
+const GOOGLE_EXPIRES_CHANGED = 1_700_000_004_000;
+
+type OAuthStatus = { authenticated: boolean; expires?: number };
+type ProviderId = "anthropic" | "openai-codex" | "google-gemini-cli";
+type StatusMap = Partial<Record<ProviderId, OAuthStatus>>;
+
+function fileUrl(file: string): string {
+	return `file://${file.replace(/\\/g, "/")}`;
+}
+
+test.beforeAll(() => {
+	fs.mkdirSync(BUNDLE_DIR, { recursive: true });
+	buildBundle({
+		entry: ENTRY,
+		outfile: BUNDLE,
+		deps: [ENTRY, SESSION_MANAGER_SRC, DIALOGS_SRC, DIALOGS_LAZY_SRC, GATEWAY_FETCH_SRC, STATE_SRC],
+	});
+});
+
+async function loadFixture(page: Page, statuses: StatusMap, opts: { preserveStorage?: boolean } = {}): Promise<void> {
+	await page.goto(fileUrl(SHELL));
+	await page.addScriptTag({ path: BUNDLE });
+	await page.waitForFunction(() => (window as any).__oauthExpiryFixtureReady === true, null, { timeout: 10_000 });
+	if (opts.preserveStorage) {
+		await page.evaluate((next) => (window as any).__setOAuthExpiryStatuses(next), statuses);
+	} else {
+		await page.evaluate((next) => (window as any).__resetOAuthExpiryFixture(next), statuses);
+	}
+}
+
+async function runGatewayAuth(page: Page): Promise<void> {
+	await page.evaluate(() => (window as any).__runGatewayAuth());
+}
+
+async function startGatewayAuth(page: Page): Promise<void> {
+	await page.evaluate(() => (window as any).__startGatewayAuth());
+}
+
+function expired(expires: number): OAuthStatus {
+	return { authenticated: false, expires };
+}
+
+function authenticated(): OAuthStatus {
+	return { authenticated: true, expires: Date.now() + 86_400_000 };
+}
+
+function modalPrimary(page: Page) {
+	return page.getByRole("button", { name: "Go to Account Settings" });
+}
+
+function modalDismiss(page: Page) {
+	return page.getByRole("button", { name: "Dismiss" });
+}
+
+async function expectExpiryModalFor(page: Page, providerNames: string[]): Promise<void> {
+	await expect(modalPrimary(page)).toBeVisible();
+	await expect(modalDismiss(page)).toBeVisible();
+	for (const name of providerNames) {
+		await expect(page.locator("body")).toContainText(name);
+	}
+}
+
+test.describe("OAuth expiry modal fixture", () => {
+	test("expired existing credentials for every account provider show one provider-neutral modal", async ({ page }) => {
+		await loadFixture(page, {
+			anthropic: expired(ANTHROPIC_EXPIRES),
+			"openai-codex": expired(OPENAI_EXPIRES),
+			"google-gemini-cli": expired(GOOGLE_EXPIRES),
+		});
+
+		await startGatewayAuth(page);
+
+		await expectExpiryModalFor(page, ["Anthropic", "OpenAI", "Google"]);
+		await expect(page.locator("button")).toHaveText(["Dismiss", "Go to Account Settings"]);
+	});
+
+	test("never-authenticated or missing credentials do not show the expiry modal or launch legacy OAuth", async ({ page }) => {
+		await loadFixture(page, {
+			anthropic: { authenticated: false },
+			"openai-codex": { authenticated: false },
+			"google-gemini-cli": { authenticated: false },
+		});
+
+		await startGatewayAuth(page);
+		await page.waitForTimeout(250);
+
+		await expect(modalPrimary(page)).toHaveCount(0);
+		await expect(page.locator("body")).not.toContainText(/Anthropic Login|OpenAI Login|Google Login/);
+	});
+
+	test("dismiss suppresses the same provider plus expiry reminder across auth checks and reloads", async ({ page }) => {
+		const statuses = {
+			anthropic: authenticated(),
+			"openai-codex": { authenticated: false },
+			"google-gemini-cli": expired(GOOGLE_EXPIRES),
+		} satisfies StatusMap;
+		await loadFixture(page, statuses);
+
+		await runGatewayAuth(page);
+		await expectExpiryModalFor(page, ["Google"]);
+		await modalDismiss(page).click();
+		await expect(modalPrimary(page)).toHaveCount(0);
+
+		await runGatewayAuth(page);
+		await page.waitForTimeout(100);
+		await expect(modalPrimary(page)).toHaveCount(0);
+
+		await loadFixture(page, statuses, { preserveStorage: true });
+		await runGatewayAuth(page);
+		await page.waitForTimeout(100);
+		await expect(modalPrimary(page)).toHaveCount(0);
+	});
+
+	test("a different expired provider resurfaces the modal after dismissing another provider", async ({ page }) => {
+		await loadFixture(page, {
+			anthropic: authenticated(),
+			"openai-codex": { authenticated: false },
+			"google-gemini-cli": expired(GOOGLE_EXPIRES),
+		});
+		await runGatewayAuth(page);
+		await expectExpiryModalFor(page, ["Google"]);
+		await modalDismiss(page).click();
+
+		await page.evaluate((next) => (window as any).__setOAuthExpiryStatuses(next), {
+			anthropic: authenticated(),
+			"openai-codex": expired(OPENAI_EXPIRES),
+			"google-gemini-cli": expired(GOOGLE_EXPIRES),
+		} satisfies StatusMap);
+		await runGatewayAuth(page);
+
+		await expectExpiryModalFor(page, ["OpenAI"]);
+	});
+
+	test("a changed expiry timestamp resurfaces the modal for the same provider", async ({ page }) => {
+		await loadFixture(page, {
+			anthropic: authenticated(),
+			"openai-codex": { authenticated: false },
+			"google-gemini-cli": expired(GOOGLE_EXPIRES),
+		});
+		await runGatewayAuth(page);
+		await expectExpiryModalFor(page, ["Google"]);
+		await modalDismiss(page).click();
+
+		await page.evaluate((next) => (window as any).__setOAuthExpiryStatuses(next), {
+			anthropic: authenticated(),
+			"openai-codex": { authenticated: false },
+			"google-gemini-cli": expired(GOOGLE_EXPIRES_CHANGED),
+		} satisfies StatusMap);
+		await runGatewayAuth(page);
+
+		await expectExpiryModalFor(page, ["Google"]);
+	});
+
+	test("Go to Account Settings closes the modal and navigates to the Account tab", async ({ page }) => {
+		await loadFixture(page, {
+			anthropic: authenticated(),
+			"openai-codex": { authenticated: false },
+			"google-gemini-cli": expired(GOOGLE_EXPIRES),
+		});
+		await runGatewayAuth(page);
+		await expectExpiryModalFor(page, ["Google"]);
+
+		await modalPrimary(page).click();
+
+		await expect.poll(() => page.evaluate(() => window.location.hash)).toBe("#/settings/system/account");
+		await expect(modalPrimary(page)).toHaveCount(0);
+	});
+});


### PR DESCRIPTION
## Summary

- Replace Anthropic-only OAuth auto-login during gateway auth with provider-neutral expiry reminders.
- Add shared Account OAuth provider metadata for Anthropic, OpenAI, and Google.
- Add dismissible expiry modal with Settings → Account navigation and provider+expiry suppression.
- Add file:// browser fixture coverage for modal behavior, dismissal persistence, reauth cleanup, and transient status failures.
- Document client expiry reminder behavior in the OAuth REST docs.

## Validation

- `npm run check`
- `npx playwright test -c tests/playwright.config.ts tests/ui-fixtures/oauth-expiry-modal.spec.ts`
- Workflow implementation gate passed full verification.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
