### PR TITLE
Fix verifier restart recovery

### DIFF
--- a/docs/llm-review-recovery.md
+++ b/docs/llm-review-recovery.md
@@ -149,11 +149,12 @@ Reviewer and QA sessions are `nonInteractive`: normal user prompts are blocked, 
 In-flight reviewer steps also persist in active verification state. After a gateway restart, `resumeInterruptedVerifications()` tries to recover them through `_tryResumeFromSession()`:
 
 - If the reviewer session still exists, it is re-registered with the team store and wired to a fresh `verification_result` resolver.
-- If the restored reviewer is already `idle`, the harness sends the reminder immediately instead of waiting for the long busy-session window.
-- If the restored reviewer is still busy, the harness waits for either `verification_result` or actual idle before reminding it. This keeps the harness from interrupting an active turn while making the waiting behavior explicit.
-- Reminder dispatch to a cold restored reviewer uses `promptWhenReady()` so the agent has time to load before the prompt timeout starts.
-- After a reminder is accepted, the harness waits for `waitForStreaming()` before racing against post-reminder idle, so an already-idle status cannot instantly fail and terminate the reviewer before it reads the reminder.
-- If the resume reminder cannot reach the reviewer because of a cold-agent timeout or process/runtime transient, the result is marked as transient and restart-interrupted, not as a hard review failure.
+- If the restored reviewer is already `idle` because the gateway interrupted its turn, the first harness prompt is restart-aware continuation guidance, not `VERIFICATION_RESULT_REMINDER`. It tells the reviewer that infrastructure restarted mid-turn, the transcript/context were preserved, it should continue the interrupted analysis, and it should call `verification_result` only when the review is complete.
+- If the restored reviewer is idle for an ordinary non-restart reason, or if the post-restart continuation turn later goes idle without a result, the normal idle-without-result path still applies: a JSON/tool-validation retry prompt when appropriate, otherwise `VERIFICATION_RESULT_REMINDER`.
+- If the restored reviewer is still busy, the harness waits for either `verification_result` or actual idle before prompting it. This keeps the harness from interrupting an active turn while making the waiting behavior explicit.
+- Prompt dispatch to a cold restored reviewer uses `promptWhenReady()` so the agent has time to load before the prompt timeout starts.
+- After the continuation or reminder prompt is accepted, the harness waits for `waitForStreaming()` before racing against post-prompt idle, so an already-idle status cannot instantly fail and terminate the reviewer before it has a real continuation turn.
+- If the resume prompt cannot reach the reviewer because of a cold-agent timeout or process/runtime transient, the result is marked as transient and restart-interrupted, not as a hard review failure.
 - `_resumeOneVerification()` then re-runs the original `llm-review` step from the workflow definition when context is available.
 - If the restart interruption cannot be safely re-run, the gate is left pending so it can be re-signaled instead of being marked failed for an infrastructure interruption.
 
@@ -199,22 +200,22 @@ Provider-backoff timeouts also include a suffix describing the active provider b
 
 Relevant unit coverage:
 
