### PR TITLE
Side Panel Buttons

### DIFF
--- a/docs/pr-walkthrough-panel.md
+++ b/docs/pr-walkthrough-panel.md
@@ -507,9 +507,10 @@ workspace. It uses the same shared controls as every side panel: fullscreen,
 collapse/restore, split view, and popout. There is no walkthrough-specific resize
 code path, and no preview-specific localStorage collapse key; size mode persists
 as `sidePanelWorkspace.sizeMode` on the reviewer session and syncs across reloads
-and browser contexts. The shared keyboard shortcuts expand one level
-(`collapsed → split → fullscreen`), collapse one level (`fullscreen → split → collapsed`),
-and toggle fullscreen/collapsed.
+and browser contexts. Shared visible controls and shortcuts expand one level
+(`collapsed → split → fullscreen`) or collapse one level (`fullscreen → split → collapsed`).
+The explicit `Ctrl+#` fullscreen toggle is the only shared control that jumps
+between fullscreen and collapsed.
 
 The panel **never auto-enters fullscreen**. Fullscreen is strictly user-initiated,
 via a toolbar button or one of those shortcuts. This matches the preview panel and
@@ -552,9 +553,8 @@ and the user-terminate control are pinned in the API spec
 real PR through a click, so the spawn/lifecycle assertions live there, not in the
 browser spec).
 Preview panel sizing through the shared side-panel controls is independently pinned by
-`tests/e2e/ui/preview-fullscreen-controls.spec.ts` (preview is one workspace
-panel kind using the same sizing logic as pack, proposal, review, and inbox
-panels). See
+`tests/ui-fixtures/preview-panel.spec.ts` (preview is one workspace panel kind
+using the same sizing logic as pack, proposal, review, and inbox panels). See
 [design/walkthrough-panel-resize-fix.md](design/walkthrough-panel-resize-fix.md)
 for the root-cause analysis and the corrected design.
 

--- a/docs/side-panel-workspace.md
+++ b/docs/side-panel-workspace.md
@@ -154,11 +154,20 @@ The side-panel shell renders every tab kind with the same workspace chrome:
 
 Panel-specific actions remain inside the panel or per-tab action slot. Preview keeps refresh/direct preview behavior; pack panels keep scoped Host API behavior; proposal/review/inbox panels keep their business actions.
 
-Keyboard shortcuts target the active side panel, regardless of kind:
+Size mode is a three-level ladder: `collapsed` (closed), `split` (beside chat), and `fullscreen` (side panel owns the window). The visible window controls move only one level at a time:
+
+- expand/restore from `collapsed` opens `split`;
+- expand from `split` opens `fullscreen`;
+- collapse from `fullscreen` restores `split`;
+- collapse from `split` closes to `collapsed`.
+
+A toolbar control must not jump directly between `fullscreen` and `collapsed`; that jump is reserved for the explicit `Ctrl+#` fullscreen toggle. Labels reflect the target: `Expand` moves upward, `Collapse` moves downward, and `Restore split view` returns from fullscreen to split instead of closing the panel.
+
+Keyboard shortcuts target the active side panel, regardless of kind, and use the same level model:
 
 - expand: `collapsed -> split -> fullscreen`;
 - collapse: `fullscreen -> split -> collapsed`;
-- fullscreen toggle: non-fullscreen -> `fullscreen`, fullscreen -> `collapsed`.
+- fullscreen toggle (`Ctrl+#`): non-fullscreen -> `fullscreen`, fullscreen -> `collapsed`.
 
 ## Popout and deep links
 
@@ -217,6 +226,6 @@ Useful checks:
 - stale localStorage should not change the workspace after `migratedFromLocalStorageAt` is set;
 - preview restart restore should show the active preview tab in the workspace after gateway restart, and a user-closed preview tab should stay absent even while `GET /api/preview/mount` still succeeds.
 
