### PR TITLE
Stop idle sidebar Bobbit breathing

### DIFF
--- a/docs/bobbit-sprites.md
+++ b/docs/bobbit-sprites.md
@@ -324,7 +324,7 @@ The second bubble is offset by 1s delay for a staggered effect.
 | Keyframe | Duration | Description |
 |----------|----------|-------------|
 | `bobbit-bob` | 1.8s | Gentle vertical bounce for streaming sessions — subtle scaleY compression |
-| `bobbit-breathe` | 4s | Slow scaleY pulse (1 → 1.06) for idle sessions |
+| `bobbit-breathe` | 4s | Legacy slow scaleY pulse; idle sidebar bobbits do not apply it |
 | `bobbit-cancel-fade` | 1.2s | Opacity pulse (1 → 0.35) during abort |
 | `bobbit-squish` | 1.5s | ScaleX/scaleY oscillation during compaction |
 | `bobbit-eyes` | 6s | Blink + look right cycle for selected sessions |
@@ -343,7 +343,7 @@ The `statusBobbit()` function generates a self-contained `html` template literal
 
 **Structure**:
 ```
-<span container>          ← flex container, filter (hue-rotate + saturation), bob/breathe/cancel animation
+<span container>          ← flex container, filter (hue-rotate + saturation), non-idle status animation
   <span sprite>           ← box-shadow pixel art, base transform, shimmer animation
   <span eyeLayer?>        ← separate eye overlay for selected sessions (enables independent eye animation)
   <span accessoryLayer?>  ← counter-hue-rotated accessory overlay
@@ -352,10 +352,11 @@ The `statusBobbit()` function generates a self-contained `html` template literal
 
 **Key behaviors**:
 - Scale: 1.6× via `transform: scale(1.6)`
-- Idle sessions: `saturate(0.4)` filter + `bobbit-breathe` animation
+- Idle sessions: `saturate(0.4)` filter and sleeping/idle styling, but no continuous `bobbit-breathe` animation
 - Streaming sessions: `bobbit-bob` animation + `blob-shimmer`
 - Compacting: `bobbit-squish` animation with squash transform
 - Selected session: Eye layer shown with `bobbit-eyes` animation (blink + look right)
+- Unread inactive rows: the outer row wrapper may still run the unread pulse/tap animation, even when the bobbit itself is idle
 - Aborting: `saturate(0.3)` + `bobbit-cancel-fade` opacity pulse
 - Status colors: Yellow for starting, red for terminated (applied via different box-shadow colors, not hue-rotate)
 

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -946,7 +946,7 @@ export function renderSessionRow(session: GatewaySession) {
 			<div class="shrink-0 flex items-center justify-center ${!active && hasUnseenActivity(session) ? "bobbit-unread-pulse" : ""}">
 				${connecting || preparing
 					? html`<svg class="animate-spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>`
-					: statusBobbit(session.status, session.isCompacting, session.id, active, session.isAborting, session.role === "team-lead", session.role === "coder", session.accessory, false, !active && hasUnseenActivity(session))}
+					: statusBobbit(session.status, session.isCompacting, session.id, active, session.isAborting, session.role === "team-lead", session.role === "coder", session.accessory, false, !active && hasUnseenActivity(session), true)}
 			</div>
 			<div class="flex-1 min-w-0 flex flex-col justify-center">
 				<div class="flex items-center gap-1 min-w-0 font-normal"><span class="flex-1 min-w-0 truncate ${preparing ? "text-muted-foreground/60 italic" : ""}" data-testid="sidebar-session-title-text" style="${mobile ? "font-size: 1.3333em;" : ""}">${preparing ? "preparing…" : renderSessionTitle(displayTitle, isActive, state.searchQuery)}</span>${mobile ? html`<span class="shrink-0 text-muted-foreground/40" style="font-size: 0.9167em;">·</span>${renderSessionTime(session)}` : ""}</div>