-- `tests/verification-logic.test.ts` — socket/WebSocket/process classifiers, generic runtime retry, deterministic non-retryable failures, provider backoff classification, retry decisions.
-- `tests/transient-review-error.test.ts` — legacy transient review classifier coverage.
-- `tests/auto-retry-policy.test.ts` — session-level auto-retry policy and schedules.
-- `tests/verification-reminder-race.test.ts` — reminder `waitForStreaming()` guard and post-reminder transient recovery ordering.
+- `tests2/core/verification-logic.test.ts` — socket/WebSocket/process classifiers, generic runtime retry, deterministic non-retryable failures, provider backoff classification, retry decisions.
+- `tests2/core/transient-review-error.test.ts` — legacy transient review classifier coverage.
+- `tests2/core/auto-retry-policy.test.ts` — session-level auto-retry policy and schedules.
+- `tests2/core/verification-reminder-race.test.ts` — restart-aware continuation prompt selection, ordinary idle reminder behavior, and the reminder `waitForStreaming()` guard.
 - `tests2/core/verification-harness-review-reliability.test.ts` — fresh session id per from-scratch attempt (attempt 1's transcript preserved), late-`verification_result`-during-teardown honored (not 404-dropped), and the "did not call after reminder" non-transient classification.
 - `tests2/core/session-id-clobber-guard.test.ts` — `createSession` refuses to clobber a live session id, while `allowSessionReuse` bypasses the guard for the sanctioned resume path.
-- `tests/verification-resume-restart-prompt.test.ts` — cold restart resume prompt timeout routes to pending instead of hard failure.
-- `tests/verification-resume-restart-recovery.test.ts` — cold reviewer readiness wait and transient resume failure rerun path.
-- `tests/reviewer-archive-metadata.test.ts` — verifier metadata persistence before startup and legacy SessionStore backfill.
-- `tests/ui-fixtures/sidebar-archived-fixture.spec.ts` — archived verifier bucketing and transcript/placeholder fallback visibility.
+- `tests2/core/verification-resume-restart-prompt.test.ts` — cold restart resume prompt timeout routes to pending instead of hard failure.
+- `tests2/core/verification-resume-restart-recovery.test.ts` — cold reviewer readiness wait and transient resume failure rerun path.
+- `tests2/core/reviewer-archive-metadata.test.ts` — verifier metadata persistence before startup and legacy SessionStore backfill.
+- `tests2/browser/fixtures/sidebar-archived-fixture.spec.ts` — archived verifier bucketing and transcript/placeholder fallback visibility.
 
 Focused checks while changing this area:
 
 ```bash
-npx tsx --test tests/verification-logic.test.ts tests/transient-review-error.test.ts tests/verification-reminder-race.test.ts tests/verification-resume-restart-prompt.test.ts tests/verification-resume-restart-recovery.test.ts tests/reviewer-archive-metadata.test.ts
-npx playwright test tests/ui-fixtures/sidebar-archived-fixture.spec.ts
+npx tsx --test tests2/core/verification-logic.test.ts tests2/core/transient-review-error.test.ts tests2/core/verification-reminder-race.test.ts tests2/core/verification-resume-restart-prompt.test.ts tests2/core/verification-resume-restart-recovery.test.ts tests2/core/reviewer-archive-metadata.test.ts
+npx playwright test tests2/browser/fixtures/sidebar-archived-fixture.spec.ts
 ```
 
 Full required checks for production changes in this area:

--- a/src/server/agent/verification-harness.ts
+++ b/src/server/agent/verification-harness.ts
@@ -157,6 +157,7 @@ import {
 	isPreImplementationGate,
 	isProviderBackoffError,
 	isRetryableGenericAgentError,
+	TRANSIENT_INFRA_ERROR_REGEXES,
 	shouldRetryVerificationStep,
 	isRestartInterruptError,
 	isRestartInterruptedStep,
@@ -704,6 +705,12 @@ export const VERIFICATION_RESULT_REMINDER =
 	"Call the `verification_result` tool now with your verdict and summary. " +
 	"This is REQUIRED — the verification system only receives results through this tool.";
 
+/** Prompt sent to verifier sessions whose turn was interrupted by a server restart. */
+export const VERIFICATION_RESTART_RESUME_PROMPT =
+	"The Bobbit server/infrastructure restarted while your verification turn was in progress. " +
+	"Your transcript and verification context were preserved. Review the recent context, continue the interrupted review/QA analysis from where you left off, " +
+	"and call `verification_result` only when your analysis is complete.";
+
 /**
  * Build a context-rich reminder for live (not resumed) reviewers
  * who emit their verdict as chat-text and end the turn instead of calling
@@ -723,8 +730,9 @@ export const VERIFICATION_RESULT_REMINDER =
  *      agent has the original task spec back in context.
  *
  * Wire this into BOTH the LLM-review reminder path and the agent-QA reminder
- * path. The resume path (`_tryResumeFromSession`) keeps the legacy terse
- * reminder because it doesn't have access to rebuild the kickoff.
+ * path. The resume path (`_tryResumeFromSession`) uses either the legacy terse
+ * reminder or a restart-aware continuation prompt because it doesn't have
+ * access to rebuild the kickoff.
  */
 export function buildContextRichReminder(originalKickoff: string): string {
 	return `## STOP — verification_result not called
@@ -1105,6 +1113,14 @@ const REVIEWER_REMINDER_LATE_VERDICT_SETTLE_MS = 20_000;
 
 function isRetryableLlmReviewRecovery(output: string): boolean {
 	return isTransientReviewError(output) || isRetryableGenericAgentError(output);
+}
+
+function isVerifierInfrastructureDisconnectError(output: string): boolean {
+	if (!output) return false;
+	if (TRANSIENT_INFRA_ERROR_REGEXES.some(re => re.test(output))) return true;
+	return /\b(?:ECONNRESET|ENOTCONN|EPIPE|WebSocket error|socket error|socket hang up|connect ECONNREFUSED)\b/i.test(output)
+		|| /\b(?:network|internet|connection|wifi|wi-fi)\b.{0,80}\b(?:lost|reset|closed|dropped|disconnected|unavailable|timeout|timed out|failed|error)\b/i.test(output)
+		|| /\b(?:lost|reset|closed|dropped|disconnected|unavailable|timeout|timed out|failed|error)\b.{0,80}\b(?:network|internet|connection|wifi|wi-fi)\b/i.test(output);
 }
 
 function classifyLlmReviewRecoveryError(output: string): string {
@@ -1957,10 +1973,14 @@ export class VerificationHarness {
 		});
 
 		try {
-			// If restoreSession already revived the reviewer to idle, remind it
+			const restartInterruptedTurn = session.restoreStartupWasStreaming === true;
+			// If restoreSession already revived the reviewer to idle, prompt it
 			// immediately. Otherwise wait for the active turn to finish before sending
-			// a reminder, so the harness remains the only driver for nonInteractive
-			// reviewers and never races the generic restoreSession boot prompt.
+			// a prompt, so the harness remains the only driver for nonInteractive
+			// reviewers and never races the generic restoreSession boot prompt. A
+			// restart-interrupted reviewer gets continuation instructions as its first
+			// post-restart prompt; the generic idle-without-result reminder remains for
+			// ordinary resumed sessions.
 			const idleResult = session.status === "idle"
 				? ({ type: "idle" as const })
 				: await Promise.race([
@@ -1999,10 +2019,18 @@ export class VerificationHarness {
 
 			// Agent went idle without calling verification_result — inspect whether
 			// the previous turn hit a JSON / tool-argument validation glitch, and
-			// send a targeted nudge if so. Falls back to the generic reminder.
+			// send a targeted nudge if so. If this was the first post-restart prompt
+			// after an interrupted turn, send restart-aware continuation instructions
+			// instead of the generic idle-without-result reminder.
 			const jsonErr = lastErroredToolOutput ? detectJsonValidationError(lastErroredToolOutput) : null;
-			const reminderPrompt = jsonErr ? buildJsonRetryPrompt(jsonErr) : VERIFICATION_RESULT_REMINDER;
-			console.log(`[verification] No verification_result from resumed session ${step.sessionId}, sending ${jsonErr ? "JSON-retry" : "generic"} reminder...`);
+			const useRestartContinuationPrompt = restartInterruptedTurn && !jsonErr;
+			const reminderPrompt = jsonErr
+				? buildJsonRetryPrompt(jsonErr)
+				: useRestartContinuationPrompt
+					? VERIFICATION_RESTART_RESUME_PROMPT
+					: VERIFICATION_RESULT_REMINDER;
+			const reminderKind = jsonErr ? "JSON-retry" : useRestartContinuationPrompt ? "restart-resume" : "generic";
+			console.log(`[verification] No verification_result from resumed session ${step.sessionId}, sending ${reminderKind} reminder...`);
 			// A freshly-revived reviewer is COLD (model init + MCP extension load),
 			// often needing 30-90s to first respond — worse under 5-way parallel
 			// session restore. So (1) wait for the agent to become ready before
@@ -2062,6 +2090,62 @@ export class VerificationHarness {
 					output: postReminderRecovery.output,
 					duration_ms: Date.now() - step.startedAt,
 				};
+			}
+
+			// The restart-aware continuation prompt is only the first post-restart
+			// prompt. If that continuation turn ends without verification_result,
+			// fall back to the normal idle-without-result reminder (or JSON retry if
+			// the continuation turn exposed a tool-argument validation error) and give
+			// that reminder the same fair start/idle window before hard failure.
+			if (useRestartContinuationPrompt) {
+				const fallbackJsonErr = lastErroredToolOutput ? detectJsonValidationError(lastErroredToolOutput) : null;
+				const fallbackPrompt = fallbackJsonErr ? buildJsonRetryPrompt(fallbackJsonErr) : VERIFICATION_RESULT_REMINDER;
+				const fallbackKind = fallbackJsonErr ? "JSON-retry" : "generic";
+				console.log(`[verification] Restart continuation for resumed session ${step.sessionId} ended without verification_result, sending ${fallbackKind} fallback reminder...`);
+				try {
+					await session.rpcClient.promptWhenReady(fallbackPrompt, undefined);
+					await this.sessionManager!.waitForStreaming(step.sessionId, 10_000).catch(() => {});
+				} catch (resumeErr) {
+					const msg = (resumeErr as Error)?.message || String(resumeErr);
+					console.warn(`[verification] Post-continuation fallback reminder for ${step.sessionId} could not reach the revived reviewer: ${msg}`);
+					return {
+						name: step.name, type: step.type, passed: false,
+						output: `Reviewer agent was not ready / timed out while sending post-continuation reminder after server restart: ${msg}`,
+						duration_ms: Date.now() - step.startedAt,
+					};
+				}
+
+				const fallbackResult = await Promise.race([
+					resultPromise.then((r: VerificationResult) => ({ type: "result" as const, ...r })),
+					this.sessionManager!.waitForIdle(step.sessionId, 120_000).then(() => ({ type: "idle" as const })),
+				]).catch(() => ({ type: "idle" as const }));
+
+				if (fallbackResult.type === "result") {
+					return {
+						name: step.name, type: step.type,
+						passed: fallbackResult.verdict,
+						output: fallbackResult.summary,
+						duration_ms: Date.now() - step.startedAt,
+					};
+				}
+
+				const postFallbackRecovery = await this.waitForReviewerErroredTurnRecovery(step.sessionId, resultPromise, 120_000, step.name);
+				if (postFallbackRecovery.type === "result") {
+					return {
+						name: step.name, type: step.type,
+						passed: postFallbackRecovery.verdict,
+						output: postFallbackRecovery.summary,
+						duration_ms: Date.now() - step.startedAt,
+					};
+				}
+				if (postFallbackRecovery.type === "errored") {
+					return {
+						name: step.name, type: step.type,
+						passed: false,
+						output: postFallbackRecovery.output,
+						duration_ms: Date.now() - step.startedAt,
+					};
+				}
 			}
 
 			return {
@@ -3838,6 +3922,7 @@ export class VerificationHarness {
 		| { type: "idle" }
 		| { type: "errored"; output: string }
 	> {
+		let dispatchedInfrastructureRecovery = false;
 		for (;;) {
 			const session = this.sessionManager?.getSession(sessionId);
 			const errMsg = session?.lastTurnErrored ? (session.lastTurnErrorMessage || "") : "";
@@ -3849,7 +3934,18 @@ export class VerificationHarness {
 			}
 
 			if (!session?.pendingAutoRetryTimer) {
-				return { type: "errored", output: `LLM review failed: ${errMsg}${backoffSuffix}` };
+				if (!dispatchedInfrastructureRecovery && isVerifierInfrastructureDisconnectError(errMsg)) {
+					dispatchedInfrastructureRecovery = true;
+					console.log(`[verification] Reviewer ${sessionId} for "${stepName}" ended with infrastructure/network error and no pending auto-retry; dispatching one continuation retry before failing...`);
+					try {
+						await this.sessionManager!.retryLastPrompt(sessionId, { auto: true });
+					} catch (retryErr) {
+						const retryMsg = (retryErr as Error)?.message || String(retryErr);
+						return { type: "errored", output: `LLM review failed to resume after infrastructure/network disconnect: ${retryMsg}${backoffSuffix}` };
+					}
+				} else {
+					return { type: "errored", output: `LLM review failed: ${errMsg}${backoffSuffix}` };
+				}
 			}
 
 			const graceMs = Math.min(

--- a/tests2/core/verification-reminder-race.test.ts
+++ b/tests2/core/verification-reminder-race.test.ts
@@ -29,7 +29,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { VerificationHarness } from "../../src/server/agent/verification-harness.ts";
+import { VerificationHarness, VERIFICATION_RESTART_RESUME_PROMPT, VERIFICATION_RESULT_REMINDER } from "../../src/server/agent/verification-harness.ts";
 
 /**
  * `SessionManager` transitively pulls in flexsearch (via search-service),
@@ -98,7 +98,317 @@ function waitForIdle(session: FakeSession, timeoutMs: number): Promise<void> {
 	});
 }
 
+async function captureResumePromptForRestoredReviewer(opts: { restoreStartupWasStreaming: boolean }): Promise<string[]> {
+	const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "verification-restart-resume-prompt-"));
+	const sessionId = opts.restoreStartupWasStreaming ? "restart-interrupted-reviewer" : "ordinary-idle-reviewer";
+	const prompts: string[] = [];
+	let harness: VerificationHarness;
+	try {
+		const fakeSession = {
+			id: sessionId,
+			status: "idle",
+			nonInteractive: true,
+			restoreStartupWasStreaming: opts.restoreStartupWasStreaming,
+			rpcClient: {
+				onEvent: (_fn: (event: any) => void) => () => {},
+				waitForReady: async () => {},
+				prompt: async (text: string) => {
+					prompts.push(text);
+					const resolver = (harness as any).pendingResults.get(sessionId);
+					resolver?.({ verdict: true, summary: "Continuation completed." });
+					return { success: true };
+				},
+				async promptWhenReady(text: string) {
+					return this.prompt(text);
+				},
+			},
+		};
+		const sessionManager = {
+			getSession: () => fakeSession,
+			waitForIdle: () => new Promise<void>(() => {}),
+			waitForStreaming: () => Promise.resolve(),
+			terminateSession: () => Promise.resolve(),
+		} as any;
+		const gateStore = {
+			updateSignalVerification: () => {},
+			updateGateStatus: () => {},
+			getGate: () => undefined,
+			getGatesForGoal: () => [],
+		} as any;
+		harness = new VerificationHarness(
+			stateDir,
+			gateStore,
+			() => {},
+			{ get: () => undefined, getAll: () => [] } as any,
+			undefined,
+			sessionManager,
+			{ registerReviewerSession: () => {}, unregisterReviewerSession: () => {} } as any,
+		) as any;
+
+		await (harness as any)._tryResumeFromSession(
+			{ goalId: "goal-1", gateId: "gate-1", signalId: "signal-1" },
+			{ name: "Restart resume review", type: "llm-review", status: "running", startedAt: Date.now() - 1_000, sessionId },
+		);
+		return prompts;
+	} finally {
+		fs.rmSync(stateDir, { recursive: true, force: true });
+	}
+}
+
+async function runRestartContinuationFallback(opts: { jsonValidationErrorDuringContinuation?: boolean } = {}) {
+	const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "verification-post-continuation-fallback-"));
+	const sessionId = "restart-continuation-fallback-reviewer";
+	const prompts: string[] = [];
+	const calls: string[] = [];
+	const listeners: Array<(event: any) => void> = [];
+	let harness: VerificationHarness;
+	try {
+		const fakeSession = {
+			id: sessionId,
+			status: "idle",
+			nonInteractive: true,
+			restoreStartupWasStreaming: true,
+			lastTurnErrored: false,
+			lastTurnErrorMessage: "",
+			rpcClient: {
+				onEvent: (fn: (event: any) => void) => {
+					listeners.push(fn);
+					return () => {
+						const i = listeners.indexOf(fn);
+						if (i >= 0) listeners.splice(i, 1);
+					};
+				},
+				waitForReady: async () => {},
+				prompt: async (text: string) => {
+					return fakeSession.rpcClient.promptWhenReady(text);
+				},
+				promptWhenReady: async (text: string) => {
+					prompts.push(text);
+					calls.push(`prompt:${prompts.length}`);
+					if (prompts.length === 2) {
+						const resolver = (harness as any).pendingResults.get(sessionId);
+						resolver?.({ verdict: true, summary: "Fallback reminder completed." });
+					}
+					return { success: true };
+				},
+			},
+		};
+		const sessionManager = {
+			getSession: () => fakeSession,
+			waitForStreaming: async () => {
+				calls.push(`waitForStreaming:${prompts.length}`);
+				fakeSession.status = "streaming";
+				if (prompts.length === 1 && opts.jsonValidationErrorDuringContinuation) {
+					for (const listener of [...listeners]) {
+						listener({
+							type: "tool_execution_end",
+							isError: true,
+							result: "Validation failed for tool verification_result: Expected property name in JSON at position 2",
+						});
+					}
+				}
+			},
+			waitForIdle: async () => {
+				calls.push(`waitForIdle:${prompts.length}`);
+				fakeSession.status = "idle";
+			},
+			terminateSession: async () => {
+				calls.push(`terminate:${prompts.length}`);
+			},
+		} as any;
+		const gateStore = {
+			updateSignalVerification: () => {},
+			updateGateStatus: () => {},
+			getGate: () => undefined,
+			getGatesForGoal: () => [],
+		} as any;
+		harness = new VerificationHarness(
+			stateDir,
+			gateStore,
+			() => {},
+			{ get: () => undefined, getAll: () => [] } as any,
+			undefined,
+			sessionManager,
+			{ registerReviewerSession: () => {}, unregisterReviewerSession: () => {} } as any,
+		) as any;
+
+		const result = await (harness as any)._tryResumeFromSession(
+			{ goalId: "goal-1", gateId: "gate-1", signalId: "signal-1" },
+			{ name: "Restart resume review", type: "llm-review", status: "running", startedAt: Date.now() - 1_000, sessionId },
+		);
+		return { prompts, calls, result };
+	} finally {
+		fs.rmSync(stateDir, { recursive: true, force: true });
+	}
+}
+
+async function runNetworkDisconnectRecovery() {
+	const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "verification-network-disconnect-recovery-"));
+	const sessionId = "sleep-wifi-disconnected-reviewer";
+	const prompts: string[] = [];
+	const calls: string[] = [];
+	let harness: VerificationHarness;
+	try {
+		const fakeSession = {
+			id: sessionId,
+			status: "idle",
+			nonInteractive: true,
+			restoreStartupWasStreaming: false,
+			lastTurnErrored: true,
+			lastTurnErrorMessage: "socket hang up while streaming from provider after Wi-Fi disconnect",
+			pendingAutoRetryTimer: undefined,
+			rpcClient: {
+				onEvent: (_fn: (event: any) => void) => () => {},
+				waitForReady: async () => {},
+				prompt: async (text: string) => {
+					prompts.push(text);
+					return { success: true };
+				},
+				promptWhenReady: async (text: string) => {
+					prompts.push(text);
+					return { success: true };
+				},
+			},
+		};
+		const sessionManager = {
+			getSession: () => fakeSession,
+			retryLastPrompt: async () => {
+				calls.push("retryLastPrompt:auto");
+				fakeSession.lastTurnErrored = false;
+				fakeSession.lastTurnErrorMessage = "";
+				fakeSession.status = "streaming";
+			},
+			waitForStreaming: async () => {
+				calls.push("waitForStreaming");
+				fakeSession.status = "streaming";
+			},
+			waitForIdle: async () => {
+				calls.push("waitForIdle");
+				const resolver = (harness as any).pendingResults.get(sessionId);
+				resolver?.({ verdict: true, summary: "Recovered after network disconnect." });
+				await Promise.resolve();
+				fakeSession.status = "idle";
+			},
+			terminateSession: async () => {
+				calls.push("terminateSession");
+			},
+		} as any;
+		const gateStore = {
+			updateSignalVerification: () => {},
+			updateGateStatus: () => {},
+			getGate: () => undefined,
+			getGatesForGoal: () => [],
+		} as any;
+		harness = new VerificationHarness(
+			stateDir,
+			gateStore,
+			() => {},
+			{ get: () => undefined, getAll: () => [] } as any,
+			undefined,
+			sessionManager,
+			{ registerReviewerSession: () => {}, unregisterReviewerSession: () => {} } as any,
+		) as any;
+
+		const result = await (harness as any)._tryResumeFromSession(
+			{ goalId: "goal-1", gateId: "gate-1", signalId: "signal-1" },
+			{ name: "Sleep/Wi-Fi disconnect review", type: "llm-review", status: "running", startedAt: Date.now() - 1_000, sessionId },
+		);
+		return { prompts, calls, result };
+	} finally {
+		fs.rmSync(stateDir, { recursive: true, force: true });
+	}
+}
+
 describe("verification reminder race — Bug 2 (resumed reviewer terminated early)", () => {
+	it("restart-interrupted restored idle nonInteractive reviewer gets a restart-aware continuation prompt first", async () => {
+		const prompts = await captureResumePromptForRestoredReviewer({ restoreStartupWasStreaming: true });
+		const firstPrompt = prompts[0] ?? "";
+
+		assert.equal(prompts.length, 1, `RESTART_RESUME_REGRESSION: expected exactly one first post-restart prompt, got ${prompts.length}: ${JSON.stringify(prompts)}`);
+		assert.notEqual(
+			firstPrompt,
+			VERIFICATION_RESULT_REMINDER,
+			`RESTART_RESUME_REGRESSION: restored idle nonInteractive verifier with restoreStartupWasStreaming=true received VERIFICATION_RESULT_REMINDER as the first post-restart prompt instead of restart-aware continuation instructions. prompt=${JSON.stringify(firstPrompt)}`,
+		);
+		assert.match(
+			firstPrompt,
+			/restart|restarted/i,
+			`RESTART_RESUME_REGRESSION: restart-aware continuation prompt must mention that infrastructure restarted mid-turn. prompt=${JSON.stringify(firstPrompt)}`,
+		);
+		assert.match(
+			firstPrompt,
+			/transcript|context/i,
+			`RESTART_RESUME_REGRESSION: restart-aware continuation prompt must tell the reviewer to use preserved transcript/context. prompt=${JSON.stringify(firstPrompt)}`,
+		);
+		assert.match(
+			firstPrompt,
+			/continue/i,
+			`RESTART_RESUME_REGRESSION: restart-aware continuation prompt must tell the reviewer to continue the interrupted review. prompt=${JSON.stringify(firstPrompt)}`,
+		);
+		assert.match(
+			firstPrompt,
+			/verification_result[\s\S]*complete|complete[\s\S]*verification_result/i,
+			`RESTART_RESUME_REGRESSION: restart-aware continuation prompt must reserve verification_result for when review is complete. prompt=${JSON.stringify(firstPrompt)}`,
+		);
+	});
+
+	it("ordinary restored idle nonInteractive reviewer still gets the idle-without-result reminder", async () => {
+		const prompts = await captureResumePromptForRestoredReviewer({ restoreStartupWasStreaming: false });
+
+		assert.deepEqual(
+			prompts,
+			[VERIFICATION_RESULT_REMINDER],
+			`Ordinary non-restart idle-without-result verifier should still receive VERIFICATION_RESULT_REMINDER. prompts=${JSON.stringify(prompts)}`,
+		);
+	});
+
+	it("post-restart continuation that goes idle without a result falls back to the normal reminder with a fair turn", async () => {
+		const { prompts, calls, result } = await runRestartContinuationFallback();
+
+		assert.deepEqual(
+			prompts,
+			[VERIFICATION_RESTART_RESUME_PROMPT, VERIFICATION_RESULT_REMINDER],
+			`Restart-aware continuation must only be the first post-restart prompt; a no-result continuation turn should receive the normal reminder next. prompts=${JSON.stringify(prompts)}`,
+		);
+		assert.deepEqual(
+			calls.slice(0, 6),
+			["prompt:1", "waitForStreaming:1", "waitForIdle:1", "prompt:2", "waitForStreaming:2", "waitForIdle:2"],
+			`Fallback reminder must use the same promptWhenReady + waitForStreaming + idle wait sequence before completion/failure. calls=${JSON.stringify(calls)}`,
+		);
+		assert.equal(result.passed, true);
+		assert.equal(result.output, "Fallback reminder completed.");
+		assert.ok(calls.includes("terminate:2"), `resumed reviewer should be terminated only after the fallback turn resolves. calls=${JSON.stringify(calls)}`);
+	});
+
+	it("post-restart continuation JSON glitch falls back to JSON retry instead of another restart prompt", async () => {
+		const { prompts, calls, result } = await runRestartContinuationFallback({ jsonValidationErrorDuringContinuation: true });
+
+		assert.equal(prompts[0], VERIFICATION_RESTART_RESUME_PROMPT);
+		assert.notEqual(prompts[1], VERIFICATION_RESTART_RESUME_PROMPT, "restart-aware continuation prompt must not be reused after the first post-restart turn");
+		assert.notEqual(prompts[1], VERIFICATION_RESULT_REMINDER, "a validation error during the continuation turn should use the targeted JSON retry fallback");
+		assert.match(prompts[1], /Validation failed for tool|Expected property name in JSON/i);
+		assert.deepEqual(
+			calls.slice(0, 6),
+			["prompt:1", "waitForStreaming:1", "waitForIdle:1", "prompt:2", "waitForStreaming:2", "waitForIdle:2"],
+			`JSON fallback must still get a fair promptWhenReady + waitForStreaming + idle wait turn. calls=${JSON.stringify(calls)}`,
+		);
+		assert.equal(result.passed, true);
+	});
+
+	it("sleep or Wi-Fi disconnect resumes the same reviewer instead of surfacing a transient rerun", async () => {
+		const { prompts, calls, result } = await runNetworkDisconnectRecovery();
+
+		assert.deepEqual(prompts, [], "Infrastructure disconnect recovery should retry/continue the existing reviewer, not send a reminder or start a fresh prompt path");
+		assert.deepEqual(
+			calls.slice(0, 3),
+			["retryLastPrompt:auto", "waitForStreaming", "waitForIdle"],
+			`Sleep/Wi-Fi disconnect should get one continuation retry and a fair streaming+idle turn before teardown/rerun. calls=${JSON.stringify(calls)}`,
+		);
+		assert.equal(result.passed, true);
+		assert.equal(result.output, "Recovered after network disconnect.");
+		assert.ok(calls.includes("terminateSession"), "session cleanup should happen after the continued reviewer returns a result");
+	});
+
 	it("waitForStreaming resolves when an idle session transitions to streaming", async () => {
 		const session = new FakeSession("rv-1");
 


### PR DESCRIPTION
## Summary
- Add restart-aware continuation prompts for restored nonInteractive verifier sessions interrupted mid-turn.
- Keep normal idle-without-result reminder behavior for non-restart cases and post-continuation fallback.
- Recover sleep/Wi-Fi and infrastructure disconnects on the same reviewer session before falling back to fresh reruns.
- Update verifier recovery docs and regression tests.

## Validation
- Implementation gate passed: build, type check, focused repro, unit, browser, E2E, and LLM review phases.
- Focused local check: npx vitest run --config vitest.config.ts tests2/core/verification-reminder-race.test.ts.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)