### PR TITLE
Allow ext endpoints in sandbox guard for PR walkthrough reviewer sessions

### DIFF
--- a/src/server/auth/sandbox-guard.ts
+++ b/src/server/auth/sandbox-guard.ts
@@ -81,9 +81,16 @@ export function isSandboxAllowed(
 	// session's project scope; this guard only lets the request reach that scoped
 	// handler, not the host-side /api/internal/mcp-call executor above.
 	if (pathname === "/api/internal/mcp-describe" && m === "POST") return true;
-	// PR walkthrough YAML submission is allowed through the sandbox guard; the
-	// route manager performs the scoped child-session/job ownership check.
+	// PR walkthrough YAML submission — legacy direct path kept for backward compat;
+	// tools have migrated to the ext/route/publish dispatch pattern below.
 	if (pathname === "/api/internal/pr-walkthrough/submit-yaml" && m === "POST") return true;
+	// Ext route endpoints — handlers enforce session+tool ownership via
+	// authorizeScopedRequest / sandboxScope session checks; the ext framework
+	// is the correct auth boundary for these routes.
+	if (pathname === "/api/ext/surface-token" && m === "POST") return true;
+	if (/^\/api\/ext\/route\/[^/]+$/.test(pathname) && m === "POST") return true;
+	// PR walkthrough bundle read — handler performs its own sandbox session-scope check.
+	if ((pathname === "/api/internal/pr-walkthrough/bundle" || pathname === "/api/internal/pr-walkthrough/analysis-bundle") && m === "POST") return true;
 	// /api/internal/user-question/submit is called from UI widgets (not the
 	// sandboxed agent) — the legacy POST /api/internal/user-question used by the
 	// blocking tool extension has been removed.

--- a/tests/sandbox-guard.test.ts
+++ b/tests/sandbox-guard.test.ts
@@ -85,6 +85,30 @@ describe("sandbox route guard", () => {
 		assert.equal(isSandboxAllowed("/api/image-generation/generate", "POST", scope()), true);
 	});
 
+	describe("ext endpoints for PR walkthrough reviewer sessions", () => {
+		it("allows POST /api/ext/surface-token (needed for surface-token mint step)", () => {
+			assert.equal(isSandboxAllowed("/api/ext/surface-token", "POST", scope()), true);
+			assert.equal(isSandboxAllowed("/api/ext/surface-token", "GET", scope()), false);
+			assert.equal(isSandboxAllowed("/api/ext/surface-token", "DELETE", scope()), false);
+		});
+
+		it("allows POST /api/ext/route/:name (needed for all ext route dispatches)", () => {
+			assert.equal(isSandboxAllowed("/api/ext/route/submit-chunk", "POST", scope()), true);
+			assert.equal(isSandboxAllowed("/api/ext/route/finalize", "POST", scope()), true);
+			assert.equal(isSandboxAllowed("/api/ext/route/submit-yaml", "POST", scope()), true);
+			assert.equal(isSandboxAllowed("/api/ext/route/submission-status", "GET", scope()), false);
+			// nested paths must not match
+			assert.equal(isSandboxAllowed("/api/ext/route/submit-chunk/extra", "POST", scope()), false);
+		});
+
+		it("allows POST /api/internal/pr-walkthrough/bundle and /analysis-bundle (needed for read_pr_walkthrough_bundle)", () => {
+			assert.equal(isSandboxAllowed("/api/internal/pr-walkthrough/bundle", "POST", scope()), true);
+			assert.equal(isSandboxAllowed("/api/internal/pr-walkthrough/analysis-bundle", "POST", scope()), true);
+			assert.equal(isSandboxAllowed("/api/internal/pr-walkthrough/bundle", "GET", scope()), false);
+			assert.equal(isSandboxAllowed("/api/internal/pr-walkthrough/analysis-bundle", "GET", scope()), false);
+		});
+	});
+
 	describe("google-code-assist runtime token endpoint", () => {
 		it("allows a sandboxed session to GET its OWN token endpoint", () => {
 			assert.equal(


### PR DESCRIPTION
## Problem

PR walkthrough reviewer sessions get a scoped gateway token via `mintScopedGatewayToken`. When their pi-extension tools call back to the gateway, they use `BOBBIT_TOKEN` from env (the scoped token), which hits the sandbox guard and gets a 403.

The sandbox guard (`isSandboxAllowed`) was missing:
- `POST /api/ext/surface-token` — needed for the surface-token mint step
- `POST /api/ext/route/:name` — needed for all ext route dispatches
- `POST /api/internal/pr-walkthrough/bundle` (+ `/analysis-bundle`) — needed for `read_pr_walkthrough_bundle`

## Fix

Added three allow-rules to `isSandboxAllowed` in `src/server/auth/sandbox-guard.ts`:

```ts
if (pathname === "/api/ext/surface-token" && m === "POST") return true;
if (/^\/api\/ext\/route\/[^/]+$/.test(pathname) && m === "POST") return true;
if ((pathname === "/api/internal/pr-walkthrough/bundle" || pathname === "/api/internal/pr-walkthrough/analysis-bundle") && m === "POST") return true;
```

The existing `/api/internal/pr-walkthrough/submit-yaml` entry is kept for backward compat with a clarifying comment.

## Tests

Extended `tests/sandbox-guard.test.ts` with a new `describe` block covering all three new paths (allowed methods and denied methods/nested paths).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)