### PR TITLE
Direct-agent admin token

### DIFF
--- a/docs/bobbit-gateway-tool.md
+++ b/docs/bobbit-gateway-tool.md
@@ -174,6 +174,29 @@ Internal / UI-only endpoints (side-panel workspace, review annotations, preview
 mounts, `ext/*` pack surfaces, provider-hooks, proposal drafts, bg-processes)
 are deliberately out of scope.
 
+## Auth: direct vs sandboxed agents (interim rollback)
+
+The token an agent presents to the gateway depends on where it runs:
+
+- **Non-sandboxed ("direct") agents** run directly on the host as the host user
+  and receive the gateway **admin token** as `BOBBIT_TOKEN`. This is a
+  deliberate **interim rollback** to the pre-HQ-split behaviour: a host-resident
+  agent can already read the admin token off disk (`serverSecretsDir()/token`),
+  so handing it over grants no new capability — it just removes the functional
+  friction where direct agents used to 403 with *"sandbox token cannot access
+  this endpoint"* on gateway-wide routes (`bobbit_read`/`bobbit_orchestrate`/
+  `bobbit_admin`, cross-project `read_session`). Wired in
+  `SessionManager.scopedGatewayEnvForDirectAgent` / `applyScopedGatewayCredentials`.
+- **Sandboxed (Docker) agents** are unchanged: they receive a per-project
+  **scoped token** (`SandboxTokenStore` + `mintScopedGatewayToken`) confined by
+  the `isSandboxAllowed()` route whitelist. The admin token is never injected
+  into the container. This is a real security boundary and must stay.
+
+This direct-agent admin-token behaviour is a stop-gap. The longer-term
+direction is a policy-driven, session-authenticated model where the tool's
+grant policy is the authority and the admin token never leaves the server
+(specced separately).
+
 ## Result and error shape
 
 - **Success** — the tool returns the gateway's JSON verbatim.

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -1920,24 +1920,50 @@ export class SessionManager {
 		return scopedToken;
 	}
 
+	/**
+	 * Set gateway credentials on restore/revive/respawn for NON-sandboxed (direct)
+	 * agents. Deliberate interim rollback (pre-HQ-split behaviour): direct agents
+	 * receive the gateway ADMIN token rather than a per-project scoped token. A
+	 * host-resident direct agent already runs as the host user and can read the
+	 * admin token off disk, so this grants no new capability — it only removes the
+	 * functional friction where direct agents 403 on gateway-wide routes. The
+	 * scoped-token boundary that still matters is preserved for sandboxed agents
+	 * (see applySandboxWiring). Pending a policy-driven session-authenticated auth
+	 * model, specced separately. sessionId/projectId/goalId are retained to avoid
+	 * churning call sites.
+	 */
 	private applyScopedGatewayCredentials(
 		bridgeOptions: RpcBridgeOptions,
-		sessionId: string,
-		projectId: string | undefined,
-		goalId?: string,
+		_sessionId: string,
+		_projectId: string | undefined,
+		_goalId?: string,
 	): void {
 		const gwUrl = this.readGatewayUrlForAgent();
 		if (gwUrl) bridgeOptions.gatewayUrl = gwUrl;
-		const scopedToken = this.mintScopedGatewayToken(projectId, sessionId, goalId ?? bridgeOptions.env?.BOBBIT_GOAL_ID);
-		if (scopedToken) bridgeOptions.gatewayToken = scopedToken;
+		const adminToken = readToken();
+		if (adminToken === null) throw new Error("Cannot read gateway admin token for direct agent");
+		bridgeOptions.gatewayToken = adminToken;
 	}
 
