### PR TITLE
Fix: Support Assistant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ AGENTS.md is loaded into **every** agent turn. Keep it small and general.
 
 - **No specific recipes or debugging entries.** Symptom→fix lookups belong in `docs/debugging.md`; how-to-do-X belongs in the relevant `docs/<topic>.md`. Agents discover them via the "Before editing" search step above.
 - **No invariant prose pretending to prevent regressions.** Write the test that pins it instead.
-- Keep this file under ~5 KB. If it grows, the new content probably belongs in `docs/`.
+- Keep it small; new content usually belongs in `docs/`.
 
 ## Reference docs
 

--- a/docs/support-assistant.md
+++ b/docs/support-assistant.md
@@ -1,10 +1,9 @@
 # Support Assistant
 
-The **Support Assistant** is a built-in Bobbit agent you launch from Headquarters
-to ask "how do I…" questions about Bobbit itself — *before* you go to the
-maintainers. It answers in plain language, grounds every answer in Bobbit's own
-documentation and source, and — after you explicitly agree — can apply
-server-side changes on your behalf by driving the running gateway.
+The **Support Assistant** is a built-in Bobbit agent for "how do I…" questions
+about Bobbit itself. It answers in plain language, grounds every answer in
+Bobbit's docs and source, and — after you explicitly agree — can apply
+server-side changes by driving the running gateway.
 
 ## Why it exists
 
@@ -15,29 +14,58 @@ experienced users alike hit questions like "how do I start a new session?",
 projects?". The Support Assistant closes the gap between *asking a question* and
 *getting the change made*:
 
-- It **answers** the question, grounded in the actual docs and code (no guessing).
+- It **answers** the question, grounded in the actual docs and code.
 - Where the answer is a server-side setting, it **offers to make the change for
-  you** rather than leaving you to hunt through the UI or the REST API.
+  you** rather than leaving you to hunt through the UI or REST API.
 
 This lowers the support burden on maintainers and gives users a self-service
 first stop that understands Bobbit's real behaviour.
 
 ## Launching it
 
-The Support Assistant is launched from a dedicated **`LifeBuoy` icon button**
-labelled *Support*, positioned immediately to the **left of the QR-code button**
-in both the desktop sidebar header and the mobile header.
+The Support Assistant is launched from a dedicated Lucide
+`MessageCircleQuestion` icon button positioned immediately to the **left of the
+QR-code button** in both the desktop sidebar header and the mobile header. The
+button title is `Open a new support agent session`.
 
-The button is **only visible when Headquarters is the active project**. Because
-support is a server-wide concern (it operates the whole gateway, not one repo),
-it lives in Headquarters — Bobbit's built-in server workspace (see
-[Headquarters](headquarters.md)). Switch to a normal project and the launcher
-disappears.
+The launcher is visible whenever the **Show Headquarters in project lists**
+preference is enabled (`showHeadquartersInProjectLists !== false`). It is not
+limited to the currently active project: if a normal project is active, the
+button still appears and still opens Support in Headquarters. If the preference
+is disabled, the launcher is hidden along with the Headquarters shortcut.
 
-Clicking it starts a `support` assistant session inside Headquarters and
-connects you to it. The session opens with a short greeting inviting your
-question — it has no goal, worktree, or task board; it is a plain conversational
-assistant with the gateway tools attached.
+Clicking the launcher starts a `support` assistant session in Headquarters and
+connects you to it. Support is a server-wide concern — it operates the gateway,
+not one repository — so sessions always target Headquarters even when launched
+from another project. The launcher uses the same sizing and spacing as the
+sibling header controls (`h-6 w-6` where the compact desktop controls need an
+explicit class), and its `data-testid` wrapper uses `display: contents` so it
+does not add an extra flex gap.
+
+A new Support session opens automatically with a short capability overview. The
+opening reply explains that it can answer Bobbit questions from docs/source,
+make confirmed gateway changes, gives a few example questions, and then invites
+your question.
+
+## Session titles
+
+Support and the other built-in assistant chats start with a short type prefix and
+auto-rename after the first **genuine user message**:
+
+| Assistant type | Initial title | Generated title shape |
+|---|---|---|
+| Goal | `New Goal` | `New Goal: <summary>` |
+| Role | `New Role` | `New Role: <summary>` |
+| Tool | `New Tool` | `New Tool: <summary>` |
+| Staff | `New Staff` | `New Staff: <summary>` |
+| Project | `New Project` | `New Project: <summary>` |
+| Support | `Support` | `Support: <summary>` |
+
+The automatic kickoff prompt is marked non-title-generating, so titles are based
+on what the user actually asks rather than on boilerplate startup text. Restored
+assistant sessions that already have a generated title keep it; sessions still
+showing the bare prefix remain eligible for the first real user message to name
+them.
 
 ## Confirmation-first behaviour
 
@@ -73,9 +101,9 @@ gateway tool suite. Access is tiered by privilege:
 
 | Tier | Tool | What it does | Availability to Support |
 |---|---|---|---|
-| Read | `bobbit_read` | Introspect goals, sessions, projects, tasks, gates, config, health. No side effects. | Always allowed (used freely to check state). |
-| Orchestrate | `bobbit_orchestrate` | Mutate runtime state: goals, sessions, tasks, gates, staff, team lifecycle. | Allowed (still gated by confirmation-first). |
-| Admin | `bobbit_admin` | Config + destructive maintenance: `update_project_config`, provider keys, marketplace, `harness_restart`, `shutdown`. | Behind `ask` (confirm on every use). |
+| Read | `bobbit_read` | Introspect goals, sessions, projects, tasks, gates, config, health. No side effects. | Always allowed; used freely to check state. |
+| Orchestrate | `bobbit_orchestrate` | Mutate runtime state: goals, sessions, tasks, gates, staff, team lifecycle. | Allowed, still gated by confirmation-first. |
+| Admin | `bobbit_admin` | Config and destructive maintenance: project config, provider keys, marketplace, restart, shutdown. | Behind `ask`, so every use requires confirmation. |
 
 The `bobbit_admin` tier is the most powerful and includes destructive
 operations, which is why it is kept behind an `ask` policy in addition to the
@@ -86,16 +114,20 @@ rationale behind the tier split, see
 Worked examples of the intended behaviour:
 
 - *"How do I start a new session?"* → explains the steps.
+- *"How do workflows and gates work?"* → answers from the docs and source.
 - *"Can I turn off worktree pools for all my projects?"* → explains it is a
   per-project config change, then offers to apply it across every project via
   `bobbit_admin.update_project_config`.
+- *"Can you archive my finished goals?"* → inspects the current goals, explains
+  the proposed archive set, and asks before calling a mutating tool.
 
 ### Client-only state is guided, not applied
 
 Some appearance and UI state (for example, theme choices stored in the browser)
 is **client-only** — it lives in the browser, not on the server, so the gateway
 tools cannot change it. For those, the Support Assistant explains the steps and
-guides you to make the change yourself in the UI rather than offering to apply it.
+guides you to make the change yourself in the UI rather than offering to apply
+it.
 
 ## Constraints
 
@@ -105,51 +137,63 @@ via the `bobbit` tools. But it has one firm boundary:
 
 - **It must never edit or commit Bobbit's source code.** It reads docs and
   source for reference only — no `write`/`edit` on source files, and no
-  `git commit`/`git push`. Its `bash` access is read-only inspection
-  (`rg`, `cat`, `git log`, `git status`, and similar). The *only* way it changes
-  state is through the `bobbit` gateway tools.
+  `git commit`/`git push`. Its `bash` access is read-only inspection (`rg`,
+  `cat`, `git log`, `git status`, and similar). The *only* way it changes state
+  is through the `bobbit` gateway tools.
 
 ## How it works
 
-A developer-oriented summary of the moving parts. For the full design — file
-paths, signatures, and the partition plan — see
-[docs/design/support-assistant.md](design/support-assistant.md).
+A developer-oriented summary of the moving parts:
 
-- **Assistant type.** `support` is registered in the assistant registry
-  (`src/server/agent/assistant-registry.ts`, `FALLBACK_DEFAULTS`) with session
-  title *Support* and prompt title *Bobbit Support Assistant*. Its prompt lives
-  in a dedicated module (`src/server/agent/support-assistant.ts`,
-  `SUPPORT_ASSISTANT_PROMPT`), mirroring the other assistant prompt modules. It
-  reuses the existing assistant session machinery, so a support session gets no
-  goal or worktree.
+- **Assistant type.** `support` is registered in the assistant registry with the
+  title prefix `Support` and prompt title `Bobbit Support Assistant`. It reuses
+  the existing assistant session machinery, so a support session gets no goal,
+  worktree, or task board. The same registry field that provides the initial
+  title also provides the auto-rename prefix.
 
