### PR TITLE
Tool Startup Resilience

### DIFF
--- a/defaults/tools/_shared/gateway.js
+++ b/defaults/tools/_shared/gateway.js
@@ -1,0 +1,4 @@
+// Compatibility entrypoint for extensions that import ../_shared/gateway.js.
+// The implementation lives in gateway.ts so TypeScript and JavaScript import
+// specifiers both resolve in the raw defaults tree copied into dist/.
+export * from "./gateway.ts";

--- a/defaults/tools/agent/extension.ts
+++ b/defaults/tools/agent/extension.ts
@@ -9,7 +9,7 @@
  * allowed cross-session prompt/steer) for every session.
  *
  * All verbs are agent-process tools: they call the gateway over authenticated
- * REST using on-disk credentials (`_shared/gateway.ts`) and hit the
+ * REST using on-disk credentials (`agent/gateway.js`) and hit the
  * server-side `/api/sessions/:id/orchestrate/*` routes, which invoke the
  * in-process `OrchestrationCore`. There is NO inlined creds logic and NO
  * client-side spawn/wait loop — the server owns the child lifecycle.
@@ -22,7 +22,7 @@
 
 import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
-import { readGatewayCreds, apiCall } from "../_shared/gateway.js";
+import { readGatewayCreds, apiCall } from "./gateway.js";
 
 // ── Types ──
 

--- a/defaults/tools/agent/gateway.js
+++ b/defaults/tools/agent/gateway.js
@@ -1,0 +1,138 @@
+// Group-local gateway helpers for the bundled Agent tool extension.
+//
+// Keep this file inside defaults/tools/agent/ so project-level copies of the
+// whole Agent tool group remain self-contained. Tool metadata edits copy only
+// the edited group into .bobbit/config/tools/<group>; importing ../_shared/*
+// from here would make copied Agent overrides fail during agent startup.
+
+import fs from "node:fs";
+import path from "node:path";
+import { homedir } from "node:os";
+
+function diskStateDir() {
+	return process.env.BOBBIT_DIR
+		? path.join(process.env.BOBBIT_DIR, "state")
+		: path.join(homedir(), ".pi");
+}
+
+function diskTokenPath() {
+	const tokenFile = process.env.BOBBIT_DIR ? "token" : "gateway-token";
+	return path.join(diskStateDir(), tokenFile);
+}
+
+function diskUrlPath() {
+	return path.join(diskStateDir(), "gateway-url");
+}
+
+export function readGatewayCreds() {
+	try {
+		const token = fs.readFileSync(diskTokenPath(), "utf-8").trim();
+		const baseUrl = fs.readFileSync(diskUrlPath(), "utf-8").trim().replace(/\/+$/, "");
+		return { token, baseUrl };
+	} catch {
+		// Disk-read failed (e.g. running under a sandboxed test harness without
+		// a state dir). Fall through to env.
+	}
+	const envToken = process.env.BOBBIT_TOKEN;
+	const envUrl = process.env.BOBBIT_GATEWAY_URL;
+	if (envToken && envUrl) {
+		return { token: envToken, baseUrl: envUrl.replace(/\/+$/, "") };
+	}
+	return { error: "BOBBIT credentials not found on disk or in env" };
+}
+
+let credsCache = null;
+const CREDS_TTL_MS = 1_000;
+
+function readGatewayCredsCached() {
+	const now = Date.now();
+	if (credsCache && now - credsCache.ts < CREDS_TTL_MS) return credsCache.creds;
+	const fresh = readGatewayCreds();
+	credsCache = { creds: fresh, ts: now };
+	return fresh;
+}
+
+function clearCredsCache() {
+	credsCache = null;
+}
+
+const TRANSIENT_RE = /ECONNRESET|ECONNREFUSED|EPIPE|socket hang up|UND_ERR_SOCKET|fetch failed/i;
+
+function isTransientFetchError(err) {
+	if (!(err instanceof Error)) return false;
+	const cause = err.cause;
+	const causeMsg = cause instanceof Error ? cause.message : "";
+	const causeCode = cause && typeof cause === "object" && "code" in cause
+		? String(cause.code)
+		: "";
+	const composite = [err.message, causeMsg, causeCode].filter(Boolean).join(" ");
+	return TRANSIENT_RE.test(composite);
+}
+
+export async function apiCall(creds, method, urlPath, body, opts) {
+	const maxAttempts = (opts?.retries ?? 3) + 1;
+	let lastErr;
+	let usedCreds = creds;
+	let didCredsRefresh = false;
+
+	for (let attempt = 0; attempt < maxAttempts; attempt++) {
+		try {
+			const headers = {
+				Authorization: `Bearer ${usedCreds.token}`,
+				"Content-Type": "application/json",
+				...(opts?.extraHeaders ?? {}),
+			};
+			const resp = await fetch(`${usedCreds.baseUrl}${urlPath}`, {
+				method,
+				headers,
+				body: body !== undefined ? JSON.stringify(body) : undefined,
+			});
+			if (resp.status === 401 && !didCredsRefresh) {
+				didCredsRefresh = true;
+				clearCredsCache();
+				const fresh = readGatewayCredsCached();
+				if (!("error" in fresh)) {
+					usedCreds = fresh;
+					console.warn(`[gateway] 401 on ${method} ${urlPath} — refreshed creds from disk and retrying`);
+					continue;
+				}
+			}
+			const text = await resp.text();
+			let data;
+			try { data = JSON.parse(text); } catch { data = text; }
+			if (!resp.ok) {
+				const msg = typeof data === "object" && data !== null && "error" in data
+					? String(data.error)
+					: `HTTP ${resp.status}: ${text}`;
+				throw new Error(msg);
+			}
+			return data;
+		} catch (err) {
+			lastErr = err;
+			const transient = isTransientFetchError(err);
+			const isFinal = attempt === maxAttempts - 1;
+			if (!transient || isFinal) {
+				if (isFinal && transient) {
+					const diskPath = diskUrlPath();
+					throw new Error(
+						`Gateway request failed after ${maxAttempts} attempts: ${method} ${usedCreds.baseUrl}${urlPath} — ` +
+						`last error: ${err instanceof Error ? err.message : String(err)}. ` +
+						`Cached gateway-url: ${usedCreds.baseUrl}; on-disk: ${diskPath}.`,
+					);
+				}
+				throw err;
+			}
+			const backoff = 250 * Math.pow(2, attempt);
+			console.warn(
+				`[gateway] ${method} ${urlPath} transient error (attempt ${attempt + 1}/${maxAttempts}): ` +
+				`${err instanceof Error ? err.message : String(err)} — retrying in ${backoff}ms`,
+			);
+			await new Promise(r => setTimeout(r, backoff));
+		}
+	}
+	throw lastErr;
+}
+
+export function __clearCredsCacheForTesting() {
+	clearCredsCache();
+}

--- a/docs/session-prompt-tools.md
+++ b/docs/session-prompt-tools.md
@@ -7,6 +7,8 @@ Bobbit has two agent-facing ways to send a message to an existing session:
 
 Both surfaces feed the same server-side delivery helper, which chooses between normal prompt queue delivery and live steering. Keeping mode selection centralized ensures prompt/steer recovery, queue persistence, and `bash_bg wait` interruption stay consistent across tools.
 
+For startup, restart, and broken override fallback behavior, see [Tool override startup resilience](tool-startup-resilience.md).
+
 ## Delivery modes
 
 | Mode | Streaming target | Idle / non-streaming target | Typical use |

--- a/docs/tool-startup-resilience.md
+++ b/docs/tool-startup-resilience.md
@@ -1,0 +1,78 @@
+# Tool override startup resilience
+
+Bobbit lets projects override bundled agent tools by placing tool groups under `.bobbit/config/tools/<group>/`. Those overrides are trusted project code, but they still run in the agent startup path. A broken override must not prevent agents from launching, restoring after restart, or using the bundled fallback tool.
+
+This behavior sits between the config cascade and agent launch:
+
+- config and bundled tool YAML are resolved with normal precedence;
+- active config-level Bobbit extension files are preflighted before they are passed to the agent process;
+- invalid config overrides are skipped with diagnostics;
+- lower-priority bundled or market-pack tools are used when available.
+
+The goal is resilience, not sandboxing. Project tool code remains trusted once it passes preflight.
+
+## Archive and disable locations
+
+Use `.bobbit/config/tools-disabled/` as the explicit archive location for disabled project tool overrides. Bobbit does not scan this directory as an active tool source, so archived groups there cannot shadow bundled tools.
+
+Bobbit also ignores archive-style group names directly under `.bobbit/config/tools/`:
+
+- dot-prefixed group directories, such as `.agent`;
+- names ending in `.disabled`, such as `agent.disabled`;
+- names containing `.disabled-`, such as `agent.disabled-20260630`;
+- names containing `.disabled_`, such as `agent.disabled_backup`.
+
+These ignore rules apply to immediate tool-group directories under `.bobbit/config/tools/`. They provide a safe rename path when temporarily disabling an override in place, but `.bobbit/config/tools-disabled/` is the clearer long-term archive location.
+
+## Preflighted extension failures
+
+For config-level Bobbit tool extensions, Bobbit validates the extension before building the agent launch arguments. Preflight catches failures that would otherwise crash the agent process during module import, including:
+
+- a declared extension file that is missing;
+- missing relative imports, for example `import "./missing-helper.js"`;
+- bare module imports that cannot be resolved from the project or Bobbit installation;
+- module-load failures, including top-level throws during import;
+- module-load timeouts.
+
+When preflight fails, Bobbit treats the config-level override as invalid for launch. The invalid extension path is not passed to the agent process.
+
+## Fallback semantics
+
+Valid override precedence is unchanged: a valid project override still wins over lower-priority bundled or market-pack tools.
+
+Invalid config overrides are skipped before precedence can make them the runtime provider:
+
+- If a lower-priority tool with the same name exists, that fallback becomes the active tool.
+- If a config group contains a broken shared `extension.ts`, Bobbit avoids whole-group shadowing so bundled tools in the same group can reappear.
+- If a custom config-only tool has no fallback, Bobbit omits that tool from runtime activation and reports the diagnostic instead of crashing startup.
+- Valid tools in the same group can still win when they do not depend on the broken extension.
+
+This keeps `/api/tools`, prompt tool docs, renderer/action resolution, and agent launch consistent: the Tools page shows the same effective tools that can actually be activated.
+
+## Diagnostics
+
+Invalid overrides are visible in two places.
+
+Server logs emit a warning like:
+
+```text
+[tool-manager] Invalid config tool override "<tool>" in group "<group>" skipped: <reason>
+```
+
+The Tools page reads diagnostics from `/api/tools`. It shows a diagnostics panel and attaches related diagnostics to affected tools. Diagnostic rows include the skipped tool or group, source path, code, and message when available.
+
+Diagnostics are deliberate: Bobbit should not silently ignore broken custom tools. A skipped config-only tool still has a clear diagnostic even though it has no fallback row.
+
+## `session_prompt` restart resilience
+
+`session_prompt` is provided by the bundled Agent tool group. The bundled `defaults/tools/agent/extension.ts` imports its gateway helper from a group-local `defaults/tools/agent/gateway.js` file. Keeping that helper inside the Agent group makes copied project overrides self-contained: editing or copying `.bobbit/config/tools/agent/` does not leave the extension depending on a missing shared helper outside the group.
+
+Gateway credentials are read from disk first and environment variables are only a fallback. This matters after server restart or dormant-session restore because on-disk gateway URL and token files are refreshed by the gateway, while spawned-agent environment variables may be stale. The helper caches briefly, refreshes on unauthorized responses, and retries transient gateway errors so `session_prompt` can continue working across restart/restore flows.
+
+If a project-level Agent override imports a missing helper, preflight marks that override invalid, skips it, and the bundled `session_prompt` implementation remains available.
+
+## Related files
+
+- [Session prompt tools](session-prompt-tools.md) covers the `session_prompt` and `team_prompt` API and authorization behavior.
+- [Internals — config cascade](internals.md#config-cascade) describes normal tool precedence and project-scoped resolution.
+- [Marketplace](marketplace.md) describes pack-based tool precedence and activation filtering.

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -2585,17 +2585,29 @@ function normalizeToolInfo(raw: unknown): ToolInfo | null {
 	return raw as unknown as ToolInfo;
 }
 
+function dedupeToolDiagnostics(diagnostics: ToolDiagnostic[]): ToolDiagnostic[] {
+	const seen = new Set<string>();
+	return diagnostics.filter((diagnostic) => {
+		const key = [diagnostic.toolName, diagnostic.tool, diagnostic.name, diagnostic.extensionPath, diagnostic.path, diagnostic.sourcePath, diagnostic.code, diagnostic.reason, diagnostic.message]
+			.map((value) => typeof value === "string" ? value : "")
+			.join("\0");
+		if (seen.has(key)) return false;
+		seen.add(key);
+		return true;
+	});
+}
+
 export function normalizeToolsResponse(data: unknown): ToolsResponse {
 	const root = isToolApiRecord(data) ? data : undefined;
 	const rawTools = Array.isArray(root?.tools) ? root.tools : Array.isArray(data) ? data : [];
 	return {
 		tools: rawTools.map(normalizeToolInfo).filter((tool): tool is ToolInfo => Boolean(tool)),
-		diagnostics: [
+		diagnostics: dedupeToolDiagnostics([
 			...normalizeToolDiagnostics(root?.diagnostics),
 			...normalizeToolDiagnostics(root?.toolDiagnostics),
 			...normalizeToolDiagnostics(root?.invalidTools),
 			...normalizeToolDiagnostics(root?.invalidToolDiagnostics),
-		],
+		]),
 	};
 }
 

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -2504,6 +2504,32 @@ export interface ToolProviderProvenance {
 	sourcePath?: string;
 }
 
+export interface ToolDiagnostic {
+	severity?: "error" | "warning" | "info" | string;
+	level?: "error" | "warning" | "info" | string;
+	code?: string;
+	message?: string;
+	reason?: string;
+	tool?: string;
+	toolName?: string;
+	name?: string;
+	group?: string;
+	groupDir?: string;
+	sourcePath?: string;
+	path?: string;
+	providerKey?: string;
+	origin?: string;
+	fallback?: string;
+	fallbackTool?: string;
+	skipped?: boolean;
+	[key: string]: unknown;
+}
+
+export interface ToolsResponse {
+	tools: ToolInfo[];
+	diagnostics: ToolDiagnostic[];
+}
+
 export interface ToolInfo {
 	name: string;
 	description: string;
@@ -2532,6 +2558,45 @@ export interface ToolInfo {
 	originPackId?: string | null;
 	sourcePath?: string;
 	providers?: ToolProviderProvenance[];
+	/** Optional backend diagnostics for invalid/skipped config-level tool overrides. */
+	diagnostics?: Array<ToolDiagnostic | string> | ToolDiagnostic | string;
+	invalidReason?: ToolDiagnostic | string | Record<string, unknown>;
+	invalid?: boolean;
+	valid?: boolean;
+}
+
+function isToolApiRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function normalizeToolDiagnostics(raw: unknown): ToolDiagnostic[] {
+	if (!raw) return [];
+	if (typeof raw === "string") return raw.trim() ? [{ message: raw }] : [];
+	if (Array.isArray(raw)) return raw.flatMap((item) => normalizeToolDiagnostics(item));
+	if (isToolApiRecord(raw)) return [raw as ToolDiagnostic];
+	return [];
+}
+
+function normalizeToolInfo(raw: unknown): ToolInfo | null {
+	if (typeof raw === "string") return { name: raw, description: "", group: "Other" };
+	if (!isToolApiRecord(raw)) return null;
+	const name = typeof raw.name === "string" ? raw.name : undefined;
+	if (!name) return null;
+	return raw as unknown as ToolInfo;
+}
+
+export function normalizeToolsResponse(data: unknown): ToolsResponse {
+	const root = isToolApiRecord(data) ? data : undefined;
+	const rawTools = Array.isArray(root?.tools) ? root.tools : Array.isArray(data) ? data : [];
+	return {
+		tools: rawTools.map(normalizeToolInfo).filter((tool): tool is ToolInfo => Boolean(tool)),
+		diagnostics: [
+			...normalizeToolDiagnostics(root?.diagnostics),
+			...normalizeToolDiagnostics(root?.toolDiagnostics),
+			...normalizeToolDiagnostics(root?.invalidTools),
+			...normalizeToolDiagnostics(root?.invalidToolDiagnostics),
+		],
+	};
 }
 
 // ============================================================================
@@ -2594,22 +2659,20 @@ export async function fetchContributions(projectId?: string): Promise<PackContri
 	}
 }
 
