### PR TITLE
Reviewer Archive Cleanup

### DIFF
--- a/docs/llm-review-recovery.md
+++ b/docs/llm-review-recovery.md
@@ -118,6 +118,8 @@ In-flight reviewer steps also persist in active verification state. After a gate
 
 Live `nonInteractive` sessions that are not referenced by active verification state are surfaced deterministically during boot resume. The harness asks `SessionManager.listOrphanedNonInteractiveSessions()` before any long resume wait and logs the orphaned reviewers; operators can inspect and terminate stale records through Settings → Maintenance or the `/api/maintenance/orphaned-sessions` and `/api/maintenance/cleanup-sessions` routes. A late `verification_result` from these orphaned sessions has no pending resolver, so surfacing is safer than silently waiting for timeout cleanup.
 
+Archived reviewer rows have an additional bucketing contract: verifier sessions are goal-owned even when old persisted metadata only has `goalId`, and transcript-bearing review/QA output must stay reachable while empty failed-startup placeholders stay out of standalone archive lists. See [Reviewer Archive Cleanup](reviewer-archive-cleanup.md) for the SessionStore backfill, sidebar fallback order, and pre-startup metadata stamping rules.
+
 This preserves the distinction between "the reviewed work is bad" and "the reviewer was interrupted by the gateway/runtime."
 
 ## Exhausted recovery diagnostics
@@ -156,11 +158,14 @@ Relevant unit coverage:
 - `tests/verification-reminder-race.test.ts` — reminder `waitForStreaming()` guard and post-reminder transient recovery ordering.
 - `tests/verification-resume-restart-prompt.test.ts` — cold restart resume prompt timeout routes to pending instead of hard failure.
 - `tests/verification-resume-restart-recovery.test.ts` — cold reviewer readiness wait and transient resume failure rerun path.
+- `tests/reviewer-archive-metadata.test.ts` — verifier metadata persistence before startup and legacy SessionStore backfill.
+- `tests/ui-fixtures/sidebar-archived-fixture.spec.ts` — archived verifier bucketing and transcript/placeholder fallback visibility.
 
 Focused checks while changing this area:
 
 ```bash
-npx tsx --test tests/verification-logic.test.ts tests/transient-review-error.test.ts tests/verification-reminder-race.test.ts tests/verification-resume-restart-prompt.test.ts tests/verification-resume-restart-recovery.test.ts
+npx tsx --test tests/verification-logic.test.ts tests/transient-review-error.test.ts tests/verification-reminder-race.test.ts tests/verification-resume-restart-prompt.test.ts tests/verification-resume-restart-recovery.test.ts tests/reviewer-archive-metadata.test.ts
+npx playwright test tests/ui-fixtures/sidebar-archived-fixture.spec.ts
 ```
 
 Full required checks for production changes in this area:

--- a/docs/reviewer-archive-cleanup.md
+++ b/docs/reviewer-archive-cleanup.md
@@ -1,0 +1,85 @@
+# Reviewer Archive Cleanup
+
+`llm-review` and `agent-qa` verification steps run as visible, non-interactive sessions so their transcript can be inspected and restart recovery can re-drive them. Those sessions are not standalone user chats: they are owned by the gate's goal and, when team mode is active, by the team lead that triggered verification.
+
+This document defines how Bobbit keeps archived verifier sessions out of the top-level Archived → Sessions list without losing real review or QA transcripts.
+
+## Session identity and ownership
+
+Verifier-owned sessions are recognized by their generated IDs:
+
+- `llm-review-*`
+- `agent-qa-*`
+
+The verification harness stamps reviewer metadata before agent startup by building a shared reviewer metadata payload and passing it into `SessionManager.createSession()`. That payload includes:
+
+- `teamGoalId` — the owning goal, even though `goalId` may also be present for compatibility;
+- `teamLeadSessionId` — the triggering team lead when known;
+- `role` and reviewer accessory;
+- `nonInteractive: true`.
+
+Pre-startup stamping matters because setup can fail after the persisted session row is created but before the agent produces a transcript or receives a title. A failed-startup placeholder must already carry enough goal/team metadata to avoid becoming a generic archived session row.
+
+After startup, the harness still sets the generated review title and rewrites the same metadata as a belt-and-suspenders update. It also registers the session in team state as a reviewer, not a worker, so restart resume can rebind it while worker-capacity and team-lead nudges ignore it.
+
+## Legacy SessionStore backfill
+
+Older persisted rows may have only `goalId`, a generic title such as `New session`, and no `teamGoalId` / `teamLeadSessionId`. `SessionStore` normalizes these rows when it loads `sessions.json`:
+
+1. Only recognized verifier IDs are considered. Ordinary archived sessions with `goalId` remain unchanged.
+2. If a verifier has `goalId` but no `teamGoalId`, the store sets `teamGoalId = goalId`.
+3. If exactly one team-lead session can be inferred for that goal, the store fills `teamLeadSessionId`.
+4. The store stamps `nonInteractive: true` and a default verifier accessory when missing.
+5. Existing transcript paths, titles, archive timestamps, project IDs, and other metadata are preserved.
+
+The backfill is intentionally conservative: it repairs ownership/display metadata only. It does not delete transcript-bearing rows or reinterpret unrelated user sessions.
+
+## Archived sidebar bucketing
+
+The sidebar uses an effective archived team-goal relationship for archived rows:
+
+```text
+effectiveArchivedTeamGoalId = session.teamGoalId
+  ?? (is verifier session ? session.goalId : undefined)
+```
+
+That effective relationship drives both desktop and mobile archived render paths:
+
+- goal-affiliated verifiers nest under their owning archived/live goal;
+- when a matching team lead is available, they nest with that lead's members;
+- verifier rows with only legacy `goalId` no longer qualify as project-level standalone archived sessions;
+- normal standalone archived user sessions still render in the project Archived → Sessions bucket.
+
+Search follows the same affiliation rule, so archived-goal matches can include legacy verifier titles/roles without promoting those verifier rows to standalone sessions.
+
+## Placeholder vs transcript fallback
+
+Bobbit treats empty failed-startup placeholders differently from real review output.
+
+A verifier placeholder with no readable or recoverable transcript and only a generic title should not appear as a top-level archived session. If it has an owning goal, it is bucketed under that goal instead of the standalone list. If the owning goal is unavailable and the row has no useful content, the sidebar hides it.
+
+A transcript-bearing verifier must remain reachable even when ownership inference is incomplete. Fallback visibility is:
+
+1. Prefer nesting under the owning goal/team lead when `teamGoalId`, backfilled `goalId`, or an inferred lead makes that possible.
+2. If the owning goal is renderable but no lead can be inferred, show it under the goal's archived/member bucket rather than the top-level sessions bucket.
+3. If no owning goal is renderable but the row has a transcript path or meaningful title, keep it visible as a last-resort standalone archived session.
+4. Hide only verifier rows that are both ownership-orphaned and content-empty.
+
+This preserves access to real reviewer/QA transcripts while removing empty `New session` placeholders from the archived-session flood.
+
+## Regression coverage
+
+Relevant tests:
+
+- `tests/reviewer-archive-metadata.test.ts` — verifier metadata is built before `createSession()`, and legacy `SessionStore` rows are backfilled.
+- `tests/ui-fixtures/sidebar-archived-fixture.spec.ts` — legacy verifier rows stay out of standalone archive buckets, nest near live/archived team leads when possible, preserve transcript fallback visibility, and keep ordinary standalone sessions visible.
+- `tests/ui-fixtures/sidebar-archived-fixture-entry.ts` — shared desktop/mobile fixture data for archived bucketing cases.
+
+Focused checks while changing this area:
+
+```bash
+npx tsx --test tests/reviewer-archive-metadata.test.ts
+npx playwright test tests/ui-fixtures/sidebar-archived-fixture.spec.ts
+```
+
+Run the broader checks required by the code touched: UI-only changes need `npm run test:unit`; server lifecycle changes need `npm run check` plus the relevant unit/E2E coverage.

--- a/docs/sidebar-archived-search.md
+++ b/docs/sidebar-archived-search.md
@@ -32,7 +32,7 @@ Archived search uses the same case-insensitive substring contract as the sidebar
 - Archived goals match on `title`.
 - Archived goals also match when an affiliated non-child session matches on `title` or `role`.
 
