### PR TITLE
Stop Pi Migration

### DIFF
--- a/docs/configurable-agent-directory.md
+++ b/docs/configurable-agent-directory.md
@@ -9,9 +9,10 @@ The active directory is resolved once when the gateway starts. Settings changes 
 At startup Bobbit resolves the agent directory with this exact precedence:
 
 1. `BOBBIT_AGENT_DIR`
-2. `PI_CODING_AGENT_DIR`
-3. persisted Settings value (`agentDir` in `.bobbit/state/preferences.json`)
-4. default: `<projectRoot>/.bobbit/agent/`
+2. persisted Settings value (`agentDir` in `.bobbit/state/preferences.json`)
+3. default: `<projectRoot>/.bobbit/agent/`
+
+`PI_CODING_AGENT_DIR` is not accepted as a user-facing Bobbit startup override. Bobbit may set it internally when spawning the underlying `pi-coding-agent`, but only to the already-resolved Bobbit agent directory so child processes cannot fall back to raw pi state.
 
 Inputs are normalized before use:
 
@@ -39,16 +40,16 @@ New scaffolds and upgraded existing scaffolds ensure `.bobbit/.gitignore` contai
 The Settings → Maintenance **Agent Directory** card shows:
 
 - **Active directory** — the startup-pinned directory used by this process.
-- **Startup source** — `BOBBIT_AGENT_DIR`, `PI_CODING_AGENT_DIR`, `persisted`, or `default`.
+- **Startup source** — `BOBBIT_AGENT_DIR`, `persisted`, or `default`.
 - **Default** — `<projectRoot>/.bobbit/agent/`.
-- **Persisted / pending** — the saved directory that will be considered on future starts when no higher-precedence env var overrides it.
+- **Persisted / pending** — the saved directory that will be considered on future starts when no `BOBBIT_AGENT_DIR` override is active.
 - **Effective after restart** — the directory Bobbit would use after restart with the current environment.
 - **Restart guidance** — whether restart is required and which directory is active now vs next start.
-- **Environment override** — a warning when `BOBBIT_AGENT_DIR` or `PI_CODING_AGENT_DIR` is active.
+- **Environment override** — a warning when `BOBBIT_AGENT_DIR` is active.
 
-Saving a path writes only the next-start preference. It does not migrate data or switch live sessions. Clearing the setting removes the persisted path and returns future starts to env/default precedence.
+Saving a path writes only the next-start preference. It does not copy data or switch live sessions. Clearing the setting removes the persisted path and returns future starts to env/default precedence.
 
-When an environment override is active, the UI can still save a persisted path, but the override remains effective after restart until the env var is removed. `BOBBIT_AGENT_DIR` also wins over `PI_CODING_AGENT_DIR` if both are set.
+When `BOBBIT_AGENT_DIR` is active, the UI can still save a persisted path, but the override remains effective after restart until the env var is removed.
 
 ## Path validation
 
@@ -67,11 +68,11 @@ Validation rules:
 
 Structured validation errors include stable codes such as `EMPTY_PATH`, `INSIDE_WORKTREE`, `CREATE_FAILED`, `NOT_DIRECTORY`, `ACCESS_DENIED`, and `PROBE_FAILED`.
 
-## Copy-only migration
+## Copy data
 
-Migration is explicit and copy-only. Bobbit never silently migrates data at startup, never deletes the source, and never renames the source directory.
+Copying data is explicit, user-initiated, and copy-only. Bobbit never silently migrates data at startup, never deletes the source, and never renames the source directory.
 
-The migration card appears when the pending directory differs from the active directory. It copies from an active or historical agent directory to the pending next-start directory.
+The Settings **Copy data** card appears when the pending directory differs from the active directory. It copies from an active or historical configured agent directory to the pending next-start directory. It does not auto-discover `~/.pi/agent` and does not treat raw pi state as an implicit source.
 
 Allowlist:
 
@@ -91,22 +92,24 @@ Symlink safety:
 - Existing destination symlinks are not overwritten.
 - Recursive copies verify destination paths stay inside the selected pending directory.
 
-The migration response reports copied, skipped, overwritten, missing, warning, and error entries, followed by the same restart guidance shown after save.
+The copy response reports copied, skipped, overwritten, missing, warning, and error entries, followed by the same restart guidance shown after save.
 
 ## Transcript compatibility
 
-Persisted sessions store `agentSessionFile` as an absolute path. Bobbit keeps those paths readable across migrations and future configuration changes.
+Persisted sessions store `agentSessionFile` as an absolute path. Bobbit keeps those paths readable across copy operations and future configuration changes.
 
 Compatibility rules:
 
 - New sessions write transcripts under the active startup directory's `sessions/` root.
-- Existing absolute `agentSessionFile` values stay authoritative for host-side reads; migration does not rewrite them.
-- `agentDirHistory` records startup, saved, and migrated directories, seeded with legacy `~/.bobbit/agent` and `~/.pi/agent` roots.
-- Recovery scans active sessions first, then historical sessions roots, then legacy roots.
-- Transcript guards accept paths inside trusted active/historical/legacy `sessions/` roots.
+- Existing absolute `agentSessionFile` values stay authoritative for host-side reads; Copy data does not rewrite them.
+- `agentDirHistory` records configured startup, saved, and copied directories; it is not seeded from `~/.pi/agent`.
+- Recovery scans active sessions first, then historical sessions roots, then read-only legacy transcript roots.
+- Transcript guards accept paths inside trusted active, historical, or legacy `sessions/` roots.
 - Exact persisted outside-root transcript paths are read-compatible only after they are registered from a persisted session and verified as regular, non-symlink `.jsonl` transcript files. They are not sanitizer write targets and are not deleted by purge.
 
 For sandboxed sessions, the agent can see only the active mounted sessions root. If a persisted historical host transcript has been copied to the active root, Bobbit remaps `switch_session` to the active mounted copy while preserving the historical absolute path for host reads. If no active copy exists, the historical path remains unchanged and may not be visible inside the sandbox.
+
+Legacy transcript roots, including `~/.pi/agent/sessions`, are read compatibility fallbacks only. Startup does not rename, move, copy from, or write marker directories into `~/.pi/agent`.
 
 ## Sandbox safeguards
 
@@ -132,8 +135,8 @@ Remote-less sandbox clone sources are also sanitized. Instead of bind-mounting t
 
 Primary implementation modules:
 
