### PR TITLE
Market-Pack Roles in Teams

### DIFF
--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -519,11 +519,20 @@ Market-pack entities are read-only on those pages (manage them from the Market s
 
 ### Runtime role lookup
 
-Any role returned by `GET /api/roles` is usable anywhere the runtime accepts a role id. Session creation (`POST /api/sessions`), session role assignment (`PATCH /api/sessions/:id`), staff create/update validation, and persisted-session rehydration paths resolve roles through `ConfigCascade.resolveRoles(projectId)` first, then fall back to the legacy `roleManager.getRole(...)` store lookup for compatibility.
+Any role returned by `GET /api/roles` is usable anywhere the runtime accepts a role id. Session creation (`POST /api/sessions`), session role assignment (`PATCH /api/sessions/:id`), staff create/update validation, persisted-session rehydration, **goal-team spawns** (`team_spawn`), and **role-carrying delegates** (`team_delegate(role: X)`) resolve roles through `ConfigCascade.resolveRoles(projectId)` first, then fall back to the legacy `roleManager.getRole(...)` / `RoleStore` lookup for compatibility.
 
 This keeps the API and runtime in sync: a market-pack or built-in first-party pack role shown in the Roles page can be selected for sessions and staff agents. The winning role is the same one the cascade exposes, so existing precedence still applies: project-specific entries win over server/global-user entries, and user-pack overrides win over market packs in the same scope (see [Scopes & precedence](#scopes--precedence)).
 
 Runtime resolution preserves the full role record, including `promptTemplate`, `accessory`, `model`, `thinkingLevel`, and `toolPolicies`, so pack roles can carry prompts, UI accessories, model/thinking defaults, and tool grants into sessions just like hand-written roles.
+
+#### Team-lead and delegate role resolution
+
+Roles inside a goal team, and roles passed to `team_delegate`, resolve through the **same** config cascade — closing two earlier gaps where they only saw the bare in-memory `RoleStore` and so **could not see market-pack roles at all**:
+
+- **Team leads inside goals.** `TeamManager` resolves roles via `resolveRoleSource(goal)` (`team-manager.ts`), a cascade-aware `RoleSource` (see `resolve-role.ts::RoleSource`) that prefers the project's `configCascade.resolveRoles(projectId)` (project→server→builtin→market-packs) and keeps the bare `RoleStore` only as a fallback. So a team lead can `team_spawn` a role installed **only** as a market pack, the `{{AVAILABLE_ROLES}}` list injected into the team-lead prompt lists those pack roles, and the "Role X not found" error enumerates everything actually spawnable. Precedence is unchanged: goal `inlineRoles` first, then the cascade, then the store — de-duplicated by name with cascade first.
+- **`team_delegate(role: X)`.** The delegated child now carries role X's `promptTemplate` (system prompt) **and** `accessory` (sidebar), resolved through the same cascade — previously only the role's tools were applied. `session-manager.ts::createDelegateSession` threads `role`/`roleName`/`rolePrompt` into its `SessionSetupPlan`, so the shared role-prompt + role-accessory application in `session-setup.ts` runs for the bare/delegate spawn exactly as it already did for the full `createSession` path.
+
+**Why:** both spawn paths (bare `createDelegateSession` and full `createSession`) now derive role prompt + accessory + tools from **one** resolution pipeline instead of ad-hoc per-path code — a single source of truth. See [docs/orchestration.md](orchestration.md#team_delegate) for the delegate-side behaviour and the preserved invariants (recursion guard, `read_only` tool stripping, sandbox/credential scope inheritance, `ROLE_TOOLS_UNRESOLVED` fail-closed).
 
 Unknown role ids still fail loudly in REST validation paths, normally as `404`. Callers cannot select a pack identity directly: runtime paths only consume roles already resolved by the config cascade for the target project/scope, which preserves the marketplace security boundary and avoids trusting caller-supplied provenance.
 

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -78,7 +78,29 @@ mutating (file-changing) tool.
 - **Model inheritance** — the child inherits **your current model** (and thinking level)
   unless you pass `model` / `thinking_level`. (The old `delegate` silently dropped to the
   system default; that bug is gone.)
+- **Role injection (`role: X`)** — the child carries role X's **`promptTemplate`** (its
+  system prompt, with the usual `{{AGENT_ID}}` / `{{GOAL_BRANCH}}` / prompt-conditional
+  substitution) **and** its **`accessory`** (the sidebar badge, respecting the `"none"`
+  convention; an explicit caller-supplied accessory still wins). The role resolves through
+  the **config cascade** (project→server→builtin→market-packs), so a market-pack role works
+  for `team_delegate` just like a stored role. Earlier, a role-carrying delegate got only the
+  role's *tools* — a generic system prompt and no accessory; now prompt, accessory, and tools
+  all come from one resolution pipeline. A role-**less** `team_delegate` is unchanged (no role
+  prompt, no accessory, inherits your stripped tools).
 - **Timeout** — blocking-mode default is 10 minutes.
+
+> **One shared role pipeline (no ad-hoc per-path code).** The bare delegate path
+> (`session-manager.ts::createDelegateSession`) now threads `role` / `roleName` / `rolePrompt`
+> into its `SessionSetupPlan`, so the **same** role-prompt + role-accessory application in
+> `session-setup.ts` runs for both `team_delegate` (bare) and `team_spawn` / full `createSession`.
+> Role injection **never widens tools**: the child's `allowedTools` are still the spawn-verb-
+> and (for `read_only`) mutating-tool-stripped set from `OrchestrationCore.childAllowedTools`,
+> and role resolution does not re-add spawn verbs. Sandbox / project (credential) scope
+> inheritance is unchanged. When a `role` spawn cannot resolve the role's tool grants the spawn
+> fails closed with `ROLE_TOOLS_UNRESOLVED` rather than inheriting the owner's broader tools.
+> Market-pack roles becoming usable by team leads inside goals (`team_spawn` +
+> `{{AVAILABLE_ROLES}}`) rides the same cascade — see
+> [docs/marketplace.md § Team-lead and delegate role resolution](marketplace.md#team-lead-and-delegate-role-resolution).
 
 The System Prompt Inspector treats the child's persisted `instructions` and optional `context` as a durable **Delegate Task**. Prompt-section refreshes, including provider `before-prompt` hooks and restart restore, rebuild that task from the session record so the viewer keeps the same task-oriented section the model received. Delegate instructions should appear in that Task section only, not duplicated into both Goal and Task.
 

--- a/src/server/agent/orchestration-core.ts
+++ b/src/server/agent/orchestration-core.ts
@@ -313,6 +313,10 @@ export interface OrchestrationSessionView {
 		allowedTools?: string[];
 		initialModel?: string;
 		initialThinkingLevel?: string;
+		/** Optional role injection: threads role prompt + accessory through the
+		 *  shared session-setup pipeline. Tools are NOT recomputed here (they are
+		 *  already the spawn-verb/read-only-stripped role tools from childAllowedTools). */
+		role?: string;
 		/** NON-SECRET tool-scoping env vars (additive; never widens sandbox/project scope). */
 		env?: Record<string, string>;
 		/** Persisted so the source discriminator survives restart (§3). Default "delegate". */
@@ -541,6 +545,7 @@ export class OrchestrationCore {
 				// restart (§3): rebuildIndexFromPersisted reads childKind to reconstruct
 				// e.g. host-agents children instead of mislabelling them "delegate".
 				childKind,
+				role: opts.role,
 				readOnly: opts.readOnly,
 			});
 			childId = child.id;

--- a/src/server/agent/resolve-role.ts
+++ b/src/server/agent/resolve-role.ts
@@ -16,7 +16,18 @@
  */
 
 import type { PersistedGoal } from "./goal-store.js";
-import type { Role, RoleStore } from "./role-store.js";
+import type { Role } from "./role-store.js";
+
+/**
+ * Minimal structural role source. `RoleStore` is structurally compatible
+ * (it has `get`/`getAll`), so existing callers keep working, but a
+ * cascade-aware source (project→server→builtin→market-packs) can be passed
+ * in too — see `TeamManager.resolveRoleSource`.
+ */
+export interface RoleSource {
+	get(name: string): Role | undefined;
+	getAll(): Role[];
+}
 
 /**
  * Resolve a role by name for a given goal. Returns the inline definition
@@ -32,7 +43,7 @@ import type { Role, RoleStore } from "./role-store.js";
 export function resolveRole(
 	goal: PersistedGoal | undefined,
 	name: string,
-	roleStore: RoleStore | undefined,
+	roleStore: RoleSource | undefined,
 ): Role | undefined {
 	const inline = goal?.inlineRoles?.[name];
 	if (inline) return inline;
@@ -47,7 +58,7 @@ export function resolveRole(
  */
 export function listAvailableRoles(
 	goal: PersistedGoal | undefined,
-	roleStore: RoleStore | undefined,
+	roleStore: RoleSource | undefined,
 ): string[] {
 	const inline = goal?.inlineRoles ? Object.keys(goal.inlineRoles) : [];
 	const stored = roleStore?.getAll().map(r => r.name) ?? [];

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -2729,6 +2729,33 @@ export class SessionManager {
 		return this.roleManager?.getRole(name);
 	}
 
+	/**
+	 * Cascade-aware role source for `{{AVAILABLE_ROLES}}` substitution. The bare
+	 * `RoleManager` view only sees stored roles, so a team-lead prompt rebuilt via
+	 * `getPromptParts` (freshly-created sessions never cache promptParts because
+	 * assemblePrompt runs before the session is registered) would drop market-pack
+	 * roles that the real team-manager prompt lists via the config cascade. This
+	 * source merges cascade roles (incl. server/project market packs) over the
+	 * role-manager view so the reconstructed prompt matches the assembled one.
+	 */
+	private availableRolesSource(projectId: string | undefined): { getAll: () => import("./role-store.js").Role[] } {
+		return {
+			getAll: () => {
+				const seen = new Set<string>();
+				const out: import("./role-store.js").Role[] = [];
+				let cascade: import("./role-store.js").Role[] = [];
+				if (this.configCascade) {
+					try { cascade = this.configCascade.resolveRoles(projectId).map(r => r.item); } catch { cascade = []; }
+				}
+				const mgr = this.roleManager?.listRoles?.() ?? [];
+				for (const r of [...cascade, ...mgr]) {
+					if (!seen.has(r.name)) { seen.add(r.name); out.push(r); }
+				}
+				return out;
+			},
+		};
+	}
+
 	/** Generate tool docs and inject into prompt parts before assembly. */
 	private assemblePrompt(sessionId: string, parts: PromptParts): string | undefined {
 		return profile("sessionManager.assemblePrompt", () => this._assemblePrompt(sessionId, parts));
@@ -2833,7 +2860,29 @@ export class SessionManager {
 		context?: Record<string, string>;
 		allowedTools?: string[];
 		sectionOrder?: string[];
+		/** Role name for a `team_delegate(role: X)` child — surfaces the role
+		 *  promptTemplate in the reconstructed parts (rolePrompt is not persisted). */
+		role?: string;
+		projectId?: string;
+		goalId?: string;
+		sessionId?: string;
 	}): PromptParts {
+		// Role injection (§Gap 2): re-resolve the role prompt cascade-first so a
+		// role-carrying delegate's reconstructed parts (inspector / prompt-sections)
+		// match the assembled system prompt. Role-less delegates leave it undefined.
+		let rolePrompt: string | undefined;
+		if (opts.role) {
+			const template = this.resolveRolePromptTemplate(opts.role, opts.projectId);
+			if (template) {
+				const goalBranch = opts.goalId ? this.resolveGoal(opts.goalId)?.branch : undefined;
+				rolePrompt = resolveRolePrompt({ promptTemplate: template }, {
+					branch: goalBranch,
+					agentId: `${opts.role}-${(opts.sessionId ?? "").slice(0, 8)}`,
+					roleManager: this.availableRolesSource(opts.projectId) as unknown as RoleManager,
+					subGoalsEnabled: this.isSubgoalsEnabled,
+				});
+			}
+		}
 		return {
 			baseSystemPromptPath: this.systemPromptPath,
 			cwd: opts.cwd,
@@ -2844,6 +2893,8 @@ export class SessionManager {
 			// and never duplicates the instructions across Goal + Task.
 			taskTitle: "Delegate Task",
 			taskSpec: this.buildDelegateTaskSpec(opts.instructions, opts.context),
+			rolePrompt,
+			roleName: rolePrompt ? opts.role : undefined,
 			allowedTools: opts.allowedTools,
 			projectConfigStore: this.projectConfigStore,
 			sectionOrder: opts.sectionOrder,
@@ -2875,6 +2926,10 @@ export class SessionManager {
 				context: persisted.context,
 				allowedTools: session.allowedTools ?? persisted.allowedTools,
 				sectionOrder,
+				role: session.role ?? persisted.role,
+				projectId: session.projectId ?? persisted.projectId,
+				goalId: effectiveGoalId,
+				sessionId: session.id,
 			});
 			parts.dynamicContext = session.promptParts?.dynamicContext;
 			if (this.toolManager && !parts.toolDocs) {
@@ -2946,7 +3001,9 @@ export class SessionManager {
 			const rolePrompt = resolveRolePrompt(tmpl ? { promptTemplate: tmpl } : undefined, {
 				branch: goal?.branch,
 				agentId: `${session.role}-${(session.goalId || session.id).slice(0, 8)}`,
-				roleManager: this.roleManager,
+				// Cascade-aware so {{AVAILABLE_ROLES}} in a rebuilt team-lead prompt
+				// lists market-pack roles (matches the team-manager assembled prompt).
+				roleManager: this.availableRolesSource(session.projectId) as unknown as RoleManager,
 				subGoalsEnabled: this.isSubgoalsEnabled,
 			});
 			const roleName = rolePrompt ? session.role : undefined;
@@ -5341,6 +5398,12 @@ export class SessionManager {
 				context: ps.context,
 				allowedTools: restoredAllowedNames,
 				sectionOrder: restoreSectionOrder,
+				// Re-attach a role-carrying delegate's prompt on restart (rolePrompt is
+				// not persisted). Role-less delegates leave it undefined — unchanged.
+				role: ps.role,
+				projectId: ps.projectId,
+				goalId: ps.teamGoalId,
+				sessionId: ps.id,
 			}));
 			if (promptPath) bridgeOptions.systemPromptPath = promptPath;
 		} else {
@@ -5897,6 +5960,16 @@ export class SessionManager {
 		 */
 		readOnly?: boolean;
 		/**
+		 * Optional role injection (`team_delegate(role: X)`). Threads the role's
+		 * promptTemplate + accessory through the SHARED session-setup pipeline (via
+		 * plan.role/roleName/rolePrompt), exactly like the full createSession path.
+		 * Tools are NOT recomputed from the role — `effectiveAllowedTools` already
+		 * carries the spawn-verb/read-only-stripped role tools from the caller
+		 * (OrchestrationCore.childAllowedTools). Role injection must never widen
+		 * a delegate's tools.
+		 */
+		role?: string;
+		/**
 		 * NON-SECRET tool-scoping env vars merged into the child process env
 		 * (additive, alongside the gateway-set BOBBIT_SESSION_ID/SECRET). Used by
 		 * tool policies that read process env (e.g. the pr-walkthrough reviewer's
@@ -5964,9 +6037,31 @@ export class SessionManager {
 			? this.scopedGatewayEnvForDirectAgent(id, parentProjectId, parentEffectiveGoalId)
 			: undefined;
 
+		// Role injection (§Gap 2): resolve the role prompt cascade-first, mirroring
+		// createSession, so a `team_delegate(role: X)` child carries role X's
+		// promptTemplate. Tools are left untouched (already stripped by the caller).
+		let resolvedRolePrompt: string | undefined;
+		if (opts.role) {
+			const template = this.resolveRolePromptTemplate(opts.role, parentProjectId);
+			if (template) {
+				const goalBranch = parentEffectiveGoalId ? this.resolveGoal(parentEffectiveGoalId)?.branch : undefined;
+				resolvedRolePrompt = resolveRolePrompt({ promptTemplate: template }, {
+					branch: goalBranch,
+					agentId: `${opts.role}-${id.slice(0, 8)}`,
+					roleManager: this.roleManager ?? undefined,
+					subGoalsEnabled: this.isSubgoalsEnabled,
+				});
+			}
+		}
+
 		const plan: SessionSetupPlan = {
 			id,
 			mode: "delegate",
+			// Role injection: role/roleName drive the shared role-accessory application
+			// in session-setup; rolePrompt reaches assemblePrompt via _resolvePrompt.
+			role: opts.role,
+			roleName: opts.role,
+			rolePrompt: resolvedRolePrompt,
 			title: titleSummary,
 			cwd: opts.cwd,
 			delegateOf: parentSessionId,

--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -802,6 +802,11 @@ function _resolvePrompt(plan: SessionSetupPlan, ctx: PipelineContext): void {
 			projectRoot: plan.repoPath,
 			taskTitle: "Delegate Task",
 			taskSpec,
+			// Role injection (§Gap 2): a `team_delegate(role: X)` child threads the
+			// role promptTemplate here — same as the normal/worktree branch. A
+			// role-LESS delegate leaves both undefined → byte-identical to before.
+			rolePrompt: plan.rolePrompt,
+			roleName: plan.roleName,
 			allowedTools: plan.effectiveAllowedTools?.map(e => e.name),
 			projectConfigStore: ctx.projectConfigStore ?? undefined,
 			sectionOrder,

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -10,7 +10,7 @@ import { GoalStore, type PersistedGoal } from "./goal-store.js";
 import { createWorktree, cleanupWorktree } from "../skills/git.js";
 import { applyPromptConditionals } from "./prompt-conditionals.js";
 import type { RoleStore, Role } from "./role-store.js";
-import { resolveRole, listAvailableRoles } from "./resolve-role.js";
+import { resolveRole, listAvailableRoles, type RoleSource } from "./resolve-role.js";
 import { GoalPausedError } from "./goal-paused-guard.js";
 import { TeamStore } from "./team-store.js";
 import { bobbitStateDir } from "../bobbit-dir.js";
@@ -247,6 +247,10 @@ export interface TeamManagerConfig {
 	taskManager: TaskManager;
 	/** Role store for looking up role definitions (prompts, accessories, tools) */
 	roleStore?: RoleStore;
+	/** Cascade-aware single-role resolver (project→server→builtin→market-packs). server.ts wires resolveRoleForProject. */
+	resolveRoleForProject?: (roleName: string, projectId?: string) => Role | undefined;
+	/** Cascade-aware all-roles resolver for a project scope. server.ts wires configCascade.resolveRoles(projectId).map(r=>r.item). */
+	resolveRolesForProject?: (projectId?: string) => Role[];
 	/** @deprecated Gate store — resolve per-goal via projectContextManager instead. */
 	gateStore?: GateStore;
 	/** Broadcast a WS event to all clients viewing a goal */
@@ -1654,6 +1658,33 @@ export class TeamManager {
 		return this.taskManager.getTasksForSession(sessionId);
 	}
 
+	/**
+	 * Build a cascade-aware RoleSource scoped to a goal's project. Prefers the
+	 * config-cascade resolvers (project→server→builtin→market-packs) with the
+	 * bare RoleStore as a fallback, de-duplicating by name with cascade
+	 * precedence first. Falls back to the bare RoleStore when no cascade
+	 * resolvers are wired (e.g. in tests).
+	 */
+	private resolveRoleSource(goal: PersistedGoal | undefined): RoleSource {
+		const projectId = goal?.projectId;
+		const one = this.config.resolveRoleForProject;
+		const all = this.config.resolveRolesForProject;
+		if (one || all) {
+			return {
+				get: (name) => one?.(name, projectId) ?? this.config.roleStore?.get(name),
+				getAll: () => {
+					const seen = new Set<string>();
+					const out: Role[] = [];
+					for (const r of [...(all?.(projectId) ?? []), ...(this.config.roleStore?.getAll() ?? [])]) {
+						if (!seen.has(r.name)) { seen.add(r.name); out.push(r); }
+					}
+					return out;
+				},
+			};
+		}
+		return this.config.roleStore ?? { get: () => undefined, getAll: () => [] };
+	}
+
 	/** Resolve a goal across all project contexts. */
 	private resolveGoal(goalId: string): PersistedGoal | undefined {
 		if (this.config.projectContextManager) {
@@ -1720,10 +1751,10 @@ export class TeamManager {
 
 		// Build the Team Lead role prompt with structural placeholders only
 		// Secrets (gateway URL, auth token, goal ID) are passed as env vars, NOT embedded in prompt text
-		const roleStore = this.config.roleStore;
 		// Resolve via the goal's inline-roles snapshot first, then the
-		// project/server/builtin role-store cascade — same precedence as spawnRole().
-		const storedRole = resolveRole(goal, "team-lead", roleStore);
+		// config cascade (project→server→builtin→market-packs) — same precedence as spawnRole().
+		const roleSource = this.resolveRoleSource(goal);
+		const storedRole = resolveRole(goal, "team-lead", roleSource);
 		if (!storedRole) {
 			throw new Error('Role "team-lead" not found. Ensure roles/team-lead.yaml exists.');
 		}
@@ -1732,7 +1763,7 @@ export class TeamManager {
 			teamLeadPromptTemplate
 				.replace(/\{\{GOAL_BRANCH\}\}/g, goal.branch || "main")
 				.replace(/\{\{AGENT_ID\}\}/g, `team-lead-${goalId.slice(0, 8)}`)
-				.replace(/\{\{AVAILABLE_ROLES\}\}/g, buildAvailableRolesList(roleStore)),
+				.replace(/\{\{AVAILABLE_ROLES\}\}/g, buildAvailableRolesList(roleSource)),
 			{ subGoalsEnabled: this.sessionManager.isSubgoalsEnabled },
 		);
 
@@ -1901,14 +1932,14 @@ export class TeamManager {
 		task: string,
 		opts?: { workflowGateId?: string; inputGateIds?: string[] },
 	): Promise<{ sessionId: string; worktreePath?: string }> {
-		const roleStore = this.config.roleStore;
 		// Resolve via the goal's inline-roles snapshot first, then the
-		// project/server/builtin role-store cascade. See resolveRole() and the
-		// PersistedGoal.inlineRoles field doc for the precedence rule.
+		// config cascade (project→server→builtin→market-packs). See resolveRole()
+		// and the PersistedGoal.inlineRoles field doc for the precedence rule.
 		const goalForRole = this.resolveGoal(goalId);
-		const storedRoleDef = resolveRole(goalForRole, role, roleStore);
+		const roleSource = this.resolveRoleSource(goalForRole);
+		const storedRoleDef = resolveRole(goalForRole, role, roleSource);
 		if (!storedRoleDef) {
-			const available = listAvailableRoles(goalForRole, roleStore).join(", ") || "none";
+			const available = listAvailableRoles(goalForRole, roleSource).join(", ") || "none";
 			throw new Error(`Role "${role}" not found. Available roles: ${available}`);
 		}
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2422,6 +2422,8 @@ export function createGateway(config: GatewayConfig) {
 		colorStore,
 		taskManager: new TaskManager(taskStore),
 		roleStore,
+		resolveRoleForProject,
+		resolveRolesForProject: (projectId?: string) => configCascade.resolveRoles(projectId).map(r => r.item),
 		projectContextManager,
 		toolManager,
 		orchestrationCore,

--- a/tests/e2e/market-pack-team-roles.spec.ts
+++ b/tests/e2e/market-pack-team-roles.spec.ts
@@ -1,0 +1,317 @@
+/**
+ * API E2E — TDD reproducing tests for "Market-Pack Roles in Teams".
+ *
+ * These specs pin the two role-plumbing gaps described in the goal's Issue
+ * Analysis gate. They are written FIRST (TDD) and are expected to FAIL on the
+ * current HEAD; the production fix makes them pass.
+ *
+ *   Gap 1 — a team lead inside a goal cannot `team_spawn` a role that exists
+ *           ONLY as a market-pack install, and the pack role is missing from
+ *           the team-lead's {{AVAILABLE_ROLES}} injection. TeamManager resolves
+ *           roles through the bare RoleStore, never the config cascade.
+ *
+ *   Gap 2 — `team_delegate(role: X)` (POST /orchestrate/spawn with a `role`)
+ *           produces a child that has the role's TOOLS but neither the role's
+ *           promptTemplate in its system prompt NOR the role accessory, because
+ *           the bare-delegate spawn path drops role prompt + accessory.
+ *
+ * Plus three regression guards (expected to PASS on current HEAD) that pin the
+ * intentional behaviour differences the fix must NOT regress.
+ *
+ * Every currently-failing assertion carries the distinctive REPRO marker
+ * MARKET_PACK_TEAM_ROLE_REGRESSION so the team lead can wire an expect-failure
+ * gate error_pattern to it.
+ *
+ * The market-pack install/cleanup helpers are copied from
+ * tests/e2e/market-pack-roles-api.spec.ts (same fixture pack, server scope).
+ */
+import { test, expect } from "./in-process-harness.js";
+import { apiFetch, createGoal, startTeam, deleteGoal, teardownTeam, createSession, deleteSession } from "./e2e-setup.js";
+import { pollUntil } from "./test-utils/cleanup.js";
+import { fileURLToPath } from "node:url";
+
+const SOURCE_DIR = fileURLToPath(new URL("../fixtures/market-sources/market-role-fixture-src", import.meta.url));
+const PACK_NAME = "market-role-fixture";
+const ROLE_ID = "fixture-pack-nurse";
+const ROLE_ACCESSORY = "stethoscope";
+const ROLE_PROMPT_MARKER = "FIXTURE_PACK_ROLE_PROMPT";
+const REPRO = "MARKET_PACK_TEAM_ROLE_REGRESSION";
+
+let sourceId: string | undefined;
+
+async function readJson(resp: Response): Promise<any> {
+	const text = await resp.text();
+	try {
+		return text ? JSON.parse(text) : {};
+	} catch {
+		return { raw: text };
+	}
+}
+
+async function addSource(): Promise<string> {
+	const add = await apiFetch("/api/marketplace/sources", {
+		method: "POST",
+		body: JSON.stringify({ url: SOURCE_DIR }),
+	});
+	const text = await add.text();
+	if (add.status === 409) {
+		const list = await apiFetch("/api/marketplace/sources");
+		expect(list.status, `${REPRO}: failed to list existing marketplace sources after source conflict`).toBe(200);
+		const source = ((await list.json()).sources ?? []).find((item: any) => item.url === SOURCE_DIR);
+		expect(source, `${REPRO}: existing marketplace source for fixture pack should be discoverable`).toBeTruthy();
+		return source.id;
+	}
+	expect(add.status, `${REPRO}: failed to register fixture marketplace source; body=${text}`).toBe(201);
+	return JSON.parse(text).source.id;
+}
+
+async function installPack(): Promise<void> {
+	await apiFetch("/api/marketplace/installed", {
+		method: "DELETE",
+		body: JSON.stringify({ scope: "server", packName: PACK_NAME }),
+	}).catch(() => {});
+
+	sourceId = await addSource();
+	const install = await apiFetch("/api/marketplace/install", {
+		method: "POST",
+		body: JSON.stringify({ sourceId, dirName: PACK_NAME, scope: "server" }),
+	});
+	const installText = await install.text();
+	expect(install.status, `${REPRO}: fixture marketplace pack install failed; body=${installText}`).toBe(201);
+
+	const activation = await apiFetch("/api/marketplace/pack-activation", {
+		method: "PUT",
+		body: JSON.stringify({ scope: "server", packName: PACK_NAME, disabled: {} }),
+	});
+	const activationText = await activation.text();
+	expect(activation.status, `${REPRO}: fixture role pack activation refresh failed; body=${activationText}`).toBe(200);
+}
+
+async function uninstallPack(): Promise<void> {
+	await apiFetch("/api/marketplace/installed", {
+		method: "DELETE",
+		body: JSON.stringify({ scope: "server", packName: PACK_NAME }),
+	}).catch(() => {});
+	if (sourceId) {
+		await apiFetch(`/api/marketplace/sources/${encodeURIComponent(sourceId)}`, { method: "DELETE" }).catch(() => {});
+	}
+}
+
+/** Sanity: the fixture role must be visible through GET /api/roles before we
+ *  exercise the team/delegate spawn paths — the whole point is that it lives in
+ *  the config cascade, not the bare RoleStore. */
+async function assertFixtureRoleVisible(): Promise<void> {
+	const res = await apiFetch("/api/roles");
+	const body = await readJson(res);
+	expect(res.status, `${REPRO}: GET /api/roles failed; body=${JSON.stringify(body)}`).toBe(200);
+	const role = (body.roles ?? []).find((item: any) => item.name === ROLE_ID);
+	expect(role, `${REPRO}: fixture market-pack role must be installed + cascade-visible before team/delegate tests`).toBeTruthy();
+	expect(role.accessory).toBe(ROLE_ACCESSORY);
+	expect(String(role.promptTemplate ?? "")).toContain(ROLE_PROMPT_MARKER);
+}
+
+test.describe("market-pack roles in teams", () => {
+	test.beforeAll(async () => {
+		await installPack();
+	});
+
+	test.afterAll(async () => {
+		await uninstallPack();
+	});
+
+	// ────────────────────────────────────────────────────────────────────────
+	// Gap 1 — team lead can team_spawn a market-pack role (CURRENTLY FAILS)
+	// ────────────────────────────────────────────────────────────────────────
+	test("Gap 1: a team lead can team_spawn a market-pack role and the agent carries its prompt + accessory", async ({ gateway }) => {
+		await assertFixtureRoleVisible();
+		const goal = await createGoal({ title: "Team spawns a market-pack role", team: true });
+		let leadId: string | undefined;
+		let workerId: string | undefined;
+		try {
+			leadId = await startTeam(goal.id as string);
+			expect(leadId, `${REPRO}: team lead must start for the goal`).toBeTruthy();
+
+			// team_spawn the pack role via the goal team route. On current HEAD this
+			// 4xx's with "Role not found" because TeamManager.spawnRole resolves via
+			// the bare RoleStore, never the config cascade where pack roles live.
+			const spawn = await apiFetch(`/api/goals/${goal.id}/team/spawn`, {
+				method: "POST",
+				body: JSON.stringify({ role: ROLE_ID, task: "Market-pack role worker — verify prompt + accessory." }),
+			});
+			const spawnBody = await readJson(spawn);
+			expect(
+				spawn.status,
+				`${REPRO}: team_spawn must accept market-pack role ${ROLE_ID} resolved through the config cascade; body=${JSON.stringify(spawnBody)}`,
+			).toBe(201);
+			workerId = spawnBody.sessionId as string;
+			expect(workerId, `${REPRO}: team_spawn of a market-pack role must return a worker session id`).toBeTruthy();
+
+			// The spawned worker carries the pack role's accessory…
+			const accessory = await pollUntil(async () => {
+				return gateway.sessionManager.getPersistedSession(workerId!)?.accessory ?? null;
+			}, { timeoutMs: 5_000, intervalMs: 50, label: "pack-role worker accessory" }).catch(() => undefined);
+			expect(
+				accessory,
+				`${REPRO}: team_spawn'd market-pack worker must use the pack role accessory`,
+			).toBe(ROLE_ACCESSORY);
+
+			// …and the pack role's promptTemplate in its system prompt.
+			const rolePrompt = String(gateway.sessionManager.getPromptParts(workerId!)?.rolePrompt ?? "");
+			expect(
+				rolePrompt,
+				`${REPRO}: team_spawn'd market-pack worker's system prompt must contain the pack role promptTemplate`,
+			).toContain(ROLE_PROMPT_MARKER);
+		} finally {
+			if (workerId) await apiFetch(`/api/goals/${goal.id}/team/dismiss`, { method: "POST", body: JSON.stringify({ sessionId: workerId }) }).catch(() => {});
+			await teardownTeam(goal.id as string).catch(() => {});
+			await deleteGoal(goal.id as string).catch(() => {});
+		}
+	});
+
+	test("Gap 1: the team lead's {{AVAILABLE_ROLES}} lists the installed market-pack role", async ({ gateway }) => {
+		await assertFixtureRoleVisible();
+		const goal = await createGoal({ title: "Team lead sees market-pack role", team: true });
+		let leadId: string | undefined;
+		try {
+			leadId = await startTeam(goal.id as string);
+			expect(leadId, `${REPRO}: team lead must start for the goal`).toBeTruthy();
+
+			// The team-lead prompt bakes {{AVAILABLE_ROLES}} at start time from
+			// buildAvailableRolesList(roleStore). On current HEAD the market-pack role
+			// is absent because the list is built from the bare RoleStore, not the
+			// config cascade.
+			const leadPrompt = String(gateway.sessionManager.getPromptParts(leadId!)?.rolePrompt ?? "");
+			expect(
+				leadPrompt,
+				`${REPRO}: team-lead {{AVAILABLE_ROLES}} must include the installed market-pack role so the lead can spawn it`,
+			).toContain(ROLE_ID);
+		} finally {
+			await teardownTeam(goal.id as string).catch(() => {});
+			await deleteGoal(goal.id as string).catch(() => {});
+		}
+	});
+
+	// ────────────────────────────────────────────────────────────────────────
+	// Gap 2 — team_delegate(role) drops prompt + accessory (CURRENTLY FAILS)
+	// ────────────────────────────────────────────────────────────────────────
+	test("Gap 2: team_delegate(role) child carries the role promptTemplate and accessory", async ({ gateway }) => {
+		await assertFixtureRoleVisible();
+		const parent = await createSession();
+		let childId: string | undefined;
+		try {
+			// Default (bare, shared-worktree) delegate spawn with a role. Tools resolve
+			// cascade-aware today, but the bare path drops role prompt + accessory.
+			const spawn = await apiFetch(`/api/sessions/${parent}/orchestrate/spawn`, {
+				method: "POST",
+				body: JSON.stringify({ instructions: "market-pack role delegate", role: ROLE_ID }),
+			});
+			const spawnBody = await readJson(spawn);
+			expect(
+				spawn.status,
+				`${REPRO}: team_delegate(role) spawn should succeed; body=${JSON.stringify(spawnBody)}`,
+			).toBe(201);
+			childId = spawnBody.childSessionId as string;
+			expect(childId, `${REPRO}: team_delegate(role) must return a child session id`).toBeTruthy();
+
+			// The child's system prompt must contain the role promptTemplate — the
+			// bare delegate path currently never threads rolePrompt to assemblePrompt.
+			const rolePrompt = String(gateway.sessionManager.getPromptParts(childId!)?.rolePrompt ?? "");
+			expect(
+				rolePrompt,
+				`${REPRO}: team_delegate(role) child's system prompt must contain the role promptTemplate`,
+			).toContain(ROLE_PROMPT_MARKER);
+
+			// The child's sidebar entry must show the role accessory — the generic
+			// role-accessory block in session-setup is skipped for the bare path today.
+			const accessory = await pollUntil(async () => {
+				return gateway.sessionManager.getPersistedSession(childId!)?.accessory ?? null;
+			}, { timeoutMs: 5_000, intervalMs: 50, label: "delegate role accessory" }).catch(() => undefined);
+			expect(
+				accessory,
+				`${REPRO}: team_delegate(role) child must persist the role accessory`,
+			).toBe(ROLE_ACCESSORY);
+		} finally {
+			if (childId) await apiFetch(`/api/sessions/${parent}/orchestrate/dismiss`, { method: "POST", body: JSON.stringify({ childSessionId: childId }) }).catch(() => {});
+			await deleteSession(parent);
+		}
+	});
+
+	// ────────────────────────────────────────────────────────────────────────
+	// Regression guards — intentional differences the fix must NOT regress.
+	// These are expected to PASS on current HEAD.
+	// ────────────────────────────────────────────────────────────────────────
+	test("Regression: a role-carrying team_delegate child still has spawn verbs stripped (recursion guard)", async ({ gateway }) => {
+		await assertFixtureRoleVisible();
+		const parent = await createSession();
+		let childId: string | undefined;
+		try {
+			const spawn = await apiFetch(`/api/sessions/${parent}/orchestrate/spawn`, {
+				method: "POST",
+				body: JSON.stringify({ instructions: "recursion-guard role delegate", role: ROLE_ID }),
+			});
+			const spawnBody = await readJson(spawn);
+			expect(spawn.status, `team_delegate(role) spawn should succeed; body=${JSON.stringify(spawnBody)}`).toBe(201);
+			childId = spawnBody.childSessionId as string;
+
+			const persistedTools = gateway.sessionManager.getPersistedSession(childId!)?.allowedTools ?? [];
+			expect(persistedTools.length, "child must have an explicit persisted allow-list").toBeGreaterThan(0);
+			// The recursion guard strips the CHILD-CREATING spawn verbs so a delegate
+			// cannot spawn grandchildren. (team_wait is not a spawn verb — it does not
+			// create children — so it is intentionally NOT stripped; mirrors the existing
+			// team-delegate.spec.ts guard.)
+			for (const verb of ["team_spawn", "team_delegate"]) {
+				expect(persistedTools, `role injection must NOT re-add spawn verb ${verb} to a delegate child`).not.toContain(verb);
+			}
+		} finally {
+			if (childId) await apiFetch(`/api/sessions/${parent}/orchestrate/dismiss`, { method: "POST", body: JSON.stringify({ childSessionId: childId }) }).catch(() => {});
+			await deleteSession(parent);
+		}
+	});
+
+	test("Regression: a read_only role delegate still has all mutating tools stripped", async ({ gateway }) => {
+		await assertFixtureRoleVisible();
+		const parent = await createSession();
+		let childId: string | undefined;
+		try {
+			const spawn = await apiFetch(`/api/sessions/${parent}/orchestrate/spawn`, {
+				method: "POST",
+				body: JSON.stringify({ instructions: "read-only role delegate", role: ROLE_ID, read_only: true }),
+			});
+			const spawnBody = await readJson(spawn);
+			expect(spawn.status, `read_only team_delegate(role) spawn should succeed; body=${JSON.stringify(spawnBody)}`).toBe(201);
+			childId = spawnBody.childSessionId as string;
+
+			const persistedTools = gateway.sessionManager.getPersistedSession(childId!)?.allowedTools ?? [];
+			expect(Boolean(gateway.sessionManager.getPersistedSession(childId!)?.readOnly), "read_only marker persisted").toBe(true);
+			for (const tool of ["write", "edit", "bash", "bash_bg"]) {
+				expect(persistedTools, `read_only role delegate must not regain mutating tool ${tool} via role injection`).not.toContain(tool);
+			}
+			// It keeps read/search tooling.
+			expect(persistedTools, "read_only delegate still keeps read").toContain("read");
+		} finally {
+			if (childId) await apiFetch(`/api/sessions/${parent}/orchestrate/dismiss`, { method: "POST", body: JSON.stringify({ childSessionId: childId }) }).catch(() => {});
+			await deleteSession(parent);
+		}
+	});
+
+	test("Regression: team_spawn stays goal/team-only — it fails without an active goal team", async () => {
+		// team_spawn is a goal/team-lead-only verb (contrast with team_delegate,
+		// which any session can drive via /orchestrate/spawn). At the API surface it
+		// requires a goal WITH an active team; spawning before startTeam must be
+		// rejected. Use a builtin role so resolution succeeds and we reach the
+		// team-context guard (not a role-lookup error).
+		const goal = await createGoal({ title: "team_spawn requires an active team", team: true });
+		try {
+			const spawn = await apiFetch(`/api/goals/${goal.id}/team/spawn`, {
+				method: "POST",
+				body: JSON.stringify({ role: "coder", task: "should be rejected — no active team" }),
+			});
+			const body = await readJson(spawn);
+			expect(spawn.status, `team_spawn without an active team must be rejected; body=${JSON.stringify(body)}`).not.toBe(201);
+			expect(String(body.error ?? body.message ?? ""), "rejection should mention the missing active team").toMatch(/no active team/i);
+		} finally {
+			await teardownTeam(goal.id as string).catch(() => {});
+			await deleteGoal(goal.id as string).catch(() => {});
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Routes all role-carrying spawns through the shared config-cascade role resolution so market-pack roles are spawnable/listed by team leads, and a `team_delegate(role: X)` child shows the role prompt in its system prompt and the role accessory in the sidebar — without regressing the intentional differences between `team_spawn` and `team_delegate`.

### Gap 1 — Market-pack roles usable by team leads inside goals
- `resolve-role.ts`: added structural `RoleSource` interface; widened `resolveRole()`/`listAvailableRoles()` to accept it (precedence unchanged: goal `inlineRoles` → cascade → bare store).
- `team-manager.ts`: new cascade-aware `resolveRoleSource(goal)` (cascade-first, bare-store fallback, de-dup by name) used by `spawnRole()` and the team-lead `{{AVAILABLE_ROLES}}` prompt; also fixed the `getPromptParts` team-lead rebuild path.
- `server.ts`: wired `resolveRoleForProject` + `resolveRolesForProject` (from `configCascade`) into the `TeamManager` config.

### Gap 2 — `team_delegate(role)` carries role prompt + accessory
- `orchestration-core.ts`: threads `role` through the bare `spawn()` → `createDelegateSession`.
- `session-manager.ts`: `createDelegateSession` resolves the role prompt cascade-first and sets `plan.role`/`roleName`/`rolePrompt` (tools left as the pre-stripped list); fixed the delegate `getPromptParts` rebuild path too.
- `session-setup.ts`: delegate branch of `_resolvePrompt` now threads `rolePrompt`/`roleName` into `assemblePrompt`. Accessory applies via the existing generic role-accessory block. Both spawn paths now share the same session-setup role resolution.

### Preserved invariants
`team_spawn` stays goal-only + sub-branch worktree; `team_delegate` stays shared-worktree; recursion guard (spawn verbs stripped) intact; `read_only` mutating-tool stripping intact; sandbox/project scope inheritance unchanged; `ROLE_TOOLS_UNRESOLVED` fail-closed preserved; role-less `team_delegate` unchanged.

## Tests
- New reproducing E2E: `tests/e2e/market-pack-team-roles.spec.ts` (TDD — 3 repro assertions + 3 regression guards).
- Verified: type-check, build, repro spec (6 passed), targeted regressions (market-pack-roles-api, team-delegate, delegate-prompt-sections), full unit (5218 pass) and full E2E green; LLM reviews (gap analysis, code quality, regression coverage, bug hunt, security) + QA passed.

## Docs
Updated `docs/marketplace.md` and `docs/orchestration.md`.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)