### PR TITLE
Align sidebar header icons

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -19,6 +19,54 @@ bell-toggle button {
 	color: var(--color-muted-foreground) !important;
 }
 
+.sidebar-header-shell {
+	gap: 0.5rem;
+	min-width: 0;
+}
+
+.sidebar-header-brand {
+	flex: 1 1 auto;
+	min-width: 0;
+	max-width: calc(100% - 7.25rem);
+}
+
+.sidebar-header-actions {
+	width: 6.75rem;
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.125rem;
+}
+
+.sidebar-header-actions > *,
+.sidebar-header-actions > [data-testid="support-launcher"] {
+	width: 1.5rem;
+	height: 1.5rem;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 1.5rem;
+}
+
+.sidebar-header-actions button {
+	width: 1.5rem !important;
+	height: 1.5rem !important;
+	min-width: 1.5rem !important;
+	padding: 0 !important;
+	display: inline-flex !important;
+	align-items: center !important;
+	justify-content: center !important;
+	line-height: 1 !important;
+}
+
+.sidebar-header-actions svg {
+	width: 1rem !important;
+	height: 1rem !important;
+	display: block;
+	flex-shrink: 0;
+}
+
 /* Sidebar icon affordances that opt in here scale from .sidebar-root font-size.
  * Keep selectors narrow so compound plus overlays are never clipped by generic
  * sidebar SVG/span rules. */

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -3128,12 +3128,12 @@ export function doRenderApp(): void {
 						${bobbitIcon}
 					</div>
 					` : html`
-					<div class="shrink-0 flex items-center justify-between px-3 self-stretch" style="background: var(--sidebar); width: var(--sidebar-w, 240px);">
-						<div class="flex items-center gap-2">
+					<div class="sidebar-header-shell shrink-0 flex items-center justify-between px-3 self-stretch" style="background: var(--sidebar); width: var(--sidebar-w, 240px);">
+						<div class="sidebar-header-brand flex items-center gap-2">
 							${bobbitIcon}
-							<span class="text-base font-semibold text-foreground">Bobbit</span>
+							<span class="text-base font-semibold text-foreground truncate">Bobbit</span>
 						</div>
-						<div class="flex items-center" style="gap:1px;margin-right:-4px">
+						<div class="sidebar-header-actions" aria-label="Sidebar shortcuts">
 							${state.showHeadquartersInProjectLists !== false
 								? html`<span data-testid="support-launcher" style="display:contents">${Button({
 									variant: "ghost",
@@ -3141,7 +3141,7 @@ export function doRenderApp(): void {
 									children: html`${icon(MessageCircleQuestion, "xs")}`,
 									onClick: () => { showSupportDialog(); },
 									title: "Open a new support agent session",
-									className: "h-6 w-6 text-muted-foreground",
+									className: "sidebar-header-icon-btn h-6 w-6 text-muted-foreground",
 								})}</span>`
 								: nothing}
 							${Button({
@@ -3150,7 +3150,7 @@ export function doRenderApp(): void {
 								children: html`${icon(QrCode, "xs")}`,
 								onClick: showQrCodeDialog,
 								title: "Show QR code",
-								className: "h-6 w-6 text-muted-foreground",
+								className: "sidebar-header-icon-btn h-6 w-6 text-muted-foreground",
 							})}
 							<bell-toggle></bell-toggle>
 							<theme-toggle></theme-toggle>

--- a/tests2/browser/journeys/support-launcher.journey.spec.ts
+++ b/tests2/browser/journeys/support-launcher.journey.spec.ts
@@ -49,6 +49,30 @@ async function centerX(loc: import("@playwright/test").Locator): Promise<number>
 	return box.x + box.width / 2;
 }
 
+async function centerY(loc: import("@playwright/test").Locator): Promise<number> {
+	const box = await loc.boundingBox();
+	if (!box) throw new Error("element has no bounding box");
+	return box.y + box.height / 2;
+}
+
+async function expectDesktopSidebarHeaderActionsAligned(page: Page): Promise<void> {
+	const buttons = page.locator(".sidebar-header-actions button");
+	await expect(buttons).toHaveCount(4);
+	const centers = await Promise.all([0, 1, 2, 3].map(async (index) => ({
+		x: await centerX(buttons.nth(index)),
+		y: await centerY(buttons.nth(index)),
+	})));
+	for (let i = 1; i < centers.length; i++) {
+		expect(centers[i].x, "sidebar header actions should be ordered horizontally").toBeGreaterThan(centers[i - 1].x);
+		expect(Math.abs(centers[i].y - centers[0].y), "sidebar header actions should be vertically aligned").toBeLessThanOrEqual(1);
+	}
+	const gaps = centers.slice(1).map((center, index) => center.x - centers[index].x);
+	const averageGap = gaps.reduce((sum, gap) => sum + gap, 0) / gaps.length;
+	for (const gap of gaps) {
+		expect(Math.abs(gap - averageGap), "sidebar header actions should be evenly distributed").toBeLessThanOrEqual(2);
+	}
+}
+
 /**
  * Create a default (non-Headquarters) project session and navigate to it so
  * state.activeProjectId is NOT "headquarters" — proving the launcher no longer
@@ -93,11 +117,13 @@ test.describe("Journey: Support Launcher", () => {
 			await expect(launcherBtn(page)).toHaveClass(/(?:^|\s)h-6(?:\s|$)/);
 			await expect(launcherBtn(page)).toHaveClass(/(?:^|\s)w-6(?:\s|$)/);
 
-			// Sits immediately LEFT of the QR button (same header row).
+			// Sits immediately LEFT of the QR button (same header row), and the
+			// full desktop sidebar header action cluster is evenly spaced/aligned.
 			await expect(qrButton(page)).toBeVisible({ timeout: 15_000 });
 			const supportX = await centerX(launcherBtn(page));
 			const qrX = await centerX(qrButton(page));
 			expect(supportX, "support launcher should sit left of the QR button").toBeLessThan(qrX);
+			await expectDesktopSidebarHeaderActionsAligned(page);
 		} finally {
 			if (session) await deleteSession(session).catch(() => {});
 		}


### PR DESCRIPTION
## Summary
- Align the sidebar header action cluster with fixed-size evenly distributed buttons.
- Keep the Bobbit brand from pushing icons out of layout by truncating it.
- Add a browser journey assertion for horizontal spacing and vertical alignment.

## Tests
- npm run check
- npm run build
- npx playwright test tests2/browser/journeys/support-launcher.journey.spec.ts --config playwright-v2.config.ts --project=browser-v2

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)