### PR TITLE
Consolidate bobbit tools into one group + tier role policies

### DIFF
--- a/defaults/roles/general.yaml
+++ b/defaults/roles/general.yaml
@@ -4,6 +4,12 @@ accessory: none
 toolPolicies:
   Gates: ask
   Tasks: ask
+  # Bobbit gateway tiers. bobbit_orchestrate/bobbit_admin default to
+  # grantPolicy: never (see defaults/tools/bobbit/*.yaml); these per-tool
+  # role grants beat that default (resolveGrantPolicy step 1 > step 5).
+  # general is the only role granted bobbit_admin, and only behind `ask`.
+  bobbit_orchestrate: allow
+  bobbit_admin: ask
 createdAt: 0
 updatedAt: 1775083871266
 promptTemplate: ""

--- a/defaults/roles/team-lead.yaml
+++ b/defaults/roles/team-lead.yaml
@@ -44,6 +44,12 @@ toolPolicies:
   goal_archive_child: always-allow
   goal_decide_mutation: always-allow
   goal_set_policy: always-allow
+  # Bobbit gateway orchestration tier. bobbit_orchestrate defaults to
+  # grantPolicy: never (defaults/tools/bobbit/bobbit_orchestrate.yaml); this
+  # per-tool grant re-enables it for the lead (resolveGrantPolicy step 1 >
+  # step 5). bobbit_admin is intentionally NOT granted here — only `general`
+  # gets it (behind `ask`).
+  bobbit_orchestrate: always-allow
 createdAt: 1773875507369
 updatedAt: 1775088361805
 promptTemplate: |