-An affiliated session is attached through the goal relationship fields used by the sidebar (`goalId` or `teamGoalId`). Delegate and child sessions are not direct goal-match evidence, but the API can return related archived sessions for a matched goal page so the sidebar can render nesting correctly.
+An affiliated session is attached through the goal relationship fields used by the sidebar (`goalId` or `teamGoalId`). Archived verifier sessions (`llm-review-*` / `agent-qa-*`) also use `goalId` as an effective team-goal fallback when legacy rows are missing `teamGoalId`; see [Reviewer Archive Cleanup](reviewer-archive-cleanup.md). Delegate and child sessions are not direct goal-match evidence, but the API can return related archived sessions for a matched goal page so the sidebar can render nesting correctly.
 
 Search does not inspect transcript contents, tool output, goal specs, or task text.
 

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -90,6 +90,18 @@ export function isChildSession(session: GatewaySession): boolean {
 	return !!sessionParentId(session);
 }
 
+export function isVerifierSessionId(id: string | null | undefined): boolean {
+	return !!id && (/^llm-review-/.test(id) || /^agent-qa-/.test(id));
+}
+
+export function effectiveArchivedTeamGoalId(session: GatewaySession): string | undefined {
+	return session.teamGoalId || (isVerifierSessionId(session.id) ? session.goalId : undefined);
+}
+
+export function isStandaloneArchivedSession(session: GatewaySession): boolean {
+	return !effectiveArchivedTeamGoalId(session) && !isChildSession(session);
+}
+
 function isFirstClassChildSession(session: GatewaySession): boolean {
 	return !!session.parentSessionId && !session.delegateOf;
 }
@@ -165,7 +177,7 @@ export function filterArchivedGoalsByQuery(
 	const combined = [...liveSessions, ...archivedSessions];
 	return archivedGoals.filter(goal => {
 		if (goal.title.toLowerCase().includes(q)) return true;
-		const affiliated = combined.filter(s => (s.goalId === goal.id || s.teamGoalId === goal.id) && !isChildSession(s));
+		const affiliated = combined.filter(s => (s.goalId === goal.id || effectiveArchivedTeamGoalId(s) === goal.id) && !isChildSession(s));
 		return affiliated.some(s => s.title?.toLowerCase().includes(q) || s.role?.toLowerCase().includes(q));
 	});
 }
