### PR TITLE
Auto Retry Errors

### DIFF
--- a/docs/auto-retry.md
+++ b/docs/auto-retry.md
@@ -1,199 +1,94 @@
-# Auto-Retry: Provider Overload and Transient Errors
+# Auto-Retry
 
-## Background
+## Purpose
 
-When the Anthropic API (or another provider) returns a transient error mid-turn
-— such as `overloaded_error` (HTTP 529) or `rate_limit_error` (HTTP 429) — the
-session used to stall silently and require the user to click **Retry** manually.
-During peak load these events can last 10+ minutes; surfacing the error to the
-user is worse than waiting.
+Bobbit auto-retries agent turns when the last turn ended with a retryable infrastructure or agent-runtime error. The retry uses the same `retryLastPrompt(sessionId, { auto: true })` path as the chat **Retry** button so continuation safety stays centralized: if a failed turn already ran tools, Retry resumes rather than blindly replaying side effects.
 
-The auto-retry system automatically reschedules the turn with an exponential
-backoff, keeps the UI informed, and cancels gracefully whenever the user or
-session intervenes.
+Auto-retry is intentionally conservative. It keeps transient provider and runtime failures moving, but stops when the error looks deterministic and needs a human fix.
 
----
+## Retry policies
 
-## Two retry policies
+| Error class | Classifier | Schedule | Stop condition |
+|-------------|------------|----------|----------------|
+| Provider overload / rate-limit | `isProviderBackoffError()` | Exponential from 1 s, capped at 5 min, ±20% jitter | No hard attempt cap; stops on success, termination, new prompt, or explicit Retry |
+| JSON/network transient | `isTransientReviewError()` and not provider backoff | 1 s, 2 s, 4 s | After 3 failed auto attempts, leave manual Retry available |
+| Generic unexpected/internal/system agent error | `isRetryableGenericAgentError()` and not transient | 1 s, 5 s, 60 s | After 3 failed auto attempts, leave manual Retry available |
 
-### 1. Provider overload / rate-limit (unbounded)
+The bounded policies exist to recover from short-lived failures without looping forever on a broken model, invalid request, or bad configuration. Provider overload stays effectively unbounded because real provider incidents can last longer than a short retry burst; the long capped backoff prevents tight retry loops while still recovering without user action.
 
-Detected by `isProviderBackoffError()` in `verification-logic.ts`.
+## Classification
 
-Triggers on:
-- `overloaded_error` — Anthropic HTTP 529
-- `rate_limit_error` — Anthropic HTTP 429
-- Phrasings matching `HTTP 429`, `HTTP 529`, `status 429`, `statusCode: 529`,
-  etc. (via `PROVIDER_BACKOFF_REGEXES`)
+Core retry classification lives in `src/server/agent/verification-logic.ts`:
 
-Behaviour:
-- **No hard attempt cap.** Provider outages legitimately last 10+ minutes.
-- **Exponential backoff** starting at 1 s, doubling each attempt, capped at
-  **300 000 ms (5 minutes)** per attempt.
-- **±20% jitter** applied after the cap so multiple concurrent team-lead
-  sessions don't hammer the API at exactly the same moment.
-- `transientRetryAttempts` is **preserved** across auto-retries so the delay
-  keeps growing toward the cap. It is **not** reset until the session succeeds,
-  is terminated, or the user explicitly clicks Retry.
+- `isProviderBackoffError(output)` matches provider overload/rate-limit signals such as `overloaded_error`, `rate_limit_error`, `HTTP 429`, and `HTTP 529`.
+- `isTransientReviewError(output)` matches retryable transient glitches such as malformed streamed tool JSON, `ECONNRESET`, `EPIPE`, `socket hang up`, process exits, and `Validation failed for tool`.
+- `isRetryableGenericAgentError(output)` matches sanitized runtime failures such as `The system encountered an unexpected error`, `unexpected internal error`, and `system server error`.
 
-Backoff sequence (no jitter, `random() = 0.5`):
+Generic auto-retry excludes errors that are likely deterministic or operator-actionable before applying the retryable match. Exclusions include:
 
-| Attempt | Delay  |
-|---------|--------|
-| 1       | 1 s    |
-| 2       | 2 s    |
-| 3       | 4 s    |
-| 4       | 8 s    |
-| 5       | 16 s   |
-| …       | …      |
-| 10+     | 300 s (cap) |
+- authentication or authorization failures
+- missing, invalid, expired, or unconfigured API keys/tokens/credentials
+- configuration errors
+- permission denials
+- user/human aborts or cancellations
+- content/safety-policy blocks
+- validation, bad-request, or schema-validation failures
 
-### 2. Other transient errors (bounded, 3 attempts)
+This ordering matters: a wrapper like `The system encountered an unexpected error: missing API key` must not retry just because it contains the generic unexpected-error text.
 
-Detected by `isTransientReviewError()` but **not** `isProviderBackoffError()`.
+## Scheduling lifecycle
 
-Triggers on: malformed tool-call JSON (`SyntaxError … in JSON at position N`),
-`ECONNRESET`, `EPIPE`, `socket hang up`, `process exited`, `Validation failed
-for tool`, etc. (via `TRANSIENT_ERROR_PATTERNS` and `TRANSIENT_ERROR_REGEXES`).
+`SessionManager.maybeAutoRetryTransient(session)` runs after a turn ends with `message_end.stopReason === "error"`.
 
-Behaviour:
-- Maximum **3 attempts** at fixed 1 s / 2 s / 4 s delays (legacy schedule,
-  preserved for compatibility).
-- After the third failure the error is surfaced to the user and the manual
-  Retry button is required.
+When a policy applies, it:
 
