### PR TITLE
Bypass Merge Button

### DIFF
--- a/docs/git-status-diff-viewer.md
+++ b/docs/git-status-diff-viewer.md
@@ -150,6 +150,29 @@ The server uses the commit SHA plus destination path to find rename metadata and
 
 Multi-repo dirty-file rows continue to call the same diff opener with the repo name. URL construction still appends `repo=<repoName>` only when the repo is not `.`. The rich viewer is only a renderer and does not know about repo routing.
 
+### PR bypass merge control
+
+The PR section can show a **Bypass merge** button for users GitHub allows to bypass pull-request requirements. This is separate from the normal **Merge PR** button: normal merge behavior stays tied to GitHub's ordinary mergeability result, while bypass is a narrower capability used when branch protection or ruleset requirements block the PR but GitHub says the viewer may bypass them.
+
+The widget shows **Bypass merge** only when all of the following are true:
+
+- the PR is open;
+- `viewerCanMergeAsAdmin` is `true` in the PR status data;
+- `prMergeable !== "CONFLICTING"`.
+
+`viewerIsAdmin` alone is not enough. Admin users do not see the bypass button unless the PR status capability says bypass is available, and non-admin users may see it when GitHub rulesets grant them bypass permission.
+
+The server computes `viewerCanMergeAsAdmin` from two GitHub signals:
+
+1. `PullRequest.viewerCanMergeAsAdmin` from the GraphQL API.
+2. Matching branch rules/rulesets for the PR base branch when GraphQL is false. A matching rule or ruleset grants bypass when `current_user_can_bypass` is `"always"` or `"pull_requests_only"`.
+
+Ruleset probing is best-effort. If branch-rule or ruleset detail calls fail, PR status still returns using the GraphQL value and the legacy repository-permission fallback instead of failing the whole status refresh.
+
+Clicking **Bypass merge** dispatches the existing `pr-merge` event with `admin: true`. Session and goal handlers forward that to the existing `/pr-merge` endpoints, which invoke `gh pr merge <branch> --<method> --admin` via `execFile` argv arrays. Branch names, repository names, and ruleset paths are never shell-interpolated; branch text remains a single argv argument, and branch-rule lookups URL-encode the base branch path segment.
+
+The capability is part of the PR status payload and cache plumbing. It is carried through the persistent PR status store, session `AgentInterface`, goal dashboard state, and `state.prStatusCache`. Cache comparison includes `viewerCanMergeAsAdmin`, so session and dashboard widgets update when GitHub starts or stops reporting bypass permission without requiring an unrelated PR status change.
+
 ## PR Walkthrough portability boundary
 
 The Git status viewer and PR Walkthrough can share UX ideas, not runtime UI code.
@@ -175,7 +198,8 @@ Coverage for this area is split by responsibility:
 
 - `tests/git-diff-unified-parser.test.ts` covers multi-file parsing, renames, added/deleted files, binary diffs, no-newline markers, truncation, synthetic hunk-only files, and split pairing.
 - `tests/rich-git-diff-viewer.spec.ts` covers collapsible file sections/counts/rename paths, file toggle `aria-expanded`, split/inline `aria-checked`, context expansion, responsive auto mode and explicit override, raw fallback, and truncation warning.
-- `tests/git-status-widget-states.spec.ts` covers the widget modal integration, commit-file rename URL shape, modal ARIA, and preserved modal behavior.
+- `tests/git-status-widget-states.spec.ts` covers the widget modal integration, commit-file rename URL shape, modal ARIA, preserved modal behavior, and bypass-merge button visibility/event details.
+- `tests/pr-status-lookup.test.ts` covers PR status lookup argv construction, GraphQL bypass capability, ruleset-backed bypass capability, best-effort ruleset failures, and malicious branch text staying in one argv argument.
 - `tests/e2e/ui/session-git-status-multi-repo.spec.ts` covers the browser path for multi-repo `repo=` routing and new viewer rendering.
 - `tests/e2e/commit-file-diffs-api.spec.ts` and `tests/e2e/session-git-status-multi-repo.spec.ts` keep server rename and repo routing semantics pinned.
 - `tests/pr-walkthrough-pack-boundary.test.ts` keeps the pack/core boundary explicit.

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -1452,7 +1452,7 @@ export async function refreshPrStatusCache(skipRender = false): Promise<boolean>
 				if (res.status === 204 || res.status === 404) return { goalId: g.id, pr: null, noPr: true };
 				if (!res.ok) return { goalId: g.id, pr: null, noPr: false };
 				const data = await res.json();
-				return { goalId: g.id, pr: data as { state: string; url?: string; number?: number; reviewDecision?: string; mergeable?: string }, noPr: false };
+				return { goalId: g.id, pr: data as { state: string; url?: string; number?: number; reviewDecision?: string; mergeable?: string; viewerCanMergeAsAdmin?: boolean }, noPr: false };
 			} catch {
 				return { goalId: g.id, pr: null, noPr: false };
 			}
