### PR TITLE
Entrypoint Icons

### DIFF
--- a/docs/extension-host-authoring.md
+++ b/docs/extension-host-authoring.md
@@ -887,8 +887,8 @@ fails closed instead of silently spawning a host shell.
 
 The built-in xterm panel behavior:
 
-- Entrypoints: session menu `Open Terminal` and composer slash `/terminal` both open/focus the
-  terminal side panel without writing terminal output into chat.
+- Entrypoints: session menu `Open Terminal` (`icon: terminal`) and composer slash `/terminal`
+  both open/focus the terminal side panel without writing terminal output into chat.
 - Identity: one session-persistent singleton channel (`singletonKey: session-terminal`) for the
   built-in terminal pack.
 - Output following: new PTY output and local typing keep the active prompt/input visible after large
@@ -1153,8 +1153,59 @@ is not loaded).
 id: my-pack.open
 kind: composer-slash          # composer-slash | session-menu
 label: My Viewer              # required for launcher kinds
+icon: zap                     # optional; stable launcher icon id
 target:
   route: my-pack              # OR { panelId: ... }
+```
+
+Launcher entrypoints may declare an optional **`icon`** field. This is the canonical
+field name; use lower-case stable ids, not Lucide component names or inline SVG. Supported
+stable ids are:
+
+| `icon` | Renders as | Typical use |
+|---|---|---|
+| `zap` | Lightning bolt | Default / generic launcher |
+| `terminal` | Terminal | Terminal or shell launchers |
+| `git-pull-request` | Pull request | PR review / PR walkthrough launchers |
+
+`icon` is available only on launcher kinds (`composer-slash` and `session-menu`). Route-only
+entrypoints have no clickable menu surface, so they should not declare it. When `icon` is absent,
+Bobbit keeps the existing `zap` icon. When `icon` is unknown or not a string, pack loading remains
+tolerant: the invalid value is dropped with a warning, `/api/ext/contributions` omits it, and the
+client falls back to `zap`. This keeps menus safe because packs can choose only from Bobbit's
+bundled icon registry, never arbitrary HTML or SVG.
+
+For `session-menu` launchers, the resolved icon is used in every session action menu surface that
+shows extension launchers: the sidebar session-row overflow menu and the chat/mobile header
+hamburger menu. The label remains the accessible action name.
+
+First-party launcher examples:
+
+```yaml
+# market-packs/terminal/entrypoints/terminal-session-menu.yaml
+id: terminal.session-menu
+kind: session-menu
+label: Open Terminal
+icon: terminal
+target:
+  action: channel-panel
+  channel: terminal
+  singletonKey: session-terminal
+  panelId: terminal.panel
+  params:
+    autoStart: true
+```
+
+```yaml
+# market-packs/pr-walkthrough/entrypoints/pr-walkthrough-session-menu.yaml
+id: pr-walkthrough.session-menu
+kind: session-menu
+label: PR Walkthrough
+icon: git-pull-request
+target:
+  action: spawn
+  route: run
+  panelId: pr-walkthrough.panel
 ```
 
 A launcher normally carries **no** static `params` — the panel derives whatever
@@ -1661,7 +1712,7 @@ pr-walkthrough/
 |---|---|
 | `PrWalkthroughPanel` viewer | `panels/pr-walkthrough-panel.yaml` (`pr-walkthrough.panel` → `../lib/panel.js`). Entrypoints carry **no** hard-coded `jobId`. The panel lives **only** in the reviewer child session — there is no owner-session surface. Inside the bound child pane it auto-opens (the read-only carve-out), self-polls `status`, and renders; on reload it re-renders via the child-self `recover` |
 | Reviewer tools | `tools/pr-walkthrough/*.yaml` + `extension.ts`. These are normal `bobbit-extension` agent tools, not Host API surfaces. The bundle tool keeps legacy JSON as the omitted/default `format` while opt-in `format=compact` emits a unified-diff-like model-facing view. The durable flow uses compact chunk-save output, full status readback, and finalization tools; `submit_pr_walkthrough_yaml` remains a compatibility wrapper. Tools are granted only through role/tool-policy resolution; disabling one concrete tool in Market removes just that tool from runtime resolution |
-| Launch — spawn-on-click, a real isolated reviewer | both launchers carry `target: { action: spawn, route: run, panelId: pr-walkthrough.panel }`. On click the platform calls the `run` route, which mints a fresh read-only child via **`host.agents.spawn({ role: "pr-reviewer", readOnly: true, lifecycle: "full", deferInitialPrompt: true, title: "PR Walkthrough", toolEnv })`** — NOT `host.session.postMessage`; the user's own agent is never driven — then opens the panel in the returned `childSessionId` (contract-v2 `host.ui.openPanel({ panelId, sessionId })`, a real session switch). A `NO_PR` / failure surfaces through launcher feedback from the session menu; nothing is spawned |
+| Launch — spawn-on-click, a real isolated reviewer | both launchers carry `icon: git-pull-request` and `target: { action: spawn, route: run, panelId: pr-walkthrough.panel }`. On click the platform calls the `run` route, which mints a fresh read-only child via **`host.agents.spawn({ role: "pr-reviewer", readOnly: true, lifecycle: "full", deferInitialPrompt: true, title: "PR Walkthrough", toolEnv })`** — NOT `host.session.postMessage`; the user's own agent is never driven — then opens the panel in the returned `childSessionId` (contract-v2 `host.ui.openPanel({ panelId, sessionId })`, a real session switch). A `NO_PR` / failure surfaces through launcher feedback from the session menu; nothing is spawned |
 | `handlePrWalkthroughApiRoute` endpoints | `pack.yaml` `routes:` (`lib/routes.mjs`, names `bundle`/`publish`/`run`/`status`/`recover`), reached via `host.callRoute(…)` (the route resolves the session's own job/binding; the caller does not pass a `jobId`) — **never** a raw fetch |
 | Durable review state + reviewer routing | **implicit store** → `host.store.*`, pack-scoped — holds `reviewers/<childSessionId>`, `reviews/<jobId>/binding/<childSessionId>`, draft chunks/status/checkpoints, and `reviews/<jobId>/final/payload`. Per-review quota scopes isolate draft/final payload size, and real `delete` / `deletePrefix` cleanup frees bytes on reviewer shutdown. Legacy `binding/<child>`, `submitted/<jobId>`, `job/<jobId>`, and `cards/<changesetId>` remain migration fallbacks only |
 | Deep-link + launchers | three `entrypoints/*.yaml` — two **spawn launchers** (composer-slash and session-menu) both carrying `target.action: spawn` **and** a `kind:"route"` deep-link (`routeId:"pr-walkthrough"`) that re-registers the panel so a child-session reload restores `#/ext/pr-walkthrough` |

--- a/market-packs/pr-walkthrough/entrypoints/pr-walkthrough-open.yaml
+++ b/market-packs/pr-walkthrough/entrypoints/pr-walkthrough-open.yaml
@@ -1,6 +1,7 @@
 id: pr-walkthrough
 kind: composer-slash
 label: PR Walkthrough
+icon: git-pull-request
 # A composer-slash LAUNCHER (the slash menu). Its selection IS the user gesture.
 # SPAWN-ON-CLICK model (launch UX correction): like every launch surface, it calls
 # the pack `run` route to mint a fresh read-only reviewer sub-agent, then opens the

--- a/market-packs/pr-walkthrough/entrypoints/pr-walkthrough-session-menu.yaml
+++ b/market-packs/pr-walkthrough/entrypoints/pr-walkthrough-session-menu.yaml
@@ -1,6 +1,7 @@
 id: pr-walkthrough.session-menu
 kind: session-menu
 label: PR Walkthrough
+icon: git-pull-request
 # A session-menu LAUNCHER (the sidebar/chat session actions overflow menu). Its
 # selection IS the user gesture. SPAWN-ON-CLICK model (launch UX correction): like
 # every launch surface, it calls the pack `run` route to mint a fresh read-only

--- a/market-packs/terminal/entrypoints/terminal-session-menu.yaml
+++ b/market-packs/terminal/entrypoints/terminal-session-menu.yaml
@@ -1,6 +1,7 @@
 id: terminal.session-menu
 kind: session-menu
 label: Open Terminal
+icon: terminal
 target:
   action: channel-panel
   channel: terminal

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -2641,6 +2641,7 @@ export interface PackEntrypointWire {
 	id: string;
 	kind: "composer-slash" | "session-menu" | "route";
 	label?: string;
+	icon?: string;
 	routeId?: string;
 	target?: { action?: string; panelId?: string; route?: string; channel?: string; singletonKey?: string; params?: Record<string, unknown> };
 	paramKeys?: string[];

--- a/src/app/entrypoint-icon-registry.ts
+++ b/src/app/entrypoint-icon-registry.ts
@@ -1,0 +1,16 @@
+import { GitPullRequest, Terminal, Zap } from "lucide";
+import {
+	DEFAULT_ENTRYPOINT_ICON_ID,
+	isSupportedEntrypointIconId,
+	type EntrypointIconId,
+} from "../shared/entrypoint-icons.js";
+
+const ENTRYPOINT_ICON_NODES = {
+	zap: Zap,
+	terminal: Terminal,
+	"git-pull-request": GitPullRequest,
+} satisfies Record<EntrypointIconId, typeof Zap>;
+
+export function entrypointIconNode(iconId?: string): typeof Zap {
+	return ENTRYPOINT_ICON_NODES[isSupportedEntrypointIconId(iconId) ? iconId : DEFAULT_ENTRYPOINT_ICON_ID];
+}

--- a/src/app/pack-entrypoints.ts
+++ b/src/app/pack-entrypoints.ts
@@ -35,6 +35,7 @@
 import { fetchContributions, type PackContributionsWire } from "./api.js";
 import { setExtRoute } from "./routing.js";
 import { openPackPanel, getLauncherHost } from "./pack-panels.js";
+import { isSupportedEntrypointIconId, type EntrypointIconId } from "../shared/entrypoint-icons.js";
 import type { PanelTarget, RouteTarget } from "../shared/extension-host/host-api.js";
 
 /** Launcher kinds (a clickable surface) PLUS the routable `route` kind (a
@@ -70,6 +71,7 @@ export interface LauncherEntrypoint {
 	packId: string;
 	kind: LauncherKind;
 	label: string;
+	icon?: EntrypointIconId;
 	target: PanelTarget | RouteTarget | SpawnLaunchTarget | ChannelPanelLaunchTarget;
 }
 
@@ -109,6 +111,7 @@ export interface RegisteredLauncher {
 	packId: string;
 	kind: LauncherKind;
 	label: string;
+	icon?: EntrypointIconId;
 	target: PanelTarget | RouteTarget | SpawnLaunchTarget | ChannelPanelLaunchTarget;
 	projectId?: string;
 }
@@ -222,6 +225,7 @@ export function registerPackEntrypoints(eps: ReadonlyArray<EntrypointInfo>, proj
 				packId: ep.packId,
 				kind: ep.kind,
 				label: ep.label,
+				...(ep.icon ? { icon: ep.icon } : {}),
 				target: ep.target,
 				projectId,
 			});
@@ -468,9 +472,10 @@ export function entrypointInfosFromContributions(packs: ReadonlyArray<PackContri
 				// OR a SpawnLaunchTarget ({action,route,panelId}). We do not validate the
 				// target internals here (registration does), so the spawn shape survives the
 				// contributions wire.
-				const target = e.target as PanelTarget | RouteTarget | SpawnLaunchTarget | undefined;
+				const target = e.target as PanelTarget | RouteTarget | SpawnLaunchTarget | ChannelPanelLaunchTarget | undefined;
 				if (!label || !target) continue;
-				out.push({ id, packId, kind, label, target });
+				const icon = isSupportedEntrypointIconId(e.icon) ? e.icon : undefined;
+				out.push({ id, packId, kind, label, ...(icon ? { icon } : {}), target });
 			}
 		}
 	}

--- a/src/app/session-actions.ts
+++ b/src/app/session-actions.ts
@@ -1,5 +1,5 @@
 import { icon } from "@mariozechner/mini-lit";
-import { ExternalLink, FileText, GitFork, Link, Pencil, RotateCcw, Trash2, Zap } from "lucide";
+import { ExternalLink, FileText, GitFork, Link, Pencil, RotateCcw, Trash2 } from "lucide";
 import type { TemplateResult } from "lit";
 import { copySidebarLink, gatewayFetch, refreshAgentSession, refreshSessions, sessionPathDeepLink, type SidebarCopyLinkTitle } from "./api.js";
 import { listLauncherEntrypoints, runResolvedLauncherEntrypoint, type LauncherDispatchResult, type SpawnLaunchTarget } from "./pack-entrypoints.js";
@@ -10,6 +10,7 @@ import { connectToSession, forkSession, terminateSession } from "./session-manag
 import { state, type GatewaySession } from "./state.js";
 import { ensureContinueSessionChooser } from "./lazy-widgets.js";
 import { errorDetails } from "./error-helpers.js";
+import { entrypointIconNode } from "./entrypoint-icon-registry.js";
 
 export type SessionActionId =
 	| "modify"
@@ -399,7 +400,7 @@ function buildSessionMenuLauncherActions(sessionId: string, onRefreshStateChange
 			id: launcher.key,
 			label: launcher.label,
 			title: isSpawn ? `Start ${launcher.label}` : launcher.label,
-			icon: icon(Zap, "xs"),
+			icon: icon(entrypointIconNode(launcher.icon), "xs"),
 			priority: 80 + index,
 			quick: false,
 			run: (event: Event) => {

--- a/src/server/agent/pack-contributions.ts
+++ b/src/server/agent/pack-contributions.ts
@@ -32,6 +32,7 @@ import path from "node:path";
 import { parse } from "yaml";
 import type { PackManifest } from "./pack-types.js";
 import { isSafeRelativePath, parseEntrypoints } from "./tool-contributions.js";
+import type { EntrypointIconId } from "../../shared/entrypoint-icons.js";
 import { isSafeBasename, isValidPackName } from "./pack-manifest.js";
 import { isPackPathWithinRoot } from "../extension-host/path-guard.js";
 import type { McpServerConfig } from "../mcp/mcp-types.js";
@@ -137,6 +138,7 @@ export interface EntrypointContribution {
 	id: string; // unique within the pack
 	kind: "composer-slash" | "session-menu" | "route";
 	label?: string; // required for launcher kinds
+	icon?: EntrypointIconId;
 	routeId?: string; // required for kind:"route"; host-global
 	target?: { action?: string; panelId?: string; route?: string; channel?: string; singletonKey?: string; params?: Record<string, unknown> };
 	paramKeys?: string[];

--- a/src/server/agent/tool-contributions.ts
+++ b/src/server/agent/tool-contributions.ts
@@ -24,6 +24,8 @@
 // tool still loads with no renderer/actions; a console.warn is emitted) — never
 // fatal, mirroring the per-tool try/catch in tool-manager.ts::scanToolsDir.
 
+import { isSupportedEntrypointIconId, type EntrypointIconId } from "../../shared/entrypoint-icons.js";
+
 /** Tool-scoped contributions parsed from a tool YAML (renderer + actions only). */
 export interface ToolContributions {
 	/** Renderer ESM module path, relative to the tool YAML's dir (contained in
@@ -58,6 +60,7 @@ export interface EntrypointContribution {
 	id: string;
 	kind: "composer-slash" | "session-menu" | "route";
 	label?: string;
+	icon?: EntrypointIconId;
 	routeId?: string;
 	target?: { action?: string; panelId?: string; route?: string; channel?: string; singletonKey?: string; params?: Record<string, unknown> };
 	paramKeys?: string[];
@@ -184,6 +187,13 @@ function parseActions(raw: unknown, filePath: string): ToolActionsContribution |
 	return out;
 }
 
+function parseLauncherEntrypointIcon(raw: unknown, id: string, filePath: string): EntrypointIconId | undefined {
+	if (raw === undefined) return undefined;
+	if (isSupportedEntrypointIconId(raw)) return raw;
+	console.warn(`[tool-contributions] Dropping unsupported launcher entrypoint icon for '${id}' in ${filePath}`);
+	return undefined;
+}
+
 /**
  * Parse an array of entrypoint declarations into typed `EntrypointContribution[]`
  * (pack-schema-v1 §1.5). Launcher kinds require a `label` + a structured `target`
@@ -286,7 +296,10 @@ export function parseEntrypoints(raw: unknown, filePath: string): EntrypointCont
 				target.route = route;
 			}
 			if (params) target.params = params;
-			out.push({ id, kind: kind as EntrypointContribution["kind"], label, target });
+			const icon = parseLauncherEntrypointIcon(obj.icon, id, filePath);
+			const launcher: EntrypointContribution = { id, kind: kind as EntrypointContribution["kind"], label, target };
+			if (icon) launcher.icon = icon;
+			out.push(launcher);
 		}
 	}
 	return out;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7059,6 +7059,7 @@ async function handleApiRoute(
 			entrypoints: p.entrypoints.map((e) => {
 				const out: Record<string, unknown> = { id: e.id, kind: e.kind, listName: e.listName };
 				if (e.label !== undefined) out.label = e.label;
+				if (e.icon !== undefined) out.icon = e.icon;
 				if (e.routeId !== undefined) out.routeId = e.routeId;
 				if (e.target !== undefined) out.target = e.target;
 				if (e.paramKeys !== undefined) out.paramKeys = e.paramKeys;

--- a/src/shared/entrypoint-icons.ts
+++ b/src/shared/entrypoint-icons.ts
@@ -1,0 +1,15 @@
+export const DEFAULT_ENTRYPOINT_ICON_ID = "zap";
+
+export const SUPPORTED_ENTRYPOINT_ICON_IDS = [
+	DEFAULT_ENTRYPOINT_ICON_ID,
+	"terminal",
+	"git-pull-request",
+] as const;
+
+export type EntrypointIconId = typeof SUPPORTED_ENTRYPOINT_ICON_IDS[number];
+
+const SUPPORTED_ENTRYPOINT_ICON_ID_SET = new Set<string>(SUPPORTED_ENTRYPOINT_ICON_IDS);
+
+export function isSupportedEntrypointIconId(value: unknown): value is EntrypointIconId {
+	return typeof value === "string" && SUPPORTED_ENTRYPOINT_ICON_ID_SET.has(value);
+}

--- a/tests/extension-host-terminal.test.ts
+++ b/tests/extension-host-terminal.test.ts
@@ -26,6 +26,7 @@ describe("built-in terminal pack", () => {
 		assert.equal(contributions.panels[0]?.id, "terminal.panel");
 		const sessionMenu = contributions.entrypoints.find((e) => e.kind === "session-menu");
 		assert.equal(sessionMenu?.label, "Open Terminal");
+		assert.equal((sessionMenu as any)?.icon, "terminal");
 		assert.deepEqual(sessionMenu?.target, {
 			action: "channel-panel",
 			channel: "terminal",

--- a/tests/fixtures/session-menu-entry.ts
+++ b/tests/fixtures/session-menu-entry.ts
@@ -40,10 +40,10 @@ function registerSessionMenu(): void {
 	registerPackEntrypoints(
 		[
 			{ id: "tp.route", packId: "tp", kind: "route", routeId: "demo.route", target: { panelId: "demo.viewer" }, paramKeys: ["itemId"] },
-			{ id: "sm.route", packId: "tp", kind: "session-menu", label: "Open Demo", target: { route: "demo.route", params: { itemId: "x1" } } },
+			{ id: "sm.route", packId: "tp", kind: "session-menu", label: "Open Demo", icon: "terminal", target: { route: "demo.route", params: { itemId: "x1" } } },
 			{ id: "sm.missing", packId: "tp", kind: "session-menu", label: "Missing Route", target: { route: "missing.route" } },
-			{ id: "sm.spawn", packId: "tp", kind: "session-menu", label: "PR Walkthrough", target: { action: "spawn", route: "run", panelId: "demo.viewer" } },
-			{ id: "sm.fail", packId: "tp", kind: "session-menu", label: "Broken Walkthrough", target: { action: "spawn", route: "run", panelId: "demo.viewer" } },
+			{ id: "sm.spawn", packId: "tp", kind: "session-menu", label: "PR Walkthrough", icon: "git-pull-request", target: { action: "spawn", route: "run", panelId: "demo.viewer" } },
+			{ id: "sm.fail", packId: "tp", kind: "session-menu", label: "Broken Walkthrough", icon: "no-such-icon", target: { action: "spawn", route: "run", panelId: "demo.viewer" } },
 		] as any,
 		"proj1",
 	);
@@ -160,6 +160,27 @@ function menuLabels(): string[] {
 	return [...document.querySelectorAll("sidebar-actions-popover [role='menuitem']")].map((el) => normalizeLabel(el.textContent));
 }
 
+function menuIconSignaturesByLabel(): Record<string, string[]> {
+	const out: Record<string, string[]> = {};
+	for (const row of document.querySelectorAll<HTMLElement>("sidebar-actions-popover [role='menuitem']")) {
+		const label = normalizeLabel(row.querySelector("[data-sidebar-actions-label]")?.textContent);
+		if (!label) continue;
+		const svg = row.querySelector<SVGElement>("[data-sidebar-actions-popover-icon] svg");
+		out[label] = svg
+			? Array.from(svg.children).map((child) => {
+				const el = child as Element;
+				const attrs = ["d", "points", "cx", "cy", "r", "x1", "x2", "y1", "y2"]
+					.map((name) => [name, el.getAttribute(name)] as const)
+					.filter(([, value]) => value !== null)
+					.map(([name, value]) => `[${name}=${JSON.stringify(value)}]`)
+					.join("");
+				return `${el.tagName.toLowerCase()}${attrs}`;
+			})
+			: [];
+	}
+	return out;
+}
+
 function launcherEntryIdsFromActions(): string[] {
 	const launchers = listLauncherEntrypoints("session-menu" as any);
 	return launchers
@@ -224,6 +245,7 @@ window.addEventListener("bobbit-launcher-feedback", (ev: Event) => {
 (window as any).__closeMenu = closeMenu;
 (window as any).__menuOpen = menuOpen;
 (window as any).__menuLabels = menuLabels;
+(window as any).__menuIconSignaturesByLabel = menuIconSignaturesByLabel;
 (window as any).__launcherEntryIdsFromMenu = launcherEntryIdsFromActions;
 (window as any).__clickMenuEntry = clickMenuEntry;
 (window as any).__launchers = (kind?: any) => listLauncherEntrypoints(kind).map((l) => l.id);

--- a/tests/marketplace-source-builtin.test.ts
+++ b/tests/marketplace-source-builtin.test.ts
@@ -126,6 +126,8 @@ describe("built-in source guards (§11.1)", () => {
 		assert.ok(baseEntrypoints.some((e) => (e as any).kind === "session-menu"), "session-menu entrypoint enabled by default");
 		assert.ok(entrypointListNames.includes("pr-walkthrough-open"), "slash entrypoint enabled by default");
 		assert.ok(entrypointListNames.includes("pr-walkthrough-route"), "route entrypoint enabled by default");
+		assert.equal((baseEntrypoints.find((e) => e.listName === "pr-walkthrough-open") as any)?.icon, "git-pull-request");
+		assert.equal((baseEntrypoints.find((e) => e.listName === "pr-walkthrough-session-menu") as any)?.icon, "git-pull-request");
 		assert.ok(!entrypointListNames.includes("pr-walkthrough-git-widget"), "old git-widget entrypoint absent");
 		assert.ok(!entrypointListNames.includes("pr-walkthrough-palette"), "old palette entrypoint absent");
 

--- a/tests/pack-contributions.test.ts
+++ b/tests/pack-contributions.test.ts
@@ -241,6 +241,20 @@ describe("loadPackContributions (§5.1) + pack-root containment (§2)", () => {
 		assert.equal(isPackPathWithinRoot(root, routesAbs), true);
 	});
 
+	it("preserves valid launcher icons and drops invalid icon fields while loading entrypoint files", () => {
+		const root = packRoot("icons", "launchers");
+		w(path.join(root, "pack.yaml"), "name: launchers\n");
+		w(path.join(root, "entrypoints", "terminal.yaml"), "id: terminal.open\nkind: session-menu\nlabel: Open Terminal\nicon: terminal\ntarget:\n  panelId: terminal.panel\n");
+		w(path.join(root, "entrypoints", "bad-icon.yaml"), "id: launchers.bad\nkind: session-menu\nlabel: Bad Icon\nicon: nope\ntarget:\n  route: demo.route\n");
+		w(path.join(root, "entrypoints", "route-icon.yaml"), "id: launchers.route\nkind: route\nrouteId: launchers.route\nicon: terminal\ntarget:\n  panelId: terminal.panel\nparamKeys: []\n");
+
+		const c = loadPackContributions(root, manifest("launchers", { entrypoints: ["terminal", "bad-icon", "route-icon"] }));
+		assert.equal((c.entrypoints.find((e) => e.listName === "terminal") as any)?.icon, "terminal");
+		assert.equal((c.entrypoints.find((e) => e.listName === "bad-icon") as any)?.icon, undefined);
+		assert.equal((c.entrypoints.find((e) => e.listName === "route-icon") as any)?.icon, undefined);
+		assert.deepEqual(c.entrypoints.map((e) => e.listName).sort(), ["bad-icon", "route-icon", "terminal"]);
+	});
+
 	it("drops a malformed panel file (bad id / missing entry) without crashing the scan", () => {
 		const root = packRoot("s1b", "p");
 		w(path.join(root, "pack.yaml"), "name: p\n");

--- a/tests/session-menu.spec.ts
+++ b/tests/session-menu.spec.ts
@@ -65,6 +65,28 @@ test.describe("pack launcher session-menu surfaces", () => {
 		expect(out.launcherIds).toEqual(expect.arrayContaining([out.routeKey, out.spawnKey]));
 	});
 
+	test("renders resolved launcher icons in sidebar and chat header menus", async ({ page }) => {
+		await ready(page);
+		const terminalSignatures = ["path[d=\"M12 19h8\"]", "path[d=\"m4 17 6-6-6-6\"]"];
+		const gitPullRequestSignatures = ["circle[cx=\"18\"][cy=\"18\"][r=\"3\"]", "line[x1=\"6\"][x2=\"6\"][y1=\"9\"][y2=\"21\"]"];
+		const zapSignature = "path[d=\"M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z\"]";
+
+		for (const surface of ["sidebar", "header"] as const) {
+			const signaturesByLabel = await page.evaluate(async (surfaceName) => {
+				const w = window as any;
+				w.__reset();
+				w.__registerSessionMenu();
+				await w.__openSurface(surfaceName);
+				return w.__menuIconSignaturesByLabel();
+			}, surface);
+
+			expect(signaturesByLabel["Open Demo"]).toEqual(expect.arrayContaining(terminalSignatures));
+			expect(signaturesByLabel["PR Walkthrough"]).toEqual(expect.arrayContaining(gitPullRequestSignatures));
+			expect(signaturesByLabel["Missing Route"]).toContain(zapSignature);
+			expect(signaturesByLabel["Broken Walkthrough"]).toContain(zapSignature);
+		}
+	});
+
 	test("clicking a route launcher uses runLauncherEntrypoint and closes the menu", async ({ page }) => {
 		await ready(page);
 		const out = await page.evaluate(async () => {

--- a/tests/tool-contributions.test.ts
+++ b/tests/tool-contributions.test.ts
@@ -157,6 +157,33 @@ describe("parseEntrypoints (reused by the pack-level loader; tolerant, never rej
 		);
 	});
 
+	it("preserves valid launcher icons and drops malformed or unknown icons without dropping the entrypoint", () => {
+		const parsed = parseEntrypoints(
+			[
+				{ id: "terminal", kind: "session-menu", label: "Open Terminal", icon: "terminal", target: { panelId: "terminal.panel" } },
+				{ id: "pr", kind: "composer-slash", label: "PR Walkthrough", icon: "git-pull-request", target: { route: "pr.run" } },
+				{ id: "bad", kind: "session-menu", label: "Bad Icon", icon: "not-a-real-icon", target: { route: "demo.route" } },
+				{ id: "malformed", kind: "session-menu", label: "Malformed Icon", icon: 42, target: { route: "demo.route" } },
+			],
+			FP,
+		) as Array<Record<string, unknown>>;
+
+		assert.equal(parsed.length, 4, "invalid icon values must not drop otherwise-valid launchers");
+		assert.equal(parsed.find((e) => e.id === "terminal")?.icon, "terminal");
+		assert.equal(parsed.find((e) => e.id === "pr")?.icon, "git-pull-request");
+		assert.equal(parsed.find((e) => e.id === "bad")?.icon, undefined);
+		assert.equal(parsed.find((e) => e.id === "malformed")?.icon, undefined);
+	});
+
+	it("ignores icon on route entrypoints", () => {
+		const parsed = parseEntrypoints(
+			[{ id: "r", kind: "route", routeId: "demo.deep", icon: "terminal", target: { panelId: "demo.viewer" }, paramKeys: [] }],
+			FP,
+		) as Array<Record<string, unknown>>;
+		assert.equal(parsed.length, 1);
+		assert.equal(parsed[0].icon, undefined);
+	});
+
 	it("drops removed command-palette and git-widget-button entrypoint kinds", () => {
 		assert.deepEqual(
 			parseEntrypoints([


### PR DESCRIPTION
## Summary

- Add canonical launcher entrypoint `icon` support with shared stable-id validation and Zap fallback.
- Thread icon ids through server contributions, `/api/ext/contributions`, client registry, and session action rendering.
- Add Terminal and PR Walkthrough first-party icon declarations, tests, and schema documentation.

## Validation

- `npm run check`
- targeted parser/API/session-menu tests
- implementation gate verification passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)