### PR TITLE
Restore Bobbit loading animation

### DIFF
--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -219,19 +219,8 @@ window.addEventListener("bobbit-open-review-document", (e: Event) => {
 import { teardownMobileScrollTracking, ensureMobileScrollTracking } from "./mobile-header.js";
 import { getRouteFromHash, setHashRoute, isRouteActive, toggleConfigPage } from "./routing.js";
 import { lookupPackRoute } from "./pack-entrypoints.js";
+import { bobbitLoadingAnimation } from "../ui/components/BobbitLoadingAnimation.js";
 import "./config-scope.css";
-
-function bobbitLoadingAnimation() {
-	return html`
-		<div class="flex items-center justify-center w-full h-full" style="background: var(--background);">
-			<div
-				class="rounded-full animate-spin"
-				style="width: 2rem; height: 2rem; border: 2px solid color-mix(in oklch, var(--muted-foreground) 22%, transparent); border-top-color: var(--primary);"
-				aria-label="Loading"
-			></div>
-		</div>
-	`;
-}
 
 // ---------------------------------------------------------------------------
 // Lazy route page loader — see docs/design/ui-bundle-size-reduction.md (Task A)

--- a/src/ui/ChatPanel.ts
+++ b/src/ui/ChatPanel.ts
@@ -9,6 +9,7 @@ import type { ArtifactsPanel } from "./tools/artifacts/index.js";
 import { registerToolRenderer } from "./tools/renderer-registry.js";
 import type { Attachment } from "./utils/attachment-utils.js";
 import { i18n } from "./utils/i18n.js";
+import { bobbitLoadingAnimation } from "./components/BobbitLoadingAnimation.js";
 
 const BREAKPOINT = 800; // px - switch between overlay and side-by-side
 
@@ -170,12 +171,7 @@ export class ChatPanel extends LitElement {
 
 	render() {
 		if (!this.agent || !this.agentInterface) {
-			return html`<div class="flex items-center justify-center h-full">
-				<div class="text-muted-foreground flex items-center gap-2">
-					<span class="animate-spin inline-block w-4 h-4 border-2 border-current border-t-transparent rounded-full"></span>
-					Connecting…
-				</div>
-			</div>`;
+			return html`<div class="h-full" aria-label="Connecting">${bobbitLoadingAnimation()}</div>`;
 		}
 
 		const isMobile = this.windowWidth < BREAKPOINT;

--- a/tests/bobbit-loading-animation-regression.test.ts
+++ b/tests/bobbit-loading-animation-regression.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const renderSource = readFileSync(new URL("../src/app/render.ts", import.meta.url), "utf8");
+const chatPanelSource = readFileSync(new URL("../src/ui/ChatPanel.ts", import.meta.url), "utf8");
+
+test("main content loader uses the Bobbit mascot animation, not a generic spinner", () => {
+	assert.match(
+		renderSource,
+		/import \{ bobbitLoadingAnimation \} from "\.\.\/ui\/components\/BobbitLoadingAnimation\.js";/,
+		"src/app/render.ts should use the shared Bobbit loading animation",
+	);
+	assert.doesNotMatch(
+		renderSource,
+		/function bobbitLoadingAnimation\s*\(/,
+		"src/app/render.ts must not shadow the shared Bobbit loader with a local fallback",
+	);
+});
+
+test("new-session ChatPanel connecting state uses the Bobbit mascot animation", () => {
+	assert.match(
+		chatPanelSource,
+		/import \{ bobbitLoadingAnimation \} from "\.\/components\/BobbitLoadingAnimation\.js";/,
+		"ChatPanel should use the shared Bobbit loading animation while connecting",
+	);
+	assert.doesNotMatch(
+		chatPanelSource,
+		/border-t-transparent rounded-full/,
+		"ChatPanel connecting state must not regress to the generic CSS spinner",
+	);
+});


### PR DESCRIPTION
## Summary
- Restore the shared jumping Bobbit loader in the main app loading path.
- Replace the new-session ChatPanel connecting spinner with the Bobbit loader.
- Add a regression test to prevent generic spinner fallbacks in these paths.

## Tests
- `npx tsx --test tests/bobbit-loading-animation-regression.test.ts`
- `npm run check`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
