### PR TITLE
Retry wedged sessions before auto-nudge

### DIFF
--- a/docs/auto-retry.md
+++ b/docs/auto-retry.md
@@ -92,18 +92,30 @@ Generic unexpected errors and non-provider transient transport failures both use
 
 ## Team-lead auto-nudge interaction
 
-Team leads rely on automatic nudges to resume work after child-agent or gate activity. `TeamManager` uses `nudgePending` to avoid flooding a lead with duplicate prompts, but sent accounting must only advance when delivery starts or is accepted as a lead turn.
+Team leads rely on automatic nudges to resume work after child-agent or gate activity. The same nudge sources also run while a lead is sitting on an errored idle turn, so `TeamManager` checks that state before adding any new `[AUTO-NUDGE]` prompt.
 
-Auto-nudge delivery now treats these as no-start outcomes:
+If the lead is `idle` with `lastTurnErrored`, retryable errors are recovered through `retryLastPrompt(sessionId, { auto: true })` instead of enqueueing a fresh nudge. This keeps recovery on the same continuation-safe path as auto-retry and the UI Retry button.
+
+Team auto-nudges are suppressed, without adding duplicate transcript cards, when:
+
+- `SessionManager` already has a pending auto-retry timer;
+- a retry or pending nudge is already in progress;
+- the error is unknown, non-retryable, or has exhausted the bounded retry budget.
+
+In the final case, the explicit UI Retry affordance remains the human-action path.
+
+Auto-nudge delivery also treats these as no-start outcomes:
 
 - `enqueuePrompt()` throws synchronously;
 - the async delivery rejects;
 - the prompt parks behind an errored/capped session;
 - delivery resolves as queued while the team lead remains idle.
 
-No-start outcomes clear `nudgePending`, do not increment the successful sent counter, and do not log `Sent ... nudge`. They advance a separate attempt counter only enough to reschedule with bounded backoff, avoiding repeated misleading “Sent” logs while the lead is still stuck.
+No-start outcomes clear `nudgePending`, do not increment the successful sent counter, and do not log `Sent ... nudge`. They advance a separate attempt counter only enough to reschedule with bounded backoff, avoiding repeated misleading “Sent” logs while the lead is still stuck. Retry attempts likewise do not count as successful nudges unless the agent actually starts.
 
 `agent_start` confirms the normal success path. Auto-nudge, task-notification, verification, and agent-sourced lead turns preserve existing nudge backoff counters; external user/system prompts reset them.
+
+See [Auto-Nudge Recovery for Errored Team Leads](design/auto-nudge-stuck-team-leads.md) for the team-manager-specific policy.
 
 ## Tests
 
@@ -112,6 +124,7 @@ Relevant coverage runs under `npm run test:unit` unless noted:
 - `tests/auto-retry-policy.test.ts` covers provider overload, generic unexpected retries at 1 s / 5 s / 60 s, retry exhaustion, deterministic exclusions, and `fetch failed` message-end scheduling.
 - `tests/session-manager-direct-prompt-lifecycle.test.ts` covers direct and queued `fetch failed` delivery failures before `message_end`, recovered queue rows, client-visible `auto_retry_pending`, `auto_retry_cancelled` on exhaustion/cancellation, no duplicate replay, fresh-prompt supersession, and stale tool-call-state clearing.
 - `tests/verification-logic.test.ts` and `tests/transient-review-error.test.ts` cover `fetch failed`, undici transport codes, deterministic exclusions, and `shouldRetryVerificationStep()` behavior.
-- `tests/team-manager-idle-nudge-backoff.test.ts` covers no-start auto-nudge accounting: rejected/parked/queued deliveries clear `nudgePending` and are not counted or logged as sent before `agent_start`.
+- `tests/team-manager-idle-nudge-backoff.test.ts` covers no-start auto-nudge accounting and errored-idle recovery: retryable errors use `retryLastPrompt(..., { auto: true })`, unknown/non-retryable/exhausted errors suppress team nudges, and repeated timer ticks do not emit duplicate `[AUTO-NUDGE]` cards.
+- `tests/team-manager.test.ts` covers worker-idle notification recovery for errored idle team leads.
 - `tests/queue-dispatch.spec.ts` covers queue-level cancellation and retry/unstick invariants.
 - `tests/e2e/ui/auto-retry-banner.spec.ts` covers the UI banner state for `auto_retry_pending`, `auto_retry_cancelled`, and `agent_start`.

