### PR TITLE
Improve archived worktree maintenance UX

### DIFF
--- a/docs/design/archived-session-worktree-api-data-plan.md
+++ b/docs/design/archived-session-worktree-api-data-plan.md
@@ -1,0 +1,425 @@
+# Archived session worktree API/data contract plan
+
+## Purpose
+
+Define the API contract that supports the revised Settings → Maintenance archived worktree UX while preserving the existing cleanup safety model and current endpoint compatibility.
+
+Primary UX question: **how many archived-session worktrees can be cleaned safely right now?** The API should make this answer explicit with `readyToClean` / `removableWorktrees`, while moving skipped and diagnostic data behind reasoned groups.
+
+## Existing endpoints to preserve
+
+### `GET /api/maintenance/archived-session-worktrees`
+
+Current query:
+
+- `includeAlreadyCleaned=1` — include `already-cleaned` rows for diagnostics. Default scans omit sessions whose rows are all already cleaned.
+
+### `POST /api/maintenance/cleanup-archived-session-worktrees`
+
+Current request support must remain valid:
+
+```ts
+type CleanupArchivedSessionWorktreesRequestV1 =
+  | { mode: "all" }
+  | {
+      mode: "selected";
+      sessionIds?: string[];
+      worktrees?: Array<{
+        sessionId: string;
+        repo?: string;
+        path?: string;
+        key?: string;
+      }>;
+    };
+```
+
+Existing validation must remain:
+
+- Missing/unknown `mode` returns `400`.
+- `mode: "all"` rejects selectors.
+- `mode: "selected"` accepts exactly one selector type: `sessionIds` or `worktrees`.
+- Empty selected input is a zero-count no-op.
+- Cleanup re-runs scan and does not trust stale client state.
+
+## Scan response contract
+
+Return the current `sessions` tree and legacy count names, then add flattened item and grouping metadata for the UX. Legacy fields remain authoritative for old clients; new fields are additive.
+
+```ts
+interface ArchivedSessionWorktreeScanResponseV2 {
+  sessions: ArchivedSessionWorktreeSessionV2[];
+  items: ArchivedSessionWorktreeItemV2[]; // flattened copy of every session.worktrees row included in this response
+  counts: ArchivedSessionWorktreeScanCountsV2;
+  groups: ArchivedSessionWorktreeGroup[];
+  selectionPresets: ArchivedSessionWorktreeSelectionPreset[];
+  generatedAt: number;
+}
+
+interface ArchivedSessionWorktreeScanCountsV2 {
+  // Existing names; keep for compatibility.
+  archivedSessions: number;
+  sessionsWithWorktrees: number; // legacy label: has worktree metadata, not necessarily removable
+  removableWorktrees: number; // same value as readyToClean
+  skippedWorktrees: number;
+  alreadyCleanedWorktrees: number;
+
+  // UX-facing names.
+  totalItems: number;
+  readyToClean: number;
+  defaultSelected: number; // rows the UI should select after scan; initially equals readyToClean
+  alreadyCleaned: number;
+  ineligible: number;
+  needsAttention: number;
+  failed: number;
+
+  byDisposition: Record<ArchivedWorktreeDisposition, number>;
+  byReason: Partial<Record<ArchivedWorktreeReason, number>>;
+  bySelectionCategory: Partial<Record<ArchivedWorktreeSelectionCategory, number>>;
+}
+```
+
+### Dispositions
+
+`status` stays compatible with the current implementation. `disposition` is the UX grouping field.
+
+```ts
+type ArchivedWorktreeLegacyStatus = "removable" | "skipped" | "already-cleaned";
+
+type ArchivedWorktreeDisposition =
+  | "ready-to-clean"      // actionable now
+  | "already-cleaned"     // no worktree remains; hidden by default unless diagnostics requested
+  | "ineligible"          // safe skip; not actionable through this feature
+  | "needs-attention"     // not safe to remove automatically, but may merit manual inspection
+  | "failed";             // scan/evaluation failed
+```
+
+Mapping:
+
+- `status: "removable"` → `disposition: "ready-to-clean"`.
+- `status: "already-cleaned"` → `disposition: "already-cleaned"`.
+- `status: "skipped"` with `reason: "stale-worktree-directory"` → `disposition: "needs-attention"`.
+- Other `status: "skipped"` reasons → `disposition: "ineligible"`.
+- Scan exceptions, if surfaced in the future, use `disposition: "failed"` and `reason: "scan-error"`.
+
+### Reason codes
+
+Use machine-readable reason codes in `reason`. Do not make the UI parse `detail` text.
+
+```ts
+type ArchivedWorktreeReason =
+  | "safe-archived-session-worktree"
+  | "already-cleaned"
+  | "no-worktree-path"
+  | "missing-repo-path"
+  | "sandbox-container-path"
+  | "delegate-shared-worktree"
+  | "stale-worktree-directory"
+  | "referenced-by-live-session"
+  | "referenced-by-live-goal"
+  | "referenced-by-live-team"
+  | "referenced-by-staff"
+  | "scan-error";
+
+type ArchivedWorktreeReasonCategory =
+  | "safe"
+  | "already-cleaned"
+  | "missing-metadata"
+  | "container-path"
+  | "shared-delegate"
+  | "stale-path"
+  | "referenced-record"
+  | "error";
+```
+
+Reason category mapping:
+
+| Reason | Category | Default UX treatment |
+| --- | --- | --- |
+| `safe-archived-session-worktree` | `safe` | visible/actionable |
+| `already-cleaned` | `already-cleaned` | hidden by default |
+| `no-worktree-path` | `missing-metadata` | troubleshooting only |
+| `missing-repo-path` | `missing-metadata` | troubleshooting only |
+| `sandbox-container-path` | `container-path` | troubleshooting only |
+| `delegate-shared-worktree` | `shared-delegate` | troubleshooting only |
+| `stale-worktree-directory` | `stale-path` | needs-attention troubleshooting |
+| `referenced-by-live-session` | `referenced-record` | troubleshooting only |
+| `referenced-by-live-goal` | `referenced-record` | troubleshooting only |
+| `referenced-by-live-team` | `referenced-record` | troubleshooting only |
+| `referenced-by-staff` | `referenced-record` | troubleshooting only |
+| `scan-error` | `error` | needs-attention troubleshooting |
+
+### Session and item metadata
+
+`ArchivedSessionWorktreeSessionV2` keeps the existing session envelope and uses the same item shape as the flattened `items` array.
+
+```ts
+interface ArchivedSessionWorktreeSessionV2 {
+  id: string;
+  title: string;
+  archivedAt?: number;
+  projectId?: string;
+  projectName?: string;
+  goalId?: string;
+  teamGoalId?: string;
+  delegateOf?: string;
+  parentSessionId?: string;
+  childKind?: string;
+  sandboxed?: boolean;
+  branch?: string;
+  repoPath?: string;
+  worktreePath?: string;
+  worktrees: ArchivedSessionWorktreeItemV2[];
+}
+```
+
+Each row should contain enough metadata for a flat actionable list, grouped examples, and selected cleanup without consulting parent session objects.
+
+```ts
+interface ArchivedSessionWorktreeItemV2 {
+  // Stable selector identity.
+  key: string; // `${sessionId}:${repo}:${normalizedPath}`
+  sessionId: string;
+
+  // Duplicated session metadata for flat rendering.
+  title: string;
+  archivedAt?: number;
+  projectId?: string;
+  projectName?: string;
+  goalId?: string;
+  teamGoalId?: string;
+  delegateOf?: string;
+  parentSessionId?: string;
+  childKind?: string;
+  sandboxed?: boolean;
+
+  // Worktree/repo metadata.
+  repo: string; // `.` for root repo; component key for multi-repo rows
+  repoPath: string;
+  repoDisplayName: string; // `.` becomes project/repo name; component keys remain readable
+  path: string;
+  branch?: string;
+  source: "repoWorktrees" | "sessionWorktree";
+
+  // Existing safety/evaluation fields.
+  pathExists: boolean;
+  gitWorktreeMetadataExists: boolean;
+  localBranchExists: boolean;
+  status: ArchivedWorktreeLegacyStatus;
+  reason: ArchivedWorktreeReason;
+  detail: string;
+  willDeleteBranch: boolean;
+  branchDeleteBlockedReason?: "branch-referenced-by-live-record";
+
+  // UX/action fields.
+  disposition: ArchivedWorktreeDisposition;
+  reasonCategory: ArchivedWorktreeReasonCategory;
+  actionable: boolean; // true only for disposition `ready-to-clean`
+  selectable: boolean; // true only when cleanup can be requested for this row
+  defaultSelected: boolean; // true for actionable rows after scan
+  selectionCategories: ArchivedWorktreeSelectionCategory[];
+}
+```
+
+`selectionCategories` are non-exclusive tags used for one-click selection presets:
+
+```ts
+type ArchivedWorktreeSelectionCategory =
+  | "archived-session"
+  | "goal-session"
+  | "team-session"
+  | "delegate-session"
+  | "child-session"
+  | "single-repo"
+  | "multi-repo";
+```
+
+Category derivation:
+
+- Always include `archived-session`.
+- Include `goal-session` when `goalId` is present.
+- Include `team-session` when `teamGoalId` is present.
+- Include `delegate-session` when `delegateOf` is present.
+- Include `child-session` when `parentSessionId` or `childKind` is present.
+- Include `multi-repo` when the item came from `repoWorktrees`; otherwise include `single-repo`.
+
+### Groups and examples
+
+The server should return stable groups so the UI can show representative examples without rendering hundreds of skipped rows.
+
+```ts
+interface ArchivedSessionWorktreeGroup {
+  key: string; // e.g. `ready-to-clean`, `reason:no-worktree-path`, `reason:referenced-by-live-session`
+  label: string;
+  description: string;
+  disposition: ArchivedWorktreeDisposition;
+  reason?: ArchivedWorktreeReason;
+  reasonCategory?: ArchivedWorktreeReasonCategory;
+  count: number;
+  sampleKeys: string[]; // first five matching item keys, stable scan order
+  hasMore: boolean;
+  actionable: boolean;
+}
+```
+
+Required groups when count is non-zero:
+
+- `ready-to-clean`
+- `already-cleaned`
+- `reason:no-worktree-path`
+- `reason:missing-repo-path`
+- `reason:sandbox-container-path`
+- `reason:delegate-shared-worktree`
+- `reason:stale-worktree-directory`
+- `reason:referenced-by-live-session`
+- `reason:referenced-by-live-goal`
+- `reason:referenced-by-live-team`
+- `reason:referenced-by-staff`
+- `reason:scan-error`
+
+The UI default view should render only `ready-to-clean` rows. Other groups power “Why not removable?” / “Show skipped or ineligible items”.
+
+### Selection presets
+
+The server should describe available one-click presets from the fresh scan. Presets select only `actionable` items.
+
+```ts
+interface ArchivedSessionWorktreeSelectionPreset {
+  id: string;
+  label: string;
+  description: string;
+  enabled: boolean;
+  count: number;
+  worktreeKeys: string[]; // actionable item keys matching this preset
+  cleanupRequest: CleanupArchivedSessionWorktreesRequestV2;
+}
+```
+
+Required presets:
+
+- `all-removable` — all actionable rows; cleanup request `{ mode: "all" }`.
+- `category:archived-session` — all actionable archived-session rows.
+- `category:goal-session` — actionable goal-linked archived sessions, only when present.
+- `category:team-session` — actionable team-linked archived sessions, only when present.
+- `category:delegate-session` — actionable delegate archived sessions with independent worktrees, only when present.
+- `project:<projectId>` — actionable rows for each project represented in the scan.
+- `repo:<normalizedRepoPath>` — actionable rows for each repository represented in the scan.
+
+## Cleanup request additions
+
+Keep current `mode: "all"` and `mode: "selected"`. Add category/preset modes only as additive support; older clients can keep posting selected `worktrees`.
+
+```ts
+type CleanupArchivedSessionWorktreesRequestV2 =
+  | CleanupArchivedSessionWorktreesRequestV1
+  | {
+      mode: "category";
+      categories: ArchivedWorktreeSelectionCategory[];
+      projectId?: string;
+      repoPath?: string;
+    }
+  | {
+      mode: "preset";
+      presetId: string;
+    };
+```
+
+Semantics:
+
+- `mode: "all"` means clean every fresh-scan item with `status: "removable"`.
+- `mode: "selected"` with `sessionIds` means clean every fresh-scan removable item for those archived sessions.
+- `mode: "selected"` with `worktrees` means clean exactly matched fresh-scan rows by `key`, or by `sessionId` + `repo` + `path` when no key is provided.
+- `mode: "category"` means clean fresh-scan removable rows whose `selectionCategories` include at least one requested category, then apply optional `projectId` and normalized `repoPath` filters.
+- `mode: "preset"` means resolve `presetId` against the same preset definitions as the fresh scan. Dynamic project/repo presets must be re-derived from the fresh scan, not trusted from the client.
+- Invalid category/preset values return `400`.
+- Empty category/preset matches return a zero-cleaned success response, not an error.
+
+## Cleanup response contract
+
+Preserve current counts and result fields, then add reason/disposition summaries.
+
+```ts
+interface CleanupArchivedSessionWorktreesResponseV2 {
+  counts: CleanupArchivedSessionWorktreeCountsV2;
+  results: ArchivedSessionWorktreeCleanupResultV2[];
+  generatedAt: number;
+}
+
+interface CleanupArchivedSessionWorktreeCountsV2 {
+  // Existing names; keep for compatibility.
+  requested: number;
+  cleaned: number;
+  branchDeleted: number;
+  skipped: number;
+  alreadyCleaned: number;
+  failed: number;
+
+  // UX diagnostics.
+  worktreeRemoved: number; // successful physical/git worktree removals; normally equals cleaned
+  invalidSelection: number;
+  notActionable: number;
+  byStatus: Partial<Record<ArchivedWorktreeCleanupStatus, number>>;
+  byReason: Partial<Record<ArchivedWorktreeCleanupReason, number>>;
+}
+
+type ArchivedWorktreeCleanupStatus = "cleaned" | "skipped" | "already-cleaned" | "failed";
+
+type ArchivedWorktreeCleanupReason =
+  | "worktree-and-branch-cleaned"
+  | "worktree-cleaned"
+  | "already-cleaned"
+  | "invalid-selection"
+  | ArchivedWorktreeReason;
+
+interface ArchivedSessionWorktreeCleanupResultV2 {
+  key: string;
+  sessionId: string;
+  title?: string;
+  repo?: string;
+  repoPath?: string;
+  path?: string;
+  branch?: string;
+  status: ArchivedWorktreeCleanupStatus;
+  reason?: ArchivedWorktreeCleanupReason;
+  detail?: string;
+  error?: string;
+  worktreeRemoved: boolean;
+  branchDeleted: boolean;
+}
+```
+
+Result rules:
+
+- A fresh removable item that cleans successfully returns `status: "cleaned"` and reason `worktree-and-branch-cleaned` or `worktree-cleaned`.
+- A stale selected item with no remaining worktree path/git metadata returns `status: "already-cleaned"`, `reason: "already-cleaned"`.
+- A selected item that is matched but no longer removable returns `status: "skipped"` and the fresh scan reason.
+- A selector that cannot be matched returns `status: "skipped"`, `reason: "invalid-selection"`.
+- Per-item failures return `status: "failed"`, preserve selector metadata, and increment only `failed`.
+
+## Server-side guard invariants
+
+The server remains the source of truth. UI selection, category, or preset requests must never bypass these guards.
+
+1. Cleanup always starts with a fresh `listArchivedSessionWorktrees(true)` scan.
+2. Only items whose fresh scan status is `removable` may call git cleanup.
+3. Archived session metadata, transcripts, proposals, prompts, colors, search/archive visibility, and persisted session rows are never deleted or mutated by this feature.
+4. Candidate sessions come from archived sessions in visible project contexts; hidden/synthetic contexts are not cleanup candidates.
+5. Guard references come from all project contexts, not only visible contexts.
+6. Never remove a worktree referenced by any non-archived persisted session, runtime session, persisted goal, team entry/agent, staff record, delegate parent, or multi-repo sibling record.
+7. `repoWorktrees` are evaluated one repo item at a time; never fall back to the flat `worktreePath` when `repoWorktrees` exists.
+8. Container-internal paths under `/workspace` or `/workspace-wt` are skipped with `sandbox-container-path` unless a host worktree path is explicitly recorded.
+9. Existing directories without matching git worktree metadata are `stale-worktree-directory` and are not removed by archived-session cleanup.
+10. Branch-only residue is `already-cleaned`; archived-session cleanup must not call git solely to delete a branch.
+11. Branch deletion is allowed only after the worktree is removed and the same branch is absent from branch guard sets for the same `repoPath`.
+12. Branch deletion failure must not turn a successful worktree removal into a failed cleanup; report `branchDeleted: false`.
+13. Cleanup is best-effort per item; one failure must not abort the request.
+14. `mode: "preset"` and `mode: "category"` must resolve against the fresh scan and then apply the same removable-only filtering.
+
+## UI usage guidance
+
+- Primary summary: `Ready to clean: counts.readyToClean`.
+- Secondary summary: `Already cleaned`, `Needs attention`, and `Ineligible` from v2 counts.
+- Do not use `sessionsWithWorktrees` as a primary label. If shown, label it “Has worktree metadata, not necessarily removable”.
+- If `readyToClean === 0`, disable cleanup actions and show an empty state: “There are no archived-session worktrees that are safe to clean right now.”
+- Render skipped/ineligible/needs-attention rows only after an explicit troubleshooting disclosure or group jump.
+- “Clean all safe candidates” should post `{ mode: "all" }`.
+- “Clean selected” can post existing selected `worktrees` keys for maximum compatibility, even when the selection came from a server preset.