@@ -1318,7 +1330,7 @@ export function renderGoalGroup(goal: Goal, opts?: { descendantCount?: number; r
 
 	// On-demand fetch for expanded goals with no visible children
 	if (isExpanded && isTeamGoal && goalSessions.length === 0 && !_goalChildrenFetched.has(goal.id)) {
-		const archivedChildren = state.archivedSessions.filter(s => s.teamGoalId === goal.id);
+		const archivedChildren = state.archivedSessions.filter(s => effectiveArchivedTeamGoalId(s) === goal.id);
 		if (archivedChildren.length === 0) {
 			_goalChildrenFetched.add(goal.id);
 			gatewayFetch(`/api/goals/${goal.id}/team/agents?include=archived`)
@@ -1406,7 +1418,7 @@ export function renderGoalGroup(goal: Goal, opts?: { descendantCount?: number; r
 		//      render-side fallback covers ambiguous remainders.
 		const archivedForLiveLead = state.showArchived
 			? state.archivedSessions.filter(s =>
-				s.teamGoalId === goal.id
+				effectiveArchivedTeamGoalId(s) === goal.id
 				&& !isChildSession(s)
 				&& s.role !== "team-lead"
 				&& (s.teamLeadSessionId === teamLead.id || !s.teamLeadSessionId)
@@ -1537,7 +1549,7 @@ export function renderGoalGroup(goal: Goal, opts?: { descendantCount?: number; r
 					</div>` : ""}
 					${teamControls}
 					${state.showArchived ? (() => {
-						const archivedForGoal = state.archivedSessions.filter(s => s.teamGoalId === goal.id && !isChildSession(s));
+						const archivedForGoal = state.archivedSessions.filter(s => effectiveArchivedTeamGoalId(s) === goal.id && !isChildSession(s));
 						const archivedLeads = archivedForGoal.filter(s => s.role === "team-lead");
 						const archivedMembers = archivedForGoal.filter(s => s.role !== "team-lead");
 
@@ -1593,6 +1605,12 @@ export function renderGoalGroup(goal: Goal, opts?: { descendantCount?: number; r
 
 						return html`
 							${archivedLeads.map((s, i) => renderLeadWithMembers(s, i === archivedLeads.length - 1 && !teamLead))}
+							${!teamLead && archivedLeads.length === 0 && unmapped.length > 0 ? html`
+								${unmapped.map(m => html`
+									${renderArchivedSessionRow(m)}
+									${renderArchivedDelegates(m.id)}
+								`)}
+							` : ""}
 						`;
 					})() : ""}
 				</div>

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -98,8 +98,25 @@ export function effectiveArchivedTeamGoalId(session: GatewaySession): string | u
 	return session.teamGoalId || (isVerifierSessionId(session.id) ? session.goalId : undefined);
 }
 
+function hasRenderableOwningGoal(goalId: string | undefined): boolean {
+	return !!goalId && state.goals.some(goal => goal.id === goalId);
+}
+
+function hasVerifierFallbackContent(session: GatewaySession): boolean {
+	const row = session as GatewaySession & { agentSessionFile?: unknown };
+	const transcript = typeof row.agentSessionFile === "string"
+		? row.agentSessionFile.trim()
+		: row.agentSessionFile;
+	const title = (session.title || "").trim();
+	return !!transcript || (!!title && title !== "New session");
+}
+
 export function isStandaloneArchivedSession(session: GatewaySession): boolean {
-	return !effectiveArchivedTeamGoalId(session) && !isChildSession(session);
+	if (isChildSession(session)) return false;
+	const owningGoalId = effectiveArchivedTeamGoalId(session);
+	if (!owningGoalId) return true;
+	if (!isVerifierSessionId(session.id)) return false;
+	return !hasRenderableOwningGoal(owningGoalId) && hasVerifierFallbackContent(session);
 }
 
 function isFirstClassChildSession(session: GatewaySession): boolean {

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -72,7 +72,7 @@ import "../ui/components/review/ReviewPane.js";
 // Register inbox panel web components
 import "../ui/inbox/InboxPanel.js";
 
-import { renderGoalGroup, renderSessionRow, renderSandboxIndicator, INDENT, getProjectAccentColor, filterArchivedGoalsByQuery, filterArchivedSessionsByQuery, bucketArchivedByProject, renderProjectArchivedSection, passesSidebarFilters, isChildSession } from "./render-helpers.js";
+import { renderGoalGroup, renderSessionRow, renderSandboxIndicator, INDENT, getProjectAccentColor, filterArchivedGoalsByQuery, filterArchivedSessionsByQuery, bucketArchivedByProject, renderProjectArchivedSection, passesSidebarFilters, isChildSession, isStandaloneArchivedSession, effectiveArchivedTeamGoalId } from "./render-helpers.js";
 import { PROPOSAL_TYPES, type ProposalType } from "./proposal-registry.js";
 import {
 	CHAT_PANEL_TAB_ID,
@@ -350,7 +350,7 @@ function renderMobileLanding() {
 		const q = state.searchQuery.toLowerCase();
 		liveGoals = liveGoals.filter(goal => {
 			const goalMatches = goal.title.toLowerCase().includes(q);
-			const goalSessions = state.gatewaySessions.filter(s => (s.goalId === goal.id || s.teamGoalId === goal.id) && !isChildSession(s));
+			const goalSessions = state.gatewaySessions.filter(s => (s.goalId === goal.id || effectiveArchivedTeamGoalId(s) === goal.id) && !isChildSession(s));
 			const hasMatchingSession = goalSessions.some(s => s.title?.toLowerCase().includes(q) || s.role?.toLowerCase().includes(q));
 			return goalMatches || hasMatchingSession;
 		});
@@ -504,7 +504,7 @@ function renderMobileLanding() {
 											bucket.staff.push(s);
 										}
 										// Bucket archived goals + standalone archived sessions per project.
-										const allStandaloneArchivedAll = state.showArchived ? state.archivedSessions.filter(s => !s.teamGoalId && !isChildSession(s)) : [];
+										const allStandaloneArchivedAll = state.showArchived ? state.archivedSessions.filter(isStandaloneArchivedSession) : [];
 										const filteredStandaloneArchivedAll = filterArchivedSessionsByQuery(allStandaloneArchivedAll, state.searchQuery);
 										const archivedByProject = bucketArchivedByProject(archivedGoals, filteredStandaloneArchivedAll, projectsForRender);
 										return html`<div data-project-reorder-list>${projectsForRender.map((project, i) => {

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -35,7 +35,7 @@ import { startNewGoalFlow, showProjectPickerPopover } from "./goal-entry.js";
 import { refreshSessions, retryLoadSessions, fetchRoles, fetchStaff, fetchOrphanedStaff, reassignStaffProject, enqueueInboxManual, fetchArchivedSessions, archivedSessionsLoaded, fetchSandboxStatus, fetchArchivedGoalsPaginated, fetchArchivedSessionsPaginated, fetchArchivedSearchGoalsPaginated, fetchArchivedSearchSessionsPaginated, gatewayFetch, clearArchivedSessionsState, clearArchivedSearchState, scheduleArchivedRemoteSearch, fetchProjects, saveProjectOrder } from "./api.js";
 import { errorFromResponse, errorDetails } from "./error-helpers.js";
 import { statusBobbit, sessionAcronym } from "./session-colors.js";
-import { renderGoalGroup, renderSessionRow, SESSION_ROW_PY, INDENT, HEADER_CHEVRON_W, terseRelativeTime, hasUnseenActivity, formatSessionAge, renderSessionTitle, getProjectAccentColor, filterArchivedGoalsByQuery, filterArchivedSessionsByQuery, renderProjectArchivedSection as renderSharedProjectArchivedSection, archivedDivider, bucketActiveArchived, passesSidebarFilters, isChildSession } from "./render-helpers.js";
+import { renderGoalGroup, renderSessionRow, SESSION_ROW_PY, INDENT, HEADER_CHEVRON_W, terseRelativeTime, hasUnseenActivity, formatSessionAge, renderSessionTitle, getProjectAccentColor, filterArchivedGoalsByQuery, filterArchivedSessionsByQuery, renderProjectArchivedSection as renderSharedProjectArchivedSection, archivedDivider, bucketActiveArchived, passesSidebarFilters, isChildSession, isStandaloneArchivedSession, effectiveArchivedTeamGoalId } from "./render-helpers.js";
 import { renderFiltersButton } from "../ui/components/sidebar-filters.js";
 import { shortcutHint } from "./shortcut-registry.js";
 import type { GatewaySession } from "./state.js";
@@ -1581,7 +1581,7 @@ export function renderSidebar() {
 								// Client-side title filter
 								filteredGoals = liveGoals.map(goal => {
 									const goalMatches = goal.title.toLowerCase().includes(q);
-									const goalSessions = state.gatewaySessions.filter(s => (s.goalId === goal.id || s.teamGoalId === goal.id) && !isChildSession(s));
+									const goalSessions = state.gatewaySessions.filter(s => (s.goalId === goal.id || effectiveArchivedTeamGoalId(s) === goal.id) && !isChildSession(s));
 									const hasMatchingSession = goalSessions.some(s => s.title?.toLowerCase().includes(q) || s.role?.toLowerCase().includes(q));
 									if (!goalMatches && !hasMatchingSession) return null as unknown as Goal;
 									return goal;
@@ -1643,7 +1643,7 @@ export function renderSidebar() {
 							}
 
 							// Filter + bucket archived goals / standalone archived sessions by project.
-							const allStandaloneArchived = state.archivedSessions.filter(s => !s.teamGoalId && !isChildSession(s));
+							const allStandaloneArchived = state.archivedSessions.filter(isStandaloneArchivedSession);
 							const filteredArchivedGoals = filterArchivedGoalsByQuery(archivedGoals, state.gatewaySessions, state.archivedSessions, state.searchQuery);
 							const filteredStandaloneArchived = filterArchivedSessionsByQuery(allStandaloneArchived, state.searchQuery);
 							for (const g of filteredArchivedGoals) {
@@ -1826,7 +1826,7 @@ function renderCollapsedSidebar(sortedGoals: Goal[], _ungroupedSessions: Gateway
 					return html`
 						${pi > 0 ? html`<div class="w-7 border-t border-border/50 my-1.5"></div>` : ""}
 						${bucket.goals.map((goal, i) => {
-							const goalSessions = allSessions.filter((s) => (s.goalId === goal.id || s.teamGoalId === goal.id) && !isChildSession(s)).sort((a, b) => a.createdAt - b.createdAt);
+							const goalSessions = allSessions.filter((s) => (s.goalId === goal.id || effectiveArchivedTeamGoalId(s) === goal.id) && !isChildSession(s)).sort((a, b) => a.createdAt - b.createdAt);
 							const expanded = expandedGoals.has(goal.id);
 							return html`
 								${i > 0 ? html`<div class="w-7 border-t border-border/50 my-1.5"></div>` : ""}
@@ -1868,7 +1868,7 @@ function renderCollapsedSidebar(sortedGoals: Goal[], _ungroupedSessions: Gateway
 				${state.showArchived && archivedGoals.length > 0 ? html`
 					<div class="w-7 border-t border-border/50 my-1.5"></div>
 					${archivedGoals.map((goal) => {
-						const goalSessions = allSessions.filter((s) => (s.goalId === goal.id || s.teamGoalId === goal.id) && !isChildSession(s)).sort((a, b) => a.createdAt - b.createdAt);
+						const goalSessions = allSessions.filter((s) => (s.goalId === goal.id || effectiveArchivedTeamGoalId(s) === goal.id) && !isChildSession(s)).sort((a, b) => a.createdAt - b.createdAt);
 						const expanded = expandedGoals.has(goal.id);
 						return html`
 							<div class="opacity-60">

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -5486,7 +5486,7 @@ export class SessionManager {
 		}
 	}
 
-	async createSession(cwd: string, agentArgs?: string[], goalId?: string, assistantType?: string, opts?: { rolePrompt?: string; roleName?: string; role?: string; accessory?: string; env?: Record<string, string>; taskId?: string; staffId?: string; allowedTools?: string[]; workflowContext?: string; worktreeOpts?: { repoPath: string }; worktreePushPolicy?: WorktreePushPolicy; reattemptGoalId?: string; sandboxed?: boolean; projectId?: string; sessionId?: string; sandboxBranch?: string; sandboxBaseBranch?: string; sandboxCwdOffset?: string; skipAutoModel?: boolean; skipAutoThinking?: boolean; initialModel?: string; initialThinkingLevel?: string; preExistingAgentSessionFile?: string; preExistingAgentSessionOldCwds?: string[]; parentSessionId?: string; childKind?: string; readOnly?: boolean; title?: string; awaitWorktreeSetup?: boolean; bypassWorktreePool?: boolean }): Promise<SessionInfo> {
+	async createSession(cwd: string, agentArgs?: string[], goalId?: string, assistantType?: string, opts?: { rolePrompt?: string; roleName?: string; role?: string; teamGoalId?: string; teamLeadSessionId?: string; accessory?: string; nonInteractive?: boolean; env?: Record<string, string>; taskId?: string; staffId?: string; allowedTools?: string[]; workflowContext?: string; worktreeOpts?: { repoPath: string }; worktreePushPolicy?: WorktreePushPolicy; reattemptGoalId?: string; sandboxed?: boolean; projectId?: string; sessionId?: string; sandboxBranch?: string; sandboxBaseBranch?: string; sandboxCwdOffset?: string; skipAutoModel?: boolean; skipAutoThinking?: boolean; initialModel?: string; initialThinkingLevel?: string; preExistingAgentSessionFile?: string; preExistingAgentSessionOldCwds?: string[]; parentSessionId?: string; childKind?: string; readOnly?: boolean; title?: string; awaitWorktreeSetup?: boolean; bypassWorktreePool?: boolean }): Promise<SessionInfo> {
 		const id = opts?.sessionId || randomUUID();
 		const optsAllowedTagged: EffectiveTool[] | undefined = opts?.allowedTools
 			? opts.allowedTools.map(n => tagAllowedTool(n, this.toolManager))
@@ -5564,6 +5564,8 @@ export class SessionManager {
 				isCompacting: false,
 				titleGenerated: false,
 				goalId,
+				teamGoalId: opts?.teamGoalId,
+				teamLeadSessionId: opts?.teamLeadSessionId,
 				assistantType,
 				taskId: opts?.taskId,
 				parentSessionId: opts?.parentSessionId,
@@ -5576,6 +5578,7 @@ export class SessionManager {
 				// keys off the right role id during the worktree-prep window.
 				role: opts?.role ?? opts?.roleName,
 				accessory: opts?.accessory,
+				nonInteractive: opts?.nonInteractive,
 				worktreePath,
 				worktreePushPolicy: opts?.worktreePushPolicy,
 				projectId,
@@ -5604,6 +5607,8 @@ export class SessionManager {
 				title: opts?.title || "New session",
 				cwd,
 				goalId,
+				teamGoalId: opts?.teamGoalId,
+				teamLeadSessionId: opts?.teamLeadSessionId,
 				assistantType,
 				taskId: opts?.taskId,
 				// Load-bearing wire: threads staffId from opts → plan → persistOnce so it
@@ -5621,6 +5626,7 @@ export class SessionManager {
 				sandboxed: opts?.sandboxed,
 				role: opts?.role,
 				accessory: opts?.accessory,
+				nonInteractive: opts?.nonInteractive,
 				agentArgs,
 				env: opts?.env,
 				rolePrompt: resolvedRolePrompt,
@@ -5691,6 +5697,8 @@ export class SessionManager {
 			title: opts?.title || "New session",
 			cwd,
 			goalId,
+			teamGoalId: opts?.teamGoalId,
+			teamLeadSessionId: opts?.teamLeadSessionId,
 			assistantType,
 			taskId: opts?.taskId,
 			parentSessionId: opts?.parentSessionId,
@@ -5704,6 +5712,7 @@ export class SessionManager {
 			sandboxed: opts?.sandboxed,
 			role: opts?.role,
 			accessory: opts?.accessory,
+			nonInteractive: opts?.nonInteractive,
 			agentArgs,
 			env: opts?.env,
 			rolePrompt: resolvedRolePrompt,

--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -246,6 +246,7 @@ export interface SessionSetupPlan {
 	 * carry `goalId`) and for goal-less sessions.
 	 */
 	teamGoalId?: string;
+	teamLeadSessionId?: string;
 	assistantType?: string;
 	delegateOf?: string;
 	parentSessionId?: string;
@@ -990,6 +991,8 @@ export function persistOnce(session: SessionInfo, plan: SessionSetupPlan, store:
 		createdAt: session.createdAt,
 		lastActivity: session.lastActivity,
 		goalId: plan.goalId,
+		teamGoalId: plan.teamGoalId,
+		teamLeadSessionId: plan.teamLeadSessionId,
 		assistantType: plan.assistantType,
 		role: plan.role ?? plan.roleName,
 		worktreePath: plan.worktreePath,
@@ -1475,6 +1478,8 @@ async function spawnAgent(plan: SessionSetupPlan, ctx: PipelineContext): Promise
 		// defaults plan.title to "New session", so any other value is a deliberate title.
 		titleGenerated: !!assistantDef || plan.mode === "delegate" || (!!plan.title && plan.title !== "New session"),
 		goalId: plan.goalId,
+		teamGoalId: plan.teamGoalId,
+		teamLeadSessionId: plan.teamLeadSessionId,
 		assistantType: plan.assistantType,
 		taskId: plan.taskId,
 		delegateOf: plan.delegateOf,
@@ -1487,6 +1492,7 @@ async function spawnAgent(plan: SessionSetupPlan, ctx: PipelineContext): Promise
 		// `tryAutoSelectModel` safety net keys off the right role id.
 		role: plan.role ?? plan.roleName,
 		accessory: plan.accessory,
+		nonInteractive: plan.nonInteractive,
 		promptQueue: new PromptQueue(),
 		spawnPinnedModel,
 		spawnPinnedThinkingLevel,

--- a/src/server/agent/session-store.ts
+++ b/src/server/agent/session-store.ts
@@ -5,6 +5,15 @@ import type { SidePanelWorkspace } from "../../shared/side-panel-workspace.js";
 
 /** 24h in ms — recency threshold for `shouldKeepDespiteOrphan`. */
 const RECENT_TRANSCRIPT_WINDOW_MS = 24 * 60 * 60 * 1000;
+const VERIFIER_SESSION_ID_RE = /^(?:llm-review|agent-qa)-/;
+
+function isVerifierSessionId(id: string): boolean {
+	return VERIFIER_SESSION_ID_RE.test(id);
+}
+
+function defaultVerifierAccessory(id: string): string {
+	return id.startsWith("agent-qa-") ? "stamp" : "magnifier";
+}
 
 /**
  * Tightened orphan-cleanup gate. Returns true when an apparently-orphaned
@@ -222,7 +231,7 @@ export class SessionStore {
 		this.load();
 	}
 
-	/** Normalise a single PersistedSession-shaped row read from disk (legacy field migration). */
+	/** Normalise PersistedSession-shaped rows read from disk (legacy field migration). */
 	private seedFromArray(rows: unknown[]): void {
 		for (const row of rows) {
 			if (!row || typeof row !== "object") continue;
@@ -247,6 +256,44 @@ export class SessionStore {
 				else if (s.toolAssistant) s.assistantType = "tool";
 			}
 			this.sessions.set(s.id, s);
+		}
+		this.normalizeLegacyVerifierSessions();
+	}
+
+	/**
+	 * Backfill archived verifier rows created before setup metadata was stamped.
+	 * Keep the rows (and any transcripts) intact; only fill ownership/display
+	 * fields so clients stop treating goal-owned verifier placeholders as
+	 * standalone user sessions.
+	 */
+	private normalizeLegacyVerifierSessions(): void {
+		const uniqueTeamLeadByGoal = new Map<string, string | null>();
+		const addTeamLeadCandidate = (goalId: string | undefined, sessionId: string) => {
+			if (!goalId) return;
+			const existing = uniqueTeamLeadByGoal.get(goalId);
+			if (existing === undefined) {
+				uniqueTeamLeadByGoal.set(goalId, sessionId);
+			} else if (existing !== sessionId) {
+				uniqueTeamLeadByGoal.set(goalId, null);
+			}
+		};
+		for (const session of this.sessions.values()) {
+			if (session.role !== "team-lead") continue;
+			addTeamLeadCandidate(session.teamGoalId, session.id);
+			addTeamLeadCandidate(session.goalId, session.id);
+		}
+
+		for (const session of this.sessions.values()) {
+			if (!isVerifierSessionId(session.id) || !session.goalId) continue;
+			if (!session.teamGoalId) session.teamGoalId = session.goalId;
+			if (!session.teamLeadSessionId) {
+				const inferredLead = uniqueTeamLeadByGoal.get(session.teamGoalId ?? session.goalId);
+				if (inferredLead) session.teamLeadSessionId = inferredLead;
+			}
+			if (session.nonInteractive !== true) session.nonInteractive = true;
+			if (!session.accessory || session.accessory === "none") {
+				session.accessory = defaultVerifierAccessory(session.id);
+			}
 		}
 	}
 

--- a/src/server/agent/verification-harness.ts
+++ b/src/server/agent/verification-harness.ts
@@ -3218,10 +3218,18 @@ export class VerificationHarness {
 				? _preRoleThinking
 				: ((_preReviewThinkingPref && _validLevels.includes(_preReviewThinkingPref)) ? _preReviewThinkingPref : "off");
 			const _preInitialThinking = clampReviewThinking(_preInitialThinkingRaw, _preInitialModel) ?? _preInitialThinkingRaw;
+			const reviewerMeta = buildVerificationReviewerMeta({
+				kind: "llm-review",
+				roleName,
+				goalId,
+				roleAccessory: role.accessory,
+				teamLeadSessionId: this.teamManager?.getTeamState(goalId)?.teamLeadSessionId,
+			});
 
 			const session = await this.sessionManager!.createSession(cwd, undefined, goalId, undefined, {
 				rolePrompt: combinedPrompt,
 				roleName,
+				...reviewerMeta,
 				sandboxed: isSandboxed,
 				sessionId,
 				skipAutoModel: true,
@@ -3243,13 +3251,7 @@ export class VerificationHarness {
 			// and the archived render path lumps them under "unmapped" — they
 			// only surface under the LAST archived team-lead. Pure-helper
 			// contract pinned by tests/verification-reviewer-meta.test.ts.
-			this.sessionManager!.updateSessionMeta(sessionId, buildVerificationReviewerMeta({
-				kind: "llm-review",
-				roleName,
-				goalId,
-				roleAccessory: role.accessory,
-				teamLeadSessionId: this.teamManager?.getTeamState(goalId)?.teamLeadSessionId,
-			}));
+			this.sessionManager!.updateSessionMeta(sessionId, reviewerMeta);
 
 			// Register in team store (if team manager available)
 			if (this.teamManager) {
@@ -3581,10 +3583,18 @@ export class VerificationHarness {
 				? _preQaRoleThinking
 				: ((_preQaReviewThinkPref && _qaValidLevels.includes(_preQaReviewThinkPref)) ? _preQaReviewThinkPref : "off");
 			const _preQaInitialThinking = clampReviewThinking(_preQaInitialThinkingRaw, _preQaInitialModel) ?? _preQaInitialThinkingRaw;
+			const qaReviewerMeta = buildVerificationReviewerMeta({
+				kind: "agent-qa",
+				roleName: qaRoleName,
+				goalId,
+				roleAccessory: role.accessory,
+				teamLeadSessionId: this.teamManager?.getTeamState(goalId)?.teamLeadSessionId,
+			});
 
 			const session = await this.sessionManager!.createSession(cwd, undefined, goalId, undefined, {
 				rolePrompt: combinedPrompt,
 				roleName: qaRoleName,
+				...qaReviewerMeta,
 				sandboxed: qaIsSandboxed,
 				sessionId: qaSessionId,
 				skipAutoModel: true,
@@ -3603,13 +3613,7 @@ export class VerificationHarness {
 			const qaTitlePrefix = step.name?.trim()
 				|| (step.role ? `QA (${step.role})` : "QA");
 			this.sessionManager!.setTitle(qaSessionId, `${qaTitlePrefix}: ${qaFunName}`);
-			this.sessionManager!.updateSessionMeta(qaSessionId, buildVerificationReviewerMeta({
-				kind: "agent-qa",
-				roleName: qaRoleName,
-				goalId,
-				roleAccessory: role.accessory,
-				teamLeadSessionId: this.teamManager?.getTeamState(goalId)?.teamLeadSessionId,
-			}));
+			this.sessionManager!.updateSessionMeta(qaSessionId, qaReviewerMeta);
 
 			// Register in team store
 			if (this.teamManager) {

--- a/tests/reviewer-archive-metadata.test.ts
+++ b/tests/reviewer-archive-metadata.test.ts
@@ -1,0 +1,214 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { SessionStore } from "../src/server/agent/session-store.js";
+
+const SRC_ROOT = path.resolve(process.cwd(), "src", "server", "agent");
+
+function src(file: string): string {
+	return fs.readFileSync(path.join(SRC_ROOT, file), "utf-8");
+}
+
+function extractSourceSlice(source: string, startMarker: string, endMarker: string): string {
+	const start = source.indexOf(startMarker);
+	assert.notEqual(start, -1, `REVIEWER_ARCHIVE_METADATA missing source marker: ${startMarker}`);
+	const end = source.indexOf(endMarker, start + startMarker.length);
+	assert.notEqual(end, -1, `REVIEWER_ARCHIVE_METADATA missing source end marker: ${endMarker}`);
+	return source.slice(start, end);
+}
+
+function createSessionOptionsSlice(methodBody: string): string {
+	const createIndex = methodBody.indexOf(".createSession(");
+	assert.notEqual(createIndex, -1, "REVIEWER_ARCHIVE_METADATA verifier path must call SessionManager.createSession");
+	const end = methodBody.indexOf("\n\t\t\t});", createIndex);
+	assert.notEqual(end, -1, "REVIEWER_ARCHIVE_METADATA could not locate createSession options object");
+	return methodBody.slice(createIndex, end + "\n\t\t\t});".length);
+}
+
+function assertVerifierCreateSessionIsPreStamped(methodBody: string, kind: "llm-review" | "agent-qa"): void {
+	const createIndex = methodBody.indexOf(".createSession(");
+	assert.notEqual(createIndex, -1, `REVIEWER_ARCHIVE_METADATA ${kind} verifier must create a visible session`);
+	const metaIndex = methodBody.indexOf(`buildVerificationReviewerMeta({\n\t\t\t\tkind: "${kind}"`);
+	assert.notEqual(metaIndex, -1, `REVIEWER_ARCHIVE_METADATA ${kind} verifier must build reviewer metadata`);
+	assert.ok(
+		metaIndex < createIndex,
+		`REVIEWER_ARCHIVE_METADATA ${kind} must build reviewer metadata before createSession so setup-failure placeholders are pre-stamped`,
+	);
+
+	const createOptions = createSessionOptionsSlice(methodBody);
+	assert.match(
+		createOptions,
+		/(\.\.\.[A-Za-z0-9_]*(?:Meta|meta|Metadata|metadata)|teamGoalId\s*:)/,
+		`REVIEWER_ARCHIVE_METADATA ${kind} createSession options must include reviewer teamGoalId metadata before startup`,
+	);
+	assert.match(
+		createOptions,
+		/(\.\.\.[A-Za-z0-9_]*(?:Meta|meta|Metadata|metadata)|teamLeadSessionId\s*:)/,
+		`REVIEWER_ARCHIVE_METADATA ${kind} createSession options must include reviewer teamLeadSessionId metadata before startup`,
+	);
+	assert.match(
+		createOptions,
+		/(\.\.\.[A-Za-z0-9_]*(?:Meta|meta|Metadata|metadata)|nonInteractive\s*:)/,
+		`REVIEWER_ARCHIVE_METADATA ${kind} createSession options must include nonInteractive before startup`,
+	);
+}
+
+describe("reviewer archive metadata persistence", () => {
+	it("threads verifier/team metadata through createSession options into setup plans before startup", () => {
+		const manager = src("session-manager.ts");
+
+		assert.match(
+			manager,
+			/teamGoalId\?:\s*string/,
+			"REVIEWER_ARCHIVE_METADATA createSession opts must accept teamGoalId",
+		);
+		assert.match(
+			manager,
+			/teamLeadSessionId\?:\s*string/,
+			"REVIEWER_ARCHIVE_METADATA createSession opts must accept teamLeadSessionId",
+		);
+		assert.match(
+			manager,
+			/nonInteractive\?:\s*boolean/,
+			"REVIEWER_ARCHIVE_METADATA createSession opts must accept nonInteractive",
+		);
+
+		assert.ok(
+			(manager.match(/teamGoalId:\s*opts\?\.teamGoalId/g) ?? []).length >= 2,
+			"REVIEWER_ARCHIVE_METADATA normal and worktree setup plans must copy opts.teamGoalId",
+		);
+		assert.ok(
+			(manager.match(/teamLeadSessionId:\s*opts\?\.teamLeadSessionId/g) ?? []).length >= 2,
+			"REVIEWER_ARCHIVE_METADATA normal and worktree setup plans must copy opts.teamLeadSessionId",
+		);
+		assert.ok(
+			(manager.match(/nonInteractive:\s*opts\?\.nonInteractive/g) ?? []).length >= 2,
+			"REVIEWER_ARCHIVE_METADATA normal and worktree setup plans must copy opts.nonInteractive",
+		);
+	});
+
+	it("persists setup-plan verifier ownership fields in the first session-store row", () => {
+		const setup = src("session-setup.ts");
+
+		assert.match(
+			setup,
+			/teamGoalId:\s*plan\.teamGoalId/,
+			"REVIEWER_ARCHIVE_METADATA persistOnce must write teamGoalId in the initial row",
+		);
+		assert.match(
+			setup,
+			/teamLeadSessionId:\s*plan\.teamLeadSessionId/,
+			"REVIEWER_ARCHIVE_METADATA persistOnce must write teamLeadSessionId in the initial row",
+		);
+		assert.match(
+			setup,
+			/nonInteractive:\s*plan\.nonInteractive/,
+			"REVIEWER_ARCHIVE_METADATA persistOnce must write nonInteractive in the initial row",
+		);
+	});
+
+	it("passes llm-review and agent-qa reviewer metadata into createSession before agent startup", () => {
+		const harness = src("verification-harness.ts");
+		const llmReviewBody = extractSourceSlice(
+			harness,
+			"private async runLlmReviewViaSession(",
+			"static buildQaKickoffMessage(",
+		);
+		const agentQaBody = extractSourceSlice(
+			harness,
+			"private async runAgentQaStep(",
+			"private async runLlmReviewDirect(",
+		);
+
+		assertVerifierCreateSessionIsPreStamped(llmReviewBody, "llm-review");
+		assertVerifierCreateSessionIsPreStamped(agentQaBody, "agent-qa");
+	});
+
+	it("normalizes legacy verifier archive rows with goalId-only while leaving standalone archived sessions unchanged", () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-reviewer-archive-"));
+		try {
+			fs.writeFileSync(path.join(tempDir, "sessions.json"), JSON.stringify({
+				version: 2,
+				epoch: 1,
+				sessions: [
+					{
+						id: "team-lead-goal-one",
+						title: "Team lead",
+						cwd: tempDir,
+						agentSessionFile: "lead.jsonl",
+						createdAt: 1,
+						lastActivity: 1,
+						archived: true,
+						role: "team-lead",
+						teamGoalId: "goal-one",
+					},
+					{
+						id: "llm-review-goal-only",
+						title: "New session",
+						cwd: tempDir,
+						agentSessionFile: "",
+						createdAt: 2,
+						lastActivity: 2,
+						archived: true,
+						goalId: "goal-one",
+						role: "bug-hunter",
+						accessory: "magnifier",
+					},
+					{
+						id: "agent-qa-goal-only",
+						title: "New session",
+						cwd: tempDir,
+						agentSessionFile: "",
+						createdAt: 3,
+						lastActivity: 3,
+						archived: true,
+						goalId: "goal-one",
+						role: "qa-tester",
+					},
+					{
+						id: "standalone-archived-user-session",
+						title: "User archived session",
+						cwd: tempDir,
+						agentSessionFile: "user.jsonl",
+						createdAt: 4,
+						lastActivity: 4,
+						archived: true,
+						goalId: "goal-two",
+					},
+				],
+			}, null, 2));
+
+			const store = new SessionStore(tempDir);
+			const byId = new Map(store.getArchived().map((session) => [session.id, session]));
+
+			for (const id of ["llm-review-goal-only", "agent-qa-goal-only"]) {
+				assert.equal(
+					byId.get(id)?.teamGoalId,
+					"goal-one",
+					`REVIEWER_ARCHIVE_METADATA ${id} must be backfilled from goalId to teamGoalId`,
+				);
+				assert.equal(
+					byId.get(id)?.teamLeadSessionId,
+					"team-lead-goal-one",
+					`REVIEWER_ARCHIVE_METADATA ${id} must infer the unique team lead for its goal`,
+				);
+			}
+
+			assert.equal(
+				byId.get("standalone-archived-user-session")?.teamGoalId,
+				undefined,
+				"REVIEWER_ARCHIVE_METADATA normal standalone archived sessions must not be converted into team sessions",
+			);
+			assert.equal(
+				byId.get("standalone-archived-user-session")?.teamLeadSessionId,
+				undefined,
+				"REVIEWER_ARCHIVE_METADATA normal standalone archived sessions must not receive a team lead",
+			);
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/tests/ui-fixtures/sidebar-archived-fixture-entry.ts
+++ b/tests/ui-fixtures/sidebar-archived-fixture-entry.ts
@@ -58,6 +58,8 @@ const IDS = {
 	archivedStandaloneB: "sidebar-archived-standalone-b",
 	legacyLlmReview: "llm-review-sidebar-archived-legacy-001",
 	legacyAgentQa: "agent-qa-sidebar-archived-legacy-001",
+	missingGoalReviewTranscript: "llm-review-sidebar-archived-missing-goal-transcript",
+	missingGoalReviewPlaceholder: "agent-qa-sidebar-archived-missing-goal-placeholder",
 	teamLead: "sidebar-archived-team-lead",
 	teamWorker: "sidebar-archived-team-worker",
 	archivedTeamLead: "sidebar-archived-archived-team-lead",
@@ -164,6 +166,8 @@ function fixtureArchivedSessions(): GatewaySession[] {
 		session({ id: IDS.archivedStandaloneA, title: "Alpha Archived Standalone Session", projectId: PROJECT_A_ID, createdAt: 70, archived: true, archivedAt: 170, status: "terminated" }),
 		session({ id: IDS.legacyLlmReview, title: "New session", projectId: PROJECT_A_ID, createdAt: 71, role: "bug-hunter", accessory: "magnifier", goalId: IDS.teamGoalA, archived: true, archivedAt: 171, status: "terminated", nonInteractive: true }),
 		session({ id: IDS.legacyAgentQa, title: "New session", projectId: PROJECT_A_ID, createdAt: 72, role: "tester", accessory: "magnifier", goalId: IDS.teamGoalA, archived: true, archivedAt: 172, status: "terminated", nonInteractive: true }),
+		session({ id: IDS.missingGoalReviewTranscript, title: "New session", projectId: PROJECT_A_ID, createdAt: 73, role: "bug-hunter", accessory: "magnifier", goalId: "sidebar-archived-missing-goal", archived: true, archivedAt: 173, status: "terminated", nonInteractive: true, ...({ agentSessionFile: "reviews/missing-goal-transcript.jsonl" } as any) }),
+		session({ id: IDS.missingGoalReviewPlaceholder, title: "New session", projectId: PROJECT_A_ID, createdAt: 74, role: "tester", accessory: "magnifier", goalId: "sidebar-archived-missing-goal", archived: true, archivedAt: 174, status: "terminated", nonInteractive: true }),
 		session({ id: IDS.archivedStandaloneB, title: "Bravo Archived Standalone Session", projectId: PROJECT_B_ID, createdAt: 80, archived: true, archivedAt: 180, status: "terminated" }),
 		session({ id: IDS.archivedTeamLead, title: "Alpha Archived Team Lead", projectId: PROJECT_A_ID, createdAt: 90, role: "team-lead", goalId: IDS.teamGoalA, teamGoalId: IDS.teamGoalA, archived: true, archivedAt: 190, status: "terminated" }),
 		session({ id: IDS.archivedTeamWorker, title: "Alpha Archived Team Worker", projectId: PROJECT_A_ID, createdAt: 91, role: "coder", goalId: IDS.teamGoalA, teamGoalId: IDS.teamGoalA, teamLeadSessionId: IDS.archivedTeamLead, archived: true, archivedAt: 191, status: "terminated" }),
@@ -282,7 +286,7 @@ async function resetFixture(options: { mode?: "desktop" | "mobile"; showArchived
 		archivedGoalsTotal: 4,
 		archivedSessionsCursor: null,
 		archivedSessionsHasMore: false,
-		archivedSessionsTotal: 8,
+		archivedSessionsTotal: 10,
 	});
 	window.history.replaceState({}, "", "#/fixture");
 	renderFixture();

--- a/tests/ui-fixtures/sidebar-archived-fixture-entry.ts
+++ b/tests/ui-fixtures/sidebar-archived-fixture-entry.ts
@@ -56,6 +56,8 @@ const IDS = {
 	archivedNestedDelegate: "sidebar-archived-nested-delegate-session",
 	archivedStandaloneA: "sidebar-archived-standalone-a",
 	archivedStandaloneB: "sidebar-archived-standalone-b",
+	legacyLlmReview: "llm-review-sidebar-archived-legacy-001",
+	legacyAgentQa: "agent-qa-sidebar-archived-legacy-001",
 	teamLead: "sidebar-archived-team-lead",
 	teamWorker: "sidebar-archived-team-worker",
 	archivedTeamLead: "sidebar-archived-archived-team-lead",
@@ -160,6 +162,8 @@ function fixtureArchivedSessions(): GatewaySession[] {
 		session({ id: IDS.archivedDelegate, title: "Alpha Archived Delegate", projectId: PROJECT_A_ID, createdAt: 60, delegateOf: IDS.liveSessionParent, archived: true, archivedAt: 160, status: "terminated" }),
 		session({ id: IDS.archivedNestedDelegate, title: "Alpha Archived Nested Delegate", projectId: PROJECT_A_ID, createdAt: 61, delegateOf: IDS.archivedDelegate, archived: true, archivedAt: 161, status: "terminated" }),
 		session({ id: IDS.archivedStandaloneA, title: "Alpha Archived Standalone Session", projectId: PROJECT_A_ID, createdAt: 70, archived: true, archivedAt: 170, status: "terminated" }),
+		session({ id: IDS.legacyLlmReview, title: "New session", projectId: PROJECT_A_ID, createdAt: 71, role: "bug-hunter", accessory: "magnifier", goalId: IDS.teamGoalA, archived: true, archivedAt: 171, status: "terminated", nonInteractive: true }),
+		session({ id: IDS.legacyAgentQa, title: "New session", projectId: PROJECT_A_ID, createdAt: 72, role: "tester", accessory: "magnifier", goalId: IDS.teamGoalA, archived: true, archivedAt: 172, status: "terminated", nonInteractive: true }),
 		session({ id: IDS.archivedStandaloneB, title: "Bravo Archived Standalone Session", projectId: PROJECT_B_ID, createdAt: 80, archived: true, archivedAt: 180, status: "terminated" }),
 		session({ id: IDS.archivedTeamLead, title: "Alpha Archived Team Lead", projectId: PROJECT_A_ID, createdAt: 90, role: "team-lead", goalId: IDS.teamGoalA, teamGoalId: IDS.teamGoalA, archived: true, archivedAt: 190, status: "terminated" }),
 		session({ id: IDS.archivedTeamWorker, title: "Alpha Archived Team Worker", projectId: PROJECT_A_ID, createdAt: 91, role: "coder", goalId: IDS.teamGoalA, teamGoalId: IDS.teamGoalA, teamLeadSessionId: IDS.archivedTeamLead, archived: true, archivedAt: 191, status: "terminated" }),
@@ -278,7 +282,7 @@ async function resetFixture(options: { mode?: "desktop" | "mobile"; showArchived
 		archivedGoalsTotal: 4,
 		archivedSessionsCursor: null,
 		archivedSessionsHasMore: false,
-		archivedSessionsTotal: 6,
+		archivedSessionsTotal: 8,
 	});
 	window.history.replaceState({}, "", "#/fixture");
 	renderFixture();

--- a/tests/ui-fixtures/sidebar-archived-fixture-entry.ts
+++ b/tests/ui-fixtures/sidebar-archived-fixture-entry.ts
@@ -5,7 +5,7 @@ import {
 	filterArchivedGoalsByQuery,
 	filterArchivedSessionsByQuery,
 	renderProjectArchivedSection,
-	isChildSession,
+	isStandaloneArchivedSession,
 } from "../../src/app/render-helpers.js";
 import {
 	expandedGoals,
@@ -200,7 +200,7 @@ function mobileArchivedTemplate() {
 	const q = state.searchQuery;
 	const archivedGoals = filterArchivedGoalsByQuery(state.goals.filter(g => g.archived), state.gatewaySessions, state.archivedSessions, q);
 	const standaloneArchived = filterArchivedSessionsByQuery(
-		state.archivedSessions.filter(s => !s.teamGoalId && !isChildSession(s)),
+		state.archivedSessions.filter(isStandaloneArchivedSession),
 		q,
 	);
 	const byProject = bucketArchivedByProject(archivedGoals, standaloneArchived, PROJECTS);

--- a/tests/ui-fixtures/sidebar-archived-fixture.spec.ts
+++ b/tests/ui-fixtures/sidebar-archived-fixture.spec.ts
@@ -72,8 +72,8 @@ function expectIncreasing(indexes: number[], label: string): void {
 	}
 }
 
-async function expectNotProjectStandaloneArchived(page: Page, sessionId: string, projectId: string, nextProjectId: string, label: string): Promise<void> {
-	const placement = await page.evaluate(({ sessionId, projectId, nextProjectId }) => {
+async function projectStandaloneArchivedPlacement(page: Page, sessionId: string, projectId: string, nextProjectId: string) {
+	return page.evaluate(({ sessionId, projectId, nextProjectId }) => {
 		const all = Array.from(document.querySelectorAll("*"));
 		const row = document.querySelector(`[data-session-id="${sessionId}"]`);
 		const archivedHeader = document.querySelector(`[data-nav-id="archived-header:${projectId}"]`);
@@ -94,7 +94,18 @@ async function expectNotProjectStandaloneArchived(page: Page, sessionId: string,
 			isStandalone: rowIndex >= 0 && headerIndex >= 0 && rowIndex > headerIndex && rowIndex < nextProjectIndex && dividerText === "Sessions",
 		};
 	}, { sessionId, projectId, nextProjectId });
+}
 
+async function expectProjectStandaloneArchived(page: Page, sessionId: string, projectId: string, nextProjectId: string, label: string): Promise<void> {
+	const placement = await projectStandaloneArchivedPlacement(page, sessionId, projectId, nextProjectId);
+	expect(
+		placement.isStandalone,
+		`${VERIFIER_MARK}: ${label} verifier ${sessionId} did not render as a project-level standalone archived session ${JSON.stringify(placement)}`,
+	).toBe(true);
+}
+
+async function expectNotProjectStandaloneArchived(page: Page, sessionId: string, projectId: string, nextProjectId: string, label: string): Promise<void> {
+	const placement = await projectStandaloneArchivedPlacement(page, sessionId, projectId, nextProjectId);
 	expect(
 		placement.isStandalone,
 		`${VERIFIER_MARK}: ${label} verifier ${sessionId} rendered as a project-level standalone archived session ${JSON.stringify(placement)}`,
@@ -177,6 +188,14 @@ test.describe("Sidebar archived deterministic fixture", () => {
 		await expectNotProjectStandaloneArchived(page, ids.legacyAgentQa, ids.projectA, ids.projectB, "desktop agent-qa");
 	});
 
+	test("missing-goal verifier transcript uses standalone fallback while empty placeholders stay hidden", async ({ page }) => {
+		await loadFixture(page, { showArchived: true });
+		const ids = await fixtureIds(page);
+
+		await expectProjectStandaloneArchived(page, ids.missingGoalReviewTranscript, ids.projectA, ids.projectB, "desktop missing-goal transcript");
+		await expect(page.locator(`[data-session-id="${ids.missingGoalReviewPlaceholder}"]`), `${VERIFIER_MARK}: empty missing-goal placeholder stays hidden`).toHaveCount(0);
+	});
+
 	test("legacy live team-goal verifier nests near the expanded live team lead", async ({ page }) => {
 		await loadFixture(page, { showArchived: true });
 		const ids = await fixtureIds(page);
@@ -232,6 +251,8 @@ test.describe("Sidebar archived deterministic fixture", () => {
 		await expect(page.locator(`[data-session-id="${ids.archivedStandaloneA}"]`), `${VERIFIER_MARK}: mobile normal standalone archived session still renders`).toBeVisible({ timeout: 10_000 });
 		await expectNotProjectStandaloneArchived(page, ids.legacyLlmReview, ids.projectA, ids.projectB, "mobile llm-review");
 		await expectNotProjectStandaloneArchived(page, ids.legacyAgentQa, ids.projectA, ids.projectB, "mobile agent-qa");
+		await expectProjectStandaloneArchived(page, ids.missingGoalReviewTranscript, ids.projectA, ids.projectB, "mobile missing-goal transcript");
+		await expect(page.locator(`[data-session-id="${ids.missingGoalReviewPlaceholder}"]`), `${VERIFIER_MARK}: mobile empty missing-goal placeholder stays hidden`).toHaveCount(0);
 		expectIncreasing(await domIndexes(page, [
 			`section[data-project-id="${ids.projectA}"]`,
 			`[data-nav-id="archived-header:${ids.projectA}"]`,

--- a/tests/ui-fixtures/sidebar-archived-fixture.spec.ts
+++ b/tests/ui-fixtures/sidebar-archived-fixture.spec.ts
@@ -20,6 +20,7 @@ const SIDEBAR_SPAWNED_SRC = path.resolve("src/app/sidebar-spawned-children.ts");
 const TEAM_ARCHIVED_BUCKET_SRC = path.resolve("src/app/team-archived-bucket.ts");
 
 const MARK = "SIDEBAR_ARCHIVED_FIXTURE";
+const VERIFIER_MARK = "SIDEBAR_ARCHIVED_VERIFIER";
 
 test.beforeAll(() => {
 	fs.mkdirSync(BUNDLE_DIR, { recursive: true });
@@ -69,6 +70,43 @@ function expectIncreasing(indexes: number[], label: string): void {
 		expect(indexes[i], `${MARK}: ${label} selector ${i} missing`).toBeGreaterThanOrEqual(0);
 		if (i > 0) expect(indexes[i], `${MARK}: ${label} order ${i}`).toBeGreaterThan(indexes[i - 1]);
 	}
+}
+
+async function expectNotProjectStandaloneArchived(page: Page, sessionId: string, projectId: string, nextProjectId: string, label: string): Promise<void> {
+	const placement = await page.evaluate(({ sessionId, projectId, nextProjectId }) => {
+		const all = Array.from(document.querySelectorAll("*"));
+		const row = document.querySelector(`[data-session-id="${sessionId}"]`);
+		const archivedHeader = document.querySelector(`[data-nav-id="archived-header:${projectId}"]`);
+		const nextProject = document.querySelector(`.project-reorder-section[data-project-id="${nextProjectId}"], section[data-project-id="${nextProjectId}"]`);
+		const rowIndex = row ? all.indexOf(row) : -1;
+		const headerIndex = archivedHeader ? all.indexOf(archivedHeader) : -1;
+		const nextProjectIndex = nextProject ? all.indexOf(nextProject) : all.length;
+		const dividerText = all
+			.slice(Math.max(0, headerIndex), Math.max(0, rowIndex))
+			.map(el => el.textContent?.trim())
+			.filter(text => text === "Goals" || text === "Sessions")
+			.at(-1) ?? "";
+		return {
+			rowIndex,
+			headerIndex,
+			nextProjectIndex,
+			dividerText,
+			isStandalone: rowIndex >= 0 && headerIndex >= 0 && rowIndex > headerIndex && rowIndex < nextProjectIndex && dividerText === "Sessions",
+		};
+	}, { sessionId, projectId, nextProjectId });
+
+	expect(
+		placement.isStandalone,
+		`${VERIFIER_MARK}: ${label} verifier ${sessionId} rendered as a project-level standalone archived session ${JSON.stringify(placement)}`,
+	).toBe(false);
+}
+
+async function expandLiveTeamLead(page: Page, teamLeadId: string, teamWorkerId: string): Promise<void> {
+	const lead = page.locator(`[data-session-id="${teamLeadId}"]`).first();
+	await expect(lead, `${VERIFIER_MARK}: live team lead renders`).toBeVisible({ timeout: 10_000 });
+	const expand = lead.locator(`span[title="Expand"]`).first();
+	if (await expand.count()) await expand.click();
+	await expect(page.locator(`[data-session-id="${teamWorkerId}"]`), `${VERIFIER_MARK}: live team lead is expanded`).toBeVisible({ timeout: 5_000 });
 }
 
 async function setShowArchived(page: Page, checked: boolean): Promise<void> {
@@ -130,6 +168,29 @@ test.describe("Sidebar archived deterministic fixture", () => {
 		await expect.poll(() => page.evaluate(() => JSON.parse(localStorage.getItem("bobbit-archived-collapsed-projects") || "[]"))).toContain(ids.projectB);
 	});
 
+	test("legacy verifier sessions stay out of project-level standalone archive rows", async ({ page }) => {
+		await loadFixture(page, { showArchived: true });
+		const ids = await fixtureIds(page);
+
+		await expect(page.locator(`[data-session-id="${ids.archivedStandaloneA}"]`), `${VERIFIER_MARK}: normal standalone archived session still renders`).toBeVisible({ timeout: 10_000 });
+		await expectNotProjectStandaloneArchived(page, ids.legacyLlmReview, ids.projectA, ids.projectB, "desktop llm-review");
+		await expectNotProjectStandaloneArchived(page, ids.legacyAgentQa, ids.projectA, ids.projectB, "desktop agent-qa");
+	});
+
+	test("legacy live team-goal verifier nests near the expanded live team lead", async ({ page }) => {
+		await loadFixture(page, { showArchived: true });
+		const ids = await fixtureIds(page);
+
+		await expandLiveTeamLead(page, ids.teamLead, ids.teamWorker);
+		await expect(page.locator(`[data-session-id="${ids.legacyLlmReview}"]`), `${VERIFIER_MARK}: legacy llm-review verifier renders under the live team lead`).toBeVisible({ timeout: 10_000 });
+		expectIncreasing(await domIndexes(page, [
+			`[data-session-id="${ids.teamLead}"]`,
+			`[data-session-id="${ids.legacyLlmReview}"]`,
+			`[data-session-id="${ids.legacyAgentQa}"]`,
+			`[data-nav-id="archived-header:${ids.projectA}"]`,
+		]), `${VERIFIER_MARK}: live team-goal verifier rows are nested before the project archived bucket`);
+	});
+
 	test("archived team leads, members, and delegates nest under their live owners", async ({ page }) => {
 		test.setTimeout(30_000);
 		await loadFixture(page, { showArchived: true });
@@ -168,6 +229,9 @@ test.describe("Sidebar archived deterministic fixture", () => {
 
 		await expect(page.locator(`[data-nav-id="archived-header:${ids.projectA}"]`), `${MARK}: mobile project A archived header`).toBeVisible({ timeout: 10_000 });
 		await expect(page.locator(`[data-nav-id="archived-header:${ids.projectB}"]`), `${MARK}: mobile project B archived header`).toBeVisible({ timeout: 10_000 });
+		await expect(page.locator(`[data-session-id="${ids.archivedStandaloneA}"]`), `${VERIFIER_MARK}: mobile normal standalone archived session still renders`).toBeVisible({ timeout: 10_000 });
+		await expectNotProjectStandaloneArchived(page, ids.legacyLlmReview, ids.projectA, ids.projectB, "mobile llm-review");
+		await expectNotProjectStandaloneArchived(page, ids.legacyAgentQa, ids.projectA, ids.projectB, "mobile agent-qa");
 		expectIncreasing(await domIndexes(page, [
 			`section[data-project-id="${ids.projectA}"]`,
 			`[data-nav-id="archived-header:${ids.projectA}"]`,


### PR DESCRIPTION
## Summary
- Keep legacy `llm-review-*` and `agent-qa-*` verifier sessions out of top-level archived session buckets when they belong to a goal.
- Persist verifier `teamGoalId`, `teamLeadSessionId`, and `nonInteractive` metadata before startup so failed verifier setup cannot leave orphan placeholders.
- Backfill legacy verifier archive rows while preserving transcript-bearing review/QA sessions and normal standalone sessions.
- Document verifier archive cleanup behavior and regression coverage.

## Tests
- `npx tsx --test tests/reviewer-archive-metadata.test.ts`
- `npx playwright test --config tests/playwright.config.ts tests/ui-fixtures/sidebar-archived-fixture.spec.ts`
- `npm run check`
- Workflow `implementation` gate passed, including build, unit, e2e, reviews, and QA.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
