### PR TITLE
Retry sidebar icon scaling

### DIFF
--- a/docs/design/sidebar-font-size-control.md
+++ b/docs/design/sidebar-font-size-control.md
@@ -1,6 +1,12 @@
-# Sidebar font-size numeric control UX check
+# Sidebar font-size control
 
-## Recommendation
+## Purpose
+
+The **System Settings → General → Appearance → Sidebar font size** control lets each browser tune sidebar readability without changing chat, header, or other app typography. The setting drives `--sidebar-font-scale` and the `.sidebar-root` font size, so all sidebar text and visual affordances should scale together.
+
+This avoids the previous mismatch where labels grew or shrank but sidebar controls kept fixed-size icons, making chevrons drift, compound plus badges disappear, or action rows overflow at large font sizes.
+
+## Control UX
 
 Use a compact numeric field in **System Settings → General → Appearance**:
 
@@ -10,22 +16,22 @@ Use a compact numeric field in **System Settings → General → Appearance**:
 - Help text: `Controls text size in the sidebar only. Chat, header, and other areas are unchanged. Saved per browser.`
 - Secondary range hint, either in help text or `aria-describedby`: `10–32 px`.
 
-## Reset copy
+### Reset copy
 
-Use explicit copy tied to the new default:
+Use explicit copy tied to the default:
 
 - Button text: **Reset to 14 px**
-- Avoid **Reset to Default** alone; it is ambiguous because existing users may remember the old 12 px default.
+- Avoid **Reset to Default** alone; it is ambiguous because existing users may remember older defaults.
 
-## Clamping behavior
+### Clamping behavior
 
-- Persisted scale values should display as rounded pixels (`scale × 12`, nearest whole px).
+- Persisted scale values display as rounded pixels (`scale × 12`, nearest whole px).
 - On commit (`change`, blur, or Enter), clamp to **10–32 px**, then save `px / 12` to `--sidebar-font-scale`.
 - Do not aggressively clamp every keystroke while the user is typing; partial values like empty, `1`, or `3` should be possible until commit.
-- If an invalid value is committed, restore/clamp visibly in the field rather than leaving a stale invalid number.
+- If an invalid value is committed, restore or clamp visibly in the field rather than leaving a stale invalid number.
 - Optional but helpful: when clamping occurs, briefly expose inline helper text such as `Minimum is 10 px` / `Maximum is 32 px`; do not rely on colour alone.
 
-## Keyboard and accessibility expectations
+### Keyboard and accessibility expectations
 
 - Use a native `input type="number"` with `min="10"`, `max="32"`, `step="1"`, `inputmode="numeric"`, and a visible focus ring matching existing settings inputs.
 - Associate the label with the input via `for`/`id`; connect help/range text with `aria-describedby`.
@@ -34,6 +40,60 @@ Use explicit copy tied to the new default:
 - The px suffix must not be the only unit signal for assistive tech; include “pixels” in accessible text.
 - Reset is a normal button reachable after the input in tab order, with no focus loss after activation.
 
-## Consistency check
+### Visual consistency
 
 Match existing settings primitives: `text-sm font-medium` label, `text-xs text-muted-foreground` help text, rounded bordered background input, tabular numeric value, and link-style muted reset action. Keep this control in the same Appearance group as the existing sidebar font-size setting; do not introduce a new section or slider-like visual pattern.