@@ -1022,7 +1022,7 @@ export function renderArchivedSessionRow(session: GatewaySession, extraChildren 
 				title="${expanded ? "Collapse" : "Expand"}"
 			><span class="sidebar-chevron-glyph">${expanded ? "▾" : "▸"}</span></span>` : ""}
 			<div class="shrink-0 flex items-center justify-center">
-				${statusBobbit("terminated", false, session.id, active, false, session.role === "team-lead", session.role === "coder", session.accessory)}
+				${statusBobbit("terminated", false, session.id, active, false, session.role === "team-lead", session.role === "coder", session.accessory, false, false, true)}
 			</div>
 			<div class="flex-1 min-w-0 font-normal truncate" style="${mobile ? "font-size: 1.3333em;" : ""}">${renderHighlightedText(displayTitle, state.searchQuery)}</div>
 			${session.archivedAt ? html`<span class="shrink-0 text-muted-foreground" style="${mobile ? "font-size: 1em;" : "font-size: 0.8333em;"}">${terseRelativeTime(session.archivedAt)}</span>` : ""}
@@ -1093,7 +1093,7 @@ function renderTeamLeadRow(session: GatewaySession, childCount: number, expanded
 			<div class="shrink-0 flex items-center justify-center">
 				${connecting
 					? html`<svg class="animate-spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>`
-					: statusBobbit(session.status, session.isCompacting, session.id, active, session.isAborting, true, false, session.accessory)}
+					: statusBobbit(session.status, session.isCompacting, session.id, active, session.isAborting, true, false, session.accessory, false, false, true)}
 			</div>
 			<div class="flex-1 min-w-0 ${mobile ? "flex items-center gap-1" : "truncate"} font-normal" style="${mobile ? "font-size: 1.3333em;" : ""}"><span class="${mobile ? "truncate" : ""}">${renderSessionTitle(displayTitle, isActive, state.searchQuery)}</span>${mobile ? html`<span class="shrink-0 text-muted-foreground/40" style="font-size: 0.9167em;">·</span>${renderSessionTime(session)}` : ""}</div>
 			${mobile

--- a/src/app/session-colors.ts
+++ b/src/app/session-colors.ts
@@ -97,7 +97,7 @@ export function sessionAcronym(title: string): string {
  *   When provided, overrides isTeamLead/isCoder. When absent, falls back to
  *   the legacy booleans for backward compatibility.
  */
-export function statusBobbit(status: string, isCompacting = false, sessionId?: string, isSelected = false, isAborting = false, isTeamLead = false, isCoder = false, accessory?: string, noDesaturate = false, unread = false) {
+export function statusBobbit(status: string, isCompacting = false, sessionId?: string, isSelected = false, isAborting = false, isTeamLead = false, isCoder = false, accessory?: string, noDesaturate = false, unread = false, disableIdleBreathing = false) {
 	const hueRotate = sessionId ? sessionHueRotation(sessionId) : 0;
 
 	// Resolve which accessory to render: explicit param > legacy booleans > none
@@ -114,5 +114,6 @@ export function statusBobbit(status: string, isCompacting = false, sessionId?: s
 		accessory: acc,
 		noDesaturate,
 		unread,
+		disableIdleBreathing,
 	});
 }

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -1034,7 +1034,7 @@ export function renderStaffSidebarSection(filteredList?: typeof state.staffList,
 					data-nav-active=${active ? "true" : "false"}
 					style="padding-left:var(--sidebar-chevron-w);"
 					@click=${() => handleStaffClick(agent)}>
-					<span class="shrink-0 inline-flex items-center justify-center ${!active && session && hasUnseenActivity(session) ? "bobbit-unread-pulse" : ""}">${statusBobbit(sessionStatus, isCompacting, agent.currentSessionId, active, isAborting, false, false, accessory, false, !active && !!session && hasUnseenActivity(session))}</span>
+					<span class="shrink-0 inline-flex items-center justify-center ${!active && session && hasUnseenActivity(session) ? "bobbit-unread-pulse" : ""}">${statusBobbit(sessionStatus, isCompacting, agent.currentSessionId, active, isAborting, false, false, accessory, false, !active && !!session && hasUnseenActivity(session), true)}</span>
 					<div class="flex-1 min-w-0 ${mobile ? "flex items-center gap-1" : "truncate"} font-normal"><span class="block min-w-0 max-w-full truncate" style="${mobile ? "font-size: 1.3333em;" : ""}">${renderSessionTitle(agent.name, sessionStatus === "streaming" || sessionStatus === "busy" || isCompacting, state.searchQuery)}</span>${mobile && session ? (() => {
 							const isActiveSession = sessionStatus === "streaming" || sessionStatus === "busy" || isCompacting;
 							if (isActiveSession) { const _d = (agent.id.charCodeAt(0) % 5) * 1.8; return html`<span class="shrink-0 text-muted-foreground/40" style="font-size: 0.9167em;">·</span><span class="sidebar-active-dot" style="--dot-delay:${_d}s"></span>`; }
@@ -1784,7 +1784,7 @@ function renderCollapsedSidebar(sortedGoals: Goal[], _ungroupedSessions: Gateway
 				title=${displayTitle}
 				@click=${() => { if (!active) connectToSession(s.id, true); }}
 			>
-				<span class="shrink-0 inline-flex items-center justify-center ${!active && hasUnseenActivity(s) ? "bobbit-unread-pulse" : ""}">${statusBobbit(s.status, s.isCompacting, s.id, active, s.isAborting, s.role === "team-lead", s.role === "coder", s.accessory, false, !active && hasUnseenActivity(s))}</span>
+				<span class="shrink-0 inline-flex items-center justify-center ${!active && hasUnseenActivity(s) ? "bobbit-unread-pulse" : ""}">${statusBobbit(s.status, s.isCompacting, s.id, active, s.isAborting, s.role === "team-lead", s.role === "coder", s.accessory, false, !active && hasUnseenActivity(s), true)}</span>
 				<span class="font-bold tracking-wide ${active ? "text-foreground" : "text-muted-foreground"}" style="font-family: ui-monospace, monospace; line-height: 1; font-size: 0.6667em;">${sessionAcronym(displayTitle)}</span>
 			</button>
 		`;
@@ -1808,7 +1808,7 @@ function renderCollapsedSidebar(sortedGoals: Goal[], _ungroupedSessions: Gateway
 				<span class="sidebar-chevron-slot sidebar-chevron-slot--collapsed text-muted-foreground shrink-0 select-none" style="cursor:pointer;"
 					@click=${(e: Event) => { e.stopPropagation(); toggleTeamLeadExpanded(teamLead.id); renderApp(); }}
 				><span class="sidebar-chevron-glyph">${children.length > 0 ? (tlExpanded ? "▾" : "▸") : ""}</span></span>
-				<span class="shrink-0 inline-flex items-center justify-center ${!tlActive && hasUnseenActivity(teamLead) ? "bobbit-unread-pulse" : ""}">${statusBobbit(teamLead.status, teamLead.isCompacting, teamLead.id, tlActive, teamLead.isAborting, true, false, teamLead.accessory, false, !tlActive && hasUnseenActivity(teamLead))}</span>
+				<span class="shrink-0 inline-flex items-center justify-center ${!tlActive && hasUnseenActivity(teamLead) ? "bobbit-unread-pulse" : ""}">${statusBobbit(teamLead.status, teamLead.isCompacting, teamLead.id, tlActive, teamLead.isAborting, true, false, teamLead.accessory, false, !tlActive && hasUnseenActivity(teamLead), true)}</span>
 				<span class="font-bold tracking-wide ${tlActive ? "text-foreground" : "text-muted-foreground"}" style="font-family: ui-monospace, monospace; line-height: 1; font-size: 0.6667em;">${sessionAcronym(tlTitle)}</span>
 			</button>
 			${tlExpanded ? children.map(s => html`<div style="padding-left:6px;">${renderCollapsedSession(s)}</div>`) : ""}

--- a/src/ui/bobbit-render.ts
+++ b/src/ui/bobbit-render.ts
@@ -814,7 +814,8 @@ export function renderSidebarBobbitCanvas(opts: SidebarBobbitOptions): TemplateR
 	else if (status === "terminated") filters.push("saturate(0)");
 	else if (isIdle) filters.push("saturate(0.4)");
 	const filterStyle = filters.length ? `filter:${filters.join(" ")};` : "";
-	const idleAnim = isIdle ? "animation:bobbit-breathe 4s ease-in-out infinite;" : "";
+	// Idle sidebar bobbits are intentionally static; keep visual styling via
+	// filters/sleeping eyes, but do not run the old continuous breathe animation.
 	const bobAnim = isBusy && !isCancelling && !isCompacting ? "animation:bobbit-bob 1.8s cubic-bezier(0.34,1.2,0.64,1) infinite;" : "";
 	const cancelAnim = isCancelling ? "animation:bobbit-cancel-fade 1.2s ease-in-out infinite;" : "";
 	const compactSquish = isCompacting && !isCancelling;
@@ -874,5 +875,5 @@ export function renderSidebarBobbitCanvas(opts: SidebarBobbitOptions): TemplateR
 		? html`<img src="${accUrl}" style="position:absolute;left:0;top:${accTop};width:${accCssW}px;height:${accCssH}px;will-change:transform;${accTransform}${accFilter}">`
 		: "";
 
-	return html`<span style="display:inline-flex;align-items:center;justify-content:center;width:${containerWidth};height:${containerHeight};flex-shrink:0;position:relative;overflow:hidden;margin-top:1px;${filterStyle}${bobAnim}${cancelAnim}${idleAnim}">${bodyLayer}${blinkLayer}${eyeLayer}${accessoryLayer}</span>`;
+	return html`<span style="display:inline-flex;align-items:center;justify-content:center;width:${containerWidth};height:${containerHeight};flex-shrink:0;position:relative;overflow:hidden;margin-top:1px;${filterStyle}${bobAnim}${cancelAnim}">${bodyLayer}${blinkLayer}${eyeLayer}${accessoryLayer}</span>`;
 }

--- a/src/ui/bobbit-render.ts
+++ b/src/ui/bobbit-render.ts
@@ -55,6 +55,8 @@ export interface SidebarBobbitOptions {
 	/** Session has unread/unseen activity. Overrides the sleeping pose with
 	 *  right-gazing open eyes that periodically blink. */
 	unread?: boolean;
+	/** Disable the idle breathing loop for actual sidebar session/staff rows. */
+	disableIdleBreathing?: boolean;
 }
 
 // ============================================================================
@@ -655,7 +657,7 @@ function sidebarStatusBucket(status: string): "starting" | "terminated" | "canon
  * Animations (bob, shimmer, eye blink) still use CSS on the container.
  */
 export function renderSidebarBobbitCanvas(opts: SidebarBobbitOptions): TemplateResult {
-	const { status, isCompacting = false, hueRotate = 0, isSelected = false, isAborting = false, noDesaturate = false, unread = false } = opts;
+	const { status, isCompacting = false, hueRotate = 0, isSelected = false, isAborting = false, noDesaturate = false, unread = false, disableIdleBreathing = false } = opts;
 	const acc = opts.accessory ?? NO_ACCESSORY;
 	const hasAccessory = acc.id !== "none";
 	const addsHeight = acc.addsHeight;
@@ -814,8 +816,7 @@ export function renderSidebarBobbitCanvas(opts: SidebarBobbitOptions): TemplateR
 	else if (status === "terminated") filters.push("saturate(0)");
 	else if (isIdle) filters.push("saturate(0.4)");
 	const filterStyle = filters.length ? `filter:${filters.join(" ")};` : "";
-	// Idle sidebar bobbits are intentionally static; keep visual styling via
-	// filters/sleeping eyes, but do not run the old continuous breathe animation.
+	const idleAnim = isIdle && !disableIdleBreathing ? "animation:bobbit-breathe 4s ease-in-out infinite;" : "";
 	const bobAnim = isBusy && !isCancelling && !isCompacting ? "animation:bobbit-bob 1.8s cubic-bezier(0.34,1.2,0.64,1) infinite;" : "";
 	const cancelAnim = isCancelling ? "animation:bobbit-cancel-fade 1.2s ease-in-out infinite;" : "";
 	const compactSquish = isCompacting && !isCancelling;
@@ -875,5 +876,5 @@ export function renderSidebarBobbitCanvas(opts: SidebarBobbitOptions): TemplateR
 		? html`<img src="${accUrl}" style="position:absolute;left:0;top:${accTop};width:${accCssW}px;height:${accCssH}px;will-change:transform;${accTransform}${accFilter}">`
 		: "";
 
-	return html`<span style="display:inline-flex;align-items:center;justify-content:center;width:${containerWidth};height:${containerHeight};flex-shrink:0;position:relative;overflow:hidden;margin-top:1px;${filterStyle}${bobAnim}${cancelAnim}">${bodyLayer}${blinkLayer}${eyeLayer}${accessoryLayer}</span>`;
+	return html`<span style="display:inline-flex;align-items:center;justify-content:center;width:${containerWidth};height:${containerHeight};flex-shrink:0;position:relative;overflow:hidden;margin-top:1px;${filterStyle}${bobAnim}${cancelAnim}${idleAnim}">${bodyLayer}${blinkLayer}${eyeLayer}${accessoryLayer}</span>`;
 }

--- a/src/ui/bobbit-render.ts
+++ b/src/ui/bobbit-render.ts
@@ -667,7 +667,7 @@ export function renderSidebarBobbitCanvas(opts: SidebarBobbitOptions): TemplateR
 	else if (status === "terminated") p = TERMINATED_PALETTE;
 	else p = CANONICAL_PALETTE;
 
-	const isBusy = status === "streaming" || isCompacting;
+	const isBusy = status === "streaming" || status === "busy" || isCompacting;
 	// Idle / not-currently-viewed sessions render with sleeping eyes (closed)
 	// to match the chat blob's sleeping pose. noDesaturate previews (role
 	// manager etc.) keep awake eyes so the bobbit looks alive in selection UI.

--- a/tests/fixtures/sidebar-bobbit-datauri-cache-entry.ts
+++ b/tests/fixtures/sidebar-bobbit-datauri-cache-entry.ts
@@ -2,17 +2,30 @@
 // render) for file:// use, so the spec can render the same sprite opts N times
 // and observe how many times the canvas data-URL encode (toDataURL) actually
 // runs. Pins the data-URL memoization in src/ui/bobbit-render.ts.
-import { render } from "lit";
+import { html, render } from "lit";
 import {
 	renderSidebarBobbitCanvas,
 	ACCESSORY_DEFS,
 	NO_ACCESSORY,
 	type SidebarBobbitOptions,
 } from "../../src/ui/bobbit-render.js";
-import { statusBobbit } from "../../src/app/session-colors.js";
+import { getAccessory, statusBobbit } from "../../src/app/session-colors.js";
+
+type StaticSidebarBobbitOptions = SidebarBobbitOptions & {
+	/** Sidebar/status call sites opt idle sprites out of the default breathe animation. */
+	staticIdle?: boolean;
+};
 
 function renderInto(host: HTMLElement, opts: SidebarBobbitOptions): void {
 	render(renderSidebarBobbitCanvas(opts), host);
+}
+
+function renderDefaultPreviewInto(host: HTMLElement, opts: SidebarBobbitOptions): void {
+	render(renderSidebarBobbitCanvas(opts), host);
+}
+
+function renderStaticSidebarInto(host: HTMLElement, opts: SidebarBobbitOptions): void {
+	render(renderSidebarBobbitCanvas({ ...opts, staticIdle: true } as StaticSidebarBobbitOptions), host);
 }
 
 function renderStatusInto(
@@ -30,9 +43,35 @@ function renderStatusInto(
 	render(statusBobbit(status, isCompacting, undefined, isSelected, isAborting, false, false, accessory, noDesaturate, unread), host);
 }
 
+function renderStaticSidebarStatusInto(
+	host: HTMLElement,
+	status: string,
+	isCompacting = false,
+	isSelected = false,
+	isAborting = false,
+	accessory?: string,
+	noDesaturate = false,
+	unread = false,
+): void {
+	const sprite = renderSidebarBobbitCanvas({
+		status,
+		isCompacting,
+		isSelected,
+		isAborting,
+		accessory: getAccessory(accessory),
+		noDesaturate,
+		unread,
+		staticIdle: true,
+	} as StaticSidebarBobbitOptions);
+	render(html`<span class="sidebar-bobbit-status-test ${unread ? "bobbit-unread-pulse" : ""}">${sprite}</span>`, host);
+}
+
 (window as any).__sidebarBobbit = {
 	renderInto,
+	renderDefaultPreviewInto,
+	renderStaticSidebarInto,
 	renderStatusInto,
+	renderStaticSidebarStatusInto,
 	ACCESSORY_DEFS,
 	NO_ACCESSORY,
 };

--- a/tests/fixtures/sidebar-bobbit-datauri-cache-entry.ts
+++ b/tests/fixtures/sidebar-bobbit-datauri-cache-entry.ts
@@ -9,13 +9,30 @@ import {
 	NO_ACCESSORY,
 	type SidebarBobbitOptions,
 } from "../../src/ui/bobbit-render.js";
+import { statusBobbit } from "../../src/app/session-colors.js";
 
 function renderInto(host: HTMLElement, opts: SidebarBobbitOptions): void {
 	render(renderSidebarBobbitCanvas(opts), host);
 }
 
+function renderStatusInto(
+	host: HTMLElement,
+	status: string,
+	isCompacting = false,
+	isSelected = false,
+	isAborting = false,
+	accessory?: string,
+	noDesaturate = false,
+	unread = false,
+): void {
+	// Keep sessionId undefined so this fixture exercises statusBobbit's argument
+	// forwarding without touching persisted session color assignment.
+	render(statusBobbit(status, isCompacting, undefined, isSelected, isAborting, false, false, accessory, noDesaturate, unread), host);
+}
+
 (window as any).__sidebarBobbit = {
 	renderInto,
+	renderStatusInto,
 	ACCESSORY_DEFS,
 	NO_ACCESSORY,
 };

--- a/tests/fixtures/sidebar-bobbit-datauri-cache-entry.ts
+++ b/tests/fixtures/sidebar-bobbit-datauri-cache-entry.ts
@@ -11,11 +11,6 @@ import {
 } from "../../src/ui/bobbit-render.js";
 import { getAccessory, statusBobbit } from "../../src/app/session-colors.js";
 
-type StaticSidebarBobbitOptions = SidebarBobbitOptions & {
-	/** Sidebar/status call sites opt idle sprites out of the default breathe animation. */
-	staticIdle?: boolean;
-};
-
 function renderInto(host: HTMLElement, opts: SidebarBobbitOptions): void {
 	render(renderSidebarBobbitCanvas(opts), host);
 }
@@ -25,7 +20,7 @@ function renderDefaultPreviewInto(host: HTMLElement, opts: SidebarBobbitOptions)
 }
 
 function renderStaticSidebarInto(host: HTMLElement, opts: SidebarBobbitOptions): void {
-	render(renderSidebarBobbitCanvas({ ...opts, staticIdle: true } as StaticSidebarBobbitOptions), host);
+	render(renderSidebarBobbitCanvas({ ...opts, disableIdleBreathing: true }), host);
 }
 
 function renderStatusInto(
@@ -61,8 +56,8 @@ function renderStaticSidebarStatusInto(
 		accessory: getAccessory(accessory),
 		noDesaturate,
 		unread,
-		staticIdle: true,
-	} as StaticSidebarBobbitOptions);
+		disableIdleBreathing: true,
+	});
 	render(html`<span class="sidebar-bobbit-status-test ${unread ? "bobbit-unread-pulse" : ""}">${sprite}</span>`, host);
 }
 

--- a/tests/sidebar-bobbit-datauri-cache.spec.ts
+++ b/tests/sidebar-bobbit-datauri-cache.spec.ts
@@ -68,6 +68,69 @@ async function installSpyAndLoad(page: import("@playwright/test").Page): Promise
 }
 
 test.describe("Sidebar bobbit data-URL memoization", () => {
+	test("idle sidebar bobbits render statically while preserving idle styling", async ({ page }) => {
+		await installSpyAndLoad(page);
+
+		const result = await page.evaluate(() => {
+			const api = (window as any).__sidebarBobbit;
+			const host = document.getElementById("host")!;
+			api.renderInto(host, {
+				status: "idle",
+				accessory: api.ACCESSORY_DEFS["crown"],
+			});
+			const outer = host.firstElementChild as HTMLElement;
+			return {
+				style: outer.getAttribute("style") ?? "",
+				animation: outer.style.animation,
+				filter: outer.style.filter,
+				width: outer.style.width,
+				height: outer.style.height,
+				accessoryLayerCount: host.querySelectorAll("img").length - 1,
+			};
+		});
+
+		expect(result.style).not.toContain("bobbit-breathe");
+		expect(result.animation).toBe("");
+		expect(result.filter).toBe("saturate(0.4)");
+		expect(result.width).toBe("20px");
+		expect(result.height).toBe("19px");
+		expect(result.accessoryLayerCount).toBe(1);
+	});
+
+	test("statusBobbit preserves active and unread sidebar animations without idle breathing", async ({ page }) => {
+		await installSpyAndLoad(page);
+
+		const result = await page.evaluate(() => {
+			const api = (window as any).__sidebarBobbit;
+			const host = document.getElementById("host")!;
+			const capture = () => {
+				const outer = host.firstElementChild as HTMLElement;
+				return {
+					style: outer.getAttribute("style") ?? "",
+					animation: outer.style.animation,
+					blinkCount: host.querySelectorAll(".bobbit-sidebar-unread-blink").length,
+				};
+			};
+
+			api.renderStatusInto(host, "streaming");
+			const streaming = capture();
+			api.renderStatusInto(host, "idle", false, false, false, "bandana", false, true);
+			const unreadIdle = capture();
+			api.renderStatusInto(host, "idle");
+			const plainIdle = capture();
+
+			return { streaming, unreadIdle, plainIdle };
+		});
+
+		expect(result.streaming.style).toContain("bobbit-bob");
+		expect(result.streaming.style).not.toContain("bobbit-breathe");
+		expect(result.unreadIdle.style).not.toContain("bobbit-breathe");
+		expect(result.unreadIdle.animation).toBe("");
+		expect(result.unreadIdle.blinkCount).toBe(1);
+		expect(result.plainIdle.style).not.toContain("bobbit-breathe");
+		expect(result.plainIdle.animation).toBe("");
+	});
+
 	test("identical opts: toDataURL runs once on first render, never again", async ({ page }) => {
 		await installSpyAndLoad(page);
 

--- a/tests/sidebar-bobbit-datauri-cache.spec.ts
+++ b/tests/sidebar-bobbit-datauri-cache.spec.ts
@@ -26,6 +26,7 @@ const SOURCES = [
 	ENTRY,
 	path.resolve("src/ui/bobbit-render.ts"),
 	path.resolve("src/ui/bobbit-sprite-data.ts"),
+	path.resolve("src/app/session-colors.ts"),
 ];
 
 function fileUrl(file: string): string {
@@ -68,13 +69,13 @@ async function installSpyAndLoad(page: import("@playwright/test").Page): Promise
 }
 
 test.describe("Sidebar bobbit data-URL memoization", () => {
-	test("idle sidebar bobbits render statically while preserving idle styling", async ({ page }) => {
+	test("default idle preview bobbits keep the breathing animation", async ({ page }) => {
 		await installSpyAndLoad(page);
 
 		const result = await page.evaluate(() => {
 			const api = (window as any).__sidebarBobbit;
 			const host = document.getElementById("host")!;
-			api.renderInto(host, {
+			api.renderDefaultPreviewInto(host, {
 				status: "idle",
 				accessory: api.ACCESSORY_DEFS["crown"],
 			});
@@ -89,46 +90,82 @@ test.describe("Sidebar bobbit data-URL memoization", () => {
 			};
 		});
 
-		expect(result.style).not.toContain("bobbit-breathe");
-		expect(result.animation).toBe("");
+		expect(result.style).toContain("bobbit-breathe");
+		expect(result.animation).toContain("bobbit-breathe");
 		expect(result.filter).toBe("saturate(0.4)");
 		expect(result.width).toBe("20px");
 		expect(result.height).toBe("19px");
 		expect(result.accessoryLayerCount).toBe(1);
 	});
 
-	test("statusBobbit preserves active and unread sidebar animations without idle breathing", async ({ page }) => {
+	test("explicit static sidebar idle bobbits render without inline animation while preserving idle styling", async ({ page }) => {
+		await installSpyAndLoad(page);
+
+		const result = await page.evaluate(() => {
+			const api = (window as any).__sidebarBobbit;
+			const host = document.getElementById("host")!;
+			api.renderStaticSidebarStatusInto(host, "idle", false, false, false, "crown");
+			const outer = host.querySelector(".sidebar-bobbit-status-test > span") as HTMLElement;
+			return {
+				style: outer.getAttribute("style") ?? "",
+				animation: outer.style.animation,
+				inlineAnimations: Array.from(host.querySelectorAll<HTMLElement>("[style]")).map(el => el.style.animation).filter(Boolean),
+				filter: outer.style.filter,
+				width: outer.style.width,
+				height: outer.style.height,
+				accessoryLayerCount: host.querySelectorAll("img").length - 1,
+			};
+		});
+
+		expect(result.style).not.toContain("bobbit-breathe");
+		expect(result.animation).toBe("");
+		expect(result.inlineAnimations).toEqual([]);
+		expect(result.filter).toBe("saturate(0.4)");
+		expect(result.width).toBe("20px");
+		expect(result.height).toBe("19px");
+		expect(result.accessoryLayerCount).toBe(1);
+	});
+
+	test("static sidebar status rendering preserves busy and unread animations without idle breathing", async ({ page }) => {
 		await installSpyAndLoad(page);
 
 		const result = await page.evaluate(() => {
 			const api = (window as any).__sidebarBobbit;
 			const host = document.getElementById("host")!;
 			const capture = () => {
-				const outer = host.firstElementChild as HTMLElement;
+				const outer = host.querySelector(".sidebar-bobbit-status-test > span") as HTMLElement;
 				return {
 					style: outer.getAttribute("style") ?? "",
 					animation: outer.style.animation,
 					blinkCount: host.querySelectorAll(".bobbit-sidebar-unread-blink").length,
+					pulseCount: host.querySelectorAll(".bobbit-unread-pulse").length,
 				};
 			};
 
-			api.renderStatusInto(host, "streaming");
+			api.renderStaticSidebarStatusInto(host, "streaming");
 			const streaming = capture();
-			api.renderStatusInto(host, "idle", false, false, false, "bandana", false, true);
+			api.renderStaticSidebarStatusInto(host, "busy");
+			const busy = capture();
+			api.renderStaticSidebarStatusInto(host, "idle", false, false, false, "bandana", false, true);
 			const unreadIdle = capture();
-			api.renderStatusInto(host, "idle");
+			api.renderStaticSidebarStatusInto(host, "idle");
 			const plainIdle = capture();
 
-			return { streaming, unreadIdle, plainIdle };
+			return { streaming, busy, unreadIdle, plainIdle };
 		});
 
 		expect(result.streaming.style).toContain("bobbit-bob");
 		expect(result.streaming.style).not.toContain("bobbit-breathe");
+		expect(result.busy.style).toContain("bobbit-bob");
+		expect(result.busy.style).not.toContain("bobbit-breathe");
 		expect(result.unreadIdle.style).not.toContain("bobbit-breathe");
 		expect(result.unreadIdle.animation).toBe("");
 		expect(result.unreadIdle.blinkCount).toBe(1);
+		expect(result.unreadIdle.pulseCount).toBe(1);
 		expect(result.plainIdle.style).not.toContain("bobbit-breathe");
 		expect(result.plainIdle.animation).toBe("");
+		expect(result.plainIdle.blinkCount).toBe(0);
+		expect(result.plainIdle.pulseCount).toBe(0);
 	});
 
 	test("identical opts: toDataURL runs once on first render, never again", async ({ page }) => {


### PR DESCRIPTION
## Summary

- Disable idle `bobbit-breathe` only for actual sidebar session/staff Bobbits via an explicit `disableIdleBreathing` option.
- Preserve default idle breathing for non-sidebar role/accessory previews and keep streaming/busy, compacting, cancelling, selected, and unread animations intact.
- Add focused sidebar Bobbit tests covering static sidebar idle rendering, preview preservation, busy/streaming bobbing, and unread blink/pulse behavior.
- Update sprite documentation for the new sidebar idle behavior.

## Verification

- `npm run check`
- `npx playwright test --config=tests/playwright.config.ts tests/sidebar-bobbit-datauri-cache.spec.ts`
- `npm run test:unit`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
