### PR TITLE
Preserve route when archiving goals

### DIFF
--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -14,7 +14,6 @@ import {
 // import it without pulling the entire app-shell graph.
 import { gatewayFetch, GW_TOKEN_KEY, GW_URL_KEY } from "./gateway-fetch.js";
 export { gatewayFetch };
-import { setHashRoute } from "./routing.js";
 import { sessionHueRotation, sessionColorMap } from "./session-colors.js";
 import { RemoteAgent } from "./remote-agent.js";
 import { showFaviconBadge } from "./favicon-badge.js";

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -1724,7 +1724,6 @@ export async function deleteGoal(id: string): Promise<void> {
 				const allIds = collectGoalIdsFor(id);
 				eagerMarkArchived(allIds);
 			}
-			setHashRoute("landing");
 			await refreshSessions();
 		}
 		return;
@@ -1751,7 +1750,6 @@ export async function deleteGoal(id: string): Promise<void> {
 		const res = await gatewayFetch(`/api/goals/${id}?cascade=false`, { method: "DELETE" });
 		if (!res.ok) throw await errorFromResponse(res, `Failed: ${res.status}`);
 		eagerMarkArchived([id]);
-		setHashRoute("landing");
 		await refreshSessions();
 	} catch (err) {
 		const { message, code, stack } = errorDetails(err);

--- a/src/app/goal-dashboard.ts
+++ b/src/app/goal-dashboard.ts
@@ -70,6 +70,43 @@ export interface CommitInfo {
 
 let currentGoalId: string | null = null;
 let currentGoal: Goal | null = null;
+
+function syncCurrentGoalLifecycleFromState(): void {
+	if (!currentGoal || !currentGoalId || currentGoal.id !== currentGoalId) return;
+	const stateGoal = state.goals.find(g => g.id === currentGoalId);
+	if (!stateGoal) return;
+
+	const archived = stateGoal.archived === true ? true : undefined;
+	const archivedAt = archived ? (stateGoal.archivedAt ?? currentGoal.archivedAt ?? Date.now()) : undefined;
+	const paused = stateGoal.paused === true ? true : undefined;
+	const setupStatus = stateGoal.setupStatus ?? currentGoal.setupStatus;
+	const setupError = stateGoal.setupError;
+	const updatedAt = stateGoal.updatedAt ?? currentGoal.updatedAt;
+
+	if (
+		currentGoal.archived === archived
+		&& currentGoal.archivedAt === archivedAt
+		&& currentGoal.paused === paused
+		&& currentGoal.setupStatus === setupStatus
+		&& currentGoal.setupError === setupError
+		&& currentGoal.state === stateGoal.state
+		&& currentGoal.updatedAt === updatedAt
+	) {
+		return;
+	}
+
+	currentGoal = {
+		...currentGoal,
+		archived,
+		archivedAt,
+		paused,
+		setupStatus,
+		setupError,
+		state: stateGoal.state,
+		updatedAt,
+	};
+}
+
 let tasks: Task[] = [];
 let commits: CommitInfo[] = [];
 let gates: GateState[] = [];
@@ -709,10 +746,11 @@ export async function loadDashboardData(goalId: string): Promise<void> {
 		const sidebarIdx = state.goals.findIndex((g) => g.id === goalId);
 		if (sidebarIdx >= 0) {
 			const sidebarGoal = state.goals[sidebarIdx];
-			if (sidebarGoal.setupStatus !== currentGoal!.setupStatus || sidebarGoal.state !== currentGoal!.state) {
+			if (sidebarGoal.setupStatus !== currentGoal!.setupStatus || sidebarGoal.setupError !== currentGoal!.setupError || sidebarGoal.state !== currentGoal!.state) {
 				state.goals[sidebarIdx] = { ...sidebarGoal, setupStatus: currentGoal!.setupStatus, setupError: currentGoal!.setupError, state: currentGoal!.state };
 			}
 		}
+		syncCurrentGoalLifecycleFromState();
 
 		if (tasksRes.ok) {
 			const data = await tasksRes.json();
@@ -922,9 +960,10 @@ export async function refreshDashboardGoal(): Promise<void> {
 			currentGoal = await res.json();
 			// Propagate setupStatus to sidebar's goal list so it stays in sync
 			const idx = state.goals.findIndex((g) => g.id === currentGoalId);
-			if (idx >= 0 && currentGoal!.setupStatus !== state.goals[idx].setupStatus) {
+			if (idx >= 0 && (currentGoal!.setupStatus !== state.goals[idx].setupStatus || currentGoal!.setupError !== state.goals[idx].setupError)) {
 				state.goals[idx] = { ...state.goals[idx], setupStatus: currentGoal!.setupStatus, setupError: currentGoal!.setupError };
 			}
+			syncCurrentGoalLifecycleFromState();
 			renderApp();
 		}
 	} catch { /* ignore - polling will catch up */ }
@@ -1856,21 +1895,21 @@ function renderNavBar(goal: Goal): TemplateResult {
 }
 
 function renderTeamButton(goal: Goal): TemplateResult {
+	if (goal.archived) {
+		return html`
+			<div class="btn-split">
+				<button class="btn-split-main" ?disabled=${true} style="opacity:0.5;cursor:default">
+					<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="5" rx="1"/><path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8"/><path d="M10 12h4"/></svg><span>Archived</span>
+				</button>
+			</div>
+		`;
+	}
 	if (teamActive) {
 		return html`
 			<div class="btn-split">
 				<button class="btn-split-main danger" title="Stop the goal team" @click=${() => handleEndTeam(goal.id)} ?disabled=${teamStopping}>
 					${svgStop}
 					<span>${teamStopping ? "Stopping\u2026" : "Stop Team"}</span>
-				</button>
-			</div>
-		`;
-	}
-	if (goal.archived) {
-		return html`
-			<div class="btn-split">
-				<button class="btn-split-main" ?disabled=${true} style="opacity:0.5;cursor:default">
-					<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="5" rx="1"/><path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8"/><path d="M10 12h4"/></svg><span>Archived</span>
 				</button>
 			</div>
 		`;
@@ -3094,6 +3133,7 @@ export function renderGoalDashboard(): TemplateResult {
 		`;
 	}
 
+	syncCurrentGoalLifecycleFromState();
 	const activeTab = dashboardTab;
 
 	const isArchived = currentGoal.archived === true;

--- a/tests/e2e/ui/goal-archive-always-on.spec.ts
+++ b/tests/e2e/ui/goal-archive-always-on.spec.ts
@@ -9,26 +9,33 @@
  *
  * Coverage:
  *  1. Sidebar goal with no PR and no team — trash icon renders, the standard
- *     "Archive Goal" confirm modal opens, cancel preserves the goal, confirm
- *     archives it, and reloading the UI shows the goal no longer present in
- *     the active goal list (persistence).
+ *     "Archive Goal" confirm modal opens, cancel preserves the goal and route,
+ *     confirm archives it without leaving an unrelated session route, and
+ *     reloading the UI shows the goal no longer present in the active goal list
+ *     (persistence).
  *  2. Sidebar goal with an active team — trash icon renders, the modal copy
  *     adapts ("Stop team and archive goal?", "Stop & Archive"), confirming
- *     tears down the team and archives the goal.
+ *     tears down the team and archives the goal without changing route.
  *  3. Goal dashboard for a no-team goal — Archive button is present, enabled,
- *     and successfully archives the goal via the same confirm flow.
+ *     and successfully archives the goal without leaving the dashboard route;
+ *     the archived/read-only state remains visible.
+ *  4. Cascade archive for a parent goal with descendants preserves the current
+ *     route after confirmation.
  */
 import type { Page } from "@playwright/test";
 import { test, expect } from "../gateway-harness.js";
 import {
 	createGoal,
 	deleteGoal,
+	createSession,
+	deleteSession,
 	apiFetch,
 	startTeam,
 	teardownTeam,
 	waitForSessionStatus,
+	seedTeamLeadHeader,
 } from "../e2e-setup.js";
-import { openApp, navigateToHash } from "./ui-helpers.js";
+import { activeSessionId, openApp, navigateToHash } from "./ui-helpers.js";
 
 /**
  * Read the live `state.goals` list from the page and return the entry with
@@ -67,6 +74,35 @@ async function teamLeadActiveForGoal(page: Page, goalId: string): Promise<boolea
 	}, goalId);
 }
 
+async function currentHash(page: Page): Promise<string> {
+	return page.evaluate(() => window.location.hash);
+}
+
+async function navigateToSessionRoute(page: Page, sessionId: string): Promise<string> {
+	await navigateToHash(page, `#/session/${sessionId}`);
+	await expect.poll(
+		async () => activeSessionId(page),
+		{ timeout: 10_000 },
+	).toBe(sessionId);
+	return currentHash(page);
+}
+
+async function expectHashPreserved(page: Page, expectedHash: string, label: string): Promise<void> {
+	const actualHash = await currentHash(page);
+	expect(
+		actualHash,
+		`archive route preservation: ${label} should preserve window.location.hash`,
+	).toBe(expectedHash);
+}
+
+async function expectSelectedSessionPreserved(page: Page, expectedSessionId: string, label: string): Promise<void> {
+	const actualSessionId = await activeSessionId(page);
+	expect(
+		actualSessionId,
+		`archive route preservation: ${label} should preserve selected session`,
+	).toBe(expectedSessionId);
+}
+
 function sidebarGoalRow(page: Page, goalId: string) {
 	return page.locator(`[data-nav-id="goal:${goalId}"]`);
 }
@@ -98,9 +134,11 @@ test.describe("Goal archive button (always-on)", () => {
 		const title = `Archive icon visibility ${Date.now()}`;
 		const goal = await createGoal({ title, team: false, worktree: false });
 		const goalId = goal.id;
+		const routeSessionId = await createSession();
 
 		try {
 			await openApp(page);
+			const sessionHash = await navigateToSessionRoute(page, routeSessionId);
 
 			// The action strip is hover-revealed on desktop. Scope to the goal row
 			// by id so the sidebar quick action and modal confirm button don't race.
@@ -112,12 +150,15 @@ test.describe("Goal archive button (always-on)", () => {
 			await expect(dialog).toContainText(title);
 			await dialog.getByRole("button", { name: "Cancel", exact: true }).click();
 			await expect(dialog).toBeHidden({ timeout: 5_000 });
+			await expectHashPreserved(page, sessionHash, "canceling normal sidebar archive");
+			await expectSelectedSessionPreserved(page, routeSessionId, "canceling normal sidebar archive");
 
 			const stillThere = await apiFetch(`/api/goals/${goalId}`);
 			expect(stillThere.ok).toBe(true);
 
 			// --- Confirm path ---
 			dialog = await openSidebarArchiveDialog(page, goalId, "Archive Goal");
+			const hashBeforeConfirm = await currentHash(page);
 			await dialog.getByRole("button", { name: "Archive", exact: true }).click();
 			await expect(dialog).toBeHidden({ timeout: 5_000 });
 
@@ -128,6 +169,8 @@ test.describe("Goal archive button (always-on)", () => {
 				const g = await r.json();
 				return g.archived === true ? "archived" : "active";
 			}, { timeout: 10_000 }).toBe("archived");
+			await expectHashPreserved(page, hashBeforeConfirm, "normal sidebar archive while viewing unrelated session");
+			await expectSelectedSessionPreserved(page, routeSessionId, "normal sidebar archive while viewing unrelated session");
 
 			// --- Persistence across reload ---
 			// Reload the UI and assert the goal no longer appears in the
@@ -152,6 +195,7 @@ test.describe("Goal archive button (always-on)", () => {
 			expect(sidebarHasTitle).toBe(0);
 		} finally {
 			await deleteGoal(goalId);
+			await deleteSession(routeSessionId);
 		}
 	});
 
@@ -173,6 +217,7 @@ test.describe("Goal archive button (always-on)", () => {
 		}
 		const goal = await probeResp.json();
 		const goalId = goal.id;
+		const routeSessionId = await createSession();
 		let teamLeadId: string | undefined;
 
 		try {
@@ -180,6 +225,7 @@ test.describe("Goal archive button (always-on)", () => {
 			await waitForSessionStatus(teamLeadId, "idle");
 
 			await openApp(page);
+			const sessionHash = await navigateToSessionRoute(page, routeSessionId);
 
 			// Wait for the client-side state to register the team-lead
 			// session as non-terminated under this goal — that's the exact
@@ -199,6 +245,8 @@ test.describe("Goal archive button (always-on)", () => {
 			await expect(confirmBtn).toBeVisible();
 
 			// Confirm — teardown then DELETE.
+			const hashBeforeConfirm = await currentHash(page);
+			expect(hashBeforeConfirm, "archive route preservation: active-team setup should start from the unrelated session hash").toBe(sessionHash);
 			await confirmBtn.click();
 			await expect(dialog).toBeHidden({ timeout: 10_000 });
 
@@ -221,6 +269,8 @@ test.describe("Goal archive button (always-on)", () => {
 				const s = await r.json();
 				return s.status;
 			}, { timeout: 15_000 }).toMatch(/^(terminated|archived)$/);
+			await expectHashPreserved(page, hashBeforeConfirm, "active-team Stop & Archive while viewing unrelated session");
+			await expectSelectedSessionPreserved(page, routeSessionId, "active-team Stop & Archive while viewing unrelated session");
 
 			// UI persistence: reload, goal is no longer in the active list.
 			await page.reload();
@@ -234,6 +284,7 @@ test.describe("Goal archive button (always-on)", () => {
 		} finally {
 			await teardownTeam(goalId).catch(() => {});
 			await deleteGoal(goalId);
+			await deleteSession(routeSessionId);
 		}
 	});
 
@@ -245,6 +296,7 @@ test.describe("Goal archive button (always-on)", () => {
 		try {
 			await openApp(page);
 			await navigateToHash(page, `#/goal/${goalId}`);
+			const dashboardHash = await currentHash(page);
 
 			// The dashboard Archive button is a `btn-icon` with the goal's
 			// archive title. After the fix it must be present and enabled
@@ -266,8 +318,75 @@ test.describe("Goal archive button (always-on)", () => {
 				const g = await r.json();
 				return g.archived === true ? "archived" : "active";
 			}, { timeout: 10_000 }).toBe("archived");
+			await expectHashPreserved(page, dashboardHash, "goal dashboard self-archive");
+			await expect(page.getByText(/This goal was archived .*Dashboard is read-only\./)).toBeVisible({ timeout: 10_000 });
+			const archivedBtn = page.locator(".dashboard-container").getByRole("button", { name: "Archived", exact: true }).first();
+			await expect(archivedBtn).toBeVisible({ timeout: 5_000 });
+			await expect(archivedBtn).toBeDisabled();
 		} finally {
 			await deleteGoal(goalId);
+		}
+	});
+
+	test("cascade archive: confirming parent archive preserves the current route", async ({ page, gateway }) => {
+		const stamp = Date.now();
+		const parentTitle = `Cascade route parent ${stamp}`;
+		const childTitle = `Cascade route child ${stamp}`;
+		const parent = await createGoal({
+			title: parentTitle,
+			team: false,
+			worktree: false,
+			subgoalsAllowed: true,
+			maxNestingDepth: 2,
+		});
+		const parentId = parent.id;
+		let childId: string | undefined;
+		const routeSessionId = await createSession();
+
+		try {
+			const childResp = await apiFetch(`/api/goals/${parentId}/spawn-child`, {
+				method: "POST",
+				headers: seedTeamLeadHeader(gateway, parentId),
+				body: JSON.stringify({
+					planId: `cascade-route-${stamp}`,
+					title: childTitle,
+					spec: "Child goal for cascade archive route-preservation browser regression coverage.",
+				}),
+			});
+			if (childResp.status !== 201) {
+				throw new Error(`spawn child for cascade archive test failed ${childResp.status}: ${await childResp.text()}`);
+			}
+			childId = (await childResp.json()).id;
+
+			await openApp(page);
+			const sessionHash = await navigateToSessionRoute(page, routeSessionId);
+			await expect.poll(async () => {
+				const v = await readGoalFromState(page, childId!);
+				return v?.present === true;
+			}, { timeout: 10_000 }).toBe(true);
+
+			const dialog = await openSidebarArchiveDialog(page, parentId, "Archive goal & descendants");
+			await expect(dialog).toContainText(parentTitle);
+			await expect(dialog).toContainText("1 descendant goal");
+			const hashBeforeConfirm = await currentHash(page);
+			expect(hashBeforeConfirm, "archive route preservation: cascade setup should start from the unrelated session hash").toBe(sessionHash);
+			await dialog.getByRole("button", { name: "Archive parent + 1 descendant", exact: true }).click();
+			await expect(dialog).toBeHidden({ timeout: 10_000 });
+
+			await expect.poll(async () => {
+				const parentResp = await apiFetch(`/api/goals/${parentId}`);
+				const childResp = childId ? await apiFetch(`/api/goals/${childId}`) : null;
+				if (!parentResp.ok || !childResp?.ok) return "missing";
+				const parentGoal = await parentResp.json();
+				const childGoal = await childResp.json();
+				return parentGoal.archived === true && childGoal.archived === true ? "archived" : "active";
+			}, { timeout: 15_000 }).toBe("archived");
+			await expectHashPreserved(page, hashBeforeConfirm, "cascade archive while viewing unrelated session");
+			await expectSelectedSessionPreserved(page, routeSessionId, "cascade archive while viewing unrelated session");
+		} finally {
+			if (childId) await deleteGoal(childId);
+			await deleteGoal(parentId);
+			await deleteSession(routeSessionId);
 		}
 	});
 });


### PR DESCRIPTION
## Summary
- Preserve the current route/context after confirming goal archive flows instead of forcing landing navigation.
- Sync archived lifecycle state into the open goal dashboard so self-archive immediately renders read-only archived UI.
- Add browser E2E regression coverage for sidebar, active-team, dashboard, cascade, and cancel archive paths.

## Tests
- npm run check
- npm run build && npx playwright test tests/e2e/ui/goal-archive-always-on.spec.ts --reporter=line

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)