-	private scopedGatewayEnvForDirectAgent(sessionId: string, projectId: string | undefined, goalId?: string): Record<string, string> | undefined {
+	/**
+	 * Build the launch env for a NON-sandboxed (direct) agent. Deliberate interim
+	 * rollback (pre-HQ-split behaviour): direct agents receive the gateway ADMIN
+	 * token rather than a per-project scoped token. A host-resident direct agent
+	 * already runs as the host user and can read the admin token off disk, so this
+	 * grants no new capability — it only removes the functional friction where
+	 * direct agents 403 on gateway-wide routes. The scoped-token boundary that
+	 * still matters is preserved for sandboxed agents (see applySandboxWiring).
+	 * Pending a policy-driven session-authenticated auth model, specced
+	 * separately. sessionId/projectId/goalId are retained to avoid churning call
+	 * sites.
+	 */
+	private scopedGatewayEnvForDirectAgent(_sessionId: string, _projectId: string | undefined, _goalId?: string): Record<string, string> | undefined {
 		const env: Record<string, string> = {};
 		const gwUrl = this.readGatewayUrlForAgent();
 		if (gwUrl) env.BOBBIT_GATEWAY_URL = gwUrl;
-		const scopedToken = this.mintScopedGatewayToken(projectId, sessionId, goalId);
-		if (scopedToken) env.BOBBIT_TOKEN = scopedToken;
+		const adminToken = readToken();
+		if (adminToken === null) throw new Error("Cannot read gateway admin token for direct agent");
+		env.BOBBIT_TOKEN = adminToken;
 		return Object.keys(env).length > 0 ? env : undefined;
 	}
 

--- a/tests2/core/cold-restart-reprompt.test.ts
+++ b/tests2/core/cold-restart-reprompt.test.ts
@@ -56,6 +56,8 @@ const { SessionManager } = await import("../../src/server/agent/session-manager.
 const { TeamManager } = await import("../../src/server/agent/team-manager.ts");
 const { registerRpcBridgeFactory } = await import("../../src/server/agent/rpc-bridge.ts");
 const { initPromptDirs } = await import("../../src/server/agent/system-prompt.ts");
+const { loadOrCreateToken } = await import("../../src/server/auth/token.ts");
+loadOrCreateToken(); // seed admin token so direct-agent spawns find it (mirrors server boot)
 
 // assemblePrompt (invoked deep inside restoreSession) writes to
 // <stateDir>/session-prompts — initialise it once so restoreSession runs

--- a/tests2/core/headquarters-no-worktree-runtime.test.ts
+++ b/tests2/core/headquarters-no-worktree-runtime.test.ts
@@ -38,6 +38,8 @@ const { StaffManager } = await import("../../src/server/agent/staff-manager.ts")
 const { registerRpcBridgeFactory } = await import("../../src/server/agent/rpc-bridge.ts");
 const { initPromptDirs } = await import("../../src/server/agent/system-prompt.ts");
 const { resetAgentDirStateForTests } = await import("../../src/server/bobbit-dir.ts");
+const { loadOrCreateToken } = await import("../../src/server/auth/token.ts");
+loadOrCreateToken(); // seed admin token so direct-agent spawns find it (mirrors server boot)
 
 // Ensure the agent-dir singleton reflects THIS file's BOBBIT_DIR even when a
 // fork-mate initialised it first (isolate:false shared fork).

--- a/tests2/core/openrouter-key-bridge-repro.test.ts
+++ b/tests2/core/openrouter-key-bridge-repro.test.ts
@@ -39,8 +39,10 @@ const { PromptQueue } = await import("../../src/server/agent/prompt-queue.ts");
 const { EventBuffer } = await import("../../src/server/agent/event-buffer.ts");
 const { registerRpcBridgeFactory } = await import("../../src/server/agent/rpc-bridge.ts");
 const { initPromptDirs } = await import("../../src/server/agent/system-prompt.ts");
+const { loadOrCreateToken } = await import("../../src/server/auth/token.ts");
 
 initPromptDirs(stateDir);
+loadOrCreateToken(); // seed admin token so direct-agent spawns find it (mirrors server boot)
 
 const FAKE_OPENROUTER_KEY = "sk-or-repro-openrouter-key-never-persist";
 const PINNED_OPENROUTER_MODEL = { provider: "openrouter", id: "anthropic/claude-3.5-sonnet" };

--- a/tests2/core/session-manager-force-abort-grace.test.ts
+++ b/tests2/core/session-manager-force-abort-grace.test.ts
@@ -27,6 +27,8 @@ const { SessionManager } = await import("../../src/server/agent/session-manager.
 const { PromptQueue } = await import("../../src/server/agent/prompt-queue.ts");
 const { EventBuffer } = await import("../../src/server/agent/event-buffer.ts");
 const { registerRpcBridgeFactory } = await import("../../src/server/agent/rpc-bridge.ts");
+const { loadOrCreateToken } = await import("../../src/server/auth/token.ts");
+loadOrCreateToken(); // seed admin token so direct-agent spawns find it (mirrors server boot)
 
 const managers: any[] = [];
 afterEach(() => {

--- a/tests2/integration/direct-agent-admin-token.test.ts
+++ b/tests2/integration/direct-agent-admin-token.test.ts
@@ -1,0 +1,162 @@
+// v2-native — NOT a migrated legacy test. Listed in tests-map.json `v2Native`.
+//
+/**
+ * Pinning test for the "Direct-agent admin token" interim rollback.
+ *
+ * Non-sandboxed ("direct") agents must receive the gateway ADMIN token
+ * (readToken()) as BOBBIT_TOKEN / bridgeOptions.gatewayToken, NOT a per-project
+ * scoped token. Sandboxed (Docker) agents are unchanged — they keep minting a
+ * per-project SCOPED token (distinct from the admin token), preserving the
+ * isSandboxAllowed() boundary.
+ *
+ * The two production methods that build direct-agent credentials
+ * (`scopedGatewayEnvForDirectAgent` used by createSession/createDelegateSession,
+ * and `applyScopedGatewayCredentials` used by restore/revive/respawn) are
+ * private; a full createSession()/createDelegateSession() run needs real git
+ * worktrees + agent spawn, so per the design doc we assert the observable
+ * behaviour of those methods directly via a typed cast, seeding a real
+ * SandboxTokenStore + a temp admin-token file so readToken() returns a known
+ * value. The sandbox path is covered by exercising `mintScopedGatewayToken`
+ * (what applySandboxWiring uses) and asserting the token differs from admin.
+ */
+import { describe, it, afterEach } from "vitest";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { guardProcessEnv } from "../core/helpers/env-guard.js";
+guardProcessEnv();
+
+import { SessionManager } from "../../src/server/agent/session-manager.js";
+import { SandboxTokenStore } from "../../src/server/auth/sandbox-token.js";
+import { readToken } from "../../src/server/auth/token.js";
+
+// A valid admin token must be >= 64 chars (see readToken() in
+// src/server/auth/token.ts). Use a recognisable, length-valid fixture.
+const TEST_ADMIN_TOKEN = "d".repeat(64);
+
+interface Harness {
+	sm: any;
+	stateRoot: string;
+	restore: () => void;
+}
+
+/**
+ * Boot a minimal SessionManager against a temp Headquarters dir. When
+ * `seedToken` is true, a valid admin token is written where readToken() looks
+ * for it (primary serverSecretsDir via BOBBIT_SECRETS_DIR + legacy state-dir
+ * fallback). Env is snapshotted/restored by the returned `restore()`.
+ */
+function makeHarness(opts?: { seedToken?: boolean }): Harness {
+	const seedToken = opts?.seedToken ?? true;
+	const stateRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "direct-token-")));
+	const prevBobbitDir = process.env.BOBBIT_DIR;
+	const prevSecrets = process.env.BOBBIT_SECRETS_DIR;
+	process.env.BOBBIT_DIR = stateRoot;
+
+	const stateDir = path.join(stateRoot, "state");
+	fs.mkdirSync(stateDir, { recursive: true });
+	fs.writeFileSync(path.join(stateDir, "gateway-url"), "https://127.0.0.1:3001\n");
+
+	const secretsDir = path.join(stateRoot, "secrets");
+	fs.mkdirSync(secretsDir, { recursive: true });
+	process.env.BOBBIT_SECRETS_DIR = secretsDir;
+	if (seedToken) {
+		fs.writeFileSync(path.join(secretsDir, "token"), `${TEST_ADMIN_TOKEN}\n`);
+		fs.writeFileSync(path.join(stateDir, "token"), `${TEST_ADMIN_TOKEN}\n`);
+	}
+
+	const sm: any = new SessionManager();
+	// A real store so the sandbox path can still mint a scoped token; direct
+	// paths must NOT consult it.
+	sm.sandboxTokenStore = new SandboxTokenStore();
+
+	const restore = () => {
+		if (prevBobbitDir === undefined) delete process.env.BOBBIT_DIR;
+		else process.env.BOBBIT_DIR = prevBobbitDir;
+		if (prevSecrets === undefined) delete process.env.BOBBIT_SECRETS_DIR;
+		else process.env.BOBBIT_SECRETS_DIR = prevSecrets;
+		try { fs.rmSync(stateRoot, { recursive: true, force: true }); } catch { /* best-effort */ }
+	};
+
+	return { sm, stateRoot, restore };
+}
+
+describe("direct-agent admin token", () => {
+	let current: Harness | undefined;
+	afterEach(() => {
+		current?.restore();
+		current = undefined;
+	});
+
+	it("scopedGatewayEnvForDirectAgent (createSession / createDelegateSession path) returns the ADMIN token", () => {
+		const h = makeHarness();
+		current = h;
+		const admin = readToken();
+		assert.equal(admin, TEST_ADMIN_TOKEN, "readToken() should return the seeded admin token");
+
+		// Simulates createSession's non-sandboxed branch.
+		const sessionEnv = h.sm.scopedGatewayEnvForDirectAgent("sess-1", "proj-1", "goal-1");
+		assert.ok(sessionEnv, "direct-agent env must be defined");
+		assert.equal(sessionEnv.BOBBIT_TOKEN, admin, "direct session BOBBIT_TOKEN must be the admin token");
+		assert.equal(sessionEnv.BOBBIT_GATEWAY_URL, "https://127.0.0.1:3001", "gateway URL wiring must be preserved");
+
+		// Simulates createDelegateSession's non-sandboxed branch (delegate child).
+		const delegateEnv = h.sm.scopedGatewayEnvForDirectAgent("sess-1-child", "proj-1", "goal-1");
+		assert.ok(delegateEnv, "delegate-child env must be defined");
+		assert.equal(delegateEnv.BOBBIT_TOKEN, admin, "delegate child BOBBIT_TOKEN must be the admin token");
+
+		// The store must NOT have been touched by the direct paths (no dead scope
+		// entries) — i.e. the admin token is not a registered scoped token.
+		assert.equal(h.sm.sandboxTokenStore.lookup(sessionEnv.BOBBIT_TOKEN), undefined,
+			"direct token must not be a registered scoped token");
+	});
+
+	it("applyScopedGatewayCredentials (restore / respawn / revive path) sets the ADMIN token", () => {
+		const h = makeHarness();
+		current = h;
+		const admin = readToken();
+
+		const bridgeOptions: any = { env: {} };
+		h.sm.applyScopedGatewayCredentials(bridgeOptions, "sess-2", "proj-1", "goal-1");
+		assert.equal(bridgeOptions.gatewayToken, admin, "restored direct session gatewayToken must be the admin token");
+		assert.equal(bridgeOptions.gatewayUrl, "https://127.0.0.1:3001", "gateway URL wiring must be preserved");
+	});
+
+	it("sandbox path still mints a SCOPED token distinct from the admin token", () => {
+		const h = makeHarness();
+		current = h;
+		const admin = readToken();
+
+		// applySandboxWiring uses mintScopedGatewayToken — the boundary the guard
+		// enforces. It must produce a per-project scoped token, NOT the admin one.
+		const scoped = h.sm.mintScopedGatewayToken("proj-1", "sess-3", "goal-1");
+		assert.ok(scoped, "sandbox path must mint a scoped token");
+		assert.equal(scoped.length, 64, "scoped token is a 64-char hex string");
+		assert.notEqual(scoped, admin, "scoped token must be DISTINCT from the admin token");
+
+		// And it is a real registered scope (so isSandboxAllowed can resolve it).
+		const scope = h.sm.sandboxTokenStore.lookup(scoped);
+		assert.ok(scope, "scoped token must resolve to a registered scope");
+		assert.equal(scope.projectId, "proj-1");
+	});
+
+	it("fails loudly when no admin token is available (no silent fallback)", () => {
+		const h = makeHarness({ seedToken: false });
+		current = h;
+		assert.equal(readToken(), null, "precondition: no admin token on disk");
+
+		assert.throws(
+			() => h.sm.scopedGatewayEnvForDirectAgent("sess-4", "proj-1", "goal-1"),
+			/admin token/i,
+			"direct env must throw when the admin token is unavailable",
+		);
+		const bridgeOptions: any = { env: {} };
+		assert.throws(
+			() => h.sm.applyScopedGatewayCredentials(bridgeOptions, "sess-4", "proj-1", "goal-1"),
+			/admin token/i,
+			"direct credentials must throw when the admin token is unavailable",
+		);
+	});
+});

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -20,6 +20,10 @@
   },
   "v2Native": [
     {
+      "path": "tests2/integration/direct-agent-admin-token.test.ts",
+      "reason": "Pinning test for the 'Direct-agent admin token' interim rollback: non-sandboxed (direct) agents receive the gateway ADMIN token (readToken()) via scopedGatewayEnvForDirectAgent (createSession/createDelegateSession) and applyScopedGatewayCredentials (restore/revive/respawn), while the sandbox path (mintScopedGatewayToken) still produces a per-project SCOPED token distinct from the admin token. Also pins the loud-throw when no admin token is available (no silent fallback)."
+    },
+    {
       "path": "tests2/core/verification-harness-review-reliability.test.ts",
       "reason": "Reproducing test for the 'Fix LLM review reliability' goal: pins per-attempt fresh reviewer session id (transcript not clobbered on retry) and honoring of a verification_result that arrives during teardown (no 404-drop). FAILS on HEAD, passes post-fix. Companion assertions pin the completed-but-missed-tool-call classification (non-transient → no from-scratch re-run) and that within-budget transient failures still retry."
     },


### PR DESCRIPTION
## Summary

Restores the pre-HQ-split behaviour where **non-sandboxed ("direct") agents receive the gateway admin token** as `BOBBIT_TOKEN`, instead of the per-project scoped token introduced by the HQ split (PR #932). This unblocks gateway-wide tool access (`bobbit_read`/`bobbit_orchestrate`/`bobbit_admin`, cross-project `read_session`) for direct agents, which previously 403'd with *"sandbox token cannot access this endpoint"*.

A host-resident direct agent already runs as the host user and can read the admin token off disk, so this grants no new capability — it only removes functional friction. **Sandboxed (Docker) agents are byte-for-byte unchanged**: they keep the per-project scoped token confined by `isSandboxAllowed()`, and the admin token is never injected into the container.

This is a **deliberate interim rollback**, pending a proper policy-driven, session-authenticated auth model (specced separately).

## Changes

- `src/server/agent/session-manager.ts`:
  - `scopedGatewayEnvForDirectAgent()` — direct-agent launch env `BOBBIT_TOKEN` now sourced from `readToken()` (admin) instead of `mintScopedGatewayToken()`; throws loudly if `readToken()` is null.
  - `applyScopedGatewayCredentials()` — restore/revive/respawn `bridgeOptions.gatewayToken` now sourced from `readToken()`; throws loudly if null.
  - `applySandboxWiring()` and `mintScopedGatewayToken()` left untouched — sandbox path still mints per-project scoped tokens.
- New pinning test `tests2/integration/direct-agent-admin-token.test.ts`: direct session/delegate env carries the admin token; restore path carries admin token; sandbox session still carries a distinct scoped token; fails loudly with no admin token.
- Seeded an admin token (`loadOrCreateToken()`, mirroring real server boot) in four bare-`SessionManager` unit tests so the new loud-throw doesn't fire in test harnesses that don't boot a full server.
- `docs/bobbit-gateway-tool.md`: new "Auth: direct vs sandboxed agents (interim rollback)" section documenting the rationale and pointing at the future proper-auth model.

## Testing

- `npm run check` clean.
- New pinning test + scoped-token guard tests (`sandbox-token`, `sandbox-security`, `gate-bypass-api`, `gate-reset-api`) pass unchanged.
- Full implementation-gate suite (build, typecheck, unit, browser, e2e) + LLM reviews + QA passed.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)