@@ -1463,7 +1463,11 @@ export async function refreshPrStatusCache(skipRender = false): Promise<boolean>
 	for (const { goalId, pr, noPr } of results) {
 		const prev = state.prStatusCache.get(goalId);
 		if (pr) {
-			if (!prev || prev.state !== pr.state || prev.reviewDecision !== pr.reviewDecision || prev.mergeable !== pr.mergeable) {
+			if (!prev
+				|| prev.state !== pr.state
+				|| prev.reviewDecision !== pr.reviewDecision
+				|| prev.mergeable !== pr.mergeable
+				|| prev.viewerCanMergeAsAdmin !== pr.viewerCanMergeAsAdmin) {
 				state.prStatusCache.set(goalId, pr);
 				changed = true;
 			}

--- a/src/app/goal-dashboard.ts
+++ b/src/app/goal-dashboard.ts
@@ -234,6 +234,7 @@ interface PrStatus {
 	state: "OPEN" | "MERGED" | "CLOSED";
 	mergeable?: string;
 	viewerIsAdmin?: boolean;
+	viewerCanMergeAsAdmin?: boolean;
 	reviewDecision?: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null;
 	headRefName?: string;
 }
@@ -2148,6 +2149,7 @@ function renderMetaRows(goal: Goal): TemplateResult {
 						.prTitle=${prStatus?.title}
 						.prMergeable=${prStatus?.mergeable}
 						.viewerIsAdmin=${prStatus?.viewerIsAdmin ?? false}
+						.viewerCanMergeAsAdmin=${prStatus?.viewerCanMergeAsAdmin ?? false}
 						.reviewDecision=${prStatus?.reviewDecision}
 						.headRefName=${prStatus?.headRefName}
 						@pr-merge=${handlePrMerge}

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -3331,6 +3331,7 @@ async function refreshPrStatusForSession(sessionId: string): Promise<void> {
 				ai.prTitle = undefined;
 				ai.prMergeable = undefined;
 				ai.viewerIsAdmin = undefined;
+				ai.viewerCanMergeAsAdmin = undefined;
 				ai.reviewDecision = undefined;
 				ai.headRefName = undefined;
 			}
@@ -3344,12 +3345,13 @@ async function refreshPrStatusForSession(sessionId: string): Promise<void> {
 			ai.prTitle = data.title;
 			ai.prMergeable = data.mergeable;
 			ai.viewerIsAdmin = data.viewerIsAdmin ?? false;
+			ai.viewerCanMergeAsAdmin = data.viewerCanMergeAsAdmin ?? false;
 			ai.reviewDecision = data.reviewDecision ?? undefined;
 			ai.headRefName = data.headRefName ?? undefined;
 		}
 		// Update goal grouping cache so sidebar reflects the new PR state immediately
 		if (goalId && data.state) {
-			state.prStatusCache.set(goalId, { state: data.state, url: data.url, number: data.number, reviewDecision: data.reviewDecision ?? null, mergeable: data.mergeable });
+			state.prStatusCache.set(goalId, { state: data.state, url: data.url, number: data.number, reviewDecision: data.reviewDecision ?? null, mergeable: data.mergeable, viewerCanMergeAsAdmin: data.viewerCanMergeAsAdmin ?? false });
 			renderApp();
 		}
 	} catch {
@@ -3360,6 +3362,7 @@ async function refreshPrStatusForSession(sessionId: string): Promise<void> {
 			ai.prTitle = undefined;
 			ai.prMergeable = undefined;
 			ai.viewerIsAdmin = undefined;
+			ai.viewerCanMergeAsAdmin = undefined;
 			ai.reviewDecision = undefined;
 			ai.headRefName = undefined;
 		}

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -338,7 +338,7 @@ export const state = {
 		}>;
 	}>(),
 	/** PR status cache: goalId → { state, url, number, reviewDecision } */
-	prStatusCache: new Map<string, { state: string; url?: string; number?: number; reviewDecision?: string | null; mergeable?: string }>(),
+	prStatusCache: new Map<string, { state: string; url?: string; number?: number; reviewDecision?: string | null; mergeable?: string; viewerCanMergeAsAdmin?: boolean }>(),
 	sessionsLoading: false,
 	sessionsError: "",
 	creatingSession: false,

--- a/src/server/agent/pr-status-store.ts
+++ b/src/server/agent/pr-status-store.ts
@@ -9,7 +9,9 @@ export interface PrStatusEntry {
 	reviewDecision?: string | null;
 	mergeable?: string;
 	viewerIsAdmin?: boolean;
+	viewerCanMergeAsAdmin?: boolean;
 	headRefName?: string;
+	baseRefName?: string;
 	updatedAt?: string;
 }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -940,13 +940,32 @@ let _dockerAvailCache: { available: boolean; error?: string; ts: number } | null
 const _prCache = new Map<string, { data: any; ts: number; ttl: number }>();
 const PR_NULL_CACHE_TTL_MS = 30_000; // 30 seconds for null (no-PR) results
 const _prInFlight = new Map<string, Promise<any | null>>();
-const PR_STATUS_FIELDS = "state,url,number,title,mergeable,headRefName,reviewDecision";
+const PR_STATUS_FIELDS = "state,url,number,title,mergeable,headRefName,baseRefName,reviewDecision";
+const PR_MERGE_PERMISSIONS_QUERY = "query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){viewerPermission pullRequest(number:$number){viewerCanMergeAsAdmin}}}";
 
 type GhExecFileForTests = (args: readonly string[], opts: { cwd: string; timeout: number }) => Promise<string>;
 let _ghExecFileForTests: GhExecFileForTests | undefined;
 
 export function buildGhPrViewArgs(branch?: string): string[] {
 	return branch ? ["pr", "view", branch, "--json", PR_STATUS_FIELDS] : ["pr", "view", "--json", PR_STATUS_FIELDS];
+}
+
+export function buildGhPrMergePermissionsArgs(owner: string, name: string, number: number): string[] {
+	return [
+		"api", "graphql",
+		"-f", `query=${PR_MERGE_PERMISSIONS_QUERY}`,
+		"-F", `owner=${owner}`,
+		"-F", `name=${name}`,
+		"-F", `number=${number}`,
+	];
+}
+
+export function buildGhBranchRulesArgs(owner: string, name: string, branch: string): string[] {
+	return ["api", `repos/${owner}/${name}/rules/branches/${encodeURIComponent(branch)}`];
+}
+
+export function buildGhRulesetArgs(owner: string, name: string, rulesetId: number): string[] {
+	return ["api", `repos/${owner}/${name}/rulesets/${rulesetId}`];
 }
 
 async function execGh(args: readonly string[], cwd: string, timeout = 10_000): Promise<string> {
@@ -984,6 +1003,79 @@ async function getViewerIsAdmin(cwd: string): Promise<boolean> {
 	}
 }
 
+function parseGithubPrRepo(url: unknown): { owner: string; name: string } | null {
+	if (typeof url !== "string" || !url) return null;
+	try {
+		const parsed = new URL(url);
+		if (parsed.protocol !== "https:" || parsed.hostname !== "github.com") return null;
+		const [owner, name, pull, number] = parsed.pathname.split("/").filter(Boolean);
+		if (!owner || !name || pull !== "pull" || !number || !/^\d+$/.test(number)) return null;
+		return { owner, name };
+	} catch {
+		return null;
+	}
+}
+
+async function getViewerMergePermissions(
+	cwd: string,
+	pr: { url?: string; number?: number; baseRefName?: string },
+): Promise<{ viewerIsAdmin: boolean; viewerCanMergeAsAdmin: boolean }> {
+	const repo = parseGithubPrRepo(pr.url);
+	if (repo && typeof pr.number === "number") {
+		try {
+			const stdout = await execGh(buildGhPrMergePermissionsArgs(repo.owner, repo.name, pr.number), cwd);
+			const parsed = JSON.parse(stdout);
+			const repository = parsed?.data?.repository;
+			const perm = repository?.viewerPermission ?? "";
+			_repoPermCache.set(cwd, { perm, ts: Date.now() });
+
+			let viewerCanMergeAsAdmin = repository?.pullRequest?.viewerCanMergeAsAdmin === true;
+			if (!viewerCanMergeAsAdmin && typeof pr.baseRefName === "string" && pr.baseRefName) {
+				viewerCanMergeAsAdmin = await getViewerCanBypassBranchRules(cwd, repo, pr.baseRefName);
+			}
+
+			return { viewerIsAdmin: perm === "ADMIN", viewerCanMergeAsAdmin };
+		} catch {
+			// Fall through to legacy permission probe.
+		}
+	}
+	return { viewerIsAdmin: await getViewerIsAdmin(cwd), viewerCanMergeAsAdmin: false };
+}
+
+async function getViewerCanBypassBranchRules(
+	cwd: string,
+	repo: { owner: string; name: string },
+	branch: string,
+): Promise<boolean> {
+	try {
+		const stdout = await execGh(buildGhBranchRulesArgs(repo.owner, repo.name, branch), cwd);
+		const rules = JSON.parse(stdout);
+		if (!Array.isArray(rules)) return false;
+
+		if (rules.some((rule) => isBypassMode(rule?.current_user_can_bypass))) return true;
+
+		const rulesetIds = [
+			...new Set(rules.map((rule) => rule?.ruleset_id).filter((id): id is number => typeof id === "number")),
+		];
+
+		for (const rulesetId of rulesetIds) {
+			try {
+				const detail = JSON.parse(await execGh(buildGhRulesetArgs(repo.owner, repo.name, rulesetId), cwd));
+				if (isBypassMode(detail?.current_user_can_bypass)) return true;
+			} catch {
+				// Continue checking other matching rulesets.
+			}
+		}
+		return false;
+	} catch {
+		return false;
+	}
+}
+
+function isBypassMode(mode: unknown): boolean {
+	return mode === "always" || mode === "pull_requests_only";
+}
+
 async function _fetchPrStatus(cwd: string, branch?: string, fallbackCwd?: string): Promise<any | null> {
 	const cacheKey = branch ? `${cwd}::${branch}` : cwd;
 	const args = buildGhPrViewArgs(branch);
@@ -994,8 +1086,19 @@ async function _fetchPrStatus(cwd: string, branch?: string, fallbackCwd?: string
 		try {
 			const stdout = await execGh(args, dir);
 			const pr = JSON.parse(stdout);
-			const viewerIsAdmin = await getViewerIsAdmin(dir);
-			const data = { number: pr.number, url: pr.url, title: pr.title, state: pr.state, mergeable: pr.mergeable, headRefName: pr.headRefName, reviewDecision: pr.reviewDecision || null, viewerIsAdmin };
+			const { viewerIsAdmin, viewerCanMergeAsAdmin } = await getViewerMergePermissions(dir, pr);
+			const data = {
+				number: pr.number,
+				url: pr.url,
+				title: pr.title,
+				state: pr.state,
+				mergeable: pr.mergeable,
+				headRefName: pr.headRefName,
+				baseRefName: pr.baseRefName,
+				reviewDecision: pr.reviewDecision || null,
+				viewerIsAdmin,
+				viewerCanMergeAsAdmin,
+			};
 			const ttl = pr.state === "OPEN" ? 10_000 : 900_000; // OPEN: 10s, CLOSED/MERGED: 15min
 			_prCache.set(cacheKey, { data, ts: Date.now(), ttl });
 			return data;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -968,6 +968,10 @@ export function buildGhRulesetArgs(owner: string, name: string, rulesetId: numbe
 	return ["api", `repos/${owner}/${name}/rulesets/${rulesetId}`];
 }
 
+export function buildGhPrMergeArgs(branch: string | undefined, method: string, admin: unknown): string[] {
+	return ["pr", "merge", ...(branch ? [branch] : []), `--${method}`, ...(admin ? ["--admin"] : [])];
+}
+
 async function execGh(args: readonly string[], cwd: string, timeout = 10_000): Promise<string> {
 	if (_ghExecFileForTests) return _ghExecFileForTests(args, { cwd, timeout });
 	const { stdout } = await execFileAsync("gh", [...args], { cwd, encoding: "utf-8", timeout });
@@ -10921,12 +10925,10 @@ async function handleApiRoute(
 			json({ error: "Invalid merge method. Must be merge, squash, or rebase." }, 400);
 			return;
 		}
-		const goalAdminFlag = body?.admin ? " --admin" : "";
 		const clientGoalBranch = typeof body?.branch === "string" ? body.branch : undefined;
 		const resolvedGoalBranch = clientGoalBranch || goal.branch;
-		const goalMergeBranch = resolvedGoalBranch ? ` ${resolvedGoalBranch}` : "";
 		try {
-			await execAsync(`gh pr merge${goalMergeBranch} --${method}${goalAdminFlag}`, { cwd, encoding: "utf-8", timeout: 30000 });
+			await execFileAsync("gh", buildGhPrMergeArgs(resolvedGoalBranch, method, body?.admin), { cwd, encoding: "utf-8", timeout: 30000 });
 			_prCache.delete(cwd);
 			if (goal.branch) _prCache.delete(`${cwd}::${goal.branch}`);
 			json({ ok: true });
@@ -13372,18 +13374,16 @@ async function handleApiRoute(
 			json({ error: "Invalid merge method. Must be merge, squash, or rebase." }, 400);
 			return;
 		}
-		const sessAdminFlag = body?.admin ? " --admin" : "";
 		// Prefer the client-provided branch (headRefName from PR status) so the merge
 		// targets the exact PR the widget displayed — avoids mismatches when the session's
 		// persisted branch differs from the PR's head ref (e.g. staff/team agent worktrees).
 		const clientBranch = typeof body?.branch === "string" ? body.branch : undefined;
 		const goalBranch = session.goalId ? getGoalAcrossProjects(session.goalId)?.branch : undefined;
 		const sessMergeBranch = clientBranch || goalBranch || sessionManager.getPersistedSession(id)?.branch;
-		const sessMergeBranchArg = sessMergeBranch ? ` ${sessMergeBranch}` : "";
 		try {
 			// PR merge uses `gh` CLI — for sandboxed sessions, run on host worktree
 			const mergeCwd = cid ? (session.worktreePath || cwd) : cwd;
-			await execAsync(`gh pr merge${sessMergeBranchArg} --${method}${sessAdminFlag}`, { cwd: mergeCwd, encoding: "utf-8", timeout: 30000 });
+			await execFileAsync("gh", buildGhPrMergeArgs(sessMergeBranch, method, body?.admin), { cwd: mergeCwd, encoding: "utf-8", timeout: 30000 });
 			_prCache.delete(cwd);
 			if (sessMergeBranch) _prCache.delete(`${cwd}::${sessMergeBranch}`);
 			json({ ok: true });

--- a/src/ui/components/AgentInterface.ts
+++ b/src/ui/components/AgentInterface.ts
@@ -107,6 +107,7 @@ export class AgentInterface extends LitElement {
 	@property() prTitle?: string;
 	@property() prMergeable?: string;
 	@property({ type: Boolean }) viewerIsAdmin?: boolean;
+	@property({ type: Boolean }) viewerCanMergeAsAdmin?: boolean;
 	@property() reviewDecision?: string;
 	@property() headRefName?: string;
 	// Background processes for this session
@@ -2232,6 +2233,7 @@ export class AgentInterface extends LitElement {
 								.prTitle=${this.prTitle}
 								.prMergeable=${this.prMergeable}
 								.viewerIsAdmin=${this.viewerIsAdmin ?? false}
+								.viewerCanMergeAsAdmin=${this.viewerCanMergeAsAdmin ?? false}
 								.reviewDecision=${this.reviewDecision}
 								.headRefName=${this.headRefName}
 								@pr-merge=${this._handlePrMerge}

--- a/src/ui/components/GitStatusWidget.ts
+++ b/src/ui/components/GitStatusWidget.ts
@@ -62,6 +62,7 @@ export class GitStatusWidget extends LitElement {
     @property() prTitle?: string;
     @property() prMergeable?: string;
     @property({ type: Boolean }) viewerIsAdmin = false;
+    @property({ type: Boolean }) viewerCanMergeAsAdmin = false;
     @property() reviewDecision?: string; // "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null
     @property() headRefName?: string; // The actual branch name the PR targets
 
@@ -450,10 +451,15 @@ export class GitStatusWidget extends LitElement {
         return html`<span style="display:inline-block;padding:1px 6px;border-radius:9999px;font-size:11px;font-weight:600;color:${c.color};background:${c.bg}">${c.label}</span>`;
     }
 
+    private _canBypassMerge(): boolean {
+        return this.viewerCanMergeAsAdmin && this.prMergeable !== "CONFLICTING";
+    }
+
     /** PR section for the expanded dropdown */
     private _renderPrSection() {
         if (!this.prState) return nothing;
 
+        const canBypassMerge = this._canBypassMerge();
         const badgeColor = this.prState === 'OPEN' ? 'oklch(0.68 0.12 145)'
             : this.prState === 'MERGED' ? 'oklch(0.62 0.13 300)'
             : 'oklch(0.62 0.14 25)';
@@ -497,14 +503,14 @@ export class GitStatusWidget extends LitElement {
                         >
                             Merge PR
                         </button>
-                        ${this.viewerIsAdmin ? html`<button
+                        ${canBypassMerge ? html`<button
                             style="font-size:12px;padding:2px 10px;border-radius:4px;border:1px solid var(--border);background:oklch(0.62 0.14 25 / 0.12);color:oklch(0.62 0.14 25);cursor:pointer;font-weight:500"
                             @click=${() => this._handleForceMerge()}
-                            title="Merge with --admin to bypass branch protection rules"
+                            title="Merge with GitHub's bypass branch protections permission"
                         >
-                            Force Merge
+                            Bypass merge
                         </button>` : nothing}
-                        ${this.prMergeable !== "MERGEABLE" && !this.viewerIsAdmin ? html`<span style="font-size:11px;color:var(--destructive)">${this.prMergeable === "CONFLICTING" ? "Has conflicts" : "Not mergeable"}</span>` : nothing}
+                        ${this.prMergeable !== "MERGEABLE" && !canBypassMerge ? html`<span style="font-size:11px;color:var(--destructive)">${this.prMergeable === "CONFLICTING" ? "Has conflicts" : "Not mergeable"}</span>` : nothing}
                         `}
                     </div>
                     ${this.mergeError ? html`<div style="font-size:12px;color:var(--destructive);margin-top:4px">${this.mergeError}</div>` : nothing}

--- a/tests/git-status-widget-states.spec.ts
+++ b/tests/git-status-widget-states.spec.ts
@@ -45,6 +45,100 @@ async function mount(
 	await page.waitForTimeout(50);
 }
 
+async function openDropdown(page: any): Promise<void> {
+	await page.locator('git-status-widget button[data-state="ready"]').click();
+	await page.waitForSelector("#git-status-dropdown", { timeout: 2_000 });
+}
+
+const OPEN_PR_PROPS = {
+	loading: false,
+	branch: "feature/pr",
+	primaryBranch: "master",
+	isOnPrimary: false,
+	clean: true,
+	statusFiles: [],
+	prState: "OPEN",
+	prNumber: 905,
+	prTitle: "Needs review",
+	prUrl: "https://github.com/example/repo/pull/905",
+	prMergeable: "MERGEABLE",
+	reviewDecision: "REVIEW_REQUIRED",
+};
+
+test.describe("GitStatusWidget bypass merge action", () => {
+	test("renders Bypass merge when viewerCanMergeAsAdmin is true", async ({ page }) => {
+		await gotoAndWait(page);
+		await mount(page, {
+			...OPEN_PR_PROPS,
+			viewerCanMergeAsAdmin: true,
+		});
+		await openDropdown(page);
+
+		await expect(page.locator("#git-status-dropdown").getByRole("button", { name: "Bypass merge" })).toBeVisible();
+		await expect(page.locator("#git-status-dropdown")).not.toContainText("Force Merge");
+	});
+
+	test("Bypass merge emits pr-merge with admin true", async ({ page }) => {
+		await gotoAndWait(page);
+		await mount(page, {
+			...OPEN_PR_PROPS,
+			viewerCanMergeAsAdmin: true,
+		});
+		await page.evaluate(() => {
+			(window as any).__prMergeEvents = [];
+			window.addEventListener("pr-merge", (event) => {
+				(window as any).__prMergeEvents.push((event as CustomEvent).detail);
+			});
+		});
+		await openDropdown(page);
+
+		await page.locator("#git-status-dropdown").getByRole("button", { name: "Bypass merge" }).click();
+
+		const events = await page.evaluate(() => (window as any).__prMergeEvents);
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({ method: "squash", admin: true });
+	});
+
+	test("hides Bypass merge when capability is false even for admins", async ({ page }) => {
+		await gotoAndWait(page);
+		await mount(page, {
+			...OPEN_PR_PROPS,
+			viewerIsAdmin: true,
+			viewerCanMergeAsAdmin: false,
+		});
+		await openDropdown(page);
+
+		await expect(page.locator("#git-status-dropdown").getByRole("button", { name: "Bypass merge" })).toHaveCount(0);
+		await expect(page.locator("#git-status-dropdown")).not.toContainText("Force Merge");
+	});
+
+	test("conflicting PR hides Bypass merge even with bypass capability", async ({ page }) => {
+		await gotoAndWait(page);
+		await mount(page, {
+			...OPEN_PR_PROPS,
+			prMergeable: "CONFLICTING",
+			viewerCanMergeAsAdmin: true,
+		});
+		await openDropdown(page);
+
+		await expect(page.locator("#git-status-dropdown").getByRole("button", { name: "Bypass merge" })).toHaveCount(0);
+		await expect(page.locator("#git-status-dropdown")).toContainText("Has conflicts");
+	});
+
+	test("non-mergeable PR shows status text when bypass is unavailable", async ({ page }) => {
+		await gotoAndWait(page);
+		await mount(page, {
+			...OPEN_PR_PROPS,
+			prMergeable: "UNKNOWN",
+			viewerCanMergeAsAdmin: false,
+		});
+		await openDropdown(page);
+
+		await expect(page.locator("#git-status-dropdown").getByRole("button", { name: "Bypass merge" })).toHaveCount(0);
+		await expect(page.locator("#git-status-dropdown")).toContainText("Not mergeable");
+	});
+});
+
 test.describe("GitStatusWidget render states", () => {
 	test("skeleton renders when loading && !branch", async ({ page }) => {
 		await gotoAndWait(page);

--- a/tests/pr-status-lookup.test.ts
+++ b/tests/pr-status-lookup.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, describe, it } from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
 
 import {
 	__getCachedPrStatusForTests,
 	__resetPrStatusCachesForTests,
 	__setGhExecFileForPrStatusTests,
 	buildGhBranchRulesArgs,
+	buildGhPrMergeArgs,
 	buildGhPrMergePermissionsArgs,
 	buildGhPrViewArgs,
 	buildGhRulesetArgs,
@@ -49,6 +51,15 @@ describe("PR status GitHub CLI lookup", () => {
 		assert.equal(args[0], "api");
 		assert.equal(args[1], `repos/acme/widget/rules/branches/${encodeURIComponent(branch)}`);
 		assert.ok(!args.includes(branch));
+	});
+
+	it("builds PR merge as execFile-safe argv", () => {
+		const branch = "feature/ok && node -e \"throw new Error('shell executed')\"";
+		assert.deepEqual(buildGhPrMergeArgs(branch, "squash", true), ["pr", "merge", branch, "--squash", "--admin"]);
+		assert.deepEqual(buildGhPrMergeArgs(undefined, "merge", false), ["pr", "merge", "--merge"]);
+
+		const source = fs.readFileSync(new URL("../src/server/server.ts", import.meta.url), "utf-8");
+		assert.ok(!source.includes("execAsync(`gh pr merge"));
 	});
 
 	it("returns viewerCanMergeAsAdmin from GraphQL without probing rulesets", async () => {

--- a/tests/pr-status-lookup.test.ts
+++ b/tests/pr-status-lookup.test.ts
@@ -5,10 +5,13 @@ import {
 	__getCachedPrStatusForTests,
 	__resetPrStatusCachesForTests,
 	__setGhExecFileForPrStatusTests,
+	buildGhBranchRulesArgs,
+	buildGhPrMergePermissionsArgs,
 	buildGhPrViewArgs,
+	buildGhRulesetArgs,
 } from "../src/server/server.ts";
 
-const PR_FIELDS = "state,url,number,title,mergeable,headRefName,reviewDecision";
+const PR_FIELDS = "state,url,number,title,mergeable,headRefName,baseRefName,reviewDecision";
 
 describe("PR status GitHub CLI lookup", () => {
 	afterEach(() => {
@@ -22,8 +25,34 @@ describe("PR status GitHub CLI lookup", () => {
 		assert.deepEqual(buildGhPrViewArgs(), ["pr", "view", "--json", PR_FIELDS]);
 	});
 
-	it("looks up PR status through execFile argv without shell interpolation", async () => {
-		const branch = "feature/sidebar-actions && node -e \"throw new Error('shell executed')\"";
+	it("builds bypass permission gh api calls as execFile-safe argv", () => {
+		const permissionsArgs = buildGhPrMergePermissionsArgs("acme", "widget", 7);
+		assert.equal(permissionsArgs[0], "api");
+		assert.equal(permissionsArgs[1], "graphql");
+		assert.ok(permissionsArgs.includes("-f"));
+		assert.ok(permissionsArgs.some((arg) => arg.startsWith("query=query($owner:String!")));
+		assert.ok(permissionsArgs.includes("-F"));
+		assert.ok(permissionsArgs.includes("owner=acme"));
+		assert.ok(permissionsArgs.includes("name=widget"));
+		assert.ok(permissionsArgs.includes("number=7"));
+
+		assert.deepEqual(buildGhRulesetArgs("acme", "widget", 18370627), [
+			"api",
+			"repos/acme/widget/rulesets/18370627",
+		]);
+	});
+
+	it("builds branch rules lookup with malicious branch text encoded in one argv element", () => {
+		const branch = "master; $(node -e 'throw new Error()')/feature\nname";
+		const args = buildGhBranchRulesArgs("acme", "widget", branch);
+		assert.equal(args.length, 2);
+		assert.equal(args[0], "api");
+		assert.equal(args[1], `repos/acme/widget/rules/branches/${encodeURIComponent(branch)}`);
+		assert.ok(!args.includes(branch));
+	});
+
+	it("returns viewerCanMergeAsAdmin from GraphQL without probing rulesets", async () => {
+		const branch = "feature/sidebar-actions";
 		const calls: Array<{ args: string[]; cwd: string; timeout: number }> = [];
 
 		__setGhExecFileForPrStatusTests(async (args, opts) => {
@@ -36,11 +65,19 @@ describe("PR status GitHub CLI lookup", () => {
 					title: "Sidebar actions",
 					mergeable: "MERGEABLE",
 					headRefName: branch,
-					reviewDecision: "APPROVED",
+					baseRefName: "master",
+					reviewDecision: "REVIEW_REQUIRED",
 				});
 			}
-			if (args[0] === "repo" && args[1] === "view") {
-				return JSON.stringify({ viewerPermission: "ADMIN" });
+			if (args[0] === "api" && args[1] === "graphql") {
+				return JSON.stringify({
+					data: {
+						repository: {
+							viewerPermission: "WRITE",
+							pullRequest: { viewerCanMergeAsAdmin: true },
+						},
+					},
+				});
 			}
 			throw new Error(`unexpected gh args: ${args.join(" ")}`);
 		});
@@ -54,8 +91,138 @@ describe("PR status GitHub CLI lookup", () => {
 			state: "OPEN",
 			mergeable: "MERGEABLE",
 			headRefName: branch,
+			baseRefName: "master",
+			reviewDecision: "REVIEW_REQUIRED",
+			viewerIsAdmin: false,
+			viewerCanMergeAsAdmin: true,
+		});
+		assert.deepEqual(calls.map((call) => call.args), [
+			["pr", "view", branch, "--json", PR_FIELDS],
+			buildGhPrMergePermissionsArgs("acme", "widget", 7),
+		]);
+	});
+
+	it("detects ruleset bypass when GraphQL viewerCanMergeAsAdmin is false", async () => {
+		const calls: string[][] = [];
+
+		__setGhExecFileForPrStatusTests(async (args) => {
+			calls.push([...args]);
+			if (args[0] === "pr" && args[1] === "view") {
+				return JSON.stringify({
+					state: "OPEN",
+					url: "https://github.com/acme/widget/pull/8",
+					number: 8,
+					title: "Ruleset bypass",
+					mergeable: "MERGEABLE",
+					headRefName: "feature/ruleset-bypass",
+					baseRefName: "master",
+					reviewDecision: "REVIEW_REQUIRED",
+				});
+			}
+			if (args[0] === "api" && args[1] === "graphql") {
+				return JSON.stringify({
+					data: {
+						repository: {
+							viewerPermission: "WRITE",
+							pullRequest: { viewerCanMergeAsAdmin: false },
+						},
+					},
+				});
+			}
+			if (args[0] === "api" && args[1] === "repos/acme/widget/rules/branches/master") {
+				return JSON.stringify([{ ruleset_id: 18370627 }]);
+			}
+			if (args[0] === "api" && args[1] === "repos/acme/widget/rulesets/18370627") {
+				return JSON.stringify({ current_user_can_bypass: "pull_requests_only" });
+			}
+			throw new Error(`unexpected gh args: ${args.join(" ")}`);
+		});
+
+		const status = await __getCachedPrStatusForTests("/repo/worktree", "feature/ruleset-bypass");
+
+		assert.equal(status?.viewerIsAdmin, false);
+		assert.equal(status?.viewerCanMergeAsAdmin, true);
+		assert.deepEqual(calls, [
+			["pr", "view", "feature/ruleset-bypass", "--json", PR_FIELDS],
+			buildGhPrMergePermissionsArgs("acme", "widget", 8),
+			buildGhBranchRulesArgs("acme", "widget", "master"),
+			buildGhRulesetArgs("acme", "widget", 18370627),
+		]);
+	});
+
+	it("treats branch rules endpoint failure as best-effort and still returns PR status", async () => {
+		__setGhExecFileForPrStatusTests(async (args) => {
+			if (args[0] === "pr" && args[1] === "view") {
+				return JSON.stringify({
+					state: "OPEN",
+					url: "https://github.com/acme/widget/pull/9",
+					number: 9,
+					title: "Rules failure",
+					mergeable: "MERGEABLE",
+					headRefName: "feature/rules-failure",
+					baseRefName: "master",
+					reviewDecision: "REVIEW_REQUIRED",
+				});
+			}
+			if (args[0] === "api" && args[1] === "graphql") {
+				return JSON.stringify({
+					data: {
+						repository: {
+							viewerPermission: "WRITE",
+							pullRequest: { viewerCanMergeAsAdmin: false },
+						},
+					},
+				});
+			}
+			if (args[0] === "api" && args[1] === "repos/acme/widget/rules/branches/master") {
+				throw new Error("rules endpoint unavailable");
+			}
+			throw new Error(`unexpected gh args: ${args.join(" ")}`);
+		});
+
+		const status = await __getCachedPrStatusForTests("/repo/worktree", "feature/rules-failure");
+
+		assert.equal(status?.viewerIsAdmin, false);
+		assert.equal(status?.viewerCanMergeAsAdmin, false);
+	});
+
+	it("falls back to legacy repo permission lookup when GraphQL cannot be used", async () => {
+		const branch = "feature/sidebar-actions && node -e \"throw new Error('shell executed')\"";
+		const calls: Array<{ args: string[]; cwd: string; timeout: number }> = [];
+
+		__setGhExecFileForPrStatusTests(async (args, opts) => {
+			calls.push({ args: [...args], cwd: opts.cwd, timeout: opts.timeout });
+			if (args[0] === "pr" && args[1] === "view") {
+				return JSON.stringify({
+					state: "OPEN",
+					url: "https://example.com/acme/widget/pull/7",
+					number: 7,
+					title: "Sidebar actions",
+					mergeable: "MERGEABLE",
+					headRefName: branch,
+					baseRefName: "master",
+					reviewDecision: "APPROVED",
+				});
+			}
+			if (args[0] === "repo" && args[1] === "view") {
+				return JSON.stringify({ viewerPermission: "ADMIN" });
+			}
+			throw new Error(`unexpected gh args: ${args.join(" ")}`);
+		});
+
+		const status = await __getCachedPrStatusForTests("/repo/worktree", branch, "/repo/main");
+
+		assert.deepEqual(status, {
+			number: 7,
+			url: "https://example.com/acme/widget/pull/7",
+			title: "Sidebar actions",
+			state: "OPEN",
+			mergeable: "MERGEABLE",
+			headRefName: branch,
+			baseRefName: "master",
 			reviewDecision: "APPROVED",
 			viewerIsAdmin: true,
+			viewerCanMergeAsAdmin: false,
 		});
 		assert.deepEqual(calls.map((call) => call.args), [
 			["pr", "view", branch, "--json", PR_FIELDS],


### PR DESCRIPTION
## Summary
- add server PR status detection for GitHub ruleset bypass permissions
- plumb viewerCanMergeAsAdmin through PR caches, dashboard/session state, and the Git status widget
- show **Bypass merge** only when bypass capability is available and the PR is not conflicting
- harden PR merge endpoints to use gh argv via execFile instead of shell interpolation
- document the behavior and test coverage

## Validation
- npm run check
- npx tsx --test tests/pr-status-lookup.test.ts
- npx playwright test tests/git-status-widget-states.spec.ts --config tests/playwright.config.ts
- implementation workflow gate passed
- documentation workflow gate passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)