### PR TITLE
Register search archive schema opt-in

### DIFF
--- a/defaults/tools/bobbit/extension.ts
+++ b/defaults/tools/bobbit/extension.ts
@@ -690,6 +690,7 @@ export default function (pi: ExtensionAPI) {
 			cursor: Type.Optional(Type.Union([Type.String(), Type.Number()], { description: "Alias for after on cursor-backed list operations." })),
 			archived: Type.Optional(Type.Boolean({ description: "Include archived items." })),
 			include: Type.Optional(Type.String({ description: "Inclusion flag, e.g. 'archived'." })),
+			includeArchived: Type.Optional(Type.Boolean({ description: "REST-style search archive opt-in." })),
 			view: Type.Optional(Type.String({ description: "Response view, e.g. 'summary'." })),
 			probe: Type.Optional(Type.String({ description: "maintenance_inspect probe selector." })),
 		}),

--- a/tests2/core/bobbit-tool-archive-filtering.test.ts
+++ b/tests2/core/bobbit-tool-archive-filtering.test.ts
@@ -179,6 +179,30 @@ describe("bobbit_read — archive-hidden search default", () => {
 		expect(ids(data.results)).toEqual(["live-result", "archived-result"]);
 	});
 
+	it("search preserves archived rows and forwards includeArchived=true when includeArchived is explicit", async () => {
+		stubFetch((url) => {
+			expect(new URL(url).searchParams.get("includeArchived")).toBe("true");
+			return {
+				body: {
+					results: [
+						{ id: "live-result", type: "goal", archived: false },
+						{ id: "archived-result", type: "goal", archived: true },
+					],
+					total: 2,
+				},
+			};
+		});
+
+		const result = await tools.get("bobbit_read")!.execute("id", {
+			operation: "search",
+			q: "archive visibility",
+			includeArchived: true,
+		});
+		const data = json(result);
+
+		expect(ids(data.results)).toEqual(["live-result", "archived-result"]);
+	});
+
 	it("search defensive filtering does not corrupt the REST grand total across pages", async () => {
 		// REST returns one page (limit 2) of a larger result set (total 50). Even if
 		// an archived row slips through the server filter, the page-level removal must

--- a/tests2/core/bobbit-tool-validation.test.ts
+++ b/tests2/core/bobbit-tool-validation.test.ts
@@ -36,6 +36,14 @@ describe("bobbit_read — paging schema", () => {
 		expect(props.after.description).toMatch(/cursor|after/i);
 		expect(props.cursor.description).toMatch(/cursor|after/i);
 	});
+
+	it("exposes the REST-style search archive opt-in", () => {
+		const props = tools.get("bobbit_read")!.parameters?.properties ?? {};
+
+		expect(props.includeArchived, "includeArchived should be registered in the bobbit_read schema").toBeTruthy();
+		expect(props.includeArchived.type).toBe("boolean");
+		expect(props.includeArchived.description).toMatch(/search|archive/i);
+	});
 });
 
 describe("bobbit tools — operation validation", () => {


### PR DESCRIPTION
## Summary
- Add includeArchived to the bobbit_read TypeBox schema
- Pin schema exposure and search forwarding behavior in tests

## Tests
- npm run test:unit -- --run tests2/core/bobbit-tool-validation.test.ts tests2/core/bobbit-tool-archive-filtering.test.ts
- npm run check

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)