### PR TITLE
Improve permission prompts and fallback tool renderers

### DIFF
--- a/src/app/message-reducer.ts
+++ b/src/app/message-reducer.ts
@@ -62,7 +62,7 @@ export type Action =
 	| { type: "optimistic-steer"; message: any }
 	| { type: "permission-needed"; card: any; seq?: number; ts?: number }
 	| { type: "permission-resolved"; messageId: string; status?: string; error?: string }
-	| { type: "permission-status"; messageId?: string; toolName?: string; status: string; error?: string; actionable?: boolean }
+	| { type: "permission-status"; messageId?: string; toolName?: string; status: string; error?: string; actionable?: boolean; fromStatus?: string }
 	| { type: "permission-reconciled"; current: any | null; reason?: string }
 	| { type: "blocked-tool-call-placeholder"; message: any; seq?: number }
 	| { type: "compaction-placeholder"; message: any }
@@ -325,6 +325,14 @@ function containsToolCall(message: any, toolCallId: string): boolean {
 		&& message.content.some((c: any) => c?.type === "toolCall" && c?.id === toolCallId);
 }
 
+function toolCallIds(message: any): string[] {
+	return Array.isArray(message?.content)
+		? message.content
+			.filter((c: any) => c?.type === "toolCall" && typeof c.id === "string")
+			.map((c: any) => c.id as string)
+		: [];
+}
+
 /**
  * Apply a reducer action to the state and return a new state. Pure.
  */
@@ -359,6 +367,19 @@ export function reduce(state: ReducerState, action: Action): ReducerState {
 			}
 			const role = incoming.role;
 			let messages = state.messages.slice();
