### PR TITLE
Disable pi context-file discovery

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -141,7 +141,7 @@ The sections are ordered so that the **stable prefix** (sections 1–5, which ar
 | # | Section | Volatile? | Source |
 |---|---------|-----------|--------|
 | 1 | **Global system prompt** | No | `.bobbit/config/system-prompt.md` (user customised) or `defaults/system-prompt.md`. Resolved by `resolveSystemPromptPath()`. See [internals.md — Config cascade](internals.md#config-cascade). |
-| 2 | **AGENTS.md / project docs** | No | From the session's working directory, with `@FILENAME.md` inline inclusion (recursive, circular-reference safe). |
+| 2 | **AGENTS.md / project docs** | No | From the registered project root and configured `agents` files, with `@FILENAME.md` inline inclusion (recursive, circular-reference safe). Falls back to the session working directory only when no project root/config store is available. |
 | 3 | **Working directory** | No | Injected `# Working Directory` block with the session's `cwd`. |
 | 4 | **Tool documentation** | No | Assembled from `defaults/tools/<group>/` (project overrides under `.bobbit/config/tools/<group>/`). |
 | 5 | **Available Skills catalog** | No | Built from the list of skills in scope for the session. |
@@ -151,6 +151,8 @@ The sections are ordered so that the **stable prefix** (sections 1–5, which ar
 | 9 | **Dynamic Context** | Yes | Provider-supplied ambient context from the `sessionSetup` lifecycle hook, fenced in `<context-block>` envelopes. Appended last (freshest, lowest-authority). Omitted unless an active provider contributes blocks. See [lifecycle-hub.md](lifecycle-hub.md#session-setup-wiring-g13). |
 
 Implementation: `src/server/agent/system-prompt.ts::_assembleSystemPrompt`. The inspector UI uses `getPromptSections()` (same file) to show labeled sections in the same order. Section 9 is appended after section 8 by the `sessionSetup` provider wiring (Extension Platform G1.3); when no provider contributes, it is absent and the prompt is byte-identical to the 1–8 layout. The same inspector section is refreshed best-effort for per-turn `beforePrompt` blocks, but those blocks reach the model through the hidden custom-message channel so provider cached system-prompt bytes stay stable across turns.
+
+Bobbit, not pi-coding-agent, owns project instruction assembly. `src/server/agent/rpc-bridge.ts::buildAgentArgs()` always launches pi with `--no-context-files` and strips caller-supplied context-file flags before appending custom args. This prevents pi's built-in upward discovery from adding parent-directory `AGENTS.md` / `CLAUDE.md` files to the runtime `systemPrompt` or `before_agent_start` hook events. The registered project's configured agent files still appear once through Bobbit's `Project AGENTS.md` section, and provider-bridge `beforePrompt` context remains unchanged: per-turn blocks are delivered as hidden `bobbit:dynamic-context` custom/user-side messages, not by mutating `systemPrompt`.
 
 ## Reconnection
 

--- a/src/server/agent/rpc-bridge.ts
+++ b/src/server/agent/rpc-bridge.ts
@@ -239,15 +239,23 @@ export function registerRpcBridgeFactory(factory: RpcBridgeFactory | null): void
  * depend on settings.json state. See goal: project-trust decision (no `.pi`
  * support).
  *
- * pi parses the trust flags sequentially, last-wins (see pi-coding-agent
- * dist/cli/args.js: `--approve`/`-a` set projectTrustOverride=true,
- * `--no-approve`/`-na` set it false). A caller-supplied `--approve` in
- * `options.args` would therefore re-enable project-local loading. To keep the
- * decline deterministic we STRIP every trust flag spelling from `options.args`
- * and emit exactly one leading `--no-approve` that no caller can override.
+ * `--no-context-files` is also ALWAYS present AND NON-OVERRIDABLE. Bobbit owns
+ * AGENTS.md / CLAUDE.md injection in system-prompt.ts, scoped to the registered
+ * project root and configured agent files; pi's independent upward context-file
+ * discovery must stay disabled so parent-directory context cannot leak into the
+ * runtime system prompt or extension hook events.
+ *
+ * pi parses the trust/context flags sequentially, last-wins (see
+ * pi-coding-agent dist/cli/args.js: `--approve`/`-a` set
+ * projectTrustOverride=true, `--no-approve`/`-na` set it false; context-file
+ * flags similarly enable/disable context loading). Caller-supplied flags in
+ * `options.args` would therefore override Bobbit's policy. To keep the decline
+ * deterministic we STRIP every trust/context flag spelling from `options.args`
+ * and emit exactly one leading `--no-approve` and `--no-context-files` that no
+ * caller can override.
  */
 export function buildAgentArgs(options: RpcBridgeOptions): string[] {
-	const args = ["--mode", "rpc", "--no-approve"];
+	const args = ["--mode", "rpc", "--no-approve", "--no-context-files"];
 	if (options.systemPromptPath) args.push("--system-prompt", options.systemPromptPath);
 	if (options.initialModel) {
 		const slash = options.initialModel.indexOf("/");
@@ -263,12 +271,24 @@ export function buildAgentArgs(options: RpcBridgeOptions): string[] {
 		}
 	}
 	if (options.args) {
-		// Drop any caller-supplied project-trust flag so the single leading
-		// `--no-approve` above is non-overridable. These flags are valueless
-		// booleans, so filtering the token alone is sufficient (no paired value to
-		// also remove).
-		const TRUST_FLAGS = new Set(["--approve", "-a", "--no-approve", "-na"]);
-		args.push(...options.args.filter((a) => !TRUST_FLAGS.has(a)));
+		// Drop any caller-supplied project-trust/context-file flag so the single
+		// leading `--no-approve` and `--no-context-files` above are
+		// non-overridable. `--context-files`/`-c` may take a following value; remove
+		// that paired value when present without disturbing unrelated flags.
+		const STRIPPED_VALUELESS_FLAGS = new Set(["--approve", "-a", "--no-approve", "-na", "--no-context-files", "-nc"]);
+		const filteredArgs: string[] = [];
+		for (let i = 0; i < options.args.length; i++) {
+			const arg = options.args[i];
+			if (STRIPPED_VALUELESS_FLAGS.has(arg)) continue;
+			if (arg === "--context-files" || arg === "-c") {
+				const next = options.args[i + 1];
+				if (next !== undefined && !next.startsWith("-")) i++;
+				continue;
+			}
+			if (arg.startsWith("--context-files=") || arg.startsWith("-c=")) continue;
+			filteredArgs.push(arg);
+		}
+		args.push(...filteredArgs);
 	}
 	return args;
 }

--- a/tests/rpc-bridge-spawn-args.test.ts
+++ b/tests/rpc-bridge-spawn-args.test.ts
@@ -34,6 +34,31 @@ describe("buildAgentArgs", () => {
 		}
 	});
 
+	it("always includes --no-context-files so pi never auto-loads parent AGENTS.md/CLAUDE.md context", () => {
+		// Bobbit owns project instruction injection via its assembled system prompt.
+		// pi's independent context-file discovery must stay disabled on every
+		// launch path so parent-directory AGENTS.md / CLAUDE.md files cannot leak
+		// into the runtime system prompt or extension hook events.
+		for (const opts of [
+			{},
+			{ initialModel: "anthropic/claude-opus-4-8" },
+			{ initialThinkingLevel: "high" },
+			{ systemPromptPath: "/tmp/p.md", initialModel: "openai/gpt-4o", initialThinkingLevel: "xhigh" },
+			{ args: ["--tools", "read,write"] },
+		]) {
+			const args = buildAgentArgs(opts);
+			assert.ok(
+				args.includes("--no-context-files"),
+				`--no-context-files must always be present to disable pi context-file discovery, got: ${args.join(" ")}`,
+			);
+			assert.equal(
+				args.filter((a) => a === "--no-context-files").length,
+				1,
+				`exactly one --no-context-files expected, got: ${args.join(" ")}`,
+			);
+		}
+	});
+
 	it("strips a caller-supplied --approve and keeps exactly one non-overridable --no-approve", () => {
 		// pi parses trust flags last-wins; a trailing --approve would re-enable
 		// project-local .pi loading. It must be stripped, leaving the leading
@@ -84,13 +109,46 @@ describe("buildAgentArgs", () => {
 		assert.equal(args[idxTools + 1], "read", "--tools value preserved");
 	});
 
+	it("strips caller-supplied context-file flags and aliases without disturbing unrelated args", () => {
+		const args = buildAgentArgs({
+			initialModel: "anthropic/claude-3-5-sonnet",
+			args: [
+				"--context-files", "/tmp/parent/AGENTS.md",
+				"-c",
+				"--no-context-files",
+				"-nc",
+				"--tools", "read",
+				"--extension", "/foo.ts",
+			],
+		});
+
+		assert.equal(
+			args.filter((a) => a === "--no-context-files").length,
+			1,
+			`exactly one --no-context-files expected, got: ${args.join(" ")}`,
+		);
+		assert.ok(!args.includes("--context-files"), `--context-files must be stripped, got: ${args.join(" ")}`);
+		assert.ok(!args.includes("-c"), `-c context-file alias must be stripped, got: ${args.join(" ")}`);
+		assert.ok(!args.includes("-nc"), `-nc alias must be de-duplicated, got: ${args.join(" ")}`);
+		assert.ok(
+			!args.includes("/tmp/parent/AGENTS.md"),
+			`--context-files paired value must be stripped with the flag, got: ${args.join(" ")}`,
+		);
+		assert.deepEqual(args, [
+			"--mode", "rpc", "--no-approve", "--no-context-files",
+			"--model", "anthropic/claude-3-5-sonnet",
+			"--tools", "read",
+			"--extension", "/foo.ts",
+		]);
+	});
+
 	it("includes --model and --thinking when initialModel/initialThinkingLevel are set", () => {
 		const args = buildAgentArgs({
 			initialModel: "anthropic/claude-3-5-sonnet",
 			initialThinkingLevel: "high",
 		});
 		assert.deepEqual(args, [
-			"--mode", "rpc", "--no-approve",
+			"--mode", "rpc", "--no-approve", "--no-context-files",
 			"--model", "anthropic/claude-3-5-sonnet",
 			"--thinking", "high",
 		]);
@@ -156,7 +214,7 @@ describe("buildAgentArgs", () => {
 		});
 
 		assert.deepEqual(args, [
-			"--mode", "rpc", "--no-approve",
+			"--mode", "rpc", "--no-approve", "--no-context-files",
 			"--model", "anthropic/claude-opus-4-8",
 			"--thinking", "xhigh",
 		]);


### PR DESCRIPTION
## Summary
- Add non-overridable `--no-context-files` to Bobbit pi agent launches via `buildAgentArgs()`
- Strip caller-supplied pi context-file flags and aliases so parent `AGENTS.md` / `CLAUDE.md` discovery cannot be re-enabled
- Add regression coverage and document Bobbit-owned project instruction assembly

## Validation
- `npx tsx --test --test-force-exit tests/rpc-bridge-spawn-args.test.ts`
- Implementation workflow gate passed: build, typecheck, repro test, unit, E2E, reviews, QA

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)