+
+## Scaled sidebar affordances
+
+The font-size setting applies to sidebar visual affordances, not just labels. Sidebar-only icon utilities should use `em` sizing or sidebar-scoped CSS custom properties under `.sidebar-root`; do not change global icon defaults.
+
+Affordances expected to scale with the sidebar font size:
+
+- Top action icons, including Roles, Tools, Skills, Workflows, Market, and New Goal.
+- Compound New Goal, New Session, and New Staff icons, including their plus overlays.
+- Disclosure chevrons for project, sessions/ungrouped sessions, staff, goals, team leads, live sessions, child sessions, archived sessions, and archived sections.
+- Collapsed-sidebar affordances, including collapsed goal, team-lead, Sessions, Staff, and archived chevrons.
+- Mobile sidebar/header affordances, including project/staff/session chevrons and role-picker chevrons.
+
+Compound icons must keep the base icon and plus overlay as separate visible elements. The compound container should allow overflow so the badge is not clipped, and the plus overlay should remain visible at every supported font size.
+
+Chevrons should remain centered in their row/control and visually attached to the disclosure target. Expanded desktop rows can keep their absolute-left slot model; mobile and collapsed layouts should use inline/flex slots so alignment follows the row.
+
+## Spacing and overflow behavior
+
+Sidebar action rows should use one sidebar-scoped gap source for related affordances. In rows with PR shortcuts plus regular quick actions, the gap between the PR icon and the first action should match the gap between adjacent actions.
+
+At all supported sidebar font sizes:
+
+- Expanded, collapsed, and mobile sidebars should avoid horizontal scrolling.
+- Top and bottom action rows may truncate labels or use flexible button sizing, but icons should remain visible and usable.
+- Scaling should preserve click target usability and layout density; avoid broad sidebar selectors that clip generic spans or SVGs.
+
+## Implementation guardrails
+
+- Keep scaling styles opt-in and scoped to `.sidebar-root`.
+- Prefer explicit classes for scalable icons, compound icon boxes, plus overlays, chevron slots/glyphs, and action clusters.
+- Do not introduce broad selectors such as generic `.sidebar-root svg`, `.sidebar-root button > span`, or overflow rules that can hide nested compound badges.
+- Keep numeric constants used for layout arithmetic separate from CSS custom properties unless every consumer is audited.
+- Do not affect icon sizing outside the sidebar.
+
+## QA and regression coverage
+
+Focused browser E2E coverage lives in `tests/e2e/ui/sidebar-font-scale.spec.ts`. It should cover both the setting and real sidebar affordances:
+
+- The setting persists, clamps to the supported range, and updates `.sidebar-root` font size.
+- Representative top action icons, compound icons, plus overlays, chevrons, and role-picker chevrons grow when the sidebar font size increases.
+- New Goal, New Session, and New Staff plus overlays are present, non-zero sized, visible, and positioned over their base icons.
+- Representative chevrons stay centered relative to their rows/controls.
+- Collapsed-sidebar affordances scale and remain overflow-safe.
+- PR/action-row gap equality is asserted within a small tolerance.
+- Expanded/collapsed sidebar states do not horizontally overflow at small and large supported font sizes.
+
+Recommended verification for sidebar font-size changes:
+
+```bash
+npm run check
+npm run test:unit
+npx playwright test tests/e2e/ui/sidebar-font-scale.spec.ts --reporter=line
+```

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -35,6 +35,32 @@ bell-toggle button {
 	--sidebar-chevron-glyph-size: 1.2em;
 	--sidebar-chevron-glyph-size-sm: 1.1em;
 	--sidebar-action-gap: 0.125em;
+	--sidebar-top-action-gap: 0.2em;
+}
+
+.sidebar-root .sidebar-top-action-row {
+	display: flex;
+	align-items: stretch;
+	gap: var(--sidebar-top-action-gap);
+	min-width: 0;
+	max-width: 100%;
+}
+
+.sidebar-root .sidebar-top-action-btn {
+	flex: 1 1 0;
+	min-width: 0;
+	max-width: 100%;
+	overflow: hidden;
+	gap: min(0.25em, 0.375rem);
+	padding-left: min(0.375em, 0.5rem);
+	padding-right: min(0.375em, 0.5rem);
+}
+
+.sidebar-root .sidebar-top-action-label {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .sidebar-root .sidebar-scale-icon,
@@ -150,9 +176,52 @@ bell-toggle button {
 	gap: var(--sidebar-action-gap);
 }
 
+.sidebar-root[data-testid="sidebar-collapsed"] {
+	width: max(3.5rem, 3.75em);
+}
+
 .sidebar-root .sidebar-collapsed-label {
 	min-width: 0;
 	overflow: hidden;
+	white-space: nowrap;
+}
+
+.sidebar-root [data-session-id] .truncate,
+.sidebar-root [data-nav-id^="session:"] .truncate {
+	display: block;
+	min-width: 0;
+	max-width: 100%;
+}
+
+.sidebar-root .sidebar-bottom-actions {
+	min-width: 0;
+	max-width: 100%;
+}
+
+.sidebar-root .sidebar-bottom-actions > button {
+	min-width: 0;
+	overflow: hidden;
+	gap: min(0.25em, 0.375rem);
+	padding-left: min(0.5em, 0.75rem);
+	padding-right: min(0.5em, 0.75rem);
+}
+
+.sidebar-root .sidebar-bottom-actions [data-testid="sidebar-filters-button"],
+.sidebar-root .sidebar-bottom-action-text {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.sidebar-root .sidebar-bottom-actions [data-testid="sidebar-filters-button"] {
+	flex: 1 1 0;
+}
+
+.sidebar-root .sidebar-bottom-actions [data-testid="sidebar-filters-button"] > span {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
 	white-space: nowrap;
 }
 
@@ -283,10 +352,10 @@ details.wf-proposal-workflow .wf-proposal-gates {
  * overlap — unlike the previous `::after` inflation attempt (reverted in
  * dd428416) where adjacent buttons ate into each other.
  *
- * Excluded: `.flex-1` tab buttons in the top tab strip (Roles / Tools /
- * Skills / Workflows / New Goal) — they already fill their row.
+ * Excluded: top tab strip buttons (Roles / Tools / Skills / Workflows /
+ * New Goal) — they already fill their row.
  */
-.sidebar-root button:not(.flex-1) {
+.sidebar-root button:not(.flex-1):not(.sidebar-top-action-btn) {
 	border: 0.5px solid transparent;
 }
 

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -19,6 +19,143 @@ bell-toggle button {
 	color: var(--color-muted-foreground) !important;
 }
 
+/* Sidebar icon affordances that opt in here scale from .sidebar-root font-size.
+ * Keep selectors narrow so compound plus overlays are never clipped by generic
+ * sidebar SVG/span rules. */
+.sidebar-root {
+	--sidebar-scale-icon-size: 1em;
+	--sidebar-compound-icon-size: 1em;
+	--sidebar-compound-icon-size-lg: 1.1429em;
+	--sidebar-compound-plus-size: 0.58em;
+	--sidebar-compound-plus-size-lg: 0.6429em;
+	--sidebar-chevron-w: 1.25em;
+	--sidebar-header-chevron-w: 1.7em;
+	--sidebar-inline-chevron-w: 1.25em;
+	--sidebar-collapsed-chevron-w: 1.2em;
+	--sidebar-chevron-glyph-size: 1.2em;
+	--sidebar-chevron-glyph-size-sm: 1.1em;
+	--sidebar-action-gap: 0.125em;
+}
+
+.sidebar-root .sidebar-scale-icon,
+.sidebar-root .sidebar-compound-icon,
+.sidebar-root .sidebar-chevron-slot {
+	box-sizing: border-box;
+}
+
+.sidebar-root .sidebar-scale-icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: var(--sidebar-scale-icon-size);
+	height: var(--sidebar-scale-icon-size);
+	min-width: var(--sidebar-scale-icon-size);
+	line-height: 1;
+	vertical-align: -0.125em;
+}
+
+.sidebar-root .sidebar-scale-icon > svg,
+.sidebar-root svg.sidebar-scale-icon {
+	width: 100% !important;
+	height: 100% !important;
+}
+
+.sidebar-root .sidebar-compound-icon {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: var(--sidebar-compound-icon-size);
+	height: var(--sidebar-compound-icon-size);
+	min-width: var(--sidebar-compound-icon-size);
+	line-height: 1;
+	overflow: visible;
+	vertical-align: -0.125em;
+}
+
+.sidebar-root .sidebar-compound-icon--lg {
+	width: var(--sidebar-compound-icon-size-lg);
+	height: var(--sidebar-compound-icon-size-lg);
+	min-width: var(--sidebar-compound-icon-size-lg);
+}
+
+.sidebar-root .sidebar-compound-base {
+	width: 100% !important;
+	height: 100% !important;
+	min-width: 0 !important;
+}
+
+.sidebar-root .sidebar-compound-plus {
+	position: absolute;
+	right: -0.08em;
+	bottom: -0.02em;
+	width: var(--sidebar-compound-plus-size);
+	height: var(--sidebar-compound-plus-size);
+	overflow: visible;
+	pointer-events: none;
+	filter: drop-shadow(0 0 1.5px var(--background));
+}
+
+.sidebar-root .sidebar-compound-icon--lg .sidebar-compound-plus {
+	width: var(--sidebar-compound-plus-size-lg);
+	height: var(--sidebar-compound-plus-size-lg);
+}
+
+.sidebar-root .sidebar-chevron-slot {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: var(--sidebar-chevron-w);
+	min-width: var(--sidebar-chevron-w);
+	flex: 0 0 var(--sidebar-chevron-w);
+	line-height: 1;
+	text-align: center;
+}
+
+.sidebar-root .sidebar-chevron-slot--header {
+	width: var(--sidebar-header-chevron-w);
+	min-width: var(--sidebar-header-chevron-w);
+	flex-basis: var(--sidebar-header-chevron-w);
+}
+
+.sidebar-root .sidebar-chevron-slot--inline {
+	width: var(--sidebar-inline-chevron-w);
+	min-width: var(--sidebar-inline-chevron-w);
+	flex-basis: var(--sidebar-inline-chevron-w);
+}
+
+.sidebar-root .sidebar-chevron-slot--collapsed {
+	width: var(--sidebar-collapsed-chevron-w);
+	min-width: var(--sidebar-collapsed-chevron-w);
+	flex-basis: var(--sidebar-collapsed-chevron-w);
+}
+
+.sidebar-root .sidebar-chevron-slot--absolute {
+	position: absolute;
+	left: 0;
+	top: 0;
+	bottom: 0;
+}
+
+.sidebar-root .sidebar-chevron-glyph {
+	font-size: var(--sidebar-chevron-glyph-size);
+	line-height: 1;
+}
+
+.sidebar-root .sidebar-chevron-slot--collapsed .sidebar-chevron-glyph {
+	font-size: var(--sidebar-chevron-glyph-size-sm);
+}
+
+.sidebar-root .sidebar-action-cluster {
+	gap: var(--sidebar-action-gap);
+}
+
+.sidebar-root .sidebar-collapsed-label {
+	min-width: 0;
+	overflow: hidden;
+	white-space: nowrap;
+}
+
 /*
  * Mobile header: when [data-mobile-header] is on the root container,
  * add top padding to the message scroll area so the first message

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -534,7 +534,7 @@ function renderSidebarQuickActions(actions: SidebarActionItem[], opts: { kind: S
 				@click=${action.run}
 				title=${action.title || action.label}
 				aria-label=${action.label}
-			>${action.icon}</button>
+			><span class="sidebar-scale-icon">${action.icon}</span></button>
 		`;
 	})}`;
 }
@@ -584,7 +584,7 @@ function renderSidebarActionsTrigger(input: {
 				if (event.key === "ArrowDown" || event.key === "ArrowUp") openFromTrigger(event);
 				else event.stopPropagation();
 			}}
-		>${icon(Menu, "xs")}</button>
+		><span class="sidebar-scale-icon">${icon(Menu, "xs")}</span></button>
 	`;
 }
 
@@ -865,10 +865,10 @@ export function renderProjectArchivedSection(
 				data-nav-id=${archHeaderNavId}
 				data-nav-active=${archHeaderActive ? "true" : "false"}
 				class="relative flex items-center gap-1 pr-1 ${headerPy} w-full text-left ${archHeaderActive ? "bg-secondary text-foreground sidebar-session-active" : (isMobile ? "active:bg-secondary/50" : "hover:bg-secondary/30")} rounded-md transition-colors"
-				style="padding-left:${HEADER_CHEVRON_W}px;"
+				style="padding-left:var(--sidebar-header-chevron-w);"
 				@click=${() => { setArchivedSectionExpanded(project.id, !expanded); renderApp(); }}
 			>
-				<span class="absolute left-0 top-0 bottom-0 flex items-center justify-center text-muted-foreground select-none opacity-60" style="width:${HEADER_CHEVRON_W}px;font-size: 1.1667em;">${expanded ? "▾" : "▸"}</span>
+				<span class="sidebar-chevron-slot sidebar-chevron-slot--header sidebar-chevron-slot--absolute text-muted-foreground select-none opacity-60"><span class="sidebar-chevron-glyph">${expanded ? "▾" : "▸"}</span></span>
 				<span class="shrink-0 text-muted-foreground opacity-60">${icon(Archive, headerSize)}</span>
 				<span class="${labelClass}" style="${labelStyle}">Archived</span>
 			</button>
@@ -933,16 +933,15 @@ export function renderSessionRow(session: GatewaySession) {
 			data-nav-active=${navActive ? "true" : "false"}
 			class="${mobile ? "" : "group relative"} relative flex items-center gap-1 pr-1 ${rowPy} rounded-md cursor-pointer transition-colors
 				${navActive ? `bg-secondary text-foreground sidebar-session-active${hasChildren ? "" : " sidebar-active-no-chevron"}` : connecting ? "bg-secondary/30 text-muted-foreground" : mobile ? "text-muted-foreground active:bg-secondary/50" : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"}"
-			style="padding-left:${CHEVRON_W}px;"
+			style="padding-left:var(--sidebar-chevron-w);"
 			${mobile ? "" : html``}
 			@click=${() => { if (!active && !connecting) connectToSession(session.id, true); }}
 			@auxclick=${(e: MouseEvent) => { if (e.button === 1) { e.preventDefault(); e.stopPropagation(); openSessionInNewWindow(session.id); } }}
 		>
 			${hasChildren ? html`<span
-				class="absolute left-0 top-0 bottom-0 flex items-center justify-center text-muted-foreground select-none cursor-pointer"
-				style="width:${CHEVRON_W}px;font-size: 1em;"
+				class="sidebar-chevron-slot sidebar-chevron-slot--absolute text-muted-foreground select-none cursor-pointer"
 				@click=${(e: Event) => { e.stopPropagation(); if (hasFirstClassChild) toggleFirstClassParentExpanded(session.id); else toggleArchivedParentExpanded(session.id); renderApp(); }}
-			>${childrenExpanded ? "▾" : "▸"}</span>` : ""}
+			><span class="sidebar-chevron-glyph">${childrenExpanded ? "▾" : "▸"}</span></span>` : ""}
 			<div class="shrink-0 flex items-center justify-center ${!active && hasUnseenActivity(session) ? "bobbit-unread-pulse" : ""}">
 				${connecting || preparing
 					? html`<svg class="animate-spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>`
@@ -955,7 +954,7 @@ export function renderSessionRow(session: GatewaySession) {
 				? buttons
 				: html`
 					<span class="group-hover:hidden group-focus-within:hidden absolute right-0 top-0 bottom-0 flex items-center pr-1 pl-8 rounded-r-md" style="background:linear-gradient(to right, transparent 0%, var(--sidebar) 50%);">${renderSessionTime(session, active)}</span>
-					<div class="sidebar-actions absolute right-0 top-0 bottom-0 flex opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto items-center gap-0 pr-1 pl-8 rounded-r-md" style="background:linear-gradient(to right, transparent 0%, var(--sidebar) 50%);">
+					<div class="sidebar-actions sidebar-action-cluster absolute right-0 top-0 bottom-0 flex opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto items-center pr-1 pl-8 rounded-r-md" style="background:linear-gradient(to right, transparent 0%, var(--sidebar) 50%);">
 						${buttons}
 					</div>`}
 		</div>
@@ -1013,15 +1012,14 @@ export function renderArchivedSessionRow(session: GatewaySession, extraChildren 
 			data-nav-active=${active ? "true" : "false"}
 			class="group relative flex items-center gap-1 pr-1 ${rowPy} rounded-md cursor-pointer transition-colors
 				${active ? `bg-secondary text-foreground sidebar-session-active${hasChildren ? "" : " sidebar-active-no-chevron"}` : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"}"
-			style="padding-left:${CHEVRON_W}px; filter:grayscale(1); opacity:0.75;"
+			style="padding-left:var(--sidebar-chevron-w); filter:grayscale(1); opacity:0.75;"
 			@click=${() => connectToSession(session.id, true, { readOnly: true })}
 		>
 			${hasChildren ? html`<span
-				class="absolute left-0 top-0 bottom-0 flex items-center justify-center text-muted-foreground select-none cursor-pointer"
-				style="width:${CHEVRON_W}px;font-size: 1em;"
+				class="sidebar-chevron-slot sidebar-chevron-slot--absolute text-muted-foreground select-none cursor-pointer"
 				@click=${(e: Event) => { e.stopPropagation(); toggleArchivedParentExpanded(session.id); renderApp(); }}
 				title="${expanded ? "Collapse" : "Expand"}"
-			>${expanded ? "▾" : "▸"}</span>` : ""}
+			><span class="sidebar-chevron-glyph">${expanded ? "▾" : "▸"}</span></span>` : ""}
 			<div class="shrink-0 flex items-center justify-center">
 				${statusBobbit("terminated", false, session.id, active, false, session.role === "team-lead", session.role === "coder", session.accessory)}
 			</div>
@@ -1070,11 +1068,10 @@ function renderTeamLeadRow(session: GatewaySession, childCount: number, expanded
 	const buttons = html`${renderSidebarQuickActions(actions, { kind: "session", entityId: session.id, mobile, btnPad })}${renderSidebarActionsTrigger({ kind: "session", entityId: session.id, actions, mobile, btnPad, refresh: actionRefresh, onBeforeOpen: resetSessionForkNewWorktree })}`;
 
 	const chevron = html`<span
-		class="absolute left-0 top-0 bottom-0 flex items-center justify-center text-muted-foreground select-none cursor-pointer"
-		style="width:${CHEVRON_W}px;font-size: 1.1667em;"
+		class="sidebar-chevron-slot sidebar-chevron-slot--absolute text-muted-foreground select-none cursor-pointer"
 		@click=${(e: Event) => { e.stopPropagation(); toggleTeamLeadExpanded(session.id); renderApp(); }}
 		title="${expanded ? "Collapse agents" : "Expand agents"}"
-	>${expanded ? "▾" : "▸"}</span>`;
+	><span class="sidebar-chevron-glyph">${expanded ? "▾" : "▸"}</span></span>`;
 
 	void childCount; // available if needed later
 
@@ -1087,7 +1084,7 @@ function renderTeamLeadRow(session: GatewaySession, childCount: number, expanded
 			data-nav-active=${active ? "true" : "false"}
 			class="${mobile ? "" : "group relative"} relative flex items-center gap-1 pr-1 ${rowPy} rounded-md cursor-pointer transition-colors
 				${active ? "bg-secondary text-foreground sidebar-session-active" : connecting ? "bg-secondary/30 text-muted-foreground" : mobile ? "text-muted-foreground active:bg-secondary/50" : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"}"
-			style="padding-left:${CHEVRON_W}px;"
+			style="padding-left:var(--sidebar-chevron-w);"
 			@click=${() => { if (!active && !connecting) connectToSession(session.id, true); }}
 			@auxclick=${(e: MouseEvent) => { if (e.button === 1) { e.preventDefault(); e.stopPropagation(); openSessionInNewWindow(session.id); } }}
 		>
@@ -1102,7 +1099,7 @@ function renderTeamLeadRow(session: GatewaySession, childCount: number, expanded
 				? buttons
 				: html`
 					<span class="group-hover:hidden group-focus-within:hidden absolute right-0 top-0 bottom-0 flex items-center pr-1 pl-8 rounded-r-md" style="background:linear-gradient(to right, transparent 0%, var(--sidebar) 50%);">${renderSessionTime(session, active)}</span>
-					<div class="sidebar-actions absolute right-0 top-0 bottom-0 flex opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto items-center gap-0 pr-1 pl-8 rounded-r-md" style="background:linear-gradient(to right, transparent 0%, var(--sidebar) 50%);">
+					<div class="sidebar-actions sidebar-action-cluster absolute right-0 top-0 bottom-0 flex opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto items-center pr-1 pl-8 rounded-r-md" style="background:linear-gradient(to right, transparent 0%, var(--sidebar) 50%);">
 						${buttons}
 					</div>`}
 		</div>
@@ -1483,10 +1480,10 @@ export function renderGoalGroup(goal: Goal, opts?: { descendantCount?: number; r
 				data-sidebar-actions-row-root
 				data-nav-id=${goalNavId}
 				data-nav-active=${goalNavActive ? "true" : "false"}
-				style="padding-left:${HEADER_CHEVRON_W}px;"
+				style="padding-left:var(--sidebar-header-chevron-w);"
 				@click=${toggleExpand}
 				@dblclick=${!mobile ? () => { if (goal.team) { const tl = goalSessions.find(s => s.role === "team-lead"); if (tl) connectToSession(tl.id, true); } } : null}>
-				<span class="absolute left-0 top-0 bottom-0 flex items-center justify-center text-muted-foreground select-none" style="width:${HEADER_CHEVRON_W}px;font-size: 1.1667em;" title="${isExpanded ? "Collapse goal" : "Expand goal"}">${isExpanded ? "▾" : "▸"}</span>
+				<span class="sidebar-chevron-slot sidebar-chevron-slot--header sidebar-chevron-slot--absolute text-muted-foreground select-none" title="${isExpanded ? "Collapse goal" : "Expand goal"}"><span class="sidebar-chevron-glyph">${isExpanded ? "▾" : "▸"}</span></span>
 				<span class="shrink-0 text-muted-foreground" style="margin-left:-3px;">${icon(GoalIcon, "xs")}</span>
 				${goal.setupStatus === "preparing" ? html`<svg class="animate-spin shrink-0" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="opacity:0.6"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>` : goal.setupStatus === "error" ? html`<span class="shrink-0" style="color:var(--destructive);font-size:0.8333em;line-height:1;" title="Worktree setup failed">⚠</span>` : ""}
 				<span class="flex-1 min-w-0 truncate text-muted-foreground uppercase tracking-wider font-medium" style="${mobile ? "font-size: 1.1667em;" : "font-size: 0.8333em;"}">${renderHighlightedText(goal.title, state.searchQuery)}${opts?.displayTitleSuffix ? html`<span class="ml-1 text-muted-foreground/60 font-mono normal-case tracking-normal" data-testid="sidebar-goal-title-suffix" title="Disambiguator: this goal shares its title with a sibling.">(${opts.displayTitleSuffix})</span>` : ""}</span>
@@ -1502,7 +1499,7 @@ export function renderGoalGroup(goal: Goal, opts?: { descendantCount?: number; r
 				${renderGoalBadge(goal)}
 				${mobile
 					? goalButtons
-					: html`<div class="sidebar-actions absolute right-0 top-0 bottom-0 flex opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto items-center gap-0 pr-1 pl-8 rounded-r-md" style="background:linear-gradient(to right, transparent 0%, var(--sidebar) 50%);">
+					: html`<div class="sidebar-actions sidebar-action-cluster absolute right-0 top-0 bottom-0 flex opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto items-center pr-1 pl-8 rounded-r-md" style="background:linear-gradient(to right, transparent 0%, var(--sidebar) 50%);">
 						${goalButtons}
 					</div>`}
 			</div>
@@ -1517,7 +1514,7 @@ export function renderGoalGroup(goal: Goal, opts?: { descendantCount?: number; r
 							   still alive — it would be misleading to offer Start Team. */
 							: (isTeamGoal && hasActiveTeam ? nothing : emptyState))
 						: (isTeamGoal ? renderTeamGroup() : displaySessions.map(renderSessionRow))}
-					${isCreatingHere ? html`<div style="padding-left:${CHEVRON_W}px;${mobile ? "" : "font-size: 0.8333em;"}" class="py-1 text-muted-foreground flex items-center gap-1">
+					${isCreatingHere ? html`<div style="padding-left:var(--sidebar-chevron-w);${mobile ? "" : "font-size: 0.8333em;"}" class="py-1 text-muted-foreground flex items-center gap-1">
 						<svg class="animate-spin" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>
 						Creating…
 					</div>` : ""}

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -391,17 +391,17 @@ function renderMobileLanding() {
 						<button class="flex-1 px-1.5 py-1 rounded transition-colors flex items-center justify-center gap-1 ${isRolesActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}" style="font-size: 1.1667em;"
 							title="Manage roles"
 							@click=${() => toggleConfigPage(["roles", "role-edit"], () => { import("./role-manager-page.js").then((m) => m.loadRolePageData()); setHashRoute("roles"); })}>
-							${icon(Users, "xs")} Roles
+							<span class="sidebar-scale-icon">${icon(Users, "xs")}</span> Roles
 						</button>
 						<button class="flex-1 px-1.5 py-1 rounded transition-colors flex items-center justify-center gap-1 ${isToolsActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}" style="font-size: 1.1667em;"
 							title="Manage tools"
 							@click=${() => toggleConfigPage(["tools", "tool-edit"], () => { import("./tool-manager-page.js").then((m) => m.loadToolPageData()); setHashRoute("tools"); })}>
-							${icon(Wrench, "xs")} Tools
+							<span class="sidebar-scale-icon">${icon(Wrench, "xs")}</span> Tools
 						</button>
 						<button class="flex-1 px-1.5 py-1 rounded transition-colors flex items-center justify-center gap-1 ${isSkillsActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}" style="font-size: 1.1667em;"
 							title="View skills"
 							@click=${() => toggleConfigPage(["skills"], () => { import("./skills-page.js").then((m) => m.loadSkillsPageData()); setHashRoute("skills"); })}>
-							${icon(Zap, "xs")} Skills
+							<span class="sidebar-scale-icon">${icon(Zap, "xs")}</span> Skills
 						</button>
 					</div>
 					<div class="flex items-center gap-1">
@@ -413,13 +413,13 @@ function renderMobileLanding() {
 								import("./workflow-page.js").then((m) => m.loadWorkflowPageData());
 								setHashRoute("settings", `${projectId}/workflows`, true);
 							}}>
-							${icon(WorkflowIcon, "xs")} Workflows
+							<span class="sidebar-scale-icon">${icon(WorkflowIcon, "xs")}</span> Workflows
 						</button>
 						<button class="flex-1 px-1.5 py-1 rounded transition-colors flex items-center justify-center gap-1 ${isMarketActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}" style="font-size: 1.1667em;"
 							data-testid="market-nav-button-mobile"
 							title="Marketplace"
 							@click=${() => toggleConfigPage(["market"], () => { import("./marketplace-page.js").then((m) => m.loadMarketplaceData()); setHashRoute("market"); })}>
-							${icon(Store, "xs")} Market
+							<span class="sidebar-scale-icon">${icon(Store, "xs")}</span> Market
 						</button>
 						<button
 							data-new-goal-trigger
@@ -430,7 +430,7 @@ function renderMobileLanding() {
 								startNewGoalFlow(e.currentTarget as HTMLElement);
 							}}
 							title=${state.projects.length === 0 ? "Add a project first" : `New goal${shortcutHint("new-goal")}`}>
-							${icon(GoalIcon, "xs")} New Goal
+							<span class="sidebar-scale-icon" data-testid="sidebar-new-goal-icon">${icon(GoalIcon, "xs")}</span> New Goal
 						</button>
 					</div>
 					`;
@@ -531,7 +531,7 @@ function renderMobileLanding() {
 														data-project-id=${project.id}
 														class="flex items-center gap-1.5 pl-0.5 pr-2 py-0.5 rounded-md cursor-pointer active:bg-secondary/50 transition-colors"
 														@click=${() => { if (isProjectReordering()) return; toggleProjectExpanded(project.id); renderApp(); }}>
-														<span class="text-muted-foreground shrink-0 select-none" style="width:14px;text-align:center;font-size: 1.1667em;">${effectiveExpanded ? "▾" : "▸"}</span>
+														<span class="sidebar-chevron-slot sidebar-chevron-slot--inline text-muted-foreground shrink-0 select-none"><span class="sidebar-chevron-glyph">${effectiveExpanded ? "▾" : "▸"}</span></span>
 														${renderProjectReorderHandle(project)}
 														<span class="shrink-0" style="color:${color};">${icon(FolderOpen, "sm")}</span>
 													<span class="flex-1 text-muted-foreground uppercase tracking-wider font-medium" style="color:${color};font-size: 1.1667em;">${project.name}</span>
@@ -546,9 +546,9 @@ function renderMobileLanding() {
 															@click=${(e: Event) => { e.stopPropagation(); showGoalDialog(undefined, project.id); }}
 															title="New goal in ${project.name}"
 														>
-															<span class="relative inline-flex items-center justify-center" style="width:16px;height:16px;">
-																${icon(GoalIcon, "sm")}
-																<svg viewBox="0 0 10 10" style="position:absolute;bottom:0px;right:-1px;width:9px;height:9px;filter:drop-shadow(0 0 1.5px var(--background));">
+															<span class="sidebar-compound-icon sidebar-compound-icon--lg" data-testid="sidebar-add-goal-icon">
+																${icon(GoalIcon, "sm", "sidebar-compound-base")}
+																<svg data-testid="sidebar-add-goal-plus" class="sidebar-compound-plus" viewBox="0 0 10 10">
 																	<path d="M5 1V9M1 5H9" stroke="${color}" stroke-width="2.5" stroke-linecap="round"/>
 																</svg>
 															</span>
@@ -564,7 +564,7 @@ function renderMobileLanding() {
 													<div class="flex flex-col gap-0.5">
 														${(() => { const _mobileUngroupedExp = isUngroupedExpanded(project.id); return html`<div class="flex items-center gap-1.5 pl-0 pr-2 py-1.5 rounded-md cursor-pointer active:bg-secondary/50 transition-colors"
 															@click=${() => { setUngroupedExpanded(project.id, !_mobileUngroupedExp); renderApp(); }}>
-															<span class="text-muted-foreground shrink-0 select-none" style="width:14px;text-align:center;font-size: 1.1667em;">${_mobileUngroupedExp ? "▾" : "▸"}</span>
+															<span class="sidebar-chevron-slot sidebar-chevron-slot--inline text-muted-foreground shrink-0 select-none"><span class="sidebar-chevron-glyph">${_mobileUngroupedExp ? "▾" : "▸"}</span></span>
 															<span class="shrink-0 text-muted-foreground">${icon(MessagesSquare, "sm")}</span>
 															<span class="flex-1 text-muted-foreground uppercase tracking-wider font-medium" style="font-size: 1.1667em;">Sessions</span>
 															<div class="flex items-center relative">
@@ -574,18 +574,18 @@ function renderMobileLanding() {
 																	@click=${(e: Event) => { e.stopPropagation(); createAndConnectSession(undefined, undefined, project.rootPath, undefined, undefined, project.id); }}
 																	title="New session in ${project.name}"
 																>
-																	<span class="relative inline-flex items-center justify-center" style="width:16px;height:16px;">
-																		${icon(MessagesSquare, "sm")}
-																		<svg viewBox="0 0 10 10" style="position:absolute;bottom:0px;right:-1px;width:9px;height:9px;filter:drop-shadow(0 0 1.5px var(--background));">
-																			<path d="M5 1V9M1 5H9" stroke="${color}" stroke-width="2.5" stroke-linecap="round"/>
-																		</svg>
-																	</span>
+																	<span class="sidebar-compound-icon sidebar-compound-icon--lg" data-testid="sidebar-add-session-icon">
+																							${icon(MessagesSquare, "sm", "sidebar-compound-base")}
+																							<svg data-testid="sidebar-add-session-plus" class="sidebar-compound-plus" viewBox="0 0 10 10">
+																								<path d="M5 1V9M1 5H9" stroke="${color}" stroke-width="2.5" stroke-linecap="round"/>
+																							</svg>
+																						</span>
 																</button>
 																<button
 																	class="p-1.5 rounded text-muted-foreground active:bg-secondary/50 transition-colors"
 																	@click=${(e: Event) => { e.stopPropagation(); toggleRolePicker(e, undefined, { projectId: project.id, projectName: project.name, projectCwd: project.rootPath }); }}
 																	title="New session with role"
-																>${icon(ChevronDown, "sm")}</button>
+																><span class="sidebar-scale-icon">${icon(ChevronDown, "sm")}</span></button>
 																${renderRolePickerDropdown()}
 															</div>
 														</div>

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -387,25 +387,25 @@ function renderMobileLanding() {
 						const isSkillsActive = isRouteActive("skills");
 						const isMarketActive = isRouteActive("market");
 						return html`
-					<div class="flex items-center gap-1">
-						<button class="flex-1 px-1.5 py-1 rounded transition-colors flex items-center justify-center gap-1 ${isRolesActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}" style="font-size: 1.1667em;"
+					<div class="sidebar-top-action-row">
+						<button class="sidebar-top-action-btn px-1.5 py-1 rounded transition-colors flex items-center justify-center ${isRolesActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}" style="font-size: 1.1667em;"
 							title="Manage roles"
 							@click=${() => toggleConfigPage(["roles", "role-edit"], () => { import("./role-manager-page.js").then((m) => m.loadRolePageData()); setHashRoute("roles"); })}>
-							<span class="sidebar-scale-icon">${icon(Users, "xs")}</span> Roles
+							<span class="sidebar-scale-icon">${icon(Users, "xs")}</span><span class="sidebar-top-action-label">Roles</span>
 						</button>
-						<button class="flex-1 px-1.5 py-1 rounded transition-colors flex items-center justify-center gap-1 ${isToolsActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}" style="font-size: 1.1667em;"
+						<button class="sidebar-top-action-btn px-1.5 py-1 rounded transition-colors flex items-center justify-center ${isToolsActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}" style="font-size: 1.1667em;"
 							title="Manage tools"
 							@click=${() => toggleConfigPage(["tools", "tool-edit"], () => { import("./tool-manager-page.js").then((m) => m.loadToolPageData()); setHashRoute("tools"); })}>
-							<span class="sidebar-scale-icon">${icon(Wrench, "xs")}</span> Tools
+							<span class="sidebar-scale-icon">${icon(Wrench, "xs")}</span><span class="sidebar-top-action-label">Tools</span>
 						</button>
-						<button class="flex-1 px-1.5 py-1 rounded transition-colors flex items-center justify-center gap-1 ${isSkillsActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}" style="font-size: 1.1667em;"
+						<button class="sidebar-top-action-btn px-1.5 py-1 rounded transition-colors flex items-center justify-center ${isSkillsActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}" style="font-size: 1.1667em;"
 							title="View skills"
 							@click=${() => toggleConfigPage(["skills"], () => { import("./skills-page.js").then((m) => m.loadSkillsPageData()); setHashRoute("skills"); })}>
-							<span class="sidebar-scale-icon">${icon(Zap, "xs")}</span> Skills
+							<span class="sidebar-scale-icon">${icon(Zap, "xs")}</span><span class="sidebar-top-action-label">Skills</span>
 						</button>
 					</div>
-					<div class="flex items-center gap-1">
-						<button class="flex-1 px-1.5 py-1 rounded transition-colors flex items-center justify-center gap-1 ${isWorkflowsActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}" style="font-size: 1.1667em;"
+					<div class="sidebar-top-action-row">
+						<button class="sidebar-top-action-btn px-1.5 py-1 rounded transition-colors flex items-center justify-center ${isWorkflowsActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}" style="font-size: 1.1667em;"
 							title="Manage workflows"
 							@click=${() => {
 								const projectId = state.activeProjectId || (state.projects[0]?.id ?? null);
@@ -413,24 +413,24 @@ function renderMobileLanding() {
 								import("./workflow-page.js").then((m) => m.loadWorkflowPageData());
 								setHashRoute("settings", `${projectId}/workflows`, true);
 							}}>
-							<span class="sidebar-scale-icon">${icon(WorkflowIcon, "xs")}</span> Workflows
+							<span class="sidebar-scale-icon">${icon(WorkflowIcon, "xs")}</span><span class="sidebar-top-action-label">Workflows</span>
 						</button>
-						<button class="flex-1 px-1.5 py-1 rounded transition-colors flex items-center justify-center gap-1 ${isMarketActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}" style="font-size: 1.1667em;"
+						<button class="sidebar-top-action-btn px-1.5 py-1 rounded transition-colors flex items-center justify-center ${isMarketActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground active:bg-secondary/50'}" style="font-size: 1.1667em;"
 							data-testid="market-nav-button-mobile"
 							title="Marketplace"
 							@click=${() => toggleConfigPage(["market"], () => { import("./marketplace-page.js").then((m) => m.loadMarketplaceData()); setHashRoute("market"); })}>
-							<span class="sidebar-scale-icon">${icon(Store, "xs")}</span> Market
+							<span class="sidebar-scale-icon">${icon(Store, "xs")}</span><span class="sidebar-top-action-label">Market</span>
 						</button>
 						<button
 							data-new-goal-trigger
-							class="flex-1 px-1.5 py-1 rounded transition-colors flex items-center justify-center gap-1 ${state.projects.length === 0 ? 'text-muted-foreground/50 cursor-not-allowed' : 'text-muted-foreground active:bg-secondary/50'}" style="font-size: 1.1667em;"
+							class="sidebar-top-action-btn px-1.5 py-1 rounded transition-colors flex items-center justify-center ${state.projects.length === 0 ? 'text-muted-foreground/50 cursor-not-allowed' : 'text-muted-foreground active:bg-secondary/50'}" style="font-size: 1.1667em;"
 							?disabled=${state.projects.length === 0}
 							@click=${(e: Event) => {
 								if (state.projects.length === 0) { showProjectDialog(); return; }
 								startNewGoalFlow(e.currentTarget as HTMLElement);
 							}}
 							title=${state.projects.length === 0 ? "Add a project first" : `New goal${shortcutHint("new-goal")}`}>
-							<span class="sidebar-scale-icon" data-testid="sidebar-new-goal-icon">${icon(GoalIcon, "xs")}</span> New Goal
+							<span class="sidebar-scale-icon" data-testid="sidebar-new-goal-icon">${icon(GoalIcon, "xs")}</span><span class="sidebar-top-action-label">New Goal</span>
 						</button>
 					</div>
 					`;
@@ -534,7 +534,7 @@ function renderMobileLanding() {
 														<span class="sidebar-chevron-slot sidebar-chevron-slot--inline text-muted-foreground shrink-0 select-none"><span class="sidebar-chevron-glyph">${effectiveExpanded ? "▾" : "▸"}</span></span>
 														${renderProjectReorderHandle(project)}
 														<span class="shrink-0" style="color:${color};">${icon(FolderOpen, "sm")}</span>
-													<span class="flex-1 text-muted-foreground uppercase tracking-wider font-medium" style="color:${color};font-size: 1.1667em;">${project.name}</span>
+													<span class="flex-1 min-w-0 truncate text-muted-foreground uppercase tracking-wider font-medium" style="color:${color};font-size: 1.1667em;">${project.name}</span>
 													<div class="flex items-center gap-2 shrink-0">
 														<button
 															class="p-0.5 rounded-md active:bg-secondary/50 text-muted-foreground transition-colors flex items-center justify-center"
@@ -566,7 +566,7 @@ function renderMobileLanding() {
 															@click=${() => { setUngroupedExpanded(project.id, !_mobileUngroupedExp); renderApp(); }}>
 															<span class="sidebar-chevron-slot sidebar-chevron-slot--inline text-muted-foreground shrink-0 select-none"><span class="sidebar-chevron-glyph">${_mobileUngroupedExp ? "▾" : "▸"}</span></span>
 															<span class="shrink-0 text-muted-foreground">${icon(MessagesSquare, "sm")}</span>
-															<span class="flex-1 text-muted-foreground uppercase tracking-wider font-medium" style="font-size: 1.1667em;">Sessions</span>
+															<span class="flex-1 min-w-0 truncate text-muted-foreground uppercase tracking-wider font-medium" style="font-size: 1.1667em;">Sessions</span>
 															<div class="flex items-center relative">
 																<button
 																	class="p-1.5 rounded text-muted-foreground active:bg-secondary/50 transition-colors relative shrink-0"

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -35,7 +35,7 @@ import { startNewGoalFlow, showProjectPickerPopover } from "./goal-entry.js";
 import { refreshSessions, retryLoadSessions, fetchRoles, fetchStaff, fetchOrphanedStaff, reassignStaffProject, enqueueInboxManual, fetchArchivedSessions, archivedSessionsLoaded, fetchSandboxStatus, fetchArchivedGoalsPaginated, fetchArchivedSessionsPaginated, fetchArchivedSearchGoalsPaginated, fetchArchivedSearchSessionsPaginated, gatewayFetch, clearArchivedSessionsState, clearArchivedSearchState, scheduleArchivedRemoteSearch, fetchProjects, saveProjectOrder } from "./api.js";
 import { errorFromResponse, errorDetails } from "./error-helpers.js";
 import { statusBobbit, sessionAcronym } from "./session-colors.js";
-import { renderGoalGroup, renderSessionRow, SESSION_ROW_PY, INDENT, CHEVRON_W, HEADER_CHEVRON_W, terseRelativeTime, hasUnseenActivity, formatSessionAge, renderSessionTitle, getProjectAccentColor, filterArchivedGoalsByQuery, filterArchivedSessionsByQuery, renderProjectArchivedSection as renderSharedProjectArchivedSection, archivedDivider, bucketActiveArchived, passesSidebarFilters, isChildSession } from "./render-helpers.js";
+import { renderGoalGroup, renderSessionRow, SESSION_ROW_PY, INDENT, HEADER_CHEVRON_W, terseRelativeTime, hasUnseenActivity, formatSessionAge, renderSessionTitle, getProjectAccentColor, filterArchivedGoalsByQuery, filterArchivedSessionsByQuery, renderProjectArchivedSection as renderSharedProjectArchivedSection, archivedDivider, bucketActiveArchived, passesSidebarFilters, isChildSession } from "./render-helpers.js";
 import { renderFiltersButton } from "../ui/components/sidebar-filters.js";
 import { shortcutHint } from "./shortcut-registry.js";
 import type { GatewaySession } from "./state.js";
@@ -977,9 +977,9 @@ export function renderStaffSidebarSection(filteredList?: typeof state.staffList,
 			<div class="relative flex items-center ${mobile ? "gap-1.5 pl-0 pr-2 py-1.5" : "gap-1 pr-1 py-0.5"} rounded-md cursor-pointer ${staffNavActive ? "bg-secondary text-foreground sidebar-session-active" : (mobile ? "active:bg-secondary/50" : "hover:bg-secondary/30")} transition-colors"
 				data-nav-id=${staffNavId}
 				data-nav-active=${staffNavActive ? "true" : "false"}
-				style="${mobile ? "" : `padding-left:${HEADER_CHEVRON_W}px;`}"
+				style="${mobile ? "" : "padding-left:var(--sidebar-header-chevron-w);"}"
 				@click=${() => { setStaffSectionExpanded(projectId || "", !staffExpanded); renderApp(); }}>
-				<span class="${mobile ? "" : "absolute left-0 top-0 bottom-0 flex items-center justify-center"} text-muted-foreground shrink-0 select-none" style="${mobile ? "width:14px;text-align:center;" : `width:${HEADER_CHEVRON_W}px;`}font-size: 1.1667em;">${staffExpanded ? "▾" : "▸"}</span>
+				<span class="sidebar-chevron-slot ${mobile ? "sidebar-chevron-slot--inline" : "sidebar-chevron-slot--header sidebar-chevron-slot--absolute"} text-muted-foreground shrink-0 select-none"><span class="sidebar-chevron-glyph">${staffExpanded ? "▾" : "▸"}</span></span>
 				<span class="shrink-0 text-muted-foreground" style="margin-left:-3px;">${icon(Bot, mobile ? "sm" : "xs")}</span>
 				<span class="flex-1 text-muted-foreground uppercase tracking-wider font-medium" style="font-size: ${mobile ? "1.1667em" : "0.75em"};">Staff</span>
 				<div class="flex items-center" @click=${(e: Event) => e.stopPropagation()}>
@@ -994,9 +994,9 @@ export function renderStaffSidebarSection(filteredList?: typeof state.staffList,
 						@click=${(e: Event) => startNewStaffFlow(e, projectId)}
 						title="New staff agent"
 					>
-						<span class="relative inline-flex items-center justify-center" style="width:${mobile ? "16px" : "12px"};height:${mobile ? "16px" : "12px"};">
-							${icon(Bot, mobile ? "sm" : "xs")}
-							<svg viewBox="0 0 10 10" style="position:absolute;bottom:0px;right:-1px;width:${mobile ? "9px" : "7px"};height:${mobile ? "9px" : "7px"};filter:drop-shadow(0 0 1.5px var(--background));">
+						<span class="sidebar-compound-icon ${mobile ? "sidebar-compound-icon--lg" : ""}" data-testid="sidebar-add-staff-icon">
+							${icon(Bot, mobile ? "sm" : "xs", "sidebar-compound-base")}
+							<svg data-testid="sidebar-add-staff-plus" class="sidebar-compound-plus" viewBox="0 0 10 10">
 								<path d="M5 1V9M1 5H9" stroke="${staffAccentColor}" stroke-width="2.5" stroke-linecap="round"/>
 							</svg>
 						</span>
@@ -1032,7 +1032,7 @@ export function renderStaffSidebarSection(filteredList?: typeof state.staffList,
 					${active ? "bg-secondary text-foreground sidebar-session-active" : mobile ? "text-muted-foreground active:bg-secondary/50" : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"}"
 					data-nav-id=${staffSessionNavId}
 					data-nav-active=${active ? "true" : "false"}
-					style="padding-left:${CHEVRON_W}px;"
+					style="padding-left:var(--sidebar-chevron-w);"
 					@click=${() => handleStaffClick(agent)}>
 					<span class="shrink-0 inline-flex items-center justify-center ${!active && session && hasUnseenActivity(session) ? "bobbit-unread-pulse" : ""}">${statusBobbit(sessionStatus, isCompacting, agent.currentSessionId, active, isAborting, false, false, accessory, false, !active && !!session && hasUnseenActivity(session))}</span>
 					<div class="flex-1 min-w-0 ${mobile ? "flex items-center gap-1" : "truncate"} font-normal"><span class="truncate" style="${mobile ? "font-size: 1.3333em;" : ""}">${renderSessionTitle(agent.name, sessionStatus === "streaming" || sessionStatus === "busy" || isCompacting, state.searchQuery)}</span>${mobile && session ? (() => {
@@ -1045,14 +1045,14 @@ export function renderStaffSidebarSection(filteredList?: typeof state.staffList,
 						})() : ""}</div>
 					${mobile
 						? editBtn
-						: html`<div class="absolute right-0 top-0 bottom-0 flex items-center gap-0 pr-1 pl-8 rounded-r-md" style="background:linear-gradient(to right, transparent 0%, var(--sidebar) 50%);">
+						: html`<div class="absolute right-0 top-0 bottom-0 flex items-center pr-1 pl-8 rounded-r-md" style="background:linear-gradient(to right, transparent 0%, var(--sidebar) 50%);">
 							<span class="group-hover:hidden flex items-center">${session ? (() => {
 								const time = terseRelativeTime(session.lastActivity);
 								if (!time) return "";
 								const unseen = hasUnseenActivity(session);
 								return html`<span class="shrink-0 flex items-center gap-0.5 tabular-nums ${unseen ? "text-foreground/70 font-medium" : "text-muted-foreground/50"}" style="font-size: 0.75em;" title="${formatSessionAge(session.lastActivity)}">${time}${unseen ? html`<span class="unseen-dot" aria-label="unread"></span>` : ""}</span>`;
 							})() : ""}</span>
-							<div class="sidebar-actions hidden group-hover:flex items-center gap-0">
+							<div class="sidebar-actions sidebar-action-cluster hidden group-hover:flex items-center">
 								${editBtn}
 							</div>
 						</div>`}
@@ -1232,7 +1232,7 @@ function renderProjectHeader(project: Project, expanded: boolean) {
 				toggleProjectExpanded(project.id);
 				renderApp();
 			}}>
-			<span class="text-muted-foreground shrink-0 select-none" style="width:12px;text-align:center;font-size: 1.1667em;">${expanded ? "▾" : "▸"}</span>
+			<span class="sidebar-chevron-slot sidebar-chevron-slot--inline text-muted-foreground shrink-0 select-none"><span class="sidebar-chevron-glyph">${expanded ? "▾" : "▸"}</span></span>
 			<span class="project-reorder-slot">${renderProjectReorderHandle(project)}</span>
 			<span class="shrink-0" style="color:${color};">${icon(FolderOpen, "xs")}</span>
 			<span class="flex-1 text-muted-foreground uppercase tracking-wider font-medium" style="color:${color};font-size: 0.75em;">${project.name}</span>
@@ -1251,9 +1251,9 @@ function renderProjectHeader(project: Project, expanded: boolean) {
 				@click=${(e: Event) => { e.stopPropagation(); showGoalDialog(undefined, project.id); }}
 				title="New goal in ${project.name}"
 			>
-				<span class="relative inline-flex" style="width:12px;height:12px;">
-					${icon(GoalIcon, "xs")}
-					<svg viewBox="0 0 10 10" style="position:absolute;bottom:0px;right:-1px;width:7px;height:7px;filter:drop-shadow(0 0 1.5px var(--background));">
+				<span class="sidebar-compound-icon" data-testid="sidebar-add-goal-icon">
+					${icon(GoalIcon, "xs", "sidebar-compound-base")}
+					<svg data-testid="sidebar-add-goal-plus" class="sidebar-compound-plus" viewBox="0 0 10 10">
 						<path d="M5 1V9M1 5H9" stroke="${color}" stroke-width="2.5" stroke-linecap="round"/>
 					</svg>
 				</span>
@@ -1412,9 +1412,9 @@ function renderProjectContent(
 			<div class="relative flex items-center gap-1 pr-1 py-0.5 rounded-md cursor-pointer ${ungActive ? "bg-secondary text-foreground sidebar-session-active" : "hover:bg-secondary/30"} transition-colors"
 				data-nav-id=${ungNavId}
 				data-nav-active=${ungActive ? "true" : "false"}
-				style="padding-left:${HEADER_CHEVRON_W}px;"
+				style="padding-left:var(--sidebar-header-chevron-w);"
 				@click=${() => { setUngroupedExpanded(project.id, !ungroupedExp); renderApp(); }}>
-				<span class="absolute left-0 top-0 bottom-0 flex items-center justify-center text-muted-foreground select-none" style="width:${HEADER_CHEVRON_W}px;font-size: 1.1667em;">${ungroupedExp ? "▾" : "▸"}</span>
+				<span class="sidebar-chevron-slot sidebar-chevron-slot--header sidebar-chevron-slot--absolute text-muted-foreground select-none"><span class="sidebar-chevron-glyph">${ungroupedExp ? "▾" : "▸"}</span></span>
 				<span class="shrink-0 text-muted-foreground" style="margin-left:-3px;">${icon(MessagesSquare, "xs")}</span>
 				<span class="flex-1 text-muted-foreground uppercase tracking-wider font-medium" style="font-size: 0.75em;">Sessions</span>
 				${!isProvisional ? html`
@@ -1426,9 +1426,9 @@ function renderProjectContent(
 						title="New session in ${project.name}"
 						?disabled=${state.creatingSession}
 					>
-						<span class="relative inline-flex items-center justify-center" style="width:12px;height:12px;">
-							${icon(MessagesSquare, "xs")}
-							<svg viewBox="0 0 10 10" style="position:absolute;bottom:0px;right:-1px;width:7px;height:7px;filter:drop-shadow(0 0 1.5px var(--background));">
+						<span class="sidebar-compound-icon" data-testid="sidebar-add-session-icon">
+							${icon(MessagesSquare, "xs", "sidebar-compound-base")}
+							<svg data-testid="sidebar-add-session-plus" class="sidebar-compound-plus" viewBox="0 0 10 10">
 								<path d="M5 1V9M1 5H9" stroke="var(--primary)" stroke-width="2.5" stroke-linecap="round"/>
 							</svg>
 						</span>
@@ -1437,7 +1437,7 @@ function renderProjectContent(
 						class="p-0.5 rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
 						@click=${(e: Event) => { e.stopPropagation(); toggleRolePicker(e, undefined, { projectId: project.id, projectName: project.name, projectCwd: project.rootPath }); }}
 						title="New session with role"
-					>${icon(ChevronDown, "xs")}</button>
+					><span class="sidebar-scale-icon">${icon(ChevronDown, "xs")}</span></button>
 					${renderRolePickerDropdown()}
 				</div>
 				` : ""}
@@ -1492,7 +1492,7 @@ export function renderSidebar() {
 						@click=${() => toggleConfigPage(["roles", "role-edit"], () => { import("./role-manager-page.js").then((m) => m.loadRolePageData()); setHashRoute("roles"); })}
 						title="Manage roles"
 					>
-						${icon(Users, "xs", "!w-3.5 !h-3.5")}
+						<span class="sidebar-scale-icon">${icon(Users, "xs")}</span>
 						<span>Roles</span>
 					</button>
 					<button
@@ -1500,7 +1500,7 @@ export function renderSidebar() {
 						@click=${() => toggleConfigPage(["tools", "tool-edit"], () => { import("./tool-manager-page.js").then((m) => m.loadToolPageData()); setHashRoute("tools"); })}
 						title="Manage tools"
 					>
-						${icon(Wrench, "xs", "!w-3.5 !h-3.5")}
+						<span class="sidebar-scale-icon">${icon(Wrench, "xs")}</span>
 						<span>Tools</span>
 					</button>
 					<button
@@ -1508,7 +1508,7 @@ export function renderSidebar() {
 						@click=${() => toggleConfigPage(["skills"], () => { import("./skills-page.js").then((m) => m.loadSkillsPageData()); setHashRoute("skills"); })}
 						title="View skills"
 					>
-						${icon(Zap, "xs", "!w-3.5 !h-3.5")}
+						<span class="sidebar-scale-icon">${icon(Zap, "xs")}</span>
 						<span>Skills</span>
 					</button>
 				</div>
@@ -1518,7 +1518,7 @@ export function renderSidebar() {
 						@click=${() => toggleConfigPage(["workflows", "workflow-edit"], () => { import("./workflow-page.js").then((m) => m.loadWorkflowPageData()); setHashRoute("workflows"); })}
 						title="Manage workflows"
 					>
-						${icon(Workflow, "xs", "!w-3.5 !h-3.5")}
+						<span class="sidebar-scale-icon">${icon(Workflow, "xs")}</span>
 						<span>Workflows</span>
 					</button>
 					<button
@@ -1527,7 +1527,7 @@ export function renderSidebar() {
 						@click=${() => toggleConfigPage(["market"], () => { import("./marketplace-page.js").then((m) => m.loadMarketplaceData()); setHashRoute("market"); })}
 						title="Marketplace"
 					>
-						${icon(Store, "xs", "!w-3.5 !h-3.5")}
+						<span class="sidebar-scale-icon">${icon(Store, "xs")}</span>
 						<span>Market</span>
 					</button>
 					<button
@@ -1540,7 +1540,7 @@ export function renderSidebar() {
 						}}
 						title=${state.projects.length === 0 ? "Add a project first" : `New goal${shortcutHint("new-goal")}`}
 					>
-						${icon(GoalIcon, "xs", "!w-3.5 !h-3.5")}
+						<span class="sidebar-scale-icon" data-testid="sidebar-new-goal-icon">${icon(GoalIcon, "xs")}</span>
 						<span>New Goal</span>
 					</button>
 				</div>
@@ -1700,7 +1700,7 @@ export function renderSidebar() {
 				` : html`
 					<div class="border-t border-border/30 my-1 mx-2"></div>
 					<button
-						class="flex items-center gap-1 px-1 py-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-secondary/50 transition-colors w-full" style="font-size: 0.8333em; padding-left:${HEADER_CHEVRON_W}px;"
+						class="flex items-center gap-1 px-1 py-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-secondary/50 transition-colors w-full" style="font-size: 0.8333em; padding-left:var(--sidebar-header-chevron-w);"
 						@click=${() => showProjectDialog()}
 						title="Register another project"
 					>
@@ -1800,12 +1800,12 @@ function renderCollapsedSidebar(sortedGoals: Goal[], _ungroupedSessions: Gateway
 
 		return html`
 			<button
-				class="flex items-center gap-0.5 ${SESSION_ROW_PY} px-1 rounded-md transition-colors w-full ${tlActive ? "bg-secondary sidebar-session-active" : "hover:bg-secondary/50"}"
+				class="flex items-center sidebar-action-cluster ${SESSION_ROW_PY} px-1 rounded-md transition-colors w-full ${tlActive ? "bg-secondary sidebar-session-active" : "hover:bg-secondary/50"}"
 				@click=${() => { if (!tlActive) connectToSession(teamLead.id, true); }}
 			>
-				<span class="text-muted-foreground shrink-0 select-none" style="width:8px;text-align:center;cursor:pointer;font-size: 0.75em;"
+				<span class="sidebar-chevron-slot sidebar-chevron-slot--collapsed text-muted-foreground shrink-0 select-none" style="cursor:pointer;"
 					@click=${(e: Event) => { e.stopPropagation(); toggleTeamLeadExpanded(teamLead.id); renderApp(); }}
-				>${children.length > 0 ? (tlExpanded ? "▾" : "▸") : ""}</span>
+				><span class="sidebar-chevron-glyph">${children.length > 0 ? (tlExpanded ? "▾" : "▸") : ""}</span></span>
 				<span class="shrink-0 inline-flex items-center justify-center ${!tlActive && hasUnseenActivity(teamLead) ? "bobbit-unread-pulse" : ""}">${statusBobbit(teamLead.status, teamLead.isCompacting, teamLead.id, tlActive, teamLead.isAborting, true, false, teamLead.accessory, false, !tlActive && hasUnseenActivity(teamLead))}</span>
 				<span class="font-bold tracking-wide ${tlActive ? "text-foreground" : "text-muted-foreground"}" style="font-family: ui-monospace, monospace; line-height: 1; font-size: 0.6667em;">${sessionAcronym(tlTitle)}</span>
 			</button>
@@ -1829,35 +1829,35 @@ function renderCollapsedSidebar(sortedGoals: Goal[], _ungroupedSessions: Gateway
 							return html`
 								${i > 0 ? html`<div class="w-7 border-t border-border/50 my-1.5"></div>` : ""}
 								<button
-									class="flex items-center py-0.5 w-full rounded-md hover:bg-secondary/50 transition-colors" style="gap:0.225rem;"
+									class="flex items-center py-0.5 w-full rounded-md hover:bg-secondary/50 transition-colors sidebar-action-cluster"
 									title=${goal.title}
 									@click=${(e: Event) => { e.stopPropagation(); if (expandedGoals.has(goal.id)) expandedGoals.delete(goal.id); else expandedGoals.add(goal.id); saveExpandedGoals(); renderApp(); }}
 								>
-									<span class="text-muted-foreground shrink-0 select-none" style="width:${CHEVRON_W}px;text-align:center;font-size: 0.9167em;">${expanded ? "▾" : "▸"}</span>
-									<span class="font-extrabold tracking-wider text-muted-foreground" style="font-family: ui-monospace, monospace; line-height: 1; font-size: 0.75em;">${sessionAcronym(goal.title)}</span>
+									<span class="sidebar-chevron-slot sidebar-chevron-slot--collapsed text-muted-foreground shrink-0 select-none"><span class="sidebar-chevron-glyph">${expanded ? "▾" : "▸"}</span></span>
+									<span class="font-extrabold tracking-wider text-muted-foreground sidebar-collapsed-label" style="font-family: ui-monospace, monospace; line-height: 1; font-size: 0.75em;">${sessionAcronym(goal.title)}</span>
 								</button>
 								${expanded ? renderCollapsedGoalSessions(goalSessions, goal) : ""}
 							`;
 						})}
 						${bucket.goals.length > 0 && bucket.sessions.length > 0 ? html`<div class="w-7 border-t border-border/50 my-1.5"></div>` : ""}
 						${bucket.goals.length > 0 && bucket.sessions.length > 0 ? html`<button
-							class="flex items-center py-0.5 w-full rounded-md hover:bg-secondary/50 transition-colors" style="gap:0.225rem;"
+							class="flex items-center py-0.5 w-full rounded-md hover:bg-secondary/50 transition-colors sidebar-action-cluster"
 							title="Ungrouped sessions in ${project.name}"
 							@click=${() => { setUngroupedExpanded(project.id, !_collapsedUngroupedExp); renderApp(); }}
 						>
-							<span class="text-muted-foreground shrink-0 select-none" style="width:${CHEVRON_W}px;text-align:center;font-size: 0.9167em;">${_collapsedUngroupedExp ? "▾" : "▸"}</span>
-							<span class="font-extrabold tracking-wider text-muted-foreground" style="font-family: ui-monospace, monospace; line-height: 1; font-size: 0.75em;">SES</span>
+							<span class="sidebar-chevron-slot sidebar-chevron-slot--collapsed text-muted-foreground shrink-0 select-none"><span class="sidebar-chevron-glyph">${_collapsedUngroupedExp ? "▾" : "▸"}</span></span>
+							<span class="font-extrabold tracking-wider text-muted-foreground sidebar-collapsed-label" style="font-family: ui-monospace, monospace; line-height: 1; font-size: 0.75em;">SES</span>
 						</button>
 						${_collapsedUngroupedExp ? bucket.sessions.map(renderCollapsedSession) : ""}` : bucket.sessions.map(renderCollapsedSession)}
 						${bucket.staff.length > 0 ? html`
 							<div class="w-7 border-t border-border/50 my-1.5"></div>
 							<button
-								class="flex items-center py-0.5 w-full rounded-md hover:bg-secondary/50 transition-colors" style="gap:0.225rem;"
+								class="flex items-center py-0.5 w-full rounded-md hover:bg-secondary/50 transition-colors sidebar-action-cluster"
 								title="Staff in ${project.name}"
 								@click=${() => { setStaffSectionExpanded(project.id, !_collapsedStaffExp); renderApp(); }}
 							>
-								<span class="text-muted-foreground shrink-0 select-none" style="width:${CHEVRON_W}px;text-align:center;font-size: 0.9167em;">${_collapsedStaffExp ? "▾" : "▸"}</span>
-								<span class="font-extrabold tracking-wider text-muted-foreground" style="font-family: ui-monospace, monospace; line-height: 1; font-size: 0.75em;">STAFF</span>
+								<span class="sidebar-chevron-slot sidebar-chevron-slot--collapsed text-muted-foreground shrink-0 select-none"><span class="sidebar-chevron-glyph">${_collapsedStaffExp ? "▾" : "▸"}</span></span>
+								<span class="font-extrabold tracking-wider text-muted-foreground sidebar-collapsed-label" style="font-family: ui-monospace, monospace; line-height: 1; font-size: 0.75em;">STAFF</span>
 							</button>
 							${_collapsedStaffExp ? bucket.staff.map(renderCollapsedSession) : ""}
 						` : ""}
@@ -1871,12 +1871,12 @@ function renderCollapsedSidebar(sortedGoals: Goal[], _ungroupedSessions: Gateway
 						return html`
 							<div class="opacity-60">
 								<button
-									class="flex items-center py-0.5 w-full rounded-md hover:bg-secondary/50 transition-colors" style="gap:0.225rem;"
+									class="flex items-center py-0.5 w-full rounded-md hover:bg-secondary/50 transition-colors sidebar-action-cluster"
 									title=${goal.title}
 									@click=${(e: Event) => { e.stopPropagation(); if (expandedGoals.has(goal.id)) expandedGoals.delete(goal.id); else expandedGoals.add(goal.id); saveExpandedGoals(); renderApp(); }}
 								>
-									<span class="text-muted-foreground shrink-0 select-none" style="width:${CHEVRON_W}px;text-align:center;font-size: 0.9167em;">${expanded ? "▾" : "▸"}</span>
-									<span class="font-extrabold tracking-wider text-muted-foreground" style="font-family: ui-monospace, monospace; line-height: 1; font-size: 0.75em;">${sessionAcronym(goal.title)}</span>
+									<span class="sidebar-chevron-slot sidebar-chevron-slot--collapsed text-muted-foreground shrink-0 select-none"><span class="sidebar-chevron-glyph">${expanded ? "▾" : "▸"}</span></span>
+									<span class="font-extrabold tracking-wider text-muted-foreground sidebar-collapsed-label" style="font-family: ui-monospace, monospace; line-height: 1; font-size: 0.75em;">${sessionAcronym(goal.title)}</span>
 								</button>
 								${expanded ? renderCollapsedGoalSessions(goalSessions, goal) : ""}
 							</div>

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -981,7 +981,7 @@ export function renderStaffSidebarSection(filteredList?: typeof state.staffList,
 				@click=${() => { setStaffSectionExpanded(projectId || "", !staffExpanded); renderApp(); }}>
 				<span class="sidebar-chevron-slot ${mobile ? "sidebar-chevron-slot--inline" : "sidebar-chevron-slot--header sidebar-chevron-slot--absolute"} text-muted-foreground shrink-0 select-none"><span class="sidebar-chevron-glyph">${staffExpanded ? "▾" : "▸"}</span></span>
 				<span class="shrink-0 text-muted-foreground" style="margin-left:-3px;">${icon(Bot, mobile ? "sm" : "xs")}</span>
-				<span class="flex-1 text-muted-foreground uppercase tracking-wider font-medium" style="font-size: ${mobile ? "1.1667em" : "0.75em"};">Staff</span>
+				<span class="flex-1 min-w-0 truncate text-muted-foreground uppercase tracking-wider font-medium" style="font-size: ${mobile ? "1.1667em" : "0.75em"};">Staff</span>
 				<div class="flex items-center" @click=${(e: Event) => e.stopPropagation()}>
 					<button
 						class="${mobile ? "p-2 rounded" : "p-0.5 rounded-md"} text-muted-foreground active:bg-secondary/50 hover:bg-secondary/50 transition-colors"
@@ -1035,7 +1035,7 @@ export function renderStaffSidebarSection(filteredList?: typeof state.staffList,
 					style="padding-left:var(--sidebar-chevron-w);"
 					@click=${() => handleStaffClick(agent)}>
 					<span class="shrink-0 inline-flex items-center justify-center ${!active && session && hasUnseenActivity(session) ? "bobbit-unread-pulse" : ""}">${statusBobbit(sessionStatus, isCompacting, agent.currentSessionId, active, isAborting, false, false, accessory, false, !active && !!session && hasUnseenActivity(session))}</span>
-					<div class="flex-1 min-w-0 ${mobile ? "flex items-center gap-1" : "truncate"} font-normal"><span class="truncate" style="${mobile ? "font-size: 1.3333em;" : ""}">${renderSessionTitle(agent.name, sessionStatus === "streaming" || sessionStatus === "busy" || isCompacting, state.searchQuery)}</span>${mobile && session ? (() => {
+					<div class="flex-1 min-w-0 ${mobile ? "flex items-center gap-1" : "truncate"} font-normal"><span class="block min-w-0 max-w-full truncate" style="${mobile ? "font-size: 1.3333em;" : ""}">${renderSessionTitle(agent.name, sessionStatus === "streaming" || sessionStatus === "busy" || isCompacting, state.searchQuery)}</span>${mobile && session ? (() => {
 							const isActiveSession = sessionStatus === "streaming" || sessionStatus === "busy" || isCompacting;
 							if (isActiveSession) { const _d = (agent.id.charCodeAt(0) % 5) * 1.8; return html`<span class="shrink-0 text-muted-foreground/40" style="font-size: 0.9167em;">·</span><span class="sidebar-active-dot" style="--dot-delay:${_d}s"></span>`; }
 							const time = terseRelativeTime(session.lastActivity);
@@ -1215,7 +1215,7 @@ function renderProjectHeader(project: Project, expanded: boolean) {
 	const reordering = isProjectReordering();
 	const reorderActive = _projectReorderState?.activeId === project.id && _projectReorderState.dragging;
 	return html`
-		<div class="group project-header flex items-center gap-1 pr-1 py-0.5 pl-0.5 rounded-md ${reordering ? "cursor-default" : "cursor-pointer"} ${reorderActive ? "project-reorder-active" : ""} ${navActive ? "bg-secondary text-foreground sidebar-session-active" : "hover:bg-secondary/30"} transition-colors"
+		<div class="group project-header relative flex items-center gap-1 pr-1 py-0.5 rounded-md ${reordering ? "cursor-default" : "cursor-pointer"} ${reorderActive ? "project-reorder-active" : ""} ${navActive ? "bg-secondary text-foreground sidebar-session-active" : "hover:bg-secondary/30"} transition-colors"
 			data-testid="project-header"
 			data-project-id=${project.id}
 			data-project-reorder-id=${project.id}
@@ -1223,6 +1223,7 @@ function renderProjectHeader(project: Project, expanded: boolean) {
 			data-project-reorder-active=${reorderActive ? "true" : "false"}
 			data-nav-id=${navId}
 			data-nav-active=${navActive ? "true" : "false"}
+			style="padding-left:var(--sidebar-header-chevron-w);"
 			@click=${(e: Event) => {
 				if (consumeProjectHeaderReorderClick() || isProjectReordering()) {
 					e.preventDefault();
@@ -1232,10 +1233,10 @@ function renderProjectHeader(project: Project, expanded: boolean) {
 				toggleProjectExpanded(project.id);
 				renderApp();
 			}}>
-			<span class="sidebar-chevron-slot sidebar-chevron-slot--inline text-muted-foreground shrink-0 select-none"><span class="sidebar-chevron-glyph">${expanded ? "▾" : "▸"}</span></span>
+			<span class="sidebar-chevron-slot sidebar-chevron-slot--header sidebar-chevron-slot--absolute text-muted-foreground select-none"><span class="sidebar-chevron-glyph">${expanded ? "▾" : "▸"}</span></span>
 			<span class="project-reorder-slot">${renderProjectReorderHandle(project)}</span>
 			<span class="shrink-0" style="color:${color};">${icon(FolderOpen, "xs")}</span>
-			<span class="flex-1 text-muted-foreground uppercase tracking-wider font-medium" style="color:${color};font-size: 0.75em;">${project.name}</span>
+			<span class="flex-1 min-w-0 truncate text-muted-foreground uppercase tracking-wider font-medium" style="color:${color};font-size: 0.75em;">${project.name}</span>
 			${isProvisional ? html`<span class="text-muted-foreground italic shrink-0" style="font-size: 0.75em;">(setting up)</span>` : html`
 			<button
 				type="button"
@@ -1416,7 +1417,7 @@ function renderProjectContent(
 				@click=${() => { setUngroupedExpanded(project.id, !ungroupedExp); renderApp(); }}>
 				<span class="sidebar-chevron-slot sidebar-chevron-slot--header sidebar-chevron-slot--absolute text-muted-foreground select-none"><span class="sidebar-chevron-glyph">${ungroupedExp ? "▾" : "▸"}</span></span>
 				<span class="shrink-0 text-muted-foreground" style="margin-left:-3px;">${icon(MessagesSquare, "xs")}</span>
-				<span class="flex-1 text-muted-foreground uppercase tracking-wider font-medium" style="font-size: 0.75em;">Sessions</span>
+				<span class="flex-1 min-w-0 truncate text-muted-foreground uppercase tracking-wider font-medium" style="font-size: 0.75em;">Sessions</span>
 				${!isProvisional ? html`
 				<div class="flex items-center relative">
 					<button
@@ -1486,53 +1487,53 @@ export function renderSidebar() {
 			${renderProjectReorderLiveRegion()}
 			<div class="sidebar-resize-handle" @pointerdown=${onSidebarResizePointerDown} @dblclick=${onSidebarResizeDoubleClick} title="Drag to resize (double-click to reset)"></div>
 			<div class="flex flex-col border-b border-border/50 px-0.5 py-1 gap-0.5">
-				<div class="flex items-center">
+				<div class="sidebar-top-action-row">
 					<button
-						class="flex-1 flex items-center justify-center gap-1 px-1 py-1 ${isRolesActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'} rounded-md transition-colors"
+						class="sidebar-top-action-btn flex items-center justify-center px-1 py-1 ${isRolesActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'} rounded-md transition-colors"
 						@click=${() => toggleConfigPage(["roles", "role-edit"], () => { import("./role-manager-page.js").then((m) => m.loadRolePageData()); setHashRoute("roles"); })}
 						title="Manage roles"
 					>
 						<span class="sidebar-scale-icon">${icon(Users, "xs")}</span>
-						<span>Roles</span>
+						<span class="sidebar-top-action-label">Roles</span>
 					</button>
 					<button
-						class="flex-1 flex items-center justify-center gap-1 px-1 py-1 ${isToolsActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'} rounded-md transition-colors"
+						class="sidebar-top-action-btn flex items-center justify-center px-1 py-1 ${isToolsActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'} rounded-md transition-colors"
 						@click=${() => toggleConfigPage(["tools", "tool-edit"], () => { import("./tool-manager-page.js").then((m) => m.loadToolPageData()); setHashRoute("tools"); })}
 						title="Manage tools"
 					>
 						<span class="sidebar-scale-icon">${icon(Wrench, "xs")}</span>
-						<span>Tools</span>
+						<span class="sidebar-top-action-label">Tools</span>
 					</button>
 					<button
-						class="flex-1 flex items-center justify-center gap-1 px-1 py-1 whitespace-nowrap ${isSkillsActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'} rounded-md transition-colors"
+						class="sidebar-top-action-btn flex items-center justify-center px-1 py-1 ${isSkillsActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'} rounded-md transition-colors"
 						@click=${() => toggleConfigPage(["skills"], () => { import("./skills-page.js").then((m) => m.loadSkillsPageData()); setHashRoute("skills"); })}
 						title="View skills"
 					>
 						<span class="sidebar-scale-icon">${icon(Zap, "xs")}</span>
-						<span>Skills</span>
+						<span class="sidebar-top-action-label">Skills</span>
 					</button>
 				</div>
-				<div class="flex items-center">
+				<div class="sidebar-top-action-row">
 					<button
-						class="flex-1 flex items-center justify-center gap-1 px-1 py-1 whitespace-nowrap ${isWorkflowsActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'} rounded-md transition-colors"
+						class="sidebar-top-action-btn flex items-center justify-center px-1 py-1 ${isWorkflowsActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'} rounded-md transition-colors"
 						@click=${() => toggleConfigPage(["workflows", "workflow-edit"], () => { import("./workflow-page.js").then((m) => m.loadWorkflowPageData()); setHashRoute("workflows"); })}
 						title="Manage workflows"
 					>
 						<span class="sidebar-scale-icon">${icon(Workflow, "xs")}</span>
-						<span>Workflows</span>
+						<span class="sidebar-top-action-label">Workflows</span>
 					</button>
 					<button
 						data-testid="market-nav-button"
-						class="flex-1 flex items-center justify-center gap-1 px-1 py-1 whitespace-nowrap ${isMarketActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'} rounded-md transition-colors"
+						class="sidebar-top-action-btn flex items-center justify-center px-1 py-1 ${isMarketActive ? 'text-primary bg-primary/10 font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'} rounded-md transition-colors"
 						@click=${() => toggleConfigPage(["market"], () => { import("./marketplace-page.js").then((m) => m.loadMarketplaceData()); setHashRoute("market"); })}
 						title="Marketplace"
 					>
 						<span class="sidebar-scale-icon">${icon(Store, "xs")}</span>
-						<span>Market</span>
+						<span class="sidebar-top-action-label">Market</span>
 					</button>
 					<button
 						data-new-goal-trigger
-						class="flex-1 flex items-center justify-center gap-1 px-1 py-1 whitespace-nowrap ${state.projects.length === 0 ? 'text-muted-foreground/50 cursor-not-allowed' : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'} rounded-md transition-colors"
+						class="sidebar-top-action-btn flex items-center justify-center px-1 py-1 ${state.projects.length === 0 ? 'text-muted-foreground/50 cursor-not-allowed' : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'} rounded-md transition-colors"
 						?disabled=${state.projects.length === 0}
 						@click=${(e: Event) => {
 							if (state.projects.length === 0) { showProjectDialog(); return; }
@@ -1541,7 +1542,7 @@ export function renderSidebar() {
 						title=${state.projects.length === 0 ? "Add a project first" : `New goal${shortcutHint("new-goal")}`}
 					>
 						<span class="sidebar-scale-icon" data-testid="sidebar-new-goal-icon">${icon(GoalIcon, "xs")}</span>
-						<span>New Goal</span>
+						<span class="sidebar-top-action-label">New Goal</span>
 					</button>
 				</div>
 			</div>
@@ -1709,14 +1710,14 @@ export function renderSidebar() {
 					</button>
 				`}
 			</div>
-			<div class="flex items-center border-t border-border/50">
+			<div class="sidebar-bottom-actions flex items-center border-t border-border/50">
 				${(() => { const isSettings = isRouteActive("settings"); return html`<button
-					class="flex items-center gap-1.5 px-3 py-2 transition-colors ${isSettings ? "text-primary bg-primary/10 font-medium" : "text-muted-foreground hover:text-foreground hover:bg-secondary/50"}"
+					class="flex items-center px-3 py-2 transition-colors ${isSettings ? "text-primary bg-primary/10 font-medium" : "text-muted-foreground hover:text-foreground hover:bg-secondary/50"}"
 					@click=${() => { import("./settings-page.js").then((m) => m.toggleSettings()); }}
 					title=${`Settings${shortcutHint("show-settings")}`}
 				>
 					${icon(Settings, "sm")}
-					<span>Settings</span>
+					<span class="sidebar-bottom-action-text">Settings</span>
 				</button>`; })()}
 				${renderFiltersButton("desktop")}
 				<span class="flex-1"></span>

--- a/tests/e2e/ui/sidebar-font-scale.spec.ts
+++ b/tests/e2e/ui/sidebar-font-scale.spec.ts
@@ -205,6 +205,95 @@ async function measureSidebarVisualAffordances(page: Page, goalTitle?: string): 
 	}, goalTitle);
 }
 
+async function assertSidebarHorizontalFit(page: Page, label: string): Promise<void> {
+	const failures = await page.evaluate(() => {
+		const out: string[] = [];
+		const root = document.querySelector<HTMLElement>('[data-testid="sidebar-expanded"], [data-testid="sidebar-collapsed"], .sidebar-root');
+		if (!root) return ["missing sidebar root"];
+		const rootRect = root.getBoundingClientRect();
+		if (root.scrollWidth > root.clientWidth + 2) {
+			const offenders = Array.from(root.querySelectorAll<HTMLElement>("*"))
+				.map((el) => ({ el, rect: el.getBoundingClientRect() }))
+				.filter(({ rect }) => rect.width > 0 && rect.right > rootRect.right + 1)
+				.slice(0, 5)
+				.map(({ el, rect }) => `${el.tagName.toLowerCase()}.${Array.from(el.classList).slice(0, 4).join(".")} title=${el.getAttribute("title") ?? ""} text=${(el.textContent ?? "").trim().slice(0, 30)} right=${rect.right.toFixed(1)}`);
+			out.push(`sidebar root scrollWidth ${root.scrollWidth} exceeds clientWidth ${root.clientWidth}; offenders: ${offenders.join(" | ")}`);
+		}
+		for (const [i, row] of Array.from(root.querySelectorAll<HTMLElement>(".sidebar-top-action-row")).entries()) {
+			const rowRect = row.getBoundingClientRect();
+			if (row.scrollWidth > row.clientWidth + 2) out.push(`top action row ${i} scrollWidth ${row.scrollWidth} exceeds clientWidth ${row.clientWidth}`);
+			if (rowRect.left < rootRect.left - 1 || rowRect.right > rootRect.right + 1) out.push(`top action row ${i} escapes sidebar bounds`);
+			for (const [j, button] of Array.from(row.querySelectorAll<HTMLElement>("button")).entries()) {
+				const buttonRect = button.getBoundingClientRect();
+				if (buttonRect.width < 24) out.push(`top action row ${i} button ${j} click target too narrow: ${buttonRect.width.toFixed(2)}px`);
+				if (buttonRect.left < rootRect.left - 1 || buttonRect.right > rootRect.right + 1) out.push(`top action row ${i} button ${j} escapes sidebar bounds`);
+			}
+		}
+		return out;
+	});
+	expect(failures, `${label} sidebar large-font horizontal fit`).toEqual([]);
+}
+
+async function assertProjectHeaderChevronAlignment(page: Page): Promise<void> {
+	const alignment = await page.evaluate(() => {
+		const header = document.querySelector<HTMLElement>('[data-testid="project-header"]');
+		const slot = header?.querySelector<HTMLElement>(".sidebar-chevron-slot");
+		if (!header || !slot) return null;
+		const headerRect = header.getBoundingClientRect();
+		const slotRect = slot.getBoundingClientRect();
+		const style = getComputedStyle(header);
+		return {
+			centerDelta: Math.abs((slotRect.top + slotRect.height / 2) - (headerRect.top + headerRect.height / 2)),
+			leftDelta: Math.abs(slotRect.left - headerRect.left),
+			paddingLeft: Number.parseFloat(style.paddingLeft || "0"),
+			slotWidth: slotRect.width,
+			absolute: getComputedStyle(slot).position === "absolute",
+		};
+	});
+	expect(alignment, "project header chevron must be measurable").not.toBeNull();
+	expect(alignment!.absolute, "desktop project chevron uses absolute-left slot").toBe(true);
+	expect(alignment!.centerDelta, "desktop project chevron stays vertically centered").toBeLessThanOrEqual(2);
+	expect(alignment!.leftDelta, "desktop project chevron slot starts at header left edge").toBeLessThanOrEqual(1);
+	expect(alignment!.paddingLeft, "desktop project header reserves matching chevron slot padding").toBeCloseTo(alignment!.slotWidth, 0);
+}
+
+async function assertSidebarActionGaps(page: Page): Promise<void> {
+	const result = await page.evaluate(() => {
+		const root = document.querySelector<HTMLElement>('[data-testid="sidebar-expanded"]');
+		if (!root) return { ok: false, reason: "missing expanded sidebar" };
+		const clusters = Array.from(root.querySelectorAll<HTMLElement>(".sidebar-actions.sidebar-action-cluster"));
+		for (const cluster of clusters) {
+			const children = Array.from(cluster.children).filter((child): child is HTMLElement => child instanceof HTMLElement && child.getBoundingClientRect().width > 0);
+			if (children.length < 3) continue;
+			const rects = children.slice(0, 3).map((child) => child.getBoundingClientRect());
+			return {
+				ok: true,
+				gap01: rects[1].left - rects[0].right,
+				gap12: rects[2].left - rects[1].right,
+				computedGap: Number.parseFloat(getComputedStyle(cluster).columnGap || getComputedStyle(cluster).gap || "0"),
+			};
+		}
+		const fixture = document.createElement("div");
+		fixture.className = "sidebar-actions sidebar-action-cluster";
+		fixture.style.cssText = "position:absolute;left:-9999px;top:0;display:flex;";
+		for (let i = 0; i < 3; i += 1) {
+			const button = document.createElement("button");
+			button.style.cssText = "width:10px;height:10px;padding:0;border:0;";
+			fixture.appendChild(button);
+		}
+		root.appendChild(fixture);
+		const rects = Array.from(fixture.children).map((child) => child.getBoundingClientRect());
+		const computedGap = Number.parseFloat(getComputedStyle(fixture).columnGap || getComputedStyle(fixture).gap || "0");
+		fixture.remove();
+		return { ok: true, gap01: rects[1].left - rects[0].right, gap12: rects[2].left - rects[1].right, computedGap, fixture: true };
+	});
+	expect(result.ok, `sidebar action gap cluster must be measurable: ${"reason" in result ? result.reason : ""}`).toBe(true);
+	if ("gap01" in result) {
+		expect(result.gap01, "PR/action-to-action gap should share one cluster gap").toBeCloseTo(result.gap12, 0);
+		expect(result.gap01, "measured action gap should match computed cluster gap").toBeCloseTo(result.computedGap, 0);
+	}
+}
+
 function assertSidebarAffordancesScale(small: SidebarVisualSnapshot, large: SidebarVisualSnapshot): void {
 	const expectedRatio = large.rootFont / small.rootFont;
 	const minRatio = expectedRatio * 0.85;
@@ -304,6 +393,10 @@ test.describe("Sidebar font scale (full-stack UI)", () => {
 		const expandedSmall = await measureSidebarVisualAffordances(page);
 		await setSidebarFontSizeDirect(page, 24);
 		const expandedLarge = await measureSidebarVisualAffordances(page);
+		await assertProjectHeaderChevronAlignment(page);
+		await assertSidebarActionGaps(page);
+		await setSidebarFontSizeDirect(page, 32);
+		await assertSidebarHorizontalFit(page, "expanded desktop");
 
 		await page.locator("button[title^='Collapse sidebar']").first().click();
 		await expect(page.locator("[data-testid='sidebar-collapsed']")).toBeVisible({ timeout: 5_000 });
@@ -316,6 +409,15 @@ test.describe("Sidebar font scale (full-stack UI)", () => {
 			{ ...expandedSmall, collapsedChevron: collapsedSmall.collapsedChevron },
 			{ ...expandedLarge, collapsedChevron: collapsedLarge.collapsedChevron },
 		);
+		await setSidebarFontSizeDirect(page, 32);
+		await assertSidebarHorizontalFit(page, "collapsed desktop");
+
+		await page.setViewportSize({ width: 375, height: 667 });
+		await page.evaluate(() => localStorage.removeItem("bobbit-sidebar-collapsed"));
+		await page.reload();
+		await expect(page.locator("button").filter({ hasText: /^\s*Roles\s*$/ }).first()).toBeVisible({ timeout: 15_000 });
+		await setSidebarFontSizeDirect(page, 32);
+		await assertSidebarHorizontalFit(page, "mobile");
 	});
 
 	test("desktop numeric control scales sidebar, persists, clamps, resets, and leaves main pane unchanged @smoke", async ({ page }) => {

--- a/tests/e2e/ui/sidebar-font-scale.spec.ts
+++ b/tests/e2e/ui/sidebar-font-scale.spec.ts
@@ -3,6 +3,7 @@
  */
 import { type Locator } from "@playwright/test";
 import { test, expect, type Page } from "../gateway-harness.js";
+import { apiFetch, createGoal, defaultProject, deleteGoal, deleteSession } from "../e2e-setup.js";
 import { openApp, navigateToHash } from "./ui-helpers.js";
 
 const SCALE_KEY = "bobbit:sidebar-font-scale";
@@ -17,6 +18,34 @@ const FONT_SIZE_INPUT_SELECTOR = [
 ].join(", ");
 
 type SidebarMeasure = { rootSize: number; emChildSize: number | null; cssVar: string };
+type VisualMetric = {
+	width: number;
+	height: number;
+	left: number;
+	right: number;
+	top: number;
+	bottom: number;
+	display: string;
+	visibility: string;
+	opacity: number;
+};
+type SidebarVisualSnapshot = {
+	rootFont: number;
+	topNewGoal: VisualMetric | null;
+	addGoalBase: VisualMetric | null;
+	addGoalPlus: VisualMetric | null;
+	addSessionBase: VisualMetric | null;
+	addSessionPlus: VisualMetric | null;
+	addStaffBase: VisualMetric | null;
+	addStaffPlus: VisualMetric | null;
+	projectChevron: VisualMetric | null;
+	rolePickerChevron: VisualMetric | null;
+	collapsedChevron?: VisualMetric | null;
+};
+
+const createdGoalIds = new Set<string>();
+const createdSessionIds = new Set<string>();
+const createdStaffIds = new Set<string>();
 
 function scaleForPx(px: number): number {
 	return px / BASE_PX;
@@ -60,6 +89,164 @@ async function setFontSizePx(page: Page, value: string): Promise<void> {
 	await input.blur();
 }
 
+async function setSidebarFontSizeDirect(page: Page, px: number): Promise<void> {
+	const scale = scaleForPx(px);
+	await page.evaluate(([key, value]) => {
+		localStorage.setItem(key as string, String(value));
+		document.documentElement.style.setProperty("--sidebar-font-scale", String(value));
+	}, [SCALE_KEY, scale]);
+	await waitForScale(page, scale);
+}
+
+async function createSidebarVisualFixture(): Promise<{ goalTitle: string }> {
+	const project = await defaultProject();
+	const token = `IconScale${Date.now()}`;
+	const goal = await createGoal({
+		title: `${token} Goal`,
+		cwd: project.rootPath,
+		projectId: project.id,
+		worktree: false,
+		autoStartTeam: false,
+	});
+	createdGoalIds.add(goal.id);
+
+	const sessionResp = await apiFetch("/api/sessions", {
+		method: "POST",
+		body: JSON.stringify({ title: `${token} Session`, cwd: project.rootPath, projectId: project.id, worktree: false }),
+	});
+	expect(sessionResp.status, `create sidebar fixture session: ${await sessionResp.clone().text()}`).toBe(201);
+	const session = await sessionResp.json();
+	createdSessionIds.add(session.id);
+
+	const staffResp = await apiFetch("/api/staff", {
+		method: "POST",
+		body: JSON.stringify({
+			name: `${token} Staff`,
+			description: "Sidebar icon scaling fixture",
+			systemPrompt: "You are a sidebar icon scaling fixture.",
+			cwd: project.rootPath,
+			projectId: project.id,
+		}),
+	});
+	expect(staffResp.status, `create sidebar fixture staff: ${await staffResp.clone().text()}`).toBe(201);
+	const staff = await staffResp.json();
+	createdStaffIds.add(staff.id);
+	if (staff.currentSessionId) createdSessionIds.add(staff.currentSessionId);
+	return { goalTitle: goal.title as string };
+}
+
+async function resetSidebarVisualState(page: Page, goalTitle: string): Promise<void> {
+	await page.evaluate((title) => {
+		localStorage.removeItem("bobbit-sidebar-collapsed");
+		localStorage.removeItem("bobbit-expanded-projects");
+		localStorage.removeItem("bobbit-collapsed-ungrouped");
+		localStorage.removeItem("bobbit-collapsed-staff");
+		const state = (window as any).bobbitState ?? (window as any).__bobbitState;
+		const goal = state?.goals?.find((g: { title?: string }) => g.title === title);
+		if (goal?.id) localStorage.setItem("bobbit-expanded-goals", JSON.stringify([goal.id]));
+	}, goalTitle);
+	await page.reload();
+	await expect(page.locator("[data-testid='sidebar-expanded']")).toBeVisible({ timeout: 15_000 });
+	await expect(page.locator("button[title^='New goal in']").first()).toBeVisible({ timeout: 10_000 });
+	await expect(page.locator("button[title^='New session in']").first()).toBeVisible({ timeout: 10_000 });
+	await expect(page.locator("button[title^='New staff agent']").first()).toBeVisible({ timeout: 10_000 });
+	await expect(page.getByText(goalTitle, { exact: false }).first()).toBeVisible({ timeout: 10_000 });
+}
+
+async function measureSidebarVisualAffordances(page: Page, goalTitle?: string): Promise<SidebarVisualSnapshot> {
+	return page.evaluate((title) => {
+		const metric = (el: Element | null): VisualMetric | null => {
+			if (!el) return null;
+			const rect = el.getBoundingClientRect();
+			const style = getComputedStyle(el as HTMLElement);
+			return {
+				width: rect.width,
+				height: rect.height,
+				left: rect.left,
+				right: rect.right,
+				top: rect.top,
+				bottom: rect.bottom,
+				display: style.display,
+				visibility: style.visibility,
+				opacity: Number.parseFloat(style.opacity || "1"),
+			};
+		};
+		const first = <T extends Element = Element>(selector: string, root: ParentNode = document): T | null => root.querySelector(selector) as T | null;
+		const compoundParts = (buttonSelector: string) => {
+			const button = first<HTMLButtonElement>(buttonSelector);
+			if (!button) return { base: null, plus: null };
+			const base = first('[data-testid$="-icon"], .sidebar-compound-icon, span', button);
+			const plus = first('[data-testid$="-plus"]', button)
+				?? Array.from(button.querySelectorAll("svg")).at(-1)
+				?? null;
+			return { base: metric(base), plus: metric(plus) };
+		};
+		const addGoal = compoundParts('button[title^="New goal in"]');
+		const addSession = compoundParts('button[title^="New session in"]');
+		const addStaff = compoundParts('button[title^="New staff agent"]');
+		const collapsedButton = title
+			? Array.from(document.querySelectorAll<HTMLButtonElement>('[data-testid="sidebar-collapsed"] button'))
+				.find((button) => button.getAttribute("title") === title)
+			: null;
+		const root = first<HTMLElement>('[data-testid="sidebar-expanded"], [data-testid="sidebar-collapsed"]');
+		return {
+			rootFont: root ? Number.parseFloat(getComputedStyle(root).fontSize) : 0,
+			topNewGoal: metric(first('button[data-new-goal-trigger] [data-testid="sidebar-new-goal-icon"], button[data-new-goal-trigger] .sidebar-scale-icon, button[data-new-goal-trigger] svg')),
+			addGoalBase: addGoal.base,
+			addGoalPlus: addGoal.plus,
+			addSessionBase: addSession.base,
+			addSessionPlus: addSession.plus,
+			addStaffBase: addStaff.base,
+			addStaffPlus: addStaff.plus,
+			projectChevron: metric(first('[data-testid="project-header"] .sidebar-chevron-slot, [data-testid="project-header"] > span:first-child')),
+			rolePickerChevron: metric(first('button[title="New session with role"] .sidebar-scale-icon, button[title="New session with role"] svg')),
+			collapsedChevron: metric(first('span', collapsedButton ?? document)),
+		};
+	}, goalTitle);
+}
+
+function assertSidebarAffordancesScale(small: SidebarVisualSnapshot, large: SidebarVisualSnapshot): void {
+	const expectedRatio = large.rootFont / small.rootFont;
+	const minRatio = expectedRatio * 0.85;
+	const failures: string[] = [];
+	const checkMetric = (label: string, a: VisualMetric | null | undefined, b: VisualMetric | null | undefined) => {
+		if (!a || !b) {
+			failures.push(`${label} missing at one or more sidebar font sizes`);
+			return;
+		}
+		const ratio = b.width / Math.max(a.width, 0.01);
+		if (ratio < minRatio) failures.push(`${label} width did not scale with sidebar font size: ${a.width.toFixed(2)}px -> ${b.width.toFixed(2)}px (ratio ${ratio.toFixed(2)}, expected >= ${minRatio.toFixed(2)})`);
+	};
+	const checkPlus = (label: string, base: VisualMetric | null, plus: VisualMetric | null) => {
+		if (!base || !plus) {
+			failures.push(`${label} plus overlay missing`);
+			return;
+		}
+		if (plus.display === "none" || plus.visibility === "hidden" || plus.opacity <= 0 || plus.width <= 0 || plus.height <= 0) {
+			failures.push(`${label} plus overlay is not visibly rendered`);
+		}
+		const overlaps = plus.left < base.right && plus.right > base.left && plus.top < base.bottom && plus.bottom > base.top;
+		if (!overlaps) failures.push(`${label} plus overlay does not overlap its compound icon box`);
+	};
+
+	expect(large.rootFont / small.rootFont, "sidebar root font size must change before icon scaling assertions").toBeCloseTo(24 / 14, 1);
+	checkMetric("top New Goal icon", small.topNewGoal, large.topNewGoal);
+	checkMetric("project New Goal compound icon box", small.addGoalBase, large.addGoalBase);
+	checkMetric("project New Goal plus overlay", small.addGoalPlus, large.addGoalPlus);
+	checkMetric("New Session compound icon box", small.addSessionBase, large.addSessionBase);
+	checkMetric("New Session plus overlay", small.addSessionPlus, large.addSessionPlus);
+	checkMetric("New Staff compound icon box", small.addStaffBase, large.addStaffBase);
+	checkMetric("New Staff plus overlay", small.addStaffPlus, large.addStaffPlus);
+	checkMetric("expanded project disclosure chevron slot", small.projectChevron, large.projectChevron);
+	checkMetric("role-picker chevron", small.rolePickerChevron, large.rolePickerChevron);
+	if (small.collapsedChevron || large.collapsedChevron) checkMetric("collapsed goal disclosure chevron slot", small.collapsedChevron, large.collapsedChevron);
+	checkPlus("project New Goal", large.addGoalBase, large.addGoalPlus);
+	checkPlus("New Session", large.addSessionBase, large.addSessionPlus);
+	checkPlus("New Staff", large.addStaffBase, large.addStaffPlus);
+
+	expect(failures, `sidebar icon scaling regression: ${failures.join("; ")}`).toEqual([]);
+}
+
 async function measureSidebar(page: Page): Promise<SidebarMeasure> {
 	const result = await page.evaluate(() => {
 		const root = document.querySelector("[data-testid='sidebar-expanded']") as HTMLElement | null;
@@ -99,6 +286,38 @@ async function activityDotSize(page: Page): Promise<number> {
 }
 
 test.describe("Sidebar font scale (full-stack UI)", () => {
+	test.afterEach(async () => {
+		for (const id of createdStaffIds) await apiFetch(`/api/staff/${id}`, { method: "DELETE" }).catch(() => {});
+		createdStaffIds.clear();
+		for (const id of createdSessionIds) await deleteSession(id).catch(() => {});
+		createdSessionIds.clear();
+		for (const id of createdGoalIds) await deleteGoal(id).catch(() => {});
+		createdGoalIds.clear();
+	});
+
+	test("real sidebar visual affordance icons scale with the sidebar font size @repro", async ({ page }) => {
+		const { goalTitle } = await createSidebarVisualFixture();
+		await openApp(page);
+		await resetSidebarVisualState(page, goalTitle);
+
+		await setSidebarFontSizeDirect(page, 14);
+		const expandedSmall = await measureSidebarVisualAffordances(page);
+		await setSidebarFontSizeDirect(page, 24);
+		const expandedLarge = await measureSidebarVisualAffordances(page);
+
+		await page.locator("button[title^='Collapse sidebar']").first().click();
+		await expect(page.locator("[data-testid='sidebar-collapsed']")).toBeVisible({ timeout: 5_000 });
+		await setSidebarFontSizeDirect(page, 14);
+		const collapsedSmall = await measureSidebarVisualAffordances(page, goalTitle);
+		await setSidebarFontSizeDirect(page, 24);
+		const collapsedLarge = await measureSidebarVisualAffordances(page, goalTitle);
+
+		assertSidebarAffordancesScale(
+			{ ...expandedSmall, collapsedChevron: collapsedSmall.collapsedChevron },
+			{ ...expandedLarge, collapsedChevron: collapsedLarge.collapsedChevron },
+		);
+	});
+
 	test("desktop numeric control scales sidebar, persists, clamps, resets, and leaves main pane unchanged @smoke", async ({ page }) => {
 		await resetScale(page);
 		await navigateToHash(page, "#/settings/system/general");


### PR DESCRIPTION
## Summary

- Rebuilds the sidebar icon scaling fix from the reverted baseline.
- Adds sidebar-scoped scalable affordance utilities for top action icons, compound New Goal/New Session/New Staff icons, plus overlays, chevrons, and action-row gaps.
- Preserves compound plus overlays and chevron alignment across expanded, collapsed, and mobile sidebar contexts.
- Adds E2E regression coverage for icon scaling, plus overlay visibility, chevron alignment, action gap equality, and no horizontal overflow at supported sidebar font sizes.
- Documents the sidebar font-size affordance behavior and QA expectations.

## Validation

- `npm run check`
- `npm run build`
- `npm run test:unit` (one unrelated timeout in follow-up run passed on focused retry)
- `npx playwright test tests/e2e/ui/sidebar-font-scale.spec.ts --reporter=line`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