+
+			// Permission blocking freezes the in-flight assistant tool-use row as a
+			// synthetic placeholder. If the matching live message_end arrives later,
+			// replace that placeholder instead of rendering the same tool calls twice
+			// until the next snapshot/reload reconciles them.
+			if (role === "assistant") {
+				const ids = toolCallIds(incoming);
+				if (ids.length > 0) {
+					const before = messages.length;
+					messages = messages.filter((m: any) => !(m._permissionBlocked === true && ids.some((id) => containsToolCall(m, id))));
+					if (messages.length !== before) incoming = { ...incoming, _permissionBlocked: true };
+				}
+			}
 
 			// Drop any prior server entry with the same id (replace-by-id).
 			if (typeof incoming.id === "string" && incoming.id.length > 0) {
@@ -873,14 +894,22 @@ export function reduce(state: ReducerState, action: Action): ReducerState {
 					: state.highestSeq + 0.25;
 			const existingIdx = state.messages.findIndex((m: any) =>
 				m.role === "tool_permission_needed"
-				&& typeof action.seq === "number"
-				&& m._order === action.seq
-				&& m.toolName === action.card.toolName
-				&& m.group === action.card.group,
+				&& (
+					(action.card.id && m.id === action.card.id)
+					|| (
+						typeof action.seq === "number"
+						&& m._order === action.seq
+						&& m.toolName === action.card.toolName
+						&& m.group === action.card.group
+					)
+				),
 			);
 			let messages = state.messages.map((m) => {
 				if (m.role !== "tool_permission_needed") return m;
 				if (existingIdx !== -1 && m === state.messages[existingIdx]) return m;
+				// Parallel calls for the same tool/group should stack under one pinned
+				// decision instead of superseding each other.
+				if (samePermissionRequest(m, action.card)) return m;
 				return isActionablePermission(m) ? settlePermission(m, "superseded") : m;
 			});
 			const card = {
@@ -889,7 +918,12 @@ export function reduce(state: ReducerState, action: Action): ReducerState {
 				actionable: action.card.actionable ?? true,
 			};
 			if (existingIdx !== -1) {
-				messages = messages.map((m, idx) => idx === existingIdx ? { ...m, ...card, _order: m._order, _origin: m._origin, _insertionTick: m._insertionTick } : m);
+				messages = messages.map((m, idx) => {
+					if (idx !== existingIdx) return m;
+					const updated = { ...m, ...card, _order: m._order, _origin: m._origin, _insertionTick: m._insertionTick };
+					if (!("error" in card)) delete (updated as any).error;
+					return updated;
+				});
 			} else {
 				messages = [
 					...messages,
@@ -925,8 +959,11 @@ export function reduce(state: ReducerState, action: Action): ReducerState {
 				const toolMatches = !action.messageId && action.toolName && m.toolName === action.toolName && isActionablePermission(m);
 				const fallbackActiveMatch = !action.messageId && !action.toolName && isActionablePermission(m);
 				if (!idMatches && !toolMatches && !fallbackActiveMatch) return m;
+				if (action.fromStatus && m.status !== action.fromStatus) return m;
 				const actionable = action.actionable ?? ACTIVE_PERMISSION_STATUSES.has(action.status);
-				return { ...m, status: action.status, actionable, ...(action.error ? { error: action.error } : {}) };
+				const updated = { ...m, status: action.status, actionable, ...(action.error ? { error: action.error } : {}) };
+				if (!action.error) delete (updated as any).error;
+				return updated;
 			});
 			return { ...state, messages };
 		}
@@ -943,16 +980,13 @@ export function reduce(state: ReducerState, action: Action): ReducerState {
 
 		case "blocked-tool-call-placeholder": {
 			const tick = state.nextTick;
-			const content = Array.isArray(action.message?.content) ? action.message.content : [];
-			const toolCallIds: string[] = content
-				.filter((c: any) => c?.type === "toolCall" && typeof c.id === "string")
-				.map((c: any) => c.id as string);
-			if (toolCallIds.length === 0) return state;
-			if (state.messages.some((m) => toolCallIds.some((id) => containsToolCall(m, id)))) return state;
+			const ids = toolCallIds(action.message);
+			if (ids.length === 0) return state;
+			if (state.messages.some((m) => ids.some((id) => containsToolCall(m, id)))) return state;
 			const order = typeof action.seq === "number" ? action.seq - 0.001 : state.highestSeq + 0.2;
 			const message = {
 				...action.message,
-				id: action.message.id || `blocked_tool_${toolCallIds[0]}`,
+				id: action.message.id || `blocked_tool_${ids[0]}`,
 				_permissionBlocked: true,
 			};
 			return {

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -1313,20 +1313,20 @@ export class RemoteAgent {
 		// no-op: tools are server-side for the coding agent
 	}
 
-	grantToolPermission(toolName: string, scope: "tool" | "group", group?: string, lastPromptText?: string, mode?: "persistent" | "session-only" | "one-time"): void {
+	grantToolPermission(toolName: string, scope: "tool" | "group", group?: string, lastPromptText?: string, mode?: "persistent" | "session-only" | "one-time", permissionId?: string): void {
 		// The guard long-poll/server grant path owns resuming the blocked tool call.
 		// Re-sending lastPromptText here would create a fresh user turn and can
 		// duplicate side-effecting tools such as session_prompt.
 		void lastPromptText;
 		this.apply({ type: "permission-status", toolName, status: "granting", actionable: true });
-		this.send({ type: "grant_tool_permission", toolName, scope, group, mode });
+		this.send({ type: "grant_tool_permission", toolName, scope, group, mode, permissionId });
 		this.emit({ type: "render" });
 	}
 
 	denyToolPermission(messageId: string, toolName?: string): void {
 		// Notify the server so the guard extension's long-poll resolves immediately
 		if (toolName) {
-			this.send({ type: "deny_tool_permission", toolName });
+			this.send({ type: "deny_tool_permission", toolName, permissionId: messageId });
 		}
 		this.apply({ type: "deny-permission-filter", messageId });
 		this.emit({ type: "render" });
@@ -2127,6 +2127,7 @@ export class RemoteAgent {
 					roleName: perm.roleName,
 					roleLabel: perm.roleLabel,
 					lastPromptText: perm.lastPromptText,
+					requestCount: typeof perm.requestCount === "number" && perm.requestCount > 1 ? perm.requestCount : undefined,
 					timestamp: Date.now(),
 					id: typeof perm.id === "string" ? perm.id : `perm_${seq ?? Date.now()}_${perm.toolName}`,
 					status: "active",
@@ -2154,8 +2155,13 @@ export class RemoteAgent {
 			case "error":
 				console.error(`[RemoteAgent] Server error: ${msg.message} (${msg.code})`);
 				if ((msg as any).code === "GRANT_ERROR") {
-					this.apply({ type: "permission-reconciled", current: null, reason: "error" });
-					this.apply({ type: "permission-status", status: "error", error: msg.message || "Permission grant failed or became stale.", actionable: false });
+					// The error frame does not carry a permission request id, so do not
+					// settle/disable all active cards client-side. Refresh from the server
+					// instead; stale grants are ignored by the server handler, and real
+					// failures should not hide a still-pending current request. Reset any
+					// local granting spinner back to an actionable error state.
+					this.apply({ type: "permission-status", status: "active", error: msg.message || "Permission grant failed.", actionable: true, fromStatus: "granting" });
+					this.requestMessages();
 					this.emit({ type: "render" });
 					break;
 				}

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -647,9 +647,18 @@ export interface SessionInfo {
 	pendingGrantRequest?: {
 		resolve: (result: ToolGrantResolution) => void;
 		reject: (err: Error) => void;
+		id: string;
 		toolName: string;
 		toolGroup: string;
 		timer: ReturnType<typeof setTimeout>;
+		/** Same-tool parallel guard calls waiting on the same user decision. */
+		requests?: Array<{
+			resolve: (result: ToolGrantResolution) => void;
+			reject: (err: Error) => void;
+			timer: ReturnType<typeof setTimeout>;
+			seq: number;
+			ts: number;
+		}>;
 		/** seq/ts of the original `tool_permission_needed` broadcast — replayed
 		 * verbatim to late-joining clients so we never burn a fresh global seq
 		 * on a unicast frame. See tests/perm-frame-late-joiner-seq-gap.test.ts. */
@@ -1007,11 +1016,13 @@ function spliceSkillExpansionsIntoEvent(
  * broadcast — never allocating a fresh sequence number. Pinned by
  * tests/perm-frame-late-joiner-seq-gap.test.ts. */
 export interface PendingToolPermissionSnapshot {
+	id?: string;
 	toolName: string;
 	group: string;
 	roleName: string;
 	roleLabel: string;
 	lastPromptText?: string;
+	requestCount?: number;
 	seq: number;
 	ts: number;
 }
@@ -4534,7 +4545,7 @@ export class SessionManager {
 	 *   - "session-only": adds to session.allowedTools in memory only (survives Refresh agent, not gateway restart)
 	 *   - "one-time": adds to session.allowedTools + tracks for revocation on agent_end
 	 */
-	async grantToolPermission(sessionId: string, toolName: string, scope: "tool" | "group", group?: string, mode?: ToolGrantMode): Promise<string[]> {
+	async grantToolPermission(sessionId: string, toolName: string, scope: "tool" | "group", group?: string, mode?: ToolGrantMode, permissionId?: string): Promise<string[]> {
 		const session = this.sessions.get(sessionId);
 		if (!session) throw new Error("Session not found");
 		if (!this.roleManager) throw new Error("No role manager available");
@@ -4575,8 +4586,15 @@ export class SessionManager {
 		}
 		const approvedGrantTools = this.mergeToolNames(undefined, grantScopeTools.length > 0 ? grantScopeTools : [toolName]) ?? [toolName];
 
+		if (permissionId && !session.pendingGrantRequest) {
+			throw new Error(`Ignored stale permission grant for ${toolName}; request is no longer pending.`);
+		}
+
 		if (session.pendingGrantRequest) {
 			const pending = session.pendingGrantRequest;
+			if (permissionId && pending.id !== permissionId) {
+				throw new Error(`Ignored stale permission grant for ${toolName}; active request changed.`);
+			}
 			const requestedToolMatches = pending.toolName.toLowerCase() === toolName.toLowerCase();
 			const requestedGroupMatches = !!group && pending.toolGroup.toLowerCase() === group.toLowerCase();
 			const approvedToolsCoverPending = approvedGrantTools.some(t => t.toLowerCase() === pending.toolName.toLowerCase());
@@ -4584,13 +4602,17 @@ export class SessionManager {
 				? requestedGroupMatches && approvedToolsCoverPending
 				: requestedToolMatches && approvedToolsCoverPending;
 			if (!grantCoversPending) {
-				this.clock.clearTimeout(pending.timer);
-				session.pendingGrantRequest = undefined;
 				const reason = `Ignored stale permission grant for ${toolName}; active request is for ${pending.toolName}.`;
-				pending.resolve({
-					granted: false,
-					reason,
-				});
+				if (permissionId) {
+					// Id-based UI actions are stale; leave the current request pending.
+					throw new Error(reason);
+				}
+				// Legacy callers have no request id, so fail closed by resolving the
+				// active guard immediately rather than letting its long-poll timeout.
+				const requests = pending.requests?.length ? pending.requests : [{ resolve: pending.resolve, reject: pending.reject, timer: pending.timer, seq: pending.seq, ts: pending.ts }];
+				for (const req of requests) this.clock.clearTimeout(req.timer);
+				session.pendingGrantRequest = undefined;
+				for (const req of requests) req.resolve({ granted: false, reason });
 				broadcast(session.clients, {
 					type: "tool_permission_settled",
 					toolName: pending.toolName,
@@ -4605,9 +4627,13 @@ export class SessionManager {
 		let resultTools: string[];
 
 		if (mode === "one-time") {
-			// Temporary grant: add to session.allowedTools, track for revocation on agent_end
+			// Temporary grant: add to session.allowedTools, but only track newly
+			// introduced tools for revocation on agent_end. Group grants may include
+			// tools already allowed/session-only; those must survive the one-time turn.
+			const previouslyAllowed = new Set((session.allowedTools ?? []).map(t => t.toLowerCase()));
+			const newlyAllowed = approvedGrantTools.filter(t => !previouslyAllowed.has(t.toLowerCase()));
 			session.allowedTools = this.mergeToolNames(session.allowedTools, approvedGrantTools) ?? [];
-			session.oneTimeGrantedTools = this.mergeToolNames(session.oneTimeGrantedTools, approvedGrantTools);
+			session.oneTimeGrantedTools = this.mergeToolNames(session.oneTimeGrantedTools, newlyAllowed);
 			resultTools = session.allowedTools;
 
 		} else if (mode === "session-only") {
@@ -4638,14 +4664,15 @@ export class SessionManager {
 		}
 
 		if (session.pendingGrantRequest) {
-			// Single-owner grant resumption: the active guard long-poll receives only
-			// the approved grant scope/delta and lets the original tool call continue.
+			// Batched grant resumption: every same-tool guard long-poll receives only
+			// the approved grant scope/delta and lets its blocked call continue.
 			// Returning the full effective surface here would let unrelated ask-gated
 			// tools bypass future prompts in the active process.
-			this.clock.clearTimeout(session.pendingGrantRequest.timer);
 			const pending = session.pendingGrantRequest;
+			const requests = pending.requests?.length ? pending.requests : [{ resolve: pending.resolve, reject: pending.reject, timer: pending.timer, seq: pending.seq, ts: pending.ts }];
+			for (const req of requests) this.clock.clearTimeout(req.timer);
 			session.pendingGrantRequest = undefined;
-			pending.resolve({ granted: true, tools: approvedGrantTools, scope, group, mode: mode ?? "persistent" });
+			for (const req of requests) req.resolve({ granted: true, tools: approvedGrantTools, scope, group, mode: mode ?? "persistent" });
 			broadcast(session.clients, {
 				type: "tool_permission_settled",
 				toolName: pending.toolName,
@@ -4668,12 +4695,30 @@ export class SessionManager {
 		const session = this.sessions.get(sessionId);
 		if (!session) throw new Error("Session not found");
 
-		// If a previous grant request is still pending, resolve it as denied and
+		// A later same-tool guard call can arrive after the user already approved
+		// a session-scoped grant. Short-circuit only explicit session grants here:
+		// one-time grants are intentionally invocation/batch-scoped and are resolved
+		// through the pending request list, not treated as broad tool access.
+		const toolLower = toolName.toLowerCase();
+		const hasTool = (tools?: string[]) => tools?.some((t) => t.toLowerCase() === toolLower) ?? false;
+		if (hasTool(session.sessionOnlyGrantedTools)) {
+			return { granted: true, tools: [toolName], scope: "tool", group: toolGroup, mode: "session-only" };
+		}
+
+		// If a different grant request is still pending, resolve it as denied and
 		// tell clients it is no longer actionable before broadcasting the new one.
-		if (session.pendingGrantRequest) {
-			const pending = session.pendingGrantRequest;
-			this.clock.clearTimeout(pending.timer);
-			pending.resolve({ granted: false });
+		// Same-tool parallel calls are batched under one user decision instead.
+		const existingPending = session.pendingGrantRequest;
+		const samePendingTool = !!existingPending
+			&& existingPending.toolName.toLowerCase() === toolName.toLowerCase()
+			&& existingPending.toolGroup.toLowerCase() === toolGroup.toLowerCase();
+		if (existingPending && !samePendingTool) {
+			const pending = existingPending;
+			const requests = pending.requests?.length ? pending.requests : [{ resolve: pending.resolve, reject: pending.reject, timer: pending.timer, seq: pending.seq, ts: pending.ts }];
+			for (const req of requests) {
+				this.clock.clearTimeout(req.timer);
+				req.resolve({ granted: false });
+			}
 			session.pendingGrantRequest = undefined;
 			broadcast(session.clients, {
 				type: "tool_permission_settled",
@@ -4684,19 +4729,77 @@ export class SessionManager {
 			});
 		}
 
+		let seq: number;
+		let ts: number;
+		let requestCount = 1;
+
+		if (samePendingTool && session.pendingGrantRequest) {
+			const pending = session.pendingGrantRequest;
+			seq = pending.seq;
+			ts = pending.ts;
+			const promise = new Promise<ToolGrantResolution>((resolve, reject) => {
+				let request: NonNullable<typeof pending.requests>[number];
+				const timer = this.clock.setTimeout(() => {
+					const live = session.pendingGrantRequest;
+					if (live?.requests?.length && request) {
+						live.requests = live.requests.filter((req) => req !== request);
+						if (live.requests.length > 0) {
+							resolve({ granted: false, reason: "Permission request expired." });
+							return;
+						}
+					}
+					session.pendingGrantRequest = undefined;
+					broadcast(session.clients, {
+						type: "tool_permission_settled",
+						toolName,
+						group: toolGroup,
+						status: "expired",
+						reason: "Permission request expired.",
+					});
+					resolve({ granted: false, reason: "Permission request expired." });
+				}, 5 * 60 * 1000);
+				request = { resolve, reject, timer, seq, ts };
+				pending.requests = pending.requests?.length
+					? [...pending.requests, request]
+					: [{ resolve: pending.resolve, reject: pending.reject, timer: pending.timer, seq: pending.seq, ts: pending.ts }, request];
+				requestCount = pending.requests.length;
+			});
+			const roleName = session.role || "general";
+			const role = this.roleManager?.getRole(roleName);
+			broadcast(session.clients, {
+				type: "tool_permission_needed",
+				id: pending.id,
+				toolName,
+				group: toolGroup,
+				roleName: role?.name ?? roleName,
+				roleLabel: role?.label ?? roleName,
+				lastPromptText: session.lastPromptText,
+				requestCount,
+			});
+			return promise;
+		}
+
 		// Stamp seq+ts so client reducer can order this frame relative to live
 		// `event` frames. See docs/design/unified-message-ordering-reducer.md §3.1.
 		// IMPORTANT: this is the ONLY frame-allocation callsite in src/server/.
-		// Late-joiners that attach while this perm is pending must REPLAY the
-		// same seq/ts (via getPendingToolPermission) — never allocate a fresh
-		// seq — or already-attached clients will gap-buffer the next live
-		// event. Pinned by tests/perm-frame-late-joiner-seq-gap.test.ts.
-		const { seq, ts } = session.eventBuffer.pushFrame();
+		const frame = session.eventBuffer.pushFrame();
+		seq = frame.seq;
+		ts = frame.ts;
+		const permissionId = `perm_${seq}_${toolName}`;
 
-		// Create promise that will be resolved by grantToolPermission
 		const promise = new Promise<ToolGrantResolution>((resolve, reject) => {
+			let request: NonNullable<NonNullable<SessionInfo["pendingGrantRequest"]>["requests"]>[number];
 			const timer = this.clock.setTimeout(() => {
+				const live = session.pendingGrantRequest;
+				if (live?.requests?.length && request) {
+					live.requests = live.requests.filter((req) => req !== request);
+					if (live.requests.length > 0) {
+						resolve({ granted: false, reason: "Permission request expired." });
+						return;
+					}
+				}
 				session.pendingGrantRequest = undefined;
+				resolve({ granted: false, reason: "Permission request expired." });
 				broadcast(session.clients, {
 					type: "tool_permission_settled",
 					toolName,
@@ -4704,10 +4807,9 @@ export class SessionManager {
 					status: "expired",
 					reason: "Permission request expired.",
 				});
-				resolve({ granted: false });
 			}, 5 * 60 * 1000); // 5 minute timeout
-
-			session.pendingGrantRequest = { resolve, reject, toolName, toolGroup, timer, seq, ts };
+			request = { resolve, reject, timer, seq, ts };
+			session.pendingGrantRequest = { id: permissionId, resolve, reject, toolName, toolGroup, timer, seq, ts, requests: [request] };
 		});
 
 		// Broadcast to UI clients
@@ -4715,11 +4817,13 @@ export class SessionManager {
 		const role = this.roleManager?.getRole(roleName);
 		broadcast(session.clients, {
 			type: "tool_permission_needed",
+			id: permissionId,
 			toolName,
 			group: toolGroup,
 			roleName: role?.name ?? roleName,
 			roleLabel: role?.label ?? roleName,
 			lastPromptText: session.lastPromptText,
+			requestCount,
 			seq,
 			ts,
 		});
@@ -4732,13 +4836,18 @@ export class SessionManager {
 	 * Resolves the pending grant request with `{ granted: false }` so the
 	 * guard extension's long-poll returns immediately instead of waiting 5 min.
 	 */
-	denyToolPermission(sessionId: string, _toolName: string): void {
+	denyToolPermission(sessionId: string, _toolName: string, permissionId?: string): void {
 		const session = this.sessions.get(sessionId);
 		if (!session?.pendingGrantRequest) return;
-		this.clock.clearTimeout(session.pendingGrantRequest.timer);
 		const pending = session.pendingGrantRequest;
+		if (_toolName && pending.toolName.toLowerCase() !== _toolName.toLowerCase()) return;
+		if (permissionId && pending.id !== permissionId) return;
+		const requests = pending.requests?.length ? pending.requests : [{ resolve: pending.resolve, reject: pending.reject, timer: pending.timer, seq: pending.seq, ts: pending.ts }];
+		for (const req of requests) {
+			this.clock.clearTimeout(req.timer);
+			req.resolve({ granted: false });
+		}
 		session.pendingGrantRequest = undefined;
-		pending.resolve({ granted: false });
 		broadcast(session.clients, {
 			type: "tool_permission_settled",
 			toolName: pending.toolName,
@@ -7047,11 +7156,13 @@ export class SessionManager {
 		const roleName = session.role || "general";
 		const role = this.roleManager?.getRole(roleName);
 		return {
+			id: session.pendingGrantRequest.id,
 			toolName: session.pendingGrantRequest.toolName,
 			group: session.pendingGrantRequest.toolGroup,
 			roleName: role?.name ?? roleName,
 			roleLabel: role?.label ?? roleName,
 			lastPromptText: session.lastPromptText,
+			requestCount: session.pendingGrantRequest.requests?.length ?? 1,
 			seq: session.pendingGrantRequest.seq,
 			ts: session.pendingGrantRequest.ts,
 		};
@@ -7910,8 +8021,11 @@ export class SessionManager {
 		// Resolve any pending grant request so the guard's long-poll returns immediately
 		if (session.pendingGrantRequest) {
 			const pending = session.pendingGrantRequest;
-			this.clock.clearTimeout(pending.timer);
-			pending.resolve({ granted: false });
+			const requests = pending.requests?.length ? pending.requests : [{ resolve: pending.resolve, reject: pending.reject, timer: pending.timer, seq: pending.seq, ts: pending.ts }];
+			for (const req of requests) {
+				this.clock.clearTimeout(req.timer);
+				req.resolve({ granted: false });
+			}
 			session.pendingGrantRequest = undefined;
 			broadcast(session.clients, {
 				type: "tool_permission_settled",

--- a/src/server/agent/tool-guard-extension.ts
+++ b/src/server/agent/tool-guard-extension.ts
@@ -142,7 +142,7 @@ export default function(pi) {
         const groupMatches = grantScope === "group" && r.group === entry.group;
         const coversCurrent = responseTools.length > 0
           ? currentListed && (grantScope !== "group" || groupMatches)
-          : groupMatches;
+          : (grantScope ? groupMatches : true);
         if (!coversCurrent) {
           return { block: true, reason: "Permission grant did not cover tool " + toolName };
         }

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -1152,13 +1152,15 @@ export function handleWebSocketConnection(
 					break;
 				}
 				case "grant_tool_permission": {
-					sessionManager.grantToolPermission(sessionId, msg.toolName, msg.scope, msg.group, msg.mode).catch((err: any) => {
+					sessionManager.grantToolPermission(sessionId, msg.toolName, msg.scope, msg.group, msg.mode, msg.permissionId).catch((err: any) => {
+						const message = String(err?.message ?? err);
+						if (message.startsWith("Ignored stale permission grant")) return;
 						send(ws, { type: "error", message: `Grant failed: ${err}`, code: "GRANT_ERROR" });
 					});
 					break;
 				}
 				case "deny_tool_permission": {
-					sessionManager.denyToolPermission(sessionId, msg.toolName);
+					sessionManager.denyToolPermission(sessionId, msg.toolName, msg.permissionId);
 					break;
 				}
 				case "restart_agent":

--- a/src/server/ws/protocol.ts
+++ b/src/server/ws/protocol.ts
@@ -118,8 +118,8 @@ export type ClientMessage =
 	| { type: "task_update"; taskId: string; updates: { title?: string; spec?: string; state?: string; assignedSessionId?: string; dependsOn?: string[] } }
 	| { type: "task_delete"; taskId: string }
 	| { type: "summarize_goal_title"; goalTitle: string }
-	| { type: "grant_tool_permission"; toolName: string; scope: "tool" | "group"; group?: string; mode?: "persistent" | "session-only" | "one-time" }
-	| { type: "deny_tool_permission"; toolName: string }
+	| { type: "grant_tool_permission"; toolName: string; scope: "tool" | "group"; group?: string; mode?: "persistent" | "session-only" | "one-time"; permissionId?: string }
+	| { type: "deny_tool_permission"; toolName: string; permissionId?: string }
 	| { type: "reorder_queue"; messageIds: string[] }
 	| { type: "restart_agent" }
 	| { type: "resume"; fromSeq: number }
@@ -250,7 +250,7 @@ export type ServerMessage =
 	| { type: "inbox.entry.updated"; staffId: string; entry: InboxEntry }
 	| { type: "inbox.entry.removed"; staffId: string; entryId: string }
 	| { type: "pr_status_changed"; goalId: string }
-	| { type: "tool_permission_needed"; toolName: string; group: string; roleName: string; roleLabel: string; lastPromptText?: string; seq?: number; ts?: number }
+	| { type: "tool_permission_needed"; id?: string; toolName: string; group: string; roleName: string; roleLabel: string; lastPromptText?: string; requestCount?: number; seq?: number; ts?: number }
 	| { type: "tool_permission_settled"; toolName: string; group?: string; status: "granted" | "denied" | "expired" | "superseded" | "cancelled" | "error"; reason?: string }
 	| { type: "index:progress"; projectId: string; phase: "rebuild" | "incremental"; total: number; completed: number; backlog: number }
 	| { type: "index:complete"; projectId: string; phase: "rebuild" | "incremental"; durationMs: number; rowsWritten: number }

--- a/src/ui/components/AgentInterface.ts
+++ b/src/ui/components/AgentInterface.ts
@@ -1119,6 +1119,7 @@ export class AgentInterface extends LitElement {
 			}
 			if ((ev as any).type === "render") {
 				// Generic re-render request (e.g. tool permission card added)
+				this._clearStreamingIfPermissionBlocked();
 				this._updateAndPin();
 				return;
 			}
@@ -1692,10 +1693,37 @@ export class AgentInterface extends LitElement {
 		});
 	}
 
+	private _activePermissionToolNames(): Set<string> {
+		return new Set(this._activePermissionRows().map((m) => m.toolName).filter((name): name is string => typeof name === "string" && name.length > 0));
+	}
+
+	private _clearStreamingIfPermissionBlocked() {
+		const blockedTools = this._activePermissionToolNames();
+		if (blockedTools.size === 0) return;
+		const streaming = this.session?.state?.streamingMessage as any;
+		const hasBlockedStreamingTool = streaming?.content?.some?.((c: any) => c?.type === "toolCall" && blockedTools.has(c.name));
+		if (hasBlockedStreamingTool && this.session?.state) {
+			(this.session.state as any).streamingMessage = null;
+			(this.session as any).streamingMessageId = undefined;
+		}
+		// RemoteAgent clears state.streamingMessage before emitting render on the
+		// permission path; clear the imperative container too so stale previews
+		// cannot remain beside the frozen blocked placeholder.
+		this._streamingContainer?.setMessage(null, true);
+	}
+
 	private _patchPermissionRow(id: string | undefined, patch: Record<string, unknown>) {
 		if (!id || !this.session?.state) return;
 		const current = ((this.session.state as any).messages || []) as any[];
 		(this.session.state as any).messages = current.map((m) => m?.role === "tool_permission_needed" && m.id === id ? { ...m, ...patch } : m);
+		this.requestUpdate();
+	}
+
+	private _patchPermissionRows(ids: string[], patch: Record<string, unknown>) {
+		if (!this.session?.state || ids.length === 0) return;
+		const idSet = new Set(ids);
+		const current = ((this.session.state as any).messages || []) as any[];
+		(this.session.state as any).messages = current.map((m) => m?.role === "tool_permission_needed" && idSet.has(m.id) ? { ...m, ...patch } : m);
 		this.requestUpdate();
 	}
 
@@ -1709,16 +1737,25 @@ export class AgentInterface extends LitElement {
 	private _renderPinnedPermissions() {
 		const rows = this._activePermissionRows();
 		if (rows.length === 0) return nothing;
+		const groups = new Map<string, any[]>();
+		for (const row of rows) {
+			const key = `${row.toolName || ""}\u0000${row.group || ""}`;
+			groups.set(key, [...(groups.get(key) ?? []), row]);
+		}
+		const groupedRows = [...groups.values()].map((items) => {
+			const first = items[0];
+			const count = Math.max(items.length, ...items.map((m) => typeof m.requestCount === "number" ? m.requestCount : 1));
+			return { first, ids: items.map((m) => m.id).filter(Boolean), count };
+		});
 		return html`
 			<div
 				data-permission-pinned
 				data-pinned-permission-controls
-				class="pinned-permission-controls sticky bottom-0 z-20 mt-3 pt-2 pb-2 px-2 sm:px-4 pointer-events-auto"
-				style="position: sticky; bottom: 0;"
+				class="pinned-permission-controls mb-2 pointer-events-auto"
 			>
-				<div class="max-w-5xl mx-auto rounded-lg border border-amber-500/30 bg-background shadow-sm p-2 space-y-2 overflow-y-auto" style="max-height: min(45vh, 22rem); background: color-mix(in oklch, var(--background) 95%, transparent); backdrop-filter: blur(8px);">
+				<div class="rounded-lg border border-amber-500/30 bg-background shadow-sm p-2 space-y-2 overflow-y-auto" style="max-height: min(45vh, 22rem); background: color-mix(in oklch, var(--background) 95%, transparent); backdrop-filter: blur(8px);">
 					<div class="text-xs font-medium text-amber-600 dark:text-amber-400 px-1">Permission required</div>
-					${rows.map((perm) => html`<tool-permission-card
+					${groupedRows.map(({ first: perm, ids, count }) => html`<tool-permission-card
 						.permissionId=${perm.id}
 						.toolName=${perm.toolName}
 						.group=${perm.group}
@@ -1727,16 +1764,17 @@ export class AgentInterface extends LitElement {
 						.status=${perm.status ?? "active"}
 						.mode=${perm.mode ?? "session-only"}
 						.error=${perm.error ?? ""}
+						.requestCount=${count}
 						.actionable=${perm.actionable !== false}
-						.onModeChange=${(mode: string) => this._patchPermissionRow(perm.id, { mode })}
+						.onModeChange=${(mode: string) => this._patchPermissionRows(ids, { mode })}
 						.onGrant=${(scope: "tool" | "group", mode?: string) => {
 							if (!this._beginPermissionGrant()) return false;
-							this._patchPermissionRow(perm.id, { status: "granting", actionable: true, mode: mode ?? perm.mode ?? "session-only" });
-							(this.session as any)?.grantToolPermission?.(perm.toolName, scope, perm.group, perm.lastPromptText, mode ?? perm.mode ?? "session-only");
+							this._patchPermissionRows(ids, { status: "granting", actionable: true, mode: mode ?? perm.mode ?? "session-only" });
+							(this.session as any)?.grantToolPermission?.(perm.toolName, scope, perm.group, perm.lastPromptText, mode ?? perm.mode ?? "session-only", perm.id);
 							return true;
 						}}
 						.onDeny=${() => {
-							this._patchPermissionRow(perm.id, { status: "denied", actionable: false });
+							this._patchPermissionRows(ids, { status: "denied", actionable: false });
 							(this.session as any)?.denyToolPermission?.(perm.id, perm.toolName);
 						}}
 					></tool-permission-card>`)}
@@ -1782,6 +1820,7 @@ export class AgentInterface extends LitElement {
 					.isStreaming=${state.isStreaming}
 					.hasStreamMessage=${!!state.streamingMessage}
 					.toolPartialResults=${(state as any).toolPartialResults}
+					.hideActionablePermissionRows=${true}
 					.onCostClick=${this.onCostClick}
 					.onDismissError=${(id: string) => {
 						if (!this.session) return;
@@ -1804,7 +1843,7 @@ export class AgentInterface extends LitElement {
 						if (!this.session || !this._beginPermissionGrant()) return;
 						const { id, toolName, scope, group, lastPromptText, mode } = e.detail;
 						this._patchPermissionRow(id, { status: "granting", actionable: true, mode });
-						(this.session as any).grantToolPermission?.(toolName, scope, group, lastPromptText, mode);
+						(this.session as any).grantToolPermission?.(toolName, scope, group, lastPromptText, mode, id);
 					}}
 					@deny-tool-permission=${(e: CustomEvent) => {
 						if (!this.session) return;
@@ -1820,6 +1859,7 @@ export class AgentInterface extends LitElement {
 					.isStreaming=${state.isStreaming}
 					.archived=${this.readOnly && !this.nonInteractive}
 					.pendingToolCalls=${state.pendingToolCalls}
+					.permissionBlockedTools=${this._activePermissionToolNames()}
 					.toolResultsById=${toolResultsById}
 					.toolPartialResults=${(state as any).toolPartialResults}
 					.onCostClick=${this.onCostClick}
@@ -2207,7 +2247,6 @@ export class AgentInterface extends LitElement {
 				<div class="flex-1 min-h-0 relative">
 					<div class="absolute inset-0 overflow-y-auto overflow-x-hidden" style="overflow-anchor: none;">
 						<div class="max-w-5xl mx-auto p-2 sm:p-4 pb-0 min-w-0">${this.renderMessages()}</div>
-						${this._renderPinnedPermissions()}
 					</div>
 					${this._renderJumpToLastPrompt()}
 					${this._renderJumpToBottom()}
@@ -2216,6 +2255,7 @@ export class AgentInterface extends LitElement {
 				<!-- Input Area -->
 				<div class="shrink-0 pt-0 pb-1 agent-input-area">
 					<div data-input-container class="max-w-5xl mx-auto px-2 relative">
+						${this._renderPinnedPermissions()}
 						${this.bgProcesses.length > 0 || this._showGitStatusWidget || this.goalId || this.teamGoalId ? html`
 						<div data-pill-strip class="absolute right-2 bottom-full mb-3 z-10 pointer-events-auto" style="max-width:${this._isNarrow ? '75%' : 'calc(100% - 8rem)'}; --pill-h: 22px">
 							<!-- Real pills with a CSS drop-shadow filter for the glow. Drop-shadow

--- a/src/ui/components/MessageList.ts
+++ b/src/ui/components/MessageList.ts
@@ -137,6 +137,8 @@ export class MessageList extends LitElement {
 	@property({ attribute: false }) onDismissError?: (id: string) => void;
 	@property({ attribute: false }) onRestartAgent?: () => void;
 	@property({ attribute: false }) onRetry?: () => void;
+	/** Hide active permission request cards when the same controls are pinned near the prompt. */
+	@property({ type: Boolean }) hideActionablePermissionRows: boolean = false;
 	/** Session id — forwarded to `<bobbit-pre-compaction-history>` when a
 	 *  compaction card appears in the transcript, so the inline expand
 	 *  affordance can call the orphan-transcript API. */
@@ -210,26 +212,34 @@ export class MessageList extends LitElement {
 				continue;
 			}
 
-			// Render tool permission request cards
+			// Render settled permission request cards as transcript history. Active rows
+			// can be suppressed when AgentInterface pins the actionable controls above
+			// the prompt, avoiding duplicate grant/deny cards for the same request.
 			if ((msg as any).role === "tool_permission_needed") {
 				const perm = msg as any;
+				if (this.hideActionablePermissionRows && isPermissionActionable(perm)) {
+					i++;
+					continue;
+				}
 				items.push({
 					key: `perm:${perm.id}`,
 					eager: true,
-					template: html`<tool-permission-card
-						.permissionId=${perm.id}
-						.toolName=${perm.toolName}
-						.group=${perm.group}
-						.roleName=${perm.roleName}
-						.roleLabel=${perm.roleLabel}
-						.status=${perm.status ?? "active"}
-						.mode=${perm.mode ?? "session-only"}
-						.error=${perm.error ?? ""}
-						.actionable=${perm.actionable !== false}
-						.onModeChange=${(mode: string) => this.dispatchEvent(new CustomEvent("permission-mode-change", { detail: { id: perm.id, mode }, bubbles: true, composed: true }))}
-						.onGrant=${(scope: "tool" | "group", mode?: string) => this.dispatchEvent(new CustomEvent("grant-tool-permission", { detail: { id: perm.id, toolName: perm.toolName, scope, group: perm.group, lastPromptText: perm.lastPromptText, mode }, bubbles: true, composed: true }))}
-						.onDeny=${() => this.dispatchEvent(new CustomEvent("deny-tool-permission", { detail: { id: perm.id, toolName: perm.toolName }, bubbles: true, composed: true }))}
-					></tool-permission-card>`,
+					template: html`<div class="px-2 sm:px-4">
+						<tool-permission-card
+							.permissionId=${perm.id}
+							.toolName=${perm.toolName}
+							.group=${perm.group}
+							.roleName=${perm.roleName}
+							.roleLabel=${perm.roleLabel}
+							.status=${perm.status ?? "active"}
+							.mode=${perm.mode ?? "session-only"}
+							.error=${perm.error ?? ""}
+							.actionable=${perm.actionable !== false}
+							.onModeChange=${(mode: string) => this.dispatchEvent(new CustomEvent("permission-mode-change", { detail: { id: perm.id, mode }, bubbles: true, composed: true }))}
+							.onGrant=${(scope: "tool" | "group", mode?: string) => this.dispatchEvent(new CustomEvent("grant-tool-permission", { detail: { id: perm.id, toolName: perm.toolName, scope, group: perm.group, lastPromptText: perm.lastPromptText, mode }, bubbles: true, composed: true }))}
+							.onDeny=${() => this.dispatchEvent(new CustomEvent("deny-tool-permission", { detail: { id: perm.id, toolName: perm.toolName }, bubbles: true, composed: true }))}
+						></tool-permission-card>
+					</div>`,
 				});
 				i++;
 				continue;

--- a/src/ui/components/StreamingMessageContainer.ts
+++ b/src/ui/components/StreamingMessageContainer.ts
@@ -11,6 +11,7 @@ export class StreamingMessageContainer extends LitElement {
 	@property({ type: Boolean }) archived = false;
 
 	@property({ type: Object }) pendingToolCalls?: Set<string>;
+	@property({ type: Object }) permissionBlockedTools?: Set<string>;
 	@property({ type: Object }) toolResultsById?: Map<string, ToolResultMessage>;
 	@property({ type: Object }) toolPartialResults?: Record<string, any>;
 	@property({ attribute: false }) onCostClick?: () => void;
@@ -356,6 +357,15 @@ export class StreamingMessageContainer extends LitElement {
 		}
 	}
 
+	private _isOnlyPermissionBlockedToolCalls(msg: AgentMessage | null): boolean {
+		if (!msg || msg.role !== "assistant") return false;
+		const content = Array.isArray((msg as any).content) ? (msg as any).content : [];
+		const toolCalls = content.filter((c: any) => c?.type === "toolCall");
+		return toolCalls.length > 0
+			&& toolCalls.length === content.length
+			&& toolCalls.every((c: any) => this.permissionBlockedTools?.has(c.name));
+	}
+
 	override render() {
 		// Unified render: the blob lives in a single, stable DOM slot so its
 		// CSS animations keep their clock across message transitions (e.g.
@@ -369,12 +379,13 @@ export class StreamingMessageContainer extends LitElement {
 		// Message content: only assistant messages render inline here. User
 		// and toolResult messages are rendered by the stable message-list.
 		let content: unknown = nothing;
-		if (msg && msg.role === "assistant") {
+		if (msg && msg.role === "assistant" && !this._isOnlyPermissionBlockedToolCalls(msg)) {
 			content = html`<assistant-message
 				.message=${msg}
 				.tools=${this.tools}
 				.isStreaming=${this.isStreaming}
 				.pendingToolCalls=${this.pendingToolCalls}
+				.permissionBlockedTools=${this.permissionBlockedTools}
 				.toolResultsById=${this.toolResultsById}
 				.toolPartialResults=${this.toolPartialResults}
 				.hideToolCalls=${false}

--- a/src/ui/components/ToolPermissionCard.ts
+++ b/src/ui/components/ToolPermissionCard.ts
@@ -19,6 +19,7 @@ export class ToolPermissionCard extends LitElement {
 	@property() status: PermissionCardStatus | string = "active";
 	@property() mode: string = "session-only";
 	@property() error = "";
+	@property({ type: Number }) requestCount = 1;
 	@property({ type: Boolean }) actionable = true;
 	@property({ attribute: false }) onModeChange?: (mode: string) => void;
 	@property({ attribute: false }) onGrant?: (scope: "tool" | "group", mode?: string) => void | boolean;
@@ -35,6 +36,14 @@ export class ToolPermissionCard extends LitElement {
 
 	private get _effectiveMode(): string {
 		return this.mode || "session-only";
+	}
+
+	private get _callCount(): number {
+		return Number.isFinite(this.requestCount) && this.requestCount > 1 ? Math.floor(this.requestCount) : 1;
+	}
+
+	private get _callCountLabel(): string {
+		return this._callCount > 1 ? `${this._callCount} calls` : "1 call";
 	}
 
 	private _setMode(mode: string) {
@@ -118,6 +127,12 @@ export class ToolPermissionCard extends LitElement {
 
 		return html`
 			<div class="px-3 py-2.5 rounded-md bg-amber-500/10 border border-amber-500/30 space-y-2">
+				${this.error ? html`
+					<div class="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-2.5 py-2 text-sm text-destructive" role="alert">
+						${icon(AlertTriangle, "sm")}
+						<span>${this.error}</span>
+					</div>
+				` : ""}
 				<div class="flex items-center gap-2 text-sm font-medium text-amber-600 dark:text-amber-400">
 					${icon(ShieldCheck, "sm")}
 					<span>Role "${this.roleLabel}" doesn't have access to <code class="px-1 py-0.5 rounded bg-amber-500/10 text-xs">${this._shortToolName}</code></span>
@@ -130,26 +145,38 @@ export class ToolPermissionCard extends LitElement {
 						@change=${(e: Event) => this._setMode((e.target as HTMLSelectElement).value)}
 					>
 						<option value="session-only">This session</option>
-						<option value="one-time">Just this once</option>
+						<option value="one-time">Just for now${this._callCount > 1 ? ` (${this._callCountLabel})` : ""}</option>
 						<option value="persistent">For all future sessions</option>
 					</select>
 				</div>
-				<div class="flex gap-2 flex-wrap">
-					<button
-						class="px-3 py-1.5 text-xs font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed"
-						?disabled=${!this._canAct || this._clicked}
-						@click=${() => this._handleGrant("group")}
-					>Allow all tools in ${this._shortGroup}</button>
-					<button
-						class="px-3 py-1.5 text-xs font-medium rounded-md bg-secondary text-secondary-foreground hover:bg-secondary/80 transition-colors cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed"
-						?disabled=${!this._canAct || this._clicked}
-						@click=${() => this._handleGrant("tool")}
-					>Allow just ${this._shortToolName}</button>
-					<button
-						class="px-3 py-1.5 text-xs font-medium rounded-md border border-border text-muted-foreground hover:bg-muted transition-colors cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed"
-						?disabled=${!this._canAct || this._clicked}
-						@click=${() => this._handleDeny()}
-					>Deny</button>
+				<div class="space-y-1.5">
+					<div class="text-xs font-medium text-foreground/90">Choose how to continue${this._callCount > 1 ? ` for these ${this._callCountLabel}` : ""}:</div>
+					<div class="grid grid-cols-1 sm:grid-cols-3 gap-2">
+						<button
+							class="min-w-0 rounded-lg border border-border bg-background px-3 py-2 text-left text-foreground shadow-xs hover:bg-secondary/50 transition-colors cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+							?disabled=${!this._canAct || this._clicked}
+							@click=${() => this._handleGrant("group")}
+						>
+							<div class="text-sm font-semibold">Allow all tools</div>
+							<div class="mt-0.5 text-[11px] text-foreground/80 truncate">in ${this._shortGroup}</div>
+						</button>
+						<button
+							class="min-w-0 rounded-lg border border-border bg-background px-3 py-2 text-left text-foreground shadow-xs hover:bg-secondary/50 transition-colors cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+							?disabled=${!this._canAct || this._clicked}
+							@click=${() => this._handleGrant("tool")}
+						>
+							<div class="text-sm font-semibold">Allow just this tool</div>
+							<div class="mt-0.5 text-[11px] text-foreground/80 truncate">${this._shortToolName}${this._callCount > 1 ? ` · ${this._callCountLabel}` : ""}</div>
+						</button>
+						<button
+							class="min-w-0 rounded-lg border border-border bg-background px-3 py-2 text-left text-foreground shadow-xs hover:bg-secondary/50 transition-colors cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+							?disabled=${!this._canAct || this._clicked}
+							@click=${() => this._handleDeny()}
+						>
+							<div class="text-sm font-semibold">Deny</div>
+							<div class="mt-0.5 text-[11px] text-foreground/80">Do not run ${this._callCount > 1 ? "them" : "it"}</div>
+						</button>
+					</div>
 				</div>
 			</div>
 		`;

--- a/src/ui/tools/index.ts
+++ b/src/ui/tools/index.ts
@@ -10,6 +10,7 @@ import { BrowserNavigateRenderer } from "./renderers/BrowserNavigateRenderer.js"
 import { BrowserTypeRenderer } from "./renderers/BrowserTypeRenderer.js";
 import { BrowserWaitRenderer } from "./renderers/BrowserWaitRenderer.js";
 import { DefaultRenderer } from "./renderers/DefaultRenderer.js";
+import { isMcpToolName, McpDefaultRenderer } from "./renderers/McpDefaultRenderer.js";
 import { EditRenderer } from "./renderers/EditRenderer.js";
 import { FindRenderer } from "./renderers/FindRenderer.js";
 import { GrepRenderer } from "./renderers/GrepRenderer.js";
@@ -181,6 +182,7 @@ registerLazyClass("goal_decide_mutation", () => import("./renderers/GoalDecideMu
 registerLazyClass("goal_set_policy", () => import("./renderers/GoalSetPolicyRenderer.js"), "GoalSetPolicyRenderer");
 
 const defaultRenderer = new DefaultRenderer();
+const mcpDefaultRenderer = new McpDefaultRenderer("mcp");
 
 // Global flag to force default JSON rendering for all tools
 let showJsonMode = false;
@@ -211,6 +213,9 @@ export function renderTool(
 	const renderer = getToolRenderer(toolName);
 	if (renderer) {
 		return renderer.render(params, result, isStreaming, ctx);
+	}
+	if (isMcpToolName(toolName)) {
+		return mcpDefaultRenderer.withToolName(toolName).render(params, result, isStreaming, ctx);
 	}
 	return defaultRenderer.withToolName(toolName).render(params, result, isStreaming);
 }

--- a/src/ui/tools/renderers/DefaultRenderer.ts
+++ b/src/ui/tools/renderers/DefaultRenderer.ts
@@ -5,14 +5,108 @@ import { i18n } from "../../utils/i18n.js";
 import { renderHeader, getToolState } from "../renderer-registry.js";
 import type { ToolRenderer, ToolRenderResult } from "../types.js";
 import { renderInlineImages } from "./image-utils.js";
+import { renderPayloadSection } from "./payload-section.js";
 
 const ERROR_PREVIEW_MAX_LENGTH = 500;
-let payloadSectionId = 0;
+const TITLE_BADGE_MAX_COUNT = 4;
+const TITLE_BADGE_MAX_VALUE_LENGTH = 36;
+const TITLE_BADGE_MAX_TOTAL_LENGTH = 90;
+const TITLE_FIELD_PRIORITY = [
+	"action", "operation", "type", "state",
+	"name", "title", "server", "provider", "selector", "outputPath",
+	"scope", "view", "probe", "level", "size", "imageSize", "aspectRatio", "format", "limit", "width", "height",
+];
+const TITLE_FIELD_SKIP = new Set(["body", "config", "prompt", "values", "questions", "content", "metadata"]);
+const SENSITIVE_FIELD_RE = /(api[-_]?key|key|token|secret|password|authorization|credential|cookie)/i;
+const SECRET_VALUE_RE = /\b(?:Bearer\s+[A-Za-z0-9._~+\/-]{10,}|sk-[A-Za-z0-9_-]{10,}|gh[opusr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|ya29\.[A-Za-z0-9._-]{10,}|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)\b/i;
+
+function containsSensitiveText(text: string): boolean {
+	return SENSITIVE_FIELD_RE.test(text) || SECRET_VALUE_RE.test(text);
+}
+
+function redactSensitiveText(text: string): string {
+	return text
+		.replace(/\b(authorization)(["'\s:=]+)(bearer\s+)?[^,\r\n}"']+/gi, "$1$2[redacted]")
+		.replace(/\b(api[-_]?key|access[-_]?token|refresh[-_]?token|client[-_]?secret|key|token|secret|password|credential|cookie)(["'\s:=]+)[^,\s&}"']+/gi, "$1$2[redacted]")
+		.replace(/\bBearer\s+[A-Za-z0-9._~+\/-]{10,}/gi, "Bearer [redacted]")
+		.replace(/\bsk-[A-Za-z0-9_-]{10,}\b/g, "sk-[redacted]")
+		.replace(/\bgh[opusr]_[A-Za-z0-9_]{20,}\b/g, "gh_[redacted]")
+		.replace(/\bgithub_pat_[A-Za-z0-9_]{20,}\b/g, "github_pat_[redacted]")
+		.replace(/\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g, "xox-[redacted]")
+		.replace(/\bya29\.[A-Za-z0-9._-]{10,}\b/g, "ya29.[redacted]")
+		.replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, "jwt-[redacted]");
+}
+
+function redactSensitive(value: unknown): unknown {
+	if (typeof value === "string") return redactSensitiveText(value);
+	if (!value || typeof value !== "object") return value;
+	if (Array.isArray(value)) return value.map(redactSensitive);
+	const out: Record<string, unknown> = {};
+	for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+		out[key] = SENSITIVE_FIELD_RE.test(key) ? "[redacted]" : redactSensitive(nested);
+	}
+	return out;
+}
 
 function truncateErrorPreview(text: string): string {
 	const trimmed = text.trim();
-	if (trimmed.length <= ERROR_PREVIEW_MAX_LENGTH) return trimmed;
-	return `${trimmed.slice(0, ERROR_PREVIEW_MAX_LENGTH)}…`;
+	let redacted = redactSensitiveText(trimmed);
+	try {
+		redacted = JSON.stringify(redactSensitive(JSON.parse(trimmed)), null, 2);
+	} catch {
+		// Non-JSON errors are still lightly redacted above.
+	}
+	if (redacted.length <= ERROR_PREVIEW_MAX_LENGTH) return redacted;
+	return `${redacted.slice(0, ERROR_PREVIEW_MAX_LENGTH)}…`;
+}
+
+function parseParams(params: unknown): unknown {
+	if (typeof params === "string") {
+		try { return JSON.parse(params); } catch { return params; }
+	}
+	return params;
+}
+
+function paramsObject(params: unknown): Record<string, unknown> | undefined {
+	const parsed = parseParams(params);
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+	return parsed as Record<string, unknown>;
+}
+
+function compactTitleValue(value: unknown): string | undefined {
+	if (typeof value === "string") {
+		const trimmed = value.trim();
+		if (!trimmed || containsSensitiveText(trimmed) || trimmed.length > TITLE_BADGE_MAX_VALUE_LENGTH) return undefined;
+		return trimmed;
+	}
+	if (typeof value === "number" || typeof value === "boolean") return String(value);
+	return undefined;
+}
+
+function titleBadgesFromParams(params: unknown): Array<{ field: string; value: string } | { more: number }> {
+	const obj = paramsObject(params);
+	if (!obj) return [];
+	const fields = Object.keys(obj);
+	const shown = new Set<string>();
+	const badges: Array<{ field: string; value: string }> = [];
+	let totalLength = 0;
+	const candidates = [
+		...TITLE_FIELD_PRIORITY.filter((field) => fields.includes(field)),
+		...fields.filter((field) => !TITLE_FIELD_PRIORITY.includes(field)),
+	];
+	for (const field of candidates) {
+		if (badges.length >= TITLE_BADGE_MAX_COUNT) break;
+		if (shown.has(field) || TITLE_FIELD_SKIP.has(field) || SENSITIVE_FIELD_RE.test(field)) continue;
+		const value = compactTitleValue(obj[field]);
+		if (!value) continue;
+		const length = field.length + value.length + 1;
+		if (totalLength + length > TITLE_BADGE_MAX_TOTAL_LENGTH) break;
+		badges.push({ field, value });
+		shown.add(field);
+		totalLength += length;
+	}
+	const more = fields.filter((field) => !shown.has(field)).length;
+	return more > 0 ? [...badges, { more }] : badges;
 }
 
 export class DefaultRenderer implements ToolRenderer {
@@ -36,37 +130,20 @@ export class DefaultRenderer implements ToolRenderer {
 			.replace(/\b\w/g, (c) => c.toUpperCase());
 	}
 
-	private renderPayloadSection(label: string, code: string, language: string) {
-		const payloadType = language === "json" ? "JSON" : "text";
-		const payloadId = `default-payload-${++payloadSectionId}`;
-		const onToggle = (event: Event) => {
-			const button = event.currentTarget as HTMLButtonElement;
-			const section = button.closest("[data-default-payload-section]");
-			const expanded = button.getAttribute("aria-expanded") === "true";
-			const nextExpanded = !expanded;
-			button.setAttribute("aria-expanded", String(nextExpanded));
-			section?.querySelector<HTMLElement>(`[data-payload-region="${payloadId}"]`)?.toggleAttribute("hidden", !nextExpanded);
-			section?.querySelector('[data-state="collapsed"]')?.toggleAttribute("hidden", nextExpanded);
-			section?.querySelector('[data-state="expanded"]')?.toggleAttribute("hidden", !nextExpanded);
-		};
-
+	private title(params: unknown) {
+		const badges = titleBadgesFromParams(params);
+		if (badges.length === 0) return this.label;
 		return html`
-			<div class="rounded-md border border-border bg-muted/20 p-2" data-default-payload-section>
-				<button
-					type="button"
-					class="cursor-pointer select-none rounded-sm text-left text-xs font-medium text-muted-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
-					aria-expanded="false"
-					aria-controls=${payloadId}
-					@click=${onToggle}
-				>
-					${label} ${payloadType} payload
-					<span class="font-normal opacity-80" data-state="collapsed">(collapsed; expand to inspect)</span>
-					<span class="font-normal opacity-80" data-state="expanded" hidden>(expanded)</span>
-				</button>
-				<div id=${payloadId} data-payload-region=${payloadId} class="mt-2" hidden>
-					<code-block .code=${code} language=${language}></code-block>
-				</div>
-			</div>
+			<span class="min-w-0">
+				<span>${this.label}</span>
+				${badges.map((badge) => "more" in badge ? html`
+					<span class="ml-2 rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">+${badge.more} more</span>
+				` : html`
+					<span class="ml-2 rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+						${badge.field}=<span class="font-mono text-foreground">${badge.value}</span>
+					</span>
+				`)}
+			</span>
 		`;
 	}
 
@@ -77,12 +154,12 @@ export class DefaultRenderer implements ToolRenderer {
 		let paramsJson = "";
 		if (params) {
 			try {
-				paramsJson = JSON.stringify(JSON.parse(params), null, 2);
+				paramsJson = JSON.stringify(redactSensitive(JSON.parse(params)), null, 2);
 			} catch {
 				try {
-					paramsJson = JSON.stringify(params, null, 2);
+					paramsJson = JSON.stringify(redactSensitive(params), null, 2);
 				} catch {
-					paramsJson = String(params);
+					paramsJson = redactSensitiveText(String(params));
 				}
 			}
 		}
@@ -100,10 +177,11 @@ export class DefaultRenderer implements ToolRenderer {
 			// Try to parse and pretty-print if it's valid JSON
 			try {
 				const parsed = JSON.parse(outputJson);
-				outputJson = JSON.stringify(parsed, null, 2);
+				outputJson = JSON.stringify(redactSensitive(parsed), null, 2);
 				outputLanguage = "json";
 			} catch {
-				// Not valid JSON, leave as-is and use text highlighting
+				// Not valid JSON, leave as text after lightweight secret redaction.
+				outputJson = redactSensitiveText(outputJson);
 			}
 
 			const errorPreview = state === "error" ? truncateErrorPreview(rawOutputText) : "";
@@ -111,10 +189,10 @@ export class DefaultRenderer implements ToolRenderer {
 			return {
 				content: html`
 					<div class="space-y-3">
-						${renderHeader(state, Code, this.label)}
+						${renderHeader(state, Code, this.title(params))}
 						${errorPreview ? html`<div class="text-sm text-destructive whitespace-pre-wrap break-words" role="alert">${errorPreview}</div>` : ""}
-						${paramsJson ? this.renderPayloadSection(i18n("Input"), paramsJson, "json") : ""}
-						${this.renderPayloadSection(i18n("Output"), outputJson, outputLanguage)}
+						${paramsJson ? renderPayloadSection(i18n("Input"), paramsJson, "json") : ""}
+						${renderPayloadSection(i18n("Output"), outputJson, outputLanguage)}
 						${images}
 					</div>
 				`,
@@ -138,8 +216,8 @@ export class DefaultRenderer implements ToolRenderer {
 			return {
 				content: html`
 					<div class="space-y-3">
-						${renderHeader(state, Code, this.label)}
-						${this.renderPayloadSection(i18n("Input"), paramsJson, "json")}
+						${renderHeader(state, Code, this.title(params))}
+						${renderPayloadSection(i18n("Input"), paramsJson, "json")}
 					</div>
 				`,
 				isCustom: false,

--- a/src/ui/tools/renderers/McpDefaultRenderer.ts
+++ b/src/ui/tools/renderers/McpDefaultRenderer.ts
@@ -1,0 +1,277 @@
+import type { ToolResultMessage } from "@earendil-works/pi-ai";
+import { html, nothing } from "lit";
+import { Plug } from "lucide";
+import { i18n } from "../../utils/i18n.js";
+import { getToolState, renderHeader } from "../renderer-registry.js";
+import type { ToolRenderContext, ToolRenderer, ToolRenderResult } from "../types.js";
+import { renderInlineImages } from "./image-utils.js";
+import { renderPayloadSection } from "./payload-section.js";
+
+const ERROR_PREVIEW_MAX_LENGTH = 500;
+const LARGE_ARG_PREVIEW_MAX = 120;
+const MAX_VISIBLE_ARGS = 6;
+const SENSITIVE_ARG_RE = /(api[-_]?key|key|token|secret|password|authorization|credential|cookie)/i;
+const SECRET_VALUE_RE = /\b(?:Bearer\s+[A-Za-z0-9._~+\/-]{10,}|sk-[A-Za-z0-9_-]{10,}|gh[opusr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|ya29\.[A-Za-z0-9._-]{10,}|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)\b/i;
+
+export function isMcpToolName(toolName: string): boolean {
+	if (toolName === "mcp_describe") return false;
+	return toolName.startsWith("mcp__") || (toolName.startsWith("mcp_") && !toolName.startsWith("mcp__") && toolName.length > "mcp_".length);
+}
+
+function containsSensitiveText(text: string): boolean {
+	return SENSITIVE_ARG_RE.test(text) || SECRET_VALUE_RE.test(text);
+}
+
+function redactSensitiveText(text: string): string {
+	return text
+		.replace(/\b(authorization)(["'\s:=]+)(bearer\s+)?[^,\r\n}"']+/gi, "$1$2[redacted]")
+		.replace(/\b(api[-_]?key|access[-_]?token|refresh[-_]?token|client[-_]?secret|key|token|secret|password|credential|cookie)(["'\s:=]+)[^,\s&}"']+/gi, "$1$2[redacted]")
+		.replace(/\bBearer\s+[A-Za-z0-9._~+\/-]{10,}/gi, "Bearer [redacted]")
+		.replace(/\bsk-[A-Za-z0-9_-]{10,}\b/g, "sk-[redacted]")
+		.replace(/\bgh[opusr]_[A-Za-z0-9_]{20,}\b/g, "gh_[redacted]")
+		.replace(/\bgithub_pat_[A-Za-z0-9_]{20,}\b/g, "github_pat_[redacted]")
+		.replace(/\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g, "xox-[redacted]")
+		.replace(/\bya29\.[A-Za-z0-9._-]{10,}\b/g, "ya29.[redacted]")
+		.replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, "jwt-[redacted]");
+}
+
+function redactSensitive(value: unknown): unknown {
+	if (typeof value === "string") return redactSensitiveText(value);
+	if (!value || typeof value !== "object") return value;
+	if (Array.isArray(value)) return value.map(redactSensitive);
+	const out: Record<string, unknown> = {};
+	for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+		out[key] = SENSITIVE_ARG_RE.test(key) ? "[redacted]" : redactSensitive(nested);
+	}
+	return out;
+}
+
+function truncateErrorPreview(text: string): string {
+	const trimmed = text.trim();
+	let redacted = redactSensitiveText(trimmed);
+	try {
+		redacted = JSON.stringify(redactSensitive(JSON.parse(trimmed)), null, 2);
+	} catch {
+		// Non-JSON errors are still lightly redacted above.
+	}
+	if (redacted.length <= ERROR_PREVIEW_MAX_LENGTH) return redacted;
+	return `${redacted.slice(0, ERROR_PREVIEW_MAX_LENGTH)}…`;
+}
+
+function parsePayload(value: unknown): unknown {
+	if (typeof value === "string") {
+		try { return JSON.parse(value); } catch { return value; }
+	}
+	return value;
+}
+
+function payloadJson(value: unknown): string {
+	if (value === undefined) return "";
+	try {
+		return JSON.stringify(redactSensitive(parsePayload(value)), null, 2);
+	} catch {
+		try { return JSON.stringify(redactSensitive(value), null, 2); } catch { return redactSensitiveText(String(value)); }
+	}
+}
+
+function outputPayload(result: ToolResultMessage | undefined): { raw: string; code: string; language: string } {
+	const raw = result?.content
+		?.filter((c) => c.type === "text")
+		.map((c: any) => c.text)
+		.join("\n") || i18n("(no output)");
+	try {
+		return { raw, code: JSON.stringify(redactSensitive(JSON.parse(raw)), null, 2), language: "json" };
+	} catch {
+		return { raw, code: redactSensitiveText(raw), language: "text" };
+	}
+}
+
+function parsePerOpName(toolName: string): { server: string; sub?: string; op: string } | null {
+	if (!toolName.startsWith("mcp__")) return null;
+	const remainder = toolName.slice(5);
+	const idx = remainder.indexOf("__");
+	if (idx <= 0) return null;
+	const server = remainder.slice(0, idx);
+	const after = remainder.slice(idx + 2);
+	if (!after) return null;
+	const subIdx = after.indexOf("__");
+	if (subIdx === -1) return { server, op: after };
+	const sub = after.slice(0, subIdx);
+	const op = after.slice(subIdx + 2);
+	return sub && op ? { server, sub, op } : { server, op: after };
+}
+
+function parseMetaName(toolName: string): { server: string; sub?: string } | null {
+	if (!toolName.startsWith("mcp_") || toolName.startsWith("mcp__")) return null;
+	const rest = toolName.slice(4);
+	if (!rest) return null;
+	const subIdx = rest.indexOf("__");
+	if (subIdx === -1) return { server: rest };
+	const server = rest.slice(0, subIdx);
+	const sub = rest.slice(subIdx + 2);
+	return server && sub ? { server, sub } : { server: rest };
+}
+
+function inputObject(value: unknown): Record<string, unknown> | undefined {
+	const parsed = parsePayload(value);
+	return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : undefined;
+}
+
+function containsSensitiveData(value: unknown): boolean {
+	if (typeof value === "string") return containsSensitiveText(value);
+	if (!value || typeof value !== "object") return false;
+	if (Array.isArray(value)) return value.some(containsSensitiveData);
+	return Object.entries(value as Record<string, unknown>).some(([key, nested]) => SENSITIVE_ARG_RE.test(key) || containsSensitiveData(nested));
+}
+
+function summarizeValue(value: unknown): string | null {
+	let preview: string;
+	if (typeof value === "string") preview = JSON.stringify(value);
+	else if (value === null || typeof value === "number" || typeof value === "boolean") preview = String(value);
+	else {
+		try { preview = JSON.stringify(value); } catch { return null; }
+	}
+	if (preview.length > LARGE_ARG_PREVIEW_MAX) return null;
+	return preview;
+}
+
+function mcpInvocation(toolName: string, input: Record<string, unknown> | undefined) {
+	const perOp = parsePerOpName(toolName);
+	if (perOp) {
+		return { server: perOp.server, sub: perOp.sub, op: perOp.op, args: input ?? {} };
+	}
+	const meta = parseMetaName(toolName);
+	const operation = typeof input?.operation === "string" ? input.operation : undefined;
+	const args = inputObject(input?.args) ?? {};
+	return {
+		server: meta?.server ?? toolName,
+		sub: meta?.sub,
+		op: operation,
+		args,
+	};
+}
+
+function renderArgSummary(args: Record<string, unknown>) {
+	const entries = Object.entries(args);
+	if (entries.length === 0) return nothing;
+	let omittedLarge = 0;
+	let omittedExtra = 0;
+	const visible: Array<[string, string]> = [];
+	for (const [key, value] of entries) {
+		if (SENSITIVE_ARG_RE.test(key) || containsSensitiveData(value)) {
+			omittedLarge++;
+			continue;
+		}
+		const summary = summarizeValue(value);
+		if (summary === null) {
+			omittedLarge++;
+			continue;
+		}
+		if (visible.length >= MAX_VISIBLE_ARGS) {
+			omittedExtra++;
+			continue;
+		}
+		visible.push([key, summary]);
+	}
+	return html`
+		<div class="space-y-1" data-mcp-arg-summary>
+			<div class="text-xs font-medium text-muted-foreground">Arguments</div>
+			${visible.length > 0 ? html`
+				<div class="flex flex-wrap gap-1.5">
+					${visible.map(([key, value]) => html`
+						<span class="rounded border border-border bg-muted/20 px-1.5 py-0.5 text-xs">
+							<span class="font-mono text-muted-foreground">${key}</span>
+							<span class="text-muted-foreground">:</span>
+							<span class="font-mono text-foreground break-all">${value}</span>
+						</span>
+					`)}
+				</div>
+			` : nothing}
+			${omittedLarge || omittedExtra ? html`
+				<div class="text-[11px] text-muted-foreground">
+					${omittedLarge ? `${omittedLarge} large argument${omittedLarge === 1 ? "" : "s"} kept in Input JSON` : ""}
+					${omittedLarge && omittedExtra ? "; " : ""}
+					${omittedExtra ? `${omittedExtra} more argument${omittedExtra === 1 ? "" : "s"} kept in Input JSON` : ""}
+				</div>
+			` : nothing}
+		</div>
+	`;
+}
+
+export class McpDefaultRenderer implements ToolRenderer {
+	private toolName: string;
+
+	constructor(toolName: string) {
+		this.toolName = toolName;
+	}
+
+	withToolName(name: string): McpDefaultRenderer {
+		return new McpDefaultRenderer(name);
+	}
+
+	private renderInvocation(input: Record<string, unknown> | undefined) {
+		const invocation = mcpInvocation(this.toolName, input);
+		const target = invocation.sub ? `${invocation.server}/${invocation.sub}` : invocation.server;
+		const op = invocation.op ?? "operation pending";
+		return {
+			header: html`
+				<span class="min-w-0">
+					<span>MCP: <span class="font-mono text-foreground">${target}</span> → <span class="font-mono text-foreground">${op}</span></span>
+					<span class="ml-2 font-mono text-[11px] text-muted-foreground/80">${this.toolName}</span>
+				</span>
+			`,
+			args: invocation.args,
+		};
+	}
+
+	render(params: unknown | undefined, result: ToolResultMessage | undefined, isStreaming?: boolean, ctx?: ToolRenderContext): ToolRenderResult {
+		const state = getToolState(result, isStreaming);
+		const rawInput = params !== undefined ? params : ctx?.toolCallInput;
+		const input = inputObject(rawInput);
+		const inputJson = payloadJson(rawInput);
+		const invocation = this.renderInvocation(input);
+
+		if (result) {
+			const output = outputPayload(result);
+			const errorPreview = state === "error" ? truncateErrorPreview(output.raw) : "";
+			const images = renderInlineImages(result.content);
+			return {
+				content: html`
+					<div class="space-y-3">
+						${renderHeader(state, Plug, invocation.header)}
+						${renderArgSummary(invocation.args)}
+						${errorPreview ? html`<div class="text-sm text-destructive whitespace-pre-wrap break-words" role="alert">${errorPreview}</div>` : ""}
+						${inputJson ? renderPayloadSection(i18n("Input"), inputJson, "json") : ""}
+						${renderPayloadSection(i18n("Output"), output.code, output.language)}
+						${images}
+					</div>
+				`,
+				isCustom: false,
+			};
+		}
+
+		if (rawInput !== undefined) {
+			if (isStreaming && (!inputJson || inputJson === "{}" || inputJson === "null")) {
+				return {
+					content: html`<div>${renderHeader(state, Plug, "Preparing MCP tool...")}</div>`,
+					isCustom: false,
+				};
+			}
+			return {
+				content: html`
+					<div class="space-y-3">
+						${renderHeader(state, Plug, invocation.header)}
+						${renderArgSummary(invocation.args)}
+						${inputJson ? renderPayloadSection(i18n("Input"), inputJson, "json") : ""}
+					</div>
+				`,
+				isCustom: false,
+			};
+		}
+
+		return {
+			content: html`<div>${renderHeader(state, Plug, "Preparing MCP tool...")}</div>`,
+			isCustom: false,
+		};
+	}
+}

--- a/src/ui/tools/renderers/payload-section.ts
+++ b/src/ui/tools/renderers/payload-section.ts
@@ -1,0 +1,38 @@
+import { html } from "lit";
+
+let payloadSectionId = 0;
+
+/** Render a collapsed JSON/text payload block shared by the generic fallback renderers. */
+export function renderPayloadSection(label: string, code: string, language: string) {
+	const payloadType = language === "json" ? "JSON" : "text";
+	const payloadId = `default-payload-${++payloadSectionId}`;
+	const onToggle = (event: Event) => {
+		const button = event.currentTarget as HTMLButtonElement;
+		const section = button.closest("[data-default-payload-section]");
+		const expanded = button.getAttribute("aria-expanded") === "true";
+		const nextExpanded = !expanded;
+		button.setAttribute("aria-expanded", String(nextExpanded));
+		section?.querySelector<HTMLElement>(`[data-payload-region="${payloadId}"]`)?.toggleAttribute("hidden", !nextExpanded);
+		section?.querySelector('[data-state="collapsed"]')?.toggleAttribute("hidden", nextExpanded);
+		section?.querySelector('[data-state="expanded"]')?.toggleAttribute("hidden", !nextExpanded);
+	};
+
+	return html`
+		<div class="rounded-md border border-border bg-muted/20 p-2" data-default-payload-section>
+			<button
+				type="button"
+				class="cursor-pointer select-none rounded-sm text-left text-xs font-medium text-muted-foreground focus-visible:outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+				aria-expanded="false"
+				aria-controls=${payloadId}
+				@click=${onToggle}
+			>
+				${label} ${payloadType} payload
+				<span class="font-normal opacity-80" data-state="collapsed">(collapsed; <span class="text-primary underline underline-offset-2 decoration-dotted">Expand</span> to inspect)</span>
+				<span class="font-normal opacity-80" data-state="expanded" hidden>(<span class="text-primary underline underline-offset-2 decoration-dotted">Collapse</span>)</span>
+			</button>
+			<div id=${payloadId} data-payload-region=${payloadId} class="mt-2" hidden>
+				<code-block .code=${code} language=${language}></code-block>
+			</div>
+		</div>
+	`;
+}

--- a/tests/fixtures/default-tool-renderer-entry.ts
+++ b/tests/fixtures/default-tool-renderer-entry.ts
@@ -1,6 +1,8 @@
 // Test entry for DefaultRenderer browser-fixture coverage.
 import { render } from "lit";
 import { DefaultRenderer } from "../../src/ui/tools/renderers/DefaultRenderer.js";
+import { McpDefaultRenderer } from "../../src/ui/tools/renderers/McpDefaultRenderer.js";
+import { renderTool } from "../../src/ui/tools/index.js";
 
 class TestCodeBlock extends HTMLElement {
 	private _code = "";
@@ -65,6 +67,33 @@ function makeResult(payload: any, isError = false) {
 	const renderer = new DefaultRenderer(toolName);
 	const result = resultPayload === undefined ? undefined : makeResult(resultPayload, isError);
 	const out = renderer.render(params, result, isStreaming);
+	render(out.content, container);
+};
+
+(window as any).__renderMcpTool = (
+	toolName: string,
+	params: any,
+	resultPayload: any,
+	isError = false,
+) => {
+	const container = document.getElementById("container");
+	if (!container) throw new Error("missing #container");
+	const renderer = new McpDefaultRenderer(toolName);
+	const result = resultPayload === undefined ? undefined : makeResult(resultPayload, isError);
+	const out = renderer.render(params, result, false);
+	render(out.content, container);
+};
+
+(window as any).__renderCascadeTool = (
+	toolName: string,
+	params: any,
+	resultPayload: any,
+	isError = false,
+) => {
+	const container = document.getElementById("container");
+	if (!container) throw new Error("missing #container");
+	const result = resultPayload === undefined ? undefined : makeResult(resultPayload, isError);
+	const out = renderTool(toolName, params, result, false);
 	render(out.content, container);
 };
 

--- a/tests/fixtures/permission-card-ux-entry.ts
+++ b/tests/fixtures/permission-card-ux-entry.ts
@@ -132,16 +132,17 @@ function selectors() {
 function geometryProbe() {
 	const s = selectors();
 	const pinned = document.querySelector(s.pinned) as HTMLElement | null;
-	const editor = document.querySelector(s.editor) as HTMLElement | null;
+	const editor = document.querySelector("message-editor") as HTMLElement | null;
 	const scroller = document.querySelector(s.scroller) as HTMLElement | null;
 	if (!pinned) return { ok: false, error: "pinned permission controls not visible" };
 	if (!editor || !scroller) return { ok: false, error: "editor or scroller missing" };
 	const pr = pinned.getBoundingClientRect();
 	const er = editor.getBoundingClientRect();
 	const sr = scroller.getBoundingClientRect();
-	const visible = pr.width > 0 && pr.height > 0 && pr.bottom <= sr.bottom + 1 && pr.top >= sr.top - 1;
+	const visible = pr.width > 0 && pr.height > 0 && pr.bottom <= window.innerHeight + 1 && pr.top >= -1;
 	const overlapsEditor = !(pr.right <= er.left || pr.left >= er.right || pr.bottom <= er.top || pr.top >= er.bottom);
-	return { ok: visible && !overlapsEditor, visible, overlapsEditor, pinned: pr.toJSON(), editor: er.toJSON(), scroller: sr.toJSON() };
+	const alignedWithEditor = Math.abs(pr.left - er.left) <= 1 && Math.abs(pr.right - er.right) <= 1;
+	return { ok: visible && !overlapsEditor && alignedWithEditor, visible, overlapsEditor, alignedWithEditor, pinned: pr.toJSON(), editor: er.toJSON(), scroller: sr.toJSON() };
 }
 
 async function remountWithoutReplay() {

--- a/tests2/browser/fixtures/default-tool-renderer.spec.ts
+++ b/tests2/browser/fixtures/default-tool-renderer.spec.ts
@@ -12,7 +12,10 @@ const BUNDLE = path.resolve("tests/fixtures/default-tool-renderer-bundle.js");
 const ENTRY = path.resolve("tests/fixtures/default-tool-renderer-entry.ts");
 
 const RENDERER_FILES = [
+	"src/ui/tools/index.ts",
 	"src/ui/tools/renderers/DefaultRenderer.ts",
+	"src/ui/tools/renderers/McpDefaultRenderer.ts",
+	"src/ui/tools/renderers/payload-section.ts",
 	"src/ui/tools/renderer-registry.ts",
 	"src/ui/components/ExpandableSection.ts",
 ].map(f => path.resolve(f));
@@ -21,6 +24,7 @@ const PAGE = `file://${FIXTURE}`;
 const INPUT_SENTINEL = "alpha-input-payload-sentinel";
 const OUTPUT_SENTINEL = "omega-output-payload-sentinel";
 const ERROR_SENTINEL = "critical-error-output-sentinel";
+const LARGE_ARG_SENTINEL = "large-mcp-argument-sentinel";
 
 test.beforeAll(() => {
 	buildBundle({ entry: ENTRY, outfile: BUNDLE, deps: [ENTRY, ...RENDERER_FILES] });
@@ -44,6 +48,17 @@ async function renderDefaultTool(page: Page, options: { isError?: boolean } = {}
 
 function payloadControl(page: Page, label: "Input" | "Output") {
 	return page.locator("#container").getByRole("button", { name: new RegExp(label, "i") }).first();
+}
+
+async function renderMcpTool(page: Page, toolName = "mcp__playwright__browser_navigate") {
+	await page.evaluate(({ toolName, large }) => {
+		(window as any).__renderMcpTool(
+			toolName,
+			{ url: "https://example.test", waitUntil: "load", payload: large },
+			{ ok: true, output: "mcp-output-sentinel" },
+			false,
+		);
+	}, { toolName, large: `${LARGE_ARG_SENTINEL}:${"x".repeat(220)}` });
 }
 
 async function payloadTextIsVisiblyPainted(page: Page, text: string): Promise<boolean> {
@@ -108,8 +123,10 @@ test.describe("DefaultRenderer payload collapse", () => {
 		await gotoAndWait(page);
 		await renderDefaultTool(page);
 
+		await expect(payloadControl(page, "Input").getByText("Expand", { exact: true })).toHaveClass(/underline/);
 		await payloadControl(page, "Input").focus();
 		await page.keyboard.press("Enter");
+		await expect(payloadControl(page, "Input").getByText("Collapse", { exact: true })).toHaveClass(/underline/);
 		await expectPayloadVisible(page, INPUT_SENTINEL, true);
 		await expectPayloadVisible(page, OUTPUT_SENTINEL, false);
 
@@ -130,5 +147,64 @@ test.describe("DefaultRenderer payload collapse", () => {
 
 		await payloadControl(page, "Output").click();
 		await expectPayloadVisible(page, ERROR_SENTINEL, true);
+	});
+
+	test("promotes action before operation in the default renderer title row", async ({ page }) => {
+		await gotoAndWait(page);
+		await page.evaluate(() => {
+			(window as any).__renderDefaultTool(
+				"bobbit_admin",
+				{ operation: "custom_providers", action: "list", scope: "server", projectId: "headquarters", config: { large: true } },
+				{ ok: true },
+				false,
+			);
+		});
+
+		await expect(page.locator("#container")).toContainText("Bobbit Admin");
+		await expect(page.locator("#container")).toContainText("action=list");
+		await expect(page.locator("#container")).toContainText("operation=custom_providers");
+		await expect(page.locator("#container")).toContainText("scope=server");
+		await expect(page.locator("#container")).toContainText("projectId=headquarters");
+		await expect(page.locator("#container")).toContainText("+1 more");
+		const headerText = await page.locator("#container").textContent();
+		const actionIndex = headerText?.indexOf("action=list") ?? -1;
+		const operationIndex = headerText?.indexOf("operation=custom_providers") ?? -1;
+		expect(actionIndex).toBeGreaterThanOrEqual(0);
+		expect(actionIndex).toBeLessThan(operationIndex);
+		await expect(payloadControl(page, "Input")).toBeVisible();
+	});
+
+	test("MCP fallback renderer shows invoked tool and omits large args from the summary", async ({ page }) => {
+		await gotoAndWait(page);
+		await renderMcpTool(page);
+
+		await expect(page.locator("#container")).toContainText("MCP:");
+		await expect(page.locator("#container")).toContainText("playwright");
+		await expect(page.locator("#container")).toContainText("browser_navigate");
+		await expect(page.locator("[data-mcp-arg-summary]")).toContainText("url");
+		await expect(page.locator("[data-mcp-arg-summary]")).toContainText("https://example.test");
+		await expect(page.locator("[data-mcp-arg-summary]")).not.toContainText(LARGE_ARG_SENTINEL);
+		await expect(page.locator("[data-mcp-arg-summary]")).toContainText("large argument");
+		await expectPayloadVisible(page, LARGE_ARG_SENTINEL, false);
+
+		await payloadControl(page, "Input").click();
+		await expectPayloadVisible(page, LARGE_ARG_SENTINEL, true);
+	});
+
+	test("renderTool cascade uses the MCP fallback for unregistered meta tools", async ({ page }) => {
+		await gotoAndWait(page);
+		await page.evaluate(() => {
+			(window as any).__renderCascadeTool(
+				"mcp_playwright",
+				{ operation: "browser_click", args: { selector: "#submit" } },
+				{ ok: true },
+				false,
+			);
+		});
+
+		await expect(page.locator("#container")).toContainText("MCP:");
+		await expect(page.locator("#container")).toContainText("mcp_playwright");
+		await expect(page.locator("#container")).toContainText("browser_click");
+		await expect(page.locator("[data-mcp-arg-summary]")).toContainText("selector");
 	});
 });

--- a/tests2/browser/fixtures/permission-card-ux.spec.ts
+++ b/tests2/browser/fixtures/permission-card-ux.spec.ts
@@ -41,6 +41,7 @@ test.describe("Permission Card UX pinned browser fixture", () => {
 	test("keeps bottom-pinned permission controls visible with a scrolled transcript and clear of the editor", async ({ page }) => {
 		await loadFixture(page);
 		await expectPinnedVisible(page);
+		await expect(page.locator("message-list tool-permission-card"), "active permission cards should not duplicate inline while pinned").toHaveCount(0);
 
 		const probe = await page.evaluate(() => (window as any).__permissionFixtureGeometry());
 		expect(probe.visible, "pinned permission controls should remain inside the chat viewport").toBe(true);

--- a/tests2/core/permission-reducer.test.ts
+++ b/tests2/core/permission-reducer.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "vitest";
 import { initialState, reduce, type ReducerState } from "../../src/app/message-reducer.js";
+import { SessionManager } from "../../src/server/agent/session-manager.js";
 
 function permissionCard(id: string, toolName: string, extra: Record<string, unknown> = {}) {
 	return {
@@ -23,6 +24,15 @@ function apply(state: ReducerState, action: any): ReducerState {
 
 function permissionRows(state: ReducerState): any[] {
 	return state.messages.filter((m: any) => m.role === "tool_permission_needed");
+}
+
+function assistantToolMessage(id: string, toolCallId: string, toolName: string) {
+	return {
+		id,
+		role: "assistant",
+		content: [{ type: "toolCall", id: toolCallId, name: toolName, arguments: { operation: "custom_providers", action: "list" } }],
+		timestamp: 20,
+	};
 }
 
 function isActionable(row: any): boolean {
@@ -71,6 +81,82 @@ describe("permission request lifecycle reducer", () => {
 		assert.ok(row, "expired permission should remain as inline history");
 		assert.match(String(row.status), /expired|stale|cancelled/i, "permission timeout did not settle active row");
 		assert.equal(isActionable(row), false, "expired/stale permission must not remain actionable or pinned");
+	});
+
+	it("replaces a blocked placeholder with the matching live assistant message instead of duplicating tool calls", () => {
+		const streaming = assistantToolMessage("streaming-bobbit-admin", "call-admin-1", "bobbit_admin");
+		const withPlaceholder = apply(initialState(), {
+			type: "blocked-tool-call-placeholder",
+			message: streaming,
+			seq: 10,
+		});
+		const withPermission = apply(withPlaceholder, {
+			type: "permission-needed",
+			card: permissionCard("perm-admin", "bobbit_admin", { group: "Bobbit" }),
+			seq: 11,
+		});
+
+		const withLiveEnd = apply(withPermission, {
+			type: "live-event",
+			seq: 12,
+			frame: { type: "message_end", message: assistantToolMessage("server-bobbit-admin", "call-admin-1", "bobbit_admin") },
+		});
+
+		const assistantRows = withLiveEnd.messages.filter((m: any) => m.role === "assistant" && m.content?.some?.((c: any) => c.id === "call-admin-1"));
+		assert.equal(assistantRows.length, 1, "blocked tool call rendered twice before refresh");
+		assert.equal((assistantRows[0] as any)._permissionBlocked, true, "surviving tool call should retain blocked styling");
+	});
+
+	it("parallel permission requests for the same tool remain actionable as a batch", () => {
+		const withA = apply(initialState(), {
+			type: "permission-needed",
+			card: permissionCard("perm-a", "Bash"),
+			seq: 1,
+		});
+		const withB = apply(withA, {
+			type: "permission-needed",
+			card: permissionCard("perm-b", "Bash"),
+			seq: 2,
+		});
+
+		const rows = permissionRows(withB);
+		assert.deepEqual(rows.filter(isActionable).map((m: any) => m.id), ["perm-a", "perm-b"], "same-tool permission requests should stack under one decision");
+	});
+
+	it("server short-circuits same-tool requests only after an explicit session grant", async () => {
+		const manager: any = new SessionManager();
+		try {
+			manager.sessions.set("s-ask-only", {
+				id: "s-ask-only",
+				allowedTools: ["bobbit_admin"],
+				clients: new Set(),
+				eventBuffer: { pushFrame: () => ({ seq: 1, ts: 1 }) },
+			});
+			const pending = manager.requestToolGrant("s-ask-only", "bobbit_admin", "Bobbit");
+			assert.ok(manager.sessions.get("s-ask-only").pendingGrantRequest, "ask-gated allowedTools alone must still create a permission card");
+			manager.denyToolPermission("s-ask-only", "bobbit_admin");
+			await pending;
+
+			manager.sessions.set("s-granted", {
+				id: "s-granted",
+				allowedTools: ["bobbit_admin"],
+				sessionOnlyGrantedTools: ["bobbit_admin"],
+				clients: new Set(),
+			});
+
+			const result = await manager.requestToolGrant("s-granted", "bobbit_admin", "Bobbit");
+			assert.deepEqual(result, {
+				granted: true,
+				tools: ["bobbit_admin"],
+				scope: "tool",
+				group: "Bobbit",
+				mode: "session-only",
+			});
+			assert.equal(manager.sessions.get("s-granted").pendingGrantRequest, undefined, "explicitly granted requests must not create another UI permission card");
+		} finally {
+			if (manager._statusHeartbeatTimer) clearInterval(manager._statusHeartbeatTimer);
+			manager.sessions?.clear?.();
+		}
 	});
 
 	it("a later permission request supersedes the earlier active request", () => {

--- a/tests2/dom/permission-card-ux.test.ts
+++ b/tests2/dom/permission-card-ux.test.ts
@@ -177,6 +177,19 @@ describe("Permission Card UX reproductions", () => {
 		expect(toolCard.textContent || "", "permission-blocked tool should communicate pending/blocked state").toMatch(/permission|blocked|pending|waiting/i);
 	});
 
+	it("clears the stale streaming preview when the blocked tool placeholder is committed", async () => {
+		const streaming = assistantToolMessage("streaming-assistant", "stream-call", "diagnostic_tool");
+		const { el, session } = await mountAgentInterface([permissionRow("perm-stream", "diagnostic_tool")]);
+		session.state.streamingMessage = streaming;
+		(session as any).streamingMessageId = streaming.id;
+
+		(el as any)._clearStreamingIfPermissionBlocked();
+		await settle(el);
+
+		assert.equal(session.state.streamingMessage, null, "permission-blocked streaming preview should be cleared so tool cards do not duplicate");
+		assert.equal((session as any).streamingMessageId, undefined);
+	});
+
 	it("preserves the streaming tool-call context when tool_permission_needed arrives", async () => {
 		const agent: any = new RemoteAgent();
 		agent.send = () => {};
@@ -204,8 +217,9 @@ describe("Permission Card UX reproductions", () => {
 
 	it("clears grant spinner and marks the row stale/error after a grant failure", async () => {
 		const { el, session } = await mountAgentInterface([permissionRow("perm-error")]);
-		const card = inlineCards(el)[0];
-		assert.ok(card, "inline permission card should render");
+		const card = pinnedCards(el)[0];
+		assert.ok(card, "pinned permission card should render");
+		assert.equal(inlineCards(el).length, 0, "active permission card should not duplicate inline while pinned");
 		clickButton(card, /Allow just/i);
 		await settle(el);
 		expect(el.textContent || "").toContain("Granting permission");
@@ -220,26 +234,47 @@ describe("Permission Card UX reproductions", () => {
 		expect(el.textContent || "", "stale grant error should be visible").toMatch(/stale|error|failed/i);
 	});
 
-	it("shares duration and disabled/granting feedback between inline and pinned copies", async () => {
+	it("uses pinned controls only for active permission requests", async () => {
 		const { el, session } = await mountAgentInterface([permissionRow("perm-shared")]);
 		const pinned = pinnedCards(el)[0];
 		if (!pinned) assert.fail("pinned permission controls not visible");
-		const inline = inlineCards(el)[0];
-		assert.ok(inline, "inline permission history card should still render");
+		assert.equal(inlineCards(el).length, 0, "active permission history card should be hidden while pinned");
 
-		const inlineSelect = inline.querySelector("select") as HTMLSelectElement | null;
-		assert.ok(inlineSelect, "inline duration select should be visible");
-		inlineSelect.value = "persistent";
-		inlineSelect.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+		const pinnedSelect = pinned.querySelector("select") as HTMLSelectElement | null;
+		assert.ok(pinnedSelect, "pinned duration select should be visible");
+		pinnedSelect.value = "persistent";
+		pinnedSelect.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
 		await settle(el);
 
 		clickButton(pinned, /Allow just/i);
 		await settle(el);
 
 		assert.equal(session.grantCalls.length, 1, "duplicate grant clicks should be suppressed");
-		assert.equal(session.grantCalls[0].mode, "persistent", "pinned grant should use duration selected in inline copy");
-		const copiesText = [inline, pinned].map((c) => c.textContent || "");
-		assert.ok(copiesText.every((text) => /Granting|Permission granted/i.test(text)), "inline and pinned copies should show the same grant feedback");
+		assert.equal(session.grantCalls[0].mode, "persistent", "pinned grant should use selected duration");
+		expect(pinned.textContent || "").toMatch(/Granting|Permission granted/i);
+		assert.equal(inlineCards(el).length, 0, "granting permission card should not duplicate inline while pinned");
+	});
+
+	it("groups parallel same-tool permission requests into one pinned batch", async () => {
+		const { el, session } = await mountAgentInterface([
+			permissionRow("perm-a", "diagnostic_tool", { requestCount: 2 }),
+			permissionRow("perm-b", "diagnostic_tool", { requestCount: 2 }),
+		]);
+		const pinned = pinnedCards(el);
+		assert.equal(pinned.length, 1, "same-tool requests should render as one pinned permission card");
+		expect(pinned[0].textContent || "").toMatch(/2 calls|Just for now/i);
+
+		const select = pinned[0].querySelector("select") as HTMLSelectElement | null;
+		assert.ok(select, "duration selector should render");
+		select.value = "one-time";
+		select.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+		await settle(el);
+		clickButton(pinned[0], /Allow just/i);
+		await settle(el);
+
+		assert.equal(session.grantCalls.length, 1);
+		assert.equal(session.grantCalls[0].mode, "one-time");
+		assert.equal(inlineCards(el).length, 0, "batched active rows should not duplicate inline while granting");
 	});
 
 	it("grant and deny from pinned controls use the same session payloads, settle pinned rows, and keep inline history", async () => {


### PR DESCRIPTION
## Summary
- Batch same-tool permission prompts across parallel tool calls and prevent repeat prompts after explicit temporary grants.
- Keep active permission controls pinned near the prompt without duplicate inline cards or stale streaming previews.
- Improve fallback/default tool renderers with MCP-specific display, clickable payload toggles, and compact title badges for key args.

## Tests
- npm run check
- npx vitest run tests2/core/permission-reducer.test.ts tests2/dom/permission-card-ux.test.ts --config vitest.config.ts
- npx playwright test tests2/browser/fixtures/permission-card-ux.spec.ts --config=playwright-v2.config.ts
- npx playwright test tests2/browser/fixtures/default-tool-renderer.spec.ts --config=playwright-v2.config.ts

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)