### PR TITLE
Prevent settings fields from unwanted autofill

### DIFF
--- a/src/app/dialogs.ts
+++ b/src/app/dialogs.ts
@@ -826,6 +826,8 @@ export function openGatewayDialog(): void {
 									<label class="text-xs text-muted-foreground mb-1 block">Gateway URL</label>
 									${Input({
 										type: "text",
+										name: "bobbit-gateway-url",
+										autocomplete: "off",
 										placeholder: "http://localhost:3001",
 										value: urlValue,
 										onInput: (e: Event) => {
@@ -837,6 +839,8 @@ export function openGatewayDialog(): void {
 									<label class="text-xs text-muted-foreground mb-1 block">Auth Token</label>
 									${Input({
 										type: "password",
+										name: "bobbit-gateway-auth-token",
+										autocomplete: "new-password",
 										placeholder: "Paste token from gateway terminal",
 										value: tokenValue,
 										onInput: (e: Event) => {

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -2042,6 +2042,11 @@ export function renderModelsTab() {
 							type="text"
 							class="flex-1 px-3 py-2 rounded-md border border-input bg-background text-foreground text-sm
 								focus:outline-none focus:ring-2 focus:ring-ring"
+							data-testid="aigw-url-input"
+							name="bobbit-aigw-url"
+							autocomplete="off"
+							autocapitalize="off"
+							spellcheck="false"
 							placeholder="http://gateway-host/v1"
 							.value=${aigwUrl}
 							?disabled=${busy}

--- a/src/ui/components/ProviderKeyInput.ts
+++ b/src/ui/components/ProviderKeyInput.ts
@@ -117,6 +117,12 @@ export class ProviderKeyInput extends LitElement {
 				<div class="flex items-center gap-2">
 					${Input({
 						type: "password",
+						// These are API keys, not website login passwords. Use a
+						// provider-specific field name plus new-password autocomplete so
+						// browser password managers do not prefill unrelated credentials
+						// (notably "Google" account passwords) into an empty key field.
+						name: `bobbit-provider-api-key-${this.provider || "unknown"}`,
+						autocomplete: "new-password",
 						placeholder: this.hasKey ? "••••••••••••" : i18n("Enter API key"),
 						value: this.keyInput,
 						onInput: (e: Event) => {

--- a/tests/settings-models-tab-redesign.spec.ts
+++ b/tests/settings-models-tab-redesign.spec.ts
@@ -140,6 +140,11 @@ test.describe("Settings Models tab redesign", () => {
 		const defaultsBox = page.locator('[data-testid="defaults-section"]');
 		await expect(aigwBox).toBeVisible();
 		await expect(defaultsBox).toBeVisible();
+		const gatewayUrlInput = aigwBox.locator('[data-testid="aigw-url-input"]');
+		await expect(gatewayUrlInput).toHaveAttribute("name", "bobbit-aigw-url");
+		await expect(gatewayUrlInput).toHaveAttribute("autocomplete", "off");
+		await expect(gatewayUrlInput).toHaveAttribute("autocapitalize", "off");
+		await expect(gatewayUrlInput).toHaveAttribute("spellcheck", "false");
 
 		// Assert DOM order: aigw appears before defaults in document order.
 		const order = await page.evaluate(() => {

--- a/tests/settings-models-tab-redesign.spec.ts
+++ b/tests/settings-models-tab-redesign.spec.ts
@@ -30,6 +30,7 @@ const BUNDLE = path.resolve("tests/fixtures/settings-models-tab-bundle.js");
 const ENTRY = path.resolve("tests/fixtures/settings-models-tab-entry.ts");
 const SETTINGS_SRC = path.resolve("src/app/settings-page.ts");
 const DIALOG_SRC = path.resolve("src/ui/dialogs/AigwModelsDialog.ts");
+const PROVIDER_KEY_SRC = path.resolve("src/ui/components/ProviderKeyInput.ts");
 
 test.beforeAll(async () => {
 	// Full-suite browser fixture runs can be CPU/IO constrained while multiple
@@ -40,6 +41,7 @@ test.beforeAll(async () => {
 		fs.statSync(ENTRY).mtimeMs,
 		fs.statSync(SETTINGS_SRC).mtimeMs,
 		fs.statSync(DIALOG_SRC).mtimeMs,
+		fs.statSync(PROVIDER_KEY_SRC).mtimeMs,
 	);
 	const bundleExists = fs.existsSync(BUNDLE);
 	const bundleStale = bundleExists && fs.statSync(BUNDLE).mtimeMs < entryMtime;
@@ -269,6 +271,12 @@ test.describe("Settings Models tab redesign", () => {
 		await expect(googleKey.locator("provider-key-input")).toHaveCount(1);
 		// The component renders its (capitalized) provider name in the label.
 		await expect(googleKey).toContainText(/google/i);
+		// API-key fields are not website login passwords; do not let browser password
+		// managers prefill unrelated Google account credentials into this empty field.
+		const googleInput = googleKey.locator('input[type="password"]');
+		await expect(googleInput).toHaveAttribute("name", "bobbit-provider-api-key-google");
+		await expect(googleInput).toHaveAttribute("autocomplete", "new-password");
+		await expect(googleInput).toHaveValue("");
 
 		// OpenRouter key input wrapper + its provider-key-input element render too.
 		const openrouterKey = page.locator('[data-testid="provider-key-input-openrouter"]');


### PR DESCRIPTION
## Summary
- Prevent browser/password-manager autofill in provider API key fields with provider-specific names and `autocomplete="new-password"`.
- Disable autocomplete-related behavior on AI Gateway URL fields and the Connect to Gateway URL/token dialog.
- Add regression coverage for the Settings → Models gateway and provider-key inputs.

## Testing
- `npm run check`
- `npx playwright test --config tests/playwright.config.ts tests/settings-models-tab-redesign.spec.ts tests/ui-fixtures/settings-account-tab.spec.ts`
- `npm run build:ui`
- `npm run test:unit` — node logic passed; browser fixtures failed in unrelated `client-host-api` / `pr-walkthrough-panel-parity` tests.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