----
+1. increments `session.transientRetryAttempts`;
+2. computes the policy delay;
+3. emits `auto_retry_pending` through the session event stream;
+4. sets `session.pendingAutoRetryTimer`;
+5. when the timer fires, calls `retryLastPrompt(session.id, { auto: true })` if the session is still the current idle session.
 
-## Key functions
+A pending timer is cancelled when the user sends a new prompt, clicks explicit Retry, terminates the session, or the gateway shuts down. Cancellation emits `auto_retry_cancelled` except during shutdown.
 
-| Symbol | Location | Responsibility |
-|--------|----------|----------------|
-| `isTransientReviewError(output)` | `verification-logic.ts` | Returns true for both policy classes. |
-| `isProviderBackoffError(output)` | `verification-logic.ts` | Narrows to the unbounded backoff class. |
-| `TRANSIENT_ERROR_PATTERNS` | `verification-logic.ts` | Literal substring list (includes `overloaded_error`, `rate_limit_error`). |
-| `PROVIDER_BACKOFF_REGEXES` | `verification-logic.ts` | Regex list for HTTP 429/529 status phrasings. |
-| `TRANSIENT_ERROR_REGEXES` | `verification-logic.ts` | Regex list for JSON-glitch / Node `SyntaxError` variants. |
-| `nextBackoffDelay(attempt, opts)` | `session-setup.ts` | Pure function: `baseMs * 2^(attempt-1)`, capped, then ±`jitterRatio` jitter. |
-| `maybeAutoRetryTransient(session)` | `session-manager.ts` | Selects policy, computes delay, broadcasts `auto_retry_pending`, sets `pendingAutoRetryTimer`. |
-| `cancelPendingAutoRetry(session, reason)` | `session-manager.ts` | Tears down the timer and broadcasts `auto_retry_cancelled`. |
-| `retryLastPrompt(id, {auto})` | `session-manager.ts` | Performs the actual retry; `auto: true` preserves `transientRetryAttempts`. |
+`retryLastPrompt(..., { auto: true })` preserves `transientRetryAttempts` so repeated auto failures advance the schedule. Explicit user Retry resets the counter, because human intervention is treated as a fresh recovery attempt.
 
-All detection logic is pure (no I/O) and lives in `verification-logic.ts`.
-All scheduling / timer logic lives in `session-manager.ts`.
+## UI events
 
----
-
-## `transientRetryAttempts` and the explicit vs. auto distinction
-
-`retryLastPrompt` accepts `{ auto: boolean }`:
-
-- **`auto: false`** (user clicked Retry): resets `transientRetryAttempts` to 0
-  and calls `cancelPendingAutoRetry(…, "explicit-retry")`. The next failure
-  starts fresh at the 1 s base delay.
-- **`auto: true`** (timer fired): does **not** touch `transientRetryAttempts`.
-  If the retry itself ends in another overload, `maybeAutoRetryTransient` will
-  find the counter already incremented and schedule a longer delay.
-
-This is intentional: human intervention gets a fresh budget; the auto path must
-grow toward the 5-minute cap or the backoff serves no purpose.
-
----
-
-## Timer lifecycle — when pending retries are cancelled
-
-A pending auto-retry timer is cleared (and `auto_retry_cancelled` broadcast)
-in all of these situations:
-
-| Trigger | Reason string |
-|---------|---------------|
-| User sends a new prompt | `"new-prompt"` |
-| User clicks the Retry button (explicit retry) | `"explicit-retry"` |
-| Session is terminated | `"terminated"` |
-| Gateway shuts down (all sessions) | `"shutdown"` |
-
-The `"shutdown"` case does not broadcast to clients (WebSocket is already torn
-down).
-
----
-
-## UI: auto-retry banner
-
-When a retry is scheduled the server broadcasts a WebSocket event:
+The server emits `auto_retry_pending` while a retry timer is waiting:
 
 ```json
 {
-  "type": "event",
-  "data": {
-    "type": "auto_retry_pending",
-    "reason": "provider-overload" | "transient-error",
-    "retryDelayMs": 4000,
-    "attempt": 3,
-    "scheduledAt": 1715800000000,
-    "error": "<first 200 chars of error message>"
-  }
+  "type": "auto_retry_pending",
+  "reason": "provider-overload" | "transient-error",
+  "retryDelayMs": 5000,
+  "attempt": 2,
+  "scheduledAt": 1715800000000,
+  "error": "The system encountered an unexpected error."
 }
 ```
 
-The client stores this in `state.autoRetryPending`. `AgentInterface` renders a
-banner below the composer:
+Generic unexpected errors use `reason: "transient-error"` on the wire; the policy distinction is server-side. The client stores the event in `state.autoRetryPending` and renders the retry banner while the session remains `idle`.
 
