### PR TITLE
Skip PRW Reminders

### DIFF
--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -197,10 +197,11 @@ giving delegates the two things workers always had: a **durable task** and **liv
    task (not an empty goal/role prompt).
 3. **Re-run + reminded.** The respawned delegate is re-driven by the shared boot-resume
    drain (the same mechanism that resumes a mid-turn worker). When a restored parent has
-   live children, the core injects a **system reminder** (`remindOwnersWithLiveChildren`)
-   enumerating them and pointing at `team_wait`; the parent re-collects through the shared
-   wait, which now re-attaches to a **live** child and returns a **real** result instead of a
-   `terminated` placeholder.
+   collectable live children, the core injects a **system reminder**
+   (`remindOwnersWithLiveChildren`) enumerating them and pointing at `team_wait`; the parent
+   re-collects through the shared wait, which now re-attaches to a **live** child and returns
+   a **real** result instead of a `terminated` placeholder. Regular delegate children remain
+   in this generic collection flow.
 4. **Orphans still reaped.** A child is reaped on boot **only** if its parent is gone or
    archived, **or** if the child carries a generic terminal marker (see below) — the
    generalized `shouldReapChildOnBoot`, covering delegate, `host.agents`, and future kinds.
@@ -222,6 +223,15 @@ giving delegates the two things workers always had: a **durable task** and **liv
 > the owner-gone/archived rule below or explicit user termination — never by a terminal
 > marker (see [docs/pr-walkthrough-panel.md](pr-walkthrough-panel.md)).
 
+> **Restart collection reminder policy.** The generic post-restart `team_wait` reminder is
+> only for child kinds that the owning agent can collect directly. It includes regular
+> collectable delegates and deliberately excludes non-collectable child kinds handled by
+> other workflows: `team` (handled by `TeamManager`), `host-agents` (polled/managed by the
+> extension workflow), and the legacy `pr-walkthrough` kind. Current PR Walkthrough reviewers
+> are `host-agents` children with role `pr-reviewer` and title `PR Walkthrough`, so they are
+> restored and kept visible without asking the owning agent to collect them via generic
+> `team_wait`.
+>
 > **Why reuse the worker machinery?** Delegates and workers now share **one** restart path —
 > durable task + live restore + prompt rebuild + re-nudge — with no parallel registry. The
 > earlier "delegates stay dormant" carve-out is what lost work and dropped the task; folding

--- a/docs/pr-walkthrough-panel.md
+++ b/docs/pr-walkthrough-panel.md
@@ -487,11 +487,15 @@ reaps it automatically.
 - **Restart survival.** Because no `childTerminal` marker is stamped, a finalized
   reviewer **survives a gateway restart** like any other session. Its durable
   progress is review-scoped in the pack store, and the lifecycle provider injects
