### PR TITLE
Make Headquarters a normal reorderable project

### DIFF
--- a/src/app/headquarters.ts
+++ b/src/app/headquarters.ts
@@ -25,15 +25,6 @@ export function projectDisplayName(project?: ProjectIdentity | null): string {
 	return isHeadquartersProject(project) ? HEADQUARTERS_PROJECT_NAME : (project?.name || "Project");
 }
 
-export function sortProjectsWithHeadquartersFirst<T extends ProjectIdentity>(projects: readonly T[]): T[] {
-	return [...projects].sort((a, b) => {
-		const ah = isHeadquartersProject(a);
-		const bh = isHeadquartersProject(b);
-		if (ah === bh) return 0;
-		return ah ? -1 : 1;
-	});
-}
-
 export function projectIconComponent(project?: ProjectIdentity | string | null): typeof FolderOpen {
 	return isHeadquartersProject(project) ? TowerControl : FolderOpen;
 }

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -694,7 +694,6 @@ function renderMobileLanding() {
 														<span class="shrink-0 inline-flex items-center" data-testid=${projectIconTestId(project)} data-project-icon=${projectIconKind(project)} style="color:${color};">${icon(projectIconComponent(project), "sm")}</span>
 													<span class="flex-1 min-w-0 flex flex-col leading-tight">
 														<span class="truncate text-muted-foreground uppercase tracking-wider font-medium" style="color:${color};font-size: 1.1667em;">${project.name}</span>
-														${isHeadquartersProject(project) ? html`<span class="truncate text-xs text-muted-foreground normal-case tracking-normal">${HEADQUARTERS_HELPER_TEXT}</span>` : nothing}
 													</span>
 													<div class="flex items-center gap-2 shrink-0">
 														<button

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -77,7 +77,7 @@ let _suppressProjectHeaderClick = false;
 let _suppressProjectHeaderClickTimer: number | null = null;
 
 function currentProjectIds(): string[] {
-	return state.projects.filter((project) => !isHeadquartersProject(project)).map((project) => project.id);
+	return state.projects.map((project) => project.id);
 }
 
 function completeProjectOrderIds(projectIds: string[]): string[] {
@@ -100,17 +100,15 @@ function completeProjectOrderIds(projectIds: string[]): string[] {
 function orderProjectsByIds(projects: Project[], projectIds: string[]): Project[] {
 	const byId = new Map(projects.map((project) => [project.id, project]));
 	const seen = new Set<string>();
-	const headquarters = projects.filter((project) => isHeadquartersProject(project));
-	const ordered: Project[] = [...headquarters];
-	for (const project of headquarters) seen.add(project.id);
+	const ordered: Project[] = [];
 	for (const id of projectIds) {
 		const project = byId.get(id);
-		if (!project || seen.has(id) || isHeadquartersProject(project)) continue;
+		if (!project || seen.has(id)) continue;
 		seen.add(id);
 		ordered.push(project);
 	}
 	for (const project of projects) {
-		if (seen.has(project.id) || isHeadquartersProject(project)) continue;
+		if (seen.has(project.id)) continue;
 		seen.add(project.id);
 		ordered.push(project);
 	}
@@ -195,7 +193,6 @@ function beginProjectReorder(): void {
 
 export function startProjectReorder(e: PointerEvent, projectId: string): void {
 	if (e.pointerType === "mouse" && e.button !== 0) return;
-	if (isHeadquartersProject(projectId)) return;
 	e.preventDefault();
 	e.stopPropagation();
 	if (_projectReorderState) return;
@@ -266,9 +263,12 @@ function handleProjectReorderPointerUp(e: PointerEvent): void {
 	if (!reorder || reorder.keyboard || reorder.pointerId !== e.pointerId) return;
 	e.preventDefault();
 	e.stopPropagation();
-	const target = document.elementFromPoint(e.clientX, e.clientY) as HTMLElement | null;
-	const droppedInsideList = !!target?.closest("[data-project-reorder-list]");
-	void finishProjectReorder(!reorder.dragging || !droppedInsideList);
+	// Commit the previewed order on any release while dragging, even when the
+	// pointer is dropped outside the list (e.g. far above it). The preview is
+	// always clamped to a valid slot, so releasing anywhere saves that slot.
+	// Only a non-drag (a click that never crossed the drag threshold) is a no-op;
+	// cancellation is reserved for Escape / pointercancel.
+	void finishProjectReorder(!reorder.dragging);
 }
 
 function handleProjectReorderPointerCancel(e: PointerEvent): void {
@@ -383,7 +383,6 @@ export async function finishProjectReorder(cancel = false): Promise<void> {
 }
 
 export function renderProjectReorderHandle(project: Project) {
-	if (isHeadquartersProject(project)) return nothing;
 	const active = _projectReorderState?.activeId === project.id && _projectReorderState.dragging;
 	return html`
 		<button
@@ -1314,7 +1313,7 @@ function renderProjectHeader(project: Project, expanded: boolean) {
 		<div class="group project-header relative flex items-center gap-1 pr-1 py-0.5 rounded-md ${reordering ? "cursor-default" : "cursor-pointer"} ${reorderActive ? "project-reorder-active" : ""} ${navActive ? "bg-secondary text-foreground sidebar-session-active" : "hover:bg-secondary/30"} transition-colors"
 			data-testid="project-header"
 			data-project-id=${project.id}
-			data-project-reorder-id=${isHeadquarters ? nothing : project.id}
+			data-project-reorder-id=${project.id}
 			data-project-reordering=${reordering ? "true" : "false"}
 			data-project-reorder-active=${reorderActive ? "true" : "false"}
 			data-nav-id=${navId}

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -4,7 +4,7 @@ import type { InboxEntry } from "../server/agent/inbox-store.js";
 import type { PanelWorkspaceTab } from "./panel-workspace.js";
 import type { SidePanelWorkspace } from "./side-panel-workspace.js";
 import { isConfigPageRoute } from "./routing.js";
-import { sortProjectsWithHeadquartersFirst, type ProjectKind } from "./headquarters.js";
+import { type ProjectKind } from "./headquarters.js";
 import { safeSetItem, safeGetItem, safeGetJSON } from "./safe-storage.js";
 import {
 	clearSidebarTreePreference,
@@ -842,10 +842,11 @@ export function setRenderSuppressed(suppressed: boolean): void {
 /** Update the project list and ensure activeProjectId stays in sync.
  *  Defaults to the first project when no explicit selection exists. */
 export function setProjects(projects: Project[]): void {
-	const ordered = sortProjectsWithHeadquartersFirst(projects);
-	state.projects = ordered;
-	if (!state.activeProjectId || !ordered.some(p => p.id === state.activeProjectId)) {
-		state.activeProjectId = ordered[0]?.id ?? null;
+	// Respect the server's user-controlled order; Headquarters is a normal
+	// reorderable project and is no longer anchored first.
+	state.projects = projects;
+	if (!state.activeProjectId || !projects.some(p => p.id === state.activeProjectId)) {
+		state.activeProjectId = projects[0]?.id ?? null;
 	}
 }
 

--- a/src/server/agent/project-registry.ts
+++ b/src/server/agent/project-registry.ts
@@ -179,11 +179,12 @@ export class ProjectRegistry {
   }
 
   private participatesInVisibleOrder(project: RegisteredProject): boolean {
-    return this.isVisibleListProject(project) && !isHeadquartersProject(project);
+    // Headquarters is a first-class, user-reorderable project like any other
+    // visible project; only hidden/system anchors are excluded.
+    return this.isVisibleListProject(project);
   }
 
   private listSortCategory(project: RegisteredProject): number {
-    if (this.isVisibleListProject(project) && isHeadquartersProject(project)) return 0;
     if (this.participatesInVisibleOrder(project)) return 1;
     return 2;
   }
@@ -420,7 +421,17 @@ export class ProjectRegistry {
       .map(entry => entry.project);
   }
 
-  setVisibleOrder(projectIds: string[]): RegisteredProject[] {
+  /**
+   * Persist a user-controlled ordering of the visible projects.
+   *
+   * `options.excludeIds` lists participating projects that are NOT part of the
+   * caller's reorder scope (e.g. Headquarters when it is hidden from project
+   * lists via preference). Excluded projects are not expected in the payload
+   * and keep their current slot; the received ids fill the remaining slots in
+   * the given order. This keeps strict staleness detection for the ids the
+   * caller actually controls.
+   */
+  setVisibleOrder(projectIds: string[], options?: { excludeIds?: readonly string[] }): RegisteredProject[] {
     if (!Array.isArray(projectIds) || projectIds.some(id => typeof id !== "string")) {
       throw new ProjectOrderError("invalid_project_order", "projectIds must be an array of strings");
     }
@@ -433,14 +444,16 @@ export class ProjectRegistry {
       seen.add(id);
     }
 
-    const expectedProjectIds = this.list()
-      .filter(project => this.participatesInVisibleOrder(project))
+    const excluded = new Set(options?.excludeIds ?? []);
+    const participating = this.list().filter(project => this.participatesInVisibleOrder(project));
+    const expectedProjectIds = participating
+      .filter(project => !excluded.has(project.id))
       .map(project => project.id);
     const receivedProjectIds = [...projectIds];
 
     for (const id of receivedProjectIds) {
       const project = this.projects.get(id);
-      if (!project || !this.participatesInVisibleOrder(project)) {
+      if (!project || !this.participatesInVisibleOrder(project) || excluded.has(id)) {
         throw new ProjectOrderError("invalid_project_order", `Invalid project id in order: ${id}`);
       }
     }
@@ -453,7 +466,13 @@ export class ProjectRegistry {
       });
     }
 
-    receivedProjectIds.forEach((id, position) => {
+    // Rebuild the full participating order: excluded projects keep their slot,
+    // received ids fill the remaining slots in their new order.
+    const receivedQueue = [...receivedProjectIds];
+    const finalOrder = participating.map(project =>
+      excluded.has(project.id) ? project.id : receivedQueue.shift()!,
+    );
+    finalOrder.forEach((id, position) => {
       const project = this.projects.get(id)!;
       project.position = position;
     });
@@ -778,6 +797,10 @@ export class ProjectRegistry {
         kind: "headquarters",
         colorLight: DEFAULT_PROJECT_COLOR_LIGHT,
         colorDark: DEFAULT_PROJECT_COLOR_DARK,
+        // Headquarters is a normal, user-reorderable project: a freshly
+        // registered one appends to the end of the visible order just like any
+        // other new project. Its position persists and can be changed by drag.
+        position: this.nextVisiblePosition(),
       };
     }
 
@@ -789,7 +812,8 @@ export class ProjectRegistry {
     // parentProjectId cleanup below.
     delete project.hidden;
     delete project.provisional;
-    delete project.position;
+    // Headquarters participates in user-controlled ordering; preserve any saved
+    // position and let normalizeVisiblePositions() assign one when missing.
     delete project.parentProjectId;
     project.colorLight = project.colorLight || DEFAULT_PROJECT_COLOR_LIGHT;
     project.colorDark = project.colorDark || DEFAULT_PROJECT_COLOR_DARK;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4886,7 +4886,12 @@ async function handleApiRoute(
 	if (url.pathname === "/api/projects/order" && req.method === "PUT") {
 		const body = await readBody(req);
 		try {
-			projectRegistry.setVisibleOrder(body?.projectIds);
+			// When Headquarters is hidden from project lists it is not part of the
+			// client-visible reorder set, so the client cannot include it in the
+			// payload. Exclude it from reconciliation so its position is preserved
+			// rather than triggering a stale-order rejection.
+			const excludeIds = shouldShowHeadquartersInProjectLists() ? [] : [HEADQUARTERS_PROJECT_ID];
+			projectRegistry.setVisibleOrder(body?.projectIds, { excludeIds });
 			const projects = listProjectsForApi();
 			broadcastToAll({ type: "projects_changed", projects });
 			json({ projects });

--- a/src/ui/components/ProjectPickerPopover.ts
+++ b/src/ui/components/ProjectPickerPopover.ts
@@ -12,7 +12,7 @@
 import { icon } from "@mariozechner/mini-lit";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import { HEADQUARTERS_HELPER_TEXT, isHeadquartersProject, projectIconComponent, projectIconKind, projectIconTestId, projectSearchText, sortProjectsWithHeadquartersFirst } from "../../app/headquarters.js";
+import { HEADQUARTERS_HELPER_TEXT, isHeadquartersProject, projectIconComponent, projectIconKind, projectIconTestId, projectSearchText } from "../../app/headquarters.js";
 
 /**
  * Project info exposed to the picker. Callers pass the subset of their
@@ -169,7 +169,9 @@ export class ProjectPickerPopover extends LitElement {
 	}
 
 	private _filteredProjects(): ProjectPickerItem[] {
-		const projects = sortProjectsWithHeadquartersFirst(this.projects);
+		// Preserve the caller-supplied order (the server's user-controlled project
+		// order); Headquarters is a normal reorderable project, not anchored first.
+		const projects = [...this.projects];
 		const q = this._query.trim().toLowerCase();
 		if (!q) return projects;
 		return projects.filter(p => projectSearchText(p).toLowerCase().includes(q));

--- a/tests/e2e/ui/headquarters.spec.ts
+++ b/tests/e2e/ui/headquarters.spec.ts
@@ -312,7 +312,11 @@ test.describe("Headquarters browser UX", () => {
 		const headerIds = await page.locator('[data-testid="project-header"][data-project-id]').evaluateAll((els) =>
 			els.map((el) => (el as HTMLElement).dataset.projectId).filter(Boolean),
 		);
-		expect(headerIds.slice(0, 2), "Headquarters should be first and same-root normal project second").toEqual([HEADQUARTERS_PROJECT_ID, sameRootProject.id]);
+		// Headquarters is a normal reorderable project (no longer anchored first),
+		// so a project that was registered before it — here the same-root startup
+		// project seeded ahead of Headquarters — sorts ahead of it by default.
+		expect(new Set(headerIds.slice(0, 2)), "both Headquarters and the same-root project appear at the top").toEqual(new Set([HEADQUARTERS_PROJECT_ID, sameRootProject.id]));
+		expect(headerIds.indexOf(sameRootProject.id), "same-root project registered before Headquarters sorts ahead of it").toBeLessThan(headerIds.indexOf(HEADQUARTERS_PROJECT_ID));
 		await expect(headquartersIcon(hqHeader), "Headquarters row should use TowerControl").toBeVisible({ timeout: 10_000 });
 		await expect(normalProjectIcon(sameRootHeader), "same-root normal project should keep folder identity").toBeVisible({ timeout: 10_000 });
 		await expect(headquartersIcon(sameRootHeader), "same-root normal project must not use TowerControl").toHaveCount(0);
@@ -323,10 +327,12 @@ test.describe("Headquarters browser UX", () => {
 		const picker = page.locator('[data-testid="splash-project-picker"]').first();
 		await expect(picker).toBeVisible({ timeout: 10_000 });
 		const rows = picker.locator('[data-testid="splash-project-picker-item"]');
-		await expect(rows.first()).toContainText(HEADQUARTERS_NAME);
-		await expect(headquartersIcon(rows.first()), "picker should use TowerControl for Headquarters").toBeVisible({ timeout: 10_000 });
-		await expect(rows.nth(1)).toContainText(sameRootProject.name);
-		await expect(normalProjectIcon(rows.nth(1)), "picker should use folder identity for same-root normal project").toBeVisible({ timeout: 10_000 });
+		const hqRow = rows.filter({ hasText: HEADQUARTERS_NAME }).first();
+		const sameRootRow = rows.filter({ hasText: sameRootProject.name }).first();
+		await expect(hqRow, "picker should list Headquarters").toBeVisible({ timeout: 10_000 });
+		await expect(headquartersIcon(hqRow), "picker should use TowerControl for Headquarters").toBeVisible({ timeout: 10_000 });
+		await expect(sameRootRow, "picker should list the same-root normal project").toBeVisible({ timeout: 10_000 });
+		await expect(normalProjectIcon(sameRootRow), "picker should use folder identity for same-root normal project").toBeVisible({ timeout: 10_000 });
 		await page.keyboard.press("Escape");
 
 		const hqSession = await createSessionViaSplashPicker(page, HEADQUARTERS_NAME);

--- a/tests/e2e/ui/project-drag-reorder.spec.ts
+++ b/tests/e2e/ui/project-drag-reorder.spec.ts
@@ -342,16 +342,70 @@ test.describe("Project drag reorder (browser E2E)", () => {
 		await setHeadquartersVisible(true).catch(() => {});
 	});
 
-	test("Headquarters is anchored first and has no reorder handle", async ({ page }) => {
+	test("Headquarters is first by default but is a reorderable project like any other", async ({ page }) => {
 		await setHeadquartersVisible(true);
 		await openDesktop(page);
 		const headerIds = await page.locator('[data-testid="project-header"][data-project-id]').evaluateAll((els) =>
 			els.map((el) => (el as HTMLElement).dataset.projectId).filter(Boolean),
 		);
-		expect(headerIds[0], "Headquarters should be anchored first when visible").toBe(HEADQUARTERS_PROJECT_ID);
+		expect(headerIds[0], "Headquarters should be first by default when visible").toBe(HEADQUARTERS_PROJECT_ID);
 		await expect(projectHeader(page, HEADQUARTERS_PROJECT_ID)).toBeVisible({ timeout: 20_000 });
-		await expect(projectReorderRow(page, HEADQUARTERS_PROJECT_ID), "Headquarters should be excluded from reorder rows").toHaveCount(0);
-		await expect(projectHandle(page, HEADQUARTERS_PROJECT_ID), "Headquarters should not render a reorder handle").toHaveCount(0);
+		await expect(projectReorderRow(page, HEADQUARTERS_PROJECT_ID), "Headquarters participates in reorder rows").toHaveCount(1);
+		await expect(projectHandle(page, HEADQUARTERS_PROJECT_ID), "Headquarters renders a reorder handle like any other project").toHaveCount(1);
+	});
+
+	test("Headquarters can be dragged to a new position and it persists across reload", async ({ page }) => {
+		test.setTimeout(120_000);
+		await setHeadquartersVisible(true);
+		const alpha = await createProjectFixture("hq-drag-alpha");
+		const beta = await createProjectFixture("hq-drag-beta");
+		const hq = { id: HEADQUARTERS_PROJECT_ID, name: "Headquarters", rootPath: "", sessionId: "", sessionTitle: "" } as ProjectFixture;
+
+		await openDesktop(page);
+		await waitForProjects(page, [alpha, beta]);
+		// Headquarters is first by default, then user-ordered normal projects.
+		await expectRenderedOrder(page, [hq, alpha, beta]);
+
+		// Drag Headquarters to the end — it is a first-class reorderable project.
+		await startProjectDrag(page, hq);
+		await dropProjectOn(page, beta, "after");
+
+		await expectRenderedOrder(page, [alpha, beta, hq]);
+		await expectPersistedOrder([alpha, beta, hq]);
+		await expectNoProjectOrderFailureDialog(page);
+
+		await page.reload();
+		await waitForProjects(page, [alpha, beta]);
+		await expectRenderedOrder(page, [alpha, beta, hq]);
+	});
+
+	test("releasing the drag outside the list commits the previewed order", async ({ page }) => {
+		test.setTimeout(120_000);
+		await setHeadquartersVisible(false);
+		const alpha = await createProjectFixture("outside-alpha");
+		const beta = await createProjectFixture("outside-beta");
+		const gamma = await createProjectFixture("outside-gamma");
+
+		await openDesktop(page);
+		await waitForProjects(page, [alpha, beta, gamma]);
+		await expectRenderedOrder(page, [alpha, beta, gamma]);
+
+		// Pick up gamma and drag it far above the list, then release completely
+		// outside the reorder list. The preview clamps gamma to the top slot.
+		await startProjectDrag(page, gamma);
+		await page.mouse.move(200, 4, { steps: 12 });
+		await expectRenderedOrder(page, [gamma, alpha, beta]);
+		await page.mouse.up();
+		await expect(reorderMode(page), "release should exit reorder mode").toHaveCount(0, { timeout: 10_000 });
+
+		// The previewed order must persist even though the release was outside the list.
+		await expectRenderedOrder(page, [gamma, alpha, beta]);
+		await expectPersistedOrder([gamma, alpha, beta]);
+		await expectNoProjectOrderFailureDialog(page);
+
+		await page.reload();
+		await waitForProjects(page, [alpha, beta, gamma]);
+		await expectRenderedOrder(page, [gamma, alpha, beta]);
 	});
 
 	test("desktop affordances, pointer reorder persistence, live sync, cancel, and collapsed sidebar order", async ({ page }) => {
@@ -434,7 +488,9 @@ test.describe("Project drag reorder (browser E2E)", () => {
 				timeout: 10_000,
 			}).toBeGreaterThan(0);
 			const savedOrderPayload = savedOrderPayloads[savedOrderPayloads.length - 1];
-			expect(savedOrderPayload).not.toContain(HEADQUARTERS_PROJECT_ID);
+			// Headquarters is now a first-class reorderable project, so it participates
+			// in the persisted order payload (first here, since only normals moved).
+			expect(savedOrderPayload[0], "Headquarters should be included in the reorder payload").toBe(HEADQUARTERS_PROJECT_ID);
 			expect(savedOrderPayload.filter(id => [gamma.id, alpha.id, beta.id].includes(id))).toEqual([
 				gamma.id,
 				alpha.id,

--- a/tests/headquarters-config-alias.test.ts
+++ b/tests/headquarters-config-alias.test.ts
@@ -179,7 +179,7 @@ describe("Headquarters storage and config aliasing", () => {
 });
 
 describe("ProjectRegistry Headquarters ordering", () => {
-	it("ensureHeadquartersProject creates stable Headquarters and excludes it from user reorder", async () => {
+	it("ensureHeadquartersProject creates stable Headquarters as a reorderable project", async () => {
 		const { ProjectRegistry, SYSTEM_PROJECT_ID } = await import("../src/server/agent/project-registry.ts");
 		const stateDir = mkTemp("registry-state");
 		const configDir = mkTemp("registry-config");
@@ -200,25 +200,38 @@ describe("ProjectRegistry Headquarters ordering", () => {
 		assert.equal(path.resolve(hq.rootPath), path.resolve(hqRoot));
 		assert.notEqual(hq.hidden, true);
 		assert.notEqual(hq.provisional, true);
-		assert.equal(hq.position, undefined, "Headquarters is anchored, not user-positioned");
+		assert.equal(hq.position, 0, "Headquarters participates in user-controlled ordering (anchored first only by default)");
 
 		const sameRootNormal = registry.register("Server Root Normal", serverRoot, { acceptCanonical: true });
 		const b = registry.register("B", mkTemp("registry-b"), { acceptCanonical: true });
-		const reordered = registry.setVisibleOrder([b.id, sameRootNormal.id]);
-		assert.deepEqual(reordered.map(project => project.id), [HEADQUARTERS_PROJECT_ID, b.id, sameRootNormal.id]);
+		// Headquarters is now a first-class reorderable project and MUST be included
+		// in the reorder payload alongside the normal projects.
+		const reordered = registry.setVisibleOrder([b.id, HEADQUARTERS_PROJECT_ID, sameRootNormal.id]);
+		assert.deepEqual(reordered.map(project => project.id), [b.id, HEADQUARTERS_PROJECT_ID, sameRootNormal.id]);
 		assert.deepEqual(
 			registry.list().filter(project => !project.hidden && project.id !== SYSTEM_PROJECT_ID).map(project => project.id),
-			[HEADQUARTERS_PROJECT_ID, b.id, sameRootNormal.id],
+			[b.id, HEADQUARTERS_PROJECT_ID, sameRootNormal.id],
 		);
 		assert.throws(
-			() => registry.setVisibleOrder([HEADQUARTERS_PROJECT_ID, b.id, sameRootNormal.id]),
-			/error|invalid_project_order/i,
-			"Headquarters must not be accepted in client-supplied reorder payloads",
+			() => registry.setVisibleOrder([b.id, sameRootNormal.id]),
+			/stale/i,
+			"reorder payloads must include Headquarters now that it participates in ordering",
 		);
 		assert.throws(
 			() => registry.register("HQ Dir", hqRoot, { acceptCanonical: true }),
 			/Headquarters|immutable/i,
 			"normal projects cannot be registered at the physical Headquarters directory",
+		);
+
+		// When Headquarters is hidden from project lists it is excluded from the
+		// reorder scope: the client omits it, so setVisibleOrder must accept a
+		// payload without it, preserve its slot, and reorder only the normals.
+		registry.setVisibleOrder([HEADQUARTERS_PROJECT_ID, sameRootNormal.id, b.id]);
+		const hiddenReordered = registry.setVisibleOrder([b.id, sameRootNormal.id], { excludeIds: [HEADQUARTERS_PROJECT_ID] });
+		assert.deepEqual(
+			hiddenReordered.map(project => project.id),
+			[HEADQUARTERS_PROJECT_ID, b.id, sameRootNormal.id],
+			"Headquarters keeps its slot while the excluded reorder repositions the normals",
 		);
 	});
 });


### PR DESCRIPTION
## Summary

Makes the built-in **Headquarters** project behave like every other project in the sidebar. Previously it was special-cased: anchored first, not reorderable, and labelled with a "Server workspace" subtitle.

## Changes

- **Reorderable + persisted (server).** Headquarters now participates in the visible project order, is assigned a persisted `position`, and is accepted in reorder payloads. `setVisibleOrder` gains an `excludeIds` option so a *preference-hidden* Headquarters (which the client omits from the payload) keeps its slot instead of triggering a stale-order rejection.
- **Reorderable (client).** Removed the "Headquarters first / not reorderable" special-casing in the sidebar, `state.setProjects`, and the project pickers. Headquarters now renders a drag handle and all surfaces respect the saved order.
- **Mobile sidebar label.** Dropped the "Server workspace" subtitle under Headquarters on the mobile sidebar (kept in the splash picker, project picker, and Settings config scope).
- **Release-to-commit.** Releasing a project drag now commits the currently-previewed order even when the pointer is released outside the list (the preview is always clamped to a valid slot). Cancellation is reserved for Escape / pointer-cancel.

Kept the distinctive TowerControl icon so Headquarters is still glanceable.

## Behaviour note

Since Headquarters is no longer anchored, a project registered *before* it (e.g. a same-root startup project) now sorts ahead of it by default. On fresh installs Headquarters is created first, so it still appears first. Position is user-controlled and persists.

## Testing

- `npm run check` — pass
- `npm run test:unit` — pass
- Updated the ordering unit test (`headquarters-config-alias.test.ts`) incl. hidden-Headquarters reorder reconciliation
- Updated/added E2E: `project-drag-reorder.spec.ts` (drag Headquarters; release-outside-commits), `headquarters.spec.ts`, plus verified `splash-multi-project`, `remove-first-project`, `instant-loader`, `splash-no-projects` — all pass

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)