-- `src/server/agent-dir-config.ts` — resolution, validation, state, migration, restart guidance.
-- `src/server/bobbit-dir.ts` — public directory helpers and legacy exports.
+- `src/server/agent-dir-config.ts` — resolution, validation, state, copy-data reporting, restart guidance.
+- `src/server/bobbit-dir.ts` — public directory helpers.
 - `src/server/server.ts` — `/api/agent-dir*` endpoints.
 - `src/app/settings-page.ts` — Maintenance settings UI.
 - `src/server/agent/agent-session-path.ts` and `transcript-sanitizer.ts` — transcript compatibility and safety.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -948,9 +948,9 @@ Symptom: Settings → Maintenance shows a saved pending directory, but sessions,
 Checklist:
 
 1. Check `GET /api/agent-dir`. `activePath` is the startup-pinned directory for this process; `nextStart.dir` is only effective after restart.
-2. If `activeSource` is `BOBBIT_AGENT_DIR` or `PI_CODING_AGENT_DIR`, the env override wins over the persisted setting. Remove the env var and restart to use the saved path.
+2. If `activeSource` is `BOBBIT_AGENT_DIR`, the env override wins over the persisted setting. Remove the env var and restart to use the saved path. `PI_CODING_AGENT_DIR` is not a Bobbit startup override.
 3. If validation returns `INSIDE_WORKTREE`, choose a path outside the git worktree or use the exact default `<projectRoot>/.bobbit/agent/`. Relative paths are resolved against `<projectRoot>` before this check.
-4. Migration copies only the allowlist and skips existing files unless overwrite is selected. A skipped `auth.json` or `models.json` usually means the destination already had one.
+4. Settings **Copy data** copies only the allowlist from a configured active/historical source to the pending destination and skips existing files unless overwrite is selected. It does not auto-source `~/.pi/agent`; a skipped `auth.json` or `models.json` usually means the destination already had one.
 5. Sandboxed sessions after an agent-dir change require container recreation because Docker bind mounts are immutable. `ProjectSandbox` detects stale active sessions/model mounts and recreates the project container; look for `[project-sandbox] ... stale agent-dir mounts` if a sandbox still sees old transcripts.
 
 See [Configurable agent directory](configurable-agent-directory.md).