-- **Role.** `defaults/roles/support.yaml` defines the `support` role with
-  `accessory: headset` and per-tool grants that layer over the tool defaults:
-  `bobbit_orchestrate: allow` and `bobbit_admin: ask` (`bobbit_read` needs no
-  entry — its `allow` default already applies). These role policies beat the
-  `grantPolicy: never` defaults on the orchestrate/admin tool YAMLs.
+- **Why this stays an assistant type.** Support intentionally keeps the
+  `assistantType: "support"` path instead of launching as a plain role. That path
+  injects `{{BOBBIT_DOCS_DIR}}`, `{{BOBBIT_SRC_DIR}}`, and `{{AGENT_ID}}` into
+  the prompt at resolution time. Headquarters sessions often run from the
+  Headquarters workspace rather than the Bobbit package directory, especially
+  for npm-installed or offline users, so a plain role spawn would not reliably
+  know where the bundled docs and source live.
 
-- **Type → role mapping.** `assistantRoleForType()` in the assistant registry
-  maps the `support` assistant type to the `support` role; every other assistant
-  type resolves the read-only advisor `assistant` role. This is what gives the
-  support session its elevated `bobbit` tool grants.
+- **Prompt composition.** The session prompt has a dedicated `Role: support`
+  section containing the `support` role's `promptTemplate`, plus a separate
+  `Goal` section containing the Support Assistant prompt with bundled path
+  substitutions applied. Keeping these sections separate matches normal role
+  spawns and keeps the role template from being folded into or duplicated inside
+  the assistant prompt. Other assistant types use the same split with
+  `Role: assistant` and their own assistant-specific `Goal` prompt.
 
-- **Offline docs + source packaging.** `package.json` `files` ships `docs/` and
-  `src/` in the npm tarball (tests are excluded). At runtime,
-  `src/server/agent/bundled-paths.ts` resolves the absolute `docs/` and `src/`
-  paths from `import.meta.url` — working both in this repo (running from source)
-  and from a built, installed package layout, where the session's cwd is the
-  user's workspace rather than the package root. Those absolute paths are
-  substituted into the support prompt via the `{{BOBBIT_DOCS_DIR}}` and
-  `{{BOBBIT_SRC_DIR}}` placeholders at prompt-resolution time, so the agent knows
-  exactly where to read from.
+- **Role metadata and tool policies.** `assistantRoleForType()` is the single
+  source of truth for assistant-type-to-role mapping: `support` resolves to the
+  `support` role, while the other assistant types resolve to the advisor
+  `assistant` role. For Support, the persisted session metadata is therefore
+  `session.role === "support"` and `session.accessory === "headset"`, matching
+  the Role Manager. Setting the resolved role on the plan also means the role's
+  tool policies apply: `bobbit_orchestrate: allow` and `bobbit_admin: ask`.
 
-- **Launcher UI.** The `LifeBuoy` button in `src/app/render.ts` (both the desktop
-  sidebar header and the mobile header, each gated on
-  `isHeadquartersProject(...)`, carrying `data-testid="support-launcher"`) calls
-  `showSupportDialog()` in `src/app/dialogs.ts`, which `POST`s
-  `/api/sessions { assistantType: "support", projectId: HEADQUARTERS_PROJECT_ID }`
-  and connects to the new session.
+- **Support role.** `defaults/roles/support.yaml` defines the `support` role with
+  `accessory: headset` and per-tool grants that layer over the tool defaults.
+  `bobbit_read` needs no entry because its `allow` default already applies. The
+  support role's prompt carries the hard constraints against editing source code
+  or acting without confirmation.
+
+- **Offline docs and source packaging.** The npm package ships `docs/` and
+  `src/`. At runtime, bundled path resolution finds their absolute locations
+  from the package module URL, working both in this repository and from an
+  installed package. Those absolute paths are substituted into the support prompt
+  so the agent reads the right files without depending on the current working
+  directory.
+
+- **Launcher flow.** The client renders the `MessageCircleQuestion` launcher
+  when Headquarters is visible in project lists. The dialog posts a new session
+  with `assistantType: "support"` and the Headquarters project id, then connects
+  to that session. The client also sends the non-title-generating support kickoff
+  prompt, `Start the support session.`, so the agent greets with its capability
+  overview.
 
 ## See also
 
@@ -157,5 +201,5 @@ paths, signatures, and the partition plan — see
   suite the Support Assistant uses to apply changes.
 - [Headquarters](headquarters.md) — the server workspace the Support Assistant
   runs in.