--- a/docs/design/auto-nudge-stuck-team-leads.md
+++ b/docs/design/auto-nudge-stuck-team-leads.md
@@ -1,0 +1,50 @@
+# Auto-Nudge Recovery for Errored Team Leads
+
+## Context
+
+Team goals have several server-side paths that wake an idle team lead when work may be stuck:
+
+- workers-active idle checks;
+- no-workers idle checks;
+- worker-idle notifications after a child agent finishes;
+- the stuck-team watchdog for fully idle teams.
+
+All of these paths can produce an `[AUTO-NUDGE]` prompt. That is useful when the lead is simply idle, but harmful when the lead is already stopped on an errored turn: a new nudge appends another transcript card behind the visible error instead of resolving the failed turn.
+
+## Retry before auto-nudge
+
+`TeamManager` now checks the target session before sending an auto-nudge. If the team lead is `idle` and `lastTurnErrored` is true, the nudge path treats the error state as already requiring retry handling and does not enqueue or steer a fresh `[AUTO-NUDGE]` message.
+
+For retryable errored idle sessions, `TeamManager` recovers through the same path as the automatic retry scheduler and the UI Retry affordance:
+
+```ts
+retryLastPrompt(sessionId, { auto: true })
+```
+
+Using `retryLastPrompt` keeps continuation safety centralized in `SessionManager`. If the failed turn already ran tools, retry resumes the interrupted work instead of replaying side effects; if the prompt failed before the agent started, recovered queue rows are consumed by the retry path rather than duplicated.
+
+## Suppression cases
+
+The team nudge path suppresses duplicate transcript cards in these cases:
+
+- **Retry pending** — if `pendingAutoRetryTimer` is set, `SessionManager` already owns the scheduled retry. Team nudges do not start another retry and do not add `[AUTO-NUDGE]` cards.
+- **Retry in progress / pending lead turn** — `nudgePending` blocks later timer ticks while recovery is being handled, so repeated watchdog passes do not stack new nudges.
+- **Unknown, non-retryable, or exhausted errors** — if the error is unclassified, matches a non-retryable classifier, or has exhausted the bounded retry budget, team nudges are suppressed and the explicit UI Retry button remains the human-action path.
+
+Provider backoff errors use the existing unbounded provider-overload policy. Other retryable transient/generic errors share the bounded retry budget used by auto-retry; after the budget is exhausted, the lead remains on the error with manual Retry available.
+
+## Accounting
+
+A retry attempt is not counted as a successful auto-nudge. Successful nudge counters and “Sent nudge” logs advance only when an auto-nudge delivery actually starts or is accepted as a lead turn. If recovery is suppressed, pending, parked, or fails before `agent_start`, the no-start accounting path preserves backoff semantics and avoids misleading transcript/log churn.
+
+This preserves the distinction between two outcomes:
+
+- the agent actually started processing an auto-nudge; and
+- the team manager merely observed an errored idle session and delegated recovery to retry handling.
+
+## Related docs and tests
+
+- [Auto-Retry](../auto-retry.md) describes retry classification, scheduling, and UI events.
+- [Notification Policy](notification-policy.md#9-team-lead-idle-nudge-backoff) describes team-lead idle nudge cadence and prompt provenance.
+- `tests/team-manager-idle-nudge-backoff.test.ts` covers retry-before-nudge, suppression for unknown/non-retryable errors, and duplicate-card prevention while auto-retry is pending.
+- `tests/team-manager.test.ts` covers worker-idle notification recovery for errored idle team leads.

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
 import type { PromptSource, SessionManager, SessionInfo } from "./session-manager.js";
-import { isNonRetryableAgentError } from "./verification-logic.js";
+import { isNonRetryableAgentError, isProviderBackoffError, isRetryableGenericAgentError, isTransientReviewError } from "./verification-logic.js";
 import { GoalManager } from "./goal-manager.js";
 import { GoalStore, type PersistedGoal } from "./goal-store.js";
 import { createWorktree, cleanupWorktree } from "../skills/git.js";
@@ -77,6 +77,26 @@ function discoverAgentsForGoalAcrossSessionRoots(teamLeadWorktreePath: string) {
 		}
 	}
 	return out;
