### PR TITLE
Fix sidebar bobbit compaction clipping

### DIFF
--- a/src/ui/bobbit-render.ts
+++ b/src/ui/bobbit-render.ts
@@ -821,8 +821,6 @@ export function renderSidebarBobbitCanvas(opts: SidebarBobbitOptions): TemplateR
 	const cancelAnim = isCancelling ? "animation:bobbit-cancel-fade 1.2s ease-in-out infinite;" : "";
 	const compactSquish = isCompacting && !isCancelling;
 
-	const compactTopOffset = compactSquish ? 2 : 0;
-
 	// Body transform: image already at CSS target size, no base scale needed.
 	// Compaction uses -s (smooth) keyframes that omit scale(1.6).
 	// transform-origin adjusted from 9px (sprite coords) to 14.4px (CSS coords).
@@ -851,9 +849,12 @@ export function renderSidebarBobbitCanvas(opts: SidebarBobbitOptions): TemplateR
 			: `transform:scaleY(0.75) translateY(${(isBandanaStyle ? 4 : 4.5) * S}px)${isCrown ? ` translateX(${-0.5 * S}px)` : ""};transform-origin:0 ${BODY_HEIGHT * S}px;`)
 		: `${isBandanaStyle ? `transform:translateY(${-0.5 * S}px);` : ""}${isCrown ? `transform:translateX(${-0.5 * S}px);` : ""}`;
 
-	const innerTop = addsHeight ? `${4 + compactTopOffset}px` : `${compactTopOffset}px`;
-	const eyeTop = addsHeight ? `${4 + compactTopOffset}px` : `${compactTopOffset}px`;
-	const accTop = addsHeight ? `${acc.yOffset + compactTopOffset}px` : `${compactTopOffset}px`;
+	// Keep the compacting sprite on the same baseline as every other sidebar
+	// state. The squish animation already scales around the body bottom; adding a
+	// top offset pushes that fixed bottom edge outside the clipped wrapper.
+	const innerTop = addsHeight ? "4px" : "0px";
+	const eyeTop = innerTop;
+	const accTop = addsHeight ? `${acc.yOffset}px` : "0px";
 	const containerHeight = addsHeight ? "19px" : "15px";
 	const containerWidth = "20px";
 

--- a/tests/sidebar-bobbit-datauri-cache.spec.ts
+++ b/tests/sidebar-bobbit-datauri-cache.spec.ts
@@ -168,6 +168,54 @@ test.describe("Sidebar bobbit data-URL memoization", () => {
 		expect(result.plainIdle.pulseCount).toBe(0);
 	});
 
+	test("compacting sidebar bobbits stay inside the clipped wrapper without layout shift", async ({ page }) => {
+		await installSpyAndLoad(page);
+
+		const result = await page.evaluate(() => {
+			const api = (window as any).__sidebarBobbit;
+			const host = document.getElementById("host")!;
+			const capture = (isCompacting: boolean, accessory?: string) => {
+				api.renderStaticSidebarStatusInto(host, "idle", isCompacting, true, false, accessory);
+				const outer = host.querySelector(".sidebar-bobbit-status-test > span") as HTMLElement;
+				return {
+					outerHeight: parseFloat(outer.style.height),
+					layers: Array.from(host.querySelectorAll<HTMLImageElement>("img")).map(img => {
+						const top = parseFloat(img.style.top || "0");
+						const height = parseFloat(img.style.height || "0");
+						return {
+							top,
+							height,
+							bottom: top + height,
+							animation: img.style.animation,
+						};
+					}),
+				};
+			};
+
+			return {
+				plainIdle: capture(false),
+				plainCompact: capture(true),
+				crownIdle: capture(false, "crown"),
+				crownCompact: capture(true, "crown"),
+			};
+		});
+
+		expect(result.plainCompact.outerHeight).toBe(result.plainIdle.outerHeight);
+		expect(result.crownCompact.outerHeight).toBe(result.crownIdle.outerHeight);
+		expect(result.plainCompact.layers.map(l => l.top)).toEqual(result.plainIdle.layers.map(l => l.top));
+		expect(result.crownCompact.layers.map(l => l.top)).toEqual(result.crownIdle.layers.map(l => l.top));
+		expect(result.plainCompact.layers.length).toBe(2); // body + selected-eye overlay
+		expect(result.crownCompact.layers.length).toBe(3); // body + eye + accessory
+
+		for (const scenario of [result.plainCompact, result.crownCompact]) {
+			for (const layer of scenario.layers) {
+				expect(layer.bottom).toBeLessThanOrEqual(scenario.outerHeight + 0.01);
+			}
+		}
+		expect(result.plainCompact.layers[0].animation).toContain("bobbit-squish-s");
+		expect(result.crownCompact.layers[2].animation).toContain("bobbit-squish-crown-s");
+	});
+
 	test("identical opts: toDataURL runs once on first render, never again", async ({ page }) => {
 		await installSpyAndLoad(page);
 


### PR DESCRIPTION
## Summary
- Remove the compacting-only top offset from sidebar bobbit layers so the squish animation keeps its baseline inside the clipped wrapper.
- Add regression coverage for compacting plain and accessory sprites to prevent clipping and layout shift.

## Verification
- npx playwright test tests/sidebar-bobbit-datauri-cache.spec.ts --config tests/playwright.config.ts
- npm run check
- npm run test:unit

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)