### PR TITLE
Fix delegate prompt inspector task sections

### DIFF
--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -80,6 +80,8 @@ mutating (file-changing) tool.
   system default; that bug is gone.)
 - **Timeout** — blocking-mode default is 10 minutes.
 
+The System Prompt Inspector treats the child's persisted `instructions` and optional `context` as a durable **Delegate Task**. Prompt-section refreshes, including provider `before-prompt` hooks and restart restore, rebuild that task from the session record so the viewer keeps the same task-oriented section the model received. Delegate instructions should appear in that Task section only, not duplicated into both Goal and Task.
+
 > ### ⚠️ Shared-worktree race (non-blocking mode) — accepted, not mitigated
 >
 > A `team_delegate` child runs in **your** worktree (shares your `cwd`). In **blocking**

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -2736,7 +2736,6 @@ export class SessionManager {
 	getPromptParts(sessionId: string): PromptParts | undefined {
 		const session = this.sessions.get(sessionId);
 		if (!session) return undefined;
-		if (session.promptParts) return session.promptParts;
 
 		let persisted: PersistedSession | undefined;
 		try { persisted = this.resolveStoreForId(session.id)?.get(session.id); }
@@ -2744,12 +2743,13 @@ export class SessionManager {
 		const effectiveGoalId = session.goalId ?? session.teamGoalId ?? persisted?.goalId ?? persisted?.teamGoalId;
 		const sectionOrder = this.promptSectionOrderForGoal(effectiveGoalId, session.projectId ?? persisted?.projectId);
 
-		// Rebuild on demand for dormant / restored sessions missing cached parts
-		const assistantDef = session.assistantType ? getAssistantDef(session.assistantType) : undefined;
-		let parts: PromptParts;
-
-		if ((session.delegateOf || persisted?.delegateOf) && persisted?.instructions?.trim()) {
-			parts = this.buildDelegatePromptParts({
+		// Delegate task instructions are durable store data, not ordinary cached prompt
+		// state. A provider hook can run after an early incomplete cache was created;
+		// for delegates, always rebuild from persisted instructions/context so the
+		// refresh path cannot overwrite the inspector snapshot with a task-less prompt.
+		const isDelegate = !!(session.delegateOf || persisted?.delegateOf);
+		if (isDelegate && persisted?.instructions?.trim()) {
+			const parts = this.buildDelegatePromptParts({
 				cwd: session.cwd,
 				projectRoot: persisted.repoPath,
 				instructions: persisted.instructions,
@@ -2757,7 +2757,33 @@ export class SessionManager {
 				allowedTools: session.allowedTools ?? persisted.allowedTools,
 				sectionOrder,
 			});
-		} else if (assistantDef) {
+			parts.dynamicContext = session.promptParts?.dynamicContext;
+			if (this.toolManager && !parts.toolDocs) {
+				parts.toolDocs = this.toolManager.getToolDocsForPrompt(parts.allowedTools, bobbitStateDir());
+			}
+			if (!parts.skillsCatalog) {
+				parts.skillsCatalog = this.computeSkillsCatalog(
+					parts.allowedTools,
+					parts.projectRoot || parts.cwd,
+					parts.projectConfigStore,
+					session.projectId ?? persisted.projectId,
+				);
+			}
+			if (parts.skillsCatalogBudget === undefined && this.preferencesStore) {
+				const pref = this.preferencesStore.get("skillsCatalogBudget");
+				if (typeof pref === "number" && Number.isFinite(pref)) parts.skillsCatalogBudget = pref;
+			}
+			session.promptParts = parts;
+			return parts;
+		}
+
+		if (session.promptParts) return session.promptParts;
+
+		// Rebuild on demand for dormant / restored sessions missing cached parts
+		const assistantDef = session.assistantType ? getAssistantDef(session.assistantType) : undefined;
+		let parts: PromptParts;
+
+		if (assistantDef) {
 			const assistantTemplate = this.resolveRolePromptTemplate("assistant", session.projectId);
 			let assistantGoalSpec = "";
 			if (assistantTemplate) {

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -2696,6 +2696,41 @@ export class SessionManager {
 		}
 	}
 
+	private buildDelegateTaskSpec(instructions: string, context?: Record<string, string>): string {
+		let taskSpec = instructions;
+		if (context && Object.keys(context).length > 0) {
+			taskSpec += "\n\n## Context";
+			for (const [key, value] of Object.entries(context)) {
+				taskSpec += `\n- **${key}**: ${value}`;
+			}
+		}
+		return taskSpec;
+	}
+
+	private buildDelegatePromptParts(opts: {
+		cwd: string;
+		projectRoot?: string;
+		instructions: string;
+		context?: Record<string, string>;
+		allowedTools?: string[];
+		sectionOrder?: string[];
+	}): PromptParts {
+		return {
+			baseSystemPromptPath: this.systemPromptPath,
+			cwd: opts.cwd,
+			projectRoot: opts.projectRoot,
+			// Delegates carry a durable task, not a goal. Older spawn code mapped this
+			// through goalSpec before the live SessionInfo existed; reconstruction uses
+			// the existing Task renderer so the inspector shows one task-oriented section
+			// and never duplicates the instructions across Goal + Task.
+			taskTitle: "Delegate Task",
+			taskSpec: this.buildDelegateTaskSpec(opts.instructions, opts.context),
+			allowedTools: opts.allowedTools,
+			projectConfigStore: this.projectConfigStore,
+			sectionOrder: opts.sectionOrder,
+		};
+	}
+
 	/** Get cached PromptParts for serving prompt-sections API.
 	 *  If not cached (e.g. dormant session), rebuild from session metadata. */
 	getPromptParts(sessionId: string): PromptParts | undefined {
@@ -2703,11 +2738,26 @@ export class SessionManager {
 		if (!session) return undefined;
 		if (session.promptParts) return session.promptParts;
 
+		let persisted: PersistedSession | undefined;
+		try { persisted = this.resolveStoreForId(session.id)?.get(session.id); }
+		catch { persisted = undefined; }
+		const effectiveGoalId = session.goalId ?? session.teamGoalId ?? persisted?.goalId ?? persisted?.teamGoalId;
+		const sectionOrder = this.promptSectionOrderForGoal(effectiveGoalId, session.projectId ?? persisted?.projectId);
+
 		// Rebuild on demand for dormant / restored sessions missing cached parts
 		const assistantDef = session.assistantType ? getAssistantDef(session.assistantType) : undefined;
 		let parts: PromptParts;
 
-		if (assistantDef) {
+		if ((session.delegateOf || persisted?.delegateOf) && persisted?.instructions?.trim()) {
+			parts = this.buildDelegatePromptParts({
+				cwd: session.cwd,
+				projectRoot: persisted.repoPath,
+				instructions: persisted.instructions,
+				context: persisted.context,
+				allowedTools: session.allowedTools ?? persisted.allowedTools,
+				sectionOrder,
+			});
+		} else if (assistantDef) {
 			const assistantTemplate = this.resolveRolePromptTemplate("assistant", session.projectId);
 			let assistantGoalSpec = "";
 			if (assistantTemplate) {
@@ -2732,11 +2782,13 @@ export class SessionManager {
 				// so it survives respawn / rebuild paths (not just initial session-setup).
 				baseSystemPromptPath: this.systemPromptPath,
 				cwd: session.cwd,
+				projectRoot: persisted?.repoPath,
 				goalSpec: assistantGoalSpec,
 				goalTitle: assistantDef.promptTitle,
 				goalState: "active",
 				allowedTools: session.allowedTools,
 				projectConfigStore: this.projectConfigStore,
+				sectionOrder,
 			};
 		} else {
 			const goal = session.goalId ? this.resolveGoal(session.goalId) : undefined;
@@ -2757,6 +2809,7 @@ export class SessionManager {
 			parts = {
 				baseSystemPromptPath: this.systemPromptPath,
 				cwd: session.cwd,
+				projectRoot: persisted?.repoPath,
 				goalTitle: goal?.title,
 				goalState: goal?.state,
 				goalSpec: goal?.spec,
@@ -2764,7 +2817,24 @@ export class SessionManager {
 				roleName,
 				allowedTools: session.allowedTools,
 				projectConfigStore: this.projectConfigStore,
+				sectionOrder,
 			};
+		}
+
+		if (this.toolManager && !parts.toolDocs) {
+			parts.toolDocs = this.toolManager.getToolDocsForPrompt(parts.allowedTools, bobbitStateDir());
+		}
+		if (!parts.skillsCatalog) {
+			parts.skillsCatalog = this.computeSkillsCatalog(
+				parts.allowedTools,
+				parts.projectRoot || parts.cwd,
+				parts.projectConfigStore,
+				session.projectId ?? persisted?.projectId,
+			);
+		}
+		if (parts.skillsCatalogBudget === undefined && this.preferencesStore) {
+			const pref = this.preferencesStore.get("skillsCatalogBudget");
+			if (typeof pref === "number" && Number.isFinite(pref)) parts.skillsCatalogBudget = pref;
 		}
 
 		// Cache for future calls
@@ -5074,31 +5144,19 @@ export class SessionManager {
 			});
 			if (promptPath) bridgeOptions.systemPromptPath = promptPath;
 		} else if (ps.delegateOf && !ps.goalId) {
-			// Delegate restore: rebuild the system prompt from the durable task fields
-			// (instructions + context) — the delegate's equivalent of a worker's goal
-			// spec. Mirrors session-setup.ts::_resolvePrompt mode === "delegate" so a
-			// revived delegate carries its original task, not an empty goal/role prompt.
-			let taskSpec = ps.instructions || "";
-			if (ps.context && Object.keys(ps.context).length > 0) {
-				taskSpec += "\n\n## Context";
-				for (const [key, value] of Object.entries(ps.context)) {
-					taskSpec += `\n- **${key}**: ${value}`;
-				}
-			}
-			const promptPath = this.assemblePrompt(ps.id, {
-				baseSystemPromptPath: this.systemPromptPath,
+			// Delegate restore: rebuild the system prompt from durable instructions +
+			// context — the delegate's equivalent of a worker task spec. Use the Task
+			// fields so restored delegates and prompt-section reconstruction agree.
+			const promptPath = this.assemblePrompt(ps.id, this.buildDelegatePromptParts({
 				cwd: ps.cwd,
-				// Mirror the spawn path (session-setup.ts::_resolvePrompt mode ===
-				// "delegate") so AGENTS.md / project config dirs are readable for
-				// sandbox or multi-repo delegates whose cwd is container-internal.
+				// Keep AGENTS.md / project config dirs readable for sandbox or multi-repo
+				// delegates whose cwd is container-internal.
 				projectRoot: ps.repoPath,
-				goalSpec: taskSpec,
-				goalTitle: "Delegate Task",
-				goalState: "active",
+				instructions: ps.instructions || "",
+				context: ps.context,
 				allowedTools: restoredAllowedNames,
-				projectConfigStore: this.projectConfigStore,
 				sectionOrder: restoreSectionOrder,
-			});
+			}));
 			if (promptPath) bridgeOptions.systemPromptPath = promptPath;
 		} else {
 			const goal = ps.goalId ? this.resolveGoal(ps.goalId) : undefined;

--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -783,7 +783,9 @@ function _resolvePrompt(plan: SessionSetupPlan, ctx: PipelineContext): void {
 		});
 		if (promptPath) plan.bridgeOptions.systemPromptPath = promptPath;
 	} else if (plan.mode === "delegate") {
-		// Delegate sessions: AGENTS.md only + task spec
+		// Delegate sessions: AGENTS.md + durable task spec. Render through the Task
+		// section (not Goal) so fresh spawn, restore, cached PromptParts, and
+		// prompt-section refresh all expose one task-oriented delegate section.
 		let taskSpec = plan.instructions || "";
 		if (plan.context && Object.keys(plan.context).length > 0) {
 			taskSpec += "\n\n## Context";
@@ -794,14 +796,12 @@ function _resolvePrompt(plan: SessionSetupPlan, ctx: PipelineContext): void {
 
 		const promptPath = ctx.assemblePrompt(plan.id, {
 			dynamicContext: plan.dynamicContextBlocks,
-			// Delegates still get the global base system prompt. The task spec is
-			// layered on top as goalSpec; AGENTS.md from the worktree is also included.
 			baseSystemPromptPath: ctx.systemPromptPath,
 			cwd: plan.cwd,
 			projectRoot: plan.repoPath,
-			goalSpec: taskSpec,
-			goalTitle: "Delegate Task",
-			goalState: "active",
+			taskTitle: "Delegate Task",
+			taskSpec,
+			allowedTools: plan.effectiveAllowedTools?.map(e => e.name),
 			projectConfigStore: ctx.projectConfigStore ?? undefined,
 			sectionOrder,
 		});

--- a/tests/e2e/delegate-prompt-sections.spec.ts
+++ b/tests/e2e/delegate-prompt-sections.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * Regression coverage for delegate prompt-section snapshots.
+ *
+ * A team_delegate child receives durable instructions in its assembled prompt.
+ * The provider before-prompt hook refreshes the persisted prompt-sections JSON;
+ * that refresh must not reconstruct the prompt without the delegate task.
+ */
+import { test, expect } from "./in-process-harness.js";
+import { apiFetch, createSession, deleteSession } from "./e2e-setup.js";
+
+const PROMPT_REFRESH_ASSERTION = "Expected refreshed delegate prompt sections to retain durable delegate instructions";
+
+test.setTimeout(45_000);
+
+async function spawnDelegate(parentId: string, instructions: string, readOnly: boolean): Promise<string> {
+	const resp = await apiFetch(`/api/sessions/${parentId}/orchestrate/spawn`, {
+		method: "POST",
+		body: JSON.stringify({ instructions, read_only: readOnly }),
+	});
+	expect(resp.status).toBe(201);
+	const body = await resp.json();
+	expect(typeof body.childSessionId).toBe("string");
+	return body.childSessionId;
+}
+
+async function promptSectionsText(sessionId: string): Promise<string> {
+	const resp = await apiFetch(`/api/sessions/${sessionId}/prompt-sections`);
+	expect(resp.status).toBe(200);
+	const body = await resp.json();
+	expect(Array.isArray(body.sections)).toBe(true);
+	return body.sections
+		.map((section: any) => `${section.label ?? ""}\n${section.source ?? ""}\n${section.content ?? ""}`)
+		.join("\n\n---\n\n");
+}
+
+async function refreshPromptSections(sessionId: string): Promise<void> {
+	const resp = await apiFetch(`/api/sessions/${sessionId}/provider-hooks/before-prompt`, {
+		method: "POST",
+		body: JSON.stringify({ prompt: "refresh prompt-section snapshot" }),
+	});
+	expect(resp.status).toBe(200);
+}
+
+for (const { name, readOnly } of [
+	{ name: "normal delegate", readOnly: false },
+	{ name: "read-only delegate", readOnly: true },
+]) {
+	test(`${name} keeps durable instructions in prompt sections after before-prompt refresh`, async () => {
+		const parentId = await createSession();
+		const marker = `delegate-prompt-viewer-${readOnly ? "readonly" : "normal"}-${Date.now()}`;
+		const instructions = `Preserve this durable delegate task marker in prompt sections: ${marker}`;
+		let delegateId: string | undefined;
+
+		try {
+			delegateId = await spawnDelegate(parentId, instructions, readOnly);
+
+			const beforeRefresh = await promptSectionsText(delegateId);
+			expect(
+				beforeRefresh,
+				"Delegate prompt sections should initially expose the durable instructions before the provider hook refresh",
+			).toContain(marker);
+
+			await refreshPromptSections(delegateId);
+
+			const afterRefresh = await promptSectionsText(delegateId);
+			expect(afterRefresh, PROMPT_REFRESH_ASSERTION).toContain(marker);
+		} finally {
+			if (delegateId) await deleteSession(delegateId).catch(() => {});
+			await deleteSession(parentId).catch(() => {});
+		}
+	});
+}

--- a/tests/e2e/orchestrate-restart.spec.ts
+++ b/tests/e2e/orchestrate-restart.spec.ts
@@ -21,10 +21,10 @@ import { pollUntil } from "./test-utils/cleanup.js";
 
 test.describe.configure({ mode: "serial" });
 
-async function spawnChild(ownerId: string, instructions: string): Promise<string> {
+async function spawnChild(ownerId: string, instructions: string, readOnly = false): Promise<string> {
 	const resp = await apiFetch(`/api/sessions/${ownerId}/orchestrate/spawn`, {
 		method: "POST",
-		body: JSON.stringify({ instructions }),
+		body: JSON.stringify({ instructions, read_only: readOnly }),
 	});
 	expect(resp.status).toBe(201);
 	return (await resp.json()).childSessionId as string;
@@ -34,6 +34,24 @@ async function listChildren(ownerId: string): Promise<string[]> {
 	const resp = await apiFetch(`/api/sessions/${ownerId}/orchestrate/children`);
 	expect(resp.status).toBe(200);
 	return ((await resp.json()).children ?? []).map((c: any) => c.sessionId);
+}
+
+async function promptSectionsText(sessionId: string): Promise<string> {
+	const resp = await apiFetch(`/api/sessions/${sessionId}/prompt-sections`);
+	expect(resp.status).toBe(200);
+	const body = await resp.json();
+	expect(Array.isArray(body.sections)).toBe(true);
+	return body.sections
+		.map((section: any) => `${section.label ?? ""}\n${section.source ?? ""}\n${section.content ?? ""}`)
+		.join("\n\n---\n\n");
+}
+
+async function refreshPromptSections(sessionId: string): Promise<void> {
+	const resp = await apiFetch(`/api/sessions/${sessionId}/provider-hooks/before-prompt`, {
+		method: "POST",
+		body: JSON.stringify({ prompt: "refresh restored delegate prompt sections" }),
+	});
+	expect(resp.status).toBe(200);
 }
 
 function messageText(m: WsMsg): string {
@@ -162,7 +180,8 @@ test.describe("orchestration restart survival", () => {
 		const sm = gateway.sessionManager;
 		const parent = await createSession();
 		// Distinctive marker so we can assert it lands in the rebuilt system prompt.
-		const child = await spawnChild(parent, "restart-live-survivor-MARKER helper task");
+		const marker = "restart-live-survivor-MARKER";
+		const child = await spawnChild(parent, `${marker} helper task`);
 		try {
 			// Drive the child's spawn prompt to completion (mock agent → "OK") so a
 			// persisted transcript + agentSessionFile exist before the reboot.
@@ -206,8 +225,21 @@ test.describe("orchestration restart survival", () => {
 				try { promptText = readFileSync(promptPath, "utf-8"); } catch { /* file gone */ }
 			}
 			const ps = sm.getPersistedSession(child) as any;
-			expect(promptText).toContain("restart-live-survivor-MARKER");
-			expect(`${ps?.instructions ?? ""}`).toContain("restart-live-survivor-MARKER");
+			expect(promptText).toContain(marker);
+			expect(`${ps?.instructions ?? ""}`).toContain(marker);
+
+			const restoredSections = await promptSectionsText(child);
+			expect(
+				restoredSections,
+				"Restored delegate prompt sections should expose the durable task instructions",
+			).toContain(marker);
+
+			await refreshPromptSections(child);
+			const refreshedSections = await promptSectionsText(child);
+			expect(
+				refreshedSections,
+				"before-prompt refresh should retain restored delegate task instructions in prompt sections",
+			).toContain(marker);
 		} finally {
 			await deleteSession(child).catch(() => {});
 			await deleteSession(parent).catch(() => {});

--- a/tests/session-manager-delegate-restore.test.ts
+++ b/tests/session-manager-delegate-restore.test.ts
@@ -32,9 +32,9 @@ type PersistedSession = import("../src/server/agent/session-store.ts").Persisted
 initPromptDirs(path.join(tmpRoot, "state"));
 
 /**
- * Verbatim copy of restoreSession()'s delegate-branch taskSpec assembly
- * (and session-setup.ts::_resolvePrompt mode === "delegate"). Kept in lock-step
- * with the production branch by the source guard below.
+ * Verbatim copy of the durable delegate taskSpec assembly used by
+ * session-manager.ts::buildDelegatePromptParts and session-setup.ts::_resolvePrompt
+ * mode === "delegate". Kept in lock-step with production by the source guard below.
  */
 function buildDelegateTaskSpec(ps: Pick<PersistedSession, "instructions" | "context">): string {
 	let taskSpec = ps.instructions || "";
@@ -105,12 +105,15 @@ describe("delegate restore — source guards", () => {
 		const delegateBranchIdx = window.indexOf("} else if (ps.delegateOf && !ps.goalId) {");
 		assert.ok(delegateBranchIdx > 0, "restoreSession must have an `else if (ps.delegateOf && !ps.goalId)` branch");
 
-		// The delegate branch builds the task spec from instructions + context.
-		const branchWindow = window.slice(delegateBranchIdx, delegateBranchIdx + 1200);
-		assert.match(branchWindow, /let taskSpec = ps\.instructions \|\| ""/);
-		assert.match(branchWindow, /for \(const \[key, value\] of Object\.entries\(ps\.context\)\)/);
+		// The delegate branch rebuilds prompt parts from durable instructions + context.
+		const branchWindow = window.slice(delegateBranchIdx, delegateBranchIdx + 1400);
+		assert.match(branchWindow, /this\.buildDelegatePromptParts\(\{/);
+		assert.match(branchWindow, /cwd: ps\.cwd/);
 		assert.match(branchWindow, /projectRoot: ps\.repoPath/);
-		assert.match(branchWindow, /goalSpec: taskSpec/);
+		assert.match(branchWindow, /instructions: ps\.instructions \|\| ""/);
+		assert.match(branchWindow, /context: ps\.context/);
+		assert.match(branchWindow, /allowedTools: restoredAllowedNames/);
+		assert.match(branchWindow, /sectionOrder: restoreSectionOrder/);
 
 		// It must precede the goal/role else branch (which resolves goal?.spec).
 		const goalElseIdx = window.indexOf("const goal = ps.goalId ? this.resolveGoal(ps.goalId) : undefined;");


### PR DESCRIPTION
## Summary
- Preserve `team_delegate` task instructions in prompt-section snapshots after provider `before-prompt` refreshes.
- Reconstruct delegate prompt parts from durable `instructions` and `context` for live fallback and restore paths.
- Add regression coverage for normal/read-only delegates and restored delegates, plus docs for the prompt-inspector invariant.

## Validation
- `npm run check`
- `npx tsx --test tests/session-manager-delegate-restore.test.ts`
- `npm run test:e2e:run -- --project=api tests/e2e/delegate-prompt-sections.spec.ts tests/e2e/orchestrate-restart.spec.ts`
- Workflow implementation and documentation gates passed.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)