+}
+
+const BOUNDED_ERRORED_IDLE_AUTO_RETRY_ATTEMPTS = 3;
+
+function isErroredIdleAutoRetryEligible(session: SessionInfo): boolean {
+	const errMsg = session.lastTurnErrorMessage || "";
+	if (!errMsg || isNonRetryableAgentError(errMsg)) return false;
+
+	const isBackoff = isProviderBackoffError(errMsg);
+	const isTransient = isTransientReviewError(errMsg);
+	const isGenericRetryable = !isTransient && isRetryableGenericAgentError(errMsg);
+	// OpenAI/Codex reports retryable 5xx failures with a compact `server_error`
+	// code; keep team-manager recovery consistent with the visible Retry path for
+	// that provider code without treating arbitrary unknown errors as retryable.
+	const isRetryableServerErrorCode = /\bserver_error\b/i.test(errMsg);
+	if (!isBackoff && !isTransient && !isGenericRetryable && !isRetryableServerErrorCode) return false;
+	if (isBackoff) return true;
+
+	return (session.transientRetryAttempts ?? 0) < BOUNDED_ERRORED_IDLE_AUTO_RETRY_ATTEMPTS
+		&& (session.consecutiveErrorTurns ?? 0) < BOUNDED_ERRORED_IDLE_AUTO_RETRY_ATTEMPTS;
 }
 
 async function gitRefExists(repoPath: string, ref: string): Promise<boolean> {
@@ -1121,12 +1141,18 @@ export class TeamManager {
 			return true;
 		}
 
-		const errMsg = session.lastTurnErrorMessage || "";
-		const exhausted = (session.consecutiveErrorTurns ?? 0) >= 3;
-		if (exhausted || isNonRetryableAgentError(errMsg)) {
+		if (!isErroredIdleAutoRetryEligible(session)) {
+			const errMsg = session.lastTurnErrorMessage || "";
+			const exhausted = (session.consecutiveErrorTurns ?? 0) >= BOUNDED_ERRORED_IDLE_AUTO_RETRY_ATTEMPTS
+				|| (session.transientRetryAttempts ?? 0) >= BOUNDED_ERRORED_IDLE_AUTO_RETRY_ATTEMPTS;
+			const reason = exhausted
+				? " after exhausted retries"
+				: isNonRetryableAgentError(errMsg)
+					? " for a non-retryable error"
+					: " for an unclassified error";
 			console.log(
 				`[team-manager] ${label} suppressed for errored idle session ${sessionId}; ` +
-				`manual Retry required${exhausted ? " after exhausted retries" : ""}`,
+				`manual Retry required${reason}`,
 			);
 			return true;
 		}

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
 import type { PromptSource, SessionManager, SessionInfo } from "./session-manager.js";
+import { isNonRetryableAgentError } from "./verification-logic.js";
 import { GoalManager } from "./goal-manager.js";
 import { GoalStore, type PersistedGoal } from "./goal-store.js";
 import { createWorktree, cleanupWorktree } from "../skills/git.js";
@@ -1073,6 +1074,8 @@ export class TeamManager {
 		label: string,
 		accounting?: { onStarted?: () => void; onNoStart?: () => void },
 	): boolean {
+		if (this.recoverErroredIdleSessionBeforeNudge(goalId, sessionId, label)) return true;
+
 		this.nudgePending.set(goalId, true);
 		if (accounting) this.pendingNudgeAccounting.set(goalId, accounting);
 
@@ -1101,6 +1104,44 @@ export class TeamManager {
 			);
 		}
 
+		return true;
+	}
+
+	private recoverErroredIdleSessionBeforeNudge(goalId: string, sessionId: string, label: string): boolean {
+		const session = this.sessionManager.getSession(sessionId);
+		if (!session || session.status !== "idle" || !session.lastTurnErrored) return false;
+
+		// Treat the errored idle state as handled by the session retry/manual Retry path.
+		// This guard prevents every team-manager watchdog from appending fresh
+		// [AUTO-NUDGE] cards behind the visible error affordance.
+		this.nudgePending.set(goalId, true);
+
+		if (session.pendingAutoRetryTimer) {
+			console.log(`[team-manager] ${label} skipped for goal ${goalId}; session ${sessionId} already has an auto-retry pending`);
+			return true;
+		}
+
+		const errMsg = session.lastTurnErrorMessage || "";
+		const exhausted = (session.consecutiveErrorTurns ?? 0) >= 3;
+		if (exhausted || isNonRetryableAgentError(errMsg)) {
+			console.log(
+				`[team-manager] ${label} suppressed for errored idle session ${sessionId}; ` +
+				`manual Retry required${exhausted ? " after exhausted retries" : ""}`,
+			);
+			return true;
+		}
+
+		try {
+			const retry = this.sessionManager.retryLastPrompt(sessionId, { auto: true });
+			if (this.isThenable(retry)) {
+				void retry.catch((err) => {
+					console.error(`[team-manager] ${label} retryLastPrompt failed for goal ${goalId}:`, err);
+				});
+			}
+			console.log(`[team-manager] ${label} recovered errored idle session ${sessionId} via retryLastPrompt(auto)`);
+		} catch (err) {
+			console.error(`[team-manager] ${label} retryLastPrompt failed for goal ${goalId}:`, err);
+		}
 		return true;
 	}
 
@@ -2119,6 +2160,7 @@ export class TeamManager {
 
 		const teamLeadSession = this.sessionManager.getSession(entry.teamLeadSessionId);
 		if (!teamLeadSession || teamLeadSession.status === "terminated") return;
+		if (this.recoverErroredIdleSessionBeforeNudge(goalId, entry.teamLeadSessionId, "Worker-idle notification")) return;
 
 		// Debounce: skip if we notified about this worker in the last 30 seconds
 		const now = Date.now();
@@ -2128,12 +2170,6 @@ export class TeamManager {
 			return;
 		}
 		this.lastNotifyTime.set(workerSessionId, now);
-
-		// Note: we no longer suppress notifications when the team lead's last
-		// turn errored. SessionManager.enqueuePrompt / deliverLiveSteer now own
-		// the error-state policy (implicit unstick up to MAX_CONSECUTIVE_ERROR_TURNS,
-		// park afterwards). A single source of truth avoids nudges being
-		// silently dropped on the floor.
 
 		// Look up tasks assigned to the worker
 		const tasks = this.resolveTasksForSession(goalId, workerSessionId);

--- a/tests/team-manager-idle-nudge-backoff.test.ts
+++ b/tests/team-manager-idle-nudge-backoff.test.ts
@@ -316,6 +316,96 @@ describe("TeamManager — errored idle team lead auto-retry (regression)", () =>
 			t.mock.timers.reset();
 		}
 	});
