### PR TITLE
Adjust sidebar indentation defaults

### DIFF
--- a/docs/sidebar-tree-indentation.md
+++ b/docs/sidebar-tree-indentation.md
@@ -15,16 +15,16 @@ The control is a numeric pixel input with a visible `px` suffix and a reset acti
 | Property | Value |
 |---|---|
 | Storage key | `bobbit:sidebar-tree-indent` |
-| Default | `16` px |
-| Range | `8`–`28` px |
+| Default | `6` px |
+| Range | `1`–`28` px |
 | Step | `1` px |
-| Reset copy | `Reset to 16 px` |
+| Reset copy | `Reset to 6 px` |
 | Scope | Current browser only |
 
 Behavior:
 
 - Values are saved in `localStorage` under `bobbit:sidebar-tree-indent`.
-- Missing, empty, non-numeric, `NaN`, or unavailable storage falls back to `16` px.
+- Missing, empty, non-numeric, `NaN`, or unavailable storage falls back to `6` px.
 - Finite out-of-range values clamp to the nearest bound.
 - Decimal values round to the nearest 1 px step.
 - Saving is best-effort: if storage writes fail, Bobbit still applies the clamped value in memory for the current page.
@@ -41,15 +41,15 @@ The setting affects only sidebar tree spacing. It does not change persisted expa
 {
   version: 1,
   indentMode: "comfortable",
-  baseIndentPx: 16,
-  nestedGoalIndentPx: 16
+  baseIndentPx: 6,
+  nestedGoalIndentPx: 6
 }
 ```
 
 Rules:
 
 - `baseIndentPx` and `nestedGoalIndentPx` both come from the clamped user preference in normal runtime use.
-- The builder also accepts partial layout objects for tests and future callers; missing values fall back to builder defaults (`baseIndentPx: 5`, `nestedGoalIndentPx: 16`) before clamping.
+- The builder also accepts partial layout objects for tests and future callers; missing values fall back to builder defaults (`baseIndentPx: 5`, `nestedGoalIndentPx: 6`) before clamping.
 - Project-forest and archived-forest goal rows use `nestedGoalIndentPx`.
 - Runtime rows under goals, sessions, team leads, delegates, and spawned child goals use `baseIndentPx`.
 - Collapsed sidebars use a derived value: `min(6, max(2, round(indent / 3)))` so nesting remains visible without pushing compact labels into overflow.
@@ -72,9 +72,9 @@ Fallback/default variables scoped under `.sidebar-root`:
 
 | Variable | Default |
 |---|---|
-| `--sidebar-tree-base-indent-default` | `5px` |
-| `--sidebar-tree-nested-goal-indent-default` | `16px` |
-| `--sidebar-tree-collapsed-indent-default` | `5px` |
+| `--sidebar-tree-base-indent-default` | `6px` |
+| `--sidebar-tree-nested-goal-indent-default` | `6px` |
+| `--sidebar-tree-collapsed-indent-default` | `2px` |
 | `--sidebar-tree-half-indent` | Half of the active base indent |
 
 Consumption should use logical padding and fallback-aware CSS, for example:
@@ -112,7 +112,7 @@ Template helpers:
 Renderer guidance:
 
 - Pass `loadSidebarTreeLayoutPreference()` into sidebar tree construction for desktop, mobile, and collapsed viewports.
-- Use helper-generated `padding-inline-start` instead of hardcoded `padding-left`, `node.depth * 16`, or direct `node.indentPx` strings.
+- Use helper-generated `padding-inline-start` instead of hardcoded `padding-left`, fixed depth multipliers, or direct `node.indentPx` strings.
 - Keep `min-w-0`, `truncate`, overflow gradients, active row classes, and chevron slot padding independent from the indent preference.
 
 ## Implementation map

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -23,9 +23,9 @@ bell-toggle button {
  * Keep selectors narrow so compound plus overlays are never clipped by generic
  * sidebar SVG/span rules. */
 .sidebar-root {
-	--sidebar-tree-base-indent-default: 5px;
-	--sidebar-tree-nested-goal-indent-default: 16px;
-	--sidebar-tree-collapsed-indent-default: 5px;
+	--sidebar-tree-base-indent-default: 6px;
+	--sidebar-tree-nested-goal-indent-default: 6px;
+	--sidebar-tree-collapsed-indent-default: 2px;
 	--sidebar-tree-half-indent: calc(var(--sidebar-tree-base-indent, var(--sidebar-tree-base-indent-default)) / 2);
 	--sidebar-scale-icon-size: 1em;
 	--sidebar-compound-icon-size: 1em;

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -646,6 +646,7 @@ function renderMobileLanding() {
 													${projectTree.goalForest.length > 0 ? html`<div class="border-t border-border/30 mx-2"></div>` : ""}
 													<div class="flex flex-col gap-0.5">
 														${(() => { const _mobileUngroupedExp = projectTree.sessionsSectionNode.expanded; return html`<div class="flex items-center gap-1 pl-0 pr-2 py-0.5 rounded-md cursor-pointer active:bg-secondary/50 transition-colors"