-Regression coverage: `tests/e2e/ui/preview-durable-restart.spec.ts`.
+Regression coverage: `tests/e2e/ui/preview-durable-restart.spec.ts` for restart restore and `tests/ui-fixtures/preview-panel.spec.ts` for one-step visible sizing controls.
 
 Related docs: [architecture.md](architecture.md#side-panel-workspace), [preview-architecture.md](preview-architecture.md#restart-restore), [extension-host-authoring.md](extension-host-authoring.md#panels--persistent-side-panels-hostuiopenpanel), [rest-api.md](rest-api.md#side-panel-workspace), and [websocket-protocol.md](websocket-protocol.md#server--client).

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -2521,13 +2521,17 @@ export function doRenderApp(): void {
 
 	const sidePanelWindowControls = (tab: UnifiedContentTab, mode: SidePanelSizeMode) => {
 		const fullscreenTitle = tab.kind === "preview"
-			? `Fullscreen preview${shortcutHint("toggle-sidebar")}`
-			: `Fullscreen side panel${shortcutHint("toggle-sidebar")}`;
-		const restoreTitle = `Restore side panel${shortcutHint("toggle-sidebar")}`;
+			? `Expand preview to fullscreen${shortcutHint("toggle-sidebar")}`
+			: `Expand side panel to fullscreen${shortcutHint("toggle-sidebar")}`;
+		const restoreTitle = `Restore split view${shortcutHint("toggle-preview")}`;
+		const collapseTarget: SidePanelSizeMode = mode === "fullscreen" ? "split" : "collapsed";
+		const collapseTitle = mode === "fullscreen"
+			? `Collapse to split view${shortcutHint("toggle-preview")}`
+			: `Collapse side panel${shortcutHint("toggle-preview")}`;
 		return html`
 		${mode === "fullscreen" ? html`
 			<button @click=${() => setSidePanelModeAndRender("split")} class=${sidePanelChromeButtonClass} style=${sidePanelChromeButtonStyle} title=${restoreTitle} data-testid="side-panel-restore">
-				${icon(PanelRightOpen, "sm")}
+				${icon(PanelRightClose, "sm")}
 			</button>
 		` : html`
 			<button @click=${() => setSidePanelModeAndRender("fullscreen")} class=${sidePanelChromeButtonClass} style=${sidePanelChromeButtonStyle} title=${fullscreenTitle} data-testid="side-panel-fullscreen">
@@ -2543,7 +2547,7 @@ export function doRenderApp(): void {
 			title="Open side panel in new tab"
 			data-testid="side-panel-popout"
 		>${icon(ExternalLink, "sm")}</a>` : ""}
-		<button @click=${() => setSidePanelModeAndRender("collapsed")} class=${sidePanelChromeButtonClass} style=${sidePanelChromeButtonStyle} title=${`Collapse side panel${shortcutHint("toggle-preview")}`} data-testid="side-panel-collapse">
+		<button @click=${() => setSidePanelModeAndRender(collapseTarget)} class=${sidePanelChromeButtonClass} style=${sidePanelChromeButtonStyle} title=${collapseTitle} data-testid="side-panel-collapse">
 			${icon(PanelRightClose, "sm")}
 		</button>
 	`;

--- a/tests/ui-fixtures/preview-panel.spec.ts
+++ b/tests/ui-fixtures/preview-panel.spec.ts
@@ -67,6 +67,31 @@ async function previewState(page: Page): Promise<any> {
 	return page.evaluate(() => (window as any).__getDynamicPanelWorkspaceState());
 }
 
+type VisibleSidePanelSizeMode = "collapsed" | "split" | "fullscreen" | "unknown";
+
+async function visibleSidePanelSizeMode(page: Page): Promise<VisibleSidePanelSizeMode> {
+	return page.evaluate(() => {
+		const visible = (selector: string): boolean => {
+			const element = document.querySelector(selector) as HTMLElement | null;
+			if (!element) return false;
+			const style = window.getComputedStyle(element);
+			const rect = element.getBoundingClientRect();
+			return style.display !== "none" && style.visibility !== "hidden" && rect.width > 0 && rect.height > 0;
+		};
+		if (visible(".side-panel-fullscreen-prompt")) return "fullscreen";
+		if (visible('[data-testid="side-panel-fullscreen"]')) return "split";
+		if (visible('[data-testid="side-panel-restore"]') && !visible('[data-testid="side-panel-collapse"]')) return "collapsed";
+		return "unknown";
+	}) as Promise<VisibleSidePanelSizeMode>;
+}
+
+async function expectVisibleSidePanelSizeMode(page: Page, expected: VisibleSidePanelSizeMode, message: string): Promise<void> {
+	await expect.poll(async () => visibleSidePanelSizeMode(page), {
+		timeout: 5_000,
+		message: `${message}: expected visible side-panel sizeMode ${expected}; fullscreen collapse must go to split, not collapsed`,
+	}).toBe(expected);
+}
+
 test.describe("Preview panel fixture", () => {
 	test.beforeEach(async ({ page }) => {
 		await loadFixture(page);
@@ -111,6 +136,25 @@ test.describe("Preview panel fixture", () => {
 			timeout: 5_000,
 			message: "fullscreen Refresh should update the iframe cache-buster",
 		}).not.toEqual(refreshedSrc);
+	});
+
+	test("visible side-panel controls move one size level at a time", async ({ page }) => {
+		await setLivePreview(page, "levels.html", hashOf("d"), "level controls");
+
+		await expectVisibleSidePanelSizeMode(page, "split", "live preview should start in split mode");
+
+		await page.getByTestId("side-panel-collapse").click();
+		await expectVisibleSidePanelSizeMode(page, "collapsed", "split collapse should move one level to collapsed");
+		await expect(page.getByTestId("side-panel-restore")).toBeVisible({ timeout: 5_000 });
+
+		await page.getByTestId("side-panel-restore").click();
+		await expectVisibleSidePanelSizeMode(page, "split", "collapsed restore should move one level to split");
+
+		await page.getByTestId("side-panel-fullscreen").click();
+		await expectVisibleSidePanelSizeMode(page, "fullscreen", "split fullscreen expand should move one level to fullscreen");
+
+		await page.getByTestId("side-panel-collapse").click();
+		await expectVisibleSidePanelSizeMode(page, "split", "fullscreen collapse should move one level to split, not collapsed");
 	});
 
 	test("dismissed live preview stays closed until new preview content reopens it", async ({ page }) => {


### PR DESCRIPTION
## Summary
- make visible side-panel expand/collapse controls move one size level at a time
- keep Ctrl+# as the explicit fullscreen/collapsed jump
- add UI fixture coverage for collapsed, split, and fullscreen button transitions
- document shared side-panel sizing semantics

## Tests
- npx playwright test --config tests/playwright.config.ts tests/ui-fixtures/preview-panel.spec.ts --grep "visible side-panel controls move one size level at a time"
- npm run check
- implementation gate: build, type check, repro test, unit, E2E, reviews, QA passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)