### PR TITLE
Collapse JSON tool payloads by default

### DIFF
--- a/src/ui/tools/renderers/DefaultRenderer.ts
+++ b/src/ui/tools/renderers/DefaultRenderer.ts
@@ -7,6 +7,7 @@ import type { ToolRenderer, ToolRenderResult } from "../types.js";
 import { renderInlineImages } from "./image-utils.js";
 
 const ERROR_PREVIEW_MAX_LENGTH = 500;
+let payloadSectionId = 0;
 
 function truncateErrorPreview(text: string): string {
 	const trimmed = text.trim();
@@ -37,23 +38,35 @@ export class DefaultRenderer implements ToolRenderer {
 
 	private renderPayloadSection(label: string, code: string, language: string) {
 		const payloadType = language === "json" ? "JSON" : "text";
+		const payloadId = `default-payload-${++payloadSectionId}`;
 		const onToggle = (event: Event) => {
-			const details = event.currentTarget as HTMLDetailsElement;
-			details.querySelector('[data-state="collapsed"]')?.toggleAttribute("hidden", details.open);
-			details.querySelector('[data-state="expanded"]')?.toggleAttribute("hidden", !details.open);
+			const button = event.currentTarget as HTMLButtonElement;
+			const section = button.closest("[data-default-payload-section]");
+			const expanded = button.getAttribute("aria-expanded") === "true";
+			const nextExpanded = !expanded;
+			button.setAttribute("aria-expanded", String(nextExpanded));
+			section?.querySelector<HTMLElement>(`[data-payload-region="${payloadId}"]`)?.toggleAttribute("hidden", !nextExpanded);
+			section?.querySelector('[data-state="collapsed"]')?.toggleAttribute("hidden", nextExpanded);
+			section?.querySelector('[data-state="expanded"]')?.toggleAttribute("hidden", !nextExpanded);
 		};
 
 		return html`
-			<details class="rounded-md border border-border bg-muted/20 p-2" data-default-payload-section @toggle=${onToggle}>
-				<summary class="cursor-pointer select-none rounded-sm text-xs font-medium text-muted-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]">
+			<div class="rounded-md border border-border bg-muted/20 p-2" data-default-payload-section>
+				<button
+					type="button"
+					class="cursor-pointer select-none rounded-sm text-left text-xs font-medium text-muted-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+					aria-expanded="false"
+					aria-controls=${payloadId}
+					@click=${onToggle}
+				>
 					${label} ${payloadType} payload
 					<span class="font-normal opacity-80" data-state="collapsed">(collapsed; expand to inspect)</span>
 					<span class="font-normal opacity-80" data-state="expanded" hidden>(expanded)</span>
-				</summary>
-				<div class="mt-2">
+				</button>
+				<div id=${payloadId} data-payload-region=${payloadId} class="mt-2" hidden>
 					<code-block .code=${code} language=${language}></code-block>
 				</div>
-			</details>
+			</div>
 		`;
 	}
 

--- a/src/ui/tools/renderers/DefaultRenderer.ts
+++ b/src/ui/tools/renderers/DefaultRenderer.ts
@@ -6,6 +6,14 @@ import { renderHeader, getToolState } from "../renderer-registry.js";
 import type { ToolRenderer, ToolRenderResult } from "../types.js";
 import { renderInlineImages } from "./image-utils.js";
 
+const ERROR_PREVIEW_MAX_LENGTH = 500;
+
+function truncateErrorPreview(text: string): string {
+	const trimmed = text.trim();
+	if (trimmed.length <= ERROR_PREVIEW_MAX_LENGTH) return trimmed;
+	return `${trimmed.slice(0, ERROR_PREVIEW_MAX_LENGTH)}…`;
+}
+
 export class DefaultRenderer implements ToolRenderer {
 	private toolName?: string;
 
@@ -27,6 +35,28 @@ export class DefaultRenderer implements ToolRenderer {
 			.replace(/\b\w/g, (c) => c.toUpperCase());
 	}
 
+	private renderPayloadSection(label: string, code: string, language: string) {
+		const payloadType = language === "json" ? "JSON" : "text";
+		const onToggle = (event: Event) => {
+			const details = event.currentTarget as HTMLDetailsElement;
+			details.querySelector('[data-state="collapsed"]')?.toggleAttribute("hidden", details.open);
+			details.querySelector('[data-state="expanded"]')?.toggleAttribute("hidden", !details.open);
+		};
+
+		return html`
+			<details class="rounded-md border border-border bg-muted/20 p-2" data-default-payload-section @toggle=${onToggle}>
+				<summary class="cursor-pointer select-none rounded-sm text-xs font-medium text-muted-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]">
+					${label} ${payloadType} payload
+					<span class="font-normal opacity-80" data-state="collapsed">(collapsed; expand to inspect)</span>
+					<span class="font-normal opacity-80" data-state="expanded" hidden>(expanded)</span>
+				</summary>
+				<div class="mt-2">
+					<code-block .code=${code} language=${language}></code-block>
+				</div>
+			</details>
+		`;
+	}
+
 	render(params: any | undefined, result: ToolResultMessage | undefined, isStreaming?: boolean): ToolRenderResult {
 		const state = getToolState(result, isStreaming);
 
@@ -46,11 +76,12 @@ export class DefaultRenderer implements ToolRenderer {
 
 		// With result: show header + params + result
 		if (result) {
-			let outputJson =
+			const rawOutputText =
 				result.content
 					?.filter((c) => c.type === "text")
 					.map((c: any) => c.text)
 					.join("\n") || i18n("(no output)");
+			let outputJson = rawOutputText;
 			let outputLanguage = "text";
 
 			// Try to parse and pretty-print if it's valid JSON
@@ -62,23 +93,15 @@ export class DefaultRenderer implements ToolRenderer {
 				// Not valid JSON, leave as-is and use text highlighting
 			}
 
+			const errorPreview = state === "error" ? truncateErrorPreview(rawOutputText) : "";
 			const images = renderInlineImages(result.content);
 			return {
 				content: html`
 					<div class="space-y-3">
 						${renderHeader(state, Code, this.label)}
-						${
-							paramsJson
-								? html`<div>
-							<div class="text-xs font-medium mb-1 text-muted-foreground">${i18n("Input")}</div>
-							<code-block .code=${paramsJson} language="json"></code-block>
-						</div>`
-								: ""
-						}
-						<div>
-							<div class="text-xs font-medium mb-1 text-muted-foreground">${i18n("Output")}</div>
-							<code-block .code=${outputJson} language="${outputLanguage}"></code-block>
-						</div>
+						${errorPreview ? html`<div class="text-sm text-destructive whitespace-pre-wrap break-words" role="alert">${errorPreview}</div>` : ""}
+						${paramsJson ? this.renderPayloadSection(i18n("Input"), paramsJson, "json") : ""}
+						${this.renderPayloadSection(i18n("Output"), outputJson, outputLanguage)}
 						${images}
 					</div>
 				`,
@@ -103,10 +126,7 @@ export class DefaultRenderer implements ToolRenderer {
 				content: html`
 					<div class="space-y-3">
 						${renderHeader(state, Code, this.label)}
-						<div>
-							<div class="text-xs font-medium mb-1 text-muted-foreground">${i18n("Input")}</div>
-							<code-block .code=${paramsJson} language="json"></code-block>
-						</div>
+						${this.renderPayloadSection(i18n("Input"), paramsJson, "json")}
 					</div>
 				`,
 				isCustom: false,

--- a/tests/children-tool-renderers.spec.ts
+++ b/tests/children-tool-renderers.spec.ts
@@ -21,6 +21,8 @@ const RENDERER_FILES = [
 	"src/ui/tools/renderers/GoalDecideMutationRenderer.ts",
 	"src/ui/tools/renderers/GoalSetPolicyRenderer.ts",
 	"src/ui/tools/renderers/children-renderer-helpers.ts",
+	"src/ui/tools/renderers/DefaultRenderer.ts",
+	"src/ui/components/ExpandableSection.ts",
 	"src/ui/lazy/children-mutation-approval.ts",
 	"src/ui/lazy/children-goal-state-pill.ts",
 ].map(f => path.resolve(f));
@@ -241,7 +243,7 @@ test.describe("remaining children tool success outputs", () => {
 });
 
 test.describe("feature flag off → falls through to DefaultRenderer", () => {
-	test("goal_spawn_child renders raw JSON code-block when flag off", async ({ page }) => {
+	test("goal_spawn_child keeps DefaultRenderer fallback payloads collapsed", async ({ page }) => {
 		await gotoAndWait(page);
 		await page.evaluate(() => {
 			(window as any).__setFlag(false);
@@ -251,8 +253,9 @@ test.describe("feature flag off → falls through to DefaultRenderer", () => {
 					isError: false, content: [{ type: "text", text: JSON.stringify({ id: "g-1" }) }], timestamp: 0 },
 				false);
 		});
-		// DefaultRenderer emits a <code-block> for the JSON payload.
-		await expect(page.locator("#container code-block")).toHaveCount(2);
+		await expect(page.locator("#container")).toContainText("Goal Spawn Child");
+		await expect(page.locator("#container").getByRole("button", { name: /input/i })).toBeVisible();
+		await expect(page.locator("#container").getByRole("button", { name: /output/i })).toBeVisible();
 		await expect(page.locator('[data-testid="children-spawn-title"]')).toHaveCount(0);
 	});
 });

--- a/tests/default-tool-renderer.spec.ts
+++ b/tests/default-tool-renderer.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * Regression coverage for the generic DefaultRenderer payload sections.
+ * Uses a file:// fixture with a tiny test-only <code-block> implementation so
+ * raw payload visibility can be asserted without depending on the app shell.
+ */
+import { test, expect, type Page } from "@playwright/test";
+import path from "node:path";
+import { buildBundle } from "./fixtures/build-bundle.js";
+
+const FIXTURE = path.resolve("tests/fixtures/default-tool-renderer.html");
+const BUNDLE = path.resolve("tests/fixtures/default-tool-renderer-bundle.js");
+const ENTRY = path.resolve("tests/fixtures/default-tool-renderer-entry.ts");
+
+const RENDERER_FILES = [
+	"src/ui/tools/renderers/DefaultRenderer.ts",
+	"src/ui/tools/renderer-registry.ts",
+	"src/ui/components/ExpandableSection.ts",
+].map(f => path.resolve(f));
+
+const PAGE = `file://${FIXTURE}`;
+const INPUT_SENTINEL = "alpha-input-payload-sentinel";
+const OUTPUT_SENTINEL = "omega-output-payload-sentinel";
+const ERROR_SENTINEL = "critical-error-output-sentinel";
+
+test.beforeAll(() => {
+	buildBundle({ entry: ENTRY, outfile: BUNDLE, deps: [ENTRY, ...RENDERER_FILES] });
+});
+
+async function gotoAndWait(page: Page) {
+	await page.goto(PAGE);
+	await page.waitForFunction(() => (window as any).__ready === true, null, { timeout: 10_000 });
+}
+
+async function renderDefaultTool(page: Page, options: { isError?: boolean } = {}) {
+	await page.evaluate(({ input, output, isError }) => {
+		(window as any).__renderDefaultTool(
+			"diagnostic_tool",
+			{ query: input, nested: { count: 2, flag: true } },
+			{ ok: !isError, output, nested: { items: ["one", "two"] } },
+			Boolean(isError),
+		);
+	}, { input: INPUT_SENTINEL, output: options.isError ? ERROR_SENTINEL : OUTPUT_SENTINEL, isError: options.isError });
+}
+
+function payloadControl(page: Page, label: "Input" | "Output") {
+	return page.locator("#container").getByRole("button", { name: new RegExp(label, "i") }).first();
+}
+
+async function payloadTextIsVisiblyPainted(page: Page, text: string): Promise<boolean> {
+	return page.evaluate((needle) => {
+		const container = document.getElementById("container");
+		if (!container) return false;
+
+		const hasUsableRect = (rect: DOMRect) => rect.width > 0 && rect.height > 0;
+		const intersects = (a: DOMRect, b: DOMRect) =>
+			Math.min(a.right, b.right) > Math.max(a.left, b.left) &&
+			Math.min(a.bottom, b.bottom) > Math.max(a.top, b.top);
+
+		const isPainted = (el: Element): boolean => {
+			let rect = el.getBoundingClientRect();
+			if (!hasUsableRect(rect)) return false;
+
+			for (let node: Element | null = el; node && node !== document.documentElement; node = node.parentElement) {
+				const style = window.getComputedStyle(node);
+				if (style.display === "none" || style.visibility === "hidden" || style.opacity === "0") return false;
+				if (node instanceof HTMLDetailsElement && !node.open && !el.closest("summary")) return false;
+
+				const clips = /(hidden|clip|auto|scroll)/.test(`${style.overflow}${style.overflowX}${style.overflowY}`);
+				if (clips) {
+					const ancestorRect = node.getBoundingClientRect();
+					if (!hasUsableRect(ancestorRect) || !intersects(rect, ancestorRect)) return false;
+					rect = new DOMRect(
+						Math.max(rect.left, ancestorRect.left),
+						Math.max(rect.top, ancestorRect.top),
+						Math.max(0, Math.min(rect.right, ancestorRect.right) - Math.max(rect.left, ancestorRect.left)),
+						Math.max(0, Math.min(rect.bottom, ancestorRect.bottom) - Math.max(rect.top, ancestorRect.top)),
+					);
+				}
+			}
+			return true;
+		};
+
+		return Array.from(container.querySelectorAll("code-block, pre"))
+			.filter(el => el.textContent?.includes(needle))
+			.some(isPainted);
+	}, text);
+}
+
+async function expectPayloadVisible(page: Page, text: string, visible: boolean) {
+	expect(await payloadTextIsVisiblyPainted(page, text)).toBe(visible);
+}
+
+test.describe("DefaultRenderer payload collapse", () => {
+	test("keeps the header/status visible while JSON input and output are collapsed by default", async ({ page }) => {
+		await gotoAndWait(page);
+		await renderDefaultTool(page);
+
+		await expect(page.locator("#container")).toContainText("Diagnostic Tool");
+		await expect(page.locator("#container span[class*='text-green']").first()).toBeVisible();
+		await expect(payloadControl(page, "Input")).toBeVisible();
+		await expect(payloadControl(page, "Output")).toBeVisible();
+
+		await expectPayloadVisible(page, INPUT_SENTINEL, false);
+		await expectPayloadVisible(page, OUTPUT_SENTINEL, false);
+	});
+
+	test("allows keyboard and click expansion of full JSON input and output payloads", async ({ page }) => {
+		await gotoAndWait(page);
+		await renderDefaultTool(page);
+
+		await payloadControl(page, "Input").focus();
+		await page.keyboard.press("Enter");
+		await expectPayloadVisible(page, INPUT_SENTINEL, true);
+		await expectPayloadVisible(page, OUTPUT_SENTINEL, false);
+
+		await payloadControl(page, "Output").click();
+		await expectPayloadVisible(page, INPUT_SENTINEL, true);
+		await expectPayloadVisible(page, OUTPUT_SENTINEL, true);
+		await expect(page.locator("#container code-block")).toHaveCount(2);
+	});
+
+	test("does not hide error status indicators behind collapsed raw output", async ({ page }) => {
+		await gotoAndWait(page);
+		await renderDefaultTool(page, { isError: true });
+
+		await expect(page.locator("#container")).toContainText("Diagnostic Tool");
+		await expect(page.locator("#container span[class*='text-destructive']").first()).toBeVisible();
+		await expect(payloadControl(page, "Output")).toBeVisible();
+		await expectPayloadVisible(page, ERROR_SENTINEL, false);
+
+		await payloadControl(page, "Output").click();
+		await expectPayloadVisible(page, ERROR_SENTINEL, true);
+	});
+});

--- a/tests/e2e/ui/skill-multifile.spec.ts
+++ b/tests/e2e/ui/skill-multifile.spec.ts
@@ -43,6 +43,14 @@ function skillChip(page: import("@playwright/test").Page) {
 	return page.locator("skill-chip").first();
 }
 
+async function expandLatestDefaultPayload(page: import("@playwright/test").Page, name: RegExp) {
+	const button = page.getByRole("button", { name }).last();
+	await expect(button).toBeVisible({ timeout: 5_000 });
+	await expect(button).toHaveAttribute("aria-expanded", "false");
+	await button.click();
+	await expect(button).toHaveAttribute("aria-expanded", "true");
+}
+
 test.describe("multi-file skill activation", () => {
 	test("chip renders without activation-header fence; server includes header + resource manifest; reload preserves", async ({ page }) => {
 		const cwd = nonGitCwd();
@@ -130,13 +138,23 @@ test.describe("multi-file skill activation", () => {
 		await expect(
 			page.getByText("Done. Used Read tool.").first(),
 		).toBeVisible({ timeout: 20_000 });
-		await expect(
-			page.getByText("READ_THIS_CONTENT_E2E").first(),
-		).toBeVisible({ timeout: 5_000 });
+		const readInputPayload = page.getByRole("button", { name: /Input JSON payload/i }).last();
+		const readOutputPayload = page.getByRole("button", { name: /Output (?:JSON|text) payload/i }).last();
+		await expect(readInputPayload).toHaveAttribute("aria-expanded", "false");
+		await expect(readOutputPayload).toHaveAttribute("aria-expanded", "false");
+
+		// DefaultRenderer keeps raw payloads collapsed by default; expand them
+		// before asserting the Read input path and output content are inspectable.
+		await expandLatestDefaultPayload(page, /Input JSON payload/i);
 		// Path round-trip: the rendered tool input contains the references/
 		// path the agent resolved against the activation-header skill root.
 		await expect(
 			page.locator("code").filter({ hasText: "references/REFERENCE.md" }).first(),
+		).toBeVisible({ timeout: 5_000 });
+
+		await expandLatestDefaultPayload(page, /Output (?:JSON|text) payload/i);
+		await expect(
+			page.getByText("READ_THIS_CONTENT_E2E").first(),
 		).toBeVisible({ timeout: 5_000 });
 	});
 });

--- a/tests/fixtures/default-tool-renderer-entry.ts
+++ b/tests/fixtures/default-tool-renderer-entry.ts
@@ -1,0 +1,71 @@
+// Test entry for DefaultRenderer browser-fixture coverage.
+import { render } from "lit";
+import { DefaultRenderer } from "../../src/ui/tools/renderers/DefaultRenderer.js";
+
+class TestCodeBlock extends HTMLElement {
+	private _code = "";
+
+	set code(value: string) {
+		this._code = value ?? "";
+		this.render();
+	}
+
+	get code(): string {
+		return this._code;
+	}
+
+	static get observedAttributes() {
+		return ["code", "language"];
+	}
+
+	connectedCallback() {
+		this.render();
+	}
+
+	attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
+		if (name === "code") this._code = newValue ?? "";
+		this.render();
+	}
+
+	private render() {
+		const language = this.getAttribute("language") || "";
+		this.style.display = "block";
+		this.innerHTML = "";
+		const pre = document.createElement("pre");
+		pre.setAttribute("data-language", language);
+		pre.textContent = this._code;
+		this.appendChild(pre);
+	}
+}
+
+if (!customElements.get("code-block")) {
+	customElements.define("code-block", TestCodeBlock);
+}
+
+function makeResult(payload: any, isError = false) {
+	return {
+		role: "toolResult",
+		toolCallId: "t1",
+		toolName: "diagnostic_tool",
+		isError,
+		content: [{ type: "text", text: typeof payload === "string" ? payload : JSON.stringify(payload) }],
+		timestamp: Date.now(),
+	};
+}
+
+(window as any).__renderDefaultTool = (
+	toolName: string,
+	params: any,
+	resultPayload: any,
+	isError = false,
+	isStreaming = false,
+) => {
+	const container = document.getElementById("container");
+	if (!container) throw new Error("missing #container");
+	const renderer = new DefaultRenderer(toolName);
+	const result = resultPayload === undefined ? undefined : makeResult(resultPayload, isError);
+	const out = renderer.render(params, result, isStreaming);
+	render(out.content, container);
+};
+
+(window as any).__ready = true;

--- a/tests/fixtures/default-tool-renderer.html
+++ b/tests/fixtures/default-tool-renderer.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Default tool renderer fixture</title>
+<style>
+	body { font-family: sans-serif; padding: 8px; }
+	.font-mono { font-family: ui-monospace, monospace; }
+	.text-muted-foreground { color: #666; }
+	.text-foreground { color: #111; }
+	.text-destructive { color: #c00; }
+	.text-green-600 { color: #15803d; }
+	.hidden { display: none; }
+	.max-h-0 { max-height: 0; overflow: hidden; }
+	.max-h-\[2000px\] { max-height: 2000px; }
+	.mt-3 { margin-top: 0.75rem; }
+	code-block { border: 1px solid #ccc; padding: 4px; margin-top: 4px; }
+	pre { margin: 0; white-space: pre-wrap; }
+</style>
+</head>
+<body>
+<div id="container"></div>
+<script src="./default-tool-renderer-bundle.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Collapse generic DefaultRenderer input/output payloads behind accessible buttons by default.
- Keep tool headers/status visible, including an inline error preview for error results.
- Add regression coverage for DefaultRenderer payload expansion and fallback renderer behavior.
- Update skill multifile E2E to expand collapsed default payloads before inspecting raw Read input/output.

## Validation
- `npx playwright test tests/default-tool-renderer.spec.ts tests/children-tool-renderers.spec.ts --config=tests/playwright.config.ts --grep "DefaultRenderer payload collapse|feature flag off"`
- `npx playwright test tests/e2e/ui/skill-multifile.spec.ts --config=playwright-e2e.config.ts --project=browser`
- Implementation gate passed (build, typecheck, unit, E2E, reviews)

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