-- [docs/design/support-assistant.md](design/support-assistant.md) — the full
-  design doc.
+- [Support Assistant design](design/support-assistant.md) — implementation
+  history and original partitioning notes.

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -969,7 +969,7 @@ export class RemoteAgent {
 
 	// ── Agent commands (proxied to gateway) ──────────────────────────
 
-	async prompt(input: string | any | any[], _images?: any[]): Promise<void> {
+	async prompt(input: string | any | any[], _images?: any[], promptOpts?: { suppressTitleGen?: boolean }): Promise<void> {
 		this._clearProviderAuthRequired();
 		this.emit({ type: "render" });
 		let text: string;
@@ -1030,6 +1030,9 @@ export class RemoteAgent {
 			text,
 			...(imageData?.length ? { images: imageData } : {}),
 			...(attachments?.length ? { attachments } : {}),
+			// Assistant auto-kickoff prompts must not seed the session title —
+			// naming fires on the first genuine user message instead.
+			...(promptOpts?.suppressTitleGen ? { suppressTitleGen: true } : {}),
 		});
 	}
 

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -8,7 +8,7 @@ import { html, render, nothing } from "lit";
 import { repeat } from "lit/directives/repeat.js";
 import type Sortable from "sortablejs";
 import { shortcutHint } from "./shortcut-registry.js";
-import { AlertTriangle, Archive, ArrowLeft, ExternalLink, FolderPlus, LifeBuoy, Menu, MessagesSquare, ChevronDown, Goal as GoalIcon, PanelRightClose, PanelRightOpen, Plus, QrCode, RotateCw, Server, Settings, Store, Unplug, Users, Workflow as WorkflowIcon, Wrench, X, Zap } from "lucide";
+import { AlertTriangle, Archive, ArrowLeft, ExternalLink, FolderPlus, MessageCircleQuestion, Menu, MessagesSquare, ChevronDown, Goal as GoalIcon, PanelRightClose, PanelRightOpen, Plus, QrCode, RotateCw, Server, Settings, Store, Unplug, Users, Workflow as WorkflowIcon, Wrench, X, Zap } from "lucide";
 import {
 	state,
 	renderApp,
@@ -2307,13 +2307,13 @@ export function doRenderApp(): void {
 		return html`
 			<div class="flex items-center gap-1 px-2">
 				${settingsBtn}
-				${isHeadquartersProject(state.activeProjectId)
-					? html`<span data-testid="support-launcher">${Button({
+				${state.showHeadquartersInProjectLists !== false
+					? html`<span data-testid="support-launcher" style="display:contents">${Button({
 						variant: "ghost",
 						size: "sm",
-						children: html`${icon(LifeBuoy, "sm")}`,
+						children: html`${icon(MessageCircleQuestion, "sm")}`,
 						onClick: () => { showSupportDialog(); },
-						title: "Support",
+						title: "Open a new support agent session",
 					})}</span>`
 					: nothing}
 				${Button({
@@ -3134,13 +3134,13 @@ export function doRenderApp(): void {
 							<span class="text-base font-semibold text-foreground">Bobbit</span>
 						</div>
 						<div class="flex items-center" style="gap:1px;margin-right:-4px">
-							${isHeadquartersProject(state.activeProjectId)
-								? html`<span data-testid="support-launcher">${Button({
+							${state.showHeadquartersInProjectLists !== false
+								? html`<span data-testid="support-launcher" style="display:contents">${Button({
 									variant: "ghost",
 									size: "sm",
-									children: html`${icon(LifeBuoy, "xs")}`,
+									children: html`${icon(MessageCircleQuestion, "xs")}`,
 									onClick: () => { showSupportDialog(); },
-									title: "Support",
+									title: "Open a new support agent session",
 									className: "h-6 w-6 text-muted-foreground",
 								})}</span>`
 								: nothing}

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -1533,6 +1533,7 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			tool: "Start the tool assistant session. Help me document, improve, or create tools.",
 			staff: "Start the staff agent creation session.",
 			setup: "Start the project setup session.",
+			support: "Start the support session.",
 		};
 		if (options?.assistantType && !isExisting) {
 			let autoPrompt: string | undefined;
@@ -1554,7 +1555,9 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			} else {
 				autoPrompt = AUTO_PROMPTS[options.assistantType];
 			}
-			if (autoPrompt) remote.prompt(autoPrompt);
+			// The kickoff is the assistant's FIRST message. Flag it non-title-generating
+			// so auto-naming keys off the first GENUINE user message, not the kickoff.
+			if (autoPrompt) remote.prompt(autoPrompt, undefined, { suppressTitleGen: true });
 		}
 
 		// Apply restored model (already resolved or resolving in parallel)

--- a/src/server/agent/assistant-registry.ts
+++ b/src/server/agent/assistant-registry.ts
@@ -29,6 +29,22 @@ export interface AssistantDef {
 	title: string;
 	promptTitle: string;
 	prompt: string;
+	/**
+	 * Short prefix used for BOTH the initial session title (shown before the
+	 * first message) AND the auto-rename prefix, so the two always agree. After
+	 * the first genuine user message an assistant session is renamed to
+	 * `"<titlePrefix>: <AI summary>"`.
+	 */
+	titlePrefix: string;
+}
+
+/**
+ * Compose an assistant session title from its type prefix and an AI-generated
+ * summary. Pure + tiny so the `"<prefix>: <summary>"` shape is unit-testable
+ * without a running gateway.
+ */
+export function composeAssistantTitle(titlePrefix: string, summary: string): string {
+	return `${titlePrefix}: ${summary}`;
 }
 
 /** Hardcoded fallback defaults used when YAML files don't exist on disk. */
@@ -38,42 +54,49 @@ const FALLBACK_DEFAULTS: Record<string, AssistantDef> = {
 		title: "Goal Assistant",
 		promptTitle: "Goal Creation Assistant",
 		prompt: GOAL_ASSISTANT_PROMPT,
+		titlePrefix: "New Goal",
 	},
 	role: {
 		type: "role",
 		title: "Role Assistant",
 		promptTitle: "Role Creation Assistant",
 		prompt: ROLE_ASSISTANT_PROMPT,
+		titlePrefix: "New Role",
 	},
 	tool: {
 		type: "tool",
 		title: "Tool Assistant",
 		promptTitle: "Tool Management Assistant",
 		prompt: TOOL_ASSISTANT_PROMPT,
+		titlePrefix: "New Tool",
 	},
 	staff: {
 		type: "staff",
 		title: "Staff Assistant",
 		promptTitle: "Staff Agent Creation Assistant",
 		prompt: STAFF_ASSISTANT_PROMPT,
+		titlePrefix: "New Staff",
 	},
 	project: {
 		type: "project",
 		title: "Project Assistant",
 		promptTitle: "Project Registration Assistant",
 		prompt: PROJECT_ASSISTANT_PROMPT,
+		titlePrefix: "New Project",
 	},
 	"project-scaffolding": {
 		type: "project-scaffolding",
 		title: "Project Scaffolding Assistant",
 		promptTitle: "New Project Setup Assistant",
 		prompt: PROJECT_ASSISTANT_SCAFFOLDING_PROMPT,
+		titlePrefix: "New Project",
 	},
 	support: {
 		type: "support",
 		title: "Support",
 		promptTitle: "Bobbit Support Assistant",
 		prompt: SUPPORT_ASSISTANT_PROMPT,
+		titlePrefix: "Support",
 	},
 };
 
@@ -103,6 +126,7 @@ function loadYamlDef(filePath: string): AssistantDef | undefined {
 				title: data.title || data.type,
 				promptTitle: data.promptTitle || data.title || data.type,
 				prompt: data.prompt,
+				titlePrefix: data.titlePrefix || FALLBACK_DEFAULTS[data.type]?.titlePrefix || data.title || data.type,
 			};
 		}
 	} catch {
@@ -176,6 +200,7 @@ export function updateAssistantDef(
 		title: updates.title ?? existing.title,
 		promptTitle: updates.promptTitle ?? existing.promptTitle,
 		prompt: updates.prompt ?? existing.prompt,
+		titlePrefix: existing.titlePrefix,
 	};
 
 	// Write to disk

--- a/src/server/agent/prompt-queue.ts
+++ b/src/server/agent/prompt-queue.ts
@@ -20,6 +20,7 @@ export class PromptQueue {
 		images?: Array<{ type: "image"; data: string; mimeType: string }>;
 		attachments?: unknown[];
 		isSteered?: boolean;
+		suppressTitleGen?: boolean;
 	}): QueuedMessage {
 		const msg: QueuedMessage = {
 			id: randomUUID(),
@@ -29,6 +30,7 @@ export class PromptQueue {
 		};
 		if (opts?.images?.length) msg.images = opts.images;
 		if (opts?.attachments?.length) msg.attachments = opts.attachments;
+		if (opts?.suppressTitleGen) msg.suppressTitleGen = true;
 
 		this.queue.push(msg);
 		if (msg.isSteered) this.reorder();

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -38,7 +38,7 @@ import { SessionSecretStore } from "../auth/session-secret.js";
 import { redactSensitive } from "../auth/redact.js";
 import { readToken } from "../auth/token.js";
 import { shouldKeepDespiteOrphan, scanOrphanedTranscripts } from "./orphan-cleanup.js";
-import { getAssistantDef, assistantRoleForType } from "./assistant-registry.js";
+import { getAssistantDef, assistantRoleForType, composeAssistantTitle } from "./assistant-registry.js";
 import { resolveBundledDocsDir, resolveBundledSrcDir } from "./bundled-paths.js";
 import { buildReattemptContext } from "./goal-assistant.js";
 import { assembleSystemPrompt, cleanupSessionPrompt, persistPromptSections, purgePromptSectionsJson, type PromptParts } from "./system-prompt.js";
@@ -3022,13 +3022,15 @@ export class SessionManager {
 		let parts: PromptParts;
 
 		if (assistantDef) {
-			const assistantTemplate = this.resolveRolePromptTemplate(assistantRoleForType(session.assistantType), session.projectId);
-			let assistantGoalSpec = "";
-			if (assistantTemplate) {
-				assistantGoalSpec = assistantTemplate.replace(/\{\{AGENT_ID\}\}/g, `assistant-${(session.goalId || session.id).slice(0, 8)}`);
-				assistantGoalSpec += "\n\n---\n\n";
-			}
-			assistantGoalSpec += assistantDef.prompt;
+			// Mirror the spawn/restore paths: the backing role's template is a
+			// dedicated "Role" section (rolePrompt/roleName), NOT folded into Goal,
+			// so the reconstructed prompt-sections snapshot matches what was spawned.
+			const assistantRoleName = assistantRoleForType(session.assistantType);
+			const assistantTemplate = this.resolveRolePromptTemplate(assistantRoleName, session.projectId);
+			const assistantRolePrompt = assistantTemplate
+				? assistantTemplate.replace(/\{\{AGENT_ID\}\}/g, `assistant-${(session.goalId || session.id).slice(0, 8)}`)
+				: undefined;
+			let assistantGoalSpec = assistantDef.prompt;
 			if (session.assistantType === "goal") {
 				assistantGoalSpec = assistantGoalSpec.replace('{{AVAILABLE_WORKFLOWS}}', this._buildWorkflowList(session.projectId));
 				// Inject re-attempt context if this is a re-attempt session
@@ -3055,6 +3057,8 @@ export class SessionManager {
 				goalSpec: assistantGoalSpec,
 				goalTitle: assistantDef.promptTitle,
 				goalState: "active",
+				rolePrompt: assistantRolePrompt,
+				roleName: assistantRoleName,
 				allowedTools: session.allowedTools,
 				projectConfigStore: this.projectConfigStore,
 				sectionOrder,
@@ -3190,6 +3194,11 @@ export class SessionManager {
 		 *  RpcBridge.promptWhenReady, so the boot-resume nudge actually lands
 		 *  instead of timing out on the default 30s. */
 		coldStart?: boolean;
+		/** When true, this prompt must NOT trigger first-message auto-title
+		 *  generation. Set for assistant auto-kickoff prompts so naming fires on
+		 *  the first GENUINE user message rather than the kickoff text. Does NOT
+		 *  mark the session titleGenerated, so the next real prompt still names it. */
+		suppressTitleGen?: boolean;
 	}): Promise<{ status: "dispatched" | "queued" }> {
 		let session = this.sessions.get(sessionId);
 		if (!session) return { status: "queued" };
@@ -3285,6 +3294,7 @@ export class SessionManager {
 					images: opts?.images,
 					attachments: opts?.attachments,
 					isSteered: opts?.isSteered,
+					suppressTitleGen: opts?.suppressTitleGen,
 				});
 				this.broadcastQueue(session);
 				return { status: "queued" };
@@ -3312,7 +3322,9 @@ export class SessionManager {
 			session.transientRetryAttempts = 0;
 
 			// Title generation uses the user-visible original text (better UX).
-			this.tryGenerateTitleFromPrompt(sessionId, text);
+			// Skip for suppressed kickoff prompts so naming fires on the first
+			// genuine user message instead.
+			if (!opts?.suppressTitleGen) this.tryGenerateTitleFromPrompt(sessionId, text);
 
 			// Blank-text poison: the live process's in-memory history still holds
 			// the committed blank ContentBlock, so dispatching this follow-up to
@@ -3349,7 +3361,7 @@ export class SessionManager {
 		// before awaiting rpcClient.prompt(): Pi 0.77 OpenAI/Codex preflight can be
 		// slow, and clients/API polling must see the turn as in-flight immediately.
 		if (session.status === "idle" && session.promptQueue.isEmpty) {
-			this.tryGenerateTitleFromPrompt(sessionId, text);
+			if (!opts?.suppressTitleGen) this.tryGenerateTitleFromPrompt(sessionId, text);
 			await this.dispatchDirectPrompt(session, dispatchText, opts?.images, opts?.attachments, !!opts?.isSteered, !!opts?.coldStart);
 			return { status: "dispatched" };
 		}
@@ -3362,6 +3374,7 @@ export class SessionManager {
 			images: opts?.images,
 			attachments: opts?.attachments,
 			isSteered: opts?.isSteered,
+			suppressTitleGen: opts?.suppressTitleGen,
 		});
 		this.broadcastQueue(session);
 
@@ -3773,8 +3786,10 @@ export class SessionManager {
 		this.broadcastQueue(session);
 		if (!next) return;
 
-		// Title generation for the first real prompt
-		this.tryGenerateTitleFromPrompt(session.id, next.text);
+		// Title generation for the first real prompt. Suppressed kickoff prompts
+		// (assistant auto-kickoff) never seed the title — naming fires on the
+		// first genuine user message.
+		if (!next.suppressTitleGen) this.tryGenerateTitleFromPrompt(session.id, next.text);
 
 		// Track for retry
 		session.lastPromptText = next.text;
@@ -5421,14 +5436,16 @@ export class SessionManager {
 		// Re-assemble system prompt (global + AGENTS.md + goal spec)
 		const assistantDef = ps.assistantType ? getAssistantDef(ps.assistantType) : undefined;
 		if (assistantDef) {
-			// Combine assistant role's shared prompt with per-type specialized prompt
-			const assistantTemplate = this.resolveRolePromptTemplate(assistantRoleForType(ps.assistantType), ps.projectId);
-			let assistantGoalSpec = "";
-			if (assistantTemplate) {
-				assistantGoalSpec = assistantTemplate.replace(/\{\{AGENT_ID\}\}/g, `assistant-${(ps.goalId || ps.id).slice(0, 8)}`);
-				assistantGoalSpec += "\n\n---\n\n";
-			}
-			assistantGoalSpec += assistantDef.prompt;
+			// Mirror the spawn path (session-setup.ts): the backing role's template
+			// is rendered as its OWN dedicated "Role" section via rolePrompt/roleName
+			// below — NOT folded into the Goal section — so restored assistant
+			// sessions keep the same Role/Goal split as freshly-spawned ones.
+			const assistantRoleName = assistantRoleForType(ps.assistantType);
+			const assistantTemplate = this.resolveRolePromptTemplate(assistantRoleName, ps.projectId);
+			const assistantRolePrompt = assistantTemplate
+				? assistantTemplate.replace(/\{\{AGENT_ID\}\}/g, `assistant-${(ps.goalId || ps.id).slice(0, 8)}`)
+				: undefined;
+			let assistantGoalSpec = assistantDef.prompt;
 			if (ps.assistantType === "goal") {
 				assistantGoalSpec = assistantGoalSpec.replace('{{AVAILABLE_WORKFLOWS}}', this._buildWorkflowList(ps.projectId));
 				// Inject re-attempt context if this is a re-attempt session
@@ -5454,6 +5471,8 @@ export class SessionManager {
 				goalSpec: assistantGoalSpec,
 				goalTitle: assistantDef.promptTitle,
 				goalState: "active",
+				rolePrompt: assistantRolePrompt,
+				roleName: assistantRoleName,
 				allowedTools: restoredAllowedNames,
 				projectConfigStore: this.projectConfigStore,
 				sectionOrder: restoreSectionOrder,
@@ -5557,7 +5576,13 @@ export class SessionManager {
 			eventBuffer,
 			unsubscribe: () => {},
 			isCompacting: false,
-			titleGenerated: ps.title !== "New session",
+			// Assistant sessions: a title still equal to the bare type prefix (e.g.
+			// "Support", "New Goal") is not yet generated — stay eligible so the first
+			// genuine user message renames it; a renamed title ("<prefix>: …") must NOT
+			// regenerate. Non-assistant sessions keep the "New session" rule.
+			titleGenerated: assistantDef?.titlePrefix
+				? ps.title !== assistantDef.titlePrefix
+				: ps.title !== "New session",
 			goalId: ps.goalId,
 			assistantType: ps.assistantType,
 			delegateOf: ps.delegateOf,
@@ -7572,8 +7597,13 @@ export class SessionManager {
 
 	private async autoGenerateTitleFromText(session: SessionInfo, userText: string): Promise<void> {
 		const messages = [{ role: "user", content: userText }];
-		const title = await generateSessionTitle(messages, this.getTitleGenOptions());
-		if (title) {
+		const summary = await generateSessionTitle(messages, this.getTitleGenOptions());
+		if (summary) {
+			// Assistant sessions keep a type prefix (e.g. "Support: <summary>",
+			// "New Goal: <summary>") so the rename stays identifiable; the prefix
+			// matches the initial session title. Non-assistant sessions are unchanged.
+			const titlePrefix = session.assistantType ? getAssistantDef(session.assistantType)?.titlePrefix : undefined;
+			const title = titlePrefix ? composeAssistantTitle(titlePrefix, summary) : summary;
 			session.title = title;
 			this.resolveStoreForSession(session.id).update(session.id, { title });
 			broadcast(session.clients, { type: "session_title", sessionId: session.id, title });

--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -739,17 +739,23 @@ function _resolvePrompt(plan: SessionSetupPlan, ctx: PipelineContext): void {
 	applyDisabledToolsFilter(plan, disabledTools);
 
 	if (assistantDef) {
-		// Assistant sessions (goal/role/tool/support assistants)
-		const assistantRole = lookupRole(assistantRoleForType(plan.assistantType), plan, ctx);
-		let assistantGoalSpec = "";
-		if (assistantRole?.promptTemplate) {
-			assistantGoalSpec = assistantRole.promptTemplate.replace(
+		// Assistant sessions (goal/role/tool/staff/project/support assistants).
+		// The backing role (support -> `support`, else -> advisor `assistant`) is
+		// rendered as its OWN dedicated "Role" section via rolePrompt/roleName
+		// below — NOT folded into the "Goal" section. `assistantRoleForType` stays
+		// the single source of truth for the assistant-type -> role mapping.
+		const resolvedRoleName = assistantRoleForType(plan.assistantType);
+		const assistantRole = lookupRole(resolvedRoleName, plan, ctx);
+		const assistantRolePrompt = assistantRole?.promptTemplate
+			? assistantRole.promptTemplate.replace(
 				/\{\{AGENT_ID\}\}/g,
 				`assistant-${(plan.goalId || plan.id).slice(0, 8)}`,
-			);
-			assistantGoalSpec += "\n\n---\n\n";
-		}
-		assistantGoalSpec += assistantDef.prompt;
+			)
+			: undefined;
+		// The Goal section carries ONLY the assistant-specific prompt (with its
+		// own substitutions applied below); the role template lives solely in the
+		// Role section, so it is never emitted twice.
+		let assistantGoalSpec = assistantDef.prompt;
 		if (plan.assistantType === "goal") {
 			assistantGoalSpec = assistantGoalSpec.replace("{{AVAILABLE_WORKFLOWS}}", ctx.buildWorkflowList(plan.projectId));
 			if (plan.reattemptGoalId) {
@@ -769,6 +775,12 @@ function _resolvePrompt(plan: SessionSetupPlan, ctx: PipelineContext): void {
 		assistantGoalSpec = applyPromptConditionals(assistantGoalSpec, {
 			subGoalsEnabled: ctx.groupPolicyStore?.getSubgoalsEnabled?.() ?? false,
 		});
+
+		// Enforce the backing role's tool policies via the activation cascade:
+		// resolveToolActivation keys off plan.roleName (support gains
+		// bobbit_orchestrate:allow / bobbit_admin:ask; the advisor `assistant`
+		// role has empty toolPolicies -> no behavioural change for the others).
+		plan.roleName = resolvedRoleName;
 
 		// Use assistant role's tool restrictions
 		if (assistantRole && ctx.toolManager) {
@@ -790,6 +802,10 @@ function _resolvePrompt(plan: SessionSetupPlan, ctx: PipelineContext): void {
 			goalSpec: assistantGoalSpec,
 			goalTitle: assistantDef.promptTitle,
 			goalState: "active",
+			// Emit the backing role's promptTemplate as a dedicated "Role" section
+			// (source: "Role: <roleName>"), matching the normal/delegate branches.
+			rolePrompt: assistantRolePrompt,
+			roleName: resolvedRoleName,
 			allowedTools: plan.effectiveAllowedTools?.map(e => e.name),
 			projectConfigStore: ctx.projectConfigStore ?? undefined,
 			sectionOrder,
@@ -1485,7 +1501,10 @@ async function spawnAgent(plan: SessionSetupPlan, ctx: PipelineContext): Promise
 
 	const session: SessionInfo = {
 		id: plan.id,
-		title: assistantDef?.title ?? (plan.mode === "delegate"
+		// Assistant sessions start with the type's short titlePrefix (e.g.
+		// "New Goal", "Support"); after the first genuine user message
+		// tryGenerateTitleFromPrompt renames to "<titlePrefix>: <summary>".
+		title: assistantDef?.titlePrefix ?? (plan.mode === "delegate"
 			? `⚡${plan.title}`
 			: plan.title),
 		cwd: effectiveCwd,
@@ -1502,7 +1521,10 @@ async function spawnAgent(plan: SessionSetupPlan, ctx: PipelineContext): Promise
 		// "PR Walkthrough") must NOT be clobbered by first-prompt auto-title generation
 		// (tryGenerateTitleFromPrompt skips when titleGenerated is true). createSession
 		// defaults plan.title to "New session", so any other value is a deliberate title.
-		titleGenerated: !!assistantDef || plan.mode === "delegate" || (!!plan.title && plan.title !== "New session"),
+		// Assistant sessions are NOT force-marked generated: they keep their bare
+		// titlePrefix until the first genuine user message renames them
+		// "<titlePrefix>: <summary>" (the auto-kickoff prompt is suppressed).
+		titleGenerated: plan.mode === "delegate" || (!!plan.title && plan.title !== "New session"),
 		goalId: plan.goalId,
 		teamGoalId: plan.teamGoalId,
 		teamLeadSessionId: plan.teamLeadSessionId,

--- a/src/server/agent/support-assistant.ts
+++ b/src/server/agent/support-assistant.ts
@@ -15,11 +15,12 @@ You are Bobbit's built-in Support assistant. Users come to you *before* the main
 
 ## First message
 
-When the session starts, greet the user briefly and invite their question. Something like:
+The session opens with an automatic kickoff. Your FIRST reply is a concise capability overview — not just "hi". Briefly explain what you can do for the user:
 
-"Hi — I'm Bobbit's support assistant. Ask me how to do anything in Bobbit, and I can often make the change for you. What do you need help with?"
+- Answer "how do I…" questions about Bobbit, grounded in its own docs and source.
+- With your confirmation, make changes on your behalf via the gateway — e.g. change project config like worktree pools, or manage sessions and goals.
 
-Keep it to 1-2 sentences.
+Give 2-3 concrete example questions (e.g. "How do I turn off worktree pools?", "How do workflows and gates work?", "Can you archive my finished goals?"), then invite the user's question. Keep it to a short paragraph plus a few bullets — do not act yet.
 
 ## Grounding your answers
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -568,7 +568,7 @@ import { buildConflictsFor, type ConflictWire, type PackScope, type PackEntry } 
 import { isSafeBasename } from "./agent/pack-manifest.js";
 import { gatewayMcpActivationContributionId, gatewayMcpRuntimeKey } from "./agent/mcp-gateway-runtime-identity.js";
 
-import { initAssistantRegistry } from "./agent/assistant-registry.js";
+import { initAssistantRegistry, assistantRoleForType } from "./agent/assistant-registry.js";
 import {
 	deleteProposalFile,
 	editProposalFile,
@@ -6519,11 +6519,18 @@ async function handleApiRoute(
 				readOnly: typeof body?.readOnly === "boolean" ? body.readOnly : undefined,
 			});
 
-			// Set assistant role metadata if no explicit role was provided
+			// Set assistant role metadata if no explicit role was provided.
+			// Role-aware: resolve the backing role via `assistantRoleForType` (the
+			// single source of truth) and read its accessory from the resolved role
+			// definition (support -> `support` + `headset`; other assistants ->
+			// `assistant` + `wand`). Never hardcode the accessory string.
 			if (!createOpts?.role && assistantType) {
-				sessionManager.updateSessionMeta(session.id, { role: "assistant", accessory: "wand" });
-				session.role = "assistant";
-				session.accessory = "wand";
+				const resolvedRoleName = assistantRoleForType(assistantType);
+				const resolvedRole = resolveRoleForProject(resolvedRoleName, resolvedProjectId);
+				const resolvedAccessory = resolvedRole?.accessory ?? "wand";
+				sessionManager.updateSessionMeta(session.id, { role: resolvedRoleName, accessory: resolvedAccessory });
+				session.role = resolvedRoleName;
+				session.accessory = resolvedAccessory;
 			}
 
 			// Store reattemptGoalId on the session if provided

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -820,6 +820,8 @@ export function handleWebSocketConnection(
 						skillExpansions: expansions.length ? expansions : undefined,
 						fileMentions: wireFileMentions,
 						modelText: modelChanged ? mergedModelText : undefined,
+						// Assistant auto-kickoff prompts opt out of first-message title-gen.
+						suppressTitleGen: msg.suppressTitleGen === true,
 					});
 					break;
 				}

--- a/src/server/ws/protocol.ts
+++ b/src/server/ws/protocol.ts
@@ -54,6 +54,12 @@ export interface QueuedMessage {
 	attachments?: unknown[];
 	isSteered: boolean;
 	createdAt: number;
+	/**
+	 * When true, this prompt must NOT trigger first-message auto-title
+	 * generation (used for assistant auto-kickoff prompts so naming fires on
+	 * the first genuine user message instead of the kickoff text).
+	 */
+	suppressTitleGen?: boolean;
 }
 
 export interface SessionCostSnapshot {
@@ -93,7 +99,7 @@ export type ClientMessage =
 	// unspoofable browser authority signal; endpoint auth still comes from the bearer
 	// token plus server-side session/surface/capability checks.
 	| { type: "auth"; token: string; clientKind?: "app" | "extension-channel" }
-	| { type: "prompt"; text: string; images?: Array<{ type: "image"; data: string; mimeType: string }>; attachments?: unknown[] }
+	| { type: "prompt"; text: string; images?: Array<{ type: "image"; data: string; mimeType: string }>; attachments?: unknown[]; suppressTitleGen?: boolean }
 	| { type: "steer"; text: string }
 	| { type: "steer_queued"; messageId: string }
 	| { type: "remove_queued"; messageId: string }

--- a/tests2/browser/journeys/support-launcher.journey.spec.ts
+++ b/tests2/browser/journeys/support-launcher.journey.spec.ts
@@ -1,21 +1,23 @@
 /**
  * Journey: Support Launcher — v2 browser smoke
  *
- * Covers the Headquarters-only "Support" launcher (goal: Support Assistant, §5):
- *   - LifeBuoy icon Button wrapped in <span data-testid="support-launcher"> with
- *     title="Support", rendered in BOTH the desktop sidebar header and the mobile
- *     header, immediately to the LEFT of the QR-code button (title="Show QR code").
- *   - Rendered ONLY when isHeadquartersProject(state.activeProjectId) — hidden for
- *     normal projects, visible when Headquarters is the active project.
+ * Covers the "Support" launcher (goal: Support Assistant fix-up, Defects 1-4):
+ *   - MessageCircleQuestion (help / message-question) icon Button wrapped in
+ *     <span data-testid="support-launcher" style="display:contents"> with
+ *     title="Open a new support agent session", rendered in BOTH the desktop
+ *     sidebar header and the mobile header, immediately to the LEFT of the
+ *     QR-code button (title="Show QR code").
+ *   - Rendered whenever Headquarters is shown in project lists
+ *     (state.showHeadquartersInProjectLists !== false) — visible even when a
+ *     NON-Headquarters project is active; hidden ONLY when the
+ *     "Show Headquarters in project lists" preference is off.
+ *   - The desktop launcher Button matches its QR sibling's sizing (h-6 w-6).
  *   - Clicking it POSTs /api/sessions { assistantType:"support",
- *     projectId:"headquarters" } and connects to the new session.
+ *     projectId:"headquarters" } and connects to the new session — even when a
+ *     non-HQ project is the active project.
  *
- * state.activeProjectId becomes "headquarters" via applyProjectPalette(session.projectId)
- * when connecting to a session whose project is Headquarters (session-manager.ts) — so
- * these tests make HQ active by creating + navigating to a Headquarters-project session.
- * (Requires Headquarters to be present in the client project list, i.e. the
- * showHeadquartersInProjectLists preference — see setHeadquartersVisible below — because
- * applyProjectPalette only sets activeProjectId for a project that exists in state.projects.)
+ * The wrapper span uses display:contents so it does not add a flex box; assert
+ * visibility / geometry / title / classes on the inner <button>.
  */
 import type { Page } from "@playwright/test";
 import { test, expect, openApp, navigateToHash, createSession, deleteSession, waitForSessionStatus, apiFetch } from "../_helpers/journey-fixture.js";
@@ -24,8 +26,13 @@ const HEADQUARTERS_PROJECT_ID = "headquarters";
 const DESKTOP = { width: 1280, height: 800 };
 const MOBILE = { width: 375, height: 667 };
 
+/** The testid wrapper (display:contents span). Use for presence/absence. */
 const launcher = (page: Page) => page.locator('[data-testid="support-launcher"]').first();
+/** The actual clickable Button inside the launcher. Use for visibility/geometry/title. */
+const launcherBtn = (page: Page) => page.locator('[data-testid="support-launcher"] button').first();
 const qrButton = (page: Page) => page.locator('button[title="Show QR code"]').first();
+
+const SUPPORT_TITLE = "Open a new support agent session";
 
 async function setHeadquartersVisible(visible: boolean): Promise<void> {
 	const resp = await apiFetch("/api/preferences", {
@@ -43,19 +50,20 @@ async function centerX(loc: import("@playwright/test").Locator): Promise<number>
 }
 
 /**
- * Create a Headquarters-project session and navigate to it so
- * state.activeProjectId becomes "headquarters" (the launcher's gate).
+ * Create a default (non-Headquarters) project session and navigate to it so
+ * state.activeProjectId is NOT "headquarters" — proving the launcher no longer
+ * depends on the active project being Headquarters.
  * Returns the created session id (caller cleans up).
  */
-async function openHeadquartersSession(page: Page): Promise<string> {
-	const sessionId = await createSession({ projectId: HEADQUARTERS_PROJECT_ID });
+async function openNonHqSession(page: Page): Promise<string> {
+	const sessionId = await createSession();
 	await waitForSessionStatus(sessionId, "idle");
 	await navigateToHash(page, `#/session/${sessionId}`);
 	await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 20_000 });
-	// Confirm the app considers Headquarters the active project.
+	// Confirm the app does NOT consider Headquarters the active project.
 	await expect
 		.poll(() => page.evaluate(() => (window as any).bobbitState?.activeProjectId ?? null), { timeout: 15_000 })
-		.toBe(HEADQUARTERS_PROJECT_ID);
+		.not.toBe(HEADQUARTERS_PROJECT_ID);
 	return sessionId;
 }
 
@@ -64,83 +72,90 @@ test.describe("Journey: Support Launcher", () => {
 		await setHeadquartersVisible(true);
 	});
 
-	test("launcher is hidden when a normal (non-HQ) project is active", async ({ page }) => {
+	test("launcher is visible (left of QR) with a non-HQ project active when Headquarters is enabled (desktop)", async ({ page }) => {
 		await page.setViewportSize(DESKTOP);
-		// A default-project session keeps the active project non-Headquarters.
-		const sessionId = await createSession();
-		await waitForSessionStatus(sessionId, "idle");
+		let session: string | undefined;
 		try {
 			await openApp(page);
-			await navigateToHash(page, `#/session/${sessionId}`);
-			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 20_000 });
+			session = await openNonHqSession(page);
 
-			// Sanity: active project is NOT headquarters for a default-project session.
-			await expect
-				.poll(() => page.evaluate(() => (window as any).bobbitState?.activeProjectId ?? null), { timeout: 15_000 })
-				.not.toBe(HEADQUARTERS_PROJECT_ID);
+			// Present + visible even though the active project is NOT Headquarters.
+			await expect(launcher(page)).toHaveCount(1);
+			await expect(launcherBtn(page)).toBeVisible({ timeout: 15_000 });
 
-			// The QR button is present (proves the header rendered) but the launcher is absent.
-			await expect(qrButton(page)).toBeVisible({ timeout: 15_000 });
-			await expect(page.locator('[data-testid="support-launcher"]')).toHaveCount(0);
-		} finally {
-			await deleteSession(sessionId).catch(() => {});
-		}
-	});
+			// Descriptive tooltip.
+			await expect(launcherBtn(page)).toHaveAttribute("title", SUPPORT_TITLE);
 
-	test("launcher is visible left of the QR button under Headquarters (desktop)", async ({ page }) => {
-		await page.setViewportSize(DESKTOP);
-		let hqSession: string | undefined;
-		try {
-			await openApp(page);
-			hqSession = await openHeadquartersSession(page);
+			// Renders an icon (message-question) — assert an svg is present.
+			await expect(launcherBtn(page).locator("svg").first()).toBeVisible({ timeout: 15_000 });
 
-			await expect(launcher(page)).toBeVisible({ timeout: 15_000 });
-			await expect(launcher(page)).toHaveAttribute("data-testid", "support-launcher");
-			// The launcher wraps a Button titled "Support".
-			await expect(launcher(page).locator('button[title="Support"]')).toBeVisible({ timeout: 15_000 });
+			// Matches sibling sizing (same as the QR button: h-6 w-6).
+			await expect(launcherBtn(page)).toHaveClass(/(?:^|\s)h-6(?:\s|$)/);
+			await expect(launcherBtn(page)).toHaveClass(/(?:^|\s)w-6(?:\s|$)/);
 
 			// Sits immediately LEFT of the QR button (same header row).
 			await expect(qrButton(page)).toBeVisible({ timeout: 15_000 });
-			const supportX = await centerX(launcher(page));
+			const supportX = await centerX(launcherBtn(page));
 			const qrX = await centerX(qrButton(page));
 			expect(supportX, "support launcher should sit left of the QR button").toBeLessThan(qrX);
 		} finally {
-			if (hqSession) await deleteSession(hqSession).catch(() => {});
+			if (session) await deleteSession(session).catch(() => {});
 		}
 	});
 
-	test("launcher is visible left of the QR button under Headquarters (mobile)", async ({ page }) => {
+	test("launcher is hidden when 'Show Headquarters in project lists' is off", async ({ page }) => {
+		await page.setViewportSize(DESKTOP);
+		// Turn the preference off BEFORE the app boots so the client picks it up.
+		await setHeadquartersVisible(false);
+		let session: string | undefined;
+		try {
+			session = await createSession();
+			await waitForSessionStatus(session, "idle");
+			await openApp(page);
+			await navigateToHash(page, `#/session/${session}`);
+			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 20_000 });
+
+			// The QR button proves the header rendered, but the launcher is absent.
+			await expect(qrButton(page)).toBeVisible({ timeout: 15_000 });
+			await expect(page.locator('[data-testid="support-launcher"]')).toHaveCount(0);
+		} finally {
+			if (session) await deleteSession(session).catch(() => {});
+		}
+	});
+
+	test("launcher is visible left of the QR button with a non-HQ project active (mobile)", async ({ page }) => {
 		await page.setViewportSize(MOBILE);
-		let hqSession: string | undefined;
+		let session: string | undefined;
 		try {
 			await openApp(page);
-			hqSession = await openHeadquartersSession(page);
+			session = await openNonHqSession(page);
 
 			// The mobile launcher renders in the mobile landing header (not the in-session
-			// header), so drop back to the landing route — activeProjectId stays Headquarters.
+			// header), so drop back to the landing route.
 			await navigateToHash(page, "#/");
-			await expect(launcher(page)).toBeVisible({ timeout: 20_000 });
-			await expect(launcher(page).locator('button[title="Support"]')).toBeVisible({ timeout: 15_000 });
+			await expect(launcher(page)).toHaveCount(1);
+			await expect(launcherBtn(page)).toBeVisible({ timeout: 20_000 });
+			await expect(launcherBtn(page)).toHaveAttribute("title", SUPPORT_TITLE);
 
 			// Sits left of the QR button in the mobile header too.
 			await expect(qrButton(page)).toBeVisible({ timeout: 15_000 });
-			const supportX = await centerX(launcher(page));
+			const supportX = await centerX(launcherBtn(page));
 			const qrX = await centerX(qrButton(page));
 			expect(supportX, "mobile support launcher should sit left of the QR button").toBeLessThan(qrX);
 		} finally {
-			if (hqSession) await deleteSession(hqSession).catch(() => {});
+			if (session) await deleteSession(session).catch(() => {});
 		}
 	});
 
-	test("clicking the launcher creates + opens an HQ support session that persists across reload", async ({ page }) => {
+	test("clicking the launcher (from a non-HQ project) creates + opens an HQ support session that persists across reload", async ({ page }) => {
 		test.setTimeout(90_000);
 		await page.setViewportSize(DESKTOP);
-		let hqSession: string | undefined;
+		let session: string | undefined;
 		let supportSession: string | undefined;
 		try {
 			await openApp(page);
-			hqSession = await openHeadquartersSession(page);
-			await expect(launcher(page)).toBeVisible({ timeout: 15_000 });
+			session = await openNonHqSession(page);
+			await expect(launcherBtn(page)).toBeVisible({ timeout: 15_000 });
 
 			// Capture the session-create POST driven by showSupportDialog().
 			const reqPromise = page.waitForRequest(
@@ -152,7 +167,7 @@ test.describe("Journey: Support Launcher", () => {
 				{ timeout: 30_000 },
 			);
 
-			await launcher(page).click();
+			await launcherBtn(page).click();
 
 			const req = await reqPromise;
 			const body = JSON.parse(req.postData() || "{}") as { assistantType?: string; projectId?: string };
@@ -187,7 +202,7 @@ test.describe("Journey: Support Launcher", () => {
 			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 20_000 });
 		} finally {
 			if (supportSession) await deleteSession(supportSession).catch(() => {});
-			if (hqSession) await deleteSession(hqSession).catch(() => {});
+			if (session) await deleteSession(session).catch(() => {});
 		}
 	});
 });

--- a/tests2/core/support-assistant.test.ts
+++ b/tests2/core/support-assistant.test.ts
@@ -15,7 +15,7 @@ import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 import YAML from "yaml";
 
-const { getAssistantDef, assistantRoleForType } = await import("../../src/server/agent/assistant-registry.ts");
+const { getAssistantDef, assistantRoleForType, composeAssistantTitle } = await import("../../src/server/agent/assistant-registry.ts");
 const { SUPPORT_ASSISTANT_PROMPT } = await import("../../src/server/agent/support-assistant.ts");
 
 const DEFAULTS_DIR = path.resolve(import.meta.dirname, "..", "..", "defaults");
@@ -48,6 +48,32 @@ describe("assistantRoleForType", () => {
 		assert.equal(assistantRoleForType("goal"), "assistant");
 		assert.equal(assistantRoleForType("project"), "assistant");
 		assert.equal(assistantRoleForType(undefined), "assistant");
+	});
+});
+
+describe("assistant titlePrefix", () => {
+	it("exposes the exact type prefixes used for initial title + auto-rename", () => {
+		const cases: Record<string, string> = {
+			goal: "New Goal",
+			role: "New Role",
+			tool: "New Tool",
+			staff: "New Staff",
+			project: "New Project",
+			"project-scaffolding": "New Project",
+			support: "Support",
+		};
+		for (const [type, prefix] of Object.entries(cases)) {
+			const def = getAssistantDef(type);
+			assert.ok(def, `assistant def must be registered for ${type}`);
+			assert.equal(def!.titlePrefix, prefix, `titlePrefix for ${type}`);
+		}
+	});
+});
+
+describe("composeAssistantTitle", () => {
+	it("composes '<prefix>: <summary>'", () => {
+		assert.equal(composeAssistantTitle("Support", "reset worktree pool"), "Support: reset worktree pool");
+		assert.equal(composeAssistantTitle("New Goal", "add dark mode"), "New Goal: add dark mode");
 	});
 });
 

--- a/tests2/integration/support-session-role-wiring.test.ts
+++ b/tests2/integration/support-session-role-wiring.test.ts
@@ -58,16 +58,22 @@ async function getSession(id: string): Promise<any> {
 
 async function getPromptSections(id: string): Promise<PromptSection[]> {
 	// Poll until the persisted prompt-sections snapshot is available.
-	let sections: PromptSection[] | undefined;
-	await expect(async () => {
-		const resp = await rawApiFetch(`/api/sessions/${id}/prompt-sections`);
-		expect(resp.status).toBe(200);
-		const body = await resp.json();
-		expect(Array.isArray(body?.sections)).toBe(true);
-		expect(body.sections.length).toBeGreaterThan(0);
-		sections = body.sections as PromptSection[];
-	}).toPass({ timeout: 10_000 });
-	return sections!;
+	const start = Date.now();
+	let lastErr: unknown;
+	while (Date.now() - start < 10_000) {
+		try {
+			const resp = await rawApiFetch(`/api/sessions/${id}/prompt-sections`);
+			expect(resp.status).toBe(200);
+			const body = await resp.json();
+			expect(Array.isArray(body?.sections)).toBe(true);
+			expect(body.sections.length).toBeGreaterThan(0);
+			return body.sections as PromptSection[];
+		} catch (err) {
+			lastErr = err;
+			await new Promise(r => setTimeout(r, 100));
+		}
+	}
+	throw lastErr instanceof Error ? lastErr : new Error("prompt-sections not available within 10000ms");
 }
 
 test.describe("Support session role wiring (reproducing defects 5 & 6)", () => {

--- a/tests2/integration/support-session-role-wiring.test.ts
+++ b/tests2/integration/support-session-role-wiring.test.ts
@@ -1,0 +1,121 @@
+/**
+ * REPRODUCING integration test for the Support Assistant fix-up (defects 5 & 6).
+ *
+ * This asserts the FIXED behaviour, so it FAILS on the current (unfixed) code:
+ *
+ *   Defect 6 — a running Support session must carry the support role identity
+ *   (`role: "support"`, `accessory: "headset"`), matching the Role Manager and
+ *   defaults/roles/support.yaml. Current code hardcodes `role: "assistant"`,
+ *   `accessory: "wand"` for every assistant session (server.ts ~line 6524).
+ *
+ *   Defect 5 — an assistant session's system prompt must expose a dedicated
+ *   `Role`-typed section (`source: "Role: support"`) carrying the support
+ *   role's promptTemplate, WITHOUT folding that template into the `Goal`
+ *   section. Current code prepends the role template into the goal spec and
+ *   passes no rolePrompt/roleName to assemblePrompt (session-setup.ts
+ *   resolvePrompt assistant branch), so there is no `Role` section and the
+ *   role text is duplicated into `Goal`.
+ *
+ * Support targets Headquarters (mirrors the client launcher in
+ * src/app/dialogs.ts::showSupportDialog which POSTs
+ * `{ assistantType: "support", projectId: HEADQUARTERS_PROJECT_ID }`).
+ *
+ * External-free, retries:0 — waits on observable state (polls GET) instead of
+ * fixed sleeps.
+ */
+import { test, expect } from "./_e2e/in-process-harness.js";
+import { rawApiFetch, deleteSession } from "./_e2e/e2e-setup.js";
+
+const HEADQUARTERS_PROJECT_ID = "headquarters";
+
+// Distinctive substring from defaults/roles/support.yaml `promptTemplate` — NOT
+// present in SUPPORT_ASSISTANT_PROMPT (which uses "## Grounding your answers").
+// After the fix this must live ONLY in the dedicated Role section.
+const ROLE_TEMPLATE_PHRASE = "Read all of Bobbit's documentation and source freely";
+// Distinctive phrase from SUPPORT_ASSISTANT_PROMPT (the Goal-section content).
+const GOAL_PROMPT_PHRASE = "Bobbit Support Assistant";
+
+interface PromptSection { label: string; source: string; content: string; tokens: number }
+
+async function createSupportSession(): Promise<string> {
+	const resp = await rawApiFetch("/api/sessions", {
+		method: "POST",
+		body: JSON.stringify({ assistantType: "support", projectId: HEADQUARTERS_PROJECT_ID }),
+	});
+	const text = await resp.text();
+	expect(resp.status, `create support session; got ${resp.status} body=${text}`).toBe(201);
+	const data = JSON.parse(text);
+	expect(data.id).toBeTruthy();
+	expect(data.assistantType).toBe("support");
+	return data.id as string;
+}
+
+async function getSession(id: string): Promise<any> {
+	const resp = await rawApiFetch(`/api/sessions/${id}`);
+	expect(resp.status, `GET session ${id}`).toBe(200);
+	return resp.json();
+}
+
+async function getPromptSections(id: string): Promise<PromptSection[]> {
+	// Poll until the persisted prompt-sections snapshot is available.
+	let sections: PromptSection[] | undefined;
+	await expect(async () => {
+		const resp = await rawApiFetch(`/api/sessions/${id}/prompt-sections`);
+		expect(resp.status).toBe(200);
+		const body = await resp.json();
+		expect(Array.isArray(body?.sections)).toBe(true);
+		expect(body.sections.length).toBeGreaterThan(0);
+		sections = body.sections as PromptSection[];
+	}).toPass({ timeout: 10_000 });
+	return sections!;
+}
+
+test.describe("Support session role wiring (reproducing defects 5 & 6)", () => {
+	test("Defect 6 — support session persists role=support, accessory=headset", async () => {
+		const id = await createSupportSession();
+		try {
+			const session = await getSession(id);
+			expect(session.role, `support session role should be "support", got "${session.role}"`).toBe("support");
+			expect(session.accessory, `support session accessory should be "headset", got "${session.accessory}"`).toBe("headset");
+		} finally {
+			await deleteSession(id);
+		}
+	});
+
+	test("Defect 5 — assembled prompt exposes a dedicated Role section, not folded into Goal", async () => {
+		const id = await createSupportSession();
+		try {
+			const sections = await getPromptSections(id);
+
+			// A dedicated Role-typed section carrying the support role's promptTemplate.
+			const roleSection = sections.find(s => s.label === "Role");
+			expect(roleSection, `expected a section with label "Role"; labels were: ${sections.map(s => s.label).join(", ")}`).toBeTruthy();
+			expect(roleSection!.source).toBe("Role: support");
+			expect(
+				roleSection!.content.includes(ROLE_TEMPLATE_PHRASE),
+				`Role section should carry the support role promptTemplate (missing "${ROLE_TEMPLATE_PHRASE}")`,
+			).toBe(true);
+
+			// The Goal section must carry the assistant prompt, NOT the role template.
+			const goalSection = sections.find(s => s.label === "Goal");
+			expect(goalSection, `expected a section with label "Goal"`).toBeTruthy();
+			expect(
+				goalSection!.content.includes(GOAL_PROMPT_PHRASE),
+				`Goal section should carry SUPPORT_ASSISTANT_PROMPT (missing "${GOAL_PROMPT_PHRASE}")`,
+			).toBe(true);
+			expect(
+				goalSection!.content.includes(ROLE_TEMPLATE_PHRASE),
+				`Goal section must NOT fold in the role template (found "${ROLE_TEMPLATE_PHRASE}")`,
+			).toBe(false);
+
+			// No duplication: the role template phrase appears in exactly one section.
+			const withRolePhrase = sections.filter(s => s.content.includes(ROLE_TEMPLATE_PHRASE));
+			expect(
+				withRolePhrase.map(s => s.label),
+				`role template phrase should appear in exactly one section (the Role section)`,
+			).toEqual(["Role"]);
+		} finally {
+			await deleteSession(id);
+		}
+	});
+});

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -72,6 +72,10 @@
       "reason": "Support assistant offline packaging: package.json files ships docs/ + src/; npm pack --dry-run --json lists docs/ + src/ entries; resolveBundledDocsDir/resolveBundledSrcDir return existing directories."
     },
     {
+      "path": "tests2/integration/support-session-role-wiring.test.ts",
+      "reason": "Reproducing integration test for the Support Assistant fix-up (defects 5 & 6): a running Support session (assistantType=support, projectId=headquarters) must persist role=support + accessory=headset (not the hardcoded assistant/wand), and its prompt-sections must expose a dedicated Role section (source 'Role: support') carrying the support role promptTemplate WITHOUT folding it into the Goal section (no duplication)."
+    },
+    {
       "path": "tests2/core/cli-real-deps.test.ts",
       "reason": "DI contract: cli.ts passes no test doubles (default-real wiring)."
     },


### PR DESCRIPTION
Fix-up on top of the merged Support Assistant feature (PR #960). No revert — the existing `support-assistant.ts`, `defaults/roles/support.yaml`, launcher, packaging and tests all stay. Fixes 8 defects, keeping the `assistantType:"support"` code path (so offline `{{BOBBIT_DOCS_DIR}}`/`{{BOBBIT_SRC_DIR}}`/`{{AGENT_ID}}` injection is preserved for npm-installed/offline Headquarters users).

## Defects fixed
1. **Launcher icon** — `LifeBuoy` → `MessageCircleQuestion` (desktop + mobile).
2. **Launcher visibility** — gated on `showHeadquartersInProjectLists !== false` instead of `isHeadquartersProject(activeProject)`, so it stays visible with a non-HQ project active; still creates the Support session in Headquarters.
3. **Header spacing** — `support-launcher` wrapper set to `display:contents` so the Button is the flex child; matches sibling icons (`h-6 w-6`).
4. **Tooltip** — `title="Open a new support agent session"`.
5. **Dedicated Role section** — assistant sessions (all types) now emit a separate `Role: <name>` prompt section via `rolePrompt`/`roleName` + `plan.roleName` (also applied to restore + prompt-sections snapshot paths); the role's tool policies now apply.
6. **Headset accessory** — Support session persists `role="support"`, `accessory="headset"` (role-aware via `assistantRoleForType`), matching the Role Manager.
7. **Assistant auto-rename** — chats auto-rename to `"<prefix>: <summary>"` after the first genuine user message (new `AssistantDef.titlePrefix`); auto-kickoff flagged non-title-generating (`suppressTitleGen`).
8. **Support kickoff + greeting** — Support now has an `AUTO_PROMPTS` kickoff and opens with a capability overview (how-to answers + confirmed gateway changes + example questions), confirmation-first preserved.

`assistantRoleForType` remains the single source of truth for assistant-type → role.

## Tests
- New reproducing integration test `tests2/integration/support-session-role-wiring.test.ts` (defects 5 & 6).
- Extended `tests2/core/support-assistant.test.ts` (titlePrefix + `composeAssistantTitle`).
- Rewrote browser journey `tests2/browser/journeys/support-launcher.journey.spec.ts` to the new visibility/geometry/tooltip/icon/click rules.
- Trimmed `AGENTS.md` back under its 6144B budget (the #960 `support-assistant.md` link had tipped it over).
- Updated `docs/support-assistant.md`.

Workflow gates passed: issue-analysis, reproducing-test, implementation (build/typecheck/repro/unit/browser/e2e/LLM reviews/QA), documentation.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