--- a/docs/design/configurable-agent-dir.md
+++ b/docs/design/configurable-agent-dir.md
@@ -5,9 +5,10 @@ This design has shipped. The durable behavior is documented in [Configurable age
 ## Final decisions
 
 - Default agent directory: `<projectRoot>/.bobbit/agent/`.
-- Startup precedence: `BOBBIT_AGENT_DIR` > `PI_CODING_AGENT_DIR` > persisted Settings value > default.
+- Startup precedence: `BOBBIT_AGENT_DIR` > persisted Settings value > default.
+- `PI_CODING_AGENT_DIR` is not a Bobbit startup configuration input. Bobbit sets it only internally for spawned `pi-coding-agent` processes, pointing at the resolved Bobbit agent directory.
 - The active directory is resolved once at gateway startup. Settings writes are next-start only; there is no live switching or multi-root write mode.
-- Migration is user-initiated and copy-only. It preserves the source directory and copies only the allowlist: `sessions/`, `auth.json`, `models.json`, `settings.json`, `google-code-assist.json`, and `bin/`.
+- Copy data is user-initiated and copy-only. It preserves the source directory and copies only the allowlist: `sessions/`, `auth.json`, `models.json`, `settings.json`, `google-code-assist.json`, and `bin/`. Sources are active or historical configured Bobbit agent directories, not an automatic `~/.pi/agent` source.
 - Transcript compatibility is read-oriented: existing absolute `agentSessionFile` paths remain authoritative, historical roots are remembered, and exact outside-root transcripts are readable only after persisted-session registration and transcript-shape validation.
 - Sandbox access remains narrow: active sessions and read-only models are mounted, sandbox auth is generated/scoped, and host `auth.json` is never mounted.
 - Project scaffolding ensures `.bobbit/.gitignore` ignores `agent/` as well as `state/`.
@@ -16,9 +17,9 @@ This design has shipped. The durable behavior is documented in [Configurable age
 
 The agent directory feeds process environment, binary staging, Docker bind mounts, transcript path translation, model cache reads, and auth/cache files. Live switching would create split-brain state: running agents and long-lived containers would keep old paths while the server starts writing new metadata elsewhere. Pinning the directory at startup keeps one active runtime root and makes Settings changes explicit: save, optionally copy data, restart.
 
-## Why copy-only migration
+## Why Copy data is explicit
 
-Credentials and transcripts are user data. Bobbit should not silently move or delete them, especially when users may still run older installations against `~/.bobbit/agent/`. Copy-only migration lets the user preserve the source as a rollback path while preparing the next-start directory.
+Credentials and transcripts are user data. Bobbit should not silently move, copy, or delete them, especially when users may also run raw pi on the same machine. Copy-only data transfer lets the user preserve the source as a rollback path while preparing the next-start directory, and avoiding automatic `~/.pi/agent` discovery lets Bobbit coexist with pi without mutating pi-owned state.
 
 ## Why the project-local default is allowed inside the worktree
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -789,7 +789,7 @@ There is no `?scope=server` parameter on workflow endpoints — it was removed w
 
 Model-related preference keys include `default.sessionModel`, `default.reviewModel`, `default.imageModel`, and `allowSessionModelFallback`. The fallback setting defaults to off when absent; see [Controlled session model fallback](session-model-fallback.md).
 
-`agentDir` and `agentDirHistory` are managed by the dedicated agent-directory workflow, not generic preferences. `PUT /api/preferences` rejects those keys with `400 { code: "AGENT_DIR_PREFERENCE_FORBIDDEN", use: "/api/agent-dir/pending" }` so callers cannot bypass validation, migration guidance, or restart-gated semantics.
+`agentDir` and `agentDirHistory` are managed by the dedicated agent-directory workflow, not generic preferences. `PUT /api/preferences` rejects those keys with `400 { code: "AGENT_DIR_PREFERENCE_FORBIDDEN", use: "/api/agent-dir/pending" }` so callers cannot bypass validation, copy guidance, or restart-gated semantics.
 
 ### Agent directory
 
@@ -800,12 +800,12 @@ These endpoints back Settings → Maintenance → Agent Directory. They are rest
 | `GET` | `/api/agent-dir` | Return active, default, persisted/pending, next-start, restart, env override, and history state. |
 | `POST` | `/api/agent-dir/validate` | Validate/probe a candidate target path. Body `{ path }`. May create the directory to prove access. |
 | `PUT` | `/api/agent-dir/pending` | Save or clear the persisted next-start agent dir. Body `{ path }`, where `null` or empty clears. |
-| `POST` | `/api/agent-dir/migrate` | Copy allowlisted data from active/historical source to pending destination. Body `{ sourcePath, destinationPath, overwrite? }`. |
+| `POST` | `/api/agent-dir/migrate` | Explicitly copy allowlisted data from an active/historical configured source to the pending destination. Body `{ sourcePath, destinationPath, overwrite? }`. |
 
 `GET /api/agent-dir` returns:
 
 ```ts
-type AgentDirSource = "BOBBIT_AGENT_DIR" | "PI_CODING_AGENT_DIR" | "persisted" | "default";
+type AgentDirSource = "BOBBIT_AGENT_DIR" | "persisted" | "default";
 
 interface AgentDirResolution {
   dir: string;
@@ -826,7 +826,7 @@ interface AgentDirApiState {
   restartRequired: boolean;
   envOverride?: {
     active: true;
-    source: "BOBBIT_AGENT_DIR" | "PI_CODING_AGENT_DIR";
+    source: "BOBBIT_AGENT_DIR";
     value: string;
     savedPathIgnored: boolean;
   };
@@ -836,7 +836,7 @@ interface AgentDirApiState {
 
 `PUT /api/agent-dir/pending` returns the same state plus `guidance`. Non-empty paths are validated with the same rules as `POST /api/agent-dir/validate`: `~` expansion, relative-to-project resolution, git-worktree exclusion except `<projectRoot>/.bobbit/agent/`, symlink/realpath checks, `mkdir`, and read/write probe. Validation failures return `{ ok:false, error:{ code, message, rawInput, resolvedPath? } }` with HTTP 400 on save.
 
-`POST /api/agent-dir/migrate` accepts only sources known from the active or historical agent-directory set and destinations equal to the pending next-start directory. It copies only `sessions/`, `auth.json`, `models.json`, `settings.json`, `google-code-assist.json`, and `bin/`; existing files are skipped unless `overwrite:true`. The response is an `AgentDirMigrationReport` with `copied`, `skipped`, `overwritten`, `missing`, `warnings`, `errors`, and `guidance`. Relationship/symlink violations return HTTP 400 with a report-level `error.code`.
+`POST /api/agent-dir/migrate` is the Settings **Copy data** action. It accepts only user-selected sources known from the active or historical configured agent-directory set and destinations equal to the pending next-start directory. It does not auto-discover or special-case `~/.pi/agent`. It copies only `sessions/`, `auth.json`, `models.json`, `settings.json`, `google-code-assist.json`, and `bin/`; existing files are skipped unless `overwrite:true`. The response is an `AgentDirMigrationReport` with `copied`, `skipped`, `overwritten`, `missing`, `warnings`, `errors`, and `guidance`. Relationship/symlink violations return HTTP 400 with a report-level `error.code`.
 
 ### Models
 

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -5082,10 +5082,10 @@ function parseAgentDirState(data: any): AgentDirDisplayState {
 	const nextStartSource = firstString(source?.nextStartSource, source?.nextStart?.source, source?.effectiveNextStartSource) ?? startupSource;
 	const envOverride = (() => {
 		const raw = source?.envOverride;
-		if (raw === true) return startupSource === "BOBBIT_AGENT_DIR" || startupSource === "PI_CODING_AGENT_DIR" ? startupSource : "environment variable";
-		if (!raw) return startupSource === "BOBBIT_AGENT_DIR" || startupSource === "PI_CODING_AGENT_DIR" ? startupSource : null;
+		if (raw === true) return startupSource === "BOBBIT_AGENT_DIR" ? startupSource : "environment variable";
+		if (!raw) return startupSource === "BOBBIT_AGENT_DIR" ? startupSource : null;
 		if (typeof raw === "string") return raw;
-		return firstString(raw.name, raw.source, raw.key, raw.variable) ?? (startupSource === "BOBBIT_AGENT_DIR" || startupSource === "PI_CODING_AGENT_DIR" ? startupSource : null);
+		return firstString(raw.name, raw.source, raw.key, raw.variable) ?? (startupSource === "BOBBIT_AGENT_DIR" ? startupSource : null);
 	})();
 	return {
 		activePath,

--- a/src/server/agent-dir-config.ts
+++ b/src/server/agent-dir-config.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 
-export type AgentDirSource = "BOBBIT_AGENT_DIR" | "PI_CODING_AGENT_DIR" | "persisted" | "default";
+export type AgentDirSource = "BOBBIT_AGENT_DIR" | "persisted" | "default";
 
 export interface AgentDirResolution {
 	dir: string;
@@ -46,7 +46,7 @@ export interface AgentDirApiState {
 	restartRequired: boolean;
 	envOverride?: {
 		active: true;
-		source: "BOBBIT_AGENT_DIR" | "PI_CODING_AGENT_DIR";
+		source: "BOBBIT_AGENT_DIR";
 		value: string;
 		savedPathIgnored: boolean;
 	};
@@ -109,10 +109,6 @@ export function resolveAgentDir(input: ResolveAgentDirInput): AgentDirResolution
 	const bobbitEnv = nonEmptyString(env.BOBBIT_AGENT_DIR);
 	if (bobbitEnv) {
 		return { dir: normalizeAgentDirInput(bobbitEnv, projectRoot), source: "BOBBIT_AGENT_DIR", raw: bobbitEnv, projectRoot, defaultDir };
-	}
-	const piEnv = nonEmptyString(env.PI_CODING_AGENT_DIR);
-	if (piEnv) {
-		return { dir: normalizeAgentDirInput(piEnv, projectRoot), source: "PI_CODING_AGENT_DIR", raw: piEnv, projectRoot, defaultDir };
 	}
 	const persisted = nonEmptyString(input.persisted);
 	if (persisted) {
@@ -177,7 +173,7 @@ export function getAgentDirState(): AgentDirRuntimeState {
 export function getAgentDirApiState(): AgentDirApiState {
 	const state = getAgentDirState();
 	const persistedPath = state.persisted;
-	const envSource = state.startup.source === "BOBBIT_AGENT_DIR" || state.startup.source === "PI_CODING_AGENT_DIR" ? state.startup.source : undefined;
+	const envSource = state.startup.source === "BOBBIT_AGENT_DIR" ? state.startup.source : undefined;
 	return {
 		activePath: state.startup.dir,
 		activeSource: state.startup.source,
@@ -418,7 +414,7 @@ export function isPendingAgentDir(dir: string, state = runtimeState): boolean {
 
 export function buildAgentDirRestartGuidance(): string {
 	const state = getAgentDirState();
-	if (state.startup.source === "BOBBIT_AGENT_DIR" || state.startup.source === "PI_CODING_AGENT_DIR") {
+	if (state.startup.source === "BOBBIT_AGENT_DIR") {
 		const pending = state.persisted ? ` Saved pending directory: ${state.persisted}.` : " No persisted pending directory is set.";
 		return `${state.startup.source} is active, so this process continues using ${state.startup.dir}.${pending} Remove the environment override and restart to use the persisted setting.`;
 	}
@@ -464,7 +460,6 @@ function writeAgentDirHistoryIfReady(stateDir: string, history: string[]): void 
 function mergeAgentDirHistory(projectRoot: string, stateDir: string | undefined, dirs: Array<string | undefined>): string[] {
 	const seeded = [
 		path.join(os.homedir(), ".bobbit", "agent"),
-		path.join(os.homedir(), ".pi", "agent"),
 		defaultAgentDir(projectRoot),
 		...inMemoryAgentDirHistory,
 		...(stateDir ? readPersistedAgentDirHistory(stateDir) : []),

--- a/src/server/agent-dir-config.ts
+++ b/src/server/agent-dir-config.ts
@@ -225,7 +225,8 @@ export function readPersistedAgentDirHistory(stateDir: string): string[] {
 
 export function recordAgentDirHistory(dir: string, stateDir = runtimeStateDir, projectRoot = runtimeState?.startup.projectRoot): string[] {
 	const resolvedProjectRoot = normalizeAbsolutePath(projectRoot ?? process.cwd());
-	const history = mergeAgentDirHistory(resolvedProjectRoot, stateDir, [dir]);
+	const legacyAllowDirs = runtimeState ? [runtimeState.startup.dir, runtimeState.persisted, runtimeState.nextStart.dir] : [];
+	const history = mergeAgentDirHistory(resolvedProjectRoot, stateDir, [dir], legacyAllowDirs);
 	inMemoryAgentDirHistory = history;
 	if (stateDir) writeAgentDirHistoryIfReady(stateDir, history);
 	if (runtimeState) runtimeState = { ...runtimeState, history };
@@ -457,7 +458,14 @@ function writeAgentDirHistoryIfReady(stateDir: string, history: string[]): void 
 	}
 }
 
-function mergeAgentDirHistory(projectRoot: string, stateDir: string | undefined, dirs: Array<string | undefined>): string[] {
+function mergeAgentDirHistory(
+	projectRoot: string,
+	stateDir: string | undefined,
+	dirs: Array<string | undefined>,
+	legacyAllowDirs: Array<string | undefined> = dirs,
+): string[] {
+	const legacyRawPiAgentDir = normalizeAbsolutePath(path.join(os.homedir(), ".pi", "agent"));
+	const allowLegacyRawPiAgentDir = legacyAllowDirs.some((dir) => dir && samePath(normalizeAgentDirInput(dir, projectRoot), legacyRawPiAgentDir));
 	const seeded = [
 		path.join(os.homedir(), ".bobbit", "agent"),
 		defaultAgentDir(projectRoot),
@@ -469,6 +477,7 @@ function mergeAgentDirHistory(projectRoot: string, stateDir: string | undefined,
 	for (const dir of seeded) {
 		if (!dir) continue;
 		const normalized = normalizeAgentDirInput(dir, projectRoot);
+		if (!allowLegacyRawPiAgentDir && samePath(normalized, legacyRawPiAgentDir)) continue;
 		if (!history.some((entry) => samePath(entry, normalized))) history.push(normalized);
 	}
 	return history;

--- a/src/server/agent/rpc-bridge.ts
+++ b/src/server/agent/rpc-bridge.ts
@@ -425,11 +425,11 @@ export class RpcBridge {
 				env: {
 					...process.env,
 					BOBBIT_DIR: bobbitDir(),
+					...tlsEnv,
+					...this.options.env,
 					// Ensure the agent subprocess uses the same agent dir as Bobbit's globalAgentDir(),
 					// preventing split-brain between ~/.bobbit/agent/ and ~/.pi/agent/.
 					PI_CODING_AGENT_DIR: globalAgentDir(),
-					...tlsEnv,
-					...this.options.env,
 				},
 			});
 		}

--- a/src/server/bobbit-dir.ts
+++ b/src/server/bobbit-dir.ts
@@ -1,5 +1,3 @@
-import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import {
   defaultAgentDir as resolveDefaultAgentDir,
@@ -76,7 +74,7 @@ export function defaultAgentDir(projectRoot = getProjectRoot()): string {
 
 /**
  * Returns the startup-resolved global agent directory.
- * Priority at initialization: BOBBIT_AGENT_DIR env > PI_CODING_AGENT_DIR env > persisted agentDir > <projectRoot>/.bobbit/agent/.
+ * Priority at initialization: BOBBIT_AGENT_DIR env > persisted agentDir > <projectRoot>/.bobbit/agent/.
  */
 export function globalAgentDir(): string {
   try {
@@ -84,76 +82,6 @@ export function globalAgentDir(): string {
   } catch {
     const projectRoot = getProjectRoot();
     return initializeRuntimeAgentDir({ projectRoot, stateDir: bobbitStateDir(projectRoot) }).startup.dir;
-  }
-}
-
-/**
- * Migrate ~/.pi/agent/ contents to ~/.bobbit/agent/ at startup.
- * - If ~/.pi/agent/ doesn't exist or was already migrated (.pi/agent.pre-bobbit/ exists), no-op.
- * - If ~/.bobbit/agent/ doesn't exist, rename ~/.pi/agent/ to ~/.bobbit/agent/.
- * - If both exist, merge: move session dirs from .pi to .bobbit (skip existing),
- *   copy auth.json/models.json/settings.json if not already in .bobbit.
- * - After migration, rename ~/.pi/agent/ to ~/.pi/agent.pre-bobbit/.
- * Idempotent and safe.
- */
-export function migrateFromLegacyPiDir(): void {
-  const legacyDir = path.join(os.homedir(), ".pi", "agent");
-  const markerDir = path.join(os.homedir(), ".pi", "agent.pre-bobbit");
-  const newDir = path.join(os.homedir(), ".bobbit", "agent");
-
-  // Already migrated or no legacy dir
-  if (!fs.existsSync(legacyDir) || fs.existsSync(markerDir)) return;
-
-  try {
-    if (!fs.existsSync(newDir)) {
-      // Simple case: just move
-      fs.mkdirSync(path.join(os.homedir(), ".bobbit"), { recursive: true });
-      fs.renameSync(legacyDir, newDir);
-      console.log(`[migration] Moved ~/.pi/agent/ → ~/.bobbit/agent/`);
-    } else {
-      // Merge: move session dirs from .pi to .bobbit (skip existing)
-      const legacySessionsDir = path.join(legacyDir, "sessions");
-      const newSessionsDir = path.join(newDir, "sessions");
-      if (fs.existsSync(legacySessionsDir)) {
-        fs.mkdirSync(newSessionsDir, { recursive: true });
-        let moved = 0;
-        for (const entry of fs.readdirSync(legacySessionsDir)) {
-          const src = path.join(legacySessionsDir, entry);
-          const dst = path.join(newSessionsDir, entry);
-          if (!fs.existsSync(dst)) {
-            try {
-              fs.renameSync(src, dst);
-              moved++;
-            } catch {
-              // Cross-device or permission error — skip
-            }
-          }
-        }
-        if (moved > 0) {
-          console.log(`[migration] Moved ${moved} session dirs from ~/.pi/agent/sessions/ → ~/.bobbit/agent/sessions/`);
-        }
-      }
-
-      // Copy config files if not already present in .bobbit
-      for (const file of ["auth.json", "models.json", "settings.json"]) {
-        const src = path.join(legacyDir, file);
-        const dst = path.join(newDir, file);
-        if (fs.existsSync(src) && !fs.existsSync(dst)) {
-          try {
-            fs.copyFileSync(src, dst);
-            console.log(`[migration] Copied ~/.pi/agent/${file} → ~/.bobbit/agent/${file}`);
-          } catch {
-            // Permission error — skip
-          }
-        }
-      }
-
-      // Rename legacy dir to mark as migrated
-      fs.renameSync(legacyDir, markerDir);
-      console.log(`[migration] Renamed ~/.pi/agent/ → ~/.pi/agent.pre-bobbit/`);
-    }
-  } catch (err) {
-    console.warn(`[migration] Failed to migrate ~/.pi/agent/: ${err}`);
   }
 }
 

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { setProjectRoot, bobbitStateDir, migrateFromLegacyPiDir, globalAgentDir, initializeAgentDirRuntime } from "./bobbit-dir.js";
+import { setProjectRoot, bobbitStateDir, globalAgentDir, initializeAgentDirRuntime } from "./bobbit-dir.js";
 import { scaffoldBobbitDir } from "./scaffold.js";
 import { stageBundledBinaries } from "./binaries.js";
 import { resolveSystemPromptPath } from "./agent/system-prompt.js";
@@ -149,10 +149,6 @@ async function main() {
 
 	// Scaffold .bobbit/ on first run (creates config, extensions, state dirs)
 	scaffoldBobbitDir(args.cwd);
-
-	// Migrate legacy ~/.pi/agent/ to ~/.bobbit/agent/ if needed. This only preserves
-	// the historical Pi rename path; project-default migration is user-initiated.
-	migrateFromLegacyPiDir();
 
 	// Resolve the agent dir once for this process. Settings changes only affect the
 	// next start; runtime callers keep using this startup-resolved directory.

--- a/tests/bobbit-dir-agent-dir.test.ts
+++ b/tests/bobbit-dir-agent-dir.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -42,7 +43,7 @@ describe("agent directory resolver", () => {
 		assertSamePath(resolved.defaultDir!, path.join(projectRoot, ".bobbit", "agent"));
 	});
 
-	it("uses exact precedence BOBBIT_AGENT_DIR > PI_CODING_AGENT_DIR > persisted > default", async () => {
+	it("uses exact precedence BOBBIT_AGENT_DIR > persisted > default and ignores PI_CODING_AGENT_DIR", async () => {
 		const mod = await loadAgentDirConfigModule();
 		assert.equal(typeof mod.resolveAgentDir, "function", "resolveAgentDir must be exported");
 		const projectRoot = tempProjectRoot("precedence");
@@ -56,7 +57,11 @@ describe("agent directory resolver", () => {
 		);
 		assert.deepEqual(
 			pick(mod.resolveAgentDir({ env: { PI_CODING_AGENT_DIR: pi }, projectRoot, persisted })),
-			{ source: "PI_CODING_AGENT_DIR", dir: path.normalize(pi), raw: pi },
+			{ source: "persisted", dir: path.normalize(persisted), raw: persisted },
+		);
+		assert.deepEqual(
+			pick(mod.resolveAgentDir({ env: { PI_CODING_AGENT_DIR: pi }, projectRoot })),
+			{ source: "default", dir: path.normalize(path.join(projectRoot, ".bobbit", "agent")), raw: undefined },
 		);
 		assert.deepEqual(
 			pick(mod.resolveAgentDir({ env: {}, projectRoot, persisted })),
@@ -117,8 +122,94 @@ describe("agent directory resolver", () => {
 			"globalAgentDir must not recompute from env after startup initialization",
 		);
 	});
+
+	it("scaffold and agent-dir runtime leave existing ~/.pi/agent untouched", async (t) => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-pi-agent-untouched-"));
+		const projectRoot = path.join(root, "project");
+		const tempHome = path.join(root, "home");
+		const legacyAgentDir = path.join(tempHome, ".pi", "agent");
+		const bobbitAgentDir = path.join(projectRoot, ".bobbit", "agent");
+		fs.mkdirSync(path.join(legacyAgentDir, "sessions", "--legacy-project--"), { recursive: true });
+		fs.mkdirSync(projectRoot, { recursive: true });
+		fs.writeFileSync(path.join(legacyAgentDir, "auth.json"), JSON.stringify({ token: "raw-pi-auth" }), "utf-8");
+		fs.writeFileSync(path.join(legacyAgentDir, "models.json"), JSON.stringify({ models: ["raw-pi-model"] }), "utf-8");
+		fs.writeFileSync(path.join(legacyAgentDir, "settings.json"), JSON.stringify({ setting: "raw-pi-setting" }), "utf-8");
+		fs.writeFileSync(
+			path.join(legacyAgentDir, "sessions", "--legacy-project--", "2026-06-27T00-00-00.000Z_session.jsonl"),
+			'{"message":"raw pi session"}\n',
+			"utf-8",
+		);
+		const before = snapshotTree(legacyAgentDir);
+
+		const envKeys = ["BOBBIT_DIR", "BOBBIT_AGENT_DIR", "PI_CODING_AGENT_DIR", "HOME", "USERPROFILE", "HOMEDRIVE", "HOMEPATH"] as const;
+		const oldEnv = new Map(envKeys.map((key) => [key, process.env[key]]));
+		t.after(() => {
+			for (const key of envKeys) {
+				const value = oldEnv.get(key);
+				if (value === undefined) delete process.env[key]; else process.env[key] = value;
+			}
+			fs.rmSync(root, { recursive: true, force: true });
+		});
+
+		process.env.HOME = tempHome;
+		process.env.USERPROFILE = tempHome;
+		delete process.env.HOMEDRIVE;
+		delete process.env.HOMEPATH;
+		process.env.BOBBIT_DIR = path.join(projectRoot, ".bobbit");
+		delete process.env.BOBBIT_AGENT_DIR;
+		process.env.PI_CODING_AGENT_DIR = legacyAgentDir;
+
+		const bobbitDirMod = await import("../src/server/bobbit-dir.ts") as Record<string, any>;
+		const scaffoldMod = await import("../src/server/scaffold.ts") as Record<string, any>;
+		assert.equal(bobbitDirMod.migrateFromLegacyPiDir, undefined, "Bobbit must not export or call automatic ~/.pi/agent migration");
+		assert.equal(typeof scaffoldMod.scaffoldBobbitDir, "function", "scaffoldBobbitDir must be exported");
+		assert.equal(typeof bobbitDirMod.initializeAgentDirRuntime, "function", "initializeAgentDirRuntime must be exported");
+		assert.equal(typeof bobbitDirMod.globalAgentDir, "function", "globalAgentDir must be exported");
+
+		bobbitDirMod.resetAgentDirStateForTests?.();
+		bobbitDirMod.setProjectRoot?.(projectRoot);
+		scaffoldMod.scaffoldBobbitDir(projectRoot);
+		const state = bobbitDirMod.initializeAgentDirRuntime({
+			env: { PI_CODING_AGENT_DIR: legacyAgentDir },
+			projectRoot,
+			stateDir: path.join(projectRoot, ".bobbit", "state"),
+		});
+
+		assert.deepEqual(snapshotTree(legacyAgentDir), before, "raw pi-owned ~/.pi/agent tree must remain byte-for-byte unchanged");
+		assert.ok(!fs.existsSync(path.join(tempHome, ".pi", "agent.pre-bobbit")), "startup must not write a ~/.pi/agent.pre-bobbit marker");
+		assert.ok(!fs.existsSync(path.join(tempHome, ".bobbit", "agent", "auth.json")), "startup must not copy auth.json out of ~/.pi/agent");
+		assertSamePath(state.startup.dir, bobbitAgentDir, "PI_CODING_AGENT_DIR must not become Bobbit's active agent dir");
+		assert.equal(state.startup.source, "default");
+		assert.ok(
+			!state.history.some((entry: string) => path.normalize(entry) === path.normalize(legacyAgentDir)),
+			"~/.pi/agent must not be seeded into agent-dir history as an implicit migration source",
+		);
+		assertSamePath(bobbitDirMod.globalAgentDir(), bobbitAgentDir, "runtime global agent dir stays on Bobbit's resolved directory");
+	});
 });
 
 function pick(value: AgentDirResolution): { source: string; dir: string; raw?: string } {
 	return { source: value.source, dir: path.normalize(value.dir), raw: value.raw };
+}
+
+type TreeSnapshot = Record<string, { type: "dir" } | { type: "file"; content: string }>;
+
+function snapshotTree(root: string): TreeSnapshot {
+	const snapshot: TreeSnapshot = {};
+	function walk(dir: string, rel: string): void {
+		snapshot[rel || "."] = { type: "dir" };
+		const entries = fs.readdirSync(dir).sort((a, b) => a.localeCompare(b));
+		for (const entry of entries) {
+			const abs = path.join(dir, entry);
+			const childRel = rel ? path.join(rel, entry) : entry;
+			const stat = fs.statSync(abs);
+			if (stat.isDirectory()) {
+				walk(abs, childRel);
+			} else if (stat.isFile()) {
+				snapshot[childRel] = { type: "file", content: fs.readFileSync(abs, "utf-8") };
+			}
+		}
+	}
+	walk(root, "");
+	return snapshot;
 }

--- a/tests/bobbit-dir-agent-dir.test.ts
+++ b/tests/bobbit-dir-agent-dir.test.ts
@@ -186,6 +186,71 @@ describe("agent directory resolver", () => {
 		);
 		assertSamePath(bobbitDirMod.globalAgentDir(), bobbitAgentDir, "runtime global agent dir stays on Bobbit's resolved directory");
 	});
+
+	it("filters stale persisted ~/.pi/agent history but preserves explicit config", async (t) => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-pi-history-filter-"));
+		const projectRoot = path.join(root, "project");
+		const tempHome = path.join(root, "home");
+		const legacyAgentDir = path.join(tempHome, ".pi", "agent");
+		const stateDir = path.join(projectRoot, ".bobbit", "state");
+		fs.mkdirSync(stateDir, { recursive: true });
+		fs.mkdirSync(legacyAgentDir, { recursive: true });
+		fs.writeFileSync(path.join(stateDir, "preferences.json"), JSON.stringify({ agentDirHistory: [legacyAgentDir, "~/.pi/agent"] }, null, 2), "utf-8");
+
+		const envKeys = ["HOME", "USERPROFILE", "HOMEDRIVE", "HOMEPATH", "BOBBIT_AGENT_DIR", "PI_CODING_AGENT_DIR"] as const;
+		const oldEnv = new Map(envKeys.map((key) => [key, process.env[key]]));
+		t.after(() => {
+			for (const key of envKeys) {
+				const value = oldEnv.get(key);
+				if (value === undefined) delete process.env[key]; else process.env[key] = value;
+			}
+			fs.rmSync(root, { recursive: true, force: true });
+		});
+
+		process.env.HOME = tempHome;
+		process.env.USERPROFILE = tempHome;
+		delete process.env.HOMEDRIVE;
+		delete process.env.HOMEPATH;
+		delete process.env.BOBBIT_AGENT_DIR;
+		delete process.env.PI_CODING_AGENT_DIR;
+
+		const mod = await loadAgentDirConfigModule();
+		mod.resetAgentDirStateForTests?.();
+		const state = mod.initializeAgentDirRuntime({ env: {}, projectRoot, stateDir });
+		const rewrittenPrefs = JSON.parse(fs.readFileSync(path.join(stateDir, "preferences.json"), "utf-8"));
+		assert.ok(
+			!state.history.some((entry: string) => path.normalize(entry) === path.normalize(legacyAgentDir)),
+			"stale ~/.pi/agent history must not remain known after runtime init",
+		);
+		assert.ok(
+			!rewrittenPrefs.agentDirHistory.some((entry: string) => path.normalize(entry) === path.normalize(legacyAgentDir)),
+			"rewritten preferences must drop stale ~/.pi/agent history",
+		);
+
+		const persistedStateDir = path.join(projectRoot, ".bobbit", "state-persisted");
+		fs.mkdirSync(persistedStateDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(persistedStateDir, "preferences.json"),
+			JSON.stringify({ agentDir: "~/.pi/agent", agentDirHistory: ["~/.pi/agent"] }, null, 2),
+			"utf-8",
+		);
+		mod.resetAgentDirStateForTests?.();
+		const persistedState = mod.initializeAgentDirRuntime({ env: {}, projectRoot, stateDir: persistedStateDir });
+		assert.ok(
+			persistedState.history.some((entry: string) => path.normalize(entry) === path.normalize(legacyAgentDir)),
+			"~/.pi/agent remains known when explicitly configured as persisted agent dir",
+		);
+
+		const envStateDir = path.join(projectRoot, ".bobbit", "state-env");
+		fs.mkdirSync(envStateDir, { recursive: true });
+		fs.writeFileSync(path.join(envStateDir, "preferences.json"), JSON.stringify({ agentDirHistory: ["~/.pi/agent"] }, null, 2), "utf-8");
+		mod.resetAgentDirStateForTests?.();
+		const envState = mod.initializeAgentDirRuntime({ env: { BOBBIT_AGENT_DIR: "~/.pi/agent" }, projectRoot, stateDir: envStateDir });
+		assert.ok(
+			envState.history.some((entry: string) => path.normalize(entry) === path.normalize(legacyAgentDir)),
+			"~/.pi/agent remains known when explicitly configured via BOBBIT_AGENT_DIR",
+		);
+	});
 });
 
 function pick(value: AgentDirResolution): { source: string; dir: string; raw?: string } {

--- a/tests/container-path-translation.test.ts
+++ b/tests/container-path-translation.test.ts
@@ -13,17 +13,13 @@ import assert from "node:assert/strict";
 const TEST_AGENT_DIR = process.platform === "win32"
 	? "C:\\Users\\test\\project\\.bobbit\\agent"
 	: "/home/test/project/.bobbit/agent";
-const LEGACY_AGENT_DIR = process.platform === "win32"
-	? "C:\\Users\\test\\legacy-pi-agent"
-	: "/home/test/legacy-pi-agent";
 const TEST_BOBBIT_DIR = process.platform === "win32"
 	? "C:\\Users\\test\\project\\.bobbit"
 	: "/home/test/project/.bobbit";
 
 // Set env vars before importing the module so the startup-resolved active
-// agent dir is configurable. BOBBIT_AGENT_DIR must win over the legacy env var.
+// agent dir is configurable via BOBBIT_AGENT_DIR.
 process.env.BOBBIT_AGENT_DIR = TEST_AGENT_DIR;
-process.env.PI_CODING_AGENT_DIR = LEGACY_AGENT_DIR;
 process.env.BOBBIT_DIR = TEST_BOBBIT_DIR;
 
 const { containerPathToHost, hostPathToContainer } = await import("../src/server/agent/rpc-bridge.ts");
@@ -36,7 +32,7 @@ describe("containerPathToHost (bind-mount fallback)", () => {
 			? "C:\\Users\\test\\project\\.bobbit\\agent\\sessions\\--workspace--\\2026-01-01.jsonl"
 			: "/home/test/project/.bobbit/agent/sessions/--workspace--/2026-01-01.jsonl";
 		assert.equal(hostPath, expected);
-		assert.ok(!hostPath.includes("legacy-pi-agent"), "must use the configured active agent dir, not the legacy env fallback");
+		assert.ok(hostPath.includes(".bobbit"), "must use the configured active Bobbit agent dir");
 	});
 
 	it("translates /bobbit-state subdirectory paths", () => {

--- a/tests/e2e/aigw-session-header.spec.ts
+++ b/tests/e2e/aigw-session-header.spec.ts
@@ -47,7 +47,7 @@ const MOCK_MODELS = {
 };
 
 function getModelsJsonPath(): string {
-	const envDir = process.env.BOBBIT_AGENT_DIR || process.env.PI_CODING_AGENT_DIR;
+	const envDir = process.env.BOBBIT_AGENT_DIR;
 	let agentDir: string;
 	if (envDir) {
 		if (envDir === "~") agentDir = homedir();

--- a/tests/e2e/aigw-startup-refresh.spec.ts
+++ b/tests/e2e/aigw-startup-refresh.spec.ts
@@ -87,7 +87,6 @@ async function startSeededGateway(opts: SeedOpts): Promise<StartedGateway> {
 	process.env.BOBBIT_DIR = bobbitDir;
 	// Isolate the agent dir so each test has its own ~/.bobbit/agent equivalent.
 	process.env.BOBBIT_AGENT_DIR = agentDir;
-	process.env.PI_CODING_AGENT_DIR = agentDir;
 	process.env.NODE_ENV = "test";
 	process.env.BOBBIT_SKIP_MCP = "1";
 	process.env.BOBBIT_SKIP_NPM_CI = "1";

--- a/tests/e2e/context-window-overrides.spec.ts
+++ b/tests/e2e/context-window-overrides.spec.ts
@@ -7,26 +7,23 @@
  */
 
 import { test, expect } from "./in-process-harness.js";
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
 /**
- * Resolve the models.json path the same way aigw-manager does:
- * BOBBIT_AGENT_DIR / PI_CODING_AGENT_DIR env → ~/.bobbit/agent (fallback ~/.pi/agent)
+ * Resolve the models.json path the same way Bobbit startup does:
+ * BOBBIT_AGENT_DIR env → ~/.bobbit/agent.
  */
 function getModelsJsonPath(): string {
-	const envDir = process.env.BOBBIT_AGENT_DIR || process.env.PI_CODING_AGENT_DIR;
+	const envDir = process.env.BOBBIT_AGENT_DIR;
 	let agentDir: string;
 	if (envDir) {
 		if (envDir === "~") agentDir = homedir();
 		else if (envDir.startsWith("~/")) agentDir = homedir() + envDir.slice(1);
 		else agentDir = envDir;
 	} else {
-		// Prefer ~/.bobbit/agent, fall back to ~/.pi/agent for legacy installs
-		const bobbitDir = join(homedir(), ".bobbit", "agent");
-		const piDir = join(homedir(), ".pi", "agent");
-		agentDir = existsSync(bobbitDir) ? bobbitDir : existsSync(piDir) ? piDir : bobbitDir;
+		agentDir = join(homedir(), ".bobbit", "agent");
 	}
 	return join(agentDir, "models.json");
 }

--- a/tests/e2e/continue-archived-multi-repo.spec.ts
+++ b/tests/e2e/continue-archived-multi-repo.spec.ts
@@ -50,7 +50,7 @@ function slugifyCwd(cwd: string): string {
 }
 
 function globalAgentSessionsDir(): string {
-	const env = process.env.BOBBIT_AGENT_DIR || process.env.PI_CODING_AGENT_DIR;
+	const env = process.env.BOBBIT_AGENT_DIR;
 	return join(env ?? join(homedir(), ".bobbit", "agent"), "sessions");
 }
 

--- a/tests/e2e/continue-archived-worktree-pool.spec.ts
+++ b/tests/e2e/continue-archived-worktree-pool.spec.ts
@@ -51,7 +51,7 @@ function slugifyCwd(cwd: string): string {
 }
 
 function globalAgentSessionsDir(): string {
-	const env = process.env.BOBBIT_AGENT_DIR || process.env.PI_CODING_AGENT_DIR;
+	const env = process.env.BOBBIT_AGENT_DIR;
 	return join(env ?? join(homedir(), ".bobbit", "agent"), "sessions");
 }
 

--- a/tests/e2e/continue-archived-worktree-stale-source.spec.ts
+++ b/tests/e2e/continue-archived-worktree-stale-source.spec.ts
@@ -68,7 +68,7 @@ function slugifyCwd(cwd: string): string {
 }
 
 function globalAgentSessionsDir(): string {
-	const env = process.env.BOBBIT_AGENT_DIR || process.env.PI_CODING_AGENT_DIR;
+	const env = process.env.BOBBIT_AGENT_DIR;
 	const base = env ?? join(homedir(), ".bobbit", "agent");
 	return join(base, "sessions");
 }

--- a/tests/e2e/continue-archived-worktree.spec.ts
+++ b/tests/e2e/continue-archived-worktree.spec.ts
@@ -55,7 +55,7 @@ function slugifyCwd(cwd: string): string {
 }
 
 function globalAgentSessionsDir(): string {
-	const env = process.env.BOBBIT_AGENT_DIR || process.env.PI_CODING_AGENT_DIR;
+	const env = process.env.BOBBIT_AGENT_DIR;
 	const base = env ?? join(homedir(), ".bobbit", "agent");
 	return join(base, "sessions");
 }

--- a/tests/e2e/in-process-harness.ts
+++ b/tests/e2e/in-process-harness.ts
@@ -180,7 +180,6 @@ export const test = base.extend<{ restoreDefaultProject: void }, { enableWorktre
 		// Isolate the agent CLI directory as well as .bobbit/. Without this, API
 		// workers race through ~/.bobbit/agent/models.json during startup/aigw tests.
 		process.env.BOBBIT_AGENT_DIR = agentDir;
-		process.env.PI_CODING_AGENT_DIR = agentDir;
 		process.env.BOBBIT_SKIP_MCP = "1";
 		process.env.NODE_ENV = "test";
 		process.env.BOBBIT_SKIP_NPM_CI = "1";

--- a/tests/e2e/session-recovery.spec.ts
+++ b/tests/e2e/session-recovery.spec.ts
@@ -65,7 +65,6 @@ async function bootGateway(bobbitDir: string, opts: { freshDir: boolean }): Prom
 
 	process.env.BOBBIT_DIR = bobbitDir;
 	process.env.BOBBIT_AGENT_DIR = agentDir;
-	process.env.PI_CODING_AGENT_DIR = agentDir;
 	process.env.BOBBIT_SKIP_MCP = "1";
 	process.env.NODE_ENV = "test";
 	process.env.BOBBIT_SKIP_NPM_CI = "1";

--- a/tests/e2e/sidebar-actions-server.spec.ts
+++ b/tests/e2e/sidebar-actions-server.spec.ts
@@ -83,7 +83,7 @@ function slugifyCwd(cwd: string): string {
 }
 
 function globalAgentSessionsDir(): string {
-	const env = process.env.BOBBIT_AGENT_DIR || process.env.PI_CODING_AGENT_DIR;
+	const env = process.env.BOBBIT_AGENT_DIR;
 	const base = env ?? join(homedir(), ".bobbit", "agent");
 	return join(base, "sessions");
 }


### PR DESCRIPTION
## Summary
- Remove automatic startup migration from raw pi-owned ~/.pi/agent state.
- Ignore user-supplied PI_CODING_AGENT_DIR for Bobbit agent-dir resolution while preserving internal child-process assignment.
- Prevent stale ~/.pi/agent history from remaining an implicit Copy data source and add regression coverage.
- Update agent-dir docs/tests for explicit copy-only behavior.

## Validation
- npm run build, npm run check, npm run test:unit, and npm run test:e2e passed via implementation gate verification.
- npx tsx --test tests/bobbit-dir-agent-dir.test.ts passed after review fix.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)