### PR TITLE
Bound PR Walkthrough

### DIFF
--- a/docs/pr-walkthrough-durable-reviews.md
+++ b/docs/pr-walkthrough-durable-reviews.md
@@ -40,9 +40,54 @@ read_pr_walkthrough_bundle mode=manifest format=compact limit=50
 read_pr_walkthrough_bundle mode=file path=src/example.ts format=compact hunkOffset=0 hunkLimit=20
 ```
 
-Compact output is lossless for the diff content the legacy bundle returned: file identity/status, hunk headers, context lines, additions, deletions, and truncation indicators are preserved. It omits redundant per-line addressing fields such as line object ids, `old_line`, and `new_line`. Request `format="legacy"` only when exact legacy anchors or per-line metadata are required.
+For non-windowed content, compact output preserves the diff information reviewers need: file identity/status, hunk headers, context lines, additions, deletions, and truncation indicators. It omits redundant per-line addressing fields such as line object ids, `old_line`, and `new_line`. Request `format="legacy"` only when exact legacy anchors or per-line metadata are required.
 
 The compact manifest remains the authoritative envelope read: target metadata, SHAs, stats, warnings, limits, export metadata, and file summaries appear there. Compact follow-up reads (`summary`, `files`, and `file`) include only a short bundle reference plus the requested file or hunk data, so repeated target/changeset/limits blocks do not re-enter the model context.
+
+### Compact file read bounds
+
+`mode=file format=compact` is bounded in two layers so a reviewer cannot accidentally paste a generated bundle into its context window:
+
+1. **Server-side bundle read windowing.** The bundle store first applies the requested `hunkOffset`/`hunkLimit`, then windows the selected hunk bodies by bytes and lines before returning JSON to the tool. Long hunk headers and diff lines are clipped with inline markers; very large hunks stop after the read window is exhausted.
+2. **Compact formatter hard cap.** The extension formatter renders that windowed JSON to unified-diff-like text and enforces a final **64KiB** hard cap before returning model-facing text. It also caps individual compact diff lines and hunk line counts as defense in depth.
+
+Windowing is explicit in the response:
+
+- `truncated=true` means either the hunk page was partial or the read window changed the returned file body.
+- `hunk_truncated=true` is only hunk pagination (`hunkOffset`/`hunkLimit`), so callers can distinguish pagination from byte/line clipping.
+- `read_window` reports whether windowing applied, the configured budgets, returned/omitted line and byte counts, reasons such as `line-bytes`, `line-window`, or `content-bytes`, and guidance for a narrower follow-up read.
+- Windowed files, hunks, and long lines carry `is_truncated` / `truncated` markers plus inline text such as `bundle-store read window` or `bytes omitted`.
+- Manifest and file-list summaries surface the same state: `is_truncated` becomes true when either source truncation or read-window truncation applies, while `source_is_truncated` preserves whether the original parsed diff was already truncated.
+
+If a file needs more inspection, request a more specific slice instead of rereading a broad range:
+
+```text
+read_pr_walkthrough_bundle mode=file path=market-packs/terminal/lib/terminal-panel.js format=compact hunkOffset=0 hunkLimit=1
+```
+
+Use `format="legacy"` only for exact line ids or `old_line` / `new_line` fields; it is not the normal review path.
+
+### Generated and minified artifacts
+
+PR Walkthrough marks generated or low-signal files before they reach reviewer prompts. The generated-path classifier includes:
+
+- built marketplace pack output such as `market-packs/<pack>/lib/**`, including `market-packs/terminal/lib/terminal-panel.js`;
+- minified filenames containing `.min.` across extensions;
+- lockfiles such as npm, pnpm, Yarn, Bun, Cargo, Composer, Gem, Poetry, and similar ecosystem locks;
+- common build/output/generated directories such as `dist`, `build`, `coverage`, `.next`, `generated`, `__generated__`, and snapshots;
+- source names that conventionally indicate generated code, such as protobuf, grpc, designer, generated, or source-map files.
+
+Generated files get `is_generated=true` in manifest/file summaries and a warning that they may be low-signal for review. Path classification is separate from read-window truncation: a normal source file can be `is_truncated=true` because it is too large to return safely, and a generated file can also be windowed if it contains long minified lines.
+
+### Reviewer guidance for low-signal files
+
+Reviewer agents should spend context on source changes that can affect behavior:
+
+- Start with `read_pr_walkthrough_bundle mode=manifest format=compact` and use manifest `generated` / `truncated` flags to plan coverage.
+- Avoid generated, minified, lockfile, build, and bundle artifacts unless they are necessary to prove a user-facing change.
+- Prefer listing those files in the audit `generated_or_binary_files` section over reading their contents.
+- If inspection is necessary, use a path-specific compact read with a very small hunk window, usually `hunkLimit=1`, and stop once there is enough evidence.
+- Do not repeatedly reread large generated/truncated output. Treat `read_window` guidance and inline truncation markers as instructions to narrow the slice, not as a reason to request a broader one.
 
 ### Chunk saves and status
 

--- a/market-packs/pr-walkthrough/roles/pr-reviewer.yaml
+++ b/market-packs/pr-walkthrough/roles/pr-reviewer.yaml
@@ -54,6 +54,8 @@ promptTemplate: |
   You are a read-only PR walkthrough agent.
   Investigate the PR using only read-only tools and report rough percentage progress in chat.
   Start by calling `read_pr_walkthrough_bundle mode=manifest format=compact`; it is the authoritative launch-time PR metadata and diff bundle for this job. Then request individual files with `format=compact`. Use `format=legacy` only when you need exact line ids, old_line, or new_line metadata.
+  Trust the manifest `generated` and `truncated` flags when planning review coverage. Avoid generated, minified, lockfile, build, and bundle artifacts unless they are needed to prove a user-facing change; normally list them in audit `generated_or_binary_files` instead of reading them.
+  If a generated/minified/truncated artifact must be inspected, use only small bounded compact slices (specific path plus narrow hunk/line offsets and limits, e.g. `hunkLimit=1`) and stop once you have enough evidence. Do not repeatedly reread large low-signal bundle output.
   Use readonly_bash only for narrow read-only follow-ups the persisted bundle cannot answer, not broad repository exploration. Blocked shell patterns include multi-line commands, heredocs, pipes/chaining, command substitution, and recursive root searches.
   Do not edit files, run tests/builds, install dependencies, push, commit, or submit GitHub reviews/comments.
 

--- a/market-packs/pr-walkthrough/tools/pr-walkthrough/extension.ts
+++ b/market-packs/pr-walkthrough/tools/pr-walkthrough/extension.ts
@@ -709,6 +709,67 @@ function compactJson(value: unknown): string {
 	return JSON.stringify(value ?? null);
 }
 
+const COMPACT_FILE_HARD_BUDGET_BYTES = 64 * 1024;
+const COMPACT_FILE_RESERVED_FOOTER_BYTES = 4 * 1024;
+const COMPACT_FILE_BODY_BUDGET_BYTES = COMPACT_FILE_HARD_BUDGET_BYTES - COMPACT_FILE_RESERVED_FOOTER_BYTES;
+const COMPACT_FILE_MAX_HUNK_LINES = 200;
+const COMPACT_FILE_MAX_DIFF_LINE_BYTES = 4 * 1024;
+const COMPACT_FILE_NARROW_READ_INSTRUCTIONS = "Request a narrower read with mode=file format=compact hunkOffset=<n> hunkLimit=1; use format=legacy only when exact line ids/old_line/new_line are required.";
+
+function utf8ByteLength(value: string): number {
+	return Buffer.byteLength(value, "utf8");
+}
+
+function utf8Prefix(value: string, maxBytes: number): string {
+	if (maxBytes <= 0) return "";
+	if (utf8ByteLength(value) <= maxBytes) return value;
+	let low = 0;
+	let high = Math.min(value.length, maxBytes);
+	while (low < high) {
+		const mid = Math.ceil((low + high) / 2);
+		if (utf8ByteLength(value.slice(0, mid)) <= maxBytes) low = mid;
+		else high = mid - 1;
+	}
+	return value.slice(0, low);
+}
+
+function lineJoinBytes(lines: string[], nextLine?: string): number {
+	const base = lines.reduce((total, line, index) => total + utf8ByteLength(line) + (index > 0 ? 1 : 0), 0);
+	if (nextLine === undefined) return base;
+	return base + (lines.length > 0 ? 1 : 0) + utf8ByteLength(nextLine);
+}
+
+function appendLineWithinBudget(lines: string[], line: string, budgetBytes: number): boolean {
+	if (lineJoinBytes(lines, line) <= budgetBytes) {
+		lines.push(line);
+		return true;
+	}
+	return false;
+}
+
+function compactDiffLine(marker: "+" | "-" | " ", text: string): { line: string; truncated: boolean; omittedBytes: number } {
+	const fullLine = `${marker}${text}`;
+	if (utf8ByteLength(fullLine) <= COMPACT_FILE_MAX_DIFF_LINE_BYTES) return { line: fullLine, truncated: false, omittedBytes: 0 };
+
+	let suffix = " … [line truncated; request narrower hunkOffset/hunkLimit]";
+	let prefixBudget = COMPACT_FILE_MAX_DIFF_LINE_BYTES - utf8ByteLength(marker) - utf8ByteLength(suffix);
+	let prefix = utf8Prefix(text, prefixBudget);
+	let omittedBytes = Math.max(0, utf8ByteLength(text) - utf8ByteLength(prefix));
+	suffix = ` … [line truncated: ${omittedBytes} bytes omitted; request narrower hunkOffset/hunkLimit]`;
+	prefixBudget = COMPACT_FILE_MAX_DIFF_LINE_BYTES - utf8ByteLength(marker) - utf8ByteLength(suffix);
+	prefix = utf8Prefix(text, prefixBudget);
+	omittedBytes = Math.max(0, utf8ByteLength(text) - utf8ByteLength(prefix));
+	return { line: `${marker}${prefix}${suffix}`, truncated: true, omittedBytes };
+}
+
+function finalizeCompactFileOutput(lines: string[]): string {
+	const text = lines.join("\n").replace(/\n+$/, "");
+	if (utf8ByteLength(text) <= COMPACT_FILE_HARD_BUDGET_BYTES) return text;
+	const suffix = "\n... [compact output hard cap reached; output truncated to 64KiB. Request narrower mode=file format=compact hunkOffset/hunkLimit or format=legacy.]";
+	const prefixBudget = Math.max(0, COMPACT_FILE_HARD_BUDGET_BYTES - utf8ByteLength(suffix));
+	return `${utf8Prefix(text, prefixBudget).replace(/\n+$/, "")}${suffix}`;
+}
+
 function bundleRef(data: Record<string, unknown>): string {
 	const bundle = isRecord(data.bundle) ? data.bundle : {};
 	const jobId = stringValue(bundle.job_id) ?? stringValue(data.job_id) ?? "unknown";
@@ -791,6 +852,8 @@ function formatCompactFile(data: Record<string, unknown>): string {
 	const file = isRecord(data.file) ? data.file : {};
 	const hunks = Array.isArray(file.hunks) ? file.hunks : [];
 	const formatterWarnings: string[] = [];
+	const windowWarnings: string[] = [];
+	let outputBudgetReached = false;
 	const hunkOffset = numberValue(data.hunkOffset) ?? 0;
 	const totalHunks = numberValue(data.totalHunks) ?? hunks.length;
 	const hunkEnd = hunks.length ? hunkOffset + hunks.length - 1 : hunkOffset;
@@ -806,38 +869,67 @@ function formatCompactFile(data: Record<string, unknown>): string {
 		`flags: truncated=${Boolean(file.is_truncated ?? file.truncated)} binary=${Boolean(file.is_binary)} generated=${Boolean(file.is_generated)}`,
 		`hunks: ${hunkOffset}-${hunkEnd} of ${totalHunks} (hunkOffset=${hunkOffset} hunkLimit=${data.hunkLimit ?? hunks.length} truncated=${Boolean(data.truncated)})`,
 		"anchoring: Use format=legacy for exact line ids/old_line/new_line metadata.",
+		`compact_budget: hard_cap=${COMPACT_FILE_HARD_BUDGET_BYTES} bytes max_line_bytes=${COMPACT_FILE_MAX_DIFF_LINE_BYTES} max_hunk_lines=${COMPACT_FILE_MAX_HUNK_LINES}`,
 		"",
 	);
 
-	hunks.forEach((hunk, hunkIndex) => {
+	const appendBodyLine = (line: string): boolean => {
+		if (appendLineWithinBudget(lines, line, COMPACT_FILE_BODY_BUDGET_BYTES)) return true;
+		if (!outputBudgetReached) {
+			outputBudgetReached = true;
+			const marker = `... [compact output windowed: body budget reached; remaining hunk content omitted. ${COMPACT_FILE_NARROW_READ_INSTRUCTIONS}]`;
+			appendLineWithinBudget(lines, marker, COMPACT_FILE_BODY_BUDGET_BYTES);
+			windowWarnings.push("compact output body budget reached before all selected hunk lines could be rendered");
+		}
+		return false;
+	};
+
+	outer: for (const [hunkIndex, hunk] of hunks.entries()) {
 		const warningHunk = hunkOffset + hunkIndex + 1;
 		if (!isRecord(hunk)) {
 			formatterWarnings.push(`hunk ${warningHunk} was not an object; omitted because no legacy lines were present`);
-			return;
+			continue;
 		}
-		if (typeof hunk.header === "string") lines.push(hunk.header);
-		else formatterWarnings.push(`hunk ${warningHunk} had missing header`);
+		if (typeof hunk.header === "string") {
+			if (!appendBodyLine(hunk.header)) break;
+		} else formatterWarnings.push(`hunk ${warningHunk} had missing header`);
 		const hunkLines = Array.isArray(hunk.lines) ? hunk.lines : [];
-		hunkLines.forEach((line, lineIndex) => {
+		const visibleHunkLines = hunkLines.slice(0, COMPACT_FILE_MAX_HUNK_LINES);
+		for (const [lineIndex, line] of visibleHunkLines.entries()) {
 			const warningLine = lineIndex + 1;
 			if (!isRecord(line)) {
-				lines.push(" ");
+				if (!appendBodyLine(" ")) break outer;
 				formatterWarnings.push(`hunk ${warningHunk} line ${warningLine} was not an object; preserved as blank context marker`);
-				return;
+				continue;
 			}
 			const marker = compactLineMarker(line.kind);
 			const text = typeof line.text === "string" ? line.text : "";
 			if (!marker) formatterWarnings.push(`hunk ${warningHunk} line ${warningLine} had unknown kind; preserved as context marker`);
-			lines.push(`${marker ?? " "}${text}`);
-		});
-		if (hunkIndex < hunks.length - 1) lines.push("");
-	});
+			const compactLine = compactDiffLine(marker ?? " ", text);
+			if (compactLine.truncated) {
+				windowWarnings.push(`hunk ${warningHunk} line ${warningLine} exceeded ${COMPACT_FILE_MAX_DIFF_LINE_BYTES} bytes; ${compactLine.omittedBytes} bytes omitted`);
+			}
+			if (!appendBodyLine(compactLine.line)) break outer;
+		}
+		if (hunkLines.length > visibleHunkLines.length) {
+			const omitted = hunkLines.length - visibleHunkLines.length;
+			windowWarnings.push(`hunk ${warningHunk} exceeded ${COMPACT_FILE_MAX_HUNK_LINES} compact lines; ${omitted} lines omitted`);
+			if (!appendBodyLine(`... [hunk line windowed: ${omitted} lines omitted. ${COMPACT_FILE_NARROW_READ_INSTRUCTIONS}]`)) break;
+		}
+		if (hunkIndex < hunks.length - 1 && !appendBodyLine("")) break;
+	}
 
+	if (windowWarnings.length > 0 || outputBudgetReached) {
+		lines.push("", "output_windowing:");
+		lines.push(`- compact file text is hard-capped at ${COMPACT_FILE_HARD_BUDGET_BYTES} bytes before it is returned to the model`);
+		for (const warning of windowWarnings) lines.push(`- ${warning}`);
+		lines.push(`- ${COMPACT_FILE_NARROW_READ_INSTRUCTIONS}`);
+	}
 	if (formatterWarnings.length > 0) {
 		lines.push("", "formatter_warnings:");
 		for (const warning of formatterWarnings) lines.push(`- ${warning}`);
 	}
-	return lines.join("\n").replace(/\n+$/, "");
+	return finalizeCompactFileOutput(lines);
 }
 
 export function formatCompactPrWalkthroughBundleRead(data: unknown, args: { mode?: unknown; path?: unknown; index?: unknown } = {}): string {

--- a/market-packs/pr-walkthrough/tools/pr-walkthrough/read_pr_walkthrough_bundle.yaml
+++ b/market-packs/pr-walkthrough/tools/pr-walkthrough/read_pr_walkthrough_bundle.yaml
@@ -14,6 +14,8 @@ notes:
   - The gateway validates the caller session secret and resolves the bound walkthrough job.
   - The persisted bundle is authoritative for the launched PR metadata and diff content.
   - format=compact returns a unified-diff-like tool result for lower token use; compact manifest is the authoritative envelope read, while compact summary/files/file reads suppress repeated target/changeset/limits blocks.
+  - Compact file output is hard-capped at 64KiB and may window long lines or large hunks; truncation markers explain omitted bytes/lines.
+  - For generated/minified or very large files, request narrow reads with mode=file format=compact hunkOffset=<n> hunkLimit=1; use format=legacy only when exact line ids, old_line, or new_line metadata is required.
   - format is optional. When omitted, legacy output is preserved for compatibility; use format=legacy when exact line ids, old_line, or new_line metadata is required.
   - Does not read arbitrary filesystem paths and does not loosen readonly_bash.
   - Large bundles are truncated by limit/offset; use mode=files or mode=file with format=compact for bounded follow-up reads.

--- a/src/server/pr-walkthrough/walkthrough-analysis-bundle.ts
+++ b/src/server/pr-walkthrough/walkthrough-analysis-bundle.ts
@@ -12,6 +12,16 @@ export const PR_WALKTHROUGH_ANALYSIS_BUNDLE_SCHEMA_VERSION = 1;
 export const PR_WALKTHROUGH_ANALYSIS_BUNDLE_KIND = "pr_walkthrough_analysis_bundle";
 const STORE_DIR = "pr-walkthrough-analysis-bundles";
 
+export const PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW = {
+	maxContentBytes: 48 * 1024,
+	maxHeaderBytes: 512,
+	maxLineBytes: 8 * 1024,
+	maxLines: 600,
+	maxLinesPerHunk: 200,
+} as const;
+const READ_WINDOW_MARKER_RESERVE_BYTES = 1024;
+const READ_WINDOW_GUIDANCE = "Bundle store windowed this file read before returning it. Request narrower slices with mode=file hunkOffset=<n> hunkLimit=1 when more hunk context is needed.";
+
 export type PrWalkthroughAnalysisBundleTarget = {
 	provider: "github" | string;
 	owner?: string;
@@ -90,6 +100,25 @@ export type PrWalkthroughAnalysisBundleMetadata = {
 	files: number;
 };
 
+type BundleFileReadWindowMetadata = {
+	applied: boolean;
+	maxContentBytes: number;
+	maxHeaderBytes: number;
+	maxLineBytes: number;
+	maxLines: number;
+	maxLinesPerHunk: number;
+	selectedHunks: number;
+	returnedHunks: number;
+	returnedLines: number;
+	markerLines: number;
+	omittedLines: number;
+	truncatedLines: number;
+	omittedBytes: number;
+	returnedBytes: number;
+	reasons: string[];
+	guidance: string;
+};
+
 export type ReadPrWalkthroughBundleRequest = {
 	sessionId: string;
 	jobId: string;
@@ -140,7 +169,18 @@ export class WalkthroughAnalysisBundleStore {
 			const hunkOffset = clampInteger(request.hunkOffset ?? request.offset, 0, Number.MAX_SAFE_INTEGER, 0);
 			const hunkLimit = clampInteger(request.hunkLimit ?? request.limit, 1, 200, 50);
 			const hunks = file.hunks.slice(hunkOffset, hunkOffset + hunkLimit);
-			return { bundle: bundleHeader(bundle), file: { ...file, hunks }, hunkOffset, hunkLimit, totalHunks: file.hunks.length, truncated: hunkOffset > 0 || hunkOffset + hunkLimit < file.hunks.length };
+			const windowed = windowFileRead(file, hunks, hunkOffset);
+			const hunkWindowTruncated = hunkOffset > 0 || hunkOffset + hunkLimit < file.hunks.length;
+			return {
+				bundle: bundleHeader(bundle),
+				file: windowed.file,
+				hunkOffset,
+				hunkLimit,
+				totalHunks: file.hunks.length,
+				truncated: hunkWindowTruncated || windowed.window.applied,
+				hunk_truncated: hunkWindowTruncated,
+				read_window: windowed.window,
+			};
 		}
 		throw bundleReadError(400, "Unsupported PR walkthrough bundle read mode", { code: "INVALID_BUNDLE_READ_REQUEST", retryable: false });
 	}
@@ -408,6 +448,8 @@ function bundleHeader(bundle: PrWalkthroughAnalysisBundle): Record<string, unkno
 }
 
 function fileManifest(file: PrWalkthroughAnalysisBundleFile): Record<string, unknown> {
+	const readWindow = summarizeFileReadWindow(file);
+	const readWindowed = Boolean(readWindow.applied);
 	return {
 		path: file.path,
 		old_path: file.old_path,
@@ -416,9 +458,240 @@ function fileManifest(file: PrWalkthroughAnalysisBundleFile): Record<string, unk
 		deletions: file.deletions,
 		is_binary: file.is_binary,
 		is_generated: file.is_generated,
-		is_truncated: file.is_truncated,
+		is_truncated: file.is_truncated || readWindowed,
+		source_is_truncated: file.is_truncated,
+		read_window: readWindow,
 		hunks: file.hunks.length,
 	};
+}
+
+function windowFileRead(file: PrWalkthroughAnalysisBundleFile, selectedHunks: PrWalkthroughAnalysisBundleHunk[], hunkOffset: number): { file: PrWalkthroughAnalysisBundleFile; window: BundleFileReadWindowMetadata } {
+	const window = newFileReadWindowMetadata(selectedHunks.length);
+	const reasons = new Set<string>();
+	let remainingBytes = PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW.maxContentBytes;
+	let remainingLines = PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW.maxLines;
+
+	const hunks = selectedHunks.map((hunk, selectedIndex) => {
+		const absoluteHunkIndex = hunkOffset + selectedIndex;
+		const hunkWindow = {
+			applied: false,
+			omittedLines: 0,
+			truncatedLines: 0,
+			omittedBytes: 0,
+		};
+		const lines: PrWalkthroughAnalysisBundleLine[] = [];
+		const header = windowTextToBudget(
+			typeof hunk.header === "string" ? hunk.header : "",
+			Math.min(PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW.maxHeaderBytes, Math.max(0, remainingBytes - READ_WINDOW_MARKER_RESERVE_BYTES)),
+			` … [hunk header truncated by bundle-store read window; request hunkOffset=${absoluteHunkIndex} hunkLimit=1 if needed]`,
+		);
+		remainingBytes = consumeWindowBytes(remainingBytes, header.text);
+		window.returnedBytes += utf8Bytes(header.text);
+		if (header.truncated) {
+			hunkWindow.applied = true;
+			hunkWindow.omittedBytes += header.omittedBytes;
+			reasons.add("header-bytes");
+		}
+
+		let hunkReturnedSourceLines = 0;
+		for (let lineIndex = 0; lineIndex < hunk.lines.length; lineIndex++) {
+			const line = hunk.lines[lineIndex];
+			if (hunkReturnedSourceLines >= PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW.maxLinesPerHunk || remainingLines <= 0 || remainingBytes <= READ_WINDOW_MARKER_RESERVE_BYTES) {
+				const omitted = summarizeOmittedLines(hunk.lines, lineIndex);
+				hunkWindow.applied = true;
+				hunkWindow.omittedLines += omitted.lines;
+				hunkWindow.omittedBytes += omitted.bytes;
+				if (remainingBytes <= READ_WINDOW_MARKER_RESERVE_BYTES) reasons.add("content-bytes");
+				else reasons.add("line-window");
+				break;
+			}
+
+			const availableForLine = Math.min(
+				PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW.maxLineBytes,
+				Math.max(0, remainingBytes - READ_WINDOW_MARKER_RESERVE_BYTES),
+			);
+			const originalText = typeof line.text === "string" ? line.text : "";
+			const text = windowTextToBudget(
+				originalText,
+				availableForLine,
+				` … [line truncated by bundle-store read window; request hunkOffset=${absoluteHunkIndex} hunkLimit=1 if needed]`,
+			);
+			const returnedLine = { ...line, text: text.text } as PrWalkthroughAnalysisBundleLine & Record<string, unknown>;
+			if (text.truncated) {
+				returnedLine.is_truncated = true;
+				returnedLine.truncated = true;
+				returnedLine.read_window = {
+					applied: true,
+					originalBytes: text.originalBytes,
+					returnedBytes: utf8Bytes(text.text),
+					omittedBytes: text.omittedBytes,
+				};
+				hunkWindow.applied = true;
+				hunkWindow.truncatedLines++;
+				hunkWindow.omittedBytes += text.omittedBytes;
+				reasons.add("line-bytes");
+			}
+			lines.push(returnedLine as PrWalkthroughAnalysisBundleLine);
+			remainingBytes = consumeWindowBytes(remainingBytes, text.text);
+			window.returnedBytes += utf8Bytes(text.text);
+			window.returnedLines++;
+			remainingLines--;
+			hunkReturnedSourceLines++;
+		}
+
+		if (hunkWindow.applied) {
+			appendWindowMarkerLine(lines, hunkWindowMarker(absoluteHunkIndex, hunkWindow), window, remainingBytes, (text) => {
+				remainingBytes = consumeWindowBytes(remainingBytes, text);
+			});
+		}
+
+		window.omittedLines += hunkWindow.omittedLines;
+		window.truncatedLines += hunkWindow.truncatedLines;
+		window.omittedBytes += hunkWindow.omittedBytes;
+		const windowedHunk = { ...hunk, header: header.text, lines } as PrWalkthroughAnalysisBundleHunk & Record<string, unknown>;
+		if (hunkWindow.applied) {
+			windowedHunk.is_truncated = true;
+			windowedHunk.truncated = true;
+			windowedHunk.read_window = { ...hunkWindow, guidance: READ_WINDOW_GUIDANCE };
+		}
+		return windowedHunk as PrWalkthroughAnalysisBundleHunk;
+	});
+
+	window.applied = reasons.size > 0 || window.omittedLines > 0 || window.truncatedLines > 0 || window.omittedBytes > 0;
+	window.reasons = [...reasons];
+	if (window.applied && hunks.length > 0) prependWindowNotice(hunks[0], window);
+	const windowedFile = { ...file, is_truncated: file.is_truncated || window.applied, hunks } as PrWalkthroughAnalysisBundleFile & Record<string, unknown>;
+	windowedFile.truncated = windowedFile.is_truncated;
+	windowedFile.read_window = window;
+	return { file: windowedFile as PrWalkthroughAnalysisBundleFile, window };
+}
+
+function newFileReadWindowMetadata(selectedHunks: number): BundleFileReadWindowMetadata {
+	return {
+		applied: false,
+		maxContentBytes: PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW.maxContentBytes,
+		maxHeaderBytes: PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW.maxHeaderBytes,
+		maxLineBytes: PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW.maxLineBytes,
+		maxLines: PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW.maxLines,
+		maxLinesPerHunk: PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW.maxLinesPerHunk,
+		selectedHunks,
+		returnedHunks: selectedHunks,
+		returnedLines: 0,
+		markerLines: 0,
+		omittedLines: 0,
+		truncatedLines: 0,
+		omittedBytes: 0,
+		returnedBytes: 0,
+		reasons: [],
+		guidance: READ_WINDOW_GUIDANCE,
+	};
+}
+
+function summarizeFileReadWindow(file: PrWalkthroughAnalysisBundleFile): Record<string, unknown> {
+	let totalLines = 0;
+	let totalBytes = 0;
+	let longestLineBytes = 0;
+	let longLines = 0;
+	const reasons = new Set<string>();
+	for (const hunk of file.hunks) {
+		const headerBytes = utf8Bytes(typeof hunk.header === "string" ? hunk.header : "");
+		if (headerBytes > PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW.maxHeaderBytes) reasons.add("header-bytes");
+		totalBytes += headerBytes;
+		if (hunk.lines.length > PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW.maxLinesPerHunk) reasons.add("line-window");
+		for (const line of hunk.lines) {
+			const lineBytes = utf8Bytes(typeof line.text === "string" ? line.text : "");
+			totalLines++;
+			totalBytes += lineBytes;
+			longestLineBytes = Math.max(longestLineBytes, lineBytes);
+			if (lineBytes > PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW.maxLineBytes) {
+				longLines++;
+				reasons.add("line-bytes");
+			}
+		}
+	}
+	if (totalLines > PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW.maxLines) reasons.add("line-window");
+	if (totalBytes > PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW.maxContentBytes) reasons.add("content-bytes");
+	const applied = reasons.size > 0;
+	return {
+		applied,
+		maxContentBytes: PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW.maxContentBytes,
+		maxHeaderBytes: PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW.maxHeaderBytes,
+		maxLineBytes: PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW.maxLineBytes,
+		maxLines: PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW.maxLines,
+		maxLinesPerHunk: PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW.maxLinesPerHunk,
+		totalLines,
+		totalBytes,
+		longestLineBytes,
+		longLines,
+		reasons: [...reasons],
+		guidance: applied ? READ_WINDOW_GUIDANCE : undefined,
+	};
+}
+
+function windowTextToBudget(text: string, maxBytes: number, marker: string): { text: string; truncated: boolean; originalBytes: number; omittedBytes: number } {
+	const originalBytes = utf8Bytes(text);
+	if (originalBytes <= maxBytes) return { text, truncated: false, originalBytes, omittedBytes: 0 };
+	if (maxBytes <= 0) return { text: "", truncated: true, originalBytes, omittedBytes: originalBytes };
+	const fallbackMarker = " … [truncated by bundle-store read window]";
+	let suffix = marker;
+	let prefixBytes = Math.max(0, maxBytes - utf8Bytes(suffix));
+	let prefix = utf8Prefix(text, prefixBytes);
+	let omittedBytes = originalBytes - utf8Bytes(prefix);
+	suffix = marker.replace("request ", `${omittedBytes} bytes omitted; request `);
+	prefixBytes = Math.max(0, maxBytes - utf8Bytes(suffix));
+	if (prefixBytes === 0 && utf8Bytes(suffix) > maxBytes) suffix = utf8Prefix(fallbackMarker, maxBytes);
+	else prefix = utf8Prefix(text, prefixBytes);
+	omittedBytes = originalBytes - utf8Bytes(prefix);
+	const clipped = utf8Prefix(`${prefix}${suffix}`, maxBytes);
+	return { text: clipped, truncated: true, originalBytes, omittedBytes };
+}
+
+function appendWindowMarkerLine(lines: PrWalkthroughAnalysisBundleLine[], marker: string, window: BundleFileReadWindowMetadata, remainingBytes: number, consume: (text: string) => void): void {
+	if (remainingBytes <= 0) return;
+	const text = utf8Prefix(marker, Math.min(READ_WINDOW_MARKER_RESERVE_BYTES, remainingBytes));
+	if (!text) return;
+	lines.push({ kind: "context", side: "context", text });
+	window.markerLines++;
+	window.returnedBytes += utf8Bytes(text);
+	consume(text);
+}
+
+function prependWindowNotice(hunk: PrWalkthroughAnalysisBundleHunk, window: BundleFileReadWindowMetadata): void {
+	const text = `[bundle-store read window applied: omitted ${window.omittedLines} lines and ${window.omittedBytes} bytes; request narrower slices with hunkOffset=<n> hunkLimit=1 if needed]`;
+	hunk.lines.unshift({ kind: "context", side: "context", text });
+	window.markerLines++;
+	window.returnedBytes += utf8Bytes(text);
+}
+
+function hunkWindowMarker(hunkIndex: number, window: { omittedLines: number; truncatedLines: number; omittedBytes: number }): string {
+	return `[bundle-store read window: hunkOffset=${hunkIndex} windowed; omitted ${window.omittedLines} lines, truncated ${window.truncatedLines} long lines, ${window.omittedBytes} bytes omitted; request hunkOffset=${hunkIndex} hunkLimit=1 for a narrower slice]`;
+}
+
+function summarizeOmittedLines(lines: PrWalkthroughAnalysisBundleLine[], startIndex: number): { lines: number; bytes: number } {
+	let bytes = 0;
+	for (let i = startIndex; i < lines.length; i++) bytes += utf8Bytes(typeof lines[i].text === "string" ? lines[i].text : "");
+	return { lines: Math.max(0, lines.length - startIndex), bytes };
+}
+
+function consumeWindowBytes(remaining: number, text: string): number {
+	return Math.max(0, remaining - utf8Bytes(text) - 1);
+}
+
+function utf8Bytes(text: string): number {
+	return Buffer.byteLength(text, "utf8");
+}
+
+function utf8Prefix(text: string, maxBytes: number): string {
+	if (maxBytes <= 0) return "";
+	if (utf8Bytes(text) <= maxBytes) return text;
+	let low = 0;
+	let high = text.length;
+	while (low < high) {
+		const mid = Math.ceil((low + high) / 2);
+		if (utf8Bytes(text.slice(0, mid)) <= maxBytes) low = mid;
+		else high = mid - 1;
+	}
+	return text.slice(0, low);
 }
 
 function selectFile(bundle: PrWalkthroughAnalysisBundle, filePath: string | undefined, index: number | undefined): PrWalkthroughAnalysisBundleFile | undefined {

--- a/src/shared/pr-walkthrough/generated-path.ts
+++ b/src/shared/pr-walkthrough/generated-path.ts
@@ -1,14 +1,53 @@
+const GENERATED_DIRECTORY_NAMES = new Set([
+	".next",
+	".nuxt",
+	"build",
+	"coverage",
+	"dist",
+	"gen",
+	"generated",
+	"out",
+	"target",
+	"__generated__",
+	"__snapshots__",
+]);
+
+const LOCKFILE_NAMES = new Set([
+	"bun.lock",
+	"bun.lockb",
+	"cargo.lock",
+	"composer.lock",
+	"gemfile.lock",
+	"go.sum",
+	"npm-shrinkwrap.json",
+	"package-lock.json",
+	"pipfile.lock",
+	"pnpm-lock.yaml",
+	"poetry.lock",
+	"uv.lock",
+	"yarn.lock",
+]);
+
+const GENERATED_BASENAME_MARKER = /(?:^|[._-])(?:designer|gen|generated|grpc|pb|pb2)(?:[._-]|$)|[._-]g[._-]/;
+
 export function isLikelyGeneratedPath(filePath: string): boolean {
-	const normalized = filePath.replace(/\\/g, "/").toLowerCase();
-	return normalized.startsWith("dist/")
-		|| normalized.includes("/dist/")
-		|| normalized.includes("/generated/")
-		|| normalized.includes("__snapshots__/")
-		|| normalized.endsWith(".snap")
-		|| normalized.endsWith("package-lock.json")
-		|| normalized.endsWith("pnpm-lock.yaml")
-		|| normalized.endsWith("yarn.lock")
-		|| normalized.endsWith("bun.lockb")
-		|| normalized.endsWith(".min.js")
-		|| normalized.endsWith(".min.css");
+	const normalized = filePath.replace(/\\/g, "/").toLowerCase().replace(/^\.\/+/, "");
+	const segments = normalized.split("/").filter(Boolean);
+	const basename = segments.at(-1) ?? normalized;
+	const directories = segments.slice(0, -1);
+
+	return isBuiltMarketPackOutput(segments)
+		|| directories.some(segment => GENERATED_DIRECTORY_NAMES.has(segment))
+		|| LOCKFILE_NAMES.has(basename)
+		|| basename.endsWith(".snap")
+		|| basename.includes(".min.")
+		|| basename.endsWith(".map")
+		|| GENERATED_BASENAME_MARKER.test(basename);
+}
+
+function isBuiltMarketPackOutput(segments: string[]): boolean {
+	for (let index = 0; index < segments.length - 3; index += 1) {
+		if (segments[index] === "market-packs" && segments[index + 2] === "lib") return true;
+	}
+	return false;
 }

--- a/tests/pr-walkthrough-bundle-store-read-window.test.ts
+++ b/tests/pr-walkthrough-bundle-store-read-window.test.ts
@@ -1,0 +1,150 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+	PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW,
+	PR_WALKTHROUGH_ANALYSIS_BUNDLE_KIND,
+	PR_WALKTHROUGH_ANALYSIS_BUNDLE_SCHEMA_VERSION,
+	WalkthroughAnalysisBundleStore,
+} from "../src/server/pr-walkthrough/walkthrough-analysis-bundle.ts";
+import type { PrWalkthroughAnalysisBundle } from "../src/server/pr-walkthrough/walkthrough-analysis-bundle.ts";
+import type { PrWalkthroughJobRecord } from "../src/server/pr-walkthrough/walkthrough-agent-store.ts";
+
+function withStore<T>(fn: (store: WalkthroughAnalysisBundleStore, job: PrWalkthroughJobRecord) => T): T {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-prw-bundle-window-"));
+	try {
+		const store = new WalkthroughAnalysisBundleStore(dir);
+		const job = jobRecord("job-window-test");
+		return fn(store, job);
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+function jobRecord(jobId: string): PrWalkthroughJobRecord {
+	return {
+		schemaVersion: 1,
+		jobId,
+		parentSessionId: "parent-session",
+		childSessionId: "child-session",
+		cwd: process.cwd(),
+		target: { provider: "github", owner: "SuuBro", repo: "bobbit", number: 879, prUrl: "https://github.com/SuuBro/bobbit/pull/879" },
+		changesetId: "changeset-window-test",
+		tabId: "tab-window-test",
+		status: "running",
+		title: "Window test",
+		createdAt: "2026-06-01T00:00:00.000Z",
+		updatedAt: "2026-06-01T00:00:00.000Z",
+	} as PrWalkthroughJobRecord;
+}
+
+function bundleWithLargeSingleLine(jobId: string): PrWalkthroughAnalysisBundle {
+	return {
+		schema_version: PR_WALKTHROUGH_ANALYSIS_BUNDLE_SCHEMA_VERSION,
+		kind: PR_WALKTHROUGH_ANALYSIS_BUNDLE_KIND,
+		generated_at: "2026-06-01T00:00:00.000Z",
+		job_id: jobId,
+		target: { provider: "github", owner: "SuuBro", repo: "bobbit", number: 879, url: "https://github.com/SuuBro/bobbit/pull/879" },
+		changeset: { base_sha: "base", head_sha: "head", title: "Large generated bundle", body: "", files_changed: 1, additions: 1, deletions: 0 },
+		warnings: [],
+		files: [{
+			path: "market-packs/terminal/lib/terminal-panel.js",
+			status: "modified",
+			additions: 1,
+			deletions: 0,
+			is_binary: false,
+			is_generated: false,
+			is_truncated: false,
+			hunks: [{
+				id: "hunk-large",
+				header: "@@ -1,0 +1,1 @@",
+				old_start: 1,
+				old_lines: 0,
+				new_start: 1,
+				new_lines: 1,
+				lines: [{
+					id: "line-large",
+					kind: "add",
+					side: "new",
+					new_line: 1,
+					text: `(()=>{${"a".repeat(700_000)}})();`,
+				}],
+			}],
+		}],
+	};
+}
+
+function bundleWithMultipleHunks(jobId: string): PrWalkthroughAnalysisBundle {
+	return {
+		schema_version: PR_WALKTHROUGH_ANALYSIS_BUNDLE_SCHEMA_VERSION,
+		kind: PR_WALKTHROUGH_ANALYSIS_BUNDLE_KIND,
+		generated_at: "2026-06-01T00:00:00.000Z",
+		job_id: jobId,
+		target: { provider: "github", owner: "SuuBro", repo: "bobbit", number: 1 },
+		changeset: { files_changed: 1, additions: 3, deletions: 0 },
+		warnings: [],
+		files: [{
+			path: "src/example.ts",
+			status: "modified",
+			additions: 3,
+			deletions: 0,
+			is_binary: false,
+			is_generated: false,
+			is_truncated: false,
+			hunks: [0, 1, 2].map((index) => ({
+				id: `hunk-${index}`,
+				header: `@@ -${index + 1},1 +${index + 1},1 @@`,
+				lines: [{ kind: "add", side: "new", new_line: index + 1, text: `line ${index}` }],
+			})),
+		}],
+	};
+}
+
+describe("WalkthroughAnalysisBundleStore file read windowing", () => {
+	it("bounds a 700k single-line hunk and returns truncation metadata before callers format it", () => withStore((store, job) => {
+		store.save(job.jobId, bundleWithLargeSingleLine(job.jobId));
+
+		const result = store.read(job, { mode: "file", path: "market-packs/terminal/lib/terminal-panel.js", hunkLimit: 1 }) as any;
+		const serializedBytes = Buffer.byteLength(JSON.stringify(result), "utf8");
+		const file = result.file;
+		const lines = file.hunks[0].lines;
+		const joinedText = lines.map((line: any) => String(line.text ?? "")).join("\n");
+
+		assert.ok(serializedBytes < 64 * 1024, `store file read should stay compact before formatter output, got ${serializedBytes} bytes`);
+		assert.equal(result.truncated, true);
+		assert.equal(result.hunk_truncated, false, "hunkOffset/hunkLimit pagination should remain distinct from byte windowing");
+		assert.equal(result.read_window.applied, true);
+		assert.equal(file.is_truncated, true);
+		assert.ok(result.read_window.omittedBytes > 690_000, "read window should report omitted long-line bytes");
+		assert.ok(Buffer.byteLength(joinedText, "utf8") <= PR_WALKTHROUGH_ANALYSIS_BUNDLE_FILE_READ_WINDOW.maxLineBytes + 2048);
+		assert.match(joinedText, /bundle-store read window/i);
+		assert.match(joinedText, /bytes omitted/i);
+		assert.match(joinedText, /hunkOffset=0 hunkLimit=1/i);
+		assert.doesNotMatch(joinedText, /a{100000}/, "large minified payload must not reach callers intact");
+
+		const manifest = store.read(job, { mode: "manifest" }) as any;
+		assert.equal(manifest.files[0].is_truncated, true);
+		assert.equal(manifest.files[0].source_is_truncated, false);
+		assert.equal(manifest.files[0].read_window.applied, true);
+		assert.match(manifest.files[0].read_window.reasons.join(","), /line-bytes|content-bytes/);
+	}));
+
+	it("preserves hunkOffset and hunkLimit while only windowing selected hunk bodies", () => withStore((store, job) => {
+		store.save(job.jobId, bundleWithMultipleHunks(job.jobId));
+
+		const result = store.read(job, { mode: "file", path: "src/example.ts", hunkOffset: 1, hunkLimit: 1 }) as any;
+
+		assert.equal(result.hunkOffset, 1);
+		assert.equal(result.hunkLimit, 1);
+		assert.equal(result.totalHunks, 3);
+		assert.equal(result.truncated, true);
+		assert.equal(result.hunk_truncated, true);
+		assert.equal(result.read_window.applied, false);
+		assert.deepEqual(result.file.hunks.map((hunk: any) => hunk.id), ["hunk-1"]);
+		assert.equal(result.file.hunks[0].lines[0].text, "line 1");
+		assert.equal(result.file.is_truncated, false);
+	}));
+});

--- a/tests/pr-walkthrough-compact-bundle-format.test.ts
+++ b/tests/pr-walkthrough-compact-bundle-format.test.ts
@@ -6,6 +6,7 @@ import * as prWalkthroughExtension from "../market-packs/pr-walkthrough/tools/pr
 
 const extension = extensionModule as any;
 const compactApi = prWalkthroughExtension as any;
+const HARD_COMPACT_FILE_BUDGET_BYTES = 64 * 1024;
 
 type RegisteredTool = { name: string; execute: (...args: any[]) => Promise<any>; parameters?: any };
 
@@ -109,6 +110,38 @@ function modifiedFile() {
 					{ id: "block-modified:h1:l1", kind: "del", side: "old", old_line: 31, text: "value -= 1;" },
 					{ id: "block-modified:h1:l2", kind: "add", side: "new", new_line: 32, text: "value += 1;" },
 					{ id: "block-modified:h1:l3", kind: "context", side: "context", old_line: 32, new_line: 33, text: "return value;" },
+				],
+			},
+		],
+	};
+}
+
+function largeSingleLineBundleFile() {
+	return {
+		path: "market-packs/terminal/lib/terminal-panel.js",
+		old_path: undefined,
+		status: "modified",
+		additions: 1,
+		deletions: 0,
+		is_binary: false,
+		is_generated: false,
+		is_truncated: false,
+		hunks: [
+			{
+				id: "block-terminal-panel:h0",
+				header: "@@ -1,0 +1,1 @@",
+				old_start: 1,
+				old_lines: 0,
+				new_start: 1,
+				new_lines: 1,
+				lines: [
+					{
+						id: "block-terminal-panel:h0:l0",
+						kind: "add",
+						side: "new",
+						new_line: 1,
+						text: `(()=>{${"a".repeat(700_000)}})();`,
+					},
 				],
 			},
 		],
@@ -397,6 +430,28 @@ describe("PR walkthrough compact bundle tool integration", () => {
 				const serialized = JSON.stringify(result);
 				assert.doesNotMatch(serialized, /"old_line"|"new_line"|"side"|"lines"/);
 				assert.doesNotMatch(serialized, /"changeset"|"limits"|baseSha|headSha|maxFiles|maxLinesPerFile/);
+			} finally {
+				restoreEnv();
+			}
+		});
+	});
+
+	it("bounds compact file reads for a 700k single-line hunk with truncation/window markers", async () => {
+		const { tools, restoreEnv } = installEnvAndRegisterTools();
+		const bundleTool = tools.get("read_pr_walkthrough_bundle");
+		assert.ok(bundleTool, "expected read_pr_walkthrough_bundle to be registered");
+		const file = largeSingleLineBundleFile();
+		await withMockedFetch(async () => new Response(JSON.stringify(fileRead(file as any, { totalHunks: 1, hunkLimit: 1, truncated: false })), { status: 200 }), async () => {
+			try {
+				const result = await bundleTool.execute("call-large-compact", { mode: "file", path: file.path, hunkLimit: 1, format: "compact" });
+				const output = String(result.content[0].text);
+				const outputBytes = Buffer.byteLength(output, "utf8");
+				const hasTruncationOrWindowMarker = /truncated=true|window(?:ed|ing)|omitted|bytes? omitted|request .*slice/i.test(output);
+
+				assert.ok(
+					outputBytes <= HARD_COMPACT_FILE_BUDGET_BYTES && hasTruncationOrWindowMarker,
+					`compact output must stay below hard budget and include truncation/window markers (bytes=${outputBytes}, budget=${HARD_COMPACT_FILE_BUDGET_BYTES}, hasMarker=${hasTruncationOrWindowMarker})`,
+				);
 			} finally {
 				restoreEnv();
 			}

--- a/tests/pr-walkthrough-generated-path.test.ts
+++ b/tests/pr-walkthrough-generated-path.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isLikelyGeneratedPath } from "../src/shared/pr-walkthrough/generated-path.ts";
+
+describe("isLikelyGeneratedPath", () => {
+	it("classifies built marketplace pack outputs as generated", () => {
+		assert.equal(isLikelyGeneratedPath("market-packs/terminal/lib/terminal-panel.js"), true);
+		assert.equal(isLikelyGeneratedPath("market-packs/example/lib/nested/chunk.mjs"), true);
+		assert.equal(isLikelyGeneratedPath("market-packs/terminal/src/terminal-panel.ts"), false);
+	});
+
+	it("classifies broad minified filenames and lockfiles as generated", () => {
+		for (const filePath of [
+			"assets/app.min.js",
+			"assets/app.min.mjs",
+			"assets/app.min.cjs",
+			"assets/app.min.css.map",
+			"package-lock.json",
+			"npm-shrinkwrap.json",
+			"pnpm-lock.yaml",
+			"yarn.lock",
+			"bun.lock",
+			"bun.lockb",
+			"Cargo.lock",
+			"Gemfile.lock",
+			"poetry.lock",
+			"go.sum",
+		]) {
+			assert.equal(isLikelyGeneratedPath(filePath), true, filePath);
+		}
+	});
+
+	it("classifies dist, build, generated, and common output paths", () => {
+		for (const filePath of [
+			"dist/bundle.js",
+			"packages/app/build/client.js",
+			"generated/schema.ts",
+			"src/__generated__/types.ts",
+			"coverage/lcov.info",
+			".next/server/app.js",
+			"schema.generated.ts",
+			"service.pb.go",
+			"foo_pb2.py",
+			"component.g.cs",
+			"model.designer.cs",
+			"bundle.js.map",
+		]) {
+			assert.equal(isLikelyGeneratedPath(filePath), true, filePath);
+		}
+	});
+
+	it("does not classify ordinary source paths as generated", () => {
+		for (const filePath of [
+			"src/lib/terminal-panel.ts",
+			"src/components/build-panel.ts",
+			"src/lockfile-editor.ts",
+			"src/g.ts",
+			"market-packs/terminal/src/terminal-panel.ts",
+		]) {
+			assert.equal(isLikelyGeneratedPath(filePath), false, filePath);
+		}
+	});
+});

--- a/tests/pr-walkthrough-role-tools-policy.test.ts
+++ b/tests/pr-walkthrough-role-tools-policy.test.ts
@@ -127,6 +127,17 @@ describe("PR Walkthrough role↔tool-group boundary (resolved)", () => {
 		assert.doesNotMatch(prompt, /When complete, call submit_pr_walkthrough_yaml/);
 	});
 
+	it("the pr-reviewer prompt avoids generated or truncated artifacts by default", () => {
+		const reviewer = loadRole(PR_REVIEWER_ROLE_FILE);
+		const prompt = reviewer.promptTemplate ?? "";
+		assert.match(prompt, /manifest `generated` and `truncated` flags/);
+		assert.match(prompt, /Avoid generated, minified, lockfile, build, and bundle artifacts/);
+		assert.match(prompt, /generated_or_binary_files/);
+		assert.match(prompt, /small bounded compact slices/);
+		assert.match(prompt, /hunkLimit=1/);
+		assert.match(prompt, /Do not repeatedly reread large low-signal bundle output/);
+	});
+
 	for (const tool of PR_WALKTHROUGH_TOOLS) {
 		it(`pr-reviewer role resolves ${tool} to allow`, () => {
 			const reviewer = loadRole(PR_REVIEWER_ROLE_FILE);


### PR DESCRIPTION
## Summary
- Bound compact PR walkthrough file reads with hard output caps and truncation guidance.
- Add server-side bundle read windowing and improved generated artifact detection for built/minified outputs.
- Update reviewer guidance/docs and regression coverage for large single-line diffs.

## Tests
- npx tsx --import ./tests/helpers/css-stub-loader.mjs --test --test-force-exit tests/pr-walkthrough-compact-bundle-format.test.ts tests/pr-walkthrough-bundle-store-read-window.test.ts tests/pr-walkthrough-generated-path.test.ts tests/pr-walkthrough-role-tools-policy.test.ts tests/pr-walkthrough-tool-metadata.test.ts tests/pr-walkthrough-bundle-tool-metadata.test.ts
- npx tsx --test tests/pr-walkthrough-bundle-store-read-window.test.ts tests/pr-walkthrough-generated-path.test.ts

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)