### PR TITLE
Fix market pack roles

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -367,7 +367,7 @@ On server startup, standalone stores (`roleStore`) are seeded with builtins that
 
 #### Session setup integration
 
-The session setup pipeline (`session-setup.ts`) resolves roles and tools through `ConfigCascade` when a `plan.projectId` is available. A `lookupRole()` helper in the pipeline prefers cascade-resolved roles, falling back to the standalone store. This ensures sessions see the full three-layer resolution even when project config dirs are empty.
+The session setup pipeline (`session-setup.ts`) resolves roles and tools through `ConfigCascade` when a `plan.projectId` is available. A `lookupRole()` helper in the pipeline prefers cascade-resolved roles, falling back to the standalone store. Session and staff REST paths use the same cascade-first role lookup for creation, assignment, validation, and persisted-session rehydration, so any role shown by `GET /api/roles` can run in the matching project scope. Unknown roles still fail before dispatch.
 
 #### REST API
 
@@ -857,7 +857,7 @@ Non-sandboxed continues use the same worktree allocation path as normal session 
 
 - `projectId`
 - `modelProvider`, `modelId` (applied post-create via `setModel` + persisted immediately; worktree sessions set the model once the agent is ready)
-- `role` (resolved via `roleManager.getRole()`, so prompt/accessory/tool policies are re-applied fresh)
+- `role` (resolved cascade-first, with legacy `roleManager.getRole()` fallback, so prompt/accessory/tool policies are re-applied fresh)
 - `sandboxed` flag (new container state per normal per-project sandbox rules)
 - `worktreePath` presence - if the source had a worktree, the new session requests a fresh worktree via the standard create-session pipeline against the current project repo/base ref, including normal pool claim/fallback semantics for non-sandboxed sessions
 

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -496,6 +496,16 @@ The Roles (`#/roles`), Tools (`#/tools`), and Skills (`#/skills`) pages need no 
 
 Market-pack entities are read-only on those pages (manage them from the Market surface, not by editing the config page).
 
