### PR TITLE
Fix WS frame limit routing

### DIFF
--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -18,6 +18,24 @@ Goal-scoped broadcasts (`gate_*`, `team_*`, `goal_*`) reach viewer sockets only 
 
 Session-list invalidations (`session_created`, `sessions_changed`, and `session_removed`) are global. The browser keeps a lightweight `/ws/viewer` connection open even when no session `RemoteAgent` is active, so desktop sidebars, mobile landing pages, and dashboards can refresh `GET /api/sessions` promptly instead of waiting for the periodic poll. Session sockets also handle the same invalidations for already-open chats. Treat these messages as refresh triggers only; the session list REST response remains the source of truth.
 
+## Frame size routing and limits
+
+Bobbit has separate limits for the socket transport, the chat composer, and Extension Host channel envelopes. They are intentionally layered so normal chat prompts can carry large legitimate payloads while channel traffic stays bounded.
+
+| Limit | Source of truth | Scope | Current default | Why it exists |
+|---|---|---|---|---|
+| WebSocket transport payload | `WS_MAX_PAYLOAD_BYTES` in `src/server/server.ts` | All inbound frames accepted by the gateway WebSocket server | 256 MiB | Keeps the `ws` transport bounded, but high enough that the composer can reject oversized prompt sends with a clear UI error before the socket is torn down. |
+| Composer serialized-send guard | `MessageEditor.MAX_SERIALIZED_SEND_BYTES` in `src/ui/components/MessageEditor.ts` | User prompt sends assembled by the message editor, especially attachment/image sends whose serialized prompt frame can include multiple base64 copies | 200 MiB | Gives users an actionable inline error and preserves the draft/attachments instead of relying on transport-level close behavior. |
+| Extension-channel envelope cap | `MAX_EXTENSION_CHANNEL_WS_ENVELOPE_BYTES` in `src/server/ws/handler.ts` | Authenticated client messages whose `type` is `ext_channel_*` | 1 MiB | Keeps generic Extension Host channel operation envelopes cheap to parse and route; channel handlers still enforce their own contribution quotas. |
+
+Routing rules:
+
+- The first unauthenticated frame is only expected to authenticate. Oversized unauthenticated frames are rejected before command routing to avoid parsing arbitrary large unauthenticated input.
+- After authentication, non-extension session commands such as `prompt`, `steer`, `follow_up`, queue edits, `ext_session_write_permit`, and `ext_session_post` are governed by the WebSocket transport limit plus their feature-specific validation. They are **not** rejected solely because the serialized frame is larger than the 1 MiB extension-channel envelope cap.
+- Prompt frames sent from the browser composer should stay below `MessageEditor.MAX_SERIALIZED_SEND_BYTES`, which is deliberately lower than `WS_MAX_PAYLOAD_BYTES`. This ordering makes the composer error the common failure mode for oversized attachment sends, not a socket close.
+- Extension-channel operations (`ext_channel_open_grant`, `ext_channel_open`, `ext_channel_attach`, `ext_channel_list`, `ext_channel_send`, `ext_channel_close`, `ext_channel_detach`) remain capped by `MAX_EXTENSION_CHANNEL_WS_ENVELOPE_BYTES`. If one is too large, the server returns a structured size error and leaves the socket usable. With a `requestId`, callers receive an `ext_channel_result` or `ext_channel_open_grant_result` failure; without one, the fallback is a normal `error` frame with code `FRAME_TOO_LARGE`.
+- The 1 MiB cap is only an envelope guard. It does not replace per-channel quotas such as declared frame and inbound-byte limits, pack identity checks, open grants, attachment checks, or session-write permits.
+
 ## Client → Server
 
 | Type | Fields | Description |

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -274,10 +274,32 @@ type ExtensionChannelRegistry = {
 };
 
 const MAX_EXTENSION_CHANNEL_WS_ENVELOPE_BYTES = 1024 * 1024;
