### PR TITLE
Sidebar Reveal On Nav

### DIFF
--- a/docs/sidebar-keyboard-navigation.md
+++ b/docs/sidebar-keyboard-navigation.md
@@ -171,6 +171,15 @@ buttons already provide. Mouse behavior is unchanged:
 the keyboard equivalent of clicking a chevron. Nothing about mouse
 interactions was changed by this feature.
 
+## Relationship to reveal-on-nav
+
+Keyboard navigation is independent of the reveal that fires when the app
+navigates to a session or goal *route* (deep-links, clicks, back/forward). Both
+share the `data-nav-id="<kind>:<id>"` row contract, but reveal-on-nav never
+touches `state.keyboardNavActiveId`, `data-nav-active`, `getVisibleNavOrder`, or
+the override-clear listener — it only expands the target's ancestors and scrolls
+the row into view. See [Sidebar reveal on nav](sidebar-reveal-on-nav.md).
+
 ## Internals — file map
 
 - [`src/app/sidebar-nav.ts`](../src/app/sidebar-nav.ts) — `parseNavId`,

--- a/docs/sidebar-reveal-on-nav.md
+++ b/docs/sidebar-reveal-on-nav.md
@@ -1,0 +1,166 @@
+# Sidebar reveal on nav
+
+When the app navigates to a session or goal route, the sidebar must show the
+target row: expand any collapsed ancestors so the row is rendered, then scroll
+it into view. This applies both to initial deep-links (pasting or opening
+`#/session/<id>` / `#/goal/<id>`) and to in-app route changes (clicking,
+keyboard-nav landings, browser back/forward).
+
+## Why this exists
+
+The plumbing for both halves already existed, but nothing bridged *route
+navigation* to *sidebar reveal*:
+
+- Ancestor goals were auto-expanded only when new sessions arrived over the
+  WebSocket (`src/app/api.ts`), not when the user navigated to an existing one.
+- Keyboard navigation (`Ctrl+↑/↓`) opened rows but is a separate concern — it
+  moves an in-sidebar cursor, it does not react to arbitrary route changes.
+- No code scrolled the sidebar to the active row on navigation at all.
+
+The consequence: deep-linking to a session nested inside a collapsed project or
+goal, or clicking a goal whose row is scrolled off-screen, left the user staring
+at a sidebar that gave no visual anchor for where they now were. Reveal-on-nav
+closes that gap by treating route navigation as the trigger and driving the two
+existing subsystems (the [tree expansion state](sidebar-tree-state.md) and the
+DOM row layout) from it.
+
+The feature is deliberately **UI-only** and lives in
+[`src/app/sidebar-reveal.ts`](../src/app/sidebar-reveal.ts). It is invoked from
+route handling (`handleHashChange` and cold-start boot in
+[`src/app/main.ts`](../src/app/main.ts)), never bolted onto keyboard nav, so the
+two navigation models stay independent.
+
+## What it does
+
+Given a session or goal route, `revealSidebarTargetForRoute(route)`:
+
+1. Resolves the target's canonical [sidebar-tree key](sidebar-tree-state.md#canonical-keys)
+   (`session:<id>` → `{ kind: "session", sessionId }`; goal / goal-dashboard →
+   `{ kind: "goal", goalId }`). Non-session/goal routes are a no-op.
+2. Looks the node up in the tree model and walks its `parentKey` chain,
+   expanding each ancestor so the target row will render. For a session this
+   covers its project, the relevant section header (ungrouped sessions / staff /
+   archived), any parent-session child groups, and every ancestor goal in the
+   nesting chain. For a goal it covers the project and the full `parentGoalId`
+   chain up to the top-level goal.
+3. Scrolls the target row into view once it exists in the DOM.
+
+## Design decisions (the WHY)
+
+### Ephemeral, non-destructive expansion
+
+Reveal expands ancestors only through
+`expandSidebarTreeNode(key, { explicit: false })`. This is the *safe automatic*
+path in [`sidebar-tree-state.ts`](../src/app/sidebar-tree-state.ts): it
+early-returns when the node already has a stored preference and when the node's
+default is already expanded, and it never writes to
+`bobbit-sidebar-tree-state:v1`.
+
+The reason is the ephemeral contract: revealing a target must never overwrite an
+explicit user *collapse*. If the user deliberately collapsed a project, deep-
+linking to a session inside it should still reveal the path (because navigation
+is an explicit intent), but the reveal path used here respects a stored collapse
+on any node *not* on the path to the target — those nodes are simply never
+touched. Using `setSidebarTreeExpanded` instead would persist a choice the user
+never made and would clobber their collapse preferences on the next poll or
+reload. See
+[Expansion defaults and persistence](sidebar-tree-state.md#expansion-defaults-and-persistence)
+for why explicit-vs-ephemeral is the mechanism that keeps user intent durable.
+
+Only ancestors of the target are walked — the `parentKey` chain, guarded by a
+`seen` set against any pathological cycle. Unrelated collapsed nodes stay
+collapsed.
+
+### Exactly once per navigation — the `revealToken`
+
+A monotonic `revealToken` is incremented on every call to
+`revealSidebarTargetForRoute`. All the deferred callbacks (see async retry
+below) capture the token value at scheduling time and bail out immediately if
+`revealToken` has since advanced.
+
+The reason is that navigations can supersede each other faster than the async
+retries resolve — a user clicking through several rows, or rapid keyboard nav,
+fires the reveal repeatedly. Without the token, an earlier navigation's
+in-flight retry could expand ancestors for a stale target or scroll to a row the
+user has already navigated away from. The token guarantees that only the most
+recent navigation's reveal ever completes, so the sidebar always settles on the
+row the user actually landed on and never fights itself.
+
+### Async deep-link retry
+
+On a deep-link, the target session or goal data loads asynchronously — the row
+(and often the node itself) does not exist on the first paint. Reveal handles
+this with two bounded `requestAnimationFrame` polls (falling back to
+`setTimeout` in non-DOM/test environments):
+
+- **Model poll** (`attemptReveal`): rebuilds the tree model each frame until the
+  target node appears in `flatByKey`, then expands the ancestor chain and calls
+  `renderApp()`.
+- **DOM poll** (`attemptScroll`): after the render, retries locating the row by
+  `data-nav-id` until it is committed, because lit commits the DOM
+  asynchronously after `renderApp`.
+
+Both polls are bounded (`MAX_ATTEMPTS`, ~0.5 s at 60 fps). Each call site invokes
+the reveal only *after* awaiting its data load (`refreshSessions` /
+`loadDashboardData` / `connectToSession`), so the node is usually present on the
+first attempt; the retry budget only matters for the rare case where data
+streams in slightly after the reveal fires. Combined with the `revealToken`,
+the retries stay bounded and still run exactly once per navigation.
+
+### Resolve against the unfiltered tree model
+
+Reveal walks `buildSidebarTreeModel()`, exported from
+[`src/app/sidebar.ts`](../src/app/sidebar.ts), which returns the tree model
+*before* the search-query goal filter is applied. `buildDesktopSidebarTree`
+still applies that filter on top, so rendering is unchanged.
+
+The reason is that ancestor resolution must keep working even when the sidebar
+search box is non-empty. If reveal walked the filtered model, a goal pruned by
+an active search query would have no node to expand and the target would never
+be revealed. Resolving against the full model decouples "where does this row
+live in the hierarchy" from "what is currently shown by search".
+
+### `scrollIntoView({ block: "nearest" })` only
+
+The row is scrolled with `scrollIntoView({ block: "nearest" })` — no
+`smooth`/animated behavior. `block: "nearest"` scrolls only when the row is
+off-screen and is a no-op when it is already visible, so navigating to an
+already-visible row produces no jarring jump. Animated scroll is avoided because
+it would compete with the message-pane auto-scroll (`AgentInterface`) and the
+keyboard-nav override, and because reveal can fire in quick succession — smooth
+scroll would produce visible thrash.
+
+## Relationship to adjacent features
+
+- **[Keyboard navigation](sidebar-keyboard-navigation.md)** is a separate model.
+  Reveal never mutates `state.keyboardNavActiveId`, `data-nav-active`,
+  `getVisibleNavOrder`, or the override-clear listener — it only reads the DOM
+  (via the shared `data-nav-id` contract) and flips ephemeral expansion prefs.
+  Keyboard nav moves a cursor through visible rows; reveal reacts to route
+  changes. They share the `data-nav-id="<kind>:<id>"` row tagging but are
+  otherwise independent.
+- **[Sidebar tree state](sidebar-tree-state.md)** owns the expansion model,
+  canonical keys, and the explicit-vs-ephemeral persistence contract that reveal
+  relies on. Reveal is a consumer of `expandSidebarTreeNode(..., { explicit:
+  false })`, the same non-destructive path `api.ts` and `createGoal()` use for
+  auto-expansion.
+
+## Internals — file map
+
+- [`src/app/sidebar-reveal.ts`](../src/app/sidebar-reveal.ts) —
+  `revealSidebarTargetForRoute` (public entry), `targetForRoute`,
+  `attemptReveal`, `attemptScroll`, `navRowForId`, and the `revealToken` /
+  `pending` state.
+- [`src/app/main.ts`](../src/app/main.ts) — invokes the reveal from each
+  session / goal / goal-dashboard branch of `handleHashChange` (including the
+  already-connected early return) and from the cold-start deep-link boot block
+  in `initApp`.
+- [`src/app/sidebar.ts`](../src/app/sidebar.ts) — exports
+  `buildSidebarTreeModel` (the pre-search-filter model); rendering via
+  `buildDesktopSidebarTree` is unchanged.
+- [`src/app/sidebar-tree-state.ts`](../src/app/sidebar-tree-state.ts) —
+  `expandSidebarTreeNode(key, { explicit: false })`, the ephemeral expansion
+  path.
+- [`tests/e2e/ui/sidebar-reveal.spec.ts`](../tests/e2e/ui/sidebar-reveal.spec.ts)
+  — deep-link session and sub-goal reveal, in-app off-screen scroll vs
+  no-jump-when-visible, and the ephemeral-collapse contract.

--- a/docs/sidebar-tree-state.md
+++ b/docs/sidebar-tree-state.md
@@ -114,6 +114,8 @@ All goal nodes default collapsed, including top-level goals and sub-goals. The r
 
 Because automatic expansion is non-explicit, an explicit collapsed parent remains collapsed across later polling and restart.
 
+Route navigation reuses the same non-explicit path to reveal a target row's ancestors on deep-links and in-app route changes. See [Sidebar reveal on nav](sidebar-reveal-on-nav.md).
+
 ## Archived and search behavior
 
 Archived visibility and tree expansion are separate preferences:

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -35,6 +35,7 @@ import {
 } from "./state.js";
 import { fetchProjects, gatewayFetch, refreshSessions, resetPrPollThrottle } from "./api.js";
 import { getRouteFromHash, setHashRoute } from "./routing.js";
+import { revealSidebarTargetForRoute } from "./sidebar-reveal.js";
 import { authenticateGateway, connectToSession, createAndConnectSession, terminateSession, applyProjectPalette, flushAndTeardownDraft, flushPendingDraft } from "./session-manager.js";
 import { selectProposalWorkspaceTab } from "./preview-panel.js";
 import { migrateLegacyVisitedMap } from "./render-helpers.js";
@@ -345,10 +346,12 @@ async function handleHashChange(): Promise<void> {
 			applyProjectPalette(goalForPalette?.projectId);
 			await refreshSessions();
 			await loadDashboardData(route.goalId);
+			revealSidebarTargetForRoute(route);
 		} else if (route.view === "session" && route.sessionId) {
 			clearDashboardState();
 			if (state.selectedSessionId === route.sessionId || state.connectingSessionId === route.sessionId || state.remoteAgent?.gatewaySessionId === route.sessionId) {
 				await restoreSessionPanelRoute(route.sessionId, route.panelTabId);
+				revealSidebarTargetForRoute(route);
 				return;
 			}
 			if (state.remoteAgent) {
@@ -361,6 +364,7 @@ async function handleHashChange(): Promise<void> {
 			if (checkRes.ok) {
 				await connectToSession(route.sessionId, true);
 				await restoreSessionPanelRoute(route.sessionId, route.panelTabId);
+				revealSidebarTargetForRoute(route);
 			} else {
 				setHashRoute("landing");
 				state.appView = "authenticated";
@@ -431,6 +435,7 @@ async function handleHashChange(): Promise<void> {
 			loadDashboardData(route.goalId);
 			renderApp();
 			await refreshSessions();
+			revealSidebarTargetForRoute(route);
 		} else if (route.view === "roles") {
 			clearDashboardState();
 			if (state.remoteAgent) {
@@ -738,17 +743,20 @@ async function initApp() {
 			const route = getRouteFromHash();
 			if (route.view === "goal" && route.goalId) {
 				await loadDashboardData(route.goalId);
+				revealSidebarTargetForRoute(route);
 			} else if (route.view === "session" && route.sessionId) {
 				const checkRes = await gatewayFetch(`/api/sessions/${route.sessionId}`);
 				if (checkRes.ok) {
 					await connectToSession(route.sessionId, true);
 					await restoreSessionPanelRoute(route.sessionId, route.panelTabId);
+					revealSidebarTargetForRoute(route);
 				}
 			} else if (route.view === "goal-dashboard" && route.goalId) {
 				state.goalDashboardId = route.goalId;
 				loadDashboardData(route.goalId);
 				renderApp();
 				await refreshSessions();
+				revealSidebarTargetForRoute(route);
 			} else if (route.view === "ext") {
 				// Slice C1 — cold-load pack deep-link restoration.
 				state.appView = "authenticated";

--- a/src/app/sidebar-reveal.ts
+++ b/src/app/sidebar-reveal.ts
@@ -1,0 +1,137 @@
+// ============================================================================
+// SIDEBAR REVEAL ON NAV
+//
+// Bridges *route navigation* to the sidebar tree: when the app navigates to a
+// session or goal route — on initial deep-links AND in-app hash/route changes
+// (clicks, keyboard-nav landings, browser back/forward) — this module
+//   (1) expands every collapsed ancestor of the target row so it is rendered,
+//   (2) scrolls the row into view with `scrollIntoView({ block: "nearest" })`.
+//
+// Expansion is *ephemeral*: it only ever calls
+// `expandSidebarTreeNode(key, { explicit: false })`, which no-ops when the node
+// already has a stored preference (so an explicit user *collapse* is never
+// overwritten) and when the node's default is already expanded. Only ancestors
+// on the path to the target are touched — unrelated collapsed nodes stay put.
+//
+// The keyboard-nav model (`state.keyboardNavActiveId`, `data-nav-active`,
+// `getVisibleNavOrder`, the override-clear listener) is never mutated here — we
+// only read the DOM and flip ephemeral expansion prefs. A monotonic
+// `revealToken` guarantees a superseded navigation's in-flight rAF callbacks
+// no-op, so exactly one reveal runs per navigation.
+// ============================================================================
+
+import { renderApp } from "./state.js";
+import { getRouteFromHash, type AppRoute } from "./routing.js";
+import { buildSidebarTreeModel } from "./sidebar.js";
+import { expandSidebarTreeNode } from "./sidebar-tree-state.js";
+import { sidebarTreeKey } from "./sidebar-tree-builder.js";
+
+/** Max retry attempts for both the model-lookup and the DOM-scroll polls.
+ *
+ * Each call site invokes the reveal only AFTER awaiting the relevant data load
+ * (`refreshSessions` / `loadDashboardData` / `connectToSession`), so the target
+ * node is normally present on the very first attempt and the row commits within
+ * a frame or two. The generous bound (~0.5s at 60fps) only matters for the rare
+ * deep-link case where session/goal data streams in slightly after the reveal
+ * fires; it stays bounded (`revealToken` still guarantees exactly-once). */
+const MAX_ATTEMPTS = 30;
+
+interface PendingReveal {
+	/** Canonical sidebar-tree key of the target node (session or goal). */
+	key: string;
+	/** DOM `data-nav-id` of the target row (`session:<id>` / `goal:<id>`). */
+	navId: string;
+}
+
+let pending: PendingReveal | null = null;
+let revealToken = 0;
+
+/** Schedule a callback on the next animation frame (falls back to setTimeout
+ *  in non-DOM / test environments without `requestAnimationFrame`). */
+function nextFrame(cb: () => void): void {
+	if (typeof requestAnimationFrame === "function") requestAnimationFrame(() => cb());
+	else setTimeout(cb, 16);
+}
+
+/** Resolve the reveal target for a route, or null when the route is not a
+ *  session / goal destination. */
+function targetForRoute(route: AppRoute): PendingReveal | null {
+	if ((route.view === "goal" || route.view === "goal-dashboard") && route.goalId) {
+		return { key: sidebarTreeKey({ kind: "goal", goalId: route.goalId }), navId: `goal:${route.goalId}` };
+	}
+	if (route.view === "session" && route.sessionId) {
+		return { key: sidebarTreeKey({ kind: "session", sessionId: route.sessionId }), navId: `session:${route.sessionId}` };
+	}
+	return null;
+}
+
+/**
+ * Public entry point. Expand the collapsed ancestor tree for the route's
+ * target row and scroll it into view. Safe to call from any route branch and
+ * from cold-start boot; a no-op for non-session/goal routes.
+ */
+export function revealSidebarTargetForRoute(route: AppRoute = getRouteFromHash()): void {
+	const target = targetForRoute(route);
+	// Bump the token on every call so any earlier in-flight reveal is cancelled
+	// (guards "exactly once per navigation").
+	const token = ++revealToken;
+	if (!target) {
+		pending = null;
+		return;
+	}
+	pending = target;
+	attemptReveal(token, 0);
+}
+
+/** Bounded rAF poll: find the target node in the (unfiltered) tree model,
+ *  expand its ancestor chain, then hand off to the scroll poll. Retries while
+ *  the node is still absent (data loading async on a deep-link). */
+function attemptReveal(token: number, attempt: number): void {
+	if (token !== revealToken || !pending) return;
+	const current = pending;
+	const model = buildSidebarTreeModel();
+	const node = model.flatByKey.get(current.key);
+	if (!node) {
+		if (attempt < MAX_ATTEMPTS) nextFrame(() => attemptReveal(token, attempt + 1));
+		return;
+	}
+	// Walk the parent chain, expanding each ancestor ephemerally. A `seen`
+	// guard defends against any pathological cycle in `parentKey`.
+	const seen = new Set<string>();
+	let pk = node.parentKey;
+	while (pk && !seen.has(pk)) {
+		seen.add(pk);
+		const parent = model.flatByKey.get(pk);
+		if (!parent) break;
+		expandSidebarTreeNode(parent.nodeKey, { explicit: false });
+		pk = parent.parentKey;
+	}
+	renderApp();
+	attemptScroll(current.navId, token, 0);
+}
+
+/** Bounded rAF poll: locate the target row in the DOM and scroll it into
+ *  view. Retries because lit commits the DOM asynchronously after `renderApp`. */
+function attemptScroll(navId: string, token: number, attempt: number): void {
+	if (token !== revealToken) return;
+	const row = navRowForId(navId);
+	if (row) {
+		row.scrollIntoView({ block: "nearest" });
+		if (pending && pending.navId === navId) pending = null;
+		return;
+	}
+	if (attempt < MAX_ATTEMPTS) nextFrame(() => attemptScroll(navId, token, attempt + 1));
+}
+
+/** Locate a sidebar row by its `data-nav-id`. Scans (rather than using a CSS
+ *  selector) to avoid escaping bugs with ids containing special characters —
+ *  mirrors `navRowForId` in `sidebar-nav.ts`. */
+function navRowForId(navId: string): HTMLElement | null {
+	if (typeof document === "undefined") return null;
+	const sidebar = document.querySelector(".sidebar-edge");
+	if (!sidebar) return null;
+	for (const el of sidebar.querySelectorAll<HTMLElement>("[data-nav-id]")) {
+		if (el.getAttribute("data-nav-id") === navId) return el;
+	}
+	return null;
+}

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -1608,7 +1608,21 @@ function renderNestedNode(
 	`;
 }
 
-function buildDesktopSidebarTree(sidebarData = getSidebarData()): SidebarTreeModel {
+/**
+ * Build the FULL, pre-search-filter sidebar tree model.
+ *
+ * Returns the `model` exactly as produced by `buildSidebarTree` — i.e. before
+ * `filterSidebarTreeModelGoalsForSearch` prunes non-matching goal nodes while a
+ * search query is active. Reveal-on-nav (`sidebar-reveal.ts`) walks this
+ * unfiltered model's `flatByKey`/`parentKey` chain so ancestor resolution keeps
+ * working even when the sidebar search box is non-empty. `buildDesktopSidebarTree`
+ * applies the goal-search filter on top so rendering behaviour is unchanged.
+ */
+export function buildSidebarTreeModel(sidebarData = getSidebarData()): SidebarTreeModel {
+	return buildSidebarTreeModelWithSearch(sidebarData).model;
+}
+
+function buildSidebarTreeModelWithSearch(sidebarData = getSidebarData()): { model: SidebarTreeModel; visibleSearchGoalIds: Set<string> | null } {
 	const query = state.searchQuery.trim();
 	const q = query.toLowerCase();
 	const bypassFilters = Boolean(query);
@@ -1686,6 +1700,11 @@ function buildDesktopSidebarTree(sidebarData = getSidebarData()): SidebarTreeMod
 		},
 		expansion: sidebarTreeExpansionInput(),
 	});
+	return { model, visibleSearchGoalIds };
+}
+
+function buildDesktopSidebarTree(sidebarData = getSidebarData()): SidebarTreeModel {
+	const { model, visibleSearchGoalIds } = buildSidebarTreeModelWithSearch(sidebarData);
 	return visibleSearchGoalIds ? filterSidebarTreeModelGoalsForSearch(model, visibleSearchGoalIds) : model;
 }
 

--- a/tests/e2e/ui/sidebar-reveal.spec.ts
+++ b/tests/e2e/ui/sidebar-reveal.spec.ts
@@ -1,0 +1,266 @@
+/**
+ * Browser E2E for "Sidebar Reveal On Nav".
+ *
+ * On navigation to a session / goal route — both initial deep-links and in-app
+ * hash changes — the sidebar must (1) expand the collapsed ancestor tree so the
+ * target row renders, and (2) scroll the row into view with
+ * `scrollIntoView({ block: "nearest" })`. Expansion is ephemeral: it never
+ * overwrites an explicit user collapse.
+ */
+import { test, expect, type Page } from "../gateway-harness.js";
+import {
+	apiFetch,
+	base,
+	createGoal,
+	createSession,
+	defaultProjectId,
+	deleteGoal,
+	deleteSession,
+	readE2ETokenAsync,
+	waitForHealth,
+} from "../e2e-setup.js";
+import { openApp } from "./ui-helpers.js";
+
+const TREE_STATE_KEY = "bobbit-sidebar-tree-state:v1";
+const SPEC = "Sidebar reveal-on-nav fixture goal with enough detail to satisfy validation.";
+const FILLER_GOAL_COUNT = 16;
+
+type Fixture = {
+	projectId: string;
+	parentGoalId: string;
+	childGoalId: string;
+	nestedSessionId: string;
+	standaloneSessionId: string;
+	fillerGoalIds: string[];
+};
+
+let fixture: Fixture;
+const createdGoalIds: string[] = [];
+const createdSessionIds: string[] = [];
+
+function treeKey(kind: "project-sessions" | "goal", id: string): string {
+	return `sidebar-tree/v1/${kind}/${encodeURIComponent(id)}`;
+}
+
+async function createChildGoal(projectId: string, parentGoalId: string, title: string): Promise<string> {
+	const resp = await apiFetch("/api/goals", {
+		method: "POST",
+		body: JSON.stringify({ title, spec: SPEC, projectId, parentGoalId, team: false, worktree: false, autoStartTeam: false }),
+	});
+	expect(resp.status, `create child goal ${title}: ${await resp.clone().text()}`).toBe(201);
+	return (await resp.json()).id as string;
+}
+
+/** Seed a clean browser state before boot; optionally pre-store explicit
+ *  expansion preferences (canonicalKey → "expanded" | "collapsed"). */
+async function seedBrowserState(page: Page, prefs: Record<string, "expanded" | "collapsed"> = {}): Promise<void> {
+	await page.addInitScript(({ treeStateKey, expansion }) => {
+		localStorage.removeItem("bobbit-sidebar-collapsed");
+		localStorage.setItem("bobbit-show-archived", "false");
+		if (Object.keys(expansion).length > 0) {
+			localStorage.setItem(treeStateKey, JSON.stringify({ version: 1, expansion }));
+		} else {
+			localStorage.removeItem(treeStateKey);
+		}
+	}, { treeStateKey: TREE_STATE_KEY, expansion: prefs });
+}
+
+/** Open the app booting directly at a hash deep-link. */
+async function openAppAtHash(page: Page, hash: string): Promise<void> {
+	const token = await readE2ETokenAsync();
+	await page.goto(`${base()}/?token=${encodeURIComponent(token)}${hash}`);
+	await expect(page.locator(".sidebar-edge")).toBeVisible({ timeout: 20_000 });
+}
+
+function navRow(page: Page, navId: string) {
+	return page.locator(`[data-nav-id="${navId}"]`).first();
+}
+
+async function storedPreference(page: Page, canonicalKey: string): Promise<string | undefined> {
+	return page.evaluate(({ storageKey, canonicalKey }) => {
+		const raw = localStorage.getItem(storageKey);
+		if (!raw) return undefined;
+		try { return JSON.parse(raw).expansion?.[canonicalKey]; } catch { return undefined; }
+	}, { storageKey: TREE_STATE_KEY, canonicalKey });
+}
+
+type RowGeometry = {
+	found: boolean;
+	within: boolean;
+	scrollTop: number;
+	scrollHeight: number;
+	clientHeight: number;
+	overflowing: boolean;
+};
+
+async function rowGeometry(page: Page, navId: string): Promise<RowGeometry> {
+	return page.evaluate((navId) => {
+		const sidebar = document.querySelector(".sidebar-edge");
+		const container = sidebar?.querySelector<HTMLElement>("[data-project-reorder-list]");
+		const empty = { found: false, within: false, scrollTop: -1, scrollHeight: -1, clientHeight: -1, overflowing: false };
+		if (!sidebar || !container) return empty;
+		let row: HTMLElement | null = null;
+		for (const el of sidebar.querySelectorAll<HTMLElement>("[data-nav-id]")) {
+			if (el.getAttribute("data-nav-id") === navId) { row = el; break; }
+		}
+		const meta = {
+			scrollTop: container.scrollTop,
+			scrollHeight: container.scrollHeight,
+			clientHeight: container.clientHeight,
+			overflowing: container.scrollHeight - container.clientHeight > 4,
+		};
+		if (!row) return { ...meta, found: false, within: false };
+		const cr = container.getBoundingClientRect();
+		const rr = row.getBoundingClientRect();
+		const within = rr.top >= cr.top - 1 && rr.bottom <= cr.bottom + 1;
+		return { ...meta, found: true, within };
+	}, navId);
+}
+
+async function fullyVisibleNavIds(page: Page): Promise<string[]> {
+	return page.evaluate(() => {
+		const sidebar = document.querySelector(".sidebar-edge");
+		const container = sidebar?.querySelector<HTMLElement>("[data-project-reorder-list]");
+		if (!sidebar || !container) return [];
+		const cr = container.getBoundingClientRect();
+		const out: string[] = [];
+		for (const el of sidebar.querySelectorAll<HTMLElement>("[data-nav-id]")) {
+			const id = el.getAttribute("data-nav-id");
+			if (!id) continue;
+			const rr = el.getBoundingClientRect();
+			if (rr.top >= cr.top && rr.bottom <= cr.bottom && rr.height > 0) out.push(id);
+		}
+		return out;
+	});
+}
+
+async function setSidebarScrollTop(page: Page, value: number): Promise<void> {
+	await page.evaluate((value) => {
+		const c = document.querySelector<HTMLElement>(".sidebar-edge [data-project-reorder-list]");
+		if (c) c.scrollTop = value;
+	}, value);
+}
+
+async function inAppNavigate(page: Page, hash: string): Promise<void> {
+	await page.evaluate((h) => { window.location.hash = h; }, hash);
+}
+
+test.describe("Sidebar reveal on nav", () => {
+	test.beforeAll(async () => {
+		await waitForHealth();
+		const projectId = (await defaultProjectId())!;
+		const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+
+		const prefs = await apiFetch("/api/preferences", { method: "PUT", body: JSON.stringify({ subgoalsEnabled: true }) });
+		expect(prefs.status, `enable subgoals: ${await prefs.clone().text()}`).toBe(200);
+
+		const parent = await createGoal({ title: `Reveal parent ${stamp}`, projectId, team: false, worktree: false, subgoalsAllowed: true, maxNestingDepth: 3 });
+		createdGoalIds.push(parent.id);
+		const childGoalId = await createChildGoal(projectId, parent.id, `Reveal child ${stamp}`);
+		createdGoalIds.push(childGoalId);
+
+		const nestedSessionId = await createSession({ projectId, goalId: childGoalId });
+		const standaloneSessionId = await createSession({ projectId });
+		createdSessionIds.push(nestedSessionId, standaloneSessionId);
+
+		const fillerGoals = await Promise.all(
+			Array.from({ length: FILLER_GOAL_COUNT }, (_, i) =>
+				createGoal({ title: `Reveal filler ${i} ${stamp}`, projectId, team: false, worktree: false })),
+		);
+		const fillerGoalIds = fillerGoals.map(g => g.id);
+		createdGoalIds.push(...fillerGoalIds);
+
+		fixture = { projectId, parentGoalId: parent.id, childGoalId, nestedSessionId, standaloneSessionId, fillerGoalIds };
+	});
+
+	test.afterAll(async () => {
+		for (const id of [...createdSessionIds].reverse()) await deleteSession(id).catch(() => {});
+		createdSessionIds.length = 0;
+		for (const id of [...createdGoalIds].reverse()) await deleteGoal(id).catch(() => {});
+		createdGoalIds.length = 0;
+	});
+
+	test("deep-link to a session nested in collapsed goals expands ancestors and scrolls the row into view", async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 620 });
+		await seedBrowserState(page);
+		await openAppAtHash(page, `#/session/${fixture.nestedSessionId}`);
+
+		// Ancestor goals default-collapsed → the reveal must expand them so the
+		// nested session row renders and becomes the active row.
+		await expect(navRow(page, `goal:${fixture.parentGoalId}`)).toBeVisible({ timeout: 15_000 });
+		await expect(navRow(page, `goal:${fixture.childGoalId}`)).toBeVisible({ timeout: 10_000 });
+		const sessionRow = navRow(page, `session:${fixture.nestedSessionId}`);
+		await expect(sessionRow).toBeVisible({ timeout: 10_000 });
+		await expect(sessionRow).toHaveAttribute("data-nav-active", "true", { timeout: 10_000 });
+
+		await expect.poll(async () => (await rowGeometry(page, `session:${fixture.nestedSessionId}`)).within, { timeout: 10_000 })
+			.toBe(true);
+	});
+
+	test("deep-link to a nested sub-goal expands the parent chain and shows the goal row", async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 620 });
+		await seedBrowserState(page);
+		await openAppAtHash(page, `#/goal/${fixture.childGoalId}`);
+
+		await expect(navRow(page, `goal:${fixture.parentGoalId}`)).toBeVisible({ timeout: 15_000 });
+		const childRow = navRow(page, `goal:${fixture.childGoalId}`);
+		await expect(childRow).toBeVisible({ timeout: 10_000 });
+		await expect.poll(async () => (await rowGeometry(page, `goal:${fixture.childGoalId}`)).within, { timeout: 10_000 })
+			.toBe(true);
+	});
+
+	test("in-app route change scrolls an off-screen row into view; an already-visible row does not jump", async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 360 });
+		await seedBrowserState(page);
+		await openApp(page);
+		await expect(navRow(page, `goal:${fixture.parentGoalId}`)).toBeVisible({ timeout: 15_000 });
+
+		// Force overflow, then pin the scroll to the top so the last filler goal
+		// is off-screen.
+		await setSidebarScrollTop(page, 0);
+		const lastGoalId = fixture.fillerGoalIds[fixture.fillerGoalIds.length - 1];
+		const lastNav = `goal:${lastGoalId}`;
+		await expect.poll(async () => (await rowGeometry(page, lastNav)).overflowing, { timeout: 10_000 }).toBe(true);
+		expect((await rowGeometry(page, lastNav)).within, "last filler goal should start off-screen").toBe(false);
+
+		// In-app navigation to the off-screen row must scroll it into view.
+		await inAppNavigate(page, `#/goal/${lastGoalId}`);
+		await expect.poll(async () => (await rowGeometry(page, lastNav)).within, { timeout: 10_000 }).toBe(true);
+
+		// Now navigate to a DIFFERENT row that is already fully visible — the
+		// reveal must not jump the scroll position (block:"nearest" no-op).
+		const visible = (await fullyVisibleNavIds(page)).filter(id => id.startsWith("goal:") && id !== lastNav);
+		expect(visible.length, "expected another goal row visible alongside the target").toBeGreaterThan(0);
+		const scrollBefore = (await rowGeometry(page, lastNav)).scrollTop;
+		await inAppNavigate(page, `#/${visible[0].replace("goal:", "goal/")}`);
+		await expect(navRow(page, visible[0])).toHaveAttribute("data-nav-active", "true", { timeout: 10_000 });
+		// Give any (erroneous) scroll a chance to happen, then assert it didn't.
+		await page.evaluate(() => new Promise<void>(r => requestAnimationFrame(() => requestAnimationFrame(() => r()))));
+		expect((await rowGeometry(page, lastNav)).scrollTop, "already-visible target must not move the sidebar scroll").toBe(scrollBefore);
+	});
+
+	test("ephemeral contract: off-path collapse is preserved, and an on-path explicit collapse is never overwritten", async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 620 });
+		// Part A: explicitly collapse the (off-path) Sessions section AND the
+		// (on-path) parent goal, then deep-link to the sub-goal.
+		const sessionsKey = treeKey("project-sessions", fixture.projectId);
+		const parentGoalKey = treeKey("goal", fixture.parentGoalId);
+		await seedBrowserState(page, { [sessionsKey]: "collapsed" });
+		await openAppAtHash(page, `#/goal/${fixture.childGoalId}`);
+
+		// The sub-goal reveal expands the parent goal (on path) but must NOT
+		// touch the off-path Sessions section.
+		await expect(navRow(page, `goal:${fixture.childGoalId}`)).toBeVisible({ timeout: 15_000 });
+		await expect(navRow(page, `session:${fixture.standaloneSessionId}`), "off-path collapsed Sessions section stays collapsed").toBeHidden({ timeout: 10_000 });
+		expect(await storedPreference(page, sessionsKey), "off-path explicit collapse preserved").toBe("collapsed");
+
+		// Part B: explicitly collapse the parent goal (on path) and deep-link to
+		// the nested session. The reveal must NOT overwrite the explicit collapse,
+		// so the parent stays collapsed and the nested session row stays hidden.
+		await seedBrowserState(page, { [parentGoalKey]: "collapsed" });
+		await openAppAtHash(page, `#/session/${fixture.nestedSessionId}`);
+		await expect(navRow(page, `goal:${fixture.parentGoalId}`)).toBeVisible({ timeout: 15_000 });
+		await expect(navRow(page, `session:${fixture.nestedSessionId}`), "on-path explicit collapse must keep the nested row hidden").toBeHidden({ timeout: 10_000 });
+		expect(await storedPreference(page, parentGoalKey), "on-path explicit collapse must not be overwritten").toBe("collapsed");
+	});
+});