--- a/docs/design/archived-session-worktree-maintenance-ux.md
+++ b/docs/design/archived-session-worktree-maintenance-ux.md
@@ -1,0 +1,382 @@
+# Archived Session Worktree Maintenance UX
+
+**Surface:** Settings → Maintenance → Archived Session Worktrees  
+**Owner:** UX design only. Production implementation remains in `src/app/settings-page.ts`.  
+**Related docs:** [Archived session worktree cleanup](./archived-session-worktree-cleanup.md), [Maintenance](../maintenance.md#archived-session-worktrees)
+
+## Problem to solve
+
+The current card exposes technically correct scan data, but the hierarchy makes the wrong question feel primary. A count such as **With worktrees: 162** can be read as “162 things I can clean”, even when **Removable: 0**. The redesigned card must answer, in order:
+
+1. **Can I clean anything right now?**
+2. **What is the safest one-click action?**
+3. **If nothing is removable, why not?**
+4. **How can I inspect representative examples without scrolling through hundreds of skipped rows?**
+
+## UX principles
+
+- **Actionable first:** default view shows removable candidates only.
+- **Safety visible, not noisy:** skipped/ineligible data is available, but hidden behind explicit troubleshooting disclosure.
+- **Server remains source of truth:** UI selection is convenience only; cleanup still re-scans and guards on the server.
+- **Counts use user intent language:** avoid primary labels that describe implementation state instead of actionability.
+- **Small samples before full lists:** every non-actionable group defaults to first 5 examples with a Show all affordance.
+
+## Recommended layout
+
+Keep the existing maintenance card structure and visual language:
+
+- container: `flex flex-col gap-2 rounded-md border border-border p-4`
+- title: `text-sm font-semibold text-foreground`
+- description/help text: `text-xs text-muted-foreground`
+- buttons: reuse existing scan/action button classes and disabled opacity behaviour
+- rows: compact `text-xs`, monospaced technical fields, `bg-secondary/20` or `bg-background/70` cards
+
+### Card header
+
+```text
+Archived Session Worktrees
+Reclaim git worktrees from archived sessions while keeping transcripts, proposals, and archive visibility intact.
+```
+
+Header actions, right-aligned on wider screens and stacked below on narrow screens:
+
+1. **Scan** / **Rescan**
+2. **Clean all safe candidates** — primary when `readyToClean > 0`
+3. **Clean selected** — secondary or primary-outline when selection is non-empty
+
+If no scan has run, show only Scan plus disabled cleanup buttons with helper text.
+
+## Action-oriented summary labels
+
+Replace the current primary count chips with a two-tier summary.
+
+### Primary summary row
+
+Use larger, action-oriented summary cards/chips:
+
+| Label | Source | Purpose |
+|---|---:|---|
+| **Ready to clean** | `counts.removableWorktrees` | Main answer: how many safe candidates exist now. |
+| **Selected** | selected removable row count | Shows what Clean selected will affect. |
+| **Already cleaned** | `counts.alreadyCleanedWorktrees` | Reassures user that old archive metadata is not still actionable. |
+| **Needs attention** | skipped + failed result count | Secondary troubleshooting count. |
+
+Copy examples:
+
+- `Ready to clean: 0`
+- `Selected: 0`
+- `Already cleaned: 148`
+- `Needs attention: 14`
+
+Do **not** show `With worktrees` as a primary chip. If useful in troubleshooting, relabel as:
+
+```text
+Has worktree metadata: 162 — historical records, not necessarily removable
+```
+
+### Secondary scan metadata
+
+Place in muted text below the primary row or inside troubleshooting details:
+
+```text
+Scanned 167 archived sessions. 162 have historical worktree metadata.
+```
+
+## Zero-removable empty state
+
+When a scan has completed and `Ready to clean` is 0, the default body should be an empty state, not a long skipped list.
+
+### Empty state copy
+
+```text
+Nothing safe to clean right now
+Archived sessions were scanned, but no removable host worktrees are currently safe to delete.
+
+Common reasons: the worktree is already gone, the archived record has no host worktree path, the path belongs to a sandbox/container, or another live session, goal, team member, or staff agent still references it.
+```
+
+Primary action: **Rescan**  
+Secondary action/disclosure: **Show why not removable**
+
+Disabled cleanup helper:
+
+```text
+Cleanup is disabled because there are 0 safe candidates.
+```
+
+Accessibility: the empty-state heading should be a real text node announced after scan; if practical, wrap summary/empty state in `aria-live="polite"`.
+
+## Cleanup actions
+
+### Clean all safe candidates
+
+Visible after scan. Enabled only when `Ready to clean > 0`.
+
+- Label: `Clean all safe candidates (N)`
+- Request: `POST /api/maintenance/cleanup-archived-session-worktrees` with `{ "mode": "all" }`
+- Confirmation text:
+
+```text
+Clean N archived-session worktree(s)?
+This removes only git worktrees and eligible branches. Archived sessions, transcripts, proposals, and archive visibility are preserved.
+```
+
+### Clean selected
+
+Enabled only when selected removable count > 0.
+
+- Label: `Clean selected (N)`
+- Request: selected worktree keys as currently implemented
+- Helper when disabled:
+  - no scan: `Scan first to find safe candidates.`
+  - zero ready: `No safe candidates are available.`
+  - zero selected: `Select at least one safe candidate.`
+
+### Selection presets
+
+Show as small secondary buttons immediately above the actionable list when `Ready to clean > 0`:
+
+| Preset | Behaviour |
+|---|---|
+| **Select all removable** | selects every `status: "removable"` item |
+| **Archived sessions only** | selects removable items where `delegateOf`, `teamGoalId`, and team/delegate category fields are absent |
+| **Current project only** | selects removable items whose `projectId` matches active project, if scan data supports comparison; hide if not supported |
+| **Goal/team/delegate worktrees** | selects removable items with `goalId`, `teamGoalId`, `delegateOf`, `parentSessionId`, or `childKind`; hide if count is 0 |
+| **Clear selection** | clears all selections |
+
+Preset buttons should display resulting counts when possible, e.g. `Current project (3)`. Hide unsupported presets rather than showing disabled clutter, except **Clear selection**, which may be disabled when selection is already 0.
+
+## Default actionable list
+
+When `Ready to clean > 0`, show removable rows only by default. Rows are grouped by archived session, but the group header must not dominate the row action.
+
+### Group header
+
+```text
+<session title>
+<short session id> · <project/repo> · archived <relative date>
+```
+
+If the title is empty: `Untitled archived session`.
+
+### Row default copy
+
+Each removable row should include only useful default details:
+
+```text
+Ready to clean
+Safe to remove: archived session worktree is not referenced by any live session, goal, team member, staff agent, or multi-repo sibling.
+
+Repo: .
+Branch: goal/b45d2643/ux-designer-1227
+Worktree: C:\Users\jsubr\w\bobbit-wt\goal-b45d2643-ux-designer-1227
+Branch: will be deleted / branch will be kept — <blocked reason>
+```
+
+Recommended status wording:
+
+| Raw status/reason | User-facing label | Detail copy |
+|---|---|---|
+| `removable` / `safe-archived-session-worktree` | `Ready to clean` | `Safe to remove: no live session, goal, team, staff, or sibling worktree references this path.` |
+| branch delete allowed | `Branch will be deleted` | `The matching local branch is not referenced elsewhere.` |
+| branch delete blocked | `Branch will be kept` | Use `branchDeleteBlockedReason`; prefix with `Branch kept:`. |
+
+Use a checkbox per removable row. The label must include session title + repo + path so screen readers announce meaningful context.
+
+## Hidden skipped/ineligible disclosure
+
+Skipped and already-cleaned details are hidden by default. Add a disclosure below the actionable list or empty state:
+
+```text
+Show skipped / ineligible items
+```
+
+Expanded label:
+
+```text
+Hide skipped / ineligible items
+```
+
+Expanded content starts with a compact explanation:
+
+```text
+These records are not cleanup actions. They are shown for troubleshooting and audit only.
+```
+
+The disclosure should include skipped, already-cleaned, and failed cleanup-result examples grouped by category. It must not auto-expand after scan unless cleanup produces failures.
+
+## Grouped examples by status/reason
+
+Provide filters or grouped sections. Each group shows the first 5 rows by default and a **Show all (N)** button when `N > 5`. The Show all state is per group, so expanding one noisy reason does not flood the whole card.
+
+### Group set
+
+Minimum groups:
+
+1. **Ready to clean** — shown in main list; also available as a filter target from summary.
+2. **Already cleaned** — `status: "already-cleaned"`.
+3. **Missing worktree path** — `reason: "no-worktree-path"`.
+4. **Missing repo path** — `reason: "missing-repo-path"`.
+5. **Sandbox/container path** — `reason: "sandbox-container-path"`.
+6. **Referenced by live session/goal/team/staff** — split into subgroups when counts are non-zero:
+   - `referenced-by-live-session`
+   - `referenced-by-live-goal`
+   - `referenced-by-live-team`
+   - `referenced-by-staff`
+7. **Delegate/shared worktree** — `reason: "delegate-shared-worktree"`.
+8. **Invalid selection** — cleanup result `reason: "invalid-selection"`.
+9. **Cleanup failed** — cleanup result `status: "failed"`; auto-focus/announce after cleanup.
+
+### Example group header copy
+
+```text
+Missing worktree path (94)
+These archived sessions have no host worktree path recorded, so there is nothing for this tool to remove.
+```
+
+```text
+Referenced by live goal (2)
+Protected because another durable goal record still points at this path or branch.
+```
+
+```text
+Already cleaned (148)
+The archive still remembers the old path, but the worktree and git metadata are already gone.
+```
+
+### Example row copy
+
+Rows in troubleshooting groups are disabled and compact:
+
+```text
+Skipped — missing worktree path
+Untitled archived session · ses_abc12345 · Bobbit
+No host worktree path is recorded for this archived session.
+```
+
+```text
+Skipped — sandbox/container path
+Fix login retry · ses_def67890 · repo: .
+Path /workspace-wt/session/fix-login exists only inside a sandbox container, not as a host worktree.
+```
+
+```text
+Already cleaned
+Refactor API client · ses_ghi23456 · branch: session/refactor-api-client
+The worktree path and git worktree metadata are gone; no cleanup is needed.
+```
+
+```text
+Cleanup failed
+Build dashboard · ses_jkl34567 · C:\...\bobbit-wt\session\build-dashboard
+Git refused to remove the worktree: <error>
+```
+
+## Summary-to-examples navigation
+
+Summary chips should be interactive when they have relevant rows:
+
+- **Ready to clean** scrolls/focuses the actionable list.
+- **Already cleaned** expands troubleshooting and focuses the Already cleaned group.
+- **Needs attention** expands troubleshooting and focuses the first skipped/failed group.
+
+Use buttons styled as chips rather than inert spans when they trigger navigation. Provide `aria-controls` pointing to the group panel.
+
+## Cleanup result summary
+
+After cleanup, show a compact result panel above the scan results and then rescan.
+
+Default success copy:
+
+```text
+Cleanup complete
+Cleaned 6 worktrees. Deleted 4 branches. 2 branches were kept because they are referenced elsewhere.
+```
+
+Mixed result copy:
+
+```text
+Cleanup finished with attention needed
+Cleaned 5, skipped 2, already cleaned 1, failed 1.
+```
+
+Only failed/skipped result rows should be shown by default after cleanup; successful rows can be summarized. Provide **Show cleanup details** for per-item results.
+
+## Accessibility requirements
+
+- Card section: `role="region"`, labelled by the card heading.
+- Scan and cleanup result updates: `aria-live="polite"`.
+- Cleanup failures: use `aria-live="assertive"` or move focus to the failure summary after action completes.
+- Disabled cleanup buttons must have visible helper text, not only a disabled state or tooltip.
+- Summary chips that navigate/filter are `<button>` elements with visible focus rings.
+- Row checkboxes include accessible names containing action, session title/id, repo, and path.
+- Disclosure uses a native `<details>/<summary>` or a button with `aria-expanded` and `aria-controls`.
+- Do not rely on color alone: every state chip includes text (`Ready to clean`, `Skipped`, `Already cleaned`, `Failed`).
+- Path text remains selectable and wraps with `break-all`; avoid horizontal-only scrolling for critical details.
+- Keyboard order: Scan → Clean all → selection presets → row checkboxes → Clean selected → troubleshooting disclosure/groups.
+
+## Test selectors
+
+Preserve existing selectors and add stable selectors for the new interactions. Prefer `data-testid` for tests and `data-action` for existing maintenance action consistency.
+
+### Section and actions
+
+| Element | Selector |
+|---|---|
+| Section | `data-section="archived-session-worktrees"` |
+| Scan/rescan | `data-action="scan-archived-session-worktrees"` |
+| Clean all | `data-action="cleanup-all-archived-session-worktrees"` |
+| Clean selected | `data-action="cleanup-archived-session-worktrees"` |
+| Empty state | `data-testid="archived-worktrees-empty"` |
+| Cleanup helper | `data-testid="archived-worktrees-cleanup-helper"` |
+| Result summary | `data-testid="archived-worktrees-cleanup-result"` |
+
+### Summary counts
+
+| Count | Selector |
+|---|---|
+| Ready to clean | `data-testid="archived-worktrees-ready-count"` |
+| Selected | `data-testid="archived-worktrees-selected-count"` |
+| Already cleaned | `data-testid="archived-worktrees-already-cleaned-count"` |
+| Needs attention | `data-testid="archived-worktrees-needs-attention-count"` |
+| Historical metadata detail | `data-testid="archived-worktrees-metadata-count"` |
+
+### Selection presets
+
+| Preset | Selector |
+|---|---|
+| Select all removable | `data-action="select-all-removable-archived-worktrees"` |
+| Archived sessions only | `data-action="select-archived-session-worktrees-only"` |
+| Current project only | `data-action="select-current-project-archived-worktrees"` |
+| Goal/team/delegate | `data-action="select-goal-team-delegate-archived-worktrees"` |
+| Clear selection | `data-action="clear-archived-worktree-selection"` |
+
+### Rows and groups
+
+| Element | Selector |
+|---|---|
+| Worktree row | `data-archived-worktree-key="<key>"` |
+| Row status | `data-archived-worktree-status="removable|skipped|already-cleaned|failed"` |
+| Row reason | `data-archived-worktree-reason="<reason>"` |
+| Troubleshooting disclosure | `data-testid="archived-worktrees-troubleshooting-toggle"` |
+| Troubleshooting panel | `data-testid="archived-worktrees-troubleshooting"` |
+| Example group | `data-testid="archived-worktree-example-group" data-reason="<reason>"` |
+| Show all in group | `data-action="show-all-archived-worktree-examples" data-reason="<reason>"` |
+
+## UI test coverage checklist
+
+Browser/fixture tests should cover:
+
+1. Default card before scan: cleanup disabled, helper explains Scan first.
+2. Zero-removable scan: shows `Ready to clean: 0`, empty state, cleanup disabled, skipped details hidden.
+3. Hidden disclosure: opening it reveals grouped first-5 examples and Show all for noisy groups.
+4. Removable scan: removable rows selected by default; skipped rows absent from default list.
+5. Selection presets: each preset updates Selected count and selected row checkboxes.
+6. Clean all: posts `{ "mode": "all" }` after confirmation and displays cleanup result.
+7. Clean selected: posts selected worktree keys only; disabled when selection is empty.
+8. Summary navigation: Already cleaned / Needs attention chips expand and focus the correct group.
+9. Accessibility smoke: buttons have accessible names, disabled state has visible helper text, disclosure is keyboard operable.
+
+## Consistency rationale
+
+This design intentionally reuses the existing Settings → Maintenance primitives: bordered cards, compact `text-xs` metadata, chip-like summary labels, small rounded buttons, and row cards with monospaced technical fields. The only new pattern is grouped troubleshooting examples, but it is an extension of existing progressive disclosure (`details`-style diagnostics) rather than a new visual system. The hierarchy changes, not the component language: primary counts now describe actionability, and noisy technical rows move behind an explicit disclosure.

--- a/docs/design/archived-session-worktree-ux-test-plan.md
+++ b/docs/design/archived-session-worktree-ux-test-plan.md
@@ -1,0 +1,309 @@
+# Archived Session Worktree UX Test Plan
+
+## Scope
+
+This plan covers the archived-session worktree maintenance reattempt. It is a test strategy only; implementation should update the test files named below after the API/UI contract lands.
+
+Primary risks to pin:
+
+- Users must see the actionable answer first: `Ready to clean`, not ambiguous `With worktrees`.
+- Skipped/ineligible records must not dominate the default UI.
+- Cleanup must remain server-authoritative and must never remove worktrees or branches still referenced by live sessions, goals, team/delegate records, staff, or multi-repo sibling records.
+- Archived sessions, transcript files, and metadata must survive worktree cleanup.
+
+## Existing coverage reviewed
+
+- `tests/e2e/maintenance-api.spec.ts`
+  - Already seeds archived sessions directly through the isolated gateway project context.
+  - Already covers current scan/cleanup shape, selected cleanup, already-cleaned behavior, stale directories, key/session mismatch, sandbox container paths, multi-repo rows, and live-session guard.
+  - Needs expansion for the new UX-oriented contract: action categories, machine-readable reason/category fields, grouped summary counts, category cleanup/selection support if added, and guard behavior in `mode: all` or category cleanup.
+- `tests/e2e/ui/settings*.spec.ts`
+  - Existing spawned-browser settings specs cover route/navigation-level behavior only.
+  - There is no Settings -> Maintenance browser E2E coverage for archived worktree cleanup.
+- `tests/ui-fixtures/settings-admin-fixture-*`
+  - Existing fixture renders `renderSettingsPage()` with stubbed settings APIs.
+  - Current maintenance stubs return `{ count: 0, sample: [] }`, so fixture support must be added for archived-session scan/cleanup responses.
+  - Best fit for deterministic UI state matrices: zero-removable, actionable-only default, hidden skipped disclosure, selection presets, examples/grouping.
+- `src/app/settings-page.ts` selectors
+  - Current archived worktree section has `data-section="archived-session-worktrees"` plus scan/cleanup `data-action` attributes and row `data-archived-worktree-key`.
+  - The reattempt should add stable `data-testid` hooks for summaries, filters/disclosures, group/example sections, selection presets, row categories, and cleanup buttons. Tests should not depend on Tailwind classes or incidental copy beyond acceptance-critical labels.
+- `docs/testing-strategy.md`
+  - Put deterministic UI matrices in `tests/ui-fixtures/*.spec.ts` (unit browser / file://).
+  - Put server contracts in API E2E.
+  - Use spawned browser E2E only for the small full-stack Settings -> Maintenance journey and persistence/archived-session preservation path.
+
+## Proposed API contract coverage
+
+### File: `tests/e2e/maintenance-api.spec.ts`
+
+Extend the existing `archived session worktree maintenance` describe block. Keep using isolated temp git repos and direct session-store seeding.
+
+#### Shared shape assertions
+
+Update or add helpers so every scan row asserts:
+
+- `status`: one of `removable`, `already-cleaned`, `skipped`, `failed` if scan failures are represented as rows.
+- `category`: machine-readable group used by UI selection/examples, e.g. `ready`, `already-cleaned`, `missing-worktree-path`, `sandbox-container-path`, `referenced`, `stale`, `failed`.
+- `reason`: stable machine-readable reason code.
+- `reasonLabel` or `detail`: human-readable explanation.
+- `isActionable` or equivalent boolean for UI filtering.
+- Required metadata: `key`, `sessionId`, `title`, `repo`, `repoPath`, `path`, `branch`, `projectId/projectName` when known, and branch deletion flags.
+
+Update counts assertions to include action-oriented and troubleshooting counts. Minimum expected shape:
+
+- `readyToClean`
+- `selected` is UI-only unless server returns selected state; do not require from scan API if the server is stateless.
+- `alreadyCleaned`
+- `needsAttention`
+- `skipped` / `ineligible`
+- existing legacy counts may remain, but tests must not let `sessionsWithWorktrees` be the primary actionable count.
+
+#### Scenario: scan categories and reason codes
+
+Seed one archived session for each representative reason, then call:
+
+`GET /api/maintenance/archived-session-worktrees?includeAlreadyCleaned=1`
+
+Assert grouped categories/reasons are stable:
+
+- removable host worktree -> `status: "removable"`, `reason: "safe-archived-session-worktree"`, category/actionable true.
+- missing worktree path -> `reason: "no-worktree-path"`, non-actionable.
+- missing repo path -> `reason: "missing-repo-path"`, non-actionable.
+- sandbox/container path -> `reason: "sandbox-container-path"`, non-actionable.
+- delegate shared worktree -> `reason: "delegate-shared-worktree"`, non-actionable.
+- already removed path/git metadata -> `status: "already-cleaned"`, `reason: "already-cleaned"`.
+- stale non-git directory -> `reason: "stale-worktree-directory"`, non-actionable.
+- live session reference -> `reason: "referenced-by-live-session"`, non-actionable.
+- live goal/team/staff references, where practical with lightweight store seeding -> `referenced-by-live-goal`, `referenced-by-live-team`, `referenced-by-staff`.
+- multi-repo session -> one row per `repoWorktrees` entry with per-repo `repo`, `repoPath`, `path`, and category.
+
+Also assert default scan without `includeAlreadyCleaned=1` excludes already-cleaned rows from displayed `sessions` while still reporting counts.
+
+#### Scenario: cleanup response shape and selected guards
+
+Extend the selected cleanup tests to assert:
+
+- Response counts include `requested`, `cleaned`, `branchDeleted`, `skipped`, `alreadyCleaned`, `failed`.
+- Each result carries `key`, `sessionId`, `repo`, `path`, `branch`, `status`, `reason` or `error`, `worktreeRemoved`, `branchDeleted`.
+- Invalid key/session selector returns a skipped `invalid-selection` result and does not remove the real worktree.
+- Selecting an ineligible row returns skipped with the same row reason and does not remove directory, git worktree metadata, or branch.
+- Selecting an already-cleaned row returns `already-cleaned` and does not delete branch-only residue.
+
+#### Scenario: clean all safe candidates remains guarded
+
+Seed at least:
+
+- one removable archived worktree,
+- one archived worktree referenced by a live session,
+- one sandbox/container path,
+- one already-cleaned row,
+- one stale directory.
+
+Call:
+
+`POST /api/maintenance/cleanup-archived-session-worktrees` with `{ "mode": "all" }`
+
+Assert only the removable row is cleaned. All ineligible rows remain untouched and appear as skipped/already-cleaned only if the response includes them; if `mode: all` intentionally returns only attempted removable rows, assert counts/documented shape matches that contract and add a separate category cleanup test.
+
+#### Scenario: category-based cleanup, if implemented
+
+If the API supports category selectors, add validation and guard tests for:
+
+- `{ "mode": "category", "categories": ["ready"] }` cleans only actionable rows.
+- Unsupported categories return `400` with a useful error.
+- Mixed selected IDs and categories return `400` unless explicitly supported.
+- Category cleanup still re-scans server-side and skips rows whose safety changed after the UI scan.
+
+#### Scenario: archived session preservation
+
+Keep and strengthen the existing preservation test:
+
+- After cleanup, `GET /api/sessions/:id?include=archived` returns the archived session.
+- Persisted session metadata still includes title, archive flags, branch/repo/worktree metadata.
+- Transcript/proposal/archive files remain present.
+- A follow-up archived-session list/search path still shows the session if an existing API supports it.
+
+## Proposed UI fixture coverage
+
+### Files
+
+- Add or extend: `tests/ui-fixtures/settings-admin-fixture-entry.ts`
+- Add tests in: `tests/ui-fixtures/settings-admin-fixture.spec.ts`
+
+The fixture should expose deterministic controls:
+
+- `__setArchivedWorktreeScan(response)`
+- `__getSettingsAdminFetchLog()` already exists and should capture cleanup request bodies.
+- Optional `__setArchivedWorktreeCleanup(response)` or make the POST handler mutate fixture state from removable to already-cleaned.
+
+### Required stable selectors
+
+Implementation should expose selectors before tests are added:
+
+- `data-testid="archived-worktree-maintenance"`
+- `data-testid="archived-worktree-summary-ready"`
+- `data-testid="archived-worktree-summary-selected"`
+- `data-testid="archived-worktree-summary-already-cleaned"`
+- `data-testid="archived-worktree-summary-needs-attention"`
+- `data-testid="archived-worktree-empty-state"`
+- `data-testid="archived-worktree-scan"`
+- `data-testid="archived-worktree-clean-all"`
+- `data-testid="archived-worktree-clean-selected"`
+- `data-testid="archived-worktree-select-all-removable"`
+- `data-testid="archived-worktree-select-archived-sessions"`
+- `data-testid="archived-worktree-select-current-project"` if current-project filtering is supported.
+- `data-testid="archived-worktree-clear-selection"`
+- `data-testid="archived-worktree-show-skipped"`
+- `data-testid="archived-worktree-group-<category-or-reason>"`
+- `data-testid="archived-worktree-show-all-<category-or-reason>"`
+- `data-testid="archived-worktree-row"` with `data-status`, `data-reason`, `data-category`, and `data-archived-worktree-key`.
+
+### Scenario: default actionable-only view
+
+Fixture scan data: two removable rows, ten skipped rows, one already-cleaned row.
+
+Assert after clicking Scan:
+
+- `Ready to clean: 2` is the prominent count.
+- `Selected: 2` appears if default selection is all safe candidates.
+- Visible rows are only `data-status="removable"` by default.
+- Skipped/ineligible reason text such as `no-worktree-path` and `sandbox-container-path` is not visible until the troubleshooting disclosure is opened.
+- `With worktrees` is not shown as a primary summary label. If retained, it must be secondary copy like `Has worktree metadata, not necessarily removable`.
+
+### Scenario: zero-removable empty state
+
+Fixture scan data: zero removable, many skipped/already-cleaned rows.
+
+Assert:
+
+- Summary shows `Ready to clean: 0`.
+- Empty state explains there is nothing safe to remove.
+- `Clean all safe candidates` and `Clean selected` are disabled or absent.
+- Helper text explains why cleanup is unavailable.
+- Skipped details remain hidden by default.
+
+### Scenario: hidden skipped disclosure
+
+Using the zero/actionable fixture data:
+
+- Before opening disclosure, skipped rows are not visible.
+- Click `Show skipped / ineligible items`.
+- Representative grouped sections appear by reason/category.
+- Each group shows a small sample, default max 5 rows.
+- `Show all` expands only that group.
+- Closing the disclosure hides skipped details again without changing selected removable rows.
+
+### Scenario: one-click selection presets
+
+Fixture scan data: removable rows across categories/project/repo plus ineligible rows.
+
+Assert:
+
+- `Select all removable` selects only actionable rows.
+- `Clear selection` sets `Selected: 0` and disables `Clean selected`.
+- `Select archived session worktrees only` selects only matching actionable rows.
+- `Select current project/repo only`, if supported by scan data, selects only actionable rows for the active project/repo.
+- Presets never select skipped or already-cleaned rows.
+
+### Scenario: clean selected flow
+
+- Start with two removable rows.
+- Clear selection; select one row.
+- Click `Clean selected`.
+- Assert the POST body uses `mode: "selected"` and includes only that row key/session selector.
+- Mock cleanup result with `cleaned: 1` and rescan with remaining rows.
+- Assert cleanup result summary reports cleaned/skipped/failed/already-cleaned counts concisely and the cleaned row is no longer actionable.
+
+### Scenario: clean all safe candidates flow
+
+- Start with removable rows selected or not selected.
+- Click `Clean all safe candidates`.
+- Assert the POST body uses either `{ mode: "all" }` or the documented category/actionable request, not a fragile client-built skipped-row list.
+- Assert server-side result summary appears and the UI rescans.
+- Assert cleanup buttons become disabled when rescan returns `Ready to clean: 0`.
+
+### Scenario: grouped examples by reason/category
+
+Fixture scan data: groups for `ready`, `already-cleaned`, `missing-worktree-path`, `sandbox-container-path`, `referenced-by-live-session`, and `stale-worktree-directory`.
+
+Assert:
+
+- Summary count affordances jump/filter to the matching group.
+- Each group title uses human-readable wording.
+- Rows show useful default fields only: title, short session id, project/repo, branch, worktree path when present, and reason label.
+- Raw/technical details are behind per-row expansion.
+
+## Proposed spawned-browser E2E coverage
+
+### File: `tests/e2e/ui/settings-maintenance-archived-worktrees.spec.ts`
+
+Use the real gateway only for one or two full-stack journeys. Avoid duplicating the full fixture matrix.
+
+#### Scenario: Settings -> Maintenance full cleanup journey
+
+- Seed an archived, worktree-backed session in an isolated temp git repo. Prefer extracting a helper from the API spec only if it can be shared cleanly; otherwise duplicate a small setup helper in this spec.
+- Open app with `openApp(page)`.
+- Navigate to `#/settings/system/maintenance` using `navigateToHash`.
+- Click Scan.
+- Assert `Ready to clean: 1`, actionable row visible, skipped details hidden.
+- Click `Clean all safe candidates` or select the row and click `Clean selected` depending on final UX.
+- Assert cleanup result summary and rescan show `Ready to clean: 0`.
+- Assert the git worktree path and eligible branch are gone.
+- Assert `GET /api/sessions/:id?include=archived` still returns the archived session and the title is visible in the archived-session UI path if a stable navigation exists.
+
+#### Scenario: zero-removable empty state with skipped hidden by default
+
+This can be either real-gateway seeded data or a Playwright `page.route()` response stub for the maintenance endpoints. Prefer route stubbing if the goal is pure UI wiring.
+
+- Route `GET /api/maintenance/archived-session-worktrees` to return zero removable plus many skipped rows.
+- Navigate to Maintenance and scan.
+- Assert empty state, disabled cleanup buttons, no visible skipped rows by default, and disclosure reveals grouped examples.
+
+## Manual QA checklist
+
+Run once after implementation on a real development project:
+
+1. Create or identify a worktree-backed session.
+2. Archive it.
+3. Open Settings -> Maintenance.
+4. Scan archived session worktrees.
+5. Confirm the row appears under `Ready to clean` with a clear safe-to-remove reason.
+6. Use `Clean all safe candidates`.
+7. Confirm the git worktree and eligible branch are removed.
+8. Confirm the archived session remains visible/readable, including transcript/proposal/archive metadata.
+9. Confirm skipped details are hidden by default and representative examples are available without scrolling through all rows.
+
+## Commands
+
+Focused feedback while developing tests:
+
+```bash
+npx playwright test --config playwright-e2e.config.ts --project=api tests/e2e/maintenance-api.spec.ts
+npx playwright test --config tests/playwright.config.ts tests/ui-fixtures/settings-admin-fixture.spec.ts
+npx playwright test --config playwright-e2e.config.ts --project=browser tests/e2e/ui/settings-maintenance-archived-worktrees.spec.ts
+```
+
+Required final verification for the goal branch:
+
+```bash
+npm run check
+npm run test:unit
+npm run test:e2e
+```
+
+Manual QA command is not automated; run the checklist above after `npm run dev:harness` or against the packaged app.
+
+## Acceptance mapping
+
+| Acceptance item | Primary test location |
+| --- | --- |
+| Clear whether any archived worktrees can be cleaned | UI fixture + browser E2E |
+| No implication that `With worktrees` means eligible | UI fixture text assertion |
+| Zero removable disables/omits cleanup with reason | UI fixture + browser E2E |
+| Skipped/ineligible hidden by default | UI fixture + browser E2E |
+| Clean all safe candidates in one/two clicks | Browser E2E + API `mode: all` |
+| One-click category selection | UI fixture |
+| Representative examples by status/reason/category | UI fixture |
+| Cleanup result summary counts | API shape + UI fixture |
+| Archived sessions remain visible/readable | API E2E + browser E2E/manual QA |
+| Live/goals/delegates/team/staff/multi-repo safeguards | API E2E |

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -6,36 +6,81 @@ The Maintenance tab is user-facing, but the same actions are exposed through `/a
 
 ## Archived Session Worktrees
 
-**Settings → Maintenance → Archived Session Worktrees** finds git worktrees that are still owned by archived session records. It solves a different problem from **Orphaned Worktrees**:
+**Settings → Maintenance → Archived Session Worktrees** finds git worktrees that are still recorded on archived session records. It solves a different problem from **Orphaned Worktrees**:
 
 - **Orphaned Worktrees** are branch-centric git entries with no owning live session reference.
 - **Archived Session Worktrees** are still referenced by archived session metadata, but the user may want to reclaim the checkout and branch while keeping the archive.
 
-This cleanup removes only git worktrees and, when safe, their corresponding branches. It does **not** delete archived session rows, transcripts, proposals, prompt records, search visibility, or archive list entries.
+This cleanup removes only host git worktrees and, when safe, their corresponding local branches. It does **not** delete archived session rows, transcripts, proposal drafts, prompt records, search visibility, or archive list entries.
 
-### Scan behavior
+### Actionable-first scan
 
-Click **Scan** to call `GET /api/maintenance/archived-session-worktrees`. The scan groups results by archived session and shows:
+Click **Scan** or **Rescan** to call `GET /api/maintenance/archived-session-worktrees`. The default UI is organized around the question: "What can I clean up right now?"
 
-- session title and id;
-- project and repo/component;
-- branch;
-- worktree path;
-- status and explanatory detail.
+The primary panel shows actionable rows first:
 
-Rows can have three statuses:
+- rows classified as `Ready to clean` are selectable and checked by default unless the server says otherwise;
+- skipped, ineligible, already-cleaned, and failed rows are hidden behind the troubleshooting disclosure;
+- the historical metadata count is secondary and labelled as metadata, not as eligibility.
 
-| Status | Meaning | UI behavior |
+This avoids treating "has worktree metadata" as "safe to remove." A scan can find many archived sessions with old worktree-related fields and still have `Ready to clean: 0`.
+
+### Summary labels
+
+| Label | Meaning | User action |
 |---|---|---|
-| `removable` | The worktree path or git worktree metadata still exists, and no guard references it. | Checked by default and eligible for cleanup. |
-| `skipped` | The row is not safe or actionable, with `reason`/`detail` explaining why. | Disabled. |
-| `already-cleaned` | The worktree path and git worktree metadata are already gone. A remaining branch alone does not make the row actionable. | Hidden by default; diagnostics may show it disabled. |
+| **Ready to clean** | Server-classified removable archived-session worktrees. These have a host path or git worktree entry and no protected references. | Use **Clean all safe candidates** or selection presets. |
+| **Selected** | Current number of ready-to-clean rows selected in the UI. | Use **Clean selected** when non-zero. |
+| **Already cleaned** | Archived records whose remembered worktree/git metadata is already gone. | No cleanup needed; inspect examples only when troubleshooting. |
+| **Needs attention** | Non-actionable rows such as stale paths, scan errors, or protected references that may need manual inspection. | Open **Show skipped / ineligible items** or **Show why not removable**. |
 
-The default scan omits sessions whose rows are all `already-cleaned`. Add `?includeAlreadyCleaned=1` to the API request for diagnostics.
+`Has worktree metadata` may appear as secondary scan detail. It means Bobbit found historical worktree-related data on archived records; it does not mean those records are removable.
 
-### Cleanup behavior
+### Zero-removable empty state
 
-The UI posts selected rows to `POST /api/maintenance/cleanup-archived-session-worktrees` as:
+When `Ready to clean` is zero, cleanup actions are disabled and the panel shows **Nothing safe to clean right now**. This is a successful scan, not an error.
+
+Common explanations include:
+
+- the worktree and git metadata are already gone;
+- the archived record has no host worktree path;
+- the recorded path is sandbox/container-internal, such as `/workspace` or `/workspace-wt`;
+- the path or branch is still referenced by a live session, goal, delegate, team member, staff agent, or multi-repo sibling;
+- the path exists on disk but is not a git worktree entry, so Bobbit leaves it for manual inspection.
+
+Skipped, ineligible, already-cleaned, and failed examples stay hidden by default. The disclosure shows grouped examples by reason, capped to a small sample with a **Show all** option for each group.
+
+### Troubleshooting examples
+
+The scan response includes groups such as:
+
+- **Ready to clean**;
+- **Already cleaned**;
+- **Missing worktree path**;
+- **Missing repository path**;
+- **Sandbox/container path**;
+- **Shared delegate worktree**;
+- **Stale worktree directory**;
+- **Referenced by live session / goal / team / staff**;
+- **Scan errors**.
+
+Each group includes representative `sampleItems` so the UI can explain why records are not removable without rendering hundreds of skipped rows. Rows show practical details first: title, session id, project/repo, branch, worktree path, and a human-readable reason. Technical fields are secondary details.
+
+### Cleanup flows
+
+#### Clean all safe candidates
+
+Use **Clean all safe candidates** when the scan reports `Ready to clean > 0`. The UI sends:
+
+```json
+{ "mode": "all" }
+```
+
+The server re-scans before cleanup and removes only rows that are still classified as removable. If a row became unsafe or already cleaned after the UI scan, it is skipped or reported as already cleaned in the result.
+
+#### Clean selected
+
+The scan selects ready-to-clean rows by default. The user can narrow that set with row checkboxes or presets, then use **Clean selected**. The UI sends selected worktree selectors, usually including `sessionId`, `key`, `repo`, and `path`.
 
 ```json
 {
@@ -46,38 +91,57 @@ The UI posts selected rows to `POST /api/maintenance/cleanup-archived-session-wo
 }
 ```
 
-The server re-runs the scan before deleting anything, so stale UI selections cannot bypass safety checks. It cleans only rows that are still `removable` in the fresh scan. One item failure does not abort the rest of the request.
+Empty selected cleanup is a no-op. Invalid or stale selectors are reported as skipped; they do not make the server delete anything outside the fresh scan's removable set.
 
-Successful cleanup removes the host git worktree. Branch deletion is best-effort and only happens when the branch is local to the same repo and not referenced by any protected live or durable owner. If branch deletion is blocked, the worktree can still be removed and the result reports `branchDeleted: false`.
+### Selection presets and categories
 
-### Safety rules
+The UI provides one-click selection controls for common cleanup choices:
 
-A candidate is skipped rather than removed when any protected owner still references the same worktree path or branch. Guards include:
+- **Select all removable**;
+- **Archived sessions only**;
+- **Current project** when the active project matches scan data;
+- **Goal/team/delegate worktrees** when represented in the scan;
+- **Clear selection**.
 
-- non-archived persisted sessions and current runtime sessions;
-- persisted goals, including archived goals that still exist in the goal store;
+The API also exposes `selectionPresets` and `selectionCategories` so clients can render equivalent controls without hardcoding every rule. Categories are descriptive filters over already-removable rows, such as `archived-session`, `goal-session`, `team-session`, `delegate-session`, `child-session`, `single-repo`, and `multi-repo`.
+
+### Safety guarantees
+
+The server is the source of truth for cleanup eligibility. UI selection can only request cleanup; it cannot bypass guards.
+
+Before deleting anything, cleanup re-runs the archived-session worktree scan and only acts on fresh `removable` / `ready-to-clean` rows. Protected rows are skipped.
+
+Cleanup preserves:
+
+- archived session metadata and archive visibility;
+- transcripts and prompt history;
+- proposal drafts and proposal history;
+- search/index records until their normal maintenance paths handle them.
+
+Cleanup refuses to remove worktrees or branches still referenced by:
+
+- non-archived persisted sessions or current runtime sessions;
+- persisted goals;
+- delegates or shared-worktree parent/child records;
 - team entries and team agents;
 - staff records, including paused staff;
 - multi-repo sibling `repoWorktrees` entries;
-- delegate/shared-worktree records without an independent worktree;
-- container-internal sandbox paths such as `/workspace` or `/workspace-wt`.
+- sandbox/container-internal paths that do not identify a host worktree.
 
-Multi-repo archived sessions are evaluated per repo item. One component worktree may be removable while another is skipped.
+Branch deletion is best-effort and narrower than worktree deletion. Bobbit deletes an eligible local branch only when it belongs to the same repo and no protected live or durable record still references it. A cleanup result can therefore report `worktreeRemoved: true` and `branchDeleted: false`.
 
-### What is preserved
+Multi-repo archived sessions are evaluated per repo item. One component worktree may be removable while another component is skipped.
 
-Archived-session worktree cleanup never purges the archived session. After cleanup, the archived session can still appear in archive/search surfaces and its transcript/proposals remain available. The archived metadata may still display the historical worktree path, but that path can now point to a removed directory.
+## API shape
 
-## REST API
-
-See [REST API — Maintenance](rest-api.md#maintenance) for request and response shapes.
+See [REST API — Maintenance](rest-api.md#maintenance) for the route table and interface sketch.
 
 Key routes:
 
 | Method | Path | Purpose |
 |---|---|---|
-| `GET` | `/api/maintenance/archived-session-worktrees` | Preview archived-session worktree candidates. |
-| `POST` | `/api/maintenance/cleanup-archived-session-worktrees` | Clean selected or all currently removable archived-session worktrees. |
+| `GET` | `/api/maintenance/archived-session-worktrees` | Preview archived-session worktree candidates and UX grouping data. |
+| `POST` | `/api/maintenance/cleanup-archived-session-worktrees` | Clean all, selected, category-filtered, or preset-filtered removable archived-session worktrees. |
 | `GET` | `/api/maintenance/orphaned-worktrees` | Preview git worktrees not owned by live session references. |
 | `POST` | `/api/maintenance/cleanup-worktrees` | Clean selected orphaned worktrees. |
 | `GET` | `/api/maintenance/orphaned-sessions` | Preview non-interactive session records that can be terminated. |
@@ -86,3 +150,5 @@ Key routes:
 | `POST` | `/api/maintenance/purge-archives` | Purge expired archives. |
 | `GET` | `/api/maintenance/orphaned-index-rows` | Preview search index rows whose parent records are gone. |
 | `POST` | `/api/maintenance/cleanup-index-rows` | Delete orphaned search index rows. |
+
+The archived-session scan keeps the older `sessions` and `counts` fields while adding flattened `items`, `groups`, `sampleItems`, reason categories, selection categories, and `selectionPresets`. These additive fields exist for UX filtering and examples; clients should tolerate new reasons, groups, and presets over time.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -1066,59 +1066,48 @@ Maintenance endpoints back Settings → Maintenance. They are preview-first and 
 | `GET` | `/api/maintenance/orphaned-index-rows` | List search index rows whose parent records are gone (`?projectId=`). |
 | `POST` | `/api/maintenance/cleanup-index-rows` | Delete orphaned search index rows (`{ projectId }`). |
 
-**`GET /api/maintenance/archived-session-worktrees`** returns:
+**`GET /api/maintenance/archived-session-worktrees`** returns an actionable-first scan for Settings → Maintenance. The response keeps the session-grouped shape and adds UX-oriented flattened data:
 
 ```ts
 interface ArchivedSessionWorktreeScanResponse {
   sessions: ArchivedSessionWorktreeSession[];
+  items: ArchivedSessionWorktreeItem[];
+  groups: ArchivedSessionWorktreeGroup[];
+  selectionPresets: ArchivedSessionWorktreeSelectionPreset[];
   counts: {
     archivedSessions: number;
-    sessionsWithWorktrees: number;
-    removableWorktrees: number;
+    sessionsWithWorktrees: number;      // metadata count, not eligibility
+    removableWorktrees: number;         // legacy name for ready-to-clean
     skippedWorktrees: number;
     alreadyCleanedWorktrees: number;
+    totalItems: number;
+    readyToClean: number;
+    defaultSelected: number;
+    alreadyCleaned: number;
+    ineligible: number;
+    needsAttention: number;
+    failed: number;
+    byDisposition: Record<string, number>;
+    byReason: Record<string, number>;
+    bySelectionCategory: Record<string, number>;
   };
-}
-
-interface ArchivedSessionWorktreeSession {
-  id: string;
-  title: string;
-  archivedAt?: number;
-  projectId?: string;
-  projectName?: string;
-  goalId?: string;
-  teamGoalId?: string;
-  delegateOf?: string;
-  parentSessionId?: string;
-  childKind?: string;
-  sandboxed?: boolean;
-  branch?: string;
-  repoPath?: string;
-  worktreePath?: string;
-  worktrees: ArchivedSessionWorktreeItem[];
-}
-
-interface ArchivedSessionWorktreeItem {
-  key: string;
-  sessionId: string;
-  repo: string;
-  repoPath: string;
-  path: string;
-  branch?: string;
-  pathExists: boolean;
-  gitWorktreeMetadataExists: boolean;
-  localBranchExists: boolean;
-  status: "removable" | "skipped" | "already-cleaned";
-  reason: string;
-  detail: string;
-  willDeleteBranch: boolean;
-  branchDeleteBlockedReason?: string;
+  generatedAt: number;
 }
 ```
 
-Default scans omit sessions whose rows are all `already-cleaned`; those rows still contribute to `counts.alreadyCleanedWorktrees`.
+Items include title/session metadata, project/repo, branch, worktree path, git-existence booleans, `status`, `disposition`, machine-readable `reason` and `reasonCategory`, human-readable `detail`, `actionable` / `selectable` / `defaultSelected`, `selectionCategories`, and branch-deletion hints. Groups include `sampleItems` capped for examples and filtering. Presets include an id, label, enabled/count state, matching keys, and the cleanup request they represent.
 
-**`POST /api/maintenance/cleanup-archived-session-worktrees`** accepts either `{ "mode": "all" }` or `{ "mode": "selected", "sessionIds": [...] }` or `{ "mode": "selected", "worktrees": [...] }`. `mode: "all"` rejects selectors. `mode: "selected"` accepts exactly one selector type; an empty selected request is a zero-count no-op. Worktree selectors contain `sessionId` plus optional `repo`, `path`, and `key` strings.
+Default scans omit sessions whose rows are all `already-cleaned`; those rows still contribute to aggregate counts. Use `?includeAlreadyCleaned=1` for diagnostics.
+
+**`POST /api/maintenance/cleanup-archived-session-worktrees`** accepts:
+
+- `{ "mode": "all" }`;
+- `{ "mode": "selected", "sessionIds": [...] }`;
+- `{ "mode": "selected", "worktrees": [{ "sessionId": "...", "key": "...", "repo": ".", "path": "..." }] }`;
+- `{ "mode": "category", "categories": [...], "projectId"?: "...", "repoPath"?: "..." }`;
+- `{ "mode": "preset", "presetId": "..." }`.
+
+`mode: "all"` rejects selectors. `mode: "selected"` accepts either session ids or worktree selectors, not both. Category and preset modes are convenience filters over the fresh server scan; they do not bypass safety checks.
 
 The server always re-runs the scan before cleanup and only removes fresh rows with `status: "removable"`. Stale selected rows that are already gone return `already-cleaned`; unmatched selections return `skipped` with `reason: "invalid-selection"`.
 
@@ -1131,8 +1120,14 @@ interface CleanupArchivedSessionWorktreesResponse {
     skipped: number;
     alreadyCleaned: number;
     failed: number;
+    worktreeRemoved: number;
+    invalidSelection: number;
+    notActionable: number;
+    byStatus: Record<string, number>;
+    byReason: Record<string, number>;
   };
   results: ArchivedSessionWorktreeCleanupResult[];
+  generatedAt: number;
 }
 
 interface ArchivedSessionWorktreeCleanupResult {
@@ -1145,6 +1140,7 @@ interface ArchivedSessionWorktreeCleanupResult {
   branch?: string;
   status: "cleaned" | "skipped" | "already-cleaned" | "failed";
   reason?: string;
+  detail?: string;
   error?: string;
   worktreeRemoved: boolean;
   branchDeleted: boolean;

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -3952,8 +3952,12 @@ type ArchivedSessionWorktreeGroup = {
 	category?: string;
 	label?: string;
 	detail?: string;
+	description?: string;
 	count: number;
 	itemKeys?: string[];
+	sampleKeys?: string[];
+	items?: ArchivedSessionWorktreeItem[];
+	sampleItems?: ArchivedSessionWorktreeItem[];
 };
 
 type ArchivedSessionWorktreeSelectionPreset = {
@@ -4625,16 +4629,29 @@ type ArchivedWorktreeExample = {
 	row?: { session: ArchivedSessionWorktreeSession; item: ArchivedSessionWorktreeItem };
 };
 
-function archivedWorktreeExamplesByReason(): Array<{ reason: string; label: string; detail: string; examples: ArchivedWorktreeExample[] }> {
-	const groups = new Map<string, ArchivedWorktreeExample[]>();
-	for (const row of archivedSessionWorktreeRows()) {
-		const { session, item } = row;
-		if (isArchivedSessionWorktreeActionable(item)) continue;
+function archivedWorktreeExamplesByReason(): Array<{ reason: string; label: string; detail: string; count: number; examples: ArchivedWorktreeExample[] }> {
+	type GroupBucket = { label?: string; detail?: string; count?: number; examples: ArchivedWorktreeExample[]; keys: Set<string> };
+	const groups = new Map<string, GroupBucket>();
+	const bucketFor = (reason: string): GroupBucket => {
+		let bucket = groups.get(reason);
+		if (!bucket) {
+			bucket = { examples: [], keys: new Set() };
+			groups.set(reason, bucket);
+		}
+		return bucket;
+	};
+	const addRowExample = (session: ArchivedSessionWorktreeSession, item: ArchivedSessionWorktreeItem, preferredReason?: string, bucketMeta?: { label?: string; detail?: string; count?: number }): void => {
+		if (isArchivedSessionWorktreeActionable(item)) return;
 		const disposition = archivedSessionWorktreeDisposition(item);
-		const reason = item.reason || item.reasonCategory || disposition;
+		const reason = preferredReason || item.reason || item.reasonCategory || disposition;
 		const key = archivedSessionWorktreeKey(item);
-		const examples = groups.get(reason) ?? [];
-		examples.push({
+		const bucket = bucketFor(reason);
+		if (bucketMeta?.label) bucket.label = bucketMeta.label;
+		if (bucketMeta?.detail) bucket.detail = bucketMeta.detail;
+		if (bucketMeta?.count !== undefined) bucket.count = Math.max(bucket.count ?? 0, bucketMeta.count);
+		if (bucket.keys.has(key)) return;
+		bucket.keys.add(key);
+		bucket.examples.push({
 			key,
 			status: item.status,
 			disposition,
@@ -4647,15 +4664,45 @@ function archivedWorktreeExamplesByReason(): Array<{ reason: string; label: stri
 			branch: item.branch,
 			path: item.path,
 			detail: item.detail || archivedSessionWorktreeReasonDetail(reason),
-			row,
+			row: { session, item },
 		});
-		groups.set(reason, examples);
+	};
+	for (const row of archivedSessionWorktreeRows()) addRowExample(row.session, row.item);
+	for (const group of archivedSessionWorktreeScan?.groups ?? []) {
+		const sampleItems = group.items ?? group.sampleItems ?? [];
+		if (sampleItems.length === 0) continue;
+		const disposition = group.disposition ?? sampleItems[0]?.disposition ?? archivedSessionWorktreeDisposition(sampleItems[0]);
+		if (disposition === "ready-to-clean") continue;
+		const reason = group.reason || group.reasonCategory || disposition;
+		const meta = { label: group.label, detail: group.detail || group.description, count: group.count };
+		for (const item of sampleItems) {
+			const session: ArchivedSessionWorktreeSession = {
+				id: item.sessionId,
+				title: item.title || "Untitled archived session",
+				archivedAt: item.archivedAt,
+				projectId: item.projectId,
+				projectName: item.projectName,
+				goalId: item.goalId,
+				teamGoalId: item.teamGoalId,
+				delegateOf: item.delegateOf,
+				parentSessionId: item.parentSessionId,
+				childKind: item.childKind,
+				sandboxed: item.sandboxed,
+				repoPath: item.repoPath,
+				worktreePath: item.path,
+				branch: item.branch,
+				worktrees: [item],
+			};
+			addRowExample(session, item, reason, meta);
+		}
 	}
 	for (const result of archivedSessionWorktreeCleanup?.results ?? []) {
 		if (result.status !== "failed" && result.status !== "skipped" && result.status !== "already-cleaned") continue;
 		const reason = result.status === "failed" ? "cleanup-failed" : (result.reason || result.status);
-		const examples = groups.get(reason) ?? [];
-		examples.push({
+		const bucket = bucketFor(reason);
+		if (bucket.keys.has(result.key)) continue;
+		bucket.keys.add(result.key);
+		bucket.examples.push({
 			key: result.key,
 			status: result.status,
 			disposition: result.status === "failed" ? "failed" : result.status === "already-cleaned" ? "already-cleaned" : "needs-attention",
@@ -4669,14 +4716,14 @@ function archivedWorktreeExamplesByReason(): Array<{ reason: string; label: stri
 			path: result.path,
 			detail: result.error || result.detail || result.reason,
 		});
-		groups.set(reason, examples);
 	}
-	return Array.from(groups.entries()).map(([reason, examples]) => ({
+	return Array.from(groups.entries()).map(([reason, bucket]) => ({
 		reason,
-		label: archivedSessionWorktreeReasonLabel(reason),
-		detail: archivedSessionWorktreeReasonDetail(reason),
-		examples,
-	})).sort((a, b) => a.label.localeCompare(b.label));
+		label: bucket.label || archivedSessionWorktreeReasonLabel(reason),
+		detail: bucket.detail || archivedSessionWorktreeReasonDetail(reason),
+		count: bucket.count ?? bucket.examples.length,
+		examples: bucket.examples,
+	})).filter(group => group.examples.length > 0).sort((a, b) => a.label.localeCompare(b.label));
 }
 
 function renderArchivedWorktreeExample(example: ArchivedWorktreeExample) {
@@ -4730,7 +4777,7 @@ function renderArchivedWorktreeTroubleshooting() {
 					>
 						<div class="flex flex-wrap items-start justify-between gap-2">
 							<div>
-								<h4 class="text-xs font-semibold text-foreground">${group.label} (${group.examples.length})</h4>
+								<h4 class="text-xs font-semibold text-foreground">${group.label} (${group.count})</h4>
 								<p class="text-[11px] text-muted-foreground">${group.detail}</p>
 							</div>
 							${group.examples.length > 5 ? html`

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -4477,7 +4477,7 @@ function archivedSessionWorktreeReasonDetail(reason: string): string {
 
 function archivedSessionWorktreeSafeReason(item: ArchivedSessionWorktreeItem): string {
 	if (isArchivedSessionWorktreeActionable(item)) return "Safe to remove: no live session, goal, team, staff, or sibling worktree references this path.";
-	return item.detail || archivedSessionWorktreeReasonDetail(item.reasonCategory || item.reason || archivedSessionWorktreeDisposition(item));
+	return item.detail || archivedSessionWorktreeReasonDetail(item.reason || item.reasonCategory || archivedSessionWorktreeDisposition(item));
 }
 
 function sanitizeArchivedWorktreeGroupId(value: string): string {
@@ -4514,7 +4514,7 @@ function showArchivedWorktreeTroubleshootingAndFocus(reason?: string): void {
 
 function renderArchivedWorktreeSummaryChip(label: string, value: number, testId: string, onClick?: () => void) {
 	const content = html`
-		<span class="text-[11px] text-muted-foreground">${label}</span>
+		<span class="text-[11px] text-muted-foreground">${label}:</span>
 		<span class="text-sm font-semibold text-foreground">${value}</span>
 	`;
 	const classes = "flex min-w-[8rem] flex-col gap-0.5 rounded-md border border-border bg-secondary/30 px-3 py-2 text-left";
@@ -4529,7 +4529,7 @@ function renderArchivedWorktreeRow(session: ArchivedSessionWorktreeSession, item
 	const key = archivedSessionWorktreeKey(item);
 	const selected = archivedSessionWorktreeSelection.has(key);
 	const disposition = archivedSessionWorktreeDisposition(item);
-	const reason = item.reasonCategory || item.reason || disposition;
+	const reason = item.reason || item.reasonCategory || disposition;
 	const category = item.selectionCategories?.[0] || disposition;
 	const status = item.status || (disposition === "ready-to-clean" ? "removable" : "skipped");
 	const title = item.title || session.title || "Untitled archived session";
@@ -4631,7 +4631,7 @@ function archivedWorktreeExamplesByReason(): Array<{ reason: string; label: stri
 		const { session, item } = row;
 		if (isArchivedSessionWorktreeActionable(item)) continue;
 		const disposition = archivedSessionWorktreeDisposition(item);
-		const reason = item.reasonCategory || item.reason || disposition;
+		const reason = item.reason || item.reasonCategory || disposition;
 		const key = archivedSessionWorktreeKey(item);
 		const examples = groups.get(reason) ?? [];
 		examples.push({
@@ -4766,7 +4766,7 @@ function renderArchivedWorktreeCleanupResult() {
 		<div class="rounded-md bg-secondary/30 border border-border p-2 text-xs text-muted-foreground mt-1" data-testid="archived-worktree-cleanup-result" aria-live=${attention > 0 ? "assertive" : "polite"}>
 			<div class="text-foreground font-medium">${attention > 0 ? "Cleanup finished with attention needed" : "Cleanup complete"}</div>
 			<div>
-				Cleaned ${cleanup.counts.cleaned}, deleted ${cleanup.counts.branchDeleted} branch${cleanup.counts.branchDeleted === 1 ? "" : "es"}, skipped ${cleanup.counts.skipped}, already cleaned ${cleanup.counts.alreadyCleaned}, failed ${cleanup.counts.failed}.
+				Cleaned: ${cleanup.counts.cleaned}, branches deleted: ${cleanup.counts.branchDeleted}, skipped: ${cleanup.counts.skipped}, already cleaned: ${cleanup.counts.alreadyCleaned}, failed: ${cleanup.counts.failed}.
 			</div>
 			${attention > 0 ? html`
 				<div class="mt-1 text-muted-foreground">Open skipped / ineligible items to inspect skipped or failed cleanup examples.</div>

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -3886,21 +3886,40 @@ function renderAppearanceTab(projectId: string) {
 
 // ── Maintenance tab state ──
 
-type ArchivedSessionWorktreeStatus = "removable" | "skipped" | "already-cleaned";
+type ArchivedSessionWorktreeStatus = "removable" | "skipped" | "already-cleaned" | "failed";
+type ArchivedSessionWorktreeDisposition = "ready-to-clean" | "already-cleaned" | "ineligible" | "needs-attention" | "failed";
 
 type ArchivedSessionWorktreeItem = {
-	key: string;
+	key?: string;
 	sessionId: string;
+	title?: string;
+	archivedAt?: number;
+	projectId?: string;
+	projectName?: string;
+	goalId?: string;
+	teamGoalId?: string;
+	delegateOf?: string;
+	parentSessionId?: string;
+	childKind?: string;
+	sandboxed?: boolean;
 	repo: string;
 	repoPath: string;
+	repoDisplayName?: string;
 	path: string;
 	branch?: string;
-	pathExists: boolean;
-	gitWorktreeMetadataExists: boolean;
-	localBranchExists: boolean;
+	source?: string;
+	pathExists?: boolean;
+	gitWorktreeMetadataExists?: boolean;
+	localBranchExists?: boolean;
 	status: ArchivedSessionWorktreeStatus;
+	disposition?: ArchivedSessionWorktreeDisposition;
 	reason: string;
+	reasonCategory?: string;
 	detail: string;
+	actionable?: boolean;
+	selectable?: boolean;
+	defaultSelected?: boolean;
+	selectionCategories?: string[];
 	willDeleteBranch: boolean;
 	branchDeleteBlockedReason?: string;
 };
@@ -3923,14 +3942,50 @@ type ArchivedSessionWorktreeSession = {
 	worktrees: ArchivedSessionWorktreeItem[];
 };
 
+type ArchivedSessionWorktreeGroup = {
+	id?: string;
+	key?: string;
+	status?: string;
+	disposition?: ArchivedSessionWorktreeDisposition;
+	reason?: string;
+	reasonCategory?: string;
+	category?: string;
+	label?: string;
+	detail?: string;
+	count: number;
+	itemKeys?: string[];
+};
+
+type ArchivedSessionWorktreeSelectionPreset = {
+	id: string;
+	label: string;
+	category?: string;
+	count?: number;
+	itemKeys?: string[];
+};
+
 type ArchivedSessionWorktreeScanResponse = {
 	sessions: ArchivedSessionWorktreeSession[];
+	items?: ArchivedSessionWorktreeItem[];
+	groups?: ArchivedSessionWorktreeGroup[];
+	selectionPresets?: ArchivedSessionWorktreeSelectionPreset[];
+	generatedAt?: number;
 	counts: {
 		archivedSessions: number;
 		sessionsWithWorktrees: number;
 		removableWorktrees: number;
 		skippedWorktrees: number;
 		alreadyCleanedWorktrees: number;
+		totalItems?: number;
+		readyToClean?: number;
+		defaultSelected?: number;
+		alreadyCleaned?: number;
+		ineligible?: number;
+		needsAttention?: number;
+		failed?: number;
+		byDisposition?: Record<string, number>;
+		byReason?: Record<string, number>;
+		bySelectionCategory?: Record<string, number>;
 	};
 };
 
@@ -3953,6 +4008,7 @@ type ArchivedSessionWorktreeCleanupResponse = {
 		branch?: string;
 		status: "cleaned" | "skipped" | "already-cleaned" | "failed";
 		reason?: string;
+		detail?: string;
 		error?: string;
 		worktreeRemoved: boolean;
 		branchDeleted: boolean;
@@ -3967,6 +4023,8 @@ let archivedSessionWorktreeScan: ArchivedSessionWorktreeScanResponse | null = nu
 let archivedSessionWorktreeSelection = new Set<string>();
 let archivedSessionWorktreeCleanup: ArchivedSessionWorktreeCleanupResponse | null = null;
 let archivedSessionWorktreeError: string | null = null;
+let archivedSessionWorktreeShowSkipped = false;
+const archivedSessionWorktreeExpandedGroups = new Set<string>();
 
 // Search Index panel state
 let searchIndexStats: SearchStats | null = null;
@@ -4121,32 +4179,178 @@ async function cleanupWorktrees(): Promise<void> {
 function emptyArchivedSessionWorktreeScan(): ArchivedSessionWorktreeScanResponse {
 	return {
 		sessions: [],
+		items: [],
+		groups: [],
+		selectionPresets: [],
+		generatedAt: Date.now(),
 		counts: {
 			archivedSessions: 0,
 			sessionsWithWorktrees: 0,
 			removableWorktrees: 0,
 			skippedWorktrees: 0,
 			alreadyCleanedWorktrees: 0,
+			totalItems: 0,
+			readyToClean: 0,
+			defaultSelected: 0,
+			alreadyCleaned: 0,
+			ineligible: 0,
+			needsAttention: 0,
+			failed: 0,
+			byDisposition: {},
+			byReason: {},
+			bySelectionCategory: {},
 		},
 	};
 }
 
+function archivedSessionWorktreeKey(item: ArchivedSessionWorktreeItem): string {
+	return item.key || `${item.sessionId}:${item.repo || ""}:${item.path || ""}`;
+}
+
+function archivedSessionWorktreeDisposition(item: ArchivedSessionWorktreeItem): ArchivedSessionWorktreeDisposition {
+	if (item.disposition) return item.disposition;
+	if (item.status === "removable") return "ready-to-clean";
+	if (item.status === "already-cleaned") return "already-cleaned";
+	if (item.status === "failed") return "failed";
+	return "ineligible";
+}
+
+function isArchivedSessionWorktreeActionable(item: ArchivedSessionWorktreeItem): boolean {
+	if (item.actionable === false || item.selectable === false) return false;
+	return item.status === "removable" || archivedSessionWorktreeDisposition(item) === "ready-to-clean";
+}
+
 function archivedSessionWorktreeRows(): Array<{ session: ArchivedSessionWorktreeSession; item: ArchivedSessionWorktreeItem }> {
-	return (archivedSessionWorktreeScan?.sessions ?? []).flatMap(session =>
-		(session.worktrees ?? []).map(item => ({ session, item }))
+	const scan = archivedSessionWorktreeScan;
+	if (!scan) return [];
+	const sessionsById = new Map((scan.sessions ?? []).map(session => [session.id, session] as const));
+	if ((scan.items ?? []).length > 0) {
+		return (scan.items ?? []).map(item => {
+			const existing = sessionsById.get(item.sessionId);
+			const session: ArchivedSessionWorktreeSession = existing ?? {
+				id: item.sessionId,
+				title: item.title || "Untitled archived session",
+				archivedAt: item.archivedAt,
+				projectId: item.projectId,
+				projectName: item.projectName,
+				goalId: item.goalId,
+				teamGoalId: item.teamGoalId,
+				delegateOf: item.delegateOf,
+				parentSessionId: item.parentSessionId,
+				childKind: item.childKind,
+				sandboxed: item.sandboxed,
+				repoPath: item.repoPath,
+				worktreePath: item.path,
+				branch: item.branch,
+				worktrees: [],
+			};
+			return {
+				session,
+				item: {
+					...item,
+					title: item.title ?? session.title,
+					archivedAt: item.archivedAt ?? session.archivedAt,
+					projectId: item.projectId ?? session.projectId,
+					projectName: item.projectName ?? session.projectName,
+					goalId: item.goalId ?? session.goalId,
+					teamGoalId: item.teamGoalId ?? session.teamGoalId,
+					delegateOf: item.delegateOf ?? session.delegateOf,
+					parentSessionId: item.parentSessionId ?? session.parentSessionId,
+					childKind: item.childKind ?? session.childKind,
+					sandboxed: item.sandboxed ?? session.sandboxed,
+				},
+			};
+		});
+	}
+	return (scan.sessions ?? []).flatMap(session =>
+		(session.worktrees ?? []).map(item => ({
+			session,
+			item: {
+				...item,
+				title: item.title ?? session.title,
+				archivedAt: item.archivedAt ?? session.archivedAt,
+				projectId: item.projectId ?? session.projectId,
+				projectName: item.projectName ?? session.projectName,
+				goalId: item.goalId ?? session.goalId,
+				teamGoalId: item.teamGoalId ?? session.teamGoalId,
+				delegateOf: item.delegateOf ?? session.delegateOf,
+				parentSessionId: item.parentSessionId ?? session.parentSessionId,
+				childKind: item.childKind ?? session.childKind,
+				sandboxed: item.sandboxed ?? session.sandboxed,
+			},
+		}))
 	);
 }
 
+function archivedSessionWorktreeActionableRows(): Array<{ session: ArchivedSessionWorktreeSession; item: ArchivedSessionWorktreeItem }> {
+	return archivedSessionWorktreeRows().filter(({ item }) => isArchivedSessionWorktreeActionable(item));
+}
+
 function selectedArchivedSessionWorktrees(): Array<{ sessionId: string; repo?: string; path?: string; key?: string }> {
-	return archivedSessionWorktreeRows()
-		.filter(({ item }) => item.status === "removable" && archivedSessionWorktreeSelection.has(item.key))
-		.map(({ item }) => ({ sessionId: item.sessionId, repo: item.repo, path: item.path, key: item.key }));
+	return archivedSessionWorktreeActionableRows()
+		.filter(({ item }) => archivedSessionWorktreeSelection.has(archivedSessionWorktreeKey(item)))
+		.map(({ item }) => ({ sessionId: item.sessionId, repo: item.repo, path: item.path, key: archivedSessionWorktreeKey(item) }));
 }
 
 function toggleArchivedSessionWorktreeSelection(key: string, checked: boolean): void {
 	if (checked) archivedSessionWorktreeSelection.add(key);
 	else archivedSessionWorktreeSelection.delete(key);
 	renderApp();
+}
+
+function setArchivedSessionWorktreeSelection(rows: Array<{ item: ArchivedSessionWorktreeItem }>): void {
+	archivedSessionWorktreeSelection = new Set(rows.map(({ item }) => archivedSessionWorktreeKey(item)));
+	renderApp();
+}
+
+function archivedSessionWorktreeSelectionCategories(item: ArchivedSessionWorktreeItem): string[] {
+	return Array.isArray(item.selectionCategories) ? item.selectionCategories : [];
+}
+
+function isArchivedSessionOnlyWorktree(session: ArchivedSessionWorktreeSession, item: ArchivedSessionWorktreeItem): boolean {
+	const categories = archivedSessionWorktreeSelectionCategories(item);
+	if (categories.some(category => /goal|team|delegate/i.test(category))) return false;
+	return !item.goalId && !session.goalId && !item.teamGoalId && !session.teamGoalId && !item.delegateOf && !session.delegateOf && !item.parentSessionId && !session.parentSessionId && !item.childKind && !session.childKind;
+}
+
+function isGoalTeamDelegateWorktree(session: ArchivedSessionWorktreeSession, item: ArchivedSessionWorktreeItem): boolean {
+	const categories = archivedSessionWorktreeSelectionCategories(item);
+	return categories.some(category => /goal|team|delegate/i.test(category)) || !!item.goalId || !!session.goalId || !!item.teamGoalId || !!session.teamGoalId || !!item.delegateOf || !!session.delegateOf || !!item.parentSessionId || !!session.parentSessionId || !!item.childKind || !!session.childKind;
+}
+
+function archivedSessionWorktreeCounts(rows = archivedSessionWorktreeRows()): { readyToClean: number; alreadyCleaned: number; needsAttention: number; failed: number; totalItems: number } {
+	const counts = archivedSessionWorktreeScan?.counts;
+	const failed = counts?.failed ?? rows.filter(({ item }) => archivedSessionWorktreeDisposition(item) === "failed" || item.status === "failed").length;
+	return {
+		readyToClean: counts?.readyToClean ?? counts?.removableWorktrees ?? rows.filter(({ item }) => isArchivedSessionWorktreeActionable(item)).length,
+		alreadyCleaned: counts?.alreadyCleaned ?? counts?.alreadyCleanedWorktrees ?? rows.filter(({ item }) => archivedSessionWorktreeDisposition(item) === "already-cleaned").length,
+		needsAttention: counts?.needsAttention ?? ((counts?.skippedWorktrees ?? rows.filter(({ item }) => !isArchivedSessionWorktreeActionable(item) && archivedSessionWorktreeDisposition(item) !== "already-cleaned").length) + failed),
+		failed,
+		totalItems: counts?.totalItems ?? rows.length,
+	};
+}
+
+function normalizeArchivedSessionWorktreeScan(data: ArchivedSessionWorktreeScanResponse): ArchivedSessionWorktreeScanResponse {
+	const empty = emptyArchivedSessionWorktreeScan();
+	const rawCounts = data.counts ?? empty.counts;
+	const mergedCounts = {
+		...empty.counts,
+		...rawCounts,
+		readyToClean: rawCounts.readyToClean ?? rawCounts.removableWorktrees ?? 0,
+		alreadyCleaned: rawCounts.alreadyCleaned ?? rawCounts.alreadyCleanedWorktrees ?? 0,
+		failed: rawCounts.failed ?? 0,
+		ineligible: rawCounts.ineligible ?? rawCounts.skippedWorktrees ?? 0,
+		needsAttention: rawCounts.needsAttention ?? ((rawCounts.skippedWorktrees ?? 0) + (rawCounts.failed ?? 0)),
+		totalItems: rawCounts.totalItems ?? (rawCounts.removableWorktrees ?? 0) + (rawCounts.skippedWorktrees ?? 0) + (rawCounts.alreadyCleanedWorktrees ?? 0),
+	};
+	return {
+		sessions: data.sessions ?? [],
+		items: data.items ?? [],
+		groups: data.groups ?? [],
+		selectionPresets: data.selectionPresets ?? [],
+		generatedAt: data.generatedAt ?? Date.now(),
+		counts: mergedCounts,
+	};
 }
 
 async function scanArchivedSessionWorktrees(options: { preserveCleanupResult?: boolean } = {}): Promise<void> {
@@ -4158,15 +4362,14 @@ async function scanArchivedSessionWorktrees(options: { preserveCleanupResult?: b
 		const res = await gatewayFetch("/api/maintenance/archived-session-worktrees");
 		if (res.ok) {
 			const data = await res.json() as ArchivedSessionWorktreeScanResponse;
-			archivedSessionWorktreeScan = {
-				sessions: data.sessions ?? [],
-				counts: data.counts ?? emptyArchivedSessionWorktreeScan().counts,
-			};
+			archivedSessionWorktreeScan = normalizeArchivedSessionWorktreeScan(data);
 			archivedSessionWorktreeSelection = new Set(
-				archivedSessionWorktreeRows()
-					.filter(({ item }) => item.status === "removable")
-					.map(({ item }) => item.key)
+				archivedSessionWorktreeActionableRows()
+					.filter(({ item }) => item.defaultSelected !== false)
+					.map(({ item }) => archivedSessionWorktreeKey(item))
 			);
+			archivedSessionWorktreeExpandedGroups.clear();
+			if (!options.preserveCleanupResult) archivedSessionWorktreeShowSkipped = false;
 		} else {
 			archivedSessionWorktreeScan = emptyArchivedSessionWorktreeScan();
 			archivedSessionWorktreeSelection = new Set();
@@ -4181,9 +4384,20 @@ async function scanArchivedSessionWorktrees(options: { preserveCleanupResult?: b
 	renderApp();
 }
 
-async function cleanupArchivedSessionWorktrees(): Promise<void> {
+async function cleanupArchivedSessionWorktrees(mode: "selected" | "all" = "selected"): Promise<void> {
 	const worktrees = selectedArchivedSessionWorktrees();
-	if (worktrees.length === 0) return;
+	const readyToClean = archivedSessionWorktreeCounts().readyToClean;
+	if (mode === "selected" && worktrees.length === 0) return;
+	if (mode === "all" && readyToClean === 0) return;
+	if (mode === "all") {
+		const confirmed = await confirmAction(
+			`Clean ${readyToClean} archived-session worktree${readyToClean === 1 ? "" : "s"}?`,
+			"This removes only git worktrees and eligible branches. Archived sessions, transcripts, proposals, and archive visibility are preserved.",
+			"Clean worktrees",
+			true,
+		);
+		if (!confirmed) return;
+	}
 	maintenanceLoading = "archivedWorktrees";
 	archivedSessionWorktreeError = null;
 	let shouldRescan = false;
@@ -4191,10 +4405,11 @@ async function cleanupArchivedSessionWorktrees(): Promise<void> {
 	try {
 		const res = await gatewayFetch("/api/maintenance/cleanup-archived-session-worktrees", {
 			method: "POST",
-			body: JSON.stringify({ mode: "selected", worktrees }),
+			body: JSON.stringify(mode === "all" ? { mode: "all" } : { mode: "selected", worktrees }),
 		});
 		if (res.ok) {
 			archivedSessionWorktreeCleanup = await res.json() as ArchivedSessionWorktreeCleanupResponse;
+			archivedSessionWorktreeShowSkipped = (archivedSessionWorktreeCleanup.counts.failed + archivedSessionWorktreeCleanup.counts.skipped) > 0;
 			shouldRescan = true;
 		} else {
 			archivedSessionWorktreeCleanup = null;
@@ -4209,10 +4424,490 @@ async function cleanupArchivedSessionWorktrees(): Promise<void> {
 	else renderApp();
 }
 
-function archivedSessionWorktreeStatusClass(status: ArchivedSessionWorktreeStatus): string {
-	if (status === "removable") return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300 border border-emerald-500/20";
-	if (status === "already-cleaned") return "bg-secondary text-muted-foreground border border-border";
+function archivedSessionWorktreeStatusClass(status: ArchivedSessionWorktreeStatus | string, disposition?: ArchivedSessionWorktreeDisposition): string {
+	if (status === "removable" || disposition === "ready-to-clean") return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300 border border-emerald-500/20";
+	if (status === "already-cleaned" || disposition === "already-cleaned") return "bg-secondary text-muted-foreground border border-border";
+	if (status === "failed" || disposition === "failed") return "bg-destructive/10 text-destructive border border-destructive/20";
 	return "bg-amber-500/10 text-amber-700 dark:text-amber-300 border border-amber-500/20";
+}
+
+function archivedSessionWorktreeStatusLabel(status: ArchivedSessionWorktreeStatus | string, disposition?: ArchivedSessionWorktreeDisposition): string {
+	if (status === "removable" || disposition === "ready-to-clean") return "Ready to clean";
+	if (status === "already-cleaned" || disposition === "already-cleaned") return "Already cleaned";
+	if (status === "failed" || disposition === "failed") return "Cleanup failed";
+	return "Skipped";
+}
+
+function archivedSessionWorktreeReasonLabel(reason: string): string {
+	const labels: Record<string, string> = {
+		"safe-archived-session-worktree": "Ready to clean",
+		"already-cleaned": "Already cleaned",
+		"no-worktree-path": "Missing worktree path",
+		"missing-repo-path": "Missing repo path",
+		"sandbox-container-path": "Sandbox/container path",
+		"delegate-shared-worktree": "Delegate/shared worktree",
+		"stale-worktree-directory": "Stale worktree directory",
+		"referenced-by-live-session": "Referenced by live session",
+		"referenced-by-live-goal": "Referenced by live goal",
+		"referenced-by-live-team": "Referenced by live team",
+		"referenced-by-staff": "Referenced by staff",
+		"scan-error": "Scan error",
+		"cleanup-failed": "Cleanup failed",
+		"invalid-selection": "Invalid selection",
+	};
+	return labels[reason] ?? reason.replace(/-/g, " ").replace(/\b\w/g, ch => ch.toUpperCase());
+}
+
+function archivedSessionWorktreeReasonDetail(reason: string): string {
+	const details: Record<string, string> = {
+		"already-cleaned": "The archive still remembers the old path, but the worktree and git metadata are already gone.",
+		"no-worktree-path": "These archived sessions have no host worktree path recorded, so there is nothing for this tool to remove.",
+		"missing-repo-path": "The archived record does not include a repo path that can be checked on this host.",
+		"sandbox-container-path": "The path belongs to a sandbox/container context, not a host worktree that this maintenance action can remove.",
+		"delegate-shared-worktree": "Protected because another delegate or related record shares this worktree.",
+		"referenced-by-live-session": "Protected because a live session still references this path or branch.",
+		"referenced-by-live-goal": "Protected because another durable goal record still points at this path or branch.",
+		"referenced-by-live-team": "Protected because a team member record still references this path or branch.",
+		"referenced-by-staff": "Protected because a staff agent record still references this path or branch.",
+		"scan-error": "The server could not safely classify these records during the scan.",
+		"cleanup-failed": "Cleanup was requested, but git or filesystem operations did not complete for these records.",
+	};
+	return details[reason] ?? "These records are shown for troubleshooting and audit only.";
+}
+
+function archivedSessionWorktreeSafeReason(item: ArchivedSessionWorktreeItem): string {
+	if (isArchivedSessionWorktreeActionable(item)) return "Safe to remove: no live session, goal, team, staff, or sibling worktree references this path.";
+	return item.detail || archivedSessionWorktreeReasonDetail(item.reasonCategory || item.reason || archivedSessionWorktreeDisposition(item));
+}
+
+function sanitizeArchivedWorktreeGroupId(value: string): string {
+	return (value || "unknown").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "unknown";
+}
+
+function shortArchivedSessionId(id: string): string {
+	return id.length > 12 ? id.slice(0, 8) : id;
+}
+
+function archivedWorktreeProjectLabel(session: ArchivedSessionWorktreeSession, item: ArchivedSessionWorktreeItem): string {
+	return item.projectName || session.projectName || item.projectId || session.projectId || "No project";
+}
+
+function archivedWorktreeBranchOutcome(item: ArchivedSessionWorktreeItem): string {
+	if (item.willDeleteBranch) return "Branch will be deleted";
+	if (item.branchDeleteBlockedReason) return `Branch will be kept: ${item.branchDeleteBlockedReason}`;
+	return item.branch ? "Branch will be kept" : "No branch recorded";
+}
+
+function focusArchivedWorktreeElement(id: string): void {
+	window.setTimeout(() => {
+		const el = document.getElementById(id) as HTMLElement | null;
+		el?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+		el?.focus({ preventScroll: true });
+	}, 0);
+}
+
+function showArchivedWorktreeTroubleshootingAndFocus(reason?: string): void {
+	archivedSessionWorktreeShowSkipped = true;
+	renderApp();
+	focusArchivedWorktreeElement(reason ? `archived-worktree-group-${sanitizeArchivedWorktreeGroupId(reason)}` : "archived-worktree-troubleshooting-panel");
+}
+
+function renderArchivedWorktreeSummaryChip(label: string, value: number, testId: string, onClick?: () => void) {
+	const content = html`
+		<span class="text-[11px] text-muted-foreground">${label}</span>
+		<span class="text-sm font-semibold text-foreground">${value}</span>
+	`;
+	const classes = "flex min-w-[8rem] flex-col gap-0.5 rounded-md border border-border bg-secondary/30 px-3 py-2 text-left";
+	return onClick && value > 0 ? html`
+		<button type="button" class="${classes} hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring" data-testid=${testId} @click=${onClick}>${content}</button>
+	` : html`
+		<div class="${classes}" data-testid=${testId}>${content}</div>
+	`;
+}
+
+function renderArchivedWorktreeRow(session: ArchivedSessionWorktreeSession, item: ArchivedSessionWorktreeItem, options: { selectable: boolean }) {
+	const key = archivedSessionWorktreeKey(item);
+	const selected = archivedSessionWorktreeSelection.has(key);
+	const disposition = archivedSessionWorktreeDisposition(item);
+	const reason = item.reasonCategory || item.reason || disposition;
+	const category = item.selectionCategories?.[0] || disposition;
+	const status = item.status || (disposition === "ready-to-clean" ? "removable" : "skipped");
+	const title = item.title || session.title || "Untitled archived session";
+	const repoLabel = item.repoDisplayName || item.repo || ".";
+	const path = item.path || session.worktreePath || "No worktree path recorded";
+	const checkboxLabel = `Select archived worktree ${title} ${shortArchivedSessionId(session.id)} repo ${repoLabel} path ${path}`;
+	const body = html`
+		<div class="min-w-0 flex-1 flex flex-col gap-1">
+			<div class="flex flex-wrap items-center gap-1.5">
+				<span class="text-[10px] px-1.5 py-0.5 rounded ${archivedSessionWorktreeStatusClass(status, disposition)}">${archivedSessionWorktreeStatusLabel(status, disposition)}</span>
+				<span class="font-medium text-foreground truncate max-w-full">${title}</span>
+				<span class="font-mono text-[10px] text-muted-foreground">${shortArchivedSessionId(session.id)}</span>
+				<span class="text-[10px] px-1.5 py-0.5 rounded bg-secondary text-secondary-foreground">${archivedWorktreeProjectLabel(session, item)}</span>
+				${item.sandboxed || session.sandboxed ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-background text-muted-foreground border border-border">sandboxed</span>` : ""}
+			</div>
+			<div class="text-muted-foreground">${archivedSessionWorktreeSafeReason(item)}</div>
+			<div class="grid grid-cols-1 sm:grid-cols-2 gap-x-3 gap-y-1 font-mono text-muted-foreground">
+				<div class="break-all">repo: ${repoLabel}</div>
+				<div class="break-all">branch: ${item.branch || "none"}</div>
+				<div class="sm:col-span-2 break-all">worktree: ${path}</div>
+				${item.repoPath ? html`<div class="sm:col-span-2 break-all">repo path: ${item.repoPath}</div>` : ""}
+			</div>
+			<div class="text-muted-foreground">${archivedWorktreeBranchOutcome(item)}</div>
+			<details class="mt-1">
+				<summary class="cursor-pointer text-[11px] text-muted-foreground hover:text-foreground">Technical details</summary>
+				<div class="mt-1 grid grid-cols-1 sm:grid-cols-2 gap-x-3 gap-y-1 font-mono text-[11px] text-muted-foreground">
+					<div>status: ${status}</div>
+					<div>reason: ${reason}</div>
+					<div>disposition: ${disposition}</div>
+					<div>source: ${item.source || "session"}</div>
+					<div class="sm:col-span-2 break-all">key: ${key}</div>
+					${item.detail ? html`<div class="sm:col-span-2 break-all">detail: ${item.detail}</div>` : ""}
+				</div>
+			</details>
+		</div>
+	`;
+	const attrs = {
+		key,
+		status,
+		reason,
+		category,
+	};
+	return options.selectable ? html`
+		<label
+			class="flex items-start gap-2 rounded border border-border bg-background/70 p-2 text-xs cursor-pointer"
+			data-testid="archived-worktree-row"
+			data-status=${attrs.status}
+			data-reason=${attrs.reason}
+			data-category=${attrs.category}
+			data-archived-worktree-key=${attrs.key}
+			data-archived-worktree-status=${attrs.status}
+			data-archived-worktree-reason=${attrs.reason}
+		>
+			<input
+				type="checkbox"
+				class="mt-0.5 w-4 h-4 rounded border-input accent-primary shrink-0"
+				aria-label=${checkboxLabel}
+				.checked=${selected}
+				?disabled=${maintenanceLoading === "archivedWorktrees"}
+				@change=${(e: Event) => toggleArchivedSessionWorktreeSelection(key, (e.target as HTMLInputElement).checked)}
+			/>
+			${body}
+		</label>
+	` : html`
+		<div
+			class="flex items-start gap-2 rounded border border-border bg-background/70 p-2 text-xs opacity-90"
+			data-testid="archived-worktree-row"
+			data-status=${attrs.status}
+			data-reason=${attrs.reason}
+			data-category=${attrs.category}
+			data-archived-worktree-key=${attrs.key}
+			data-archived-worktree-status=${attrs.status}
+			data-archived-worktree-reason=${attrs.reason}
+		>
+			${body}
+		</div>
+	`;
+}
+
+type ArchivedWorktreeExample = {
+	key: string;
+	status: string;
+	disposition: ArchivedSessionWorktreeDisposition;
+	reason: string;
+	category: string;
+	title: string;
+	sessionId: string;
+	project: string;
+	repo?: string;
+	branch?: string;
+	path?: string;
+	detail?: string;
+	row?: { session: ArchivedSessionWorktreeSession; item: ArchivedSessionWorktreeItem };
+};
+
+function archivedWorktreeExamplesByReason(): Array<{ reason: string; label: string; detail: string; examples: ArchivedWorktreeExample[] }> {
+	const groups = new Map<string, ArchivedWorktreeExample[]>();
+	for (const row of archivedSessionWorktreeRows()) {
+		const { session, item } = row;
+		if (isArchivedSessionWorktreeActionable(item)) continue;
+		const disposition = archivedSessionWorktreeDisposition(item);
+		const reason = item.reasonCategory || item.reason || disposition;
+		const key = archivedSessionWorktreeKey(item);
+		const examples = groups.get(reason) ?? [];
+		examples.push({
+			key,
+			status: item.status,
+			disposition,
+			reason,
+			category: item.selectionCategories?.[0] || disposition,
+			title: item.title || session.title || "Untitled archived session",
+			sessionId: session.id,
+			project: archivedWorktreeProjectLabel(session, item),
+			repo: item.repoDisplayName || item.repo,
+			branch: item.branch,
+			path: item.path,
+			detail: item.detail || archivedSessionWorktreeReasonDetail(reason),
+			row,
+		});
+		groups.set(reason, examples);
+	}
+	for (const result of archivedSessionWorktreeCleanup?.results ?? []) {
+		if (result.status !== "failed" && result.status !== "skipped" && result.status !== "already-cleaned") continue;
+		const reason = result.status === "failed" ? "cleanup-failed" : (result.reason || result.status);
+		const examples = groups.get(reason) ?? [];
+		examples.push({
+			key: result.key,
+			status: result.status,
+			disposition: result.status === "failed" ? "failed" : result.status === "already-cleaned" ? "already-cleaned" : "needs-attention",
+			reason,
+			category: result.status,
+			title: result.title || "Archived session worktree",
+			sessionId: result.sessionId,
+			project: "Cleanup result",
+			repo: result.repo,
+			branch: result.branch,
+			path: result.path,
+			detail: result.error || result.detail || result.reason,
+		});
+		groups.set(reason, examples);
+	}
+	return Array.from(groups.entries()).map(([reason, examples]) => ({
+		reason,
+		label: archivedSessionWorktreeReasonLabel(reason),
+		detail: archivedSessionWorktreeReasonDetail(reason),
+		examples,
+	})).sort((a, b) => a.label.localeCompare(b.label));
+}
+
+function renderArchivedWorktreeExample(example: ArchivedWorktreeExample) {
+	if (example.row) return renderArchivedWorktreeRow(example.row.session, example.row.item, { selectable: false });
+	const groupStatus = example.status === "failed" ? "failed" : example.status === "already-cleaned" ? "already-cleaned" : "skipped";
+	return html`
+		<div
+			class="rounded border border-border bg-background/70 p-2 text-xs"
+			data-testid="archived-worktree-row"
+			data-status=${groupStatus}
+			data-reason=${example.reason}
+			data-category=${example.category}
+			data-archived-worktree-key=${example.key}
+			data-archived-worktree-status=${groupStatus}
+			data-archived-worktree-reason=${example.reason}
+		>
+			<div class="flex flex-wrap items-center gap-1.5">
+				<span class="text-[10px] px-1.5 py-0.5 rounded ${archivedSessionWorktreeStatusClass(groupStatus, example.disposition)}">${archivedSessionWorktreeStatusLabel(groupStatus, example.disposition)}</span>
+				<span class="font-medium text-foreground">${example.title}</span>
+				<span class="font-mono text-[10px] text-muted-foreground">${shortArchivedSessionId(example.sessionId)}</span>
+				<span class="text-[10px] px-1.5 py-0.5 rounded bg-secondary text-secondary-foreground">${example.project}</span>
+			</div>
+			<div class="mt-1 text-muted-foreground">${example.detail || archivedSessionWorktreeReasonDetail(example.reason)}</div>
+			<div class="mt-1 grid grid-cols-1 sm:grid-cols-2 gap-x-3 gap-y-1 font-mono text-muted-foreground">
+				${example.repo ? html`<div class="break-all">repo: ${example.repo}</div>` : ""}
+				${example.branch ? html`<div class="break-all">branch: ${example.branch}</div>` : ""}
+				${example.path ? html`<div class="sm:col-span-2 break-all">worktree: ${example.path}</div>` : ""}
+			</div>
+		</div>
+	`;
+}
+
+function renderArchivedWorktreeTroubleshooting() {
+	const groups = archivedWorktreeExamplesByReason();
+	if (groups.length === 0) return html``;
+	return html`
+		<div id="archived-worktree-troubleshooting-panel" tabindex="-1" class="flex flex-col gap-2 rounded-md border border-border bg-secondary/20 p-3" data-testid="archived-worktree-troubleshooting">
+			<p class="text-xs text-muted-foreground">These records are not cleanup actions. They are shown for troubleshooting and audit only.</p>
+			${groups.map(group => {
+				const id = sanitizeArchivedWorktreeGroupId(group.reason);
+				const expanded = archivedSessionWorktreeExpandedGroups.has(id);
+				const visible = expanded ? group.examples : group.examples.slice(0, 5);
+				return html`
+					<section
+						id="archived-worktree-group-${id}"
+						tabindex="-1"
+						class="flex flex-col gap-1 rounded-md border border-border bg-background/60 p-2"
+						data-testid="archived-worktree-group-${id}"
+						data-reason=${group.reason}
+						data-category=${id}
+					>
+						<div class="flex flex-wrap items-start justify-between gap-2">
+							<div>
+								<h4 class="text-xs font-semibold text-foreground">${group.label} (${group.examples.length})</h4>
+								<p class="text-[11px] text-muted-foreground">${group.detail}</p>
+							</div>
+							${group.examples.length > 5 ? html`
+								<button
+									type="button"
+									class="px-2 py-1 text-[11px] rounded-md border border-input bg-background text-foreground hover:bg-secondary transition-colors"
+									data-testid="archived-worktree-show-all-${id}"
+									data-action="show-all-archived-worktree-examples"
+									data-reason=${group.reason}
+									@click=${() => {
+										if (expanded) archivedSessionWorktreeExpandedGroups.delete(id);
+										else archivedSessionWorktreeExpandedGroups.add(id);
+										renderApp();
+									}}
+								>${expanded ? "Show first 5" : `Show all (${group.examples.length})`}</button>
+							` : ""}
+						</div>
+						<div class="flex flex-col gap-1 mt-1">
+							${visible.map(renderArchivedWorktreeExample)}
+						</div>
+					</section>
+				`;
+			})}
+		</div>
+	`;
+}
+
+function renderArchivedWorktreeCleanupResult() {
+	const cleanup = archivedSessionWorktreeCleanup;
+	if (!cleanup) return html``;
+	const attention = cleanup.counts.failed + cleanup.counts.skipped;
+	return html`
+		<div class="rounded-md bg-secondary/30 border border-border p-2 text-xs text-muted-foreground mt-1" data-testid="archived-worktree-cleanup-result" aria-live=${attention > 0 ? "assertive" : "polite"}>
+			<div class="text-foreground font-medium">${attention > 0 ? "Cleanup finished with attention needed" : "Cleanup complete"}</div>
+			<div>
+				Cleaned ${cleanup.counts.cleaned}, deleted ${cleanup.counts.branchDeleted} branch${cleanup.counts.branchDeleted === 1 ? "" : "es"}, skipped ${cleanup.counts.skipped}, already cleaned ${cleanup.counts.alreadyCleaned}, failed ${cleanup.counts.failed}.
+			</div>
+			${attention > 0 ? html`
+				<div class="mt-1 text-muted-foreground">Open skipped / ineligible items to inspect skipped or failed cleanup examples.</div>
+			` : ""}
+		</div>
+	`;
+}
+
+function renderArchivedSessionWorktreeMaintenance(scanBtnClass: string, actionBtnClass: string) {
+	const rows = archivedSessionWorktreeRows();
+	const actionableRows = rows.filter(({ item }) => isArchivedSessionWorktreeActionable(item));
+	const counts = archivedSessionWorktreeCounts(rows);
+	const selectedCount = selectedArchivedSessionWorktrees().length;
+	const hasScan = !!archivedSessionWorktreeScan;
+	const loading = maintenanceLoading === "archivedWorktrees";
+	const currentProjectRows = state.activeProjectId
+		? actionableRows.filter(({ item }) => item.projectId === state.activeProjectId)
+		: [];
+	const archivedOnlyRows = actionableRows.filter(({ session, item }) => isArchivedSessionOnlyWorktree(session, item));
+	const goalTeamDelegateRows = actionableRows.filter(({ session, item }) => isGoalTeamDelegateWorktree(session, item));
+	const cleanupHelper = !hasScan
+		? "Scan first to find safe candidates."
+		: counts.readyToClean === 0
+			? "Cleanup is disabled because there are 0 safe candidates."
+			: selectedCount === 0
+				? "Select at least one safe candidate."
+				: "Cleanup removes only git worktrees and eligible branches; archived sessions stay visible.";
+	const scanLabel = loading && !hasScan ? "Scanning..." : hasScan ? "Rescan" : "Scan";
+	return html`
+		<div class="flex flex-col gap-2 rounded-md border border-border p-4" data-section="archived-session-worktrees" data-testid="archived-worktree-maintenance" role="region" aria-labelledby="archived-worktree-maintenance-title">
+			<div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+				<div>
+					<h3 id="archived-worktree-maintenance-title" class="text-sm font-semibold text-foreground">Archived Session Worktrees</h3>
+					<p class="text-xs text-muted-foreground">
+						Reclaim git worktrees from archived sessions while keeping transcripts, proposals, and archive visibility intact.
+					</p>
+				</div>
+				<div class="flex flex-wrap items-center gap-2">
+					<button
+						class="${scanBtnClass}"
+						?disabled=${loading}
+						@click=${() => scanArchivedSessionWorktrees()}
+						data-testid="archived-worktree-scan"
+						data-action="scan-archived-session-worktrees"
+					>${scanLabel}</button>
+					<button
+						class="${actionBtnClass}"
+						?disabled=${loading || !hasScan || counts.readyToClean === 0}
+						@click=${() => cleanupArchivedSessionWorktrees("all")}
+						data-testid="archived-worktree-clean-all"
+						data-action="cleanup-all-archived-session-worktrees"
+					>${loading && hasScan ? "Cleaning..." : `Clean all safe candidates${counts.readyToClean > 0 ? ` (${counts.readyToClean})` : ""}`}</button>
+				</div>
+			</div>
+
+			<div aria-live="polite" class="flex flex-col gap-2">
+				${hasScan ? html`
+					<div class="grid grid-cols-2 lg:grid-cols-4 gap-2 mt-1" aria-controls="archived-worktree-actionable-list archived-worktree-troubleshooting-panel">
+						${renderArchivedWorktreeSummaryChip("Ready to clean", counts.readyToClean, "archived-worktree-summary-ready", counts.readyToClean > 0 ? () => focusArchivedWorktreeElement("archived-worktree-actionable-list") : undefined)}
+						${renderArchivedWorktreeSummaryChip("Selected", selectedCount, "archived-worktree-summary-selected")}
+						${renderArchivedWorktreeSummaryChip("Already cleaned", counts.alreadyCleaned, "archived-worktree-summary-already-cleaned", counts.alreadyCleaned > 0 ? () => showArchivedWorktreeTroubleshootingAndFocus("already-cleaned") : undefined)}
+						${renderArchivedWorktreeSummaryChip("Needs attention", counts.needsAttention, "archived-worktree-summary-needs-attention", counts.needsAttention > 0 ? () => showArchivedWorktreeTroubleshootingAndFocus(archivedWorktreeExamplesByReason().find(group => group.reason !== "already-cleaned")?.reason) : undefined)}
+					</div>
+					<p class="text-[11px] text-muted-foreground" data-testid="archived-worktree-metadata-count">
+						Scanned ${archivedSessionWorktreeScan?.counts.archivedSessions ?? 0} archived sessions. Has worktree metadata: ${archivedSessionWorktreeScan?.counts.sessionsWithWorktrees ?? 0} — historical records, not necessarily removable.
+					</p>
+				` : ""}
+
+				${renderArchivedWorktreeCleanupResult()}
+
+				${archivedSessionWorktreeError ? html`
+					<p class="text-xs text-destructive mt-1" aria-live="assertive">${archivedSessionWorktreeError}</p>
+				` : ""}
+
+				<p class="text-xs text-muted-foreground" data-testid="archived-worktree-cleanup-helper">${cleanupHelper}</p>
+
+				${hasScan && counts.readyToClean === 0 ? html`
+					<div class="rounded-md border border-border bg-secondary/20 p-3 text-xs" data-testid="archived-worktree-empty-state">
+						<h4 class="text-sm font-semibold text-foreground">Nothing safe to clean right now</h4>
+						<p class="mt-1 text-muted-foreground">Archived sessions were scanned, but no removable host worktrees are currently safe to delete.</p>
+						<p class="mt-1 text-muted-foreground">Common reasons: the worktree is already gone, the archived record has no host worktree path, the path belongs to a sandbox/container, or another live session, goal, team member, or staff agent still references it.</p>
+					</div>
+				` : ""}
+
+				${hasScan && counts.readyToClean > 0 ? html`
+					<div id="archived-worktree-actionable-list" tabindex="-1" class="flex flex-col gap-2 mt-1">
+						<div class="flex flex-wrap items-center gap-2">
+							<button type="button" class="px-2 py-1 text-xs rounded-md border border-input bg-background text-foreground hover:bg-secondary transition-colors" data-testid="archived-worktree-select-all-removable" data-action="select-all-removable-archived-worktrees" @click=${() => setArchivedSessionWorktreeSelection(actionableRows)}>Select all removable (${actionableRows.length})</button>
+							${archivedOnlyRows.length > 0 ? html`<button type="button" class="px-2 py-1 text-xs rounded-md border border-input bg-background text-foreground hover:bg-secondary transition-colors" data-testid="archived-worktree-select-archived-sessions" data-action="select-archived-session-worktrees-only" @click=${() => setArchivedSessionWorktreeSelection(archivedOnlyRows)}>Archived sessions only (${archivedOnlyRows.length})</button>` : ""}
+							${currentProjectRows.length > 0 ? html`<button type="button" class="px-2 py-1 text-xs rounded-md border border-input bg-background text-foreground hover:bg-secondary transition-colors" data-testid="archived-worktree-select-current-project" data-action="select-current-project-archived-worktrees" @click=${() => setArchivedSessionWorktreeSelection(currentProjectRows)}>Current project (${currentProjectRows.length})</button>` : ""}
+							${goalTeamDelegateRows.length > 0 ? html`<button type="button" class="px-2 py-1 text-xs rounded-md border border-input bg-background text-foreground hover:bg-secondary transition-colors" data-testid="archived-worktree-select-goal-team-delegate" data-action="select-goal-team-delegate-archived-worktrees" @click=${() => setArchivedSessionWorktreeSelection(goalTeamDelegateRows)}>Goal/team/delegate worktrees (${goalTeamDelegateRows.length})</button>` : ""}
+							<button type="button" class="px-2 py-1 text-xs rounded-md border border-input bg-background text-foreground hover:bg-secondary transition-colors disabled:opacity-50" ?disabled=${selectedCount === 0} data-testid="archived-worktree-clear-selection" data-action="clear-archived-worktree-selection" @click=${() => setArchivedSessionWorktreeSelection([])}>Clear selection</button>
+						</div>
+						<div class="flex flex-col gap-1 max-h-96 overflow-y-auto">
+							${actionableRows.map(({ session, item }) => renderArchivedWorktreeRow(session, item, { selectable: true }))}
+						</div>
+						<div class="flex items-center gap-2">
+							<button
+								class="${actionBtnClass}"
+								?disabled=${loading || selectedCount === 0}
+								@click=${() => cleanupArchivedSessionWorktrees("selected")}
+								data-testid="archived-worktree-clean-selected"
+								data-action="cleanup-archived-session-worktrees"
+							>${loading ? "Cleaning..." : `Clean selected (${selectedCount})`}</button>
+							<span class="text-xs text-muted-foreground">${selectedCount} selected</span>
+						</div>
+					</div>
+				` : hasScan ? html`
+					<button
+						type="button"
+						class="self-start px-2 py-1 text-xs rounded-md border border-input bg-background text-foreground hover:bg-secondary transition-colors"
+						data-testid="archived-worktree-clean-selected"
+						data-action="cleanup-archived-session-worktrees"
+						?disabled=${true}
+					>Clean selected (0)</button>
+				` : html`
+					<button
+						type="button"
+						class="self-start px-2 py-1 text-xs rounded-md border border-input bg-background text-foreground hover:bg-secondary transition-colors disabled:opacity-50"
+						data-testid="archived-worktree-clean-selected"
+						data-action="cleanup-archived-session-worktrees"
+						?disabled=${true}
+					>Clean selected</button>
+				`}
+
+				${hasScan && archivedWorktreeExamplesByReason().length > 0 ? html`
+					<div class="flex flex-col gap-2 mt-1">
+						<button
+							type="button"
+							class="self-start px-2 py-1 text-xs rounded-md border border-input bg-background text-foreground hover:bg-secondary transition-colors"
+							aria-expanded=${archivedSessionWorktreeShowSkipped ? "true" : "false"}
+							aria-controls="archived-worktree-troubleshooting-panel"
+							data-testid="archived-worktree-show-skipped"
+							@click=${() => { archivedSessionWorktreeShowSkipped = !archivedSessionWorktreeShowSkipped; renderApp(); }}
+						>${archivedSessionWorktreeShowSkipped ? "Hide skipped / ineligible items" : counts.readyToClean === 0 ? "Show why not removable" : "Show skipped / ineligible items"}</button>
+						${archivedSessionWorktreeShowSkipped ? renderArchivedWorktreeTroubleshooting() : ""}
+					</div>
+				` : ""}
+			</div>
+		</div>
+	`;
 }
 
 async function scanSessions(): Promise<void> {
@@ -4285,9 +4980,6 @@ function renderMaintenanceTab() {
 		if (total <= 0) return 0; // indeterminate
 		return Math.min(100, Math.round((completed / total) * 100));
 	})();
-	const archivedWorktreeRows = archivedSessionWorktreeRows();
-	const selectedArchivedWorktreeCount = selectedArchivedSessionWorktrees().length;
-
 	return html`
 		<div class="flex flex-col gap-6">
 			<p class="text-sm text-muted-foreground">
@@ -4389,102 +5081,7 @@ function renderMaintenanceTab() {
 			</div>
 
 			<!-- Archived Session Worktrees -->
-			<div class="flex flex-col gap-2 rounded-md border border-border p-4" data-section="archived-session-worktrees">
-				<h3 class="text-sm font-semibold text-foreground">Archived Session Worktrees</h3>
-				<p class="text-xs text-muted-foreground">
-					Git worktrees owned by archived sessions. Cleanup removes only git worktrees and eligible branches; archived sessions stay visible.
-				</p>
-				${archivedSessionWorktreeScan ? html`
-					<div class="flex flex-wrap gap-1.5 mt-1">
-						<span class="text-[10px] px-1.5 py-0.5 rounded bg-secondary text-secondary-foreground">Archived sessions: ${archivedSessionWorktreeScan.counts.archivedSessions}</span>
-						<span class="text-[10px] px-1.5 py-0.5 rounded bg-secondary text-secondary-foreground">With worktrees: ${archivedSessionWorktreeScan.counts.sessionsWithWorktrees}</span>
-						<span class="text-[10px] px-1.5 py-0.5 rounded bg-secondary text-secondary-foreground">Removable: ${archivedSessionWorktreeScan.counts.removableWorktrees}</span>
-						<span class="text-[10px] px-1.5 py-0.5 rounded bg-secondary text-secondary-foreground">Skipped: ${archivedSessionWorktreeScan.counts.skippedWorktrees}</span>
-						<span class="text-[10px] px-1.5 py-0.5 rounded bg-secondary text-secondary-foreground">Already cleaned: ${archivedSessionWorktreeScan.counts.alreadyCleanedWorktrees}</span>
-					</div>
-					${archivedSessionWorktreeScan.sessions.length > 0 ? html`
-						<div class="flex flex-col gap-2 mt-1 max-h-96 overflow-y-auto">
-							${archivedSessionWorktreeScan.sessions.map(session => html`
-								<div class="rounded-md border border-border bg-secondary/20 p-2">
-									<div class="flex flex-wrap items-center gap-2 text-xs mb-2">
-										<span class="font-medium text-foreground truncate max-w-full">${session.title || "Untitled archived session"}</span>
-										<span class="font-mono text-[10px] text-muted-foreground">${session.id}</span>
-										${session.projectName || session.projectId ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-background text-muted-foreground border border-border">${session.projectName || session.projectId}</span>` : ""}
-										${session.sandboxed ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-background text-muted-foreground border border-border">sandboxed</span>` : ""}
-									</div>
-									<div class="flex flex-col gap-1">
-										${session.worktrees.map(item => {
-											const removable = item.status === "removable";
-											const selected = archivedSessionWorktreeSelection.has(item.key);
-											return html`
-												<label
-													class="flex items-start gap-2 rounded border border-border bg-background/70 p-2 text-xs ${removable ? "cursor-pointer" : "opacity-75"}"
-													data-archived-worktree-key=${item.key}
-												>
-													<input
-														type="checkbox"
-														class="mt-0.5 w-4 h-4 rounded border-input accent-primary shrink-0"
-														.checked=${selected}
-														?disabled=${!removable || maintenanceLoading === "archivedWorktrees"}
-														@change=${(e: Event) => toggleArchivedSessionWorktreeSelection(item.key, (e.target as HTMLInputElement).checked)}
-													/>
-													<div class="min-w-0 flex-1 flex flex-col gap-1">
-														<div class="flex flex-wrap items-center gap-1.5">
-															<span class="text-[10px] px-1.5 py-0.5 rounded ${archivedSessionWorktreeStatusClass(item.status)}">${item.status}</span>
-															<span class="font-mono text-muted-foreground">repo: ${item.repo}</span>
-															<span class="font-mono text-muted-foreground">branch: ${item.branch || "none"}</span>
-															${item.willDeleteBranch ? html`<span class="text-[10px] px-1.5 py-0.5 rounded bg-destructive/10 text-destructive">branch will be deleted</span>` : ""}
-														</div>
-														<div class="font-mono text-muted-foreground break-all">worktree: ${item.path}</div>
-														<div class="font-mono text-muted-foreground break-all">repo path: ${item.repoPath}</div>
-														<div class="text-muted-foreground">${item.detail || item.reason}</div>
-														${item.branchDeleteBlockedReason ? html`<div class="text-muted-foreground">Branch kept: ${item.branchDeleteBlockedReason}</div>` : ""}
-													</div>
-												</label>
-											`;
-										})}
-									</div>
-								</div>
-							`)}
-						</div>
-					` : html`
-						<p class="text-xs text-muted-foreground italic mt-1">No archived session worktrees found.</p>
-					`}
-				` : ""}
-				${archivedSessionWorktreeCleanup ? html`
-					<div class="rounded-md bg-secondary/30 border border-border p-2 text-xs text-muted-foreground mt-1">
-						<span class="text-foreground font-medium">Cleanup result:</span>
-						requested ${archivedSessionWorktreeCleanup.counts.requested}, cleaned ${archivedSessionWorktreeCleanup.counts.cleaned}, branch deleted ${archivedSessionWorktreeCleanup.counts.branchDeleted}, skipped ${archivedSessionWorktreeCleanup.counts.skipped}, already cleaned ${archivedSessionWorktreeCleanup.counts.alreadyCleaned}, failed ${archivedSessionWorktreeCleanup.counts.failed}.
-						${archivedSessionWorktreeCleanup.results.some(result => result.status === "failed") ? html`
-							<div class="mt-1 flex flex-col gap-1">
-								${archivedSessionWorktreeCleanup.results.filter(result => result.status === "failed").map(result => html`
-									<div class="text-destructive font-mono break-all">${result.path || result.key}: ${result.error || result.reason || "failed"}</div>
-								`)}
-							</div>
-						` : ""}
-					</div>
-				` : ""}
-				${archivedSessionWorktreeError ? html`
-					<p class="text-xs text-destructive mt-1">${archivedSessionWorktreeError}</p>
-				` : ""}
-				<div class="flex items-center gap-2 mt-2">
-					<button
-						class="${scanBtnClass}"
-						?disabled=${maintenanceLoading === "archivedWorktrees"}
-						@click=${() => scanArchivedSessionWorktrees()}
-						data-action="scan-archived-session-worktrees"
-					>${maintenanceLoading === "archivedWorktrees" && archivedSessionWorktreeScan === null ? "Scanning..." : "Scan"}</button>
-					<button
-						class="${actionBtnClass}"
-						?disabled=${maintenanceLoading === "archivedWorktrees" || !archivedSessionWorktreeScan || selectedArchivedWorktreeCount === 0}
-						@click=${cleanupArchivedSessionWorktrees}
-						data-action="cleanup-archived-session-worktrees"
-					>${maintenanceLoading === "archivedWorktrees" && archivedSessionWorktreeScan !== null ? "Cleaning..." : `Clean Up Selected${selectedArchivedWorktreeCount > 0 ? ` (${selectedArchivedWorktreeCount})` : ""}`}</button>
-					${archivedSessionWorktreeScan && archivedWorktreeRows.length > 0 ? html`
-						<span class="text-xs text-muted-foreground">${selectedArchivedWorktreeCount} selected</span>
-					` : ""}
-				</div>
-			</div>
+			${renderArchivedSessionWorktreeMaintenance(scanBtnClass, actionBtnClass)}
 
 			<!-- Orphaned Sessions -->
 			<div class="flex flex-col gap-2 rounded-md border border-border p-4">

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -169,6 +169,7 @@ export interface ArchivedSessionWorktreeGroup {
 	reasonCategory?: ArchivedWorktreeReasonCategory;
 	count: number;
 	sampleKeys: string[];
+	sampleItems: ArchivedSessionWorktreeItem[];
 	hasMore: boolean;
 	actionable: boolean;
 }
@@ -227,7 +228,7 @@ export interface ArchivedSessionWorktreeItem {
 	reason: ArchivedWorktreeReason;
 	detail: string;
 	willDeleteBranch: boolean;
-	branchDeleteBlockedReason?: "branch-referenced-by-live-record";
+	branchDeleteBlockedReason?: "branch-referenced-by-live-record" | "branch-referenced-by-archived-record";
 	disposition: ArchivedWorktreeDisposition;
 	reasonCategory: ArchivedWorktreeReasonCategory;
 	actionable: boolean;
@@ -301,6 +302,7 @@ interface ArchivedWorktreeScanContext {
 	teamRefs: ArchivedWorktreeGuardRef[];
 	staffRefs: ArchivedWorktreeGuardRef[];
 	branchGuardsByRepo: Map<string, Set<string>>;
+	archivedBranchGuardsByRepo: Map<string, Map<string, Set<string>>>;
 	gitRefsCache: Map<string, Promise<GitWorktreeRefs>>;
 	branchExistsCache: Map<string, Promise<boolean>>;
 }
@@ -7522,7 +7524,7 @@ export class SessionManager {
 			sessions,
 			items: responseItems,
 			counts,
-			groups: this.buildArchivedWorktreeGroups(responseItems),
+			groups: this.buildArchivedWorktreeGroups(allItems),
 			selectionPresets: this.buildArchivedWorktreeSelectionPresets(responseItems),
 			generatedAt: Date.now(),
 		};
@@ -7702,6 +7704,7 @@ export class SessionManager {
 				? items.filter(item => item.disposition === "ready-to-clean")
 				: items.filter(item => item.reason === spec.reason);
 			if (matches.length === 0) return [];
+			const sampleItems = matches.slice(0, 5);
 			return [{
 				key: spec.key,
 				label: spec.label,
@@ -7710,7 +7713,8 @@ export class SessionManager {
 				reason: spec.reason,
 				reasonCategory: spec.reason ? this.archivedWorktreeReasonCategory(spec.reason) : undefined,
 				count: matches.length,
-				sampleKeys: matches.slice(0, 5).map(item => item.key),
+				sampleKeys: sampleItems.map(item => item.key),
+				sampleItems,
 				hasMore: matches.length > 5,
 				actionable: spec.disposition === "ready-to-clean",
 			}];
@@ -7810,6 +7814,7 @@ export class SessionManager {
 		const teamRefs: ArchivedWorktreeGuardRef[] = [];
 		const staffRefs: ArchivedWorktreeGuardRef[] = [];
 		const branchGuardsByRepo = new Map<string, Set<string>>();
+		const archivedBranchGuardsByRepo = new Map<string, Map<string, Set<string>>>();
 		const addBranchGuard = (repoPath: string | undefined, branch: string | undefined) => {
 			const repoKey = normalizeWorktreeHostPath(repoPath);
 			if (!repoKey || !branch) return;
@@ -7819,6 +7824,21 @@ export class SessionManager {
 				branchGuardsByRepo.set(repoKey, set);
 			}
 			set.add(branch);
+		};
+		const addArchivedBranchGuard = (repoPath: string | undefined, branch: string | undefined, itemKey: string) => {
+			const repoKey = normalizeWorktreeHostPath(repoPath);
+			if (!repoKey || !branch) return;
+			let branches = archivedBranchGuardsByRepo.get(repoKey);
+			if (!branches) {
+				branches = new Map<string, Set<string>>();
+				archivedBranchGuardsByRepo.set(repoKey, branches);
+			}
+			let keys = branches.get(branch);
+			if (!keys) {
+				keys = new Set<string>();
+				branches.set(branch, keys);
+			}
+			keys.add(itemKey);
 		};
 		const addRepoBranches = (repoPath: string | undefined, branch: string | undefined, repoWorktrees?: Record<string, string>) => {
 			if (repoWorktrees && repoPath) {
@@ -7842,6 +7862,20 @@ export class SessionManager {
 				for (const wt of session.repoWorktrees) addBranchGuard(wt.repoPath, session.branch);
 			} else {
 				addBranchGuard(session.repoPath, session.branch);
+			}
+		}
+
+		const archivedSessions = this.projectContextManager
+			? allContexts.flatMap(ctx => ctx.sessionStore.getArchived())
+			: (this._testStore?.getArchived() ?? []);
+		for (const ps of archivedSessions) {
+			if (ps.repoWorktrees && Object.keys(ps.repoWorktrees).length > 0 && ps.repoPath) {
+				for (const [repo, wt] of Object.entries(ps.repoWorktrees)) {
+					const repoPath = repo === "." ? ps.repoPath : path.join(ps.repoPath, repo);
+					addArchivedBranchGuard(repoPath, ps.branch, this.archivedWorktreeKey(ps.id, repo, wt));
+				}
+			} else {
+				addArchivedBranchGuard(ps.repoPath, ps.branch, this.archivedWorktreeKey(ps.id, ".", ps.worktreePath));
 			}
 		}
 
@@ -7876,6 +7910,7 @@ export class SessionManager {
 			teamRefs,
 			staffRefs,
 			branchGuardsByRepo,
+			archivedBranchGuardsByRepo,
 			gitRefsCache: new Map(),
 			branchExistsCache: new Map(),
 		};
@@ -7992,8 +8027,8 @@ export class SessionManager {
 			});
 		}
 
-		const branchDeleteBlockedReason = localBranchExists && !this.branchDeletionAllowed(spec.branch, spec.repoPath, ctx)
-			? "branch-referenced-by-live-record"
+		const branchDeleteBlockedReason = localBranchExists
+			? this.branchDeleteBlockedReason(spec.branch, spec.repoPath, ctx, key)
 			: undefined;
 		const willDeleteBranch = localBranchExists && !branchDeleteBlockedReason;
 		return base({
@@ -8002,9 +8037,11 @@ export class SessionManager {
 			localBranchExists,
 			status: "removable",
 			reason: "safe-archived-session-worktree",
-			detail: branchDeleteBlockedReason
-				? "Archived session worktree is safe to remove; branch deletion is blocked because another record still references the branch."
-				: "Archived session worktree is safe to remove.",
+			detail: branchDeleteBlockedReason === "branch-referenced-by-archived-record"
+				? "Archived session worktree is safe to remove; branch deletion is blocked because another archived record still references the branch."
+				: branchDeleteBlockedReason
+					? "Archived session worktree is safe to remove; branch deletion is blocked because another live record still references the branch."
+					: "Archived session worktree is safe to remove.",
 			willDeleteBranch,
 			branchDeleteBlockedReason,
 		});
@@ -8035,11 +8072,18 @@ export class SessionManager {
 		return false;
 	}
 
-	private branchDeletionAllowed(branch: string | undefined, repoPath: string, ctx: ArchivedWorktreeScanContext): boolean {
-		if (!branch) return false;
+	private branchDeleteBlockedReason(branch: string | undefined, repoPath: string, ctx: ArchivedWorktreeScanContext, ownKey?: string): ArchivedSessionWorktreeItem["branchDeleteBlockedReason"] | undefined {
+		if (!branch) return "branch-referenced-by-live-record";
 		const repoKey = normalizeWorktreeHostPath(repoPath);
-		if (!repoKey) return false;
-		return !ctx.branchGuardsByRepo.get(repoKey)?.has(branch);
+		if (!repoKey) return "branch-referenced-by-live-record";
+		if (ctx.branchGuardsByRepo.get(repoKey)?.has(branch)) return "branch-referenced-by-live-record";
+		const archivedKeys = ctx.archivedBranchGuardsByRepo.get(repoKey)?.get(branch);
+		if (archivedKeys && [...archivedKeys].some(key => key !== ownKey)) return "branch-referenced-by-archived-record";
+		return undefined;
+	}
+
+	private branchDeletionAllowed(branch: string | undefined, repoPath: string, ctx: ArchivedWorktreeScanContext, ownKey?: string): boolean {
+		return !this.branchDeleteBlockedReason(branch, repoPath, ctx, ownKey);
 	}
 
 	private async archivedWorktreeRemoved(item: ArchivedSessionWorktreeItem): Promise<boolean> {
@@ -8054,7 +8098,7 @@ export class SessionManager {
 	private async deleteArchivedWorktreeBranchIfAllowed(item: ArchivedSessionWorktreeItem): Promise<boolean> {
 		if (!item.willDeleteBranch || !item.branch || !item.localBranchExists) return false;
 		const ctx = this.buildArchivedWorktreeScanContext();
-		if (!this.branchDeletionAllowed(item.branch, item.repoPath, ctx)) return false;
+		if (!this.branchDeletionAllowed(item.branch, item.repoPath, ctx, item.key)) return false;
 		try {
 			await execFileAsync("git", ["branch", "-D", item.branch], { cwd: item.repoPath });
 		} catch {

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -7516,13 +7516,14 @@ export class SessionManager {
 			});
 		}
 
+		const responseItems = sessions.flatMap(session => session.worktrees);
 		this.populateArchivedWorktreeUxCounts(counts, allItems);
 		return {
 			sessions,
-			items: allItems,
+			items: responseItems,
 			counts,
-			groups: this.buildArchivedWorktreeGroups(allItems),
-			selectionPresets: this.buildArchivedWorktreeSelectionPresets(allItems),
+			groups: this.buildArchivedWorktreeGroups(responseItems),
+			selectionPresets: this.buildArchivedWorktreeSelectionPresets(responseItems),
 			generatedAt: Date.now(),
 		};
 	}
@@ -7965,19 +7966,6 @@ export class SessionManager {
 		const normalizedCandidate = normalizeWorktreeHostPath(spec.worktreePath);
 		const gitWorktreeMetadataExists = this.gitWorktreeMetadataMatches(gitRefs, normalizedCandidate, spec.branch);
 		const localBranchExists = await this.localBranchExists(spec.repoPath, spec.branch, ctx);
-		if (!gitWorktreeMetadataExists) {
-			return base({
-				pathExists,
-				gitWorktreeMetadataExists,
-				localBranchExists,
-				status: pathExists ? "skipped" : "already-cleaned",
-				reason: pathExists ? "stale-worktree-directory" : "already-cleaned",
-				detail: pathExists
-					? "Recorded path exists but no matching git worktree metadata remains; archived-session cleanup will not remove stale directories."
-					: "No worktree directory or git worktree metadata remains; any branch-only residue is out of scope for archived-session worktree cleanup.",
-			});
-		}
-
 		const sessionReferenced = isWorktreePathReferencedByLiveSession(spec.worktreePath, ctx.sessionPathRecords, { ignoreSessionId: ps.id });
 		if (sessionReferenced) {
 			return base({ pathExists, gitWorktreeMetadataExists, localBranchExists, status: "skipped", reason: "referenced-by-live-session", detail: "Another non-archived or runtime session still references this worktree." });
@@ -7990,6 +7978,18 @@ export class SessionManager {
 		}
 		if (this.isWorktreeReferencedByRefs(spec.worktreePath, ctx.staffRefs)) {
 			return base({ pathExists, gitWorktreeMetadataExists, localBranchExists, status: "skipped", reason: "referenced-by-staff", detail: "A staff record still references this worktree." });
+		}
+		if (!gitWorktreeMetadataExists) {
+			return base({
+				pathExists,
+				gitWorktreeMetadataExists,
+				localBranchExists,
+				status: pathExists ? "skipped" : "already-cleaned",
+				reason: pathExists ? "stale-worktree-directory" : "already-cleaned",
+				detail: pathExists
+					? "Recorded path exists but no matching git worktree metadata remains; archived-session cleanup will not remove stale directories."
+					: "No worktree directory or git worktree metadata remains; any branch-only residue is out of scope for archived-session worktree cleanup.",
+			});
 		}
 
 		const branchDeleteBlockedReason = localBranchExists && !this.branchDeletionAllowed(spec.branch, spec.repoPath, ctx)

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -107,15 +107,80 @@ function isSandboxContainerPath(cwd?: string): boolean {
 	return !!cwd && (cwd === "/workspace" || cwd.startsWith("/workspace/") || cwd === "/workspace-wt" || cwd.startsWith("/workspace-wt/"));
 }
 
+export type ArchivedWorktreeLegacyStatus = "removable" | "skipped" | "already-cleaned";
+export type ArchivedWorktreeDisposition = "ready-to-clean" | "already-cleaned" | "ineligible" | "needs-attention" | "failed";
+export type ArchivedWorktreeReason =
+	| "safe-archived-session-worktree"
+	| "already-cleaned"
+	| "no-worktree-path"
+	| "missing-repo-path"
+	| "sandbox-container-path"
+	| "delegate-shared-worktree"
+	| "stale-worktree-directory"
+	| "referenced-by-live-session"
+	| "referenced-by-live-goal"
+	| "referenced-by-live-team"
+	| "referenced-by-staff"
+	| "scan-error";
+export type ArchivedWorktreeReasonCategory = "safe" | "already-cleaned" | "missing-metadata" | "container-path" | "shared-delegate" | "stale-path" | "referenced-record" | "error";
+export type ArchivedWorktreeSelectionCategory = "archived-session" | "goal-session" | "team-session" | "delegate-session" | "child-session" | "single-repo" | "multi-repo";
+export type ArchivedWorktreeCleanupStatus = "cleaned" | "skipped" | "already-cleaned" | "failed";
+export type ArchivedWorktreeCleanupReason = "worktree-and-branch-cleaned" | "worktree-cleaned" | "already-cleaned" | "invalid-selection" | ArchivedWorktreeReason;
+
+export class CleanupArchivedSessionWorktreesRequestError extends Error {
+	statusCode = 400;
+	constructor(message: string) {
+		super(message);
+		this.name = "CleanupArchivedSessionWorktreesRequestError";
+	}
+}
+
 export interface ArchivedSessionWorktreeScanResponse {
 	sessions: ArchivedSessionWorktreeSession[];
+	items: ArchivedSessionWorktreeItem[];
 	counts: {
 		archivedSessions: number;
 		sessionsWithWorktrees: number;
 		removableWorktrees: number;
 		skippedWorktrees: number;
 		alreadyCleanedWorktrees: number;
+		totalItems: number;
+		readyToClean: number;
+		defaultSelected: number;
+		alreadyCleaned: number;
+		ineligible: number;
+		needsAttention: number;
+		failed: number;
+		byDisposition: Partial<Record<ArchivedWorktreeDisposition, number>>;
+		byReason: Partial<Record<ArchivedWorktreeReason, number>>;
+		bySelectionCategory: Partial<Record<ArchivedWorktreeSelectionCategory, number>>;
 	};
+	groups: ArchivedSessionWorktreeGroup[];
+	selectionPresets: ArchivedSessionWorktreeSelectionPreset[];
+	generatedAt: number;
+}
+
+export interface ArchivedSessionWorktreeGroup {
+	key: string;
+	label: string;
+	description: string;
+	disposition: ArchivedWorktreeDisposition;
+	reason?: ArchivedWorktreeReason;
+	reasonCategory?: ArchivedWorktreeReasonCategory;
+	count: number;
+	sampleKeys: string[];
+	hasMore: boolean;
+	actionable: boolean;
+}
+
+export interface ArchivedSessionWorktreeSelectionPreset {
+	id: string;
+	label: string;
+	description: string;
+	enabled: boolean;
+	count: number;
+	worktreeKeys: string[];
+	cleanupRequest: CleanupArchivedSessionWorktreesRequest;
 }
 
 export interface ArchivedSessionWorktreeSession {
@@ -139,23 +204,43 @@ export interface ArchivedSessionWorktreeSession {
 export interface ArchivedSessionWorktreeItem {
 	key: string;
 	sessionId: string;
+	title: string;
+	archivedAt?: number;
+	projectId?: string;
+	projectName?: string;
+	goalId?: string;
+	teamGoalId?: string;
+	delegateOf?: string;
+	parentSessionId?: string;
+	childKind?: string;
+	sandboxed?: boolean;
 	repo: string;
 	repoPath: string;
+	repoDisplayName: string;
 	path: string;
 	branch?: string;
+	source: "repoWorktrees" | "sessionWorktree";
 	pathExists: boolean;
 	gitWorktreeMetadataExists: boolean;
 	localBranchExists: boolean;
-	status: "removable" | "skipped" | "already-cleaned";
-	reason: string;
+	status: ArchivedWorktreeLegacyStatus;
+	reason: ArchivedWorktreeReason;
 	detail: string;
 	willDeleteBranch: boolean;
-	branchDeleteBlockedReason?: string;
+	branchDeleteBlockedReason?: "branch-referenced-by-live-record";
+	disposition: ArchivedWorktreeDisposition;
+	reasonCategory: ArchivedWorktreeReasonCategory;
+	actionable: boolean;
+	selectable: boolean;
+	defaultSelected: boolean;
+	selectionCategories: ArchivedWorktreeSelectionCategory[];
 }
 
 export type CleanupArchivedSessionWorktreesRequest =
 	| { mode: "all" }
-	| { mode: "selected"; sessionIds?: string[]; worktrees?: Array<{ sessionId: string; repo?: string; path?: string; key?: string }> };
+	| { mode: "selected"; sessionIds?: string[]; worktrees?: Array<{ sessionId: string; repo?: string; path?: string; key?: string }> }
+	| { mode: "category"; categories: ArchivedWorktreeSelectionCategory[]; projectId?: string; repoPath?: string }
+	| { mode: "preset"; presetId: string };
 
 export interface CleanupArchivedSessionWorktreesResponse {
 	counts: {
@@ -165,8 +250,14 @@ export interface CleanupArchivedSessionWorktreesResponse {
 		skipped: number;
 		alreadyCleaned: number;
 		failed: number;
+		worktreeRemoved: number;
+		invalidSelection: number;
+		notActionable: number;
+		byStatus: Partial<Record<ArchivedWorktreeCleanupStatus, number>>;
+		byReason: Partial<Record<ArchivedWorktreeCleanupReason, number>>;
 	};
 	results: ArchivedSessionWorktreeCleanupResult[];
+	generatedAt: number;
 }
 
 export interface ArchivedSessionWorktreeCleanupResult {
@@ -177,8 +268,9 @@ export interface ArchivedSessionWorktreeCleanupResult {
 	repoPath?: string;
 	path?: string;
 	branch?: string;
-	status: "cleaned" | "skipped" | "already-cleaned" | "failed";
-	reason?: string;
+	status: ArchivedWorktreeCleanupStatus;
+	reason?: ArchivedWorktreeCleanupReason;
+	detail?: string;
 	error?: string;
 	worktreeRemoved: boolean;
 	branchDeleted: boolean;
@@ -7364,12 +7456,23 @@ export class SessionManager {
 	async listArchivedSessionWorktrees(includeAlreadyCleaned = false): Promise<ArchivedSessionWorktreeScanResponse> {
 		const ctx = this.buildArchivedWorktreeScanContext();
 		const sessions: ArchivedSessionWorktreeSession[] = [];
+		const allItems: ArchivedSessionWorktreeItem[] = [];
 		const counts: ArchivedSessionWorktreeScanResponse["counts"] = {
 			archivedSessions: 0,
 			sessionsWithWorktrees: 0,
 			removableWorktrees: 0,
 			skippedWorktrees: 0,
 			alreadyCleanedWorktrees: 0,
+			totalItems: 0,
+			readyToClean: 0,
+			defaultSelected: 0,
+			alreadyCleaned: 0,
+			ineligible: 0,
+			needsAttention: 0,
+			failed: 0,
+			byDisposition: {},
+			byReason: {},
+			bySelectionCategory: {},
 		};
 
 		const archivedRows: Array<{ ps: PersistedSession; projectName?: string }> = [];
@@ -7385,7 +7488,8 @@ export class SessionManager {
 
 		counts.archivedSessions = archivedRows.length;
 		for (const { ps, projectName } of archivedRows) {
-			const worktrees = await this.archivedSessionWorktreeItems(ps, ctx);
+			const worktrees = await this.archivedSessionWorktreeItems(ps, ctx, projectName);
+			allItems.push(...worktrees);
 			for (const item of worktrees) {
 				if (item.status === "removable") counts.removableWorktrees++;
 				else if (item.status === "already-cleaned") counts.alreadyCleanedWorktrees++;
@@ -7412,31 +7516,52 @@ export class SessionManager {
 			});
 		}
 
-		return { sessions, counts };
+		this.populateArchivedWorktreeUxCounts(counts, allItems);
+		return {
+			sessions,
+			items: allItems,
+			counts,
+			groups: this.buildArchivedWorktreeGroups(allItems),
+			selectionPresets: this.buildArchivedWorktreeSelectionPresets(allItems),
+			generatedAt: Date.now(),
+		};
 	}
 
 	async cleanupArchivedSessionWorktrees(request: CleanupArchivedSessionWorktreesRequest): Promise<CleanupArchivedSessionWorktreesResponse> {
-		const zeroCounts = (): CleanupArchivedSessionWorktreesResponse["counts"] => ({ requested: 0, cleaned: 0, branchDeleted: 0, skipped: 0, alreadyCleaned: 0, failed: 0 });
-		const response: CleanupArchivedSessionWorktreesResponse = { counts: zeroCounts(), results: [] };
+		const zeroCounts = (): CleanupArchivedSessionWorktreesResponse["counts"] => ({
+			requested: 0,
+			cleaned: 0,
+			branchDeleted: 0,
+			skipped: 0,
+			alreadyCleaned: 0,
+			failed: 0,
+			worktreeRemoved: 0,
+			invalidSelection: 0,
+			notActionable: 0,
+			byStatus: {},
+			byReason: {},
+		});
+		const response: CleanupArchivedSessionWorktreesResponse = { counts: zeroCounts(), results: [], generatedAt: Date.now() };
 		const scan = await this.listArchivedSessionWorktrees(true);
-		const rows = scan.sessions.flatMap(session => session.worktrees.map(item => ({ session, item })));
+		const sessionById = new Map(scan.sessions.map(session => [session.id, session]));
+		const rows = scan.items.map(item => ({ session: sessionById.get(item.sessionId), item }));
 
-		let selected: Array<{ session: ArchivedSessionWorktreeSession; item: ArchivedSessionWorktreeItem }> = [];
+		let selected: Array<{ session?: ArchivedSessionWorktreeSession; item: ArchivedSessionWorktreeItem }> = [];
 		const invalidSelections: ArchivedSessionWorktreeCleanupResult[] = [];
 		if (request.mode === "all") {
 			selected = rows.filter(row => row.item.status === "removable");
-		} else if (request.sessionIds) {
+		} else if (request.mode === "selected" && request.sessionIds) {
 			const ids = new Set(request.sessionIds);
-			selected = rows.filter(row => ids.has(row.session.id));
+			selected = rows.filter(row => ids.has(row.item.sessionId));
 			for (const id of ids) {
-				if (!scan.sessions.some(session => session.id === id)) {
+				if (!rows.some(row => row.item.sessionId === id)) {
 					invalidSelections.push({ key: id, sessionId: id, status: "skipped", reason: "invalid-selection", worktreeRemoved: false, branchDeleted: false });
 				}
 			}
-		} else if (request.worktrees) {
+		} else if (request.mode === "selected" && request.worktrees) {
 			for (const selector of request.worktrees) {
 				const match = rows.find(row => {
-					if (row.session.id !== selector.sessionId) return false;
+					if (row.item.sessionId !== selector.sessionId) return false;
 					if (selector.key) return row.item.key === selector.key;
 					if (selector.repo !== undefined && row.item.repo !== selector.repo) return false;
 					if (selector.path !== undefined && normalizeWorktreeHostPath(row.item.path) !== normalizeWorktreeHostPath(selector.path)) return false;
@@ -7449,6 +7574,23 @@ export class SessionManager {
 					invalidSelections.push({ key, sessionId: selector.sessionId, repo: selector.repo, path: selector.path, status: "skipped", reason: "invalid-selection", worktreeRemoved: false, branchDeleted: false });
 				}
 			}
+		} else if (request.mode === "selected") {
+			selected = [];
+		} else if (request.mode === "category") {
+			const categories = new Set(request.categories);
+			const repoFilter = normalizeWorktreeHostPath(request.repoPath);
+			selected = rows.filter(row => {
+				if (row.item.status !== "removable") return false;
+				if (!row.item.selectionCategories.some(category => categories.has(category))) return false;
+				if (request.projectId && row.item.projectId !== request.projectId) return false;
+				if (repoFilter && normalizeWorktreeHostPath(row.item.repoPath) !== repoFilter) return false;
+				return true;
+			});
+		} else if (request.mode === "preset") {
+			const preset = scan.selectionPresets.find(candidate => candidate.id === request.presetId);
+			if (!preset) throw new CleanupArchivedSessionWorktreesRequestError("Invalid cleanup preset");
+			const keys = new Set(preset.worktreeKeys);
+			selected = rows.filter(row => row.item.status === "removable" && keys.has(row.item.key));
 		}
 
 		const seen = new Set<string>();
@@ -7459,8 +7601,17 @@ export class SessionManager {
 		});
 		response.counts.requested = selected.length + invalidSelections.length;
 
+		const recordResult = (result: ArchivedSessionWorktreeCleanupResult) => {
+			response.results.push(result);
+			response.counts.byStatus[result.status] = (response.counts.byStatus[result.status] ?? 0) + 1;
+			if (result.reason) response.counts.byReason[result.reason] = (response.counts.byReason[result.reason] ?? 0) + 1;
+			if (result.worktreeRemoved) response.counts.worktreeRemoved++;
+			if (result.reason === "invalid-selection") response.counts.invalidSelection++;
+			if (result.status === "skipped" && result.reason !== "invalid-selection") response.counts.notActionable++;
+		};
+
 		for (const invalid of invalidSelections) {
-			response.results.push(invalid);
+			recordResult(invalid);
 			response.counts.skipped++;
 		}
 
@@ -7468,19 +7619,19 @@ export class SessionManager {
 			const base: Omit<ArchivedSessionWorktreeCleanupResult, "status" | "worktreeRemoved" | "branchDeleted"> = {
 				key: item.key,
 				sessionId: item.sessionId,
-				title: session.title,
+				title: session?.title ?? item.title,
 				repo: item.repo,
 				repoPath: item.repoPath,
 				path: item.path,
 				branch: item.branch,
 			};
 			if (item.status === "already-cleaned") {
-				response.results.push({ ...base, status: "already-cleaned", reason: "already-cleaned", worktreeRemoved: false, branchDeleted: false });
+				recordResult({ ...base, status: "already-cleaned", reason: "already-cleaned", detail: item.detail, worktreeRemoved: false, branchDeleted: false });
 				response.counts.alreadyCleaned++;
 				continue;
 			}
 			if (item.status !== "removable") {
-				response.results.push({ ...base, status: "skipped", reason: item.reason, worktreeRemoved: false, branchDeleted: false });
+				recordResult({ ...base, status: "skipped", reason: item.reason, detail: item.detail, worktreeRemoved: false, branchDeleted: false });
 				response.counts.skipped++;
 				continue;
 			}
@@ -7491,13 +7642,13 @@ export class SessionManager {
 
 				const worktreeRemoved = await this.archivedWorktreeRemoved(item);
 				if (!worktreeRemoved) {
-					response.results.push({ ...base, status: "failed", error: "cleanup did not remove worktree path or git metadata", worktreeRemoved: false, branchDeleted: false });
+					recordResult({ ...base, status: "failed", reason: "scan-error", error: "cleanup did not remove worktree path or git metadata", worktreeRemoved: false, branchDeleted: false });
 					response.counts.failed++;
 					continue;
 				}
 
 				const branchDeleted = await this.deleteArchivedWorktreeBranchIfAllowed(item);
-				response.results.push({
+				recordResult({
 					...base,
 					status: "cleaned",
 					reason: branchDeleted ? "worktree-and-branch-cleaned" : "worktree-cleaned",
@@ -7507,12 +7658,147 @@ export class SessionManager {
 				response.counts.cleaned++;
 				if (branchDeleted) response.counts.branchDeleted++;
 			} catch (err) {
-				response.results.push({ ...base, status: "failed", error: err instanceof Error ? err.message : String(err), worktreeRemoved: false, branchDeleted: false });
+				recordResult({ ...base, status: "failed", reason: "scan-error", error: err instanceof Error ? err.message : String(err), worktreeRemoved: false, branchDeleted: false });
 				response.counts.failed++;
 			}
 		}
 
 		return response;
+	}
+
+	private populateArchivedWorktreeUxCounts(counts: ArchivedSessionWorktreeScanResponse["counts"], items: ArchivedSessionWorktreeItem[]): void {
+		counts.totalItems = items.length;
+		for (const item of items) {
+			counts.byDisposition[item.disposition] = (counts.byDisposition[item.disposition] ?? 0) + 1;
+			counts.byReason[item.reason] = (counts.byReason[item.reason] ?? 0) + 1;
+			for (const category of item.selectionCategories) counts.bySelectionCategory[category] = (counts.bySelectionCategory[category] ?? 0) + 1;
+			if (item.disposition === "ready-to-clean") counts.readyToClean++;
+			if (item.defaultSelected) counts.defaultSelected++;
+			if (item.disposition === "already-cleaned") counts.alreadyCleaned++;
+			if (item.disposition === "ineligible") counts.ineligible++;
+			if (item.disposition === "failed") counts.failed++;
+			if (item.disposition === "needs-attention" || item.disposition === "failed") counts.needsAttention++;
+		}
+	}
+
+	private buildArchivedWorktreeGroups(items: ArchivedSessionWorktreeItem[]): ArchivedSessionWorktreeGroup[] {
+		const groupSpecs: Array<{ key: string; label: string; description: string; disposition: ArchivedWorktreeDisposition; reason?: ArchivedWorktreeReason }> = [
+			{ key: "ready-to-clean", label: "Ready to clean", description: "Archived-session worktrees that are safe to remove now.", disposition: "ready-to-clean", reason: "safe-archived-session-worktree" },
+			{ key: "already-cleaned", label: "Already cleaned", description: "Archived sessions whose recorded git worktree is already gone.", disposition: "already-cleaned", reason: "already-cleaned" },
+			{ key: "reason:no-worktree-path", label: "Missing worktree path", description: "Archived sessions without a recorded host worktree path.", disposition: "ineligible", reason: "no-worktree-path" },
+			{ key: "reason:missing-repo-path", label: "Missing repository path", description: "Archived sessions without enough repository metadata to evaluate cleanup.", disposition: "ineligible", reason: "missing-repo-path" },
+			{ key: "reason:sandbox-container-path", label: "Sandbox/container path", description: "Recorded paths are container-internal and do not identify a host worktree.", disposition: "ineligible", reason: "sandbox-container-path" },
+			{ key: "reason:delegate-shared-worktree", label: "Shared delegate worktree", description: "Archived delegates that appear to share a parent worktree.", disposition: "ineligible", reason: "delegate-shared-worktree" },
+			{ key: "reason:stale-worktree-directory", label: "Stale worktree directory", description: "A path remains on disk without matching git worktree metadata; manual inspection may be needed.", disposition: "needs-attention", reason: "stale-worktree-directory" },
+			{ key: "reason:referenced-by-live-session", label: "Referenced by live session", description: "A non-archived or runtime session still references the worktree.", disposition: "ineligible", reason: "referenced-by-live-session" },
+			{ key: "reason:referenced-by-live-goal", label: "Referenced by live goal", description: "A persisted goal still references the worktree.", disposition: "ineligible", reason: "referenced-by-live-goal" },
+			{ key: "reason:referenced-by-live-team", label: "Referenced by live team", description: "A team entry or team agent still references the worktree.", disposition: "ineligible", reason: "referenced-by-live-team" },
+			{ key: "reason:referenced-by-staff", label: "Referenced by staff", description: "A staff record still references the worktree.", disposition: "ineligible", reason: "referenced-by-staff" },
+			{ key: "reason:scan-error", label: "Scan errors", description: "Worktrees that could not be evaluated safely.", disposition: "failed", reason: "scan-error" },
+		];
+		return groupSpecs.flatMap(spec => {
+			const matches = spec.key === "ready-to-clean"
+				? items.filter(item => item.disposition === "ready-to-clean")
+				: items.filter(item => item.reason === spec.reason);
+			if (matches.length === 0) return [];
+			return [{
+				key: spec.key,
+				label: spec.label,
+				description: spec.description,
+				disposition: spec.disposition,
+				reason: spec.reason,
+				reasonCategory: spec.reason ? this.archivedWorktreeReasonCategory(spec.reason) : undefined,
+				count: matches.length,
+				sampleKeys: matches.slice(0, 5).map(item => item.key),
+				hasMore: matches.length > 5,
+				actionable: spec.disposition === "ready-to-clean",
+			}];
+		});
+	}
+
+	private buildArchivedWorktreeSelectionPresets(items: ArchivedSessionWorktreeItem[]): ArchivedSessionWorktreeSelectionPreset[] {
+		const actionable = items.filter(item => item.actionable);
+		const makePreset = (id: string, label: string, description: string, matches: ArchivedSessionWorktreeItem[], cleanupRequest: CleanupArchivedSessionWorktreesRequest): ArchivedSessionWorktreeSelectionPreset => ({
+			id,
+			label,
+			description,
+			enabled: matches.length > 0,
+			count: matches.length,
+			worktreeKeys: matches.map(item => item.key),
+			cleanupRequest,
+		});
+		const presets: ArchivedSessionWorktreeSelectionPreset[] = [
+			makePreset("all-removable", "Select all removable", "Select every archived-session worktree that is safe to clean.", actionable, { mode: "all" }),
+			makePreset("category:archived-session", "Archived sessions only", "Select all actionable archived-session worktrees.", actionable.filter(item => item.selectionCategories.includes("archived-session")), { mode: "category", categories: ["archived-session"] }),
+		];
+		const categoryLabels: Partial<Record<ArchivedWorktreeSelectionCategory, string>> = {
+			"goal-session": "Goal sessions",
+			"team-session": "Goal/team worktrees",
+			"delegate-session": "Delegate worktrees",
+		};
+		for (const category of ["goal-session", "team-session", "delegate-session"] as const) {
+			const matches = actionable.filter(item => item.selectionCategories.includes(category));
+			if (matches.length > 0) presets.push(makePreset(`category:${category}`, categoryLabels[category] ?? category, `Select actionable ${category.replace(/-/g, " ")} worktrees.`, matches, { mode: "category", categories: [category] }));
+		}
+		const projects = new Map<string, ArchivedSessionWorktreeItem[]>();
+		const repos = new Map<string, ArchivedSessionWorktreeItem[]>();
+		for (const item of actionable) {
+			if (item.projectId) {
+				const existing = projects.get(item.projectId) ?? [];
+				existing.push(item);
+				projects.set(item.projectId, existing);
+			}
+			const repoKey = normalizeWorktreeHostPath(item.repoPath);
+			if (repoKey) {
+				const existing = repos.get(repoKey) ?? [];
+				existing.push(item);
+				repos.set(repoKey, existing);
+			}
+		}
+		for (const [projectId, matches] of projects) {
+			const label = matches[0]?.projectName ? `Current project: ${matches[0].projectName}` : "Current project";
+			presets.push(makePreset(`project:${projectId}`, label, "Select actionable archived worktrees in this project.", matches, { mode: "category", categories: ["archived-session"], projectId }));
+		}
+		for (const [repoPath, matches] of repos) {
+			const label = matches[0]?.repoDisplayName ? `Repository: ${matches[0].repoDisplayName}` : "Repository";
+			presets.push(makePreset(`repo:${repoPath}`, label, "Select actionable archived worktrees in this repository.", matches, { mode: "category", categories: ["archived-session"], repoPath }));
+		}
+		return presets;
+	}
+
+	private archivedWorktreeDisposition(status: ArchivedWorktreeLegacyStatus, reason: ArchivedWorktreeReason): ArchivedWorktreeDisposition {
+		if (status === "removable") return "ready-to-clean";
+		if (status === "already-cleaned") return "already-cleaned";
+		if (reason === "stale-worktree-directory") return "needs-attention";
+		if (reason === "scan-error") return "failed";
+		return "ineligible";
+	}
+
+	private archivedWorktreeReasonCategory(reason: ArchivedWorktreeReason): ArchivedWorktreeReasonCategory {
+		switch (reason) {
+			case "safe-archived-session-worktree": return "safe";
+			case "already-cleaned": return "already-cleaned";
+			case "no-worktree-path":
+			case "missing-repo-path": return "missing-metadata";
+			case "sandbox-container-path": return "container-path";
+			case "delegate-shared-worktree": return "shared-delegate";
+			case "stale-worktree-directory": return "stale-path";
+			case "referenced-by-live-session":
+			case "referenced-by-live-goal":
+			case "referenced-by-live-team":
+			case "referenced-by-staff": return "referenced-record";
+			case "scan-error": return "error";
+		}
+	}
+
+	private archivedWorktreeSelectionCategories(ps: PersistedSession, source: "repoWorktrees" | "sessionWorktree"): ArchivedWorktreeSelectionCategory[] {
+		const categories: ArchivedWorktreeSelectionCategory[] = ["archived-session"];
+		if (ps.goalId) categories.push("goal-session");
+		if (ps.teamGoalId) categories.push("team-session");
+		if (ps.delegateOf) categories.push("delegate-session");
+		if (ps.parentSessionId || ps.childKind) categories.push("child-session");
+		categories.push(source === "repoWorktrees" ? "multi-repo" : "single-repo");
+		return categories;
 	}
 
 	private buildArchivedWorktreeScanContext(): ArchivedWorktreeScanContext {
@@ -7594,19 +7880,19 @@ export class SessionManager {
 		};
 	}
 
-	private async archivedSessionWorktreeItems(ps: PersistedSession, ctx: ArchivedWorktreeScanContext): Promise<ArchivedSessionWorktreeItem[]> {
-		const specs: Array<{ repo: string; repoPath?: string; worktreePath?: string; branch?: string }> = [];
+	private async archivedSessionWorktreeItems(ps: PersistedSession, ctx: ArchivedWorktreeScanContext, projectName?: string): Promise<ArchivedSessionWorktreeItem[]> {
+		const specs: Array<{ repo: string; repoPath?: string; worktreePath?: string; branch?: string; source: "repoWorktrees" | "sessionWorktree" }> = [];
 		if (ps.repoWorktrees && Object.keys(ps.repoWorktrees).length > 0) {
 			for (const [repo, wt] of Object.entries(ps.repoWorktrees)) {
-				specs.push({ repo, repoPath: ps.repoPath ? (repo === "." ? ps.repoPath : path.join(ps.repoPath, repo)) : undefined, worktreePath: wt, branch: ps.branch });
+				specs.push({ repo, repoPath: ps.repoPath ? (repo === "." ? ps.repoPath : path.join(ps.repoPath, repo)) : undefined, worktreePath: wt, branch: ps.branch, source: "repoWorktrees" });
 			}
 		} else {
-			specs.push({ repo: ".", repoPath: ps.repoPath, worktreePath: ps.worktreePath, branch: ps.branch });
+			specs.push({ repo: ".", repoPath: ps.repoPath, worktreePath: ps.worktreePath, branch: ps.branch, source: "sessionWorktree" });
 		}
 
 		const items: ArchivedSessionWorktreeItem[] = [];
 		for (const spec of specs) {
-			const item = await this.archivedSessionWorktreeItem(ps, spec, ctx);
+			const item = await this.archivedSessionWorktreeItem(ps, spec, ctx, projectName);
 			items.push(item);
 		}
 		return items;
@@ -7614,26 +7900,57 @@ export class SessionManager {
 
 	private async archivedSessionWorktreeItem(
 		ps: PersistedSession,
-		spec: { repo: string; repoPath?: string; worktreePath?: string; branch?: string },
+		spec: { repo: string; repoPath?: string; worktreePath?: string; branch?: string; source: "repoWorktrees" | "sessionWorktree" },
 		ctx: ArchivedWorktreeScanContext,
+		projectName?: string,
 	): Promise<ArchivedSessionWorktreeItem> {
 		const key = this.archivedWorktreeKey(ps.id, spec.repo, spec.worktreePath);
-		const base = (overrides: Partial<ArchivedSessionWorktreeItem>): ArchivedSessionWorktreeItem => ({
-			key,
-			sessionId: ps.id,
-			repo: spec.repo,
-			repoPath: spec.repoPath ?? "",
-			path: spec.worktreePath ?? "",
-			branch: spec.branch,
-			pathExists: false,
-			gitWorktreeMetadataExists: false,
-			localBranchExists: false,
-			status: "skipped",
-			reason: "invalid-selection",
-			detail: "Not evaluated.",
-			willDeleteBranch: false,
-			...overrides,
-		});
+		const repoDisplayName = spec.repo === "." ? (projectName ?? (spec.repoPath ? path.basename(spec.repoPath) : ".")) : spec.repo;
+		const base = (overrides: Partial<ArchivedSessionWorktreeItem>): ArchivedSessionWorktreeItem => {
+			const raw = {
+				key,
+				sessionId: ps.id,
+				title: ps.title,
+				archivedAt: ps.archivedAt,
+				projectId: ps.projectId,
+				projectName,
+				goalId: ps.goalId,
+				teamGoalId: ps.teamGoalId,
+				delegateOf: ps.delegateOf,
+				parentSessionId: ps.parentSessionId,
+				childKind: ps.childKind,
+				sandboxed: ps.sandboxed,
+				repo: spec.repo,
+				repoPath: spec.repoPath ?? "",
+				repoDisplayName,
+				path: spec.worktreePath ?? "",
+				branch: spec.branch,
+				source: spec.source,
+				pathExists: false,
+				gitWorktreeMetadataExists: false,
+				localBranchExists: false,
+				status: "skipped" as ArchivedWorktreeLegacyStatus,
+				reason: "scan-error" as ArchivedWorktreeReason,
+				detail: "Not evaluated.",
+				willDeleteBranch: false,
+				selectionCategories: this.archivedWorktreeSelectionCategories(ps, spec.source),
+				...overrides,
+			};
+			const status = raw.status ?? "skipped";
+			const reason = raw.reason ?? "scan-error";
+			const disposition = raw.disposition ?? this.archivedWorktreeDisposition(status, reason);
+			const actionable = raw.actionable ?? disposition === "ready-to-clean";
+			return {
+				...raw,
+				status,
+				reason,
+				disposition,
+				reasonCategory: raw.reasonCategory ?? this.archivedWorktreeReasonCategory(reason),
+				actionable,
+				selectable: raw.selectable ?? actionable,
+				defaultSelected: raw.defaultSelected ?? actionable,
+			};
+		};
 
 		if (!spec.worktreePath) return base({ status: "skipped", reason: "no-worktree-path", detail: "Archived session has no recorded worktree path." });
 		if (!spec.repoPath) return base({ status: "skipped", reason: "missing-repo-path", detail: "Archived session has no recorded repository path for this worktree." });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -14085,7 +14085,7 @@ async function handleApiRoute(
 			return;
 		}
 		if (mode === "all") {
-			if (hasSessionIds || hasWorktrees || hasCategories || hasPresetId) {
+			if (hasSessionIds || hasWorktrees || hasCategories || hasPresetId || hasProjectId || hasRepoPath) {
 				json({ error: "mode=all does not accept selectors" }, 400);
 				return;
 			}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -14060,55 +14060,106 @@ async function handleApiRoute(
 			json({ error: "Request body must be an object" }, 400);
 			return;
 		}
-		const mode = (body as any).mode;
+		const rec = body as Record<string, unknown>;
+		const mode = rec.mode;
 		const hasSessionIds = Object.prototype.hasOwnProperty.call(body, "sessionIds");
 		const hasWorktrees = Object.prototype.hasOwnProperty.call(body, "worktrees");
-		if (mode !== "all" && mode !== "selected") {
+		const hasCategories = Object.prototype.hasOwnProperty.call(body, "categories");
+		const hasPresetId = Object.prototype.hasOwnProperty.call(body, "presetId");
+		const hasProjectId = Object.prototype.hasOwnProperty.call(body, "projectId");
+		const hasRepoPath = Object.prototype.hasOwnProperty.call(body, "repoPath");
+		const cleanup = async (request: any) => {
+			try {
+				const result = await sessionManager.cleanupArchivedSessionWorktrees(request);
+				json(result);
+			} catch (err) {
+				if (err instanceof Error && (err.name === "CleanupArchivedSessionWorktreesRequestError" || (err as any).statusCode === 400)) {
+					json({ error: err.message }, 400);
+					return;
+				}
+				throw err;
+			}
+		};
+		if (mode !== "all" && mode !== "selected" && mode !== "category" && mode !== "preset") {
 			json({ error: "Invalid cleanup mode" }, 400);
 			return;
 		}
 		if (mode === "all") {
-			if (hasSessionIds || hasWorktrees) {
+			if (hasSessionIds || hasWorktrees || hasCategories || hasPresetId) {
 				json({ error: "mode=all does not accept selectors" }, 400);
 				return;
 			}
-			const result = await sessionManager.cleanupArchivedSessionWorktrees({ mode: "all" });
-			json(result);
+			await cleanup({ mode: "all" });
 			return;
 		}
-		if (hasSessionIds && hasWorktrees) {
-			json({ error: "mode=selected accepts either sessionIds or worktrees, not both" }, 400);
-			return;
-		}
-		if (hasSessionIds) {
-			const sessionIds = (body as any).sessionIds;
-			if (!Array.isArray(sessionIds) || sessionIds.some((id: unknown) => typeof id !== "string")) {
-				json({ error: "sessionIds must be an array of strings" }, 400);
+		if (mode === "selected") {
+			if (hasCategories || hasPresetId) {
+				json({ error: "mode=selected accepts sessionIds or worktrees selectors only" }, 400);
 				return;
 			}
-			const result = await sessionManager.cleanupArchivedSessionWorktrees({ mode: "selected", sessionIds });
-			json(result);
-			return;
-		}
-		if (hasWorktrees) {
-			const worktrees = (body as any).worktrees;
-			if (!Array.isArray(worktrees) || worktrees.some((wt: unknown) => {
-				if (!wt || typeof wt !== "object" || Array.isArray(wt)) return true;
-				const rec = wt as Record<string, unknown>;
-				return typeof rec.sessionId !== "string"
-					|| (rec.repo !== undefined && typeof rec.repo !== "string")
-					|| (rec.path !== undefined && typeof rec.path !== "string")
-					|| (rec.key !== undefined && typeof rec.key !== "string");
-			})) {
-				json({ error: "worktrees must be an array of selector objects with string fields" }, 400);
+			if (hasSessionIds && hasWorktrees) {
+				json({ error: "mode=selected accepts either sessionIds or worktrees, not both" }, 400);
 				return;
 			}
-			const result = await sessionManager.cleanupArchivedSessionWorktrees({ mode: "selected", worktrees });
-			json(result);
+			if (hasSessionIds) {
+				const sessionIds = rec.sessionIds;
+				if (!Array.isArray(sessionIds) || sessionIds.some((id: unknown) => typeof id !== "string")) {
+					json({ error: "sessionIds must be an array of strings" }, 400);
+					return;
+				}
+				await cleanup({ mode: "selected", sessionIds });
+				return;
+			}
+			if (hasWorktrees) {
+				const worktrees = rec.worktrees;
+				if (!Array.isArray(worktrees) || worktrees.some((wt: unknown) => {
+					if (!wt || typeof wt !== "object" || Array.isArray(wt)) return true;
+					const selector = wt as Record<string, unknown>;
+					return typeof selector.sessionId !== "string"
+						|| (selector.repo !== undefined && typeof selector.repo !== "string")
+						|| (selector.path !== undefined && typeof selector.path !== "string")
+						|| (selector.key !== undefined && typeof selector.key !== "string");
+				})) {
+					json({ error: "worktrees must be an array of selector objects with string fields" }, 400);
+					return;
+				}
+				await cleanup({ mode: "selected", worktrees });
+				return;
+			}
+			await cleanup({ mode: "selected" });
 			return;
 		}
-		const result = await sessionManager.cleanupArchivedSessionWorktrees({ mode: "selected" });
-		json(result);
+		if (mode === "category") {
+			if (hasSessionIds || hasWorktrees || hasPresetId) {
+				json({ error: "mode=category accepts categories with optional projectId or repoPath only" }, 400);
+				return;
+			}
+			const categories = rec.categories;
+			const validCategories = new Set(["archived-session", "goal-session", "team-session", "delegate-session", "child-session", "single-repo", "multi-repo"]);
+			if (!Array.isArray(categories) || categories.some((category: unknown) => typeof category !== "string" || !validCategories.has(category as string))) {
+				json({ error: "categories must be an array of supported category strings" }, 400);
+				return;
+			}
+			if (rec.projectId !== undefined && typeof rec.projectId !== "string") {
+				json({ error: "projectId must be a string" }, 400);
+				return;
+			}
+			if (rec.repoPath !== undefined && typeof rec.repoPath !== "string") {
+				json({ error: "repoPath must be a string" }, 400);
+				return;
+			}
+			await cleanup({ mode: "category", categories, projectId: rec.projectId, repoPath: rec.repoPath });
+			return;
+		}
+		if (hasSessionIds || hasWorktrees || hasCategories || hasProjectId || hasRepoPath) {
+			json({ error: "mode=preset accepts presetId only" }, 400);
+			return;
+		}
+		if (typeof rec.presetId !== "string") {
+			json({ error: "presetId must be a string" }, 400);
+			return;
+		}
+		await cleanup({ mode: "preset", presetId: rec.presetId });
 		return;
 	}
 

--- a/tests/e2e/maintenance-api.spec.ts
+++ b/tests/e2e/maintenance-api.spec.ts
@@ -28,6 +28,13 @@ const archivedScanCountKeys = [
 	"removableWorktrees",
 	"skippedWorktrees",
 	"alreadyCleanedWorktrees",
+	"totalItems",
+	"readyToClean",
+	"defaultSelected",
+	"alreadyCleaned",
+	"ineligible",
+	"needsAttention",
+	"failed",
 ] as const;
 
 const archivedCleanupCountKeys = [
@@ -37,7 +44,30 @@ const archivedCleanupCountKeys = [
 	"skipped",
 	"alreadyCleaned",
 	"failed",
+	"worktreeRemoved",
+	"invalidSelection",
+	"notActionable",
 ] as const;
+
+const archivedWorktreeStatuses = ["removable", "skipped", "already-cleaned"] as const;
+const archivedWorktreeDispositions = ["ready-to-clean", "already-cleaned", "ineligible", "needs-attention", "failed"] as const;
+const archivedWorktreeReasons = [
+	"safe-archived-session-worktree",
+	"already-cleaned",
+	"no-worktree-path",
+	"missing-repo-path",
+	"sandbox-container-path",
+	"delegate-shared-worktree",
+	"stale-worktree-directory",
+	"referenced-by-live-session",
+	"referenced-by-live-goal",
+	"referenced-by-live-team",
+	"referenced-by-staff",
+	"scan-error",
+] as const;
+const archivedWorktreeReasonCategories = ["safe", "already-cleaned", "missing-metadata", "container-path", "shared-delegate", "stale-path", "referenced-record", "error"] as const;
+const archivedWorktreeSelectionCategories = ["archived-session", "goal-session", "team-session", "delegate-session", "child-session", "single-repo", "multi-repo"] as const;
+const archivedCleanupStatuses = ["cleaned", "skipped", "already-cleaned", "failed"] as const;
 
 function expectNumberCounts(body: any, keys: readonly string[]): void {
 	expect(body).toHaveProperty("counts");
@@ -46,38 +76,157 @@ function expectNumberCounts(body: any, keys: readonly string[]): void {
 	}
 }
 
+function expectNumberMap(value: any, label: string): void {
+	expect(value && typeof value === "object" && !Array.isArray(value), label).toBe(true);
+	for (const [key, count] of Object.entries(value)) {
+		expect(typeof key, `${label} key`).toBe("string");
+		expect(typeof count, `${label}.${key}`).toBe("number");
+	}
+}
+
+function flattenedArchivedWorktreeItems(body: any): any[] {
+	return (body.sessions as any[]).flatMap((session) => session.worktrees as any[]);
+}
+
+function expectArchivedWorktreeItemShape(item: any, parentSession?: any): void {
+	expect(typeof item.key).toBe("string");
+	expect(typeof item.sessionId).toBe("string");
+	if (parentSession) {
+		expect(item.sessionId).toBe(parentSession.id);
+		expect(item.title).toBe(parentSession.title);
+	}
+	expect(typeof item.title).toBe("string");
+	if (item.archivedAt !== undefined) expect(typeof item.archivedAt).toBe("number");
+	if (item.projectId !== undefined) expect(typeof item.projectId).toBe("string");
+	if (item.projectName !== undefined) expect(typeof item.projectName).toBe("string");
+	if (item.goalId !== undefined) expect(typeof item.goalId).toBe("string");
+	if (item.teamGoalId !== undefined) expect(typeof item.teamGoalId).toBe("string");
+	if (item.delegateOf !== undefined) expect(typeof item.delegateOf).toBe("string");
+	if (item.parentSessionId !== undefined) expect(typeof item.parentSessionId).toBe("string");
+	if (item.childKind !== undefined) expect(typeof item.childKind).toBe("string");
+	if (item.sandboxed !== undefined) expect(typeof item.sandboxed).toBe("boolean");
+	expect(typeof item.repo).toBe("string");
+	expect(typeof item.repoPath).toBe("string");
+	expect(typeof item.repoDisplayName).toBe("string");
+	expect(typeof item.path).toBe("string");
+	if (item.branch !== undefined) expect(typeof item.branch).toBe("string");
+	expect(["repoWorktrees", "sessionWorktree"]).toContain(item.source);
+	expect(typeof item.pathExists).toBe("boolean");
+	expect(typeof item.gitWorktreeMetadataExists).toBe("boolean");
+	expect(typeof item.localBranchExists).toBe("boolean");
+	expect([...archivedWorktreeStatuses]).toContain(item.status);
+	expect([...archivedWorktreeReasons]).toContain(item.reason);
+	expect(typeof item.detail).toBe("string");
+	expect(typeof item.willDeleteBranch).toBe("boolean");
+	if (item.branchDeleteBlockedReason !== undefined) expect(item.branchDeleteBlockedReason).toBe("branch-referenced-by-live-record");
+	expect([...archivedWorktreeDispositions]).toContain(item.disposition);
+	expect([...archivedWorktreeReasonCategories]).toContain(item.reasonCategory);
+	expect(typeof item.actionable).toBe("boolean");
+	expect(typeof item.selectable).toBe("boolean");
+	expect(typeof item.defaultSelected).toBe("boolean");
+	expect(Array.isArray(item.selectionCategories)).toBe(true);
+	for (const category of item.selectionCategories) expect([...archivedWorktreeSelectionCategories]).toContain(category);
+	if (item.status === "removable") {
+		expect(item).toMatchObject({
+			reason: "safe-archived-session-worktree",
+			disposition: "ready-to-clean",
+			reasonCategory: "safe",
+			actionable: true,
+			selectable: true,
+			defaultSelected: true,
+		});
+	}
+	if (item.status === "already-cleaned") {
+		expect(item).toMatchObject({
+			reason: "already-cleaned",
+			disposition: "already-cleaned",
+			reasonCategory: "already-cleaned",
+			actionable: false,
+			selectable: false,
+			defaultSelected: false,
+		});
+	}
+}
+
 function expectArchivedScanShape(body: any): void {
 	expect(body).toHaveProperty("sessions");
 	expect(Array.isArray(body.sessions)).toBe(true);
 	expectNumberCounts(body, archivedScanCountKeys);
+	expectNumberMap(body.counts.byDisposition, "counts.byDisposition");
+	expectNumberMap(body.counts.byReason, "counts.byReason");
+	expectNumberMap(body.counts.bySelectionCategory, "counts.bySelectionCategory");
+	expect(body.counts.readyToClean).toBe(body.counts.removableWorktrees);
+	expect(body.counts.defaultSelected).toBe(body.counts.readyToClean);
+	expect(body.counts.alreadyCleaned).toBe(body.counts.alreadyCleanedWorktrees);
+	expect(typeof body.generatedAt).toBe("number");
+	expect(Array.isArray(body.items)).toBe(true);
+	expect(Array.isArray(body.groups)).toBe(true);
+	expect(Array.isArray(body.selectionPresets)).toBe(true);
+	const flattenedItems = flattenedArchivedWorktreeItems(body);
+	expect(body.items.map((item: any) => item.key).sort()).toEqual(flattenedItems.map((item: any) => item.key).sort());
 	for (const session of body.sessions as any[]) {
 		expect(typeof session.id).toBe("string");
 		expect(typeof session.title).toBe("string");
+		if (session.archivedAt !== undefined) expect(typeof session.archivedAt).toBe("number");
+		if (session.projectId !== undefined) expect(typeof session.projectId).toBe("string");
+		if (session.projectName !== undefined) expect(typeof session.projectName).toBe("string");
 		expect(Array.isArray(session.worktrees)).toBe(true);
-		for (const item of session.worktrees as any[]) {
-			expect(typeof item.key).toBe("string");
-			expect(item.sessionId).toBe(session.id);
-			expect(typeof item.repo).toBe("string");
-			expect(typeof item.repoPath).toBe("string");
-			expect(typeof item.path).toBe("string");
-			expect(typeof item.pathExists).toBe("boolean");
-			expect(typeof item.gitWorktreeMetadataExists).toBe("boolean");
-			expect(typeof item.localBranchExists).toBe("boolean");
-			expect(["removable", "skipped", "already-cleaned"]).toContain(item.status);
-			expect(typeof item.reason).toBe("string");
-			expect(typeof item.detail).toBe("string");
-			expect(typeof item.willDeleteBranch).toBe("boolean");
+		for (const item of session.worktrees as any[]) expectArchivedWorktreeItemShape(item, session);
+	}
+	for (const item of body.items as any[]) expectArchivedWorktreeItemShape(item);
+	for (const group of body.groups as any[]) {
+		expect(typeof group.key).toBe("string");
+		expect(typeof group.label).toBe("string");
+		expect(typeof group.description).toBe("string");
+		expect([...archivedWorktreeDispositions]).toContain(group.disposition);
+		if (group.reason !== undefined) expect([...archivedWorktreeReasons]).toContain(group.reason);
+		if (group.reasonCategory !== undefined) expect([...archivedWorktreeReasonCategories]).toContain(group.reasonCategory);
+		expect(typeof group.count).toBe("number");
+		expect(Array.isArray(group.sampleKeys)).toBe(true);
+		expect(group.sampleKeys.length).toBeLessThanOrEqual(5);
+		for (const key of group.sampleKeys) expect(typeof key, `group ${group.key} sample key`).toBe("string");
+		expect(typeof group.hasMore).toBe("boolean");
+		expect(typeof group.actionable).toBe("boolean");
+	}
+	const allRemovablePreset = (body.selectionPresets as any[]).find((preset) => preset.id === "all-removable");
+	expect(allRemovablePreset).toBeTruthy();
+	for (const preset of body.selectionPresets as any[]) {
+		expect(typeof preset.id).toBe("string");
+		expect(typeof preset.label).toBe("string");
+		expect(typeof preset.description).toBe("string");
+		expect(typeof preset.enabled).toBe("boolean");
+		expect(typeof preset.count).toBe("number");
+		expect(Array.isArray(preset.worktreeKeys)).toBe(true);
+		expect(preset.worktreeKeys).toHaveLength(preset.count);
+		expect(preset.cleanupRequest && typeof preset.cleanupRequest).toBe("object");
+		for (const key of preset.worktreeKeys) {
+			const item = (body.items as any[]).find((candidate) => candidate.key === key);
+			expect(item, `preset ${preset.id} key ${key}`).toBeTruthy();
+			expect(item.actionable, `preset ${preset.id} must select only actionable rows`).toBe(true);
 		}
 	}
+	expect(allRemovablePreset.cleanupRequest).toMatchObject({ mode: "all" });
+	expect(allRemovablePreset.count).toBe(body.counts.readyToClean);
 }
 
 function expectArchivedCleanupShape(body: any): void {
 	expectNumberCounts(body, archivedCleanupCountKeys);
+	expectNumberMap(body.counts.byStatus, "counts.byStatus");
+	expectNumberMap(body.counts.byReason, "counts.byReason");
+	expect(typeof body.generatedAt).toBe("number");
 	expect(Array.isArray(body.results)).toBe(true);
 	for (const result of body.results as any[]) {
 		expect(typeof result.key).toBe("string");
 		expect(typeof result.sessionId).toBe("string");
-		expect(["cleaned", "skipped", "already-cleaned", "failed"]).toContain(result.status);
+		if (result.title !== undefined) expect(typeof result.title).toBe("string");
+		if (result.repo !== undefined) expect(typeof result.repo).toBe("string");
+		if (result.repoPath !== undefined) expect(typeof result.repoPath).toBe("string");
+		if (result.path !== undefined) expect(typeof result.path).toBe("string");
+		if (result.branch !== undefined) expect(typeof result.branch).toBe("string");
+		expect([...archivedCleanupStatuses]).toContain(result.status);
+		if (result.reason !== undefined) expect(typeof result.reason).toBe("string");
+		if (result.detail !== undefined) expect(typeof result.detail).toBe("string");
+		if (result.error !== undefined) expect(typeof result.error).toBe("string");
 		expect(typeof result.worktreeRemoved).toBe("boolean");
 		expect(typeof result.branchDeleted).toBe("boolean");
 	}
@@ -155,6 +304,14 @@ async function seedArchivedSession(gateway: any, overrides: Partial<any> & { id?
 
 function findArchivedSession(scan: any, sessionId: string): any | undefined {
 	return (scan.sessions as any[]).find((session) => session.id === sessionId);
+}
+
+function findArchivedWorktreeItem(scan: any, sessionId: string): any | undefined {
+	return (scan.items as any[]).find((item) => item.sessionId === sessionId);
+}
+
+function findArchivedWorktreeGroup(scan: any, key: string): any | undefined {
+	return (scan.groups as any[]).find((group) => group.key === key);
 }
 
 async function getArchivedWorktreeScan(query = ""): Promise<any> {
@@ -247,9 +404,106 @@ test("POST /api/maintenance/purge-archives runs purge", async () => {
 // Archived session worktree maintenance
 // ---------------------------------------------------------------------------
 test.describe("archived session worktree maintenance", () => {
-	test("GET /api/maintenance/archived-session-worktrees returns sessions and counts", async () => {
+	test("GET /api/maintenance/archived-session-worktrees returns sessions, flattened items, groups, presets, and additive counts", async () => {
 		const body = await getArchivedWorktreeScan();
 		expectArchivedScanShape(body);
+	});
+
+	test("scan exposes UX dispositions, reason categories, groups, and selection presets", async ({ gateway }) => {
+		test.slow();
+		const baseDir = mkdtempSync(join(tmpdir(), "bobbit-e2e-archived-wt-v2-scan-"));
+		const repoPath = join(baseDir, "repo");
+		const removablePath = join(baseDir, "removable-worktree");
+		const liveReferencedPath = join(baseDir, "live-referenced-worktree");
+		const stalePath = join(baseDir, "stale-directory");
+		const missingPath = join(baseDir, "already-cleaned-worktree");
+		const removableBranch = `archived-v2-removable-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+		const liveBranch = `archived-v2-live-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+		const staleBranch = `archived-v2-stale-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+		const missingBranch = `archived-v2-missing-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+		const seeded: SeededSession[] = [];
+		let liveSessionId: string | undefined;
+		try {
+			initGitRepo(repoPath);
+			git(repoPath, ["worktree", "add", "-b", removableBranch, removablePath, "HEAD"]);
+			git(repoPath, ["worktree", "add", "-b", liveBranch, liveReferencedPath, "HEAD"]);
+			git(repoPath, ["branch", staleBranch, "HEAD"]);
+			git(repoPath, ["branch", missingBranch, "HEAD"]);
+			mkdirSync(stalePath, { recursive: true });
+
+			const removable = await seedArchivedSession(gateway, { baseDir, title: "V2 removable archived worktree", cwd: removablePath, repoPath, worktreePath: removablePath, branch: removableBranch });
+			const noPath = await seedArchivedSession(gateway, { baseDir, title: "V2 missing worktree path", cwd: join(baseDir, "no-path"), repoPath, worktreePath: undefined });
+			const missingRepo = await seedArchivedSession(gateway, { baseDir, title: "V2 missing repo path", cwd: join(baseDir, "missing-repo"), repoPath: undefined, worktreePath: join(baseDir, "missing-repo") });
+			const sandbox = await seedArchivedSession(gateway, { baseDir, title: "V2 sandbox path", cwd: "/workspace-wt/session/v2-sandbox", repoPath, worktreePath: "/workspace-wt/session/v2-sandbox", branch: "v2-sandbox", sandboxed: true });
+			const delegate = await seedArchivedSession(gateway, { baseDir, title: "V2 delegate shared worktree", cwd: join(baseDir, "delegate"), repoPath, worktreePath: join(baseDir, "delegate"), branch: undefined, delegateOf: "parent-session-id" });
+			const alreadyCleaned = await seedArchivedSession(gateway, { baseDir, title: "V2 already cleaned", cwd: missingPath, repoPath, worktreePath: missingPath, branch: missingBranch });
+			const stale = await seedArchivedSession(gateway, { baseDir, title: "V2 stale path", cwd: stalePath, repoPath, worktreePath: stalePath, branch: staleBranch });
+			const liveReferenced = await seedArchivedSession(gateway, { baseDir, title: "V2 live referenced", cwd: liveReferencedPath, repoPath, worktreePath: liveReferencedPath, branch: liveBranch });
+			seeded.push(removable, noPath, missingRepo, sandbox, delegate, alreadyCleaned, stale, liveReferenced);
+			liveSessionId = `live-v2-guard-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+			removable.ctx.sessionStore.put({
+				id: liveSessionId,
+				title: "Live session sharing archived worktree path",
+				cwd: liveReferencedPath,
+				agentSessionFile: join(baseDir, `${liveSessionId}.jsonl`),
+				createdAt: Date.now(),
+				lastActivity: Date.now(),
+				archived: false,
+				projectId: removable.projectId,
+				repoPath,
+				worktreePath: liveReferencedPath,
+				branch: liveBranch,
+			});
+
+			const scan = await getArchivedWorktreeScan("?includeAlreadyCleaned=1");
+			const cases: Array<[SeededSession, string, string, string, string, boolean]> = [
+				[removable, "removable", "safe-archived-session-worktree", "ready-to-clean", "safe", true],
+				[noPath, "skipped", "no-worktree-path", "ineligible", "missing-metadata", false],
+				[missingRepo, "skipped", "missing-repo-path", "ineligible", "missing-metadata", false],
+				[sandbox, "skipped", "sandbox-container-path", "ineligible", "container-path", false],
+				[delegate, "skipped", "delegate-shared-worktree", "ineligible", "shared-delegate", false],
+				[alreadyCleaned, "already-cleaned", "already-cleaned", "already-cleaned", "already-cleaned", false],
+				[stale, "skipped", "stale-worktree-directory", "needs-attention", "stale-path", false],
+				[liveReferenced, "skipped", "referenced-by-live-session", "ineligible", "referenced-record", false],
+			];
+			for (const [seed, status, reason, disposition, reasonCategory, actionable] of cases) {
+				const item = findArchivedWorktreeItem(scan, seed.session.id);
+				expect(item, seed.session.title).toBeTruthy();
+				expect(item).toMatchObject({ status, reason, disposition, reasonCategory, actionable, selectable: actionable, defaultSelected: actionable });
+				expect(scan.counts.byReason[reason]).toBeGreaterThanOrEqual(1);
+				expect(scan.counts.byDisposition[disposition]).toBeGreaterThanOrEqual(1);
+				const groupKey = disposition === "ready-to-clean" ? "ready-to-clean" : disposition === "already-cleaned" ? "already-cleaned" : `reason:${reason}`;
+				const group = findArchivedWorktreeGroup(scan, groupKey);
+				expect(group, groupKey).toBeTruthy();
+				expect(group.count).toBeGreaterThanOrEqual(1);
+			}
+
+			const removableItem = findArchivedWorktreeItem(scan, removable.session.id);
+			expect(removableItem.selectionCategories).toEqual(expect.arrayContaining(["archived-session", "single-repo"]));
+			expect(scan.counts.readyToClean).toBeGreaterThanOrEqual(1);
+			expect(scan.counts.defaultSelected).toBe(scan.counts.readyToClean);
+			expect(scan.counts.alreadyCleaned).toBeGreaterThanOrEqual(1);
+			expect(scan.counts.needsAttention).toBeGreaterThanOrEqual(1);
+			expect(scan.counts.bySelectionCategory["archived-session"]).toBeGreaterThanOrEqual(1);
+			const allPreset = scan.selectionPresets.find((preset: any) => preset.id === "all-removable");
+			expect(allPreset).toMatchObject({ enabled: true, count: scan.counts.readyToClean, cleanupRequest: { mode: "all" } });
+			expect(allPreset.worktreeKeys).toContain(removableItem.key);
+			const archivedPreset = scan.selectionPresets.find((preset: any) => preset.id === "category:archived-session");
+			expect(archivedPreset).toBeTruthy();
+			expect(archivedPreset.worktreeKeys).toContain(removableItem.key);
+			expect(archivedPreset.worktreeKeys).not.toContain(findArchivedWorktreeItem(scan, stale.session.id).key);
+
+			const defaultScan = await getArchivedWorktreeScan();
+			expect(findArchivedWorktreeItem(defaultScan, alreadyCleaned.session.id)).toBeUndefined();
+			expect(defaultScan.counts.alreadyCleaned).toBeGreaterThanOrEqual(1);
+		} finally {
+			if (liveSessionId && seeded[0]) seeded[0].ctx.sessionStore.remove(liveSessionId);
+			for (const seed of seeded) seed.ctx.sessionStore.remove(seed.session.id);
+			tryRemoveWorktree(repoPath, removablePath);
+			tryRemoveWorktree(repoPath, liveReferencedPath);
+			for (const branch of [removableBranch, liveBranch, staleBranch, missingBranch]) tryDeleteBranch(repoPath, branch);
+			rmSync(baseDir, { recursive: true, force: true });
+		}
 	});
 
 	test("POST /api/maintenance/cleanup-archived-session-worktrees validates request shape", async () => {
@@ -321,13 +575,27 @@ test.describe("archived session worktree maintenance", () => {
 			expect(scannedSession).toBeTruthy();
 			expect(scannedSession.worktrees).toHaveLength(1);
 			const candidate = scannedSession.worktrees[0];
-			expect(candidate.status).toBe("removable");
-			expect(candidate.path).toBe(worktreePath);
-			expect(candidate.repoPath).toBe(repoPath);
-			expect(candidate.pathExists).toBe(true);
-			expect(candidate.gitWorktreeMetadataExists).toBe(true);
-			expect(candidate.localBranchExists).toBe(true);
-			expect(candidate.willDeleteBranch).toBe(true);
+			expect(candidate).toMatchObject({
+				status: "removable",
+				reason: "safe-archived-session-worktree",
+				disposition: "ready-to-clean",
+				reasonCategory: "safe",
+				actionable: true,
+				selectable: true,
+				defaultSelected: true,
+				title: "Archived cleanup candidate",
+				repo: ".",
+				repoPath,
+				repoDisplayName: expect.any(String),
+				path: worktreePath,
+				branch,
+				source: "sessionWorktree",
+				pathExists: true,
+				gitWorktreeMetadataExists: true,
+				localBranchExists: true,
+				willDeleteBranch: true,
+			});
+			expect(candidate.selectionCategories).toEqual(expect.arrayContaining(["archived-session", "single-repo"]));
 
 			const cleanup = await apiFetch("/api/maintenance/cleanup-archived-session-worktrees", {
 				method: "POST",
@@ -339,13 +607,26 @@ test.describe("archived session worktree maintenance", () => {
 			expect(cleanup.status).toBe(200);
 			const cleanupBody = await cleanup.json();
 			expectArchivedCleanupShape(cleanupBody);
-			expect(cleanupBody.counts.cleaned).toBe(1);
-			expect(cleanupBody.counts.branchDeleted).toBe(1);
-			expect(cleanupBody.counts.failed).toBe(0);
+			expect(cleanupBody.counts).toMatchObject({
+				requested: 1,
+				cleaned: 1,
+				branchDeleted: 1,
+				worktreeRemoved: 1,
+				invalidSelection: 0,
+				notActionable: 0,
+				failed: 0,
+			});
+			expect(cleanupBody.counts.byStatus.cleaned).toBe(1);
 			expect(cleanupBody.results).toContainEqual(expect.objectContaining({
 				sessionId: seeded.session.id,
 				key: candidate.key,
+				title: "Archived cleanup candidate",
+				repo: ".",
+				repoPath,
+				path: worktreePath,
+				branch,
 				status: "cleaned",
+				reason: "worktree-and-branch-cleaned",
 				worktreeRemoved: true,
 				branchDeleted: true,
 			}));
@@ -407,11 +688,19 @@ test.describe("archived session worktree maintenance", () => {
 			expect(diagnosticSession).toBeTruthy();
 			expect(diagnosticSession.worktrees).toHaveLength(1);
 			const item = diagnosticSession.worktrees[0];
-			expect(item.status).toBe("already-cleaned");
-			expect(item.pathExists).toBe(false);
-			expect(item.gitWorktreeMetadataExists).toBe(false);
-			expect(item.localBranchExists).toBe(true);
-			expect(item.willDeleteBranch).toBe(false);
+			expect(item).toMatchObject({
+				status: "already-cleaned",
+				reason: "already-cleaned",
+				disposition: "already-cleaned",
+				reasonCategory: "already-cleaned",
+				actionable: false,
+				selectable: false,
+				defaultSelected: false,
+				pathExists: false,
+				gitWorktreeMetadataExists: false,
+				localBranchExists: true,
+				willDeleteBranch: false,
+			});
 
 			const cleanup = await apiFetch("/api/maintenance/cleanup-archived-session-worktrees", {
 				method: "POST",
@@ -423,14 +712,27 @@ test.describe("archived session worktree maintenance", () => {
 			expect(cleanup.status).toBe(200);
 			const cleanupBody = await cleanup.json();
 			expectArchivedCleanupShape(cleanupBody);
-			expect(cleanupBody.counts.cleaned).toBe(0);
-			expect(cleanupBody.counts.branchDeleted).toBe(0);
-			expect(cleanupBody.counts.failed).toBe(0);
-			expect(cleanupBody.counts.alreadyCleaned).toBe(1);
+			expect(cleanupBody.counts).toMatchObject({
+				requested: 1,
+				cleaned: 0,
+				branchDeleted: 0,
+				worktreeRemoved: 0,
+				invalidSelection: 0,
+				notActionable: 0,
+				failed: 0,
+				alreadyCleaned: 1,
+			});
+			expect(cleanupBody.counts.byStatus["already-cleaned"]).toBe(1);
+			expect(cleanupBody.counts.byReason["already-cleaned"]).toBe(1);
 			expect(cleanupBody.results).toContainEqual(expect.objectContaining({
 				sessionId: seeded.session.id,
 				key: item.key,
+				repo: ".",
+				repoPath,
+				path: missingWorktreePath,
+				branch,
 				status: "already-cleaned",
+				reason: "already-cleaned",
 				worktreeRemoved: false,
 				branchDeleted: false,
 			}));
@@ -543,6 +845,11 @@ test.describe("archived session worktree maintenance", () => {
 			expect(item).toMatchObject({
 				status: "skipped",
 				reason: "stale-worktree-directory",
+				disposition: "needs-attention",
+				reasonCategory: "stale-path",
+				actionable: false,
+				selectable: false,
+				defaultSelected: false,
 				pathExists: true,
 				gitWorktreeMetadataExists: false,
 				localBranchExists: true,
@@ -559,10 +866,15 @@ test.describe("archived session worktree maintenance", () => {
 			expect(cleanup.status).toBe(200);
 			const cleanupBody = await cleanup.json();
 			expectArchivedCleanupShape(cleanupBody);
-			expect(cleanupBody.counts).toMatchObject({ cleaned: 0, branchDeleted: 0, skipped: 1, failed: 0 });
+			expect(cleanupBody.counts).toMatchObject({ cleaned: 0, branchDeleted: 0, skipped: 1, notActionable: 1, failed: 0 });
+			expect(cleanupBody.counts.byReason["stale-worktree-directory"]).toBe(1);
 			expect(cleanupBody.results).toContainEqual(expect.objectContaining({
 				sessionId: seeded.session.id,
 				key: item.key,
+				repo: ".",
+				repoPath,
+				path: staleWorktreePath,
+				branch,
 				status: "skipped",
 				reason: "stale-worktree-directory",
 				worktreeRemoved: false,
@@ -610,13 +922,14 @@ test.describe("archived session worktree maintenance", () => {
 				method: "POST",
 				body: JSON.stringify({
 					mode: "selected",
-					worktrees: [{ sessionId: `${seeded.session.id}-wrong`, key: item.key }],
+					worktrees: [{ sessionId: `${seeded.session.id}-wrong`, key: item.key, repo: item.repo, path: item.path }],
 				}),
 			});
 			expect(cleanup.status).toBe(200);
 			const cleanupBody = await cleanup.json();
 			expectArchivedCleanupShape(cleanupBody);
-			expect(cleanupBody.counts).toMatchObject({ requested: 1, cleaned: 0, branchDeleted: 0, skipped: 1, failed: 0 });
+			expect(cleanupBody.counts).toMatchObject({ requested: 1, cleaned: 0, branchDeleted: 0, skipped: 1, invalidSelection: 1, failed: 0 });
+			expect(cleanupBody.counts.byReason["invalid-selection"]).toBe(1);
 			expect(cleanupBody.results).toContainEqual(expect.objectContaining({
 				key: item.key,
 				sessionId: `${seeded.session.id}-wrong`,
@@ -632,6 +945,98 @@ test.describe("archived session worktree maintenance", () => {
 			if (seeded) seeded.ctx.sessionStore.remove(seeded.session.id);
 			tryRemoveWorktree(repoPath, worktreePath);
 			tryDeleteBranch(repoPath, branch);
+			rmSync(baseDir, { recursive: true, force: true });
+		}
+	});
+
+	test("mode all cleans only safe candidates and leaves ineligible archived records untouched", async ({ gateway }) => {
+		test.slow();
+		const baseDir = mkdtempSync(join(tmpdir(), "bobbit-e2e-archived-wt-all-guard-"));
+		const repoPath = join(baseDir, "repo");
+		const removablePath = join(baseDir, "all-removable-worktree");
+		const liveReferencedPath = join(baseDir, "all-live-referenced-worktree");
+		const stalePath = join(baseDir, "all-stale-directory");
+		const alreadyCleanedPath = join(baseDir, "all-already-cleaned");
+		const removableBranch = `archived-all-removable-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+		const liveBranch = `archived-all-live-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+		const staleBranch = `archived-all-stale-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+		const alreadyBranch = `archived-all-already-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+		const seeded: SeededSession[] = [];
+		let liveSessionId: string | undefined;
+		try {
+			initGitRepo(repoPath);
+			git(repoPath, ["worktree", "add", "-b", removableBranch, removablePath, "HEAD"]);
+			git(repoPath, ["worktree", "add", "-b", liveBranch, liveReferencedPath, "HEAD"]);
+			git(repoPath, ["branch", staleBranch, "HEAD"]);
+			git(repoPath, ["branch", alreadyBranch, "HEAD"]);
+			mkdirSync(stalePath, { recursive: true });
+
+			const removable = await seedArchivedSession(gateway, { baseDir, title: "All removable", cwd: removablePath, repoPath, worktreePath: removablePath, branch: removableBranch });
+			const liveReferenced = await seedArchivedSession(gateway, { baseDir, title: "All live referenced", cwd: liveReferencedPath, repoPath, worktreePath: liveReferencedPath, branch: liveBranch });
+			const sandbox = await seedArchivedSession(gateway, { baseDir, title: "All sandbox", cwd: "/workspace-wt/session/all-sandbox", repoPath, worktreePath: "/workspace-wt/session/all-sandbox", branch: "all-sandbox", sandboxed: true });
+			const stale = await seedArchivedSession(gateway, { baseDir, title: "All stale", cwd: stalePath, repoPath, worktreePath: stalePath, branch: staleBranch });
+			const alreadyCleaned = await seedArchivedSession(gateway, { baseDir, title: "All already cleaned", cwd: alreadyCleanedPath, repoPath, worktreePath: alreadyCleanedPath, branch: alreadyBranch });
+			seeded.push(removable, liveReferenced, sandbox, stale, alreadyCleaned);
+			liveSessionId = `live-all-guard-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+			removable.ctx.sessionStore.put({
+				id: liveSessionId,
+				title: "Live guard for clean all",
+				cwd: liveReferencedPath,
+				agentSessionFile: join(baseDir, `${liveSessionId}.jsonl`),
+				createdAt: Date.now(),
+				lastActivity: Date.now(),
+				archived: false,
+				projectId: removable.projectId,
+				repoPath,
+				worktreePath: liveReferencedPath,
+				branch: liveBranch,
+			});
+
+			const before = await getArchivedWorktreeScan("?includeAlreadyCleaned=1");
+			expect(findArchivedWorktreeItem(before, removable.session.id)).toMatchObject({ status: "removable", actionable: true });
+			expect(findArchivedWorktreeItem(before, liveReferenced.session.id)).toMatchObject({ status: "skipped", reason: "referenced-by-live-session", actionable: false });
+			expect(findArchivedWorktreeItem(before, sandbox.session.id)).toMatchObject({ status: "skipped", reason: "sandbox-container-path", actionable: false });
+			expect(findArchivedWorktreeItem(before, stale.session.id)).toMatchObject({ status: "skipped", reason: "stale-worktree-directory", actionable: false });
+			expect(findArchivedWorktreeItem(before, alreadyCleaned.session.id)).toMatchObject({ status: "already-cleaned", reason: "already-cleaned", actionable: false });
+
+			const cleanup = await apiFetch("/api/maintenance/cleanup-archived-session-worktrees", {
+				method: "POST",
+				body: JSON.stringify({ mode: "all" }),
+			});
+			expect(cleanup.status).toBe(200);
+			const cleanupBody = await cleanup.json();
+			expectArchivedCleanupShape(cleanupBody);
+			expect(cleanupBody.counts).toMatchObject({ cleaned: 1, branchDeleted: 1, worktreeRemoved: 1, invalidSelection: 0, notActionable: 0, failed: 0 });
+			expect(cleanupBody.results).toContainEqual(expect.objectContaining({
+				sessionId: removable.session.id,
+				status: "cleaned",
+				path: removablePath,
+				branch: removableBranch,
+				worktreeRemoved: true,
+				branchDeleted: true,
+			}));
+			expect(cleanupBody.results.some((result: any) => [liveReferenced.session.id, sandbox.session.id, stale.session.id, alreadyCleaned.session.id].includes(result.sessionId))).toBe(false);
+
+			expect(existsSync(removablePath)).toBe(false);
+			expect(branchExists(repoPath, removableBranch)).toBe(false);
+			expect(existsSync(liveReferencedPath)).toBe(true);
+			expect(listedWorktreePaths(repoPath)).toContain(normalizeTestPath(liveReferencedPath));
+			expect(existsSync(stalePath)).toBe(true);
+			expect(branchExists(repoPath, liveBranch)).toBe(true);
+			expect(branchExists(repoPath, staleBranch)).toBe(true);
+			expect(branchExists(repoPath, alreadyBranch)).toBe(true);
+
+			const after = await getArchivedWorktreeScan("?includeAlreadyCleaned=1");
+			expect(findArchivedWorktreeItem(after, removable.session.id)).toMatchObject({ status: "already-cleaned", reason: "already-cleaned" });
+			expect(findArchivedWorktreeItem(after, liveReferenced.session.id)).toMatchObject({ status: "skipped", reason: "referenced-by-live-session" });
+			expect(findArchivedWorktreeItem(after, sandbox.session.id)).toMatchObject({ status: "skipped", reason: "sandbox-container-path" });
+			expect(findArchivedWorktreeItem(after, stale.session.id)).toMatchObject({ status: "skipped", reason: "stale-worktree-directory" });
+		} finally {
+			if (liveSessionId && seeded[0]) seeded[0].ctx.sessionStore.remove(liveSessionId);
+			for (const seed of seeded) seed.ctx.sessionStore.remove(seed.session.id);
+			tryRemoveWorktree(repoPath, removablePath);
+			tryRemoveWorktree(repoPath, liveReferencedPath);
+			for (const branch of [removableBranch, liveBranch, staleBranch, alreadyBranch]) tryDeleteBranch(repoPath, branch);
 			rmSync(baseDir, { recursive: true, force: true });
 		}
 	});
@@ -657,12 +1062,38 @@ test.describe("archived session worktree maintenance", () => {
 			expect(scannedSession).toBeTruthy();
 			expect(scannedSession.sandboxed).toBe(true);
 			expect(scannedSession.worktrees).toHaveLength(1);
-			expect(scannedSession.worktrees[0]).toMatchObject({
+			const item = scannedSession.worktrees[0];
+			expect(item).toMatchObject({
 				sessionId: seeded.session.id,
 				path: "/workspace-wt/session/archived-sandbox",
 				status: "skipped",
+				reason: "sandbox-container-path",
+				disposition: "ineligible",
+				reasonCategory: "container-path",
+				actionable: false,
+				selectable: false,
 				willDeleteBranch: false,
 			});
+
+			const cleanup = await apiFetch("/api/maintenance/cleanup-archived-session-worktrees", {
+				method: "POST",
+				body: JSON.stringify({
+					mode: "selected",
+					worktrees: [{ sessionId: seeded.session.id, key: item.key }],
+				}),
+			});
+			expect(cleanup.status).toBe(200);
+			const cleanupBody = await cleanup.json();
+			expectArchivedCleanupShape(cleanupBody);
+			expect(cleanupBody.counts).toMatchObject({ cleaned: 0, skipped: 1, notActionable: 1, failed: 0 });
+			expect(cleanupBody.results).toContainEqual(expect.objectContaining({
+				sessionId: seeded.session.id,
+				key: item.key,
+				status: "skipped",
+				reason: "sandbox-container-path",
+				worktreeRemoved: false,
+				branchDeleted: false,
+			}));
 		} finally {
 			if (seeded) seeded.ctx.sessionStore.remove(seeded.session.id);
 			rmSync(baseDir, { recursive: true, force: true });
@@ -700,19 +1131,35 @@ test.describe("archived session worktree maintenance", () => {
 			expect(scannedSession.worktrees).toHaveLength(2);
 			const byRepo = new Map(scannedSession.worktrees.map((item: any) => [item.repo, item]));
 			expect(byRepo.get(".")).toMatchObject({
+				title: "Archived multi-repo worktree",
 				repo: ".",
 				repoPath,
+				repoDisplayName: expect.any(String),
 				path: join(baseDir, "missing-root-worktree"),
+				branch,
+				source: "repoWorktrees",
 				status: "already-cleaned",
+				reason: "already-cleaned",
+				disposition: "already-cleaned",
+				reasonCategory: "already-cleaned",
 				localBranchExists: true,
 			});
+			expect(byRepo.get(".").selectionCategories).toEqual(expect.arrayContaining(["archived-session", "multi-repo"]));
 			expect(byRepo.get("packages/api")).toMatchObject({
+				title: "Archived multi-repo worktree",
 				repo: "packages/api",
 				repoPath: packageRepoPath,
+				repoDisplayName: expect.any(String),
 				path: join(baseDir, "missing-api-worktree"),
+				branch,
+				source: "repoWorktrees",
 				status: "already-cleaned",
+				reason: "already-cleaned",
+				disposition: "already-cleaned",
+				reasonCategory: "already-cleaned",
 				localBranchExists: true,
 			});
+			expect(byRepo.get("packages/api").selectionCategories).toEqual(expect.arrayContaining(["archived-session", "multi-repo"]));
 		} finally {
 			if (seeded) seeded.ctx.sessionStore.remove(seeded.session.id);
 			tryDeleteBranch(repoPath, branch);
@@ -762,6 +1209,11 @@ test.describe("archived session worktree maintenance", () => {
 				path: sharedWorktreePath,
 				pathExists: true,
 				status: "skipped",
+				reason: "referenced-by-live-session",
+				disposition: "ineligible",
+				reasonCategory: "referenced-record",
+				actionable: false,
+				selectable: false,
 				willDeleteBranch: false,
 			});
 		} finally {

--- a/tests/e2e/maintenance-api.spec.ts
+++ b/tests/e2e/maintenance-api.spec.ts
@@ -118,7 +118,7 @@ function expectArchivedWorktreeItemShape(item: any, parentSession?: any): void {
 	expect([...archivedWorktreeReasons]).toContain(item.reason);
 	expect(typeof item.detail).toBe("string");
 	expect(typeof item.willDeleteBranch).toBe("boolean");
-	if (item.branchDeleteBlockedReason !== undefined) expect(item.branchDeleteBlockedReason).toBe("branch-referenced-by-live-record");
+	if (item.branchDeleteBlockedReason !== undefined) expect(["branch-referenced-by-live-record", "branch-referenced-by-archived-record"]).toContain(item.branchDeleteBlockedReason);
 	expect([...archivedWorktreeDispositions]).toContain(item.disposition);
 	expect([...archivedWorktreeReasonCategories]).toContain(item.reasonCategory);
 	expect(typeof item.actionable).toBe("boolean");
@@ -185,6 +185,9 @@ function expectArchivedScanShape(body: any): void {
 		expect(Array.isArray(group.sampleKeys)).toBe(true);
 		expect(group.sampleKeys.length).toBeLessThanOrEqual(5);
 		for (const key of group.sampleKeys) expect(typeof key, `group ${group.key} sample key`).toBe("string");
+		expect(Array.isArray(group.sampleItems)).toBe(true);
+		expect(group.sampleItems.length).toBe(group.sampleKeys.length);
+		for (const item of group.sampleItems) expectArchivedWorktreeItemShape(item);
 		expect(typeof group.hasMore).toBe("boolean");
 		expect(typeof group.actionable).toBe("boolean");
 	}
@@ -694,6 +697,15 @@ test.describe("archived session worktree maintenance", () => {
 
 			const defaultScan = await getArchivedWorktreeScan();
 			expect(findArchivedSession(defaultScan, seeded.session.id)).toBeUndefined();
+			expect(findArchivedWorktreeItem(defaultScan, seeded.session.id)).toBeUndefined();
+			expect(defaultScan.counts.alreadyCleaned).toBeGreaterThanOrEqual(1);
+			const defaultAlreadyGroup = findArchivedWorktreeGroup(defaultScan, "already-cleaned");
+			expect(defaultAlreadyGroup).toBeTruthy();
+			expect(defaultAlreadyGroup.sampleItems).toContainEqual(expect.objectContaining({
+				sessionId: seeded.session.id,
+				status: "already-cleaned",
+				reason: "already-cleaned",
+			}));
 
 			const diagnosticScan = await getArchivedWorktreeScan("?includeAlreadyCleaned=1");
 			const diagnosticSession = findArchivedSession(diagnosticScan, seeded.session.id);
@@ -751,6 +763,67 @@ test.describe("archived session worktree maintenance", () => {
 			expect(branchExists(repoPath, branch)).toBe(true);
 		} finally {
 			if (seeded) seeded.ctx.sessionStore.remove(seeded.session.id);
+			tryDeleteBranch(repoPath, branch);
+			rmSync(baseDir, { recursive: true, force: true });
+		}
+	});
+
+	test("branch deletion is blocked when another archived record in the same repo references the branch", async ({ gateway }) => {
+		const baseDir = mkdtempSync(join(tmpdir(), "bobbit-e2e-archived-wt-archived-branch-guard-"));
+		const repoPath = join(baseDir, "repo");
+		const removablePath = join(baseDir, "removable-worktree");
+		const alreadyCleanedPath = join(baseDir, "already-cleaned-worktree");
+		const branch = `archived-branch-guard-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+		let removable: SeededSession | undefined;
+		let archivedReference: SeededSession | undefined;
+		try {
+			initGitRepo(repoPath);
+			git(repoPath, ["worktree", "add", "-b", branch, removablePath, "HEAD"]);
+			removable = await seedArchivedSession(gateway, {
+				baseDir,
+				title: "Archived removable with shared branch",
+				cwd: removablePath,
+				repoPath,
+				worktreePath: removablePath,
+				branch,
+			});
+			archivedReference = await seedArchivedSession(gateway, {
+				baseDir,
+				title: "Archived already cleaned branch reference",
+				cwd: alreadyCleanedPath,
+				repoPath,
+				worktreePath: alreadyCleanedPath,
+				branch,
+			});
+
+			const before = await getArchivedWorktreeScan("?includeAlreadyCleaned=1");
+			const candidate = findArchivedWorktreeItem(before, removable.session.id);
+			expect(candidate).toMatchObject({
+				status: "removable",
+				localBranchExists: true,
+				willDeleteBranch: false,
+				branchDeleteBlockedReason: "branch-referenced-by-archived-record",
+			});
+			expect(findArchivedWorktreeItem(before, archivedReference.session.id)).toMatchObject({ status: "already-cleaned", branch });
+
+			const cleanup = await apiFetch("/api/maintenance/cleanup-archived-session-worktrees", {
+				method: "POST",
+				body: JSON.stringify({ mode: "all" }),
+			});
+			expect(cleanup.status).toBe(200);
+			const cleanupBody = await cleanup.json();
+			expectArchivedCleanupShape(cleanupBody);
+			expect(cleanupBody.results).toContainEqual(expect.objectContaining({
+				sessionId: removable.session.id,
+				status: "cleaned",
+				worktreeRemoved: true,
+				branchDeleted: false,
+			}));
+			expect(branchExists(repoPath, branch)).toBe(true);
+		} finally {
+			if (removable) removable.ctx.sessionStore.remove(removable.session.id);
+			if (archivedReference) archivedReference.ctx.sessionStore.remove(archivedReference.session.id);
+			tryRemoveWorktree(repoPath, removablePath);
 			tryDeleteBranch(repoPath, branch);
 			rmSync(baseDir, { recursive: true, force: true });
 		}

--- a/tests/e2e/maintenance-api.spec.ts
+++ b/tests/e2e/maintenance-api.spec.ts
@@ -540,6 +540,18 @@ test.describe("archived session worktree maintenance", () => {
 		});
 		expect(emptyBody.results).toEqual([]);
 
+		const allWithProjectSelector = await apiFetch("/api/maintenance/cleanup-archived-session-worktrees", {
+			method: "POST",
+			body: JSON.stringify({ mode: "all", projectId: "project-a" }),
+		});
+		expect(allWithProjectSelector.status).toBe(400);
+
+		const allWithRepoSelector = await apiFetch("/api/maintenance/cleanup-archived-session-worktrees", {
+			method: "POST",
+			body: JSON.stringify({ mode: "all", repoPath: "/tmp/repo-a" }),
+		});
+		expect(allWithRepoSelector.status).toBe(400);
+
 		const allMode = await apiFetch("/api/maintenance/cleanup-archived-session-worktrees", {
 			method: "POST",
 			body: JSON.stringify({ mode: "all" }),

--- a/tests/e2e/ui/settings-maintenance-archived-worktrees.spec.ts
+++ b/tests/e2e/ui/settings-maintenance-archived-worktrees.spec.ts
@@ -1,0 +1,201 @@
+import type { Page, Route } from "@playwright/test";
+import { test, expect } from "../gateway-harness.js";
+import { navigateToHash, openApp } from "./ui-helpers.js";
+
+type MaintenanceStubState = {
+	scan: any;
+	cleanup: any;
+	nextScan?: any;
+	cleanupBodies: any[];
+};
+
+function archivedWorktreeItem(overrides: Record<string, any>): Record<string, any> {
+	const actionable = overrides.actionable ?? overrides.status === "removable";
+	return {
+		key: overrides.key,
+		sessionId: overrides.sessionId,
+		title: overrides.title,
+		archivedAt: 1_700_000_000_000,
+		projectId: "default",
+		projectName: "default",
+		repo: ".",
+		repoPath: "/fixture/project",
+		repoDisplayName: "app",
+		path: `/fixture/worktrees/${overrides.key}`,
+		branch: `archived/${overrides.key}`,
+		source: "worktreePath",
+		status: overrides.status,
+		disposition: overrides.disposition,
+		reason: overrides.reason,
+		reasonCategory: overrides.reasonCategory,
+		detail: actionable
+			? "Safe to remove: no live session, goal, team, staff, or sibling worktree references this path."
+			: "Not removable in this fixture category.",
+		actionable,
+		selectable: actionable,
+		defaultSelected: actionable,
+		selectionCategories: actionable ? ["all-removable", ...(overrides.selectionCategories ?? ["archived-session"])] : [],
+		pathExists: actionable,
+		gitWorktreeMetadataExists: actionable,
+		localBranchExists: actionable,
+		willDeleteBranch: actionable,
+		...overrides,
+	};
+}
+
+function scanResponse(items: Record<string, any>[]): any {
+	const byDisposition: Record<string, number> = {};
+	const byReason: Record<string, number> = {};
+	const bySelectionCategory: Record<string, number> = {};
+	for (const item of items) {
+		byDisposition[item.disposition] = (byDisposition[item.disposition] || 0) + 1;
+		byReason[item.reason] = (byReason[item.reason] || 0) + 1;
+		for (const category of item.selectionCategories || []) bySelectionCategory[category] = (bySelectionCategory[category] || 0) + 1;
+	}
+	const groupedItems = new Map<string, Record<string, any>[]>();
+	for (const item of items) {
+		const groupId = item.status === "removable" ? "ready-to-clean" : item.reason;
+		groupedItems.set(groupId, [...(groupedItems.get(groupId) || []), item]);
+	}
+	const ready = items.filter((item) => item.status === "removable");
+	const already = items.filter((item) => item.status === "already-cleaned");
+	const ineligible = items.filter((item) => item.status === "skipped" || item.disposition === "ineligible");
+	const failed = items.filter((item) => item.status === "failed" || item.disposition === "failed");
+	return {
+		sessions: [...new Map(items.map((item) => [item.sessionId, item])).values()].map((sessionItem: any) => ({
+			id: sessionItem.sessionId,
+			title: sessionItem.title,
+			archivedAt: sessionItem.archivedAt,
+			projectId: sessionItem.projectId,
+			projectName: sessionItem.projectName,
+			worktrees: items.filter((item) => item.sessionId === sessionItem.sessionId),
+		})),
+		items,
+		counts: {
+			archivedSessions: new Set(items.map((item) => item.sessionId)).size,
+			sessionsWithWorktrees: items.filter((item) => item.path).length,
+			removableWorktrees: ready.length,
+			skippedWorktrees: ineligible.length,
+			alreadyCleanedWorktrees: already.length,
+			totalItems: items.length,
+			readyToClean: ready.length,
+			defaultSelected: ready.length,
+			alreadyCleaned: already.length,
+			ineligible: ineligible.length,
+			needsAttention: ineligible.length + failed.length,
+			failed: failed.length,
+			byDisposition,
+			byReason,
+			bySelectionCategory,
+		},
+		groups: [...groupedItems.entries()].map(([id, groupItems]) => ({
+			id,
+			label: id.split("-").map((part) => part[0]?.toUpperCase() + part.slice(1)).join(" "),
+			disposition: groupItems[0]?.disposition,
+			reason: groupItems[0]?.reason,
+			reasonCategory: groupItems[0]?.reasonCategory,
+			count: groupItems.length,
+			itemKeys: groupItems.map((item) => item.key),
+			items: groupItems.slice(0, 5),
+		})),
+		selectionPresets: [
+			{ id: "all-removable", label: "Select all removable", itemKeys: ready.map((item) => item.key), categories: ["all-removable"] },
+			{ id: "archived-session", label: "Archived sessions only", itemKeys: ready.filter((item) => item.selectionCategories?.includes("archived-session")).map((item) => item.key), categories: ["archived-session"] },
+		],
+		generatedAt: Date.now(),
+	};
+}
+
+function cleanupResponse(counts: Record<string, number>, results: any[] = []): any {
+	return {
+		counts: { requested: 0, cleaned: 0, branchDeleted: 0, skipped: 0, alreadyCleaned: 0, failed: 0, ...counts },
+		results,
+	};
+}
+
+async function installMaintenanceRoutes(page: Page, state: MaintenanceStubState): Promise<void> {
+	await page.route(/\/api\/maintenance\/archived-session-worktrees(?:\?.*)?$/, async (route: Route) => {
+		if (route.request().method() !== "GET") return route.fallback();
+		await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(state.scan) });
+	});
+	await page.route(/\/api\/maintenance\/cleanup-archived-session-worktrees(?:\?.*)?$/, async (route: Route) => {
+		if (route.request().method() !== "POST") return route.fallback();
+		state.cleanupBodies.push(route.request().postDataJSON?.() ?? JSON.parse(route.request().postData() || "{}"));
+		if (state.nextScan) state.scan = state.nextScan;
+		await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(state.cleanup) });
+	});
+}
+
+async function openMaintenance(page: Page): Promise<void> {
+	await openApp(page);
+	await navigateToHash(page, "#/settings/system/maintenance");
+	await expect(page.getByTestId("archived-worktree-maintenance")).toBeVisible({ timeout: 10_000 });
+}
+
+test.describe("Settings Maintenance archived worktree UX", () => {
+	test("clean-all journey shows actionable-only defaults, posts server-authoritative mode, and rescans empty", async ({ page }) => {
+		const skipped = archivedWorktreeItem({ key: "skip-live", sessionId: "skip-live", title: "Referenced by live session", status: "skipped", disposition: "ineligible", reason: "referenced-by-live-session", reasonCategory: "referenced" });
+		const state: MaintenanceStubState = {
+			scan: scanResponse([
+				archivedWorktreeItem({ key: "ready-1", sessionId: "ready-1", title: "Ready archived worktree", status: "removable", disposition: "ready-to-clean", reason: "safe-archived-session-worktree", reasonCategory: "ready" }),
+				skipped,
+			]),
+			cleanup: cleanupResponse({ requested: 1, cleaned: 1, branchDeleted: 1 }, [
+				{ key: "ready-1", sessionId: "ready-1", status: "cleaned", reason: "safe-archived-session-worktree", worktreeRemoved: true, branchDeleted: true },
+			]),
+			nextScan: scanResponse([skipped]),
+			cleanupBodies: [],
+		};
+		await installMaintenanceRoutes(page, state);
+		await openMaintenance(page);
+
+		const card = page.getByTestId("archived-worktree-maintenance");
+		await card.getByTestId("archived-worktree-scan").click();
+		await expect(card.getByTestId("archived-worktree-summary-ready")).toContainText(/Ready to clean:\s*1/);
+		await expect(card.getByTestId("archived-worktree-summary-selected")).toContainText(/Selected:\s*1/);
+		await expect(card).not.toContainText(/With worktrees\s*:/);
+		await expect(page.locator('[data-testid="archived-worktree-row"][data-status="removable"]:visible')).toHaveCount(1);
+		await expect(page.locator('[data-testid="archived-worktree-row"][data-status="skipped"]:visible')).toHaveCount(0);
+
+		await card.getByTestId("archived-worktree-clean-all").click();
+		await expect.poll(() => state.cleanupBodies).toEqual([{ mode: "all" }]);
+		await expect(card).toContainText(/Cleaned:\s*1|Removed:\s*1/i);
+		await expect(card.getByTestId("archived-worktree-summary-ready")).toContainText(/Ready to clean:\s*0/);
+		await expect(card.getByTestId("archived-worktree-empty-state")).toBeVisible();
+		await expect(card.getByTestId("archived-worktree-clean-all")).toBeDisabled();
+		await expect(card.getByTestId("archived-worktree-clean-selected")).toBeDisabled();
+	});
+
+	test("zero-removable state hides skipped examples until disclosure and supports grouped samples", async ({ page }) => {
+		const state: MaintenanceStubState = {
+			scan: scanResponse([
+				...Array.from({ length: 6 }, (_, i) => archivedWorktreeItem({ key: `missing-${i}`, sessionId: `missing-${i}`, title: `Missing path ${i}`, status: "skipped", disposition: "ineligible", reason: "no-worktree-path", reasonCategory: "missing-worktree-path", path: "" })),
+				archivedWorktreeItem({ key: "sandbox-1", sessionId: "sandbox-1", title: "Sandbox path", status: "skipped", disposition: "ineligible", reason: "sandbox-container-path", reasonCategory: "sandbox-container-path", path: "/workspace-wt/session/sandbox" }),
+				archivedWorktreeItem({ key: "already-1", sessionId: "already-1", title: "Already cleaned", status: "already-cleaned", disposition: "already-cleaned", reason: "already-cleaned", reasonCategory: "already-cleaned" }),
+			]),
+			cleanup: cleanupResponse({}),
+			cleanupBodies: [],
+		};
+		await installMaintenanceRoutes(page, state);
+		await openMaintenance(page);
+
+		const card = page.getByTestId("archived-worktree-maintenance");
+		await card.getByTestId("archived-worktree-scan").click();
+		await expect(card.getByTestId("archived-worktree-summary-ready")).toContainText(/Ready to clean:\s*0/);
+		await expect(card.getByTestId("archived-worktree-empty-state")).toContainText(/Nothing safe to clean right now/i);
+		await expect(card).toContainText(/Cleanup is disabled because there are 0 safe candidates/i);
+		await expect(card.getByTestId("archived-worktree-clean-all")).toBeDisabled();
+		await expect(card.getByTestId("archived-worktree-clean-selected")).toBeDisabled();
+		await expect(page.locator('[data-testid="archived-worktree-row"][data-status="skipped"]:visible')).toHaveCount(0);
+		await expect(card).not.toContainText("Missing path 0");
+		await expect(card).not.toContainText(/With worktrees\s*:/);
+
+		await card.getByTestId("archived-worktree-show-skipped").click();
+		const missingGroup = card.getByTestId("archived-worktree-group-no-worktree-path");
+		await expect(missingGroup).toBeVisible();
+		await expect(missingGroup.locator('[data-testid="archived-worktree-row"]:visible')).toHaveCount(5);
+		await expect(card.getByTestId("archived-worktree-group-sandbox-container-path")).toBeVisible();
+		await card.getByTestId("archived-worktree-show-all-no-worktree-path").click();
+		await expect(missingGroup.locator('[data-testid="archived-worktree-row"]:visible')).toHaveCount(6);
+	});
+});

--- a/tests/e2e/ui/settings-maintenance-archived-worktrees.spec.ts
+++ b/tests/e2e/ui/settings-maintenance-archived-worktrees.spec.ts
@@ -158,6 +158,7 @@ test.describe("Settings Maintenance archived worktree UX", () => {
 		await expect(page.locator('[data-testid="archived-worktree-row"][data-status="skipped"]:visible')).toHaveCount(0);
 
 		await card.getByTestId("archived-worktree-clean-all").click();
+		await page.getByRole("button", { name: "Clean worktrees" }).evaluate((button: HTMLElement) => button.click());
 		await expect.poll(() => state.cleanupBodies).toEqual([{ mode: "all" }]);
 		await expect(card).toContainText(/Cleaned:\s*1|Removed:\s*1/i);
 		await expect(card.getByTestId("archived-worktree-summary-ready")).toContainText(/Ready to clean:\s*0/);

--- a/tests/e2e/ui/settings-maintenance-archived-worktrees.spec.ts
+++ b/tests/e2e/ui/settings-maintenance-archived-worktrees.spec.ts
@@ -199,4 +199,30 @@ test.describe("Settings Maintenance archived worktree UX", () => {
 		await card.getByTestId("archived-worktree-show-all-no-worktree-path").click();
 		await expect(missingGroup.locator('[data-testid="archived-worktree-row"]:visible')).toHaveCount(6);
 	});
+
+	test("zero-removable all-already-cleaned scan shows representative already-cleaned examples", async ({ page }) => {
+		const alreadyCleaned = archivedWorktreeItem({ key: "already-only-1", sessionId: "already-only-1", title: "Already cleaned only", status: "already-cleaned", disposition: "already-cleaned", reason: "already-cleaned", reasonCategory: "already-cleaned" });
+		const scan = scanResponse([alreadyCleaned]);
+		scan.sessions = [];
+		scan.items = [];
+		const state: MaintenanceStubState = {
+			scan,
+			cleanup: cleanupResponse({}),
+			cleanupBodies: [],
+		};
+		await installMaintenanceRoutes(page, state);
+		await openMaintenance(page);
+
+		const card = page.getByTestId("archived-worktree-maintenance");
+		await card.getByTestId("archived-worktree-scan").click();
+		await expect(card.getByTestId("archived-worktree-summary-ready")).toContainText(/Ready to clean:\s*0/);
+		await expect(card.getByTestId("archived-worktree-summary-already-cleaned")).toContainText(/Already cleaned:\s*1/);
+		await expect(card.getByTestId("archived-worktree-empty-state")).toBeVisible();
+		await expect(page.locator('[data-testid="archived-worktree-row"]:visible')).toHaveCount(0);
+		await card.getByTestId("archived-worktree-show-skipped").click();
+		const alreadyGroup = card.getByTestId("archived-worktree-group-already-cleaned");
+		await expect(alreadyGroup).toBeVisible();
+		await expect(alreadyGroup).toContainText("Already cleaned only");
+		await expect(alreadyGroup.locator('[data-testid="archived-worktree-row"][data-status="already-cleaned"]:visible')).toHaveCount(1);
+	});
 });

--- a/tests/ui-fixtures/search-preview-maintenance.spec.ts
+++ b/tests/ui-fixtures/search-preview-maintenance.spec.ts
@@ -61,8 +61,14 @@ function archivedWorktreeScan() {
 						gitWorktreeMetadataExists: true,
 						localBranchExists: true,
 						status: "removable",
-						reason: "Safe to remove",
+						disposition: "ready-to-clean",
+						reason: "safe-archived-session-worktree",
+						reasonCategory: "safe",
 						detail: "No live session, goal, team, staff, or sibling record references this path.",
+						actionable: true,
+						selectable: true,
+						defaultSelected: true,
+						selectionCategories: ["archived-session", "multi-repo"],
 						willDeleteBranch: true,
 					},
 				],
@@ -87,10 +93,16 @@ function archivedWorktreeScan() {
 						gitWorktreeMetadataExists: true,
 						localBranchExists: true,
 						status: "skipped",
-						reason: "Still referenced",
+						disposition: "ineligible",
+						reason: "referenced-by-live-team",
+						reasonCategory: "referenced-record",
 						detail: "A live team member still uses this worktree path.",
+						actionable: false,
+						selectable: false,
+						defaultSelected: false,
+						selectionCategories: [],
 						willDeleteBranch: false,
-						branchDeleteBlockedReason: "Branch is referenced by a live team member.",
+						branchDeleteBlockedReason: "branch-referenced-by-live-record",
 					},
 				],
 			},
@@ -128,8 +140,14 @@ function alreadyCleanedArchivedWorktreeScan() {
 						gitWorktreeMetadataExists: false,
 						localBranchExists: true,
 						status: "already-cleaned",
-						reason: "Already cleaned",
+						disposition: "already-cleaned",
+						reason: "already-cleaned",
+						reasonCategory: "already-cleaned",
 						detail: "The worktree path and git worktree metadata are gone.",
+						actionable: false,
+						selectable: false,
+						defaultSelected: false,
+						selectionCategories: [],
 						willDeleteBranch: false,
 					},
 				],
@@ -179,7 +197,7 @@ test.describe("Maintenance tab fixture", () => {
 		await expect(page.getByText(/No orphaned worktrees found/)).toBeVisible({ timeout: 5_000 });
 
 		await archivedWorktreeCard(page).locator('[data-action="scan-archived-session-worktrees"]').click();
-		await expect(archivedWorktreeCard(page).getByText(/No archived(?: session)? worktrees found/i)).toBeVisible({ timeout: 5_000 });
+		await expect(archivedWorktreeCard(page).getByTestId("archived-worktree-empty-state")).toContainText(/Nothing safe to clean right now/i, { timeout: 5_000 });
 
 		await maintenanceCardByHeading(page, "Orphaned Sessions").getByRole("button", { name: "Scan" }).click();
 		await expect(page.getByText(/No orphaned sessions found/)).toBeVisible({ timeout: 5_000 });
@@ -195,36 +213,39 @@ test.describe("Maintenance tab fixture", () => {
 		]));
 	});
 
-	test("archived worktree scan renders removable and skipped rows with safety details", async ({ page }) => {
+	test("archived worktree scan defaults to actionable rows and exposes skipped details on demand", async ({ page }) => {
 		await setupMaintenance(page, { archivedWorktreeScan: archivedWorktreeScan() });
 
 		await archivedWorktreeCard(page).locator('[data-action="scan-archived-session-worktrees"]').click();
 		const card = archivedWorktreeCard(page);
 		await expect(card.getByText("Archived cleanup target")).toBeVisible({ timeout: 5_000 });
-		await expect(card.getByText("Guarded archived delegate")).toBeVisible();
-		await expect(card.getByText("arch-rem")).toBeVisible();
-		await expect(card.getByText("arch-ski")).toBeVisible();
+		await expect(card.getByText("Guarded archived delegate")).toHaveCount(0);
+		await expect(card.getByTestId("archived-worktree-summary-ready")).toContainText(/Ready to clean:\s*1/);
+		await expect(card.getByTestId("archived-worktree-summary-needs-attention")).toContainText(/Needs attention:\s*1/);
 
 		const removableRow = card.locator('[data-archived-worktree-key="arch-alpha::packages-web"]');
-		await expect(removableRow).toContainText("removable");
+		await expect(removableRow).toContainText("Ready to clean");
 		await expect(removableRow).toContainText("repo: packages/web");
 		await expect(removableRow).toContainText("branch: session/archived-alpha");
-		await expect(removableRow).toContainText("branch will be deleted");
+		await expect(removableRow).toContainText("Branch will be deleted");
 		await expect(removableRow).toContainText("worktree: C:/repo-wt/session-archived-alpha/packages/web");
 		await expect(removableRow).toContainText("repo path: C:/repo/packages/web");
-		await expect(removableRow).toContainText("No live session, goal, team, staff, or sibling record references this path.");
+		await expect(removableRow).toContainText("Safe to remove: no live session, goal, team, staff, or sibling worktree references this path.");
 		await expect(removableRow.getByRole("checkbox")).toBeEnabled();
 		await expect(removableRow.getByRole("checkbox")).toBeChecked();
 
+		await expect(card.locator('[data-archived-worktree-key="arch-skip::root"]')).toHaveCount(0);
+		await card.getByTestId("archived-worktree-show-skipped").click();
 		const skippedRow = card.locator('[data-archived-worktree-key="arch-skip::root"]');
-		await expect(skippedRow).toContainText("skipped");
+		await expect(skippedRow).toContainText("Skipped");
+		await expect(skippedRow).toHaveAttribute("data-reason", "referenced-by-live-team");
 		await expect(skippedRow).toContainText("repo: .");
 		await expect(skippedRow).toContainText("branch: session/shared-branch");
 		await expect(skippedRow).toContainText("worktree: C:/repo-wt/shared-worktree");
 		await expect(skippedRow).toContainText("repo path: C:/repo");
 		await expect(skippedRow).toContainText("A live team member still uses this worktree path.");
-		await expect(skippedRow).toContainText("Branch kept: Branch is referenced by a live team member.");
-		await expect(skippedRow.getByRole("checkbox")).toBeDisabled();
+		await expect(skippedRow).toContainText("Branch will be kept: branch-referenced-by-live-record");
+		await expect(skippedRow.getByRole("checkbox")).toHaveCount(0);
 	});
 
 	test("archived selected cleanup posts selected worktrees, shows counts, clears cleaned rows, and rescans", async ({ page }) => {
@@ -236,7 +257,8 @@ test.describe("Maintenance tab fixture", () => {
 		await card.locator('[data-action="cleanup-archived-session-worktrees"]').click();
 
 		await expect(card.locator('[data-archived-worktree-key="arch-alpha::packages-web"]')).toHaveCount(0, { timeout: 5_000 });
-		await expect(card.locator('[data-archived-worktree-key="arch-skip::root"]')).toBeVisible();
+		await expect(card.getByTestId("archived-worktree-empty-state")).toContainText(/Nothing safe to clean right now/i);
+		await expect(card.locator('[data-archived-worktree-key="arch-skip::root"]')).toHaveCount(0);
 		await expect.poll(async () => await card.textContent()).toMatch(/(cleaned\D+1|1\D+cleaned)/i);
 		await expect.poll(async () => await card.textContent()).toMatch(/(branch\D+1|1\D+branch)/i);
 
@@ -257,28 +279,28 @@ test.describe("Maintenance tab fixture", () => {
 		expect(log.filter(entry => entry.method === "GET" && entry.url.startsWith("/api/maintenance/archived-session-worktrees"))).toHaveLength(2);
 	});
 
-	test("already-cleaned archived diagnostic rows are disabled when the UI exposes them", async ({ page }) => {
+	test("already-cleaned archived diagnostic rows are hidden until troubleshooting is expanded", async ({ page }) => {
 		await setupMaintenance(page, { archivedWorktreeScan: alreadyCleanedArchivedWorktreeScan() });
 		const card = archivedWorktreeCard(page);
 
-		const diagnosticsControl = card.getByRole("checkbox", { name: /already cleaned|diagnostic/i })
-			.or(card.getByRole("button", { name: /already cleaned|diagnostic/i }));
-		if (await diagnosticsControl.count()) await diagnosticsControl.first().click();
-
 		await card.locator('[data-action="scan-archived-session-worktrees"]').click();
-		const cleanedRow = card.locator('[data-archived-worktree-key="arch-cleaned::root"]');
-		if (await cleanedRow.count() === 0) test.skip(true, "Archived worktree diagnostics are not exposed by this UI.");
+		await expect(card.getByTestId("archived-worktree-empty-state")).toContainText(/Nothing safe to clean right now/i, { timeout: 5_000 });
+		await expect(card.locator('[data-archived-worktree-key="arch-cleaned::root"]')).toHaveCount(0);
+		await expect(card.locator('[data-action="cleanup-archived-session-worktrees"]')).toBeDisabled();
 
+		await card.getByTestId("archived-worktree-show-skipped").click();
+		const cleanedRow = card.locator('[data-archived-worktree-key="arch-cleaned::root"]');
+		await expect(cleanedRow).toBeVisible();
 		await expect(card.getByText("Already cleaned archive")).toBeVisible();
-		await expect(card.getByText("arch-cle")).toBeVisible();
-		await expect(cleanedRow).toContainText("already-cleaned");
+		await expect(cleanedRow.getByText("arch-cle", { exact: true })).toBeVisible();
+		await expect(cleanedRow).toContainText("Already cleaned");
+		await expect(cleanedRow).toHaveAttribute("data-reason", "already-cleaned");
 		await expect(cleanedRow).toContainText("repo: .");
 		await expect(cleanedRow).toContainText("branch: session/already-cleaned");
 		await expect(cleanedRow).toContainText("worktree: C:/repo-wt/already-cleaned");
 		await expect(cleanedRow).toContainText("repo path: C:/repo");
 		await expect(cleanedRow).toContainText("The worktree path and git worktree metadata are gone.");
-		await expect(cleanedRow.getByRole("checkbox")).toBeDisabled();
-		await expect(card.locator('[data-action="cleanup-archived-session-worktrees"]')).toBeDisabled();
+		await expect(cleanedRow.getByRole("checkbox")).toHaveCount(0);
 	});
 
 	test("cleanup actions POST and then rescan", async ({ page }) => {

--- a/tests/ui-fixtures/settings-admin-fixture-entry.ts
+++ b/tests/ui-fixtures/settings-admin-fixture-entry.ts
@@ -9,6 +9,7 @@ import type { RoleData, ToolInfo, Workflow } from "../../src/app/api.js";
 type FetchLogEntry = { url: string; method: string; body: any };
 type OAuthStatus = Partial<Record<"anthropic" | "openai-codex", { authenticated: boolean; expires?: number }>>;
 type StructuredProject = { components: any[]; workflows?: Record<string, unknown>; worktree_root?: string };
+type ArchivedWorktreeFixture = Record<string, any>;
 
 const STORE_PREFIX = "bobbit-settings-admin-fixture";
 const PREFS_KEY = `${STORE_PREFIX}:prefs`;
@@ -81,6 +82,40 @@ function defaultStructuredProjects(): Record<string, StructuredProject> {
 	};
 }
 
+function defaultArchivedWorktreeScan(): ArchivedWorktreeFixture {
+	return {
+		sessions: [],
+		items: [],
+		counts: {
+			archivedSessions: 0,
+			sessionsWithWorktrees: 0,
+			removableWorktrees: 0,
+			skippedWorktrees: 0,
+			alreadyCleanedWorktrees: 0,
+			totalItems: 0,
+			readyToClean: 0,
+			defaultSelected: 0,
+			alreadyCleaned: 0,
+			ineligible: 0,
+			needsAttention: 0,
+			failed: 0,
+			byDisposition: {},
+			byReason: {},
+			bySelectionCategory: {},
+		},
+		groups: [],
+		selectionPresets: [],
+		generatedAt: Date.now(),
+	};
+}
+
+function defaultArchivedWorktreeCleanup(): ArchivedWorktreeFixture {
+	return {
+		counts: { requested: 0, cleaned: 0, branchDeleted: 0, skipped: 0, alreadyCleaned: 0, failed: 0 },
+		results: [],
+	};
+}
+
 let currentPage: "settings" | "roles" | "tools" = "settings";
 let prefs: Record<string, any> = readJson(PREFS_KEY, {});
 let roles: RoleData[] = readJson(ROLES_KEY, defaultRoles());
@@ -92,6 +127,9 @@ let oauthStatus: OAuthStatus = {
 	anthropic: { authenticated: true },
 	"openai-codex": { authenticated: false },
 };
+let archivedWorktreeScan: ArchivedWorktreeFixture = defaultArchivedWorktreeScan();
+let archivedWorktreeCleanup: ArchivedWorktreeFixture = defaultArchivedWorktreeCleanup();
+let archivedWorktreeNextScan: ArchivedWorktreeFixture | null = null;
 let fetchLog: FetchLogEntry[] = [];
 
 function readJson<T>(key: string, fallback: T): T {
@@ -273,6 +311,15 @@ window.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
 	if (pathname === "/api/sandbox-status") return response({ available: false, configured: false });
 	if (pathname === "/api/worktree-pool") return response({ enabled: false });
 	if (pathname === "/api/sandbox/host-tokens") return response([]);
+	if (pathname === "/api/maintenance/archived-session-worktrees" && method === "GET") return response(archivedWorktreeScan);
+	if (pathname === "/api/maintenance/cleanup-archived-session-worktrees" && method === "POST") {
+		const cleanup = archivedWorktreeCleanup;
+		if (archivedWorktreeNextScan) {
+			archivedWorktreeScan = archivedWorktreeNextScan;
+			archivedWorktreeNextScan = null;
+		}
+		return response(cleanup);
+	}
 	if (pathname.startsWith("/api/search/") || pathname.startsWith("/api/maintenance/")) return response({ count: 0, sample: [] });
 
 	return response({ ok: true });
@@ -318,6 +365,9 @@ updatePlayFinishDataset();
 		"openai-codex": { authenticated: false },
 		...(opts.oauthStatus || {}),
 	};
+	archivedWorktreeScan = defaultArchivedWorktreeScan();
+	archivedWorktreeCleanup = defaultArchivedWorktreeCleanup();
+	archivedWorktreeNextScan = null;
 	fetchLog = [];
 	setConfigScope("system");
 	persistStores();
@@ -358,6 +408,11 @@ updatePlayFinishDataset();
 (window as any).__getSettingsAdminPrefs = () => ({ ...prefs });
 (window as any).__getSettingsAdminRoles = () => roles.map((r) => ({ ...r }));
 (window as any).__getSettingsAdminStructured = (projectId = "proj-1") => JSON.parse(JSON.stringify(structuredProjects[projectId] || null));
+(window as any).__setArchivedWorktreeScan = (scan: ArchivedWorktreeFixture) => { archivedWorktreeScan = scan; };
+(window as any).__setArchivedWorktreeCleanup = (cleanup: ArchivedWorktreeFixture, nextScan?: ArchivedWorktreeFixture) => {
+	archivedWorktreeCleanup = cleanup;
+	archivedWorktreeNextScan = nextScan || null;
+};
 (window as any).__getSettingsAdminFetchLog = () => fetchLog.slice();
 (window as any).__clearSettingsAdminFetchLog = () => { fetchLog = []; };
 (window as any).__settingsAdminReady = true;

--- a/tests/ui-fixtures/settings-admin-fixture.spec.ts
+++ b/tests/ui-fixtures/settings-admin-fixture.spec.ts
@@ -277,6 +277,26 @@ test.describe("Settings/admin UI fixture", () => {
 		await expect(card).not.toContainText(/With worktrees\s*:/);
 	});
 
+	test("archived worktree maintenance exposes already-cleaned examples from group samples", async ({ page }) => {
+		const alreadyCleaned = archivedWorktreeItem({ key: "already-only-1", sessionId: "already-only-1", title: "Already cleaned only", status: "already-cleaned", disposition: "already-cleaned", reason: "already-cleaned", reasonCategory: "already-cleaned" });
+		const scan = archivedWorktreeScan([alreadyCleaned]);
+		scan.sessions = [];
+		scan.items = [];
+		await setArchivedWorktreeScan(page, scan);
+		await renderSettings(page, "#/settings/system/maintenance");
+
+		const card = await scanArchivedWorktrees(page);
+		await expect(card.getByTestId("archived-worktree-summary-ready")).toContainText(/Ready to clean:\s*0/);
+		await expect(card.getByTestId("archived-worktree-summary-already-cleaned")).toContainText(/Already cleaned:\s*1/);
+		await expect(card.getByTestId("archived-worktree-empty-state")).toBeVisible();
+		await expect(page.locator('[data-testid="archived-worktree-row"]:visible')).toHaveCount(0);
+		await card.getByTestId("archived-worktree-show-skipped").click();
+		const alreadyGroup = card.getByTestId("archived-worktree-group-already-cleaned");
+		await expect(alreadyGroup).toBeVisible();
+		await expect(alreadyGroup).toContainText("Already cleaned only");
+		await expect(alreadyGroup.locator('[data-testid="archived-worktree-row"][data-status="already-cleaned"]:visible')).toHaveCount(1);
+	});
+
 	test("archived worktree skipped disclosure groups examples and expands one reason at a time", async ({ page }) => {
 		const scan = archivedWorktreeScan([
 			...Array.from({ length: 6 }, (_, i) => archivedWorktreeItem({ key: `missing-${i}`, sessionId: `missing-${i}`, title: `Missing path ${i}`, status: "skipped", disposition: "ineligible", reason: "no-worktree-path", reasonCategory: "missing-worktree-path", path: "" })),

--- a/tests/ui-fixtures/settings-admin-fixture.spec.ts
+++ b/tests/ui-fixtures/settings-admin-fixture.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect, type Locator, type Page } from "@playwright/test";
 import fs from "node:fs";
 import path from "node:path";
 import { buildBundle } from "../fixtures/build-bundle.js";
@@ -69,10 +69,312 @@ async function prefs(page: Page): Promise<Record<string, any>> {
 	return await page.evaluate(() => (window as any).__getSettingsAdminPrefs());
 }
 
+type ArchivedWorktreeItemFixture = {
+	key: string;
+	sessionId: string;
+	title: string;
+	status: "removable" | "skipped" | "already-cleaned" | "failed";
+	disposition: "ready-to-clean" | "already-cleaned" | "ineligible" | "needs-attention" | "failed";
+	reason: string;
+	reasonCategory: string;
+	selectionCategories?: string[];
+	projectId?: string;
+	projectName?: string;
+	repo?: string;
+	repoPath?: string;
+	path?: string;
+	branch?: string;
+	detail?: string;
+	actionable?: boolean;
+	selectable?: boolean;
+	defaultSelected?: boolean;
+};
+
+function archivedWorktreeItem(overrides: Partial<ArchivedWorktreeItemFixture> & Pick<ArchivedWorktreeItemFixture, "key" | "sessionId" | "title" | "status" | "disposition" | "reason" | "reasonCategory">): ArchivedWorktreeItemFixture & Record<string, any> {
+	const actionable = overrides.actionable ?? overrides.status === "removable";
+	return {
+		archivedAt: 1_700_000_000_000,
+		projectId: "proj-1",
+		projectName: "Scope UI Project",
+		repo: ".",
+		repoPath: "/fixture/project",
+		repoDisplayName: "app",
+		path: `/fixture/worktrees/${overrides.key}`,
+		branch: `archived/${overrides.key}`,
+		source: "worktreePath",
+		pathExists: actionable,
+		gitWorktreeMetadataExists: actionable,
+		localBranchExists: actionable,
+		willDeleteBranch: actionable,
+		detail: overrides.status === "removable"
+			? "Safe to remove: no live session, goal, team, staff, or sibling worktree references this path."
+			: "Not removable in this fixture category.",
+		actionable,
+		selectable: actionable,
+		defaultSelected: actionable,
+		selectionCategories: actionable ? ["all-removable", ...(overrides.selectionCategories ?? ["archived-session"])] : [],
+		...overrides,
+	};
+}
+
+function archivedWorktreeScan(items: Array<ArchivedWorktreeItemFixture & Record<string, any>>) {
+	const byDisposition: Record<string, number> = {};
+	const byReason: Record<string, number> = {};
+	const bySelectionCategory: Record<string, number> = {};
+	for (const item of items) {
+		byDisposition[item.disposition] = (byDisposition[item.disposition] || 0) + 1;
+		byReason[item.reason] = (byReason[item.reason] || 0) + 1;
+		for (const category of item.selectionCategories || []) bySelectionCategory[category] = (bySelectionCategory[category] || 0) + 1;
+	}
+	const groupedItems = new Map<string, Array<any>>();
+	for (const item of items) {
+		const groupId = item.status === "removable" ? "ready-to-clean" : item.reason;
+		groupedItems.set(groupId, [...(groupedItems.get(groupId) || []), item]);
+	}
+	const groups = [...groupedItems.entries()].map(([id, groupItems]) => ({
+		id,
+		label: id === "ready-to-clean" ? "Ready to clean" : humanizeReason(id),
+		disposition: groupItems[0]?.disposition,
+		reason: groupItems[0]?.reason,
+		reasonCategory: groupItems[0]?.reasonCategory,
+		count: groupItems.length,
+		itemKeys: groupItems.map((item) => item.key),
+		items: groupItems.slice(0, 5),
+	}));
+	const ready = items.filter((item) => item.status === "removable");
+	const already = items.filter((item) => item.status === "already-cleaned");
+	const failed = items.filter((item) => item.status === "failed" || item.disposition === "failed");
+	const ineligible = items.filter((item) => item.status === "skipped" || item.disposition === "ineligible");
+	const sessions = [...new Map(items.map((item) => [item.sessionId, item])).values()].map((sessionItem: any) => ({
+		id: sessionItem.sessionId,
+		title: sessionItem.title,
+		archivedAt: sessionItem.archivedAt,
+		projectId: sessionItem.projectId,
+		projectName: sessionItem.projectName,
+		sandboxed: Boolean(sessionItem.sandboxed),
+		worktrees: items.filter((item) => item.sessionId === sessionItem.sessionId),
+	}));
+	return {
+		sessions,
+		items,
+		counts: {
+			archivedSessions: sessions.length,
+			sessionsWithWorktrees: items.filter((item) => item.path).length,
+			removableWorktrees: ready.length,
+			skippedWorktrees: ineligible.length,
+			alreadyCleanedWorktrees: already.length,
+			totalItems: items.length,
+			readyToClean: ready.length,
+			defaultSelected: ready.filter((item) => item.defaultSelected).length,
+			alreadyCleaned: already.length,
+			ineligible: ineligible.length,
+			needsAttention: ineligible.length + failed.length,
+			failed: failed.length,
+			byDisposition,
+			byReason,
+			bySelectionCategory,
+		},
+		groups,
+		selectionPresets: [
+			{ id: "all-removable", label: "Select all removable", itemKeys: ready.map((item) => item.key), categories: ["all-removable"] },
+			{ id: "archived-session", label: "Archived sessions only", itemKeys: ready.filter((item) => item.selectionCategories?.includes("archived-session")).map((item) => item.key), categories: ["archived-session"] },
+			{ id: "current-project", label: "Current project", itemKeys: ready.filter((item) => item.selectionCategories?.includes("current-project")).map((item) => item.key), categories: ["current-project"] },
+			{ id: "goal-team-delegate", label: "Goal/team/delegate worktrees", itemKeys: ready.filter((item) => item.selectionCategories?.includes("goal-team-delegate")).map((item) => item.key), categories: ["goal-team-delegate"] },
+		],
+		generatedAt: Date.now(),
+	};
+}
+
+function humanizeReason(reason: string): string {
+	return reason.split("-").map((part) => part[0]?.toUpperCase() + part.slice(1)).join(" ");
+}
+
+function cleanupResponse(counts: Partial<Record<"requested" | "cleaned" | "branchDeleted" | "skipped" | "alreadyCleaned" | "failed", number>>, results: any[] = []) {
+	return {
+		counts: { requested: 0, cleaned: 0, branchDeleted: 0, skipped: 0, alreadyCleaned: 0, failed: 0, ...counts },
+		results,
+	};
+}
+
+async function setArchivedWorktreeScan(page: Page, scan: any): Promise<void> {
+	await page.evaluate((payload) => (window as any).__setArchivedWorktreeScan(payload), scan);
+}
+
+async function setArchivedWorktreeCleanup(page: Page, cleanup: any, nextScan?: any): Promise<void> {
+	await page.evaluate(({ response, next }) => (window as any).__setArchivedWorktreeCleanup(response, next), { response: cleanup, next: nextScan });
+}
+
+async function scanArchivedWorktrees(page: Page) {
+	const card = page.getByTestId("archived-worktree-maintenance");
+	await expect(card).toBeVisible();
+	await card.getByTestId("archived-worktree-scan").click();
+	await expect(card.getByTestId("archived-worktree-summary-ready")).toBeVisible();
+	return card;
+}
+
+function visibleArchivedRows(page: Page): Locator {
+	return page.locator('[data-testid="archived-worktree-row"]:visible');
+}
+
+async function clickArchivedWorktreeRowCheckbox(page: Page, key: string): Promise<void> {
+	const row = page.locator(`[data-testid="archived-worktree-row"][data-archived-worktree-key="${key}"]`).first();
+	await expect(row).toBeVisible();
+	const checkbox = row.locator('input[type="checkbox"], [role="checkbox"]').first();
+	if (await checkbox.count()) await checkbox.click();
+	else await row.click();
+}
+
 test.describe("Settings/admin UI fixture", () => {
 	test.beforeEach(async ({ page }) => {
 		await loadFixture(page);
 		await resetFixture(page);
+	});
+
+	test("archived worktree maintenance defaults to actionable rows and avoids ambiguous primary counts", async ({ page }) => {
+		const scan = archivedWorktreeScan([
+			archivedWorktreeItem({ key: "ready-1", sessionId: "arch-1", title: "Ready archived one", status: "removable", disposition: "ready-to-clean", reason: "safe-archived-session-worktree", reasonCategory: "ready" }),
+			archivedWorktreeItem({ key: "ready-2", sessionId: "arch-2", title: "Ready archived two", status: "removable", disposition: "ready-to-clean", reason: "safe-archived-session-worktree", reasonCategory: "ready" }),
+			...Array.from({ length: 8 }, (_, i) => archivedWorktreeItem({ key: `missing-${i}`, sessionId: `skip-missing-${i}`, title: `Missing path ${i}`, status: "skipped", disposition: "ineligible", reason: "no-worktree-path", reasonCategory: "missing-worktree-path", path: "" })),
+			archivedWorktreeItem({ key: "sandbox-1", sessionId: "skip-sandbox-1", title: "Sandbox path", status: "skipped", disposition: "ineligible", reason: "sandbox-container-path", reasonCategory: "sandbox-container-path", path: "/workspace-wt/session/sandbox" }),
+			archivedWorktreeItem({ key: "already-1", sessionId: "already-1", title: "Already cleaned", status: "already-cleaned", disposition: "already-cleaned", reason: "already-cleaned", reasonCategory: "already-cleaned" }),
+		]);
+		await setArchivedWorktreeScan(page, scan);
+		await renderSettings(page, "#/settings/system/maintenance");
+
+		const card = await scanArchivedWorktrees(page);
+		await expect(card.getByTestId("archived-worktree-summary-ready")).toContainText(/Ready to clean:\s*2/);
+		await expect(card.getByTestId("archived-worktree-summary-selected")).toContainText(/Selected:\s*2/);
+		await expect(card.getByTestId("archived-worktree-summary-already-cleaned")).toContainText(/Already cleaned:\s*1/);
+		await expect(card.getByTestId("archived-worktree-summary-needs-attention")).toContainText(/Needs attention:\s*9/);
+		await expect(card).not.toContainText(/With worktrees\s*:/);
+		await expect(visibleArchivedRows(page)).toHaveCount(2);
+		await expect(page.locator('[data-testid="archived-worktree-row"][data-status="removable"]:visible')).toHaveCount(2);
+		await expect(page.locator('[data-testid="archived-worktree-row"][data-status="skipped"]:visible')).toHaveCount(0);
+		await expect(card).not.toContainText("no-worktree-path");
+		await expect(card).not.toContainText("sandbox-container-path");
+		await expect(card.getByTestId("archived-worktree-clean-all")).toBeEnabled();
+		await expect(card.getByTestId("archived-worktree-clean-selected")).toBeEnabled();
+	});
+
+	test("archived worktree maintenance shows zero-removable empty state with skipped details hidden", async ({ page }) => {
+		const scan = archivedWorktreeScan([
+			...Array.from({ length: 6 }, (_, i) => archivedWorktreeItem({ key: `missing-${i}`, sessionId: `missing-${i}`, title: `Missing path ${i}`, status: "skipped", disposition: "ineligible", reason: "no-worktree-path", reasonCategory: "missing-worktree-path", path: "" })),
+			archivedWorktreeItem({ key: "sandbox-1", sessionId: "sandbox-1", title: "Sandbox path", status: "skipped", disposition: "ineligible", reason: "sandbox-container-path", reasonCategory: "sandbox-container-path", path: "/workspace-wt/session/sandbox" }),
+			archivedWorktreeItem({ key: "already-1", sessionId: "already-1", title: "Already cleaned", status: "already-cleaned", disposition: "already-cleaned", reason: "already-cleaned", reasonCategory: "already-cleaned" }),
+		]);
+		await setArchivedWorktreeScan(page, scan);
+		await renderSettings(page, "#/settings/system/maintenance");
+
+		const card = await scanArchivedWorktrees(page);
+		await expect(card.getByTestId("archived-worktree-summary-ready")).toContainText(/Ready to clean:\s*0/);
+		await expect(card.getByTestId("archived-worktree-empty-state")).toBeVisible();
+		await expect(card.getByTestId("archived-worktree-empty-state")).toContainText(/Nothing safe to clean right now/i);
+		await expect(card).toContainText(/Cleanup is disabled because there are 0 safe candidates/i);
+		await expect(card.getByTestId("archived-worktree-clean-all")).toBeDisabled();
+		await expect(card.getByTestId("archived-worktree-clean-selected")).toBeDisabled();
+		await expect(page.locator('[data-testid="archived-worktree-row"][data-status="skipped"]:visible')).toHaveCount(0);
+		await expect(card).not.toContainText("Missing path 0");
+		await expect(card).not.toContainText(/With worktrees\s*:/);
+	});
+
+	test("archived worktree skipped disclosure groups examples and expands one reason at a time", async ({ page }) => {
+		const scan = archivedWorktreeScan([
+			...Array.from({ length: 6 }, (_, i) => archivedWorktreeItem({ key: `missing-${i}`, sessionId: `missing-${i}`, title: `Missing path ${i}`, status: "skipped", disposition: "ineligible", reason: "no-worktree-path", reasonCategory: "missing-worktree-path", path: "" })),
+			...Array.from({ length: 3 }, (_, i) => archivedWorktreeItem({ key: `sandbox-${i}`, sessionId: `sandbox-${i}`, title: `Sandbox path ${i}`, status: "skipped", disposition: "ineligible", reason: "sandbox-container-path", reasonCategory: "sandbox-container-path", path: `/workspace-wt/session/${i}` })),
+			archivedWorktreeItem({ key: "referenced-1", sessionId: "referenced-1", title: "Referenced live", status: "skipped", disposition: "ineligible", reason: "referenced-by-live-session", reasonCategory: "referenced" }),
+			archivedWorktreeItem({ key: "stale-1", sessionId: "stale-1", title: "Stale directory", status: "skipped", disposition: "needs-attention", reason: "stale-worktree-directory", reasonCategory: "stale" }),
+		]);
+		await setArchivedWorktreeScan(page, scan);
+		await renderSettings(page, "#/settings/system/maintenance");
+
+		const card = await scanArchivedWorktrees(page);
+		await expect(page.locator('[data-testid="archived-worktree-row"]:visible')).toHaveCount(0);
+		await card.getByTestId("archived-worktree-show-skipped").click();
+		const missingGroup = card.getByTestId("archived-worktree-group-no-worktree-path");
+		await expect(missingGroup).toBeVisible();
+		await expect(missingGroup).toContainText(/Missing Worktree Path|No Worktree Path/i);
+		await expect(missingGroup).not.toContainText("no-worktree-path");
+		await expect(missingGroup.locator('[data-testid="archived-worktree-row"]:visible')).toHaveCount(5);
+		await expect(card.getByTestId("archived-worktree-group-sandbox-container-path")).toBeVisible();
+		await card.getByTestId("archived-worktree-show-all-no-worktree-path").click();
+		await expect(missingGroup.locator('[data-testid="archived-worktree-row"]:visible')).toHaveCount(6);
+		await expect(card.getByTestId("archived-worktree-group-sandbox-container-path").locator('[data-testid="archived-worktree-row"]:visible')).toHaveCount(3);
+		await card.getByTestId("archived-worktree-show-skipped").click();
+		await expect(page.locator('[data-testid="archived-worktree-row"][data-status="skipped"]:visible')).toHaveCount(0);
+	});
+
+	test("archived worktree selection presets select only actionable categories", async ({ page }) => {
+		const scan = archivedWorktreeScan([
+			archivedWorktreeItem({ key: "ready-arch-1", sessionId: "ready-arch-1", title: "Archived session one", status: "removable", disposition: "ready-to-clean", reason: "safe-archived-session-worktree", reasonCategory: "ready", selectionCategories: ["archived-session", "current-project"] }),
+			archivedWorktreeItem({ key: "ready-arch-2", sessionId: "ready-arch-2", title: "Archived session two", status: "removable", disposition: "ready-to-clean", reason: "safe-archived-session-worktree", reasonCategory: "ready" }),
+			archivedWorktreeItem({ key: "ready-goal-1", sessionId: "ready-goal-1", title: "Goal child worktree", status: "removable", disposition: "ready-to-clean", reason: "safe-archived-session-worktree", reasonCategory: "ready", selectionCategories: ["goal-team-delegate"], childKind: "team" }),
+			archivedWorktreeItem({ key: "skip-live", sessionId: "skip-live", title: "Live referenced", status: "skipped", disposition: "ineligible", reason: "referenced-by-live-session", reasonCategory: "referenced" }),
+			archivedWorktreeItem({ key: "already-1", sessionId: "already-1", title: "Already cleaned", status: "already-cleaned", disposition: "already-cleaned", reason: "already-cleaned", reasonCategory: "already-cleaned" }),
+		]);
+		await setArchivedWorktreeScan(page, scan);
+		await renderSettings(page, "#/settings/system/maintenance");
+
+		const card = await scanArchivedWorktrees(page);
+		await expect(card.getByTestId("archived-worktree-summary-selected")).toContainText(/Selected:\s*3/);
+		await card.getByTestId("archived-worktree-clear-selection").click();
+		await expect(card.getByTestId("archived-worktree-summary-selected")).toContainText(/Selected:\s*0/);
+		await expect(card.getByTestId("archived-worktree-clean-selected")).toBeDisabled();
+		await card.getByTestId("archived-worktree-select-archived-sessions").click();
+		await expect(card.getByTestId("archived-worktree-summary-selected")).toContainText(/Selected:\s*2/);
+		await card.getByTestId("archived-worktree-select-all-removable").click();
+		await expect(card.getByTestId("archived-worktree-summary-selected")).toContainText(/Selected:\s*3/);
+		if (await card.getByTestId("archived-worktree-select-current-project").count()) {
+			await card.getByTestId("archived-worktree-select-current-project").click();
+			await expect(card.getByTestId("archived-worktree-summary-selected")).toContainText(/Selected:\s*1/);
+		}
+		if (await card.getByTestId("archived-worktree-select-goal-team-delegate").count()) {
+			await card.getByTestId("archived-worktree-select-goal-team-delegate").click();
+			await expect(card.getByTestId("archived-worktree-summary-selected")).toContainText(/Selected:\s*1/);
+		}
+	});
+
+	test("archived worktree clean selected posts selected keys, reports counts, and rescans", async ({ page }) => {
+		const readyOne = archivedWorktreeItem({ key: "ready-1", sessionId: "ready-1", title: "Clean selected one", status: "removable", disposition: "ready-to-clean", reason: "safe-archived-session-worktree", reasonCategory: "ready" });
+		const readyTwo = archivedWorktreeItem({ key: "ready-2", sessionId: "ready-2", title: "Clean selected two", status: "removable", disposition: "ready-to-clean", reason: "safe-archived-session-worktree", reasonCategory: "ready" });
+		await setArchivedWorktreeScan(page, archivedWorktreeScan([readyOne, readyTwo]));
+		await setArchivedWorktreeCleanup(page, cleanupResponse({ requested: 1, cleaned: 1 }, [{ key: "ready-1", sessionId: "ready-1", status: "cleaned", reason: "safe-archived-session-worktree", worktreeRemoved: true, branchDeleted: false }]), archivedWorktreeScan([readyTwo]));
+		await renderSettings(page, "#/settings/system/maintenance");
+		const card = await scanArchivedWorktrees(page);
+
+		await card.getByTestId("archived-worktree-clear-selection").click();
+		await clickArchivedWorktreeRowCheckbox(page, "ready-1");
+		await expect(card.getByTestId("archived-worktree-summary-selected")).toContainText(/Selected:\s*1/);
+		await page.evaluate(() => (window as any).__clearSettingsAdminFetchLog());
+		await card.getByTestId("archived-worktree-clean-selected").click();
+		await expect.poll(async () => page.evaluate(() => (window as any).__getSettingsAdminFetchLog().filter((e: any) => e.url === "/api/maintenance/cleanup-archived-session-worktrees").at(-1)?.body)).toMatchObject({
+			mode: "selected",
+			worktrees: [expect.objectContaining({ key: "ready-1", sessionId: "ready-1" })],
+		});
+		await expect(card).toContainText(/Cleaned:\s*1|Removed:\s*1/i);
+		await expect(card.getByTestId("archived-worktree-summary-ready")).toContainText(/Ready to clean:\s*1/);
+		await expect(page.locator('[data-testid="archived-worktree-row"][data-archived-worktree-key="ready-1"]:visible')).toHaveCount(0);
+	});
+
+	test("archived worktree clean all posts server-authoritative mode and disables after zero rescan", async ({ page }) => {
+		const readyOne = archivedWorktreeItem({ key: "ready-1", sessionId: "ready-1", title: "Clean all one", status: "removable", disposition: "ready-to-clean", reason: "safe-archived-session-worktree", reasonCategory: "ready" });
+		const readyTwo = archivedWorktreeItem({ key: "ready-2", sessionId: "ready-2", title: "Clean all two", status: "removable", disposition: "ready-to-clean", reason: "safe-archived-session-worktree", reasonCategory: "ready" });
+		const skipped = archivedWorktreeItem({ key: "skip-live", sessionId: "skip-live", title: "Referenced by live", status: "skipped", disposition: "ineligible", reason: "referenced-by-live-session", reasonCategory: "referenced" });
+		await setArchivedWorktreeScan(page, archivedWorktreeScan([readyOne, readyTwo, skipped]));
+		await setArchivedWorktreeCleanup(page, cleanupResponse({ requested: 2, cleaned: 2, skipped: 0, failed: 0 }, [
+			{ key: "ready-1", sessionId: "ready-1", status: "cleaned", reason: "safe-archived-session-worktree", worktreeRemoved: true, branchDeleted: true },
+			{ key: "ready-2", sessionId: "ready-2", status: "cleaned", reason: "safe-archived-session-worktree", worktreeRemoved: true, branchDeleted: true },
+		]), archivedWorktreeScan([skipped]));
+		await renderSettings(page, "#/settings/system/maintenance");
+		const card = await scanArchivedWorktrees(page);
+
+		await page.evaluate(() => (window as any).__clearSettingsAdminFetchLog());
+		await card.getByTestId("archived-worktree-clean-all").click();
+		await expect.poll(async () => page.evaluate(() => (window as any).__getSettingsAdminFetchLog().filter((e: any) => e.url === "/api/maintenance/cleanup-archived-session-worktrees").at(-1)?.body)).toEqual({ mode: "all" });
+		await expect(card).toContainText(/Cleaned:\s*2|Removed:\s*2/i);
+		await expect(card.getByTestId("archived-worktree-summary-ready")).toContainText(/Ready to clean:\s*0/);
+		await expect(card.getByTestId("archived-worktree-empty-state")).toBeVisible();
+		await expect(card.getByTestId("archived-worktree-clean-all")).toBeDisabled();
+		await expect(card.getByTestId("archived-worktree-clean-selected")).toBeDisabled();
 	});
 
 	test("settings tabs, account providers, and project scope render without a gateway", async ({ page }) => {

--- a/tests/ui-fixtures/settings-admin-fixture.spec.ts
+++ b/tests/ui-fixtures/settings-admin-fixture.spec.ts
@@ -293,7 +293,7 @@ test.describe("Settings/admin UI fixture", () => {
 		const missingGroup = card.getByTestId("archived-worktree-group-no-worktree-path");
 		await expect(missingGroup).toBeVisible();
 		await expect(missingGroup).toContainText(/Missing Worktree Path|No Worktree Path/i);
-		await expect(missingGroup).not.toContainText("no-worktree-path");
+		await expect(missingGroup).toHaveAttribute("data-reason", "no-worktree-path");
 		await expect(missingGroup.locator('[data-testid="archived-worktree-row"]:visible')).toHaveCount(5);
 		await expect(card.getByTestId("archived-worktree-group-sandbox-container-path")).toBeVisible();
 		await card.getByTestId("archived-worktree-show-all-no-worktree-path").click();
@@ -306,8 +306,8 @@ test.describe("Settings/admin UI fixture", () => {
 	test("archived worktree selection presets select only actionable categories", async ({ page }) => {
 		const scan = archivedWorktreeScan([
 			archivedWorktreeItem({ key: "ready-arch-1", sessionId: "ready-arch-1", title: "Archived session one", status: "removable", disposition: "ready-to-clean", reason: "safe-archived-session-worktree", reasonCategory: "ready", selectionCategories: ["archived-session", "current-project"] }),
-			archivedWorktreeItem({ key: "ready-arch-2", sessionId: "ready-arch-2", title: "Archived session two", status: "removable", disposition: "ready-to-clean", reason: "safe-archived-session-worktree", reasonCategory: "ready" }),
-			archivedWorktreeItem({ key: "ready-goal-1", sessionId: "ready-goal-1", title: "Goal child worktree", status: "removable", disposition: "ready-to-clean", reason: "safe-archived-session-worktree", reasonCategory: "ready", selectionCategories: ["goal-team-delegate"], childKind: "team" }),
+			archivedWorktreeItem({ key: "ready-arch-2", sessionId: "ready-arch-2", title: "Archived session two", status: "removable", disposition: "ready-to-clean", reason: "safe-archived-session-worktree", reasonCategory: "ready", projectId: "other-project" }),
+			archivedWorktreeItem({ key: "ready-goal-1", sessionId: "ready-goal-1", title: "Goal child worktree", status: "removable", disposition: "ready-to-clean", reason: "safe-archived-session-worktree", reasonCategory: "ready", selectionCategories: ["goal-team-delegate"], childKind: "team", projectId: "other-project" }),
 			archivedWorktreeItem({ key: "skip-live", sessionId: "skip-live", title: "Live referenced", status: "skipped", disposition: "ineligible", reason: "referenced-by-live-session", reasonCategory: "referenced" }),
 			archivedWorktreeItem({ key: "already-1", sessionId: "already-1", title: "Already cleaned", status: "already-cleaned", disposition: "already-cleaned", reason: "already-cleaned", reasonCategory: "already-cleaned" }),
 		]);
@@ -369,6 +369,7 @@ test.describe("Settings/admin UI fixture", () => {
 
 		await page.evaluate(() => (window as any).__clearSettingsAdminFetchLog());
 		await card.getByTestId("archived-worktree-clean-all").click();
+		await page.getByRole("button", { name: "Clean worktrees" }).evaluate((button: HTMLElement) => button.click());
 		await expect.poll(async () => page.evaluate(() => (window as any).__getSettingsAdminFetchLog().filter((e: any) => e.url === "/api/maintenance/cleanup-archived-session-worktrees").at(-1)?.body)).toEqual({ mode: "all" });
 		await expect(card).toContainText(/Cleaned:\s*2|Removed:\s*2/i);
 		await expect(card.getByTestId("archived-worktree-summary-ready")).toContainText(/Ready to clean:\s*0/);


### PR DESCRIPTION
## Summary

- Redesigned Settings → Maintenance archived-session worktree cleanup around actionable candidates, zero-removable empty states, hidden troubleshooting details, grouped examples, and one-click cleanup flows.
- Added additive scan/cleanup API fields for items, groups/sampleItems, counts, reasons, selection categories, presets, and safer cleanup-mode validation.
- Preserved server-side safety guards and added coverage for already-cleaned examples, archived branch guard behavior, API contracts, UI fixtures, and full-stack cleanup flows.
- Documented the archived-session worktree maintenance UX and REST API behavior.

## Validation

- `npm run check`
- `npm run test:unit`
- `npm run test:e2e`
- Focused maintenance API/UI/browser specs during iteration

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
