### PR TITLE
Fix session menu deep links to use working hash form

### DIFF
--- a/src/app/session-actions.ts
+++ b/src/app/session-actions.ts
@@ -1,7 +1,7 @@
 import { icon } from "@mariozechner/mini-lit";
 import { ExternalLink, FileText, GitFork, Link, Pencil, RotateCcw, Trash2 } from "lucide";
 import type { TemplateResult } from "lit";
-import { copySidebarLink, gatewayFetch, refreshAgentSession, refreshSessions, sessionPathDeepLink, type SidebarCopyLinkTitle } from "./api.js";
+import { copySidebarLink, gatewayFetch, refreshAgentSession, refreshSessions, sessionDeepLink, type SidebarCopyLinkTitle } from "./api.js";
 import { listLauncherEntrypoints, runResolvedLauncherEntrypoint, type LauncherDispatchResult, type SpawnLaunchTarget } from "./pack-entrypoints.js";
 import { confirmAction, showConnectionError, showRenameDialog } from "./dialogs-lazy.js";
 import { setHashRoute } from "./routing.js";
@@ -201,7 +201,7 @@ export function buildArchivedSessionActions(input: BuildArchivedSessionActionsIn
 			run: (event: Event) => {
 				event.preventDefault();
 				event.stopPropagation();
-				void copyLink(sessionPathDeepLink(session.id), "Copy session link");
+				void copyLink(sessionDeepLink(session.id), "Copy session link");
 			},
 		},
 		{
@@ -349,7 +349,7 @@ export function buildSessionActions(input: BuildSessionActionsInput): SessionAct
 			quick: false,
 			run: (event: Event) => {
 				event.stopPropagation();
-				void copyLink(sessionPathDeepLink(session.id), "Copy session link");
+				void copyLink(sessionDeepLink(session.id), "Copy session link");
 			},
 		},
 		{
@@ -484,5 +484,5 @@ function openExternalUrl(url: string): void {
 }
 
 export function openSessionInNewWindow(sessionId: string): void {
-	openExternalUrl(sessionPathDeepLink(sessionId));
+	openExternalUrl(sessionDeepLink(sessionId));
 }

--- a/tests/e2e/ui/copy-session-link.spec.ts
+++ b/tests/e2e/ui/copy-session-link.spec.ts
@@ -174,10 +174,18 @@ test.describe("Copy session link button (UI)", () => {
 				`hash precedence load: HASH_PRECEDENCE_SESSION_URL must not canonicalize conflicting path session ${oldSessionId}`,
 			).not.toBe(`${base()}/#/session/${oldSessionId}`);
 
+			// Copy uses absoluteHashUrl (origin+pathname+search+#/session/<id>). Here the
+			// path entrypoint is intentionally NOT canonicalized, so the copied hash link
+			// retains the current pathname while targeting newSessionId — assert against
+			// the exact form the app builds from the live location.
+			const expectedCopy = await page.evaluate(
+				(id) => `${location.origin}${location.pathname}${location.search}#/session/${id}`,
+				newSessionId,
+			);
 			await clickCopySessionAction(page);
 			await expect(async () => {
 				const clip = await page.evaluate(() => navigator.clipboard.readText());
-				expect(clip).toBe(`${base()}/#/session/${newSessionId}`);
+				expect(clip).toBe(expectedCopy);
 			}).toPass({ timeout: 5_000 });
 		} finally {
 			await deleteSession(oldSessionId).catch(() => { /* best-effort */ });

--- a/tests/e2e/ui/copy-session-link.spec.ts
+++ b/tests/e2e/ui/copy-session-link.spec.ts
@@ -3,8 +3,8 @@
  *
  * Covers the project's hard E2E rule (AGENTS.md):
  *   1. Navigation — open the app, create a session, button visible.
- *   2. Happy path — click → clipboard contains `${origin}/session/<id>`,
- *      and the header-toast ("Link copied") appears.
+ *   2. Happy path — click → clipboard contains `${origin}/#/session/<id>`
+ *      (the hash form), and the header-toast ("Link copied") appears.
  *   3. Persistence across reload — after page.reload() the button is still
  *      present and click still copies.
  */
@@ -74,8 +74,9 @@ test.describe("Copy session link button (UI)", () => {
 
 			// Click and verify clipboard.
 			await clickCopySessionAction(page);
+			// Session links use the hash form (absoluteHashUrl): origin+pathname+search+#/session/<id>.
 			const expectedUrl = await page.evaluate(
-				(id) => `${location.origin}/session/${id}`,
+				(id) => `${location.origin}${location.pathname}${location.search}#/session/${id}`,
 				sessionId,
 			);
 			await expect(async () => {
@@ -122,7 +123,7 @@ test.describe("Copy session link button (UI)", () => {
 		}
 	});
 
-	test("copied path-style session link opens in a fresh full-page load", async ({ page, browser }) => {
+	test("copied session link opens in a fresh full-page load", async ({ page, browser }) => {
 		const sessionId = await createSession();
 		await waitForSessionStatus(sessionId, "idle");
 		const freshContext = await browser.newContext({ permissions: ["clipboard-read", "clipboard-write"] });
@@ -135,10 +136,12 @@ test.describe("Copy session link button (UI)", () => {
 			await expectCopyActionReachable(page);
 			await clickCopySessionAction(page);
 			const copiedUrl = await page.evaluate(() => navigator.clipboard.readText());
-			expect(copiedUrl, "copy action should produce the path-style session URL being fixed").toBe(`${base()}/session/${sessionId}`);
+			expect(copiedUrl, "copy action should produce the hash-style session URL").toBe(`${base()}/#/session/${sessionId}`);
 
+			// The copied link is the hash form; inject the auth token BEFORE the
+			// fragment — a query string after '#' would be swallowed into the hash.
 			const token = await readE2ETokenAsync();
-			await freshPage.goto(`${copiedUrl}?token=${encodeURIComponent(token)}`);
+			await freshPage.goto(`${base()}/?token=${encodeURIComponent(token)}#/session/${sessionId}`);
 			await expectSessionComposer(freshPage, sessionId, "copied path link fresh load");
 			await expectCanonicalSessionHashUrl(freshPage, sessionId, "copied path link fresh load");
 		} finally {
@@ -174,7 +177,7 @@ test.describe("Copy session link button (UI)", () => {
 			await clickCopySessionAction(page);
 			await expect(async () => {
 				const clip = await page.evaluate(() => navigator.clipboard.readText());
-				expect(clip).toBe(`${base()}/session/${newSessionId}`);
+				expect(clip).toBe(`${base()}/#/session/${newSessionId}`);
 			}).toPass({ timeout: 5_000 });
 		} finally {
 			await deleteSession(oldSessionId).catch(() => { /* best-effort */ });

--- a/tests/e2e/ui/open-session-new-window.spec.ts
+++ b/tests/e2e/ui/open-session-new-window.spec.ts
@@ -61,8 +61,9 @@ async function stubWindowOpen(page: Page): Promise<void> {
 	});
 }
 
-function expectedPathDeepLink(page: Page, sessionId: string): Promise<string> {
-	return page.evaluate((id) => `${location.origin}/session/${id}`, sessionId);
+// Session deep links use the hash form (absoluteHashUrl): origin+pathname+search+#/session/<id>.
+function expectedSessionDeepLink(page: Page, sessionId: string): Promise<string> {
+	return page.evaluate((id) => `${location.origin}${location.pathname}${location.search}#/session/${id}`, sessionId);
 }
 
 test.describe("Open session in new window (UI)", () => {
@@ -82,7 +83,7 @@ test.describe("Open session in new window (UI)", () => {
 		await waitForSessionStatus(sessionId, "idle");
 
 		const row = await openSession(page, sessionId);
-		const deepLink = await expectedPathDeepLink(page, sessionId);
+		const deepLink = await expectedSessionDeepLink(page, sessionId);
 		await stubWindowOpen(page);
 
 		await openMenu(row, sessionId);
@@ -110,7 +111,7 @@ test.describe("Open session in new window (UI)", () => {
 		await openSession(page, activeId);
 		const otherRow = sessionRow(page, otherId);
 		await expect(otherRow).toBeVisible({ timeout: 10_000 });
-		const otherDeepLink = await expectedPathDeepLink(page, otherId);
+		const otherDeepLink = await expectedSessionDeepLink(page, otherId);
 		await stubWindowOpen(page);
 
 		// Root cause of the flake: Playwright's real middle-click

--- a/tests2/browser/fixtures/archived-session-actions.spec.ts
+++ b/tests2/browser/fixtures/archived-session-actions.spec.ts
@@ -220,7 +220,7 @@ test.describe("archived session actions", () => {
 		await expect.poll(() => page.evaluate(() => (window as any).bobbitState?.selectedSessionId ?? null), { message: "archived sidebar hamburger must not select the row" }).toBe(selectedBefore);
 
 		await menuItem(page, "copy-link").click();
-		await expect.poll(() => page.evaluate(() => navigator.clipboard.readText()), { timeout: 5_000 }).toBe(`${base()}/session/${archivedId}`);
+		await expect.poll(() => page.evaluate(() => navigator.clipboard.readText()), { timeout: 5_000 }).toBe(`${base()}/#/session/${archivedId}`);
 		await expect.poll(() => page.evaluate(() => window.location.hash), { message: "copy link must not navigate" }).toBe(hashBefore);
 		await closePopover(page);
 
@@ -228,7 +228,7 @@ test.describe("archived session actions", () => {
 		await openArchivedSidebarMenu(page, archivedId);
 		await menuItem(page, "open-new-window").click();
 		await expect.poll(() => page.evaluate(() => (window as any).__opened), { timeout: 5_000 }).toEqual([
-			{ url: `${base()}/session/${archivedId}`, target: "_blank", features: "noopener" },
+			{ url: `${base()}/#/session/${archivedId}`, target: "_blank", features: "noopener" },
 		]);
 		await expect.poll(() => page.evaluate(() => window.location.hash), { message: "open in new window must not navigate in-place" }).toBe(hashBefore);
 		await closePopover(page);

--- a/tests2/browser/fixtures/session-actions.spec.ts
+++ b/tests2/browser/fixtures/session-actions.spec.ts
@@ -513,7 +513,7 @@ test.describe("unified session actions", () => {
 		});
 
 		await clickHeaderAction(page, "copy-link");
-		await expect.poll(() => page.evaluate(() => navigator.clipboard.readText()), { timeout: 5_000 }).toBe(`${base()}/session/${sessionId}`);
+		await expect.poll(() => page.evaluate(() => navigator.clipboard.readText()), { timeout: 5_000 }).toBe(`${base()}/#/session/${sessionId}`);
 
 		await clickHeaderAction(page, "view-system-prompt");
 		await expect(page.locator("system-prompt-dialog").getByText("System Prompt Inspector")).toBeVisible({ timeout: 10_000 });
@@ -521,7 +521,7 @@ test.describe("unified session actions", () => {
 
 		await clickHeaderAction(page, "open-new-window");
 		await expect.poll(() => page.evaluate(() => (window as any).__sessionActionOpenedUrls), { timeout: 5_000 }).toEqual([
-			`${base()}/session/${sessionId}`,
+			`${base()}/#/session/${sessionId}`,
 		]);
 	});
 });

--- a/tests2/browser/journeys/app-smoke.journey.spec.ts
+++ b/tests2/browser/journeys/app-smoke.journey.spec.ts
@@ -357,7 +357,8 @@ test.describe("Journey: Open in New Window", () => {
 			await expect(page.locator("textarea").first()).toBeVisible({ timeout: 15_000 });
 			const row = page.locator(`[data-session-id="${sessionId}"]`).first();
 			await expect(row).toBeVisible({ timeout: 10_000 });
-			const deepLink = await page.evaluate((id) => `${location.origin}/session/${id}`, sessionId);
+			// Session deep links use the hash form (absoluteHashUrl): origin+pathname+search+#/session/<id>.
+			const deepLink = await page.evaluate((id) => `${location.origin}${location.pathname}${location.search}#/session/${id}`, sessionId);
 			// Capture window.open (stub applied right before the action so a render
 			// pass cannot restore the native impl between hover and click).
 			await page.evaluate(() => {

--- a/tests2/browser/journeys/session-lifecycle.journey.spec.ts
+++ b/tests2/browser/journeys/session-lifecycle.journey.spec.ts
@@ -322,7 +322,7 @@ test.describe("Journey: Copy Session Link", () => {
 			}
 
 			// Clipboard should contain the session URL
-			const expectedUrl = `${base()}/session/${sessionId}`;
+			const expectedUrl = `${base()}/#/session/${sessionId}`;
 			await expect.poll(() => page.evaluate(() => navigator.clipboard.readText()), { timeout: 15_000 }).toBe(expectedUrl);
 		} finally {
 			await deleteSession(sessionId).catch(() => {});
@@ -354,7 +354,7 @@ test.describe("Journey: Copy Session Link", () => {
 				test.skip(true, "copy-link not reachable after reload; skipped");
 				return;
 			}
-			const expectedUrl = `${base()}/session/${sessionId}`;
+			const expectedUrl = `${base()}/#/session/${sessionId}`;
 			await expect.poll(() => page.evaluate(() => navigator.clipboard.readText()), { timeout: 15_000 }).toBe(expectedUrl);
 		} finally {
 			await deleteSession(sessionId).catch(() => {});


### PR DESCRIPTION
## Problem

Copying a session link (or "Open in new window") from the session hamburger menu produced a bare-path URL like `https://host/session/<id>` — **no `#`**. That form relies on server SPA-fallback plus `canonicalizePathSessionRoute` to rewrite it to `/#/session/<id>`. The Vite dev server (`:5173`) does not serve `index.html` for that path, so the link lands on nothing before the client router ever runs.

Goal links were unaffected because they already use the hash form (`goalDeepLink` → `absoluteHashUrl`).

## Fix

Point the three session menu actions at `sessionDeepLink()` (hash form, `…/#/session/<id>`) instead of `sessionPathDeepLink()`:

- `session-actions.ts:204` — Copy session link (live)
- `session-actions.ts:352` — Copy session link (archived)
- `session-actions.ts:487` — Open in new window

The hash form works on both the Vite dev server and the gateway, matching the goal-link behaviour. `sessionPathDeepLink()` is left defined in `api.ts` (still valid for server-served path deep-links) but is no longer used by the menus.

## Test

`tsc -p tsconfig.web.json --noEmit` clean. Manually verified `sessionDeepLink()` yields `…/#/session/<id>` (the form confirmed working in-browser).

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)