### PR TITLE
Grant support session prompt by default

### DIFF
--- a/defaults/roles/support.yaml
+++ b/defaults/roles/support.yaml
@@ -7,11 +7,14 @@ toolPolicies:
   # role grants beat that default (resolveGrantPolicy step 1 > step 5).
   # The support role may change a running Bobbit instance via the gateway
   # tools — orchestrate is allowed, admin is behind `ask` (destructive ops).
+  # It may also prompt/steer another live support target via session_prompt;
+  # that tool defaults to `never` because it can target any live session.
   # bobbit_read needs no entry (its `allow` default already applies).
   bobbit_orchestrate: allow
   bobbit_admin: ask
+  session_prompt: allow
 createdAt: 0
-updatedAt: 1775090000000
+updatedAt: 1783635694555
 promptTemplate: |
   You are the **Support** agent (id: {{AGENT_ID}}) — Bobbit's built-in support assistant.
 

--- a/tests2/core/support-assistant.test.ts
+++ b/tests2/core/support-assistant.test.ts
@@ -2,8 +2,8 @@
 //
 // Pins the backend surface for the built-in Support assistant:
 //   • getAssistantDef("support") is registered (title/promptTitle).
-//   • defaults/roles/support.yaml loads with accessory: headset and the
-//     bobbit tier tool policies (orchestrate: allow, admin: ask).
+//   • defaults/roles/support.yaml loads with accessory: headset, bobbit tier
+//     tool policies (orchestrate: allow, admin: ask), and session_prompt: allow.
 //   • SUPPORT_ASSISTANT_PROMPT carries the confirmation-first instruction.
 //   • assistantRoleForType maps support -> support, everything else -> assistant.
 import { guardProcessEnv } from "./helpers/env-guard.js";
@@ -78,7 +78,7 @@ describe("composeAssistantTitle", () => {
 });
 
 describe("support role definition", () => {
-	it("defaults/roles/support.yaml loads with headset accessory + bobbit tier policies", () => {
+	it("defaults/roles/support.yaml loads with headset accessory + support tool policies", () => {
 		const raw = fs.readFileSync(SUPPORT_ROLE_FILE, "utf-8");
 		const role = YAML.parse(raw) as {
 			name?: string;
@@ -90,6 +90,7 @@ describe("support role definition", () => {
 		assert.equal(role.accessory, "headset");
 		assert.equal(role.toolPolicies?.bobbit_orchestrate, "allow");
 		assert.equal(role.toolPolicies?.bobbit_admin, "ask");
+		assert.equal(role.toolPolicies?.session_prompt, "allow");
 		// bobbit_read must NOT be listed — its `allow` default already applies.
 		assert.equal(role.toolPolicies?.bobbit_read, undefined);
 		assert.ok(role.promptTemplate && role.promptTemplate.length > 0, "support role needs a promptTemplate");

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -77,7 +77,7 @@
     },
     {
       "path": "tests2/core/support-assistant.test.ts",
-      "reason": "Support assistant backend wiring: getAssistantDef('support') registered; defaults/roles/support.yaml loads with accessory headset + bobbit tier policies (orchestrate allow, admin ask); SUPPORT_ASSISTANT_PROMPT carries the confirmation-first instruction; assistantRoleForType maps support->support else assistant."
+      "reason": "Support assistant backend wiring: getAssistantDef('support') registered; defaults/roles/support.yaml loads with accessory headset + support policies (orchestrate allow, admin ask, session_prompt allow); SUPPORT_ASSISTANT_PROMPT carries the confirmation-first instruction; assistantRoleForType maps support->support else assistant."
     },
     {
       "path": "tests2/core/support-packaging.test.ts",


### PR DESCRIPTION
## Summary
- Move the support role's session_prompt allow policy into the built-in default role.
- Pin the default support role policy in the support assistant core test.
- Update the v2 tests map rationale.

## Tests
- npx vitest run --config vitest.config.ts tests2/core/support-assistant.test.ts
- npm run check

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)