--- a/defaults/tools/bobbit/bobbit_admin.yaml
+++ b/defaults/tools/bobbit/bobbit_admin.yaml
@@ -5,10 +5,10 @@ params: [operation, projectId?, workflowId?, name?, provider?, scope?, action?, 
 provider:
   type: bobbit-extension
   extension: extension.ts
-group: BobbitAdmin
+group: Bobbit
 grantPolicy: never
 docs: |-
-  Highest-privilege gateway surface: project config, provider keys, custom providers / AI gateway, marketplace install/update/uninstall, tool/role/workflow overrides, destructive maintenance cleanup, sandbox image build, and harness restart/shutdown. Hidden unless a role/project/user policy enables the `BobbitAdmin` group.
+  Highest-privilege gateway surface: project config, provider keys, custom providers / AI gateway, marketplace install/update/uninstall, tool/role/workflow overrides, destructive maintenance cleanup, sandbox image build, and harness restart/shutdown. Hidden unless a role/project/user policy enables the `Bobbit` group.
 detail_docs: >-
   ## Purpose
 
@@ -19,7 +19,7 @@ detail_docs: >-
 
 
   `grantPolicy: never` — registered but hidden unless a role, project, or user
-  tool-group policy explicitly enables the `BobbitAdmin` group. Keep this the
+  tool-group policy explicitly enables the `Bobbit` group. Keep this the
   most conservative tier.
 
 

--- a/defaults/tools/bobbit/bobbit_orchestrate.yaml
+++ b/defaults/tools/bobbit/bobbit_orchestrate.yaml
@@ -5,10 +5,10 @@ params: [operation, goalId?, sessionId?, taskId?, gateId?, projectId?, title?, t
 provider:
   type: bobbit-extension
   extension: extension.ts
-group: BobbitOrchestrate
+group: Bobbit
 grantPolicy: never
 docs: |-
-  Gateway-wide runtime mutations addressed by explicit id (create/update/archive goals, sessions, tasks, gates, staff, team lifecycle). Hidden unless a role/project/user policy enables the `BobbitOrchestrate` group. Complements the current-goal `task_*`/`gate_*`/`team_*` tools — it does not replace them.
+  Gateway-wide runtime mutations addressed by explicit id (create/update/archive goals, sessions, tasks, gates, staff, team lifecycle). Hidden unless a role/project/user policy enables the `Bobbit` group. Complements the current-goal `task_*`/`gate_*`/`team_*` tools — it does not replace them.
 detail_docs: >-
   ## Purpose
 
@@ -19,7 +19,7 @@ detail_docs: >-
 
 
   `grantPolicy: never` — this tool is registered but hidden unless a role,
-  project, or user tool-group policy enables the `BobbitOrchestrate` group.
+  project, or user tool-group policy enables the `Bobbit` group.
 
 
   ## Parameters

--- a/defaults/tools/bobbit/bobbit_read.yaml
+++ b/defaults/tools/bobbit/bobbit_read.yaml
@@ -5,7 +5,7 @@ params: [operation, goalId?, sessionId?, taskId?, projectId?, workflowId?, q?, v
 provider:
   type: bobbit-extension
   extension: extension.ts
-group: BobbitRead
+group: Bobbit
 grantPolicy: allow
 docs: |-
   Read-only, gateway-wide introspection. Pick an `operation` and pass its required ids. Addresses entities by explicit id (not the current goal), so it complements — never replaces — `task_list`/`gate_list`. Returns the gateway's JSON verbatim.

--- a/defaults/tools/bobbit/extension.ts
+++ b/defaults/tools/bobbit/extension.ts
@@ -5,9 +5,12 @@
  * drive the server without hand-rolling `curl`, resolving the gateway URL, or
  * hunting for the auth token:
  *
- *   - `bobbit_read`        (group BobbitRead,        grantPolicy allow) — GET-only introspection
- *   - `bobbit_orchestrate` (group BobbitOrchestrate, grantPolicy never) — runtime state mutations
- *   - `bobbit_admin`       (group BobbitAdmin,        grantPolicy never) — config + destructive maintenance
+ *   - `bobbit_read`        (group Bobbit, grantPolicy allow) — GET-only introspection
+ *   - `bobbit_orchestrate` (group Bobbit, grantPolicy never) — runtime state mutations
+ *   - `bobbit_admin`       (group Bobbit, grantPolicy never) — config + destructive maintenance
+ *
+ * All three share the single `Bobbit` tool-group; tier separation is enforced
+ * purely by each tool's grantPolicy (allow/never/never).
  *
  * Unlike `tasks`/`team`, this is a NORMAL built-in tool group: it does NOT gate
  * on BOBBIT_SESSION_ID / BOBBIT_GOAL_ID. It registers purely on gateway

--- a/docs/bobbit-gateway-tool.md
+++ b/docs/bobbit-gateway-tool.md
@@ -27,11 +27,14 @@ session" is a higher-risk action than "list goals", and "mutate config /
 destroy worktrees" is higher-risk still — separate groups let a user grant read
 broadly, gate orchestration behind confirmation, and keep admin locked down.
 
+All three tools share a single `Bobbit` tool-group; tier separation is
+enforced purely by each tool's `grantPolicy`.
+
 | Tool | Group | Default `grantPolicy` | Scope |
 |---|---|---|---|
-| `bobbit_read` | `BobbitRead` | `allow` | Read-only introspection (GET; no side effects) |
-| `bobbit_orchestrate` | `BobbitOrchestrate` | `never` | Runtime state mutations (goals/sessions/tasks/gates/staff/team lifecycle) |
-| `bobbit_admin` | `BobbitAdmin` | `never` | Config + destructive maintenance (highest privilege) |
+| `bobbit_read` | `Bobbit` | `allow` | Read-only introspection (GET; no side effects) |
+| `bobbit_orchestrate` | `Bobbit` | `never` | Runtime state mutations (goals/sessions/tasks/gates/staff/team lifecycle) |
+| `bobbit_admin` | `Bobbit` | `never` | Config + destructive maintenance (highest privilege) |
 
 ### What `never` means and how to enable a tier
 
@@ -46,16 +49,20 @@ which is `grantPolicy: never` for the same reason.
 
 To enable `bobbit_orchestrate` or `bobbit_admin` for a session, do one of:
 
-- **Tool-group policy** — set the policy for the group to `allow` (or `ask`, for
-  confirm-on-use) at the desired scope: `PUT /api/tool-group-policies/:group`
-  (with `:group` = `BobbitOrchestrate` or `BobbitAdmin`). Read current policies
-  via `GET /api/tool-group-policies`.
-- **Role allowlist** — a role definition can enable a group through its `tools`
-  allowlist or `toolPolicies`.
+- **Tool-group policy** — set the policy for the `Bobbit` group to `allow` (or
+  `ask`, for confirm-on-use) at the desired scope: `PUT
+  /api/tool-group-policies/Bobbit`. Read current policies via `GET
+  /api/tool-group-policies`.
+- **Role allowlist** — a role definition can enable the group through its
+  `tools` allowlist or `toolPolicies`.
 
-Because each tier is a distinct group, a typical setup grants `BobbitRead`
-everywhere, gates `BobbitOrchestrate` behind `ask` for orchestration roles, and
-leaves `BobbitAdmin` at `never` except for a trusted admin role.
+Because all three tiers now live in the single `Bobbit` group, a group-level
+`allow` reveals every tier whose own `grantPolicy` is not `never`. `bobbit_read`
+(`grantPolicy: allow`) is visible by default; `bobbit_orchestrate` and
+`bobbit_admin` stay hidden until the group is enabled *and* their `never`
+default is overridden (e.g. a role that lists the tool explicitly). Grouping
+them together means the group policy can no longer gate the tiers independently
+— that separation now rests entirely on the per-tool `grantPolicy`.
 
 ## Registration model
 

--- a/docs/design/bobbit-gateway-tool.md
+++ b/docs/design/bobbit-gateway-tool.md
@@ -80,9 +80,9 @@ structured error surfacing the gateway `{ error, code }` shape.
 ```
 defaults/tools/bobbit/
   extension.ts             # single ExtensionFactory; registers all 3 tools
-  bobbit_read.yaml         # group: BobbitRead,        grantPolicy: allow
-  bobbit_orchestrate.yaml  # group: BobbitOrchestrate, grantPolicy: never
-  bobbit_admin.yaml        # group: BobbitAdmin,        grantPolicy: never
+  bobbit_read.yaml         # group: Bobbit, grantPolicy: allow
+  bobbit_orchestrate.yaml  # group: Bobbit, grantPolicy: never
+  bobbit_admin.yaml        # group: Bobbit, grantPolicy: never
 ```
 
 - **`extension.ts`** — one default-export `ExtensionFactory`. Resolves
@@ -221,7 +221,7 @@ All paths are verified against `src/server/server.ts` line references (2026-07
 `handleApiRoute()`). `:x` = path segment from a param. Query params are shown
 as `?k=`. "Body" lists the JSON body keys the handler reads.
 
-### 5.1 `bobbit_read` (group `BobbitRead`, all GET)
+### 5.1 `bobbit_read` (group `Bobbit`, all GET)
 
 | operation | method | path | required | optional |
 |---|---|---|---|---|
@@ -269,7 +269,7 @@ as `?k=`. "Body" lists the JSON body keys the handler reads.
 > no server-scope workflow set). We mark `projectId` **required** at the tool
 > layer for a useful result, but the call itself will not error without it.
 
-### 5.2 `bobbit_orchestrate` (group `BobbitOrchestrate`)
+### 5.2 `bobbit_orchestrate` (group `Bobbit`)
 
 | operation | method | path | required | optional / body |
 |---|---|---|---|---|
@@ -306,7 +306,7 @@ as `?k=`. "Body" lists the JSON body keys the handler reads.
   `team_dismiss`, `team_complete`, `team_abort`, `team_steer`, `team_prompt`
   are NOT re-exposed — use the dedicated `team_*` tools.
 
-### 5.3 `bobbit_admin` (group `BobbitAdmin`)
+### 5.3 `bobbit_admin` (group `Bobbit`)
 
 | operation | method | path | required | optional / body |
 |---|---|---|---|---|
@@ -393,13 +393,13 @@ the fields that tier uses — smaller schema, lower budget.
 
 ## 6. Tiering & `grantPolicy`
 
-Each YAML assigns a distinct `group`:
+All three YAMLs share a single `group`; tier separation rests on `grantPolicy`:
 
 | tool | group | grantPolicy |
 |---|---|---|
-| `bobbit_read` | `BobbitRead` | `allow` |
-| `bobbit_orchestrate` | `BobbitOrchestrate` | `never` |
-| `bobbit_admin` | `BobbitAdmin` | `never` |
+| `bobbit_read` | `Bobbit` | `allow` |
+| `bobbit_orchestrate` | `Bobbit` | `never` |
+| `bobbit_admin` | `Bobbit` | `never` |
 
 - `grantPolicy: allow` — available by default wherever the group registers.
 - `grantPolicy: never` — the tool is registered (visible in `/api/tools`) but
@@ -407,11 +407,14 @@ Each YAML assigns a distinct `group`:
   policy explicitly enables its group. Mechanism is identical to
   `session_prompt` (group `Agent`, `grantPolicy: never`).
 
-**Enabling `orchestrate`/`admin` for a role:** set a tool-group policy for
-`BobbitOrchestrate` / `BobbitAdmin` to `allow` (or `ask`) at the desired scope.
-Tool-group policies are read/written via `GET /api/tool-group-policies` and
-`PUT /api/tool-group-policies/:group` (see `src/server/server.ts` ~8354). A
-role definition can also enable specific groups via its `tools` allowlist.
+**Enabling `orchestrate`/`admin` for a role:** set the tool-group policy for
+`Bobbit` to `allow` (or `ask`) at the desired scope. Because all three tiers
+share the one group, the group policy no longer gates the tiers independently
+— that now rests on each tool's `grantPolicy` (`orchestrate`/`admin` stay
+hidden under `never` until a role lists them explicitly). Tool-group policies
+are read/written via `GET /api/tool-group-policies` and `PUT
+/api/tool-group-policies/:group` (see `src/server/server.ts` ~8354). A role
+definition can also enable the group via its `tools` allowlist.
 Because the three tools carry separate groups, a user can grant `read` broadly,
 gate `orchestrate` behind `ask`, and keep `admin` `never` except for a trusted
 admin role.
@@ -500,8 +503,8 @@ Register new files in `tests2/tests-map.json`.
    includes both message and `[CODE]` and HTTP status; 204 → `{ ok:true }`.
 
 6. **`tests2/core/bobbit-tool-tiers.test.ts` (new, bucket: core).** Parse the
-   three YAMLs; assert `group` values (`BobbitRead`/`BobbitOrchestrate`/
-   `BobbitAdmin`) and `grantPolicy` defaults (`allow`/`never`/`never`), and that
+   three YAMLs; assert all share `group: Bobbit`
+   and `grantPolicy` defaults (`allow`/`never`/`never`), and that
    each YAML `params.operation` union matches the operations the extension
    actually dispatches (guard against catalogue drift between YAML docs and
    code).

--- a/market-packs/pr-walkthrough/roles/pr-reviewer.yaml
+++ b/market-packs/pr-walkthrough/roles/pr-reviewer.yaml
@@ -31,9 +31,7 @@ toolPolicies:
   "mcp__": never
   "Agent": never
   "Ask": never
-  "BobbitRead": never
-  "BobbitOrchestrate": never
-  "BobbitAdmin": never
+  "Bobbit": never
   "Browser": never
   "Children": never
   "File System": never

--- a/tests2/core/bobbit-tool-tiers.test.ts
+++ b/tests2/core/bobbit-tool-tiers.test.ts
@@ -47,9 +47,9 @@ const EXPECTED_OPS = {
 } as const;
 
 const EXPECTED_TIERS: Record<string, { group: string; grantPolicy: string; file: string }> = {
-	bobbit_read: { group: "BobbitRead", grantPolicy: "allow", file: "bobbit_read.yaml" },
-	bobbit_orchestrate: { group: "BobbitOrchestrate", grantPolicy: "never", file: "bobbit_orchestrate.yaml" },
-	bobbit_admin: { group: "BobbitAdmin", grantPolicy: "never", file: "bobbit_admin.yaml" },
+	bobbit_read: { group: "Bobbit", grantPolicy: "allow", file: "bobbit_read.yaml" },
+	bobbit_orchestrate: { group: "Bobbit", grantPolicy: "never", file: "bobbit_orchestrate.yaml" },
+	bobbit_admin: { group: "Bobbit", grantPolicy: "never", file: "bobbit_admin.yaml" },
 };
 
 function yamlField(raw: string, key: string): string | undefined {

--- a/tests2/core/role-bobbit-tools-policy.test.ts
+++ b/tests2/core/role-bobbit-tools-policy.test.ts
@@ -1,0 +1,145 @@
+// v2-native — bobbit gateway tier role-policy invariant.
+//
+// Requirement (see defaults/tools/bobbit/*.yaml + docs/bobbit-gateway-tool.md):
+//   • bobbit_orchestrate + bobbit_admin default to grantPolicy: never (hidden
+//     from every session's toolset).
+//   • ONLY the `general` and `team-lead` roles re-grant bobbit_orchestrate
+//     (resolveGrantPolicy step 1 per-tool > step 5 YAML default).
+//   • ONLY `general` gets bobbit_admin, and only behind an `ask` policy.
+// This test pins that surface so a role edit can't silently widen it.
+import { guardProcessEnv } from "./helpers/env-guard.js";
+guardProcessEnv();
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+import YAML from "yaml";
+
+const { resolveGrantPolicy } = await import("../../src/server/agent/tool-activation.ts");
+import type { GroupPolicyProvider } from "../../src/server/agent/tool-activation.ts";
+import type { GrantPolicy } from "../../src/server/agent/role-store.ts";
+
+const DEFAULTS_DIR = path.resolve(import.meta.dirname, "..", "..", "defaults");
+const ROLES_DIR = path.join(DEFAULTS_DIR, "roles");
+const GROUP_POLICIES_FILE = path.join(DEFAULTS_DIR, "tool-group-policies.yaml");
+const BOBBIT_TOOLS_DIR = path.join(DEFAULTS_DIR, "tools", "bobbit");
+
+const BOBBIT_GROUP = "Bobbit";
+
+function loadGroupPolicies(): Record<string, GrantPolicy> {
+	const text = fs.readFileSync(GROUP_POLICIES_FILE, "utf-8");
+	return (YAML.parse(text) ?? {}) as Record<string, GrantPolicy>;
+}
+
+function loadRole(name: string): { toolPolicies?: Record<string, GrantPolicy> } {
+	const text = fs.readFileSync(path.join(ROLES_DIR, `${name}.yaml`), "utf-8");
+	return YAML.parse(text) as { toolPolicies?: Record<string, GrantPolicy> };
+}
+
+/** Top-level role names discovered under defaults/roles. */
+function allRoleNames(): string[] {
+	return fs
+		.readdirSync(ROLES_DIR, { withFileTypes: true })
+		.filter((e) => e.isFile() && e.name.endsWith(".yaml"))
+		.map((e) => e.name.replace(/\.yaml$/, ""));
+}
+
+/** Read a bobbit tool YAML's declared group + grantPolicy default. */
+function bobbitToolDef(toolName: string): { group?: string; grantPolicy?: GrantPolicy } {
+	const def = YAML.parse(fs.readFileSync(path.join(BOBBIT_TOOLS_DIR, `${toolName}.yaml`), "utf-8")) as {
+		group?: string;
+		grantPolicy?: GrantPolicy;
+	};
+	return def;
+}
+
+function defaultGroupPolicyProvider(): GroupPolicyProvider {
+	const raw = loadGroupPolicies();
+	return {
+		getGroupPolicy: (group: string) => raw[group] ?? null,
+		getAll: () => raw,
+		getSubgoalsEnabled: () => true,
+	};
+}
+
+// Minimal ToolManager stub: resolveGrantPolicy step 5 reads the tool YAML's
+// grantPolicy default, so the `never` default is only observable with a manager.
+function bobbitToolManager(): { getToolByName: (name: string) => { grantPolicy?: GrantPolicy; group?: string } | undefined } {
+	return {
+		getToolByName: (name: string) => {
+			if (!name.startsWith("bobbit_")) return undefined;
+			const def = bobbitToolDef(name);
+			return { grantPolicy: def.grantPolicy, group: def.group };
+		},
+	};
+}
+
+describe("bobbit tier YAML defaults", () => {
+	it("bobbit_orchestrate + bobbit_admin default to grantPolicy: never, group Bobbit", () => {
+		for (const tool of ["bobbit_orchestrate", "bobbit_admin"]) {
+			const def = bobbitToolDef(tool);
+			assert.equal(def.grantPolicy, "never", `${tool}.yaml must declare \`grantPolicy: never\``);
+			assert.equal(def.group, BOBBIT_GROUP, `${tool}.yaml must declare \`group: ${BOBBIT_GROUP}\``);
+		}
+	});
+
+	it("bobbit_read stays grantPolicy: allow in group Bobbit", () => {
+		const def = bobbitToolDef("bobbit_read");
+		assert.equal(def.grantPolicy, "allow");
+		assert.equal(def.group, BOBBIT_GROUP);
+	});
+});
+
+describe("bobbit tier resolved role policy", () => {
+	const groupPolicyStore = defaultGroupPolicyProvider();
+	const toolManager = bobbitToolManager();
+
+	const resolve = (tool: string, role: { toolPolicies?: Record<string, GrantPolicy> } | undefined) =>
+		resolveGrantPolicy(tool, BOBBIT_GROUP, role, toolManager as never, groupPolicyStore);
+
+	it("a role with no bobbit grant resolves both tiers to never", () => {
+		const coder = loadRole("coder");
+		assert.equal(resolve("bobbit_orchestrate", coder), "never");
+		assert.equal(resolve("bobbit_admin", coder), "never");
+	});
+
+	it("general resolves bobbit_orchestrate=allow and bobbit_admin=ask", () => {
+		const general = loadRole("general");
+		assert.equal(resolve("bobbit_orchestrate", general), "allow");
+		assert.equal(resolve("bobbit_admin", general), "ask");
+	});
+
+	it("team-lead resolves bobbit_orchestrate=allow and bobbit_admin=never (not granted)", () => {
+		const lead = loadRole("team-lead");
+		assert.equal(resolve("bobbit_orchestrate", lead), "allow");
+		assert.equal(resolve("bobbit_admin", lead), "never");
+	});
+});
+
+describe("bobbit tier grant surface is exactly {general, team-lead} / {general}", () => {
+	const groupPolicyStore = defaultGroupPolicyProvider();
+	const toolManager = bobbitToolManager();
+
+	it("ONLY general + team-lead resolve bobbit_orchestrate to non-never", () => {
+		const granted = allRoleNames().filter(
+			(name) =>
+				resolveGrantPolicy("bobbit_orchestrate", BOBBIT_GROUP, loadRole(name), toolManager as never, groupPolicyStore) !==
+				"never",
+		);
+		assert.deepEqual(granted.sort(), ["general", "team-lead"]);
+	});
+
+	it("ONLY general resolves bobbit_admin to non-never (and it is `ask`)", () => {
+		const granted = allRoleNames().filter(
+			(name) =>
+				resolveGrantPolicy("bobbit_admin", BOBBIT_GROUP, loadRole(name), toolManager as never, groupPolicyStore) !==
+				"never",
+		);
+		assert.deepEqual(granted.sort(), ["general"]);
+		assert.equal(
+			resolveGrantPolicy("bobbit_admin", BOBBIT_GROUP, loadRole("general"), toolManager as never, groupPolicyStore),
+			"ask",
+		);
+	});
+});

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -52,6 +52,10 @@
       "reason": "bobbit gateway tool suite: tier separation — YAML group/grantPolicy defaults and operation-union drift guard vs the dispatched catalogue and design §5."
     },
     {
+      "path": "tests2/core/role-bobbit-tools-policy.test.ts",
+      "reason": "bobbit gateway tier role-policy invariant: bobbit_orchestrate/bobbit_admin default never; ONLY general + team-lead re-grant orchestrate, ONLY general gets admin behind ask."
+    },
+    {
       "path": "tests2/core/cli-real-deps.test.ts",
       "reason": "DI contract: cli.ts passes no test doubles (default-real wiring)."
     },


### PR DESCRIPTION
## Summary

Consolidates the three Bobbit gateway tools into a single `Bobbit` tool-group and layers explicit per-role access policies on the orchestrate/admin tiers.

Previously each tier had its own group (`BobbitRead` / `BobbitOrchestrate` / `BobbitAdmin`). They now share one `Bobbit` group; tier separation rests entirely on each tool's per-tool `grantPolicy` (`allow` / `never` / `never`).

## Access policy

| Tool | Default | `general` | `team-lead` | other roles |
|---|---|---|---|---|
| `bobbit_read` | `allow` | allow | allow | allow |
| `bobbit_orchestrate` | `never` | **allow** | **always-allow** | never |
| `bobbit_admin` | `never` | **ask** | never | never |

`general` is the only role granted `bobbit_admin`, and only behind an `ask` confirmation. This works because a role's per-tool policy (`resolveGrantPolicy` step 1) beats the tool's YAML `never` default (step 5) — no group-policy change needed.

## Changes

- **`defaults/tools/bobbit/*.yaml`** + **`extension.ts`** — all three tools moved to `group: Bobbit`; comments/docs updated.
- **`defaults/roles/general.yaml`** — `bobbit_orchestrate: allow`, `bobbit_admin: ask`.
- **`defaults/roles/team-lead.yaml`** — `bobbit_orchestrate: always-allow`.
- **`market-packs/pr-walkthrough/roles/pr-reviewer.yaml`** — collapsed three group denials into one `Bobbit: never`.
- **`tests2/core/role-bobbit-tools-policy.test.ts`** (new) — pins the exact grant surface: enumerates all roles and asserts only `{general, team-lead}` resolve orchestrate to non-`never`, and only `{general}` resolves admin (to `ask`).
- **`tests2/core/bobbit-tool-tiers.test.ts`** + docs — updated for the single group.

## Testing

- `role-bobbit-tools-policy`, `bobbit-tool-*`, `pr-walkthrough-role-tools-policy`, `role-team-tools-policy`, `role-children-tools-policy`, `guard-v2` — **217 passed**.
- `parity.mjs --scope core` — PASS, 0 orphans.
- `npm run check` — clean.

## Note

Because the tiers now share one group, a group-level policy can no longer gate read/orchestrate/admin independently — that separation is now purely per-tool `grantPolicy`. Default visibility is unchanged.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