-> ↻ *Retrying in ~4s due to provider overload…* (attempt #3)
+`lastTurnErrored` remains true while auto-retry is pending, so the normal manual Retry affordance is still available. If the bounded retry budget is exhausted, no new pending event is emitted and the user must click Retry after fixing or accepting the failure.
 
-When the retry fires, or the user intervenes, the server broadcasts
-`auto_retry_cancelled` (fields: `reason: "explicit-retry" | "new-prompt" |
-"terminated" | "shutdown"`, `cancelledAt: number`) and the banner disappears.
-The session status remains `"idle"` throughout — the banner is the only
-visible indicator of the pending wait.
+## Team-lead auto-nudge interaction
 
-**Wire-shape pin.** Both events are typed in the WS protocol union as
-`AutoRetryPendingEvent` / `AutoRetryCancelledEvent` exported from
-`src/server/ws/protocol.ts`. The producer (`session-manager.ts`) and consumer
-(`src/app/remote-agent.ts`) both rely on this typing — no runtime `typeof`
-guards on the consumer side. If you need to add or rename a field, update the
-protocol types first; both ends will fail to type-check until they agree.
+Team leads rely on automatic nudges to resume work after child-agent or gate activity. `TeamManager` uses `nudgePending` to avoid flooding a lead with duplicate prompts, but that guard must only stay set when a lead turn actually starts.
 
----
+Auto-nudge delivery now clears or avoids sticky `nudgePending` when delivery does not start a turn, including:
 
-## Testing
+- `enqueuePrompt()` throws synchronously;
+- the async delivery rejects;
+- the prompt parks behind an errored/capped session;
+- delivery resolves as queued while the team lead remains idle.
 
-Three unit test files cover this feature, all runnable via `npm run test:unit`:
+`agent_start` still clears `nudgePending` for the normal success path. This prevents an errored retry or parked nudge from permanently suppressing later team-lead nudges.
 
-**`tests/backoff-delay.test.ts`** — pins `nextBackoffDelay` in isolation:
-- Correct doubling sequence (1 s, 2 s, 4 s, …)
-- Cap enforcement at `maxMs` before and after jitter
-- Jitter bounds (±20% across a sweep of deterministic `random()` values)
-- Finite, non-negative output even for very large attempt counts (no `Infinity`/`NaN`)
+## Tests
 
-**`tests/auto-retry-policy.test.ts`** — pins the end-to-end policy decision
-tree (`decideRetryPolicy` mirrors `maybeAutoRetryTransient`'s logic using the
-same exported building blocks):
-- Overload / rate-limit errors retry indefinitely past the 3-attempt bounded cap
-- HTTP 429/529 status phrasings are classified as provider-backoff
-- Non-provider transient errors stop after attempt 3
-- Non-transient errors produce no retry
+Relevant unit coverage runs under `npm run test:unit`:
 
-**`tests/queue-dispatch.spec.ts`** — integration-level pins on
-`SessionManager`-style simulation:
-- Explicit `retryLastPrompt` clears `pendingAutoRetryTimer`
-- Explicit retry resets `transientRetryAttempts`; auto retry preserves it
-- Provider-overload error retries past the 3-attempt non-provider cap
-
----
-
-## E2E harness: canonical path helper
-
-The E2E test harnesses (`gateway-harness`, `in-process-harness`) were updated
-alongside this feature to fix a macOS path-canonicalization issue unrelated to
-retry logic but discovered during the same work.
-
-On macOS, `os.tmpdir()` returns `/var/folders/…` which is a symlink to
-`/private/var/folders/…`. `POST /api/projects` rejects a symlinked `rootPath`
-unless `acceptCanonical: true` is supplied. The harnesses were silently eating
-the resulting 400, leaving the gateway with zero registered projects at startup.
-
-The fix: `apiFetch` in `tests/e2e/e2e-setup.ts` now intercepts every `POST
-/api/projects` call, resolves `rootPath` through `realpathSync`, and
-automatically adds `acceptCanonical: true`. Tests that intentionally exercise
-the 400 path use `rawApiFetch`, which bypasses this interceptor. The opt-out
-marker `__e2e_no_accept_canonical: true` is also reserved for future negative
-tests routed through `apiFetch`.
+- `tests/backoff-delay.test.ts` pins `nextBackoffDelay()` math, cap handling, and jitter bounds.
+- `tests/auto-retry-policy.test.ts` covers provider overload, JSON/network transient retries, generic unexpected retries at 1 s / 5 s / 60 s, retry exhaustion, non-retryable generic-looking exclusions, and dispatch through the existing auto Retry path.
+- `tests/queue-dispatch.spec.ts` covers retry-counter preservation/reset and pending timer cancellation around prompt dispatch.
+- `tests/team-manager-idle-nudge-backoff.test.ts` covers `nudgePending` clearing when a team-lead auto-nudge parks instead of starting a turn.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -270,17 +270,17 @@ See [docs/archived-proposal-reopen.md](archived-proposal-reopen.md) for the full
   1. `[session-manager] Session … implicit unstick from enqueuePrompt (consecutiveErrorTurns=…)` or `… from deliverLiveSteer` log lines — if missing, the call didn't reach the helper. Steers must route through `SessionManager.deliverLiveSteer()` (see the abort/steer section above).
   2. `consecutiveErrorTurns` on the session info — if it's ≥ 3, the cap is parking. Click Retry or fix the upstream.
   3. Team-lead nudges to an errored worker: no longer suppressed in `team-manager.ts` (the old `if (teamLeadSession.lastTurnErrored) return;` guard was removed). SessionManager is now the single source of truth for error-state policy.
-- **Related**: pattern-matching on error text via `TRANSIENT_ERROR_PATTERNS` + auto-retry (`transientRetryAttempts`, `maybeAutoRetryTransient`) handles transient in-band recovery. See [docs/auto-retry.md](auto-retry.md) for the full policy. The implicit-unstick path is the structural fallback when the whitelist doesn't match.
+- **Related**: auto-retry (`transientRetryAttempts`, `maybeAutoRetryTransient`) handles provider backoff, JSON/network transients, and retryable generic unexpected/internal/system errors. See [docs/auto-retry.md](auto-retry.md) for the full policy. The implicit-unstick path is the structural fallback when auto-retry does not apply or has exhausted its bounded budget.
 
-## Provider overload / rate-limit: session appears frozen with no retry banner
+## Auto-retryable error: session appears frozen with no retry banner
 
-- **Symptom**: turn ended with `overloaded_error` or `rate_limit_error` (or `HTTP 429/529`); session is `idle` but the UI shows no retry banner and nothing happens.
-- **Expected behaviour**: `maybeAutoRetryTransient` schedules an exponential-backoff retry automatically and broadcasts `auto_retry_pending`. The banner reads *"Retrying in ~Xs due to provider overload…"*.
+- **Symptom**: turn ended with `overloaded_error`, `rate_limit_error`, `HTTP 429/529`, or a sanitized message such as `The system encountered an unexpected error`; session is `idle` but the UI shows no retry banner and nothing happens.
+- **Expected behaviour**: `maybeAutoRetryTransient` schedules auto-retry and broadcasts `auto_retry_pending`. Provider overload uses long capped exponential backoff; generic unexpected errors use the bounded 1 s / 5 s / 60 s policy.
 - **Diagnosis**:
-  1. Check server log for `[session-manager] Session … hit provider overload/rate-limit`. If missing, `isProviderBackoffError` didn't match — verify the error string contains `overloaded_error`, `rate_limit_error`, or an HTTP 429/529 phrase.
+  1. Check server logs for `[session-manager] Session … hit provider overload/rate-limit`, `… turn failed transiently`, or `… retryable generic error`. If none appear, the classifier did not match or a non-retryable exclusion matched first.
   2. Check `session.pendingAutoRetryTimer` is set (non-null). If the timer fired but the retry itself failed again, look for `[session-manager] Auto-retry failed for session` in the log.
   3. Banner missing despite `auto_retry_pending` being broadcast? Check `state.autoRetryPending` in `remote-agent.ts` — the `case "auto_retry_pending"` handler must have run. If it did, verify `AgentInterface` re-renders on `auto_retry_pending` events (see `AgentInterface._handleEvent`).
-- See [docs/auto-retry.md](auto-retry.md) for the full policy, cancellation triggers, and test coverage.
+- See [docs/auto-retry.md](auto-retry.md) for the full policy, cancellation triggers, non-retryable exclusions, and test coverage.
 
 ## "Setting up worktree…" banner missing on a brand-new session / preparing UX absent
 

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -61,7 +61,7 @@ import type { ToolGroupPolicyStore } from "./tool-group-policy-store.js";
 import { decideOverflowAction } from "../ws-overflow-guard.js";
 
 import { McpManager, type MarketplaceMcpResolver, type McpReloadResult } from "../mcp/mcp-manager.js";
-import { isTransientReviewError, isProviderBackoffError } from "./verification-logic.js";
+import { isTransientReviewError, isProviderBackoffError, isRetryableGenericAgentError } from "./verification-logic.js";
 import { truncateLargeToolContent, truncateLargeToolContentInMessages } from "./truncate-large-content.js";
 import { getAigwUrl, discoverAigwModels, deriveName, inferMeta } from "./aigw-manager.js";
 import { defaultImageModelPref, getAvailableImageModels, parseImageModelPref } from "./image-generation.js";
@@ -3528,20 +3528,28 @@ export class SessionManager {
 	 * - Other transient glitches (malformed tool-call JSON, ECONNRESET, etc.):
 	 *   bounded 3 attempts at 1s/2s/4s, after which the error surfaces and
 	 *   the user can manually retry.
+	 *
+	 * - Retryable generic agent/runtime errors (sanitized unexpected/internal
+	 *   system errors): bounded 3 attempts at 1s/5s/60s, then manual retry.
 	 */
 	private maybeAutoRetryTransient(session: SessionInfo): void {
 		const BOUNDED_MAX_ATTEMPTS = 3;
 		const PROVIDER_BACKOFF_MAX_MS = 300_000; // 5 minutes
+		const GENERIC_RETRY_DELAYS_MS = [1000, 5000, 60_000] as const;
 		const errMsg = session.lastTurnErrorMessage || "";
 		if (!errMsg) return;
-		if (!isTransientReviewError(errMsg)) return;
 
 		const isBackoff = isProviderBackoffError(errMsg);
+		const isTransient = isTransientReviewError(errMsg);
+		const isGenericRetryable = !isTransient && isRetryableGenericAgentError(errMsg);
+		if (!isBackoff && !isTransient && !isGenericRetryable) return;
+
 		const attempt = (session.transientRetryAttempts ?? 0) + 1;
 
 		if (!isBackoff && attempt > BOUNDED_MAX_ATTEMPTS) {
+			const label = isGenericRetryable ? "generic" : "transient";
 			console.warn(
-				`[session-manager] Session ${session.id} exhausted ${BOUNDED_MAX_ATTEMPTS} transient auto-retries; surfacing error to user. Last error: ${errMsg.slice(0, 200)}`
+				`[session-manager] Session ${session.id} exhausted ${BOUNDED_MAX_ATTEMPTS} ${label} auto-retries; surfacing error to user. Last error: ${errMsg.slice(0, 200)}`
 			);
 			session.transientRetryAttempts = 0;
 			return;
@@ -3550,11 +3558,17 @@ export class SessionManager {
 
 		const delayMs = isBackoff
 			? nextBackoffDelay(attempt, { baseMs: 1000, maxMs: PROVIDER_BACKOFF_MAX_MS, jitterRatio: 0.2 })
-			: 1000 * Math.pow(2, attempt - 1); // 1s, 2s, 4s (preserve exact legacy schedule)
+			: isGenericRetryable
+				? GENERIC_RETRY_DELAYS_MS[attempt - 1]!
+				: 1000 * Math.pow(2, attempt - 1); // 1s, 2s, 4s (preserve exact legacy schedule)
 
 		if (isBackoff) {
 			console.log(
 				`[session-manager] Session ${session.id} hit provider overload/rate-limit (attempt ${attempt}); auto-retrying in ${Math.round(delayMs / 1000)}s. Error: ${errMsg.slice(0, 200)}`
+			);
+		} else if (isGenericRetryable) {
+			console.log(
+				`[session-manager] Session ${session.id} turn failed with a retryable generic error (attempt ${attempt}/${BOUNDED_MAX_ATTEMPTS}), auto-retrying in ${delayMs / 1000}s. Error: ${errMsg.slice(0, 200)}`
 			);
 		} else {
 			console.log(

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
-import type { SessionManager, SessionInfo } from "./session-manager.js";
+import type { PromptSource, SessionManager, SessionInfo } from "./session-manager.js";
 import { GoalManager } from "./goal-manager.js";
 import { GoalStore, type PersistedGoal } from "./goal-store.js";
 import { createWorktree, cleanupWorktree } from "../skills/git.js";
@@ -372,14 +372,8 @@ export class TeamManager {
 			"merge a finished branch, mark a task complete, or signal the next gate.\n" +
 			"If all gates have passed, call `team_complete`.";
 
-		this.nudgePending.set(goalId, true);
+		if (!this.enqueueAutoNudge(goalId, entry.teamLeadSessionId!, message, { isSteered: true }, "Stuck-team watchdog")) return;
 		this.lastNudgeAtPerGoal.set(goalId, now);
-		try {
-			this.sessionManager.enqueuePrompt(entry.teamLeadSessionId!, message, { isSteered: true });
-		} catch (err) {
-			console.error(`[team-manager] Stuck-team watchdog enqueuePrompt failed for goal ${goalId}:`, err);
-			return;
-		}
 		console.log(`[team-manager] Stuck-team watchdog fired for goal ${goalId} after ${minutes}m idle`);
 	}
 
@@ -1016,11 +1010,9 @@ export class TeamManager {
 				"if everything is genuinely done.";
 			// enqueuePrompt drains ASYNCHRONOUSLY: for an idle lead with an empty
 			// queue it awaits dispatchDirectPrompt → rpcClient.prompt(), which on
-			// a cold agent rejects with the cold-start timeout. Dispatch through a
-			// helper that owns (awaits + catches) that rejection so it never
-			// escapes as `[gateway] Unhandled rejection`.
-			void this._dispatchBootResumeNudge(entry.teamLeadSessionId, msg, goalId);
-			this.nudgePending.set(goalId, true);
+			// a cold agent rejects with the cold-start timeout. The helper owns
+			// async rejection handling so it never escapes as `[gateway] Unhandled rejection`.
+			if (!this.enqueueAutoNudge(goalId, entry.teamLeadSessionId, msg, { isSteered: true, coldStart: true }, "Boot-resume nudge")) continue;
 			this.lastNudgeAtPerGoal.set(goalId, now);
 			resumed++;
 			console.log(`[team-manager] Boot-resume nudge sent for goal=${goalId} (${summary})`);
@@ -1030,18 +1022,59 @@ export class TeamManager {
 		}
 	}
 
-	/**
-	 * Dispatch a boot-resume nudge through enqueuePrompt with cold-start
-	 * handling, owning the async drain's rejection so a cold-start prompt
-	 * timeout is caught and logged here rather than escaping as a process-level
-	 * `[gateway] Unhandled rejection`.
-	 */
-	private async _dispatchBootResumeNudge(sessionId: string, msg: string, goalId: string): Promise<void> {
+	private enqueueAutoNudge(
+		goalId: string,
+		sessionId: string,
+		message: string,
+		opts: { isSteered: true; source?: PromptSource; coldStart?: boolean },
+		label: string,
+	): boolean {
+		this.nudgePending.set(goalId, true);
+
+		let delivery: unknown;
 		try {
-			await this.sessionManager.enqueuePrompt(sessionId, msg, { isSteered: true, coldStart: true });
+			delivery = this.sessionManager.enqueuePrompt(sessionId, message, opts);
 		} catch (err) {
-			console.error(`[team-manager] Boot-resume nudge failed for goal=${goalId}:`, err);
+			this.nudgePending.delete(goalId);
+			console.error(`[team-manager] ${label} enqueuePrompt failed for goal ${goalId}:`, err);
+			return false;
 		}
+
+		this.clearNudgePendingIfDeliveryDidNotStart(goalId, delivery);
+		if (this.isThenable(delivery)) {
+			// A parked/capped enqueue returns a resolved promise while the lead stays idle.
+			// Clear on the next macrotask if no agent_start/status transition happened.
+			setTimeout(() => {
+				if (this.isTeamLeadIdle(goalId)) this.nudgePending.delete(goalId);
+			}, 0);
+			void delivery.then(
+				(result) => this.clearNudgePendingIfDeliveryDidNotStart(goalId, result),
+				(err) => {
+					this.nudgePending.delete(goalId);
+					console.error(`[team-manager] ${label} failed for goal ${goalId}:`, err);
+				},
+			);
+		}
+
+		return true;
+	}
+
+	private clearNudgePendingIfDeliveryDidNotStart(goalId: string, delivery: unknown): void {
+		if (!delivery || typeof delivery !== "object") return;
+		const result = delivery as { status?: unknown; parked?: unknown };
+		if (result.parked === true || (result.status === "queued" && this.isTeamLeadIdle(goalId))) {
+			this.nudgePending.delete(goalId);
+		}
+	}
+
+	private isThenable(value: unknown): value is PromiseLike<unknown> {
+		return !!value && (typeof value === "object" || typeof value === "function") && typeof (value as { then?: unknown }).then === "function";
+	}
+
+	private isTeamLeadIdle(goalId: string): boolean {
+		const entry = this.teams.get(goalId);
+		if (!entry?.teamLeadSessionId) return false;
+		return this.sessionManager.getSession(entry.teamLeadSessionId)?.status === "idle";
 	}
 
 	/**
@@ -1190,8 +1223,7 @@ export class TeamManager {
 				`If there's more work to do, spawn agents or do it yourself. ` +
 				`If all work is complete and gates are passed, call team_complete to finish the goal.`;
 
-			this.nudgePending.set(goalId, true);
-			this.sessionManager.enqueuePrompt(entry.teamLeadSessionId!, message, { isSteered: true, source: "auto-nudge" });
+			if (!this.enqueueAutoNudge(goalId, entry.teamLeadSessionId!, message, { isSteered: true, source: "auto-nudge" }, "No-workers nudge")) return;
 			this.noWorkersNudgeCount.set(goalId, count + 1);
 			const nextDelay = Math.min(
 				TeamManager.NO_WORKERS_NUDGE_DELAY_MS * Math.pow(2, count + 1),
@@ -1274,8 +1306,7 @@ export class TeamManager {
 				`If an agent is idle and their work looks complete, mark their task as done and dismiss them. ` +
 				`If idle agents have more to do, prompt them to continue.`;
 
-			this.nudgePending.set(goalId, true);
-			this.sessionManager.enqueuePrompt(entry.teamLeadSessionId!, message, { isSteered: true, source: "auto-nudge" });
+			if (!this.enqueueAutoNudge(goalId, entry.teamLeadSessionId!, message, { isSteered: true, source: "auto-nudge" }, "Idle nudge")) return;
 			this.idleNudgeCount.set(goalId, count + 1);
 			const nextDelay = Math.min(
 				TeamManager.IDLE_NUDGE_DELAY_MS * Math.pow(2, count + 1),

--- a/src/server/agent/verification-logic.ts
+++ b/src/server/agent/verification-logic.ts
@@ -260,6 +260,37 @@ export function isProviderBackoffError(output: string): boolean {
 	return PROVIDER_BACKOFF_REGEXES.some(re => re.test(output));
 }
 
+const GENERIC_AGENT_RETRYABLE_REGEXES: RegExp[] = [
+	/\bthe system encountered an unexpected error\b/i,
+	/\ban unexpected (?:agent |system |internal )?error (?:occurred|happened|was encountered)\b/i,
+	/\b(?:internal|system) (?:server )?error\b/i,
+];
+
+const GENERIC_AGENT_NON_RETRYABLE_REGEXES: RegExp[] = [
+	/\b(?:auth(?:entication|orization)?|unauthori[sz]ed|forbidden)\b/i,
+	/\b(?:invalid|missing|no) api key\b/i,
+	/\b(?:api key|token|credential)s? (?:is |are )?(?:missing|invalid|expired|not configured|required)\b/i,
+	/\b(?:configuration|config) (?:error|invalid|missing|not configured)\b/i,
+	/\b(?:permission denied|access denied|operation not permitted|eacces|eperm)\b/i,
+	/\b(?:user|human) (?:aborted|cancelled|canceled|interrupted)\b/i,
+	/\b(?:aborterror|cancelled by user|canceled by user)\b/i,
+	/\b(?:content policy|policy violation|safety policy|blocked by policy|disallowed content)\b/i,
+	/\b(?:validationerror|validation error|invalid request|bad request|schema validation)\b/i,
+];
+
+/**
+ * Classify generic agent/runtime failures that are worth one short bounded
+ * retry burst even when they do not match the narrower transient/provider
+ * classifiers above. Deterministic operator/config/user-policy failures are
+ * excluded first so sanitized "unexpected error" wrappers with a concrete
+ * cause (for example, "missing API key") do not loop.
+ */
+export function isRetryableGenericAgentError(output: string): boolean {
+	if (!output) return false;
+	if (GENERIC_AGENT_NON_RETRYABLE_REGEXES.some(re => re.test(output))) return false;
+	return GENERIC_AGENT_RETRYABLE_REGEXES.some(re => re.test(output));
+}
+
 /**
  * Decide whether a verification-step retry loop should attempt another
  * pass given the latest result, or break out.

--- a/tests/auto-retry-policy.test.ts
+++ b/tests/auto-retry-policy.test.ts
@@ -16,18 +16,30 @@
  *   1. Provider overload / rate-limit errors → effectively unbounded retries,
  *      exponential backoff capped at 300_000 ms.
  *   2. Non-provider transient errors → bounded at 3 attempts (1s, 2s, 4s).
- *   3. Non-transient errors → no auto-retry.
+ *   3. Generic unexpected agent errors → bounded at 3 attempts (1s, 5s, 60s)
+ *      and delivered through the same auto retry path as the Retry button.
+ *   4. Deterministic/non-retryable errors → no auto-retry.
  *
  * Runs via `npm run test:unit` (Node test runner).
  */
-import { describe, it } from "node:test";
+import { afterEach, describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 import {
 	isTransientReviewError,
 	isProviderBackoffError,
 } from "../src/server/agent/verification-logic.ts";
 import { nextBackoffDelay } from "../src/server/agent/session-setup.ts";
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "auto-retry-policy-test-"));
+process.env.BOBBIT_DIR = tmpRoot;
+
+const { SessionManager } = await import("../src/server/agent/session-manager.ts");
+const { PromptQueue } = await import("../src/server/agent/prompt-queue.ts");
+const { EventBuffer } = await import("../src/server/agent/event-buffer.ts");
 
 // ── Policy under test ──────────────────────────────────────────────────────
 
@@ -72,6 +84,89 @@ const RATE_LIMIT_JSON = '{"type":"rate_limit_error","message":"Rate limited"}';
 const JSON_GLITCH =
 	"Error: Expected ',' or '}' after property value in JSON at position 320";
 const NETWORK_BLIP = "Error: read ECONNRESET";
+const GENERIC_UNEXPECTED = "The system encountered an unexpected error.";
+
+const managers: any[] = [];
+
+type TestClient = {
+	readyState: number;
+	bufferedAmount: number;
+	sent: any[];
+	send(data: string): void;
+	close(code?: number, reason?: string): void;
+};
+
+function makeClient(): TestClient {
+	return {
+		readyState: 1,
+		bufferedAmount: 0,
+		sent: [],
+		send(data: string) { this.sent.push(JSON.parse(data)); },
+		close() { this.readyState = 3; },
+	};
+}
+
+function makeManager(): any {
+	const manager: any = new SessionManager();
+	manager._testStore = {
+		update: mock.fn(() => {}),
+		get: mock.fn(() => undefined),
+	};
+	managers.push(manager);
+	return manager;
+}
+
+function cleanupManager(manager: any): void {
+	if (manager._statusHeartbeatTimer) {
+		clearInterval(manager._statusHeartbeatTimer);
+		manager._statusHeartbeatTimer = null;
+	}
+	for (const session of manager.sessions?.values?.() ?? []) {
+		if (session.pendingAutoRetryTimer) clearTimeout(session.pendingAutoRetryTimer);
+	}
+	manager.sessionsWithConnectedClients?.clear();
+	manager.sessions?.clear();
+}
+
+function putRetryStateSession(manager: any, overrides: Record<string, any> = {}): { session: any; client: TestClient; prompt: any } {
+	const client = makeClient();
+	const prompt = mock.fn(async () => ({ success: true }));
+	const session = {
+		id: `s-auto-retry-${Math.random().toString(36).slice(2)}`,
+		title: "Auto retry policy test",
+		titleGenerated: true,
+		cwd: tmpRoot,
+		status: "idle",
+		statusVersion: 0,
+		createdAt: Date.now(),
+		lastActivity: Date.now(),
+		clients: new Set([client]),
+		promptQueue: new PromptQueue(),
+		eventBuffer: new EventBuffer(),
+		rpcClient: { prompt },
+		lastTurnErrored: true,
+		lastTurnErrorMessage: GENERIC_UNEXPECTED,
+		lastPromptText: "retry the last user request",
+		turnHadToolCalls: false,
+		consecutiveErrorTurns: 1,
+		transientRetryAttempts: 0,
+		lifecycleGeneration: 0,
+		...overrides,
+	};
+	manager.sessions.set(session.id, session);
+	return { session, client, prompt };
+}
+
+function autoRetryPendingEvents(session: any): any[] {
+	return session.eventBuffer
+		.getAll()
+		.map((entry: any) => entry.event)
+		.filter((event: any) => event?.type === "auto_retry_pending");
+}
+
+afterEach(() => {
+	while (managers.length > 0) cleanupManager(managers.pop());
+});
 
 // ── Provider-backoff path: effectively unbounded ──────────────────────────
 
@@ -180,6 +275,104 @@ describe("decideRetryPolicy — non-provider transient (bounded)", () => {
 		);
 		assert.equal(r.retry, true);
 		assert.equal((r as any).reason, "transient-error");
+	});
+});
+
+// ── Generic unexpected errors: bounded scheduler path ─────────────────────
+
+describe("SessionManager generic unexpected auto-retry policy", () => {
+	it("schedules generic unexpected agent errors at 1s/5s/60s while preserving Retry state", () => {
+		const manager = makeManager();
+		const { session } = putRetryStateSession(manager);
+		for (const [attempt, expectedDelayMs] of [
+			[1, 1000],
+			[2, 5000],
+			[3, 60_000],
+		] as const) {
+			manager.maybeAutoRetryTransient(session);
+
+			assert.equal(session.lastTurnErrored, true, "the chat Retry affordance should remain available while auto-retry is pending");
+			assert.ok(
+				session.pendingAutoRetryTimer,
+				`expected generic unexpected error to schedule auto-retry attempt ${attempt}`,
+			);
+			const pending = autoRetryPendingEvents(session).at(-1);
+			assert.ok(pending, "expected auto_retry_pending event for generic unexpected error");
+			assert.equal(pending.retryDelayMs, expectedDelayMs);
+			assert.equal(pending.attempt, attempt);
+
+			clearTimeout(session.pendingAutoRetryTimer);
+			session.pendingAutoRetryTimer = undefined;
+		}
+	});
+
+	it("uses the pending timer to call the existing auto retry path after the first 1s generic retry", async (t) => {
+		t.mock.timers.enable({ apis: ["setTimeout"] });
+		const manager = makeManager();
+		const { session, prompt } = putRetryStateSession(manager, {
+			lastPromptText: "please retry this user request",
+		});
+
+		manager.maybeAutoRetryTransient(session);
+
+		assert.ok(session.pendingAutoRetryTimer, "expected a pending auto-retry timer for generic unexpected errors");
+		t.mock.timers.tick(999);
+		assert.equal(prompt.mock.callCount(), 0, "auto retry should not fire before its 1s delay");
+
+		t.mock.timers.tick(1);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		assert.equal(prompt.mock.callCount(), 1, "generic auto retry should dispatch through retryLastPrompt(..., { auto: true })");
+		assert.equal(prompt.mock.calls[0].arguments[0], "please retry this user request");
+		assert.equal(session.lastTurnErrored, false, "retryLastPrompt should clear error state once the auto retry starts");
+		assert.equal(session.status, "streaming");
+	});
+
+	it("stops after the third generic unexpected retry and leaves manual Retry available", () => {
+		const manager = makeManager();
+		const { session } = putRetryStateSession(manager);
+		for (let i = 0; i < 3; i++) {
+			manager.maybeAutoRetryTransient(session);
+			if (session.pendingAutoRetryTimer) clearTimeout(session.pendingAutoRetryTimer);
+			session.pendingAutoRetryTimer = undefined;
+		}
+		const emittedBeforeExhaustion = autoRetryPendingEvents(session).length;
+
+		manager.maybeAutoRetryTransient(session);
+
+		assert.equal(session.pendingAutoRetryTimer, undefined);
+		assert.equal(
+			autoRetryPendingEvents(session).length,
+			emittedBeforeExhaustion,
+			"exhausted generic auto-retry must not emit a new pending event",
+		);
+		assert.equal(session.lastTurnErrored, true, "after exhaustion the session should still expose manual Retry");
+	});
+
+	it("does not auto-retry deterministic generic-looking failures", () => {
+		const nonRetryable = [
+			"Authentication failed: invalid API key for provider",
+			"Configuration error: model provider is not configured",
+			"No API key found for openrouter",
+			"Permission denied while reading workspace file",
+			"User aborted the request",
+			"Content policy violation: disallowed content",
+			"ValidationError: invalid session id",
+			"The system encountered an unexpected error: missing API key",
+		];
+
+		for (const message of nonRetryable) {
+			const manager = makeManager();
+			const { session } = putRetryStateSession(manager, {
+				lastTurnErrorMessage: message,
+			});
+
+			manager.maybeAutoRetryTransient(session);
+
+			assert.equal(session.pendingAutoRetryTimer, undefined, `did not expect auto-retry for: ${message}`);
+			assert.equal(autoRetryPendingEvents(session).length, 0, `did not expect auto_retry_pending for: ${message}`);
+		}
 	});
 });
 

--- a/tests/team-manager-idle-nudge-backoff.test.ts
+++ b/tests/team-manager-idle-nudge-backoff.test.ts
@@ -358,6 +358,56 @@ describe("TeamManager — idle-nudge exponential backoff (regression)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Sticky nudgePending guard — delivery that parks before agent_start
+// ---------------------------------------------------------------------------
+
+describe("TeamManager — nudgePending clears when delivery does not start a turn (regression)", () => {
+	it("does not permanently suppress later no-workers nudges after a parked auto-nudge", async (t) => {
+		t.mock.timers.enable({ apis: ["setInterval", "setTimeout"] });
+
+		try {
+			const { sm, tlSession, enqueuePrompt, fire } = await setupTeamWithCapturedEvents();
+			enqueuePrompt.mock.mockImplementation((sid: string, _msg: string, opts?: any) => {
+				const s = sm._sessions.get(sid);
+				if (s) {
+					// Mirror SessionManager's cap path: provenance is recorded but the
+					// prompt is parked/queued and no agent_start event is emitted.
+					s.lastPromptSource = opts?.source ?? "user";
+				}
+				return Promise.resolve({ queued: true, parked: true, id: "parked-auto-nudge" });
+			});
+
+			const BASE = 5 * 60 * 1000;
+			const SLACK = 1_000;
+
+			tlSession.status = "idle";
+			fire("agent_end");
+
+			// First no-workers nudge reaches SessionManager but is parked behind the
+			// errored/capped team-lead state. No agent_start follows.
+			t.mock.timers.tick(BASE + SLACK);
+			assert.equal(enqueuePrompt.mock.callCount(), 1,
+				"first parked no-workers nudge should be enqueued at the base delay");
+			assert.equal((enqueuePrompt.mock.calls[0].arguments[2] as any)?.source, "auto-nudge",
+				"the parked delivery must still be tagged as an auto-nudge");
+
+			// The next eligible no-workers nudge should still fire after the normal
+			// backoff delay. A sticky nudgePending flag suppresses this forever today.
+			tlSession.status = "idle";
+			t.mock.timers.tick(BASE * 2 + SLACK);
+			assert.equal(
+				enqueuePrompt.mock.callCount(),
+				2,
+				"nudgePending sticky regression: expected a second no-workers auto-nudge " +
+					"after the parked delivery did not start a lead turn",
+			);
+		} finally {
+			t.mock.timers.reset();
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
 // PromptSource semantics — reset vs. preserve behaviour of subscribeTeamLeadEvents
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds bounded auto-retry for retryable generic unexpected/internal agent errors at 1s, 5s, and 60s using the existing continuation-safe Retry path.
- Keeps provider overload/rate-limit on the existing long backoff policy and excludes deterministic auth/config/permission/content-policy/validation failures.
- Fixes TeamManager auto-nudge `nudgePending` so parked or failed nudges do not permanently suppress future team-lead nudges.
- Updates auto-retry and debugging docs.

## Validation

- `npx tsx --test tests/auto-retry-policy.test.ts tests/team-manager-idle-nudge-backoff.test.ts`
- Implementation gate passed: build, type check, repro test, unit/e2e suites, review/QA checks.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)