### PR TITLE
Fix fork cwd rebasing

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -223,6 +223,7 @@ See [docs/archived-proposal-reopen.md](archived-proposal-reopen.md) for the full
 - `sandboxed` is a typed field on `SessionInfo` (no `(session as any)._sandboxed` hack)
 - `restoreSessions()` in `session-manager.ts` skips sessions with missing `.jsonl` files
 - Failed restores create dormant entries that revive on client connect
+- **Forked session restore fails with `Stored session working directory does not exist` after source cleanup**: the fork clone kept stale source cwd metadata. `POST /api/sessions/:id/fork` must pass source cwd/worktree candidates as `preExistingAgentSessionOldCwds`, like Continue-Archived, so only top-level runtime cwd metadata is rebased before `switch_session`; message content mentioning old paths stays byte-identical. Pinned by `tests/e2e/sidebar-actions-server.spec.ts`.
 - **Server restarts are safe** — restarting the gateway never deletes worktrees, terminates sessions, or purges archives. All agent work survives intact. Orphaned resources can be cleaned up manually via Settings → Maintenance tab or the `/api/maintenance/*` REST endpoints.
 
 ## Staff inbox tools missing after restart / `[INBOX]` completion silently fails

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -697,14 +697,17 @@ This means crash recovery doesn't require the user to manually clean up pool det
 4. **Orphan detection**: Orphaned `session/*` worktrees (from ungraceful shutdowns where cleanup didn't run) are exposed in Settings → Maintenance and through the REST API (`GET /api/maintenance/orphaned-worktrees`, `POST /api/maintenance/cleanup-worktrees`). The same shared-path guard keeps live referenced paths out of the orphan list; unreferenced worktrees remain eligible for cleanup.
 5. **Restore**: After a restart, existing session worktrees are reused - the server reconnects to the worktree on disk without recreating it.
 
-**Session creation modes:** The session-setup pipeline (`src/server/agent/session-setup.ts`) handles four modes, all routed through the same plan/execute structure:
+**Session creation modes:** The session-setup pipeline (`src/server/agent/session-setup.ts`) handles these modes, all routed through the same plan/execute structure:
 
 | Mode | Triggered by | Worktree? | Seed context? |
 |---|---|---|---|
 | Normal (assistant) | `POST /api/sessions` for assistant types (goal/project/tool) | No | No |
 | Worktree | `POST /api/sessions` for non-goal, non-assistant sessions in a git repo | Yes (auto) | No |
 | Delegate | Parent session spawns a child via the `team_delegate` tool (or the `host.agents` pack capability) — both go through `OrchestrationCore`; see [orchestration.md](orchestration.md) | Inherits parent cwd | No |
+| Fork | `POST /api/sessions/:id/fork` | Fresh by default; can reuse the source cwd/worktree with `newWorktree:false` | No - agent CLI rehydrates from a clone of the source `.jsonl` |
 | Continue-Archived | `POST /api/sessions/:archivedId/continue` | Yes (fresh) if source had one | No - agent CLI rehydrates from a clone of the source `.jsonl` (no system-prompt injection) |
+
+Fork and Continue-Archived both clone transcript history and hand that clone to the agent with `switch_session`. Any path values copied from the source runtime must be treated as provenance, not as the fork/continue runtime. Their handlers therefore pass old cwd candidates as `preExistingAgentSessionOldCwds` so `session-setup.ts` can rebase only top-level runtime cwd metadata before `switch_session`. User and assistant message content is not inspected or rewritten, so ordinary mentions of old paths remain byte-identical. Fork stale-source coverage is pinned in `tests/e2e/sidebar-actions-server.spec.ts`.
 
 Continue-Archived sessions are covered in detail under [Continue-Archived sessions](#continue-archived-sessions) below.
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -10320,12 +10320,15 @@ async function handleApiRoute(
 			console.warn(`[fork] proposal-dir copy failed (non-fatal): ${err}`);
 		}
 
+		const oldTranscriptCwds = Array.from(new Set([ps.cwd, ps.worktreePath, source.cwd]
+			.filter((v): v is string => typeof v === "string" && v.length > 0)));
 		const createOpts: any = {
 			sessionId: forkId,
 			projectId,
 			sandboxed: !!ps.sandboxed,
 			worktreeOpts,
 			preExistingAgentSessionFile: destJsonl,
+			preExistingAgentSessionOldCwds: oldTranscriptCwds,
 			taskId: ps.taskId,
 			reattemptGoalId: ps.reattemptGoalId,
 			staffId: ps.staffId,

--- a/tests/e2e/sidebar-actions-server.spec.ts
+++ b/tests/e2e/sidebar-actions-server.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "./in-process-harness.js";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, realpathSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
 	agentEndPredicate,
@@ -44,6 +44,117 @@ async function waitUntilReady(id: string): Promise<any> {
 		const rec = await getPersisted(id);
 		return rec && rec.status !== "preparing" && rec.status !== "starting" ? rec : null;
 	}, { timeoutMs: 30_000, intervalMs: 150, label: `session ${id} left preparing` });
+}
+
+function branchExists(repoPath: string, branch: string): boolean {
+	try {
+		execFileSync("git", ["rev-parse", "--verify", `refs/heads/${branch}`], { cwd: repoPath, stdio: "pipe" });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function deleteBranchIfPresent(repoPath: string, branch: string): void {
+	try {
+		execFileSync("git", ["branch", "-D", branch], { cwd: repoPath, stdio: "pipe" });
+	} catch {
+		// Best-effort cleanup; assertions verify the stale state.
+	}
+}
+
+function removeWorktreeIfPresent(repoPath: string, worktreePath: string): void {
+	try {
+		execFileSync("git", ["worktree", "remove", "--force", worktreePath], { cwd: repoPath, stdio: "pipe" });
+	} catch {
+		// It may already have been removed by archive cleanup.
+	}
+	rmSync(worktreePath, { recursive: true, force: true });
+	try {
+		execFileSync("git", ["worktree", "prune"], { cwd: repoPath, stdio: "pipe" });
+	} catch {
+		// Best-effort cleanup.
+	}
+}
+
+/** Slugify the way `formatAgentSessionFilePath` does (no collapse, just non-alnum→`-`). */
+function slugifyCwd(cwd: string): string {
+	return cwd.replace(/[^a-zA-Z0-9]/g, "-");
+}
+
+function globalAgentSessionsDir(): string {
+	const env = process.env.BOBBIT_AGENT_DIR || process.env.PI_CODING_AGENT_DIR;
+	const base = env ?? join(homedir(), ".bobbit", "agent");
+	return join(base, "sessions");
+}
+
+/** Find a `.jsonl` file in a sessions slug-dir whose name contains `sessionId`. */
+function findClonedJsonl(slugDir: string, sessionId: string): string | null {
+	if (!existsSync(slugDir)) return null;
+	try {
+		const entries = readdirSync(slugDir);
+		const match = entries.find((f) => f.endsWith(`_${sessionId}.jsonl`));
+		return match ? join(slugDir, match) : null;
+	} catch {
+		return null;
+	}
+}
+
+type RuntimeCwdRecord = { type: "system" | "session"; cwd: string };
+
+function readRuntimeCwdRecords(jsonlPath: string): RuntimeCwdRecord[] {
+	const records: RuntimeCwdRecord[] = [];
+	for (const line of readFileSync(jsonlPath, "utf8").split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		try {
+			const parsed = JSON.parse(trimmed);
+			if ((parsed?.type === "system" || parsed?.type === "session") && typeof parsed.cwd === "string") {
+				records.push({ type: parsed.type, cwd: parsed.cwd });
+			}
+		} catch {
+			// Ignore malformed transcript lines; the mock agent does the same.
+		}
+	}
+	return records;
+}
+
+function readRuntimeCwds(jsonlPath: string): string[] {
+	return readRuntimeCwdRecords(jsonlPath).map((record) => record.cwd);
+}
+
+function hasRuntimeCwdRecord(jsonlPath: string, type: RuntimeCwdRecord["type"], cwd: string): boolean {
+	return readRuntimeCwdRecords(jsonlPath).some((record) => record.type === type && record.cwd === cwd);
+}
+
+function ensureStaleRuntimeCwdMetadata(jsonlPath: string, cwd: string, sessionId: string): void {
+	if (!hasRuntimeCwdRecord(jsonlPath, "system", cwd)) {
+		appendFileSync(jsonlPath, `${JSON.stringify({ type: "system", subtype: "init", cwd })}\n`);
+	}
+	if (!hasRuntimeCwdRecord(jsonlPath, "session", cwd)) {
+		appendFileSync(jsonlPath, `${JSON.stringify({
+			type: "session",
+			version: 3,
+			id: `pi-style-${sessionId}`,
+			timestamp: "2026-06-17T12:20:31.770Z",
+			cwd,
+		})}\n`);
+	}
+}
+
+function appendOldCwdMessageContentSentinels(jsonlPath: string, cwd: string, marker: string): { userLine: string; assistantLine: string } {
+	const userLine = JSON.stringify({
+		type: "message",
+		id: `${marker}-user`,
+		message: { role: "user", content: [{ type: "text", text: `${marker} user mentions old cwd ${cwd}` }] },
+	});
+	const assistantLine = JSON.stringify({
+		type: "message",
+		id: `${marker}-assistant`,
+		message: { role: "assistant", content: [{ type: "text", text: `${marker} assistant mentions old cwd ${cwd}` }] },
+	});
+	appendFileSync(jsonlPath, `${userLine}\n${assistantLine}\n`);
+	return { userLine, assistantLine };
 }
 
 // Fork's worktree-choice test allocates a real worktree; disable the warm pool
@@ -220,12 +331,13 @@ test.describe("sidebar actions server endpoints", () => {
 // can allocate a distinct worktree/branch and newWorktree=false can reuse the
 // source session's worktree path.
 test.describe("fork worktree choice", () => {
+	let baseDir: string;
 	let repoPath: string;
 	let projectId: string;
 
 	test.beforeAll(async () => {
-		const base = realpathSync(tmpdir()) + `/bobbit-e2e-fork-wt-${process.pid}-${Date.now()}`;
-		repoPath = join(base, "repo");
+		baseDir = realpathSync(tmpdir()) + `/bobbit-e2e-fork-wt-${process.pid}-${Date.now()}`;
+		repoPath = join(baseDir, "repo");
 		mkdirSync(repoPath, { recursive: true });
 		execFileSync("git", ["init", "--initial-branch=master"], { cwd: repoPath });
 		execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: repoPath });
@@ -238,6 +350,15 @@ test.describe("fork worktree choice", () => {
 		});
 		expect(reg.status).toBe(201);
 		projectId = (await reg.json()).id;
+	});
+
+	test.afterAll(async () => {
+		if (projectId) {
+			await apiFetch(`/api/projects/${projectId}`, { method: "DELETE" }).catch(() => {});
+		}
+		if (baseDir) {
+			rmSync(baseDir, { recursive: true, force: true });
+		}
 	});
 
 	test("newWorktree=true allocates a distinct worktree/branch; newWorktree=false reuses the source worktree", async ({ gateway }) => {
@@ -326,6 +447,98 @@ test.describe("fork worktree choice", () => {
 					body: JSON.stringify({ base_ref: "" }),
 				}).catch(() => {});
 			}
+		}
+	});
+
+	test("newWorktree=true rebases cloned runtime cwd metadata off a stale source worktree", async ({ gateway }) => {
+		const created: string[] = [];
+		let sourceId: string | undefined;
+		let forkId: string | undefined;
+
+		const repoBaseRef = await apiFetch(`/api/projects/${projectId}/config`, {
+			method: "PUT",
+			body: JSON.stringify({ base_ref: "master" }),
+		});
+		expect(repoBaseRef.status, await repoBaseRef.text()).toBe(200);
+
+		const sresp = await apiFetch("/api/sessions", {
+			method: "POST",
+			body: JSON.stringify({ cwd: repoPath, worktree: true, projectId }),
+		});
+		expect(sresp.status, await sresp.clone().text()).toBe(201);
+		sourceId = (await sresp.json()).id;
+		created.push(sourceId!);
+
+		try {
+			const srcRec = await waitUntilReady(sourceId!);
+			expect(srcRec.projectId).toBe(projectId);
+			expect(srcRec.worktreePath).toBeTruthy();
+			expect(srcRec.cwd).toBe(srcRec.worktreePath);
+			expect(srcRec.branch).toBe(`session/${sourceId!.slice(0, 8)}`);
+			expect(existsSync(srcRec.worktreePath), "source worktree should exist before staling it").toBe(true);
+			expect(branchExists(repoPath, srcRec.branch), "source branch should exist before staling it").toBe(true);
+
+			const transcriptMarker = `FORK_STALE_CWD_TRANSCRIPT_${Date.now()}`;
+			await sendPromptAndWait(sourceId!, `${transcriptMarker} hello from stale fork source`);
+
+			const sourceJsonl = await pollUntil<string>(() => {
+				const file = gateway.sessionManager.getPersistedSession(sourceId!)?.agentSessionFile;
+				return file && existsSync(file) ? file : "";
+			}, {
+				timeoutMs: 10_000,
+				intervalMs: 100,
+				label: "source session jsonl exists",
+			});
+			ensureStaleRuntimeCwdMetadata(sourceJsonl, srcRec.worktreePath, sourceId!);
+			const contentMarker = `FORK_STALE_CWD_CONTENT_${Date.now()}`;
+			const { userLine, assistantLine } = appendOldCwdMessageContentSentinels(sourceJsonl, srcRec.worktreePath, contentMarker);
+			expect(readRuntimeCwdRecords(sourceJsonl), "source transcript should contain stale system cwd metadata before fork").toContainEqual({ type: "system", cwd: srcRec.worktreePath });
+			expect(readRuntimeCwdRecords(sourceJsonl), "source transcript should contain stale Pi-style session cwd metadata before fork").toContainEqual({ type: "session", cwd: srcRec.worktreePath });
+
+			const forkResp = await apiFetch(`/api/sessions/${sourceId}/fork`, {
+				method: "POST",
+				body: JSON.stringify({ newWorktree: true }),
+			});
+			expect(forkResp.status, await forkResp.clone().text()).toBe(201);
+			forkId = (await forkResp.json()).id;
+			created.push(forkId!);
+
+			const forkRec = await waitUntilReady(forkId!);
+			expect(forkRec.projectId).toBe(projectId);
+			expect(forkRec.archived).toBeFalsy();
+			expect(forkRec.branch).toBe(`session/${forkId!.slice(0, 8)}`);
+			expect(forkRec.branch).not.toBe(srcRec.branch);
+			expect(forkRec.worktreePath).toBeTruthy();
+			expect(forkRec.worktreePath).not.toBe(srcRec.worktreePath);
+			expect(forkRec.cwd).toBe(forkRec.worktreePath);
+			expect(existsSync(forkRec.worktreePath), "fork worktree should exist").toBe(true);
+			expect(branchExists(repoPath, forkRec.branch), "fork branch should exist").toBe(true);
+
+			await deleteSession(sourceId!);
+			removeWorktreeIfPresent(repoPath, srcRec.worktreePath);
+			deleteBranchIfPresent(repoPath, srcRec.branch);
+			expect(existsSync(srcRec.worktreePath), "source worktree must be deleted before inspecting fork clone").toBe(false);
+			expect(branchExists(repoPath, srcRec.branch), "source branch must be deleted before inspecting fork clone").toBe(false);
+
+			const sessionsDir = globalAgentSessionsDir();
+			const sourceSlugDir = join(sessionsDir, `--${slugifyCwd(srcRec.worktreePath)}--`);
+			const forkWtSlugDir = join(sessionsDir, `--${slugifyCwd(forkRec.worktreePath)}--`);
+			const clonedAtSource = findClonedJsonl(sourceSlugDir, forkId!);
+			const clonedAtForkWt = findClonedJsonl(forkWtSlugDir, forkId!);
+
+			expect(clonedAtSource, "fork cloned .jsonl must not live under the deleted source worktree slug").toBeNull();
+			expect(clonedAtForkWt, "fork cloned .jsonl must live under the fork worktree-cwd slug").toBeTruthy();
+			expect(readFileSync(clonedAtForkWt!, "utf8"), "fork cloned transcript should include the source prompt marker").toContain(transcriptMarker);
+			const clonedText = readFileSync(clonedAtForkWt!, "utf8");
+			expect(clonedText, "ordinary user message content mentioning the old cwd must remain byte-identical").toContain(userLine);
+			expect(clonedText, "ordinary assistant message content mentioning the old cwd must remain byte-identical").toContain(assistantLine);
+
+			const clonedRuntimeCwdRecords = readRuntimeCwdRecords(clonedAtForkWt!);
+			expect(readRuntimeCwds(clonedAtForkWt!), "fork runtime cwd metadata should be rebased off the deleted source worktree").not.toContain(srcRec.worktreePath);
+			expect(clonedRuntimeCwdRecords, "fork system cwd metadata should reference the fresh fork worktree cwd").toContainEqual({ type: "system", cwd: forkRec.worktreePath });
+			expect(clonedRuntimeCwdRecords, "fork Pi-style session cwd metadata should reference the fresh fork worktree cwd").toContainEqual({ type: "session", cwd: forkRec.worktreePath });
+		} finally {
+			for (const id of created.reverse()) await deleteSession(id);
 		}
 	});
 });


### PR DESCRIPTION
## Summary

- Rebase cloned fork transcript runtime cwd metadata from source cwd/worktree paths to the fork cwd before switch_session.
- Add E2E coverage for stale worktree-backed fork transcripts, including content-preservation sentinels.
- Document the fork/continue transcript cwd rebasing invariant and debugging symptom.

## Verification

- npm run check
- npm run test:unit
- npm run test:e2e
- npm run test:e2e:run -- tests/e2e/sidebar-actions-server.spec.ts --grep "rebases cloned runtime cwd metadata"

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)