+### Runtime role lookup
+
+Any role returned by `GET /api/roles` is usable anywhere the runtime accepts a role id. Session creation (`POST /api/sessions`), session role assignment (`PATCH /api/sessions/:id`), staff create/update validation, and persisted-session rehydration paths resolve roles through `ConfigCascade.resolveRoles(projectId)` first, then fall back to the legacy `roleManager.getRole(...)` store lookup for compatibility.
+
+This keeps the API and runtime in sync: a market-pack or built-in first-party pack role shown in the Roles page can be selected for sessions and staff agents. The winning role is the same one the cascade exposes, so existing precedence still applies: project-specific entries win over server/global-user entries, and user-pack overrides win over market packs in the same scope (see [Scopes & precedence](#scopes--precedence)).
+
+Runtime resolution preserves the full role record, including `promptTemplate`, `accessory`, `model`, `thinkingLevel`, and `toolPolicies`, so pack roles can carry prompts, UI accessories, model/thinking defaults, and tool grants into sessions just like hand-written roles.
+
+Unknown role ids still fail loudly in REST validation paths, normally as `404`. Callers cannot select a pack identity directly: runtime paths only consume roles already resolved by the config cascade for the target project/scope, which preserves the marketplace security boundary and avoids trusting caller-supplied provenance.
+
 ## Scopes & precedence
 
 The base scope order is **fixed**, lowest→highest priority:

--- a/src/server/agent/role-prompt.ts
+++ b/src/server/agent/role-prompt.ts
@@ -4,7 +4,17 @@ import type { RoleManager } from "./role-manager.js";
 import type { PersistedStaff } from "./staff-store.js";
 
 interface RoleLike {
+	name?: string;
 	promptTemplate?: string;
+	accessory?: string;
+}
+
+type RoleResolver = (roleName: string, projectId?: string) => RoleLike | undefined;
+type RoleManagerWithResolver = RoleManager & { resolveRoleForProject?: RoleResolver };
+
+function resolverFromRoleManager(roleManager?: RoleManager): RoleResolver | undefined {
+	const maybeResolver = (roleManager as RoleManagerWithResolver | undefined)?.resolveRoleForProject;
+	return typeof maybeResolver === "function" ? maybeResolver.bind(roleManager) : undefined;
 }
 
 interface RoleSource {
@@ -58,10 +68,12 @@ export function resolveRolePrompt(
 export function buildStaffSystemPrompt(
 	staff: PersistedStaff,
 	roleManager?: RoleManager,
+	resolveRole?: RoleResolver,
 ): string {
 	let prompt = "";
-	if (staff.roleId && roleManager) {
-		const role = roleManager.getRole(staff.roleId);
+	if (staff.roleId) {
+		const cascadeResolver = resolveRole ?? resolverFromRoleManager(roleManager);
+		const role = cascadeResolver?.(staff.roleId, staff.projectId) ?? roleManager?.getRole(staff.roleId);
 		const rolePrompt = resolveRolePrompt(role, {
 			branch: staff.branch,
 			agentId: `staff-${staff.id.slice(0, 8)}`,
@@ -101,6 +113,8 @@ export function buildRestoreRolePrompt(
 		 * view so project-scoped `promptTemplate` overrides survive a restart.
 		 */
 		resolveTemplate?: (roleName: string, projectId?: string) => string | undefined;
+		/** Optional cascade-first full-role resolver for pack-contributed roles. */
+		resolveRole?: RoleResolver;
 		/** System-scope subgoals feature flag — gates `{if:subGoalsEnabled}` blocks. */
 		subGoalsEnabled?: boolean;
 	},
@@ -108,11 +122,13 @@ export function buildRestoreRolePrompt(
 	if (ps.staffId && ctx.getStaff) {
 		const staff = ctx.getStaff(ps.staffId);
 		if (staff) {
-			return { rolePrompt: buildStaffSystemPrompt(staff, ctx.roleManager), roleName: staff.roleId };
+			return { rolePrompt: buildStaffSystemPrompt(staff, ctx.roleManager, ctx.resolveRole), roleName: staff.roleId };
 		}
 	}
+	const cascadeResolver = ctx.resolveRole ?? resolverFromRoleManager(ctx.roleManager);
 	const template = ps.role
 		? (ctx.resolveTemplate?.(ps.role, ps.projectId)
+			?? cascadeResolver?.(ps.role, ps.projectId)?.promptTemplate
 			?? (ctx.roleManager ? ctx.roleManager.getRole(ps.role)?.promptTemplate : undefined))
 		: undefined;
 	const rolePrompt = resolveRolePrompt(template ? { promptTemplate: template } : undefined, {

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -2599,9 +2599,10 @@ export class SessionManager {
 		// Cascade-first: pack-shipped roles (e.g. `pr-reviewer`) live in the config
 		// cascade, not the in-memory RoleManager. Resolving via roleManager alone
 		// returns `undefined` for a pack role, which on the restore / force-respawn
-		// paths drops its tools (guard falls through to group defaults). Mirror the
-		// cascade-first-then-roleManager pattern used by resolveRolePromptTemplate.
-		if (projectId && this.configCascade) {
+		// paths drops its tools (guard falls through to group defaults). Always ask
+		// the cascade, even without projectId, so server-scope/builtin market-pack
+		// roles work for system-scope sessions too.
+		if (this.configCascade) {
 			try {
 				const match = this.configCascade.resolveRoles(projectId).find(r => r.item.name === name);
 				if (match) return match.item;
@@ -6009,14 +6010,39 @@ export class SessionManager {
 	 * best-ranked model when gateway is configured, otherwise does nothing
 	 * (pi-coding-agent uses its own built-in default).
 	 */
-	/** Resolve a role-level model override for the session, if any. */
-	private resolveRoleModel(session: SessionInfo): string | undefined {
-		if (!session.role || !this.configCascade) return undefined;
+	private readRoleStringField(role: Role | undefined, field: "model" | "thinkingLevel"): string | undefined {
+		const value = role?.[field];
+		if (typeof value !== "string") return undefined;
+		return value.trim().length > 0 ? value : undefined;
+	}
+
+	private resolveRoleModelValue(roleName: string | undefined, projectId: string | undefined): string | undefined {
+		if (!roleName) return undefined;
+		const cascadeValue = this.readRoleStringField(this.resolveSessionRole(roleName, undefined, projectId), "model");
+		if (cascadeValue) return cascadeValue;
+		if (!this.configCascade) return undefined;
 		try {
-			return this.configCascade.resolveRoleModel(session.role, session.projectId);
+			return this.configCascade.resolveRoleModel(roleName, projectId);
 		} catch {
 			return undefined;
 		}
+	}
+
+	private resolveRoleThinkingLevelValue(roleName: string | undefined, projectId: string | undefined): string | undefined {
+		if (!roleName) return undefined;
+		const cascadeValue = this.readRoleStringField(this.resolveSessionRole(roleName, undefined, projectId), "thinkingLevel");
+		if (cascadeValue) return cascadeValue;
+		if (!this.configCascade) return undefined;
+		try {
+			return this.configCascade.resolveRoleThinkingLevel(roleName, projectId);
+		} catch {
+			return undefined;
+		}
+	}
+
+	/** Resolve a role-level model override for the session, if any. */
+	private resolveRoleModel(session: SessionInfo): string | undefined {
+		return this.resolveRoleModelValue(session.role, session.projectId);
 	}
 
 	/**
@@ -6047,12 +6073,7 @@ export class SessionManager {
 
 	/** Resolve a role-level thinkingLevel override for the session, if any. */
 	private resolveRoleThinkingLevel(session: SessionInfo): string | undefined {
-		if (!session.role || !this.configCascade) return undefined;
-		try {
-			return this.configCascade.resolveRoleThinkingLevel(session.role, session.projectId);
-		} catch {
-			return undefined;
-		}
+		return this.resolveRoleThinkingLevelValue(session.role, session.projectId);
 	}
 
 	/**
@@ -6066,13 +6087,11 @@ export class SessionManager {
 	 */
 	resolveInitialModel(role: string | undefined, projectId: string | undefined): string | undefined {
 		// Role override
-		if (role && this.configCascade) {
-			try {
-				const m = this.configCascade.resolveRoleModel(role, projectId);
-				// Skip models that can't run in an agent session (e.g. google-gemini-cli
-				// Code Assist) so a role override doesn't pin an unrunnable provider.
-				if (m && /^[^/]+\/.+$/.test(m) && isSessionSelectableModelString(m)) return m;
-			} catch { /* fall through */ }
+		if (role) {
+			const m = this.resolveRoleModelValue(role, projectId);
+			// Skip models that can't run in an agent session (e.g. google-gemini-cli
+			// Code Assist) so a role override doesn't pin an unrunnable provider.
+			if (m && /^[^/]+\/.+$/.test(m) && isSessionSelectableModelString(m)) return m;
 		}
 		// default.sessionModel preference
 		const pref = this.preferencesStore?.get("default.sessionModel") as string | undefined;
@@ -6088,12 +6107,10 @@ export class SessionManager {
 	 */
 	resolveInitialThinkingLevel(role: string | undefined, projectId: string | undefined): string | undefined {
 		let candidate: string | undefined;
-		if (role && this.configCascade) {
-			try {
-				const t = this.configCascade.resolveRoleThinkingLevel(role, projectId);
-				const known = isKnownThinkingLevel(t);
-				if (known) candidate = known;
-			} catch { /* fall through */ }
+		if (role) {
+			const t = this.resolveRoleThinkingLevelValue(role, projectId);
+			const known = isKnownThinkingLevel(t);
+			if (known) candidate = known;
 		}
 		if (!candidate) {
 			const pref = this.preferencesStore?.get("default.sessionThinkingLevel") as string | undefined;
@@ -6122,11 +6139,9 @@ export class SessionManager {
 	 * verification-harness precedence: role override → `default.reviewModel`.
 	 */
 	resolveInitialReviewModel(role: string | undefined, projectId: string | undefined): string | undefined {
-		if (role && this.configCascade) {
-			try {
-				const m = this.configCascade.resolveRoleModel(role, projectId);
-				if (m && /^[^/]+\/.+$/.test(m) && isSessionSelectableModelString(m)) return m;
-			} catch { /* fall through */ }
+		if (role) {
+			const m = this.resolveRoleModelValue(role, projectId);
+			if (m && /^[^/]+\/.+$/.test(m) && isSessionSelectableModelString(m)) return m;
 		}
 		const pref = this.preferencesStore?.get("default.reviewModel") as string | undefined;
 		if (pref && /^[^/]+\/.+$/.test(pref) && isSessionSelectableModelString(pref)) return pref;
@@ -6665,6 +6680,8 @@ export class SessionManager {
 		reattemptGoalId?: string;
 		sandboxed?: boolean;
 		projectId?: string;
+		spawnPinnedModel?: string;
+		spawnPinnedThinkingLevel?: string;
 	}> {
 		return Array.from(this.sessions.values()).map((s) => {
 			let ps: PersistedSession | undefined;
@@ -6705,6 +6722,8 @@ export class SessionManager {
 				reattemptGoalId: ps?.reattemptGoalId,
 				sandboxed: ps?.sandboxed || s.sandboxed,
 				projectId: ps?.projectId || s.projectId,
+				spawnPinnedModel: s.spawnPinnedModel,
+				spawnPinnedThinkingLevel: s.spawnPinnedThinkingLevel,
 			};
 		});
 	}

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -56,7 +56,7 @@ import { discoverSlashSkills, type SkillMarketContext } from "../skills/slash-sk
 import { getProjectRoot } from "../bobbit-dir.js";
 import { shouldSkipRemotePush, shouldSkipRemoteGitForTests, shouldSkipRemotePushForTests, detectPrimaryBranch, isGitRepo, getRepoRoot, isUnresolvedHeadWorktreeError } from "../skills/git.js";
 import { eagerDeleteRemoteSessionBranch } from "./session-eager-branch-delete.js";
-import type { GrantPolicy } from "./role-store.js";
+import type { GrantPolicy, Role } from "./role-store.js";
 import { applyModelString } from "./review-model-override.js";
 import { sanitizeModelErrorForLog, sanitizeModelErrorText } from "./model-error-sanitizer.js";
 import type { ToolGroupPolicyStore } from "./tool-group-policy-store.js";
@@ -4168,9 +4168,10 @@ export class SessionManager {
 		if (!session) throw new Error("Session not found");
 		if (!this.roleManager) throw new Error("No role manager available");
 
-		// Use explicit role, or fall back to "general" role (implicit default for all sessions)
+		// Use explicit role, or fall back to "general" role (implicit default for all sessions).
+		// Resolve cascade-first so pack-contributed roles keep their policies here too.
 		const roleName = session.role || "general";
-		const role = this.roleManager.getRole(roleName);
+		const role = this.resolveSessionRole(roleName, undefined, session.projectId);
 		if (!role) throw new Error(`Role "${roleName}" not found`);
 
 		const effectiveAllowed = this.resolveEffectiveAllowedTools(role).map(e => e.name);
@@ -4230,15 +4231,20 @@ export class SessionManager {
 			resultTools = session.allowedTools;
 
 		} else {
-			// Persistent grant (default): update toolPolicies on role YAML (allowedTools is derived automatically)
+			// Persistent grant (default): update toolPolicies on role YAML when the
+			// role is locally writable. Pack roles are read-only through RoleManager,
+			// so keep the grant effective for this session without writing to the pack.
 			const updatedPolicies = { ...role.toolPolicies };
 			for (const t of newTools) {
 				updatedPolicies[t] = 'allow' as GrantPolicy;
 			}
-			this.roleManager.updateRole(role.name, { toolPolicies: updatedPolicies });
-			// Re-read role and recompute effective allowed tools
-			const updatedRole = this.roleManager.getRole(role.name);
-			const updatedEffective = this.resolveEffectiveAllowedTools(updatedRole ?? role).map(e => e.name);
+			const writableRole = this.roleManager.getRole(role.name);
+			let effectiveRole: Role = { ...role, toolPolicies: updatedPolicies };
+			if (writableRole) {
+				this.roleManager.updateRole(role.name, { toolPolicies: updatedPolicies });
+				effectiveRole = this.resolveSessionRole(role.name, undefined, session.projectId) ?? effectiveRole;
+			}
+			const updatedEffective = this.resolveEffectiveAllowedTools(effectiveRole).map(e => e.name);
 			session.allowedTools = updatedEffective;
 			await this._restartSessionWithUpdatedRole(session);
 
@@ -6900,8 +6906,9 @@ export class SessionManager {
 		// Reassemble system prompt with role instructions as separate fields
 		const goal = session.goalId ? this.resolveGoal(session.goalId) : undefined;
 		const goalSpec = goal?.spec;
-		// Look up the full role (with toolPolicies) from roleManager if available
-		const fullRole = this.roleManager?.getRole(role.name);
+		// Look up the full role (with toolPolicies) cascade-first so pack-contributed
+		// roles keep their policies during role reassignment.
+		const fullRole = this.resolveSessionRole(role.name, undefined, session.projectId) ?? (role as Role);
 		// Filter goal-metadata disabled tools (bobbit.disabledTools) for the
 		// session's effective goal so the reassembled prompt, the activation args,
 		// and the persisted allowedTools all agree after a role reassignment.

--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -647,14 +647,10 @@ function _resolveTools(plan: SessionSetupPlan, ctx: PipelineContext): void {
 	// must be preserved so lower activation sees zero tools — never widened back
 	// to the general/role default on first spawn.
 	if (effectiveAllowedTools === undefined && ctx.roleManager) {
-		// Use cascade-resolved role when a projectId is available
+		// Use cascade-resolved role first, including server-scope market-pack roles
+		// when no projectId is present.
 		const roleName = plan.roleName || "general";
-		let role = ctx.roleManager.getRole(roleName);
-		if (plan.projectId && ctx.configCascade) {
-			const resolved = ctx.configCascade.resolveRoles(plan.projectId);
-			const match = resolved.find(r => r.item.name === roleName);
-			if (match) role = match.item;
-		}
+		const role = lookupRole(roleName, plan, ctx);
 		if (role && ctx.toolManager) {
 			effectiveAllowedTools = computeEffectiveAllowedTools(
 				ctx.toolManager, role, ctx.groupPolicyStore ?? undefined, ctx.mcpManager ?? undefined, scopedToolContext(plan.projectId, plan.cwd),
@@ -684,7 +680,7 @@ function _resolveTools(plan: SessionSetupPlan, ctx: PipelineContext): void {
 
 /** Look up a role by name, preferring the cascade-resolved version when available. */
 function lookupRole(name: string, plan: SessionSetupPlan, ctx: PipelineContext): import("./role-store.js").Role | undefined {
-	if (plan.projectId && ctx.configCascade) {
+	if (ctx.configCascade) {
 		const resolved = ctx.configCascade.resolveRoles(plan.projectId);
 		const match = resolved.find(r => r.item.name === name);
 		if (match) return match.item;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -52,7 +52,7 @@ import { backfillLegacyCostGoalIds, backfillLegacyCostGoalIdsFromTranscripts } f
 import { checkGateDependencies } from "./agent/gate-dependency-check.js";
 import { shouldCreateWorktree } from "./agent/worktree-decision.js";
 import { resolveWorktreeSupport } from "./agent/worktree-support.js";
-import { RoleStore } from "./agent/role-store.js";
+import { RoleStore, type Role } from "./agent/role-store.js";
 import { RoleManager } from "./agent/role-manager.js";
 import { ToolManager, copyDirRecursive, __resetToolScanCache, type MarketToolRoot, type PiExtensionExternalTool, type ScopedToolContext } from "./agent/tool-manager.js";
 import { ActionDispatcher, ActionError, resolveActionToolManager } from "./extension-host/action-dispatcher.js";
@@ -1654,6 +1654,11 @@ export function createGateway(config: GatewayConfig) {
 		getToolGroupPolicies: () => groupPolicyStore.getAll(),
 	}, projectContextManager);
 	sessionManager.configCascade = configCascade;
+	const resolveRoleForProject = (roleId: string, projectId?: string): Role | undefined => {
+		const cascadeRole = configCascade.resolveRoles(projectId).find(r => r.item.name === roleId)?.item;
+		return cascadeRole ?? roleManager.getRole(roleId);
+	};
+	(roleManager as RoleManager & { resolveRoleForProject?: typeof resolveRoleForProject }).resolveRoleForProject = resolveRoleForProject;
 
 	// ── Pack-Based Marketplace (single resolver over installed packs) ──────
 	// Sources are global to the server; the cache + sources file live under
@@ -2050,7 +2055,7 @@ export function createGateway(config: GatewayConfig) {
 			const ps = sessionManager.getPersistedSession(sessionId);
 			const roleName = session?.role ?? ps?.role
 				?? ((session?.assistantType ?? ps?.assistantType) ? "assistant" : "general");
-			const role = roleManager.getRole(roleName);
+			const role = resolveRoleForProject(roleName, session?.projectId ?? ps?.projectId);
 			if (!role) return undefined;
 			const mcpManager = sessionManager.getMcpManagerForSession(sessionId)
 				?? ((session?.projectId ?? ps?.projectId ?? session?.cwd ?? ps?.cwd) ? null : sessionManager.getMcpManager());
@@ -2064,8 +2069,7 @@ export function createGateway(config: GatewayConfig) {
 		// compat: a role-carrying team_delegate spawn must not fail closed). Mirrors
 		// the resolveEffectiveTools grant pipeline above.
 		resolveRoleAllowedTools: (roleName: string, projectId?: string) => {
-			const cascadeRole = configCascade.resolveRoles(projectId).find(r => r.item.name === roleName)?.item;
-			const role = cascadeRole ?? roleManager.getRole(roleName);
+			const role = resolveRoleForProject(roleName, projectId);
 			if (!role) return undefined;
 			const mcpManager = projectId ? sessionManager.getMcpManager({ projectId }) : sessionManager.getMcpManager();
 			return computeEffectiveAllowedTools(toolManager, role, groupPolicyStore, mcpManager ?? undefined).map(e => e.name);
@@ -3310,6 +3314,16 @@ async function handleApiRoute(
 		// so roles/tools match the skills wire shape (finding #3).
 		originPackId: r.originPackId ?? null,
 		originPackName: r.originPackName ?? null,
+	});
+	const resolveRoleForProject = (roleId: string, projectId?: string): Role | undefined => {
+		const cascadeRole = configCascade.resolveRoles(projectId).find(r => r.item.name === roleId)?.item;
+		return cascadeRole ?? roleManager.getRole(roleId);
+	};
+	const roleCreateOptions = (role: Role): { rolePrompt?: string; roleName: string; role: string; accessory?: string } => ({
+		rolePrompt: role.promptTemplate,
+		roleName: role.name,
+		role: role.name,
+		accessory: role.accessory,
 	});
 	// Roles/tools resolution is recomputed per call; the slash-skills TTL cache
 	// and the ToolManager mtime-keyed scan cache both need busting after a
@@ -5457,23 +5471,9 @@ async function handleApiRoute(
 
 		const args = body?.args;
 
-		// If a roleId is provided, look up the role and pass its prompt/tools/accessory
+		// If a roleId is provided, resolve/apply it after resolvedProjectId is known.
 		const roleId = body?.roleId;
 		let createOpts: { rolePrompt?: string; roleName?: string; role?: string; accessory?: string } | undefined;
-
-		if (roleId && typeof roleId === "string") {
-			const role = roleManager.getRole(roleId);
-			if (!role) {
-				json({ error: `Role "${roleId}" not found` }, 404);
-				return;
-			}
-			createOpts = {
-				rolePrompt: role.promptTemplate,
-				roleName: role.name,
-				role: role.name,
-				accessory: role.accessory,
-			};
-		}
 
 		// ── Worktree support ──
 		// Non-assistant, non-goal sessions get a worktree by default unless explicitly opted out.
@@ -5585,6 +5585,15 @@ async function handleApiRoute(
 			const resolved = resolveProjectForRequest(projectRegistry, projectContextManager, { projectId: body?.projectId, cwd });
 			if (!resolved.ok) { json({ error: resolved.error }, resolved.status); return; }
 			resolvedProjectId = resolved.projectId;
+		}
+
+		if (roleId && typeof roleId === "string") {
+			const role = resolveRoleForProject(roleId, resolvedProjectId);
+			if (!role) {
+				json({ error: `Role "${roleId}" not found` }, 404);
+				return;
+			}
+			createOpts = roleCreateOptions(role);
 		}
 
 		// Now that `resolvedProjectId` is known, resolve `worktreeOpts`.
@@ -8770,10 +8779,9 @@ async function handleApiRoute(
 
 		if (req.method === "GET") {
 			const qProjectId = url.searchParams.get("projectId") || undefined;
-			if (qProjectId) {
-				const resolved = configCascade.resolveRoles(qProjectId);
-				const found = resolved.find(r => r.item.name === name);
-				if (!found) { json({ error: "Role not found" }, 404); return; }
+			const resolved = configCascade.resolveRoles(qProjectId);
+			const found = resolved.find(r => r.item.name === name);
+			if (found) {
 				json(withOrigin(found as any));
 			} else {
 				const role = roleManager.getRole(name);
@@ -10924,17 +10932,14 @@ async function handleApiRoute(
 
 		const staff = ps.staffId ? staffManager.getStaff(ps.staffId) : undefined;
 		if (staff) {
-			createOpts.rolePrompt = buildStaffSystemPrompt(staff, roleManager);
+			createOpts.rolePrompt = buildStaffSystemPrompt(staff, roleManager, resolveRoleForProject);
 			createOpts.roleName = staff.roleId;
 			createOpts.accessory = staff.accessory;
 			createOpts.env = { BOBBIT_STAFF_ID: ps.staffId };
 		} else {
-			const role = ps.role ? roleManager.getRole(ps.role) : undefined;
+			const role = ps.role ? resolveRoleForProject(ps.role, projectId) : undefined;
 			if (role) {
-				createOpts.rolePrompt = role.promptTemplate;
-				createOpts.roleName = role.name;
-				createOpts.role = role.name;
-				createOpts.accessory = role.accessory;
+				Object.assign(createOpts, roleCreateOptions(role));
 			} else if (ps.role) {
 				createOpts.role = ps.role;
 				createOpts.roleName = ps.role;
@@ -11406,7 +11411,7 @@ async function handleApiRoute(
 			console.warn(`[continue-archived] proposal-dir copy failed (non-fatal): ${err}`);
 		}
 
-		const role = ps.role ? roleManager.getRole(ps.role) : undefined;
+		const role = ps.role ? resolveRoleForProject(ps.role, ps.projectId) : undefined;
 		const oldTranscriptCwds = Array.from(new Set([ps.cwd, ps.worktreePath]
 			.filter((v): v is string => typeof v === "string" && v.length > 0)));
 		const createOpts: any = {
@@ -11429,10 +11434,7 @@ async function handleApiRoute(
 			createOpts.initialModel = `${ps.modelProvider}/${ps.modelId}`;
 		}
 		if (role) {
-			createOpts.rolePrompt = role.promptTemplate;
-			createOpts.roleName = role.name;
-			createOpts.role = role.name;
-			createOpts.accessory = role.accessory;
+			Object.assign(createOpts, roleCreateOptions(role));
 		} else if (ps.role) {
 			// Persisted role name without a registered Role definition (e.g. the
 			// generic "assistant" role assigned to assistant sessions). Propagate
@@ -11533,7 +11535,9 @@ async function handleApiRoute(
 		}
 
 		if (typeof body.roleId === "string" && body.roleId !== "") {
-			const role = roleManager.getRole(body.roleId);
+			const session = sessionManager.getSession(id);
+			const ps = sessionManager.getPersistedSession(id);
+			const role = resolveRoleForProject(body.roleId, session?.projectId ?? ps?.projectId);
 			if (!role) { json({ error: `Role "${body.roleId}" not found` }, 404); return; }
 			try {
 				const ok = await sessionManager.assignRole(id, role);
@@ -13886,12 +13890,6 @@ async function handleApiRoute(
 			json({ error: "roleId must be a string or null" }, 400);
 			return;
 		}
-		// Validate the referenced role exists (when provided). roleId omitted or
-		// null/empty is allowed — staff with no role behave as before.
-		if (typeof body.roleId === "string" && body.roleId.length > 0 && !roleManager.getRole(body.roleId)) {
-			json({ error: "Role not found" }, 404);
-			return;
-		}
 		// Validate goal-* triggers carry a non-empty prompt (push-based
 		// dispatcher has no fallback; the prompt is mandatory).
 		try {
@@ -13924,6 +13922,12 @@ async function handleApiRoute(
 		}
 		const cwd = explicitCwd ?? resolved.project.rootPath;
 		const projectId = resolved.projectId;
+		// Validate the referenced role exists in the selected project's cascade.
+		// roleId omitted or null/empty is allowed — staff with no role behave as before.
+		if (typeof body.roleId === "string" && body.roleId.length > 0 && !resolveRoleForProject(body.roleId, projectId)) {
+			json({ error: "Role not found" }, 404);
+			return;
+		}
 		try {
 			const staff = await staffManager.createStaff(
 				body.name,
@@ -13991,9 +13995,11 @@ async function handleApiRoute(
 				json({ error: "roleId must be a string or null" }, 400);
 				return;
 			}
-			// Validate the referenced role exists (when provided). roleId: null
-			// (clear) and omitted are allowed.
-			if (typeof body.roleId === "string" && body.roleId.length > 0 && !roleManager.getRole(body.roleId)) {
+			const existingStaff = staffManager.getStaff(id);
+			if (!existingStaff) { json({ error: "Staff agent not found" }, 404); return; }
+			// Validate the referenced role exists in the staff agent's project cascade.
+			// roleId: null (clear) and omitted are allowed.
+			if (typeof body.roleId === "string" && body.roleId.length > 0 && !resolveRoleForProject(body.roleId, existingStaff.projectId)) {
 				json({ error: "Role not found" }, 404);
 				return;
 			}
@@ -14011,8 +14017,7 @@ async function handleApiRoute(
 
 			let cwdUpdate: string | undefined;
 			if (Object.prototype.hasOwnProperty.call(body, "cwd")) {
-				const staff = staffManager.getStaff(id);
-				if (!staff) { json({ error: "Staff agent not found" }, 404); return; }
+				const staff = existingStaff;
 				if (typeof body.cwd !== "string" || body.cwd.trim().length === 0) {
 					json({ error: "cwd must be a non-empty string" }, 400);
 					return;
@@ -14356,7 +14361,7 @@ async function handleApiRoute(
 			// after the meta-tool is granted wholesale.
 			if (toolStr.startsWith("mcp__")) {
 				const roleName = mcpSession?.role ?? (persistedSession as any)?.role;
-				const role = roleName ? roleManager.getRole(roleName) : undefined;
+				const role = roleName ? resolveRoleForProject(roleName, mcpSession?.projectId ?? (persistedSession as any)?.projectId) : undefined;
 				const parsed = parseMcpToolName(toolStr);
 				const opGroup = parsed?.server ? `MCP: ${parsed.server}` : undefined;
 				const policy = resolveGrantPolicy(toolStr, opGroup, role, toolManager, groupPolicyStore);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -406,6 +406,7 @@ import { validateAnswers, crossValidate, type UserQuestion } from "./agent/ask-u
 import { buildAskResponseEnvelope, findAskResponseAnswers } from "../shared/ask-envelope.js";
 import { isKnownThinkingLevel } from "../shared/thinking-levels.js";
 import { clampThinkingLevelForModel } from "./agent/thinking-level-clamp.js";
+import { isSessionSelectableModelString } from "./agent/google-code-assist.js";
 
 // In-memory dedup guard for ask_user_choices /submit. Keyed by
 // `${sessionId}::${toolUseId}`. Populated synchronously before enqueuing the
@@ -3319,12 +3320,21 @@ async function handleApiRoute(
 		const cascadeRole = configCascade.resolveRoles(projectId).find(r => r.item.name === roleId)?.item;
 		return cascadeRole ?? roleManager.getRole(roleId);
 	};
-	const roleCreateOptions = (role: Role): { rolePrompt?: string; roleName: string; role: string; accessory?: string } => ({
-		rolePrompt: role.promptTemplate,
-		roleName: role.name,
-		role: role.name,
-		accessory: role.accessory,
-	});
+	type RoleCreateOptions = { rolePrompt?: string; roleName: string; role: string; accessory?: string; initialModel?: string; initialThinkingLevel?: string };
+	const roleCreateOptions = (role: Role): RoleCreateOptions => {
+		const initialModel = typeof role.model === "string" && /^[^/]+\/.+$/.test(role.model) && isSessionSelectableModelString(role.model)
+			? role.model
+			: undefined;
+		const initialThinkingLevel = clampRoleThinking(role.thinkingLevel, initialModel);
+		return {
+			rolePrompt: role.promptTemplate,
+			roleName: role.name,
+			role: role.name,
+			accessory: role.accessory,
+			...(initialModel ? { initialModel } : {}),
+			...(initialThinkingLevel ? { initialThinkingLevel } : {}),
+		};
+	};
 	// Roles/tools resolution is recomputed per call; the slash-skills TTL cache
 	// and the ToolManager mtime-keyed scan cache both need busting after a
 	// marketplace pack-list mutation (design §9.1 / finding #1) so newly
@@ -5391,6 +5401,8 @@ async function handleApiRoute(
 			// reaching into the WS state stream.
 			modelProvider: sessionPs?.modelProvider,
 			modelId: sessionPs?.modelId,
+			spawnPinnedModel: session.spawnPinnedModel,
+			spawnPinnedThinkingLevel: session.spawnPinnedThinkingLevel,
 			restoreError: session.restoreError,
 			lastTurnErrored: session.lastTurnErrored ?? false,
 			consecutiveErrorTurns: session.consecutiveErrorTurns ?? 0,
@@ -5473,7 +5485,7 @@ async function handleApiRoute(
 
 		// If a roleId is provided, resolve/apply it after resolvedProjectId is known.
 		const roleId = body?.roleId;
-		let createOpts: { rolePrompt?: string; roleName?: string; role?: string; accessory?: string } | undefined;
+		let createOpts: RoleCreateOptions | undefined;
 
 		// ── Worktree support ──
 		// Non-assistant, non-goal sessions get a worktree by default unless explicitly opted out.
@@ -10939,7 +10951,9 @@ async function handleApiRoute(
 		} else {
 			const role = ps.role ? resolveRoleForProject(ps.role, projectId) : undefined;
 			if (role) {
-				Object.assign(createOpts, roleCreateOptions(role));
+				const opts = roleCreateOptions(role);
+				if (createOpts.initialModel) delete opts.initialModel;
+				Object.assign(createOpts, opts);
 			} else if (ps.role) {
 				createOpts.role = ps.role;
 				createOpts.roleName = ps.role;
@@ -11434,7 +11448,9 @@ async function handleApiRoute(
 			createOpts.initialModel = `${ps.modelProvider}/${ps.modelId}`;
 		}
 		if (role) {
-			Object.assign(createOpts, roleCreateOptions(role));
+			const opts = roleCreateOptions(role);
+			if (createOpts.initialModel) delete opts.initialModel;
+			Object.assign(createOpts, opts);
 		} else if (ps.role) {
 			// Persisted role name without a registered Role definition (e.g. the
 			// generic "assistant" role assigned to assistant sessions). Propagate

--- a/tests/e2e/market-pack-roles-api.spec.ts
+++ b/tests/e2e/market-pack-roles-api.spec.ts
@@ -83,6 +83,19 @@ async function createPlainSession(): Promise<string> {
 	return id;
 }
 
+async function expectLiveSessionRolePins(sessionId: string, label: string): Promise<void> {
+	const list = await apiFetch("/api/sessions");
+	const body = await readJson(list);
+	expect(list.status, `${REPRO}: ${label} failed to list sessions; body=${JSON.stringify(body)}`).toBe(200);
+	const live = (body.sessions ?? []).find((item: any) => item.id === sessionId);
+	expect(live, `${REPRO}: ${label} session should appear in live session list`).toBeTruthy();
+	expect(live.spawnPinnedModel, `${REPRO}: ${label} should pin the market-pack role model at spawn/respawn`).toBe("openai/gpt-4.1-mini");
+	// The fixture's role field is `low`, asserted on /api/roles above. Runtime
+	// spawn clamps it to `off` because gpt-4.1-mini is non-reasoning; this is the
+	// closest stable API assertion that role model/thinking reached session setup.
+	expect(live.spawnPinnedThinkingLevel, `${REPRO}: ${label} should pin the clamped market-pack role thinking level at spawn/respawn`).toBe("off");
+}
+
 async function createPlainStaff(name: string): Promise<any> {
 	const project = await defaultProject();
 	const res = await apiFetch("/api/staff", {
@@ -157,6 +170,7 @@ test.describe("market-pack roles API regression", () => {
 		const session = await readJson(get);
 		expect(session.role, `${REPRO}: created session should persist the market-pack role name`).toBe(ROLE_ID);
 		expect(session.accessory, `${REPRO}: created session should use the market-pack role accessory`).toBe("stethoscope");
+		await expectLiveSessionRolePins(created.id, "POST /api/sessions");
 	});
 
 	test("PATCH /api/sessions/:id accepts a role that is visible through the market-pack cascade", async () => {
@@ -175,6 +189,7 @@ test.describe("market-pack roles API regression", () => {
 		const session = await readJson(get);
 		expect(session.role, `${REPRO}: patched session should persist the market-pack role name`).toBe(ROLE_ID);
 		expect(session.accessory, `${REPRO}: patched session should use the market-pack role accessory`).toBe("stethoscope");
+		await expectLiveSessionRolePins(sessionId, "PATCH /api/sessions/:id");
 	});
 
 	test("POST /api/staff validates roleId through the market-pack cascade", async () => {

--- a/tests/e2e/market-pack-roles-api.spec.ts
+++ b/tests/e2e/market-pack-roles-api.spec.ts
@@ -1,0 +1,248 @@
+import { test, expect } from "./in-process-harness.js";
+import { apiFetch, defaultProject, nonGitCwd } from "./e2e-setup.js";
+import { fileURLToPath } from "node:url";
+
+const SOURCE_DIR = fileURLToPath(new URL("../fixtures/market-sources/market-role-fixture-src", import.meta.url));
+const PACK_NAME = "market-role-fixture";
+const ROLE_ID = "fixture-pack-nurse";
+const UNKNOWN_ROLE_ID = "definitely-not-a-role-market-pack-regression";
+const REPRO = "MARKET_PACK_ROLE_REGRESSION";
+
+let sourceId: string | undefined;
+const sessions: string[] = [];
+const staffIds: string[] = [];
+
+async function readJson(resp: Response): Promise<any> {
+	const text = await resp.text();
+	try {
+		return text ? JSON.parse(text) : {};
+	} catch {
+		return { raw: text };
+	}
+}
+
+async function addSource(): Promise<string> {
+	const add = await apiFetch("/api/marketplace/sources", {
+		method: "POST",
+		body: JSON.stringify({ url: SOURCE_DIR }),
+	});
+	const text = await add.text();
+	if (add.status === 409) {
+		const list = await apiFetch("/api/marketplace/sources");
+		expect(list.status, `${REPRO}: failed to list existing marketplace sources after source conflict`).toBe(200);
+		const source = ((await list.json()).sources ?? []).find((item: any) => item.url === SOURCE_DIR);
+		expect(source, `${REPRO}: existing marketplace source for fixture pack should be discoverable`).toBeTruthy();
+		return source.id;
+	}
+	expect(add.status, `${REPRO}: failed to register fixture marketplace source; body=${text}`).toBe(201);
+	return JSON.parse(text).source.id;
+}
+
+async function installPack(): Promise<void> {
+	await apiFetch("/api/marketplace/installed", {
+		method: "DELETE",
+		body: JSON.stringify({ scope: "server", packName: PACK_NAME }),
+	}).catch(() => {});
+
+	sourceId = await addSource();
+	const install = await apiFetch("/api/marketplace/install", {
+		method: "POST",
+		body: JSON.stringify({ sourceId, dirName: PACK_NAME, scope: "server" }),
+	});
+	const installText = await install.text();
+	expect(install.status, `${REPRO}: fixture marketplace pack install failed; body=${installText}`).toBe(201);
+
+	const activation = await apiFetch("/api/marketplace/pack-activation", {
+		method: "PUT",
+		body: JSON.stringify({ scope: "server", packName: PACK_NAME, disabled: {} }),
+	});
+	const activationText = await activation.text();
+	expect(activation.status, `${REPRO}: fixture role pack activation refresh failed; body=${activationText}`).toBe(200);
+}
+
+async function fixtureRole(projectId?: string): Promise<any> {
+	const qs = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
+	const res = await apiFetch(`/api/roles${qs}`);
+	const body = await readJson(res);
+	expect(res.status, `${REPRO}: GET /api/roles failed; body=${JSON.stringify(body)}`).toBe(200);
+	const role = (body.roles ?? []).find((item: any) => item.name === ROLE_ID);
+	expect(role, `${REPRO}: ${ROLE_ID} must appear in GET /api/roles before it is used by session/staff APIs`).toBeTruthy();
+	return role;
+}
+
+async function createPlainSession(): Promise<string> {
+	const project = await defaultProject();
+	const res = await apiFetch("/api/sessions", {
+		method: "POST",
+		body: JSON.stringify({ cwd: nonGitCwd(), projectId: project.id }),
+	});
+	const text = await res.text();
+	expect(res.status, `${REPRO}: setup session creation failed; body=${text}`).toBe(201);
+	const id = JSON.parse(text).id;
+	sessions.push(id);
+	return id;
+}
+
+async function createPlainStaff(name: string): Promise<any> {
+	const project = await defaultProject();
+	const res = await apiFetch("/api/staff", {
+		method: "POST",
+		body: JSON.stringify({
+			name,
+			systemPrompt: "Staff fixture without a market-pack role yet.",
+			cwd: project.rootPath,
+			projectId: project.id,
+		}),
+	});
+	const text = await res.text();
+	expect(res.status, `${REPRO}: setup staff creation failed; body=${text}`).toBe(201);
+	const staff = JSON.parse(text);
+	staffIds.push(staff.id);
+	if (staff.currentSessionId) sessions.push(staff.currentSessionId);
+	return staff;
+}
+
+async function expectRole404(resp: Response, label: string): Promise<void> {
+	const body = await readJson(resp);
+	expect(resp.status, `${REPRO}: ${label} should still fail loudly for truly unknown roles; body=${JSON.stringify(body)}`).toBe(404);
+	expect(String(body.error ?? body.message ?? ""), `${REPRO}: ${label} unknown-role response should mention role lookup failure`).toMatch(/role/i);
+}
+
+test.describe("market-pack roles API regression", () => {
+	test.beforeAll(async () => {
+		await installPack();
+	});
+
+	test.afterAll(async () => {
+		for (const staffId of staffIds.splice(0).reverse()) {
+			await apiFetch(`/api/staff/${staffId}`, { method: "DELETE" }).catch(() => {});
+		}
+		for (const sessionId of sessions.splice(0).reverse()) {
+			await apiFetch(`/api/sessions/${sessionId}`, { method: "DELETE" }).catch(() => {});
+		}
+		await apiFetch("/api/marketplace/installed", {
+			method: "DELETE",
+			body: JSON.stringify({ scope: "server", packName: PACK_NAME }),
+		}).catch(() => {});
+		if (sourceId) {
+			await apiFetch(`/api/marketplace/sources/${encodeURIComponent(sourceId)}`, { method: "DELETE" }).catch(() => {});
+		}
+	});
+
+	test("GET /api/roles exposes the market-pack role with distinctive fields", async () => {
+		const project = await defaultProject();
+		const role = await fixtureRole(project.id);
+		expect(role.originPackName, `${REPRO}: fixture role should be tagged with its market pack`).toBe(PACK_NAME);
+		expect(role.promptTemplate, `${REPRO}: fixture role prompt marker should survive cascade serialization`).toContain("FIXTURE_PACK_ROLE_PROMPT");
+		expect(role.accessory).toBe("stethoscope");
+		expect(role.model).toBe("openai/gpt-4.1-mini");
+		expect(role.thinkingLevel).toBe("low");
+		expect(role.toolPolicies).toMatchObject({ Shell: "never", "File System": "ask" });
+	});
+
+	test("POST /api/sessions accepts a role that is visible through the market-pack cascade", async () => {
+		const project = await defaultProject();
+		await fixtureRole(project.id);
+
+		const resp = await apiFetch("/api/sessions", {
+			method: "POST",
+			body: JSON.stringify({ cwd: nonGitCwd(), projectId: project.id, roleId: ROLE_ID }),
+		});
+		const text = await resp.text();
+		expect(resp.status, `${REPRO}: POST /api/sessions must accept market-pack role ${ROLE_ID} that appears in GET /api/roles; body=${text}`).toBe(201);
+		const created = JSON.parse(text);
+		sessions.push(created.id);
+
+		const get = await apiFetch(`/api/sessions/${created.id}`);
+		const session = await readJson(get);
+		expect(session.role, `${REPRO}: created session should persist the market-pack role name`).toBe(ROLE_ID);
+		expect(session.accessory, `${REPRO}: created session should use the market-pack role accessory`).toBe("stethoscope");
+	});
+
+	test("PATCH /api/sessions/:id accepts a role that is visible through the market-pack cascade", async () => {
+		const project = await defaultProject();
+		await fixtureRole(project.id);
+		const sessionId = await createPlainSession();
+
+		const resp = await apiFetch(`/api/sessions/${sessionId}`, {
+			method: "PATCH",
+			body: JSON.stringify({ roleId: ROLE_ID }),
+		});
+		const body = await readJson(resp);
+		expect(resp.status, `${REPRO}: PATCH /api/sessions/:id must assign market-pack role ${ROLE_ID} that appears in GET /api/roles; body=${JSON.stringify(body)}`).toBe(200);
+
+		const get = await apiFetch(`/api/sessions/${sessionId}`);
+		const session = await readJson(get);
+		expect(session.role, `${REPRO}: patched session should persist the market-pack role name`).toBe(ROLE_ID);
+		expect(session.accessory, `${REPRO}: patched session should use the market-pack role accessory`).toBe("stethoscope");
+	});
+
+	test("POST /api/staff validates roleId through the market-pack cascade", async () => {
+		const project = await defaultProject();
+		await fixtureRole(project.id);
+
+		const resp = await apiFetch("/api/staff", {
+			method: "POST",
+			body: JSON.stringify({
+				name: `Market Role Staff ${Date.now()}`,
+				systemPrompt: "Staff using the fixture market-pack role.",
+				cwd: project.rootPath,
+				projectId: project.id,
+				roleId: ROLE_ID,
+			}),
+		});
+		const text = await resp.text();
+		expect(resp.status, `${REPRO}: POST /api/staff must accept market-pack role ${ROLE_ID} that appears in GET /api/roles; body=${text}`).toBe(201);
+		const staff = JSON.parse(text);
+		staffIds.push(staff.id);
+		if (staff.currentSessionId) sessions.push(staff.currentSessionId);
+		expect(staff.roleId, `${REPRO}: created staff should persist market-pack roleId`).toBe(ROLE_ID);
+	});
+
+	test("PUT /api/staff/:id validates roleId through the market-pack cascade", async () => {
+		const project = await defaultProject();
+		await fixtureRole(project.id);
+		const staff = await createPlainStaff(`Market Role Update Staff ${Date.now()}`);
+
+		const resp = await apiFetch(`/api/staff/${staff.id}`, {
+			method: "PUT",
+			body: JSON.stringify({ roleId: ROLE_ID }),
+		});
+		const body = await readJson(resp);
+		expect(resp.status, `${REPRO}: PUT /api/staff/:id must accept market-pack role ${ROLE_ID} that appears in GET /api/roles; body=${JSON.stringify(body)}`).toBe(200);
+		expect(body.roleId, `${REPRO}: updated staff should persist market-pack roleId`).toBe(ROLE_ID);
+	});
+
+	test("unknown roles still return clear 404s on session and staff validation paths", async () => {
+		const project = await defaultProject();
+		await fixtureRole(project.id);
+
+		await expectRole404(await apiFetch("/api/sessions", {
+			method: "POST",
+			body: JSON.stringify({ cwd: nonGitCwd(), projectId: project.id, roleId: UNKNOWN_ROLE_ID }),
+		}), "POST /api/sessions");
+
+		const sessionId = await createPlainSession();
+		await expectRole404(await apiFetch(`/api/sessions/${sessionId}`, {
+			method: "PATCH",
+			body: JSON.stringify({ roleId: UNKNOWN_ROLE_ID }),
+		}), "PATCH /api/sessions/:id");
+
+		await expectRole404(await apiFetch("/api/staff", {
+			method: "POST",
+			body: JSON.stringify({
+				name: `Unknown Role Staff ${Date.now()}`,
+				systemPrompt: "Staff using an unknown role.",
+				cwd: project.rootPath,
+				projectId: project.id,
+				roleId: UNKNOWN_ROLE_ID,
+			}),
+		}), "POST /api/staff");
+
+		const staff = await createPlainStaff(`Unknown Role Update Staff ${Date.now()}`);
+		await expectRole404(await apiFetch(`/api/staff/${staff.id}`, {
+			method: "PUT",
+			body: JSON.stringify({ roleId: UNKNOWN_ROLE_ID }),
+		}), "PUT /api/staff/:id");
+	});
+});

--- a/tests/e2e/pr-walkthrough-host-agents.spec.ts
+++ b/tests/e2e/pr-walkthrough-host-agents.spec.ts
@@ -899,11 +899,12 @@ test.describe("PR walkthrough → host.agents reviewer (API E2E)", () => {
 
 	// ── Row A4: a reviewer surviving a gateway restart keeps its tools. ──
 	// The restore / force-respawn paths resolve the session role via
-	// `resolveSessionRole`, which the fix makes cascade-aware + projectId-scoped.
-	// Without the projectId the pack role is lost (roleManager has no `pr-reviewer`)
-	// and the regenerated guard re-blocks the three tools. This pins the restore
-	// path's resolution against the gateway's REAL group-policy store.
-	test("a restored reviewer re-resolves the pack role (cascade + projectId) and keeps its three tools", async ({ gateway }) => {
+	// `resolveSessionRole`, which is cascade-aware and projectId-scoped when a
+	// project is present. A missing projectId still resolves server-scope/built-in
+	// pack roles, while truly unknown roles continue to fail loud by resolving to
+	// undefined. This pins restore resolution against the gateway's REAL
+	// group-policy store.
+	test("a restored reviewer re-resolves the pack role (cascade + projectId) and keeps its walkthrough tools", async ({ gateway }) => {
 		const { resolveGrantPolicy } = await import("../../dist/server/agent/tool-activation.js");
 		const fixture = makeGitFixture();
 		const owner = await createSession({ cwd: fixture.cwd });
@@ -917,15 +918,20 @@ test.describe("PR walkthrough → host.agents reviewer (API E2E)", () => {
 			const sm: any = gateway.sessionManager;
 			const groupPolicyStore = sm.groupPolicyStore;
 
-			// The restore path now calls resolveSessionRole(ps.role, ps.assistantType, ps.projectId).
+			// The restore path calls resolveSessionRole(ps.role, ps.assistantType, ps.projectId).
 			const restoredRole = sm.resolveSessionRole(ps?.role, ps?.assistantType, ps?.projectId);
 			expect(restoredRole?.name).toBe("pr-reviewer");
 			expect(restoredRole?.toolPolicies?.["PR Walkthrough"]).toBe("allow");
 
-			// The PRE-FIX call shape (no projectId) loses the pack role entirely —
-			// roleManager has no `pr-reviewer`, so the guard would re-block the trio.
-			const preFixRole = sm.resolveSessionRole(ps?.role, ps?.assistantType, undefined);
-			expect(preFixRole).toBeUndefined();
+			// Server-scope/built-in market-pack roles remain resolvable even when an
+			// older persisted call shape lacks projectId.
+			const noProjectRole = sm.resolveSessionRole(ps?.role, ps?.assistantType, undefined);
+			expect(noProjectRole?.name).toBe("pr-reviewer");
+			expect(noProjectRole?.toolPolicies?.["PR Walkthrough"]).toBe("allow");
+
+			// Truly unknown roles still do not inherit the PR Walkthrough group allow.
+			const unknownRole = sm.resolveSessionRole("prw-e2e-missing-role", ps?.assistantType, ps?.projectId);
+			expect(unknownRole).toBeUndefined();
 
 			// The restore prompt path resolves the role's promptTemplate via
 			// resolveRolePromptTemplate, which is now pack-aware — so a restored reviewer
@@ -934,13 +940,15 @@ test.describe("PR walkthrough → host.agents reviewer (API E2E)", () => {
 			expect(restoredTemplate).toContain("schema_version");
 			expect(restoredTemplate).toContain("merge_assessment");
 
-			// The restored allowlist (persisted) still carries the three tools, and the
-			// regenerated guard (driven by resolveGrantPolicy over the restored role)
-			// grants them — while the pre-fix undefined role would resolve them to never.
+			// The restored allowlist (persisted) still carries the walkthrough tools, and
+			// the regenerated guard (driven by resolveGrantPolicy over the restored role)
+			// grants them. The no-project role behaves the same for server-scope/built-in
+			// pack roles, while an unknown role falls back to the group default deny.
 			for (const t of REVIEWER_TOOLS) {
 				expect((ps?.allowedTools ?? []).includes(t), `restored allowlist must keep ${t}`).toBe(true);
 				expect(resolveGrantPolicy(t, "PR Walkthrough", restoredRole, undefined, groupPolicyStore)).toBe("allow");
-				expect(resolveGrantPolicy(t, "PR Walkthrough", preFixRole, undefined, groupPolicyStore)).toBe("never");
+				expect(resolveGrantPolicy(t, "PR Walkthrough", noProjectRole, undefined, groupPolicyStore)).toBe("allow");
+				expect(resolveGrantPolicy(t, "PR Walkthrough", unknownRole, undefined, groupPolicyStore)).toBe("never");
 			}
 		} finally {
 			fixture.cleanup();

--- a/tests/fixtures/market-sources/market-role-fixture-src/market-role-fixture/pack.yaml
+++ b/tests/fixtures/market-sources/market-role-fixture-src/market-role-fixture/pack.yaml
@@ -1,0 +1,9 @@
+name: market-role-fixture
+description: E2E fixture pack contributing a role used to reproduce cascade role lookup regressions.
+version: 1.0.0
+schema: 2
+contents:
+  roles: [fixture-pack-nurse]
+  tools: []
+  skills: []
+  entrypoints: []

--- a/tests/fixtures/market-sources/market-role-fixture-src/market-role-fixture/roles/fixture-pack-nurse.yaml
+++ b/tests/fixtures/market-sources/market-role-fixture-src/market-role-fixture/roles/fixture-pack-nurse.yaml
@@ -1,0 +1,13 @@
+name: fixture-pack-nurse
+label: Fixture Pack Nurse
+accessory: stethoscope
+model: openai/gpt-4.1-mini
+thinkingLevel: low
+toolPolicies:
+  Shell: never
+  "File System": ask
+createdAt: 1782736000000
+updatedAt: 1782736000000
+promptTemplate: |
+  FIXTURE_PACK_ROLE_PROMPT
+  You are the isolated market-pack role fixture. Agent id: {{AGENT_ID}}.

--- a/tests/goal-metadata-allowlist-empty-fixes.test.ts
+++ b/tests/goal-metadata-allowlist-empty-fixes.test.ts
@@ -146,15 +146,27 @@ describe("session-setup _resolveTools preserves explicit empty allowlist (F2)", 
 			.replace(": EffectiveTool[] | undefined", "");
 	}
 	const BLOCK = extractResolveBlock();
-	// `computeEffectiveAllowedTools` and `scopedToolContext` are free identifiers;
-	// inject sentinels so a wrongful fallback and scoped context drift are observable.
-	const runBlock = new Function("plan", "ctx", "computeEffectiveAllowedTools", "scopedToolContext", BLOCK) as (
+	// `computeEffectiveAllowedTools`, `scopedToolContext`, and module-private
+	// `lookupRole` are free identifiers; inject sentinels so a wrongful fallback,
+	// scoped context drift, and lookup-role contract drift are observable.
+	const runExtractedBlock = new Function("plan", "ctx", "computeEffectiveAllowedTools", "scopedToolContext", "lookupRole", BLOCK) as (
 		plan: { effectiveAllowedTools?: unknown[]; roleName?: string; projectId?: string; cwd?: string },
 		ctx: unknown,
 		ceat: (...a: unknown[]) => unknown[],
 		scope: (projectId: string | undefined, cwd: string | undefined) => unknown,
+		lookup: (name: string, plan: unknown, ctx: unknown) => unknown,
 	) => void;
 	const defaultScope = (projectId: string | undefined, cwd: string | undefined) => ({ projectId, cwd, scopeKey: projectId ? `project:${projectId}` : cwd ? `cwd:${cwd}` : "default" });
+
+	const sentinelRole = { name: "coder" };
+	const defaultLookupRole = (name: string) => name === "coder" ? sentinelRole : undefined;
+	const runBlock = (
+		plan: { effectiveAllowedTools?: unknown[]; roleName?: string; projectId?: string; cwd?: string },
+		ctx: unknown,
+		ceat: (...a: unknown[]) => unknown[],
+		scope: (projectId: string | undefined, cwd: string | undefined) => unknown,
+		lookup = defaultLookupRole,
+	) => runExtractedBlock(plan, ctx, ceat, scope, lookup);
 
 	const sentinel = [{ name: "ROLE_FALLBACK" }];
 	const ctxWithRole = {
@@ -177,19 +189,26 @@ describe("session-setup _resolveTools preserves explicit empty allowlist (F2)", 
 		const scoped = { projectId: "project-a", cwd: "/tmp/project-a", scopeKey: "project:project-a" };
 		const seenScopeArgs: Array<[string | undefined, string | undefined]> = [];
 		let computeScopeArg: unknown;
+		const lookupCalls: Array<[string, unknown, unknown]> = [];
 		runBlock(
 			plan,
 			ctxWithRole,
 			(...args: unknown[]) => {
 				computeScopeArg = args[4];
+				assert.equal(args[1], sentinelRole);
 				return sentinel;
 			},
 			(projectId, cwd) => {
 				seenScopeArgs.push([projectId, cwd]);
 				return scoped;
 			},
+			(name, lookupPlan, lookupCtx) => {
+				lookupCalls.push([name, lookupPlan, lookupCtx]);
+				return sentinelRole;
+			},
 		);
 		assert.deepEqual(plan.effectiveAllowedTools, sentinel);
+		assert.deepEqual(lookupCalls, [["coder", plan, ctxWithRole]]);
 		assert.deepEqual(seenScopeArgs, [["project-a", "/tmp/project-a"]]);
 		assert.equal(computeScopeArg, scoped);
 	});
@@ -204,6 +223,8 @@ describe("session-setup _resolveTools preserves explicit empty allowlist (F2)", 
 	it("source: fallback guard is `=== undefined`, never `.length === 0`", () => {
 		assert.ok(/if \(effectiveAllowedTools === undefined && ctx\.roleManager\)/.test(SS_SRC),
 			"_resolveTools must only fall back when no allowlist was supplied");
+		assert.ok(/const role = lookupRole\(roleName, plan, ctx\);/.test(SS_SRC),
+			"_resolveTools must resolve fallback roles through the cascade-aware lookup helper");
 		assert.ok(!/!effectiveAllowedTools \|\| effectiveAllowedTools\.length === 0/.test(SS_SRC),
 			"explicit-empty allowlist must not trigger the role fallback");
 	});

--- a/tests/ui-fixtures/preview-panel.spec.ts
+++ b/tests/ui-fixtures/preview-panel.spec.ts
@@ -101,6 +101,13 @@ async function sidePanelControlTitles(page: Page): Promise<string[]> {
 	});
 }
 
+async function expectSidePanelControlTitles(page: Page, expected: string[], message: string): Promise<void> {
+	await expect.poll(async () => sidePanelControlTitles(page), {
+		timeout: 5_000,
+		message,
+	}).toEqual(expected);
+}
+
 test.describe("Preview panel fixture", () => {
 	test.beforeEach(async ({ page }) => {
 		await loadFixture(page);
@@ -125,12 +132,12 @@ test.describe("Preview panel fixture", () => {
 		expect(await openLink.getAttribute("href")).not.toMatch(/[?#]mtime=/);
 		await expect(page.getByTestId("side-panel-popout"), "preview tab should not render the generic side-panel popout").toHaveCount(0);
 
-		await expect(sidePanelControlTitles(page)).resolves.toEqual([
+		await expectSidePanelControlTitles(page, [
 			"Refresh preview",
 			"Open preview in new tab",
 			"Expand preview to fullscreen",
 			"Collapse side panel",
-		]);
+		], "preview split controls should appear in stable action order");
 
 		const refresh = page.locator('button[title="Refresh preview"]').first();
 		await expect(refresh).toBeVisible();
@@ -147,11 +154,11 @@ test.describe("Preview panel fixture", () => {
 		await expect(page.getByTestId("side-panel-restore"), "fullscreen chrome should not show a duplicate restore/collapse button").toHaveCount(0);
 		await expect(openLink, "Open-in-new-tab remains available in fullscreen chrome").toBeVisible({ timeout: 5_000 });
 		await expect(refresh, "Refresh remains available in fullscreen chrome").toBeVisible({ timeout: 5_000 });
-		await expect(sidePanelControlTitles(page)).resolves.toEqual([
+		await expectSidePanelControlTitles(page, [
 			"Refresh preview",
 			"Open preview in new tab",
 			"Collapse to split view",
-		]);
+		], "preview fullscreen controls should appear in stable action order");
 
 		await refresh.click();
 		await expect.poll(async () => iframe.getAttribute("src"), {
@@ -162,20 +169,20 @@ test.describe("Preview panel fixture", () => {
 
 	test("uses the same action order for preview and non-preview panel tabs", async ({ page }) => {
 		await setLivePreview(page, "order.html", hashOf("e"), "preview order");
-		await expect(sidePanelControlTitles(page)).resolves.toEqual([
+		await expectSidePanelControlTitles(page, [
 			"Refresh preview",
 			"Open preview in new tab",
 			"Expand preview to fullscreen",
 			"Collapse side panel",
-		]);
+		], "preview controls should appear in stable action order");
 
 		await page.evaluate(() => (window as any).__openDynamicReviewDoc({ title: "Review panel", markdown: "# Review panel" }));
 		await expect(page.getByTestId("side-panel-popout")).toBeVisible({ timeout: 5_000 });
-		await expect(sidePanelControlTitles(page)).resolves.toEqual([
+		await expectSidePanelControlTitles(page, [
 			"Open side panel in new tab",
 			"Expand side panel to fullscreen",
 			"Collapse side panel",
-		]);
+		], "non-preview controls should appear in stable action order");
 	});
 
 	test("visible side-panel controls move one size level at a time", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Resolve runtime role lookups through the config cascade before legacy RoleManager fallback so market-pack roles listed by `/api/roles` work in sessions and staff paths.
- Preserve pack role prompt, accessory, model, thinking level, and tool policies across create, assign, restore, fork/continue, and staff validation flows.
- Add isolated market-pack role regression coverage and update related docs/test fixtures.

## Verification
- Implementation gate passed: build, type check, focused repro, unit, E2E, reviews, QA.
- Documentation gate passed.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)