### PR TITLE
Fix Reviewer Nudges

### DIFF
--- a/docs/cold-restart-reprompt.md
+++ b/docs/cold-restart-reprompt.md
@@ -71,12 +71,20 @@ Three boot-recovery paths use this helper:
 
 ## Mid-turn re-prompt path
 
-`SessionManager.restoreSession` detects a session that was mid-turn at shutdown
-(`wasStreaming`) and re-prompts it with a "the server restarted, continue where
-you left off" system message. It dispatches through `rpcClient.promptWhenReady(...)`
-(fire-and-forget with a `.catch()` so a failure is logged and never throws), so a
-cold agent is woken before the prompt is sent and the prompt itself gets the
-generous timeout.
+`SessionManager.shutdown` snapshots restart re-drive need before killing agent
+processes. The durable field is still named `wasStreaming`, but it now means
+"this session was active/busy enough to need restart re-drive": idle and
+terminated sessions are false; active states such as streaming, preparing,
+aborting, and fresh starting are true. During a restore-startup window,
+`sessionNeedsRestartRedrive()` keeps the pre-restore persisted bit authoritative
+so a quick second shutdown does not turn a previously idle restored session into a
+false interrupted-turn prompt.
+
+`SessionManager.restoreSession` then re-prompts interrupted interactive sessions
+with a "the server restarted, continue where you left off" system message. It
+dispatches through `rpcClient.promptWhenReady(...)` (fire-and-forget with a
+`.catch()` so a failure is logged and never throws), so a cold agent is woken
+before the prompt is sent and the prompt itself gets the generous timeout.
 
 `nonInteractive` reviewer / QA sessions are **excluded** here — they are re-driven
 exclusively by the verification harness (`resumeInterruptedVerifications` →

--- a/docs/features.md
+++ b/docs/features.md
@@ -6,7 +6,7 @@ Detailed reference for all Bobbit features. For a quick overview, see the [READM
 
 Each session is a running `pi-coding-agent` child process with its own conversation history.
 
-- **Persistence**: Session metadata (id, title, cwd, agent session file, `wasStreaming` flag) persists to `.bobbit/state/sessions.json`. On server restart, sessions restore by re-spawning agents and using `switch_session` RPC to resume from the agent's `.jsonl` file. If an agent was mid-turn when the server died, it is automatically re-prompted.
+- **Persistence**: Session metadata (id, title, cwd, agent session file, restart re-drive marker stored in `wasStreaming`) persists to `.bobbit/state/sessions.json`. On server restart, sessions restore by re-spawning agents and using `switch_session` RPC to resume from the agent's `.jsonl` file. Active interactive sessions are automatically re-prompted; non-interactive verification reviewers are re-driven by the verification harness.
 - **Auto-titles**: When the user sends their first prompt, `tryGenerateTitleFromPrompt()` fires **immediately** (before the agent replies) and calls Claude Haiku for a 2–3 word summary. The explicit `generate_title` command uses the full conversation history instead.
 - **Multi-device**: Multiple browser tabs/devices can connect to the same session. Events are broadcast to all clients.
 - **Session actions**: Sidebar rows and open-session headers share one canonical action model for rename/edit staff, terminate/end team, refresh, fork, copy link, system prompt inspection, and opening sessions in new windows. See [session-actions.md](session-actions.md).

--- a/docs/llm-review-recovery.md
+++ b/docs/llm-review-recovery.md
@@ -100,13 +100,23 @@ The `waitForStreaming()` guard is important. Without it, `waitForIdle()` can res
 
 ## Restart resume and rerun
 
-In-flight reviewer steps persist in active verification state. After a gateway restart, `resumeInterruptedVerifications()` tries to recover them through `_tryResumeFromSession()`:
+Reviewer and QA sessions are `nonInteractive`: normal user prompts are blocked, and only the verification harness should drive them. Restart recovery therefore has two owners:
+
+- `SessionManager.shutdown()` records restart re-drive need in the legacy `wasStreaming` field using `sessionNeedsRestartRedrive()`. The predicate is false for `idle` and `terminated`, true for active/busy states such as `streaming`, `preparing`, `aborting`, and fresh `starting`, and preserves the prior persisted bit during the restore-startup window so a rapid shutdown does not invent a false interrupted turn.
+- `SessionManager.restoreSession()` revives the process but deliberately does **not** send the generic mid-turn boot prompt to `nonInteractive` sessions. It clears the persisted marker and leaves reviewer/QA re-drive to `VerificationHarness.resumeInterruptedVerifications()` so two prompts cannot race into the same cold reviewer.
+
+In-flight reviewer steps also persist in active verification state. After a gateway restart, `resumeInterruptedVerifications()` tries to recover them through `_tryResumeFromSession()`:
 
 - If the reviewer session still exists, it is re-registered with the team store and wired to a fresh `verification_result` resolver.
-- If the reviewer is cold after restart, the resume path waits for readiness and uses a generous prompt timeout via `promptWhenReady()` before sending the reminder.
+- If the restored reviewer is already `idle`, the harness sends the reminder immediately instead of waiting for the long busy-session window.
+- If the restored reviewer is still busy, the harness waits for either `verification_result` or actual idle before reminding it. This keeps the harness from interrupting an active turn while making the waiting behavior explicit.
+- Reminder dispatch to a cold restored reviewer uses `promptWhenReady()` so the agent has time to load before the prompt timeout starts.
+- After a reminder is accepted, the harness waits for `waitForStreaming()` before racing against post-reminder idle, so an already-idle status cannot instantly fail and terminate the reviewer before it reads the reminder.
 - If the resume reminder cannot reach the reviewer because of a cold-agent timeout or process/runtime transient, the result is marked as transient and restart-interrupted, not as a hard review failure.
 - `_resumeOneVerification()` then re-runs the original `llm-review` step from the workflow definition when context is available.
 - If the restart interruption cannot be safely re-run, the gate is left pending so it can be re-signaled instead of being marked failed for an infrastructure interruption.
+
+Live `nonInteractive` sessions that are not referenced by active verification state are surfaced deterministically during boot resume. The harness asks `SessionManager.listOrphanedNonInteractiveSessions()` before any long resume wait and logs the orphaned reviewers; operators can inspect and terminate stale records through Settings → Maintenance or the `/api/maintenance/orphaned-sessions` and `/api/maintenance/cleanup-sessions` routes. A late `verification_result` from these orphaned sessions has no pending resolver, so surfacing is safer than silently waiting for timeout cleanup.
 
 This preserves the distinction between "the reviewed work is bad" and "the reviewer was interrupted by the gateway/runtime."
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -96,6 +96,12 @@ These compatibility calls also re-scan through the unified inventory and clean o
 
 `POST /api/maintenance/cleanup-archived-session-worktrees` still accepts its legacy modes (`all`, `selected`, `category`, and `preset`). These requests are compatibility filters over the fresh unified scan and preserve archived session rows, transcripts, proposals, prompt records, search records, and archive visibility.
 
+## Orphaned non-interactive sessions
+
+Verification reviewer and QA sessions are non-interactive: users cannot safely prompt them directly, and `verification_result` only matters while the verification harness has a pending resolver for that session. If a live non-interactive session is no longer referenced by active verification state, Bobbit treats it as an orphaned session.
+
+Gateway boot surfaces these orphans deterministically before the verification harness enters any long reviewer-resume wait. The maintenance scan is still explicit and preview-first: `GET /api/maintenance/orphaned-sessions` lists candidates, and `POST /api/maintenance/cleanup-sessions` terminates only sessions that are still orphaned at cleanup time.
+
 ## REST API
 
 See [REST API — Maintenance](rest-api.md#maintenance) and [REST API — Agent directory](rest-api.md#agent-directory) for request and response shapes.

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -347,14 +347,28 @@ interface ArchivedWorktreeScanContext {
 
 export type SessionStatus = "starting" | "preparing" | "idle" | "streaming" | "aborting" | "terminated";
 
+export type RestartRedriveSnapshot = {
+	status: SessionStatus;
+	/**
+	 * Set only while restoreSession() is recreating a persisted session. During
+	 * that restore-startup window, `starting` is a lifecycle state, not proof of
+	 * an interrupted turn; the persisted pre-restore value stays authoritative.
+	 */
+	restoreStartupWasStreaming?: boolean;
+};
+
 /**
  * Durable restart re-drive marker for every active/busy session state.
  * The persisted field is still named `wasStreaming` for compatibility, but
- * restart recovery must cover all non-idle, non-terminal statuses — not only
- * the exact `streaming` state.
+ * restart recovery must cover real non-idle/non-terminal work — not cold
+ * restore-startup of a previously idle session.
  */
-export function sessionNeedsRestartRedrive(status: SessionStatus): boolean {
-	return status !== "idle" && status !== "terminated";
+export function sessionNeedsRestartRedrive(snapshot: SessionStatus | RestartRedriveSnapshot): boolean {
+	const status = typeof snapshot === "string" ? snapshot : snapshot.status;
+	const restoreStartupWasStreaming = typeof snapshot === "string" ? undefined : snapshot.restoreStartupWasStreaming;
+	if (status === "idle" || status === "terminated") return false;
+	if (status === "starting" && restoreStartupWasStreaming !== undefined) return restoreStartupWasStreaming;
+	return true;
 }
 
 /**
@@ -555,6 +569,12 @@ export interface SessionInfo {
 	recoveredPromptDispatchQueueIds?: string[];
 	/** Error message captured when restoreSession() failed; cleared on successful revive. */
 	restoreError?: string;
+	/**
+	 * Persisted wasStreaming value captured while restoreSession() is in its
+	 * startup window. Prevents rapid shutdown during cold restore from converting
+	 * a previously idle interactive session into a false interrupted-turn prompt.
+	 */
+	restoreStartupWasStreaming?: boolean;
 	/**
 	 * True for a DORMANT entry (restored delegate/kinded child whose agent process
 	 * is NOT running — placeholder RpcBridge). Used by `isSessionLive` so the
@@ -5289,6 +5309,7 @@ export class SessionManager {
 			allowedTools: restoredAllowedNames,
 			promptQueue: new PromptQueue(ps.messageQueue),
 			streamingStartedAt: ps.streamingStartedAt,
+			restoreStartupWasStreaming: ps.wasStreaming === true,
 			projectId: ps.projectId,
 			inFlightSteerTexts: Array.isArray(ps.inFlightSteerTexts) ? [...ps.inFlightSteerTexts] : undefined,
 			spawnPinnedModel: bridgeOptions.initialModel,
@@ -9306,7 +9327,7 @@ export class SessionManager {
 			// This is authoritative — the in-memory status is always correct,
 			// and we write it here to handle the case where shutdown() races
 			// with a pending lifecycle event that hasn't flushed to disk yet.
-			const needsRestartRedrive = sessionNeedsRestartRedrive(session.status);
+			const needsRestartRedrive = sessionNeedsRestartRedrive(session);
 			this.resolveStoreForSession(id).update(id, {
 				wasStreaming: needsRestartRedrive,
 				streamingStartedAt: needsRestartRedrive ? (session.streamingStartedAt ?? Date.now()) : undefined,

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -348,6 +348,16 @@ interface ArchivedWorktreeScanContext {
 export type SessionStatus = "starting" | "preparing" | "idle" | "streaming" | "aborting" | "terminated";
 
 /**
+ * Durable restart re-drive marker for every active/busy session state.
+ * The persisted field is still named `wasStreaming` for compatibility, but
+ * restart recovery must cover all non-idle, non-terminal statuses — not only
+ * the exact `streaming` state.
+ */
+export function sessionNeedsRestartRedrive(status: SessionStatus): boolean {
+	return status !== "idle" && status !== "terminated";
+}
+
+/**
  * Max consecutive errored agent turns before an incoming prompt/steer is
  * parked instead of implicitly unsticking the session. Counter increments on
  * every `message_end` with `stopReason:"error"` and resets on any successful
@@ -9281,8 +9291,10 @@ export class SessionManager {
 		}
 
 		// Don't remove from store on shutdown — sessions should survive restart.
-		// Persist the streaming state for each session so interrupted agents
-		// can be re-prompted on the next startup.
+		// Persist the active/busy state for each session so interrupted agents
+		// can be re-driven on the next startup. The durable field is still named
+		// `wasStreaming` for store compatibility, but it means "restart re-drive
+		// needed" for every non-idle, non-terminal session status.
 		const ids = Array.from(this.sessions.keys());
 		for (const id of ids) {
 			const session = this.sessions.get(id);
@@ -9290,11 +9302,15 @@ export class SessionManager {
 
 			await this.closeExtensionChannelsForSession(id, "gateway-shutdown");
 
-			// Snapshot the current streaming state before we kill the process.
+			// Snapshot the current active state before we kill the process.
 			// This is authoritative — the in-memory status is always correct,
 			// and we write it here to handle the case where shutdown() races
-			// with a pending agent_end that hasn't flushed to disk yet.
-			this.resolveStoreForSession(id).update(id, { wasStreaming: session.status === "streaming", streamingStartedAt: session.streamingStartedAt });
+			// with a pending lifecycle event that hasn't flushed to disk yet.
+			const needsRestartRedrive = sessionNeedsRestartRedrive(session.status);
+			this.resolveStoreForSession(id).update(id, {
+				wasStreaming: needsRestartRedrive,
+				streamingStartedAt: needsRestartRedrive ? (session.streamingStartedAt ?? Date.now()) : undefined,
+			});
 
 			// Cancel any pending transient/provider-backoff auto-retry so the
 			// timer doesn't fire after the agent has been stopped. Clients are

--- a/src/server/agent/verification-harness.ts
+++ b/src/server/agent/verification-harness.ts
@@ -979,6 +979,7 @@ export class VerificationHarness {
 	private readonly bootEpoch: string = randomUUID();
 	private readonly _persistPath: string;
 	private projectContextManager: ProjectContextManager | null;
+	private surfacedOrphanedNonInteractiveSessionIds = new Set<string>();
 
 	/** Limits concurrent command steps (type-check, tests) across all goals. */
 	private commandSemaphore = new Semaphore(4);
@@ -1227,8 +1228,12 @@ export class VerificationHarness {
 	 */
 	async resumeInterruptedVerifications(): Promise<void> {
 		const persisted = this._loadActive();
+		// Surface orphaned reviewers before resuming unrelated active verifications.
+		// A resumed reviewer can wait minutes for a busy turn to settle; reviewers
+		// absent from active verification context should not be hidden behind that
+		// sequential recovery path.
+		await this._surfaceOrphanedNonInteractiveReviewers();
 		if (persisted.length === 0) {
-			await this._surfaceOrphanedNonInteractiveReviewers();
 			return;
 		}
 
@@ -1236,7 +1241,6 @@ export class VerificationHarness {
 		if (running.length === 0) {
 			// Clean up stale file
 			try { fs.unlinkSync(this._persistPath); } catch {}
-			await this._surfaceOrphanedNonInteractiveReviewers();
 			return;
 		}
 
@@ -1342,7 +1346,9 @@ export class VerificationHarness {
 			console.warn("[verification] Failed to inspect orphaned nonInteractive reviewer sessions:", err);
 			return;
 		}
+		orphans = orphans.filter(o => !this.surfacedOrphanedNonInteractiveSessionIds.has(o.id));
 		if (orphans.length === 0) return;
+		for (const orphan of orphans) this.surfacedOrphanedNonInteractiveSessionIds.add(orphan.id);
 		const summary = orphans
 			.map(o => `${o.title || "Untitled"} (${o.id}, created ${new Date(o.createdAt).toISOString()})`)
 			.join("; ");

--- a/src/server/agent/verification-harness.ts
+++ b/src/server/agent/verification-harness.ts
@@ -1227,12 +1227,16 @@ export class VerificationHarness {
 	 */
 	async resumeInterruptedVerifications(): Promise<void> {
 		const persisted = this._loadActive();
-		if (persisted.length === 0) return;
+		if (persisted.length === 0) {
+			await this._surfaceOrphanedNonInteractiveReviewers();
+			return;
+		}
 
 		const running = persisted.filter(v => v.overallStatus === "running");
 		if (running.length === 0) {
 			// Clean up stale file
 			try { fs.unlinkSync(this._persistPath); } catch {}
+			await this._surfaceOrphanedNonInteractiveReviewers();
 			return;
 		}
 
@@ -1317,7 +1321,35 @@ export class VerificationHarness {
 
 		// Clear persisted file after all verifications finalized
 		try { fs.unlinkSync(this._persistPath); } catch {}
+		await this._surfaceOrphanedNonInteractiveReviewers();
 		if (process.env.BOBBIT_DEBUG) console.log("[verification] Finished resuming interrupted verifications.");
+	}
+
+	/**
+	 * Surface live nonInteractive reviewer sessions that are not covered by any
+	 * active verification context. They cannot accept user prompts, and any late
+	 * `verification_result` would be ignored because no pending result resolver
+	 * exists, so boot must make them visible deterministically instead of leaving
+	 * them to a long timeout path.
+	 */
+	private async _surfaceOrphanedNonInteractiveReviewers(): Promise<void> {
+		const sm = this.sessionManager as any;
+		if (!sm?.listOrphanedNonInteractiveSessions) return;
+		let orphans: Array<{ id: string; title: string; createdAt: number }> = [];
+		try {
+			orphans = await sm.listOrphanedNonInteractiveSessions();
+		} catch (err) {
+			console.warn("[verification] Failed to inspect orphaned nonInteractive reviewer sessions:", err);
+			return;
+		}
+		if (orphans.length === 0) return;
+		const summary = orphans
+			.map(o => `${o.title || "Untitled"} (${o.id}, created ${new Date(o.createdAt).toISOString()})`)
+			.join("; ");
+		console.warn(
+			`[verification] Found ${orphans.length} live nonInteractive reviewer session(s) without active verification context: ${summary}. ` +
+			"They are not harness-resumable; use maintenance orphan cleanup to terminate them if they are stale.",
+		);
 	}
 
 	/**
@@ -1596,11 +1628,16 @@ export class VerificationHarness {
 		});
 
 		try {
-			// Wait for the agent to finish if it was mid-turn
-			const idleResult = await Promise.race([
-				resultPromise.then((r: VerificationResult) => ({ type: "result" as const, ...r })),
-				this.sessionManager!.waitForIdle(step.sessionId, 180_000).then(() => ({ type: "idle" as const })),
-			]).catch(() => ({ type: "idle" as const }));
+			// If restoreSession already revived the reviewer to idle, remind it
+			// immediately. Otherwise wait for the active turn to finish before sending
+			// a reminder, so the harness remains the only driver for nonInteractive
+			// reviewers and never races the generic restoreSession boot prompt.
+			const idleResult = session.status === "idle"
+				? ({ type: "idle" as const })
+				: await Promise.race([
+					resultPromise.then((r: VerificationResult) => ({ type: "result" as const, ...r })),
+					this.sessionManager!.waitForIdle(step.sessionId, 180_000).then(() => ({ type: "idle" as const })),
+				]).catch(() => ({ type: "idle" as const }));
 
 			if (idleResult.type === "result") {
 				await this.sessionManager!.waitForIdle(step.sessionId, 30_000).catch(() => {});

--- a/tests/reviewer-resume-shutdown-state.test.ts
+++ b/tests/reviewer-resume-shutdown-state.test.ts
@@ -16,8 +16,19 @@ function shutdownBody(source: string): string {
 }
 
 test("shutdown does not persist only exact streaming sessions as interrupted", () => {
-	const body = shutdownBody(sessionManagerSource());
+	const source = sessionManagerSource();
+	const body = shutdownBody(source);
 
+	assert.match(
+		source,
+		/export function sessionNeedsRestartRedrive\(status: SessionStatus\): boolean \{\s*return status !== "idle" && status !== "terminated";\s*\}/,
+		"SessionManager must centralize the restart re-drive status predicate so future busy states are not missed.",
+	);
+	assert.match(
+		body,
+		/wasStreaming:\s*needsRestartRedrive\s*[,}]/,
+		"shutdown must persist the centralized restart re-drive predicate into the legacy wasStreaming field.",
+	);
 	assert.doesNotMatch(
 		body,
 		/wasStreaming:\s*session\.status\s*===\s*["']streaming["']\s*[,}]/,

--- a/tests/reviewer-resume-shutdown-state.test.ts
+++ b/tests/reviewer-resume-shutdown-state.test.ts
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
+import { SessionManager, sessionNeedsRestartRedrive } from "../src/server/agent/session-manager.ts";
 
 function sessionManagerSource(): string {
 	return fs.readFileSync(path.join(process.cwd(), "src/server/agent/session-manager.ts"), "utf-8");
@@ -15,15 +16,75 @@ function shutdownBody(source: string): string {
 	return source.slice(start, end);
 }
 
-test("shutdown does not persist only exact streaming sessions as interrupted", () => {
+function makeShutdownSession(id: string, status: any, extra: Record<string, unknown> = {}) {
+	return {
+		id,
+		title: id,
+		status,
+		streamingStartedAt: undefined,
+		clients: new Set<any>(),
+		rpcClient: { stop: async () => {} },
+		unsubscribe: () => {},
+		promptQueue: { length: 0 },
+		...extra,
+	};
+}
+
+test("restart re-drive predicate covers busy states but not idle/terminal states", () => {
+	assert.equal(sessionNeedsRestartRedrive("idle"), false);
+	assert.equal(sessionNeedsRestartRedrive("terminated"), false);
+	assert.equal(sessionNeedsRestartRedrive("streaming"), true);
+	assert.equal(sessionNeedsRestartRedrive("preparing"), true);
+	assert.equal(sessionNeedsRestartRedrive("aborting"), true);
+	assert.equal(sessionNeedsRestartRedrive("starting"), true, "fresh active startup should still be redriven");
+});
+
+test("restore-startup starting uses the persisted interrupted-turn bit", () => {
+	assert.equal(
+		sessionNeedsRestartRedrive({ status: "starting", restoreStartupWasStreaming: false }),
+		false,
+		"rapid shutdown during cold restore of a previously idle session must not create a false boot re-prompt",
+	);
+	assert.equal(
+		sessionNeedsRestartRedrive({ status: "starting", restoreStartupWasStreaming: true }),
+		true,
+		"rapid shutdown during cold restore of a truly interrupted session must preserve re-drive",
+	);
+});
+
+test("shutdown persists re-drive state from session lifecycle state", async () => {
+	const updates: Record<string, any> = {};
+	const manager: any = new SessionManager();
+	manager._testStore = {
+		update: (id: string, update: any) => { updates[id] = update; },
+		get: () => undefined,
+		flush: () => {},
+	};
+	manager.closeExtensionChannelsForSession = async () => {};
+	manager.cancelPendingAutoRetry = () => {};
+	manager._untrackConnectedSession = () => {};
+
+	manager.sessions.set("restored-idle", makeShutdownSession("restored-idle", "starting", { restoreStartupWasStreaming: false }));
+	manager.sessions.set("restored-active", makeShutdownSession("restored-active", "starting", { restoreStartupWasStreaming: true }));
+	manager.sessions.set("fresh-starting", makeShutdownSession("fresh-starting", "starting"));
+	manager.sessions.set("preparing", makeShutdownSession("preparing", "preparing"));
+	manager.sessions.set("idle", makeShutdownSession("idle", "idle"));
+
+	await manager.shutdown();
+
+	assert.equal(updates["restored-idle"].wasStreaming, false);
+	assert.equal(updates["restored-idle"].streamingStartedAt, undefined);
+	assert.equal(updates["restored-active"].wasStreaming, true);
+	assert.equal(typeof updates["restored-active"].streamingStartedAt, "number");
+	assert.equal(updates["fresh-starting"].wasStreaming, true);
+	assert.equal(updates.preparing.wasStreaming, true);
+	assert.equal(updates.idle.wasStreaming, false);
+});
+
+test("shutdown uses the centralized restart re-drive predicate, not exact streaming", () => {
 	const source = sessionManagerSource();
 	const body = shutdownBody(source);
 
-	assert.match(
-		source,
-		/export function sessionNeedsRestartRedrive\(status: SessionStatus\): boolean \{\s*return status !== "idle" && status !== "terminated";\s*\}/,
-		"SessionManager must centralize the restart re-drive status predicate so future busy states are not missed.",
-	);
 	assert.match(
 		body,
 		/wasStreaming:\s*needsRestartRedrive\s*[,}]/,
@@ -32,6 +93,6 @@ test("shutdown does not persist only exact streaming sessions as interrupted", (
 	assert.doesNotMatch(
 		body,
 		/wasStreaming:\s*session\.status\s*===\s*["']streaming["']\s*[,}]/,
-		`SessionManager.shutdown() must mark every active/busy reviewer status as interrupted for restart re-drive, not only status === "streaming". A nonInteractive reviewer killed while "starting", "preparing", or "aborting" is currently persisted with wasStreaming:false, so restore delegates to the verification harness without enough state for a prompt resume nudge. Replace the exact streaming-only snapshot with a centralized active-status predicate.`,
+		"SessionManager.shutdown() must mark active/busy reviewer statuses as interrupted for restart re-drive, not only status === \"streaming\".",
 	);
 });

--- a/tests/reviewer-resume-shutdown-state.test.ts
+++ b/tests/reviewer-resume-shutdown-state.test.ts
@@ -1,0 +1,26 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+function sessionManagerSource(): string {
+	return fs.readFileSync(path.join(process.cwd(), "src/server/agent/session-manager.ts"), "utf-8");
+}
+
+function shutdownBody(source: string): string {
+	const start = source.indexOf("\tasync shutdown(): Promise<void> {");
+	assert.notEqual(start, -1, "precondition: SessionManager.shutdown() must exist");
+	const end = source.indexOf("\n// ── Sandbox credential auto-resolution", start);
+	assert.notEqual(end, -1, "precondition: SessionManager.shutdown() section must be bounded before sandbox credential code");
+	return source.slice(start, end);
+}
+
+test("shutdown does not persist only exact streaming sessions as interrupted", () => {
+	const body = shutdownBody(sessionManagerSource());
+
+	assert.doesNotMatch(
+		body,
+		/wasStreaming:\s*session\.status\s*===\s*["']streaming["']\s*[,}]/,
+		`SessionManager.shutdown() must mark every active/busy reviewer status as interrupted for restart re-drive, not only status === "streaming". A nonInteractive reviewer killed while "starting", "preparing", or "aborting" is currently persisted with wasStreaming:false, so restore delegates to the verification harness without enough state for a prompt resume nudge. Replace the exact streaming-only snapshot with a centralized active-status predicate.`,
+	);
+});

--- a/tests/verification-reminder-race.test.ts
+++ b/tests/verification-reminder-race.test.ts
@@ -23,7 +23,9 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
+import { VerificationHarness } from "../src/server/agent/verification-harness.ts";
 
 /**
  * `SessionManager` transitively pulls in flexsearch (via search-service),
@@ -296,14 +298,78 @@ describe("verification reminder race — Bug 2 (resumed reviewer terminated earl
 		);
 		assert.match(
 			resumeBody,
-			/await this\._surfaceOrphanedNonInteractiveReviewers\(\);/,
-			"Boot resume must surface orphaned nonInteractive reviewer sessions deterministically.",
+			/await this\._surfaceOrphanedNonInteractiveReviewers\(\);[\s\S]*if \(persisted\.length === 0\)/,
+			"Boot resume must surface orphaned nonInteractive reviewer sessions before any early return.",
 		);
 		assert.match(
 			source,
 			/listOrphanedNonInteractiveSessions\(\)/,
 			"Orphan surfacing should use SessionManager's active-verification-aware orphan detector.",
 		);
+	});
+
+	it("orphan surfacing is not blocked behind unrelated running verification resume", async () => {
+		const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "verification-orphan-surface-"));
+		try {
+			fs.writeFileSync(path.join(stateDir, "active-verifications.json"), JSON.stringify({
+				verifications: [{
+					goalId: "goal-1",
+					gateId: "gate-1",
+					signalId: "signal-1",
+					overallStatus: "running",
+					startedAt: Date.now(),
+					steps: [{
+						name: "Busy review",
+						type: "llm-review",
+						status: "running",
+						startedAt: Date.now(),
+						sessionId: "active-reviewer",
+					}],
+				}],
+			}, null, 2));
+
+			let orphanListCalls = 0;
+			const fakeSession = {
+				status: "streaming",
+				rpcClient: { onEvent: () => () => {} },
+			};
+			const sessionManager = {
+				getSession: () => fakeSession,
+				waitForIdle: () => new Promise<void>(() => {}),
+				waitForStreaming: () => Promise.resolve(),
+				terminateSession: () => Promise.resolve(),
+				listOrphanedNonInteractiveSessions: async () => {
+					orphanListCalls += 1;
+					return [{ id: "orphan-reviewer", title: "Orphan reviewer", createdAt: Date.now() }];
+				},
+			} as any;
+			const gateStore = {
+				updateSignalVerification: () => {},
+				updateGateStatus: () => {},
+				getGate: () => undefined,
+				getGatesForGoal: () => [],
+			} as any;
+			const harness = new VerificationHarness(
+				stateDir,
+				gateStore,
+				() => {},
+				{ get: () => undefined, getAll: () => [] } as any,
+				undefined,
+				sessionManager,
+				{ registerReviewerSession: () => {}, unregisterReviewerSession: () => {} } as any,
+			);
+
+			void harness.resumeInterruptedVerifications();
+			await new Promise((resolve) => setTimeout(resolve, 50));
+
+			assert.equal(
+				orphanListCalls,
+				1,
+				"orphan reviewer surfacing must run promptly before an unrelated running verification can block in waitForIdle",
+			);
+		} finally {
+			fs.rmSync(stateDir, { recursive: true, force: true });
+		}
 	});
 
 	it("live llm-review checks errored-turn recovery after post-reminder idle before declaring the reminder ignored", () => {

--- a/tests/verification-reminder-race.test.ts
+++ b/tests/verification-reminder-race.test.ts
@@ -261,6 +261,51 @@ describe("verification reminder race — Bug 2 (resumed reviewer terminated earl
 		);
 	});
 
+	it("resumed idle reviewers are reminded immediately without waiting for the long busy window", () => {
+		const source = fs.readFileSync(path.join(process.cwd(), "src/server/agent/verification-harness.ts"), "utf8");
+		const start = source.indexOf("private async _tryResumeFromSession");
+		assert.ok(start >= 0, "_tryResumeFromSession should exist");
+		const reminder = source.indexOf("No verification_result from resumed session", start);
+		assert.ok(reminder > start, "resumed reminder path should exist");
+		const preReminder = source.slice(start, reminder);
+
+		assert.match(
+			preReminder,
+			/const idleResult = session\.status === "idle"\s*\? \(\{ type: "idle" as const \}\)\s*:\s*await Promise\.race/,
+			"A restored reviewer that is already idle must go straight to the reminder instead of waiting for the 180s busy-session window.",
+		);
+		assert.match(
+			preReminder,
+			/waitForIdle\(step\.sessionId, 180_000\)/,
+			"Busy resumed reviewers should still wait for actual idle before the reminder; the long wait must be explicit.",
+		);
+	});
+
+	it("resume boot surfaces nonInteractive reviewers with no active verification context", () => {
+		const source = fs.readFileSync(path.join(process.cwd(), "src/server/agent/verification-harness.ts"), "utf8");
+		const resumeStart = source.indexOf("async resumeInterruptedVerifications(): Promise<void>");
+		assert.ok(resumeStart >= 0, "resumeInterruptedVerifications should exist");
+		const findStepStart = source.indexOf("private async _resumeOneVerification", resumeStart);
+		assert.ok(findStepStart > resumeStart, "resumeInterruptedVerifications should be bounded");
+		const resumeBody = source.slice(resumeStart, findStepStart);
+
+		assert.doesNotMatch(
+			resumeBody,
+			/if \(persisted\.length === 0\) return;/,
+			"Boot resume must not silently return when there is no active verification context; orphaned nonInteractive reviewers must be surfaced deterministically.",
+		);
+		assert.match(
+			resumeBody,
+			/await this\._surfaceOrphanedNonInteractiveReviewers\(\);/,
+			"Boot resume must surface orphaned nonInteractive reviewer sessions deterministically.",
+		);
+		assert.match(
+			source,
+			/listOrphanedNonInteractiveSessions\(\)/,
+			"Orphan surfacing should use SessionManager's active-verification-aware orphan detector.",
+		);
+	});
+
 	it("live llm-review checks errored-turn recovery after post-reminder idle before declaring the reminder ignored", () => {
 		const source = fs.readFileSync(path.join(process.cwd(), "src/server/agent/verification-harness.ts"), "utf8");
 		const livePathStart = source.indexOf("private async runLlmReviewViaSession");


### PR DESCRIPTION
## Summary

- Persist restart re-drive state for active/busy sessions without false prompts for idle restore-startup sessions.
- Resume nonInteractive verification reviewers through the verification harness, with immediate reminders for restored idle reviewers and explicit busy-session waiting.
- Surface orphan nonInteractive reviewers promptly and document reviewer restart recovery behavior.

## Validation

- `npx tsx --test tests/reviewer-resume-shutdown-state.test.ts tests/verification-resume-restart-prompt.test.ts tests/verification-reminder-race.test.ts tests/team-manager-reviewer-resume.test.ts`
- Workflow implementation gate passed: build, typecheck, unit, E2E, and reviews

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