+const MAX_UNAUTHENTICATED_WS_ENVELOPE_BYTES = 1024 * 1024;
+const EXTENSION_CHANNEL_WS_ENVELOPE_TOO_LARGE_MESSAGE = `Extension channel frame exceeds maximum envelope size (${MAX_EXTENSION_CHANNEL_WS_ENVELOPE_BYTES} bytes)`;
+
+type ExtensionChannelClientMessageType = Extract<ClientMessage, { type: `ext_channel_${string}` }>['type'];
+
+const EXTENSION_CHANNEL_CLIENT_MESSAGE_TYPES: ReadonlySet<ExtensionChannelClientMessageType> = new Set([
+	"ext_channel_open_grant",
+	"ext_channel_open",
+	"ext_channel_attach",
+	"ext_channel_list",
+	"ext_channel_send",
+	"ext_channel_close",
+	"ext_channel_detach",
+]);
 
 function rawWsMessageBytes(data: unknown): number {
 	if (Array.isArray(data)) return data.reduce((sum, part) => sum + rawWsMessageBytes(part), 0);
-	return Buffer.byteLength(data as any);
+	if (typeof data === "string") return Buffer.byteLength(data);
+	if (Buffer.isBuffer(data)) return data.byteLength;
+	if (data instanceof ArrayBuffer) return data.byteLength;
+	if (ArrayBuffer.isView(data)) return data.byteLength;
+	return Buffer.byteLength(String(data));
+}
+
+function isExtensionChannelClientMessageType(type: unknown): type is ExtensionChannelClientMessageType {
+	return typeof type === "string" && EXTENSION_CHANNEL_CLIENT_MESSAGE_TYPES.has(type as ExtensionChannelClientMessageType);
 }
 
 function isHostChannelFrame(frame: unknown): frame is HostChannelFrame {
@@ -323,6 +345,25 @@ export function handleWebSocketConnection(
 		const status = typeof record?.status === "number" ? record.status : undefined;
 		send(ws, { type: "ext_channel_result", requestId, ok: false, error, message, status });
 	};
+	const sendExtChannelEnvelopeTooLarge = (msg: Extract<ClientMessage, { type: `ext_channel_${string}` }>): void => {
+		const requestId = typeof msg.requestId === "string" ? msg.requestId : "";
+		if (!requestId) {
+			send(ws, { type: "error", message: EXTENSION_CHANNEL_WS_ENVELOPE_TOO_LARGE_MESSAGE, code: "FRAME_TOO_LARGE" });
+			return;
+		}
+		if (msg.type === "ext_channel_open_grant") {
+			send(ws, { type: "ext_channel_open_grant_result", requestId, ok: false, error: "FRAME_TOO_LARGE" });
+			return;
+		}
+		send(ws, {
+			type: "ext_channel_result",
+			requestId,
+			ok: false,
+			error: "FRAME_TOO_LARGE",
+			message: EXTENSION_CHANNEL_WS_ENVELOPE_TOO_LARGE_MESSAGE,
+			status: 413,
+		});
+	};
 
 	// 5-second window to authenticate before disconnection
 	const authTimeout = setTimeout(() => {
@@ -332,8 +373,9 @@ export function handleWebSocketConnection(
 	}, 5000);
 
 	ws.on("message", async (data) => {
-		if (rawWsMessageBytes(data) > MAX_EXTENSION_CHANNEL_WS_ENVELOPE_BYTES) {
-			send(ws, { type: "error", message: "WebSocket frame exceeds maximum envelope size", code: "FRAME_TOO_LARGE" });
+		const frameBytes = rawWsMessageBytes(data);
+		if (!authenticated && frameBytes > MAX_UNAUTHENTICATED_WS_ENVELOPE_BYTES) {
+			send(ws, { type: "error", message: "Unauthenticated WebSocket frame exceeds maximum envelope size", code: "FRAME_TOO_LARGE" });
 			return;
 		}
 		let msg: ClientMessage;
@@ -523,6 +565,11 @@ export function handleWebSocketConnection(
 			if (pendingPerm) {
 				send(ws, { type: "tool_permission_needed", ...pendingPerm });
 			}
+			return;
+		}
+
+		if (isExtensionChannelClientMessageType(msg.type) && frameBytes > MAX_EXTENSION_CHANNEL_WS_ENVELOPE_BYTES) {
+			sendExtChannelEnvelopeTooLarge(msg as Extract<ClientMessage, { type: `ext_channel_${string}` }>);
 			return;
 		}
 

--- a/tests/e2e/ws-frame-limit-regression.spec.ts
+++ b/tests/e2e/ws-frame-limit-regression.spec.ts
@@ -1,0 +1,34 @@
+import { expect } from "@playwright/test";
+import { test } from "./in-process-harness.js";
+import { connectWs, createSession, deleteSession, messageEndPredicate } from "./e2e-setup.js";
+
+const EXTENSION_CHANNEL_ENVELOPE_CAP_BYTES = 1024 * 1024;
+
+test.describe("WebSocket frame size routing", () => {
+	test("allows authenticated non-extension prompt frames over the extension-channel envelope cap", async () => {
+		const sessionId = await createSession();
+		try {
+			const conn = await connectWs(sessionId);
+			try {
+				const promptText = "x".repeat(EXTENSION_CHANNEL_ENVELOPE_CAP_BYTES + 1);
+				const cursor = conn.messageCount();
+				conn.send({ type: "prompt", text: promptText });
+
+				const outcome = await conn.waitForFrom(
+					cursor,
+					(m) => m.type === "error" || messageEndPredicate("user")(m),
+					10_000,
+				);
+
+				expect(
+					messageEndPredicate("user")(outcome),
+					`Non-extension prompt frames larger than 1 MiB must not be rejected by the extension-channel envelope guard; received ${JSON.stringify(outcome)}. FRAME_TOO_LARGE means the regression is present.`,
+				).toBe(true);
+			} finally {
+				conn.close();
+			}
+		} finally {
+			await deleteSession(sessionId);
+		}
+	});
+});

--- a/tests/e2e/ws-frame-limit-regression.spec.ts
+++ b/tests/e2e/ws-frame-limit-regression.spec.ts
@@ -31,4 +31,52 @@ test.describe("WebSocket frame size routing", () => {
 			await deleteSession(sessionId);
 		}
 	});
+
+	test("rejects oversized extension-channel frames with a structured result and keeps the socket usable", async () => {
+		const sessionId = await createSession();
+		try {
+			const conn = await connectWs(sessionId);
+			try {
+				const requestId = "oversized-ext-channel-send";
+				const oversizedFrameText = "x".repeat(EXTENSION_CHANNEL_ENVELOPE_CAP_BYTES + 1);
+				const cursor = conn.messageCount();
+				conn.send({
+					type: "ext_channel_send",
+					requestId,
+					channelId: "channel-not-attached",
+					frame: { kind: "text", data: oversizedFrameText },
+				});
+
+				const result = await conn.waitForFrom(
+					cursor,
+					(m) =>
+						(m.type === "ext_channel_result" && m.requestId === requestId) ||
+						m.type === "error",
+					10_000,
+				);
+
+				const structuredFrameTooLargeError =
+					(result.type === "error" &&
+						result.code === "FRAME_TOO_LARGE" &&
+						/WebSocket frame exceeds maximum envelope size|too large|size/i.test(result.message ?? "")) ||
+					(result.type === "ext_channel_result" &&
+						result.requestId === requestId &&
+						result.ok === false &&
+						/FRAME_TOO_LARGE|maximum envelope|too large|size/i.test(`${result.error ?? ""} ${result.message ?? ""}`));
+
+				expect(
+					structuredFrameTooLargeError,
+					`Oversized extension-channel frames must reject with a structured size error instead of closing/crashing; received ${JSON.stringify(result)}`,
+				).toBe(true);
+
+				const pingCursor = conn.messageCount();
+				conn.send({ type: "ping" });
+				await conn.waitForFrom(pingCursor, (m) => m.type === "pong", 5_000);
+			} finally {
+				conn.close();
+			}
+		} finally {
+			await deleteSession(sessionId);
+		}
+	});
 });


### PR DESCRIPTION
## Summary
- Scope the 1 MiB WebSocket envelope guard to extension-channel messages only.
- Keep unauthenticated frames bounded before JSON parsing.
- Add API E2E coverage for large non-extension prompts and oversized extension-channel structured errors.
- Document WebSocket frame-size routing limits.

## Validation
- `npm run build:server && npm run test:e2e:run -- --project=api tests/e2e/ws-frame-limit-regression.spec.ts --workers=1 --retries=0`
- Workflow implementation gate passed full verification.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