+															data-testid="sidebar-sessions-header"
 															data-tree-key=${projectTree.sessionsSectionNode.key}
 															@click=${() => { setUngroupedExpanded(project.id, !_mobileUngroupedExp); renderApp(); }}>
 															<span class="sidebar-chevron-slot sidebar-chevron-slot--header text-muted-foreground shrink-0 select-none"><span class="sidebar-chevron-glyph">${_mobileUngroupedExp ? "▾" : "▸"}</span></span>
@@ -667,6 +668,7 @@ function renderMobileLanding() {
 																</button>
 																<button
 																	class="p-1 rounded text-muted-foreground active:bg-secondary/50 transition-colors"
+																	style="line-height:0;"
 																	@click=${(e: Event) => { e.stopPropagation(); toggleRolePicker(e, undefined, { projectId: project.id, projectName: project.name, projectCwd: project.rootPath }); }}
 																	title="New session with role"
 																><span class="sidebar-scale-icon">${icon(ChevronDown, "sm")}</span></button>

--- a/src/app/sidebar-tree-layout.ts
+++ b/src/app/sidebar-tree-layout.ts
@@ -2,8 +2,8 @@ import type { SidebarTreeLayoutPreferenceV1, SidebarTreeNode } from "./sidebar-t
 import { safeGetItem, safeSetItem } from "./safe-storage.js";
 
 export const SIDEBAR_TREE_INDENT_KEY = "bobbit:sidebar-tree-indent";
-export const SIDEBAR_TREE_INDENT_DEFAULT_PX = 16;
-export const SIDEBAR_TREE_INDENT_MIN_PX = 8;
+export const SIDEBAR_TREE_INDENT_DEFAULT_PX = 6;
+export const SIDEBAR_TREE_INDENT_MIN_PX = 1;
 export const SIDEBAR_TREE_INDENT_MAX_PX = 28;
 export const SIDEBAR_TREE_INDENT_STEP_PX = 1;
 export const SIDEBAR_TREE_BASE_INDENT_PX = 5;

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -960,6 +960,7 @@ export function renderStaffSidebarSection(filteredList?: typeof state.staffList,
 		<div class="border-t border-border/30 ${mobile ? "my-0.5" : "my-1"} mx-2"></div>
 		<div class="flex flex-col gap-0.5">
 			<div class="relative flex items-center ${mobile ? "gap-1 pl-0 pr-2 py-0.5" : "gap-1 pr-1 py-0.5"} rounded-md cursor-pointer ${staffNavActive ? "bg-secondary text-foreground sidebar-session-active" : (mobile ? "active:bg-secondary/50" : "hover:bg-secondary/30")} transition-colors"
+				data-testid="sidebar-staff-header"
 				data-tree-key=${dataTreeKey ?? ""}
 				data-nav-id=${staffNavId}
 				data-nav-active=${staffNavActive ? "true" : "false"}
@@ -1607,6 +1608,7 @@ function renderProjectContent(projectTree: SidebarProjectTree) {
 		<div class="flex flex-col gap-0.5">
 			${(() => { const ungNavId = `ungrouped-header:${project.id}`; const ungActive = getActiveNavId() === ungNavId; return html`
 			<div class="relative flex items-center gap-1 pr-1 py-0.5 rounded-md cursor-pointer ${ungActive ? "bg-secondary text-foreground sidebar-session-active" : "hover:bg-secondary/30"} transition-colors"
+				data-testid="sidebar-sessions-header"
 				data-tree-key=${projectTree.sessionsSectionNode.key}
 				data-nav-id=${ungNavId}
 				data-nav-active=${ungActive ? "true" : "false"}
@@ -1633,6 +1635,7 @@ function renderProjectContent(projectTree: SidebarProjectTree) {
 					</button>
 					<button
 						class="p-0.5 rounded-md hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+						style="line-height:0;"
 						@click=${(e: Event) => { e.stopPropagation(); toggleRolePicker(e, undefined, { projectId: project.id, projectName: project.name, projectCwd: project.rootPath }); }}
 						title="New session with role"
 					><span class="sidebar-scale-icon">${icon(ChevronDown, "xs")}</span></button>

--- a/tests/e2e/ui/sidebar-indent.spec.ts
+++ b/tests/e2e/ui/sidebar-indent.spec.ts
@@ -6,8 +6,8 @@ import { apiFetch, createGoal, defaultProjectId, deleteGoal } from "../e2e-setup
 import { openApp, navigateToHash } from "./ui-helpers.js";
 
 const INDENT_KEY = "bobbit:sidebar-tree-indent";
-const DEFAULT_PX = 16;
-const MIN_PX = 8;
+const DEFAULT_PX = 6;
+const MIN_PX = 1;
 const MAX_PX = 28;
 const INDENT_INPUT = "[data-testid='sidebar-tree-indent-input']";
 const INDENT_RESET = "[data-testid='sidebar-tree-indent-reset']";
@@ -203,7 +203,7 @@ test.describe("Sidebar tree indentation (full-stack UI)", () => {
 		expect(await inputValueAsNumber(page)).toBe(DEFAULT_PX);
 		await waitForRuntimeIndent(page, DEFAULT_PX);
 		const defaultOffset = await childOffset(page, fixture);
-		expect(defaultOffset, "default nested child goal offset should be visibly indented").toBeGreaterThan(8);
+		expect(defaultOffset, "default nested child goal offset should be visibly indented").toBeGreaterThan(2);
 
 		await setIndentPx(page, "24");
 		await waitForRuntimeIndent(page, 24);

--- a/tests/e2e/ui/sidebar-indent.spec.ts
+++ b/tests/e2e/ui/sidebar-indent.spec.ts
@@ -191,6 +191,9 @@ test.describe("Sidebar tree indentation (full-stack UI)", () => {
 		await openApp(page);
 		await seedSidebarState(page, fixture);
 		await reloadAndWaitForSidebarTree(page, fixture);
+		const sessionsHeaderBox = await page.getByTestId("sidebar-sessions-header").first().boundingBox();
+		const staffHeaderBox = await page.getByTestId("sidebar-staff-header").first().boundingBox();
+		expect(Math.round(sessionsHeaderBox?.height ?? 0), "Sessions and Staff sidebar headers should match height").toBe(Math.round(staffHeaderBox?.height ?? 0));
 		await openGeneralSettings(page);
 
 		await expect(page.getByLabel("Sidebar tree indentation")).toBeVisible({ timeout: 5_000 });

--- a/tests/sidebar-tree-builder.test.ts
+++ b/tests/sidebar-tree-builder.test.ts
@@ -75,10 +75,10 @@ describe("sidebar tree key primitives", () => {
 	});
 
 	it("resolves clamped indentation defaults for builder metadata", () => {
-		assert.deepEqual(resolveSidebarTreeLayoutPreference(), { version: 1, indentMode: "comfortable", baseIndentPx: 5, nestedGoalIndentPx: 16 });
+		assert.deepEqual(resolveSidebarTreeLayoutPreference(), { version: 1, indentMode: "comfortable", baseIndentPx: 5, nestedGoalIndentPx: 6 });
 		assert.deepEqual(resolveSidebarTreeLayoutPreference({ indentMode: "spacious", baseIndentPx: 16, nestedGoalIndentPx: 28 }), { version: 1, indentMode: "spacious", baseIndentPx: 16, nestedGoalIndentPx: 28 });
-		assert.deepEqual(resolveSidebarTreeLayoutPreference({ indentMode: "spacious", baseIndentPx: 99, nestedGoalIndentPx: Number.NaN }), { version: 1, indentMode: "spacious", baseIndentPx: 28, nestedGoalIndentPx: 16 });
-		assert.deepEqual(resolveSidebarTreeLayoutPreference({ baseIndentPx: -10, nestedGoalIndentPx: -1 }), { version: 1, indentMode: "comfortable", baseIndentPx: 8, nestedGoalIndentPx: 8 });
+		assert.deepEqual(resolveSidebarTreeLayoutPreference({ indentMode: "spacious", baseIndentPx: 99, nestedGoalIndentPx: Number.NaN }), { version: 1, indentMode: "spacious", baseIndentPx: 28, nestedGoalIndentPx: 6 });
+		assert.deepEqual(resolveSidebarTreeLayoutPreference({ baseIndentPx: -10, nestedGoalIndentPx: -1 }), { version: 1, indentMode: "comfortable", baseIndentPx: 1, nestedGoalIndentPx: 1 });
 		assert.deepEqual(resolveSidebarTreeLayoutPreference({ baseIndentPx: 99, nestedGoalIndentPx: 99 }), { version: 1, indentMode: "comfortable", baseIndentPx: 28, nestedGoalIndentPx: 28 });
 	});
 });
@@ -167,8 +167,8 @@ describe("buildSidebarTree", () => {
 		assert.equal(childA.logicalDepth, 2);
 		assert.equal(grand.logicalDepth, 3);
 		assert.equal(root.indentPx, 0);
-		assert.equal(childA.indentPx, 16);
-		assert.equal(grand.indentPx, 32);
+		assert.equal(childA.indentPx, 6);
+		assert.equal(grand.indentPx, 12);
 		assert.equal(root.context.descendantCount, 3);
 		assert.equal(childA.context.displayTitleSuffix, "child-" );
 		assert.equal(childB.context.displayTitleSuffix, "child-" );
@@ -360,7 +360,7 @@ describe("buildSidebarTree", () => {
 		assert.equal(archivedRoot.logicalDepth, (model.projects[0].archivedSectionNode?.logicalDepth ?? 0) + 1);
 		assert.equal(archivedRoot.indentPx, 0);
 		assert.equal(archivedGrand.entityId, "archived-grand");
-		assert.equal(archivedGrand.indentPx, 16);
+		assert.equal(archivedGrand.indentPx, 6);
 	});
 
 	it("terminates malformed spawned descendant cycles before recursive subtree conversion", () => {

--- a/tests/sidebar-tree-layout.test.ts
+++ b/tests/sidebar-tree-layout.test.ts
@@ -70,7 +70,7 @@ describe("sidebar tree indent preference helpers", () => {
 		assert.equal(clampSidebarTreeIndentPx("18"), SIDEBAR_TREE_INDENT_DEFAULT_PX);
 		// @ts-expect-error explicit missing-value coverage
 		assert.equal(clampSidebarTreeIndentPx(undefined), SIDEBAR_TREE_INDENT_DEFAULT_PX);
-		assert.equal(clampSidebarTreeIndentPx(7), SIDEBAR_TREE_INDENT_MIN_PX);
+		assert.equal(clampSidebarTreeIndentPx(0), SIDEBAR_TREE_INDENT_MIN_PX);
 		assert.equal(clampSidebarTreeIndentPx(29), SIDEBAR_TREE_INDENT_MAX_PX);
 		assert.equal(clampSidebarTreeIndentPx(18.4), 18);
 		assert.equal(clampSidebarTreeIndentPx(18.5), 19);
@@ -89,8 +89,8 @@ describe("sidebar tree indent preference helpers", () => {
 			baseIndentPx: 28,
 			nestedGoalIndentPx: 28,
 		});
-		assert.equal(sidebarTreeCollapsedIndentPx(8), 3);
-		assert.equal(sidebarTreeCollapsedIndentPx(16), 5);
+		assert.equal(sidebarTreeCollapsedIndentPx(1), 2);
+		assert.equal(sidebarTreeCollapsedIndentPx(6), 2);
 		assert.equal(sidebarTreeCollapsedIndentPx(28), 6);
 	});
 
@@ -143,7 +143,7 @@ describe("sidebar tree indent storage", () => {
 		localStorage.setItem(SIDEBAR_TREE_INDENT_KEY, "22");
 		assert.equal(loadSidebarTreeIndentPx(), 22);
 		assert.deepEqual(loadSidebarTreeLayoutPreference(), { version: 1, indentMode: "comfortable", baseIndentPx: 22, nestedGoalIndentPx: 22 });
-		localStorage.setItem(SIDEBAR_TREE_INDENT_KEY, "2");
+		localStorage.setItem(SIDEBAR_TREE_INDENT_KEY, "0");
 		assert.equal(loadSidebarTreeIndentPx(), SIDEBAR_TREE_INDENT_MIN_PX);
 		localStorage.setItem(SIDEBAR_TREE_INDENT_KEY, "200");
 		assert.equal(loadSidebarTreeIndentPx(), SIDEBAR_TREE_INDENT_MAX_PX);
@@ -186,9 +186,9 @@ describe("applySidebarTreeLayoutVars", () => {
 
 		vars = installDocumentStyleShim();
 		applySidebarTreeLayoutVars({ version: 1, indentMode: "comfortable", baseIndentPx: -1, nestedGoalIndentPx: Number.NaN });
-		assert.equal(vars.get("--sidebar-tree-base-indent"), "8px");
-		assert.equal(vars.get("--sidebar-tree-nested-goal-indent"), "16px");
-		assert.equal(vars.get("--sidebar-tree-collapsed-indent"), "3px");
+		assert.equal(vars.get("--sidebar-tree-base-indent"), "1px");
+		assert.equal(vars.get("--sidebar-tree-nested-goal-indent"), "6px");
+		assert.equal(vars.get("--sidebar-tree-collapsed-indent"), "2px");
 	});
 
 	it("is safe without document", () => {


### PR DESCRIPTION
## Summary
- Lower sidebar tree indentation minimum from 8px to 1px
- Change default/reset indentation from 16px to 6px
- Update docs and sidebar indentation tests

## Validation
- npx tsx --test tests/sidebar-tree-layout.test.ts tests/sidebar-tree-builder.test.ts
- npm run check

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)