-  a bounded chunk/finalization summary before prompts. It is reaped only by the
-  standard `host.agents` **owner-gone** rule (`shouldReapChildOnBoot` in
-  `OrchestrationCore` removes it when its owner is archived/gone) — never by a
-  PR-walkthrough terminal marker. See
-  [docs/orchestration.md](orchestration.md#hostagents--orchestration-for-extension-packs).
+  a bounded chunk/finalization summary before prompts. The reviewer is a
+  `host-agents` child (`role: "pr-reviewer"`, title `PR Walkthrough`), so it is
+  polled and managed by the extension workflow; the owner does **not** receive the
+  generic post-restart `team_wait` collection reminder for it. Restoration,
+  binding, submission, and visibility behavior are otherwise unchanged. It is
+  reaped only by the standard `host.agents` **owner-gone** rule
+  (`shouldReapChildOnBoot` in `OrchestrationCore` removes it when its owner is
+  archived/gone) — never by a PR-walkthrough terminal marker. See
+  [docs/orchestration.md](orchestration.md#restart-survival).
 - **Termination is the user's call.** The user terminates the reviewer through the
   existing per-session terminate/dismiss control in the sidebar (the same archive
   action exposed for `host.agents` child sessions). On reviewer shutdown/archive,

--- a/src/server/agent/aigw-manager.ts
+++ b/src/server/agent/aigw-manager.ts
@@ -241,36 +241,177 @@ function writeModelsJson(data: Record<string, any>): void {
 	}
 }
 
+function unescapeGeneratedString(raw: string): string {
+	try {
+		return JSON.parse(`"${raw}"`);
+	} catch {
+		return raw.replace(/\\(["'\\])/g, "$1");
+	}
+}
+
+function findMatchingBrace(source: string, openBraceIndex: number): number {
+	let depth = 0;
+	let quote: string | null = null;
+	let escaped = false;
+	let lineComment = false;
+	let blockComment = false;
+
+	for (let i = openBraceIndex; i < source.length; i++) {
+		const ch = source[i];
+		const next = source[i + 1];
+
+		if (lineComment) {
+			if (ch === "\n" || ch === "\r") lineComment = false;
+			continue;
+		}
+		if (blockComment) {
+			if (ch === "*" && next === "/") {
+				blockComment = false;
+				i++;
+			}
+			continue;
+		}
+		if (quote) {
+			if (escaped) {
+				escaped = false;
+			} else if (ch === "\\") {
+				escaped = true;
+			} else if (ch === quote) {
+				quote = null;
+			}
+			continue;
+		}
+
+		if (ch === "/" && next === "/") {
+			lineComment = true;
+			i++;
+			continue;
+		}
+		if (ch === "/" && next === "*") {
+			blockComment = true;
+			i++;
+			continue;
+		}
+		if (ch === '"' || ch === "'" || ch === "`") {
+			quote = ch;
+			continue;
+		}
+		if (ch === "{") depth++;
+		else if (ch === "}") {
+			depth--;
+			if (depth === 0) return i;
+		}
+	}
+	return -1;
+}
+
+function topLevelDepthAt(source: string, targetIndex: number): number {
+	let depth = 0;
+	let quote: string | null = null;
+	let escaped = false;
+	let lineComment = false;
+	let blockComment = false;
+
+	for (let i = 0; i < targetIndex; i++) {
+		const ch = source[i];
+		const next = source[i + 1];
+
+		if (lineComment) {
+			if (ch === "\n" || ch === "\r") lineComment = false;
+			continue;
+		}
+		if (blockComment) {
+			if (ch === "*" && next === "/") {
+				blockComment = false;
+				i++;
+			}
+			continue;
+		}
+		if (quote) {
+			if (escaped) escaped = false;
+			else if (ch === "\\") escaped = true;
+			else if (ch === quote) quote = null;
+			continue;
+		}
+
+		if (ch === "/" && next === "/") {
+			lineComment = true;
+			i++;
+			continue;
+		}
+		if (ch === "/" && next === "*") {
+			blockComment = true;
+			i++;
+			continue;
+		}
+		if (ch === '"' || ch === "'" || ch === "`") {
+			quote = ch;
+			continue;
+		}
+		if (ch === "{") depth++;
+		else if (ch === "}") depth = Math.max(0, depth - 1);
+	}
+	return depth;
+}
+
+function topLevelStringProperty(objectBody: string, property: string): string | undefined {
+	const quoted = property.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const propertyRegex = new RegExp(`(?:^|[,\\s])(?:"${quoted}"|${quoted})\\s*:\\s*"((?:\\\\.|[^"\\\\])*)"`, "g");
+	let match: RegExpExecArray | null;
+	while ((match = propertyRegex.exec(objectBody)) !== null) {
+		if (topLevelDepthAt(objectBody, match.index) === 0) {
+			return unescapeGeneratedString(match[1]);
+		}
+	}
+	return undefined;
+}
+
+function addProviderModel(providerModels: Map<string, string[]>, provider: string, modelId: string): void {
+	if (!provider || !modelId) return;
+	const models = providerModels.get(provider) ?? [];
+	if (!models.includes(modelId)) models.push(modelId);
+	providerModels.set(provider, models);
+}
+
+/**
+ * Parse model IDs from pi-ai's models.generated.js text, grouped by provider.
+ * Supports both the older flat shape and the current provider-nested shape.
+ */
+export function parseModelsGeneratedText(text: string): Map<string, string[]> {
+	const providerModels = new Map<string, string[]>();
+	const entryRegex = /"((?:\\.|[^"\\])+)"\s*:\s*\{/g;
+	let match: RegExpExecArray | null;
+
+	while ((match = entryRegex.exec(text)) !== null) {
+		const key = unescapeGeneratedString(match[1]);
+		const openBraceIndex = entryRegex.lastIndex - 1;
+		const closeBraceIndex = findMatchingBrace(text, openBraceIndex);
+		if (closeBraceIndex < 0) continue;
+
+		const objectBody = text.slice(openBraceIndex + 1, closeBraceIndex);
+		const provider = topLevelStringProperty(objectBody, "provider");
+		if (!provider) continue;
+
+		addProviderModel(providerModels, provider, topLevelStringProperty(objectBody, "id") ?? key);
+		entryRegex.lastIndex = closeBraceIndex + 1;
+	}
+
+	return providerModels;
+}
+
 /**
  * Parse model IDs from pi-ai's models.generated.js, grouped by provider.
- * Reads the file as text and extracts id+provider pairs via regex.
  */
 function parseModelsGenerated(): Map<string, string[]> {
-	const providerModels = new Map<string, string[]>();
 	try {
 		const pkgUrl = import.meta.resolve("@earendil-works/pi-ai");
 		const pkgDir = path.dirname(fileURLToPath(pkgUrl));
 		const modelsPath = path.join(pkgDir, "models.generated.js");
-		const text = fs.readFileSync(modelsPath, "utf-8");
-
-		// The file has entries like:
-		//   "some-model-id": {
-		//       id: "some-model-id",
-		//       ...
-		//       provider: "amazon-bedrock",
-		// We extract (id, provider) pairs.
-		const entryRegex = /"([^"]+)":\s*\{[^}]*?provider:\s*"([^"]+)"/g;
-		let match: RegExpExecArray | null;
-		while ((match = entryRegex.exec(text)) !== null) {
-			const modelId = match[1];
-			const provider = match[2];
-			if (!providerModels.has(provider)) providerModels.set(provider, []);
-			providerModels.get(provider)!.push(modelId);
-		}
+		return parseModelsGeneratedText(fs.readFileSync(modelsPath, "utf-8"));
 	} catch (err) {
 		console.error("[aigw-manager] Failed to parse models.generated.js:", err);
+		return new Map<string, string[]>();
 	}
-	return providerModels;
 }
 
 /**
@@ -284,16 +425,14 @@ function parseModelsGenerated(): Map<string, string[]> {
  * Preserves existing user modelOverrides — only sets contextWindow if the user
  * hasn't already overridden it for that model.
  */
-export function writeContextWindowOverrides(): void {
-	const providerModels = parseModelsGenerated();
-	const targetProviders = ["amazon-bedrock", "anthropic"];
+const CONTEXT_WINDOW_OVERRIDE_PROVIDERS = ["amazon-bedrock", "anthropic"] as const;
 
-	const data = readModelsJson();
+export function applyContextWindowOverrides(data: Record<string, any>, providerModels: Map<string, string[]>): number {
 	if (!data.providers) data.providers = {};
 
 	let overridesWritten = 0;
 
-	for (const provider of targetProviders) {
+	for (const provider of CONTEXT_WINDOW_OVERRIDE_PROVIDERS) {
 		const modelIds = providerModels.get(provider) || [];
 		const claudeIds = modelIds.filter(id => id.toLowerCase().includes("claude"));
 
@@ -316,6 +455,14 @@ export function writeContextWindowOverrides(): void {
 			}
 		}
 	}
+
+	return overridesWritten;
+}
+
+export function writeContextWindowOverrides(): void {
+	const providerModels = parseModelsGenerated();
+	const data = readModelsJson();
+	const overridesWritten = applyContextWindowOverrides(data, providerModels);
 
 	if (overridesWritten > 0) {
 		writeModelsJson(data);

--- a/src/server/agent/orchestration-core.ts
+++ b/src/server/agent/orchestration-core.ts
@@ -155,6 +155,20 @@ export interface ChildHandle {
 	blocking: boolean;
 }
 
+const RESTART_COLLECTION_REMINDER_EXCLUDED_CHILD_KINDS = new Set<ChildKind>([
+	"team",
+	"pr-walkthrough",
+]);
+
+/**
+ * Whether a restored child belongs to the generic post-restart collection flow.
+ * Non-collectable workflows opt out by child kind; all other child kinds keep
+ * existing restart-reminder behaviour and can be collected through `team_wait`.
+ */
+export function shouldSendRestartCollectionReminder(handle: Pick<ChildHandle, "childKind">): boolean {
+	return !RESTART_COLLECTION_REMINDER_EXCLUDED_CHILD_KINDS.has(handle.childKind);
+}
+
 export interface WaitResult {
 	/** Session id of the first child that became settled (idle or terminal). */
 	firstIdle?: string;
@@ -772,8 +786,8 @@ export class OrchestrationCore {
 	 * restored child (restart survival, §4). The owner re-collects through the
 	 * shared `team_wait` path — no transparent tool-call resumption.
 	 *
-	 * `filterOwner` lets callers skip owners handled elsewhere (e.g. team-managed
-	 * children are nudged by team-manager — filter childKind!=="team").
+	 * `filterOwner` lets callers skip child kinds handled elsewhere; the boot path
+	 * uses `shouldSendRestartCollectionReminder` for that policy.
 	 */
 	async remindOwnersWithLiveChildren(filter?: (handle: ChildHandle) => boolean): Promise<number> {
 		let reminded = 0;

--- a/src/server/agent/orchestration-core.ts
+++ b/src/server/agent/orchestration-core.ts
@@ -158,12 +158,15 @@ export interface ChildHandle {
 const RESTART_COLLECTION_REMINDER_EXCLUDED_CHILD_KINDS = new Set<ChildKind>([
 	"team",
 	"pr-walkthrough",
+	"host-agents",
 ]);
 
 /**
  * Whether a restored child belongs to the generic post-restart collection flow.
  * Non-collectable workflows opt out by child kind; all other child kinds keep
  * existing restart-reminder behaviour and can be collected through `team_wait`.
+ * `host-agents` children are collected/polled by their owning extension workflow
+ * (for example PR Walkthrough reviewers), not by generic `team_wait` reminders.
  */
 export function shouldSendRestartCollectionReminder(handle: Pick<ChildHandle, "childKind">): boolean {
 	return !RESTART_COLLECTION_REMINDER_EXCLUDED_CHILD_KINDS.has(handle.childKind);

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -82,7 +82,7 @@ import { TaskStore } from "./task-store.js";
 import type { GateStore } from "./gate-store.js";
 import { bobbitStateDir, bobbitConfigDir, globalAuthPath } from "../bobbit-dir.js";
 import { activeAgentSessionsDir, migratedActiveAgentSessionFileForHostPath, trustedAgentSessionsRoots } from "./agent-session-path.js";
-import { shouldReapChildOnBoot, type OrchestrationCore } from "./orchestration-core.js";
+import { shouldReapChildOnBoot, shouldSendRestartCollectionReminder, type OrchestrationCore } from "./orchestration-core.js";
 
 import type { SandboxManager } from "./sandbox-manager.js";
 import type { LifecycleHub } from "./lifecycle-hub.js";
@@ -4569,12 +4569,12 @@ export class SessionManager {
 		// already-persisted link fields (delegateOf / parentSessionId+childKind)
 		// — no new persisted registry — then remind any owner with live restored
 		// children to re-collect them via team_wait (restart survival, no
-		// transparent tool-call resumption). Team-managed children (childKind
-		// "team") are skipped here; team-manager nudges those in resubscribeTeamEvents.
+		// transparent tool-call resumption). Non-collectable child kinds (for
+		// example team-managed and PR Walkthrough children) are skipped here.
 		if (this.orchestrationCore) {
 			try {
 				this.orchestrationCore.rebuildIndexFromPersisted(persisted);
-				await this.orchestrationCore.remindOwnersWithLiveChildren(h => h.childKind !== "team");
+				await this.orchestrationCore.remindOwnersWithLiveChildren(shouldSendRestartCollectionReminder);
 			} catch (err) {
 				console.warn("[session-manager] OrchestrationCore boot index/reminder failed:", err);
 			}

--- a/tests/aigw-context-window-overrides.test.ts
+++ b/tests/aigw-context-window-overrides.test.ts
@@ -1,0 +1,92 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { applyContextWindowOverrides, parseModelsGeneratedText } = await import("../src/server/agent/aigw-manager.ts");
+
+function modelsFor(providerModels: Map<string, string[]>, provider: string): string[] {
+	return providerModels.get(provider) ?? [];
+}
+
+describe("AIGW contextWindow overrides", () => {
+	it("parses provider-nested and flat models.generated.js shapes", () => {
+		const nested = `
+			export const MODELS = {
+				"amazon-bedrock": {
+					"us.anthropic.claude-sonnet-4-5-v1:0": {
+						id: "us.anthropic.claude-sonnet-4-5-v1:0",
+						provider: "amazon-bedrock",
+						pricing: { input: 3, output: 15 },
+					},
+					"us.anthropic.claude-opus-4-1-v1:0": {
+						provider: "amazon-bedrock",
+					},
+				},
+				"anthropic": {
+					"claude-sonnet-4-5": {
+						provider: "anthropic",
+					},
+					"claude-opus-4-1": {
+						id: "claude-opus-4-1",
+						provider: "anthropic",
+					},
+				},
+			};
+		`;
+
+		const nestedModels = parseModelsGeneratedText(nested);
+		assert.deepEqual(modelsFor(nestedModels, "amazon-bedrock"), [
+			"us.anthropic.claude-sonnet-4-5-v1:0",
+			"us.anthropic.claude-opus-4-1-v1:0",
+		]);
+		assert.deepEqual(modelsFor(nestedModels, "anthropic"), [
+			"claude-sonnet-4-5",
+			"claude-opus-4-1",
+		]);
+		assert.equal(modelsFor(nestedModels, "amazon-bedrock").includes("amazon-bedrock"), false);
+		assert.equal(modelsFor(nestedModels, "anthropic").includes("anthropic"), false);
+
+		const flat = `
+			export const MODELS = {
+				"claude-sonnet-4-5": { id: "claude-sonnet-4-5", provider: "anthropic" },
+				"aws/us.anthropic.claude-opus-4-1-v1:0": { provider: "amazon-bedrock" },
+			};
+		`;
+
+		const flatModels = parseModelsGeneratedText(flat);
+		assert.deepEqual(modelsFor(flatModels, "anthropic"), ["claude-sonnet-4-5"]);
+		assert.deepEqual(modelsFor(flatModels, "amazon-bedrock"), ["aws/us.anthropic.claude-opus-4-1-v1:0"]);
+	});
+
+	it("writes 1M Sonnet/Opus overrides without clobbering user context windows", () => {
+		const data: Record<string, any> = {
+			providers: {
+				anthropic: {
+					apiKey: "sk-test",
+					modelOverrides: {
+						"claude-sonnet-4-5": { contextWindow: 123_456, custom: true },
+					},
+				},
+			},
+		};
+		const providerModels = new Map<string, string[]>([
+			["amazon-bedrock", [
+				"us.anthropic.claude-sonnet-4-5-v1:0",
+				"us.anthropic.claude-opus-4-1-v1:0",
+				"us.anthropic.claude-haiku-4-5-v1:0",
+			]],
+			["anthropic", [
+				"claude-sonnet-4-5",
+				"claude-opus-4-1",
+			]],
+		]);
+
+		const written = applyContextWindowOverrides(data, providerModels);
+		assert.equal(written, 3);
+		assert.equal(data.providers["amazon-bedrock"].modelOverrides["us.anthropic.claude-sonnet-4-5-v1:0"].contextWindow, 1_000_000);
+		assert.equal(data.providers["amazon-bedrock"].modelOverrides["us.anthropic.claude-opus-4-1-v1:0"].contextWindow, 1_000_000);
+		assert.equal(data.providers["amazon-bedrock"].modelOverrides["us.anthropic.claude-haiku-4-5-v1:0"], undefined);
+		assert.deepEqual(data.providers.anthropic.modelOverrides["claude-sonnet-4-5"], { contextWindow: 123_456, custom: true });
+		assert.equal(data.providers.anthropic.modelOverrides["claude-opus-4-1"].contextWindow, 1_000_000);
+		assert.equal(data.providers.anthropic.apiKey, "sk-test");
+	});
+});

--- a/tests/client-host-api.spec.ts
+++ b/tests/client-host-api.spec.ts
@@ -15,9 +15,8 @@
  * once, a file:// fixture loads it, and we drive the helpers via window globals.
  */
 import { test, expect } from "@playwright/test";
-import { execSync } from "node:child_process";
-import fs from "node:fs";
 import path from "node:path";
+import { buildBundle } from "./fixtures/build-bundle";
 
 const FIXTURE = path.resolve("tests/fixtures/client-host-api.html");
 const BUNDLE = path.resolve("tests/fixtures/client-host-api-bundle.js");
@@ -26,26 +25,11 @@ const HOST_SRC = path.resolve("src/app/host-api.ts");
 const SHARED_SRC = path.resolve("src/shared/extension-host/host-api.ts");
 
 test.beforeAll(() => {
-	const entryMtime = Math.max(
-		fs.statSync(ENTRY).mtimeMs,
-		fs.statSync(HOST_SRC).mtimeMs,
-		fs.statSync(SHARED_SRC).mtimeMs,
-	);
-	const bundleExists = fs.existsSync(BUNDLE);
-	const bundleStale = bundleExists && fs.statSync(BUNDLE).mtimeMs < entryMtime;
-	if (!bundleExists || bundleStale) {
-		execSync(
-			[
-				`npx esbuild ${ENTRY}`,
-				"--bundle --format=iife --target=es2022",
-				`--outfile=${BUNDLE}`,
-				"--tsconfig=tsconfig.web.json",
-				"--alias:pdfjs-dist=./tests/fixtures/empty-shim",
-				"--define:import.meta.url='\"http://localhost/\"'",
-			].join(" "),
-			{ stdio: "pipe" },
-		);
-	}
+	buildBundle({
+		entry: ENTRY,
+		outfile: BUNDLE,
+		deps: [ENTRY, HOST_SRC, SHARED_SRC],
+	});
 });
 
 const PAGE = `file://${FIXTURE}`;

--- a/tests/e2e/orchestrate-restart.spec.ts
+++ b/tests/e2e/orchestrate-restart.spec.ts
@@ -242,13 +242,31 @@ test.describe("orchestration restart survival", () => {
 			undefined, undefined, undefined,
 			{ parentSessionId: parent, childKind: "pr-walkthrough", projectId: parentProjectId, title: "PR Walkthrough" },
 		);
+		const hostAgentsInfo = await sm.createSession(
+			sm.getSession(parent)?.cwd,
+			undefined, undefined, undefined,
+			{
+				parentSessionId: parent,
+				childKind: "host-agents",
+				projectId: parentProjectId,
+				title: "PR Walkthrough",
+				role: "pr-reviewer",
+				readOnly: true,
+			},
+		);
 		const teamInfo = await sm.createSession(
 			sm.getSession(parent)?.cwd,
 			undefined, undefined, undefined,
 			{ parentSessionId: parent, childKind: "team", projectId: parentProjectId, title: "Team Worker" },
 		);
 		const prWalkthroughChild = prWalkthroughInfo.id;
+		const hostAgentsChild = hostAgentsInfo.id;
 		const teamChild = teamInfo.id;
+		const persistedHostAgent = sm.getPersistedSession(hostAgentsChild);
+		expect(persistedHostAgent?.childKind).toBe("host-agents");
+		expect(persistedHostAgent?.title).toBe("PR Walkthrough");
+		expect(persistedHostAgent?.role).toBe("pr-reviewer");
+		expect(persistedHostAgent?.readOnly).toBe(true);
 		const parentWs = await connectWs(parent);
 
 		const origRestoreOne = (sm as any).restoreOneSession;
@@ -261,13 +279,15 @@ test.describe("orchestration restart survival", () => {
 			const reminderText = messageText(reminder);
 
 			expect(reminderText).toContain(delegateChild);
-			expect(reminderText, "PR Walkthrough child sessions must not receive generic restart team_wait reminders").not.toContain(prWalkthroughChild);
+			expect(reminderText, "legacy PR Walkthrough child sessions must not receive generic restart team_wait reminders").not.toContain(prWalkthroughChild);
+			expect(reminderText, "PR Walkthrough host-agents reviewers must be polled by their extension workflow, not collected through team_wait").not.toContain(hostAgentsChild);
 			expect(reminderText).not.toContain(teamChild);
 			expect(reminderText).toContain("You have 1 live child agent(s)");
 		} finally {
 			parentWs.close();
 			(sm as any).restoreOneSession = origRestoreOne;
 			await deleteSession(teamChild).catch(() => {});
+			await deleteSession(hostAgentsChild).catch(() => {});
 			await deleteSession(prWalkthroughChild).catch(() => {});
 			await deleteSession(delegateChild).catch(() => {});
 			await deleteSession(parent).catch(() => {});
@@ -311,7 +331,8 @@ test.describe("orchestration restart survival", () => {
 			// The reminder filter skips children handled by other workflows but covers
 			// collectable delegate children.
 			expect(remindFilter!({ childKind: "team" })).toBe(false);
-			expect(remindFilter!({ childKind: "pr-walkthrough" }), "PR Walkthrough child sessions must not receive generic restart team_wait reminders").toBe(false);
+			expect(remindFilter!({ childKind: "pr-walkthrough" }), "legacy PR Walkthrough child sessions must not receive generic restart team_wait reminders").toBe(false);
+			expect(remindFilter!({ childKind: "host-agents" }), "host.agents children are polled by the owning extension workflow, not generic team_wait reminders").toBe(false);
 			expect(remindFilter!({ childKind: "delegate" })).toBe(true);
 
 			// Boot-reap: the orphaned (owner-archived) live child is archived, not left

--- a/tests/e2e/orchestrate-restart.spec.ts
+++ b/tests/e2e/orchestrate-restart.spec.ts
@@ -36,15 +36,20 @@ async function listChildren(ownerId: string): Promise<string[]> {
 	return ((await resp.json()).children ?? []).map((c: any) => c.sessionId);
 }
 
+function messageText(m: WsMsg): string {
+	const msg = m.data?.message;
+	return Array.isArray(msg?.content)
+		? msg.content.map((c: any) => c?.text ?? "").join("")
+		: "";
+}
+
 /** Predicate: parent received an [ORCHESTRATION] live-children reminder. */
 function orchestrationReminderPredicate(): (m: WsMsg) => boolean {
 	return (m) => {
 		if (m.type !== "event" || m.data?.type !== "message_end") return false;
 		const msg = m.data?.message;
 		if (msg?.role !== "user") return false;
-		const text = Array.isArray(msg.content)
-			? msg.content.map((c: any) => c?.text ?? "").join("")
-			: "";
+		const text = messageText(m);
 		return text.includes("[ORCHESTRATION]") && text.includes("team_wait");
 	};
 }
@@ -227,13 +232,55 @@ test.describe("orchestration restart survival", () => {
 		await deleteSession(child).catch(() => {});
 	});
 
+	test("restoreSessions() sends restart collection reminders only for collectable child kinds", async ({ gateway }) => {
+		const sm = gateway.sessionManager;
+		const parent = await createSession();
+		const parentProjectId = sm.getPersistedSession(parent)?.projectId;
+		const delegateChild = await spawnChild(parent, "collectable delegate restart-reminder helper");
+		const prWalkthroughInfo = await sm.createSession(
+			sm.getSession(parent)?.cwd,
+			undefined, undefined, undefined,
+			{ parentSessionId: parent, childKind: "pr-walkthrough", projectId: parentProjectId, title: "PR Walkthrough" },
+		);
+		const teamInfo = await sm.createSession(
+			sm.getSession(parent)?.cwd,
+			undefined, undefined, undefined,
+			{ parentSessionId: parent, childKind: "team", projectId: parentProjectId, title: "Team Worker" },
+		);
+		const prWalkthroughChild = prWalkthroughInfo.id;
+		const teamChild = teamInfo.id;
+		const parentWs = await connectWs(parent);
+
+		const origRestoreOne = (sm as any).restoreOneSession;
+		(sm as any).restoreOneSession = async () => { /* skip heavy live-session restore */ };
+
+		try {
+			const cursor = parentWs.messageCount();
+			await sm.restoreSessions();
+			const reminder = await parentWs.waitForFrom(cursor, orchestrationReminderPredicate(), 15_000);
+			const reminderText = messageText(reminder);
+
+			expect(reminderText).toContain(delegateChild);
+			expect(reminderText, "PR Walkthrough child sessions must not receive generic restart team_wait reminders").not.toContain(prWalkthroughChild);
+			expect(reminderText).not.toContain(teamChild);
+			expect(reminderText).toContain("You have 1 live child agent(s)");
+		} finally {
+			parentWs.close();
+			(sm as any).restoreOneSession = origRestoreOne;
+			await deleteSession(teamChild).catch(() => {});
+			await deleteSession(prWalkthroughChild).catch(() => {});
+			await deleteSession(delegateChild).catch(() => {});
+			await deleteSession(parent).catch(() => {});
+		}
+	});
+
 	// The two tests above drive the boot helpers DIRECTLY. This one asserts the
 	// actual WIRING: that SessionManager.restoreSessions() invokes the rebuild +
-	// the reminder with the childKind!=="team" filter, and that its delegate
+	// the reminder with the restart collection filter, and that its delegate
 	// boot-reap archives an orphaned (owner-archived) live child. Deterministic —
 	// no real reboot, no real LLM. restoreOneSession is stubbed so re-running
 	// restore does not re-spawn already-live regular sessions.
-	test("restoreSessions() wires the rebuild + team-filtered reminder and boot-reaps an orphaned child", async ({ gateway }) => {
+	test("restoreSessions() wires the rebuild + restart collection reminder filter and boot-reaps an orphaned child", async ({ gateway }) => {
 		const sm = gateway.sessionManager;
 		const core = gateway.orchestrationCore;
 		const parent = await createSession();
@@ -261,9 +308,10 @@ test.describe("orchestration restart survival", () => {
 			// Rebuild + reminder were actually invoked by restoreSessions().
 			expect(rebuildCalled).toBe(true);
 			expect(typeof remindFilter).toBe("function");
-			// The reminder filter skips team-managed children (team-manager nudges
-			// those separately) but covers delegate children.
+			// The reminder filter skips children handled by other workflows but covers
+			// collectable delegate children.
 			expect(remindFilter!({ childKind: "team" })).toBe(false);
+			expect(remindFilter!({ childKind: "pr-walkthrough" }), "PR Walkthrough child sessions must not receive generic restart team_wait reminders").toBe(false);
 			expect(remindFilter!({ childKind: "delegate" })).toBe(true);
 
 			// Boot-reap: the orphaned (owner-archived) live child is archived, not left

--- a/tests/e2e/ui/pill-overflow-promotion.spec.ts
+++ b/tests/e2e/ui/pill-overflow-promotion.spec.ts
@@ -14,6 +14,34 @@ import type { Page } from "@playwright/test";
 import { navigateToHash, openApp } from "./ui-helpers.js";
 
 const padName = (i: number): string => `qa-pill-xxxxxx-${i.toString().padStart(2, "0")}`;
+const bgProcessesRoute = (sessionId: string): string => `**/api/sessions/${sessionId}/bg-processes`;
+
+type MockBgProcess = {
+	id: string;
+	name: string;
+	command: string;
+	pid: number;
+	status: "running";
+	exitCode: null;
+	terminalReason: null;
+	startTime: number;
+	endTime: null;
+};
+
+function createMockProcesses(count: number): MockBgProcess[] {
+	const startTime = Date.now();
+	return Array.from({ length: count }, (_, i) => ({
+		id: `mock-bg-${i + 1}`,
+		name: padName(i + 1),
+		command: "mock long-running command",
+		pid: 10_000 + i,
+		status: "running" as const,
+		exitCode: null,
+		terminalReason: null,
+		startTime: startTime + i,
+		endTime: null,
+	}));
+}
 
 async function settleTwoRafs(page: Page): Promise<void> {
 	await page.evaluate(
@@ -47,34 +75,36 @@ async function forcePillOverflowMeasure(page: Page): Promise<boolean> {
 	});
 }
 
-async function seedPillsInUI(page: Page, count: number): Promise<string[]> {
-	const startTime = Date.now();
-	const processes = Array.from({ length: count }, (_, i) => ({
-		id: `mock-bg-${i + 1}`,
-		name: padName(i + 1),
-		command: "mock long-running command",
-		pid: 10_000 + i,
-		status: "running" as const,
-		exitCode: null,
-		terminalReason: null,
-		startTime: startTime + i,
-		endTime: null,
-	}));
-	await page.evaluate(async (mockProcesses) => {
-		await customElements.whenDefined("bg-process-pill");
+async function installMockBgProcessesApi(page: Page, sessionId: string, processes: MockBgProcess[]): Promise<void> {
+	await page.route(bgProcessesRoute(sessionId), async (route) => {
+		if (route.request().method() !== "GET") {
+			await route.fallback();
+			return;
+		}
+		await route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify({ processes }),
+		});
+	});
+}
+
+async function waitForMockPillsHydrated(page: Page, sessionId: string, expectedCount: number): Promise<void> {
+	await page.waitForFunction(({ id, count }) => {
 		const ai = document.querySelector("agent-interface") as
-			| (HTMLElement & { bgProcesses?: unknown[]; requestUpdate?: () => void; updateComplete?: Promise<unknown>; _measurePillOverflow?: () => void })
+			| (HTMLElement & { session?: { sessionId?: string }; bgProcesses?: Array<{ id?: string }> })
 			| null;
-		if (!ai) throw new Error("agent-interface not mounted");
-		ai.bgProcesses = mockProcesses;
-		ai.requestUpdate?.();
-		await ai.updateComplete;
-		await new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())));
-		ai._measurePillOverflow?.();
-		await ai.updateComplete;
-	}, processes);
+		return ai?.session?.sessionId === id
+			&& Array.isArray(ai.bgProcesses)
+			&& ai.bgProcesses.length === count
+			&& ai.bgProcesses.every((p) => typeof p.id === "string" && p.id.startsWith("mock-bg-"));
+	}, { id: sessionId, count: expectedCount }, { timeout: 15_000 });
+	await customElementsReady(page);
 	await settleTwoRafs(page);
-	return processes.map((p) => p.id);
+}
+
+async function customElementsReady(page: Page): Promise<void> {
+	await page.evaluate(() => customElements.whenDefined("bg-process-pill"));
 }
 
 async function dismissPillsFromUI(page: Page, idsToRemove: string[]): Promise<void> {
@@ -101,13 +131,23 @@ test.describe("pill strip overflow — real app smoke", () => {
 		const sessionId = await createSession();
 		await waitForSessionStatus(sessionId, "idle");
 
+		const processes = createMockProcesses(15);
+		await installMockBgProcessesApi(page, sessionId, processes);
+		const bgProcessesLoaded = page.waitForResponse((response) => {
+			return response.url().includes(`/api/sessions/${sessionId}/bg-processes`)
+				&& response.request().method() === "GET"
+				&& response.ok();
+		}, { timeout: 15_000 });
+
 		await openApp(page);
 		await navigateToHash(page, `#/session/${sessionId}`);
 		await waitForActiveSession(page, sessionId);
 		await expect(page.locator("textarea").first()).toBeVisible({ timeout: 15_000 });
+		await bgProcessesLoaded;
+		await waitForMockPillsHydrated(page, sessionId, processes.length);
 		await page.setViewportSize({ width: 540, height: 800 });
 
-		const ids = await seedPillsInUI(page, 15);
+		const ids = processes.map((p) => p.id);
 		await expect.poll(() => forcePillOverflowMeasure(page), {
 			timeout: 10_000,
 			message: "mocked background pills should collapse behind the More button",

--- a/tests/e2e/ui/pr-walkthrough-pack.spec.ts
+++ b/tests/e2e/ui/pr-walkthrough-pack.spec.ts
@@ -713,9 +713,9 @@ test.describe("PR walkthrough — launch UX (NO_PR error + child-session pane)",
 		return (await page.locator('[data-testid="prw-persisted-at"]').first().textContent())?.trim();
 	}
 
-	async function assertLabelledRailRowsDoNotOverlap(page: import("@playwright/test").Page, label: string): Promise<void> {
+	async function assertCompactRailStepsDoNotOverlap(page: import("@playwright/test").Page, label: string): Promise<void> {
 		const violations = await page.evaluate(() => {
-			const rail = document.querySelector('[data-testid="pr-walkthrough-labelled-rail"]');
+			const rail = document.querySelector('[data-testid="pr-walkthrough-collapsed-rail"]');
 			const isVisible = (element: Element | null): element is HTMLElement => {
 				if (!(element instanceof HTMLElement)) return false;
 				const style = getComputedStyle(element);
@@ -723,35 +723,22 @@ test.describe("PR walkthrough — launch UX (NO_PR error + child-session pane)",
 				return style.visibility !== "hidden" && style.display !== "none" && rect.width > 0 && rect.height > 0;
 			};
 			const problems: string[] = [];
-			if (!rail || !isVisible(rail)) return ["labelled rail is not visible"];
-			for (const row of Array.from(rail.querySelectorAll('[data-testid="pr-walkthrough-phase-button"]'))) {
-				if (!isVisible(row)) continue;
-				const name = row.querySelector(".phase-name");
-				const count = row.querySelector(".phase-count");
-				if (!isVisible(name) || !isVisible(count)) continue;
-				const rowBox = row.getBoundingClientRect();
-				const nameBox = name.getBoundingClientRect();
-				const countBox = count.getBoundingClientRect();
-				const title = (name.textContent || "phase").trim();
-				if (nameBox.right > countBox.left - 2) problems.push(`${title}: phase name overlaps count (${nameBox.right.toFixed(1)} > ${countBox.left.toFixed(1)} - 2)`);
-				if (nameBox.left < rowBox.left - 0.5) problems.push(`${title}: phase name starts outside row`);
-				if (countBox.right > rowBox.right + 0.5) problems.push(`${title}: phase count ends outside row`);
-			}
-			for (const row of Array.from(rail.querySelectorAll(".card-button"))) {
-				if (!isVisible(row)) continue;
-				const dot = row.querySelector(".card-dot");
-				const label = row.querySelector(".card-label");
-				if (!isVisible(dot) || !isVisible(label)) continue;
-				const rowBox = row.getBoundingClientRect();
+			if (!rail || !isVisible(rail)) return ["compact rail is not visible"];
+			const railBox = rail.getBoundingClientRect();
+			for (const step of Array.from(rail.querySelectorAll('[data-testid="pr-walkthrough-orientation-step"], [data-testid="pr-walkthrough-card-step"]'))) {
+				if (!isVisible(step)) continue;
+				const dot = step.querySelector(".step-dot, .card-dot");
+				if (!isVisible(dot)) continue;
+				const stepBox = step.getBoundingClientRect();
 				const dotBox = dot.getBoundingClientRect();
-				const labelBox = label.getBoundingClientRect();
-				const title = (label.textContent || "card").trim();
-				if (dotBox.right > labelBox.left + 0.5) problems.push(`${title}: card dot overlaps label (${dotBox.right.toFixed(1)} > ${labelBox.left.toFixed(1)})`);
-				if (labelBox.right > rowBox.right + 0.5) problems.push(`${title}: card label ends outside row`);
+				const title = step.getAttribute("aria-label") || step.getAttribute("data-card-id") || "step";
+				if (stepBox.width > railBox.width + 0.5) problems.push(`${title}: step overflows rail width (${stepBox.width.toFixed(1)} > ${railBox.width.toFixed(1)})`);
+				if (dotBox.left < railBox.left - 0.5 || dotBox.right > railBox.right + 0.5) problems.push(`${title}: dot overflows rail`);
+				if (Math.abs((dotBox.left + dotBox.width / 2) - (railBox.left + railBox.width / 2)) > 1.5) problems.push(`${title}: dot is not centered in rail`);
 			}
 			return problems;
 		});
-		expect.soft(violations, `${label}: phase/card rail rows must not overlap fixed dots or counts`).toEqual([]);
+		expect.soft(violations, `${label}: compact rail steps must stay centered and non-overlapping`).toEqual([]);
 	}
 
 	// ── T-4: the walkthrough pane lives WITH the reviewer-child session. On mount the
@@ -807,10 +794,9 @@ test.describe("PR walkthrough — launch UX (NO_PR error + child-session pane)",
 		expect(persistedAt2, "reload must rehydrate the SAME persisted store record via recover").toBe(persistedAt1);
 	});
 
-	// ── T-5: regression coverage for the PR walkthrough rail polish. Orientation
-	//    beats are the only orientation navigation surface; phase counters use the
-	//    same compact gate-counter vocabulary; title rows reserve fixed dot/count
-	//    real estate at both default and constrained widths. ──
+	// ── T-5: regression coverage for the simplified PR walkthrough rail polish.
+	//    Orientation beats are represented once, labelled/toggle/resize rail chrome
+	//    stays absent, and compact step counters remain centered/non-overlapping. ──
 	test("T-5 — sidebar de-duplicates orientation and keeps rail counters compact/non-overlapping", async ({ page, gateway }) => {
 		await page.setViewportSize({ width: 1600, height: 900 });
 		const sid = await seedReadyWalkthrough(page, gateway, "prw-t5-sidebar-regression");
@@ -820,66 +806,46 @@ test.describe("PR walkthrough — launch UX (NO_PR error + child-session pane)",
 		});
 		await openRecoveredReadyWalkthrough(page, "prw-t5-sidebar-regression");
 
-		const labelledRail = page.getByTestId("pr-walkthrough-labelled-rail");
-		if (!(await labelledRail.isVisible())) {
-			await page.getByTestId("pr-walkthrough-collapsed-rail").getByTestId("pr-walkthrough-rail-toggle").click();
-		}
-		await expect(labelledRail, "labelled rail must render in expanded mode").toBeVisible();
-		await expect(labelledRail.getByTestId("pr-walkthrough-orientation-rail"), "orientation beats must render in the labelled rail").toBeVisible();
+		const compactRail = page.getByTestId("pr-walkthrough-collapsed-rail");
+		await expect(compactRail, "simplified compact rail must render").toBeVisible();
+		await expect(page.getByTestId("pr-walkthrough-labelled-rail"), "obsolete labelled rail must not render").toHaveCount(0);
+		await expect(page.getByTestId("pr-walkthrough-rail-toggle"), "simplified rail must not expose expand/collapse controls").toHaveCount(0);
+		await expect(page.getByTestId("pr-walkthrough-rail-resize"), "simplified rail must not expose resize controls").toHaveCount(0);
+		await expect(page.getByTestId("pr-walkthrough-phase-button"), "simplified rail must not render phase/category rows").toHaveCount(0);
 
-		const labelledDuplicateOrientationCards = labelledRail.locator('.card-button[data-prw-nav="orientation-summary"]:visible');
+		const orientationRail = compactRail.getByTestId("pr-walkthrough-orientation-rail");
+		await expect(orientationRail, "orientation beats must render once in the compact rail").toBeVisible();
+		expect.soft(await compactRail.getByTestId("pr-walkthrough-orientation-rail").count(), "compact rail must not duplicate the orientation beat rail").toBe(1);
+		expect.soft(await compactRail.getByTestId("pr-walkthrough-orientation-step").count(), "orientation beat controls must be present").toBeGreaterThan(0);
 		expect.soft(
-			await labelledDuplicateOrientationCards.count(),
-			"labelled rail must not duplicate orientation card buttons outside the orientation beat rail",
+			await compactRail.locator('.card-button[data-prw-nav="orientation-summary"]:visible').count(),
+			"compact rail must not duplicate orientation card buttons outside the orientation beat controls",
 		).toBe(0);
 		expect.soft(
-			await labelledRail.getByTestId("pr-walkthrough-phase-button").filter({ has: page.locator(".phase-name").filter({ hasText: /^Orientation$/ }) }).count(),
-			"labelled rail must not render a duplicate Orientation phase row when orientation beats are present",
+			await compactRail.locator('[data-testid="pr-walkthrough-phase-button"][aria-label="Orientation"]:visible').count(),
+			"compact rail must not render a duplicate Orientation phase pip when orientation beats are present",
 		).toBe(0);
 
-		const phaseCounts = labelledRail.locator('[data-testid="pr-walkthrough-phase-button"]:visible .phase-count');
-		expect(await phaseCounts.count(), "the labelled rail must expose phase progress counts").toBeGreaterThan(0);
-		const countTexts = (await phaseCounts.allTextContents()).map((text) => text.trim());
-		for (const text of countTexts) {
-			expect.soft(text, `phase progress count must use gate-counter format (n/total), got ${text}`).toMatch(/^\(\d+\/\d+\)$/);
-		}
-		const firstCountStyle = await phaseCounts.first().evaluate((node) => {
-			const style = getComputedStyle(node as HTMLElement);
+		const reviewSteps = compactRail.getByTestId("pr-walkthrough-card-step");
+		expect(await reviewSteps.count(), "review card steps must render after orientation beats").toBeGreaterThan(0);
+		const firstReviewStepText = (await reviewSteps.first().textContent())?.trim() || "";
+		expect(firstReviewStepText, "review step counters must use compact numeric dots").toMatch(/^\d+$/);
+		const firstStepMetrics = await compactRail.locator('[data-testid="pr-walkthrough-orientation-step"], [data-testid="pr-walkthrough-card-step"]').first().evaluate((node) => {
+			const dot = node.querySelector(".step-dot, .card-dot") as HTMLElement | null;
+			const style = dot ? getComputedStyle(dot) : undefined;
 			return {
-				whiteSpace: style.whiteSpace,
-				fontWeight: Number.parseInt(style.fontWeight, 10),
-				fontSize: Number.parseFloat(style.fontSize),
-				letterSpacing: style.letterSpacing,
+				fontSize: style ? Number.parseFloat(style.fontSize) : 0,
+				width: dot?.getBoundingClientRect().width || 0,
+				height: dot?.getBoundingClientRect().height || 0,
 			};
 		});
-		expect.soft(firstCountStyle.whiteSpace, "phase progress count must not wrap").toBe("nowrap");
-		expect.soft(firstCountStyle.fontWeight, "phase progress count must be semibold/bold like gate counters").toBeGreaterThanOrEqual(600);
-		expect.soft(firstCountStyle.fontSize, "phase progress count must stay compact like gate counters").toBeLessThanOrEqual(12);
-		expect.soft(firstCountStyle.letterSpacing, "phase progress count should use tight gate-counter letter spacing").not.toBe("normal");
+		expect.soft(firstStepMetrics.fontSize, "compact step counters must stay small").toBeLessThanOrEqual(12);
+		expect.soft(firstStepMetrics.width, "compact step dots must reserve a fixed width").toBeGreaterThanOrEqual(18);
+		expect.soft(firstStepMetrics.height, "compact step dots must reserve a fixed height").toBeGreaterThanOrEqual(18);
 
-		await assertLabelledRailRowsDoNotOverlap(page, "default rail width");
-
-		const resizeHandle = page.getByTestId("pr-walkthrough-rail-resize");
-		await expect(resizeHandle, "expanded desktop rail must expose the resize handle").toBeVisible();
-		const resizeBox = await resizeHandle.boundingBox();
-		expect(resizeBox, "resize handle must have a measurable box").toBeTruthy();
-		await page.mouse.move(resizeBox!.x + resizeBox!.width / 2, resizeBox!.y + resizeBox!.height / 2);
-		await page.mouse.down();
-		await page.mouse.move(resizeBox!.x - 110, resizeBox!.y + resizeBox!.height / 2, { steps: 8 });
-		await page.mouse.up();
-		await assertLabelledRailRowsDoNotOverlap(page, "constrained rail width");
-
-		await page.getByTestId("pr-walkthrough-rail-toggle").click();
-		const collapsedRail = page.getByTestId("pr-walkthrough-collapsed-rail");
-		await expect(collapsedRail, "collapsed rail must render after toggling").toBeVisible();
-		await expect(collapsedRail.getByTestId("pr-walkthrough-orientation-rail"), "orientation beats must remain represented in collapsed mode").toBeVisible();
-		expect.soft(
-			await collapsedRail.locator('.card-button[data-prw-nav="orientation-summary"]:visible').count(),
-			"collapsed rail must not duplicate orientation card buttons outside the orientation beat controls",
-		).toBe(0);
-		expect.soft(
-			await collapsedRail.locator('[data-testid="pr-walkthrough-phase-button"][aria-label="Orientation"]:visible').count(),
-			"collapsed rail must not render a duplicate Orientation phase pip when orientation beats are present",
-		).toBe(0);
+		await assertCompactRailStepsDoNotOverlap(page, "fullscreen rail width");
+		await page.setViewportSize({ width: 900, height: 720 });
+		await expect(compactRail, "compact rail must remain visible in constrained width").toBeVisible();
+		await assertCompactRailStepsDoNotOverlap(page, "constrained rail width");
 	});
 });

--- a/tests/e2e/ui/terminal-pack.spec.ts
+++ b/tests/e2e/ui/terminal-pack.spec.ts
@@ -323,19 +323,36 @@ async function assertNoRepeatedTopRowGlyphArtifact(page: import("@playwright/tes
 }
 
 async function assertLatestTerminalInputVisibleAtBottom(page: import("@playwright/test").Page, expected: string, reason: string): Promise<void> {
-	const snapshot = await terminalViewportContent(page);
-	const bottomRows = nearBottomRows(snapshot.rows);
-	const bottomText = bottomRows.join("\n");
-	const bottomSoftWrappedText = bottomRows.join("");
 	const expectedTail = expected.slice(-32);
-	expect(
-		snapshot.atBottom,
-		`${reason}: terminal scroll regression - xterm viewport should be pinned to the bottom for the active prompt/input. scrollTop=${snapshot.scrollTop}, maxScrollTop=${snapshot.maxScrollTop}`,
-	).toBe(true);
-	expect(
-		bottomSoftWrappedText.includes(expected) || bottomSoftWrappedText.includes(expectedTail),
-		`${reason}: terminal scroll regression - expected latest prompt/input "${expected}" or its unique tail "${expectedTail}" in the near-bottom xterm rows, allowing xterm soft wrapping and trailing blank rows. Bottom rows:\n${bottomText}\n\nVisible rows:\n${snapshot.rows.join("\n")}`,
-	).toBe(true);
+	let lastSnapshot: Awaited<ReturnType<typeof terminalViewportContent>> | undefined;
+	try {
+		await expect.poll(async () => {
+			lastSnapshot = await terminalViewportContent(page);
+			return latestTerminalInputVisibleAtBottom(lastSnapshot, expected, expectedTail);
+		}, {
+			message: `${reason}: latest prompt/input should settle in the near-bottom xterm rows after PTY echo and prompt pinning`,
+			timeout: 10_000,
+		}).toBe(true);
+		return;
+	} catch {
+		const snapshot = lastSnapshot ?? await terminalViewportContent(page);
+		const bottomRows = nearBottomRows(snapshot.rows);
+		const bottomText = bottomRows.join("\n");
+		const bottomSoftWrappedText = bottomRows.join("");
+		expect(
+			snapshot.atBottom,
+			`${reason}: terminal scroll regression - xterm viewport should be pinned to the bottom for the active prompt/input. scrollTop=${snapshot.scrollTop}, maxScrollTop=${snapshot.maxScrollTop}`,
+		).toBe(true);
+		expect(
+			bottomSoftWrappedText.includes(expected) || bottomSoftWrappedText.includes(expectedTail),
+			`${reason}: terminal scroll regression - expected latest prompt/input "${expected}" or its unique tail "${expectedTail}" in the near-bottom xterm rows, allowing xterm soft wrapping and trailing blank rows. Bottom rows:\n${bottomText}\n\nVisible rows:\n${snapshot.rows.join("\n")}`,
+		).toBe(true);
+	}
+}
+
+function latestTerminalInputVisibleAtBottom(snapshot: Awaited<ReturnType<typeof terminalViewportContent>>, expected: string, expectedTail: string): boolean {
+	const bottomSoftWrappedText = nearBottomRows(snapshot.rows).join("");
+	return snapshot.atBottom && (bottomSoftWrappedText.includes(expected) || bottomSoftWrappedText.includes(expectedTail));
 }
 
 async function assertTerminalTextVisibleNearBottom(page: import("@playwright/test").Page, expected: string, reason: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Suppress generic post-restart `team_wait` collection reminders for PR Walkthrough reviewer children, including current `host-agents` reviewers.
- Keep regular delegate restart reminders intact and keep `team` children excluded.
- Add restart-reminder E2E coverage for delegate, `pr-walkthrough`, `host-agents`, and `team` child kinds.
- Update orchestration and PR Walkthrough docs for the child-kind reminder policy.

## Validation

- `npm run check`
- `npm run build:server`
- `npm run test:e2e:run -- tests/e2e/orchestrate-restart.spec.ts -g "restoreSessions\(\) sends restart collection reminders only for collectable child kinds|restoreSessions\(\) wires the rebuild \+ restart collection reminder filter"`
- `npm run test:e2e:run -- tests/e2e/pr-walkthrough-host-agents.spec.ts -g "a post-submit reviewer survives a simulated restart"`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)