### PR DESCRIPTION
## Summary

Navigating to a session (`#/session/<id>`) or goal (`#/goal/<id>`) route now expands the collapsed sidebar ancestor tree so the target row renders, then scrolls it into view. Applies on initial deep-links, in-app route changes (clicks, keyboard-nav landings), and browser back/forward — closing the gap where route navigation was never bridged to sidebar reveal.

## What changed

- **NEW `src/app/sidebar-reveal.ts`** — `revealSidebarTargetForRoute(route)` resolves the session/goal target, looks it up in the **unfiltered** tree model (`buildSidebarTreeModel`), walks its `parentKey` chain expanding each ancestor via `expandSidebarTreeNode(nodeKey, { explicit: false })` (ephemeral; never overwrites an explicit user collapse; `seen`-guarded against cycles), re-renders, then `scrollIntoView({ block: "nearest" })`. A monotonic `revealToken` guarantees exactly-once-per-navigation; bounded `requestAnimationFrame` polls cover async data loads (deep-links) and lit's async DOM commit.
- **`src/app/sidebar.ts`** — extracted + exported `buildSidebarTreeModel()` (pre-search-filter model); `buildDesktopSidebarTree` still applies the search filter so rendering is byte-identical. Using the unfiltered model means reveal works even while the sidebar search box is non-empty.
- **`src/app/main.ts`** — reveal wired into every relevant `handleHashChange` branch (goal, session normal-connect **and** already-connected early-return, goal-dashboard) plus the cold-start deep-link boot block.
- **NEW `tests/e2e/ui/sidebar-reveal.spec.ts`** — 4 E2E tests: deep-link session nested in collapsed goals; deep-link nested sub-goal; in-app off-screen scroll-into-view vs. already-visible no-jump; ephemeral-collapse contract.
- **Docs** — `docs/sidebar-reveal-on-nav.md` (new) + cross-references in `docs/sidebar-keyboard-navigation.md` and `docs/sidebar-tree-state.md`.

## Contracts preserved

Keyboard-nav model untouched (`keyboardNavActiveId`, `data-nav-active`, `getVisibleNavOrder`, override-clear listener). Expansion is ephemeral (`explicit: false`) — never overwrites an explicit user collapse. Scroll is `block: "nearest"` only, no smooth/animated scroll, scoped to the sidebar so it does not fight the message-pane auto-scroll.

## Verification

`npm run check`, unit, E2E, gap analysis, code-quality, bug-hunt, security, and QA gates all green.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)