### PR TITLE
Fix Vite dev server paths after Headquarters split

### DIFF
--- a/.bobbit/.gitignore
+++ b/.bobbit/.gitignore
@@ -1,2 +1,3 @@
 state/
 agent/
+headquarters/

--- a/tests/vite-config-paths.test.ts
+++ b/tests/vite-config-paths.test.ts
@@ -1,0 +1,61 @@
+/**
+ * vite.config.ts path-resolution mirror — pinning test.
+ *
+ * `vite.config.ts` must resolve the Headquarters state dir (for `gateway-url`)
+ * and the OS-level server secrets dir (for TLS material) the SAME way the server
+ * does in `src/server/bobbit-dir.ts`. The two are intentionally duplicated:
+ * vite.config must stay lightweight and cannot import the server module graph
+ * (agent-dir-config, etc.), so we cannot share the code. This test is the guard
+ * that keeps the copy honest — if the resolution logic changes in one file, the
+ * shared "signatures" below must change in both or this test fails.
+ *
+ * See the sync note at the top of vite.config.ts::headquartersDir().
+ */
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const viteConfig = fs.readFileSync(path.join(projectRoot, "vite.config.ts"), "utf-8");
+const bobbitDir = fs.readFileSync(path.join(projectRoot, "src", "server", "bobbit-dir.ts"), "utf-8");
+
+// Resolution signatures that MUST appear (identically) in both files. These are
+// the load-bearing expressions of the Headquarters + secrets dir resolution.
+const SHARED_SIGNATURES: Array<{ label: string; needle: string }> = [
+	// Headquarters dir resolution
+	{ label: "BOBBIT_DIR env override", needle: "process.env.BOBBIT_DIR" },
+	{ label: "BOBBIT_PI_DIR legacy override", needle: "process.env.BOBBIT_PI_DIR" },
+	{ label: "headquarters dir segment", needle: '".bobbit", "headquarters"' },
+	// Secrets dir resolution
+	{ label: "BOBBIT_SECRETS_DIR override", needle: "process.env.BOBBIT_SECRETS_DIR" },
+	{ label: "secrets dir hash", needle: 'createHash("sha256").update(headquartersDir()).digest("hex").slice(0, 16)' },
+	{ label: "secrets path segment", needle: '"bobbit", "secrets", hash' },
+	{ label: "win32 APPDATA base", needle: 'process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming")' },
+	{ label: "darwin Application Support base", needle: 'path.join(os.homedir(), "Library", "Application Support", "bobbit", "secrets", hash)' },
+	{ label: "linux XDG_STATE_HOME base", needle: 'process.env.XDG_STATE_HOME || path.join(os.homedir(), ".local", "state")' },
+];
+
+test("vite.config.ts mirrors bobbit-dir.ts Headquarters + secrets resolution", () => {
+	for (const { label, needle } of SHARED_SIGNATURES) {
+		assert.ok(
+			bobbitDir.includes(needle),
+			`bobbit-dir.ts must contain the ${label} signature: ${needle}`,
+		);
+		assert.ok(
+			viteConfig.includes(needle),
+			`vite.config.ts drifted from bobbit-dir.ts — missing the ${label} signature: ${needle}. `
+				+ "Update vite.config.ts to match src/server/bobbit-dir.ts.",
+		);
+	}
+});
+
+test("vite.config.ts reads gateway-url from the Headquarters state dir", () => {
+	// The dev proxy must read <headquartersDir>/state/gateway-url, not the legacy
+	// <cwd>/.bobbit/state/gateway-url that predates the Headquarters split.
+	assert.ok(
+		viteConfig.includes("headquartersStateDir()") && viteConfig.includes('"gateway-url"'),
+		"vite.config.ts must resolve gateway-url via headquartersStateDir()",
+	);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,39 @@
 import tailwindcss from "@tailwindcss/vite";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import http from "node:http";
 import https from "node:https";
 import os from "node:os";
 import path from "node:path";
 import { defineConfig, type Plugin } from "vite";
+
+/**
+ * Mirror of the server's bobbit-dir.ts resolution so Vite finds the same
+ * Headquarters state dir and OS-level secrets dir. Kept in sync manually;
+ * pinned by tests/vite-config-paths.test.ts.
+ */
+function headquartersDir(): string {
+	if (process.env.BOBBIT_DIR) return path.resolve(process.env.BOBBIT_DIR);
+	if (process.env.BOBBIT_PI_DIR) return path.resolve(process.env.BOBBIT_PI_DIR);
+	return path.join(process.cwd(), ".bobbit", "headquarters");
+}
+function headquartersStateDir(): string {
+	return path.join(headquartersDir(), "state");
+}
+/** OS-level server secrets dir (TLS material lives under <secretsDir>/tls). */
+function serverSecretsDir(): string {
+	if (process.env.BOBBIT_SECRETS_DIR) return path.resolve(process.env.BOBBIT_SECRETS_DIR);
+	const hash = crypto.createHash("sha256").update(headquartersDir()).digest("hex").slice(0, 16);
+	if (process.platform === "win32") {
+		const base = process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming");
+		return path.join(base, "bobbit", "secrets", hash);
+	}
+	if (process.platform === "darwin") {
+		return path.join(os.homedir(), "Library", "Application Support", "bobbit", "secrets", hash);
+	}
+	const base = process.env.XDG_STATE_HOME || path.join(os.homedir(), ".local", "state");
+	return path.join(base, "bobbit", "secrets", hash);
+}
 
 /** Find the NordLynx (NordVPN mesh) interface IPv4 address. */
 function findNordLynxIp(): string | null {
@@ -39,15 +68,22 @@ const proto = host === "localhost" ? "http" : "https";
  */
 function readGatewayUrl(): string {
 	if (process.env.GATEWAY_URL) return process.env.GATEWAY_URL;
-	const gwFile = path.join(process.cwd(), ".bobbit", "state", "gateway-url");
+	const gwFile = path.join(headquartersStateDir(), "gateway-url");
 	try {
 		if (fs.existsSync(gwFile)) return fs.readFileSync(gwFile, "utf-8").trim();
 	} catch {}
 	return `${proto}://${host}:3001`;  // fallback before first startup
 }
 
-// Load TLS cert for vite's own HTTPS server + proxy trust
-const tlsDir = path.join(process.cwd(), ".bobbit", "state", "tls");
+// Load TLS cert for vite's own HTTPS server + proxy trust. The HQ split
+// relocated TLS material from <project>/.bobbit/state/tls to the OS-level
+// serverSecretsDir(); fall back to the legacy path for pre-split installs.
+function resolveTlsDir(): string {
+	const secretsTls = path.join(serverSecretsDir(), "tls");
+	if (fs.existsSync(path.join(secretsTls, "cert.pem"))) return secretsTls;
+	return path.join(process.cwd(), ".bobbit", "state", "tls");
+}
+const tlsDir = resolveTlsDir();
 const certPath = path.join(tlsDir, "cert.pem");
 const keyPath = path.join(tlsDir, "key.pem");
 const tlsAvailable = proto === "https" && fs.existsSync(certPath) && fs.existsSync(keyPath);


### PR DESCRIPTION
## Summary

The Headquarters split moved two files the Vite dev server depends on:

- `gateway-url` → the **Headquarters state dir** (`<hq>/state/gateway-url`)
- TLS cert/key → an **OS-level secrets dir** (away from any project-reachable path)

But `vite.config.ts` still resolved the legacy `<cwd>/.bobbit/state/...` paths, so the dev proxy couldn't find the gateway address or the HTTPS certificate.

## Changes

- **`vite.config.ts`** — mirror `src/server/bobbit-dir.ts`'s `headquartersDir()` / `serverSecretsDir()` resolution. Read `gateway-url` from the Headquarters state dir; load TLS from the secrets dir, falling back to the legacy `tls/` path for pre-split installs.
- **`tests/vite-config-paths.test.ts`** — new pinning test. The resolution logic is intentionally duplicated (vite.config can't import the server module graph), so this guards the two copies against drift: if the recipe changes in one file, the shared signatures must change in both or the test fails.
- **`.bobbit/.gitignore`** — ignore the local `headquarters/` runtime dir.

## Testing

- `tests/vite-config-paths.test.ts` — passes (2/2)
- `tests/test-phase-invariant.test.ts` — passes
- `tsc -p tsconfig.server.json --noEmit` — clean

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)