### PR TITLE
Page Bobbit Tools

### DIFF
--- a/defaults/tools/bobbit/bobbit_read.yaml
+++ b/defaults/tools/bobbit/bobbit_read.yaml
@@ -1,14 +1,14 @@
 name: bobbit_read
 description: "Read-only gateway introspection: goals, sessions, projects, tasks, gates, search, maintenance probes."
 summary: "Read gateway state (goals/sessions/projects/…)"
-params: [operation, goalId?, sessionId?, taskId?, projectId?, workflowId?, q?, view?, probe?]
+params: [operation, goalId?, sessionId?, taskId?, projectId?, workflowId?, q?, type?, limit?, offset?, after?, cursor?, archived?, include?, view?, probe?]
 provider:
   type: bobbit-extension
   extension: extension.ts
 group: Bobbit
 grantPolicy: allow
 docs: |-
-  Read-only, gateway-wide introspection. Pick an `operation` and pass its required ids. Addresses entities by explicit id (not the current goal), so it complements — never replaces — `task_list`/`gate_list`. Returns the gateway's JSON verbatim.
+  Read-only, gateway-wide introspection. Pick an `operation` and pass its required ids. Addresses entities by explicit id (not the current goal), so it complements — never replaces — `task_list`/`gate_list`. List-style operations return bounded pages by default with pagination metadata.
 detail_docs: >-
   ## Purpose
 
@@ -33,76 +33,136 @@ detail_docs: >-
   - Ids: `goalId`, `sessionId`, `taskId`, `projectId`, `workflowId` — supply the
   ones the chosen operation requires.
 
-  - Query-ish: `q` (search/list filter), `type`/`limit`/`offset` (search),
-  `archived` (list_goals), `include` (list_sessions, e.g. `archived`),
-  `view` (gates/tasks summary), `probe` (maintenance_inspect selector).
+  - Semantic filters: `q` (free-text list/search filter), `type` (search result
+  type), `archived` (list_goals), `include` (list_sessions, e.g. `archived`),
+  `view` (gates/tasks projection), `probe` (maintenance_inspect selector).
+
+  - Shared paging: `limit`, `offset`, `after`, `cursor`. List-style operations
+  use `limit=50` and `offset=0` by default, clamp `limit` to a maximum of `200`,
+  and return pagination metadata. `search` keeps its search endpoint defaults
+  (`limit=20`, maximum `100`) unless you pass `limit` explicitly.
+
+  - Cursor aliases: `cursor` is the generic cursor input; `after` is the gateway
+  query name used by archived session/goal paths. If both cursor and offset
+  inputs are present for a cursor-backed call, the cursor form wins.
+
+
+  ## Pagination contract
+
+
+  List-style operations return the endpoint's normal fields plus a
+  `pagination` object. The primary item key is preserved (`sessions`, `goals`,
+  `projects`, `workflows`, `roles`, `tools`, `gates`, `tasks`, `staff`,
+  `servers`, `results`, or probe-specific keys such as `worktrees`/`sample`).
+  Fallback tool-side paging happens only after the gateway has applied semantic
+  filters.
+
+
+  `pagination` includes:
+
+
+  - `limit` — effective page size.
+
+  - `offset` and `nextOffset` for offset pages.
+
+  - `cursor` and `nextCursor` for cursor pages.
+
+  - `total` when the gateway/tool can know the total after filtering.
+
+  - `hasMore` — whether another page is available.
+
+  - `mode` — `offset` or `cursor`.
+
+  - `itemKey` — the response field that was paged.
+
+  - `pagedBy` — `rest` when the gateway endpoint paged, `tool` when the tool
+  bounded an unpaged endpoint response.
 
 
   ## Operation catalogue
 
-  | operation | GET path | required |
+  | operation | GET path | required | semantic filters / paging |
 
-  |---|---|---|
+  |---|---|---|---|
 
-  | `health` | `/api/health` | — |
+  | `health` | `/api/health` | — | — |
 
-  | `connection_info` | `/api/connection-info` | — |
+  | `connection_info` | `/api/connection-info` | — | — |
 
-  | `list_goals` | `/api/goals` (`?archived`, `?q`) | — |
+  | `list_goals` | `/api/goals` (`?projectId`, `?archived`, `?q`, paging) | — | `projectId`, `archived`, `q`, `limit`, `offset`, `after`/`cursor` |
 
-  | `get_goal` | `/api/goals/:goalId` | `goalId` |
+  | `get_goal` | `/api/goals/:goalId` | `goalId` | — |
 
-  | `goal_cost` | `/api/goals/:goalId/cost` | `goalId` |
+  | `goal_cost` | `/api/goals/:goalId/cost` | `goalId` | — |
 
-  | `goal_git_status` | `/api/goals/:goalId/git-status` | `goalId` |
+  | `goal_git_status` | `/api/goals/:goalId/git-status` | `goalId` | — |
 
-  | `goal_commits` | `/api/goals/:goalId/commits` | `goalId` |
+  | `goal_commits` | `/api/goals/:goalId/commits` | `goalId` | — |
 
-  | `goal_pr_status` | `/api/goals/:goalId/pr-status` | `goalId` |
+  | `goal_pr_status` | `/api/goals/:goalId/pr-status` | `goalId` | — |
 
-  | `list_sessions` | `/api/sessions` (`?include`, `?q`, `?projectId`) | — |
+  | `list_sessions` | `/api/sessions` (`?include`, `?q`, `?projectId`, paging) | — | `include`, `q`, `projectId`, `limit`, `offset`, `after`/`cursor` |
 
-  | `get_session` | `/api/sessions/:sessionId` | `sessionId` |
+  | `get_session` | `/api/sessions/:sessionId` | `sessionId` | — |
 
-  | `session_cost` | `/api/sessions/:sessionId/cost` | `sessionId` |
+  | `session_cost` | `/api/sessions/:sessionId/cost` | `sessionId` | — |
 
-  | `search` | `/api/search` (`?q`, `?type`, `?limit`, `?offset`, `?projectId`) | `q` |
+  | `search` | `/api/search` (`?q`, `?type`, `?limit`, `?offset`, `?projectId`) | `q` | `q`, `type`, `projectId`, `limit`, `offset` |
 
-  | `list_projects` | `/api/projects` | — |
+  | `list_projects` | `/api/projects` (paging) | — | `limit`, `offset` |
 
-  | `get_project` | `/api/projects/:projectId` | `projectId` |
+  | `get_project` | `/api/projects/:projectId` | `projectId` | — |
 
-  | `list_workflows` | `/api/workflows` (`?projectId`) | `projectId`* |
+  | `list_workflows` | `/api/workflows` (`?projectId`, paging) | `projectId`* | `projectId`, `limit`, `offset` |
 
-  | `get_workflow` | `/api/workflows/:workflowId` (`?projectId`) | `workflowId` |
+  | `get_workflow` | `/api/workflows/:workflowId` (`?projectId`) | `workflowId` | `projectId` |
 
-  | `list_roles` | `/api/roles` | — |
+  | `list_roles` | `/api/roles` (`?projectId`, paging) | — | `projectId`, `limit`, `offset` |
 
-  | `list_tools` | `/api/tools` (`?projectId`) | — |
+  | `list_tools` | `/api/tools` (`?projectId`, paging) | — | `projectId`, `limit`, `offset` |
 
-  | `list_gates` | `/api/goals/:goalId/gates` (`?view`) | `goalId` |
+  | `list_gates` | `/api/goals/:goalId/gates` (`?view`, paging) | `goalId` | `view`, `limit`, `offset` |
 
-  | `list_tasks` | `/api/goals/:goalId/tasks` (`?view`) | `goalId` |
+  | `list_tasks` | `/api/goals/:goalId/tasks` (`?view`, paging) | `goalId` | `view`, `limit`, `offset` |
 
-  | `get_task` | `/api/tasks/:taskId` | `taskId` |
+  | `get_task` | `/api/tasks/:taskId` | `taskId` | — |
 
-  | `list_staff` | `/api/staff` | — |
+  | `list_staff` | `/api/staff` (`?projectId`, paging) | — | `projectId`, `limit`, `offset` |
 
-  | `list_mcp_servers` | `/api/mcp-servers` | — |
+  | `list_mcp_servers` | `/api/mcp-servers` (`?projectId`, paging) | — | `projectId`, `limit`, `offset` |
 
-  | `maintenance_inspect` | see `probe` below | `probe` |
+  | `maintenance_inspect` | see `probe` below | `probe` | `probe`, supported `projectId`, paging for large array probes |
 
 
   \* `list_workflows` returns an empty list without `projectId` — the gateway
   will not error, but pass `projectId` for a useful result.
 
 
+  ### Semantic filter audit
+
+
+  - `projectId` scopes `list_sessions`, `list_goals`, `list_workflows`,
+  `get_workflow`, `list_roles`, `list_tools`, `list_staff`, `list_mcp_servers`,
+  and supported maintenance probes.
+
+  - `goalId` path-scopes `list_gates` and `list_tasks`; `view` projection is
+  applied before paging.
+
+  - `q` filters `list_sessions`, `list_goals`, and `search`; `type` applies only
+  to `search`.
+
+  - `include` applies only to `list_sessions`; `archived` applies only to
+  `list_goals`.
+
+
   ### `maintenance_inspect` probes (`probe=`)
 
-  `orphaned_worktrees`, `orphaned_sessions`, `expired_archives`,
-  `orphaned_index_rows` (`?projectId`), `worktrees`,
-  `archived_session_worktrees`, `worktree_pool`, `sandbox_pool`,
-  `sandbox_status`, `search_stats` (`?projectId`).
+  `orphaned_worktrees` (paged `worktrees`), `orphaned_sessions` (paged
+  `sessions`), `expired_archives`, `orphaned_index_rows` (`?projectId`, paged
+  `sample`), `worktrees`, `archived_session_worktrees` (paged `worktrees`),
+  `worktree_pool` (`?projectId`), `sandbox_pool`, `sandbox_status`
+  (`?projectId`), `search_stats` (`?projectId`). Scalar/stat probes return
+  unchanged unless they include a large array key.
 
 
   ## Overlap policy (use the dedicated tool instead)
@@ -116,7 +176,10 @@ detail_docs: >-
 
   ## Notes / Gotchas
 
-  - Returns the gateway JSON verbatim; on failure surfaces `{ error, code }`
-  as one readable line including the HTTP status.
+  - List-style operations are bounded by default and include `pagination`.
+  Non-list operations return the gateway JSON unchanged.
+
+  - On failure, the tool surfaces `{ error, code }` as one readable line
+  including the HTTP status.
 
   - No side effects — safe to call freely.

--- a/defaults/tools/bobbit/bobbit_read.yaml
+++ b/defaults/tools/bobbit/bobbit_read.yaml
@@ -42,6 +42,13 @@ detail_docs: >-
   and return pagination metadata. `search` keeps its search endpoint defaults
   (`limit=20`, maximum `100`) unless you pass `limit` explicitly.
 
+  - REST vs tool paging: paging is forwarded to REST for `list_sessions`,
+  `list_goals`, and `search`. Other list-style operations are paged in the tool
+  after the gateway applies semantic filters such as `projectId`, `goalId`, or
+  `view`. If a response already contains REST page fields (`total`, `hasMore`,
+  `nextOffset`, `nextCursor`, or `pagination`), the tool treats it as REST-paged
+  and does **not** slice the array again.
+
   - Cursor aliases: `cursor` is the generic cursor input; `after` is the gateway
   query name used by archived session/goal paths. If both cursor and offset
   inputs are present for a cursor-backed call, the cursor form wins.
@@ -55,7 +62,7 @@ detail_docs: >-
   `projects`, `workflows`, `roles`, `tools`, `gates`, `tasks`, `staff`,
   `servers`, `results`, or probe-specific keys such as `worktrees`/`sample`).
   Fallback tool-side paging happens only after the gateway has applied semantic
-  filters.
+  filters, and REST-paged responses are annotated rather than re-sliced.
 
 
   `pagination` includes:
@@ -109,33 +116,29 @@ detail_docs: >-
 
   | `search` | `/api/search` (`?q`, `?type`, `?limit`, `?offset`, `?projectId`) | `q` | `q`, `type`, `projectId`, `limit`, `offset` |
 
-  | `list_projects` | `/api/projects` (paging) | — | `limit`, `offset` |
+  | `list_projects` | `/api/projects` | — | `limit`, `offset` (tool-side fallback) |
 
   | `get_project` | `/api/projects/:projectId` | `projectId` | — |
 
-  | `list_workflows` | `/api/workflows` (`?projectId`, paging) | `projectId`* | `projectId`, `limit`, `offset` |
+  | `list_workflows` | `/api/workflows` (`?projectId`) | `projectId` | `projectId`, `limit`, `offset` (tool-side fallback) |
 
   | `get_workflow` | `/api/workflows/:workflowId` (`?projectId`) | `workflowId` | `projectId` |
 
-  | `list_roles` | `/api/roles` (`?projectId`, paging) | — | `projectId`, `limit`, `offset` |
+  | `list_roles` | `/api/roles` (`?projectId`) | — | `projectId`, `limit`, `offset` (tool-side fallback) |
 
-  | `list_tools` | `/api/tools` (`?projectId`, paging) | — | `projectId`, `limit`, `offset` |
+  | `list_tools` | `/api/tools` (`?projectId`) | — | `projectId`, `limit`, `offset` (tool-side fallback) |
 
-  | `list_gates` | `/api/goals/:goalId/gates` (`?view`, paging) | `goalId` | `view`, `limit`, `offset` |
+  | `list_gates` | `/api/goals/:goalId/gates` (`?view`) | `goalId` | `view`, `limit`, `offset` (tool-side fallback) |
 
-  | `list_tasks` | `/api/goals/:goalId/tasks` (`?view`, paging) | `goalId` | `view`, `limit`, `offset` |
+  | `list_tasks` | `/api/goals/:goalId/tasks` (`?view`) | `goalId` | `view`, `limit`, `offset` (tool-side fallback) |
 
   | `get_task` | `/api/tasks/:taskId` | `taskId` | — |
 