-export async function fetchTools(projectId?: string): Promise<ToolInfo[]> {
+export async function fetchToolsResponse(projectId?: string): Promise<ToolsResponse> {
 	try {
 		const qs = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
 		const res = await gatewayFetch(`/api/tools${qs}`);
 		if (!res.ok) throw await errorFromResponse(res, `Failed to fetch tools: ${res.status}`);
-		const data = await res.json();
-		const tools = data.tools || data || [];
-		// Handle legacy string[] format
-		if (tools.length > 0 && typeof tools[0] === "string") {
-			return tools.map((name: string) => ({ name, description: "", group: "Other" }));
-		}
-		return tools;
+		return normalizeToolsResponse(await res.json());
 	} catch (err) {
 		console.error("[role-api] fetchTools failed:", err);
-		return [];
+		return { tools: [], diagnostics: [] };
 	}
+}
+
+export async function fetchTools(projectId?: string): Promise<ToolInfo[]> {
+	return (await fetchToolsResponse(projectId)).tools;
 }
 
 export async function fetchToolDetail(name: string, projectId?: string): Promise<ToolInfo | null> {

--- a/src/app/tool-manager-page.ts
+++ b/src/app/tool-manager-page.ts
@@ -3,7 +3,7 @@ import { icon } from "@mariozechner/mini-lit";
 import { Button } from "@mariozechner/mini-lit/dist/Button.js";
 import { html, nothing, type TemplateResult } from "lit";
 import { ArrowLeft, Pencil, Plus } from "lucide";
-import { fetchToolDetail, updateTool, fetchRoles, updateRole, fetchGroupPolicies, updateGroupPolicy, fetchMcpServers, gatewayFetch, type ToolInfo, type RoleData, type McpServerInfo, type McpOperationInfo, type ToolProviderProvenance } from "./api.js";
+import { fetchToolDetail, fetchToolsResponse, normalizeToolDiagnostics, updateTool, fetchRoles, updateRole, fetchGroupPolicies, updateGroupPolicy, fetchMcpServers, gatewayFetch, type ToolInfo, type RoleData, type McpServerInfo, type McpOperationInfo, type ToolProviderProvenance, type ToolDiagnostic } from "./api.js";
 import { errorFromResponse, errorDetails } from "./error-helpers.js";
 import { connectToSession } from "./session-manager.js";
 import { showConnectionError } from "./dialogs.js";
@@ -246,6 +246,7 @@ type View = "list" | "edit";
 
 let currentView: View = "list";
 let tools: ToolInfo[] = [];
+let toolDiagnostics: ToolDiagnostic[] = [];
 let roles: RoleData[] = [];
 let groupPolicies: Record<string, string> = {};
 let mcpServers: McpServerInfo[] = [];
@@ -398,20 +399,9 @@ function policySource(toolName: string, toolGroup: string, roleToolPolicies?: Re
 // ============================================================================
 
 async function fetchToolsScoped(): Promise<ToolInfo[]> {
-	const projectId = getConfigProjectId();
-	const url = projectId ? `/api/tools?projectId=${encodeURIComponent(projectId)}` : "/api/tools";
-	try {
-		const res = await gatewayFetch(url);
-		if (!res.ok) return [];
-		const data = await res.json();
-		const toolsList = data.tools || data || [];
-		if (toolsList.length > 0 && typeof toolsList[0] === "string") {
-			return toolsList.map((name: string) => ({ name, description: "", group: "Other" }));
-		}
-		return toolsList;
-	} catch {
-		return [];
-	}
+	const response = await fetchToolsResponse(getConfigProjectId());
+	toolDiagnostics = response.diagnostics;
+	return response.tools;
 }
 
 export async function loadToolPageData(): Promise<void> {
@@ -439,6 +429,7 @@ export async function loadToolPageData(): Promise<void> {
 export function clearToolPageState(): void {
 	currentView = "list";
 	selectedTool = null;
+	toolDiagnostics = [];
 	loading = true;
 	saving = false;
 }
@@ -921,6 +912,104 @@ async function handleScopeChange(scope: string): Promise<void> {
 	renderApp();
 }
 
+function firstDiagnosticString(diagnostic: ToolDiagnostic, keys: string[]): string | undefined {
+	for (const key of keys) {
+		const value = diagnostic[key];
+		if (typeof value === "string" && value.trim()) return value.trim();
+	}
+	return undefined;
+}
+
+function shortDiagnosticText(text: string, max = 360): string {
+	return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
+
+function diagnosticMessage(diagnostic: ToolDiagnostic): string {
+	const message = firstDiagnosticString(diagnostic, ["message", "reason", "invalidReason", "error", "detail", "details"]);
+	if (message) return shortDiagnosticText(message);
+	try {
+		return shortDiagnosticText(JSON.stringify(diagnostic));
+	} catch {
+		return "Tool override was reported invalid.";
+	}
+}
+
+function diagnosticSeverity(diagnostic: ToolDiagnostic): "error" | "warning" | "info" {
+	const raw = firstDiagnosticString(diagnostic, ["severity", "level", "type"])?.toLowerCase() ?? "";
+	if (raw.includes("error") || raw.includes("fail") || raw.includes("invalid")) return "error";
+	if (raw.includes("info") || raw.includes("ok")) return "info";
+	return "warning";
+}
+
+function diagnosticTitle(diagnostic: ToolDiagnostic): string {
+	const subject = firstDiagnosticString(diagnostic, ["toolName", "tool", "name", "groupDir", "group", "providerKey"]);
+	const status = firstDiagnosticString(diagnostic, ["status", "action"])?.toLowerCase() ?? "";
+	const skipped = diagnostic.skipped === true || status.includes("skip");
+	const label = skipped ? "Skipped tool override" : diagnosticSeverity(diagnostic) === "error" ? "Invalid tool override" : "Tool diagnostic";
+	return subject ? `${label}: ${subject}` : label;
+}
+
+function toolDiagnosticEntries(tool: ToolInfo): ToolDiagnostic[] {
+	const diagnostics = [
+		...normalizeToolDiagnostics(tool.invalidReason),
+		...normalizeToolDiagnostics(tool.diagnostics),
+	];
+	if ((tool.invalid === true || tool.valid === false) && diagnostics.length === 0) {
+		diagnostics.push({ severity: "error", message: "This tool was reported invalid by /api/tools." });
+	}
+	return diagnostics;
+}
+
+function renderDiagnosticChips(diagnostic: ToolDiagnostic): TemplateResult | typeof nothing {
+	const chips: Array<[string, string | undefined]> = [
+		["Code", firstDiagnosticString(diagnostic, ["code", "type"])],
+		["Group", firstDiagnosticString(diagnostic, ["groupDir", "group"])],
+		["Tool", firstDiagnosticString(diagnostic, ["toolName", "tool", "name"])],
+		["Source", firstDiagnosticString(diagnostic, ["sourcePath", "path", "file"])],
+		["Fallback", firstDiagnosticString(diagnostic, ["fallbackTool", "fallbackProvider", "fallback"])],
+	];
+	const visible = chips.filter(([, value]) => Boolean(value));
+	if (!visible.length) return nothing;
+	return html`
+		<div class="flex flex-wrap gap-1 mt-2">
+			${visible.map(([label, value]) => html`
+				<span class="text-[11px] px-1.5 py-0.5 rounded border border-border text-muted-foreground" title=${value!}>${label}: ${shortDiagnosticText(value!, 90)}</span>
+			`)}
+		</div>
+	`;
+}
+
+function renderToolDiagnosticsPanel(diagnostics: ToolDiagnostic[], title = "Tool diagnostics"): TemplateResult | typeof nothing {
+	if (!diagnostics.length) return nothing;
+	return html`
+		<div class="tools-section" data-testid="tool-diagnostics" style="max-width:900px;margin:0 auto 16px;border-color:color-mix(in oklch, var(--warning) 55%, var(--border));background:color-mix(in oklch, var(--warning) 10%, transparent);">
+			<h2 class="tools-section-title">${title}</h2>
+			<p class="tools-note">Invalid config-level tool overrides are skipped before agent launch. Bobbit will use a lower-priority fallback when one is available.</p>
+			<div class="flex flex-col gap-2 mt-3">
+				${diagnostics.map((diagnostic) => {
+					const severity = diagnosticSeverity(diagnostic);
+					return html`
+						<div data-testid="tool-diagnostic" class="rounded border border-border bg-card px-3 py-2">
+							<div class="flex items-center gap-2 text-sm font-semibold">
+								<span class="uppercase text-[10px] tracking-wide text-muted-foreground">${severity}</span>
+								<span>${diagnosticTitle(diagnostic)}</span>
+							</div>
+							<div class="tools-note mt-1">${diagnosticMessage(diagnostic)}</div>
+							${renderDiagnosticChips(diagnostic)}
+						</div>
+					`;
+				})}
+			</div>
+		</div>
+	`;
+}
+
+function renderToolDiagnosticBadge(tool: ToolInfo): TemplateResult | typeof nothing {
+	const diagnostics = toolDiagnosticEntries(tool);
+	if (!diagnostics.length) return nothing;
+	return html`<span class="config-readonly-note" data-testid="tool-diagnostic-badge" title=${diagnostics.map(diagnosticMessage).join("\n")}>Diagnostic</span>`;
+}
+
 function renderToolRow(tool: ToolInfo): TemplateResult {
 	const origin = isConfigOrigin(tool.origin) ? tool.origin : undefined;
 	const inherited = isInherited(origin);
@@ -928,7 +1017,7 @@ function renderToolRow(tool: ToolInfo): TemplateResult {
 		<div class="tool-row ${inherited ? "config-item-inherited" : ""}" tabindex="0" role="button"
 			@click=${() => showEdit(tool)}
 			@keydown=${(e: KeyboardEvent) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); showEdit(tool); } }}>
-			<span class="tool-row-name">${tool.name} ${renderToolOriginBadges(tool)}</span>
+			<span class="tool-row-name">${tool.name} ${renderToolOriginBadges(tool)} ${renderToolDiagnosticBadge(tool)}</span>
 			<span class="tool-row-desc">${tool.description}</span>
 			<div class="tool-row-actions">
 				<button class="tool-row-action-btn" @click=${(e: Event) => { e.stopPropagation(); showEdit(tool); }} title="Edit">
@@ -951,8 +1040,11 @@ function renderListView(): TemplateResult {
 		`;
 	}
 
+	const diagnosticsPanel = renderToolDiagnosticsPanel(toolDiagnostics);
+
 	if (tools.length === 0) {
 		return html`
+			${diagnosticsPanel}
 			<div class="tools-empty">
 				<p class="tools-empty-title">No tools found</p>
 				<p class="tools-empty-desc">Tools are registered by the agent runtime and appear here automatically.</p>
@@ -982,6 +1074,7 @@ function renderListView(): TemplateResult {
 	const chevronSvg = html`<svg class="tool-group-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>`;
 
 	return html`
+		${diagnosticsPanel}
 		<p class="text-sm text-muted-foreground mb-6" style="max-width: 700px; margin-inline: auto;">Tools are the capabilities available to agents \u2014 file editing, shell commands, web search, and more. This page lets you view and document them.</p>
 		<div class="tools-list">
 			${sortedGroups.map((groupName) => {
@@ -1190,6 +1283,7 @@ function renderEditView(): TemplateResult {
 				<div class="tools-identity-section">
 					${selectedTool.origin || isPiExtensionTool(selectedTool) ? html`<div class="mb-1 inline-flex items-center gap-2">${renderToolOriginBadges(selectedTool)}${renderCustomizeRevertButtons()}</div>` : ""}
 					${renderPiExtensionProvenance(selectedTool)}
+					${renderToolDiagnosticsPanel(toolDiagnosticEntries(selectedTool), "Tool diagnostics")}
 					<div class="tools-identity-row">
 						<label class="tools-field-label">Name</label>
 						<div class="tools-field-readonly">${selectedTool.name}</div>

--- a/src/server/agent/builtin-config.ts
+++ b/src/server/agent/builtin-config.ts
@@ -19,6 +19,7 @@ import { normalizeGrantPolicy, validateModelString, validateThinkingLevel } from
 import type { Workflow } from "./workflow-store.js";
 import type { ToolInfo } from "./tool-manager.js";
 import { parseContributions, computeRendererKind } from "./tool-contributions.js";
+import { isIgnoredToolGroupDir } from "./tool-extension-preflight.js";
 
 // ── Shared parse helpers (single source of truth) ───────────────
 //
@@ -116,7 +117,7 @@ export function parseToolsDir(toolsDir: string): ToolInfo[] {
 
 	// First pass: grouped subdirectories (tools/<group>/*.yaml)
 	for (const entry of entries) {
-		if (!entry.isDirectory()) continue;
+		if (!entry.isDirectory() || isIgnoredToolGroupDir(entry.name)) continue;
 		const groupPath = path.join(toolsDir, entry.name);
 		try {
 			const files = fs.readdirSync(groupPath, { withFileTypes: true });

--- a/src/server/agent/tool-extension-preflight.ts
+++ b/src/server/agent/tool-extension-preflight.ts
@@ -1,0 +1,182 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { ToolProvider } from "./tool-manager.js";
+
+export interface ToolExtensionDiagnostic {
+	type: "invalid-tool-extension";
+	toolName: string;
+	groupDir: string;
+	extensionPath: string;
+	message: string;
+}
+
+export function isIgnoredToolGroupDir(name: string): boolean {
+	if (name.startsWith(".")) return true;
+	return /\.disabled(?:$|[-_])/.test(name);
+}
+
+function formatFsError(err: unknown): string {
+	if (err instanceof Error) return err.message;
+	return String(err);
+}
+
+function isScriptFile(filePath: string): boolean {
+	return /\.(?:[cm]?[jt]sx?)$/i.test(filePath);
+}
+
+function candidateFiles(candidate: string): string[] {
+	const ext = path.extname(candidate);
+	if (ext) {
+		const base = candidate.slice(0, -ext.length);
+		const aliases = ext === ".js"
+			? [candidate, `${base}.ts`, `${base}.tsx`, `${base}.mts`, `${base}.cts`, `${base}.jsx`, `${base}.mjs`, `${base}.cjs`]
+			: ext === ".mjs"
+				? [candidate, `${base}.mts`, `${base}.ts`]
+				: ext === ".cjs"
+					? [candidate, `${base}.cts`, `${base}.ts`]
+					: [candidate];
+		return [...new Set(aliases)];
+	}
+	return [
+		candidate,
+		`${candidate}.ts`,
+		`${candidate}.tsx`,
+		`${candidate}.mts`,
+		`${candidate}.cts`,
+		`${candidate}.js`,
+		`${candidate}.jsx`,
+		`${candidate}.mjs`,
+		`${candidate}.cjs`,
+		`${candidate}.json`,
+		path.join(candidate, "index.ts"),
+		path.join(candidate, "index.tsx"),
+		path.join(candidate, "index.mts"),
+		path.join(candidate, "index.cts"),
+		path.join(candidate, "index.js"),
+		path.join(candidate, "index.jsx"),
+		path.join(candidate, "index.mjs"),
+		path.join(candidate, "index.cjs"),
+	];
+}
+
+function resolveLocalImport(fromFile: string, specifier: string): string | undefined {
+	const candidate = path.resolve(path.dirname(fromFile), specifier);
+	for (const file of candidateFiles(candidate)) {
+		try {
+			if (fs.statSync(file).isFile()) return file;
+		} catch { /* try next */ }
+	}
+	return undefined;
+}
+
+function stripComments(source: string): string {
+	return source
+		.replace(/\/\*[\s\S]*?\*\//g, "")
+		.replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+
+function localImportSpecifiers(source: string): string[] {
+	const specs: string[] = [];
+	const body = stripComments(source);
+	const re = /(?:\bimport\s+(?:[^'"()]*?\s+from\s+)?|\bexport\s+(?:[^'"]*?\s+from\s+)|\bimport\s*\(\s*)["']([^"']+)["']/g;
+	let match: RegExpExecArray | null;
+	while ((match = re.exec(body))) {
+		const spec = match[1];
+		if (spec.startsWith("./") || spec.startsWith("../")) specs.push(spec);
+	}
+	return specs;
+}
+
+function validateImportGraph(entryPath: string): string | undefined {
+	const seen = new Set<string>();
+	const stack = [entryPath];
+	while (stack.length > 0) {
+		const file = stack.pop()!;
+		const resolvedFile = path.resolve(file);
+		if (seen.has(resolvedFile)) continue;
+		seen.add(resolvedFile);
+
+		let raw: string;
+		try {
+			raw = fs.readFileSync(resolvedFile, "utf-8");
+		} catch (err) {
+			return `cannot read ${resolvedFile}: ${formatFsError(err)}`;
+		}
+
+		if (!isScriptFile(resolvedFile)) continue;
+		for (const specifier of localImportSpecifiers(raw)) {
+			const child = resolveLocalImport(resolvedFile, specifier);
+			if (!child) {
+				return `missing local import ${JSON.stringify(specifier)} from ${resolvedFile}`;
+			}
+			if (isScriptFile(child)) stack.push(child);
+		}
+	}
+	return undefined;
+}
+
+export function preflightConfigBobbitExtension(input: {
+	toolName: string;
+	groupDir: string;
+	baseDir: string;
+	provider?: ToolProvider;
+}): ToolExtensionDiagnostic | undefined {
+	if (input.provider?.type !== "bobbit-extension") return undefined;
+	if (!input.provider.extension) {
+		const extensionPath = path.join(input.baseDir, input.groupDir, "<missing>");
+		return {
+			type: "invalid-tool-extension",
+			toolName: input.toolName,
+			groupDir: input.groupDir,
+			extensionPath,
+			message: `bobbit-extension provider for ${input.toolName} does not declare an extension file`,
+		};
+	}
+
+	const extensionPath = path.resolve(input.baseDir, input.groupDir, input.provider.extension);
+	try {
+		if (!fs.statSync(extensionPath).isFile()) {
+			return {
+				type: "invalid-tool-extension",
+				toolName: input.toolName,
+				groupDir: input.groupDir,
+				extensionPath,
+				message: `extension file does not exist: ${extensionPath}`,
+			};
+		}
+	} catch (err) {
+		return {
+			type: "invalid-tool-extension",
+			toolName: input.toolName,
+			groupDir: input.groupDir,
+			extensionPath,
+			message: `extension file cannot be loaded: ${extensionPath}: ${formatFsError(err)}`,
+		};
+	}
+
+	const importError = validateImportGraph(extensionPath);
+	if (importError) {
+		return {
+			type: "invalid-tool-extension",
+			toolName: input.toolName,
+			groupDir: input.groupDir,
+			extensionPath,
+			message: `${extensionPath}: ${importError}`,
+		};
+	}
+	return undefined;
+}
+
+const loggedDiagnostics = new Set<string>();
+
+export function logToolExtensionDiagnostic(diagnostic: ToolExtensionDiagnostic): void {
+	const key = `${diagnostic.toolName}\0${diagnostic.extensionPath}\0${diagnostic.message}`;
+	if (loggedDiagnostics.has(key)) return;
+	loggedDiagnostics.add(key);
+	console.warn(`[tool-manager] Invalid config tool override "${diagnostic.toolName}" in group "${diagnostic.groupDir}" skipped: ${diagnostic.message}`);
+}
+
+export function __resetToolExtensionPreflightDiagnostics(): void {
+	loggedDiagnostics.clear();
+}

--- a/src/server/agent/tool-extension-preflight.ts
+++ b/src/server/agent/tool-extension-preflight.ts
@@ -177,21 +177,113 @@ const MODULE_LOAD_TIMEOUT_MS = 5_000;
 const MODULE_LOAD_MAX_OUTPUT_BYTES = 64 * 1024;
 const moduleLoadCache = new Map<string, { fingerprint: string; error?: string }>();
 
-function supportsNativeModuleLoadPreflight(extensionPath: string): boolean {
-	// Plain node does not necessarily resolve TypeScript's extension aliases
-	// (for example import "./helper.js" backed by helper.ts) the same way the
-	// agent loader does. Keep executable module-load isolation to JS entries;
-	// TypeScript entries still get static local/bare import validation above.
-	return [".js", ".mjs", ".cjs"].includes(path.extname(extensionPath).toLowerCase());
-}
-
 function sanitizeModuleLoadOutput(value: unknown): string {
 	const text = String(value ?? "").replace(/\s+/g, " ").trim();
 	return text.length > 2_000 ? `${text.slice(0, 2_000)}…` : text;
 }
 
+function moduleLoadPreflightScript(extensionPath: string): string {
+	// Bundle first, then import the bundle in the child process. This lets the
+	// executable preflight cover TypeScript config extensions while preserving
+	// copied overrides that import Bobbit-installed dependencies (for example
+	// @sinclair/typebox) from isolated project config directories.
+	const bobbitRequire = createRequire(import.meta.url);
+	const esbuildPath = bobbitRequire.resolve("esbuild");
+	const esbuildPackageJson = bobbitRequire.resolve("esbuild/package.json");
+	const bobbitRoot = path.dirname(path.dirname(path.dirname(esbuildPackageJson)));
+	return `
+import fs from "node:fs";
+import path from "node:path";
+import { builtinModules } from "node:module";
+import { pathToFileURL } from "node:url";
+import { build } from ${JSON.stringify(pathToFileURL(esbuildPath).href)};
+
+const entry = ${JSON.stringify(extensionPath)};
+const bobbitRoot = ${JSON.stringify(bobbitRoot)};
+const builtins = new Set([...builtinModules, ...builtinModules.map((name) => "node:" + name)]);
+function isBuiltin(specifier) {
+	if (builtins.has(specifier)) return true;
+	if (specifier.startsWith("node:")) return builtins.has(specifier.slice(5));
+	const head = specifier.split("/")[0];
+	return builtins.has(head);
+}
+function candidateFiles(candidate) {
+	const ext = path.extname(candidate);
+	if (ext) {
+		const base = candidate.slice(0, -ext.length);
+		const aliases = ext === ".js"
+			? [candidate, base + ".ts", base + ".tsx", base + ".mts", base + ".cts", base + ".jsx", base + ".mjs", base + ".cjs"]
+			: ext === ".mjs"
+				? [candidate, base + ".mts", base + ".ts"]
+				: ext === ".cjs"
+					? [candidate, base + ".cts", base + ".ts"]
+					: [candidate];
+		return [...new Set(aliases)];
+	}
+	return [
+		candidate,
+		candidate + ".ts",
+		candidate + ".tsx",
+		candidate + ".mts",
+		candidate + ".cts",
+		candidate + ".js",
+		candidate + ".jsx",
+		candidate + ".mjs",
+		candidate + ".cjs",
+		candidate + ".json",
+		path.join(candidate, "index.ts"),
+		path.join(candidate, "index.tsx"),
+		path.join(candidate, "index.mts"),
+		path.join(candidate, "index.cts"),
+		path.join(candidate, "index.js"),
+		path.join(candidate, "index.jsx"),
+		path.join(candidate, "index.mjs"),
+		path.join(candidate, "index.cjs"),
+	];
+}
+function resolveLocalImport(resolveDir, specifier) {
+	const candidate = path.resolve(resolveDir, specifier);
+	for (const file of candidateFiles(candidate)) {
+		try { if (fs.statSync(file).isFile()) return file; } catch {}
+	}
+	return undefined;
+}
+const result = await build({
+	entryPoints: [entry],
+	bundle: true,
+	write: false,
+	platform: "node",
+	format: "esm",
+	target: "node20",
+	logLevel: "silent",
+	packages: "external",
+	plugins: [{
+		name: "bobbit-tool-preflight-resolve",
+		setup(build) {
+			build.onResolve({ filter: /.*/ }, (args) => {
+				if (args.kind === "entry-point") return undefined;
+				if (args.path.startsWith("./") || args.path.startsWith("../")) {
+					const resolved = resolveLocalImport(args.resolveDir, args.path);
+					if (resolved) return { path: resolved };
+					return undefined;
+				}
+				if (isBuiltin(args.path)) return { path: args.path, external: true };
+				return { path: args.path, external: true };
+			});
+		},
+	}],
+});
+const outFile = path.join(bobbitRoot, ".bobbit-tool-preflight-" + process.pid + "-" + Date.now() + ".mjs");
+try {
+	fs.writeFileSync(outFile, result.outputFiles[0].text, "utf-8");
+	await import(pathToFileURL(outFile).href);
+} finally {
+	try { fs.rmSync(outFile, { force: true }); } catch {}
+}
+`;
+}
+
 function moduleLoadFailure(extensionPath: string): string | undefined {
-	if (!supportsNativeModuleLoadPreflight(extensionPath)) return undefined;
 	let stat: fs.Stats;
 	try {
 		stat = fs.statSync(extensionPath);
@@ -202,7 +294,12 @@ function moduleLoadFailure(extensionPath: string): string | undefined {
 	const cached = moduleLoadCache.get(extensionPath);
 	if (cached?.fingerprint === fingerprint) return cached.error;
 
-	const script = `import(${JSON.stringify(pathToFileURL(extensionPath).href)}).then(() => undefined).catch((err) => { console.error(err && err.stack ? err.stack : err); process.exitCode = 1; });`;
+	let script: string;
+	try {
+		script = moduleLoadPreflightScript(extensionPath);
+	} catch (err) {
+		return `module load failed: cannot prepare preflight: ${formatFsError(err)}`;
+	}
 	const result = spawnSync(process.execPath, ["--input-type=module", "--eval", script], {
 		cwd: path.dirname(extensionPath),
 		env: { ...process.env, BOBBIT_TOOL_PREFLIGHT: "1" },
@@ -240,24 +337,7 @@ function makeDiagnostic(input: { toolName: string; groupDir: string }, extension
 	};
 }
 
-export function preflightConfigBobbitExtension(input: {
-	toolName: string;
-	groupDir: string;
-	baseDir: string;
-	provider?: ToolProvider;
-}): ToolExtensionDiagnostic | undefined {
-	if (input.provider?.type !== "bobbit-extension") return undefined;
-	if (!input.provider.extension) {
-		const extensionPath = path.join(input.baseDir, input.groupDir, "<missing>");
-		return makeDiagnostic(
-			input,
-			extensionPath,
-			"missing-extension",
-			`bobbit-extension provider for ${input.toolName} does not declare an extension file`,
-		);
-	}
-
-	const extensionPath = path.resolve(input.baseDir, input.groupDir, input.provider.extension);
+function preflightConfigExtensionPath(input: { toolName: string; groupDir: string }, extensionPath: string): ToolExtensionDiagnostic | undefined {
 	try {
 		if (!fs.statSync(extensionPath).isFile()) {
 			return makeDiagnostic(input, extensionPath, "missing-extension", `extension file does not exist: ${extensionPath}`);
@@ -275,6 +355,43 @@ export function preflightConfigBobbitExtension(input: {
 		return makeDiagnostic(input, extensionPath, "module-load-failed", `${extensionPath}: ${loadError}`);
 	}
 	return undefined;
+}
+
+export function preflightConfigExtensionFile(input: {
+	toolName: string;
+	groupDir: string;
+	baseDir: string;
+	extension: string;
+}): ToolExtensionDiagnostic | undefined {
+	return preflightConfigExtensionPath(
+		{ toolName: input.toolName, groupDir: input.groupDir },
+		path.resolve(input.baseDir, input.groupDir, input.extension),
+	);
+}
+
+export function preflightConfigBobbitExtension(input: {
+	toolName: string;
+	groupDir: string;
+	baseDir: string;
+	provider?: ToolProvider;
+}): ToolExtensionDiagnostic | undefined {
+	if (input.provider?.type !== "bobbit-extension") return undefined;
+	if (!input.provider.extension) {
+		const extensionPath = path.join(input.baseDir, input.groupDir, "<missing>");
+		return makeDiagnostic(
+			input,
+			extensionPath,
+			"missing-extension",
+			`bobbit-extension provider for ${input.toolName} does not declare an extension file`,
+		);
+	}
+
+	return preflightConfigExtensionFile({
+		toolName: input.toolName,
+		groupDir: input.groupDir,
+		baseDir: input.baseDir,
+		extension: input.provider.extension,
+	});
 }
 
 const loggedDiagnostics = new Set<string>();

--- a/src/server/agent/tool-extension-preflight.ts
+++ b/src/server/agent/tool-extension-preflight.ts
@@ -157,8 +157,16 @@ function validateImportGraph(entryPath: string): ImportGraphError | undefined {
 			if (isNodeBuiltinSpecifier(specifier)) continue;
 			try {
 				createRequire(resolvedFile).resolve(specifier);
-			} catch (err) {
-				return { code: "module-load-failed", message: `cannot resolve module import ${JSON.stringify(specifier)} from ${resolvedFile}: ${formatFsError(err)}` };
+			} catch (localErr) {
+				try {
+					// Config-level tool groups are often copied into isolated project
+					// directories without their own node_modules. Bare imports should
+					// still resolve against Bobbit's installed dependencies, matching
+					// how bundled tool extensions run from the app installation.
+					createRequire(import.meta.url).resolve(specifier);
+				} catch {
+					return { code: "module-load-failed", message: `cannot resolve module import ${JSON.stringify(specifier)} from ${resolvedFile}: ${formatFsError(localErr)}` };
+				}
 			}
 		}
 	}

--- a/src/server/agent/tool-extension-preflight.ts
+++ b/src/server/agent/tool-extension-preflight.ts
@@ -1,14 +1,24 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import { builtinModules, createRequire } from "node:module";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 import type { ToolProvider } from "./tool-manager.js";
 
 export interface ToolExtensionDiagnostic {
 	type: "invalid-tool-extension";
+	severity: "error";
+	code: "missing-extension" | "missing-local-import" | "module-load-failed";
 	toolName: string;
+	tool?: string;
 	groupDir: string;
+	group?: string;
 	extensionPath: string;
+	path?: string;
+	sourcePath?: string;
 	message: string;
+	skipped: true;
 }
 
 export function isIgnoredToolGroupDir(name: string): boolean {
@@ -76,19 +86,48 @@ function stripComments(source: string): string {
 		.replace(/(^|[^:])\/\/.*$/gm, "$1");
 }
 
-function localImportSpecifiers(source: string): string[] {
-	const specs: string[] = [];
+interface ImportSpecifier {
+	specifier: string;
+	typeOnly: boolean;
+}
+
+function importSpecifiers(source: string): ImportSpecifier[] {
+	const specs: ImportSpecifier[] = [];
 	const body = stripComments(source);
-	const re = /(?:\bimport\s+(?:[^'"()]*?\s+from\s+)?|\bexport\s+(?:[^'"]*?\s+from\s+)|\bimport\s*\(\s*)["']([^"']+)["']/g;
+	const staticRe = /\b(import|export)\s+(type\s+)?(?:[^'"()]*?\s+from\s+)?["']([^"']+)["']/g;
 	let match: RegExpExecArray | null;
-	while ((match = re.exec(body))) {
-		const spec = match[1];
-		if (spec.startsWith("./") || spec.startsWith("../")) specs.push(spec);
+	while ((match = staticRe.exec(body))) {
+		specs.push({ specifier: match[3], typeOnly: !!match[2] });
+	}
+	const dynamicRe = /\bimport\s*\(\s*["']([^"']+)["']/g;
+	while ((match = dynamicRe.exec(body))) {
+		specs.push({ specifier: match[1], typeOnly: false });
 	}
 	return specs;
 }
 
-function validateImportGraph(entryPath: string): string | undefined {
+const NODE_BUILTINS = new Set<string>([
+	...builtinModules,
+	...builtinModules.map((name) => `node:${name}`),
+]);
+
+function isNodeBuiltinSpecifier(specifier: string): boolean {
+	if (NODE_BUILTINS.has(specifier)) return true;
+	if (specifier.startsWith("node:")) return NODE_BUILTINS.has(specifier.slice(5));
+	const [head] = specifier.split("/");
+	return NODE_BUILTINS.has(head);
+}
+
+function isRelativeSpecifier(specifier: string): boolean {
+	return specifier.startsWith("./") || specifier.startsWith("../");
+}
+
+interface ImportGraphError {
+	code: ToolExtensionDiagnostic["code"];
+	message: string;
+}
+
+function validateImportGraph(entryPath: string): ImportGraphError | undefined {
 	const seen = new Set<string>();
 	const stack = [entryPath];
 	while (stack.length > 0) {
@@ -101,19 +140,96 @@ function validateImportGraph(entryPath: string): string | undefined {
 		try {
 			raw = fs.readFileSync(resolvedFile, "utf-8");
 		} catch (err) {
-			return `cannot read ${resolvedFile}: ${formatFsError(err)}`;
+			return { code: "module-load-failed", message: `cannot read ${resolvedFile}: ${formatFsError(err)}` };
 		}
 
 		if (!isScriptFile(resolvedFile)) continue;
-		for (const specifier of localImportSpecifiers(raw)) {
-			const child = resolveLocalImport(resolvedFile, specifier);
-			if (!child) {
-				return `missing local import ${JSON.stringify(specifier)} from ${resolvedFile}`;
+		for (const { specifier, typeOnly } of importSpecifiers(raw)) {
+			if (typeOnly) continue;
+			if (isRelativeSpecifier(specifier)) {
+				const child = resolveLocalImport(resolvedFile, specifier);
+				if (!child) {
+					return { code: "missing-local-import", message: `missing local import ${JSON.stringify(specifier)} from ${resolvedFile}` };
+				}
+				if (isScriptFile(child)) stack.push(child);
+				continue;
 			}
-			if (isScriptFile(child)) stack.push(child);
+			if (isNodeBuiltinSpecifier(specifier)) continue;
+			try {
+				createRequire(resolvedFile).resolve(specifier);
+			} catch (err) {
+				return { code: "module-load-failed", message: `cannot resolve module import ${JSON.stringify(specifier)} from ${resolvedFile}: ${formatFsError(err)}` };
+			}
 		}
 	}
 	return undefined;
+}
+
+const MODULE_LOAD_TIMEOUT_MS = 5_000;
+const MODULE_LOAD_MAX_OUTPUT_BYTES = 64 * 1024;
+const moduleLoadCache = new Map<string, { fingerprint: string; error?: string }>();
+
+function supportsNativeModuleLoadPreflight(extensionPath: string): boolean {
+	// Plain node does not necessarily resolve TypeScript's extension aliases
+	// (for example import "./helper.js" backed by helper.ts) the same way the
+	// agent loader does. Keep executable module-load isolation to JS entries;
+	// TypeScript entries still get static local/bare import validation above.
+	return [".js", ".mjs", ".cjs"].includes(path.extname(extensionPath).toLowerCase());
+}
+
+function sanitizeModuleLoadOutput(value: unknown): string {
+	const text = String(value ?? "").replace(/\s+/g, " ").trim();
+	return text.length > 2_000 ? `${text.slice(0, 2_000)}…` : text;
+}
+
+function moduleLoadFailure(extensionPath: string): string | undefined {
+	if (!supportsNativeModuleLoadPreflight(extensionPath)) return undefined;
+	let stat: fs.Stats;
+	try {
+		stat = fs.statSync(extensionPath);
+	} catch (err) {
+		return `extension file cannot be loaded: ${extensionPath}: ${formatFsError(err)}`;
+	}
+	const fingerprint = `${extensionPath}:${stat.mtimeMs}:${stat.size}`;
+	const cached = moduleLoadCache.get(extensionPath);
+	if (cached?.fingerprint === fingerprint) return cached.error;
+
+	const script = `import(${JSON.stringify(pathToFileURL(extensionPath).href)}).then(() => undefined).catch((err) => { console.error(err && err.stack ? err.stack : err); process.exitCode = 1; });`;
+	const result = spawnSync(process.execPath, ["--input-type=module", "--eval", script], {
+		cwd: path.dirname(extensionPath),
+		env: { ...process.env, BOBBIT_TOOL_PREFLIGHT: "1" },
+		encoding: "utf-8",
+		windowsHide: true,
+		timeout: MODULE_LOAD_TIMEOUT_MS,
+		maxBuffer: MODULE_LOAD_MAX_OUTPUT_BYTES,
+	});
+	let error: string | undefined;
+	if ((result.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT" || result.signal === "SIGTERM") {
+		error = `module load timed out after ${MODULE_LOAD_TIMEOUT_MS}ms`;
+	} else if (result.error) {
+		error = `module load failed: ${formatFsError(result.error)}`;
+	} else if ((result.status ?? 0) !== 0) {
+		error = `module load failed: ${sanitizeModuleLoadOutput(result.stderr || result.stdout || `exit ${result.status}`)}`;
+	}
+	moduleLoadCache.set(extensionPath, { fingerprint, error });
+	return error;
+}
+
+function makeDiagnostic(input: { toolName: string; groupDir: string }, extensionPath: string, code: ToolExtensionDiagnostic["code"], message: string): ToolExtensionDiagnostic {
+	return {
+		type: "invalid-tool-extension",
+		severity: "error",
+		code,
+		toolName: input.toolName,
+		tool: input.toolName,
+		groupDir: input.groupDir,
+		group: input.groupDir,
+		extensionPath,
+		path: extensionPath,
+		sourcePath: extensionPath,
+		message,
+		skipped: true,
+	};
 }
 
 export function preflightConfigBobbitExtension(input: {
@@ -125,45 +241,30 @@ export function preflightConfigBobbitExtension(input: {
 	if (input.provider?.type !== "bobbit-extension") return undefined;
 	if (!input.provider.extension) {
 		const extensionPath = path.join(input.baseDir, input.groupDir, "<missing>");
-		return {
-			type: "invalid-tool-extension",
-			toolName: input.toolName,
-			groupDir: input.groupDir,
+		return makeDiagnostic(
+			input,
 			extensionPath,
-			message: `bobbit-extension provider for ${input.toolName} does not declare an extension file`,
-		};
+			"missing-extension",
+			`bobbit-extension provider for ${input.toolName} does not declare an extension file`,
+		);
 	}
 
 	const extensionPath = path.resolve(input.baseDir, input.groupDir, input.provider.extension);
 	try {
 		if (!fs.statSync(extensionPath).isFile()) {
-			return {
-				type: "invalid-tool-extension",
-				toolName: input.toolName,
-				groupDir: input.groupDir,
-				extensionPath,
-				message: `extension file does not exist: ${extensionPath}`,
-			};
+			return makeDiagnostic(input, extensionPath, "missing-extension", `extension file does not exist: ${extensionPath}`);
 		}
 	} catch (err) {
-		return {
-			type: "invalid-tool-extension",
-			toolName: input.toolName,
-			groupDir: input.groupDir,
-			extensionPath,
-			message: `extension file cannot be loaded: ${extensionPath}: ${formatFsError(err)}`,
-		};
+		return makeDiagnostic(input, extensionPath, "missing-extension", `extension file cannot be loaded: ${extensionPath}: ${formatFsError(err)}`);
 	}
 
 	const importError = validateImportGraph(extensionPath);
 	if (importError) {
-		return {
-			type: "invalid-tool-extension",
-			toolName: input.toolName,
-			groupDir: input.groupDir,
-			extensionPath,
-			message: `${extensionPath}: ${importError}`,
-		};
+		return makeDiagnostic(input, extensionPath, importError.code, `${extensionPath}: ${importError.message}`);
+	}
+	const loadError = moduleLoadFailure(extensionPath);
+	if (loadError) {
+		return makeDiagnostic(input, extensionPath, "module-load-failed", `${extensionPath}: ${loadError}`);
 	}
 	return undefined;
 }
@@ -179,4 +280,5 @@ export function logToolExtensionDiagnostic(diagnostic: ToolExtensionDiagnostic):
 
 export function __resetToolExtensionPreflightDiagnostics(): void {
 	loggedDiagnostics.clear();
+	moduleLoadCache.clear();
 }

--- a/src/server/agent/tool-extension-preflight.ts
+++ b/src/server/agent/tool-extension-preflight.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import { builtinModules, createRequire } from "node:module";
+import { tmpdir as osTmpDir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -182,36 +183,82 @@ function sanitizeModuleLoadOutput(value: unknown): string {
 	return text.length > 2_000 ? `${text.slice(0, 2_000)}…` : text;
 }
 
-function bobbitInstallRoot(): string {
-	const bobbitRequire = createRequire(import.meta.url);
-	const esbuildPackageJson = bobbitRequire.resolve("esbuild/package.json");
-	return path.dirname(path.dirname(path.dirname(esbuildPackageJson)));
+function moduleLoadPreflightLoaderScript(): string {
+	// The child imports the original extension path (not a bundle) so bare package
+	// resolution starts from the extension/project directory. The loader only fills
+	// two gaps that Bobbit's runtime supports in practice: TS source files imported
+	// through emitted .js specifiers, and copied config overrides that import a
+	// Bobbit-installed dependency such as @sinclair/typebox.
+	const bobbitModuleUrl = import.meta.url;
+	return `
+import fs from "node:fs";
+import { builtinModules, createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const bobbitRequire = createRequire(${JSON.stringify(bobbitModuleUrl)});
+const nodeBuiltins = new Set([...builtinModules, ...builtinModules.map((name) => "node:" + name)]);
+
+function isRelativeSpecifier(specifier) {
+	return specifier.startsWith("./") || specifier.startsWith("../");
 }
 
-function bundleForModuleLoadPreflight(extensionPath: string): string {
-	// Bundle in the parent process, then import only the generated bundle in the
-	// child process. This keeps executable preflight fast enough for startup while
-	// still covering TypeScript config extensions and preserving copied overrides
-	// that import Bobbit-installed dependencies (for example @sinclair/typebox).
-	const bobbitRequire = createRequire(import.meta.url);
-	const esbuild = bobbitRequire("esbuild") as typeof import("esbuild");
-	const result = esbuild.buildSync({
-		entryPoints: [extensionPath],
-		bundle: true,
-		write: false,
-		platform: "node",
-		format: "esm",
-		target: "node20",
-		logLevel: "silent",
-		packages: "external",
-	});
-	const source = result.outputFiles?.[0]?.text;
-	if (!source) throw new Error("esbuild produced no output");
-	return source;
+function isBareSpecifier(specifier) {
+	return !isRelativeSpecifier(specifier) && !specifier.startsWith("/") && !specifier.match(/^[A-Za-z]:[\\\\/]/) && !specifier.startsWith("file:");
 }
 
-function moduleLoadPreflightScript(bundlePath: string): string {
-	return `await import(${JSON.stringify(pathToFileURL(bundlePath).href)});`;
+function isNodeBuiltinSpecifier(specifier) {
+	if (nodeBuiltins.has(specifier)) return true;
+	if (specifier.startsWith("node:")) return nodeBuiltins.has(specifier.slice(5));
+	const [head] = specifier.split("/");
+	return nodeBuiltins.has(head);
+}
+
+function candidateFiles(candidate) {
+	const ext = path.extname(candidate);
+	if (ext) {
+		const base = candidate.slice(0, -ext.length);
+		if (ext === ".js") return [candidate, base + ".ts", base + ".tsx", base + ".mts", base + ".cts", base + ".jsx", base + ".mjs", base + ".cjs"];
+		if (ext === ".mjs") return [candidate, base + ".mts", base + ".ts"];
+		if (ext === ".cjs") return [candidate, base + ".cts", base + ".ts"];
+		return [candidate];
+	}
+	return [candidate, candidate + ".ts", candidate + ".tsx", candidate + ".mts", candidate + ".cts", candidate + ".js", candidate + ".jsx", candidate + ".mjs", candidate + ".cjs", candidate + ".json", path.join(candidate, "index.ts"), path.join(candidate, "index.tsx"), path.join(candidate, "index.mts"), path.join(candidate, "index.cts"), path.join(candidate, "index.js"), path.join(candidate, "index.jsx"), path.join(candidate, "index.mjs"), path.join(candidate, "index.cjs")];
+}
+
+function resolveLocalImport(parentUrl, specifier) {
+	if (!parentUrl?.startsWith("file:")) return undefined;
+	const parentPath = fileURLToPath(parentUrl);
+	const candidate = path.resolve(path.dirname(parentPath), specifier);
+	for (const file of candidateFiles(candidate)) {
+		try {
+			if (fs.statSync(file).isFile()) return pathToFileURL(file).href;
+		} catch {}
+	}
+	return undefined;
+}
+
+export async function resolve(specifier, context, nextResolve) {
+	try {
+		return await nextResolve(specifier, context);
+	} catch (err) {
+		if (isRelativeSpecifier(specifier)) {
+			const localUrl = resolveLocalImport(context.parentURL, specifier);
+			if (localUrl) return { url: localUrl, shortCircuit: true };
+		}
+		if (isBareSpecifier(specifier) && !isNodeBuiltinSpecifier(specifier)) {
+			try {
+				return { url: pathToFileURL(bobbitRequire.resolve(specifier)).href, shortCircuit: true };
+			} catch {}
+		}
+		throw err;
+	}
+}
+`;
+}
+
+function moduleLoadPreflightScript(extensionPath: string): string {
+	return `await import(${JSON.stringify(pathToFileURL(extensionPath).href)});`;
 }
 
 function moduleLoadFailure(extensionPath: string): string | undefined {
@@ -225,12 +272,13 @@ function moduleLoadFailure(extensionPath: string): string | undefined {
 	const cached = moduleLoadCache.get(extensionPath);
 	if (cached?.fingerprint === fingerprint) return cached.error;
 
-	let bundlePath: string | undefined;
+	let tempDir: string | undefined;
 	let result: ReturnType<typeof spawnSync>;
 	try {
-		bundlePath = path.join(bobbitInstallRoot(), `.bobbit-tool-preflight-${process.pid}-${Date.now()}.mjs`);
-		fs.writeFileSync(bundlePath, bundleForModuleLoadPreflight(extensionPath), "utf-8");
-		result = spawnSync(process.execPath, ["--input-type=module", "--eval", moduleLoadPreflightScript(bundlePath)], {
+		tempDir = fs.mkdtempSync(path.join(osTmpDir(), "bobbit-tool-preflight-"));
+		const loaderPath = path.join(tempDir, "loader.mjs");
+		fs.writeFileSync(loaderPath, moduleLoadPreflightLoaderScript(), "utf-8");
+		result = spawnSync(process.execPath, ["--no-warnings", "--experimental-loader", pathToFileURL(loaderPath).href, "--input-type=module", "--eval", moduleLoadPreflightScript(extensionPath)], {
 			cwd: path.dirname(extensionPath),
 			env: { ...process.env, BOBBIT_TOOL_PREFLIGHT: "1" },
 			encoding: "utf-8",
@@ -241,8 +289,8 @@ function moduleLoadFailure(extensionPath: string): string | undefined {
 	} catch (err) {
 		return `module load failed: cannot prepare preflight: ${formatFsError(err)}`;
 	} finally {
-		if (bundlePath) {
-			try { fs.rmSync(bundlePath, { force: true }); } catch { /* ignore */ }
+		if (tempDir) {
+			try { fs.rmSync(tempDir, { recursive: true, force: true }); } catch { /* ignore */ }
 		}
 	}
 	let error: string | undefined;

--- a/src/server/agent/tool-extension-preflight.ts
+++ b/src/server/agent/tool-extension-preflight.ts
@@ -182,105 +182,36 @@ function sanitizeModuleLoadOutput(value: unknown): string {
 	return text.length > 2_000 ? `${text.slice(0, 2_000)}…` : text;
 }
 
-function moduleLoadPreflightScript(extensionPath: string): string {
-	// Bundle first, then import the bundle in the child process. This lets the
-	// executable preflight cover TypeScript config extensions while preserving
-	// copied overrides that import Bobbit-installed dependencies (for example
-	// @sinclair/typebox) from isolated project config directories.
+function bobbitInstallRoot(): string {
 	const bobbitRequire = createRequire(import.meta.url);
-	const esbuildPath = bobbitRequire.resolve("esbuild");
 	const esbuildPackageJson = bobbitRequire.resolve("esbuild/package.json");
-	const bobbitRoot = path.dirname(path.dirname(path.dirname(esbuildPackageJson)));
-	return `
-import fs from "node:fs";
-import path from "node:path";
-import { builtinModules } from "node:module";
-import { pathToFileURL } from "node:url";
-import { build } from ${JSON.stringify(pathToFileURL(esbuildPath).href)};
+	return path.dirname(path.dirname(path.dirname(esbuildPackageJson)));
+}
 
-const entry = ${JSON.stringify(extensionPath)};
-const bobbitRoot = ${JSON.stringify(bobbitRoot)};
-const builtins = new Set([...builtinModules, ...builtinModules.map((name) => "node:" + name)]);
-function isBuiltin(specifier) {
-	if (builtins.has(specifier)) return true;
-	if (specifier.startsWith("node:")) return builtins.has(specifier.slice(5));
-	const head = specifier.split("/")[0];
-	return builtins.has(head);
+function bundleForModuleLoadPreflight(extensionPath: string): string {
+	// Bundle in the parent process, then import only the generated bundle in the
+	// child process. This keeps executable preflight fast enough for startup while
+	// still covering TypeScript config extensions and preserving copied overrides
+	// that import Bobbit-installed dependencies (for example @sinclair/typebox).
+	const bobbitRequire = createRequire(import.meta.url);
+	const esbuild = bobbitRequire("esbuild") as typeof import("esbuild");
+	const result = esbuild.buildSync({
+		entryPoints: [extensionPath],
+		bundle: true,
+		write: false,
+		platform: "node",
+		format: "esm",
+		target: "node20",
+		logLevel: "silent",
+		packages: "external",
+	});
+	const source = result.outputFiles?.[0]?.text;
+	if (!source) throw new Error("esbuild produced no output");
+	return source;
 }
-function candidateFiles(candidate) {
-	const ext = path.extname(candidate);
-	if (ext) {
-		const base = candidate.slice(0, -ext.length);
-		const aliases = ext === ".js"
-			? [candidate, base + ".ts", base + ".tsx", base + ".mts", base + ".cts", base + ".jsx", base + ".mjs", base + ".cjs"]
-			: ext === ".mjs"
-				? [candidate, base + ".mts", base + ".ts"]
-				: ext === ".cjs"
-					? [candidate, base + ".cts", base + ".ts"]
-					: [candidate];
-		return [...new Set(aliases)];
-	}
-	return [
-		candidate,
-		candidate + ".ts",
-		candidate + ".tsx",
-		candidate + ".mts",
-		candidate + ".cts",
-		candidate + ".js",
-		candidate + ".jsx",
-		candidate + ".mjs",
-		candidate + ".cjs",
-		candidate + ".json",
-		path.join(candidate, "index.ts"),
-		path.join(candidate, "index.tsx"),
-		path.join(candidate, "index.mts"),
-		path.join(candidate, "index.cts"),
-		path.join(candidate, "index.js"),
-		path.join(candidate, "index.jsx"),
-		path.join(candidate, "index.mjs"),
-		path.join(candidate, "index.cjs"),
-	];
-}
-function resolveLocalImport(resolveDir, specifier) {
-	const candidate = path.resolve(resolveDir, specifier);
-	for (const file of candidateFiles(candidate)) {
-		try { if (fs.statSync(file).isFile()) return file; } catch {}
-	}
-	return undefined;
-}
-const result = await build({
-	entryPoints: [entry],
-	bundle: true,
-	write: false,
-	platform: "node",
-	format: "esm",
-	target: "node20",
-	logLevel: "silent",
-	packages: "external",
-	plugins: [{
-		name: "bobbit-tool-preflight-resolve",
-		setup(build) {
-			build.onResolve({ filter: /.*/ }, (args) => {
-				if (args.kind === "entry-point") return undefined;
-				if (args.path.startsWith("./") || args.path.startsWith("../")) {
-					const resolved = resolveLocalImport(args.resolveDir, args.path);
-					if (resolved) return { path: resolved };
-					return undefined;
-				}
-				if (isBuiltin(args.path)) return { path: args.path, external: true };
-				return { path: args.path, external: true };
-			});
-		},
-	}],
-});
-const outFile = path.join(bobbitRoot, ".bobbit-tool-preflight-" + process.pid + "-" + Date.now() + ".mjs");
-try {
-	fs.writeFileSync(outFile, result.outputFiles[0].text, "utf-8");
-	await import(pathToFileURL(outFile).href);
-} finally {
-	try { fs.rmSync(outFile, { force: true }); } catch {}
-}
-`;
+
+function moduleLoadPreflightScript(bundlePath: string): string {
+	return `await import(${JSON.stringify(pathToFileURL(bundlePath).href)});`;
 }
 
 function moduleLoadFailure(extensionPath: string): string | undefined {
@@ -294,20 +225,26 @@ function moduleLoadFailure(extensionPath: string): string | undefined {
 	const cached = moduleLoadCache.get(extensionPath);
 	if (cached?.fingerprint === fingerprint) return cached.error;
 
-	let script: string;
+	let bundlePath: string | undefined;
+	let result: ReturnType<typeof spawnSync>;
 	try {
-		script = moduleLoadPreflightScript(extensionPath);
+		bundlePath = path.join(bobbitInstallRoot(), `.bobbit-tool-preflight-${process.pid}-${Date.now()}.mjs`);
+		fs.writeFileSync(bundlePath, bundleForModuleLoadPreflight(extensionPath), "utf-8");
+		result = spawnSync(process.execPath, ["--input-type=module", "--eval", moduleLoadPreflightScript(bundlePath)], {
+			cwd: path.dirname(extensionPath),
+			env: { ...process.env, BOBBIT_TOOL_PREFLIGHT: "1" },
+			encoding: "utf-8",
+			windowsHide: true,
+			timeout: MODULE_LOAD_TIMEOUT_MS,
+			maxBuffer: MODULE_LOAD_MAX_OUTPUT_BYTES,
+		});
 	} catch (err) {
 		return `module load failed: cannot prepare preflight: ${formatFsError(err)}`;
+	} finally {
+		if (bundlePath) {
+			try { fs.rmSync(bundlePath, { force: true }); } catch { /* ignore */ }
+		}
 	}
-	const result = spawnSync(process.execPath, ["--input-type=module", "--eval", script], {
-		cwd: path.dirname(extensionPath),
-		env: { ...process.env, BOBBIT_TOOL_PREFLIGHT: "1" },
-		encoding: "utf-8",
-		windowsHide: true,
-		timeout: MODULE_LOAD_TIMEOUT_MS,
-		maxBuffer: MODULE_LOAD_MAX_OUTPUT_BYTES,
-	});
 	let error: string | undefined;
 	if ((result.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT" || result.signal === "SIGTERM") {
 		error = `module load timed out after ${MODULE_LOAD_TIMEOUT_MS}ms`;

--- a/src/server/agent/tool-manager.ts
+++ b/src/server/agent/tool-manager.ts
@@ -112,6 +112,8 @@ export interface ToolInfo {
 	originPackId?: string;
 	sourcePath?: string;
 	providers?: PiExtensionToolProviderInfo[];
+	/** Invalid config-level override diagnostics related to this tool, when a lower-priority fallback won. */
+	diagnostics?: ToolExtensionDiagnostic[];
 }
 
 /** Map the extension-host contribution fields from a scanned BaseToolInfo onto the
@@ -294,13 +296,27 @@ function invalidConfigToolDiagnostic(tool: BaseToolInfo): ToolExtensionDiagnosti
 	});
 }
 
-function filterInvalidConfigTools(tools: BaseToolInfo[]): BaseToolInfo[] {
-	return tools.filter((tool) => {
+function collectInvalidConfigToolDiagnostics(tools: BaseToolInfo[]): ToolExtensionDiagnostic[] {
+	const diagnostics: ToolExtensionDiagnostic[] = [];
+	const seen = new Set<string>();
+	for (const tool of tools) {
 		const diagnostic = invalidConfigToolDiagnostic(tool);
-		if (!diagnostic) return true;
+		if (!diagnostic) continue;
+		const key = `${diagnostic.toolName}\0${diagnostic.extensionPath}\0${diagnostic.message}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
+		diagnostics.push(diagnostic);
+	}
+	return diagnostics;
+}
+
+function filterInvalidConfigTools(tools: BaseToolInfo[]): BaseToolInfo[] {
+	const invalidNames = new Set<string>();
+	for (const diagnostic of collectInvalidConfigToolDiagnostics(tools)) {
 		logToolExtensionDiagnostic(diagnostic);
-		return false;
-	});
+		invalidNames.add(diagnostic.toolName);
+	}
+	return tools.filter((tool) => !invalidNames.has(tool.name));
 }
 
 /**
@@ -668,6 +684,13 @@ export class ToolManager {
 			grantPolicy: tool.grantPolicy,
 			params: tool.params,
 		}));
+	}
+
+	/** Invalid active config-level tool override diagnostics for this manager's config dir. */
+	getToolDiagnostics(): ToolExtensionDiagnostic[] {
+		const diagnostics = collectInvalidConfigToolDiagnostics(scanToolsDir(this.toolsDir, this.toolsDir));
+		for (const diagnostic of diagnostics) logToolExtensionDiagnostic(diagnostic);
+		return diagnostics;
 	}
 
 	/** Returns all tools, re-scanning the YAML directory on every call. */

--- a/src/server/agent/tool-manager.ts
+++ b/src/server/agent/tool-manager.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import type { GrantPolicy } from "./role-store.js";
 import { profile } from "./profiling.js";
 import { parseContributions, computeRendererKind, type ToolContributions } from "./tool-contributions.js";
-import { __resetToolExtensionPreflightDiagnostics, isIgnoredToolGroupDir, logToolExtensionDiagnostic, preflightConfigBobbitExtension, type ToolExtensionDiagnostic } from "./tool-extension-preflight.js";
+import { __resetToolExtensionPreflightDiagnostics, isIgnoredToolGroupDir, logToolExtensionDiagnostic, preflightConfigBobbitExtension, preflightConfigExtensionFile, type ToolExtensionDiagnostic } from "./tool-extension-preflight.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -296,6 +296,38 @@ function invalidConfigToolDiagnostic(tool: BaseToolInfo): ToolExtensionDiagnosti
 	});
 }
 
+function groupHasBobbitProviderForExtension(tools: BaseToolInfo[], groupDir: string, extension: string): boolean {
+	return tools.some((tool) => tool.groupDir === groupDir && tool.provider?.type === "bobbit-extension" && (tool.provider.extension ?? "extension.ts") === extension);
+}
+
+function invalidConfigGroupExtensionDiagnostic(toolsDir: string, groupDir: string, extension = "extension.ts", groupTools?: BaseToolInfo[]): ToolExtensionDiagnostic | undefined {
+	if (groupTools && groupHasBobbitProviderForExtension(groupTools, groupDir, extension)) return undefined;
+	const extensionPath = path.join(toolsDir, groupDir, extension);
+	try {
+		if (!fs.statSync(extensionPath).isFile()) return undefined;
+	} catch {
+		return undefined;
+	}
+	return preflightConfigExtensionFile({
+		toolName: `${groupDir}/${extension}`,
+		groupDir,
+		baseDir: toolsDir,
+		extension,
+	});
+}
+
+function collectInvalidConfigGroupExtensionDiagnostics(toolsDir: string, tools: BaseToolInfo[] = scanToolsDirCached(toolsDir, toolsDir)): ToolExtensionDiagnostic[] {
+	const diagnostics: ToolExtensionDiagnostic[] = [];
+	try {
+		for (const entry of fs.readdirSync(toolsDir, { withFileTypes: true })) {
+			if (!entry.isDirectory() || isIgnoredToolGroupDir(entry.name)) continue;
+			const diagnostic = invalidConfigGroupExtensionDiagnostic(toolsDir, entry.name, "extension.ts", tools);
+			if (diagnostic) diagnostics.push(diagnostic);
+		}
+	} catch { /* config tools dir absent */ }
+	return diagnostics;
+}
+
 function collectInvalidConfigToolDiagnostics(tools: BaseToolInfo[]): ToolExtensionDiagnostic[] {
 	const diagnostics: ToolExtensionDiagnostic[] = [];
 	const seen = new Set<string>();
@@ -310,13 +342,20 @@ function collectInvalidConfigToolDiagnostics(tools: BaseToolInfo[]): ToolExtensi
 	return diagnostics;
 }
 
-function filterInvalidConfigTools(tools: BaseToolInfo[]): BaseToolInfo[] {
+function filterInvalidConfigTools(tools: BaseToolInfo[], invalidGroupExtensions: Set<string> = new Set()): BaseToolInfo[] {
 	const invalidNames = new Set<string>();
 	for (const diagnostic of collectInvalidConfigToolDiagnostics(tools)) {
 		logToolExtensionDiagnostic(diagnostic);
 		invalidNames.add(diagnostic.toolName);
 	}
-	return tools.filter((tool) => !invalidNames.has(tool.name));
+	return tools.filter((tool) => !invalidNames.has(tool.name) && !toolDependsOnInvalidGroupExtension(tool, invalidGroupExtensions));
+}
+
+function toolDependsOnInvalidGroupExtension(tool: BaseToolInfo, invalidGroupExtensions: Set<string>): boolean {
+	if (!tool.groupDir || !invalidGroupExtensions.has(tool.groupDir)) return false;
+	if (tool.provider?.type === "builtin" && tool.provider.tool === "bash") return true;
+	if (tool.provider?.type === "bobbit-extension" && (tool.provider.extension ?? "extension.ts") === "extension.ts") return true;
+	return false;
 }
 
 /**
@@ -368,17 +407,28 @@ function _loadToolDefinitions(toolsDir: string, builtinToolsDir?: string, market
 	layers.push({ dir: toolsDir, isBuiltin: false }); // user `toolsDir` (highest)
 	const userIdx = layers.length - 1;
 
+	const invalidUserGroupExtensions = new Set<string>();
+	for (const diagnostic of collectInvalidConfigGroupExtensionDiagnostics(toolsDir)) {
+		logToolExtensionDiagnostic(diagnostic);
+		invalidUserGroupExtensions.add(diagnostic.groupDir);
+	}
+	const invalidUserToolGroups = new Set<string>(invalidUserGroupExtensions);
 	const scanned = layers.map((l, idx) => {
 		const tools = scanToolsDirCached(l.dir, l.dir);
-		return idx === userIdx ? filterInvalidConfigTools(tools) : tools;
+		if (idx !== userIdx) return tools;
+		for (const diagnostic of collectInvalidConfigToolDiagnostics(tools)) invalidUserToolGroups.add(diagnostic.groupDir);
+		return filterInvalidConfigTools(tools, invalidUserGroupExtensions);
 	});
 
 	// Builtin ↔ user whole-group replace (legacy, ONLY this pair): a group the
 	// USER layer defines fully shadows the SAME group in the BUILTIN layer.
 	// Market layers neither own nor are shadowed by groups — they overlay by
-	// tool NAME only (design §3.2 / finding #1).
+	// tool NAME only (design §3.2 / finding #1). If any config tool/extension in
+	// the group failed preflight, disable whole-group shadowing so lower-priority
+	// builtins can still provide per-tool fallbacks while valid config tools keep
+	// winning by name.
 	const userGroups = new Set<string>();
-	for (const t of scanned[userIdx]) if (t.groupDir) userGroups.add(t.groupDir);
+	for (const t of scanned[userIdx]) if (t.groupDir && !invalidUserToolGroups.has(t.groupDir)) userGroups.add(t.groupDir);
 
 	// Resolve the winner per tool name (higher layer wins — matches the
 	// PackResolver), but emit in first-seen low→high order so prompt/doc output
@@ -445,9 +495,14 @@ export class ToolManager {
 		this.builtinToolsDir = builtinToolsDir ?? defaultBuiltinToolsDir();
 	}
 
-	private configGroupHasInvalidBobbitExtension(groupDir: string): boolean {
-		const tools = scanToolsDirCached(this.toolsDir, this.toolsDir).filter((tool) => tool.groupDir === groupDir);
+	private configGroupHasInvalidExtension(groupDir: string): boolean {
 		let invalid = false;
+		const tools = scanToolsDirCached(this.toolsDir, this.toolsDir).filter((tool) => tool.groupDir === groupDir);
+		const groupDiagnostic = invalidConfigGroupExtensionDiagnostic(this.toolsDir, groupDir, "extension.ts", tools);
+		if (groupDiagnostic) {
+			logToolExtensionDiagnostic(groupDiagnostic);
+			invalid = true;
+		}
 		for (const tool of tools) {
 			const diagnostic = invalidConfigToolDiagnostic(tool);
 			if (!diagnostic) continue;
@@ -497,7 +552,7 @@ export class ToolManager {
 		// config-level bobbit-extension providers must not shadow bundled tools.
 		const configGroup = path.join(this.toolsDir, groupDir);
 		try {
-			if (!isIgnoredToolGroupDir(groupDir) && fs.statSync(configGroup).isDirectory() && !this.configGroupHasInvalidBobbitExtension(groupDir)) return this.toolsDir;
+			if (!isIgnoredToolGroupDir(groupDir) && fs.statSync(configGroup).isDirectory() && !this.configGroupHasInvalidExtension(groupDir)) return this.toolsDir;
 		} catch { /* not found */ }
 
 		// Check builtins
@@ -688,9 +743,19 @@ export class ToolManager {
 
 	/** Invalid active config-level tool override diagnostics for this manager's config dir. */
 	getToolDiagnostics(): ToolExtensionDiagnostic[] {
-		const diagnostics = collectInvalidConfigToolDiagnostics(scanToolsDir(this.toolsDir, this.toolsDir));
-		for (const diagnostic of diagnostics) logToolExtensionDiagnostic(diagnostic);
-		return diagnostics;
+		const diagnostics = [
+			...collectInvalidConfigGroupExtensionDiagnostics(this.toolsDir),
+			...collectInvalidConfigToolDiagnostics(scanToolsDir(this.toolsDir, this.toolsDir)),
+		];
+		const seen = new Set<string>();
+		const unique = diagnostics.filter((diagnostic) => {
+			const key = `${diagnostic.toolName}\0${diagnostic.extensionPath}\0${diagnostic.message}`;
+			if (seen.has(key)) return false;
+			seen.add(key);
+			return true;
+		});
+		for (const diagnostic of unique) logToolExtensionDiagnostic(diagnostic);
+		return unique;
 	}
 
 	/** Returns all tools, re-scanning the YAML directory on every call. */

--- a/src/server/agent/tool-manager.ts
+++ b/src/server/agent/tool-manager.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import type { GrantPolicy } from "./role-store.js";
 import { profile } from "./profiling.js";
 import { parseContributions, computeRendererKind, type ToolContributions } from "./tool-contributions.js";
+import { __resetToolExtensionPreflightDiagnostics, isIgnoredToolGroupDir, logToolExtensionDiagnostic, preflightConfigBobbitExtension, type ToolExtensionDiagnostic } from "./tool-extension-preflight.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -164,7 +165,7 @@ function scanToolsDir(toolsDir: string, baseDir: string): BaseToolInfo[] {
 
 		// First pass: scan group subdirectories (tools/<group>/*.yaml)
 		for (const entry of entries) {
-			if (!entry.isDirectory()) continue;
+			if (!entry.isDirectory() || isIgnoredToolGroupDir(entry.name)) continue;
 			const groupDir = entry.name;
 			const groupPath = path.join(toolsDir, groupDir);
 			try {
@@ -281,6 +282,25 @@ function scanToolsDirCached(toolsDir: string, baseDir: string): BaseToolInfo[] {
 /** Test/maintenance hook: drop the scan cache. */
 export function __resetToolScanCache(): void {
 	_scanCache.clear();
+	__resetToolExtensionPreflightDiagnostics();
+}
+
+function invalidConfigToolDiagnostic(tool: BaseToolInfo): ToolExtensionDiagnostic | undefined {
+	return preflightConfigBobbitExtension({
+		toolName: tool.name,
+		groupDir: tool.groupDir,
+		baseDir: tool.baseDir,
+		provider: tool.provider,
+	});
+}
+
+function filterInvalidConfigTools(tools: BaseToolInfo[]): BaseToolInfo[] {
+	return tools.filter((tool) => {
+		const diagnostic = invalidConfigToolDiagnostic(tool);
+		if (!diagnostic) return true;
+		logToolExtensionDiagnostic(diagnostic);
+		return false;
+	});
 }
 
 /**
@@ -332,7 +352,10 @@ function _loadToolDefinitions(toolsDir: string, builtinToolsDir?: string, market
 	layers.push({ dir: toolsDir, isBuiltin: false }); // user `toolsDir` (highest)
 	const userIdx = layers.length - 1;
 
-	const scanned = layers.map((l) => scanToolsDirCached(l.dir, l.dir));
+	const scanned = layers.map((l, idx) => {
+		const tools = scanToolsDirCached(l.dir, l.dir);
+		return idx === userIdx ? filterInvalidConfigTools(tools) : tools;
+	});
 
 	// Builtin ↔ user whole-group replace (legacy, ONLY this pair): a group the
 	// USER layer defines fully shadows the SAME group in the BUILTIN layer.
@@ -406,6 +429,18 @@ export class ToolManager {
 		this.builtinToolsDir = builtinToolsDir ?? defaultBuiltinToolsDir();
 	}
 
+	private configGroupHasInvalidBobbitExtension(groupDir: string): boolean {
+		const tools = scanToolsDirCached(this.toolsDir, this.toolsDir).filter((tool) => tool.groupDir === groupDir);
+		let invalid = false;
+		for (const tool of tools) {
+			const diagnostic = invalidConfigToolDiagnostic(tool);
+			if (!diagnostic) continue;
+			logToolExtensionDiagnostic(diagnostic);
+			invalid = true;
+		}
+		return invalid;
+	}
+
 	/**
 	 * Late-bind the installed market-pack `tools/` roots provider (design §3.2).
 	 * A root may be a bare `dir` string (no activation filtering) or a
@@ -442,10 +477,11 @@ export class ToolManager {
 	 * Config-level (toolsDir) takes priority over builtins.
 	 */
 	getToolGroupBaseDir(groupDir: string): string {
-		// Check config-level first
+		// Check config-level first. Archived/disabled groups and groups with broken
+		// config-level bobbit-extension providers must not shadow bundled tools.
 		const configGroup = path.join(this.toolsDir, groupDir);
 		try {
-			if (fs.statSync(configGroup).isDirectory()) return this.toolsDir;
+			if (!isIgnoredToolGroupDir(groupDir) && fs.statSync(configGroup).isDirectory() && !this.configGroupHasInvalidBobbitExtension(groupDir)) return this.toolsDir;
 		} catch { /* not found */ }
 
 		// Check builtins
@@ -619,7 +655,7 @@ export class ToolManager {
 	 */
 	getLocalTools(): ToolInfo[] {
 		// Scan only the config-level tools dir — no builtins
-		const tools = scanToolsDir(this.toolsDir, this.toolsDir);
+		const tools = filterInvalidConfigTools(scanToolsDir(this.toolsDir, this.toolsDir));
 		return tools.map((tool) => ({
 			name: tool.name,
 			description: tool.description,

--- a/src/server/agent/tool-manager.ts
+++ b/src/server/agent/tool-manager.ts
@@ -725,8 +725,16 @@ export class ToolManager {
 	 * Used by the config cascade to determine which tools are server/project overrides.
 	 */
 	getLocalTools(): ToolInfo[] {
-		// Scan only the config-level tools dir — no builtins
-		const tools = filterInvalidConfigTools(scanToolsDir(this.toolsDir, this.toolsDir));
+		// Scan only the config-level tools dir — no builtins. Apply the same
+		// invalid direct group-extension filtering as runtime resolution so the
+		// config cascade and /api/tools do not advertise overrides that launch will skip.
+		const scanned = scanToolsDir(this.toolsDir, this.toolsDir);
+		const invalidGroupExtensions = new Set<string>();
+		for (const diagnostic of collectInvalidConfigGroupExtensionDiagnostics(this.toolsDir, scanned)) {
+			logToolExtensionDiagnostic(diagnostic);
+			invalidGroupExtensions.add(diagnostic.groupDir);
+		}
+		const tools = filterInvalidConfigTools(scanned, invalidGroupExtensions);
 		return tools.map((tool) => ({
 			name: tool.name,
 			description: tool.description,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -6696,6 +6696,31 @@ async function handleApiRoute(
 
 	// ── Role endpoints ─────────────────────────────────────────────
 
+	const toolDiagnosticsForProject = (projectId?: string): Array<Record<string, unknown>> => {
+		const diagnostics: Array<Record<string, unknown>> = [];
+		const seen = new Set<string>();
+		const add = (rows: Array<Record<string, unknown>> | undefined): void => {
+			for (const row of rows ?? []) {
+				const key = `${row.toolName ?? row.tool ?? ""}\0${row.extensionPath ?? row.path ?? ""}\0${row.message ?? ""}`;
+				if (seen.has(key)) continue;
+				seen.add(key);
+				diagnostics.push(row);
+			}
+		};
+		if (toolManager) add(toolManager.getToolDiagnostics() as unknown as Array<Record<string, unknown>>);
+		if (projectId) add(projectContextManager.getOrCreate(projectId)?.toolManager.getToolDiagnostics() as unknown as Array<Record<string, unknown>> | undefined);
+		return diagnostics;
+	};
+	const attachToolDiagnostics = (tools: Array<Record<string, unknown>>, diagnostics: Array<Record<string, unknown>>): void => {
+		if (diagnostics.length === 0) return;
+		for (const tool of tools) {
+			const name = typeof tool.name === "string" ? tool.name : undefined;
+			if (!name) continue;
+			const related = diagnostics.filter((diagnostic) => diagnostic.toolName === name || diagnostic.tool === name || diagnostic.name === name);
+			if (related.length > 0) tool.diagnostics = related;
+		}
+	};
+
 	// GET /api/tools — list available agent tools (with cascade origin)
 	if (url.pathname === "/api/tools" && req.method === "GET") {
 		const projectId = url.searchParams.get("projectId") || undefined;
@@ -6729,7 +6754,9 @@ async function handleApiRoute(
 			}
 		}
 		appendPiExtensionToolRows(tools, buildPiExtensionToolRows(sessionManager.resolveMarketplacePiExtensionContributions(projectId)));
-		json({ tools });
+		const toolDiagnostics = toolDiagnosticsForProject(projectId);
+		attachToolDiagnostics(tools, toolDiagnostics);
+		json({ tools, diagnostics: toolDiagnostics, toolDiagnostics });
 		return;
 	}
 
@@ -6754,6 +6781,7 @@ async function handleApiRoute(
 			// Without this, the tools edit page replaces the cascade list item with the
 			// raw detail and a market-pack tool loses its origin badge + read-only state.
 			const cascadeEntry = configCascade.resolveTools(projectId).find(r => r.item.name === name);
+			const toolDiagnostics = toolDiagnosticsForProject(projectId);
 			if (cascadeEntry && tool) {
 				const withMeta = withOrigin(cascadeEntry as any);
 				// pack-schema-v1: mirror the LIST endpoint's structural packId so the
@@ -6761,13 +6789,17 @@ async function handleApiRoute(
 				const packId = cascadeEntry.originPackId ? resolvePackIdentityForTool(tm, name).packId : "";
 				const detail: Record<string, unknown> = { ...tool, origin: withMeta.origin, ...(withMeta.overrides ? { overrides: withMeta.overrides } : {}), originPackId: withMeta.originPackId, originPackName: withMeta.originPackName, ...(packId ? { packId } : {}) };
 				if (piTool) appendPiExtensionToolRows([detail], [piTool]);
+				attachToolDiagnostics([detail], toolDiagnostics);
 				json(detail);
 			} else if (tool) {
 				const detail: Record<string, unknown> = { ...tool };
 				if (piTool) appendPiExtensionToolRows([detail], [piTool]);
+				attachToolDiagnostics([detail], toolDiagnostics);
 				json(detail);
 			} else {
-				json(piTool);
+				const detail: Record<string, unknown> = { ...(piTool as Record<string, unknown>) };
+				attachToolDiagnostics([detail], toolDiagnostics);
+				json(detail);
 			}
 			return;
 		}

--- a/tests/tool-startup-resilience.test.ts
+++ b/tests/tool-startup-resilience.test.ts
@@ -246,6 +246,11 @@ describe("tool startup resilience", () => {
 		assert.ok(diagnostics.some((d) => d.groupDir === "_builtins" && /broken config builtins/.test(d.message)));
 		assert.ok(diagnostics.some((d) => d.groupDir === "shell" && /broken config shell/.test(d.message)));
 		assert.equal(tm.getToolByName("bash")?.description, "bundled bash");
+		assert.equal(
+			tm.getLocalTools().some((tool) => tool.name === "bash"),
+			false,
+			"config cascade local tools must skip direct group-extension failures so /api/tools shows the bundled fallback",
+		);
 	});
 
 	it("keeps valid same-group overrides while falling back only invalid tools", () => {
@@ -303,6 +308,38 @@ describe("tool startup resilience", () => {
 		assert.deepEqual(tm.getToolDiagnostics(), []);
 		assert.equal(tm.getToolByName("session_prompt")?.description, "valid copied config session prompt override");
 		assert.ok(activeExtensions.some((p) => path.resolve(p) === path.resolve(fixture.configAgentExtension)));
+	});
+
+	it("preserves valid TypeScript overrides that import project-local packages", () => {
+		const fixture = makeAgentFixture();
+		const projectRoot = path.dirname(path.dirname(fixture.configDir));
+		const pkgDir = path.join(projectRoot, "node_modules", "project-local-tool-dep");
+		writeFile(path.join(pkgDir, "package.json"), JSON.stringify({ type: "module", exports: "./index.js" }));
+		writeFile(path.join(pkgDir, "index.js"), "export const projectLocalOk = true;\n");
+		writeTool(fixture.configToolsDir, "agent", "session_prompt.yaml", {
+			name: "session_prompt",
+			description: "valid project-local package override",
+		});
+		writeFile(fixture.configAgentExtension, [
+			"import { projectLocalOk } from 'project-local-tool-dep';",
+			"if (!projectLocalOk) throw new Error('project local package import failed');",
+			"export default function extension() { return { projectLocalOk }; }",
+			"",
+		].join("\n"));
+
+		__resetToolScanCache();
+		const tm = new ToolManager(fixture.configDir, fixture.builtinToolsDir);
+		const result = computeToolActivationArgs([{ kind: "yaml", name: "session_prompt" }], tm);
+		const activeExtensions = nonBuiltinExtensionPaths(result.args);
+
+		assert.deepEqual(tm.getToolDiagnostics(), []);
+		assert.equal(tm.getToolByName("session_prompt")?.description, "valid project-local package override");
+		assert.ok(activeExtensions.some((p) => path.resolve(p) === path.resolve(fixture.configAgentExtension)));
+	});
+
+	it("does not depend on dev-only esbuild for runtime preflight", () => {
+		const source = fs.readFileSync(path.resolve("src/server/agent/tool-extension-preflight.ts"), "utf-8");
+		assert.doesNotMatch(source, /\besbuild\b/);
 	});
 
 	it("omits and diagnoses a broken config-only extension instead of activating it", () => {

--- a/tests/tool-startup-resilience.test.ts
+++ b/tests/tool-startup-resilience.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { parseToolsDir } from "../src/server/agent/builtin-config.ts";
+import { computeToolActivationArgs, type EffectiveTool } from "../src/server/agent/tool-activation.ts";
+import { ToolManager, __resetToolScanCache } from "../src/server/agent/tool-manager.ts";
+
+const roots: string[] = [];
+
+afterEach(() => {
+	__resetToolScanCache();
+	for (const root of roots.splice(0)) {
+		try { fs.rmSync(root, { recursive: true, force: true }); } catch { /* ignore */ }
+	}
+});
+
+function tempRoot(): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "tool-startup-resilience-"));
+	roots.push(root);
+	return root;
+}
+
+function writeFile(file: string, content: string): void {
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, content, "utf-8");
+}
+
+function writeTool(toolsDir: string, groupDir: string, fileName: string, opts: {
+	name: string;
+	description: string;
+	provider?: string;
+}): void {
+	writeFile(path.join(toolsDir, groupDir, fileName), [
+		`name: ${opts.name}`,
+		`description: ${opts.description}`,
+		"group: Agent",
+		opts.provider ?? "provider:\n  type: bobbit-extension\n  extension: extension.ts",
+		"",
+	].join("\n"));
+}
+
+function extensionPaths(args: string[]): string[] {
+	const out: string[] = [];
+	for (let i = 0; i < args.length - 1; i++) {
+		if (args[i] === "--extension") out.push(path.normalize(args[i + 1]));
+	}
+	return out;
+}
+
+function nonBuiltinExtensionPaths(args: string[]): string[] {
+	return extensionPaths(args).filter((p) => !p.endsWith(path.join("_builtins", "extension.ts")));
+}
+
+function captureToolDiagnostics(fn: () => void): string {
+	const messages: string[] = [];
+	const originalWarn = console.warn;
+	const originalError = console.error;
+	console.warn = (...args: unknown[]) => { messages.push(args.map(String).join(" ")); };
+	console.error = (...args: unknown[]) => { messages.push(args.map(String).join(" ")); };
+	try {
+		fn();
+	} finally {
+		console.warn = originalWarn;
+		console.error = originalError;
+	}
+	return messages.join("\n");
+}
+
+function makeAgentFixture(): {
+	configDir: string;
+	builtinToolsDir: string;
+	configToolsDir: string;
+	builtinAgentExtension: string;
+	configAgentExtension: string;
+} {
+	const root = tempRoot();
+	const configDir = path.join(root, "project", ".bobbit", "config");
+	const configToolsDir = path.join(configDir, "tools");
+	const builtinToolsDir = path.join(root, "defaults", "tools");
+	const builtinAgentExtension = path.join(builtinToolsDir, "agent", "extension.ts");
+	const configAgentExtension = path.join(configToolsDir, "agent", "extension.ts");
+
+	writeTool(builtinToolsDir, "agent", "session_prompt.yaml", {
+		name: "session_prompt",
+		description: "bundled session prompt",
+	});
+	writeFile(builtinAgentExtension, "export default function extension() { return {}; }\n");
+	fs.mkdirSync(configToolsDir, { recursive: true });
+
+	return { configDir, builtinToolsDir, configToolsDir, builtinAgentExtension, configAgentExtension };
+}
+
+describe("tool startup resilience", () => {
+	it("rejects a broken active config agent override and falls back to bundled session_prompt", () => {
+		const fixture = makeAgentFixture();
+		writeTool(fixture.configToolsDir, "agent", "session_prompt.yaml", {
+			name: "session_prompt",
+			description: "broken config session prompt override",
+		});
+		writeFile(fixture.configAgentExtension, [
+			"import './missing-local-gateway.js';",
+			"export default function extension() { return {}; }",
+			"",
+		].join("\n"));
+
+		__resetToolScanCache();
+		const tm = new ToolManager(fixture.configDir, fixture.builtinToolsDir);
+
+		assert.equal(
+			tm.getToolByName("session_prompt")?.description,
+			"bundled session prompt",
+			"invalid config-level agent override must not shadow bundled session_prompt",
+		);
+
+		const provider = tm.getToolProviders().get("session_prompt");
+		assert.ok(provider, "session_prompt must still have a provider via bundled fallback");
+		assert.equal(path.resolve(provider.baseDir), path.resolve(fixture.builtinToolsDir));
+
+		const result = computeToolActivationArgs([{ kind: "yaml", name: "session_prompt" }], tm);
+		const activeExtensions = nonBuiltinExtensionPaths(result.args);
+		assert.ok(
+			activeExtensions.some((p) => path.resolve(p) === path.resolve(fixture.builtinAgentExtension)),
+			`expected bundled agent extension activation, got ${JSON.stringify(activeExtensions)}`,
+		);
+		assert.ok(
+			!activeExtensions.some((p) => path.resolve(p) === path.resolve(fixture.configAgentExtension)),
+			"broken config agent extension must not become runtime activation",
+		);
+	});
+
+	it("ignores dot-prefixed and disabled/archive config tool-group directories", () => {
+		const archiveNames = [".agent", "agent.disabled", "agent.disabled-20260630", "agent.disabled_backup"];
+
+		for (const archiveName of archiveNames) {
+			const fixture = makeAgentFixture();
+			writeTool(fixture.configToolsDir, archiveName, "session_prompt.yaml", {
+				name: "session_prompt",
+				description: `archived override from ${archiveName}`,
+			});
+			writeTool(fixture.configToolsDir, archiveName, "archived_only.yaml", {
+				name: `archived_only_${archiveName.replace(/[^a-z0-9]/gi, "_")}`,
+				description: `archived-only tool from ${archiveName}`,
+			});
+			writeFile(path.join(fixture.configToolsDir, archiveName, "extension.ts"), "export default function extension() { return {}; }\n");
+
+			__resetToolScanCache();
+			const tm = new ToolManager(fixture.configDir, fixture.builtinToolsDir);
+			assert.equal(
+				tm.getToolByName("session_prompt")?.description,
+				"bundled session prompt",
+				`archived group ${archiveName} must not override bundled tools`,
+			);
+			assert.ok(
+				!tm.getAllToolNames().some((name) => name.startsWith("archived_only_")),
+				`archived group ${archiveName} must not contribute custom tools`,
+			);
+
+			const apiNames = parseToolsDir(fixture.configToolsDir).map((tool) => tool.name);
+			assert.deepEqual(apiNames, [], `parseToolsDir must ignore archived group ${archiveName} for /api/tools consistency`);
+		}
+	});
+
+	it("omits and diagnoses a broken config-only extension instead of activating it", () => {
+		const root = tempRoot();
+		const configDir = path.join(root, "project", ".bobbit", "config");
+		const configToolsDir = path.join(configDir, "tools");
+		const builtinToolsDir = path.join(root, "defaults", "tools");
+		const customExtension = path.join(configToolsDir, "custom", "extension.ts");
+
+		writeTool(configToolsDir, "custom", "broken_custom.yaml", {
+			name: "broken_custom",
+			description: "broken config-only extension tool",
+			provider: "provider:\n  type: bobbit-extension\n  extension: extension.ts",
+		});
+		writeFile(customExtension, [
+			"import './missing-local-helper.js';",
+			"export default function extension() { return {}; }",
+			"",
+		].join("\n"));
+
+		__resetToolScanCache();
+		const tm = new ToolManager(configDir, builtinToolsDir);
+		let result: ReturnType<typeof computeToolActivationArgs> | undefined;
+		const diagnostics = captureToolDiagnostics(() => {
+			assert.equal(
+				tm.getToolProviders().has("broken_custom"),
+				false,
+				"broken config-only extension must not expose a runtime provider",
+			);
+			const allowed: EffectiveTool[] = [{ kind: "yaml", name: "broken_custom" }];
+			result = computeToolActivationArgs(allowed, tm);
+		});
+
+		assert.ok(result, "activation args should be computed without throwing");
+		assert.ok(
+			!nonBuiltinExtensionPaths(result!.args).some((p) => path.resolve(p) === path.resolve(customExtension)),
+			"broken config-only extension must not become runtime activation",
+		);
+		assert.match(
+			diagnostics,
+			/broken_custom|missing-local-helper|custom[\\/]extension\.ts/i,
+			"broken config-only extension must emit a clear diagnostic",
+		);
+	});
+});

--- a/tests/tool-startup-resilience.test.ts
+++ b/tests/tool-startup-resilience.test.ts
@@ -187,13 +187,12 @@ describe("tool startup resilience", () => {
 		assert.match(diagnostics[0].message, /missing-local-gateway|agent[\\/]extension\.ts/i);
 	});
 
-	it("catches module-load failures before activating a config override", () => {
+	it("catches TypeScript module-load failures before activating a config override", () => {
 		const fixture = makeAgentFixture();
-		const configExtension = path.join(fixture.configToolsDir, "agent", "extension.mjs");
+		const configExtension = path.join(fixture.configToolsDir, "agent", "extension.ts");
 		writeTool(fixture.configToolsDir, "agent", "session_prompt.yaml", {
 			name: "session_prompt",
 			description: "throwing config session prompt override",
-			provider: "provider:\n  type: bobbit-extension\n  extension: extension.mjs",
 		});
 		writeFile(configExtension, "throw new Error('boom during module load');\nexport default function extension() { return {}; }\n");
 
@@ -205,11 +204,105 @@ describe("tool startup resilience", () => {
 		assert.equal(tm.getToolByName("session_prompt")?.description, "bundled session prompt");
 		assert.equal(diagnostics.length, 1);
 		assert.equal(diagnostics[0].code, "module-load-failed");
-		assert.match(diagnostics[0].message, /boom during module load|extension\.js/i);
+		assert.match(diagnostics[0].message, /boom during module load|extension\.ts/i);
 		assert.ok(
 			!nonBuiltinExtensionPaths(result.args).some((p) => path.resolve(p) === path.resolve(configExtension)),
 			"throwing config extension must not become runtime activation",
 		);
+	});
+
+	it("falls back from invalid config _builtins and shell extension files before launch", () => {
+		const fixture = makeAgentFixture();
+		const builtinBuiltinsExtension = path.join(fixture.builtinToolsDir, "_builtins", "extension.ts");
+		const configBuiltinsExtension = path.join(fixture.configToolsDir, "_builtins", "extension.ts");
+		const builtinShellExtension = path.join(fixture.builtinToolsDir, "shell", "extension.ts");
+		const configShellExtension = path.join(fixture.configToolsDir, "shell", "extension.ts");
+
+		writeTool(fixture.builtinToolsDir, "shell", "bash.yaml", {
+			name: "bash",
+			description: "bundled bash",
+			provider: "provider:\n  type: builtin\n  tool: bash",
+		});
+		writeFile(builtinBuiltinsExtension, "export default function extension() { return {}; }\n");
+		writeFile(builtinShellExtension, "export default function extension() { return {}; }\n");
+		writeFile(configBuiltinsExtension, "throw new Error('broken config builtins');\nexport default function extension() { return {}; }\n");
+		writeTool(fixture.configToolsDir, "shell", "bash.yaml", {
+			name: "bash",
+			description: "config bash with broken extension",
+			provider: "provider:\n  type: builtin\n  tool: bash",
+		});
+		writeFile(configShellExtension, "throw new Error('broken config shell');\nexport default function extension() { return {}; }\n");
+
+		__resetToolScanCache();
+		const tm = new ToolManager(fixture.configDir, fixture.builtinToolsDir);
+		const result = computeToolActivationArgs([{ kind: "yaml", name: "bash" }], tm);
+		const activeExtensions = extensionPaths(result.args);
+		const diagnostics = tm.getToolDiagnostics();
+
+		assert.ok(activeExtensions.some((p) => path.resolve(p) === path.resolve(builtinBuiltinsExtension)));
+		assert.ok(activeExtensions.some((p) => path.resolve(p) === path.resolve(builtinShellExtension)));
+		assert.ok(!activeExtensions.some((p) => path.resolve(p) === path.resolve(configBuiltinsExtension)));
+		assert.ok(!activeExtensions.some((p) => path.resolve(p) === path.resolve(configShellExtension)));
+		assert.ok(diagnostics.some((d) => d.groupDir === "_builtins" && /broken config builtins/.test(d.message)));
+		assert.ok(diagnostics.some((d) => d.groupDir === "shell" && /broken config shell/.test(d.message)));
+		assert.equal(tm.getToolByName("bash")?.description, "bundled bash");
+	});
+
+	it("keeps valid same-group overrides while falling back only invalid tools", () => {
+		const fixture = makeAgentFixture();
+		const validExtension = path.join(fixture.configToolsDir, "agent", "valid-extension.ts");
+		writeTool(fixture.configToolsDir, "agent", "session_prompt.yaml", {
+			name: "session_prompt",
+			description: "broken config session prompt override",
+		});
+		writeTool(fixture.configToolsDir, "agent", "valid_agent_tool.yaml", {
+			name: "valid_agent_tool",
+			description: "valid config agent tool",
+			provider: "provider:\n  type: bobbit-extension\n  extension: valid-extension.ts",
+		});
+		writeFile(fixture.configAgentExtension, [
+			"import './missing-local-gateway.js';",
+			"export default function extension() { return {}; }",
+			"",
+		].join("\n"));
+		writeFile(validExtension, "export default function extension() { return {}; }\n");
+
+		__resetToolScanCache();
+		const tm = new ToolManager(fixture.configDir, fixture.builtinToolsDir);
+		const result = computeToolActivationArgs([
+			{ kind: "yaml", name: "session_prompt" },
+			{ kind: "yaml", name: "valid_agent_tool" },
+		], tm);
+		const activeExtensions = nonBuiltinExtensionPaths(result.args);
+
+		assert.equal(tm.getToolByName("session_prompt")?.description, "bundled session prompt");
+		assert.equal(tm.getToolByName("valid_agent_tool")?.description, "valid config agent tool");
+		assert.ok(activeExtensions.some((p) => path.resolve(p) === path.resolve(fixture.builtinAgentExtension)));
+		assert.ok(activeExtensions.some((p) => path.resolve(p) === path.resolve(validExtension)));
+		assert.ok(!activeExtensions.some((p) => path.resolve(p) === path.resolve(fixture.configAgentExtension)));
+	});
+
+	it("preserves valid copied TypeScript overrides that import Bobbit dependencies", () => {
+		const fixture = makeAgentFixture();
+		writeTool(fixture.configToolsDir, "agent", "session_prompt.yaml", {
+			name: "session_prompt",
+			description: "valid copied config session prompt override",
+		});
+		writeFile(fixture.configAgentExtension, [
+			"import { Type } from '@sinclair/typebox';",
+			"const schema = Type.Object({ ok: Type.Boolean() });",
+			"export default function extension() { return { schema }; }",
+			"",
+		].join("\n"));
+
+		__resetToolScanCache();
+		const tm = new ToolManager(fixture.configDir, fixture.builtinToolsDir);
+		const result = computeToolActivationArgs([{ kind: "yaml", name: "session_prompt" }], tm);
+		const activeExtensions = nonBuiltinExtensionPaths(result.args);
+
+		assert.deepEqual(tm.getToolDiagnostics(), []);
+		assert.equal(tm.getToolByName("session_prompt")?.description, "valid copied config session prompt override");
+		assert.ok(activeExtensions.some((p) => path.resolve(p) === path.resolve(fixture.configAgentExtension)));
 	});
 
 	it("omits and diagnoses a broken config-only extension instead of activating it", () => {

--- a/tests/tool-startup-resilience.test.ts
+++ b/tests/tool-startup-resilience.test.ts
@@ -163,6 +163,55 @@ describe("tool startup resilience", () => {
 		}
 	});
 
+	it("exposes diagnostics for a broken config override while bundled fallback wins", () => {
+		const fixture = makeAgentFixture();
+		writeTool(fixture.configToolsDir, "agent", "session_prompt.yaml", {
+			name: "session_prompt",
+			description: "broken config session prompt override",
+		});
+		writeFile(fixture.configAgentExtension, [
+			"import './missing-local-gateway.js';",
+			"export default function extension() { return {}; }",
+			"",
+		].join("\n"));
+
+		__resetToolScanCache();
+		const tm = new ToolManager(fixture.configDir, fixture.builtinToolsDir);
+		const tools = tm.getAvailableTools();
+		const diagnostics = tm.getToolDiagnostics();
+
+		assert.equal(tools.find((tool) => tool.name === "session_prompt")?.description, "bundled session prompt");
+		assert.equal(diagnostics.length, 1);
+		assert.equal(diagnostics[0].toolName, "session_prompt");
+		assert.equal(diagnostics[0].code, "missing-local-import");
+		assert.match(diagnostics[0].message, /missing-local-gateway|agent[\\/]extension\.ts/i);
+	});
+
+	it("catches module-load failures before activating a config override", () => {
+		const fixture = makeAgentFixture();
+		const configExtension = path.join(fixture.configToolsDir, "agent", "extension.mjs");
+		writeTool(fixture.configToolsDir, "agent", "session_prompt.yaml", {
+			name: "session_prompt",
+			description: "throwing config session prompt override",
+			provider: "provider:\n  type: bobbit-extension\n  extension: extension.mjs",
+		});
+		writeFile(configExtension, "throw new Error('boom during module load');\nexport default function extension() { return {}; }\n");
+
+		__resetToolScanCache();
+		const tm = new ToolManager(fixture.configDir, fixture.builtinToolsDir);
+		const diagnostics = tm.getToolDiagnostics();
+		const result = computeToolActivationArgs([{ kind: "yaml", name: "session_prompt" }], tm);
+
+		assert.equal(tm.getToolByName("session_prompt")?.description, "bundled session prompt");
+		assert.equal(diagnostics.length, 1);
+		assert.equal(diagnostics[0].code, "module-load-failed");
+		assert.match(diagnostics[0].message, /boom during module load|extension\.js/i);
+		assert.ok(
+			!nonBuiltinExtensionPaths(result.args).some((p) => path.resolve(p) === path.resolve(configExtension)),
+			"throwing config extension must not become runtime activation",
+		);
+	});
+
 	it("omits and diagnoses a broken config-only extension instead of activating it", () => {
 		const root = tempRoot();
 		const configDir = path.join(root, "project", ".bobbit", "config");


### PR DESCRIPTION
## Summary
- skip invalid config-level tool overrides before agent launch and fall back to bundled/market tools when available
- add production-safe extension preflight with diagnostics surfaced in logs and the Tools page
- make bundled session_prompt helper packaging self-contained and document override archive/disable behavior

## Validation
- npm run check
- npx tsx --test tests/tool-startup-resilience.test.ts
- npm run test:e2e -- tests/e2e/tools-api.spec.ts tests/e2e/tools-cascade.spec.ts
- implementation and documentation workflow gates passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
