### PR TITLE
Fix provider API key status in settings

### DIFF
--- a/src/ui/components/ProviderKeyInput.ts
+++ b/src/ui/components/ProviderKeyInput.ts
@@ -41,8 +41,21 @@ export class ProviderKeyInput extends LitElement {
 
 	private async checkKeyStatus() {
 		try {
+			// Server preferences are authoritative for user-saved API keys. The
+			// client provider-keys store may contain the `gateway-managed` sentinel
+			// used to suppress direct-mode prompts for a remote session; that is not a
+			// real API key and must not make Settings show a key as configured.
+			const res = await gatewayFetch("/api/provider-keys");
+			if (res.ok) {
+				const data = await res.json() as { providers?: unknown };
+				this.hasKey = Array.isArray(data.providers) && data.providers.includes(this.provider);
+				return;
+			}
+		} catch { /* fall back to the legacy local store below */ }
+
+		try {
 			const key = await getAppStorage().providerKeys.get(this.provider);
-			this.hasKey = !!key;
+			this.hasKey = !!key && key !== "gateway-managed";
 		} catch (error) {
 			console.error("Failed to check key status:", error);
 		}
@@ -73,13 +86,15 @@ export class ProviderKeyInput extends LitElement {
 
 		if (success) {
 			try {
-				await getAppStorage().providerKeys.set(this.provider, this.keyInput);
-				// Also store server-side for unified model registry auth detection
-				gatewayFetch(`/api/provider-keys/${encodeURIComponent(this.provider)}`, {
+				// Store server-side first so Settings only reports a key as configured
+				// once the runtime's authoritative preference store has it.
+				const res = await gatewayFetch(`/api/provider-keys/${encodeURIComponent(this.provider)}`, {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({ key: this.keyInput }),
-				}).catch(() => {});
+				});
+				if (!res.ok) throw new Error(`Failed to save provider key: HTTP ${res.status}`);
+				await getAppStorage().providerKeys.set(this.provider, this.keyInput);
 				this.hasKey = true;
 				this.inputChanged = false;
 				this.requestUpdate();
@@ -109,7 +124,7 @@ export class ProviderKeyInput extends LitElement {
 						this.testing
 							? Badge({ children: i18n("Testing..."), variant: "secondary" })
 							: this.hasKey
-								? html`<span class="text-green-600 dark:text-green-400">✓</span>`
+								? html`<span class="text-green-600 dark:text-green-400" data-testid="provider-key-present">✓</span>`
 								: ""
 					}
 					${this.failed ? Badge({ children: i18n("✗ Invalid"), variant: "destructive" }) : ""}

--- a/tests/fixtures/settings-models-tab-entry.ts
+++ b/tests/fixtures/settings-models-tab-entry.ts
@@ -4,6 +4,7 @@
 import { render } from "lit";
 import { __testResetModelsTab, renderModelsTab } from "../../src/app/settings-page.js";
 import { setRenderApp } from "../../src/app/state.js";
+import { storage } from "../../src/app/storage.js";
 
 // ── Fetch stub ────────────────────────────────────────────────────────────────
 type StubResponseInit = { ok: boolean; status?: number; body: any };
@@ -15,6 +16,8 @@ let responder: Responder = { ok: true, body: {} };
 (window as any).__setNextFetchResponse = (r: Responder) => { responder = r; };
 (window as any).__getFetchLog = () => fetchLog.slice();
 (window as any).__clearFetchLog = () => { fetchLog.length = 0; };
+(window as any).__seedProviderKey = (provider: string, key: string) => storage.providerKeys.set(provider, key);
+(window as any).__clearProviderKey = (provider: string) => storage.providerKeys.delete(provider);
 
 const origFetch = window.fetch.bind(window);
 window.fetch = (async (input: any, init?: RequestInit) => {

--- a/tests/settings-models-tab-redesign.spec.ts
+++ b/tests/settings-models-tab-redesign.spec.ts
@@ -255,6 +255,29 @@ test.describe("Settings Models tab redesign", () => {
 		expect(dialogExists).toBe(true);
 	});
 
+	test("Provider API Keys ignores gateway-managed session sentinel", async ({ page }) => {
+		await gotoAndWait(page);
+		await page.evaluate(async () => {
+			await (window as any).__seedProviderKey("anthropic", "gateway-managed");
+			(window as any).__setNextFetchResponse((url: string) => {
+				if (url === "/api/provider-keys") return { ok: true, body: { providers: [] } };
+				if (url === "/api/aigw/status") return { ok: true, body: { configured: false, url: "", models: [] } };
+				if (url === "/api/models") return { ok: true, body: [] };
+				if (url === "/api/image-models") return { ok: true, body: [] };
+				return { ok: true, body: {} };
+			});
+			(window as any).__clearFetchLog();
+		});
+		await page.evaluate((opts) => (window as any).__resetModelsTab(opts), {
+			aigwConfigured: false,
+			allModels: ALL_MODELS,
+		});
+
+		await page.waitForFunction(() => (window as any).__getFetchLog().filter((e: any) => e.url === "/api/provider-keys").length >= 4);
+		const anthropicKey = page.locator('[data-testid="provider-key-input-anthropic"]');
+		await expect(anthropicKey.locator('[data-testid="provider-key-present"]')).toHaveCount(0);
+	});
+
 	// Settings-drift acceptance: the live Models tab must expose a Provider API
 	// Keys entry point (the API-key fallback) so users are not directed to a
 	// nonexistent screen. The Google AI Studio key path (`google`) must be present.


### PR DESCRIPTION
## Summary
- Treat server provider-key preferences as the authoritative Settings status source.
- Ignore the local `gateway-managed` sentinel so remote sessions do not appear as saved API keys.
- Add a regression test for the Anthropic false-positive status.

## Tests
- `npm run check`
- `npm run test:unit`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)