+
+	it("suppresses unknown errored idle sessions without retrying or enqueueing [AUTO-NUDGE] cards", async (t) => {
+		t.mock.timers.enable({ apis: ["setInterval", "setTimeout"] });
+
+		try {
+			const { tlSession, enqueuePrompt, retryLastPrompt, deliverLiveSteer, fire } = await setupTeamWithCapturedEvents();
+			tlSession.status = "idle";
+			tlSession.lastTurnErrored = true;
+			tlSession.lastTurnErrorMessage = "model stopped with an unexplained deterministic failure";
+			tlSession.lastPromptText = "continue coordinating the team";
+
+			fire("agent_end");
+			t.mock.timers.tick(5 * 60 * 1000 + 1_000);
+			await Promise.resolve();
+			await Promise.resolve();
+
+			assert.equal(retryLastPrompt.mock.callCount(), 0,
+				"unknown/unclassified errors must not be auto-retried by the team-manager nudge path");
+			assert.equal(enqueuePrompt.mock.calls.filter((call: any) =>
+				String(call.arguments[1] ?? "").includes("[AUTO-NUDGE]"),
+			).length, 0,
+				"unknown errored idle sessions must suppress auto-nudge transcript cards");
+			assert.equal(deliverLiveSteer.mock.calls.filter((call: any) =>
+				String(call.arguments[1] ?? "").includes("[AUTO-NUDGE]"),
+			).length, 0,
+				"unknown errored idle sessions must suppress auto-nudge steer cards");
+		} finally {
+			t.mock.timers.reset();
+		}
+	});
+
+	it("suppresses non-retryable errored idle sessions without retrying or enqueueing [AUTO-NUDGE] cards", async (t) => {
+		t.mock.timers.enable({ apis: ["setInterval", "setTimeout"] });
+
+		try {
+			const { tlSession, enqueuePrompt, retryLastPrompt, fire } = await setupTeamWithCapturedEvents();
+			tlSession.status = "idle";
+			tlSession.lastTurnErrored = true;
+			tlSession.lastTurnErrorMessage = "Authentication failed: invalid API key for provider";
+			tlSession.lastPromptText = "continue coordinating the team";
+
+			fire("agent_end");
+			t.mock.timers.tick(5 * 60 * 1000 + 1_000);
+			await Promise.resolve();
+
+			assert.equal(retryLastPrompt.mock.callCount(), 0,
+				"non-retryable errors must leave manual Retry instead of using retryLastPrompt(auto)");
+			assert.equal(enqueuePrompt.mock.calls.filter((call: any) =>
+				String(call.arguments[1] ?? "").includes("[AUTO-NUDGE]"),
+			).length, 0,
+				"non-retryable errored idle sessions must suppress auto-nudge transcript cards");
+		} finally {
+			t.mock.timers.reset();
+		}
+	});
+
+	it("does not emit duplicate [AUTO-NUDGE] cards while session auto-retry is pending", async (t) => {
+		t.mock.timers.enable({ apis: ["setInterval", "setTimeout"] });
+		let pendingAutoRetryTimer: ReturnType<typeof setTimeout> | undefined;
+
+		try {
+			const { tlSession, enqueuePrompt, retryLastPrompt, deliverLiveSteer, fire } = await setupTeamWithCapturedEvents();
+			tlSession.status = "idle";
+			tlSession.lastTurnErrored = true;
+			tlSession.lastTurnErrorMessage = "server_error: upstream provider returned retryable server error";
+			tlSession.lastPromptText = "continue coordinating the team";
+			pendingAutoRetryTimer = setTimeout(() => {}, 60 * 60 * 1000);
+			tlSession.pendingAutoRetryTimer = pendingAutoRetryTimer as any;
+
+			for (let i = 0; i < 3; i++) {
+				fire("agent_end");
+				t.mock.timers.tick(5 * 60 * 1000 + 1_000);
+				await Promise.resolve();
+			}
+
+			assert.equal(retryLastPrompt.mock.callCount(), 0,
+				"team-manager must not start another retry while SessionManager auto-retry is pending");
+			assert.equal(enqueuePrompt.mock.calls.filter((call: any) =>
+				String(call.arguments[1] ?? "").includes("[AUTO-NUDGE]"),
+			).length, 0,
+				"repeated timer ticks while auto-retry is pending must not enqueue duplicate auto-nudge cards");
+			assert.equal(deliverLiveSteer.mock.calls.filter((call: any) =>
+				String(call.arguments[1] ?? "").includes("[AUTO-NUDGE]"),
+			).length, 0,
+				"repeated timer ticks while auto-retry is pending must not steer duplicate auto-nudge cards");
+		} finally {
+			if (pendingAutoRetryTimer) clearTimeout(pendingAutoRetryTimer);
+			t.mock.timers.reset();
+		}
+	});
 });
 
 describe("TeamManager — idle-nudge exponential backoff (regression)", () => {

--- a/tests/team-manager-idle-nudge-backoff.test.ts
+++ b/tests/team-manager-idle-nudge-backoff.test.ts
@@ -209,7 +209,11 @@ async function setupTeamWithCapturedEvents(opts: { addIdleWorker?: boolean } = {
 		const s = sm._sessions.get(sid);
 		if (s) s.lastPromptSource = opts?.source ?? "user";
 	});
+	const retryLastPrompt = mock.fn(async (_sid: string, _opts?: any) => {});
+	const deliverLiveSteer = mock.fn(async (_sid: string, _msg: string, _opts?: any) => {});
 	sm.enqueuePrompt = enqueuePrompt;
+	sm.retryLastPrompt = retryLastPrompt;
+	sm.deliverLiveSteer = deliverLiveSteer;
 
 	const eventCallbacks: Array<(event: any) => void> = [];
 	const origCreateSession = sm.createSession.bind(sm);
@@ -256,12 +260,63 @@ async function setupTeamWithCapturedEvents(opts: { addIdleWorker?: boolean } = {
 		for (const cb of eventCallbacks) cb({ type });
 	}
 
-	return { team, sm, tlSession, enqueuePrompt, fire };
+	return { team, sm, tlSession, enqueuePrompt, retryLastPrompt, deliverLiveSteer, fire };
 }
 
 // ---------------------------------------------------------------------------
 // Bug repro scenarios
 // ---------------------------------------------------------------------------
+
+describe("TeamManager — errored idle team lead auto-retry (regression)", () => {
+	it("retries an errored idle team lead instead of enqueueing no-workers [AUTO-NUDGE] cards", async (t) => {
+		t.mock.timers.enable({ apis: ["setInterval", "setTimeout"] });
+
+		try {
+			const { tlSession, enqueuePrompt, retryLastPrompt, deliverLiveSteer, fire } = await setupTeamWithCapturedEvents();
+			tlSession.status = "idle";
+			tlSession.lastTurnErrored = true;
+			tlSession.lastTurnErrorMessage = "server_error: upstream provider returned retryable server error";
+			tlSession.lastPromptText = "continue coordinating the team";
+
+			fire("agent_end");
+
+			// Base no-workers delay is 5 minutes. The timer path should recover via
+			// retryLastPrompt({ auto: true }) rather than append a fresh auto-nudge.
+			t.mock.timers.tick(5 * 60 * 1000 + 1_000);
+			await Promise.resolve();
+			await Promise.resolve();
+
+			assert.equal(
+				retryLastPrompt.mock.callCount(),
+				1,
+				"errored idle team lead should be recovered through retryLastPrompt, not a new prompt card",
+			);
+			assert.deepEqual(
+				retryLastPrompt.mock.calls[0].arguments,
+				[tlSession.id, { auto: true }],
+				"team-manager retry should use the existing automatic retry path",
+			);
+			const autoNudgePrompts = enqueuePrompt.mock.calls.filter((call: any) =>
+				String(call.arguments[1] ?? "").includes("[AUTO-NUDGE]"),
+			);
+			assert.equal(
+				autoNudgePrompts.length,
+				0,
+				"errored idle recovery must not enqueue duplicate [AUTO-NUDGE] transcript cards",
+			);
+			const autoNudgeSteers = deliverLiveSteer.mock.calls.filter((call: any) =>
+				String(call.arguments[1] ?? "").includes("[AUTO-NUDGE]"),
+			);
+			assert.equal(
+				autoNudgeSteers.length,
+				0,
+				"errored idle recovery must not steer duplicate [AUTO-NUDGE] transcript cards",
+			);
+		} finally {
+			t.mock.timers.reset();
+		}
+	});
+});
 
 describe("TeamManager — idle-nudge exponential backoff (regression)", () => {
 	it("should back off the no-workers nudge exponentially across nudge-reply cycles", async (t) => {

--- a/tests/team-manager.test.ts
+++ b/tests/team-manager.test.ts
@@ -1036,52 +1036,43 @@ describe("TeamManager", () => {
 	});
 
 	// ---------------------------------------------------------------------------
-	// Tests: notifyTeamLead no longer suppressed when team lead errored
-	// (part of "Unstick sessions on new input" goal)
+	// Tests: notifyTeamLead retries errored idle team leads instead of nudging
 	// ---------------------------------------------------------------------------
 
-	describe("notifyTeamLead (errored-suppression removed)", () => {
-		it("delivers worker agent_end nudge even when team lead lastTurnErrored", async () => {
+	describe("notifyTeamLead errored idle recovery", () => {
+		it("retries worker agent_end nudge when team lead lastTurnErrored without enqueueing auto-nudge", async () => {
 			const goals = new Map<string, MockGoal>();
 			const goal = createMockGoal();
 			goals.set(goal.id, goal);
 			const sm = createMockSessionManager(goals);
 			const enqueuePrompt = mock.fn((_id: string, _msg: string, _opts?: any) => {});
 			const deliverLiveSteer = mock.fn(async (_id: string, _msg: string) => {});
+			const retryLastPrompt = mock.fn((_id: string, _opts?: any) => ({ status: "queued" }));
 			sm.enqueuePrompt = enqueuePrompt;
 			sm.deliverLiveSteer = deliverLiveSteer;
+			sm.retryLastPrompt = retryLastPrompt;
 
 			const team = createTeamManager(sm);
 			const teamLead = await team.startTeam("goal-1");
-			// Put the team lead into errored+idle state.
 			(teamLead as any).status = "idle";
 			(teamLead as any).lastTurnErrored = true;
 
-			// Register a worker in the team so notifyTeamLead has a target.
 			const entry = (team as any).teams.get("goal-1")!;
-			const workerSession = {
+			sm._sessions.set("worker-1", {
 				id: "worker-1",
 				status: "idle",
 				cwd: "/tmp/worker",
 				rpcClient: { prompt: mock.fn(async () => {}), onEvent: mock.fn(() => () => {}) },
 				clients: new Set(),
-			};
-			sm._sessions.set("worker-1", workerSession);
+			});
 			entry.agents.push({ sessionId: "worker-1", role: "coder", task: "work", createdAt: Date.now() });
 
-			// Directly invoke the private notifyTeamLead.
 			await (team as any).notifyTeamLead("goal-1", "worker-1", "coder", "coder-xyz");
 
-			// Team lead is idle — should use enqueuePrompt. Pre-fix, this was
-			// suppressed entirely and callCount would be 0.
-			assert.equal(
-				enqueuePrompt.mock.callCount(), 1,
-				"notifyTeamLead should deliver the nudge even when team lead lastTurnErrored",
-			);
-			const [sessionId, message, opts] = enqueuePrompt.mock.calls[0].arguments as any[];
-			assert.equal(sessionId, teamLead.id);
-			assert.ok(String(message).includes("coder-xyz"), "nudge message should reference the worker");
-			assert.equal(opts?.isSteered, true);
+			assert.equal(retryLastPrompt.mock.callCount(), 1);
+			assert.deepEqual(retryLastPrompt.mock.calls[0].arguments, [teamLead.id, { auto: true }]);
+			assert.equal(enqueuePrompt.mock.callCount(), 0, "errored idle team lead should not receive an auto-nudge prompt");
+			assert.equal(deliverLiveSteer.mock.callCount(), 0, "errored idle team lead should not receive a live auto-nudge steer");
 		});
 
 		it("formats worker completion nudges as compact markdown with task_list next step", async () => {

--- a/tests/team-manager.test.ts
+++ b/tests/team-manager.test.ts
@@ -1056,6 +1056,7 @@ describe("TeamManager", () => {
 			const teamLead = await team.startTeam("goal-1");
 			(teamLead as any).status = "idle";
 			(teamLead as any).lastTurnErrored = true;
+			(teamLead as any).lastTurnErrorMessage = "server_error: upstream provider returned retryable server error";
 
 			const entry = (team as any).teams.get("goal-1")!;
 			sm._sessions.set("worker-1", {


### PR DESCRIPTION
## Summary
- Route errored idle team auto-nudge targets through retryLastPrompt(auto) for retryable errors
- Suppress duplicate [AUTO-NUDGE] cards while retry is pending and leave manual Retry for unknown/non-retryable/exhausted errors
- Add regression coverage for no-workers and worker notification paths plus documentation

## Validation
- npx tsx --test tests/team-manager.test.ts tests/team-manager-idle-nudge-backoff.test.ts
- npm run check
- Workflow gates: reproducing-test, implementation, documentation passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)