-  | `list_staff` | `/api/staff` (`?projectId`, paging) | — | `projectId`, `limit`, `offset` |
+  | `list_staff` | `/api/staff` (`?projectId`) | — | `projectId`, `limit`, `offset` (tool-side fallback) |
 
-  | `list_mcp_servers` | `/api/mcp-servers` (`?projectId`, paging) | — | `projectId`, `limit`, `offset` |
+  | `list_mcp_servers` | `/api/mcp-servers` (`?projectId`) | — | `projectId`, `limit`, `offset` (tool-side fallback) |
 
-  | `maintenance_inspect` | see `probe` below | `probe` | `probe`, supported `projectId`, paging for large array probes |
-
-
-  \* `list_workflows` returns an empty list without `projectId` — the gateway
-  will not error, but pass `projectId` for a useful result.
+  | `maintenance_inspect` | see `probe` below | `probe` | `probe`, supported `projectId`, tool-side paging for large array probes |
 
 
   ### Semantic filter audit

--- a/defaults/tools/bobbit/extension.ts
+++ b/defaults/tools/bobbit/extension.ts
@@ -185,7 +185,7 @@ function sliceByPath(data: unknown, spec: PageSpec, paging: NormalizedPaging): {
 
 	const start = hasRestPagination ? 0 : paging.mode === "offset" ? paging.offset : 0;
 	const end = start + paging.limit;
-	const shouldSlice = !hasRestPagination || sourceItems.length > paging.limit;
+	const shouldSlice = !hasRestPagination;
 	const items = shouldSlice ? sourceItems.slice(start, end) : sourceItems;
 	const total = numberField(data, "total") ?? numberField(pagination, "total") ?? (hasRestPagination ? undefined : sourceItems.length);
 	const pagedBy = shouldSlice ? "tool" : "rest";

--- a/defaults/tools/bobbit/extension.ts
+++ b/defaults/tools/bobbit/extension.ts
@@ -114,7 +114,7 @@ function normalizePaging(params: Params, spec: PageSpec): NormalizedPaging {
 function appendPagingQuery(base: string, entries: Array<[string, unknown]>, params: Params, spec: PageSpec): string {
 	const paging = normalizePaging(params, spec);
 	const pagingEntries: Array<[string, unknown]> = [["limit", paging.limit]];
-	if (paging.mode === "cursor") {
+	if (paging.mode === "cursor" && paging.cursor !== undefined) {
 		pagingEntries.push(["after", paging.cursor]);
 	} else {
 		pagingEntries.push(["offset", paging.offset]);

--- a/defaults/tools/bobbit/extension.ts
+++ b/defaults/tools/bobbit/extension.ts
@@ -616,7 +616,7 @@ export default function (pi: ExtensionAPI) {
 			workflowId: Type.Optional(Type.String({ description: "Workflow id." })),
 			q: Type.Optional(Type.String({ description: "Free-text query filter." })),
 			type: Type.Optional(Type.String({ description: "search type: all|goals|sessions|messages|staff." })),
-			limit: Type.Optional(Type.Number({ description: "Page size for list operations. Defaults to 50 (20 for search), max 200 (100 for search)." })),
+			limit: Type.Optional(Type.Number({ description: "Page size. Defaults: lists 50, search 20; max: lists 200, search 100." })),
 			offset: Type.Optional(Type.Number({ description: "Offset for list operations. Defaults to 0; ignored when cursor/after is used." })),
 			after: Type.Optional(Type.Union([Type.String(), Type.Number()], { description: "Cursor for cursor-backed list operations." })),
 			cursor: Type.Optional(Type.Union([Type.String(), Type.Number()], { description: "Alias for after on cursor-backed list operations." })),

--- a/defaults/tools/bobbit/extension.ts
+++ b/defaults/tools/bobbit/extension.ts
@@ -39,6 +39,19 @@ class ApiError extends Error {
 
 type Params = Record<string, any>;
 
+interface PageSpec {
+	/** Primary array key exposed in the response and pagination metadata. */
+	itemKey: string;
+	/** Optional nested path to the array; defaults to [itemKey]. */
+	itemPath?: string[];
+	/** Default page size for this operation. */
+	defaultLimit?: number;
+	/** Maximum page size for this operation. */
+	maxLimit?: number;
+	/** Whether this operation should use cursor (`after`) pagination for these params. */
+	cursor?: boolean | ((p: Params) => boolean);
+}
+
 interface OpSpec {
 	/** HTTP method, or a function of params for verb-multiplexed operations. */
 	method: string | ((p: Params) => string);
@@ -46,6 +59,22 @@ interface OpSpec {
 	buildBody?: (p: Params) => unknown;
 	/** Param names that must be present (non-empty) before dispatch. */
 	required: string[];
+	/** Optional tool-output pagination for list-style read operations. */
+	page?: PageSpec | ((p: Params) => PageSpec | undefined);
+}
+
+const DEFAULT_PAGE_LIMIT = 50;
+const MAX_PAGE_LIMIT = 200;
+const DEFAULT_SEARCH_LIMIT = 20;
+const MAX_SEARCH_LIMIT = 100;
+
+type PageMode = "offset" | "cursor";
+
+interface NormalizedPaging {
+	limit: number;
+	offset: number;
+	cursor?: string | number;
+	mode: PageMode;
 }
 
 /** Build a path with a query string, skipping undefined/null/"" values. */
@@ -56,6 +85,146 @@ function withQuery(base: string, entries: Array<[string, unknown]>): string {
 	}
 	const s = qs.toString();
 	return s ? `${base}?${s}` : base;
+}
+
+function parseInteger(value: unknown): number | undefined {
+	if (value === undefined || value === null || value === "") return undefined;
+	const n = typeof value === "number" ? value : Number.parseInt(String(value), 10);
+	return Number.isFinite(n) ? Math.trunc(n) : undefined;
+}
+
+function clampInteger(value: unknown, fallback: number, min: number, max: number): number {
+	const n = parseInteger(value) ?? fallback;
+	return Math.min(Math.max(n, min), max);
+}
+
+function isCursorPaging(params: Params, spec: PageSpec): boolean {
+	return typeof spec.cursor === "function" ? spec.cursor(params) : spec.cursor === true;
+}
+
+function normalizePaging(params: Params, spec: PageSpec): NormalizedPaging {
+	const limit = clampInteger(params.limit, spec.defaultLimit ?? DEFAULT_PAGE_LIMIT, 1, spec.maxLimit ?? MAX_PAGE_LIMIT);
+	const offset = Math.max(0, parseInteger(params.offset) ?? 0);
+	const rawCursor = params.cursor ?? params.after;
+	const cursor = rawCursor !== undefined && rawCursor !== null && rawCursor !== "" ? rawCursor as string | number : undefined;
+	const mode: PageMode = isCursorPaging(params, spec) ? "cursor" : "offset";
+	return { limit, offset, cursor, mode };
+}
+
+function appendPagingQuery(base: string, entries: Array<[string, unknown]>, params: Params, spec: PageSpec): string {
+	const paging = normalizePaging(params, spec);
+	const pagingEntries: Array<[string, unknown]> = [["limit", paging.limit]];
+	if (paging.mode === "cursor") {
+		pagingEntries.push(["after", paging.cursor]);
+	} else {
+		pagingEntries.push(["offset", paging.offset]);
+	}
+	return withQuery(base, [...entries, ...pagingEntries]);
+}
+
+function getAtPath(value: unknown, itemPath: string[]): unknown {
+	let current = value as any;
+	for (const key of itemPath) {
+		if (current === undefined || current === null) return undefined;
+		current = current[key];
+	}
+	return current;
+}
+
+function setAtPath(value: Record<string, unknown>, itemPath: string[], replacement: unknown): Record<string, unknown> {
+	const clone: Record<string, unknown> = Array.isArray(value) ? [...value] as any : { ...value };
+	let current: any = clone;
+	for (let i = 0; i < itemPath.length - 1; i += 1) {
+		const key = itemPath[i];
+		const next = current[key];
+		current[key] = next && typeof next === "object" ? (Array.isArray(next) ? [...next] : { ...next }) : {};
+		current = current[key];
+	}
+	current[itemPath[itemPath.length - 1]] = replacement;
+	return clone;
+}
+
+function numberField(source: unknown, field: string): number | undefined {
+	if (!source || typeof source !== "object") return undefined;
+	const value = (source as Record<string, unknown>)[field];
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function booleanField(source: unknown, field: string): boolean | undefined {
+	if (!source || typeof source !== "object") return undefined;
+	const value = (source as Record<string, unknown>)[field];
+	return typeof value === "boolean" ? value : undefined;
+}
+
+function valueField(source: unknown, field: string): string | number | undefined {
+	if (!source || typeof source !== "object") return undefined;
+	const value = (source as Record<string, unknown>)[field];
+	return typeof value === "string" || typeof value === "number" ? value : undefined;
+}
+
+function sliceByPath(data: unknown, spec: PageSpec, paging: NormalizedPaging): {
+	result: unknown;
+	items: unknown[];
+	total?: number;
+	hasRestPagination: boolean;
+	pagedBy: "rest" | "tool";
+	start: number;
+	sourceLength: number;
+} | undefined {
+	const itemPath = spec.itemPath ?? [spec.itemKey];
+	const pagination = data && typeof data === "object" && !Array.isArray(data) ? (data as Record<string, unknown>).pagination : undefined;
+	const hasRestPagination = Boolean(
+		pagination
+		|| numberField(data, "total") !== undefined
+		|| booleanField(data, "hasMore") !== undefined
+		|| valueField(data, "nextCursor") !== undefined
+		|| numberField(data, "nextOffset") !== undefined,
+	);
+	const sourceItems = Array.isArray(data) ? data : getAtPath(data, itemPath);
+	if (!Array.isArray(sourceItems)) return undefined;
+
+	const start = hasRestPagination ? 0 : paging.mode === "offset" ? paging.offset : 0;
+	const end = start + paging.limit;
+	const shouldSlice = !hasRestPagination || sourceItems.length > paging.limit;
+	const items = shouldSlice ? sourceItems.slice(start, end) : sourceItems;
+	const total = numberField(data, "total") ?? numberField(pagination, "total") ?? (hasRestPagination ? undefined : sourceItems.length);
+	const pagedBy = shouldSlice ? "tool" : "rest";
+	const result = Array.isArray(data)
+		? { [spec.itemKey]: items }
+		: setAtPath(data as Record<string, unknown>, itemPath, items);
+	return { result, items, total, hasRestPagination, pagedBy, start, sourceLength: sourceItems.length };
+}
+
+function pageResult(data: unknown, params: Params, spec: PageSpec): unknown {
+	const paging = normalizePaging(params, spec);
+	const sliced = sliceByPath(data, spec, paging);
+	if (!sliced) return data;
+	const pagination = data && typeof data === "object" && !Array.isArray(data) ? (data as Record<string, unknown>).pagination : undefined;
+	const total = sliced.total;
+	const computedHasMore = (sliced.start + sliced.items.length) < (total ?? sliced.sourceLength);
+	const topLevelHasMore = booleanField(data, "hasMore") ?? booleanField(pagination, "hasMore");
+	const hasMore = Boolean(sliced.pagedBy === "tool" ? (topLevelHasMore || computedHasMore) : (topLevelHasMore ?? computedHasMore));
+	const nextOffset = paging.mode === "offset" && hasMore
+		? numberField(data, "nextOffset") ?? numberField(pagination, "nextOffset") ?? paging.offset + sliced.items.length
+		: undefined;
+	const nextCursor = paging.mode === "cursor"
+		? valueField(data, "nextCursor") ?? valueField(pagination, "nextCursor")
+		: undefined;
+	return {
+		...(sliced.result as Record<string, unknown>),
+		pagination: {
+			limit: paging.limit,
+			...(paging.mode === "offset" ? { offset: paging.offset } : {}),
+			...(total !== undefined ? { total } : {}),
+			hasMore,
+			...(nextOffset !== undefined ? { nextOffset } : {}),
+			...(paging.mode === "cursor" && paging.cursor !== undefined ? { cursor: paging.cursor } : {}),
+			...(nextCursor !== undefined ? { nextCursor } : {}),
+			mode: paging.mode,
+			itemKey: spec.itemKey,
+			pagedBy: sliced.pagedBy,
+		},
+	};
 }
 
 // GET-only maintenance probes for bobbit_read.maintenance_inspect.
@@ -70,6 +239,15 @@ const PROBE_PATHS: Record<string, string> = {
 	sandbox_pool: "/api/sandbox-pool",
 	sandbox_status: "/api/sandbox-status",
 	search_stats: "/api/search/stats",
+};
+
+const MAINTENANCE_PROJECT_FILTER_PROBES = new Set(["orphaned_index_rows", "search_stats", "worktree_pool", "sandbox_status"]);
+
+const MAINTENANCE_PAGE_SPECS: Record<string, PageSpec | undefined> = {
+	orphaned_worktrees: { itemKey: "worktrees" },
+	orphaned_sessions: { itemKey: "sessions" },
+	orphaned_index_rows: { itemKey: "sample" },
+	archived_session_worktrees: { itemKey: "worktrees" },
 };
 
 // POST maintenance/search actions for bobbit_admin.maintenance_cleanup.
@@ -89,8 +267,12 @@ const READ_OPS: Record<string, OpSpec> = {
 	connection_info: { method: "GET", buildPath: () => "/api/connection-info", required: [] },
 	list_goals: {
 		method: "GET",
-		buildPath: (p) => withQuery("/api/goals", [["archived", p.archived], ["q", p.q]]),
+		buildPath: (p) => appendPagingQuery("/api/goals", [["archived", p.archived], ["q", p.q], ["projectId", p.projectId]], p, {
+			itemKey: "goals",
+			cursor: (params) => params.archived === true || params.archived === "true",
+		}),
 		required: [],
+		page: (p) => ({ itemKey: "goals", cursor: p.archived === true || p.archived === "true" }),
 	},
 	get_goal: { method: "GET", buildPath: (p) => `/api/goals/${p.goalId}`, required: ["goalId"] },
 	goal_cost: { method: "GET", buildPath: (p) => `/api/goals/${p.goalId}/cost`, required: ["goalId"] },
@@ -99,61 +281,66 @@ const READ_OPS: Record<string, OpSpec> = {
 	goal_pr_status: { method: "GET", buildPath: (p) => `/api/goals/${p.goalId}/pr-status`, required: ["goalId"] },
 	list_sessions: {
 		method: "GET",
-		buildPath: (p) => withQuery("/api/sessions", [["include", p.include], ["q", p.q], ["projectId", p.projectId]]),
+		buildPath: (p) => appendPagingQuery("/api/sessions", [["include", p.include], ["q", p.q], ["projectId", p.projectId]], p, {
+			itemKey: "sessions",
+			cursor: (params) => String(params.include ?? "").split(",").includes("archived"),
+		}),
 		required: [],
+		page: (p) => ({ itemKey: "sessions", cursor: String(p.include ?? "").split(",").includes("archived") }),
 	},
 	get_session: { method: "GET", buildPath: (p) => `/api/sessions/${p.sessionId}`, required: ["sessionId"] },
 	session_cost: { method: "GET", buildPath: (p) => `/api/sessions/${p.sessionId}/cost`, required: ["sessionId"] },
 	search: {
 		method: "GET",
-		buildPath: (p) =>
-			withQuery("/api/search", [
-				["q", p.q],
-				["type", p.type],
-				["limit", p.limit],
-				["offset", p.offset],
-				["projectId", p.projectId],
-			]),
+		buildPath: (p) => appendPagingQuery("/api/search", [["q", p.q], ["type", p.type], ["projectId", p.projectId]], p, {
+			itemKey: "results",
+			defaultLimit: DEFAULT_SEARCH_LIMIT,
+			maxLimit: MAX_SEARCH_LIMIT,
+		}),
 		required: ["q"],
+		page: { itemKey: "results", defaultLimit: DEFAULT_SEARCH_LIMIT, maxLimit: MAX_SEARCH_LIMIT },
 	},
-	list_projects: { method: "GET", buildPath: () => "/api/projects", required: [] },
+	list_projects: { method: "GET", buildPath: () => "/api/projects", required: [], page: { itemKey: "projects" } },
 	get_project: { method: "GET", buildPath: (p) => `/api/projects/${p.projectId}`, required: ["projectId"] },
 	list_workflows: {
 		method: "GET",
 		buildPath: (p) => withQuery("/api/workflows", [["projectId", p.projectId]]),
 		required: ["projectId"],
+		page: { itemKey: "workflows" },
 	},
 	get_workflow: {
 		method: "GET",
 		buildPath: (p) => withQuery(`/api/workflows/${p.workflowId}`, [["projectId", p.projectId]]),
 		required: ["workflowId"],
 	},
-	list_roles: { method: "GET", buildPath: () => "/api/roles", required: [] },
-	list_tools: { method: "GET", buildPath: (p) => withQuery("/api/tools", [["projectId", p.projectId]]), required: [] },
+	list_roles: { method: "GET", buildPath: (p) => withQuery("/api/roles", [["projectId", p.projectId]]), required: [], page: { itemKey: "roles" } },
+	list_tools: { method: "GET", buildPath: (p) => withQuery("/api/tools", [["projectId", p.projectId]]), required: [], page: { itemKey: "tools" } },
 	list_gates: {
 		method: "GET",
 		buildPath: (p) => withQuery(`/api/goals/${p.goalId}/gates`, [["view", p.view]]),
 		required: ["goalId"],
+		page: { itemKey: "gates" },
 	},
 	list_tasks: {
 		method: "GET",
 		buildPath: (p) => withQuery(`/api/goals/${p.goalId}/tasks`, [["view", p.view]]),
 		required: ["goalId"],
+		page: { itemKey: "tasks" },
 	},
 	get_task: { method: "GET", buildPath: (p) => `/api/tasks/${p.taskId}`, required: ["taskId"] },
-	list_staff: { method: "GET", buildPath: () => "/api/staff", required: [] },
-	list_mcp_servers: { method: "GET", buildPath: () => "/api/mcp-servers", required: [] },
+	list_staff: { method: "GET", buildPath: (p) => withQuery("/api/staff", [["projectId", p.projectId]]), required: [], page: { itemKey: "staff" } },
+	list_mcp_servers: { method: "GET", buildPath: (p) => withQuery("/api/mcp-servers", [["projectId", p.projectId]]), required: [], page: { itemKey: "servers" } },
 	maintenance_inspect: {
 		method: "GET",
 		buildPath: (p) => {
 			const base = PROBE_PATHS[p.probe];
 			if (!base) throw new Error(`unknown maintenance_inspect probe '${p.probe}'`);
-			if (p.probe === "orphaned_index_rows" || p.probe === "search_stats") {
-				return withQuery(base, [["projectId", p.projectId]]);
-			}
-			return base;
+			return MAINTENANCE_PROJECT_FILTER_PROBES.has(p.probe)
+				? withQuery(base, [["projectId", p.projectId]])
+				: base;
 		},
 		required: ["probe"],
+		page: (p) => MAINTENANCE_PAGE_SPECS[p.probe],
 	},
 };
 
@@ -383,8 +570,12 @@ export default function (pi: ExtensionAPI) {
 		return { content: [{ type: "text" as const, text: msg }], details: undefined, isError: true };
 	}
 
+	function resolvePageSpec(spec: OpSpec, params: Params): PageSpec | undefined {
+		return typeof spec.page === "function" ? spec.page(params) : spec.page;
+	}
+
 	/** Dispatch an operation through a tier's OpSpec table. */
-	async function dispatch(ops: Record<string, OpSpec>, params: Params) {
+	async function dispatch(ops: Record<string, OpSpec>, params: Params, options?: { pageResults?: boolean }) {
 		const spec = ops[params.operation];
 		if (!spec) return err(`unknown operation '${params.operation}'`);
 		for (const field of spec.required) {
@@ -397,7 +588,9 @@ export default function (pi: ExtensionAPI) {
 			const method = typeof spec.method === "function" ? spec.method(params) : spec.method;
 			const urlPath = spec.buildPath(params);
 			const body = spec.buildBody ? spec.buildBody(params) : undefined;
-			return ok(await api(method, urlPath, body));
+			const data = await api(method, urlPath, body);
+			const pageSpec = options?.pageResults ? resolvePageSpec(spec, params) : undefined;
+			return ok(pageSpec ? pageResult(data, params, pageSpec) : data);
 		} catch (e: any) {
 			return err(e.message);
 		}
@@ -423,15 +616,17 @@ export default function (pi: ExtensionAPI) {
 			workflowId: Type.Optional(Type.String({ description: "Workflow id." })),
 			q: Type.Optional(Type.String({ description: "Free-text query filter." })),
 			type: Type.Optional(Type.String({ description: "search type: all|goals|sessions|messages|staff." })),
-			limit: Type.Optional(Type.Number({ description: "search: max results." })),
-			offset: Type.Optional(Type.Number({ description: "search: result offset." })),
+			limit: Type.Optional(Type.Number({ description: "Page size for list operations. Defaults to 50 (20 for search), max 200 (100 for search)." })),
+			offset: Type.Optional(Type.Number({ description: "Offset for list operations. Defaults to 0; ignored when cursor/after is used." })),
+			after: Type.Optional(Type.Union([Type.String(), Type.Number()], { description: "Cursor for cursor-backed list operations." })),
+			cursor: Type.Optional(Type.Union([Type.String(), Type.Number()], { description: "Alias for after on cursor-backed list operations." })),
 			archived: Type.Optional(Type.Boolean({ description: "Include archived items." })),
 			include: Type.Optional(Type.String({ description: "Inclusion flag, e.g. 'archived'." })),
 			view: Type.Optional(Type.String({ description: "Response view, e.g. 'summary'." })),
 			probe: Type.Optional(Type.String({ description: "maintenance_inspect probe selector." })),
 		}),
 		async execute(_id: string, params: Params) {
-			return dispatch(READ_OPS, params);
+			return dispatch(READ_OPS, params, { pageResults: true });
 		},
 	});
 

--- a/docs/bobbit-gateway-tool.md
+++ b/docs/bobbit-gateway-tool.md
@@ -91,7 +91,11 @@ methods, and body keys see each tool's `detail_docs` and
 
 ### `bobbit_read` — read-only introspection
 
-All operations are GETs with no side effects.
+All operations are GETs with no side effects. List-style operations are bounded
+by default (`limit=50`, `offset=0`, max `200`) and return a `pagination` object.
+`list_sessions`, `list_goals`, and `search` use REST pagination; other list
+operations page the already-filtered gateway response in the tool. REST-paged
+responses are annotated, not re-sliced.
 
 - `health`, `connection_info` — gateway liveness + network info.
 - `list_goals` (`archived`, `q`), `get_goal` — enumerate / fetch goals.
@@ -101,8 +105,8 @@ All operations are GETs with no side effects.
   `session_cost` — enumerate / fetch sessions and their cost.
 - `search` — full-text search across goals/sessions/messages/staff.
 - `list_projects`, `get_project` — project registry.
-- `list_workflows`, `get_workflow` — workflow templates (pass `projectId`;
-  `list_workflows` returns an empty list without it — the call does not error).
+- `list_workflows`, `get_workflow` — workflow templates (`list_workflows`
+  requires `projectId`; `get_workflow` accepts it as a scope filter).
 - `list_roles`, `list_tools` — resolved roles and the tool catalogue.
 - `list_gates`, `list_tasks` (by arbitrary `goalId`), `get_task` — cross-goal
   gate/task boards.

--- a/docs/design/bobbit-gateway-tool.md
+++ b/docs/design/bobbit-gateway-tool.md
@@ -21,8 +21,9 @@ operation-dispatched surface split into three tools by privilege:
 - **`bobbit_admin`** — config + destructive maintenance (highest privilege).
 
 Each tool takes an `operation` discriminator plus operation-specific params
-(validated with TypeBox), and returns the gateway's JSON verbatim, or a
-structured error surfacing the gateway `{ error, code }` shape.
+(validated with TypeBox). Non-list reads return the gateway JSON unchanged;
+`bobbit_read` list operations return bounded pages with pagination metadata.
+Failures surface the gateway `{ error, code }` shape.
 
 ## 2. Resolved decisions (decided — do not re-litigate)
 
@@ -193,7 +194,8 @@ operations would (a) blow the param-description budget and (b) be unwieldy.
     the catalogue is in `detail_docs`).
   - A flat set of `Type.Optional(...)` shared params covering the union of
     fields the operations use (e.g. `goalId?`, `sessionId?`, `taskId?`,
-    `projectId?`, `gateId?`, `q?`, `archived?`, `include?`, `body?`). Common
+    `projectId?`, `gateId?`, `q?`, `limit?`, `offset?`, `after?`, `cursor?`,
+    `archived?`, `include?`, `body?`). Common
     scalar ids are first-class optional fields; free-form request bodies for the
     richer POST/PUT operations are passed via a single
     `body?: Type.Optional(Type.Record(Type.String(), Type.Unknown()))` (or
@@ -223,47 +225,99 @@ as `?k=`. "Body" lists the JSON body keys the handler reads.
 
 ### 5.1 `bobbit_read` (group `Bobbit`, all GET)
 
-| operation | method | path | required | optional |
+`bobbit_read` is read-only. Non-list operations return the gateway response
+unchanged. List-style operations are bounded by default so agents do not dump
+large collections into context.
+
+#### Shared pagination
+
+Shared paging params for list-style reads:
+
+- `limit` — page size. Default `50`, maximum `200`.
+- `offset` — zero-based offset. Default `0`.
+- `after` — cursor query name used by archived session/goal endpoints.
+- `cursor` — generic alias for cursor-backed calls. If both cursor and offset
+  params are present for a cursor-backed operation, cursor mode wins.
+
+`search` keeps its endpoint-specific defaults (`limit=20`, max `100`) unless a
+caller passes `limit`, but still returns normalized pagination metadata.
+
+List responses preserve the endpoint's normal item key and add:
+
+```ts
+interface PageMetadata {
+  limit: number;
+  offset?: number;
+  total?: number;
+  hasMore: boolean;
+  nextOffset?: number;
+  cursor?: string | number;
+  nextCursor?: string | number;
+  mode: "offset" | "cursor";
+  itemKey: string;
+  pagedBy: "rest" | "tool";
+}
+```
+
+REST-level paging is preferred when the endpoint supports it. Otherwise the tool
+pages the already-filtered gateway response and preserves ancillary fields such
+as counts, diagnostics, summaries, and delegate/session metadata.
+
+#### Operation catalogue and semantic filters
+
+| operation | method | path | required | semantic filters / paging |
 |---|---|---|---|---|
 | `health` | GET | `/api/health` | — | — |
 | `connection_info` | GET | `/api/connection-info` | — | — |
-| `list_goals` | GET | `/api/goals` | — | `archived` (`?archived=true`), `q` |
+| `list_goals` | GET | `/api/goals` | — | `projectId`, `archived` (`?archived=true`), `q`, `limit`, `offset`, `after`/`cursor` |
 | `get_goal` | GET | `/api/goals/:goalId` | `goalId` | — |
 | `goal_cost` | GET | `/api/goals/:goalId/cost` | `goalId` | — |
 | `goal_git_status` | GET | `/api/goals/:goalId/git-status` | `goalId` | — |
 | `goal_commits` | GET | `/api/goals/:goalId/commits` | `goalId` | — |
 | `goal_pr_status` | GET | `/api/goals/:goalId/pr-status` | `goalId` | — |
-| `list_sessions` | GET | `/api/sessions` | — | `include` (`?include=archived`), `q`, `projectId` |
+| `list_sessions` | GET | `/api/sessions` | — | `include`, `q`, `projectId`, `limit`, `offset`, `after`/`cursor` |
 | `get_session` | GET | `/api/sessions/:sessionId` | `sessionId` | — |
 | `session_cost` | GET | `/api/sessions/:sessionId/cost` | `sessionId` | — |
-| `search` | GET | `/api/search` | `q` | `type` (all\|goals\|sessions\|messages\|staff), `limit`, `offset`, `projectId` |
-| `list_projects` | GET | `/api/projects` | — | — |
+| `search` | GET | `/api/search` | `q` | `q`, `type` (all\|goals\|sessions\|messages\|staff), `projectId`, `limit`, `offset` |
+| `list_projects` | GET | `/api/projects` | — | `limit`, `offset` |
 | `get_project` | GET | `/api/projects/:projectId` | `projectId` | — |
-| `list_workflows` | GET | `/api/workflows` | `projectId` | — (empty list without projectId) |
+| `list_workflows` | GET | `/api/workflows` | `projectId` | `projectId`, `limit`, `offset` |
 | `get_workflow` | GET | `/api/workflows/:workflowId` | `workflowId` | `projectId` (`?projectId=`) |
-| `list_roles` | GET | `/api/roles` | — | — |
-| `list_tools` | GET | `/api/tools` | — | `projectId` (config scope) |
-| `list_gates` | GET | `/api/goals/:goalId/gates` | `goalId` | `view` (`?view=summary`) |
-| `list_tasks` | GET | `/api/goals/:goalId/tasks` | `goalId` | `view` (`?view=summary`) |
+| `list_roles` | GET | `/api/roles` | — | `projectId`, `limit`, `offset` |
+| `list_tools` | GET | `/api/tools` | — | `projectId`, `limit`, `offset` |
+| `list_gates` | GET | `/api/goals/:goalId/gates` | `goalId` | `view` (`?view=summary`), `limit`, `offset` |
+| `list_tasks` | GET | `/api/goals/:goalId/tasks` | `goalId` | `view` (`?view=summary`), `limit`, `offset` |
 | `get_task` | GET | `/api/tasks/:taskId` | `taskId` | — |
-| `list_staff` | GET | `/api/staff` | — | — |
-| `list_mcp_servers` | GET | `/api/mcp-servers` | — | — |
-| `maintenance_inspect` | GET | (see sub-probes) | `probe` | `projectId` |
+| `list_staff` | GET | `/api/staff` | — | `projectId`, `limit`, `offset` |
+| `list_mcp_servers` | GET | `/api/mcp-servers` | — | `projectId`, `limit`, `offset` |
+| `maintenance_inspect` | GET | (see sub-probes) | `probe` | `probe`, supported `projectId`, paging for large array probes |
+
+Semantic filter notes:
+
+- `projectId` is forwarded for `list_sessions`, `list_goals`,
+  `list_workflows`, `get_workflow`, `list_roles`, `list_tools`, `list_staff`,
+  `list_mcp_servers`, and supported maintenance probes.
+- `goalId` path-scopes `list_gates` and `list_tasks`; `view` projection is
+  applied before paging.
+- `q` filters `list_sessions`, `list_goals`, and `search`; `type` applies only
+  to `search`.
+- `include` applies only to `list_sessions`; `archived` applies only to
+  `list_goals`.
 
 **`maintenance_inspect`** takes a `probe` param selecting one GET-only probe:
 
-| `probe` value | path |
-|---|---|
-| `orphaned_worktrees` | `/api/maintenance/orphaned-worktrees` |
-| `orphaned_sessions` | `/api/maintenance/orphaned-sessions` |
-| `expired_archives` | `/api/maintenance/expired-archives` |
-| `orphaned_index_rows` | `/api/maintenance/orphaned-index-rows` (`?projectId=`) |
-| `worktrees` | `/api/maintenance/worktrees` |
-| `archived_session_worktrees` | `/api/maintenance/archived-session-worktrees` |
-| `worktree_pool` | `/api/worktree-pool` |
-| `sandbox_pool` | `/api/sandbox-pool` |
-| `sandbox_status` | `/api/sandbox-status` |
-| `search_stats` | `/api/search/stats` (`?projectId=`) |
+| `probe` value | path | filters / paging |
+|---|---|---|
+| `orphaned_worktrees` | `/api/maintenance/orphaned-worktrees` | pages `worktrees` |
+| `orphaned_sessions` | `/api/maintenance/orphaned-sessions` | pages `sessions` |
+| `expired_archives` | `/api/maintenance/expired-archives` | scalar/stat response |
+| `orphaned_index_rows` | `/api/maintenance/orphaned-index-rows` | `projectId`, pages `sample` |
+| `worktrees` | `/api/maintenance/worktrees` | scalar/stat response unless an array key is present |
+| `archived_session_worktrees` | `/api/maintenance/archived-session-worktrees` | pages `worktrees` |
+| `worktree_pool` | `/api/worktree-pool` | `projectId` |
+| `sandbox_pool` | `/api/sandbox-pool` | scalar/stat response |
+| `sandbox_status` | `/api/sandbox-status` | `projectId` |
+| `search_stats` | `/api/search/stats` | `projectId` |
 
 > `list_workflows` returns an empty list when `projectId` is omitted (there is
 > no server-scope workflow set). We mark `projectId` **required** at the tool
@@ -372,6 +426,11 @@ Type.Object({
   name: Type.Optional(Type.String({ description: "Resource name (tool/role/provider/pack/staff)." })),
   // query-ish
   q: Type.Optional(Type.String({ description: "Free-text query filter." })),
+  type: Type.Optional(Type.String({ description: "search: all|goals|sessions|messages|staff." })),
+  limit: Type.Optional(Type.Number({ description: "Page size for list/search results." })),
+  offset: Type.Optional(Type.Number({ description: "Zero-based offset for paged results." })),
+  after: Type.Optional(Type.String({ description: "Cursor token for cursor-backed endpoints." })),
+  cursor: Type.Optional(Type.String({ description: "Generic cursor alias; cursor wins over offset." })),
   archived: Type.Optional(Type.Boolean({ description: "Include archived items." })),
   include: Type.Optional(Type.String({ description: "Inclusion flag, e.g. 'archived'." })),
   view: Type.Optional(Type.String({ description: "Response view, e.g. 'summary'." })),
@@ -386,10 +445,11 @@ Type.Object({
 })
 ```
 
-Keep every `description` ≤ 80 chars (budget §9). `bobbit_read` omits
-`cascade`/`action`/`body`; `bobbit_orchestrate` omits `probe`;
-`bobbit_admin` omits `probe`/`gateId`. Trim the shared block per tool to only
-the fields that tier uses — smaller schema, lower budget.
+Keep every `description` ≤ 80 chars (budget §9). `bobbit_read` includes the
+shared paging fields (`limit`, `offset`, `after`, `cursor`) and omits
+`cascade`/`action`/`body`; `bobbit_orchestrate` omits `probe` and paging unless
+an operation needs it; `bobbit_admin` omits `probe`/`gateId`. Trim the shared
+block per tool to only the fields that tier uses — smaller schema, lower budget.
 
 ## 6. Tiering & `grantPolicy`
 

--- a/docs/design/bobbit-gateway-tool.md
+++ b/docs/design/bobbit-gateway-tool.md
@@ -259,9 +259,14 @@ interface PageMetadata {
 }
 ```
 
-REST-level paging is preferred when the endpoint supports it. Otherwise the tool
-pages the already-filtered gateway response and preserves ancillary fields such
-as counts, diagnostics, summaries, and delegate/session metadata.
+REST-level paging is used by `list_sessions`, `list_goals`, and `search`, which
+return page fields such as `total`, `hasMore`, `nextOffset`, or `nextCursor`.
+When those REST page fields are present, the tool adds normalized `pagination`
+metadata but does **not** slice the returned array again. Other list-style
+operations are paged tool-side after the gateway response has already been
+scoped by semantic filters such as `projectId`, `goalId`, and `view`; ancillary
+fields such as counts, diagnostics, summaries, and delegate/session metadata are
+preserved.
 
 #### Operation catalogue and semantic filters
 
@@ -279,18 +284,18 @@ as counts, diagnostics, summaries, and delegate/session metadata.
 | `get_session` | GET | `/api/sessions/:sessionId` | `sessionId` | — |
 | `session_cost` | GET | `/api/sessions/:sessionId/cost` | `sessionId` | — |
 | `search` | GET | `/api/search` | `q` | `q`, `type` (all\|goals\|sessions\|messages\|staff), `projectId`, `limit`, `offset` |
-| `list_projects` | GET | `/api/projects` | — | `limit`, `offset` |
+| `list_projects` | GET | `/api/projects` | — | `limit`, `offset` (tool-side fallback) |
 | `get_project` | GET | `/api/projects/:projectId` | `projectId` | — |
-| `list_workflows` | GET | `/api/workflows` | `projectId` | `projectId`, `limit`, `offset` |
+| `list_workflows` | GET | `/api/workflows` | `projectId` | `projectId`, `limit`, `offset` (tool-side fallback) |
 | `get_workflow` | GET | `/api/workflows/:workflowId` | `workflowId` | `projectId` (`?projectId=`) |
-| `list_roles` | GET | `/api/roles` | — | `projectId`, `limit`, `offset` |
-| `list_tools` | GET | `/api/tools` | — | `projectId`, `limit`, `offset` |
-| `list_gates` | GET | `/api/goals/:goalId/gates` | `goalId` | `view` (`?view=summary`), `limit`, `offset` |
-| `list_tasks` | GET | `/api/goals/:goalId/tasks` | `goalId` | `view` (`?view=summary`), `limit`, `offset` |
+| `list_roles` | GET | `/api/roles` | — | `projectId`, `limit`, `offset` (tool-side fallback) |
+| `list_tools` | GET | `/api/tools` | — | `projectId`, `limit`, `offset` (tool-side fallback) |
+| `list_gates` | GET | `/api/goals/:goalId/gates` | `goalId` | `view` (`?view=summary`), `limit`, `offset` (tool-side fallback) |
+| `list_tasks` | GET | `/api/goals/:goalId/tasks` | `goalId` | `view` (`?view=summary`), `limit`, `offset` (tool-side fallback) |
 | `get_task` | GET | `/api/tasks/:taskId` | `taskId` | — |
-| `list_staff` | GET | `/api/staff` | — | `projectId`, `limit`, `offset` |
-| `list_mcp_servers` | GET | `/api/mcp-servers` | — | `projectId`, `limit`, `offset` |
-| `maintenance_inspect` | GET | (see sub-probes) | `probe` | `probe`, supported `projectId`, paging for large array probes |
+| `list_staff` | GET | `/api/staff` | — | `projectId`, `limit`, `offset` (tool-side fallback) |
+| `list_mcp_servers` | GET | `/api/mcp-servers` | — | `projectId`, `limit`, `offset` (tool-side fallback) |
+| `maintenance_inspect` | GET | (see sub-probes) | `probe` | `probe`, supported `projectId`, tool-side paging for large array probes |
 
 Semantic filter notes:
 
@@ -319,9 +324,8 @@ Semantic filter notes:
 | `sandbox_status` | `/api/sandbox-status` | `projectId` |
 | `search_stats` | `/api/search/stats` | `projectId` |
 
-> `list_workflows` returns an empty list when `projectId` is omitted (there is
-> no server-scope workflow set). We mark `projectId` **required** at the tool
-> layer for a useful result, but the call itself will not error without it.
+> `list_workflows` has no useful server-scope result, so `projectId` is
+> required at the tool layer.
 
 ### 5.2 `bobbit_orchestrate` (group `Bobbit`)
 

--- a/docs/design/bobbit-read-pagination.md
+++ b/docs/design/bobbit-read-pagination.md
@@ -1,10 +1,19 @@
 # Design: `bobbit_read` pagination
 
-Status: **design** · Goal: Page Bobbit Tools · Author: coder-861a
+Status: **implemented** · Goal: Page Bobbit Tools · Author: coder-861a
 
 ## 1. Problem
 
-`defaults/tools/bobbit/extension.ts` currently returns gateway JSON verbatim. For list-style `bobbit_read` operations this can emit unbounded arrays into the agent context, especially sessions, goals, tools, MCP servers, and maintenance probes. The fix should make tool calls bounded by default while keeping REST/UI behaviour backward-compatible unless a caller explicitly opts into paging.
+`defaults/tools/bobbit/extension.ts` previously returned gateway JSON verbatim. For list-style `bobbit_read` operations this could emit unbounded arrays into the agent context, especially sessions, goals, tools, MCP servers, and maintenance probes. The implemented fix makes tool calls bounded by default while keeping REST/UI behaviour backward-compatible unless a caller explicitly opts into paging.
+
+## 1.1 Implemented behaviour
+
+- `bobbit_read` list operations default to `limit=50`, `offset=0`, and clamp list limits to `200`; `search` defaults to `20` and clamps to `100`.
+- The tool forwards REST paging only for `list_sessions`, `list_goals`, and `search`. These are the high-volume endpoints where the gateway returns page fields such as `total`, `hasMore`, `nextOffset`, or `nextCursor`.
+- When a gateway response already includes REST paging fields or a `pagination` object, the tool adds normalized `pagination` metadata and marks `pagedBy: "rest"`; it does **not** re-slice the returned array. This matters for responses such as `include=archived` sessions, where the REST payload can include live sessions plus an archived page.
+- Other list-style operations use tool-side fallback paging after the endpoint has applied semantic filters (`projectId`, `goalId`, `view`, `q`, `include`, or `archived` as applicable). Fallback responses are marked `pagedBy: "tool"`.
+- Tool-side fallback preserves ancillary fields such as `generation`, `archivedDelegates`, `archivedSessions`, diagnostics, summary counts, and maintenance probe counts.
+- Cursor inputs use `cursor` as the generic alias and `after` as the gateway query name for archived session/goal paths. Cursor mode wins over offset mode only when the operation is cursor-backed and a cursor value is supplied.
 
 ## 2. Scope
 
@@ -22,7 +31,7 @@ Out of scope:
 - UI migration to paged list endpoints. UI callers remain unpaged unless they pass paging params.
 - Replacing `read_session`; transcript pagination stays in the dedicated tool.
 
-## 3. Files and functions to change
+## 3. Implementation surface
 
 ### Tool extension
 
@@ -49,7 +58,7 @@ Out of scope:
 
 ### Gateway REST endpoints
 
-Change only when the endpoint can safely expose optional paging without changing default responses:
+REST-level changes are optional and must not change default responses for callers that omit paging params. The implemented `bobbit_read` tool forwards paging only where it relies on REST-paged output; otherwise it uses tool-side fallback after semantic filters have run.
 
 - `src/server/server.ts::handleApiRoute()`
   - `GET /api/sessions` block: add offset pagination for live/default sessions when `limit` or `offset` is present; keep existing archived `limit + after` path, and optionally accept `offset` for archived too.
@@ -145,22 +154,22 @@ async function dispatch(ops: Record<string, OpSpec>, params: Params, opts?: { pa
 }
 ```
 
-## 6. Operation-by-operation plan
+## 6. Operation-by-operation behaviour
 
-| operation | primary array | semantic filters | paging plan |
+| operation | primary array | semantic filters | paging behaviour |
 |---|---:|---|---|
-| `list_sessions` | `sessions` | `include`, `q`, `projectId` | Forward `projectId`, `include`, `q`, `limit`, `offset`; use `after` for archived cursor path. Add REST paging for live sessions so filtering happens before slicing. |
-| `list_goals` | `goals` | `archived`, `q`, `projectId` | Add missing `projectId` forwarding. Archived REST already pages with `limit + after`; live REST should add optional `limit`/`offset` after `listGoalsAcrossProjects({ projectId })`. |
-| `list_projects` | `projects` or bare array today | hidden/system/HQ preference filter inside `listProjectsForApi()` | Prefer optional REST paging after `listProjectsForApi()`. If kept as array response, tool should normalize to `{ projects, pagination }` only for tool output. |
-| `list_workflows` | `workflows` | `projectId` required | Forward paging if REST added; otherwise tool fallback after `configCascade.resolveWorkflows(projectId)`. |
-| `list_roles` | `roles` | `projectId` config scope | Add `projectId` forwarding; REST requires explicit config scope. Tool fallback is acceptable. |
-| `list_tools` | `tools` | `projectId` config scope | Already forwards `projectId`; fallback page `tools` and preserve `diagnostics`/`toolDiagnostics`. |
-| `list_gates` | `gates` | `goalId`, `view` | Add optional REST paging after summary/full projection. Preserve summary count fields; do not page before computing counts. |
-| `list_tasks` | `tasks` | `goalId`, `view` | Add optional REST paging after summary/full projection. |
-| `list_staff` | `staff` | `projectId` supported by REST | Add missing `projectId` forwarding. Fallback page `staff` if REST remains unpaged. |
-| `list_mcp_servers` | bare array today | `projectId` supported by REST; `cwd`/`ensure` exist in REST but not schema | Add `projectId` forwarding. Tool can normalize bare array to `{ servers, pagination }`. Do not expose `ensure` through `bobbit_read` unless explicitly desired, because it can initialize managers. |
-| `maintenance_inspect` | varies | `probe`, sometimes `projectId` | See §7. Page probes with large arrays/samples; scalar/stat probes return unchanged or metadata only when an array is present. |
-| `search` | `results` | `q`, `type`, `limit`, `offset`, `projectId` | Already forwards paging. Add normalized `pagination` from `{ results, total }`: `hasMore = offset + results.length < total`. |
+| `list_sessions` | `sessions` | `include`, `q`, `projectId` | Forwards filters plus `limit`; forwards `offset` for offset mode and `after` for archived cursor mode. REST-paged results are not re-sliced. |
+| `list_goals` | `goals` | `archived`, `q`, `projectId` | Forwards filters plus `limit`; forwards `offset` for live/offset mode and `after` for archived cursor mode. REST-paged results are not re-sliced. |
+| `list_projects` | `projects` or bare array | hidden/system/HQ preference filter inside `listProjectsForApi()` | Tool fallback pages the filtered response and normalizes tool output to `{ projects, pagination }` when needed. |
+| `list_workflows` | `workflows` | `projectId` required | Forwards `projectId`; tool fallback pages after workflow resolution. |
+| `list_roles` | `roles` | `projectId` config scope | Forwards `projectId`; tool fallback pages after config-scope resolution. |
+| `list_tools` | `tools` | `projectId` config scope | Forwards `projectId`; tool fallback pages `tools` and preserves `diagnostics`/`toolDiagnostics`. |
+| `list_gates` | `gates` | `goalId`, `view` | Path-scoped by `goalId`; tool fallback pages the selected `view` output and preserves summary fields. |
+| `list_tasks` | `tasks` | `goalId`, `view` | Path-scoped by `goalId`; tool fallback pages the selected `view` output. |
+| `list_staff` | `staff` | `projectId` supported by REST | Forwards `projectId`; tool fallback pages `staff`. |
+| `list_mcp_servers` | bare array | `projectId` supported by REST; `cwd`/`ensure` exist in REST but not schema | Forwards `projectId`; tool fallback normalizes the array to `{ servers, pagination }`. Does not expose `ensure`, because it can initialize managers. |
+| `maintenance_inspect` | varies | `probe`, sometimes `projectId` | See §7. Tool fallback pages probes with large arrays/samples; scalar/stat probes return unchanged unless an array key is present. |
+| `search` | `results` | `q`, `type`, `limit`, `offset`, `projectId` | Forwards paging. Adds normalized `pagination` from REST results without re-slicing. |
 
 Non-list read operations are unchanged and do not receive pagination metadata.
 
@@ -217,17 +226,17 @@ If a probe returns a bare array, normalize it to `{ items: [...], pagination: { 
 
 ## 9. REST vs tool fallback policy
 
-Prefer REST paging when:
+Use REST paging when:
 
-- The endpoint already supports paging (`search`, archived `goals`, archived `sessions`).
-- The endpoint performs expensive semantic filtering or aggregation and can cheaply slice after filtering (`sessions`, live `goals`, tasks/gates).
-- Returning the full response to the tool would defeat the main goal for common large datasets.
+- The endpoint already supports paging and the tool forwards page params (`search`, `list_sessions`, `list_goals`).
+- The endpoint returns page fields (`total`, `hasMore`, `nextOffset`, `nextCursor`, or `pagination`); the tool treats these responses as already paged and does not re-slice them.
 
 Use tool fallback when:
 
 - The endpoint is primarily used by UI and changing response shape would be risky.
 - The endpoint returns small config lists but can still be noisy in agent context (`roles`, `tools`, `workflows`).
 - The endpoint returns a bare array and REST-level shape changes might break consumers (`mcp-servers`, possibly `projects`).
+- The implemented `bobbit_read` path does not forward paging for that operation; fallback still happens after forwarded semantic filters are applied.
 
 Backward compatibility rule: REST endpoints must keep their existing response shape when no paging params are present. If REST receives `limit`, `offset`, `after`, or `cursor`, it may return page metadata. The `bobbit_read` tool should always request or apply paging for list operations, so agents get bounded output by default without forcing UI changes.
 

--- a/docs/design/bobbit-read-pagination.md
+++ b/docs/design/bobbit-read-pagination.md
@@ -1,0 +1,277 @@
+# Design: `bobbit_read` pagination
+
+Status: **design** · Goal: Page Bobbit Tools · Author: coder-861a
+
+## 1. Problem
+
+`defaults/tools/bobbit/extension.ts` currently returns gateway JSON verbatim. For list-style `bobbit_read` operations this can emit unbounded arrays into the agent context, especially sessions, goals, tools, MCP servers, and maintenance probes. The fix should make tool calls bounded by default while keeping REST/UI behaviour backward-compatible unless a caller explicitly opts into paging.
+
+## 2. Scope
+
+In scope:
+
+- Add shared paging params to `bobbit_read`: `limit`, `offset`, and `after`/`cursor` for cursor-backed endpoints.
+- Return page metadata for every paged list-style `bobbit_read` operation.
+- Preserve semantic filters and forward missing supported filters.
+- Add REST-level pagination where it is useful and safe; otherwise page the tool response after fetch.
+- Update `bobbit_read` YAML/schema docs and core tests.
+
+Out of scope:
+
+- Changing non-list read operations (`get_*`, costs, git status, health, connection info).
+- UI migration to paged list endpoints. UI callers remain unpaged unless they pass paging params.
+- Replacing `read_session`; transcript pagination stays in the dedicated tool.
+
+## 3. Files and functions to change
+
+### Tool extension
+
+- `defaults/tools/bobbit/extension.ts`
+  - Extend `Params` use with `limit`, `offset`, `after`, `cursor`.
+  - Extend `OpSpec` with pagination metadata:
+    - `page?: PageSpec`
+    - optional `semanticQuery?: string[]` if the implementation chooses a declarative query builder.
+  - Add helpers near `withQuery()`:
+    - `normalizePaging(params, mode?)`
+    - `appendPagingQuery(entries, params, spec)`
+    - `pageResult(operation, data, params, spec)`
+    - `sliceByPath(data, path, page)`
+  - Update `READ_OPS` paths to forward `projectId` for `list_goals`, `list_staff`, `list_mcp_servers`, `list_roles`, and paging params where REST supports or will support them.
+  - Change `dispatch()` so `bobbit_read` list operations return normalized paged payloads instead of raw JSON. Keep orchestrate/admin raw.
+  - Update registered `bobbit_read` parameter schema descriptions for shared paging.
+
+### Tool manifest
+
+- `defaults/tools/bobbit/bobbit_read.yaml`
+  - Update `params` to include `limit?`, `offset?`, `after?`, `cursor?`, `type?`, `archived?`, `include?`.
+  - Replace “returns JSON verbatim” for list operations with the bounded page contract.
+  - Document default page size, max page size, metadata, and semantic filters per operation.
+
+### Gateway REST endpoints
+
+Change only when the endpoint can safely expose optional paging without changing default responses:
+
+- `src/server/server.ts::handleApiRoute()`
+  - `GET /api/sessions` block: add offset pagination for live/default sessions when `limit` or `offset` is present; keep existing archived `limit + after` path, and optionally accept `offset` for archived too.
+  - `GET /api/goals` block: live goals currently support `projectId` only; add optional `limit`/`offset` paging after `listGoalsAcrossProjects({ projectId })`. Existing archived path already supports `limit + after`.
+  - `GET /api/projects`: add optional `limit`/`offset` around `listProjectsForApi()`.
+  - `GET /api/goals/:goalId/tasks`: add optional `limit`/`offset` after `view=summary`/full projection is chosen.
+  - `GET /api/goals/:goalId/gates`: add optional `limit`/`offset` after `view=summary`/full projection is chosen.
+  - Optional, low-risk forwards: `GET /api/staff`, `GET /api/mcp-servers`, `GET /api/workflows`, `GET /api/roles`, `GET /api/tools` can accept paging, but tool-side fallback is sufficient if UI risk or route complexity is high.
+  - Maintenance probes: add paging to probes that already materialize arrays (`orphaned-worktrees`, `orphaned-sessions`, `orphaned-index-rows` sample) only if straightforward; otherwise keep REST as-is and page in the tool.
+
+## 4. Paging contract
+
+### Defaults
+
+- Default `bobbit_read` list page size: **50**.
+- Max page size: **200** for list-style operations.
+- `search` keeps the existing REST default/max (`20` default, `100` max) unless the caller passes a `limit`; normalize metadata around its existing response.
+- `offset` defaults to `0`.
+- Cursor params are accepted as aliases:
+  - `cursor` is a generic alias.
+  - `after` is forwarded to existing archived session/goal REST paths.
+
+### Response shape
+
+For all list-style `bobbit_read` operations, return the original response fields plus a `pagination` object:
+
+```ts
+interface PageMetadata {
+  limit: number;
+  offset?: number;
+  total?: number;
+  hasMore: boolean;
+  nextOffset?: number;
+  cursor?: string | number;
+  nextCursor?: string | number;
+  mode: "offset" | "cursor";
+  itemKey: string;
+  pagedBy: "rest" | "tool";
+}
+```
+
+Rules:
+
+- Preserve the endpoint’s top-level shape and primary array key (`sessions`, `goals`, `projects`, `tools`, etc.).
+- Add `pagination` at top level.
+- If REST already returns `total`, `hasMore`, or `nextCursor`, mirror those into `pagination` and leave the original fields intact for compatibility.
+- For tool-side fallback, compute:
+  - `total = fullArray.length`
+  - `items = fullArray.slice(offset, offset + limit)`
+  - `hasMore = offset + items.length < total`
+  - `nextOffset = hasMore ? offset + limit : undefined`
+- For cursor-backed fallback, prefer REST cursor metadata; do not invent stable cursors from unordered arrays.
+
+## 5. Helper shape
+
+Add small, pure helpers in `defaults/tools/bobbit/extension.ts`.
+
+```ts
+type PageMode = "offset" | "cursor";
+
+type PageSpec = {
+  itemKey: string;                 // e.g. "sessions"
+  defaultLimit?: number;           // default 50; search may set 20
+  maxLimit?: number;               // default 200; search may set 100
+  mode?: PageMode;                 // default "offset"
+  restPaging?: boolean;            // true when buildPath forwards paging
+  cursorParam?: "after" | "cursor";
+  preserveKeys?: string[];         // ancillary fields to keep untouched
+};
+
+type NormalizedPage = {
+  limit: number;
+  offset: number;
+  cursor?: string | number;
+};
+```
+
+Implementation notes:
+
+- `normalizePaging()` clamps invalid, missing, or negative values.
+- `appendPagingQuery()` appends `limit`, `offset`, and cursor params only for operations with `restPaging: true`.
+- `pageResult()` handles three cases:
+  1. REST-paged response with metadata: only add/normalize `pagination`.
+  2. REST-paged response without full metadata: infer from returned item count when possible.
+  3. Tool fallback: slice the primary array and add metadata.
+- `dispatch()` can call `pageResult()` only for `bobbit_read` by adding an optional postprocessor parameter:
+
+```ts
+async function dispatch(ops: Record<string, OpSpec>, params: Params, opts?: { pageLists?: boolean }) {
+  // existing validation/buildPath/api flow
+  const data = await api(method, urlPath, body);
+  return ok(opts?.pageLists ? pageIfConfigured(params.operation, data, params, spec) : data);
+}
+```
+
+## 6. Operation-by-operation plan
+
+| operation | primary array | semantic filters | paging plan |
+|---|---:|---|---|
+| `list_sessions` | `sessions` | `include`, `q`, `projectId` | Forward `projectId`, `include`, `q`, `limit`, `offset`; use `after` for archived cursor path. Add REST paging for live sessions so filtering happens before slicing. |
+| `list_goals` | `goals` | `archived`, `q`, `projectId` | Add missing `projectId` forwarding. Archived REST already pages with `limit + after`; live REST should add optional `limit`/`offset` after `listGoalsAcrossProjects({ projectId })`. |
+| `list_projects` | `projects` or bare array today | hidden/system/HQ preference filter inside `listProjectsForApi()` | Prefer optional REST paging after `listProjectsForApi()`. If kept as array response, tool should normalize to `{ projects, pagination }` only for tool output. |
+| `list_workflows` | `workflows` | `projectId` required | Forward paging if REST added; otherwise tool fallback after `configCascade.resolveWorkflows(projectId)`. |
+| `list_roles` | `roles` | `projectId` config scope | Add `projectId` forwarding; REST requires explicit config scope. Tool fallback is acceptable. |
+| `list_tools` | `tools` | `projectId` config scope | Already forwards `projectId`; fallback page `tools` and preserve `diagnostics`/`toolDiagnostics`. |
+| `list_gates` | `gates` | `goalId`, `view` | Add optional REST paging after summary/full projection. Preserve summary count fields; do not page before computing counts. |
+| `list_tasks` | `tasks` | `goalId`, `view` | Add optional REST paging after summary/full projection. |
+| `list_staff` | `staff` | `projectId` supported by REST | Add missing `projectId` forwarding. Fallback page `staff` if REST remains unpaged. |
+| `list_mcp_servers` | bare array today | `projectId` supported by REST; `cwd`/`ensure` exist in REST but not schema | Add `projectId` forwarding. Tool can normalize bare array to `{ servers, pagination }`. Do not expose `ensure` through `bobbit_read` unless explicitly desired, because it can initialize managers. |
+| `maintenance_inspect` | varies | `probe`, sometimes `projectId` | See §7. Page probes with large arrays/samples; scalar/stat probes return unchanged or metadata only when an array is present. |
+| `search` | `results` | `q`, `type`, `limit`, `offset`, `projectId` | Already forwards paging. Add normalized `pagination` from `{ results, total }`: `hasMore = offset + results.length < total`. |
+
+Non-list read operations are unchanged and do not receive pagination metadata.
+
+## 7. Maintenance probe handling
+
+`PROBE_PATHS` currently maps:
+
+- `orphaned_worktrees` → `/api/maintenance/orphaned-worktrees` returns a collection from `worktreeInventory().legacyOrphanedWorktrees()`.
+- `orphaned_sessions` → `{ sessions }`.
+- `expired_archives` → stats; likely not paged.
+- `orphaned_index_rows` → `{ count, sample }` and requires `projectId`.
+- `worktrees` → `/api/maintenance/worktrees` (verify route before implementation; if absent, existing operation already errors through REST).
+- `archived_session_worktrees` → `/api/maintenance/archived-session-worktrees`.
+- `worktree_pool` → `/api/worktree-pool` returns either one status object or `{ pools }`; page `pools` only if it is large by converting entries to a page in a `pools` object plus metadata, otherwise leave unchanged.
+- `sandbox_pool` → scalar stats; unchanged.
+- `sandbox_status` → scalar status; should forward `projectId` because REST supports it.
+- `search_stats` → scalar stats; requires/forwards `projectId`.
+
+Probe page specs should be keyed by probe, not just operation:
+
+```ts
+const MAINTENANCE_PAGE_SPECS: Record<string, PageSpec | undefined> = {
+  orphaned_worktrees: { itemKey: "worktrees" },
+  orphaned_sessions: { itemKey: "sessions" },
+  orphaned_index_rows: { itemKey: "sample" },
+  archived_session_worktrees: { itemKey: "worktrees" },
+};
+```
+
+If a probe returns a bare array, normalize it to `{ items: [...], pagination: { itemKey: "items", ... } }` unless a better key is known. Preserve counts such as `count` from `orphaned_index_rows`; for a paged sample, `count` remains total orphan count reported by the REST endpoint and `pagination.total` should use that when available.
+
+## 8. Semantic filter forwarding audit
+
+- `projectId`
+  - Add to `list_goals` query.
+  - Add to `list_roles` query because `/api/roles` requires explicit config scope.
+  - Add to `list_staff` query because `/api/staff` already supports it.
+  - Add to `list_mcp_servers` query because `/api/mcp-servers` already supports it.
+  - Add to `maintenance_inspect` probes whose REST supports/requires it: `worktree_pool`, `sandbox_status`, `orphaned_index_rows`, `search_stats`; keep existing for `orphaned_index_rows`/`search_stats`.
+- `goalId`
+  - `list_gates` and `list_tasks` remain path-scoped by `goalId`; apply paging only after this scope.
+- `q`
+  - `list_sessions` uses `q` only for archived sessions today; keep this behaviour and document it.
+  - `list_goals` uses `q` only for archived goals today; keep this unless a separate live-goal search is intentionally added.
+  - `search` keeps `q` required.
+- `type`
+  - Only `search` uses `type`; validate/forward as today.
+- `include`
+  - Only `list_sessions`; `include=archived` includes live sessions plus archived page/delegates. Preserve archived delegate enrichment.
+- `archived`
+  - Only `list_goals`; `archived=true` selects archived path.
+- `view`
+  - Only `list_gates`/`list_tasks`; compute summary/full projection first, then page the displayed list.
+
+## 9. REST vs tool fallback policy
+
+Prefer REST paging when:
+
+- The endpoint already supports paging (`search`, archived `goals`, archived `sessions`).
+- The endpoint performs expensive semantic filtering or aggregation and can cheaply slice after filtering (`sessions`, live `goals`, tasks/gates).
+- Returning the full response to the tool would defeat the main goal for common large datasets.
+
+Use tool fallback when:
+
+- The endpoint is primarily used by UI and changing response shape would be risky.
+- The endpoint returns small config lists but can still be noisy in agent context (`roles`, `tools`, `workflows`).
+- The endpoint returns a bare array and REST-level shape changes might break consumers (`mcp-servers`, possibly `projects`).
+
+Backward compatibility rule: REST endpoints must keep their existing response shape when no paging params are present. If REST receives `limit`, `offset`, `after`, or `cursor`, it may return page metadata. The `bobbit_read` tool should always request or apply paging for list operations, so agents get bounded output by default without forcing UI changes.
+
+## 10. Backward compatibility and edge cases
+
+- Existing API consumers that do not pass paging params see current unpaged responses.
+- Existing `bobbit_read.search` callers keep working; new metadata is additive.
+- Existing `limit`/`offset` params in the `bobbit_read` schema become shared, not search-only.
+- Invalid `limit`/`offset` should be clamped, not surfaced as validation errors, matching existing REST style.
+- If a caller asks for `limit` larger than max, return the clamped `limit` in metadata.
+- Cursor and offset should not both drive the same request. If both are supplied for a cursor operation, cursor wins and metadata uses `mode: "cursor"`.
+- Tool-side fallback must preserve ancillary fields (`generation`, `archivedDelegates`, `archivedSessions`, diagnostics, counts, summaries).
+- Avoid exposing `cwd`/`ensure` on `list_mcp_servers` in this goal; `ensure=true` has initialization side effects and `bobbit_read` should stay read-only.
+
+## 11. Focused test plan
+
+Update or add core tests only under `tests2/core/` and register any new file in `tests2/tests-map.json` if needed.
+
+- `tests2/core/bobbit-tool-dispatch.test.ts`
+  - `list_sessions` default call appends `limit=50&offset=0` or otherwise returns a default page through the postprocessor.
+  - `list_sessions` explicit `{ projectId: "p1", limit: 10, offset: 20 }` forwards `projectId`, `limit`, and `offset` together.
+  - `list_goals` forwards `projectId` plus paging and preserves `archived`/`q`.
+  - `list_staff`, `list_roles`, and `list_mcp_servers` forward `projectId`.
+  - Archived goals/sessions forward cursor (`after` or `cursor`) when supplied.
+- New or expanded `tests2/core/bobbit-tool-pagination.test.ts`
+  - Tool fallback pages a stubbed `{ tools: [..], diagnostics: ... }` response and returns `{ tools: firstPage, diagnostics, pagination }`.
+  - Bare-array fallback for `list_mcp_servers` normalizes to a bounded keyed payload.
+  - `search` response `{ results, total }` gains correct `pagination.hasMore`/`nextOffset`.
+  - Maintenance probe fallback pages `{ sessions: [...] }` and `{ count, sample: [...] }` without losing `count`.
+- `tests2/core/bobbit-tool-validation.test.ts`
+  - Schema exposes shared `limit`, `offset`, `after`, and `cursor` with non-search descriptions.
+- `tests2/core/bobbit-tool-tiers.test.ts`
+  - Keep operation catalogue unchanged unless adding no new operations.
+  - Add a YAML/detail-doc drift assertion if practical: docs mention shared paging and `projectId` filters for the affected operations.
+- REST-focused tests if helpers are extracted/pure:
+  - Optional paging helper clamps limits and computes metadata.
+  - Live sessions/goals filter by `projectId` before slicing.
+  - Task/gate `view=summary` counts remain full-board counts while `gates`/`tasks` array is paged.
+
+Verification commands:
+
+```bash
+npm run check
+npx vitest run tests2/core/bobbit-tool-dispatch.test.ts tests2/core/bobbit-tool-validation.test.ts tests2/core/bobbit-tool-tiers.test.ts tests2/core/bobbit-tool-pagination.test.ts
+```
+
+If no new test file is added, omit it from the Vitest command.

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3930,6 +3930,32 @@ async function handleApiRoute(
 		console.error(`[api] ${status} error:`, e.stack ?? e.message);
 		json({ error: e.message, ...extra }, status);
 	};
+	const hasPagingParams = (): boolean => ["limit", "offset", "after", "cursor"].some(param => url.searchParams.has(param));
+	const parsePagingInt = (value: string | null, fallback: number, min: number, max: number): number => {
+		const parsed = value === null ? fallback : parseInt(value, 10);
+		const safe = Number.isFinite(parsed) ? parsed : fallback;
+		return Math.min(Math.max(min, safe), max);
+	};
+	const readOffsetPaging = (): { enabled: boolean; limit: number; offset: number } => ({
+		enabled: hasPagingParams(),
+		limit: parsePagingInt(url.searchParams.get("limit"), 50, 1, 200),
+		offset: parsePagingInt(url.searchParams.get("offset"), 0, 0, Number.MAX_SAFE_INTEGER),
+	});
+	const pageArray = <T>(items: T[], paging = readOffsetPaging()): { items: T[]; total: number; limit: number; offset: number; hasMore: boolean; nextOffset?: number } => {
+		const total = items.length;
+		const start = Math.min(paging.offset, total);
+		const end = start + paging.limit;
+		const pagedItems = items.slice(start, end);
+		const hasMore = end < total;
+		return {
+			items: pagedItems,
+			total,
+			limit: paging.limit,
+			offset: paging.offset,
+			hasMore,
+			...(hasMore ? { nextOffset: end } : {}),
+		};
+	};
 
 	const canonicalPathForCompare = (inputPath: string): string => {
 		let resolved = path.resolve(inputPath);
@@ -4844,7 +4870,14 @@ async function handleApiRoute(
 
 	// GET /api/projects
 	if (url.pathname === "/api/projects" && req.method === "GET") {
-		json(listProjectsForApi());
+		const projects = listProjectsForApi();
+		const paging = readOffsetPaging();
+		if (paging.enabled) {
+			const page = pageArray(projects, paging);
+			json({ projects: page.items, total: page.total, limit: page.limit, offset: page.offset, hasMore: page.hasMore, ...(page.nextOffset !== undefined ? { nextOffset: page.nextOffset } : {}) });
+			return;
+		}
+		json(projects);
 		return;
 	}
 
@@ -5760,26 +5793,29 @@ async function handleApiRoute(
 				}
 			}
 
-			const limitParam = url.searchParams.get("limit");
-			const afterParam = url.searchParams.get("after");
-			if (limitParam) {
-				// Paginated archived sessions
-				const limit = Math.min(Math.max(1, parseInt(limitParam, 10) || 50), 200);
-				const afterCursor = afterParam ? parseInt(afterParam, 10) : undefined;
-				let page = filteredArchived;
-				if (afterCursor !== undefined) {
-					page = page.filter((s: any) => ((s as any).archivedAt ?? 0) < afterCursor);
+			if (hasPagingParams()) {
+				// Paginated archived sessions. Cursor pagination wins over offset when supplied.
+				const paging = readOffsetPaging();
+				const cursorParam = url.searchParams.get("cursor") ?? url.searchParams.get("after");
+				const afterCursor = cursorParam !== null ? parseInt(cursorParam, 10) : undefined;
+				const hasCursor = afterCursor !== undefined && Number.isFinite(afterCursor);
+				let pagePool = filteredArchived;
+				if (hasCursor) {
+					pagePool = pagePool.filter((s: any) => ((s as any).archivedAt ?? 0) < afterCursor!);
+				} else if (paging.offset > 0) {
+					pagePool = pagePool.slice(paging.offset);
 				}
 				const total = filteredArchived.length;
-				const hasMore = page.length > limit;
-				const sliced = page.slice(0, limit);
+				const hasMore = pagePool.length > paging.limit;
+				const sliced = pagePool.slice(0, paging.limit);
 				const nextCursor = sliced.length > 0 ? (sliced[sliced.length - 1] as any).archivedAt : undefined;
+				const nextOffset = hasMore && !hasCursor ? paging.offset + paging.limit : undefined;
 
 				// BFS: collect archived children reachable from live sessions and goals
 				const liveIdSet = new Set(sessions.map(s => s.id));
 				const archivedDelegatesOfLive = bfsEnrichArchived([...liveIdSet, ...liveGoalIds], allArchivedForBfs);
 
-				json({ generation: currentGen, sessions: [...sessions, ...sliced], total, hasMore, nextCursor, archivedDelegates: archivedDelegatesOfLive });
+				json({ generation: currentGen, sessions: [...sessions, ...sliced], total, limit: paging.limit, offset: !hasCursor ? paging.offset : undefined, hasMore, nextCursor, ...(nextOffset !== undefined ? { nextOffset } : {}), archivedDelegates: archivedDelegatesOfLive });
 			} else {
 				// BFS: collect archived children reachable from live sessions and goals
 				const liveIdSet = new Set(sessions.map(s => s.id));
@@ -5807,7 +5843,13 @@ async function handleApiRoute(
 			}
 			// BFS: live parents/goals → their archived children → children of those, etc.
 			const archivedDelegatesOfLive = bfsEnrichArchived([...liveIdSet, ...liveGoalIdsNonPaginated], allArchivedForBfsNonPaginated);
-			json({ generation: currentGen, sessions, archivedDelegates: archivedDelegatesOfLive });
+			const paging = readOffsetPaging();
+			if (paging.enabled) {
+				const page = pageArray(sessions, paging);
+				json({ generation: currentGen, sessions: page.items, total: page.total, limit: page.limit, offset: page.offset, hasMore: page.hasMore, ...(page.nextOffset !== undefined ? { nextOffset: page.nextOffset } : {}), archivedDelegates: archivedDelegatesOfLive });
+			} else {
+				json({ generation: currentGen, sessions, archivedDelegates: archivedDelegatesOfLive });
+			}
 		}
 		return;
 	}
@@ -6717,9 +6759,10 @@ async function handleApiRoute(
 	if (url.pathname === "/api/goals" && req.method === "GET") {
 		// Paginated archived goals — aggregate across all projects
 		if (url.searchParams.get("archived") === "true") {
-			const limit = Math.min(Math.max(1, parseInt(url.searchParams.get("limit") || "50", 10) || 50), 200);
-			const afterParam = url.searchParams.get("after");
-			const afterCursor = afterParam ? parseInt(afterParam, 10) : undefined;
+			const paging = readOffsetPaging();
+			const cursorParam = url.searchParams.get("cursor") ?? url.searchParams.get("after");
+			const afterCursor = cursorParam !== null ? parseInt(cursorParam, 10) : undefined;
+			const hasCursor = afterCursor !== undefined && Number.isFinite(afterCursor);
 			const filterProjectId = url.searchParams.get("projectId") || undefined;
 			const archivedQuery = normalizedArchivedQuery(url.searchParams.get("q"));
 			// Aggregate archived goals across all project contexts
@@ -6741,12 +6784,15 @@ async function handleApiRoute(
 			}
 			allArchived.sort((a, b) => (b.archivedAt ?? 0) - (a.archivedAt ?? 0));
 			const total = allArchived.length;
-			if (afterCursor !== undefined) {
-				allArchived = allArchived.filter(g => (g.archivedAt ?? 0) < afterCursor);
+			if (hasCursor) {
+				allArchived = allArchived.filter(g => (g.archivedAt ?? 0) < afterCursor!);
+			} else if (paging.offset > 0) {
+				allArchived = allArchived.slice(paging.offset);
 			}
-			const page = allArchived.slice(0, limit);
-			const hasMore = allArchived.length > limit;
+			const page = allArchived.slice(0, paging.limit);
+			const hasMore = allArchived.length > paging.limit;
 			const nextCursor = page.length > 0 ? page[page.length - 1].archivedAt : undefined;
+			const nextOffset = hasMore && !hasCursor ? paging.offset + paging.limit : undefined;
 
 			// Collect archived sessions affiliated with goals in this page
 			const goalIdsInPage = new Set(page.map((g: any) => g.id));
@@ -6775,7 +6821,7 @@ async function handleApiRoute(
 				}
 			}
 
-			json({ goals: page, total, hasMore, nextCursor, archivedSessions: affiliatedSessions });
+			json({ goals: page, total, limit: paging.limit, offset: !hasCursor ? paging.offset : undefined, hasMore, nextCursor, ...(nextOffset !== undefined ? { nextOffset } : {}), archivedSessions: affiliatedSessions });
 			return;
 		}
 
@@ -6790,6 +6836,12 @@ async function handleApiRoute(
 		}
 		const filterProjectId = url.searchParams.get("projectId") || undefined;
 		const goals = listGoalsAcrossProjects({ projectId: filterProjectId });
+		const paging = readOffsetPaging();
+		if (paging.enabled) {
+			const page = pageArray(goals, paging);
+			json({ generation: currentGen, goals: page.items, total: page.total, limit: page.limit, offset: page.offset, hasMore: page.hasMore, ...(page.nextOffset !== undefined ? { nextOffset: page.nextOffset } : {}) });
+			return;
+		}
 		json({ generation: currentGen, goals });
 		return;
 	}
@@ -10117,6 +10169,12 @@ async function handleApiRoute(
 	const goalTasksMatch = url.pathname.match(/^\/api\/goals\/([^/]+)\/tasks$/);
 	if (goalTasksMatch && req.method === "GET") {
 		const tasks = getTaskManagerForGoal(goalTasksMatch[1]).getTasksForGoal(goalTasksMatch[1]);
+		const paging = readOffsetPaging();
+		const withTaskPaging = <T>(items: T[]): Record<string, unknown> => {
+			if (!paging.enabled) return { tasks: items };
+			const page = pageArray(items, paging);
+			return { tasks: page.items, total: page.total, limit: page.limit, offset: page.offset, hasMore: page.hasMore, ...(page.nextOffset !== undefined ? { nextOffset: page.nextOffset } : {}) };
+		};
 		if (url.searchParams.get("view") === "summary") {
 			const slim = tasks.map(t => ({
 				id: t.id,
@@ -10129,10 +10187,10 @@ async function handleApiRoute(
 				workflowGateId: t.workflowGateId,
 				dependsOn: t.dependsOn || [],
 			}));
-			json({ tasks: slim });
+			json(withTaskPaging(slim));
 			return;
 		}
-		json({ tasks });
+		json(withTaskPaging(tasks));
 		return;
 	}
 
@@ -10200,6 +10258,12 @@ async function handleApiRoute(
 			}
 			return base;
 		});
+		const paging = readOffsetPaging();
+		const gatePagingMetadata = <T>(items: T[]): { gates: T[]; total?: number; limit?: number; offset?: number; hasMore?: boolean; nextOffset?: number } => {
+			if (!paging.enabled) return { gates: items };
+			const page = pageArray(items, paging);
+			return { gates: page.items, total: page.total, limit: page.limit, offset: page.offset, hasMore: page.hasMore, ...(page.nextOffset !== undefined ? { nextOffset: page.nextOffset } : {}) };
+		};
 		if (url.searchParams.get("view") === "summary") {
 			const summary = buildGateStatusSummary({
 				workflow: goal.workflow,
@@ -10207,13 +10271,14 @@ async function handleApiRoute(
 				activeVerifications: verificationHarness.getActiveVerifications(goalId),
 			});
 			const { gates: summaryGates, ...counts } = summary;
-			json({ gates: summaryGates, ...counts, summary });
+			const page = gatePagingMetadata(summaryGates);
+			json({ ...page, ...counts, summary: paging.enabled ? { ...summary, gates: page.gates } : summary });
 			return;
 		}
 		// Slim the list payload: strip inline step output / artifact bodies /
 		// diagnostics. Full step text is fetched lazily on expand via the
 		// gate-detail + verification-snapshot paths below.
-		json({ gates: enriched.map(g => projectGateForList(g)) });
+		json(gatePagingMetadata(enriched.map(g => projectGateForList(g))));
 		return;
 	}
 

--- a/tests2/browser/fixtures/sidebar-actions-menu-fixture.spec.ts
+++ b/tests2/browser/fixtures/sidebar-actions-menu-fixture.spec.ts
@@ -217,7 +217,7 @@ test("copy link fallback uses legacy execCommand without surfacing a modal", asy
 	await expectNoPopover(page);
 	await expect(page.locator("copy-link-fallback-dialog")).toHaveCount(0);
 	await expect.poll(() => page.evaluate(() => (window as any).__sidebarActionsExecCopies)).toContain(
-		await page.evaluate((id) => `${location.protocol}//${location.host}/session/${id}`, ids.session),
+		await page.evaluate((id) => `${location.origin}${location.pathname}${location.search}#/session/${id}`, ids.session),
 	);
 
 	await openMenu(page, "goal", ids.goal);

--- a/tests2/core/bobbit-tool-dispatch.test.ts
+++ b/tests2/core/bobbit-tool-dispatch.test.ts
@@ -23,6 +23,10 @@ async function run(tool: string, params: any): Promise<FetchCall> {
 	return calls[0];
 }
 
+function query(url: string): URLSearchParams {
+	return new URL(url).searchParams;
+}
+
 describe("bobbit_read — path & query building", () => {
 	it("get_goal builds GET /api/goals/:id", async () => {
 		const c = await run("bobbit_read", { operation: "get_goal", goalId: "g1" });
@@ -49,7 +53,82 @@ describe("bobbit_read — path & query building", () => {
 			probe: "orphaned_index_rows",
 			projectId: "p1",
 		});
-		expect(c.url).toBe("https://gw.test/api/maintenance/orphaned-index-rows?projectId=p1");
+		expect(c.url).toContain("/api/maintenance/orphaned-index-rows?");
+		expect(query(c.url).get("projectId")).toBe("p1");
+	});
+
+	it("list_sessions defaults to a bounded first page", async () => {
+		const c = await run("bobbit_read", { operation: "list_sessions" });
+		expect(c.method).toBe("GET");
+		expect(c.url).toContain("/api/sessions?");
+		expect(query(c.url).get("limit")).toBe("50");
+		expect(query(c.url).get("offset")).toBe("0");
+	});
+
+	it("list_sessions composes semantic filters with explicit limit/offset", async () => {
+		const c = await run("bobbit_read", {
+			operation: "list_sessions",
+			projectId: "proj-1",
+			include: "archived",
+			q: "review",
+			limit: 25,
+			offset: 75,
+		});
+		const qs = query(c.url);
+		expect(c.url).toContain("/api/sessions?");
+		expect(qs.get("projectId")).toBe("proj-1");
+		expect(qs.get("include")).toBe("archived");
+		expect(qs.get("q")).toBe("review");
+		expect(qs.get("limit")).toBe("25");
+		expect(qs.get("offset")).toBe("75");
+	});
+
+	it("list_goals forwards projectId and paging without dropping existing filters", async () => {
+		const c = await run("bobbit_read", {
+			operation: "list_goals",
+			projectId: "proj-2",
+			archived: true,
+			q: "ship",
+			limit: 10,
+			offset: 20,
+		});
+		const qs = query(c.url);
+		expect(c.url).toContain("/api/goals?");
+		expect(qs.get("projectId")).toBe("proj-2");
+		expect(qs.get("archived")).toBe("true");
+		expect(qs.get("q")).toBe("ship");
+		expect(qs.get("limit")).toBe("10");
+		expect(qs.get("offset")).toBe("20");
+	});
+
+	it("archived list operations forward cursor-style after tokens", async () => {
+		const sessionCall = await run("bobbit_read", {
+			operation: "list_sessions",
+			include: "archived",
+			limit: 25,
+			after: "sess-cur-1",
+		});
+		const goalCall = await run("bobbit_read", {
+			operation: "list_goals",
+			archived: true,
+			limit: 25,
+			after: "goal-cur-1",
+		});
+		expect(query(sessionCall.url).get("after")).toBe("sess-cur-1");
+		expect(query(goalCall.url).get("after")).toBe("goal-cur-1");
+	});
+
+	it("project-scoped list operations forward projectId without read-time side effects", async () => {
+		const roleCall = await run("bobbit_read", { operation: "list_roles", projectId: "proj-3" });
+		const staffCall = await run("bobbit_read", { operation: "list_staff", projectId: "proj-3" });
+		const mcpCall = await run("bobbit_read", { operation: "list_mcp_servers", projectId: "proj-3" });
+
+		for (const c of [roleCall, staffCall, mcpCall]) {
+			const qs = query(c.url);
+			expect(qs.get("projectId")).toBe("proj-3");
+			expect(qs.has("ensure")).toBe(false);
+			expect(qs.has("cwd")).toBe(false);
+		}
 	});
 });
 

--- a/tests2/core/bobbit-tool-pagination.test.ts
+++ b/tests2/core/bobbit-tool-pagination.test.ts
@@ -1,0 +1,192 @@
+// v2-native — bobbit gateway tool suite. Listed in tests-map.json `v2Native`.
+//
+// Pagination contract: list-style bobbit_read operations return bounded pages by
+// default, preserve ancillary fields, and add normalized pagination metadata even
+// when the gateway endpoint itself returns an unpaged array.
+import { guardProcessEnv } from "./helpers/env-guard.js";
+guardProcessEnv();
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { loadBobbitTools, stubFetch, type CapturedTool } from "./helpers/bobbit-harness.ts";
+
+let tools: Map<string, CapturedTool>;
+
+beforeAll(() => {
+	process.env.BOBBIT_TOKEN = "tok";
+	process.env.BOBBIT_GATEWAY_URL = "https://gw.test";
+	tools = loadBobbitTools();
+});
+
+function text(result: any): string {
+	return result?.content?.[0]?.text ?? "";
+}
+
+function json(result: any): any {
+	expect(result.isError).toBeFalsy();
+	return JSON.parse(text(result));
+}
+
+describe("bobbit_read — fallback pagination", () => {
+	it("pages list_tools responses after fetch while preserving diagnostics", async () => {
+		const allTools = Array.from({ length: 75 }, (_, i) => ({ name: `tool-${i}` }));
+		stubFetch(() => ({
+			body: {
+				tools: allTools,
+				diagnostics: [{ level: "warning", message: "custom override ignored" }],
+			},
+		}));
+
+		const result = await tools.get("bobbit_read")!.execute("id", {
+			operation: "list_tools",
+			projectId: "proj-tools",
+			limit: 10,
+			offset: 20,
+		});
+		const data = json(result);
+
+		expect(data.tools.map((t: any) => t.name)).toEqual(Array.from({ length: 10 }, (_, i) => `tool-${i + 20}`));
+		expect(data.diagnostics).toEqual([{ level: "warning", message: "custom override ignored" }]);
+		expect(data.pagination).toMatchObject({
+			limit: 10,
+			offset: 20,
+			total: 75,
+			hasMore: true,
+			nextOffset: 30,
+			mode: "offset",
+			itemKey: "tools",
+			pagedBy: "tool",
+		});
+	});
+
+	it("normalizes bare-array list_mcp_servers responses to a bounded servers payload", async () => {
+		const allServers = Array.from({ length: 55 }, (_, i) => ({ id: `mcp-${i}` }));
+		stubFetch(() => ({ body: allServers }));
+
+		const result = await tools.get("bobbit_read")!.execute("id", {
+			operation: "list_mcp_servers",
+			projectId: "proj-mcp",
+			limit: 5,
+			offset: 50,
+		});
+		const data = json(result);
+
+		expect(data).not.toBeInstanceOf(Array);
+		expect(data.servers.map((s: any) => s.id)).toEqual(["mcp-50", "mcp-51", "mcp-52", "mcp-53", "mcp-54"]);
+		expect(data.pagination).toMatchObject({
+			limit: 5,
+			offset: 50,
+			total: 55,
+			hasMore: false,
+			mode: "offset",
+			itemKey: "servers",
+			pagedBy: "tool",
+		});
+		expect(data.pagination.nextOffset).toBeUndefined();
+	});
+
+	it("pages maintenance sessions probes without losing ancillary fields", async () => {
+		const sessions = Array.from({ length: 12 }, (_, i) => ({ id: `session-${i}` }));
+		stubFetch(() => ({ body: { sessions, scannedAt: "2026-07-09T00:00:00.000Z" } }));
+
+		const result = await tools.get("bobbit_read")!.execute("id", {
+			operation: "maintenance_inspect",
+			probe: "orphaned_sessions",
+			limit: 3,
+			offset: 4,
+		});
+		const data = json(result);
+
+		expect(data.sessions.map((s: any) => s.id)).toEqual(["session-4", "session-5", "session-6"]);
+		expect(data.scannedAt).toBe("2026-07-09T00:00:00.000Z");
+		expect(data.pagination).toMatchObject({
+			limit: 3,
+			offset: 4,
+			total: 12,
+			hasMore: true,
+			nextOffset: 7,
+			mode: "offset",
+			itemKey: "sessions",
+			pagedBy: "tool",
+		});
+	});
+
+	it("pages maintenance sample probes without losing the authoritative count", async () => {
+		const sample = Array.from({ length: 30 }, (_, i) => ({ rowId: `row-${i}` }));
+		stubFetch(() => ({ body: { count: 30, sample } }));
+
+		const result = await tools.get("bobbit_read")!.execute("id", {
+			operation: "maintenance_inspect",
+			probe: "orphaned_index_rows",
+			projectId: "proj-index",
+			limit: 4,
+			offset: 8,
+		});
+		const data = json(result);
+
+		expect(data.count).toBe(30);
+		expect(data.sample.map((r: any) => r.rowId)).toEqual(["row-8", "row-9", "row-10", "row-11"]);
+		expect(data.pagination).toMatchObject({
+			limit: 4,
+			offset: 8,
+			total: 30,
+			hasMore: true,
+			nextOffset: 12,
+			mode: "offset",
+			itemKey: "sample",
+			pagedBy: "tool",
+		});
+	});
+});
+
+describe("bobbit_read — normalized REST pagination metadata", () => {
+	it("returns a bounded default first page for list_sessions", async () => {
+		stubFetch((url) => {
+			const limit = Number(new URL(url).searchParams.get("limit") ?? "60");
+			const sessions = Array.from({ length: limit }, (_, i) => ({ id: `session-${i}` }));
+			return { body: { sessions, total: 60 } };
+		});
+
+		const result = await tools.get("bobbit_read")!.execute("id", { operation: "list_sessions" });
+		const data = json(result);
+
+		expect(data.sessions).toHaveLength(50);
+		expect(data.pagination).toMatchObject({
+			limit: 50,
+			offset: 0,
+			total: 60,
+			hasMore: true,
+			nextOffset: 50,
+			mode: "offset",
+			itemKey: "sessions",
+			pagedBy: "rest",
+		});
+	});
+
+	it("adds pagination metadata to search without re-slicing REST results", async () => {
+		const results = Array.from({ length: 5 }, (_, i) => ({ id: `result-${i + 10}` }));
+		stubFetch(() => ({ body: { results, total: 18 } }));
+
+		const result = await tools.get("bobbit_read")!.execute("id", {
+			operation: "search",
+			q: "pagination",
+			type: "all",
+			projectId: "proj-search",
+			limit: 5,
+			offset: 10,
+		});
+		const data = json(result);
+
+		expect(data.results).toEqual(results);
+		expect(data.total).toBe(18);
+		expect(data.pagination).toMatchObject({
+			limit: 5,
+			offset: 10,
+			total: 18,
+			hasMore: true,
+			nextOffset: 15,
+			mode: "offset",
+			itemKey: "results",
+			pagedBy: "rest",
+		});
+	});
+});

--- a/tests2/core/bobbit-tool-pagination.test.ts
+++ b/tests2/core/bobbit-tool-pagination.test.ts
@@ -162,6 +162,32 @@ describe("bobbit_read — normalized REST pagination metadata", () => {
 		});
 	});
 
+	it("does not re-slice REST-paged archived session pages that include live sessions", async () => {
+		const sessions = [
+			{ id: "live-0" },
+			...Array.from({ length: 5 }, (_, i) => ({ id: `archived-${i}` })),
+		];
+		stubFetch(() => ({ body: { sessions, total: 12, hasMore: true, nextCursor: "archived-cur-4" } }));
+
+		const result = await tools.get("bobbit_read")!.execute("id", {
+			operation: "list_sessions",
+			include: "archived",
+			limit: 5,
+		});
+		const data = json(result);
+
+		expect(data.sessions).toEqual(sessions);
+		expect(data.pagination).toMatchObject({
+			limit: 5,
+			total: 12,
+			hasMore: true,
+			nextCursor: "archived-cur-4",
+			mode: "cursor",
+			itemKey: "sessions",
+			pagedBy: "rest",
+		});
+	});
+
 	it("adds pagination metadata to search without re-slicing REST results", async () => {
 		const results = Array.from({ length: 5 }, (_, i) => ({ id: `result-${i + 10}` }));
 		stubFetch(() => ({ body: { results, total: 18 } }));

--- a/tests2/core/bobbit-tool-tiers.test.ts
+++ b/tests2/core/bobbit-tool-tiers.test.ts
@@ -100,8 +100,8 @@ describe("bobbit_read docs — pagination and semantic filters", () => {
 		for (const param of ["limit?", "offset?", "after?", "cursor?"]) {
 			expect(paramsLine, `params should include ${param}`).toContain(param);
 		}
-		expect(raw).toMatch(/default\s+page\s+size[^\n]*50|50[^\n]*default\s+page\s+size/i);
-		expect(raw).toMatch(/max(?:imum)?\s+page\s+size[^\n]*200|200[^\n]*max(?:imum)?\s+page\s+size/i);
+		expect(raw).toMatch(/limit=50[^\n]*default|default[^\n]*limit=50/i);
+		expect(raw).toMatch(/maximum[^\n]*200|200[^\n]*maximum/i);
 		expect(raw).toMatch(/pagination/i);
 		for (const field of ["hasMore", "nextOffset", "nextCursor", "pagedBy", "itemKey"]) {
 			expect(raw).toContain(field);
@@ -112,7 +112,7 @@ describe("bobbit_read docs — pagination and semantic filters", () => {
 	it("documents projectId support for list operations that are project-scoped", () => {
 		const raw = readYaml();
 		for (const operation of ["list_goals", "list_sessions", "list_workflows", "list_roles", "list_tools", "list_staff", "list_mcp_servers"]) {
-			const row = raw.match(new RegExp(`\\| \\`${operation}\\` \\|[^\\n]+`, "i"))?.[0] ?? "";
+			const row = raw.match(new RegExp("\\| `" + operation + "` \\|[^\\n]+", "i"))?.[0] ?? "";
 			expect(row, `${operation} docs should mention projectId`).toContain("projectId");
 		}
 	});

--- a/tests2/core/bobbit-tool-tiers.test.ts
+++ b/tests2/core/bobbit-tool-tiers.test.ts
@@ -90,3 +90,30 @@ describe("bobbit tiers — operation catalogue drift guard", () => {
 		});
 	}
 });
+
+describe("bobbit_read docs — pagination and semantic filters", () => {
+	const readYaml = () => readFileSync(path.join(YAML_DIR, "bobbit_read.yaml"), "utf8");
+
+	it("documents shared paging params, defaults, max, and pagination metadata", () => {
+		const raw = readYaml();
+		const paramsLine = raw.match(/^params:\s*(.+)$/m)?.[1] ?? "";
+		for (const param of ["limit?", "offset?", "after?", "cursor?"]) {
+			expect(paramsLine, `params should include ${param}`).toContain(param);
+		}
+		expect(raw).toMatch(/default\s+page\s+size[^\n]*50|50[^\n]*default\s+page\s+size/i);
+		expect(raw).toMatch(/max(?:imum)?\s+page\s+size[^\n]*200|200[^\n]*max(?:imum)?\s+page\s+size/i);
+		expect(raw).toMatch(/pagination/i);
+		for (const field of ["hasMore", "nextOffset", "nextCursor", "pagedBy", "itemKey"]) {
+			expect(raw).toContain(field);
+		}
+		expect(raw).not.toMatch(/Returns the gateway(?:'s)? JSON verbatim; on failure/i);
+	});
+
+	it("documents projectId support for list operations that are project-scoped", () => {
+		const raw = readYaml();
+		for (const operation of ["list_goals", "list_sessions", "list_workflows", "list_roles", "list_tools", "list_staff", "list_mcp_servers"]) {
+			const row = raw.match(new RegExp(`\\| \\`${operation}\\` \\|[^\\n]+`, "i"))?.[0] ?? "";
+			expect(row, `${operation} docs should mention projectId`).toContain("projectId");
+		}
+	});
+});

--- a/tests2/core/bobbit-tool-validation.test.ts
+++ b/tests2/core/bobbit-tool-validation.test.ts
@@ -21,6 +21,23 @@ function text(result: any): string {
 	return result?.content?.[0]?.text ?? "";
 }
 
+describe("bobbit_read — paging schema", () => {
+	it("exposes shared paging and cursor params as list-wide controls", () => {
+		const props = tools.get("bobbit_read")!.parameters?.properties ?? {};
+
+		for (const name of ["limit", "offset", "after", "cursor"]) {
+			expect(props[name], `${name} should be registered in the bobbit_read schema`).toBeTruthy();
+		}
+
+		expect(props.limit.description).toMatch(/page|list|bounded/i);
+		expect(props.limit.description).not.toMatch(/^search:/i);
+		expect(props.offset.description).toMatch(/page|list|offset/i);
+		expect(props.offset.description).not.toMatch(/^search:/i);
+		expect(props.after.description).toMatch(/cursor|after/i);
+		expect(props.cursor.description).toMatch(/cursor|after/i);
+	});
+});
+
 describe("bobbit tools — operation validation", () => {
 	it("unknown operation → isError, no fetch", async () => {
 		const calls = stubFetch();

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -72,6 +72,10 @@
       "reason": "bobbit gateway tool suite: tier separation — YAML group/grantPolicy defaults and operation-union drift guard vs the dispatched catalogue and design §5."
     },
     {
+      "path": "tests2/core/bobbit-tool-pagination.test.ts",
+      "reason": "bobbit gateway tool suite: pagination contract — bounded list-style bobbit_read responses, fallback/post-response slicing, preserved ancillary fields, and normalized pagination metadata."
+    },
+    {
       "path": "tests2/core/role-bobbit-tools-policy.test.ts",
       "reason": "bobbit gateway tier role-policy invariant: bobbit_orchestrate/bobbit_admin default never; ONLY general + support + team-lead re-grant orchestrate, ONLY general + support get admin behind ask."
     },


### PR DESCRIPTION
## Summary

- Adds bounded default pagination to list-style `bobbit_read` operations with normalized pagination metadata.
- Forwards paging and semantic filters, including missing `projectId` filters, and adds optional REST paging for sessions/goals/projects/tasks/gates while preserving unpaged API compatibility.
- Updates docs and adds core coverage for dispatch, schema/docs drift, fallback paging, cursor handling, maintenance probes, and REST-paged archived sessions.

## Validation

- `npm run build:server`
- `npm run check`
- `npx vitest run tests2/core/tool-description-budget.test.ts tests2/core/bobbit-tool-dispatch.test.ts tests2/core/bobbit-tool-validation.test.ts tests2/core/bobbit-tool-tiers.test.ts tests2/core/bobbit-tool-pagination.test.ts`
- `npx playwright test tests2/browser/fixtures/sidebar-actions-menu-fixture.spec.ts:212 --config=playwright-v2.config.ts --reporter=line`
- `npx playwright test tests2/browser/journeys/cross-session-proposal-mirror.journey.spec.ts:187 --config=playwright-v2.config.ts --reporter=line`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)