### PR TITLE
fix: handle Windows EPERM on atomic rename in flex-store

### DIFF
--- a/src/server/search/flex-store.ts
+++ b/src/server/search/flex-store.ts
@@ -20,6 +20,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import * as os from "node:os";
 import { Document as FlexDocument } from "flexsearch";
 import { profileAsync } from "../agent/profiling.js";
 import { highlight } from "./snippet.js";
@@ -30,6 +31,29 @@ import {
 	type MetaRowPersisted,
 } from "./meta.js";
 import type { Indexable, SearchQuery, SearchResult, SearchResults } from "./types.js";
+
+/**
+ * Atomic rename that works on Windows.
+ *
+ * POSIX `rename(2)` is atomic and silently replaces the destination.
+ * On Windows, `fs.rename` over an existing file raises EPERM (-4048).
+ * The workaround is to unlink the destination first, then rename.
+ * The window between unlink and rename is tiny; we accept the theoretical
+ * non-atomicity because the alternative is a persistent error loop.
+ */
+async function atomicRename(src: string, dest: string): Promise<void> {
+	try {
+		await fs.promises.rename(src, dest);
+	} catch (err) {
+		const e = err as NodeJS.ErrnoException;
+		if ((e.code === "EPERM" || e.code === "EEXIST") && os.platform() === "win32") {
+			try { await fs.promises.unlink(dest); } catch { /* dest may not exist */ }
+			await fs.promises.rename(src, dest);
+		} else {
+			throw err;
+		}
+	}
+}
 
 // Minimal typing for the subset of FlexSearch we touch. FlexSearch's
 // shipped types describe both sync and Promise return shapes; we use
@@ -441,7 +465,7 @@ export class FlexSearchStore {
 		try {
 			await fs.promises.mkdir(this.dataDir, { recursive: true });
 			await fs.promises.writeFile(tmp, JSON.stringify(writeMetaRow(meta)), "utf-8");
-			await fs.promises.rename(tmp, final);
+			await atomicRename(tmp, final);
 		} catch (err) {
 			if (this._isBenignTeardownError(err)) return;
 			throw err;
@@ -550,7 +574,7 @@ export class FlexSearchStore {
 		const docsTmp = `${docsFinal}.tmp`;
 		const serialisedDocs = JSON.stringify(Array.from(this._docs.values()));
 		await fs.promises.writeFile(docsTmp, serialisedDocs, "utf-8");
-		await fs.promises.rename(docsTmp, docsFinal);
+		await atomicRename(docsTmp, docsFinal);
 		written.push(`${docsKey}.json`);
 
 		await this._idx.export(async (key: string, data: unknown) => {
@@ -572,7 +596,7 @@ export class FlexSearchStore {
 			const tmp = `${final}.tmp`;
 			const payload = typeof payloadData === "string" ? payloadData : JSON.stringify(payloadData);
 			await fs.promises.writeFile(tmp, payload, "utf-8");
-			await fs.promises.rename(tmp, final);
+			await atomicRename(tmp, final);
 			written.push(`${safeKey}.json`);
 		});
 


### PR DESCRIPTION
## Problem

On Windows, `fs.rename` over an existing file raises `EPERM` (errno -4048). The flex search store uses an atomic write-then-rename pattern for persistence, but the destination file already exists on subsequent flushes, causing an endless error loop in the harness log:

```
[search] flex flush error: Error: EPERM: operation not permitted, rename '...text.2.map.json.tmp' -> '...text.2.map.json'
```

## Fix

Add an `atomicRename(src, dest)` helper that catches `EPERM`/`EEXIST` on `win32` and falls back to `unlink(dest)` before retrying the rename. All three rename sites in `flex-store.ts` use it:

- `writeMeta`
- docs map flush (`__docs__.json`)
- per-key index file flush

The unlink→rename window is non-atomic, but this is acceptable — the file is a cache that's fully rewritten on every flush, and the alternative is a persistent crash loop.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)