### PR TITLE
Scale sidebar icons with font size

### DIFF
--- a/docs/design/sidebar-font-size-control.md
+++ b/docs/design/sidebar-font-size-control.md
@@ -1,4 +1,6 @@
-# Sidebar font-size numeric control UX check
+# Sidebar font-size control
+
+The sidebar font-size setting is a browser-local appearance preference for the app shell sidebar. It changes the sidebar's text rhythm without changing chat, headers, dialogs, or other product surfaces.
 
 ## Recommendation
 
@@ -37,3 +39,21 @@ Use explicit copy tied to the new default:
 ## Consistency check
 
 Match existing settings primitives: `text-sm font-medium` label, `text-xs text-muted-foreground` help text, rounded bordered background input, tabular numeric value, and link-style muted reset action. Keep this control in the same Appearance group as the existing sidebar font-size setting; do not introduce a new section or slider-like visual pattern.
+
+## Sidebar affordance scaling
+
+The setting writes the persisted scale to `--sidebar-font-scale`; `.sidebar-root` consumes it as its base `font-size`. Sidebar affordance icons then inherit that size through sidebar-scoped `em` and CSS-variable utilities instead of fixed pixel dimensions.
+
+Covered affordances include:
+
+- top action icons: Roles, Tools, Skills, Workflows, Market, and New Goal;
+- add-goal, add-staff, and add-session compound icons, including the plus overlays;
+- expanded, collapsed, mobile, project, staff, session, goal, team-lead, ungrouped, and archived disclosure chevrons;
+- role-picker / “New session with role” chevrons;
+- sidebar action rows where PR badges and adjacent action buttons share the same gap source.
+
+These utilities are scoped under `.sidebar-root` so changing the sidebar font size cannot resize lucide icons or action spacing elsewhere in the app. The scope also keeps sidebar-specific density rules local: visual icon size follows the font scale, while click targets and non-sidebar surfaces keep their existing behavior.
+
+## Regression coverage
+
+`tests/e2e/ui/sidebar-font-scale.spec.ts` owns the full-stack regression coverage. The `sidebar icons, chevrons, overflow, and action gaps follow sidebar font size @repro` path checks desktop affordances, collapsed-sidebar chevrons, min/max horizontal overflow, vertical scrolling, and PR-to-action gap equality. The mobile `@repro` path checks project/sidebar affordances at a phone viewport, including project and sessions chevrons, add buttons, role-picker chevrons, max-size overflow, and vertical scrolling.

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -154,6 +154,159 @@ details.wf-proposal-workflow .wf-proposal-gates {
 }
 
 /* ============================================================================
+ * SIDEBAR — scalable icon, chevron, and action affordances
+ * ============================================================================ */
+.sidebar-root {
+	--sidebar-icon-size: 1em;
+	--sidebar-compound-icon-size: 0.8571em;
+	--sidebar-compound-icon-size-lg: 1.1429em;
+	--sidebar-compound-plus-size: 0.5em;
+	--sidebar-compound-plus-size-lg: 0.6429em;
+	--sidebar-chevron-w: 1em;
+	--sidebar-header-chevron-w: 1.4286em;
+	--sidebar-project-chevron-w: 0.8571em;
+	--sidebar-action-gap: 0.1429em;
+	--sidebar-action-pad: 0.1429em;
+}
+
+.sidebar-root .flex-1,
+.sidebar-root .truncate,
+.sidebar-root .sidebar-action-cluster,
+.sidebar-root .sidebar-actions,
+.sidebar-root .sidebar-top-actions,
+.sidebar-root .sidebar-top-actions > div,
+.sidebar-root .sidebar-top-actions button {
+	max-width: 100%;
+	overflow: hidden;
+}
+
+.sidebar-root button,
+.sidebar-root .sidebar-top-actions button {
+	min-width: 0;
+}
+
+.sidebar-root button > span:not(.shrink-0):not(.sidebar-compound-icon):not(.sidebar-chevron):not(.project-reorder-slot) {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.sidebar-root .sidebar-top-actions button > span {
+	display: block;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.sidebar-root .sidebar-top-actions svg {
+	width: var(--sidebar-icon-size) !important;
+	height: var(--sidebar-icon-size) !important;
+	flex-shrink: 0;
+}
+
+.sidebar-root .sidebar-scale-icon,
+.sidebar-root .sidebar-scale-icon svg {
+	width: var(--sidebar-icon-size) !important;
+	height: var(--sidebar-icon-size) !important;
+}
+
+.sidebar-root .sidebar-compound-icon {
+	width: var(--sidebar-compound-icon-size);
+	height: var(--sidebar-compound-icon-size);
+}
+
+.sidebar-root .sidebar-compound-icon--lg {
+	width: var(--sidebar-compound-icon-size-lg);
+	height: var(--sidebar-compound-icon-size-lg);
+}
+
+.sidebar-root .sidebar-compound-icon > svg:not(.sidebar-compound-plus) {
+	width: 100% !important;
+	height: 100% !important;
+}
+
+.sidebar-root .sidebar-compound-plus {
+	position: absolute;
+	right: -0.0714em;
+	bottom: 0;
+	width: var(--sidebar-compound-plus-size);
+	height: var(--sidebar-compound-plus-size);
+	filter: drop-shadow(0 0 1.5px var(--background));
+}
+
+.sidebar-root .sidebar-compound-plus--lg {
+	width: var(--sidebar-compound-plus-size-lg);
+	height: var(--sidebar-compound-plus-size-lg);
+}
+
+.sidebar-root .sidebar-chevron {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 var(--sidebar-chevron-w);
+	width: var(--sidebar-chevron-w);
+	min-width: var(--sidebar-chevron-w);
+	line-height: 1;
+	text-align: center;
+}
+
+.sidebar-root .sidebar-chevron--header {
+	flex-basis: var(--sidebar-header-chevron-w);
+	width: var(--sidebar-header-chevron-w);
+	min-width: var(--sidebar-header-chevron-w);
+}
+
+.sidebar-root .sidebar-chevron--project {
+	flex-basis: var(--sidebar-project-chevron-w);
+	width: var(--sidebar-project-chevron-w);
+	min-width: var(--sidebar-project-chevron-w);
+}
+
+.sidebar-root .sidebar-chevron-glyph--lg {
+	font-size: 1.1667em;
+}
+
+.sidebar-root .sidebar-chevron-glyph--sm {
+	font-size: 0.9167em;
+}
+
+.sidebar-root[data-testid="sidebar-collapsed"] {
+	--sidebar-chevron-w: 0.75em;
+}
+
+.sidebar-root[data-testid="sidebar-collapsed"],
+.sidebar-root[data-testid="sidebar-collapsed"] .overflow-y-auto,
+.sidebar-root[data-testid="sidebar-collapsed"] button {
+	max-width: 100%;
+	overflow-x: hidden;
+}
+
+.sidebar-root[data-testid="sidebar-collapsed"] button {
+	min-width: 0;
+	overflow-y: hidden;
+}
+
+.sidebar-root[data-testid="sidebar-collapsed"] .font-extrabold {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: clip;
+	white-space: nowrap;
+}
+
+.sidebar-root .sidebar-action-cluster,
+.sidebar-root .sidebar-actions {
+	gap: var(--sidebar-action-gap);
+}
+
+.sidebar-root .sidebar-pr-badge {
+	padding: var(--sidebar-action-pad);
+	border-radius: 0.25rem;
+	line-height: 0;
+}
+
+/* ============================================================================
  * SIDEBAR — project drag reorder
  * ============================================================================ */
 .project-header {

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -177,7 +177,7 @@ details.wf-proposal-workflow .wf-proposal-gates {
 .sidebar-root .sidebar-top-actions > div,
 .sidebar-root .sidebar-top-actions button {
 	max-width: 100%;
-	overflow: hidden;
+	overflow-x: hidden;
 }
 
 .sidebar-root button,
@@ -285,7 +285,6 @@ details.wf-proposal-workflow .wf-proposal-gates {
 
 .sidebar-root[data-testid="sidebar-collapsed"] button {
 	min-width: 0;
-	overflow-y: hidden;
 }
 
 .sidebar-root[data-testid="sidebar-collapsed"] .font-extrabold {

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -401,10 +401,10 @@ export const SESSION_ROW_PY = "py-0.5";
 
 /** Consistent indent per nesting level (px). */
 export const INDENT = 5;
-/** Width of the chevron/spacer slot (px) — same for all chevrons. */
-export const CHEVRON_W = 14;
+/** CSS width of the chevron/spacer slot - scales with `.sidebar-root` font size. */
+export const CHEVRON_W = "var(--sidebar-chevron-w)";
 /** Wider chevron slot for level-0 section headers (extra right breathing room). */
-export const HEADER_CHEVRON_W = 20;
+export const HEADER_CHEVRON_W = "var(--sidebar-header-chevron-w)";
 
 // ============================================================================
 // SIDEBAR ACTIONS MENU
@@ -584,7 +584,7 @@ function renderSidebarActionsTrigger(input: {
 				if (event.key === "ArrowDown" || event.key === "ArrowUp") openFromTrigger(event);
 				else event.stopPropagation();
 			}}
-		>${icon(Menu, "xs")}</button>
+		>${icon(Menu, "xs", "sidebar-scale-icon")}</button>
 	`;
 }
 
@@ -865,10 +865,10 @@ export function renderProjectArchivedSection(
 				data-nav-id=${archHeaderNavId}
 				data-nav-active=${archHeaderActive ? "true" : "false"}
 				class="relative flex items-center gap-1 pr-1 ${headerPy} w-full text-left ${archHeaderActive ? "bg-secondary text-foreground sidebar-session-active" : (isMobile ? "active:bg-secondary/50" : "hover:bg-secondary/30")} rounded-md transition-colors"
-				style="padding-left:${HEADER_CHEVRON_W}px;"
+				style="padding-left:${HEADER_CHEVRON_W};"
 				@click=${() => { setArchivedSectionExpanded(project.id, !expanded); renderApp(); }}
 			>
-				<span class="absolute left-0 top-0 bottom-0 flex items-center justify-center text-muted-foreground select-none opacity-60" style="width:${HEADER_CHEVRON_W}px;font-size: 1.1667em;">${expanded ? "▾" : "▸"}</span>
+				<span class="sidebar-chevron sidebar-chevron--header absolute left-0 top-0 bottom-0 text-muted-foreground select-none opacity-60"><span class="sidebar-chevron-glyph--lg">${expanded ? "▾" : "▸"}</span></span>
 				<span class="shrink-0 text-muted-foreground opacity-60">${icon(Archive, headerSize)}</span>
 				<span class="${labelClass}" style="${labelStyle}">Archived</span>
 			</button>
@@ -933,14 +933,13 @@ export function renderSessionRow(session: GatewaySession) {
 			data-nav-active=${navActive ? "true" : "false"}
 			class="${mobile ? "" : "group relative"} relative flex items-center gap-1 pr-1 ${rowPy} rounded-md cursor-pointer transition-colors
 				${navActive ? `bg-secondary text-foreground sidebar-session-active${hasChildren ? "" : " sidebar-active-no-chevron"}` : connecting ? "bg-secondary/30 text-muted-foreground" : mobile ? "text-muted-foreground active:bg-secondary/50" : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"}"
-			style="padding-left:${CHEVRON_W}px;"
+			style="padding-left:${CHEVRON_W};"
 			${mobile ? "" : html``}
 			@click=${() => { if (!active && !connecting) connectToSession(session.id, true); }}
 			@auxclick=${(e: MouseEvent) => { if (e.button === 1) { e.preventDefault(); e.stopPropagation(); openSessionInNewWindow(session.id); } }}
 		>
 			${hasChildren ? html`<span
-				class="absolute left-0 top-0 bottom-0 flex items-center justify-center text-muted-foreground select-none cursor-pointer"
-				style="width:${CHEVRON_W}px;font-size: 1em;"
+				class="sidebar-chevron absolute left-0 top-0 bottom-0 text-muted-foreground select-none cursor-pointer"
 				@click=${(e: Event) => { e.stopPropagation(); if (hasFirstClassChild) toggleFirstClassParentExpanded(session.id); else toggleArchivedParentExpanded(session.id); renderApp(); }}
 			>${childrenExpanded ? "▾" : "▸"}</span>` : ""}
 			<div class="shrink-0 flex items-center justify-center ${!active && hasUnseenActivity(session) ? "bobbit-unread-pulse" : ""}">
@@ -955,7 +954,7 @@ export function renderSessionRow(session: GatewaySession) {
 				? buttons
 				: html`
 					<span class="group-hover:hidden group-focus-within:hidden absolute right-0 top-0 bottom-0 flex items-center pr-1 pl-8 rounded-r-md" style="background:linear-gradient(to right, transparent 0%, var(--sidebar) 50%);">${renderSessionTime(session, active)}</span>
-					<div class="sidebar-actions absolute right-0 top-0 bottom-0 flex opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto items-center gap-0 pr-1 pl-8 rounded-r-md" style="background:linear-gradient(to right, transparent 0%, var(--sidebar) 50%);">
+					<div class="sidebar-actions absolute right-0 top-0 bottom-0 flex opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto items-center pr-1 pl-8 rounded-r-md" style="background:linear-gradient(to right, transparent 0%, var(--sidebar) 50%);">
 						${buttons}
 					</div>`}
 		</div>
@@ -1013,12 +1012,11 @@ export function renderArchivedSessionRow(session: GatewaySession, extraChildren 
 			data-nav-active=${active ? "true" : "false"}
 			class="group relative flex items-center gap-1 pr-1 ${rowPy} rounded-md cursor-pointer transition-colors
 				${active ? `bg-secondary text-foreground sidebar-session-active${hasChildren ? "" : " sidebar-active-no-chevron"}` : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"}"
-			style="padding-left:${CHEVRON_W}px; filter:grayscale(1); opacity:0.75;"
+			style="padding-left:${CHEVRON_W}; filter:grayscale(1); opacity:0.75;"
 			@click=${() => connectToSession(session.id, true, { readOnly: true })}
 		>
 			${hasChildren ? html`<span
-				class="absolute left-0 top-0 bottom-0 flex items-center justify-center text-muted-foreground select-none cursor-pointer"
-				style="width:${CHEVRON_W}px;font-size: 1em;"
+				class="sidebar-chevron absolute left-0 top-0 bottom-0 text-muted-foreground select-none cursor-pointer"
 				@click=${(e: Event) => { e.stopPropagation(); toggleArchivedParentExpanded(session.id); renderApp(); }}
 				title="${expanded ? "Collapse" : "Expand"}"
 			>${expanded ? "▾" : "▸"}</span>` : ""}
@@ -1070,8 +1068,7 @@ function renderTeamLeadRow(session: GatewaySession, childCount: number, expanded
 	const buttons = html`${renderSidebarQuickActions(actions, { kind: "session", entityId: session.id, mobile, btnPad })}${renderSidebarActionsTrigger({ kind: "session", entityId: session.id, actions, mobile, btnPad, refresh: actionRefresh, onBeforeOpen: resetSessionForkNewWorktree })}`;
 
 	const chevron = html`<span
-		class="absolute left-0 top-0 bottom-0 flex items-center justify-center text-muted-foreground select-none cursor-pointer"
-		style="width:${CHEVRON_W}px;font-size: 1.1667em;"
+		class="sidebar-chevron absolute left-0 top-0 bottom-0 text-muted-foreground select-none cursor-pointer"
 		@click=${(e: Event) => { e.stopPropagation(); toggleTeamLeadExpanded(session.id); renderApp(); }}
 		title="${expanded ? "Collapse agents" : "Expand agents"}"
 	>${expanded ? "▾" : "▸"}</span>`;
@@ -1087,7 +1084,7 @@ function renderTeamLeadRow(session: GatewaySession, childCount: number, expanded
 			data-nav-active=${active ? "true" : "false"}
 			class="${mobile ? "" : "group relative"} relative flex items-center gap-1 pr-1 ${rowPy} rounded-md cursor-pointer transition-colors
 				${active ? "bg-secondary text-foreground sidebar-session-active" : connecting ? "bg-secondary/30 text-muted-foreground" : mobile ? "text-muted-foreground active:bg-secondary/50" : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"}"
-			style="padding-left:${CHEVRON_W}px;"
+			style="padding-left:${CHEVRON_W};"
 			@click=${() => { if (!active && !connecting) connectToSession(session.id, true); }}
 			@auxclick=${(e: MouseEvent) => { if (e.button === 1) { e.preventDefault(); e.stopPropagation(); openSessionInNewWindow(session.id); } }}
 		>
@@ -1102,7 +1099,7 @@ function renderTeamLeadRow(session: GatewaySession, childCount: number, expanded
 				? buttons
 				: html`
 					<span class="group-hover:hidden group-focus-within:hidden absolute right-0 top-0 bottom-0 flex items-center pr-1 pl-8 rounded-r-md" style="background:linear-gradient(to right, transparent 0%, var(--sidebar) 50%);">${renderSessionTime(session, active)}</span>
-					<div class="sidebar-actions absolute right-0 top-0 bottom-0 flex opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto items-center gap-0 pr-1 pl-8 rounded-r-md" style="background:linear-gradient(to right, transparent 0%, var(--sidebar) 50%);">
+					<div class="sidebar-actions absolute right-0 top-0 bottom-0 flex opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto items-center pr-1 pl-8 rounded-r-md" style="background:linear-gradient(to right, transparent 0%, var(--sidebar) 50%);">
 						${buttons}
 					</div>`}
 		</div>
@@ -1254,9 +1251,9 @@ function renderGoalBadge(goal: Goal) {
 	if (!badge.show) return gateBadge;
 	const prIcon = goalPrIconSvg(badge.color);
 	if (badge.url) {
-		return html`<a class="shrink-0 flex items-center ${badge.hasConflicts ? "pr-conflict-pulse" : ""}" href=${badge.url} target="_blank" rel="noopener" title=${badge.label} @click=${(e: Event) => e.stopPropagation()}>${prIcon}</a>`;
+		return html`<a class="sidebar-pr-badge shrink-0 flex items-center ${badge.hasConflicts ? "pr-conflict-pulse" : ""}" href=${badge.url} target="_blank" rel="noopener" title=${badge.label} @click=${(e: Event) => e.stopPropagation()}>${prIcon}</a>`;
 	}
-	return html`<span class="shrink-0 flex items-center ${badge.hasConflicts ? "pr-conflict-pulse" : ""}" title=${badge.label}>${prIcon}</span>`;
+	return html`<span class="sidebar-pr-badge shrink-0 flex items-center ${badge.hasConflicts ? "pr-conflict-pulse" : ""}" title=${badge.label}>${prIcon}</span>`;
 }
 
 /**
@@ -1483,10 +1480,10 @@ export function renderGoalGroup(goal: Goal, opts?: { descendantCount?: number; r
 				data-sidebar-actions-row-root
 				data-nav-id=${goalNavId}
 				data-nav-active=${goalNavActive ? "true" : "false"}
-				style="padding-left:${HEADER_CHEVRON_W}px;"
+				style="padding-left:${HEADER_CHEVRON_W};"
 				@click=${toggleExpand}
 				@dblclick=${!mobile ? () => { if (goal.team) { const tl = goalSessions.find(s => s.role === "team-lead"); if (tl) connectToSession(tl.id, true); } } : null}>
-				<span class="absolute left-0 top-0 bottom-0 flex items-center justify-center text-muted-foreground select-none" style="width:${HEADER_CHEVRON_W}px;font-size: 1.1667em;" title="${isExpanded ? "Collapse goal" : "Expand goal"}">${isExpanded ? "▾" : "▸"}</span>
+				<span class="sidebar-chevron sidebar-chevron--header absolute left-0 top-0 bottom-0 text-muted-foreground select-none" title="${isExpanded ? "Collapse goal" : "Expand goal"}"><span class="sidebar-chevron-glyph--lg">${isExpanded ? "▾" : "▸"}</span></span>
 				<span class="shrink-0 text-muted-foreground" style="margin-left:-3px;">${icon(GoalIcon, "xs")}</span>
 				${goal.setupStatus === "preparing" ? html`<svg class="animate-spin shrink-0" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="opacity:0.6"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>` : goal.setupStatus === "error" ? html`<span class="shrink-0" style="color:var(--destructive);font-size:0.8333em;line-height:1;" title="Worktree setup failed">⚠</span>` : ""}
 				<span class="flex-1 min-w-0 truncate text-muted-foreground uppercase tracking-wider font-medium" style="${mobile ? "font-size: 1.1667em;" : "font-size: 0.8333em;"}">${renderHighlightedText(goal.title, state.searchQuery)}${opts?.displayTitleSuffix ? html`<span class="ml-1 text-muted-foreground/60 font-mono normal-case tracking-normal" data-testid="sidebar-goal-title-suffix" title="Disambiguator: this goal shares its title with a sibling.">(${opts.displayTitleSuffix})</span>` : ""}</span>
@@ -1499,11 +1496,13 @@ export function renderGoalGroup(goal: Goal, opts?: { descendantCount?: number; r
 						${opts!.descendantCount}
 					</span>
 				` : nothing}
-				${renderGoalBadge(goal)}
 				${mobile
-					? goalButtons
-					: html`<div class="sidebar-actions absolute right-0 top-0 bottom-0 flex opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto items-center gap-0 pr-1 pl-8 rounded-r-md" style="background:linear-gradient(to right, transparent 0%, var(--sidebar) 50%);">
-						${goalButtons}
+					? html`${renderGoalBadge(goal)}${goalButtons}`
+					: html`<div class="sidebar-action-cluster absolute right-0 top-0 bottom-0 flex items-center pr-1 pl-8 rounded-r-md" style="background:linear-gradient(to right, transparent 0%, var(--sidebar) 50%);">
+						${renderGoalBadge(goal)}
+						<div class="sidebar-actions flex opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto items-center">
+							${goalButtons}
+						</div>
 					</div>`}
 			</div>
 			${isExpanded ? html`
@@ -1517,7 +1516,7 @@ export function renderGoalGroup(goal: Goal, opts?: { descendantCount?: number; r
 							   still alive — it would be misleading to offer Start Team. */
 							: (isTeamGoal && hasActiveTeam ? nothing : emptyState))
 						: (isTeamGoal ? renderTeamGroup() : displaySessions.map(renderSessionRow))}
-					${isCreatingHere ? html`<div style="padding-left:${CHEVRON_W}px;${mobile ? "" : "font-size: 0.8333em;"}" class="py-1 text-muted-foreground flex items-center gap-1">
+					${isCreatingHere ? html`<div style="padding-left:${CHEVRON_W};${mobile ? "" : "font-size: 0.8333em;"}" class="py-1 text-muted-foreground flex items-center gap-1">
 						<svg class="animate-spin" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>
 						Creating…
 					</div>` : ""}

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -377,7 +377,7 @@ function renderMobileLanding() {
 		<div class="flex-1 flex flex-col overflow-y-auto sidebar-root" data-project-reordering=${isProjectReordering() ? "true" : "false"}>
 			${renderProjectReorderLiveRegion()}
 			<div class="w-full max-w-xl mx-auto px-2 py-4 pb-16 flex flex-col gap-1">
-				<div class="flex flex-col gap-1 px-1 pb-2 mb-1 border-b border-border/30">
+				<div class="sidebar-top-actions flex flex-col gap-1 px-1 pb-2 mb-1 border-b border-border/30">
 					${(() => {
 						const isRolesActive = isRouteActive("roles", "role-edit");
 						const isToolsActive = isRouteActive("tools", "tool-edit");
@@ -391,17 +391,17 @@ function renderMobileLanding() {
 						<button class="flex-1 px-1.5 py-1 rounded transition-colors flex items-center justify-center gap-1 ${isRolesActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}" style="font-size: 1.1667em;"
 							title="Manage roles"
 							@click=${() => toggleConfigPage(["roles", "role-edit"], () => { import("./role-manager-page.js").then((m) => m.loadRolePageData()); setHashRoute("roles"); })}>
-							${icon(Users, "xs")} Roles
+							${icon(Users, "xs", "sidebar-scale-icon")} Roles
 						</button>
 						<button class="flex-1 px-1.5 py-1 rounded transition-colors flex items-center justify-center gap-1 ${isToolsActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}" style="font-size: 1.1667em;"
 							title="Manage tools"
 							@click=${() => toggleConfigPage(["tools", "tool-edit"], () => { import("./tool-manager-page.js").then((m) => m.loadToolPageData()); setHashRoute("tools"); })}>
-							${icon(Wrench, "xs")} Tools
+							${icon(Wrench, "xs", "sidebar-scale-icon")} Tools
 						</button>
 						<button class="flex-1 px-1.5 py-1 rounded transition-colors flex items-center justify-center gap-1 ${isSkillsActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}" style="font-size: 1.1667em;"
 							title="View skills"
 							@click=${() => toggleConfigPage(["skills"], () => { import("./skills-page.js").then((m) => m.loadSkillsPageData()); setHashRoute("skills"); })}>
-							${icon(Zap, "xs")} Skills
+							${icon(Zap, "xs", "sidebar-scale-icon")} Skills
 						</button>
 					</div>
 					<div class="flex items-center gap-1">
@@ -413,13 +413,13 @@ function renderMobileLanding() {
 								import("./workflow-page.js").then((m) => m.loadWorkflowPageData());
 								setHashRoute("settings", `${projectId}/workflows`, true);
 							}}>
-							${icon(WorkflowIcon, "xs")} Workflows
+							${icon(WorkflowIcon, "xs", "sidebar-scale-icon")} Workflows
 						</button>
 						<button class="flex-1 px-1.5 py-1 rounded transition-colors flex items-center justify-center gap-1 ${isMarketActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}" style="font-size: 1.1667em;"
 							data-testid="market-nav-button-mobile"
 							title="Marketplace"
 							@click=${() => toggleConfigPage(["market"], () => { import("./marketplace-page.js").then((m) => m.loadMarketplaceData()); setHashRoute("market"); })}>
-							${icon(Store, "xs")} Market
+							${icon(Store, "xs", "sidebar-scale-icon")} Market
 						</button>
 						<button
 							data-new-goal-trigger
@@ -430,7 +430,7 @@ function renderMobileLanding() {
 								startNewGoalFlow(e.currentTarget as HTMLElement);
 							}}
 							title=${state.projects.length === 0 ? "Add a project first" : `New goal${shortcutHint("new-goal")}`}>
-							${icon(GoalIcon, "xs")} New Goal
+							${icon(GoalIcon, "xs", "sidebar-scale-icon")} New Goal
 						</button>
 					</div>
 					`;
@@ -531,7 +531,7 @@ function renderMobileLanding() {
 														data-project-id=${project.id}
 														class="flex items-center gap-1.5 pl-0.5 pr-2 py-0.5 rounded-md cursor-pointer active:bg-secondary/50 transition-colors"
 														@click=${() => { if (isProjectReordering()) return; toggleProjectExpanded(project.id); renderApp(); }}>
-														<span class="text-muted-foreground shrink-0 select-none" style="width:14px;text-align:center;font-size: 1.1667em;">${effectiveExpanded ? "▾" : "▸"}</span>
+														<span class="sidebar-chevron sidebar-chevron--project text-muted-foreground shrink-0 select-none"><span class="sidebar-chevron-glyph--lg">${effectiveExpanded ? "▾" : "▸"}</span></span>
 														${renderProjectReorderHandle(project)}
 														<span class="shrink-0" style="color:${color};">${icon(FolderOpen, "sm")}</span>
 													<span class="flex-1 text-muted-foreground uppercase tracking-wider font-medium" style="color:${color};font-size: 1.1667em;">${project.name}</span>
@@ -546,9 +546,9 @@ function renderMobileLanding() {
 															@click=${(e: Event) => { e.stopPropagation(); showGoalDialog(undefined, project.id); }}
 															title="New goal in ${project.name}"
 														>
-															<span class="relative inline-flex items-center justify-center" style="width:16px;height:16px;">
+															<span class="sidebar-compound-icon sidebar-compound-icon--lg relative inline-flex items-center justify-center">
 																${icon(GoalIcon, "sm")}
-																<svg viewBox="0 0 10 10" style="position:absolute;bottom:0px;right:-1px;width:9px;height:9px;filter:drop-shadow(0 0 1.5px var(--background));">
+																<svg class="sidebar-compound-plus sidebar-compound-plus--lg" viewBox="0 0 10 10">
 																	<path d="M5 1V9M1 5H9" stroke="${color}" stroke-width="2.5" stroke-linecap="round"/>
 																</svg>
 															</span>
@@ -564,7 +564,7 @@ function renderMobileLanding() {
 													<div class="flex flex-col gap-0.5">
 														${(() => { const _mobileUngroupedExp = isUngroupedExpanded(project.id); return html`<div class="flex items-center gap-1.5 pl-0 pr-2 py-1.5 rounded-md cursor-pointer active:bg-secondary/50 transition-colors"
 															@click=${() => { setUngroupedExpanded(project.id, !_mobileUngroupedExp); renderApp(); }}>
-															<span class="text-muted-foreground shrink-0 select-none" style="width:14px;text-align:center;font-size: 1.1667em;">${_mobileUngroupedExp ? "▾" : "▸"}</span>
+															<span class="sidebar-chevron text-muted-foreground shrink-0 select-none"><span class="sidebar-chevron-glyph--lg">${_mobileUngroupedExp ? "▾" : "▸"}</span></span>
 															<span class="shrink-0 text-muted-foreground">${icon(MessagesSquare, "sm")}</span>
 															<span class="flex-1 text-muted-foreground uppercase tracking-wider font-medium" style="font-size: 1.1667em;">Sessions</span>
 															<div class="flex items-center relative">
@@ -574,9 +574,9 @@ function renderMobileLanding() {
 																	@click=${(e: Event) => { e.stopPropagation(); createAndConnectSession(undefined, undefined, project.rootPath, undefined, undefined, project.id); }}
 																	title="New session in ${project.name}"
 																>
-																	<span class="relative inline-flex items-center justify-center" style="width:16px;height:16px;">
+																	<span class="sidebar-compound-icon sidebar-compound-icon--lg relative inline-flex items-center justify-center">
 																		${icon(MessagesSquare, "sm")}
-																		<svg viewBox="0 0 10 10" style="position:absolute;bottom:0px;right:-1px;width:9px;height:9px;filter:drop-shadow(0 0 1.5px var(--background));">
+																		<svg class="sidebar-compound-plus sidebar-compound-plus--lg" viewBox="0 0 10 10">
 																			<path d="M5 1V9M1 5H9" stroke="${color}" stroke-width="2.5" stroke-linecap="round"/>
 																		</svg>
 																	</span>
@@ -585,7 +585,7 @@ function renderMobileLanding() {
 																	class="p-1.5 rounded text-muted-foreground active:bg-secondary/50 transition-colors"
 																	@click=${(e: Event) => { e.stopPropagation(); toggleRolePicker(e, undefined, { projectId: project.id, projectName: project.name, projectCwd: project.rootPath }); }}
 																	title="New session with role"
-																>${icon(ChevronDown, "sm")}</button>
+																>${icon(ChevronDown, "sm", "sidebar-scale-icon")}</button>
 																${renderRolePickerDropdown()}
 															</div>
 														</div>

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -977,9 +977,9 @@ export function renderStaffSidebarSection(filteredList?: typeof state.staffList,
 			<div class="relative flex items-center ${mobile ? "gap-1.5 pl-0 pr-2 py-1.5" : "gap-1 pr-1 py-0.5"} rounded-md cursor-pointer ${staffNavActive ? "bg-secondary text-foreground sidebar-session-active" : (mobile ? "active:bg-secondary/50" : "hover:bg-secondary/30")} transition-colors"
 				data-nav-id=${staffNavId}
 				data-nav-active=${staffNavActive ? "true" : "false"}
-				style="${mobile ? "" : `padding-left:${HEADER_CHEVRON_W}px;`}"
+				style="${mobile ? "" : `padding-left:${HEADER_CHEVRON_W};`}"
 				@click=${() => { setStaffSectionExpanded(projectId || "", !staffExpanded); renderApp(); }}>
-				<span class="${mobile ? "" : "absolute left-0 top-0 bottom-0 flex items-center justify-center"} text-muted-foreground shrink-0 select-none" style="${mobile ? "width:14px;text-align:center;" : `width:${HEADER_CHEVRON_W}px;`}font-size: 1.1667em;">${staffExpanded ? "▾" : "▸"}</span>
+				<span class="sidebar-chevron sidebar-chevron--header ${mobile ? "" : "absolute left-0 top-0 bottom-0"} text-muted-foreground shrink-0 select-none"><span class="sidebar-chevron-glyph--lg">${staffExpanded ? "▾" : "▸"}</span></span>
 				<span class="shrink-0 text-muted-foreground" style="margin-left:-3px;">${icon(Bot, mobile ? "sm" : "xs")}</span>
 				<span class="flex-1 text-muted-foreground uppercase tracking-wider font-medium" style="font-size: ${mobile ? "1.1667em" : "0.75em"};">Staff</span>
 				<div class="flex items-center" @click=${(e: Event) => e.stopPropagation()}>
@@ -994,9 +994,9 @@ export function renderStaffSidebarSection(filteredList?: typeof state.staffList,
 						@click=${(e: Event) => startNewStaffFlow(e, projectId)}
 						title="New staff agent"
 					>
-						<span class="relative inline-flex items-center justify-center" style="width:${mobile ? "16px" : "12px"};height:${mobile ? "16px" : "12px"};">
+						<span class="sidebar-compound-icon ${mobile ? "sidebar-compound-icon--lg" : ""} relative inline-flex items-center justify-center">
 							${icon(Bot, mobile ? "sm" : "xs")}
-							<svg viewBox="0 0 10 10" style="position:absolute;bottom:0px;right:-1px;width:${mobile ? "9px" : "7px"};height:${mobile ? "9px" : "7px"};filter:drop-shadow(0 0 1.5px var(--background));">
+							<svg class="sidebar-compound-plus ${mobile ? "sidebar-compound-plus--lg" : ""}" viewBox="0 0 10 10">
 								<path d="M5 1V9M1 5H9" stroke="${staffAccentColor}" stroke-width="2.5" stroke-linecap="round"/>
 							</svg>
 						</span>
@@ -1032,7 +1032,7 @@ export function renderStaffSidebarSection(filteredList?: typeof state.staffList,
 					${active ? "bg-secondary text-foreground sidebar-session-active" : mobile ? "text-muted-foreground active:bg-secondary/50" : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"}"
 					data-nav-id=${staffSessionNavId}
 					data-nav-active=${active ? "true" : "false"}
-					style="padding-left:${CHEVRON_W}px;"
+					style="padding-left:${CHEVRON_W};"
 					@click=${() => handleStaffClick(agent)}>
 					<span class="shrink-0 inline-flex items-center justify-center ${!active && session && hasUnseenActivity(session) ? "bobbit-unread-pulse" : ""}">${statusBobbit(sessionStatus, isCompacting, agent.currentSessionId, active, isAborting, false, false, accessory, false, !active && !!session && hasUnseenActivity(session))}</span>
 					<div class="flex-1 min-w-0 ${mobile ? "flex items-center gap-1" : "truncate"} font-normal"><span class="truncate" style="${mobile ? "font-size: 1.3333em;" : ""}">${renderSessionTitle(agent.name, sessionStatus === "streaming" || sessionStatus === "busy" || isCompacting, state.searchQuery)}</span>${mobile && session ? (() => {
@@ -1045,14 +1045,14 @@ export function renderStaffSidebarSection(filteredList?: typeof state.staffList,
 						})() : ""}</div>
 					${mobile
 						? editBtn
-						: html`<div class="absolute right-0 top-0 bottom-0 flex items-center gap-0 pr-1 pl-8 rounded-r-md" style="background:linear-gradient(to right, transparent 0%, var(--sidebar) 50%);">
+						: html`<div class="absolute right-0 top-0 bottom-0 flex items-center pr-1 pl-8 rounded-r-md" style="background:linear-gradient(to right, transparent 0%, var(--sidebar) 50%);">
 							<span class="group-hover:hidden flex items-center">${session ? (() => {
 								const time = terseRelativeTime(session.lastActivity);
 								if (!time) return "";
 								const unseen = hasUnseenActivity(session);
 								return html`<span class="shrink-0 flex items-center gap-0.5 tabular-nums ${unseen ? "text-foreground/70 font-medium" : "text-muted-foreground/50"}" style="font-size: 0.75em;" title="${formatSessionAge(session.lastActivity)}">${time}${unseen ? html`<span class="unseen-dot" aria-label="unread"></span>` : ""}</span>`;
 							})() : ""}</span>
-							<div class="sidebar-actions hidden group-hover:flex items-center gap-0">
+							<div class="sidebar-actions hidden group-hover:flex items-center">
 								${editBtn}
 							</div>
 						</div>`}
@@ -1232,7 +1232,7 @@ function renderProjectHeader(project: Project, expanded: boolean) {
 				toggleProjectExpanded(project.id);
 				renderApp();
 			}}>
-			<span class="text-muted-foreground shrink-0 select-none" style="width:12px;text-align:center;font-size: 1.1667em;">${expanded ? "▾" : "▸"}</span>
+			<span class="sidebar-chevron sidebar-chevron--project text-muted-foreground shrink-0 select-none"><span class="sidebar-chevron-glyph--lg">${expanded ? "▾" : "▸"}</span></span>
 			<span class="project-reorder-slot">${renderProjectReorderHandle(project)}</span>
 			<span class="shrink-0" style="color:${color};">${icon(FolderOpen, "xs")}</span>
 			<span class="flex-1 text-muted-foreground uppercase tracking-wider font-medium" style="color:${color};font-size: 0.75em;">${project.name}</span>
@@ -1251,9 +1251,9 @@ function renderProjectHeader(project: Project, expanded: boolean) {
 				@click=${(e: Event) => { e.stopPropagation(); showGoalDialog(undefined, project.id); }}
 				title="New goal in ${project.name}"
 			>
-				<span class="relative inline-flex" style="width:12px;height:12px;">
+				<span class="sidebar-compound-icon relative inline-flex">
 					${icon(GoalIcon, "xs")}
-					<svg viewBox="0 0 10 10" style="position:absolute;bottom:0px;right:-1px;width:7px;height:7px;filter:drop-shadow(0 0 1.5px var(--background));">
+					<svg class="sidebar-compound-plus" viewBox="0 0 10 10">
 						<path d="M5 1V9M1 5H9" stroke="${color}" stroke-width="2.5" stroke-linecap="round"/>
 					</svg>
 				</span>
@@ -1300,7 +1300,7 @@ function renderTruncationRow(projectId: string, count: number, depth: number) {
 		<div
 			class="flex items-center gap-1 pr-1 py-0.5 rounded-md cursor-pointer hover:bg-secondary/30 transition-colors text-[10px] text-muted-foreground italic"
 			data-testid="sidebar-show-more-children"
-			style="padding-left:${indentPx + HEADER_CHEVRON_W}px;"
+			style="padding-left:calc(${indentPx}px + ${HEADER_CHEVRON_W});"
 			@click=${(e: Event) => { e.stopPropagation(); _expandNestedDepth(projectId); }}
 			title="Reveal deeper nested goals">
 			Show ${count} more child goal${count === 1 ? "" : "s"}…
@@ -1412,9 +1412,9 @@ function renderProjectContent(
 			<div class="relative flex items-center gap-1 pr-1 py-0.5 rounded-md cursor-pointer ${ungActive ? "bg-secondary text-foreground sidebar-session-active" : "hover:bg-secondary/30"} transition-colors"
 				data-nav-id=${ungNavId}
 				data-nav-active=${ungActive ? "true" : "false"}
-				style="padding-left:${HEADER_CHEVRON_W}px;"
+				style="padding-left:${HEADER_CHEVRON_W};"
 				@click=${() => { setUngroupedExpanded(project.id, !ungroupedExp); renderApp(); }}>
-				<span class="absolute left-0 top-0 bottom-0 flex items-center justify-center text-muted-foreground select-none" style="width:${HEADER_CHEVRON_W}px;font-size: 1.1667em;">${ungroupedExp ? "▾" : "▸"}</span>
+				<span class="sidebar-chevron sidebar-chevron--header absolute left-0 top-0 bottom-0 text-muted-foreground select-none"><span class="sidebar-chevron-glyph--lg">${ungroupedExp ? "▾" : "▸"}</span></span>
 				<span class="shrink-0 text-muted-foreground" style="margin-left:-3px;">${icon(MessagesSquare, "xs")}</span>
 				<span class="flex-1 text-muted-foreground uppercase tracking-wider font-medium" style="font-size: 0.75em;">Sessions</span>
 				${!isProvisional ? html`
@@ -1426,9 +1426,9 @@ function renderProjectContent(
 						title="New session in ${project.name}"
 						?disabled=${state.creatingSession}
 					>
-						<span class="relative inline-flex items-center justify-center" style="width:12px;height:12px;">
+						<span class="sidebar-compound-icon relative inline-flex items-center justify-center">
 							${icon(MessagesSquare, "xs")}
-							<svg viewBox="0 0 10 10" style="position:absolute;bottom:0px;right:-1px;width:7px;height:7px;filter:drop-shadow(0 0 1.5px var(--background));">
+							<svg class="sidebar-compound-plus" viewBox="0 0 10 10">
 								<path d="M5 1V9M1 5H9" stroke="var(--primary)" stroke-width="2.5" stroke-linecap="round"/>
 							</svg>
 						</span>
@@ -1437,7 +1437,7 @@ function renderProjectContent(
 						class="p-0.5 rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
 						@click=${(e: Event) => { e.stopPropagation(); toggleRolePicker(e, undefined, { projectId: project.id, projectName: project.name, projectCwd: project.rootPath }); }}
 						title="New session with role"
-					>${icon(ChevronDown, "xs")}</button>
+					>${icon(ChevronDown, "xs", "sidebar-scale-icon")}</button>
 					${renderRolePickerDropdown()}
 				</div>
 				` : ""}
@@ -1485,14 +1485,14 @@ export function renderSidebar() {
 		<div class="shrink-0 h-full flex flex-col sidebar-edge sidebar-root relative" data-testid="sidebar-expanded" data-project-reordering=${isProjectReordering() ? "true" : "false"} style="background: var(--sidebar); width: var(--sidebar-w, 240px);">
 			${renderProjectReorderLiveRegion()}
 			<div class="sidebar-resize-handle" @pointerdown=${onSidebarResizePointerDown} @dblclick=${onSidebarResizeDoubleClick} title="Drag to resize (double-click to reset)"></div>
-			<div class="flex flex-col border-b border-border/50 px-0.5 py-1 gap-0.5">
+			<div class="sidebar-top-actions flex flex-col border-b border-border/50 px-0.5 py-1 gap-0.5">
 				<div class="flex items-center">
 					<button
 						class="flex-1 flex items-center justify-center gap-1 px-1 py-1 ${isRolesActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'} rounded-md transition-colors"
 						@click=${() => toggleConfigPage(["roles", "role-edit"], () => { import("./role-manager-page.js").then((m) => m.loadRolePageData()); setHashRoute("roles"); })}
 						title="Manage roles"
 					>
-						${icon(Users, "xs", "!w-3.5 !h-3.5")}
+						${icon(Users, "xs", "sidebar-scale-icon")}
 						<span>Roles</span>
 					</button>
 					<button
@@ -1500,7 +1500,7 @@ export function renderSidebar() {
 						@click=${() => toggleConfigPage(["tools", "tool-edit"], () => { import("./tool-manager-page.js").then((m) => m.loadToolPageData()); setHashRoute("tools"); })}
 						title="Manage tools"
 					>
-						${icon(Wrench, "xs", "!w-3.5 !h-3.5")}
+						${icon(Wrench, "xs", "sidebar-scale-icon")}
 						<span>Tools</span>
 					</button>
 					<button
@@ -1508,7 +1508,7 @@ export function renderSidebar() {
 						@click=${() => toggleConfigPage(["skills"], () => { import("./skills-page.js").then((m) => m.loadSkillsPageData()); setHashRoute("skills"); })}
 						title="View skills"
 					>
-						${icon(Zap, "xs", "!w-3.5 !h-3.5")}
+						${icon(Zap, "xs", "sidebar-scale-icon")}
 						<span>Skills</span>
 					</button>
 				</div>
@@ -1518,7 +1518,7 @@ export function renderSidebar() {
 						@click=${() => toggleConfigPage(["workflows", "workflow-edit"], () => { import("./workflow-page.js").then((m) => m.loadWorkflowPageData()); setHashRoute("workflows"); })}
 						title="Manage workflows"
 					>
-						${icon(Workflow, "xs", "!w-3.5 !h-3.5")}
+						${icon(Workflow, "xs", "sidebar-scale-icon")}
 						<span>Workflows</span>
 					</button>
 					<button
@@ -1527,7 +1527,7 @@ export function renderSidebar() {
 						@click=${() => toggleConfigPage(["market"], () => { import("./marketplace-page.js").then((m) => m.loadMarketplaceData()); setHashRoute("market"); })}
 						title="Marketplace"
 					>
-						${icon(Store, "xs", "!w-3.5 !h-3.5")}
+						${icon(Store, "xs", "sidebar-scale-icon")}
 						<span>Market</span>
 					</button>
 					<button
@@ -1540,7 +1540,7 @@ export function renderSidebar() {
 						}}
 						title=${state.projects.length === 0 ? "Add a project first" : `New goal${shortcutHint("new-goal")}`}
 					>
-						${icon(GoalIcon, "xs", "!w-3.5 !h-3.5")}
+						${icon(GoalIcon, "xs", "sidebar-scale-icon")}
 						<span>New Goal</span>
 					</button>
 				</div>
@@ -1700,7 +1700,7 @@ export function renderSidebar() {
 				` : html`
 					<div class="border-t border-border/30 my-1 mx-2"></div>
 					<button
-						class="flex items-center gap-1 px-1 py-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-secondary/50 transition-colors w-full" style="font-size: 0.8333em; padding-left:${HEADER_CHEVRON_W}px;"
+						class="flex items-center gap-1 px-1 py-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-secondary/50 transition-colors w-full" style="font-size: 0.8333em; padding-left:${HEADER_CHEVRON_W};"
 						@click=${() => showProjectDialog()}
 						title="Register another project"
 					>
@@ -1803,9 +1803,9 @@ function renderCollapsedSidebar(sortedGoals: Goal[], _ungroupedSessions: Gateway
 				class="flex items-center gap-0.5 ${SESSION_ROW_PY} px-1 rounded-md transition-colors w-full ${tlActive ? "bg-secondary sidebar-session-active" : "hover:bg-secondary/50"}"
 				@click=${() => { if (!tlActive) connectToSession(teamLead.id, true); }}
 			>
-				<span class="text-muted-foreground shrink-0 select-none" style="width:8px;text-align:center;cursor:pointer;font-size: 0.75em;"
+				<span class="sidebar-chevron text-muted-foreground shrink-0 select-none" style="cursor:pointer;"
 					@click=${(e: Event) => { e.stopPropagation(); toggleTeamLeadExpanded(teamLead.id); renderApp(); }}
-				>${children.length > 0 ? (tlExpanded ? "▾" : "▸") : ""}</span>
+				><span class="sidebar-chevron-glyph--sm">${children.length > 0 ? (tlExpanded ? "▾" : "▸") : ""}</span></span>
 				<span class="shrink-0 inline-flex items-center justify-center ${!tlActive && hasUnseenActivity(teamLead) ? "bobbit-unread-pulse" : ""}">${statusBobbit(teamLead.status, teamLead.isCompacting, teamLead.id, tlActive, teamLead.isAborting, true, false, teamLead.accessory, false, !tlActive && hasUnseenActivity(teamLead))}</span>
 				<span class="font-bold tracking-wide ${tlActive ? "text-foreground" : "text-muted-foreground"}" style="font-family: ui-monospace, monospace; line-height: 1; font-size: 0.6667em;">${sessionAcronym(tlTitle)}</span>
 			</button>
@@ -1833,7 +1833,7 @@ function renderCollapsedSidebar(sortedGoals: Goal[], _ungroupedSessions: Gateway
 									title=${goal.title}
 									@click=${(e: Event) => { e.stopPropagation(); if (expandedGoals.has(goal.id)) expandedGoals.delete(goal.id); else expandedGoals.add(goal.id); saveExpandedGoals(); renderApp(); }}
 								>
-									<span class="text-muted-foreground shrink-0 select-none" style="width:${CHEVRON_W}px;text-align:center;font-size: 0.9167em;">${expanded ? "▾" : "▸"}</span>
+									<span class="sidebar-chevron text-muted-foreground shrink-0 select-none"><span class="sidebar-chevron-glyph--sm">${expanded ? "▾" : "▸"}</span></span>
 									<span class="font-extrabold tracking-wider text-muted-foreground" style="font-family: ui-monospace, monospace; line-height: 1; font-size: 0.75em;">${sessionAcronym(goal.title)}</span>
 								</button>
 								${expanded ? renderCollapsedGoalSessions(goalSessions, goal) : ""}
@@ -1845,7 +1845,7 @@ function renderCollapsedSidebar(sortedGoals: Goal[], _ungroupedSessions: Gateway
 							title="Ungrouped sessions in ${project.name}"
 							@click=${() => { setUngroupedExpanded(project.id, !_collapsedUngroupedExp); renderApp(); }}
 						>
-							<span class="text-muted-foreground shrink-0 select-none" style="width:${CHEVRON_W}px;text-align:center;font-size: 0.9167em;">${_collapsedUngroupedExp ? "▾" : "▸"}</span>
+							<span class="sidebar-chevron text-muted-foreground shrink-0 select-none"><span class="sidebar-chevron-glyph--sm">${_collapsedUngroupedExp ? "▾" : "▸"}</span></span>
 							<span class="font-extrabold tracking-wider text-muted-foreground" style="font-family: ui-monospace, monospace; line-height: 1; font-size: 0.75em;">SES</span>
 						</button>
 						${_collapsedUngroupedExp ? bucket.sessions.map(renderCollapsedSession) : ""}` : bucket.sessions.map(renderCollapsedSession)}
@@ -1856,7 +1856,7 @@ function renderCollapsedSidebar(sortedGoals: Goal[], _ungroupedSessions: Gateway
 								title="Staff in ${project.name}"
 								@click=${() => { setStaffSectionExpanded(project.id, !_collapsedStaffExp); renderApp(); }}
 							>
-								<span class="text-muted-foreground shrink-0 select-none" style="width:${CHEVRON_W}px;text-align:center;font-size: 0.9167em;">${_collapsedStaffExp ? "▾" : "▸"}</span>
+								<span class="sidebar-chevron text-muted-foreground shrink-0 select-none"><span class="sidebar-chevron-glyph--sm">${_collapsedStaffExp ? "▾" : "▸"}</span></span>
 								<span class="font-extrabold tracking-wider text-muted-foreground" style="font-family: ui-monospace, monospace; line-height: 1; font-size: 0.75em;">STAFF</span>
 							</button>
 							${_collapsedStaffExp ? bucket.staff.map(renderCollapsedSession) : ""}
@@ -1875,7 +1875,7 @@ function renderCollapsedSidebar(sortedGoals: Goal[], _ungroupedSessions: Gateway
 									title=${goal.title}
 									@click=${(e: Event) => { e.stopPropagation(); if (expandedGoals.has(goal.id)) expandedGoals.delete(goal.id); else expandedGoals.add(goal.id); saveExpandedGoals(); renderApp(); }}
 								>
-									<span class="text-muted-foreground shrink-0 select-none" style="width:${CHEVRON_W}px;text-align:center;font-size: 0.9167em;">${expanded ? "▾" : "▸"}</span>
+									<span class="sidebar-chevron text-muted-foreground shrink-0 select-none"><span class="sidebar-chevron-glyph--sm">${expanded ? "▾" : "▸"}</span></span>
 									<span class="font-extrabold tracking-wider text-muted-foreground" style="font-family: ui-monospace, monospace; line-height: 1; font-size: 0.75em;">${sessionAcronym(goal.title)}</span>
 								</button>
 								${expanded ? renderCollapsedGoalSessions(goalSessions, goal) : ""}

--- a/tests/e2e/ui/sidebar-font-scale.spec.ts
+++ b/tests/e2e/ui/sidebar-font-scale.spec.ts
@@ -112,7 +112,7 @@ type IconDimensionName =
 	| "collapsedDisclosureChevron";
 
 type IconDimensionSnapshot = Record<IconDimensionName, { width: number; height: number }> & { rootFontSize: number };
-type OverflowSnapshot = Array<{ label: string; scrollWidth: number; clientWidth: number; overflow: number }>;
+type OverflowSnapshot = Array<{ label: string; scrollWidth: number; clientWidth: number; overflow: number; overflowY: string }>;
 type ActionGapSnapshot = { prToFirstAction: number; firstToSecondAction: number; delta: number };
 
 async function applySidebarFontSizePx(page: Page, px: number): Promise<void> {
@@ -212,6 +212,81 @@ function assertDimensionScales(
 	}
 }
 
+type MobileIconDimensionName =
+	| "mobileNewGoalIcon"
+	| "mobileProjectChevron"
+	| "mobileProjectAddGoalBox"
+	| "mobileProjectAddGoalPlus"
+	| "mobileSessionsChevron"
+	| "mobileAddSessionBox"
+	| "mobileAddSessionPlus"
+	| "mobileRolePickerChevron";
+
+type MobileIconDimensionSnapshot = Record<MobileIconDimensionName, { width: number; height: number }> & { rootFontSize: number; overflow: number; overflowY: string };
+
+async function waitForMobileSidebarFixture(page: Page): Promise<void> {
+	await expect(page.locator(".sidebar-root").first()).toBeVisible({ timeout: 15_000 });
+	await expect(page.locator("[data-testid='project-header']").first()).toBeVisible({ timeout: 15_000 });
+	await expect(page.locator("[data-new-goal-trigger]").first()).toBeVisible({ timeout: 5_000 });
+	await expect(page.locator("button[title^='New goal in']").first()).toBeVisible({ timeout: 5_000 });
+	await expect(page.locator("button[title^='New session in']").first()).toBeVisible({ timeout: 5_000 });
+	await expect(page.locator("button[title='New session with role']").first()).toBeVisible({ timeout: 5_000 });
+}
+
+async function measureMobileIconDimensions(page: Page): Promise<MobileIconDimensionSnapshot> {
+	return page.evaluate(() => {
+		const requireEl = <T extends Element>(selector: string, root: ParentNode = document): T => {
+			const el = root.querySelector<T>(selector);
+			if (!el) throw new Error(`missing mobile sidebar measurement target: ${selector}`);
+			return el;
+		};
+		const rectOf = (el: Element) => {
+			const r = el.getBoundingClientRect();
+			return { width: r.width, height: r.height };
+		};
+		const root = requireEl<HTMLElement>(".sidebar-root");
+		const newGoalButton = requireEl<HTMLElement>("[data-new-goal-trigger]", root);
+		const projectHeader = requireEl<HTMLElement>("[data-testid='project-header']", root);
+		const projectAddButton = requireEl<HTMLElement>("button[title^='New goal in']", root);
+		const addSessionButton = requireEl<HTMLElement>("button[title^='New session in']", root);
+		const sessionsHeader = addSessionButton.closest<HTMLElement>(".cursor-pointer");
+		if (!sessionsHeader) throw new Error("missing mobile sessions header");
+		const rolePickerButton = requireEl<HTMLElement>("button[title='New session with role']", root);
+		const style = getComputedStyle(root);
+		return {
+			rootFontSize: parseFloat(style.fontSize),
+			overflow: root.scrollWidth - root.clientWidth,
+			overflowY: style.overflowY,
+			mobileNewGoalIcon: rectOf(requireEl("svg", newGoalButton)),
+			mobileProjectChevron: rectOf(requireEl(".sidebar-chevron", projectHeader)),
+			mobileProjectAddGoalBox: rectOf(requireEl(".sidebar-compound-icon", projectAddButton)),
+			mobileProjectAddGoalPlus: rectOf(requireEl(".sidebar-compound-plus", projectAddButton)),
+			mobileSessionsChevron: rectOf(requireEl(".sidebar-chevron", sessionsHeader)),
+			mobileAddSessionBox: rectOf(requireEl(".sidebar-compound-icon", addSessionButton)),
+			mobileAddSessionPlus: rectOf(requireEl(".sidebar-compound-plus", addSessionButton)),
+			mobileRolePickerChevron: rectOf(requireEl("svg", rolePickerButton)),
+		};
+	});
+}
+
+function assertMobileDimensionScales(
+	failures: string[],
+	name: MobileIconDimensionName,
+	baseline: MobileIconDimensionSnapshot,
+	large: MobileIconDimensionSnapshot,
+	small: MobileIconDimensionSnapshot,
+): void {
+	const base = baseline[name].width;
+	const largeWidth = large[name].width;
+	const smallWidth = small[name].width;
+	if (!(largeWidth > base * 1.35)) {
+		failures.push(`${name}: large dimension should grow with sidebar font size (baseline=${base.toFixed(2)}px, large=${largeWidth.toFixed(2)}px)`);
+	}
+	if (!(smallWidth < base * 0.9)) {
+		failures.push(`${name}: small dimension should shrink with sidebar font size (baseline=${base.toFixed(2)}px, small=${smallWidth.toFixed(2)}px)`);
+	}
+}
+
 async function measureCollapsedChevronDimension(page: Page): Promise<{ width: number; height: number }> {
 	return page.evaluate(() => {
 		const collapsed = document.querySelector<HTMLElement>("[data-testid='sidebar-collapsed']");
@@ -226,12 +301,16 @@ async function measureCollapsedChevronDimension(page: Page): Promise<{ width: nu
 async function measureHorizontalOverflow(page: Page): Promise<OverflowSnapshot> {
 	return page.evaluate(() => {
 		const roots = Array.from(document.querySelectorAll<HTMLElement>("[data-testid='sidebar-expanded'], [data-testid='sidebar-collapsed']"));
-		const items: Array<{ label: string; scrollWidth: number; clientWidth: number; overflow: number }> = [];
+		const items: Array<{ label: string; scrollWidth: number; clientWidth: number; overflow: number; overflowY: string }> = [];
+		const snap = (label: string, el: HTMLElement) => {
+			const style = getComputedStyle(el);
+			items.push({ label, scrollWidth: el.scrollWidth, clientWidth: el.clientWidth, overflow: el.scrollWidth - el.clientWidth, overflowY: style.overflowY });
+		};
 		for (const root of roots) {
 			const label = root.dataset.testid || "sidebar-root";
-			items.push({ label, scrollWidth: root.scrollWidth, clientWidth: root.clientWidth, overflow: root.scrollWidth - root.clientWidth });
+			snap(label, root);
 			const scroller = root.querySelector<HTMLElement>(".overflow-y-auto");
-			if (scroller) items.push({ label: `${label} scroller`, scrollWidth: scroller.scrollWidth, clientWidth: scroller.clientWidth, overflow: scroller.scrollWidth - scroller.clientWidth });
+			if (scroller) snap(`${label} scroller`, scroller);
 		}
 		return items;
 	});
@@ -313,6 +392,9 @@ test.describe("Sidebar font scale (full-stack UI)", () => {
 					if (item.overflow > 2) {
 						failures.push(`${item.label}: horizontal overflow at ${px}px (scrollWidth=${item.scrollWidth}, clientWidth=${item.clientWidth})`);
 					}
+					if (item.label.endsWith("scroller") && item.overflowY === "hidden") {
+						failures.push(`${item.label}: vertical scrolling must remain enabled at ${px}px`);
+					}
 				}
 			}
 
@@ -332,6 +414,9 @@ test.describe("Sidebar font scale (full-stack UI)", () => {
 				for (const item of await measureHorizontalOverflow(page)) {
 					if (item.overflow > 2) {
 						failures.push(`${item.label}: horizontal overflow at ${px}px collapsed (scrollWidth=${item.scrollWidth}, clientWidth=${item.clientWidth})`);
+					}
+					if (item.label.endsWith("scroller") && item.overflowY === "hidden") {
+						failures.push(`${item.label}: vertical scrolling must remain enabled at ${px}px collapsed`);
 					}
 				}
 			}
@@ -362,6 +447,68 @@ test.describe("Sidebar font scale (full-stack UI)", () => {
 			).toEqual([]);
 		} finally {
 			if (staffId) await apiFetch(`/api/staff/${staffId}`, { method: "DELETE" }).catch(() => {});
+			if (sessionId) await deleteSession(sessionId).catch(() => {});
+			if (goalId) await deleteGoal(goalId).catch(() => {});
+		}
+	});
+
+	test("mobile project sidebar affordances follow sidebar font size @repro", async ({ page }) => {
+		const project = await defaultProject();
+		const tag = Date.now();
+		let goalId: string | undefined;
+		let sessionId: string | undefined;
+
+		try {
+			const goal = await createGoal({ title: `MobileFontScaleGoal${tag}`, projectId: project.id, cwd: project.rootPath, worktree: false, team: false });
+			goalId = goal.id as string;
+			sessionId = await createSession({ projectId: project.id, cwd: project.rootPath });
+
+			await page.setViewportSize({ width: 375, height: 667 });
+			await openApp(page);
+			await resetSidebarVisualState(page, goalId);
+			await page.reload();
+			await waitForMobileSidebarFixture(page);
+
+			await applySidebarFontSizePx(page, 14);
+			const baseline = await measureMobileIconDimensions(page);
+			expect(baseline.rootFontSize).toBeCloseTo(14, 1);
+
+			await applySidebarFontSizePx(page, 24);
+			const large = await measureMobileIconDimensions(page);
+			expect(large.rootFontSize).toBeCloseTo(24, 1);
+
+			await applySidebarFontSizePx(page, MIN_PX);
+			const small = await measureMobileIconDimensions(page);
+			expect(small.rootFontSize).toBeCloseTo(MIN_PX, 1);
+
+			const failures: string[] = [];
+			for (const name of [
+				"mobileNewGoalIcon",
+				"mobileProjectChevron",
+				"mobileProjectAddGoalBox",
+				"mobileProjectAddGoalPlus",
+				"mobileSessionsChevron",
+				"mobileAddSessionBox",
+				"mobileAddSessionPlus",
+				"mobileRolePickerChevron",
+			] satisfies MobileIconDimensionName[]) {
+				assertMobileDimensionScales(failures, name, baseline, large, small);
+			}
+
+			await applySidebarFontSizePx(page, MAX_PX);
+			const max = await measureMobileIconDimensions(page);
+			if (max.overflow > 2) {
+				failures.push(`mobile sidebar: horizontal overflow at ${MAX_PX}px (overflow=${max.overflow})`);
+			}
+			if (max.overflowY === "hidden") {
+				failures.push("mobile sidebar: vertical scrolling must remain enabled");
+			}
+
+			expect(
+				failures,
+				"SIDEBAR_MOBILE_ICON_SCALE_REGRESSION: mobile sidebar project affordances must follow sidebar font size",
+			).toEqual([]);
+		} finally {
 			if (sessionId) await deleteSession(sessionId).catch(() => {});
 			if (goalId) await deleteGoal(goalId).catch(() => {});
 		}

--- a/tests/e2e/ui/sidebar-font-scale.spec.ts
+++ b/tests/e2e/ui/sidebar-font-scale.spec.ts
@@ -3,6 +3,7 @@
  */
 import { type Locator } from "@playwright/test";
 import { test, expect, type Page } from "../gateway-harness.js";
+import { apiFetch, createGoal, createSession, defaultProject, deleteGoal, deleteSession } from "../e2e-setup.js";
 import { openApp, navigateToHash } from "./ui-helpers.js";
 
 const SCALE_KEY = "bobbit:sidebar-font-scale";
@@ -98,7 +99,274 @@ async function activityDotSize(page: Page): Promise<number> {
 	);
 }
 
+type IconDimensionName =
+	| "newGoalIcon"
+	| "projectAddGoalBox"
+	| "projectAddGoalPlus"
+	| "addSessionBox"
+	| "addSessionPlus"
+	| "addStaffBox"
+	| "addStaffPlus"
+	| "expandedDisclosureChevron"
+	| "rolePickerChevron"
+	| "collapsedDisclosureChevron";
+
+type IconDimensionSnapshot = Record<IconDimensionName, { width: number; height: number }> & { rootFontSize: number };
+type OverflowSnapshot = Array<{ label: string; scrollWidth: number; clientWidth: number; overflow: number }>;
+type ActionGapSnapshot = { prToFirstAction: number; firstToSecondAction: number; delta: number };
+
+async function applySidebarFontSizePx(page: Page, px: number): Promise<void> {
+	const scale = scaleForPx(px);
+	await page.evaluate(([key, value]) => {
+		localStorage.setItem(key as string, String(value));
+		document.documentElement.style.setProperty("--sidebar-font-scale", String(value));
+	}, [SCALE_KEY, scale]);
+	await waitForScale(page, scale);
+}
+
+async function createStaffAgent(project: { id: string; rootPath: string }, name: string): Promise<{ id: string }> {
+	const resp = await apiFetch("/api/staff", {
+		method: "POST",
+		body: JSON.stringify({ name, systemPrompt: "You are a sidebar font-scale test bot.", cwd: project.rootPath, projectId: project.id }),
+	});
+	if (resp.status !== 201) {
+		expect(resp.status, `test setup should create staff agent: ${await resp.text().catch(() => "")}`).toBe(201);
+	}
+	return resp.json();
+}
+
+async function resetSidebarVisualState(page: Page, goalId: string): Promise<void> {
+	await page.evaluate(({ scaleKey, gid }) => {
+		localStorage.removeItem(scaleKey);
+		localStorage.removeItem("bobbit-sidebar-collapsed");
+		localStorage.removeItem("bobbit-expanded-projects");
+		localStorage.setItem("bobbit-collapsed-ungrouped", "[]");
+		localStorage.setItem("bobbit-collapsed-staff", "[]");
+		localStorage.setItem("bobbit-archived-collapsed-projects", "[]");
+		localStorage.setItem("bobbit-expanded-goals", JSON.stringify([gid]));
+	}, { scaleKey: SCALE_KEY, gid: goalId });
+}
+
+async function waitForSidebarFixture(page: Page, goalId: string, staffName: string): Promise<void> {
+	await expect(page.locator("[data-testid='sidebar-expanded']")).toBeVisible({ timeout: 15_000 });
+	await expect(page.locator(`[data-nav-id="goal:${goalId}"]`).first()).toBeVisible({ timeout: 15_000 });
+	await expect(page.locator("button[title^='New goal in']").first()).toBeVisible({ timeout: 5_000 });
+	await expect(page.locator("button[title^='New session in']").first()).toBeVisible({ timeout: 5_000 });
+	await expect(page.locator("button[title='New staff agent']").first()).toBeVisible({ timeout: 5_000 });
+	await expect(page.getByText(staffName, { exact: true }).first()).toBeVisible({ timeout: 15_000 });
+}
+
+async function measureIconDimensions(page: Page, goalId: string): Promise<IconDimensionSnapshot> {
+	const result = await page.evaluate((gid) => {
+		const requireEl = <T extends Element>(selector: string, root: ParentNode = document): T => {
+			const el = root.querySelector<T>(selector);
+			if (!el) throw new Error(`missing sidebar measurement target: ${selector}`);
+			return el;
+		};
+		const rectOf = (el: Element) => {
+			const r = el.getBoundingClientRect();
+			return { width: r.width, height: r.height };
+		};
+		const expanded = requireEl<HTMLElement>("[data-testid='sidebar-expanded']");
+		const newGoalButton = requireEl<HTMLElement>("[data-new-goal-trigger]", expanded);
+		const projectAddButton = requireEl<HTMLElement>("button[title^='New goal in']", expanded);
+		const addSessionButton = requireEl<HTMLElement>("button[title^='New session in']", expanded);
+		const addStaffButton = requireEl<HTMLElement>("button[title='New staff agent']", expanded);
+		const rolePickerButton = requireEl<HTMLElement>("button[title='New session with role']", expanded);
+		const goalRow = requireEl<HTMLElement>(`[data-nav-id="goal:${gid}"]`, expanded);
+		const collapsed = document.querySelector<HTMLElement>("[data-testid='sidebar-collapsed']");
+		return {
+			rootFontSize: parseFloat(getComputedStyle(expanded).fontSize),
+			newGoalIcon: rectOf(requireEl("svg", newGoalButton)),
+			projectAddGoalBox: rectOf(requireEl("span.relative.inline-flex", projectAddButton)),
+			projectAddGoalPlus: rectOf(requireEl("span.relative.inline-flex svg[viewBox='0 0 10 10']", projectAddButton)),
+			addSessionBox: rectOf(requireEl("span.relative.inline-flex", addSessionButton)),
+			addSessionPlus: rectOf(requireEl("span.relative.inline-flex svg[viewBox='0 0 10 10']", addSessionButton)),
+			addStaffBox: rectOf(requireEl("span.relative.inline-flex", addStaffButton)),
+			addStaffPlus: rectOf(requireEl("span.relative.inline-flex svg[viewBox='0 0 10 10']", addStaffButton)),
+			expandedDisclosureChevron: rectOf(requireEl("span[title*='goal']", goalRow)),
+			rolePickerChevron: rectOf(requireEl("svg", rolePickerButton)),
+			collapsedDisclosureChevron: collapsed
+				? rectOf(requireEl("button[title] span:first-child", collapsed))
+				: { width: Number.NaN, height: Number.NaN },
+		};
+	}, goalId);
+	return result;
+}
+
+function assertDimensionScales(
+	failures: string[],
+	name: IconDimensionName,
+	baseline: IconDimensionSnapshot,
+	large: IconDimensionSnapshot,
+	small: IconDimensionSnapshot,
+): void {
+	const base = baseline[name].width;
+	const largeWidth = large[name].width;
+	const smallWidth = small[name].width;
+	if (!(largeWidth > base * 1.35)) {
+		failures.push(`${name}: large dimension should grow with sidebar font size (baseline=${base.toFixed(2)}px, large=${largeWidth.toFixed(2)}px)`);
+	}
+	if (!(smallWidth < base * 0.9)) {
+		failures.push(`${name}: small dimension should shrink with sidebar font size (baseline=${base.toFixed(2)}px, small=${smallWidth.toFixed(2)}px)`);
+	}
+}
+
+async function measureCollapsedChevronDimension(page: Page): Promise<{ width: number; height: number }> {
+	return page.evaluate(() => {
+		const collapsed = document.querySelector<HTMLElement>("[data-testid='sidebar-collapsed']");
+		if (!collapsed) throw new Error("missing collapsed sidebar for chevron measurement");
+		const chevron = collapsed.querySelector<HTMLElement>("button[title] span:first-child");
+		if (!chevron) throw new Error("missing collapsed sidebar disclosure chevron");
+		const rect = chevron.getBoundingClientRect();
+		return { width: rect.width, height: rect.height };
+	});
+}
+
+async function measureHorizontalOverflow(page: Page): Promise<OverflowSnapshot> {
+	return page.evaluate(() => {
+		const roots = Array.from(document.querySelectorAll<HTMLElement>("[data-testid='sidebar-expanded'], [data-testid='sidebar-collapsed']"));
+		const items: Array<{ label: string; scrollWidth: number; clientWidth: number; overflow: number }> = [];
+		for (const root of roots) {
+			const label = root.dataset.testid || "sidebar-root";
+			items.push({ label, scrollWidth: root.scrollWidth, clientWidth: root.clientWidth, overflow: root.scrollWidth - root.clientWidth });
+			const scroller = root.querySelector<HTMLElement>(".overflow-y-auto");
+			if (scroller) items.push({ label: `${label} scroller`, scrollWidth: scroller.scrollWidth, clientWidth: scroller.clientWidth, overflow: scroller.scrollWidth - scroller.clientWidth });
+		}
+		return items;
+	});
+}
+
+async function measureGoalActionGaps(page: Page, goalId: string, prUrl: string): Promise<ActionGapSnapshot> {
+	const row = page.locator(`[data-nav-id="goal:${goalId}"]`).first();
+	await row.hover();
+	await expect(row.locator(".sidebar-actions").first()).toHaveCSS("opacity", "1", { timeout: 5_000 });
+	return page.evaluate(({ gid, url }) => {
+		const row = document.querySelector<HTMLElement>(`[data-nav-id="goal:${gid}"]`);
+		if (!row) throw new Error(`missing goal row for gap measurement: ${gid}`);
+		const prSvg = row.querySelector<SVGGraphicsElement>(`a[href="${url}"] svg`);
+		const actionSvgs = Array.from(row.querySelectorAll<SVGGraphicsElement>(".sidebar-actions button svg"));
+		if (!prSvg || actionSvgs.length < 2) {
+			throw new Error(`missing PR/action icons for gap measurement: pr=${!!prSvg}, actions=${actionSvgs.length}`);
+		}
+		const pr = prSvg.getBoundingClientRect();
+		const first = actionSvgs[0].getBoundingClientRect();
+		const second = actionSvgs[1].getBoundingClientRect();
+		const prToFirstAction = first.left - pr.right;
+		const firstToSecondAction = second.left - first.right;
+		return { prToFirstAction, firstToSecondAction, delta: Math.abs(prToFirstAction - firstToSecondAction) };
+	}, { gid: goalId, url: prUrl });
+}
+
 test.describe("Sidebar font scale (full-stack UI)", () => {
+	test("sidebar icons, chevrons, overflow, and action gaps follow sidebar font size @repro", async ({ page }) => {
+		const project = await defaultProject();
+		const tag = Date.now();
+		const staffName = `FontScaleStaff${tag}`;
+		const prUrl = `https://github.com/acme/sidebar-font-scale/pull/${tag}`;
+		let goalId: string | undefined;
+		let sessionId: string | undefined;
+		let staffId: string | undefined;
+
+		try {
+			const goal = await createGoal({ title: `FontScaleGoal${tag}`, projectId: project.id, cwd: project.rootPath, worktree: false, team: false });
+			goalId = goal.id as string;
+			sessionId = await createSession({ projectId: project.id, cwd: project.rootPath });
+			const staff = await createStaffAgent(project, staffName);
+			staffId = staff.id;
+
+			await openApp(page);
+			await resetSidebarVisualState(page, goalId);
+			await page.reload();
+			await waitForSidebarFixture(page, goalId, staffName);
+			await applySidebarFontSizePx(page, 14);
+
+			const baseline = await measureIconDimensions(page, goalId);
+			expect(baseline.rootFontSize).toBeCloseTo(14, 1);
+
+			await applySidebarFontSizePx(page, 24);
+			const large = await measureIconDimensions(page, goalId);
+			expect(large.rootFontSize).toBeCloseTo(24, 1);
+
+			await applySidebarFontSizePx(page, MIN_PX);
+			const small = await measureIconDimensions(page, goalId);
+			expect(small.rootFontSize).toBeCloseTo(MIN_PX, 1);
+
+			const failures: string[] = [];
+			for (const name of [
+				"newGoalIcon",
+				"projectAddGoalBox",
+				"projectAddGoalPlus",
+				"addSessionBox",
+				"addSessionPlus",
+				"addStaffBox",
+				"addStaffPlus",
+				"expandedDisclosureChevron",
+				"rolePickerChevron",
+			] satisfies IconDimensionName[]) {
+				assertDimensionScales(failures, name, baseline, large, small);
+			}
+
+			for (const px of [MIN_PX, MAX_PX]) {
+				await applySidebarFontSizePx(page, px);
+				for (const item of await measureHorizontalOverflow(page)) {
+					if (item.overflow > 2) {
+						failures.push(`${item.label}: horizontal overflow at ${px}px (scrollWidth=${item.scrollWidth}, clientWidth=${item.clientWidth})`);
+					}
+				}
+			}
+
+			await page.evaluate(() => localStorage.setItem("bobbit-sidebar-collapsed", "true"));
+			await page.reload();
+			await expect(page.locator("[data-testid='sidebar-collapsed']")).toBeVisible({ timeout: 15_000 });
+			await applySidebarFontSizePx(page, 14);
+			const collapsedBaseline = { ...baseline, collapsedDisclosureChevron: await measureCollapsedChevronDimension(page) };
+			await applySidebarFontSizePx(page, 24);
+			const collapsedLarge = { ...large, collapsedDisclosureChevron: await measureCollapsedChevronDimension(page) };
+			await applySidebarFontSizePx(page, MIN_PX);
+			const collapsedSmall = { ...small, collapsedDisclosureChevron: await measureCollapsedChevronDimension(page) };
+			assertDimensionScales(failures, "collapsedDisclosureChevron", collapsedBaseline, collapsedLarge, collapsedSmall);
+
+			for (const px of [MIN_PX, MAX_PX]) {
+				await applySidebarFontSizePx(page, px);
+				for (const item of await measureHorizontalOverflow(page)) {
+					if (item.overflow > 2) {
+						failures.push(`${item.label}: horizontal overflow at ${px}px collapsed (scrollWidth=${item.scrollWidth}, clientWidth=${item.clientWidth})`);
+					}
+				}
+			}
+
+			await page.evaluate(() => localStorage.removeItem("bobbit-sidebar-collapsed"));
+			await page.reload();
+			await waitForSidebarFixture(page, goalId, staffName);
+			await applySidebarFontSizePx(page, 14);
+			await page.evaluate(({ gid, url }) => {
+				const state: any = (window as any).bobbitState ?? (window as any).__bobbitState;
+				if (state?.sessionPollTimer) {
+					clearInterval(state.sessionPollTimer);
+					state.sessionPollTimer = null;
+				}
+				state.prStatusCache.set(gid, { state: "OPEN", url, number: 42 });
+				state.gateStatusCache.set(gid, { passed: 1, total: 1, verifying: false, verifyingCount: 0, awaitingSignoffCount: 0, awaitingHumanSignoff: false, runningGateIds: [], gates: [] });
+				(window as any).__bobbitRenderApp?.();
+			}, { gid: goalId, url: prUrl });
+			await expect(page.locator(`[data-nav-id="goal:${goalId}"] a[href="${prUrl}"]`).first()).toBeVisible({ timeout: 5_000 });
+			const gaps = await measureGoalActionGaps(page, goalId, prUrl);
+			if (gaps.delta > 2) {
+				failures.push(`goal action row: PR-to-action gap should match action-to-action gap (prToFirst=${gaps.prToFirstAction.toFixed(2)}px, actionToAction=${gaps.firstToSecondAction.toFixed(2)}px, delta=${gaps.delta.toFixed(2)}px)`);
+			}
+
+			expect(
+				failures,
+				"SIDEBAR_ICON_SCALE_REGRESSION: sidebar visual icons, chevrons, overflow, and action gaps must follow sidebar font size",
+			).toEqual([]);
+		} finally {
+			if (staffId) await apiFetch(`/api/staff/${staffId}`, { method: "DELETE" }).catch(() => {});
+			if (sessionId) await deleteSession(sessionId).catch(() => {});
+			if (goalId) await deleteGoal(goalId).catch(() => {});
+		}
+	});
+
 	test("desktop numeric control scales sidebar, persists, clamps, resets, and leaves main pane unchanged @smoke", async ({ page }) => {
 		await resetScale(page);
 		await navigateToHash(page, "#/settings/system/general");


### PR DESCRIPTION
## Summary

- Add sidebar-scoped scalable icon/chevron utilities and apply them across expanded, collapsed, and mobile/project sidebar paths.
- Scale add-goal/add-staff/add-session compound icons and plus overlays with the sidebar font-size setting.
- Normalize sidebar action row spacing so PR/action gaps match, while preserving vertical scrolling and min/max sidebar density.
- Add E2E regression coverage for desktop, collapsed, mobile/project, overflow, vertical scrolling, and action-gap behavior.
- Document the sidebar affordance scaling design and test expectations.

## Validation

- `npm run check`
- `npm run test:unit`
- `npm run test:e2e:run -- --project=browser tests/e2e/ui/sidebar-font-scale.spec.ts --grep "@repro"`
- Workflow implementation and documentation gates passed.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
